### PR TITLE
[RFC] Travis: Disable building 'nightly' tag.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: c
 os:
   - linux
+branches:
+  except:
+    - nightly
 env:
   global:
     - CI_SCRIPTS=$TRAVIS_BUILD_DIR/.ci


### PR DESCRIPTION
Reduce the load on Travis a tiny little bit by not building the `nightly` tag.
