### PR TITLE
[RFC] Fix an fs_spec test under FreeBSD and a symlinked home directory.

### DIFF
--- a/test/unit/os/fs_spec.lua
+++ b/test/unit/os/fs_spec.lua
@@ -170,12 +170,20 @@ describe('fs function', function()
 
     it('returns the absolute path when given an executable relative to the current dir', function()
       local old_dir = lfs.currentdir()
+
       lfs.chdir(directory)
       local relative_executable = './' .. executable_name
+
       -- Don't test yet; we need to chdir back first.
       local res = exe(relative_executable)
+
       lfs.chdir(old_dir)
-      eq(absolute_executable, res)
+
+      -- Need to canonicalize the absolute path taken from arg[0], because the
+      -- path may have a symlink in it.  For example, /home is symlinked in
+      -- FreeBSD 10's VM image.
+      local expected = exe(absolute_executable)
+      eq(expected, res)
     end)
   end)
 


### PR DESCRIPTION
It turns out the FreeBSD 10 VM has a symlink for the home directory to
/usr/home.  Unfortunately, this breaks the test as arg[0] may not have
the symlink resolved, but the path returned from the exe() call will.
As a result, the comparison fails, even though the result is correct.

Let's fix this by running the absolute path through exe() too, and then
comparing the results.
