### PR TITLE
[RFC] Minor cleanups

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7287,8 +7287,7 @@ static void f_browse(typval_T *argvars, typval_T *rettv)
  */
 static void f_browsedir(typval_T *argvars, typval_T *rettv)
 {
-  rettv->vval.v_string = NULL;
-  rettv->v_type = VAR_STRING;
+  f_browse(argvars, rettv);
 }
 
 

--- a/src/nvim/farsi.c
+++ b/src/nvim/farsi.c
@@ -1561,9 +1561,6 @@ int fkmap(int c)
         if (!curwin->w_cursor.col) {
           return ALEF_U_H;
         }
-      }
-
-      if (!p_ri) {
         dec_cursor();
       }
 
@@ -1595,9 +1592,6 @@ int fkmap(int c)
         if (!curwin->w_cursor.col) {
           return ALEF;
         }
-      }
-
-      if (!p_ri) {
         dec_cursor();
       }
 
@@ -1673,9 +1667,6 @@ int fkmap(int c)
         if (!curwin->w_cursor.col) {
           return TEE;
         }
-      }
-
-      if (!p_ri) {
         dec_cursor();
       }
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1729,14 +1729,14 @@ failed:
     }
   }
 
-  if (set_options)
-    save_file_ff(curbuf);               /* remember the current file format */
-
-  /* If editing a new file: set 'fenc' for the current buffer.
-   * Also for ":read ++edit file". */
-  if (set_options)
+  if (set_options) {
+    // Remember the current file format.
+    save_file_ff(curbuf);
+    // If editing a new file: set 'fenc' for the current buffer.
+    // Also for ":read ++edit file". 
     set_string_option_direct((char_u *)"fenc", -1, fenc,
-        OPT_FREE|OPT_LOCAL, 0);
+        OPT_FREE | OPT_LOCAL, 0);
+  }
   if (fenc_alloced)
     free(fenc);
 # ifdef USE_ICONV

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1277,7 +1277,6 @@ recover_names (
   int num_files;
   int file_count = 0;
   char_u      **files;
-  int i;
   char_u      *dirp;
   char_u      *dir_name;
   char_u      *fname_res = NULL;
@@ -1357,12 +1356,13 @@ recover_names (
       }
     }
 
-    /* check for out-of-memory */
-    for (i = 0; i < num_names; ++i) {
+    // check for out-of-memory
+    for (int i = 0; i < num_names; ++i) {
       if (names[i] == NULL) {
-        for (i = 0; i < num_names; ++i)
-          free(names[i]);
+        for (int j = 0; j < num_names; ++j)
+          free(names[j]);
         num_names = 0;
+        break;
       }
     }
     if (num_names == 0)
@@ -1394,7 +1394,7 @@ recover_names (
      */
     if (curbuf->b_ml.ml_mfp != NULL
         && (p = curbuf->b_ml.ml_mfp->mf_fname) != NULL) {
-      for (i = 0; i < num_files; ++i)
+      for (int i = 0; i < num_files; ++i)
         if (path_full_compare(p, files[i], TRUE) & kEqualFiles) {
           /* Remove the name from files[i].  Move further entries
            * down.  When the array becomes empty free it here, since
@@ -1427,7 +1427,7 @@ recover_names (
       }
 
       if (num_files) {
-        for (i = 0; i < num_files; ++i) {
+        for (int i = 0; i < num_files; ++i) {
           /* print the swap file name */
           msg_outnum((long)++file_count);
           MSG_PUTS(".    ");
@@ -1441,7 +1441,7 @@ recover_names (
     } else
       file_count += num_files;
 
-    for (i = 0; i < num_names; ++i)
+    for (int i = 0; i < num_names; ++i)
       free(names[i]);
     if (num_files > 0)
       FreeWild(num_files, files);

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1474,7 +1474,6 @@ void ex_menutranslate(exarg_T *eap)
         tp->to = to;
       } else {
         free(from);
-        free(from_noamp);
         free(to);
       }
     }

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -5322,7 +5322,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
         if (ireg_icombine && len == 0) {
           /* If \Z was present, then ignore composing characters.
            * When ignoring the base character this always matches. */
-          if (len == 0 && sta->c != curc)
+          if (sta->c != curc)
             result = FAIL;
           else
             result = OK;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4253,7 +4253,7 @@ search_line:
            * looking for a define).  A line starting with "# define"
            * is not considered to be a comment line.
            */
-          if (!define_matched && skip_comments) {
+          if (skip_comments) {
             if ((*line != '#' ||
                  STRNCMP(skipwhite(line + 1), "define", 6) != 0)
                 && get_leader_len(line, NULL, FALSE, TRUE))

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -223,7 +223,7 @@ do_tag (
   /*
    * Don't add a tag to the tagstack if 'tagstack' has been reset.
    */
-  if ((!p_tgst && *tag != NUL)) {
+  if (!p_tgst && *tag != NUL) {
     use_tagstack = FALSE;
     new_tag = TRUE;
   } else {


### PR DESCRIPTION
Here are a few minor cleanups. Issues were discovered by static analysis (mainly by PVS-Studio).

Summary of changes:
- Remove expressions which always evaluate to TRUE in their context in `regexp_nfa.c` and `search.c` (`len == 0` and `!define_matched`)
- Merge consecutive identical 'if' statements in `farsi.c` and `fileio.c`
- Remove redundant parentheses in `tag.c`
- Fix an out-of-memory cleanup in `memline.c` (`i` was used for both outer and inner loops)
- Remove unnecessary `free()` from `menu.c` (`from_noamp` is always NULL there)
- Call `f_browse()` from  `f_browsedir` (since they are identical)
