### PR TITLE
[RFC] SIGSEV: event_init called too late

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -266,6 +266,8 @@ int main(int argc, char **argv)
   if (GARGCOUNT > 1 && !silent_mode)
     printf(_("%d files to edit\n"), GARGCOUNT);
 
+  event_early_init();
+
   if (params.want_full_screen && !silent_mode) {
     if (embedded_mode) {
       // In embedded mode don't do terminal-related initializations, assume an

--- a/src/nvim/os/event.c
+++ b/src/nvim/os/event.c
@@ -43,11 +43,15 @@ typedef struct {
 static klist_t(Event) *deferred_events = NULL, *immediate_events = NULL;
 static int deferred_events_allowed = 0;
 
-void event_init(void)
+void event_early_init(void)
 {
   // Initialize the event queues
   deferred_events = kl_init(Event);
   immediate_events = kl_init(Event);
+}
+
+void event_init(void)
+{
   // early msgpack-rpc initialization
   msgpack_rpc_init_method_table();
   msgpack_rpc_helpers_init();

--- a/test/unit/os/shell_spec.lua
+++ b/test/unit/os/shell_spec.lua
@@ -24,6 +24,7 @@ local NULL = ffi.cast('void *', 0)
 
 describe('shell functions', function()
   setup(function()
+    shell.event_early_init()
     shell.event_init()
     -- os_system() can't work when the p_sh and p_shcf variables are unset
     shell.p_sh = to_cstr('/bin/bash')

--- a/test/unit/term_spec.lua
+++ b/test/unit/term_spec.lua
@@ -1,0 +1,22 @@
+
+local helpers = require 'test.unit.helpers'
+local main = helpers.cimport(
+  './src/nvim/main.h',
+  './src/nvim/os/event.h',
+  './src/nvim/term.h'
+)
+
+helpers.vim_init()
+-- termcapinit requires event_early init
+main.event_early_init()
+
+describe('termcapinit', function()
+
+  it('works with ansi', function()
+    main.termcapinit(helpers.to_cstr('ansi'))
+  end)
+
+  it('works with unknown type', function()
+    main.termcapinit(helpers.to_cstr('XXX'))
+  end)
+end)


### PR DESCRIPTION
Earlier today I got a SIGSEV when running in Windows (Wine/Mingw)  - I can't replicate in Unix, but the issue still seems valid without my changes. Here is a trace

```
Program received signal SIGSEGV, Segmentation fault.
0x00000000005c99fa in kl_shift_Event (kl=0x0, d=0x33f860) at /home/raf/Code/neovim/src/nvim/os/event.c:28
28      KLIST_INIT(Event, Event, _destroy_event)
(gdb) bt
#0  0x00000000005c99fa in kl_shift_Event (kl=0x0, d=0x33f860) at /home/raf/Code/neovim/src/nvim/os/event.c:28
#1  0x00000000005c9dc1 in process_events_from (queue=0x0) at /home/raf/Code/neovim/src/nvim/os/event.c:173
#2  0x00000000005c9c6e in event_poll (ms=2000) at /home/raf/Code/neovim/src/nvim/os/event.c:135
#3  0x00000000005cf44f in os_delay (milliseconds=2000, ignoreinput=true)
    at /home/raf/Code/neovim/src/nvim/os/time.c:48
#4  0x0000000000453a50 in set_termname (term=0x638ca6 <farsi_text_5+7773> "win32")
    at /home/raf/Code/neovim/src/nvim/term.c:1329
#5  0x00000000004541c2 in termcapinit (name=0x0) at /home/raf/Code/neovim/src/nvim/term.c:1803
#6  0x0000000000543e1e in main (argc=1, argv=0xa51960) at /home/raf/Code/neovim/src/nvim/main.c:282
```

Which seems to happen because that failing call to `termcapinit()` happens before `event_init()` is called - resulting in NULL pointer being passed to process_events.

The minimal fix I added just moves the call to `event_init()`, but we could be more defensive and check the pointer, or add function attributes or an assert in process_events.
