### PR TITLE
[RFC] shadow previously set signs on the line

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4337,10 +4337,8 @@ void buf_addsign(
         if (lnum == sign->lnum && id == sign->id) {
             sign->typenr = typenr;
             return;
-        }
-        else if (id < 0 /* keep signs sorted by lnum */
-                 && lnum < sign->lnum)
-        {
+        } else if ((lnum == sign->lnum && id != sign->id)
+                   || (id < 0 && lnum < sign->lnum)) {  // attempt to keep signs sorted by lnum
             insert_sign(buf, prev, sign, id, lnum, typenr);
             return;
         }

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -1,0 +1,45 @@
+local helpers = require('test.functional.helpers')
+local Screen = require('test.functional.ui.screen')
+local clear, feed, execute = helpers.clear, helpers.feed, helpers.execute
+
+describe('Signs', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new()
+    screen:attach()
+    screen:set_default_attr_ignore( {{}, {bold=true, foreground=255}} ) 
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  describe(':sign place', function()
+    it('shadows previously placed signs', function()
+      feed('ia<cr>b<cr>c<cr><esc>')
+      execute('sign define piet text=>> texthl=Search')
+      execute('sign define pietx text=>! texthl=Search')
+      execute('sign place 1 line=1 name=piet buffer=1')
+      execute('sign place 2 line=3 name=piet buffer=1')
+      execute('sign place 3 line=1 name=pietx buffer=1')
+      screen:expect([[
+        >!a                                                  |
+          b                                                  |
+        >>c                                                  |
+          ^                                                  |
+          ~                                                  |
+          ~                                                  |
+          ~                                                  |
+          ~                                                  |
+          ~                                                  |
+          ~                                                  |
+          ~                                                  |
+          ~                                                  |
+          ~                                                  |
+        :sign place 3 line=1 name=pietx buffer=1             |
+      ]])
+    end)
+  end)
+end)


### PR DESCRIPTION
Fixes issue #1886.

Note: I'm not sure why vim would shadow previously set signs, since the code shouldn't do anything in the case where there is a previously placed sign and the id is different. Anyway, I think shadowing is the desired/expected behavior.
