### PR TITLE
[WIP] Review trailers tooling.

### DIFF
--- a/contrib/review-trailers-tooling/GIT_DIR/hooks/post-rewrite
+++ b/contrib/review-trailers-tooling/GIT_DIR/hooks/post-rewrite
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# After rebase, detect review commits fixedup/squashed into others,
+# and add appropiate "Helped-by" trailers.
+#
+# Review commits must be titled "Review: <github-username>: ..."
+# for this to work.
+
+set -e -o pipefail
+
+# Avoid executing hook recursively.
+if [[ "$GITHOOK_POST_REWRITE_RUNNING" == "1" ]]; then
+    exit 0
+fi
+export GITHOOK_POST_REWRITE_RUNNING=1
+
+# Only run for "rebase" command (not for "amend").
+if [[ "$1" != "rebase" ]]; then
+    exit 0
+fi
+
+commit_title()
+{
+    echo $(git show --format="%s" --no-patch $1)
+}
+
+review_commit_pattern="^Review: *(.+):.*"
+
+is_review_commit()
+{
+    if [[ "$(commit_title $1)" =~ $review_commit_pattern ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+add_trailer()
+{
+    local trailer=$(github_user_info "$1" 2> /dev/null)
+    if [ "$trailer" ]; then
+        git commit -q --amend -m "$(git log --format="%B" -1 |
+            git interpret-trailers --trailer "Helped-by: $trailer")"
+        return 0
+    else
+        return 1
+    fi
+}
+    
+# Detect review commits fixedup/squashed into others,
+# and build a list of pending amend operations.
+# Also compute final commits list (can be needed later).
+declare -a final_commits
+declare -a pending_amendments
+while read source_sha target_sha
+do
+    if [[ "$target_sha" != "$prev_target_sha" ]]; then
+        final_commits+=("$target_sha")
+    elif is_review_commit $source_sha; then
+        reviewer="${BASH_REMATCH[1]}"
+        pending_amendments+=("$target_sha $reviewer")
+    fi
+    prev_target_sha=$target_sha
+done
+
+# If there are pending amendments:
+# - Checkout detached HEAD at previous rebase upstream point.
+# - Replay final commits, making corresponding amendments after each of them.
+# - Checkout previous branch at the new tip.
+pending_amendments_index=0
+if [[ "${#pending_amendments[@]}" != "0" ]]; then
+    echo "Automatic trailer addition:"
+    branch=$(git rev-parse --abbrev-ref HEAD)
+    git checkout -q HEAD~${#final_commits[@]}
+    for final_commit in "${final_commits[@]}"
+    do
+        git cherry-pick $final_commit > /dev/null 2>&1
+        read target_sha reviewer <<< "${pending_amendments[$pending_amendments_index]}"
+        while [[ "$target_sha" == "$final_commit" ]]
+        do
+            if add_trailer $reviewer; then
+                echo "Trailer added into $(git rev-parse HEAD)."
+            else
+                echo "Failed to add trailer into $(git rev-parse HEAD) for $reviewer."
+            fi
+            ((pending_amendments_index++))
+            read target_sha reviewer <<< "${pending_amendments[$pending_amendments_index]}"
+        done
+    done
+    git checkout -q --no-track -B $branch
+fi

--- a/contrib/review-trailers-tooling/NVIM_RUNTIME_PATH/UltiSnips/gitcommit.snippets
+++ b/contrib/review-trailers-tooling/NVIM_RUNTIME_PATH/UltiSnips/gitcommit.snippets
@@ -1,0 +1,7 @@
+snippet "^r" "Insert Reviewed-by trailer" rb
+Reviewed-by: ${0}
+endsnippet
+
+snippet "^h" "Insert Helped-by trailer" rb
+Helped-by: ${0}
+endsnippet

--- a/contrib/review-trailers-tooling/NVIM_RUNTIME_PATH/plugin/insert-github-user-info.vim
+++ b/contrib/review-trailers-tooling/NVIM_RUNTIME_PATH/plugin/insert-github-user-info.vim
@@ -1,0 +1,14 @@
+" Replace word under cursor (which should be a GitHub username)
+" with some user info ("Full Name <email@address>").
+" If info cout not be found, "Not found" is inserted.
+function! <SID>InsertGitHubUserInfo()
+    let l:user = expand('<cWORD>')
+    " final slice is to remove ending newline
+    let l:info = system('github_user_info ' . l:user . ' 2> /dev/null')[:-2]
+    if v:shell_error
+        let l:info = 'Not found'
+    endif
+    execute "normal! diWa" . l:info . "\<esc>"
+endfunction
+
+nnoremap <silent> <leader>gu :call <SID>InsertGitHubUserInfo()<cr>

--- a/contrib/review-trailers-tooling/PATH/github_user_info
+++ b/contrib/review-trailers-tooling/PATH/github_user_info
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Given a GitHub username as first argument,
+# get corresponding full name and email
+# and output them in the format "Full Name <email@address>".
+#
+# A cache of previous results is maintained.
+# If found in cache, result is returned from there.
+# If not, GitHub API is used to get data from there.
+# If data complete, result is returned at this point.
+# Some users don't have an email in their GitHub profile.
+# If at least fullname was available from GitHub,
+# try to find corresponding email looking at local repo log.
+# If some of the above succeeded, output result with exit status 0.
+# If non succeeded, exit with status 1.
+
+users_api="https://api.github.com/users"
+cache_file="$HOME/.github_user_info_cache"
+username="$1"
+fullname=
+email=
+result=
+
+get_from_cache()
+{
+    [ ! -f "$cache_file" ] && return 1
+    result=$(grep "^$username|" "$cache_file" | sed "s/^$username|//")
+    [ "$result" ] && { >&2 echo "Found at cache."; return 0; }
+    return 1
+}
+
+get_from_github()
+{
+    IFS='|' read fullname email < <(curl -s "$users_api/$username" |
+                                    jq -r '.name + "|" + .email')
+    [ "$fullname" ] && [ "$email" ] && {
+        result="$fullname <$email>"
+        echo "$username|$result" >> "$cache_file"
+        >&2 echo "Found at GitHub."
+        return 0
+    }
+    return 1
+}
+
+get_from_log()
+{
+    result=$(git log --author="$fullname" -1 |
+             grep "^Author" | sed "s/^Author: //")
+    [ "$result" ] && {
+        echo "$username|$result" >> "$cache_file"
+        >&2 echo "Found at local repo log."
+        return 0
+    }
+    return 1
+}
+
+get_from_cache && { echo "$result"; exit 0; }
+get_from_github && { echo "$result"; exit 0; }
+[ "$fullname" ] && get_from_log && { echo "$result"; exit 0; }
+>&2 echo "Not found."
+exit 1

--- a/contrib/review-trailers-tooling/README.md
+++ b/contrib/review-trailers-tooling/README.md
@@ -1,0 +1,41 @@
+## What's this?
+
+A basic set of tools to ease adding review trailers, in order to acknowledge reviewers' work.
+
+## Which trailers are to be added?
+
+- `Helped-by: Full Name <email@address>`
+   Added by regular users to particular commits within a PR. Applies to the commit it appears on. Means "this commit was somehow improved based on suggestions by @reviewer".
+- `Reviewed-by: Full Name <email@address>`
+   Added by maintainer to PR merge commit. Applies to whole PR. Means "these changes were carefully reviewed by @reviewer an he has stated conformity with them."
+
+## Which tools are included, and how they help?
+
+- **github_user_info**: Command line tool to transform GitHub usernames into `Full Name <email@address>` info.
+  It's a bash script that uses GitHub API to look for the info. If user doesn't have a published email, it tries to find a matching one at local git repo. Successful results are cached locally to speed up subsequent requests for the same user.
+  INSTALL: You need curl and jq for this work. Then, put the script in your path.
+
+- **insert-github-user-info.vim**: Vim plugin to insert user info. It shells out to use previous script and inserts result in place.
+  Type a username, Esc to normal mode, and press `<Leader>gu`. Username will be replace by user info.
+  INSTALL: Put file in $NVIM_RUNTIME_PATH/plugin, or copy its contents into your $NVIMRC.
+
+- **gitcommit.snippets**: UltiSnips templates to insert "Helped-by: " and "Reviewed-by: " headers.
+  They will only fire when editing a git commit message, and at the beginning of a line.
+  Press h (or r) and UltiSnips trigger.
+  INSTALL: Put file under UltiSnips search path (usually $NVIM_RUNTIME_PATH/UltiSnips).
+
+- **post_rewrite**: Git hook for automatic insertion of Helped-by trailers on rebase:
+  This is done so that regular users dont' have to deal with trailers at all, as long as they follow a simple convention: Title review commits (commits introducing changes suggested by others, meant to be fixedup/squashed with original commits before merging) this way:
+  `Review: <reviewer-github-username>: ...`.
+  If you do that, when you fixup/squash that commit into other (through git rebase -i), corresponding Helped-by trailer will be automatically added.
+  INSTALL: Put file in $GIT_DIR/hooks. Check it's executable. You need a git version recent enough to support interpret-trailers for this to work. You should also set `git config trailer.ifexists addIfDifferent`.
+
+## Intended workflow
+
+- User opens a PR.
+- It receives comments from reviewers.
+- User adds review commits titled as specified above to address reviewers comments he agrees on, and pushes to PR. This gets repeated until all reviewers have stated "LGTM".
+- User reintegrates review commits into original commits (through git rebase -i), force-pushes to PR, and marks RDY. Helped-by trailers have automatically been added here.
+- Maintainer adds Reviewed-by trailers to merge commit, and commits.
+
+Note that's the usual workflow considered better, but others are equally supported. For example, you can reintegrate review commits and force push before being finished, if that's considered better for the PR at hand.


### PR DESCRIPTION
Some basic tooling to support review trailers. See README for details.

@justinmk Your opinion on this is very important, as it can carry some work for you (and any other committing to master). That's because I've tried to do something so that regular users don't have to deal with trailers at all, as far as they follow a simple convention on review commits' titles. But that leaves adding Reviewed-by trailers on the shoulders of the one committing to master. I think things are left simple enough for that not to be a problem. But I'm not completely convinced. If you are not sure, proposed tools are easily modifiable so that regular users do add all trailers with little effort. But that would require regular users having to remember to do it. So, I'm open to discussion here.
