### PR TITLE
Improve YCM contrib.

### DIFF
--- a/contrib/YouCompleteMe/README.md
+++ b/contrib/YouCompleteMe/README.md
@@ -1,4 +1,8 @@
-# YouCompleteMe
+# YouCompleteMe Integration
+
+## What is this?
+
+This provides the necessary to configure vim's YCM plugin to provide C semantic support (completion, go-to-definition, etc) for the neovim project.
 
 ## Installation
 
@@ -9,7 +13,10 @@ Install [YouCompleteMe](https://github.com/Valloric/YouCompleteMe).
 ### Step 2
 
 ```bash
-cp ycm_extra_conf.py ../../src/nvim/.ycm_extra_conf.py
-echo src/nvim/.ycm_extra_conf.py >> ../../.git/info/exclude
-make -C ../.. cmake
+cp contrib/YouCompleteMe/ycm_extra_conf.py src/.ycm_extra_conf.py
+echo .ycm_extra_conf.py >> .git/info/exclude
+make
+
+(somewhere in you .vimrc files)
+autocmd FileType c nnoremap <buffer> <silent> <C-]> :YcmCompleter GoTo<cr>
 ```

--- a/contrib/YouCompleteMe/ycm_extra_conf.py
+++ b/contrib/YouCompleteMe/ycm_extra_conf.py
@@ -8,7 +8,7 @@ def DirectoryOfThisScript():
 
 
 def GetDatabase():
-    compilation_database_folder = DirectoryOfThisScript() + '/../../build'
+    compilation_database_folder = DirectoryOfThisScript() + '/../build'
     if os.path.exists(compilation_database_folder):
         return ycm_core.CompilationDatabase(compilation_database_folder)
     return None


### PR DESCRIPTION
YCM was signaling an erroneous warning `no newline at end of file` that was bothering me much.
I discussed it with @Valloric some time ago (https://github.com/Valloric/YouCompleteMe/issues/950), and the culprit turned out to be libclang, not YCM. @Valloric gave me the keys to understand the problem and fixing it. This solves the issue by passing additional flag -Wno_newline_eof to YCM.

Documentation is also slightly improved.
