### PR TITLE
[RDY] clipboard: support separate +/* clipboards, linewise copy/paste and add test

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -1,8 +1,8 @@
 " The clipboard provider uses shell commands to communicate with the clipboard.
 " The provider function will only be registered if one of the supported
 " commands are available.
-let s:copy = ''
-let s:paste = ''
+let s:copy = {}
+let s:paste = {}
 
 function! s:try_cmd(cmd, ...)
   let out = a:0 ? systemlist(a:cmd, a:1) : systemlist(a:cmd)
@@ -14,14 +14,20 @@ function! s:try_cmd(cmd, ...)
 endfunction
 
 if executable('pbcopy')
-  let s:copy = 'pbcopy'
-  let s:paste = 'pbpaste'
-elseif executable('xsel')
-  let s:copy = 'xsel -i -b'
-  let s:paste = 'xsel -o -b'
+  let s:copy['+'] = 'pbcopy'
+  let s:paste['+'] = 'pbpaste'
+  let s:copy['*'] = s:copy['+']
+  let s:paste['*'] = s:paste['+']
 elseif executable('xclip')
-  let s:copy = 'xclip -i -selection clipboard'
-  let s:paste = 'xclip -o -selection clipboard'
+  let s:copy['+'] = 'xclip -i -selection clipboard'
+  let s:paste['+'] = 'xclip -o -selection clipboard'
+  let s:copy['*'] = 'xclip -i -selection primary'
+  let s:paste['*'] = 'xclip -o -selection primary'
+elseif executable('xsel')
+  let s:copy['+'] = 'xsel -i -b'
+  let s:paste['+'] = 'xsel -o -b'
+  let s:copy['*'] = 'xsel -i -p'
+  let s:paste['*'] = 'xsel -o -p'
 else
   echom 'clipboard: No shell command for communicating with the clipboard found.'
   finish
@@ -29,14 +35,14 @@ endif
 
 let s:clipboard = {}
 
-function! s:clipboard.get(...)
-  return s:try_cmd(s:paste)
+function! s:clipboard.get(reg)
+  return s:try_cmd(s:paste[a:reg])
 endfunction
 
-function! s:clipboard.set(...)
-  call s:try_cmd(s:copy, a:1)
+function! s:clipboard.set(lines, reg)
+  call s:try_cmd(s:copy[a:reg], a:lines)
 endfunction
 
 function! provider#clipboard#Call(method, args)
-  return s:clipboard[a:method](a:args)
+  return call(s:clipboard[a:method],a:args,s:clipboard)
 endfunction

--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -5,7 +5,7 @@ let s:copy = {}
 let s:paste = {}
 
 function! s:try_cmd(cmd, ...)
-  let out = a:0 ? systemlist(a:cmd, a:1) : systemlist(a:cmd)
+  let out = a:0 ? systemlist(a:cmd, a:1, 1) : systemlist(a:cmd, [''], 1)
   if v:shell_error
     echo "clipboard: error: ".(len(out) ? out[0] : '')
     return ''
@@ -39,7 +39,7 @@ function! s:clipboard.get(reg)
   return s:try_cmd(s:paste[a:reg])
 endfunction
 
-function! s:clipboard.set(lines, reg)
+function! s:clipboard.set(lines, regtype, reg)
   call s:try_cmd(s:copy[a:reg], a:lines)
 endfunction
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7547,13 +7547,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Note that this causes the whole buffer to be stored in memory.  Set
 	this option to a lower value if you run out of memory.
 
-			                          {Nvim} *'unnamedclip'* *ucp'*
-'unnamedclip' 'ucp'	boolean	(default off)
-			global
-	Use the unnamed register to access the clipboard(when available).
-	This option has the same effect of setting 'clipboard' to
-	'unnamed/unnamedplus' in Vim.
-
 						*'updatecount'* *'uc'*
 'updatecount' 'uc'	number	(default: 200)
 			global

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19829,16 +19829,12 @@ typval_T eval_call_provider(char *provider, char *method, list_T *arguments)
 
 bool eval_has_provider(char *name)
 {
-#define source_provider(name) \
-  do_source((uint8_t *)"$VIMRUNTIME/autoload/provider/" name ".vim", \
-                       false, \
-                       false)
 
 #define check_provider(name)                                              \
   if (has_##name == -1) {                                                 \
     has_##name = !!find_func((uint8_t *)"provider#" #name "#Call");       \
     if (!has_##name) {                                                    \
-      source_provider(#name);                                             \
+      script_autoload((uint8_t *)"provider#" #name "#Call", false);       \
       has_##name = !!find_func((uint8_t *)"provider#" #name "#Call");     \
     }                                                                     \
   }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5119,6 +5119,20 @@ void list_append_tv(list_T *l, typval_T *tv)
 }
 
 /*
+ * Add a list to a list.
+ */
+void list_append_list(list_T *list, list_T *itemlist)
+{
+  listitem_T  *li = listitem_alloc();
+
+  li->li_tv.v_type = VAR_LIST;
+  li->li_tv.v_lock = 0;
+  li->li_tv.vval.v_list = itemlist;
+  list_append(list, li);
+  ++list->lv_refcount;
+}
+
+/*
  * Add a dictionary to a list.  Used by getqflist().
  */
 void list_append_dict(list_T *list, dict_T *dict)

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -915,14 +915,7 @@ getcount:
       && !oap->op_type
       && (idx < 0 || !(nv_cmds[idx].cmd_flags & NV_KEEPREG))) {
     clearop(oap);
-    {
-      int regname = 0;
-
-      /* Adjust the register according to 'clipboard', so that when
-       * "unnamed" is present it becomes '*' or '+' instead of '"'. */
-      adjust_clipboard_register(&regname);
-      set_reg_var(regname);
-    }
+    set_reg_var(0);
   }
 
   /* Get the length of mapped chars again after typing a count, second
@@ -5105,7 +5098,6 @@ static void nv_brackets(cmdarg_T *cap)
         end = equalpos(start, VIsual) ? curwin->w_cursor : VIsual;
         curwin->w_cursor = (dir == BACKWARD ? start : end);
       }
-      adjust_clipboard_register(&regname);
       prep_redo_cmd(cap);
       do_put(regname, dir, cap->count1, PUT_FIXINDENT);
       if (was_visual) {
@@ -7272,10 +7264,8 @@ static void nv_put(cmdarg_T *cap)
        */
       was_visual = true;
       regname = cap->oap->regname;
