### PR TITLE
[RFC] IPv6 support for API server

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -479,3 +479,14 @@ bool os_fileid_equal_fileinfo(const FileID *file_id,
          && file_id->device_id == file_info->stat.st_dev;
 }
 
+
+/// Set access time and modification time of a file
+///
+/// @return `0` on success, a libuv error code on failure.
+int os_utime(const char *path, double atime, double mtime)
+{
+  uv_fs_t utime_req;
+  int r = uv_fs_utime(uv_default_loop(), &utime_req, path, atime, mtime, NULL);
+  uv_fs_req_cleanup(&utime_req);
+  return r;
+}

--- a/src/nvim/os/server.c
+++ b/src/nvim/os/server.c
@@ -16,7 +16,7 @@
 
 #define MAX_CONNECTIONS 32
 #define ADDRESS_MAX_SIZE 256
-#define NEOVIM_DEFAULT_TCP_PORT 7450
+#define NVIM_DEFAULT_TCP_PORT 7450
 #define LISTEN_ADDRESS_ENV_VAR "NVIM_LISTEN_ADDRESS"
 
 typedef enum {
@@ -32,7 +32,10 @@ typedef struct {
   union {
     struct {
       uv_tcp_t handle;
-      struct sockaddr_in addr;
+      union {
+        struct sockaddr_in ipv4;
+        struct sockaddr_in6 ipv6;
+      } addr;
     } tcp;
     struct {
       uv_pipe_t handle;
@@ -83,7 +86,7 @@ void server_teardown(void)
 /// `endpoint` for API calls. The type of socket used(tcp or unix/pipe) will
 /// be determined by parsing `endpoint`: If it's a valid tcp address in the
 /// 'ip[:port]' format, then it will be tcp socket. The port is optional
-/// and if omitted will default to NEOVIM_DEFAULT_TCP_PORT. Otherwise it will
+/// and if omitted will default to NVIM_DEFAULT_TCP_PORT. Otherwise it will
 /// be a unix socket or named pipe.
 ///
 /// @param endpoint Address of the server. Either a 'ip[:port]' string or an
@@ -108,7 +111,18 @@ void server_start(char *endpoint)
 
   ServerType server_type = kServerTypeTcp;
   Server *server = xmalloc(sizeof(Server));
-  char ip[16], *ip_end = strrchr(addr, ':');
+  char ip[INET6_ADDRSTRLEN + 2], *ip_end = NULL;
+
+  // Is it an IPv6 address in the form
+  // [2001:db8:85a3:8d3:1319:8a2e:370:7348]:PORT?
+  if (addr[0] == '[') {
+    char *tmp = strrchr(addr, ']');
+    if (tmp) {
+      ip_end = strrchr(tmp, ':');
+    }
+  } else {
+    ip_end = strrchr(addr, ':');
+  }
 
   if (!ip_end) {
     ip_end = strchr(addr, NUL);
@@ -117,14 +131,15 @@ void server_start(char *endpoint)
   uint32_t addr_len = ip_end - addr;
 
   if (addr_len > sizeof(ip) - 1) {
-    // Maximum length of an IP address buffer is 15(eg: 255.255.255.255)
+    // Maximum length of an IPv6 address buffer is 48
+    // (e.g.: [0000:0000:0000:0000:0000:0000:255.255.255.255])
     addr_len = sizeof(ip) - 1;
   }
 
   // Extract the address part
   xstrlcpy(ip, addr, addr_len + 1);
 
-  int port = NEOVIM_DEFAULT_TCP_PORT;
+  in_port_t port = NVIM_DEFAULT_TCP_PORT;
 
   if (*ip_end == ':') {
     // Extract the port
@@ -133,15 +148,26 @@ void server_start(char *endpoint)
       // Invalid port, treat as named pipe or unix socket
       server_type = kServerTypePipe;
     } else {
-      port = (int) lport;
+      port = (in_port_t) lport;
     }
   }
 
   if (server_type == kServerTypeTcp) {
-    // Try to parse ip address
-    if (uv_ip4_addr(ip, port, &server->socket.tcp.addr)) {
-      // Invalid address, treat as named pipe or unix socket
-      server_type = kServerTypePipe;
+    // Try to parse ip address,
+    // if it starts with a '[' it's supposed to be an IPv6 address,
+    // otherwise try to parse it as an IPv4 address.
+    if (ip[0] == '[' && ip[addr_len - 1] == ']') {
+      char *addr = ip;
+      addr++[addr_len - 1] = '\0';
+      if (uv_ip6_addr(addr, port, &server->socket.tcp.addr.ipv6)) {
+        // Invalid address, treat as named pipe or unix socket
+        server_type = kServerTypePipe;
+      }
+    } else {
+      if (uv_ip4_addr(ip, port, &server->socket.tcp.addr.ipv4)) {
+        // Invalid address, treat as named pipe or unix socket
+        server_type = kServerTypePipe;
+      }
     }
   }
 


### PR DESCRIPTION
IPv6 addresses are specified as suggested in http://tools.ietf.org/html/rfc5952
using square brackets, e.g. [2001:db8:85a3:8d3:1319:8a2e:370:7348]:1337

(Sorry for the previous PR with unlinted file)
