### PR TITLE
[RDY] systemlist: add `keepempty` option to preserve final newline

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6188,11 +6188,12 @@ system({expr} [, {input}])				*system()* *E677*
 		Use |:checktime| to force a check.
 
 
-systemlist({expr} [, {input}])				*systemlist()*
+systemlist({expr} [, {input} [, {keepempty}]])		*systemlist()*
 		Same as |system()|, but returns a |List| with lines (parts of 
 		output separated by NL) with NULs transformed into NLs. Output 
 		is the same as |readfile()| will output with {binary} argument 
-		set to "b".
+		set to "b", except that a final newline is not preserved,
+		unless {keepempty} is present and it's non-zero.
 
 		Returns an empty string on error, so be careful not to run 
 		into |E706|.

--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -188,6 +188,16 @@ describe('systemlist()', function()
     end)
   end)
 
+  describe('handles empty lines', function()
+    it('in the middle', function()
+      eq({'line one','','line two'}, eval("systemlist('cat',['line one','','line two'])"))
+    end)
+
+    it('in the beginning', function()
+      eq({'','line one','line two'}, eval("systemlist('cat',['','line one','line two'])"))
+    end)
+  end)
+
   describe('when keepempty option is', function()
     it('0, ignores trailing newline', function()
       eq({'aa','bb'}, eval("systemlist('cat',['aa','bb'],0)"))

--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -188,6 +188,18 @@ describe('systemlist()', function()
     end)
   end)
 
+  describe('when keepempty option is', function()
+    it('0, ignores trailing newline', function()
+      eq({'aa','bb'}, eval("systemlist('cat',['aa','bb'],0)"))
+      eq({'aa','bb'}, eval("systemlist('cat',['aa','bb',''],0)"))
+    end)
+
+    it('1, preserves trailing newline', function()
+      eq({'aa','bb'}, eval("systemlist('cat',['aa','bb'],1)"))
+      eq({'aa','bb',''}, eval("systemlist('cat',['aa','bb',''],2)"))
+    end)
+  end)
+
   if xclip then
     describe("with a program that doesn't close stdout", function()
       it('will exit properly after passing input', function()


### PR DESCRIPTION
Broken out of #1182 , this adds an option to `systemlist()` to preserve information about about the final newline ( it is named as `keepempty` of `split()`. ) Also update the documentation of the present behaviour.
