### PR TITLE
[RFC] vim-patch:7.4.446

### DIFF
--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -489,7 +489,8 @@ void free_all_mem(void)
     return;
   entered = true;
 
-  block_autocmds();         /* don't want to trigger autocommands here */
+  // Don't want to trigger autocommands from here on.
+  block_autocmds();
 
   /* Close all tabs and windows.  Reset 'equalalways' to avoid redraws. */
   p_ea = FALSE;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -299,7 +299,7 @@ static int included_patches[] = {
   449,
   //448 NA
   447,
-  //446,
+  446,
   //445,
   444,
   //443 NA

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1024,7 +1024,7 @@ static void win_init(win_T *newp, win_T *oldp, int flags)
 }
 
 /*
- * Initialize window "newp" from window"old".
+ * Initialize window "newp" from window "old".
  * Only the essential things are copied.
  */
 static void win_init_some(win_T *newp, win_T *oldp)
@@ -5190,8 +5190,8 @@ static win_T *restore_snapshot_rec(frame_T *sn, frame_T *fr)
 
 /*
  * Set "win" to be the curwin and "tp" to be the current tab page.
- * restore_win() MUST be called to undo.
- * No autocommands will be executed.
+ * restore_win() MUST be called to undo, also when FAIL is returned.
+ * No autocommands will be executed until restore_win() is called.
  * When "no_display" is TRUE the display won't be affected, no redraw is
  * triggered, another tabpage access is limited.
  * Returns FAIL if switching to "win" failed.
@@ -5212,7 +5212,6 @@ int switch_win(win_T **save_curwin, tabpage_T **save_curtab, win_T *win, tabpage
       goto_tabpage_tp(tp, FALSE, FALSE);
   }
   if (!win_valid(win)) {
-    unblock_autocmds();
     return FAIL;
   }
   curwin = win;


### PR DESCRIPTION
```
Problem:    In some situations, when setting up an environment to trigger an
        autocommand, the environment is not properly restored.
Solution:   Check the return value of switch_win() and call restore_win()
        always.  (Daniel Hahler)
```

https://code.google.com/p/vim/source/detail?r=v7-4-446

Additionally to original patch I have changed some local variables to bool and updated the style of some comments by the way. AFAIR it is permitted :-)
