### PR TITLE
[RFC] Ignore update errors in vim-patch script.

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -29,7 +29,7 @@ if [[ ! -d ${VIM_SOURCE_DIR} ]]; then
 else
   echo "Updating Vim sources in '${VIM_SOURCE_DIR}'."
   cd ${VIM_SOURCE_DIR}
-  hg pull --update
+  hg pull --update || echo 'Could not update Vim sources.'
 fi
 
 vim_tag="v${vim_version//./-}"


### PR DESCRIPTION
`hg pull` will of course fail if there's no internet connection, but that doesn't matter if the required vim tag is already in the hg repo. So let's just ignore the error.
