### PR TITLE
[RDY] Fix shell command output

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -97,9 +97,10 @@ if(USE_BUNDLED_LIBUNIBILIUM)
       -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
     CONFIGURE_COMMAND ""
     BUILD_IN_SOURCE 1
-    BUILD_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
+    BUILD_COMMAND ${MAKE_PRG} CC=${CMAKE_C_COMPILER}
                               PREFIX=${DEPS_INSTALL_DIR}
-                              CFLAGS=-fPIC
+                              CFLAGS+=${CMAKE_C_COMPILER_ARG1}
+                              CFLAGS+=-fPIC
     INSTALL_COMMAND ${MAKE_PRG} PREFIX=${DEPS_INSTALL_DIR} install)
   list(APPEND THIRD_PARTY_DEPS libunibilium)
 endif()
@@ -120,10 +121,11 @@ if(USE_BUNDLED_LIBTERMKEY)
     CONFIGURE_COMMAND ""
     BUILD_IN_SOURCE 1
     BUILD_COMMAND ""
-    INSTALL_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
+    INSTALL_COMMAND ${MAKE_PRG} CC=${CMAKE_C_COMPILER}
                                 PREFIX=${DEPS_INSTALL_DIR}
                                 PKG_CONFIG_PATH=${DEPS_LIB_DIR}/pkgconfig
-                                CFLAGS=-fPIC
+                                CFLAGS+=${CMAKE_C_COMPILER_ARG1}
+                                CFLAGS+=-fPIC
                                 install)
   list(APPEND THIRD_PARTY_DEPS libtermkey)
   add_dependencies(libtermkey libunibilium)
@@ -145,10 +147,11 @@ if(USE_BUNDLED_LIBTICKIT)
     CONFIGURE_COMMAND ""
     BUILD_IN_SOURCE 1
     BUILD_COMMAND ""
-    INSTALL_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
+    INSTALL_COMMAND ${MAKE_PRG} CC=${CMAKE_C_COMPILER}
                                 PREFIX=${DEPS_INSTALL_DIR}
                                 PKG_CONFIG_PATH=${DEPS_LIB_DIR}/pkgconfig
-                                CFLAGS=-fPIC
+                                CFLAGS+=${CMAKE_C_COMPILER_ARG1}
+                                CFLAGS+=-fPIC
                                 install)
   list(APPEND THIRD_PARTY_DEPS libtickit)
   add_dependencies(libtickit libtermkey)


### PR DESCRIPTION
Shell command output was broken in @8a5a8db, which refactored nvim to no longer
switch to cooked mode(linefeeds are processed differently).

Fix the problem by refactoring write_output to accept to extra arguments that
control the flushing behavior and where data will be written to: buffer or
raw editor screen.

Close #1612.
