### PR TITLE
[RFC] constify and func-attribute memory.c and strings.c

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -81,7 +81,6 @@ set(CONV_SOURCES
   search.c
   sha256.c
   spell.c
-  strings.c
   syntax.c
   tag.c
   term.c

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1850,7 +1850,7 @@ int hexhex2nr(char_u *p)
 #endif // if defined(FEAT_TERMRESPONSE) || defined(FEAT_GUI_GTK)
        // || defined(PROTO)
 
-/// Return TRUE if "str" starts with a backslash that should be removed.
+/// Return true if "str" starts with a backslash that should be removed.
 /// For WIN32 this is only done when the character after the
 /// backslash is not a normal file name character.
 /// '$' is a valid file name character, we don't remove the backslash before
@@ -1864,8 +1864,8 @@ int hexhex2nr(char_u *p)
 ///
 /// @param str
 ///
-/// @return TRUE if `str` starts with a backslash that should be removed.
-int rem_backslash(char_u *str)
+/// @return true if `str` starts with a backslash that should be removed.
+bool rem_backslash(const char_u *str)
 {
 #ifdef BACKSLASH_IN_FILENAME
   return str[0] == '\\'

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1813,10 +1813,10 @@ void ex_loadkeymap(exarg_T *eap)
     if ((*p != '"') && (*p != NUL)) {
       kmap_T *kp = GA_APPEND_VIA_PTR(kmap_T, &curbuf->b_kmap_ga);
       s = skiptowhite(p);
-      kp->from = vim_strnsave(p, (int)(s - p));
+      kp->from = vim_strnsave(p, (size_t)(s - p));
       p = skipwhite(s);
       s = skiptowhite(p);
-      kp->to = vim_strnsave(p, (int)(s - p));
+      kp->to = vim_strnsave(p, (size_t)(s - p));
 
       if ((STRLEN(kp->from) + STRLEN(kp->to) >= KMAP_LLEN)
           || (*kp->from == NUL)

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7480,7 +7480,7 @@ static void ex_tag_cmd(exarg_T *eap, char_u *name)
  * If found return one of the SPEC_ values and set "*usedlen" to the length of
  * the variable.  Otherwise return -1 and "*usedlen" is unchanged.
  */
-int find_cmdline_var(char_u *src, int *usedlen)
+int find_cmdline_var(const char_u *src, int *usedlen) FUNC_ATTR_NONNULL_ALL
 {
   int len;
   int i;

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -143,8 +143,9 @@
 /* get length of multi-byte char, not including composing chars */
 # define mb_cptr2len(p)     (enc_utf8 ? utf_ptr2len(p) : (*mb_ptr2len)(p))
 
-# define MB_COPY_CHAR(f, \
-                      t) if (has_mbyte) mb_copy_char(&f, &t); else *t++ = *f++
+# define MB_COPY_CHAR(f, t) \
+  if (has_mbyte) mb_copy_char((const char_u **)(&f), &t); \
+  else *t++ = *f++
 # define MB_CHARLEN(p)      (has_mbyte ? mb_charlen(p) : (int)STRLEN(p))
 # define MB_CHAR2LEN(c)     (has_mbyte ? mb_char2len(c) : 1)
 # define PTR2CHAR(p)        (has_mbyte ? mb_ptr2char(p) : (int)*(p))

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -3003,7 +3003,7 @@ int utf_head_off(const char_u *base, const char_u *p)
 /*
  * Copy a character from "*fp" to "*tp" and advance the pointers.
  */
-void mb_copy_char(char_u **fp, char_u **tp)
+void mb_copy_char(const char_u **fp, char_u **tp)
 {
   int l = (*mb_ptr2len)(*fp);
 

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -305,6 +305,7 @@ char *xstpncpy(char *restrict dst, const char *restrict src, size_t maxlen)
 /// @param size Size of destination buffer
 /// @return Length of the source string (i.e.: strlen(src))
 size_t xstrlcpy(char *restrict dst, const char *restrict src, size_t size)
+  FUNC_ATTR_NONNULL_ALL
 {
     size_t ret = strlen(src);
 
@@ -348,7 +349,7 @@ char *xstrdup(const char *str)
 /// @param c   The byte to search for.
 /// @param len The length of the memory object.
 /// @returns a pointer to the found byte in src[len], or NULL.
-void *xmemrchr(void *src, uint8_t c, size_t len)
+void *xmemrchr(const void *src, uint8_t c, size_t len)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
   while (len--) {

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -43,7 +43,7 @@ char *os_getenvname_at_index(size_t index)
   if (str == NULL) {
     return NULL;
   }
-  int namesize = 0;
+  size_t namesize = 0;
   while (str[namesize] != '=' && str[namesize] != NUL) {
     namesize++;
   }

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -50,7 +50,8 @@
 /*
  * Copy "string" into newly allocated memory.
  */
-char_u *vim_strsave(char_u *string) FUNC_ATTR_NONNULL_RET
+char_u *vim_strsave(const char_u *string)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
   return (char_u *)xstrdup((char *)string);
 }
@@ -61,7 +62,8 @@ char_u *vim_strsave(char_u *string) FUNC_ATTR_NONNULL_RET
  * The allocated memory always has size "len + 1", also when "string" is
  * shorter.
  */
-char_u *vim_strnsave(char_u *string, int len) FUNC_ATTR_NONNULL_RET
+char_u *vim_strnsave(const char_u *string, int len)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
   return (char_u *)strncpy(xmallocz(len), (char *)string, len);
 }
@@ -70,8 +72,8 @@ char_u *vim_strnsave(char_u *string, int len) FUNC_ATTR_NONNULL_RET
  * Same as vim_strsave(), but any characters found in esc_chars are preceded
  * by a backslash.
  */
-char_u *vim_strsave_escaped(char_u *string, char_u *esc_chars)
-  FUNC_ATTR_NONNULL_RET
+char_u *vim_strsave_escaped(const char_u *string, const char_u *esc_chars)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
   return vim_strsave_escaped_ext(string, esc_chars, '\\', FALSE);
 }
@@ -81,8 +83,9 @@ char_u *vim_strsave_escaped(char_u *string, char_u *esc_chars)
  * characters where rem_backslash() would remove the backslash.
  * Escape the characters with "cc".
  */
-char_u *vim_strsave_escaped_ext(char_u *string, char_u *esc_chars, int cc, int bsl)
-  FUNC_ATTR_NONNULL_RET
+char_u *vim_strsave_escaped_ext(const char_u *string, const char_u *esc_chars,
+                                int cc, int bsl)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
   unsigned length;
   int l;
@@ -92,7 +95,7 @@ char_u *vim_strsave_escaped_ext(char_u *string, char_u *esc_chars, int cc, int b
    * Then allocate the memory and insert them.
    */
   length = 1;                           /* count the trailing NUL */
-  for (char_u *p = string; *p; p++) {
+  for (const char_u *p = string; *p; p++) {
     if (has_mbyte && (l = (*mb_ptr2len)(p)) > 1) {
       length += l;                      /* count a multibyte char */
       p += l - 1;
@@ -105,7 +108,7 @@ char_u *vim_strsave_escaped_ext(char_u *string, char_u *esc_chars, int cc, int b
 
   char_u *escaped_string = xmalloc(length);
   char_u *p2 = escaped_string;
-  for (char_u *p = string; *p; p++) {
+  for (const char_u *p = string; *p; p++) {
     if (has_mbyte && (l = (*mb_ptr2len)(p)) > 1) {
       memmove(p2, p, (size_t)l);
       p2 += l;
@@ -131,10 +134,10 @@ char_u *vim_strsave_escaped_ext(char_u *string, char_u *esc_chars, int cc, int b
  * When "do_newline" is false do not escape newline unless it is csh shell.
  * Returns the result in allocated memory.
  */
-char_u *vim_strsave_shellescape(char_u *string, bool do_special, bool do_newline)
+char_u *vim_strsave_shellescape(const char_u *string,
+                                bool do_special, bool do_newline)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
-  unsigned length;
-  char_u      *p;
   char_u      *d;
   char_u      *escaped_string;
   int l;
@@ -147,8 +150,8 @@ char_u *vim_strsave_shellescape(char_u *string, bool do_special, bool do_newline
   csh_like = csh_like_shell();
 
   /* First count the number of extra bytes required. */
-  length = (unsigned)STRLEN(string) + 3;    /* two quotes and a trailing NUL */
-  for (p = string; *p != NUL; mb_ptr_adv(p)) {
+  size_t length = STRLEN(string) + 3;       // two quotes and a trailing NUL
+  for (const char_u *p = string; *p != NUL; mb_ptr_adv(p)) {
     if (*p == '\'')
       length += 3;                      /* ' => '\'' */
     if ((*p == '\n' && (csh_like || do_newline))
@@ -170,7 +173,7 @@ char_u *vim_strsave_shellescape(char_u *string, bool do_special, bool do_newline
   /* add opening quote */
   *d++ = '\'';
 
-  for (p = string; *p != NUL; ) {
+  for (const char_u *p = string; *p != NUL; ) {
     if (*p == '\'') {
       *d++ = '\'';
       *d++ = '\\';
@@ -208,7 +211,8 @@ char_u *vim_strsave_shellescape(char_u *string, bool do_special, bool do_newline
  * Like vim_strsave(), but make all characters uppercase.
  * This uses ASCII lower-to-upper case translation, language independent.
  */
-char_u *vim_strsave_up(char_u *string)
+char_u *vim_strsave_up(const char_u *string)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
   char_u *p1;
 
@@ -221,7 +225,8 @@ char_u *vim_strsave_up(char_u *string)
  * Like vim_strnsave(), but make all characters uppercase.
  * This uses ASCII lower-to-upper case translation, language independent.
  */
-char_u *vim_strnsave_up(char_u *string, int len) FUNC_ATTR_NONNULL_RET
+char_u *vim_strnsave_up(const char_u *string, int len)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
   char_u *p1 = vim_strnsave(string, len);
   vim_strup(p1);
@@ -232,6 +237,7 @@ char_u *vim_strnsave_up(char_u *string, int len) FUNC_ATTR_NONNULL_RET
  * ASCII lower-to-upper case translation, language independent.
  */
 void vim_strup(char_u *p)
+  FUNC_ATTR_NONNULL_ALL
 {
   char_u  *p2;
   int c;
@@ -247,7 +253,8 @@ void vim_strup(char_u *p)
  * Make string "s" all upper-case and return it in allocated memory.
  * Handles multi-byte characters as well as possible.
  */
-char_u *strup_save(char_u *orig)
+char_u *strup_save(const char_u *orig)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
   char_u *res = vim_strsave(orig);
 
@@ -290,6 +297,7 @@ char_u *strup_save(char_u *orig)
  * copy a space a number of times
  */
 void copy_spaces(char_u *ptr, size_t count)
+  FUNC_ATTR_NONNULL_ALL
 {
   size_t i = count;
   char_u      *p = ptr;
@@ -303,6 +311,7 @@ void copy_spaces(char_u *ptr, size_t count)
  * Does not work for multi-byte characters!
  */
 void copy_chars(char_u *ptr, size_t count, int c)
+  FUNC_ATTR_NONNULL_ALL
 {
   size_t i = count;
   char_u      *p = ptr;
@@ -315,6 +324,7 @@ void copy_chars(char_u *ptr, size_t count, int c)
  * delete spaces at the end of a string
  */
 void del_trailing_spaces(char_u *ptr)
+  FUNC_ATTR_NONNULL_ALL
 {
   char_u      *q;
 
@@ -327,7 +337,8 @@ void del_trailing_spaces(char_u *ptr)
  * Like strncpy(), but always terminate the result with one NUL.
  * "to" must be "len + 1" long!
  */
-void vim_strncpy(char_u *to, char_u *from, size_t len)
+void vim_strncpy(char_u *restrict to, const char_u *restrict from, size_t len)
+  FUNC_ATTR_NONNULL_ALL
 {
   STRNCPY(to, from, len);
   to[len] = NUL;
@@ -337,13 +348,15 @@ void vim_strncpy(char_u *to, char_u *from, size_t len)
  * Like strcat(), but make sure the result fits in "tosize" bytes and is
  * always NUL terminated.
  */
-void vim_strcat(char_u *to, char_u *from, size_t tosize)
+void vim_strcat(char_u *restrict to, const char_u *restrict from,
+                size_t tosize)
+  FUNC_ATTR_NONNULL_ALL
 {
   size_t tolen = STRLEN(to);
   size_t fromlen = STRLEN(from);
 
   if (tolen + fromlen + 1 > tosize) {
-    memmove(to + tolen, from, tosize - tolen - 1);
+    memcpy(to + tolen, from, tosize - tolen - 1);
     to[tosize - 1] = NUL;
   } else
     STRCPY(to + tolen, from);
@@ -355,7 +368,8 @@ void vim_strcat(char_u *to, char_u *from, size_t tosize)
  * Doesn't work for multi-byte characters.
  * return 0 for match, < 0 for smaller, > 0 for bigger
  */
-int vim_stricmp(char *s1, char *s2)
+int vim_stricmp(const char *s1, const char *s2)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
   int i;
 
@@ -378,7 +392,8 @@ int vim_stricmp(char *s1, char *s2)
  * Doesn't work for multi-byte characters.
  * return 0 for match, < 0 for smaller, > 0 for bigger
  */
-int vim_strnicmp(char *s1, char *s2, size_t len)
+int vim_strnicmp(const char *s1, const char *s2, size_t len)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
   int i;
 
@@ -401,16 +416,16 @@ int vim_strnicmp(char *s1, char *s2, size_t len)
  * with characters from 128 to 255 correctly.  It also doesn't return a
  * pointer to the NUL at the end of the string.
  */
-char_u *vim_strchr(char_u *string, int c)
+char_u *vim_strchr(const char_u *string, int c)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
-  char_u      *p;
   int b;
 
-  p = string;
+  const char_u *p = string;
   if (enc_utf8 && c >= 0x80) {
     while (*p != NUL) {
       if (utf_ptr2char(p) == c)
-        return p;
+        return (char_u *) p;
       p += (*mb_ptr2len)(p);
     }
     return NULL;
@@ -421,7 +436,7 @@ char_u *vim_strchr(char_u *string, int c)
     c = ((unsigned)c >> 8) & 0xff;
     while ((b = *p) != NUL) {
       if (b == c && p[1] == n2)
-        return p;
+        return (char_u *) p;
       p += (*mb_ptr2len)(p);
     }
     return NULL;
@@ -429,14 +444,14 @@ char_u *vim_strchr(char_u *string, int c)
   if (has_mbyte) {
     while ((b = *p) != NUL) {
       if (b == c)
-        return p;
+        return (char_u *) p;
       p += (*mb_ptr2len)(p);
     }
     return NULL;
   }
   while ((b = *p) != NUL) {
     if (b == c)
-      return p;
+      return (char_u *) p;
     ++p;
   }
   return NULL;
@@ -447,13 +462,14 @@ char_u *vim_strchr(char_u *string, int c)
  * strings with characters above 128 correctly. It also doesn't return a
  * pointer to the NUL at the end of the string.
  */
-char_u *vim_strbyte(char_u *string, int c)
+char_u *vim_strbyte(const char_u *string, int c)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
-  char_u      *p = string;
+  const char_u *p = string;
 
   while (*p != NUL) {
     if (*p == c)
-      return p;
+      return (char_u *) p;
     ++p;
   }
   return NULL;
@@ -464,17 +480,18 @@ char_u *vim_strbyte(char_u *string, int c)
  * Return NULL if not found.
  * Does not handle multi-byte char for "c"!
  */
-char_u *vim_strrchr(char_u *string, int c)
+char_u *vim_strrchr(const char_u *string, int c)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
-  char_u      *retval = NULL;
-  char_u      *p = string;
+  const char_u *retval = NULL;
+  const char_u *p = string;
 
   while (*p) {
     if (*p == c)
       retval = p;
     mb_ptr_adv(p);
   }
-  return retval;
+  return (char_u *) retval;
 }
 
 /*
@@ -482,6 +499,7 @@ char_u *vim_strrchr(char_u *string, int c)
  * can't handle characters above 128.
  */
 int vim_isspace(int x)
+  FUNC_ATTR_CONST
 {
   return (x >= 9 && x <= 13) || x == ' ';
 }
@@ -494,6 +512,7 @@ int vim_isspace(int x)
 # include "strings.c.generated.h"
 #endif
 static int sort_compare(const void *s1, const void *s2)
+  FUNC_ATTR_NONNULL_ALL
 {
   return STRCMP(*(char **)s1, *(char **)s2);
 }
@@ -507,9 +526,10 @@ void sort_strings(char_u **files, int count)
  * Return TRUE if string "s" contains a non-ASCII character (128 or higher).
  * When "s" is NULL FALSE is returned.
  */
-int has_non_ascii(char_u *s)
+int has_non_ascii(const char_u *s)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
-  char_u      *p;
+  const char_u *p;
 
   if (s != NULL)
     for (p = s; *p != NUL; ++p)
@@ -521,7 +541,8 @@ int has_non_ascii(char_u *s)
 /*
  * Concatenate two strings and return the result in allocated memory.
  */
-char_u *concat_str(char_u *str1, char_u *str2) FUNC_ATTR_NONNULL_RET
+char_u *concat_str(const char_u *restrict str1, const char_u *restrict str2)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
   size_t l = STRLEN(str1);
   char_u *dest = xmalloc(l + STRLEN(str2) + 1);


### PR DESCRIPTION
Not having `string.c` functions take `const` pointers really makes it annoying to write `const`-aware functions on top of them, which always makes me refrain from mentioning this in code reviews. As a bonus, I added some `FUNC_ATTR_*` stuff.

I used the standard C library convention: Take a `const` pointer, but return a non-`const` one. It's not safe, but the alternative would be to make `const` versions of each function. 
