### PR TITLE
[RFC] ex_cmds2.c:fix for issue #1164

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1914,7 +1914,7 @@ void ex_listdo(exarg_T *eap)
             break;
           }
         }
-        if (buf_still_exists) {
+        if (!buf_still_exists) {
           break;
         }
 


### PR DESCRIPTION
fix condition while iterating over all buffers

This fixes a bug introduced by PR #1024. This was reported in issue #1164.
