### PR TITLE
[RFC] Fix several unused variable warnings in the release build.

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2783,7 +2783,11 @@ int get_tags(list_T *list, char_u *pat)
   if (ret == OK && num_matches > 0) {
     for (i = 0; i < num_matches; ++i) {
       int parse_result = parse_match(matches[i], &tp);
+
+      // Avoid an unused variable warning in release builds.
+      (void) parse_result;
       assert(parse_result == OK);
+
       is_static = test_for_static(&tp);
 
       /* Skip pseudo-tag lines. */

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2677,7 +2677,10 @@ void u_undoline(void)
 void u_blockfree(buf_T *buf)
 {
   while (buf->b_u_oldhead != NULL) {
+#ifndef NDEBUG
     u_header_T *previous_oldhead = buf->b_u_oldhead;
+#endif
+
     u_freeheader(buf, buf->b_u_oldhead, NULL);
     assert(buf->b_u_oldhead != previous_oldhead);
   }


### PR DESCRIPTION
I'm not particularly happy with this, so I'm definitely looking for feedback.  I'm tempted to remove the two asserts that necessitate the `#ifndef NDEBUG` lines.  I'm not quite sure what the concern is and why that was the right place to assert.  I mean, I understand what the code is trying to do, but I'm not sure what the benefit is.  It seems like both might be better caught by unit tests rather than having asserts in the code base.

In the fix for `tag.c`, I think it should probably be a runtime check rather than an assert.  There exists the possibility to exit with an error (unlike the others) and we probably should, but it's complicated as you'd have to free the memory consumed by matches (which requires looping through it from the point of failure to the end).  At least it can be converted to a one-liner though.

An alternate solution for `tag.c` might look like this:

``` c
diff --git a/src/nvim/tag.c b/src/nvim/tag.c
index a259c29..6826676 100644
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2782,7 +2782,12 @@ int get_tags(list_T *list, char_u *pat)
       TAG_REGEXP | TAG_NOIC, (int)MAXCOL, NULL);
   if (ret == OK && num_matches > 0) {
     for (i = 0; i < num_matches; ++i) {
-      assert(parse_match(matches[i], &tp) == OK);
+      if (parse_match(matches[i], &tp) != OK)
+      {
+        ret = FAIL;
+        continue;
+      }
+
       is_static = test_for_static(&tp);

       /* Skip pseudo-tag lines. */
```

This would allow it to continue through the loop and ultimately free the memory and return a failure, but I'm not quite sure that's the behavior we want either.

Opinions welcome. ;-)  I took the simple way out here to start a discussion, but I'm willing to work this differently--assuming that it can be done without an insane amount of work.
