### PR TITLE
[RFC] Update os_unix_defs.h to replace every ~ with $HOME

### DIFF
--- a/src/nvim/os_unix_defs.h
+++ b/src/nvim/os_unix_defs.h
@@ -151,7 +151,7 @@
 
 
 #if !defined(USR_EXRC_FILE2)
-#    define USR_VIMRC_FILE2     "~/.nvim/nvimrc"
+#    define USR_VIMRC_FILE2     "$HOME/.nvim/nvimrc"
 #endif
 
 
@@ -160,7 +160,7 @@
 #endif
 
 #ifndef USR_GVIMRC_FILE2
-#   define USR_GVIMRC_FILE2     "~/.nvim/ngvimrc"
+#   define USR_GVIMRC_FILE2     "$HOME/.nvim/ngvimrc"
 #endif
 
 
@@ -186,11 +186,11 @@
 #endif
 
 #ifndef DFLT_BDIR
-#   define DFLT_BDIR    ".,~/tmp,~/"    /* default for 'backupdir' */
+#   define DFLT_BDIR    ".,$HOME/tmp,$HOME/"    /* default for 'backupdir' */
 #endif
 
 #ifndef DFLT_DIR
-#   define DFLT_DIR     ".,~/tmp,/var/tmp,/tmp" /* default for 'directory' */
+#   define DFLT_DIR     ".,$HOME/tmp,/var/tmp,/tmp" /* default for 'directory' */
 #endif
 
 #ifndef DFLT_VDIR
@@ -200,11 +200,11 @@
 #define DFLT_ERRORFILE          "errors.err"
 
 #  ifdef RUNTIME_GLOBAL
-#   define DFLT_RUNTIMEPATH     "~/.nvim," RUNTIME_GLOBAL ",$VIMRUNTIME," \
-  RUNTIME_GLOBAL "/after,~/.nvim/after"
+#   define DFLT_RUNTIMEPATH     "$HOME/.nvim," RUNTIME_GLOBAL ",$VIMRUNTIME," \
+  RUNTIME_GLOBAL "/after,$HOME/.nvim/after"
 #  else
 #   define DFLT_RUNTIMEPATH \
-  "~/.nvim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,~/.nvim/after"
+  "$HOME/.nvim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,$HOME/.nvim/after"
 #  endif
 
 #  define TEMPDIRNAMES  "$TMPDIR", "/tmp", ".", "$HOME"


### PR DESCRIPTION
Be consistant inside os_unix_defs.h, only use $HOME.

I do that because `nvim --version` looked ugly.
