### PR TITLE
[RDY] Remove unused argument 'defer' in function 'job_start'.

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10498,7 +10498,6 @@ static void f_job_start(typval_T *argvars, typval_T *rettv)
             on_job_stdout,
             on_job_stderr,
             on_job_exit,
-            true,
             0,
             &rettv->vval.v_number);
 

--- a/src/nvim/os/channel.c
+++ b/src/nvim/os/channel.c
@@ -96,7 +96,6 @@ uint64_t channel_from_job(char **argv)
                                 job_out,
                                 job_err,
                                 NULL,
-                                true,
                                 0,
                                 &status);
 

--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -39,7 +39,6 @@ struct job {
   int pending_closes;
   // If the job was already stopped
   bool stopped;
-  bool defer;
   // Data associated with the job
   void *data;
   // Callbacks
@@ -130,19 +129,16 @@ void job_teardown(void)
 ///        on stdout
 /// @param stderr_cb Callback that will be invoked when data is available
 ///        on stderr
-/// @param exit_cb Callback that will be invoked when the job exits
-/// @param defer If the job callbacks invocation should be deferred to vim
-///         main loop
+/// @param job_exit_cb Callback that will be invoked when the job exits
 /// @param maxmem Maximum amount of memory used by the job WStream
-/// @param[out] The job id if the job started successfully, 0 if the job table
-///             is full, -1 if the program could not be executed.
+/// @param[out] status The job id if the job started successfully, 0 if the job
+///             table is full, -1 if the program could not be executed.
 /// @return The job pointer if the job started successfully, NULL otherwise
 Job *job_start(char **argv,
                void *data,
                rstream_cb stdout_cb,
                rstream_cb stderr_cb,
                job_exit_cb job_exit_cb,
-               bool defer,
                size_t maxmem,
                int *status)
 {
@@ -187,7 +183,6 @@ Job *job_start(char **argv,
   job->proc_stdin.data = NULL;
   job->proc_stdout.data = NULL;
   job->proc_stderr.data = NULL;
-  job->defer = defer;
 
   // Initialize the job std{in,out,err}
   uv_pipe_init(uv_default_loop(), &job->proc_stdin, 0);

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -280,7 +280,6 @@ int os_system(const char *cmd,
                        system_data_cb,
                        system_data_cb,
                        NULL,
-                       false,
                        0,
                        &i);
 


### PR DESCRIPTION
Remove unused argument `defer` in function `job_start`.
- With the changes in commit
  "events: Refactor how event deferral is handled"
  (2e4ea29d2c7b62eb8baf1c41cd43433e085dda0) the function argument
  `defer` of `job_start` and member variable `defer` of `struct job`
  can be removed.
- Update/Fix the documentation for function `job_start`.

ping @tarruda to verify nothing else is planned for the `defer` member variable of `struct job`.
