### PR TITLE
[RDY] Remove include for sys/select.h in vim.h

### DIFF
--- a/config/config.h.in
+++ b/config/config.h.in
@@ -72,7 +72,6 @@
 // #define HAVE_SYSCONF 1
 #define HAVE_SYS_IOCTL_H 1
 #define HAVE_SYS_PARAM_H 1
-#define HAVE_SYS_SELECT_H 1
 #define HAVE_SYS_STATFS_H 1
 // TODO: add proper cmake check
 // #define HAVE_SYS_SYSINFO_H 1

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -109,11 +109,6 @@ typedef uint32_t u8char_T;
 #include <wctype.h>
 #include <stdarg.h>
 
-#if defined(HAVE_SYS_SELECT_H) && \
-  (!defined(HAVE_SYS_TIME_H) || defined(SYS_SELECT_WITH_SYS_TIME))
-# include <sys/select.h>
-#endif
-
 /* ================ end of the header file puzzle =============== */
 
 #ifdef HAVE_WORKING_LIBINTL


### PR DESCRIPTION
- There is no need to include sys/select.h anymore. Remove the last inclusion of sys/select.h in Neovim
