### PR TITLE
[RFC] rename misc2.c to be more descriptive

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -47,7 +47,7 @@ set(CONV_SOURCES
   map.c
   memfile.c
   memory.c
-  core.c
+  fundamental.c
   profile.c
   tempfile.c
   )

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -47,7 +47,7 @@ set(CONV_SOURCES
   map.c
   memfile.c
   memory.c
-  misc2.c
+  core.c
   profile.c
   tempfile.c
   )

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -14,7 +14,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/mark.h"
 #include "nvim/fileio.h"

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -14,7 +14,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/mark.h"
 #include "nvim/fileio.h"

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -21,7 +21,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/eval.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/term.h"
 #include "nvim/getchar.h"
 #include "nvim/os/input.h"

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -21,7 +21,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/eval.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/term.h"
 #include "nvim/getchar.h"
 #include "nvim/os/input.h"

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -10,7 +10,7 @@
 #include "nvim/window.h"
 #include "nvim/screen.h"
 #include "nvim/move.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 
 
 /// Gets the current buffer in a window

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -10,7 +10,7 @@
 #include "nvim/window.h"
 #include "nvim/screen.h"
 #include "nvim/move.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 
 
 /// Gets the current buffer in a window

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -56,7 +56,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/option.h"

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -56,7 +56,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/option.h"

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -19,7 +19,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/os_unix.h"

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -19,7 +19,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/os_unix.h"

--- a/src/nvim/core.c
+++ b/src/nvim/core.c
@@ -7,7 +7,7 @@
  */
 
 /*
- * misc2.c: Various functions.
+ * core.c: Various fundamental functions.
  */
 #include <errno.h>
 #include <inttypes.h>
@@ -15,10 +15,9 @@
 
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
-#include "nvim/misc2.h"
-#include "nvim/file_search.h"
 #include "nvim/buffer.h"
 #include "nvim/charset.h"
+#include "nvim/core.h"
 #include "nvim/cursor.h"
 #include "nvim/diff.h"
 #include "nvim/edit.h"
@@ -27,6 +26,7 @@
 #include "nvim/ex_docmd.h"
 #include "nvim/ex_getln.h"
 #include "nvim/fileio.h"
+#include "nvim/file_search.h"
 #include "nvim/fold.h"
 #include "nvim/getchar.h"
 #include "nvim/mark.h"
