### PR TITLE
[RFC] Set some defaults early

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -1,0 +1,72 @@
+" defaults.vim
+"
+" some defaults set early on initialization.
+"
+" based on tpope's sensible.vim[1], with some suggestions gathered 
+" at neovim's issue #276[2]
+"
+" [1]: https://github.com/tpope/vim-sensible
+" [2]: https://github.com/neovim/neovim/issues/276
+
+filetype plugin indent on
+syntax enable
+
+set autoindent
+set backspace=indent,eol,start
+set complete-=i
+set smarttab
+
+set nrformats-=octal
+
+set ttimeout
+set ttimeoutlen=100
+
+set incsearch
+set hlsearch
+" use <C-L> to clear the highlighting of :set hlsearch.
+nnoremap <silent> <C-L> :nohlsearch<CR><C-L>
+
+set mouse=a
+
+set laststatus=2
+set ruler
+set showcmd
+set wildmenu
+set wildmode=list:longest,full
+
+set scrolloff=1
+set sidescrolloff=5
+set display+=lastline
+
+set listchars=tab:>\ ,trail:-,extends:>,precedes:<,nbsp:+
+
+set formatoptions+=j
+
+" search upwards for tags file
+setglobal tags-=./tags  tags^=./tags;
+
+set autoread
+set fileformats+=mac
+
+set history=1000
+set tabpagemax=50
+set viminfo^=!
+set sessionoptions-=options
+
+" allow color schemes to do bright colors without forcing bold.
+if &t_Co == 8 && $TERM !~# '^linux'
+    set t_Co=16
+endif
+
+runtime! macros/matchit.vim
+unlet g:loaded_matchit " allow a user installed matchit version to be resourced
+
+" Y yanks to the end of the line 
+noremap Y y$
+
+" allow undoing <C-u> (delete text typed in the current line)
+inoremap <C-U> <C-G>u<C-U>
+
+" <home> goes to the beginning of the text on first press 
+" and the beginning of the line on second. it alternates afterwards
+noremap <expr> <home> virtcol('.') - 1 <= indent('.') && col('.') > 1 ? '0' : '_'

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -352,8 +352,8 @@ argument.
 <		Also consider using autocommands; see |autocommand|.
 		When {vimrc} is equal to "NONE" (all uppercase), all
 		initializations from files and environment variables are
-		skipped, including reading the |gvimrc| file when the GUI
-		starts.  Loading plugins is also skipped.
+		skipped, including the |defaults.vim| file.  Loading plugins
+                is also skipped.
 		When {vimrc} is equal to "NORC" (all uppercase), this has the
 		same effect as "NONE", but loading plugins is not skipped.
 		{not in Vi}
@@ -539,14 +539,21 @@ accordingly.  Vim proceeds in this order:
 	If Vim was started in Ex mode with the "-s" argument, all following
 	initializations until 4. are skipped.  Only the "-u" option is
 	interpreted.
+
+                                                        *defaults.vim*
+     a. $VIMRUNTIME/defaults.vim is loaded first of all. This script sets some
+        basic settings which should be desirable for everyone. These defaults
+        are set here so the behavior of "set all&" is not changed (see |:set-&|). 
+        The defaults.vim file won't be loaded if nvim is started with '|-u| NONE'.
+
 							*system-vimrc*
-     a. For Unix, MS-DOS, MS-Windows, and Macintosh, the system vimrc file is
+     b. For Unix, MS-DOS, MS-Windows, and Macintosh, the system vimrc file is
 	read for initializations.  The path of this file is shown with the
 	":version" command.  Mostly it's "$VIM/vimrc".
 	For the Macintosh the $VIMRUNTIME/macmap.vim is read.
 
 	  *VIMINIT* *.vimrc* *_vimrc* *EXINIT* *.exrc* *_exrc* *$MYVIMRC*
-     b. Four places are searched for initializations.  The first that exists
+     c. Four places are searched for initializations.  The first that exists
 	is used, the others are ignored.  The $MYVIMRC environment variable is
 	set to the file that was first found, unless $MYVIMRC was already set
 	and when using VIMINIT.
@@ -571,7 +578,7 @@ accordingly.  Vim proceeds in this order:
 	   "vimrc" replaced by "exrc".  But only one of ".exrc" and "_exrc" is
 	   used, depending on the system.
 
-     c. If the 'exrc' option is on (which is not the default), the current
+     d. If the 'exrc' option is on (which is not the default), the current
 	directory is searched for three files.  The first that exists is used,
 	the others are ignored.
 	-  The file ".vimrc" (for Unix)

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -82,6 +82,7 @@ typedef struct {
   char        **argv;
 
   char_u      *use_vimrc;               /* vimrc from -u argument */
+  bool use_defaults;                    /* use defaults.vim */
 
   int n_commands;                            /* no. of commands from + or -c */
   char_u      *commands[MAX_ARG_CMDS];       /* commands from + or -c arg. */
@@ -1235,6 +1236,11 @@ scripterror:
 
           case 'u':               /* "-u {vimrc}" vim inits file */
             parmp->use_vimrc = (char_u *)argv[0];
+            if (STRCMP(parmp->use_vimrc, "NONE") == 0) {
+                parmp->use_defaults = false;
+            } else if (STRCMP(parmp->use_vimrc, "NORC") == 0) {
+                parmp->use_defaults = true;
+            }
             break;
 
           case 'U':               /* "-U {gvimrc}" gvim inits file */
@@ -1775,6 +1781,13 @@ static void exe_commands(mparm_T *parmp)
 static void source_startup_scripts(mparm_T *parmp)
 {
   int i;
+
+  // Source defaults.vim first of all, to change some defaults 
+  // without changing the behavior of "set all&"
+  if (parmp->use_defaults != false) {
+      (void)do_source((char_u *)NVIM_DEFAULTS_FILE, FALSE, DOSO_NONE);
+      TIME_MSG("source defaults file");
+  }
 
   /*
    * If -u argument given, use only the initializations from that file and

--- a/src/nvim/os_unix_defs.h
+++ b/src/nvim/os_unix_defs.h
@@ -121,6 +121,10 @@
 #    define USR_VIMRC_FILE2     "~/.nvim/nvimrc"
 #endif
 
+#ifndef NVIM_DEFAULTS_FILE
+# define NVIM_DEFAULTS_FILE     "$VIMRUNTIME/defaults.vim"
+#endif
+
 # ifndef VIMINFO_FILE
 #   define VIMINFO_FILE "~/.nviminfo"
 # endif


### PR DESCRIPTION
Implements idea from issue #1664 
- [x] Create `runtime/defaults.vim` (definition of contents ongoing)
- [x] Load `runtime/defaults.vim` from `main.c:source_startup_scripts()`.
- [x] Update `runtime/doc/starting.txt`.
- [x] Fix handling of `-u` arguments, so `-u NONE` doesn't load these defaults.

Notes: `defaults.vim` is mostly based on vim-sensible. I removed feature checks since they are unneded in neovim. 
