### PR TITLE
[WIP] build: move the lint target into CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,3 +310,10 @@ if(BUSTED_PRG)
       -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
     DEPENDS nvim)
 endif()
+
+add_custom_target(lint
+  COMMAND ${CMAKE_COMMAND}
+    -DLINT_PRG=${CMAKE_CURRENT_SOURCE_DIR}/clint.py
+    -DLINT_DIR=${CMAKE_CURRENT_SOURCE_DIR}/src
+    -DLINT_IGNORE_FILE=${CMAKE_CURRENT_SOURCE_DIR}/clint-ignored-files.txt
+    -P ${PROJECT_SOURCE_DIR}/cmake/RunLint.cmake)

--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,6 @@ install: | nvim
 	+$(BUILD_CMD) -C build install
 
 lint:
-	cmake -DLINT_PRG=./clint.py \
-		-DLINT_DIR=src \
-		-DLINT_IGNORE_FILE=clint-ignored-files.txt \
-		-P cmake/RunLint.cmake
+	+$(BUILD_CMD) -C build lint
 
 .PHONY: test functionaltest unittest lint clean distclean nvim libnvim cmake deps install


### PR DESCRIPTION
The Makefile is really meant to be a shortcut to get people going.  This
change allows others who invoke CMake directly to have access to the
lint target too.
