### PR TITLE
[RFC] vim-patch:bd18da9 (runtime update)

### DIFF
--- a/runtime/autoload/phpcomplete.vim
+++ b/runtime/autoload/phpcomplete.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Dávid Szabó ( complex857 AT gmail DOT com )
 " Previous Maintainer:	Mikolaj Machowski ( mikmach AT wp DOT pl )
 " URL: https://github.com/shawncplus/phpcomplete.vim
-" Last Change:  2014 Aug 10
+" Last Change:  2014 Oct 02
 "
 "	OPTIONS:
 "
@@ -2343,6 +2343,9 @@ function! phpcomplete#GetCurrentNameSpace(file_lines) " {{{
 							endif
 						endfor
 					endif
+				endif
+				if exists('no_namespace_candidate')
+					unlet no_namespace_candidate
 				endif
 			endfor
 		endif

--- a/runtime/compiler/msvc.vim
+++ b/runtime/compiler/msvc.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
-" Compiler:	Miscrosoft Visual C
+" Compiler:	Microsoft Visual C
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2005 Nov 30
+" Last Change:	2014 Sep 20
 
 if exists("current_compiler")
   finish

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1,4 +1,4 @@
-*autocmd.txt*   For Vim version 7.4.  Last change: 2014 Aug 22
+*autocmd.txt*   For Vim version 7.4.  Last change: 2014 Sep 23
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -520,6 +520,11 @@ CursorHold			When the user doesn't press a key for the time
 				operator.
 				While recording the CursorHold event is not
 				triggered. |q|
+							*<CursorHold>*
+				Internally the autocommand is triggered by the
+				<CursorHold> key. In an expression mapping
+				|getchar()| may see this character.
+
 				Note: Interactive commands cannot be used for
 				this event.  There is no hit-enter prompt,
 				the screen is updated directly (when needed).

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 7.4.  Last change: 2014 Sep 09
+*eval.txt*	For Vim version 7.4.  Last change: 2014 Sep 27
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1751,7 +1751,7 @@ confirm( {msg} [, {choices} [, {default} [, {type}]]])
 copy( {expr})			any	make a shallow copy of {expr}
 cos( {expr})			Float	cosine of {expr}
 cosh( {expr})			Float	hyperbolic cosine of {expr}
-count( {list}, {expr} [, {start} [, {ic}]])
+count( {list}, {expr} [, {ic} [, {start}]])
 				Number	 count how many {expr} are in {list}
 cscope_connection( [{num} , {dbpath} [, {prepend}]])
 				Number	checks existence of cscope connection

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1,4 +1,4 @@
-*map.txt*       For Vim version 7.4.  Last change: 2014 Jun 02
+*map.txt*       For Vim version 7.4.  Last change: 2014 Sep 30
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1282,6 +1282,8 @@ completion can be enabled:
 	-complete=var		user variables
 	-complete=custom,{func} custom completion, defined via {func}
 	-complete=customlist,{func} custom completion, defined via {func}
+
+Note: That some completion methods might expand environment variables.
 
 
 Custom completion			*:command-completion-custom*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 7.4.  Last change: 2014 Sep 09
+*options.txt*	For Vim version 7.4.  Last change: 2014 Sep 23
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -3937,6 +3937,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When Vim was compiled with HAVE_X11 defined, the original icon will be
 	restored if possible |X11|.  See |X11-icon| for changing the icon on
 	X11.
+	For MS-Windows the icon can be changed, see |windows-icon|.
 
 						*'iconstring'*
 'iconstring'		string	(default "")

--- a/runtime/doc/os_win32.txt
+++ b/runtime/doc/os_win32.txt
@@ -1,4 +1,4 @@
-*os_win32.txt*  For Vim version 7.4.  Last change: 2014 Aug 29
+*os_win32.txt*  For Vim version 7.4.  Last change: 2014 Sep 25
 
 
 		  VIM REFERENCE MANUAL    by George Reilly
