### PR TITLE
[RFC] Remove spurious file 'del' left after old tests.

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -106,7 +106,8 @@ clean:
 	        $(RM_ON_START) \
 	        valgrind.*     \
 	        .*.swp         \
-	        .*.swo
+	        .*.swo         \
+	        del
 
 test1.out: .gdbinit test1.in
 	-rm -rf $*.failed $(RM_ON_RUN) $(RM_ON_START) wrongtermsize


### PR DESCRIPTION
Executing old tests leaves an empty file 'del' that doesn't get removed
by `make clean`.
