### PR TITLE
[RDY] Remove unused USE_TERM_CONSOLE ifdefs

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -2593,7 +2593,6 @@ Macintosh:
     ":noremap".  Add "mapcmd({string}, {mode})?  Use code from ":mkexrc".
 9   incsearch is incorrect for "/that/<Return>/this/;//" (last search pattern
     isn't updated).
-9   term_console is used before it is set (msdos, Amiga).
 9   Get out-of-memory for ":g/^/,$s//@/" on 1000 lines, this is not handled
     correctly.  Get many error messages while redrawing the screen, which
     cause another redraw, etc.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -902,9 +902,6 @@ EXTERN int read_cmd_fd INIT(= 0);           /* fd to read commands from */
 /* volatile because it is used in signal handler catch_sigint(). */
 EXTERN volatile int got_int INIT(= FALSE);    /* set to TRUE when interrupt
                                                  signal occurred */
-#ifdef USE_TERM_CONSOLE
-EXTERN int term_console INIT(= FALSE);      /* set to TRUE when console used */
-#endif
 EXTERN int termcap_active INIT(= FALSE);        /* set by starttermcap() */
 EXTERN int cur_tmode INIT(= TMODE_COOK);        /* input terminal mode */
 EXTERN int bangredo INIT(= FALSE);          /* set to TRUE with ! command */

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -1553,27 +1553,11 @@ int set_termname(char_u *term)
 # endif
 
 
-#ifdef USE_TERM_CONSOLE
-  /* DEFAULT_TERM indicates that it is the machine console. */
-  if (STRCMP(term, DEFAULT_TERM) != 0)
-    term_console = FALSE;
-  else {
-    term_console = TRUE;
-  }
-#endif
-
 #if defined(UNIX)
   /*
    * 'ttyfast' is default on for xterm, iris-ansi and a few others.
    */
   if (vim_is_fastterm(term))
-    p_tf = TRUE;
-#endif
-#ifdef USE_TERM_CONSOLE
-  /*
-   * 'ttyfast' is default on consoles
-   */
-  if (term_console)
     p_tf = TRUE;
 #endif
 


### PR DESCRIPTION
This is unused after dropped amiga and msdos support.
