### PR TITLE
[RDY] Implement startuptime functions on top of profiling functions

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9731,9 +9731,7 @@ static void f_has(typval_T *argvars, typval_T *rettv)
     "cmdline_info",
     "signs",
     "smartindent",
-#ifdef STARTUPTIME
     "startuptime",
-#endif
     "statusline",
     "spell",
     "syntax",

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2262,8 +2262,8 @@ do_source (
   int save_debug_break_level = debug_break_level;
   scriptitem_T            *si = NULL;
 #ifdef STARTUPTIME
-  struct timeval tv_rel;
-  struct timeval tv_start;
+  proftime_T tv_rel;
+  proftime_T tv_start;
 #endif
   proftime_T wait_start;
 
@@ -2494,7 +2494,7 @@ do_source (
   if (time_fd != NULL) {
     vim_snprintf((char *)IObuff, IOSIZE, "sourcing %s", fname);
     time_msg((char *)IObuff, &tv_start);
-    time_pop(&tv_rel);
+    time_pop(tv_rel);
   }
 #endif
 

--- a/src/nvim/garray.h
+++ b/src/nvim/garray.h
@@ -1,6 +1,9 @@
 #ifndef NVIM_GARRAY_H
 #define NVIM_GARRAY_H
 
+#include <stddef.h>  // for size_t
+
+#include "nvim/types.h"  // for char_u
 #include "nvim/log.h"
 
 /// Structure used for growing arrays.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -10,14 +10,35 @@
 
 #include <stdbool.h>
 
+// EXTERN is only defined in main.c. That's where global variables are
+// actually defined and initialized.
+#ifndef EXTERN
+# define EXTERN extern
+# define INIT(x)
+#else
+# ifndef INIT
+#  define INIT(x) x
+#  define DO_INIT
+# endif
+#endif
+
 #include "nvim/ex_eval.h"
 #include "nvim/mbyte.h"
 #include "nvim/menu.h"
 #include "nvim/syntax_defs.h"
+#include "nvim/types.h"
 
 /*
  * definition of global variables
  */
+
+#define IOSIZE         (1024+1)          // file I/O and sprintf buffer size
+
+#define MAX_MCO        6                 // maximum value for 'maxcombine'
+
+# define MSG_BUF_LEN 480                 // length of buffer for small messages
+# define MSG_BUF_CLEN  (MSG_BUF_LEN / 6) // cell length (worst case: utf-8
+                                         // takes 6 bytes for one cell)
 
 /* Values for "starting" */
 #define NO_SCREEN       2       /* no screen updating yet */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1207,9 +1207,7 @@ EXTERN char bot_top_msg[] INIT(= N_("search hit BOTTOM, continuing at TOP"));
 /* For undo we need to know the lowest time possible. */
 EXTERN time_t starttime;
 
-#ifdef STARTUPTIME
 EXTERN FILE *time_fd INIT(= NULL);  /* where to write startup timing */
-#endif
 
 /*
  * Some compilers warn for not using a return value, but in some situations we

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -116,12 +116,6 @@
 #  define mch_open_rw(n, f)     os_open((n), (f), 0)
 #endif
 
-#ifdef STARTUPTIME
-# define TIME_MSG(s) { if (time_fd != NULL) time_msg(s, NULL); }
-#else
-# define TIME_MSG(s)
-#endif
-
 # define REPLACE_NORMAL(s) (((s) & REPLACE_FLAG) && !((s) & VREPLACE_FLAG))
 
 # define UTF_COMPOSINGLIKE(p1, p2)  utf_composinglike((p1), (p2))

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1472,7 +1472,7 @@ static void init_startuptime(mparm_T *paramp)
   for (i = 1; i < paramp->argc; ++i) {
     if (STRICMP(paramp->argv[i], "--startuptime") == 0 && i + 1 < paramp->argc) {
       time_fd = mch_fopen(paramp->argv[i + 1], "a");
-      TIME_MSG("--- VIM STARTING ---");
+      time_start("--- VIM STARTING ---");
       break;
     }
   }

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -711,7 +711,6 @@ main_loop (
 
       do_redraw = FALSE;
 
-#ifdef STARTUPTIME
       /* Now that we have drawn the first screen all the startup stuff
        * has been done, close any file for startup messages. */
       if (time_fd != NULL) {
@@ -720,7 +719,6 @@ main_loop (
         fclose(time_fd);
         time_fd = NULL;
       }
-#endif
     }
 
     /*
@@ -1467,16 +1465,14 @@ static void init_params(mparm_T *paramp, int argc, char **argv)
  */
 static void init_startuptime(mparm_T *paramp)
 {
-#ifdef STARTUPTIME
-  int i;
-  for (i = 1; i < paramp->argc; ++i) {
+  for (int i = 1; i < paramp->argc; i++) {
     if (STRICMP(paramp->argv[i], "--startuptime") == 0 && i + 1 < paramp->argc) {
       time_fd = mch_fopen(paramp->argv[i + 1], "a");
       time_start("--- VIM STARTING ---");
       break;
     }
   }
-#endif
+
   starttime = time(NULL);
 }
 
@@ -2221,9 +2217,7 @@ static void usage(void)
   main_msg(_("-s <scriptin>\tRead Normal mode commands from file <scriptin>"));
   main_msg(_("-w <scriptout>\tAppend all typed commands to file <scriptout>"));
   main_msg(_("-W <scriptout>\tWrite all typed commands to file <scriptout>"));
-#ifdef STARTUPTIME
   main_msg(_("--startuptime <file>\tWrite startup timing messages to <file>"));
-#endif
   main_msg(_("-i <viminfo>\t\tUse <viminfo> instead of .viminfo"));
   main_msg(_("--api-msgpack-metadata\tDump API metadata information and exit"));
   main_msg(_("-h  or  --help\tPrint Help (this message) and exit"));

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -45,6 +45,7 @@
 #include "nvim/option.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
+#include "nvim/profile.h"
 #include "nvim/quickfix.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"
@@ -2246,92 +2247,5 @@ static void check_swap_exists_action(void)
 }
 
 #endif
-
-#endif
-
-#if defined(STARTUPTIME) || defined(PROTO)
-
-static struct timeval prev_timeval;
-
-
-/*
- * Save the previous time before doing something that could nest.
- * set "*tv_rel" to the time elapsed so far.
- */
-void time_push(void *tv_rel, void *tv_start)
-{
-  *((struct timeval *)tv_rel) = prev_timeval;
-  gettimeofday(&prev_timeval, NULL);
-  ((struct timeval *)tv_rel)->tv_usec = prev_timeval.tv_usec
-    - ((struct timeval *)tv_rel)->tv_usec;
-  ((struct timeval *)tv_rel)->tv_sec = prev_timeval.tv_sec
-    - ((struct timeval *)tv_rel)->tv_sec;
-  if (((struct timeval *)tv_rel)->tv_usec < 0) {
-    ((struct timeval *)tv_rel)->tv_usec += 1000000;
-    --((struct timeval *)tv_rel)->tv_sec;
-  }
-  *(struct timeval *)tv_start = prev_timeval;
-}
-
-/*
- * Compute the previous time after doing something that could nest.
- * Subtract "*tp" from prev_timeval;
- * Note: The arguments are (void *) to avoid trouble with systems that don't
- * have struct timeval.
- */
-void 
-time_pop (
-    void *tp        /* actually (struct timeval *) */
-)
-{
-  prev_timeval.tv_usec -= ((struct timeval *)tp)->tv_usec;
-  prev_timeval.tv_sec -= ((struct timeval *)tp)->tv_sec;
-  if (prev_timeval.tv_usec < 0) {
-    prev_timeval.tv_usec += 1000000;
-    --prev_timeval.tv_sec;
-  }
-}
-
-static void time_diff(struct timeval *then, struct timeval *now)
-{
-  long usec;
-  long msec;
-
-  usec = now->tv_usec - then->tv_usec;
-  msec = (now->tv_sec - then->tv_sec) * 1000L + usec / 1000L,
-       usec = usec % 1000L;
-  fprintf(time_fd, "%03ld.%03ld", msec, usec >= 0 ? usec : usec + 1000L);
-}
-
-void 
-time_msg (
-    char *mesg,
-    void *tv_start      /* only for do_source: start time; actually
-                                 (struct timeval *) */
-)
-{
-  static struct timeval start;
-  struct timeval now;
-
-  if (time_fd != NULL) {
-    if (strstr(mesg, "STARTING") != NULL) {
-      gettimeofday(&start, NULL);
-      prev_timeval = start;
-      fprintf(time_fd, "\n\ntimes in msec\n");
-      fprintf(time_fd, " clock   self+sourced   self:  sourced script\n");
-      fprintf(time_fd, " clock   elapsed:              other lines\n\n");
-    }
-    gettimeofday(&now, NULL);
-    time_diff(&start, &now);
-    if (((struct timeval *)tv_start) != NULL) {
-      fprintf(time_fd, "  ");
-      time_diff(((struct timeval *)tv_start), &now);
-    }
-    fprintf(time_fd, "  ");
-    time_diff(&prev_timeval, &now);
-    prev_timeval = now;
-    fprintf(time_fd, ": %s\n", mesg);
-  }
-}
 
 #endif

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -715,7 +715,7 @@ main_loop (
        * has been done, close any file for startup messages. */
       if (time_fd != NULL) {
         TIME_MSG("first screen update");
-        TIME_MSG("--- VIM STARTED ---");
+        TIME_MSG("--- NVIM STARTED ---");
         fclose(time_fd);
         time_fd = NULL;
       }
@@ -1468,7 +1468,7 @@ static void init_startuptime(mparm_T *paramp)
   for (int i = 1; i < paramp->argc; i++) {
     if (STRICMP(paramp->argv[i], "--startuptime") == 0 && i + 1 < paramp->argc) {
       time_fd = mch_fopen(paramp->argv[i + 1], "a");
-      time_start("--- VIM STARTING ---");
+      time_start("--- NVIM STARTING ---");
       break;
     }
   }

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -6,9 +6,7 @@
 #include "nvim/os/time.h"
 #include "nvim/func_attr.h"
 
-#ifdef STARTUPTIME
-#include "nvim/vim.h"  // for the global `time_fd`
-#endif
+#include "nvim/globals.h"  // for the global `time_fd` (startuptime)
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "profile.c.generated.h"
@@ -187,8 +185,7 @@ int profile_cmp(proftime_T tm1, proftime_T tm2) FUNC_ATTR_CONST
   return sgn64((int64_t)(tm2 - tm1));
 }
 
-#ifdef STARTUPTIME
-
+/// globals for use in the startuptime related functionality (time_*).
 static proftime_T g_start_time;
 static proftime_T g_prev_time;
 
@@ -282,5 +279,3 @@ void time_msg(const char *mesg, const proftime_T *start)
   g_prev_time = now;
   fprintf(time_fd, ": %s\n", mesg);
 }
-
-#endif

--- a/src/nvim/profile.h
+++ b/src/nvim/profile.h
@@ -6,6 +6,14 @@
 
 typedef uint64_t proftime_T;
 
+#ifdef STARTUPTIME
+#define TIME_MSG(s) do { \
+  if (time_fd != NULL) time_msg(s, NULL); \
+} while (0)
+#else
+#define TIME_MSG(s)
+#endif
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "profile.h.generated.h"
 #endif

