### PR TITLE
[RDY] Invert -Wconversion handling & fix some warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 2.8.7)
-project (NEOVIM)
+cmake_minimum_required(VERSION 2.8.7)
+project(NEOVIM)
 
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
@@ -66,6 +66,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Default to -O2 on release builds.
 string(REPLACE "-O3" "-O2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+
+# Enable -Wconversion.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion")
 
 # gcc 4.0 and better turn on _FORTIFY_SOURCE=2 automatically.  This currently
 # does not work with Neovim due to some uses of dynamically-sized structures.

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -43,7 +43,6 @@ set(CONV_SOURCES
   buffer.c
   charset.c
   diff.c
-  digraph.c
   edit.c
   eval.c
   ex_cmds2.c

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -38,34 +38,68 @@ endforeach()
 
 list(REMOVE_ITEM NEOVIM_SOURCES ${to_remove})
 
+# Handle legacy files that don't yet pass -Wconversion.
 set(CONV_SOURCES
-  arabic.c
-  cursor.c
-  garray.c
-  hashtab.c
-  log.c
-  map.c
-  memfile.c
-  memory.c
-  misc2.c
-  profile.c
-  tempfile.c
-  )
+  buffer.c
+  charset.c
+  cursor_shape.c
+  diff.c
+  digraph.c
+  edit.c
+  eval.c
+  ex_cmds2.c
+  ex_cmds.c
+  ex_docmd.c
+  ex_eval.c
+  ex_getln.c
+  farsi.c
+  fileio.c
+  file_search.c
+  fold.c
+  getchar.c
+  hardcopy.c
+  if_cscope.c
+  indent.c
+  indent_c.c
+  keymap.c
+  main.c
+  mark.c
+  mbyte.c
+  memline.c
+  menu.c
+  message.c
+  misc1.c
+  move.c
+  normal.c
+  ops.c
+  option.c
+  os_unix.c
+  path.c
+  popupmnu.c
+  quickfix.c
+  regexp.c
+  regexp_nfa.c
+  screen.c
+  search.c
+  sha256.c
+  spell.c
+  strings.c
+  syntax.c
+  tag.c
+  term.c
+  ui.c
+  undo.c
+  version.c
+  window.c)
 
 foreach(sfile ${CONV_SOURCES})
   if(NOT EXISTS "${PROJECT_SOURCE_DIR}/src/nvim/${sfile}")
-    message(FATAL_ERROR "${sfile} doesn't exist(it was added to CONV_SOURCES)")
+    message(FATAL_ERROR "${sfile} doesn't exist (it was added to CONV_SOURCES)")
   endif()
 endforeach()
 
-file(GLOB_RECURSE EXTRA_CONV_SOURCES os/*.c api/*.c msgpack_rpc/*.c)
-foreach(sfile ${EXTRA_CONV_SOURCES})
-  file(RELATIVE_PATH f "${PROJECT_SOURCE_DIR}/src/nvim" "${sfile}")
-  list(APPEND CONV_SOURCES ${f})
-endforeach()
-
 set_source_files_properties(
-  ${CONV_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wconversion")
+  ${CONV_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-conversion")
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
   if(DEFINED ENV{SANITIZE})

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -42,7 +42,6 @@ list(REMOVE_ITEM NEOVIM_SOURCES ${to_remove})
 set(CONV_SOURCES
   buffer.c
   charset.c
-  cursor_shape.c
   diff.c
   digraph.c
   edit.c

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdint.h>
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/cursor_shape.h"
@@ -52,7 +53,6 @@ char_u *parse_shape_opt(int what)
   int all_idx;
   int len;
   int i;
-  long n;
   int found_ve = FALSE;                 /* found "ve" flag */
   int round;
 
@@ -135,7 +135,9 @@ char_u *parse_shape_opt(int what)
               p += len;
               if (!VIM_ISDIGIT(*p))
                 return (char_u *)N_("E548: digit expected");
-              n = getdigits(&p);
+              long digits = getdigits(&p);
+              assert(digits <= INT_MAX);
+              int n = (int)digits;
               if (len == 3) {               /* "ver" or "hor" */
                 if (n == 0)
                   return (char_u *)N_("E549: Illegal percentage");

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -2,7 +2,9 @@
 ///
 /// code for digraphs
 
+#include <assert.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <inttypes.h>
 
 #include "nvim/vim.h"
@@ -1582,7 +1584,7 @@ int getdigraph(int char1, int char2, int meta_char)
 /// @param str
 void putdigraph(char_u *str)
 {
-  int char1, char2, n;
+  char_u char1, char2;
   digr_T *dp;
 
   while (*str != NUL) {
@@ -1609,7 +1611,9 @@ void putdigraph(char_u *str)
       EMSG(_(e_number_exp));
       return;
     }
-    n = getdigits(&str);
+    long digits = getdigits(&str);
+    assert(digits <= INT_MAX);
+    int n = (int)digits;
 
     // If the digraph already exists, replace the result.
     dp = (digr_T *)user_digraphs.ga_data;
@@ -1711,7 +1715,8 @@ static void printdigraph(digr_T *dp)
     if (char2cells(dp->result) == 1) {
       *p++ = ' ';
     }
-    vim_snprintf((char *)p, sizeof(buf) - (p - buf), " %3d", dp->result);
+    assert(p >= buf);
+    vim_snprintf((char *)p, sizeof(buf) - (size_t)(p - buf), " %3d", dp->result);
     msg_outtrans(buf);
   }
 }


### PR DESCRIPTION
Instead of selectively enabling `-Wconversion`, I think it might be better to instead disable this for some files to avoid accidentally missing some (e.g. newly created) files. This will also give a list of "problematic" files right in the CMake file.

Also added two commits fixing the warnings in `cursor_shape.c` and `digraph.c`.
