### PR TITLE
[RDY] Update APT package sources in travis.sh.

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -166,12 +166,13 @@ elif [ "$TRAVIS_BUILD_TYPE" = "clint" ]; then
     ./scripts/clint.sh
 elif [ "$TRAVIS_BUILD_TYPE" = "api/python" ]; then
     set_environment /opt/neovim-deps
-    $MAKE_CMD
+    sudo apt-get update
     sudo apt-get install expect valgrind
+    $MAKE_CMD
     git clone --depth=1 -b master git://github.com/neovim/python-client
     cd python-client
-  sudo pip install .
-  sudo pip install nose
+    sudo pip install .
+    sudo pip install nose
     test_cmd="nosetests --verbosity=2"
     nvim_cmd="valgrind -q --track-origins=yes --leak-check=yes --suppressions=$suppressions --log-file=$tmpdir/valgrind-%p.log ../build/bin/nvim -u NONE"
     if ! ../scripts/run-api-tests.exp "$test_cmd" "$nvim_cmd"; then


### PR DESCRIPTION
Apparently, there has been an updated package in the APT repos, which causes `api/python` builds to [fail](https://travis-ci.org/neovim/neovim/jobs/31790494) with

> Err http://us.archive.ubuntu.com/ubuntu/ precise-updates/main libc6-dev amd64 2.15-0ubuntu10.5
> 404 Not Found [IP: 2001:67c:1562::13 80]

Current version in the repos is 2.15-0ubuntu10.**6**; executing `apt-get update` before installing packages should resolve this. Also fixed indentation.
