### PR TITLE
[RDY] Improve functional test debuggability and efficiency

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -17,9 +17,17 @@ if(BUSTED_OUTPUT_TYPE STREQUAL junit)
   set(EXTRA_ARGS OUTPUT_FILE ${BUILD_DIR}/${TEST_TYPE}test-junit.xml)
 endif()
 
+if(DEFINED ENV{TEST_TAG})
+  set(TEST_TAG "--tags=$ENV{TEST_TAG}")
+endif()
+
+if(DEFINED ENV{TEST_FILTER})
+  set(TEST_TAG "--filter=$ENV{TEST_FILTER}")
+endif()
+
 execute_process(
-  COMMAND ${BUSTED_PRG} -v -o ${BUSTED_OUTPUT_TYPE}
-    --helper=${TEST_DIR}/${TEST_TYPE}/preload.lua
+  COMMAND ${BUSTED_PRG} ${TEST_TAG} ${TEST_FILTER} -v -o ${BUSTED_OUTPUT_TYPE}
+    --lazy --helper=${TEST_DIR}/${TEST_TYPE}/preload.lua
     --lpath=${BUILD_DIR}/?.lua ${TEST_PATH}
   WORKING_DIRECTORY ${WORKING_DIR}
   ERROR_VARIABLE err

--- a/test/functional/autocmd/tabnew_spec.lua
+++ b/test/functional/autocmd/tabnew_spec.lua
@@ -4,8 +4,8 @@ local clear, nvim, buffer, curbuf, curwin, eq, neq, ok =
   helpers.eq, helpers.neq, helpers.ok
 
 describe('TabNew', function()
+    setup(clear)
     describe('au TabNew', function()
-        clear()
         describe('with * as <afile>', function()
             it('matches when opening any new tab', function()
                 nvim('command', 'au! TabNew * echom "tabnew:".tabpagenr().":".bufnr("")')

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -276,8 +276,6 @@ local function expect(contents)
   return eq(dedent(contents), curbuf_contents())
 end
 
-clear()
-
 return {
   clear = clear,
   spawn = spawn,

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -162,15 +162,20 @@ local function rawfeed(...)
   end
 end
 
+local function spawn(argv)
+  local loop = Loop.new()
+  local msgpack_stream = MsgpackStream.new(loop)
+  local async_session = AsyncSession.new(msgpack_stream)
+  local session = Session.new(async_session)
+  loop:spawn(argv)
+  return session
+end
+
 local function clear()
   if session then
     session:exit(0)
   end
-  local loop = Loop.new()
-  local msgpack_stream = MsgpackStream.new(loop)
-  local async_session = AsyncSession.new(msgpack_stream)
-  session = Session.new(async_session)
-  loop:spawn(nvim_argv)
+  session = spawn(nvim_argv)
 end
 
 local function insert(...)
@@ -275,6 +280,7 @@ clear()
 
 return {
   clear = clear,
+  spawn = spawn,
   dedent = dedent,
   source = source,
   rawfeed = rawfeed,
@@ -292,6 +298,7 @@ return {
   expect = expect,
   ok = ok,
   nvim = nvim,
+  nvim_prog = nvim_prog,
   nvim_dir = nvim_dir,
   buffer = buffer,
   window = window,

--- a/test/functional/job/job_spec.lua
+++ b/test/functional/job/job_spec.lua
@@ -6,10 +6,14 @@ local clear, nvim, eq, neq, ok, expect, eval, next_message, run, stop, session
   helpers.stop, helpers.session
 local nvim_dir, insert = helpers.nvim_dir, helpers.insert
 
-local channel = nvim('get_api_info')[1]
 
 describe('jobs', function()
-  before_each(clear)
+  local channel
+
+  before_each(function()
+    clear()
+    channel = nvim('get_api_info')[1]
+  end)
 
   -- Creates the string to make an autocmd to notify us.
   local notify_str = function(expr1, expr2)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -123,15 +123,25 @@ if os.getenv('CI_TARGET') then
   default_screen_timeout = default_screen_timeout * 3
 end
 
-local colors = request('vim_get_color_map')
-local colornames = {}
-for name, rgb in pairs(colors) do
+do
+  local spawn, nvim_prog = helpers.spawn, helpers.nvim_prog
+  local session = spawn({nvim_prog, '-u', 'NONE', '-N', '--embed'})
+  local status, rv = session:request('vim_get_color_map')
+  if not status then
+    print('failed to get color map')
+    os.exit(1)
+  end
+  local colors = rv
+  local colornames = {}
+  for name, rgb in pairs(colors) do
     -- we disregard the case that colornames might not be unique, as
     -- this is just a helper to get any canonical name of a color
     colornames[rgb] = name
+  end
+  session:exit(0)
+  Screen.colors = colors
+  Screen.colornames = colornames
 end
-
-Screen.colors = colors
 
 function Screen.debug(command)
   if not command then
@@ -497,8 +507,8 @@ function pprint_attrs(attrs)
     for f, v in pairs(attrs) do
       local desc = tostring(v)
       if f == "foreground" or f == "background" then
-        if colornames[v] ~= nil then
-          desc = "Screen.colors."..colornames[v]
+        if Screen.colornames[v] ~= nil then
+          desc = "Screen.colors."..Screen.colornames[v]
         end
       end
       table.insert(items, f.." = "..desc)

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -36,11 +36,11 @@ add_custom_command(OUTPUT ${DEPS_LIB_DIR}/luarocks/rocks/stable-busted-deps
   COMMAND ${DEPS_BIN_DIR}/luarocks
   ARGS build dkjson 2.5-1 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
   COMMAND ${DEPS_BIN_DIR}/luarocks
-  ARGS build say 1.2-1 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
+  ARGS build say 1.3-0 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
   COMMAND ${DEPS_BIN_DIR}/luarocks
-  ARGS build luassert 1.7.2-0 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
+  ARGS build luassert 1.7.4-0 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
   COMMAND ${DEPS_BIN_DIR}/luarocks
-  ARGS build ansicolors 1.0.2-3 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
+  ARGS build lua-term 0.1-1 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
   COMMAND ${DEPS_BIN_DIR}/luarocks
   ARGS build penlight 1.0.0-1 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
   COMMAND ${DEPS_BIN_DIR}/luarocks
@@ -56,7 +56,7 @@ add_custom_target(stable-busted-deps
 
 add_custom_command(OUTPUT ${DEPS_BIN_DIR}/busted
   COMMAND ${DEPS_BIN_DIR}/luarocks
-  ARGS build busted 2.0.rc4 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
+  ARGS build https://raw.githubusercontent.com/Olivine-Labs/busted/master/busted-scm-0.rockspec CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
   COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/utfTerminalDetailed.lua
   ${DEPS_INSTALL_DIR}/share/lua/5.1/busted/outputHandlers
   DEPENDS stable-busted-deps)

--- a/third-party/utfTerminalDetailed.lua
+++ b/third-party/utfTerminalDetailed.lua
@@ -1,13 +1,18 @@
 -- busted output handler that immediately prints file and test names before
 -- tests are executed. It simplifies identifying which tests are
 -- hanging/crashing
-local ansicolors = require 'ansicolors'
+if package.config:sub(1,1) == '\\' and not os.getenv("ANSICON") then
+  -- Disable colors on Windows.
+  colors = setmetatable({}, {__index = function() return function(s) return s end end})
+else
+  colors = require 'term.colors'
+end
 
 return function(options, busted)
   local handler = require 'busted.outputHandlers.utfTerminal'(options, busted)
 
   handler.fileStart = function(name)
-    io.write('\n' .. ansicolors('%{cyan}' .. name) .. ':')
+    io.write('\n' .. colors.cyan(name) .. ':')
   end
 
   handler.testStart = function(element, parent, status, debug)


### PR DESCRIPTION
- Read TEST_TAG env var from cmake/RunTests.cmake. Setting this environment
  variable will pass --tags with its value to busted, which is used to filter
  which tests will be executed.
- Remove calls to nvim msgpack-rpc API outside tests. This removes the
  requirement of having a static `clear` call in test/functional/helpers.lua
- Replace all `setup` calls by the `before_first` function  which is injected on
  the top of each test file that needs to have suite setup. This differs from
  `setup` in that the callback will only be executed if at least one test will
  be ran in the suite, where `setup` always executes the callback regardless of
  test filters.

After this commit its possible to run/debug a single test like this:

``` sh
TEST_TAG=some-tag make test
```

After putting #some-tag into the test title. This also improves debugging
experience because there will be no unnecessary gdbserver instances whe GDB=1 is
passed.
