### PR TITLE
[RFC] Fix a couple warnings in the release build.

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -338,12 +338,12 @@ static void job_err(RStream *rstream, void *data, bool eof)
 {
   size_t count;
   char buf[256];
-  Channel *channel = job_data(data);
 
   while ((count = rstream_pending(rstream))) {
     size_t read = rstream_read(rstream, buf, sizeof(buf) - 1);
     buf[read] = NUL;
-    ELOG("Channel %" PRIu64 " stderr: %s", channel->id, buf);
+    ELOG("Channel %" PRIu64 " stderr: %s",
+         ((Channel *)job_data(data))->id, buf);
   }
 }
 

--- a/src/nvim/os/wstream.c
+++ b/src/nvim/os/wstream.c
@@ -116,9 +116,8 @@ void wstream_set_stream(WStream *wstream, uv_stream_t *stream)
 /// @param file The file descriptor
 void wstream_set_file(WStream *wstream, uv_file file)
 {
-  uv_handle_type type = uv_guess_handle(file);
-
-  assert(type == UV_NAMED_PIPE || type == UV_TTY);
+  assert(uv_guess_handle(file) == UV_NAMED_PIPE ||
+         uv_guess_handle(file) == UV_TTY);
   wstream->stream = xmalloc(sizeof(uv_pipe_t));
   uv_pipe_init(uv_default_loop(), (uv_pipe_t *)wstream->stream, 0);
   uv_pipe_open((uv_pipe_t *)wstream->stream, file);


### PR DESCRIPTION
I'd be very interested in people's opinion of what to do for the fix in wstream.c.  I took one approach, but I'm happy to take another if anyone has a better idea (or a preference).

I'd like to get master building with no warnings for the release build, so that we can add another build to the Travis build matrix and check that we are clean in the presence of optimizations.  I had started this in #1071, but I'm going to close that and split the work more.  Plus, the build system has changed considerably (at least from the Travis perspective).
