### PR TITLE
[RFC] Fix clang analysis warnings. (4)

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12523,6 +12523,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_NUMBER;
   rettv->vval.v_number = 0;
+  const int l_provider_call_nesting = provider_call_nesting;
 
   if (check_restricted() || check_secure()) {
     return;
@@ -12550,7 +12551,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv)
   int save_autocmd_fname_full, save_autocmd_bufnr;
   void *save_funccalp;
 
-  if (provider_call_nesting) {
+  if (l_provider_call_nesting) {
     // If this is called from a provider function, restore the scope
     // information of the caller.
     save_current_SID = current_SID;
@@ -12579,7 +12580,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv)
                                     args,
                                     &err);
 
-  if (provider_call_nesting) {
+  if (l_provider_call_nesting) {
     current_SID = save_current_SID;
     sourcing_name = save_sourcing_name;
     sourcing_lnum = save_sourcing_lnum;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -18496,8 +18496,10 @@ call_user_func (
     /* Set l:self to "selfdict".  Use "name" to avoid a warning from
      * some compiler that checks the destination size. */
     v = &fc->fixvar[fixvar_idx++].var;
+#ifndef __clang_analyzer__
     name = v->di_key;
     STRCPY(name, "self");
+#endif
     v->di_flags = DI_FLAGS_RO + DI_FLAGS_FIX;
     hash_add(&fc->l_vars.dv_hashtab, DI2HIKEY(v));
     v->di_tv.v_type = VAR_DICT;
@@ -18517,8 +18519,10 @@ call_user_func (
   /* Use "name" to avoid a warning from some compiler that checks the
    * destination size. */
   v = &fc->fixvar[fixvar_idx++].var;
+#ifndef __clang_analyzer__
   name = v->di_key;
   STRCPY(name, "000");
+#endif
   v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
   hash_add(&fc->l_avars.dv_hashtab, DI2HIKEY(v));
   v->di_tv.v_type = VAR_LIST;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5734,7 +5734,9 @@ dict_free (
 dictitem_T *dictitem_alloc(char_u *key) FUNC_ATTR_NONNULL_RET
 {
   dictitem_T *di = xmalloc(sizeof(dictitem_T) + STRLEN(key));
+#ifndef __clang_analyzer__
   STRCPY(di->di_key, key);
+#endif
   di->di_flags = 0;
   return di;
 }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -18901,8 +18901,10 @@ int do_return(exarg_T *eap, int reanimate, int is_cmd, void *rettv)
     else {
       /* When undoing a return in order to make it pending, get the stored
        * return rettv. */
-      if (reanimate)
+      if (reanimate) {
+        assert(current_funccal->rettv);
         rettv = current_funccal->rettv;
+      }
 
       if (rettv != NULL) {
         /* Store the value of the pending return. */

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2272,6 +2272,7 @@ static void set_var_lval(lval_T *lp, char_u *endp, typval_T *rettv, int copy, ch
       if (lp->ll_li->li_next == NULL) {
         /* Need to add an empty item. */
         list_append_number(lp->ll_list, 0);
+        assert(lp->ll_li->li_next);
       }
       lp->ll_li = lp->ll_li->li_next;
       ++lp->ll_n1;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -18280,6 +18280,7 @@ char_u *get_user_func_name(expand_T *xp, int idx)
     done = 0;
     hi = func_hashtab.ht_array;
   }
+  assert(hi);
   if (done < func_hashtab.ht_used) {
     if (done++ > 0)
       ++hi;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -18809,7 +18809,9 @@ free_funccal (
  */
 static void add_nr_var(dict_T *dp, dictitem_T *v, char *name, varnumber_T nr)
 {
+#ifndef __clang_analyzer__
   STRCPY(v->di_key, name);
+#endif
   v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
   hash_add(&dp->dv_hashtab, DI2HIKEY(v));
   v->di_tv.v_type = VAR_NUMBER;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6301,6 +6301,8 @@ void screenalloc(bool doclear)
   static int entered = FALSE;                   /* avoid recursiveness */
   static int done_outofmem_msg = FALSE;         /* did outofmem message */
   int retry_count = 0;
+  const bool l_enc_utf8 = enc_utf8;
+  const int l_enc_dbcs = enc_dbcs;
 
 retry:
   /*
@@ -6311,8 +6313,8 @@ retry:
   if ((ScreenLines != NULL
        && Rows == screen_Rows
        && Columns == screen_Columns
-       && enc_utf8 == (ScreenLinesUC != NULL)
-       && (enc_dbcs == DBCS_JPNU) == (ScreenLines2 != NULL)
+       && l_enc_utf8 == (ScreenLinesUC != NULL)
+       && (l_enc_dbcs == DBCS_JPNU) == (ScreenLines2 != NULL)
        && p_mco == Screen_mco
        )
       || Rows == 0
@@ -6358,13 +6360,13 @@ retry:
 
   new_ScreenLines = xmalloc((size_t)((Rows + 1) * Columns * sizeof(schar_T)));
   memset(new_ScreenLinesC, 0, sizeof(u8char_T *) * MAX_MCO);
-  if (enc_utf8) {
+  if (l_enc_utf8) {
     new_ScreenLinesUC = xmalloc(
         (size_t)((Rows + 1) * Columns * sizeof(u8char_T)));
     for (i = 0; i < p_mco; ++i)
       new_ScreenLinesC[i] = xcalloc((Rows + 1) * Columns, sizeof(u8char_T));
   }
-  if (enc_dbcs == DBCS_JPNU)
+  if (l_enc_dbcs == DBCS_JPNU)
     new_ScreenLines2 = xmalloc(
         (size_t)((Rows + 1) * Columns * sizeof(schar_T)));
   new_ScreenAttrs = xmalloc((size_t)((Rows + 1) * Columns * sizeof(sattr_T)));
@@ -6383,8 +6385,8 @@ retry:
     if (new_ScreenLinesC[i] == NULL)
       break;
   if (new_ScreenLines == NULL
-      || (enc_utf8 && (new_ScreenLinesUC == NULL || i != p_mco))
-      || (enc_dbcs == DBCS_JPNU && new_ScreenLines2 == NULL)
+      || (l_enc_utf8 && (new_ScreenLinesUC == NULL || i != p_mco))
+      || (l_enc_dbcs == DBCS_JPNU && new_ScreenLines2 == NULL)
       || new_ScreenAttrs == NULL
       || new_LineOffset == NULL
       || new_LineWraps == NULL
@@ -6432,7 +6434,7 @@ retry:
       if (!doclear) {
         (void)memset(new_ScreenLines + new_row * Columns,
             ' ', (size_t)Columns * sizeof(schar_T));
-        if (enc_utf8) {
+        if (l_enc_utf8) {
           (void)memset(new_ScreenLinesUC + new_row * Columns,
               0, (size_t)Columns * sizeof(u8char_T));
           for (i = 0; i < p_mco; ++i)
@@ -6440,7 +6442,7 @@ retry:
                 + new_row * Columns,
                 0, (size_t)Columns * sizeof(u8char_T));
         }
-        if (enc_dbcs == DBCS_JPNU)
+        if (l_enc_dbcs == DBCS_JPNU)
           (void)memset(new_ScreenLines2 + new_row * Columns,
               0, (size_t)Columns * sizeof(schar_T));
         (void)memset(new_ScreenAttrs + new_row * Columns,
@@ -6453,12 +6455,12 @@ retry:
             len = Columns;
           /* When switching to utf-8 don't copy characters, they
            * may be invalid now.  Also when p_mco changes. */
-          if (!(enc_utf8 && ScreenLinesUC == NULL)
+          if (!(l_enc_utf8 && ScreenLinesUC == NULL)
               && p_mco == Screen_mco)
             memmove(new_ScreenLines + new_LineOffset[new_row],
                 ScreenLines + LineOffset[old_row],
                 (size_t)len * sizeof(schar_T));
-          if (enc_utf8 && ScreenLinesUC != NULL
+          if (l_enc_utf8 && ScreenLinesUC != NULL
               && p_mco == Screen_mco) {
             memmove(new_ScreenLinesUC + new_LineOffset[new_row],
                 ScreenLinesUC + LineOffset[old_row],
@@ -6469,7 +6471,7 @@ retry:
                   ScreenLinesC[i] + LineOffset[old_row],
                   (size_t)len * sizeof(u8char_T));
           }
-          if (enc_dbcs == DBCS_JPNU && ScreenLines2 != NULL)
+          if (l_enc_dbcs == DBCS_JPNU && ScreenLines2 != NULL)
             memmove(new_ScreenLines2 + new_LineOffset[new_row],
                 ScreenLines2 + LineOffset[old_row],
                 (size_t)len * sizeof(schar_T));

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2799,7 +2799,7 @@ int get_tags(list_T *list, char_u *pat)
           || add_tag_field(dict, "cmd", tp.command,
               tp.command_end) == FAIL
           || add_tag_field(dict, "kind", tp.tagkind,
-              tp.tagkind_end) == FAIL
+              tp.tagkind ? tp.tagkind_end : NULL) == FAIL
           || dict_add_nr_str(dict, "static", is_static, NULL) == FAIL)
         ret = FAIL;
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -10,6 +10,7 @@
  * Code to handle tags and the tag stack
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -2779,7 +2780,8 @@ int get_tags(list_T *list, char_u *pat)
       TAG_REGEXP | TAG_NOIC, (int)MAXCOL, NULL);
   if (ret == OK && num_matches > 0) {
     for (i = 0; i < num_matches; ++i) {
-      parse_match(matches[i], &tp);
+      int parse_result = parse_match(matches[i], &tp);
+      assert(parse_result == OK);
       is_static = test_for_static(&tp);
 
       /* Skip pseudo-tag lines. */

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2308,6 +2308,7 @@ jumpto_tag (
   win_T       *curwin_save = NULL;
   char_u      *full_fname = NULL;
   int old_KeyTyped = KeyTyped;              /* getting the file may reset it */
+  const int l_g_do_tagpreview = g_do_tagpreview;
 
   pbuf = xmalloc(LSIZE);
 
@@ -2364,7 +2365,7 @@ jumpto_tag (
   ++RedrawingDisabled;
 
 
-  if (g_do_tagpreview != 0) {
+  if (l_g_do_tagpreview != 0) {
     postponed_split = 0;        /* don't split again below */
     curwin_save = curwin;       /* Save current window */
 
@@ -2396,7 +2397,7 @@ jumpto_tag (
   if (keep_help) {
     /* A :ta from a help file will keep the b_help flag set.  For ":ptag"
      * we need to use the flag from the window where we came from. */
-    if (g_do_tagpreview != 0)
+    if (l_g_do_tagpreview != 0)
       keep_help_flag = curwin_save->w_buffer->b_help;
     else
       keep_help_flag = curbuf->b_help;
@@ -2542,7 +2543,7 @@ jumpto_tag (
         foldOpenCursor();
     }
 
-    if (g_do_tagpreview != 0
+    if (l_g_do_tagpreview != 0
         && curwin != curwin_save && win_valid(curwin_save)) {
       /* Return cursor to where we were */
       validate_cursor();

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2194,6 +2194,7 @@ winframe_remove (
        * the frames into this list. */
       if (frp2->fr_child == frp)
         frp2->fr_child = frp->fr_child;
+      assert(frp->fr_child);
       frp->fr_child->fr_prev = frp->fr_prev;
       if (frp->fr_prev != NULL)
         frp->fr_prev->fr_next = frp->fr_child;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4504,6 +4504,7 @@ void win_drag_vsep_line(win_T *dragwin, int offset)
       room += fr->fr_width - frame_minwidth(fr, NULL);
     fr = curfr;                         /* put fr at window that grows */
   }
+  assert(fr);
 
   if (room < offset)            /* Not enough room */
     offset = room;              /* Move as far as we can */

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4976,6 +4976,7 @@ static void last_status_rec(frame_T *fr, int statusline)
  */
 int tabline_height(void)
 {
+  assert(first_tabpage);
   switch (p_stal) {
   case 0: return 0;
   case 1: return (first_tabpage->tp_next == NULL) ? 0 : 1;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1230,7 +1230,6 @@ static void win_rotate(int upwards, int count)
     return;
   }
 
-
   /* Check if all frames in this row/col have one window. */
   for (frp = curwin->w_frame->fr_parent->fr_child; frp != NULL;
        frp = frp->fr_next)
@@ -1246,6 +1245,7 @@ static void win_rotate(int upwards, int count)
       wp1 = frp->fr_win;
       win_remove(wp1, NULL);
       frame_remove(frp);
+      assert(frp->fr_parent->fr_child);
 
       /* find last frame and append removed window/frame after it */
       for (; frp->fr_next != NULL; frp = frp->fr_next)
@@ -1263,6 +1263,7 @@ static void win_rotate(int upwards, int count)
       wp2 = wp1->w_prev;                    /* will become last window */
       win_remove(wp1, NULL);
       frame_remove(frp);
+      assert(frp->fr_parent->fr_child);
 
       /* append the removed window/frame before the first in the list */
       win_append(frp->fr_parent->fr_child->fr_win->w_prev, wp1);


### PR DESCRIPTION
Continues #1389, #1431, and #1460 .

This fixes **19** warnings in:
- tag.c
- window.c
- eval.c
- screen.c
