### PR TITLE
[RFC] Improve neovim.rb

### DIFF
--- a/neovim.rb
+++ b/neovim.rb
@@ -7,6 +7,7 @@ class Neovim < Formula
   depends_on "cmake" => :build
   depends_on "libtool" => :build
   depends_on "automake" => :build
+  depends_on "autoconf" => :build
 
   def install
     ENV.deparallelize

--- a/neovim.rb
+++ b/neovim.rb
@@ -4,7 +4,6 @@ class Neovim < Formula
   homepage "http://neovim.org"
   head "https://github.com/neovim/neovim.git"
 
-  depends_on "md5sha1sum" => :build unless Formula["polarssl"].installed?
   depends_on "cmake" => :build
   depends_on "libtool" => :build
   depends_on "automake" => :build

--- a/neovim.rb
+++ b/neovim.rb
@@ -1,13 +1,13 @@
-require 'formula'
+require "formula"
 
 class Neovim < Formula
-  homepage 'http://neovim.org'
-  head 'https://github.com/neovim/neovim.git'
+  homepage "http://neovim.org"
+  head "https://github.com/neovim/neovim.git"
 
-  depends_on 'md5sha1sum'
-  depends_on 'cmake'
-  depends_on 'libtool'
-  depends_on 'automake'
+  depends_on "md5sha1sum" => :build unless Formula["polarssl"].installed?
+  depends_on "cmake" => :build
+  depends_on "libtool" => :build
+  depends_on "automake" => :build
 
   def install
     ENV.deparallelize


### PR DESCRIPTION
1. Fix the conflict between `md5sha1sum` and `polarssl`. Both of them provide the same CLT.
2. Add `=> :build` to reduce warning in `brew audit`.
3. Modernize, replace single quotes to double quotes. https://github.com/styleguide/ruby
