### PR TITLE
runtime: Refer to plugins running outside Nvim as "remote plugins"

### DIFF
--- a/runtime/autoload/provider/python.vim
+++ b/runtime/autoload/provider/python.vim
@@ -11,11 +11,11 @@ let s:loaded_python_provider = 1
 let s:plugin_path = expand('<sfile>:p:h').'/script_host.py'
 " The python provider plugin will run in a separate instance of the python
 " host.
-call rpc#host#RegisterClone('legacy-python-provider', 'python')
-call rpc#host#RegisterPlugin('legacy-python-provider', s:plugin_path, [])
+call remote#host#RegisterClone('legacy-python-provider', 'python')
+call remote#host#RegisterPlugin('legacy-python-provider', s:plugin_path, [])
 " Ensure that we can load the python host before bootstrapping
 try
-  let s:host = rpc#host#Require('legacy-python-provider')
+  let s:host = remote#host#Require('legacy-python-provider')
 catch
   echomsg v:exception
   finish

--- a/runtime/autoload/remote/define.vim
+++ b/runtime/autoload/remote/define.vim
@@ -1,4 +1,4 @@
-function! rpc#define#CommandOnHost(host, method, sync, name, opts)
+function! remote#define#CommandOnHost(host, method, sync, name, opts)
   let prefix = ''
 
   if has_key(a:opts, 'range') 
@@ -28,7 +28,7 @@ function! rpc#define#CommandOnHost(host, method, sync, name, opts)
   endif
 
   exe s:GetCommandPrefix(a:name, a:opts)
-        \ .' call rpc#define#CommandBootstrap("'.a:host.'"'
+        \ .' call remote#define#CommandBootstrap("'.a:host.'"'
         \ .                                ', "'.a:method.'"'
         \ .                                ', "'.a:sync.'"'
         \ .                                ', "'.a:name.'"'
@@ -38,11 +38,11 @@ function! rpc#define#CommandOnHost(host, method, sync, name, opts)
 endfunction
 
 
-function! rpc#define#CommandBootstrap(host, method, sync, name, opts, forward)
-  let channel = rpc#host#Require(a:host)
+function! remote#define#CommandBootstrap(host, method, sync, name, opts, forward)
+  let channel = remote#host#Require(a:host)
 
   if channel
-    call rpc#define#CommandOnChannel(channel, a:method, a:sync, a:name, a:opts)
+    call remote#define#CommandOnChannel(channel, a:method, a:sync, a:name, a:opts)
     exe a:forward
   else
     exe 'delcommand '.a:name
@@ -51,7 +51,7 @@ function! rpc#define#CommandBootstrap(host, method, sync, name, opts, forward)
 endfunction
 
 
-function! rpc#define#CommandOnChannel(channel, method, sync, name, opts)
+function! remote#define#CommandOnChannel(channel, method, sync, name, opts)
   let rpcargs = [a:channel, '"'.a:method.'"']
   if has_key(a:opts, 'nargs')
     " -nargs, pass arguments in a list
@@ -87,12 +87,12 @@ function! rpc#define#CommandOnChannel(channel, method, sync, name, opts)
 endfunction
 
 
-function! rpc#define#AutocmdOnHost(host, method, sync, name, opts)
+function! remote#define#AutocmdOnHost(host, method, sync, name, opts)
   let group = s:GetNextAutocmdGroup()
   let forward = '"doau '.group.' '.a:name.' ".'.'expand("<amatch>")'
   let a:opts.group = group
   let bootstrap_def = s:GetAutocmdPrefix(a:name, a:opts)
-        \ .' call rpc#define#AutocmdBootstrap("'.a:host.'"'
+        \ .' call remote#define#AutocmdBootstrap("'.a:host.'"'
         \ .                                ', "'.a:method.'"'
         \ .                                ', "'.a:sync.'"'
         \ .                                ', "'.a:name.'"'
@@ -103,12 +103,12 @@ function! rpc#define#AutocmdOnHost(host, method, sync, name, opts)
 endfunction
 
 
