### PR TITLE
[RDY] Remove FOR_ALL_WINDOWS and replace with FOR_ALL_WINDOWS_IN_TAB(curtab)

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1760,7 +1760,7 @@ buflist_findpat (
               /* Ignore the match if the buffer is not open in
                * the current tab. */
               bool found_window = false;
-              FOR_ALL_WINDOWS(wp) {
+              FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
                 if (wp->w_buffer == buf) {
                   found_window = true;
                   break;
@@ -2025,7 +2025,7 @@ static void buflist_setfpos(buf_T *buf, win_T *win, linenr_T lnum, colnr_T col, 
 static bool wininfo_other_tab_diff(wininfo_T *wip)
 {
   if (wip->wi_opt.wo_diff) {
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       /* return false when it's a window in the current tab page, thus
        * the buffer was in diff mode here */
       if (wip->wi_win == wp) {
@@ -3761,7 +3761,7 @@ do_arg_all (
     if (opened[i] > 0) {
       /* Move the already present window to below the current window */
       if (curwin->w_arg_idx != i) {
-        FOR_ALL_WINDOWS(wp) {
+        FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
           if (wp->w_arg_idx == i) {
             if (keep_tabs) {
               new_curwin = wp;

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -87,7 +87,7 @@ void diff_buf_adjust(win_T *win)
     // When there is no window showing a diff for this buffer, remove
     // it from the diffs.
     bool found_win = false;
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if ((wp->w_buffer == win->w_buffer) && wp->w_p_diff) {
         found_win = true;
       }
@@ -578,7 +578,7 @@ static int diff_check_sanity(tabpage_T *tp, diff_T *dp)
 /// @param dofold Also recompute the folds
 static void diff_redraw(int dofold)
 {
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_p_diff) {
       redraw_win_later(wp, SOME_VALID);
       if (dofold && foldmethodIsDiff(wp)) {
@@ -1107,7 +1107,7 @@ void ex_diffoff(exarg_T *eap)
   win_T *old_curwin = curwin;
   int diffwin = FALSE;
 
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (eap->forceit ? wp->w_p_diff : (wp == curwin)) {
       // Set 'diff', 'scrollbind' off and 'wrap' on. If option values
       // were saved in diff_win_options() restore them.
@@ -2358,7 +2358,7 @@ void ex_diffgetput(exarg_T *eap)
 /// @param skip_idx
 static void diff_fold_update(diff_T *dp, int skip_idx)
 {
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     for (int i = 0; i < DB_COUNT; ++i) {
       if ((curtab->tp_diffbuf[i] == wp->w_buffer) && (i != skip_idx)) {
         foldUpdate(wp, dp->df_lnum[i], dp->df_lnum[i] + dp->df_count[i]);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7397,7 +7397,7 @@ static void f_bufwinnr(typval_T *argvars, typval_T *rettv)
   buf_T *buf = get_buf_tv(&argvars[0], TRUE);
   int winnr = 0;
   bool found_buf = false;
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     ++winnr;
     if (wp->w_buffer == buf) {
       found_buf = true;
@@ -14967,7 +14967,7 @@ static void f_winrestcmd(typval_T *argvars, typval_T *rettv)
   char_u buf[50];
 
   ga_init(&ga, (int)sizeof(char), 70);
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     sprintf((char *)buf, "%dresize %d|", winnr, wp->w_height);
     ga_concat(&ga, buf);
     sprintf((char *)buf, "vert %dresize %d|", winnr, wp->w_width);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4614,7 +4614,7 @@ prepare_tagpreview (
    */
   if (!curwin->w_p_pvw) {
     bool found_win = false;
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_p_pvw) {
         win_enter(wp, undo_sync);
         found_win = true;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1217,7 +1217,7 @@ check_changed_any (
   /* curbuf */
   bufnrs[bufnum++] = curbuf->b_fnum;
   /* buf in curtab */
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer != curbuf) {
       add_bufnum(bufnrs, &bufnum, wp->w_buffer->b_fnum);
     }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5188,7 +5188,7 @@ static void ex_close(exarg_T *eap)
  */
 static void ex_pclose(exarg_T *eap)
 {
-  FOR_ALL_WINDOWS(win) {
+  FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
     if (win->w_p_pvw) {
       ex_win_close(eap->forceit, win, NULL);
       break;
@@ -6137,7 +6137,7 @@ static void ex_syncbind(exarg_T *eap)
    */
   if (curwin->w_p_scb) {
     topline = curwin->w_topline;
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_p_scb && wp->w_buffer) {
         y = wp->w_buffer->b_ml.ml_line_count - p_so;
         if (topline > y) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8025,7 +8025,7 @@ makeopens (
      * Remember the window number of the current window after restoring.
      */
     nr = 0;
-    for (wp = tab_firstwin; wp != NULL; wp = W_NEXT(wp)) {
+    for (wp = tab_firstwin; wp != NULL; wp = wp->w_next) {
       if (ses_do_win(wp))
         ++nr;
       else

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -6180,7 +6180,7 @@ aucmd_prepbuf (
     win = curwin;
   } else {
     win = NULL;
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_buffer == buf) {
         win = wp;
         break;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -463,7 +463,7 @@ void newFoldLevel(void)
     /*
      * Set the same foldlevel in other windows in diff mode.
      */
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp != curwin && foldmethodIsDiff(wp) && wp->w_p_scb) {
         wp->w_p_fdl = curwin->w_p_fdl;
         newFoldLevelWin(wp);
@@ -1143,7 +1143,7 @@ setManualFold (
      * Do the same operation in other windows in diff mode.  Calculate the
      * line number from the diffs.
      */
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp != curwin && foldmethodIsDiff(wp) && wp->w_p_scb) {
         dlnum = diff_lnum_win(curwin->w_cursor.lnum, wp);
         if (dlnum != 0) {

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -519,8 +519,6 @@ EXTERN win_T    *firstwin;              /* first window */
 EXTERN win_T    *lastwin;               /* last window */
 EXTERN win_T    *prevwin INIT(= NULL);  /* previous window */
 # define W_NEXT(wp) ((wp)->w_next)
-# define FOR_ALL_WINDOWS(wp) \
-   FOR_ALL_WINDOWS_IN_TAB(wp, curtab)
 /*
  * When using this macro "break" only breaks out of the inner loop. Use "goto"
  * to break out of the tabpage loop.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -518,7 +518,6 @@ EXTERN int updating_screen INIT(= FALSE);
 EXTERN win_T    *firstwin;              /* first window */
 EXTERN win_T    *lastwin;               /* last window */
 EXTERN win_T    *prevwin INIT(= NULL);  /* previous window */
-# define W_NEXT(wp) ((wp)->w_next)
 /*
  * When using this macro "break" only breaks out of the inner loop. Use "goto"
  * to break out of the tabpage loop.

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -475,7 +475,7 @@ int main(int argc, char **argv)
 
   if (params.diff_mode) {
     /* set options in each window for "vimdiff". */
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       diff_win_options(wp, TRUE);
     }
   }

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -511,7 +511,7 @@ void fmarks_check_names(buf_T *buf)
   for (i = 0; i < NMARKS + EXTRA_MARKS; ++i)
     fmarks_check_one(&namedfm[i], name, buf);
 
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     for (i = 0; i < wp->w_jumplistlen; ++i) {
       fmarks_check_one(&wp->w_jumplist[i], name, buf);
     }
@@ -1092,7 +1092,7 @@ void mark_col_adjust(linenr_T lnum, colnr_T mincol, long lnum_amount, long col_a
   /*
    * Adjust items in all windows related to the current buffer.
    */
-  FOR_ALL_WINDOWS(win) {
+  FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
     /* marks in the jumplist */
     for (i = 0; i < win->w_jumplistlen; ++i) {
       if (win->w_jumplist[i].fmark.fnum == fnum) {
@@ -1533,7 +1533,7 @@ void copy_viminfo_marks(vir_T *virp, FILE *fp_out, int count, int eof, int flags
         fputs((char *)line, fp_out);
     }
     if (load_marks) {
-      FOR_ALL_WINDOWS(wp) {
+      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
         if (wp->w_buffer == curbuf)
           wp->w_changelistidx = curbuf->b_changelistlen;
       }

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1879,7 +1879,7 @@ void changed_bytes(linenr_T lnum, colnr_T col)
   if (curwin->w_p_diff) {
     linenr_T wlnum;
 
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_p_diff && wp != curwin) {
         redraw_win_later(wp, VALID);
         wlnum = diff_lnum_win(lnum, wp);
@@ -1975,7 +1975,7 @@ changed_lines (
      * displaying. */
     linenr_T wlnum;
 
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_p_diff && wp != curwin) {
         redraw_win_later(wp, VALID);
         wlnum = diff_lnum_win(lnum, wp);
@@ -2212,7 +2212,7 @@ unchanged (
  */
 void check_status(buf_T *buf)
 {
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer == buf && wp->w_status_height) {
       wp->w_redr_status = TRUE;
       if (must_redraw < VALID) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4014,7 +4014,7 @@ dozet:
   if (old_fen != curwin->w_p_fen) {
     if (foldmethodIsDiff(curwin) && curwin->w_p_scb) {
       /* Adjust 'foldenable' in diff-synced windows. */
-      FOR_ALL_WINDOWS(wp) {
+      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
         if (wp != curwin && foldmethodIsDiff(wp) && wp->w_p_scb) {
           wp->w_p_fen = curwin->w_p_fen;
           changed_window_setting_win(wp);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3697,7 +3697,7 @@ op_format (
   }
 
   if (oap->is_VIsual) {
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_old_cursor_lnum != 0) {
         /* When lines have been inserted or deleted, adjust the end of
          * the Visual area to be redrawn. */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4309,7 +4309,7 @@ did_set_string_option (
     }
 
     if (errmsg == NULL) {
-      FOR_ALL_WINDOWS(wp) {
+      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
         if (wp->w_buffer == curbuf && wp->w_p_spell) {
           errmsg = did_set_spelllang(wp);
           break;
@@ -5068,7 +5068,7 @@ set_bool_option (
   /* There can be only one window with 'previewwindow' set. */
   else if ((int *)varp == &curwin->w_p_pvw) {
     if (curwin->w_p_pvw) {
-      FOR_ALL_WINDOWS(win) {
+      FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
         if (win->w_p_pvw && win != curwin) {
           curwin->w_p_pvw = FALSE;
           return (char_u *)N_("E590: A preview window already exists");

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1382,7 +1382,7 @@ void qf_jump(qf_info_T *qi, int dir, int errornr, int forceit)
     win_T *wp = NULL;
 
     if (cmdmod.tab == 0) {
-      FOR_ALL_WINDOWS(wp2) {
+      FOR_ALL_WINDOWS_IN_TAB(wp2, curtab) {
         if (wp2->w_buffer != NULL && wp2->w_buffer->b_help) {
           wp = wp2;
           break;
@@ -1441,7 +1441,7 @@ void qf_jump(qf_info_T *qi, int dir, int errornr, int forceit)
     if (ll_ref != NULL) {
       /* Find a window using the same location list that is not a
        * quickfix window. */
-      FOR_ALL_WINDOWS(wp) {
+      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
         if (wp->w_llist == ll_ref
             && wp->w_buffer->b_p_bt[0] != 'q') {
           usable_win = true;
@@ -1453,7 +1453,7 @@ void qf_jump(qf_info_T *qi, int dir, int errornr, int forceit)
 
     if (!usable_win) {
       /* Locate a window showing a normal buffer */
-      FOR_ALL_WINDOWS(wp) {
+      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
         if (wp->w_buffer->b_p_bt[0] == NUL) {
           usable_win = true;
           break;
@@ -1502,7 +1502,7 @@ win_found:
         win = usable_win_ptr;
         if (win == NULL) {
           /* Find the window showing the selected file */
-          FOR_ALL_WINDOWS(wp) {
+          FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
             if (wp->w_buffer->b_fnum == qf_ptr->qf_fnum) {
               win = wp;
               break;
@@ -2217,7 +2217,7 @@ static int is_qf_win(win_T *win, qf_info_T *qi)
  */
 static win_T *qf_find_win(qf_info_T *qi)
 {
-  FOR_ALL_WINDOWS(win) {
+  FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
     if (is_qf_win(win, qi)) {
       return win;
     }
@@ -3507,7 +3507,7 @@ void ex_helpgrep(exarg_T *eap)
     qi = NULL;
 
     /* Find an existing help window */
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_buffer != NULL && wp->w_buffer->b_help) {
         qi = wp->w_llist;
       }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -206,7 +206,7 @@ void redraw_later_clear(void)
  */
 void redraw_all_later(int type)
 {
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     redraw_win_later(wp, type);
   }
 }
@@ -221,7 +221,7 @@ void redraw_curbuf_later(int type)
 
 void redraw_buf_later(buf_T *buf, int type)
 {
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer == buf) {
       redraw_win_later(wp, type);
     }
@@ -432,7 +432,7 @@ void update_screen(int type)
       check_for_delay(FALSE);
       if (screen_ins_lines(0, 0, msg_scrolled, (int)Rows, NULL) == FAIL)
         type = CLEAR;
-      FOR_ALL_WINDOWS(wp) {
+      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
         if (wp->w_winrow < msg_scrolled) {
           if (wp->w_winrow + wp->w_height > msg_scrolled
               && wp->w_redr_type < REDRAW_TOP
@@ -506,7 +506,7 @@ void update_screen(int type)
    * Correct stored syntax highlighting info for changes in each displayed
    * buffer.  Each buffer must only be done once.
    */
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer->b_mod_set) {
       win_T       *wwp;
 
@@ -527,7 +527,7 @@ void update_screen(int type)
    */
   did_one = FALSE;
   search_hl.rm.regprog = NULL;
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_redr_type != 0) {
       cursor_off();
       if (!did_one) {
@@ -550,7 +550,7 @@ void update_screen(int type)
 
   /* Reset b_mod_set flags.  Going through all windows is probably faster
    * than going through all buffers (there could be many buffers). */
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     wp->w_buffer->b_mod_set = FALSE;
   }
 
@@ -659,7 +659,7 @@ void update_debug_sign(buf_T *buf, linenr_T lnum)
     win_foldinfo.fi_level = 0;
 
     /* update/delete a specific mark */
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (buf != NULL && lnum > 0) {
         if (wp->w_buffer == buf && lnum >= wp->w_topline
             && lnum < wp->w_botline) {
@@ -688,7 +688,7 @@ void update_debug_sign(buf_T *buf, linenr_T lnum)
     /* update all windows that need updating */
     update_prepare();
 
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_redr_type != 0) {
         win_update(wp);
       }
@@ -4555,7 +4555,7 @@ void rl_mirror(char_u *str)
 void status_redraw_all(void)
 {
 
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_status_height) {
       wp->w_redr_status = TRUE;
       redraw_later(VALID);
@@ -4568,7 +4568,7 @@ void status_redraw_all(void)
  */
 void status_redraw_curbuf(void)
 {
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_status_height != 0 && wp->w_buffer == curbuf) {
       wp->w_redr_status = TRUE;
       redraw_later(VALID);
@@ -4581,7 +4581,7 @@ void status_redraw_curbuf(void)
  */
 void redraw_statuslines(void)
 {
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_redr_status) {
       win_redr_status(wp);
     }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6927,7 +6927,7 @@ int win_ins_lines(win_T *wp, int row, int line_count, int invalid, int mayclear)
     /* deletion will have messed up other windows */
     if (did_delete) {
       wp->w_redr_status = TRUE;
-      win_rest_invalid(W_NEXT(wp));
+      win_rest_invalid(wp->w_next);
     }
     return FAIL;
   }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -4162,7 +4162,7 @@ void spell_reload(void)
   spell_free_all();
 
   // Go through all buffers and handle 'spelllang'.
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     // Only load the wordlists when 'spelllang' is set and there is a
     // window for this buffer in which 'spell' is set.
     if (*wp->w_s->b_p_spl != NUL) {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -987,7 +987,7 @@ void syn_stack_free_all(synblock_T *block)
   syn_stack_free_block(block);
 
   /* When using "syntax" fold method, must update all folds. */
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_s == block && foldmethodIsSyntax(wp)) {
       foldUpdateAll(wp);
     }
@@ -1074,7 +1074,7 @@ void syn_stack_apply_changes(buf_T *buf)
 {
   syn_stack_apply_changes_block(&buf->b_s, buf);
 
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if ((wp->w_buffer == buf) && (wp->w_s != &buf->b_s)) {
       syn_stack_apply_changes_block(wp->w_s, buf);
     }

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2191,7 +2191,7 @@ u_undo_end (
     u_add_time(msgbuf, sizeof(msgbuf), uhp->uh_time);
 
   {
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_buffer == curbuf && wp->w_p_cole > 0) {
         redraw_win_later(wp, NOT_VALID);
       }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1037,7 +1037,7 @@ int win_valid(win_T *win)
 {
   if (win == NULL)
     return FALSE;
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp == win) {
       return TRUE;
     }
@@ -1052,7 +1052,7 @@ int win_count(void)
 {
   int count = 0;
 
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     ++count;
   }
   return count;
@@ -1735,7 +1735,7 @@ bool one_window(void)
 {
   bool seen_one = false;
 
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp != aucmd_win) {
       if (seen_one) {
         return false;
@@ -3537,7 +3537,7 @@ static void win_enter_ext(win_T *wp, bool undo_sync, int curwin_invalid, int tri
  */
 win_T *buf_jump_open_win(buf_T *buf)
 {
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer == buf) {
       win_enter(wp, false);
       return wp;
@@ -3856,7 +3856,7 @@ void win_size_save(garray_T *gap)
 {
   ga_init(gap, (int)sizeof(int), 1);
   ga_grow(gap, win_count() * 2);
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     ((int *)gap->ga_data)[gap->ga_len++] =
       wp->w_width + wp->w_vsep_width;
     ((int *)gap->ga_data)[gap->ga_len++] = wp->w_height;
@@ -3875,7 +3875,7 @@ void win_size_restore(garray_T *gap)
     for (int j = 0; j < 2; ++j)
     {
       int i = 0;
-      FOR_ALL_WINDOWS(wp) {
+      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
         frame_setwidth(wp->w_frame, ((int *)gap->ga_data)[i++]);
         win_setheight_win(((int *)gap->ga_data)[i++], wp);
       }
@@ -4309,7 +4309,7 @@ void win_setminheight(void)
   while (p_wmh > 0) {
     /* TODO: handle vertical splits */
     room = -p_wh;
-    FOR_ALL_WINDOWS(wp) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       room += wp->w_height - p_wmh;
     }
     if (room >= 0)
@@ -5004,7 +5004,7 @@ int only_one_window(void)
   if (first_tabpage->tp_next != NULL)
     return FALSE;
 
-  FOR_ALL_WINDOWS(wp) {
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer != NULL
         && (!((wp->w_buffer->b_help && !curbuf->b_help)
               || wp->w_p_pvw


### PR DESCRIPTION
`FOR_ALL_WINDOWS` suggests that all windows are iterated over. In reality it is just the windows in the current tab. Replacing makes the behavior clearer.

Also removed `W_NEXT(wp)` since it was used in two places and doesn't buy anything over the `wp->w_next` that it expands to.
