### PR TITLE
[RFC] coverity/102151: initialize `our_paren_pos`

### DIFF
--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -1805,6 +1805,7 @@ int get_c_indent(void)
     }
 
     if (trypos != NULL) {
+      our_paren_pos = *trypos;
       /*
        * If the matching paren is more than one line away, use the indent of
        * a previous non-empty line that matches the same paren.
@@ -1814,7 +1815,6 @@ int get_c_indent(void)
         amount = get_indent_lnum(curwin->w_cursor.lnum - 1);      /* XXX */
       } else {
         amount = -1;
-        our_paren_pos = *trypos;
         for (lnum = cur_curpos.lnum - 1; lnum > our_paren_pos.lnum; --lnum) {
           l = skipwhite(ml_get(lnum));
           if (cin_nocode(l))                    /* skip comment lines */


### PR DESCRIPTION
This hoists the initialization of `our_paren_pos` outside a conditional
so it can be safely referenced further down in this function.

This fixes [CID #102151](https://scan8.coverity.com/reports.htm#v22612/p10672/fileInstanceId=3625174&defectInstanceId=1525719&mergedDefectId=102151)

Originally broken in:
https://code.google.com/p/vim/source/diff?spec=svndc8197342755fda6ca4d6619dac228406867a7ce&old=01583c79d5f4d3f29d4c33dd10dd29efd349cad0&r=dc8197342755fda6ca4d6619dac228406867a7ce&format=unidiff&path=%2Fsrc%2Fmisc1.c
