### PR TITLE
[WIP] Replace $VIMRUNTIME with $NVIMRUNTIME

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -1,7 +1,7 @@
 get_filename_component(BUSTED_DIR ${BUSTED_PRG} PATH)
 set(ENV{PATH} "${BUSTED_DIR}:$ENV{PATH}")
 
-set(ENV{VIMRUNTIME} ${WORKING_DIR}/runtime)
+set(ENV{NVIMRUNTIME} ${WORKING_DIR}/runtime)
 
 if(NVIM_PRG)
   set(ENV{NVIM_PROG} "${NVIM_PRG}")

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -129,7 +129,7 @@ A few special texts:
 		|-q|.
 	Last set from environment variable ~
 		Option was set from an environment variable, $NVIMINIT,
-		$GVIMINIT or $EXINIT.
+		or $EXINIT.
 	Last set from error handler ~
 		Option was cleared when evaluating it resulted in an error.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -128,7 +128,7 @@ A few special texts:
 		Option was set with command line argument |-c|, +, |-S| or
 		|-q|.
 	Last set from environment variable ~
-		Option was set from an environment variable, $VIMINIT,
+		Option was set from an environment variable, $NVIMINIT,
 		$GVIMINIT or $EXINIT.
 	Last set from error handler ~
 		Option was cleared when evaluating it resulted in an error.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -545,13 +545,13 @@ accordingly.  Vim proceeds in this order:
 	":version" command.  Mostly it's "$VIM/vimrc".
 	For the Macintosh the $VIMRUNTIME/macmap.vim is read.
 
-	  *VIMINIT* *.vimrc* *_vimrc* *EXINIT* *.exrc* *_exrc* *$MYVIMRC*
+	  *NVIMINIT* *.vimrc* *_vimrc* *EXINIT* *.exrc* *_exrc* *$MYVIMRC*
      b. Four places are searched for initializations.  The first that exists
 	is used, the others are ignored.  The $MYVIMRC environment variable is
 	set to the file that was first found, unless $MYVIMRC was already set
-	and when using VIMINIT.
-	-  The environment variable VIMINIT
-	   The value of $VIMINIT is used as an Ex command line.
+	and when using NVIMINIT.
+	-  The environment variable NVIMINIT
+	   The value of $NVIMINIT is used as an Ex command line.
 	-  The user vimrc file(s):
 		    "$HOME/.vimrc"	   (for Unix)
 		    "$HOME/.vim/vimrc"	   (for Unix)
@@ -684,7 +684,7 @@ else created and contains nasty commands.  The disabled commands are the ones
 that start a shell, the ones that write to a file, and ":autocmd".  The ":map"
 commands are echoed, so you can see which keys are being mapped.
 	If you want Vim to execute all commands in a local vimrc file, you
