### PR TITLE
[RDY] Compile static luajit library with -fPIC

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -115,6 +115,7 @@ if(USE_BUNDLED_LUAJIT)
     BUILD_COMMAND ""
     INSTALL_COMMAND ${MAKE_PRG} CC=${CMAKE_C_COMPILER}
                                 PREFIX=${DEPS_INSTALL_DIR}
+                                CFLAGS=-fPIC
                                 BUILDMODE=static
                                 install)
   list(APPEND THIRD_PARTY_DEPS luajit)


### PR DESCRIPTION
Should fix the following travis error:

```
/usr/bin/ld: /opt/neovim-deps/lib/libluajit-5.1.a(lj_err.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/opt/neovim-deps/lib/libluajit-5.1.a: could not read symbols: Bad value
```

Fixes #905.
