### PR TITLE
[RFC] rework title & icon updates

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -48,6 +48,7 @@ set(CONV_SRCS
   misc2.c
   map.c
   profile.c
+  title.c
   os/env.c
   os/event.c
   os/job.c

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -61,6 +61,7 @@
 #include "nvim/tag.h"
 #include "nvim/tempfile.h"
 #include "nvim/term.h"
+#include "nvim/title.h"
 #include "nvim/ui.h"
 #include "nvim/undo.h"
 #include "nvim/window.h"

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -48,6 +48,7 @@
 #include "nvim/screen.h"
 #include "nvim/strings.h"
 #include "nvim/term.h"
+#include "nvim/title.h"
 #include "nvim/undo.h"
 #include "nvim/window.h"
 #include "nvim/profile.h"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -61,6 +61,7 @@
 #include "nvim/syntax.h"
 #include "nvim/tag.h"
 #include "nvim/term.h"
+#include "nvim/title.h"
 #include "nvim/ui.h"
 #include "nvim/undo.h"
 #include "nvim/version.h"
@@ -5383,10 +5384,11 @@ static void ex_stop(exarg_T *eap)
     out_flush();
     stoptermcap();
     out_flush();                /* needed for SUN to restore xterm buffer */
-    mch_restore_title(3);       /* restore window titles */
+    mch_restore_title();        /* restore window titles */
+    mch_restore_icon();
     ui_suspend();               /* call machine specific function */
     maketitle();
-    resettitle();               /* force updating the title */
+    force_update_title();       /* force updating the title */
     starttermcap();
     scroll_start();             /* scroll screen before redrawing */
     redraw_later_clear();

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -231,7 +231,7 @@ EXTERN int no_wait_return INIT(= 0);        /* don't wait for return for now */
 EXTERN int need_wait_return INIT(= 0);      /* need to wait for return later */
 EXTERN int did_wait_return INIT(= FALSE);       /* wait_return() was used and
                                                    nothing written since then */
-EXTERN int need_maketitle INIT(= TRUE);      /* call maketitle() soon */
+EXTERN int need_maketitle INIT(= TRUE);     // call maketitle() soon
 
 EXTERN int quit_more INIT(= FALSE);         /* 'q' hit at "--more--" msg */
 #if defined(UNIX) || defined(MACOS_X)

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -53,6 +53,7 @@
 #include "nvim/strings.h"
 #include "nvim/syntax.h"
 #include "nvim/term.h"
+#include "nvim/title.h"
 #include "nvim/ui.h"
 #include "nvim/version.h"
 #include "nvim/window.h"

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -39,6 +39,7 @@
 #include "nvim/syntax.h"
 #include "nvim/tag.h"
 #include "nvim/term.h"
+#include "nvim/title.h"
 #include "nvim/ui.h"
 #include "nvim/window.h"
 #include "nvim/os/os.h"

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1858,8 +1858,8 @@ void changed_int(void)
   curbuf->b_changed = TRUE;
   ml_setflags(curbuf);
   check_status(curbuf);
+  need_maketitle = TRUE; // Set window title later.
   redraw_tabline = TRUE;
-  need_maketitle = TRUE;            /* set window title later */
 }
 
 
@@ -2200,8 +2200,8 @@ unchanged (
     if (ff)
       save_file_ff(buf);
     check_status(buf);
+    need_maketitle = TRUE; // Set window title later.
     redraw_tabline = TRUE;
-    need_maketitle = TRUE;          /* set window title later */
   }
   ++buf->b_changedtick;
 }

--- a/src/nvim/misc2.c
+++ b/src/nvim/misc2.c
@@ -270,8 +270,8 @@ void set_fileformat(int eol_style, int opt_flags)
 
   // This may cause the buffer to become (un)modified.
   check_status(curbuf);
+  need_maketitle = TRUE; // Set window title later.
   redraw_tabline = TRUE;
