### PR TITLE
[RFC] Dont force ../.deps in third-party/CMakeLists.txt use the Makefile instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,8 @@ project(NEOVIM)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # Prefer our bundled versions of dependencies.
-set(DEPS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.deps")
-set(DEPS_BUILD_DIR "${DEPS_DIR}/build")
-set(DEPS_INSTALL_DIR "${DEPS_DIR}/usr")
-set(DEPS_BIN_DIR "${DEPS_INSTALL_DIR}/bin")
-
-list(APPEND CMAKE_PREFIX_PATH ${DEPS_INSTALL_DIR})
+set(DEPS_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/.deps/usr" CACHE PATH "Path prefix for finding dependencies")
+list(INSERT CMAKE_PREFIX_PATH 0 ${DEPS_PREFIX})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   # CMake tries to treat /sw and /opt/local as extension of the system path, but

--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,15 @@ build/.ran-cmake: | deps
 
 deps: | build/.ran-third-party-cmake
 ifeq ($(call filter-true,$(USE_BUNDLED_DEPS)),)
-	+$(BUILD_CMD) -C .deps/build/third-party
+	+$(BUILD_CMD) -C .deps
 endif
 
 build/.ran-third-party-cmake:
 ifeq ($(call filter-true,$(USE_BUNDLED_DEPS)),)
-	mkdir -p .deps/build/third-party
-	cd .deps/build/third-party && \
+	mkdir -p .deps
+	cd .deps && \
 		cmake -G '$(BUILD_TYPE)' $(BUNDLED_CMAKE_FLAG) \
-		$(DEPS_CMAKE_FLAGS) ../../../third-party
+		$(DEPS_CMAKE_FLAGS) ../third-party
 endif
 	mkdir -p build
 	touch $@

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -2,15 +2,10 @@
 cmake_minimum_required (VERSION 2.8.7)
 project(NEOVIM_DEPS)
 
-if(NOT DEPS_DIR)
-  get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH)
-  set(DEPS_DIR ${PARENT_DIR}/.deps)
-endif()
-
-set(DEPS_INSTALL_DIR "${DEPS_DIR}/usr")
-set(DEPS_BIN_DIR "${DEPS_DIR}/usr/bin")
-set(DEPS_LIB_DIR "${DEPS_DIR}/usr/lib")
-set(DEPS_BUILD_DIR "${DEPS_DIR}/build")
+set(DEPS_INSTALL_DIR "${CMAKE_BINARY_DIR}/usr")
+set(DEPS_BIN_DIR "${CMAKE_BINARY_DIR}/usr/bin")
+set(DEPS_LIB_DIR "${CMAKE_BINARY_DIR}/usr/lib")
+set(DEPS_BUILD_DIR "${CMAKE_BINARY_DIR}/build")
 set(DEPS_DOWNLOAD_DIR "${DEPS_BUILD_DIR}/downloads")
 
 option(USE_BUNDLED "Use bundled dependencies." ON)


### PR DESCRIPTION
- third-party is built under .deps by default instead of using its own
  ${CMAKE_BINARY_DIR}, move this default setting out of the cmake
  settings and into the Makefile.
- As a consequence the workflow of building third-party using CMake
  should feel more natural, avoid the additional folder or setting
  DEPS_DIR from the command line.
- This commit does not change the default behaviour when calling the
  Makefile wrapper.

i.e. to build deps in an alternative location just

```
mkdir deps2 && cd deps2 && cmake ../third-party
```

instead of 

```
mkdir deps2 && cd deps2 && cmake ../third-party -DDEPS_DIR=.
```

EDIT: Switched text to reflect new purpose.
