### PR TITLE
[RFC] vim-patch:babc6a1 (runtime update)

### DIFF
--- a/runtime/compiler/go.vim
+++ b/runtime/compiler/go.vim
@@ -1,0 +1,29 @@
+" Vim compiler file
+" Compiler:	Go
+" Maintainer:	David Barnett (https://github.com/google/vim-ft-go)
+" Last Change:	2014 Aug 16
+
+if exists('current_compiler')
+  finish
+endif
+let current_compiler = 'go'
+
+if exists(':CompilerSet') != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:save_cpo = &cpo
+set cpo-=C
+
+CompilerSet makeprg=go\ build
+CompilerSet errorformat=
+    \%-G#\ %.%#,
+    \%A%f:%l:%c:\ %m,
+    \%A%f:%l:\ %m,
+    \%C%*\\s%m,
+    \%-G%.%#
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: sw=2 sts=2 et

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1,4 +1,4 @@
-*autocmd.txt*   For Vim version 7.4.  Last change: 2014 May 02
+*autocmd.txt*   For Vim version 7.4.  Last change: 2014 Aug 22
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1,4 +1,4 @@
-*cmdline.txt*   For Vim version 7.4.  Last change: 2014 Feb 23
+*cmdline.txt*   For Vim version 7.4.  Last change: 2014 Aug 16
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1079,6 +1079,9 @@ While in the command-line window you cannot use the mouse to put the cursor in
 another window, or drag statuslines of other windows.  You can drag the
 statusline of the command-line window itself and the statusline above it.
 Thus you can resize the command-line window, but not others.
+
+The |getcmdwintype()| function returns the type of the command-line being
+edited as described in |cmdwin-char|.
 
 
 AUTOCOMMANDS

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 7.4.  Last change: 2014 Jul 19
+*eval.txt*	For Vim version 7.4.  Last change: 2014 Aug 16
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1807,7 +1807,8 @@ getchar( [expr])		Number	get one character from the user
 getcharmod( )			Number	modifiers for the last typed character
 getcmdline()			String	return the current command-line
 getcmdpos()			Number	return cursor position in command-line
-getcmdtype()			String	return the current command-line type
+getcmdtype()			String	return current command-line type
+getcmdwintype()			String	return current command-line window type
 getcurpos()			List	position of the cursor
 getcwd()			String	the current working directory
 getfontname( [{name}])		String	name of font being used
@@ -2122,8 +2123,8 @@ argidx()	The result is the current index in the argument list.  0 is
 arglistid([{winnr}, [ {tabnr} ]])
 		Return the argument list ID.  This is a number which
 		identifies the argument list being used.  Zero is used for the
-		global argument list.
-		Return zero if the arguments are invalid.
+		global argument list.  See |arglist|.
+		Return -1 if the arguments are invalid.
 
 		Without arguments use the current window.
 		With {winnr} only use this window in the current tab page.
@@ -3359,6 +3360,11 @@ getcmdtype()						*getcmdtype()*
 		Returns an empty string otherwise.
 		Also see |getcmdpos()|, |setcmdpos()| and |getcmdline()|.
 
+getcmdwintype()						*getcmdwintype()*
+		Return the current |command-line-window| type. Possible return
+		values are the same as |getcmdtype()|. Returns an empty string
+		when not in the command-line window.
+
 							*getcurpos()*
 getcurpos()	Get the position of the cursor.  This is like getpos('.'), but
 		includes an extra item in the list:
@@ -3369,7 +3375,7 @@ getcurpos()	Get the position of the cursor.  This is like getpos('.'), but
 			let save_cursor = getcurpos()
 			MoveTheCursorAround
 			call setpos('.', save_cursor)
-
+<
 							*getcwd()*
 getcwd()	The result is a String, which is the name of the current
 		working directory.

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1,4 +1,4 @@
-*insert.txt*    For Vim version 7.4.  Last change: 2014 Jul 06
+*insert.txt*    For Vim version 7.4.  Last change: 2014 Aug 04
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -51,6 +51,8 @@ char		action	~
 		abbreviation.
 		Note: If your <Esc> key is hard to hit on your keyboard, train
 		yourself to use CTRL-[.
+		If Esc doesn't work and you are using a Mac, try CTRL-Esc.
+		Or disable Listening under Accessibility preferences.
 						*i_CTRL-C*
 CTRL-C		Quit insert mode, go back to Normal mode.  Do not check for
 		abbreviations.  Does not trigger the |InsertLeave| autocommand

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 7.4.  Last change: 2014 Jul 23
+*options.txt*	For Vim version 7.4.  Last change: 2014 Aug 09
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -5557,6 +5557,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	NOTE: To avoid portability problems with Vim scripts, always keep
 	this option at the default "on".  Only switch it off when working with
 	old Vi scripts.
+
+						*'renderoptions'* *'rop'*
+'renderoptions' 'rop'	Removed. {Nvim} will choose the best renderer available.
 
 						*'report'*
 'report'		number	(default 2)

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1,4 +1,4 @@
-*pattern.txt*   For Vim version 7.4.  Last change: 2014 May 28
+*pattern.txt*   For Vim version 7.4.  Last change: 2014 Jul 30
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -706,11 +706,18 @@ overview.
 	But to limit the time needed, only the line where what follows matches
 	is searched, and one line before that (if there is one).  This should
 	be sufficient to match most things and not be too slow.
-	The part of the pattern after "\@<=" and "\@<!" are checked for a
-	match first, thus things like "\1" don't work to reference \(\) inside
-	the preceding atom.  It does work the other way around:
-	Example			matches ~
-	\1\@<=,\([a-z]\+\)	",abc" in "abc,abc"
+
+	In the old regexp engine the part of the pattern after "\@<=" and
+	"\@<!" are checked for a match first, thus things like "\1" don't work
+	to reference \(\) inside the preceding atom.  It does work the other
+	way around:
+	Bad example			matches ~
+	\%#=1\1\@<=,\([a-z]\+\)		",abc" in "abc,abc"
+
+	However, the new regexp engine works differently, it is better to not
+	rely on this behavior, do not use \@<= if it can be avoided:
+	Example				matches ~
+	\([a-z]\+\)\zs,\1		",abc" in "abc,abc"
 
 \@123<=
 	Like "\@<=" but only look back 123 bytes. This avoids trying lots

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -1,4 +1,4 @@
-*quickref.txt*  For Vim version 7.4.  Last change: 2014 Jun 25
+*quickref.txt*  For Vim version 7.4.  Last change: 2014 Aug 06
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -826,6 +826,7 @@ Short explanation of each option:		*option-list*
 'regexpengine'	  're'	    default regexp engine to use
 'relativenumber'  'rnu'	    show relative line number in front of each line
 'remap'			    allow mappings to work recursively
+'renderoptions'	  'rop'	    options for text rendering on Windows
 'report'		    threshold for reporting nr. of lines changed
 'restorescreen'   'rs'	    Win32: restore screen when exiting
 'revins'	  'ri'	    inserting characters will work backwards

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 7.4.  Last change: 2014 Aug 22
+*todo.txt*      For Vim version 7.4.  Last change: 2014 Aug 23
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -53,10 +53,6 @@ Regexp problems:
 
 Still using freed memory after using setloclist(). (lcd, 2014 Jul 23)
 More info Jul 24.  Not clear why.
-
-Patch for:
-    CmdUndefined    - Like FuncUndefined but for user commands.
-Yasuhiro Matsumoto, 2014 Aug 18
 
 Patch to make getregtype() return the right size for non-linux systems.
 (Yasuhiro Matsumoto, 2014 Jul 8)
@@ -262,7 +258,7 @@ Issue 28.
 Go through more coverity reports.
 
 Patch to add ":undorecover", get as much text out of the undo file as
-possible. (Christian Brabandt, 2014 Mar 12, update Aug 16)
+possible. (Christian Brabandt, 2014 Mar 12, update Aug 22)
 
 Updated spec ftplugin. (Matěj Cepl, 2013 Oct 16)
 

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 7.4.  Last change: 2014 Jul 26
+*todo.txt*      For Vim version 7.4.  Last change: 2014 Aug 22
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -47,30 +47,72 @@ Regexp problems:
 - Does not work with NFA regexp engine:
   \%u, \%x, \%o, \%d followed by a composing character
 - Bug relating to back references. (Ingo Karkat, 2014 Jul 24)
+- Using back reference before the capturing group sometimes works with the old
+  engine, can we do this with the new engine?  E.g. with
+  "/\%(<\1>\)\@<=.*\%(<\/\(\w\+\)>\)\@=" matching text inside HTML tags.
 
 Still using freed memory after using setloclist(). (lcd, 2014 Jul 23)
+More info Jul 24.  Not clear why.
+
+Patch for:
+    CmdUndefined    - Like FuncUndefined but for user commands.
+Yasuhiro Matsumoto, 2014 Aug 18
 
 Patch to make getregtype() return the right size for non-linux systems.
 (Yasuhiro Matsumoto, 2014 Jul 8)
 Breaks test_eval.  Inefficient, can we only compute y_width when needed?
 
+Patch to fix a problem with breakindent. (Christian Brabandt, 2014 Aug 17)
+It's actually not a breakindent problem. With test: Aug 19.
+With renamed test: Aug 20
+
 Problem that a previous silent ":throw" causes a following try/catch not to
 work. (ZyX, 2013 Sep 28)
 
-DiffChange highlighting doesn't combine with 'cursurline'. (Benjamin Fritz)
-Patch by Christian (2014 Jul 12)
+ml_get error when using Python, issue 248.
 
-BufWinLeave autocommand executed in the wrong buffer? (Davit Samvelyan, 2014
-Jul 14)
+Patch to fix typos in help files. (Dominique, 2014 Aug 9)
 
-When 'clipboard' is "unnamed", :g/pat/d is very slow.  Only set the clipboard
-after the last delete? (Praful, 2014 May 28)
-Patch by Christian Brabandt, 2014 Jun 18.  Update Jun 25.
+Way to reproduce problem that characters are put on the screen twice in Insert
+mode when using system(). (Jacob Niehus, 2014 Aug 9)
+Related to setting TMODE_COOK.  Perhaps we can omit that for system()?
+
+Update for Romanian spell file. (Vanilla Ice, 2014 Aug 13)
+
+Patch to remove ETO_IGNORELANGUAGE, it causes Chinese characters not to show
+up. (Paul Moore, 2014 Jul 30)
+Should it depend on the Windows version?  Waiting for feedback.
+No longer needed after including DirectX patch?
+
+Patch by Marcin Szamotulski to add count to :close (2014 Aug 10, update Aug
+14)
+    Make ":1close" close the first window.
+    Make ":+1close" close the next window.
+    Make ":-1close" close the previous window.
+Can't easily close the help window, like ":pc" closes the preview window and
+":ccl" closes the quickfix window.  Add ":hclose". (Chris Gaal)
+Patch for :helpclose, Christian Brabandt, 2010 Sep 6.
+
+Patch by Marcin Szamotulski to add +cmd to buffer commands.
+(2014 Aug 18)
+
+Patch to fix that system() with empty input fails. (Olaf Dabrunz, 2014 Aug 19)
+
+When using a visual selection of multiple words and doing CTRL-W_] it jumps to
+the tag matching the word under the cursor, not the selected text.
+(Patrick hemmer)
+Patch by Christian, 2014 Aug 8.
 
 Completion for :buf does not use 'wildignorecase'. (Akshay H, 2014 May 31)
 
