### PR TITLE
[RFC] Don't read ~/.nviminfo when running the functional tests.

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -4,8 +4,11 @@ local MsgpackStream = require('nvim.msgpack_stream')
 local AsyncSession = require('nvim.async_session')
 local Session = require('nvim.session')
 
+local viminfo_name = 'nviminfo'
 local nvim_prog = os.getenv('NVIM_PROG') or 'build/bin/nvim'
-local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N', '--embed'}
+-- set viminfo file to avoid conflicts during local test runs
+local nvim_argv = {nvim_prog, '-u', 'NONE',
+                   '--cmd', 'set viminfo+=n'..viminfo_name, '-N', '--embed'}
 local prepend_argv
 
 if os.getenv('VALGRIND') then
@@ -155,6 +158,7 @@ local function clear()
     session:request('vim_command', 'qa!')
     session:exit()
   end
+  os.remove(viminfo_name)
   local loop = Loop.new()
   local msgpack_stream = MsgpackStream.new(loop)
   local async_session = AsyncSession.new(msgpack_stream)

--- a/test/functional/options/viminfo_spec.lua
+++ b/test/functional/options/viminfo_spec.lua
@@ -1,0 +1,30 @@
+local helpers = require('test.functional.helpers')
+local clear, execute, ok = helpers.clear, helpers.execute, helpers.ok
+
+describe('viminfo', function()
+  setup(clear)
+
+  it('`n`: uses a different viminfo name', function()
+    local viminfo_name = 'nviminfo_foobar'
+    execute("set viminfo='100,n"..viminfo_name)
+
+    os.remove(viminfo_name)
+    execute('wviminfo!')
+    execute("call system('sync')")
+    ok(os.remove(viminfo_name))
+  end)
+
+  --pending('`!`: saves/restores uppercase variables - migrate test74')
+  --pending('`"`: tests max number of lines saved for each register')
+  --pending('`<`: tests max number of lines saved for each register')
+  --pending('`%`: saves/restores the buffer list')
+  --pending("`'`: remembers marks for a maximum number of files")
+  --pending('`/`: tests max number of items in the search pattern history')
+  --pending('`:`: tests max number of items in the command-line history')
+  --pending('`@`: tests max number of items in the input-line history')
+  --pending('`c`: converts viminfo file to different encoding')
+  --pending('`f`: stores file marks')
+  --pending("`h`: disables the effect of 'hlsearch'")
+  --pending("`r`: doesn't store marks for removable media")
+  --pending('`s`: tests maximum size of an item')
+end)


### PR DESCRIPTION
With `nocp` set as the default, nvim reads the viminfo file before running the old tests. This can lead to unexpected test failures, like in #1673 .

This PR sets `viminfo=` in the test vimrc file and changes it back to the default value in `dotest.in`. 

Edit: I also thought about `-i NONE`, but test74 explicitly tests some viminfo behavior. 
