### PR TITLE
[RDY] api: window_set_cursor doesn't always update position.

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -9,6 +9,7 @@
 #include "nvim/cursor.h"
 #include "nvim/window.h"
 #include "nvim/screen.h"
+#include "nvim/move.h"
 #include "nvim/misc2.h"
 
 
@@ -86,6 +87,10 @@ void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   win->w_cursor.coladd = 0;
   // When column is out of range silently correct it.
   check_cursor_col_win(win);
+
+  // make sure cursor is in visible range even if win != curwin
+  update_topline_win(win);
+
   update_screen(VALID);
 }
 

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -34,6 +34,7 @@
 #include "nvim/popupmnu.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"
+#include "nvim/window.h"
 
 typedef struct {
   linenr_T lnum;                /* line number */
@@ -312,6 +313,17 @@ void update_topline(void)
   }
 
   p_so = save_so;
+}
+
+/*
+ * Update win->w_topline to move the cursor onto the screen.
+ */
+void update_topline_win(win_T* win)
+{
+  win_T *save_curwin;
+  switch_win(&save_curwin, NULL, win, NULL, true);
+  update_topline();
+  restore_win(save_curwin, NULL, true);
 }
 
 /*


### PR DESCRIPTION
When setting cursor position using api, visible range is only updated (if needed) if window is the current one. To reproduce,
open nvim with two (+100 lines ) files.

```
NEOVIM_LISTEN_ADDRESS=/tmp/neovim nvim -o file1 file2
```

And in a Python shell run

```
# to setup
v = neovim.connect("/tmp/neovim")
w1, w2 = v.windows
v.current.window = w1
w1.cursor = [1,0]
v.current.window = w2

# and then
w1.cursor = [100,0]
```

the last line will not cause the upper window to scroll, so line 100 remains invisible.

This seems to be the simplest fix. Not that I really like the curwin change workaround, but it was already used for set_height below (and a lot of vim's windowing/drawing code seems to assume the current window...)

Similar issue: `buf.options['ft'] = 'python'` doesn't work for non-current buffer `buf`, `&ft` does change but no changes in syntax highlighting etc are triggered.
