### PR TITLE
[RDY] Replace cursor_{on,off} by busy_{stop,start}

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1400,7 +1400,6 @@ void display_dollar(colnr_T col)
   if (!redrawing())
     return;
 
-  ui_cursor_off();
   save_col = curwin->w_cursor.col;
   curwin->w_cursor.col = col;
   if (has_mbyte) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1063,9 +1063,7 @@ do_filter (
 
   /* Create the shell command in allocated memory. */
   cmd_buf = make_filter_cmd(cmd, itmp, otmp);
-
   ui_cursor_goto((int)Rows - 1, 0);
-  ui_cursor_on();
 
   /*
    * When not redirecting the output the command can write anything to the
@@ -1248,7 +1246,6 @@ do_shell (
   // This ui_cursor_goto is required for when the '\n' resulted in a "delete line
   // 1" command to the terminal.
   ui_cursor_goto(msg_row, msg_col);
-  ui_cursor_on();
   (void)call_shell(cmd, flags, NULL);
   did_check_timestamps = FALSE;
   need_check_timestamps = TRUE;
@@ -1963,7 +1960,6 @@ void print_line(linenr_T lnum, int use_number, int list)
   print_line_no_prefix(lnum, use_number, list);
   if (save_silent) {
     msg_putchar('\n');
-    ui_cursor_on();                /* msg_start() switches it off */
     ui_flush();
     silent_mode = save_silent;
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6381,9 +6381,7 @@ static void ex_sleep(exarg_T *eap)
 void do_sleep(long msec)
 {
   long done;
-
-  ui_cursor_on();
-  ui_flush();
+  ui_flush();  // flush before waiting
   for (done = 0; !got_int && done < msec; done += 1000L) {
     os_delay(msec - done > 1000L ? 1000L : msec - done, true);
     os_breakcheck();

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1364,7 +1364,6 @@ cmdline_changed:
       if (ccline.cmdlen == 0)
         i = 0;
       else {
-        ui_cursor_off();                   /* so the user knows we're busy */
         ui_flush();
         ++emsg_off;            /* So it doesn't beep if bad expr */
         /* Set the time limit to half a second. */
@@ -1700,10 +1699,6 @@ getexmodeline (
   int vcol = 0;
   char_u      *p;
   int prev_char;
-
-  /* Switch cursor on now.  This avoids that it happens after the "\n", which
-   * confuses the system function that computes tabstops. */
-  ui_cursor_on();
 
   /* always start in column 0; write a newline if necessary */
   compute_cmdrow();

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2379,11 +2379,6 @@ inchar (
   int retesc = FALSE;               /* return ESC with gotint */
   int script_char;
 
-  if (wait_time == -1L || wait_time > 100L) {  /* flush output before waiting */
-    ui_cursor_on();
-    ui_flush();
-  }
-
   /*
    * Don't reset these when at the hit-return prompt, otherwise an endless
    * recursive loop may result (write error in swapfile, hit-return, timeout

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -641,7 +641,6 @@ main_loop (
         curwin->w_valid &= ~VALID_CROW;
       }
       setcursor();
-      ui_cursor_on();
 
       do_redraw = FALSE;
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -998,7 +998,6 @@ void msg_start(void)
     msg_starthere();
   if (msg_silent == 0) {
     msg_didout = FALSE;                     /* no output on current line yet */
-    ui_cursor_off();
   }
 
   /* when redirecting, may need to start a new line. */

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2364,8 +2364,6 @@ int get_keystroke(void)
 
   mapped_ctrl_c = FALSE;        /* mappings are not used here */
   for (;; ) {
-    ui_cursor_on();
-    ui_flush();
 
     /* Leave some room for check_termcode() to insert a key code into (max
      * 5 chars plus NUL).  And fix_input_buffer() can triple the number of

--- a/src/nvim/misc2.c
+++ b/src/nvim/misc2.c
@@ -297,7 +297,6 @@ int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
     smsg((char_u *)_("Calling shell to execute: \"%s\""),
         cmd == NULL ? p_sh : cmd);
     ui_putc('\n');
-    ui_cursor_on();
     verbose_leave();
   }
 

--- a/src/nvim/msgpack_rpc/remote_ui.c
+++ b/src/nvim/msgpack_rpc/remote_ui.c
@@ -82,8 +82,8 @@ static Object remote_ui_attach(uint64_t channel_id, uint64_t request_id,
   ui->clear = remote_ui_clear;
   ui->eol_clear = remote_ui_eol_clear;
   ui->cursor_goto = remote_ui_cursor_goto;
-  ui->cursor_on = remote_ui_cursor_on;
-  ui->cursor_off = remote_ui_cursor_off;
+  ui->busy_start = remote_ui_busy_start;
+  ui->busy_stop = remote_ui_busy_stop;
   ui->mouse_on = remote_ui_mouse_on;
   ui->mouse_off = remote_ui_mouse_off;
   ui->insert_mode = remote_ui_insert_mode;
@@ -190,16 +190,16 @@ static void remote_ui_cursor_goto(UI *ui, int row, int col)
   push_call(ui, "cursor_goto", args);
 }
 
-static void remote_ui_cursor_on(UI *ui)
+static void remote_ui_busy_start(UI *ui)
 {
   Array args = ARRAY_DICT_INIT;
-  push_call(ui, "cursor_on", args);
+  push_call(ui, "busy_start", args);
 }
 
-static void remote_ui_cursor_off(UI *ui)
+static void remote_ui_busy_stop(UI *ui)
 {
   Array args = ARRAY_DICT_INIT;
-  push_call(ui, "cursor_off", args);
+  push_call(ui, "busy_stop", args);
 }
 
 static void remote_ui_mouse_on(UI *ui)

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -983,7 +983,6 @@ getcount:
       free(kmsg);
     }
     setcursor();
-    ui_cursor_on();
     ui_flush();
     if (msg_scroll || emsg_on_display)
       os_delay(1000L, true);            /* wait at least one second */
@@ -2997,8 +2996,6 @@ void pop_showcmd(void)
 static void display_showcmd(void)
 {
   int len;
-
-  ui_cursor_off();
 
   len = (int)STRLEN(showcmd_buf);
   if (len == 0)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3042,7 +3042,6 @@ theend:
     silent_mode = FALSE;
     info_message = TRUE;        /* use mch_msg(), not mch_errmsg() */
     msg_putchar('\n');
-    ui_cursor_on();                /* msg_start() switches it off */
     ui_flush();
     silent_mode = TRUE;
     info_message = FALSE;       /* use mch_msg(), not mch_errmsg() */

--- a/src/nvim/os/event.h
+++ b/src/nvim/os/event.h
@@ -8,9 +8,15 @@
 #include "nvim/os/job_defs.h"
 #include "nvim/os/time.h"
 
-// Poll for events until a condition is true or a timeout has passed
+void ui_busy_start(void);
+void ui_busy_stop(void);
+
+// Poll for events until a condition or timeout
 #define event_poll_until(timeout, condition)                                 \
   do {                                                                       \
+    if (timeout < 0 || timeout > 100) {                                      \
+      ui_busy_stop();                                                        \
+    }                                                                        \
     int remaining = timeout;                                                 \
     uint64_t before = (remaining > 0) ? os_hrtime() : 0;                     \
     while (!(condition)) {                                                   \
@@ -26,9 +32,13 @@
         }                                                                    \
       }                                                                      \
     }                                                                        \
+    if (timeout < 0 || timeout > 100) {                                      \
+      ui_busy_start();                                                       \
+    }                                                                        \
   } while (0)
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/event.h.generated.h"
 #endif
+
 #endif  // NVIM_OS_EVENT_H

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -99,7 +99,6 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_args)
   char *output = NULL, **output_ptr = NULL;
   int current_state = State;
   bool forward_output = true;
-  ui_flush();
 
   // While the child is running, ignore terminating signals
   signal_reject_deadly();
@@ -239,7 +238,11 @@ static int shell(const char *cmd,
     job_close_in(job);
   }
 
+  // invoke busy_start here so event_poll_until wont change the busy state for
+  // the UI
+  ui_busy_start();
   status = job_wait(job, -1);
+  ui_busy_stop();
 
   // prepare the out parameters if requested
   if (output) {

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -232,15 +232,7 @@ void mch_exit(int r)
 {
   exiting = TRUE;
 
-  {
-    ui_builtin_stop();
-
-    // Cursor may have been switched off without calling starttermcap()
-    // when doing "vim -u vimrc" and vimrc contains ":q". */
-    if (full_screen) {
-      ui_cursor_on();
-    }
-  }
+  ui_builtin_stop();
   ui_flush();
   ml_close_all(TRUE);           /* remove all memfiles */
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -416,7 +416,6 @@ void update_screen(int type)
   search_hl.rm.regprog = NULL;
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_redr_type != 0) {
-      ui_cursor_off();
       if (!did_one) {
         did_one = TRUE;
         start_search_hl();
@@ -426,7 +425,6 @@ void update_screen(int type)
 
     /* redraw status line after the window to minimize cursor movement */
     if (wp->w_redr_status) {
-      ui_cursor_off();
       win_redr_status(wp);
     }
   }
@@ -521,7 +519,6 @@ void update_single_line(win_T *wp, linenr_T lnum)
  */
 static void update_prepare(void)
 {
-    ui_cursor_off();
     updating_screen = TRUE;
     start_search_hl();
 }
@@ -6566,7 +6563,6 @@ int showmode(void)
 
     /* Position on the last line in the window, column 0 */
     msg_pos_mode();
-    ui_cursor_off();
     attr = hl_attr(HLF_CM);                     /* Highlight mode */
     if (do_mode) {
       MSG_PUTS_ATTR("--", attr);
@@ -7015,7 +7011,6 @@ static void win_redr_ruler(win_T *wp, int always)
              || wp->w_buffer->b_ml.ml_line_count != wp->w_ru_line_count
              || wp->w_topfill != wp->w_ru_topfill
              || empty_line != wp->w_ru_empty) {
-    ui_cursor_off();
 
     int width;
     int row;
@@ -7238,7 +7233,6 @@ void screen_resize(int width, int height)
           setcursor();
       }
     }
-    ui_cursor_on();            /* redrawing may have switched it off */
   }
   ui_flush();
   --busy;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2044,7 +2044,6 @@ showmatch (
       p_siso = 0;                       /* don't use 'sidescrolloff' here */
       showruler(FALSE);
       setcursor();
-      ui_cursor_on();                      /* make sure that the cursor is shown */
       ui_flush();
       /* Restore dollar_vcol(), because setcursor() may call curs_rows()
        * which resets it if the matching position is in a previous line

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -44,7 +44,8 @@ static struct {
   int top, bot, left, right;
 } sr;
 static int current_attr_code = 0;
-static bool cursor_enabled = true, pending_cursor_update = false;
+static bool pending_cursor_update = false;
+static int busy = 1;
 static int height, width;
 
 // This set of macros allow us to use UI_CALL to invoke any function on
@@ -150,23 +151,22 @@ void ui_resize(int new_width, int new_height)
   UI_CALL(resize, width, height);
 }
 
-void ui_cursor_on(void)
+void ui_busy_start(void)
 {
-  if (!cursor_enabled) {
-    UI_CALL(cursor_on);
-    cursor_enabled = true;
+  if (!(busy++)) {
+    UI_CALL(busy_start);
   }
+  ui_flush();
 }
 
-void ui_cursor_off(void)
+void ui_busy_stop(void)
 {
-  if (full_screen) {
-    if (cursor_enabled) {
-      UI_CALL(cursor_off);
-    }
-    cursor_enabled = false;
+  if (!(--busy)) {
+    UI_CALL(busy_stop);
   }
+  ui_flush();
 }
+
 
 void ui_mouse_on(void)
 {

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -20,8 +20,8 @@ struct ui_t {
   void (*clear)(UI *ui);
   void (*eol_clear)(UI *ui);
   void (*cursor_goto)(UI *ui, int row, int col);
-  void (*cursor_on)(UI *ui);
-  void (*cursor_off)(UI *ui);
+  void (*busy_start)(UI *ui);
+  void (*busy_stop)(UI *ui);
   void (*mouse_on)(UI *ui);
   void (*mouse_off)(UI *ui);
   void (*insert_mode)(UI *ui);

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -164,8 +164,9 @@ function Screen.new(width, height)
     _mouse_enabled = true,
     _attrs = {},
     _cursor = {
-      enabled = true, row = 1, col = 1
-    }
+      row = 1, col = 1
+    },
+    _busy = true
   }, Screen)
   self:_handle_resize(width, height)
   return self
@@ -282,12 +283,12 @@ function Screen:_handle_cursor_goto(row, col)
   self._cursor.col = col + 1
 end
 
-function Screen:_handle_cursor_on()
-  self._cursor.enabled = true
+function Screen:_handle_busy_start()
+  self._busy = true
 end
 
-function Screen:_handle_cursor_off()
-  self._cursor.enabled = false
+function Screen:_handle_busy_stop()
+  self._busy = false
 end
 
 function Screen:_handle_mouse_on()

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -53,7 +53,7 @@ add_custom_target(stable-busted-deps
 add_custom_command(OUTPUT ${DEPS_BIN_DIR}/busted
   COMMAND ${DEPS_BIN_DIR}/luarocks
   ARGS build busted 2.0.rc4 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
-  COMMAND cp ${PROJECT_SOURCE_DIR}/utfTerminalDetailed.lua
+  COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/utfTerminalDetailed.lua
   ${DEPS_INSTALL_DIR}/share/lua/5.1/busted/outputHandlers
   DEPENDS stable-busted-deps)
 add_custom_target(busted


### PR DESCRIPTION
Switching cursor off is only necessary in two occasions:
- When redrawing to avoid terminal flickering
- When the editor is busy

The first can now be handled by the TUI, so most calls to ui_cursor_off can be
removed from the core.

So, before this commit it was only necessary to switch the cursor off to notify
the user that nvim was running some long operation. Now the cursor_{on,off}
functions have been replaced by busy_{stop,start} which can be handled in a
UI-specific way(turning the cursor off or showing a busy indicator, for
example).

To make things even more simpler, nvim is always busy except when waiting for
user input or other asynchronous events: It automatically switches to a non-busy
state when the event loop is about to be entered for more than 100 milliseconds.

`ui_busy_start` can be called when its not desired to change the busy state in
the event loop (As its now done by functions that perform blocking shell
invocations).
