### PR TITLE
[RFC] Remove redundant USE_ICONV define from config.h.in.

### DIFF
--- a/config/config.h.in
+++ b/config/config.h.in
@@ -29,7 +29,6 @@
 #cmakedefine HAVE_GETPWNAM
 #cmakedefine HAVE_GETPWUID
 #cmakedefine HAVE_ICONV
-#cmakedefine USE_ICONV
 #cmakedefine HAVE_ICONV_H
 #cmakedefine HAVE_LANGINFO_H
 #cmakedefine HAVE_LIBGEN_H


### PR DESCRIPTION
This was noticed during a review of #1437.
