### PR TITLE
[RFC] Allow all tests to pass with nocp

### DIFF
--- a/src/nvim/testdir/dotest.in
+++ b/src/nvim/testdir/dotest.in
@@ -1,3 +1,3 @@
-:set nocp
+:set nocp nomore
 :map dotest /^STARTTESTj:set ff=unix cpo-=A:.,/ENDTEST/-1w! Xdotest:set ff& cpo+=Anj0:so! Xdotestdotest
 dotest

--- a/src/nvim/testdir/dotest.in
+++ b/src/nvim/testdir/dotest.in
@@ -1,3 +1,3 @@
-:set cp
+:set nocp
 :map dotest /^STARTTESTj:set ff=unix cpo-=A:.,/ENDTEST/-1w! Xdotest:set ff& cpo+=Anj0:so! Xdotestdotest
 dotest

--- a/src/nvim/testdir/test40.in
+++ b/src/nvim/testdir/test40.in
@@ -2,6 +2,7 @@ Test for "*Cmd" autocommands
 
 STARTTEST
 :so small.vim
+:set wildchar=^E
 :/^start/,$w! Xxx		" write lines below to Xxx
 :au BufReadCmd XtestA 0r Xxx|$del
 :e XtestA			" will read text of Xxd instead

--- a/src/nvim/testdir/test48.in
+++ b/src/nvim/testdir/test48.in
@@ -4,7 +4,7 @@ STARTTEST
 :so small.vim
 :set noswf
 :set ve=all
--dgg
+j-dgg
 :"
 :"   Insert "keyword keyw", ESC, C CTRL-N, shows "keyword ykeyword".
 :"    Repeating CTRL-N fixes it. (Mary Ellen Foster)

--- a/src/nvim/testdir/test60.in
+++ b/src/nvim/testdir/test60.in
@@ -2,6 +2,7 @@ Tests for the exists() and has() functions.  vim: set ft=vim ts=8 sw=2 :
 
 STARTTEST
 :so small.vim
+:set wildchar=^E
 :function! RunTest(str, result)
     if exists(a:str) == a:result
 	echo "OK"

--- a/src/nvim/testdir/test68.in
+++ b/src/nvim/testdir/test68.in
@@ -30,7 +30,7 @@ STARTTEST
 /^{/+1
 :set tw=3 fo=t
 gqgqo
-a 
+a 
 ENDTEST
 
 {
@@ -99,7 +99,7 @@ ENDTEST
 STARTTEST
 /^{/+2
 :set tw& fo=a
-I^^
+I^^
 ENDTEST
 
 {

--- a/src/nvim/testdir/test69.in
+++ b/src/nvim/testdir/test69.in
@@ -15,7 +15,7 @@ STARTTEST
 :set tw=2 fo=t
 gqgqjgqgqo
 ＸＹＺ
-abc ＸＹＺ
+abc ＸＹＺ
 ENDTEST
 
 {
@@ -31,7 +31,7 @@ gqgqjgqgqjgqgqjgqgqjgqgqo
 Ｘa
 Ｘ a
 ＸＹ
-Ｘ Ｙ
+Ｘ Ｙ
 ENDTEST
 
 {
@@ -55,7 +55,7 @@ aＸ
 abＸ
 abcＸ
 abＸ c
-abＸＹ
+abＸＹ
 ENDTEST
 
 {
@@ -110,7 +110,7 @@ gqgqjgqgqjgqgqjgqgqjgqgqjgqgqjgqgqjgqgqjgqgqjgqgqo
 Ｘ ＹＺ
 ＸＸ
 ＸＸa
-ＸＸＹ
+ＸＸＹ
 ENDTEST
 
 {

--- a/src/nvim/testdir/test_breakindent.in
+++ b/src/nvim/testdir/test_breakindent.in
@@ -3,6 +3,7 @@ Test for breakindent
 STARTTEST
 :so small.vim
 :if !exists("+breakindent") | e! test.ok | w! test.out | qa! | endif
+:set wildchar=^E
 :10new|:vsp|:vert resize 20
 :put =\"\tabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP\"
 :set ts=4 sw=4 sts=4 breakindent

--- a/src/nvim/testdir/test_breakindent.ok
+++ b/src/nvim/testdir/test_breakindent.ok
@@ -33,13 +33,13 @@ Test 4: Simple breakindent + min width: 18
 
  Test 7: breakindent + shift by +1 + nu + sbr=? briopt:sbr
   2     ab
-?        m
-?        x
+    ?    m
+    ?    x
 
  Test 8: breakindent + shift:1 + nu + sbr=# list briopt:sbr
   2 ^Iabcd
-#      opq
-#      BCD
+    #  opq
+    #  BCD
 
  Test 9: breakindent + shift by +1 + 'nu' + sbr=# list
   2 ^Iabcd

--- a/src/nvim/testdir/test_listlbr.in
+++ b/src/nvim/testdir/test_listlbr.in
@@ -3,6 +3,7 @@ Test for linebreak and list option (non-utf8)
 STARTTEST
 :so small.vim
 :if !exists("+linebreak") | e! test.ok | w! test.out | qa! | endif
+:set wildchar=^E
 :10new|:vsp|:vert resize 20
 :put =\"\tabcdef hijklmn\tpqrstuvwxyz_1060ABCDEFGHIJKLMNOP \"
 :norm! zt

--- a/src/nvim/testdir/test_listlbr_utf8.in
+++ b/src/nvim/testdir/test_listlbr_utf8.in
@@ -3,6 +3,7 @@ Test for linebreak and list option in utf-8 mode
 STARTTEST
 :so small.vim
 :if !exists("+linebreak") | e! test.ok | w! test.out | qa! | endif
+:set wildchar=^E
 :so mbyte.vim
 :if &enc !=? 'utf-8'|:e! test.ok|:w! test.out|qa!|endif
 :10new|:vsp|:vert resize 20

--- a/test/functional/legacy/033_lisp_indent_spec.lua
+++ b/test/functional/legacy/033_lisp_indent_spec.lua
@@ -22,7 +22,7 @@ describe('lisp indent', function()
       :if-exists :supersede)
       (let ((,ti ,title))
       (as title ,ti)
-      (with center
+      (with center 
       (as h2 (string-upcase ,ti)))
       (brs 3)
       ,@body))))
@@ -35,7 +35,7 @@ describe('lisp indent', function()
       ,@body
       (princ "</a>")))]])
 
-    execute('set lisp expandtab')
+    execute('set lisp')
     execute('/^(defun')
     feed('=G:/^(defun/,$yank A<cr>')
 
@@ -52,15 +52,15 @@ describe('lisp indent', function()
       (defmacro page (name title &rest body)
         (let ((ti (gensym)))
           `(with-open-file (*standard-output*
-                             (html-file ,name)
-                             :direction :output
-                             :if-exists :supersede)
+      		       (html-file ,name)
+      		       :direction :output
+      		       :if-exists :supersede)
              (let ((,ti ,title))
-               (as title ,ti)
-               (with center
-                     (as h2 (string-upcase ,ti)))
-               (brs 3)
-               ,@body))))
+      	 (as title ,ti)
+      	 (with center 
+      	       (as h2 (string-upcase ,ti)))
+      	 (brs 3)
+      	 ,@body))))
       
       ;;; Utilities for generating links
       


### PR DESCRIPTION
This is a follow up on #671. I can now run `make oldtest` with `nocompatible` without any errors.
