### PR TITLE
[RDY] Avoid linking with libform(w).so

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -146,7 +146,7 @@ else()
     list(APPEND NVIM_LINK_LIBRARIES tinfo)
   else()
     find_package(Curses REQUIRED)
-    list(APPEND NVIM_LINK_LIBRARIES ${CURSES_LIBRARIES})
+    list(APPEND NVIM_LINK_LIBRARIES ${CURSES_LIBRARY})
   endif()
 endif()
 


### PR DESCRIPTION
If libtgent or libcurses is installed, the first one found of them
is linked to.

But if not, a find_package(Curses REQUIRED) is used and CURSES_LIBRARIES
is added to NVIM_LINK_LIBRARIES. This contains libform(w).so on many
systems, causing nvim to be linked to and depend on libform(w).so,
which may not be installed one some space-constrained systems,unnecessarily.
