### PR TITLE
[RFC] TravisCI: use container-based infrastructure

### DIFF
--- a/.ci/clang.sh
+++ b/.ci/clang.sh
@@ -1,34 +1,21 @@
 . "$CI_SCRIPTS/common.sh"
 
-sudo pip install cpp-coveralls
-
-# Use custom Clang and enable ASAN on Linux.
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-	clang_version=3.4.2
-	clang_suffix=x86_64-unknown-ubuntu12.04.xz
-	if [ ! -d /usr/local/clang-$clang_version ]; then
-		echo "Downloading clang $clang_version..."
-		sudo mkdir /usr/local/clang-$clang_version
-		wget -q -O - http://llvm.org/releases/$clang_version/clang+llvm-$clang_version-$clang_suffix \
-			| sudo tar xJf - --strip-components=1 -C /usr/local/clang-$clang_version
-	fi
-	export CC=/usr/local/clang-$clang_version/bin/clang
-	symbolizer=/usr/local/clang-$clang_version/bin/llvm-symbolizer
-	export ASAN_SYMBOLIZER_PATH=$symbolizer
-	export ASAN_OPTIONS="detect_leaks=1:log_path=$tmpdir/asan"
-	export TSAN_OPTIONS="external_symbolizer_path=$symbolizer:log_path=$tmpdir/tsan"
-	export UBSAN_OPTIONS="log_path=$tmpdir/ubsan" # not sure if this works
-	CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
-		-DUSE_GCOV=ON \
-		-DBUSTED_OUTPUT_TYPE=plainTerminal \
-		-DSANITIZE=ON"
+    export CC=clang
+    symbolizer=/usr/local/clang-3.4/bin/llvm-symbolizer
+    export ASAN_SYMBOLIZER_PATH=$symbolizer
+    export ASAN_OPTIONS="detect_leaks=1:log_path=$tmpdir/asan"
+    export TSAN_OPTIONS="external_symbolizer_path=$symbolizer:log_path=$tmpdir/tsan"
+    export UBSAN_OPTIONS="log_path=$tmpdir/ubsan" # not sure if this works
+    CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
+        -DUSE_GCOV=ON \
+        -DBUSTED_OUTPUT_TYPE=plainTerminal \
+        -DSANITIZE=ON"
 else
-	CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
-		-DUSE_GCOV=ON \
-		-DBUSTED_OUTPUT_TYPE=plainTerminal"
+    CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
+        -DUSE_GCOV=ON \
+        -DBUSTED_OUTPUT_TYPE=plainTerminal"
 fi
-
-setup_deps x64
 
 # Build and output version info.
 $MAKE_CMD CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS" nvim
@@ -39,22 +26,22 @@ make unittest
 
 # Run functional tests.
 if ! $MAKE_CMD test; then
-	asan_check "$tmpdir"
-	exit 1
+    asan_check "$tmpdir"
+    exit 1
 fi
 asan_check "$tmpdir"
 
 # Run legacy tests.
 if ! $MAKE_CMD oldtest; then
-	reset
-	asan_check "$tmpdir"
-	exit 1
+    reset
+    asan_check "$tmpdir"
+    exit 1
 fi
 asan_check "$tmpdir"
 
 coveralls --encoding iso-8859-1 || echo 'coveralls upload failed.'
 
 # Test if correctly installed.
-sudo -E $MAKE_CMD install
-/usr/local/bin/nvim --version
-/usr/local/bin/nvim -e -c "quit"
+make DESTDIR="$HOME/neovim-install" install
+$HOME/neovim-install/usr/local/bin/nvim --version
+$HOME/neovim-install/usr/local/bin/nvim -e -c "quit"

--- a/.ci/clang.sh
+++ b/.ci/clang.sh
@@ -17,6 +17,8 @@ else
 		-DBUSTED_OUTPUT_TYPE=plainTerminal"
 fi
 
+setup_deps x64
+
 # Build and output version info.
 $MAKE_CMD CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS" nvim
 build/bin/nvim --version

--- a/.ci/clang.sh
+++ b/.ci/clang.sh
@@ -1,20 +1,20 @@
 . "$CI_SCRIPTS/common.sh"
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    export CC=clang
-    symbolizer=/usr/local/clang-3.4/bin/llvm-symbolizer
-    export ASAN_SYMBOLIZER_PATH=$symbolizer
-    export ASAN_OPTIONS="detect_leaks=1:log_path=$tmpdir/asan"
-    export TSAN_OPTIONS="external_symbolizer_path=$symbolizer:log_path=$tmpdir/tsan"
-    export UBSAN_OPTIONS="log_path=$tmpdir/ubsan" # not sure if this works
-    CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
-        -DUSE_GCOV=ON \
-        -DBUSTED_OUTPUT_TYPE=plainTerminal \
-        -DSANITIZE=ON"
+	export CC=clang
+	symbolizer=/usr/local/clang-3.4/bin/llvm-symbolizer
+	export ASAN_SYMBOLIZER_PATH=$symbolizer
+	export ASAN_OPTIONS="detect_leaks=1:log_path=$tmpdir/asan"
+	export TSAN_OPTIONS="external_symbolizer_path=$symbolizer:log_path=$tmpdir/tsan"
+	export UBSAN_OPTIONS="log_path=$tmpdir/ubsan" # not sure if this works
+	CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
+		-DUSE_GCOV=ON \
+		-DBUSTED_OUTPUT_TYPE=plainTerminal \
+		-DSANITIZE=ON"
 else
