### PR TITLE
[RFC] Read $NVIMINIT before $VIMINIT (was: Rename $VIMINIT, $VIMRUNTIME and $MYVIMRC)

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -132,8 +132,8 @@ A few special texts:
 		Option was set with command line argument |-c|, +, |-S| or
 		|-q|.
 	Last set from environment variable ~
-		Option was set from an environment variable, $VIMINIT,
-		$GVIMINIT or $EXINIT.
+		Option was set from an environment variable, $NVIMINIT,
+		$VIMINIT, $GVIMINIT or $EXINIT.
 	Last set from error handler ~
 		Option was cleared when evaluating it resulted in an error.
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -797,13 +797,14 @@ accordingly.  Vim proceeds in this order:
 	nocp" command if you like.
 	For the Macintosh the $VIMRUNTIME/macmap.vim is read.
 
-	  *VIMINIT* *.vimrc* *_vimrc* *EXINIT* *.exrc* *_exrc* *$MYVIMRC*
-     c. Four places are searched for initializations.  The first that exists
+	  *NVIMINIT* *VIMINIT* *.vimrc* *_vimrc* *EXINIT* *.exrc* *_exrc* *$MYVIMRC*
+     c. Five places are searched for initializations.  The first that exists
 	is used, the others are ignored.  The $MYVIMRC environment variable is
 	set to the file that was first found, unless $MYVIMRC was already set
-	and when using VIMINIT.
-	-  The environment variable VIMINIT (see also |compatible-default|) (*)
-	   The value of $VIMINIT is used as an Ex command line.
+	and when using NVIMINIT or VIMINIT.
+	-  The environment variable NVIMINIT or (if the former has not been
+	   set) VIMINIT (see also |compatible-default|) (*)
+	   The value of $NVIMINIT or $VIMINIT is used as an Ex command line.
 	-  The user vimrc file(s):
 		    "$HOME/.vimrc"	   (for Unix and OS/2) (*)
 		    "$HOME/.vim/vimrc"	   (for Unix and OS/2) (*)

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1948,7 +1948,7 @@ static void source_startup_scripts(mparm_T *parmp)
 
     /*
      * Try to read initialization commands from the following places:
-     * - environment variable VIMINIT
+     * - environment variable NVIMINIT, then VIMINIT
      * - user vimrc file (s:.vimrc for Amiga, ~/.vimrc otherwise)
      * - second user vimrc file ($VIM/.vimrc for Dos)
      * - environment variable EXINIT
@@ -1956,7 +1956,8 @@ static void source_startup_scripts(mparm_T *parmp)
      * - second user exrc file ($VIM/.exrc for Dos)
      * The first that exists is used, the rest is ignored.
      */
-    if (process_env((char_u *)"VIMINIT", TRUE) != OK) {
+    if (process_env((char_u *)"NVIMINIT", TRUE) != OK
+        && process_env((char_u *)"VIMINIT", TRUE) != OK) {
       if (do_source((char_u *)USR_VIMRC_FILE, TRUE, DOSO_VIMRC) == FAIL
 #ifdef USR_VIMRC_FILE2
           && do_source((char_u *)USR_VIMRC_FILE2, TRUE,
@@ -2056,7 +2057,7 @@ static void main_start_gui(void)
 int 
 process_env (
     char_u *env,
-    int is_viminit             /* when TRUE, called for VIMINIT */
+    int is_viminit             /* when TRUE, called for {N,}VIMINIT */
 )
 {
   char_u      *initstr;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7779,7 +7779,7 @@ static void paste_option_changed(void)
 }
 
 /*
- * vimrc_found() - Called when a ".vimrc" or "VIMINIT" has been found.
+ * vimrc_found() - Called when a ".vimrc", "NVIMINIT" or "VIMINIT" has been found.
  *
  * Reset 'compatible' and set the values for options that didn't get set yet
  * to the Vim defaults.


### PR DESCRIPTION
I found [this](http://tlvince.com/vim-respect-xdg) article which explains how to make vim respect the XDG Base Directory Specification and did the same changes to my setup (until #78 is figured out). Now the problem is that I want to use neovim and vim in parallel, but have different configurations (`$XDG_CONFIG_HOME/nvim` vs `$XDG_CONFIG_HOME/vim`) for them. The problem is that both read the same environment variables.

The basic idea is to change the location of `.vimrc` via $VIMINIT which is read before the configuration file is loaded.

> _(This PR renames these variables to have a cleaner separation between neovim and vim. I know that these changes are very selective though.)_

**EDIT:** @justinmk [suggested (comment)](https://github.com/neovim/neovim/pull/1153#issuecomment-55039622) as less crappy way to fix this problem.
