### PR TITLE
[RFC]CID 71507: Unchecked return value (CHECKED_RETURN)

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4424,7 +4424,7 @@ linenr_T buf_delsign(
 
     /* When deleted the last sign needs to redraw the windows to remove the
      * sign column. Not when curwin is NULL (this means we're exiting). */
-    if (buf->b_signlist != NULL && curwin != NULL) {
+    if (buf->b_signlist == NULL && curwin != NULL) {
         redraw_buf_later(buf, NOT_VALID);
         changed_cline_bef_curs();
     }


### PR DESCRIPTION
Check for the return value of object_to_vim instead of checking for err.set