-function! rpc#define#AutocmdBootstrap(host, method, sync, name, opts, forward)
-  let channel = rpc#host#Require(a:host)
+function! remote#define#AutocmdBootstrap(host, method, sync, name, opts, forward)
+  let channel = remote#host#Require(a:host)
 
   exe 'autocmd! '.a:opts.group
   if channel
-    call rpc#define#AutocmdOnChannel(channel, a:method, a:sync, a:name,
+    call remote#define#AutocmdOnChannel(channel, a:method, a:sync, a:name,
           \ a:opts)
     exe eval(a:forward)
   else
@@ -118,7 +118,7 @@ function! rpc#define#AutocmdBootstrap(host, method, sync, name, opts, forward)
 endfunction
 
 
-function! rpc#define#AutocmdOnChannel(channel, method, sync, name, opts)
+function! remote#define#AutocmdOnChannel(channel, method, sync, name, opts)
   let rpcargs = [a:channel, '"'.a:method.'"']
   call s:AddEval(rpcargs, a:opts)
 
@@ -128,10 +128,10 @@ function! rpc#define#AutocmdOnChannel(channel, method, sync, name, opts)
 endfunction
 
 
-function! rpc#define#FunctionOnHost(host, method, sync, name, opts)
+function! remote#define#FunctionOnHost(host, method, sync, name, opts)
   let group = s:GetNextAutocmdGroup()
   exe 'autocmd! '.group.' FuncUndefined '.a:name
-        \ .' call rpc#define#FunctionBootstrap("'.a:host.'"'
+        \ .' call remote#define#FunctionBootstrap("'.a:host.'"'
         \ .                                 ', "'.a:method.'"'
         \ .                                 ', "'.a:sync.'"'
         \ .                                 ', "'.a:name.'"'
@@ -141,13 +141,13 @@ function! rpc#define#FunctionOnHost(host, method, sync, name, opts)
 endfunction
 
 
-function! rpc#define#FunctionBootstrap(host, method, sync, name, opts, group)
-  let channel = rpc#host#Require(a:host)
+function! remote#define#FunctionBootstrap(host, method, sync, name, opts, group)
+  let channel = remote#host#Require(a:host)
 
   exe 'autocmd! '.a:group
   exe 'augroup! '.a:group
   if channel
-    call rpc#define#FunctionOnChannel(channel, a:method, a:sync, a:name,
+    call remote#define#FunctionOnChannel(channel, a:method, a:sync, a:name,
           \ a:opts)
   else
     echoerr 'Host "'a:host.'" for "'.a:name.'" function is not available'
@@ -155,7 +155,7 @@ function! rpc#define#FunctionBootstrap(host, method, sync, name, opts, group)
 endfunction
 
 
-function! rpc#define#FunctionOnChannel(channel, method, sync, name, opts)
+function! remote#define#FunctionOnChannel(channel, method, sync, name, opts)
   let rpcargs = [a:channel, '"'.a:method.'"', 'a:000']
   call s:AddEval(rpcargs, a:opts)
 

--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -21,7 +21,7 @@ DOCS = \
 	digraph.txt \
 	editing.txt \
 	eval.txt \
-	external_plugin.txt \
+	remote_plugin.txt \
 	farsi.txt \
 	filetype.txt \
 	fold.txt \
@@ -142,7 +142,7 @@ HTMLS = \
 	digraph.html \
 	editing.html \
 	eval.html \
-	external_plugin.html \
+	remote_plugin.html \
 	farsi.html \
 	filetype.html \
 	fold.html \

--- a/runtime/doc/nvim_intro.txt
+++ b/runtime/doc/nvim_intro.txt
@@ -17,7 +17,7 @@ differentiate Nvim from Vim:
 2. Job control			|job-control|
 3. Python plugins		|nvim-python|
 4. Clipboard integration	|nvim-clipboard|
-5. External plugins	  	|external-plugin|
+5. Remote plugins	  	|remote-plugin|
 6. Provider infrastructure	|nvim-provider|
 
 ==============================================================================

--- a/runtime/doc/remote_plugin.txt
+++ b/runtime/doc/remote_plugin.txt
@@ -1,22 +1,22 @@
-*external_plugin.txt*    For Nvim.					 {Nvim}
+*remote_plugin.txt*    For Nvim.					 {Nvim}
 
 
 		 NVIM REFERENCE MANUAL    by Thiago de Arruda
 
 
