### PR TITLE
[WIP] Remove -C and -N vi compatibility arguments

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1670,8 +1670,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	happen for the system-wide vimrc or gvimrc file, nor for a file given
 	with the |-u| argument).  Also see |compatible-default| and
 	|posix-compliance|.
-	You can also set this option with the "-C" argument, and reset it with
-	"-N".  See |-C| and |-N|.
 	Switching this option off makes the Vim defaults be used for options
 	that have a different Vi and Vim default value.  See the options
 	marked with a '+' below.  Other options are not modified.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -339,24 +339,6 @@ a slash.  Thus "-R" means recovery and "-/R" readonly.
 		{not available when compiled without the |+eval| feature}
 		{not in Vi}
 
-							*-C*
--C		Compatible mode.  Sets the 'compatible' option.  You can use
-		this to get 'compatible', even though a .vimrc file exists.
-		Keep in mind that the command ":set nocompatible" in some
-		plugin or startup script overrules this, so you may end up
-		with 'nocompatible' anyway.  To find out, use: >
-			:verbose set compatible?
-<		Several plugins won't work with 'compatible' set.  You may
-		want to set it after startup this way: >
-			vim "+set cp" filename
-<		Also see |compatible-default|.  {not in Vi}
-
-							*-N*
--N		Not compatible mode.  Resets the 'compatible' option.  You can
-		use this to get 'nocompatible', when there is no .vimrc file
-		or when using "-u NONE".
-		Also see |compatible-default|.  {not in Vi}
-
 							*-y* *easy*
 -y		Easy mode.  Implied for |evim| and |eview|.  Starts with
 		'insertmode' set and behaves like a click-and-type editor.
@@ -960,15 +942,10 @@ mappings depend on a certain value of 'compatible', set or reset it before
 giving the mapping.
 
 The above behavior can be overridden in these ways:
-- If the "-N" command line argument is given, 'nocompatible' will be used,
-  even when no vimrc file exists.
-- If the "-C" command line argument is given, 'compatible' will be used, even
-  when a vimrc file exists.
 - If the "-u {vimrc}" argument is used, 'compatible' will be used.
-- When the name of the executable ends in "ex", then this works like the "-C"
-  argument was given: 'compatible' will be used, even when a vimrc file
-  exists.  This has been done to make Vim behave like "ex", when it is started
-  as "ex".
+- When the name of the executable ends in "ex", 'compatible' will be used,
+  even when a vimrc file exists.  This has been done to make Vim behave like
+  "ex", when it is started as "ex".
 
 Avoiding trojan horses:					*trojan-horse*
 While reading the "vimrc" or the "exrc" file in the current directory, some

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1054,10 +1054,6 @@ static void command_line_scan(mparm_T *parmp)
           curbuf->b_p_bin = 1;                /* binary file I/O */
           break;
 
-        case 'C':                 /* "-C"  Compatible */
-          change_compatible(TRUE);
-          break;
-
         case 'e':                 /* "-e" Ex mode */
           exmode_active = EXMODE_NORMAL;
           break;
@@ -1103,10 +1099,6 @@ static void command_line_scan(mparm_T *parmp)
 
         case 'y':                 /* "-y"  easy mode */
           parmp->evim_mode = TRUE;
-          break;
-
-        case 'N':                 /* "-N"  Nocompatible */
-          change_compatible(FALSE);
           break;
 
         case 'n':                 /* "-n" no swap file */
@@ -2171,8 +2163,6 @@ static void usage(void)
   main_msg(_("-M\t\t\tModifications in text not allowed"));
   main_msg(_("-b\t\t\tBinary mode"));
   main_msg(_("-l\t\t\tLisp mode"));
-  main_msg(_("-C\t\t\tCompatible with Vi: 'compatible'"));
-  main_msg(_("-N\t\t\tNot fully Vi compatible: 'nocompatible'"));
   main_msg(_("-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"));
   main_msg(_("-D\t\t\tDebugging mode"));
   main_msg(_("-n\t\t\tNo swap file, use memory only"));


### PR DESCRIPTION
Removing vi compatibility completely is currently blocked on getting the testdir/ tests working without it.

However, this pull request takes baby steps towards removing vi compatibility by removing the -C and -N command line arguments. Splitting up vi compatibility removal in multiple steps is probably the way forward, since the full removal task would be large for one pull request.