-    CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
-        -DUSE_GCOV=ON \
-        -DBUSTED_OUTPUT_TYPE=plainTerminal"
+	CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
+		-DUSE_GCOV=ON \
+		-DBUSTED_OUTPUT_TYPE=plainTerminal"
 fi
 
 # Build and output version info.
@@ -26,16 +26,16 @@ make unittest
 
 # Run functional tests.
 if ! $MAKE_CMD test; then
-    asan_check "$tmpdir"
-    exit 1
+	asan_check "$tmpdir"
+	exit 1
 fi
 asan_check "$tmpdir"
 
 # Run legacy tests.
 if ! $MAKE_CMD oldtest; then
-    reset
-    asan_check "$tmpdir"
-    exit 1
+	reset
+	asan_check "$tmpdir"
+	exit 1
 fi
 asan_check "$tmpdir"
 

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -51,8 +51,13 @@ check_core_dumps() {
 }
 
 setup_deps() {
-	if [ "$BUILD_NVIM_DEPS" != "true" ]; then
+	if [ "$BUILD_NVIM_DEPS" != "true" ] && [ "$TRAVIS_OS_NAME" = "osx" ]; then
 		eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) deps-${1}"
+	elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
+		# Make sure deps are up-to-date before proceeding
+		# Remove sources from cache to force download on dependency changes
+		rm -rf .deps/build/src
+		make deps
 	fi
 }
 

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -51,20 +51,8 @@ check_core_dumps() {
 }
 
 setup_deps() {
-	sudo pip install --upgrade pip
-	sudo pip install neovim
-
-	# For pip3
-	# https://github.com/travis-ci/travis-ci/issues/1528
-	# sudo apt-get install -q python3.3-dev
-	# curl -Ss http://python-distribute.org/distribute_setup.py | sudo python3
-	# curl -Ss https://raw.github.com/pypa/pip/master/contrib/get-pip.py | sudo python3
-	# sudo pip3.3 install neovim
-
 	if [ "$BUILD_NVIM_DEPS" != "true" ]; then
 		eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) deps-${1}"
-	elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
-		sudo apt-get install libtool
 	fi
 }
 

--- a/.ci/gcc-32.sh
+++ b/.ci/gcc-32.sh
@@ -1,5 +1,7 @@
 . "$CI_SCRIPTS/common.sh"
 
+setup_deps x86
+
 CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
 	-DCMAKE_SYSTEM_PROCESSOR=i386 \
 	-DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32 \

--- a/.ci/gcc-32.sh
+++ b/.ci/gcc-32.sh
@@ -1,9 +1,5 @@
 . "$CI_SCRIPTS/common.sh"
 
-sudo apt-get install gcc-multilib g++-multilib
-
-setup_deps x86
-
 CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
 	-DCMAKE_SYSTEM_PROCESSOR=i386 \
 	-DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32 \
@@ -32,6 +28,6 @@ $MAKE_CMD oldtest
 check_core_dumps
 
 # Test if correctly installed.
-sudo -E $MAKE_CMD install
-/usr/local/bin/nvim --version
-/usr/local/bin/nvim -e -c "quit"
+$MAKE_CMD DESTDIR="$HOME/neovim-install" install
+$HOME/neovim-install/usr/local/bin/nvim --version
+$HOME/neovim-install/usr/local/bin/nvim -e -c "quit"

--- a/.ci/gcc.sh
+++ b/.ci/gcc.sh
@@ -1,14 +1,9 @@
 . "$CI_SCRIPTS/common.sh"
 
-sudo pip install cpp-coveralls
-
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-	sudo apt-get install valgrind
 	export VALGRIND=1
 	export VALGRIND_LOG="$tmpdir/valgrind-%p.log"
 fi
-
-setup_deps x64
 
 CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
 	-DUSE_JEMALLOC=OFF \

--- a/.ci/gcc.sh
+++ b/.ci/gcc.sh
@@ -5,6 +5,8 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 	export VALGRIND_LOG="$tmpdir/valgrind-%p.log"
 fi
 
