### PR TITLE
Unit test tempfile - add more test cases

### DIFF
--- a/test/unit/tempfile_spec.lua
+++ b/test/unit/tempfile_spec.lua
@@ -1,41 +1,43 @@
+local cimport, vim_init, ffi, to_cstr, eq, neq = (function()
+  local _ = require 'test.unit.helpers'
+  return _.cimport, _.vim_init, _.ffi, _.to_cstr, _.eq, _.neq
+end)()
+
 local lfs = require 'lfs'
 
-local helpers = require 'test.unit.helpers'
-local cimport, vim_init, ffi, to_cstr =
-  helpers.cimport, helpers.vim_init, helpers.ffi, helpers.to_cstr
+local os = cimport './src/nvim/os/os.h'
 
-local os = helpers.cimport './src/nvim/os/os.h'
-local os_isdir, os_file_is_writable, os_file_exists =
-  os.os_isdir, os.os_file_is_writable, os.os_file_exists
-
-local is_dir = function(x) return os_isdir(x) end
+-- is_dir('/a/b/') will return true if '/a/b/' is a directory name
+local is_dir = function(x) return 'directory' == lfs.attributes(x, 'mode') end
 
 -- os_file_is_writable returns 2 for a directory which we have rights
 -- to write into.
-local is_writable = function(x) return os_file_is_writable(to_cstr(x)) == 2 end
+local is_writable = function(x) return os.os_file_is_writable(to_cstr(x)) == 2 end
 
+-- is_empty('/a/b/') will return true if 'a/b/' is a directory linking only to itself and the parent dir
 local is_empty = function(x)
-  local r = true
   for f in lfs.dir(x) do
-    r = r and (f == '.' or f == '..')
+    if f ~= '.' and f ~= '..' then return false end
   end
-  return r
+  return true
 end
 
-local file_exists = function(x) return os_file_exists(x) end
+-- file_exists('/a/b/c') will return true if '/a/b/c' is an existing file
+local file_exists = os.os_file_exists
 
+-- path_contains_dir('/a/b/c', '/a/b/') will return true
 local path_contains_dir = function(path, dir)
   return (path ~= nil) and (path:find("^" .. tostring(dir) .. "[^/]*$") ~= nil)
 end
 
+-- dir_of_path('/a/b/c') will return '/a/b/'
 local dir_of_path = function(path)
   return path:match('(.-)[^/]+$') or ''
 end
 
 local ok = function(x) return assert.True(x) end
-local notok = function(x) return assert.False(x) end
 
-local tempfile = helpers.cimport './src/nvim/tempfile.h'
+local tempfile = cimport './src/nvim/tempfile.h'
 local vim_gettempdir = function() return ffi.string(tempfile.vim_gettempdir()) end
 local vim_tempname = function() return ffi.string(tempfile.vim_tempname()) end
 local vim_deltempdir = function() return tempfile.vim_deltempdir() end
@@ -51,51 +53,49 @@ describe('tempfile module:', function()
     it('generates directory name to a writable, empty directory on first call', function()
       local dir = vim_gettempdir()
       ok(dir ~= nil and dir:len() > 0)
-      ok((is_dir(dir)) and (is_writable(dir)) and (is_empty(dir)))
+      ok(is_dir(dir))
+      ok(is_writable(dir))
+      ok(is_empty(dir))
     end)
 
     it('generates a directory which can be later deleted', function()
       local dir = vim_gettempdir()
       ok(is_dir(dir))
       vim_deltempdir()
-      notok(is_dir(dir))
+      ok(not is_dir(dir))
     end)
 
     context('called successively', function()
 
       it('generates the same directory name', function()
-        local dir1, dir2
-        dir1 = vim_gettempdir()
-        dir2 = vim_gettempdir()
+        local dir1 = vim_gettempdir()
+        local dir2 = vim_gettempdir()
         ok(dir1 == dir2)
       end)
 
       it('interrupted by generating a file name, generates the same directory name', function()
-        local dir1, dir2
-        dir1 = vim_gettempdir()
+        local dir1 = vim_gettempdir()
         vim_tempname()
-        dir2 = vim_gettempdir()
-        ok(dir1 == dir2)
+        local dir2 = vim_gettempdir()
+        eq(dir1, dir2)
       end)
 
       it('interrupted by deleting the temp directory, generates different directory names with corresponding directories', function()
-        local dir1, dir2
-        dir1 = vim_gettempdir()
+        local dir1 = vim_gettempdir()
         ok(is_dir(dir1))
         vim_deltempdir()
-        dir2 = vim_gettempdir()
+        local dir2 = vim_gettempdir()
         ok(is_dir(dir2))
-        ok(dir1 ~= dir2)
+        neq(dir1, dir2)
       end)
 
       it('interrupted by externally deleting the temp directory, generates the same directory name and with no corresponding director ', function()
-        local dir1, dir2
-        dir1 = vim_gettempdir()
+        local dir1 = vim_gettempdir()
         ok(is_dir(dir1))
         ok(lfs.rmdir(dir1))
-        dir2 = vim_gettempdir()
-        notok(is_dir(dir2))
-        notok(dir1 ~= dir2)
+        local dir2 = vim_gettempdir()
+        ok(not is_dir(dir2))
+        eq(dir1, dir2)
       end)
     end)
   end)