-can reset the 'secure' option in the EXINIT or VIMINIT environment variable or
+can reset the 'secure' option in the EXINIT or NVIMINIT environment variable or
 in the global "exrc" or "vimrc" file.  This is not possible in "vimrc" or
 "exrc" in the current directory, for obvious reasons.
 	On Unix systems, this only happens if you are not the owner of the

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -145,6 +145,21 @@ void early_init(void)
 {
   handle_init();
 
+  // Use $NVIM and $NVIMRUNTIME as $VIM and $VIMRUNTIME
+  // or unset them to avoid accidentaly using the Vim runtime
+  const char *env_nvimruntime = os_getenv("NVIMRUNTIME");
+  if (env_nvimruntime) {
+    os_setenv("VIMRUNTIME", env_nvimruntime, true);
+  } else {
+    os_unsetenv("VIMRUNTIME");
+  }
+  const char *env_nvim = os_getenv("NVIM");
+  if (env_nvim) {
+    os_setenv("VIM", env_nvim, true);
+  } else {
+    os_unsetenv("VIM");
+  }
+
   (void)mb_init();      // init mb_bytelen_tab[] to ones
   eval_init();          // init global variables
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1800,7 +1800,7 @@ static void source_startup_scripts(mparm_T *parmp)
 
     /*
      * Try to read initialization commands from the following places:
-     * - environment variable VIMINIT
+     * - environment variable NVIMINIT
      * - user vimrc file (~/.vimrc)
      * - second user vimrc file ($VIM/.vimrc for Dos)
      * - environment variable EXINIT
@@ -1808,7 +1808,7 @@ static void source_startup_scripts(mparm_T *parmp)
      * - second user exrc file ($VIM/.exrc for Dos)
      * The first that exists is used, the rest is ignored.
      */
-    if (process_env((char_u *)"VIMINIT", TRUE) != OK) {
+    if (process_env((char_u *)"NVIMINIT", TRUE) != OK) {
       if (do_source((char_u *)USR_VIMRC_FILE, TRUE, DOSO_VIMRC) == FAIL
 #ifdef USR_VIMRC_FILE2
           && do_source((char_u *)USR_VIMRC_FILE2, TRUE,
@@ -1907,7 +1907,7 @@ static void main_start_gui(void)
 int
 process_env (
     char_u *env,
-    int is_viminit             /* when TRUE, called for VIMINIT */
+    int is_viminit             /* when TRUE, called for NVIMINIT */
 )
 {
   char_u      *initstr;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7422,7 +7422,7 @@ static void paste_option_changed(void)
   old_p_paste = p_paste;
 }
 
-/// vimrc_found() - Called when a ".vimrc" or "VIMINIT" has been found.
+/// vimrc_found() - Called when a ".vimrc" or "NVIMINIT" has been found.
 ///
 /// Set the values for options that didn't get set yet to the Vim defaults.
 /// When "fname" is not NULL, use it to set $"envname" when it wasn't set yet.

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -86,7 +86,7 @@ $(SCRIPTS) $(SCRIPTS_GUI): $(VIMPROG) test1.out
 
 RM_ON_RUN   := test.out X* viminfo
 RM_ON_START := tiny.vim small.vim mbyte.vim test.ok
-RUN_VIM     := VIMRUNTIME=$(SCRIPTSOURCE); export VIMRUNTIME; $(TOOL) $(VIMPROG) -u unix.vim -U NONE -i viminfo --noplugin -s dotest.in
+RUN_VIM     := NVIMRUNTIME=$(SCRIPTSOURCE); export NVIMRUNTIME; $(TOOL) $(VIMPROG) -u unix.vim -U NONE -i viminfo --noplugin -s dotest.in
 
 clean:
 	-rm -rf *.out          \

--- a/test/unit/env_nvim2_spec.lua
+++ b/test/unit/env_nvim2_spec.lua
@@ -1,0 +1,23 @@
+local helpers = require("test.unit.helpers")
+local cimport = helpers.cimport
+local env = cimport('./src/nvim/os/os.h')
+local eq = helpers.eq
+local neq = helpers.neq
+
+describe('Dont use $VIM/$VIMRUNTIME', function()
+
+  env.os_unsetenv('NVIM')
+  env.os_unsetenv('NVIMRUNTIME')
+  env.os_setenv('VIM', 'VIM_VALUE', 1)
+  env.os_setenv('VIMRUNTIME', 'VIMRUNTIME_VALUE', 1)
+
+  helpers.vim_init()
+
+  describe('$VIM is cleared if $NVIM is unset', function()
+      neq(os.getenv('VIM'), 'VIM_VALUE')
+  end)
+  describe('$VIMRUNTIME is cleared if $NVIMRUNTIME is unset', function()
+      neq(os.getenv('VIMRUNTIME'), 'VIMRUNTIME_VALUE')
+  end)
+end)
+

--- a/test/unit/env_nvim_spec.lua
+++ b/test/unit/env_nvim_spec.lua
@@ -1,0 +1,20 @@
+local helpers = require("test.unit.helpers")
+local cimport = helpers.cimport
+local env = cimport('./src/nvim/os/os.h')
+local eq = helpers.eq
+
+describe('Use $NVIM/$NVIMRUNTIME as $VIM/$VIMRUNTIME', function()
+
+  env.os_setenv('NVIM', 'NVIM_VALUE', 1)
+  env.os_setenv('NVIMRUNTIME', 'NVIMRUNTIME_VALUE', 1)
+
+  helpers.vim_init()
+
+  describe('$VIM is $NVIM', function()
+      eq(os.getenv('VIM'), os.getenv('NVIM'))
+  end)
+  describe('$VIMRUNTIME is $NVIMRUNTIME', function()
+      eq(os.getenv('VIMRUNTIME'), os.getenv('NVIMRUNTIME'))
+  end)
+end)
+


### PR DESCRIPTION
- For compatibility plugins still need $VIMRUNTIME, but getting or
  settings VIMRUNTIME will use NVIMRUNTIME instead.

For #1924.
