### PR TITLE
[WIP/RFC] Add Function type to the API

### DIFF
--- a/scripts/msgpack-gen.lua
+++ b/scripts/msgpack-gen.lua
@@ -133,7 +133,7 @@ void msgpack_rpc_init_function_metadata(Dictionary *metadata)
     abort();
   }
   Object functions;
-  msgpack_rpc_to_object(&unpacked.data, &functions);
+  msgpack_rpc_to_object(&unpacked.data, &functions, 0);
   msgpack_unpacked_destroy(&unpacked);
   PUT(*metadata, "functions", functions);
 }
@@ -182,7 +182,7 @@ for i = 1, #functions do
     arg = '(req->via.array.ptr[3].via.array.ptr + '..(j - 1)..')'
     converted = 'arg_'..j
     convert_arg = 'msgpack_rpc_to_'..real_type(param[1]):lower()
-    output:write('\n  if (!'..convert_arg..'('..arg..', &'..converted..')) {')
+    output:write('\n  if (!'..convert_arg..'('..arg..', &'..converted..', channel_id)) {')
     output:write('\n    snprintf(error->msg, sizeof(error->msg), "Wrong type for argument '..j..', expecting '..param[1]..'");')
     output:write('\n    error->set = true;')
     output:write('\n    goto cleanup;')

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -9,6 +9,11 @@
 #define STRING_INIT {.data = NULL, .size = 0}
 #define OBJECT_INIT { .type = kObjectTypeNil }
 #define ERROR_INIT { .set = false }
+#define FUNCTION_INIT {                                   \
+  .data = {.name = NULL, .channel = 0, .async = false},   \
+  .ptr = NULL                                             \
+}
+
 #define REMOTE_TYPE(type) typedef uint64_t type
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -41,6 +46,7 @@ REMOTE_TYPE(Buffer);
 REMOTE_TYPE(Window);
 REMOTE_TYPE(Tabpage);
 
+typedef struct function Function;
 typedef struct object Object;
 
 typedef struct {
@@ -55,10 +61,22 @@ typedef struct {
   size_t size, capacity;
 } Dictionary;
 
+typedef struct {
+  char *name;
+  uint64_t channel;
+  bool async;
+} FunctionData;
+
+struct function {
+  Object (*ptr)(FunctionData *data, Array args, Error *err);
+  FunctionData data;
+};
+
 typedef enum {
   kObjectTypeBuffer,
   kObjectTypeWindow,
   kObjectTypeTabpage,
+  kObjectTypeFunction,
   kObjectTypeNil,
   kObjectTypeBoolean,
   kObjectTypeInteger,
@@ -74,6 +92,7 @@ struct object {
     Buffer buffer;
     Window window;
     Tabpage tabpage;
+    Function function;
     Boolean boolean;
     Integer integer;
     Float floating;
@@ -87,7 +106,6 @@ struct key_value_pair {
   String key;
   Object value;
 };
-
 
 #endif  // NVIM_API_PRIVATE_DEFS_H
 

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -6,6 +6,7 @@
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/handle.h"
+#include "nvim/os/channel.h"
 #include "nvim/os/provider.h"
 #include "nvim/ascii.h"
 #include "nvim/vim.h"
@@ -475,6 +476,13 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
       }
       tv->vval.v_dict->dv_refcount++;
       break;
+
+    case kObjectTypeFunction:
+      api_set_error(err,
+                    Exception,
+                    _("Cannot convert Function to vim function"));
+      return false;
+
     default:
       abort();
   }
@@ -515,6 +523,10 @@ void api_free_object(Object value)
       api_free_dictionary(value.data.dictionary);
       break;
 
+    case kObjectTypeFunction:
+      api_free_function(value.data.function);
+      break;
+
     default:
       abort();
   }
@@ -537,6 +549,15 @@ void api_free_dictionary(Dictionary value)
   }
 
   free(value.items);
+}
+
+void api_free_function(Function value)
+{
+  if (!value.data.name) {
+    return;
+  }
+
+  free(value.data.name);
 }
 
 Dictionary api_metadata(void)
