### PR TITLE
[RDY] Create new mode() value for terminal-mode ('t')

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4602,6 +4602,7 @@ mode([expr])	Return a string that indicates the current mode.
 			i	Insert
 			R	Replace |R|
 			Rv	Virtual Replace |gR|
+			t	Terminal {Nvim}
 			c	Command-line
 			cv	Vim Ex mode |gQ|
 			ce	Normal Ex mode |Q|

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11769,6 +11769,8 @@ static void f_mode(typval_T *argvars, typval_T *rettv)
   } else if (exmode_active) {
     buf[0] = 'c';
     buf[1] = 'e';
+  } else if (State & TERM_FOCUS) {
+    buf[0] = 't';
   } else {
     buf[0] = 'n';
     if (finish_op)


### PR DESCRIPTION
This can be usefull in custom statuslines. For example, it makes my vim-airline able to show I'm in terminal-mode.
