### PR TITLE
[RDY] cmake: handle missing git or .git/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ list(APPEND CMAKE_PREFIX_PATH ${DEPS_INSTALL_DIR})
 # Version tokens
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC NVIM_VERSION_COMMIT)
+if (NOT NVIM_VERSION_COMMIT)
+  set(NVIM_VERSION_COMMIT "?")
+endif()
 set(NVIM_VERSION_MAJOR 0)
 set(NVIM_VERSION_MINOR 0)
 set(NVIM_VERSION_PATCH 0)
@@ -22,7 +25,9 @@ set(NVIM_VERSION_PRERELEASE "-alpha")
 # TODO(justinmk): UTC time would be nice here #1071
 git_timestamp(GIT_TIMESTAMP)
 # TODO(justinmk): do not set this for "release" builds #1071
-set(NVIM_VERSION_BUILD "+${GIT_TIMESTAMP}")
+if (GIT_TIMESTAMP)
+  set(NVIM_VERSION_BUILD "+${GIT_TIMESTAMP}")
+endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -70,8 +70,6 @@ endfunction()
 function(get_git_head_revision _refspecvar _hashvar)
   get_git_dir(GIT_DIR)
   if(NOT GIT_DIR)
-    set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
-    set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
     return()
   endif()
 
@@ -96,6 +94,11 @@ function(get_git_head_revision _refspecvar _hashvar)
 endfunction()
 
 function(git_describe _var)
+  get_git_dir(GIT_DIR)
+  if(NOT GIT_DIR)
+    return()
+  endif()
+
   if(NOT GIT_FOUND)
     find_package(Git QUIET)
   endif()
@@ -103,26 +106,12 @@ function(git_describe _var)
     set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
     return()
   endif()
-  get_git_dir(GIT_DIR)
-  if(NOT GIT_DIR)
-    set(${_var} "GITDIR-NOTFOUND" PARENT_SCOPE)
-    return()
-  endif()
+
   get_git_head_revision(refspec hash)
   if(NOT hash)
     set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
     return()
   endif()
-
-  # TODO sanitize
-  #if((${ARGN}" MATCHES "&&") OR
-  #	(ARGN MATCHES "||") OR
-  #	(ARGN MATCHES "\\;"))
-  #	message("Please report the following error to the project!")
-  #	message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
-  #endif()
-
-  #message(STATUS "Arguments to execute_process: ${ARGN}")
 
   execute_process(COMMAND
     "${GIT_EXECUTABLE}"
@@ -145,18 +134,18 @@ function(git_describe _var)
 endfunction()
 
 function(git_timestamp _var)
+  get_git_dir(GIT_DIR)
+  if(NOT GIT_DIR)
+    return()
+  endif()
+
   if(NOT GIT_FOUND)
     find_package(Git QUIET)
   endif()
   if(NOT GIT_FOUND)
-    set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
     return()
   endif()
-  get_git_dir(GIT_DIR)
-  if(NOT GIT_DIR)
-    set(${_var} "GITDIR-NOTFOUND" PARENT_SCOPE)
-    return()
-  endif()
+
   get_git_head_revision(refspec hash)
   if(NOT hash)
     set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)

--- a/neovim.rb
+++ b/neovim.rb
@@ -10,6 +10,7 @@ class Neovim < Formula
   depends_on "autoconf" => :build
 
   def install
+    ENV["GIT_DIR"] = cached_download/".git" if build.head?
     ENV.deparallelize
     system "make", "CMAKE_EXTRA_FLAGS=\"-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}\"", "install"
   end


### PR DESCRIPTION
re https://github.com/neovim/neovim/issues/1292

Use @xu-cheng 's commit to try to get the commit for homebrew users. Failing that, it will simply leave out the "pre release" portion of the version (i.e., it will show `NVIM 0.0.0-alpha` instead of `NVIM 0.0.0-alpha+HEAD-HASH-NOTFOUND`).
