### PR TITLE
[RFC] Remove Vi compatible mode

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6987,9 +6987,6 @@ static void ex_mkrc(exarg_T *eap)
     if (eap->cmdidx != CMD_mkview) {
       /* Write setting 'compatible' first, because it has side effects.
        * For that same reason only do it when needed. */
-      if (p_cp)
-        (void)put_line(fd, "if !&cp | set cp | endif");
-      else
         (void)put_line(fd, "if &cp | set nocp | endif");
     }
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -938,7 +938,6 @@ static void parse_command_name(mparm_T *parmp)
       exmode_active = EXMODE_VIM;
     else
       exmode_active = EXMODE_NORMAL;
-    change_compatible(TRUE);            /* set 'compatible' */
   }
 }
 
@@ -1065,10 +1064,6 @@ static void command_line_scan(mparm_T *parmp)
           curbuf->b_p_bin = 1;                /* binary file I/O */
           break;
 
-        case 'C':                 /* "-C"  Compatible */
-          change_compatible(TRUE);
-          break;
-
         case 'e':                 /* "-e" Ex mode */
           exmode_active = EXMODE_NORMAL;
           break;
@@ -1114,10 +1109,6 @@ static void command_line_scan(mparm_T *parmp)
 
         case 'y':                 /* "-y"  easy mode */
           parmp->evim_mode = TRUE;
-          break;
-
-        case 'N':                 /* "-N"  Nocompatible */
-          change_compatible(FALSE);
           break;
 
         case 'n':                 /* "-n" no swap file */
@@ -2194,8 +2185,6 @@ static void usage(void)
   main_msg(_("-M\t\t\tModifications in text not allowed"));
   main_msg(_("-b\t\t\tBinary mode"));
   main_msg(_("-l\t\t\tLisp mode"));
-  main_msg(_("-C\t\t\tCompatible with Vi: 'compatible'"));
-  main_msg(_("-N\t\t\tNot fully Vi compatible: 'nocompatible'"));
   main_msg(_("-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"));
   main_msg(_("-D\t\t\tDebugging mode"));
   main_msg(_("-n\t\t\tNo swap file, use memory only"));

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -829,7 +829,7 @@ void wait_return(int redraw)
        * to avoid that typing one 'j' too many makes the messages
        * disappear.
        */
