### PR TITLE
[RFC] terminal: Handle loss of focus in event loop.

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -246,7 +246,7 @@ edit (
 )
 {
   if (curbuf->terminal) {
-    terminal_enter(curbuf->terminal, true);
+    terminal_enter(true);
     return false;
   }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -338,7 +338,7 @@ void terminal_resize(Terminal *term, uint16_t width, uint16_t height)
   // terminal in the current tab.
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (!wp->w_closing && wp->w_buffer == term->buf) {
-      width = (uint16_t)MIN(width, (uint16_t)wp->w_width);
+      width = (uint16_t)MIN(width, (uint16_t)(wp->w_width - win_col_off(wp)));
       height = (uint16_t)MIN(height, (uint16_t)wp->w_height);
     }
   }
@@ -357,6 +357,9 @@ void terminal_enter(bool process_deferred)
 {
   Terminal *term = curbuf->terminal;
   assert(term && "should only be called when curbuf has a terminal");
+
+  // Ensure the terminal is properly sized.
+  terminal_resize(term, 0, 0);
 
   checkpcmark();
   setpcmark();

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -170,15 +170,18 @@ describe('terminal buffer', function()
     source([[
     function! SplitWindow()
       new
+      call feedkeys("iabc\<Esc>")
     endfunction
 
     startinsert
     call jobstart(['sh', '-c', 'exit'], {'on_exit': function("SplitWindow")})
+    call feedkeys("\<C-\>", 't')  " vim will expect <C-n>, but be exited out of
+                                  " the terminal before it can be entered.
     ]])
 
     -- We should be in a new buffer now.
     screen:expect([[
-      ^                                                  |
+      ab^c                                               |
       ~                                                 |
       ==========                                        |
       rows: 2, cols: 50                                 |
@@ -188,7 +191,7 @@ describe('terminal buffer', function()
     ]])
 
     neq(tbuf, eval('bufnr("%")'))
-    execute('quit')  -- Should exit the new window, not the terminal.
+    execute('quit!')  -- Should exit the new window, not the terminal.
     eq(tbuf, eval('bufnr("%")'))
 
     execute('set laststatus=1')  -- Restore laststatus to the default.

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -50,6 +50,20 @@ describe('terminal mouse', function()
       ]])
     end)
 
+    it('will exit focus after <C-\\>, then scrolled', function()
+      feed('<C-\\>')
+      feed('<MouseDown><0,0>')
+      screen:expect([[
+        line23                                            |
+        line24                                            |
+        line25                                            |
+        line26                                            |
+        line27                                            |
+        ^line28                                            |
+                                                          |
+      ]])
+    end)
+
     describe('with mouse events enabled by the program', function()
       before_each(function()
         thelpers.enable_mouse()


### PR DESCRIPTION
While in a terminal and insert mode, if an aucmd or event caused loss of focus, nvim would stay in the terminal event loop causing an inconsistent view of internal state and/or segfault.

Remove the "term" argument from terminal_enter() as it only makes sense to call it with curbuf->terminal. Terminate the loop either when focus is lost or the terminal closes.

~~Implement redraw() in terms of the pointer...~~

fixes #2301

@tarruda, for `terminal_enter()`, I notice that it has only one call site, and that `process_deferred` is unconditionally true. Do or will we need this to be called with `process_deferred=false` at any point, or can we simplify this?
