### PR TITLE
[RDY] Remove nondeterminism in systemlist interrupt tests

### DIFF
--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -248,7 +248,7 @@ describe('systemlist()', function()
     end)
 
     it('`yes` and is directly interrupted with CTRL-C', function()
-      feed(':call systemlist("echo")<cr><c-c>')
+      feed(':call systemlist("yes | xargs")<cr><c-c>')
       screen:expect([[
         ^                                                    |
         ~                                                    |
@@ -268,7 +268,7 @@ describe('systemlist()', function()
     end)
 
     it('`yes` and is a little bit later interrupted with CTRL-C', function()
-      feed(':call systemlist("echo")<cr>')
+      feed(':call systemlist("yes | xargs")<cr>')
       feed('<c-c>')
       screen:expect([[
         ^                                                    |


### PR DESCRIPTION
The systemlist test currently calls the `echo` command which can potentially
complete before being interrupted, causing random test failures.

Use `yes | xargs` instead. A `yes` invocation that is not piped through `xargs`
can produce a huge amount of lines in a very short time, leading memory
starvation when the result is being converted into a list. `xargs` ensures only
one line of output will be produced while allowing interrupt to be tested.
