### PR TITLE
[RFC] vim-patch:6921742,  vim-patch:37c2403 (runtime updates)

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1,4 +1,4 @@
-*cmdline.txt*   For Vim version 7.4.  Last change: 2014 Aug 16
+*cmdline.txt*   For Vim version 7.4.  Last change: 2014 Sep 06
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -56,7 +56,7 @@ history tables:
 These are completely separate.  Each history can only be accessed when
 entering the same type of line.
 Use the 'history' option to set the number of lines that are remembered
-(default: 20).
+(default: 50).
 Notes:
 - When you enter a command-line that is exactly the same as an older one, the
   old one is removed (to avoid repeated commands moving older commands out of

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 7.4.  Last change: 2014 Aug 16
+*eval.txt*	For Vim version 7.4.  Last change: 2014 Aug 29
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1102,9 +1102,9 @@ are known inside the current Vim session.  Using expand() will first try using
 the environment variables known inside the current Vim session.  If that
 fails, a shell will be used to expand the variable.  This can be slow, but it
 does expand all variables that the shell knows about.  Example: >
-	:echo $version
-	:echo expand("$version")
-The first one probably doesn't echo anything, the second echoes the $version
+	:echo $shell
+	:echo expand("$shell")
+The first one probably doesn't echo anything, the second echoes the $shell
 variable (if your shell supports it).
 
 
@@ -2632,7 +2632,7 @@ cursor({list})
 		line.
 		If {col} is zero, the cursor will stay in the current column.
 		If {curswant} is given it is used to set the preferred column
-		for vertical movment.  Otherwise {col} is used.
+		for vertical movement.  Otherwise {col} is used.
 		When 'virtualedit' is used {off} specifies the offset in
 		screen columns from the start of the character.  E.g., a
 		position within a <Tab> or after the last character.
@@ -2923,7 +2923,8 @@ expand({expr} [, {nosuf} [, {list}]])				*expand()*
 <
 		Expand() can also be used to expand variables and environment
 		variables that are only known in a shell.  But this can be
-		slow, because a shell must be started.	See |expr-env-expand|.
+		slow, because a shell may be used to do the expansion.  See
+		|expr-env-expand|.
 		The expanded variable is still handled like a list of file
 		names.	When an environment variable cannot be expanded, it is
 		left unchanged.  Thus ":echo expand('$FOOBAR')" results in
@@ -5558,7 +5559,7 @@ setreg({regname}, {value} [,{options}])
 		Returns zero for success, non-zero for failure.
 
 							*E883*
-		Note: you may not use |List| containing more then one item to 
+		Note: you may not use |List| containing more than one item to 
 		      set search and expression registers. Lists containing no 
 		      items act like empty strings.
 
@@ -5707,7 +5708,7 @@ sort({list} [, {func} [, {dict}]])			*sort()* *E702*
 		after Strings, |Lists| after Numbers.  For sorting text in the
 		current buffer use |:sort|.
 
-		When {func} is given and it is is '1' or 'i' then case is
+		When {func} is given and it is '1' or 'i' then case is
 		ignored.
 		
 		When {func} is given and it is 'n' then all items will be

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 7.4.  Last change: 2014 Aug 29
+*eval.txt*	For Vim version 7.4.  Last change: 2014 Sep 09
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -3356,6 +3356,7 @@ getcmdtype()						*getcmdtype()*
 		    ?	backward search command
 		    @	|input()| command
 		    -	|:insert| or |:append| command
+		    =	|i_CTRL-R_=|
 		Only works when editing the command line, thus requires use of
 		|c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
 		Returns an empty string otherwise.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 7.4.  Last change: 2014 Aug 09
+*options.txt*	For Vim version 7.4.  Last change: 2014 Sep 09
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -3300,7 +3300,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	NOTE: This option is reset when 'compatible' is set.
 
 						*'grepformat'* *'gfm'*
-'grepformat' 'gfm'	string	(default "%f:%l%m,%f  %l%m")
+'grepformat' 'gfm'	string	(default "%f:%l:%m,%f:%l%m,%f  %l%m")
 			global
 			{not in Vi}
 	Format to recognize for the ":grep" command output.
@@ -7601,6 +7601,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			fold options
 	   options	options and mappings local to a window or buffer (not
 			global values for local options)
+	   localoptions same as "options"
 	   slash	backslashes in file names replaced with forward
 			slashes
 	   unix		with Unix end-of-line format (single <NL>), even when

--- a/runtime/doc/os_win32.txt
+++ b/runtime/doc/os_win32.txt
@@ -1,4 +1,4 @@
-*os_win32.txt*  For Vim version 7.4.  Last change: 2012 May 18
+*os_win32.txt*  For Vim version 7.4.  Last change: 2014 Aug 29
 
 
 		  VIM REFERENCE MANUAL    by George Reilly

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1,4 +1,4 @@
-*pattern.txt*   For Vim version 7.4.  Last change: 2014 Jul 30
+*pattern.txt*   For Vim version 7.4.  Last change: 2014 Aug 29
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -829,6 +829,7 @@ $	At end of pattern or in front of "\|", "\)" or "\n" ('magic' on):
 	branch is used.  Example: >
 		/\(.\{-}\zsFab\)\{3}
 <	Finds the third occurrence of "Fab".
+	This cannot be followed by a multi. *E888*
 	{not in Vi} {not available when compiled without the |+syntax| feature}
 							*/\ze*
 \ze	Matches at any position, and sets the end of the match there: The
@@ -837,6 +838,7 @@ $	At end of pattern or in front of "\|", "\)" or "\n" ('magic' on):
 	branch is used.
 	Example: "end\ze\(if\|for\)" matches the "end" in "endif" and
 	"endfor".
+	This cannot be followed by a multi. *E888*
 	{not in Vi} {not available when compiled without the |+syntax| feature}
 
 						*/\%^* *start-of-file*

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1,4 +1,4 @@
-*pattern.txt*   For Vim version 7.4.  Last change: 2014 Aug 29
+*pattern.txt*   For Vim version 7.4.  Last change: 2014 Sep 06
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -838,7 +838,7 @@ $	At end of pattern or in front of "\|", "\)" or "\n" ('magic' on):
 	branch is used.
 	Example: "end\ze\(if\|for\)" matches the "end" in "endif" and
 	"endfor".
-	This cannot be followed by a multi. *E888*
+	This cannot be followed by a multi. |E888|
 	{not in Vi} {not available when compiled without the |+syntax| feature}
 
 						*/\%^* *start-of-file*

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 7.4.  Last change: 2014 Aug 29
+*syntax.txt*	For Vim version 7.4.  Last change: 2014 Sep 09
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2975,6 +2975,7 @@ TEX				*tex.vim* *ft-tex-syntax* *latex-syntax*
 	Tex: Taking Advantage of Conceal Mode		|tex-conceal|
 	Tex: Selective Conceal Mode			|g:tex_conceal|
 	Tex: Controlling iskeyword			|g:tex_isk|
+	Tex: Fine Subscript and Superscript Control	|tex-supersub|
 
 				*tex-folding* *g:tex_fold_enabled*
  Tex: Want Syntax Folding? ~
@@ -3068,6 +3069,7 @@ selectively to enable just some syntax highlighting: >
 <
 As an example, let g:tex_fast= "M" will allow math-associated highlighting
 but suppress all the other region-based syntax highlighting.
+(also see: |g:tex_conceal| and |tex-supersub|)
 
 					*tex-morecommands* *tex-package*
  Tex: Want To Highlight More Commands? ~
@@ -3168,6 +3170,28 @@ syntax highlighting script handles this with the following logic:
 
 	* If g:tex_isk exists, then it will be used for the local 'iskeyword'
 	* Else the local 'iskeyword' will be set to 48-57,a-z,A-Z,192-255
+
+			*tex-supersub* *g:tex_superscripts* *g:tex_subscripts*
+ Tex: Fine Subscript and Superscript Control~
+
+	See |tex-conceal| for how to enable concealed character replacement.
+
+	See |g:tex_conceal| for selectively concealing accents, bold/italic,
+	math, Greek, and superscripts/subscripts.
+
+	One may exert fine control over which superscripts and subscripts one
+	wants syntax-based concealment for (see |:syn-cchar|).  Since not all
+	fonts support all characters, one may override the
+	concealed-replacement lists; by default these lists are given by: >
+
+	    let g:tex_superscripts= "[0-9a-zA-W.,:;+-<>/()=]"
+	    let g:tex_subscripts= "[0-9aehijklmnoprstuvx,+-/().]"
+<
+	For example, I use Luxi Mono Bold; it doesn't support subscript
+	characters for "hklmnpst", so I put >
+		let g:tex_subscripts= "[0-9aeijoruvx,+-/().]"
+<	in ~/.vim/ftplugin/tex/tex.vim in order to avoid having inscrutable
+	utf-8 glyphs appear.
 
 
 TF						*tf.vim* *ft-tf-syntax*

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 7.4.  Last change: 2014 Jun 27
+*syntax.txt*	For Vim version 7.4.  Last change: 2014 Aug 29
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -501,7 +501,7 @@ inserted for that purpose if no line numbers are shown. This ID attribute
 takes the form of L123 for single-buffer HTML pages, or W2L123 for diff-view
 pages, and is used to jump to a specific line (in a specific window of a diff
 view). Javascript is inserted to open any closed dynamic folds
-(|g:html_dynamic_folds|) containing the specificed line before jumping. The
+(|g:html_dynamic_folds|) containing the specified line before jumping. The
 javascript also allows omitting the window ID in the url, and the leading L.
 For example: >
 

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 7.4.  Last change: 2014 Aug 23
+*todo.txt*      For Vim version 7.4.  Last change: 2014 Aug 29
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -58,14 +58,8 @@ Patch to make getregtype() return the right size for non-linux systems.
 (Yasuhiro Matsumoto, 2014 Jul 8)
 Breaks test_eval.  Inefficient, can we only compute y_width when needed?
 
-Patch to fix a problem with breakindent. (Christian Brabandt, 2014 Aug 17)
-It's actually not a breakindent problem. With test: Aug 19.
-With renamed test: Aug 20
-
 Problem that a previous silent ":throw" causes a following try/catch not to
 work. (ZyX, 2013 Sep 28)
-
-ml_get error when using Python, issue 248.
 
 Patch to fix typos in help files. (Dominique, 2014 Aug 9)
 
@@ -75,10 +69,20 @@ Related to setting TMODE_COOK.  Perhaps we can omit that for system()?
 
 Update for Romanian spell file. (Vanilla Ice, 2014 Aug 13)
 
+exepath() may return the wrong value.  Patch by Yasuhiro Matsumoto, 2014 Aug
+26.
+
+Win32: use different args for SearchPath()? (Yasuhiro Matsumoto, 2009 Jan 30)
+Also fixes wrong result from executable().
+Update from Ken Takata, 2014 Jan 10. Newer 2014 Apr 3.
+
 Patch to remove ETO_IGNORELANGUAGE, it causes Chinese characters not to show
 up. (Paul Moore, 2014 Jul 30)
 Should it depend on the Windows version?  Waiting for feedback.
 No longer needed after including DirectX patch?
+
+Fix for ":set all&" not taking care of side effect. (Yukihiro Nakadaira, 2014
+Aug 28)
 
 Patch by Marcin Szamotulski to add count to :close (2014 Aug 10, update Aug
 14)
@@ -104,6 +108,8 @@ Completion for :buf does not use 'wildignorecase'. (Akshay H, 2014 May 31)
 Patch to handle list with some items locked. (ZyX, 2014 Aug 17)
 Prefer the second solution.
 
+Issue 252.  Patch by Christian, 2014 Aug 26.
+
 ":cd C:\Windows\System32\drivers\etc*" does not work, even though the
 directory exists. (Sergio Gallelli, 2013 Dec 29)
 
@@ -118,7 +124,7 @@ Problem using ":try" inside ":execute". (ZyX, 2013 Sep 15)
 Python: ":py raw_input('prompt')" doesn't work. (Manu Hack)
 
 Value returned by virtcol() changes depending on how lines wrap.  This is
-inconsistant with the documentation.
+inconsistent with the documentation.
 
 MS-Windows: Crash opening very long file name starting with "\\".
 (Christian Brock, 2012 Jun 29)
@@ -141,20 +147,18 @@ Spell files use a latin single quote. Unicode also has another single quote:
 New OpenOffice spell files support this with ICONV.  But they are not
 compatible with Vim spell files.  The old files can no longer be downloaded.
 
-Win32: use different args for SearchPath()? (Yasuhiro Matsumoto, 2009 Jan 30)
-Also fixes wrong result from executable().
-Update from Ken Takata, 2014 Jan 10. Newer 2014 Apr 3.
-
 Win32: patch to use 64 bit stat() if possible. (Ken Takata, 2014 May 12)
 More tests May 14. Update May 29.  Update Aug 10.
 
 The garbage collector may use too much stack.  Make set_ref_in_item()
 iterative instead of recursive.   Test program by Marc Weber (2013 Dec 10)
 Patch by Ben Fritz, 2014 Jun 22.
+Related: Vim hangs when freeing a lot of objects.  Patch by Yasuhiro
+Matsumoto, 2014 Aug 26.
 
 Idea: For a window in the middle (has window above and below it), use
 right-mouse-drag on the status line to move a window up/down without changing
-it's height?  It's like dragging the status bar above it at the same time.
+its height?  It's like dragging the status bar above it at the same time.
 
 Can we make ":unlet $VAR" use unsetenv() to delete the env var?
 What for systems that don't have unsetenv()?
@@ -236,7 +240,7 @@ Or should we add a more general mechanism, like lambda functions?
 Patch for XDG base directory support. (Jean François Bignolles, 2014 Mar 4)
 Remark on the docs.  Should not be a compile time feature.  But then what?
 
-Completion of ":e" is ":earlier", whould be ":edit".  Complete to the matching
+Completion of ":e" is ":earlier", should be ":edit".  Complete to the matching
 command instead of doing this alphabetically. (Mikel Jorgensen)
 
 Patch to add v:completed_item. (Shougo Matsu, 2013 Nov 29).
@@ -1437,8 +1441,8 @@ files with "foo/**" in 'path'.  (Kalisiak, 2006 July 15)
 Additional info: When using the |wildcards| ** globing, vim hangs
 indefinitely on lots of directories. The |file-searching| globing, like in
 ":set path=/**" does not hang as often as with globing with |wildcards|, like
-in ":1find /**/file".  This is for a files that unix "find" can find very
-quick. Merging the 2 kinds of globing might make this an easier fix. (Ian
+in ":1find /**/file".  This is for files that unix "find" can find very
+quickly. Merging the 2 kinds of globing might make this an easier fix. (Ian
 Kelling, 2008 July 4)
 
 When the file name has parenthesis, e.g., "foo (bar).txt", ":!ls '%'" has the

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 7.4.  Last change: 2014 Aug 29
+*todo.txt*      For Vim version 7.4.  Last change: 2014 Sep 09
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -61,31 +61,24 @@ Breaks test_eval.  Inefficient, can we only compute y_width when needed?
 Problem that a previous silent ":throw" causes a following try/catch not to
 work. (ZyX, 2013 Sep 28)
 
-Patch to fix typos in help files. (Dominique, 2014 Aug 9)
-
-Way to reproduce problem that characters are put on the screen twice in Insert
-mode when using system(). (Jacob Niehus, 2014 Aug 9)
-Related to setting TMODE_COOK.  Perhaps we can omit that for system()?
-
 Update for Romanian spell file. (Vanilla Ice, 2014 Aug 13)
-
-exepath() may return the wrong value.  Patch by Yasuhiro Matsumoto, 2014 Aug
-26.
-
-Win32: use different args for SearchPath()? (Yasuhiro Matsumoto, 2009 Jan 30)
-Also fixes wrong result from executable().
-Update from Ken Takata, 2014 Jan 10. Newer 2014 Apr 3.
+Still produces errors.
+Add flag to ignore fifth argument of SFX.
+Conversion from utf-8 to cp1250 can't be without errors.
 
 Patch to remove ETO_IGNORELANGUAGE, it causes Chinese characters not to show
 up. (Paul Moore, 2014 Jul 30)
 Should it depend on the Windows version?  Waiting for feedback.
 No longer needed after including DirectX patch?
+Related to issue 255?
 
-Fix for ":set all&" not taking care of side effect. (Yukihiro Nakadaira, 2014
-Aug 28)
+Problem with linebreak, adds a test that fails. (Nazri Ramliy, 2014 Sep 6)
+
+Patch to avoid problems with encoding conversion with diff.vim.
+(Yasuhiro Matsumoto, 2014 Sep 1.
 
 Patch by Marcin Szamotulski to add count to :close (2014 Aug 10, update Aug
-14)
+14, Aug 30)
     Make ":1close" close the first window.
     Make ":+1close" close the next window.
     Make ":-1close" close the previous window.
@@ -93,8 +86,15 @@ Can't easily close the help window, like ":pc" closes the preview window and
 ":ccl" closes the quickfix window.  Add ":hclose". (Chris Gaal)
 Patch for :helpclose, Christian Brabandt, 2010 Sep 6.
 
+Patch to fix line formatting bug. (Christian Brabandt, 2014 Sep 7)
+
+Patch to fix ml_get error. (Christian Brabandt, 2014 Sep 7)
+
 Patch by Marcin Szamotulski to add +cmd to buffer commands.
 (2014 Aug 18)
+
+Patch to fix encoding of arguments when setting 'encoding'. (Yasuhiro
+Matsumoto, 2014 Sep 4)
 
 Patch to fix that system() with empty input fails. (Olaf Dabrunz, 2014 Aug 19)
 
@@ -130,6 +130,9 @@ MS-Windows: Crash opening very long file name starting with "\\".
 (Christian Brock, 2012 Jun 29)
 
 Syntax highlighting slow (hangs) in SASS file. (Niek Bosch, 2013 Aug 21)
+
+Patch to allow for a different icon on MS-Windows. (Yasuhiro Matsumoto, 2014
+Sep 7).
 
 Adding "~" to 'cdpath' doesn't work for completion?  (Davido, 2013 Aug 19)
 
@@ -265,9 +268,6 @@ Patch to add ":undorecover", get as much text out of the undo file as
 possible. (Christian Brabandt, 2014 Mar 12, update Aug 22)
 
 Updated spec ftplugin. (Matěj Cepl, 2013 Oct 16)
-
-Some quickfix messages appear twice. (Gary Johnson, 2014 Feb 16)
-Patch by Christian Brabandt, 2014 Feb 17.
 
 Patch to right-align signs. (James Kolb (email james), 2013 Sep 23)
 
@@ -1889,6 +1889,10 @@ restored. (Luc St-Louis)
 
 Patch to support horizontal scroll wheel in GTK. Untested. (Bjorn Winckler,
 2010 Jun 30)
+
+Add an option for a minimal text length before inserting a line break for
+'textwidth'.  Avoids very short lines when a very long word follows.
+(Kartik Agaram)
 
 
 At next release:

--- a/runtime/doc/usr_04.txt
+++ b/runtime/doc/usr_04.txt
@@ -1,4 +1,4 @@
-*usr_04.txt*	For Vim version 7.4.  Last change: 2008 Sep 06
+*usr_04.txt*	For Vim version 7.4.  Last change: 2014 Aug 29
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -186,7 +186,7 @@ commands:
 	/four<Enter>	find the first string "four"
 	cwfive<Esc>	change the word to "five"
 	n		find the next "four"
-	.		repeat the change to "five'
+	.		repeat the change to "five"
 	n		find the next "four"
 	.		repeat the change
 			etc.

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Aug 23
+" Last Change:	2014 Aug 29
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")
@@ -525,6 +525,9 @@ au BufNewFile,BufRead configure.in,configure.ac setf config
 
 " CUDA  Cumpute Unified Device Architecture
 au BufNewFile,BufRead *.cu			setf cuda
+
+" Dockerfile
+au BufNewFile,BufRead Dockerfile		setf=dockerfile
 
 " WildPackets EtherPeek Decoder
 au BufNewFile,BufRead *.dcd			setf dcd

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Aug 29
+" Last Change:	2014 Sep 05
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")
@@ -527,7 +527,7 @@ au BufNewFile,BufRead configure.in,configure.ac setf config
 au BufNewFile,BufRead *.cu			setf cuda
 
 " Dockerfile
-au BufNewFile,BufRead Dockerfile		setf=dockerfile
+au BufNewFile,BufRead Dockerfile		setf dockerfile
 
 " WildPackets EtherPeek Decoder
 au BufNewFile,BufRead *.dcd			setf dcd
@@ -1099,6 +1099,9 @@ au BufNewFile,BufRead *.lou,*.lout		setf lout
 
 " Lua
 au BufNewFile,BufRead *.lua			setf lua
+
+" Luarocks
+au BufNewFile,BufRead *.rockspec		setf lua
 
 " Linden Scripting Language (Second Life)
 au BufNewFile,BufRead *.lsl			setf lsl

--- a/runtime/ftplugin/dockerfile.vim
+++ b/runtime/ftplugin/dockerfile.vim
@@ -1,0 +1,16 @@
+" Vim filetype plugin
+" Language:	Dockerfile
+" Maintainer:   Honza Pokorny <http://honza.ca>
+" Last Change:	2014 Aug 29
+
+" Only do this when not done yet for this buffer
+if exists("b:did_ftplugin")
+  finish
+endif
+
+" Don't load another plugin for this buffer
+let b:did_ftplugin = 1
+
+let b:undo_ftplugin = "setl commentstring<"
+
+setlocal commentstring=#\ %s

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:	Vim
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2013 Jun 26
+" Last Change:	2014 Sep 07
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -62,9 +62,12 @@ if exists("loaded_matchit")
 	\ '\<try\>:\<cat\%[ch]\>:\<fina\%[lly]\>:\<endt\%[ry]\>,' .
 	\ '\<aug\%[roup]\s\+\%(END\>\)\@!\S:\<aug\%[roup]\s\+END\>,' .
 	\ '(:)'
-  " Ignore ":syntax region" commands, the 'end' argument clobbers if-endif
-  let b:match_skip = 'getline(".") =~ "^\\s*sy\\%[ntax]\\s\\+region" ||
-	\ synIDattr(synID(line("."),col("."),1),"name") =~? "comment\\|string"'
+  " Ignore syntax region commands and settings, any 'en*' would clobber
+  " if-endif.
+  " - set spl=de,en
+  " - au! FileType javascript syntax region foldBraces start=/{/ end=/}/ …
+  let b:match_skip = 'synIDattr(synID(line("."),col("."),1),"name")
+        \ =~? "comment\\|string\\|vimSynReg\\|vimSet"'
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/indent/json.vim
+++ b/runtime/indent/json.vim
@@ -1,13 +1,168 @@
 " Vim indent file
 " Language:		JSON
-" Maintainer:		David Barnett <daviebdawg+vim@gmail.com>
-" Last Change:		2014 Jul 16
+" Mantainer:		Eli Parra <eli@elzr.com> https://github.com/elzr/vim-json
+" Last Change:          2014 Aug 29
+"   https://github.com/jakar/vim-json/commit/20b650e22aa750c4ab6a66aa646bdd95d7cd548a#diff-e81fc111b2052e306d126bd9989f7b7c
+" Original Author:	Rogerz Zhang <rogerz.zhang at gmail.com> http://github.com/rogerz/vim-json
+" Acknowledgement:      Based off of vim-javascript maintained by Darrick Wiebe 
+"                       http://www.vim.org/scripts/script.php?script_id=2765
 
-if exists('b:did_indent')
-   finish
+" 0. Initialization {{{1
+" =================
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+setlocal nosmartindent
+
+" Now, set up our indentation expression and keys that trigger it.
+setlocal indentexpr=GetJSONIndent()
+setlocal indentkeys=0{,0},0),0[,0],!^F,o,O,e
+
+" Only define the function once.
+if exists("*GetJSONIndent")
+  finish
 endif
 
-" JSON is a subset of JavaScript. JavaScript indenting should work fine.
-runtime! indent/javascript.vim
+let s:cpo_save = &cpo
+set cpo&vim
 
-let b:did_indent = 1
+" 1. Variables {{{1
+" ============
+
+let s:line_term = '\s*\%(\%(\/\/\).*\)\=$'
+" Regex that defines blocks.
+let s:block_regex = '\%({\)\s*\%(|\%([*@]\=\h\w*,\=\s*\)\%(,\s*[*@]\=\h\w*\)*|\)\=' . s:line_term
+
+" 2. Auxiliary Functions {{{1
+" ======================
+
+" Check if the character at lnum:col is inside a string.
+function s:IsInString(lnum, col)
+  return synIDattr(synID(a:lnum, a:col, 1), 'name') == 'jsonString'
+endfunction
+
+" Find line above 'lnum' that isn't empty, or in a string.
+function s:PrevNonBlankNonString(lnum)
+  let lnum = prevnonblank(a:lnum)
+  while lnum > 0
+    " If the line isn't empty or in a string, end search.
+    let line = getline(lnum)
+    if !(s:IsInString(lnum, 1) && s:IsInString(lnum, strlen(line)))
+      break
+    endif
+    let lnum = prevnonblank(lnum - 1)
+  endwhile
+  return lnum
+endfunction
+
+" Check if line 'lnum' has more opening brackets than closing ones.
+function s:LineHasOpeningBrackets(lnum)
+  let open_0 = 0
+  let open_2 = 0
+  let open_4 = 0
+  let line = getline(a:lnum)
+  let pos = match(line, '[][(){}]', 0)
+  while pos != -1
+    let idx = stridx('(){}[]', line[pos])
+    if idx % 2 == 0
+      let open_{idx} = open_{idx} + 1
+    else
+      let open_{idx - 1} = open_{idx - 1} - 1
+    endif
+    let pos = match(line, '[][(){}]', pos + 1)
+  endwhile
+  return (open_0 > 0) . (open_2 > 0) . (open_4 > 0)
+endfunction
+
+function s:Match(lnum, regex)
+  let col = match(getline(a:lnum), a:regex) + 1
+  return col > 0 && !s:IsInString(a:lnum, col) ? col : 0
+endfunction
+
+" 3. GetJSONIndent Function {{{1
+" =========================
+
+function GetJSONIndent()
+  " 3.1. Setup {{{2
+  " ----------
+
+  " Set up variables for restoring position in file.  Could use v:lnum here.
+  let vcol = col('.')
+
+  " 3.2. Work on the current line {{{2
+  " -----------------------------
+
+  " Get the current line.
+  let line = getline(v:lnum)
+  let ind = -1
+
+  " If we got a closing bracket on an empty line, find its match and indent
+  " according to it.
+  let col = matchend(line, '^\s*[]}]')
+
+  if col > 0 && !s:IsInString(v:lnum, col)
+    call cursor(v:lnum, col)
+    let bs = strpart('{}[]', stridx('}]', line[col - 1]) * 2, 2)
+
+    let pairstart = escape(bs[0], '[')
+    let pairend = escape(bs[1], ']')
+    let pairline = searchpair(pairstart, '', pairend, 'bW')
+
+    if pairline > 0 
+      let ind = indent(pairline)
+    else
+      let ind = virtcol('.') - 1
+    endif
+
+    return ind
+  endif
+
+  " If we are in a multi-line string, don't do anything to it.
+  if s:IsInString(v:lnum, matchend(line, '^\s*') + 1)
+    return indent('.')
+  endif
+
+  " 3.3. Work on the previous line. {{{2
+  " -------------------------------
+
+  let lnum = prevnonblank(v:lnum - 1)
+
+  if lnum == 0
+    return 0
+  endif
+
+  " Set up variables for current line.
+  let line = getline(lnum)
+  let ind = indent(lnum)
+
+  " If the previous line ended with a block opening, add a level of indent.
+  " if s:Match(lnum, s:block_regex)
+    " return indent(lnum) + &sw
+  " endif
+
+  " If the previous line contained an opening bracket, and we are still in it,
+  " add indent depending on the bracket type.
+  if line =~ '[[({]'
+    let counts = s:LineHasOpeningBrackets(lnum)
+    if counts[0] == '1' || counts[1] == '1' || counts[2] == '1'
+      return ind + &sw
+    else
+      call cursor(v:lnum, vcol)
+    end
+  endif
+
+  " }}}2
+
+  return ind
+endfunction
+
+" }}}1
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim:set sw=2 sts=2 ts=8 noet:

--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types in scripts
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last change:	2013 May 24
+" Last change:	2014 Aug 24
 
 " This file is called by an autocommand for every file that has just been
 " loaded into a buffer.  It checks if the type of file can be recognized by
@@ -313,6 +313,10 @@ else
   " Valgrind
   elseif s:line1 =~ '^==\d\+== valgrind' || s:line3 =~ '^==\d\+== Using valgrind'
     set ft=valgrind
+
+  " Go docs
+  elseif s:line1 =~ '^PACKAGE DOCUMENTATION$'
+    set ft=godoc
 
   " Renderman Interface Bytestream
   elseif s:line1 =~ '^##RenderMan'

--- a/runtime/syntax/asciidoc.vim
+++ b/runtime/syntax/asciidoc.vim
@@ -5,6 +5,7 @@
 " URL:          http://asciidoc.org/
 " Licence:      GPL (http://www.gnu.org)
 " Remarks:      Vim 6 or greater
+" Last Update:  2014 Aug 29 (see Issue 240)
 " Limitations:
 " 
 " - Nested quoted text formatting is highlighted according to the outer
@@ -155,7 +156,8 @@ hi def link asciidocQuotedAttributeList Special
 hi def link asciidocQuotedBold Special
 hi def link asciidocQuotedDoubleQuoted Label
 hi def link asciidocQuotedEmphasized2 Type
-hi def link asciidocQuotedEmphasized Type
+hi asciidocQuotedEmphasizedItalic term=italic cterm=italic gui=italic
+hi def link asciidocQuotedEmphasized asciidocQuotedEmphasizedItalic
 hi def link asciidocQuotedMonospaced2 Identifier
 hi def link asciidocQuotedMonospaced Identifier
 hi def link asciidocQuotedSingleQuoted Label

--- a/runtime/syntax/dockerfile.vim
+++ b/runtime/syntax/dockerfile.vim
@@ -1,0 +1,24 @@
+" dockerfile.vim - Syntax highlighting for Dockerfiles
+" Maintainer:   Honza Pokorny <http://honza.ca>
+" Version:      0.5
+" Last Change:  2014 Aug 29
+" License:      BSD
+
+
+if exists("b:current_syntax")
+    finish
+endif
+
+let b:current_syntax = "dockerfile"
+
+syntax case ignore
+
+syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|VOLUME|WORKDIR|COPY)\s/
+
+syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/
+
+syntax match dockerfileComment "\v^\s*#.*$"
+
+hi def link dockerfileString String
+hi def link dockerfileKeyword Keyword
+hi def link dockerfileComment Comment

