### PR TITLE
[RFC] Change refs for joyent/libuv repo to libuv/libuv

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For lots more details, see
 
 ### What's being worked on now
 
-- Port all IO to [libuv](https://github.com/joyent/libuv/blob/master/README.md)
+- Port all IO to [libuv](https://github.com/libuv/libuv/blob/master/README.md)
 - Lots of refactoring
 - A VimL => Lua transpiler
 

--- a/runtime/doc/job_control.txt
+++ b/runtime/doc/job_control.txt
@@ -31,7 +31,7 @@ facilities for calling with external commands, job control does not depend
 on installed shells, calling OS functions for process management directly.
 
 Internally, Nvim job control is powered by libuv, which has a nice
-cross-platform API for managing processes. See https://github.com/joyent/libuv
+cross-platform API for managing processes. See https://github.com/libuv/libuv
 for details
 
 ==============================================================================

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 
 include(ExternalProject)
 
-set(LIBUV_URL https://github.com/joyent/libuv/archive/v0.11.28.tar.gz)
+set(LIBUV_URL https://github.com/libuv/libuv/archive/v0.11.28.tar.gz)
 set(LIBUV_SHA1 3b70b65467ee693228b8b8385665a52690d74092)
 set(LIBUV_MD5 1a849ba4fc571d531482ed74bc7aabc4)
 


### PR DESCRIPTION
- References to old repository found through grepping
- Replace references from github.com/joyent/libuv to
  github.com/libuv/libuv

For issue #1560. First pull request -- please provide comments/ feedback.
