### PR TITLE
[RFC] eval: fix incorrect refcount in list_append_list

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5129,7 +5129,7 @@ void list_append_list(list_T *list, list_T *itemlist)
   li->li_tv.v_lock = 0;
   li->li_tv.vval.v_list = itemlist;
   list_append(list, li);
-  ++list->lv_refcount;
+  ++itemlist->lv_refcount;
 }
 
 /*


### PR DESCRIPTION
Sorry for this very small PR but this fixes a small refcount error introduced in #1182. Thanks to @oni-link for pointing this out.
