### PR TITLE
[RFC] Fix some clang analysis warnings

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4908,14 +4908,13 @@ insertchar (
     char_u  *line;
     char_u lead_end[COM_MAX_LEN];           /* end-comment string */
     int middle_len, end_len;
-    int i;
 
     /*
      * Need to remove existing (middle) comment leader and insert end
      * comment leader.  First, check what comment leader we can find.
      */
-    i = get_leader_len(line = get_cursor_line_ptr(), &p, FALSE, TRUE);
-    if (i > 0 && vim_strchr(p, COM_MIDDLE) != NULL) {   /* Just checking */
+    size_t i = get_leader_len(line = get_cursor_line_ptr(), &p, FALSE, TRUE);
+    if (i != 0 && vim_strchr(p, COM_MIDDLE) != NULL) {   /* Just checking */
       /* Skip middle-comment string */
       while (*p && p[-1] != ':')        /* find end of middle flags */
         ++p;
@@ -4931,17 +4930,16 @@ insertchar (
 
       /* Skip white space before the cursor */
       i = curwin->w_cursor.col;
-      while (--i >= 0 && vim_iswhite(line[i]))
-        ;
-      i++;
-
-      /* Skip to before the middle leader */
-      i -= middle_len;
+      while (i != 0 && vim_iswhite(line[i - 1])) {
+        i--;
+      }
 
       /* Check some expected things before we go on */
-      if (i >= 0 && lead_end[end_len - 1] == end_comment_pending) {
-        /* Backspace over all the stuff we want to replace */
-        backspace_until_column(i);
+      if (i >= (size_t)middle_len
+          && lead_end[end_len - 1] == end_comment_pending) {
+        // Backspace over all the stuff we want to replace.
+        // Subtract middle_len to skip to before the middle leader.
+        backspace_until_column(i - middle_len);
 
         /*
          * Insert the end-comment string, except for the last
@@ -5064,7 +5062,7 @@ internal_format (
   int fo_multibyte = has_format_option(FO_MBYTE_BREAK);
   int fo_white_par = has_format_option(FO_WHITE_PAR);
   int first_line = TRUE;
-  colnr_T leader_len;
+  size_t leader_len;
   int no_leader = FALSE;
   int do_comments = (flags & INSCHAR_DO_COM);
 
@@ -5159,15 +5157,19 @@ internal_format (
         if (curwin->w_cursor.col == 0 && WHITECHAR(cc))
           break;                        /* only spaces in front of text */
         /* Don't break until after the comment leader */
-        if (curwin->w_cursor.col < leader_len)
+        if (curwin->w_cursor.col < 0
+            || (size_t)curwin->w_cursor.col < leader_len) {
           break;
+        }
         if (has_format_option(FO_ONE_LETTER)) {
           /* do not break after one-letter words */
           if (curwin->w_cursor.col == 0)
             break;              /* one-letter word at begin */
           /* do not break "#a b" when 'tw' is 2 */
-          if (curwin->w_cursor.col <= leader_len)
+          if (curwin->w_cursor.col < 0
+              || (size_t)curwin->w_cursor.col <= leader_len) {
             break;
+          }
           col = curwin->w_cursor.col;
           dec_cursor();
           cc = gchar_cursor();
@@ -5187,8 +5189,10 @@ internal_format (
         /* Break after or before a multi-byte character. */
         if (curwin->w_cursor.col != startcol) {
           /* Don't break until after the comment leader */
-          if (curwin->w_cursor.col < leader_len)
+          if (curwin->w_cursor.col < 0
+              || (size_t)curwin->w_cursor.col < leader_len) {
             break;
+          }
           col = curwin->w_cursor.col;
           inc_cursor();
           /* Don't change end_foundcol if already set. */
@@ -5212,8 +5216,10 @@ internal_format (
         if (WHITECHAR(cc))
           continue;                     /* break with space */
         /* Don't break until after the comment leader */
-        if (curwin->w_cursor.col < leader_len)
+        if (curwin->w_cursor.col < 0
+            || (size_t)curwin->w_cursor.col < leader_len) {
           break;
+        }
 
         curwin->w_cursor.col = col;
 
@@ -5304,9 +5310,10 @@ internal_format (
           if (State & VREPLACE_FLAG)
             change_indent(INDENT_SET, second_indent,
                 FALSE, NUL, TRUE);
-          else if (leader_len > 0 && second_indent - leader_len > 0) {
+          else if (leader_len != 0 && second_indent >= 0
+                   && (size_t)second_indent > leader_len) {
             int i;
-            int padding = second_indent - leader_len;
+            int padding = second_indent - (int)leader_len;
 
             /* We started at the first_line of a numbered list
              * that has a comment.  the open_line() function has

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -400,7 +400,7 @@ int get_number_indent(linenr_T lnum)
   colnr_T col;
   pos_T pos;
   regmatch_T regmatch;
-  int lead_len = 0;  // Length of comment leader.
+  size_t lead_len = 0;  // Length of comment leader.
 
   if (lnum > curbuf->b_ml.ml_line_count) {
     return -1;

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -737,7 +737,7 @@ open_line (
     p_extra = (char_u *)"";                 /* append empty line */
 
   /* concatenate leader and p_extra, if there is a leader */
-  if (lead_len) {
+  if (lead_len > 0) {
     if (flags & OPENLINE_COM_LIST && second_line_indent > 0) {
       int i;
       int padding = second_line_indent

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -213,7 +213,7 @@ open_line (
       old_cursor = curwin->w_cursor;
       ptr = saved_line;
       if (flags & OPENLINE_DO_COM)
-        lead_len = get_leader_len(ptr, NULL, FALSE, TRUE);
+        lead_len = (int)get_leader_len(ptr, NULL, FALSE, TRUE);
       else
         lead_len = 0;
       if (dir == FORWARD) {
@@ -229,7 +229,7 @@ open_line (
           newindent = get_indent();
         }
         if (flags & OPENLINE_DO_COM)
-          lead_len = get_leader_len(ptr, NULL, FALSE, TRUE);
+          lead_len = (int)get_leader_len(ptr, NULL, FALSE, TRUE);
         else
           lead_len = 0;
         if (lead_len > 0) {
@@ -352,7 +352,8 @@ open_line (
    */
   end_comment_pending = NUL;
   if (flags & OPENLINE_DO_COM)
-    lead_len = get_leader_len(saved_line, &lead_flags, dir == BACKWARD, TRUE);
+    lead_len = (int)get_leader_len(saved_line, &lead_flags,
+                                   dir == BACKWARD, TRUE);
   else
     lead_len = 0;
   if (lead_len > 0) {
@@ -949,16 +950,17 @@ theend:
  * If "include_space" is set, include trailing whitespace while calculating the
  * length.
  */
-int get_leader_len(char_u *line, char_u **flags, int backward, int include_space)
+size_t get_leader_len(char_u *line, char_u **flags, int backward,
+                      int include_space)
 {
-  int i, j;
-  int result;
+  size_t i, j;
+  size_t result;
   int got_com = FALSE;
   int found_one;
   char_u part_buf[COM_MAX_LEN];         /* buffer for one option part */
   char_u      *string;                  /* pointer to comment string */
   char_u      *list;
-  int middle_match_len = 0;
+  size_t middle_match_len = 0;
   char_u      *prev_list;
   char_u      *saved_flags = NULL;
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3339,7 +3339,7 @@ find_decl (
       }
       break;
     }
-    if (get_leader_len(get_cursor_line_ptr(), NULL, FALSE, TRUE) > 0) {
+    if (get_leader_len(get_cursor_line_ptr(), NULL, FALSE, TRUE) != 0) {
       /* Ignore this line, continue at start of next line. */
       ++curwin->w_cursor.lnum;
       curwin->w_cursor.col = 0;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3339,7 +3339,6 @@ dis_msg (
 static char_u *skip_comment(char_u *line, int process, int include_space, int *is_comment)
 {
   char_u *comment_flags = NULL;
-  int lead_len;
   int leader_offset = get_last_leader_offset(line, &comment_flags);
 
   *is_comment = FALSE;
@@ -3360,7 +3359,7 @@ static char_u *skip_comment(char_u *line, int process, int include_space, int *i
   if (process == FALSE)
     return line;
 
-  lead_len = get_leader_len(line, &comment_flags, FALSE, include_space);
+  size_t lead_len = get_leader_len(line, &comment_flags, FALSE, include_space);
 
   if (lead_len == 0)
     return line;
@@ -3586,9 +3585,10 @@ theend:
  * the first line.  White-space is ignored.  Note that the whole of
  * 'leader1' must match 'leader2_len' characters from 'leader2' -- webb
  */
-static int same_leader(linenr_T lnum, int leader1_len, char_u *leader1_flags, int leader2_len, char_u *leader2_flags)
+static int same_leader(linenr_T lnum, size_t leader1_len, char_u *leader1_flags,
+                       size_t leader2_len, char_u *leader2_flags)
 {
-  int idx1 = 0, idx2 = 0;
+  size_t idx1 = 0, idx2 = 0;
   char_u  *p;
   char_u  *line1;
   char_u  *line2;
@@ -3779,8 +3779,8 @@ format_lines (
   int is_end_par;                       /* at end of paragraph */
   int prev_is_end_par = FALSE;          /* prev. line not part of parag. */
   int next_is_start_par = FALSE;
-  int leader_len = 0;                   /* leader len of current line */
-  int next_leader_len;                  /* leader len of next line */
+  size_t leader_len = 0;                /* leader len of current line */
+  size_t next_leader_len;               /* leader len of next line */
   char_u      *leader_flags = NULL;     /* flags for leader of current line */
   char_u      *next_leader_flags;       /* flags for leader of next line */
   int do_comments;                      /* format comments */
@@ -3811,14 +3811,12 @@ format_lines (
    * Get info about the previous and current line.
    */
   if (curwin->w_cursor.lnum > 1)
-    is_not_par = fmt_check_par(curwin->w_cursor.lnum - 1
-        , &leader_len, &leader_flags, do_comments
-        );
+    is_not_par = fmt_check_par(curwin->w_cursor.lnum - 1, &leader_len,
+                               &leader_flags, do_comments);
   else
     is_not_par = TRUE;
-  next_is_not_par = fmt_check_par(curwin->w_cursor.lnum
-      , &next_leader_len, &next_leader_flags, do_comments
-      );
+  next_is_not_par = fmt_check_par(curwin->w_cursor.lnum, &next_leader_len,
+                                  &next_leader_flags, do_comments);
   is_end_par = (is_not_par || next_is_not_par);
   if (!is_end_par && do_trail_white)
     is_end_par = !ends_in_white(curwin->w_cursor.lnum - 1);
@@ -3844,9 +3842,10 @@ format_lines (
       next_leader_len = 0;
       next_leader_flags = NULL;
     } else {
-      next_is_not_par = fmt_check_par(curwin->w_cursor.lnum + 1
-          , &next_leader_len, &next_leader_flags, do_comments
-          );
+      next_is_not_par = fmt_check_par(curwin->w_cursor.lnum + 1,
+                                      &next_leader_len,
+                                      &next_leader_flags,
+                                      do_comments);
       if (do_number_indent)
         next_is_start_par =
           (get_number_indent(curwin->w_cursor.lnum + 1) > 0);
@@ -3954,10 +3953,10 @@ format_lines (
         curwin->w_cursor.col = 0;
         if (line_count < 0 && u_save_cursor() == FAIL)
           break;
-        if (next_leader_len > 0) {
+        if (next_leader_len != 0) {
           (void)del_bytes((long)next_leader_len, FALSE, FALSE);
           mark_col_adjust(curwin->w_cursor.lnum, (colnr_T)0, 0L,
-              (long)-next_leader_len);
+                          -((long)next_leader_len));
         } else if (second_indent > 0) {  /* the "leader" for FO_Q_SECOND */
           char_u *p = get_cursor_line_ptr();
           int indent = (int)(skipwhite(p) - p);
@@ -4009,7 +4008,8 @@ static int ends_in_white(linenr_T lnum)
  * previous line.  A new paragraph starts after a blank line, or when the
  * comment leader changes -- webb.
  */
-static int fmt_check_par(linenr_T lnum, int *leader_len, char_u **leader_flags, int do_comments)
+static int fmt_check_par(linenr_T lnum, size_t *leader_len,
+                         char_u **leader_flags, int do_comments)
 {
   char_u      *flags = NULL;        /* init for GCC */
   char_u      *ptr;
@@ -4041,9 +4041,9 @@ static int fmt_check_par(linenr_T lnum, int *leader_len, char_u **leader_flags, 
 int paragraph_start(linenr_T lnum)
 {
   char_u *p;
-  int leader_len = 0;                   /* leader len of current line */
+  size_t leader_len = 0;                /* leader len of current line */
   char_u *leader_flags = NULL;          /* flags for leader of current line */
-  int next_leader_len = 0;              /* leader len of next line */
+  size_t next_leader_len = 0;           /* leader len of next line */
   char_u *next_leader_flags = NULL;     /* flags for leader of next line */
   int do_comments;                      /* format comments */
 
@@ -4055,14 +4055,10 @@ int paragraph_start(linenr_T lnum)
     return TRUE;                /* after empty line */
 
   do_comments = has_format_option(FO_Q_COMS);
-  if (fmt_check_par(lnum - 1
-          , &leader_len, &leader_flags, do_comments
-          ))
+  if (fmt_check_par(lnum - 1, &leader_len, &leader_flags, do_comments))
     return TRUE;                /* after non-paragraph line */
 
-  if (fmt_check_par(lnum
-          , &next_leader_len, &next_leader_flags, do_comments
-          ))
+  if (fmt_check_par(lnum, &next_leader_len, &next_leader_flags, do_comments))
     return TRUE;                /* "lnum" is not a paragraph line */
 
   if (has_format_option(FO_WHITE_PAR) && !ends_in_white(lnum - 1))
@@ -4072,7 +4068,7 @@ int paragraph_start(linenr_T lnum)
     return TRUE;                /* numbered item starts in "lnum". */
 
   if (!same_leader(lnum - 1, leader_len, leader_flags,
-          next_leader_len, next_leader_flags))
+                   next_leader_len, next_leader_flags))
     return TRUE;                /* change of comment leader. */
 
   return FALSE;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3402,6 +3402,10 @@ int do_join(size_t count,
             int use_formatoptions,
             bool setmark)
 {
+  if (count < 2) {
+    return OK;
+  }
+
   char_u      *curr = NULL;
   char_u      *curr_start = NULL;
   char_u      *cend;
@@ -3517,7 +3521,7 @@ int do_join(size_t count,
    * column.  This is not Vi compatible, but Vi deletes the marks, thus that
    * should not really be a problem.
    */
-  for (size_t t = count - 1; t > 0; --t) {
+  for (size_t t = count - 1; ; --t) {
     cend -= currsize;
     memmove(cend, curr, (size_t)currsize);
     if (spaces[t] > 0) {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3396,7 +3396,7 @@ static char_u *skip_comment(char_u *line, int process, int include_space, int *i
 // to set those marks.
 //
 // return FAIL for failure, OK otherwise
-int do_join(long count,
+int do_join(size_t count,
             int insert_space,
             int save_undo,
             int use_formatoptions,
@@ -3411,7 +3411,6 @@ int do_join(long count,
   int endcurr2 = NUL;
   int currsize = 0;             /* size of the current line */
   int sumsize = 0;              /* size of the long new line */
-  linenr_T t;
   colnr_T col = 0;
   int ret = OK;
   int         *comments = NULL;
@@ -3436,7 +3435,7 @@ int do_join(long count,
    * Don't move anything, just compute the final line length
    * and setup the array of space strings lengths
    */
-  for (t = 0; t < count; ++t) {
+  for (size_t t = 0; t < count; ++t) {
     curr = curr_start = ml_get((linenr_T)(curwin->w_cursor.lnum + t));
     if (t == 0 && setmark) {
       // Set the '[ mark.
@@ -3518,14 +3517,14 @@ int do_join(long count,
    * column.  This is not Vi compatible, but Vi deletes the marks, thus that
    * should not really be a problem.
    */
-  for (t = count - 1;; --t) {
+  for (size_t t = count - 1; t > 0; --t) {
     cend -= currsize;
     memmove(cend, curr, (size_t)currsize);
     if (spaces[t] > 0) {
       cend -= spaces[t];
       copy_spaces(cend, (size_t)(spaces[t]));
     }
-    mark_col_adjust(curwin->w_cursor.lnum + t, (colnr_T)0, (linenr_T)-t,
+    mark_col_adjust(curwin->w_cursor.lnum + t, (colnr_T)0, -((linenr_T)t),
         (long)(cend - newp + spaces[t] - (curr - curr_start)));
     if (t == 0)
       break;
@@ -3552,12 +3551,12 @@ int do_join(long count,
   /*
    * Delete following lines. To do this we move the cursor there
    * briefly, and then move it back. After del_lines() the cursor may
-   * have moved up (last line deleted), so the current lnum is kept in t.
+   * have moved up (last line deleted), so the current lnum is kept in tmp.
    */
-  t = curwin->w_cursor.lnum;
+  linenr_T tmp = curwin->w_cursor.lnum;
   ++curwin->w_cursor.lnum;
   del_lines(count - 1, FALSE);
-  curwin->w_cursor.lnum = t;
+  curwin->w_cursor.lnum = tmp;
 
   /*
    * Set the cursor column:

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4239,7 +4239,7 @@ search_line:
           if (!define_matched && skip_comments) {
             if ((*line != '#' ||
                  STRNCMP(skipwhite(line + 1), "define", 6) != 0)
-                && get_leader_len(line, NULL, FALSE, TRUE))
+                && get_leader_len(line, NULL, FALSE, TRUE) != 0)
               matched = FALSE;
 
             /*

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2054,17 +2054,17 @@ spell_move_to (
 {
   linenr_T lnum;
   pos_T found_pos;
-  int found_len = 0;
+  size_t found_len = 0;
   char_u      *line;
   char_u      *p;
   char_u      *endp;
   hlf_T attr;
-  int len;
+  size_t len;
   int has_syntax = syntax_present(wp);
   int col;
   bool can_spell;
   char_u      *buf = NULL;
-  int buflen = 0;
+  size_t buflen = 0;
   int skip = 0;
   int capcol = -1;
   bool found_one = false;
@@ -2088,7 +2088,7 @@ spell_move_to (
   while (!got_int) {
     line = ml_get_buf(wp->w_buffer, lnum, FALSE);
 
-    len = (int)STRLEN(line);
+    len = STRLEN(line);
     if (buflen < len + MAXWLEN + 2) {
       free(buf);
       buflen = len + MAXWLEN + 2;
@@ -2144,9 +2144,8 @@ spell_move_to (
               || lnum != wp->w_cursor.lnum
               || (lnum == wp->w_cursor.lnum
                   && (wrapped
-                      || (colnr_T)(curline ? p - buf + len
-                                   : p - buf)
-                      > wp->w_cursor.col))) {
+                      || (colnr_T)(p - buf + (curline ? len : 0))
+                          > wp->w_cursor.col))) {
             if (has_syntax) {
               col = (int)(p - buf);
               (void)syn_get_id(wp, lnum, (colnr_T)col,


### PR DESCRIPTION
For the time being I fixed only [two](http://neovim.org/doc/build-reports/clang/report-21342f.html#EndPath) [errors](http://neovim.org/doc/build-reports/clang/report-f0c777.html#EndPath) `Argument with 'nonnull' attribute passed null` in `open_line()` from `misc1.c`.
The problem is that `clang` don't know that `int get_leader_len()` can't return something less than 0.
Better solution could be the change of the return type to `size_t` or `uint32_t` but it would involve more changes and I can't decide which type would be the best. Though if it is desirable I would be glad to realise that change.

I plan to fix some more warnings in the future in this PR.
