### PR TITLE
[RFC] snapshot_util (Screen Tests for the Lazy) and enable stricter highlight tests

### DIFF
--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -52,6 +52,8 @@ describe('Default highlight groups', function()
       [1] = {reverse = true, bold = true},  -- StatusLine
       [2] = {reverse = true}                -- StatusLineNC
     })
+    --ignore highligting of ~-lines
+    screen:set_default_attr_ignore( {{}, {bold=true, foreground=hlgroup_colors.NonText}} )
     execute('sp', 'vsp', 'vsp')
     screen:expect([[
       ^                   {2:|}                {2:|}               |

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -10,6 +10,7 @@ describe('Screen', function()
     clear()
     screen = Screen.new()
     screen:attach()
+    screen:set_default_attr_ignore( {{}, {bold=true, foreground=255}} ) 
   end)
 
   after_each(function()


### PR DESCRIPTION
This defines a utility function `screen:snapshot_util()` that can be placed in an screen test file at any point where one would like to have a `screen:expect([...])` and it will spit out such a statement to stdout that would match the current screen state exactly.

In a fresh vim, it for instance prints:

```
screen:expect([[
  ^                                                    |
  {1:~                                                    }|
  {1:~                                                    }|
  {1:~                                                    }|
  {1:~                                                    }|
  {1:~                                                    }|
  {1:~                                                    }|
  {1:~                                                    }|
  {1:~                                                    }|
  {1:~                                                    }|
  {1:~                                                    }|
  {1:~                                                    }|
  {1:~                                                    }|
                                                       |
]], {[1] = {bold = true, foreground = 255}})
```

But I'm not really happy it yet, due to what I perceive as a limitation of `screen:except` itself. If I understand it correctly, it will not be able to detect that a previously unhighlighted area incorrectly gets new a new, unexpected highlighting, say, the middle of the first line suddenly gets the background color 156. (Unless, of course, one also wraps all unhighlighted areas with some `{N:` and `}`, but that would be just clumsy). 

Instead, when `attr_ids` is specified to `expect`, I think an entirely unexpected attr set should be a test failure, where one for convenience could be able to to specify that some allowed attr sets should be just ignored (for instance, the `bold+fg=255` that every entire empty line is highlighted with :) )
