### PR TITLE
[RFC] Fix #963

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4615,7 +4615,7 @@ int vim_rename(char_u *from, char_u *to)
   acl = mch_get_acl(from);
 #endif
   fd_in = os_open((char *)from, O_RDONLY, 0);
-  if (fd_in == -1) {
+  if (fd_in < 0) {
 #ifdef HAVE_ACL
     mch_free_acl(acl);
 #endif
@@ -4625,7 +4625,7 @@ int vim_rename(char_u *from, char_u *to)
   /* Create the new file with same permissions as the original. */
   fd_out = os_open((char *)to,
       O_CREAT|O_EXCL|O_WRONLY|O_NOFOLLOW, (int)perm);
-  if (fd_out == -1) {
+  if (fd_out < 0) {
     close(fd_in);
 #ifdef HAVE_ACL
     mch_free_acl(acl);


### PR DESCRIPTION
Problem: Bug was introduced because `os_open` returns `-errno` in case
of an error instead of just `-1` which was returned by `mch_open`.
Solution: Check return value with `< 0` instead of `== -1`.

Btw, most of such checks were changed by @justinmk in original PR #846.
