### PR TITLE
[RFC] Fix memory leak in job_start().

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -119,7 +119,7 @@ void channel_teardown(void)
 /// Creates an API channel by starting a job and connecting to its
 /// stdin/stdout. stderr is forwarded to the editor error stream.
 ///
-/// @param argv The argument vector for the process
+/// @param argv The argument vector for the process. [consumed]
 /// @return The channel id
 uint64_t channel_from_job(char **argv)
 {

--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -139,6 +139,7 @@ Job *job_start(char **argv,
 
   if (i == MAX_RUNNING_JOBS) {
     // No free slots
+    shell_free_argv(argv);
     *status = 0;
     return NULL;
   }

--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -105,7 +105,8 @@ void job_teardown(void)
 /// Tries to start a new job.
 ///
 /// @param argv Argument vector for the process. The first item is the
-///        executable to run.
+///             executable to run.
+///             [consumed]
 /// @param data Caller data that will be associated with the job
 /// @param writable If true the job stdin will be available for writing with
 ///                 job_write, otherwise it will be redirected to /dev/null

--- a/src/nvim/os/wstream.c
+++ b/src/nvim/os/wstream.c
@@ -230,7 +230,11 @@ static void write_cb(uv_write_t *req, int status)
 
   if (data->wstream->freed && data->wstream->pending_reqs == 0) {
     // Last pending write, free the wstream;
-    free(data->wstream);
+    if (data->wstream->free_handle) {
+      uv_close((uv_handle_t *)data->wstream->stream, close_cb);
+    } else {
+      free(data->wstream);
+    }
   }
 
   kmp_free(WRequestPool, wrequest_pool, data);


### PR DESCRIPTION
Fix for memory leak in job_start().

If a new job cannot be started because no slots a free, we return early
without freeing the argv argument.
