### PR TITLE
[WIP] Refactor deferred event processing

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -58,7 +58,6 @@
 #include "nvim/ui.h"
 #include "nvim/undo.h"
 #include "nvim/window.h"
-#include "nvim/os/event.h"
 
 /*
  * definitions used for CTRL-X submode
@@ -941,10 +940,6 @@ doESCkey:
     case K_CURSORHOLD:          /* Didn't type something for a while. */
       apply_autocmds(EVENT_CURSORHOLDI, NULL, NULL, FALSE, curbuf);
       did_cursorhold = TRUE;
-      break;
-
-    case K_EVENT:
-      event_process();
       break;
 
     case K_HOME:        /* <Home> */

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -62,7 +62,6 @@
 #include "nvim/window.h"
 #include "nvim/ui.h"
 #include "nvim/os/os.h"
-#include "nvim/os/event.h"
 
 /*
  * Variables shared between getcmdline(), redrawcmdline() and others.
@@ -769,11 +768,6 @@ getcmdline (
      * Big switch for a typed command line character.
      */
     switch (c) {
-    case K_EVENT:
-      event_process();
-      // Force a redraw even though the command line didn't change
-      shell_resized();
-      goto cmdline_not_changed;
     case K_BS:
     case Ctrl_H:
     case K_DEL:
@@ -1885,8 +1879,6 @@ redraw:
       }
 
       if (IS_SPECIAL(c1)) {
-        // Process deferred events
-        event_process();
         // Ignore other special key codes
         continue;
       }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -49,7 +49,6 @@
 #include "nvim/term.h"
 #include "nvim/ui.h"
 #include "nvim/undo.h"
-#include "nvim/os/event.h"
 #include "nvim/os/input.h"
 
 /*
@@ -2481,7 +2480,6 @@ inchar (
       char_u dum[DUM_LEN + 1];
 
       for (;; ) {
-        event_process();
         len = ui_inchar(dum, DUM_LEN, 0L, 0);
         if (len == 0 || (len == 1 && dum[0] == 3))
           break;
@@ -3753,7 +3751,7 @@ eval_map_expr (
 
 static bool is_user_input(int k)
 {
-  return k != (int)KE_EVENT && k != (int)KE_CURSORHOLD;
+  return k != (int)KE_CURSORHOLD;
 }
 
 /*

--- a/src/nvim/keymap.h
+++ b/src/nvim/keymap.h
@@ -266,7 +266,6 @@ enum key_extra {
   , KE_NOP              /* doesn't do something */
   , KE_FOCUSGAINED      /* focus gained */
   , KE_FOCUSLOST        /* focus lost */
-  , KE_EVENT            // event
 };
 
 /*
@@ -463,7 +462,6 @@ enum key_extra {
 #define K_FOCUSLOST     TERMCAP2KEY(KS_EXTRA, KE_FOCUSLOST)
 
 #define K_CURSORHOLD    TERMCAP2KEY(KS_EXTRA, KE_CURSORHOLD)
-#define K_EVENT         TERMCAP2KEY(KS_EXTRA, KE_EVENT)
 
 /* Bits for modifier mask */
 /* 0x01 cannot be used, because the modifier must be 0x02 or higher */

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -44,7 +44,6 @@
 #include "nvim/term.h"
 #include "nvim/ui.h"
 #include "nvim/os/os.h"
-#include "nvim/os/event.h"
 
 /*
  * To be able to scroll back at the "more" and "hit-enter" prompts we need to
@@ -2076,9 +2075,6 @@ static int do_more_prompt(int typed_char)
 
     toscroll = 0;
     switch (c) {
-    case K_EVENT:
-      event_process();
-      break;
     case BS:                    /* scroll one line back */
     case K_BS:
     case 'k':
@@ -2738,8 +2734,6 @@ do_dialog (
       break;
     default:                  /* Could be a hotkey? */
       if (c < 0) {            /* special keys are ignored here */
-        // drain event queue to prevent infinite loop
-        event_process();
         continue;
       }
       if (c == ':' && ex_cmd) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -59,7 +59,6 @@
 #include "nvim/ui.h"
 #include "nvim/undo.h"
 #include "nvim/window.h"
-#include "nvim/os/event.h"
 
 /*
  * The Visual area is remembered for reselection.
@@ -312,7 +311,6 @@ static const struct nv_cmd {
   {K_F8,      farsi_fkey,     0,                      0},
   {K_F9,      farsi_fkey,     0,                      0},
   {K_CURSORHOLD, nv_cursorhold, NV_KEEPREG,           0},
-  {K_EVENT,   nv_event,       NV_KEEPREG,             0},
 };
 
 /* Number of commands in nv_cmds[]. */
@@ -7372,9 +7370,4 @@ static void nv_cursorhold(cmdarg_T *cap)
   apply_autocmds(EVENT_CURSORHOLD, NULL, NULL, false, curbuf);
   did_cursorhold = true;
   cap->retval |= CA_COMMAND_BUSY;       /* don't call edit() now */
-}
-
-static void nv_event(cmdarg_T *cap)
-{
-  event_process();
 }


### PR DESCRIPTION
My second attempt at removing K_EVENT for handling arbitrary events
- Remove K_EVENT special key
- Process all events directly in event_poll(remove deferred queue)

This should remove problems with K_EVENT interrupting operator-pending mode or insert-mode completion.
