### PR TITLE
[RFC] unittests: define _Thread_local to be nothing

### DIFF
--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -102,7 +102,10 @@ local Gcc = {
    '-D "EXTERN=extern"',
    '-D "INIT(...)="',
    '-D_GNU_SOURCE',
-   '-DINCLUDE_GENERATED_DECLARATIONS'
+   '-DINCLUDE_GENERATED_DECLARATIONS',
+
+   -- Needed for FreeBSD
+   '-D "_Thread_local="'
   }
 }
 


### PR DESCRIPTION
This helps the LuaJIT ffi module to parse the header correctly.
Otherwise, the whole suite of tests fail.
