### PR TITLE
[RFC] vim-patch:7.4.450

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1042,36 +1042,41 @@ list of buffers. |unlisted-buffer|
 		a number).  Insert a backslash before a space in a buffer
 		name.
 
-:[N]b[uffer][!] [N]			*:b* *:bu* *:buf* *:buffer* *E86*
+:[N]b[uffer][!] [+cmd] [N]		*:b* *:bu* *:buf* *:buffer* *E86*
 		Edit buffer [N] from the buffer list.  If [N] is not given,
 		the current buffer remains being edited.  See |:buffer-!| for
 		[!].  This will also edit a buffer that is not in the buffer
 		list, without setting the 'buflisted' flag.
+		Also see ||+cmd|.
 
-:[N]b[uffer][!] {bufname}
+:[N]b[uffer][!] [+cmd] {bufname}
 		Edit buffer for {bufname} from the buffer list.  See
 		|:buffer-!| for [!].  This will also edit a buffer that is not
 		in the buffer list, without setting the 'buflisted' flag.
+		Also see ||+cmd|.
 
-:[N]sb[uffer] [N]					*:sb* *:sbuffer*
+:[N]sb[uffer] [+cmd] [N]				*:sb* *:sbuffer*
 		Split window and edit buffer [N] from the buffer list.  If [N]
 		is not given, the current buffer is edited.  Respects the
 		"useopen" setting of 'switchbuf' when splitting.  This will
 		also edit a buffer that is not in the buffer list, without
 		setting the 'buflisted' flag.
+		Also see ||+cmd|.
 
-:[N]sb[uffer] {bufname}
+:[N]sb[uffer] [+cmd] {bufname}
 		Split window and edit buffer for {bufname} from the buffer
 		list.  This will also edit a buffer that is not in the buffer
 		list, without setting the 'buflisted' flag.
 		Note: If what you want to do is split the buffer, make a copy
 		under another name, you can do it this way: >
 			:w foobar | sp #
+<		Also see ||+cmd|.
 
-:[N]bn[ext][!] [N]					*:bn* *:bnext* *E87*
+:[N]bn[ext][!] [+cmd] [N]				*:bn* *:bnext* *E87*
 		Go to [N]th next buffer in buffer list.  [N] defaults to one.
 		Wraps around the end of the buffer list.
 		See |:buffer-!| for [!].
+		Also see ||+cmd|.
 		If you are in a help buffer, this takes you to the next help
 		buffer (if there is one).  Similarly, if you are in a normal
 		(non-help) buffer, this takes you to the next normal buffer.
@@ -1079,55 +1084,61 @@ list of buffers. |unlisted-buffer|
 		the way when you're browsing code/text buffers.  The next three
 		commands also work like this.
 
+
 							*:sbn* *:sbnext*
-:[N]sbn[ext] [N]
+:[N]sbn[ext] [+cmd] [N]
 		Split window and go to [N]th next buffer in buffer list.
 		Wraps around the end of the buffer list.  Uses 'switchbuf'
+		Also see ||+cmd|.
 
-:[N]bN[ext][!] [N]			*:bN* *:bNext* *:bp* *:bprevious* *E88*
-:[N]bp[revious][!] [N]
+:[N]bN[ext][!] [+cmd] [N]		*:bN* *:bNext* *:bp* *:bprevious* *E88*
+:[N]bp[revious][!] [+cmd] [N]
 		Go to [N]th previous buffer in buffer list.  [N] defaults to
 		one.  Wraps around the start of the buffer list.
 		See |:buffer-!| for [!] and 'switchbuf'.
+		Also see ||+cmd|.
 
-:[N]sbN[ext] [N]			*:sbN* *:sbNext* *:sbp* *:sbprevious*
-:[N]sbp[revious] [N]
+:[N]sbN[ext] [+cmd] [N]			*:sbN* *:sbNext* *:sbp* *:sbprevious*
+:[N]sbp[revious] [+cmd] [N]
 		Split window and go to [N]th previous buffer in buffer list.
 		Wraps around the start of the buffer list.
 		Uses 'switchbuf'.
+		Also see ||+cmd|.
 
