### PR TITLE
[RDY] Fix two android compile errors in fs.c

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -37,9 +37,9 @@ int os_dirname(char_u *buf, size_t len)
 {
   assert(buf && len);
 
-  int errno;
-  if ((errno = uv_cwd((char *)buf, &len)) != kLibuvSuccess) {
-    STRLCPY(buf, uv_strerror(errno), len);
+  int error_number;
+  if ((error_number = uv_cwd((char *)buf, &len)) != kLibuvSuccess) {
+    STRLCPY(buf, uv_strerror(error_number), len);
     return FAIL;
   }
   return OK;
@@ -92,7 +92,7 @@ static bool is_executable(const char_u *name)
     return false;
   }
 
-  if (S_ISREG(mode) && (S_IEXEC & mode)) {
+  if (S_ISREG(mode) && (S_IXUSR & mode)) {
     return true;
   }
 


### PR DESCRIPTION
- Replace usage of deprecated S_IEXEC with S_IXUSR:

As noted in http://www.gnu.org/savannah-checkouts/gnu/libc/manual/html_node/Permission-Bits.html, "S_IEXEC is an obsolete synonym provided for BSD compatibility", so should be a general improvement to avoid using outdated constructs.
- Rename a variable named "errno" to avoid clashing with define:

As noted in http://man7.org/linux/man-pages/man3/errno.3.html, "errno may be a macro", so having a variable  named errno should be avoided in general.