--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	TeX
 " Maintainer:	Charles E. Campbell <NdrchipO@ScampbellPfamily.AbizM>
-" Last Change:	Mar 20, 2014
-" Version:	81
+" Last Change:	Sep 09, 2014
+" Version:	82
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_TEX
 "
 " Notes: {{{1
@@ -87,6 +87,12 @@ if !exists("g:tex_conceal")
  let s:tex_conceal= 'abdmgsS'
 else
  let s:tex_conceal= g:tex_conceal
+endif
+if !exists("g:tex_superscripts")
+ let g:tex_superscripts= "[0-9a-zA-W.,:;+-<>/()=]"
+endif
+if !exists("g:tex_subscripts")
+ let g:tex_subscripts= "[0-9aehijklmnoprstuvx,+-/().]"
 endif
 
 " Determine whether or not to use "*.sty" mode {{{1
@@ -331,22 +337,22 @@ syn match texSpaceCodeChar    "`\\\=.\(\^.\)\==\(\d\|\"\x\{1,6}\|`.\)"	contained
 if s:tex_fast =~ 'p'
   if !exists("g:tex_nospell") || !g:tex_nospell
    if g:tex_fold_enabled && has("folding")
-    syn region texDocZone			matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											fold contains=@texFoldGroup,@texDocGroup,@Spell
+    syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											fold contains=@texFoldGroup,@texDocGroup,@Spell
     syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								fold contains=@texFoldGroup,@texPartGroup,@Spell
     syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							fold contains=@texFoldGroup,@texChapterGroup,@Spell
     syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					fold contains=@texFoldGroup,@texSectionGroup,@Spell
