### PR TITLE
[RDY] Assert libuv event loop is properly cleaned up

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19541,7 +19541,7 @@ char_u *do_string_sub(char_u *str, char_u *pat, char_u *sub, char_u *flags)
     event_push((Event) {                                             \
       .handler = on_job_event,                                       \
       .data = event_data                                             \
-    });                                                              \
+    }, true);                                                        \
   } while(0)
 
 static void on_job_stdout(RStream *rstream, void *data, bool eof)

--- a/src/nvim/os/event.c
+++ b/src/nvim/os/event.c
@@ -71,7 +71,15 @@ void event_teardown(void)
   channel_teardown();
   job_teardown();
   server_teardown();
+  signal_teardown();
   input_stop();
+  input_teardown();
+  do {
+    // This will loop forever if we leave any unclosed handles. Currently it is
+    // the most reliable way to use travis for verifying the no libuv-related
+    // bugs(which can be hard to track later) were introduced on a PR.
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  } while (uv_loop_close(uv_default_loop()));
 }
 
 // Wait for some event

--- a/src/nvim/os/event.c
+++ b/src/nvim/os/event.c
@@ -14,6 +14,7 @@
 #include "nvim/os/provider.h"
 #include "nvim/os/signal.h"
 #include "nvim/os/rstream.h"
+#include "nvim/os/wstream.h"
 #include "nvim/os/job.h"
 #include "nvim/vim.h"
 #include "nvim/memory.h"
@@ -43,6 +44,7 @@ void event_init(void)
   msgpack_rpc_helpers_init();
   // Initialize the event queues
   pending_events = kl_init(Event);
+  wstream_init();
   // Initialize input events
   input_init();
   // Timer to wake the event loop if a timeout argument is passed to

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -52,6 +52,15 @@ void input_init(void)
   rstream_set_file(read_stream, read_cmd_fd);
 }
 
+void input_teardown(void)
+{
+  if (embedded_mode) {
+    return;
+  }
+
+  rstream_free(read_stream);
+}
+
 // Listen for input
 void input_start(void)
 {

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -55,6 +55,20 @@ void signal_init(void)
 #endif
 }
 
+void signal_teardown(void)
+{
+  signal_stop();
+  uv_close((uv_handle_t *)&sint, NULL);
+  uv_close((uv_handle_t *)&spipe, NULL);
+  uv_close((uv_handle_t *)&shup, NULL);
+  uv_close((uv_handle_t *)&squit, NULL);
+  uv_close((uv_handle_t *)&sterm, NULL);
+  uv_close((uv_handle_t *)&swinch, NULL);
+#ifdef SIGPWR
+  uv_close((uv_handle_t *)&spwr, NULL);
+#endif
+}
+
 void signal_stop(void)
 {
   uv_signal_stop(&sint);

--- a/src/nvim/os/wstream.c
+++ b/src/nvim/os/wstream.c
@@ -5,6 +5,8 @@
 
 #include <uv.h>
 
+#include "nvim/lib/klist.h"
+
 #include "nvim/os/uv_helpers.h"
 #include "nvim/os/wstream.h"
 #include "nvim/os/wstream_defs.h"
@@ -36,12 +38,26 @@ struct wbuffer {
 typedef struct {
   WStream *wstream;
   WBuffer *buffer;
-} WriteData;
+  uv_write_t uv_req;
+} WRequest;
 
+#define WRequestFreer(x)
+KMEMPOOL_INIT(WRequestPool, WRequest, WRequestFreer)
+kmempool_t(WRequestPool) *wrequest_pool = NULL;
+#define WBufferFreer(x)
+KMEMPOOL_INIT(WBufferPool, WBuffer, WBufferFreer)
+kmempool_t(WBufferPool) *wbuffer_pool = NULL;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/wstream.c.generated.h"
 #endif
+
+/// Initialize pools for reusing commonly created objects
+void wstream_init(void)
+{
+  wrequest_pool = kmp_init(WRequestPool);
+  wbuffer_pool = kmp_init(WBufferPool);
+}
 
 /// Creates a new WStream instance. A WStream encapsulates all the boilerplate
 /// necessary for writing to a libuv stream.
@@ -148,20 +164,17 @@ bool wstream_write(WStream *wstream, WBuffer *buffer)
 
   wstream->curmem += buffer->size;
 
-  WriteData *data = xmalloc(sizeof(WriteData));
+  WRequest *data = kmp_alloc(WRequestPool, wrequest_pool);
   data->wstream = wstream;
   data->buffer = buffer;
-
-  uv_write_t *req = xmalloc(sizeof(uv_write_t));
-  req->data = data;
+  data->uv_req.data = data;
 
   uv_buf_t uvbuf;
   uvbuf.base = buffer->data;
   uvbuf.len = buffer->size;
 
-  if (uv_write(req, wstream->stream, &uvbuf, 1, write_cb)) {
-    free(data);
-    free(req);
+  if (uv_write(&data->uv_req, wstream->stream, &uvbuf, 1, write_cb)) {
+    kmp_free(WRequestPool, wrequest_pool, data);
     goto err;
   }
 
@@ -190,7 +203,7 @@ WBuffer *wstream_new_buffer(char *data,
                             size_t refcount,
                             wbuffer_data_finalizer cb)
 {
-  WBuffer *rv = xmalloc(sizeof(WBuffer));
+  WBuffer *rv = kmp_alloc(WBufferPool, wbuffer_pool);
   rv->size = size;
   rv->refcount = refcount;
   rv->cb = cb;
@@ -201,9 +214,8 @@ WBuffer *wstream_new_buffer(char *data,
 
 static void write_cb(uv_write_t *req, int status)
 {
-  WriteData *data = req->data;
+  WRequest *data = req->data;
 
-  free(req);
   data->wstream->curmem -= data->buffer->size;
 
   release_wbuffer(data->buffer);
@@ -221,7 +233,7 @@ static void write_cb(uv_write_t *req, int status)
     free(data->wstream);
   }
 
-  free(data);
+  kmp_free(WRequestPool, wrequest_pool, data);
 }
 
 static void release_wbuffer(WBuffer *buffer)
@@ -231,7 +243,7 @@ static void release_wbuffer(WBuffer *buffer)
       buffer->cb(buffer->data);
     }
 
-    free(buffer);
+    kmp_free(WBufferPool, wbuffer_pool, buffer);
   }
 }
 

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -522,8 +522,6 @@ void mch_exit(int r)
 {
   exiting = TRUE;
 
-  event_teardown();
-
   {
     settmode(TMODE_COOK);
     mch_restore_title(3);       /* restore xterm title and icon name */
@@ -559,7 +557,7 @@ void mch_exit(int r)
   mac_conv_cleanup();
 #endif
 
-
+  event_teardown();
 
 #ifdef EXITFREE
   free_all_mem();


### PR DESCRIPTION
Some assertions at event_teardown that should simplify finding bugs due to unclosed handles in libuv, as suggested by @aktau 
