### PR TITLE
[RFC] Avoid printing an error response when detecting xclip.

### DIFF
--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -22,11 +22,9 @@ end
 
 -- Some tests require the xclip program and a x server.
 local xclip = nil
-do 
+do
   if os.getenv('DISPLAY') then
-    local proc = io.popen('which xclip') 
-    xclip = proc:read()
-    proc:close()
+    xclip = (os.execute('command -v xclip > /dev/null 2>&1') == 0)
   end
 end
 


### PR DESCRIPTION
While we're at, using the slightly more portable hash technique to
detect the executable.  Also, there's no need to use `io.popen()` if we
aren't going to record the path.  Instead, let's use the simpler
`os.execute()` to detect the presence of xclip.
