### PR TITLE
[RFC] Fixed ignorecase flag in namespace parsing in phpcomplete.vim

### DIFF
--- a/runtime/autoload/phpcomplete.vim
+++ b/runtime/autoload/phpcomplete.vim
@@ -2257,7 +2257,7 @@ function! phpcomplete#GetCurrentNameSpace(file_lines) " {{{
 			let use_parts = map(split(use_expression, '\s*,\s*'), 'substitute(v:val, "\\s+", " ", "g")')
 			for part in use_parts
 				if part =~? '\s\+as\s\+'
-					let [object, name] = split(part, '\s\+as\s\+')
+					let [object, name] = split(part, '\s\+as\s\+\c')
 					let object = substitute(object, '^\\', '', '')
 					let name   = substitute(name, '^\\', '', '')
 				else


### PR DESCRIPTION
Hi!

There was an error in phpcomplete.vim with uses written such way:
use Some\Path\To\Class AS SomeLocalName;
because "as" can be in any case and split by default is case-sensitive. It's the same error, that was fixed [here](https://github.com/shawncplus/phpcomplete.vim/pull/56)
