### PR TITLE
[RDY] vim-patch:7.4.457

### DIFF
--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -281,6 +281,7 @@ static struct key_name_entry {
   {K_ZERO,            (char_u *)"Nul"},
   {K_SNR,             (char_u *)"SNR"},
   {K_PLUG,            (char_u *)"Plug"},
+  {K_CURSORHOLD,      (char_u *)"CursorHold"},
   {0,                 NULL}
 };
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -280,7 +280,7 @@ static int included_patches[] = {
   //460 NA
   //459 NA
   //458,
-  //457,
+  457,
   //456,
   455,
   454,


### PR DESCRIPTION
```
Problem:  Using getchar() in an expression mapping may result in
          K_CURSORHOLD, which can't be recognized.
Solution: Add the <CursorHold> key.  (Hirohito Higashi)

https://code.google.com/p/vim/source/detail?r=v7-4-457
```

Succeeds #1226.