-    syn region texSubSectionZone		matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				fold contains=@texFoldGroup,@texSubSectionGroup,@Spell
+    syn region texSubSectionZone	matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				fold contains=@texFoldGroup,@texSubSectionGroup,@Spell
     syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				fold contains=@texFoldGroup,@texSubSubSectionGroup,@Spell
     syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			fold contains=@texFoldGroup,@texParaGroup,@Spell
     syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	fold contains=@texFoldGroup,@Spell
     syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													fold contains=@texFoldGroup,@Spell
     syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											fold contains=@texFoldGroup,@Spell
    else
-    syn region texDocZone			matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup,@Spell
+    syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup,@Spell
     syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								contains=@texFoldGroup,@texPartGroup,@Spell
     syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							contains=@texFoldGroup,@texChapterGroup,@Spell
     syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					contains=@texFoldGroup,@texSectionGroup,@Spell
-    syn region texSubSectionZone		matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup,@Spell
+    syn region texSubSectionZone	matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup,@Spell
     syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSubSectionGroup,@Spell
     syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			contains=@texFoldGroup,@texParaGroup,@Spell
     syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	contains=@texFoldGroup,@Spell
@@ -355,22 +361,22 @@ if s:tex_fast =~ 'p'
    endif
   else
    if g:tex_fold_enabled && has("folding")
