### PR TITLE
[RFC] Improve usability as a library

### DIFF
--- a/src/nvim/api/msgpack.c
+++ b/src/nvim/api/msgpack.c
@@ -1,0 +1,132 @@
+#include "nvim/api/msgpack.h"
+#include "nvim/api/private/helpers.h"
+#include "nvim/api/private/defs.h"
+
+#ifdef MAKE_LIB
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "api/msgpack.c.generated.h"
+#endif
+
+void vim_array_add_buffer(Buffer val, Array *arr)
+{
+  Object o = OBJECT_INIT;
+  o.type = kObjectTypeBuffer;
+  o.data.buffer = val;
+  ADD(*arr, o);
+}
+
+void vim_array_add_window(Window val, Array *arr)
+{
+  Object o = OBJECT_INIT;
+  o.type = kObjectTypeWindow;
+  o.data.window = val;
+  ADD(*arr, o);
+}
+
+void vim_array_add_tabpage(Tabpage val, Array *arr)
+{
+  Object o = OBJECT_INIT;
+  o.type = kObjectTypeTabpage;
+  o.data.tabpage = val;
+  ADD(*arr, o);
+}
+
+void vim_array_add_nil(Array *arr)
+{
+  Object o = OBJECT_INIT;
+  o.type = kObjectTypeNil;
+  ADD(*arr, o);
+}
+
+void vim_array_add_boolean(Boolean val, Array *arr)
+{
+  Object o = OBJECT_INIT;
+  o.type = kObjectTypeBoolean;
+  o.data.boolean = val;
+  ADD(*arr, o);
+}
+
+void vim_array_add_integer(Integer val, Array *arr)
+{
+  Object o = OBJECT_INIT;
+  o.type = kObjectTypeInteger;
+  o.data.integer = val;
+  ADD(*arr, o);
+}
+
+void vim_array_add_float(Float val, Array *arr)
+{
+  Object o = OBJECT_INIT;
+  o.type = kObjectTypeFloat;
+  o.data.floating = val;
+  ADD(*arr, o);
+}
+
+void vim_array_add_string(String val, Array *arr)
+{
+  Object o = OBJECT_INIT;
+  o.type = kObjectTypeString;
+  o.data.string = val;
+  ADD(*arr, o);
+}
+
+void vim_array_add_array(Array val, Array *arr)
+{
+  Object o = OBJECT_INIT;
+  o.type = kObjectTypeArray;
+  o.data.array = val;
+  ADD(*arr, o);
+}
+
+void vim_array_add_dictionary(Dictionary val, Array *arr)
+{
+  Object o = OBJECT_INIT;
+  o.type = kObjectTypeDictionary;
+  o.data.dictionary = val;
+  ADD(*arr, o);
+}
+
+msgpack_sbuffer *vim_msgpack_new(void)
+{
+  return msgpack_sbuffer_new();
+}
+
+void vim_msgpack_free(msgpack_sbuffer *buf)
+{
+  msgpack_sbuffer_free(buf);
+}
+
+void vim_msgpack_parse(String message, Array *arr)
+{
+  msgpack_unpacker *unpacker = msgpack_unpacker_new(message.size);
+  msgpack_unpacker_reserve_buffer(unpacker, message.size);
+  char *buf = msgpack_unpacker_buffer(unpacker);
+  memcpy(buf, message.data, message.size);
+  msgpack_unpacker_buffer_consumed(unpacker, message.size);
+
+  msgpack_unpacked unpacked;
+  msgpack_unpacked_init(&unpacked);
+  msgpack_unpack_return result;
+
+  if ((result = msgpack_unpacker_next(unpacker, &unpacked)) ==
+      MSGPACK_UNPACK_SUCCESS)
+  {
+    msgpack_rpc_to_array(&unpacked.data, arr);
+  }
+
+  msgpack_unpacked_destroy(&unpacked);
+  msgpack_unpacker_free(unpacker);
+}
+
+void vim_serialize_request(uint64_t request_id,
+                           String method,
+                           Array args,
+                           msgpack_sbuffer *buf)
+{
+  msgpack_packer pac;
+  msgpack_packer_init(&pac, buf, msgpack_sbuffer_write);
+  msgpack_rpc_serialize_request(request_id, method, args, &pac);
+}
+
+#endif  // MAKE_LIB

--- a/src/nvim/api/msgpack.h
+++ b/src/nvim/api/msgpack.h
@@ -1,0 +1,13 @@
+#ifndef NVIM_API_MSGPACK_H
+#define NVIM_API_MSGPACK_H
+
+#include <stdint.h>
+#include <msgpack.h>
+
+#include "nvim/api/private/defs.h"
+#include "nvim/msgpack_rpc/helpers.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "api/msgpack.h.generated.h"
+#endif
+#endif  // NVIM_API_MSGPACK_H

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -178,7 +178,7 @@ void early_init(void)
 }
 
 #ifdef MAKE_LIB
-int nvim_main(int argc, char **argv)
+int nvim_main_setup(int argc, char **argv)
 #else
 int main(int argc, char **argv)
 #endif
@@ -505,6 +505,13 @@ int main(int argc, char **argv)
     stuffcharReadbuff(K_NOP);
 
   TIME_MSG("before starting main loop");
+#ifdef MAKE_LIB
+  return 0;
+}
+
+int nvim_main_loop(void)
+{
+#endif
 
   /*
    * Call the main command loop.  This never returns.


### PR DESCRIPTION
While my previous PR added the rudimentary ability to compile Neovim as a static library, it currently isn't very useful. All we can do is write a program that calls `nvim_main` programmatically. There is no supported way to run functions before the main loop starts, and no easy way to re-use Neovim's msgpack functions for encoding the client-side API calls.

My goal is to be able to write a Neovim GUI that has Neovim itself compiled into it. The program will run Neovim in a separate thread (or `fork`ed process) and communicate with it over an [anonymous pipe](http://en.wikipedia.org/wiki/Anonymous_pipe). This has the advantage of being able to distribute the program as a self-contained executable, and allows it to use the same msgpack code on the client that Neovim itself uses.

This PR does three things:
1. Splits up `nvim_main` into two separate functions, `nvim_main_setup` and `nvim_main_loop`. This allows the library user to run arbitrary functions after the setup process but before the main loop is run.
2. Adds the `channel_from_fds` function so the library user can make a channel from arbitrary file descriptors, such as those from an anonymous pipe. This would be run between the two aforementioned main functions.
3. Adds various functions to the API that provide high-level access to the msgpack functionality. This allows the library user to re-use Neovim's msgpack code for the client. They are designed to be easy to use via any language's FFI system (they wrap inlined functions and macros for you).

I don't have anything available right now that showcases this stuff being used, but hopefully it's easy to see how it might be useful given the use-case I described.
