### PR TITLE
[RDY] Add ":profile dump" and ":profile stop"

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -586,6 +586,9 @@ For example, to profile the one_script.vim script file: >
 		If {fname} already exists it will be silently overwritten.
 		The variable |v:profiling| is set to one.
 
+:prof[ile] stop
+		Write the logfile and stop profiling.
+
 :prof[ile] pause
 		Don't profile until the following ":profile continue".  Can be
 		used when doing something that should not be counted (e.g., an

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -609,6 +609,9 @@ For example, to profile the one_script.vim script file: >
 		after this command.  A :profile command in the script itself
 		won't work.
 
+:prof[ile] dump
+		Don't wait until exiting Vim and write the current state of
+		profiling to the log immediately.
 
 :profd[el] ...						*:profd* *:profdel*
 		Stop profiling for the arguments specified. See |:breakdel|

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -229,49 +229,10 @@ static int echo_attr = 0;   /* attributes used for ":echo" */
 #define GLV_QUIET       TFN_QUIET       /* no error messages */
 #define GLV_NO_AUTOLOAD TFN_NO_AUTOLOAD /* do not use script autoloading */
 
-/*
- * Structure to hold info for a user function.
- */
-typedef struct ufunc ufunc_T;
-
-struct ufunc {
-  int uf_varargs;               /* variable nr of arguments */
-  int uf_flags;
-  int uf_calls;                 /* nr of active calls */
-  garray_T uf_args;             /* arguments */
-  garray_T uf_lines;            /* function lines */
-  int uf_profiling;             /* TRUE when func is being profiled */
-  /* profiling the function as a whole */
-  int uf_tm_count;              /* nr of calls */
-  proftime_T uf_tm_total;       /* time spent in function + children */
-  proftime_T uf_tm_self;        /* time spent in function itself */
-  proftime_T uf_tm_children;    /* time spent in children this call */
-  /* profiling the function per line */
-  int         *uf_tml_count;    /* nr of times line was executed */
-  proftime_T  *uf_tml_total;    /* time spent in a line + children */
-  proftime_T  *uf_tml_self;     /* time spent in a line itself */
-  proftime_T uf_tml_start;      /* start time for current line */
-  proftime_T uf_tml_children;    /* time spent in children for this line */
-  proftime_T uf_tml_wait;       /* start wait time for current line */
-  int uf_tml_idx;               /* index of line being timed; -1 if none */
-  int uf_tml_execed;            /* line being timed was executed */
-  scid_T uf_script_ID;          /* ID of script where function was defined,
-                                   used for s: variables */
-  int uf_refcount;              /* for numbered function: reference count */
-  char_u uf_name[1];            /* name of function (actually longer); can
-                                   start with <SNR>123_ (<SNR> is K_SPECIAL
-                                   KS_EXTRA KE_SNR) */
-};
-
 /* function flags */
 #define FC_ABORT    1           /* abort function on error */
 #define FC_RANGE    2           /* function accepts range */
 #define FC_DICT     4           /* Dict function, uses "self" */
-
-/*
- * All user-defined functions are found in this hashtable.
- */
-static hashtab_T func_hashtab;
 
 /* The names of packages that once were loaded are remembered. */
 static garray_T ga_loaded = {0, 0, sizeof(char_u *), 4, NULL};
@@ -279,12 +240,6 @@ static garray_T ga_loaded = {0, 0, sizeof(char_u *), 4, NULL};
 /* list heads for garbage collection */
 static dict_T           *first_dict = NULL;     /* list of all dicts */
 static list_T           *first_list = NULL;     /* list of all lists */
-
-/* From user function to hashitem and back. */
-static ufunc_T dumuf;
-#define UF2HIKEY(fp) ((fp)->uf_name)
-#define HIKEY2UF(p)  ((ufunc_T *)(p - (dumuf.uf_name - (char_u *)&dumuf)))
-#define HI2UF(hi)     HIKEY2UF((hi)->hi_key)
 
 #define FUNCARG(fp, j)  ((char_u **)(fp->uf_args.ga_data))[j]
 #define FUNCLINE(fp, j) ((char_u **)(fp->uf_lines.ga_data))[j]

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -5,6 +5,47 @@
 
 #include "nvim/profile.h"
 
+// All user-defined functions are found in this hashtable.
+EXTERN hashtab_T func_hashtab;
+
+// Structure to hold info for a user function.
+typedef struct ufunc ufunc_T;
+
+struct ufunc {
+  int          uf_varargs;       ///< variable nr of arguments
+  int          uf_flags;
+  int          uf_calls;         ///< nr of active calls
+  garray_T     uf_args;          ///< arguments
+  garray_T     uf_lines;         ///< function lines
+  int          uf_profiling;     ///< true when func is being profiled
+  // Profiling the function as a whole.
+  int          uf_tm_count;      ///< nr of calls
+  proftime_T   uf_tm_total;      ///< time spent in function + children
+  proftime_T   uf_tm_self;       ///< time spent in function itself
+  proftime_T   uf_tm_children;   ///< time spent in children this call
+  // Profiling the function per line.
+  int         *uf_tml_count;     ///< nr of times line was executed
+  proftime_T  *uf_tml_total;     ///< time spent in a line + children
+  proftime_T  *uf_tml_self;      ///< time spent in a line itself
+  proftime_T   uf_tml_start;     ///< start time for current line
+  proftime_T   uf_tml_children;  ///< time spent in children for this line
+  proftime_T   uf_tml_wait;      ///< start wait time for current line
+  int          uf_tml_idx;       ///< index of line being timed; -1 if none
+  int          uf_tml_execed;    ///< line being timed was executed
+  scid_T       uf_script_ID;     ///< ID of script where function was defined,
+                                 //   used for s: variables
+  int          uf_refcount;      ///< for numbered function: reference count
+  char_u       uf_name[1];       ///< name of function (actually longer); can
+                                 //   start with <SNR>123_ (<SNR> is K_SPECIAL
+                                 //   KS_EXTRA KE_SNR)
+};
+
+// From user function to hashitem and back.
+EXTERN ufunc_T dumuf;
+#define UF2HIKEY(fp) ((fp)->uf_name)
+#define HIKEY2UF(p)  ((ufunc_T *)(p - (dumuf.uf_name - (char_u *)&dumuf)))
+#define HI2UF(hi)    HIKEY2UF((hi)->hi_key)
+
 /* Defines for Vim variables.  These must match vimvars[] in eval.c! */
 enum {
     VV_COUNT,

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -817,17 +817,11 @@ static enum {
 
 static char *pexpand_cmds[] = {
   "start",
-#define PROFCMD_START   0
   "pause",
-#define PROFCMD_PAUSE   1
   "continue",
-#define PROFCMD_CONTINUE 2
   "func",
-#define PROFCMD_FUNC    3
   "file",
-#define PROFCMD_FILE    4
   NULL
-#define PROFCMD_LAST    5
 };
 
 /*

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -773,6 +773,8 @@ void ex_profile(exarg_T *eap)
       profile_set_wait(profile_add(profile_get_wait(), pause_time));
     }
     do_profiling = PROF_YES;
+  } else if (STRCMP(eap->arg, "dump") == 0) {
+    profile_dump();
   } else {
     /* The rest is similar to ":breakadd". */
     ex_breakadd(eap);
@@ -821,6 +823,7 @@ static char *pexpand_cmds[] = {
   "continue",
   "func",
   "file",
+  "dump",
   NULL
 };
 

--- a/test/functional/ex_cmds/profile_spec.lua
+++ b/test/functional/ex_cmds/profile_spec.lua
@@ -1,0 +1,51 @@
+require('os')
+require('lfs')
+
+local helpers  = require('test.functional.helpers')
+local eval     = helpers.eval
+local command  = helpers.command
+local eq, neq  = helpers.eq, helpers.neq
+local tempfile = os.tmpname()
+
+-- os.tmpname() also creates the file on POSIX systems. Remove it again.
+-- We just need the name, ignoring any race conditions.
+if lfs.attributes(tempfile, 'uid') then
+  os.remove(tempfile)
+end
+
+local function assert_file_exists(filepath)
+  -- Use 2-argument lfs.attributes() so no extra table gets created.
+  -- We don't really care for the uid.
+  neq(nil, lfs.attributes(filepath, 'uid'))
+end
+
+local function assert_file_exists_not(filepath)
+  eq(nil, lfs.attributes(filepath, 'uid'))
+end
+
+describe(':profile', function()
+  before_each(helpers.clear)
+
+  after_each(function()
+    if lfs.attributes(tempfile, 'uid') ~= nil then
+      os.remove(tempfile)
+    end
+  end)
+
+  it('dump', function()
+    eq(0, eval('v:profiling'))
+    command('profile start ' .. tempfile)
+    eq(1, eval('v:profiling'))
+    assert_file_exists_not(tempfile)
+    command('profile dump')
+    assert_file_exists(tempfile)
+  end)
+
+  it('stop', function()
+    command('profile start ' .. tempfile)
+    assert_file_exists_not(tempfile)
+    command('profile stop')
+    assert_file_exists(tempfile)
+    eq(0, eval('v:profiling'))
+  end)
+end)


### PR DESCRIPTION
Currently the logfile (":profile start {logfile}") only gets written when Vim
exits. This new command allows to dump the log immediately without exiting.
