### PR TITLE
[RDY] Api: Improve Nul handling

### DIFF
--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -34,6 +34,11 @@ describe('buffer_* functions', function()
       curbuf('del_line', 0)
       eq('', curbuf('get_line', 0))
     end)
+
+    it('can handle NULs', function()
+      curbuf('set_line', 0, 'ab\0cd')
+      eq('ab\0cd', curbuf('get_line', 0))
+    end)
   end)
 
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -36,6 +36,10 @@ describe('vim_* functions', function()
       -- 19 * 2 (each japanese character occupies two cells)
       eq(44, nvim('strwidth', 'neovimのデザインかなりまともなのになってる。'))
     end)
+
+    it('cannot handle NULs', function()
+      eq(0, nvim('strwidth', '\0abc'))
+    end)
   end)
 
   describe('{get,set}_current_line', function()
@@ -51,6 +55,11 @@ describe('vim_* functions', function()
       nvim('set_var', 'lua', {1, 2, {['3'] = 1}})
       eq({1, 2, {['3'] = 1}}, nvim('get_var', 'lua'))
       eq({1, 2, {['3'] = 1}}, nvim('eval', 'g:lua'))
+    end)
+
+    it('truncates values with NULs in them', function()
+      nvim('set_var', 'xxx', 'ab\0cd')
+      eq('ab', nvim('get_var', 'xxx'))
     end)
   end)
 


### PR DESCRIPTION
Allows the API functions `buffer_get/set_line()` and friends to accept NULs and convert them to vim's internal representation (new lines). Also adds a few tests for when to allow NULs, and when not to. Does not include the necessary changes for the clipboard because #1335 will fix that by using `systemlist()` for receiving the clipboard, and sending `system()` a list for setting it.

Not sure if there's anywhere else we need to handle NULs, but there are certain places we cannot, for vimscript compatibility, which is why I didn't modify anything except `buffer_get/set`.

Particularly, will be needed to test #1182 (ping @bfredl).
