### PR TITLE
[RFC] build: ensure umask 0022 during `make install`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required (VERSION 2.8.7)
 project (NEOVIM)
 
+if (UNIX)
+  execute_process(COMMAND umask 0022)
+endif()
+
 # Point CMake at any custom modules we may ship
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 


### PR DESCRIPTION
I noticed that `sudo make install` doesn't allow non-root users access to `/usr/local/share/nvim/`. This is because my `.bashrc` defaults to `umask 0077`. `sudo` inherits this (unless `umask_override` is [configured](http://superuser.com/a/315115/114842)) and that causes `sudo make install` to create files that are unreadable by non-root users.

One could argue that people running with a restrictive `umask` should deal with this on their own, but `apt-get` doesn't have this problem, and it's probably a good idea to make the install step as robust as possible--assuming there's no surprising or undesirable side effects.

CMake doesn't seem to allow detection of the "current target", so I can't do something like:

```
if (TARGET MATCHES install)
    ...
endif()
```

If anyone knows a better way to handle this, or knows of any problems this could cause, let me know.
