### PR TITLE
Added legacy test 001

### DIFF
--- a/test/functional/legacy/001_script_test_spec.lua
+++ b/test/functional/legacy/001_script_test_spec.lua
@@ -1,0 +1,33 @@
+-- First a simple test to check if the test script works.
+
+local helpers = require('test.functional.helpers')
+local feed, insert, source = helpers.feed, helpers.insert, helpers.source
+local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
+local eval = helpers.eval
+
+describe('test script', function()
+  setup(clear)
+
+  it('is working', function()
+    -- Write a single line to test.out to check if testing works at all.
+    execute('%d')
+    feed('athis is a test<esc>')
+
+    -- Assert buffer contents.
+    expect([[
+      this is a test]])
+  end)
+end)
+
+describe('term size', function()
+  setup(clear)
+
+  it('is greater than 80x24', function()
+    -- (Some tests will fail. When columns and/or lines are small).
+    local lines = eval('&lines')
+    local columns = eval('&columns')
+    assert.False( lines < 24 )
+    assert.False( columns < 80 )
+  end)
+end)
+

--- a/test/functional/legacy/001_script_test_spec.lua
+++ b/test/functional/legacy/001_script_test_spec.lua
@@ -9,7 +9,7 @@ describe('test script', function()
   setup(clear)
 
   it('is working', function()
-    -- Write a single line to test.out to check if testing works at all.
+    -- Insert a single line to check if testing works at all.
     execute('%d')
     feed('athis is a test<esc>')
 
@@ -22,12 +22,12 @@ end)
 describe('term size', function()
   setup(clear)
 
-  it('is greater than 80x24', function()
-    -- (Some tests will fail. When columns and/or lines are small).
+  it('at least 80x24', function()
+    -- (Some tests will fail when columns and/or lines are small).
     local lines = eval('&lines')
     local columns = eval('&columns')
-    assert.False( lines < 24 )
-    assert.False( columns < 80 )
+    assert.True( lines >= 24 )
+    assert.True( columns >= 80 )
   end)
 end)
 


### PR DESCRIPTION
Because Neovim always ships with all features the small.vim, tiny.vim, mbyte.vim, mzscheme.vim, and lua.vim files are not applicable. It is also useless to create 'wrontermsize' since the existence of this file was checked by the legacy test makefile. Instead a minimum terminal size assert is performed.