@@ -568,6 +589,18 @@ static void init_error_type_metadata(Dictionary *metadata)
 
   PUT(*metadata, "error_types", DICTIONARY_OBJ(types));
 }
+
+/// Wrapper to call function->ptr passing function->data;
+Object api_call_function(Function *function, Array args, Error *err)
+{
+  return function->ptr(&function->data, args, err);
+}
+
+bool api_function_is_valid(Function *function)
+{
+  return channel_exists(function->data.channel);
+}
+
 static void init_type_metadata(Dictionary *metadata)
 {
   Dictionary types = ARRAY_DICT_INIT;
@@ -581,9 +614,13 @@ static void init_type_metadata(Dictionary *metadata)
   Dictionary tabpage_metadata = ARRAY_DICT_INIT;
   PUT(tabpage_metadata, "id", INTEGER_OBJ(kObjectTypeTabpage));
 
+  Dictionary function_metadata = ARRAY_DICT_INIT;
+  PUT(function_metadata, "id", INTEGER_OBJ(kObjectTypeFunction));
+
   PUT(types, "Buffer", DICTIONARY_OBJ(buffer_metadata));
   PUT(types, "Window", DICTIONARY_OBJ(window_metadata));
   PUT(types, "Tabpage", DICTIONARY_OBJ(tabpage_metadata));
+  PUT(types, "Function", DICTIONARY_OBJ(function_metadata));
 
   PUT(*metadata, "types", DICTIONARY_OBJ(types));
 }

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -478,10 +478,9 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
       break;
 
     case kObjectTypeFunction:
-      api_set_error(err,
-                    Exception,
-                    _("Cannot convert Function to vim function"));
-      return false;
+      tv->v_type = VAR_FUNC;
+      tv->vval.v_string = (uint8_t *)eval_wrap_function(obj.data.function);
+      break;
 
     default:
       abort();

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -80,6 +80,7 @@
 #define api_init_object = NIL
 #define api_init_array = ARRAY_DICT_INIT
 #define api_init_dictionary = ARRAY_DICT_INIT
+#define api_init_function = FUNCTION_INIT
 
 #define api_free_boolean(value)
 #define api_free_integer(value)

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -511,20 +511,15 @@ void vim_unsubscribe(uint64_t channel_id, String event)
   channel_unsubscribe(channel_id, e);
 }
 
-/// Registers the channel as the provider for `feature`. This fails if
-/// a provider for `feature` is already provided by another channel.
+/// Registers a provider for `feature`. This fails if `feature` is already
+/// provided by another extension.
 ///
 /// @param channel_id The channel id
 /// @param feature The feature name
 /// @param[out] err Details of an error that may have occurred
-void vim_register_provider(uint64_t channel_id, String feature, Error *err)
+void vim_register_provider(String feature, Dictionary handlers, Error *err)
 {
-  char buf[METHOD_MAXLEN];
-  xstrlcpy(buf, feature.data, sizeof(buf));
-
-  if (!provider_register(buf, channel_id)) {
-    api_set_error(err, Validation, _("Feature doesn't exist"));
-  }
+  provider_register(feature.data, handlers, err);
 }
 
 Array vim_get_api_info(uint64_t channel_id)

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -117,15 +117,19 @@ Object vim_eval(String str, Error *err)
   try_start();
   typval_T *expr_result = eval_expr((char_u *) str.data, NULL);
 
+  if (try_end(err)) {
+    goto end;
+  }
+
   if (!expr_result) {
     api_set_error(err, Exception, _("Failed to evaluate expression"));
+    goto end;
   }
 
-  if (!try_end(err)) {
-    // No errors, convert the result
-    rv = vim_to_object(expr_result);
-  }
+  // No errors, convert the result
+  rv = vim_to_object(expr_result);
 
