### PR TITLE
Revert "Homebrew: Compile as release build."

### DIFF
--- a/neovim.rb
+++ b/neovim.rb
@@ -12,6 +12,6 @@ class Neovim < Formula
   def install
     ENV["GIT_DIR"] = cached_download/".git" if build.head?
     ENV.deparallelize
-    system "make", "CMAKE_BUILD_TYPE=RelWithDebInfo", "CMAKE_EXTRA_FLAGS=\"-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}\"", "install"
+    system "make", "CMAKE_EXTRA_FLAGS=\"-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}\"", "install"
   end
 end


### PR DESCRIPTION
Reverts neovim/neovim#1366, since asserts are valuable while the project is still in heavy development.

We can use `-Og` for gcc builds to get a reasonably optimized debug builds:

https://github.com/neovim/neovim/pull/1366#issuecomment-61325586

For clang we will just need to deal with it.
