### PR TITLE
[RDY] vim-patch:7.4.456

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -921,7 +921,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'backupcopy'* *'bkc'*
 'backupcopy' 'bkc'	string	(Vi default for Unix: "yes", otherwise: "auto")
-			global
+			global or local to buffer |global-local|
 			{not in Vi}
 	When writing a file and a backup is made, this option tells how it's
 	done.  This is a comma separated list of words.

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1530,6 +1530,7 @@ void free_buf_options(buf_T *buf, int free_p_ff)
   buf->b_p_ar = -1;
   buf->b_p_ul = NO_LOCAL_UNDOLEVEL;
   clear_string_option(&buf->b_p_lw);
+  clear_string_option(&buf->b_p_bkc);
 }
 
 /*

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -596,6 +596,8 @@ struct file_buffer {
 
   int b_p_ai;                   /* 'autoindent' */
   int b_p_ai_nopaste;           /* b_p_ai saved for paste mode */
+  char_u      *b_p_bkc;         ///< 'backupcopy'
+  unsigned int b_bkc_flags;     ///< flags for 'backupcopy'
   int b_p_ci;                   /* 'copyindent' */
   int b_p_bin;                  /* 'binary' */
   int b_p_bomb;                 /* 'bomb' */

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2313,6 +2313,7 @@ buf_write (
 #endif
   int write_undo_file = FALSE;
   context_sha256_T sha_ctx;
+  unsigned int bkc = get_bkc_value(buf);
 
   if (fname == NULL || *fname == NUL)   /* safety check */
     return FAIL;
@@ -2701,9 +2702,9 @@ buf_write (
   if (!(append && *p_pm == NUL) && !filtering && perm >= 0 && dobackup) {
     FileInfo file_info;
 
-    if ((bkc_flags & BKC_YES) || append) {       /* "yes" */
+    if ((bkc & BKC_YES) || append) {       /* "yes" */
       backup_copy = TRUE;
-    } else if ((bkc_flags & BKC_AUTO)) {          /* "auto" */
+    } else if ((bkc & BKC_AUTO)) {          /* "auto" */
       int i;
 
 # ifdef UNIX
@@ -2758,19 +2759,19 @@ buf_write (
     /*
      * Break symlinks and/or hardlinks if we've been asked to.
      */
-    if ((bkc_flags & BKC_BREAKSYMLINK) || (bkc_flags & BKC_BREAKHARDLINK)) {
+    if ((bkc & BKC_BREAKSYMLINK) || (bkc & BKC_BREAKHARDLINK)) {
 # ifdef UNIX
       bool file_info_link_ok = os_fileinfo_link((char *)fname, &file_info);
 
       /* Symlinks. */
-      if ((bkc_flags & BKC_BREAKSYMLINK)
+      if ((bkc & BKC_BREAKSYMLINK)
           && file_info_link_ok
           && !os_fileinfo_id_equal(&file_info, &file_info_old)) {
         backup_copy = FALSE;
       }
 
       /* Hardlinks. */
-      if ((bkc_flags & BKC_BREAKHARDLINK)
+      if ((bkc & BKC_BREAKHARDLINK)
           && os_fileinfo_hardlinks(&file_info_old) > 1
           && (!file_info_link_ok
               || os_fileinfo_id_equal(&file_info, &file_info_old))) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -103,6 +103,7 @@
  */
 #define PV_AI           OPT_BUF(BV_AI)
 #define PV_AR           OPT_BOTH(OPT_BUF(BV_AR))
+#define PV_BKC          OPT_BOTH(OPT_BUF(BV_BKC))
 # define PV_BH          OPT_BUF(BV_BH)
 # define PV_BT          OPT_BUF(BV_BT)
 # define PV_EFM         OPT_BOTH(OPT_BUF(BV_EFM))
@@ -438,7 +439,7 @@ static struct vimoption
    (char_u *)&p_bk, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"backupcopy",  "bkc",  P_STRING|P_VIM|P_COMMA|P_NODUP,
-   (char_u *)&p_bkc, PV_NONE,
+   (char_u *)&p_bkc, PV_BKC,
 #ifdef UNIX
    {(char_u *)"yes", (char_u *)"auto"}
 #else
@@ -3526,6 +3527,7 @@ void check_buf_options(buf_T *buf)
   check_string_option(&buf->b_p_dict);
   check_string_option(&buf->b_p_tsr);
   check_string_option(&buf->b_p_lw);
+  check_string_option(&buf->b_p_bkc);
 }
 
 /*
@@ -3782,14 +3784,24 @@ did_set_string_option (
       redraw_later_clear();
   }
   /* 'backupcopy' */
-  else if (varp == &p_bkc) {
-    if (opt_strings_flags(p_bkc, p_bkc_values, &bkc_flags, TRUE) != OK)
+  else if (gvarp == &p_bkc) {
+    char_u       *bkc   = p_bkc;
+    unsigned int *flags = &bkc_flags;
+
+    if (opt_flags & OPT_LOCAL) {
+      bkc   = curbuf->b_p_bkc;
+      flags = &curbuf->b_bkc_flags;
+    }
+
+    if (opt_strings_flags(bkc, p_bkc_values, flags, TRUE) != OK) {
       errmsg = e_invarg;
-    if (((bkc_flags & BKC_AUTO) != 0)
-        + ((bkc_flags & BKC_YES) != 0)
-        + ((bkc_flags & BKC_NO) != 0) != 1) {
+    }
+
+    if (((*flags & BKC_AUTO) != 0)
+        + ((*flags & BKC_YES) != 0)
+        + ((*flags & BKC_NO) != 0) != 1) {
       /* Must have exactly one of "auto", "yes"  and "no". */
-      (void)opt_strings_flags(oldval, p_bkc_values, &bkc_flags, TRUE);
+      (void)opt_strings_flags(oldval, p_bkc_values, flags, TRUE);
       errmsg = e_invarg;
     }
   }
@@ -6518,6 +6530,10 @@ void unset_global_local_option(char *name, void *from)
     case PV_AR:
       buf->b_p_ar = -1;
       break;
+    case PV_BKC:
+      clear_string_option(&buf->b_p_bkc);
+      buf->b_bkc_flags = 0;
+      break;
     case PV_TAGS:
       clear_string_option(&buf->b_p_tags);
       break;
@@ -6581,6 +6597,7 @@ static char_u *get_varp_scope(struct vimoption *p, int opt_flags)
     case PV_STL:  return (char_u *)&(curwin->w_p_stl);
     case PV_UL:   return (char_u *)&(curbuf->b_p_ul);
     case PV_LW:   return (char_u *)&(curbuf->b_p_lw);
+    case PV_BKC:  return (char_u *)&(curbuf->b_p_bkc);
     }
     return NULL;     /* "cannot happen" */
   }
@@ -6610,6 +6627,8 @@ static char_u *get_varp(struct vimoption *p)
            ? (char_u *)&(curbuf->b_p_ar) : p->var;
   case PV_TAGS:   return *curbuf->b_p_tags != NUL
            ? (char_u *)&(curbuf->b_p_tags) : p->var;
+  case PV_BKC:    return *curbuf->b_p_bkc != NUL
+           ? (char_u *)&(curbuf->b_p_bkc) : p->var;
   case PV_DEF:    return *curbuf->b_p_def != NUL
            ? (char_u *)&(curbuf->b_p_def) : p->var;
   case PV_INC:    return *curbuf->b_p_inc != NUL
@@ -6975,6 +6994,8 @@ void buf_copy_options(buf_T *buf, int flags)
        * are not copied, start using the global value */
       buf->b_p_ar = -1;
       buf->b_p_ul = NO_LOCAL_UNDOLEVEL;
+      buf->b_p_bkc = empty_option;
+      buf->b_bkc_flags = 0;
       buf->b_p_gp = empty_option;
       buf->b_p_mp = empty_option;
       buf->b_p_efm = empty_option;
@@ -8116,3 +8137,10 @@ static bool briopt_check(win_T *wp)
   return true;
 }
 
+/// Get the local or global value of 'backupcopy'.
+///
+/// @param buf The buffer.
+unsigned int get_bkc_value(buf_T *buf)
+{
+  return buf->b_bkc_flags ? buf->b_bkc_flags : bkc_flags;
+}

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -292,7 +292,7 @@ EXTERN char_u   *p_bs;          /* 'backspace' */
 EXTERN char_u   *p_bg;          /* 'background' */
 EXTERN int p_bk;                /* 'backup' */
 EXTERN char_u   *p_bkc;         /* 'backupcopy' */
-EXTERN unsigned bkc_flags;
+EXTERN unsigned int bkc_flags;  ///< flags from 'backupcopy'
 #ifdef IN_OPTION_C
 static char *(p_bkc_values[]) =
 {"yes", "auto", "no", "breaksymlink", "breakhardlink", NULL};
@@ -643,6 +643,7 @@ enum {
   BV_AI = 0
   , BV_AR
   , BV_BH
+  , BV_BKC
   , BV_BT
   , BV_EFM
   , BV_GP

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -281,7 +281,7 @@ static int included_patches[] = {
   //459 NA
   //458,
   //457,
-  //456,
+  456,
   455,
   454,
   //453 NA


### PR DESCRIPTION
```
Problem:  'backupcopy' is global, cannot write only some
          files in a different way.
Solution: Make 'backupcopy' global-local. (Christian Brabandt)

https://code.google.com/p/vim/source/detail?r=v7-4-456
```

Succeeds #1228. Changed the type for the flags per https://github.com/neovim/neovim/pull/1228#discussion_r18125563, but used `unsigned int` instead of suggested `int` (seems to be used for other flags, e.g. https://github.com/neovim/neovim/blob/7fc7f026ad1103b1f6670507cd9cd7a816ae3539/src/nvim/option_defs.h#L310).

Original patch:

``` diff
diff --git a/runtime/doc/options.txt b/runtime/doc/options.txt
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -921,7 +921,7 @@ A jump table for the options with a shor

                        *'backupcopy'* *'bkc'*
 'backupcopy' 'bkc' string  (Vi default for Unix: "yes", otherwise: "auto")
-           global
+           global or local to buffer |global-local|
            {not in Vi}
    When writing a file and a backup is made, this option tells how it's
    done.  This is a comma separated list of words.
diff --git a/src/buffer.c b/src/buffer.c
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2001,6 +2001,7 @@ free_buf_options(buf, free_p_ff)
 #ifdef FEAT_LISP
     clear_string_option(&buf->b_p_lw);
 #endif
+    clear_string_option(&buf->b_p_bkc);
 }

 /*
diff --git a/src/fileio.c b/src/fileio.c
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -3149,6 +3149,7 @@ buf_write(buf, fname, sfname, start, end
     int            write_undo_file = FALSE;
     context_sha256_T sha_ctx;
 #endif
+    unsigned int    bkc = get_bkc_value(buf);

     if (fname == NULL || *fname == NUL)    /* safety check */
    return FAIL;
@@ -3647,10 +3648,10 @@ buf_write(buf, fname, sfname, start, end
    struct stat st;
 #endif

-   if ((bkc_flags & BKC_YES) || append)    /* "yes" */
+   if ((bkc & BKC_YES) || append)  /* "yes" */
        backup_copy = TRUE;
 #if defined(UNIX) || defined(WIN32)
-   else if ((bkc_flags & BKC_AUTO))    /* "auto" */
+   else if ((bkc & BKC_AUTO))  /* "auto" */
    {
        int     i;

@@ -3738,7 +3739,7 @@ buf_write(buf, fname, sfname, start, end
    /*
     * Break symlinks and/or hardlinks if we've been asked to.
     */
-   if ((bkc_flags & BKC_BREAKSYMLINK) || (bkc_flags & BKC_BREAKHARDLINK))
+   if ((bkc & BKC_BREAKSYMLINK) || (bkc & BKC_BREAKHARDLINK))
    {
 # ifdef UNIX
        int lstat_res;
@@ -3746,24 +3747,24 @@ buf_write(buf, fname, sfname, start, end
        lstat_res = mch_lstat((char *)fname, &st);

        /* Symlinks. */
-       if ((bkc_flags & BKC_BREAKSYMLINK)
+       if ((bkc & BKC_BREAKSYMLINK)
            && lstat_res == 0
            && st.st_ino != st_old.st_ino)
        backup_copy = FALSE;

        /* Hardlinks. */
-       if ((bkc_flags & BKC_BREAKHARDLINK)
+       if ((bkc & BKC_BREAKHARDLINK)
            && st_old.st_nlink > 1
            && (lstat_res != 0 || st.st_ino == st_old.st_ino))
        backup_copy = FALSE;
 # else
 #  if defined(WIN32)
        /* Symlinks. */
-       if ((bkc_flags & BKC_BREAKSYMLINK) && mch_is_symbolic_link(fname))
+       if ((bkc & BKC_BREAKSYMLINK) && mch_is_symbolic_link(fname))
        backup_copy = FALSE;

        /* Hardlinks. */
-       if ((bkc_flags & BKC_BREAKHARDLINK) && mch_is_hard_link(fname))
+       if ((bkc & BKC_BREAKHARDLINK) && mch_is_hard_link(fname))
        backup_copy = FALSE;
 #  endif
 # endif
diff --git a/src/option.c b/src/option.c
--- a/src/option.c
+++ b/src/option.c
@@ -56,6 +56,7 @@
  */
 #define PV_AI      OPT_BUF(BV_AI)
 #define PV_AR      OPT_BOTH(OPT_BUF(BV_AR))
+#define PV_BKC     OPT_BOTH(OPT_BUF(BV_BKC))
 #ifdef FEAT_QUICKFIX
 # define PV_BH     OPT_BUF(BV_BH)
 # define PV_BT     OPT_BUF(BV_BT)
@@ -582,7 +583,7 @@ static struct vimoption
                (char_u *)&p_bk, PV_NONE,
                {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
     {"backupcopy",  "bkc",  P_STRING|P_VIM|P_COMMA|P_NODUP,
-               (char_u *)&p_bkc, PV_NONE,
+               (char_u *)&p_bkc, PV_BKC,
 #ifdef UNIX
                {(char_u *)"yes", (char_u *)"auto"}
 #else
@@ -5412,6 +5413,7 @@ check_buf_options(buf)
 #ifdef FEAT_LISP
     check_string_option(&buf->b_p_lw);
 #endif
+    check_string_option(&buf->b_p_bkc);
 }

 /*
@@ -5729,16 +5731,25 @@ did_set_string_option(opt_idx, varp, new
     }

     /* 'backupcopy' */
-    else if (varp == &p_bkc)
-    {
-   if (opt_strings_flags(p_bkc, p_bkc_values, &bkc_flags, TRUE) != OK)
+    else if (gvarp == &p_bkc)
+    {
+   char_u      *bkc = p_bkc;
+   unsigned int    *flags = &bkc_flags;
+
+   if (opt_flags & OPT_LOCAL)
+   {
+       bkc = curbuf->b_p_bkc;
+       flags = &curbuf->b_bkc_flags;
+   }
+
+   if (opt_strings_flags(bkc, p_bkc_values, flags, TRUE) != OK)
        errmsg = e_invarg;
-   if (((bkc_flags & BKC_AUTO) != 0)
-       + ((bkc_flags & BKC_YES) != 0)
-       + ((bkc_flags & BKC_NO) != 0) != 1)
+   if ((((int)*flags & BKC_AUTO) != 0)
+       + (((int)*flags & BKC_YES) != 0)
+       + (((int)*flags & BKC_NO) != 0) != 1)
    {
        /* Must have exactly one of "auto", "yes"  and "no". */
-       (void)opt_strings_flags(oldval, p_bkc_values, &bkc_flags, TRUE);
+       (void)opt_strings_flags(oldval, p_bkc_values, flags, TRUE);
        errmsg = e_invarg;
    }
     }
@@ -9025,12 +9036,13 @@ get_option_value_strict(name, numval, st
 }

 /*
- * Iterate over options. First argument is a pointer to a pointer to a structure 
- * inside options[] array, second is option type like in the above function.
+ * Iterate over options. First argument is a pointer to a pointer to a
+ * structure inside options[] array, second is option type like in the above
+ * function.
  *
- * If first argument points to NULL it is assumed that iteration just started 
+ * If first argument points to NULL it is assumed that iteration just started
  * and caller needs the very first value.
- * If first argument points to the end marker function returns NULL and sets 
+ * If first argument points to the end marker function returns NULL and sets
  * first argument to NULL.
  *
  * Returns full option name for current option on each call.
@@ -9856,6 +9868,10 @@ unset_global_local_option(name, from)
    case PV_AR:
        buf->b_p_ar = -1;
        break;
+   case PV_BKC:
+       clear_string_option(&buf->b_p_bkc);
+       buf->b_bkc_flags = 0;
+       break;
    case PV_TAGS:
        clear_string_option(&buf->b_p_tags);
        break;
@@ -9961,6 +9977,7 @@ get_varp_scope(p, opt_flags)
 #ifdef FEAT_LISP
        case PV_LW:   return (char_u *)&(curbuf->b_p_lw);
 #endif
+       case PV_BKC:  return (char_u *)&(curbuf->b_p_bkc);
    }
    return NULL; /* "cannot happen" */
     }
@@ -9993,6 +10010,8 @@ get_varp(p)
                    ? (char_u *)&(curbuf->b_p_ar) : p->var;
    case PV_TAGS:   return *curbuf->b_p_tags != NUL
                    ? (char_u *)&(curbuf->b_p_tags) : p->var;
+   case PV_BKC:    return *curbuf->b_p_bkc != NUL
+                   ? (char_u *)&(curbuf->b_p_bkc) : p->var;
 #ifdef FEAT_FIND_ID
    case PV_DEF:    return *curbuf->b_p_def != NUL
                    ? (char_u *)&(curbuf->b_p_def) : p->var;
@@ -10585,6 +10604,8 @@ buf_copy_options(buf, flags)
         * are not copied, start using the global value */
        buf->b_p_ar = -1;
        buf->b_p_ul = NO_LOCAL_UNDOLEVEL;
+       buf->b_p_bkc = empty_option;
+       buf->b_bkc_flags = 0;
 #ifdef FEAT_QUICKFIX
        buf->b_p_gp = empty_option;
        buf->b_p_mp = empty_option;
@@ -12052,3 +12073,13 @@ briopt_check(wp)
     return OK;
 }
 #endif
+
+/*
+ * Get the local or global value of 'backupcopy'.
+ */
+    unsigned int
+get_bkc_value(buf)
+    buf_T *buf;
+{
+    return buf->b_bkc_flags ? buf->b_bkc_flags : bkc_flags;
+}
diff --git a/src/option.h b/src/option.h
--- a/src/option.h
+++ b/src/option.h
@@ -327,7 +327,7 @@ EXTERN char_u   *p_bs;      /* 'backspace' */
 EXTERN char_u  *p_bg;      /* 'background' */
 EXTERN int p_bk;       /* 'backup' */
 EXTERN char_u  *p_bkc;     /* 'backupcopy' */
-EXTERN unsigned    bkc_flags;
+EXTERN unsigned    bkc_flags;  /* flags from 'backupcopy' */
 #ifdef IN_OPTION_C
 static char *(p_bkc_values[]) = {"yes", "auto", "no", "breaksymlink", "breakhardlink", NULL};
 #endif
@@ -918,6 +918,9 @@ enum
     , BV_AR
 #ifdef FEAT_QUICKFIX
     , BV_BH
+#endif
+    , BV_BKC
+#ifdef FEAT_QUICKFIX
     , BV_BT
     , BV_EFM
     , BV_GP
diff --git a/src/proto/option.pro b/src/proto/option.pro
--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -62,4 +62,5 @@ int check_ff_value __ARGS((char_u *p));
 long get_sw_value __ARGS((buf_T *buf));
 long get_sts_value __ARGS((void));
 void find_mps_values __ARGS((int *initc, int *findc, int *backwards, int switchit));
+unsigned int get_bkc_value __ARGS((buf_T *buf));
 /* vim: set ft=c : */
diff --git a/src/structs.h b/src/structs.h
--- a/src/structs.h
+++ b/src/structs.h
@@ -137,7 +137,7 @@ typedef struct
 #ifdef FEAT_LINEBREAK
     int        wo_bri;
 # define w_p_bri w_onebuf_opt.wo_bri   /* 'breakindent' */
-    char_u     *wo_briopt;
+    char_u *wo_briopt;
 # define w_p_briopt w_onebuf_opt.wo_briopt /* 'breakindentopt' */
 #endif
 #ifdef FEAT_DIFF
@@ -1537,6 +1537,8 @@ struct file_buffer

     int        b_p_ai;     /* 'autoindent' */
     int        b_p_ai_nopaste; /* b_p_ai saved for paste mode */
+    char_u *b_p_bkc;   /* 'backupcopy' */
+    unsigned   b_bkc_flags;    /* flags for 'backupcopy' */
     int        b_p_ci;     /* 'copyindent' */
     int        b_p_bin;    /* 'binary' */
 #ifdef FEAT_MBYTE
diff --git a/src/version.c b/src/version.c
--- a/src/version.c
+++ b/src/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    456,
+/**/
     455,
 /**/
     454,
```
