### PR TITLE
[RFC] Change vimdir path from vim to nvim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,8 @@ if(BUSTED_PRG)
     DEPENDS nvim-test unittest-headers)
 endif()
 
+install(DIRECTORY runtime DESTINATION share/nvim/)
+
 # Unfortunately, the below does not work under Ninja.  Ninja doesn't use a
 # pseudo-tty when launching processes, because it can put many jobs in parallel
 # and eat-up all the available pseudo-ttys.  Unfortunately, that doesn't work

--- a/config/pathdef.c.in
+++ b/config/pathdef.c.in
@@ -1,5 +1,5 @@
 #include "${PROJECT_SOURCE_DIR}/src/nvim/vim.h"
-char_u *default_vim_dir = (char_u *)"${CMAKE_INSTALL_PREFIX}/share/vim";
+char_u *default_vim_dir = (char_u *)"${CMAKE_INSTALL_PREFIX}/share/nvim";
 char_u *default_vimruntime_dir = (char_u *)"";
 char_u *all_cflags = (char_u *)"${COMPILER_FLAGS}";
 char_u *all_lflags = (char_u *)"${LINKER_FLAGS}";


### PR DESCRIPTION
Now that the runtime is back, we should stop pointing to Vim's runtime.

PS: maybe add an install target for the runtime too?
