### PR TITLE
[RDY] Add missing stdarg.h include.  Fixes build issue

### DIFF
--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -2,6 +2,7 @@
 #define NVIM_MESSAGE_H
 
 #include <stdbool.h>
+#include <stdarg.h>
 #include "nvim/eval_defs.h"  // for typval_T
 
 /*


### PR DESCRIPTION
This is a trivial change.  On my Linux machine with gcc 4.1.2, this include is required.  WIthout it, I get the following build error (while using d5a7947e8b3fc9b8f45ad1a0f0380e22e67fe6d1):

```
In file included from /rd/gen/lxd/do_not_delete/devel/neovim/src/nvim/message.h:27,
                 from /rd/gen/lxd/do_not_delete/devel/neovim/src/nvim/buffer.c:57:
/rd/gen/lxd/do_not_delete/devel/neovim/build/include/message.h.generated.h:79: error: expected declaration specifiers or '...' before 'va_list'
```

I have another machine with gcc 4.7, which doesn't require this.  So I'm guessing this might be related to the oldness of 4.1?
