### PR TITLE
[RFC] vim-patch:7.4.317

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -278,7 +278,7 @@ static int included_patches[] = {
   //320,
   //319 NA
   318,
-  //317,
+  317,
   //316 NA
   315,
   314,

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3730,8 +3730,11 @@ void win_alloc_lines(win_T *wp)
  */
 void win_free_lsize(win_T *wp)
 {
-  free(wp->w_lines);
-  wp->w_lines = NULL;
+  // TODO: why would wp be NULL here?
+  if (wp != NULL) {
+    free(wp->w_lines);
+    wp->w_lines = NULL;
+  }
 }
 
 /*


### PR DESCRIPTION
Problem:    Crash when starting gvim.  Issue 230.
Solution:   Check for a pointer to be NULL. (Christian Brabandt)

https://code.google.com/p/vim/source/detail?r=8ffcb546d782
