### PR TITLE
[RDY] cmake: upgrade libuv 0.11.23 -> 0.11.26

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -46,8 +46,8 @@ endif()
 
 include(ExternalProject)
 
-set(LIBUV_URL https://github.com/joyent/libuv/archive/v0.11.23.tar.gz)
-set(LIBUV_MD5 e02a3da9fba9ebe72a84e4abd312ee4d)
+set(LIBUV_URL https://github.com/joyent/libuv/archive/v0.11.26.tar.gz)
+set(LIBUV_MD5 05fabe884173f422649fbe1047ca62b1)
 
 set(MSGPACK_URL https://github.com/msgpack/msgpack-c/releases/download/cpp-0.5.8/msgpack-0.5.8.tar.gz)
 set(MSGPACK_MD5 ea0bee0939d2980c0df91f0e4843ccc4)


### PR DESCRIPTION
Fixes some bugs and increase the performance of uv_hrtime() on OSX, which
reduces its prominence in performance traces. This allows us to better see
what's really causing slowness.

ref:
- https://github.com/neovim/neovim/issues/868
- https://github.com/joyent/libuv/pull/1325
- https://github.com/joyent/libuv/releases