-Nvim support for external plugins 		  *external-plugin*
+Nvim support for remote plugins 		  *remote-plugin*
 
-1. Introduction			|external-plugin-intro|
-2. Plugin hosts			|external-plugin-hosts|
-3. Example			|external-plugin-example|
-4. Plugin manifest		|external-plugin-manifest|
+1. Introduction					|remote-plugin-intro|
+2. Plugin hosts					|remote-plugin-hosts|
+3. Example					|remote-plugin-example|
+4. Plugin manifest				|remote-plugin-manifest|
 
 ==============================================================================
-1. Introduction					    *external-plugin-intro*
+1. Introduction					    *remote-plugin-intro*
 
 A big Nvim goal is to allow extensibility in arbitrary programming languages
 without requiring direct support from the editor. This is achieved with
-external plugins, coprocesses that have a direct communication channel(via
+remote plugins, coprocesses that have a direct communication channel(via
 |msgpack-rpc|) with the Nvim process.
 
 Even though these plugins are running in separate processes, they can call, be
@@ -24,7 +24,7 @@ called, and receive events just as if the code was being executed in the main
 process.
 
 ==============================================================================
-2. Plugin hosts					    *external-plugin-hosts*
+2. Plugin hosts					    *remote-plugin-hosts*
 
 While plugins can be implemented as arbitrary programs that communicate
 directly with Nvim API and are called via |rpcrequest()| and |rpcnotify()|,
@@ -39,9 +39,9 @@ loaded the first time one of its registered plugins are required, keeping
 Nvim startup as fast a possible despite the number of installed plugins/hosts.
 
 ==============================================================================
-3. Example					    *external-plugin-example*
+3. Example					    *remote-plugin-example*
 
-The best way to learn about external plugins is with an example, so let's see
+The best way to learn about remote plugins is with an example, so let's see
 how a very useless python plugin looks like. This plugin exports a command, a
 function and an autocmd. The plugin is called 'Limit', and all it does is
 limit the number of requests made to it. Here's the plugin source code:
@@ -93,31 +93,31 @@ value. Without the "sync" flag, the call is made using a fire and forget
 approach with |rpcnotify()|(return values or exceptions raised in the handler
 function are ignored)
 
-To test the above plugin, it must be saved in "external-plugin/python" in a
-'runtimepath' directory(~/.nvim/external-plugin/python/limit.py for example).
-Then, the external plugin manifest must be generated with
-`:UpdateExternalPlugins`. 
+To test the above plugin, it must be saved in "rplugin/python" in a
+'runtimepath' directory(~/.nvim/rplugin/python/limit.py for example).
+Then, the remote plugin manifest must be generated with
+`:UpdateRemotePlugins`. 
 
 ==============================================================================
-4. External plugin manifest			    *external-plugin-manifest*
+4. remote plugin manifest			    *remote-plugin-manifest*
 
-Just installing external plugins to "external-plugin/{host}" isn't enough to
-load them at startup. The `:UpdateExternalPlugins`  command must be executed
-every time an external plugin is installed, updated, or deleted.
+Just installing remote plugins to "rplugin/{host}" isn't enough to
+load them at startup. The `:UpdateRemotePlugins`  command must be executed
+every time a remote plugin is installed, updated, or deleted.
 
-`:UpdateExternalPlugins` will generate the external plugin manifest, a special
+`:UpdateRemotePlugins` will generate the remote plugin manifest, a special
 vimscript file containing declarations for all vimscript entities
-(commands/autocommands/functions) defined by all external plugins, with each
+(commands/autocommands/functions) defined by all remote plugins, with each
 entity associated with the host and plugin path. The manifest can be seen as a
 generated extension to the user's vimrc(it even has the vimrc filename
 prepended).
 
-The manifest declarations are nothing but calls to the rpc#host#RegisterPlugin
+The manifest declarations are nothing but calls to the remote#host#RegisterPlugin
 function, which will take care of bootstrapping the host as soon as the
 declared command, autocommand or function is used for the first time.
 
 The manifest generation step is necessary to keep editor startup fast in
