### PR TITLE
[RDY] restore 'Not Implemented' for legacy script commands (:lua :ruby ...)

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1236,6 +1236,21 @@ return {
     func='ex_tag',
   },
   {
+    command='lua',
+    flags=bit.bor(RANGE, EXTRA, NEEDARG, CMDWIN),
+    func='ex_script_ni',
+  },
+  {
+    command='luado',
+    flags=bit.bor(RANGE, DFLALL, EXTRA, NEEDARG, CMDWIN),
+    func='ex_ni',
+  },
+  {
+    command='luafile',
+    flags=bit.bor(RANGE, FILE1, NEEDARG, CMDWIN),
+    func='ex_ni',
+  },
+  {
     command='lunmap',
     flags=bit.bor(EXTRA, TRLBAR, NOTRLCOM, USECTRLV, CMDWIN),
     func='ex_unmap',
@@ -1339,6 +1354,16 @@ return {
     command='mode',
     flags=bit.bor(WORD1, TRLBAR, CMDWIN),
     func='ex_mode',
+  },
+  {
+    command='mzscheme',
+    flags=bit.bor(RANGE, EXTRA, DFLALL, NEEDARG, CMDWIN, SBOXOK),
+    func='ex_script_ni',
+  },
+  {
+    command='mzfile',
+    flags=bit.bor(RANGE, FILE1, NEEDARG, CMDWIN),
+    func='ex_ni',
   },
   {
     command='next',
@@ -1511,6 +1536,16 @@ return {
     func='ex_pclose',
   },
   {
+    command='perl',
+    flags=bit.bor(RANGE, EXTRA, DFLALL, NEEDARG, SBOXOK, CMDWIN),
+    func='ex_script_ni',
+  },
+  {
+    command='perldo',
+    flags=bit.bor(RANGE, EXTRA, DFLALL, NEEDARG, CMDWIN),
+    func='ex_ni',
+  },
+  {
     command='pedit',
     flags=bit.bor(BANG, FILE1, EDITCMD, ARGOPT, TRLBAR),
     func='ex_pedit',
@@ -1636,6 +1671,26 @@ return {
     func='ex_pyfile',
   },
   {
+    command='py3',
+    flags=bit.bor(RANGE, EXTRA, NEEDARG, CMDWIN),
+    func='ex_script_ni',
+  },
+  {
+    command='py3do',
+    flags=bit.bor(RANGE, DFLALL, EXTRA, NEEDARG, CMDWIN),
+    func='ex_ni',
+  },
+  {
+    command='python3',
+    flags=bit.bor(RANGE, EXTRA, NEEDARG, CMDWIN),
+    func='ex_script_ni',
+  },
+  {
+    command='py3file',
+    flags=bit.bor(RANGE, FILE1, NEEDARG, CMDWIN),
+    func='ex_ni',
+  },
+  {
     command='quit',
     flags=bit.bor(BANG, TRLBAR, CMDWIN),
     func='ex_quit',
@@ -1724,6 +1779,21 @@ return {
     command='rundo',
     flags=bit.bor(NEEDARG, FILE1),
     func='ex_rundo',
+  },
+  {
+    command='ruby',
+    flags=bit.bor(RANGE, EXTRA, NEEDARG, CMDWIN),
+    func='ex_script_ni',
+  },
+  {
+    command='rubydo',
+    flags=bit.bor(RANGE, DFLALL, EXTRA, NEEDARG, CMDWIN),
+    func='ex_ni',
+  },
+  {
+    command='rubyfile',
+    flags=bit.bor(RANGE, FILE1, NEEDARG, CMDWIN),
+    func='ex_ni',
   },
   {
     command='rviminfo',
@@ -2149,6 +2219,21 @@ return {
     command='tabs',
     flags=bit.bor(TRLBAR, CMDWIN),
     func='ex_tabs',
+  },
+  {
+    command='tcl',
+    flags=bit.bor(RANGE,EXTRA,NEEDARG,CMDWIN),
+    func='ex_script_ni',
+  },
+  {
+    command='tcldo',
+    flags=bit.bor(RANGE,DFLALL,EXTRA,NEEDARG,CMDWIN),
+    func='ex_ni',
+  },
+  {
+    command='tclfile',
+    flags=bit.bor(RANGE,FILE1,NEEDARG,CMDWIN),
+    func='ex_ni',
   },
   {
     command='tearoff',

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -138,7 +138,6 @@ struct dbg_stuff {
 # include "ex_docmd.c.generated.h"
 #endif
 
-# define HAVE_EX_SCRIPT_NI
 # define ex_gui                 ex_nogui
 # define ex_tearoff             ex_ni
 # define ex_popup               ex_ni
@@ -1494,9 +1493,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
 
   ni = (!IS_USER_CMDIDX(ea.cmdidx)
         && (cmdnames[ea.cmdidx].cmd_func == ex_ni
-#ifdef HAVE_EX_SCRIPT_NI
            || cmdnames[ea.cmdidx].cmd_func == ex_script_ni
-#endif
     ));
 
 
@@ -1832,19 +1829,26 @@ static char_u * do_one_cmd(char_u **cmdlinep,
     case CMD_leftabove:
     case CMD_let:
     case CMD_lockmarks:
+    case CMD_lua:
     case CMD_match:
+    case CMD_mzscheme:
     case CMD_noautocmd:
     case CMD_noswapfile:
+    case CMD_perl:
     case CMD_psearch:
     case CMD_python:
+    case CMD_py3:
+    case CMD_python3:
     case CMD_return:
     case CMD_rightbelow:
+    case CMD_ruby:
     case CMD_silent:
     case CMD_smagic:
     case CMD_snomagic:
     case CMD_substitute:
     case CMD_syntax:
     case CMD_tab:
+    case CMD_tcl:
     case CMD_throw:
     case CMD_tilde:
     case CMD_topleft:
@@ -1854,7 +1858,8 @@ static char_u * do_one_cmd(char_u **cmdlinep,
     case CMD_wincmd:
       break;
 
-    default:            goto doend;
+    default:
+      goto doend;
     }
   }
 
@@ -3291,9 +3296,7 @@ static void get_flags(exarg_T *eap)
   }
 }
 
-/*
- * Function called for command which is Not Implemented.  NI!
- */
+/// Stub function for command which is Not Implemented. NI!
 void ex_ni(exarg_T *eap)
 {
   if (!eap->skip)
@@ -3301,11 +3304,8 @@ void ex_ni(exarg_T *eap)
         "E319: Sorry, the command is not available in this version");
 }
 
-#ifdef HAVE_EX_SCRIPT_NI
-/*
- * Function called for script command which is Not Implemented.  NI!
- * Skips over ":perl <<EOF" constructs.
- */
+/// Stub function for script command which is Not Implemented. NI!
+/// Skips over ":perl <<EOF" constructs.
 static void ex_script_ni(exarg_T *eap)
 {
   if (!eap->skip)
@@ -3313,7 +3313,6 @@ static void ex_script_ni(exarg_T *eap)
   else
     free(script_get(eap, eap->arg));
 }
-#endif
 
 /*
  * Check range in Ex command for validity.


### PR DESCRIPTION
- restores behavior equivalent to Vim compiled without FEAT_MZSCHEME, etc.
  (avoids spurious "E492: Not an editor command: EOF") for code such as:

``` vim
  if 0
    perl << EOF
  end
  EOF
  endif
```
- see `:help script-here`
- fixes #1308
- fixes https://github.com/junegunn/vim-plug/issues/111