-    syn region texDocZone			matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											fold contains=@texFoldGroup,@texDocGroup
+    syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											fold contains=@texFoldGroup,@texDocGroup
     syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								fold contains=@texFoldGroup,@texPartGroup
     syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							fold contains=@texFoldGroup,@texChapterGroup
     syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					fold contains=@texFoldGroup,@texSectionGroup
-    syn region texSubSectionZone		matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				fold contains=@texFoldGroup,@texSubSectionGroup
+    syn region texSubSectionZone	matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				fold contains=@texFoldGroup,@texSubSectionGroup
     syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				fold contains=@texFoldGroup,@texSubSubSectionGroup
     syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			fold contains=@texFoldGroup,@texParaGroup
     syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	fold contains=@texFoldGroup
     syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													fold contains=@texFoldGroup
     syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											fold contains=@texFoldGroup
    else
-    syn region texDocZone			matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup
+    syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup
     syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								contains=@texFoldGroup,@texPartGroup
     syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							contains=@texFoldGroup,@texChapterGroup
     syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					contains=@texFoldGroup,@texSectionGroup
-    syn region texSubSectionZone		matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup
+    syn region texSubSectionZone	matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup
     syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSubSectionGroup
     syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			contains=@texFoldGroup,@texParaGroup
     syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	contains=@texFoldGroup
