### PR TITLE
[RFC] Remove char_u (4)

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -808,7 +808,7 @@ static void diff_file(char_u *tmp_orig, char_u *tmp_new, char_u *tmp_diff)
 
     /* We don't want $DIFF_OPTIONS to get in the way. */
     if (os_getenv("DIFF_OPTIONS")) {
-      vim_setenv((char_u *)"DIFF_OPTIONS", (char_u *)"");
+      vim_setenv("DIFF_OPTIONS", "");
     }
 
     /* Build the diff command and execute it.  Always use -a, binary

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1751,13 +1751,11 @@ ex_let_one (
         name[len] = NUL;
         p = get_tv_string_chk(tv);
         if (p != NULL && op != NULL && *op == '.') {
-          bool mustfree = false;
-          char *s = vim_getenv((char *)name, &mustfree);
+          char *s = vim_getenv((char *)name);
 
           if (s != NULL) {
             p = tofree = concat_str((char_u *)s, p);
-            if (mustfree)
-              xfree(s);
+            xfree(s);
           }
         }
         if (p != NULL) {
@@ -6357,7 +6355,6 @@ static int get_env_tv(char_u **arg, typval_T *rettv, int evaluate)
 {
   char_u *name;
   char_u *string = NULL;
-  bool    mustfree = false;
   int     len;
   int     cc;
 
@@ -6372,15 +6369,9 @@ static int get_env_tv(char_u **arg, typval_T *rettv, int evaluate)
     cc = name[len];
     name[len] = NUL;
     // First try vim_getenv(), fast for normal environment vars.
-    string = (char_u *)vim_getenv((char *)name, &mustfree);
-    if (string != NULL && *string != NUL) {
-      if (!mustfree) {
-        string = vim_strsave(string);
-      }
-    } else {
-      if (mustfree) {
-        xfree(string);
-      }
+    string = (char_u *)vim_getenv((char *)name);
+    if (string == NULL || *string == NUL) {
+      xfree(string);
 
       // Next try expanding things like $VIM and ${HOME}.
       string = expand_env_save(name - 1);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1752,10 +1752,10 @@ ex_let_one (
         p = get_tv_string_chk(tv);
         if (p != NULL && op != NULL && *op == '.') {
           bool mustfree = false;
-          char_u  *s = vim_getenv(name, &mustfree);
+          char *s = vim_getenv((char *)name, &mustfree);
 
           if (s != NULL) {
-            p = tofree = concat_str(s, p);
+            p = tofree = concat_str((char_u *)s, p);
             if (mustfree)
               xfree(s);
           }
@@ -6372,7 +6372,7 @@ static int get_env_tv(char_u **arg, typval_T *rettv, int evaluate)
     cc = name[len];
     name[len] = NUL;
     // First try vim_getenv(), fast for normal environment vars.
-    string = vim_getenv(name, &mustfree);
+    string = (char_u *)vim_getenv((char *)name, &mustfree);
     if (string != NULL && *string != NUL) {
       if (!mustfree) {
         string = vim_strsave(string);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1761,7 +1761,7 @@ ex_let_one (
           }
         }
         if (p != NULL) {
-          vim_setenv(name, p);
+          vim_setenv((char *)name, (char *)p);
           if (STRICMP(name, "HOME") == 0)
             init_homedir();
           else if (didset_vim && STRICMP(name, "VIM") == 0)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12417,7 +12417,7 @@ static void f_resolve(typval_T *argvars, typval_T *rettv)
       is_relative_to_current = TRUE;
 
     len = STRLEN(p);
-    if (len > 0 && after_pathsep(p, p + len)) {
+    if (len > 0 && after_pathsep((char *)p, (char *)p + len)) {
       has_trailing_pathsep = TRUE;
       p[len - 1] = NUL;       /* the trailing slash breaks readlink() */
     }
@@ -12531,7 +12531,7 @@ static void f_resolve(typval_T *argvars, typval_T *rettv)
      * if the argument had none.  But keep "/" or "//". */
     if (!has_trailing_pathsep) {
       q = p + STRLEN(p);
-      if (after_pathsep(p, q))
+      if (after_pathsep((char *)p, (char *)q))
         *path_tail_with_sep(p) = NUL;
     }
 
@@ -19921,7 +19921,7 @@ repeat:
     valid |= VALID_HEAD;
     *usedlen += 2;
     s = get_past_head(*fnamep);
-    while (tail > s && after_pathsep(s, tail))
+    while (tail > s && after_pathsep((char *)s, (char *)tail))
       mb_ptr_back(*fnamep, tail);
     *fnamelen = (int)(tail - *fnamep);
     if (*fnamelen == 0) {
@@ -19930,7 +19930,7 @@ repeat:
       *bufp = *fnamep = tail = vim_strsave((char_u *)".");
       *fnamelen = 1;
     } else {
-      while (tail > s && !after_pathsep(s, tail))
+      while (tail > s && !after_pathsep((char *)s, (char *)tail))
         mb_ptr_back(*fnamep, tail);
     }
   }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5061,7 +5061,6 @@ void fix_help_buffer(void)
   char_u      *fname;
   char_u      *p;
   char_u      *rt;
