### PR TITLE
[RDY] Remove unnecessary PATHS from cmake modules

### DIFF
--- a/cmake/FindLibUV.cmake
+++ b/cmake/FindLibUV.cmake
@@ -23,7 +23,6 @@ endif()
 
 find_path(LIBUV_INCLUDE_DIR uv.h
   HINTS ${PC_LIBUV_INCLUDEDIR} ${PC_LIBUV_INCLUDE_DIRS}
-  PATHS "${DEPS_INSTALL_DIR}"
   ${LIMIT_SEARCH})
 
 # If we're asked to use static linkage, add libuv.a as a preferred library name.
@@ -36,7 +35,6 @@ list(APPEND LIBUV_NAMES uv)
 
 find_library(LIBUV_LIBRARY NAMES ${LIBUV_NAMES}
   HINTS ${PC_LIBUV_LIBDIR} ${PC_LIBUV_LIBRARY_DIRS}
-  PATHS "${DEPS_INSTALL_DIR}"
   ${LIMIT_SEARCH})
 
 mark_as_advanced(LIBUV_INCLUDE_DIR LIBUV_LIBRARY)

--- a/cmake/FindMsgpack.cmake
+++ b/cmake/FindMsgpack.cmake
@@ -22,7 +22,6 @@ set(MSGPACK_DEFINITIONS ${PC_MSGPACK_CFLAGS_OTHER})
 
 find_path(MSGPACK_INCLUDE_DIR msgpack.h
   HINTS ${PC_MSGPACK_INCLUDEDIR} ${PC_MSGPACK_INCLUDE_DIRS}
-  PATHS "${DEPS_INSTALL_DIR}"
   ${LIMIT_SEARCH})
 
 # If we're asked to use static linkage, add libmsgpackc.a as a preferred library name.
@@ -35,7 +34,6 @@ list(APPEND MSGPACK_NAMES msgpackc)
 
 find_library(MSGPACK_LIBRARY NAMES ${MSGPACK_NAMES}
   HINTS ${PC_MSGPACK_LIBDIR} ${PC_MSGPACK_LIBRARY_DIRS}
-  PATHS "${DEPS_INSTALL_DIR}"
   ${LIMIT_SEARCH})
 
 mark_as_advanced(MSGPACK_INCLUDE_DIR MSGPACK_LIBRARY)


### PR DESCRIPTION
- DEPS_INSTALL_DIR is already set into CMAKE_PREFIX_PATH in
  the main CMakeLists.txt and is not needed in FindLibUv/FindMsgpack
