### PR TITLE
[RFC] Abstract UI termcap

### DIFF
--- a/scripts/msgpack-gen.lua
+++ b/scripts/msgpack-gen.lua
@@ -252,6 +252,11 @@ end
 output:write([[
 static Map(String, MsgpackRpcRequestHandler) *methods = NULL;
 
+void msgpack_rpc_add_method_handler(String method, MsgpackRpcRequestHandler handler)
+{
+  map_put(String, MsgpackRpcRequestHandler)(methods, method, handler);
+}
+
 void msgpack_rpc_init_method_table(void)
 {
   methods = map_new(String, MsgpackRpcRequestHandler)();
@@ -263,7 +268,7 @@ void msgpack_rpc_init_method_table(void)
 local max_fname_len = 0
 for i = 1, #functions do
   local fn = functions[i]
-  output:write('  map_put(String, MsgpackRpcRequestHandler)(methods, '..
+  output:write('  msgpack_rpc_add_method_handler('..
                '(String) {.data = "'..fn.name..'", '..
                '.size = sizeof("'..fn.name..'") - 1}, '..
                '(MsgpackRpcRequestHandler) {.fn = handle_'..  fn.name..

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -21,6 +21,7 @@
 #include "nvim/message.h"
 #include "nvim/eval.h"
 #include "nvim/misc2.h"
+#include "nvim/syntax.h"
 #include "nvim/term.h"
 #include "nvim/getchar.h"
 #include "nvim/os/input.h"
@@ -544,6 +545,11 @@ void vim_unsubscribe(uint64_t channel_id, String event)
   memcpy(e, event.data, length);
   e[length] = NUL;
   channel_unsubscribe(channel_id, e);
+}
+
+Integer vim_name_to_color(String name)
+{
+  return name_to_color((uint8_t *)name.data);
 }
 
 Array vim_get_api_info(uint64_t channel_id)

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1984,10 +1984,6 @@ void free_cmdline_buf(void)
  */
 static void draw_cmdline(int start, int len)
 {
-  if (embedded_mode) {
-    return;
-  }
-
   int i;
 
   if (cmdline_star > 0)

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2513,6 +2513,13 @@ fix_input_buffer (
     int script                     /* TRUE when reading from a script */
 )
 {
+  if (abstract_ui) {
+    // Should not escape K_SPECIAL/CSI while in embedded mode because vim key
+    // codes keys are processed in input.c/input_enqueue.
+    buf[len] = NUL;
+    return len;
+  }
+
   int i;
   char_u      *p = buf;
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -465,6 +465,8 @@ EXTERN int highlight_stlnc[9];                  /* On top of user */
 EXTERN int cterm_normal_fg_color INIT(= 0);
 EXTERN int cterm_normal_fg_bold INIT(= 0);
 EXTERN int cterm_normal_bg_color INIT(= 0);
+EXTERN RgbValue normal_fg INIT(= -1);
+EXTERN RgbValue normal_bg INIT(= -1);
 
 EXTERN int autocmd_busy INIT(= FALSE);          /* Is apply_autocmds() busy? */
 EXTERN int autocmd_no_enter INIT(= FALSE);      /* *Enter autocmds disabled */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1251,6 +1251,8 @@ EXTERN int curr_tmode INIT(= TMODE_COOK); /* contains current terminal mode */
 
 // If a msgpack-rpc channel should be started over stdin/stdout
 EXTERN bool embedded_mode INIT(= false);
+// Using the "abstract_ui" termcap
+EXTERN bool abstract_ui INIT(= false);
 
 /// Used to track the status of external functions.
 /// Currently only used for iconv().

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -452,7 +452,7 @@ void setmouse(void)
     return;
 
   /* don't switch mouse on when not in raw mode (Ex mode) */
-  if (cur_tmode != TMODE_RAW) {
+  if (!abstract_ui && cur_tmode != TMODE_RAW) {
     mch_setmouse(false);
     return;
   }
@@ -470,10 +470,11 @@ void setmouse(void)
   else
     checkfor = MOUSE_NORMAL;        /* assume normal mode */
 
-  if (mouse_has(checkfor))
-    mch_setmouse(true);
-  else
-    mch_setmouse(false);
+  if (mouse_has(checkfor)) {
+    ui_mouse_on();
+  } else {
+    ui_mouse_off();
+  }
 }
 
 /*

--- a/src/nvim/msgpack_rpc/defs.h
+++ b/src/nvim/msgpack_rpc/defs.h
@@ -19,6 +19,10 @@ typedef struct {
 /// Initializes the msgpack-rpc method table
 void msgpack_rpc_init_method_table(void);
 
+// Add a handler to the method table
+void msgpack_rpc_add_method_handler(String method,
+                                    MsgpackRpcRequestHandler handler);
+
 void msgpack_rpc_init_function_metadata(Dictionary *metadata);
 
 /// Dispatches to the actual API function after basic payload validation by

--- a/src/nvim/msgpack_rpc/remote_ui.c
+++ b/src/nvim/msgpack_rpc/remote_ui.c
@@ -1,0 +1,280 @@
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "nvim/vim.h"
+#include "nvim/ui.h"
+#include "nvim/memory.h"
+#include "nvim/map.h"
+#include "nvim/msgpack_rpc/remote_ui.h"
+#include "nvim/msgpack_rpc/channel.h"
+#include "nvim/api/private/defs.h"
+#include "nvim/api/private/helpers.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "msgpack_rpc/remote_ui.c.generated.h"
+#endif
+
+typedef struct {
+  uint64_t channel_id;
+  Array buffer;
+} UIData;
+
+static PMap(uint64_t) *connected_uis = NULL;
+
+void remote_ui_init(void)
+{
+  connected_uis = pmap_new(uint64_t)();
+}
+
+Object remote_ui_attach(uint64_t channel_id, uint64_t request_id, Array args,
+                        Error *error)
+{
+  if (pmap_has(uint64_t)(connected_uis, channel_id)) {
+    api_set_error(error, Exception, _("UI already attached for channel"));
+    return NIL;
+  }
+
+  if (args.size != 2 || args.items[0].type != kObjectTypeInteger
+      || args.items[1].type != kObjectTypeInteger
+      || args.items[0].data.integer <= 0 || args.items[1].data.integer <= 0) {
+    api_set_error(error, Validation,
+                  _("Arguments must be a pair of positive integers "
+                    "representing the remote screen width/height"));
+    return NIL;
+  }
+  UIData *data = xmalloc(sizeof(UIData));
+  data->channel_id = channel_id;
+  data->buffer = (Array)ARRAY_DICT_INIT;
+  UI *ui = xcalloc(1, sizeof(UI));
+  ui->width = (int)args.items[0].data.integer;
+  ui->height = (int)args.items[1].data.integer;
+  ui->data = data;
+  ui->resize = remote_ui_resize;
+  ui->clear = remote_ui_clear;
+  ui->eol_clear = remote_ui_eol_clear;
+  ui->cursor_goto = remote_ui_cursor_goto;
+  ui->cursor_on = remote_ui_cursor_on;
+  ui->cursor_off = remote_ui_cursor_off;
+  ui->mouse_on = remote_ui_mouse_on;
+  ui->mouse_off = remote_ui_mouse_off;
+  ui->insert_mode = remote_ui_insert_mode;
+  ui->normal_mode = remote_ui_normal_mode;
+  ui->set_scroll_region = remote_ui_set_scroll_region;
+  ui->scroll = remote_ui_scroll;
+  ui->highlight_set = remote_ui_highlight_set;
+  ui->put = remote_ui_put;
+  ui->bell = remote_ui_bell;
+  ui->visual_bell = remote_ui_visual_bell;
+  ui->flush = remote_ui_flush;
+  ui->suspend = remote_ui_suspend;
+  pmap_put(uint64_t)(connected_uis, channel_id, ui);
+  ui_attach(ui);
+
+  return NIL;
+}
+
+Object remote_ui_detach(uint64_t channel_id, uint64_t request_id, Array args,
+                        Error *error)
+{
+  if (!pmap_has(uint64_t)(connected_uis, channel_id)) {
+    api_set_error(error, Exception, _("UI is not attached for channel"));
+  }
+  remote_ui_disconnect(channel_id);
+
+  return NIL;
+}
+
+void remote_ui_disconnect(uint64_t channel_id)
+{
+  UI *ui = pmap_get(uint64_t)(connected_uis, channel_id);
+  if (!ui) {
+    return;
+  }
+  UIData *data = ui->data;
+  // destroy pending screen updates
+  api_free_array(data->buffer);
+  pmap_del(uint64_t)(connected_uis, channel_id);
+  free(ui->data);
+  ui_detach(ui);
+  free(ui);
+}
+
+static void push_call(UI *ui, char *name, Array args)
+{
+  Array call = ARRAY_DICT_INIT;
+  UIData *data = ui->data;
+
+  // To optimize data transfer(especially for "put"), we bundle adjacent
+  // calls to same method together, so only add a new call entry if the last
+  // method call is different from "name"
+  if (kv_size(data->buffer)) {
+    call = kv_A(data->buffer, kv_size(data->buffer) - 1).data.array;
+  }
+
+  if (!kv_size(call) || strcmp(kv_A(call, 0).data.string.data, name)) {
+    call = (Array)ARRAY_DICT_INIT;
+    ADD(data->buffer, ARRAY_OBJ(call));
+    ADD(call, STRING_OBJ(cstr_to_string(name)));
+  }
+
+  ADD(call, ARRAY_OBJ(args));
+  kv_A(data->buffer, kv_size(data->buffer) - 1).data.array = call;
+}
+
+static void remote_ui_resize(UI *ui, int width, int height)
+{
+  Array args = ARRAY_DICT_INIT;
+  ADD(args, INTEGER_OBJ(width));
+  ADD(args, INTEGER_OBJ(height));
+  push_call(ui, "resize", args);
+}
+
+static void remote_ui_clear(UI *ui)
+{
+  Array args = ARRAY_DICT_INIT;
+  push_call(ui, "clear", args);
+}
+
+static void remote_ui_eol_clear(UI *ui)
+{
+  Array args = ARRAY_DICT_INIT;
+  push_call(ui, "eol_clear", args);
+}
+
+static void remote_ui_cursor_goto(UI *ui, int row, int col)
+{
+  Array args = ARRAY_DICT_INIT;
+  ADD(args, INTEGER_OBJ(row));
+  ADD(args, INTEGER_OBJ(col));
+  push_call(ui, "cursor_goto", args);
+}
+
+static void remote_ui_cursor_on(UI *ui)
+{
+  Array args = ARRAY_DICT_INIT;
+  push_call(ui, "cursor_on", args);
+}
+
+static void remote_ui_cursor_off(UI *ui)
+{
+  Array args = ARRAY_DICT_INIT;
+  push_call(ui, "cursor_off", args);
+}
+
+static void remote_ui_mouse_on(UI *ui)
+{
+  Array args = ARRAY_DICT_INIT;
+  push_call(ui, "mouse_on", args);
+}
+
+static void remote_ui_mouse_off(UI *ui)
+{
+  Array args = ARRAY_DICT_INIT;
+  push_call(ui, "mouse_off", args);
+}
+
+static void remote_ui_insert_mode(UI *ui)
+{
+  Array args = ARRAY_DICT_INIT;
+  push_call(ui, "insert_mode", args);
+}
+
+static void remote_ui_normal_mode(UI *ui)
+{
+  Array args = ARRAY_DICT_INIT;
+  push_call(ui, "normal_mode", args);
+}
+
+static void remote_ui_set_scroll_region(UI *ui, int top, int bot, int left,
+    int right)
+{
+  Array args = ARRAY_DICT_INIT;
+  ADD(args, INTEGER_OBJ(top));
+  ADD(args, INTEGER_OBJ(bot));
+  ADD(args, INTEGER_OBJ(left));
+  ADD(args, INTEGER_OBJ(right));
+  push_call(ui, "set_scroll_region", args);
+}
+
+static void remote_ui_scroll(UI *ui, int count)
+{
+  Array args = ARRAY_DICT_INIT;
+  ADD(args, INTEGER_OBJ(count));
+  push_call(ui, "scroll", args);
+}
+
+static void remote_ui_highlight_set(UI *ui, HlAttrs attrs)
+{
+  Array args = ARRAY_DICT_INIT;
+  Dictionary hl = ARRAY_DICT_INIT;
+
+  if (attrs.bold) {
+    PUT(hl, "bold", BOOLEAN_OBJ(true));
+  }
+
+  if (attrs.standout) {
+    PUT(hl, "standout", BOOLEAN_OBJ(true));
+  }
+
+  if (attrs.underline) {
+    PUT(hl, "underline", BOOLEAN_OBJ(true));
+  }
+
+  if (attrs.undercurl) {
+    PUT(hl, "undercurl", BOOLEAN_OBJ(true));
+  }
+
+  if (attrs.italic) {
+    PUT(hl, "italic", BOOLEAN_OBJ(true));
+  }
+
+  if (attrs.reverse) {
+    PUT(hl, "reverse", BOOLEAN_OBJ(true));
+  }
+
+  if (attrs.foreground != -1) {
+    PUT(hl, "foreground", INTEGER_OBJ(attrs.foreground));
+  }
+
+  if (attrs.background != -1) {
+    PUT(hl, "background", INTEGER_OBJ(attrs.background));
+  }
+
+  ADD(args, DICTIONARY_OBJ(hl));
+  push_call(ui, "highlight_set", args);
+}
+
+static void remote_ui_put(UI *ui, uint8_t *data, size_t size)
+{
+  Array args = ARRAY_DICT_INIT;
+  String str = {.data = xmemdupz(data, size), .size = size};
+  ADD(args, STRING_OBJ(str));
+  push_call(ui, "put", args);
+}
+
+static void remote_ui_bell(UI *ui)
+{
+  Array args = ARRAY_DICT_INIT;
+  push_call(ui, "bell", args);
+}
+
+static void remote_ui_visual_bell(UI *ui)
+{
+  Array args = ARRAY_DICT_INIT;
+  push_call(ui, "visual_bell", args);
+}
+
+static void remote_ui_flush(UI *ui)
+{
+  UIData *data = ui->data;
+  channel_send_event(data->channel_id, "redraw", data->buffer);
+  data->buffer = (Array)ARRAY_DICT_INIT;
+}
+
+static void remote_ui_suspend(UI *ui)
+{
+  UIData *data = ui->data;
+  remote_ui_disconnect(data->channel_id);
+}

--- a/src/nvim/msgpack_rpc/remote_ui.h
+++ b/src/nvim/msgpack_rpc/remote_ui.h
@@ -1,0 +1,9 @@
+#ifndef NVIM_MSGPACK_RPC_REMOTE_UI_H
+#define NVIM_MSGPACK_RPC_REMOTE_UI_H
+
+#include "nvim/ui.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "msgpack_rpc/remote_ui.h.generated.h"
+#endif
+#endif  // NVIM_MSGPACK_RPC_REMOTE_UI_H

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -45,7 +45,7 @@ void signal_init(void)
   uv_signal_start(&shup, signal_cb, SIGHUP);
   uv_signal_start(&squit, signal_cb, SIGQUIT);
   uv_signal_start(&sterm, signal_cb, SIGTERM);
-  if (!embedded_mode) {
+  if (!abstract_ui) {
     // TODO(tarruda): There must be an API function for resizing window
     uv_signal_start(&swinch, signal_cb, SIGWINCH);
   }

--- a/src/nvim/syntax.h
+++ b/src/nvim/syntax.h
@@ -5,8 +5,6 @@
 
 #include "nvim/buffer_defs.h"
 
-typedef int guicolor_T;
-
 /*
  * Terminal highlighting attribute bits.
  * Attributes above HL_ALL are used for syntax highlighting.

--- a/src/nvim/syntax_defs.h
+++ b/src/nvim/syntax_defs.h
@@ -3,6 +3,8 @@
 
 #include "nvim/regexp_defs.h"
 
+typedef int32_t RgbValue;
+
 # define SST_MIN_ENTRIES 150    /* minimal size for state stack array */
 # define SST_MAX_ENTRIES 1000   /* maximal size for state stack array */
 # define SST_FIX_STATES  7      /* size of sst_stack[]. */
@@ -70,6 +72,7 @@ struct syn_state {
  */
 typedef struct attr_entry {
   short ae_attr;                        /* HL_BOLD, etc. */
+  RgbValue fg_color, bg_color;
   union {
     struct {
       char_u          *start;           /* start escape sequence */

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -15,20 +15,24 @@
  * 3. Input buffer stuff.
  */
 
+#include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
 
 #include "nvim/vim.h"
 #include "nvim/ui.h"
+#include "nvim/charset.h"
 #include "nvim/cursor.h"
 #include "nvim/diff.h"
 #include "nvim/ex_cmds2.h"
 #include "nvim/fold.h"
 #include "nvim/main.h"
 #include "nvim/mbyte.h"
+#include "nvim/ascii.h"
 #include "nvim/misc1.h"
 #include "nvim/misc2.h"
+#include "nvim/mbyte.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"
@@ -39,27 +43,74 @@
 #include "nvim/os/input.h"
 #include "nvim/os/signal.h"
 #include "nvim/screen.h"
+#include "nvim/syntax.h"
 #include "nvim/term.h"
 #include "nvim/window.h"
 
-void ui_write(char_u *s, int len)
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "ui.c.generated.h"
+#endif
+
+#define MAX_UI_COUNT 16
+
+static UI *uis[MAX_UI_COUNT];
+static size_t ui_count = 0;
+static int row, col;
+static struct {
+  int top, bot, left, right;
+} sr;
+static int current_highlight_mask = 0;
+static HlAttrs current_attrs = {
+  false, false, false, false, false, false, -1, -1
+};
+static bool cursor_enabled = true;
+static int height = INT_MAX, width = INT_MAX;
+
+// This set of macros allow us to use UI_CALL to invoke any function on
+// registered UI instances. The functions can have 0-5 arguments(configurable
+// by SELECT_NTH)
+//
+// See http://stackoverflow.com/a/11172679 for a better explanation of how it
+// works.
+#define UI_CALL(...)                                              \
+  do {                                                            \
+    for (size_t i = 0; i < ui_count; i++) {                       \
+      UI *ui = uis[i];                                            \
+      UI_CALL_HELPER(CNT(__VA_ARGS__), __VA_ARGS__);              \
+    }                                                             \
+  } while (0)
+#define CNT(...) SELECT_NTH(__VA_ARGS__, MORE, MORE, MORE, MORE, ZERO, ignore)
+#define SELECT_NTH(a1, a2, a3, a4, a5, a6, ...) a6
+#define UI_CALL_HELPER(c, ...) UI_CALL_HELPER2(c, __VA_ARGS__)
+#define UI_CALL_HELPER2(c, ...) UI_CALL_##c(__VA_ARGS__)
+#define UI_CALL_MORE(method, ...) ui->method(ui, __VA_ARGS__)
+#define UI_CALL_ZERO(method) ui->method(ui)
+
+void ui_write(uint8_t *s, int len)
 {
-  /* Don't output anything in silent mode ("ex -s") unless 'verbose' set */
-  if (!(silent_mode && p_verbose == 0)) {
-    char_u  *tofree = NULL;
-
-    if (output_conv.vc_type != CONV_NONE) {
-      /* Convert characters from 'encoding' to 'termencoding'. */
-      tofree = string_convert(&output_conv, s, &len);
-      if (tofree != NULL)
-        s = tofree;
-    }
-
-    term_write(s, len);
-
-    if (output_conv.vc_type != CONV_NONE)
-      free(tofree);
+  if (silent_mode && !p_verbose) {
+    // Don't output anything in silent mode ("ex -s") unless 'verbose' set
+    return;
   }
+
+  if (abstract_ui) {
+    parse_abstract_ui_codes(s, len);
+    return;
+  }
+
+  char_u  *tofree = NULL;
+
+  if (output_conv.vc_type != CONV_NONE) {
+    /* Convert characters from 'encoding' to 'termencoding'. */
+    tofree = string_convert(&output_conv, s, &len);
+    if (tofree != NULL)
+      s = tofree;
+  }
+
+  term_write(s, len);
+
+  if (output_conv.vc_type != CONV_NONE)
+    free(tofree);
 }
 
 /*
@@ -69,7 +120,11 @@ void ui_write(char_u *s, int len)
  */
 void ui_suspend(void)
 {
-  mch_suspend();
+  if (abstract_ui) {
+    UI_CALL(suspend);
+  } else {
+    mch_suspend();
+  }
 }
 
 /*
@@ -79,6 +134,10 @@ void ui_suspend(void)
  */
 int ui_get_shellsize(void)
 {
+  if (abstract_ui) {
+    return FAIL;
+  }
+
   int retval;
 
   retval = mch_get_shellsize();
@@ -98,7 +157,373 @@ int ui_get_shellsize(void)
  */
 void ui_cursor_shape(void)
 {
-  term_cursor_shape();
+  if (abstract_ui) {
+    ui_change_mode();
+  } else {
+    term_cursor_shape();
+    conceal_check_cursur_line();
+  }
+}
+
+void ui_resize(int width, int height)
+{
+  sr.top = 0;
+  sr.bot = height - 1;
+  sr.left = 0;
+  sr.right = width - 1;
+  UI_CALL(resize, width, height);
+}
+
+void ui_cursor_on(void)
+{
+  if (!cursor_enabled) {
+    UI_CALL(cursor_on);
+    cursor_enabled = true;
+  }
+}
+
+void ui_cursor_off(void)
+{
+  if (full_screen) {
+    if (cursor_enabled) {
+      UI_CALL(cursor_off);
+    }
+    cursor_enabled = false;
+  }
+}
+
+void ui_mouse_on(void)
+{
+  if (abstract_ui) {
+    UI_CALL(mouse_on);
+  } else {
+    mch_setmouse(true);
+  }
+}
+
+void ui_mouse_off(void)
+{
+  if (abstract_ui) {
+    UI_CALL(mouse_off);
+  } else {
+    mch_setmouse(false);
+  }
+}
+
+// Notify that the current mode has changed. Can be used to change cursor
+// shape, for example.
+void ui_change_mode(void)
+{
+  static int showing_insert_mode = MAYBE;
+
+  if (!full_screen)
+    return;
+
+  if (State & INSERT) {
+    if (showing_insert_mode != TRUE) {
+      UI_CALL(insert_mode);
+    }
+    showing_insert_mode = TRUE;
+  } else {
+    if (showing_insert_mode != FALSE) {
+      UI_CALL(normal_mode);
+    }
+    showing_insert_mode = FALSE;
+  }
   conceal_check_cursur_line();
 }
 
+void ui_attach(UI *ui)
+{
+  if (ui_count == MAX_UI_COUNT) {
+    abort();
+  }
+
+  uis[ui_count++] = ui;
+  resized(ui);
+}
+
+void ui_detach(UI *ui)
+{
+  size_t shift_index = MAX_UI_COUNT;
+
+  // Find the index that will be removed
+  for (size_t i = 0; i < ui_count; i++) {
+    if (uis[i] == ui) {
+      shift_index = i;
+      break;
+    }
+  }
+
+  if (shift_index == MAX_UI_COUNT) {
+    abort();
+  }
+
+  // Shift UIs at "shift_index"
+  while (shift_index < ui_count - 1) {
+    uis[shift_index] = uis[shift_index + 1];
+    shift_index++;
+  }
+
+  ui_count--;
+
+  if (ui->width == width || ui->height == height) {
+    // It is possible that the UI being detached had the smallest screen,
+    // so check for the new minimum dimensions
+    width = height = INT_MAX;
+    for (size_t i = 0; i < ui_count; i++) {
+      check_dimensions(uis[i]);
+    }
+  }
+
+  if (ui_count) {
+    screen_resize(width, height, true);
+  }
+}
+
+static void highlight_start(int mask)
+{
+  if (mask > HL_ALL) {
+    // attribute code
+    current_highlight_mask = mask;
+  } else {
+    // attribute mask
+    current_highlight_mask |= mask;
+  }
+
+  if (!ui_count) {
+    return;
+  }
+
+  set_highlight_args(current_highlight_mask, &current_attrs);
+  UI_CALL(highlight_set, current_attrs);
+}
+
+static void highlight_stop(int mask)
+{
+  if (mask > HL_ALL) {
+    // attribute code
+    current_highlight_mask = HL_NORMAL;
+  } else {
+    // attribute mask
+    current_highlight_mask &= ~mask;
+  }
+
+  set_highlight_args(current_highlight_mask, &current_attrs);
+  UI_CALL(highlight_set, current_attrs);
+}
+
+static void set_highlight_args(int mask, HlAttrs *attrs)
+{
+  attrentry_T *aep = NULL;
+  attrs->foreground = -1;
+  attrs->background = -1;
+
+  if (mask > HL_ALL) {
+    aep = syn_cterm_attr2entry(mask);
+    mask = aep ? aep->ae_attr : 0;
+  }
+
+  attrs->bold = mask & HL_BOLD;
+  attrs->standout = mask & HL_STANDOUT;
+  attrs->underline = mask & HL_UNDERLINE;
+  attrs->undercurl = mask & HL_UNDERCURL;
+  attrs->italic = mask & HL_ITALIC;
+  attrs->reverse = mask & HL_INVERSE;
+
+  if (aep && aep->ae_u.cterm.fg_color
+      && (cterm_normal_fg_color != aep->ae_u.cterm.fg_color)) {
+    attrs->foreground = aep->ae_u.cterm.fg_color - 1;
+  }
+
+  if (aep && aep->ae_u.cterm.bg_color
+      && (cterm_normal_bg_color != aep->ae_u.cterm.bg_color)) {
+    attrs->background = aep->ae_u.cterm.bg_color - 1;
+  }
+}
+
+static void parse_abstract_ui_codes(uint8_t *ptr, int len)
+{
+  int arg1 = 0, arg2 = 0;
+  uint8_t *end = ptr + len, *p, c;
+  bool update_cursor = false;
+
+  while (ptr < end) {
+    if (ptr < end - 1 && ptr[0] == ESC && ptr[1] == '|') {
+      p = ptr + 2;
+      assert(p != end);
+
+      if (VIM_ISDIGIT(*p)) {
+        arg1 = (int)getdigits(&p);
+        if (p >= end) {
+          break;
+        }
+
+        if (*p == ';') {
+          p++;
+          arg2 = (int)getdigits(&p);
+          if (p >= end)
+            break;
+        }
+      }
+
+      switch (*p) {
+        case 'C':
+          UI_CALL(clear);
+          break;
+        case 'M':
+          ui_cursor_goto(arg1, arg2);
+          break;
+        case 's':
+          update_cursor = true;
+          break;
+        case 'R':
+          if (arg1 < arg2) {
+            sr.top = arg1;
+            sr.bot = arg2;
+            UI_CALL(set_scroll_region, sr.top, sr.bot, sr.left, sr.right);
+          } else {
+            sr.top = arg2;
+            sr.bot = arg1;
+            UI_CALL(set_scroll_region, sr.top, sr.bot, sr.left, sr.right);
+          }
+          break;
+        case 'V':
+          if (arg1 < arg2) {
+            sr.left = arg1;
+            sr.right = arg2;
+            UI_CALL(set_scroll_region, sr.top, sr.bot, sr.left, sr.right);
+          } else {
+            sr.left = arg2;
+            sr.right = arg1;
+            UI_CALL(set_scroll_region, sr.top, sr.bot, sr.left, sr.right);
+          }
+          break;
+        case 'd':
+          UI_CALL(scroll, 1);
+          break;
+        case 'D':
+          UI_CALL(scroll, arg1);
+          break;
+        case 'i':
+          UI_CALL(scroll, -1);
+          break;
+        case 'I':
+          UI_CALL(scroll, -arg1);
+          break;
+        case '$':
+          UI_CALL(eol_clear);
+          break;
+        case 'h':
+          highlight_start(arg1);
+          break;
+        case 'H':
+          highlight_stop(arg1);
+          break;
+        case 'f':
+          UI_CALL(visual_bell);
+          break;
+        default:
+          // Skip the ESC
+          p = ptr + 1;
+          break;
+      }
+      ptr = ++p;
+    } else if ((c = *ptr) < 0x20) {
+      // Ctrl character
+      if (c == '\n') {
+        ui_linefeed();
+      } else if (c == '\r') {
+        ui_carriage_return();
+      } else if (c == '\b') {
+        ui_cursor_left();
+      } else if (c == Ctrl_L) {  // cursor right
+        ui_cursor_right();
+      } else if (c == Ctrl_G) {
+        UI_CALL(bell);
+      }
+      ptr++;
+    } else {
+      p = ptr;
+      while (p < end && (*p >= 0x20)) {
+        size_t clen = (size_t)mb_ptr2len(p);
+        UI_CALL(put, p, (size_t)clen);
+        col++;
+        if (mb_ptr2cells(p) > 1) {
+          // double cell character, blank the next cell
+          UI_CALL(put, NULL, 0);
+          col++;
+        }
+        p += clen;
+      }
+      ptr = p;
+    }
+  }
+
+  if (update_cursor) {
+    ui_cursor_shape();
+  }
+
+  UI_CALL(flush);
+}
+
+static void resized(UI *ui)
+{
+  check_dimensions(ui);
+  screen_resize(width, height, true);
+}
+
+static void check_dimensions(UI *ui)
+{
+  // The internal screen dimensions are always the minimum required to fit on
+  // all connected screens
+  if (ui->width < width) {
+    width = ui->width;
+  }
+
+  if (ui->height < height) {
+    height = ui->height;
+  }
+}
+
+static void ui_linefeed(void)
+{
+  int new_col = 0;
+  int new_row = row;
+  if (new_row < sr.bot) {
+    new_row++;
+  } else {
+    UI_CALL(scroll, 1);
+  }
+  ui_cursor_goto(new_row, new_col);
+}
+
+static void ui_carriage_return(void)
+{
+  int new_col = 0;
+  ui_cursor_goto(row, new_col);
+}
+
+static void ui_cursor_left(void)
+{
+  int new_col = col - 1;
+  assert(new_col >= 0);
+  ui_cursor_goto(row, new_col);
+}
+
+static void ui_cursor_right(void)
+{
+  int new_col = col + 1;
+  assert(new_col < width);
+  ui_cursor_goto(row, new_col);
+}
+
+static void ui_cursor_goto(int new_row, int new_col)
+{
+  if (new_row == row && new_col == col) {
+    return;
+  }
+  row = new_row;
+  col = new_col;
+  UI_CALL(cursor_goto, row, col);
+}

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -316,8 +316,6 @@ static void highlight_stop(int mask)
 static void set_highlight_args(int mask, HlAttrs *attrs)
 {
   attrentry_T *aep = NULL;
-  attrs->foreground = -1;
-  attrs->background = -1;
 
   if (mask > HL_ALL) {
     aep = syn_cterm_attr2entry(mask);
@@ -330,16 +328,8 @@ static void set_highlight_args(int mask, HlAttrs *attrs)
   attrs->undercurl = mask & HL_UNDERCURL;
   attrs->italic = mask & HL_ITALIC;
   attrs->reverse = mask & HL_INVERSE;
-
-  if (aep && aep->ae_u.cterm.fg_color
-      && (cterm_normal_fg_color != aep->ae_u.cterm.fg_color)) {
-    attrs->foreground = aep->ae_u.cterm.fg_color - 1;
-  }
-
-  if (aep && aep->ae_u.cterm.bg_color
-      && (cterm_normal_bg_color != aep->ae_u.cterm.bg_color)) {
-    attrs->background = aep->ae_u.cterm.bg_color - 1;
-  }
+  attrs->foreground = aep && aep->fg_color >= 0 ? aep->fg_color : normal_fg;
+  attrs->background = aep && aep->bg_color >= 0 ? aep->bg_color : normal_bg;
 }
 
 static void parse_abstract_ui_codes(uint8_t *ptr, int len)

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -1,7 +1,39 @@
 #ifndef NVIM_UI_H
 #define NVIM_UI_H
 
+#include <stddef.h>
 #include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+  bool bold, standout, underline, undercurl, italic, reverse;
+  int foreground, background;
+} HlAttrs;
+
+typedef struct ui_t UI;
+
+struct ui_t {
+  int width, height;
+  void *data;
+  void (*resize)(UI *ui, int rows, int columns);
+  void (*clear)(UI *ui);
+  void (*eol_clear)(UI *ui);
+  void (*cursor_goto)(UI *ui, int row, int col);
+  void (*cursor_on)(UI *ui);
+  void (*cursor_off)(UI *ui);
+  void (*mouse_on)(UI *ui);
+  void (*mouse_off)(UI *ui);
+  void (*insert_mode)(UI *ui);
+  void (*normal_mode)(UI *ui);
+  void (*set_scroll_region)(UI *ui, int top, int bot, int left, int right);
+  void (*scroll)(UI *ui, int count);
+  void (*highlight_set)(UI *ui, HlAttrs attrs);
+  void (*put)(UI *ui, uint8_t *str, size_t len);
+  void (*bell)(UI *ui);
+  void (*visual_bell)(UI *ui);
+  void (*flush)(UI *ui);
+  void (*suspend)(UI *ui);
+};
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui.h.generated.h"

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1,0 +1,184 @@
+local helpers = require('test.functional.helpers')
+local Screen = require('test.functional.ui.screen')
+local clear, feed, nvim = helpers.clear, helpers.feed, helpers.nvim
+local execute = helpers.execute
+
+describe('Default highlight groups', function()
+  -- Test the default attributes for highlight groups shown by the :highlight
+  -- command
+  local screen, hlgroup_colors
+
+  setup(function()
+    hlgroup_colors = {
+      NonText = nvim('name_to_color', 'Blue'),
+      Question = nvim('name_to_color', 'SeaGreen')
+    }
+  end)
+
+  before_each(function()
+    clear()
+    screen = Screen.new()
+    screen:attach()
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  it('window status bar', function()
+    screen:set_default_attr_ids({
+      [1] = {reverse = true, bold = true},  -- StatusLine
+      [2] = {reverse = true}                -- StatusLineNC
+    })
+    execute('sp', 'vsp', 'vsp')
+    screen:expect([[
+      ^                   {2:|}                {2:|}               |
+      ~                   {2:|}~               {2:|}~              |
+      ~                   {2:|}~               {2:|}~              |
+      ~                   {2:|}~               {2:|}~              |
+      ~                   {2:|}~               {2:|}~              |
+      ~                   {2:|}~               {2:|}~              |
+      {1:[No Name]            }{2:[No Name]        [No Name]      }|
+                                                           |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      {2:[No Name]                                            }|
+                                                           |
+    ]])
+    -- navigate to verify that the attributes are properly moved
+    feed('<c-w>j')
+    screen:expect([[
+                          {2:|}                {2:|}               |
+      ~                   {2:|}~               {2:|}~              |
+      ~                   {2:|}~               {2:|}~              |
+      ~                   {2:|}~               {2:|}~              |
+      ~                   {2:|}~               {2:|}~              |
+      ~                   {2:|}~               {2:|}~              |
+      {2:[No Name]            [No Name]        [No Name]      }|
+      ^                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      {1:[No Name]                                            }|
+                                                           |
+    ]])
+    -- note that when moving to a window with small width nvim will increase
+    -- the width of the new active window at the expense of a inactive window
+    -- (upstream vim has the same behavior)
+    feed('<c-w>k<c-w>l')
+    screen:expect([[
+                          {2:|}^                   {2:|}           |
+      ~                   {2:|}~                   {2:|}~          |
+      ~                   {2:|}~                   {2:|}~          |
+      ~                   {2:|}~                   {2:|}~          |
+      ~                   {2:|}~                   {2:|}~          |
+      ~                   {2:|}~                   {2:|}~          |
+      {2:[No Name]            }{1:[No Name]            }{2:[No Name]  }|
+                                                           |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      {2:[No Name]                                            }|
+                                                           |
+    ]])
+    feed('<c-w>l')
+    screen:expect([[
+                          {2:|}           {2:|}^                   |
+      ~                   {2:|}~          {2:|}~                   |
+      ~                   {2:|}~          {2:|}~                   |
+      ~                   {2:|}~          {2:|}~                   |
+      ~                   {2:|}~          {2:|}~                   |
+      ~                   {2:|}~          {2:|}~                   |
+      {2:[No Name]            [No Name]   }{1:[No Name]           }|
+                                                           |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      {2:[No Name]                                            }|
+                                                           |
+    ]])
+    feed('<c-w>h<c-w>h')
+    screen:expect([[
+      ^                   {2:|}                    {2:|}           |
+      ~                   {2:|}~                   {2:|}~          |
+      ~                   {2:|}~                   {2:|}~          |
+      ~                   {2:|}~                   {2:|}~          |
+      ~                   {2:|}~                   {2:|}~          |
+      ~                   {2:|}~                   {2:|}~          |
+      {1:[No Name]            }{2:[No Name]            [No Name]  }|
+                                                           |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      {2:[No Name]                                            }|
+                                                           |
+    ]])
+  end)
+
+  it('insert mode text', function()
+    feed('i')
+    screen:expect([[
+      ^                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      {1:-- INSERT --}                                         |
+    ]], {[1] = {bold = true}})
+  end)
+
+  it('end of file markers', function()
+    nvim('command', 'hi Normal guibg=black')
+    screen:expect([[
+      ^                                                    |
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                    }|
+                                                           |
+    ]], {[1] = {bold = true, foreground = hlgroup_colors.NonText}})
+  end)
+
+  it('"wait return" text', function()
+    feed(':ls<cr>')
+    screen:expect([[
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      :ls                                                  |
+        1 %a   "[No Name]"                    line 1       |
+      {1:Press ENTER or type command to continue}^             |
+    ]], {[1] = {bold = true, foreground = hlgroup_colors.Question}})
+    feed('<cr>') --  skip the "Press ENTER..." state or tests will hang
+  end)
+end)

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -1,0 +1,40 @@
+local helpers = require('test.functional.helpers')
+local clear, execute, nvim = helpers.clear, helpers.execute, helpers.nvim
+local feed, next_message, eq = helpers.feed, helpers.next_message, helpers.eq
+
+describe('mappings', function()
+  local cid
+
+  local add_mapping = function(mapping, send)
+    local str = 'mapped '..mapping
+    local cmd = "nnoremap "..mapping.." :call rpcnotify("..cid..", 'mapped', '"
+                ..send:gsub('<', '<lt>').."')<cr>"
+    execute(cmd)
+  end
+
+  local check_mapping = function(mapping, expected)
+    feed(mapping)
+    eq({'notification', 'mapped', {expected}}, next_message())
+  end
+
+  before_each(function()
+    clear()
+    cid = nvim('get_api_info')[1]
+    add_mapping('<s-up>', '<s-up>')
+    add_mapping('<s-up>', '<s-up>')
+    add_mapping('<c-s-up>', '<c-s-up>')
+    add_mapping('<c-s-a-up>', '<c-s-a-up>')
+  end)
+
+  it('ok', function()
+    check_mapping('<s-up>', '<s-up>')
+    check_mapping('<c-s-up>', '<c-s-up>')
+    check_mapping('<s-c-up>', '<c-s-up>')
+    check_mapping('<c-s-a-up>', '<c-s-a-up>')
+    check_mapping('<s-c-a-up>', '<c-s-a-up>')
+    check_mapping('<c-a-s-up>', '<c-s-a-up>')
+    check_mapping('<s-a-c-up>', '<c-s-a-up>')
+    check_mapping('<a-c-s-up>', '<c-s-a-up>')
+    check_mapping('<a-s-c-up>', '<c-s-a-up>')
+  end)
+end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1,0 +1,380 @@
+-- This module contains the Screen class, a complete Nvim screen implementation
+-- designed for functional testing. The goal is to provide a simple and
+-- intuitive API for verifying screen state after a set of actions.
+--
+-- The screen class exposes a single assertion method, "Screen:expect". This
+-- method takes a string representing the expected screen state and an optional
+-- set of attribute identifiers for checking highlighted characters(more on
+-- this later).
+--
+-- The string passed to "expect" will be processed according to these rules:
+--
+--  - Each line of the string represents and is matched individually against
+--    a screen row.
+--  - The entire string is stripped of common indentation
+--  - Expected screen rows are stripped of the last character. The last
+--    character should be used to write pipes(|) that make clear where the
+--    screen ends
+--  - The last line is stripped, so the string must have (row count + 1)
+--    lines.
+--
+-- Example usage:
+--
+--     local screen = Screen.new(25, 10)
+--     -- attach the screen to the current Nvim instance
+--     screen:attach()
+--     --enter insert mode and type some text
+--     feed('ihello screen')
+--     -- declare an expectation for the eventual screen state
+--     screen:expect([[
+--       hello screen             |
+--       ~                        |
+--       ~                        |
+--       ~                        |
+--       ~                        |
+--       ~                        |
+--       ~                        |
+--       ~                        |
+--       ~                        |
+--       -- INSERT --             |
+--     ]]) -- <- Last line is stripped
+--
+-- Since screen updates are received asynchronously, "expect" is actually
+-- specifying the eventual screen state. This is how "expect" works: It will
+-- start the event loop with a timeout of 5 seconds. Each time it receives an
+-- update the expected state will be checked against the updated state.
+--
+-- If the expected state matches the current state, the event loop will be
+-- stopped and "expect" will return.  If the timeout expires, the last match
+-- error will be reported and the test will fail.
+--
+-- If the second argument is passed to "expect", the screen rows will be
+-- transformed before being matched against the string lines. The
+-- transformation rule is simple: Each substring "S" composed with characters
+-- having the exact same set of attributes will be substituted by "{K:S}",
+-- where K is a key associated the attribute set via the second argument of
+-- "expect".
+--
+-- Too illustrate how this works, let's say that in the above example we wanted
+-- to assert that the "-- INSERT --" string is highlighted with the bold
+-- attribute(which normally is), here's how the call to "expect" should look
+-- like:
+--
+--     screen:expect([[
+--       hello screen             \
+--       ~                        \
+--       ~                        \
+--       ~                        \
+--       ~                        \
+--       ~                        \
+--       ~                        \
+--       ~                        \
+--       ~                        \
+--       {b:-- INSERT --}             \
+--     ]], {b = {bold = true}})
+--
+-- In this case "b" is a string associated with the set composed of one
+-- attribute: bold. Note that since the {b:} markup is not a real part of the
+-- screen, the delimiter(|) had to be moved right
+local helpers = require('test.functional.helpers')
+local request, run, stop = helpers.request, helpers.run, helpers.stop
+local eq, dedent = helpers.eq, helpers.dedent
+
+local Screen = {}
+Screen.__index = Screen
+
+function Screen.new(width, height)
+  if not width then
+    width = 53
+  end
+  if not height then
+    height = 14
+  end
+  return setmetatable({
+    _default_attr_ids = nil,
+    _width = width,
+    _height = height,
+    _rows = new_cell_grid(width, height),
+    _mode = 'normal',
+    _mouse_enabled = true,
+    _bell = false,
+    _visual_bell = false,
+    _suspended = true,
+    _attrs = {},
+    _cursor = {
+      enabled = true, row = 1, col = 1
+    },
+    _scroll_region = {
+      top = 1, bot = height, left = 1, right = width
+    }
+  }, Screen)
+end
+
+function Screen:set_default_attr_ids(attr_ids)
+  self._default_attr_ids = attr_ids
+end
+
+function Screen:attach()
+  request('attach_ui', self._width, self._height)
+  self._suspended = false
+end
+
+function Screen:detach()
+  request('detach_ui')
+  self._suspended = true
+end
+
+function Screen:expect(expected, attr_ids)
+  -- remove the last line and dedent
+  expected = dedent(expected:gsub('\n[ ]+$', ''))
+  local expected_rows = {}
+  for row in expected:gmatch('[^\n]+') do
+    -- the last character should be the screen delimiter
+    row = row:sub(1, #row - 1)
+    table.insert(expected_rows, row)
+  end
+  local ids = attr_ids or self._default_attr_ids
+  self:_wait(function()
+    for i = 1, self._height do
+      local expected_row = expected_rows[i]
+      local actual_row = self:_row_repr(self._rows[i], ids)
+      if expected_row ~= actual_row then
+        return 'Row '..tostring(i)..' didnt match.\nExpected: "'..
+               expected_row..'"\nActual:   "'..actual_row..'"'
+      end
+    end
+  end)
+end
+
+function Screen:_wait(check, timeout)
+  local err
+  local function notification_cb(method, args)
+    assert(method == 'redraw')
+    self:_redraw(args)
+    err = check()
+    if not err then
+      stop()
+    end
+    return true
+  end
+  run(nil, notification_cb, nil, timeout or 5000)
+  if err then
+    error(err)
+  end
+end
+
+function Screen:_redraw(updates)
+  for _, update in ipairs(updates) do
+    -- print('--')
+    -- print(require('inspect')(update))
+    local method = update[1]
+    for i = 2, #update do
+      local handler = self['_handle_'..method]
+      handler(self, unpack(update[i]))
+    end
+    -- print(self:_current_screen())
+  end
+end
+
+function Screen:_handle_resize(width, height)
+  self._rows = new_cell_grid(width, height)
+end
+
+function Screen:_handle_clear()
+  self:_clear_block(1, self._height, 1, self._width)
+end
+
+function Screen:_handle_eol_clear()
+  local row, col = self._cursor.row, self._cursor.col
+  self:_clear_block(row, 1, col, self._width - col)
+end
+
+function Screen:_handle_cursor_goto(row, col)
+  self._cursor.row = row + 1
+  self._cursor.col = col + 1
+end
+
+function Screen:_handle_cursor_on()
+  self._cursor.enabled = true
+end
+
+function Screen:_handle_cursor_off()
+  self._cursor.enabled = false
+end
+
+function Screen:_handle_mouse_on()
+  self._mouse_enabled = true
+end
+
+function Screen:_handle_mouse_off()
+  self._mouse_enabled = false
+end
+
+function Screen:_handle_insert_mode()
+  self._mode = 'insert'
+end
+
+function Screen:_handle_normal_mode()
+  self._mode = 'normal'
+end
+
+function Screen:_handle_set_scroll_region(top, bot, left, right)
+  self._scroll_region.top = top + 1
+  self._scroll_region.bot = bot + 1
+  self._scroll_region.left = left + 1
+  self._scroll_region.right = right + 1
+end
+
+function Screen:_handle_scroll(count)
+  local top = self._scroll_region.top
+  local bot = self._scroll_region.bot
+  local left = self._scroll_region.left
+  local right = self._scroll_region.right
+  local start, stop, step
+
+  if count > 0 then
+    start = top
+    stop = bot - count
+    step = 1
+  else
+    start = bot
+    stop = top - count
+    step = -1
+  end
+
+  -- shift scroll region
+  for i = start, stop, step do
+    local target = self._rows[i]
+    local source = self._rows[i + count]
+    self:_copy_row_section(target, source, left, right)
+  end
+
+  -- clear invalid rows
+  for i = stop + 1, stop + count, step do
+    self:_clear_row_section(i, left, right)
+  end
+end
+
+function Screen:_handle_highlight_set(attrs)
+  self._attrs = attrs
+end
+
+function Screen:_handle_put(str)
+  local cell = self._rows[self._cursor.row][self._cursor.col]
+  cell.text = str
+  cell.attrs = self._attrs
+  self._cursor.col = self._cursor.col + 1
+end
+
+function Screen:_handle_bell()
+  self._bell = true
+end
+
+function Screen:_handle_visual_bell()
+  self._visual_bell = true
+end
+
+function Screen:_handle_suspend()
+  self._suspended = true
+end
+
+function Screen:_clear_block(top, lines, left, columns)
+  for i = top, top + lines - 1 do
+    self:_clear_row_section(i, left, left + columns - 1)
+  end
+end
+
+function Screen:_clear_row_section(rownum, startcol, stopcol)
+  local row = self._rows[rownum]
+  for i = startcol, stopcol do
+    row[i].text = ' '
+    row[i].attrs = {}
+  end
+end
+
+function Screen:_copy_row_section(target, source, startcol, stopcol)
+  for i = startcol, stopcol do
+    target[i].text = source[i].text
+    target[i].attrs = source[i].attrs
+  end
+end
+
+function Screen:_row_repr(row, attr_ids)
+  local rv = {}
+  local current_attr_id
+  for i = 1, self._width do
+    local attr_id = get_attr_id(attr_ids, row[i].attrs)
+    if current_attr_id and attr_id ~= current_attr_id then
+      -- close current attribute bracket, add it before any whitespace
+      -- up to the current cell
+      -- table.insert(rv, backward_find_meaningful(rv, i), '}')
+      table.insert(rv, '}')
+      current_attr_id = nil
+    end
+    if not current_attr_id and attr_id then
+      -- open a new attribute bracket
+      table.insert(rv, '{' .. attr_id .. ':')
+      current_attr_id = attr_id
+    end
+    if self._rows[self._cursor.row] == row and self._cursor.col == i then
+      table.insert(rv, '^')
+    else
+      table.insert(rv, row[i].text)
+    end
+  end
+  if current_attr_id then
+    table.insert(rv, '}')
+  end
+  -- return the line representation, but remove empty attribute brackets and
+  -- trailing whitespace
+  return table.concat(rv, '')--:gsub('%s+$', '')
+end
+
+
+function Screen:_current_screen()
+  -- get a string that represents the current screen state(debugging helper)
+  local rv = {}
+  for i = 1, self._height do
+    table.insert(rv, "'"..self:_row_repr(self._rows[i]).."'")
+  end
+  return table.concat(rv, '\n')
+end
+
+function backward_find_meaningful(tbl, from)
+  for i = from or #tbl, 1, -1 do
+    if tbl[i] ~= ' ' then
+      return i + 1
+    end
+  end
+  return from
+end
+
+function new_cell_grid(width, height)
+  local rows = {}
+  for i = 1, height do
+    local cols = {}
+    for j = 1, width do
+      table.insert(cols, {text = ' ', attrs = {}})
+    end
+    table.insert(rows, cols)
+  end
+  return rows
+end
+
+function get_attr_id(attr_ids, attrs)
+  if not attr_ids then
+    return
+  end
+  for id, a in pairs(attr_ids) do
+    if a.bold == attrs.bold and a.standout == attrs.standout and
+       a.underline == attrs.underline and a.undercurl == attrs.undercurl and
+       a.italic == attrs.italic and a.reverse == attrs.reverse and
+       a.foreground == attrs.foreground and
+       a.background == attrs.background then
+       return id
+     end
+  end
+  return nil
+end
+
+return Screen

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -1,0 +1,224 @@
+local helpers = require('test.functional.helpers')
+local Screen = require('test.functional.ui.screen')
+local clear, feed, execute = helpers.clear, helpers.feed, helpers.execute
+local insert = helpers.insert
+
+describe('Screen', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new()
+    screen:attach()
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  describe('window', function()
+    describe('split', function()
+      it('horizontal', function()
+        execute('sp')
+        screen:expect([[
+          ^                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          [No Name]                                            |
+                                                               |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          [No Name]                                            |
+          :sp                                                  |
+        ]])
+      end)
+
+      it('horizontal and resize', function()
+        execute('sp')
+        execute('resize 8')
+        screen:expect([[
+          ^                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          [No Name]                                            |
+                                                               |
+          ~                                                    |
+          ~                                                    |
+          [No Name]                                            |
+          :resize 8                                            |
+        ]])
+      end)
+
+      it('horizontal and vertical', function()
+        execute('sp', 'vsp', 'vsp')
+        screen:expect([[
+          ^                   |                |               |
+          ~                   |~               |~              |
+          ~                   |~               |~              |
+          ~                   |~               |~              |
+          ~                   |~               |~              |
+          ~                   |~               |~              |
+          [No Name]            [No Name]        [No Name]      |
+                                                               |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          [No Name]                                            |
+                                                               |
+        ]])
+        insert('hello')
+        screen:expect([[
+          hell^               |hello           |hello          |
+          ~                   |~               |~              |
+          ~                   |~               |~              |
+          ~                   |~               |~              |
+          ~                   |~               |~              |
+          ~                   |~               |~              |
+          [No Name] [+]        [No Name] [+]    [No Name] [+]  |
+          hello                                                |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          [No Name] [+]                                        |
+                                                               |
+        ]])
+      end)
+    end)
+  end)
+
+  describe('tabnew', function()
+    it('creates a new buffer', function()
+      execute('sp', 'vsp', 'vsp')
+      insert('hello')
+      screen:expect([[
+        hell^               |hello           |hello          |
+        ~                   |~               |~              |
+        ~                   |~               |~              |
+        ~                   |~               |~              |
+        ~                   |~               |~              |
+        ~                   |~               |~              |
+        [No Name] [+]        [No Name] [+]    [No Name] [+]  |
+        hello                                                |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        [No Name] [+]                                        |
+                                                             |
+      ]])
+      execute('tabnew')
+      insert('hello2')
+      feed('h')
+      screen:expect([[
+         4+ [No Name]  + [No Name]                          X|
+        hell^2                                               |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+                                                             |
+      ]])
+      execute('tabprevious')
+      screen:expect([[
+         4+ [No Name]  + [No Name]                          X|
+        hell^               |hello           |hello          |
+        ~                   |~               |~              |
+        ~                   |~               |~              |
+        ~                   |~               |~              |
+        ~                   |~               |~              |
+        ~                   |~               |~              |
+        [No Name] [+]        [No Name] [+]    [No Name] [+]  |
+        hello                                                |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        [No Name] [+]                                        |
+                                                             |
+      ]])
+    end)
+  end)
+
+  describe('insert mode', function()
+    it('move to next line with <cr>', function()
+      feed('iline 1<cr>line 2<cr>')
+      screen:expect([[
+        line 1                                               |
+        line 2                                               |
+        ^                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        -- INSERT --                                         |
+      ]])
+    end)
+  end)
+
+  describe('command mode', function()
+    it('typing commands', function()
+      feed(':ls')
+      screen:expect([[
+                                                             |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        :ls^                                                 |
+      ]])
+    end)
+
+    it('execute command with multi-line output', function()
+      feed(':ls<cr>')
+      screen:expect([[
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        :ls                                                  |
+          1 %a   "[No Name]"                    line 1       |
+        Press ENTER or type command to continue^             |
+      ]])
+      feed('<cr>') --  skip the "Press ENTER..." state or tests will hang
+    end)
+  end)
+end)


### PR DESCRIPTION
Implement a builtin termcap based on the old gui. This is how Nvim behaves when the "abstract_ui" termcap is activated:
- No data is written/read to stdout/stdin by default.
- Instead of sending data to stdout, ui_write will parse the termcap codes
  and invoke dispatch functions in the ui.c module.
- The dispatch functions will forward the calls to all attached UI instances.
- Like with the "builtin_gui" termcap, "abstract_ui" does not contain any key
  sequences. Instead, vim key strings(<cr>, <esc>, etc) are parsed directly by
  input_enqueue and the translated strings are pushed to the input buffer.

With this new input model, its not possible to send mouse events yet. Thats
because mouse sequence parsing happens in term.c/check_termcodes which returns
early when "abstract_ui" is activated.

On top of the new UI infrastructure, a remote_ui module was added. It enables
the implementation of remote UIs via msgpack-rpc.

This will replace #781 and is the beginning of a complete refactor of the UI layer
