### PR TITLE
[RFC] vim-patch:7.4.410

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -5200,8 +5200,13 @@ static int ex_window(void)
 
   RedrawingDisabled = i;
 
+  int save_KeyTyped = KeyTyped;
+
   /* Trigger CmdwinLeave autocommands. */
   apply_autocmds(EVENT_CMDWINLEAVE, typestr, typestr, FALSE, curbuf);
+
+  /* Restore KeyTyped in case it is modified by autocommands */
+  KeyTyped = save_KeyTyped;
 
   /* Restore the command line info. */
   ccline = save_ccline;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -185,7 +185,7 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
-  //410,
+  410,
   //409 NA
   //408,
   //407,


### PR DESCRIPTION
Problem:    Fold does not open after search when there is a CmdwinLeave
            autocommand.
Solution:   Restore KeyTyped. (Jacob Niehus)

https://code.google.com/p/vim/source/detail?r=v7-4-410