-							*:br* *:brewind*
-:br[ewind][!]	Go to first buffer in buffer list.  If the buffer list is
+:br[ewind][!] [+cmd]					*:br* *:brewind*
+		Go to first buffer in buffer list.  If the buffer list is
 		empty, go to the first unlisted buffer.
 		See |:buffer-!| for [!].
 
-							*:bf* *:bfirst*
-:bf[irst]	Same as ":brewind".
+:bf[irst] [+cmd]					*:bf* *:bfirst*
+		Same as |:brewind|.
+		Also see |+cmd|.
 
-							*:sbr* *:sbrewind*
-:sbr[ewind]	Split window and go to first buffer in buffer list.  If the
+:sbr[ewind] [+cmd]					*:sbr* *:sbrewind*
+		Split window and go to first buffer in buffer list.  If the
 		buffer list is empty, go to the first unlisted buffer.
 		Respects the 'switchbuf' option.
+		Also see |+cmd|.
 
-							*:sbf* *:sbfirst*
-:sbf[irst]	Same as ":sbrewind".
+:sbf[irst] [+cmd]					*:sbf* *:sbfirst*
+		Same as ":sbrewind".
 
-							*:bl* *:blast*
-:bl[ast][!]	Go to last buffer in buffer list.  If the buffer list is
+:bl[ast][!] [+cmd]					*:bl* *:blast*
+		Go to last buffer in buffer list.  If the buffer list is
 		empty, go to the last unlisted buffer.
 		See |:buffer-!| for [!].
 
-							*:sbl* *:sblast*
-:sbl[ast]	Split window and go to last buffer in buffer list.  If the
+:sbl[ast] [+cmd]					*:sbl* *:sblast*
+		Split window and go to last buffer in buffer list.  If the
 		buffer list is empty, go to the last unlisted buffer.
 		Respects 'switchbuf' option.
 
-:[N]bm[odified][!] [N]				*:bm* *:bmodified* *E84*
+:[N]bm[odified][!] [+cmd] [N]			*:bm* *:bmodified* *E84*
 		Go to [N]th next modified buffer.  Note: this command also
 		finds unlisted buffers.  If there is no modified buffer the
 		command fails.
 
