### PR TITLE
[RDY] Update luarocks.

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -55,8 +55,8 @@ set(MSGPACK_MD5 ea0bee0939d2980c0df91f0e4843ccc4)
 set(LUAJIT_URL http://luajit.org/download/LuaJIT-2.0.3.tar.gz)
 set(LUAJIT_MD5 f14e9104be513913810cd59c8c658dc0)
 
-set(LUAROCKS_URL http://github.com/keplerproject/luarocks/archive/v2.1.2.tar.gz)
-set(LUAROCKS_MD5 df591c00a85d51fb754ec08c77896aad)
+set(LUAROCKS_URL https://github.com/keplerproject/luarocks/archive/v2.2.0beta1.tar.gz)
+set(LUAROCKS_MD5 d865fd8c333d6daca98ea052ff919043)
 
 if(USE_BUNDLED_LIBUV)
   ExternalProject_Add(libuv
@@ -152,7 +152,6 @@ if(USE_BUNDLED_LUAROCKS)
 
   add_custom_command(OUTPUT ${DEPS_BIN_DIR}/moon ${DEPS_BIN_DIR}/moonc
     COMMAND ${DEPS_BIN_DIR}/luarocks ARGS install moonscript
-            --server=http://rocks.moonscript.org
     DEPENDS luarocks)
   add_custom_target(moonscript
     DEPENDS ${DEPS_BIN_DIR}/moon ${DEPS_BIN_DIR}/moonc)
@@ -162,7 +161,6 @@ if(USE_BUNDLED_LUAROCKS)
   # to be serialized.
   add_custom_command(OUTPUT ${DEPS_BIN_DIR}/busted
     COMMAND ${DEPS_BIN_DIR}/luarocks ARGS install busted 1.10.0
-            --server=http://rocks.moonscript.org
     DEPENDS moonscript)
   add_custom_target(busted
     DEPENDS ${DEPS_BIN_DIR}/busted)


### PR DESCRIPTION
This forces luarocks to use the rocks.moonscript.org server, which was already used for some `luarocks install` commands and, additionally, currently seems to be the recommended luarocks repo server (see keplerproject/luarocks#276). This should fix #1013.
