### PR TITLE
coverity/74718: FP: NULL Pointer Dereference

### DIFF
--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -396,6 +396,7 @@ static void read_input(DynamicBuffer *buf)
               curbuf->b_ml.ml_line_count
               || curbuf->b_p_eol))) {
         dynamic_buffer_ensure(buf, buf->len + 1);
+        assert(buf->data != NULL);
         buf->data[buf->len++] = NL;
       }
       ++lnum;


### PR DESCRIPTION
dynamic_buffer_ensure() allocates buf->data; add an assert to make this
clear to coverity.