-      bool adjusted = adjust_clipboard_register(&regname);
       if (regname == 0 || regname == '"'
           || VIM_ISDIGIT(regname) || regname == '-'
-          || adjusted
           ) {
         /* The delete is going to overwrite the register we want to
          * put, save it first. */

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5244,7 +5244,11 @@ static void get_clipboard(int name)
 
   struct yankreg *reg = &y_regs[CLIP_REGISTER];
   free_register(reg);
+
   list_T *args = list_alloc();
+  char_u regname = (char_u)name;
+  list_append_string(args, &regname, 1);
+
   typval_T result = eval_call_provider("clipboard", "get", args);
 
   if (result.v_type != VAR_LIST) {
@@ -5294,6 +5298,7 @@ static void set_clipboard(int name)
   if (!name && p_unc) {
     // copy from the unnamed register
     copy_register(reg, &y_regs[0]);
+    name = '+';
   }
 
   list_T *lines = list_alloc();
@@ -5302,5 +5307,11 @@ static void set_clipboard(int name)
     list_append_string(lines, reg->y_array[i], -1);
   }
 
-  (void)eval_call_provider("clipboard", "set", lines);
+  list_T *args = list_alloc();
+  list_append_list(args, lines);
+
+  char_u regname = (char_u)name;
+  list_append_string(args, &regname, 1);
+
+  (void)eval_call_provider("clipboard", "set", args);
 }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4825,6 +4825,7 @@ void write_reg_contents_ex(int name,
   if (!y_append && !must_append)
     free_yank_all();
   str_to_reg(y_current, yank_type, str, len, block_len);
+  set_clipboard(name);
 
 
   /* ':let @" = "val"' should change the meaning of the "" register */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -527,7 +527,7 @@ static struct vimoption
     (char_u *)0L}
    SCRIPTID_INIT},
   {"clipboard",   "cb",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)NULL, PV_NONE,
