### PR TITLE
[RFC] Exclude build directory from Coveralls

### DIFF
--- a/.ci/clang.sh
+++ b/.ci/clang.sh
@@ -52,7 +52,7 @@ if ! $MAKE_CMD oldtest; then
 fi
 asan_check "$tmpdir"
 
-coveralls --encoding iso-8859-1 || echo 'coveralls upload failed.'
+coveralls --encoding iso-8859-1 --exclude test --exclude cmake --exclude config || echo 'coveralls upload failed.'
 
 # Test if correctly installed.
 sudo -E $MAKE_CMD install

--- a/.ci/gcc.sh
+++ b/.ci/gcc.sh
@@ -38,4 +38,4 @@ if ! $MAKE_CMD oldtest; then
 fi
 valgrind_check "$tmpdir"
 
-coveralls --encoding iso-8859-1 || echo 'coveralls upload failed.'
+coveralls --encoding iso-8859-1 --exclude test --exclude cmake --exclude config || echo 'coveralls upload failed.'


### PR DESCRIPTION
I know this patch is split among two different commits. Before I waste time squashing them I'd like to know if this is a desired change. 
