### PR TITLE
[RDY] vim-patch:7.4.324

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -416,7 +416,7 @@ static int included_patches[] = {
   327,
   //326 NA
   325,
-  //324,
+  324,
   323,
   //322 NA
   //321 NA


### PR DESCRIPTION
```
Problem:    In Ex mode, cyrillic characters are not handled. (Stas Malavin)
Solution:   Support multi-byte characters in Ex mode. (Yukihiro Nakadaira)
```

This one concerns Ex mode. I think there was a discussion about whether to keep Ex mode, so it is possible that this patch may become obsolete in the future. But anyway, it fixes a problem and it's ported now.

Original patch:

``` diff
diff --git a/src/nvim/ex_getln.c b/src/nvim/ex_getln.c
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2188,6 +2188,7 @@ getexmodeline(promptc, cookie, indent)
     int        vcol = 0;
     char_u *p;
     int        prev_char;
+    int        len;

     /* Switch cursor on now.  This avoids that it happens after the "\n", which
      * confuses the system function that computes tabstops. */
@@ -2264,7 +2265,17 @@ getexmodeline(promptc, cookie, indent)
        {
        if (line_ga.ga_len > 0)
        {
-           --line_ga.ga_len;
+#ifdef FEAT_MBYTE
+           if (has_mbyte)
+           {
+           p = (char_u *)line_ga.ga_data;
+           p[line_ga.ga_len] = NUL;
+           len = (*mb_head_off)(p, p + line_ga.ga_len - 1) + 1;
+           line_ga.ga_len -= len;
+           }
+           else
+#endif
+           --line_ga.ga_len;
            goto redraw;
        }
        continue;
@@ -2280,7 +2291,7 @@ getexmodeline(promptc, cookie, indent)

        if (c1 == Ctrl_T)
        {
-       long        sw = get_sw_value(curbuf);
+       long        sw = get_sw_value(curbuf);

        p = (char_u *)line_ga.ga_data;
        p[line_ga.ga_len] = NUL;
@@ -2300,8 +2311,9 @@ redraw:
        /* redraw the line */
        msg_col = startcol;
        vcol = 0;
-       for (p = (char_u *)line_ga.ga_data;
-             p < (char_u *)line_ga.ga_data + line_ga.ga_len; ++p)
+       p = (char_u *)line_ga.ga_data;
+       p[line_ga.ga_len] = NUL;
+       while (p < (char_u *)line_ga.ga_data + line_ga.ga_len)
        {
            if (*p == TAB)
            {
@@ -2309,11 +2321,14 @@ redraw:
            {
                msg_putchar(' ');
            } while (++vcol % 8);
+           ++p;
            }
            else
            {
-           msg_outtrans_len(p, 1);
-           vcol += char2cells(*p);
+           len = MB_PTR2LEN(p);
+           msg_outtrans_len(p, len);
+           vcol += ptr2cells(p);
+           p += len;
            }
        }
        msg_clr_eos();
@@ -2362,7 +2377,16 @@ redraw:

    if (IS_SPECIAL(c1))
        c1 = '?';
-   ((char_u *)line_ga.ga_data)[line_ga.ga_len] = c1;
+#ifdef FEAT_MBYTE
+   if (has_mbyte)
+       len = (*mb_char2bytes)(c1,
+                 (char_u *)line_ga.ga_data + line_ga.ga_len);
+   else
+#endif
+   {
+       len = 1;
+       ((char_u *)line_ga.ga_data)[line_ga.ga_len] = c1;
+   }
    if (c1 == '\n')
        msg_putchar('\n');
    else if (c1 == TAB)
@@ -2376,10 +2400,10 @@ redraw:
    else
    {
        msg_outtrans_len(
-            ((char_u *)line_ga.ga_data) + line_ga.ga_len, 1);
+            ((char_u *)line_ga.ga_data) + line_ga.ga_len, len);
        vcol += char2cells(c1);
    }
-   ++line_ga.ga_len;
+   line_ga.ga_len += len;
    escaped = FALSE;

    windgoto(msg_row, msg_col);
diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -735,6 +735,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    324,
+/**/
     323,
 /**/
     322,
```