+   (char_u *)&p_cb, PV_NONE,
    {(char_u *)"", (char_u *)0L}
    SCRIPTID_INIT},
   {"cmdheight",   "ch",   P_NUM|P_VI_DEF|P_RALL,
@@ -1620,9 +1620,6 @@ static struct vimoption
   {"undoreload",  "ur",   P_NUM|P_VI_DEF,
    (char_u *)&p_ur, PV_NONE,
    { (char_u *)10000L, (char_u *)0L} SCRIPTID_INIT},
-  {"unnamedclip",  "ucp",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_unc, PV_NONE,
-   {(char_u *)FALSE, (char_u *)FALSE} SCRIPTID_INIT},
   {"updatecount", "uc",   P_NUM|P_VI_DEF,
    (char_u *)&p_uc, PV_NONE,
    {(char_u *)200L, (char_u *)0L} SCRIPTID_INIT},
@@ -4279,6 +4276,10 @@ did_set_string_option (
     if (check_opt_strings(p_ead, p_ead_values, FALSE) != OK)
       errmsg = e_invarg;
   }
+  else if (varp == &p_cb) {
+    if (opt_strings_flags(p_cb, p_cb_values, &cb_flags, TRUE) != OK)
+      errmsg = e_invarg;
+  }
   /* When 'spelllang' or 'spellfile' is set and there is a window for this
    * buffer in which 'spell' is set load the wordlists. */
   else if (varp == &(curbuf->b_s.b_p_spl) || varp == &(curbuf->b_s.b_p_spf)) {
@@ -4845,7 +4846,6 @@ char_u *check_stl_option(char_u *s)
     return (char_u *)N_("E542: unbalanced groups");
   return NULL;
 }
-
 
 /*
  * Set curbuf->b_cap_prog to the regexp program for 'spellcapcheck'.

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -317,6 +317,13 @@ EXTERN char_u   *p_enc;         /* 'encoding' */
 EXTERN int p_deco;              /* 'delcombine' */
 EXTERN char_u   *p_ccv;         /* 'charconvert' */
 EXTERN char_u   *p_cedit;       /* 'cedit' */
+EXTERN char_u   *p_cb;          /* 'clipboard' */
+EXTERN unsigned cb_flags;
+#ifdef IN_OPTION_C
+static char *(p_cb_values[]) = {"unnamed", "unnamedplus", NULL};
+#endif
+# define CB_UNNAMED             0x001
+# define CB_UNNAMEDPLUS         0x002
 EXTERN long p_cwh;              /* 'cmdwinheight' */
 EXTERN long p_ch;               /* 'cmdheight' */
 EXTERN int p_confirm;           /* 'confirm' */
@@ -582,7 +589,6 @@ static char *(p_ttym_values[]) =
 EXTERN char_u   *p_udir;        /* 'undodir' */
 EXTERN long p_ul;               /* 'undolevels' */
 EXTERN long p_ur;               /* 'undoreload' */
-EXTERN int p_unc;               /* 'unnamedclip' */
 EXTERN long p_uc;               /* 'updatecount' */
 EXTERN long p_ut;               /* 'updatetime' */
 EXTERN char_u   *p_fcs;         /* 'fillchar' */

--- a/test/functional/clipboard/autoload/provider/clipboard.vim
+++ b/test/functional/clipboard/autoload/provider/clipboard.vim
@@ -1,0 +1,16 @@
+let g:test_clip = { '+': [''], '*': [''], }
+
+let s:methods = {}
+
+function! s:methods.get(reg)
+  return g:test_clip[a:reg]
+endfunction
+
+function! s:methods.set(lines, regtype, reg)
+  let g:test_clip[a:reg] = a:lines
+endfunction
+
+
+function! provider#clipboard#Call(method, args)
+  return call(s:methods[a:method],a:args,s:methods)
+endfunction

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -1,0 +1,129 @@
+-- Test clipboard provider support
+
+local helpers = require('test.functional.helpers')
+local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
+local execute, expect, eq, eval = helpers.execute, helpers.expect, helpers.eq, helpers.eval
+local nvim, run, stop, restart = helpers.nvim, helpers.run, helpers.stop, helpers.restart
+
+local function reset()
+  clear()
+  execute('let &rtp = "test/functional/clipboard,".&rtp')
+end
+
+local function basic_register_test()
+  insert("some words")
+
+  feed('^dwP')
+  expect('some words')
+
+  feed('veyP')
+  expect('some words words')
+
+  feed('^dwywe"-p')
+  expect('wordssome  words')
+
+  feed('p')
+  expect('wordssome words  words')
+
+  feed('yyp')
+  expect([[
+    wordssome words  words
+    wordssome words  words]])
+  feed('d-')
+
+  insert([[
+    some text, and some more
+    random text stuff]])
+  feed('ggtav+2ed$p')
+  expect([[
+    some text, stuff and some more
+    random text]])
+  reset()
+end
+
+describe('clipboard usage', function()
+  setup(reset)
+  it("works", function()
+    basic_register_test()
+
+    -- "* and unnamed should function as independent registers
+    insert("some words")
+    feed('^"*dwdw"*P')
+    expect('some ')
+    eq({'some '}, eval("g:test_clip['*']"))
+    reset()
+
+    -- "* and "+ should be independent when the provider supports it
+    insert([[
+      text:
+      first line
+      secound line
+      third line]])
+
+    feed('G"+dd"*dddd"+p"*pp')
+    expect([[
+      text:
+      third line
+      secound line
+      first line]])
+    -- linewise selection should be encoded as an extra newline
+    eq({'third line', ''}, eval("g:test_clip['+']"))
+    eq({'secound line', ''}, eval("g:test_clip['*']"))
+    reset()
+
+    -- handle null bytes
+    insert("some\x16000text\n\x16000very binary\x16000")
+    feed('"*y-+"*p')
+    eq({'some\ntext', '\nvery binary\n',''}, eval("g:test_clip['*']"))
+    expect("some\x00text\n\x00very binary\x00\nsome\x00text\n\x00very binary\x00")
+
+    -- test getreg/getregtype
+    eq('some\ntext\n\nvery binary\n\n', eval("getreg('*', 1)"))
+    eq("V", eval("getregtype('*')"))
+    reset()
+
+    -- blockwise paste
+    insert([[
+      much
+      text]])
+    feed('"*yy') -- force load of provider
+    execute("let g:test_clip['*'] = [['very','block'],'b']")
+    feed('gg"*P')
+    expect([[
+      very much
+      blocktext]])
+    eq("\x165", eval("getregtype('*')"))
+    reset()
+
+    -- test setreg
+    execute('call setreg("*", "setted\\ntext", "c")')
+    execute('call setreg("+", "explicitly\\nlines", "l")')
+    feed('"+P"*p')
+    expect([[
+        esetted
+        textxplicitly
+        lines
+        ]])
+    reset()
+
+    -- the basic behavior of unnamed register should be the same
+    -- even when handled by clipboard provider
+    execute('set clipboard=unnamed')
+    basic_register_test()
+
+    -- with cb=unnamed, "* and unnamed will be the same register
+    execute('set clipboard=unnamed')
+    insert("some words")
+    feed('^"*dwdw"*P')
+    expect('words')
+    eq({'words'}, eval("g:test_clip['*']"))
+
+    execute("let g:test_clip['*'] = ['linewise stuff','']")
+    feed('p')
+    expect([[
+      words
+      linewise stuff]])
+    reset()
+
+    end)
+end)

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -106,6 +106,18 @@ describe('clipboard usage', function()
         ]])
     reset()
 
