### PR TITLE
[RFC] Add missing patch version 422 in version.c

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -318,7 +318,7 @@ static int included_patches[] = {
   425,
   //424 NA
   423,
-  //422,
+  422,
   421,
   //420 NA
   419,


### PR DESCRIPTION
Vim patch 7.4.422 was ported and merged in #1332, but the patch number in `version.c` is still commented out. Fixed here.
