### PR TITLE
[RFC] vim-patch:7.4.395

### DIFF
--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -1545,6 +1545,7 @@ int get_c_indent(void)
   char_u      *linecopy;
   pos_T       *trypos;
   pos_T       *tryposBrace = NULL;
+  pos_T       tryposBraceCopy;
   pos_T our_paren_pos;
   char_u      *start;
   int start_brace;
@@ -2026,6 +2027,10 @@ int get_c_indent(void)
     } else {
       // We are inside braces, there is a { before this line at the position
       // stored in tryposBrace.
+      // Make a copy of tryposBrace, it may point to pos_copy inside
+      // find_start_brace(), which may be changed somewhere.
+      tryposBraceCopy = *tryposBrace;
+      tryposBrace = &tryposBraceCopy;
       trypos = tryposBrace;
       ourscope = trypos->lnum;
       start = ml_get(ourscope);

--- a/src/nvim/testdir/test3.in
+++ b/src/nvim/testdir/test3.in
@@ -464,6 +464,14 @@ label:  if (asdf &&
 	asdfasdf
 }
 
+{
+for ( int i = 0;
+	i < 10; i++ )
+{
+}
+	i = 0;
+}
+
 class bob
 {
 	int foo() {return 1;}

--- a/src/nvim/testdir/test3.ok
+++ b/src/nvim/testdir/test3.ok
@@ -452,6 +452,14 @@ label:  if (asdf &&
 	asdfasdf
 }
 
+{
+	for ( int i = 0;
+			i < 10; i++ )
+	{
+	}
+	i = 0;
+}
+
 class bob
 {
 	int foo() {return 1;}

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -342,7 +342,7 @@ static int included_patches[] = {
   //398 NA
   397,
   //396,
-  //395,
+  395,
   //394 NA
   //393 NA
   392,


### PR DESCRIPTION
```
Problem:    C indent is wrong below an if with wrapped condition followed by
        curly braces. (Trevor Powell)
Solution:   Make a copy of tryposBrace.

https://code.google.com/p/vim/source/detail?r=v7-4-395
```

Original patch:

``` diff
diff --git a/src/nvim/misc1.c b/src/nvim/misc1.c
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -6995,6 +6995,7 @@ get_c_indent()
     char_u *linecopy;
     pos_T  *trypos;
     pos_T  *tryposBrace = NULL;
+    pos_T  tryposBraceCopy;
     pos_T  our_paren_pos;
     char_u *start;
     int        start_brace;
@@ -7532,7 +7533,11 @@ get_c_indent()
    /*
     * We are inside braces, there is a { before this line at the position
     * stored in tryposBrace.
+    * Make a copy of tryposBrace, it may point to pos_copy inside
+    * find_start_brace(), which may be changed somewhere.
     */
+   tryposBraceCopy = *tryposBrace;
+   tryposBrace = &tryposBraceCopy;
    trypos = tryposBrace;
    ourscope = trypos->lnum;
    start = ml_get(ourscope);
diff --git a/src/nvim/testdir/test3.in b/src/nvim/testdir/test3.in
--- a/src/nvim/testdir/test3.in
+++ b/src/nvim/testdir/test3.in
@@ -464,6 +464,14 @@ label:  if (asdf &&
    asdfasdf
 }

+{
+for ( int i = 0;
+   i < 10; i++ )
+{
+}
+   i = 0;
+}
+
 class bob
 {
    int foo() {return 1;}
diff --git a/src/nvim/testdir/test3.ok b/src/nvim/testdir/test3.ok
--- a/src/nvim/testdir/test3.ok
+++ b/src/nvim/testdir/test3.ok
@@ -452,6 +452,14 @@ label:  if (asdf &&
    asdfasdf
 }

+{
+   for ( int i = 0;
+           i < 10; i++ )
+   {
+   }
+   i = 0;
+}
+
 class bob
 {
    int foo() {return 1;}
diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    395,
+/**/
     394,
 /**/
     393,
```
