### PR TITLE
[RDY] Fix reading when stdin is not a pty

### DIFF
--- a/src/nvim/os/rstream.c
+++ b/src/nvim/os/rstream.c
@@ -243,8 +243,10 @@ void rstream_set_file(RStream *rstream, uv_file file)
     // previously allocated memory
     if (rstream->fread_idle != NULL) {
       uv_close((uv_handle_t *)rstream->fread_idle, close_cb);
+      rstream->fread_idle = NULL;
     } else {
       uv_close((uv_handle_t *)rstream->stream, close_cb);
+      rstream->stream = NULL;
     }
   }
 
@@ -387,6 +389,7 @@ static void fread_idle_cb(uv_idle_t *handle)
 
   if (req.result <= 0) {
     uv_idle_stop(rstream->fread_idle);
+    rstream->cb(rstream, rstream->data, true);
     return;
   }
 


### PR DESCRIPTION
Instead of selecting stderr on startup if stdin is not a tty, first try reading from it and only switch to stderr when reading fails. This behavior was accidentally removed when refactoring the builtin TUI and is necessary to support commands like:

```
echo q | nvim -es
```

or

```
ls *.md | xargs nvim
```

Fixed small bugs in rstream.c to make this happen.

Should fix #2189 (@fwalch can you confirm?)
