### PR TITLE
[RFC] vim-patch: Mark patches 7.4.{402,443,509} as NA

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -229,7 +229,7 @@ static int included_patches[] = {
   //512 NA
   //511 NA
   //510 NA
-  //509,
+  //509 NA
   508,
   //507 NA
   //506 NA
@@ -294,7 +294,7 @@ static int included_patches[] = {
   //446,
   //445,
   444,
-  //443,
+  //443 NA
   442,
   441,
   440,
@@ -335,7 +335,7 @@ static int included_patches[] = {
   405,
   //404 NA
   //403 NA
-  //402,
+  //402 NA
   //401 NA
   //400 NA
   //399 NA


### PR DESCRIPTION
Mark patches 7.4.{402,443,509} as NA

Code modified in patch 7.4.402 and 7.4.443 was introduced with
patch 7.4.399, which is also marked as NA (FEAT_CRYPT was removed).

Patch 7.4.509 needs the removed FEAT_CRYPT.

[vim patch 7.4.509](https://code.google.com/p/vim/source/detail?r=v7-4-509)
[vim patch 7.4.443](https://code.google.com/p/vim/source/detail?r=v7-4-443)
[vim patch 7.4.402](https://code.google.com/p/vim/source/detail?r=v7-4-402)
[vim patch 7.4.399](https://code.google.com/p/vim/source/detail?r=v7-4-399)
