### PR TITLE
[RFC] vim-patch:7.4.320

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -318,7 +318,7 @@ close_buffer (
   } else if (buf->b_p_bh[0] == 'u')     /* 'bufhidden' == "unload" */
     unload_buf = true;
 
-  if (win != NULL) {
+  if (win_valid(win)) {
     /* Set b_last_cursor when closing the last window for the buffer.
      * Remember the last cursor position and window options of the buffer.
      * This used to be only for the current window, but then options like

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -6754,7 +6754,8 @@ apply_autocmds_group (
   --nesting;            /* see matching increment above */
 
   // When stopping to execute autocommands, restore the search patterns and
-  // the redo buffer.  Free buffers in the au_pending_free_buf list.
+  // the redo buffer. Free any buffers in the au_pending_free_buf list and
+  // free any windows in the au_pending_free_win list.
   if (!autocmd_busy) {
     restore_search_patterns();
     restoreRedobuff();
@@ -6763,6 +6764,11 @@ apply_autocmds_group (
       buf_T *b = au_pending_free_buf->b_next;
       free(au_pending_free_buf);
       au_pending_free_buf = b;
+    }
+    while (au_pending_free_win != NULL) {
+      win_T *w = au_pending_free_win->w_next;
+      free(au_pending_free_win);
+      au_pending_free_win = w;
     }
   }
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -468,10 +468,12 @@ EXTERN int keep_filetype INIT(= FALSE);         /* value for did_filetype when
  * which one is preferred, au_new_curbuf is set to it */
 EXTERN buf_T    *au_new_curbuf INIT(= NULL);
 
-// When deleting the buffer and autocmd_busy is TRUE, do not free the buffer
-// but link it in the list starting with au_pending_free_buf, using b_next.
-// Free the buffer when autocmd_busy is set to FALSE.
+// When deleting a buffer/window and autocmd_busy is TRUE, do not free the
+// buffer/window. but link it in the list starting with
+// au_pending_free_buf/ap_pending_free_win, using b_next/w_next.
+// Free the buffer/window when autocmd_busy is being set to FALSE.
 EXTERN buf_T *au_pending_free_buf INIT(= NULL);
+EXTERN win_T *au_pending_free_win INIT(= NULL);
 
 /*
  * Mouse coordinates, set by check_termcode()

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -308,7 +308,7 @@ static int included_patches[] = {
   323,
   //322 NA
   //321 NA
-  //320,
+  320,
   //319 NA
   318,
   317,

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3679,7 +3679,12 @@ win_free (
 
   if (wp != aucmd_win)
     win_remove(wp, tp);
-  free(wp);
+  if (autocmd_busy) {
+    wp->w_next = au_pending_free_win;
+    au_pending_free_win = wp;
+  } else {
+    free(wp);
+  }
 
   unblock_autocmds();
 }


### PR DESCRIPTION
Problem:    Possible crash when an BufLeave autocommand deletes the buffer.
Solution:   Check for the window pointer being valid.  Postpone freeing the window until autocommands are done. (Yasuhiro Matsumoto)

https://code.google.com/p/vim/source/detail?r=v7-4-320
