### PR TITLE
CmdPre autocommand / event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -275,6 +275,8 @@ Name			triggered by ~
 |FileChangedShellPost|	After handling a file changed since editing started
 |FileChangedRO|		before making the first change to a read-only file
 
+|CmdPre|		before executing a command
+
 |ShellCmdPost|		after executing a shell command
 |ShellFilterPost|	after filtering with a shell command
 
@@ -466,6 +468,13 @@ BufWriteCmd			Before writing the whole buffer to a file.
 							*BufWritePost*
 BufWritePost			After writing the whole buffer to a file
 				(should undo the commands for BufWritePre).
+
+						        *CmdPre*
+CmdPre                          Before executing a command, either built-in or
+				user defined. The pattern is matched against the
+				command. Can be used to ensure some condition
+				is met before the command is executed.
+
 							*CmdwinEnter*
 CmdwinEnter			After entering the command-line window.
 				Useful for setting options specifically for

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1892,8 +1892,15 @@ static char_u * do_one_cmd(char_u **cmdlinep,
   ea.cookie = cookie;
   ea.cstack = cstack;
 
-  // apply CmdPre autocommands
-  apply_autocmds(EVENT_CMDPRE, cmdnames[ea.cmdidx].cmd_name, NULL, false, NULL);
+  // Apply CmdPre autocommands
+  char* cmd_name; 
+  if (USER_CMDIDX(ea.cmdidx)) {
+      cmd_name = (char*)strtok((char*)ea.cmd, " ");
+  } else {
+      cmd_name = (char*)cmdnames[ea.cmdidx].cmd_name;
+  }
+  apply_autocmds(EVENT_CMDPRE, (char_u *)cmd_name, NULL, false, NULL);
+  free(cmd_name);
 
   if (USER_CMDIDX(ea.cmdidx)) {
     /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1892,6 +1892,9 @@ static char_u * do_one_cmd(char_u **cmdlinep,
   ea.cookie = cookie;
   ea.cstack = cstack;
 
+  // apply CmdPre autocommands
+  apply_autocmds(EVENT_CMDPRE, cmdnames[ea.cmdidx].cmd_name, NULL, false, NULL);
+
   if (USER_CMDIDX(ea.cmdidx)) {
     /*
      * Execute a user-defined command.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1900,7 +1900,6 @@ static char_u * do_one_cmd(char_u **cmdlinep,
       cmd_name = (char*)cmdnames[ea.cmdidx].cmd_name;
   }
   apply_autocmds(EVENT_CMDPRE, (char_u *)cmd_name, NULL, false, NULL);
-  free(cmd_name);
 
   if (USER_CMDIDX(ea.cmdidx)) {
     /*

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5194,6 +5194,7 @@ static struct event_name {
   {"BufWritePost",    EVENT_BUFWRITEPOST},
   {"BufWritePre",     EVENT_BUFWRITEPRE},
   {"BufWriteCmd",     EVENT_BUFWRITECMD},
+  {"CmdPre",          EVENT_CMDPRE},
   {"CmdwinEnter",     EVENT_CMDWINENTER},
   {"CmdwinLeave",     EVENT_CMDWINLEAVE},
   {"ColorScheme",     EVENT_COLORSCHEME},
@@ -5269,7 +5270,7 @@ static AutoPat *first_autopat[NUM_EVENTS] =
   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-  NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
+  NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
 };
 
 static AutoPatCmd *active_apc_list = NULL; /* stack of active autocommands */
@@ -6625,7 +6626,8 @@ apply_autocmds_group (
         || event == EVENT_QUICKFIXCMDPRE
         || event == EVENT_COLORSCHEME
         || event == EVENT_QUICKFIXCMDPOST
-        || event == EVENT_JOBACTIVITY)
+        || event == EVENT_JOBACTIVITY
+        || event == EVENT_CMDPRE)
       fname = vim_strsave(fname);
     else
       fname = FullName_save(fname, FALSE);

--- a/src/nvim/fileio.h
+++ b/src/nvim/fileio.h
@@ -35,6 +35,7 @@ typedef enum auto_event {
   EVENT_BUFWRITEPOST,           /* after writing a buffer */
   EVENT_BUFWRITEPRE,            /* before writing a buffer */
   EVENT_BUFWRITECMD,            /* write buffer using command */
+  EVENT_CMDPRE,                 /* before executing a command */
   EVENT_CMDWINENTER,            /* after entering the cmdline window */
   EVENT_CMDWINLEAVE,            /* before leaving the cmdline window */
   EVENT_COLORSCHEME,            /* after loading a colorscheme */


### PR DESCRIPTION
Triggers before commands are executed. The pattern is matched against the command. Can be used to ensure some condition is met before the command is executed.

Inspired by the discussion on issue #1190. This event can be used to do this: 

``` vim
function! python_setup()
    if !exists('loaded_python_setup') || g:loaded_python_setup != 1
        " initialize the python host
        ...
        let g:loaded_python_setup = 1
    endif
endfunction

au! CmdPre python call python_setup()
```
## TODO
- [ ] Add tests.
- [ ] Idea: Allow the pattern to match a glob, like `py*`.
- [ ] Idea: Make command arguments available within the auto-command.