@@ -620,7 +626,7 @@ if s:tex_fast =~ 'r'
   syn region texRefZone		matchgroup=texStatement start="\\\(page\|eq\)ref{"	end="}\|%stopzone\>"	contains=@texRefGroup
   syn region texRefZone		matchgroup=texStatement start="\\v\=ref{"		end="}\|%stopzone\>"	contains=@texRefGroup
   syn region texRefOption	contained	matchgroup=Delimiter start='\[' end=']'		contains=@texRefGroup,texRefZone	nextgroup=texRefOption,texCite
-  syn region texCite	contained	matchgroup=Delimiter start='{' end='}'		contains=@texRefGroup,texRefZone,texCite
+  syn region texCite		contained	matchgroup=Delimiter start='{' end='}'		contains=@texRefGroup,texRefZone,texCite
 endif
 syn match  texRefZone		'\\cite\%([tp]\*\=\)\=' nextgroup=texRefOption,texCite
 
@@ -1045,8 +1051,11 @@ if has("conceal") && &enc == 'utf-8'
    syn region texSubscript	matchgroup=Delimiter start='_{'		skip="\\\\\|\\[{}]" end='}'	contained concealends contains=texSpecialChar,texSubscripts,texStatement,texSubscript,texSuperscript,texMathMatcher
   endif
   fun! s:SuperSub(group,leader,pat,cchar)