+end:
   // Free the vim object
   free_tv(expr_result);
   return rv;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11644,7 +11644,7 @@ static void f_pumvisible(typval_T *argvars, typval_T *rettv)
  */
 static void f_pyeval(typval_T *argvars, typval_T *rettv)
 {
-  script_host_eval("python_eval", argvars, rettv);
+  script_host_eval("python", "eval", argvars, rettv);
 }
 
 /*
@@ -19464,11 +19464,14 @@ static void apply_job_autocmds(Job *job, char *name, char *type, char *str)
   apply_autocmds(EVENT_JOBACTIVITY, (uint8_t *)name, NULL, TRUE, NULL);
 }
 
-static void script_host_eval(char *method, typval_T *argvars, typval_T *rettv)
+static void script_host_eval(char *feature,
+                             char *method,
+                             typval_T *argvars,
+                             typval_T *rettv)
 {
   Array args = ARRAY_DICT_INIT;
   ADD(args, vim_to_object(argvars));
-  Object result = provider_call(method, args);
+  Object result = provider_call(feature, method, args);
 
   if (result.type == kObjectTypeNil) {
     return;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -83,6 +83,7 @@
 #include "nvim/os/time.h"
 #include "nvim/os/channel.h"
 #include "nvim/api/private/helpers.h"
+#include "nvim/api/private/defs.h"
 #include "nvim/api/vim.h"
 #include "nvim/os/dl.h"
 #include "nvim/os/provider.h"
@@ -95,6 +96,7 @@
 #define AUTOLOAD_CHAR '#'       /* Character used as separator in autoload 
                                    function/variable names. */
 
+static int func_nr = 0;         // number for nameless function
 /*
  * In a hashtab item "hi_key" points to "di_key" in a dictitem.
  * This avoids adding a pointer to the hashtab item.
@@ -248,6 +250,7 @@ struct ufunc {
   scid_T uf_script_ID;          /* ID of script where function was defined,
                                    used for s: variables */
   int uf_refcount;              /* for numbered function: reference count */
+  Function ext_function;        // Actual Function implementation
   char_u uf_name[1];            /* name of function (actually longer); can
                                    start with <SNR>123_ (<SNR> is K_SPECIAL
                                    KS_EXTRA KE_SNR) */
