### PR TITLE
[RFC] Move breakcheck functions from misc1.c to breakcheck.c

### DIFF
--- a/src/nvim/breakcheck.c
+++ b/src/nvim/breakcheck.c
@@ -1,0 +1,28 @@
+#include "nvim/breakcheck.h"
+#include "nvim/os/input.h"
+
+// Functions to reduce os_breakcheck() calls
+
+static const int kBreakCheckSkip = 32;
+static int skip_count = 0;
+
+// Checks for CTRL-C pressed, but only once in a while.
+// Should be used instead of os_breakcheck() for functions that check for
+// each line in the file.  Calling os_breakcheck() each time takes too much
+// time, because it can be a system call.
+void line_breakcheck(void)
+{
+  if (++skip_count >= kBreakCheckSkip) {
+    skip_count = 0;
+    os_breakcheck();
+  }
+}
+
+// Like line_breakcheck() but checks 10 times less often.
+void fast_breakcheck(void)
+{
+  if (++skip_count >= kBreakCheckSkip * 10) {
+    skip_count = 0;
+    os_breakcheck();
+  }
+}

--- a/src/nvim/breakcheck.h
+++ b/src/nvim/breakcheck.h
@@ -1,0 +1,7 @@
+#ifndef NVIM_BREAKCHECK_H
+#define NVIM_BREAKCHECK_H
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "breakcheck.h.generated.h"
+#endif
+#endif  // NVIM_BREAKCHECK_H

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -38,6 +38,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/keymap.h"
 #include "nvim/move.h"

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -53,6 +53,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/keymap.h"
 #include "nvim/file_search.h"

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -43,6 +43,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -36,6 +36,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/garray.h"
 #include "nvim/memory.h"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -43,6 +43,7 @@
 #include "nvim/menu.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/keymap.h"
 #include "nvim/file_search.h"

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -42,6 +42,7 @@
 #include "nvim/menu.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/memory.h"
 #include "nvim/cursor_shape.h"

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -37,6 +37,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -29,6 +29,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/garray.h"
 #include "nvim/move.h"

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -36,6 +36,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -61,6 +61,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/option.h"
 #include "nvim/os_unix.h"

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -3361,38 +3361,6 @@ void preserve_exit(void)
   getout(1);
 }
 
-/*
- * Check for CTRL-C pressed, but only once in a while.
- * Should be used instead of os_breakcheck() for functions that check for
- * each line in the file.  Calling os_breakcheck() each time takes too much
- * time, because it can be a system call.
- */
-
-#ifndef BREAKCHECK_SKIP
-#  define BREAKCHECK_SKIP 32
-#endif
-
-static int breakcheck_count = 0;
-
-void line_breakcheck(void)
-{
-  if (++breakcheck_count >= BREAKCHECK_SKIP) {
-    breakcheck_count = 0;
-    os_breakcheck();
-  }
-}
-
-/*
- * Like line_breakcheck() but check 10 times less often.
- */
-void fast_breakcheck(void)
-{
-  if (++breakcheck_count >= BREAKCHECK_SKIP * 10) {
-    breakcheck_count = 0;
-    os_breakcheck();
-  }
-}
-
 #ifndef SEEK_SET
 # define SEEK_SET 0
 #endif

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -43,6 +43,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/keymap.h"
 #include "nvim/move.h"

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -36,6 +36,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/move.h"
 #include "nvim/normal.h"

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -36,6 +36,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -59,6 +59,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/garray.h"
 #include "nvim/strings.h"

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -37,6 +37,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/move.h"
 #include "nvim/mouse.h"

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -312,6 +312,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/garray.h"
 #include "nvim/normal.h"

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -33,6 +33,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -35,6 +35,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/file_search.h"
 #include "nvim/garray.h"

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -98,6 +98,7 @@
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
+#include "nvim/breakcheck.h"
 #include "nvim/misc2.h"
 #include "nvim/memory.h"
 #include "nvim/garray.h"


### PR DESCRIPTION
Contributes to #209 by extracting the functions `line_breakcheck()` and `fast_breakcheck()` from misc1.c and putting them into a new module consisting of breakcheck.h and breakcheck.c  
I also refactored the code to meet neovim's style guide.
