### PR TITLE
[RFC] treat NULL initialized vimscript string as api type String

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -644,10 +644,8 @@ static Object vim_to_object_rec(typval_T *obj, PMap(ptr_t) *lookup)
 
   switch (obj->v_type) {
     case VAR_STRING:
-      if (obj->vval.v_string != NULL) {
-        rv.type = kObjectTypeString;
-        rv.data.string = cstr_to_string((char *) obj->vval.v_string);
-      }
+      rv.type = kObjectTypeString;
+      rv.data.string = cstr_to_string((char *) obj->vval.v_string);
       break;
 
     case VAR_NUMBER:

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -27,6 +27,11 @@ describe('vim_* functions', function()
       nvim('command', 'let g:v2 = [1, 2, {"v3": 3}]')
       eq({v1 = 'a', v2 = {1, 2, {v3 = 3}}}, nvim('eval', 'g:'))
     end)
+
+    it('handles NULL-initialized strings correctly', function()
+      eq(1, nvim('eval',"matcharg(1) == ['', '']"))
+      eq({'', ''}, nvim('eval','matcharg(1)'))
+    end)
   end)
 
   describe('strwidth', function()

--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -191,7 +191,7 @@ describe('system()', function()
   if xclip then
     describe("with a program that doesn't close stdout", function()
       it('will exit properly after passing input', function()
-        eq(nil, eval([[system('xclip -i -selection clipboard', 'clip-data')]]))
+        eq('', eval([[system('xclip -i -selection clipboard', 'clip-data')]]))
         eq('clip-data', eval([[system('xclip -o -selection clipboard')]]))
       end)
     end)


### PR DESCRIPTION
Demonstrating an unexpected failure I found while working on porting test 63 (matchadd and friends). Sometimes what looks like empty strings to vimscript get returned as null values in msgpack, while

```
!echo matcharg(1)
['', '']
```

`eval('matcharg(1)')` appears as empty table `{}` in lua (and `[None, None]` in python). I suppose this is unintentional behaviour and should be changed?
