### PR TITLE
[RFC/WIP] Push input via the API

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -22,6 +22,7 @@
 #include "nvim/misc2.h"
 #include "nvim/term.h"
 #include "nvim/getchar.h"
+#include "nvim/ui.h"
 
 #define LINE_BUFFER_SIZE 4096
 
@@ -32,9 +33,10 @@
 /// Send keys to vim input buffer, simulating user input.
 ///
 /// @param str The keys to send
-void vim_push_keys(String str)
+/// @return The amount of bytes from str written into the input buffer
+Integer vim_push_keys(String str)
 {
-  abort();
+  return (Integer)add_to_input_buf_csi((char_u *) str.data, str.size);
 }
 
 /// Executes an ex-mode command str


### PR DESCRIPTION
Following from #781 - there is a (currently abort()s) function vim_push_keys() in the API to pass input to Neovim. I enabled the function by calling the old input functions add_to_input_buf()  used by the GUI in original Vim.

This is not ideal because it passes bytes directly into the input buffer and what we really want is an API for clients to push input, i.e.:
- key sequences the user types in the keyboard
- key + modifiers e.g. Ctrl+x
- special key + modifiers (by special I mean things that cannot be encoded as strings - F1, Backspace, PgDown)

Finally a quick link to a must read discussion on [vim-dev](http://vim.1045645.n5.nabble.com/Keyboard-input-handling-td1211322.html) on keyboard input. Maybe we can steal some ideas for the API from there.
