### PR TITLE
[RFC] Update busted to version 2.

### DIFF
--- a/.ci/gcc-ia32.sh
+++ b/.ci/gcc-ia32.sh
@@ -16,7 +16,7 @@ sudo apt-get install gcc-multilib g++-multilib
 # correctly.
 sudo apt-get install libncurses5-dev:i386
 
-CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=color_terminal \
+CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
 	-DCMAKE_SYSTEM_PROCESSOR=i386 \
 	-DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32 \
 	-DFIND_LIBRARY_USE_LIB64_PATHS=OFF \

--- a/.ci/gcc-unittest.sh
+++ b/.ci/gcc-unittest.sh
@@ -6,6 +6,6 @@ sudo pip install cpp-coveralls
 
 export CC=gcc
 export SKIP_EXEC=1
-$MAKE_CMD CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DBUSTED_OUTPUT_TYPE=color_terminal -DUSE_GCOV=ON" unittest
+$MAKE_CMD CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DUSE_GCOV=ON" unittest
 
 coveralls --encoding iso-8859-1 || echo 'coveralls upload failed.'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ if(CMAKE_GENERATOR MATCHES "Makefiles")
 endif()
 
 if(NOT BUSTED_OUTPUT_TYPE)
-  set(BUSTED_OUTPUT_TYPE "utf_terminal")
+  set(BUSTED_OUTPUT_TYPE "utfTerminal")
 endif()
 
 if(BUSTED_PRG)

--- a/cmake/RunUnittests.cmake
+++ b/cmake/RunUnittests.cmake
@@ -5,7 +5,7 @@ if(DEFINED ENV{TEST_FILE})
 endif()
 
 execute_process(
-  COMMAND ${BUSTED_PRG} -o ${BUSTED_OUTPUT_TYPE} --lpath=${BUILD_DIR}/?.lua ${TEST_DIR}
+  COMMAND ${BUSTED_PRG} -v -o ${BUSTED_OUTPUT_TYPE} --lpath=${BUILD_DIR}/?.lua ${TEST_DIR}
   WORKING_DIRECTORY ${WORKING_DIR}
   RESULT_VARIABLE res)
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -153,7 +153,7 @@ if(USE_BUNDLED_LUAROCKS)
 
   add_custom_command(OUTPUT ${DEPS_BIN_DIR}/busted
     COMMAND ${DEPS_BIN_DIR}/luarocks
-    ARGS build busted 1.10.0 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
+    ARGS build busted 2.0.rc3 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
     DEPENDS luarocks)
   add_custom_target(busted
     DEPENDS ${DEPS_BIN_DIR}/busted)


### PR DESCRIPTION
Busted 1.x doesn't seem to be supported anymore (no 1.x branch on Github), so I think we have to update sooner or later. I am not sure why the changes to the test files are necessary (or rather, why it worked before), maybe someone can shed light on that?

Also (and this was why I originally tried this) this fixes #1031 (and obsoletes #1092). But (and I only thought about this after I had already created these commits) the `color_terminal` output from #983 won't work with this anymore.

From https://github.com/Olivine-Labs/busted/blob/master/busted/outputHandlers/utfTerminal.lua#L48-L50: a traceback is printed in the default `utfTerminal` output handler if verbose is set, so I changed this to be the default (for local builds as well):

```
Failure → /home/florian/Projects/neovim/test/unit/fileio_spec.lua @ 19
file_pat functions file_pat_to_reg_pat returns ^path$ regex for literal path input
/home/florian/Projects/neovim/test/unit/fileio_spec.lua:20: Expected objects to not be the same. Passed in:
(string) '^path$'
Did not expect:
(string) '^path$'

stack traceback:
    /home/florian/Projects/neovim/test/unit/fileio_spec.lua:19: in function </home/florian/Projects/neovim/test/unit/fileio_spec.lua:12>
```

If there are no errors, the output is the same as non-verbose. Output handlers other than `utfTerminal` and `plainTerminal` don't use the verbose flag.

Would this be an acceptable replacement for `color_terminal` for now? An improved output handler could be sent as a PR to busted, maybe it would even get into 2.0.
