### PR TITLE
[RFC] Fix #1920: Unable to build on openSUSE 13.2 x64

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -164,7 +164,8 @@ if(USE_BUNDLED_LIBUV)
       -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
     CONFIGURE_COMMAND sh ${DEPS_BUILD_DIR}/src/libuv/autogen.sh &&
       ${DEPS_BUILD_DIR}/src/libuv/configure --with-pic --disable-shared
-        --prefix=${DEPS_INSTALL_DIR} CC=${DEPS_C_COMPILER}
+        --prefix=${DEPS_INSTALL_DIR} --libdir=${DEPS_INSTALL_DIR}/lib
+        CC=${DEPS_C_COMPILER}
     INSTALL_COMMAND ${MAKE_PRG} install)
   list(APPEND THIRD_PARTY_DEPS libuv)
 endif()


### PR DESCRIPTION
The issue is that libuv decides to use ${PREFIX}/lib64 as the lib
directory instead of ${PREFIX}/lib.  Since we're just installing it to
provide access to the static library, let's just force the libdir to be
${PREFIX}/lib.
