### PR TITLE
[RFC] vim-patch:7.4.492

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -5751,8 +5751,12 @@ stop_insert (
       }
       if (curwin->w_cursor.lnum != tpos.lnum)
         curwin->w_cursor = tpos;
-      else if (cc != NUL)
-        ++curwin->w_cursor.col;         /* put cursor back on the NUL */
+      else {
+        tpos.col++;
+        if (cc != NUL && gchar_pos(&tpos) == NUL) {
+          ++curwin->w_cursor.col;         // put cursor back on the NUL
+        }
+      }
 
       /* <C-S-Right> may have started Visual mode, adjust the position for
        * deleted characters. */

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -253,7 +253,7 @@ static int included_patches[] = {
   //495 NA
   494,
   493,
-  //492,
+  492,
   491,
   490,
   489,

--- a/test/functional/legacy/004_bufenter_with_modelines_spec.lua
+++ b/test/functional/legacy/004_bufenter_with_modelines_spec.lua
@@ -46,6 +46,12 @@ describe('BufEnter with modelines', function()
     -- Include Xxx in the current file
     feed('G:r Xxx<CR>')
 
+    -- Vim issue #57 do not move cursor on <c-o> when autoindent is set
+    execute('set fo+=r')
+    feed('G')
+    feed('o# abcdef<Esc>2hi<CR><c-o>d0<Esc>')
+    feed('o# abcdef<Esc>2hi<c-o>d0<Esc>')
+
     expect([[
       startstart
       start of test file Xxx
@@ -63,7 +69,10 @@ describe('BufEnter with modelines', function()
           this is a test
           this is a test
       this should be in column 1
-      end of test file Xxx]])
+      end of test file Xxx
+      # abc
+      def
+      def]])
   end)
 
   teardown(function()


### PR DESCRIPTION
```
Problem:    In Insert mode, after inserting a newline that inserts a comment
        leader, CTRL-O moves to the right. (ZyX) Issue 57.
Solution:   Correct the condition for moving the cursor back to the NUL.
        (Christian Brabandt)
```

  https://code.google.com/p/vim/source/detail?r=v7-4-492

  Original patch:

``` diff
  diff --git a/src/nvim/edit.c b/src/nvim/edit.c
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -6916,8 +6916,12 @@ stop_insert(end_insert_pos, esc, nomove)
        }
        if (curwin->w_cursor.lnum != tpos.lnum)
        curwin->w_cursor = tpos;
-       else if (cc != NUL)
-       ++curwin->w_cursor.col; /* put cursor back on the NUL */
+       else
+       {
+       tpos.col++;
+       if (cc != NUL && gchar_pos(&tpos) == NUL)
+           ++curwin->w_cursor.col; /* put cursor back on the NUL */
+       }

        /* <C-S-Right> may have started Visual mode, adjust the position for
         * deleted characters. */
diff --git a/src/nvim/testdir/test4.in b/src/nvim/testdir/test4.in
--- a/src/nvim/testdir/test4.in
+++ b/src/nvim/testdir/test4.in
@@ -17,6 +17,9 @@ othis should be auto-indented
 G?this is a
 othis should be in column 1:wq " append text without autoindent to Xxx
 G:r Xxx             " include Xxx in the current file
+:set fo+=r          " issue #57 do not move cursor on <c-o> when autoindent is set
+Go# abcdef2hi
+d0o# abcdef2hid0
 :?startstart?,$w! test.out
 :qa!
 ENDTEST
diff --git a/src/nvim/testdir/test4.ok b/src/nvim/testdir/test4.ok
--- a/src/nvim/testdir/test4.ok
+++ b/src/nvim/testdir/test4.ok
@@ -15,3 +15,6 @@ vim: set noai :
    this is a test
 this should be in column 1
 end of test file Xxx
+# abc
+def
+def
diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    492,
+/**/
     491,
 /**/
     490,
```
