### PR TITLE
[RFC] Fix Makefile for running valgrind with old tests.

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -52,13 +52,13 @@ ifdef USE_VALGRIND
 	                 --leak-check=yes    \
 	                 --track-origins=yes
 #        VALGRIND_TOOL := exp-sgcheck
-	TOOL := valgrind -q                                  \
-	                 -q                                  \
-	                 $(VALGRIND_TOOL)                    \
-	                 --suppressions=../../.valgrind.supp \
-	                 --error-exitcode=123                \
-	                 --log-file=valgrind.\%p.$*          \
-	                 $(VGDB)                             \
+	TOOL := valgrind -q                                     \
+	                 -q                                     \
+	                 $(VALGRIND_TOOL)                       \
+	                 --suppressions=../../../.valgrind.supp \
+	                 --error-exitcode=123                   \
+	                 --log-file=valgrind.\%p.$*             \
+	                 $(VGDB)                                \
 	                 --trace-children=yes
 else
 	ifdef USE_GDB


### PR DESCRIPTION
- `export USE_VALGRIND=1; make oldtest` cannot be run without this patch. 
- Also related: the Makefile uses `USE_VALGRIND`, but `.ci/gcc.sh` sets `export VALGRIND` which seems to only affct the new functional tests in `test/functional`. Is this intentional? 

Edit: sry, I forgot to add [RFC]
