### PR TITLE
[RFC] vim-patch:7.4.503

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2049,7 +2049,7 @@ winrestcmd()			String	returns command to restore window sizes
 winrestview( {dict})		none	restore view of current window
 winsaveview()			Dict	save view of current window
 winwidth( {nr})			Number	width of window {nr}
-writefile( {list}, {fname} [, {binary}])
+writefile( {list}, {fname} [, {flags}])
 				Number	write list of lines to file {fname}
 xor( {expr}, {expr})		Number  bitwise XOR
 
@@ -6593,13 +6593,19 @@ winwidth({nr})						*winwidth()*
   :endif
 <
 							*writefile()*
-writefile({list}, {fname} [, {binary}])
+writefile({list}, {fname} [, {flags}])
 		Write |List| {list} to file {fname}.  Each list item is
 		separated with a NL.  Each list item must be a String or
 		Number.
-		When {binary} is equal to "b" binary mode is used: There will
+		When {flags} contains "b" then binary mode is used: There will
 		not be a NL after the last list item.  An empty item at the
 		end does cause the last line in the file to end in a NL.
+
+		When {flags} contains "a" then append mode is used, lines are
+		appended to the file: >
+			:call writefile(["foo"], "event.log", "a")
+			:call writefile(["bar"], "event.log", "a")
+
 		All NL characters are replaced with a NUL character.
 		Inserting CR characters needs to be done before passing {list}
 		to writefile().

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -15453,16 +15453,22 @@ static void f_writefile(typval_T *argvars, typval_T *rettv)
   }
 
   bool binary = false;
-  if (argvars[2].v_type != VAR_UNKNOWN
-      && STRCMP(get_tv_string(&argvars[2]), "b") == 0) {
-    binary = true;
+  bool append = false;
+  if (argvars[2].v_type != VAR_UNKNOWN) {
+    if (vim_strchr(get_tv_string(&argvars[2]), 'b')) {
+      binary = true;
+    }
+    if (vim_strchr(get_tv_string(&argvars[2]), 'a')) {
+      append = true;
+    }
   }
 
   // Always open the file in binary mode, library functions have a mind of
   // their own about CR-LF conversion.
   char_u *fname = get_tv_string(&argvars[1]);
   FILE *fd;
-  if (*fname == NUL || (fd = mch_fopen((char *)fname, WRITEBIN)) == NULL) {
+  if (*fname == NUL || (fd = mch_fopen((char *)fname,
+       append ? APPENDBIN : WRITEBIN)) == NULL) {
     EMSG2(_(e_notcreate), *fname == NUL ? (char_u *)_("<empty>") : fname);
     rettv->vval.v_number = -1;
   } else {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -337,7 +337,7 @@ static int included_patches[] = {
   //506 NA
   //505 NA
   //504 NA
-  //503,
+  503,
   //502,
   //501 NA
   500,

--- a/test/functional/legacy/writefile_spec.lua
+++ b/test/functional/legacy/writefile_spec.lua
@@ -1,0 +1,30 @@
+-- Tests for writefile()
+
+local helpers = require('test.functional.helpers')
+local feed, insert, source = helpers.feed, helpers.insert, helpers.source
+local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
+
+describe('writefile', function()
+  setup(clear)
+
+  it('is working', function()
+    execute('%delete _')
+    execute('let f = tempname()')
+    execute('call writefile(["over","written"], f, "b")')
+    execute('call writefile(["hello","world"], f, "b")')
+    execute('call writefile(["!", "good"], f, "a")')
+    execute('call writefile(["morning"], f, "ab")')
+    execute('call writefile(["", "vimmers"], f, "ab")')
+    execute('bwipeout!')
+    execute('$put =readfile(f)')
+    execute('1 delete _')
+
+    -- Assert buffer contents.
+    expect([[
+      hello
+      world!
+      good
+      morning
+      vimmers]])
+  end)
+end)


### PR DESCRIPTION
Problem:    Cannot append a list of lines to a file.
Solution:   Add the append option to writefile(). (Yasuhiro Matsumoto)

https://code.google.com/p/vim/source/detail?r=v7-4-503

Tested with: make oldtest, make test on OS X.

Signed-off-by: Perry Hung iperry@gmail.com
