### PR TITLE
[RDY] Add new highlight groups TermCursor and TermCursorNC

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -99,16 +99,13 @@ variables (set via the |TermOpen| autocmd):
 - `{g,b}:terminal_color_$NUM`: The terminal color palette, where `$NUM` is the
   color index, between 0 and 255 inclusive. This only affects UIs with RGB
   capabilities; for normal terminals the color index is simply forwarded.
-- `{g,b}:terminal_focused_cursor_highlight`: Highlight group applied to the
-  cursor in a focused terminal. The default equivalent to having a group with
-  `cterm=reverse` `gui=reverse``.
-- `{g,b}:terminal_unfocused_cursor_highlight`: Highlight group applied to the
-  cursor in an unfocused terminal. The default equivalent to having a group with
-  `ctermbg=11` `guibg=#fce94f``.
 
 The configuration variables are only processed when the terminal starts, which
 is why it needs to be done with the |TermOpen| autocmd or setting global
 variables before the terminal is started.
+
+The terminal cursor can be highlighted via |hl-TermCursor| and
+|hl-TermCursorNC|.
 
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3651,17 +3651,19 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'highlight'* *'hl'*
 'highlight' 'hl'	string	(default (as a single string):
-				     "8:SpecialKey,~:EndOfBuffer,@:NonText,i
-				     d:Directory,e:ErrorMsg,i:IncSearch,
-				     l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,
+				     "8:SpecialKey,~:EndOfBuffer,z:TermCursor,
+				     Z:TermCursorNC,@:NonText,d:Directory,
+				     e:ErrorMsg,i:IncSearch,l:Search,
+				     m:MoreMsg,M:ModeMsg,n:LineNr,
 				     N:CursorLineNr,r:Question,s:StatusLine,
 				     S:StatusLineNC,c:VertSplit,t:Title,
-				     v:Visual,w:WarningMsg,W:WildMenu,f:Folded,
-				     F:FoldColumn,A:DiffAdd,C:DiffChange,
-				     D:DiffDelete,T:DiffText,>:SignColumn,
-				     B:SpellBad,P:SpellCap,R:SpellRare,
-				     L:SpellLocal,-:Conceal,+:Pmenu,=:PmenuSel,
-				     x:PmenuSbar,X:PmenuThumb")
+				     v:Visual,w:WarningMsg,W:WildMenu,
+				     f:Folded,F:FoldColumn,A:DiffAdd,
+				     C:DiffChange,D:DiffDelete,T:DiffText,
+				     >:SignColumn,B:SpellBad,P:SpellCap,
+				     R:SpellRare,L:SpellLocal,-:Conceal,
+				     +:Pmenu,=:PmenuSel,x:PmenuSbar,
+				     X:PmenuThumb")
 			global
 			{not in Vi}
 	This option can be used to set highlighting mode for various
@@ -3670,6 +3672,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	use for that occasion.  The occasions are:
 	|hl-SpecialKey|	 8  Meta and special keys listed with ":map"
 	|hl-EndOfBuffer|      ~ lines after the last line in the buffer
+	|hl-TermCursor|	 z  Cursor in a focused terminal
+	|hl-TermCursorNC| Z Cursor in an unfocused terminal
 	|hl-NonText|	 @  '@' at the end of the window and
 			    characters from 'showbreak'
 	|hl-Directory|	 d  directories in CTRL-D listing and other special
@@ -3681,7 +3685,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|hl-ModeMsg|	 M  Mode (e.g., "-- INSERT --")
 	|hl-LineNr|	 n  line number for ":number" and ":#" commands, and
 			    when 'number' or 'relativenumber' option is set.
-	|hl-CursorLineNr|  N like n for when 'cursorline' or 'relativenumber' is
+	|hl-CursorLineNr| N like n for when 'cursorline' or 'relativenumber' is
 			    set.
 	|hl-Question|	 r  |hit-enter| prompt and yes/no questions
 	|hl-StatusLine|	 s  status line of current window |status-line|

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4763,6 +4763,10 @@ DiffText	diff mode: Changed text within a changed line |diff.txt|
 						 {Nvim} *hl-EndOfBuffer*
 EndOfBuffer	filler lines (~) after the end of the buffer.
 		By default, this is highlighted like |hl-NonText|.
+						 {Nvim} *hl-TermCursor*
+TermCursor	cursor in a focused terminal
+						 {Nvim} *hl-TermCursorNC*
+TermCursorNC	cursor in an unfocused terminal
 							*hl-ErrorMsg*
 ErrorMsg	error messages on the command line
 							*hl-VertSplit*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -68,6 +68,8 @@ Events:
 
 Highlight groups:
 - |hl-EndOfBuffer|
+- |hl-TermCursor|
+- |hl-TermCursorNC|
 
 ==============================================================================
 5. Missing legacy features				 *nvim-features-missing*

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -68,7 +68,7 @@ syn keyword vimAutoEvent contained	BufAdd BufCreate BufDelete BufEnter BufFilePo
 syn keyword vimGroup contained	Comment Constant String Character Number Boolean Float Identifier Function Statement Conditional Repeat Label Operator Keyword Exception PreProc Include Define Macro PreCondit Type StorageClass Structure Typedef Special SpecialChar Tag Delimiter SpecialComment Debug Underlined Ignore Error Todo 
 
 " Default highlighting groups {{{2
-syn keyword vimHLGroup contained	ColorColumn Cursor CursorColumn CursorIM CursorLine CursorLineNr DiffAdd DiffChange DiffDelete DiffText Directory EndOfBuffer ErrorMsg FoldColumn Folded IncSearch LineNr MatchParen Menu ModeMsg MoreMsg NonText Normal Pmenu PmenuSbar PmenuSel PmenuThumb Question Scrollbar Search SignColumn SpecialKey SpellBad SpellCap SpellLocal SpellRare StatusLine StatusLineNC TabLine TabLineFill TabLineSel Title Tooltip VertSplit Visual VisualNOS WarningMsg WildMenu 
+syn keyword vimHLGroup contained	ColorColumn Cursor CursorColumn CursorIM CursorLine CursorLineNr DiffAdd DiffChange DiffDelete DiffText Directory EndOfBuffer ErrorMsg FoldColumn Folded IncSearch LineNr MatchParen Menu ModeMsg MoreMsg NonText Normal Pmenu PmenuSbar PmenuSel PmenuThumb Question Scrollbar Search SignColumn SpecialKey SpellBad SpellCap SpellLocal SpellRare StatusLine StatusLineNC TabLine TabLineFill TabLineSel TermCursor TermCursorNC Title Tooltip VertSplit Visual VisualNOS WarningMsg WildMenu
 syn match vimHLGroup contained	"Conceal"
 syn case match
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -404,7 +404,9 @@ EXTERN int no_check_timestamps INIT(= 0);       /* Don't check timestamps */
 typedef enum {
   HLF_8 = 0         /* Meta & special keys listed with ":map", text that is
                        displayed different from what it is */
-  , HLF_EOB         // after the last line in the buffer
+  , HLF_EOB         //< after the last line in the buffer
+  , HLF_TERM        //< terminal cursor focused
+  , HLF_TERMNC      //< terminal cursor unfocused
   , HLF_AT          /* @ characters at end of screen, characters that
                        don't really exist in the text */
   , HLF_D           /* directories in CTRL-D listing */
@@ -451,10 +453,10 @@ typedef enum {
 
 /* The HL_FLAGS must be in the same order as the HLF_ enums!
  * When changing this also adjust the default for 'highlight'. */
-#define HL_FLAGS {'8', '~', '@', 'd', 'e', 'i', 'l', 'm', 'M', 'n', 'N', 'r', \
-                  's', 'S', 'c', 't', 'v', 'V', 'w', 'W', 'f', 'F', 'A', 'C', \
-                  'D', 'T', '-', '>', 'B', 'P', 'R', 'L', '+', '=', 'x', 'X', \
-                  '*', '#', '_', '!', '.', 'o'}
+#define HL_FLAGS {'8', '~', 'z', 'Z', '@', 'd', 'e', 'i', 'l', 'm', 'M', 'n', \
+                  'N', 'r', 's', 'S', 'c', 't', 'v', 'V', 'w', 'W', 'f', 'F', \
+                  'A', 'C', 'D', 'T', '-', '>', 'B', 'P', 'R', 'L', '+', '=', \
+                  'x', 'X', '*', '#', '_', '!', '.', 'o'}
 
 EXTERN int highlight_attr[HLF_COUNT];       /* Highl. attr for each context. */
 EXTERN int highlight_user[9];                   /* User[1-9] attributes */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -363,13 +363,14 @@ typedef struct vimoption {
 # define ISP_LATIN1 (char_u *)"@,161-255"
 
 #define HIGHLIGHT_INIT \
-  "8:SpecialKey,~:EndOfBuffer,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch," \
-  "l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine," \
-  "S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg," \
-  "W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete," \
-  "T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare," \
-  "L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar,X:PmenuThumb,*:TabLine," \
-  "#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn"
+  "8:SpecialKey,~:EndOfBuffer,z:TermCursor,Z:TermCursorNC,@:NonText," \
+  "d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr," \
+  "N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title," \
+  "v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn," \
+  "A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal," \
+  "B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel," \
+  "x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill," \
+  "!:CursorColumn,.:CursorLine,o:ColorColumn"
 
 /*
  * options[] is initialized here.

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5785,6 +5785,8 @@ static char *(highlight_init_both[]) =
       "TabLineSel term=bold cterm=bold gui=bold"),
   CENT("TabLineFill term=reverse cterm=reverse",
       "TabLineFill term=reverse cterm=reverse gui=reverse"),
+  CENT("TermCursor cterm=reverse",
+      "TermCursor cterm=reverse gui=reverse"),
   NULL
 };
 

--- a/test/functional/legacy/051_highlight_spec.lua
+++ b/test/functional/legacy/051_highlight_spec.lua
@@ -24,10 +24,10 @@ describe(':highlight', function()
                          guifg=Blue      |
       EndOfBuffer    xxx links to NonText|
                                          |
+      TermCursor     xxx cterm=reverse   |
+                         gui=reverse     |
+      TermCursorNC   xxx cleared         |
       NonText        xxx ctermfg=12      |
-                         gui=bold        |
-                         guifg=Blue      |
-      Directory      xxx ctermfg=4       |
       -- More --^                         |
     ]])
     feed('q')

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -129,10 +129,8 @@ describe('cursor with customized highlighting', function()
 
   before_each(function()
     clear()
-    nvim('set_var', 'terminal_focused_cursor_highlight', 'CursorFocused')
-    nvim('set_var', 'terminal_unfocused_cursor_highlight', 'CursorUnfocused')
-    nvim('command', 'highlight CursorFocused ctermfg=45 ctermbg=46')
-    nvim('command', 'highlight CursorUnfocused ctermfg=55 ctermbg=56')
+    nvim('command', 'highlight TermCursor ctermfg=45 ctermbg=46 cterm=NONE')
+    nvim('command', 'highlight TermCursorNC ctermfg=55 ctermbg=56 cterm=NONE')
     screen = Screen.new(50, 7)
     screen:set_default_attr_ids({
       [1] = {foreground = 45, background = 46},

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -34,6 +34,8 @@ local function disable_mouse() feed_termcode('[?1002l') end
 
 
 local function screen_setup(extra_height)
+  nvim('command', 'highlight TermCursor cterm=reverse')
+  nvim('command', 'highlight TermCursorNC ctermbg=11')
   nvim('set_var', 'terminal_scrollback_buffer_size', 10)
   if not extra_height then extra_height = 0 end
   local screen = Screen.new(50, 7 + extra_height)


### PR DESCRIPTION
This replaces these variables:
- `{g,b}:terminal_focused_cursor_highlight`
- `{g,b}:terminal_unfocused_cursor_highlight`
