### PR TITLE
[RDY] remove HAVE_DUP

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1755,13 +1755,11 @@ failed:
 #endif
   xfree(buffer);
 
-#ifdef HAVE_DUP
   if (read_stdin) {
     /* Use stderr for stdin, makes shell commands work. */
     close(0);
     ignored = dup(2);
   }
-#endif
 
   if (tmpname != NULL) {
     os_remove((char *)tmpname);  // delete converted file

--- a/src/nvim/os/os_defs.h
+++ b/src/nvim/os/os_defs.h
@@ -103,9 +103,6 @@
 # include <strings.h>
 #endif
 
-// For dup(3).
-#define HAVE_DUP
-
 /// Function to convert -errno error to char * error description
 ///
 /// -errno errors are returned by a number of os functions.


### PR DESCRIPTION
Vim defines this for Windows, so there's no Neovim-supported system for which this would not be defined.

Also obviates https://code.google.com/p/vim/source/detail?r=v7-4-216 .

MSDN says `dup()` is deprecated, so maybe we should have an `os_dup()` that wraps `_dup` for Windows.
