### PR TITLE
[RFC] Fix clang analysis warnings. (1)

### DIFF
--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/cursor_shape.h"
@@ -76,6 +77,7 @@ char_u *parse_shape_opt(int what)
        * For the 'a' mode, we loop to handle all the modes.
        */
       all_idx = -1;
+      assert(modep < colonp);
       while (modep < colonp || all_idx >= 0) {
         if (all_idx < 0) {
           /* Find the mode. */

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7455,7 +7455,9 @@ static int ins_bs(int c, int mode, int *inserted_space_p)
         if (State & REPLACE_FLAG)
           replace_do_bs(-1);
         else {
-          if (enc_utf8 && p_deco)
+          const bool l_enc_utf8 = enc_utf8;
+          const int l_p_deco = p_deco;
+          if (l_enc_utf8 && l_p_deco)
             (void)utfc_ptr2char(get_cursor_pos_ptr(), cpc);
           (void)del_char(FALSE);
           /*
@@ -7463,7 +7465,7 @@ static int ins_bs(int c, int mode, int *inserted_space_p)
            * move the cursor back.  Don't back up before the base
            * character.
            */
-          if (enc_utf8 && p_deco && cpc[0] != NUL)
+          if (l_enc_utf8 && l_p_deco && cpc[0] != NUL)
             inc_cursor();
           if (revins_chars) {
             revins_chars--;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3231,6 +3231,7 @@ static buf_T *ins_compl_next_buf(buf_T *buf, int flag)
   if (flag == 'w') {            /* just windows */
     if (buf == curbuf)          /* first call for this flag/expansion */
       wp = curwin;
+    assert(wp);
     while ((wp = (wp->w_next != NULL ? wp->w_next : firstwin)) != curwin
            && wp->w_buffer->b_scanned)
       ;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3613,6 +3613,7 @@ static int ins_compl_get_exp(pos_T *ini)
        * If 'infercase' is set, don't use 'smartcase' here
        */
       save_p_scs = p_scs;
+      assert(ins_buf);
       if (ins_buf->b_p_inf)
         p_scs = FALSE;
 
@@ -3761,8 +3762,10 @@ static int ins_compl_get_exp(pos_T *ini)
       compl_started = TRUE;
     } else {
       /* Mark a buffer scanned when it has been scanned completely */
-      if (type == 0 || type == CTRL_X_PATH_PATTERNS)
+      if (type == 0 || type == CTRL_X_PATH_PATTERNS) {
+        assert(ins_buf);
         ins_buf->b_scanned = TRUE;
+      }
 
       compl_started = FALSE;
     }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -6336,10 +6336,11 @@ static void replace_do_bs(int limit_col)
   char_u      *p;
   int i;
   int vcol;
+  const int l_State = State;
 
   cc = replace_pop();
   if (cc > 0) {
-    if (State & VREPLACE_FLAG) {
+    if (l_State & VREPLACE_FLAG) {
       /* Get the number of screen cells used by the character we are
        * going to delete. */
       getvcol(curwin, &curwin->w_cursor, NULL, &start_vcol, NULL);
@@ -6347,17 +6348,17 @@ static void replace_do_bs(int limit_col)
     }
     if (has_mbyte) {
       (void)del_char_after_col(limit_col);
-      if (State & VREPLACE_FLAG)
+      if (l_State & VREPLACE_FLAG)
         orig_len = (int)STRLEN(get_cursor_pos_ptr());
       replace_push(cc);
     } else {
       pchar_cursor(cc);
-      if (State & VREPLACE_FLAG)
+      if (l_State & VREPLACE_FLAG)
         orig_len = (int)STRLEN(get_cursor_pos_ptr()) - 1;
     }
     replace_pop_ins();
 
-    if (State & VREPLACE_FLAG) {
+    if (l_State & VREPLACE_FLAG) {
       /* Get the number of screen cells used by the inserted characters */
       p = get_cursor_pos_ptr();
       ins_len = (int)STRLEN(p) - orig_len;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -6290,6 +6290,7 @@ static void mb_replace_pop_ins(int cc)
         break;
       } else {
         buf[0] = c;
+        assert(n > 1);
         for (i = 1; i < n; ++i)
           buf[i] = replace_pop();
         if (utf_iscomposing(utf_ptr2char(buf)))

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -11,6 +11,7 @@
  *	  op_change, op_yank, do_put, do_join
  */
 
+#include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
@@ -3436,7 +3437,7 @@ int do_join(long count,
                         && has_format_option(FO_REMOVE_COMS);
   int prev_was_comment;
 
-
+  assert(count > 1);
   if (save_undo && u_save((linenr_T)(curwin->w_cursor.lnum - 1),
           (linenr_T)(curwin->w_cursor.lnum + count)) == FAIL)
     return FAIL;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5028,6 +5028,8 @@ void cursor_pos_info(void)
   pos_T min_pos, max_pos;
   oparg_T oparg;
   struct block_def bd;
+  const int l_VIsual_active = VIsual_active;
+  const int l_VIsual_mode = VIsual_mode;
 
   /*
    * Compute the length of the file in characters.
@@ -5040,7 +5042,7 @@ void cursor_pos_info(void)
     else
       eol_size = 1;
 
-    if (VIsual_active) {
+    if (l_VIsual_active) {
       if (lt(VIsual, curwin->w_cursor)) {
         min_pos = VIsual;
         max_pos = curwin->w_cursor;
@@ -5051,7 +5053,7 @@ void cursor_pos_info(void)
       if (*p_sel == 'e' && max_pos.col > 0)
         --max_pos.col;
 
-      if (VIsual_mode == Ctrl_V) {
+      if (l_VIsual_mode == Ctrl_V) {
         char_u * saved_sbr = p_sbr;
 
         /* Make 'sbr' empty for a moment to get the correct size. */
@@ -5084,12 +5086,12 @@ void cursor_pos_info(void)
       }
 
       /* Do extra processing for VIsual mode. */
-      if (VIsual_active
+      if (l_VIsual_active
           && lnum >= min_pos.lnum && lnum <= max_pos.lnum) {
         char_u      *s = NULL;
         long len = 0L;
 
-        switch (VIsual_mode) {
+        switch (l_VIsual_mode) {
         case Ctrl_V:
           virtual_op = virtual_active();
           block_prep(&oparg, &bd, lnum, 0);
@@ -5142,8 +5144,8 @@ void cursor_pos_info(void)
     if (!curbuf->b_p_eol && curbuf->b_p_bin)
       byte_count -= eol_size;
 
-    if (VIsual_active) {
-      if (VIsual_mode == Ctrl_V && curwin->w_curswant < MAXCOL) {
+    if (l_VIsual_active) {
+      if (l_VIsual_mode == Ctrl_V && curwin->w_curswant < MAXCOL) {
         getvcols(curwin, &min_pos, &max_pos, &min_pos.col,
             &max_pos.col);
         vim_snprintf((char *)buf1, sizeof(buf1), _("%" PRId64 " Cols; "),

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1199,10 +1199,7 @@ char_u *skip_regexp(char_u *startp, int dirc, int magic, char_u **newp)
           *newp = vim_strsave(startp);
           p = *newp + (p - startp);
         }
-        if (*newp != NULL)
-          STRMOVE(p, p + 1);
-        else
-          ++p;
+        STRMOVE(p, p + 1);
       } else
         ++p;            /* skip next character */
       if (*p == 'v')

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1297,16 +1297,18 @@ static regprog_T *bt_regcomp(char_u *expr, int re_flags)
         r->regstart = (*mb_ptr2char)(OPERAND(scan));
       else
         r->regstart = *OPERAND(scan);
-    } else if ((OP(scan) == BOW
-                || OP(scan) == EOW
-                || OP(scan) == NOTHING
-                || OP(scan) == MOPEN + 0 || OP(scan) == NOPEN
-                || OP(scan) == MCLOSE + 0 || OP(scan) == NCLOSE)
-               && OP(regnext(scan)) == EXACTLY) {
-      if (has_mbyte)
-        r->regstart = (*mb_ptr2char)(OPERAND(regnext(scan)));
-      else
-        r->regstart = *OPERAND(regnext(scan));
+    } else if (OP(scan) == BOW
+               || OP(scan) == EOW
+               || OP(scan) == NOTHING
+               || OP(scan) == MOPEN  + 0 || OP(scan) == NOPEN
+               || OP(scan) == MCLOSE + 0 || OP(scan) == NCLOSE) {
+      char_u *regnext_scan = regnext(scan);
+      if (OP(regnext_scan) == EXACTLY) {
+        if (has_mbyte)
+          r->regstart = (*mb_ptr2char)(OPERAND(regnext_scan));
+        else
+          r->regstart = *OPERAND(regnext_scan);
+      }
     }
 
     /*

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -43,6 +43,7 @@
 /* #undef REGEXP_DEBUG */
 /* #define REGEXP_DEBUG */
 
+#include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
@@ -5625,6 +5626,8 @@ static int match_with_backref(linenr_T start_lnum, colnr_T start_col, linenr_T e
 
     /* Get the line to compare with. */
     p = reg_getline(clnum);
+    assert(p);
+
     if (clnum == end_lnum)
       len = end_col - ccol;
     else

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7709,7 +7709,6 @@ static void draw_tabline(void)
 
     attr = attr_nosel;
     tabcount = 0;
-    scol = 0;
 
     FOR_ALL_TABS(tp) {
       if (col >= Columns - 4) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3867,7 +3867,7 @@ win_line (
       /* Get rid of the boguscols now, we want to draw until the right
        * edge for 'cursorcolumn'. */
       col -= boguscols;
-      boguscols = 0;
+      // boguscols = 0;  // Disabled because value never read after this
 
       if (draw_color_col)
         draw_color_col = advance_color_col(VCOL_HLC, &color_cols);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -244,6 +244,9 @@ int redraw_asap(int type)
   u8char_T    *screenlineUC = NULL;     /* copy from ScreenLinesUC[] */
   u8char_T    *screenlineC[MAX_MCO];    /* copy from ScreenLinesC[][] */
   schar_T     *screenline2 = NULL;      /* copy from ScreenLines2[] */
+  const bool l_enc_utf8 = enc_utf8;
+  const int l_enc_dbcs = enc_dbcs;
+  const long l_p_mco = p_mco;
 
   redraw_later(type);
   if (msg_scrolled || (State != NORMAL && State != NORMAL_BUSY))
@@ -254,14 +257,14 @@ int redraw_asap(int type)
   screenline = xmalloc((size_t)(rows * Columns * sizeof(schar_T)));
   screenattr = xmalloc((size_t)(rows * Columns * sizeof(sattr_T)));
 
-  if (enc_utf8) {
+  if (l_enc_utf8) {
     screenlineUC = xmalloc((size_t)(rows * Columns * sizeof(u8char_T)));
 
-    for (i = 0; i < p_mco; ++i) {
+    for (i = 0; i < l_p_mco; ++i) {
       screenlineC[i] = xmalloc((size_t)(rows * Columns * sizeof(u8char_T)));
     }
   }
-  if (enc_dbcs == DBCS_JPNU) {
+  if (l_enc_dbcs == DBCS_JPNU) {
     screenline2 = xmalloc((size_t)(rows * Columns * sizeof(schar_T)));
   }
 
@@ -273,16 +276,16 @@ int redraw_asap(int type)
     memmove(screenattr + r * Columns,
         ScreenAttrs + LineOffset[cmdline_row + r],
         (size_t)Columns * sizeof(sattr_T));
-    if (enc_utf8) {
+    if (l_enc_utf8) {
       memmove(screenlineUC + r * Columns,
           ScreenLinesUC + LineOffset[cmdline_row + r],
           (size_t)Columns * sizeof(u8char_T));
-      for (i = 0; i < p_mco; ++i)
+      for (i = 0; i < l_p_mco; ++i)
         memmove(screenlineC[i] + r * Columns,
             ScreenLinesC[r] + LineOffset[cmdline_row + r],
             (size_t)Columns * sizeof(u8char_T));
     }
-    if (enc_dbcs == DBCS_JPNU)
+    if (l_enc_dbcs == DBCS_JPNU)
       memmove(screenline2 + r * Columns,
           ScreenLines2 + LineOffset[cmdline_row + r],
           (size_t)Columns * sizeof(schar_T));
@@ -302,16 +305,16 @@ int redraw_asap(int type)
       memmove(ScreenAttrs + off,
           screenattr + r * Columns,
           (size_t)Columns * sizeof(sattr_T));
-      if (enc_utf8) {
+      if (l_enc_utf8) {
         memmove(ScreenLinesUC + off,
             screenlineUC + r * Columns,
             (size_t)Columns * sizeof(u8char_T));
-        for (i = 0; i < p_mco; ++i)
+        for (i = 0; i < l_p_mco; ++i)
           memmove(ScreenLinesC[i] + off,
               screenlineC[i] + r * Columns,
               (size_t)Columns * sizeof(u8char_T));
       }
-      if (enc_dbcs == DBCS_JPNU)
+      if (l_enc_dbcs == DBCS_JPNU)
         memmove(ScreenLines2 + off,
             screenline2 + r * Columns,
             (size_t)Columns * sizeof(schar_T));
@@ -322,12 +325,12 @@ int redraw_asap(int type)
 
   free(screenline);
   free(screenattr);
-  if (enc_utf8) {
+  if (l_enc_utf8) {
     free(screenlineUC);
-    for (i = 0; i < p_mco; ++i)
+    for (i = 0; i < l_p_mco; ++i)
       free(screenlineC[i]);
   }
-  if (enc_dbcs == DBCS_JPNU)
+  if (l_enc_dbcs == DBCS_JPNU)
     free(screenline2);
 
   /* Show the intro message when appropriate. */

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7534,7 +7534,6 @@ int showmode(void)
             msg_puts_attr(edit_submode_extra, sub_attr);
           }
         }
-        length = 0;
       } else {
         if (State & VREPLACE_FLAG)
           MSG_PUTS_ATTR(_(" VREPLACE"), attr);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3477,7 +3477,6 @@ win_line (
             n_extra = tab_len;
           } else {
             char_u *p;
-            int    len = n_extra;
             int    i;
             int    saved_nextra = n_extra;
 
@@ -3488,7 +3487,7 @@ win_line (
 
             /* if n_extra > 0, it gives the number of chars to use for
              * a tab, else we need to calculate the width for a tab */
-            len = (tab_len * mb_char2len(lcs_tab2));
+            int len = (tab_len * mb_char2len(lcs_tab2));
             if (n_extra > 0) {
               len += n_extra - tab_len;
             }


### PR DESCRIPTION
This is the first of a series of PR's aimed at taking the number of clang analysis warnings down to zero.

IMPORTANT: Commits contain links to online clang report entries, to ease review. I'm not sure if clang report generated links are deterministic. It that's not the case, then links would become stale on next report. So, if this can happen, please review this before merging other things into master (which would trigger a new clang report). UPDATE: Links are broken and won't be fixed. See below.

In principle, one warning is resolved in one commit (to match granularity of clang report and ease identification). But, when possible, warnings sharing a common cause/fix and belonging to the same function are grouped.

Following classification is used to describe warnings, after they have been resolved. 

| Code | Type | Meaning |
| --- | --- | --- |
| CW | Cautionary warning | Signaled circumstance is not necessarily an issue, but for some reason it's considered better to avoid it. |
| FP | False positive | Error condition cannot really occur, because of things we know, but the compiler doesn't. These are usually solved just asserting what the compiler needs to know. |
| MI | Multithreading issue | Error condition can be a real issue, but only under multithreading conditions. These are usually caused by use of global state and are usually solved by making local copies instead. |
| HI | Harmless issue | Error condition is in fact an issue, but a harmless one. These are usually solved removing/editing whatever is causing the warning. |
| RI | Real issue | Error condition can in fact occur under normal circumstances and has some undesirable effects. |

`Code` is added as last part of commit messages to allow for a quick glimpse on diagnosed warning types without having to read full commit message.

This PR gets rid of **23** warnings in:
- curshor_shape.c
- screen.c
- ops.c
- regexp.c
- edit.c
