### PR TITLE
[RDY] Remove 2-iteration loop in syn_combine_list() (rebase)

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4562,13 +4562,14 @@ static int syn_compare_stub(const void *v1, const void *v2)
   return *s1 > *s2 ? 1 : *s1 < *s2 ? -1 : 0;
 }
 
-/// Counts the unique elements in lists g1 & g2
+/// Count how many elements will be necessary for the list resulting from the
+/// list_op operation on the two lists.
 ///
-/// @param g1       Pointer to list 1
-/// @param g2       Pointer to list 2
-/// @param list_op  Option for combining the lists
-///
-/// @return Count of unique elements in g1 & g2
+/// @param g1 The first sorted NUL terminated list
+/// @param g2 The second sorted NUL terminated list
+/// @param list_op The operation that will be performed on the two lists
+/// @return The count of elemnts of the list resulting from the list_op
+/// operation on the two lists
 static int syn_combine_list_count(const short *g1, const short *g2, int list_op)
 {
   int count = 0;
@@ -4594,11 +4595,10 @@ static int syn_combine_list_count(const short *g1, const short *g2, int list_op)
   }
 
   // Now add the leftovers from whichever list didn't get finished first.
-  // As before, only add from the second list if we're adding the lists.
   for (; *g1; g1++) {
     count++;
   }
