### PR TITLE
[RDY] remove vim_round() in favour of round()

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12168,15 +12168,6 @@ theend:
   return retval;
 }
 
-
-/*
- * round() is not in C90, use ceil() or floor() instead.
- */
-float_T vim_round(float_T f)
-{
-  return f > 0 ? floor(f + 0.5) : ceil(f - 0.5);
-}
-
 /*
  * "round({float})" function
  */
@@ -12186,7 +12177,7 @@ static void f_round(typval_T *argvars, typval_T *rettv)
 
   rettv->v_type = VAR_FLOAT;
   if (get_float_arg(argvars, &f) == OK)
-    rettv->vval.v_float = vim_round(f);
+    rettv->vval.v_float = round(f);
   else
     rettv->vval.v_float = 0.0;
 }

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -841,7 +841,7 @@ void profile_divide(proftime_T *tm, int count, proftime_T *tm2)
     double usec = (tm->tv_sec * 1000000.0 + tm->tv_usec) / count;
 
     tm2->tv_sec = floor(usec / 1000000.0);
-    tm2->tv_usec = vim_round(usec - (tm2->tv_sec * 1000000.0));
+    tm2->tv_usec = round(usec - (tm2->tv_sec * 1000000.0));
   }
 }
 


### PR DESCRIPTION
C89 did not have round(), vim emulated it with vim_round. But since we're using C99 this is not a problem anymore.

This conflicts a tiny bit with the profiling PR (#839), I'll rebase whichever one gets merged second.
