### PR TITLE
build: allow installing into the root directory (/)

### DIFF
--- a/cmake/InstallHelpers.cmake
+++ b/cmake/InstallHelpers.cmake
@@ -22,10 +22,6 @@ function(create_install_dir_with_perms)
 
   install(CODE
     "
-    if(DEFINED ENV{DESTDIR} AND NOT IS_ABSOLUTE \${CMAKE_INSTALL_PREFIX})
-      message(FATAL_ERROR \"Install prefix must be absolute when using DESTDIR\")
-    endif()
-
     set(_current_dir \"\${CMAKE_INSTALL_PREFIX}/${_install_dir_DESTINATION}\")
     set(_dir_permissions \"${_install_dir_DIRECTORY_PERMISSIONS}\")
 


### PR DESCRIPTION
It turns out that CMake always canonicalizes `CMAKE_INSTALL_PREFIX` to
an absolute path--if it's a relative path, it canonicalizes it relative
to the build directory.  As a result, the only thing the DESTDIR and
relative directory check prevents is an installation into the root
directory since CMake strips the trailing slash, turning "/" into an
empty string.  Let's just remove the check all together, since it cannot
accomplish what we intended.