-    exe 'syn match '.a:group." '".a:leader.a:pat."' contained conceal cchar=".a:cchar
-    exe 'syn match '.a:group."s '".a:pat."' contained conceal cchar=".a:cchar.' nextgroup='.a:group.'s'
+    if a:pat =~ '^\\' || (a:leader == '\^' && a:pat =~ g:tex_superscripts) || (a:leader == '_' && a:pat =~ g:tex_subscripts)
+"     call Decho("SuperSub: group<".a:group."> leader<".a:leader."> pat<".a:pat."> cchar<".a:cchar.">")
+     exe 'syn match '.a:group." '".a:leader.a:pat."' contained conceal cchar=".a:cchar
+     exe 'syn match '.a:group."s '".a:pat."' contained conceal cchar=".a:cchar.' nextgroup='.a:group.'s'
+    endif
   endfun
   call s:SuperSub('texSuperscript','\^','0','⁰')
   call s:SuperSub('texSuperscript','\^','1','¹')
@@ -1170,44 +1179,44 @@ if has("conceal") && &enc == 'utf-8'
       let i= i + 1
      endfor
    endfun
-   "                    \`  \'  \^  \"  \~  \.  \=  \c  \H  \k  \r  \u  \v
-   call   s:Accents('a','à','á','â','ä','ã','ȧ','ā',' ',' ','ą','å','ă','ǎ')
-   call   s:Accents('A','À','Á','Â','Ä','Ã','Ȧ','Ā',' ',' ','Ą','Å','Ă','Ǎ')
-   call   s:Accents('c',' ','ć','ĉ',' ',' ','ċ',' ','ç',' ',' ',' ',' ','č')
-   call   s:Accents('C',' ','Ć','Ĉ',' ',' ','Ċ',' ','Ç',' ',' ',' ',' ','Č')
-   call   s:Accents('d',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ','ď')
-   call   s:Accents('D',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ','Ď')
-   call   s:Accents('e','è','é','ê','ë','ẽ','ė','ē','ȩ',' ','ę',' ','ĕ','ě')
-   call   s:Accents('E','È','É','Ê','Ë','Ẽ','Ė','Ē','Ȩ',' ','Ę',' ','Ĕ','Ě')
-   call   s:Accents('g',' ','ǵ','ĝ',' ',' ','ġ',' ','ģ',' ',' ',' ','ğ','ǧ')
-   call   s:Accents('G',' ','Ǵ','Ĝ',' ',' ','Ġ',' ','Ģ',' ',' ',' ','Ğ','Ǧ')
-   call   s:Accents('h',' ',' ','ĥ',' ',' ',' ',' ',' ',' ',' ',' ',' ','ȟ')
-   call   s:Accents('H',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ','Ȟ')
-   call   s:Accents('i','ì','í','î','ï','ĩ','į','ī',' ',' ','į',' ','ĭ','ǐ')
-   call   s:Accents('I','Ì','Í','Î','Ï','Ĩ','İ','Ī',' ',' ','Į',' ','Ĭ','Ǐ')
-   call   s:Accents('J',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ','ǰ')
-   call   s:Accents('k',' ',' ',' ',' ',' ',' ',' ','ķ',' ',' ',' ',' ','ǩ')
-   call   s:Accents('K',' ',' ',' ',' ',' ',' ',' ','Ķ',' ',' ',' ',' ','Ǩ')
-   call   s:Accents('l',' ','ĺ','ľ',' ',' ',' ',' ','ļ',' ',' ',' ',' ','ľ')
-   call   s:Accents('L',' ','Ĺ','Ľ',' ',' ',' ',' ','Ļ',' ',' ',' ',' ','Ľ')
-   call   s:Accents('n',' ','ń',' ',' ','ñ',' ',' ','ņ',' ',' ',' ',' ','ň')
-   call   s:Accents('N',' ','Ń',' ',' ','Ñ',' ',' ','Ņ',' ',' ',' ',' ','Ň')
-   call   s:Accents('o','ò','ó','ô','ö','õ','ȯ','ō',' ','ő','ǫ',' ','ŏ','ǒ')
-   call   s:Accents('O','Ò','Ó','Ô','Ö','Õ','Ȯ','Ō',' ','Ő','Ǫ',' ','Ŏ','Ǒ')
-   call   s:Accents('r',' ','ŕ',' ',' ',' ',' ',' ','ŗ',' ',' ',' ',' ','ř')
-   call   s:Accents('R',' ','Ŕ',' ',' ',' ',' ',' ','Ŗ',' ',' ',' ',' ','Ř')
-   call   s:Accents('s',' ','ś','ŝ',' ',' ',' ',' ','ş',' ','ȿ',' ',' ','š')
-   call   s:Accents('S',' ','Ś','Ŝ',' ',' ',' ',' ','Ş',' ',' ',' ',' ','Š')
-   call   s:Accents('t',' ',' ',' ',' ',' ',' ',' ','ţ',' ',' ',' ',' ','ť')
-   call   s:Accents('T',' ',' ',' ',' ',' ',' ',' ','Ţ',' ',' ',' ',' ','Ť')
-   call   s:Accents('u','ù','ú','û','ü','ũ',' ','ū',' ','ű','ų','ů','ŭ','ǔ')
-   call   s:Accents('U','Ù','Ú','Û','Ü','Ũ',' ','Ū',' ','Ű','Ų','Ů','Ŭ','Ǔ')
-   call   s:Accents('w',' ',' ','ŵ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ')
-   call   s:Accents('W',' ',' ','Ŵ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ')
-   call   s:Accents('y','ỳ','ý','ŷ','ÿ','ỹ',' ',' ',' ',' ',' ',' ',' ',' ')
-   call   s:Accents('Y','Ỳ','Ý','Ŷ','Ÿ','Ỹ',' ',' ',' ',' ',' ',' ',' ',' ')
-   call   s:Accents('z',' ','ź',' ',' ',' ','ż',' ',' ',' ',' ',' ',' ','ž')
-   call   s:Accents('Z',' ','Ź',' ',' ',' ','Ż',' ',' ',' ',' ',' ',' ','Ž')
+   "                  \`  \'  \^  \"  \~  \.  \=  \c  \H  \k  \r  \u  \v
+   call s:Accents('a','à','á','â','ä','ã','ȧ','ā',' ',' ','ą','å','ă','ǎ')
+   call s:Accents('A','À','Á','Â','Ä','Ã','Ȧ','Ā',' ',' ','Ą','Å','Ă','Ǎ')
+   call s:Accents('c',' ','ć','ĉ',' ',' ','ċ',' ','ç',' ',' ',' ',' ','č')
+   call s:Accents('C',' ','Ć','Ĉ',' ',' ','Ċ',' ','Ç',' ',' ',' ',' ','Č')
+   call s:Accents('d',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ','ď')
+   call s:Accents('D',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ','Ď')
+   call s:Accents('e','è','é','ê','ë','ẽ','ė','ē','ȩ',' ','ę',' ','ĕ','ě')
+   call s:Accents('E','È','É','Ê','Ë','Ẽ','Ė','Ē','Ȩ',' ','Ę',' ','Ĕ','Ě')
+   call s:Accents('g',' ','ǵ','ĝ',' ',' ','ġ',' ','ģ',' ',' ',' ','ğ','ǧ')
+   call s:Accents('G',' ','Ǵ','Ĝ',' ',' ','Ġ',' ','Ģ',' ',' ',' ','Ğ','Ǧ')
+   call s:Accents('h',' ',' ','ĥ',' ',' ',' ',' ',' ',' ',' ',' ',' ','ȟ')
+   call s:Accents('H',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ','Ȟ')
+   call s:Accents('i','ì','í','î','ï','ĩ','į','ī',' ',' ','į',' ','ĭ','ǐ')
+   call s:Accents('I','Ì','Í','Î','Ï','Ĩ','İ','Ī',' ',' ','Į',' ','Ĭ','Ǐ')
+   call s:Accents('J',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ','ǰ')
+   call s:Accents('k',' ',' ',' ',' ',' ',' ',' ','ķ',' ',' ',' ',' ','ǩ')
+   call s:Accents('K',' ',' ',' ',' ',' ',' ',' ','Ķ',' ',' ',' ',' ','Ǩ')
+   call s:Accents('l',' ','ĺ','ľ',' ',' ',' ',' ','ļ',' ',' ',' ',' ','ľ')
+   call s:Accents('L',' ','Ĺ','Ľ',' ',' ',' ',' ','Ļ',' ',' ',' ',' ','Ľ')
+   call s:Accents('n',' ','ń',' ',' ','ñ',' ',' ','ņ',' ',' ',' ',' ','ň')
+   call s:Accents('N',' ','Ń',' ',' ','Ñ',' ',' ','Ņ',' ',' ',' ',' ','Ň')
+   call s:Accents('o','ò','ó','ô','ö','õ','ȯ','ō',' ','ő','ǫ',' ','ŏ','ǒ')
+   call s:Accents('O','Ò','Ó','Ô','Ö','Õ','Ȯ','Ō',' ','Ő','Ǫ',' ','Ŏ','Ǒ')
+   call s:Accents('r',' ','ŕ',' ',' ',' ',' ',' ','ŗ',' ',' ',' ',' ','ř')
+   call s:Accents('R',' ','Ŕ',' ',' ',' ',' ',' ','Ŗ',' ',' ',' ',' ','Ř')
+   call s:Accents('s',' ','ś','ŝ',' ',' ',' ',' ','ş',' ','ȿ',' ',' ','š')
+   call s:Accents('S',' ','Ś','Ŝ',' ',' ',' ',' ','Ş',' ',' ',' ',' ','Š')
+   call s:Accents('t',' ',' ',' ',' ',' ',' ',' ','ţ',' ',' ',' ',' ','ť')
+   call s:Accents('T',' ',' ',' ',' ',' ',' ',' ','Ţ',' ',' ',' ',' ','Ť')
+   call s:Accents('u','ù','ú','û','ü','ũ',' ','ū',' ','ű','ų','ů','ŭ','ǔ')
+   call s:Accents('U','Ù','Ú','Û','Ü','Ũ',' ','Ū',' ','Ű','Ų','Ů','Ŭ','Ǔ')
+   call s:Accents('w',' ',' ','ŵ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ')
+   call s:Accents('W',' ',' ','Ŵ',' ',' ',' ',' ',' ',' ',' ',' ',' ',' ')
+   call s:Accents('y','ỳ','ý','ŷ','ÿ','ỹ',' ',' ',' ',' ',' ',' ',' ',' ')
+   call s:Accents('Y','Ỳ','Ý','Ŷ','Ÿ','Ỹ',' ',' ',' ',' ',' ',' ',' ',' ')
+   call s:Accents('z',' ','ź',' ',' ',' ','ż',' ',' ',' ',' ',' ',' ','ž')
+   call s:Accents('Z',' ','Ź',' ',' ',' ','Ż',' ',' ',' ',' ',' ',' ','Ž')
    call s:Accents('\\i','ì','í','î','ï','ĩ','į',' ',' ',' ',' ',' ','ĭ',' ')
    "                    \`  \'  \^  \"  \~  \.  \=  \c  \H  \k  \r  \u  \v
    delfun s:Accents
@@ -1252,7 +1261,7 @@ endif
 if did_tex_syntax_inits == 1
  let did_tex_syntax_inits= 2
   " TeX highlighting groups which should share similar highlighting
-  if !exists("s:tex_no_error")
+  if !exists("g:tex_no_error")
    if !exists("g:tex_no_math")
     HiLink texBadMath		texError
     HiLink texMathDelimBad	texError

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -887,7 +887,7 @@ static struct vimoption
    SCRIPTID_INIT},
   {"history",     "hi",   P_NUM|P_VIM,
    (char_u *)&p_hi, PV_NONE,
-   {(char_u *)0L, (char_u *)20L} SCRIPTID_INIT},
+   {(char_u *)0L, (char_u *)50L} SCRIPTID_INIT},
   {"hkmap",       "hk",   P_BOOL|P_VI_DEF|P_VIM,
    (char_u *)&p_hkmap, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},


### PR DESCRIPTION
No manual changes, only ran `patch -p1 < vim-6921742.diff`, with following output:

```
patching file runtime/doc/eval.txt
Hunk #3 succeeded at 2632 (offset 10 lines).
Hunk #4 succeeded at 2923 (offset 10 lines).
Hunk #5 succeeded at 5559 (offset 68 lines).
Hunk #6 succeeded at 5708 (offset 67 lines).
can't find file to patch at input line 63
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/os_vms.txt b/runtime/doc/os_vms.txt
|--- a/runtime/doc/os_vms.txt
|+++ b/runtime/doc/os_vms.txt
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
2 out of 2 hunks ignored
patching file runtime/doc/os_win32.txt
Hunk #2 FAILED at 334.
1 out of 2 hunks FAILED -- saving rejects to file runtime/doc/os_win32.txt.rej
patching file runtime/doc/pattern.txt
patching file runtime/doc/syntax.txt
patching file runtime/doc/tags
Hunk #1 FAILED at 4329.
1 out of 1 hunk FAILED -- saving rejects to file runtime/doc/tags.rej
patching file runtime/doc/todo.txt
Hunk #7 succeeded at 240 (offset -3 lines).
Hunk #8 succeeded at 1441 (offset -10 lines).
patching file runtime/doc/usr_04.txt
can't find file to patch at input line 281
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/version6.txt b/runtime/doc/version6.txt
|--- a/runtime/doc/version6.txt
|+++ b/runtime/doc/version6.txt
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
2 out of 2 hunks ignored
can't find file to patch at input line 299
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/version7.txt b/runtime/doc/version7.txt
|--- a/runtime/doc/version7.txt
|+++ b/runtime/doc/version7.txt
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
6 out of 6 hunks ignored
patching file runtime/filetype.vim
Hunk #2 succeeded at 526 (offset -4 lines).
patching file runtime/ftplugin/dockerfile.vim
patching file runtime/indent/json.vim
patching file runtime/scripts.vim
Hunk #2 succeeded at 314 (offset -5 lines).
patching file runtime/syntax/asciidoc.vim
patching file runtime/syntax/dockerfile.vim
```

The rejected change to the `tags` file is irrelevant, as that file is not in Neovim. The rejected `win32` hunk is already in Neovim. Contents of `runtime/doc/os_win32.txt.rej`:

``` diff
--- runtime/doc/os_win32.txt
+++ runtime/doc/os_win32.txt
@@ -334,7 +334,7 @@
         :!start /min ctags -R .
 <  When it has finished you should see file named "tags" in your current
    directory.  You should notice the window title blinking on your taskbar.
-   This is more noticable for commands that take longer.
+   This is more noticeable for commands that take longer.
    Now delete the "tags" file and run this command: >
         :!start /b ctags -R .
 <  You should have the same "tags" file, but this time there will be no
```
