### PR TITLE
[RFC] vim-patch:7.4.382

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2209,6 +2209,12 @@ static int vgetorpeek(int advance)
         }
         if (c < 0)
           continue;             /* end of input script reached */
+
+        // Allow mapping for just typed characters. When we get here c
+        // is the number of extra bytes and typebuf.tb_len is 1.
+        for (n = 1; n <= c; n++) {
+          typebuf.tb_noremap[typebuf.tb_off + n] = RM_YES;
+        }
         typebuf.tb_len += c;
 
         /* buffer full, don't map */

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -213,7 +213,7 @@ static int included_patches[] = {
   //385,
   //384 NA
   383,
-  //382,
+  382,
   381,
   //380 NA
   379,


### PR DESCRIPTION
Problem:    Mapping characters may not work after typing Esc in Insert mode.
Solution:   Fix the noremap flags for inserted characters. (Jacob Niehus)

https://code.google.com/p/vim/source/detail?r=v7-4-382
