### PR TITLE
[RDY] os_scandir/scandir_next/closedir()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
   endif()
+
+  # Enable fixing case-insensitive filenames for Mac.
+  set(USE_FNAME_CASE TRUE)
 endif()
 
 # Set available build types for CMake GUIs.

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -15,7 +15,6 @@
 
 #cmakedefine HAVE__NSGETENVIRON
 #cmakedefine HAVE_CRT_EXTERNS_H
-#cmakedefine HAVE_DIRENT_H
 #cmakedefine HAVE_FCNTL_H
 #cmakedefine HAVE_FD_CLOEXEC
 #cmakedefine HAVE_FSEEKO
@@ -60,6 +59,7 @@
 #define SIGRETURN return
 #define TIME_WITH_SYS_TIME 1
 #cmakedefine UNIX
+#cmakedefine USE_FNAME_CASE
 #define USEMAN_S 1
 
 #define FEAT_BROWSE

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2253,7 +2253,7 @@ setfname (
     }
     sfname = vim_strsave(sfname);
 #ifdef USE_FNAME_CASE
-    fname_case(sfname, 0);            /* set correct case for short file name */
+    path_fix_case(sfname);            /* set correct case for short file name */
 #endif
     free(buf->b_ffname);
     free(buf->b_sfname);

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -24,6 +24,7 @@
 #include "nvim/move.h"
 #include "nvim/os_unix.h"
 #include "nvim/strings.h"
+#include "nvim/path.h"
 
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -871,7 +872,7 @@ int vim_isfilec(int c)
 
 /// return TRUE if 'c' is a valid file-name character or a wildcard character
 /// Assume characters above 0x100 are valid (multi-byte).
-/// Explicitly interpret ']' as a wildcard character as mch_has_wildcard("]")
+/// Explicitly interpret ']' as a wildcard character as path_has_wildcard("]")
 /// returns false.
 ///
 /// @param c
@@ -882,7 +883,7 @@ int vim_isfilec_or_wc(int c)
   char_u buf[2];
   buf[0] = (char_u)c;
   buf[1] = NUL;
-  return vim_isfilec(c) || c == ']' || mch_has_wildcard(buf);
+  return vim_isfilec(c) || c == ']' || path_has_wildcard(buf);
 }
 
 /// return TRUE if 'c' is a printable character

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9895,9 +9895,7 @@ static void f_has(typval_T *argvars, typval_T *rettv)
 #if defined(WIN64) || defined(_WIN64)
     "win64",
 #endif
-#ifndef CASE_INSENSITIVE_FILENAME
     "fname_case",
