### PR TITLE
Added Mousescroll Option 

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5088,6 +5088,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	The 'mousemodel' option is set by the |:behave| command.
 
+						*'mousescroll'* *'mscr'*
+'mousescroll' 'mscr'	number	(default 1)
+			global
+			{not in Vim}
+	This option tells NVim how many lines to scroll when a mouse scroll
+	keycode is recieved. Also allows for deactivation of scrolling when 0
+
 					*'mouseshape'* *'mouses'* *E547*
 'mouseshape' 'mouses'	string	(default "i:beam,r:beam,s:updown,sd:cross,
 					m:no,ml:up-arrow,v:rightup-arrow")

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3531,8 +3531,8 @@ static void nv_mousescroll(cmdarg_T *cap)
     if (mod_mask & (MOD_MASK_SHIFT | MOD_MASK_CTRL)) {
       (void)onepage(cap->arg ? FORWARD : BACKWARD, 1L);
     } else {
-      cap->count1 = 3;
-      cap->count0 = 3;
+      cap->count1 = (long)p_mscr;
+      cap->count0 = (long)p_mscr;
       nv_scroll_line(cap);
     }
   }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1155,6 +1155,12 @@ static struct vimoption
      (char_u *)"extend",
      (char_u *)0L
    } SCRIPTID_INIT},
+  {"mousescroll", "mscr", P_NUM|P_VI_DEF,
+    (char_u *)&p_mscr, PV_NONE,
+    {
+      (char_u *)1L,
+      (char_u *)1L
+    } SCRIPTID_INIT},
   {"mouseshape",  "mouses",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
    (char_u *)NULL, PV_NONE,
    {(char_u *)NULL, (char_u *)0L}

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -454,6 +454,7 @@ EXTERN char_u   *p_msm;         /* 'mkspellmem' */
 EXTERN long p_mls;              /* 'modelines' */
 EXTERN char_u   *p_mouse;       /* 'mouse' */
 EXTERN char_u   *p_mousem;      /* 'mousemodel' */
+EXTERN long p_mscr;             /* 'mousescroll' */
 EXTERN long p_mouset;           /* 'mousetime' */
 EXTERN int p_more;              /* 'more' */
 EXTERN char_u   *p_opfunc;      /* 'operatorfunc' */


### PR DESCRIPTION
When scrolling with my laptop's touchpad, I noticed that too many lines were scrolled. This PR provides an option for how many lines are translated on each mouse-scroll. Normally, this option would be set to 3, but I saw aesthetic improvements when scrolling 1 line at a time so I made it the default.

This feature implemented by myself has been proposed in #185 & #273 but was denied in those instances because of (respectively) odd PR shenanigans and a lack of documentation. I hope this will be more to everyone's liking.

ex.
`:set mousescroll=3`
`:set mscr=1`
