### PR TITLE
[RFC] Remove potential NULL dereference.

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -243,19 +243,16 @@ void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, bool esc, bool one,
         // Verify that we have found the end of a UNIX ${VAR} style variable
         if (src[1] == '{' && *tail != '}') {
           var = NULL;
-        } else if (src[1] == '{') {
-          ++tail;
-        }
-#elif defined(MSWIN)
-        // Verify that we have found the end of a Windows %VAR% style variable
-        if (src[0] == '%' && *tail != '%') {
-          var = NULL;
-        } else if (src[0] == '%') {
-          ++tail;
-        }
+        } else {
+          if (src[1] == '{') {
+            ++tail;
+          }
 #endif
         *var = NUL;
         var = vim_getenv(dst, &mustfree);
+#if defined(UNIX)
+        }
+#endif
       } else if (  src[1] == NUL /* home directory */
                  || vim_ispathsep(src[1])
                  || vim_strchr((char_u *)" ,\t\n", src[1]) != NULL) {


### PR DESCRIPTION
Re-doing #2250, because I accidentally closed it (Sorry.)
- Clang Report: http://neovim.org/doc/reports/clang/report-1699be.html#EndPath
- Introduced in this commit: https://github.com/neovim/neovim/commit/03d47965c0ad5941c88ebd3b91233e7a566935f7
- I attempted to simulate the old logic [here](https://github.com/neovim/neovim/commit/03d47965c0ad5941c88ebd3b91233e7a566935f7#diff-169f130e2342d3edf99a9ecee222e4b9L2759), which has been here, far as I can tell, since the initial merge.

This also removes the `#elseif defined(MSWIN)` clause. Due to the
enclosing `if` block, we will never get to this point when src starts with
a '%', making the whole #elseif block dead code.
[Discussion here](https://github.com/neovim/neovim/pull/2250#discussion-diff-27332673)
