### PR TITLE
[RFC] job.c: Prevent early return from job_wait().

### DIFF
--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -6,6 +6,8 @@ local helpers = require('test.functional.helpers')
 local eq, clear, eval, feed, nvim =
   helpers.eq, helpers.clear, helpers.eval, helpers.feed, helpers.nvim
 
+local Screen = require('test.functional.ui.screen')
+
 
 local function create_file_with_nuls(name)
   return function()
@@ -40,6 +42,81 @@ describe('system()', function()
     eq(5, eval('v:shell_error'))
     eval([[system('this-should-not-exist')]])
     eq(127, eval('v:shell_error'))
+  end)
+
+  describe('executes shell function', function()
+    local screen
+
+    before_each(function()
+        clear()
+        screen = Screen.new()
+        screen:attach()
+    end)
+
+    after_each(function()
+        screen:detach()
+    end)
+
+    it('`echo` and waits for its return', function()
+      feed(':call system("echo")<cr>')
+      screen:expect([[
+        ^                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        :call system("echo")                                 |
+      ]])
+    end)
+
+    it('`yes` and is directly interrupted with CTRL-C', function()
+      feed(':call system("yes")<cr><c-c>')
+      screen:expect([[
+        ^                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        Type  :quit<Enter>  to exit Vim                      |
+      ]])
+    end)
+
+    it('`yes` and is a little bit later interrupted with CTRL-C', function()
+      feed(':call system("yes")<cr>')
+      feed('<c-c>')
+      screen:expect([[
+        ^                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        Type  :quit<Enter>  to exit Vim                      |
+      ]])
+    end)
   end)
 
   describe('passing no input', function()
@@ -135,6 +212,81 @@ describe('systemlist()', function()
     eq(5, eval('v:shell_error'))
     eval([[systemlist('this-should-not-exist')]])
     eq(127, eval('v:shell_error'))
+  end)
+
+  describe('exectues shell function', function()
+    local screen
+
+    before_each(function()
+        clear()
+        screen = Screen.new()
+        screen:attach()
+    end)
+
+    after_each(function()
+        screen:detach()
+    end)
+
+    it('`echo` and waits for its return', function()
+      feed(':call systemlist("echo")<cr>')
+      screen:expect([[
+        ^                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        :call systemlist("echo")                             |
+      ]])
+    end)
+
+    it('`yes` and is directly interrupted with CTRL-C', function()
+      feed(':call systemlist("echo")<cr><c-c>')
+      screen:expect([[
+        ^                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        Type  :quit<Enter>  to exit Vim                      |
+      ]])
+    end)
+
+    it('`yes` and is a little bit later interrupted with CTRL-C', function()
+      feed(':call systemlist("echo")<cr>')
+      feed('<c-c>')
+      screen:expect([[
+        ^                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        Type  :quit<Enter>  to exit Vim                      |
+      ]])
+    end)
   end)
 
   describe('passing string with linefeed characters as input', function()


### PR DESCRIPTION
job.c: Prevent early return from job_wait().

A blocking call job_wait(job, -1) can only return after job is finished
and all handles of job are closed. But hitting CTRL-C makes job_wait()
return early while handles can still be open. This can lead to problems
with the job/handle callbacks if the caller (of job_wait()) already
freed the memory that is used in the job callbacks.

To fix this, only return after all handles of the job are closed.

Can reproduce an assert on my system trying to abort the following command:

``` viml
:call system('sleep 100')
```

https://github.com/neovim/neovim/pull/1365#discussion_r22559122
ping @tarruda
