### PR TITLE
[RDY] misc2.c -Wconversion changes

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -44,7 +44,7 @@ set(CONV_SRCS
   log.c
   map.c
   memory.c
-  map.c
+  misc2.c
   os/env.c
   os/event.c
   os/job.c

--- a/src/nvim/misc2.c
+++ b/src/nvim/misc2.c
@@ -485,28 +485,20 @@ time_t get8ctime(FILE *fd)
   return n;
 }
 
-/*
- * Read a string of length "cnt" from "fd" into allocated memory.
- * Returns NULL when unable to read that many bytes.
- */
-char_u *read_string(FILE *fd, int cnt)
+/// Reads a string of length "cnt" from "fd" into allocated memory.
+/// @return pointer to the string or NULL when unable to read that many bytes.
+char *read_string(FILE *fd, size_t cnt)
 {
-  int i;
-  int c;
-
-  char_u *str = xmallocz(cnt);
-  /* Read the string.  Quit when running into the EOF. */
-  for (i = 0; i < cnt; ++i) {
-    c = getc(fd);
+  uint8_t *str = xmallocz(cnt);
+  for (size_t i = 0; i < cnt; i++) {
+    int c = getc(fd);
     if (c == EOF) {
       free(str);
       return NULL;
     }
-    str[i] = c;
+    str[i] = (uint8_t)c;
   }
-  str[i] = NUL;
-
-  return str;
+  return (char *)str;
 }
 
 /*

--- a/src/nvim/misc2.h
+++ b/src/nvim/misc2.h
@@ -3,7 +3,10 @@
 
 #include "nvim/os/shell.h"
 
+#define READ_STRING(x, y) (char_u *)read_string((x), (size_t)(y))
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "misc2.h.generated.h"
 #endif
+
 #endif  // NVIM_MISC2_H

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2596,7 +2596,7 @@ spell_load_file (
     res = 0;
     switch (n) {
     case SN_INFO:
-      lp->sl_info = read_string(fd, len);               // <infotext>
+      lp->sl_info = READ_STRING(fd, len);               // <infotext>
       if (lp->sl_info == NULL)
         goto endFAIL;
       break;
@@ -2610,7 +2610,7 @@ spell_load_file (
       break;
 
     case SN_MIDWORD:
-      lp->sl_midword = read_string(fd, len);            // <midword>
+      lp->sl_midword = READ_STRING(fd, len);            // <midword>
       if (lp->sl_midword == NULL)
         goto endFAIL;
       break;
@@ -2636,7 +2636,7 @@ spell_load_file (
       break;
 
     case SN_MAP:
-      p = read_string(fd, len);                         // <mapstr>
+      p = READ_STRING(fd, len);                         // <mapstr>
       if (p == NULL)
         goto endFAIL;
       set_map_str(lp, p);
@@ -2664,7 +2664,7 @@ spell_load_file (
       break;
 
     case SN_SYLLABLE:
-      lp->sl_syllable = read_string(fd, len);           // <syllable>
+      lp->sl_syllable = READ_STRING(fd, len);           // <syllable>
       if (lp->sl_syllable == NULL)
         goto endFAIL;
       if (init_syl_tab(lp) == FAIL)
@@ -2760,7 +2760,7 @@ static char_u *read_cnt_string(FILE *fd, int cnt_bytes, int *cntp)
   if (cnt == 0)
     return NULL;            // nothing to read, return NULL
 
-  str = read_string(fd, cnt);
+  str = READ_STRING(fd, cnt);
   if (str == NULL)
     *cntp = SP_OTHERERROR;
   return str;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -913,7 +913,7 @@ static u_entry_T *unserialize_uep(FILE *fp, int *error, char_u *file_name)
   for (i = 0; i < uep->ue_size; ++i) {
     line_len = get4c(fp);
     if (line_len >= 0)
-      line = read_string(fp, line_len);
+      line = READ_STRING(fp, line_len);
     else {
       line = NULL;
       corruption_error("line length", file_name);
@@ -1313,7 +1313,7 @@ void u_read_undo(char_u *name, char_u *hash, char_u *orig_name)
   if (str_len < 0)
     goto error;
   if (str_len > 0)
-    line_ptr = read_string(fp, str_len);
+    line_ptr = READ_STRING(fp, str_len);
   line_lnum = (linenr_T)get4c(fp);
   line_colnr = (colnr_T)get4c(fp);
   if (line_lnum < 0 || line_colnr < 0) {


### PR DESCRIPTION
First go at helping out. Hopefully misc2.c goes away, but in the mean time I fixed up the one method in it that had -Wconversion errors, per #567.

xmallocz zeroes the string at the end, no need to double up on nulling it.

After looking, it seemed like a cnt of int was adequate, no callers used larger sizes. Still, should it be size_t?
