### PR TITLE
[WIP/RFC] Run vroom integration tests in CMake.

### DIFF
--- a/.ci/clang-asan.sh
+++ b/.ci/clang-asan.sh
@@ -1,7 +1,5 @@
 . "$CI_SCRIPTS/common.sh"
 
-install_vroom
-
 set_environment /opt/neovim-deps/64
 
 sudo pip install cpp-coveralls

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -53,26 +53,15 @@ set_environment() {
 	export PATH="$prefix/bin:$PATH"
 	export PKG_CONFIG_PATH="$prefix/lib/pkgconfig"
 	export USE_BUNDLED_DEPS=OFF
+	export PYTHONPATH="$prefix/lib/python2.7/site-packages"
 }
 
 
 install_prebuilt_deps() {
 	# install prebuilt dependencies
 	if [ ! -d /opt/neovim-deps ]; then
-		cd /opt
-		sudo git clone --depth=1 git://github.com/neovim/deps neovim-deps
-		cd -
+		sudo git clone --depth=1 --branch=testing git://github.com/fwalch/deps /opt/neovim-deps
 	fi
-}
-
-install_vroom() {
-	(
-	sudo pip install git+https://github.com/neovim/python-client.git
-	git clone git://github.com/google/vroom
-	cd vroom
-	python setup.py build
-	sudo python setup.py install
-	)
 }
 
 tmpdir="$(pwd)/tmp"

--- a/.ci/gcc-ia32.sh
+++ b/.ci/gcc-ia32.sh
@@ -1,7 +1,5 @@
 . "$CI_SCRIPTS/common.sh"
 
-install_vroom
-
 set_environment /opt/neovim-deps/32
 
 # Need this to keep apt-get from removing gcc when installing libncurses

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,12 +119,6 @@ endif()
 
 message(STATUS "Using the Lua interpreter ${LUA_PRG}")
 
-# Setup busted.
-find_program(BUSTED_PRG busted)
-if(NOT BUSTED_OUTPUT_TYPE)
-  set(BUSTED_OUTPUT_TYPE "utfTerminal")
-endif()
-
 # Setup make.
 find_program(MAKE_PRG NAMES gmake make)
 if(MAKE_PRG)
@@ -188,7 +182,14 @@ add_subdirectory(test/includes)
 
 # Setup some test-related bits.  We do this after going down the tree because we
 # need some of the targets.
+
+# Setup busted.
+find_program(BUSTED_PRG busted)
 if(BUSTED_PRG)
+  if(NOT BUSTED_OUTPUT_TYPE)
+    set(BUSTED_OUTPUT_TYPE "utfTerminal")
+  endif()
+
   get_property(TEST_INCLUDE_DIRS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     PROPERTY INCLUDE_DIRECTORIES)
 
@@ -213,4 +214,19 @@ if(BUSTED_PRG)
       -DBUILD_DIR=${CMAKE_BINARY_DIR}
       -P ${CMAKE_MODULE_PATH}/RunUnittests.cmake
     DEPENDS nvim-test unittest-headers)
+endif()
+
+# Setup vroom.
+find_program(VROOM_PRG vroom)
+if(VROOM_PRG)
+  add_custom_target(integrationtest
+    COMMAND ${CMAKE_COMMAND}
+      -DVROOM_PRG=${VROOM_PRG}
+      -DWORKING_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+      -DTEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test
+      -DBUILD_DIR=${CMAKE_BINARY_DIR}
+      -DDEPS_INSTALL_DIR=${DEPS_INSTALL_DIR}
+      -P ${CMAKE_MODULE_PATH}/RunIntegrationtests.cmake)
+    #TODO(fwalch): following doesn't work
+    #DEPENDS nvim-python)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,13 @@ endif
 	mkdir -p build
 	touch $@
 
-test: | nvim
+test: | integrationtest legacytest
+
+integrationtest: | nvim
+	+$(BUILD_CMD) -C build integrationtest
+
+legacytest: | nvim
 	+$(SINGLE_MAKE) -C src/nvim/testdir $(MAKEOVERRIDES)
-	PATH="$$(pwd)/build/bin:$$PATH" vroom --neovim --crawl test
 
 unittest: | nvim
 	+$(BUILD_CMD) -C build unittest
@@ -91,4 +95,5 @@ distclean: clean
 install: | nvim
 	+$(BUILD_CMD) -C build install
 
-.PHONY: test unittest clean distclean nvim cmake deps install
+.PHONY: test integrationtest legacytest unittest \
+        clean distclean nvim cmake deps install

--- a/cmake/RunIntegrationtests.cmake
+++ b/cmake/RunIntegrationtests.cmake
@@ -1,0 +1,20 @@
+if(DEFINED ENV{TEST_FILE})
+  set(TEST_DIR $ENV{TEST_FILE})
+endif()
+
+set(ENV{PATH} "${BUILD_DIR}/bin:$ENV{PATH}")
+
+#TODO
+find_package(PythonInterp 2.6 REQUIRED)
+if(NOT ENV{USE_BUNDLED_DEPS} STREQUAL "OFF")
+  set(ENV{PYTHONPATH} "${DEPS_INSTALL_DIR}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/:$ENV{PYTHONPATH}")
+endif()
+
+execute_process(
+  COMMAND ${PYTHON_EXECUTABLE} ${VROOM_PRG} --neovim --crawl ${TEST_DIR}
+  WORKING_DIRECTORY ${WORKING_DIR}
+  RESULT_VARIABLE res)
+
+if(NOT res EQUAL 0)
+  message(FATAL_ERROR "Integration tests failed.")
+endif()

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -19,6 +19,8 @@ option(USE_BUNDLED_LIBUV "Use the bundled libuv." ${USE_BUNDLED})
 option(USE_BUNDLED_MSGPACK "Use the bundled msgpack." ${USE_BUNDLED})
 option(USE_BUNDLED_LUAJIT "Use the bundled version of luajit." ${USE_BUNDLED})
 option(USE_BUNDLED_LUAROCKS "Use the bundled version of luarocks." ${USE_BUNDLED})