--- a/src/nvim/profile.h
+++ b/src/nvim/profile.h
@@ -6,13 +6,9 @@
 
 typedef uint64_t proftime_T;
 
-#ifdef STARTUPTIME
 #define TIME_MSG(s) do { \
-  if (time_fd != NULL) time_msg(s, NULL); \
-} while (0)
-#else
-#define TIME_MSG(s)
-#endif
+    if (time_fd != NULL) time_msg(s, NULL); \
+  } while (0)
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "profile.h.generated.h"

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -24,4 +24,13 @@ typedef unsigned long long_u;
  */
 typedef unsigned char char_u;
 
+// The u8char_T can hold one decoded UTF-8 character. We normally use 32
+// bits now, since some Asian characters don't fit in 16 bits. u8char_T is
+// only used for displaying, it could be 16 bits to save memory.
+#ifdef UNICODE16
+typedef uint16_t u8char_T;
+#else
+typedef uint32_t u8char_T;
+#endif
+
 #endif /* NVIM_TYPES_H */

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -145,11 +145,7 @@ static char *(features[]) = {
   "+scrollbind",
   "+signs",
   "+smartindent",
-#ifdef STARTUPTIME
   "+startuptime",
-#else  // ifdef STARTUPTIME
-  "-startuptime",
-#endif  // ifdef STARTUPTIME
   "+statusline",
   "+syntax",
   "+tag_binary",

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -61,18 +61,6 @@ Error: configure did not run properly.Check auto/config.log.
 
 # define MAX_TYPENR 65535
 
-/*
- * The u8char_T can hold one decoded UTF-8 character.
- * We normally use 32 bits now, since some Asian characters don't fit in 16
- * bits.  u8char_T is only used for displaying, it could be 16 bits to save
- * memory.
- */
-# ifdef UNICODE16
-typedef uint16_t u8char_T;
-# else
-typedef uint32_t u8char_T;
-# endif
-
 #include "nvim/keymap.h"
 #include "nvim/term_defs.h"
 #include "nvim/macros.h"
@@ -258,14 +246,7 @@ enum {
 
 #define LSIZE       512         /* max. size of a line in the tags file */
 
-#define IOSIZE     (1024+1)     /* file i/o and sprintf buffer size */
-
 #define DIALOG_MSG_SIZE 1000    /* buffer size for dialog_msg() */
-
-# define MSG_BUF_LEN 480        /* length of buffer for small messages */
-# define MSG_BUF_CLEN  (MSG_BUF_LEN / 6)    /* cell length (worst case: utf-8
-                                               takes 6 bytes for one cell) */
-
 
 /*
  * Maximum length of key sequence to be mapped.
@@ -392,36 +373,10 @@ enum {
  */
 #define vim_iswhite(x)  ((x) == ' ' || (x) == '\t')
 
-/*
- * EXTERN is only defined in main.c.  That's where global variables are
- * actually defined and initialized.
- */
-#ifndef EXTERN
-# define EXTERN extern
-# define INIT(x)
-#else
-# ifndef INIT
-#  define INIT(x) x
-#  define DO_INIT
-# endif
-#endif
-
-# define MAX_MCO        6       /* maximum value for 'maxcombine' */
-
 /* Maximum number of bytes in a multi-byte character.  It can be one 32-bit
  * character of up to 6 bytes, or one 16-bit character of up to three bytes
  * plus six following composing characters of three bytes each. */
 # define MB_MAXBYTES    21
-
-
-
-
-
-
-
-
-#include "nvim/buffer_defs.h"         /* buffer and windows */
-#include "nvim/ex_cmds_defs.h"        /* Ex command defines */
 
 /* This has to go after the include of proto.h, as proto/gui.pro declares
  * functions of these names. The declarations would break if the defines had
@@ -436,11 +391,9 @@ enum {
 # define USE_MCH_ERRMSG
 #endif
 
-
-
-
 #include "nvim/globals.h"        /* global variables and messages */
-
+#include "nvim/buffer_defs.h"         /* buffer and windows */
+#include "nvim/ex_cmds_defs.h"        /* Ex command defines */
 
 # ifdef USE_ICONV
 #  ifndef EILSEQ


### PR DESCRIPTION
Another notch in the belt of reducing our dependence on `gettimeofday`, which is not present on Windows. It's also a nice cleanup.

Ping @equalsraf.

Ref: #784, #810, #696.

**NOTE**: for reviewers, travis is not actually compiling the new implementations of the `time_*` functions because one needs to define `STARTUPTIME` for that. We could contemplate taking the `#ifdef's` out of `profile.c` so these functions are always compiled in (and probably left out when using `-flto` and compiling as an executable).

To compile:

``` bash
$ make CFLAGS='-DSTARTUPTIME -DNDEBUG' DEBUG=0
# or: full speed ahead!
$ make CFLAGS='-DSTARTUPTIME -DNDEBUG -flto -march=native' CMAKE_EXTRA_FLAGS='-DCMAKE_BUILD_TYPE=MinSizeRel' DEBUG=0 VERBOSE=1
```

To compare with neovim before I did the changes, I did:

``` bash
#!/bin/bash

BASE="$HOME/experiments/neovim/profile-cmp"

NVIM_OLD="$BASE/nvim_old.log"
NVIM_NEW="$BASE/nvim_new.log"
# EXTRA="-u NONE"

>| "$NVIM_OLD"
>| "$NVIM_NEW"
~/github/aktau/neovim-startuptime-before/build/bin/nvim $EXTRA --startuptime "$NVIM_OLD" -c quit
~/github/aktau/neovim/build/bin/nvim $EXTRA --startuptime "$NVIM_NEW" -c quit

sdiff "$NVIM_OLD" "$NVIM_NEW"
```
