### PR TITLE
[RDY] Make os_get_localtime() portable + fix bug on win

### DIFF
--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -84,7 +84,8 @@ static void microdelay(uint64_t microseconds)
 /// Portable version of POSIX localtime_r()
 ///
 /// @return NULL in case of error
-struct tm *os_localtime_r(const time_t *clock, struct tm *result)
+struct tm *os_localtime_r(const time_t *restrict clock,
+                          struct tm *restrict result) FUNC_ATTR_NONNULL_ALL
 {
 #ifdef UNIX
   // POSIX provides localtime_r() as a thread-safe version of localtime().
@@ -93,8 +94,11 @@ struct tm *os_localtime_r(const time_t *clock, struct tm *result)
   // Windows version of localtime() is thread-safe.
   // See http://msdn.microsoft.com/en-us/library/bf12f0hc%28VS.80%29.aspx
   struct tm *local_time = localtime(clock);  // NOLINT
+  if (!local_time) {
+    return NULL;
+  }
   *result = *local_time;
-return result;
+  return result;
 #endif
 }
 
@@ -103,7 +107,7 @@ return result;
 /// @param result Pointer to a 'struct tm' where the result should be placed
 /// @return A pointer to a 'struct tm' in the current time zone (the 'result'
 ///         argument) or NULL in case of error
-struct tm *os_get_localtime(struct tm *result)
+struct tm *os_get_localtime(struct tm *result) FUNC_ATTR_NONNULL_ALL
 {
   time_t rawtime = time(NULL);
   return os_localtime_r(&rawtime, result);

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -1,6 +1,6 @@
 #include <stdint.h>
 #include <stdbool.h>
-#include <sys/time.h>
+#include <time.h>
 
 #include <uv.h>
 
@@ -105,10 +105,6 @@ return result;
 ///         argument) or NULL in case of error
 struct tm *os_get_localtime(struct tm *result)
 {
-  struct timeval tv;
-  if (gettimeofday(&tv, NULL) < 0) {
-    return NULL;
-  }
-
-  return os_localtime_r(&tv.tv_sec, result);
+  time_t rawtime = time(NULL);
+  return os_localtime_r(&rawtime, result);
 }

--- a/src/nvim/os/time.h
+++ b/src/nvim/os/time.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <time.h>
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/time.h.generated.h"


### PR DESCRIPTION
@equalsraf rightly notices that `gettimeofday` is not portable, so I'm looking if all our uses of it are warranted. In this specific case I think we might just as well use `time()`. Since @philix wrote the code, I'd like to request a comment from him. (I suspect there was a good reason for using `gettimeofday` but I didn't find it. If that is the case, we can still use a portable `gettimeofday` emulator, for example: https://code.google.com/p/tesseract-ocr/issues/detail?id=631

Relevant articles/docs for future discussion:
- [_ftime(64)](http://msdn.microsoft.com/en-us/library/z54t9z5f.aspx)
- [Win32 Performance Measurement Options](http://www.drdobbs.com/windows/win32-performance-measurement-options/184416651)
- [On the various ways of getting the current time and date in Win32](http://blogs.msdn.com/b/oldnewthing/archive/2013/11/01/10462403.aspx)
