### PR TITLE
[RFC] Fix build warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ list(APPEND CMAKE_PREFIX_PATH ${DEPS_INSTALL_DIR})
 # Version tokens
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC NVIM_VERSION_COMMIT)
-if (NOT NVIM_VERSION_COMMIT)
+if(NOT NVIM_VERSION_COMMIT)
   set(NVIM_VERSION_COMMIT "?")
 endif()
 set(NVIM_VERSION_MAJOR 0)
@@ -25,7 +25,7 @@ set(NVIM_VERSION_PRERELEASE "-alpha")
 # TODO(justinmk): UTC time would be nice here #1071
 git_timestamp(GIT_TIMESTAMP)
 # TODO(justinmk): do not set this for "release" builds #1071
-if (GIT_TIMESTAMP)
+if(GIT_TIMESTAMP)
   set(NVIM_VERSION_BUILD "+${GIT_TIMESTAMP}")
 endif()
 
@@ -45,7 +45,8 @@ endif()
 # gcc 4.0 and better turn on _FORTIFY_SOURCE=2 automatically.  This currently
 # does not work with Neovim due to some uses of dynamically-sized structures.
 # See https://github.com/neovim/neovim/issues/223 for details.
-if(CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS "4")
+if(CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS "4"
+    AND CMAKE_BUILD_TYPE MATCHES "^Rel")
   # -U in add_definitions doesn't end up in the correct spot, so we add it to
   # the flags variable instead.
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ if(BUSTED_PRG)
       -P ${CMAKE_MODULE_PATH}/RunTests.cmake
     DEPENDS nvim-test unittest-headers)
 
-  add_custom_target(test
+  add_custom_target(functionaltest
     COMMAND ${CMAKE_COMMAND}
       -DBUSTED_PRG=${BUSTED_PRG}
       -DWORKING_DIR=${CMAKE_CURRENT_SOURCE_DIR}
@@ -258,5 +258,5 @@ if(BUSTED_PRG)
       -DBUILD_DIR=${CMAKE_BINARY_DIR}
       -DTEST_TYPE=functional
       -P ${CMAKE_MODULE_PATH}/RunTests.cmake
-    DEPENDS nvim) 
+    DEPENDS nvim)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,10 @@ endif
 oldtest: | nvim
 	+$(SINGLE_MAKE) -C src/nvim/testdir $(MAKEOVERRIDES)
 
-test: | nvim
-	+$(BUILD_CMD) -C build test
+functionaltest: | nvim
+	+$(BUILD_CMD) -C build functionaltest
+
+test: functionaltest
 
 unittest: | nvim
 	+$(BUILD_CMD) -C build unittest
@@ -93,4 +95,4 @@ distclean: clean
 install: | nvim
 	+$(BUILD_CMD) -C build install
 
-.PHONY: test unittest clean distclean nvim cmake deps install
+.PHONY: test functionaltest unittest clean distclean nvim cmake deps install

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -88,7 +88,8 @@ get_directory_property(gen_includes INCLUDE_DIRECTORIES)
 foreach(gen_include ${gen_includes})
   set(gen_cflags "${gen_cflags} -I${gen_include}")
 endforeach()
-set(gen_cflags "${gen_cflags} ${CMAKE_C_FLAGS}")
+string(TOUPPER "${CMAKE_BUILD_TYPE}" _build_type)
+set(gen_cflags "${gen_cflags} ${CMAKE_C_FLAGS_${_build_type}} ${CMAKE_C_FLAGS}")
 
 foreach(sfile ${NEOVIM_SOURCES}
               "${PROJECT_SOURCE_DIR}/src/nvim/regexp_nfa.c")


### PR DESCRIPTION
Fixes two build warnings in separate commits:

```
# warning _FORTIFY_SOURCE requires compiling with optimization (-O)

The target name "test" is reserved or not valid for certain CMake
features, such as generator expressions, and may result in undefined
behavior.
```
