### PR TITLE
[RFC] clang: Null pointer passed as an argument to a 'nonnull' parameter

### DIFF
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -503,7 +503,7 @@ open_line (
         break;
       }
     }
-    if (lead_len) {
+    if (lead_len > 0) {
       /* allocate buffer (may concatenate p_extra later) */
       leader = xmalloc(lead_len + lead_repl_len + extra_space + extra_len
           + (second_line_indent > 0 ? second_line_indent : 0) + 1);


### PR DESCRIPTION
http://neovim.org/doc/build-reports/clang/report-deb3be.html#EndPath