@@ -363,5 +363,11 @@ Q. I use Vim under Win32s and NT.  In NT, I can define the console to default to
    W3.1x, or am I stuck with 80x25?
 A. Edit SYSTEM.INI and add 'ScreenLines=50' to the [NonWindowsApp] section.  DOS
    prompts and external DOS commands will now run in a 50-line window.
+
+						*windows-icon*
+Q. I don't like the Vim icon, can I change it?
+A. Yes, place your favorite icon in bitmaps/vim.ico in a directory of
+   'runtimepath'.  For example ~/vimfiles/bitmaps/vim.ico.
+
 
  vim:tw=78:fo=tcq2:ts=8:ft=help:norl:

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 7.4.  Last change: 2014 Sep 09
+*syntax.txt*	For Vim version 7.4.  Last change: 2014 Sep 27
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -3799,7 +3799,7 @@ The 'foldnestmax' option limits the nesting of syntax folds.
 
 
 			*:syn-contains* *E405* *E406* *E407* *E408* *E409*
-contains={groupname},..
+contains={group-name},..
 
 The "contains" argument is followed by a list of syntax group names.  These
 groups will be allowed to begin inside the item (they may extend past the
@@ -3852,13 +3852,13 @@ region where contained items do match.	Note that this may also limit the
 area that is highlighted
 
 
-containedin={groupname}...				*:syn-containedin*
+containedin={group-name}...				*:syn-containedin*
 
 The "containedin" argument is followed by a list of syntax group names.  The
 item will be allowed to begin inside these groups.  This works as if the
 containing item has a "contains=" argument that includes this item.
 
-The {groupname}... can be used just like for "contains", as explained above.
+The {group-name}... can be used just like for "contains", as explained above.
 
 This is useful when adding a syntax item afterwards.  An item can be told to
 be included inside an already existing item, without changing the definition
@@ -3874,7 +3874,7 @@ keywords never contain another item, thus adding them to "containedin" won't
 work.
 
 
-nextgroup={groupname},..				*:syn-nextgroup*
+nextgroup={group-name},..				*:syn-nextgroup*
 
 The "nextgroup" argument is followed by a list of syntax group names,
 separated by commas (just like with "contains", so you can also use patterns).

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 7.4.  Last change: 2014 Sep 19
+*todo.txt*      For Vim version 7.4.  Last change: 2014 Oct 02
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -58,6 +58,15 @@ Patch to make getregtype() return the right size for non-linux systems.
 (Yasuhiro Matsumoto, 2014 Jul 8)
 Breaks test_eval.  Inefficient, can we only compute y_width when needed?
 
+Patch to fix 'linebreak' when applying an operator.  And fix the test not
+actually testing. (Christian Brabandt, 2014 Sep 23)
+
+patch to fix issue 26. (Christian)
+
+Test 11 and 100 do not work properly on Windows.
+Patch by Ken Takata (2014 Sep 25)
+Alternative patch Oct 1.
+
 Problem that a previous silent ":throw" causes a following try/catch not to
 work. (ZyX, 2013 Sep 28)
 
@@ -65,25 +74,14 @@ Patch to avoid problems with encoding conversion with diff.vim.
 (Yasuhiro Matsumoto, 2014 Sep 1.
 Depends on current language, language of file can be different.
 
-Patch for C/C++ syntax string handling. (Brian Bi, 2014 Sep 13)
-
-When using a visual selection of multiple words and doing CTRL-W_] it jumps to
-the tag matching the word under the cursor, not the selected text.
-(Patrick hemmer)
-Patch by Christian, 2014 Aug 8.
-
-Completion for :buf does not use 'wildignorecase'. (Akshay H, 2014 May 31)
-
-'backupcopy' should be global-local, so that some files can be written in a
-different way.  Patch by Christian, 2014 Sep 17.
-
-Patch to handle list with some items locked. (ZyX, 2014 Aug 17)
-Prefer the second solution.
-
-Issue 252.  Patch by Christian, 2014 Aug 26.
+Add books from Steve Oualline to Vim website. (2014 Sep 25)
 
 ":cd C:\Windows\System32\drivers\etc*" does not work, even though the
 directory exists. (Sergio Gallelli, 2013 Dec 29)
+
+Patch to have the fold and sign column and at the last line of the buffer.
+(Marco Hinz, 2014 Sep 25)
+Alternate suggestion: let all columns continue, also number column.
 
 Patch by Marcin Szamotulski to add count to :close (2014 Aug 10, update Aug
 14, Aug 30)
@@ -92,18 +90,40 @@ Patch by Marcin Szamotulski to add count to :close (2014 Aug 10, update Aug
     Make ":-1close" close the previous window.
 Doesn't look right, asked for updates.
 
-Patch to add a special key name for K_CURSORHOLD. (Hirohito Higashi, 2014 Aug
-10)
+Patch to handle multi-byte printer name on MS-Windows. (Yasuhiro Matsumoto,
+2014 Sept 28)
+
+Two patches by Christian, 2014 Sep 29:
+- Combination of precedes listchar and 'showbreak' doesn't work well.
+- Moving cursor is off when 'nu' and 'sbr' are set.
 
 The entries added by matchaddpos() are returned by getmatches() but can't be
 set with setmatches(). (lcd47, 2014 Jun 29)
+
+Patch to fix window title for a command window on MS-Windows. (Yasuhiro
+Matsumoto, 2014 Sep 28)
+
+Patch to fix that 0x80 in abbreviation isn't handled correctly.
+(Christian Brabandt, 2014 Oct 1)
+
+Patch to fix issue 57, on the issue.
+
+Patch for issue 101, maintainer unreachable.
+
+Remove restriction in NSIS installer that the end of the path must be "Vim".
+(Tim Lebedkov, 2014 Sep 24)
 
 Problem using ":try" inside ":execute". (ZyX, 2013 Sep 15)
 
 Python: ":py raw_input('prompt')" doesn't work. (Manu Hack)
 
+'foldexpr' applies to help. (Paul Marshall, 2014 Sep 24)
+
 Value returned by virtcol() changes depending on how lines wrap.  This is
 inconsistent with the documentation.
+
+On MS-Windows running tests with Mercurial has problems when the input files
+are changed. (Ken Takata, Taro Muraoka, 2014 Sep 25)
 
 MS-Windows: Crash opening very long file name starting with "\\".
 (Christian Brock, 2012 Jun 29)
@@ -111,10 +131,12 @@ MS-Windows: Crash opening very long file name starting with "\\".
 ml_updatechunk() is slow when retrying for another encoding. (John Little,
 2014 Sep 11)
 
-Syntax highlighting slow (hangs) in SASS file. (Niek Bosch, 2013 Aug 21)
+Make comments in the test Makefile silent. (Kartik Agaram, 2014 Sep 24)
 
-Patch to allow for a different icon on MS-Windows. (Yasuhiro Matsumoto, 2014
-Sep 7).
+When in 'comments' "n:x" follows after three-part comment directly it repeats
+any one-character from the previous line. (Kartik Agaram, 2014 Sep 19)
+
+Syntax highlighting slow (hangs) in SASS file. (Niek Bosch, 2013 Aug 21)
 
 Adding "~" to 'cdpath' doesn't work for completion?  (Davido, 2013 Aug 19)
 
@@ -164,6 +186,8 @@ from?
 
 Problem with upwards search on Windows (works OK on Linux). (Brett Stahlman,
 2014 Jun 8)
+
+Patch to load TCL dynamically. (Ken Takata, 2014 Sep 20)
 
 Include a plugin manager with Vim? Neobundle seems to be the best currently.
 Long message about this from ZyX, 2014 Mar 23.  And following replies.

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1,4 +1,4 @@
-*windows.txt*   For Vim version 7.4.  Last change: 2014 Mar 25
+*windows.txt*   For Vim version 7.4.  Last change: 2014 Sep 23
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -726,18 +726,21 @@ the buffer.  The result is that all buffers will use the 'encoding' encoding
 
 CTRL-W ]					*CTRL-W_]* *CTRL-W_CTRL-]*
 CTRL-W CTRL-]	Split current window in two.  Use identifier under cursor as a
