### PR TITLE
[RFC] Replace strncpy + str[last] = '\0' to strlcpy

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -232,8 +232,7 @@ void vim_change_directory(String dir, Error *err)
   }
 
   char string[MAXPATHL];
-  strncpy(string, dir.data, dir.size);
-  string[dir.size] = NUL;
+  xstrlcpy(string, dir.data, dir.size+1);
 
   try_start();
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -280,8 +280,8 @@ static int linelen(int *has_tab)
 
 /* Buffer for two lines used during sorting.  They are allocated to
  * contain the longest line being sorted. */
-static char_u   *sortbuf1;
-static char_u   *sortbuf2;
+static char *sortbuf1;
+static char *sortbuf2;
 
 static int sort_ic;                     /* ignore case */
 static int sort_nr;                     /* sort on number */
@@ -321,12 +321,10 @@ static int sort_compare(const void *s1, const void *s2)
     /* We need to copy one line into "sortbuf1", because there is no
      * guarantee that the first pointer becomes invalid when obtaining the
      * second one. */
-    STRNCPY(sortbuf1, ml_get(l1.lnum) + l1.start_col_nr,
+    xstrlcpy(sortbuf1, (char *)ml_get(l1.lnum) + l1.start_col_nr,
         l1.end_col_nr - l1.start_col_nr + 1);
-    sortbuf1[l1.end_col_nr - l1.start_col_nr] = 0;
-    STRNCPY(sortbuf2, ml_get(l2.lnum) + l2.start_col_nr,
+    xstrlcpy(sortbuf2, (char *)ml_get(l2.lnum) + l2.start_col_nr,
         l2.end_col_nr - l2.start_col_nr + 1);
-    sortbuf2[l2.end_col_nr - l2.start_col_nr] = 0;
 
     result = sort_ic ? STRICMP(sortbuf1, sortbuf2)
              : STRCMP(sortbuf1, sortbuf2);

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -88,8 +88,7 @@ void os_get_hostname(char *hostname, size_t len)
   if (uname(&vutsname) < 0) {
     *hostname = '\0';
   } else {
-    strncpy(hostname, vutsname.nodename, len - 1);
-    hostname[len - 1] = '\0';
+    xstrlcpy(hostname, vutsname.nodename, len);
   }
 #else
   // TODO(unknown): Implement this for windows.

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -2066,8 +2066,7 @@ static int path_get_absolute_path(char_u *fname, char_u *buf, int len, int force
   // expand it if forced or not an absolute path
   if (force || !path_is_absolute_path(fname)) {
     if ((p = vim_strrchr(fname, '/')) != NULL) {
-      STRNCPY(relative_directory, fname, p-fname);
-      relative_directory[p-fname] = NUL;
+      xstrlcpy(relative_directory, (char *)fname, p-fname+1);
       end_of_path = (char *) (p + 1);
     } else {
       relative_directory[0] = NUL;


### PR DESCRIPTION
char_u was changed to char to suppress compile warning and sortbufs are
really used as ordinary character arrays.

This PR is related to #731.
