### PR TITLE
[WIP] avoid unnecessary calls to get_cursor_line_ptr

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -6575,7 +6575,9 @@ int in_cinkeys(int keytyped, int when, int line_is_empty)
     else if (*look == ':') {
       if (try_match && keytyped == ':') {
         p = get_cursor_line_ptr();
-        if (cin_iscase(p, FALSE) || cin_isscopedecl(p) || cin_islabel())
+        if (cin_iscase(p, FALSE)
+            || cin_isscopedecl(p)
+            || cin_islabel(curwin->w_cursor.lnum))
           return TRUE;
         /* Need to get the line again after cin_islabel(). */
         p = get_cursor_line_ptr();
@@ -6584,7 +6586,7 @@ int in_cinkeys(int keytyped, int when, int line_is_empty)
             && p[curwin->w_cursor.col - 2] == ':') {
           p[curwin->w_cursor.col - 1] = ' ';
           i = (cin_iscase(p, FALSE) || cin_isscopedecl(p)
-               || cin_islabel());
+               || cin_islabel(curwin->w_cursor.lnum));
           p = get_cursor_line_ptr();
           p[curwin->w_cursor.col - 1] = ':';
           if (i)

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -481,15 +481,12 @@ static char_u *after_label(char_u *l)
  * Get indent of line "lnum", skipping a label.
  * Return 0 if there is nothing after the label.
  */
-static int 
-get_indent_nolabel (     /* XXX */
-    linenr_T lnum
-)
-{
-  char_u      *l;
+static int get_indent_after_label(linenr_T lnum)
+{ /* XXX */
+  char_u *l;
   pos_T fp;
   colnr_T col;
-  char_u      *p;
+  char_u *p;
 
   l = ml_get(lnum);
   p = after_label(l);
@@ -508,7 +505,8 @@ get_indent_nolabel (     /* XXX */
  *   label:	if (asdf && asdfasdf)
  *		^
  */
-static int skip_label(linenr_T lnum, char_u **pp) FUNC_ATTR_NONNULL_ALL
+static int get_indent_after_label_with_ref(linenr_T lnum, char_u **pp)
+  FUNC_ATTR_NONNULL_ALL
 { /* XXX */
   char_u *l = ml_get(lnum);
   int indent;
@@ -1874,7 +1872,7 @@ int get_c_indent(void)
             cin_is_if_for_while_before_offset(line, &outermost.col);
         }
 
-        amount = skip_label(our_paren_pos.lnum, &look);
+        amount = get_indent_after_label_with_ref(our_paren_pos.lnum, &look);
         look = skipwhite(look);
         if (*look == '(') {
           linenr_T save_lnum = curwin->w_cursor.lnum;
@@ -2061,7 +2059,7 @@ int get_c_indent(void)
         } else if (curbuf->b_ind_js) {
           amount = get_indent_lnum(lnum);
         } else {
-          amount = skip_label(lnum, &l);
+          amount = get_indent_after_label_with_ref(lnum, &l);
         }
 
         start_brace = BRACE_AT_END;
@@ -2392,7 +2390,7 @@ int get_c_indent(void)
               continue;
             }
 
-            n = get_indent_nolabel(curwin->w_cursor.lnum);          /* XXX */
+            n = get_indent_after_label(curwin->w_cursor.lnum);          /* XXX */
 
             /*
              *	 case xx: if (cond)	    <- line up with this if
@@ -2624,7 +2622,8 @@ int get_c_indent(void)
             if (curbuf->b_ind_js) {
               cur_amount = get_indent();
             } else {
-              cur_amount = skip_label(curwin->w_cursor.lnum, &l);
+              cur_amount = get_indent_after_label_with_ref(
+                             curwin->w_cursor.lnum, &l);
             }
             /*
              * If this is just above the line we are indenting, and it
@@ -2975,7 +2974,8 @@ term_again:
                * Get indent and pointer to text for current line,
                * ignoring any jump label.
                */
-              amount = skip_label(curwin->w_cursor.lnum, &l);
+              amount = get_indent_after_label_with_ref(
+                         curwin->w_cursor.lnum, &l);
 
               if (theline[0] == '{')
                 amount += curbuf->b_ind_open_extra;

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -508,29 +508,24 @@ get_indent_nolabel (     /* XXX */
  *   label:	if (asdf && asdfasdf)
  *		^
  */
-static int skip_label(linenr_T lnum, char_u **pp)
-{
-  char_u      *l;
-  int amount;
-  pos_T cursor_save;
+static int skip_label(linenr_T lnum, char_u **pp) FUNC_ATTR_NONNULL_ALL
+{ /* XXX */
+  char_u *l = ml_get(lnum);
+  int indent;
 
-  cursor_save = curwin->w_cursor;
-  curwin->w_cursor.lnum = lnum;
-  l = get_cursor_line_ptr();
-  /* XXX */
+  /* We repeatedly call "ml_get(lnum)" because every time it's called    */
+  /* (or any time we call a function that calls it, marked with an 'XXX' */
+  /* comment) the returned pointer is invalidated.                       */
   if (cin_iscase(l, FALSE) || cin_isscopedecl(l) || cin_islabel()) {
-    amount = get_indent_nolabel(lnum);
-    l = after_label(get_cursor_line_ptr());
-    if (l == NULL)              /* just in case */
-      l = get_cursor_line_ptr();
+    indent = get_indent_after_label(lnum);
+    l = after_label(ml_get(lnum));
+    *pp = (l == NULL) ? ml_get(lnum) : l;
   } else {
-    amount = get_indent();
-    l = get_cursor_line_ptr();
+    *pp = l = ml_get(lnum);
+    indent = get_indent_str(l, (int)curbuf->b_p_ts, false);
   }
-  *pp = l;
 
-  curwin->w_cursor = cursor_save;
-  return amount;
+  return indent;
 }
 
 /*

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -477,10 +477,16 @@ static char_u *after_label(char_u *l)
   return l;
 }
 
-/*
- * Get indent of line "lnum", skipping a label.
- * Return 0 if there is nothing after the label.
- */
+/// Gets the indent of line "lnum", skipping any label.
+///
+/// For the following text the marked character is the indent value:
+///
+///   label: if (asdf && asdfasdf)
+///          ^
+/// @param lnum The line number on which to calculate the indent.
+///
+/// @returns The indent column (after any labels) or 0 if there is no text
+///          after the label.
 static int get_indent_after_label(linenr_T lnum)
 { /* XXX */
   char_u *l;
@@ -499,21 +505,26 @@ static int get_indent_after_label(linenr_T lnum)
   return (int)col;
 }
 
-/*
- * Find indent for line "lnum", ignoring any case or jump label.
- * Also return a pointer to the text (after the label) in "pp".
- *   label:	if (asdf && asdfasdf)
- *		^
- */
+/// Find indent for line "lnum", ignoring any case or jump label.
+///
+/// For the following text it'll select the marked character as the indent
+/// value:
+///
+///   label: if (asdf && asdfasdf)
+///          ^
+/// @param      lnum The line number for which you want the indent value.
+/// @param[out] pp A pointer to store a reference to the text at this indent.
+///
+/// @returns An integer representing the number of columns of indent.
 static int get_indent_after_label_with_ref(linenr_T lnum, char_u **pp)
   FUNC_ATTR_NONNULL_ALL
 { /* XXX */
   char_u *l = ml_get(lnum);
   int indent;
 
-  /* We repeatedly call "ml_get(lnum)" because every time it's called    */
-  /* (or any time we call a function that calls it, marked with an 'XXX' */
-  /* comment) the returned pointer is invalidated.                       */
+  // We repeatedly call "ml_get(lnum)" because every time it's called
+  // (or any time we call a function that calls it, marked with an 'XXX'
+  // comment) the returned pointer is invalidated.
   if (cin_iscase(l, FALSE) || cin_isscopedecl(l) || cin_islabel()) {
     indent = get_indent_after_label(lnum);
     l = after_label(ml_get(lnum));


### PR DESCRIPTION
This is my first contribution and I figured I'd clean up `skip_label`.

This commit refactors the function-local variables to be initialized or
reassigned a fewer number of times.
