### PR TITLE
[WIP/RFC] Clean up and split 2-step antipattern in set_char_option()

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4710,7 +4710,7 @@ skip:
  */
 static char_u *set_chars_option(char_u **varp)
 {
-  char_u      *p, *s;
+  char_u *s;
   int c1, c2 = 0;
   struct charstab {
     int     *cp;
@@ -4758,8 +4758,7 @@ static char_u *set_chars_option(char_u **varp)
       else
         fill_diff = '-';
     }
-    p = *varp;
-    while (*p) {
+    for (char_u *p = *varp; *p;) {
       bool valid = false;
       for (int i = 0; i < entries; ++i) {
         int len = (int)STRLEN(tab[i].name);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4737,10 +4737,10 @@ static char_u *set_chars_option(char_u **varp)
   int entries;
   if (varp == &p_lcs) {
     tab = lcstab;
-    entries = sizeof(lcstab) / sizeof(struct charstab);
+    entries = sizeof(lcstab) / sizeof(*tab);
   } else {
     tab = filltab;
-    entries = sizeof(filltab) / sizeof(struct charstab);
+    entries = sizeof(filltab) / sizeof(*tab);
   }
 
   /* first round: check for valid value, second round: assign values */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4710,7 +4710,7 @@ skip:
  */
 static char_u *set_chars_option(char_u **varp)
 {
-  int round, i, entries;
+  int round, entries;
   char_u      *p, *s;
   int c1, c2 = 0;
   struct charstab {
@@ -4750,7 +4750,7 @@ static char_u *set_chars_option(char_u **varp)
     if (round > 0) {
       /* After checking that the value is valid: set defaults: space for
        * 'fillchars', NUL for 'listchars' */
-      for (i = 0; i < entries; ++i)
+      for (int i = 0; i < entries; ++i)
         if (tab[i].cp != NULL)
           *(tab[i].cp) = (varp == &p_lcs ? NUL : ' ');
       if (varp == &p_lcs)
@@ -4760,7 +4760,8 @@ static char_u *set_chars_option(char_u **varp)
     }
     p = *varp;
     while (*p) {
-      for (i = 0; i < entries; ++i) {
+      bool valid = false;
+      for (int i = 0; i < entries; ++i) {
         int len = (int)STRLEN(tab[i].name);
         if (STRNCMP(p, tab[i].name, len) == 0
             && p[len] == ':'
@@ -4786,12 +4787,13 @@ static char_u *set_chars_option(char_u **varp)
 
             }
             p = s;
+            valid = true;
             break;
           }
         }
       }
 
-      if (i == entries)
+      if (!valid)
         return e_invarg;
       if (*p == ',')
         ++p;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4704,10 +4704,9 @@ skip:
   return NULL;    /* no error */
 }
 
-/*
- * Handle setting 'listchars' or 'fillchars'.
- * Returns error message, NULL if it's OK.
- */
+
+// Handle setting 'listchars' or 'fillchars'.
+// Returns error message, NULL if it's OK.
 static char_u *set_chars_option(char_u **varp)
 {
   struct charstab {
@@ -4743,11 +4742,11 @@ static char_u *set_chars_option(char_u **varp)
     entries = sizeof(filltab) / sizeof(*tab);
   }
 
-  /* first round: check for valid value, second round: assign values */
+  // First round: check for valid value, second round: assign values.
   for (int round = 0; round <= 1; ++round) {
     if (round > 0) {
-      /* After checking that the value is valid: set defaults: space for
-       * 'fillchars', NUL for 'listchars' */
+      // After checking that the value is valid: set defaults: space for
+      // 'fillchars', NUL for 'listchars'.
       for (int i = 0; i < entries; ++i) {
         if (tab[i].cp != NULL) {
           *(tab[i].cp) = (varp == &p_lcs ? NUL : ' ');
@@ -4806,7 +4805,7 @@ static char_u *set_chars_option(char_u **varp)
     }
   }
 
-  return NULL;          /* no error */
+  return NULL; // No error.
 }
 
 /*

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2142,7 +2142,7 @@ void set_init_1(void)
  * Set an option to its default value.
  * This does not take care of side effects!
  */
-static void 
+static void
 set_option_default (
     int opt_idx,
     int opt_flags,                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
@@ -2205,7 +2205,7 @@ set_option_default (
 /*
  * Set all options (except terminal options) to their default value.
  */
-static void 
+static void
 set_options_default (
     int opt_flags                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
 )
@@ -2496,7 +2496,7 @@ void set_title_defaults(void)
  *
  * returns FAIL if an error is detected, OK otherwise
  */
-int 
+int
 do_set (
     char_u *arg,               /* option string (may be written to!) */
     int opt_flags
@@ -3237,7 +3237,7 @@ theend:
  * Call this when an option has been given a new value through a user command.
  * Sets the P_WAS_SET flag and takes care of the P_INSECURE flag.
  */
-static void 
+static void
 did_set_option (
     int opt_idx,
     int opt_flags,              /* possibly with OPT_MODELINE */
@@ -3309,7 +3309,7 @@ static char_u *check_cedit(void)
  * When switching the title or icon off, call mch_restore_title() to get
  * the old value back.
  */
-static void 
+static void
 did_set_title (
     int icon                   /* Did set icon instead of title */
 )
@@ -3330,7 +3330,7 @@ did_set_title (
 /*
  * set_options_bin -  called when 'bin' changes value.
  */
-void 
+void
 set_options_bin (
     int oldval,
     int newval,
@@ -3643,7 +3643,7 @@ static void redraw_titles(void) {
  * When "set_sid" is zero set the scriptID to current_SID.  When "set_sid" is
  * SID_NONE don't set the scriptID.  Otherwise set the scriptID to "set_sid".
  */
-void 
+void
 set_string_option_direct (
     char_u *name,
     int opt_idx,
@@ -3697,7 +3697,7 @@ set_string_option_direct (
 /*
  * Set global value for string option when it's a local option.
  */
-static void 
+static void
 set_string_option_global (
     int opt_idx,                    /* option index */
     char_u **varp             /* pointer to option variable */
@@ -4710,7 +4710,7 @@ skip:
  */
 static char_u *set_chars_option(char_u **varp)
 {
-  int round, i, len, entries;
+  int round, i, entries;
   char_u      *p, *s;
   int c1, c2 = 0;
   struct charstab {
@@ -4761,7 +4761,7 @@ static char_u *set_chars_option(char_u **varp)
     p = *varp;
     while (*p) {
       for (i = 0; i < entries; ++i) {
-        len = (int)STRLEN(tab[i].name);
+        int len = (int)STRLEN(tab[i].name);
         if (STRNCMP(p, tab[i].name, len) == 0
             && p[len] == ':'
             && p[len + 1] != NUL) {
@@ -5752,7 +5752,7 @@ static int findoption(char_u *arg)
  *	     hidden String option: -2.
  *		   unknown option: -3.
  */
-int 
+int
 get_option_value (
     char_u *name,
     long *numval,
@@ -5804,7 +5804,7 @@ get_option_value (
 // opt_type). Uses
 //
 // Returned flags:
-//       0 hidden or unknown option, also option that does not have requested 
+//       0 hidden or unknown option, also option that does not have requested
 //         type (see SREQ_* in option_defs.h)
 //  see SOPT_* in option_defs.h for other flags
 //
@@ -6046,7 +6046,7 @@ static int find_key_option(char_u *arg)
  * if 'all' == 1: show all normal options
  * if 'all' == 2: show all terminal options
  */
-static void 
+static void
 showoptions (
     int all,
     int opt_flags                  /* OPT_LOCAL and/or OPT_GLOBAL */
@@ -6161,7 +6161,7 @@ static int optval_default(struct vimoption *p, char_u *varp)
  * showoneopt: show the value of one option
  * must not be called with a hidden option!
  */
-static void 
+static void
 showoneopt (
     struct vimoption *p,
     int opt_flags                          /* OPT_LOCAL or OPT_GLOBAL */
@@ -7083,7 +7083,7 @@ static int expand_option_idx = -1;
 static char_u expand_option_name[5] = {'t', '_', NUL, NUL, NUL};
 static int expand_option_flags = 0;
 
-void 
+void
 set_context_in_set_cmd (
     expand_T *xp,
     char_u *arg,
@@ -7438,7 +7438,7 @@ void ExpandOldSetting(int *num_file, char_u ***file)
  * Get the value for the numeric or string option *opp in a nice format into
  * NameBuff[].  Must not be called with a hidden option!
  */
-static void 
+static void
 option_value2string (
     struct vimoption *opp,
     int opt_flags                          /* OPT_GLOBAL and/or OPT_LOCAL */
@@ -7495,7 +7495,7 @@ static int wc_use_keyname(char_u *varp, long *wcp)
  *
  * langmap_mapchar[] maps any of 256 chars to an ASCII char used for Vim
  * commands.
- * langmap_mapga.ga_data is a sorted table of langmap_entry_T. 
+ * langmap_mapga.ga_data is a sorted table of langmap_entry_T.
  * This does the same as langmap_mapchar[] for characters >= 256.
  */
 /*
@@ -7889,7 +7889,7 @@ static void fill_breakat_flags(void)
  * Return OK for correct value, FAIL otherwise.
  * Empty is always OK.
  */
-static int 
+static int
 check_opt_strings (
     char_u *val,
     char **values,
@@ -7906,7 +7906,7 @@ check_opt_strings (
  * Return OK for correct value, FAIL otherwise.
  * Empty is always OK.
  */
-static int 
+static int
 opt_strings_flags (
     char_u *val,               /* new value */
     char **values,           /* array of valid string values */
@@ -7989,7 +7989,7 @@ static int check_opt_wim(void)
 /*
  * Check if backspacing over something is allowed.
  */
-int 
+int
 can_bs (
     int what                   /* BS_INDENT, BS_EOL or BS_START */
 )
@@ -8148,7 +8148,7 @@ void find_mps_values(int *initc, int *findc, int *backwards, int switchit)
 
 /* This is called when 'breakindentopt' is changed and when a window is
    initialized */
-int briopt_check(void) 
+int briopt_check(void)
 {
   char_u	*p;
   int bri_shift = 0;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4710,7 +4710,6 @@ skip:
  */
 static char_u *set_chars_option(char_u **varp)
 {
-  int entries;
   char_u      *p, *s;
   int c1, c2 = 0;
   struct charstab {
@@ -4737,6 +4736,7 @@ static char_u *set_chars_option(char_u **varp)
   };
   struct charstab *tab;
 
+  int entries;
   if (varp == &p_lcs) {
     tab = lcstab;
     entries = sizeof(lcstab) / sizeof(struct charstab);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4748,13 +4748,16 @@ static char_u *set_chars_option(char_u **varp)
     if (round > 0) {
       /* After checking that the value is valid: set defaults: space for
        * 'fillchars', NUL for 'listchars' */
-      for (int i = 0; i < entries; ++i)
-        if (tab[i].cp != NULL)
+      for (int i = 0; i < entries; ++i) {
+        if (tab[i].cp != NULL) {
           *(tab[i].cp) = (varp == &p_lcs ? NUL : ' ');
-      if (varp == &p_lcs)
+        }
+      }
+      if (varp == &p_lcs) {
         lcs_tab1 = NUL;
-      else
+      } else {
         fill_diff = '-';
+      }
     }
     for (char_u *p = *varp; *p;) {
       bool valid = false;
@@ -4765,24 +4768,27 @@ static char_u *set_chars_option(char_u **varp)
             && p[len + 1] != NUL) {
           char_u *s = p + len + 1;
           int c1 = mb_ptr2char_adv(&s);
-          if (mb_char2cells(c1) > 1)
+          if (mb_char2cells(c1) > 1) {
             continue;
+          }
           int c2 = 0;
           if (tab[i].cp == &lcs_tab2) {
-            if (*s == NUL)
+            if (*s == NUL) {
               continue;
+            }
             c2 = mb_ptr2char_adv(&s);
-            if (mb_char2cells(c2) > 1)
+            if (mb_char2cells(c2) > 1) {
               continue;
+            }
           }
           if (*s == ',' || *s == NUL) {
             if (round) {
               if (tab[i].cp == &lcs_tab2) {
                 lcs_tab1 = c1;
                 lcs_tab2 = c2;
-              } else if (tab[i].cp != NULL)
+              } else if (tab[i].cp != NULL) {
                 *(tab[i].cp) = c1;
-
+              }
             }
             p = s;
             valid = true;
@@ -4791,10 +4797,12 @@ static char_u *set_chars_option(char_u **varp)
         }
       }
 
-      if (!valid)
+      if (!valid) {
         return e_invarg;
-      if (*p == ',')
+      }
+      if (*p == ',') {
         ++p;
+      }
     }
   }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4710,7 +4710,7 @@ skip:
  */
 static char_u *set_chars_option(char_u **varp)
 {
-  int c1, c2 = 0;
+  int c2 = 0;
   struct charstab {
     int     *cp;
     char    *name;
@@ -4765,7 +4765,7 @@ static char_u *set_chars_option(char_u **varp)
             && p[len] == ':'
             && p[len + 1] != NUL) {
           char_u *s = p + len + 1;
-          c1 = mb_ptr2char_adv(&s);
+          int c1 = mb_ptr2char_adv(&s);
           if (mb_char2cells(c1) > 1)
             continue;
           if (tab[i].cp == &lcs_tab2) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4710,7 +4710,6 @@ skip:
  */
 static char_u *set_chars_option(char_u **varp)
 {
-  int c2 = 0;
   struct charstab {
     int     *cp;
     char    *name;
@@ -4768,6 +4767,7 @@ static char_u *set_chars_option(char_u **varp)
           int c1 = mb_ptr2char_adv(&s);
           if (mb_char2cells(c1) > 1)
             continue;
+          int c2 = 0;
           if (tab[i].cp == &lcs_tab2) {
             if (*s == NUL)
               continue;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4710,7 +4710,6 @@ skip:
  */
 static char_u *set_chars_option(char_u **varp)
 {
-  char_u *s;
   int c1, c2 = 0;
   struct charstab {
     int     *cp;
@@ -4765,7 +4764,7 @@ static char_u *set_chars_option(char_u **varp)
         if (STRNCMP(p, tab[i].name, len) == 0
             && p[len] == ':'
             && p[len + 1] != NUL) {
-          s = p + len + 1;
+          char_u *s = p + len + 1;
           c1 = mb_ptr2char_adv(&s);
           if (mb_char2cells(c1) > 1)
             continue;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4710,7 +4710,7 @@ skip:
  */
 static char_u *set_chars_option(char_u **varp)
 {
-  int round, entries;
+  int entries;
   char_u      *p, *s;
   int c1, c2 = 0;
   struct charstab {
@@ -4746,7 +4746,7 @@ static char_u *set_chars_option(char_u **varp)
   }
 
   /* first round: check for valid value, second round: assign values */
-  for (round = 0; round <= 1; ++round) {
+  for (int round = 0; round <= 1; ++round) {
     if (round > 0) {
       /* After checking that the value is valid: set defaults: space for
        * 'fillchars', NUL for 'listchars' */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4743,11 +4743,11 @@ static char_u *set_chars_option(char_u **varp)
   }
 
   // First round: check for valid value, second round: assign values.
-  for (int round = 0; round <= 1; ++round) {
+  for (int round = 0; round <= 1; round++) {
     if (round > 0) {
       // After checking that the value is valid: set defaults: space for
       // 'fillchars', NUL for 'listchars'.
-      for (int i = 0; i < entries; ++i) {
+      for (int i = 0; i < entries; i++) {
         if (tab[i].cp != NULL) {
           *(tab[i].cp) = (varp == &p_lcs ? NUL : ' ');
         }
@@ -4760,7 +4760,7 @@ static char_u *set_chars_option(char_u **varp)
     }
     for (char_u *p = *varp; *p;) {
       bool valid = false;
-      for (int i = 0; i < entries; ++i) {
+      for (int i = 0; i < entries; i++) {
         int len = (int)STRLEN(tab[i].name);
         if (STRNCMP(p, tab[i].name, len) == 0
             && p[len] == ':'
@@ -4800,7 +4800,7 @@ static char_u *set_chars_option(char_u **varp)
         return e_invarg;
       }
       if (*p == ',') {
-        ++p;
+        p++;
       }
     }
   }


### PR DESCRIPTION
A lot of small changes in the set_char_option() function in option.c (for compliance with the neovim style guide), and the split of the 2-step loop as discussed in issue #572.

There is a lot of commits that might be needless in history. I would like an external opinion on how to squash them. Further refactoring suggestions appreciated as well.
