### PR TITLE
[RFC] Fix outdated doc: Connecting to nvim through python REPL.

### DIFF
--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -113,7 +113,9 @@ string 'hello world!' on the current nvim instance:
 A better way is to use the python REPL with the `neovim` package, where API
 functions can be called interactively:
 >
-    >>> import neovim; nvim = neovim.connect('[address]')
+    >>> from neovim import socket_session, Nvim
+    >>> session = socket_session('[address]')
+    >>> nvim = Nvim.from_session(session)
     >>> nvim.command('echo "hello world!"')
 <
 ==============================================================================


### PR DESCRIPTION
After neovim/python-client@b8b48bbe8fe9ee41ad73c9bd5a45e808504399e2, doc was no longer relevant. 

This updates doc from instructions in python-client README.md.

Now, a couple of extra comments on this:
- Not sure if ruby instructions above those of python are completely up-to-date, too (I would say yes, but not sure).
- I find the old way (`neovim.connect(<address>)`) much more pythonic than the new one. Couldn't we reintroduce a `connect` function, taking session params, that does the same we are doing manually now?
