### PR TITLE
Fix #1484: search gettext subdir for header

### DIFF
--- a/cmake/FindLibIntl.cmake
+++ b/cmake/FindLibIntl.cmake
@@ -23,6 +23,7 @@ endif()
 
 find_path(LibIntl_INCLUDE_DIR
     NAMES libintl.h
+    PATH_SUFFIXES gettext
 )
 
 find_library(LibIntl_LIBRARY


### PR DESCRIPTION
On some systems, such as NetBSD, the gettext header is tucked under the
gettext directory in the system include area.  Let's add a path suffix
to ensure we correctly discover the header on such systems.
