### PR TITLE
[RFC] Let homebrew formula find neovim git version

### DIFF
--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -42,7 +42,7 @@ set(__get_git_revision_description YES)
 get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
 
 function(get_git_dir _gitdir)
-  # .git dir not found, search parent directories
+  # check GIT_DIR in environment first
   set(GIT_DIR "$ENV{GIT_DIR}")
   if(NOT GIT_DIR)
     set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -41,16 +41,18 @@ set(__get_git_revision_description YES)
 # to find the path to this module rather than the path to a calling list file
 get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
 
-function(get_git_head_revision _refspecvar _hashvar)
-  set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-  set(GIT_DIR "${GIT_PARENT_DIR}/.git")
-  while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
+function(get_git_dir _gitdir)
+  # .git dir not found, search parent directories
+  set(GIT_DIR "$ENV{GIT_DIR}")
+  if(NOT GIT_DIR)
+    set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+    set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+  endif()
+  # .git dir not found, search parent directories
+  while(NOT EXISTS "${GIT_DIR}")
     set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
     get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
     if(GIT_PARENT_DIR STREQUAL GIT_PREVIOUS_PARENT)
-      # We have reached the root directory, we are not in git
-      set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
-      set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
       return()
     endif()
     set(GIT_DIR "${GIT_PARENT_DIR}/.git")
@@ -62,6 +64,17 @@ function(get_git_head_revision _refspecvar _hashvar)
     get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
     get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
   endif()
+  set(${_gitdir} ${GIT_DIR} PARENT_SCOPE)
+endfunction()
+
+function(get_git_head_revision _refspecvar _hashvar)
+  get_git_dir(GIT_DIR)
+  if(NOT GIT_DIR)
+    set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+    set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+    return()
+  endif()
+
   set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
   if(NOT EXISTS "${GIT_DATA}")
     file(MAKE_DIRECTORY "${GIT_DATA}")
@@ -86,11 +99,16 @@ function(git_describe _var)
   if(NOT GIT_FOUND)
     find_package(Git QUIET)
   endif()
-  get_git_head_revision(refspec hash)
   if(NOT GIT_FOUND)
     set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
     return()
   endif()
+  get_git_dir(GIT_DIR)
+  if(NOT GIT_DIR)
+    set(${_var} "GITDIR-NOTFOUND" PARENT_SCOPE)
+    return()
+  endif()
+  get_git_head_revision(refspec hash)
   if(NOT hash)
     set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
     return()
@@ -112,7 +130,7 @@ function(git_describe _var)
     ${hash}
     ${ARGN}
     WORKING_DIRECTORY
-    "${CMAKE_SOURCE_DIR}"
+    "${GIT_DIR}"
     RESULT_VARIABLE
     res
     OUTPUT_VARIABLE
@@ -130,18 +148,23 @@ function(git_timestamp _var)
   if(NOT GIT_FOUND)
     find_package(Git QUIET)
   endif()
-  get_git_head_revision(refspec hash)
   if(NOT GIT_FOUND)
     set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
     return()
   endif()
+  get_git_dir(GIT_DIR)
+  if(NOT GIT_DIR)
+    set(${_var} "GITDIR-NOTFOUND" PARENT_SCOPE)
+    return()
+  endif()
+  get_git_head_revision(refspec hash)
   if(NOT hash)
     set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
     return()
   endif()
 
   execute_process(COMMAND "${GIT_EXECUTABLE}" log -1 --format="%ci" ${hash} ${ARGN}
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    WORKING_DIRECTORY "${GIT_DIR}"
     RESULT_VARIABLE res
     OUTPUT_VARIABLE out
     ERROR_QUIET

--- a/neovim.rb
+++ b/neovim.rb
@@ -10,6 +10,7 @@ class Neovim < Formula
   depends_on "autoconf" => :build
 
   def install
+    ENV["GIT_DIR"] = cached_download/".git" if build.head?
     ENV.deparallelize
     system "make", "CMAKE_EXTRA_FLAGS=\"-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}\"", "install"
   end


### PR DESCRIPTION
In https://github.com/neovim/neovim/pull/1267, neovim began using git commit date as part of alpha version string. This pull request fixs the issue that homebrew build cannot find .git directory to extract git information.
