### PR TITLE
[RFC] coverity/71508: Fix potential null dereference.

### DIFF
--- a/src/nvim/os/provider.c
+++ b/src/nvim/os/provider.c
@@ -158,8 +158,10 @@ static uint64_t get_provider_for(char *method)
 
 err:
   // Ensure we won't try to restart the provider
-  f->bootstrap_command = NULL;
-  f->channel_id = 0;
+  if (f) {
+    f->bootstrap_command = NULL;
+    f->channel_id = 0;
+  }
   return 0;
 }
 


### PR DESCRIPTION
Make sure feature pointer is not null before dereferencing.