-		tag and jump to it in the new upper window.  Make new window N
-		high.
+		tag and jump to it in the new upper window.
+		In Visual mode uses the Visually selected text as a tag.
+		Make new window N high.
 
 							*CTRL-W_g]*
 CTRL-W g ]	Split current window in two.  Use identifier under cursor as a
 		tag and perform ":tselect" on it in the new upper window.
+		In Visual mode uses the Visually selected text as a tag.
 		Make new window N high.
 
 							*CTRL-W_g_CTRL-]*
 CTRL-W g CTRL-]	Split current window in two.  Use identifier under cursor as a
-		tag and perform ":tjump" on it in the new upper window.  Make
-		new window N high.
+		tag and perform ":tjump" on it in the new upper window.
+		In Visual mode uses the Visually selected text as a tag.
+		Make new window N high.
 
 CTRL-W f					*CTRL-W_f* *CTRL-W_CTRL-F*
 CTRL-W CTRL-F	Split current window in two.  Edit file name under cursor.

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	C
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 May 26
+" Last Change:	2014 Sep 23
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -35,27 +35,36 @@ syn match	cSpecial	display contained "\\\(x\x\+\|\o\{1,3}\|.\|$\)"
 if !exists("c_no_utf")
   syn match	cSpecial	display contained "\\\(u\x\{4}\|U\x\{8}\)"
 endif