-  need_maketitle = TRUE;  // Set window title later.
 }
 
 /*

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -75,6 +75,7 @@
 #include "nvim/strings.h"
 #include "nvim/syntax.h"
 #include "nvim/term.h"
+#include "nvim/title.h"
 #include "nvim/ui.h"
 #include "nvim/undo.h"
 #include "nvim/window.h"
@@ -2469,13 +2470,13 @@ void set_title_defaults(void)
    */
   idx1 = findoption((char_u *)"title");
   if (idx1 >= 0 && !(options[idx1].flags & P_WAS_SET)) {
-    val = mch_can_restore_title();
+    val = FALSE;
     options[idx1].def_val[VI_DEFAULT] = (char_u *)val;
     p_title = val;
   }
   idx1 = findoption((char_u *)"icon");
   if (idx1 >= 0 && !(options[idx1].flags & P_WAS_SET)) {
-    val = mch_can_restore_icon();
+    val = FALSE;
     options[idx1].def_val[VI_DEFAULT] = (char_u *)val;
     p_icon = val;
   }
@@ -3304,30 +3305,6 @@ static char_u *check_cedit(void)
 }
 
 /*
- * When changing 'title', 'titlestring', 'icon' or 'iconstring', call
- * maketitle() to create and display it.
- * When switching the title or icon off, call mch_restore_title() to get
- * the old value back.
- */
-static void 
-did_set_title (
-    int icon                   /* Did set icon instead of title */
-)
-{
-  if (starting != NO_SCREEN
-      ) {
-    maketitle();
-    if (icon) {
-      if (!p_icon)
-        mch_restore_title(2);
-    } else {
-      if (!p_title)
-        mch_restore_title(1);
-    }
-  }
-}
-
-/*
  * set_options_bin -  called when 'bin' changes value.
  */
 void 
@@ -3627,14 +3604,6 @@ static long_u *insecure_flag(int opt_idx, int opt_flags)
   return &options[opt_idx].flags;
 }
 
-
-/*
- * Redraw the window title and/or tab page text later.
- */
-static void redraw_titles(void) {
-  need_maketitle = TRUE;
-  redraw_tabline = TRUE;
-}
 
 /*
  * Set a string option to a new value (without checking the effect).
@@ -3958,7 +3927,8 @@ did_set_string_option (
         errmsg = e_invarg;
       else {
         /* May show a "+" in the title now. */
-        redraw_titles();
+        need_maketitle = TRUE; // Set window title later.
+        redraw_tabline = TRUE;
         /* Add 'fileencoding' to the swap file. */
         ml_setflags(curbuf);
       }
@@ -3970,7 +3940,8 @@ did_set_string_option (
       *varp = p;
       if (varp == &p_enc) {
         errmsg = mb_init();
-        redraw_titles();
+        need_maketitle = TRUE; // Set window title later.
+        redraw_tabline = TRUE;
       }
     }
 
