### PR TITLE
[RFC] Default 'encoding'-option from latin to utf-8

### DIFF
--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -49,7 +49,7 @@
 # define ENC_UCSBOM     "ucs-bom"       /* check for BOM at start of file */
 
 /* default value for 'encoding' */
-# define ENC_DFLT       "latin1"
+# define ENC_DFLT       "utf-8"
 
 /* end-of-line style */
 #define EOL_UNKNOWN     -1      /* not defined yet */


### PR DESCRIPTION
Normally the default encoding does not have much effect, since it's
overridden by the environment.

But when it's not (test with "LANG= LC_ALL= C_CTYPE= nvim" and perform
":set encoding?"), utf-8 should be the default encoding for a 21st
century editor :).
