### PR TITLE
[RFC] diff: Send the text of the comparison through stdin.

### DIFF
--- a/src/nvim/dynamic_buffer.c
+++ b/src/nvim/dynamic_buffer.c
@@ -1,0 +1,59 @@
+
+#include <stddef.h>
+
+#include "nvim/dynamic_buffer.h"
+#include "nvim/func_attr.h"
+#include "nvim/lib/kvec.h"
+#include "nvim/vim.h"
+
+///  - ensures at least `desired` bytes in buffer
+///
+/// TODO(aktau): fold with kvec/garray
+void dynamic_buffer_ensure(DynamicBuffer *buf, size_t desired)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (buf->cap >= desired) {
+    return;
+  }
+
+  buf->cap = desired;
+  kv_roundup32(buf->cap);
+  buf->data = xrealloc(buf->data, buf->cap);
+}
+
+void dynamic_buffer_clear(DynamicBuffer *buf)
+{
+  free(buf->data);
+  buf->data = NULL;
+  buf->len = buf->cap = 0;
+}
+
+/// Makes room for at least `n` more bytes.
+void dynamic_buffer_grow(DynamicBuffer *buf, size_t n)
+  FUNC_ATTR_NONNULL_ALL
+{
+  dynamic_buffer_ensure(buf, buf->len + n);
+}
+
+/// Appends one character, `c`, to `buf`.
+void dynamic_buffer_append(DynamicBuffer *buf, char c)
+  FUNC_ATTR_NONNULL_ALL
+{
+  dynamic_buffer_grow(buf, 1);
+  buf->data[buf->len++] = c;
+}
+
+/// Concatenates a string, `s`, of length `len`, to `buf`. Use -1 for the
+/// length if unknown.
+void dynamic_buffer_concat(DynamicBuffer *buf, char_u *restrict s,
+                           ptrdiff_t len)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (len == -1) {
+    len = STRLEN(s);
+  }
+
+  dynamic_buffer_grow(buf, len);
+  memcpy(buf->data + buf->len, s, len);
+  buf->len += len;
+}

--- a/src/nvim/dynamic_buffer.h
+++ b/src/nvim/dynamic_buffer.h
@@ -1,0 +1,18 @@
+
+#ifndef NVIM_DYNAMIC_BUFFER_H
+#define NVIM_DYNAMIC_BUFFER_H
+
+#include "nvim/types.h"
+
+#define DYNAMIC_BUFFER_INIT {NULL, 0, 0}
+
+typedef struct {
+  char *data;
+  size_t cap, len;
+} DynamicBuffer;
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "dynamic_buffer.h.generated.h"
+#endif
+
+#endif


### PR DESCRIPTION
Slight performance increase of `:diff[update|split]` in using `os_system()` to send the contents of the buffer. Here's my benchmark:

``` vim
function! s:diff()
  edit nvim/diff.c 
  vert diffsplit nvim/eval.c " Test for two completely different files.
  new | only
  edit nvim/diff.c
  vert diffsplit nvim/diff.master " Two similar files.
endfunction

command! Do call s:diff()
```

And the results zooming in on the `diffsplit` lines:

```
branch  total (s)   self (s)  type
mastr   0.460142   0.210851    completely different
job     0.431205   0.216067
sys-out 0.429822   0.203984
this    0.408696   0.199957

mastr   0.279197   0.114843   similar
job     0.213775   0.062578
sys-out 0.222114   0.073695
this    0.215443   0.068872
```

| name | branch | link |
| --- | --- | --- |
| mastr | master | N/A |
| this | this branch | N/A |
| job | Using a job instead of os_system | https://github.com/splinterofchaos/neovim/tree/diff-job-in |
| sys-out | using os_system instead of redir | https://github.com/splinterofchaos/neovim/tree/diff-sys-out |

so not the most exciting results in the world. Note: I found I got the biggest performance increase when I had CPU-intensive processes running in the background. I attempted various things such as running the `diff` program as a job, using a read callback, and using `os_system()` to get the output instead of using redirection, but I actually found these made it slower. (In case anyone's curious to test it, here's my branch for running `diff` in a job: https://github.com/splinterofchaos/neovim/tree/diff-job-in)
