### PR TITLE
globals.h: remove u_sync_once

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -6765,10 +6765,6 @@ static void ins_reg(void)
    * message for it. Only call it explicitly. */
   ++no_u_sync;
   if (regname == '=') {
-    /* Sync undo when evaluating the expression calls setline() or
-     * append(), so that it can be undone separately. */
-    u_sync_once = 2;
-
     regname = get_expr_register();
   }
   if (regname == NUL || !valid_yank_reg(regname, FALSE)) {
@@ -6794,9 +6790,6 @@ static void ins_reg(void)
 
   }
   --no_u_sync;
-  if (u_sync_once == 1)
-    ins_need_undo = TRUE;
-  u_sync_once = 0;
   clear_showcmd();
 
   /* If the inserted register is empty, we need to remove the '"' */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -828,8 +828,6 @@ EXTERN int no_zero_mapping INIT(= 0);   /* mapping zero not allowed */
 EXTERN int allow_keys INIT(= FALSE);    /* allow key codes when no_mapping
                                          * is set */
 EXTERN int no_u_sync INIT(= 0);         /* Don't call u_sync() */
-EXTERN int u_sync_once INIT(= 0);       /* Call u_sync() once when evaluating
-                                           an expression. */
 
 EXTERN int restart_edit INIT(= 0);      /* call edit when next cmd finished */
 EXTERN int arrow_used;                  /* Normally FALSE, set to TRUE after


### PR DESCRIPTION
As far as I could tell this global is also never used. I removed the IF statement as well since it appeared it's contents were unreachable.
