### PR TITLE
[RFC] coverity/68610: Fix out of bounds access

### DIFF
--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1702,7 +1702,7 @@ static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
       context = cntxts[idx];
     else
       context = globalcntx;
-    newsize = strlen(context) + strlen(cntxformat);
+    newsize = strlen(context) + strlen(cntxformat) + 1;
 
     if (bufsize < newsize) {
       buf = xrealloc(buf, newsize);


### PR DESCRIPTION
If buf is reallocated on 1708, it will be one character too short for
the terminating NULL character on 1712.