+Patch to handle list with some items locked. (ZyX, 2014 Aug 17)
+Prefer the second solution.
+
 ":cd C:\Windows\System32\drivers\etc*" does not work, even though the
 directory exists. (Sergio Gallelli, 2013 Dec 29)
+
+Patch to add a special key name for K_CURSORHOLD. (Hirohito Higashi, 2014 Aug
+10)
 
 The entries added by matchaddpos() are returned by getmatches() but can't be
 set with setmatches(). (lcd47, 2014 Jun 29)
@@ -78,8 +120,6 @@ set with setmatches(). (lcd47, 2014 Jun 29)
 Problem using ":try" inside ":execute". (ZyX, 2013 Sep 15)
 
 Python: ":py raw_input('prompt')" doesn't work. (Manu Hack)
-
-When using an undo file, also restore the changelist, so that "g;" works.
 
 Value returned by virtcol() changes depending on how lines wrap.  This is
 inconsistant with the documentation.
@@ -94,18 +134,11 @@ Adding "~" to 'cdpath' doesn't work for completion?  (Davido, 2013 Aug 19)
 "hi link" does not respect groups with GUI settings only. (Mark Lodato, 2014
 Jun 8)
 
-Syntax file for gnuplot.  Existing one is very old. (Andrew Rasmussen, 2014
-Feb 24)
-
-Issue 174: Detect Mason files.
-
 No error for missing endwhile. (ZyX, 2014 Mar 20)
 
-Phpcomplete.vim update. (Complex, 2014 Jan 15)
+Patch to add :arglocal and :arglists. (Marcin Szamotulski, 2014 Aug 6)
 
 PHP syntax is extremely slow. (Anhad Jai Singh, 2014 Jan 19)
-
-Patch for matchparen. (James McCoy, 2014 Jul 11)
 
 Spell files use a latin single quote. Unicode also has another single quote:
 0x2019.  (Ron Aaron, 2014 Apr 4)
@@ -116,8 +149,8 @@ Win32: use different args for SearchPath()? (Yasuhiro Matsumoto, 2009 Jan 30)
 Also fixes wrong result from executable().
 Update from Ken Takata, 2014 Jan 10. Newer 2014 Apr 3.
 
-Win32: use 64 bit stat() if possible. (Ken Takata, 2014 May 12)
-More tests May 14. Update May 29.
+Win32: patch to use 64 bit stat() if possible. (Ken Takata, 2014 May 12)
+More tests May 14. Update May 29.  Update Aug 10.
 
 The garbage collector may use too much stack.  Make set_ref_in_item()
 iterative instead of recursive.   Test program by Marc Weber (2013 Dec 10)
@@ -212,6 +245,8 @@ command instead of doing this alphabetically. (Mikel Jorgensen)
 
 Patch to add v:completed_item. (Shougo Matsu, 2013 Nov 29).
 
+Patch to get MSVC version in a nicer way. (Ken Takata, 2014 Jul 24)
+
 Patch to make test 100 work on MS-Windows. (Taro Muraoka, 2013 Dec 12)
 
 Patch to define macros for hardcoded values. (Elias Diem, 2013 Dec 14)
@@ -227,7 +262,7 @@ Issue 28.
 Go through more coverity reports.
 
 Patch to add ":undorecover", get as much text out of the undo file as
-possible. (Christian Brabandt, 2014 Mar 12)
+possible. (Christian Brabandt, 2014 Mar 12, update Aug 16)
 
 Updated spec ftplugin. (Matěj Cepl, 2013 Oct 16)
 
@@ -362,7 +397,7 @@ Patch to allow setting w:quickfix_title via setqflist() and setloclist()
 functions. (Christian Brabandt, 2013 May 8, update May 21)
 Patch to add getlocstack() / setlocstack(). (Christian Brabandt, 2013 May 14)
 Second one. Update May 22.
-Update by Daniel Hahler, 2014 Jul 4.
+Update by Daniel Hahler, 2014 Jul 4, Aug 14.
 
 Patch to make fold updates much faster. (Christian Brabandt, 2012 Dec)
 
@@ -416,13 +451,6 @@ Do we need some way (option) to show the sign column even when there are no
 signs?  Patch by Christian Brabandt, 2013 Aug 22.
 
 Patch to remove flicker from popup menu. (Yasuhiro Matsumoto, 2013 Aug 15)
-
-Patch to use directX to draw text on Windows.  Adds the 'renderoptions'
-option.  (Taro Muraoka, 2013 Jan 25, update 2013 Apr 3, May 14)
-Fixes this problem:
-8   Win32: Multi-byte characters are not displayed, even though the same font
-    in Notepad can display them. (Srinath Avadhanula)  Try with the
-    UTF-8-demo.txt page with Andale Mono.
 
 Patch to add 'completeselect' option.  Specifies how to select a candidate in
 insert completion. (Shougo, 2013 May 29)
@@ -637,6 +665,7 @@ effects?  (Christian Brabandt, 2012 Aug 5, Update 2013 Aug 12)
 Would also need to do this for spellbadword() and spellsuggest().
 
 Patch for variable tabstops.  On github (Christian Brabandt, 2014 May 15)
+Update Aug 16 (email).
 
 On 64 bit MS-Windows "long" is only 32 bits, but we sometimes need to store a
 64 bits value.  Change all number options to use nropt_T and define it to the
@@ -1343,10 +1372,6 @@ Jul 31)
 
 C syntax: {} inside () causes following {} to be highlighted as error.
 (Michalis Giannakidis, 2006 Jun 1)
-
-Can't easily close the help window, like ":pc" closes the preview window and
-":ccl" closes the quickfix window.  Add ":hclose". (Chris Gaal)
-Patch for :helpclose, Christian Brabandt, 2010 Sep 6.
 
 When 'diffopt' has "context:0" a single deleted line causes two folds to merge
 and mess up syncing. (Austin Jennings, 2008 Jan 31)
@@ -2955,6 +2980,8 @@ Spell checking:
 
 
 Diff mode:
+9   When making small changes, e.g. deleting a character, update the diff.
+    Possibly without running diff.
 9   Instead invoking an external diff program, use builtin code.  One can be
     found here: http://www.ioplex.com/~miallen/libmba/dl/src/diff.c
     It's quite big and badly documented though.
@@ -3844,7 +3871,6 @@ Autocommands:
 		      when exiting isn't a good idea.
     CursorHoldC     - CursorHold while command-line editing
     WinMoved	    - when windows have been moved around, e.g, ":wincmd J"
-    CmdUndefined    - Like FuncUndefined but for user commands.
     SearchPost	    - After doing a search command (e.g. to do "M")
     PreDirChanged/PostDirChanged
 		    - Before/after ":cd" has been used (for changing the

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1,4 +1,4 @@
-*usr_41.txt*	For Vim version 7.4.  Last change: 2014 May 28
+*usr_41.txt*	For Vim version 7.4.  Last change: 2014 Aug 16
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -793,6 +793,7 @@ Command line:					*command-line-functions*
 	getcmdpos()		get position of the cursor in the command line
 	setcmdpos()		set position of the cursor in the command line
 	getcmdtype()		return the current command-line type
+	getcmdwintype()		return the current command-line window type
 
 Quickfix and location lists:			*quickfix-functions*
 	getqflist()		list of quickfix errors

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -1,4 +1,4 @@
-*various.txt*   For Vim version 7.4.  Last change: 2014 May 22
+*various.txt*   For Vim version 7.4.  Last change: 2014 Aug 06
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Aug 22
+" Last Change:	2014 Aug 23
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")
@@ -1007,7 +1007,7 @@ au BufNewFile,BufRead *.jgr			setf jgraph
 au BufNewFile,BufRead *.jov,*.j73,*.jovial	setf jovial
 
 " JSON
-au BufNewFile,BufRead *.json			setf json
+au BufNewFile,BufRead *.json,*.jsonp		setf json
 
 " Kixtart
 au BufNewFile,BufRead *.kix			setf kix

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Jul 23
+" Last Change:	2014 Aug 22
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")
@@ -807,6 +807,9 @@ au BufNewFile,BufRead {,.}gitolite.rc,example.gitolite.rc	setf perl
 " Gnuplot scripts
 au BufNewFile,BufRead *.gpi			setf gnuplot
 
+" Go (Google)
+au BufNewFile,BufRead *.go			setf go
+
 " GrADS scripts
 au BufNewFile,BufRead *.gs			setf grads
 
@@ -1141,7 +1144,7 @@ au BufNewFile,BufRead *.map			setf map
 au BufNewFile,BufRead *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,README.md  setf markdown
 
 " Mason
-au BufNewFile,BufRead *.mason,*.mhtml		setf mason
+au BufNewFile,BufRead *.mason,*.mhtml,*.comp	setf mason
 
 " Matlab or Objective C
 au BufNewFile,BufRead *.m			call s:FTm()

--- a/runtime/ftplugin/go.vim
+++ b/runtime/ftplugin/go.vim
@@ -1,0 +1,18 @@
+" Vim filetype plugin file
+" Language:	Go
+" Maintainer:	David Barnett (https://github.com/google/vim-ft-go)
+" Last Change:	2014 Aug 16
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal formatoptions-=t
+
+setlocal comments=s1:/*,mb:*,ex:*/,://
+setlocal commentstring=//\ %s
+
+let b:undo_ftplugin = 'setl fo< com< cms<'
+
+" vim: sw=2 sts=2 et

--- a/runtime/ftplugin/vroom.vim
+++ b/runtime/ftplugin/vroom.vim
@@ -1,6 +1,6 @@
 " Vim filetype plugin file
 " Language:	Vroom (vim testing and executable documentation)
-" Maintainer:	David Barnett (https://github.com/google/vim-ft.vroom)
+" Maintainer:	David Barnett (https://github.com/google/vim-ft-vroom)
 " Last Change:	2014 Jul 23
 
 if exists('b:did_ftplugin')

--- a/runtime/indent/go.vim
+++ b/runtime/indent/go.vim
@@ -1,0 +1,78 @@
+" Vim indent file
+" Language:	Go
+" Maintainer:	David Barnett (https://github.com/google/vim-ft-go)
+" Last Change:	2014 Aug 16
+"
+" TODO:
+" - function invocations split across lines
+" - general line splits (line ends in an operator)
+
+if exists('b:did_indent')
+  finish
+endif
+let b:did_indent = 1
+
+" C indentation is too far off useful, mainly due to Go's := operator.
+" Let's just define our own.
+setlocal nolisp
+setlocal autoindent
+setlocal indentexpr=GoIndent(v:lnum)
+setlocal indentkeys+=<:>,0=},0=)
+
+if exists('*GoIndent')
+  finish
+endif
+
+" The shiftwidth() function is relatively new.
+" Don't require it to exist.
+if exists('*shiftwidth')
+  function s:sw() abort
+    return shiftwidth()
+  endfunction
+else
+  function s:sw() abort
+    return &shiftwidth
+  endfunction
+endif
+
+function! GoIndent(lnum)
+  let l:prevlnum = prevnonblank(a:lnum-1)
+  if l:prevlnum == 0
+    " top of file
+    return 0
+  endif
+
+  " grab the previous and current line, stripping comments.
+  let l:prevl = substitute(getline(l:prevlnum), '//.*$', '', '')
+  let l:thisl = substitute(getline(a:lnum), '//.*$', '', '')
+  let l:previ = indent(l:prevlnum)
+
+  let l:ind = l:previ
+
+  if l:prevl =~ '[({]\s*$'
+    " previous line opened a block
+    let l:ind += s:sw()
+  endif
+  if l:prevl =~# '^\s*\(case .*\|default\):$'
+    " previous line is part of a switch statement
+    let l:ind += s:sw()
+  endif
+  " TODO: handle if the previous line is a label.
+
+  if l:thisl =~ '^\s*[)}]'
+    " this line closed a block
+    let l:ind -= s:sw()
+  endif
+
+  " Colons are tricky.
+  " We want to outdent if it's part of a switch ("case foo:" or "default:").
+  " We ignore trying to deal with jump labels because (a) they're rare, and
+  " (b) they're hard to disambiguate from a composite literal key.
+  if l:thisl =~# '^\s*\(case .*\|default\):$'
+    let l:ind -= s:sw()
+  endif
+
+  return l:ind
+endfunction
+
+" vim: sw=2 sts=2 et

