### PR TITLE
[RFC] re-add has('mac') and has('macunix')

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9702,6 +9702,10 @@ static void f_has(typval_T *argvars, typval_T *rettv)
     "lispindent",
     "listcmds",
     "localmap",
+#ifdef __APPLE__
+    "mac",
+    "macunix",
+#endif
     "menu",
     "mksession",
     "modify_fname",


### PR DESCRIPTION
They were removed but they can be handy to separate some things to do at
startup in a .vimrc for example.

In vanilla vim:

eval.c:

``` c
#ifdef MACOS
    "mac",
#endif
#if defined(MACOS_X_UNIX)
    "macunix",
#endif
```

vim.h

``` c
/*
 * MACOS_CLASSIC compiling for MacOS prior to MacOS X
 * MACOS_X_UNIX  compiling for MacOS X (using os_unix.c)
 * MACOS_X       compiling for MacOS X (using os_unix.c)
 * MACOS     compiling for either one
 */
#if defined(macintosh) && !defined(MACOS_CLASSIC)
# define MACOS_CLASSIC
#endif
#if defined(MACOS_X_UNIX)
# define MACOS_X
# ifndef HAVE_CONFIG_H
#  define UNIX
# endif
# ifndef FEAT_CLIPBOARD
#  define FEAT_CLIPBOARD
#  if defined(FEAT_SMALL) && !defined(FEAT_MOUSE)
#   define FEAT_MOUSE
#  endif
# endif
#endif
#if defined(MACOS_X) || defined(MACOS_CLASSIC)
# define MACOS
#endif
#if defined(MACOS_X) && defined(MACOS_CLASSIC)
    Error: To compile for both MACOS X and Classic use a Classic Carbon
#endif
/* Unless made through the Makefile enforce GUI on Mac */
#if defined(MACOS) && !defined(HAVE_CONFIG_H)
# define FEAT_GUI_MAC
#endif
```
