### PR TITLE
[RFC] Remove setting default to "Be Vi compatible"

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1870,9 +1870,6 @@ void set_init_1(void)
 
   langmap_init();
 
-  /* Be Vi compatible by default */
-  p_cp = TRUE;
-
   /* Use POSIX compatibility when $VIM_POSIX is set. */
   if (os_getenv("VIM_POSIX") != NULL) {
     set_string_default("cpo", (char_u *)CPO_ALL);


### PR DESCRIPTION
Unless I'm missing something, this setting is now a no-op, so it can be removed.
