### PR TITLE
Remove Vi compatible mode note from intro message

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -892,11 +892,6 @@ void intro_message(int colon)
   // blanklines = screen height - # message lines
   blanklines = (int)Rows - ((sizeof(lines) / sizeof(char *)) - 1);
 
-  if (!p_cp) {
-    // add 4 for not showing "Vi compatible" message
-    blanklines += 4;
-  }
-
   // Don't overwrite a statusline.  Depends on 'cmdheight'.
   if (p_ls > 1) {
     blanklines -= Rows - topframe->fr_height;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -887,11 +887,6 @@ void intro_message(int colon)
     "",
     N_("type  :q<Enter>               to exit         "),
     N_("type  :help<Enter>  or  <F1>  for on-line help"),
-    NULL,
-    "",
-    N_("Running in Vi compatible mode"),
-    N_("type  :set nocp<Enter>        for Vim defaults"),
-    N_("type  :help cp-default<Enter> for info on this"),
   };
 
   // blanklines = screen height - # message lines


### PR DESCRIPTION
Removed the note about Vi compatible mode in the intro message. 

I thought about changing the message to saying Neovim doesn't support Vi compatible mode, but just seemed cleaner to completely remove the note since it's the intro.

Also, I suspect the people who will care about the option will already know Neovim doesn't support it. 

[ci skip]
