### PR TITLE
Fix the ctrl + left click test.

### DIFF
--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -145,6 +145,7 @@ describe('Mouse input', function()
   end)
 
   it('ctrl + left click will search for a tag', function()
+    nvim('set_option', 'tags', './non-existent-tags-file')
     feed('<C-LeftMouse><0,0>')
     screen:expect([[
       E433: No tags file       |


### PR DESCRIPTION
The test was hoping to not find a tags file, but didn't actively guard
against it.  In my case, I had a tags file present which was causing
different output to be generated.  To fix this, let's set the tags
option to look for an unlikely filename.
