### PR TITLE
[RDY] implement system() with pipes

### DIFF
--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -21,7 +21,7 @@
 
 #define EXIT_TIMEOUT 25
 #define MAX_RUNNING_JOBS 100
-#define JOB_BUFFER_SIZE 1024
+#define JOB_BUFFER_SIZE 0xFFFF
 
 struct job {
   // Job id the index in the job table plus one.

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -47,16 +47,13 @@ typedef struct {
 /// @param extra_shell_opt Extra argument to the shell. If NULL it is ignored
 /// @return A newly allocated argument vector. It must be freed with
 ///         `shell_free_argv` when no longer needed.
-char ** shell_build_argv(char_u *cmd, char_u *extra_shell_opt)
+char **shell_build_argv(const char_u *cmd, const char_u *extra_shell_opt)
 {
-  int i;
-  char **rv;
   int argc = tokenize(p_sh, NULL) + tokenize(p_shcf, NULL);
-
-  rv = (char **)xmalloc((unsigned)((argc + 4) * sizeof(char *)));
+  char **rv = xmalloc((unsigned)((argc + 4) * sizeof(char *)));
 
   // Split 'shell'
-  i = tokenize(p_sh, rv);
+  int i = tokenize(p_sh, rv);
 
   if (extra_shell_opt != NULL) {
     // Push a copy of `extra_shell_opt`
@@ -244,10 +241,10 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
 /// @param argv The vector that will be filled with copies of the parsed
 ///        words. It can be NULL if the caller only needs to count words.
 /// @return The number of words parsed.
-static int tokenize(char_u *str, char **argv)
+static int tokenize(const char_u *str, char **argv)
 {
   int argc = 0, len;
-  char_u *p = str;
+  char_u *p = (char_u *) str;
 
   while (*p != NUL) {
     len = word_length(p);
@@ -271,9 +268,9 @@ static int tokenize(char_u *str, char **argv)
 ///
 /// @param str A pointer to the first character of the word
 /// @return The offset from `str` at which the word ends.
-static int word_length(char_u *str)
+static int word_length(const char_u *str)
 {
-  char_u *p = str;
+  const char_u *p = str;
   bool inquote = false;
   int length = 0;
 

--- a/src/nvim/os/wstream.c
+++ b/src/nvim/os/wstream.c
@@ -204,7 +204,10 @@ static void write_cb(uv_write_t *req, int status)
 static void release_wbuffer(WBuffer *buffer)
 {
   if (!--buffer->refcount) {
-    buffer->cb(buffer->data);
+    if (buffer->cb) {
+      buffer->cb(buffer->data);
+    }
+
     free(buffer);
   }
 }

--- a/src/nvim/os/wstream.c
+++ b/src/nvim/os/wstream.c
@@ -21,6 +21,9 @@ struct wstream {
   // Number of pending requests
   size_t pending_reqs;
   bool freed;
+  // (optional) Write callback and data
+  wstream_cb cb;
+  void *data;
 };
 
 struct wbuffer {
@@ -57,6 +60,7 @@ WStream * wstream_new(size_t maxmem)
   rv->curmem = 0;
   rv->pending_reqs = 0;
   rv->freed = false;
+  rv->cb = NULL;
 
   return rv;
 }
@@ -81,6 +85,25 @@ void wstream_set_stream(WStream *wstream, uv_stream_t *stream)
 {
   handle_set_wstream((uv_handle_t *)stream, wstream);
   wstream->stream = stream;
+}
+
+/// Sets a callback that will be called on completion of a write request,
+/// indicating failure/success.
+///
+/// This affects all requests currently in-flight as well. Overwrites any
+/// possible earlier callback.
+///
+/// @note This callback will not fire if the write request couldn't even be
+///       queued properly (i.e.: when `wstream_write() returns an error`).
+///
+/// @param wstream The `WStream` instance
+/// @param cb The callback
+/// @param data User-provided data that will be passed to `cb`
+void wstream_set_write_cb(WStream *wstream, wstream_cb cb, void *data)
+  FUNC_ATTR_NONNULL_ARG(1)
+{
+  wstream->cb = cb;
+  wstream->data = data;
 }
 
 /// Queues data for writing to the backing file descriptor of a `WStream`
@@ -162,6 +185,14 @@ static void write_cb(uv_write_t *req, int status)
   release_wbuffer(data->buffer);
 
   data->wstream->pending_reqs--;
+
+  if (data->wstream->cb) {
+    data->wstream->cb(data->wstream,
+                      data->wstream->data,
+                      data->wstream->pending_reqs,
+                      status);
+  }
+
   if (data->wstream->freed && data->wstream->pending_reqs == 0) {
     // Last pending write, free the wstream;
     free(data->wstream);

--- a/src/nvim/os/wstream_defs.h
+++ b/src/nvim/os/wstream_defs.h
@@ -5,5 +5,17 @@ typedef struct wbuffer WBuffer;
 typedef struct wstream WStream;
 typedef void (*wbuffer_data_finalizer)(void *data);
 
+/// Type of function called when the WStream has information about a write
+/// request.
+///
+/// @param wstream The `WStream` instance
+/// @param data User-defined data
+/// @param pending The number of write requests that are still pending
+/// @param status 0 on success, anything else indicates failure
+typedef void (*wstream_cb)(WStream *wstream,
+                           void *data,
+                           size_t pending,
+                           int status);
+
 #endif  // NVIM_OS_WSTREAM_DEFS_H
 

--- a/test/unit/formatc.lua
+++ b/test/unit/formatc.lua
@@ -218,6 +218,8 @@ local function standalone(...)
   require "moonscript"
   Preprocess = require("preprocess")
   Preprocess.add_to_include_path('./../../src')
+  Preprocess.add_to_include_path('./../../build/include')
+  Preprocess.add_to_include_path('./../../.deps/usr/include')
 
   input = Preprocess.preprocess_stream(arg[1])
   local raw = input:read('*all')

--- a/test/unit/formatc.lua
+++ b/test/unit/formatc.lua
@@ -176,9 +176,10 @@ local function formatc(str)
         end_at_brace = false
       end
     elseif typ == 'identifier' then
-      -- static usually indicates an inline header function, which has no
-      -- trailing ';', so we have to add a newline after the '}' ourselves.
-      if token[1] == 'static' then
+      -- static and/or inline usually indicate an inline header function,
+      -- which has no trailing ';', so we have to add a newline after the
+      -- '}' ourselves.
+      if token[1] == 'static' or token[1] == 'inline' then
         end_at_brace = true
       end
     elseif typ == 'preprocessor' then

--- a/test/unit/helpers.moon
+++ b/test/unit/helpers.moon
@@ -88,9 +88,9 @@ cimport './src/nvim/types.h'
 
 -- take a pointer to a C-allocated string and return an interned
 -- version while also freeing the memory
-internalize = (cdata) ->
+internalize = (cdata, len) ->
   ffi.gc cdata, ffi.C.free
-  return ffi.string cdata
+  return ffi.string cdata, len
 
 cstr = ffi.typeof 'char[?]'
 

--- a/test/unit/os/shell_spec.lua
+++ b/test/unit/os/shell_spec.lua
@@ -1,0 +1,74 @@
+-- not all operating systems support the system()-tests, as of yet.
+local allowed_os = {
+  Linux = true,
+  OSX = true,
+  BSD = true,
+  POSIX = true
+}
+
+if allowed_os[jit.os] ~= true then
+  return
+end
+
+local helpers = require('test.unit.helpers')
+local shell = helpers.cimport(
+  './src/nvim/os/shell.h',
+  './src/nvim/option_defs.h',
+  './src/nvim/os/event.h',
+  './src/nvim/misc1.h'
+)
+local ffi, eq, neq = helpers.ffi, helpers.eq, helpers.neq
+local intern = helpers.internalize
+local to_cstr = helpers.to_cstr
+local NULL = ffi.cast('void *', 0)
+
+describe('shell functions', function()
+  setup(function()
+    -- the logging functions are complain if I don't do this
+    shell.init_homedir()
+
+    shell.event_init()
+
+    -- os_system() can't work when the p_sh and p_shcf variables are unset
+    shell.p_sh = to_cstr('/bin/bash')
+    shell.p_shcf = to_cstr('-c')
+  end)
+
+  teardown(function()
+    shell.event_teardown()
+  end)
+
+  local function os_system(cmd, input)
+    local input_or = input and to_cstr(input) or NULL
+    local input_len = (input ~= nil) and string.len(input) or 0
+    local output = ffi.new('char *[1]')
+    local nread = ffi.new('size_t[1]')
+
+    local status = shell.os_system(to_cstr(cmd), input_or, input_len, output, nread)
+
+    return status, intern(output[0], nread[0])
+  end
+
+  describe('os_system', function()
+    it('can echo some output (shell builtin)', function()
+      local cmd, text = 'echo -n', 'some text'
+      local status, output = os_system(cmd .. ' ' .. text)
+      eq(text, output)
+      eq(0, status)
+    end)
+
+    it('can deal with empty output', function()
+      local cmd = 'echo -n'
+      local status, output = os_system(cmd)
+      eq('', output)
+      eq(0, status)
+    end)
+
+    it('can pass input on stdin', function()
+      local cmd, input = 'cat -', 'some text\nsome other text'
+      local status, output = os_system(cmd, input)
+      eq(input, output)
+      eq(0, status)
+    end)
+  end)
+end)


### PR DESCRIPTION
So this is attempt 2 with hopefully less code duplication. For attempt 1 and its discussion, see #807.

I would like to request @tarruda to look over this code, while it's WIP because he knows the job architecture best and in many cases I'm not at all sure if I've made the best decisions. Ignore the logging statements for now please.

Preliminary results (thanks to @Shougo for the benchmark script):

``` vim
let cnt = 50

let start = reltime()

for i in range(1, cnt)
  " 13MB file
  call system('cat song.flac')
endfor

echomsg 'system()         = ' . reltimestr(reltime(start))
```

~~I compile on release mode (otherwise the benchmark doesn't even work, yes that's strange and it worries me too). Neovim master doesn't show this problem, so it's been introduced somewhere in these commits. I can only think of  the `ELOG`'s, but standard neovim also produces logs.~~ (fixed: it was the logs, because the read stream or libuv only reads 1024 bytes at a time, the log was getting swamped and making my computer do very strange things. I even think that I could input keys and exit vim while this was happening because I'm returning too early from `job_wait()`, but @tarruda will have to confirm that. In reality I don't see how it can happen though, `system_out_cb` shouldn't be called after the job exits, at all).

``` bash
$ make CFLAGS='-flto -DNDEBUG -march=native' CMAKE_EXTRA_FLAGS='-DCMAKE_BUILD_TYPE=MinSizeRel' DEBUG=0
```

I run it with:

``` bash
$ $VIM -u NONE -U NONE -E -c "source bench.vim"
```
- Vanilla vim: ~12.5 sec (somehow, it's faster than master here, usually it isn't)
- Neovim master (optimized): ~14 sec
- Neovim on pipes (optimized): ~4 sec (quite a bit better, difference not very obvious for small commands)

I have no idea if that's the best way to do it. If someone knows a better way, I'm all ears.

To compare with some sort of baseline, I do:

``` bash
# can't do "cat song.flac > /dev/null" because it seems cat is being clever and does nothing
# which is why I create a ramdisk...
$ diskutil erasevolume HFS+ 'aramdisk' `hdiutil attach -nomount ram://131072`
$ time (for run in {1..50}; do cat song.flac > /Volumes/aramdisk/song.flac; done)
0,10s user 1,37s system 92% cpu 1,592 total
```

**EDIT**: I would love to receive other peoples benchmark results too.
~~**EDIT 2**: As some will notice, when compiling in DEBUG mode the benchmark doesn't work. I'm not sure why yet.~~
**EDIT 3**: it should be a little slower than the approach in #807, as the `rstream` has an intermediate buffer (which means redundant copying happens, the data gets copied once in #807, but twice in this PR). It's still better than writing and reading from a temporary file though.
