### PR TITLE
[RDY] FOR_ALL_TAB_WINDOWS cleanup. Add FOR_ALL_TABS and FOR_ALL_WINDOWS_IN_TAB.

### DIFF
--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -7,6 +7,7 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/memory.h"
+#include "nvim/window.h"
 
 /// Gets the number of windows in a tabpage
 ///
@@ -18,27 +19,18 @@ ArrayOf(Window) tabpage_get_windows(Tabpage tabpage, Error *err)
   Array rv = ARRAY_DICT_INIT;
   tabpage_T *tab = find_tab_by_handle(tabpage, err);
 
-  if (!tab) {
+  if (!tab || !valid_tabpage(tab)) {
     return rv;
   }
 
-  tabpage_T *tp;
-  win_T *wp;
-
-  FOR_ALL_TAB_WINDOWS(tp, wp) {
-    if (tp != tab) {
-      break;
-    }
+  FOR_ALL_WINDOWS_IN_TAB(wp, tab) {
     rv.size++;
   }
 
   rv.items = xmalloc(sizeof(Object) * rv.size);
   size_t i = 0;
 
-  FOR_ALL_TAB_WINDOWS(tp, wp) {
-    if (tp != tab) {
-      break;
-    }
+  FOR_ALL_WINDOWS_IN_TAB(wp, tab) {
     rv.items[i++] = WINDOW_OBJ(wp->handle);
   }
 
@@ -90,18 +82,15 @@ Window tabpage_get_window(Tabpage tabpage, Error *err)
   Window rv = 0;
   tabpage_T *tab = find_tab_by_handle(tabpage, err);
 
-  if (!tab) {
+  if (!tab || !valid_tabpage(tab)) {
     return rv;
   }
 
   if (tab == curtab) {
     return vim_get_current_window();
   } else {
-    tabpage_T *tp;
-    win_T *wp;
-
-    FOR_ALL_TAB_WINDOWS(tp, wp) {
-      if (tp == tab && wp == tab->tp_curwin) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, tab) {
+      if (wp == tab->tp_curwin) {
         return wp->handle;
       }
     }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -380,8 +380,6 @@ void vim_set_current_buffer(Buffer buffer, Error *err)
 ArrayOf(Window) vim_get_windows(void)
 {
   Array rv = ARRAY_DICT_INIT;
-  tabpage_T *tp;
-  win_T *wp;
 
   FOR_ALL_TAB_WINDOWS(tp, wp) {
     rv.size++;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -514,13 +514,9 @@ void buf_freeall(buf_T *buf, int flags)
     reset_synblock(curwin);
 
   /* No folds in an empty buffer. */
-  {
-    win_T           *win;
-    tabpage_T       *tp;
-
-    FOR_ALL_TAB_WINDOWS(tp, win) {
-      if (win->w_buffer == buf)
-        clearFolding(win);
+  FOR_ALL_TAB_WINDOWS(tp, win) {
+    if (win->w_buffer == buf) {
+      clearFolding(win);
     }
   }
 
@@ -4206,8 +4202,6 @@ int read_viminfo_bufferlist(vir_T *virp, int writing)
 
 void write_viminfo_bufferlist(FILE *fp)
 {
-  win_T       *win;
-  tabpage_T   *tp;
   char_u      *line;
   int max_buffers;
 
@@ -4284,8 +4278,12 @@ char_u *buf_spname(buf_T *buf)
  */
 bool find_win_for_buf(buf_T *buf, win_T **wp, tabpage_T **tp)
 {
-  FOR_ALL_TAB_WINDOWS(*tp, *wp) {
-    if ((*wp)->w_buffer == buf) {
+  *wp = NULL;
+  *tp = NULL;
+  FOR_ALL_TAB_WINDOWS(tp2, wp2) {
+    if (wp2->w_buffer == buf) {
+      *tp = tp2;
+      *wp = wp2;
       return true;
     }
   }

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -62,8 +62,7 @@ static int diff_a_works = MAYBE;
 /// @param buf
 void diff_buf_delete(buf_T *buf)
 {
-  tabpage_T *tp;
-  for (tp = first_tabpage; tp != NULL; tp = tp->tp_next) {
+  FOR_ALL_TABS(tp) {
     int i = diff_buf_idx_tp(buf, tp);
 
     if (i != DB_COUNT) {
@@ -175,8 +174,7 @@ static int diff_buf_idx_tp(buf_T *buf, tabpage_T *tp)
 /// @param buf
 void diff_invalidate(buf_T *buf)
 {
-  tabpage_T *tp;
-  for (tp = first_tabpage; tp != NULL; tp = tp->tp_next) {
+  FOR_ALL_TABS(tp) {
     int i = diff_buf_idx_tp(buf, tp);
     if (i != DB_COUNT) {
       tp->tp_diff_invalid = TRUE;
@@ -197,8 +195,7 @@ void diff_mark_adjust(linenr_T line1, linenr_T line2, long amount,
                       long amount_after)
 {
   // Handle all tab pages that use the current buffer in a diff.
-  tabpage_T *tp;
-  for (tp = first_tabpage; tp != NULL; tp = tp->tp_next) {
+  FOR_ALL_TABS(tp) {
     int idx = diff_buf_idx_tp(curbuf, tp);
     if (idx != DB_COUNT) {
       diff_mark_adjust_tp(tp, idx, line1, line2, amount, amount_after);
@@ -1819,8 +1816,7 @@ int diffopt_changed(void)
 
   // If "icase" or "iwhite" was added or removed, need to update the diff.
   if (diff_flags != diff_flags_new) {
-    tabpage_T *tp;
-    for (tp = first_tabpage; tp != NULL; tp = tp->tp_next) {
+    FOR_ALL_TABS(tp) {
       tp->tp_diff_invalid = TRUE;
     }
   }
@@ -2376,15 +2372,14 @@ static void diff_fold_update(diff_T *dp, int skip_idx)
 /// @param buf The buffer to check.
 ///
 /// @return TRUE if buffer "buf" is in diff-mode.
-int diff_mode_buf(buf_T *buf)
+bool diff_mode_buf(buf_T *buf)
 {
-  tabpage_T *tp;
-  for (tp = first_tabpage; tp != NULL; tp = tp->tp_next) {
+  FOR_ALL_TABS(tp) {
     if (diff_buf_idx_tp(buf, tp) != DB_COUNT) {
-      return TRUE;
+      return true;
     }
   }
-  return FALSE;
+  return false;
 }
 
 /// Move "count" times in direction "dir" to the next diff block.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5407,7 +5407,6 @@ int garbage_collect(void)
   funccall_T  *fc, **pfc;
   int did_free;
   int did_free_funccal = FALSE;
-  tabpage_T   *tp;
 
   /* Only do this once. */
   want_garbage_collect = FALSE;
@@ -5442,14 +5441,19 @@ int garbage_collect(void)
   }
 
   /* window-local variables */
-  FOR_ALL_TAB_WINDOWS(tp, wp)
-  set_ref_in_item(&wp->w_winvar.di_tv, copyID);
+  {
+    tabpage_T *tp;
+    FOR_ALL_TAB_WINDOWS(tp, wp) {
+      set_ref_in_item(&wp->w_winvar.di_tv, copyID);
+    }
+  }
   if (aucmd_win != NULL)
     set_ref_in_item(&aucmd_win->w_winvar.di_tv, copyID);
 
   /* tabpage-local variables */
-  for (tp = first_tabpage; tp != NULL; tp = tp->tp_next)
+  FOR_ALL_TABS(tp) {
     set_ref_in_item(&tp->tp_winvar.di_tv, copyID);
+  }
 
   /* global variables */
   set_ref_in_ht(&globvarht, copyID);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2962,13 +2962,10 @@ do_ecmd (
 
     /* It's possible that all lines in the buffer changed.  Need to update
      * automatic folding for all windows where it's used. */
-    {
-      win_T           *win;
-      tabpage_T       *tp;
-
-      FOR_ALL_TAB_WINDOWS(tp, win)
-      if (win->w_buffer == curbuf)
+    FOR_ALL_TAB_WINDOWS(tp, win) {
+      if (win->w_buffer == curbuf) {
         foldUpdateAll(win);
+      }
     }
 
     /* Change directories when the 'acd' option is set. */

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1204,7 +1204,6 @@ check_changed_any (
   int bufnum = 0;
   int bufcount = 0;
   int         *bufnrs;
-  tabpage_T   *tp;
 
   FOR_ALL_BUFFERS(buf) {
     ++bufcount;
@@ -1225,7 +1224,7 @@ check_changed_any (
   }
 
   /* buf in other tab */
-  for (tp = first_tabpage; tp != NULL; tp = tp->tp_next) {
+  FOR_ALL_TABS(tp) {
     if (tp != curtab) {
       for (win_T *wp = tp->tp_firstwin; wp != NULL; wp = wp->w_next) {
         add_bufnum(bufnrs, &bufnum, wp->w_buffer->b_fnum);
@@ -1283,6 +1282,7 @@ check_changed_any (
   /* Try to find a window that contains the buffer. */
   if (buf != curbuf) {
     win_T *wp;
+    tabpage_T *tp;
     FOR_ALL_TAB_WINDOWS(tp, wp) {
       if (wp->w_buffer == buf) {
         goto_tabpage_win(tp, wp);

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1226,7 +1226,7 @@ check_changed_any (
   /* buf in other tab */
   FOR_ALL_TABS(tp) {
     if (tp != curtab) {
-      for (win_T *wp = tp->tp_firstwin; wp != NULL; wp = wp->w_next) {
+      FOR_ALL_WINDOWS_IN_TAB(wp, tp) {
         add_bufnum(bufnrs, &bufnum, wp->w_buffer->b_fnum);
       }
     }
@@ -1281,8 +1281,6 @@ check_changed_any (
 
   /* Try to find a window that contains the buffer. */
   if (buf != curbuf) {
-    win_T *wp;
-    tabpage_T *tp;
     FOR_ALL_TAB_WINDOWS(tp, wp) {
       if (wp->w_buffer == buf) {
         goto_tabpage_win(tp, wp);
@@ -1510,12 +1508,11 @@ do_arglist (
  */
 static void alist_check_arg_idx(void)
 {
-  win_T       *win;
-  tabpage_T   *tp;
-
-  FOR_ALL_TAB_WINDOWS(tp, win)
-  if (win->w_alist == curwin->w_alist)
-    check_arg_idx(win);
+  FOR_ALL_TAB_WINDOWS(tp, win) {
+    if (win->w_alist == curwin->w_alist) {
+      check_arg_idx(win);
+    }
+  }
 }
 
 /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5606,18 +5606,21 @@ alist_add (
  */
 void alist_slash_adjust(void)
 {
-  int i;
-  win_T       *wp;
-  tabpage_T   *tp;
-
-  for (i = 0; i < GARGCOUNT; ++i)
-    if (GARGLIST[i].ae_fname != NULL)
+  for (int i = 0; i < GARGCOUNT; ++i) {
+    if (GARGLIST[i].ae_fname != NULL) {
       slash_adjust(GARGLIST[i].ae_fname);
-  FOR_ALL_TAB_WINDOWS(tp, wp)
-  if (wp->w_alist != &global_alist)
-    for (i = 0; i < WARGCOUNT(wp); ++i)
-      if (WARGLIST(wp)[i].ae_fname != NULL)
-        slash_adjust(WARGLIST(wp)[i].ae_fname);
+    }
+  }
+
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
+    if (wp->w_alist != &global_alist) {
+      for (int i = 0; i < WARGCOUNT(wp); ++i) {
+        if (WARGLIST(wp)[i].ae_fname != NULL) {
+          slash_adjust(WARGLIST(wp)[i].ae_fname);
+        }
+      }
+    }
+  }
 }
 
 #endif
@@ -5823,13 +5826,11 @@ static void ex_tabs(exarg_T *eap)
     out_flush();            /* output one line at a time */
     ui_breakcheck();
 
-    win_T *wp;
-    if (tp  == curtab) {
-      wp = firstwin;
-    } else {
-      wp = tp->tp_firstwin;
-    }
-    for (; wp != NULL && !got_int; wp = wp->w_next) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, tp) {
+      if (got_int) {
+        break;
+      }
+
       msg_putchar('\n');
       msg_putchar(wp == curwin ? '>' : ' ');
       msg_putchar(' ');

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5102,16 +5102,15 @@ void buf_reload(buf_T *buf, int orig_mode)
   check_cursor();
   update_topline();
   keep_filetype = FALSE;
-  {
-    win_T       *wp;
-    tabpage_T   *tp;
 
-    /* Update folds unless they are defined manually. */
-    FOR_ALL_TAB_WINDOWS(tp, wp)
+  /* Update folds unless they are defined manually. */
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
     if (wp->w_buffer == curwin->w_buffer
-        && !foldmethodIsManual(wp))
+        && !foldmethodIsManual(wp)) {
       foldUpdateAll(wp);
+    }
   }
+
   /* If the mode didn't change and 'readonly' was set, keep the old
    * value; the user probably used the ":view" command.  But don't
    * reset it, might have had a read error. */
@@ -6269,14 +6268,11 @@ aucmd_restbuf (
      * page. Do not trigger autocommands here. */
     block_autocmds();
     if (curwin != aucmd_win) {
-      tabpage_T   *tp;
-      win_T       *wp;
-
-      FOR_ALL_TAB_WINDOWS(tp, wp)
-      {
+      FOR_ALL_TAB_WINDOWS(tp, wp) {
         if (wp == aucmd_win) {
-          if (tp != curtab)
+          if (tp != curtab) {
             goto_tabpage_tp(tp, TRUE, TRUE);
+          }
           win_goto(aucmd_win);
           goto win_found;
         }

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -548,6 +548,9 @@ EXTERN tabpage_T    *first_tabpage;
 EXTERN tabpage_T    *curtab;
 EXTERN int redraw_tabline INIT(= FALSE);           /* need to redraw tabline */
 
+// Iterates over all tabs in the tab list
+# define FOR_ALL_TABS(tp) for (tabpage_T *tp = first_tabpage; tp != NULL; tp = tp->tp_next)
+
 /*
  * All buffers are linked in a list. 'firstbuf' points to the first entry,
  * 'lastbuf' to the last entry and 'curbuf' to the currently active buffer.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -525,9 +525,12 @@ EXTERN win_T    *prevwin INIT(= NULL);  /* previous window */
  * to break out of the tabpage loop.
  */
 # define FOR_ALL_TAB_WINDOWS(tp, wp) \
-  for ((tp) = first_tabpage; (tp) != NULL; (tp) = (tp)->tp_next) \
-    for ((wp) = ((tp) == curtab) \
-                ? firstwin : (tp)->tp_firstwin; (wp); (wp) = (wp)->w_next)
+  FOR_ALL_TABS(tp) \
+    FOR_ALL_WINDOWS_IN_TAB(wp, tp)
+
+# define FOR_ALL_WINDOWS_IN_TAB(wp, tp) \
+  for (win_T *wp = ((tp) == curtab) \
+              ? firstwin : (tp)->tp_firstwin; wp != NULL; wp = wp->w_next)
 
 EXTERN win_T    *curwin;        /* currently active window */
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -519,7 +519,8 @@ EXTERN win_T    *firstwin;              /* first window */
 EXTERN win_T    *lastwin;               /* last window */
 EXTERN win_T    *prevwin INIT(= NULL);  /* previous window */
 # define W_NEXT(wp) ((wp)->w_next)
-# define FOR_ALL_WINDOWS(wp) for (win_T *wp = firstwin; wp != NULL; wp = wp->w_next)
+# define FOR_ALL_WINDOWS(wp) \
+   FOR_ALL_WINDOWS_IN_TAB(wp, curtab)
 /*
  * When using this macro "break" only breaks out of the inner loop. Use "goto"
  * to break out of the tabpage loop.

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -758,7 +758,6 @@ main_loop (
 /* Exit properly */
 void getout(int exitval)
 {
-  win_T       *wp;
   tabpage_T   *tp, *next_tp;
 
   exiting = TRUE;
@@ -780,11 +779,12 @@ void getout(int exitval)
     /* Trigger BufWinLeave for all windows, but only once per buffer. */
     for (tp = first_tabpage; tp != NULL; tp = next_tp) {
       next_tp = tp->tp_next;
-      for (wp = (tp == curtab)
-          ? firstwin : tp->tp_firstwin; wp != NULL; wp = wp->w_next) {
-        if (wp->w_buffer == NULL)
+      FOR_ALL_WINDOWS_IN_TAB(wp, tp) {
+        if (wp->w_buffer == NULL) {
           /* Autocmd must have close the buffer already, skip. */
           continue;
+        }
+
         buf_T *buf = wp->w_buffer;
         if (buf->b_changedtick != -1) {
           apply_autocmds(EVENT_BUFWINLEAVE, buf->b_fname,

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -452,13 +452,9 @@ void free_all_mem(void)
   p_hi = 0;
   init_history();
 
-  {
-    win_T       *win;
-    tabpage_T   *tab;
-
-    qf_free_all(NULL);
-    /* Free all location lists */
-    FOR_ALL_TAB_WINDOWS(tab, win)
+  qf_free_all(NULL);
+  /* Free all location lists */
+  FOR_ALL_TAB_WINDOWS(tab, win) {
     qf_free_all(win);
   }
 

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2027,8 +2027,6 @@ changed_lines_buf (
  */
 static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, long xtra)
 {
-  win_T       *wp;
-  tabpage_T   *tp;
   int i;
   int cols;
   pos_T       *p;
@@ -2072,21 +2070,21 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, long xtra
           curbuf->b_changelistlen = JUMPLISTSIZE - 1;
           memmove(curbuf->b_changelist, curbuf->b_changelist + 1,
               sizeof(pos_T) * (JUMPLISTSIZE - 1));
-          FOR_ALL_TAB_WINDOWS(tp, wp)
-          {
+          FOR_ALL_TAB_WINDOWS(tp, wp) {
             /* Correct position in changelist for other windows on
              * this buffer. */
-            if (wp->w_buffer == curbuf && wp->w_changelistidx > 0)
+            if (wp->w_buffer == curbuf && wp->w_changelistidx > 0) {
               --wp->w_changelistidx;
+            }
           }
         }
-        FOR_ALL_TAB_WINDOWS(tp, wp)
-        {
+        FOR_ALL_TAB_WINDOWS(tp, wp) {
           /* For other windows, if the position in the changelist is
            * at the end it stays at the end. */
           if (wp->w_buffer == curbuf
-              && wp->w_changelistidx == curbuf->b_changelistlen)
+              && wp->w_changelistidx == curbuf->b_changelistlen) {
             ++wp->w_changelistidx;
+          }
         }
         ++curbuf->b_changelistlen;
       }
@@ -2098,8 +2096,7 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, long xtra
     curwin->w_changelistidx = curbuf->b_changelistlen;
   }
 
-  FOR_ALL_TAB_WINDOWS(tp, wp)
-  {
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
     if (wp->w_buffer == curbuf) {
       /* Mark this window to be redrawn later. */
       if (wp->w_redr_type < VALID)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2210,17 +2210,16 @@ set_options_default (
     int opt_flags                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
 )
 {
-  int i;
-  win_T       *wp;
-  tabpage_T   *tp;
-
-  for (i = 0; !istermoption(&options[i]); i++)
-    if (!(options[i].flags & P_NODEFAULT))
+  for (int i = 0; !istermoption(&options[i]); i++) {
+    if (!(options[i].flags & P_NODEFAULT)) {
       set_option_default(i, opt_flags, p_cp);
+    }
+  }
 
   /* The 'scroll' option must be computed for all windows. */
-  FOR_ALL_TAB_WINDOWS(tp, wp)
-  win_comp_scroll(wp);
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
+    win_comp_scroll(wp);
+  }
 }
 
 /// Set the Vi-default value of a string option.
@@ -5532,13 +5531,11 @@ set_num_option (
       errmsg = e_positive;
       curbuf->b_p_tw = 0;
     }
-    {
-      win_T       *wp;
-      tabpage_T   *tp;
 
-      FOR_ALL_TAB_WINDOWS(tp, wp)
+    FOR_ALL_TAB_WINDOWS(tp, wp) {
       check_colorcolumn(wp);
     }
+
   }
 
   /*

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1466,11 +1466,7 @@ void qf_jump(qf_info_T *qi, int dir, int errornr, int forceit)
      * then search in other tabs.
      */
     if (!usable_win && (swb_flags & SWB_USETAB)) {
-      tabpage_T   *tp;
-      win_T       *wp;
-
-      FOR_ALL_TAB_WINDOWS(tp, wp)
-      {
+      FOR_ALL_TAB_WINDOWS(tp, wp) {
         if (wp->w_buffer->b_fnum == qf_ptr->qf_fnum) {
           goto_tabpage_win(tp, wp);
           usable_win = true;
@@ -2236,12 +2232,11 @@ static win_T *qf_find_win(qf_info_T *qi)
  */
 static buf_T *qf_find_buf(qf_info_T *qi)
 {
-  tabpage_T   *tp;
-  win_T       *win;
-
-  FOR_ALL_TAB_WINDOWS(tp, win)
-  if (is_qf_win(win, qi))
-    return win->w_buffer;
+  FOR_ALL_TAB_WINDOWS(tp, win) {
+    if (is_qf_win(win, qi)) {
+      return win->w_buffer;
+    }
+  }
 
   return NULL;
 }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7632,7 +7632,6 @@ void unshowmode(int force)
 static void draw_tabline(void)
 {
   int tabcount = 0;
-  tabpage_T   *tp;
   int tabwidth;
   int col = 0;
   int scol = 0;
@@ -7675,8 +7674,9 @@ static void draw_tabline(void)
           (char_u *)"", OPT_FREE, SID_ERROR);
     called_emsg |= save_called_emsg;
   } else {
-    for (tp = first_tabpage; tp != NULL; tp = tp->tp_next)
+    FOR_ALL_TABS(tp) {
       ++tabcount;
+    }
 
     tabwidth = (Columns - 1 + tabcount / 2) / tabcount;
     if (tabwidth < 6)
@@ -7685,8 +7685,12 @@ static void draw_tabline(void)
     attr = attr_nosel;
     tabcount = 0;
     scol = 0;
-    for (tp = first_tabpage; tp != NULL && col < Columns - 4;
-         tp = tp->tp_next) {
+
+    FOR_ALL_TABS(tp) {
+      if (col >= Columns - 4) {
+        break;
+      }
+
       scol = col;
 
       if (tp->tp_topframe == topframe)

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6263,7 +6263,6 @@ int screen_valid(int doclear)
 void screenalloc(bool doclear)
 {
   int new_row, old_row;
-  win_T           *wp;
   int outofmem = FALSE;
   int len;
   schar_T         *new_ScreenLines;
@@ -6275,7 +6274,6 @@ void screenalloc(bool doclear)
   unsigned        *new_LineOffset;
   char_u          *new_LineWraps;
   short           *new_TabPageIdxs;
-  tabpage_T       *tp;
   static int entered = FALSE;                   /* avoid recursiveness */
   static int done_outofmem_msg = FALSE;         /* did outofmem message */
   int retry_count = 0;
@@ -6328,8 +6326,9 @@ retry:
    * Continuing with the old ScreenLines may result in a crash, because the
    * size is wrong.
    */
-  FOR_ALL_TAB_WINDOWS(tp, wp)
-  win_free_lsize(wp);
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
+    win_free_lsize(wp);
+  }
   if (aucmd_win != NULL)
     win_free_lsize(aucmd_win);
 
@@ -6349,8 +6348,7 @@ retry:
   new_LineWraps = xmalloc((size_t)(Rows * sizeof(char_u)));
   new_TabPageIdxs = xmalloc((size_t)(Columns * sizeof(short)));
 
-  FOR_ALL_TAB_WINDOWS(tp, wp)
-  {
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
     win_alloc_lines(wp);
   }
   if (aucmd_win != NULL && aucmd_win->w_lines == NULL) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1674,13 +1674,12 @@ close_windows (
     int keep_curwin                    /* don't close "curwin" */
 )
 {
-  win_T       *wp;
   tabpage_T   *tp, *nexttp;
   int h = tabline_height();
 
   ++RedrawingDisabled;
 
-  for (wp = firstwin; wp != NULL && lastwin != firstwin; ) {
+  for (win_T *wp = firstwin; wp != NULL && lastwin != firstwin; ) {
     if (wp->w_buffer == buf && (!keep_curwin || wp != curwin)
         && !(wp->w_closing || wp->w_buffer->b_closing)
         ) {
@@ -1695,8 +1694,8 @@ close_windows (
   /* Also check windows in other tab pages. */
   for (tp = first_tabpage; tp != NULL; tp = nexttp) {
     nexttp = tp->tp_next;
-    if (tp != curtab)
-      for (wp = tp->tp_firstwin; wp != NULL; wp = wp->w_next)
+    if (tp != curtab) {
+      FOR_ALL_WINDOWS_IN_TAB(wp, tp) {
         if (wp->w_buffer == buf
             && !(wp->w_closing || wp->w_buffer->b_closing)
             ) {
@@ -1707,6 +1706,8 @@ close_windows (
           nexttp = first_tabpage;
           break;
         }
+      }
+    }
   }
 
   --RedrawingDisabled;
@@ -1963,7 +1964,6 @@ int win_close(win_T *win, int free_buf)
  */
 void win_close_othertab(win_T *win, int free_buf, tabpage_T *tp)
 {
-  win_T       *wp;
   int dir;
   tabpage_T   *ptp = NULL;
   int free_tp = FALSE;
@@ -1982,10 +1982,18 @@ void win_close_othertab(win_T *win, int free_buf, tabpage_T *tp)
     return;
 
   /* Autocommands may have closed the window already. */
-  for (wp = tp->tp_firstwin; wp != NULL && wp != win; wp = wp->w_next)
-    ;
-  if (wp == NULL)
-    return;
+  {
+    bool found_window = false;
+    FOR_ALL_WINDOWS_IN_TAB(wp, tp) {
+      if (wp == win) {
+         found_window = true;
+         break;
+      }
+    }
+    if (!found_window) {
+       return;
+    }
+  }
 
   /* When closing the last window in a tab page remove the tab page. */
   if (tp->tp_firstwin == tp->tp_lastwin) {
@@ -3285,14 +3293,11 @@ void win_goto(win_T *wp)
  */
 tabpage_T *win_find_tabpage(win_T *win)
 {
-  win_T       *wp;
-  tabpage_T   *tp;
-
-  for (tp = first_tabpage; tp != NULL; tp = tp->tp_next)
-    for (wp = (tp == curtab ? firstwin : tp->tp_firstwin);
-         wp != NULL; wp = wp->w_next)
-      if (wp == win)
-        return tp;
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
+    if (wp == win) {
+      return tp;
+    }
+  }
   return NULL;
 }
 
@@ -3549,28 +3554,36 @@ win_T *buf_jump_open_win(buf_T *buf)
  */
 win_T *buf_jump_open_tab(buf_T *buf)
 {
-  win_T       *wp;
 
-  /* First try the current tab page. */
-  wp = buf_jump_open_win(buf);
-  if (wp != NULL)
-    return wp;
+  // First try the current tab page.
+  {
+    win_T *wp = buf_jump_open_win(buf);
+    if (wp != NULL)
+      return wp;
+  }
 
   FOR_ALL_TABS(tp) {
+    // Skip the current tab since we already checked it.
     if (tp != curtab) {
-      for (wp = tp->tp_firstwin; wp != NULL; wp = wp->w_next)
-        if (wp->w_buffer == buf)
-          break;
-      if (wp != NULL) {
-        goto_tabpage_win(tp, wp);
-        if (curwin != wp)
-          wp = NULL;            /* something went wrong */
-        break;
+      FOR_ALL_WINDOWS_IN_TAB(wp, tp) {
+        if (wp->w_buffer == buf) {
+          goto_tabpage_win(tp, wp);
+
+          // If we the current window didn't switch,
+          // something went wrong.
+          if (curwin != wp) {
+            wp = NULL;
+          }
+
+          // Return the window we switched to.
+          return wp;
+        }
       }
     }
   }
 
-  return wp;
+  // If we made it this far, we didn't find the buffer.
+  return NULL;
 }
 
 /*
@@ -5011,16 +5024,15 @@ int only_one_window(void)
  */
 void check_lnums(int do_curwin)
 {
-  win_T       *wp;
-
-  tabpage_T   *tp;
-
-  FOR_ALL_TAB_WINDOWS(tp, wp)
-  if ((do_curwin || wp != curwin) && wp->w_buffer == curbuf) {
-    if (wp->w_cursor.lnum > curbuf->b_ml.ml_line_count)
-      wp->w_cursor.lnum = curbuf->b_ml.ml_line_count;
-    if (wp->w_topline > curbuf->b_ml.ml_line_count)
-      wp->w_topline = curbuf->b_ml.ml_line_count;
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
+    if ((do_curwin || wp != curwin) && wp->w_buffer == curbuf) {
+      if (wp->w_cursor.lnum > curbuf->b_ml.ml_line_count) {
+        wp->w_cursor.lnum = curbuf->b_ml.ml_line_count;
+      }
+      if (wp->w_topline > curbuf->b_ml.ml_line_count) {
+        wp->w_topline = curbuf->b_ml.ml_line_count;
+      }
+    }
   }
 }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2986,14 +2986,14 @@ int make_tabpages(int maxcount)
 /*
  * Return TRUE when "tpc" points to a valid tab page.
  */
-int valid_tabpage(tabpage_T *tpc)
+bool valid_tabpage(tabpage_T *tpc)
 {
-  tabpage_T   *tp;
-
-  for (tp = first_tabpage; tp != NULL; tp = tp->tp_next)
-    if (tp == tpc)
-      return TRUE;
-  return FALSE;
+  FOR_ALL_TABS(tp) {
+    if (tp == tpc) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /*
@@ -3550,14 +3550,13 @@ win_T *buf_jump_open_win(buf_T *buf)
 win_T *buf_jump_open_tab(buf_T *buf)
 {
   win_T       *wp;
-  tabpage_T   *tp;
 
   /* First try the current tab page. */
   wp = buf_jump_open_win(buf);
   if (wp != NULL)
     return wp;
 
-  for (tp = first_tabpage; tp != NULL; tp = tp->tp_next)
+  FOR_ALL_TABS(tp) {
     if (tp != curtab) {
       for (wp = tp->tp_firstwin; wp != NULL; wp = wp->w_next)
         if (wp->w_buffer == buf)
@@ -3569,6 +3568,7 @@ win_T *buf_jump_open_tab(buf_T *buf)
         break;
       }
     }
+  }
 
   return wp;
 }
@@ -4963,18 +4963,15 @@ int tabline_height(void)
  */
 int min_rows(void)
 {
-  int total;
-  tabpage_T   *tp;
-  int n;
-
   if (firstwin == NULL)         /* not initialized yet */
     return MIN_LINES;
 
-  total = 0;
-  for (tp = first_tabpage; tp != NULL; tp = tp->tp_next) {
-    n = frame_minheight(tp->tp_topframe, NULL);
-    if (total < n)
+  int total = 0;
+  FOR_ALL_TABS(tp) {
+    int n = frame_minheight(tp->tp_topframe, NULL);
+    if (total < n) {
       total = n;
+    }
   }
   total += tabline_height();
   total += 1;           /* count the room for the command line */


### PR DESCRIPTION
Adds `FOR_ALL_TABS` and `FOR_ALL_WINDOWS_IN_TAB`. These combine together to make the `FOR_ALL_TAB_WINDOWS` helper that already existed.
