### PR TITLE
Fix the policy warning CMP0026 in CMake 3.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,12 @@ endif()
 if(BUSTED_PRG)
   get_property(TEST_INCLUDE_DIRS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     PROPERTY INCLUDE_DIRECTORIES)
+
+  # Set policy CMP0026 to OLD so we avoid CMake warnings on newer
+  # versions of cmake.
+  if(POLICY CMP0026)
+    cmake_policy(SET CMP0026 OLD)
+  endif()
   get_target_property(TEST_LIBNVIM_PATH nvim-test LOCATION)
 
   configure_file(


### PR DESCRIPTION
get_target_property LOCATION is not supposed to be used anymore.

configure_file() cannot be used with generator expressions, and
file(GENERATE) cannot do normal variable substitution so we have to
generate the paths.lua file in two steps.
