### PR TITLE
Remove BINARY_FILE_IO option

### DIFF
--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -97,15 +97,9 @@
  */
 #define vim_isbreak(c) (breakat_flags[(char_u)(c)])
 
-#ifdef BINARY_FILE_IO
-# define WRITEBIN   "wb"        /* no CR-LF translation */
-# define READBIN    "rb"
-# define APPENDBIN  "ab"
-#else
-# define WRITEBIN   "w"
-# define READBIN    "r"
-# define APPENDBIN  "a"
-#endif
+#define WRITEBIN   "wb"        /* no CR-LF translation */
+#define READBIN    "rb"
+#define APPENDBIN  "ab"
 
 #  define mch_fopen(n, p)       fopen((n), (p))
 


### PR DESCRIPTION
The 'binary' mode flag is ignored on all POSIX conforming systems (man 3
fopen). For all the others, BINARY_FILE_IO needs to be set.

Always set BINARY_FILE_IO.

Signed-off-by: Perry Hung iperry@gmail.com
