### PR TITLE
[RDY] Prepare to rewrite the terminal UI

### DIFF
--- a/cmake/FindLibTermkey.cmake
+++ b/cmake/FindLibTermkey.cmake
@@ -1,0 +1,48 @@
+# - Try to find libtermkey
+# Once done this will define
+#  LIBTERMKEY_FOUND - System has libtermkey
+#  LIBTERMKEY_INCLUDE_DIRS - The libtermkey include directories
+#  LIBTERMKEY_LIBRARIES - The libraries needed to use libtermkey
+
+find_package(PkgConfig)
+if(NOT LIBTERMKEY_USE_BUNDLED)
+  find_package(PkgConfig)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_LIBTERMKEY QUIET libtermkey)
+  endif()
+else()
+  set(PC_LIBTERMKEY_INCLUDEDIR)
+  set(PC_LIBTERMKEY_INCLUDE_DIRS)
+  set(PC_LIBTERMKEY_LIBDIR)
+  set(PC_LIBTERMKEY_LIBRARY_DIRS)
+  set(LIMIT_SEARCH NO_DEFAULT_PATH)
+endif()
+
+set(LIBTERMKEY_DEFINITIONS ${PC_LIBTERMKEY_CFLAGS_OTHER})
+
+find_path(LIBTERMKEY_INCLUDE_DIR termkey.h
+          PATHS ${PC_LIBTERMKEY_INCLUDEDIR} ${PC_LIBTERMKEY_INCLUDE_DIRS}
+          ${LIMIT_SEARCH})
+
+# If we're asked to use static linkage, add libuv.a as a preferred library name.
+if(LIBTERMKEY_USE_STATIC)
+  list(APPEND LIBTERMKEY_NAMES
+    "${CMAKE_STATIC_LIBRARY_PREFIX}termkey${CMAKE_STATIC_LIBRARY_SUFFIX}")
+endif()
+
+list(APPEND LIBTERMKEY_NAMES termkey)
+
+find_library(LIBTERMKEY_LIBRARY NAMES ${LIBTERMKEY_NAMES}
+  HINTS ${PC_LIBTERMKEY_LIBDIR} ${PC_LIBTERMKEY_LIBRARY_DIRS}
+  ${LIMIT_SEARCH})
+
+set(LIBTERMKEY_LIBRARIES ${LIBTERMKEY_LIBRARY})
+set(LIBTERMKEY_INCLUDE_DIRS ${LIBTERMKEY_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set LIBTERMKEY_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(LibTermkey DEFAULT_MSG
+  LIBTERMKEY_LIBRARY LIBTERMKEY_INCLUDE_DIR)
+
+mark_as_advanced(LIBTERMKEY_INCLUDE_DIR LIBTERMKEY_LIBRARY)

--- a/cmake/FindLibTickit.cmake
+++ b/cmake/FindLibTickit.cmake
@@ -1,0 +1,48 @@
+# - Try to find libtickit
+# Once done this will define
+#  LIBTICKIT_FOUND - System has libtickit
+#  LIBTICKIT_INCLUDE_DIRS - The libtickit include directories
+#  LIBTICKIT_LIBRARIES - The libraries needed to use libtickit
+
+find_package(PkgConfig)
+if(NOT LIBTICKIT_USE_BUNDLED)
+  find_package(PkgConfig)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_LIBTICKIT QUIET libtickit)
+  endif()
+else()
+  set(PC_LIBTICKIT_INCLUDEDIR)
+  set(PC_LIBTICKIT_INCLUDE_DIRS)
+  set(PC_LIBTICKIT_LIBDIR)
+  set(PC_LIBTICKIT_LIBRARY_DIRS)
+  set(LIMIT_SEARCH NO_DEFAULT_PATH)
+endif()
+
+set(LIBTICKIT_DEFINITIONS ${PC_LIBTICKIT_CFLAGS_OTHER})
+
+find_path(LIBTICKIT_INCLUDE_DIR tickit.h
+          PATHS ${PC_LIBTICKIT_INCLUDEDIR} ${PC_LIBTICKIT_INCLUDE_DIRS}
+          ${LIMIT_SEARCH})
+
+# If we're asked to use static linkage, add libuv.a as a preferred library name.
+if(LIBTICKIT_USE_STATIC)
+  list(APPEND LIBTICKIT_NAMES
+    "${CMAKE_STATIC_LIBRARY_PREFIX}tickit${CMAKE_STATIC_LIBRARY_SUFFIX}")
+endif()
+
+list(APPEND LIBTICKIT_NAMES tickit)
+
+find_library(LIBTICKIT_LIBRARY NAMES ${LIBTICKIT_NAMES}
+  HINTS ${PC_LIBTICKIT_LIBDIR} ${PC_LIBTICKIT_LIBRARY_DIRS}
+  ${LIMIT_SEARCH})
+
+set(LIBTICKIT_LIBRARIES ${LIBTICKIT_LIBRARY})
+set(LIBTICKIT_INCLUDE_DIRS ${LIBTICKIT_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set LIBTICKIT_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(LibTickit DEFAULT_MSG
+  LIBTICKIT_LIBRARY LIBTICKIT_INCLUDE_DIR)
+
+mark_as_advanced(LIBTICKIT_INCLUDE_DIR LIBTICKIT_LIBRARY)

--- a/cmake/FindLibUnibilium.cmake
+++ b/cmake/FindLibUnibilium.cmake
@@ -1,0 +1,48 @@
+# - Try to find libunibilium
+# Once done this will define
+#  LIBUNIBILIUM_FOUND - System has libunibilium
+#  LIBUNIBILIUM_INCLUDE_DIRS - The libunibilium include directories
+#  LIBUNIBILIUM_LIBRARIES - The libraries needed to use libunibilium
+
+find_package(PkgConfig)
+if(NOT LIBUNIBILIUM_USE_BUNDLED)
+  find_package(PkgConfig)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_LIBUNIBILIUM QUIET libunibilium)
+  endif()
+else()
+  set(PC_LIBUNIBILIUM_INCLUDEDIR)
+  set(PC_LIBUNIBILIUM_INCLUDE_DIRS)
+  set(PC_LIBUNIBILIUM_LIBDIR)
+  set(PC_LIBUNIBILIUM_LIBRARY_DIRS)
+  set(LIMIT_SEARCH NO_DEFAULT_PATH)
+endif()
+
+set(LIBUNIBILIUM_DEFINITIONS ${PC_LIBUNIBILIUM_CFLAGS_OTHER})
+
+find_path(LIBUNIBILIUM_INCLUDE_DIR unibilium.h
+          PATHS ${PC_LIBUNIBILIUM_INCLUDEDIR} ${PC_LIBUNIBILIUM_INCLUDE_DIRS}
+          ${LIMIT_SEARCH})
+
+# If we're asked to use static linkage, add libuv.a as a preferred library name.
+if(LIBUNIBILIUM_USE_STATIC)
+  list(APPEND LIBUNIBILIUM_NAMES
+    "${CMAKE_STATIC_LIBRARY_PREFIX}unibilium${CMAKE_STATIC_LIBRARY_SUFFIX}")
+endif()
+
+list(APPEND LIBUNIBILIUM_NAMES unibilium)
+
+find_library(LIBUNIBILIUM_LIBRARY NAMES ${LIBUNIBILIUM_NAMES}
+  HINTS ${PC_LIBUNIBILIUM_LIBDIR} ${PC_LIBUNIBILIUM_LIBRARY_DIRS}
+  ${LIMIT_SEARCH})
+
+set(LIBUNIBILIUM_LIBRARIES ${LIBUNIBILIUM_LIBRARY})
+set(LIBUNIBILIUM_INCLUDE_DIRS ${LIBUNIBILIUM_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set LIBUNIBILIUM_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(LibUnibilium DEFAULT_MSG
+  LIBUNIBILIUM_LIBRARY LIBUNIBILIUM_INCLUDE_DIR)
+
+mark_as_advanced(LIBUNIBILIUM_INCLUDE_DIR LIBUNIBILIUM_LIBRARY)

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -47,6 +47,7 @@
 #include "nvim/garray.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"
+#include "nvim/mouse.h"
 #include "nvim/normal.h"
 #include "nvim/ops.h"
 #include "nvim/option.h"

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -157,7 +157,6 @@ void do_debug(char_u *cmd)
 
   /* Make sure we are in raw mode and start termcap mode.  Might have side
    * effects... */
-  settmode(TMODE_RAW);
   starttermcap();
 
   ++RedrawingDisabled;          /* don't redisplay the window */

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6446,7 +6446,7 @@ static void ex_winsize(exarg_T *eap)
   p = arg;
   h = getdigits(&arg);
   if (*p != NUL && *arg == NUL)
-    set_shellsize(w, h, TRUE);
+    screen_resize(w, h, TRUE);
   else
     EMSG(_("E465: :winsize requires two number arguments"));
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5107,7 +5107,6 @@ static void ex_highlight(exarg_T *eap)
 void not_exiting(void)
 {
   exiting = FALSE;
-  settmode(TMODE_RAW);
 }
 
 /*
@@ -5994,7 +5993,6 @@ do_exedit (
 {
   int n;
   int need_hide;
-  int exmode_was = exmode_active;
 
   /*
    * ":vi" command ends Ex mode.
@@ -6014,8 +6012,6 @@ do_exedit (
           eap->nextcmd = NULL;
         }
 
-        if (exmode_was != EXMODE_VIM)
-          settmode(TMODE_RAW);
         RedrawingDisabled = 0;
         no_wait_return = 0;
         need_wait_return = FALSE;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -48,6 +48,7 @@
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
+#include "nvim/mouse.h"
 #include "nvim/ops.h"
 #include "nvim/option.h"
 #include "nvim/os_unix.h"

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -270,10 +270,6 @@ getcmdline (
   setmouse();
   ui_cursor_shape();            /* may show different cursor shape */
 
-  /* When inside an autocommand for writing "exiting" may be set and
-  * terminal mode set to cooked.  Need to set raw mode here then. */
-  settmode(TMODE_RAW);
-
   init_history();
   hiscnt = hislen;              /* set hiscnt to impossible history value */
   histype = hist_char2type(firstc);

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1812,7 +1812,6 @@ failed:
      * Switch on raw mode now and clear the screen.
      */
     if (read_stdin) {
-      settmode(TMODE_RAW);              /* set to raw mode */
       starttermcap();
       screenclear();
     }
@@ -2386,9 +2385,6 @@ buf_write (
     overwriting = TRUE;
   else
     overwriting = FALSE;
-
-  if (exiting)
-    settmode(TMODE_COOK);           /* when exiting allow typeahead now */
 
   ++no_wait_return;                 /* don't wait for return yet */
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -281,7 +281,7 @@ int main(int argc, char **argv)
       // In embedded mode don't do terminal-related initializations, assume an
       // initial screen size of 80x20
       full_screen = true;
-      set_shellsize(80, 20, false);
+      screen_resize(80, 20, false);
     } else {
       // set terminal name and get terminal capabilities (will set full_screen)
       // Do some initialization of the screen

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -43,6 +43,7 @@
 #include "nvim/log.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"
+#include "nvim/mouse.h"
 #include "nvim/normal.h"
 #include "nvim/ops.h"
 #include "nvim/option.h"

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2286,8 +2286,6 @@ int ask_yesno(char_u *str, int direct)
   int r = ' ';
   int save_State = State;
 
-  if (exiting)                  /* put terminal in raw mode for this question */
-    settmode(TMODE_RAW);
   ++no_wait_return;
 #ifdef USE_ON_FLY_SCROLL
   dont_scroll = TRUE;           /* disallow scrolling here */

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -42,6 +42,7 @@
 #include "nvim/misc2.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
+#include "nvim/mouse.h"
 #include "nvim/option.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -169,11 +169,9 @@ retnomove:
     // (MOUSE_FOCUS was set above if we dragged first).
     if (dragwin == NULL || (flags & MOUSE_RELEASED))
       win_enter(wp, true);                      // can make wp invalid!
-# ifdef CHECK_DOUBLE_CLICK
     // set topline, to be able to check for double click ourselves
     if (curwin != old_curwin)
       set_mouse_topline(curwin);
-# endif
     if (on_status_line) {                       // In (or below) status line
       // Don't use start_arrow() if we're in the same window
       if (curwin == old_curwin)

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -2,8 +2,12 @@
 
 #include "nvim/mouse.h"
 #include "nvim/vim.h"
-#include "nvim/screen.h"
+#include "nvim/ascii.h"
 #include "nvim/window.h"
+#include "nvim/strings.h"
+#include "nvim/screen.h"
+#include "nvim/ui.h"
+#include "nvim/os_unix.h"
 #include "nvim/term.h"
 #include "nvim/fold.h"
 #include "nvim/diff.h"
@@ -435,4 +439,63 @@ win_T *mouse_find_win(int *rowp, int *colp)
     }
   }
   return fp->fr_win;
+}
+
+/*
+ * setmouse() - switch mouse on/off depending on current mode and 'mouse'
+ */
+void setmouse(void)
+{
+  int checkfor;
+
+
+  /* be quick when mouse is off */
+  if (*p_mouse == NUL)
+    return;
+
+  /* don't switch mouse on when not in raw mode (Ex mode) */
+  if (cur_tmode != TMODE_RAW) {
+    mch_setmouse(false);
+    return;
+  }
+
+  if (VIsual_active)
+    checkfor = MOUSE_VISUAL;
+  else if (State == HITRETURN || State == ASKMORE || State == SETWSIZE)
+    checkfor = MOUSE_RETURN;
+  else if (State & INSERT)
+    checkfor = MOUSE_INSERT;
+  else if (State & CMDLINE)
+    checkfor = MOUSE_COMMAND;
+  else if (State == CONFIRM || State == EXTERNCMD)
+    checkfor = ' ';     /* don't use mouse for ":confirm" or ":!cmd" */
+  else
+    checkfor = MOUSE_NORMAL;        /* assume normal mode */
+
+  if (mouse_has(checkfor))
+    mch_setmouse(true);
+  else
+    mch_setmouse(false);
+}
+
+/*
+ * Return true if
+ * - "c" is in 'mouse', or
+ * - 'a' is in 'mouse' and "c" is in MOUSE_A, or
+ * - the current buffer is a help file and 'h' is in 'mouse' and we are in a
+ *   normal editing mode (not at hit-return message).
+ */
+int mouse_has(int c)
+{
+  for (char_u *p = p_mouse; *p; ++p)
+    switch (*p) {
+    case 'a': if (vim_strchr((char_u *)MOUSE_A, c) != NULL)
+        return true;
+      break;
+    case MOUSE_HELP: if (c != MOUSE_RETURN && curbuf->b_help)
+        return true;
+      break;
+    default: if (c == *p) return true; break;
+    }
+  return false;
 }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -46,6 +46,7 @@
 #include "nvim/misc2.h"
 #include "nvim/keymap.h"
 #include "nvim/move.h"
+#include "nvim/mouse.h"
 #include "nvim/ops.h"
 #include "nvim/option.h"
 #include "nvim/quickfix.h"
@@ -7373,4 +7374,12 @@ static void nv_cursorhold(cmdarg_T *cap)
   apply_autocmds(EVENT_CURSORHOLD, NULL, NULL, false, curbuf);
   did_cursorhold = true;
   cap->retval |= CA_COMMAND_BUSY;       /* don't call edit() now */
+}
+
+/*
+ * Return TRUE when 'mousemodel' is set to "popup" or "popup_setpos".
+ */
+static int mouse_model_popup(void)
+{
+  return p_mousem[0] == 'p';
 }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5540,7 +5540,7 @@ set_num_option (
       *pp = old_value;
     else if (full_screen
              )
-      set_shellsize((int)Columns, (int)Rows, TRUE);
+      screen_resize((int)Columns, (int)Rows, TRUE);
     else {
       /* Postpone the resizing; check the size and cmdline position for
        * messages. */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -66,6 +66,7 @@
 #include "nvim/garray.h"
 #include "nvim/cursor_shape.h"
 #include "nvim/move.h"
+#include "nvim/mouse.h"
 #include "nvim/normal.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -104,13 +104,9 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_arg)
 {
   DynamicBuffer input = DYNAMIC_BUFFER_INIT;
   char *output = NULL, **output_ptr = NULL;
-  int current_state = State, old_mode = cur_tmode;
+  int current_state = State;
   bool forward_output = true;
   out_flush();
-
-  if (opts & kShellOptCooked) {
-    settmode(TMODE_COOK);
-  }
 
   // While the child is running, ignore terminating signals
   signal_reject_deadly();
@@ -155,10 +151,6 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_arg)
     msg_putchar('\n');
   }
 
-  if (old_mode == TMODE_RAW) {
-    // restore mode
-    settmode(TMODE_RAW);
-  }
   State = current_state;
   signal_accept_deadly();
 

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -6,6 +6,7 @@
 #include <uv.h>
 
 #include "nvim/os/time.h"
+#include "nvim/os/event.h"
 #include "nvim/vim.h"
 #include "nvim/term.h"
 
@@ -38,31 +39,22 @@ uint64_t os_hrtime(void)
 /// @param ignoreinput If true, allow a SIGINT to interrupt us
 void os_delay(uint64_t milliseconds, bool ignoreinput)
 {
-  os_microdelay(milliseconds * 1000, ignoreinput);
+  if (ignoreinput) {
+    if (milliseconds > INT_MAX) {
+      milliseconds = INT_MAX;
+    }
+    event_poll_until((int)milliseconds, got_int);
+  } else {
+    os_microdelay(milliseconds * 1000);
+  }
 }
 
 /// Sleeps for a certain amount of microseconds
 ///
 /// @param microseconds Number of microseconds to sleep
-/// @param ignoreinput If true, allow a SIGINT to interrupt us
-void os_microdelay(uint64_t microseconds, bool ignoreinput)
+void os_microdelay(uint64_t microseconds)
 {
-  int old_tmode;
-
-  if (ignoreinput) {
-    // Go to cooked mode without echo, to allow SIGINT interrupting us
-    // here
-    old_tmode = curr_tmode;
-
-    if (curr_tmode == TMODE_RAW)
-      settmode(TMODE_SLEEP);
-
-    microdelay(microseconds);
-
-    settmode(old_tmode);
-  } else {
-    microdelay(microseconds);
-  }
+  microdelay(microseconds);
 }
 
 /// Portable version of POSIX localtime_r()

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -37,6 +37,7 @@
 #include "nvim/message.h"
 #include "nvim/misc1.h"
 #include "nvim/misc2.h"
+#include "nvim/mouse.h"
 #include "nvim/garray.h"
 #include "nvim/path.h"
 #include "nvim/screen.h"

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -39,6 +39,7 @@
 #include "nvim/misc1.h"
 #include "nvim/misc2.h"
 #include "nvim/move.h"
+#include "nvim/mouse.h"
 #include "nvim/normal.h"
 #include "nvim/option.h"
 #include "nvim/path.h"

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -1472,7 +1472,7 @@ int set_termname(char_u *term)
     width = 80;
     height = 24;            /* most terminals are 24 lines */
   }
-  set_shellsize(width, height, FALSE);          /* may change Rows */
+  screen_resize(width, height, FALSE);          /* may change Rows */
   if (starting != NO_SCREEN) {
     if (scroll_region)
       scroll_region_reset();                    /* In case Rows changed */
@@ -2289,7 +2289,7 @@ void win_new_shellsize(void)
  */
 void shell_resized(void)
 {
-  set_shellsize(0, 0, FALSE);
+  screen_resize(0, 0, FALSE);
 }
 
 /*
@@ -2308,102 +2308,6 @@ void shell_resized_check(void)
     if (old_Rows != Rows || old_Columns != Columns)
       shell_resized();
   }
-}
-
-/*
- * Set size of the Vim shell.
- * If 'mustset' is TRUE, we must set Rows and Columns, do not get the real
- * window size (this is used for the :win command).
- * If 'mustset' is FALSE, we may try to get the real window size and if
- * it fails use 'width' and 'height'.
- */
-void set_shellsize(int width, int height, int mustset)
-{
-  static int busy = FALSE;
-
-  /*
-   * Avoid recursiveness, can happen when setting the window size causes
-   * another window-changed signal.
-   */
-  if (busy)
-    return;
-
-  if (width < 0 || height < 0)      /* just checking... */
-    return;
-
-  if (State == HITRETURN || State == SETWSIZE) {
-    /* postpone the resizing */
-    State = SETWSIZE;
-    return;
-  }
-
-  /* curwin->w_buffer can be NULL when we are closing a window and the
-   * buffer has already been closed and removing a scrollbar causes a resize
-   * event. Don't resize then, it will happen after entering another buffer.
-   */
-  if (curwin->w_buffer == NULL)
-    return;
-
-  ++busy;
-
-
-  if (mustset || (ui_get_shellsize() == FAIL && height != 0)) {
-    Rows = height;
-    Columns = width;
-    check_shellsize();
-    mch_set_shellsize();
-  } else
-    check_shellsize();
-
-  /* The window layout used to be adjusted here, but it now happens in
-   * screenalloc() (also invoked from screenclear()).  That is because the
-   * "busy" check above may skip this, but not screenalloc(). */
-
-  if (State != ASKMORE && State != EXTERNCMD && State != CONFIRM)
-    screenclear();
-  else
-    screen_start();         /* don't know where cursor is now */
-
-  if (starting != NO_SCREEN) {
-    maketitle();
-    changed_line_abv_curs();
-    invalidate_botline();
-
-    /*
-     * We only redraw when it's needed:
-     * - While at the more prompt or executing an external command, don't
-     *   redraw, but position the cursor.
-     * - While editing the command line, only redraw that.
-     * - in Ex mode, don't redraw anything.
-     * - Otherwise, redraw right now, and position the cursor.
-     * Always need to call update_screen() or screenalloc(), to make
-     * sure Rows/Columns and the size of ScreenLines[] is correct!
-     */
-    if (State == ASKMORE || State == EXTERNCMD || State == CONFIRM
-        || exmode_active) {
-      screenalloc(false);
-      repeat_message();
-    } else {
-      if (curwin->w_p_scb)
-        do_check_scrollbind(TRUE);
-      if (State & CMDLINE) {
-        update_screen(NOT_VALID);
-        redrawcmdline();
-      } else {
-        update_topline();
-        if (pum_visible()) {
-          redraw_later(NOT_VALID);
-          ins_compl_show_pum();           /* This includes the redraw. */
-        } else
-          update_screen(NOT_VALID);
-        if (redrawing())
-          setcursor();
-      }
-    }
-    cursor_on();            /* redrawing may have switched it off */
-  }
-  out_flush();
-  --busy;
 }
 
 /*

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -2819,11 +2819,9 @@ static void switch_to_8bit(void)
   LOG_TR("Switching to 8 bit");
 }
 
-#ifdef CHECK_DOUBLE_CLICK
 static linenr_T orig_topline = 0;
 static int orig_topfill = 0;
-#endif
-#if defined(CHECK_DOUBLE_CLICK) || defined(PROTO)
+
 /*
  * Checking for double clicks ourselves.
  * "orig_topline" is used to avoid detecting a double-click when the window
@@ -2838,7 +2836,6 @@ void set_mouse_topline(win_T *wp)
   orig_topline = wp->w_topline;
   orig_topfill = wp->w_topfill;
 }
-#endif
 
 /*
  * Check if typebuf.tb_buf[] contains a terminal key code.
@@ -3529,7 +3526,6 @@ int check_termcode(int max_offset, char_u *buf, int bufsize, int *buflen)
           is_drag = TRUE;
         current_button = held_button;
       } else if (wheel_code == 0)   {
-# ifdef CHECK_DOUBLE_CLICK
         {
           static int orig_mouse_col = 0;
           static int orig_mouse_row = 0;
@@ -3563,9 +3559,6 @@ int check_termcode(int max_offset, char_u *buf, int bufsize, int *buflen)
           orig_topline = curwin->w_topline;
           orig_topfill = curwin->w_topfill;
         }
-# else
-        orig_num_clicks = NUM_MOUSE_CLICKS(mouse_code);
-# endif
         is_click = TRUE;
         orig_mouse_code = mouse_code;
       }

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -1865,7 +1865,7 @@ void term_write(char_u *s, size_t len)
 
 #ifdef UNIX
   if (p_wd) {           // Unix is too fast, slow down a bit more
-    os_microdelay(p_wd, false);
+    os_microdelay(p_wd);
   }
 #endif
 }

--- a/src/nvim/term.h
+++ b/src/nvim/term.h
@@ -52,10 +52,6 @@
  * 128 = 16384 columns, now it's reduced to 10000. */
 #define MOUSE_COLOFF 10000
 
-#if defined(UNIX)
-# define CHECK_DOUBLE_CLICK 1  /* Checking for double clicks ourselves. */
-#endif
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "term.h.generated.h"
 #endif

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -41,6 +41,7 @@
 #include "nvim/file_search.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"
+#include "nvim/mouse.h"
 #include "nvim/normal.h"
 #include "nvim/option.h"
 #include "nvim/os_unix.h"

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -15,6 +15,9 @@ set(DEPS_DOWNLOAD_DIR "${DEPS_BUILD_DIR}/downloads")
 
 option(USE_BUNDLED "Use bundled dependencies." ON)
 
+option(USE_BUNDLED_LIBUNIBILIUM "Use the bundled libunibilium." ${USE_BUNDLED})
+option(USE_BUNDLED_LIBTERMKEY "Use the bundled libtermkey." ${USE_BUNDLED})
+option(USE_BUNDLED_LIBTICKIT "Use the bundled libtickit." ${USE_BUNDLED})
 option(USE_BUNDLED_LIBUV "Use the bundled libuv." ${USE_BUNDLED})
 option(USE_BUNDLED_MSGPACK "Use the bundled msgpack." ${USE_BUNDLED})
 option(USE_BUNDLED_LUAJIT "Use the bundled version of luajit." ${USE_BUNDLED})
@@ -66,6 +69,90 @@ set(LUAJIT_MD5 f14e9104be513913810cd59c8c658dc0)
 set(LUAROCKS_URL https://github.com/keplerproject/luarocks/archive/0587afbb5fe8ceb2f2eea16f486bd6183bf02f29.tar.gz)
 set(LUAROCKS_SHA1 61a894fd5d61987bf7e7f9c3e0c5de16ba4b68c4)
 set(LUAROCKS_MD5 0f53f42909fbcd2c88be303e8f970516)
+
+set(LIBUNIBILIUM_URL https://github.com/mauke/unibilium/archive/v1.1.0.tar.gz)
+set(LIBUNIBILIUM_SHA1 edda116e736396315abb33397f7815103e2d4fe4)
+set(LIBUNIBILIUM_MD5 60f3e6db236daf12cbc92f0b60d9eddc)
+
+set(LIBTERMKEY_URL https://github.com/neovim/libtermkey/archive/neovim.tar.gz)
+set(LIBTERMKEY_SHA1 a309038a2297fe4905f03a8807723a9aa07c272a)
+set(LIBTERMKEY_MD5 c99e5546da0063fa26dfa7d7f1d5a26f)
+
+set(LIBTICKIT_URL https://github.com/neovim/libtickit/archive/neovim.tar.gz)
+set(LIBTICKIT_SHA1 49e609de29c3bdc3b40d2ade76e69fde6e0d74bc)
+set(LIBTICKIT_MD5 71a5d36d0ef6688d79828aabaf27eb36)
+
+if(USE_BUNDLED_LIBUNIBILIUM)
+  ExternalProject_Add(libunibilium
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${LIBUNIBILIUM_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/libunibilium
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/libunibilium
+      -DURL=${LIBUNIBILIUM_URL}
+      -DEXPECTED_SHA1=${LIBUNIBILIUM_SHA1}
+      -DEXPECTED_MD5=${LIBUNIBILIUM_MD5}
+      -DTARGET=libunibilium
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    CONFIGURE_COMMAND ""
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
+                              PREFIX=${DEPS_INSTALL_DIR}
+                              CFLAGS=-fPIC
+    INSTALL_COMMAND ${MAKE_PRG} PREFIX=${DEPS_INSTALL_DIR} install)
+  list(APPEND THIRD_PARTY_DEPS libunibilium)
+endif()
+
+if(USE_BUNDLED_LIBTERMKEY)
+  ExternalProject_Add(libtermkey
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${LIBTERMKEY_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/libtermkey
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/libtermkey
+      -DURL=${LIBTERMKEY_URL}
+      -DEXPECTED_SHA1=${LIBTERMKEY_SHA1}
+      -DEXPECTED_MD5=${LIBTERMKEY_MD5}
+      -DTARGET=libtermkey
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    CONFIGURE_COMMAND ""
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
+                                PREFIX=${DEPS_INSTALL_DIR}
+                                PKG_CONFIG_PATH=${DEPS_LIB_DIR}/pkgconfig
+                                CFLAGS=-fPIC
+                                install)
+  list(APPEND THIRD_PARTY_DEPS libtermkey)
+  add_dependencies(libtermkey libunibilium)
+endif()
+
+if(USE_BUNDLED_LIBTICKIT)
+  ExternalProject_Add(libtickit
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${LIBTICKIT_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/libtickit
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/libtickit
+      -DURL=${LIBTICKIT_URL}
+      -DEXPECTED_SHA1=${LIBTICKIT_SHA1}
+      -DEXPECTED_MD5=${LIBTICKIT_MD5}
+      -DTARGET=libtickit
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    CONFIGURE_COMMAND ""
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
+                                PREFIX=${DEPS_INSTALL_DIR}
+                                PKG_CONFIG_PATH=${DEPS_LIB_DIR}/pkgconfig
+                                CFLAGS=-fPIC
+                                install)
+  list(APPEND THIRD_PARTY_DEPS libtickit)
+  add_dependencies(libtickit libtermkey)
+endif()
 
 if(USE_BUNDLED_LIBUV)
   ExternalProject_Add(libuv


### PR DESCRIPTION
This follows #1565 and extracts some changes from a [huge commit](https://github.com/tarruda/neovim/commit/8026446ff2a9eec1ef26c8279feaec61b0a44da8) that completely rewrites the UI layer and removes all term.\* files.

Libtickit/libtermkey are being used to implement the new terminal UI, so I add them as bunded dependencies in this PR