-  bool mustfree;
 
   /* set filetype to "help". */
   set_option_value((char_u *)"ft", 0L, (char_u *)"help", OPT_LOCAL);
@@ -5116,8 +5115,7 @@ void fix_help_buffer(void)
       p = p_rtp;
       while (*p != NUL) {
         copy_option_part(&p, NameBuff, MAXPATHL, ",");
-        mustfree = FALSE;
-        rt = (char_u *)vim_getenv("VIMRUNTIME", &mustfree);
+        rt = (char_u *)vim_getenv("VIMRUNTIME");
         if (path_full_compare(rt, NameBuff, FALSE) != kEqualFiles) {
           int fcount;
           char_u      **fnames;
@@ -5242,8 +5240,7 @@ void fix_help_buffer(void)
             FreeWild(fcount, fnames);
           }
         }
-        if (mustfree)
-          xfree(rt);
+        xfree(rt);
       }
       break;
     }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5117,7 +5117,7 @@ void fix_help_buffer(void)
       while (*p != NUL) {
         copy_option_part(&p, NameBuff, MAXPATHL, ",");
         mustfree = FALSE;
-        rt = vim_getenv((char_u *)"VIMRUNTIME", &mustfree);
+        rt = (char_u *)vim_getenv("VIMRUNTIME", &mustfree);
         if (path_full_compare(rt, NameBuff, FALSE) != kEqualFiles) {
           int fcount;
           char_u      **fnames;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3127,22 +3127,20 @@ void ex_language(exarg_T *eap)
       ++_nl_msg_cat_cntr;
 #endif
       /* Reset $LC_ALL, otherwise it would overrule everything. */
-      vim_setenv((char_u *)"LC_ALL", (char_u *)"");
+      vim_setenv("LC_ALL", "");
 
       if (what != LC_TIME) {
         /* Tell gettext() what to translate to.  It apparently doesn't
          * use the currently effective locale. */
         if (what == LC_ALL) {
-          vim_setenv((char_u *)"LANG", name);
+          vim_setenv("LANG", (char *)name);
 
           /* Clear $LANGUAGE because GNU gettext uses it. */
-          vim_setenv((char_u *)"LANGUAGE", (char_u *)"");
+          vim_setenv("LANGUAGE", "");
         }
         if (what != LC_CTYPE) {
-          char_u      *mname;
-          mname = name;
-          vim_setenv((char_u *)"LC_MESSAGES", mname);
-          set_helplang_default(mname);
+          vim_setenv("LC_MESSAGES", (char *)name);
+          set_helplang_default((char *)name);
         }
       }
 

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2970,26 +2970,26 @@ static char *get_locale_val(int what)
  * Obtain the current messages language.  Used to set the default for
  * 'helplang'.  May return NULL or an empty string.
  */
-char_u *get_mess_lang(void)
+char *get_mess_lang(void)
 {
-  char_u *p;
+  char *p;
 
 # ifdef HAVE_GET_LOCALE_VAL
 #  if defined(LC_MESSAGES)
-  p = (char_u *)get_locale_val(LC_MESSAGES);
+  p = get_locale_val(LC_MESSAGES);
 #  else
   /* This is necessary for Win32, where LC_MESSAGES is not defined and $LANG
    * may be set to the LCID number.  LC_COLLATE is the best guess, LC_TIME
    * and LC_MONETARY may be set differently for a Japanese working in the
    * US. */
-  p = (char_u *)get_locale_val(LC_COLLATE);
+  p = get_locale_val(LC_COLLATE);
 #  endif
 # else
-  p = os_getenv((char_u *)"LC_ALL");
+  p = os_getenv("LC_ALL");
   if (p == NULL || *p == NUL) {
-    p = os_getenv((char_u *)"LC_MESSAGES");
+    p = os_getenv("LC_MESSAGES");
     if (p == NULL || *p == NUL)
-      p = os_getenv((char_u *)"LANG");
+      p = os_getenv("LANG");
   }
 # endif
   return p;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3849,7 +3849,7 @@ static void expand_shellcmd(char_u *filepat, int *num_file, char_u ***file,
                               || (pat[1] == '.' && vim_ispathsep(pat[2])))))
     path = (char_u *)".";
   else {
-    path = vim_getenv((char_u *)"PATH", &mustfree);
+    path = (char_u *)vim_getenv("PATH", &mustfree);
     if (path == NULL)
       path = (char_u *)"";
   }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3825,7 +3825,6 @@ static void expand_shellcmd(char_u *filepat, int *num_file, char_u ***file,
   char_u      *pat;
   int i;
   char_u      *path;
-  bool mustfree = false;
   garray_T ga;
   char_u *buf = xmalloc(MAXPATHL);
   size_t l;
@@ -3849,7 +3848,7 @@ static void expand_shellcmd(char_u *filepat, int *num_file, char_u ***file,
                               || (pat[1] == '.' && vim_ispathsep(pat[2])))))
     path = (char_u *)".";
   else {
-    path = (char_u *)vim_getenv("PATH", &mustfree);
+    path = (char_u *)vim_getenv("PATH");
     if (path == NULL)
       path = (char_u *)"";
   }
