### PR TITLE
[RFC] Ensure well-defined alloc behaviour.

### DIFF
--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -77,17 +77,16 @@ static void try_to_free_memory()
 /// @return pointer to allocated space. NULL if out of memory
 void *try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1)
 {
+  size = size ? size : 1; // At least allocate one byte.
+
   void *ret = malloc(size);
 
-  if (!ret && !size) {
-    ret = malloc(1);
-  }
   if (!ret) {
     try_to_free_memory();
     ret = malloc(size);
-    if (!ret && !size) {
+
+    if (!ret)
       ret = malloc(1);
-    }
   }
   return ret;
 }
@@ -136,16 +135,21 @@ void *xmalloc(size_t size)
 void *xcalloc(size_t count, size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE_PROD(1, 2) FUNC_ATTR_NONNULL_RET
 {
+  // Make sure we allocate at least one byte. calloc on a size of zero is
+  // undefined and can return either NULL or a non-NULL pointer.
+  count = count ? count : 1;
+  size  = size  ?  size : 1;
+  
   void *ret = calloc(count, size);
-
-  if (!ret && (!count || !size))
-    ret = calloc(1, 1);
 
   if (!ret) {
     try_to_free_memory();
+
     ret = calloc(count, size);
-    if (!ret && (!count || !size))
-      ret = calloc(1, 1);
+
+    if (!ret)
+      ret = calloc(1,1);
+
     if (!ret) {
       OUT_STR("Vim: Error: Out of memory.\n");
       preserve_exit();


### PR DESCRIPTION
clang defect report [1] caught this potential bug in memory.c, line 112:

> Call to 'calloc' has an allocation size of 0 bytes

calloc(0,x) or (x,0) and malloc(0) may return a NULL or non-NULL pointer
[2] on some implementations. Set the size and/or count to at least one
before calling an alloc() function to avoid undefined behaviour.

[1] defect report:
http://ruiabreu.org/neovim-analysis/report-oLRUxF.html#Path4

[2] http://man.he.net/man3/calloc

I'm certain that no code using `xcalloc()` right now is broken. I experimentally found that gcc will zero-fill at least 24 bytes of space, even on `calloc(0,0)`, but I hope nothing actually relies on that behaviour.

``` c
#include <stdlib.h>
#include <stdio.h>

int main() {
    char* p = calloc(0,0); // OOPS!

    if( p == NULL ) return 1;

    size_t i = 0;
    for( ; p[i] == 0; i++ )
        printf("char @ %zu = %i\n", (size_t)p + i, (int)p[i]);
    printf("char @ %zu = %i\n", (size_t)p, (int)p[i]);

    free(p);
    return 0;
}
```

Tested with:

``` bash
$ gcc alloc.c
$ ./a.out | wc --lines
25
```

static analyser: #167 
