### PR TITLE
[RDY] Fix clang analysis warnings. (3)

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -978,7 +978,6 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
   int mb_added = 0;
   int numberextra;
   char_u *ps;
-  int tab_corr = (*s == TAB);
   int n;
 
   // No 'linebreak', 'showbreak' and 'breakindent': return quickly.
@@ -992,7 +991,7 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
   // First get normal size, without 'linebreak'
   int size = win_chartabsize(wp, s, col);
   int c = *s;
-  if (tab_corr) {
+  if (*s == TAB) {
       col_adj = size - 1;
   }
 
@@ -1034,7 +1033,6 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
 
       if (col2 >= colmax) { /* doesn't fit */
         size = colmax - col + col_adj;
-        tab_corr = FALSE;
         break;
       }
     }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -31,6 +31,7 @@
 #include "nvim/ex_getln.h"
 #include "nvim/fileio.h"
 #include "nvim/fold.h"
+#include "nvim/func_attr.h"
 #include "nvim/getchar.h"
 #include "nvim/hardcopy.h"
 #include "nvim/if_cscope.h"
@@ -4025,7 +4026,7 @@ static void ex_blast(exarg_T *eap)
   goto_buffer(eap, DOBUF_LAST, BACKWARD, 0);
 }
 
-int ends_excmd(int c)
+int ends_excmd(int c) FUNC_ATTR_CONST
 {
   return c == NUL || c == '|' || c == '"' || c == '\n';
 }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2563,7 +2563,6 @@ do_set (
       /* find end of name */
       key = 0;
       if (*arg == '<') {
-        nextchar = 0;
         opt_idx = -1;
         /* look out for <t_>;> */
         if (arg[1] == 't' && arg[2] == '_' && arg[3] && arg[4])

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -10,6 +10,7 @@
  * quickfix.c: functions for quickfix mode, using a file with error messages
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -880,7 +881,7 @@ void qf_free_all(win_T *wp)
 static int 
 qf_add_entry (
     qf_info_T *qi,                /* quickfix list */
-    qfline_T **prevp,            /* pointer to previously added entry or NULL */
+    qfline_T **prevp,            /* nonnull pointer (to previously added entry or NULL) */
     char_u *dir,               /* optional directory name */
     char_u *fname,             /* file name or NULL */
     int bufnum,                     /* buffer number or zero */
@@ -920,6 +921,7 @@ qf_add_entry (
     qi->qf_lists[qi->qf_curlist].qf_start = qfp;
     qfp->qf_prev = qfp;         /* first element points to itself */
   } else {
+    assert(*prevp);
     qfp->qf_prev = *prevp;
     (*prevp)->qf_next = qfp;
   }

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1084,7 +1084,6 @@ static int nfa_regatom(void)
   int extra = 0;
   int emit_range;
   int negated;
-  int result;
   int startc = -1;
   int endc = -1;
   int oldstartc = -1;
@@ -1452,8 +1451,8 @@ collection:
        * recognize that [0-9] stands for \d and [A-Za-z_] for \h,
        * and perform the necessary substitutions in the NFA.
        */
-      result = nfa_recognize_char_class(regparse, endp,
-          extra == NFA_ADD_NL);
+      int result = nfa_recognize_char_class(regparse, endp,
+                                            extra == NFA_ADD_NL);
       if (result != FAIL) {
         if (result >= NFA_FIRST_NL && result <= NFA_LAST_NL) {
           EMIT(result - NFA_ADD_NL);
@@ -1557,7 +1556,6 @@ collection:
           /* Try equivalence class [=a=] and the like */
           if (equiclass != 0) {
             nfa_emit_equi_class(equiclass);
-            result = OK;
             continue;
           }
           /* Try collating class like [. .]  */

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3973,6 +3973,7 @@ find_pattern_in_path (
   char_u      *startp = NULL;
   char_u      *inc_opt = NULL;
   win_T       *curwin_save = NULL;
+  const int l_g_do_tagpreview = g_do_tagpreview;
 
   regmatch.regprog = NULL;
   incl_regmatch.regprog = NULL;
@@ -4370,7 +4371,7 @@ search_line:
       } else if (--count <= 0) {
         found = TRUE;
         if (depth == -1 && lnum == curwin->w_cursor.lnum
-            && g_do_tagpreview == 0
+            && l_g_do_tagpreview == 0
             )
           EMSG(_("E387: Match is on current line"));
         else if (action == ACTION_SHOW) {
@@ -4380,7 +4381,7 @@ search_line:
           did_show = TRUE;
         } else {
           /* ":psearch" uses the preview window */
-          if (g_do_tagpreview != 0) {
+          if (l_g_do_tagpreview != 0) {
             curwin_save = curwin;
             prepare_tagpreview(true);
           }
@@ -4391,7 +4392,7 @@ search_line:
           }
           if (depth == -1) {
             /* match in current file */
-            if (g_do_tagpreview != 0) {
+            if (l_g_do_tagpreview != 0) {
               if (getfile(0, curwin_save->w_buffer->b_fname,
                       NULL, TRUE, lnum, FALSE) > 0)
                 break;                  /* failed to jump to file */
@@ -4412,7 +4413,7 @@ search_line:
           curwin->w_set_curswant = TRUE;
         }
 
-        if (g_do_tagpreview != 0
+        if (l_g_do_tagpreview != 0
             && curwin != curwin_save && win_valid(curwin_save)) {
           /* Return cursor to where we were */
           validate_cursor();

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1599,7 +1599,9 @@ static void find_word(matchinf_T *mip, int mode)
             mip->mi_compoff = (int)(p - mip->mi_fword);
           }
         }
+#if 0
         c = mip->mi_compoff;
+#endif
         ++mip->mi_complen;
         if (flags & WF_COMPROOT)
           ++mip->mi_compextra;

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -5804,6 +5804,8 @@ store_aff_word (
                   // Get compound IDS from the affix list.
                   get_compflags(affile, ae->ae_flags,
                       use_pfxlist + use_pfxlen);
+                else
+                  use_pfxlist[use_pfxlen] = NUL;
 
                 // Combine the list of compound flags.
                 // Concatenate them to the prefix IDs list.

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -4466,7 +4466,7 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
             || aff->af_pref.ht_used > 0)
           smsg((char_u *)_("FLAG after using flags in %s line %d: %s"),
               fname, lnum, items[1]);
-      } else if (spell_info_item(items[0]))   {
+      } else if (spell_info_item(items[0]) && itemcnt > 1)   {
         p = (char_u *)getroom(spin,
             (spin->si_info == NULL ? 0 : STRLEN(spin->si_info))
             + STRLEN(items[0])

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2061,7 +2061,7 @@ spell_move_to (
   char_u      *line;
   char_u      *p;
   char_u      *endp;
-  hlf_T attr;
+  hlf_T attr = HLF_COUNT;
   int len;
   int has_syntax = syntax_present(wp);
   int col;

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -284,6 +284,7 @@
 //                          stored as an offset to the previous number in as
 //                          few bytes as possible, see offset2bytes())
 
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -2096,6 +2097,7 @@ spell_move_to (
       buflen = len + MAXWLEN + 2;
       buf = xmalloc(buflen);
     }
+    assert(buf && buflen >= len + MAXWLEN + 2);
 
     // In first line check first word for Capital.
     if (lnum == 1)

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -12503,8 +12503,9 @@ static int spell_edit_score(slang_T *slang, char_u *badword, char_u *goodword)
   char_u      *p;
   int wbadword[MAXWLEN];
   int wgoodword[MAXWLEN];
+  const int l_has_mbyte = has_mbyte;
 
-  if (has_mbyte) {
+  if (l_has_mbyte) {
     // Get the characters from the multi-byte strings and put them in an
     // int array for easy access.
     for (p = badword, badlen = 0; *p != NUL; )
@@ -12529,7 +12530,7 @@ static int spell_edit_score(slang_T *slang, char_u *badword, char_u *goodword)
   for (i = 1; i <= badlen; ++i) {
     CNT(i, 0) = CNT(i - 1, 0) + SCORE_DEL;
     for (j = 1; j <= goodlen; ++j) {
-      if (has_mbyte) {
+      if (l_has_mbyte) {
         bc = wbadword[i - 1];
         gc = wgoodword[j - 1];
       } else {
@@ -12553,7 +12554,7 @@ static int spell_edit_score(slang_T *slang, char_u *badword, char_u *goodword)
         }
 
         if (i > 1 && j > 1) {
-          if (has_mbyte) {
+          if (l_has_mbyte) {
             pbc = wbadword[i - 2];
             pgc = wgoodword[j - 2];
           } else {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5106,7 +5106,7 @@ get_id_list (
      * parse the arguments after "contains"
      */
     count = 0;
-    while (!ends_excmd(*p)) {
+    do {
       for (end = p; *end && !vim_iswhite(*end) && *end != ','; ++end)
         ;
       name = xmalloc((int)(end - p + 3));             /* leave room for "^$" */
@@ -5199,7 +5199,7 @@ get_id_list (
       if (*p != ',')
         break;
       p = skipwhite(p + 1);             /* skip comma in between arguments */
-    }
+    } while (!ends_excmd(*p));
     if (failed)
       break;
     if (round == 1) {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -2851,15 +2851,16 @@ static int syn_regexec(regmmatch_T *rmp, linenr_T lnum, colnr_T col, syn_time_T 
 {
   int r;
   proftime_T pt;
+  const int l_syn_time_on = syn_time_on;
 
-  if (syn_time_on) {
+  if (l_syn_time_on) {
     pt = profile_start();
   }
 
   rmp->rmm_maxcol = syn_buf->b_p_smc;
   r = vim_regexec_multi(rmp, syn_win, syn_buf, lnum, col, NULL);
 
-  if (syn_time_on) {
+  if (l_syn_time_on) {
     pt = profile_end(pt);
     st->total = profile_add(st->total, pt);
     if (profile_cmp(pt, st->slowest) < 0) {

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -80,6 +80,7 @@
 #define UH_MAGIC 0x18dade       /* value for uh_magic when in use */
 #define UE_MAGIC 0xabc123       /* value for ue_magic when in use */
 
+#include <assert.h>
 #include <inttypes.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -2682,8 +2683,11 @@ void u_undoline(void)
  */
 void u_blockfree(buf_T *buf)
 {
-  while (buf->b_u_oldhead != NULL)
+  while (buf->b_u_oldhead != NULL) {
+    u_header_T *previous_oldhead = buf->b_u_oldhead;
     u_freeheader(buf, buf->b_u_oldhead, NULL);
+    assert(buf->b_u_oldhead != previous_oldhead);
+  }
   free(buf->b_u_line_ptr);
 }
 


### PR DESCRIPTION
Continues #1389 and #1431.

Fixes **15** warnings in:
- option.c
- quickfix.c
- regexp_nfa.c
- search.c
- spell.c
- syntax.c
- undo.c
- charset.c
