### PR TITLE
[RDY] Remove platform dependent HAVE_OPENDIR

### DIFF
--- a/config/config.h.in
+++ b/config/config.h.in
@@ -37,7 +37,6 @@
 #cmakedefine HAVE_LSTAT
 #cmakedefine HAVE_NL_LANGINFO_CODESET
 #cmakedefine HAVE_NL_MSG_CAT_CNTR
-#cmakedefine HAVE_OPENDIR
 #define HAVE_OSPEED 1
 #cmakedefine HAVE_PUTENV
 #cmakedefine HAVE_PWD_H

--- a/src/nvim/os_unix_defs.h
+++ b/src/nvim/os_unix_defs.h
@@ -195,10 +195,6 @@
 /* Special wildcards that need to be handled by the shell */
 #define SPECIAL_WILDCHAR    "`'{"
 
-#ifndef HAVE_OPENDIR
-# define NO_EXPANDPATH
-#endif
-
 /*
  * Unix has plenty of memory, use large buffers
  */

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -401,8 +401,6 @@ char_u *save_absolute_path(const char_u *name)
 }
 
 
-#if !defined(NO_EXPANDPATH)
-
 #if defined(UNIX) || defined(USE_UNIXFILENAME)
 /*
  * Unix style wildcard expansion code.
@@ -1244,7 +1242,6 @@ addfile (
     add_pathsep(p);
   GA_APPEND(char_u *, gap, p);
 }
-#endif /* !NO_EXPANDPATH */
 
 /*
  * Converts a file name into a canonical form. It simplifies a file name into
@@ -1618,7 +1615,6 @@ int same_directory(char_u *f1, char_u *f2)
          && pathcmp((char *)ffname, (char *)f2, (int)(t1 - ffname)) == 0;
 }
 
-#if !defined(NO_EXPANDPATH)
 /*
  * Compare path "p[]" to "q[]".
  * If "maxlen" >= 0 compare "p[maxlen]" to "q[maxlen]"
@@ -1683,9 +1679,7 @@ int pathcmp(const char *p, const char *q, int maxlen)
     return -1;              /* no match */
   return 1;
 }
-#endif
 
-#ifndef NO_EXPANDPATH
 /*
  * Expand a path into all matching files and/or directories.  Handles "*",
  * "?", "[a-z]", "**", etc.
@@ -1698,7 +1692,6 @@ int mch_expandpath(garray_T *gap, char_u *path, int flags)
 {
   return unix_expandpath(gap, path, 0, flags, FALSE);
 }
-#endif
 
 /// Try to find a shortname by comparing the fullname with the current
 /// directory.

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -185,13 +185,6 @@ enum {
 };
 
 
-#ifdef NO_EXPANDPATH
-# define gen_expand_wildcards mch_expand_wildcards
-#endif
-
-
-
-
 
 
 


### PR DESCRIPTION
As far as I understand, HAVE_OPENDIR is platform specific, so remove it.

With HAVE_OPENDIR=1, "gen_expand_wildcards" calls "mch_expand_wildcards".
With HAVE_OPENDIR=0, vim.h maps "gen_expand_wildcards" directly to "mch_expand_wildcards"

So, if this pull request gets accepted, my next try would be remove "gen_expand_wildcards" and use only "mch_expand_wildcards".
