### PR TITLE
[RDY] Define and use the ARRAY_SIZE macro

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6652,7 +6652,7 @@ char_u *get_function_name(expand_T *xp, int idx)
     if (name != NULL)
       return name;
   }
-  if (++intidx < (int)(sizeof(functions) / sizeof(struct fst))) {
+  if (++intidx < (int)ARRAY_SIZE(functions)) {
     STRCPY(IObuff, functions[intidx].f_name);
     STRCAT(IObuff, "(");
     if (functions[intidx].f_max_argc == 0)
@@ -6695,7 +6695,7 @@ find_internal_func (
 )
 {
   int first = 0;
-  int last = (int)(sizeof(functions) / sizeof(struct fst)) - 1;
+  int last = (int)ARRAY_SIZE(functions) - 1;
 
   /*
    * Find the function name in the table. Binary search.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4954,7 +4954,7 @@ int find_help_tags(char_u *arg, int *num_matches, char_u ***matches, int keep_la
    * Recognize a few exceptions to the rule.	Some strings that contain '*'
    * with "star".  Otherwise '*' is recognized as a wildcard.
    */
-  for (i = (int)(sizeof(mtable) / sizeof(char *)); --i >= 0; )
+  for (i = (int)ARRAY_SIZE(mtable); --i >= 0; )
     if (STRCMP(arg, mtable[i]) == 0) {
       STRCPY(d, rtable[i]);
       break;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2281,7 +2281,7 @@ int modifier_len(char_u *cmd)
 
   if (VIM_ISDIGIT(*cmd))
     p = skipwhite(skipdigits(cmd));
-  for (i = 0; i < (int)(sizeof(cmdmods) / sizeof(struct cmdmod)); ++i) {
+  for (i = 0; i < (int)ARRAY_SIZE(cmdmods); ++i) {
     for (j = 0; p[j] != NUL; ++j)
       if (p[j] != cmdmods[i].name[j])
         break;
@@ -2306,7 +2306,7 @@ int cmd_exists(char_u *name)
   char_u      *p;
 
   /* Check command modifiers. */
-  for (i = 0; i < (int)(sizeof(cmdmods) / sizeof(struct cmdmod)); ++i) {
+  for (i = 0; i < (int)ARRAY_SIZE(cmdmods); ++i) {
     for (j = 0; name[j] != NUL; ++j)
       if (name[j] != cmdmods[i].name[j])
         break;
@@ -4974,7 +4974,7 @@ char_u *get_user_cmd_flags(expand_T *xp, int idx)
   {"bang", "bar", "buffer", "complete", "count",
    "nargs", "range", "register"};
 
-  if (idx >= (int)(sizeof(user_cmd_flags) / sizeof(user_cmd_flags[0])))
+  if (idx >= (int)ARRAY_SIZE(user_cmd_flags))
     return NULL;
   return (char_u *)user_cmd_flags[idx];
 }
@@ -4986,7 +4986,7 @@ char_u *get_user_cmd_nargs(expand_T *xp, int idx)
 {
   static char *user_cmd_nargs[] = {"0", "1", "*", "?", "+"};
 
-  if (idx >= (int)(sizeof(user_cmd_nargs) / sizeof(user_cmd_nargs[0])))
+  if (idx >= (int)ARRAY_SIZE(user_cmd_nargs))
     return NULL;
   return (char_u *)user_cmd_nargs[idx];
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7482,7 +7482,7 @@ int find_cmdline_var(const char_u *src, int *usedlen) FUNC_ATTR_NONNULL_ALL
 # define SPEC_AMATCH 9
   };
 
-  for (i = 0; i < (int)(sizeof(spec_str) / sizeof(char *)); ++i) {
+  for (i = 0; i < (int)ARRAY_SIZE(spec_str); ++i) {
     len = (int)STRLEN(spec_str[i]);
     if (STRNCMP(src, spec_str[i], len) == 0) {
       *usedlen = len;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3715,7 +3715,7 @@ ExpandFromContext (
      * right function to do the expansion.
      */
     ret = FAIL;
-    for (i = 0; i < (int)(sizeof(tab) / sizeof(struct expgen)); ++i)
+    for (i = 0; i < (int)ARRAY_SIZE(tab); ++i)
       if (xp->xp_context == tab[i].context) {
         if (tab[i].ic) {
           regmatch.rm_ic = TRUE;
@@ -4155,7 +4155,7 @@ static char_u *get_history_arg(expand_T *xp, int idx)
   static char_u compl[2] = { NUL, NUL };
   char *short_names = ":=@>?/";
   int short_names_count = (int)STRLEN(short_names);
-  int history_name_count = sizeof(history_names) / sizeof(char *) - 1;
+  int history_name_count = ARRAY_SIZE(history_names) - 1;
 
   if (idx < short_names_count) {
     compl[0] = (char_u)short_names[idx];

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -945,8 +945,6 @@ static colnr_T hardcopy_line(prt_settings_T *psettings, int page_line, prt_pos_T
  * http://www.adobe.com
  */
 
-#define NUM_ELEMENTS(arr)   (sizeof(arr)/sizeof((arr)[0]))
-
 #define PRT_PS_DEFAULT_DPI          (72)    /* Default user space resolution */
 #define PRT_PS_DEFAULT_FONTSIZE     (10)
 #define PRT_PS_DEFAULT_BUFFER_SIZE  (80)
@@ -1139,33 +1137,33 @@ static struct prt_ps_charset_S k_charsets[] =
 static struct prt_ps_mbfont_S prt_ps_mbfonts[] =
 {
   {
-    NUM_ELEMENTS(j_encodings),
+    ARRAY_SIZE(j_encodings),
     j_encodings,
-    NUM_ELEMENTS(j_charsets),
+    ARRAY_SIZE(j_charsets),
     j_charsets,
     "jis_roman",
     "JIS_X_1983"
   },
   {
-    NUM_ELEMENTS(sc_encodings),
+    ARRAY_SIZE(sc_encodings),
     sc_encodings,
-    NUM_ELEMENTS(sc_charsets),
+    ARRAY_SIZE(sc_charsets),
     sc_charsets,
     "gb_roman",
     "GB_2312-80"
   },
   {
-    NUM_ELEMENTS(tc_encodings),
+    ARRAY_SIZE(tc_encodings),
     tc_encodings,
-    NUM_ELEMENTS(tc_charsets),
+    ARRAY_SIZE(tc_charsets),
     tc_charsets,
     "cns_roman",
     "BIG5"
   },
   {
-    NUM_ELEMENTS(k_encodings),
+    ARRAY_SIZE(k_encodings),
     k_encodings,
-    NUM_ELEMENTS(k_charsets),
+    ARRAY_SIZE(k_charsets),
     k_charsets,
     "ks_roman",
     "KS_X_1992"
@@ -1639,12 +1637,12 @@ static int prt_next_dsc(struct prt_dsc_line_S *p_dsc_line)
     return FALSE;
 
   /* Find type of DSC comment */
-  for (comment = 0; comment < (int)NUM_ELEMENTS(prt_dsc_table); comment++)
+  for (comment = 0; comment < (int)ARRAY_SIZE(prt_dsc_table); comment++)
     if (prt_resfile_strncmp(0, prt_dsc_table[comment].string,
             prt_dsc_table[comment].len) == 0)
       break;
 
-  if (comment != NUM_ELEMENTS(prt_dsc_table)) {
+  if (comment != ARRAY_SIZE(prt_dsc_table)) {
     /* Return type of comment */
     p_dsc_line->type = prt_dsc_table[comment].type;
     offset = prt_dsc_table[comment].len;
@@ -2135,7 +2133,7 @@ int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
   props = enc_canon_props(p_encoding);
   if (!(props & ENC_8BIT) && ((*p_pmcs != NUL) || !(props & ENC_UNICODE))) {
     p_mbenc_first = NULL;
-    for (cmap = 0; cmap < (int)NUM_ELEMENTS(prt_ps_mbfonts); cmap++)
+    for (cmap = 0; cmap < (int)ARRAY_SIZE(prt_ps_mbfonts); cmap++)
       if (prt_match_encoding((char *)p_encoding, &prt_ps_mbfonts[cmap],
               &p_mbenc)) {
         if (p_mbenc_first == NULL)

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -303,7 +303,7 @@ static int cin_isinit(void)
   for (;; ) {
     int i, l;
 
-    for (i = 0; i < (int)(sizeof(skip) / sizeof(char *)); ++i) {
+    for (i = 0; i < (int)ARRAY_SIZE(skip); ++i) {
       l = (int)strlen(skip[i]);
       if (cin_starts_with(s, skip[i])) {
         s = cin_skipcomment(s + l);

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -284,8 +284,7 @@ static struct key_name_entry {
   {0,                 NULL}
 };
 
-#define KEY_NAMES_TABLE_LEN (sizeof(key_names_table) / \
-                             sizeof(struct key_name_entry))
+#define KEY_NAMES_TABLE_LEN ARRAY_SIZE(key_names_table)
 
 static struct mousetable {
   int pseudo_code;              /* Code for pseudo mouse event */

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -152,4 +152,12 @@
 
 # define RESET_BINDING(wp)  (wp)->w_p_scb = FALSE; (wp)->w_p_crb = FALSE
 
+/// Calculate the length of a C array.
+///
+/// This should be called with a real array. Calling this with a pointer is an
+/// error. A mechanism to detect many (though not all) of those errors at compile
+/// time is implemented. It works by the second division producing a division by
+/// zero in those cases (-Wdiv-by-zero in GCC).
+#define ARRAY_SIZE(arr) ((sizeof(arr)/sizeof((arr)[0])) / ((size_t)(!(sizeof(arr) % sizeof((arr)[0])))))
+
 #endif  // NVIM_MACROS_H

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -2168,7 +2168,7 @@ static void usage(void)
   for (i = 0;; ++i) {
     mch_msg(_(" vim [arguments] "));
     mch_msg(_(use[i]));
-    if (i == (sizeof(use) / sizeof(char_u *)) - 1)
+    if (i == ARRAY_SIZE(use) - 1)
       break;
     mch_msg(_("\n   or:"));
   }

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2346,13 +2346,12 @@ static convertStruct foldCase[] =
  * Return the converted equivalent of "a", which is a UCS-4 character.  Use
  * the given conversion "table".  Uses binary search on "table".
  */
-static int utf_convert(int a, convertStruct *table, int tableSize)
+static int utf_convert(int a, convertStruct *table, size_t n_items)
 {
-  int start, mid, end;   /* indices into table */
-  int entries = tableSize / sizeof(convertStruct);
+  size_t start, mid, end;   /* indices into table */
 
   start = 0;
-  end = entries;
+  end = n_items;
   while (start < end) {
     /* need to search further */
     mid = (end + start) / 2;
@@ -2361,7 +2360,7 @@ static int utf_convert(int a, convertStruct *table, int tableSize)
     else
       end = mid;
   }
-  if (start < entries
+  if (start < n_items
       && table[start].rangeStart <= a
       && a <= table[start].rangeEnd
       && (a - table[start].rangeStart) % table[start].step == 0)
@@ -2376,7 +2375,7 @@ static int utf_convert(int a, convertStruct *table, int tableSize)
  */
 int utf_fold(int a)
 {
-  return utf_convert(a, foldCase, (int)sizeof(foldCase));
+  return utf_convert(a, foldCase, ARRAY_SIZE(foldCase));
 }
 
 static convertStruct toLower[] =
@@ -2702,7 +2701,7 @@ int utf_toupper(int a)
     return TOUPPER_LOC(a);
 
   /* For any other characters use the above mapping table. */
-  return utf_convert(a, toUpper, (int)sizeof(toUpper));
+  return utf_convert(a, toUpper, ARRAY_SIZE(toUpper));
 }
 
 bool utf_islower(int a)
@@ -2732,7 +2731,7 @@ int utf_tolower(int a)
     return TOLOWER_LOC(a);
 
   /* For any other characters use the above mapping table. */
-  return utf_convert(a, toLower, (int)sizeof(toLower));
+  return utf_convert(a, toLower, ARRAY_SIZE(toLower));
 }
 
 bool utf_isupper(int a)

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2138,7 +2138,7 @@ int utf_class(int c)
     {0x2f800, 0x2fa1f, 0x4e00},         /* CJK Ideographs */
   };
   int bot = 0;
-  int top = sizeof(classes) / sizeof(struct clinterval) - 1;
+  int top = ARRAY_SIZE(classes) - 1;
   int mid;
 
   /* First quick check for Latin1 characters, use 'iskeyword'. */

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -925,9 +925,9 @@ static int dbcs_ptr2len_len(const char_u *p, int size)
 }
 
 /*
- * Return true if "c" is in "table[size / sizeof(struct interval)]".
+ * Return true if "c" is in "table".
  */
-static bool intable(const struct interval *table, size_t size, int c)
+static bool intable(const struct interval *table, size_t n_items, int c)
 {
   int mid, bot, top;
 
@@ -937,7 +937,7 @@ static bool intable(const struct interval *table, size_t size, int c)
 
   /* binary search in table */
   bot = 0;
-  top = (int)(size / sizeof(struct interval) - 1);
+  top = (int)(n_items - 1);
   while (top >= bot) {
     mid = (bot + top) / 2;
     if (table[mid].last < c)
@@ -1204,7 +1204,7 @@ int utf_char2cells(int c)
 #else
     if (!utf_printable(c))
       return 6;                 /* unprintable, displays <xxxx> */
-    if (intable(doublewidth, sizeof(doublewidth), c))
+    if (intable(doublewidth, ARRAY_SIZE(doublewidth), c))
       return 2;
 #endif
   }
@@ -1212,7 +1212,7 @@ int utf_char2cells(int c)
   else if (c >= 0x80 && !vim_isprintc(c))
     return 4;                   /* unprintable, displays <xx> */
 
-  if (c >= 0x80 && *p_ambw == 'd' && intable(ambiguous, sizeof(ambiguous), c))
+  if (c >= 0x80 && *p_ambw == 'd' && intable(ambiguous, ARRAY_SIZE(ambiguous), c))
     return 2;
 
   return 1;
@@ -2026,7 +2026,7 @@ bool utf_iscomposing(int c)
     {0xe0100, 0xe01ef}
   };
 
-  return intable(combining, sizeof(combining), c);
+  return intable(combining, ARRAY_SIZE(combining), c);
 }
 
 /*
@@ -2050,7 +2050,7 @@ bool utf_printable(int c)
     {0xfffe, 0xffff}
   };
 
-  return !intable(nonprint, sizeof(nonprint), c);
+  return !intable(nonprint, ARRAY_SIZE(nonprint), c);
 #endif
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -318,7 +318,7 @@ static const struct nv_cmd {
 };
 
 /* Number of commands in nv_cmds[]. */
-#define NV_CMDS_SIZE (sizeof(nv_cmds) / sizeof(struct nv_cmd))
+#define NV_CMDS_SIZE ARRAY_SIZE(nv_cmds)
 
 /* Sorted index of commands in nv_cmds[]. */
 static short nv_cmd_idx[NV_CMDS_SIZE];

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1808,7 +1808,7 @@ static struct vimoption
   }
 };
 
-#define PARAM_COUNT (sizeof(options) / sizeof(struct vimoption))
+#define PARAM_COUNT ARRAY_SIZE(options)
 
 static char *(p_ambw_values[]) = {"single", "double", NULL};
 static char *(p_bg_values[]) = {"light", "dark", NULL};

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1883,7 +1883,7 @@ void set_init_1(void)
     int mustfree;
 
     ga_init(&ga, 1, 100);
-    for (n = 0; n < (long)(sizeof(names) / sizeof(char *)); ++n) {
+    for (n = 0; n < (long)ARRAY_SIZE(names); ++n) {
       mustfree = FALSE;
 # ifdef UNIX
       if (*names[n] == NUL)
@@ -4723,10 +4723,10 @@ static char_u *set_chars_option(char_u **varp)
 
   if (varp == &p_lcs) {
     tab = lcstab;
-    entries = sizeof(lcstab) / sizeof(struct charstab);
+    entries = ARRAY_SIZE(lcstab);
   } else {
     tab = filltab;
-    entries = sizeof(filltab) / sizeof(struct charstab);
+    entries = ARRAY_SIZE(filltab);
   }
 
   /* first round: check for valid value, second round: assign values */
@@ -7250,7 +7250,7 @@ int ExpandSettings(expand_T *xp, regmatch_T *regmatch, int *num_file, char_u ***
   for (loop = 0; loop <= 1; ++loop) {
     regmatch->rm_ic = ic;
     if (xp->xp_context != EXPAND_BOOL_SETTINGS) {
-      for (match = 0; match < (int)(sizeof(names) / sizeof(char *));
+      for (match = 0; match < (int)ARRAY_SIZE(names);
            ++match)
         if (vim_regexec(regmatch, (char_u *)names[match], (colnr_T)0)) {
           if (loop == 0)

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -602,7 +602,7 @@ static int get_char_class(char_u **pp)
   int i;
 
   if ((*pp)[1] == ':') {
-    for (i = 0; i < (int)(sizeof(class_names) / sizeof(*class_names)); ++i)
+    for (i = 0; i < (int)ARRAY_SIZE(class_names); ++i)
       if (STRNCMP(*pp + 2, class_names[i], STRLEN(class_names[i])) == 0) {
         *pp += STRLEN(class_names[i]) + 2;
         return i;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3943,7 +3943,7 @@ get_syn_options (
     if (strchr(first_letters, *arg) == NULL)
       break;
 
-    for (fidx = sizeof(flagtab) / sizeof(struct flag); --fidx >= 0; ) {
+    for (fidx = ARRAY_SIZE(flagtab); --fidx >= 0; ) {
       p = flagtab[fidx].name;
       int i;
       for (i = 0, len = 0; p[i] != NUL; i += 2, ++len)
@@ -6295,7 +6295,7 @@ do_highlight (
         attr = 0;
         off = 0;
         while (arg[off] != NUL) {
-          for (i = sizeof(hl_attr_table) / sizeof(int); --i >= 0; ) {
+          for (i = ARRAY_SIZE(hl_attr_table); --i >= 0; ) {
             len = (int)STRLEN(hl_name_table[i]);
             if (STRNICMP(arg + off, hl_name_table[i], len) == 0) {
               attr |= hl_attr_table[i];
@@ -6416,7 +6416,7 @@ do_highlight (
 
             /* reduce calls to STRICMP a bit, it can be slow */
             off = TOUPPER_ASC(*arg);
-            for (i = (sizeof(color_names) / sizeof(char *)); --i >= 0; )
+            for (i = ARRAY_SIZE(color_names); --i >= 0; )
               if (off == color_names[i][0]
                   && STRICMP(arg + 1, color_names[i] + 1) == 0)
                 break;

--- a/src/nvim/tempfile.c
+++ b/src/nvim/tempfile.c
@@ -30,7 +30,7 @@ static void vim_maketempdir(void)
   // Try the entries in `TEMP_DIR_NAMES` to create the temp directory.
   char_u template[TEMP_FILE_PATH_MAXLEN];
   char_u path[TEMP_FILE_PATH_MAXLEN];
-  for (size_t i = 0; i < sizeof(temp_dirs) / sizeof(char *); ++i) {
+  for (size_t i = 0; i < ARRAY_SIZE(temp_dirs); ++i) {
     // Expand environment variables, leave room for "/nvimXXXXXX/999999999"
     expand_env((char_u *)temp_dirs[i], template, TEMP_FILE_PATH_MAXLEN - 22);
     if (!os_isdir(template)) {  // directory doesn't exist

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -986,7 +986,7 @@ void intro_message(int colon)
   };
 
   // blanklines = screen height - # message lines
-  blanklines = (int)Rows - ((sizeof(lines) / sizeof(char *)) - 1);
+  blanklines = (int)Rows - (ARRAY_SIZE(lines) - 1);
 
   // Don't overwrite a statusline.  Depends on 'cmdheight'.
   if (p_ls > 1) {
@@ -1006,7 +1006,7 @@ void intro_message(int colon)
   row = blanklines / 2;
 
   if (((row >= 2) && (Columns >= 50)) || colon) {
-    for (i = 0; i < (int)(sizeof(lines) / sizeof(char *)); ++i) {
+    for (i = 0; i < (int)ARRAY_SIZE(lines); ++i) {
       p = lines[i];
 
       if (sponsor != 0) {


### PR DESCRIPTION
A similar macro is defined in the Linux kernel [1].

To refactor the code I used a slightly modified Coccinelle script I found in
[2].

``` diff
// Use the macro ARRAY_SIZE when possible
//
// Confidence: High
// Copyright: (C) Gilles Muller, Julia Lawall, EMN, DIKU.  GPLv2.
// URL: http://www.emn.fr/x-info/coccinelle/rules/array.html
// Options: -I ... -all_includes can give more complete results

@@
type T;
T[] E;
@@

- (sizeof(E)/sizeof(*E))
+ ARRAY_SIZE(E)

@@
type T;
T[] E;
@@

- (sizeof(E)/sizeof(E[...]))
+ ARRAY_SIZE(E)

@@
type T;
T[] E;
@@

- (sizeof(E)/sizeof(T))
+ ARRAY_SIZE(E)

@n@
identifier AS,E;
@@

- #define AS(E) ARRAY_SIZE(E)

@@
expression E;
identifier n.AS;
@@

- AS(E)
+ ARRAY_SIZE(E)
```

`spatch --in-place --sp-file array_size.cocci -I src/ -I build/include/ -I build/src/nvim/auto/ src/nvim/*.c`

[1] http://lxr.free-electrons.com/source/include/linux/kernel.h#L54
[2] http://www.emn.fr/z-info/coccinelle/rules/#macros
