### PR TITLE
[RDY] Implement `os_mkdtemp` on top of `uv_fs_mkdtemp`

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -566,11 +566,9 @@ attack or other people reading your file).  When Vim exits the directory and
 all files in it are deleted.  When Vim has the setuid bit set this may cause
 problems, the temp file is owned by the setuid user but the filter command
 probably runs as the original user.
-On MS-DOS and OS/2 the first of these directories that works is used: $TMP,
-$TEMP, c:\TMP, c:\TEMP.
-For Unix the list of directories is: $TMPDIR, /tmp, current-dir, $HOME.
-For MS-Windows the GetTempFileName() system function is used.
-For other systems the tmpnam() library function is used.
+Directory for temporary files is created in the first suitable directory of:
+For Unix: $TMPDIR, /tmp, current-dir, $HOME.
+For MS-Windows: $TMP, $TEMP, $USERPROFILE, current-dir.
 
 
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6212,8 +6212,7 @@ taglist({expr})							*taglist()*
 
 tempname()					*tempname()* *temp-file-name*
 		The result is a String, which is the name of a file that
-		doesn't exist.	It can be used for a temporary file.  The name
-		is different for at least 26 consecutive calls.  Example: >
+		doesn't exist.	It can be used for a temporary file.  Example: >
 			:let tmpfile = tempname()
 			:exe "redir > " . tmpfile
 <		For Unix, the file will be in a private directory |tempfile|.


### PR DESCRIPTION
5 days ago libuv 0.11.27 was released. It includes `uv_fs_mkdtemp` from https://github.com/joyent/libuv/pull/1368. This PR should finally close #812.
