### PR TITLE
[RFC] CMake: Set executable permissions when installing runtime.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,25 @@ if(BUSTED_PRG)
 endif()
 
 install(DIRECTORY runtime DESTINATION share/nvim)
+
+set(RUNTIME_PROGRAMS
+  runtime/macros/less.sh
+  runtime/tools/efm_filter.pl
+  runtime/tools/efm_perl.pl
+  runtime/tools/mve.awk
+  runtime/tools/pltags.pl
+  runtime/tools/ref
+  runtime/tools/shtags.pl
+  runtime/tools/vim132
+  runtime/tools/vimm
+  runtime/tools/vimspell.sh)
+
+foreach(program ${RUNTIME_PROGRAMS})
+  get_filename_component(program_dir ${program} PATH)
+  file(TO_CMAKE_PATH share/nvim/${program_dir} program_destination)
+  install(PROGRAMS ${program} DESTINATION ${program_destination})
+endforeach()
+
 install(SCRIPT ${CMAKE_MODULE_PATH}/GenerateHelptags.cmake)
 
 # Unfortunately, the below does not work under Ninja.  Ninja doesn't use a


### PR DESCRIPTION
From the [Arch Linux package comments](https://aur.archlinux.org/packages/neovim-git):

> /usr/share/nvim/runtime/macros/less.sh is not executable

This is because CMake's installing step doesn't keep the file permissions by default. Adding `USE_SOURCE_PERMISSIONS` fixes that.