@@ -57,7 +57,7 @@
 
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "misc2.c.generated.h"
+# include "core.c.generated.h"
 #endif
 /*
  * Return TRUE if in the current mode we need to use virtual.

--- a/src/nvim/core.h
+++ b/src/nvim/core.h
@@ -1,12 +1,12 @@
-#ifndef NVIM_MISC2_H
-#define NVIM_MISC2_H
+#ifndef NVIM_CORE_H
+#define NVIM_CORE_H
 
 #include "nvim/os/shell.h"
 
 #define READ_STRING(x, y) (char_u *)read_string((x), (size_t)(y))
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "misc2.h.generated.h"
+# include "core.h.generated.h"
 #endif
 
-#endif  // NVIM_MISC2_H
+#endif  // NVIM_CORE_H

--- a/src/nvim/cursor.h
+++ b/src/nvim/cursor.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #include "nvim/vim.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "cursor.h.generated.h"

--- a/src/nvim/cursor.h
+++ b/src/nvim/cursor.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #include "nvim/vim.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "cursor.h.generated.h"

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -2,7 +2,7 @@
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/cursor_shape.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/ex_getln.h"
 #include "nvim/charset.h"
 #include "nvim/strings.h"

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -2,7 +2,7 @@
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/cursor_shape.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/ex_getln.h"
 #include "nvim/charset.h"
 #include "nvim/strings.h"

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -22,7 +22,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -22,7 +22,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -15,7 +15,7 @@
 #include "nvim/getchar.h"
 #include "nvim/mbyte.h"
 #include "nvim/message.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/memory.h"
 #include "nvim/garray.h"
 #include "nvim/normal.h"

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -15,7 +15,7 @@
 #include "nvim/getchar.h"
 #include "nvim/mbyte.h"
 #include "nvim/message.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/memory.h"
 #include "nvim/garray.h"
 #include "nvim/normal.h"

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -38,7 +38,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/keymap.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -38,7 +38,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/keymap.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -53,7 +53,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/keymap.h"
 #include "nvim/file_search.h"
 #include "nvim/garray.h"

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -53,7 +53,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/keymap.h"
 #include "nvim/file_search.h"
 #include "nvim/garray.h"

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -43,7 +43,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -43,7 +43,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -36,7 +36,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -36,7 +36,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -42,7 +42,7 @@
 #include "nvim/menu.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/keymap.h"
 #include "nvim/file_search.h"
 #include "nvim/garray.h"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -42,7 +42,7 @@
 #include "nvim/menu.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/keymap.h"
 #include "nvim/file_search.h"
 #include "nvim/garray.h"

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -21,7 +21,7 @@
 #include "nvim/ex_cmds2.h"
 #include "nvim/ex_docmd.h"
 #include "nvim/message.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/memory.h"
 #include "nvim/regexp.h"
 #include "nvim/strings.h"

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -21,7 +21,7 @@
 #include "nvim/ex_cmds2.h"
 #include "nvim/ex_docmd.h"
 #include "nvim/message.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/memory.h"
 #include "nvim/regexp.h"
 #include "nvim/strings.h"

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -42,7 +42,7 @@
 #include "nvim/menu.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/memory.h"
 #include "nvim/cursor_shape.h"
 #include "nvim/keymap.h"

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -42,7 +42,7 @@
 #include "nvim/menu.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/memory.h"
 #include "nvim/cursor_shape.h"
 #include "nvim/keymap.h"

--- a/src/nvim/farsi.c
+++ b/src/nvim/farsi.c
@@ -14,7 +14,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"
 #include "nvim/vim.h"

--- a/src/nvim/farsi.c
+++ b/src/nvim/farsi.c
@@ -14,7 +14,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"
 #include "nvim/vim.h"

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -57,7 +57,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
 #include "nvim/strings.h"

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -57,7 +57,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
 #include "nvim/strings.h"

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -37,7 +37,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -37,7 +37,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -29,7 +29,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/option.h"

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -29,7 +29,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/option.h"

--- a/src/nvim/fundamental.c
+++ b/src/nvim/fundamental.c
@@ -7,7 +7,7 @@
  */
 
 /*
- * core.c: Various fundamental functions.
+ * fundamental.c: Various fundamental functions.
  */
 #include <errno.h>
 #include <inttypes.h>
@@ -17,7 +17,7 @@
 #include "nvim/ascii.h"
 #include "nvim/buffer.h"
 #include "nvim/charset.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/cursor.h"
 #include "nvim/diff.h"
 #include "nvim/edit.h"
