### PR TITLE
[RFC] vim-patch:7.4.411

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -217,7 +217,7 @@ static int included_patches[] = {
   //414,
   //413 NA
   //412 NA
-  //411,
+  411,
   410,
   //409 NA
   //408,


### PR DESCRIPTION
Problem:    "foo bar" sorts before "foo" with sort(). (John Little)
Solution:   Avoid putting quotes around strings before comparing them.

https://code.google.com/p/vim/source/detail?r=v7-4-411
