### PR TITLE
[RFC] Issue #988: Use safe string functions for copying values

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5325,9 +5325,9 @@ void ex_helptags(exarg_T *eap)
   }
 
   /* Get a list of all files in the help directory and in subdirectories. */
-  STRCPY(NameBuff, dirname);
+  STRNCPY(NameBuff, dirname, MAXPATHL);
   add_pathsep(NameBuff);
-  STRCAT(NameBuff, "**");
+  STRNCAT(NameBuff, "**", MAXPATHL);
 
   // Note: We cannot just do `&NameBuff` because it is a statically sized array
   //       so `NameBuff == &NameBuff` according to C semantics.
@@ -5427,9 +5427,9 @@ helptags_one (
    * Find all *.txt files.
    */
   dirlen = (int)STRLEN(dir);
-  STRCPY(NameBuff, dir);
-  STRCAT(NameBuff, "/**/*");
-  STRCAT(NameBuff, ext);
+  STRNCPY(NameBuff, dir, MAXPATHL);
+  STRNCAT(NameBuff, "/**/*", MAXPATHL);
+  STRNCAT(NameBuff, ext, MAXPATHL);
 
   // Note: We cannot just do `&NameBuff` because it is a statically sized array
   //       so `NameBuff == &NameBuff` according to C semantics.
@@ -5448,7 +5448,7 @@ helptags_one (
    */
   STRCPY(NameBuff, dir);
   add_pathsep(NameBuff);
-  STRCAT(NameBuff, tagfname);
+  STRNCAT(NameBuff, tagfname, MAXPATHL);
   fd_tags = mch_fopen((char *)NameBuff, "w");
   if (fd_tags == NULL) {
     EMSG2(_("E152: Cannot open %s for writing"), NameBuff);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7447,7 +7447,7 @@ option_value2string (
     long wc = 0;
 
     if (wc_use_keyname(varp, &wc))
-      STRCPY(NameBuff, get_special_key_name((int)wc, 0));
+      STRNCPY(NameBuff, get_special_key_name((int)wc, 0), MAXPATHL);
     else if (wc != 0)
       STRCPY(NameBuff, transchar((int)wc));
     else


### PR DESCRIPTION
Fix coverity issues in #988 by using safe string functions
