### PR TITLE
[RFC] Fix functional tests failing on OSX.

### DIFF
--- a/test/functional/legacy/105_filename_modifiers_spec.lua
+++ b/test/functional/legacy/105_filename_modifiers_spec.lua
@@ -8,7 +8,9 @@ describe('filename modifiers', function()
   setup(clear)
 
   it('is working', function()
-    execute('cd /tmp')
+    local tmpdir = helpers.nvim('eval', 'resolve("/tmp")')
+
+    execute('cd ' .. tmpdir)
     execute([=[set shell=sh]=])
     execute([=[set shellslash]=])
     execute([=[let tab="\t"]=])
@@ -62,7 +64,7 @@ describe('filename modifiers', function()
       fnamemodify('abc.fb2.tar.gz', ':r'      )	'abc.fb2.tar'
       fnamemodify('abc.fb2.tar.gz', ':r:r'    )	'abc.fb2'
       fnamemodify('abc.fb2.tar.gz', ':r:r:r'  )	'abc'
-      substitute(fnamemodify('abc.fb2.tar.gz', ':p:r:r'), '.*\(nvim/testdir/.*\)', '\1', '')	'/tmp/abc.fb2'
+      substitute(fnamemodify('abc.fb2.tar.gz', ':p:r:r'), '.*\(nvim/testdir/.*\)', '\1', '')	']=] .. tmpdir .. [=[/abc.fb2'
       fnamemodify('abc.fb2.tar.gz', ':e'      )	'gz'
       fnamemodify('abc.fb2.tar.gz', ':e:e'    )	'tar.gz'
       fnamemodify('abc.fb2.tar.gz', ':e:e:e'  )	'fb2.tar.gz'


### PR DESCRIPTION
See https://github.com/neovim/neovim/issues/1519 for failure report.

```
Cause    : In OSX, /tmp is a symbolic link to /private/tmp, which causes
           expected and got results different because of implicit
           resolution.
Solution : Resolve path before setting expected value.
```

Fixes #1519.

@rainerborene I add this as a quick fix, to have functional tests passing on master. If you later want to provide another PR improving on this, it's up to you.
