### PR TITLE
[RDY] Improve ui/busy handling and early input reading

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1364,6 +1364,7 @@ cmdline_changed:
       if (ccline.cmdlen == 0)
         i = 0;
       else {
+        ui_busy_start();
         ui_flush();
         ++emsg_off;            /* So it doesn't beep if bad expr */
         /* Set the time limit to half a second. */
@@ -1381,6 +1382,7 @@ cmdline_changed:
         } else if (char_avail())
           /* cancelled searching because a char was typed */
           incsearch_postponed = TRUE;
+        ui_busy_stop();
       }
       if (i != 0)
         highlight_match = TRUE;                 /* highlight position */

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2379,6 +2379,11 @@ inchar (
   int retesc = FALSE;               /* return ESC with gotint */
   int script_char;
 
+  if (wait_time == -1L || wait_time > 100L) {
+    // flush output before waiting
+    ui_flush();
+  }
+
   /*
    * Don't reset these when at the hit-return prompt, otherwise an endless
    * recursive loop may result (write error in swapfile, hit-return, timeout

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2364,6 +2364,7 @@ int get_keystroke(void)
 
   mapped_ctrl_c = FALSE;        /* mappings are not used here */
   for (;; ) {
+    // flush output before waiting
     ui_flush();
     /* Leave some room for check_termcode() to insert a key code into (max
      * 5 chars plus NUL).  And fix_input_buffer() can triple the number of

--- a/src/nvim/os/event.h
+++ b/src/nvim/os/event.h
@@ -8,15 +8,9 @@
 #include "nvim/os/job_defs.h"
 #include "nvim/os/time.h"
 
-void ui_busy_start(void);
-void ui_busy_stop(void);
-
 // Poll for events until a condition or timeout
 #define event_poll_until(timeout, condition)                                 \
   do {                                                                       \
-    if (timeout < 0 || timeout > 100) {                                      \
-      ui_busy_stop();                                                        \
-    }                                                                        \
     int remaining = timeout;                                                 \
     uint64_t before = (remaining > 0) ? os_hrtime() : 0;                     \
     while (!(condition)) {                                                   \
@@ -31,9 +25,6 @@ void ui_busy_stop(void);
           break;                                                             \
         }                                                                    \
       }                                                                      \
-    }                                                                        \
-    if (timeout < 0 || timeout > 100) {                                      \
-      ui_busy_start();                                                       \
     }                                                                        \
   } while (0)
 

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -46,7 +46,7 @@ void input_init(void)
   input_buffer = rbuffer_new(INPUT_BUFFER_SIZE + MAX_KEY_CODE_LEN);
 }
 
-void input_start_stdin(void)
+void input_start_stdin(int fd)
 {
   if (read_stream) {
     return;
@@ -54,7 +54,7 @@ void input_start_stdin(void)
 
   read_buffer = rbuffer_new(READ_BUFFER_SIZE);
   read_stream = rstream_new(read_cb, read_buffer, NULL);
-  rstream_set_file(read_stream, fileno(stdin));
+  rstream_set_file(read_stream, fd);
   rstream_start(read_stream);
 }
 
@@ -69,7 +69,7 @@ void input_stop_stdin(void)
   read_stream = NULL;
 }
 
-// Low level input function.
+// Low level input function
 int os_inchar(uint8_t *buf, int maxlen, int ms, int tb_change_cnt)
 {
   if (rbuffer_pending(input_buffer)) {

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -241,6 +241,7 @@ static int shell(const char *cmd,
   // invoke busy_start here so event_poll_until wont change the busy state for
   // the UI
   ui_busy_start();
+  ui_flush();
   status = job_wait(job, -1);
   ui_busy_stop();
 

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -45,7 +45,7 @@ static struct {
 } sr;
 static int current_attr_code = 0;
 static bool pending_cursor_update = false;
-static int busy = 1;
+static int busy = 0;
 static int height, width;
 
 // This set of macros allow us to use UI_CALL to invoke any function on
@@ -155,7 +155,6 @@ void ui_busy_start(void)
 {
   if (!(busy++)) {
     UI_CALL(busy_start);
-    ui_flush();
   }
 }
 
@@ -163,10 +162,8 @@ void ui_busy_stop(void)
 {
   if (!(--busy)) {
     UI_CALL(busy_stop);
-    ui_flush();
   }
 }
-
 
 void ui_mouse_on(void)
 {

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -166,7 +166,7 @@ function Screen.new(width, height)
     _cursor = {
       row = 1, col = 1
     },
-    _busy = true
+    _busy = false
   }, Screen)
   self:_handle_resize(width, height)
   return self


### PR DESCRIPTION
@oni-link this changes the behavior of assuming busy state by default. I did this because there was some cursor flashing despite all optimizations. Also made a small change in tui.c to allow sending the the cursor_normal command in the same `write` call
