### PR TITLE
[RFC] Improvements to API error handling

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -125,7 +125,7 @@ ArrayOf(String) buffer_get_slice(Buffer buffer,
     int64_t lnum = start + (int64_t)i;
 
     if (lnum > LONG_MAX) {
-      set_api_error("Line index is too high", err);
+      api_set_error(err, Validation, _("Line index is too high"));
       goto end;
     }
 
@@ -175,7 +175,9 @@ void buffer_set_slice(Buffer buffer,
   end = normalize_index(buf, end) + (include_end ? 1 : 0);
 
   if (start > end) {
-    set_api_error("start > end", err);
+    api_set_error(err,
+                  Validation,
+                  _("Argument \"start\" is higher than \"end\""));
     return;
   }
 
@@ -189,7 +191,9 @@ void buffer_set_slice(Buffer buffer,
 
   for (size_t i = 0; i < new_len; i++) {
     if (replacement.items[i].type != kObjectTypeString) {
-      set_api_error("all items in the replacement array must be strings", err);
+      api_set_error(err,
+                    Validation,
+                    _("All items in the replacement array must be strings"));
       goto end;
     }
 
@@ -201,7 +205,7 @@ void buffer_set_slice(Buffer buffer,
   switch_to_win_for_buf(buf, &save_curwin, &save_curtab, &save_curbuf);
 
   if (u_save((linenr_T)(start - 1), (linenr_T)end) == FAIL) {
-    set_api_error("Cannot save undo information", err);
+    api_set_error(err, Exception, _("Failed to save undo information"));
     goto end;
   }
 
@@ -211,7 +215,7 @@ void buffer_set_slice(Buffer buffer,
   size_t to_delete = (new_len < old_len) ? (size_t)(old_len - new_len) : 0;
   for (size_t i = 0; i < to_delete; i++) {
     if (ml_delete((linenr_T)start, false) == FAIL) {
-      set_api_error("Cannot delete line", err);
+      api_set_error(err, Exception, _("Failed to delete line"));
       goto end;
     }
   }
@@ -228,12 +232,12 @@ void buffer_set_slice(Buffer buffer,
     int64_t lnum = start + (int64_t)i;
 
     if (lnum > LONG_MAX) {
-      set_api_error("Index value is too high", err);
+      api_set_error(err, Validation, _("Index value is too high"));
       goto end;
     }
 
     if (ml_replace((linenr_T)lnum, (char_u *)lines[i], false) == FAIL) {
-      set_api_error("Cannot replace line", err);
+      api_set_error(err, Exception, _("Failed to replace line"));
       goto end;
     }
     // Mark lines that haven't been passed to the buffer as they need
@@ -246,12 +250,12 @@ void buffer_set_slice(Buffer buffer,
     int64_t lnum = start + (int64_t)i - 1;
 
     if (lnum > LONG_MAX) {
-      set_api_error("Index value is too high", err);
+      api_set_error(err, Validation, _("Index value is too high"));
       goto end;
     }
 
     if (ml_append((linenr_T)lnum, (char_u *)lines[i], 0, false) == FAIL) {
-      set_api_error("Cannot insert line", err);
+      api_set_error(err, Exception, _("Failed to insert line"));
       goto end;
     }
 
@@ -415,7 +419,7 @@ void buffer_set_name(Buffer buffer, String name, Error *err)
   }
 
   if (ren_ret == FAIL) {
-    set_api_error("failed to rename buffer", err);
+    api_set_error(err, Exception, _("Failed to rename buffer"));
   }
 }
 
@@ -425,7 +429,7 @@ void buffer_set_name(Buffer buffer, String name, Error *err)
 /// @return true if the buffer is valid, false otherwise
 Boolean buffer_is_valid(Buffer buffer)
 {
-  Error stub = {.set = false};
+  Error stub = ERROR_INIT;
   return find_buffer_by_handle(buffer, &stub) != NULL;
 }
 
@@ -460,7 +464,7 @@ ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, Error *err)
   }
 
   if (name.size != 1) {
-    set_api_error("mark name must be a single character", err);
+    api_set_error(err, Validation, _("Mark name must be a single character"));
     return rv;
   }
 
@@ -478,7 +482,7 @@ ArrayOf(Integer, 2) buffer_get_mark(Buffer buffer, String name, Error *err)
   }
 
   if (posp == NULL) {
-    set_api_error("invalid mark name", err);
+    api_set_error(err, Validation, _("Invalid mark name"));
     return rv;
   }
 

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -8,6 +8,7 @@
 #define ARRAY_DICT_INIT {.size = 0, .capacity = 0, .items = NULL}
 #define STRING_INIT {.data = NULL, .size = 0}
 #define OBJECT_INIT { .type = kObjectTypeNil }
+#define ERROR_INIT { .set = false }
 #define REMOTE_TYPE(type) typedef uint64_t type
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -16,8 +17,14 @@
 #endif
 
 // Basic types
+typedef enum {
+  kErrorTypeException,
+  kErrorTypeValidation
+} ErrorType;
+
 typedef struct {
-  char msg[256];
+  ErrorType type;
+  char msg[1024];
   bool set;
 } Error;
 

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -8,10 +8,13 @@
 #include "nvim/memory.h"
 #include "nvim/lib/kvec.h"
 
-#define set_api_error(message, err)                \
-  do {                                             \
-    xstrlcpy(err->msg, message, sizeof(err->msg)); \
-    err->set = true;                               \
+#define api_set_error(err, errtype, ...)             \
+  do {                                               \
+    snprintf((err)->msg,                             \
+             sizeof((err)->msg),                     \
+             __VA_ARGS__);                           \
+    (err)->set = true;                               \
+    (err)->type = kErrorType##errtype;               \
   } while (0)
 
 #define OBJECT_OBJ(o) o

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -116,7 +116,7 @@ Window tabpage_get_window(Tabpage tabpage, Error *err)
 /// @return true if the tab page is valid, false otherwise
 Boolean tabpage_is_valid(Tabpage tabpage)
 {
-  Error stub = {.set = false};
+  Error stub = ERROR_INIT;
   return find_tab_by_handle(tabpage, &stub) != NULL;
 }
 

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -57,7 +57,9 @@ void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
 
   if (pos.size != 2 || pos.items[0].type != kObjectTypeInteger ||
       pos.items[1].type != kObjectTypeInteger) {
-    set_api_error("\"pos\" argument must be a [row, col] array", err);
+    api_set_error(err,
+                  Validation,
+                  _("Argument \"pos\" must be a [row, col] array"));
     return;
   }
 
@@ -69,12 +71,12 @@ void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   int64_t col = pos.items[1].data.integer;
 
   if (row <= 0 || row > win->w_buffer->b_ml.ml_line_count) {
-    set_api_error("cursor position outside buffer", err);
+    api_set_error(err, Validation, _("Cursor position outside buffer"));
     return;
   }
 
   if (col > MAXCOL || col < 0) {
-    set_api_error("Column value outside range", err);
+    api_set_error(err, Validation, _("Column value outside range"));
     return;
   }
 
@@ -117,7 +119,7 @@ void window_set_height(Window window, Integer height, Error *err)
   }
 
   if (height > INT_MAX || height < INT_MIN) {
-    set_api_error("Height value outside range", err);
+    api_set_error(err, Validation, _("Height value outside range"));
     return;
   }
 
@@ -160,7 +162,7 @@ void window_set_width(Window window, Integer width, Error *err)
   }
 
   if (width > INT_MAX || width < INT_MIN) {
-    set_api_error("Width value outside range", err);
+    api_set_error(err, Validation, _("Width value outside range"));
     return;
   }
 
@@ -283,7 +285,7 @@ Tabpage window_get_tabpage(Window window, Error *err)
 /// @return true if the window is valid, false otherwise
 Boolean window_is_valid(Window window)
 {
-  Error stub = {.set = false};
+  Error stub = ERROR_INIT;
   return find_window_by_handle(window, &stub) != NULL;
 }
 

--- a/src/nvim/os/provider.c
+++ b/src/nvim/os/provider.c
@@ -107,12 +107,11 @@ Object provider_call(char *method, Array args)
     return NIL;
   }
 
-  bool error = false;
-  Object result = NIL;
-  channel_send_call(f->channel_id, method, args, &result, &error);
+  Error err = ERROR_INIT;
+  Object result = NIL = channel_send_call(f->channel_id, method, args, &err);
 
-  if (error) {
-    vim_report_error(result.data.string);
+  if (err.set) {
+    vim_report_error(cstr_as_string(err.msg));
     api_free_object(result);
     return NIL;
   }


### PR DESCRIPTION
- Add error type information to `Error`
- Rename `set_api_error` to `api_set_error` for consistency with other api_*
  functions/macros.
- Refactor the api_set_error macro to accept formatted strings and error types
- Improve error messages
- Wrap error messages with gettext macro
- Refactor msgpack-rpc serialization to transform Error instances into [type,
  message] arrays
- Add error type information to API metadata
- Normalize nvim->client and client->nvim error handling(change
  channel_send_call to accept an Error pointer instead of the `errored` boolean
  pointer)
- Use macro to initialize Error structures
