### PR TITLE
third-party: use the official jemalloc tarball

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -74,8 +74,8 @@ set(LIBTERMKEY_SHA256 21846369081e6c9a0b615f4b3889c4cb809321c5ccc6e6c1640eb138f1
 set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/1b745d29d45623aa8d22a7b9288c7b0e331c7088.tar.gz)
 set(LIBVTERM_SHA256 3fc75908256c0d158d6c2a32d39f34e86bfd26364f5404b7d9c03bb70cdc3611)
 
-set(JEMALLOC_URL https://github.com/jemalloc/jemalloc/archive/3.6.0.tar.gz)
-set(JEMALLOC_SHA256 68175f729423305dc8573cb093025a8db525e1956583c7c5924416a9abaaacb6)
+set(JEMALLOC_URL http://www.canonware.com/download/jemalloc/jemalloc-3.6.0.tar.bz2)
+set(JEMALLOC_SHA256 e16c2159dd3c81ca2dc3b5c9ef0d43e1f2f45b04548f42db12e7c12d7bdf84fe)
 
 if(USE_BUNDLED_UNIBILIUM)
   include(BuildUnibilium)

--- a/third-party/cmake/BuildJeMalloc.cmake
+++ b/third-party/cmake/BuildJeMalloc.cmake
@@ -10,9 +10,9 @@ ExternalProject_Add(jemalloc
     -DTARGET=jemalloc
     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
   BUILD_IN_SOURCE 1
-  CONFIGURE_COMMAND sh ${DEPS_BUILD_DIR}/src/jemalloc/autogen.sh &&
-    ${DEPS_BUILD_DIR}/src/jemalloc/configure --with-jemalloc-prefix=je_
-    --enable-cc-silence CC=${DEPS_C_COMPILER} --prefix=${DEPS_INSTALL_DIR}
+  CONFIGURE_COMMAND ${DEPS_BUILD_DIR}/src/jemalloc/configure
+     --with-jemalloc-prefix=je_ --enable-cc-silence
+     CC=${DEPS_C_COMPILER} --prefix=${DEPS_INSTALL_DIR}
   BUILD_COMMAND ""
   INSTALL_COMMAND ${MAKE_PRG} install_include install_lib)
 


### PR DESCRIPTION
This avoids messages to stderr about VERSION being missing, and allows
us to skip the autogen step.