-
+  // As before, only add from the second list if we're adding the lists.
   if (list_op == CLUSTER_ADD) {
     for (; *g2; g2++) {
       count++;
@@ -4608,15 +4608,13 @@ static int syn_combine_list_count(const short *g1, const short *g2, int list_op)
   return count;
 }
 
-/// Merges the 2 lists g1 & g2 and puts results in clrstr
+/// Combines two lists according to list_op using the mergesort algorithm.
 ///
-/// Uses a mergesort-like method, adding the smaller of the current
-/// elements in each list to the new list.
-///
-/// @param      g1      Pointer to list 1
-/// @param      g2      Pointer to list 2
-/// @param      list_op Option for combining the lists
-/// @param[out] clstr   Pointer to the merged list
+/// @param g1 The first sorted NUL terminated list
+/// @param g2 The second sorted NUL terminated list
+/// @param list_op The type of combination (operation) that should be performed
+/// on the two lists
+/// @param[out] clstr Pointer to the resulting list
 static void syn_combine_list_merge(const short *g1, const short *g2, int list_op, short *clstr)
 {
   int i = 0;
@@ -4642,11 +4640,10 @@ static void syn_combine_list_merge(const short *g1, const short *g2, int list_op
   }
 
   // Now add the leftovers from whichever list didn't get finished first.
-  // As before, only add from the second list if we're adding the lists.
   for (; *g1; g1++) {
     clstr[i++] = *g1;
   }
-
+  // As before, only add from the second list if we're adding the lists.
   if (list_op == CLUSTER_ADD) {
     for (; *g2; g2++) {
       clstr[i++] = *g2;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4570,9 +4570,9 @@ static int syn_compare_stub(const void *v1, const void *v2)
 /// @param list_op The operation that will be performed on the two lists
 /// @return The count of elemnts of the list resulting from the list_op
 /// operation on the two lists
-static int syn_combine_list_count(const short *g1, const short *g2, int list_op)
+static size_t syn_combine_list_count(const short *g1, const short *g2, int list_op)
 {
-  int count = 0;
+  size_t count = 0;
 
   // Loop through the lists until one of them is empty.
   while (*g1 && *g2) {
@@ -4616,7 +4616,7 @@ static int syn_combine_list_count(const short *g1, const short *g2, int list_op)
 /// @param[out] clstr Pointer to the resulting list
 static void syn_combine_list_merge(const short *g1, const short *g2, int list_op, short *clstr)
 {
-  int i = 0;
+  size_t i = 0;
 
   // Loop through the lists until one of them is empty.
   while (*g1 && *g2) {
@@ -4655,11 +4655,8 @@ static void syn_combine_list_merge(const short *g1, const short *g2, int list_op
  */
 static void syn_combine_list(short **clstr1, short **clstr2, int list_op)
 {
-  int count1 = 0;
-  int count2 = 0;
   short       *g1;
   short       *g2;
-  int count;
 
   /*
    * Handle degenerate cases.
@@ -4676,19 +4673,23 @@ static void syn_combine_list(short **clstr1, short **clstr2, int list_op)
     return;
   }
 
-  for (g1 = *clstr1; *g1; g1++)
+  size_t count1 = 0;
+  for (g1 = *clstr1; *g1; g1++) {
     ++count1;
-  for (g2 = *clstr2; *g2; g2++)
+  }
+  size_t count2 = 0;
+  for (g2 = *clstr2; *g2; g2++) {
     ++count2;
+  }
 
   /*
    * For speed purposes, sort both lists.
    */
-  qsort(*clstr1, (size_t)count1, sizeof(short), syn_compare_stub);
-  qsort(*clstr2, (size_t)count2, sizeof(short), syn_compare_stub);
+  qsort(*clstr1, count1, sizeof(short), syn_compare_stub);
+  qsort(*clstr2, count2, sizeof(short), syn_compare_stub);
 
   //  Count the elements to place in the new list
-  count = syn_combine_list_count(*clstr1, *clstr2, list_op);
+  size_t count = syn_combine_list_count(*clstr1, *clstr2, list_op);
 
   // If the group ended up empty, we don't need to allocate any space for it.
   short *clstr = NULL;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4565,8 +4565,8 @@ static int syn_compare_stub(const void *v1, const void *v2)
 /// Count how many elements will be necessary for the list resulting from the
 /// list_op operation on the two lists.
 ///
-/// @param g1 The first sorted NUL terminated list
-/// @param g2 The second sorted NUL terminated list
+/// @param g1 The first sorted zero-terminated list
+/// @param g2 The second sorted zero-terminated list
 /// @param list_op The operation that will be performed on the two lists
 /// @return The count of elemnts of the list resulting from the list_op
 /// operation on the two lists
@@ -4586,6 +4586,8 @@ static size_t syn_combine_list_count(const short *g1, const short *g2, int list_
         count++;
       }
 
+      // Count only unique elements and elements that are not removed
+      // (list_op == CLUSTER_SUBTRACT) from the result list.
       if (*g1 == *g2) {
         g1++;
       }
@@ -4607,10 +4609,10 @@ static size_t syn_combine_list_count(const short *g1, const short *g2, int list_
   return count;
 }
 
-/// Combines two lists according to list_op using the mergesort algorithm.
+/// Combines two lists according to list_op using a merge algorithm.
 ///
-/// @param g1 The first sorted NUL terminated list
-/// @param g2 The second sorted NUL terminated list
+/// @param g1 The first sorted zero-terminated list
+/// @param g2 The second sorted zero-terminated list
 /// @param list_op The type of combination (operation) that should be performed
 /// on the two lists
 /// @param[out] clstr Pointer to the resulting list
@@ -4630,6 +4632,8 @@ static void syn_combine_list_merge(const short *g1, const short *g2, int list_op
         clstr[i++] = *g2;
       }
 
+      // Add only unique elements and elements that are not removed
+      // (list_op == CLUSTER_SUBTRACT) from the result list.
       if (*g1 == *g2) {
         g1++;
       }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4580,18 +4580,17 @@ static int syn_combine_list_count(const short *g1, const short *g2, int list_op)
     if (*g1 < *g2) {
       count++;
       g1++;
-      continue;
-    }
+    } else {
+      // Only add from the second list if we're adding the lists.
+      if (list_op == CLUSTER_ADD) {
+        count++;
+      }
 
-    // Only add from the second list if we're adding the lists.
-    if (list_op == CLUSTER_ADD) {
-      count++;
+      if (*g1 == *g2) {
+        g1++;
+      }
+      g2++;
     }
-
-    if (*g1 == *g2) {
-      g1++;
-    }
-    g2++;
   }
 
   // Now add the leftovers from whichever list didn't get finished first.
@@ -4625,18 +4624,17 @@ static void syn_combine_list_merge(const short *g1, const short *g2, int list_op
     if (*g1 < *g2) {
       clstr[i++] = *g1;
       g1++;
-      continue;
-    }
+    } else {
+      // Only add from the second list if we're adding the lists.
+      if (list_op == CLUSTER_ADD) {
+        clstr[i++] = *g2;
+      }
 
-    // Only add from the second list if we're adding the lists.
-    if (list_op == CLUSTER_ADD) {
-      clstr[i++] = *g2;
+      if (*g1 == *g2) {
+        g1++;
+      }
+      g2++;
     }
-
-    if (*g1 == *g2) {
-      g1++;
-    }
-    g2++;
   }
 
   // Now add the leftovers from whichever list didn't get finished first.


### PR DESCRIPTION
Rebased #692, reviewed it carefully again, improved the comments, and tested it as I described in https://github.com/neovim/neovim/pull/692#issuecomment-48123606

Preserved @harsh1kumar commit.
