### PR TITLE
oldtest: remove old tests

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -35,9 +35,7 @@ SCRIPTS := test_autoformat_join.out                                    \
            test_listlbr.out test_listlbr_utf8.out                      \
            test_changelist.out                                         \
            test_qf_title.out                                           \
-           test_breakindent.out                                        \
-           test_insertcount.out                                        \
-           test_utf8.out
+           test_breakindent.out
 
 SCRIPTS_GUI := test16.out
 


### PR DESCRIPTION
test_insertcount and test_utf8 have already been ported to the new Lua
test framework.

See: 79cd4a98ecc100694e2e35df7ec05971bd720830,
    683b75d052038e33a6e7129d754ee9b7827071bf,
    #2188  #2178

Signed-off-by: Perry Hung iperry@gmail.com
