### PR TITLE
[RFC] CMake: Remove shared libraries for messagepack.

### DIFF
--- a/third-party/cmake/InstallMsgpack.cmake
+++ b/third-party/cmake/InstallMsgpack.cmake
@@ -6,7 +6,7 @@ if(NOT res EQUAL 0)
   message(FATAL_ERROR "Installing msgpack failed.")
 endif()
 
-file(GLOB FILES_TO_REMOVE ${REMOVE_FILE_GLOB})
+file(GLOB_RECURSE FILES_TO_REMOVE ${REMOVE_FILE_GLOB})
 if(FILES_TO_REMOVE)
   file(REMOVE ${FILES_TO_REMOVE})
 endif()


### PR DESCRIPTION
The first commit is a quick fix for the "subdirectory problem" pointed out by @jszakmeister in https://github.com/neovim/neovim/issues/1579#issuecomment-64996605. With this, I managed to build an Ubuntu package (although I didn't try to install it yet, so I don't know if it executes).

Also noticed that shared libraries for the new dependencies (libtickit etc) were still there; I tried to adapt the msgpack install script, but it didn't really work out yet.. these changes are in a separate commit.
