### PR TITLE
[RFC] Fix for clang analyzer warning in ops.c

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4483,10 +4483,7 @@ int read_viminfo_register(vir_T *virp, int force)
     if (set_prev)
       y_previous = y_current;
 
-    for (int i = 0; i < y_current->y_size; i++) {
-      free(y_current->y_array[i]);
-    }
-    free(y_current->y_array);
+    free_yank_all();
     array = xmalloc(limit * sizeof(char_u *));
 
     str = skipwhite(skiptowhite(str));
@@ -4515,7 +4512,6 @@ int read_viminfo_register(vir_T *virp, int force)
   if (do_it) {
     if (size == 0) {
       free(array);
-      y_current->y_array = NULL;
     } else if (size < limit) {
       y_current->y_array = xrealloc(array, size * sizeof(char_u *));
     } else {


### PR DESCRIPTION
Fix warning: ops.c: read_viminfo_register():  Dereference of null pointer: RI.

Problem    : Array access (via field 'y_array') results in a null pointer
dereference @ 4487.

Diagnostic : Real issue.

Rationale  : If the array was previously freed and the size of the array
(`y_current->y_size`) was not updated to zero, the loop @4486
could be entered and a `NULL` pointer would be dereferenced.

Resolution : Use `free_yank_all()` to take care of the `NULL` check and
to free the current yank register.
