### PR TITLE
[WIP] Fix vim_strchr() duplication

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -401,7 +401,7 @@ int vim_strnicmp(char *s1, char *s2, size_t len)
  * with characters from 128 to 255 correctly.  It also doesn't return a
  * pointer to the NUL at the end of the string.
  */
-char_u *vim_strchr(char_u *string, int c)
+char_u *vim_strchr(char_u *string, int c) FUNC_ATTR_NONNULL_ARG(1)
 {
   char_u      *p;
   int b;

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -443,7 +443,7 @@ char_u *vim_strchr(char_u *string, int c) FUNC_ATTR_NONNULL_ARG(1)
  * strings with characters above 128 correctly. It also doesn't return a
  * pointer to the NUL at the end of the string.
  */
-char_u *vim_strbyte(char_u *string, int c)
+char_u *vim_strbyte(char_u *string, int c) FUNC_ATTR_NONNULL_ARG(1)
 {
   char_u      *p = string;
 

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -401,7 +401,7 @@ int vim_strnicmp(char *s1, char *s2, size_t len)
  * with characters from 128 to 255 correctly.  It also doesn't return a
  * pointer to the NUL at the end of the string.
  */
-char_u *vim_strchr(char_u *string, int c) FUNC_ATTR_NONNULL_ARG(1)
+char_u *vim_strchr(const char_u *string, int c) FUNC_ATTR_NONNULL_ARG(1)
 {
   char_u      *p;
   int b;

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -434,12 +434,8 @@ char_u *vim_strchr(char_u *string, int c)
     }
     return NULL;
   }
-  while ((b = *p) != NUL) {
-    if (b == c)
-      return p;
-    ++p;
-  }
-  return NULL;
+
+  return vim_strbyte(p, c);
 }
 
 /*


### PR DESCRIPTION
Replacing duplicated code at the tail end of vim_strchr() and adds nonnull arg function attributes on vim_strchr and vim_strbyte

https://github.com/neovim/neovim/issues/1474
