### PR TITLE
[RDY] Small changes to ui_busy functions and testing

### DIFF
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2364,7 +2364,7 @@ int get_keystroke(void)
 
   mapped_ctrl_c = FALSE;        /* mappings are not used here */
   for (;; ) {
-
+    ui_flush();
     /* Leave some room for check_termcode() to insert a key code into (max
      * 5 chars plus NUL).  And fix_input_buffer() can triple the number of
      * bytes. */

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -155,16 +155,16 @@ void ui_busy_start(void)
 {
   if (!(busy++)) {
     UI_CALL(busy_start);
+    ui_flush();
   }
-  ui_flush();
 }
 
 void ui_busy_stop(void)
 {
   if (!(--busy)) {
     UI_CALL(busy_stop);
+    ui_flush();
   }
-  ui_flush();
 }
 
 

--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -93,7 +93,7 @@ describe('system()', function()
         ~                                                    |
         ~                                                    |
         ~                                                    |
-        ^:call system("yes")                                  |
+        :call system("yes")                                  |
       ]])
       feed('<c-c>')
       screen:expect([[
@@ -259,7 +259,7 @@ describe('systemlist()', function()
         ~                                                    |
         ~                                                    |
         ~                                                    |
-        ^:call systemlist("yes | xargs")                      |
+        :call systemlist("yes | xargs")                      |
       ]])
       feed('<c-c>')
       screen:expect([[

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -417,7 +417,7 @@ function Screen:_row_repr(row, attr_ids, attr_ignore)
       table.insert(rv, '{' .. attr_id .. ':')
       current_attr_id = attr_id
     end
-    if self._rows[self._cursor.row] == row and self._cursor.col == i then
+    if not self._busy and self._rows[self._cursor.row] == row and self._cursor.col == i then
       table.insert(rv, '^')
     end
     table.insert(rv, row[i].text)


### PR DESCRIPTION
- Only call `ui_flush` when necessary(when the busy state changes or in `get_keystroke` to display the prompt)
- Allow the busy state to be tested by hiding the cursor marker when nvim is busy
