### PR TITLE
[RFC] coverity/74717: FP: NULL Pointer Dereference

### DIFF
--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -268,6 +268,7 @@ static int shell(const char *cmd,
 static void dynamic_buffer_ensure(DynamicBuffer *buf, size_t desired)
 {
   if (buf->cap >= desired) {
+    assert(buf->data);
     return;
   }
 


### PR DESCRIPTION
dynamic_buffer_ensure() allocates buf->data; add an assert to make this clear to coverity.
