### PR TITLE
[RFC] Update luarocks: Use commit with correct version number.

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -55,8 +55,8 @@ set(MSGPACK_MD5 ea0bee0939d2980c0df91f0e4843ccc4)
 set(LUAJIT_URL http://luajit.org/download/LuaJIT-2.0.3.tar.gz)
 set(LUAJIT_MD5 f14e9104be513913810cd59c8c658dc0)
 
-set(LUAROCKS_URL https://github.com/keplerproject/luarocks/archive/v2.2.0.tar.gz)
-set(LUAROCKS_MD5 881321272f2d2ac0811baf03a3fc6f77)
+set(LUAROCKS_URL https://github.com/keplerproject/luarocks/archive/0587afbb5fe8ceb2f2eea16f486bd6183bf02f29.tar.gz)
+set(LUAROCKS_MD5 0f53f42909fbcd2c88be303e8f970516)
 
 if(USE_BUNDLED_LIBUV)
   ExternalProject_Add(libuv


### PR DESCRIPTION
Luarocks 2.2.0 release has a wrong version number, which is fixed in later commits (https://github.com/keplerproject/luarocks/commit/ffba28653288f695515910f156b8dd4d74cc4005, https://github.com/keplerproject/luarocks/commit/0587afbb5fe8ceb2f2eea16f486bd6183bf02f29). There are are [no intermediate commits in the history since the 2.2.0 release](https://github.com/keplerproject/luarocks/compare/v2.2.0...0587afbb5fe8ceb2f2eea16f486bd6183bf02f29), so it is safe to use the latest, keplerproject/luarocks@0587afb.
