### PR TITLE
[RFC] coverity/74718: RI: os_call_shell: handle null `cmd`

### DIFF
--- a/src/nvim/misc2.c
+++ b/src/nvim/misc2.c
@@ -285,9 +285,7 @@ int default_fileformat(void)
   return EOL_UNIX;
 }
 
-/*
- * Call shell.	Calls mch_call_shell, with 'shellxquote' added.
- */
+// Call shell. Calls os_call_shell, with 'shellxquote' added.
 int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
 {
   char_u      *ncmd;

--- a/src/nvim/os/shell.h
+++ b/src/nvim/os/shell.h
@@ -3,7 +3,7 @@
 
 #include "nvim/types.h"
 
-// Flags for mch_call_shell() second argument
+// Flags for os_call_shell() second argument
 typedef enum {
   kShellOptFilter = 1,     ///< filtering text
   kShellOptExpand = 2,     ///< expanding wildcards

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -1117,7 +1117,7 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
 
   free(command);
 
-  if (i != 0) {                         /* mch_call_shell() failed */
+  if (i) {                         /* os_call_shell() failed */
     os_remove((char *)tempname);
     free(tempname);
     /*


### PR DESCRIPTION
- remove invalid `FUNC_ATTR_NONNULL_ARG(1)`
- receive `(char *)` internally
- modify identifier names for consistency
- edit comments for concision and consistency