@@ -4026,7 +3997,8 @@ did_set_string_option (
     else if (check_opt_strings(*varp, p_ff_values, FALSE) != OK)
       errmsg = e_invarg;
     else {
-      redraw_titles();
+      need_maketitle = TRUE; // Set window title later.
+      redraw_tabline = TRUE;
       /* update flag in swap file */
       ml_setflags(curbuf);
       /* Redraw needed when switching to/from "mac": a CR in the text
@@ -4227,8 +4199,17 @@ did_set_string_option (
       stl_syntax |= flagval;
     else
       stl_syntax &= ~flagval;
-    did_set_title(varp == &p_iconstring);
 
+    if (starting != NO_SCREEN) {
+      maketitle();
+      if (varp == &p_iconstring) {
+        if (!p_icon)
+          mch_restore_icon();
+      } else {
+        if (!p_title)
+          mch_restore_title();
+      }
+    }
   }
 
 
@@ -4346,7 +4327,8 @@ did_set_string_option (
         redraw_later(VALID);
       }
       curbuf->b_help = (curbuf->b_p_bt[0] == 'h');
-      redraw_titles();
+      need_maketitle = TRUE; // Set window title later.
+      redraw_tabline = TRUE;
     }
   }
   /* 'statusline' or 'rulerformat' */
@@ -4982,24 +4964,29 @@ set_bool_option (
     if (curbuf->b_p_ro)
       curbuf->b_did_warn = FALSE;
 
-    redraw_titles();
+    need_maketitle = TRUE; // Set window title later.
+    redraw_tabline = TRUE;
   }
   /* when 'modifiable' is changed, redraw the window title */
   else if ((int *)varp == &curbuf->b_p_ma) {
-    redraw_titles();
+    need_maketitle = TRUE; // Set window title later.
+    redraw_tabline = TRUE;
   }
   /* when 'endofline' is changed, redraw the window title */
   else if ((int *)varp == &curbuf->b_p_eol) {
-    redraw_titles();
+    need_maketitle = TRUE; // Set window title later.
+    redraw_tabline = TRUE;
   }
   /* when 'bomb' is changed, redraw the window title and tab page text */
   else if ((int *)varp == &curbuf->b_p_bomb) {
-    redraw_titles();
+    need_maketitle = TRUE; // Set window title later.
+    redraw_tabline = TRUE;
   }
   /* when 'bin' is set also set some other options */
   else if ((int *)varp == &curbuf->b_p_bin) {
     set_options_bin(old_value, curbuf->b_p_bin, opt_flags);
-    redraw_titles();
+    need_maketitle = TRUE; // Set window title later.
+    redraw_tabline = TRUE;
   }
   /* when 'buflisted' changes, trigger autocommands */
   else if ((int *)varp == &curbuf->b_p_bl && old_value != curbuf->b_p_bl) {
@@ -5086,13 +5073,23 @@ set_bool_option (
   }
   /* when 'title' changed, may need to change the title; same for 'icon' */
   else if ((int *)varp == &p_title) {
-    did_set_title(FALSE);
+    if (starting != NO_SCREEN) {
+      maketitle();
+      if (!p_title)
+        mch_restore_title();
+    }
   } else if ((int *)varp == &p_icon) {
-    did_set_title(TRUE);
+    if (starting != NO_SCREEN) {
+      maketitle();
+      if (!p_icon)
+        mch_restore_icon();
+
+    }
   } else if ((int *)varp == &curbuf->b_changed) {
     if (!value)
       save_file_ff(curbuf);             /* Buffer is unchanged */
-    redraw_titles();
+    need_maketitle = TRUE; // Set window title later.
+    redraw_tabline = TRUE;
     modified_was_set = value;
   }
 
@@ -6410,7 +6407,9 @@ void clear_termoptions(void)
    * screen will be cleared later, so this is OK.
    */
   mch_setmouse(FALSE);              /* switch mouse off */
-  mch_restore_title(3);             /* restore window titles */
+  mch_restore_title();              /* restore window titles */
+  mch_restore_icon();
+
   stoptermcap();                        /* stop termcap mode */
 
   free_termoptions();

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -129,6 +129,7 @@
 #include "nvim/strings.h"
 #include "nvim/syntax.h"
 #include "nvim/term.h"
+#include "nvim/title.h"
 #include "nvim/ui.h"
 #include "nvim/undo.h"
 #include "nvim/version.h"

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -31,6 +31,7 @@
 #include "nvim/ascii.h"
 #include "nvim/term.h"
 #include "nvim/buffer.h"
+#include "nvim/title.h"
 #include "nvim/charset.h"
 #include "nvim/edit.h"
 #include "nvim/eval.h"

--- a/src/nvim/title.c
+++ b/src/nvim/title.c
@@ -1,0 +1,274 @@
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "nvim/ascii.h"
+#include "nvim/vim.h"
+#include "nvim/buffer.h"
+#include "nvim/charset.h"
+#include "nvim/globals.h"
+#include "nvim/message.h"
+#include "nvim/option.h"
+#include "nvim/os_unix.h"
+#include "nvim/screen.h"
+#include "nvim/strings.h"
+#include "nvim/path.h"
+#include "nvim/memory.h"
+#include "nvim/undo.h"
+#include "nvim/misc1.h"
+
+#include "nvim/title.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "title.c.generated.h"
+#endif
+
+
+// Manage the
+
+static char_u *lasttitle = NULL;
+static char_u *lasticon = NULL;
+
+static int build_title(void);
+static void build_default_title(char_u *buf, int maxlen);
+static void build_as_stl(char_u *out, size_t outlen, char_u *fmt, int maxwidth, char *setting);
+static int build_icon(void);
+static void build_default_icon(char_u *i_str);
+static int should_update_title(char_u *str, char_u **last);
+
+# if defined(EXITFREE) || defined(PROTO)
+void free_titles(void)
+{
+  free(lasttitle);
+  free(lasticon);
+}
+# endif
+
+// Put current window title back using lasttitle
+// & lasticon (used after calling a shell)
+void force_update_title(void)
+{
+  mch_settitle(lasttitle, lasticon);
+}
+
+// Rebuild title and icon from current settings,
+// redrawing if any changes occured
+void maketitle(void)
+{
+  int need_redraw;
+
+  if (!redrawing()) {
+    // Postpone updating the title when 'lazyredraw' is set.
+    need_maketitle = true;
+    return;
+  }
+
+  need_maketitle = false;
+  need_redraw = false;
+  need_redraw |= build_title();
+  need_redraw |= build_icon();
+
+  if (need_redraw) {
+    force_update_title();
+  }
+}
+
+// Build title and place it into lasttitle,
+// if lasttitle is changed return true, otherwise false
+static int build_title(void)
+{
+  char_u *t_str = NULL;
+  int maxlen = 0;
+  char_u buf[IOSIZE];
+
+  if (!p_title && lasttitle == NULL)
+    return false;
+
+  if (p_title) {
+    if (p_titlelen > 0) {
+      maxlen = (int)p_titlelen * (int)Columns / 100;
+      if (maxlen < 10) {
+        maxlen = 10;
+      }
+    }
+
+    t_str = buf;
+    if (*p_titlestring != NUL) {
+      if (stl_syntax & STL_IN_TITLE) {
+        build_as_stl(t_str, sizeof(buf), p_titlestring, maxlen, "titlestring");
+      } else {
+        t_str = p_titlestring;
+      }
+    } else {
+      build_default_title(t_str, maxlen);
+    }
+  }
+
+  return should_update_title(t_str, &lasttitle);
+}
+
+// Build a title into buf with the format:
+// "fname + (path) (1 of 2) - VIM"
+static void build_default_title(char_u *buf, int maxlen)
+{
+  char_u *p;
+  int off;
+
+#define SPACE_FOR_FNAME (IOSIZE - 100)
+#define SPACE_FOR_DIR   (IOSIZE - 20)
+#define SPACE_FOR_ARGNR (IOSIZE - 10)  // at least room for " - VIM"
+  if (curbuf->b_fname == NULL) {
+    STRLCPY(buf, _("[No Name]"), SPACE_FOR_FNAME + 1);
+  } else {
+    p = transstr(path_tail(curbuf->b_fname));
+    STRLCPY(buf, p, SPACE_FOR_FNAME + 1);
+    free(p);
+  }
+
+  switch (bufIsChanged(curbuf)
+      + (curbuf->b_p_ro * 2)
+      + (!curbuf->b_p_ma * 4)) {
+    case 1: STRCAT(buf, " +"); break;
+    case 2: STRCAT(buf, " ="); break;
+    case 3: STRCAT(buf, " =+"); break;
+    case 4:
+    case 6: STRCAT(buf, " -"); break;
+    case 5:
+    case 7: STRCAT(buf, " -+"); break;
+  }
+
+  if (curbuf->b_fname != NULL) {
+    // Get path of file, replace home dir with ~
+    off = (int)STRLEN(buf);
+    buf[off++] = ' ';
+    buf[off++] = '(';
+    home_replace(curbuf, curbuf->b_ffname,
+        buf + off, SPACE_FOR_DIR - off, true);
+#ifdef BACKSLASH_IN_FILENAME
+    // avoid "c:/name" to be reduced to "c"
+    if (isalpha(buf[off]) && buf[off + 1] == ':')
+      off += 2;
+#endif
+    // remove the file name
+    p = path_tail_with_sep(buf + off);
+    if (p == buf + off) {
+      // must be a help buffer
+      STRLCPY(buf + off, _("help"), SPACE_FOR_DIR - off);
+    } else {
+      *p = NUL;
+    }
+
+    // Translate unprintable chars and concatenate.  Keep some
+    // room for the server name.  When there is no room (very long
+    // file name) use (...).
+    if (off < SPACE_FOR_DIR) {
+      p = transstr(buf + off);
+      STRLCPY(buf + off, p, SPACE_FOR_DIR - off + 1);
+      free(p);
+    } else {
+      STRLCPY(buf + off, "...", SPACE_FOR_ARGNR - off + 1);
+    }
+    STRCAT(buf, ")");
+  }
+
+  append_arg_number(curwin, buf, SPACE_FOR_ARGNR, false);
+
+  STRCAT(buf, " - VIM");
+
+  if (maxlen > 0) {
+    // make it shorter by removing a bit in the middle
+    if (vim_strsize(buf) > maxlen) {
+      trunc_string(buf, buf, maxlen, IOSIZE);
+    }
+  }
+}
+
+// Build title or icon using a statusline format, using
+// a sandbox if the setting was set insecurely
+static void build_as_stl(
+    char_u *out,
+    size_t outlen,
+    char_u *fmt,
+    int maxwidth,
+    char *setting
+)
+{
+  int use_sandbox = false;
+  int save_called_emsg = called_emsg;
+
+  use_sandbox = was_set_insecurely((char_u *)setting, 0);
+  called_emsg = false;
+  build_stl_str_hl(curwin, out, outlen, fmt,
+      use_sandbox, 0, maxwidth, NULL, NULL);
+  if (called_emsg) {
+    set_string_option_direct((char_u *)setting, -1,
+        (char_u *)"", OPT_FREE, SID_ERROR);
+  }
+  called_emsg |= save_called_emsg;
+}
+
+// Build icon and place it into lasticon,
+// if lasticon is changed return true, otherwise false
+static int build_icon(void)
+{
+  char_u *i_str = NULL;
+  char_u buf[IOSIZE];
+
+  if (p_icon) {
+    i_str = buf;
+    if (*p_iconstring != NUL) {
+      if (stl_syntax & STL_IN_ICON) {
+        build_as_stl(i_str, sizeof(buf), p_iconstring, 0, "iconstring");
+      } else {
+        i_str = p_iconstring;
+      }
+    } else {
+      build_default_icon(i_str);
+    }
+    return should_update_title(i_str, &lasticon);
+  }
+
+  return false;
+}
+
+// Build an icon from the current buffer's special name
+// or filename, trucating at 100 bytes
+static void build_default_icon(char_u *i_str)
+{
+  int len;
+  char_u *i_name;
+
+  if (buf_spname(curbuf) != NULL) {
+    i_name = buf_spname(curbuf);
+  } else {                        /* use file name only in icon */
+    i_name = path_tail(curbuf->b_ffname);
+  }
+  *i_str = NUL;
+  /* Truncate name at 100 bytes. */
+  len = (int)STRLEN(i_name);
+  if (len > 100) {
+    len -= 100;
+    if (has_mbyte) {
+      len += (*mb_tail_off)(i_name, i_name + len) + 1;
+    }
+    i_name += len;
+  }
+  STRCPY(i_str, i_name);
+  trans_characters(i_str, IOSIZE);
+}
+
+static int should_update_title(char_u *str, char_u **last)
+{
+  if ((str == NULL) != (*last == NULL)
+      || (str != NULL && *last != NULL && STRCMP(str, *last) != 0)) {
+    free(*last);
+    if (str == NULL) {
+      *last = NULL;
+    } else {
+      *last = vim_strsave(str);
+    }
+    return true;
+  }
+  return false;
+}

--- a/src/nvim/title.h
+++ b/src/nvim/title.h
@@ -1,0 +1,7 @@
+#ifndef NVIM_TITLE_H
+#define NVIM_TITLE_H
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "title.h.generated.h"
+#endif
+#endif  // NVIM_TITLE_H

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -52,6 +52,7 @@
 #include "nvim/strings.h"
 #include "nvim/syntax.h"
 #include "nvim/term.h"
+#include "nvim/title.h"
 #include "nvim/undo.h"
 #include "nvim/os/os.h"
 


### PR DESCRIPTION
unify title update access to
- `maketitle()` and the `need_maketitle` flag for use on update
- `free_titles()` for use on exit
- `force_update_title()` for use after suspend/resume

additionally
- remove unused `get_i11_title()`, `mch_can_restore_title()`,
  `mch_can_restore_icon()`, `oldtitle`
- extract `mch_restore_icon()` from `mch_restore_title()`
