### PR TITLE
[RDY] Remove Clang 3.4 installation in travis.sh.

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -6,67 +6,67 @@ mkdir -p "$tmpdir"
 suppressions="$(pwd)/.valgrind.supp"
 
 valgrind_check() {
-	(
-	cd $1
-	set -- valgrind-[*] valgrind-*
-	case $1$2 in
-		'valgrind-[*]valgrind-*')
-			;;
-		*)
-			shift
-			local err=''
-			for valgrind_log in "$@"; do
-				# Remove useless warning
-				sed -i "$valgrind_log" \
-					-e '/Warning: noted but unhandled ioctl/d' \
-					-e '/could cause spurious value errors to appear/d' \
-					-e '/See README_MISSING_SYSCALL_OR_IOCTL for guidance/d'
-				if [ "$(stat -c %s $valgrind_log)" != "0" ]; then
-					# if after removing the warning, the log still has errors, show its
-					# contents and set the flag so we exit with non-zero status
-					cat "$valgrind_log"
-					err=1
-				fi
-			done
-			if [ -n "$err" ]; then
-				echo "Runtime errors detected"
-				exit 1
-			fi
-			;;
-	esac
-	)
+    (
+    cd $1
+    set -- valgrind-[*] valgrind-*
+    case $1$2 in
+        'valgrind-[*]valgrind-*')
+            ;;
+        *)
+            shift
+            local err=''
+            for valgrind_log in "$@"; do
+                # Remove useless warning
+                sed -i "$valgrind_log" \
+                    -e '/Warning: noted but unhandled ioctl/d' \
+                    -e '/could cause spurious value errors to appear/d' \
+                    -e '/See README_MISSING_SYSCALL_OR_IOCTL for guidance/d'
+                if [ "$(stat -c %s $valgrind_log)" != "0" ]; then
+                    # if after removing the warning, the log still has errors, show its
+                    # contents and set the flag so we exit with non-zero status
+                    cat "$valgrind_log"
+                    err=1
+                fi
+            done
+            if [ -n "$err" ]; then
+                echo "Runtime errors detected"
+                exit 1
+            fi
+            ;;
+    esac
+    )
 }
 
 asan_check() {
-	(
-	cd $1
-	set -- [*]san.[*] *san.*
-	case $1$2 in
-		'[*]san.[*]*san.*')
-			;;
-		*)
-			shift
-			cat "$@"
-			echo "Runtime errors detected"
-			exit 1
-			;;
-	esac
-	)
+    (
+    cd $1
+    set -- [*]san.[*] *san.*
+    case $1$2 in
+        '[*]san.[*]*san.*')
+            ;;
+        *)
+            shift
+            cat "$@"
+            echo "Runtime errors detected"
+            exit 1
+            ;;
+    esac
+    )
 }
 
 set_environment() {
-	local prefix="$1"
-	eval $($prefix/bin/luarocks path)
-	export PATH="$prefix/bin:$PATH"
-	export PKG_CONFIG_PATH="$prefix/lib/pkgconfig"
-	export USE_BUNDLED_DEPS=OFF
+    local prefix="$1"
+    eval $($prefix/bin/luarocks path)
+    export PATH="$prefix/bin:$PATH"
+    export PKG_CONFIG_PATH="$prefix/lib/pkgconfig"
+    export USE_BUNDLED_DEPS=OFF
 }
 
 # install prebuilt dependencies
 if [ ! -d /opt/neovim-deps ]; then
-	cd /opt
-	sudo git clone --depth=1 git://github.com/tarruda/neovim-deps
-	cd -
+    cd /opt
+    sudo git clone --depth=1 git://github.com/tarruda/neovim-deps
+    cd -
 fi
 
 # Travis reports back that it has 32-cores via /proc/cpuinfo, but it's not
@@ -92,110 +92,110 @@ if [ "$TRAVIS_BUILD_TYPE" = "coverity" ]; then
     set -e
     exit 0
 elif [ "$TRAVIS_BUILD_TYPE" = "clang/asan" ]; then
-	if [ ! -d /usr/local/clang-3.4 ]; then
-		echo "Downloading clang 3.4..."
-		sudo sh <<- "EOF"
-		mkdir /usr/local/clang-3.4
-		wget -q -O - http://llvm.org/releases/3.4/clang+llvm-3.4-x86_64-unknown-ubuntu12.04.tar.xz |
-		unxz -c | tar xf - --strip-components=1 -C /usr/local/clang-3.4
-		EOF
-	fi
-	sudo pip install cpp-coveralls
+    if [ ! -d /usr/local/clang-3.4 ]; then
+        echo "Downloading clang 3.4..."
+        sudo sh <<- "EOF"
+        mkdir /usr/local/clang-3.4
+        wget -q -O - http://llvm.org/releases/3.4/clang+llvm-3.4-x86_64-unknown-ubuntu12.04.tar.xz |
+        unxz -c | tar xf - --strip-components=1 -C /usr/local/clang-3.4
+        EOF
+    fi
+    sudo pip install cpp-coveralls
 
