### PR TITLE
[RDY] Reimplement :drop

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3291,3 +3291,79 @@ static void script_host_do_range(char *name, exarg_T *eap)
   (void)eval_call_provider(name, "do_range", args);
 }
 
+/*
+ * ":drop"
+ * Opens the first argument in a window.  When there are two or more arguments
+ * the argument list is redefined.
+ */
+void ex_drop(exarg_T   *eap)
+{
+    int                split = FALSE;
+    buf_T      *buf;
+
+    /*
+     * Check if the first argument is already being edited in a window.  If
+     * so, jump to that window.
+     * We would actually need to check all arguments, but that's complicated
+     * and mostly only one file is dropped.
+     * This also ignores wildcards, since it is very unlikely the user is
+     * editing a file name with a wildcard character.
+     */
+    do_arglist(eap->arg, AL_SET, 0);
+
+    /*
+     * Expanding wildcards may result in an empty argument list.  E.g. when
+     * editing "foo.pyc" and ".pyc" is in 'wildignore'.  Assume that we
+     * already did an error message for this.
+     */
+    if (ARGCOUNT == 0)
+       return;
+
+    if (cmdmod.tab)
+    {
+       /* ":tab drop file ...": open a tab for each argument that isn't
+        * edited in a window yet.  It's like ":tab all" but without closing
+        * windows or tabs. */
+       ex_all(eap);
+    }
+    else
+    {
+       /* ":drop file ...": Edit the first argument.  Jump to an existing
+        * window if possible, edit in current window if the current buffer
+        * can be abandoned, otherwise open a new window. */
+       buf = buflist_findnr(ARGLIST[0].ae_fnum);
+
+       FOR_ALL_TAB_WINDOWS(tp, wp)
+       {
+           if (wp->w_buffer == buf)
+           {
+               goto_tabpage_win(tp, wp);
+               curwin->w_arg_idx = 0;
+               return;
+           }
+       }
+
+       /*
+        * Check whether the current buffer is changed. If so, we will need
+        * to split the current window or data could be lost.
+        * Skip the check if the 'hidden' option is set, as in this case the
+        * buffer won't be lost.
+        */
+       if (!P_HID(curbuf))
+       {
+           ++emsg_off;
+           split = check_changed(curbuf, CCGD_AW | CCGD_EXCMD);
+           --emsg_off;
+       }
+
+       /* Fake a ":sfirst" or ":first" command edit the first argument. */
+       if (split)
+       {
+           eap->cmdidx = CMD_sfirst;
+           eap->cmd[0] = 's';
+       }
+       else
+           eap->cmdidx = CMD_first;
+       ex_rewind(eap);
+    }
+}

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -135,7 +135,6 @@ struct dbg_stuff {
 #endif
 
 # define HAVE_EX_SCRIPT_NI
-# define ex_drop                ex_ni
 # define ex_gui                 ex_nogui
 # define ex_tearoff             ex_ni
 # define ex_popup               ex_ni


### PR DESCRIPTION
The :drop ex command was inadvertently removed when removing FEAT_GUI. See issue #1132.
This patch reintroduces it.
