### PR TITLE
[RFC] vim-patch: Mark patches as NA.

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -178,6 +178,14 @@ static char *(features[]) = {
 };
 
 static int included_patches[] = {
+  //560,
+  //559,
+  //558 NA
+  //557 NA
+  //556 NA
+  //555 NA
+  //554,
+  //553,
   //552,
   //551,
   //550,


### PR DESCRIPTION
- https://code.google.com/p/vim/source/detail?r=v7-4-558 deals with X11.
- https://code.google.com/p/vim/source/detail?r=v7-4-557 updates a function protype.
- https://code.google.com/p/vim/source/detail?r=v7-4-556 is about the Python interface (provider).
- https://code.google.com/p/vim/source/detail?r=v7-4-555 is about feature sets (tiny, small) in functional tests.