+option(USE_BUNDLED_VROOM "Use the bundled version of vroom." ${USE_BUNDLED})
+option(USE_BUNDLED_NVIM_CLIENT "Use the bundled version of the neovim python client." ${USE_BUNDLED})
 
 # TODO: add windows support
 
@@ -62,6 +64,12 @@ set(LUAJIT_MD5 f14e9104be513913810cd59c8c658dc0)
 
 set(LUAROCKS_URL https://github.com/keplerproject/luarocks/archive/0587afbb5fe8ceb2f2eea16f486bd6183bf02f29.tar.gz)
 set(LUAROCKS_MD5 0f53f42909fbcd2c88be303e8f970516)
+
+set(VROOM_URL https://github.com/google/vroom/archive/master.tar.gz)
+set(VROOM_MD5 SKIP)
+
+set(NVIM_PYTHON_URL https://github.com/neovim/python-client/archive/master.tar.gz)
+set(NVIM_PYTHON_MD5 SKIP)
 
 if(USE_BUNDLED_LIBUV)
   ExternalProject_Add(libuv
@@ -190,6 +198,54 @@ if(USE_BUNDLED_LUAROCKS)
     DEPENDS ${DEPS_LIB_DIR}/luarocks/rocks/lpeg)
 
   list(APPEND THIRD_PARTY_DEPS busted lua-messagepack lpeg)
+endif()
+
+find_package(PythonInterp 2.6)
+if(PYTHONINTERP_FOUND)
+  if(USE_BUNDLED_VROOM OR USE_BUNDLED_NVIM_CLIENT)
+    set(PYTHONPATH "${DEPS_INSTALL_DIR}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/")
+    file(MAKE_DIRECTORY ${PYTHONPATH})
+  endif()
+
+  if(USE_BUNDLED_VROOM)
+    ExternalProject_Add(vroom
+      PREFIX ${DEPS_BUILD_DIR}
+      URL ${VROOM_URL}
+      URL_MD5 ${VROOM_MD5}
+      DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/vroom
+      DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+        -DPREFIX=${DEPS_BUILD_DIR}
+        -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/vroom
+        -DURL=${VROOM_URL}
+        -DEXPECTED_MD5=${VROOM_MD5}
+        -DTARGET=vroom
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+      BUILD_IN_SOURCE 1
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build
+      INSTALL_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON_EXECUTABLE} setup.py install --prefix=${DEPS_INSTALL_DIR})
+    list(APPEND THIRD_PARTY_DEPS vroom)
+  endif()
+
+  if(USE_BUNDLED_NVIM_CLIENT)
+    ExternalProject_Add(nvim-python
+      PREFIX ${DEPS_BUILD_DIR}
+      URL ${NVIM_PYTHON_URL}
+      URL_MD5 ${NVIM_PYTHON_MD5}
+      DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/nvim-python
+      DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+        -DPREFIX=${DEPS_BUILD_DIR}
+        -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/nvim-python
+        -DURL=${NVIM_PYTHON_URL}
+        -DEXPECTED_MD5=${NVIM_PYTHON_MD5}
+        -DTARGET=nvim-python
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+      BUILD_IN_SOURCE 1
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND ${PYTHON_EXECUTABLE} setup.py build
+      INSTALL_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON_EXECUTABLE} setup.py install --prefix=${DEPS_INSTALL_DIR})
+    list(APPEND THIRD_PARTY_DEPS nvim-python)
+  endif()
 endif()
 
 add_custom_target(third-party ALL

--- a/third-party/cmake/DownloadAndExtractFile.cmake
+++ b/third-party/cmake/DownloadAndExtractFile.cmake
@@ -46,11 +46,18 @@ message(STATUS "downloading...
      dst='${file}'
      timeout='${timeout_msg}'")
 
-file(DOWNLOAD ${URL} ${file}
-  ${timeout_args}
-  EXPECTED_MD5 ${EXPECTED_MD5}
-  STATUS status
-  LOG log)
+ if(EXPECTED_MD5 STREQUAL "SKIP")
+  file(DOWNLOAD ${URL} ${file}
+    ${timeout_args}
+    STATUS status
+    LOG log)
+ else()
+  file(DOWNLOAD ${URL} ${file}
+    ${timeout_args}
+    EXPECTED_MD5 ${EXPECTED_MD5}
+    STATUS status
+    LOG log)
+endif()
 
 list(GET status 0 status_code)
 list(GET status 1 status_string)


### PR DESCRIPTION
When running tests locally, developers have to take care to have the latest vroom and neovim-python installed. This PR moves the installation of these dependencies into CMake, like it was done with busted etc.

To be able download the latest versions of these two dependencies, the CMake download code was modified to accept an md5 sum of `SKIP`.

I'm not sure if this _should_ be done (especially the `PYTHONPATH` stuff is very hacky, and I don't know if this can be improved), but I'd like to hear your opinions.
