### PR TITLE
[RDY] Use strict function prototypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,8 @@ if(APPLE)
   endif()
 endif()
 
-add_definitions(-Wall -Wextra -pedantic -Wno-unused-parameter -std=gnu99)
+add_definitions(-Wall -Wextra -pedantic -Wno-unused-parameter
+    -Wstrict-prototypes -std=gnu99)
 
 option(
   TRAVIS_CI_BUILD "Travis CI build.  Extra compilation flags will be set." OFF)

--- a/src/nvim/api/private/handle.c
+++ b/src/nvim/api/private/handle.c
@@ -33,7 +33,7 @@ HANDLE_IMPL(buf_T, buffer)
 HANDLE_IMPL(win_T, window)
 HANDLE_IMPL(tabpage_T, tabpage)
 
-void handle_init()
+void handle_init(void)
 {
   HANDLE_INIT(buffer);
   HANDLE_INIT(window);

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -22,7 +22,7 @@
 #endif
 
 /// Start block that may cause vimscript exceptions
-void try_start()
+void try_start(void)
 {
   ++trylevel;
 }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4484,7 +4484,7 @@ void buf_delete_signs(buf_T *buf)
 /*
  * Delete all signs in all buffers.
  */
-void buf_delete_all_signs()
+void buf_delete_all_signs(void)
 {
     buf_T *buf;     /* buffer we are checking for signs */
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11649,9 +11649,7 @@ static void f_readfile(typval_T *argvars, typval_T *rettv)
  * Convert a List to proftime_T.
  * Return FAIL when there is something wrong.
  */
-static int list2proftime(arg, tm)
-typval_T    *arg;
-proftime_T  *tm;
+static int list2proftime(typval_T *arg, proftime_T *tm)
 {
   long n1, n2;
   int error = FALSE;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3932,11 +3932,8 @@ expand_shellcmd (
  * Call "user_expand_func()" to invoke a user defined VimL function and return
  * the result (either a string or a List).
  */
-static void * call_user_expand_func(user_expand_func, xp, num_file, file)
-user_expand_func_T user_expand_func;
-expand_T           *xp;
-int                *num_file;
-char_u             ***file;
+static void * call_user_expand_func(user_expand_func_T user_expand_func,
+                                    expand_T *xp, int *num_file, char_u ***file)
 {
   int keep = 0;
   char_u num[50];

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -396,7 +396,7 @@ int stuff_empty(void)
  * Return TRUE if readbuf1 is empty.  There may still be redo characters in
  * redbuf2.
  */
-int readbuf1_empty()
+int readbuf1_empty(void)
 {
   return (readbuf1.bh_first.b_next == NULL);
 }

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -416,7 +416,7 @@ int enc_canon_props(char_u *name)
  * When there is something wrong: Returns an error message and doesn't change
  * anything.
  */
-char_u * mb_init()
+char_u * mb_init(void)
 {
   int i;
   int idx;
@@ -620,7 +620,7 @@ char_u * mb_init()
  * 4 - UCS-4 BOM
  * 3 - UTF-8 BOM
  */
-int bomb_size()
+int bomb_size(void)
 {
   int n = 0;
 
@@ -2850,7 +2850,7 @@ int mb_strnicmp(char_u *s1, char_u *s2, size_t nn)
  * "g8": show bytes of the UTF-8 char under the cursor.  Doesn't matter what
  * 'encoding' has been set to.
  */
-void show_utf8()
+void show_utf8(void)
 {
   int len;
   int rlen = 0;
@@ -3080,7 +3080,7 @@ int mb_tail_off(char_u *base, char_u *p)
 /*
  * Find the next illegal byte sequence.
  */
-void utf_find_illegal()
+void utf_find_illegal(void)
 {
   pos_T pos = curwin->w_cursor;
   char_u      *p;
@@ -3147,7 +3147,7 @@ theend:
  * If the cursor moves on an trail byte, set the cursor on the lead byte.
  * Thus it moves left if necessary.
  */
-void mb_adjust_cursor()
+void mb_adjust_cursor(void)
 {
   mb_adjustpos(curbuf, &curwin->w_cursor);
 }
@@ -3401,7 +3401,7 @@ static int enc_alias_search(char_u *name)
  * Get the canonicalized encoding of the current locale.
  * Returns an allocated string when successful, NULL when not.
  */
-char_u * enc_locale()
+char_u * enc_locale(void)
 {
   char        *s;
   char        *p;
@@ -3696,7 +3696,7 @@ bool iconv_enabled(bool verbose)
   return true;
 }
 
-void iconv_end()
+void iconv_end(void)
 {
   /* Don't use iconv() when inputting or outputting characters. */
   if (input_conv.vc_type == CONV_ICONV)

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -49,7 +49,7 @@
 
 /// Try to free memory. Used when trying to recover from out of memory errors.
 /// @see {xmalloc}
-static void try_to_free_memory()
+static void try_to_free_memory(void)
 {
   static bool trying_to_free = false;
   // avoid recursive calls

--- a/src/nvim/os/channel.c
+++ b/src/nvim/os/channel.c
@@ -56,7 +56,7 @@ static msgpack_sbuffer out_buffer;
 #endif
 
 /// Initializes the module
-void channel_init()
+void channel_init(void)
 {
   channels = pmap_new(uint64_t)();
   event_strings = pmap_new(cstr_t)();
@@ -64,7 +64,7 @@ void channel_init()
 }
 
 /// Teardown the module
-void channel_teardown()
+void channel_teardown(void)
 {
   if (!channels) {
     return;
@@ -470,7 +470,7 @@ static void close_cb(uv_handle_t *handle)
   free(handle);
 }
 
-static Channel *register_channel()
+static Channel *register_channel(void)
 {
   Channel *rv = xmalloc(sizeof(Channel));
   rv->enabled = true;

--- a/src/nvim/os/dl.c
+++ b/src/nvim/os/dl.c
@@ -13,7 +13,7 @@
 /// int -> string
 /// string -> string
 /// string -> int
-typedef void (*gen_fn)();
+typedef void (*gen_fn)(void);
 typedef const char *(*str_str_fn)(const char *str);
 typedef int64_t (*str_int_fn)(const char *str);
 typedef const char *(*int_str_fn)(int64_t i);

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -55,7 +55,7 @@ char *os_getenvname_at_index(size_t index)
 /// Get the process ID of the Neovim process.
 ///
 /// @return the process ID.
-int64_t os_get_pid()
+int64_t os_get_pid(void)
 {
 #ifdef _WIN32
   return (int64_t)GetCurrentProcessId();

--- a/src/nvim/os/event.c
+++ b/src/nvim/os/event.c
@@ -33,7 +33,7 @@ typedef struct {
 #endif
 static klist_t(Event) *deferred_events, *immediate_events;
 
-void event_init()
+void event_init(void)
 {
   // Initialize the event queues
   deferred_events = kl_init(Event);
@@ -52,7 +52,7 @@ void event_init()
   server_init();
 }
 
-void event_teardown()
+void event_teardown(void)
 {
   channel_teardown();
   job_teardown();
@@ -122,7 +122,7 @@ bool event_poll(int32_t ms)
   return !timer_data.timed_out && (events_processed || event_has_deferred());
 }
 
-bool event_has_deferred()
+bool event_has_deferred(void)
 {
   return !kl_empty(get_queue(true));
 }

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -32,20 +32,20 @@ static bool eof = false, started_reading = false;
 // Helper function used to push bytes from the 'event' key sequence partially
 // between calls to os_inchar when maxlen < 3
 
-void input_init()
+void input_init(void)
 {
   read_stream = rstream_new(read_cb, READ_BUFFER_SIZE, NULL, false);
   rstream_set_file(read_stream, read_cmd_fd);
 }
 
 // Listen for input
-void input_start()
+void input_start(void)
 {
   rstream_start(read_stream);
 }
 
 // Stop listening for input
-void input_stop()
+void input_stop(void)
 {
   rstream_stop(read_stream);
 }
@@ -105,14 +105,14 @@ int os_inchar(uint8_t *buf, int maxlen, int32_t ms, int tb_change_cnt)
 }
 
 // Check if a character is available for reading
-bool os_char_avail()
+bool os_char_avail(void)
 {
   return inbuf_poll(0) == kInputAvail;
 }
 
 // Check for CTRL-C typed by reading all available characters.
 // In cooked mode we should get SIGINT, no need to check.
-void os_breakcheck()
+void os_breakcheck(void)
 {
   if (curr_tmode == TMODE_RAW && input_poll(0))
     fill_input_buf(false);
@@ -148,7 +148,7 @@ static InbufPollResult inbuf_poll(int32_t ms)
   return kInputNone;
 }
 
-static void stderr_switch()
+static void stderr_switch(void)
 {
   int mode = cur_tmode;
   // We probably set the wrong file descriptor to raw mode. Switch back to
@@ -198,7 +198,7 @@ static int push_event_key(uint8_t *buf, int maxlen)
 }
 
 // Check if there's pending input
-bool input_ready()
+bool input_ready(void)
 {
   return rstream_available(read_stream) > 0 || eof;
 }

--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -65,14 +65,14 @@ static uv_prepare_t job_prepare;
 // Callbacks for libuv
 
 /// Initializes job control resources
-void job_init()
+void job_init(void)
 {
   uv_disable_stdio_inheritance();
   uv_prepare_init(uv_default_loop(), &job_prepare);
 }
 
 /// Releases job control resources and terminates running jobs
-void job_teardown()
+void job_teardown(void)
 {
   // 20 tries will give processes about 1 sec to exit cleanly
   uint32_t remaining_tries = 20;

--- a/src/nvim/os/server.c
+++ b/src/nvim/os/server.c
@@ -47,7 +47,7 @@ static PMap(cstr_t) *servers = NULL;
 #endif
 
 /// Initializes the module
-void server_init()
+void server_init(void)
 {
   servers = pmap_new(cstr_t)();
 
@@ -61,7 +61,7 @@ void server_init()
 }
 
 /// Teardown the server module
-void server_teardown()
+void server_teardown(void)
 {
   if (!servers) {
     return;

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -26,7 +26,7 @@ static bool rejecting_deadly;
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/signal.c.generated.h"
 #endif
-void signal_init()
+void signal_init(void)
 {
   uv_signal_init(uv_default_loop(), &sint);
   uv_signal_init(uv_default_loop(), &spipe);
@@ -46,7 +46,7 @@ void signal_init()
 #endif
 }
 
-void signal_stop()
+void signal_stop(void)
 {
   uv_signal_stop(&sint);
   uv_signal_stop(&spipe);
@@ -59,12 +59,12 @@ void signal_stop()
 #endif
 }
 
-void signal_reject_deadly()
+void signal_reject_deadly(void)
 {
   rejecting_deadly = true;
 }
 
-void signal_accept_deadly()
+void signal_accept_deadly(void)
 {
   rejecting_deadly = false;
 }

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -16,7 +16,7 @@ static uv_cond_t delay_cond;
 # include "os/time.c.generated.h"
 #endif
 /// Initializes the time module
-void time_init()
+void time_init(void)
 {
   uv_mutex_init(&delay_mutex);
   uv_cond_init(&delay_cond);

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -104,7 +104,7 @@ void mch_write(char_u *s, int len)
  * If the machine has job control, use it to suspend the program,
  * otherwise fake it by starting a new shell.
  */
-void mch_suspend()
+void mch_suspend(void)
 {
   /* BeOS does have SIGTSTP, but it doesn't work. */
 #if defined(SIGTSTP) && !defined(__BEOS__)
@@ -148,7 +148,7 @@ void mch_suspend()
 #endif
 }
 
-void mch_init()
+void mch_init(void)
 {
   Columns = 80;
   Rows = 24;
@@ -179,12 +179,12 @@ static int get_x11_icon(int test_only)
 }
 
 
-int mch_can_restore_title()
+int mch_can_restore_title(void)
 {
   return get_x11_title(TRUE);
 }
 
-int mch_can_restore_icon()
+int mch_can_restore_icon(void)
 {
   return get_x11_icon(TRUE);
 }
@@ -292,7 +292,7 @@ int use_xterm_like_mouse(char_u *name)
  * Return 3 for "urxvt".
  * Return 4 for "sgr".
  */
-int use_xterm_mouse()
+int use_xterm_mouse(void)
 {
   if (ttym_flags == TTYM_SGR)
     return 4;
@@ -506,14 +506,15 @@ int mch_nodetype(char_u *name)
   return NODE_WRITABLE;
 }
 
-void mch_early_init()
+void mch_early_init(void)
 {
   handle_init();
   time_init();
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void mch_free_mem()          {
+void mch_free_mem(void)
+{
   free(oldtitle);
   free(oldicon);
 }
@@ -525,7 +526,7 @@ void mch_free_mem()          {
  * Output a newline when exiting.
  * Make sure the newline goes to the same stream as the text.
  */
-static void exit_scroll()
+static void exit_scroll(void)
 {
   if (silent_mode)
     return;
@@ -691,7 +692,7 @@ void mch_settmode(int tmode)
  * be), they're going to get really annoyed if their erase key starts
  * doing forward deletes for no reason. (Eric Fischer)
  */
-void get_stty()
+void get_stty(void)
 {
   char_u buf[2];
   char_u  *p;
@@ -788,7 +789,7 @@ void mch_setmouse(int on)
 /*
  * Set the mouse termcode, depending on the 'term' and 'ttymouse' options.
  */
-void check_mouse_termcode()
+void check_mouse_termcode(void)
 {
   if (use_xterm_mouse()
       && use_xterm_mouse() != 3
@@ -860,7 +861,7 @@ void check_mouse_termcode()
  * 4. keep using the old values
  * Return OK when size could be determined, FAIL otherwise.
  */
-int mch_get_shellsize()
+int mch_get_shellsize(void)
 {
   long rows = 0;
   long columns = 0;
@@ -937,7 +938,7 @@ int mch_get_shellsize()
 /*
  * Try to set the window size to Rows and Columns.
  */
-void mch_set_shellsize()
+void mch_set_shellsize(void)
 {
   if (*T_CWS) {
     /*

--- a/src/nvim/os_unix_defs.h
+++ b/src/nvim/os_unix_defs.h
@@ -41,17 +41,14 @@
 
 #ifdef SIGHASARG
 # ifdef SIGHAS3ARGS
-#  define SIGPROTOARG   (int, int, struct sigcontext *)
-#  define SIGDEFARG(s)  (s, sig2, scont) int s, sig2; struct sigcontext *scont;
+#  define SIGDEFARG(s)  (int s, int sig2, struct sigcontext *scont)
 #  define SIGDUMMYARG   0, 0, (struct sigcontext *)0
 # else
-#  define SIGPROTOARG   (int)
-#  define SIGDEFARG(s)  (s) int s;
+#  define SIGDEFARG(s)  (int s)
 #  define SIGDUMMYARG   0
 # endif
 #else
-# define SIGPROTOARG   (void)
-# define SIGDEFARG(s)  ()
+# define SIGDEFARG(s)  (void)
 # define SIGDUMMYARG
 #endif
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -274,7 +274,7 @@
  * This is impossible, so we declare a pointer to a function returning a
  * pointer to a function returning void. This should work for all compilers.
  */
-typedef void (*(*fptr_T)(int *, int))();
+typedef void (*(*fptr_T)(int *, int))(void);
 
 typedef struct {
   char_u     *regparse;
@@ -3266,21 +3266,20 @@ bt_regexec_nl (
 }
 
 
-/*
- * Match a regexp against multiple lines.
- * "rmp->regprog" is a compiled regexp as returned by vim_regcomp().
- * Uses curbuf for line count and 'iskeyword'.
- *
- * Return zero if there is no match.  Return number of lines contained in the
- * match otherwise.
- */
-static long bt_regexec_multi(rmp, win, buf, lnum, col, tm)
-regmmatch_T *rmp;
-win_T       *win;               /* window in which to search or NULL */
-buf_T       *buf;               /* buffer in which to search */
-linenr_T lnum;                  /* nr of line to start looking for match */
-colnr_T col;                    /* column to start looking for match */
-proftime_T  *tm;                /* timeout limit or NULL */
+/// Matches a regexp against multiple lines.
+/// "rmp->regprog" is a compiled regexp as returned by vim_regcomp().
+/// Uses curbuf for line count and 'iskeyword'.
+/// 
+/// @param win Window in which to search or NULL
+/// @param buf Buffer in which to search
+/// @param lnum Number of line to start looking for match 
+/// @param col Column to start looking for match
+/// @param tm Timeout limit or NULL
+///
+/// @return zero if there is no match and number of lines contained in the match
+///         otherwise.
+static long bt_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf,
+                             linenr_T lnum, colnr_T col, proftime_T *tm)
 {
   long r;
 
@@ -6265,36 +6264,28 @@ static char_u *cstrchr(char_u *s, int c)
 
 
 
-static fptr_T do_upper(d, c)
-int         *d;
-int c;
+static fptr_T do_upper(int *d, int c)
 {
   *d = vim_toupper(c);
 
   return (fptr_T)NULL;
 }
 
-static fptr_T do_Upper(d, c)
-int         *d;
-int c;
+static fptr_T do_Upper(int *d, int c)
 {
   *d = vim_toupper(c);
 
   return (fptr_T)do_Upper;
 }
 
-static fptr_T do_lower(d, c)
-int         *d;
-int c;
+static fptr_T do_lower(int *d, int c)
 {
   *d = vim_tolower(c);
 
   return (fptr_T)NULL;
 }
 
-static fptr_T do_Lower(d, c)
-int         *d;
-int c;
+static fptr_T do_Lower(int *d, int c)
 {
   *d = vim_tolower(c);
 

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -6338,38 +6338,42 @@ nfa_regexec_nl (
   return nfa_regexec_both(line, col) != 0;
 }
 
-/*
- * Match a regexp against multiple lines.
- * "rmp->regprog" is a compiled regexp as returned by vim_regcomp().
- * Uses curbuf for line count and 'iskeyword'.
- *
- * Return zero if there is no match.  Return number of lines contained in the
- * match otherwise.
- *
- * Note: the body is the same as bt_regexec() except for nfa_regexec_both()
- *
- * ! Also NOTE : match may actually be in another line. e.g.:
- * when r.e. is \nc, cursor is at 'a' and the text buffer looks like
- *
- * +-------------------------+
- * |a                        |
- * |b                        |
- * |c                        |
- * |                         |
- * +-------------------------+
- *
- * then nfa_regexec_multi() returns 3. while the original
- * vim_regexec_multi() returns 0 and a second call at line 2 will return 2.
- *
- * FIXME if this behavior is not compatible.
- */
-static long nfa_regexec_multi(rmp, win, buf, lnum, col, tm)
-regmmatch_T *rmp;
-win_T       *win;               /* window in which to search or NULL */
-buf_T       *buf;               /* buffer in which to search */
-linenr_T lnum;                  /* nr of line to start looking for match */
-colnr_T col;                    /* column to start looking for match */
-proftime_T  *tm;         /* timeout limit or NULL */
+/// Matches a regexp against multiple lines.
+/// "rmp->regprog" is a compiled regexp as returned by vim_regcomp().
+/// Uses curbuf for line count and 'iskeyword'.
+///
+/// @param win Window in which to search or NULL
+/// @param buf Buffer in which to search
+/// @param lnum Number of line to start looking for match
+/// @param col Column to start looking for match
+/// @param tm Timeout limit or NULL
+///
+/// @return Zero if there is no match and number of lines contained in the match
+/// otherwise.
+///
+/// @note The body is the same as bt_regexec() except for nfa_regexec_both()
+///
+/// @warning
+/// Match may actually be in another line. e.g.:
+/// when r.e. is \nc, cursor is at 'a' and the text buffer looks like
+///
+/// @par
+///
+///     +-------------------------+
+///     |a                        |
+///     |b                        |
+///     |c                        |
+///     |                         |
+///     +-------------------------+
+///
+/// @par
+/// then nfa_regexec_multi() returns 3. while the original vim_regexec_multi()
+/// returns 0 and a second call at line 2 will return 2.
+///
+/// @par
+/// FIXME if this behavior is not compatible.
+static long nfa_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf,
+                              linenr_T lnum, colnr_T col, proftime_T *tm)
 {
   reg_match = NULL;
   reg_mmatch = rmp;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -639,7 +639,7 @@ void update_single_line(win_T *wp, linenr_T lnum)
  * Prepare for updating one or more windows.
  * Caller must check for "updating_screen" already set to avoid recursiveness.
  */
-static void update_prepare()
+static void update_prepare(void)
 {
     cursor_off();
     updating_screen = TRUE;
@@ -649,7 +649,7 @@ static void update_prepare()
 /*
  * Finish updating one or more windows.
  */
-static void update_finish()
+static void update_finish(void)
 {
     if (redraw_cmdline) {
         showmode();

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -67,7 +67,7 @@
  * A few linux systems define outfuntype in termcap.h to be used as the third
  * argument for tputs().
  */
-#   define TPUTSFUNCAST (int (*)())
+#   define TPUTSFUNCAST (int (*)(int))
 #endif
 
 #undef tgetstr


### PR DESCRIPTION
`-Wstrict-prototypes` warn if a function is declared or defined without
specifying the argument types.

This warning disallow function prototypes with empty parameter list.
In C, a function declared with an empty parameter list accepts an
arbitrary number of arguments when being called. This is for historic
reasons; originally, C functions didn't have prototypes, as C evolved
from B, a typeless language. When prototypes were added, the original
typeless declarations were left in the language for backwards
compatibility.
Instead we should provide `void` in argument list to state
that function doesn't have arguments.

Also this warning disallow declaring type of the parameters after the
parentheses because Neovim's header generator doesn't use this
information and produce typeless declarations.