-situations where a user has external plugins with different hosts. For
+situations where a user has remote plugins with different hosts. For
 example, imagine a user that has three plugins, for python, java and .NET
 hosts respectively, if we were to load all three plugins at startup, then
 three language runtimes would also be spawned which could take seconds!
@@ -127,7 +127,7 @@ with the example, imagine the java plugin is a semantic completion engine for
 java files, if it defines an BufEnter *.java autocommand then the java host
 will only be spawned when java source files are loaded. 
 
-If the explicit call to `:UpdateExternalPlugins` seems incovenient, try
+If the explicit call to `:UpdateRemotePlugins` seems incovenient, try
 to see it like this: Its a way to give IDE-like capabilities to nvim while
 still keeping it a fast/lightweight editor for general use. It can also be
 seen as an analogous to the |:helptags| facility.

--- a/runtime/plugin/external_plugins.vim
+++ b/runtime/plugin/external_plugins.vim
@@ -1,5 +1,0 @@
-if exists('loaded_external_plugins') || &cp
-  finish
-endif
-let loaded_external_plugins = 1
-call rpc#host#LoadExternalPlugins()

--- a/runtime/plugin/rplugin.vim
+++ b/runtime/plugin/rplugin.vim
@@ -1,0 +1,5 @@
+if exists('loaded_remote_plugins') || &cp
+  finish
+endif
+let loaded_remote_plugins = 1
+call remote#host#LoadRemotePlugins()

--- a/test/functional/runtime/autoload/remote/define_spec.lua
+++ b/test/functional/runtime/autoload/remote/define_spec.lua
@@ -346,20 +346,20 @@ local function host()
 end
 
 local function register()
-  eval('rpc#host#Register("busted", '..channel()..')')
+  eval('remote#host#Register("busted", '..channel()..')')
 end
 
-command_specs_for('rpc#define#CommandOnChannel', true, channel)
-command_specs_for('rpc#define#CommandOnChannel', false, channel)
-command_specs_for('rpc#define#CommandOnHost', true, host, register)
-command_specs_for('rpc#define#CommandOnHost', false, host, register)
+command_specs_for('remote#define#CommandOnChannel', true, channel)
+command_specs_for('remote#define#CommandOnChannel', false, channel)
+command_specs_for('remote#define#CommandOnHost', true, host, register)
+command_specs_for('remote#define#CommandOnHost', false, host, register)
 
-autocmd_specs_for('rpc#define#AutocmdOnChannel', true, channel)
-autocmd_specs_for('rpc#define#AutocmdOnChannel', false, channel)
-autocmd_specs_for('rpc#define#AutocmdOnHost', true, host, register)
-autocmd_specs_for('rpc#define#AutocmdOnHost', false, host, register)
+autocmd_specs_for('remote#define#AutocmdOnChannel', true, channel)
+autocmd_specs_for('remote#define#AutocmdOnChannel', false, channel)
+autocmd_specs_for('remote#define#AutocmdOnHost', true, host, register)
+autocmd_specs_for('remote#define#AutocmdOnHost', false, host, register)
 
-function_specs_for('rpc#define#FunctionOnChannel', true, channel)
-function_specs_for('rpc#define#FunctionOnChannel', false, channel)
-function_specs_for('rpc#define#FunctionOnHost', true, host, register)
-function_specs_for('rpc#define#FunctionOnHost', false, host, register)
+function_specs_for('remote#define#FunctionOnChannel', true, channel)
+function_specs_for('remote#define#FunctionOnChannel', false, channel)
+function_specs_for('remote#define#FunctionOnHost', true, host, register)
+function_specs_for('remote#define#FunctionOnHost', false, host, register)


### PR DESCRIPTION
This is @elmart's suggestion. Remote is a better term than rpc or external. 

I'm tempted to also rename the msgpack-rpc functions from `rpcrequest`/`rpcnotify`/`rpcstart`/`rpcstop` to `rrequest`/`rnotify`/`rstart`/`rstop`, hiding protocol details from the public API. What do you guys think?
