### PR TITLE
[RFC] vim-patch:7.4.325

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -270,7 +270,7 @@ static int included_patches[] = {
   328,
   327,
   //326 NA
-  //325,
+  325,
   //324,
   323,
   //322 NA

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4484,7 +4484,12 @@ void win_new_height(win_T *wp, int height)
 
   if (wp->w_height > 0) {
     if (wp == curwin) {
-      validate_cursor();  // w_wrow needs to be valid
+      // w_wrow needs to be valid. When setting 'laststatus' this may
+      // call win_new_height() recursively.
+      validate_cursor();
+    }
+    if (wp->w_height != prev_height) {
+      return;  // Recursive call already changed the size, bail out.
     }
     if (wp->w_wrow != wp->w_prev_fraction_row) {
       set_fraction(wp);


### PR DESCRIPTION
This is another ostensibly GUI-related change that seems worth including because it helps robustness.

---

Problem:    When starting the gui and changing the window size the status line
            may not be drawn correctly.
Solution:   Catch new_win_height() being called recursively. (Christian
            Brabandt)

https://code.google.com/p/vim/source/detail?r=1f288d247548