--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -2,7 +2,7 @@
 " Header: "{{{
 " Maintainer:	Bram Moolenaar
 " Original Author: Andy Wokula <anwoku@yahoo.de>
-" Last Change:	2014 Jul 04
+" Last Change:	2014 Aug 23
 " Version:	1.0
 " Description:	HTML indent script with cached state for faster indenting on a
 "		range of lines.
@@ -497,7 +497,7 @@ func! s:FreshState(lnum)
   " If previous line ended in a closing tag, line up with the opening tag.
   if !swendtag && text =~ '</\w\+\s*>\s*$'
     call cursor(state.lnum, 99999)
-    normal F<
+    normal! F<
     let start_lnum = HtmlIndent_FindStartTag()
     if start_lnum > 0
       let state.baseindent = indent(start_lnum)
@@ -898,7 +898,7 @@ func! HtmlIndent()
   " a tag works very differently. Do not do this when the line starts with
   " "<", it gets the "htmlTag" ID but we are not inside a tag then.
   if curtext !~ '^\s*<'
-    normal ^
+    normal! ^
     let stack = synstack(v:lnum, col('.'))  " assumes there are no tabs
     let foundHtmlString = 0
     for synid in reverse(stack)

--- a/runtime/indent/sh.vim
+++ b/runtime/indent/sh.vim
@@ -2,7 +2,7 @@
 " Language:         Shell Script
 " Maintainer:       Peter Aronoff <telemachus@arpinum.org>
 " Original Author:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:  2013-11-28
+" Latest Revision:  2014-08-22
 
 if exists("b:did_indent")
   finish
@@ -91,7 +91,9 @@ function! GetShIndent()
     if s:is_case(pine)
       let ind = indent(lnum) + s:indent_value('case-labels')
     else
-      let ind -= s:indent_value('case-statements') - s:indent_value('case-breaks')
+      let ind -= (s:is_case_label(pine, lnum) && s:is_case_ended(pine) ?
+                  \ 0 : s:indent_value('case-statements')) -
+                  \ s:indent_value('case-breaks')
     endif
   elseif s:is_case_break(line)
     let ind -= s:indent_value('case-breaks')

--- a/runtime/indent/vroom.vim
+++ b/runtime/indent/vroom.vim
@@ -1,6 +1,6 @@
 " Vim indent file
 " Language:	Vroom (vim testing and executable documentation)
-" Maintainer:	David Barnett (https://github.com/google/vim-ft.vroom)
+" Maintainer:	David Barnett (https://github.com/google/vim-ft-vroom)
 " Last Change:	2014 Jul 23
 
 if exists('b:did_indent')

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,7 @@
 " These commands create the option window.
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Apr 01
+" Last Change:	2014 Aug 06
 
 " If there already is an option window, jump to that one.
 if bufwinnr("option-window") > 0

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -2,7 +2,7 @@
 " This file is normally sourced from menu.vim.
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2013 Jun 24
+" Last Change:	2014 Aug 13
 
 " Define the SetSyn function, used for the Syntax menu entries.
 " Set 'filetype' and also 'syntax' if it is manually selected.
@@ -326,6 +326,7 @@ an 50.70.270 &Syntax.M.Messages\ (/var/log) :cal SetSyn("messages")<CR>
 an 50.70.280 &Syntax.M.Metafont :cal SetSyn("mf")<CR>
 an 50.70.290 &Syntax.M.MetaPost :cal SetSyn("mp")<CR>
 an 50.70.300 &Syntax.M.MGL :cal SetSyn("mgl")<CR>
+an 50.70.305 &Syntax.M.MIX :cal SetSyn("mix")<CR>
 an 50.70.310 &Syntax.M.MMIX :cal SetSyn("mmix")<CR>
 an 50.70.320 &Syntax.M.Modconf :cal SetSyn("modconf")<CR>
 an 50.70.330 &Syntax.M.Model :cal SetSyn("model")<CR>

--- a/runtime/syntax/gnuplot.vim
+++ b/runtime/syntax/gnuplot.vim
@@ -1,176 +1,505 @@
 " Vim syntax file
-" Language:	gnuplot 3.8i.0
-" Maintainer:	John Hoelzel johnh51@users.sourceforge.net
-" Last Change:	Mon May 26 02:33:33 UTC 2003
-" Filenames:	*.gpi  *.gih   scripts: #!*gnuplot
-" URL:		http://johnh51.get.to/vim/syntax/gnuplot.vim
-"
+" Language:	gnuplot 4.7.0
+" Maintainer:	Andrew Rasmussen andyras@users.sourceforge.net
+" Original Maintainer:	John Hoelzel johnh51@users.sourceforge.net
+" Last Change:	2014-02-24
+" Filenames:	*.gnu *.plt *.gpi *.gih *.gp *.gnuplot scripts: #!*gnuplot
+" URL:		http://www.vim.org/scripts/script.php?script_id=4873
+" Original URL:	http://johnh51.get.to/vim/syntax/gnuplot.vim
 
-" thanks to "David Necas (Yeti)" <yeti@physics.muni.cz> for heads up - working on more changes .
-" *.gpi      = GnuPlot Input - what I use because there is no other guideline. jeh 11/2000
-" *.gih      = makes using cut/pasting from gnuplot.gih easier ...
-" #!*gnuplot = for Linux bash shell scripts of gnuplot commands.
-"	       emacs used a suffix of '<gp?>'
-" gnuplot demo files show no preference.
-" I will post mail and newsgroup comments on a standard suffix in 'URL' directory.
+" thanks to "David Necas (Yeti)" <yeti@physics.muni.cz>
 
-" For version 5.x: Clear all syntax items
-" For version 6.x: Quit when a syntax file was already loaded
+" credit also to Jim Eberle <jim.eberle@fastnlight.com>
+" for the script http://www.vim.org/scripts/script.php?script_id=1737
+
+" some shortened names to make demo files look clean... jeh. 11/2000
+" demos -> 3.8i ... jeh. 5/2003 - a work in progress...
+" added current commands, keywords, variables, todos, macros... amr 2014-02-24
+
+" For vim version 5.x: Clear all syntax items
+" For vim version 6.x: Quit when a syntax file was already loaded
+
 if version < 600
   syntax clear
 elseif exists("b:current_syntax")
   finish
 endif
 
-" some shortened names to make demo files look clean... jeh. 11/2000
-" demos -> 3.8i ... jeh. 5/2003 - a work in progress...
+" ---- Special characters ---- "
 
-" commands
+" no harm in just matching any \[char] within double quotes, right?
+syn match gnuplotSpecial	"\\." contained
+" syn match gnuplotSpecial	"\\\o\o\o\|\\x\x\x\|\\c[^"]\|\\[a-z\\]" contained
 
-syn keyword gnuplotStatement	cd call clear exit set unset plot splot help
-syn keyword gnuplotStatement	load pause quit fit rep[lot] if
-syn keyword gnuplotStatement	FIT_LIMIT FIT_MAXITER FIT_START_LAMBDA
-syn keyword gnuplotStatement	FIT_LAMBDA_FACTOR FIT_LOG FIT_SCRIPT
-syn keyword gnuplotStatement	print pwd reread reset save show test ! functions var
-syn keyword gnuplotConditional	if
-" if is cond + stmt - ok?
+" measurements in the units in, cm and pt are special
+syn match gnuplotUnit		"[0-9]+in"
+syn match gnuplotUnit		"[0-9]+cm"
+syn match gnuplotUnit		"[0-9]+pt"
 
-" numbers fm c.vim
+" external (shell) commands are special
+syn region gnuplotExternal	start="!" end="$"
 
-"	integer number, or floating point number without a dot and with "f".
+" ---- Comments ---- "
+
+syn region gnuplotComment	start="#" end="$" contains=gnuplotTodo
+
+" ---- Constants ---- "
+
+" strings
+syn region gnuplotString	start=+"+ skip=+\\"+ end=+"+ contains=gnuplotSpecial
+syn region gnuplotString	start="'" end="'"
+
+" built-in variables
+syn keyword gnuplotNumber	GNUTERM GPVAL_TERM GPVAL_TERMOPTIONS GPVAL_SPLOT
+syn keyword gnuplotNumber	GPVAL_OUTPUT GPVAL_ENCODING GPVAL_VERSION
+syn keyword gnuplotNumber	GPVAL_PATCHLEVEL GPVAL_COMPILE_OPTIONS
+syn keyword gnuplotNumber	GPVAL_MULTIPLOT GPVAL_PLOT GPVAL_VIEW_ZSCALE
+syn keyword gnuplotNumber	GPVAL_TERMINALS GPVAL_pi GPVAL_NaN
+syn keyword gnuplotNumber	GPVAL_ERRNO GPVAL_ERRMSG GPVAL_PWD
+syn keyword gnuplotNumber	pi NaN GPVAL_LAST_PLOT GPVAL_TERM_WINDOWID
+syn keyword gnuplotNumber	GPVAL_X_MIN GPVAL_X_MAX GPVAL_X_LOG
+syn keyword gnuplotNumber	GPVAL_DATA_X_MIN GPVAL_DATA_X_MAX GPVAL_Y_MIN
+syn keyword gnuplotNumber	GPVAL_Y_MAX GPVAL_Y_LOG GPVAL_DATA_Y_MIN
+syn keyword gnuplotNumber	GPVAL_DATA_Y_MAX GPVAL_X2_MIN GPVAL_X2_MAX
+syn keyword gnuplotNumber	GPVAL_X2_LOG GPVAL_DATA_X2_MIN GPVAL_DATA_X2_MAX
+syn keyword gnuplotNumber	GPVAL_Y2_MIN GPVAL_Y2_MAX GPVAL_Y2_LOG
+syn keyword gnuplotNumber	GPVAL_DATA_Y2_MIN GPVAL_DATA_Y2_MAX GPVAL_Z_MIN
+syn keyword gnuplotNumber	GPVAL_Z_MAX GPVAL_Z_LOG GPVAL_DATA_Z_MIN
+syn keyword gnuplotNumber	GPVAL_DATA_Z_MAX GPVAL_CB_MIN GPVAL_CB_MAX
+syn keyword gnuplotNumber	GPVAL_CB_LOG GPVAL_DATA_CB_MIN GPVAL_DATA_CB_MAX
+syn keyword gnuplotNumber	GPVAL_T_MIN GPVAL_T_MAX GPVAL_T_LOG GPVAL_U_MIN
+syn keyword gnuplotNumber	GPVAL_U_MAX GPVAL_U_LOG GPVAL_V_MIN GPVAL_V_MAX
+syn keyword gnuplotNumber	GPVAL_V_LOG GPVAL_R_MIN GPVAL_R_LOG
+syn keyword gnuplotNumber	GPVAL_TERM_XMIN GPVAL_TERM_XMAX GPVAL_TERM_YMIN
+syn keyword gnuplotNumber	GPVAL_TERM_YMAX GPVAL_TERM_XSIZE
+syn keyword gnuplotNumber	GPVAL_TERM_YSIZE GPVAL_VIEW_MAP GPVAL_VIEW_ROT_X
+syn keyword gnuplotNumber	GPVAL_VIEW_ROT_Z GPVAL_VIEW_SCALE
+
+" function name variables
+syn match gnuplotNumber		"GPFUN_[a-zA-Z_]*"
+
+" stats variables
+syn keyword gnuplotNumber	STATS_records STATS_outofrange STATS_invalid
+syn keyword gnuplotNumber	STATS_blank STATS_blocks STATS_columns STATS_min
+syn keyword gnuplotNumber	STATS_max STATS_index_min STATS_index_max
+syn keyword gnuplotNumber	STATS_lo_quartile STATS_median STATS_up_quartile
+syn keyword gnuplotNumber	STATS_mean STATS_stddev STATS_sum STATS_sumsq
+syn keyword gnuplotNumber	STATS_correlation STATS_slope STATS_intercept
+syn keyword gnuplotNumber	STATS_sumxy STATS_pos_min_y STATS_pos_max_y
+syn keyword gnuplotNumber	STATS_mean STATS_stddev STATS_mean_x STATS_sum_x
+syn keyword gnuplotNumber	STATS_stddev_x STATS_sumsq_x STATS_min_x
+syn keyword gnuplotNumber	STATS_max_x STATS_median_x STATS_lo_quartile_x
+syn keyword gnuplotNumber	STATS_up_quartile_x STATS_index_min_x
+syn keyword gnuplotNumber	STATS_index_max_x STATS_mean_y STATS_stddev_y
+syn keyword gnuplotNumber	STATS_sum_y STATS_sumsq_y STATS_min_y
+syn keyword gnuplotNumber	STATS_max_y STATS_median_y STATS_lo_quartile_y
+syn keyword gnuplotNumber	STATS_up_quartile_y STATS_index_min_y
+syn keyword gnuplotNumber	STATS_index_max_y STATS_correlation STATS_sumxy
+
+" deprecated fit variables
+syn keyword gnuplotError	FIT_LIMIT FIT_MAXITER FIT_START_LAMBDA
+syn keyword gnuplotError	FIT_LAMBDA_FACTOR FIT_LOG FIT_SCRIPT
+
+" numbers, from c.vim
+
+" integer number, or floating point number without a dot and with "f".
 syn case    ignore
 syn match   gnuplotNumber	"\<[0-9]\+\(u\=l\=\|lu\|f\)\>"
-"	floating point number, with dot, optional exponent
+
+" floating point number, with dot, optional exponent
 syn match   gnuplotFloat	"\<[0-9]\+\.[0-9]*\(e[-+]\=[0-9]\+\)\=[fl]\=\>"
-"	floating point number, starting with a dot, optional exponent
+
+" floating point number, starting with a dot, optional exponent
 syn match   gnuplotFloat	"\.[0-9]\+\(e[-+]\=[0-9]\+\)\=[fl]\=\>"
-"	floating point number, without dot, with exponent
+
+" floating point number, without dot, with exponent
 syn match   gnuplotFloat	"\<[0-9]\+e[-+]\=[0-9]\+[fl]\=\>"
-"	hex number
+
+" hex number
 syn match   gnuplotNumber	"\<0x[0-9a-f]\+\(u\=l\=\|lu\)\>"
 syn case    match
-"	flag an octal number with wrong digits by not hilighting
+
+" flag an octal number with wrong digits by not highlighting
 syn match   gnuplotOctalError	"\<0[0-7]*[89]"
 
-" plot args
+" ---- Identifiers: Functions ---- "
 
-syn keyword gnuplotType		u[sing] tit[le] notit[le] wi[th] steps fs[teps]
-syn keyword gnuplotType		title notitle t
-syn keyword gnuplotType		with w
-syn keyword gnuplotType		li[nes] l
-" t - too much?  w - too much?  l - too much?
-syn keyword gnuplotType		linespoints via
+" numerical functions
+syn keyword gnuplotFunc		abs acos acosh airy arg asin asinh atan atan2
+syn keyword gnuplotFunc		atanh EllipticK EllipticE EllipticPi besj0 besj1
+syn keyword gnuplotFunc		besy0 besy1 ceil cos cosh erf erfc exp expint
+syn keyword gnuplotFunc		floor gamma ibeta inverf igamma imag invnorm int
+syn keyword gnuplotFunc		lambertw lgamma log log10 norm rand real sgn sin
+syn keyword gnuplotFunc		sin sinh sqrt tan tanh voigt
 
-" funcs
+" string functions
+syn keyword gnuplotFunc		gprintf sprintf strlen strstrt substr strftime
+syn keyword gnuplotFunc		strptime system word words
 
-syn keyword gnuplotFunc		abs acos acosh arg asin asinh atan atanh atan2
-syn keyword gnuplotFunc		besj0 besj1 besy0 besy1
-syn keyword gnuplotFunc		ceil column cos cosh erf erfc exp floor gamma
-syn keyword gnuplotFunc		ibeta inverf igamma imag invnorm int lgamma
-syn keyword gnuplotFunc		log log10 norm rand real sgn sin sinh sqrt tan
-syn keyword gnuplotFunc		lambertw
-syn keyword gnuplotFunc		tanh valid
-syn keyword gnuplotFunc		tm_hour tm_mday tm_min tm_mon tm_sec
-syn keyword gnuplotFunc		tm_wday tm_yday tm_year
+" other functions
+syn keyword gnuplotFunc		column columnhead columnheader defined exists
+syn keyword gnuplotFunc		hsv2rgb stringcolumn timecolumn tm_hour tm_mday
+syn keyword gnuplotFunc		tm_min tm_mon tm_sec tm_wday tm_yday tm_year
+syn keyword gnuplotFunc		time valid value
 
-" set vars
+" ---- Statements ---- "
 
-syn keyword gnuplotType		xdata timefmt grid noytics ytics fs
-syn keyword gnuplotType		logscale time notime mxtics nomxtics style mcbtics
-syn keyword gnuplotType		nologscale
-syn keyword gnuplotType		axes x1y2 unique acs[plines]
-syn keyword gnuplotType		size origin multiplot xtics xr[ange] yr[ange] square nosquare ratio noratio
-syn keyword gnuplotType		binary matrix index every thru sm[ooth]
-syn keyword gnuplotType		all angles degrees radians
-syn keyword gnuplotType		arrow noarrow autoscale noautoscale arrowstyle
-" autoscale args = x y xy z t ymin ... - too much?
-" needs code to: using title vs autoscale t
-syn keyword gnuplotType		x y z zcb
-syn keyword gnuplotType		linear  cubicspline  bspline order level[s]
-syn keyword gnuplotType		auto disc[rete] incr[emental] from to head nohead
-syn keyword gnuplotType		graph base both nosurface table out[put] data
-syn keyword gnuplotType		bar border noborder boxwidth
-syn keyword gnuplotType		clabel noclabel clip noclip cntrp[aram]
-syn keyword gnuplotType		contour nocontour
-syn keyword gnuplotType		dgrid3d nodgrid3d dummy encoding format
-" set encoding args not included - yet.
-syn keyword gnuplotType		function grid nogrid hidden[3d] nohidden[3d] isosample[s] key nokey
-syn keyword gnuplotType		historysize nohistorysize
-syn keyword gnuplotType		defaults offset nooffset trianglepattern undefined noundefined altdiagonal bentover noaltdiagonal nobentover
-syn keyword gnuplotType		left right top bottom outside below samplen spacing width height box nobox linestyle ls linetype lt linewidth lw
-syn keyword gnuplotType		Left Right autotitles noautotitles enhanced noenhanced
-syn keyword gnuplotType		isosamples
-syn keyword gnuplotType		label nolabel logscale nolog[scale] missing center font locale
-syn keyword gnuplotType		mapping margin bmargin lmargin rmargin tmargin spherical cylindrical cartesian
-syn keyword gnuplotType		linestyle nolinestyle linetype lt linewidth lw pointtype pt pointsize ps
-syn keyword gnuplotType		mouse nomouse
-syn keyword gnuplotType		nooffsets data candlesticks financebars linespoints lp vector nosurface
-syn keyword gnuplotType		term[inal] linux aed767 aed512 gpic
-syn keyword gnuplotType		regis tek410x tek40 vttek kc-tek40xx
-syn keyword gnuplotType		km-tek40xx selanar bitgraph xlib x11 X11
-" x11 args
-syn keyword gnuplotType		aifm cgm dumb fig gif small large size nofontlist winword6 corel dxf emf
-syn keyword gnuplotType		hpgl
-" syn keyword gnuplotType	transparent hp2623a hp2648 hp500c pcl5				      why jeh
-syn keyword gnuplotType		hp2623a hp2648 hp500c pcl5
-syn match gnuplotType		"\<transparent\>"
-syn keyword gnuplotType		hpljii hpdj hppj imagen mif pbm png svg
-syn keyword gnuplotType		postscript enhanced_postscript qms table
-" postscript editing values?
-syn keyword gnuplotType		tgif tkcanvas epson-180dpi epson-60dpi
-syn keyword gnuplotType		epson-lx800 nec-cp6 okidata starc
-syn keyword gnuplotType		tandy-60dpi latex emtex pslatex pstex epslatex
-syn keyword gnuplotType		eepic tpic pstricks texdraw mf metafont mpost mp
-syn keyword gnuplotType		timestamp notimestamp
-syn keyword gnuplotType		variables version
-syn keyword gnuplotType		x2data y2data ydata zdata
-syn keyword gnuplotType		reverse writeback noreverse nowriteback
-syn keyword gnuplotType		axis mirror autofreq nomirror rotate autofreq norotate
-syn keyword gnuplotType		update
-syn keyword gnuplotType		multiplot nomultiplot mytics
-syn keyword gnuplotType		nomytics mztics nomztics mx2tics nomx2tics
-syn keyword gnuplotType		my2tics nomy2tics offsets origin output
-syn keyword gnuplotType		para[metric] nopara[metric] pointsize polar nopolar
-syn keyword gnuplotType		zrange x2range y2range rrange cbrange
-syn keyword gnuplotType		trange urange vrange sample[s] size
-syn keyword gnuplotType		bezier boxerrorbars boxes bargraph bar[s]
-syn keyword gnuplotType		boxxy[errorbars] csplines dots fsteps histeps impulses
-syn keyword gnuplotType		line[s] linesp[oints] points poiinttype sbezier splines steps
-" w lt lw ls	      = optional
-syn keyword gnuplotType		vectors xerr[orbars] xyerr[orbars] yerr[orbars] financebars candlesticks vector
-syn keyword gnuplotType		errorb[ars] surface
-syn keyword gnuplotType		filledcurve[s] pm3d   x1 x2 y1 y2 xy closed
-syn keyword gnuplotType		at pi front
-syn keyword gnuplotType		errorlines xerrorlines yerrorlines xyerrorlines
-syn keyword gnuplotType		tics ticslevel ticscale time timefmt view
-syn keyword gnuplotType		xdata xdtics noxdtics ydtics noydtics
-syn keyword gnuplotType		zdtics nozdtics x2dtics nox2dtics y2dtics noy2dtics
-syn keyword gnuplotType		xlab[el] ylab[el] zlab[el] cblab[el] x2label y2label xmtics
-syn keyword gnuplotType		xmtics noxmtics ymtics noymtics zmtics nozmtics
-syn keyword gnuplotType		x2mtics nox2mtics y2mtics noy2mtics
-syn keyword gnuplotType		cbdtics nocbdtics cbmtics nocbmtics cbtics nocbtics
-syn keyword gnuplotType		xtics noxtics ytics noytics
-syn keyword gnuplotType		ztics noztics x2tics nox2tics
-syn keyword gnuplotType		y2tics noy2tics zero nozero zeroaxis nozeroaxis
-syn keyword gnuplotType		xzeroaxis noxzeroaxis yzeroaxis noyzeroaxis
-syn keyword gnuplotType		x2zeroaxis nox2zeroaxis y2zeroaxis noy2zeroaxis
-syn keyword gnuplotType		angles one two fill empty solid pattern
-syn keyword gnuplotType		default
-syn keyword gnuplotType		scansautomatic flush b[egin] noftriangles implicit
-" b too much? - used in demo
-syn keyword gnuplotType		palette positive negative ps_allcF nops_allcF maxcolors
-syn keyword gnuplotType		push fontfile pop
-syn keyword gnuplotType		rgbformulae defined file color model gradient colornames
-syn keyword gnuplotType		RGB HSV CMY YIQ XYZ
-syn keyword gnuplotType		colorbox vertical horizontal user bdefault
-syn keyword gnuplotType		loadpath fontpath decimalsign in out
+" common (builtin) variable names
+syn keyword gnuplotKeyword	x y t u v z s
 
-" comments + strings
-syn region gnuplotComment	start="#" end="$"
-syn region gnuplotComment	start=+"+ skip=+\\"+ end=+"+
-syn region gnuplotComment	start=+'+	     end=+'+
+" conditionals
+syn keyword gnuplotConditional	if else
 
-" Define the default highlighting.
+" repeats
+syn keyword gnuplotRepeat	do for while
+
+" operators
+syn match gnuplotOperator	"[-+*/^|&?:]"
+syn match gnuplotOperator	"\*\*"
+syn match gnuplotOperator	"&&"
+syn match gnuplotOperator	"||"
+
+" Keywords
+
+" keywords for 'fit' command
+syn keyword gnuplotKeyword	via z x:z x:z:s x:y:z:s
+syn keyword gnuplotKeyword	x:y:t:z:s x:y:t:u:z:s x:y:t:u:v:z:s
+
+" keywords for 'plot' command
+" 'axes' keyword
+syn keyword gnuplotKeyword	axes x1y1 x1y2 x2y1 x2y2
+" 'binary' keyword
+syn keyword gnuplotKeyword	binary matrix general array record format endian
+syn keyword gnuplotKeyword	filetype avs edf png scan transpose dx dy dz
+syn keyword gnuplotKeyword	flipx flipy flipz origin center rotate using
+syn keyword gnuplotKeyword	perpendicular skip every
+" datafile keywords
+syn keyword gnuplotKeyword	binary nonuniform matrix index every using
+syn keyword gnuplotKeyword	smooth volatile noautoscale every index
+" 'smooth' keywords
+syn keyword gnuplotKeyword	unique frequency cumulative cnormal kdensity
+syn keyword gnuplotKeyword	csplines acsplines bezer sbezier
+" deprecated 'thru' keyword
+syn keyword gnuplotError	thru
+" 'using' keyword
+syn keyword gnuplotKeyword	using u xticlabels yticlabels zticlabels
+syn keyword gnuplotKeyword	x2ticlabels y2ticlabels xtic ytic ztic
+" 'errorbars' keywords
+syn keyword gnuplotKeyword	errorbars xerrorbars yerrorbars xyerrorbars
+" 'errorlines' keywords
+syn keyword gnuplotKeyword	errorlines xerrorlines yerrorlines xyerrorlines
+" 'title' keywords
+syn keyword gnuplotKeyword	title t tit notitle columnheader at beginning
+syn keyword gnuplotKeyword	end
+" 'with' keywords
+syn keyword gnuplotKeyword	with w linestyle ls linetype lt linewidth
+syn keyword gnuplotKeyword	lw linecolor lc pointtype pt pointsize ps
+syn keyword gnuplotKeyword	fill fs nohidden3d nocontours nosurface palette
+" styles for 'with'
+syn keyword gnuplotKeyword	lines l points p linespoints lp surface dots
+syn keyword gnuplotKeyword	impulses labels vectors steps fsteps histeps
+syn keyword gnuplotKeyword	errorbars errorlines financebars xerrorbars
+syn keyword gnuplotKeyword	xerrorlines xyerrorbars yerrorbars yerrorlines
+syn keyword gnuplotKeyword	boxes boxerrorbars boxxyerrorbars boxplot
+syn keyword gnuplotKeyword	candlesticks circles ellipses filledcurves
+syn keyword gnuplotKeyword	histogram image rgbimage rgbalpha pm3d variable
+
+" keywords for 'save' command
+syn keyword gnuplotKeyword	save functions func variables all var terminal
+syn keyword gnuplotKeyword	term set
+
+" keywords for 'set/show' command
+" set angles
+syn keyword gnuplotKeyword	angles degrees deg radians rad
+" set arrow
+syn keyword gnuplotKeyword	arrow from to rto length angle arrowstyle as
+syn keyword gnuplotKeyword	nohead head backhead heads size filled empty
+syn keyword gnuplotKeyword	nofilled front back linestyle linetype linewidth
+" set autoscale
+" TODO regexp here
+syn keyword gnuplotKeyword	autoscale x y z cb x2 y2 zy min max fixmin
+syn keyword gnuplotKeyword	fixmax fix keepfix noextend
+" set bars
+syn keyword gnuplotKeyword	bars small large fullwidth front back
+" set bind
+syn keyword gnuplotKeyword	bind
+" set margins
+" TODO regexp
+syn keyword gnuplotKeyword	margin bmargin lmargin rmargin tmargin
+" set border
+syn keyword gnuplotKeyword	border front back
+" set boxwidth
+syn keyword gnuplotKeyword	boxwidth absolute relative
+" deprecated set clabel
+syn keyword gnuplotError	clabel
+" set clip
+syn keyword gnuplotKeyword	clip points one two
+" set cntrlabel
+syn keyword gnuplotKeyword	cntrlabel format font start interval onecolor
+" set cntrparam
+syn keyword gnuplotKeyword	cntrparam linear cubicspline bspline points
+syn keyword gnuplotKeyword	order levels auto discrete incremental
+" set colorbox
+syn keyword gnuplotKeyword	colorbox vertical horizontal default user origin
+syn keyword gnuplotKeyword	size front back noborder bdefault border
+" show colornames
+syn keyword gnuplotKeyword	colornames
+" set contour
+syn keyword gnuplotKeyword	contour base surface both
+" set datafile
+syn keyword gnuplotKeyword	datafile fortran nofpe_trap missing separator
+syn keyword gnuplotKeyword	whitespace tab comma commentschars binary
+" set decimalsign
+syn keyword gnuplotKeyword	decimalsign locale
+" set dgrid3d
+syn keyword gnuplotKeyword	dgrid3d splines qnorm gauss cauchy exp box hann
+syn keyword gnuplotKeyword	kdensity
+" set dummy
+syn keyword gnuplotKeyword	dummy
+" set encoding
+syn keyword gnuplotKeyword	encoding default iso_8859_1 iso_8859_15
+syn keyword gnuplotKeyword	iso_8859_2 iso_8859_9 koi8r koi8u cp437 cp850
+syn keyword gnuplotKeyword	cp852 cp950 cp1250 cp1251 cp1254 sjis utf8
+" set fit
+syn keyword gnuplotKeyword	fit logfile default quiet noquiet results brief
+syn keyword gnuplotKeyword	verbose errorvariables noerrorvariables
+syn keyword gnuplotKeyword	errorscaling noerrorscaling prescale noprescale
+syn keyword gnuplotKeyword	maxiter none limit limit_abs start-lambda script
+syn keyword gnuplotKeyword	lambda-factor
+" set fontpath
+syn keyword gnuplotKeyword	fontpath
+" set format
+syn keyword gnuplotKeyword	format
+" show functions
+syn keyword gnuplotKeyword	functions
+" set grid
+syn keyword gnuplotKeyword	grid polar layerdefault xtics ytics ztics x2tics
+syn keyword gnuplotKeyword	y2tics cbtics mxtics mytics mztics mx2tics
+syn keyword gnuplotKeyword	my2tics mcbtics xmtics ymtics zmtics x2mtics
+syn keyword gnuplotKeyword	y2mtics cbmtics noxtics noytics noztics nox2tics
+syn keyword gnuplotKeyword	noy2tics nocbtics nomxtics nomytics nomztics
+syn keyword gnuplotKeyword	nomx2tics nomy2tics nomcbtics
+" set hidden3d
+syn keyword gnuplotKeyword	hidden3d offset trianglepattern undefined
+syn keyword gnuplotKeyword	altdiagonal noaltdiagonal bentover nobentover
+syn keyword gnuplotKeyword	noundefined
+" set historysize
+syn keyword gnuplotKeyword	historysize
+" set isosamples
+syn keyword gnuplotKeyword	isosamples
+" set key
+syn keyword gnuplotKeyword	key on off inside outside at left right center
+syn keyword gnuplotKeyword	top bottom vertical horizontal Left Right
+syn keyword gnuplotKeyword	opaque noopaque reverse noreverse invert maxrows
+syn keyword gnuplotKeyword	noinvert samplen spacing width height autotitle
+syn keyword gnuplotKeyword	noautotitle title enhanced noenhanced font
+syn keyword gnuplotKeyword	textcolor box nobox linetype linewidth maxcols
+" set label
+syn keyword gnuplotKeyword	label left center right rotate norotate by font
+syn keyword gnuplotKeyword	front back textcolor point nopoint offset boxed
+syn keyword gnuplotKeyword	hypertext
+" set linetype
+syn keyword gnuplotKeyword	linetype
+" set link
+syn keyword gnuplotKeyword	link via inverse
+" set loadpath
+syn keyword gnuplotKeyword	loadpath
+" set locale
+syn keyword gnuplotKeyword	locale
+" set logscale
+syn keyword gnuplotKeyword	logscale log
+" set macros
+syn keyword gnuplotKeyword	macros
+" set mapping
+syn keyword gnuplotKeyword	mapping cartesian spherical cylindrical
+" set mouse
+syn keyword gnuplotKeyword	mouse doubleclick nodoubleclick zoomcoordinates
+syn keyword gnuplotKeyword	nozoomcoordinates ruler noruler at polardistance
+syn keyword gnuplotKeyword	nopolardistance deg tan format clipboardformat
+syn keyword gnuplotKeyword	mouseformat labels nolabels zoomjump nozoomjump
+syn keyword gnuplotKeyword	verbose noverbose
+" set multiplot
+syn keyword gnuplotKeyword	multiplot title font layout rowsfirst downwards
+syn keyword gnuplotKeyword	downwards upwards scale offset
+" set object
+syn keyword gnuplotKeyword	object behind fillcolor fc fs rectangle ellipse
+syn keyword gnuplotKeyword	circle polygon at center size units xy xx yy to
+syn keyword gnuplotKeyword	from
+" set offsets
+syn keyword gnuplotKeyword	offsets
+" set origin
+syn keyword gnuplotKeyword	origin
+" set output
+syn keyword gnuplotKeyword	output
+" set parametric
+syn keyword gnuplotKeyword	parametric
+" show plot
+syn keyword gnuplotKeyword	plot add2history
+" set pm3d
+syn keyword gnuplotKeyword	hidden3d interpolate scansautomatic scansforward
+syn keyword gnuplotKeyword	scansbackward depthorder flush begin center end
+syn keyword gnuplotKeyword	ftriangles noftriangles clip1in clip4in mean map
+syn keyword gnuplotKeyword	corners2color geomean harmean rms median min max
+syn keyword gnuplotKeyword	c1 c2 c3 c4 pm3d at nohidden3d implicit explicit
+" set palette
+syn keyword gnuplotKeyword	palette gray color gamma rgbformulae defined
+syn keyword gnuplotKeyword	file functions cubehelix start cycles saturation
+syn keyword gnuplotKeyword	model RGB HSV CMY YIQ XYZ positive negative
+syn keyword gnuplotKeyword	nops_allcF ps_allcF maxcolors float int gradient
+syn keyword gnuplotKeyword	fit2rgbformulae rgbformulae
+" set pointintervalbox
+syn keyword gnuplotKeyword	pointintervalbox
+" set pointsize
+syn keyword gnuplotKeyword	pointsize
+" set polar
+syn keyword gnuplotKeyword	polar
+" set print
+syn keyword gnuplotKeyword	print append
+" set psdir
+syn keyword gnuplotKeyword	psdir
+" set raxis
+syn keyword gnuplotKeyword	raxis rrange rtics
+" set samples
+syn keyword gnuplotKeyword	samples
+" set size
+syn keyword gnuplotKeyword	size square nosquare ratio noratio
+" set style
+syn keyword gnuplotKeyword	style function data noborder rectangle arrow
+syn keyword gnuplotKeyword	default nohead head heads size filled empty
+syn keyword gnuplotKeyword	nofilled front back boxplot range fraction
+syn keyword gnuplotKeyword	outliers nooutliers pointtype candlesticks
+syn keyword gnuplotKeyword	separation labels off auto x x2 sorted unsorted
+syn keyword gnuplotKeyword	fill empty transparent solid pattern border
+syn keyword gnuplotKeyword	increment userstyles financebars line default
+syn keyword gnuplotKeyword	linetype lt linecolor lc linewidth lw pointtype
+syn keyword gnuplotKeyword	pt pointsize ps pointinterval pi palette circle
+syn keyword gnuplotKeyword	radius graph screen wedge nowedge ellipse size
+syn keyword gnuplotKeyword	units xx xy yy histogram line textbox opaque
+syn keyword gnuplotKeyword	border noborder
+" set surface
+syn keyword gnuplotKeyword	surface implicit explicit
+" set table
+syn keyword gnuplotKeyword	table
+" set terminal (list of terminals)
+syn keyword gnuplotKeyword	terminal term push pop aed512 aed767 aifm aqua
+syn keyword gnuplotKeyword	be cairo cairolatex canvas cgm context corel
+syn keyword gnuplotKeyword	debug dumb dxf dxy800a eepic emf emxvga epscairo
+syn keyword gnuplotKeyword	epslatex epson_180dpi excl fig ggi gif gpic hpgl
+syn keyword gnuplotKeyword	grass hp2623a hp2648 hp500c hpljii hppj imagen
+syn keyword gnuplotKeyword	jpeg kyo latex linux lua mf mif mp next openstep
+syn keyword gnuplotKeyword	pbm pdf pdfcairo pm png pngcairo postscript
+syn keyword gnuplotKeyword	pslatex pstex pstricks qms qt regis sun svg svga
+syn keyword gnuplotKeyword	tek40 tek410x texdraw tgif tikz tkcanvas tpic
+syn keyword gnuplotKeyword	vgagl vws vx384 windows wx wxt x11 xlib
+" keywords for 'set terminal'
+syn keyword gnuplotKeyword	color monochrome dashlength dl eps pdf fontscale
+syn keyword gnuplotKeyword	standalone blacktext colortext colourtext header
+syn keyword gnuplotKeyword	noheader mono color solid dashed notransparent
+syn keyword gnuplotKeyword	crop crop background input rounded butt square
+syn keyword gnuplotKeyword	size fsize standalone name jsdir defaultsize
+syn keyword gnuplotKeyword	timestamp notimestamp colour mitered beveled
+syn keyword gnuplotKeyword	round squared palfuncparam blacktext nec_cp6
+syn keyword gnuplotKeyword	mppoints inlineimages externalimages defaultfont
+syn keyword gnuplotKeyword	aspect feed nofeed rotate small tiny standalone
+syn keyword gnuplotKeyword	oldstyle newstyle level1 leveldefault level3
+syn keyword gnuplotKeyword	background nobackground solid clip noclip
+syn keyword gnuplotKeyword	colortext colourtext epson_60dpi epson_lx800
+syn keyword gnuplotKeyword	okidata starc tandy_60dpi dpu414 nec_cp6 draft
+syn keyword gnuplotKeyword	medium large normal landscape portrait big
+syn keyword gnuplotKeyword	inches pointsmax textspecial texthidden
+syn keyword gnuplotKeyword	thickness depth version acceleration giant
+syn keyword gnuplotKeyword	delay loop optimize nooptimize pspoints
+syn keyword gnuplotKeyword	FNT9X17 FNT13X25 interlace nointerlace courier
+syn keyword gnuplotKeyword	originreset nooriginreset gparrows nogparrows
+syn keyword gnuplotKeyword	picenvironment nopicenvironment tightboundingbox
+syn keyword gnuplotKeyword	notightboundingbox charsize gppoints nogppoints
+syn keyword gnuplotKeyword	fontscale textscale fulldoc nofulldoc standalone
+syn keyword gnuplotKeyword	preamble header tikzplot tikzarrows notikzarrows
+syn keyword gnuplotKeyword	cmykimages externalimages noexternalimages
+syn keyword gnuplotKeyword	polyline vectors magnification psnfss nopsnfss
+syn keyword gnuplotKeyword	psnfss-version7 prologues a4paper amstex fname
+syn keyword gnuplotKeyword	fsize server persist widelines interlace
+syn keyword gnuplotKeyword	truecolor notruecolor defaultplex simplex duplex
+syn keyword gnuplotKeyword	nofontfiles adobeglyphnames noadobeglyphnames
+syn keyword gnuplotKeyword	nostandalone metric textrigid animate nopspoints
+syn keyword gnuplotKeyword	hpdj FNT5X9 roman emtex rgbimages bitmap
+syn keyword gnuplotKeyword	nobitmap providevars nointerlace add delete
+syn keyword gnuplotKeyword	auxfile hacktext unit raise palfuncparam
+syn keyword gnuplotKeyword	noauxfile nohacktext nounit noraise ctrl noctrl
+syn keyword gnuplotKeyword	close widget fixed dynamic tek40xx vttek
+syn keyword gnuplotKeyword	kc-tek40xx km-tek40xx bitgraph perltk
+syn keyword gnuplotKeyword	interactive red green blue interpolate mode
+syn keyword gnuplotKeyword	position ctrlq replotonresize position noctrlq
+syn keyword gnuplotKeyword	noreplotonresize
+" set termoption
+syn keyword gnuplotKeyword	termoption font fontscale solid dashed
+" set tics
+syn keyword gnuplotKeyword	tics add axis border mirror nomirror in out
+syn keyword gnuplotKeyword	scale rotate norotate by offset nooffset left
+syn keyword gnuplotKeyword	autojustify format font textcolor right center
+" deprecated set ticslevel
+syn keyword gnuplotError	ticslevel ticscale
+" set timestamp
+syn keyword gnuplotKeyword	timestamp top bottom offset font
+" set timefmt
+syn keyword gnuplotKeyword	timefmt
+" set title
+syn keyword gnuplotKeyword	title offset font textcolor tc
+" set ranges
+syn keyword gnuplotKeyword	trange urange vrange
+" show variables
+syn keyword gnuplotKeyword	variables
+" show version
+syn keyword gnuplotKeyword	version
+" set view
+syn keyword gnuplotKeyword	view map equal noequal xy xyz
+" set x2data
+syn keyword gnuplotKeyword	xdata ydata zdata x2data y2data cbdata xdtics
+syn keyword gnuplotKeyword	ydtics zdtics x2dtics y2dtics cbdtics xzeroaxis
+syn keyword gnuplotKeyword	yzeroaxis zzeroaxis x2zeroaxis y2zeroaxis
+syn keyword gnuplotKeyword	cbzeroaxis time geographic
+" set label
+syn keyword gnuplotKeyword	xlabel ylabel zlabel x2label y2label cblabel
+syn keyword gnuplotKeyword	offset font textcolor by parallel
+" set range
+syn keyword gnuplotKeyword	xrange yrange zrange x2range y2range cbrange
+" set xyplane
+syn keyword gnuplotKeyword	xyplane
+" set zeroaxis
+" set zero
+syn keyword gnuplotKeyword	zero
+" set zeroaxis
+syn keyword gnuplotKeyword	zeroaxis
+
+" keywords for 'stats' command
+syn keyword gnuplotKeyword	nooutput
+
+" keywords for 'test' command
+syn keyword gnuplotKeyword	terminal palette rgb rbg grb gbr brg bgr
+
+" ---- Macros ---- "
+
+syn region gnuplotMacro		start="@" end=" "
+
+" ---- Todos ---- "
+
+syn keyword gnuplotTodo		contained TODO FIXME XXX
+
+" ---- Types: gnuplot commands ---- "
+
+" I set the commands as Types to distinguish them visually from keywords for the
+" commands.  This comes at the end of the syntax file because some commands
+" are redundant with keywords.  It's probably too much trouble to go and
+" create special regions for each redundant keyword/command pair, which means
+" that some keywords (e.g. 'p') will be highlighted as commands.
+
+syn keyword gnuplotStatement	cd call clear evaluate exit fit help history
+syn keyword gnuplotStatement	load lower pause plot p print pwd quit raise
+syn keyword gnuplotStatement	refresh replot rep reread reset save set show
+syn keyword gnuplotStatement	shell splot spstats system test undefine unset
+syn keyword gnuplotStatement	update
+
+" ---- Define the default highlighting ---- "
 " For version 5.7 and earlier: only when not done already
 " For version 5.8 and later: only when an item doesn't have highlighting yet
 if version >= 508 || !exists("did_gnuplot_syntax_inits")
@@ -181,14 +510,41 @@ if version >= 508 || !exists("did_gnuplot_syntax_inits")
     command -nargs=+ HiLink hi def link <args>
   endif
 
-  HiLink gnuplotStatement	Statement
-  HiLink gnuplotConditional	Conditional
+  " ---- Comments ---- "
+  HiLink gnuplotComment		Comment
+
+  " ---- Constants ---- "
+  HiLink gnuplotString		String
   HiLink gnuplotNumber		Number
   HiLink gnuplotFloat		Float
+
+  " ---- Identifiers ---- "
+  HiLink gnuplotIdentifier	Identifier
+
+  " ---- Statements ---- "
+  HiLink gnuplotConditional	Conditional
+  HiLink gnuplotRepeat		Repeat
+  HiLink gnuplotKeyword		Keyword
+  HiLink gnuplotOperator	Operator
+
+  " ---- PreProcs ---- "
+  HiLink gnuplotMacro		Macro
+
+  " ---- Types ---- "
+  HiLink gnuplotStatement	Type
+  HiLink gnuplotFunc		Identifier
+
+  " ---- Specials ---- "
+  HiLink gnuplotSpecial		Special
+  HiLink gnuplotUnit		Special
+  HiLink gnuplotExternal	Special
+
+  " ---- Errors ---- "
+  HiLink gnuplotError		Error
   HiLink gnuplotOctalError	Error
-  HiLink gnuplotFunc		Type
-  HiLink gnuplotType		Type
-  HiLink gnuplotComment	Comment
+
+  " ---- Todos ---- "
+  HiLink gnuplotTodo		Todo
 
   delcommand HiLink
 endif

--- a/runtime/syntax/go.vim
+++ b/runtime/syntax/go.vim
@@ -1,0 +1,208 @@
+" Vim syntax file
+" Language:	Go
+" Maintainer:	David Barnett (https://github.com/google/vim-ft-go)
+" Last Change:	2014 Aug 16
+
+" Options:
+"   There are some options for customizing the highlighting; the recommended
+"   settings are the default values, but you can write:
+"     let OPTION_NAME = 0
+"   in your ~/.vimrc file to disable particular options. You can also write:
+"     let OPTION_NAME = 1
+"   to enable particular options. At present, all options default to on.
+"
+"   - g:go_highlight_array_whitespace_error
+"     Highlights white space after "[]".
+"   - g:go_highlight_chan_whitespace_error
+"     Highlights white space around the communications operator that don't
+"     follow the standard style.
+"   - g:go_highlight_extra_types
+"     Highlights commonly used library types (io.Reader, etc.).
+"   - g:go_highlight_space_tab_error
+"     Highlights instances of tabs following spaces.
+"   - g:go_highlight_trailing_whitespace_error
+"     Highlights trailing white space.
+
+" Quit when a (custom) syntax file was already loaded
+if exists('b:current_syntax')
+  finish
+endif
+
+if !exists('g:go_highlight_array_whitespace_error')
+  let g:go_highlight_array_whitespace_error = 1
+endif
+if !exists('g:go_highlight_chan_whitespace_error')
+  let g:go_highlight_chan_whitespace_error = 1
+endif
+if !exists('g:go_highlight_extra_types')
+  let g:go_highlight_extra_types = 1
+endif
+if !exists('g:go_highlight_space_tab_error')
+  let g:go_highlight_space_tab_error = 1
+endif
+if !exists('g:go_highlight_trailing_whitespace_error')
+  let g:go_highlight_trailing_whitespace_error = 1
+endif
+
+syn case match
+
+syn keyword     goDirective         package import
+syn keyword     goDeclaration       var const type
+syn keyword     goDeclType          struct interface
+
+hi def link     goDirective         Statement
+hi def link     goDeclaration       Keyword
+hi def link     goDeclType          Keyword
+
+" Keywords within functions
+syn keyword     goStatement         defer go goto return break continue fallthrough
+syn keyword     goConditional       if else switch select
+syn keyword     goLabel             case default
+syn keyword     goRepeat            for range
+
+hi def link     goStatement         Statement
+hi def link     goConditional       Conditional
+hi def link     goLabel             Label
+hi def link     goRepeat            Repeat
+
+" Predefined types
+syn keyword     goType              chan map bool string error
+syn keyword     goSignedInts        int int8 int16 int32 int64 rune
+syn keyword     goUnsignedInts      byte uint uint8 uint16 uint32 uint64 uintptr
+syn keyword     goFloats            float32 float64
+syn keyword     goComplexes         complex64 complex128
+
+hi def link     goType              Type
+hi def link     goSignedInts        Type
+hi def link     goUnsignedInts      Type
+hi def link     goFloats            Type
+hi def link     goComplexes         Type
+
+" Treat func specially: it's a declaration at the start of a line, but a type
+" elsewhere. Order matters here.
+syn match       goType              /\<func\>/
+syn match       goDeclaration       /^func\>/
+
+" Predefined functions and values
+syn keyword     goBuiltins          append cap close complex copy delete imag len
+syn keyword     goBuiltins          make new panic print println real recover
+syn keyword     goConstants         iota true false nil
+
+hi def link     goBuiltins          Keyword
+hi def link     goConstants         Keyword
+
+" Comments; their contents
+syn keyword     goTodo              contained TODO FIXME XXX BUG
+syn cluster     goCommentGroup      contains=goTodo
+syn region      goComment           start="/\*" end="\*/" contains=@goCommentGroup,@Spell
+syn region      goComment           start="//" end="$" contains=@goCommentGroup,@Spell
+
+hi def link     goComment           Comment
+hi def link     goTodo              Todo
+
+" Go escapes
+syn match       goEscapeOctal       display contained "\\[0-7]\{3}"
+syn match       goEscapeC           display contained +\\[abfnrtv\\'"]+
+syn match       goEscapeX           display contained "\\x\x\{2}"
+syn match       goEscapeU           display contained "\\u\x\{4}"
+syn match       goEscapeBigU        display contained "\\U\x\{8}"
+syn match       goEscapeError       display contained +\\[^0-7xuUabfnrtv\\'"]+
+
+hi def link     goEscapeOctal       goSpecialString
+hi def link     goEscapeC           goSpecialString
+hi def link     goEscapeX           goSpecialString
+hi def link     goEscapeU           goSpecialString
+hi def link     goEscapeBigU        goSpecialString
+hi def link     goSpecialString     Special
+hi def link     goEscapeError       Error
+
+" Strings and their contents
+syn cluster     goStringGroup       contains=goEscapeOctal,goEscapeC,goEscapeX,goEscapeU,goEscapeBigU,goEscapeError
+syn region      goString            start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@goStringGroup
+syn region      goRawString         start=+`+ end=+`+
+
+hi def link     goString            String
+hi def link     goRawString         String
+
+" Characters; their contents
+syn cluster     goCharacterGroup    contains=goEscapeOctal,goEscapeC,goEscapeX,goEscapeU,goEscapeBigU
+syn region      goCharacter         start=+'+ skip=+\\\\\|\\'+ end=+'+ contains=@goCharacterGroup
+
+hi def link     goCharacter         Character
+
+" Regions
+syn region      goBlock             start="{" end="}" transparent fold
+syn region      goParen             start='(' end=')' transparent
+
+" Integers
+syn match       goDecimalInt        "\<\d\+\([Ee]\d\+\)\?\>"
+syn match       goHexadecimalInt    "\<0x\x\+\>"
+syn match       goOctalInt          "\<0\o\+\>"
+syn match       goOctalError        "\<0\o*[89]\d*\>"
+
+hi def link     goDecimalInt        Integer
+hi def link     goHexadecimalInt    Integer
+hi def link     goOctalInt          Integer
+hi def link     Integer             Number
+
+" Floating point
+syn match       goFloat             "\<\d\+\.\d*\([Ee][-+]\d\+\)\?\>"
+syn match       goFloat             "\<\.\d\+\([Ee][-+]\d\+\)\?\>"
+syn match       goFloat             "\<\d\+[Ee][-+]\d\+\>"
+
+hi def link     goFloat             Float
+
+" Imaginary literals
+syn match       goImaginary         "\<\d\+i\>"
+syn match       goImaginary         "\<\d\+\.\d*\([Ee][-+]\d\+\)\?i\>"
+syn match       goImaginary         "\<\.\d\+\([Ee][-+]\d\+\)\?i\>"
+syn match       goImaginary         "\<\d\+[Ee][-+]\d\+i\>"
+
+hi def link     goImaginary         Number
+
+" Spaces after "[]"
+if go_highlight_array_whitespace_error != 0
+  syn match goSpaceError display "\(\[\]\)\@<=\s\+"
+endif
+
+" Spacing errors around the 'chan' keyword
+if go_highlight_chan_whitespace_error != 0
+  " receive-only annotation on chan type
+  syn match goSpaceError display "\(<-\)\@<=\s\+\(chan\>\)\@="
+  " send-only annotation on chan type
+  syn match goSpaceError display "\(\<chan\)\@<=\s\+\(<-\)\@="
+  " value-ignoring receives in a few contexts
+  syn match goSpaceError display "\(\(^\|[={(,;]\)\s*<-\)\@<=\s\+"
+endif
+
+" Extra types commonly seen
+if go_highlight_extra_types != 0
+  syn match goExtraType /\<bytes\.\(Buffer\)\>/
+  syn match goExtraType /\<io\.\(Reader\|Writer\|ReadWriter\|ReadWriteCloser\)\>/
+  syn match goExtraType /\<reflect\.\(Kind\|Type\|Value\)\>/
+  syn match goExtraType /\<unsafe\.Pointer\>/
+endif
+
+" Space-tab error
+if go_highlight_space_tab_error != 0
+  syn match goSpaceError display " \+\t"me=e-1
+endif
+
+" Trailing white space error
+if go_highlight_trailing_whitespace_error != 0
+  syn match goSpaceError display excludenl "\s\+$"
+endif
+
+hi def link     goExtraType         Type
+hi def link     goSpaceError        Error
+
+" Search backwards for a global declaration to start processing the syntax.
+"syn sync match goSync grouphere NONE /^\(const\|var\|type\|func\)\>/
+
+" There's a bug in the implementation of grouphere. For now, use the
+" following as a more expensive/less precise workaround.
+syn sync minlines=500
+
+let b:current_syntax = 'go'
+
+" vim: sw=2 sts=2 et

--- a/runtime/syntax/godoc.vim
+++ b/runtime/syntax/godoc.vim
@@ -1,0 +1,21 @@
+" Vim syntax file
+" Language:	Godoc (generated documentation for go)
+" Maintainer:	David Barnett (https://github.com/google/vim-ft-go)
+" Last Change:	2014 Aug 16
+
+if exists('b:current_syntax')
+  finish
+endif
+
+syn case match
+syn match godocTitle "^\([A-Z][A-Z ]*\)$"
+
+command -nargs=+ HiLink hi def link <args>
+
+HiLink godocTitle Title
+
+delcommand HiLink
+
+let b:current_syntax = 'godoc'
+
+" vim: sw=2 sts=2 et

--- a/runtime/syntax/json.vim
+++ b/runtime/syntax/json.vim
@@ -1,16 +1,143 @@
 " Vim syntax file
-" Language:		JSON
-" Maintainer:		David Barnett <daviebdawg+vim@gmail.com>
-" Last Change:		2014 Jul 16
+" Language:	JSON
+" Maintainer:	Eli Parra <eli@elzr.com>
+" Last Change:	2014 Aug 23
+" Version:      0.12
 
-" For version 5.x: Clear all syntax items.
-" For version 6.x and later: Quit when a syntax file was already loaded.
-if exists('b:current_syntax')
-  finish
+if !exists("main_syntax")
+  if version < 600
+    syntax clear
+  elseif exists("b:current_syntax")
+    finish
+  endif
+  let main_syntax = 'json'
 endif
 
-" Use JavaScript syntax. JSON is a subset of JavaScript.
-runtime! syntax/javascript.vim
-unlet b:current_syntax
+syntax match   jsonNoise           /\%(:\|,\)/
 
-let b:current_syntax = 'json'
+" NOTE that for the concealing to work your conceallevel should be set to 2
+
+" Syntax: Strings
+" Separated into a match and region because a region by itself is always greedy
+syn match  jsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
+if has('conceal')
+	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ concealends contains=jsonEscape contained
+else
+	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ contains=jsonEscape contained
+endif
+
+" Syntax: JSON does not allow strings with single quotes, unlike JavaScript.
+syn region  jsonStringSQError oneline  start=+'+  skip=+\\\\\|\\"+  end=+'+
+
+" Syntax: JSON Keywords
+" Separated into a match and region because a region by itself is always greedy
+syn match  jsonKeywordMatch /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
+if has('conceal')
+   syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ concealends contained
+else
+   syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contained
+endif
+
+" Syntax: Escape sequences
+syn match   jsonEscape    "\\["\\/bfnrt]" contained
+syn match   jsonEscape    "\\u\x\{4}" contained
+
+" Syntax: Numbers
+syn match   jsonNumber    "-\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+\)\=\>\ze[[:blank:]\r\n]*[,}\]]"
+
+" ERROR WARNINGS **********************************************
+if (!exists("g:vim_json_warnings") || g:vim_json_warnings==1)
+	" Syntax: Strings should always be enclosed with quotes.
+	syn match   jsonNoQuotesError  "\<[[:alpha:]][[:alnum:]]*\>"
+	syn match   jsonTripleQuotesError  /"""/
+
+	" Syntax: An integer part of 0 followed by other digits is not allowed.
+	syn match   jsonNumError  "-\=\<0\d\.\d*\>"
+
+	" Syntax: Decimals smaller than one should begin with 0 (so .1 should be 0.1).
+	syn match   jsonNumError  "\:\@<=[[:blank:]\r\n]*\zs\.\d\+"
+
+	" Syntax: No comments in JSON, see http://stackoverflow.com/questions/244777/can-i-comment-a-json-file
+	syn match   jsonCommentError  "//.*"
+	syn match   jsonCommentError  "\(/\*\)\|\(\*/\)"
+
+	" Syntax: No semicolons in JSON
+	syn match   jsonSemicolonError  ";"
+
+	" Syntax: No trailing comma after the last element of arrays or objects
+	syn match   jsonTrailingCommaError  ",\_s*[}\]]"
+
+	" Syntax: Watch out for missing commas between elements
+	syn match   jsonMissingCommaError /\("\|\]\|\d\)\zs\_s\+\ze"/
+	syn match   jsonMissingCommaError /\(\]\|\}\)\_s\+\ze"/ "arrays/objects as values
+	syn match   jsonMissingCommaError /}\_s\+\ze{/ "objects as elements in an array
+	syn match   jsonMissingCommaError /\(true\|false\)\_s\+\ze"/ "true/false as value
+endif
+
+" ********************************************** END OF ERROR WARNINGS
+" Allowances for JSONP: function call at the beginning of the file,
+" parenthesis and semicolon at the end.
+" Function name validation based on
+" http://stackoverflow.com/questions/2008279/validate-a-javascript-function-name/2008444#2008444
+syn match  jsonPadding "\%^[[:blank:]\r\n]*[_$[:alpha:]][_$[:alnum:]]*[[:blank:]\r\n]*("
+syn match  jsonPadding ");[[:blank:]\r\n]*\%$"
+
+" Syntax: Boolean
+syn match  jsonBoolean /\(true\|false\)\(\_s\+\ze"\)\@!/
+
+" Syntax: Null
+syn keyword  jsonNull      null
+
+" Syntax: Braces
+syn region  jsonFold matchgroup=jsonBraces start="{" end=/}\(\_s\+\ze\("\|{\)\)\@!/ transparent fold
+syn region  jsonFold matchgroup=jsonBraces start="\[" end=/]\(\_s\+\ze"\)\@!/ transparent fold
+
+" Define the default highlighting.
+" For version 5.7 and earlier: only when not done already
+" For version 5.8 and later: only when an item doesn't have highlighting yet
+if version >= 508 || !exists("did_json_syn_inits")
+  if version < 508
+    let did_json_syn_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+  HiLink jsonPadding         Operator
+  HiLink jsonString          String
+  HiLink jsonTest          Label
+  HiLink jsonEscape          Special
+  HiLink jsonNumber          Number
+  HiLink jsonBraces          Delimiter
+  HiLink jsonNull            Function
+  HiLink jsonBoolean         Boolean
+  HiLink jsonKeyword         Label
+
+	if (!exists("g:vim_json_warnings") || g:vim_json_warnings==1)
+	  HiLink jsonNumError        Error
+	  HiLink jsonCommentError    Error
+	  HiLink jsonSemicolonError  Error
+	  HiLink jsonTrailingCommaError     Error
+	  HiLink jsonMissingCommaError      Error
+	  HiLink jsonStringSQError        	Error
+	  HiLink jsonNoQuotesError        	Error
+	  HiLink jsonTripleQuotesError     	Error
+  endif
+  HiLink jsonQuote           Quote
+  HiLink jsonNoise           Noise
+  delcommand HiLink
+endif
+
+let b:current_syntax = "json"
+if main_syntax == 'json'
+  unlet main_syntax
+endif
+
+" Vim settings
+" vim: ts=8 fdm=marker
+
+" MIT License
+" Copyright (c) 2013, Jeroen Ruigrok van der Werven, Eli Parra
+"Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the Software), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+"The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+"THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"See https://twitter.com/elzr/status/294964017926119424

--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:         reStructuredText documentation format
-" Maintainer:       Nikolai Weibull <now@bitwi.se>
-" Latest Revision:  2013-11-26
+" Maintainer:       Marshall Ward <marshall.ward@gmail.com>
+" Previous Maintainer: Nikolai Weibull <now@bitwi.se>
+" Latest Revision:  2014-08-23
 
 if exists("b:current_syntax")
   finish
@@ -47,7 +48,7 @@ syn match   rstSimpleTableLines     contained display
 syn cluster rstDirectives           contains=rstFootnote,rstCitation,
       \ rstHyperlinkTarget,rstExDirective
 
-syn match   rstExplicitMarkup       '^\.\.\_s'
+syn match   rstExplicitMarkup       '^\s*\.\.\_s'
       \ nextgroup=@rstDirectives,rstComment,rstSubstitutionDefinition
 
 let s:ReferenceName = '[[:alnum:]]\+\%([_.-][[:alnum:]]\+\)*'
@@ -99,11 +100,11 @@ function! s:DefineInlineMarkup(name, start, middle, end)
         \ ""
 
   call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, "'", "'")
-  call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, '"', '"') 
-  call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, '(', ')') 
-  call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, '\[', '\]') 
-  call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, '{', '}') 
-  call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, '<', '>') 
+  call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, '"', '"')
+  call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, '(', ')')
+  call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, '\[', '\]')
+  call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, '{', '}')
+  call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, '<', '>')
 
   call s:DefineOneInlineMarkup(a:name, a:start, middle, a:end, '\%(^\|\s\|[/:]\)', '')
 
@@ -136,23 +137,24 @@ syn match   rstStandaloneHyperlink  contains=@NoSpell
       \ "\<\%(\%(\%(https\=\|file\|ftp\|gopher\)://\|\%(mailto\|news\):\)[^[:space:]'\"<>]\+\|www[[:alnum:]_-]*\.[[:alnum:]_-]\+\.[^[:space:]'\"<>]\+\)[[:alnum:]/]"
 
 syn region rstCodeBlock contained matchgroup=rstDirective
-      \ start=+\%(sourcecode\|code\%(-block\)\=\)::\s+
+      \ start=+\%(sourcecode\|code\%(-block\)\=\)::\_s*\n\ze\z(\s\+\)+
       \ skip=+^$+
-      \ end=+^\s\@!+ 
+      \ end=+^\z1\@!+
       \ contains=@NoSpell
 syn cluster rstDirectives add=rstCodeBlock
 
 if !exists('g:rst_syntax_code_list')
-    let g:rst_syntax_code_list = ['vim', 'java', 'cpp', 'lisp', 'php', 'python', 'perl']
+    let g:rst_syntax_code_list = ['vim', 'java', 'cpp', 'lisp', 'php',
+                                \ 'python', 'perl', 'sh']
 endif
 
 for code in g:rst_syntax_code_list
     unlet! b:current_syntax
     exe 'syn include @rst'.code.' syntax/'.code.'.vim'
     exe 'syn region rstDirective'.code.' matchgroup=rstDirective fold '
-                \.'start=#\%(sourcecode\|code\%(-block\)\=\)::\s\+'.code.'\s*$# '
+                \.'start=#\%(sourcecode\|code\%(-block\)\=\)::\s\+'.code.'\_s*\n\ze\z(\s\+\)# '
                 \.'skip=#^$# '
-                \.'end=#^\s\@!# contains=@NoSpell,@rst'.code.' keepend'
+                \.'end=#^\z1\@!# contains=@NoSpell,@rst'.code
     exe 'syn cluster rstDirectives add=rstDirective'.code
 endfor
 

--- a/runtime/syntax/vroom.vim
+++ b/runtime/syntax/vroom.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language:	Vroom (vim testing and executable documentation)
-" Maintainer:	David Barnett (https://github.com/google/vim-ft.vroom)
+" Maintainer:	David Barnett (https://github.com/google/vim-ft-vroom)
 " Last Change:	2014 Jul 23
 
 " For version 5.x: Clear all syntax items.


### PR DESCRIPTION
On top of #1744.

Patch output:

```
patching file runtime/doc/autocmd.txt
patching file runtime/doc/tags
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file runtime/doc/tags.rej
patching file runtime/doc/todo.txt
Hunk #3 succeeded at 258 with fuzz 2 (offset -3 lines).
patching file runtime/filetype.vim
Hunk #2 succeeded at 1007 (offset -4 lines).
patching file runtime/indent/html.vim
patching file runtime/syntax/json.vim
patching file runtime/syntax/rst.vim
```

So no manual changes, only a conflict with `runtime/doc/tags` (which is not in Neovim's repo anyway).
