### PR TITLE
[RFC] Homebrew: Compile as release build.

### DIFF
--- a/neovim.rb
+++ b/neovim.rb
@@ -12,6 +12,6 @@ class Neovim < Formula
   def install
     ENV["GIT_DIR"] = cached_download/".git" if build.head?
     ENV.deparallelize
-    system "make", "CMAKE_EXTRA_FLAGS=\"-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}\"", "install"
+    system "make", "CMAKE_BUILD_TYPE=RelWithDebInfo", "CMAKE_EXTRA_FLAGS=\"-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}\"", "install"
   end
 end


### PR DESCRIPTION
To avoid problems such as #1362.
