### PR TITLE
[RFC] Travis: Add subdirectories to dependency paths.

### DIFF
--- a/.ci/api-python.sh
+++ b/.ci/api-python.sh
@@ -1,6 +1,6 @@
 . "$CI_SCRIPTS/common.sh"
 
-set_environment /opt/neovim-deps
+set_environment /opt/neovim-deps/64
 
 sudo apt-get install expect valgrind
 

--- a/.ci/clang-asan.sh
+++ b/.ci/clang-asan.sh
@@ -2,7 +2,7 @@
 
 install_vroom
 
-set_environment /opt/neovim-deps
+set_environment /opt/neovim-deps/64
 
 sudo pip install cpp-coveralls
 

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -48,7 +48,7 @@ asan_check() {
 }
 
 set_environment() {
-	local prefix="$1"
+	local prefix="$1/usr"
 	eval $($prefix/bin/luarocks path)
 	export PATH="$prefix/bin:$PATH"
 	export PKG_CONFIG_PATH="$prefix/lib/pkgconfig"

--- a/.ci/gcc-unittest.sh
+++ b/.ci/gcc-unittest.sh
@@ -1,6 +1,6 @@
 . "$CI_SCRIPTS/common.sh"
 
-set_environment /opt/neovim-deps
+set_environment /opt/neovim-deps/64
 
 sudo pip install cpp-coveralls
 


### PR DESCRIPTION
Update paths in `travis.sh` to work with automatic dependency builds on Travis (see neovim/bot-ci#8). The last commit is a quick fix for the problems in #1031 so that builds won't fail because of that.

Would need to be merged after neovim/bot-ci#8 is merged and a `neovim/bot-ci` build has been successful. Until then, this PR will not build on Travis, because the updated paths are not yet in `neovim/deps`.

Related: #1033.
