### PR TITLE
[RDY] Non-unix-specific os_unix function. 

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -60,6 +60,7 @@
 #include "nvim/os/time.h"
 #include "nvim/os/input.h"
 #include "nvim/os/os.h"
+#include "nvim/os/event.h"
 #include "nvim/os/signal.h"
 #include "nvim/msgpack_rpc/helpers.h"
 #include "nvim/api/private/defs.h"
@@ -252,14 +253,12 @@ int main(int argc, char **argv)
    */
 
 
-  /*
-   * mch_init() sets up the terminal (window) for use.  This must be
-   * done after resetting full_screen, otherwise it may move the cursor
-   * Note that we may use mch_exit() before mch_init()!
-   */
-  mch_init();
+  // term_init() sets up the terminal (window) for use.  This must be
+  // done after resetting full_screen, otherwise it may move the cursor
+  term_init();
   TIME_MSG("shell init");
 
+  event_init();
 
   if (!embedded_mode) {
     // Print a warning if stdout is not a terminal.

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -82,30 +82,6 @@ static int did_set_title = FALSE;
 static char_u   *oldicon = NULL;
 static int did_set_icon = FALSE;
 
-
-
-/*
- * Write s[len] to the screen.
- */
-void mch_write(char_u *s, int len)
-{
-  if (embedded_mode) {
-    // TODO(tarruda): This is a temporary hack to stop Neovim from writing
-    // messages to stdout in embedded mode. In the future, embedded mode will
-    // be the only possibility(GUIs will always start neovim with a msgpack-rpc
-    // over stdio) and this function won't exist.
-    //
-    // The reason for this is because before Neovim fully migrates to a
-    // msgpack-rpc-driven architecture, we must have a fully functional
-    // UI working
-    return;
-  }
-
-  ignored = (int)write(1, (char *)s, len);
-  if (p_wd)             /* Unix is too fast, slow down a bit more */
-    os_microdelay(p_wd, false);
-}
-
 /*
  * If the machine has job control, use it to suspend the program,
  * otherwise fake it by starting a new shell.
@@ -158,6 +134,12 @@ void mch_init(void)
 {
   Columns = 80;
   Rows = 24;
+
+  // Prevent buffering output.
+  // Output gets explicitly buffered and flushed by out_flush() at times like,
+  // for example, when the user presses a key. Without this line, vim will not
+  // render the screen correctly.
+  setbuf(stdout, NULL);
 
   out_flush();
 

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -439,12 +439,6 @@ int mch_nodetype(char_u *name)
   return NODE_WRITABLE;
 }
 
-void mch_early_init(void)
-{
-  handle_init();
-  time_init();
-}
-
 #if defined(EXITFREE) || defined(PROTO)
 void mch_free_mem(void)
 {

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -88,17 +88,16 @@ static int did_set_icon = FALSE;
  */
 void mch_suspend(void)
 {
-  /* BeOS does have SIGTSTP, but it doesn't work. */
-#if defined(SIGTSTP) && !defined(__BEOS__)
+#if defined(SIGTSTP)
   out_flush();              /* needed to make cursor visible on some systems */
   settmode(TMODE_COOK);
   out_flush();              /* needed to disable mouse on some systems */
 
-
+  // Note: compiler defines _REENTRANT when given -pthread flag.
 # if defined(_REENTRANT) && defined(SIGCONT)
   sigcont_received = FALSE;
 # endif
-  kill(0, SIGTSTP);         /* send ourselves a STOP signal */
+  uv_kill(0, SIGTSTP);         // send ourselves a STOP signal
 # if defined(_REENTRANT) && defined(SIGCONT)
   /*
    * Wait for the SIGCONT signal to be handled. It generally happens

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -130,26 +130,6 @@ void mch_suspend(void)
 #endif
 }
 
-void mch_init(void)
-{
-  Columns = 80;
-  Rows = 24;
-
-  // Prevent buffering output.
-  // Output gets explicitly buffered and flushed by out_flush() at times like,
-  // for example, when the user presses a key. Without this line, vim will not
-  // render the screen correctly.
-  setbuf(stdout, NULL);
-
-  out_flush();
-
-#ifdef MACOS_CONVERT
-  mac_conv_init();
-#endif
-
-  event_init();
-}
-
 static int get_x11_title(int test_only)
 {
   return FALSE;

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -1010,6 +1010,30 @@ static struct builtin_term builtin_termcaps[] =
 # define DEFAULT_TERM   (char_u *)"dumb"
 #endif
 
+/// Sets up the terminal window for use.
+///
+/// This must be done after resetting full_screen, otherwise it may move the
+/// cursor.
+///
+/// @remark We may call mch_exit() before calling this.
+void term_init(void)
+{
+  Columns = 80;
+  Rows = 24;
+
+  // Prevent buffering output.
+  // Output gets explicitly buffered and flushed by out_flush() at times like,
+  // for example, when the user presses a key. Without this line, vim will not
+  // render the screen correctly.
+  setbuf(stdout, NULL);
+
+  out_flush();
+
+#ifdef MACOS_CONVERT
+  mac_conv_init();
+#endif
+}
+
 /*
  * Term_strings contains currently used terminal output strings.
  * It is initialized with the default values by parse_builtin_tcap().

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -55,7 +55,7 @@ void ui_write(char_u *s, int len)
         s = tofree;
     }
 
-    mch_write(s, len);
+    term_write(s, len);
 
     if (output_conv.vc_type != CONV_NONE)
       free(tofree);

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -139,26 +139,10 @@ local function vim_init()
   if vim_init_called ~= nil then
     return 
   end
-  -- import os_unix.h for mch_early_init(), which initializes some globals
-  local all = cimport('./src/nvim/os_unix.h',
-                      './src/nvim/misc1.h',
-                      './src/nvim/eval.h',
-                      './src/nvim/os_unix.h',
-                      './src/nvim/option.h',
-                      './src/nvim/ex_cmds2.h',
-                      './src/nvim/window.h',
-                      './src/nvim/ops.h',
-                      './src/nvim/normal.h',
-                      './src/nvim/mbyte.h')
-  all.mch_early_init()
-  all.mb_init()
-  all.eval_init()
-  all.init_normal_cmds()
-  all.win_alloc_first()
-  all.init_yank()
-  all.init_homedir()
-  all.set_init_1()
-  all.set_lang_var()
+  local main = cimport('./src/nvim/main.h')
+  local time = cimport('./src/nvim/os/time.h')
+  time.time_init()
+  main.early_init()
   vim_init_called = true
 end
 


### PR DESCRIPTION
I noticed that `mch_write()` looked just a stone's throw from being OS-independent. Posting early to see if anyone can point out a flaw in my logic.

A few other functions in `os_unix.c` don't really depend on unix, like `mch_init()`, so I plan to add more to this.