@@ -57,7 +57,7 @@
 
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "core.c.generated.h"
+# include "fundamental.c.generated.h"
 #endif
 /*
  * Return TRUE if in the current mode we need to use virtual.

--- a/src/nvim/fundamental.h
+++ b/src/nvim/fundamental.h
@@ -1,12 +1,12 @@
-#ifndef NVIM_CORE_H
-#define NVIM_CORE_H
+#ifndef NVIM_FUNDAMENTAL_H
+#define NVIM_FUNDAMENTAL_H
 
 #include "nvim/os/shell.h"
 
 #define READ_STRING(x, y) (char_u *)read_string((x), (size_t)(y))
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "core.h.generated.h"
+# include "fundamental.h.generated.h"
 #endif
 
-#endif  // NVIM_CORE_H
+#endif  // NVIM_FUNDAMENTAL_H

--- a/src/nvim/garray.c
+++ b/src/nvim/garray.c
@@ -8,7 +8,7 @@
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/log.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/memory.h"
 #include "nvim/path.h"
 #include "nvim/garray.h"

--- a/src/nvim/garray.c
+++ b/src/nvim/garray.c
@@ -8,7 +8,7 @@
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/log.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/memory.h"
 #include "nvim/path.h"
 #include "nvim/garray.h"

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -36,7 +36,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -36,7 +36,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -32,7 +32,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/option.h"
 #include "nvim/path.h"

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -32,7 +32,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/option.h"
 #include "nvim/path.h"

--- a/src/nvim/hashtab.c
+++ b/src/nvim/hashtab.c
@@ -28,7 +28,7 @@
 #include "nvim/hashtab.h"
 #include "nvim/message.h"
 #include "nvim/memory.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 
 // Magic value for algorithm that walks through the array.
 #define PERTURB_SHIFT 5

--- a/src/nvim/hashtab.c
+++ b/src/nvim/hashtab.c
@@ -28,7 +28,7 @@
 #include "nvim/hashtab.h"
 #include "nvim/message.h"
 #include "nvim/memory.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 
 // Magic value for algorithm that walks through the array.
 #define PERTURB_SHIFT 5

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -21,7 +21,7 @@
 #include "nvim/fileio.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/memory.h"
 #include "nvim/os/time.h"
 #include "nvim/path.h"

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -21,7 +21,7 @@
 #include "nvim/fileio.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/memory.h"
 #include "nvim/os/time.h"
 #include "nvim/path.h"

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -9,7 +9,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/move.h"
 #include "nvim/option.h"
 #include "nvim/regexp.h"

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -9,7 +9,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/move.h"
 #include "nvim/option.h"
 #include "nvim/regexp.h"

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -10,7 +10,7 @@
 #include "nvim/indent_c.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/option.h"
 #include "nvim/search.h"
 #include "nvim/strings.h"

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -10,7 +10,7 @@
 #include "nvim/indent_c.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/option.h"
 #include "nvim/search.h"
 #include "nvim/strings.h"

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -38,7 +38,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/log.h"
 #include "nvim/memory.h"

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -38,7 +38,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/log.h"
 #include "nvim/memory.h"

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -30,7 +30,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/normal.h"
 #include "nvim/option.h"
 #include "nvim/path.h"

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -30,7 +30,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/normal.h"
 #include "nvim/option.h"
 #include "nvim/path.h"

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -97,7 +97,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/memory.h"
 #include "nvim/option.h"
 #include "nvim/screen.h"

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -97,7 +97,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/memory.h"
 #include "nvim/option.h"
 #include "nvim/screen.h"

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -57,7 +57,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/memory.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -57,7 +57,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/memory.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -61,7 +61,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/option.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -61,7 +61,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/option.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 
 #include "nvim/vim.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/eval.h"
 #include "nvim/memfile.h"
 #include "nvim/memory.h"

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 
 #include "nvim/vim.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/eval.h"
 #include "nvim/memfile.h"
 #include "nvim/memory.h"

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -25,7 +25,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/strings.h"

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -25,7 +25,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/strings.h"

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -33,7 +33,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/ops.h"
@@ -581,7 +581,7 @@ int emsg2(char_u *s, char_u *a1)
   return emsg3(s, a1, NULL);
 }
 
-/* emsg3() and emsgn() are in misc2.c to avoid warnings for the prototypes. */
+/* emsg3() and emsgn() are in core.c to avoid warnings for the prototypes. */
 
 void emsg_invreg(int name)
 {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -33,7 +33,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/ops.h"

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -39,7 +39,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/option.h"

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -39,7 +39,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/option.h"

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -30,7 +30,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/popupmnu.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -30,7 +30,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/popupmnu.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -43,7 +43,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/keymap.h"
 #include "nvim/move.h"
 #include "nvim/ops.h"

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -43,7 +43,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/keymap.h"
 #include "nvim/move.h"
 #include "nvim/ops.h"

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -36,7 +36,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"
 #include "nvim/option.h"

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -36,7 +36,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"
 #include "nvim/option.h"

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -61,7 +61,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/cursor_shape.h"

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -61,7 +61,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/cursor_shape.h"

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -4,7 +4,7 @@
 
 #include "nvim/ascii.h"
 #include "nvim/os/os.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/strings.h"
 
 #ifdef HAVE__NSGETENVIRON

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -4,7 +4,7 @@
 
 #include "nvim/ascii.h"
 #include "nvim/os/os.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/strings.h"
 
 #ifdef HAVE__NSGETENVIRON

--- a/src/nvim/os/event.c
+++ b/src/nvim/os/event.c
@@ -18,7 +18,7 @@
 #include "nvim/os/job.h"
 #include "nvim/vim.h"
 #include "nvim/memory.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 
 #include "nvim/lib/klist.h"
 

--- a/src/nvim/os/event.c
+++ b/src/nvim/os/event.c
@@ -18,7 +18,7 @@
 #include "nvim/os/job.h"
 #include "nvim/vim.h"
 #include "nvim/memory.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 
 #include "nvim/lib/klist.h"
 

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -8,7 +8,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/path.h"
 #include "nvim/strings.h"
 

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -8,7 +8,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/path.h"
 #include "nvim/strings.h"
 

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -18,7 +18,7 @@
 #include "nvim/message.h"
 #include "nvim/memory.h"
 #include "nvim/term.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/screen.h"
 #include "nvim/memline.h"
 #include "nvim/option_defs.h"

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -18,7 +18,7 @@
 #include "nvim/message.h"
 #include "nvim/memory.h"
 #include "nvim/term.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/screen.h"
 #include "nvim/memline.h"
 #include "nvim/option_defs.h"

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -13,7 +13,7 @@
 #include "nvim/term.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/os/signal.h"
 #include "nvim/os/event.h"
 

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -13,7 +13,7 @@
 #include "nvim/term.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/os/signal.h"
 #include "nvim/os/event.h"
 

--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -6,7 +6,7 @@
 #include "nvim/os/os.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/strings.h"
 #ifdef HAVE_PWD_H
 # include <pwd.h>

--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -6,7 +6,7 @@
 #include "nvim/os/os.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/strings.h"
 #ifdef HAVE_PWD_H
 # include <pwd.h>

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -37,7 +37,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/path.h"
 #include "nvim/screen.h"

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -37,7 +37,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/path.h"
 #include "nvim/screen.h"

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -20,7 +20,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/option.h"
 #include "nvim/os/os.h"
 #include "nvim/os/shell.h"

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -20,7 +20,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/option.h"
 #include "nvim/os/os.h"
 #include "nvim/os/shell.h"

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -11,7 +11,7 @@
 #include "nvim/charset.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/memline.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/move.h"
 #include "nvim/option.h"
 #include "nvim/screen.h"

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -11,7 +11,7 @@
 #include "nvim/charset.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/memline.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/move.h"
 #include "nvim/option.h"
 #include "nvim/screen.h"

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -35,7 +35,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -35,7 +35,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -59,7 +59,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/strings.h"
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -59,7 +59,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/strings.h"
 

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 #include "nvim/ascii.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 
 /*

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 
 #include "nvim/ascii.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 
 /*

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -115,7 +115,7 @@
 #include "nvim/menu.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -115,7 +115,7 @@
 #include "nvim/menu.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -37,7 +37,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"
 #include "nvim/option.h"

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -37,7 +37,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"
 #include "nvim/option.h"

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -310,7 +310,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/normal.h"
 #include "nvim/option.h"

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -310,7 +310,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/normal.h"
 #include "nvim/option.h"

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -7,7 +7,7 @@
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/strings.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/file_search.h"
 #include "nvim/buffer.h"
 #include "nvim/charset.h"

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -7,7 +7,7 @@
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/strings.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/file_search.h"
 #include "nvim/buffer.h"
 #include "nvim/charset.h"

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -33,7 +33,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/option.h"

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -33,7 +33,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/option.h"

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -34,7 +34,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/file_search.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -34,7 +34,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/file_search.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -38,7 +38,7 @@
 #include "nvim/fileio.h"
 #include "nvim/getchar.h"
 #include "nvim/message.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/keymap.h"
 #include "nvim/memory.h"

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -38,7 +38,7 @@
 #include "nvim/fileio.h"
 #include "nvim/getchar.h"
 #include "nvim/message.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/keymap.h"
 #include "nvim/memory.h"

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -28,7 +28,7 @@
 #include "nvim/main.h"
 #include "nvim/mbyte.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -28,7 +28,7 @@
 #include "nvim/main.h"
 #include "nvim/mbyte.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -97,7 +97,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/memory.h"
 #include "nvim/garray.h"
 #include "nvim/option.h"

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -97,7 +97,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/memory.h"
 #include "nvim/garray.h"
 #include "nvim/option.h"

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -13,7 +13,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"
 #include "nvim/version_defs.h"

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -13,7 +13,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"
 #include "nvim/version_defs.h"

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -37,7 +37,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/core.h"
+#include "nvim/fundamental.h"
 #include "nvim/file_search.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -37,7 +37,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
-#include "nvim/misc2.h"
+#include "nvim/core.h"
 #include "nvim/file_search.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"


### PR DESCRIPTION
In effort to eliminate the need for misc2.c (#209), I have pulled out various functions defined in misc2.c related to file IO to, correspondingly, fileio.c.