-	export CC=clang
-	set_environment /opt/neovim-deps
-	if test -f /usr/local/clang-3.4/bin/clang; then
-		USE_CLANG_34=true
-		export CC=/usr/local/clang-3.4/bin/clang
-		symbolizer=/usr/local/clang-3.4/bin/llvm-symbolizer
-	fi
+    export CC=clang
+    set_environment /opt/neovim-deps
+    if test -f /usr/local/clang-3.4/bin/clang; then
+        USE_CLANG_34=true
+        export CC=/usr/local/clang-3.4/bin/clang
+        symbolizer=/usr/local/clang-3.4/bin/llvm-symbolizer
+    fi
 
-	# Try to detect clang-3.4 installed via apt and through llvm.org/apt/.
-	if dpkg -s clang-3.4 > /dev/null 2>&1; then
-		USE_CLANG_34=true
-		export CC=/usr/bin/clang
-		symbolizer=/usr/bin/llvm-symbolizer-3.4
-	fi
+    # Try to detect clang-3.4 installed via apt and through llvm.org/apt/.
+    if dpkg -s clang-3.4 > /dev/null 2>&1; then
+        USE_CLANG_34=true
+        export CC=/usr/bin/clang
+        symbolizer=/usr/bin/llvm-symbolizer-3.4
+    fi
 
-	install_dir="$(pwd)/dist"
-	# temporary directory for writing sanitizer logs
+    install_dir="$(pwd)/dist"
+    # temporary directory for writing sanitizer logs
 
-	# need the symbolizer path for stack traces with source information
-	if [ -n "$USE_CLANG_34" ]; then
-		export ASAN_OPTIONS="detect_leaks=1:"
-	else
-		symbolizer=/usr/local/clang-3.3/bin/llvm-symbolizer
-	fi
+    # need the symbolizer path for stack traces with source information
+    if [ -n "$USE_CLANG_34" ]; then
+        export ASAN_OPTIONS="detect_leaks=1:"
+    else
+        symbolizer=/usr/local/clang-3.3/bin/llvm-symbolizer
+    fi
 
-	export SANITIZE=1
-	export ASAN_SYMBOLIZER_PATH=$symbolizer
-	export ASAN_OPTIONS="${ASAN_OPTIONS}log_path=$tmpdir/asan"
-	export TSAN_OPTIONS="external_symbolizer_path=$symbolizer:log_path=$tmpdir/tsan"
+    export SANITIZE=1
+    export ASAN_SYMBOLIZER_PATH=$symbolizer
+    export ASAN_OPTIONS="${ASAN_OPTIONS}log_path=$tmpdir/asan"
+    export TSAN_OPTIONS="external_symbolizer_path=$symbolizer:log_path=$tmpdir/tsan"
 
-	export SKIP_UNITTEST=1
-	export UBSAN_OPTIONS="log_path=$tmpdir/ubsan" # not sure if this works
+    export SKIP_UNITTEST=1
+    export UBSAN_OPTIONS="log_path=$tmpdir/ubsan" # not sure if this works
 
-	$MAKE_CMD cmake CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DCMAKE_INSTALL_PREFIX=$install_dir -DUSE_GCOV=ON"
-	$MAKE_CMD
-	if ! $MAKE_CMD test; then
-		reset
-		asan_check "$tmpdir"
-		exit 1
-	fi
-	asan_check "$tmpdir"
-	coveralls --encoding iso-8859-1 || echo 'coveralls upload failed.'
-	$MAKE_CMD install
+    $MAKE_CMD cmake CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DCMAKE_INSTALL_PREFIX=$install_dir -DUSE_GCOV=ON"
+    $MAKE_CMD
+    if ! $MAKE_CMD test; then
+        reset
+        asan_check "$tmpdir"
+        exit 1
+    fi
+    asan_check "$tmpdir"
+    coveralls --encoding iso-8859-1 || echo 'coveralls upload failed.'
+    $MAKE_CMD install
 elif [ "$TRAVIS_BUILD_TYPE" = "gcc/unittest" ]; then
-	sudo pip install cpp-coveralls
-	export CC=gcc
-	set_environment /opt/neovim-deps
-	export SKIP_EXEC=1
-	$MAKE_CMD CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=TAP -DUSE_GCOV=ON" unittest
-	coveralls --encoding iso-8859-1 || echo 'coveralls upload failed.'
+    sudo pip install cpp-coveralls
+    export CC=gcc
+    set_environment /opt/neovim-deps
+    export SKIP_EXEC=1
+    $MAKE_CMD CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=TAP -DUSE_GCOV=ON" unittest
+    coveralls --encoding iso-8859-1 || echo 'coveralls upload failed.'
 elif [ "$TRAVIS_BUILD_TYPE" = "gcc/ia32" ]; then
