### PR TITLE
[RFC] Fix some bugs with clipboard=unnamed

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -914,7 +914,7 @@ getcount:
       && !oap->op_type
       && (idx < 0 || !(nv_cmds[idx].cmd_flags & NV_KEEPREG))) {
     clearop(oap);
-    set_reg_var(0);
+    set_reg_var(get_default_register_name());
   }
 
   /* Get the length of mapped chars again after typing a count, second

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5310,7 +5310,28 @@ static void free_register(struct yankreg *reg)
   y_current = curr;
 }
 
-// return target register
+/// Check if the default register (used in an unnamed paste) should be a
+/// clipboard register. This happens when `clipboard=unnamed[plus]` is set
+/// and a provider is available.
+///
+/// @returns the name of of a clipboard register that should be used, or `NUL` if none.
+int get_default_register_name(void)
+{
+  int name = NUL;
+  adjust_clipboard_name(&name, true, false);
+  return name;
+}
+
+/// Determine if register `*name` should be used as a clipboard.
+/// In an unnammed operation, `*name` is `NUL` and will be adjusted to `'*'/'+'` if
+/// `clipboard=unnamed[plus]` is set.
+///
+/// @param name The name of register, or `NUL` if unnamed.
+/// @param quiet Suppress error messages
+/// @param writing if we're setting the contents of the clipboard
+///
+/// @returns the yankreg that should be used, or `NULL`
+/// if the register isn't a clipboard or provider isn't available.
 static struct yankreg* adjust_clipboard_name(int *name, bool quiet, bool writing) {
   if (*name == '*' || *name == '+') {
     if(!eval_has_provider("clipboard")) {

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -72,6 +72,7 @@ end
 describe('the unnamed register', function()
   before_each(clear)
   it('works without provider', function()
+    eq('"', eval('v:register'))
     basic_register_test()
   end)
 end)
@@ -225,6 +226,13 @@ describe('clipboard usage', function()
         a line
         b line
         a line]])
+    end)
+
+    it('supports v:register and getreg() without parameters', function()
+      eq('*', eval('v:register'))
+      execute("let g:test_clip['*'] = [['some block',''], 'b']")
+      eq('some block', eval('getreg()'))
+      eq('\02210', eval('getregtype()'))
     end)
 
   end)

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -55,6 +55,12 @@ local function basic_register_test(noblock)
     , stuff and some more
     some textsome some text, stuff and some more]])
 
+  -- deleting a line does update ""
+  feed('ggdd""P')
+  expect([[
+    , stuff and some more
+    some textsome some text, stuff and some more]])
+
   feed('ggw<c-v>jwyggP')
   if noblock then
     expect([[


### PR DESCRIPTION
`getreg(v:register)` and `dd""p` are both broken when `clipboard=unnamed`. This might fix #2105 and #1690 (or parts thereof). 

Should have some tests, too. 
