### PR TITLE
[RDY] Use line-specific method names where possible

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -31,7 +31,7 @@
 /// @param buffer The buffer handle
 /// @param[out] err Details of an error that may have occurred
 /// @return The line count
-Integer buffer_get_length(Buffer buffer, Error *err)
+Integer buffer_line_count(Buffer buffer, Error *err)
 {
   buf_T *buf = find_buffer_by_handle(buffer, err);
 
@@ -51,7 +51,7 @@ Integer buffer_get_length(Buffer buffer, Error *err)
 String buffer_get_line(Buffer buffer, Integer index, Error *err)
 {
   String rv = {.size = 0};
-  Array slice = buffer_get_slice(buffer, index, index, true, true, err);
+  Array slice = buffer_get_line_slice(buffer, index, index, true, true, err);
 
   if (!err->set && slice.size) {
     rv = slice.items[0].data.string;
@@ -72,7 +72,7 @@ void buffer_set_line(Buffer buffer, Integer index, String line, Error *err)
 {
   Object l = STRING_OBJ(line);
   Array array = {.items = &l, .size = 1};
-  buffer_set_slice(buffer, index, index, true, true, array, err);
+  buffer_set_line_slice(buffer, index, index, true, true, array, err);
 }
 
 /// Deletes a buffer line
@@ -83,7 +83,7 @@ void buffer_set_line(Buffer buffer, Integer index, String line, Error *err)
 void buffer_del_line(Buffer buffer, Integer index, Error *err)
 {
   Array array = ARRAY_DICT_INIT;
-  buffer_set_slice(buffer, index, index, true, true, array, err);
+  buffer_set_line_slice(buffer, index, index, true, true, array, err);
 }
 
 /// Retrieves a line range from the buffer
@@ -95,7 +95,7 @@ void buffer_del_line(Buffer buffer, Integer index, Error *err)
 /// @param include_end True if the slice includes the `end` parameter
 /// @param[out] err Details of an error that may have occurred
 /// @return An array of lines
-ArrayOf(String) buffer_get_slice(Buffer buffer,
+ArrayOf(String) buffer_get_line_slice(Buffer buffer,
                                  Integer start,
                                  Integer end,
                                  Boolean include_start,
@@ -156,7 +156,7 @@ end:
 /// @param replacement An array of lines to use as replacement(A 0-length
 //         array will simply delete the line range)
 /// @param[out] err Details of an error that may have occurred
-void buffer_set_slice(Buffer buffer,
+void buffer_set_line_slice(Buffer buffer,
                       Integer start,
                       Integer end,
                       Boolean include_start,
@@ -445,7 +445,7 @@ void buffer_insert(Buffer buffer,
                    ArrayOf(String) lines,
                    Error *err)
 {
-  buffer_set_slice(buffer, lnum, lnum, false, true, lines, err);
+  buffer_set_line_slice(buffer, lnum, lnum, false, true, lines, err);
 }
 
 /// Return a tuple (row,col) representing the position of the named mark


### PR DESCRIPTION
Per #1251 

Note this is a breaking change in the API. Hence changes will be required in plugins/packages that depend on the API (`python-client`, Go `neovim` package etc)
