### PR TITLE
[RDY] Better handling for invalid msgpack-rpc

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -473,6 +473,10 @@ static bool channel_write(Channel *channel, WBuffer *buffer)
 {
   bool success;
 
+  if (channel->closed) {
+    return false;
+  }
+
   if (channel->is_job) {
     success = job_write(channel->data.job, buffer);
   } else {

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -418,6 +418,11 @@ static void handle_request(Channel *channel, msgpack_object *request)
                                      &error,
                                      NIL,
                                      &out_buffer));
+    char buf[256];
+    snprintf(buf, sizeof(buf),
+             "Channel %" PRIu64 " sent an invalid message, closing.",
+             channel->id);
+    call_set_error(channel, buf);
     return;
   }
 

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -377,14 +377,17 @@ void msgpack_rpc_validate(uint64_t *response_id,
   // Validate the basic structure of the msgpack-rpc payload
   if (req->type != MSGPACK_OBJECT_ARRAY) {
     api_set_error(err, Validation, _("Request is not an array"));
+    return;
   }
 
   if (req->via.array.size != 4) {
     api_set_error(err, Validation, _("Request array size should be 4"));
+    return;
   }
 
   if (req->via.array.ptr[1].type != MSGPACK_OBJECT_POSITIVE_INTEGER) {
     api_set_error(err, Validation, _("Id must be a positive integer"));
+    return;
   }
 
   // Set the response id, which is the same as the request
@@ -392,18 +395,22 @@ void msgpack_rpc_validate(uint64_t *response_id,
 
   if (req->via.array.ptr[0].type != MSGPACK_OBJECT_POSITIVE_INTEGER) {
     api_set_error(err, Validation, _("Message type must be an integer"));
+    return;
   }
 
   if (req->via.array.ptr[0].via.u64 != 0) {
     api_set_error(err, Validation, _("Message type must be 0"));
+    return;
   }
 
   if (req->via.array.ptr[2].type != MSGPACK_OBJECT_BIN
     && req->via.array.ptr[2].type != MSGPACK_OBJECT_STR) {
     api_set_error(err, Validation, _("Method must be a string"));
+    return;
   }
 
   if (req->via.array.ptr[3].type != MSGPACK_OBJECT_ARRAY) {
     api_set_error(err, Validation, _("Paremeters must be an array"));
+    return;
   }
 }

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -410,7 +410,7 @@ void msgpack_rpc_validate(uint64_t *response_id,
   }
 
   if (req->via.array.ptr[3].type != MSGPACK_OBJECT_ARRAY) {
-    api_set_error(err, Validation, _("Paremeters must be an array"));
+    api_set_error(err, Validation, _("Parameters must be an array"));
     return;
   }
 }


### PR DESCRIPTION
Yesterday I [accidentaly](https://gist.github.com/equalsraf/62cb08bcdd654d7f12e2) crashed Neovim by having the python-client push invalid data (invalid msgpack-rpc but possibly valid msgpack) into the channel. Basically msgpack_rpc_validate treated the object as an array when there was none and then it segfaulted.

So far I only added a commit to return when an error occurs, this fixes the segfault, but what happens now is that Neovim hangs calling the python process i.e.
1. Neovim calls a function in the host
2. Python host sends some (invalid data) into the channel
3. Neovim sends an error message to the host
4. (Neovim is now blocked)

I was considering closing the channel after serializing an error message i.e.

``` diff
diff --git a/src/nvim/msgpack_rpc/channel.c b/src/nvim/msgpack_rpc/channel.c
index c2d16d1..96c24da 100644
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -418,6 +418,7 @@ static void handle_request(Channel *channel, msgpack_object *request)
                                      &error,
                                      NIL,
                                      &out_buffer));
+    close_channel(channel);
     return;
   }
```

Or perhaps `call_set_error()` would be better. But I'm tripping over myself because I get 

```
#0  0x00000000005e72b0 in wstream_write (wstream=0x0, buffer=0x8be400) at ../src/nvim/os/wstream.c:159
#1  0x00000000005e3da5 in job_write (job=0x8be570, buffer=0x8be400) at ../src/nvim/os/job.c:365
#2  0x00000000005f2801 in channel_write (channel=0x8be200, buffer=0x8be400) at ../src/nvim/msgpack_rpc/channel.c:480
#3  0x00000000005f2798 in on_request_event (event=...) at ../src/nvim/msgpack_rpc/channel.c:465
#4  0x00000000005e826b in process_events_from (queue=0x899a70) at ../src/nvim/os/event.c:159
#5  0x00000000005e81c2 in event_poll (ms=-1) at ../src/nvim/os/event.c:135
#6  0x00000000005f1cd7 in channel_send_call (id=1, method_name=0x8bdbe0 "python_eval", args=..., err=0x7fffffffbb90)
    at ../src/nvim/msgpack_rpc/channel.c:226
#7  0x000000000046d4ab in f_rpcrequest (argvars=0x7fffffffc0e0, rettv=0x7fffffffc770) at ../src/nvim/eval.c:12508
#8  0x0000000000462803 in call_func (
    funcname=0x8be2f3 "rpcrequest(s:pyhost_id, 'python_eval', '\"o\"+\"k\"') != 'ok' || !has('python')", len=10, rettv=0x7fffffffc770, 
    argcount=3, argvars=0x7fffffffc0e0, firstline=1, lastline=1, doesrange=0x7fffffffc29c, evaluate=1, selfdict=0x0)
    at ../src/nvim/eval.c:6909
```

Basically Neovim trying to write into the channel after I called close and failing hard.
