### PR TITLE
[RDY] Fix SegFault when entering Command(q:) or Search(q/) History

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -479,7 +479,7 @@ char_u *vim_strbyte(const char_u *string, int c)
  * Does not handle multi-byte char for "c"!
  */
 char_u *vim_strrchr(const char_u *string, int c)
-  FUNC_ATTR_NONNULL_RET FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
   const char_u *retval = NULL;
   const char_u *p = string;


### PR DESCRIPTION
Real issue was found (see conversation)
I've amended the commit to remove FUNC_ATTR_NONNULL_RET from vim_strrchr
old:
For some reason `if ((p = vim_strrchr(fname, '/')) != NULL)` was firing even when `vim_strrchr(fname, '/')` returns NULL. Control reaches `STRNCPY(relative_directory, fname, p-fname);` with `p == 0`, so the `p-fname` causes a segfault. This happened in both debug and release builds.
I do not know if this issue is present across more machines but this PR fixes it for me at least.

On the off chance of it being a system specific issue here are my details:
Ubuntu 14.10 64bit
Intel Core i7-2630QM
gcc version 4.9.1
