### PR TITLE
[RFC] Open `os_call_shell()` to sending to stdin/reading callbacks.

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -824,6 +824,8 @@ static void diff_file(char_u *tmp_orig, char_u *tmp_new, char_u *tmp_diff)
     (void)call_shell(
         cmd,
         kShellOptFilter | kShellOptSilent | kShellOptDoOut,
+        NULL,
+        NULL,
         NULL
         );
     unblock_autocmds();
@@ -918,7 +920,7 @@ void ex_diffpatch(exarg_T *eap)
 #endif  // ifdef UNIX
     // Avoid ShellCmdPost stuff
     block_autocmds();
-    (void)call_shell(buf, kShellOptFilter | kShellOptCooked, NULL);
+    (void)call_shell(buf, kShellOptFilter | kShellOptCooked, NULL, NULL, NULL);
     unblock_autocmds();
   }
 

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -831,6 +831,8 @@ static void diff_file(char_u *tmp_orig, char_u *tmp_new,
         cmd,
         kShellOptFilter | kShellOptSilent | kShellOptDoOut,
         NULL,
+        NULL,
+        0,
         read,
         data
         );
@@ -926,7 +928,8 @@ void ex_diffpatch(exarg_T *eap)
 #endif  // ifdef UNIX
     // Avoid ShellCmdPost stuff
     block_autocmds();
-    (void)call_shell(buf, kShellOptFilter | kShellOptCooked, NULL, NULL, NULL);
+    (void)call_shell(buf, kShellOptFilter | kShellOptCooked, NULL, NULL, 0,
+                     NULL, NULL);
     unblock_autocmds();
   }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -945,7 +945,7 @@ void do_bang(int addr_count, exarg_T *eap, int forceit, int do_in, int do_out)
     msg_clr_eos();
     windgoto(msg_row, msg_col);
 
