### PR TITLE
[RFC] build: print the error result when the tests fail

### DIFF
--- a/cmake/GenerateHelptags.cmake
+++ b/cmake/GenerateHelptags.cmake
@@ -22,5 +22,5 @@ execute_process(
   RESULT_VARIABLE res)
 
 if(NOT res EQUAL 0)
-  message(FATAL_ERROR "Generating helptags failed: ${err}")
+  message(FATAL_ERROR "Generating helptags failed: ${err} - ${res}")
 endif()

--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -20,5 +20,5 @@ execute_process(
   RESULT_VARIABLE res)
 
 if(NOT res EQUAL 0)
-  message(FATAL_ERROR "Running ${TEST_TYPE} tests failed.")
+  message(FATAL_ERROR "Running ${TEST_TYPE} tests failed with error: ${res}.")
 endif()


### PR DESCRIPTION
Any diagnostic information is useful when things fail.  In my case, it
printed out the fact that the tests were segfaulting.
