### PR TITLE
[RFC] cleanup register handling and fix missing clipboard support in `:redir`

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -6762,7 +6762,7 @@ static void ins_reg(void)
       AppendCharToRedobuff(literally);
       AppendCharToRedobuff(regname);
 
-      do_put(regname, BACKWARD, 1L,
+      do_put(regname, NULL, BACKWARD, 1L,
           (literally == Ctrl_P ? PUT_FIXINDENT : 0) | PUT_CURSEND);
     } else if (insert_reg(regname, literally) == FAIL) {
       vim_beep();

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -6752,7 +6752,7 @@ static void ins_reg(void)
 
     regname = get_expr_register();
   }
-  if (regname == NUL || !valid_yank_reg(regname, FALSE)) {
+  if (regname == NUL || !valid_yank_reg(regname, false)) {
     vim_beep();
     need_redraw = TRUE;         /* remove the '"' */
   } else {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -13629,13 +13629,12 @@ static void f_setreg(typval_T *argvars, typval_T *rettv)
   int regname;
   char_u      *strregname;
   char_u      *stropt;
-  int append;
+  bool append = false;
   char_u yank_type;
   long block_len;
 
   block_len = -1;
   yank_type = MAUTO;
-  append = FALSE;
 
   strregname = get_tv_string_chk(argvars);
   rettv->vval.v_number = 1;             /* FAIL is default */
@@ -13653,7 +13652,7 @@ static void f_setreg(typval_T *argvars, typval_T *rettv)
     for (; *stropt != NUL; ++stropt)
       switch (*stropt) {
       case 'a': case 'A':               /* append */
-        append = TRUE;
+        append = true;
         break;
       case 'v': case 'c':               /* character-wise selection */
         yank_type = MCHAR;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6487,7 +6487,7 @@ static void ex_operators(exarg_T *eap)
 
   case CMD_yank:
     oa.op_type = OP_YANK;
-    (void)op_yank(&oa, FALSE, TRUE);
+    (void)op_yank(&oa, true);
     break;
 
   default:          /* CMD_rshift or CMD_lshift */

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6515,7 +6515,7 @@ static void ex_put(exarg_T *eap)
     eap->forceit = TRUE;
   }
   curwin->w_cursor.lnum = eap->line2;
-  do_put(eap->regname, eap->forceit ? BACKWARD : FORWARD, 1L,
+  do_put(eap->regname, NULL, eap->forceit ? BACKWARD : FORWARD, 1L,
       PUT_LINE|PUT_CURSLINE);
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6738,8 +6738,7 @@ static void ex_redir(exarg_T *eap)
       /* redirect to a register a-z (resp. A-Z for appending) */
       close_redir();
       ++arg;
-      if (ASCII_ISALPHA(*arg)
-          || *arg == '"') {
+      if (valid_yank_reg(*arg, true) && *arg != '_') {
         redir_reg = *arg++;
         if (*arg == '>' && arg[1] == '>')          /* append */
           arg += 2;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2318,7 +2318,7 @@ cmdline_paste (
   /* check for valid regname; also accept special characters for CTRL-R in
    * the command line */
   if (regname != Ctrl_F && regname != Ctrl_P && regname != Ctrl_W
-      && regname != Ctrl_A && !valid_yank_reg(regname, FALSE))
+      && regname != Ctrl_A && !valid_yank_reg(regname, false))
     return FAIL;
 
   /* A register containing CTRL-R can cause an endless loop.  Allow using

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1541,7 +1541,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
           CancelRedo();
         }
       } else
-        (void)op_yank(oap, false, !gui_yank);
+        (void)op_yank(oap, !gui_yank);
       check_cursor_col();
       break;
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -714,15 +714,13 @@ char_u *get_expr_line_src(void)
   return vim_strsave(expr_line);
 }
 
-/*
- * Check if 'regname' is a valid name of a yank register.
- * Note: There is no check for 0 (default register), caller should do this
- */
-int 
-valid_yank_reg (
-    int regname,
-    int writing                /* if TRUE check for writable registers */
-)
+/// Returns whether `regname` is a valid name of a yank register.
+/// Note: There is no check for 0 (default register), caller should do this.
+/// The black hole register '_' is regarded as valid.
+///
+/// @param regname name of register
+/// @param writing allow only writable registers
+bool valid_yank_reg(int regname, bool writing)
 {
   if (       (regname > 0 && ASCII_ISALNUM(regname))
              || (!writing && vim_strchr((char_u *)
@@ -734,8 +732,8 @@ valid_yank_reg (
              || regname == '*'
              || regname == '+'
              )
-    return TRUE;
-  return FALSE;
+    return true;
+  return false;
 }
 
 typedef enum {
@@ -826,7 +824,7 @@ yankreg_T *copy_register(int name)
  */
 int yank_register_mline(int regname)
 {
-  if (regname != 0 && !valid_yank_reg(regname, FALSE))
+  if (regname != 0 && !valid_yank_reg(regname, false))
     return FALSE;
   if (regname == '_')           /* black hole is always empty */
     return FALSE;
@@ -894,7 +892,7 @@ int do_record(int c)
 static int stuff_yank(int regname, char_u *p)
 {
   /* check for read-only register */
-  if (regname != 0 && !valid_yank_reg(regname, TRUE)) {
+  if (regname != 0 && !valid_yank_reg(regname, true)) {
     xfree(p);
     return FAIL;
   }
@@ -950,7 +948,7 @@ do_execreg (
     regname = execreg_lastc;
   }
   /* check for valid regname */
-  if (regname == '%' || regname == '#' || !valid_yank_reg(regname, FALSE)) {
+  if (regname == '%' || regname == '#' || !valid_yank_reg(regname, false)) {
     emsg_invreg(regname);
     return FAIL;
   }
@@ -1116,7 +1114,7 @@ insert_reg (
     return FAIL;
 
   /* check for valid regname */
-  if (regname != NUL && !valid_yank_reg(regname, FALSE))
+  if (regname != NUL && !valid_yank_reg(regname, false))
     return FAIL;
 
   if (regname == '.')                   /* insert last inserted text */
@@ -2307,7 +2305,7 @@ bool op_yank(oparg_T *oap, bool message)
   FUNC_ATTR_NONNULL_ALL
 {
   // check for read-only register
-  if (oap->regname != 0 && !valid_yank_reg(oap->regname, TRUE)) {
+  if (oap->regname != 0 && !valid_yank_reg(oap->regname, true)) {
     beep_flush();
     return false;
   }
@@ -4621,7 +4619,7 @@ char_u get_reg_type(int regname, long *reglen)
     return MCHAR;
   }
 
-  if (regname != NUL && !valid_yank_reg(regname, FALSE))
+  if (regname != NUL && !valid_yank_reg(regname, false))
     return MAUTO;
 
   yankreg_T *reg = get_yank_register(regname, YREG_PASTE);
@@ -4677,7 +4675,7 @@ void *get_reg_contents(int regname, int flags)
     regname = '"';
 
   /* check for valid regname */
-  if (regname != NUL && !valid_yank_reg(regname, FALSE))
+  if (regname != NUL && !valid_yank_reg(regname, false))
     return NULL;
 
   char_u *retval;

--- a/src/nvim/ops.h
+++ b/src/nvim/ops.h
@@ -47,6 +47,14 @@ typedef int (*Indenter)(void);
 #define OP_FORMAT2      26      /* "gw" format operator, keeps cursor pos */
 #define OP_FUNCTION     27      /* "g@" call 'operatorfunc' */
 
+/// Contents of a yank (read-write) register
+typedef struct yankreg {
+  char_u      **y_array;        ///< pointer to array of line pointers
+  linenr_T y_size;              ///< number of lines in y_array
+  char_u y_type;                ///< MLINE, MCHAR or MBLOCK
+  colnr_T y_width;              ///< only set if y_type == MBLOCK
+} yankreg_T;
+
 /// Flags for get_reg_contents().
 enum GRegFlags {
   kGRegNoExpr  = 1,  ///< Do not allow expression register.

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -305,4 +305,28 @@ describe('clipboard usage', function()
     feed(':<c-r>*<cr>')
     expect('t/u/t/')
   end)
+
+  it('supports :redir @*>', function()
+    execute("let g:test_clip['*'] = ['stuff']")
+    execute('redir @*>')
+    -- it is made empty
+    eq({{''}, 'v'}, eval("g:test_clip['*']"))
+    execute('let g:test = doesnotexist')
+    feed('<cr>')
+    eq({{
+      '',
+      '',
+      'E121: Undefined variable: doesnotexist',
+      'E15: Invalid expression: doesnotexist',
+    }, 'v'}, eval("g:test_clip['*']"))
+    execute(':echo "Howdy!"')
+    eq({{
+      '',
+      '',
+      'E121: Undefined variable: doesnotexist',
+      'E15: Invalid expression: doesnotexist',
+      '',
+      'Howdy!',
+    }, 'v'}, eval("g:test_clip['*']"))
+  end)
 end)

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -73,6 +73,12 @@ local function basic_register_test(noblock)
       stuf, stuff and some more
       me tsome textsome some text, stuff and some more]])
   end
+
+  -- pasting in visual does unnamed delete of visual selection
+  feed('ggdG')
+  insert("one and two and three")
+  feed('"ayiwbbviw"ap^viwp$viw"-p')
+  expect("two and three and one")
 end
 
 describe('the unnamed register', function()
@@ -239,6 +245,14 @@ describe('clipboard usage', function()
       execute("let g:test_clip['*'] = [['some block',''], 'b']")
       eq('some block', eval('getreg()'))
       eq('\02210', eval('getregtype()'))
+    end)
+
+    it('yanks visual selection when pasting', function()
+      insert("indeed visual")
+      execute("let g:test_clip['*'] = [['clipboard'], 'c']")
+      feed("viwp")
+      eq({{'visual'}, 'v'}, eval("g:test_clip['*']"))
+      expect("indeed clipboard")
     end)
 
   end)


### PR DESCRIPTION
Remove static `y_current` and `y_append` and pass `yankreg`s as arguments/return values instead. Eliminates some code of this style:

```
  struct yankreg *curr = y_current;
  // Set it to 'y_current' since 'free_yank_all' operates on it
  y_current = reg;
  free_yank_all();
  // Restore 'y_current'
  y_current = curr;
```

Also make paste in visual mode (`viwp` and such) simpler and avoid spurious clipboard provider calls when `clipboard=unnamed`. 

Some more work to be done like cleaning up bools and function docs.