-    do_shell(newcmd, 0);
+    do_shell(newcmd, 0, NULL, NULL);
   } else {                            /* :range! */
     /* Careful: This may recursively call do_bang() again! (because of
      * autocommands) */
@@ -1207,10 +1207,13 @@ filterend:
 ///
 /// When "cmd" is NULL start an interactive shell.
 ///
+///
 /// @param cmd   The command string to execute.
-/// @param flags Flags to send to `os_call_shell()`. May be `kShellOptDoOut`
-///              when redirecting output.
-void do_shell(char_u *cmd, int flags)
+/// @param flags Flags to send to @ref `os_call_shell()`.
+///              May be @ref `kShellOptDoOut` when redirecting output.
+/// @param shell_read A callback to execute on stdout.
+/// @param data  Data associated with `shell_read`.
+void do_shell(char_u *cmd, int flags, shell_read_cb shell_read, void *data)
 {
   int save_nwr;
 
@@ -1251,7 +1254,7 @@ void do_shell(char_u *cmd, int flags)
   if (!swapping_screen())
     windgoto(msg_row, msg_col);
   cursor_on();
-  (void)call_shell(cmd, kShellOptCooked | flags, NULL, NULL, NULL);
+  (void)call_shell(cmd, kShellOptCooked | flags, NULL, shell_read, data);
   did_check_timestamps = FALSE;
   need_check_timestamps = TRUE;
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1097,6 +1097,8 @@ do_filter (
         kShellOptFilter | kShellOptCooked | shell_flags,
         NULL,
         NULL,
+        0,
+        NULL,
         NULL
         )) {
     redraw_later_clear();
@@ -1254,7 +1256,8 @@ void do_shell(char_u *cmd, int flags, shell_read_cb shell_read, void *data)
   if (!swapping_screen())
     windgoto(msg_row, msg_col);
   cursor_on();
-  (void)call_shell(cmd, kShellOptCooked | flags, NULL, shell_read, data);
+  (void)call_shell(cmd, kShellOptCooked | flags, NULL, NULL, 0,
+                   shell_read, data);
   did_check_timestamps = FALSE;
   need_check_timestamps = TRUE;
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1203,15 +1203,14 @@ filterend:
   free(otmp);
 }
 
-/*
- * Call a shell to execute a command.
- * When "cmd" is NULL start an interactive shell.
- */
-void 
-do_shell (
-    char_u *cmd,
-    int flags              /* may be SHELL_DOOUT when output is redirected */
-)
+/// Calls a shell to execute a command.
+///
+/// When "cmd" is NULL start an interactive shell.
+///
+/// @param cmd   The command string to execute.
+/// @param flags Flags to send to `os_call_shell()`. May be `kShellOptDoOut`
+///              when redirecting output.
+void do_shell(char_u *cmd, int flags)
 {
   int save_nwr;
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1095,6 +1095,8 @@ do_filter (
   if (call_shell(
         cmd_buf,
         kShellOptFilter | kShellOptCooked | shell_flags,
+        NULL,
+        NULL,
         NULL
         )) {
     redraw_later_clear();
@@ -1250,7 +1252,7 @@ do_shell (
   if (!swapping_screen())
     windgoto(msg_row, msg_col);
   cursor_on();
-  (void)call_shell(cmd, kShellOptCooked | flags, NULL);
+  (void)call_shell(cmd, kShellOptCooked | flags, NULL, NULL, NULL);
   did_check_timestamps = FALSE;
   need_check_timestamps = TRUE;
 

--- a/src/nvim/ex_cmds.h
+++ b/src/nvim/ex_cmds.h
@@ -23,6 +23,7 @@
 #define VIF_GET_OLDFILES        8       /* load v:oldfiles */
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
+#include "nvim/os/shell.h"  // So ex_cmds.h.gen has access to shell_read_cb.
 # include "ex_cmds.h.generated.h"
 #endif
 #endif  // NVIM_EX_CMDS_H

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -389,6 +389,25 @@ char *xstrdup(const char *str)
   return ret;
 }
 
+/// A version of memchr that starts the search at `src + len`.
+///
+/// Based on glibc's memrchr.
+///
+/// @param src The source memory object.
+/// @param c   The byte to search for.
+/// @param len The length of the memory object.
+/// @returns a pointer to the found byte in src[len], or NULL.
+void *xmemrchr(void *src, uint8_t c, size_t len)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
+{
+  while (len--) {
+    if (((uint8_t *)src)[len] == c) {
+      return (uint8_t *) src + len;
+    }
+  }
+  return NULL;
+}
+
 /// strndup() wrapper
 ///
 /// @see {xmalloc}

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -3437,7 +3437,7 @@ get_cmd_output (
    * Don't check timestamps here.
    */
   ++no_check_timestamps;
-  call_shell(command, kShellOptDoOut | kShellOptExpand | flags, NULL);
+  call_shell(command, kShellOptDoOut | kShellOptExpand | flags, NULL, NULL, NULL);
   --no_check_timestamps;
 
   free(command);

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -3437,7 +3437,7 @@ get_cmd_output (
    */
   ++no_check_timestamps;
   call_shell(command, kShellOptDoOut | kShellOptExpand | flags, NULL,
-             (shell_read_cb) cmd_output_cb, &gout);
+             NULL, 0, (shell_read_cb) cmd_output_cb, &gout);
   --no_check_timestamps;
 
   free(command);

--- a/src/nvim/misc2.c
+++ b/src/nvim/misc2.c
@@ -290,6 +290,7 @@ int default_fileformat(void)
  * Call shell.	Calls mch_call_shell, with 'shellxquote' added.
  */
 int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg,
+               char_u *input, size_t input_len,
                shell_read_cb shell_read, void *data)
 {
   char_u      *ncmd;
@@ -316,7 +317,8 @@ int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg,
     tag_freematch();
 
     if (cmd == NULL || *p_sxq == NUL)
-      retval = os_call_shell(cmd, opts, extra_shell_arg, shell_read, data);
+      retval = os_call_shell(cmd, opts, extra_shell_arg, input, input_len,
+                             shell_read, data);
     else {
       char_u *ecmd = cmd;
 
@@ -331,7 +333,8 @@ int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg,
       STRCAT(ncmd, STRCMP(p_sxq, "(") == 0 ? (char_u *)")"
           : STRCMP(p_sxq, "\"(") == 0 ? (char_u *)")\""
           : p_sxq);
-      retval = os_call_shell(ncmd, opts, extra_shell_arg, shell_read, data);
+      retval = os_call_shell(ncmd, opts, extra_shell_arg, input, input_len,
+                             shell_read, data);
       free(ncmd);
 
       if (ecmd != cmd)

--- a/src/nvim/misc2.c
+++ b/src/nvim/misc2.c
@@ -289,7 +289,8 @@ int default_fileformat(void)
 /*
  * Call shell.	Calls mch_call_shell, with 'shellxquote' added.
  */
-int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
+int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg,
+               shell_read_cb shell_read, void *data)
 {
   char_u      *ncmd;
   int retval;
@@ -315,7 +316,7 @@ int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
     tag_freematch();
 
     if (cmd == NULL || *p_sxq == NUL)
-      retval = os_call_shell(cmd, opts, extra_shell_arg);
+      retval = os_call_shell(cmd, opts, extra_shell_arg, shell_read, data);
     else {
       char_u *ecmd = cmd;
 
@@ -330,7 +331,7 @@ int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
       STRCAT(ncmd, STRCMP(p_sxq, "(") == 0 ? (char_u *)")"
           : STRCMP(p_sxq, "\"(") == 0 ? (char_u *)")\""
           : p_sxq);
-      retval = os_call_shell(ncmd, opts, extra_shell_arg);
+      retval = os_call_shell(ncmd, opts, extra_shell_arg, shell_read, data);
       free(ncmd);
 
       if (ecmd != cmd)

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -172,7 +172,9 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg,
     proc_stdio[0].flags = UV_IGNORE;
     proc_stdio[1].flags = UV_IGNORE;
     proc_stdio[2].flags = UV_IGNORE;
-  } else {
+  }
+  if (!(opts & (kShellOptHideMess | kShellOptExpand)) || out_cb)
+  {
     State = EXTERNCMD;
 
     if (opts & kShellOptWrite) {

--- a/src/nvim/os/shell.h
+++ b/src/nvim/os/shell.h
@@ -15,6 +15,8 @@ typedef enum {
   kShellOptHideMess = 128,  ///< previously a global variable from os_unix.c
 } ShellOpts;
 
+typedef void (*shell_read_cb)(char_u* buf, size_t cnt, void *data, bool eof);
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/shell.h.generated.h"
 #endif

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -1163,6 +1163,8 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
       shellopts,
       extra_shell_arg,
       NULL,
+      0,
+      NULL,
       NULL
       );
 

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -1161,7 +1161,9 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
   i = call_shell(
       command,
       shellopts,
-      extra_shell_arg
+      extra_shell_arg,
+      NULL,
+      NULL
       );
 
   /* When running in the background, give it some time to create the temp

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2503,7 +2503,7 @@ void ex_make(exarg_T *eap)
   msg_outtrans(cmd);            /* show what we are doing */
 
   /* let the shell know if we are redirecting output or not */
-  do_shell(cmd, *p_sp != NUL ? kShellOptDoOut : 0);
+  do_shell(cmd, *p_sp != NUL ? kShellOptDoOut : 0, NULL, NULL);
 
 
   res = qf_init(wp, fname, (eap->cmdidx != CMD_make


### PR DESCRIPTION
This implements one of the improvements mentioned in #473; adds a callback to `os_call_shell()` and some of its callers. Unfortunately, this does not replace the `kShellOptRead` like suggested, but it opens the door for instances of `call_shell()`, `do_shell()`, and other such functions, to gain callbacks on a case-by-case basis. Only after all cases have been handled can it be replaced.

I rewired `:diffupdate` (or `:Gdiff` to fugitives) to use a callback, and `get_cmd_output()`, but I have no clue when the latter actually gets used. (I rewired `f_system()` just to test it!).

Originally, my plan was to use this as an alternate solution to #1241, but whereas with a job I could give stdin and stderr their own callbacks, I don't see much use for that here. better would be an option to squash stdin and -err into the same pipe stream, which `ex_make()` really needs to work correctly, but I couldn't figure how to make libuv do that. (According to a libuv test named [`spawn_same_stdout_stderr`](https://github.com/joyent/libuv/blob/master/test/test-spawn.c#L643), setting the `stdio_count` to 2 should be sufficient, but it didn't work.)

Obviously there is much more work to do, but I'm a fan of small, incremental changes and this PR already modifies hundreds of lines. Posting this as `WIP/RFC` because I might decide to add/change a few things in the next couple of days, or I might not.
