### PR TITLE
[RDY] Use new output type in place of TAP

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -131,7 +131,7 @@ elif [ "$TRAVIS_BUILD_TYPE" = "gcc/unittest" ]; then
     export CC=gcc
     set_environment /opt/neovim-deps
     export SKIP_EXEC=1
-    $MAKE_CMD CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=TAP -DUSE_GCOV=ON" unittest
+    $MAKE_CMD CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=color_terminal -DUSE_GCOV=ON" unittest
     coveralls --encoding iso-8859-1 || echo 'coveralls upload failed.'
 elif [ "$TRAVIS_BUILD_TYPE" = "gcc/ia32" ]; then
     set_environment /opt/neovim-deps/32
@@ -154,7 +154,7 @@ elif [ "$TRAVIS_BUILD_TYPE" = "gcc/ia32" ]; then
     # correctly.
     sudo apt-get install libncurses5-dev:i386
 
-    CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=TAP \
+    CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=color_terminal \
         -DCMAKE_SYSTEM_PROCESSOR=i386 \
         -DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32 \
         -DFIND_LIBRARY_USE_LIB64_PATHS=OFF \

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -65,7 +65,7 @@ set_environment() {
 # install prebuilt dependencies
 if [ ! -d /opt/neovim-deps ]; then
     cd /opt
-    sudo git clone --depth=1 git://github.com/neovim/deps neovim-deps
+    sudo git clone --depth=1 -b add-color_terminal-output git://github.com/ZyX-I/deps neovim-deps
     cd -
 fi
 


### PR DESCRIPTION
Will fix #983 until we switch to busted-2.0.

Should be merged after neovim/deps#2. Remove second commit before merging: it is here for testing purposes.