@@ -257,6 +260,7 @@ struct ufunc {
 #define FC_ABORT    1           /* abort function on error */
 #define FC_RANGE    2           /* function accepts range */
 #define FC_DICT     4           /* Dict function, uses "self" */
+#define FC_EXT      8           // Function came from a API extension
 
 /*
  * All user-defined functions are found in this hashtable.
@@ -16902,6 +16906,33 @@ static char_u *find_option_end(char_u **arg, int *opt_flags)
   return p;
 }
 
+char *eval_wrap_function(Function function)
+{
+  char *name = xmalloc(20 * sizeof(char));
+  sprintf(name, "%d", ++func_nr);
+  ufunc_T *fp = xmalloc(sizeof(ufunc_T) + strlen(name));
+
+  // insert the new function in the function list
+  STRCPY(fp->uf_name, name);
+  hash_add(&func_hashtab, UF2HIKEY(fp));
+
+  ga_init(&fp->uf_args, (int)sizeof(char_u *), 3);
+  ga_init(&fp->uf_lines, (int)sizeof(char_u *), 3);
+  fp->uf_tml_count = NULL;
+  fp->uf_tml_total = NULL;
+  fp->uf_tml_self = NULL;
+  fp->uf_profiling = FALSE;
+  if (prof_def_func())
+    func_do_profile(fp);
+  fp->uf_varargs = true;
+  fp->uf_flags = FC_EXT;
+  fp->uf_calls = 0;
+  fp->uf_script_ID = current_SID;
+  fp->ext_function = function;
+
+  return name;
+}
+
 /*
  * ":function"
  */
@@ -16926,7 +16957,6 @@ void ex_function(exarg_T *eap)
   char_u      *skip_until = NULL;
   dictitem_T  *v;
   funcdict_T fudi;
-  static int func_nr = 0;           /* number for nameless function */
   int paren;
   hashtab_T   *ht;
   int todo;
@@ -17451,6 +17481,7 @@ void ex_function(exarg_T *eap)
   fp->uf_flags = flags;
   fp->uf_calls = 0;
   fp->uf_script_ID = current_SID;
+  fp->ext_function = (Function) FUNCTION_INIT;
   goto ret_free;
 
 erret:
@@ -18225,6 +18256,30 @@ call_user_func (
   char_u      *name;
   proftime_T wait_start;
   proftime_T call_start;
+
+  if (fp->uf_flags & FC_EXT) {
+    // Convert arguments and call the extension
+    Array args = ARRAY_DICT_INIT;
+
+    for (typval_T *tv = argvars + 2; tv->v_type != VAR_UNKNOWN; tv++) {
+      ADD(args, vim_to_object(tv));
+    }
+
+    Error err = ERROR_INIT;
+    Object result = api_call_function(&fp->ext_function, args, &err);
+    if (err.set) {
+      vim_report_error(cstr_as_string(err.msg));
+      goto end;
+    }
+
+    if (!object_to_vim(result, rettv, &err)) {
+      EMSG2(_("Error converting the call result: %s"), err.msg);
+    }
+
+  end:
+    api_free_object(result);
+    return;
+  }
 
   /* If depth of calling is getting too high, don't execute the function */
   if (depth >= p_mfd) {

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -1,6 +1,7 @@
 #ifndef NVIM_EVAL_H
 #define NVIM_EVAL_H
 
+#include "nvim/api/private/defs.h"
 #include "nvim/profile.h"
 
 /* Defines for Vim variables.  These must match vimvars[] in eval.c! */

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -790,17 +790,17 @@ void ex_profile(exarg_T *eap)
 
 void ex_python(exarg_T *eap)
 {
-  script_host_execute("python_execute", eap);
+  script_host_execute("python", "execute", eap);
 }
 
 void ex_pyfile(exarg_T *eap)
 {
-  script_host_execute_file("python_execute_file", eap);
+  script_host_execute_file("python", "execute_file", eap);
 }
 
 void ex_pydo(exarg_T *eap)
 {
-  script_host_do_range("python_do_range", eap);
+  script_host_do_range("python", "do_range", eap);
 }
 
 
@@ -3250,14 +3250,14 @@ char_u *get_locales(expand_T *xp, int idx)
 #endif
 
 
-static void script_host_execute(char *method, exarg_T *eap)
+static void script_host_execute(char *feature, char *method, exarg_T *eap)
 {
   char *script = (char *)script_get(eap, eap->arg);
 
   if (!eap->skip) {
     Array args = ARRAY_DICT_INIT;
     ADD(args, STRING_OBJ(cstr_to_string(script ? script : (char *)eap->arg)));
-    Object result = provider_call(method, args);
+    Object result = provider_call(feature, method, args);
     // We don't care about the result, so free it just in case a bad provider
     // returned something
     api_free_object(result);
@@ -3266,24 +3266,24 @@ static void script_host_execute(char *method, exarg_T *eap)
   free(script);
 }
 
-static void script_host_execute_file(char *method, exarg_T *eap)
+static void script_host_execute_file(char *feature, char *method, exarg_T *eap)
 {
   char buffer[MAXPATHL];
   vim_FullName(eap->arg, (uint8_t *)buffer, sizeof(buffer), false);
 
   Array args = ARRAY_DICT_INIT;
   ADD(args, STRING_OBJ(cstr_to_string(buffer)));
-  Object result = provider_call(method, args);
+  Object result = provider_call(feature, method, args);
   api_free_object(result);
 }
 
-static void script_host_do_range(char *method, exarg_T *eap)
+static void script_host_do_range(char *feature, char *method, exarg_T *eap)
 {
   Array args = ARRAY_DICT_INIT;
   ADD(args, INTEGER_OBJ(eap->line1));
   ADD(args, INTEGER_OBJ(eap->line2));
   ADD(args, STRING_OBJ(cstr_to_string((char *)eap->arg)));
-  Object result = provider_call(method, args);
+  Object result = provider_call(feature, method, args);
   api_free_object(result);
 }
 

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -4,6 +4,7 @@
 
 #include "nvim/map.h"
 #include "nvim/map_defs.h"
+#include "nvim/api/private/defs.h"
 #include "nvim/vim.h"
 #include "nvim/memory.h"
 #include "nvim/os/msgpack_rpc.h"
@@ -109,3 +110,4 @@ MAP_IMPL(cstr_t, ptr_t, DEFAULT_INITIALIZER)
 MAP_IMPL(ptr_t, ptr_t, DEFAULT_INITIALIZER)
 MAP_IMPL(uint64_t, ptr_t, DEFAULT_INITIALIZER)
 MAP_IMPL(String, rpc_method_handler_fn, DEFAULT_INITIALIZER)
+MAP_IMPL(cstr_t, Function, FUNCTION_INIT)

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -26,6 +26,7 @@ MAP_DECLS(cstr_t, ptr_t)
 MAP_DECLS(ptr_t, ptr_t)
 MAP_DECLS(uint64_t, ptr_t)
 MAP_DECLS(String, rpc_method_handler_fn)
+MAP_DECLS(cstr_t, Function)
 
 #define map_new(T, U) map_##T##_##U##_new
 #define map_free(T, U) map_##T##_##U##_free

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5230,7 +5230,7 @@ static void get_clipboard(int name)
   struct yankreg *reg = &y_regs[CLIP_REGISTER];
   free_register(reg);
   Array args = ARRAY_DICT_INIT;
-  Object result = provider_call("clipboard_get", args);
+  Object result = provider_call("clipboard", "get", args);
 
   if (result.type != kObjectTypeArray) {
     goto err;
@@ -5285,6 +5285,6 @@ static void set_clipboard(int name)
   Array args = ARRAY_DICT_INIT;
   ADD(args, ARRAY_OBJ(lines));
 
-  Object result = provider_call("clipboard_set", args);
+  Object result = provider_call("clipboard", "set", args);
   api_free_object(result);
 }

--- a/src/nvim/os/channel.c
+++ b/src/nvim/os/channel.c
@@ -584,9 +584,9 @@ static void call_stack_return(msgpack_object *obj, Channel *channel)
   frame->returned = true;
 
   if (frame->errored) {
-    msgpack_rpc_to_object(&obj->via.array.ptr[2], &frame->result);
+    msgpack_rpc_to_object(&obj->via.array.ptr[2], &frame->result, 0);
   } else {
-    msgpack_rpc_to_object(&obj->via.array.ptr[3], &frame->result);
+    msgpack_rpc_to_object(&obj->via.array.ptr[3], &frame->result, 0);
   }
 }
 

--- a/src/nvim/os/msgpack_rpc_helpers.c
+++ b/src/nvim/os/msgpack_rpc_helpers.c
@@ -148,6 +148,7 @@ bool msgpack_rpc_to_object(msgpack_object *obj,
       return msgpack_rpc_to_dictionary(obj, &arg->data.dictionary, channel);
 
     case MSGPACK_OBJECT_EXT:
+      arg->type = obj->via.ext.type;
       switch (obj->via.ext.type) {
         case kObjectTypeBuffer:
           return msgpack_rpc_to_buffer(obj, &arg->data.buffer, channel);
@@ -157,6 +158,8 @@ bool msgpack_rpc_to_object(msgpack_object *obj,
           return msgpack_rpc_to_tabpage(obj, &arg->data.tabpage, channel);
         case kObjectTypeFunction:
           return msgpack_rpc_to_function(obj, &arg->data.function, channel);
+        default:
+          arg->type = kObjectTypeNil;
       }
     default:
       return false;

--- a/src/nvim/os/msgpack_rpc_helpers.c
+++ b/src/nvim/os/msgpack_rpc_helpers.c
@@ -1,11 +1,15 @@
 #include <stdint.h>
+#include <assert.h>
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include <msgpack.h>
 
 #include "nvim/os/msgpack_rpc_helpers.h"
+#include "nvim/os/channel.h"
 #include "nvim/vim.h"
 #include "nvim/memory.h"
+#include "nvim/api/private/helpers.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/msgpack_rpc_helpers.c.generated.h"
@@ -15,7 +19,7 @@ static msgpack_zone zone;
 static msgpack_sbuffer sbuffer;
 
 #define HANDLE_TYPE_CONVERSION_IMPL(t, lt)                                  \
-  bool msgpack_rpc_to_##lt(msgpack_object *obj, t *arg)                     \
+  bool msgpack_rpc_to_##lt(msgpack_object *obj, t *arg, uint64_t channel)   \
     FUNC_ATTR_NONNULL_ALL                                                   \
   {                                                                         \
     if (obj->type != MSGPACK_OBJECT_EXT                                     \
@@ -59,15 +63,19 @@ HANDLE_TYPE_CONVERSION_IMPL(Buffer, buffer)
 HANDLE_TYPE_CONVERSION_IMPL(Window, window)
 HANDLE_TYPE_CONVERSION_IMPL(Tabpage, tabpage)
 
-bool msgpack_rpc_to_boolean(msgpack_object *obj, Boolean *arg)
-  FUNC_ATTR_NONNULL_ALL
+bool msgpack_rpc_to_boolean(msgpack_object *obj,
+                            Boolean *arg,
+                            uint64_t channel)
+  FUNC_ATTR_NONNULL_ARG(1, 2)
 {
   *arg = obj->via.boolean;
   return obj->type == MSGPACK_OBJECT_BOOLEAN;
 }
 
-bool msgpack_rpc_to_integer(msgpack_object *obj, Integer *arg)
-  FUNC_ATTR_NONNULL_ALL
+bool msgpack_rpc_to_integer(msgpack_object *obj,
+                            Integer *arg,
+                            uint64_t channel)
+  FUNC_ATTR_NONNULL_ARG(1, 2)
 {
   if (obj->type == MSGPACK_OBJECT_POSITIVE_INTEGER
       && obj->via.u64 <= INT64_MAX) {
@@ -79,15 +87,19 @@ bool msgpack_rpc_to_integer(msgpack_object *obj, Integer *arg)
   return obj->type == MSGPACK_OBJECT_NEGATIVE_INTEGER;
 }
 
-bool msgpack_rpc_to_float(msgpack_object *obj, Float *arg)
-  FUNC_ATTR_NONNULL_ALL
+bool msgpack_rpc_to_float(msgpack_object *obj,
+                          Float *arg,
+                          uint64_t channel)
+  FUNC_ATTR_NONNULL_ARG(1, 2)
 {
   *arg = obj->via.dec;
   return obj->type == MSGPACK_OBJECT_DOUBLE;
 }
 
-bool msgpack_rpc_to_string(msgpack_object *obj, String *arg)
-  FUNC_ATTR_NONNULL_ALL
+bool msgpack_rpc_to_string(msgpack_object *obj,
+                           String *arg,
+                           uint64_t channel)
+  FUNC_ATTR_NONNULL_ARG(1, 2)
 {
   if (obj->type == MSGPACK_OBJECT_BIN || obj->type == MSGPACK_OBJECT_STR) {
     arg->data = xmemdupz(obj->via.bin.ptr, obj->via.bin.size);
@@ -99,8 +111,10 @@ bool msgpack_rpc_to_string(msgpack_object *obj, String *arg)
   return true;
 }
 
-bool msgpack_rpc_to_object(msgpack_object *obj, Object *arg)
-  FUNC_ATTR_NONNULL_ALL
+bool msgpack_rpc_to_object(msgpack_object *obj,
+                           Object *arg,
+                           uint64_t channel)
+  FUNC_ATTR_NONNULL_ARG(1, 2)
 {
   switch (obj->type) {
     case MSGPACK_OBJECT_NIL:
@@ -109,46 +123,50 @@ bool msgpack_rpc_to_object(msgpack_object *obj, Object *arg)
 
     case MSGPACK_OBJECT_BOOLEAN:
       arg->type = kObjectTypeBoolean;
-      return msgpack_rpc_to_boolean(obj, &arg->data.boolean);
+      return msgpack_rpc_to_boolean(obj, &arg->data.boolean, channel);
 
     case MSGPACK_OBJECT_POSITIVE_INTEGER:
     case MSGPACK_OBJECT_NEGATIVE_INTEGER:
       arg->type = kObjectTypeInteger;
-      return msgpack_rpc_to_integer(obj, &arg->data.integer);
+      return msgpack_rpc_to_integer(obj, &arg->data.integer, channel);
 
     case MSGPACK_OBJECT_DOUBLE:
       arg->type = kObjectTypeFloat;
-      return msgpack_rpc_to_float(obj, &arg->data.floating);
+      return msgpack_rpc_to_float(obj, &arg->data.floating, channel);
 
     case MSGPACK_OBJECT_BIN:
     case MSGPACK_OBJECT_STR:
       arg->type = kObjectTypeString;
-      return msgpack_rpc_to_string(obj, &arg->data.string);
+      return msgpack_rpc_to_string(obj, &arg->data.string, channel);
 
     case MSGPACK_OBJECT_ARRAY:
       arg->type = kObjectTypeArray;
-      return msgpack_rpc_to_array(obj, &arg->data.array);
+      return msgpack_rpc_to_array(obj, &arg->data.array, channel);
 
     case MSGPACK_OBJECT_MAP:
       arg->type = kObjectTypeDictionary;
-      return msgpack_rpc_to_dictionary(obj, &arg->data.dictionary);
+      return msgpack_rpc_to_dictionary(obj, &arg->data.dictionary, channel);
 
     case MSGPACK_OBJECT_EXT:
       switch (obj->via.ext.type) {
         case kObjectTypeBuffer:
-          return msgpack_rpc_to_buffer(obj, &arg->data.buffer);
+          return msgpack_rpc_to_buffer(obj, &arg->data.buffer, channel);
         case kObjectTypeWindow:
-          return msgpack_rpc_to_window(obj, &arg->data.window);
+          return msgpack_rpc_to_window(obj, &arg->data.window, channel);
         case kObjectTypeTabpage:
-          return msgpack_rpc_to_tabpage(obj, &arg->data.tabpage);
+          return msgpack_rpc_to_tabpage(obj, &arg->data.tabpage, channel);
+        case kObjectTypeFunction:
+          return msgpack_rpc_to_function(obj, &arg->data.function, channel);
       }
     default:
       return false;
   }
 }
 
-bool msgpack_rpc_to_array(msgpack_object *obj, Array *arg)
-  FUNC_ATTR_NONNULL_ALL
+bool msgpack_rpc_to_array(msgpack_object *obj,
+                          Array *arg,
+                          uint64_t channel)
+  FUNC_ATTR_NONNULL_ARG(1, 2)
 {
   if (obj->type != MSGPACK_OBJECT_ARRAY) {
     return false;
@@ -158,7 +176,7 @@ bool msgpack_rpc_to_array(msgpack_object *obj, Array *arg)
   arg->items = xcalloc(obj->via.array.size, sizeof(Object));
 
   for (uint32_t i = 0; i < obj->via.array.size; i++) {
-    if (!msgpack_rpc_to_object(obj->via.array.ptr + i, &arg->items[i])) {
+    if (!msgpack_rpc_to_object(obj->via.array.ptr + i, &arg->items[i], channel)) {
       return false;
     }
   }
@@ -166,8 +184,10 @@ bool msgpack_rpc_to_array(msgpack_object *obj, Array *arg)
   return true;
 }
 
-bool msgpack_rpc_to_dictionary(msgpack_object *obj, Dictionary *arg)
-  FUNC_ATTR_NONNULL_ALL
+bool msgpack_rpc_to_dictionary(msgpack_object *obj,
+                               Dictionary *arg,
+                               uint64_t channel)
+  FUNC_ATTR_NONNULL_ARG(1, 2)
 {
   if (obj->type != MSGPACK_OBJECT_MAP) {
     return false;
@@ -179,16 +199,43 @@ bool msgpack_rpc_to_dictionary(msgpack_object *obj, Dictionary *arg)
 
   for (uint32_t i = 0; i < obj->via.map.size; i++) {
     if (!msgpack_rpc_to_string(&obj->via.map.ptr[i].key,
-          &arg->items[i].key)) {
+          &arg->items[i].key, channel)) {
       return false;
     }
 
     if (!msgpack_rpc_to_object(&obj->via.map.ptr[i].val,
-          &arg->items[i].value)) {
+          &arg->items[i].value, channel)) {
       return false;
     }
   }
 
+  return true;
+}
+
+bool msgpack_rpc_to_function(msgpack_object *obj,
+                             Function *arg,
+                             uint64_t channel)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (obj->type != MSGPACK_OBJECT_EXT
+      || obj->via.ext.type != kObjectTypeFunction) {
+    return false;
+  }
+
+  msgpack_object data;
+  msgpack_unpack_return ret = msgpack_unpack(obj->via.ext.ptr,
+                                             obj->via.ext.size,
+                                             NULL,
+                                             &zone,
+                                             &data);
+
+  if (ret != MSGPACK_UNPACK_SUCCESS || data.type != MSGPACK_OBJECT_BIN) {
+    return false;
+  }
+
+  arg->data.name = xmemdupz(data.via.bin.ptr, data.via.bin.size);
+  arg->data.channel = channel;
+  arg->ptr = channel_callback;
   return true;
 }
 
@@ -264,6 +311,10 @@ void msgpack_rpc_from_object(Object result, msgpack_packer *res)
     case kObjectTypeDictionary:
       msgpack_rpc_from_dictionary(result.data.dictionary, res);
       break;
+
+    case kObjectTypeFunction:
+      msgpack_rpc_from_function(result.data.function, res);
+      break;
   }
 }
 
@@ -286,4 +337,36 @@ void msgpack_rpc_from_dictionary(Dictionary result, msgpack_packer *res)
     msgpack_rpc_from_string(result.items[i].key, res);
     msgpack_rpc_from_object(result.items[i].value, res);
   }
+}
+
+void msgpack_rpc_from_function(Function result, msgpack_packer *res)
+  FUNC_ATTR_NONNULL_ARG(2)
+{
+  msgpack_packer pac;
+  msgpack_packer_init(&pac, &sbuffer, msgpack_sbuffer_write);
+  msgpack_rpc_from_string(cstr_as_string(result.data.name), &pac);
+  msgpack_pack_ext(res, sbuffer.size, kObjectTypeFunction);
+  msgpack_pack_ext_body(res, sbuffer.data, sbuffer.size);
+  msgpack_sbuffer_clear(&sbuffer);
+}
+
+static Object channel_callback(FunctionData *data, Array args, Error *err)
+{
+  assert(data->channel);
+
+  if (data->async) {
+    if (!channel_send_event(data->channel, data->name, args)) {
+      api_set_error(err, Exception, _("Invalid channel id"));
+    }
+
+    return NIL;
+  }
+
+  Object rv = channel_send_call(data->channel, data->name, args, err);
+
+  if (err->set) {
+    return NIL;
+  }
+
+  return rv;
 }


### PR DESCRIPTION
Goals of this PR:
- Finish decoupling the API from msgpack-rpc. By making functions like `vim_register_provider` and `vim_subscribe`/`vim_unsubscribe` receive Function instances, we can make the API usable by non-msgpack plugins(by libraries loaded dynamically via `libcall()` for example). Translating Function instances to remove msgpack-rpc calls will be fully handled by the msgpack-rpc layer.
- Let plugins(written in any language) to transparently pass functions to/from vimscript.
  
  For example, a python plugin may be able to do things like:

``` python
def python_execute()
  pass

def python_eval()
  pass

vim.register_provider('python', {
    'execute': python_execute
    'eval': python_eval
})

# or even

vim.vars['PythonEval'] = python_eval
# g:PythonEval is now callable from vimscript
```

Clearly this will require some support on the client, which I'm still going to implement.