+setup_deps x64
+
 CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
 	-DUSE_JEMALLOC=OFF \
 	-DUSE_GCOV=ON \

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,24 +51,8 @@ install:
   - if [ $TRAVIS_OS_NAME = osx ]; then
       brew install gettext;
     fi
-before_script:
-  # Adds user to a dummy group.
-  # That allows to test changing the group of the file by `os_fchown`.
-  # Need xvfb for running some tests with xclip
-  - if [ $TRAVIS_OS_NAME = linux ]; then
-      sudo groupadd chown_test;
-      sudo usermod -a -G chown_test $USER;
-      export DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-    elif [ $TRAVIS_OS_NAME = osx ]; then
-      sudo dscl . -create /Groups/chown_test;
-      sudo dscl . -append /Groups/chown_test GroupMembership $USER;
-    fi
 script:
-  # This will pass the environment variables down to a bash process which runs
-  # as $USER, while retaining the environment variables defined and belonging
-  # to secondary groups given above in usermod.
-  - sudo -E su $USER -c "sh -e \"$CI_SCRIPTS/$CI_TARGET.sh\""
+  - sh -e $CI_SCRIPTS/$CI_TARGET.sh
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ before_install:
       brew update;
     fi
   - pip install --user -q --upgrade pip
+  # Add location of the pip packages to the path.
+  - PATH=$HOME/.local/bin:$PATH
 install:
   - if [ $TRAVIS_OS_NAME = osx ]; then
       brew install gettext;
@@ -55,7 +57,7 @@ install:
 script:
   - sh -e $CI_SCRIPTS/$CI_TARGET.sh
 cache:
-  - build/neovim/neovim/.deps
+  - $TRAVIS_BUILD_DIR/.deps
   - apt
   - pip
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
-sudo: required
+sudo: false
 language: c
 os:
   - linux
 branches:
   except:
     - nightly
+addons:
+    apt_packages:
+        - xclip
+        - gdb
+        - valgrind
+        - libtool
+        - gcc-multilib
+cache:
+    - apt
+    - pip
 env:
   global:
     - CI_SCRIPTS=$TRAVIS_BUILD_DIR/.ci
@@ -34,18 +44,11 @@ matrix:
       compiler: gcc-4.9
   fast_finish: true
 before_install:
-  # Pins the version of the java package installed on the Travis VMs
-  # and avoids a lengthy upgrade process for them.
-  - if [ $TRAVIS_OS_NAME = linux ]; then
-      sudo apt-mark hold oracle-java7-installer oracle-java8-installer;
-      sudo apt-get update;
-    elif [ $TRAVIS_OS_NAME = osx ]; then
+  - if [ $TRAVIS_OS_NAME = osx ]; then
       brew update;
     fi
 install:
-  - if [ $TRAVIS_OS_NAME = linux ]; then
-      sudo apt-get install xclip gdb;
-    elif [ $TRAVIS_OS_NAME = osx ]; then
+  - if [ $TRAVIS_OS_NAME = osx ]; then
       brew install gettext;
     fi
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
         - valgrind
         - libtool
         - gcc-multilib
+        - clang-3.4
 cache:
     - apt
     - pip
@@ -47,10 +48,12 @@ before_install:
   - if [ $TRAVIS_OS_NAME = osx ]; then
       brew update;
     fi
+  - pip install --user -q --upgrade pip
 install:
   - if [ $TRAVIS_OS_NAME = osx ]; then
       brew install gettext;
     fi
+  - pip install --user -q cpp-coveralls neovim
 script:
   - sh -e $CI_SCRIPTS/$CI_TARGET.sh
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,14 @@ branches:
   except:
     - nightly
 addons:
-    apt_packages:
-        - xclip
-        - gdb
-        - valgrind
-        - libtool
-        - gcc-multilib
-        - clang-3.4
-cache:
-    - apt
-    - pip
+  apt_packages:
+    - xclip
+    - gdb
+    - valgrind
+    - libtool
+    - clang-3.4
+    - gcc-multilib
+    - g++-multilib
 env:
   global:
     - CI_SCRIPTS=$TRAVIS_BUILD_DIR/.ci
@@ -56,6 +54,10 @@ install:
   - pip install --user -q cpp-coveralls neovim
 script:
   - sh -e $CI_SCRIPTS/$CI_TARGET.sh
+cache:
+  - build/neovim/neovim/.deps
+  - apt
+  - pip
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
TravisCI is switching to their [container-based infrastructure](http://blog.travis-ci.com/2015-03-31-docker-default-on-the-way/). Projects need to add `sudo: required` to the `.travis.yml` if they need the `sudo` command in their scripts.

I think neovim would benefit from using the container-based infrastructure since it could result in [faster travis builds](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/). This would require us to remove all sudo commands from the travis configuration. Until then, it might make sense to explicitly state `sudo: required`.