@@ -105,45 +105,41 @@ describe('tempfile module:', function()
     it('generates path name of a non-existing file in temp directory', function()
       local path, dir = vim_tempname(), vim_gettempdir()
       ok(path_contains_dir(path, dir))
-      notok(file_exists(path))
+      ok(not file_exists(path))
     end)
 
     context('called successively', function()
 
       it('generates different paths with a common temp directory', function()
         local path1, path2 = vim_tempname(), vim_tempname()
-        ok(path1 ~= path2)
-        ok(dir_of_path(path1) == dir_of_path(path2))
+        neq(path1, path2)
+        eq(dir_of_path(path1), dir_of_path(path2))
       end)
 
       it('interrupted by generating a directory name, generates different paths with a common temp directory', function()
-        local path1, path2
-        path1 = vim_tempname()
+        local path1 = vim_tempname()
         vim_gettempdir()
-        path2 = vim_tempname()
-        ok(path1 ~= path2)
-        ok(dir_of_path(path1) == dir_of_path(path2))
+        local path2 = vim_tempname()
+        neq(path1, path2)
+        eq(dir_of_path(path1), dir_of_path(path2))
       end)
 
       it('interrupted by deleting the temp directory, generates paths with different temp directories', function()
-        local path1, path2
-        path1 = vim_tempname()
+        local path1 = vim_tempname()
         vim_deltempdir()
-        path2 = vim_tempname()
-        ok(path1 ~= path2)
-        notok(dir_of_path(path1) == dir_of_path(path2))
+        local path2 = vim_tempname()
+        neq(path1, path2)
+        neq(dir_of_path(path1), dir_of_path(path2))
       end)
 
       it('interrupted by externally deleting the temp directory, generates a path that is no longer useful', function()
-        local path1, path2
-        local dir1, dir2
-        path1 = vim_tempname()
-        dir1 = dir_of_path(path1)
+        local path1 = vim_tempname()
+        local dir1 = dir_of_path(path1)
         ok(lfs.rmdir(dir1))
-        path2 = vim_tempname()
-        dir2 = dir_of_path(path2)
-        ok(path1 ~= path2)
-        ok(dir1 == dir2)
+        local path2 = vim_tempname()
+        local dir2 = dir_of_path(path2)
+        neq(path1, path2)
+        eq(dir1, dir2)
         ok(path_contains_dir(path2, dir1))
       end)
     end)

--- a/test/unit/tempfile_spec.lua
+++ b/test/unit/tempfile_spec.lua
@@ -70,7 +70,7 @@ describe('tempfile module:', function()
       it('generates the same directory name', function()
         local dir1 = vim_gettempdir()
         local dir2 = vim_gettempdir()
-        ok(dir1 == dir2)
+        eq(dir1, dir2)
       end)
 
       it('interrupted by generating a file name, generates the same directory name', function()

--- a/test/unit/tempfile_spec.lua
+++ b/test/unit/tempfile_spec.lua
@@ -1,60 +1,84 @@
 local lfs = require 'lfs'
+
 local helpers = require 'test.unit.helpers'
+local cimport, vim_init, ffi, to_cstr =
+  helpers.cimport, helpers.vim_init, helpers.ffi, helpers.to_cstr
 
 local os = helpers.cimport './src/nvim/os/os.h'
-local tempfile = helpers.cimport './src/nvim/tempfile.h'
+local os_isdir, os_file_is_writable, os_file_exists =
+  os.os_isdir, os.os_file_is_writable, os.os_file_exists
 
-helpers.vim_init()
+local is_dir = function(x) return os_isdir(x) end
 
-describe('tempfile related functions', function()
-  after_each(function()
-    tempfile.vim_deltempdir()
-  end)
+-- os_file_is_writable returns 2 for a directory which we have rights
+-- to write into.
+local is_writable = function(x) return os_file_is_writable(to_cstr(x)) == 2 end
 
-  local vim_gettempdir = function()
-    return helpers.ffi.string(tempfile.vim_gettempdir())
+local is_empty = function(x)
+  local r = true
+  for f in lfs.dir(x) do
+    r = r and (f == '.' or f == '..')
   end
+  return r
+end
+
+local file_exists = function(x) return os_file_exists(x) end
+
+local path_contains_dir = function(path, dir)
+  return (path ~= nil) and (path:find("^" .. tostring(dir) .. "[^/]*$") ~= nil)
+end
+
+local dir_of_path = function(path)
+  return path:match('(.-)[^/]+$') or ''
+end
+
+local ok = function(x) return assert.True(x) end
+local notok = function(x) return assert.False(x) end
+
+local tempfile = helpers.cimport './src/nvim/tempfile.h'
+local vim_gettempdir = function() return ffi.string(tempfile.vim_gettempdir()) end
+local vim_tempname = function() return ffi.string(tempfile.vim_tempname()) end
+local vim_deltempdir = function() return tempfile.vim_deltempdir() end
+
+vim_init()
+
+describe('#tempfile module:', function()
+
+  after_each(function() vim_deltempdir() end)
 
   describe('vim_gettempdir', function()
-    it('returns path to Neovim own temp directory', function()
+    it('generates directory name to a writable, empty directory on first call', function()
       local dir = vim_gettempdir()
-      assert.True(dir ~= nil and dir:len() > 0)
-      -- os_file_is_writable returns 2 for a directory which we have rights
-      -- to write into.
-      assert.equals(os.os_file_is_writable(helpers.to_cstr(dir)), 2)
-      for entry in lfs.dir(dir) do
-        assert.True(entry == '.' or entry == '..')
-      end
+      ok(dir ~= nil and dir:len() > 0)
+      ok((is_dir(dir)) and (is_writable(dir)) and (is_empty(dir)))
     end)
 
-    it('returns the same directory on each call', function()
-      local dir1 = vim_gettempdir()
-      local dir2 = vim_gettempdir()
-      assert.equals(dir1, dir2)
+    context('called successively', function()
+
+      it('returns the same directory on each call', function()
+        local dir1 = vim_gettempdir()
+        local dir2 = vim_gettempdir()
+        ok(dir1 == dir2)
+      end)
     end)
   end)
 
   describe('vim_tempname', function()
-    local vim_tempname = function()
-      return helpers.ffi.string(tempfile.vim_tempname())
-    end
 
-    it('generate name of non-existing file', function()
-      local file = vim_tempname()
-      assert.truthy(file)
-      assert.False(os.os_file_exists(file))
+    it('generates path name of a non-existing file in temp directory', function()
+      local path, dir = vim_tempname(), vim_gettempdir()
+      ok(path_contains_dir(path, dir))
+      notok(file_exists(path))
     end)
 
-    it('generate different names on each call', function()
-      local fst = vim_tempname()
-      local snd = vim_tempname()
-      assert.not_equals(fst, snd)
-    end)
+    context('called successively', function()
 
-    it('generate file name in Neovim own temp directory', function()
-      local dir = vim_gettempdir()
-      local file = vim_tempname()
-      assert.truthy(file:find('^' .. dir .. '[^/]*$'))
+      it('generates different paths with a common temp directory', function()
+        local path1 = vim_tempname()
+        local path2 = vim_tempname()
+        ok(path1 ~= path2)
+        ok(dir_of_path(path1) == dir_of_path(path2))
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
The two commits in this PR originates as a followup to issue #1432. I wanted to add a test case or two to detect the issue. In the act of doing this, I realize a few more test cases of a similar nature could be added. Also, I added a test to directly verify temp directory deletion.

The new test cases are mostly concerned with testing two successive calls of gettempdir or tempname, and when the calls are interrupted by deleting the temp directory, or by doing the other operation. For example,
1. gettempdir, gettempdir
2. gettempdir, deltempdir, gettempdir - 'internally' delete temp directory
3. gettempdir, lfs.rmdir, gettempdir - 'externally' delete temp directory
4. gettempdir, tempname, gettempdir

Test case 1 appears in the original unit test, which is a check for idempotency.
Test case 4 checks for any side effects between gettempdir and tempname.
Test case 3 checks for #1432 and is to be compared with test case 2. Test case 3 is written to succeed, although it should more naturally fail, if it wasn't for the performance hit that will occur (see comments in #1432).

A similar test sequence is repeated for tempname.

Roughly speaking, the first commit re-expresses the original unit test with shortcut aliases so there is less verbosity. The first commit also merges two of the test cases into one. The second commit adds the extra test cases.
