### PR TITLE
[RDY] Set `v:job_data[2]` line-wise and `jobsend(,[list]). (#1243)

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4014,7 +4014,14 @@ items({dict})						*items()*
 
 jobsend({job}, {data})					{Nvim} *jobsend()*
 		Send data to {job} by writing it to the stdin of the process.
+		Returns 1 if the write succeeded, 0 otherwise.
 		See |job-control| for more information.
+
+		{data} may be a string, string convertible, or a list.  If
+		{data} is a list, the items will be separated by newlines and
+		any newlines in an item will be sent as a NUL.  For example: >
+			:call jobsend(j, ["abc", "123\n456"])
+< 		will send "abc<NL>123<NUL>456<NL>".
 
 jobstart({name}, {prog}[, {argv}])			{Nvim} *jobstart()*
 		Spawns {prog} as a job and associate it with the {name} string,

--- a/runtime/doc/job_control.txt
+++ b/runtime/doc/job_control.txt
@@ -47,9 +47,9 @@ event. The best way to understand is with a complete example:
     
     function JobHandler()
       if v:job_data[1] == 'stdout'
-        let str = 'shell '. v:job_data[0].' stdout: '.v:job_data[2]
+        let str = 'shell '. v:job_data[0].' stdout: '.join(v:job_data[2])
       elseif v:job_data[1] == 'stderr'
-        let str = 'shell '.v:job_data[0].' stderr: '.v:job_data[2]
+        let str = 'shell '.v:job_data[0].' stderr: '.join(v:job_data[2])
       else
         let str = 'shell '.v:job_data[0].' exited'
       endif
@@ -80,8 +80,8 @@ Here's what is happening:
   following elements:
   0: The job id
   1: The kind of activity: one of "stdout", "stderr" or "exit"
-  2: When "activity" is "stdout" or "stderr", this will contain the data read
-     from stdout or stderr
+  2: When "activity" is "stdout" or "stderr", this will contain a list of
+     lines read from stdout or stderr
 
 To send data to the job's stdin, one can use the |jobsend()| function, like
 this:

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -389,6 +389,25 @@ char *xstrdup(const char *str)
   return ret;
 }
 
+/// A version of memchr that starts the search at `src + len`.
+///
+/// Based on glibc's memrchr.
+///
+/// @param src The source memory object.
+/// @param c   The byte to search for.
+/// @param len The length of the memory object.
+/// @returns a pointer to the found byte in src[len], or NULL.
+void *xmemrchr(void *src, uint8_t c, size_t len)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
+{
+  while (len--) {
+    if (((uint8_t *)src)[len] == c) {
+      return (uint8_t *) src + len;
+    }
+  }
+  return NULL;
+}
+
 /// strndup() wrapper
 ///
 /// @see {xmalloc}

--- a/src/nvim/os/rstream.c
+++ b/src/nvim/os/rstream.c
@@ -190,6 +190,18 @@ RStream * rstream_new(rstream_cb cb, RBuffer *buffer, void *data)
   return rv;
 }
 
+/// Returns the read pointer used by the rstream.
+char *rstream_read_ptr(RStream *rstream)
+{
+  return rbuffer_read_ptr(rstream->buffer);
+}
+
+/// Returns the number of bytes before the rstream is full.
+size_t rstream_available(RStream *rstream)
+{
+  return rbuffer_available(rstream->buffer);
+}
+
 /// Frees all memory allocated for a RStream instance
 ///
 /// @param rstream The `RStream` instance

--- a/test/functional/job/job_spec.lua
+++ b/test/functional/job/job_spec.lua
@@ -82,7 +82,7 @@ describe('jobs', function()
 
   it('will not allow jobsend/stop on a non-existent job', function()
     eq(false, pcall(eval, "jobsend(-1, 'lol')"))
-    eq(false, pcall(eval, "jobstop(-1, 'lol')"))
+    eq(false, pcall(eval, "jobstop(-1)"))
   end)
 
   it('will not allow jobstop twice on the same job', function()

--- a/test/functional/job/job_spec.lua
+++ b/test/functional/job/job_spec.lua
@@ -11,8 +11,12 @@ describe('jobs', function()
   before_each(clear)
 
   -- Creates the string to make an autocmd to notify us.
-  local notify_str = function(expr)
-    return "au! JobActivity xxx call rpcnotify("..channel..", "..expr..")"
+  local notify_str = function(expr1, expr2)
+    local str = "au! JobActivity xxx call rpcnotify("..channel..", "..expr1
+    if expr2 ~= nil then
+      str = str..", "..expr2
+    end
+    return str..")"
   end
 
   local notify_job = function()
@@ -33,17 +37,27 @@ describe('jobs', function()
   end)
 
   it('allows interactive commands', function()
-    nvim('command', notify_str('v:job_data[2]'))
+    nvim('command', notify_str('v:job_data[1]', 'v:job_data[2]'))
     nvim('command', "let j = jobstart('xxx', 'cat', ['-'])")
     neq(0, eval('j'))
-    nvim('command', "call jobsend(j, 'abc')")
-    eq({'notification', 'abc', {}}, next_message())
-    nvim('command', "call jobsend(j, '123')")
-    eq({'notification', '123', {}}, next_message())
+    nvim('command', 'call jobsend(j, "abc\\n")')
+    eq({'notification', 'stdout', {{'abc'}}}, next_message())
+    nvim('command', 'call jobsend(j, "123\\nxyz\\n")')
+    eq({'notification', 'stdout', {{'123', 'xyz'}}}, next_message())
     nvim('command', notify_str('v:job_data[1])'))
     nvim('command', "call jobstop(j)")
     eq({'notification', 'exit', {}}, next_message())
   end)
+
+  it('will hold data if it does not end in a newline', function()
+    nvim('command', notify_str('v:job_data[1]', 'v:job_data[2]'))
+    nvim('command', "let j = jobstart('xxx', 'cat', ['-'])")
+    nvim('command', 'call jobsend(j, "abc\\nxyz")')
+    eq({'notification', 'stdout', {{'abc'}}}, next_message())
+    nvim('command', "call jobstop(j)")
+    eq({'notification', 'stdout', {{'xyz'}}}, next_message())
+  end)
+
 
   it('will not allow jobsend/stop on a non-existent job', function()
     eq(false, pcall(eval, "jobsend(-1, 'lol')"))
@@ -65,9 +79,9 @@ describe('jobs', function()
     nvim('command', notify_job())
     nvim('command', "let j = jobstart('xxx', 'cat', ['-'])")
     local jobid = nvim('eval', 'j')
-    nvim('eval', 'jobsend(j, "abc\ndef")')
+    nvim('eval', 'jobsend(j, "abcdef")')
     nvim('eval', 'jobstop(j)')
-    eq({'notification', 'j', {{jobid, 'stdout', 'abc\ndef'}}}, next_message())
+    eq({'notification', 'j', {{jobid, 'stdout', {'abcdef'}}}}, next_message())
     eq({'notification', 'j', {{jobid, 'exit'}}}, next_message())
   end)
 end)


### PR DESCRIPTION
As mentioned in #1243, `v:job_data[2]` should contain line-wise data and a partial read may corrupt it. This is one possible solution:

I thought maybe `rstream` is a low-level API and the solution should be in the logic for jobs, but `rstream` clients cannot view the buffer's contents before reading, so the API has to help on some level to find the new-line character. This implements `rstream_read_lines()`, which returns the buffer contents up to and including the last new line character.

A more sophisticated API might tell the user how many bytes until the last new line, but the buffer may need to grow or make space and that seemed to expose too much of the inner-logic, having the client manage the edge cases.

Vroom tests failed on travis (`AttributeError: 'module' object has no attribute 'connect'`), but not locally, so I don't think I broke them.
