### PR TITLE
[RDY] vim-patch:7.4.423

### DIFF
--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -58,8 +58,8 @@ int get_indent_str(char_u *ptr, int ts, int list)
       if (!list || lcs_tab1) {  // count a tab for what it is worth
         count += ts - (count % ts);
       } else {
-        // in list mode, when tab is not set, count screen char width for Tab:
-        // ^I
+        // In list mode, when tab is not set, count screen char width
+        // for Tab, displays: ^I
         count += ptr2cells(ptr);
       }
     } else if (*ptr == ' ') {

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -1066,10 +1066,12 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
               || pat[i][j + 1] == '`')
             *p++ = '\\';
           ++j;
-        } else if (!intick && vim_strchr(SHELL_SPECIAL,
-                       pat[i][j]) != NULL)
+        } else if (!intick
+            && ((flags & EW_KEEPDOLLAR) == 0 || pat[i][j] != '$')
+            && vim_strchr(SHELL_SPECIAL, pat[i][j]) != NULL)
           /* Put a backslash before a special character, but not
-           * when inside ``. */
+           * when inside ``. And not for $var when EW_KEEPDOLLAR is
+           * set. */
           *p++ = '\\';
 
         /* Copy one character. */

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1080,7 +1080,7 @@ gen_expand_wildcards (
           free(p);
           ga_clear_strings(&ga);
           i = mch_expand_wildcards(num_pat, pat, num_file, file,
-              flags);
+              flags | EW_KEEPDOLLAR);
           recursive = FALSE;
           return i;
         }

--- a/src/nvim/path.h
+++ b/src/nvim/path.h
@@ -17,6 +17,7 @@
 #define EW_ICASE        0x100   /* ignore case */
 #define EW_NOERROR      0x200   /* no error for bad regexp */
 #define EW_NOTWILD      0x400   /* add match with literal name if exists */
+#define EW_KEEPDOLLAR   0x800   /* do not escape $, $var is expanded */
 /* Note: mostly EW_NOTFOUND and EW_SILENT are mutually exclusive: EW_NOTFOUND
 * is used when executing commands and EW_SILENT for interactive expanding. */
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -306,7 +306,7 @@ static int included_patches[] = {
   //426 NA
   425,
   //424 NA
-  //423,
+  423,
   //422,
   421,
   //420 NA


### PR DESCRIPTION
```
Problem:    expand("$shell") does not work as documented.
Solution:   Do not escape the $ when expanding environment variables.

https://code.google.com/p/vim/source/detail?r=v7-4-423
```

Original patch:

``` diff
diff --git a/src/nvim/misc1.c b/src/nvim/misc1.c
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -78,7 +78,8 @@ get_indent_str(ptr, ts, list)
        if (!list || lcs_tab1)    /* count a tab for what it is worth */
        count += ts - (count % ts);
        else
-   /* in list mode, when tab is not set, count screen char width for Tab: ^I */
+       /* In list mode, when tab is not set, count screen char width
+        * for Tab, displays: ^I */
        count += ptr2cells(ptr);
    }
    else if (*ptr == ' ')
@@ -10767,7 +10768,7 @@ gen_expand_wildcards(num_pat, pat, num_f
            vim_free(p);
            ga_clear_strings(&ga);
            i = mch_expand_wildcards(num_pat, pat, num_file, file,
-                                      flags);
+                            flags|EW_KEEPDOLLAR);
            recursive = FALSE;
            return i;
        }
diff --git a/src/nvim/os_unix.c b/src/nvim/os_unix.c
--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -5939,10 +5939,12 @@ mch_expand_wildcards(num_pat, pat, num_f
            *p++ = '\\';
            ++j;
        }
-       else if (!intick && vim_strchr(SHELL_SPECIAL,
-                              pat[i][j]) != NULL)
+       else if (!intick
+            && ((flags & EW_KEEPDOLLAR) == 0 || pat[i][j] != '$')
+                 && vim_strchr(SHELL_SPECIAL, pat[i][j]) != NULL)
            /* Put a backslash before a special character, but not
-            * when inside ``. */
+            * when inside ``. And not for $var when EW_KEEPDOLLAR is
+            * set. */
            *p++ = '\\';

        /* Copy one character. */
diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    423,
+/**/
     422,
 /**/
     421,
diff --git a/src/nvim/vim.h b/src/nvim/vim.h
--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -835,6 +835,7 @@ extern char *(*dyn_libintl_textdomain)(c
 #define EW_ICASE   0x100   /* ignore case */
 #define EW_NOERROR 0x200   /* no error for bad regexp */
 #define EW_NOTWILD 0x400   /* add match with literal name if exists */
+#define EW_KEEPDOLLAR  0x800   /* do not escape $, $var is expanded */
 /* Note: mostly EW_NOTFOUND and EW_SILENT are mutually exclusive: EW_NOTFOUND
  * is used when executing commands and EW_SILENT for interactive expanding. */
```
