### PR TITLE
[RFC] clang: Null pointer passed as an argument to a 'nonnull' parameter

### DIFF
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -737,7 +737,7 @@ open_line (
     p_extra = (char_u *)"";                 /* append empty line */
 
   /* concatenate leader and p_extra, if there is a leader */
-  if (lead_len) {
+  if (lead_len > 0) {
     if (flags & OPENLINE_COM_LIST && second_line_indent > 0) {
       int i;
       int padding = second_line_indent


### PR DESCRIPTION
http://neovim.org/doc/reports/clang/report-f8d66a.html#EndPath

related https://github.com/neovim/neovim/pull/1090
