### PR TITLE
[RFC] vim-patch:7.4.422

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3478,6 +3478,11 @@ win_line (
             int    i;
             int    saved_nextra = n_extra;
 
+            if (is_concealing && vcol_off > 0) {
+              // there are characters to conceal
+              tab_len += vcol_off;
+            }
+
             /* if n_extra > 0, it gives the number of chars to use for
              * a tab, else we need to calculate the width for a tab */
             len = (tab_len * mb_char2len(lcs_tab2));
@@ -3495,6 +3500,12 @@ win_line (
               n_extra += mb_char2len(lcs_tab2) - (saved_nextra > 0 ? 1: 0);
             }
             p_extra = p_extra_free;
+
+            // n_extra will be increased by FIX_FOX_BOGUSCOLS
+            // macro below, so need to adjust for that here
+            if (is_concealing && vcol_off > 0) {
+              n_extra -= vcol_off;
+            }
           }
           /* Tab alignment should be identical regardless of
            * 'conceallevel' value. So tab compensates of all

--- a/src/nvim/testdir/test_listlbr.in
+++ b/src/nvim/testdir/test_listlbr.in
@@ -46,6 +46,16 @@ STARTTEST
 :redraw!
 :let line=ScreenChar(winwidth(0))
 :call DoRecordScreen()
+:let line="_S_\t bla"
+:$put =line
+:$
+:norm! zt
+:let g:test ="Test 5: set linebreak with conceal and set list and tab displayed by different char (line may not be truncated)"
+:set cpo&vim list linebreak conceallevel=2 concealcursor=nv listchars=tab:ab
+:syn match ConcealVar contained /_/ conceal
+:syn match All /.*/ contains=ConcealVar
+:let line=ScreenChar(winwidth(0))
+:call DoRecordScreen()
 :%w! test.out
 :qa!
 ENDTEST

--- a/src/nvim/testdir/test_listlbr.ok
+++ b/src/nvim/testdir/test_listlbr.ok
@@ -25,3 +25,10 @@ Test 4: set linebreak with tab and 1 line as long as screen: should break!
 +aaaaaaaaaaaaaaaaaa 
 ~                   
 ~                   
+_S_	 bla
+
+Test 5: set linebreak with conceal and set list and tab displayed by different char (line may not be truncated)
+Sabbbbbb bla        
+~                   
+~                   
+~                   


### PR DESCRIPTION
> Problem:    When using conceal with linebreak some text is not displayed correctly. (Grüner Gimpel)
> Solution:   Check for conceal mode when using linebreak. (Christian Brabandt)

https://code.google.com/p/vim/source/detail?r=v7-4-422
