### PR TITLE
[WIP/RFC] Implement server_address()

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14572,7 +14572,7 @@ static void f_serverstart(typval_T *argvars, typval_T *rettv)
       rettv->vval.v_string = vim_strsave(get_tv_string(argvars));
     }
   } else {
-    rettv->vval.v_string = vim_tempname();
+    rettv->vval.v_string = (char_u *)server_address_new();
   }
 
   int result = server_start((char *) rettv->vval.v_string);

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -101,8 +101,12 @@ char *server_address_new(void)
 /// @returns 0 on success, 1 on a regular error, and negative errno
 ///          on failure to bind or connect.
 int server_start(const char *endpoint)
-  FUNC_ATTR_NONNULL_ALL
 {
+  if (endpoint == NULL) {
+    ELOG("Attempting to start server on NULL endpoint");
+    return 1;
+  }
+
   SocketWatcher *watcher = xmalloc(sizeof(SocketWatcher));
   socket_watcher_init(&loop, watcher, endpoint, NULL);
 

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/msgpack_rpc/server.h"
@@ -35,7 +36,7 @@ bool server_init(void)
   const char *listen_address = os_getenv(LISTEN_ADDRESS_ENV_VAR);
   if (listen_address == NULL) {
     must_free = true;
-    listen_address = (char *)vim_tempname();
+    listen_address = server_address_new();
   }
 
   bool ok = (server_start(listen_address) == 0);
@@ -65,6 +66,27 @@ static void set_vservername(garray_T *srvs)
 void server_teardown(void)
 {
   GA_DEEP_CLEAR(&watchers, SocketWatcher *, close_socket_watcher);
+}
+
+/// Generates unique address for local server.
+///
+/// In Windows this is a named pipe in the format
+///     \\.\pipe\nvim-<PID>-<COUNTER>.
+///
+/// For other systems it is a path returned by vim_tempname().
+///
+/// This function is NOT thread safe
+char *server_address_new(void)
+{
+#ifdef WIN32
+  static uint32_t count = 0;
+  char template[ADDRESS_MAX_SIZE];
+  snprintf(template, ADDRESS_MAX_SIZE,
+    "\\\\.\\pipe\\nvim-%" PRIu64 "-%" PRIu32, os_get_pid(), count++);
+  return xstrdup(template);
+#else
+  return (char *)vim_tempname();
+#endif
 }
 
 /// Starts listening for API calls on the TCP address or pipe path `endpoint`.


### PR DESCRIPTION
- os_serveraddress() returns a unique address for Neovim to listen
  on when no address is supplied.
- In Unix the behaviour is unchanged, it uses vim_tempname() to
  get a path in the Neovim temp folder.
- For Windows all local pipe addresses must start with \.\pipe\
  followed by a name,  the pipe name is set as nvim-PID.
- Fixes pipe support in Windows

Following d52fb89fb85984df23b093637b9a8738fdcfe18a. I think I've addressed all the comments, I just need to go back to Windows and test if I have not broken anything. ping @aktau @justinmk 
