### PR TITLE
[WIP] clipboard: support VIMENC (modewise selection across instances) and add test

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -31,7 +31,14 @@ function! s:try_cmd(cmd, ...)
 endfunction
 
 let s:cache_enabled = 1
-if executable('pbcopy')
+let s:use_vimenc = 0
+if executable('xsel-vim')
+  let s:use_vimenc = 1
+  let s:copy['+'] = 'xsel-vim --vimenc --nodetach -i -b'
+  let s:paste['+'] = 'xsel-vim --vimenc -o -b'
+  let s:copy['*'] = 'xsel-vim --vimenc --nodetach -i -p'
+  let s:paste['*'] = 'xsel-vim --vimenc -o -p'
+elseif executable('pbcopy')
   let s:copy['+'] = 'pbcopy'
   let s:paste['+'] = 'pbpaste'
   let s:copy['*'] = s:copy['+']
@@ -54,16 +61,60 @@ endif
 
 let s:clipboard = {}
 
+" \n is really null
+let s:vimenc_to_type = {
+    \ "\n" : "v",
+    \ "\x01" : "V",
+    \ "\x02" : "b",
+    \ }
+
+let s:type_to_vimenc = {
+    \ "v" : "\n",
+    \ "V" : "\x01",
+    \ "b" : "\x02",
+    \ }
+
 function! s:clipboard.get(reg)
   if s:selections[a:reg].owner > 0
     return s:selections[a:reg].data
   end
-  return s:try_cmd(s:paste[a:reg])
+  let type = ''
+  let result = s:try_cmd(s:paste[a:reg])
+  if type(result) == type(0)
+    " error
+    return result
+  end
+  if s:use_vimenc && len(result) > 0 && len(result[0]) > 0
+    if result[0][0] == "v"
+      "vimenc format
+      let vimenc_motion = result[0][1]
+      let nullind = match(result[0], "\n", 2)
+      " FIXME: actually handle encoding...
+      let encoding = result[0][2:nullind]
+      " "result[0]" is sometimes "locked" so can't this:
+      "let result[0] = result[0][nullind+1:]
+      let result = [result[0][nullind+1:]] + result[1:]
+      " in case vim invents a fourth selection type in the meanwhile
+      " just ignore it
+      let type = get(s:vimenc_to_type, vimenc_motion, '')
+    else
+      "text format
+      let result = [result[0][1:]] + result[1:]
+    end
+  end
+  return [result, type]
 endfunction
 
 function! s:clipboard.set(lines, regtype, reg)
+  let contents = copy(a:lines)
+  if s:use_vimenc
+    let regsym = s:type_to_vimenc[a:regtype]
+    " TODO: add &encoding instead? (or even better: convert to utf-8)
+    " or pluseven better: &encoding always utf-8 ...
+    let contents[0] = regsym."utf-8\n".contents[0]
+  end
   if s:cache_enabled == 0
-    call s:try_cmd(s:copy[a:reg], a:lines)
+    call s:try_cmd(s:copy[a:reg], contents)
     return 0
   end
 
@@ -82,7 +133,7 @@ function! s:clipboard.set(lines, regtype, reg)
     echohl None
     return 0
   endif
-  call jobsend(jobid, a:lines)
+  call jobsend(jobid, contents)
   call jobclose(jobid, 'stdin')
   let selection.owner = jobid
 endfunction