-      if (p_more && !p_cp) {
+      if (p_more) {
         if (c == 'b' || c == 'k' || c == 'u' || c == 'g'
             || c == K_UP || c == K_PAGEUP) {
           if (msg_scrolled > Rows)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2048,8 +2048,7 @@ void set_init_1(void)
           || enc_utf8
           ) {
         /* Adjust the default for 'isprint' and 'iskeyword' to match
-         * latin1.  Also set the defaults for when 'nocompatible' is
-         * set. */
+         * latin1. */
         set_string_option_direct((char_u *)"isp", -1,
             ISP_LATIN1, OPT_FREE, SID_NONE);
         set_string_option_direct((char_u *)"isk", -1,
@@ -2081,8 +2080,7 @@ void set_init_1(void)
 static void 
 set_option_default (
     int opt_idx,
-    int opt_flags,                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
-    int compatible                 /* use Vi default value */
+    int opt_flags                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
 )
 {
   char_u      *varp;            /* pointer to variable for current option */
@@ -2150,7 +2148,7 @@ set_options_default (
 
   for (i = 0; !istermoption(&options[i]); i++)
     if (!(options[i].flags & P_NODEFAULT))
-      set_option_default(i, opt_flags, false);
+      set_option_default(i, opt_flags);
 
   /* The 'scroll' option must be computed for all windows. */
   FOR_ALL_TAB_WINDOWS(tp, wp)
@@ -2228,7 +2226,7 @@ void set_init_2(void)
   set_number_default("scroll", Rows / 2);
   idx = findoption((char_u *)"scroll");
   if (idx >= 0 && !(options[idx].flags & P_WAS_SET))
-    set_option_default(idx, OPT_LOCAL, false);
+    set_option_default(idx, OPT_LOCAL);
   comp_col();
 
   /*
@@ -7694,9 +7692,6 @@ static void paste_option_changed(void)
 /*
  * vimrc_found() - Called when a ".vimrc" or "VIMINIT" has been found.
  *
- * Reset 'compatible' and set the values for options that didn't get set yet
- * to the Vim defaults.
- * Don't do this if the 'compatible' option has been set or reset before.
  * When "fname" is not NULL, use it to set $"envname" when it wasn't set yet.
  */
 void vimrc_found(char_u *fname, char_u *envname)
@@ -7708,7 +7703,7 @@ void vimrc_found(char_u *fname, char_u *envname)
   if (!option_was_set((char_u *)"cp")) {
     for (opt_idx = 0; !istermoption(&options[opt_idx]); opt_idx++)
       if (!(options[opt_idx].flags & P_WAS_SET))
-        set_option_default(opt_idx, OPT_FREE, FALSE);
+        set_option_default(opt_idx, OPT_FREE);
     didset_options();
   }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -19,15 +19,11 @@
  *   - For a buffer string option, add code to check_buf_options().
  * - If it's a numeric option, add any necessary bounds checks to do_set().
  * - If it's a list of flags, add some code in do_set(), search for WW_ALL.
- * - When adding an option with expansion (P_EXPAND), but with a different
- *   default for Vi and Vim (no P_VI_DEF), add some code at VIMEXP.
  * - Add documentation!  One line in doc/help.txt, full description in
  *   options.txt, and any other related places.
  * - Add an entry in runtime/optwin.vim.
  * When making changes:
  * - Adjust the help for the option in doc/option.txt.
- * - When an entry has the P_VIM flag, or is lacking the P_VI_DEF flag, add a
- *   comment at the help for the 'compatible' option.
  */
 
 #define IN_OPTION_C
@@ -327,7 +323,6 @@ struct vimoption {
 #define P_WAS_SET       0x100   /* option has been set/reset */
 #define P_NO_MKRC       0x200   /* don't include in :mkvimrc output */
 #define P_VI_DEF        0x400   /* Use Vi default for Vim */
-#define P_VIM           0x800   /* Vim option, reset when 'cp' set */
 
 /* when option changed, what to display: */
 #define P_RSTAT         0x1000  /* redraw status lines */
@@ -383,17 +378,17 @@ static struct vimoption
      (char_u *)224L,
      (char_u *)0L
    } SCRIPTID_INIT},
-  {"antialias",   "anti", P_BOOL|P_VI_DEF|P_VIM|P_RCLR,
+  {"antialias",   "anti", P_BOOL|P_VI_DEF|P_RCLR,
    (char_u *)NULL, PV_NONE,
    {(char_u *)FALSE, (char_u *)FALSE}
    SCRIPTID_INIT},
-  {"arabic",      "arab", P_BOOL|P_VI_DEF|P_VIM|P_CURSWANT,
+  {"arabic",      "arab", P_BOOL|P_VI_DEF|P_CURSWANT,
    (char_u *)VAR_WIN, PV_ARAB,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"arabicshape", "arshape", P_BOOL|P_VI_DEF|P_VIM|P_RCLR,
+  {"arabicshape", "arshape", P_BOOL|P_VI_DEF|P_RCLR,
    (char_u *)&p_arshape, PV_NONE,
    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"allowrevins", "ari",  P_BOOL|P_VI_DEF|P_VIM,
+  {"allowrevins", "ari",  P_BOOL|P_VI_DEF,
    (char_u *)&p_ari, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"altkeymap",   "akm",  P_BOOL|P_VI_DEF,
@@ -427,13 +422,13 @@ static struct vimoption
      (char_u *)"light",
      (char_u *)0L
    } SCRIPTID_INIT},
-  {"backspace",   "bs",   P_STRING|P_VI_DEF|P_VIM|P_COMMA|P_NODUP,
+  {"backspace",   "bs",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
    (char_u *)&p_bs, PV_NONE,
    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"backup",      "bk",   P_BOOL|P_VI_DEF|P_VIM,
+  {"backup",      "bk",   P_BOOL|P_VI_DEF,
    (char_u *)&p_bk, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"backupcopy",  "bkc",  P_STRING|P_VIM|P_COMMA|P_NODUP,
+  {"backupcopy",  "bkc",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_bkc, PV_NONE,
 #ifdef UNIX
    {(char_u *)"yes", (char_u *)"auto"}
@@ -502,7 +497,7 @@ static struct vimoption
    (char_u *)&p_ccv, PV_NONE,
    {(char_u *)"", (char_u *)0L}
    SCRIPTID_INIT},
-  {"cindent",     "cin",  P_BOOL|P_VI_DEF|P_VIM,
+  {"cindent",     "cin",  P_BOOL|P_VI_DEF,
    (char_u *)&p_cin, PV_CIN,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"cinkeys",     "cink", P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
@@ -546,8 +541,8 @@ static struct vimoption
   /* P_PRI_MKRC isn't needed here, optval_default()
    * always returns TRUE for 'compatible' */
   {"compatible",  "cp",   P_BOOL|P_RALL,
-   (char_u *)&p_cp, PV_NONE,
-   {(char_u *)TRUE, (char_u *)FALSE} SCRIPTID_INIT},
+   (char_u *)&p_vi_compatible, PV_NONE,
+   {(char_u *)FALSE, (char_u *)FALSE} SCRIPTID_INIT},
   {"complete",    "cpt",  P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
    (char_u *)&p_cpt, PV_CPT,
    {(char_u *)".,w,b,u,t,i", (char_u *)0L}
@@ -574,14 +569,14 @@ static struct vimoption
   {"conskey",     "consk",P_BOOL|P_VI_DEF,
    (char_u *)NULL, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"copyindent",  "ci",   P_BOOL|P_VI_DEF|P_VIM,
+  {"copyindent",  "ci",   P_BOOL|P_VI_DEF,
    (char_u *)&p_ci, PV_CI,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"cpoptions",   "cpo",  P_STRING|P_VIM|P_RALL|P_FLAGLIST,
+  {"cpoptions",   "cpo",  P_STRING|P_RALL|P_FLAGLIST,
    (char_u *)&p_cpo, PV_NONE,
    {(char_u *)CPO_VI, (char_u *)CPO_VIM}
    SCRIPTID_INIT},
-  {"cscopepathcomp", "cspc", P_NUM|P_VI_DEF|P_VIM,
+  {"cscopepathcomp", "cspc", P_NUM|P_VI_DEF,
    (char_u *)&p_cspc, PV_NONE,
    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
   {"cscopeprg",   "csprg", P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
@@ -592,16 +587,16 @@ static struct vimoption
    (char_u *)&p_csqf, PV_NONE,
    {(char_u *)"", (char_u *)0L}
    SCRIPTID_INIT},
-  {"cscoperelative", "csre", P_BOOL|P_VI_DEF|P_VIM,
+  {"cscoperelative", "csre", P_BOOL|P_VI_DEF,
    (char_u *)&p_csre, PV_NONE,
    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"cscopetag",   "cst",  P_BOOL|P_VI_DEF|P_VIM,
+  {"cscopetag",   "cst",  P_BOOL|P_VI_DEF,
    (char_u *)&p_cst, PV_NONE,
    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"cscopetagorder", "csto", P_NUM|P_VI_DEF|P_VIM,
+  {"cscopetagorder", "csto", P_NUM|P_VI_DEF,
    (char_u *)&p_csto, PV_NONE,
    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"cscopeverbose", "csverb", P_BOOL|P_VI_DEF|P_VIM,
+  {"cscopeverbose", "csverb", P_BOOL|P_VI_DEF,
    (char_u *)&p_csverbose, PV_NONE,
    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
   {"cursorbind",  "crb",  P_BOOL|P_VI_DEF,
@@ -620,7 +615,7 @@ static struct vimoption
    (char_u *)&p_def, PV_DEF,
    {(char_u *)"^\\s*#\\s*define", (char_u *)0L}
    SCRIPTID_INIT},
-  {"delcombine", "deco",  P_BOOL|P_VI_DEF|P_VIM,
+  {"delcombine", "deco",  P_BOOL|P_VI_DEF,
    (char_u *)&p_deco, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"dictionary",  "dict", P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
@@ -637,7 +632,7 @@ static struct vimoption
    (char_u *)&p_dip, PV_NONE,
    {(char_u *)"filler", (char_u *)NULL}
    SCRIPTID_INIT},
-  {"digraph",     "dg",   P_BOOL|P_VI_DEF|P_VIM,
+  {"digraph",     "dg",   P_BOOL|P_VI_DEF,
    (char_u *)&p_dg, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"directory",   "dir",  P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP|P_SECURE,
@@ -677,13 +672,13 @@ static struct vimoption
    (char_u *)&p_efm, PV_EFM,
    {(char_u *)DFLT_EFM, (char_u *)0L}
    SCRIPTID_INIT},
-  {"esckeys",     "ek",   P_BOOL|P_VIM,
+  {"esckeys",     "ek",   P_BOOL,
    (char_u *)&p_ek, PV_NONE,
    {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
   {"eventignore", "ei",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
    (char_u *)&p_ei, PV_NONE,
    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"expandtab",   "et",   P_BOOL|P_VI_DEF|P_VIM,
+  {"expandtab",   "et",   P_BOOL|P_VI_DEF,
    (char_u *)&p_et, PV_ET,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"exrc",        "ex",   P_BOOL|P_VI_DEF|P_SECURE,
@@ -701,7 +696,7 @@ static struct vimoption
    P_CURSWANT,
    (char_u *)&p_ff, PV_FF,
    {(char_u *)DFLT_FF, (char_u *)0L} SCRIPTID_INIT},
-  {"fileformats", "ffs",  P_STRING|P_VIM|P_COMMA|P_NODUP,
+  {"fileformats", "ffs",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_ffs, PV_NONE,
    {(char_u *)DFLT_FFS_VI, (char_u *)DFLT_FFS_VIM}
    SCRIPTID_INIT},
@@ -738,11 +733,11 @@ static struct vimoption
   {"foldenable",  "fen",  P_BOOL|P_VI_DEF|P_RWIN,
    (char_u *)VAR_WIN, PV_FEN,
    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"foldexpr",    "fde",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
+  {"foldexpr",    "fde",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
    (char_u *)VAR_WIN, PV_FDE,
    {(char_u *)"0", (char_u *)NULL}
    SCRIPTID_INIT},
-  {"foldignore",  "fdi",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
+  {"foldignore",  "fdi",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
    (char_u *)VAR_WIN, PV_FDI,
    {(char_u *)"#", (char_u *)NULL} SCRIPTID_INIT},
   {"foldlevel",   "fdl",  P_NUM|P_VI_DEF|P_RWIN,
@@ -751,12 +746,12 @@ static struct vimoption
   {"foldlevelstart","fdls", P_NUM|P_VI_DEF|P_CURSWANT,
    (char_u *)&p_fdls, PV_NONE,
    {(char_u *)-1L, (char_u *)0L} SCRIPTID_INIT},
-  {"foldmarker",  "fmr",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|
+  {"foldmarker",  "fmr",  P_STRING|P_ALLOCED|P_VI_DEF|
    P_RWIN|P_COMMA|P_NODUP,
    (char_u *)VAR_WIN, PV_FMR,
    {(char_u *)"{{{,}}}", (char_u *)NULL}
    SCRIPTID_INIT},
-  {"foldmethod",  "fdm",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
+  {"foldmethod",  "fdm",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
    (char_u *)VAR_WIN, PV_FDM,
    {(char_u *)"manual", (char_u *)NULL} SCRIPTID_INIT},
   {"foldminlines","fml",  P_NUM|P_VI_DEF|P_RWIN,
@@ -769,15 +764,15 @@ static struct vimoption
    (char_u *)&p_fdo, PV_NONE,
    {(char_u *)"block,hor,mark,percent,quickfix,search,tag,undo",
     (char_u *)0L} SCRIPTID_INIT},
-  {"foldtext",    "fdt",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
+  {"foldtext",    "fdt",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
    (char_u *)VAR_WIN, PV_FDT,
    {(char_u *)"foldtext()", (char_u *)NULL}
    SCRIPTID_INIT},
-  {"formatexpr", "fex",   P_STRING|P_ALLOCED|P_VI_DEF|P_VIM,
+  {"formatexpr", "fex",   P_STRING|P_ALLOCED|P_VI_DEF,
    (char_u *)&p_fex, PV_FEX,
    {(char_u *)"", (char_u *)0L}
    SCRIPTID_INIT},
-  {"formatoptions","fo",  P_STRING|P_ALLOCED|P_VIM|P_FLAGLIST,
+  {"formatoptions","fo",  P_STRING|P_ALLOCED|P_FLAGLIST,
    (char_u *)&p_fo, PV_FO,
    {(char_u *)DFLT_FO_VI, (char_u *)DFLT_FO_VIM}
    SCRIPTID_INIT},
@@ -797,7 +792,7 @@ static struct vimoption
    {(char_u *)FALSE, (char_u *)0L}
 #endif
    SCRIPTID_INIT},
-  {"gdefault",    "gd",   P_BOOL|P_VI_DEF|P_VIM,
+  {"gdefault",    "gd",   P_BOOL|P_VI_DEF,
    (char_u *)&p_gd, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"graphic",     "gr",   P_BOOL|P_VI_DEF,
@@ -878,16 +873,16 @@ static struct vimoption
    (char_u *)&p_hl, PV_NONE,
    {(char_u *)HIGHLIGHT_INIT, (char_u *)0L}
    SCRIPTID_INIT},
-  {"history",     "hi",   P_NUM|P_VIM,
+  {"history",     "hi",   P_NUM,
    (char_u *)&p_hi, PV_NONE,
    {(char_u *)0L, (char_u *)20L} SCRIPTID_INIT},
-  {"hkmap",       "hk",   P_BOOL|P_VI_DEF|P_VIM,
+  {"hkmap",       "hk",   P_BOOL|P_VI_DEF,
    (char_u *)&p_hkmap, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"hkmapp",      "hkp",  P_BOOL|P_VI_DEF|P_VIM,
+  {"hkmapp",      "hkp",  P_BOOL|P_VI_DEF,
    (char_u *)&p_hkmapp, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"hlsearch",    "hls",  P_BOOL|P_VI_DEF|P_VIM|P_RALL,
+  {"hlsearch",    "hls",  P_BOOL|P_VI_DEF|P_RALL,
    (char_u *)&p_hls, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"icon",        NULL,   P_BOOL|P_VI_DEF,
@@ -949,10 +944,10 @@ static struct vimoption
    (char_u *)&p_inex, PV_INEX,
    {(char_u *)"", (char_u *)0L}
    SCRIPTID_INIT},
-  {"incsearch",   "is",   P_BOOL|P_VI_DEF|P_VIM,
+  {"incsearch",   "is",   P_BOOL|P_VI_DEF,
    (char_u *)&p_is, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"indentexpr", "inde",  P_STRING|P_ALLOCED|P_VI_DEF|P_VIM,
+  {"indentexpr", "inde",  P_STRING|P_ALLOCED|P_VI_DEF,
    (char_u *)&p_inde, PV_INDE,
    {(char_u *)"", (char_u *)0L}
    SCRIPTID_INIT},
@@ -963,7 +958,7 @@ static struct vimoption
   {"infercase",   "inf",  P_BOOL|P_VI_DEF,
    (char_u *)&p_inf, PV_INF,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"insertmode",  "im",   P_BOOL|P_VI_DEF|P_VIM,
+  {"insertmode",  "im",   P_BOOL|P_VI_DEF,
    (char_u *)&p_im, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"isfname",     "isf",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
@@ -984,7 +979,7 @@ static struct vimoption
      (char_u *)"@,48-57,_,192-255",
      (char_u *)0L
    } SCRIPTID_INIT},
-  {"iskeyword",   "isk",  P_STRING|P_ALLOCED|P_VIM|P_COMMA|P_NODUP,
+  {"iskeyword",   "isk",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_isk, PV_ISK,
    {
      (char_u *)"@,48-57,_",
@@ -1000,7 +995,7 @@ static struct vimoption
 #endif
      (char_u *)0L
    } SCRIPTID_INIT},
-  {"joinspaces",  "js",   P_BOOL|P_VI_DEF|P_VIM,
+  {"joinspaces",  "js",   P_BOOL|P_VI_DEF,
    (char_u *)&p_js, PV_NONE,
    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
   {"keymap",      "kmp",  P_STRING|P_ALLOCED|P_VI_DEF|P_RBUF|P_RSTAT|P_NFNAME|
@@ -1111,7 +1106,7 @@ static struct vimoption
    (char_u *)&p_msm, PV_NONE,
    {(char_u *)"460000,2000,500", (char_u *)0L}
    SCRIPTID_INIT},
-  {"modeline",    "ml",   P_BOOL|P_VIM,
+  {"modeline",    "ml",   P_BOOL,
    (char_u *)&p_ml, PV_ML,
    {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
   {"modelines",   "mls",  P_NUM|P_VI_DEF,
@@ -1123,7 +1118,7 @@ static struct vimoption
   {"modified",    "mod",  P_BOOL|P_NO_MKRC|P_VI_DEF|P_RSTAT,
    (char_u *)&p_mod, PV_MOD,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"more",        NULL,   P_BOOL|P_VIM,
+  {"more",        NULL,   P_BOOL,
    (char_u *)&p_more, PV_NONE,
    {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
   {"mouse",       NULL,   P_STRING|P_VI_DEF|P_FLAGLIST,
@@ -1161,7 +1156,7 @@ static struct vimoption
   {"number",      "nu",   P_BOOL|P_VI_DEF|P_RWIN,
    (char_u *)VAR_WIN, PV_NU,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"numberwidth", "nuw",  P_NUM|P_RWIN|P_VIM,
+  {"numberwidth", "nuw",  P_NUM|P_RWIN,
    (char_u *)VAR_WIN, PV_NUW,
    {(char_u *)8L, (char_u *)4L} SCRIPTID_INIT},
   {"omnifunc",    "ofu",  P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
@@ -1207,7 +1202,7 @@ static struct vimoption
      (char_u *)".,/usr/include,,",
      (char_u *)0L
    } SCRIPTID_INIT},
-  {"preserveindent", "pi", P_BOOL|P_VI_DEF|P_VIM,
+  {"preserveindent", "pi", P_BOOL|P_VI_DEF,
    (char_u *)&p_pi, PV_PI,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"previewheight", "pvh", P_NUM|P_VI_DEF,
@@ -1285,7 +1280,7 @@ static struct vimoption
   {"restorescreen", "rs", P_BOOL|P_VI_DEF,
    (char_u *)NULL, PV_NONE,
    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"revins",      "ri",   P_BOOL|P_VI_DEF|P_VIM,
+  {"revins",      "ri",   P_BOOL|P_VI_DEF,
    (char_u *)&p_ri, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"rightleft",   "rl",   P_BOOL|P_VI_DEF|P_RWIN,
@@ -1295,7 +1290,7 @@ static struct vimoption
    (char_u *)VAR_WIN, PV_RLC,
    {(char_u *)"search", (char_u *)NULL}
    SCRIPTID_INIT},
-  {"ruler",       "ru",   P_BOOL|P_VI_DEF|P_VIM|P_RSTAT,
+  {"ruler",       "ru",   P_BOOL|P_VI_DEF|P_RSTAT,
    (char_u *)&p_ru, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"rulerformat", "ruf",  P_STRING|P_VI_DEF|P_ALLOCED|P_RSTAT,
@@ -1311,10 +1306,10 @@ static struct vimoption
   {"scrollbind",  "scb",  P_BOOL|P_VI_DEF,
    (char_u *)VAR_WIN, PV_SCBIND,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"scrolljump",  "sj",   P_NUM|P_VI_DEF|P_VIM,
+  {"scrolljump",  "sj",   P_NUM|P_VI_DEF,
    (char_u *)&p_sj, PV_NONE,
    {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"scrolloff",   "so",   P_NUM|P_VI_DEF|P_VIM|P_RALL,
+  {"scrolloff",   "so",   P_NUM|P_VI_DEF|P_RALL,
    (char_u *)&p_so, PV_NONE,
    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
   {"scrollopt",   "sbo",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
@@ -1394,20 +1389,20 @@ static struct vimoption
      (char_u *)"",
      (char_u *)0L
    } SCRIPTID_INIT},
-  {"shiftround",  "sr",   P_BOOL|P_VI_DEF|P_VIM,
+  {"shiftround",  "sr",   P_BOOL|P_VI_DEF,
    (char_u *)&p_sr, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"shiftwidth",  "sw",   P_NUM|P_VI_DEF,
    (char_u *)&p_sw, PV_SW,
    {(char_u *)8L, (char_u *)0L} SCRIPTID_INIT},
-  {"shortmess",   "shm",  P_STRING|P_VIM|P_FLAGLIST,
+  {"shortmess",   "shm",  P_STRING|P_FLAGLIST,
    (char_u *)&p_shm, PV_NONE,
    {(char_u *)"", (char_u *)"filnxtToO"}
    SCRIPTID_INIT},
   {"showbreak",   "sbr",  P_STRING|P_VI_DEF|P_RALL,
    (char_u *)&p_sbr, PV_NONE,
    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"showcmd",     "sc",   P_BOOL|P_VIM,
+  {"showcmd",     "sc",   P_BOOL,
    (char_u *)&p_sc, PV_NONE,
    {(char_u *)FALSE,
 #ifdef UNIX
@@ -1422,7 +1417,7 @@ static struct vimoption
   {"showmatch",   "sm",   P_BOOL|P_VI_DEF,
    (char_u *)&p_sm, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"showmode",    "smd",  P_BOOL|P_VIM,
+  {"showmode",    "smd",  P_BOOL,
    (char_u *)&p_smd, PV_NONE,
    {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
   {"showtabline", "stal", P_NUM|P_VI_DEF|P_RALL,
@@ -1431,22 +1426,22 @@ static struct vimoption
   {"sidescroll",  "ss",   P_NUM|P_VI_DEF,
    (char_u *)&p_ss, PV_NONE,
    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"sidescrolloff", "siso", P_NUM|P_VI_DEF|P_VIM|P_RBUF,
+  {"sidescrolloff", "siso", P_NUM|P_VI_DEF|P_RBUF,
    (char_u *)&p_siso, PV_NONE,
    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
   {"slowopen",    "slow", P_BOOL|P_VI_DEF,
    (char_u *)NULL, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"smartcase",   "scs",  P_BOOL|P_VI_DEF|P_VIM,
+  {"smartcase",   "scs",  P_BOOL|P_VI_DEF,
    (char_u *)&p_scs, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"smartindent", "si",   P_BOOL|P_VI_DEF|P_VIM,
+  {"smartindent", "si",   P_BOOL|P_VI_DEF,
    (char_u *)&p_si, PV_SI,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"smarttab",    "sta",  P_BOOL|P_VI_DEF|P_VIM,
+  {"smarttab",    "sta",  P_BOOL|P_VI_DEF,
    (char_u *)&p_sta, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"softtabstop", "sts",  P_NUM|P_VI_DEF|P_VIM,
+  {"softtabstop", "sts",  P_NUM|P_VI_DEF,
    (char_u *)&p_sts, PV_STS,
    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
   {"sourceany",   NULL,   P_BOOL|P_VI_DEF,
@@ -1477,7 +1472,7 @@ static struct vimoption
   {"splitright",  "spr",  P_BOOL|P_VI_DEF,
    (char_u *)&p_spr, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"startofline", "sol",  P_BOOL|P_VI_DEF|P_VIM,
+  {"startofline", "sol",  P_BOOL|P_VI_DEF,
    (char_u *)&p_sol, PV_NONE,
    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
   {"statusline","stl",  P_STRING|P_VI_DEF|P_ALLOCED|P_RSTAT,
@@ -1524,7 +1519,7 @@ static struct vimoption
   {"taglength",   "tl",   P_NUM|P_VI_DEF,
    (char_u *)&p_tl, PV_NONE,
    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"tagrelative", "tr",   P_BOOL|P_VIM,
+  {"tagrelative", "tr",   P_BOOL,
    (char_u *)&p_tr, PV_NONE,
    {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
   {"tags",        "tag",  P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
@@ -1550,13 +1545,13 @@ static struct vimoption
   {"terse",       NULL,   P_BOOL|P_VI_DEF,
    (char_u *)&p_terse, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"textwidth",   "tw",   P_NUM|P_VI_DEF|P_VIM|P_RBUF,
+  {"textwidth",   "tw",   P_NUM|P_VI_DEF|P_RBUF,
    (char_u *)&p_tw, PV_TW,
    {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
   {"thesaurus",   "tsr",  P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
    (char_u *)&p_tsr, PV_TSR,
    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"tildeop",     "top",  P_BOOL|P_VI_DEF|P_VIM,
+  {"tildeop",     "top",  P_BOOL|P_VI_DEF,
    (char_u *)&p_to, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"timeout",     "to",   P_BOOL|P_VI_DEF,
@@ -1579,7 +1574,7 @@ static struct vimoption
   {"titlestring", NULL,   P_STRING|P_VI_DEF,
    (char_u *)&p_titlestring, PV_NONE,
    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"ttimeout",    NULL,   P_BOOL|P_VI_DEF|P_VIM,
+  {"ttimeout",    NULL,   P_BOOL|P_VI_DEF,
    (char_u *)&p_ttimeout, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"ttimeoutlen", "ttm",  P_NUM|P_VI_DEF,
@@ -1609,7 +1604,7 @@ static struct vimoption
    (char_u *)&p_udir, PV_NONE,
    {(char_u *)".", (char_u *)0L}
    SCRIPTID_INIT},
-  {"undofile",    "udf",  P_BOOL|P_VI_DEF|P_VIM,
+  {"undofile",    "udf",  P_BOOL|P_VI_DEF,
    (char_u *)&p_udf, PV_UDF,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"undolevels",  "ul",   P_NUM|P_VI_DEF,
@@ -1649,7 +1644,7 @@ static struct vimoption
    (char_u *)&p_viminfo, PV_NONE,
    {(char_u *)"", (char_u *)"'100,<50,s10,h"}
    SCRIPTID_INIT},
-  {"virtualedit", "ve",   P_STRING|P_COMMA|P_NODUP|P_VI_DEF|P_VIM|P_CURSWANT,
+  {"virtualedit", "ve",   P_STRING|P_COMMA|P_NODUP|P_VI_DEF|P_CURSWANT,
    (char_u *)&p_ve, PV_NONE,
    {(char_u *)"", (char_u *)""}
    SCRIPTID_INIT},
@@ -1671,10 +1666,10 @@ static struct vimoption
   {"weirdinvert", "wiv",  P_BOOL|P_VI_DEF|P_RCLR,
    (char_u *)&p_wiv, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"whichwrap",   "ww",   P_STRING|P_VIM|P_COMMA|P_FLAGLIST,
+  {"whichwrap",   "ww",   P_STRING|P_COMMA|P_FLAGLIST,
    (char_u *)&p_ww, PV_NONE,
    {(char_u *)"", (char_u *)"b,s"} SCRIPTID_INIT},
-  {"wildchar",    "wc",   P_NUM|P_VIM,
+  {"wildchar",    "wc",   P_NUM,
    (char_u *)&p_wc, PV_NONE,
    {(char_u *)(long)Ctrl_E, (char_u *)(long)TAB}
    SCRIPTID_INIT},
@@ -1737,7 +1732,7 @@ static struct vimoption
   {"writeany",    "wa",   P_BOOL|P_VI_DEF,
    (char_u *)&p_wa, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"writebackup", "wb",   P_BOOL|P_VI_DEF|P_VIM,
+  {"writebackup", "wb",   P_BOOL|P_VI_DEF,
    (char_u *)&p_wb, PV_NONE,
    {
      (char_u *)TRUE,
@@ -1858,9 +1853,6 @@ void set_init_1(void)
   long_u n;
 
   langmap_init();
-
-  /* Be Vi compatible by default */
-  p_cp = TRUE;
 
   /* Use POSIX compatibility when $VIM_POSIX is set. */
   if (os_getenv("VIM_POSIX") != NULL) {
@@ -2213,7 +2205,7 @@ set_options_default (
 
   for (i = 0; !istermoption(&options[i]); i++)
     if (!(options[i].flags & P_NODEFAULT))
-      set_option_default(i, opt_flags, p_cp);
+      set_option_default(i, opt_flags, false);
 
   /* The 'scroll' option must be computed for all windows. */
   FOR_ALL_TAB_WINDOWS(tp, wp)
@@ -2291,7 +2283,7 @@ void set_init_2(void)
   set_number_default("scroll", Rows / 2);
   idx = findoption((char_u *)"scroll");
   if (idx >= 0 && !(options[idx].flags & P_WAS_SET))
-    set_option_default(idx, OPT_LOCAL, p_cp);
+    set_option_default(idx, OPT_LOCAL, false);
   comp_col();
 
   /*
@@ -2710,7 +2702,7 @@ do_set (
 
       if (vim_strchr((char_u *)"?=:!&<", nextchar) != NULL) {
         arg += len;
-        cp_val = p_cp;
+        cp_val = false;
         if (nextchar == '&' && arg[1] == 'v' && arg[2] == 'i') {
           if (arg[3] == 'm') {          /* "opt&vim": set to Vim default */
             cp_val = FALSE;
@@ -4955,12 +4947,8 @@ set_bool_option (
    * Handle side effects of changing a bool option.
    */
 
-  /* 'compatible' */
-  if ((int *)varp == &p_cp) {
-    compatible_set();
-  }
   /* 'undofile' */
-  else if ((int *)varp == &curbuf->b_p_udf || (int *)varp == &p_udf) {
+  if ((int *)varp == &curbuf->b_p_udf || (int *)varp == &p_udf) {
     /* Only take action when the option was set. When reset we do not
      * delete the undo file, the option may be set again without making
      * any changes in between. */
@@ -6161,7 +6149,7 @@ static int optval_default(struct vimoption *p, char_u *varp)
 
   if (varp == NULL)
     return TRUE;            /* hidden option is always at default */
-  dvi = ((p->flags & P_VI_DEF) || p_cp) ? VI_DEFAULT : VIM_DEFAULT;
+  dvi = (p->flags & P_VI_DEF) ? VI_DEFAULT : VIM_DEFAULT;
   if (p->flags & P_NUM)
     return *(long *)varp == (long)p->def_val[dvi];
   if (p->flags & P_BOOL)
@@ -7782,7 +7770,6 @@ void vimrc_found(char_u *fname, char_u *envname)
   char_u      *p;
 
   if (!option_was_set((char_u *)"cp")) {
-    p_cp = FALSE;
     for (opt_idx = 0; !istermoption(&options[opt_idx]); opt_idx++)
       if (!(options[opt_idx].flags & (P_WAS_SET|P_VI_DEF)))
         set_option_default(opt_idx, OPT_FREE, FALSE);
@@ -7801,22 +7788,6 @@ void vimrc_found(char_u *fname, char_u *envname)
     } else if (dofree)
       free(p);
   }
-}
-
-/*
- * Set 'compatible' on or off.  Called for "-C" and "-N" command line arg.
- */
-void change_compatible(int on)
-{
-  int opt_idx;
-
-  if (p_cp != on) {
-    p_cp = on;
-    compatible_set();
-  }
-  opt_idx = findoption((char_u *)"cp");
-  if (opt_idx >= 0)
-    options[opt_idx].flags |= P_WAS_SET;
 }
 
 /*
@@ -7844,25 +7815,6 @@ void reset_option_was_set(char_u *name)
 
   if (idx >= 0)
     options[idx].flags &= ~P_WAS_SET;
-}
-
-/*
- * compatible_set() - Called when 'compatible' has been set or unset.
- *
- * When 'compatible' set: Set all relevant options (those that have the P_VIM)
- * flag) to a Vi compatible value.
- * When 'compatible' is unset: Set all options that have a different default
- * for Vim (without the P_VI_DEF flag) to that default.
- */
-static void compatible_set(void)
-{
-  int opt_idx;
-
-  for (opt_idx = 0; !istermoption(&options[opt_idx]); opt_idx++)
-    if (       ((options[opt_idx].flags & P_VIM) && p_cp)
-               || (!(options[opt_idx].flags & P_VI_DEF) && !p_cp))
-      set_option_default(opt_idx, OPT_FREE, p_cp);
-  didset_options();
 }
 
 /*

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -297,13 +297,10 @@ struct vimoption {
                                 * buffer-local option: global value */
   idopt_T indir;                /* global option: PV_NONE;
                                  * local option: indirect option index */
-  char_u      *def_val[2];      /* default values for variable (vi and vim) */
+  char_u      *def_val;         /* default values for variable */
   scid_T scriptID;              /* script in which the option was last set */
 # define SCRIPTID_INIT , 0
 };
-
-#define VI_DEFAULT  0       /* def_val[VI_DEFAULT] is Vi default value */
-#define VIM_DEFAULT 1       /* def_val[VIM_DEFAULT] is Vim default value */
 
 /*
  * Flags
@@ -322,7 +319,6 @@ struct vimoption {
                                     use free() when assigning new value */
 #define P_WAS_SET       0x100   /* option has been set/reset */
 #define P_NO_MKRC       0x200   /* don't include in :mkvimrc output */
-#define P_VI_DEF        0x400   /* Use Vi default for Vim */
 
 /* when option changed, what to display: */
 #define P_RSTAT         0x1000  /* redraw status lines */
@@ -372,1380 +368,1331 @@ struct vimoption {
 static struct vimoption
   options[] =
 {
-  {"aleph",       "al",   P_NUM|P_VI_DEF|P_CURSWANT,
+  {"aleph",       "al",   P_NUM|P_CURSWANT,
    (char_u *)&p_aleph, PV_NONE,
-   {
-     (char_u *)224L,
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"antialias",   "anti", P_BOOL|P_VI_DEF|P_RCLR,
+   
+     (char_u *)224L SCRIPTID_INIT},
+  {"antialias",   "anti", P_BOOL|P_RCLR,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)FALSE}
+   (char_u *)FALSE
    SCRIPTID_INIT},
-  {"arabic",      "arab", P_BOOL|P_VI_DEF|P_CURSWANT,
+  {"arabic",      "arab", P_BOOL|P_CURSWANT,
    (char_u *)VAR_WIN, PV_ARAB,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"arabicshape", "arshape", P_BOOL|P_VI_DEF|P_RCLR,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"arabicshape", "arshape", P_BOOL|P_RCLR,
    (char_u *)&p_arshape, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"allowrevins", "ari",  P_BOOL|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"allowrevins", "ari",  P_BOOL,
    (char_u *)&p_ari, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"altkeymap",   "akm",  P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"altkeymap",   "akm",  P_BOOL,
    (char_u *)&p_altkeymap, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"ambiwidth",  "ambw",  P_STRING|P_VI_DEF|P_RCLR,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"ambiwidth",  "ambw",  P_STRING|P_RCLR,
    (char_u *)&p_ambw, PV_NONE,
-   {(char_u *)"single", (char_u *)0L}
+   (char_u *)"single"
    SCRIPTID_INIT},
-  {"autochdir",  "acd",   P_BOOL|P_VI_DEF,
+  {"autochdir",  "acd",   P_BOOL,
    (char_u *)&p_acd, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"autoindent",  "ai",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"autoindent",  "ai",   P_BOOL,
    (char_u *)&p_ai, PV_AI,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"autoprint",   "ap",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"autoprint",   "ap",   P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"autoread",    "ar",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"autoread",    "ar",   P_BOOL,
    (char_u *)&p_ar, PV_AR,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"autowrite",   "aw",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"autowrite",   "aw",   P_BOOL,
    (char_u *)&p_aw, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"autowriteall","awa",  P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"autowriteall","awa",  P_BOOL,
    (char_u *)&p_awa, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"background",  "bg",   P_STRING|P_VI_DEF|P_RCLR,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"background",  "bg",   P_STRING|P_RCLR,
    (char_u *)&p_bg, PV_NONE,
-   {
-     (char_u *)"light",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"backspace",   "bs",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+   
+     (char_u *)"light" SCRIPTID_INIT},
+  {"backspace",   "bs",   P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_bs, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"backup",      "bk",   P_BOOL|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"backup",      "bk",   P_BOOL,
    (char_u *)&p_bk, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)FALSE SCRIPTID_INIT},
   {"backupcopy",  "bkc",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_bkc, PV_NONE,
 #ifdef UNIX
-   {(char_u *)"yes", (char_u *)"auto"}
+    (char_u *)"auto"
 #else
-   {(char_u *)"auto", (char_u *)"auto"}
+    (char_u *)"auto"
 #endif
    SCRIPTID_INIT},
-  {"backupdir",   "bdir", P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP|P_SECURE,
+  {"backupdir",   "bdir", P_STRING|P_EXPAND|P_COMMA|P_NODUP|P_SECURE,
    (char_u *)&p_bdir, PV_NONE,
-   {(char_u *)DFLT_BDIR, (char_u *)0L} SCRIPTID_INIT},
-  {"backupext",   "bex",  P_STRING|P_VI_DEF|P_NFNAME,
+   (char_u *)DFLT_BDIR SCRIPTID_INIT},
+  {"backupext",   "bex",  P_STRING|P_NFNAME,
    (char_u *)&p_bex, PV_NONE,
-   {
-     (char_u *)"~",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"backupskip",  "bsk",  P_STRING|P_VI_DEF|P_COMMA,
+   
+     (char_u *)"~" SCRIPTID_INIT},
+  {"backupskip",  "bsk",  P_STRING|P_COMMA,
    (char_u *)&p_bsk, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"beautify",    "bf",   P_BOOL|P_VI_DEF,
+  {"beautify",    "bf",   P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"binary",      "bin",  P_BOOL|P_VI_DEF|P_RSTAT,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"binary",      "bin",  P_BOOL|P_RSTAT,
    (char_u *)&p_bin, PV_BIN,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"bioskey",     "biosk",P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"bioskey",     "biosk",P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"bomb",        NULL,   P_BOOL|P_NO_MKRC|P_VI_DEF|P_RSTAT,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"bomb",        NULL,   P_BOOL|P_NO_MKRC|P_RSTAT,
    (char_u *)&p_bomb, PV_BOMB,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"breakat",     "brk",  P_STRING|P_VI_DEF|P_RALL|P_FLAGLIST,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"breakat",     "brk",  P_STRING|P_RALL|P_FLAGLIST,
    (char_u *)&p_breakat, PV_NONE,
-   {(char_u *)" \t!@*-+;:,./?", (char_u *)0L}
+   (char_u *)" \t!@*-+;:,./?"
    SCRIPTID_INIT},
-  {"browsedir",   "bsdir",P_STRING|P_VI_DEF,
+  {"browsedir",   "bsdir",P_STRING,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L}
+   (char_u *)0L
    SCRIPTID_INIT},
-  {"bufhidden",   "bh",   P_STRING|P_ALLOCED|P_VI_DEF|P_NOGLOB,
+  {"bufhidden",   "bh",   P_STRING|P_ALLOCED|P_NOGLOB,
    (char_u *)&p_bh, PV_BH,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"buflisted",   "bl",   P_BOOL|P_VI_DEF|P_NOGLOB,
+  {"buflisted",   "bl",   P_BOOL|P_NOGLOB,
    (char_u *)&p_bl, PV_BL,
-   {(char_u *)1L, (char_u *)0L}
+   (char_u *)1L
    SCRIPTID_INIT},
-  {"buftype",     "bt",   P_STRING|P_ALLOCED|P_VI_DEF|P_NOGLOB,
+  {"buftype",     "bt",   P_STRING|P_ALLOCED|P_NOGLOB,
    (char_u *)&p_bt, PV_BT,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"casemap",     "cmp",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"casemap",     "cmp",   P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_cmp, PV_NONE,
-   {(char_u *)"internal,keepascii", (char_u *)0L}
+   (char_u *)"internal,keepascii"
    SCRIPTID_INIT},
-  {"cdpath",      "cd",   P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
+  {"cdpath",      "cd",   P_STRING|P_EXPAND|P_COMMA|P_NODUP,
    (char_u *)&p_cdpath, PV_NONE,
-   {(char_u *)",,", (char_u *)0L}
+   (char_u *)",,"
    SCRIPTID_INIT},
   {"cedit",       NULL,   P_STRING,
    (char_u *)&p_cedit, PV_NONE,
-   {(char_u *)"", (char_u *)CTRL_F_STR}
+    (char_u *)CTRL_F_STR
    SCRIPTID_INIT},
-  {"charconvert",  "ccv", P_STRING|P_VI_DEF|P_SECURE,
+  {"charconvert",  "ccv", P_STRING|P_SECURE,
    (char_u *)&p_ccv, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"cindent",     "cin",  P_BOOL|P_VI_DEF,
+  {"cindent",     "cin",  P_BOOL,
    (char_u *)&p_cin, PV_CIN,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"cinkeys",     "cink", P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"cinkeys",     "cink", P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_cink, PV_CINK,
-   {(char_u *)"0{,0},0),:,0#,!^F,o,O,e", (char_u *)0L}
+   (char_u *)"0{,0},0),:,0#,!^F,o,O,e"
    SCRIPTID_INIT},
-  {"cinoptions",  "cino", P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
+  {"cinoptions",  "cino", P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_cino, PV_CINO,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"cinwords",    "cinw", P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)"" SCRIPTID_INIT},
+  {"cinwords",    "cinw", P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_cinw, PV_CINW,
-   {(char_u *)"if,else,while,do,for,switch",
-    (char_u *)0L}
+   (char_u *)"if,else,while,do,for,switch"
    SCRIPTID_INIT},
-  {"clipboard",   "cb",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"clipboard",   "cb",   P_STRING|P_COMMA|P_NODUP,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"cmdheight",   "ch",   P_NUM|P_VI_DEF|P_RALL,
+  {"cmdheight",   "ch",   P_NUM|P_RALL,
    (char_u *)&p_ch, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"cmdwinheight", "cwh", P_NUM|P_VI_DEF,
+   (char_u *)1L SCRIPTID_INIT},
+  {"cmdwinheight", "cwh", P_NUM,
    (char_u *)&p_cwh, PV_NONE,
-   {(char_u *)7L, (char_u *)0L} SCRIPTID_INIT},
-  {"colorcolumn", "cc",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP|P_RWIN,
+   (char_u *)7L SCRIPTID_INIT},
+  {"colorcolumn", "cc",   P_STRING|P_COMMA|P_NODUP|P_RWIN,
    (char_u *)VAR_WIN, PV_CC,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"columns",     "co",   P_NUM|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|P_RCLR,
+   (char_u *)"" SCRIPTID_INIT},
+  {"columns",     "co",   P_NUM|P_NODEFAULT|P_NO_MKRC|P_RCLR,
    (char_u *)&Columns, PV_NONE,
-   {(char_u *)80L, (char_u *)0L} SCRIPTID_INIT},
-  {"comments",    "com",  P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP|
+   (char_u *)80L SCRIPTID_INIT},
+  {"comments",    "com",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP|
    P_CURSWANT,
    (char_u *)&p_com, PV_COM,
-   {(char_u *)"s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-",
-    (char_u *)0L}
+   (char_u *)"s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-"
    SCRIPTID_INIT},
-  {"commentstring", "cms", P_STRING|P_ALLOCED|P_VI_DEF|P_CURSWANT,
+  {"commentstring", "cms", P_STRING|P_ALLOCED|P_CURSWANT,
    (char_u *)&p_cms, PV_CMS,
-   {(char_u *)"/*%s*/", (char_u *)0L}
+   (char_u *)"/*%s*/"
    SCRIPTID_INIT},
   /* P_PRI_MKRC isn't needed here, optval_default()
    * always returns TRUE for 'compatible' */
   {"compatible",  "cp",   P_BOOL|P_RALL,
    (char_u *)&p_vi_compatible, PV_NONE,
-   {(char_u *)FALSE, (char_u *)FALSE} SCRIPTID_INIT},
-  {"complete",    "cpt",  P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
+    (char_u *)FALSE SCRIPTID_INIT},
+  {"complete",    "cpt",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_cpt, PV_CPT,
-   {(char_u *)".,w,b,u,t,i", (char_u *)0L}
+   (char_u *)".,w,b,u,t,i"
    SCRIPTID_INIT},
-  {"concealcursor","cocu", P_STRING|P_ALLOCED|P_RWIN|P_VI_DEF,
+  {"concealcursor","cocu", P_STRING|P_ALLOCED|P_RWIN,
    (char_u *)VAR_WIN, PV_COCU,
-   {(char_u *)"", (char_u *)NULL}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"conceallevel","cole", P_NUM|P_RWIN|P_VI_DEF,
+  {"conceallevel","cole", P_NUM|P_RWIN,
    (char_u *)VAR_WIN, PV_COLE,
-   {(char_u *)0L, (char_u *)0L}
+   (char_u *)0L
    SCRIPTID_INIT},
-  {"completefunc", "cfu", P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
+  {"completefunc", "cfu", P_STRING|P_ALLOCED|P_SECURE,
    (char_u *)&p_cfu, PV_CFU,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"completeopt",   "cot",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"completeopt",   "cot",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_cot, PV_NONE,
-   {(char_u *)"menu,preview", (char_u *)0L}
+   (char_u *)"menu,preview"
    SCRIPTID_INIT},
-  {"confirm",     "cf",   P_BOOL|P_VI_DEF,
+  {"confirm",     "cf",   P_BOOL,
    (char_u *)&p_confirm, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"conskey",     "consk",P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"conskey",     "consk",P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"copyindent",  "ci",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"copyindent",  "ci",   P_BOOL,
    (char_u *)&p_ci, PV_CI,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)FALSE SCRIPTID_INIT},
   {"cpoptions",   "cpo",  P_STRING|P_RALL|P_FLAGLIST,
    (char_u *)&p_cpo, PV_NONE,
-   {(char_u *)CPO_VI, (char_u *)CPO_VIM}
+    (char_u *)CPO_VIM
    SCRIPTID_INIT},
-  {"cscopepathcomp", "cspc", P_NUM|P_VI_DEF,
+  {"cscopepathcomp", "cspc", P_NUM,
    (char_u *)&p_cspc, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"cscopeprg",   "csprg", P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+   (char_u *)0L SCRIPTID_INIT},
+  {"cscopeprg",   "csprg", P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_csprg, PV_NONE,
-   {(char_u *)"cscope", (char_u *)0L}
+   (char_u *)"cscope"
    SCRIPTID_INIT},
-  {"cscopequickfix", "csqf", P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"cscopequickfix", "csqf", P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_csqf, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"cscoperelative", "csre", P_BOOL|P_VI_DEF,
+  {"cscoperelative", "csre", P_BOOL,
    (char_u *)&p_csre, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"cscopetag",   "cst",  P_BOOL|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"cscopetag",   "cst",  P_BOOL,
    (char_u *)&p_cst, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"cscopetagorder", "csto", P_NUM|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"cscopetagorder", "csto", P_NUM,
    (char_u *)&p_csto, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"cscopeverbose", "csverb", P_BOOL|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"cscopeverbose", "csverb", P_BOOL,
    (char_u *)&p_csverbose, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"cursorbind",  "crb",  P_BOOL|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"cursorbind",  "crb",  P_BOOL,
    (char_u *)VAR_WIN, PV_CRBIND,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"cursorcolumn", "cuc", P_BOOL|P_VI_DEF|P_RWIN,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"cursorcolumn", "cuc", P_BOOL|P_RWIN,
    (char_u *)VAR_WIN, PV_CUC,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"cursorline",   "cul", P_BOOL|P_VI_DEF|P_RWIN,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"cursorline",   "cul", P_BOOL|P_RWIN,
    (char_u *)VAR_WIN, PV_CUL,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"debug",       NULL,   P_STRING|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"debug",       NULL,   P_STRING,
    (char_u *)&p_debug, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"define",      "def",  P_STRING|P_ALLOCED|P_VI_DEF|P_CURSWANT,
+   (char_u *)"" SCRIPTID_INIT},
+  {"define",      "def",  P_STRING|P_ALLOCED|P_CURSWANT,
    (char_u *)&p_def, PV_DEF,
-   {(char_u *)"^\\s*#\\s*define", (char_u *)0L}
+   (char_u *)"^\\s*#\\s*define"
    SCRIPTID_INIT},
-  {"delcombine", "deco",  P_BOOL|P_VI_DEF,
+  {"delcombine", "deco",  P_BOOL,
    (char_u *)&p_deco, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"dictionary",  "dict", P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"dictionary",  "dict", P_STRING|P_EXPAND|P_COMMA|P_NODUP,
    (char_u *)&p_dict, PV_DICT,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"diff",        NULL,   P_BOOL|P_VI_DEF|P_RWIN|P_NOGLOB,
+   (char_u *)"" SCRIPTID_INIT},
+  {"diff",        NULL,   P_BOOL|P_RWIN|P_NOGLOB,
    (char_u *)VAR_WIN, PV_DIFF,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"diffexpr",    "dex",  P_STRING|P_VI_DEF|P_SECURE|P_CURSWANT,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"diffexpr",    "dex",  P_STRING|P_SECURE|P_CURSWANT,
    (char_u *)&p_dex, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"diffopt",     "dip",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN|P_COMMA|P_NODUP,
+  {"diffopt",     "dip",  P_STRING|P_ALLOCED|P_RWIN|P_COMMA|P_NODUP,
    (char_u *)&p_dip, PV_NONE,
-   {(char_u *)"filler", (char_u *)NULL}
+   (char_u *)"filler"
    SCRIPTID_INIT},
-  {"digraph",     "dg",   P_BOOL|P_VI_DEF,
+  {"digraph",     "dg",   P_BOOL,
    (char_u *)&p_dg, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"directory",   "dir",  P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP|P_SECURE,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"directory",   "dir",  P_STRING|P_EXPAND|P_COMMA|P_NODUP|P_SECURE,
    (char_u *)&p_dir, PV_NONE,
-   {(char_u *)DFLT_DIR, (char_u *)0L} SCRIPTID_INIT},
-  {"display",     "dy",   P_STRING|P_VI_DEF|P_COMMA|P_RALL|P_NODUP,
+   (char_u *)DFLT_DIR SCRIPTID_INIT},
+  {"display",     "dy",   P_STRING|P_COMMA|P_RALL|P_NODUP,
    (char_u *)&p_dy, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"eadirection", "ead",  P_STRING|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"eadirection", "ead",  P_STRING,
    (char_u *)&p_ead, PV_NONE,
-   {(char_u *)"both", (char_u *)0L}
+   (char_u *)"both"
    SCRIPTID_INIT},
-  {"edcompatible","ed",   P_BOOL|P_VI_DEF,
+  {"edcompatible","ed",   P_BOOL,
    (char_u *)&p_ed, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"encoding",    "enc",  P_STRING|P_VI_DEF|P_RCLR|P_NO_ML,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"encoding",    "enc",  P_STRING|P_RCLR|P_NO_ML,
    (char_u *)&p_enc, PV_NONE,
-   {(char_u *)ENC_DFLT, (char_u *)0L}
+   (char_u *)ENC_DFLT
    SCRIPTID_INIT},
-  {"endofline",   "eol",  P_BOOL|P_NO_MKRC|P_VI_DEF|P_RSTAT,
+  {"endofline",   "eol",  P_BOOL|P_NO_MKRC|P_RSTAT,
    (char_u *)&p_eol, PV_EOL,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"equalalways", "ea",   P_BOOL|P_VI_DEF|P_RALL,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"equalalways", "ea",   P_BOOL|P_RALL,
    (char_u *)&p_ea, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"equalprg",    "ep",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"equalprg",    "ep",   P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_ep, PV_EP,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"errorbells",  "eb",   P_BOOL|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"errorbells",  "eb",   P_BOOL,
    (char_u *)&p_eb, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"errorfile",   "ef",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"errorfile",   "ef",   P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_ef, PV_NONE,
-   {(char_u *)DFLT_ERRORFILE, (char_u *)0L}
+   (char_u *)DFLT_ERRORFILE
    SCRIPTID_INIT},
-  {"errorformat", "efm",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"errorformat", "efm",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_efm, PV_EFM,
-   {(char_u *)DFLT_EFM, (char_u *)0L}
+   (char_u *)DFLT_EFM
    SCRIPTID_INIT},
   {"esckeys",     "ek",   P_BOOL,
    (char_u *)&p_ek, PV_NONE,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"eventignore", "ei",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+    (char_u *)TRUE SCRIPTID_INIT},
+  {"eventignore", "ei",   P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_ei, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"expandtab",   "et",   P_BOOL|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"expandtab",   "et",   P_BOOL,
    (char_u *)&p_et, PV_ET,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"exrc",        "ex",   P_BOOL|P_VI_DEF|P_SECURE,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"exrc",        "ex",   P_BOOL|P_SECURE,
    (char_u *)&p_exrc, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"fileencoding","fenc", P_STRING|P_ALLOCED|P_VI_DEF|P_RSTAT|P_RBUF|P_NO_MKRC,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"fileencoding","fenc", P_STRING|P_ALLOCED|P_RSTAT|P_RBUF|P_NO_MKRC,
    (char_u *)&p_fenc, PV_FENC,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"fileencodings","fencs", P_STRING|P_VI_DEF|P_COMMA,
+  {"fileencodings","fencs", P_STRING|P_COMMA,
    (char_u *)&p_fencs, PV_NONE,
-   {(char_u *)"ucs-bom", (char_u *)0L}
+   (char_u *)"ucs-bom"
    SCRIPTID_INIT},
-  {"fileformat",  "ff",   P_STRING|P_ALLOCED|P_VI_DEF|P_RSTAT|P_NO_MKRC|
+  {"fileformat",  "ff",   P_STRING|P_ALLOCED|P_RSTAT|P_NO_MKRC|
    P_CURSWANT,
    (char_u *)&p_ff, PV_FF,
-   {(char_u *)DFLT_FF, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)DFLT_FF SCRIPTID_INIT},
   {"fileformats", "ffs",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_ffs, PV_NONE,
-   {(char_u *)DFLT_FFS_VI, (char_u *)DFLT_FFS_VIM}
+    (char_u *)DFLT_FFS_VIM
    SCRIPTID_INIT},
-  {"fileignorecase", "fic", P_BOOL|P_VI_DEF,
+  {"fileignorecase", "fic", P_BOOL,
    (char_u *)&p_fic, PV_NONE,
-   {
+   
 #ifdef CASE_INSENSITIVE_FILENAME
-     (char_u *)TRUE,
+     (char_u *)TRUE
 #else
-     (char_u *)FALSE,
+     (char_u *)FALSE
 #endif
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"filetype",    "ft",   P_STRING|P_ALLOCED|P_VI_DEF|P_NOGLOB|P_NFNAME,
+ SCRIPTID_INIT},
+  {"filetype",    "ft",   P_STRING|P_ALLOCED|P_NOGLOB|P_NFNAME,
    (char_u *)&p_ft, PV_FT,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"fillchars",   "fcs",  P_STRING|P_VI_DEF|P_RALL|P_COMMA|P_NODUP,
+  {"fillchars",   "fcs",  P_STRING|P_RALL|P_COMMA|P_NODUP,
    (char_u *)&p_fcs, PV_NONE,
-   {(char_u *)"vert:|,fold:-", (char_u *)0L}
+   (char_u *)"vert:|,fold:-"
    SCRIPTID_INIT},
-  {"fkmap",       "fk",   P_BOOL|P_VI_DEF,
+  {"fkmap",       "fk",   P_BOOL,
    (char_u *)&p_fkmap, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"flash",       "fl",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"flash",       "fl",   P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"foldclose",   "fcl",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP|P_RWIN,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"foldclose",   "fcl",  P_STRING|P_COMMA|P_NODUP|P_RWIN,
    (char_u *)&p_fcl, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"foldcolumn",  "fdc",  P_NUM|P_VI_DEF|P_RWIN,
+   (char_u *)"" SCRIPTID_INIT},
+  {"foldcolumn",  "fdc",  P_NUM|P_RWIN,
    (char_u *)VAR_WIN, PV_FDC,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"foldenable",  "fen",  P_BOOL|P_VI_DEF|P_RWIN,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"foldenable",  "fen",  P_BOOL|P_RWIN,
    (char_u *)VAR_WIN, PV_FEN,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"foldexpr",    "fde",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"foldexpr",    "fde",  P_STRING|P_ALLOCED|P_RWIN,
    (char_u *)VAR_WIN, PV_FDE,
-   {(char_u *)"0", (char_u *)NULL}
+   (char_u *)"0"
    SCRIPTID_INIT},
-  {"foldignore",  "fdi",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
+  {"foldignore",  "fdi",  P_STRING|P_ALLOCED|P_RWIN,
    (char_u *)VAR_WIN, PV_FDI,
-   {(char_u *)"#", (char_u *)NULL} SCRIPTID_INIT},
-  {"foldlevel",   "fdl",  P_NUM|P_VI_DEF|P_RWIN,
+   (char_u *)"#" SCRIPTID_INIT},
+  {"foldlevel",   "fdl",  P_NUM|P_RWIN,
    (char_u *)VAR_WIN, PV_FDL,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"foldlevelstart","fdls", P_NUM|P_VI_DEF|P_CURSWANT,
+   (char_u *)0L SCRIPTID_INIT},
+  {"foldlevelstart","fdls", P_NUM|P_CURSWANT,
    (char_u *)&p_fdls, PV_NONE,
-   {(char_u *)-1L, (char_u *)0L} SCRIPTID_INIT},
-  {"foldmarker",  "fmr",  P_STRING|P_ALLOCED|P_VI_DEF|
+   (char_u *)-1L SCRIPTID_INIT},
+  {"foldmarker",  "fmr",  P_STRING|P_ALLOCED|
    P_RWIN|P_COMMA|P_NODUP,
    (char_u *)VAR_WIN, PV_FMR,
-   {(char_u *)"{{{,}}}", (char_u *)NULL}
+   (char_u *)"{{{,}}}"
    SCRIPTID_INIT},
-  {"foldmethod",  "fdm",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
+  {"foldmethod",  "fdm",  P_STRING|P_ALLOCED|P_RWIN,
    (char_u *)VAR_WIN, PV_FDM,
-   {(char_u *)"manual", (char_u *)NULL} SCRIPTID_INIT},
-  {"foldminlines","fml",  P_NUM|P_VI_DEF|P_RWIN,
+   (char_u *)"manual" SCRIPTID_INIT},
+  {"foldminlines","fml",  P_NUM|P_RWIN,
    (char_u *)VAR_WIN, PV_FML,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"foldnestmax", "fdn",  P_NUM|P_VI_DEF|P_RWIN,
+   (char_u *)1L SCRIPTID_INIT},
+  {"foldnestmax", "fdn",  P_NUM|P_RWIN,
    (char_u *)VAR_WIN, PV_FDN,
-   {(char_u *)20L, (char_u *)0L} SCRIPTID_INIT},
-  {"foldopen",    "fdo",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP|P_CURSWANT,
+   (char_u *)20L SCRIPTID_INIT},
+  {"foldopen",    "fdo",  P_STRING|P_COMMA|P_NODUP|P_CURSWANT,
    (char_u *)&p_fdo, PV_NONE,
-   {(char_u *)"block,hor,mark,percent,quickfix,search,tag,undo",
-    (char_u *)0L} SCRIPTID_INIT},
-  {"foldtext",    "fdt",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
+   (char_u *)"block,hor,mark,percent,quickfix,search,tag,undo" SCRIPTID_INIT},
+  {"foldtext",    "fdt",  P_STRING|P_ALLOCED|P_RWIN,
    (char_u *)VAR_WIN, PV_FDT,
-   {(char_u *)"foldtext()", (char_u *)NULL}
+   (char_u *)"foldtext()"
    SCRIPTID_INIT},
-  {"formatexpr", "fex",   P_STRING|P_ALLOCED|P_VI_DEF,
+  {"formatexpr", "fex",   P_STRING|P_ALLOCED,
    (char_u *)&p_fex, PV_FEX,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
   {"formatoptions","fo",  P_STRING|P_ALLOCED|P_FLAGLIST,
    (char_u *)&p_fo, PV_FO,
-   {(char_u *)DFLT_FO_VI, (char_u *)DFLT_FO_VIM}
+    (char_u *)DFLT_FO_VIM
    SCRIPTID_INIT},
-  {"formatlistpat","flp", P_STRING|P_ALLOCED|P_VI_DEF,
+  {"formatlistpat","flp", P_STRING|P_ALLOCED,
    (char_u *)&p_flp, PV_FLP,
-   {(char_u *)"^\\s*\\d\\+[\\]:.)}\\t ]\\s*",
-    (char_u *)0L} SCRIPTID_INIT},
-  {"formatprg",   "fp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+   (char_u *)"^\\s*\\d\\+[\\]:.)}\\t ]\\s*" SCRIPTID_INIT},
+  {"formatprg",   "fp",   P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_fp, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"fsync",       "fs",   P_BOOL|P_SECURE|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"fsync",       "fs",   P_BOOL|P_SECURE,
 #ifdef HAVE_FSYNC
    (char_u *)&p_fs, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L}
+   (char_u *)TRUE
 #else
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L}
+   (char_u *)FALSE
 #endif
    SCRIPTID_INIT},
-  {"gdefault",    "gd",   P_BOOL|P_VI_DEF,
+  {"gdefault",    "gd",   P_BOOL,
    (char_u *)&p_gd, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"graphic",     "gr",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"graphic",     "gr",   P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"grepformat",  "gfm",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"grepformat",  "gfm",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_gefm, PV_NONE,
-   {(char_u *)DFLT_GREPFORMAT, (char_u *)0L}
+   (char_u *)DFLT_GREPFORMAT
    SCRIPTID_INIT},
-  {"grepprg",     "gp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+  {"grepprg",     "gp",   P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_gp, PV_GP,
-   {
+   
 #  ifdef UNIX
      /* Add an extra file name so that grep will always
       * insert a file name in the match line. */
-     (char_u *)"grep -n $* /dev/null",
+     (char_u *)"grep -n $* /dev/null"
 #  else
-     (char_u *)"grep -n ",
+     (char_u *)"grep -n "
 #  endif
-     (char_u *)0L
-   }
+
    SCRIPTID_INIT},
-  {"guicursor",    "gcr",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"guicursor",    "gcr",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_guicursor, PV_NONE,
-   {
-     (char_u *)"n-v-c:block,o:hor50,i-ci:hor15,r-cr:hor30,sm:block",
-     (char_u *)0L
-   }
+   
+     (char_u *)"n-v-c:block,o:hor50,i-ci:hor15,r-cr:hor30,sm:block"
    SCRIPTID_INIT},
-  {"guifont",     "gfn",  P_STRING|P_VI_DEF|P_RCLR|P_COMMA|P_NODUP,
+  {"guifont",     "gfn",  P_STRING|P_RCLR|P_COMMA|P_NODUP,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+   (char_u *)NULL
    SCRIPTID_INIT},
-  {"guifontset",  "gfs",  P_STRING|P_VI_DEF|P_RCLR|P_COMMA,
+  {"guifontset",  "gfs",  P_STRING|P_RCLR|P_COMMA,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+   (char_u *)NULL
    SCRIPTID_INIT},
-  {"guifontwide", "gfw",  P_STRING|P_VI_DEF|P_RCLR|P_COMMA|P_NODUP,
+  {"guifontwide", "gfw",  P_STRING|P_RCLR|P_COMMA|P_NODUP,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+   (char_u *)NULL
    SCRIPTID_INIT},
-  {"guiheadroom", "ghr",  P_NUM|P_VI_DEF,
+  {"guiheadroom", "ghr",  P_NUM,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)50L, (char_u *)0L} SCRIPTID_INIT},
-  {"guioptions",  "go",   P_STRING|P_VI_DEF|P_RALL|P_FLAGLIST,
+   (char_u *)50L SCRIPTID_INIT},
+  {"guioptions",  "go",   P_STRING|P_RALL|P_FLAGLIST,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+   (char_u *)NULL
    SCRIPTID_INIT},
-  {"guipty",      NULL,   P_BOOL|P_VI_DEF,
+  {"guipty",      NULL,   P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"guitablabel",  "gtl", P_STRING|P_VI_DEF|P_RWIN,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"guitablabel",  "gtl", P_STRING|P_RWIN,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+   (char_u *)NULL
    SCRIPTID_INIT},
-  {"guitabtooltip",  "gtt", P_STRING|P_VI_DEF|P_RWIN,
+  {"guitabtooltip",  "gtt", P_STRING|P_RWIN,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+   (char_u *)NULL
    SCRIPTID_INIT},
-  {"hardtabs",    "ht",   P_NUM|P_VI_DEF,
+  {"hardtabs",    "ht",   P_NUM,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"helpfile",    "hf",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+   (char_u *)0L SCRIPTID_INIT},
+  {"helpfile",    "hf",   P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_hf, PV_NONE,
-   {(char_u *)DFLT_HELPFILE, (char_u *)0L}
+   (char_u *)DFLT_HELPFILE
    SCRIPTID_INIT},
-  {"helpheight",  "hh",   P_NUM|P_VI_DEF,
+  {"helpheight",  "hh",   P_NUM,
    (char_u *)&p_hh, PV_NONE,
-   {(char_u *)20L, (char_u *)0L} SCRIPTID_INIT},
-  {"helplang",    "hlg",  P_STRING|P_VI_DEF|P_COMMA,
+   (char_u *)20L SCRIPTID_INIT},
+  {"helplang",    "hlg",  P_STRING|P_COMMA,
    (char_u *)&p_hlg, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"hidden",      "hid",  P_BOOL|P_VI_DEF,
+  {"hidden",      "hid",  P_BOOL,
    (char_u *)&p_hid, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"highlight",   "hl",   P_STRING|P_VI_DEF|P_RCLR|P_COMMA|P_NODUP,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"highlight",   "hl",   P_STRING|P_RCLR|P_COMMA|P_NODUP,
    (char_u *)&p_hl, PV_NONE,
-   {(char_u *)HIGHLIGHT_INIT, (char_u *)0L}
+   (char_u *)HIGHLIGHT_INIT
    SCRIPTID_INIT},
   {"history",     "hi",   P_NUM,
    (char_u *)&p_hi, PV_NONE,
-   {(char_u *)0L, (char_u *)20L} SCRIPTID_INIT},
-  {"hkmap",       "hk",   P_BOOL|P_VI_DEF,
+    (char_u *)20L SCRIPTID_INIT},
+  {"hkmap",       "hk",   P_BOOL,
    (char_u *)&p_hkmap, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"hkmapp",      "hkp",  P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"hkmapp",      "hkp",  P_BOOL,
    (char_u *)&p_hkmapp, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"hlsearch",    "hls",  P_BOOL|P_VI_DEF|P_RALL,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"hlsearch",    "hls",  P_BOOL|P_RALL,
    (char_u *)&p_hls, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"icon",        NULL,   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"icon",        NULL,   P_BOOL,
    (char_u *)&p_icon, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"iconstring",  NULL,   P_STRING|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"iconstring",  NULL,   P_STRING,
    (char_u *)&p_iconstring, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"ignorecase",  "ic",   P_BOOL|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"ignorecase",  "ic",   P_BOOL,
    (char_u *)&p_ic, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"imactivatefunc","imaf",P_STRING|P_VI_DEF|P_SECURE,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"imactivatefunc","imaf",P_STRING|P_SECURE,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+   (char_u *)NULL
    SCRIPTID_INIT},
-  {"imactivatekey","imak",P_STRING|P_VI_DEF,
+  {"imactivatekey","imak",P_STRING,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"imcmdline",   "imc",  P_BOOL|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"imcmdline",   "imc",  P_BOOL,
 #ifdef USE_IM_CONTROL
    (char_u *)&p_imcmdline, PV_NONE,
 #else
    (char_u *)NULL, PV_NONE,
 #endif
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"imdisable",   "imd",  P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"imdisable",   "imd",  P_BOOL,
 #ifdef USE_IM_CONTROL
    (char_u *)&p_imdisable, PV_NONE,
 #else
    (char_u *)NULL, PV_NONE,
 #endif
-   {(char_u *)FALSE, (char_u *)0L}
+   (char_u *)FALSE
    SCRIPTID_INIT},
-  {"iminsert",    "imi",  P_NUM|P_VI_DEF,
+  {"iminsert",    "imi",  P_NUM,
    (char_u *)&p_iminsert, PV_IMI,
 #ifdef B_IMODE_IM
-   {(char_u *)B_IMODE_IM, (char_u *)0L}
+   (char_u *)B_IMODE_IM
 #else
-   {(char_u *)B_IMODE_NONE, (char_u *)0L}
+   (char_u *)B_IMODE_NONE
 #endif
    SCRIPTID_INIT},
-  {"imsearch",    "ims",  P_NUM|P_VI_DEF,
+  {"imsearch",    "ims",  P_NUM,
    (char_u *)&p_imsearch, PV_IMS,
 #ifdef B_IMODE_IM
-   {(char_u *)B_IMODE_IM, (char_u *)0L}
+   (char_u *)B_IMODE_IM
 #else
-   {(char_u *)B_IMODE_NONE, (char_u *)0L}
+   (char_u *)B_IMODE_NONE
 #endif
    SCRIPTID_INIT},
-  {"imstatusfunc","imsf",P_STRING|P_VI_DEF|P_SECURE,
+  {"imstatusfunc","imsf",P_STRING|P_SECURE,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+   (char_u *)NULL
    SCRIPTID_INIT},
-  {"include",     "inc",  P_STRING|P_ALLOCED|P_VI_DEF,
+  {"include",     "inc",  P_STRING|P_ALLOCED,
    (char_u *)&p_inc, PV_INC,
-   {(char_u *)"^\\s*#\\s*include", (char_u *)0L}
+   (char_u *)"^\\s*#\\s*include"
    SCRIPTID_INIT},
-  {"includeexpr", "inex", P_STRING|P_ALLOCED|P_VI_DEF,
+  {"includeexpr", "inex", P_STRING|P_ALLOCED,
    (char_u *)&p_inex, PV_INEX,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"incsearch",   "is",   P_BOOL|P_VI_DEF,
+  {"incsearch",   "is",   P_BOOL,
    (char_u *)&p_is, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"indentexpr", "inde",  P_STRING|P_ALLOCED|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"indentexpr", "inde",  P_STRING|P_ALLOCED,
    (char_u *)&p_inde, PV_INDE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"indentkeys", "indk",  P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
+  {"indentkeys", "indk",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_indk, PV_INDK,
-   {(char_u *)"0{,0},:,0#,!^F,o,O,e", (char_u *)0L}
+   (char_u *)"0{,0},:,0#,!^F,o,O,e"
    SCRIPTID_INIT},
-  {"infercase",   "inf",  P_BOOL|P_VI_DEF,
+  {"infercase",   "inf",  P_BOOL,
    (char_u *)&p_inf, PV_INF,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"insertmode",  "im",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"insertmode",  "im",   P_BOOL,
    (char_u *)&p_im, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"isfname",     "isf",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"isfname",     "isf",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_isf, PV_NONE,
-   {
+   
 #ifdef BACKSLASH_IN_FILENAME
      /* Excluded are: & and ^ are special in cmd.exe
      * ( and ) are used in text separating fnames */
-     (char_u *)"@,48-57,/,\\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,=",
+     (char_u *)"@,48-57,/,\\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,="
 #else
-     (char_u *)"@,48-57,/,.,-,_,+,,,#,$,%,~,=",
+     (char_u *)"@,48-57,/,.,-,_,+,,,#,$,%,~,="
 #endif
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"isident",     "isi",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+ SCRIPTID_INIT},
+  {"isident",     "isi",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_isi, PV_NONE,
-   {
-     (char_u *)"@,48-57,_,192-255",
-     (char_u *)0L
-   } SCRIPTID_INIT},
+   
+     (char_u *)"@,48-57,_,192-255" SCRIPTID_INIT},
   {"iskeyword",   "isk",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_isk, PV_ISK,
-   {
-     (char_u *)"@,48-57,_",
+   
      ISK_LATIN1
-   } SCRIPTID_INIT},
-  {"isprint",     "isp",  P_STRING|P_VI_DEF|P_RALL|P_COMMA|P_NODUP,
+    SCRIPTID_INIT},
+  {"isprint",     "isp",  P_STRING|P_RALL|P_COMMA|P_NODUP,
    (char_u *)&p_isp, PV_NONE,
-   {
+   
 #if defined(MSWIN)
-     (char_u *)"@,~-255",
+     (char_u *)"@,~-255"
 #else
-     ISP_LATIN1,
+     ISP_LATIN1
 #endif
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"joinspaces",  "js",   P_BOOL|P_VI_DEF,
+ SCRIPTID_INIT},
+  {"joinspaces",  "js",   P_BOOL,
    (char_u *)&p_js, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"keymap",      "kmp",  P_STRING|P_ALLOCED|P_VI_DEF|P_RBUF|P_RSTAT|P_NFNAME|
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"keymap",      "kmp",  P_STRING|P_ALLOCED|P_RBUF|P_RSTAT|P_NFNAME|
    P_PRI_MKRC,
    (char_u *)&p_keymap, PV_KMAP,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"keymodel",    "km",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"keymodel",    "km",   P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_km, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"keywordprg",  "kp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+   (char_u *)"" SCRIPTID_INIT},
+  {"keywordprg",  "kp",   P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_kp, PV_KP,
-   {
+   
 #  ifdef USEMAN_S
-     (char_u *)"man -s",
+     (char_u *)"man -s"
 #  else
-     (char_u *)"man",
+     (char_u *)"man"
 #  endif
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"langmap",     "lmap", P_STRING|P_VI_DEF|P_COMMA|P_NODUP|P_SECURE,
+ SCRIPTID_INIT},
+  {"langmap",     "lmap", P_STRING|P_COMMA|P_NODUP|P_SECURE,
    (char_u *)&p_langmap, PV_NONE,
-   {(char_u *)"",                               /* unmatched } */
-    (char_u *)0L} SCRIPTID_INIT},
-  {"langmenu",    "lm",   P_STRING|P_VI_DEF|P_NFNAME,
+   (char_u *)"" SCRIPTID_INIT},
+  {"langmenu",    "lm",   P_STRING|P_NFNAME,
    (char_u *)&p_lm, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"laststatus",  "ls",   P_NUM|P_VI_DEF|P_RALL,
+   (char_u *)"" SCRIPTID_INIT},
+  {"laststatus",  "ls",   P_NUM|P_RALL,
    (char_u *)&p_ls, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"lazyredraw",  "lz",   P_BOOL|P_VI_DEF,
+   (char_u *)1L SCRIPTID_INIT},
+  {"lazyredraw",  "lz",   P_BOOL,
    (char_u *)&p_lz, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"linebreak",   "lbr",  P_BOOL|P_VI_DEF|P_RWIN,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"linebreak",   "lbr",  P_BOOL|P_RWIN,
    (char_u *)VAR_WIN, PV_LBR,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"lines",       NULL,   P_NUM|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|P_RCLR,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"lines",       NULL,   P_NUM|P_NODEFAULT|P_NO_MKRC|P_RCLR,
    (char_u *)&Rows, PV_NONE,
-   {
-     (char_u *)24L,
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"linespace",   "lsp",  P_NUM|P_VI_DEF|P_RCLR,
+   
+     (char_u *)24L SCRIPTID_INIT},
+  {"linespace",   "lsp",  P_NUM|P_RCLR,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L}
+   (char_u *)0L
    SCRIPTID_INIT},
-  {"lisp",        NULL,   P_BOOL|P_VI_DEF,
+  {"lisp",        NULL,   P_BOOL,
    (char_u *)&p_lisp, PV_LISP,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"lispwords",   "lw",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"lispwords",   "lw",   P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_lispwords, PV_NONE,
-   {(char_u *)LISPWORD_VALUE, (char_u *)0L}
+   (char_u *)LISPWORD_VALUE
    SCRIPTID_INIT},
-  {"list",        NULL,   P_BOOL|P_VI_DEF|P_RWIN,
+  {"list",        NULL,   P_BOOL|P_RWIN,
    (char_u *)VAR_WIN, PV_LIST,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"listchars",   "lcs",  P_STRING|P_VI_DEF|P_RALL|P_COMMA|P_NODUP,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"listchars",   "lcs",  P_STRING|P_RALL|P_COMMA|P_NODUP,
    (char_u *)&p_lcs, PV_NONE,
-   {(char_u *)"eol:$", (char_u *)0L} SCRIPTID_INIT},
-  {"loadplugins", "lpl",  P_BOOL|P_VI_DEF,
+   (char_u *)"eol:$" SCRIPTID_INIT},
+  {"loadplugins", "lpl",  P_BOOL,
    (char_u *)&p_lpl, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"magic",       NULL,   P_BOOL|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"magic",       NULL,   P_BOOL,
    (char_u *)&p_magic, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"makeef",      "mef",  P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"makeef",      "mef",  P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_mef, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"makeprg",     "mp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+  {"makeprg",     "mp",   P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_mp, PV_MP,
-   {(char_u *)"make", (char_u *)0L}
+   (char_u *)"make"
    SCRIPTID_INIT},
-  {"matchpairs",  "mps",  P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
+  {"matchpairs",  "mps",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_mps, PV_MPS,
-   {(char_u *)"(:),{:},[:]", (char_u *)0L}
+   (char_u *)"(:),{:},[:]"
    SCRIPTID_INIT},
-  {"matchtime",   "mat",  P_NUM|P_VI_DEF,
+  {"matchtime",   "mat",  P_NUM,
    (char_u *)&p_mat, PV_NONE,
-   {(char_u *)5L, (char_u *)0L} SCRIPTID_INIT},
-  {"maxcombine",  "mco",  P_NUM|P_VI_DEF|P_CURSWANT,
+   (char_u *)5L SCRIPTID_INIT},
+  {"maxcombine",  "mco",  P_NUM|P_CURSWANT,
    (char_u *)&p_mco, PV_NONE,
-   {(char_u *)2, (char_u *)0L} SCRIPTID_INIT},
-  {"maxfuncdepth", "mfd", P_NUM|P_VI_DEF,
+   (char_u *)2 SCRIPTID_INIT},
+  {"maxfuncdepth", "mfd", P_NUM,
    (char_u *)&p_mfd, PV_NONE,
-   {(char_u *)100L, (char_u *)0L} SCRIPTID_INIT},
-  {"maxmapdepth", "mmd",  P_NUM|P_VI_DEF,
+   (char_u *)100L SCRIPTID_INIT},
+  {"maxmapdepth", "mmd",  P_NUM,
    (char_u *)&p_mmd, PV_NONE,
-   {(char_u *)1000L, (char_u *)0L} SCRIPTID_INIT},
-  {"maxmem",      "mm",   P_NUM|P_VI_DEF,
+   (char_u *)1000L SCRIPTID_INIT},
+  {"maxmem",      "mm",   P_NUM,
    (char_u *)&p_mm, PV_NONE,
-   {(char_u *)DFLT_MAXMEM, (char_u *)0L}
+   (char_u *)DFLT_MAXMEM
    SCRIPTID_INIT},
-  {"maxmempattern","mmp", P_NUM|P_VI_DEF,
+  {"maxmempattern","mmp", P_NUM,
    (char_u *)&p_mmp, PV_NONE,
-   {(char_u *)1000L, (char_u *)0L} SCRIPTID_INIT},
-  {"maxmemtot",   "mmt",  P_NUM|P_VI_DEF,
+   (char_u *)1000L SCRIPTID_INIT},
+  {"maxmemtot",   "mmt",  P_NUM,
    (char_u *)&p_mmt, PV_NONE,
-   {(char_u *)DFLT_MAXMEMTOT, (char_u *)0L}
+   (char_u *)DFLT_MAXMEMTOT
    SCRIPTID_INIT},
-  {"menuitems",   "mis",  P_NUM|P_VI_DEF,
+  {"menuitems",   "mis",  P_NUM,
    (char_u *)&p_mis, PV_NONE,
-   {(char_u *)25L, (char_u *)0L} SCRIPTID_INIT},
-  {"mesg",        NULL,   P_BOOL|P_VI_DEF,
+   (char_u *)25L SCRIPTID_INIT},
+  {"mesg",        NULL,   P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"mkspellmem",  "msm",  P_STRING|P_VI_DEF|P_EXPAND|P_SECURE,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"mkspellmem",  "msm",  P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_msm, PV_NONE,
-   {(char_u *)"460000,2000,500", (char_u *)0L}
+   (char_u *)"460000,2000,500"
    SCRIPTID_INIT},
   {"modeline",    "ml",   P_BOOL,
    (char_u *)&p_ml, PV_ML,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"modelines",   "mls",  P_NUM|P_VI_DEF,
+    (char_u *)TRUE SCRIPTID_INIT},
+  {"modelines",   "mls",  P_NUM,
    (char_u *)&p_mls, PV_NONE,
-   {(char_u *)5L, (char_u *)0L} SCRIPTID_INIT},
-  {"modifiable",  "ma",   P_BOOL|P_VI_DEF|P_NOGLOB,
+   (char_u *)5L SCRIPTID_INIT},
+  {"modifiable",  "ma",   P_BOOL|P_NOGLOB,
    (char_u *)&p_ma, PV_MA,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"modified",    "mod",  P_BOOL|P_NO_MKRC|P_VI_DEF|P_RSTAT,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"modified",    "mod",  P_BOOL|P_NO_MKRC|P_RSTAT,
    (char_u *)&p_mod, PV_MOD,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)FALSE SCRIPTID_INIT},
   {"more",        NULL,   P_BOOL,
    (char_u *)&p_more, PV_NONE,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"mouse",       NULL,   P_STRING|P_VI_DEF|P_FLAGLIST,
+    (char_u *)TRUE SCRIPTID_INIT},
+  {"mouse",       NULL,   P_STRING|P_FLAGLIST,
    (char_u *)&p_mouse, PV_NONE,
-   {
-     (char_u *)"",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"mousefocus",   "mousef", P_BOOL|P_VI_DEF,
+   
+     (char_u *)"" SCRIPTID_INIT},
+  {"mousefocus",   "mousef", P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"mousehide",   "mh",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"mousehide",   "mh",   P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"mousemodel",  "mousem", P_STRING|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"mousemodel",  "mousem", P_STRING,
    (char_u *)&p_mousem, PV_NONE,
-   {
-     (char_u *)"extend",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"mouseshape",  "mouses",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+   
+     (char_u *)"extend" SCRIPTID_INIT},
+  {"mouseshape",  "mouses",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+   (char_u *)NULL
    SCRIPTID_INIT},
-  {"mousetime",   "mouset",   P_NUM|P_VI_DEF,
+  {"mousetime",   "mouset",   P_NUM,
    (char_u *)&p_mouset, PV_NONE,
-   {(char_u *)500L, (char_u *)0L} SCRIPTID_INIT},
-  {"novice",      NULL,   P_BOOL|P_VI_DEF,
+   (char_u *)500L SCRIPTID_INIT},
+  {"novice",      NULL,   P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"nrformats",   "nf",   P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"nrformats",   "nf",   P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_nf, PV_NF,
-   {(char_u *)"octal,hex", (char_u *)0L}
+   (char_u *)"octal,hex"
    SCRIPTID_INIT},
-  {"number",      "nu",   P_BOOL|P_VI_DEF|P_RWIN,
+  {"number",      "nu",   P_BOOL|P_RWIN,
    (char_u *)VAR_WIN, PV_NU,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)FALSE SCRIPTID_INIT},
   {"numberwidth", "nuw",  P_NUM|P_RWIN,
    (char_u *)VAR_WIN, PV_NUW,
-   {(char_u *)8L, (char_u *)4L} SCRIPTID_INIT},
-  {"omnifunc",    "ofu",  P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
+    (char_u *)4L SCRIPTID_INIT},
+  {"omnifunc",    "ofu",  P_STRING|P_ALLOCED|P_SECURE,
    (char_u *)&p_ofu, PV_OFU,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"open",        NULL,   P_BOOL|P_VI_DEF,
+  {"open",        NULL,   P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"opendevice",  "odev", P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"opendevice",  "odev", P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)FALSE}
+   (char_u *)FALSE
    SCRIPTID_INIT},
-  {"operatorfunc", "opfunc", P_STRING|P_VI_DEF|P_SECURE,
+  {"operatorfunc", "opfunc", P_STRING|P_SECURE,
    (char_u *)&p_opfunc, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"optimize",    "opt",  P_BOOL|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"optimize",    "opt",  P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"osfiletype",  "oft",  P_STRING|P_ALLOCED|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"osfiletype",  "oft",  P_STRING|P_ALLOCED,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"paragraphs",  "para", P_STRING|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"paragraphs",  "para", P_STRING,
    (char_u *)&p_para, PV_NONE,
-   {(char_u *)"IPLPPPQPP TPHPLIPpLpItpplpipbp",
-    (char_u *)0L} SCRIPTID_INIT},
-  {"paste",       NULL,   P_BOOL|P_VI_DEF|P_PRI_MKRC,
+   (char_u *)"IPLPPPQPP TPHPLIPpLpItpplpipbp" SCRIPTID_INIT},
+  {"paste",       NULL,   P_BOOL|P_PRI_MKRC,
    (char_u *)&p_paste, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"pastetoggle", "pt",   P_STRING|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"pastetoggle", "pt",   P_STRING,
    (char_u *)&p_pt, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"patchexpr",   "pex",  P_STRING|P_VI_DEF|P_SECURE,
+   (char_u *)"" SCRIPTID_INIT},
+  {"patchexpr",   "pex",  P_STRING|P_SECURE,
    (char_u *)&p_pex, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"patchmode",   "pm",   P_STRING|P_VI_DEF|P_NFNAME,
+  {"patchmode",   "pm",   P_STRING|P_NFNAME,
    (char_u *)&p_pm, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"path",        "pa",   P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)"" SCRIPTID_INIT},
+  {"path",        "pa",   P_STRING|P_EXPAND|P_COMMA|P_NODUP,
    (char_u *)&p_path, PV_PATH,
-   {
-     (char_u *)".,/usr/include,,",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"preserveindent", "pi", P_BOOL|P_VI_DEF,
+   
+     (char_u *)".,/usr/include,," SCRIPTID_INIT},
+  {"preserveindent", "pi", P_BOOL,
    (char_u *)&p_pi, PV_PI,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"previewheight", "pvh", P_NUM|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"previewheight", "pvh", P_NUM,
    (char_u *)&p_pvh, PV_NONE,
-   {(char_u *)12L, (char_u *)0L} SCRIPTID_INIT},
-  {"previewwindow", "pvw", P_BOOL|P_VI_DEF|P_RSTAT|P_NOGLOB,
+   (char_u *)12L SCRIPTID_INIT},
+  {"previewwindow", "pvw", P_BOOL|P_RSTAT|P_NOGLOB,
    (char_u *)VAR_WIN, PV_PVW,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"printdevice", "pdev", P_STRING|P_VI_DEF|P_SECURE,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"printdevice", "pdev", P_STRING|P_SECURE,
    (char_u *)&p_pdev, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"printencoding", "penc", P_STRING|P_VI_DEF,
+  {"printencoding", "penc", P_STRING,
    (char_u *)&p_penc, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"printexpr", "pexpr",  P_STRING|P_VI_DEF,
+  {"printexpr", "pexpr",  P_STRING,
    (char_u *)&p_pexpr, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"printfont", "pfn",    P_STRING|P_VI_DEF,
+  {"printfont", "pfn",    P_STRING,
    (char_u *)&p_pfn, PV_NONE,
-   {
-     (char_u *)"courier",
-     (char_u *)0L
-   }
+   
+     (char_u *)"courier"
    SCRIPTID_INIT},
-  {"printheader", "pheader",  P_STRING|P_VI_DEF|P_GETTEXT,
+  {"printheader", "pheader",  P_STRING|P_GETTEXT,
    (char_u *)&p_header, PV_NONE,
-   {(char_u *)N_("%<%f%h%m%=Page %N"), (char_u *)0L}
+   (char_u *)N_("%<%f%h%m%=Page %N")
    SCRIPTID_INIT},
-  {"printmbcharset", "pmbcs",  P_STRING|P_VI_DEF,
+  {"printmbcharset", "pmbcs",  P_STRING,
    (char_u *)&p_pmcs, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"printmbfont", "pmbfn",  P_STRING|P_VI_DEF,
+  {"printmbfont", "pmbfn",  P_STRING,
    (char_u *)&p_pmfn, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"printoptions", "popt", P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"printoptions", "popt", P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_popt, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"prompt",      NULL,   P_BOOL|P_VI_DEF,
+  {"prompt",      NULL,   P_BOOL,
    (char_u *)&p_prompt, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"pumheight",   "ph",   P_NUM|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"pumheight",   "ph",   P_NUM,
    (char_u *)&p_ph, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"quoteescape", "qe",   P_STRING|P_ALLOCED|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"quoteescape", "qe",   P_STRING|P_ALLOCED,
    (char_u *)&p_qe, PV_QE,
-   {(char_u *)"\\", (char_u *)0L}
+   (char_u *)"\\"
    SCRIPTID_INIT},
-  {"readonly",    "ro",   P_BOOL|P_VI_DEF|P_RSTAT|P_NOGLOB,
+  {"readonly",    "ro",   P_BOOL|P_RSTAT|P_NOGLOB,
    (char_u *)&p_ro, PV_RO,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"redraw",      NULL,   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"redraw",      NULL,   P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"redrawtime",  "rdt",  P_NUM|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"redrawtime",  "rdt",  P_NUM,
    (char_u *)&p_rdt, PV_NONE,
-   {(char_u *)2000L, (char_u *)0L} SCRIPTID_INIT},
-  {"regexpengine", "re",  P_NUM|P_VI_DEF,
+   (char_u *)2000L SCRIPTID_INIT},
+  {"regexpengine", "re",  P_NUM,
    (char_u *)&p_re, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"relativenumber", "rnu", P_BOOL|P_VI_DEF|P_RWIN,
+   (char_u *)0L SCRIPTID_INIT},
+  {"relativenumber", "rnu", P_BOOL|P_RWIN,
    (char_u *)VAR_WIN, PV_RNU,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"remap",       NULL,   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"remap",       NULL,   P_BOOL,
    (char_u *)&p_remap, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"report",      NULL,   P_NUM|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"report",      NULL,   P_NUM,
    (char_u *)&p_report, PV_NONE,
-   {(char_u *)2L, (char_u *)0L} SCRIPTID_INIT},
-  {"restorescreen", "rs", P_BOOL|P_VI_DEF,
+   (char_u *)2L SCRIPTID_INIT},
+  {"restorescreen", "rs", P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"revins",      "ri",   P_BOOL|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"revins",      "ri",   P_BOOL,
    (char_u *)&p_ri, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"rightleft",   "rl",   P_BOOL|P_VI_DEF|P_RWIN,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"rightleft",   "rl",   P_BOOL|P_RWIN,
    (char_u *)VAR_WIN, PV_RL,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"rightleftcmd", "rlc", P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"rightleftcmd", "rlc", P_STRING|P_ALLOCED|P_RWIN,
    (char_u *)VAR_WIN, PV_RLC,
-   {(char_u *)"search", (char_u *)NULL}
+   (char_u *)"search"
    SCRIPTID_INIT},
-  {"ruler",       "ru",   P_BOOL|P_VI_DEF|P_RSTAT,
+  {"ruler",       "ru",   P_BOOL|P_RSTAT,
    (char_u *)&p_ru, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"rulerformat", "ruf",  P_STRING|P_VI_DEF|P_ALLOCED|P_RSTAT,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"rulerformat", "ruf",  P_STRING|P_ALLOCED|P_RSTAT,
    (char_u *)&p_ruf, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"runtimepath", "rtp",  P_STRING|P_VI_DEF|P_EXPAND|P_COMMA|P_NODUP|P_SECURE,
+   (char_u *)"" SCRIPTID_INIT},
+  {"runtimepath", "rtp",  P_STRING|P_EXPAND|P_COMMA|P_NODUP|P_SECURE,
    (char_u *)&p_rtp, PV_NONE,
-   {(char_u *)DFLT_RUNTIMEPATH, (char_u *)0L}
+   (char_u *)DFLT_RUNTIMEPATH
    SCRIPTID_INIT},
-  {"scroll",      "scr",  P_NUM|P_NO_MKRC|P_VI_DEF,
+  {"scroll",      "scr",  P_NUM|P_NO_MKRC,
    (char_u *)VAR_WIN, PV_SCROLL,
-   {(char_u *)12L, (char_u *)0L} SCRIPTID_INIT},
-  {"scrollbind",  "scb",  P_BOOL|P_VI_DEF,
+   (char_u *)12L SCRIPTID_INIT},
+  {"scrollbind",  "scb",  P_BOOL,
    (char_u *)VAR_WIN, PV_SCBIND,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"scrolljump",  "sj",   P_NUM|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"scrolljump",  "sj",   P_NUM,
    (char_u *)&p_sj, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"scrolloff",   "so",   P_NUM|P_VI_DEF|P_RALL,
+   (char_u *)1L SCRIPTID_INIT},
+  {"scrolloff",   "so",   P_NUM|P_RALL,
    (char_u *)&p_so, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"scrollopt",   "sbo",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)0L SCRIPTID_INIT},
+  {"scrollopt",   "sbo",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_sbo, PV_NONE,
-   {(char_u *)"ver,jump", (char_u *)0L}
+   (char_u *)"ver,jump"
    SCRIPTID_INIT},
-  {"sections",    "sect", P_STRING|P_VI_DEF,
+  {"sections",    "sect", P_STRING,
    (char_u *)&p_sections, PV_NONE,
-   {(char_u *)"SHNHH HUnhsh", (char_u *)0L}
+   (char_u *)"SHNHH HUnhsh"
    SCRIPTID_INIT},
-  {"secure",      NULL,   P_BOOL|P_VI_DEF|P_SECURE,
+  {"secure",      NULL,   P_BOOL|P_SECURE,
    (char_u *)&p_secure, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"selection",   "sel",  P_STRING|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"selection",   "sel",  P_STRING,
    (char_u *)&p_sel, PV_NONE,
-   {(char_u *)"inclusive", (char_u *)0L}
+   (char_u *)"inclusive"
    SCRIPTID_INIT},
-  {"selectmode",  "slm",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"selectmode",  "slm",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_slm, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"sessionoptions", "ssop", P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)"" SCRIPTID_INIT},
+  {"sessionoptions", "ssop", P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_ssop, PV_NONE,
-   {(char_u *)"blank,buffers,curdir,folds,help,options,tabpages,winsize",
-    (char_u *)0L}
+   (char_u *)"blank,buffers,curdir,folds,help,options,tabpages,winsize"
    SCRIPTID_INIT},
-  {"shell",       "sh",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+  {"shell",       "sh",   P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_sh, PV_NONE,
-   {
-     (char_u *)"sh",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"shellcmdflag","shcf", P_STRING|P_VI_DEF|P_SECURE,
+   
+     (char_u *)"sh" SCRIPTID_INIT},
+  {"shellcmdflag","shcf", P_STRING|P_SECURE,
    (char_u *)&p_shcf, PV_NONE,
-   {
-     (char_u *)"-c",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"shellpipe",   "sp",   P_STRING|P_VI_DEF|P_SECURE,
+   
+     (char_u *)"-c" SCRIPTID_INIT},
+  {"shellpipe",   "sp",   P_STRING|P_SECURE,
    (char_u *)&p_sp, PV_NONE,
-   {
+   
 #if defined(UNIX)
-     (char_u *)"| tee",
+     (char_u *)"| tee"
 #else
-     (char_u *)">",
+     (char_u *)">"
 #endif
-     (char_u *)0L
-   }
+
    SCRIPTID_INIT},
-  {"shellquote",  "shq",  P_STRING|P_VI_DEF|P_SECURE,
+  {"shellquote",  "shq",  P_STRING|P_SECURE,
    (char_u *)&p_shq, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"shellredir",  "srr",  P_STRING|P_VI_DEF|P_SECURE,
+   (char_u *)"" SCRIPTID_INIT},
+  {"shellredir",  "srr",  P_STRING|P_SECURE,
    (char_u *)&p_srr, PV_NONE,
-   {(char_u *)">", (char_u *)0L} SCRIPTID_INIT},
-  {"shellslash",  "ssl",   P_BOOL|P_VI_DEF,
+   (char_u *)">" SCRIPTID_INIT},
+  {"shellslash",  "ssl",   P_BOOL,
 #ifdef BACKSLASH_IN_FILENAME
    (char_u *)&p_ssl, PV_NONE,
 #else
    (char_u *)NULL, PV_NONE,
 #endif
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)FALSE SCRIPTID_INIT},
   {"shelltemp",   "stmp", P_BOOL,
    (char_u *)&p_stmp, PV_NONE,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"shelltype",   "st",   P_NUM|P_VI_DEF,
+    (char_u *)TRUE SCRIPTID_INIT},
+  {"shelltype",   "st",   P_NUM,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"shellxquote", "sxq",  P_STRING|P_VI_DEF|P_SECURE,
+   (char_u *)0L SCRIPTID_INIT},
+  {"shellxquote", "sxq",  P_STRING|P_SECURE,
    (char_u *)&p_sxq, PV_NONE,
-   {
-     (char_u *)"",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"shellxescape", "sxe", P_STRING|P_VI_DEF|P_SECURE,
+   
+     (char_u *)"" SCRIPTID_INIT},
+  {"shellxescape", "sxe", P_STRING|P_SECURE,
    (char_u *)&p_sxe, PV_NONE,
-   {
-     (char_u *)"",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"shiftround",  "sr",   P_BOOL|P_VI_DEF,
+   
+     (char_u *)"" SCRIPTID_INIT},
+  {"shiftround",  "sr",   P_BOOL,
    (char_u *)&p_sr, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"shiftwidth",  "sw",   P_NUM|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"shiftwidth",  "sw",   P_NUM,
    (char_u *)&p_sw, PV_SW,
-   {(char_u *)8L, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)8L SCRIPTID_INIT},
   {"shortmess",   "shm",  P_STRING|P_FLAGLIST,
    (char_u *)&p_shm, PV_NONE,
-   {(char_u *)"", (char_u *)"filnxtToO"}
+    (char_u *)"filnxtToO"
    SCRIPTID_INIT},
-  {"showbreak",   "sbr",  P_STRING|P_VI_DEF|P_RALL,
+  {"showbreak",   "sbr",  P_STRING|P_RALL,
    (char_u *)&p_sbr, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)"" SCRIPTID_INIT},
   {"showcmd",     "sc",   P_BOOL,
    (char_u *)&p_sc, PV_NONE,
-   {(char_u *)FALSE,
+   
 #ifdef UNIX
     (char_u *)FALSE
 #else
       (char_u *) TRUE
 #endif
-   } SCRIPTID_INIT},
-  {"showfulltag", "sft",  P_BOOL|P_VI_DEF,
+    SCRIPTID_INIT},
+  {"showfulltag", "sft",  P_BOOL,
    (char_u *)&p_sft, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"showmatch",   "sm",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"showmatch",   "sm",   P_BOOL,
    (char_u *)&p_sm, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)FALSE SCRIPTID_INIT},
   {"showmode",    "smd",  P_BOOL,
    (char_u *)&p_smd, PV_NONE,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"showtabline", "stal", P_NUM|P_VI_DEF|P_RALL,
+    (char_u *)TRUE SCRIPTID_INIT},
+  {"showtabline", "stal", P_NUM|P_RALL,
    (char_u *)&p_stal, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"sidescroll",  "ss",   P_NUM|P_VI_DEF,
+   (char_u *)1L SCRIPTID_INIT},
+  {"sidescroll",  "ss",   P_NUM,
    (char_u *)&p_ss, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"sidescrolloff", "siso", P_NUM|P_VI_DEF|P_RBUF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"sidescrolloff", "siso", P_NUM|P_RBUF,
    (char_u *)&p_siso, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"slowopen",    "slow", P_BOOL|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"slowopen",    "slow", P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"smartcase",   "scs",  P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"smartcase",   "scs",  P_BOOL,
    (char_u *)&p_scs, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"smartindent", "si",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"smartindent", "si",   P_BOOL,
    (char_u *)&p_si, PV_SI,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"smarttab",    "sta",  P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"smarttab",    "sta",  P_BOOL,
    (char_u *)&p_sta, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"softtabstop", "sts",  P_NUM|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"softtabstop", "sts",  P_NUM,
    (char_u *)&p_sts, PV_STS,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"sourceany",   NULL,   P_BOOL|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"sourceany",   NULL,   P_BOOL,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"spell",       NULL,   P_BOOL|P_VI_DEF|P_RWIN,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"spell",       NULL,   P_BOOL|P_RWIN,
    (char_u *)VAR_WIN, PV_SPELL,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"spellcapcheck", "spc", P_STRING|P_ALLOCED|P_VI_DEF|P_RBUF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"spellcapcheck", "spc", P_STRING|P_ALLOCED|P_RBUF,
    (char_u *)&p_spc, PV_SPC,
-   {(char_u *)"[.?!]\\_[\\])'\"	 ]\\+", (char_u *)0L}
+   (char_u *)"[.?!]\\_[\\])'\"	 ]\\+"
    SCRIPTID_INIT},
-  {"spellfile",   "spf",  P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_SECURE|P_COMMA,
+  {"spellfile",   "spf",  P_STRING|P_EXPAND|P_ALLOCED|P_SECURE|P_COMMA,
    (char_u *)&p_spf, PV_SPF,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"spelllang",   "spl",  P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_RBUF|P_EXPAND,
+  {"spelllang",   "spl",  P_STRING|P_ALLOCED|P_COMMA|P_RBUF|P_EXPAND,
    (char_u *)&p_spl, PV_SPL,
-   {(char_u *)"en", (char_u *)0L}
+   (char_u *)"en"
    SCRIPTID_INIT},
-  {"spellsuggest", "sps", P_STRING|P_VI_DEF|P_EXPAND|P_SECURE|P_COMMA,
+  {"spellsuggest", "sps", P_STRING|P_EXPAND|P_SECURE|P_COMMA,
    (char_u *)&p_sps, PV_NONE,
-   {(char_u *)"best", (char_u *)0L}
+   (char_u *)"best"
    SCRIPTID_INIT},
-  {"splitbelow",  "sb",   P_BOOL|P_VI_DEF,
+  {"splitbelow",  "sb",   P_BOOL,
    (char_u *)&p_sb, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"splitright",  "spr",  P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"splitright",  "spr",  P_BOOL,
    (char_u *)&p_spr, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"startofline", "sol",  P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"startofline", "sol",  P_BOOL,
    (char_u *)&p_sol, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"statusline","stl",  P_STRING|P_VI_DEF|P_ALLOCED|P_RSTAT,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"statusline","stl",  P_STRING|P_ALLOCED|P_RSTAT,
    (char_u *)&p_stl, PV_STL,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"suffixes",    "su",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)"" SCRIPTID_INIT},
+  {"suffixes",    "su",   P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_su, PV_NONE,
-   {(char_u *)".bak,~,.o,.h,.info,.swp,.obj",
-    (char_u *)0L} SCRIPTID_INIT},
-  {"suffixesadd", "sua",  P_STRING|P_VI_DEF|P_ALLOCED|P_COMMA|P_NODUP,
+   (char_u *)".bak,~,.o,.h,.info,.swp,.obj" SCRIPTID_INIT},
+  {"suffixesadd", "sua",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_sua, PV_SUA,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"swapfile",    "swf",  P_BOOL|P_VI_DEF|P_RSTAT,
+  {"swapfile",    "swf",  P_BOOL|P_RSTAT,
    (char_u *)&p_swf, PV_SWF,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"swapsync",    "sws",  P_STRING|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"swapsync",    "sws",  P_STRING,
    (char_u *)&p_sws, PV_NONE,
-   {(char_u *)"fsync", (char_u *)0L} SCRIPTID_INIT},
-  {"switchbuf",   "swb",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)"fsync" SCRIPTID_INIT},
+  {"switchbuf",   "swb",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_swb, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"synmaxcol",   "smc",  P_NUM|P_VI_DEF|P_RBUF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"synmaxcol",   "smc",  P_NUM|P_RBUF,
    (char_u *)&p_smc, PV_SMC,
-   {(char_u *)3000L, (char_u *)0L}
+   (char_u *)3000L
    SCRIPTID_INIT},
-  {"syntax",      "syn",  P_STRING|P_ALLOCED|P_VI_DEF|P_NOGLOB|P_NFNAME,
+  {"syntax",      "syn",  P_STRING|P_ALLOCED|P_NOGLOB|P_NFNAME,
    (char_u *)&p_syn, PV_SYN,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"tabline",     "tal",  P_STRING|P_VI_DEF|P_RALL,
+  {"tabline",     "tal",  P_STRING|P_RALL,
    (char_u *)&p_tal, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"tabpagemax",  "tpm",  P_NUM|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"tabpagemax",  "tpm",  P_NUM,
    (char_u *)&p_tpm, PV_NONE,
-   {(char_u *)10L, (char_u *)0L} SCRIPTID_INIT},
-  {"tabstop",     "ts",   P_NUM|P_VI_DEF|P_RBUF,
+   (char_u *)10L SCRIPTID_INIT},
+  {"tabstop",     "ts",   P_NUM|P_RBUF,
    (char_u *)&p_ts, PV_TS,
-   {(char_u *)8L, (char_u *)0L} SCRIPTID_INIT},
-  {"tagbsearch",  "tbs",   P_BOOL|P_VI_DEF,
+   (char_u *)8L SCRIPTID_INIT},
+  {"tagbsearch",  "tbs",   P_BOOL,
    (char_u *)&p_tbs, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L}
+   (char_u *)TRUE
    SCRIPTID_INIT},
-  {"taglength",   "tl",   P_NUM|P_VI_DEF,
+  {"taglength",   "tl",   P_NUM,
    (char_u *)&p_tl, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)0L SCRIPTID_INIT},
   {"tagrelative", "tr",   P_BOOL,
    (char_u *)&p_tr, PV_NONE,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"tags",        "tag",  P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
+    (char_u *)TRUE SCRIPTID_INIT},
+  {"tags",        "tag",  P_STRING|P_EXPAND|P_COMMA|P_NODUP,
    (char_u *)&p_tags, PV_TAGS,
-   {
-     (char_u *)"./tags,tags",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"tagstack",    "tgst", P_BOOL|P_VI_DEF,
+   
+     (char_u *)"./tags,tags" SCRIPTID_INIT},
+  {"tagstack",    "tgst", P_BOOL,
    (char_u *)&p_tgst, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"term",        NULL,   P_STRING|P_EXPAND|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"term",        NULL,   P_STRING|P_EXPAND|P_NODEFAULT|P_NO_MKRC|
    P_RALL,
    (char_u *)&T_NAME, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"termbidi", "tbidi",   P_BOOL|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"termbidi", "tbidi",   P_BOOL,
    (char_u *)&p_tbidi, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"termencoding", "tenc", P_STRING|P_VI_DEF|P_RCLR,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"termencoding", "tenc", P_STRING|P_RCLR,
    (char_u *)&p_tenc, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"terse",       NULL,   P_BOOL|P_VI_DEF,
+  {"terse",       NULL,   P_BOOL,
    (char_u *)&p_terse, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"textwidth",   "tw",   P_NUM|P_VI_DEF|P_RBUF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"textwidth",   "tw",   P_NUM|P_RBUF,
    (char_u *)&p_tw, PV_TW,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"thesaurus",   "tsr",  P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)0L SCRIPTID_INIT},
+  {"thesaurus",   "tsr",  P_STRING|P_EXPAND|P_COMMA|P_NODUP,
    (char_u *)&p_tsr, PV_TSR,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"tildeop",     "top",  P_BOOL|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"tildeop",     "top",  P_BOOL,
    (char_u *)&p_to, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"timeout",     "to",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"timeout",     "to",   P_BOOL,
    (char_u *)&p_timeout, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"timeoutlen",  "tm",   P_NUM|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"timeoutlen",  "tm",   P_NUM,
    (char_u *)&p_tm, PV_NONE,
-   {(char_u *)1000L, (char_u *)0L} SCRIPTID_INIT},
-  {"title",       NULL,   P_BOOL|P_VI_DEF,
+   (char_u *)1000L SCRIPTID_INIT},
+  {"title",       NULL,   P_BOOL,
    (char_u *)&p_title, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"titlelen",    NULL,   P_NUM|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"titlelen",    NULL,   P_NUM,
    (char_u *)&p_titlelen, PV_NONE,
-   {(char_u *)85L, (char_u *)0L} SCRIPTID_INIT},
-  {"titleold",    NULL,   P_STRING|P_VI_DEF|P_GETTEXT|P_SECURE|P_NO_MKRC,
+   (char_u *)85L SCRIPTID_INIT},
+  {"titleold",    NULL,   P_STRING|P_GETTEXT|P_SECURE|P_NO_MKRC,
    (char_u *)&p_titleold, PV_NONE,
-   {(char_u *)N_("Thanks for flying Vim"),
-    (char_u *)0L}
+   (char_u *)N_("Thanks for flying Vim")
    SCRIPTID_INIT},
-  {"titlestring", NULL,   P_STRING|P_VI_DEF,
+  {"titlestring", NULL,   P_STRING,
    (char_u *)&p_titlestring, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"ttimeout",    NULL,   P_BOOL|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"ttimeout",    NULL,   P_BOOL,
    (char_u *)&p_ttimeout, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"ttimeoutlen", "ttm",  P_NUM|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"ttimeoutlen", "ttm",  P_NUM,
    (char_u *)&p_ttm, PV_NONE,
-   {(char_u *)-1L, (char_u *)0L} SCRIPTID_INIT},
-  {"ttybuiltin",  "tbi",  P_BOOL|P_VI_DEF,
+   (char_u *)-1L SCRIPTID_INIT},
+  {"ttybuiltin",  "tbi",  P_BOOL,
    (char_u *)&p_tbi, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"ttyfast",     "tf",   P_BOOL|P_NO_MKRC|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"ttyfast",     "tf",   P_BOOL|P_NO_MKRC,
    (char_u *)&p_tf, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"ttymouse",    "ttym", P_STRING|P_NODEFAULT|P_NO_MKRC|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"ttymouse",    "ttym", P_STRING|P_NODEFAULT|P_NO_MKRC,
 #if defined(FEAT_MOUSE) && defined(UNIX)
    (char_u *)&p_ttym, PV_NONE,
 #else
    (char_u *)NULL, PV_NONE,
 #endif
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"ttyscroll",   "tsl",  P_NUM|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"ttyscroll",   "tsl",  P_NUM,
    (char_u *)&p_ttyscroll, PV_NONE,
-   {(char_u *)999L, (char_u *)0L} SCRIPTID_INIT},
-  {"ttytype",     "tty",  P_STRING|P_EXPAND|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|
+   (char_u *)999L SCRIPTID_INIT},
+  {"ttytype",     "tty",  P_STRING|P_EXPAND|P_NODEFAULT|P_NO_MKRC|
    P_RALL,
    (char_u *)&T_NAME, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"undodir",     "udir", P_STRING|P_EXPAND|P_COMMA|P_NODUP|P_SECURE|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"undodir",     "udir", P_STRING|P_EXPAND|P_COMMA|P_NODUP|P_SECURE,
    (char_u *)&p_udir, PV_NONE,
-   {(char_u *)".", (char_u *)0L}
+   (char_u *)"."
    SCRIPTID_INIT},
-  {"undofile",    "udf",  P_BOOL|P_VI_DEF,
+  {"undofile",    "udf",  P_BOOL,
    (char_u *)&p_udf, PV_UDF,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"undolevels",  "ul",   P_NUM|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"undolevels",  "ul",   P_NUM,
    (char_u *)&p_ul, PV_UL,
-   {
+   
 #if defined(UNIX) || defined(WIN3264)
-     (char_u *)1000L,
+     (char_u *)1000L
 #else
-     (char_u *)100L,
+     (char_u *)100L
 #endif
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"undoreload",  "ur",   P_NUM|P_VI_DEF,
+ SCRIPTID_INIT},
+  {"undoreload",  "ur",   P_NUM,
    (char_u *)&p_ur, PV_NONE,
-   { (char_u *)10000L, (char_u *)0L} SCRIPTID_INIT},
-  {"updatecount", "uc",   P_NUM|P_VI_DEF,
+    (char_u *)10000L SCRIPTID_INIT},
+  {"updatecount", "uc",   P_NUM,
    (char_u *)&p_uc, PV_NONE,
-   {(char_u *)200L, (char_u *)0L} SCRIPTID_INIT},
-  {"updatetime",  "ut",   P_NUM|P_VI_DEF,
+   (char_u *)200L SCRIPTID_INIT},
+  {"updatetime",  "ut",   P_NUM,
    (char_u *)&p_ut, PV_NONE,
-   {(char_u *)4000L, (char_u *)0L} SCRIPTID_INIT},
-  {"verbose",     "vbs",  P_NUM|P_VI_DEF,
+   (char_u *)4000L SCRIPTID_INIT},
+  {"verbose",     "vbs",  P_NUM,
    (char_u *)&p_verbose, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"verbosefile", "vfile", P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+   (char_u *)0L SCRIPTID_INIT},
+  {"verbosefile", "vfile", P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_vfile, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"viewdir",     "vdir", P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+   (char_u *)"" SCRIPTID_INIT},
+  {"viewdir",     "vdir", P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_vdir, PV_NONE,
-   {(char_u *)DFLT_VDIR, (char_u *)0L}
+   (char_u *)DFLT_VDIR
    SCRIPTID_INIT},
-  {"viewoptions", "vop",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"viewoptions", "vop",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_vop, PV_NONE,
-   {(char_u *)"folds,options,cursor", (char_u *)0L}
+   (char_u *)"folds,options,cursor"
    SCRIPTID_INIT},
   {"viminfo",     "vi",   P_STRING|P_COMMA|P_NODUP|P_SECURE,
    (char_u *)&p_viminfo, PV_NONE,
-   {(char_u *)"", (char_u *)"'100,<50,s10,h"}
+    (char_u *)"'100,<50,s10,h"
    SCRIPTID_INIT},
-  {"virtualedit", "ve",   P_STRING|P_COMMA|P_NODUP|P_VI_DEF|P_CURSWANT,
+  {"virtualedit", "ve",   P_STRING|P_COMMA|P_NODUP|P_CURSWANT,
    (char_u *)&p_ve, PV_NONE,
-   {(char_u *)"", (char_u *)""}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"visualbell",  "vb",   P_BOOL|P_VI_DEF,
+  {"visualbell",  "vb",   P_BOOL,
    (char_u *)&p_vb, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"w300",        NULL,   P_NUM|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"w300",        NULL,   P_NUM,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"w1200",       NULL,   P_NUM|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"w1200",       NULL,   P_NUM,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"w9600",       NULL,   P_NUM|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"w9600",       NULL,   P_NUM,
    (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"warn",        NULL,   P_BOOL|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"warn",        NULL,   P_BOOL,
    (char_u *)&p_warn, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"weirdinvert", "wiv",  P_BOOL|P_VI_DEF|P_RCLR,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"weirdinvert", "wiv",  P_BOOL|P_RCLR,
    (char_u *)&p_wiv, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)FALSE SCRIPTID_INIT},
   {"whichwrap",   "ww",   P_STRING|P_COMMA|P_FLAGLIST,
    (char_u *)&p_ww, PV_NONE,
-   {(char_u *)"", (char_u *)"b,s"} SCRIPTID_INIT},
+    (char_u *)"b,s" SCRIPTID_INIT},
   {"wildchar",    "wc",   P_NUM,
    (char_u *)&p_wc, PV_NONE,
-   {(char_u *)(long)Ctrl_E, (char_u *)(long)TAB}
+    (char_u *)(long)TAB
    SCRIPTID_INIT},
-  {"wildcharm",   "wcm",  P_NUM|P_VI_DEF,
+  {"wildcharm",   "wcm",  P_NUM,
    (char_u *)&p_wcm, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"wildignore",  "wig",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)0L SCRIPTID_INIT},
+  {"wildignore",  "wig",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_wig, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"wildignorecase", "wic", P_BOOL|P_VI_DEF,
+   (char_u *)"" SCRIPTID_INIT},
+  {"wildignorecase", "wic", P_BOOL,
    (char_u *)&p_wic, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"wildmenu",    "wmnu", P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"wildmenu",    "wmnu", P_BOOL,
    (char_u *)&p_wmnu, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"wildmode",    "wim",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"wildmode",    "wim",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_wim, PV_NONE,
-   {(char_u *)"full", (char_u *)0L} SCRIPTID_INIT},
-  {"wildoptions", "wop",  P_STRING|P_VI_DEF,
+   (char_u *)"full" SCRIPTID_INIT},
+  {"wildoptions", "wop",  P_STRING,
    (char_u *)&p_wop, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"winaltkeys",  "wak",  P_STRING|P_VI_DEF,
+  {"winaltkeys",  "wak",  P_STRING,
    (char_u *)&p_wak, PV_NONE,
-   {(char_u *)"menu", (char_u *)0L}
+   (char_u *)"menu"
    SCRIPTID_INIT},
-  {"window",      "wi",   P_NUM|P_VI_DEF,
+  {"window",      "wi",   P_NUM,
    (char_u *)&p_window, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"winheight",   "wh",   P_NUM|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"winheight",   "wh",   P_NUM,
    (char_u *)&p_wh, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"winfixheight", "wfh", P_BOOL|P_VI_DEF|P_RSTAT,
+   (char_u *)1L SCRIPTID_INIT},
+  {"winfixheight", "wfh", P_BOOL|P_RSTAT,
    (char_u *)VAR_WIN, PV_WFH,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"winfixwidth", "wfw", P_BOOL|P_VI_DEF|P_RSTAT,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"winfixwidth", "wfw", P_BOOL|P_RSTAT,
    (char_u *)VAR_WIN, PV_WFW,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"winminheight", "wmh", P_NUM|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"winminheight", "wmh", P_NUM,
    (char_u *)&p_wmh, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"winminwidth", "wmw", P_NUM|P_VI_DEF,
+   (char_u *)1L SCRIPTID_INIT},
+  {"winminwidth", "wmw", P_NUM,
    (char_u *)&p_wmw, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"winwidth",   "wiw",   P_NUM|P_VI_DEF,
+   (char_u *)1L SCRIPTID_INIT},
+  {"winwidth",   "wiw",   P_NUM,
    (char_u *)&p_wiw, PV_NONE,
-   {(char_u *)20L, (char_u *)0L} SCRIPTID_INIT},
-  {"wrap",        NULL,   P_BOOL|P_VI_DEF|P_RWIN,
+   (char_u *)20L SCRIPTID_INIT},
+  {"wrap",        NULL,   P_BOOL|P_RWIN,
    (char_u *)VAR_WIN, PV_WRAP,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"wrapmargin",  "wm",   P_NUM|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"wrapmargin",  "wm",   P_NUM,
    (char_u *)&p_wm, PV_WM,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"wrapscan",    "ws",   P_BOOL|P_VI_DEF,
+   (char_u *)0L SCRIPTID_INIT},
+  {"wrapscan",    "ws",   P_BOOL,
    (char_u *)&p_ws, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"write",       NULL,   P_BOOL|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"write",       NULL,   P_BOOL,
    (char_u *)&p_write, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"writeany",    "wa",   P_BOOL|P_VI_DEF,
+   (char_u *)TRUE SCRIPTID_INIT},
+  {"writeany",    "wa",   P_BOOL,
    (char_u *)&p_wa, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"writebackup", "wb",   P_BOOL|P_VI_DEF,
+   (char_u *)FALSE SCRIPTID_INIT},
+  {"writebackup", "wb",   P_BOOL,
    (char_u *)&p_wb, PV_NONE,
-   {
-     (char_u *)TRUE,
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"writedelay",  "wd",   P_NUM|P_VI_DEF,
+   
+     (char_u *)TRUE SCRIPTID_INIT},
+  {"writedelay",  "wd",   P_NUM,
    (char_u *)&p_wd, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)0L SCRIPTID_INIT},
 
   /* terminal output codes */
-#define p_term(sss, vvv)   {sss, NULL, P_STRING|P_VI_DEF|P_RALL|P_SECURE, \
+#define p_term(sss, vvv)   {sss, NULL, P_STRING|P_RALL|P_SECURE, \
                             (char_u *)&vvv, PV_NONE, \
-                            {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
+                            (char_u *)"" SCRIPTID_INIT},
 
   p_term("t_AB", T_CAB)
   p_term("t_AF", T_CAF)
@@ -1807,7 +1754,7 @@ static struct vimoption
 
   /* end marker */
   {
-    NULL, NULL, 0, NULL, PV_NONE, {NULL, NULL} SCRIPTID_INIT
+    NULL, NULL, 0, NULL, PV_NONE, NULL SCRIPTID_INIT
   }
 };
 
@@ -1917,7 +1864,7 @@ void set_init_1(void)
   opt_idx = findoption((char_u *)"maxmemtot");
   if (opt_idx >= 0) {
 #ifndef HAVE_TOTAL_MEM
-    if (options[opt_idx].def_val[VI_DEFAULT] == (char_u *)0L)
+    if (options[opt_idx].def_val == (char_u *)0L)
 #endif
     {
 #ifdef HAVE_TOTAL_MEM
@@ -1929,14 +1876,14 @@ void set_init_1(void)
 #else
       n = (0x7fffffff >> 11);
 #endif
-      options[opt_idx].def_val[VI_DEFAULT] = (char_u *)n;
+      options[opt_idx].def_val = (char_u *)n;
       opt_idx = findoption((char_u *)"maxmem");
       if (opt_idx >= 0) {
 #ifndef HAVE_TOTAL_MEM
-        if ((long)options[opt_idx].def_val[VI_DEFAULT] > (long)n
-            || (long)options[opt_idx].def_val[VI_DEFAULT] == 0L)
+        if ((long)options[opt_idx].def_val > (long)n
+            || (long)options[opt_idx].def_val == 0L)
 #endif
-        options[opt_idx].def_val[VI_DEFAULT] = (char_u *)n;
+        options[opt_idx].def_val = (char_u *)n;
       }
     }
   }
@@ -1968,7 +1915,7 @@ void set_init_1(void)
         buf[j] = NUL;
         opt_idx = findoption((char_u *)"cdpath");
         if (opt_idx >= 0) {
-          options[opt_idx].def_val[VI_DEFAULT] = buf;
+          options[opt_idx].def_val = buf;
           options[opt_idx].flags |= P_DEF_ALLOCED;
         } else
           free(buf);           /* cannot happen */
@@ -2041,8 +1988,8 @@ void set_init_1(void)
        * split P_DEF_ALLOCED in two.
        */
       if (options[opt_idx].flags & P_DEF_ALLOCED)
-        free(options[opt_idx].def_val[VI_DEFAULT]);
-      options[opt_idx].def_val[VI_DEFAULT] = p;
+        free(options[opt_idx].def_val);
+      options[opt_idx].def_val = p;
       options[opt_idx].flags |= P_DEF_ALLOCED;
     }
   }
@@ -2092,7 +2039,7 @@ void set_init_1(void)
     if (mb_init() == NULL) {
       opt_idx = findoption((char_u *)"encoding");
       if (opt_idx >= 0) {
-        options[opt_idx].def_val[VI_DEFAULT] = p_enc;
+        options[opt_idx].def_val = p_enc;
         options[opt_idx].flags |= P_DEF_ALLOCED;
       }
 
@@ -2139,7 +2086,6 @@ set_option_default (
 )
 {
   char_u      *varp;            /* pointer to variable for current option */
-  int dvi;                      /* index in def_val[] */
   long_u flags;
   long_u      *flagsp;
   int both = (opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0;
@@ -2147,31 +2093,30 @@ set_option_default (
   varp = get_varp_scope(&(options[opt_idx]), both ? OPT_LOCAL : opt_flags);
   flags = options[opt_idx].flags;
   if (varp != NULL) {       /* skip hidden option, nothing to do for it */
-    dvi = ((flags & P_VI_DEF) || compatible) ? VI_DEFAULT : VIM_DEFAULT;
     if (flags & P_STRING) {
       /* Use set_string_option_direct() for local options to handle
        * freeing and allocating the value. */
       if (options[opt_idx].indir != PV_NONE)
         set_string_option_direct(NULL, opt_idx,
-            options[opt_idx].def_val[dvi], opt_flags, 0);
+            options[opt_idx].def_val, opt_flags, 0);
       else {
         if ((opt_flags & OPT_FREE) && (flags & P_ALLOCED))
           free_string_option(*(char_u **)(varp));
-        *(char_u **)varp = options[opt_idx].def_val[dvi];
+        *(char_u **)varp = options[opt_idx].def_val;
         options[opt_idx].flags &= ~P_ALLOCED;
       }
     } else if (flags & P_NUM)   {
       if (options[opt_idx].indir == PV_SCROLL)
         win_comp_scroll(curwin);
       else {
-        *(long *)varp = (long)options[opt_idx].def_val[dvi];
+        *(long *)varp = (long)options[opt_idx].def_val;
         /* May also set global value for local option. */
         if (both)
           *(long *)get_varp_scope(&(options[opt_idx]), OPT_GLOBAL) =
             *(long *)varp;
       }
     } else {  /* P_BOOL */
-      *(int *)varp = (int)(intptr_t)options[opt_idx].def_val[dvi];
+      *(int *)varp = (int)(intptr_t)options[opt_idx].def_val;
 #ifdef UNIX
       /* 'modeline' defaults to off for root */
       if (options[opt_idx].indir == PV_ML && getuid() == ROOT_UID)
@@ -2222,10 +2167,10 @@ void set_string_default(const char *name, const char_u *val)
   int opt_idx = findoption((char_u *)name);
   if (opt_idx >= 0) {
     if (options[opt_idx].flags & P_DEF_ALLOCED) {
-      free(options[opt_idx].def_val[VI_DEFAULT]);
+      free(options[opt_idx].def_val);
     }
 
-    options[opt_idx].def_val[VI_DEFAULT] = (char_u *) xstrdup((char *) val);
+    options[opt_idx].def_val = (char_u *) xstrdup((char *) val);
     options[opt_idx].flags |= P_DEF_ALLOCED;
   }
 }
@@ -2240,7 +2185,7 @@ void set_number_default(char *name, long val)
 
   opt_idx = findoption((char_u *)name);
   if (opt_idx >= 0)
-    options[opt_idx].def_val[VI_DEFAULT] = (char_u *)val;
+    options[opt_idx].def_val = (char_u *)val;
 }
 
 #if defined(EXITFREE) || defined(PROTO)
@@ -2257,7 +2202,7 @@ void free_all_options(void)
       if (options[i].flags & P_ALLOCED && options[i].var != NULL)
         free_string_option(*(char_u **)options[i].var);
       if (options[i].flags & P_DEF_ALLOCED)
-        free_string_option(options[i].def_val[VI_DEFAULT]);
+        free_string_option(options[i].def_val);
     } else if (options[i].var != VAR_WIN
                && (options[i].flags & P_STRING))
       /* buffer-local option: free global value */
@@ -2401,11 +2346,11 @@ void set_init_3(void)
                ) {
       if (do_sp) {
         p_sp = (char_u *)"|& tee";
-        options[idx_sp].def_val[VI_DEFAULT] = p_sp;
+        options[idx_sp].def_val = p_sp;
       }
       if (do_srr) {
         p_srr = (char_u *)">&";
-        options[idx_srr].def_val[VI_DEFAULT] = p_srr;
+        options[idx_srr].def_val = p_srr;
       }
     } else if (       fnamecmp(p, "sh") == 0
                       || fnamecmp(p, "ksh") == 0
@@ -2417,11 +2362,11 @@ void set_init_3(void)
                       ) {
       if (do_sp) {
         p_sp = (char_u *)"2>&1| tee";
-        options[idx_sp].def_val[VI_DEFAULT] = p_sp;
+        options[idx_sp].def_val = p_sp;
       }
       if (do_srr) {
         p_srr = (char_u *)">%s 2>&1";
-        options[idx_srr].def_val[VI_DEFAULT] = p_srr;
+        options[idx_srr].def_val = p_srr;
       }
     }
     free(p);
@@ -2478,13 +2423,13 @@ void set_title_defaults(void)
   idx1 = findoption((char_u *)"title");
   if (idx1 >= 0 && !(options[idx1].flags & P_WAS_SET)) {
     val = mch_can_restore_title();
-    options[idx1].def_val[VI_DEFAULT] = (char_u *)val;
+    options[idx1].def_val = (char_u *)val;
     p_title = val;
   }
   idx1 = findoption((char_u *)"icon");
   if (idx1 >= 0 && !(options[idx1].flags & P_WAS_SET)) {
     val = mch_can_restore_icon();
-    options[idx1].def_val[VI_DEFAULT] = (char_u *)val;
+    options[idx1].def_val = (char_u *)val;
     p_icon = val;
   }
 }
@@ -2777,9 +2722,7 @@ do_set (
           if (nextchar == '!')
             value = *(int *)(varp) ^ 1;
           else if (nextchar == '&')
-            value = (int)(intptr_t)options[opt_idx].def_val[
-              ((flags & P_VI_DEF) || cp_val)
-              ?  VI_DEFAULT : VIM_DEFAULT];
+            value = (int)(intptr_t)options[opt_idx].def_val;
           else if (nextchar == '<') {
             /* For 'autoread' -1 means to use global value. */
             if ((int *)varp == &curbuf->b_p_ar
@@ -2824,9 +2767,7 @@ do_set (
              */
             ++arg;
             if (nextchar == '&')
-              value = (long)options[opt_idx].def_val[
-                ((flags & P_VI_DEF) || cp_val)
-                ?  VI_DEFAULT : VIM_DEFAULT];
+              value = (long)options[opt_idx].def_val;
             else if (nextchar == '<') {
               /* For 'undolevels' NO_LOCAL_UNDOLEVEL means to
                * use the global value. */
@@ -2898,9 +2839,7 @@ do_set (
              * new value is valid. */
             oldval = *(char_u **)varp;
             if (nextchar == '&') {              /* set to default val */
-              newval = options[opt_idx].def_val[
-                ((flags & P_VI_DEF) || cp_val)
-                ?  VI_DEFAULT : VIM_DEFAULT];
+              newval = options[opt_idx].def_val;
               if ((char_u **)varp == &p_bg) {
                 /* guess the value of 'background' */
                 newval = term_bg_default();
@@ -6004,7 +5943,7 @@ char_u *get_highlight_default(void)
 
   i = findoption((char_u *)"hl");
   if (i >= 0)
-    return options[i].def_val[VI_DEFAULT];
+    return options[i].def_val;
   return (char_u *)NULL;
 }
 
@@ -6014,7 +5953,7 @@ char_u *get_encoding_default(void)
 
   i = findoption((char_u *)"enc");
   if (i >= 0)
-    return options[i].def_val[VI_DEFAULT];
+    return options[i].def_val;
   return (char_u *)NULL;
 }
 
@@ -6145,17 +6084,14 @@ showoptions (
  */
 static int optval_default(struct vimoption *p, char_u *varp)
 {
-  int dvi;
-
   if (varp == NULL)
     return TRUE;            /* hidden option is always at default */
-  dvi = (p->flags & P_VI_DEF) ? VI_DEFAULT : VIM_DEFAULT;
   if (p->flags & P_NUM)
-    return *(long *)varp == (long)p->def_val[dvi];
+    return *(long *)varp == (long)p->def_val;
   if (p->flags & P_BOOL)
-    return *(int *)varp == (int)(intptr_t)p->def_val[dvi];
+    return *(int *)varp == (int)(intptr_t)p->def_val;
   /* P_STRING */
-  return STRCMP(*(char_u **)varp, p->def_val[dvi]) == 0;
+  return STRCMP(*(char_u **)varp, p->def_val) == 0;
 }
 
 /*
@@ -6426,9 +6362,9 @@ void free_termoptions(void)
       if (p->flags & P_ALLOCED)
         free_string_option(*(char_u **)(p->var));
       if (p->flags & P_DEF_ALLOCED)
-        free_string_option(p->def_val[VI_DEFAULT]);
+        free_string_option(p->def_val);
       *(char_u **)(p->var) = empty_option;
-      p->def_val[VI_DEFAULT] = empty_option;
+      p->def_val = empty_option;
       p->flags &= ~(P_ALLOCED|P_DEF_ALLOCED);
     }
   clear_termcodes();
@@ -6462,12 +6398,12 @@ void set_term_defaults(void)
   struct vimoption   *p;
 
   for (p = &options[0]; p->fullname != NULL; p++) {
-    if (istermoption(p) && p->def_val[VI_DEFAULT] != *(char_u **)(p->var)) {
+    if (istermoption(p) && p->def_val != *(char_u **)(p->var)) {
       if (p->flags & P_DEF_ALLOCED) {
-        free_string_option(p->def_val[VI_DEFAULT]);
+        free_string_option(p->def_val);
         p->flags &= ~P_DEF_ALLOCED;
       }
-      p->def_val[VI_DEFAULT] = *(char_u **)(p->var);
+      p->def_val = *(char_u **)(p->var);
       if (p->flags & P_ALLOCED) {
         p->flags |= P_DEF_ALLOCED;
         p->flags &= ~P_ALLOCED;          /* don't free the value now */
@@ -7045,7 +6981,7 @@ void reset_modifiable(void)
   p_ma = FALSE;
   opt_idx = findoption((char_u *)"ma");
   if (opt_idx >= 0)
-    options[opt_idx].def_val[VI_DEFAULT] = FALSE;
+    options[opt_idx].def_val = FALSE;
 }
 
 /*
@@ -7771,7 +7707,7 @@ void vimrc_found(char_u *fname, char_u *envname)
 
   if (!option_was_set((char_u *)"cp")) {
     for (opt_idx = 0; !istermoption(&options[opt_idx]); opt_idx++)
-      if (!(options[opt_idx].flags & (P_WAS_SET|P_VI_DEF)))
+      if (!(options[opt_idx].flags & P_WAS_SET))
         set_option_default(opt_idx, OPT_FREE, FALSE);
     didset_options();
   }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2470,7 +2470,6 @@ do_set (
   int adding;                       /* "opt+=arg" */
   int prepending;                   /* "opt^=arg" */
   int removing;                     /* "opt-=arg" */
-  int cp_val = 0;
   char_u key_name[2];
 
   if (*arg == NUL) {
@@ -2645,13 +2644,10 @@ do_set (
 
       if (vim_strchr((char_u *)"?=:!&<", nextchar) != NULL) {
         arg += len;
-        cp_val = false;
         if (nextchar == '&' && arg[1] == 'v' && arg[2] == 'i') {
           if (arg[3] == 'm') {          /* "opt&vim": set to Vim default */
-            cp_val = FALSE;
             arg += 3;
           } else {                    /* "opt&vi": set to Vi default */
-            cp_val = TRUE;
             arg += 2;
           }
         }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3181,7 +3181,7 @@ theend:
 static void 
 did_set_option (
     int opt_idx,
-    int opt_flags,              /* possibly with OPT_MODELINE */
+    int opt_flags,             /* possibly with OPT_MODELINE */
     int new_value              /* value was replaced completely */
 )
 {

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -317,7 +317,7 @@ EXTERN char_u   *p_cedit;       /* 'cedit' */
 EXTERN long p_cwh;              /* 'cmdwinheight' */
 EXTERN long p_ch;               /* 'cmdheight' */
 EXTERN int p_confirm;           /* 'confirm' */
-EXTERN int p_cp;                /* 'compatible' */
+EXTERN int p_vi_compatible;     /* 'compatible' - unused in nvim but left for compatibility */
 EXTERN char_u   *p_cot;         /* 'completeopt' */
 EXTERN long p_ph;               /* 'pumheight' */
 EXTERN char_u   *p_cpo;         /* 'cpoptions' */

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -820,21 +820,11 @@ void intro_message(int colon)
     "",
     N_("type  :q<Enter>               to exit         "),
     N_("type  :help<Enter>  or  <F1>  for on-line help"),
-    N_("type  :help version7<Enter>   for version info"),
-    NULL,
-    "",
-    N_("Running in Vi compatible mode"),
-    N_("type  :set nocp<Enter>        for Vim defaults"),
-    N_("type  :help cp-default<Enter> for info on this"),
+    N_("type  :help version7<Enter>   for version info")
   };
 
   // blanklines = screen height - # message lines
   blanklines = (int)Rows - ((sizeof(lines) / sizeof(char *)) - 1);
-
-  if (!p_cp) {
-    // add 4 for not showing "Vi compatible" message
-    blanklines += 4;
-  }
 
   // Don't overwrite a statusline.  Depends on 'cmdheight'.
   if (p_ls > 1) {
@@ -856,12 +846,6 @@ void intro_message(int colon)
   if (((row >= 2) && (Columns >= 50)) || colon) {
     for (i = 0; i < (int)(sizeof(lines) / sizeof(char *)); ++i) {
       p = lines[i];
-      if (p == NULL) {
-        if (!p_cp) {
-          break;
-        }
-        continue;
-      }
 
       if (sponsor != 0) {
         if (strstr(p, "children") != NULL) {


### PR DESCRIPTION
I guess that vi compatible mode is old cruft that should be removed from nvim?

This removes information about vim compatibility from the startup scree - if this is merged I can go on and purge vi compatibility from more places.
