### PR TITLE
[RFC][vim-dev] first conceal cchar is missing if it is the first syntax group shown

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -319,7 +319,7 @@ static char msg_no_items[] = N_("No Syntax items defined for this buffer");
 #define ID_LIST_ALL     (short *)-1 /* valid of si_cont_list for containing all
                                        but contained groups */
 
-static int next_seqnr = 0;              /* value to use for si_seqnr */
+static int next_seqnr = 1;              /* value to use for si_seqnr */
 
 /*
  * The next possible match in the current line for any pattern is remembered,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -178,6 +178,17 @@ static char *(features[]) = {
 
 // clang-format off
 static int included_patches[] = {
+  673,
+  //672,
+  //671,
+  //670,
+  //669,
+  //668,
+  //667,
+  //666,
+  //665,
+  //664,
+  //663,
   //662,
   //661,
   660,


### PR DESCRIPTION
This fixes a drawing error uncovered by @McKizzle's conceal tests in #2055 (see last comments) . Awaiting vim-dev response [here](https://groups.google.com/forum/#!topic/vim_dev/T1eovrlffNA)