-	set_environment /opt/neovim-deps/32
+    set_environment /opt/neovim-deps/32
 
-	# Pins the version of the java package installed on the Travis VMs
-	# and avoids a lengthy upgrade process for them.
-	sudo apt-mark hold oracle-java7-installer oracle-java8-installer
+    # Pins the version of the java package installed on the Travis VMs
+    # and avoids a lengthy upgrade process for them.
+    sudo apt-mark hold oracle-java7-installer oracle-java8-installer
 
-	sudo apt-get update
+    sudo apt-get update
 
-	# Need this to keep apt-get from removing gcc when installing libncurses
-	# below.
-	sudo apt-get install libc6-dev libc6-dev:i386
+    # Need this to keep apt-get from removing gcc when installing libncurses
+    # below.
+    sudo apt-get install libc6-dev libc6-dev:i386
 
-	# Do this separately so that things get configured correctly, otherwise
-	# libncurses fails to install.
-	sudo apt-get install gcc-multilib g++-multilib
+    # Do this separately so that things get configured correctly, otherwise
+    # libncurses fails to install.
+    sudo apt-get install gcc-multilib g++-multilib
 
-	# Install the dev version to get the pkg-config and symlinks installed
-	# correctly.
-	sudo apt-get install libncurses5-dev:i386
+    # Install the dev version to get the pkg-config and symlinks installed
+    # correctly.
+    sudo apt-get install libncurses5-dev:i386
 
-	CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=TAP \
-		-DCMAKE_SYSTEM_PROCESSOR=i386 \
-		-DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32 \
-		-DFIND_LIBRARY_USE_LIB64_PATHS=OFF \
-		-DCMAKE_IGNORE_PATH=/lib:/usr/lib:/usr/local/lib \
-		-DCMAKE_TOOLCHAIN_FILE=cmake/i386-linux-gnu.toolchain.cmake"
-	$MAKE_CMD CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}" unittest
-	$MAKE_CMD test
+    CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=TAP \
+        -DCMAKE_SYSTEM_PROCESSOR=i386 \
+        -DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32 \
+        -DFIND_LIBRARY_USE_LIB64_PATHS=OFF \
+        -DCMAKE_IGNORE_PATH=/lib:/usr/lib:/usr/local/lib \
+        -DCMAKE_TOOLCHAIN_FILE=cmake/i386-linux-gnu.toolchain.cmake"
+    $MAKE_CMD CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}" unittest
+    $MAKE_CMD test
 elif [ "$TRAVIS_BUILD_TYPE" = "clint" ]; then
-	./scripts/clint.sh
+    ./scripts/clint.sh
 elif [ "$TRAVIS_BUILD_TYPE" = "api/python" ]; then
-	set_environment /opt/neovim-deps
-	$MAKE_CMD
-	sudo apt-get install expect valgrind
-	git clone --depth=1 -b master git://github.com/neovim/python-client
-	cd python-client
+    set_environment /opt/neovim-deps
+    $MAKE_CMD
+    sudo apt-get install expect valgrind
+    git clone --depth=1 -b master git://github.com/neovim/python-client
+    cd python-client
   sudo pip install .
   sudo pip install nose
-	test_cmd="nosetests --verbosity=2"
-	nvim_cmd="valgrind -q --track-origins=yes --leak-check=yes --suppressions=$suppressions --log-file=$tmpdir/valgrind-%p.log ../build/bin/nvim -u NONE"
-	if ! ../scripts/run-api-tests.exp "$test_cmd" "$nvim_cmd"; then
-		valgrind_check "$tmpdir"
-		exit 1
-	fi
-	valgrind_check "$tmpdir"
+    test_cmd="nosetests --verbosity=2"
+    nvim_cmd="valgrind -q --track-origins=yes --leak-check=yes --suppressions=$suppressions --log-file=$tmpdir/valgrind-%p.log ../build/bin/nvim -u NONE"
+    if ! ../scripts/run-api-tests.exp "$test_cmd" "$nvim_cmd"; then
+        valgrind_check "$tmpdir"
+        exit 1
+    fi
+    valgrind_check "$tmpdir"
 fi

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -65,7 +65,7 @@ set_environment() {
 # install prebuilt dependencies
 if [ ! -d /opt/neovim-deps ]; then
     cd /opt
-    sudo git clone --depth=1 git://github.com/tarruda/neovim-deps
+    sudo git clone --depth=1 git://github.com/neovim/deps neovim-deps
     cd -
 fi
 


### PR DESCRIPTION
Travis provides Clang 3.4 out of the box (see http://docs.travis-ci.com/user/languages/c/#CI-environment-for-C-Projects), so the travis.sh script can be simplified.

I also added separate commits that change the dependency repo to `neovim/deps` and fix inconsistent whitespace/tabs formatting; you can append ?w=1 to the Github URL to compare without these changes (i.e. https://github.com/fwalch/neovim/commit/4734317e23d7eeaf334539fa517b34fa5a29370b?w=1).
