### PR TITLE
[RFC] vim-patch:7.4.231

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -5,6 +5,7 @@
 export SHELL := sh
 
 VIMPROG := ../../../build/bin/nvim
+SCRIPTSOURCE := ../../../runtime
 
 SCRIPTS := test_autoformat_join.out                                    \
            test_eval.out                                               \
@@ -29,7 +30,8 @@ SCRIPTS := test_autoformat_join.out                                    \
            test91.out  test92.out  test93.out  test94.out  test95.out  \
            test96.out  test97.out  test98.out  test99.out  test100.out \
            test101.out test102.out test103.out test104.out test105.out \
-           test106.out test107.out
+           test106.out test107.out \
+           test_options.out
 
 SCRIPTS_GUI := test16.out
 
@@ -86,7 +88,7 @@ $(SCRIPTS) $(SCRIPTS_GUI): $(VIMPROG) test1.out
 
 RM_ON_RUN   := test.out X* viminfo
 RM_ON_START := tiny.vim small.vim mbyte.vim mzscheme.vim lua.vim test.ok
-RUN_VIM     := $(TOOL) $(VIMPROG) -u unix.vim -U NONE --noplugin -s dotest.in
+RUN_VIM     := export VIMRUNTIME=$(SCRIPTSOURCE); $(TOOL) $(VIMPROG) -u unix.vim -U NONE --noplugin -s dotest.in
 
 clean:
 	-rm -rf *.out          \

--- a/src/nvim/testdir/test_options.in
+++ b/src/nvim/testdir/test_options.in
@@ -1,0 +1,17 @@
+Test for ":options".
+
+STARTTEST
+:so small.vim
+:let caught = 'ok'
+:try
+  :options
+:catch 
+  :let caught = v:throwpoint . "\n" . v:exception
+:endtry
+:buf 1
+:$put =caught
+:/^result/,$w! test.out
+:qa!
+ENDTEST
+
+result

--- a/src/nvim/testdir/test_options.ok
+++ b/src/nvim/testdir/test_options.ok
@@ -1,0 +1,2 @@
+result
+ok

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -364,7 +364,7 @@ static int included_patches[] = {
   234,
   233,
   232,
-  //231,
+  231,
   230,
   229,
   //228 NA


### PR DESCRIPTION
~~**vim-patch:7.4.230**~~

~~Problem:    Error when using ":options".~~
~~Solution:   Fix the entry for 'lispwords'. (Kenichi Ito)~~

~~https://code.google.com/p/vim/source/detail?r=57ecd7a8c0f052296b41b916eb1ae7~~

~~This has already been done with #938. This commit only changes version.c.~~

The current `version.c` already has patch 230 in it.

---

**vim-patch:7.4.231**

Problem:    An error in ":options" is not caught by the tests.
Solution:   Add a test for ":options".  Set $VIMRUNTIME for the tests so that
                it uses the current runtime files instead of the installed ones.

https://code.google.com/p/vim/source/detail?r=0a295a3c9e473512ad3b006a0fb752

This is the test for 7.4.230. I have changed the $SCRIPTSOURCE/$VIMRUNTIME to match the Neovim project structure.
