### PR TITLE
[RFC] Fix collection of libuv dependent libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 # Prefer our bundled versions of dependencies.
 set(DEPS_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/.deps/usr" CACHE PATH "Path prefix for finding dependencies")
 list(INSERT CMAKE_PREFIX_PATH 0 ${DEPS_PREFIX})
+set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${DEPS_PREFIX}/lib/pkgconfig")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   # CMake tries to treat /sw and /opt/local as extension of the system path, but

--- a/cmake/FindLibUV.cmake
+++ b/cmake/FindLibUV.cmake
@@ -39,7 +39,11 @@ find_library(LIBUV_LIBRARY NAMES ${LIBUV_NAMES}
 
 mark_as_advanced(LIBUV_INCLUDE_DIR LIBUV_LIBRARY)
 
-set(LIBUV_LIBRARIES ${LIBUV_LIBRARY})
+if(PC_LIBUV_LIBRARIES)
+    list(REMOVE_ITEM PC_LIBUV_LIBRARIES uv)
+endif()
+
+set(LIBUV_LIBRARIES ${LIBUV_LIBRARY} ${PC_LIBUV_LIBRARIES})
 set(LIBUV_INCLUDE_DIRS ${LIBUV_INCLUDE_DIR})
 
 # Deal with the fact that libuv.pc is missing important dependency information.


### PR DESCRIPTION
This does two things:

1) Makes sure that pkg-config will find the config files for our custom dependencies.
2) Filters off the uv library from `PC_LIBUV_LIBRARIES` so that we can specify which one we want (static or dynamic).

This should fix the Ubuntu 14.04 issues that have popped up.
