### PR TITLE
[WIP] Replace vim_strbyte with standard strchr

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5534,10 +5534,10 @@ helptags_one (
       }
       p1 = vim_strchr(IObuff, '*');             /* find first '*' */
       while (p1 != NULL) {
-        /* Use vim_strbyte() instead of vim_strchr() so that when
+        /* Use strchr() instead of vim_strchr() so that when
          * 'encoding' is dbcs it still works, don't find '*' in the
          * second byte. */
-        p2 = vim_strbyte(p1 + 1, '*');          /* find second '*' */
+        p2 = (char_u*)strchr((char*)(p1 + 1), '*');          /* find second '*' */
         if (p2 != NULL && p2 > p1 + 1) {        /* skip "*" and "**" */
           for (s = p1 + 1; s < p2; ++s)
             if (*s == ' ' || *s == '\t' || *s == '|')

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -651,7 +651,7 @@ void remove_bom(char_u *s)
   if (enc_utf8) {
     char_u *p = s;
 
-    while ((p = vim_strbyte(p, 0xef)) != NULL) {
+    while ((p = (char_u*)strchr((char*)p, 0xef)) != NULL) {
       if (p[1] == 0xbb && p[2] == 0xbf)
         STRMOVE(p, p + 3);
       else

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -3408,7 +3408,7 @@ static long bt_regexec_both(char_u *line,
     if (!ireg_ic
         && !has_mbyte
         )
-      while ((s = vim_strbyte(s, c)) != NULL) {
+      while ((s = (char_u*)strchr((char*)s, c)) != NULL) {
         if (cstrncmp(s, prog->regmust, &prog->regmlen) == 0)
           break;                        /* Found it. */
         ++s;
@@ -3460,7 +3460,7 @@ static long bt_regexec_both(char_u *line,
         if (!ireg_ic
             && !has_mbyte
             )
-          s = vim_strbyte(regline + col, prog->regstart);
+          s = (char_u*)strchr((char*)(regline + col), prog->regstart);
         else
           s = cstrchr(regline + col, prog->regstart);
         if (s == NULL) {

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -4722,7 +4722,7 @@ static int skip_to_start(int c, colnr_T *colp)
   if (!ireg_ic
       && !has_mbyte
       )
-    s = vim_strbyte(regline + *colp, c);
+    s = (char_u*)strchr((char*)(regline + *colp), c);
   else
     s = cstrchr(regline + *colp, c);
   if (s == NULL)


### PR DESCRIPTION
According to the issue #1476, we should use the standard function strchr instead of the function vim_strbyte defined in strings.c.
