### PR TITLE
[RFC] vim-patch:7.4.324

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1733,6 +1733,7 @@ getexmodeline (
   int vcol = 0;
   char_u      *p;
   int prev_char;
+  int len;
 
   /* Switch cursor on now.  This avoids that it happens after the "\n", which
    * confuses the system function that computes tabstops. */
@@ -1799,7 +1800,14 @@ getexmodeline (
       if (c1 == BS || c1 == K_BS
           || c1 == DEL || c1 == K_DEL || c1 == K_KDEL) {
         if (!GA_EMPTY(&line_ga)) {
-          --line_ga.ga_len;
+          if (has_mbyte) {
+            p = (char_u *)line_ga.ga_data;
+            p[line_ga.ga_len] = NUL;
+            len = (*mb_head_off)(p, p + line_ga.ga_len - 1) + 1;
+            line_ga.ga_len -= len;
+          } else {
+            line_ga.ga_len--;
+          }
           goto redraw;
         }
         continue;
@@ -1832,15 +1840,20 @@ redraw:
         /* redraw the line */
         msg_col = startcol;
         vcol = 0;
-        for (p = (char_u *)line_ga.ga_data;
-             p < (char_u *)line_ga.ga_data + line_ga.ga_len; ++p) {
+        ga_grow(&line_ga,1);
+        p = (char_u *)line_ga.ga_data;
+        p[line_ga.ga_len] = NUL;
+        while (p < (char_u *)line_ga.ga_data + line_ga.ga_len) {
           if (*p == TAB) {
             do {
               msg_putchar(' ');
             } while (++vcol % 8);
+            p++;
           } else {
-            msg_outtrans_len(p, 1);
-            vcol += char2cells(*p);
+            len = MB_PTR2LEN(p);
+            msg_outtrans_len(p, len);
+            vcol += ptr2cells(p);
+            p += len;
           }
         }
         msg_clr_eos();
@@ -1886,7 +1899,13 @@ redraw:
 
     if (IS_SPECIAL(c1))
       c1 = '?';
-    ((char_u *)line_ga.ga_data)[line_ga.ga_len] = c1;
+    if (has_mbyte) {
+      len = (*mb_char2bytes)(c1, (char_u *)line_ga.ga_data + line_ga.ga_len);
+    } else {
+      len = 1;
+      ((char_u *)line_ga.ga_data)[line_ga.ga_len] = c1;
+    }
+
     if (c1 == '\n')
       msg_putchar('\n');
     else if (c1 == TAB) {
@@ -1895,11 +1914,10 @@ redraw:
         msg_putchar(' ');
       } while (++vcol % 8);
     } else {
-      msg_outtrans_len(
-          ((char_u *)line_ga.ga_data) + line_ga.ga_len, 1);
+      msg_outtrans_len(((char_u *)line_ga.ga_data) + line_ga.ga_len, len);
       vcol += char2cells(c1);
     }
-    ++line_ga.ga_len;
+    line_ga.ga_len += len;
     escaped = FALSE;
 
     windgoto(msg_row, msg_col);

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -271,7 +271,7 @@ static int included_patches[] = {
   327,
   //326 NA
   325,
-  //324,
+  324,
   323,
   //322 NA
   //321 NA


### PR DESCRIPTION
Problem:   In Ex mode, cyrillic characters are not handled. (Stas Malavin)
Solution:   Support multi-byte characters in Ex mode. (Yukihiro Nakadaira)

https://code.google.com/p/vim/source/detail?r=c476e0ac8b406693c3877baffa0e97ff25e59b06
- I have changed two prefix ++ operators to postfix.
- Added `ga_grow(&line_ga,1);` on line 1843 (see discussion with @oni-link )
- ~~I'm not sure about the formatting of the ifdefs, maybe some adjustments will be needed there~~
- removed use of `FEAT_MBYTE` (see comment by @splinterofchaos)
- Does anyone know how to test this patch? Maybe there is someone on the Neovim team who uses Cyrillic characters.
