### PR TITLE
[RFC] Remove project-specific integer types: long_u. (5)

### DIFF
--- a/scripts/genex_cmds.lua
+++ b/scripts/genex_cmds.lua
@@ -67,7 +67,7 @@ for i, cmd in ipairs(defs) do
   [%s] = {
     .cmd_name = (char_u *) "%s",
     .cmd_func = &%s,
-    .cmd_argt = %uL
+    .cmd_argt = %u
   }]], enumname, cmd.command, cmd.func, cmd.flags))
 end
 defsfile:write([[

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -72,7 +72,6 @@ set(CONV_SOURCES
   move.c
   normal.c
   ops.c
-  option.c
   os_unix.c
   path.c
   popupmnu.c

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -2,6 +2,7 @@
 #define NVIM_BUFFER_DEFS_H
 
 #include <stdbool.h>
+#include <stdint.h>
 // for FILE
 #include <stdio.h>
 
@@ -626,12 +627,12 @@ struct file_buffer {
   char_u      *b_p_def;         /* 'define' local value */
   char_u      *b_p_inc;         /* 'include' */
   char_u      *b_p_inex;        /* 'includeexpr' */
-  long_u b_p_inex_flags;        /* flags for 'includeexpr' */
+  uint32_t b_p_inex_flags;      /* flags for 'includeexpr' */
   char_u      *b_p_inde;        /* 'indentexpr' */
-  long_u b_p_inde_flags;        /* flags for 'indentexpr' */
+  uint32_t b_p_inde_flags;        /* flags for 'indentexpr' */
   char_u      *b_p_indk;        /* 'indentkeys' */
   char_u      *b_p_fex;         /* 'formatexpr' */
-  long_u b_p_fex_flags;         /* flags for 'formatexpr' */
+  uint32_t b_p_fex_flags;       /* flags for 'formatexpr' */
   char_u      *b_p_kp;          /* 'keywordprg' */
   int b_p_lisp;                 /* 'lisp' */
   char_u      *b_p_mps;         /* 'matchpairs' */
@@ -1082,9 +1083,9 @@ struct window_S {
   winopt_T w_allbuf_opt;
 
   /* A few options have local flags for P_INSECURE. */
-  long_u w_p_stl_flags;             /* flags for 'statusline' */
-  long_u w_p_fde_flags;             /* flags for 'foldexpr' */
-  long_u w_p_fdt_flags;             /* flags for 'foldtext' */
+  uint32_t w_p_stl_flags;           /* flags for 'statusline' */
+  uint32_t w_p_fde_flags;           /* flags for 'foldexpr' */
+  uint32_t w_p_fdt_flags;           /* flags for 'foldtext' */
   int         *w_p_cc_cols;         /* array of columns to highlight or NULL */
   int         w_p_brimin;           /* minimum width for breakindent */
   int         w_p_brishift;         /* additional shift for breakindent */

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -791,15 +791,17 @@ int linetabsize_col(int startcol, char_u *s)
 /// @param len
 ///
 /// @return Number of characters the string will take on the screen.
-int win_linetabsize(win_T *wp, char_u *line, colnr_T len)
+unsigned int win_linetabsize(win_T *wp, char_u *line, colnr_T len)
 {
   colnr_T col = 0;
-  char_u *s;
 
-  for (s = line; *s != NUL && (len == MAXCOL || s < line + len); mb_ptr_adv(s)) {
+  for (char_u *s = line;
+       *s != NUL && (len == MAXCOL || s < line + len);
+       mb_ptr_adv(s)) {
     col += win_lbr_chartabsize(wp, line, s, col, NULL);
   }
-  return (int)col;
+
+  return (unsigned int)col;
 }
 
 /// Return TRUE if 'c' is a normal identifier character:

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10332,7 +10332,7 @@ static void get_user_input(typval_T *argvars, typval_T *rettv, int inputdialog)
       if (!inputdialog && argvars[2].v_type != VAR_UNKNOWN) {
         char_u  *xp_name;
         int xp_namelen;
-        long argt;
+        uint32_t argt;
 
         /* input() with a third argument: completion */
         rettv->vval.v_string = NULL;

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -96,7 +96,7 @@ struct exarg {
   char_u      *cmd;             ///< the name of the command (except for :make)
   char_u      **cmdlinep;       ///< pointer to pointer of allocated cmdline
   cmdidx_T cmdidx;              ///< the index for the command
-  long argt;                    ///< flags for the command
+  uint32_t argt;                ///< flags for the command
   int skip;                     ///< don't execute the command, only parse it
   int forceit;                  ///< TRUE if ! present
   int addr_count;               ///< the number of addresses given

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -8,6 +8,7 @@
 #define NVIM_EX_CMDS_DEFS_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "nvim/pos.h"      // for linenr_T
 #include "nvim/normal.h"
@@ -59,13 +60,13 @@
 #define USECTRLV       0x2000   /* do not remove CTRL-V from argument */
 #define NOTADR         0x4000   /* number before command is not an address */
 #define EDITCMD        0x8000   /* allow "+command" argument */
-#define BUFNAME       0x10000L  /* accepts buffer name */
-#define BUFUNL        0x20000L  /* accepts unlisted buffer too */
-#define ARGOPT        0x40000L  /* allow "++opt=val" argument */
-#define SBOXOK        0x80000L  /* allowed in the sandbox */
-#define CMDWIN       0x100000L  /* allowed in cmdline window */
-#define MODIFY       0x200000L  /* forbidden in non-'modifiable' buffer */
-#define EXFLAGS      0x400000L  /* allow flags after count in argument */
+#define BUFNAME       0x10000   /* accepts buffer name */
+#define BUFUNL        0x20000   /* accepts unlisted buffer too */
+#define ARGOPT        0x40000   /* allow "++opt=val" argument */
+#define SBOXOK        0x80000   /* allowed in the sandbox */
+#define CMDWIN       0x100000   /* allowed in cmdline window */
+#define MODIFY       0x200000   /* forbidden in non-'modifiable' buffer */
+#define EXFLAGS      0x400000   /* allow flags after count in argument */
 #define FILES   (XFILE | EXTRA) /* multiple extra files allowed */
 #define WORD1   (EXTRA | NOSPC) /* one extra word allowed */
 #define FILE1   (FILES | NOSPC) /* 1 file allowed, defaults to current file */
@@ -85,7 +86,7 @@ typedef char_u *(*LineGetter)(int, void *, int);
 typedef struct cmdname {
   char_u *cmd_name;    ///< Name of the command.
   ex_func_T cmd_func;  ///< Function with implementation of this command.
-  long_u cmd_argt;     ///< Relevant flags from the declared above.
+  uint32_t cmd_argt;     ///< Relevant flags from the declared above.
 } CommandDefinition;
 
 /// Arguments used for Ex commands.

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -10,6 +10,7 @@
  * misc1.c: functions that didn't seem to fit elsewhere
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -1271,7 +1272,7 @@ plines_win_nofill (
 int plines_win_nofold(win_T *wp, linenr_T lnum)
 {
   char_u      *s;
-  long col;
+  unsigned int col;
   int width;
 
   s = ml_get_buf(wp->w_buffer, lnum, FALSE);
@@ -1292,11 +1293,12 @@ int plines_win_nofold(win_T *wp, linenr_T lnum)
   width = wp->w_width - win_col_off(wp);
   if (width <= 0)
     return 32000;
-  if (col <= width)
+  if (col <= (unsigned int)width)
     return 1;
   col -= width;
   width += win_col_off2(wp);
-  return (col + (width - 1)) / width + 1;
+  assert(col <= INT_MAX && (int)col < INT_MAX - (width -1));
+  return ((int)col + (width - 1)) / width + 1;
 }
 
 /*

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4234,8 +4234,7 @@ int do_addsub(int command, linenr_T Prenum1)
   char_u buf2[NUMBUFLEN];
   int hex;                      /* 'X' or 'x': hex; '0': octal */
   static int hexupper = FALSE;          /* 0xABC */
-  unsigned long n;
-  long_u oldn;
+  unsigned long n, oldn;
   char_u      *ptr;
   int c;
   int length = 0;                       /* character length of the number */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3597,12 +3597,12 @@ static uint32_t *insecure_flag(int opt_idx, int opt_flags)
 {
   if (opt_flags & OPT_LOCAL)
     switch ((int)options[opt_idx].indir) {
-    case PV_STL:        return (uint32_t *)(&curwin->w_p_stl_flags);
-    case PV_FDE:        return (uint32_t *)(&curwin->w_p_fde_flags);
-    case PV_FDT:        return (uint32_t *)(&curwin->w_p_fdt_flags);
-    case PV_INDE:       return (uint32_t *)(&curbuf->b_p_inde_flags);
-    case PV_FEX:        return (uint32_t *)(&curbuf->b_p_fex_flags);
-    case PV_INEX:       return (uint32_t *)(&curbuf->b_p_inex_flags);
+    case PV_STL:        return &curwin->w_p_stl_flags;
+    case PV_FDE:        return &curwin->w_p_fde_flags;
+    case PV_FDT:        return &curwin->w_p_fdt_flags;
+    case PV_INDE:       return &curbuf->b_p_inde_flags;
+    case PV_FEX:        return &curbuf->b_p_fex_flags;
+    case PV_INEX:       return &curbuf->b_p_inex_flags;
     }
 
   /* Nothing special, return global flags field. */

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -4,7 +4,6 @@
 
 #include "nvim/lib/klist.h"
 
-#include "nvim/types.h"
 #include "nvim/ascii.h"
 #include "nvim/vim.h"
 #include "nvim/globals.h"

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -289,6 +289,7 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 #include <wctype.h>
@@ -6546,7 +6547,7 @@ node_compress (
       n = np->wn_flags + (np->wn_region << 8) + (np->wn_affixID << 16);
     else
       // byte node: use the byte value and the child pointer
-      n = (unsigned)(np->wn_byte + ((long_u)np->wn_child << 8));
+      n = (unsigned)(np->wn_byte + ((uintptr_t)np->wn_child << 8));
     nr = nr * 101 + n;
   }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3837,7 +3837,7 @@ static void add_keyword(char_u *name,
   }
   kp->next_list = copy_id_list(next_list);
 
-  long_u hash = hash_hash(kp->keyword);
+  hash_T hash = hash_hash(kp->keyword);
   hashtab_T *ht = (curwin->w_s->b_syn_ic) ? &curwin->w_s->b_keywtab_ic
                                           : &curwin->w_s->b_keywtab;
   hashitem_T *hi = hash_lookup(ht, kp->keyword, hash);

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -13,11 +13,6 @@
 // dummy to pass an ACL to a function
 typedef void *vim_acl_T;
 
-// According to the vanilla Vim docs, long_u needs to be big enough to hold
-// a pointer for the platform. On C99, this is easy to do with the uintptr_t
-// type in lieu of the platform-specific typedefs that existed before.
-typedef uintptr_t long_u;
-
 /*
  * Shorthand for unsigned variables. Many systems, but not all, have u_char
  * already defined, so we use char_u to avoid trouble.


### PR DESCRIPTION
Continues #1788.

Removes all remaining `long_u` instances. Finally!
