### PR TITLE
[RFC] legacy test script: string wrapping improvement

### DIFF
--- a/scripts/legacy2luatest.pl
+++ b/scripts/legacy2luatest.pl
@@ -54,9 +54,9 @@ sub read_in_file {
     if (@{$input_lines}) {
       my $last_input_line = pop @{$input_lines};
       unshift @{$command_lines}, '';
-      unshift @{$command_lines}, $last_input_line . ']])';
+      unshift @{$command_lines}, $last_input_line . ']=])';
       unshift @{$command_lines}, @{$input_lines};
-      unshift @{$command_lines}, "insert([[";
+      unshift @{$command_lines}, "insert([=[";
 
       @{$input_lines} = ();
     }
@@ -133,8 +133,15 @@ sub read_in_file {
         # If line contains single quotes or backslashes, use double
         # square brackets to wrap string.
         if (/'/ || /\\/) {
-          $startstr = '[[';
-          $endstr = ']]';
+            # If line contains ending square bracket, use square brackets
+            # with an equal sign to wrap string.
+            if (/\]/) {
+              $startstr = '[=[';
+              $endstr = ']=]';
+            } else {
+              $startstr = '[[';
+              $endstr = ']]';
+            }
         }
 
         # Emit 'feed' if not a search ('/') or ex (':') command.
@@ -190,7 +197,7 @@ sub read_ok_file {
   if (-f $ok_file) {
     push @assertions, '';
     push @assertions, "-- Assert buffer contents.";
-    push @assertions, "expect([[";
+    push @assertions, "expect([=[";
 
     open my $ok_file_handle, '<', $ok_file;
 
@@ -202,7 +209,7 @@ sub read_ok_file {
 
     close $ok_file_handle;
 
-    $assertions[-1] .= "]])";
+    $assertions[-1] .= "]=])";
   }
 
   return \@assertions;

--- a/scripts/legacy2luatest.pl
+++ b/scripts/legacy2luatest.pl
@@ -133,8 +133,8 @@ sub read_in_file {
         # If line contains single quotes or backslashes, use double
         # square brackets to wrap string.
         if (/'/ || /\\/) {
-            # If line contains ending square bracket, use square brackets
-            # with an equal sign to wrap string.
+            # If the line contains a closing square bracket,
+            # wrap it with [=[...]=].
             if (/\]/) {
               $startstr = '[=[';
               $endstr = ']=]';


### PR DESCRIPTION
I added an extra check to see if a string contains `]` and then wrap it using `[=[...]=]` instead. Only using square brackets would sometimes break, for example with `[[a = b['hello']]]`. This can be useful when migrating the larger legacy tests that contain python code.

I also changed insert() and expect() to use `[=[...]=]`.
