### PR TITLE
[RFC] Fix newline substitution: Adapt to upstream patch.

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3606,12 +3606,13 @@ void do_sub(exarg_T *eap)
     linenr_T joined_lines_count = eap->line2 < curbuf->b_ml.ml_line_count
                                   ? eap->line2 - eap->line1 + 2
                                   : eap->line2 - eap->line1 + 1;
-    if (joined_lines_count >= 2) {
+    if (joined_lines_count > 1) {
       do_join(joined_lines_count, FALSE, TRUE, FALSE, true);
+      sub_nsubs = joined_lines_count - 1;
+      sub_nlines = 1;
+      do_sub_msg(false);
+      ex_may_print(eap);
     }
-    sub_nlines = sub_nsubs = joined_lines_count - 1;
-    do_sub_msg(false);
-    ex_may_print(eap);
 
     return;
   }


### PR DESCRIPTION
Fix previous changes to be compatible with agreed changes to upstream
vim (https://code.google.com/p/vim/issues/detail?id=287).
