### PR TITLE
[RFC] CMake: Use DESTDIR for helptags generation.

### DIFF
--- a/cmake/GenerateHelptags.cmake
+++ b/cmake/GenerateHelptags.cmake
@@ -1,4 +1,8 @@
-message(STATUS "Generating helptags.")
+file(TO_CMAKE_PATH
+  "$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc"
+  HELPTAGS_WORKING_DIRECTORY)
+
+message(STATUS "Generating helptags in ${HELPTAGS_WORKING_DIRECTORY}.")
 
 execute_process(
   COMMAND "${CMAKE_CURRENT_BINARY_DIR}/bin/nvim"
@@ -6,7 +10,8 @@ execute_process(
     -esX
     -c "helptags ++t ."
     -c quit
-  WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc"
+  WORKING_DIRECTORY "${HELPTAGS_WORKING_DIRECTORY}"
+  OUTPUT_VARIABLE err
   ERROR_VARIABLE err
   RESULT_VARIABLE res)
 


### PR DESCRIPTION
When `DESTDIR` is used (`make DESTDIR=... install`), it is [ignored by the helptags generation](https://aur.archlinux.org/packages/neovim-git) (#1106), so during package building, instead of running the command in e.g. `/home/user/neovim-package/build/usr/local/share/nvim/...` it tries to execute in `/usr/local/share/nvim/...`, which is not what it's supposed to do. Adding `DESTDIR` to the working directory should fix that.

Ping @jszakmeister. Sorry about that :-(
