### PR TITLE
[RDY] Reduce indentation level by early returning or continuing loop

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2105,14 +2105,10 @@ void get_winopts(buf_T *buf)
  */
 pos_T *buflist_findfpos(buf_T *buf)
 {
-  wininfo_T   *wip;
   static pos_T no_position = INIT_POS_T(1, 0, 0);
 
-  wip = find_wininfo(buf, FALSE);
-  if (wip != NULL)
-    return &(wip->wi_fpos);
-  else
-    return &no_position;
+  wininfo_T *wip = find_wininfo(buf, FALSE);
+  return (wip == NULL) ? &no_position : &(wip->wi_fpos);
 }
 
 /*

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -579,24 +579,25 @@ static int diff_check_sanity(tabpage_T *tp, diff_T *dp)
 static void diff_redraw(int dofold)
 {
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    if (wp->w_p_diff) {
-      redraw_win_later(wp, SOME_VALID);
-      if (dofold && foldmethodIsDiff(wp)) {
-        foldUpdateAll(wp);
-      }
+    if (!wp->w_p_diff) {
+      continue;
+    }
+    redraw_win_later(wp, SOME_VALID);
+    if (dofold && foldmethodIsDiff(wp)) {
+      foldUpdateAll(wp);
+    }
 
-      /* A change may have made filler lines invalid, need to take care
-       * of that for other windows. */
-      int n = diff_check(wp, wp->w_topline);
+    /* A change may have made filler lines invalid, need to take care
+     * of that for other windows. */
+    int n = diff_check(wp, wp->w_topline);
 
