### PR TITLE
[RDY] Fix visual selection after left click on tabline

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2067,6 +2067,7 @@ do_mouse (
   } else if (is_drag && in_tab_line) {
     c1 = TabPageIdxs[mouse_col];
     tabpage_move(c1 <= 0 ? 9999 : c1 - 1);
+    in_tab_line = false;
     return false;
   }
 

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -61,7 +61,7 @@ describe('Mouse input', function()
     local tab_attrs = {
       tab  = { background=Screen.colors.LightGrey, underline=true },
       sel  = { bold=true },
-      fill = { reverse = true }
+      fill = { reverse=true }
     }
     execute('%delete')
     insert('this is foo')
@@ -118,6 +118,43 @@ describe('Mouse input', function()
       ~                        |
       {2:-- VISUAL --}             |
     ]])
+  end)
+
+  it('left drag changes visual selection after tab click', function()
+    local tab_attrs = {
+      tab  = { background=Screen.colors.LightGrey, underline=true },
+      sel  = { bold=true },
+      fill = { reverse=true },
+      vis  = { background=Screen.colors.LightGrey }
+    }
+    execute('silent file foo | tabnew | file bar')
+    insert('this is bar')
+    execute('tabprevious')  -- go to first tab
+    screen:expect([[
+      {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
+      mouse                    |
+      support and selectio^n    |
+      ~                        |
+                               |
+    ]], tab_attrs)
+    feed('<LeftMouse><10,0><LeftRelease>')  -- go to second tab
+    helpers.wait()
+    feed('<LeftMouse><0,1>')
+    screen:expect([[
+      {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+      ^this is bar              |
+      ~                        |
+      ~                        |
+                               |
+    ]], tab_attrs)
+    feed('<LeftDrag><4,1>')
+    screen:expect([[
+      {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+      {vis:this}^ is bar              |
+      ~                        |
+      ~                        |
+      {sel:-- VISUAL --}             |
+    ]], tab_attrs)
   end)
 
   it('two clicks will select the word and enter VISUAL', function()

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -57,6 +57,33 @@ describe('Mouse input', function()
     ]])
   end)
 
+  it('left click in tabline switches to tab', function()
+    local tab_attrs = {
+      tab  = { background=Screen.colors.LightGrey, underline=true },
+      sel  = { bold=true },
+      fill = { reverse = true }
+    }
+    execute('%delete')
+    insert('this is foo')
+    execute('silent file foo | tabnew | file bar')
+    insert('this is bar')
+    screen:expect([[
+      {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+      this is ba^r              |
+      ~                        |
+      ~                        |
+                               |
+    ]], tab_attrs)
+    feed('<LeftMouse><4,0>')
+    screen:expect([[
+      {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
+      this is fo^o              |
+      ~                        |
+      ~                        |
+                               |
+    ]], tab_attrs)
+  end)
+
   it('left drag changes visual selection', function()
     -- drag events must be preceded by a click
     feed('<LeftMouse><2,1>')


### PR DESCRIPTION
After left clicking on a tab in the tabline, the `in_tab_line` variable wasn't
set to `false` and every following mouse action assumed still being on the
tabline which messed up visual selection etc.

References #2382.
