### PR TITLE
[RDY] eval: re-remove USE_CR

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14103,16 +14103,7 @@ static void f_system(typval_T *argvars, typval_T *rettv)
 
   set_vim_var_nr(VV_SHELL_ERROR, (long) status);
 
-#if defined(USE_CR)
-  // translate <CR> into <NL>
-  if (res != NULL) {
-    for (char *s = res; *s; ++s) {
-      if (*s == CAR) {
-        *s = NL;
-      }
-    }
-  }
-#elif defined(USE_CRNL)
+#ifdef USE_CRNL
   // translate <CR><NL> into <NL>
   if (res != NULL) {
     char *d = res;


### PR DESCRIPTION
It was already removed in 01ca460 and I erroneously introduced it again in
PR #978.