-if exists("c_no_cformat")
-  syn region	cString		start=+L\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,@Spell extend
-  " cCppString: same as cString, but ends at end of line
-  if !exists("cpp_no_cpp11") " ISO C++11
-    syn region cCppString	start=+\(L\|u\|u8\|U\|R\|LR\|u8R\|uR\|UR\)\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
-  else
-    syn region cCppString	start=+L\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
-  endif
-  syn region	cCppOut2	contained start="0" end="^\s*\(%:\|#\)\s*\(endif\>\|else\>\|elif\>\)" contains=cSpaceError,cCppSkip
-  syn region	cCppSkip	contained start="^\s*\(%:\|#\)\s*\(if\>\|ifdef\>\|ifndef\>\)" skip="\\$" end="^\s*\(%:\|#\)\s*endif\>" contains=cSpaceError,cCppSkip
-else
+
+if !exists("c_no_cformat")
+  " Highlight % items in strings.
   if !exists("c_no_c99") " ISO C99
     syn match	cFormat		display "%\(\d\+\$\)\=[-+' #0*]*\(\d*\|\*\|\*\d\+\$\)\(\.\(\d*\|\*\|\*\d\+\$\)\)\=\([hlLjzt]\|ll\|hh\)\=\([aAbdiuoxXDOUfFeEgGcCsSpn]\|\[\^\=.[^]]*\]\)" contained
   else
     syn match	cFormat		display "%\(\d\+\$\)\=[-+' #0*]*\(\d*\|\*\|\*\d\+\$\)\(\.\(\d*\|\*\|\*\d\+\$\)\)\=\([hlL]\|ll\)\=\([bdiuoxXDOUfeEgGcCsSpn]\|\[\^\=.[^]]*\]\)" contained
   endif
   syn match	cFormat		display "%%" contained
+endif
+
+" cCppString: same as cString, but ends at end of line
+if s:ft ==# "cpp" && !exists("cpp_no_cpp11")
+  " ISO C++11
+  syn region	cString		start=+\(L\|u\|u8\|U\|R\|LR\|u8R\|uR\|UR\)\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell extend
+  syn region 	cCppString	start=+\(L\|u\|u8\|U\|R\|LR\|u8R\|uR\|UR\)\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
+elseif s:ft ==# "c" && !exists("c_no_c11")
+  " ISO C99
+  syn region	cString		start=+\%(L\|U\|u8\)\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell extend
+  syn region	cCppString	start=+\%(L\|U\|u8\)\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
+else
+  " older C or C++
   syn region	cString		start=+L\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell extend
-  " cCppString: same as cString, but ends at end of line
   syn region	cCppString	start=+L\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
 endif
