### PR TITLE
[RFC] Implement basic --embedded-mode command-line option

### DIFF
--- a/scripts/run-api-tests.exp
+++ b/scripts/run-api-tests.exp
@@ -20,43 +20,6 @@ set nvim_id $spawn_id
 # Reset function that can be invoked by test runners to put nvim in a cleaner
 # state
 send {
-:function BeforeEachTest()
-  set all&
-  let &initpython = 'python -c "import neovim; neovim.start_host()"'
-  redir => groups
-  silent augroup
-  redir END
-  for group in split(groups)
-    exe 'augroup '.group
-    autocmd!
-    augroup END
-  endfor
-  autocmd!
-  tabnew
-  let curbufnum = eval(bufnr('%'))
-  redir => buflist
-  silent ls!
-  redir END
-  let bufnums = []
-  for buf in split(buflist, '\n')
-    let bufnum = eval(split(buf, '[ u]')[0])
-    if bufnum != curbufnum
-      call add(bufnums, bufnum)
-    endif
-  endfor
-  if len(bufnums) > 0
-    exe 'silent bwipeout! '.join(bufnums, ' ')
-  endif
-  silent tabonly
-  for k in keys(g:)
-    exe 'unlet g:'.k
-  endfor
-  filetype plugin indent off
-  mapclear
-  mapclear!
-  abclear
-  comclear
-endfunction
 :echo "read"."y"
 }
 # wait until nvim is ready

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2011,6 +2011,10 @@ void free_cmdline_buf(void)
  */
 static void draw_cmdline(int start, int len)
 {
+  if (embedded_mode) {
+    return;
+  }
+
   int i;
 
   if (cmdline_star > 0)

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1233,6 +1233,9 @@ EXTERN char *ignoredp;
  * os_unix.c */
 EXTERN int curr_tmode INIT(= TMODE_COOK); /* contains current terminal mode */
 
+// If a msgpack-rpc channel should be started over stdin/stdout
+EXTERN bool embedded_mode INIT(= false);
+
 /// Used to track the status of external functions.
 /// Currently only used for iconv().
 typedef enum {

--- a/src/nvim/os/channel.c
+++ b/src/nvim/os/channel.c
@@ -67,6 +67,10 @@ void channel_init(void)
   channels = pmap_new(uint64_t)();
   event_strings = pmap_new(cstr_t)();
   msgpack_sbuffer_init(&out_buffer);
+
+  if (embedded_mode) {
+    channel_from_stdio();
+  }
 }
 
 /// Teardown the module

--- a/src/nvim/os/channel.c
+++ b/src/nvim/os/channel.c
@@ -278,6 +278,7 @@ static void job_err(RStream *rstream, void *data, bool eof)
 static void parse_msgpack(RStream *rstream, void *data, bool eof)
 {
   Channel *channel = data;
+  channel->rpc_call_level++;
 
   if (eof) {
     char buf[256];
@@ -287,10 +288,9 @@ static void parse_msgpack(RStream *rstream, void *data, bool eof)
              "closed by the client",
              channel->id);
     call_set_error(channel, buf);
-    return;
+    goto end;
   }
 
-  channel->rpc_call_level++;
   uint32_t count = rstream_available(rstream);
   DLOG("Feeding the msgpack parser with %u bytes of data from RStream(%p)",
        count,

--- a/src/nvim/os/channel.c
+++ b/src/nvim/os/channel.c
@@ -25,6 +25,8 @@
 #include "nvim/log.h"
 #include "nvim/lib/kvec.h"
 
+#define CHANNEL_BUFFER_SIZE 0xffff
+
 typedef struct {
   uint64_t request_id;
   bool errored;
@@ -117,7 +119,10 @@ void channel_from_stream(uv_stream_t *stream)
   stream->data = NULL;
   channel->is_job = false;
   // read stream
-  channel->data.streams.read = rstream_new(parse_msgpack, 1024, channel, NULL);
+  channel->data.streams.read = rstream_new(parse_msgpack,
+                                           CHANNEL_BUFFER_SIZE,
+                                           channel,
+                                           NULL);
   rstream_set_stream(channel->data.streams.read, stream);
   rstream_start(channel->data.streams.read);
   // write stream

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -39,7 +39,10 @@ void signal_init(void)
   uv_signal_start(&shup, signal_cb, SIGHUP);
   uv_signal_start(&squit, signal_cb, SIGQUIT);
   uv_signal_start(&sterm, signal_cb, SIGTERM);
-  uv_signal_start(&swinch, signal_cb, SIGWINCH);
+  if (!embedded_mode) {
+    // TODO(tarruda): There must be an API function for resizing window
+    uv_signal_start(&swinch, signal_cb, SIGWINCH);
+  }
 #ifdef SIGPWR
   uv_signal_init(uv_default_loop(), &spwr);
   uv_signal_start(&spwr, signal_cb, SIGPWR);

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -88,6 +88,18 @@ static int did_set_icon = FALSE;
  */
 void mch_write(char_u *s, int len)
 {
+  if (embedded_mode) {
+    // TODO(tarruda): This is a temporary hack to stop Neovim from writing
+    // messages to stdout in embedded mode. In the future, embedded mode will
+    // be the only possibility(GUIs will always start neovim with a msgpack-rpc
+    // over stdio) and this function won't exist.
+    //
+    // The reason for this is because before Neovim fully migrates to a
+    // msgpack-rpc-driven architecture, we must have a fully functional
+    // UI working
+    return;
+  }
+
   ignored = (int)write(1, (char *)s, len);
   if (p_wd)             /* Unix is too fast, slow down a bit more */
     os_microdelay(p_wd, false);

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -2360,6 +2360,9 @@ void set_shellsize(int width, int height, int mustset)
  */
 void settmode(int tmode)
 {
+  if (embedded_mode) {
+    return;
+  }
 
   if (full_screen) {
     /*


### PR DESCRIPTION
This option provides a simple way to embed Neovim into another process by starting an msgpack-rpc channel via stdin/stdout. This will be used run tests against a headless nvim instance and to help adapting the old terminal code to msgpack-rpc. Though the headless mode requires #781 to be "complete", I decided to make this a separate pull request.
