### PR TITLE
[RDY] Clang analyzer: fix dead stores / reduce scope

### DIFF
--- a/src/nvim/arabic.c
+++ b/src/nvim/arabic.c
@@ -1361,24 +1361,19 @@ static int half_shape(int c)
 int arabic_shape(int c, int *ccp, int *c1p, int prev_c, int prev_c1,
                  int next_c)
 {
-  int curr_c;
-  int shape_c;
-  int curr_laa;
-  int prev_laa;
-
   /* Deal only with Arabic character, pass back all others */
   if (!A_is_ok(c)) {
     return c;
   }
 
   /* half-shape current and previous character */
-  shape_c = half_shape(prev_c);
+  int shape_c = half_shape(prev_c);
 
   /* Save away current character */
-  curr_c = c;
+  int curr_c = c;
 
-  curr_laa = A_firstc_laa(c, *c1p);
-  prev_laa = A_firstc_laa(prev_c, prev_c1);
+  int curr_laa = A_firstc_laa(c, *c1p);
+  int prev_laa = A_firstc_laa(prev_c, prev_c1);
 
   if (curr_laa) {
     if (A_is_valid(prev_c) && !A_is_f(shape_c) && !A_is_s(shape_c) &&

--- a/src/nvim/garray.c
+++ b/src/nvim/garray.c
@@ -159,7 +159,7 @@ char_u *ga_concat_strings_sep(const garray_T *gap, const char *sep)
     s = xstpcpy(s, strings[i]);
     s = xstpcpy(s, sep);
   }
-  s = xstpcpy(s, strings[nelem - 1]);
+  strcpy(s, strings[nelem - 1]);
 
   return (char_u *) ret;
 }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5684,22 +5684,19 @@ static int syn_compare_syntime(const void *v1, const void *v2)
  */
 static void syntime_report(void)
 {
-  synpat_T    *spp;
-  proftime_T tm;
-  int len;
-  int total_count = 0;
-  garray_T ga;
-  time_entry_T *p;
-
   if (!syntax_present(curwin)) {
     MSG(_(msg_no_items));
     return;
   }
 
+  garray_T ga;
   ga_init(&ga, sizeof(time_entry_T), 50);
+
   proftime_T total_total = profile_zero();
+  int total_count = 0;
+  time_entry_T *p;
   for (int idx = 0; idx < curwin->w_s->b_syn_patterns.ga_len; ++idx) {
-    spp = &(SYN_ITEMS(curwin->w_s)[idx]);
+    synpat_T *spp = &(SYN_ITEMS(curwin->w_s)[idx]);
     if (spp->sp_time.count > 0) {
       p = GA_APPEND_VIA_PTR(time_entry_T, &ga);
       p->total = spp->sp_time.total;
@@ -5708,7 +5705,7 @@ static void syntime_report(void)
       p->match = spp->sp_time.match;
       total_count += spp->sp_time.count;
       p->slowest = spp->sp_time.slowest;
-      tm = profile_divide(spp->sp_time.total, spp->sp_time.count);
+      proftime_T tm = profile_divide(spp->sp_time.total, spp->sp_time.count);
       p->average = tm;
       p->id = spp->sp_syn.id;
       p->pattern = spp->sp_pattern;
@@ -5723,7 +5720,6 @@ static void syntime_report(void)
           "  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"));
   MSG_PUTS("\n");
   for (int idx = 0; idx < ga.ga_len && !got_int; ++idx) {
-    spp = &(SYN_ITEMS(curwin->w_s)[idx]);
     p = ((time_entry_T *)ga.ga_data) + idx;
 
     MSG_PUTS(profile_msg(p->total));
@@ -5745,6 +5741,7 @@ static void syntime_report(void)
     MSG_PUTS(" ");
 
     msg_advance(69);
+    int len;
     if (Columns < 80)
       len = 20;       /* will wrap anyway */
     else

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1445,7 +1445,6 @@ win_equal_rec (
     }
 
     for (fr = topfr->fr_child; fr != NULL; fr = fr->fr_next) {
-      n = m = 0;
       wincount = 1;
       if (fr->fr_next == NULL)
         /* last frame gets all that remains (avoid roundoff error) */
@@ -1566,7 +1565,6 @@ win_equal_rec (
     }
 
     for (fr = topfr->fr_child; fr != NULL; fr = fr->fr_next) {
-      n = m = 0;
       wincount = 1;
       if (fr->fr_next == NULL)
         /* last frame gets all that remains (avoid roundoff error) */


### PR DESCRIPTION
Remove dead assignments as pointed out by [static analysis](http://neovim.org/doc/build-reports/clang/). [Here](https://fwalch.github.io/doc-ci/build-reports/clang) is a static analysis report that includes the changes of this PR.

I didn't fix the [dead assignment in garray.c](http://neovim.org/doc/build-reports/clang/report-c565a2.html#EndPath), because otherwise the build would fail with `error: ignoring return value of ‘xstpcpy’, declared with attribute warn_unused_result`, and I didn't know what to do about that.
