### PR TITLE
[RDY] Fix tests for plain lua

### DIFF
--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -117,7 +117,7 @@ describe('vim_* functions', function()
 
   describe('replace_termcodes', function()
     it('escapes K_SPECIAL as K_SPECIAL KS_SPECIAL KE_FILLER', function()
-      eq(helpers.nvim('replace_termcodes', '\x80', true, true, true), '\x80\xfeX')
+      eq(helpers.nvim('replace_termcodes', '\128', true, true, true), '\128\254X')
     end)
 
     it('leaves non K_SPECIAL string unchanged', function()

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -72,10 +72,10 @@ describe('clipboard usage', function()
     reset()
 
     -- handle null bytes
-    insert("some\x16000text\n\x16000very binary\x16000")
+    insert("some\022000text\n\022000very binary\022000")
     feed('"*y-+"*p')
     eq({'some\ntext', '\nvery binary\n',''}, eval("g:test_clip['*']"))
-    expect("some\x00text\n\x00very binary\x00\nsome\x00text\n\x00very binary\x00")
+    expect("some\00text\n\00very binary\00\nsome\00text\n\00very binary\00")
 
     -- test getreg/getregtype
     eq('some\ntext\n\nvery binary\n\n', eval("getreg('*', 1)"))
@@ -92,7 +92,7 @@ describe('clipboard usage', function()
     expect([[
       very much
       blocktext]])
-    eq("\x165", eval("getregtype('*')"))
+    eq("\0225", eval("getregtype('*')"))
     reset()
 
     -- test setreg

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -5,7 +5,8 @@ local AsyncSession = require('nvim.async_session')
 local Session = require('nvim.session')
 
 local nvim_prog = os.getenv('NVIM_PROG') or 'build/bin/nvim'
-local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N', '--embed'}
+local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
+                   '--cmd', 'set shortmess+=I background=light', '--embed'}
 local prepend_argv
 
 if os.getenv('VALGRIND') then

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -219,7 +219,7 @@ end
 
 function Screen:_handle_eol_clear()
   local row, col = self._cursor.row, self._cursor.col
-  self:_clear_block(row, 1, col, self._scroll_region.right - col)
+  self:_clear_block(row, row, col, self._scroll_region.right)
 end
 
 function Screen:_handle_cursor_goto(row, col)
@@ -330,9 +330,9 @@ function Screen:_handle_set_icon(icon)
   self.icon = icon
 end
 
-function Screen:_clear_block(top, lines, left, columns)
-  for i = top, top + lines - 1 do
-    self:_clear_row_section(i, left, left + columns - 1)
+function Screen:_clear_block(top, bot, left, right)
+  for i = top, bot do
+    self:_clear_row_section(i, left, right)
   end
 end
 


### PR DESCRIPTION
Make it possible to run functional tests with plain lua, which is useful for inspecting the lua stack trace with gdb when tests hang

Also include a fix from #1820
