### PR TITLE
[RDY] CMake: Generate helptags during install step.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,8 @@ if(BUSTED_PRG)
     DEPENDS nvim-test unittest-headers)
 endif()
 
-install(DIRECTORY runtime DESTINATION share/nvim/)
+install(DIRECTORY runtime DESTINATION share/nvim)
+install(SCRIPT ${CMAKE_MODULE_PATH}/GenerateHelptags.cmake)
 
 # Unfortunately, the below does not work under Ninja.  Ninja doesn't use a
 # pseudo-tty when launching processes, because it can put many jobs in parallel

--- a/cmake/GenerateHelptags.cmake
+++ b/cmake/GenerateHelptags.cmake
@@ -1,0 +1,15 @@
+message(STATUS "Generating helptags.")
+
+execute_process(
+  COMMAND "${CMAKE_CURRENT_BINARY_DIR}/bin/nvim"
+    -u NONE
+    -esX
+    -c "helptags ++t ."
+    -c quit
+  WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc"
+  ERROR_VARIABLE err
+  RESULT_VARIABLE res)
+
+if(NOT res EQUAL 0)
+  message(FATAL_ERROR "Generating helptags failed: ${err}")
+endif()


### PR DESCRIPTION
Fixes #1056 using the [command from Vim's Makefile](https://code.google.com/p/vim/source/browse/runtime/doc/Makefile#312).

~~It's not very portable yet; I'm sure there's a Windows-compliant way to express `${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc` using some CMake variable, but I couldn't find it.~~ As the runtime is currently always installed into `share/nvim`, I guess this should be OK.

Ping @jszakmeister.
