### PR TITLE
[RFC] 7.4.371.

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3565,7 +3565,7 @@ win_line (
         } else if (c != NUL) {
           p_extra = transchar(c);
           if (n_extra == 0) {
-              n_extra = byte2cells(c);
+              n_extra = byte2cells(c) - 1;
           }
           if ((dy_flags & DY_UHEX) && wp->w_p_rl)
             rl_mirror(p_extra);                 /* reverse "<12>" */


### PR DESCRIPTION
One thing that's been bugging me: When I enter a `NUL` character in neovim (`<C-k>NU` -> `^@`), the text following it renders one space further right than it should. (`^@` renders as two characters, but includes an extra space) Turns out patch 7.4.353 introduced the bug and 4.7.371 fixed it, except for a slight error in translation. Thank goodness for `git bisect`!
