### PR TITLE
[RDY] Remove deadcode due to nonnullret funcs.

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -390,19 +390,13 @@ char_u *transstr(char_u *s) FUNC_ATTR_NONNULL_RET
   return res;
 }
 
-/// Convert the string "str[orglen]" to do ignore-case comparing.  Uses the
-/// current locale.
+/// Convert the string "str[orglen]" to do ignore-case comparing.
+/// Use the current locale.
 ///
-/// When "buf" is NULL returns an allocated string (NULL for out-of-memory).
-/// Otherwise puts the result in "buf[buflen]".
-///
-/// @param str
-/// @param orglen
-/// @param buf
-/// @param buflen
-///
-/// @return converted string.
+/// When "buf" is NULL, return an allocated string.
+/// Otherwise, put the result in buf, limited by buflen, and return buf.
 char_u* str_foldcase(char_u *str, int orglen, char_u *buf, int buflen)
+  FUNC_ATTR_NONNULL_RET
 {
   garray_T ga;
   int i;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4331,10 +4331,7 @@ static int ins_complete(int c)
 
       compl_col += startcol;
       compl_length = (int)curs_col - startcol;
-      compl_pattern = addstar(line + compl_col, compl_length,
-          EXPAND_FILES);
-      if (compl_pattern == NULL)
-        return FAIL;
+      compl_pattern = addstar(line + compl_col, compl_length, EXPAND_FILES);
     } else if (ctrl_x_mode == CTRL_X_CMDLINE) {
       compl_pattern = vim_strnsave(line, curs_col);
       set_cmd_context(&compl_xp, compl_pattern,

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4135,7 +4135,7 @@ static int ins_compl_use_match(int c)
 /*
  * Do Insert mode completion.
  * Called when character "c" was typed, which has a meaning for completion.
- * Returns OK if completion was done, FAIL if something failed (out of mem).
+ * Returns OK if completion was done, FAIL if something failed.
  */
 static int ins_complete(int c)
 {
@@ -4236,13 +4236,9 @@ static int ins_complete(int c)
           compl_length = curs_col - startcol;
         }
         if (p_ic)
-          compl_pattern = str_foldcase(line + compl_col,
-              compl_length, NULL, 0);
+          compl_pattern = str_foldcase(line + compl_col, compl_length, NULL, 0);
         else
-          compl_pattern = vim_strnsave(line + compl_col,
-              compl_length);
-        if (compl_pattern == NULL)
-          return FAIL;
+          compl_pattern = vim_strnsave(line + compl_col, compl_length);
       } else if (compl_cont_status & CONT_ADDING) {
         char_u      *prefix = (char_u *)"\\<";
 
@@ -4309,12 +4305,9 @@ static int ins_complete(int c)
       if (compl_length < 0)             /* cursor in indent: empty pattern */
         compl_length = 0;
       if (p_ic)
-        compl_pattern = str_foldcase(line + compl_col, compl_length,
-            NULL, 0);
+        compl_pattern = str_foldcase(line + compl_col, compl_length, NULL, 0);
       else
         compl_pattern = vim_strnsave(line + compl_col, compl_length);
-      if (compl_pattern == NULL)
-        return FAIL;
     } else if (ctrl_x_mode == CTRL_X_FILES) {
       /* Go back to just before the first filename character. */
       if (startcol > 0) {

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1633,11 +1633,6 @@ change_indent (
    * put it back again the way we wanted it.
    */
   if (State & VREPLACE_FLAG) {
-    /* If orig_line didn't allocate, just return.  At least we did the job,
-     * even if you can't backspace. */
-    if (orig_line == NULL)
-      return;
-
     /* Save new line */
     new_line = vim_strsave(get_cursor_line_ptr());
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2432,14 +2432,12 @@ void ins_compl_show_pum(void)
       }
   }
 
-  if (compl_match_array != NULL) {
-    /* Compute the screen column of the start of the completed text.
-     * Use the cursor to get all wrapping and other settings right. */
-    col = curwin->w_cursor.col;
-    curwin->w_cursor.col = compl_col;
-    pum_display(compl_match_array, compl_match_arraysize, cur);
-    curwin->w_cursor.col = col;
-  }
+  /* Compute the screen column of the start of the completed text.
+   * Use the cursor to get all wrapping and other settings right. */
+  col = curwin->w_cursor.col;
+  curwin->w_cursor.col = compl_col;
+  pum_display(compl_match_array, compl_match_arraysize, cur);
+  curwin->w_cursor.col = col;
 }
 
 #define DICT_FIRST      (1)     /* use just first element in "dict" */

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11628,18 +11628,12 @@ static void f_or(typval_T *argvars, typval_T *rettv)
  */
 static void f_pathshorten(typval_T *argvars, typval_T *rettv)
 {
-  char_u      *p;
-
   rettv->v_type = VAR_STRING;
-  p = get_tv_string_chk(&argvars[0]);
-  if (p == NULL)
-    rettv->vval.v_string = NULL;
-  else {
-    p = vim_strsave(p);
-    rettv->vval.v_string = p;
-    if (p != NULL)
-      shorten_dir(p);
+  rettv->vval.v_string = get_tv_string_chk(&argvars[0]);
+  if (!rettv->vval.v_string) {
+    return;
   }
+  rettv->vval.v_string = shorten_dir(vim_strsave(rettv->vval.v_string));
 }
 
 /*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -18162,8 +18162,7 @@ void func_dump_profile(FILE *fd)
       --todo;
       fp = HI2UF(hi);
       if (fp->uf_profiling) {
-        if (sorttab != NULL)
-          sorttab[st_len++] = fp;
+        sorttab[st_len++] = fp;
 
         if (fp->uf_name[0] == K_SPECIAL)
           fprintf(fd, "FUNCTION  <SNR>%s()\n", fp->uf_name + 3);
@@ -18190,7 +18189,7 @@ void func_dump_profile(FILE *fd)
     }
   }
 
-  if (sorttab != NULL && st_len > 0) {
+  if (st_len > 0) {
     qsort((void *)sorttab, (size_t)st_len, sizeof(ufunc_T *),
         prof_total_cmp);
     prof_sort_list(fd, sorttab, st_len, "TOTAL", FALSE);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4742,7 +4742,6 @@ void ex_help(exarg_T *eap)
   tag = vim_strsave(matches[i]);
   FreeWild(num_matches, matches);
 
-
   /*
    * Re-use an existing help window or open a new one.
    * Always open a new one for ":tab help".
@@ -4805,8 +4804,7 @@ void ex_help(exarg_T *eap)
    * It is needed for do_tag top open folds under the cursor. */
   KeyTyped = old_KeyTyped;
 
-  if (tag != NULL)
-    do_tag(tag, DT_HELP, 1, FALSE, TRUE);
+  do_tag(tag, DT_HELP, 1, FALSE, TRUE);
 
   /* Delete the empty buffer if we're not using it.  Careful: autocommands
    * may have jumped to another window, check that the buffer is not in a

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8589,8 +8589,6 @@ static char_u *get_view_file(int c)
     return NULL;
   }
   sname = home_replace_save(NULL, curbuf->b_ffname);
-  if (sname == NULL)
-    return NULL;
 
   /*
    * We want a file name without separators, because we're not going to make

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3033,10 +3033,8 @@ void tilde_replace(char_u *orig_pat, int num_files, char_u **files)
   if (orig_pat[0] == '~' && vim_ispathsep(orig_pat[1])) {
     for (i = 0; i < num_files; ++i) {
       p = home_replace_save(NULL, files[i]);
-      if (p != NULL) {
-        free(files[i]);
-        files[i] = p;
-      }
+      free(files[i]);
+      files[i] = p;
     }
   }
 }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3265,6 +3265,7 @@ addstar (
     int len,
     int context                    /* EXPAND_FILES etc. */
 )
+  FUNC_ATTR_NONNULL_RET
 {
   char_u      *retval;
   int i, j;
@@ -3343,35 +3344,33 @@ addstar (
     }
   } else {
     retval = xmalloc(len + 4);
-    if (retval != NULL) {
-      STRLCPY(retval, fname, len + 1);
+    STRLCPY(retval, fname, len + 1);
 
-      /*
-       * Don't add a star to *, ~, ~user, $var or `cmd`.
-       * * would become **, which walks the whole tree.
-       * ~ would be at the start of the file name, but not the tail.
-       * $ could be anywhere in the tail.
-       * ` could be anywhere in the file name.
-       * When the name ends in '$' don't add a star, remove the '$'.
-       */
-      tail = path_tail(retval);
-      ends_in_star = (len > 0 && retval[len - 1] == '*');
+    /*
+     * Don't add a star to *, ~, ~user, $var or `cmd`.
+     * * would become **, which walks the whole tree.
+     * ~ would be at the start of the file name, but not the tail.
+     * $ could be anywhere in the tail.
+     * ` could be anywhere in the file name.
+     * When the name ends in '$' don't add a star, remove the '$'.
+     */
+    tail = path_tail(retval);
+    ends_in_star = (len > 0 && retval[len - 1] == '*');
 #ifndef BACKSLASH_IN_FILENAME
-      for (i = len - 2; i >= 0; --i) {
-        if (retval[i] != '\\')
-          break;
-        ends_in_star = !ends_in_star;
-      }
-#endif
-      if ((*retval != '~' || tail != retval)
-          && !ends_in_star
-          && vim_strchr(tail, '$') == NULL
-          && vim_strchr(retval, '`') == NULL)
-        retval[len++] = '*';
-      else if (len > 0 && retval[len - 1] == '$')
-        --len;
-      retval[len] = NUL;
+    for (i = len - 2; i >= 0; --i) {
+      if (retval[i] != '\\')
+        break;
+      ends_in_star = !ends_in_star;
     }
+#endif
+    if ((*retval != '~' || tail != retval)
+        && !ends_in_star
+        && vim_strchr(tail, '$') == NULL
+        && vim_strchr(retval, '`') == NULL)
+      retval[len++] = '*';
+    else if (len > 0 && retval[len - 1] == '$')
+      --len;
+    retval[len] = NUL;
   }
   return retval;
 }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3505,8 +3505,6 @@ expand_cmdline (
   /* add star to file name, or convert to regexp if not exp. files. */
   xp->xp_pattern_len = (int)(str + col - xp->xp_pattern);
   file_str = addstar(xp->xp_pattern, xp->xp_pattern_len, xp->xp_context);
-  if (file_str == NULL)
-    return EXPAND_UNSUCCESSFUL;
 
   if (p_wic)
     options += WILD_ICASE;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -28,6 +28,7 @@
 #include "nvim/ex_docmd.h"
 #include "nvim/ex_eval.h"
 #include "nvim/fold.h"
+#include "nvim/func_attr.h"
 #include "nvim/getchar.h"
 #include "nvim/hashtab.h"
 #include "nvim/iconv.h"
@@ -2106,6 +2107,7 @@ void set_forced_fenc(exarg_T *eap)
  * When *pp is not set to NULL, the result is in allocated memory.
  */
 static char_u *next_fenc(char_u **pp)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
 {
   char_u      *p;
   char_u      *r;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4921,54 +4921,51 @@ buf_check_timestamp (
 
   if (mesg != NULL) {
     path = home_replace_save(buf, buf->b_fname);
-    if (path != NULL) {
-      if (!helpmesg)
-        mesg2 = "";
-      tbuf = xmalloc(STRLEN(path) + STRLEN(mesg) + STRLEN(mesg2) + 2);
-      sprintf((char *)tbuf, mesg, path);
-      /* Set warningmsg here, before the unimportant and output-specific
-       * mesg2 has been appended. */
-      set_vim_var_string(VV_WARNINGMSG, tbuf, -1);
-      if (can_reload) {
-        if (*mesg2 != NUL) {
-          STRCAT(tbuf, "\n");
-          STRCAT(tbuf, mesg2);
-        }
-        if (do_dialog(VIM_WARNING, (char_u *)_("Warning"), tbuf,
-                (char_u *)_("&OK\n&Load File"), 1, NULL, TRUE) == 2)
-          reload = TRUE;
-      } else if (State > NORMAL_BUSY || (State & CMDLINE) ||
-                 already_warned) {
-        if (*mesg2 != NUL) {
-          STRCAT(tbuf, "; ");
-          STRCAT(tbuf, mesg2);
-        }
-        EMSG(tbuf);
-        retval = 2;
-      } else {
-        if (!autocmd_busy) {
-          msg_start();
-          msg_puts_attr(tbuf, hl_attr(HLF_E) + MSG_HIST);
-          if (*mesg2 != NUL)
-            msg_puts_attr((char_u *)mesg2,
-                hl_attr(HLF_W) + MSG_HIST);
-          msg_clr_eos();
-          (void)msg_end();
-          if (emsg_silent == 0) {
-            out_flush();
-            /* give the user some time to think about it */
-            os_delay(1000L, true);
-
-            /* don't redraw and erase the message */
-            redraw_cmdline = FALSE;
-          }
-        }
-        already_warned = TRUE;
+    if (!helpmesg)
+      mesg2 = "";
+    tbuf = xmalloc(STRLEN(path) + STRLEN(mesg) + STRLEN(mesg2) + 2);
+    sprintf((char *)tbuf, mesg, path);
+    /* Set warningmsg here, before the unimportant and output-specific
+     * mesg2 has been appended. */
+    set_vim_var_string(VV_WARNINGMSG, tbuf, -1);
+    if (can_reload) {
+      if (*mesg2 != NUL) {
+        STRCAT(tbuf, "\n");
+        STRCAT(tbuf, mesg2);
       }
+      if (do_dialog(VIM_WARNING, (char_u *)_("Warning"), tbuf,
+                    (char_u *)_("&OK\n&Load File"), 1, NULL, TRUE) == 2)
+        reload = TRUE;
+    } else if (State > NORMAL_BUSY || (State & CMDLINE) || already_warned) {
+      if (*mesg2 != NUL) {
+        STRCAT(tbuf, "; ");
+        STRCAT(tbuf, mesg2);
+      }
+      EMSG(tbuf);
+      retval = 2;
+    } else {
+      if (!autocmd_busy) {
+        msg_start();
+        msg_puts_attr(tbuf, hl_attr(HLF_E) + MSG_HIST);
+        if (*mesg2 != NUL)
+          msg_puts_attr((char_u *)mesg2,
+                        hl_attr(HLF_W) + MSG_HIST);
+        msg_clr_eos();
+        (void)msg_end();
+        if (emsg_silent == 0) {
+          out_flush();
+          /* give the user some time to think about it */
+          os_delay(1000L, true);
 
-      free(path);
-      free(tbuf);
+          /* don't redraw and erase the message */
+          redraw_cmdline = FALSE;
+        }
+      }
+      already_warned = TRUE;
     }
+
+    free(path);
+    free(tbuf);
   }
 
   if (reload) {

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2127,10 +2127,6 @@ static char_u *next_fenc(char_u **pp)
     free(r);
     r = p;
   }
-  if (r == NULL) {      /* out of memory */
-    r = (char_u *)"";
-    *pp = NULL;
-  }
   return r;
 }
 

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1649,7 +1649,6 @@ static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
   char        *cntxformat = " <<%s>>";
   char        *context;
   char        *cstag_msg = _("Cscope tag: %s");
-  char        *csfmt_str = "%4d %6s  ";
 
   assert (num_matches > 0);
 
@@ -1691,17 +1690,15 @@ static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
 
     lno[strlen(lno)-2] = '\0';      /* ignore ;" at the end */
 
+    const char *csfmt_str = "%4d %6s  ";
     /* hopefully 'num' (num of matches) will be less than 10^16 */
     newsize = strlen(csfmt_str) + 16 + strlen(lno);
     if (bufsize < newsize) {
       buf = xrealloc(buf, newsize);
       bufsize = newsize;
     }
-    if (buf != NULL) {
-      /* csfmt_str = "%4d %6s  "; */
-      (void)sprintf(buf, csfmt_str, num, lno);
-      MSG_PUTS_ATTR(buf, hl_attr(HLF_CM));
-    }
+    (void)sprintf(buf, csfmt_str, num, lno);
+    MSG_PUTS_ATTR(buf, hl_attr(HLF_CM));
     MSG_PUTS_LONG_ATTR(cs_pathcomponents(fname), hl_attr(HLF_CM));
 
     /* compute the required space for the context */
@@ -1715,16 +1712,14 @@ static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
       buf = xrealloc(buf, newsize);
       bufsize = newsize;
     }
-    if (buf != NULL) {
-      (void)sprintf(buf, cntxformat, context);
+    (void)sprintf(buf, cntxformat, context);
 
-      /* print the context only if it fits on the same line */
-      if (msg_col + (int)strlen(buf) >= (int)Columns)
-        msg_putchar('\n');
-      msg_advance(12);
-      MSG_PUTS_LONG(buf);
+    /* print the context only if it fits on the same line */
+    if (msg_col + (int)strlen(buf) >= (int)Columns)
       msg_putchar('\n');
-    }
+    msg_advance(12);
+    MSG_PUTS_LONG(buf);
+    msg_putchar('\n');
     if (extra != NULL) {
       msg_advance(13);
       MSG_PUTS_LONG(extra);

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -1593,8 +1593,6 @@ int get_c_indent(void)
    * This is required, because only the most recent line obtained with
    * ml_get is valid! */
   linecopy = vim_strsave(ml_get(cur_curpos.lnum));
-  if (linecopy == NULL)
-    return 0;
 
   /*
    * In insert mode and the cursor is on a ')' truncate the line at the

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -506,8 +506,6 @@ void fmarks_check_names(buf_T *buf)
     return;
 
   name = home_replace_save(buf, buf->b_ffname);
-  if (name == NULL)
-    return;
 
   for (i = 0; i < NMARKS + EXTRA_MARKS; ++i)
     fmarks_check_one(&namedfm[i], name, buf);
@@ -1327,19 +1325,17 @@ int removable(char_u *name)
   size_t n;
 
   name = home_replace_save(NULL, name);
-  if (name != NULL) {
-    for (p = p_viminfo; *p; ) {
-      copy_option_part(&p, part, 51, ", ");
-      if (part[0] == 'r') {
-        n = STRLEN(part + 1);
-        if (MB_STRNICMP(part + 1, name, n) == 0) {
-          retval = TRUE;
-          break;
-        }
+  for (p = p_viminfo; *p; ) {
+    copy_option_part(&p, part, 51, ", ");
+    if (part[0] == 'r') {
+      n = STRLEN(part + 1);
+      if (MB_STRNICMP(part + 1, name, n) == 0) {
+        retval = TRUE;
+        break;
       }
     }
-    free(name);
   }
+  free(name);
   return retval;
 }
 

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1447,8 +1447,6 @@ void copy_viminfo_marks(vir_T *virp, FILE *fp_out, int count, int eof, int flags
      */
     str = skipwhite(line + 1);
     str = viminfo_readstring(virp, (int)(str - virp->vir_line), FALSE);
-    if (str == NULL)
-      continue;
     p = str + STRLEN(str);
     while (p != str && (*p == NUL || vim_isspace(*p)))
       p--;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1240,10 +1240,8 @@ theend:
       mf_put(mfp, hp, false, false);
     mf_close(mfp, false);           /* will also free(mfp->mf_fname) */
   }
-  if (buf != NULL) {
-    free(buf->b_ml.ml_stack);
-    free(buf);
-  }
+  free(buf->b_ml.ml_stack);
+  free(buf);
   if (serious_error && called_from_main)
     ml_close(curbuf, TRUE);
   else {
@@ -3279,10 +3277,7 @@ findswapname (
   /*
    * we try different names until we find one that does not exist yet
    */
-  if (dir_name == NULL)             /* out of memory */
-    fname = NULL;
-  else
-    fname = makeswapname(buf_fname, buf->b_ffname, buf, dir_name);
+  fname = makeswapname(buf_fname, buf->b_ffname, buf, dir_name);
 
   for (;; ) {
     if (fname == NULL)          /* must be out of memory */

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1083,8 +1083,7 @@ static void msg_home_replace_attr(char_u *fname, int attr)
   char_u      *name;
 
   name = home_replace_save(NULL, fname);
-  if (name != NULL)
-    msg_outtrans_attr(name, attr);
+  msg_outtrans_attr(name, attr);
   free(name);
 }
 

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -3466,8 +3466,6 @@ get_cmd_output (
   i = (int)fread((char *)buffer, (size_t)1, (size_t)len, fd);
   fclose(fd);
   os_remove((char *)tempname);
-  if (buffer == NULL)
-    goto done;
   if (i != len) {
     EMSG2(_(e_notread), tempname);
     free(buffer);

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -881,11 +881,9 @@ static void uniquefy_paths(garray_T *gap, char_u *pattern)
   }
 
   free(curdir);
-  if (in_curdir != NULL) {
-    for (int i = 0; i < gap->ga_len; i++)
-      free(in_curdir[i]);
-    free(in_curdir);
-  }
+  for (int i = 0; i < gap->ga_len; i++)
+    free(in_curdir[i]);
+  free(in_curdir);
   ga_clear_strings(&path_ga);
   vim_regfree(regmatch.regprog);
 

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -239,33 +239,31 @@ int vim_ispathlistsep(int c)
  * Shorten the path of a file from "~/foo/../.bar/fname" to "~/f/../.b/fname"
  * It's done in-place.
  */
-void shorten_dir(char_u *str)
+char_u *shorten_dir(char_u *str)
 {
-  char_u      *tail, *s, *d;
-  int skip = FALSE;
-
-  tail = path_tail(str);
-  d = str;
-  for (s = str;; ++s) {
+  char_u *tail = path_tail(str);
+  char_u *d = str;
+  bool skip = false;
+  for (char_u *s = str;; ++s) {
     if (s >= tail) {                /* copy the whole tail */
       *d++ = *s;
       if (*s == NUL)
         break;
     } else if (vim_ispathsep(*s)) {       /* copy '/' and next char */
       *d++ = *s;
-      skip = FALSE;
+      skip = false;
     } else if (!skip) {
       *d++ = *s;                    /* copy next char */
       if (*s != '~' && *s != '.')       /* and leading "~" and "." */
-        skip = TRUE;
+        skip = true;
       if (has_mbyte) {
         int l = mb_ptr2len(s);
-
         while (--l > 0)
           *d++ = *++s;
       }
     }
   }
+  return str;
 }
 
 /*

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -370,17 +370,13 @@ void pum_redraw(void)
                   size++;
                 }
               }
-              screen_puts_len(rt, (int)STRLEN(rt), row, col - size + 1,
-                              attr);
+              screen_puts_len(rt, (int)STRLEN(rt), row, col - size + 1, attr);
               free(rt_start);
               free(st);
-
               col -= width;
             } else {
-              if (st != NULL) {
-                screen_puts_len(st, (int)STRLEN(st), row, col, attr);
-                free(st);
-              }
+              screen_puts_len(st, (int)STRLEN(st), row, col, attr);
+              free(st);
               col += width;
             }
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7795,7 +7795,7 @@ static void draw_tabline(void)
       if (room > 0) {
         /* Get buffer name in NameBuff[] */
         get_trans_bufname(cwp->w_buffer);
-        shorten_dir(NameBuff);
+        (void)shorten_dir(NameBuff);
         len = vim_strsize(NameBuff);
         p = NameBuff;
         if (has_mbyte)

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4627,18 +4627,15 @@ int read_viminfo_search_pattern(vir_T *virp, int force)
     hlsearch_on = TRUE;
   if (idx >= 0) {
     if (force || spats[idx].pat == NULL) {
-      val = viminfo_readstring(virp, (int)(lp - virp->vir_line + 1),
-          TRUE);
-      if (val != NULL) {
-        set_last_search_pat(val, idx, magic, setlast);
-        free(val);
-        spats[idx].no_scs = no_scs;
-        spats[idx].off.line = off_line;
-        spats[idx].off.end = off_end;
-        spats[idx].off.off = off;
-        if (setlast) {
-          SET_NO_HLSEARCH(!hlsearch_on);
-        }
+      val = viminfo_readstring(virp, (int)(lp - virp->vir_line + 1), TRUE);
+      set_last_search_pat(val, idx, magic, setlast);
+      free(val);
+      spats[idx].no_scs = no_scs;
+      spats[idx].off.line = off_line;
+      spats[idx].off.end = off_end;
+      spats[idx].off.off = off;
+      if (setlast) {
+        SET_NO_HLSEARCH(!hlsearch_on);
       }
     }
   }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4025,8 +4025,6 @@ find_pattern_in_path (
     def_regmatch.rm_ic = FALSE;         /* don't ignore case in define pat. */
   }
   files = xcalloc(max_path_depth, sizeof(SearchedFile));
-  if (files == NULL)
-    goto fpip_end;
   old_files = max_path_depth;
   depth = depth_displayed = -1;
 

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -4545,11 +4545,9 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
         // Turn flag "c" into COMPOUNDRULE compatible string "c+",
         // "Na" into "Na+", "1234" into "1234+".
         p = getroom(spin, STRLEN(items[1]) + 2, false);
-        if (p != NULL) {
-          STRCPY(p, items[1]);
-          STRCAT(p, "+");
-          compflags = p;
-        }
+        STRCPY(p, items[1]);
+        STRCAT(p, "+");
+        compflags = p;
       } else if (is_aff_rule(items, itemcnt, "COMPOUNDRULES", 2))   {
         // We don't use the count, but do check that it's a number and
         // not COMPOUNDRULE mistyped.
@@ -4565,14 +4563,12 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
           if (compflags != NULL)
             l += (int)STRLEN(compflags) + 1;
           p = getroom(spin, l, false);
-          if (p != NULL) {
-            if (compflags != NULL) {
-              STRCPY(p, compflags);
-              STRCAT(p, "/");
-            }
-            STRCAT(p, items[1]);
-            compflags = p;
+          if (compflags != NULL) {
+            STRCPY(p, compflags);
+            STRCAT(p, "/");
           }
+          STRCAT(p, items[1]);
+          compflags = p;
         }
       } else if (is_aff_rule(items, itemcnt, "COMPOUNDWORDMAX", 2)
                  && compmax == 0) {
@@ -5199,8 +5195,6 @@ static void process_compflags(spellinfo_T *spin, afffile_T *aff, char_u *compfla
   if (spin->si_compflags != NULL)
     len += (int)STRLEN(spin->si_compflags) + 1;
   p = getroom(spin, len, false);
-  if (p == NULL)
-    return;
   if (spin->si_compflags != NULL) {
     STRCPY(p, spin->si_compflags);
     STRCAT(p, "/");


### PR DESCRIPTION
Review all invocations of functions declared as FUNC_ATTR_NONNULL_RET,
and remove redundant checks for null/not-null.