-:[N]sbm[odified] [N]					*:sbm* *:sbmodified*
+:[N]sbm[odified] [+cmd] [N]				*:sbm* *:sbmodified*
 		Split window and go to [N]th next modified buffer.
 		Respects 'switchbuf' option.
 		Note: this command also finds buffers not in the buffer list.

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -127,12 +127,12 @@ return {
   },
   {
     command='buffer',
-    flags=bit.bor(BANG, RANGE, NOTADR, BUFNAME, BUFUNL, COUNT, EXTRA, TRLBAR),
+    flags=bit.bor(BANG, RANGE, NOTADR, BUFNAME, BUFUNL, COUNT, EXTRA, EDITCMD, TRLBAR),
     func='ex_buffer',
   },
   {
     command='bNext',
-    flags=bit.bor(BANG, RANGE, NOTADR, COUNT, TRLBAR),
+    flags=bit.bor(BANG, RANGE, NOTADR, COUNT, EDITCMD, TRLBAR),
     func='ex_bprevious',
   },
   {
@@ -162,22 +162,22 @@ return {
   },
   {
     command='bfirst',
-    flags=bit.bor(BANG, RANGE, NOTADR, TRLBAR),
+    flags=bit.bor(BANG, RANGE, NOTADR, EDITCMD, TRLBAR),
     func='ex_brewind',
   },
   {
     command='blast',
-    flags=bit.bor(BANG, RANGE, NOTADR, TRLBAR),
+    flags=bit.bor(BANG, RANGE, NOTADR, EDITCMD, TRLBAR),
     func='ex_blast',
   },
   {
     command='bmodified',
-    flags=bit.bor(BANG, RANGE, NOTADR, COUNT, TRLBAR),
+    flags=bit.bor(BANG, RANGE, NOTADR, COUNT, EDITCMD, TRLBAR),
     func='ex_bmodified',
   },
   {
     command='bnext',
-    flags=bit.bor(BANG, RANGE, NOTADR, COUNT, TRLBAR),
+    flags=bit.bor(BANG, RANGE, NOTADR, COUNT, EDITCMD, TRLBAR),
     func='ex_bnext',
   },
   {
@@ -187,12 +187,12 @@ return {
   },
   {
     command='bprevious',
-    flags=bit.bor(BANG, RANGE, NOTADR, COUNT, TRLBAR),
+    flags=bit.bor(BANG, RANGE, NOTADR, COUNT, EDITCMD, TRLBAR),
     func='ex_bprevious',
   },
   {
     command='brewind',
-    flags=bit.bor(BANG, RANGE, NOTADR, TRLBAR),
+    flags=bit.bor(BANG, RANGE, NOTADR, EDITCMD, TRLBAR),
     func='ex_brewind',
   },
   {
@@ -1762,47 +1762,47 @@ return {
   },
   {
     command='sbuffer',
-    flags=bit.bor(BANG, RANGE, NOTADR, BUFNAME, BUFUNL, COUNT, EXTRA, TRLBAR),
+    flags=bit.bor(BANG, RANGE, NOTADR, BUFNAME, BUFUNL, COUNT, EXTRA, EDITCMD, TRLBAR),
     func='ex_buffer',
   },
   {
     command='sbNext',
-    flags=bit.bor(RANGE, NOTADR, COUNT, TRLBAR),
+    flags=bit.bor(RANGE, NOTADR, COUNT, EDITCMD, TRLBAR),
     func='ex_bprevious',
   },
   {
     command='sball',
-    flags=bit.bor(RANGE, NOTADR, COUNT, TRLBAR),
+    flags=bit.bor(RANGE, NOTADR, COUNT, EDITCMD, TRLBAR),
     func='ex_buffer_all',
   },
   {
     command='sbfirst',
-    flags=bit.bor(TRLBAR),
+    flags=bit.bor(EDITCMD, TRLBAR),
     func='ex_brewind',
   },
   {
     command='sblast',
-    flags=bit.bor(TRLBAR),
+    flags=bit.bor(EDITCMD, TRLBAR),
     func='ex_blast',
   },
   {
     command='sbmodified',
-    flags=bit.bor(RANGE, NOTADR, COUNT, TRLBAR),
+    flags=bit.bor(RANGE, NOTADR, COUNT, EDITCMD, TRLBAR),
     func='ex_bmodified',
   },
   {
     command='sbnext',
-    flags=bit.bor(RANGE, NOTADR, COUNT, TRLBAR),
+    flags=bit.bor(RANGE, NOTADR, COUNT, EDITCMD, TRLBAR),
     func='ex_bnext',
   },
   {
     command='sbprevious',
-    flags=bit.bor(RANGE, NOTADR, COUNT, TRLBAR),
+    flags=bit.bor(RANGE, NOTADR, COUNT, EDITCMD, TRLBAR),
     func='ex_bprevious',
   },
   {
     command='sbrewind',
-    flags=bit.bor(TRLBAR),
+    flags=bit.bor(EDITCMD, TRLBAR),
     func='ex_brewind',
   },
   {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3957,13 +3957,17 @@ static void ex_bunload(exarg_T *eap)
  */
 static void ex_buffer(exarg_T *eap)
 {
-  if (*eap->arg)
+  if (*eap->arg) {
     eap->errmsg = e_trailing;
-  else {
-    if (eap->addr_count == 0)           /* default is current buffer */
+  } else {
+    if (eap->addr_count == 0) {  // default is current buffer
       goto_buffer(eap, DOBUF_CURRENT, FORWARD, 0);
-    else
+    } else {
       goto_buffer(eap, DOBUF_FIRST, FORWARD, (int)eap->line2);
+    }
+    if (eap->do_ecmd_cmd != NULL) {
+      do_cmdline_cmd(eap->do_ecmd_cmd);
+    }
   }
 }
 
@@ -3974,6 +3978,9 @@ static void ex_buffer(exarg_T *eap)
 static void ex_bmodified(exarg_T *eap)
 {
   goto_buffer(eap, DOBUF_MOD, FORWARD, (int)eap->line2);
+  if (eap->do_ecmd_cmd != NULL) {
+    do_cmdline_cmd(eap->do_ecmd_cmd);
+  }
 }
 
 /*
@@ -3983,6 +3990,9 @@ static void ex_bmodified(exarg_T *eap)
 static void ex_bnext(exarg_T *eap)
 {
   goto_buffer(eap, DOBUF_CURRENT, FORWARD, (int)eap->line2);
+  if (eap->do_ecmd_cmd != NULL) {
+    do_cmdline_cmd(eap->do_ecmd_cmd);
+  }
 }
 
 /*
@@ -3994,6 +4004,9 @@ static void ex_bnext(exarg_T *eap)
 static void ex_bprevious(exarg_T *eap)
 {
   goto_buffer(eap, DOBUF_CURRENT, BACKWARD, (int)eap->line2);
+  if (eap->do_ecmd_cmd != NULL) {
+    do_cmdline_cmd(eap->do_ecmd_cmd);
+  }
 }
 
 /*
@@ -4005,6 +4018,9 @@ static void ex_bprevious(exarg_T *eap)
 static void ex_brewind(exarg_T *eap)
 {
   goto_buffer(eap, DOBUF_FIRST, FORWARD, 0);
+  if (eap->do_ecmd_cmd != NULL) {
+    do_cmdline_cmd(eap->do_ecmd_cmd);
+  }
 }
 
 /*
@@ -4014,6 +4030,9 @@ static void ex_brewind(exarg_T *eap)
 static void ex_blast(exarg_T *eap)
 {
   goto_buffer(eap, DOBUF_LAST, BACKWARD, 0);
+  if (eap->do_ecmd_cmd != NULL) {
+    do_cmdline_cmd(eap->do_ecmd_cmd);
+  }
 }
 
 int ends_excmd(int c) FUNC_ATTR_CONST

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -287,7 +287,7 @@ static int included_patches[] = {
   //453 NA
   452,
   //451,
-  //450,
+  450,
   449,
   //448 NA
   447,


### PR DESCRIPTION
```
Problem:    Not all commands that edit another buffer support the +cmd
        argument.
Solution:   Add the +cmd argument to relevant commands. (Marcin Szamotulski)

https://code.google.com/p/vim/source/detail?r=v7-4-450
```

``` diff
diff --git a/runtime/doc/windows.txt b/runtime/doc/windows.txt
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1042,36 +1042,41 @@ list of buffers. |unlisted-buffer|
        a number).  Insert a backslash before a space in a buffer
        name.

-:[N]b[uffer][!] [N]            *:b* *:bu* *:buf* *:buffer* *E86*
+:[N]b[uffer][!] [+cmd] [N]     *:b* *:bu* *:buf* *:buffer* *E86*
        Edit buffer [N] from the buffer list.  If [N] is not given,
        the current buffer remains being edited.  See |:buffer-!| for
        [!].  This will also edit a buffer that is not in the buffer
        list, without setting the 'buflisted' flag.
+       Also see ||+cmd|.

-:[N]b[uffer][!] {bufname}
+:[N]b[uffer][!] [+cmd] {bufname}
        Edit buffer for {bufname} from the buffer list.  See
        |:buffer-!| for [!].  This will also edit a buffer that is not
        in the buffer list, without setting the 'buflisted' flag.
+       Also see ||+cmd|.

-:[N]sb[uffer] [N]                  *:sb* *:sbuffer*
+:[N]sb[uffer] [+cmd] [N]               *:sb* *:sbuffer*
        Split window and edit buffer [N] from the buffer list.  If [N]
        is not given, the current buffer is edited.  Respects the
        "useopen" setting of 'switchbuf' when splitting.  This will
        also edit a buffer that is not in the buffer list, without
        setting the 'buflisted' flag.
+       Also see ||+cmd|.

-:[N]sb[uffer] {bufname}
+:[N]sb[uffer] [+cmd] {bufname}
        Split window and edit buffer for {bufname} from the buffer
        list.  This will also edit a buffer that is not in the buffer
        list, without setting the 'buflisted' flag.
        Note: If what you want to do is split the buffer, make a copy
        under another name, you can do it this way: >
            :w foobar | sp #
+<      Also see ||+cmd|.

-:[N]bn[ext][!] [N]                 *:bn* *:bnext* *E87*
+:[N]bn[ext][!] [+cmd] [N]              *:bn* *:bnext* *E87*
        Go to [N]th next buffer in buffer list.  [N] defaults to one.
        Wraps around the end of the buffer list.
        See |:buffer-!| for [!].
+       Also see ||+cmd|.
        If you are in a help buffer, this takes you to the next help
        buffer (if there is one).  Similarly, if you are in a normal
        (non-help) buffer, this takes you to the next normal buffer.
@@ -1079,55 +1084,61 @@ list of buffers. |unlisted-buffer|
        the way when you're browsing code/text buffers.  The next three
        commands also work like this.

+
                            *:sbn* *:sbnext*
-:[N]sbn[ext] [N]
+:[N]sbn[ext] [+cmd] [N]
        Split window and go to [N]th next buffer in buffer list.
        Wraps around the end of the buffer list.  Uses 'switchbuf'
+       Also see ||+cmd|.

-:[N]bN[ext][!] [N]         *:bN* *:bNext* *:bp* *:bprevious* *E88*
-:[N]bp[revious][!] [N]
+:[N]bN[ext][!] [+cmd] [N]      *:bN* *:bNext* *:bp* *:bprevious* *E88*
+:[N]bp[revious][!] [+cmd] [N]
        Go to [N]th previous buffer in buffer list.  [N] defaults to
        one.  Wraps around the start of the buffer list.
        See |:buffer-!| for [!] and 'switchbuf'.
+       Also see ||+cmd|.

-:[N]sbN[ext] [N]           *:sbN* *:sbNext* *:sbp* *:sbprevious*
-:[N]sbp[revious] [N]
+:[N]sbN[ext] [+cmd] [N]            *:sbN* *:sbNext* *:sbp* *:sbprevious*
+:[N]sbp[revious] [+cmd] [N]
        Split window and go to [N]th previous buffer in buffer list.
        Wraps around the start of the buffer list.
        Uses 'switchbuf'.
+       Also see ||+cmd|.

-                           *:br* *:brewind*
-:br[ewind][!]  Go to first buffer in buffer list.  If the buffer list is
+:br[ewind][!] [+cmd]                   *:br* *:brewind*
+       Go to first buffer in buffer list.  If the buffer list is
        empty, go to the first unlisted buffer.
        See |:buffer-!| for [!].

-                           *:bf* *:bfirst*
-:bf[irst]  Same as ":brewind".
+:bf[irst] [+cmd]                   *:bf* *:bfirst*
+       Same as |:brewind|.
+       Also see |+cmd|.

-                           *:sbr* *:sbrewind*
-:sbr[ewind]    Split window and go to first buffer in buffer list.  If the
+:sbr[ewind] [+cmd]                 *:sbr* *:sbrewind*
+       Split window and go to first buffer in buffer list.  If the
        buffer list is empty, go to the first unlisted buffer.
        Respects the 'switchbuf' option.
+       Also see |+cmd|.

-                           *:sbf* *:sbfirst*
-:sbf[irst] Same as ":sbrewind".
+:sbf[irst] [+cmd]                  *:sbf* *:sbfirst*
+       Same as ":sbrewind".

-                           *:bl* *:blast*
-:bl[ast][!]    Go to last buffer in buffer list.  If the buffer list is
+:bl[ast][!] [+cmd]                 *:bl* *:blast*
+       Go to last buffer in buffer list.  If the buffer list is
        empty, go to the last unlisted buffer.
        See |:buffer-!| for [!].

-                           *:sbl* *:sblast*
-:sbl[ast]  Split window and go to last buffer in buffer list.  If the
+:sbl[ast] [+cmd]                   *:sbl* *:sblast*
+       Split window and go to last buffer in buffer list.  If the
        buffer list is empty, go to the last unlisted buffer.
        Respects 'switchbuf' option.

-:[N]bm[odified][!] [N]             *:bm* *:bmodified* *E84*
+:[N]bm[odified][!] [+cmd] [N]          *:bm* *:bmodified* *E84*
        Go to [N]th next modified buffer.  Note: this command also
        finds unlisted buffers.  If there is no modified buffer the
        command fails.

-:[N]sbm[odified] [N]                   *:sbm* *:sbmodified*
+:[N]sbm[odified] [+cmd] [N]                *:sbm* *:sbmodified*
        Split window and go to [N]th next modified buffer.
        Respects 'switchbuf' option.
        Note: this command also finds buffers not in the buffer list.
diff --git a/src/nvim/ex_cmds.h b/src/nvim/ex_cmds.h
--- a/src/nvim/ex_cmds.h
+++ b/src/nvim/ex_cmds.h
@@ -132,9 +132,9 @@ EX(CMD_augroup,     "augroup",  ex_autocmd,
 EX(CMD_aunmenu,        "aunmenu",  ex_menu,
            EXTRA|TRLBAR|NOTRLCOM|USECTRLV|CMDWIN),
 EX(CMD_buffer,     "buffer",   ex_buffer,
-           BANG|RANGE|NOTADR|BUFNAME|BUFUNL|COUNT|EXTRA|TRLBAR),
+           BANG|RANGE|NOTADR|BUFNAME|BUFUNL|COUNT|EXTRA|EDITCMD|TRLBAR),
 EX(CMD_bNext,      "bNext",    ex_bprevious,
-           BANG|RANGE|NOTADR|COUNT|TRLBAR),
+           BANG|RANGE|NOTADR|COUNT|EDITCMD|TRLBAR),
 EX(CMD_ball,       "ball",     ex_buffer_all,
            RANGE|NOTADR|COUNT|TRLBAR),
 EX(CMD_badd,       "badd",     ex_edit,
@@ -146,19 +146,19 @@ EX(CMD_behave,        "behave",   ex_behave,
 EX(CMD_belowright, "belowright",   ex_wrongmodifier,
            NEEDARG|EXTRA|NOTRLCOM),
 EX(CMD_bfirst,     "bfirst",   ex_brewind,
-           BANG|RANGE|NOTADR|TRLBAR),
+           BANG|RANGE|NOTADR|EDITCMD|TRLBAR),
 EX(CMD_blast,      "blast",    ex_blast,
-           BANG|RANGE|NOTADR|TRLBAR),
+           BANG|RANGE|NOTADR|EDITCMD|TRLBAR),
 EX(CMD_bmodified,  "bmodified",    ex_bmodified,
-           BANG|RANGE|NOTADR|COUNT|TRLBAR),
+           BANG|RANGE|NOTADR|COUNT|EDITCMD|TRLBAR),
 EX(CMD_bnext,      "bnext",    ex_bnext,
-           BANG|RANGE|NOTADR|COUNT|TRLBAR),
+           BANG|RANGE|NOTADR|COUNT|EDITCMD|TRLBAR),
 EX(CMD_botright,   "botright", ex_wrongmodifier,
            NEEDARG|EXTRA|NOTRLCOM),
 EX(CMD_bprevious,  "bprevious",    ex_bprevious,
-           BANG|RANGE|NOTADR|COUNT|TRLBAR),
+           BANG|RANGE|NOTADR|COUNT|EDITCMD|TRLBAR),
 EX(CMD_brewind,        "brewind",  ex_brewind,
-           BANG|RANGE|NOTADR|TRLBAR),
+           BANG|RANGE|NOTADR|EDITCMD|TRLBAR),
 EX(CMD_break,      "break",    ex_break,
            TRLBAR|SBOXOK|CMDWIN),
 EX(CMD_breakadd,   "breakadd", ex_breakadd,
@@ -814,23 +814,23 @@ EX(CMD_sandbox,       "sandbox",  ex_wrongmodi
 EX(CMD_saveas,     "saveas",   ex_write,
            BANG|DFLALL|FILE1|ARGOPT|CMDWIN|TRLBAR),
 EX(CMD_sbuffer,        "sbuffer",  ex_buffer,
-           BANG|RANGE|NOTADR|BUFNAME|BUFUNL|COUNT|EXTRA|TRLBAR),
+           BANG|RANGE|NOTADR|BUFNAME|BUFUNL|COUNT|EXTRA|EDITCMD|TRLBAR),
 EX(CMD_sbNext,     "sbNext",   ex_bprevious,
-           RANGE|NOTADR|COUNT|TRLBAR),
+           RANGE|NOTADR|COUNT|EDITCMD|TRLBAR),
 EX(CMD_sball,      "sball",    ex_buffer_all,
-           RANGE|NOTADR|COUNT|TRLBAR),
+           RANGE|NOTADR|COUNT|EDITCMD|TRLBAR),
 EX(CMD_sbfirst,        "sbfirst",  ex_brewind,
-           TRLBAR),
+           EDITCMD|TRLBAR),
 EX(CMD_sblast,     "sblast",   ex_blast,
-           TRLBAR),
+           EDITCMD|TRLBAR),
 EX(CMD_sbmodified, "sbmodified",   ex_bmodified,
-           RANGE|NOTADR|COUNT|TRLBAR),
+           RANGE|NOTADR|COUNT|EDITCMD|TRLBAR),
 EX(CMD_sbnext,     "sbnext",   ex_bnext,
-           RANGE|NOTADR|COUNT|TRLBAR),
+           RANGE|NOTADR|COUNT|EDITCMD|TRLBAR),
 EX(CMD_sbprevious, "sbprevious",   ex_bprevious,
-           RANGE|NOTADR|COUNT|TRLBAR),
+           RANGE|NOTADR|COUNT|EDITCMD|TRLBAR),
 EX(CMD_sbrewind,   "sbrewind", ex_brewind,
-           TRLBAR),
+           EDITCMD|TRLBAR),
 EX(CMD_scriptnames,    "scriptnames",  ex_scriptnames,
            TRLBAR|CMDWIN),
 EX(CMD_scriptencoding, "scriptencoding", ex_scriptencoding,
diff --git a/src/nvim/ex_docmd.c b/src/nvim/ex_docmd.c
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5135,6 +5135,8 @@ ex_buffer(eap)
        goto_buffer(eap, DOBUF_CURRENT, FORWARD, 0);
    else
        goto_buffer(eap, DOBUF_FIRST, FORWARD, (int)eap->line2);
+   if (eap->do_ecmd_cmd != NULL)
+       do_cmdline_cmd(eap->do_ecmd_cmd);
     }
 }

@@ -5147,6 +5149,8 @@ ex_bmodified(eap)
     exarg_T    *eap;
 {
     goto_buffer(eap, DOBUF_MOD, FORWARD, (int)eap->line2);
+    if (eap->do_ecmd_cmd != NULL)
+   do_cmdline_cmd(eap->do_ecmd_cmd);
 }

 /*
@@ -5158,6 +5162,8 @@ ex_bnext(eap)
     exarg_T    *eap;
 {
     goto_buffer(eap, DOBUF_CURRENT, FORWARD, (int)eap->line2);
+    if (eap->do_ecmd_cmd != NULL)
+   do_cmdline_cmd(eap->do_ecmd_cmd);
 }

 /*
@@ -5171,6 +5177,8 @@ ex_bprevious(eap)
     exarg_T    *eap;
 {
     goto_buffer(eap, DOBUF_CURRENT, BACKWARD, (int)eap->line2);
+    if (eap->do_ecmd_cmd != NULL)
+   do_cmdline_cmd(eap->do_ecmd_cmd);
 }

 /*
@@ -5184,6 +5192,8 @@ ex_brewind(eap)
     exarg_T    *eap;
 {
     goto_buffer(eap, DOBUF_FIRST, FORWARD, 0);
+    if (eap->do_ecmd_cmd != NULL)
+   do_cmdline_cmd(eap->do_ecmd_cmd);
 }

 /*
@@ -5195,6 +5205,8 @@ ex_blast(eap)
     exarg_T    *eap;
 {
     goto_buffer(eap, DOBUF_LAST, BACKWARD, 0);
+    if (eap->do_ecmd_cmd != NULL)
+   do_cmdline_cmd(eap->do_ecmd_cmd);
 }
 #endif

diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    450,
+/**/
     449,
 /**/
     448,
```
