### PR TITLE
[RDY] Add utfTerminalDetailed busted output handler

### DIFF
--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -53,6 +53,8 @@ add_custom_target(stable-busted-deps
 add_custom_command(OUTPUT ${DEPS_BIN_DIR}/busted
   COMMAND ${DEPS_BIN_DIR}/luarocks
   ARGS build busted 2.0.rc4 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
+  COMMAND cp ${PROJECT_SOURCE_DIR}/utfTerminalDetailed.lua
+  ${DEPS_INSTALL_DIR}/share/lua/5.1/busted/outputHandlers
   DEPENDS stable-busted-deps)
 add_custom_target(busted
   DEPENDS ${DEPS_BIN_DIR}/busted)

--- a/third-party/utfTerminalDetailed.lua
+++ b/third-party/utfTerminalDetailed.lua
@@ -1,0 +1,22 @@
+-- busted output handler that immediately prints file and test names before
+-- tests are executed. It simplifies identifying which tests are
+-- hanging/crashing
+local ansicolors = require 'ansicolors'
+
+return function(options, busted)
+  local handler = require 'busted.outputHandlers.utfTerminal'(options, busted)
+
+  handler.fileStart = function(name)
+    io.write('\n' .. ansicolors('%{cyan}' .. name) .. ':')
+  end
+
+  handler.testStart = function(element, parent, status, debug)
+    io.write('\n  ' .. handler.getFullName(element) .. ' ... ')
+    io.flush()
+  end
+
+  busted.subscribe({ 'file', 'start' }, handler.fileStart)
+  busted.subscribe({ 'test', 'start' }, handler.testStart)
+
+  return handler
+end


### PR DESCRIPTION
This is a variant of the utfTerminal output handler that will:
- Output the file name before each suite is executed
- Output the test name before each test is executed

This will make it simpler to identify crashing/hanging tests.
