### PR TITLE
[RFC] build: add support for running the tests in junit format

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -13,13 +13,18 @@ else()
   set(TEST_PATH "${TEST_DIR}/${TEST_TYPE}")
 endif()
 
+if(BUSTED_OUTPUT_TYPE STREQUAL junit)
+  set(EXTRA_ARGS OUTPUT_FILE ${BUILD_DIR}/${TEST_TYPE}test-junit.xml)
+endif()
+
 execute_process(
   COMMAND ${BUSTED_PRG} -v -o ${BUSTED_OUTPUT_TYPE}
     --helper=${TEST_DIR}/${TEST_TYPE}/preload.lua
     --lpath=${BUILD_DIR}/?.lua ${TEST_PATH}
   WORKING_DIRECTORY ${WORKING_DIR}
   ERROR_VARIABLE err
-  RESULT_VARIABLE res)
+  RESULT_VARIABLE res
+  ${EXTRA_ARGS})
 
 if(NOT res EQUAL 0)
   message(STATUS "Output to stderr:\n${err}")

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -45,6 +45,10 @@ add_custom_command(OUTPUT ${DEPS_LIB_DIR}/luarocks/rocks/stable-busted-deps
   ARGS build penlight 1.0.0-1 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
   COMMAND ${DEPS_BIN_DIR}/luarocks
   ARGS build mediator_lua 1.1-3 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
+  COMMAND ${DEPS_BIN_DIR}/luarocks
+  ARGS build luasocket 3.0rc1-2 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
+  COMMAND ${DEPS_BIN_DIR}/luarocks
+  ARGS build xml 1.1.1-1 CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER}
   COMMAND touch ${DEPS_LIB_DIR}/luarocks/rocks/stable-busted-deps
   DEPENDS luarocks)
 add_custom_target(stable-busted-deps


### PR DESCRIPTION
This requires a couple of extra modules that are not installed by
default, and it requires capturing stdout of the tests--otherwise CMake
output is intermixed with the XML output of busted.
