### PR TITLE
[RFC] Only use CMAKE_C_COMPILER_ARG1 if it is set

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -43,7 +43,11 @@ if(CMAKE_GENERATOR MATCHES "Makefiles")
   set(MAKE_PRG "$(MAKE)")
 endif()
 
-set(DEPS_C_COMPILER "${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_ARG1}")
+if(CMAKE_C_COMPILER_ARG1)
+  set(DEPS_C_COMPILER "${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_ARG1}")
+else()
+  set(DEPS_C_COMPILER "${CMAKE_C_COMPILER}")
+endif()
 
 include(ExternalProject)
 


### PR DESCRIPTION
Closes #1222

Use end of options -- to preserve any trailing spaces
