### PR TITLE
[RFC] tests: require luassert in the helpers

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -1,4 +1,5 @@
 require('coxpcall')
+local assert = require('luassert')
 local Loop = require('nvim.loop')
 local MsgpackStream = require('nvim.msgpack_stream')
 local AsyncSession = require('nvim.async_session')

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -1,3 +1,4 @@
+local assert = require('luassert')
 local ffi = require('ffi')
 local formatc = require('test.unit.formatc')
 local Set = require('test.unit.set')


### PR DESCRIPTION
This is necessary for newer versions of Busted, otherwise assert will be
nil and the tests will die.

Note: this does not mean the tests now work with the latest Busted.
There are still several issues preventing that from happening.
