### PR TITLE
[RFC] Remove char_u (1): default_vim{,runtime}_dir #459

### DIFF
--- a/config/pathdef.c.in
+++ b/config/pathdef.c.in
@@ -1,5 +1,5 @@
 #include "${PROJECT_SOURCE_DIR}/src/nvim/vim.h"
-char_u *default_vim_dir = (char_u *)"${CMAKE_INSTALL_PREFIX}/share/nvim";
-char_u *default_vimruntime_dir = (char_u *)"";
+char *default_vim_dir = "${CMAKE_INSTALL_PREFIX}/share/nvim";
+char *default_vimruntime_dir = "";
 char_u *compiled_user = (char_u *)"${USERNAME}";
 char_u *compiled_sys = (char_u *)"${HOSTNAME}";

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -982,8 +982,8 @@ EXTERN char breakat_flags[256];         /* which characters are in 'breakat' */
  * Makefile to make their value depend on the Makefile.
  */
 #ifdef HAVE_PATHDEF
-extern char_u *default_vim_dir;
-extern char_u *default_vimruntime_dir;
+extern char *default_vim_dir;
+extern char *default_vimruntime_dir;
 extern char_u *compiled_user;
 extern char_u *compiled_sys;
 #endif

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -495,13 +495,14 @@ char_u *vim_getenv(char_u *name, bool *mustfree)
   if (p == NULL) {
     /* Only use default_vimruntime_dir when it is not empty */
     if (vimruntime && *default_vimruntime_dir != NUL) {
-      p = default_vimruntime_dir;
+      p = (char_u *)default_vimruntime_dir;
       *mustfree = false;
     } else if (*default_vim_dir != NUL) {
-      if (vimruntime && (p = vim_version_dir(default_vim_dir)) != NULL) {
+      if (vimruntime
+          && (p = vim_version_dir((char_u *)default_vim_dir)) != NULL) {
         *mustfree = true;
       } else {
-        p = default_vim_dir;
+        p = (char_u *)default_vim_dir;
         *mustfree = false;
       }
     }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -915,13 +915,13 @@ void list_version(void)
 
   if (*default_vim_dir != NUL) {
     version_msg(_("  fall-back for $VIM: \""));
-    version_msg((char *)default_vim_dir);
+    version_msg(default_vim_dir);
     version_msg("\"\n");
   }
 
   if (*default_vimruntime_dir != NUL) {
     version_msg(_(" f-b for $VIMRUNTIME: \""));
-    version_msg((char *)default_vimruntime_dir);
+    version_msg(default_vimruntime_dir);
     version_msg("\"\n");
   }
 #endif  // ifdef HAVE_PATHDEF


### PR DESCRIPTION
This is an initial pull just to verify I'm on the right track refactoring char_u for issue #459. 
In light of that, in vim_getenv() I setup casts to keep things working. If it looks good I'll use it as an entry point, and start working the calls that vim_getenv() uses that still have char_u, like remove_tail() and path_tail().
