### PR TITLE
Use lfs.currentdir() to fix symlink test fail.

### DIFF
--- a/test/unit/os/fs_spec.lua
+++ b/test/unit/os/fs_spec.lua
@@ -172,17 +172,17 @@ describe('fs function', function()
       local old_dir = lfs.currentdir()
 
       lfs.chdir(directory)
-      local relative_executable = './' .. executable_name
 
-      -- Don't test yet; we need to chdir back first.
+      -- Rely on currentdir to resolve symlinks, if any. Testing against 
+      -- the absolute path taken from arg[0] may result in failure where 
+      -- the path has a symlink in it.
+      local canonical = lfs.currentdir() .. '/' .. executable_name
+      local expected = exe(canonical)
+      local relative_executable = './' .. executable_name
       local res = exe(relative_executable)
 
+      -- Don't test yet; we need to chdir back first.
       lfs.chdir(old_dir)
-
-      -- Need to canonicalize the absolute path taken from arg[0], because the
-      -- path may have a symlink in it.  For example, /home is symlinked in
-      -- FreeBSD 10's VM image.
-      local expected = exe(absolute_executable)
       eq(expected, res)
     end)
   end)


### PR DESCRIPTION
```
it('returns the absolute path when given an executable relative to the current dir'
```

I noticed this test was still failing if the unittests were built with the repo on a directory path that contained a symlink (Mint 17.1, based on Ubuntu 14.04.2 LTS). This despite the recent fix  41d8c8980b088e509c577a35c765d498d5498581. Specifically, busted is invoked with the path:

```
/home/basie/work/neovim/.deps/usr/lib/luarocks/rocks/busted/scm-0/bin/busted
```

but

```
/media/work/neovim/.deps/usr/lib/luarocks/rocks/busted/scm-0/bin/busted
```

is passed in. In my case, the symlink is (obviously) `ln -s /media/work ~/work`. Because `absolute_executable` contains the former path, the test fails. `lfs.currentdir()` seems to resolve the symlink correctly allowing the test to pass. 

As this is my first PR, please treat it with deep suspicion! If @jszakmeister could check this still works on FreeBSD, that'd be great.
