### PR TITLE
[RFC] Add missing thread libraries to the tty test.

### DIFF
--- a/test/functional/job/CMakeLists.txt
+++ b/test/functional/job/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(tty-test tty-test.c)
-target_link_libraries(tty-test ${LIBUV_LIBRARIES})
+target_link_libraries(tty-test ${LIBUV_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
#2053 will fix this issue too, but for a more quick turn fix to the Ubuntu linking issue, let's add the missing thread libraries to the link line.