@@ -3900,8 +3899,7 @@ static void expand_shellcmd(char_u *filepat, int *num_file, char_u ***file,
 
   xfree(buf);
   xfree(pat);
-  if (mustfree)
-    xfree(path);
+  xfree(path);
 }
 
 /*

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -422,7 +422,7 @@ readfile (
    */
   if (fname != NULL && *fname != NUL) {
     p = fname + STRLEN(fname);
-    if (after_pathsep(fname, p) || STRLEN(fname) >= MAXPATHL) {
+    if (after_pathsep((char *)fname, (char *)p) || STRLEN(fname) >= MAXPATHL) {
       filemess(curbuf, fname, (char_u *)_("Illegal file name"), 0);
       msg_end();
       msg_scroll = msg_save;
@@ -4369,7 +4369,7 @@ modname (
       xfree(retval);
       return NULL;
     }
-    if (!after_pathsep(retval, retval + fnamelen)) {
+    if (!after_pathsep((char *)retval, (char *)retval + fnamelen)) {
       retval[fnamelen++] = PATHSEP;
       retval[fnamelen] = NUL;
     }

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -834,7 +834,7 @@ static void init_locale(void)
 
     /* expand_env() doesn't work yet, because chartab[] is not initialized
      * yet, call vim_getenv() directly */
-    p = vim_getenv((char_u *)"VIMRUNTIME", &mustfree);
+    p = (char_u *)vim_getenv("VIMRUNTIME", &mustfree);
     if (p != NULL && *p != NUL) {
       vim_snprintf((char *)NameBuff, MAXPATHL, "%s/lang", p);
       bindtextdomain(VIMPACKAGE, (char *)NameBuff);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -829,18 +829,16 @@ static void init_locale(void)
 # endif
 
   {
-    bool mustfree = false;
     char_u  *p;
 
     /* expand_env() doesn't work yet, because chartab[] is not initialized
      * yet, call vim_getenv() directly */
-    p = (char_u *)vim_getenv("VIMRUNTIME", &mustfree);
+    p = (char_u *)vim_getenv("VIMRUNTIME");
     if (p != NULL && *p != NUL) {
       vim_snprintf((char *)NameBuff, MAXPATHL, "%s/lang", p);
       bindtextdomain(VIMPACKAGE, (char *)NameBuff);
     }
-    if (mustfree)
-      xfree(p);
+    xfree(p);
     textdomain(VIMPACKAGE);
   }
   TIME_MSG("locale set");

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1340,7 +1340,7 @@ recover_names (
         num_names = 3;
       } else {
         p = dir_name + STRLEN(dir_name);
-        if (after_pathsep(dir_name, p) && p[-1] == p[-2]) {
+        if (after_pathsep((char *)dir_name, (char *)p) && p[-1] == p[-2]) {
           /* Ends with '//', Use Full path for swap name */
           tail = make_percent_swname(dir_name, fname_res);
         } else {
@@ -3066,7 +3066,7 @@ char_u *makeswapname(char_u *fname, char_u *ffname, buf_T *buf, char_u *dir_name
 #endif
 
   s = dir_name + STRLEN(dir_name);
-  if (after_pathsep(dir_name, s) && s[-1] == s[-2]) { /* Ends with '//', Use Full path */
+  if (after_pathsep((char *)dir_name, (char *)s) && s[-1] == s[-2]) { /* Ends with '//', Use Full path */
     r = NULL;
     if ((s = make_percent_swname(dir_name, fname)) != NULL) {
       r = modname(s, (char_u *)".swp", FALSE);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1804,19 +1804,20 @@ void set_init_1(void)
 # endif
     int len;
     garray_T ga;
-    bool mustfree;
 
     ga_init(&ga, 1, 100);
     for (size_t n = 0; n < ARRAY_SIZE(names); ++n) {
-      mustfree = FALSE;
+      bool mustfree = true;
 # ifdef UNIX
-      if (*names[n] == NUL)
+      if (*names[n] == NUL) {
         p = (char_u *)"/tmp";
+        mustfree = false;
+      }
       else
 # endif
-      p = (char_u *)vim_getenv(names[n], &mustfree);
+      p = (char_u *)vim_getenv(names[n]);
       if (p != NULL && *p != NUL) {
-        /* First time count the NUL, otherwise count the ','. */
+        // First time count the NUL, otherwise count the ','.
         len = (int)STRLEN(p) + 3;
         ga_grow(&ga, len);
         if (!GA_EMPTY(&ga))
@@ -1826,8 +1827,9 @@ void set_init_1(void)
         STRCAT(ga.ga_data, "*");
         ga.ga_len += len;
       }
-      if (mustfree)
+      if(mustfree) {
         xfree(p);
+      }
     }
     if (ga.ga_data != NULL) {
       set_string_default("bsk", ga.ga_data);
@@ -1861,10 +1863,9 @@ void set_init_1(void)
     char_u  *buf;
     int i;
     int j;
-    bool mustfree = false;
 
     /* Initialize the 'cdpath' option's default value. */
-    cdpath = (char_u *)vim_getenv("CDPATH", &mustfree);
+    cdpath = (char_u *)vim_getenv("CDPATH");
     if (cdpath != NULL) {
       buf = xmalloc(2 * STRLEN(cdpath) + 2);
       {
@@ -1887,8 +1888,7 @@ void set_init_1(void)
         } else
           xfree(buf);           /* cannot happen */
       }
-      if (mustfree)
-        xfree(cdpath);
+      xfree(cdpath);
     }
   }
 
@@ -7428,11 +7428,10 @@ static void paste_option_changed(void)
 /// When "fname" is not NULL, use it to set $"envname" when it wasn't set yet.
 void vimrc_found(char_u *fname, char_u *envname)
 {
-  bool dofree = false;
   char_u      *p;
 
   if (fname != NULL) {
-    p = (char_u *)vim_getenv((char *)envname, &dofree);
+    p = (char_u *)vim_getenv((char *)envname);
     if (p == NULL) {
       /* Set $MYVIMRC to the first vimrc file found. */
       p = FullName_save(fname, FALSE);
@@ -7440,8 +7439,9 @@ void vimrc_found(char_u *fname, char_u *envname)
         vim_setenv((char *)envname, (char *)p);
         xfree(p);
       }
-    } else if (dofree)
+    } else {
       xfree(p);
+    }
   }
 }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2039,7 +2039,7 @@ void set_init_1(void)
   }
 
   /* Set the default for 'helplang'. */
-  set_helplang_default((char *)get_mess_lang());
+  set_helplang_default(get_mess_lang());
 }
 
 /*

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2288,7 +2288,7 @@ void set_init_3(void)
  * When 'helplang' is still at its default value, set it to "lang".
  * Only the first two characters of "lang" are used.
  */
-void set_helplang_default(char_u *lang)
+void set_helplang_default(const char *lang)
 {
   int idx;
 
@@ -3644,11 +3644,11 @@ did_set_string_option (
   else if (varp == &p_hf) {
     /* May compute new values for $VIM and $VIMRUNTIME */
     if (didset_vim) {
-      vim_setenv((char_u *)"VIM", (char_u *)"");
+      vim_setenv("VIM", "");
       didset_vim = FALSE;
     }
     if (didset_vimruntime) {
-      vim_setenv((char_u *)"VIMRUNTIME", (char_u *)"");
+      vim_setenv("VIMRUNTIME", "");
       didset_vimruntime = FALSE;
     }
   }
@@ -7437,7 +7437,7 @@ void vimrc_found(char_u *fname, char_u *envname)
       /* Set $MYVIMRC to the first vimrc file found. */
       p = FullName_save(fname, FALSE);
       if (p != NULL) {
-        vim_setenv(envname, p);
+        vim_setenv((char *)envname, (char *)p);
         xfree(p);
       }
     } else if (dofree)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2039,7 +2039,7 @@ void set_init_1(void)
   }
 
   /* Set the default for 'helplang'. */
-  set_helplang_default(get_mess_lang());
+  set_helplang_default((char *)get_mess_lang());
 }
 
 /*
@@ -2298,7 +2298,7 @@ void set_helplang_default(const char *lang)
   if (idx >= 0 && !(options[idx].flags & P_WAS_SET)) {
     if (options[idx].flags & P_ALLOCED)
       free_string_option(p_hlg);
-    p_hlg = vim_strsave(lang);
+    p_hlg = (char_u *)xstrdup(lang);
     /* zh_CN becomes "cn", zh_TW becomes "tw". */
     if (STRNICMP(p_hlg, "zh_", 3) == 0 && STRLEN(p_hlg) >= 5) {
       p_hlg[0] = (char_u)TOLOWER_ASC(p_hlg[3]);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1814,7 +1814,7 @@ void set_init_1(void)
         p = (char_u *)"/tmp";
       else
 # endif
-      p = vim_getenv((char_u *)names[n], &mustfree);
+      p = (char_u *)vim_getenv(names[n], &mustfree);
       if (p != NULL && *p != NUL) {
         /* First time count the NUL, otherwise count the ','. */
         len = (int)STRLEN(p) + 3;
@@ -1864,7 +1864,7 @@ void set_init_1(void)
     bool mustfree = false;
 
     /* Initialize the 'cdpath' option's default value. */
-    cdpath = vim_getenv((char_u *)"CDPATH", &mustfree);
+    cdpath = (char_u *)vim_getenv("CDPATH", &mustfree);
     if (cdpath != NULL) {
       buf = xmalloc(2 * STRLEN(cdpath) + 2);
       {
@@ -7432,7 +7432,7 @@ void vimrc_found(char_u *fname, char_u *envname)
   char_u      *p;
 
   if (fname != NULL) {
-    p = vim_getenv(envname, &dofree);
+    p = (char_u *)vim_getenv((char *)envname, &dofree);
     if (p == NULL) {
       /* Set $MYVIMRC to the first vimrc file found. */
       p = FullName_save(fname, FALSE);

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -343,7 +343,7 @@ void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, bool esc, bool one,
         c = (int)STRLEN(var);
         /* if var[] ends in a path separator and tail[] starts
          * with it, skip a character */
-        if (*var != NUL && after_pathsep(dst, dst + c)
+        if (*var != NUL && after_pathsep((char *)dst, (char *)dst + c)
 #if defined(BACKSLASH_IN_FILENAME)
             && dst[-1] != ':'
 #endif
@@ -410,7 +410,7 @@ static char *remove_tail(char *p, char *pend, char *name)
 
   if (newend >= p
       && fnamencmp((char_u *)newend, (char_u *)name, len - 1) == 0
-      && (newend == p || after_pathsep((char_u *)p, (char_u *)newend)))
+      && (newend == p || after_pathsep(p, newend)))
     return newend;
   return pend;
 }
@@ -488,7 +488,7 @@ char_u *vim_getenv(char_u *name, bool *mustfree)
       }
 
       /* remove trailing path separator */
-      if (pend > p && after_pathsep(p, pend))
+      if (pend > p && after_pathsep((char *)p, (char *)pend))
         --pend;
 
       // check that the result is a directory name

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -215,31 +215,29 @@ void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, bool esc, bool one,
   int c;
   char_u      *var;
   bool copy_char;
-  bool mustfree;                 /* var was allocated, need to free it later */
-  bool at_start = true;           /* at start of a name */
+  bool mustfree;  // var was allocated, need to free it later
+  bool at_start = true;  // at start of a name
   int startstr_len = 0;
 
   if (startstr != NULL)
     startstr_len = (int)STRLEN(startstr);
 
   src = skipwhite(srcp);
-  --dstlen;                 /* leave one char space for "\," */
+  --dstlen;  // leave one char space for "\,"
   while (*src && dstlen > 0) {
     copy_char = true;
     if ((*src == '$') || (*src == '~' && at_start)) {
       mustfree = false;
 
-      /*
-       * The variable name is copied into dst temporarily, because it may
-       * be a string in read-only memory and a NUL needs to be appended.
-       */
-      if (*src != '~') {                                /* environment var */
+      // The variable name is copied into dst temporarily, because it may
+      // be a string in read-only memory and a NUL needs to be appended.
+      if (*src != '~') {  // environment var
         tail = src + 1;
         var = dst;
         c = dstlen - 1;
 
 #ifdef UNIX
-        /* Unix has ${var-name} type environment vars */
+        // Unix has ${var-name} type environment vars
         if (*tail == '{' && !vim_isIDc('{')) {
           tail++;               /* ignore '{' */
           while (c-- > 0 && *tail && *tail != '}')
@@ -262,7 +260,8 @@ void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, bool esc, bool one,
           }
 #endif
         *var = NUL;
-        var = (char_u *)vim_getenv((char *)dst, &mustfree);
+        var = (char_u *)vim_getenv((char *)dst);
+        mustfree = true;
 #if defined(UNIX)
         }
 #endif
@@ -271,11 +270,9 @@ void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, bool esc, bool one,
                  || vim_strchr((char_u *)" ,\t\n", src[1]) != NULL) {
         var = homedir;
         tail = src + 1;
-      } else {                                        /* user directory */
+      } else {  // user directory
 #if defined(UNIX)
-        /*
-         * Copy ~user to dst[], so we can put a NUL after it.
-         */
+        // Copy ~user to dst[], so we can put a NUL after it.
         tail = src;
         var = dst;
         c = dstlen - 1;
@@ -285,12 +282,10 @@ void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, bool esc, bool one,
                    && !vim_ispathsep(*tail))
           *var++ = *tail++;
         *var = NUL;
-        /*
-         * Use os_get_user_directory() to get the user directory.
-         * If this function fails, the shell is used to
-         * expand ~user. This is slower and may fail if the shell
-         * does not support ~user (old versions of /bin/sh).
-         */
+        // Use os_get_user_directory() to get the user directory.
+        // If this function fails, the shell is used to
+        // expand ~user. This is slower and may fail if the shell
+        // does not support ~user (old versions of /bin/sh).
         var = (char_u *)os_get_user_directory((char *)dst + 1);
         mustfree = true;
         if (var == NULL)
@@ -304,15 +299,15 @@ void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, bool esc, bool one,
           mustfree = true;
         }
 #else
-        /* cannot expand user's home directory, so don't try */
+        // cannot expand user's home directory, so don't try
         var = NULL;
-        tail = (char_u *)"";            /* for gcc */
-#endif /* UNIX */
+        tail = (char_u *)"";  // for gcc
+#endif  // UNIX
       }
 
 #ifdef BACKSLASH_IN_FILENAME
-      /* If 'shellslash' is set change backslashes to forward slashes.
-       * Can't use slash_adjust(), p_ssl may be set temporarily. */
+      // If 'shellslash' is set change backslashes to forward slashes.
+      // Can't use slash_adjust(), p_ssl may be set temporarily.
       if (p_ssl && var != NULL && vim_strchr(var, '\\') != NULL) {
         char_u  *p = vim_strsave(var);
 
@@ -325,8 +320,8 @@ void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, bool esc, bool one,
       }
 #endif
 
-      /* If "var" contains white space, escape it with a backslash.
-       * Required for ":e ~/tt" when $HOME includes a space. */
+      // If "var" contains white space, escape it with a backslash.
+      // Required for ":e ~/tt" when $HOME includes a space.
       if (esc && var != NULL && vim_strpbrk(var, (char_u *)" \t") != NULL) {
         char_u  *p = vim_strsave_escaped(var, (char_u *)" \t");
 
@@ -341,8 +336,8 @@ void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, bool esc, bool one,
         STRCPY(dst, var);
         dstlen -= (int)STRLEN(var);
         c = (int)STRLEN(var);
-        /* if var[] ends in a path separator and tail[] starts
-         * with it, skip a character */
+        // if var[] ends in a path separator and tail[] starts
+        // with it, skip a character
         if (*var != NUL && after_pathsep((char *)dst, (char *)dst + c)
 #if defined(BACKSLASH_IN_FILENAME)
             && dst[-1] != ':'
@@ -357,12 +352,10 @@ void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, bool esc, bool one,
         xfree(var);
     }
 
-    if (copy_char) {        /* copy at least one char */
-      /*
-       * Recognize the start of a new name, for '~'.
-       * Don't do this when "one" is true, to avoid expanding "~" in
-       * ":edit foo ~ foo".
-       */
+    if (copy_char) {  // copy at least one char
+      // Recognize the start of a new name, for '~'.
+      // Don't do this when "one" is true, to avoid expanding "~" in
+      // ":edit foo ~ foo".
       at_start = false;
       if (src[0] == '\\' && src[1] != NUL) {
         *dst++ = *src++;
@@ -384,7 +377,7 @@ void expand_env_esc(char_u *srcp, char_u *dst, int dstlen, bool esc, bool one,
 /// Check if the directory "vimdir/<version>" or "vimdir/runtime" exists.
 /// Return NULL if not, return its name in allocated memory otherwise.
 /// @param vimdir directory to test
-static char *vim_version_dir(char *vimdir)
+static char *vim_version_dir(const char *vimdir)
 {
   char_u      *p;
 
@@ -418,124 +411,112 @@ static char *remove_tail(char *p, char *pend, char *name)
 /// Vim's version of getenv().
 /// Special handling of $HOME, $VIM and $VIMRUNTIME, allowing the user to
 /// override the vim runtime directory at runtime.  Also does ACP to 'enc'
-/// conversion for Win32.
+/// conversion for Win32.  Results must be freed by the calling function.
 /// @param name Name of environment variable to expand
-/// @param[out] mustfree Ouput parameter for the caller to determine if they are
-///           responsible for releasing memory. Must be initialized to false
-///           by the caller.
-char *vim_getenv(const char *name, bool *mustfree)
+char *vim_getenv(const char *name)
 {
-  char *p;
-  char *pend;
-  int vimruntime;
-
-
-  p = (char *)os_getenv(name);
-  if (p != NULL && *p == NUL)       /* empty is the same as not set */
-    p = NULL;
-
-  if (p != NULL) {
-    return p;
+  const char *kos_env_path = os_getenv(name);
+  if (kos_env_path != NULL
+      && *kos_env_path == NUL) {  // empty is the same as not set
+    kos_env_path = NULL;
   }
 
-  vimruntime = (STRCMP(name, "VIMRUNTIME") == 0);
-  if (!vimruntime && STRCMP(name, "VIM") != 0)
-    return NULL;
+  if (kos_env_path != NULL) {
+    return xstrdup(kos_env_path);
+  }
 
-  /*
-   * When expanding $VIMRUNTIME fails, try using $VIM/vim<version> or $VIM.
-   * Don't do this when default_vimruntime_dir is non-empty.
-   */
+  bool vimruntime = (strcmp(name, "VIMRUNTIME") == 0);
+  if (!vimruntime && strcmp(name, "VIM") != 0) {
+    return NULL;
+  }
+
+  // When expanding $VIMRUNTIME fails, try using $VIM/vim<version> or $VIM.
+  // Don't do this when default_vimruntime_dir is non-empty.
+  char *vim_path = NULL;
   if (vimruntime
 #ifdef HAVE_PATHDEF
       && *default_vimruntime_dir == NUL
 #endif
       ) {
-    p = (char *)os_getenv("VIM");
-    if (p != NULL && *p == NUL)             /* empty is the same as not set */
-      p = NULL;
-    if (p != NULL) {
-      p = vim_version_dir(p);
-      if (p != NULL)
-        *mustfree = true;
-      else
-        p = (char *)os_getenv("VIM");
+    kos_env_path = os_getenv("VIM");
+    if (kos_env_path != NULL
+        && *kos_env_path == NUL) {  // empty is the same as not set
+      kos_env_path = NULL;
+    }
+    if (kos_env_path != NULL) {
+      vim_path = vim_version_dir(kos_env_path);
+      if (vim_path == NULL) {
+        vim_path = xstrdup(kos_env_path);
+      }
     }
   }
 
-  /*
-   * When expanding $VIM or $VIMRUNTIME fails, try using:
-   * - the directory name from 'helpfile' (unless it contains '$')
-   * - the executable name from argv[0]
-   */
-  if (p == NULL) {
-    if (p_hf != NULL && vim_strchr(p_hf, '$') == NULL)
-      p = (char *)p_hf;
-    if (p != NULL) {
-      /* remove the file name */
-      pend = (char *)path_tail((char_u *)p);
+  // When expanding $VIM or $VIMRUNTIME fails, try using:
+  // - the directory name from 'helpfile' (unless it contains '$')
+  // - the executable name from argv[0]
+  if (vim_path == NULL) {
+    if (p_hf != NULL && vim_strchr(p_hf, '$') == NULL) {
+      vim_path = (char *)p_hf;
+    }
+    if (vim_path != NULL) {
+      // remove the file name
+      char *vim_path_end = (char *)path_tail((char_u *)vim_path);
 
-      /* remove "doc/" from 'helpfile', if present */
-      if (p == (char *)p_hf)
-        pend = remove_tail(p, pend, "doc");
-
-      /* for $VIM, remove "runtime/" or "vim54/", if present */
-      if (!vimruntime) {
-        pend = remove_tail(p, pend, RUNTIME_DIRNAME);
-        pend = remove_tail(p, pend, VIM_VERSION_NODOT);
+      // remove "doc/" from 'helpfile', if present
+      if (vim_path == (char *)p_hf) {
+        vim_path_end = remove_tail(vim_path, vim_path_end, "doc");
       }
 
-      /* remove trailing path separator */
-      if (pend > p && after_pathsep(p, pend))
-        --pend;
+      // for $VIM, remove "runtime/" or "vim54/", if present
+      if (!vimruntime) {
+        vim_path_end = remove_tail(vim_path, vim_path_end, RUNTIME_DIRNAME);
+        vim_path_end = remove_tail(vim_path, vim_path_end, VIM_VERSION_NODOT);
+      }
+
+      // remove trailing path separator
+      if (vim_path_end > vim_path && after_pathsep(vim_path, vim_path_end)) {
+        vim_path_end--;
+      }
 
       // check that the result is a directory name
-      assert(pend >= p);
-      p = xstrndup(p, (size_t)(pend - p));
+      assert(vim_path_end >= vim_path);
+      vim_path = xstrndup(vim_path, (size_t)(vim_path_end - vim_path));
 
-      if (!os_isdir((char_u *)p)) {
-        xfree(p);
-        p = NULL;
-      } else {
-        *mustfree = true;
+      if (!os_isdir((char_u *)vim_path)) {
+        xfree(vim_path);
+        vim_path = NULL;
       }
     }
   }
 
 #ifdef HAVE_PATHDEF
-  /* When there is a pathdef.c file we can use default_vim_dir and
-   * default_vimruntime_dir */
-  if (p == NULL) {
-    /* Only use default_vimruntime_dir when it is not empty */
+  // When there is a pathdef.c file we can use default_vim_dir and
+  // default_vimruntime_dir
+  if (vim_path == NULL) {
+    // Only use default_vimruntime_dir when it is not empty
     if (vimruntime && *default_vimruntime_dir != NUL) {
-      p = default_vimruntime_dir;
-      *mustfree = false;
+      vim_path = xstrdup(default_vimruntime_dir);
     } else if (*default_vim_dir != NUL) {
       if (vimruntime
-          && (p = vim_version_dir(default_vim_dir)) != NULL) {
-        *mustfree = true;
-      } else {
-        p = default_vim_dir;
-        *mustfree = false;
+          && (vim_path = vim_version_dir(default_vim_dir)) == NULL) {
+        vim_path = xstrdup(default_vim_dir);
       }
     }
   }
 #endif
 
-  /*
-   * Set the environment variable, so that the new value can be found fast
-   * next time, and others can also use it (e.g. Perl).
-   */
-  if (p != NULL) {
+  // Set the environment variable, so that the new value can be found fast
+  // next time, and others can also use it (e.g. Perl).
+  if (vim_path != NULL) {
     if (vimruntime) {
-      vim_setenv("VIMRUNTIME", p);
+      vim_setenv("VIMRUNTIME", vim_path);
       didset_vimruntime = true;
     } else {
-      vim_setenv("VIM", p);
+      vim_setenv("VIM", vim_path);
       didset_vim = true;
     }
   }
-  return p;
+  return vim_path;
 }
 
 /// Replace home directory by "~" in each space or comma separated file name in

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -528,10 +528,10 @@ char *vim_getenv(const char *name, bool *mustfree)
    */
   if (p != NULL) {
     if (vimruntime) {
-      vim_setenv((char_u *)"VIMRUNTIME", (char_u *)p);
+      vim_setenv("VIMRUNTIME", p);
       didset_vimruntime = true;
     } else {
-      vim_setenv((char_u *)"VIM", (char_u *)p);
+      vim_setenv("VIM", p);
       didset_vim = true;
     }
   }
@@ -664,16 +664,16 @@ char_u * home_replace_save(buf_T *buf, char_u *src) FUNC_ATTR_NONNULL_RET
 /// Our portable version of setenv.
 /// Has special handling for $VIMRUNTIME to keep the localization machinery
 /// sane.
-void vim_setenv(char_u *name, char_u *val)
+void vim_setenv(const char *name, const char *val)
 {
-  os_setenv((char *)name, (char *)val, 1);
+  os_setenv(name, val, 1);
   /*
    * When setting $VIMRUNTIME adjust the directory to find message
    * translations to $VIMRUNTIME/lang.
    */
   if (*val != NUL && STRICMP(name, "VIMRUNTIME") == 0) {
-    char_u  *buf = concat_str(val, (char_u *)"/lang");
-    bindtextdomain(VIMPACKAGE, (char *)buf);
+    char *buf = (char *)concat_str((char_u *)val, (char_u *)"/lang");
+    bindtextdomain(VIMPACKAGE, buf);
     xfree(buf);
   }
 }

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1682,7 +1682,7 @@ void path_fix_case(char_u *name)
  * Takes care of multi-byte characters.
  * "b" must point to the start of the file name
  */
-int after_pathsep(char *b, char *p)
+int after_pathsep(const char *b, const char *p)
 {
   return p > b && vim_ispathsep(p[-1])
          && (!has_mbyte || (*mb_head_off)((char_u *)b, (char_u *)p - 1) == 0);
@@ -1761,7 +1761,7 @@ int pathcmp(const char *p, const char *q, int maxlen)
   /* ignore a trailing slash, but not "//" or ":/" */
   if (c2 == NUL
       && i > 0
-      && !after_pathsep((char *)s, (char *)s + i)
+      && !after_pathsep(s, s + i)
 #ifdef BACKSLASH_IN_FILENAME
       && (c1 == '/' || c1 == '\\')
 #else

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -122,7 +122,7 @@ char_u *path_tail_with_sep(char_u *fname)
   // Don't remove the '/' from "c:/file".
   char_u *past_head = get_past_head(fname);
   char_u *tail = path_tail(fname);
-  while (tail > past_head && after_pathsep(fname, tail)) {
+  while (tail > past_head && after_pathsep((char *)fname, (char *)tail)) {
     tail--;
   }
   return tail;
@@ -353,7 +353,7 @@ char_u *concat_fnames(char_u *fname1, char_u *fname2, int sep)
  */
 void add_pathsep(char_u *p)
 {
-  if (*p != NUL && !after_pathsep(p, p + STRLEN(p)))
+  if (*p != NUL && !after_pathsep((char *)p, (char *)p + STRLEN(p)))
     STRCAT(p, PATHSEPSTR);
 }
 
@@ -1356,7 +1356,7 @@ void simplify_filename(char_u *filename)
 
           --p;
           /* Skip back to after previous '/'. */
-          while (p > start && !after_pathsep(start, p))
+          while (p > start && !after_pathsep((char *)start, (char *)p))
             mb_ptr_back(start, p);
 
           if (!do_strip) {
@@ -1682,10 +1682,10 @@ void path_fix_case(char_u *name)
  * Takes care of multi-byte characters.
  * "b" must point to the start of the file name
  */
-int after_pathsep(char_u *b, char_u *p)
+int after_pathsep(char *b, char *p)
 {
   return p > b && vim_ispathsep(p[-1])
-         && (!has_mbyte || (*mb_head_off)(b, p - 1) == 0);
+         && (!has_mbyte || (*mb_head_off)((char_u *)b, (char_u *)p - 1) == 0);
 }
 
 /*
@@ -1761,7 +1761,7 @@ int pathcmp(const char *p, const char *q, int maxlen)
   /* ignore a trailing slash, but not "//" or ":/" */
   if (c2 == NUL
       && i > 0
-      && !after_pathsep((char_u *)s, (char_u *)s + i)
+      && !after_pathsep((char *)s, (char *)s + i)
 #ifdef BACKSLASH_IN_FILENAME
       && (c1 == '/' || c1 == '\\')
 #else


### PR DESCRIPTION
This pull request has multiple functions refactored, one per commit:
after_pathstep()
vim_getenv()
vim_setenv()

Note: I am concerned about vim_getenv(), as the function for os_getenv() uses the constant qualifier -- but the casts that were in place to convert to char_u pointers were discarding this.  Removing the cast throws compiler warnings for obvious reasons.  To minimize unrelated changes I kept the same behavior for now.

See also: #459 
