### PR TITLE
Call mb_init in case of failed locale search, or failed locale lookup to properly init utf-8 encoding.

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1989,7 +1989,7 @@ void set_init_1(void)
     char_u *save_enc;
 
     /* Try setting 'encoding' and check if the value is valid.
-     * If not, go back to the default "latin1". */
+     * If not, go back to the default "utf-8". */
     save_enc = p_enc;
     p_enc = p;
     if (STRCMP(p_enc, "gb18030") == 0) {
@@ -2030,7 +2030,13 @@ void set_init_1(void)
     } else {
       free(p_enc);
       p_enc = save_enc;
+      // mb_init() failed. Call it again for the saved encoding
+      mb_init();
     }
+  } else {
+    // enc_locale() didn't find a useful locale. Call mb_init() with
+    // the default utf-8 encoding
+    mb_init();
   }
 
   /* Set the default for 'helplang'. */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2030,7 +2030,13 @@ void set_init_1(void)
     } else {
       free(p_enc);
       p_enc = save_enc;
+      /* mb_init() failed. Call it again for the saved encoding */
+      mb_init();
     }
+  } else {
+    /* enc_locale() didn't find a useful locale. Call mb_init() with
+     * the default utf-8 encoding */
+    mb_init();
   }
 
   /* Set the default for 'helplang'. */


### PR DESCRIPTION
This might not be the nicest way to fix the utf-8 issues, but it is probably the least invasive and it does the job.
