### PR TITLE
[RFC] build: patch msgpack to work on FreeBSD until a proper fix is upstream

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -171,6 +171,7 @@ if(USE_BUNDLED_MSGPACK)
       -DEXPECTED_SHA1=${MSGPACK_SHA1}
       -DTARGET=msgpack
       -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/msgpack-byteswap.patch
     CONFIGURE_COMMAND cmake ${DEPS_BUILD_DIR}/src/msgpack
        -DMSGPACK_ENABLE_CXX=OFF
        -DMSGPACK_BUILD_TESTS=OFF

--- a/third-party/msgpack-byteswap.patch
+++ b/third-party/msgpack-byteswap.patch
@@ -1,0 +1,13 @@
+Allow msgpack to compile correctly on FreeBSD and OpenBSD.
+
+--- a/include/msgpack/sysdep.h
++++ b/include/msgpack/sysdep.h
+@@ -76,7 +76,7 @@ typedef unsigned int _msgpack_atomic_cou
+ #else
+ 
+ #include <arpa/inet.h>  /* __BYTE_ORDER */
+-#  if !defined(__APPLE__) && !(defined(__sun) && defined(__SVR4))
++#  if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !(defined(__sun) && defined(__SVR4))
+ #    include <byteswap.h>
+ #  endif
+ 


### PR DESCRIPTION
I'm generally not into patching sources and prefer to have things fixed upstream, but it seems like msgpack is kind of lagging a bit.  So, I think it's probably a good idea to patch msgpack for the time being.
