### PR TITLE
[RFC] Travis: Fail fast, disable JIT for functional tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
     - os: osx
       env: CI_TARGET=gcc
       compiler: gcc-4.9
+  fast_finish: true
 before_install:
   # Pins the version of the java package installed on the Travis VMs
   # and avoids a lengthy upgrade process for them.

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -1,3 +1,8 @@
+if jit then
+  -- Disable JIT because of random errors on Travis with OS X.
+  jit.off(true, true)
+end
+
 require('coxpcall')
 local Loop = require('nvim.loop')
 local MsgpackStream = require('nvim.msgpack_stream')


### PR DESCRIPTION
Disable JIT to find cause for random `PANIC: unprotected error in call to Lua API` on Travis (OS X), e.g. https://travis-ci.org/neovim/neovim/jobs/49145956. Ref https://github.com/neovim/neovim/pull/1572#issuecomment-70646528.

We won't know if this has any effect until a few builds have been performed, I guess, so maybe just merge? It shouldn't have any unwanted side-effects (https://github.com/neovim/neovim/pull/1572#issuecomment-70646528jj). For `fast_finish`, see http://blog.travis-ci.com/2013-11-27-fast-finishing-builds/.