-#endif
 #ifdef HAVE_ACL
     "acl",
 #endif

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2563,7 +2563,7 @@ do_ecmd (
       sfname = ffname;
 #ifdef USE_FNAME_CASE
     if (sfname != NULL)
-      fname_case(sfname, 0);             /* set correct case for sfname */
+      path_fix_case(sfname);             // set correct case for sfname
 #endif
 
     if ((flags & ECMD_ADDBUF) && (ffname == NULL || *ffname == NUL))

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3432,7 +3432,7 @@ int expand_filename(exarg_T *eap, char_u **cmdlinep, char_u **errormsgp)
    * the file name contains a wildcard it should not cause expanding.
    * (it will be expanded anyway if there is a wildcard before replacing).
    */
-  has_wildcards = mch_has_wildcard(p);
+  has_wildcards = path_has_wildcard(p);
   while (*p != NUL) {
     /* Skip over `=expr`, wildcards in it are not expanded. */
     if (p[0] == '`' && p[1] == '=') {
@@ -3543,7 +3543,7 @@ int expand_filename(exarg_T *eap, char_u **cmdlinep, char_u **errormsgp)
           || vim_strchr(eap->arg, '~') != NULL) {
         expand_env_esc(eap->arg, NameBuff, MAXPATHL,
             TRUE, TRUE, NULL);
-        has_wildcards = mch_has_wildcard(NameBuff);
+        has_wildcards = path_has_wildcard(NameBuff);
         p = NameBuff;
       } else
         p = NULL;

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1290,8 +1290,8 @@ scripterror:
       }
 
 #ifdef USE_FNAME_CASE
-      /* Make the case of the file name match the actual file. */
-      fname_case(p, 0);
+      // Make the case of the file name match the actual file.
+      path_fix_case(p);
 #endif
 
       alist_add(&global_alist, p,

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -348,6 +348,39 @@ int os_rmdir(const char *path)
   return result;
 }
 
+/// Opens a directory.
+/// @param[out] dir   The Directory object.
+/// @param      path  Path to the directory.
+/// @returns true if dir contains one or more items, false if not or an error
+///          occurred.
+bool os_scandir(Directory *dir, const char *path)
+  FUNC_ATTR_NONNULL_ALL
+{
+  int r = uv_fs_scandir(uv_default_loop(), &dir->request, path, 0, NULL);
+  if (r <= 0) {
+    os_closedir(dir);
+  }
+  return r > 0;
+}
+
+/// Increments the directory pointer.
+/// @param dir  The Directory object.
+/// @returns a pointer to the next path in `dir` or `NULL`.
+const char *os_scandir_next(Directory *dir)
+  FUNC_ATTR_NONNULL_ALL
+{
+  int err = uv_fs_scandir_next(&dir->request, &dir->ent);
+  return err != UV_EOF ? dir->ent.name : NULL;
+}
+
+/// Frees memory associated with `os_scandir()`.
+/// @param dir  The directory.
+void os_closedir(Directory *dir)
+  FUNC_ATTR_NONNULL_ALL
+{
+  uv_fs_req_cleanup(&dir->request);
+}
+
 /// Remove a file.
 ///
 /// @return `0` for success, non-zero for failure.

--- a/src/nvim/os/fs_defs.h
+++ b/src/nvim/os/fs_defs.h
@@ -16,4 +16,9 @@ typedef struct {
 
 #define FILE_ID_EMPTY (FileID) {.inode = 0, .device_id = 0}
 
+typedef struct {
+  uv_fs_t request;  ///< @private The request to uv for the directory.
+  uv_dirent_t ent;  ///< @private The entry information.
+} Directory;
+
 #endif  // NVIM_OS_FS_DEFS_H

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -719,47 +719,12 @@ static void save_patterns(int num_pat, char_u **pat, int *num_file,
   *num_file = num_pat;
 }
 
-/*
- * Return TRUE if the string "p" contains a wildcard that mch_expandpath() can
- * expand.
- */
-int mch_has_exp_wildcard(char_u *p)
-{
-  for (; *p; mb_ptr_adv(p)) {
-    if (*p == '\\' && p[1] != NUL)
-      ++p;
-    else if (vim_strchr((char_u *)
-                 "*?[{'"
-                 , *p) != NULL)
-      return TRUE;
-  }
-  return FALSE;
-}
-
-/*
- * Return TRUE if the string "p" contains a wildcard.
- * Don't recognize '~' at the end as a wildcard.
- */
-int mch_has_wildcard(char_u *p)
-{
-  for (; *p; mb_ptr_adv(p)) {
-    if (*p == '\\' && p[1] != NUL)
-      ++p;
-    else if (vim_strchr((char_u *)
-                 "*?[{`'$"
-                 , *p) != NULL
-             || (*p == '~' && p[1] != NUL))
-      return TRUE;
-  }
-  return FALSE;
-}
-
 static int have_wildcard(int num, char_u **file)
 {
   int i;
 
   for (i = 0; i < num; i++)
-    if (mch_has_wildcard(file[i]))
+    if (path_has_wildcard(file[i]))
       return 1;
   return 0;
 }

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -69,62 +69,6 @@ static int selinux_enabled = -1;
 # include "os_unix.c.generated.h"
 #endif
 
-#if defined(USE_FNAME_CASE)
-/*
- * Set the case of the file name, if it already exists.  This will cause the
- * file name to remain exactly the same.
- * Only required for file systems where case is ignored and preserved.
- */
-void fname_case(
-char_u      *name,
-int len               /* buffer size, only used when name gets longer */
-)
-{
-  char_u      *slash, *tail;
-  DIR         *dirp;
-  struct dirent *dp;
-
-  FileInfo file_info;
-  if (os_fileinfo_link((char *)name, &file_info)) {
-    /* Open the directory where the file is located. */
-    slash = vim_strrchr(name, '/');
-    if (slash == NULL) {
-      dirp = opendir(".");
-      tail = name;
-    } else {
-      *slash = NUL;
-      dirp = opendir((char *)name);
-      *slash = '/';
-      tail = slash + 1;
-    }
-
-    if (dirp != NULL) {
-      while ((dp = readdir(dirp)) != NULL) {
-        /* Only accept names that differ in case and are the same byte
-         * length. TODO: accept different length name. */
-        if (STRICMP(tail, dp->d_name) == 0
-            && STRLEN(tail) == STRLEN(dp->d_name)) {
-          char_u newname[MAXPATHL + 1];
-
-          /* Verify the inode is equal. */
-          STRLCPY(newname, name, MAXPATHL + 1);
-          STRLCPY(newname + (tail - name), dp->d_name,
-              MAXPATHL - (tail - name) + 1);
-          FileInfo file_info_new;
-          if (os_fileinfo_link((char *)newname, &file_info_new)
-              && os_fileinfo_id_equal(&file_info, &file_info_new)) {
-            STRCPY(tail, dp->d_name);
-            break;
-          }
-        }
-      }
-
-      closedir(dirp);
-    }
-  }
-}
-#endif
-
 #if defined(HAVE_ACL)
 # ifdef HAVE_SYS_ACL_H
 #  include <sys/acl.h>

--- a/src/nvim/os_unix_defs.h
+++ b/src/nvim/os_unix_defs.h
@@ -44,25 +44,6 @@
 # define SIGDUMMYARG
 #endif
 
-#ifdef HAVE_DIRENT_H
-# include <dirent.h>
-# ifndef NAMLEN
-#  define NAMLEN(dirent) strlen((dirent)->d_name)
-# endif
-#else
-# define dirent direct
-# define NAMLEN(dirent) (dirent)->d_namlen
-# if HAVE_SYS_NDIR_H
-#  include <sys/ndir.h>
-# endif
-# if HAVE_SYS_DIR_H
-#  include <sys/dir.h>
-# endif
-# if HAVE_NDIR_H
-#  include <ndir.h>
-# endif
-#endif
-
 #if !defined(HAVE_SYS_TIME_H) || defined(TIME_WITH_SYS_TIME)
 # include <time.h>          /* on some systems time.h should not be
                                included together with sys/time.h */

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2587,7 +2587,7 @@ static char_u *expand_tag_fname(char_u *fname, char_u *tag_fname, int expand)
   /*
    * Expand file name (for environment variables) when needed.
    */
-  if (expand && mch_has_wildcard(fname)) {
+  if (expand && path_has_wildcard(fname)) {
     ExpandInit(&xpc);
     xpc.xp_context = EXPAND_FILES;
     expanded_fname = ExpandOne(&xpc, fname, NULL,

--- a/test/unit/path_spec.lua
+++ b/test/unit/path_spec.lua
@@ -418,6 +418,30 @@ describe('more path function', function()
     end)
   end)
 
+  describe('path_fix_case', function()
+    function fix_case(file)
+      c_file = to_cstr(file)
+      path.path_fix_case(c_file)
+      return ffi.string(c_file)
+    end
+
+    if ffi.os == 'Windows' or ffi.os == 'OSX' then
+      it('Corrects the case of file names in Mac and Windows', function()
+        lfs.mkdir('CamelCase')
+        eq('CamelCase', fix_case('camelcase'))
+        eq('CamelCase', fix_case('cAMELcASE'))
+        lfs.rmdir('CamelCase')
+      end)
+    else
+      it('does nothing on Linux', function()
+        lfs.mkdir('CamelCase')
+        eq('camelcase', fix_case('camelcase'))
+        eq('cAMELcASE', fix_case('cAMELcASE'))
+        lfs.mkdir('CamelCase')
+      end)
+    end
+  end)
+
   describe('append_path', function()
     it('joins given paths with a slash', function()
       local path1 = cstr(100, 'path1')


### PR DESCRIPTION
Moves `unix_expandpath()` and `fname_case()` out of `os_unix.c`. Since they no longer require unix, I renamed them `path_expand()` and `path_fix_case()`.

`path_fix_case()` does not have any uses, so I haven't been able to test it, but I wanted it out of `os_unix.c` because we may want to enable using it for when mounting case-insensitive file systems.

This PR would benefit from upgrading libuv as it learns `uv_fs_readdir_next()` in `v0.11.29` (we use `28`) it changes the interface to `uv_fs_readdir()` and breaks the code as I have it written. In other words, either we upgrade now and hope they don't break anything again, update this code when we do upgrade, or not integrate this PR until `uv_fs_readdir()` has stabilized (which it may or may not already have).

ref: #133
