### PR TITLE
[RFC] build: fix CMAKE_MODULE_PATH usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 2.8.7)
 project (NEOVIM)
 
 # Point CMake at any custom modules we may ship
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # Prefer our bundled versions of dependencies.
 set(DEPS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.deps")
@@ -249,7 +249,7 @@ foreach(PROG ${RUNTIME_PROGRAMS})
   install_helper(PROGRAMS ${PROG} DESTINATION share/nvim/${BASEDIR})
 endforeach()
 
-install(SCRIPT ${CMAKE_MODULE_PATH}/GenerateHelptags.cmake)
+install(SCRIPT ${PROJECT_SOURCE_DIR}/cmake/GenerateHelptags.cmake)
 
 # Unfortunately, the below does not work under Ninja.  Ninja doesn't use a
 # pseudo-tty when launching processes, because it can put many jobs in parallel
@@ -297,7 +297,7 @@ if(BUSTED_PRG)
       -DTEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test
       -DBUILD_DIR=${CMAKE_BINARY_DIR}
       -DTEST_TYPE=unit
-      -P ${CMAKE_MODULE_PATH}/RunTests.cmake
+      -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
     DEPENDS nvim-test unittest-headers)
 
   add_custom_target(functionaltest
@@ -309,6 +309,6 @@ if(BUSTED_PRG)
       -DTEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test
       -DBUILD_DIR=${CMAKE_BINARY_DIR}
       -DTEST_TYPE=functional
-      -P ${CMAKE_MODULE_PATH}/RunTests.cmake
+      -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
     DEPENDS nvim)
 endif()

--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -50,7 +50,7 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG AND
         -DPOT_FILE=${NVIM_POT}
         -DSEARCH_DIR=${CMAKE_CURRENT_SOURCE_DIR}
         "'-DSOURCES=${NEOVIM_RELATIVE_SOURCES}'"
-        -P ${CMAKE_MODULE_PATH}/RunXgettext.cmake
+        -P ${PROJECT_SOURCE_DIR}/cmake/RunXgettext.cmake
     DEPENDS ${NEOVIM_SOURCES})
 
   add_custom_target(potfile DEPENDS ${NVIM_POT})
@@ -68,7 +68,7 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG AND
           -DMSGFMT_PRG=${GETTEXT_MSGFMT_EXECUTABLE}
           -DMO_FILE=${moFile}
           -DPO_FILE=${poFile}
-          -P ${CMAKE_MODULE_PATH}/RunMsgfmt.cmake
+          -P ${PROJECT_SOURCE_DIR}/cmake/RunMsgfmt.cmake
       DEPENDS ${poFile} ${NVIM_POT})
 
     install_helper(
@@ -107,7 +107,7 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG AND
         -DINPUT_ENC=${inputEnc}
         -DOUTPUT_ENC=${outputEnc}
         -DOUTPUT_CHARSET=${outputCharSet}
-        -P ${CMAKE_MODULE_PATH}/ConvertPo.cmake
+        -P ${PROJECT_SOURCE_DIR}/cmake/ConvertPo.cmake
       COMMENT "Updating ${outputName}.po"
       DEPENDS ${inputFile})
 
@@ -190,7 +190,7 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG AND
           -DMSGMERGE_PRG=${GETTEXT_MSGMERGE_EXECUTABLE}
           -DPO_FILE=${poFile}
           -DPOT_FILE=${NVIM_POT}
-          -P ${CMAKE_MODULE_PATH}/RunMsgmerge.cmake
+          -P ${PROJECT_SOURCE_DIR}/cmake/RunMsgmerge.cmake
       COMMENT "Updating ${LANGUAGE}.po"
       DEPENDS ${NVIM_POT})
 


### PR DESCRIPTION
Fixes #1447.  `CMAKE_MODULE_PATH` is meant to be a list of directories,
and as such, is not the proper way to launch our scripts.  Let's use
`${PROJECT_SOURCE_DIR}/cmake` instead.  Also, let's not outright set
`CMAKE_MODULE_PATH`, but instead append our location to the list.
