### PR TITLE
[RDY] re-enable iconv

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -43,7 +43,14 @@ check_function_exists(fsync HAVE_FSYNC)
 check_function_exists(getpwent HAVE_GETPWENT)
 check_function_exists(getpwnam HAVE_GETPWNAM)
 check_function_exists(getpwuid HAVE_GETPWUID)
+
+check_include_files(iconv.h HAVE_ICONV_H)
+check_library_exists(iconv iconv "" HAVE_ICONV_LIB)
+if(HAVE_ICONV_LIB)
+  set(CMAKE_REQUIRED_LIBRARIES iconv)
+endif()
 check_function_exists(iconv HAVE_ICONV)
+
 check_function_exists(lstat HAVE_LSTAT)
 if(NOT HAVE_LSTAT)
   # os_unix.c uses lstat.c

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -157,6 +157,10 @@ else()
   endif()
 endif()
 
+if(HAVE_ICONV_LIB)
+  list(APPEND NVIM_LINK_LIBRARIES iconv)
+endif()
+
 # Put these last on the link line, since multiple things may depend on them.
 list(APPEND NVIM_LINK_LIBRARIES
     ${LIBUV_LIBRARIES}

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -11,6 +11,8 @@
 #include "nvim/pos.h"
 // for the number window-local and buffer-local options
 #include "nvim/option_defs.h"
+// for optional iconv support
+#include "nvim/iconv.h"
 // for jump list and tag stack sizes in a buffer and mark types
 #include "nvim/mark_defs.h"
 // for u_header_T
@@ -280,15 +282,6 @@ typedef struct argentry {
 #define GARGCOUNT       (global_alist.al_ga.ga_len)
 #define ARGCOUNT        (ALIST(curwin)->al_ga.ga_len)
 #define WARGCOUNT(wp)   (ALIST(wp)->al_ga.ga_len)
-
-#ifdef USE_ICONV
-# ifdef HAVE_ICONV_H
-#  include <iconv.h>
-# else
-#    include <errno.h>
-typedef void *iconv_t;
-# endif
-#endif
 
 /*
  * Used for the typeahead buffer: typebuf.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -42,6 +42,7 @@
 #include "nvim/fold.h"
 #include "nvim/getchar.h"
 #include "nvim/hashtab.h"
+#include "nvim/iconv.h"
 #include "nvim/if_cscope.h"
 #include "nvim/indent_c.h"
 #include "nvim/indent.h"

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -30,6 +30,7 @@
 #include "nvim/fold.h"
 #include "nvim/getchar.h"
 #include "nvim/hashtab.h"
+#include "nvim/iconv.h"
 #include "nvim/mbyte.h"
 #include "nvim/memfile.h"
 #include "nvim/memline.h"

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -23,6 +23,7 @@
 #endif
 
 #include "nvim/ex_eval.h"
+#include "nvim/iconv.h"
 #include "nvim/mbyte.h"
 #include "nvim/menu.h"
 #include "nvim/syntax_defs.h"

--- a/src/nvim/iconv.h
+++ b/src/nvim/iconv.h
@@ -1,0 +1,54 @@
+#ifndef NVIM_ICONV_H
+#define NVIM_ICONV_H
+
+// iconv can be linked at compile-time as well as loaded at runtime. In the
+// latter case, some function pointers need to be initialized after loading
+// the library (see `iconv_enabled()` in mbyte.c). These function pointers
+// are stored in globals.h. Since globals.h includes iconv.h to get the
+// definition of USE_ICONV, we can't include it from iconv.h. One way to
+// solve this conundrum would be perhaps to let cmake decide the value of
+// USE_ICONV, or to put the USE_ICONV definition in config.h.in directly. As
+// it stands, globals.h needs to be included alongside iconv.h.
+
+#ifdef HAVE_CONFIG_H
+# include "auto/config.h"
+#endif
+
+// Use iconv() when it's available, either by linking to the library at
+// compile time or by loading it at runtime.
+#if (defined(HAVE_ICONV_H) && defined(HAVE_ICONV)) || defined(DYNAMIC_ICONV)
+# define USE_ICONV
+#endif
+
+// If we don't have the actual iconv header files present but USE_ICONV was
+// defined, we provide a type shim (pull in errno.h and define iconv_t).
+// This enables us to still load and use iconv dynamically at runtime.
+#ifdef USE_ICONV
+#  ifdef HAVE_ICONV_H
+#    include <iconv.h>
+#  else
+#    include <errno.h>
+typedef void *iconv_t;
+#  endif
+#endif
+
+// define some missing constants if necessary
+# ifdef USE_ICONV
+#  ifndef EILSEQ
+#   define EILSEQ 123
+#  endif
+#  ifdef DYNAMIC_ICONV
+// on win32 iconv.dll is dynamically loaded
+#   define ICONV_ERRNO (*iconv_errno())
+#   define ICONV_E2BIG  7
+#   define ICONV_EINVAL 22
+#   define ICONV_EILSEQ 42
+#  else
+#   define ICONV_ERRNO errno
+#   define ICONV_E2BIG  E2BIG
+#   define ICONV_EINVAL EINVAL
+#   define ICONV_EILSEQ EILSEQ
+#  endif
+# endif
+
+#endif  // NVIM_ICONV_H

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -28,6 +28,7 @@
 #include "nvim/fold.h"
 #include "nvim/getchar.h"
 #include "nvim/hashtab.h"
+#include "nvim/iconv.h"
 #include "nvim/if_cscope.h"
 #ifdef HAVE_LOCALE_H
 # include <locale.h>
@@ -275,7 +276,7 @@ int main(int argc, char **argv)
       // initial screen size of 80x20
       full_screen = true;
       set_shellsize(80, 20, false);
-    } else { 
+    } else {
       // set terminal name and get terminal capabilities (will set full_screen)
       // Do some initialization of the screen
       termcapinit(params.term);
@@ -546,7 +547,7 @@ int main(int argc, char **argv)
  * Also used to handle ":visual" command after ":global": execute Normal mode
  * commands, return when entering Ex mode.  "noexmode" is TRUE then.
  */
-void 
+void
 main_loop (
     int cmdwin,                 /* TRUE when working in the command-line window */
     int noexmode               /* TRUE when return on entering Ex mode */
@@ -842,7 +843,7 @@ void getout(int exitval)
 /*
  * Get a (optional) count for a Vim argument.
  */
-static int 
+static int
 get_number_arg (
     char_u *p,             /* pointer to argument */
     int *idx,           /* index in argument, is incremented */
@@ -2062,7 +2063,7 @@ static void main_start_gui(void)
  * Get an environment variable, and execute it as Ex commands.
  * Returns FAIL if the environment variable was not executed, OK otherwise.
  */
-int 
+int
 process_env (
     char_u *env,
     int is_viminit             /* when TRUE, called for VIMINIT */
@@ -2113,7 +2114,7 @@ static int file_owned(char *fname)
 /*
  * Give an error message main_errors["n"] and exit.
  */
-static void 
+static void
 mainerr (
     int n,                  /* one of the ME_ defines */
     char_u *str       /* extra argument or NULL */

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -88,6 +88,7 @@
 #ifdef HAVE_LOCALE_H
 # include <locale.h>
 #endif
+#include "nvim/iconv.h"
 #include "nvim/mbyte.h"
 #include "nvim/charset.h"
 #include "nvim/cursor.h"

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -7,6 +7,7 @@
 
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
+#include "nvim/iconv.h"
 #include "nvim/version.h"
 #include "nvim/charset.h"
 #include "nvim/memline.h"

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -381,38 +381,6 @@ enum {
 #include "nvim/buffer_defs.h"         /* buffer and windows */
 #include "nvim/ex_cmds_defs.h"        /* Ex command defines */
 
-# ifdef USE_ICONV
-#  ifndef EILSEQ
-#   define EILSEQ 123
-#  endif
-#  ifdef DYNAMIC_ICONV
-/* On Win32 iconv.dll is dynamically loaded. */
-#   define ICONV_ERRNO (*iconv_errno())
-#   define ICONV_E2BIG  7
-#   define ICONV_EINVAL 22
-#   define ICONV_EILSEQ 42
-#  else
-#   define ICONV_ERRNO errno
-#   define ICONV_E2BIG  E2BIG
-#   define ICONV_EINVAL EINVAL
-#   define ICONV_EILSEQ EILSEQ
-#  endif
-# endif
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 # define SET_NO_HLSEARCH(flag) no_hlsearch = (flag); set_vim_var_nr( \
     VV_HLSEARCH, !no_hlsearch)
 


### PR DESCRIPTION
This seems to have been disabled in the transition from vim to neovim,
re-enable it. If the disabling of iconv was intentional, why? (in which case we should delete the code that still references it).

Since this also involves the config system and I just hacked my way around it, I'd definitely like some input from @jszakmeister. How would you handle it?