+
+syn region	cCppOut2	contained start="0" end="^\s*\(%:\|#\)\s*\(endif\>\|else\>\|elif\>\)" contains=cSpaceError,cCppSkip
+syn region	cCppSkip	contained start="^\s*\(%:\|#\)\s*\(if\>\|ifdef\>\|ifndef\>\)" skip="\\$" end="^\s*\(%:\|#\)\s*endif\>" contains=cSpaceError,cCppSkip
+
+syn cluster	cStringGroup	contains=cCppString,cCppOut2,cCppSkip
 
 syn match	cCharacter	"L\='[^\\]'"
 syn match	cCharacter	"L'[^']*'" contains=cSpecial
@@ -70,12 +79,9 @@ syn match	cSpecialCharacter display "L\='\\\o\{1,3}'"
 syn match	cSpecialCharacter display "'\\x\x\{1,2}'"
 syn match	cSpecialCharacter display "L'\\x\x\+'"
 
-if !exists("c_no_c11") " ISO C11
-  if exists("c_no_cformat")
-    syn region	cString		start=+\%(U\|u8\=\)"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,@Spell extend
-  else
-    syn region	cString		start=+\%(U\|u8\=\)"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell extend
-  endif
+if (s:ft ==# "c" && !exists("c_no_c11")) || (s:ft ==# "cpp" && !exists("cpp_no_cpp11"))
+  " ISO C11 or ISO C++ 11
+  syn region	cString		start=+\%(U\|u8\=\)"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell extend
   syn match	cCharacter	"[Uu]'[^\\]'"
   syn match	cCharacter	"[Uu]'[^']*'" contains=cSpecial
   if exists("c_gnu")
@@ -102,24 +108,24 @@ endif
 " This should be before cErrInParen to avoid problems with #define ({ xxx })
 if exists("c_curly_error")
   syn match cCurlyError "}"
-  syn region	cBlock		start="{" end="}" contains=ALLBUT,cBadBlock,cCurlyError,@cParenGroup,cErrInParen,cCppParen,cErrInBracket,cCppBracket,cCppString,@Spell fold
+  syn region	cBlock		start="{" end="}" contains=ALLBUT,cBadBlock,cCurlyError,@cParenGroup,cErrInParen,cCppParen,cErrInBracket,cCppBracket,@cStringGroup,@Spell fold
 else
   syn region	cBlock		start="{" end="}" transparent fold
 endif
 
-"catch errors caused by wrong parenthesis and brackets
-" also accept <% for {, %> for }, <: for [ and :> for ] (C99)
+" Catch errors caused by wrong parenthesis and brackets.
+" Also accept <% for {, %> for }, <: for [ and :> for ] (C99)
 " But avoid matching <::.
 syn cluster	cParenGroup	contains=cParenError,cIncluded,cSpecial,cCommentSkip,cCommentString,cComment2String,@cCommentGroup,cCommentStartError,cUserLabel,cBitField,cOctalZero,@cCppOutInGroup,cFormat,cNumber,cFloat,cOctal,cOctalError,cNumbersCom
 if exists("c_no_curly_error")
   if s:ft ==# 'cpp' && !exists("cpp_no_cpp11")
-    syn region	cParen		transparent start='(' end=')' contains=ALLBUT,@cParenGroup,cCppParen,cCppString,@Spell
+    syn region	cParen		transparent start='(' end=')' contains=ALLBUT,@cParenGroup,cCppParen,@cStringGroup,@Spell
     " cCppParen: same as cParen but ends at end-of-line; used in cDefine
     syn region	cCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@cParenGroup,cParen,cString,@Spell
     syn match	cParenError	display ")"
     syn match	cErrInParen	display contained "^^<%\|^%>"
   else
-    syn region	cParen		transparent start='(' end=')' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cCppParen,cCppString,@Spell
+    syn region	cParen		transparent start='(' end=')' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cCppParen,@cStringGroup,@Spell
     " cCppParen: same as cParen but ends at end-of-line; used in cDefine
     syn region	cCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@cParenGroup,cParen,cString,@Spell
     syn match	cParenError	display ")"
@@ -127,13 +133,13 @@ if exists("c_no_curly_error")
   endif
 elseif exists("c_no_bracket_error")
   if s:ft ==# 'cpp' && !exists("cpp_no_cpp11")
-    syn region	cParen		transparent start='(' end=')' contains=ALLBUT,@cParenGroup,cCppParen,cCppString,@Spell
+    syn region	cParen		transparent start='(' end=')' contains=ALLBUT,@cParenGroup,cCppParen,@cStringGroup,@Spell
     " cCppParen: same as cParen but ends at end-of-line; used in cDefine
     syn region	cCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@cParenGroup,cParen,cString,@Spell
     syn match	cParenError	display ")"
     syn match	cErrInParen	display contained "<%\|%>"
   else
-    syn region	cParen		transparent start='(' end=')' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cCppParen,cCppString,@Spell
+    syn region	cParen		transparent start='(' end=')' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cCppParen,@cStringGroup,@Spell
     " cCppParen: same as cParen but ends at end-of-line; used in cDefine
     syn region	cCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@cParenGroup,cParen,cString,@Spell
     syn match	cParenError	display ")"
@@ -141,19 +147,19 @@ elseif exists("c_no_bracket_error")
   endif
 else
   if s:ft ==# 'cpp' && !exists("cpp_no_cpp11")
-    syn region	cParen		transparent start='(' end=')' contains=ALLBUT,@cParenGroup,cCppParen,cErrInBracket,cCppBracket,cCppString,@Spell
+    syn region	cParen		transparent start='(' end=')' contains=ALLBUT,@cParenGroup,cCppParen,cErrInBracket,cCppBracket,@cStringGroup,@Spell
     " cCppParen: same as cParen but ends at end-of-line; used in cDefine
     syn region	cCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@cParenGroup,cErrInBracket,cParen,cBracket,cString,@Spell
     syn match	cParenError	display "[\])]"
     syn match	cErrInParen	display contained "<%\|%>"
-    syn region	cBracket	transparent start='\[\|<::\@!' end=']\|:>' contains=ALLBUT,@cParenGroup,cErrInParen,cCppParen,cCppBracket,cCppString,@Spell
+    syn region	cBracket	transparent start='\[\|<::\@!' end=']\|:>' contains=ALLBUT,@cParenGroup,cErrInParen,cCppParen,cCppBracket,@cStringGroup,@Spell
   else
-    syn region	cParen		transparent start='(' end=')' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cCppParen,cErrInBracket,cCppBracket,cCppString,@Spell
+    syn region	cParen		transparent start='(' end=')' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cCppParen,cErrInBracket,cCppBracket,@cStringGroup,@Spell
     " cCppParen: same as cParen but ends at end-of-line; used in cDefine
     syn region	cCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@cParenGroup,cErrInBracket,cParen,cBracket,cString,@Spell
     syn match	cParenError	display "[\])]"
     syn match	cErrInParen	display contained "[\]{}]\|<%\|%>"
-    syn region	cBracket	transparent start='\[\|<::\@!' end=']\|:>' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cErrInParen,cCppParen,cCppBracket,cCppString,@Spell
+    syn region	cBracket	transparent start='\[\|<::\@!' end=']\|:>' end='}'me=s-1 contains=ALLBUT,cBlock,@cParenGroup,cErrInParen,cCppParen,cCppBracket,@cStringGroup,@Spell
   endif
   " cCppBracket: same as cParen but ends at end-of-line; used in cDefine
   syn region	cCppBracket	transparent start='\[\|<::\@!' skip='\\$' excludenl end=']\|:>' end='$' contained contains=ALLBUT,@cParenGroup,cErrInParen,cParen,cBracket,cString,@Spell
@@ -376,7 +382,7 @@ syn region	cPreProc	start="^\s*\(%:\|#\)\s*\(pragma\>\|line\>\|warning\>\|warn\>
 " Highlight User Labels
 syn cluster	cMultiGroup	contains=cIncluded,cSpecial,cCommentSkip,cCommentString,cComment2String,@cCommentGroup,cCommentStartError,cUserCont,cUserLabel,cBitField,cOctalZero,cCppOutWrapper,cCppInWrapper,@cCppOutInGroup,cFormat,cNumber,cFloat,cOctal,cOctalError,cNumbersCom,cCppParen,cCppBracket,cCppString
 if s:ft ==# 'c' || exists("cpp_no_cpp11")
-  syn region	cMulti		transparent start='?' skip='::' end=':' contains=ALLBUT,@cMultiGroup,@Spell
+  syn region	cMulti		transparent start='?' skip='::' end=':' contains=ALLBUT,@cMultiGroup,@Spell,@cStringGroup
 endif
 " Avoid matching foo::bar() in C++ by requiring that the next char is not ':'
 syn cluster	cLabelGroup	contains=cUserLabel

--- a/runtime/syntax/valgrind.vim
+++ b/runtime/syntax/valgrind.vim
@@ -2,9 +2,11 @@
 " Language: Valgrind Memory Debugger Output
 " Maintainer: Roger Luethi <rl@hellgate.ch>
 " Program URL: http://devel-home.kde.org/~sewardj/
-" Last Change: 2012 Apr 30
+" Last Change: 2014 Oct 02
 "
 " Notes: mostly based on strace.vim and xml.vim
+"
+" Contributors: Christoph Gysin <christoph.gysin@gmail.com>
 
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -65,7 +67,7 @@ syn match valgrindAt "at\s\@=" contained
 syn match valgrindAddr "\(\W\)\@<=0x\x\+" contained
 syn match valgrindFunc "\(: \)\@<=\w\+" contained
 syn match valgrindBin "\((\(with\|\)in \)\@<=\S\+\()\)\@=" contained
-syn match valgrindSrc "\((\)\@<=.*:\d\+\()\)\@=" contained
+syn match valgrindSrc "\((\)\@<=[^)]*:\d\+\()\)\@=" contained
 
 " Define the default highlighting
 


### PR DESCRIPTION
~~On top of #1852, which should be merged first.~~

https://code.google.com/p/vim/source/detail?r=bd18da914be9d43a70713f6af02770a0d3280159

This PR has no manual changes. Output of `patch -p1 < vim-bd18da9.diff`:

```
patching file runtime/autoload/phpcomplete.vim
patching file runtime/compiler/msvc.vim
patching file runtime/doc/autocmd.txt
Hunk #2 succeeded at 520 (offset 1 line).
patching file runtime/doc/editing.txt
Hunk #1 FAILED at 1483.
1 out of 1 hunk FAILED -- saving rejects to file runtime/doc/editing.txt.rej
patching file runtime/doc/eval.txt
patching file runtime/doc/map.txt
can't find file to patch at input line 110
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/netbeans.txt b/runtime/doc/netbeans.txt
|--- a/runtime/doc/netbeans.txt
|+++ b/runtime/doc/netbeans.txt
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
1 out of 1 hunk ignored
patching file runtime/doc/options.txt
Hunk #2 succeeded at 3937 (offset -72 lines).
patching file runtime/doc/os_win32.txt
Hunk #2 succeeded at 364 (offset -3 lines).
patching file runtime/doc/syntax.txt
can't find file to patch at input line 202
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/tags b/runtime/doc/tags
|--- a/runtime/doc/tags
|+++ b/runtime/doc/tags
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
2 out of 2 hunks ignored
patching file runtime/doc/todo.txt
can't find file to patch at input line 347
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/version7.txt b/runtime/doc/version7.txt
|--- a/runtime/doc/version7.txt
|+++ b/runtime/doc/version7.txt
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
1 out of 1 hunk ignored
patching file runtime/doc/windows.txt
patching file runtime/syntax/c.vim
patching file runtime/syntax/valgrind.vim
```

The rejected hunk in `editing.txt` was because of `cryptmethod`, which has been removed from Neovim, as have `version7.txt`, `netbeans.txt`. As usual, the `tags` file can also be ignored.
