### PR TITLE
[RFC] Add ability to detect replace mode in (T)UI

### DIFF
--- a/src/nvim/msgpack_rpc/remote_ui.c
+++ b/src/nvim/msgpack_rpc/remote_ui.c
@@ -87,6 +87,7 @@ static Object remote_ui_attach(uint64_t channel_id, uint64_t request_id,
   ui->mouse_on = remote_ui_mouse_on;
   ui->mouse_off = remote_ui_mouse_off;
   ui->insert_mode = remote_ui_insert_mode;
+  ui->replace_mode = remote_ui_insert_mode;
   ui->normal_mode = remote_ui_normal_mode;
   ui->set_scroll_region = remote_ui_set_scroll_region;
   ui->scroll = remote_ui_scroll;

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -50,7 +50,7 @@ typedef struct {
   struct {
     int enable_mouse, disable_mouse;
     int enable_bracketed_paste, disable_bracketed_paste;
-    int enter_insert_mode, exit_insert_mode;
+    int enter_replace_mode, enter_insert_mode, exit_insert_mode;
   } unibi_ext;
 } TUIData;
 
@@ -90,6 +90,7 @@ void tui_start(void)
   data->unibi_ext.disable_mouse = -1;
   data->unibi_ext.enable_bracketed_paste = -1;
   data->unibi_ext.disable_bracketed_paste = -1;
+  data->unibi_ext.enter_replace_mode = -1;
   data->unibi_ext.enter_insert_mode = -1;
   data->unibi_ext.exit_insert_mode = -1;
 
@@ -139,6 +140,7 @@ void tui_start(void)
   ui->mouse_on = tui_mouse_on;
   ui->mouse_off = tui_mouse_off;
   ui->insert_mode = tui_insert_mode;
+  ui->replace_mode = tui_replace_mode;
   ui->normal_mode = tui_normal_mode;
   ui->set_scroll_region = tui_set_scroll_region;
   ui->scroll = tui_scroll;
@@ -362,6 +364,12 @@ static void tui_mouse_off(UI *ui)
 {
   TUIData *data = ui->data;
   unibi_out(ui, (int)data->unibi_ext.disable_mouse);
+}
+
+static void tui_replace_mode(UI *ui)
+{
+  TUIData *data = ui->data;
+  unibi_out(ui, (int)data->unibi_ext.enter_replace_mode);
 }
 
 static void tui_insert_mode(UI *ui)
@@ -742,12 +750,16 @@ static void fix_terminfo(TUIData *data)
   if ((term_prog && !strcmp(term_prog, "iTerm.app"))
       || os_getenv("ITERM_SESSION_ID") != NULL) {
     // iterm
+    data->unibi_ext.enter_replace_mode = (int)unibi_add_ext_str(ut, NULL,
+        TMUX_WRAP("\x1b]50;CursorShape=2;BlinkingCursorEnabled=1\x07"));
     data->unibi_ext.enter_insert_mode = (int)unibi_add_ext_str(ut, NULL,
         TMUX_WRAP("\x1b]50;CursorShape=1;BlinkingCursorEnabled=1\x07"));
     data->unibi_ext.exit_insert_mode = (int)unibi_add_ext_str(ut, NULL,
         TMUX_WRAP("\x1b]50;CursorShape=0;BlinkingCursorEnabled=0\x07"));
   } else {
     // xterm-like sequences for blinking bar and solid block
+    data->unibi_ext.enter_replace_mode = (int)unibi_add_ext_str(ut, NULL,
+        TMUX_WRAP("\x1b[3 q"));
     data->unibi_ext.enter_insert_mode = (int)unibi_add_ext_str(ut, NULL,
         TMUX_WRAP("\x1b[5 q"));
     data->unibi_ext.exit_insert_mode = (int)unibi_add_ext_str(ut, NULL,

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -470,21 +470,29 @@ static void flush_cursor_update(void)
 static void ui_change_mode(void)
 {
   static int showing_insert_mode = MAYBE;
+  static int showing_replace_mode = MAYBE;
 
   if (!full_screen) {
     return;
   }
 
   if (State & INSERT) {
-    if (showing_insert_mode != TRUE) {
-      UI_CALL(insert_mode);
+	if (showing_replace_mode != TRUE && State & REPLACE_FLAG) {
+	  UI_CALL(replace_mode);
+	  showing_replace_mode = TRUE;
+	  showing_insert_mode = FALSE;
+	}
+    else if (showing_insert_mode != TRUE) {
+	  UI_CALL(insert_mode);
+	  showing_replace_mode = FALSE;
+	  showing_insert_mode = TRUE;
     }
-    showing_insert_mode = TRUE;
   } else {
-    if (showing_insert_mode != FALSE) {
+    if (showing_insert_mode != FALSE || showing_replace_mode != FALSE) {
       UI_CALL(normal_mode);
     }
     showing_insert_mode = FALSE;
+	showing_replace_mode = FALSE;
   }
   conceal_check_cursur_line();
 }

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -25,6 +25,7 @@ struct ui_t {
   void (*mouse_on)(UI *ui);
   void (*mouse_off)(UI *ui);
   void (*insert_mode)(UI *ui);
+  void (*replace_mode)(UI *ui);
   void (*normal_mode)(UI *ui);
   void (*set_scroll_region)(UI *ui, int top, int bot, int left, int right);
   void (*scroll)(UI *ui, int count);


### PR DESCRIPTION
This adds an extra check in ui.c to be able to tell the connected ui
clients if neovim is in insert or replace mode.

Currently, only the TUI takes advantage of this feature.

I'm really glad that the new TUI gained "native" support to change cursor shape in insert mode. I had quite a few problems getting it to work in vanilla vim with urxvt. However the current code doesn't change cursor shape when entering replace mode. So I created this pull request to add a underline cursor in replace mode.
