### PR TITLE
[RDY] Fix clang analysis warnings. (2)

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -10,6 +10,7 @@
  * ex_cmds.c: some functions for command line commands
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <string.h>
@@ -2765,9 +2766,12 @@ do_ecmd (
         /* Autocommands may open a new window and leave oldwin open
          * which leads to crashes since the above call sets
          * oldwin->w_buffer to NULL. */
-        if (curwin != oldwin && oldwin != aucmd_win
-            && win_valid(oldwin) && oldwin->w_buffer == NULL)
-          win_close(oldwin, FALSE);
+        if (curwin != oldwin && oldwin != aucmd_win && win_valid(oldwin)) {
+          assert(oldwin);
+          if (oldwin->w_buffer == NULL) {
+            win_close(oldwin, FALSE);
+          }
+        }
 
         if (aborting()) {           /* autocmds may abort script processing */
           free(new_name);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -90,8 +90,9 @@ void do_ascii(exarg_T *eap)
   int cc[MAX_MCO];
   int ci = 0;
   int len;
+  const bool l_enc_utf8 = enc_utf8;
 
-  if (enc_utf8)
+  if (l_enc_utf8)
     c = utfc_ptr2char(get_cursor_pos_ptr(), cc);
   else
     c = gchar_cursor();
@@ -123,20 +124,20 @@ void do_ascii(exarg_T *eap)
     vim_snprintf((char *)IObuff, IOSIZE,
         _("<%s>%s%s  %d,  Hex %02x,  Octal %03o"),
         transchar(c), buf1, buf2, cval, cval, cval);
-    if (enc_utf8)
+    if (l_enc_utf8)
       c = cc[ci++];
     else
       c = 0;
   }
 
   /* Repeat for combining characters. */
-  while (has_mbyte && (c >= 0x100 || (enc_utf8 && c >= 0x80))) {
+  while (has_mbyte && (c >= 0x100 || (l_enc_utf8 && c >= 0x80))) {
     len = (int)STRLEN(IObuff);
     /* This assumes every multi-byte char is printable... */
     if (len > 0)
       IObuff[len++] = ' ';
     IObuff[len++] = '<';
-    if (enc_utf8 && utf_iscomposing(c)
+    if (l_enc_utf8 && utf_iscomposing(c)
 # ifdef USE_GUI
         && !gui.in_use
 # endif
@@ -148,7 +149,7 @@ void do_ascii(exarg_T *eap)
         : _("> %d, Hex %08x, Octal %o"), c, c, c);
     if (ci == MAX_MCO)
       break;
-    if (enc_utf8)
+    if (l_enc_utf8)
       c = cc[ci++];
     else
       c = 0;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -10,6 +10,7 @@
  * ex_cmds2.c: some more functions for command line commands
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -2422,6 +2423,7 @@ do_source (
   save_current_SID = current_SID;
   FileID file_id;
   bool file_id_ok = os_fileid((char *)fname_exp, &file_id);
+  assert(script_items.ga_len >= 0);
   for (current_SID = script_items.ga_len; current_SID > 0; --current_SID) {
     si = &SCRIPT_ITEM(current_SID);
     // Compare dev/ino when possible, it catches symbolic links.

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2405,11 +2405,13 @@ do_source (
   // time_fd was successfully opened afterwards.
   proftime_T rel_time;
   proftime_T start_time;
-  if (time_fd != NULL) {
+  FILE * const l_time_fd = time_fd;
+  if (l_time_fd != NULL) {
     time_push(&rel_time, &start_time);
   }
 
-  if (do_profiling == PROF_YES)
+  const int l_do_profiling = do_profiling;
+  if (l_do_profiling == PROF_YES)
     prof_child_enter(&wait_start);              /* entering a child now */
 
   /* Don't use local function variables, if called from a function.
@@ -2457,7 +2459,7 @@ do_source (
     new_script_vars(current_SID);
   }
 
-  if (do_profiling == PROF_YES) {
+  if (l_do_profiling == PROF_YES) {
     int forceit;
 
     /* Check if we do profiling for this script. */
@@ -2479,7 +2481,7 @@ do_source (
       DOCMD_VERBOSE|DOCMD_NOWAIT|DOCMD_REPEAT);
   retval = OK;
 
-  if (do_profiling == PROF_YES) {
+  if (l_do_profiling == PROF_YES) {
     /* Get "si" again, "script_items" may have been reallocated. */
     si = &SCRIPT_ITEM(current_SID);
     if (si->sn_prof_on) {
@@ -2503,7 +2505,7 @@ do_source (
     verbose_leave();
   }
 
-  if (time_fd != NULL) {
+  if (l_time_fd != NULL) {
     vim_snprintf((char *)IObuff, IOSIZE, "sourcing %s", fname);
     time_msg((char *)IObuff, &start_time);
     time_pop(rel_time);
@@ -2519,7 +2521,7 @@ do_source (
 
   current_SID = save_current_SID;
   restore_funccal(save_funccalp);
-  if (do_profiling == PROF_YES)
+  if (l_do_profiling == PROF_YES)
     prof_child_exit(&wait_start);               /* leaving a child now */
   fclose(cookie.fp);
   free(cookie.nextline);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7699,6 +7699,10 @@ eval_vars (
       sprintf((char *)strbuf, "%" PRId64, (int64_t)sourcing_lnum);
       result = strbuf;
       break;
+    default:
+      // should not happen
+      *errormsg = (char_u *)"";
+      return NULL;
     }
 
     resultlen = (int)STRLEN(result);            /* length of new string */

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -9,8 +9,8 @@
 /*
  * ex_eval.c: functions for Ex command line for the +eval feature.
  */
+#include <assert.h>
 #include <stdbool.h>
-
 #include <inttypes.h>
 
 #include "nvim/vim.h"
@@ -670,6 +670,7 @@ static void report_pending(int action, int pending, void *value)
   char        *s;
   int save_msg_silent;
 
+  assert(value || !(pending & CSTP_THROW));
 
   switch (action) {
   case RP_MAKE:

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4245,8 +4245,10 @@ void init_history(void)
           for (i = newlen - 1;; --i) {
             if (i >= 0)                         /* copy newest entries */
               temp[i] = history[type][j];
-            else                                /* remove older entries */
+            else {                              /* remove older entries */
               free(history[type][j].hisstr);
+              history[type][j].hisstr = NULL;
+            }
             if (--j < 0)
               j = hislen - 1;
             if (j == hisidx[type])

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1751,7 +1751,9 @@ failed:
 # ifdef USE_ICONV
   if (iconv_fd != (iconv_t)-1) {
     iconv_close(iconv_fd);
+#  ifndef __clang_analyzer__
     iconv_fd = (iconv_t)-1;
+#  endif
   }
 # endif
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -6191,12 +6191,9 @@ aucmd_prepbuf (
     }
   }
 
-  /* Allocate "aucmd_win" when needed.  If this fails (out of memory) fall
-   * back to using the current window. */
+  /* Allocate "aucmd_win" when needed. */
   if (win == NULL && aucmd_win == NULL) {
     win_alloc_aucmd_win();
-    if (aucmd_win == NULL)
-      win = curwin;
   }
   if (win == NULL && aucmd_win_used)
     /* Strange recursive autocommand, fall back to using the current

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -22,6 +22,7 @@
 #include "nvim/diff.h"
 #include "nvim/eval.h"
 #include "nvim/ex_docmd.h"
+#include "nvim/func_attr.h"
 #include "nvim/indent.h"
 #include "nvim/mark.h"
 #include "nvim/memline.h"
@@ -1680,7 +1681,9 @@ static void foldDelMarker(linenr_T lnum, char_u *marker, int markerlen)
  * When 'foldtext' isn't set puts the result in "buf[51]".  Otherwise the
  * result is in allocated memory.
  */
-char_u *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume, foldinfo_T *foldinfo, char_u *buf)
+char_u *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume,
+                     foldinfo_T *foldinfo, char_u *buf)
+  FUNC_ATTR_NONNULL_ARG(1)
 {
   char_u      *text = NULL;
   /* an error occurred when evaluating 'fdt' setting */
@@ -1689,8 +1692,7 @@ char_u *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume, foldinfo_T *foldi
   static win_T    *last_wp = NULL;
   static linenr_T last_lnum = 0;
 
-  if (last_wp != wp || last_wp == NULL
-      || last_lnum > lnum || last_lnum == 0)
+  if (last_wp == NULL || last_wp != wp || last_lnum > lnum || last_lnum == 0)
     /* window changed, try evaluating foldtext setting once again */
     got_fdt_error = FALSE;
 

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -3006,7 +3006,7 @@ int mch_print_text_out(char_u *p, int len)
     /* Convert from multi-byte to 8-bit encoding */
     p = string_convert(&prt_conv, p, &len);
     if (p == NULL)
-      p = (char_u *)"";
+      p = (char_u *)xstrdup("");
   }
 
   if (prt_out_mbyte) {
@@ -3054,7 +3054,7 @@ int mch_print_text_out(char_u *p, int len)
   }
 
   /* Need to free any translated characters */
-  if (prt_do_conv && (*p != NUL))
+  if (prt_do_conv)
     free(p);
 
   prt_text_run += char_width;

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -78,17 +78,11 @@ static void try_to_free_memory(void)
 /// @return pointer to allocated space. NULL if out of memory
 void *try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1)
 {
+  size = size ? size : 1;
   void *ret = malloc(size);
-
-  if (!ret && !size) {
-    ret = malloc(1);
-  }
   if (!ret) {
     try_to_free_memory();
     ret = malloc(size);
-    if (!ret && !size) {
-      ret = malloc(1);
-    }
   }
   return ret;
 }
@@ -120,7 +114,6 @@ void *xmalloc(size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1) FUNC_ATTR_NONNULL_RET
 {
   void *ret = try_malloc(size);
-
   if (!ret) {
     OUT_STR(e_outofmem);
     out_char('\n');
@@ -138,23 +131,16 @@ void *xmalloc(size_t size)
 void *xcalloc(size_t count, size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE_PROD(1, 2) FUNC_ATTR_NONNULL_RET
 {
-  void *ret = calloc(count, size);
-
-  if (!ret && (!count || !size))
-    ret = calloc(1, 1);
-
+  void *ret = count && size ? calloc(count, size) : calloc(1, 1);
   if (!ret) {
     try_to_free_memory();
-    ret = calloc(count, size);
-    if (!ret && (!count || !size))
-      ret = calloc(1, 1);
+    ret = count && size ? calloc(count, size) : calloc(1, 1);
     if (!ret) {
       OUT_STR(e_outofmem);
       out_char('\n');
       preserve_exit();
     }
   }
-
   return ret;
 }
 
@@ -166,23 +152,16 @@ void *xcalloc(size_t count, size_t size)
 void *xrealloc(void *ptr, size_t size)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALLOC_SIZE(2) FUNC_ATTR_NONNULL_RET
 {
-  void *ret = realloc(ptr, size);
-
-  if (!ret && !size)
-    ret = realloc(ptr, 1);
-
+  void *ret = size ? realloc(ptr, size) : realloc(ptr, 1);
   if (!ret) {
     try_to_free_memory();
-    ret = realloc(ptr, size);
-    if (!ret && !size)
-      ret = realloc(ptr, 1);
+    ret = size ? realloc(ptr, size) : realloc(ptr, 1);
     if (!ret) {
       OUT_STR(e_outofmem);
       out_char('\n');
       preserve_exit();
     }
   }
-
   return ret;
 }
 
@@ -195,14 +174,12 @@ void *xmallocz(size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_RET FUNC_ATTR_WARN_UNUSED_RESULT
 {
   size_t total_size = size + 1;
-  void *ret;
-
   if (total_size < size) {
     OUT_STR(_("Vim: Data too large to fit into virtual memory space\n"));
     preserve_exit();
   }
 
-  ret = xmalloc(total_size);
+  void *ret = xmalloc(total_size);
   ((char*)ret)[size] = 0;
 
   return ret;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -12,6 +12,7 @@
 
 #define MESSAGE_FILE            /* don't include prototype for smsg() */
 
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -691,8 +692,10 @@ int delete_first_msg(void)
     return FAIL;
   p = first_msg_hist;
   first_msg_hist = p->next;
-  if (first_msg_hist == NULL)
-    last_msg_hist = NULL;      /* history is empty */
+  if (first_msg_hist == NULL) {  /* history is becoming empty */
+    assert(msg_hist_len == 1);
+    last_msg_hist = NULL;
+  }
   free(p->msg);
   free(p);
   --msg_hist_len;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3323,7 +3323,6 @@ int vim_vsnprintf(char *str, size_t str_m, char *fmt, va_list ap, typval_T *tvs)
       case 'c':
       case 's':
       case 'S':
-        length_modifier = '\0';
         str_arg_l = 1;
         switch (fmt_spec) {
         case '%':
@@ -3587,7 +3586,6 @@ int vim_vsnprintf(char *str, size_t str_m, char *fmt, va_list ap, typval_T *tvs)
                * zero value is formatted with an
                * explicit precision of zero */
               precision = num_of_digits + 1;
-              precision_specified = 1;
             }
           }
           /* zero padding to specified precision? */


### PR DESCRIPTION
This continues the work in #1389.

Fixed **17** warnings in:
- ex_cmds.c.
- ex_cmds2.c
- ex_docmd.c
- ex_eval.c
- ex_getln.c
- fileio.c
- fold.c
- hardcopy.c
- memory.c
- message.c
