### PR TITLE
[RDY] vim-patch:7.4.336

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5354,6 +5354,9 @@ set_num_option (
   if (p_hi < 0) {
     errmsg = e_positive;
     p_hi = 0;
+  } else if (p_hi > 10000) {
+    errmsg = e_invarg;
+    p_hi = 10000;
   }
   if (p_re < 0 || p_re > 2) {
     errmsg = e_invarg;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -404,7 +404,7 @@ static int included_patches[] = {
   339,
   338,
   337,
-  //336,
+  336,
   335,
   334,
   //333 NA


### PR DESCRIPTION
```
Problem:    Setting 'history' to a big value causes out-of-memory errors.
Solution:   Limit the value to 10000. (Hirohito Higashi)
```

The first hunk in `option.c` was already ported in 099fdb49a700f851f0165089fc2ca06807591f6a. As for the other hunk, the help docs already state that the maximum for `'history'` is 10000, and that statement becomes true now.

Original patch:

``` diff
diff --git a/runtime/doc/options.txt b/runtime/doc/options.txt
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3920,12 +3920,13 @@ A jump table for the options with a shor
    NOTE: This option is reset when 'compatible' is set.

                        *'history'* *'hi'*
-'history' 'hi'     number  (Vim default: 20, Vi default: 0)
+'history' 'hi'     number  (Vim default: 50, Vi default: 0)
            global
            {not in Vi}
    A history of ":" commands, and a history of previous search patterns
-   are remembered.  This option decides how many entries may be stored in
+   is remembered.  This option decides how many entries may be stored in
    each of these histories (see |cmdline-editing|).
+   The maximum value is 10000.
    NOTE: This option is set to the Vi default value when 'compatible' is
    set and to the Vim default value when 'compatible' is reset.

diff --git a/src/nvim/option.c b/src/nvim/option.c
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1392,7 +1392,7 @@ static struct vimoption
                SCRIPTID_INIT},
     {"history",        "hi",   P_NUM|P_VIM,
                (char_u *)&p_hi, PV_NONE,
-               {(char_u *)0L, (char_u *)20L} SCRIPTID_INIT},
+               {(char_u *)0L, (char_u *)50L} SCRIPTID_INIT},
     {"hkmap",      "hk",   P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_RIGHTLEFT
                (char_u *)&p_hkmap, PV_NONE,
@@ -8595,6 +8595,11 @@ set_num_option(opt_idx, varp, value, err
    errmsg = e_positive;
    p_hi = 0;
     }
+    else if (p_hi > 10000)
+    {
+   errmsg = e_invarg;
+   p_hi = 10000;
+    }
     if (p_re < 0 || p_re > 2)
     {
    errmsg = e_invarg;
diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -735,6 +735,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    336,
+/**/
     335,
 /**/
     334,
```