+    -- test let @+ (issue #1427)
+    execute("let @+ = 'some'")
+    execute("let @* = ' other stuff'")
+    eq({'some'}, eval("g:test_clip['+']"))
+    eq({' other stuff'}, eval("g:test_clip['*']"))
+    feed('"+p"*p')
+    expect('some other stuff')
+    execute("let @+ .= ' more'")
+    feed('dd"+p')
+    expect('some more')
+    reset()
+
     -- the basic behavior of unnamed register should be the same
     -- even when handled by clipboard provider
     execute('set clipboard=unnamed')


### PR DESCRIPTION
This change allows clipboard provider to distinguish between `+` and `*` registers, by passing an extra parameter to clipboard_get/set. 

Existing behaviour can be preserved by just igoring the extra parameter like [this](https://gist.github.com/bfredl/19c13ba8014bb761528c). An example provider for X11 that distinguishes between "primary selection" and clipboard (like in vim +x11) is [here](https://gist.github.com/bfredl/888e2b7c2b378d6953ee)

An open question is what to do when `unnamedclip` is set; right now it uses the name `+` (because it was easiest to implement and consistent with existing code). An alternative would be to pass the name `"` to the provider when the unnamed register is used (so it could choose between `+`/`*` itself, or implemnt a third option). In this case, and if I understand the code correctly, `adjust_clipboard_register` could be be completely removed? @tarruda

While breaking the API, something to consider is to let the provider get/set the regtype (character or linewise selection) by passing another parameter. I suppose this could be done by just doing `vim.command("call getregtype(...)")` from the provider, but IMHO it would be cleaner if this was actually part of the api. I will try to implement this later.
