### PR TITLE
make the spellfile creation use .nvim folder

### DIFF
--- a/runtime/autoload/spellfile.vim
+++ b/runtime/autoload/spellfile.vim
@@ -198,7 +198,7 @@ endfunc
 function! spellfile#WritableSpellDir()
   if has("unix")
     " For Unix always use the $HOME/.vim directory
-    return $HOME . "/.vim/spell"
+    return $HOME . "/.nvim/spell"
   endif
   for dir in split(&rtp, ',')
     if filewritable(dir) == 2


### PR DESCRIPTION
Spellfile.vim tries to create the folder `.vim/spell`.  I changed it to create `.nvim/spell`.  If there is a variable convention for referring to the nvim .vim folder, I would be happy to update the value elsewhere.
