### PR TITLE
[RDY] Fix python setup

### DIFF
--- a/runtime/plugin/python_setup.vim
+++ b/runtime/plugin/python_setup.vim
@@ -4,6 +4,14 @@ if exists("did_python_setup") || &cp
 endif
 let did_python_setup = 1
 
+" Prefix for naming things and displaying output.
+let s:plugin_name = 'Python setup'
+
+function! s:ShowError(message)
+  echohl ErrorMsg
+  echomsg s:plugin_name . ': ' . a:message . '.'
+  echohl None
+endfunction
 
 let s:get_version =
       \ ' -c "import sys; sys.stdout.write(str(sys.version_info[0]) + '.
@@ -24,6 +32,7 @@ elseif executable('python2')
   " In some distros, python3 is the default python
   let s:python_interpreter = 'python2'
 else
+  call s:ShowError('No python interpreter found')
   finish
 endif
 
@@ -32,6 +41,7 @@ endif
 let s:import_result = system(s:python_interpreter .
       \ ' -c "import neovim, sys; sys.stdout.write(\"ok\")"')
 if s:import_result != 'ok'
+  call s:ShowError('No neovim module found')
   finish
 endif
 
@@ -41,6 +51,6 @@ let s:pyhost_id = rpcstart(s:python_interpreter,
 " to block until all providers have been registered(or else some plugins loaded
 " by the user's vimrc would not get has('python') == 1
 if rpcrequest(s:pyhost_id, 'python_eval', '"o"+"k"') != 'ok' || !has('python')
-  " Something went wrong
+  call s:ShowError('Something went wrong')
   call rpcstop(s:pyhost_id)
 endif


### PR DESCRIPTION
This evening I wanted to try if my python plugins worked.
I pip installed neovim module and added the call to python_setup to my .vimrc, and started neovim.
But all my python plugins complained about python not being available.
python_setup.vim was executing before anything else, there were no errors... weird.

Until I realized it was picking the wrong version of python.
I mean, I have macports python (version 2.7.8) in addition to system-level python (2.7.6). 
Macports python is the one first in my path, and the one I used to pip install neovim module.
But, for some reason, neovim was just picking system level python.

In the end, it turns out that, in python_setup.vim:
- executable() calls do in fact respect $PATH, and detect macports version.
- system() calls do not respect $PATH, and execute system-level python.

And so, they don't find neovim module. But it doesn't say anything!

So, this PR fixes two points:
- Makes python setup report errors, if any, making clear which python version is being picked.
- Makes sure python version on user's path is used on system() calls.
