### PR TITLE
[RDY] contrib: fix YCM completion for header files

### DIFF
--- a/contrib/YouCompleteMe/ycm_extra_conf.py
+++ b/contrib/YouCompleteMe/ycm_extra_conf.py
@@ -29,7 +29,7 @@ def GetCompilationInfoForFile(filename):
         c_file = basename + '.c'
         # for pure headers (no c file), default to main.c
         if not os.path.exists(c_file):
-            c_file = os.path.join(DirectoryOfThisScript(), 'main.c')
+            c_file = os.path.join(DirectoryOfThisScript(), 'nvim', 'main.c')
         if os.path.exists(c_file):
             compilation_info = database.GetCompilationInfoForFile(c_file)
             if compilation_info.compiler_flags_:


### PR DESCRIPTION
Really minor fix to the contrib/ YCM configuration that gives YCM compilation flags for header files without a corresponding `.c` file (`pos.h` for example).
