### PR TITLE
[RFC] Fixes for two compiler warnings

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -145,7 +145,7 @@ String vim_command_output(String str, Error *err)
 Object vim_eval(String str, Error *err)
   FUNC_ATTR_DEFERRED
 {
-  Object rv;
+  Object rv = OBJECT_INIT;
   // Evaluate the expression
   try_start();
   typval_T *expr_result = eval_expr((char_u *) str.data, NULL);

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -42,8 +42,6 @@ int os_chdir(const char *path)
 int os_dirname(char_u *buf, size_t len)
   FUNC_ATTR_NONNULL_ALL
 {
-  assert(buf && len);
-
   int error_number;
   if ((error_number = uv_cwd((char *)buf, &len)) != kLibuvSuccess) {
     STRLCPY(buf, uv_strerror(error_number), len);


### PR DESCRIPTION
This removes an unnecessary assert and initializes a returned Object variable.
