### PR TITLE
[RFC] vim-patch:7.4.462

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3794,16 +3794,21 @@ did_set_string_option (
       flags = &curbuf->b_bkc_flags;
     }
 
-    if (opt_strings_flags(bkc, p_bkc_values, flags, TRUE) != OK) {
-      errmsg = e_invarg;
-    }
+    if ((opt_flags & OPT_LOCAL) && *bkc == NUL) {
+      // make the local value empty: use the global value
+      *flags = 0;
+    } else {
+      if (opt_strings_flags(bkc, p_bkc_values, flags, TRUE) != OK) {
+        errmsg = e_invarg;
+      }
 
-    if (((*flags & BKC_AUTO) != 0)
-        + ((*flags & BKC_YES) != 0)
-        + ((*flags & BKC_NO) != 0) != 1) {
-      /* Must have exactly one of "auto", "yes"  and "no". */
-      (void)opt_strings_flags(oldval, p_bkc_values, flags, TRUE);
-      errmsg = e_invarg;
+      if (((*flags & BKC_AUTO) != 0)
+          + ((*flags & BKC_YES) != 0)
+          + ((*flags & BKC_NO) != 0) != 1) {
+        // Must have exactly one of "auto", "yes"  and "no".
+        (void)opt_strings_flags(oldval, p_bkc_values, flags, TRUE);
+        errmsg = e_invarg;
+      }
     }
   }
   /* 'backupext' and 'patchmode' */

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -283,7 +283,7 @@ static int included_patches[] = {
   //465 NA
   //464 NA
   463,
-  //462,
+  462,
   //461 NA
   //460 NA
   //459 NA


### PR DESCRIPTION
```
Problem:    Setting the local value of 'backupcopy' empty gives an error.
        (Peter Mattern)
Solution:   When using an empty value set the flags to zero. (Hirohito
        Higashi)
```

https://code.google.com/p/vim/source/detail?r=v7-4-462

  Original patch:

``` diff
  diff --git a/src/nvim/option.c b/src/nvim/option.c
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5742,15 +5742,21 @@ did_set_string_option(opt_idx, varp, new
        flags = &curbuf->b_bkc_flags;
    }

-   if (opt_strings_flags(bkc, p_bkc_values, flags, TRUE) != OK)
-       errmsg = e_invarg;
-   if ((((int)*flags & BKC_AUTO) != 0)
-       + (((int)*flags & BKC_YES) != 0)
-       + (((int)*flags & BKC_NO) != 0) != 1)
-   {
-       /* Must have exactly one of "auto", "yes"  and "no". */
-       (void)opt_strings_flags(oldval, p_bkc_values, flags, TRUE);
-       errmsg = e_invarg;
+   if ((opt_flags & OPT_LOCAL) && *bkc == NUL)
+       /* make the local value empty: use the global value */
+       *flags = 0;
+   else
+   {
+       if (opt_strings_flags(bkc, p_bkc_values, flags, TRUE) != OK)
+       errmsg = e_invarg;
+       if ((((int)*flags & BKC_AUTO) != 0)
+           + (((int)*flags & BKC_YES) != 0)
+           + (((int)*flags & BKC_NO) != 0) != 1)
+       {
+       /* Must have exactly one of "auto", "yes"  and "no". */
+       (void)opt_strings_flags(oldval, p_bkc_values, flags, TRUE);
+       errmsg = e_invarg;
+       }
    }
     }

diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    462,
+/**/
     461,
 /**/
     460,
```
