### PR TITLE
tests: prevent busted from reloading the ffi module and others

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -15,6 +15,7 @@ endif()
 
 execute_process(
   COMMAND ${BUSTED_PRG} -v -o ${BUSTED_OUTPUT_TYPE}
+    --helper=${TEST_DIR}/${TEST_TYPE}/preload.lua
     --lpath=${BUILD_DIR}/?.lua ${TEST_PATH}
   WORKING_DIRECTORY ${WORKING_DIR}
   ERROR_VARIABLE err

--- a/test/functional/preload.lua
+++ b/test/functional/preload.lua
@@ -1,0 +1,5 @@
+-- Modules loaded here will not be cleared and reloaded by Busted.
+-- Busted started doing this to help provide more isolation.  See issue #62
+-- for more information about this.
+local ffi = require('ffi')
+local helpers = require('test.functional.helpers')

--- a/test/unit/preload.lua
+++ b/test/unit/preload.lua
@@ -1,0 +1,7 @@
+-- Modules loaded here will not be cleared and reloaded by Busted.
+-- Busted started doing this to help provide more isolation.  See issue #62
+-- for more information about this.
+local ffi = require('ffi')
+local helpers = require('test.unit.helpers')
+local lfs = require('lfs')
+local preprocess = require('test.unit.preprocess')


### PR DESCRIPTION
It turns out that Busted started cleaning the environment in 2.0rc5 as a
result of Olivine-Labs/busted#62.  This, in turn, caused the ffi module
to be reloaded for each spec file, and LuaJIT doesn't appreciate it.
The net effect is an assertion error in LuaJIT.

By using the --helper feature of Busted, we can pre-load some modules
ahead of Busted and prevent it from reloading them--making LuaJIT happy
again.