--- a/test/functional/clipboard/clipboard_vimenc_spec.lua
+++ b/test/functional/clipboard/clipboard_vimenc_spec.lua
@@ -1,0 +1,90 @@
+-- NB: this file could be merged with provider_spec.lua
+-- separate right now for quick testing
+
+local helpers = require('test.functional.helpers')
+local clear, feed, insert, spawn = helpers.clear, helpers.feed, helpers.insert, helpers.spawn
+local execute, expect, eq, eval = helpers.execute, helpers.expect, helpers.eq, helpers.eval
+local nvim, run, stop, restart = helpers.nvim, helpers.run, helpers.stop, helpers.restart
+local neq = helpers.neq
+
+-- this will unavoidingly clobber local clipboard
+-- could spwan a Xvfb when running locally
+describe('clipboard between instances', function()
+  local nvim2
+  -- XXX: this could be broken out to helpers if generally useful
+  local function nvim2_req(method, ...)
+    local status, rv = nvim2:request(method, ...)
+    if not status then
+      error(rv[2])
+    end
+    return rv
+  end
+
+  before_each(function()
+    clear()
+    nvim2 = spawn()
+
+    -- sanity check: these truly are distinct instances
+    neq(eval('getpid()'), nvim2_req('vim_eval', 'getpid()'))
+  end)
+
+  after_each(function()
+    nvim2:exit(0)
+  end)
+
+  it("works", function()
+    insert([[
+      some lines from
+      first instance]])
+    feed('gg"*2yywwv+e"+y')
+    -- nvim sees correct data
+    eq({{'some lines from', 'first instance'}, 'V'}, nvim2_req('vim_eval','[getreg("*", 0, 1), getregtype("*")]'))
+    eq({{'from', 'first'}, 'v'}, nvim2_req('vim_eval','[getreg("+", 0, 1), getregtype("+")]'))
+
+    -- non vimenc-aware apps sees NL-encoded line/char motions
+    eq({'some lines from', 'first instance', ''}, eval('systemlist("xsel -o -p",[],1)'))
+    eq({'from', 'first'}, eval('systemlist("xsel -o -b",[],1)'))
+  end)
+
+  it("supports vimenc motions", function()
+    insert([[
+      this is charwise data
+      block
+      selection
+      ]])
+    feed('ggv$"*y+<c-v>+$"+y')
+
+    eq({{'this is charwise data', ''}, 'v'}, nvim2_req('vim_eval','[getreg("*", 0, 1), getregtype("*")]'))
+    eq({{'block', 'selection'}, '\x169'}, nvim2_req('vim_eval','[getreg("+", 0, 1), getregtype("+")]'))
+
+    -- in pure text clipboard these are ambiguous with a line-wise selection
+    eq({'this is charwise data', ''}, eval('systemlist("xsel -o -p",[],1)'))
+    eq({'block', 'selection', ''}, eval('systemlist("xsel -o -b",[],1)'))
+  end)
+
+  it("supports NUL in clipboard data", function()
+    insert(" some very\022000NUL-ly data\022000\nin this sel\022000ection")
+    feed('gg"*2yyw"+yW')
+    eq({{' some very\nNUL-ly data\n', 'in this sel\nection'}, 'V'}, nvim2_req('vim_eval','[getreg("*", 0, 1), getregtype("*")]'))
+    eq({{'very\nNUL-ly '}, 'v'}, nvim2_req('vim_eval','[getreg("+", 0, 1), getregtype("+")]'))
+
+    -- IMHO NUL handling is simply not well-defined in the TEXT/UTF8 selection formats
+    -- for instance xsel and xcopy handles this differently
+  end)
+
+  it("pastes correctly from text-format clipboard", function()
+      eval('systemlist("xsel -i -b", ["line-wise-ish", "data", ""])')
+      eval('systemlist("xsel -i -p", ["char-wise-ish", "data"])')
+      insert('text')
+      feed('"+P"*P')
+      expect([[
+        char-wise-ish
+        dataline-wise-ish
+        data
+        text]])
+
+    eq({{'char-wise-ish', 'data'}, 'v'}, nvim2_req('vim_eval','[getreg("*", 0, 1), getregtype("*")]'))
+    eq({{'line-wise-ish', 'data'}, 'V'}, nvim2_req('vim_eval','[getreg("+", 0, 1), getregtype("+")]'))
+  end)
+
+end)

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -172,6 +172,9 @@ local function rawfeed(...)
 end
 
 local function spawn(argv)
+  if argv == nil then
+    argv = nvim_argv
+  end
   local loop = Loop.new()
   local msgpack_stream = MsgpackStream.new(loop)
   local async_session = AsyncSession.new(msgpack_stream)


### PR DESCRIPTION
Aims to fix #1822 and #1908 and some reported performance issues with `clipboard=unnamed`
- [x] Implement and use enhanced `xsel-vim` utility to support `vimenc` format (blockwise yanks and pastes between instances! including vanilla vim!) **WIP**  kfish/xsel#8
- [x] Use job control for `xsel -i` to keep track of ownership and use locally cached value when appropriate (should improve performance of `unnamed` when yanking/pasting locally) **DONE** #2703 
- [x] Restore clipboard entries in `:registers` **DONE** #2244 
- [ ] Do something for OS X? **Help Needed:** Someone on OSX needs to look into and port https://github.com/vim/vim/blob/master/src/os_macosx.m .
- [ ] Similarly for Windows, when the windows build is getting more usable. 

Currently this needs my `xsel` branch [nvim](https://github.com/bfredl/xsel/tree/nvim) compiled and put in `xsel-vim` in `$PATH`. I do some hacks right now (abuse of global variables and missing error handling), but after some cleanup this could possibly be mainlined, see kfish/xsel#7 and kfish/xsel#8
