### PR TITLE
[RFC] fix unittest issues with busted 2.x

### DIFF
--- a/test/unit/buffer_spec.lua
+++ b/test/unit/buffer_spec.lua
@@ -9,11 +9,6 @@ local buffer = helpers.cimport("./src/nvim/buffer.h")
 local window = helpers.cimport("./src/nvim/window.h")
 local option = helpers.cimport("./src/nvim/option.h")
 
---{ Initialize the options needed for interacting with buffers
-window.win_alloc_first()
-option.set_init_1()
---}
-
 describe('buffer functions', function()
 
   local buflist_new = function(file, flags)

--- a/test/unit/formatc.lua
+++ b/test/unit/formatc.lua
@@ -212,17 +212,20 @@ local function formatc(str)
   return table.concat(result)
 end
 
--- uncomment the following lines (and comment the return) for standalone
--- operation (very handy for debugging)
+-- standalone operation (very handy for debugging)
 local function standalone(...)
   Preprocess = require("preprocess")
   Preprocess.add_to_include_path('./../../src')
   Preprocess.add_to_include_path('./../../build/include')
   Preprocess.add_to_include_path('./../../.deps/usr/include')
 
-  input = Preprocess.preprocess_stream(arg[1])
+  local input = Preprocess.preprocess_stream(arg[1])
   local raw = input:read('*all')
   input:close()
+
+  if raw == nil then
+    print("ERROR: Preprocess.preprocess_stream():read() returned empty")
+  end
 
   local formatted
   if #arg == 2 and arg[2] == 'no' then
@@ -233,6 +236,9 @@ local function standalone(...)
 
   print(formatted)
 end
+-- uncomment this line (and comment the `return`) for standalone debugging
+-- example usage:
+--    ../../.deps/usr/bin/luajit formatc.lua ../../include/tempfile.h.generated.h
+--    ../../.deps/usr/bin/luajit formatc.lua /usr/include/malloc.h
 -- standalone(...)
-
 return formatc

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -64,10 +64,15 @@ function cimport(...)
     return libnvim
   end
 
-  -- preprocess the header
-  local stream = Preprocess.preprocess_stream(unpack(paths))
-  local body = stream:read("*a")
-  stream:close()
+  -- require 'pl.pretty'.dump(paths)
+  local body = nil
+  for i=1, 3 do
+    local stream = Preprocess.preprocess_stream(unpack(paths))
+    body = stream:read("*a")
+    stream:close()
+    if body ~= nil then break end
+  end
+  -- require 'pl.pretty'.dump(body)
 
   -- format it (so that the lines are "unique" statements), also filter out
   -- Objective-C blocks

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -127,8 +127,25 @@ local function vim_init()
     return 
   end
   -- import os_unix.h for mch_early_init(), which initializes some globals
-  local os = cimport('./src/nvim/os_unix.h')
-  os.mch_early_init()
+  local all = cimport('./src/nvim/os_unix.h',
+                      './src/nvim/misc1.h',
+                      './src/nvim/eval.h',
+                      './src/nvim/os_unix.h',
+                      './src/nvim/option.h',
+                      './src/nvim/ex_cmds2.h',
+                      './src/nvim/window.h',
+                      './src/nvim/ops.h',
+                      './src/nvim/normal.h',
+                      './src/nvim/mbyte.h')
+  all.mch_early_init()
+  all.mb_init()
+  all.eval_init()
+  all.init_normal_cmds()
+  all.win_alloc_first()
+  all.init_yank()
+  all.init_homedir()
+  all.set_init_1()
+  all.set_lang_var()
   vim_init_called = true
 end
 

--- a/test/unit/os/fs_spec.lua
+++ b/test/unit/os/fs_spec.lua
@@ -15,16 +15,22 @@ local FAIL = helpers.FAIL
 require('lfs')
 require('bit')
 
+cimport('unistd.h')
 local fs = cimport('./src/nvim/os/os.h')
 cppimport('sys/stat.h')
 cppimport('sys/fcntl.h')
 cppimport('sys/errno.h')
 
-function assert_file_exists(filepath)
+local len = 0
+local buf = ""
+local directory = nil
+local executable_name = nil
+
+local function assert_file_exists(filepath)
   eq(false, nil == (lfs.attributes(filepath, 'r')))
 end
 
-function assert_file_does_not_exist(filepath)
+local function assert_file_does_not_exist(filepath)
   eq(true, nil == (lfs.attributes(filepath, 'r')))
 end
 
@@ -37,7 +43,7 @@ describe('fs function', function()
     lfs.link('test.file', 'unit-test-directory/test_link.file', true)
     -- Since the tests are executed, they are called by an executable. We use
     -- that executable for several asserts.
-    absolute_executable = arg[0]
+    local absolute_executable = arg[0]
     -- Split absolute_executable into a directory and the actual file name for
     -- later usage.
     directory, executable_name = string.match(absolute_executable, '^(.*)/(.*)$')
@@ -52,7 +58,7 @@ describe('fs function', function()
   end)
 
   describe('os_dirname', function()
-    function os_dirname(buf, len)
+    local function os_dirname(buf, len)
       return fs.os_dirname(buf, len)
     end
 
@@ -73,7 +79,7 @@ describe('fs function', function()
     end)
   end)
 
-  function os_isdir(name)
+  local function os_isdir(name)
     return fs.os_isdir((to_cstr(name)))
   end
 
@@ -112,7 +118,7 @@ describe('fs function', function()
   end)
 
   describe('os_can_exe', function()
-    function os_can_exe(name)
+    local function os_can_exe(name)
       return fs.os_can_exe((to_cstr(name)))
     end
 
@@ -142,39 +148,39 @@ describe('fs function', function()
   end)
 
   describe('file permissions', function()
-    function os_getperm(filename)
+    local function os_getperm(filename)
       local perm = fs.os_getperm((to_cstr(filename)))
       return tonumber(perm)
     end
 
-    function os_setperm(filename, perm)
+    local function os_setperm(filename, perm)
       return fs.os_setperm((to_cstr(filename)), perm)
     end
 
-    function os_fchown(filename, user_id, group_id)
+    local function os_fchown(filename, user_id, group_id)
       local fd = ffi.C.open(filename, 0)
       local res = fs.os_fchown(fd, user_id, group_id)
       ffi.C.close(fd)
       return res
     end
 
-    function os_file_is_readonly(filename)
+    local function os_file_is_readonly(filename)
       return fs.os_file_is_readonly((to_cstr(filename)))
     end
 
-    function os_file_is_writable(filename)
+    local function os_file_is_writable(filename)
       return fs.os_file_is_writable((to_cstr(filename)))
     end
 
-    function bit_set(number, check_bit)
+    local function bit_set(number, check_bit)
       return 0 ~= (bit.band(number, check_bit))
     end
 
-    function set_bit(number, to_set)
+    local function set_bit(number, to_set)
       return bit.bor(number, to_set)
     end
 
-    function unset_bit(number, to_unset)
+    local function unset_bit(number, to_unset)
       return bit.band(number, (bit.bnot(to_unset)))
     end
 
@@ -295,19 +301,19 @@ describe('fs function', function()
   end)
 
   describe('file operations', function()
-    function os_file_exists(filename)
+    local function os_file_exists(filename)
       return fs.os_file_exists((to_cstr(filename)))
     end
 
-    function os_rename(path, new_path)
+    local function os_rename(path, new_path)
       return fs.os_rename((to_cstr(path)), (to_cstr(new_path)))
     end
 
-    function os_remove(path)
+    local function os_remove(path)
       return fs.os_remove((to_cstr(path)))
     end
 
-    function os_open(path, flags, mode)
+    local function os_open(path, flags, mode)
       return fs.os_open((to_cstr(path)), flags, mode)
     end
 
@@ -428,11 +434,11 @@ describe('fs function', function()
   end)
 
   describe('folder operations', function()
-    function os_mkdir(path, mode)
+    local function os_mkdir(path, mode)
       return fs.os_mkdir(to_cstr(path), mode)
     end
 
-    function os_rmdir(path)
+    local function os_rmdir(path)
       return fs.os_rmdir(to_cstr(path))
     end
 
@@ -465,18 +471,18 @@ describe('fs function', function()
   end)
 
   describe('FileInfo', function()
-    function file_info_new()
+    local function file_info_new()
       local file_info = ffi.new('FileInfo[1]')
       file_info[0].stat.st_ino = 0
       file_info[0].stat.st_dev = 0
       return file_info
     end
 
-    function is_file_info_filled(file_info)
+    local function is_file_info_filled(file_info)
       return file_info[0].stat.st_ino > 0 and file_info[0].stat.st_dev > 0
     end
 
-    function file_id_new()
+    local function file_id_new()
       local file_info = ffi.new('FileID[1]')
       file_info[0].inode = 0
       file_info[0].device_id = 0

--- a/test/unit/os/shell_spec.lua
+++ b/test/unit/os/shell_spec.lua
@@ -24,11 +24,7 @@ local NULL = ffi.cast('void *', 0)
 
 describe('shell functions', function()
   setup(function()
-    -- the logging functions are complain if I don't do this
-    shell.init_homedir()
-
     shell.event_init()
-
     -- os_system() can't work when the p_sh and p_shcf variables are unset
     shell.p_sh = to_cstr('/bin/bash')
     shell.p_shcf = to_cstr('-c')

--- a/test/unit/path_spec.lua
+++ b/test/unit/path_spec.lua
@@ -13,6 +13,7 @@ local OK = helpers.OK
 local FAIL = helpers.FAIL
 
 require('lfs')
+cimport('string.h')
 local path = cimport('./src/nvim/path.h')
 
 -- import constants parsed by ffi
@@ -21,6 +22,9 @@ local kDifferentFiles = path.kDifferentFiles
 local kBothFilesMissing = path.kBothFilesMissing
 local kOneFileMissing = path.kOneFileMissing
 local kEqualFileNames = path.kEqualFileNames
+
+local len = 0
+local buffer = nil
 
 describe('path function', function()
   describe('path_full_dir_name', function()

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -23,7 +23,7 @@ table.insert(ccs, {path = "/usr/bin/env clang", type = "clang"})
 table.insert(ccs, {path = "/usr/bin/env icc", type = "gcc"})
 
 local quote_me = '[^%w%+%-%=%@%_%/]' -- complement (needn't quote)
-function shell_quote(str)
+local function shell_quote(str)
   if string.find(str, quote_me) or str == '' then
     return "'" .. string.gsub(str, "'", [['"'"']]) .. "'"
   else
@@ -32,7 +32,7 @@ function shell_quote(str)
 end
 
 -- parse Makefile format dependencies into a Lua table
-function parse_make_deps(deps)
+local function parse_make_deps(deps)
   -- remove line breaks and line concatenators
   deps = deps:gsub("\n", ""):gsub("\\", "")
   -- remove the Makefile "target:" element
@@ -70,7 +70,7 @@ end
 -- produces:
 -- #include "vim.h"
 -- #include "memory.h"
-function headerize(headers, global)
+local function headerize(headers, global)
   local pre = '"'
   local post = pre
   if global then
@@ -166,7 +166,7 @@ local type_to_class = {
 -- find the best cc. If os.exec causes problems on windows (like popping up
 -- a console window) we might consider using something like this:
 -- http://scite-ru.googlecode.com/svn/trunk/pack/tools/LuaLib/shell.html#exec
-function find_best_cc(ccs)
+local function find_best_cc(ccs)
   for _, meta in pairs(ccs) do
     local version = io.popen(tostring(meta.path) .. " -v 2>&1")
     version:close()

--- a/test/unit/tempfile_spec.lua
+++ b/test/unit/tempfile_spec.lua
@@ -3,11 +3,12 @@ local helpers = require 'test.unit.helpers'
 
 local os = helpers.cimport './src/nvim/os/os.h'
 local tempfile = helpers.cimport './src/nvim/tempfile.h'
--- os.mch_early_init
+
+helpers.vim_init()
 
 describe('tempfile related functions', function()
   after_each(function()
-    -- tempfile.vim_deltempdir()
+    tempfile.vim_deltempdir()
   end)
 
   local vim_gettempdir = function()

--- a/test/unit/tempfile_spec.lua
+++ b/test/unit/tempfile_spec.lua
@@ -3,10 +3,11 @@ local helpers = require 'test.unit.helpers'
 
 local os = helpers.cimport './src/nvim/os/os.h'
 local tempfile = helpers.cimport './src/nvim/tempfile.h'
+-- os.mch_early_init
 
 describe('tempfile related functions', function()
   after_each(function()
-    tempfile.vim_deltempdir()
+    -- tempfile.vim_deltempdir()
   end)
 
   local vim_gettempdir = function()


### PR DESCRIPTION
Followup of https://github.com/neovim/neovim/pull/1098#issuecomment-54712118

This is on top of @fwalch's commit because these scoping issues don't occur with busted 1.x.

Regardless of what's going on with busted, it's probably a good thing to avoid global scope. 

ping @aktau because this touches the lua C preprocessor and I'm hoping there's a chance you might have a clue why `popen()` is being weird.

---

For reference, this PR should fix the issues noticed by ZyX here: https://github.com/neovim/neovim/issues/903#issuecomment-47494001
