### PR TITLE
[RFC] test: Correct lfs.attributes() call, and allow unit tests to run with gcc on OSX

### DIFF
--- a/test/unit/formatc.lua
+++ b/test/unit/formatc.lua
@@ -149,8 +149,7 @@ local C_keywords = set {
 --   };
 --
 -- would become:
---  struct mystruct
---  { int a; int b; };
+--  struct mystruct { int a; int b; };
 --
 --  The first one will have a lot of false positives (the line '{' for
 --  example), the second one is more unique.
@@ -179,7 +178,8 @@ local function formatc(str)
       -- static and/or inline usually indicate an inline header function,
       -- which has no trailing ';', so we have to add a newline after the
       -- '}' ourselves.
-      if token[1] == 'static' or token[1] == 'inline' then
+      local tok = token[1]
+      if tok == 'static' or tok == 'inline' or tok == '__inline' then
         end_at_brace = true
       end
     elseif typ == 'preprocessor' then

--- a/test/unit/os/fs_spec.lua
+++ b/test/unit/os/fs_spec.lua
@@ -33,11 +33,11 @@ local absolute_executable = nil
 local executable_name = nil
 
 local function assert_file_exists(filepath)
-  eq(false, nil == (lfs.attributes(filepath, 'r')))
+  neq(nil, lfs.attributes(filepath))
 end
 
 local function assert_file_does_not_exist(filepath)
-  eq(true, nil == (lfs.attributes(filepath, 'r')))
+  eq(nil, lfs.attributes(filepath))
 end
 
 describe('fs function', function()


### PR DESCRIPTION
Check the corresponding issues #1831 and #1572 for more details.
