### PR TITLE
[RFC] Add Boolean argument escape_csi to vim_feedkeys

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8414,7 +8414,7 @@ static void f_feedkeys(typval_T *argvars, typval_T *rettv)
     }
 
     vim_feedkeys(cstr_as_string((char *)keys),
-		    cstr_as_string((char *)flags));
+		    cstr_as_string((char *)flags), true);
   }
 }
 


### PR DESCRIPTION
- By default vim_feedkeys escaped all input for CSI/K_SPECIAL bytes
  before using it. However since vim_replace_termcodes() also escapes
  the input string chaining these functions together escapes input twice
- vim_feedkeys() now takes a third Boolean argument to enable/disable
  escaping
- Breaks API compatibility

See google/vroom#36, ping @tarruda
