### PR TITLE
third-party: avoid using `rm` in the install command

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -99,11 +99,10 @@ if(USE_BUNDLED_MSGPACK)
        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
        "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_COMPILER_ARG1} -fPIC"
     BUILD_COMMAND ${MAKE_PRG}
-    INSTALL_COMMAND ${MAKE_PRG} install &&
-       rm ${DEPS_INSTALL_DIR}/lib/libmsgpack.so &&
-       rm ${DEPS_INSTALL_DIR}/lib/libmsgpack.so.3 &&
-       rm ${DEPS_INSTALL_DIR}/lib/libmsgpack.so.4.0.0
-       )
+    INSTALL_COMMAND ${CMAKE_COMMAND}
+      -DMAKE_PRG=${MAKE_PRG}
+      -DREMOVE_FILE_GLOB=${DEPS_INSTALL_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}msgpack*${CMAKE_SHARED_LIBRARY_SUFFIX}*
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/InstallMsgpack.cmake)
   list(APPEND THIRD_PARTY_DEPS msgpack)
 endif()
 

--- a/third-party/cmake/InstallMsgpack.cmake
+++ b/third-party/cmake/InstallMsgpack.cmake
@@ -1,0 +1,12 @@
+execute_process(
+  COMMAND ${MAKE_PRG} install
+  RESULT_VARIABLE res)
+
+if(NOT res EQUAL 0)
+  message(FATAL_ERROR "Installing msgpack failed.")
+endif()
+
+file(GLOB FILES_TO_REMOVE ${REMOVE_FILE_GLOB})
+if(FILES_TO_REMOVE)
+  file(REMOVE ${FILES_TO_REMOVE})
+endif()


### PR DESCRIPTION
Also, the command was removing only .so versions of the library, and not
the the `.dylib` under Mac OS X, and in a way that it would fail if the
files weren't present.

Instead, let's delegate to a CMake script--to get the portability--and
use a glob to detect and remove the shared versions of the library.
Hopefully, this will become unnecessary as msgpack's build becomes more
full-featured, and we can just tell it to build the static version
instead.
