### PR TITLE
vim-patch:7.4.427

### DIFF
--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -277,10 +277,6 @@ void job_stop(Job *job)
 ///         is possible on some OS.
 int job_wait(Job *job, int ms) FUNC_ATTR_NONNULL_ALL
 {
-  // switch to cooked so `got_int` will be set if the user interrupts
-  int old_mode = cur_tmode;
-  settmode(TMODE_COOK);
-
   // Increase refcount to stop the job from being freed before we have a
   // chance to get the status.
   job->refcount++;
@@ -295,8 +291,6 @@ int job_wait(Job *job, int ms) FUNC_ATTR_NONNULL_ALL
     job_stop(job);
     event_poll(0);
   }
-
-  settmode(old_mode);
 
   if (!--job->refcount) {
     int status = (int) job->status;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -235,7 +235,7 @@ static int included_patches[] = {
   //430,
   //429 NA
   //428 NA
-  //427,
+  427,
   //426 NA
   //425,
   //424 NA


### PR DESCRIPTION
> Problem:    When an InsertCharPre autocommand executes system() typeahead may  be echoed and messes up the display. (Jacob Niehus)
> Solution:   Do not set cooked mode when invoked from ":silent".

https://code.google.com/p/vim/source/detail?r=v7-4-427

The heck? Who'd want to call `system()` every time they insert a char!? I just _had_ to look up the source of this problem: https://groups.google.com/forum/#!searchin/vim_dev/InsertCharPre$20autocommand$20system/vim_dev/1CEVoPZ71gY/7NAqToSYrYMJ

Run this and you might be a little surprised: `nvim -u NONE -i NONE -c 'autocmd InsertCharPre * call system("sleep 1")'`

We don't share the relevant code with vim anymore, but the fix translates well to nvim.
