### PR TITLE
[RFC] sha256.c: clint, -Wconversion, stdbool, and other improvements.

### DIFF
--- a/clint-ignored-files.txt
+++ b/clint-ignored-files.txt
@@ -106,8 +106,6 @@ src/nvim/screen.c
 src/nvim/screen.h
 src/nvim/search.c
 src/nvim/search.h
-src/nvim/sha256.c
-src/nvim/sha256.h
 src/nvim/sign_defs.h
 src/nvim/spell.c
 src/nvim/spell.h

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -81,7 +81,6 @@ set(CONV_SOURCES
   regexp.c
   screen.c
   search.c
-  sha256.c
   spell.c
   syntax.c
   tag.c

--- a/src/nvim/sha256.h
+++ b/src/nvim/sha256.h
@@ -5,10 +5,13 @@
 
 #include "nvim/types.h"  // for char_u
 
+#define SHA256_BUFFER_SIZE 64
+#define SHA256_SUM_SIZE    32
+
 typedef struct {
   uint32_t total[2];
   uint32_t state[8];
-  char_u buffer[64];
+  char_u buffer[SHA256_BUFFER_SIZE];
 } context_sha256_T;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/sha256.h
+++ b/src/nvim/sha256.h
@@ -1,6 +1,10 @@
 #ifndef NVIM_SHA256_H
 #define NVIM_SHA256_H
 
+#include <stdint.h>      // for uint32_t
+
+#include "nvim/types.h"  // for char_u
+
 typedef struct {
   uint32_t total[2];
   uint32_t state[8];


### PR DESCRIPTION
This is the smallest file in neovim's source that lacks the `-Wconversion` flag, and needed only minor changes for clint and to use bool. 

It seems that `sha256_self_test()` might have at one point returned a count of the tests that failed, but anymore it reduces to `FAIL` or `OK` and it doesn't look like anyone has touched it in a very long time.
- Add sha256.c to clint-tests.txt from pull #489.
- Enable `-Wconverion` for issue #567.
- Use `bool` instead of `OK`/`FAIL`. (Doesn't seem to be a specific issue for this.)

Update:
- Remove dead code.
- Don't include vim.h for issue #918.
- Use const.
