### PR TITLE
[RFC] ci: silence non-essential output

### DIFF
--- a/.ci/api-python.sh
+++ b/.ci/api-python.sh
@@ -2,14 +2,14 @@
 
 set_environment /opt/neovim-deps
 
-sudo apt-get install expect valgrind
+sudo apt-get -q install expect valgrind
 
 $MAKE_CMD
 
-git clone --depth=1 -b master git://github.com/neovim/python-client
+git clone -q --depth=1 -b master git://github.com/neovim/python-client
 cd python-client
 sudo pip install .
-sudo pip install nose
+sudo pip install -q nose
 test_cmd="nosetests --verbosity=2"
 nvim_cmd="valgrind -q --track-origins=yes --leak-check=yes --suppressions=$suppressions --log-file=$tmpdir/valgrind-%p.log ../build/bin/nvim -u NONE"
 if ! ../scripts/run-api-tests.exp "$test_cmd" "$nvim_cmd"; then

--- a/.ci/clang-asan.sh
+++ b/.ci/clang-asan.sh
@@ -4,7 +4,7 @@ install_vroom
 
 set_environment /opt/neovim-deps
 
-sudo pip install cpp-coveralls
+sudo pip -q install cpp-coveralls
 
 clang_version=3.4
 if [ ! -d /usr/local/clang-$clang_version ]; then

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -60,7 +60,7 @@ install_prebuilt_deps() {
 	# install prebuilt dependencies
 	if [ ! -d /opt/neovim-deps ]; then
 		cd /opt
-		sudo git clone --depth=1 git://github.com/neovim/deps neovim-deps
+		sudo git clone -q --depth=1 git://github.com/neovim/deps neovim-deps
 		cd -
 	fi
 }
@@ -68,7 +68,7 @@ install_prebuilt_deps() {
 install_vroom() {
 	(
 	sudo pip install neovim
-	git clone git://github.com/google/vroom
+	git clone -q git://github.com/google/vroom
 	cd vroom
 	python setup.py build
 	sudo python setup.py install
@@ -94,4 +94,4 @@ install_prebuilt_deps
 # and avoids a lengthy upgrade process for them.
 sudo apt-mark hold oracle-java7-installer oracle-java8-installer
 
-sudo apt-get update
+sudo apt-get -q update

--- a/.ci/gcc-ia32.sh
+++ b/.ci/gcc-ia32.sh
@@ -6,15 +6,15 @@ set_environment /opt/neovim-deps/32
 
 # Need this to keep apt-get from removing gcc when installing libncurses
 # below.
-sudo apt-get install libc6-dev libc6-dev:i386
+sudo apt-get -q install libc6-dev libc6-dev:i386
 
 # Do this separately so that things get configured correctly, otherwise
 # libncurses fails to install.
-sudo apt-get install gcc-multilib g++-multilib
+sudo apt-get -q install gcc-multilib g++-multilib
 
 # Install the dev version to get the pkg-config and symlinks installed
 # correctly.
-sudo apt-get install libncurses5-dev:i386
+sudo apt-get -q install libncurses5-dev:i386
 
 CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=color_terminal \
 	-DCMAKE_SYSTEM_PROCESSOR=i386 \

--- a/.ci/gcc-unittest.sh
+++ b/.ci/gcc-unittest.sh
@@ -2,7 +2,7 @@
 
 set_environment /opt/neovim-deps
 
-sudo pip install cpp-coveralls
+sudo pip -q install cpp-coveralls
 
 export CC=gcc
 export SKIP_EXEC=1


### PR DESCRIPTION
- Messages related to dependency resolution and third-party installs can
  be silenced without harming visibility in the build logs.
- But keep the messages for Neovim-related installs.
