### PR TITLE
[RFC] add missing refcount increment for systemlist()

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14588,8 +14588,7 @@ static void get_system_output_as_rettv(typval_T *argvars, typval_T *rettv,
   if (res == NULL) {
     if (retlist) {
       // return an empty list when there's no output
-      rettv->v_type = VAR_LIST;
-      rettv->vval.v_list = list_alloc();
+      rettv_list_alloc(rettv);
     }
     return;
   }


### PR DESCRIPTION
- get_system_output_as_rettv() was missing a refcount increment when
  returning an empty list, i.e. when there was no output
- we now use rettv_list_aloc() instead of list_alloc()
- issue #1530
