### PR TITLE
[RFC] Fix handling of `#pragma pack` in `cimport` lua helper

### DIFF
--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -66,7 +66,7 @@ local function cimport(...)
   end
 
   local body = nil
-  for i=1, 3 do
+  for i=1, 10 do
     local stream = Preprocess.preprocess_stream(unpack(paths))
     body = stream:read("*a")
     stream:close()


### PR DESCRIPTION
(followup from #1305)

OS X Yosemite triggered a bug in the code responsible for importing and preprocessing c headers for Luajit:

`cimport` did a trick to get rid of redefinitions: It formats the headers after preprocessing so that each definition gets its own line and compares if the lines are already in a set before giving them to the Luajit ffi.

This works well for c definitions, but after preprocessing there is one kind of preprocessor directive left: `#pragma pack(...)`. Each kind of pragma pack only gets sent to the Luajit ffi only once, and the last one wins for all following structs. This causes the memory layouts to be different between the c compiler and luajit.

Surprisingly, until OS X Yosemite this didn't cause any problems. But in OS X 10.10 there are some new structs with `#pragma pack(1)` in the system headers (In 10.9 there were only `#pragma pack(4)` and `#pragma pack()`):

```
#pragma pack(1)
typedef struct mach_voucher_attr_recipe_data { mach_voucher_attr_key_t key; mach_voucher_attr_recipe_command_t command; mach_voucher_name_t previous_voucher; mach_voucher_attr_content_size_t content_size; uint8_t content[]; } mach_voucher_attr_recipe_data_t;
 typedef mach_voucher_attr_recipe_data_t *mach_voucher_attr_recipe_t;
 typedef mach_msg_type_number_t mach_voucher_attr_recipe_size_t;
 typedef uint8_t *mach_voucher_attr_raw_recipe_t;
 typedef mach_voucher_attr_raw_recipe_t mach_voucher_attr_raw_recipe_array_t;
 typedef mach_msg_type_number_t mach_voucher_attr_raw_recipe_size_t;
 typedef mach_msg_type_number_t mach_voucher_attr_raw_recipe_array_size_t;
 #pragma pack()  // <--- gets removed by the `cimport` lua helper
```

So Luajit thinks that all structs get packed on byte boundaries after that. =>  :bomb: :boom: :boom:

Simple fix (that hopefully gets all cases): add a unique identifier after each pragma pack so that they all get inserted into the set. 
