### PR TITLE
[RFC] Improve unit testing infrastructure

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -22,6 +22,8 @@ file(MAKE_DIRECTORY ${GENERATED_INCLUDES_DIR}/api/private)
 
 file(GLOB NEOVIM_SOURCES *.c os/*.c api/*.c api/private/*.c)
 file(GLOB_RECURSE NEOVIM_HEADERS *.h)
+file(GLOB_RECURSE NEOVIM_TEST_MOCKS
+  ${PROJECT_SOURCE_DIR}/test/c-helpers/*.mocks.h)
 
 foreach(sfile ${NEOVIM_SOURCES})
   get_filename_component(f ${sfile} NAME)
@@ -104,11 +106,23 @@ foreach(sfile ${NEOVIM_SOURCES}
   endif()
   set(gf1 "${GENERATED_DIR}/${r}.c.generated.h")
   set(gf2 "${GENERATED_INCLUDES_DIR}/${r}.h.generated.h")
+  set(test_helper "${PROJECT_SOURCE_DIR}/test/c-helpers/${f}")
+  set(test_mocks ${NEOVIM_TEST_MOCKS})
+  if(EXISTS "${test_helper}")
+    # Ensure the mocks.h file for a module is not included in the real module
+    # or it would cause redefinition errors caused by the mock being expanded
+    # into the real function definition
+    list(REMOVE_ITEM test_mocks "${test_helper}.mocks.h")
+  else()
+    unset(test_helper)
+  endif()
+  
   add_custom_command(
     OUTPUT "${gf1}" "${gf2}"
     COMMAND "${LUA_PRG}" "${HEADER_GENERATOR}"
                              "${sfile}" "${gf1}" "${gf2}"
                              "${CMAKE_C_COMPILER} ${gen_cflags} -E"
+                             "${test_helper}" ${test_mocks}
     DEPENDS "${HEADER_GENERATOR}" "${sfile}"
     )
   list(APPEND NEOVIM_GENERATED_SOURCES "${gf1}")
@@ -168,6 +182,7 @@ if(NOT DEFINED ENV{SKIP_UNITTEST})
   add_library(nvim-test MODULE EXCLUDE_FROM_ALL ${NEOVIM_GENERATED_SOURCES}
     ${NEOVIM_SOURCES} ${NEOVIM_HEADERS})
   target_link_libraries(nvim-test ${NVIM_LINK_LIBRARIES})
+  set_target_properties(nvim-test PROPERTIES COMPILE_FLAGS -DUNIT_TESTING)
 endif()
 
 add_subdirectory(po)

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3167,13 +3167,14 @@ static char_u **find_locales(void)
 {
   garray_T locales_ga;
   char_u      *loc;
+  char *locale_a;
 
   /* Find all available locales by running command "locale -a".  If this
    * doesn't work we won't have completion. */
-  char_u *locale_a = get_cmd_output((char_u *)"locale -a",
-      NULL, kShellOptSilent);
-  if (locale_a == NULL)
+  if (os_system("locale -a", NULL, 0, &locale_a, NULL) || locale_a == NULL) {
     return NULL;
+  }
+
   ga_init(&locales_ga, sizeof(char_u *), 20);
 
   /* Transform locale_a string where each locale is separated by "\n"

--- a/test/c-helpers/ex_cmds2.c
+++ b/test/c-helpers/ex_cmds2.c
@@ -1,0 +1,7 @@
+#include "nvim/os/shell.h"
+
+char *find_locale_helper(int idx)
+{
+  char **locales = (char **)find_locales();
+  return locales[idx];
+}

--- a/test/c-helpers/message.c
+++ b/test/c-helpers/message.c
@@ -1,0 +1,17 @@
+#include <stdint.h>
+
+static emsg_mock _emsg_mock = NULL;
+
+void set_emsg_mock(emsg_mock mock)
+{
+  _emsg_mock = mock;
+}
+
+int emsg_mocker(char *msg)
+{
+  if (!_emsg_mock) {
+    return emsg((uint8_t *)msg);
+  }
+
+  return _emsg_mock(xstrdup(msg));
+}

--- a/test/c-helpers/message.c.defs.h
+++ b/test/c-helpers/message.c.defs.h
@@ -1,0 +1,1 @@
+typedef int (*emsg_mock)(char *msg);

--- a/test/c-helpers/message.c.mocks.h
+++ b/test/c-helpers/message.c.mocks.h
@@ -1,0 +1,1 @@
+#define emsg(msg) emsg_mocker((char *)msg)

--- a/test/c-helpers/os/shell.c
+++ b/test/c-helpers/os/shell.c
@@ -1,0 +1,31 @@
+static os_system_mock _os_system_mock = NULL;
+
+void set_os_system_mock(os_system_mock mock)
+{
+  _os_system_mock = mock;
+}
+
+int os_system_mocker(const char *cmd,
+                     const char *input,
+                     size_t len,
+                     char **output,
+                     size_t *nread)
+{
+  if (!_os_system_mock) {
+    return os_system(cmd, input, len, output, nread);
+  }
+
+  *output = _os_system_mock(cmd, input, len);
+
+  if (*output == NULL) {
+    return 1;
+  }
+
+  *output = xstrdup(*output);
+
+  if (nread) {
+    *nread = strlen(*output);
+  }
+
+  return 0;
+}

--- a/test/c-helpers/os/shell.c.defs.h
+++ b/test/c-helpers/os/shell.c.defs.h
@@ -1,0 +1,3 @@
+typedef char *(*os_system_mock)(const char *cmd,
+                                const char *input,
+                                size_t len);

--- a/test/c-helpers/os/shell.c.mocks.h
+++ b/test/c-helpers/os/shell.c.mocks.h
@@ -1,0 +1,1 @@
+#define os_system os_system_mocker

--- a/test/unit/ex_cmds2_spec.lua
+++ b/test/unit/ex_cmds2_spec.lua
@@ -1,0 +1,38 @@
+local helpers = require('test.unit.helpers')
+local ffi, eq = helpers.ffi, helpers.eq
+local intern = helpers.internalize
+local to_cstr = helpers.to_cstr
+local NULL = helpers.NULL
+
+local ex_cmds2 = helpers.cimport(
+  './src/nvim/os/shell.h',
+  './src/nvim/ex_cmds_defs.h',
+  './src/nvim/ex_getln.h',
+  './src/nvim/ex_cmds2.h'
+)
+
+
+describe('ex_cmds2 functions', function()
+  describe('find_locales', function()
+    function find_locale(idx)
+      return intern(ex_cmds2.find_locale_helper(idx))
+    end
+
+    before_each(function()
+      ex_cmds2.set_os_system_mock(function(cmd, input, len)
+        eq(intern(cmd), 'locale -a') -- command used to obtain locales
+        return to_cstr('locale1\nlocale2\nlocale3')
+      end)
+    end)
+
+    after_each(function()
+      ex_cmds2.set_os_system_mock(NULL)
+    end)
+
+    it('splits the locales', function()
+      eq('locale1', find_locale(0))
+      eq('locale2', find_locale(1))
+      eq('locale3', find_locale(2))
+    end)
+  end)
+end)

--- a/test/unit/preprocess.moon
+++ b/test/unit/preprocess.moon
@@ -88,7 +88,8 @@ class Gcc
    '-D "EXTERN=extern"',
    '-D "INIT(...)="',
    '-D_GNU_SOURCE',
-   '-DINCLUDE_GENERATED_DECLARATIONS'
+   '-DINCLUDE_GENERATED_DECLARATIONS',
+   '-DUNIT_TESTING'
   }
 
   new: (path) =>


### PR DESCRIPTION
With this PR we can now:
- Test static functions
- Mock functions for testing(see the find_locales example)

This is done by merging the files in the nvim/test-helpers directory with the corresponding module. Since the file is included in the automatically generated static header, we can "override" functions by using macros with the same name.

I also started work for removing `os_call_shell` in favor of `os_system`, which will require refactoring all functions that call it indirectly. There's still one more usage of `get_cmd_output` but I will remove in another PR
