### PR TITLE
[RFC] Fix newline substitution causing abort

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3602,8 +3602,13 @@ void do_sub(exarg_T *eap)
       eap->flags = EXFLAG_PRINT;
     }
 
-    do_join(eap->line2 - eap->line1 + 1, FALSE, TRUE, FALSE, true);
-    sub_nlines = sub_nsubs = eap->line2 - eap->line1 + 1;
+    linenr_T joined_lines_count = eap->line2 < curbuf->b_ml.ml_line_count
+                                  ? eap->line2 - eap->line1 + 2
+                                  : eap->line2 - eap->line1 + 1;
+    if (joined_lines_count >= 2) {
+      do_join(joined_lines_count, FALSE, TRUE, FALSE, true);
+    }
+    sub_nlines = sub_nsubs = joined_lines_count - 1;
     do_sub_msg(false);
     ex_may_print(eap);
 


### PR DESCRIPTION
Fixes #1529.

As explained there, this is one of two possible solutions, that should have to be discussed. 
But, in the meantime, it's requested for this to be merged so that master doesn't abort in that case.
