### PR TITLE
Discard exceptions once they are converted to API errors

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -65,6 +65,7 @@ bool try_end(Error *err)
     }
   } else if (did_throw) {
     api_set_error(err, Exception, "%s", current_exception->value);
+    discard_current_exception();
   }
 
   return err->set;


### PR DESCRIPTION
Fixes: #1976
