### PR TITLE
[RFC] Learn "--server location" command line option.

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -65,6 +65,7 @@
 #include "nvim/os/event.h"
 #include "nvim/os/signal.h"
 #include "nvim/msgpack_rpc/helpers.h"
+#include "nvim/msgpack_rpc/server.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/private/handle.h"
@@ -291,6 +292,7 @@ int main(int argc, char **argv)
   }
 
   event_init();
+  init_server(&params);
 
   if (abstract_ui) {
     t_colors = 256;
@@ -1069,6 +1071,9 @@ static void command_line_scan(mparm_T *parmp)
           } else if (STRNICMP(argv[0] + argv_idx, "startuptime", 11) == 0) {
             want_argument = TRUE;
             argv_idx += 11;
+          } else if (STRNICMP(argv[0] + argv_idx, "server", 6) == 0) {
+            want_argument = true;
+            argv_idx += 6;
           } else {
             if (argv[0][argv_idx])
               mainerr(ME_UNKNOWN_OPTION, (char_u *)argv[0]);
@@ -1500,6 +1505,20 @@ static void init_startuptime(mparm_T *paramp)
   }
 
   starttime = time(NULL);
+}
+
+/// Initializes the neovim server.
+static void init_server(mparm_T *paramp)
+{
+  char *server_address = NULL;
+  for (int i = 1; i < paramp->argc; i++) {
+    if (STRICMP(paramp->argv[i], "--servername") == 0 && i + 1 < paramp->argc) {
+      server_address = paramp->argv[i + 1];
+      break;
+    }
+  }
+
+  server_init(server_address);
 }
 
 /*

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdint.h>
+#include <inttypes.h>  // for size_t and PRId64
 
 #include <uv.h>
 
@@ -44,6 +44,7 @@ typedef struct {
 } Server;
 
 static PMap(cstr_t) *servers = NULL;
+static char *server_ref = NULL;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "msgpack_rpc/server.c.generated.h"
@@ -54,29 +55,78 @@ bool server_init(char *listen_address)
 {
   servers = pmap_new(cstr_t)();
 
-  if (!listen_address) {
-    listen_address = (char *) os_getenv(LISTEN_ADDRESS_ENV_VAR);
+  bool must_free = false;  // True if we allocated listen_address.
+  int error = 1;           // The result of server_start().
+
+  // Try to start the server, if given a valid address.
+  if (listen_address && *listen_address) {
+    // TODO(SplinterOfChaos): Ensure address is absolute.
+    if ((error = server_start(listen_address)) != 0) {
+      ELOG("Unable to start server at %s", listen_address);
+    }
   }
 
-  bool must_free = false;
-  if (!listen_address) {
+  // Either not given an address, or failed to start with it.
+  if (error) {
     must_free = true;
     listen_address = (char *)vim_tempname();
+    error = server_start(listen_address);
   }
 
-  os_setenv(LISTEN_ADDRESS_ENV_VAR, listen_address, 1);
+  if (error == 0) {
+    // Let subprocesses know where we've put the server.
+    os_setenv(LISTEN_ADDRESS_ENV_VAR, listen_address, 1);
 
-  int ret = server_start(listen_address);
+    // Add $NVIM_LISTEN_ADDRESS to the server list in ~/.nvim/servers.
+    char path[PATH_MAX];
+
+    size_t l = xstrlcpy(path, os_getenv("HOME"), PATH_MAX);
+    if (l + 2 >= PATH_MAX) {
+      goto end;  // Can't append servers directory.
+    }
+
+    l += add_pathsep((char_u *) path);
+    l += xstrlcpy(path + l, ".nvim/servers/", PATH_MAX - l);
+
+    if (l >= PATH_MAX) {
+      goto end;
+    }
+
+    os_mkdir(path, 0777);  // Ensure the directory exists.
+
+    snprintf(path + l, PATH_MAX - l, "%" PRIi64, os_get_pid());
+
+    FILE *f = fopen(path, "w");
+    if (!f) {
+      goto end;
+    }
+
+    fwrite(listen_address, strlen(listen_address), 1, f);
+    fclose(f);
+
+    // Save the address so we can delete this file upon leaving.
+    server_ref = xstrdup(path);
+  } else {
+    // Let the environment know there's no server.
+    os_setenv(LISTEN_ADDRESS_ENV_VAR, "", 1);
+  }
+
+end:
   if (must_free) {
     free(listen_address);
   }
 
-  return ret == 0;
+  return error == 0;
 }
 
 /// Teardown the server module
 void server_teardown(void)
 {
+  if (server_ref) {
+    remove(server_ref);
+    free(server_ref);
+  }
+
   if (!servers) {
     return;
   }

--- a/src/nvim/os/event.c
+++ b/src/nvim/os/event.c
@@ -63,7 +63,6 @@ void event_init(void)
   job_init();
   // finish mspgack-rpc initialization
   channel_init();
-  server_init();
 }
 
 void event_teardown(void)

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -356,10 +356,13 @@ char_u *concat_fnames(char_u *fname1, char_u *fname2, int sep)
  * Add a path separator to a file name, unless it already ends in a path
  * separator.
  */
-void add_pathsep(char_u *p)
+bool add_pathsep(char_u *p)
 {
-  if (*p != NUL && !after_pathsep(p, p + STRLEN(p)))
+  if (*p != NUL && !after_pathsep(p, p + STRLEN(p))) {
     STRCAT(p, PATHSEPSTR);
+    return true;
+  }
+  return false;
 }
 
 /*


### PR DESCRIPTION
Partially related to pull #1277--it would be convenient to have an alternative to `$NVIM_LISTEN_ADDRESS`, and possibly replace it. However, I don't yet know the precise strategy that should be used, so right now I just want to propose a way to override it.

As an example, I use nvim as a git editor, but when I `:!git commit`, I see "Failed to start server: address in use", so to work without error, I have to configure git like this:

``` bash
$ git config --global core.editor 'env NVIM_LISTEN_ADDRESS=/tmp/git-nvim nvim'
```

I'd rather:

``` bash
$ git config --global core.editor 'nvim --server /tmp/git-nvim'
```
