### PR TITLE
GenerateHelptags: Fix checking of DESTDIR

### DIFF
--- a/cmake/GenerateHelptags.cmake
+++ b/cmake/GenerateHelptags.cmake
@@ -1,12 +1,6 @@
-if(ENV{DESTDIR})
-  file(TO_CMAKE_PATH
-    "$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc"
-    HELPTAGS_WORKING_DIRECTORY)
-else()
-  file(TO_CMAKE_PATH
-    "${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc"
-    HELPTAGS_WORKING_DIRECTORY)
-endif()
+file(TO_CMAKE_PATH
+  "${PREFIX}/share/nvim/runtime/doc"
+  HELPTAGS_WORKING_DIRECTORY)
 
 message(STATUS "Generating helptags in ${HELPTAGS_WORKING_DIRECTORY}.")
 

--- a/cmake/InstallHelpers.cmake
+++ b/cmake/InstallHelpers.cmake
@@ -22,7 +22,7 @@ function(create_install_dir_with_perms)
 
   install(CODE
     "
-    if(ENV{DESTDIR})
+    if(DEFINED ENV{DESTDIR})
       set(PREFIX \$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX})
     else()
       set(PREFIX \${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
This should fix #1368
