### PR TITLE
[RDY] Add core dump reporting to travis

### DIFF
--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -7,10 +7,7 @@ asan_check() {
 }
 
 check_logs() {
-	# For some strange reason, now we need to give ubuntu some time to flush it's
-	# FS cache in order to see error logs, even though all commands are executing
-	# synchronously
-	sleep 1
+	check_core_dumps
 	# Iterate through each log to remove an useless warning
 	for log in $(find "$1" -type f -name "$2"); do
 		sed -i "$log" \
@@ -27,6 +24,15 @@ check_logs() {
 		echo "Runtime errors detected"
 		exit 1
 	fi
+}
+
+check_core_dumps() {
+	sleep 2
+	local c
+	for c in $(find ./ -name '*core*' -print); do
+	 	gdb -q -n -batch -ex bt build/bin/nvim $c
+		exit 1
+	done
 }
 
 set_environment() {

--- a/.ci/gcc-32.sh
+++ b/.ci/gcc-32.sh
@@ -23,4 +23,6 @@ CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
 
 $MAKE_CMD CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}" unittest
 $MAKE_CMD test
+check_core_dumps
 $MAKE_CMD oldtest
+check_core_dumps

--- a/.ci/gcc.sh
+++ b/.ci/gcc.sh
@@ -11,6 +11,7 @@ export VALGRIND_LOG="$tmpdir/valgrind-%p.log"
 CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DUSE_GCOV=ON"
 
 $MAKE_CMD CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}" unittest
+build/bin/nvim --version
 if ! $MAKE_CMD test; then
 	valgrind_check "$tmpdir"
 	exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_install:
   # Need xvfb for running some tests with xclip
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - sudo apt-get install xclip
+  - sudo apt-get install xclip gdb
 script:
   # This will pass the environment variables down to a bash process which runs
   # as $USER, while retaining the environment variables defined and belonging
   # to secondary groups given above in usermod.
-  - sudo -E su ${USER} -c "sh -e \"${CI_SCRIPTS}/${CI_TARGET}.sh\""
+  - sudo -E su ${USER} -c "ulimit -c 102400; sh -e \"${CI_SCRIPTS}/${CI_TARGET}.sh\""

--- a/.valgrind.supp
+++ b/.valgrind.supp
@@ -30,3 +30,10 @@
    fun:vim_strsave
    fun:ex_function
 }
+{
+  uv_spawn_with_optimizations
+  Memcheck:Leak
+  fun:malloc
+  fun:uv_spawn
+  fun:job_start
+}

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -600,9 +600,14 @@ static void close_channel(Channel *channel)
     if (handle) {
       uv_close(handle, close_cb);
     } else {
-      mch_exit(0);
+      event_push((Event) { .handler = on_stdio_close }, false);
     }
   }
+}
+
+static void on_stdio_close(Event e)
+{
+  mch_exit(0);
 }
 
 static void free_channel(Channel *channel)

--- a/src/nvim/os/event.c
+++ b/src/nvim/os/event.c
@@ -39,7 +39,7 @@ typedef struct {
 // immediate_events: Events that should be processed after exiting libuv event
 //                   loop(to avoid recursion), but before returning from
 //                   `event_poll`
-static klist_t(Event) *deferred_events, *immediate_events;
+static klist_t(Event) *deferred_events = NULL, *immediate_events = NULL;
 
 void event_init(void)
 {
@@ -68,6 +68,11 @@ void event_init(void)
 
 void event_teardown(void)
 {
+  if (!deferred_events) {
+    // Not initialized(possibly a --version invocation)
+    return;
+  }
+
   channel_teardown();
   job_teardown();
   server_teardown();


### PR DESCRIPTION
Currently there's no way to detect if a nvim process segfaults or aborts during functional tests if all tests passes. This improves the `check_logs` function to also check for core files and make the build fail if any were dumped
