### PR TITLE
[RDY] vim-patch:7.4.515

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2790,51 +2790,13 @@ do_ecmd (
     oldbuf = (flags & ECMD_OLDBUF);
   }
 
+  buf = curbuf;
   if ((flags & ECMD_SET_HELP) || keep_help_flag) {
-    char_u  *p;
-
-    curbuf->b_help = true;
-    set_string_option_direct((char_u *)"buftype", -1,
-        (char_u *)"help", OPT_FREE|OPT_LOCAL, 0);
-
-    /*
-     * Always set these options after jumping to a help tag, because the
-     * user may have an autocommand that gets in the way.
-     * Accept all ASCII chars for keywords, except ' ', '*', '"', '|', and
-     * latin1 word characters (for translated help files).
-     * Only set it when needed, buf_init_chartab() is some work.
-     */
-    p =
-      (char_u *)"!-~,^*,^|,^\",192-255";
-    if (STRCMP(curbuf->b_p_isk, p) != 0) {
-      set_string_option_direct((char_u *)"isk", -1, p,
-          OPT_FREE|OPT_LOCAL, 0);
-      check_buf_options(curbuf);
-      (void)buf_init_chartab(curbuf, FALSE);
-    }
-
-    curbuf->b_p_ts = 8;                 /* 'tabstop' is 8 */
-    curwin->w_p_list = FALSE;           /* no list mode */
-
-    curbuf->b_p_ma = FALSE;             /* not modifiable */
-    curbuf->b_p_bin = FALSE;            /* reset 'bin' before reading file */
-    curwin->w_p_nu = 0;                 /* no line numbers */
-    curwin->w_p_rnu = 0;                /* no relative line numbers */
-    RESET_BINDING(curwin);              /* no scroll or cursor binding */
-    curwin->w_p_arab = FALSE;           /* no arabic mode */
-    curwin->w_p_rl  = FALSE;            /* help window is left-to-right */
-    curwin->w_p_fen = FALSE;            /* No folding in the help window */
-    curwin->w_p_diff = FALSE;           /* No 'diff' */
-    curwin->w_p_spell = FALSE;          /* No spell checking */
-
-    buf = curbuf;
-    set_buflisted(FALSE);
-  } else {
-    buf = curbuf;
-    /* Don't make a buffer listed if it's a help buffer.  Useful when
-     * using CTRL-O to go back to a help file. */
-    if (!curbuf->b_help)
-      set_buflisted(TRUE);
+    prepare_help_buffer();
+  } else if (!curbuf->b_help) {
+    // Don't make a buffer listed if it's a help buffer.  Useful when using
+    // CTRL-O to go back to a help file.
+    set_buflisted(TRUE);
   }
 
   /* If autocommands change buffers under our fingers, forget about
@@ -5044,6 +5006,46 @@ int find_help_tags(char_u *arg, int *num_matches, char_u ***matches, int keep_la
       free((*matches)[--*num_matches]);
   }
   return OK;
+}
+
+/// Called when starting to edit a buffer for a help file.
+static void prepare_help_buffer(void)
+{
+  curbuf->b_help = true;
+  set_string_option_direct((char_u *)"buftype", -1, (char_u *)"help",
+                           OPT_FREE|OPT_LOCAL, 0);
+
+  // Always set these options after jumping to a help tag, because the
+  // user may have an autocommand that gets in the way.
+  // Accept all ASCII chars for keywords, except ' ', '*', '"', '|', and
+  // latin1 word characters (for translated help files).
+  // Only set it when needed, buf_init_chartab() is some work.
+  char_u *p = (char_u *)"!-~,^*,^|,^\",192-255";
+  if (STRCMP(curbuf->b_p_isk, p) != 0) {
+    set_string_option_direct((char_u *)"isk", -1, p, OPT_FREE|OPT_LOCAL, 0);
+    check_buf_options(curbuf);
+    (void)buf_init_chartab(curbuf, FALSE);
+  }
+
+  // Don't use the global foldmethod.
+  set_string_option_direct((char_u *)"fdm", -1, (char_u *)"manual",
+                           OPT_FREE|OPT_LOCAL, 0);
+
+  curbuf->b_p_ts = 8;         // 'tabstop' is 8.
+  curwin->w_p_list = FALSE;   // No list mode.
+
+  curbuf->b_p_ma = FALSE;     // Not modifiable.
+  curbuf->b_p_bin = FALSE;    // Reset 'bin' before reading file.
+  curwin->w_p_nu = 0;         // No line numbers.
+  curwin->w_p_rnu = 0;        // No relative line numbers.
+  RESET_BINDING(curwin);      // No scroll or cursor binding.
+  curwin->w_p_arab = FALSE;   // No arabic mode.
+  curwin->w_p_rl  = FALSE;    // Help window is left-to-right.
+  curwin->w_p_fen = FALSE;    // No folding in the help window.
+  curwin->w_p_diff = FALSE;   // No 'diff'.
+  curwin->w_p_spell = FALSE;  // No spell checking.
+
+  set_buflisted(FALSE);
 }
 
 /*

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -225,7 +225,7 @@ static int included_patches[] = {
   518,
   517,
   516,
-  //515,
+  515,
   514,
   513,
   //512 NA


### PR DESCRIPTION
```
Problem:    In a help buffer the global 'foldmethod' is used.  (Paul Marshall)
Solution:   Reset 'foldmethod' when starting to edit a help file.  Move the
            code to a separate function.
```

Original patch:

``` diff
diff --git a/src/nvim/ex_cmds.c b/src/nvim/ex_cmds.c
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -34,6 +34,7 @@ static int
     _RTLENTRYF
 #endif
    help_compare __ARGS((const void *s1, const void *s2));
+static void prepare_help_buffer __ARGS((void));

 /*
  * ":ascii" and "ga".
@@ -3531,71 +3532,15 @@ do_ecmd(fnum, ffname, sfname, eap, newln
    oldbuf = (flags & ECMD_OLDBUF);
     }

+#ifdef FEAT_AUTOCMD
+    buf = curbuf;
+#endif
     if ((flags & ECMD_SET_HELP) || keep_help_flag)
     {
-   char_u  *p;
-
-   curbuf->b_help = TRUE;
-#ifdef FEAT_QUICKFIX
-   set_string_option_direct((char_u *)"buftype", -1,
-                    (char_u *)"help", OPT_FREE|OPT_LOCAL, 0);
-#endif
-
-   /*
-    * Always set these options after jumping to a help tag, because the
-    * user may have an autocommand that gets in the way.
-    * Accept all ASCII chars for keywords, except ' ', '*', '"', '|', and
-    * latin1 word characters (for translated help files).
-    * Only set it when needed, buf_init_chartab() is some work.
-    */
-   p =
-#ifdef EBCDIC
-       (char_u *)"65-255,^*,^|,^\"";
-#else
-       (char_u *)"!-~,^*,^|,^\",192-255";
-#endif
-   if (STRCMP(curbuf->b_p_isk, p) != 0)
-   {
-       set_string_option_direct((char_u *)"isk", -1, p,
-                              OPT_FREE|OPT_LOCAL, 0);
-       check_buf_options(curbuf);
-       (void)buf_init_chartab(curbuf, FALSE);
-   }
-
-   curbuf->b_p_ts = 8;     /* 'tabstop' is 8 */
-   curwin->w_p_list = FALSE;   /* no list mode */
-
-   curbuf->b_p_ma = FALSE;     /* not modifiable */
-   curbuf->b_p_bin = FALSE;    /* reset 'bin' before reading file */
-   curwin->w_p_nu = 0;     /* no line numbers */
-   curwin->w_p_rnu = 0;        /* no relative line numbers */
-   RESET_BINDING(curwin);      /* no scroll or cursor binding */
-#ifdef FEAT_ARABIC
-   curwin->w_p_arab = FALSE;   /* no arabic mode */
-#endif
-#ifdef FEAT_RIGHTLEFT
-   curwin->w_p_rl  = FALSE;    /* help window is left-to-right */
-#endif
-#ifdef FEAT_FOLDING
-   curwin->w_p_fen = FALSE;    /* No folding in the help window */
-#endif
-#ifdef FEAT_DIFF
-   curwin->w_p_diff = FALSE;   /* No 'diff' */
-#endif
-#ifdef FEAT_SPELL
-   curwin->w_p_spell = FALSE;  /* No spell checking */
-#endif
-
-#ifdef FEAT_AUTOCMD
-   buf = curbuf;
-#endif
-   set_buflisted(FALSE);
+   prepare_help_buffer();
     }
     else
     {
-#ifdef FEAT_AUTOCMD
-   buf = curbuf;
-#endif
    /* Don't make a buffer listed if it's a help buffer.  Useful when
     * using CTRL-O to go back to a help file. */
    if (!curbuf->b_help)
@@ -6222,6 +6167,71 @@ find_help_tags(arg, num_matches, matches
 }

 /*
+ * Called when starting to edit a buffer for a help file.
+ */
+    static void
+prepare_help_buffer()
+{
+    char_u *p;
+
+    curbuf->b_help = TRUE;
+#ifdef FEAT_QUICKFIX
+    set_string_option_direct((char_u *)"buftype", -1,
+                    (char_u *)"help", OPT_FREE|OPT_LOCAL, 0);
+#endif
+
+    /*
+     * Always set these options after jumping to a help tag, because the
+     * user may have an autocommand that gets in the way.
+     * Accept all ASCII chars for keywords, except ' ', '*', '"', '|', and
+     * latin1 word characters (for translated help files).
+     * Only set it when needed, buf_init_chartab() is some work.
+     */
+    p =
+#ifdef EBCDIC
+       (char_u *)"65-255,^*,^|,^\"";
+#else
+       (char_u *)"!-~,^*,^|,^\",192-255";
+#endif
+    if (STRCMP(curbuf->b_p_isk, p) != 0)
+    {
+   set_string_option_direct((char_u *)"isk", -1, p, OPT_FREE|OPT_LOCAL, 0);
+   check_buf_options(curbuf);
+   (void)buf_init_chartab(curbuf, FALSE);
+    }
+
+    /* Don't use the global foldmethod.*/
+    set_string_option_direct((char_u *)"fdm", -1, (char_u *)"manual",
+                              OPT_FREE|OPT_LOCAL, 0);
+
+    curbuf->b_p_ts = 8;        /* 'tabstop' is 8 */
+    curwin->w_p_list = FALSE;  /* no list mode */
+
+    curbuf->b_p_ma = FALSE;        /* not modifiable */
+    curbuf->b_p_bin = FALSE;   /* reset 'bin' before reading file */
+    curwin->w_p_nu = 0;        /* no line numbers */
+    curwin->w_p_rnu = 0;       /* no relative line numbers */
+    RESET_BINDING(curwin);     /* no scroll or cursor binding */
+#ifdef FEAT_ARABIC
+    curwin->w_p_arab = FALSE;  /* no arabic mode */
+#endif
+#ifdef FEAT_RIGHTLEFT
+    curwin->w_p_rl  = FALSE;   /* help window is left-to-right */
+#endif
+#ifdef FEAT_FOLDING
+    curwin->w_p_fen = FALSE;   /* No folding in the help window */
+#endif
+#ifdef FEAT_DIFF
+    curwin->w_p_diff = FALSE;  /* No 'diff' */
+#endif
+#ifdef FEAT_SPELL
+    curwin->w_p_spell = FALSE; /* No spell checking */
+#endif
+
+    set_buflisted(FALSE);
+}
+
+/*
  * After reading a help file: May cleanup a help buffer when syntax
  * highlighting is not used.
  */
diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    515,
+/**/
     514,
 /**/
     513,
```
