### PR TITLE
[RFC] vim-patch:7.4.329

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -266,7 +266,7 @@ static int included_patches[] = {
   //332 NA
   331,
   //330,
-  //329,
+  329,
   328,
   327,
   //326 NA

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3396,12 +3396,19 @@ static void win_enter_ext(win_T *wp, bool undo_sync, int curwin_invalid, int tri
       return;
   }
 
-  /* sync undo before leaving the current buffer */
-  if (undo_sync && curbuf != wp->w_buffer)
+  // sync undo before leaving the current buffer
+  if (undo_sync && curbuf != wp->w_buffer) {
     u_sync(FALSE);
-  /* may have to copy the buffer options when 'cpo' contains 'S' */
-  if (wp->w_buffer != curbuf)
+  }
+
+  // Might need to scroll the old window before switching, e.g., when the
+  // cursor was moved.
+  update_topline();
+
+  // may have to copy the buffer options when 'cpo' contains 'S'
+  if (wp->w_buffer != curbuf) {
     buf_copy_options(wp->w_buffer, BCO_ENTER | BCO_NOHELP);
+  }
   if (!curwin_invalid) {
     prevwin = curwin;           /* remember for CTRL-W p */
     curwin->w_redr_status = TRUE;


### PR DESCRIPTION
Problem:    When moving the cursor and then switching to another window the
            previous window isn't scrolled. (Yukihiro Nakadaira)
Solution:   Call update_topline() before leaving the window. (Christian
            Brabandt)

https://code.google.com/p/vim/source/detail?r=018df65085f8
