### PR TITLE
[RDY] Only force-close stdout/stderr when the job exits

### DIFF
--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -270,10 +270,10 @@ void job_stop(Job *job)
   }
 
   job->stopped_time = os_hrtime();
-  // Close the standard streams of the job
+  // Close the job's stdin. If the job doesn't close it's own stdout/stderr,
+  // they will be closed when the job exits(possibly due to being terminated
+  // after a timeout)
   close_job_in(job);
-  close_job_out(job);
-  close_job_err(job);
 
   if (!stop_requests++) {
     // When there's at least one stop request pending, start a timer that

--- a/test/functional/job/job_spec.lua
+++ b/test/functional/job/job_spec.lua
@@ -15,6 +15,10 @@ describe('jobs', function()
     return "au! JobActivity xxx call rpcnotify("..channel..", "..expr..")"
   end
 
+  local notify_job = function()
+    return "au! JobActivity xxx call rpcnotify("..channel..", 'j', v:job_data)"
+  end
+
   it('returns 0 when it fails to start', function()
     local status, rv = pcall(eval, "jobstart('', '')")
     eq(false, status)
@@ -55,5 +59,15 @@ describe('jobs', function()
 
   it('will not cause a memory leak if we leave a job running', function()
     nvim('command', "call jobstart('xxx', 'cat', ['-'])")
+  end)
+
+  it('will only emit the "exit" event after "stdout" and "stderr"', function()
+    nvim('command', notify_job())
+    nvim('command', "let j = jobstart('xxx', 'cat', ['-'])")
+    local jobid = nvim('eval', 'j')
+    nvim('eval', 'jobsend(j, "abc\ndef")')
+    nvim('eval', 'jobstop(j)')
+    eq({'notification', 'j', {{jobid, 'stdout', 'abc\ndef'}}}, next_message())
+    eq({'notification', 'j', {{jobid, 'exit'}}}, next_message())
   end)
 end)


### PR DESCRIPTION
stdout/stderr should only be closed after the job truly exits, or else we can lose data sent by it.

This should fix #1418
