### PR TITLE
[RFC] tests: update legacy Makefile

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -9,35 +9,28 @@ SCRIPTSOURCE := ../../../runtime
 
 SCRIPTS := test_autoformat_join.out                                    \
            test_eval.out                                               \
-                       test2.out   test3.out   test4.out   test5.out   \
-           test6.out   test7.out   test8.out   test9.out   test10.out  \
-           test11.out  test12.out  test13.out  test14.out  test15.out  \
-                       test17.out  test18.out  test19.out  test20.out  \
-           test21.out  test22.out  test23.out  test24.out  test25.out  \
-           test26.out  test27.out  test28.out  test29.out  test30.out  \
-           test31.out  test32.out  test33.out  test34.out  test35.out  \
+                                   test3.out                           \
+                                   test8.out               test10.out  \
+           test11.out  test12.out  test13.out  test14.out              \
+                       test17.out                                      \
+                                               test24.out              \
+           test26.out  test27.out              test29.out  test30.out  \
+           test31.out  test32.out              test34.out              \
            test36.out  test37.out  test38.out  test39.out  test40.out  \
-           test41.out  test42.out  test43.out  test44.out  test45.out  \
+                       test42.out  test43.out  test44.out  test45.out  \
            test46.out  test47.out  test48.out  test49.out              \
-           test51.out  test52.out  test53.out  test54.out  test55.out  \
-           test56.out  test57.out  test58.out  test59.out  test60.out  \
+                       test52.out  test53.out              test55.out  \
+                       test57.out  test58.out  test59.out  test60.out  \
            test61.out  test62.out  test63.out  test64.out  test65.out  \
-           test66.out  test67.out  test68.out  test69.out  test70.out  \
-           test71.out  test72.out  test73.out  test74.out  test75.out  \
-           test76.out  test77.out  test78.out  test79.out  test80.out  \
-           test81.out  test82.out  test83.out  test84.out  test85.out  \
-           test86.out  test87.out  test88.out  test89.out  test90.out  \
-           test91.out  test92.out  test93.out  test94.out  test95.out  \
-           test96.out  test97.out  test98.out  test99.out  test100.out \
-           test101.out test102.out test103.out test104.out test105.out \
-           test106.out test107.out                                     \
-           test_options.out                                            \
-           test_listlbr.out test_listlbr_utf8.out                      \
-           test_changelist.out                                         \
-           test_qf_title.out                                           \
-           test_breakindent.out                                        \
-           test_insertcount.out                                        \
-           test_utf8.out
+                                   test68.out  test69.out  test70.out  \
+           test71.out              test73.out  test74.out              \
+           test76.out              test78.out  test79.out  test80.out  \
+                       test82.out  test83.out              test85.out  \
+           test86.out  test87.out  test88.out                          \
+                       test92.out  test93.out  test94.out              \
+           test96.out                          test99.out              \
+           test_listlbr.out                                            \
+           test_breakindent.out
 
 SCRIPTS_GUI := test16.out
 


### PR DESCRIPTION
Many tests were migrated, but entries were left in the old Makefile.
