### PR TITLE
[RDY] Fix some memory leaks in job.c and provider.c

### DIFF
--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -402,6 +402,14 @@ static void close_cb(uv_handle_t *handle)
     rstream_free(job->out);
     rstream_free(job->err);
     wstream_free(job->in);
+
+    // Free data memory of process and pipe handles, that was allocated
+    // by handle_set_job in job_start.
+    free(job->proc.data);
+    free(job->proc_stdin.data);
+    free(job->proc_stdout.data);
+    free(job->proc_stderr.data);
+
     shell_free_argv(job->proc_opts.args);
     free(job);
   }

--- a/src/nvim/os/provider.c
+++ b/src/nvim/os/provider.c
@@ -109,6 +109,7 @@ Object provider_call(char *method, Object arg)
              "Provider for \"%s\" is not available",
              method);
     report_error(buf);
+    msgpack_rpc_free_object(arg);
     return NIL;
   }
 


### PR DESCRIPTION
- Fixed memory leaks for jobs:  The data pointer of process and pipe handles was not freed.
- Fixed memory leak in `provider_call`, caused by an early return and not freeing an argument.
