### PR TITLE
[RDY] build: default to using -O2 for release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ if(APPLE)
   endif()
 endif()
 
+# Default to -O2 on release builds.
+string(REPLACE "-O3" "-O2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+
 # gcc 4.0 and better turn on _FORTIFY_SOURCE=2 automatically.  This currently
 # does not work with Neovim due to some uses of dynamically-sized structures.
 # See https://github.com/neovim/neovim/issues/223 for details.


### PR DESCRIPTION
The -O3 optimization level can often lead to dangerous (and sometimes
incorrect) optimizations being performed.  So let's use a level that's
more stable.