-      if (((wp != curwin) && (wp->w_topfill > 0)) || (n > 0)) {
-        if (wp->w_topfill > n) {
-          wp->w_topfill = (n < 0 ? 0 : n);
-        } else if ((n > 0) && (n > wp->w_topfill)) {
-          wp->w_topfill = n;
-        }
-        check_topfill(wp, FALSE);
+    if (((wp != curwin) && (wp->w_topfill > 0)) || (n > 0)) {
+      if (wp->w_topfill > n) {
+        wp->w_topfill = (n < 0 ? 0 : n);
+      } else if ((n > 0) && (n > wp->w_topfill)) {
+        wp->w_topfill = n;
       }
+      check_topfill(wp, FALSE);
     }
   }
 }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5987,29 +5987,30 @@ static char_u *dict2string(typval_T *tv, int copyID)
 
   todo = (int)d->dv_hashtab.ht_used;
   for (hi = d->dv_hashtab.ht_array; todo > 0 && !got_int; ++hi) {
-    if (!HASHITEM_EMPTY(hi)) {
-      --todo;
-
-      if (first)
-        first = FALSE;
-      else
-        ga_concat(&ga, (char_u *)", ");
-
-      tofree = string_quote(hi->hi_key, FALSE);
-      if (tofree != NULL) {
-        ga_concat(&ga, tofree);
-        free(tofree);
-      }
-      ga_concat(&ga, (char_u *)": ");
-      s = tv2string(&HI2DI(hi)->di_tv, &tofree, numbuf, copyID);
-      if (s != NULL)
-        ga_concat(&ga, s);
-      free(tofree);
-      if (s == NULL || did_echo_string_emsg) {
-        break;
-      }
-      line_breakcheck();
+    if (HASHITEM_EMPTY(hi)) {
+      continue;
     }
+    --todo;
+
+    if (first)
+      first = FALSE;
+    else
+      ga_concat(&ga, (char_u *)", ");
+
+    tofree = string_quote(hi->hi_key, FALSE);
+    if (tofree != NULL) {
+      ga_concat(&ga, tofree);
+      free(tofree);
+    }
+    ga_concat(&ga, (char_u *)": ");
+    s = tv2string(&HI2DI(hi)->di_tv, &tofree, numbuf, copyID);
+    if (s != NULL)
+      ga_concat(&ga, s);
+    free(tofree);
+    if (s == NULL || did_echo_string_emsg) {
+      break;
+    }
+    line_breakcheck();
   }
   if (todo > 0) {
     free(ga.ga_data);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3329,12 +3329,11 @@ void ex_z(exarg_T *eap)
     if (!VIM_ISDIGIT(*x)) {
       EMSG(_("E144: non-numeric argument to :z"));
       return;
-    } else {
-      bigness = atoi((char *)x);
-      p_window = bigness;
-      if (*kind == '=')
-        bigness += 2;
     }
+    bigness = atoi((char *)x);
+    p_window = bigness;
+    if (*kind == '=')
+      bigness += 2;
   }
 
   /* the number of '-' and '+' multiplies the distance */

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2375,34 +2375,35 @@ void do_wqall(exarg_T *eap)
     exiting = TRUE;
 
   FOR_ALL_BUFFERS(buf) {
-    if (bufIsChanged(buf)) {
-      /*
-       * Check if there is a reason the buffer cannot be written:
-       * 1. if the 'write' option is set
-       * 2. if there is no file name (even after browsing)
-       * 3. if the 'readonly' is set (even after a dialog)
-       * 4. if overwriting is allowed (even after a dialog)
-       */
-      if (not_writing()) {
-        ++error;
-        break;
-      }
-      if (buf->b_ffname == NULL) {
-        EMSGN(_("E141: No file name for buffer %" PRId64), buf->b_fnum);
-        ++error;
-      } else if (check_readonly(&eap->forceit, buf)
-                 || check_overwrite(eap, buf, buf->b_fname, buf->b_ffname,
-                     FALSE) == FAIL) {
-        ++error;
-      } else {
-        if (buf_write_all(buf, eap->forceit) == FAIL)
-          ++error;
-        /* an autocommand may have deleted the buffer */
-        if (!buf_valid(buf))
-          buf = firstbuf;
-      }
-      eap->forceit = save_forceit;          /* check_overwrite() may set it */
+    if (!bufIsChanged(buf)) {
+      continue;
     }
+    /*
+     * Check if there is a reason the buffer cannot be written:
+     * 1. if the 'write' option is set
+     * 2. if there is no file name (even after browsing)
+     * 3. if the 'readonly' is set (even after a dialog)
+     * 4. if overwriting is allowed (even after a dialog)
+     */
+    if (not_writing()) {
+      ++error;
+      break;
+    }
+    if (buf->b_ffname == NULL) {
+      EMSGN(_("E141: No file name for buffer %" PRId64), buf->b_fnum);
+      ++error;
+    } else if (check_readonly(&eap->forceit, buf)
+               || check_overwrite(eap, buf, buf->b_fname, buf->b_ffname,
+                   FALSE) == FAIL) {
+      ++error;
+    } else {
+      if (buf_write_all(buf, eap->forceit) == FAIL)
+        ++error;
+      /* an autocommand may have deleted the buffer */
+      if (!buf_valid(buf))
+        buf = firstbuf;
+    }
+    eap->forceit = save_forceit;          /* check_overwrite() may set it */
   }
   if (exiting) {
     if (!error)
@@ -5232,61 +5233,62 @@ void fix_help_buffer(void)
               if (fnames[fi] == NULL)
                 continue;
               fd = mch_fopen((char *)fnames[fi], "r");
-              if (fd != NULL) {
-                vim_fgets(IObuff, IOSIZE, fd);
-                if (IObuff[0] == '*'
-                    && (s = vim_strchr(IObuff + 1, '*'))
-                    != NULL) {
-                  int this_utf = MAYBE;
-                  /* Change tag definition to a
-                   * reference and remove <CR>/<NL>. */
-                  IObuff[0] = '|';
-                  *s = '|';
-                  while (*s != NUL) {
-                    if (*s == '\r' || *s == '\n')
-                      *s = NUL;
-                    /* The text is utf-8 when a byte
-                     * above 127 is found and no
-                     * illegal byte sequence is found.
-                     */
-                    if (*s >= 0x80 && this_utf != FALSE) {
-                      int l;
-
-                      this_utf = TRUE;
-                      l = utf_ptr2len(s);
-                      if (l == 1)
-                        this_utf = FALSE;
-                      s += l - 1;
-                    }
-                    ++s;
-                  }
-                  /* The help file is latin1 or utf-8;
-                   * conversion to the current
-                   * 'encoding' may be required. */
-                  vc.vc_type = CONV_NONE;
-                  convert_setup(&vc, (char_u *)(
-                        this_utf == TRUE ? "utf-8"
-                        : "latin1"), p_enc);
-                  if (vc.vc_type == CONV_NONE)
-                    /* No conversion needed. */
-                    cp = IObuff;
-                  else {
-                    /* Do the conversion.  If it fails
-                     * use the unconverted text. */
-                    cp = string_convert(&vc, IObuff,
-                        NULL);
-                    if (cp == NULL)
-                      cp = IObuff;
-                  }
-                  convert_setup(&vc, NULL, NULL);
-
-                  ml_append(lnum, cp, (colnr_T)0, FALSE);
-                  if (cp != IObuff)
-                    free(cp);
-                  ++lnum;
-                }
-                fclose(fd);
+              if (fd == NULL) {
+                continue;
               }
+              vim_fgets(IObuff, IOSIZE, fd);
+              if (IObuff[0] == '*'
+                  && (s = vim_strchr(IObuff + 1, '*'))
+                  != NULL) {
+                int this_utf = MAYBE;
+                /* Change tag definition to a
+                 * reference and remove <CR>/<NL>. */
+                IObuff[0] = '|';
+                *s = '|';
+                while (*s != NUL) {
+                  if (*s == '\r' || *s == '\n')
+                    *s = NUL;
+                  /* The text is utf-8 when a byte
+                   * above 127 is found and no
+                   * illegal byte sequence is found.
+                   */
+                  if (*s >= 0x80 && this_utf != FALSE) {
+                    int l;
+
+                    this_utf = TRUE;
+                    l = utf_ptr2len(s);
+                    if (l == 1)
+                      this_utf = FALSE;
+                    s += l - 1;
+                  }
+                  ++s;
+                }
+                /* The help file is latin1 or utf-8;
+                 * conversion to the current
+                 * 'encoding' may be required. */
+                vc.vc_type = CONV_NONE;
+                convert_setup(&vc, (char_u *)(
+                      this_utf == TRUE ? "utf-8"
+                      : "latin1"), p_enc);
+                if (vc.vc_type == CONV_NONE)
+                  /* No conversion needed. */
+                  cp = IObuff;
+                else {
+                  /* Do the conversion.  If it fails
+                   * use the unconverted text. */
+                  cp = string_convert(&vc, IObuff,
+                      NULL);
+                  if (cp == NULL)
+                    cp = IObuff;
+                }
+                convert_setup(&vc, NULL, NULL);
+
+                ml_append(lnum, cp, (colnr_T)0, FALSE);
+                if (cp != IObuff)
+                  free(cp);
+                ++lnum;
+              }
+              fclose(fd);
             }
             FreeWild(fcount, fnames);
           }
@@ -5368,32 +5370,33 @@ void ex_helptags(exarg_T *eap)
   ga_init(&ga, 1, 10);
   for (int i = 0; i < filecount; ++i) {
     len = (int)STRLEN(files[i]);
-    if (len > 4) {
-      if (STRICMP(files[i] + len - 4, ".txt") == 0) {
-        /* ".txt" -> language "en" */
-        lang[0] = 'e';
-        lang[1] = 'n';
-      } else if (files[i][len - 4] == '.'
-                 && ASCII_ISALPHA(files[i][len - 3])
-                 && ASCII_ISALPHA(files[i][len - 2])
-                 && TOLOWER_ASC(files[i][len - 1]) == 'x') {
-        /* ".abx" -> language "ab" */
-        lang[0] = TOLOWER_ASC(files[i][len - 3]);
-        lang[1] = TOLOWER_ASC(files[i][len - 2]);
-      } else
-        continue;
+    if (len <= 4) {
+      continue;
+    }
+    if (STRICMP(files[i] + len - 4, ".txt") == 0) {
+      /* ".txt" -> language "en" */
+      lang[0] = 'e';
+      lang[1] = 'n';
+    } else if (files[i][len - 4] == '.'
+               && ASCII_ISALPHA(files[i][len - 3])
+               && ASCII_ISALPHA(files[i][len - 2])
+               && TOLOWER_ASC(files[i][len - 1]) == 'x') {
+      /* ".abx" -> language "ab" */
+      lang[0] = TOLOWER_ASC(files[i][len - 3]);
+      lang[1] = TOLOWER_ASC(files[i][len - 2]);
+    } else
+      continue;
 
-      int j;
-      /* Did we find this language already? */
-      for (j = 0; j < ga.ga_len; j += 2)
-        if (STRNCMP(lang, ((char_u *)ga.ga_data) + j, 2) == 0)
-          break;
-      if (j == ga.ga_len) {
-        /* New language, add it. */
-        ga_grow(&ga, 2);
-        ((char_u *)ga.ga_data)[ga.ga_len++] = lang[0];
-        ((char_u *)ga.ga_data)[ga.ga_len++] = lang[1];
-      }
+    int j;
+    /* Did we find this language already? */
+    for (j = 0; j < ga.ga_len; j += 2)
+      if (STRNCMP(lang, ((char_u *)ga.ga_data) + j, 2) == 0)
+        break;
+    if (j == ga.ga_len) {
+      /* New language, add it. */
+      ga_grow(&ga, 2);
+      ((char_u *)ga.ga_data)[ga.ga_len++] = lang[0];
+      ((char_u *)ga.ga_data)[ga.ga_len++] = lang[1];
     }
   }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7748,24 +7748,25 @@ static char_u *arg_all(void)
     len = 0;
     for (idx = 0; idx < ARGCOUNT; ++idx) {
       p = alist_name(&ARGLIST[idx]);
-      if (p != NULL) {
-        if (len > 0) {
-          /* insert a space in between names */
+      if (p == NULL) {
+        continue;
+      }
+      if (len > 0) {
+        /* insert a space in between names */
+        if (retval != NULL)
+          retval[len] = ' ';
+        ++len;
+      }
+      for (; *p != NUL; ++p) {
+        if (*p == ' ' || *p == '\\') {
+          /* insert a backslash */
           if (retval != NULL)
-            retval[len] = ' ';
+            retval[len] = '\\';
           ++len;
         }
-        for (; *p != NUL; ++p) {
-          if (*p == ' ' || *p == '\\') {
-            /* insert a backslash */
-            if (retval != NULL)
-              retval[len] = '\\';
-            ++len;
-          }
-          if (retval != NULL)
-            retval[len] = *p;
-          ++len;
-        }
+        if (retval != NULL)
+          retval[len] = *p;
+        ++len;
       }
     }
 

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -246,28 +246,24 @@ int cause_errthrow(char_u *mesg, int severe, int *ignore)
         plist = &(*plist)->next;
 
       elem = xmalloc(sizeof(struct msglist));
-      {
-        elem->msg = vim_strsave(mesg);
-        {
-          elem->next = NULL;
-          elem->throw_msg = NULL;
-          *plist = elem;
-          if (plist == msg_list || severe) {
-            char_u      *tmsg;
+      elem->msg = vim_strsave(mesg);
+      elem->next = NULL;
+      elem->throw_msg = NULL;
+      *plist = elem;
+      if (plist == msg_list || severe) {
+        char_u      *tmsg;
 
-            /* Skip the extra "Vim " prefix for message "E458". */
-            tmsg = elem->msg;
-            if (STRNCMP(tmsg, "Vim E", 5) == 0
-                && VIM_ISDIGIT(tmsg[5])
-                && VIM_ISDIGIT(tmsg[6])
-                && VIM_ISDIGIT(tmsg[7])
-                && tmsg[8] == ':'
-                && tmsg[9] == ' ')
-              (*msg_list)->throw_msg = &tmsg[4];
-            else
-              (*msg_list)->throw_msg = tmsg;
-          }
-        }
+        /* Skip the extra "Vim " prefix for message "E458". */
+        tmsg = elem->msg;
+        if (STRNCMP(tmsg, "Vim E", 5) == 0
+            && VIM_ISDIGIT(tmsg[5])
+            && VIM_ISDIGIT(tmsg[6])
+            && VIM_ISDIGIT(tmsg[7])
+            && tmsg[8] == ':'
+            && tmsg[9] == ' ')
+          (*msg_list)->throw_msg = &tmsg[4];
+        else
+          (*msg_list)->throw_msg = tmsg;
       }
     }
     return TRUE;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1639,39 +1639,38 @@ deleteFoldMarkers (
  */
 static void foldDelMarker(linenr_T lnum, char_u *marker, int markerlen)
 {
-  char_u      *line;
   char_u      *newline;
-  char_u      *p;
-  int len;
   char_u      *cms = curbuf->b_p_cms;
   char_u      *cms2;
 
-  line = ml_get(lnum);
-  for (p = line; *p != NUL; ++p)
-    if (STRNCMP(p, marker, markerlen) == 0) {
-      /* Found the marker, include a digit if it's there. */
-      len = markerlen;
-      if (VIM_ISDIGIT(p[len]))
-        ++len;
-      if (*cms != NUL) {
-        /* Also delete 'commentstring' if it matches. */
-        cms2 = (char_u *)strstr((char *)cms, "%s");
-        if (p - line >= cms2 - cms
-            && STRNCMP(p - (cms2 - cms), cms, cms2 - cms) == 0
-            && STRNCMP(p + len, cms2 + 2, STRLEN(cms2 + 2)) == 0) {
-          p -= cms2 - cms;
-          len += (int)STRLEN(cms) - 2;
-        }
-      }
-      if (u_save(lnum - 1, lnum + 1) == OK) {
-        /* Make new line: text-before-marker + text-after-marker */
-        newline = xmalloc(STRLEN(line) - len + 1);
-        STRNCPY(newline, line, p - line);
-        STRCPY(newline + (p - line), p + len);
-        ml_replace(lnum, newline, FALSE);
-      }
-      break;
+  char_u *line = ml_get(lnum);
+  for (char_u *p = line; *p != NUL; ++p) {
+    if (STRNCMP(p, marker, markerlen) != 0) {
+      continue;
     }
+    /* Found the marker, include a digit if it's there. */
+    int len = markerlen;
+    if (VIM_ISDIGIT(p[len]))
+      ++len;
+    if (*cms != NUL) {
+      /* Also delete 'commentstring' if it matches. */
+      cms2 = (char_u *)strstr((char *)cms, "%s");
+      if (p - line >= cms2 - cms
+          && STRNCMP(p - (cms2 - cms), cms, cms2 - cms) == 0
+          && STRNCMP(p + len, cms2 + 2, STRLEN(cms2 + 2)) == 0) {
+        p -= cms2 - cms;
+        len += (int)STRLEN(cms) - 2;
+      }
+    }
+    if (u_save(lnum - 1, lnum + 1) == OK) {
+      /* Make new line: text-before-marker + text-after-marker */
+      newline = xmalloc(STRLEN(line) - len + 1);
+      STRNCPY(newline, line, p - line);
+      STRCPY(newline + (p - line), p + len);
+      ml_replace(lnum, newline, FALSE);
+    }
+    break;
+  }
 }
 
 /* get_foldtext() {{{2 */

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -680,33 +680,34 @@ static int read_redo(int init, int old_redo)
     p = bp->b_str;
     return OK;
   }
-  if ((c = *p) != NUL) {
-    /* Reverse the conversion done by add_char_buff() */
-    /* For a multi-byte character get all the bytes and return the
-     * converted character. */
-    if (has_mbyte && (c != K_SPECIAL || p[1] == KS_SPECIAL))
-      n = MB_BYTE2LEN_CHECK(c);
-    else
-      n = 1;
-    for (i = 0;; ++i) {
-      if (c == K_SPECIAL) {     /* special key or escaped K_SPECIAL */
-        c = TO_SPECIAL(p[1], p[2]);
-        p += 2;
-      }
-      if (*++p == NUL && bp->b_next != NULL) {
-        bp = bp->b_next;
-        p = bp->b_str;
-      }
-      buf[i] = c;
-      if (i == n - 1) {         /* last byte of a character */
-        if (n != 1)
-          c = (*mb_ptr2char)(buf);
-        break;
-      }
-      c = *p;
-      if (c == NUL)             /* cannot happen? */
-        break;
+  if ((c = *p) == NUL) {
+    return c;
+  }
+  /* Reverse the conversion done by add_char_buff() */
+  /* For a multi-byte character get all the bytes and return the
+   * converted character. */
+  if (has_mbyte && (c != K_SPECIAL || p[1] == KS_SPECIAL))
+    n = MB_BYTE2LEN_CHECK(c);
+  else
+    n = 1;
+  for (i = 0;; ++i) {
+    if (c == K_SPECIAL) {     /* special key or escaped K_SPECIAL */
+      c = TO_SPECIAL(p[1], p[2]);
+      p += 2;
     }
+    if (*++p == NUL && bp->b_next != NULL) {
+      bp = bp->b_next;
+      p = bp->b_str;
+    }
+    buf[i] = c;
+    if (i == n - 1) {         /* last byte of a character */
+      if (n != 1)
+        c = (*mb_ptr2char)(buf);
+      break;
+    }
+    c = *p;
+    if (c == NUL)             /* cannot happen? */
+      break;
   }
 
   return c;

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -233,9 +233,7 @@ static int cin_islabel_skip(char_u **s)
  */
 int cin_islabel(void)
 { /* XXX */
-  char_u      *s;
-
-  s = cin_skipcomment(get_cursor_line_ptr());
+  char_u *s = cin_skipcomment(get_cursor_line_ptr());
 
   /*
    * Exclude "default" from labels, since it should be indented

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3124,40 +3124,41 @@ void check_scrollbind(linenr_T topline_diff, long leftcol_diff)
   for (curwin = firstwin; curwin; curwin = curwin->w_next) {
     curbuf = curwin->w_buffer;
     /* skip original window  and windows with 'noscrollbind' */
-    if (curwin != old_curwin && curwin->w_p_scb) {
-      /*
-       * do the vertical scroll
-       */
-      if (want_ver) {
-        if (old_curwin->w_p_diff && curwin->w_p_diff) {
-          diff_set_topline(old_curwin, curwin);
-        } else {
-          curwin->w_scbind_pos += topline_diff;
-          topline = curwin->w_scbind_pos;
-          if (topline > curbuf->b_ml.ml_line_count)
-            topline = curbuf->b_ml.ml_line_count;
-          if (topline < 1)
-            topline = 1;
+    if (curwin == old_curwin || !curwin->w_p_scb) {
+      continue;
+    }
+    /*
+     * do the vertical scroll
+     */
+    if (want_ver) {
+      if (old_curwin->w_p_diff && curwin->w_p_diff) {
+        diff_set_topline(old_curwin, curwin);
+      } else {
+        curwin->w_scbind_pos += topline_diff;
+        topline = curwin->w_scbind_pos;
+        if (topline > curbuf->b_ml.ml_line_count)
+          topline = curbuf->b_ml.ml_line_count;
+        if (topline < 1)
+          topline = 1;
 
-          y = topline - curwin->w_topline;
-          if (y > 0)
-            scrollup(y, false);
-          else
-            scrolldown(-y, false);
-        }
-
-        redraw_later(VALID);
-        cursor_correct();
-        curwin->w_redr_status = true;
+        y = topline - curwin->w_topline;
+        if (y > 0)
+          scrollup(y, false);
+        else
+          scrolldown(-y, false);
       }
 
-      /*
-       * do the horizontal scroll
-       */
-      if (want_hor && curwin->w_leftcol != tgt_leftcol) {
-        curwin->w_leftcol = tgt_leftcol;
-        leftcol_changed();
-      }
+      redraw_later(VALID);
+      cursor_correct();
+      curwin->w_redr_status = true;
+    }
+
+    /*
+     * do the horizontal scroll
+     */
+    if (want_hor && curwin->w_leftcol != tgt_leftcol) {
+      curwin->w_leftcol = tgt_leftcol;
+      leftcol_changed();
     }
   }
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -2735,150 +2735,152 @@ static int peekchr(void)
 {
   static int after_slash = FALSE;
 
-  if (curchr == -1) {
-    switch (curchr = regparse[0]) {
-    case '.':
-    case '[':
-    case '~':
-      /* magic when 'magic' is on */
-      if (reg_magic >= MAGIC_ON)
-        curchr = Magic(curchr);
-      break;
-    case '(':
-    case ')':
-    case '{':
-    case '%':
-    case '+':
-    case '=':
-    case '?':
-    case '@':
-    case '!':
-    case '&':
-    case '|':
-    case '<':
-    case '>':
-    case '#':           /* future ext. */
-    case '"':           /* future ext. */
-    case '\'':          /* future ext. */
-    case ',':           /* future ext. */
-    case '-':           /* future ext. */
-    case ':':           /* future ext. */
-    case ';':           /* future ext. */
-    case '`':           /* future ext. */
-    case '/':           /* Can't be used in / command */
-      /* magic only after "\v" */
-      if (reg_magic == MAGIC_ALL)
-        curchr = Magic(curchr);
-      break;
-    case '*':
-      /* * is not magic as the very first character, eg "?*ptr", when
-       * after '^', eg "/^*ptr" and when after "\(", "\|", "\&".  But
-       * "\(\*" is not magic, thus must be magic if "after_slash" */
-      if (reg_magic >= MAGIC_ON
-          && !at_start
-          && !(prev_at_start && prevchr == Magic('^'))
-          && (after_slash
-              || (prevchr != Magic('(')
-                  && prevchr != Magic('&')
-                  && prevchr != Magic('|'))))
-        curchr = Magic('*');
-      break;
-    case '^':
-      /* '^' is only magic as the very first character and if it's after
-       * "\(", "\|", "\&' or "\n" */
-      if (reg_magic >= MAGIC_OFF
-          && (at_start
-              || reg_magic == MAGIC_ALL
-              || prevchr == Magic('(')
-              || prevchr == Magic('|')
-              || prevchr == Magic('&')
-              || prevchr == Magic('n')
-              || (no_Magic(prevchr) == '('
-                  && prevprevchr == Magic('%')))) {
-        curchr = Magic('^');
-        at_start = TRUE;
-        prev_at_start = FALSE;
-      }
-      break;
-    case '$':
-      /* '$' is only magic as the very last char and if it's in front of
-       * either "\|", "\)", "\&", or "\n" */
-      if (reg_magic >= MAGIC_OFF) {
-        char_u *p = regparse + 1;
-        bool is_magic_all = (reg_magic == MAGIC_ALL);
+  if (curchr != -1) {
+    return curchr;
+  }
 
-        // ignore \c \C \m \M \v \V and \Z after '$'
-        while (p[0] == '\\' && (p[1] == 'c' || p[1] == 'C'
-                                || p[1] == 'm' || p[1] == 'M'
-                                || p[1] == 'v' || p[1] == 'V'
-                                || p[1] == 'Z')) {
-          if (p[1] == 'v') {
-            is_magic_all = true;
-          } else if (p[1] == 'm' || p[1] == 'M' || p[1] == 'V') {
-            is_magic_all = false;
-          }
-          p += 2;
-        }
-        if (p[0] == NUL
-            || (p[0] == '\\'
-                && (p[1] == '|' || p[1] == '&' || p[1] == ')'
-                    || p[1] == 'n'))
-            || (is_magic_all
-                && (p[0] == '|' || p[0] == '&' || p[0] == ')'))
-            || reg_magic == MAGIC_ALL) {
-          curchr = Magic('$');
-        }
-      }
-      break;
-    case '\\':
-    {
-      int c = regparse[1];
-
-      if (c == NUL)
-        curchr = '\\';                  /* trailing '\' */
-      else if (
-        c <= '~' && META_flags[c]
-        ) {
-        /*
-         * META contains everything that may be magic sometimes,
-         * except ^ and $ ("\^" and "\$" are only magic after
-         * "\v").  We now fetch the next character and toggle its
-         * magicness.  Therefore, \ is so meta-magic that it is
-         * not in META.
-         */
-        curchr = -1;
-        prev_at_start = at_start;
-        at_start = FALSE;               /* be able to say "/\*ptr" */
-        ++regparse;
-        ++after_slash;
-        peekchr();
-        --regparse;
-        --after_slash;
-        curchr = toggle_Magic(curchr);
-      } else if (vim_strchr(REGEXP_ABBR, c)) {
-        /*
-         * Handle abbreviations, like "\t" for TAB -- webb
-         */
-        curchr = backslash_trans(c);
-      } else if (reg_magic == MAGIC_NONE && (c == '$' || c == '^'))
-        curchr = toggle_Magic(c);
-      else {
-        /*
-         * Next character can never be (made) magic?
-         * Then backslashing it won't do anything.
-         */
-        if (has_mbyte)
-          curchr = (*mb_ptr2char)(regparse + 1);
-        else
-          curchr = c;
-      }
-      break;
+  switch (curchr = regparse[0]) {
+  case '.':
+  case '[':
+  case '~':
+    /* magic when 'magic' is on */
+    if (reg_magic >= MAGIC_ON)
+      curchr = Magic(curchr);
+    break;
+  case '(':
+  case ')':
+  case '{':
+  case '%':
+  case '+':
+  case '=':
+  case '?':
+  case '@':
+  case '!':
+  case '&':
+  case '|':
+  case '<':
+  case '>':
+  case '#':           /* future ext. */
+  case '"':           /* future ext. */
+  case '\'':          /* future ext. */
+  case ',':           /* future ext. */
+  case '-':           /* future ext. */
+  case ':':           /* future ext. */
+  case ';':           /* future ext. */
+  case '`':           /* future ext. */
+  case '/':           /* Can't be used in / command */
+    /* magic only after "\v" */
+    if (reg_magic == MAGIC_ALL)
+      curchr = Magic(curchr);
+    break;
+  case '*':
+    /* * is not magic as the very first character, eg "?*ptr", when
+     * after '^', eg "/^*ptr" and when after "\(", "\|", "\&".  But
+     * "\(\*" is not magic, thus must be magic if "after_slash" */
+    if (reg_magic >= MAGIC_ON
+        && !at_start
+        && !(prev_at_start && prevchr == Magic('^'))
+        && (after_slash
+            || (prevchr != Magic('(')
+                && prevchr != Magic('&')
+                && prevchr != Magic('|'))))
+      curchr = Magic('*');
+    break;
+  case '^':
+    /* '^' is only magic as the very first character and if it's after
+     * "\(", "\|", "\&' or "\n" */
+    if (reg_magic >= MAGIC_OFF
+        && (at_start
+            || reg_magic == MAGIC_ALL
+            || prevchr == Magic('(')
+            || prevchr == Magic('|')
+            || prevchr == Magic('&')
+            || prevchr == Magic('n')
+            || (no_Magic(prevchr) == '('
+                && prevprevchr == Magic('%')))) {
+      curchr = Magic('^');
+      at_start = TRUE;
+      prev_at_start = FALSE;
     }
+    break;
+  case '$':
+    /* '$' is only magic as the very last char and if it's in front of
+     * either "\|", "\)", "\&", or "\n" */
+    if (reg_magic >= MAGIC_OFF) {
+      char_u *p = regparse + 1;
+      bool is_magic_all = (reg_magic == MAGIC_ALL);
 
-    default:
+      // ignore \c \C \m \M \v \V and \Z after '$'
+      while (p[0] == '\\' && (p[1] == 'c' || p[1] == 'C'
+                              || p[1] == 'm' || p[1] == 'M'
+                              || p[1] == 'v' || p[1] == 'V'
+                              || p[1] == 'Z')) {
+        if (p[1] == 'v') {
+          is_magic_all = true;
+        } else if (p[1] == 'm' || p[1] == 'M' || p[1] == 'V') {
+          is_magic_all = false;
+        }
+        p += 2;
+      }
+      if (p[0] == NUL
+          || (p[0] == '\\'
+              && (p[1] == '|' || p[1] == '&' || p[1] == ')'
+                  || p[1] == 'n'))
+          || (is_magic_all
+              && (p[0] == '|' || p[0] == '&' || p[0] == ')'))
+          || reg_magic == MAGIC_ALL) {
+        curchr = Magic('$');
+      }
+    }
+    break;
+  case '\\':
+  {
+    int c = regparse[1];
+
+    if (c == NUL)
+      curchr = '\\';                  /* trailing '\' */
+    else if (
+      c <= '~' && META_flags[c]
+      ) {
+      /*
+       * META contains everything that may be magic sometimes,
+       * except ^ and $ ("\^" and "\$" are only magic after
+       * "\v").  We now fetch the next character and toggle its
+       * magicness.  Therefore, \ is so meta-magic that it is
+       * not in META.
+       */
+      curchr = -1;
+      prev_at_start = at_start;
+      at_start = FALSE;               /* be able to say "/\*ptr" */
+      ++regparse;
+      ++after_slash;
+      peekchr();
+      --regparse;
+      --after_slash;
+      curchr = toggle_Magic(curchr);
+    } else if (vim_strchr(REGEXP_ABBR, c)) {
+      /*
+       * Handle abbreviations, like "\t" for TAB -- webb
+       */
+      curchr = backslash_trans(c);
+    } else if (reg_magic == MAGIC_NONE && (c == '$' || c == '^'))
+      curchr = toggle_Magic(c);
+    else {
+      /*
+       * Next character can never be (made) magic?
+       * Then backslashing it won't do anything.
+       */
       if (has_mbyte)
-        curchr = (*mb_ptr2char)(regparse);
+        curchr = (*mb_ptr2char)(regparse + 1);
+      else
+        curchr = c;
     }
+    break;
+  }
+
+  default:
+    if (has_mbyte)
+      curchr = (*mb_ptr2char)(regparse);
   }
 
   return curchr;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4283,7 +4283,7 @@ static int comp_char_differs(int off_from, int off_to)
  */
 static int char_needs_redraw(int off_from, int off_to, int cols)
 {
-  if (cols > 0
+  return (cols > 0
       && ((ScreenLines[off_from] != ScreenLines[off_to]
            || ScreenAttrs[off_from] != ScreenAttrs[off_to])
 
@@ -4299,10 +4299,7 @@ static int char_needs_redraw(int off_from, int off_to, int cols)
                       && comp_char_differs(off_from, off_to))
                   || ((*mb_off2cells)(off_from, off_from + cols) > 1
                       && ScreenLines[off_from + 1]
-                      != ScreenLines[off_to + 1])))
-          ))
-    return TRUE;
-  return FALSE;
+                      != ScreenLines[off_to + 1])))));
 }
 
 /*

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -1513,33 +1513,31 @@ syn_finish_line (
   stateitem_T *cur_si;
   colnr_T prev_current_col;
 
-  if (!current_finished) {
-    while (!current_finished) {
-      (void)syn_current_attr(syncing, FALSE, NULL, FALSE);
+  while (!current_finished) {
+    (void)syn_current_attr(syncing, FALSE, NULL, FALSE);
+    /*
+     * When syncing, and found some item, need to check the item.
+     */
+    if (syncing && current_state.ga_len) {
       /*
-       * When syncing, and found some item, need to check the item.
+       * Check for match with sync item.
        */
-      if (syncing && current_state.ga_len) {
-        /*
-         * Check for match with sync item.
-         */
-        cur_si = &CUR_STATE(current_state.ga_len - 1);
-        if (cur_si->si_idx >= 0
-            && (SYN_ITEMS(syn_block)[cur_si->si_idx].sp_flags
-                & (HL_SYNC_HERE|HL_SYNC_THERE)))
-          return TRUE;
+      cur_si = &CUR_STATE(current_state.ga_len - 1);
+      if (cur_si->si_idx >= 0
+          && (SYN_ITEMS(syn_block)[cur_si->si_idx].sp_flags
+              & (HL_SYNC_HERE|HL_SYNC_THERE)))
+        return TRUE;
 
-        /* syn_current_attr() will have skipped the check for an item
-         * that ends here, need to do that now.  Be careful not to go
-         * past the NUL. */
-        prev_current_col = current_col;
-        if (syn_getcurline()[current_col] != NUL)
-          ++current_col;
-        check_state_ends();
-        current_col = prev_current_col;
-      }
-      ++current_col;
+      /* syn_current_attr() will have skipped the check for an item
+       * that ends here, need to do that now.  Be careful not to go
+       * past the NUL. */
+      prev_current_col = current_col;
+      if (syn_getcurline()[current_col] != NUL)
+        ++current_col;
+      check_state_ends();
+      current_col = prev_current_col;
     }
+    ++current_col;
   }
   return FALSE;
 }


### PR DESCRIPTION
Where it made sense, replaced code like this

``` c
func() {
    if (cond) {
    ...
    ...
    ...
    }
    return ret;
}
```

``` c
for (...) {
    if (cond) {
    ...
    ...
    ...
    }
}
```

with this

``` c
func() {
    if (!cond) {
    return ret;
    }
    ...
    ...
    ...
}
```

``` c
for (...) {
    if (!cond) {
    continue;
    }
    ...
    ...
    ...
}
```
