### PR TITLE
[RFC] Fix coverity issues. (7)

### DIFF
--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -59,12 +59,12 @@
 /* Use our own isdigit() replacement, because on MS-Windows isdigit() returns
  * non-zero for superscript 1.  Also avoids that isdigit() crashes for numbers
  * below 0 and above 255.  */
-#define VIM_ISDIGIT(c) ((unsigned)(c) - '0' < 10)
+#define VIM_ISDIGIT(c) ((unsigned)(c) >= '0' && (unsigned)(c) <= '9')
 
 /* Like isalpha() but reject non-ASCII characters.  Can't be used with a
  * special key (negative value). */
-# define ASCII_ISLOWER(c) ((unsigned)(c) - 'a' < 26)
-# define ASCII_ISUPPER(c) ((unsigned)(c) - 'A' < 26)
+# define ASCII_ISLOWER(c) ((unsigned)(c) >= 'a' && (unsigned)(c) <= 'z')
+# define ASCII_ISUPPER(c) ((unsigned)(c) >= 'A' && (unsigned)(c) <= 'Z')
 # define ASCII_ISALPHA(c) (ASCII_ISUPPER(c) || ASCII_ISLOWER(c))
 # define ASCII_ISALNUM(c) (ASCII_ISALPHA(c) || VIM_ISDIGIT(c))
 


### PR DESCRIPTION
Fix 9 coverity issues.

All these issues are false positives that result from coverity's
inability to properly follow arithmetic implications in expressions
using some macros. Redefining some macros another way to make arithmetic
implications clearer fixes the issues.
