### PR TITLE
[RFC] tests: don't hardcode the path to tty-test

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -8,6 +8,15 @@ local nvim_prog = os.getenv('NVIM_PROG') or 'build/bin/nvim'
 local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
                    '--cmd', 'set shortmess+=I background=light noswapfile',
                    '--embed'}
+
+-- Formulate a path to the directory containing nvim.  We use this to
+-- help run test executables.  It helps to keep the tests working, even
+-- when the build is not in the default location.
+local nvim_dir = nvim_prog:gsub("[/\\][^/\\]+$", "")
+if nvim_dir == nvim_prog then
+    nvim_dir = "."
+end
+
 local prepend_argv
 
 if os.getenv('VALGRIND') then
@@ -282,6 +291,7 @@ return {
   expect = expect,
   ok = ok,
   nvim = nvim,
+  nvim_dir = nvim_dir,
   buffer = buffer,
   window = window,
   tabpage = tabpage,

--- a/test/functional/job/job_spec.lua
+++ b/test/functional/job/job_spec.lua
@@ -4,7 +4,7 @@ local clear, nvim, eq, neq, ok, expect, eval, next_message, run, stop, session
   = helpers.clear, helpers.nvim, helpers.eq, helpers.neq, helpers.ok,
   helpers.expect, helpers.eval, helpers.next_message, helpers.run,
   helpers.stop, helpers.session
-local insert = helpers.insert
+local nvim_dir, insert = helpers.nvim_dir, helpers.insert
 
 local channel = nvim('get_api_info')[1]
 
@@ -150,7 +150,7 @@ describe('jobs', function()
 
     before_each(function() 
       -- the full path to tty-test seems to be required when running on travis.
-      insert('build/bin/tty-test')
+      insert(nvim_dir .. '/tty-test')
       nvim('command', 'let exec = expand("<cfile>:p")')
       nvim('command', notify_str('v:job_data[1]', 'get(v:job_data, 2)'))
       nvim('command', "let j = jobstart('xxx', exec, [], {})")


### PR DESCRIPTION
This fixes the build for those who drive the build directly using
CMake.
