### PR TITLE
[WIP] Travis for py3 (on top of #2208)

### DIFF
--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,3 +1,5 @@
+set -eu
+
 valgrind_check() {
 	check_logs "$1" "valgrind-*"
 }
@@ -7,6 +9,7 @@ asan_check() {
 }
 
 check_logs() {
+	local err=""
 	check_core_dumps
 	# Iterate through each log to remove an useless warning
 	for log in $(find "$1" -type f -name "$2"); do
@@ -48,7 +51,16 @@ check_core_dumps() {
 }
 
 setup_deps() {
+	sudo pip install --upgrade pip
 	sudo pip install neovim
+
+	# For pip3
+	# https://github.com/travis-ci/travis-ci/issues/1528
+	# sudo apt-get install -q python3.3-dev
+	# curl -Ss http://python-distribute.org/distribute_setup.py | sudo python3
+	# curl -Ss https://raw.github.com/pypa/pip/master/contrib/get-pip.py | sudo python3
+	# sudo pip3.3 install neovim
+
 	if [ "$BUILD_NVIM_DEPS" != "true" ]; then
 		eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) deps-${1}"
 	elif [ "$TRAVIS_OS_NAME" = "linux" ]; then

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -54,13 +54,6 @@ setup_deps() {
 	sudo pip install --upgrade pip
 	sudo pip install neovim
 
-	# For pip3
-	# https://github.com/travis-ci/travis-ci/issues/1528
-	# sudo apt-get install -q python3.3-dev
-	# curl -Ss http://python-distribute.org/distribute_setup.py | sudo python3
-	# curl -Ss https://raw.github.com/pypa/pip/master/contrib/get-pip.py | sudo python3
-	# sudo pip3.3 install neovim
-
 	if [ "$BUILD_NVIM_DEPS" != "true" ]; then
 		eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) deps-${1}"
 	elif [ "$TRAVIS_OS_NAME" = "linux" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,15 +47,16 @@ before_install:
   # and avoids a lengthy upgrade process for them.
   - if [ $TRAVIS_OS_NAME = linux ]; then
       sudo apt-mark hold oracle-java7-installer oracle-java8-installer;
-      sudo apt-get update;
+      travis_retry sudo apt-get update;
     elif [ $TRAVIS_OS_NAME = osx ]; then
-      brew update;
+      travis_retry brew update;
     fi
+  - python --version
 install:
   - if [ $TRAVIS_OS_NAME = linux ]; then
-      sudo apt-get install xclip gdb;
+      travis_retry sudo apt-get install xclip gdb;
     elif [ $TRAVIS_OS_NAME = osx ]; then
-      brew install gettext;
+      travis_retry brew install gettext;
     fi
 before_script:
   # Adds user to a dummy group.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-language: c
+language: python
 os:
   - linux
 branches:
@@ -30,10 +30,8 @@ matrix:
   include:
     - os: osx
       env: CI_TARGET=clang
-      compiler: clang
     - os: osx
       env: CI_TARGET=gcc
-      compiler: gcc-4.9
     # Python 3
     - os: osx
       env: CI_TARGET=clang
@@ -51,7 +49,6 @@ before_install:
     elif [ $TRAVIS_OS_NAME = osx ]; then
       travis_retry brew update;
     fi
-  - python --version
 install:
   - if [ $TRAVIS_OS_NAME = linux ]; then
       travis_retry sudo apt-get install xclip gdb;
@@ -72,6 +69,8 @@ before_script:
       sudo dscl . -append /Groups/chown_test GroupMembership $USER;
     fi
 script:
+  - python --version
+  - python3 --version
   # This will pass the environment variables down to a bash process which runs
   # as $USER, while retaining the environment variables defined and belonging
   # to secondary groups given above in usermod.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
 branches:
   except:
     - nightly
+python:
+  - "2.7"
 env:
   global:
     - CI_SCRIPTS=$TRAVIS_BUILD_DIR/.ci
@@ -32,6 +34,13 @@ matrix:
     - os: osx
       env: CI_TARGET=gcc
       compiler: gcc-4.9
+    # Python 3
+    - os: osx
+      env: CI_TARGET=clang
+      python: "3.4"
+    - os: linux
+      env: CI_TARGET=clang
+      python: "3.4"
   fast_finish: true
 before_install:
   # Pins the version of the java package installed on the Travis VMs

--- a/runtime/autoload/provider/python3.vim
+++ b/runtime/autoload/provider/python3.vim
@@ -1,0 +1,47 @@
+" The Python3 provider uses a Python3 host to emulate an environment for running
+" python3 plugins. See ":help nvim-provider" for more information.
+"
+" Associating the plugin with the Python3 host is the first step because
+" plugins will be passed as command-line arguments
+
+if exists('g:loaded_python3_provider')
+  finish
+endif
+let g:loaded_python3_provider = 1
+
+let [s:prog, s:err] = provider#pythonx#Detect(3)
+if s:prog == ''
+  " Detection failed
+  finish
+endif
+
+function! provider#python3#Prog()
+  return s:prog
+endfunction
+
+function! provider#python3#Error()
+  return s:err
+endfunction
+
+let s:plugin_path = expand('<sfile>:p:h').'/script_host.py'
+
+" The Python3 provider plugin will run in a separate instance of the Python3
+" host.
+call remote#host#RegisterClone('legacy-python3-provider', 'python3')
+call remote#host#RegisterPlugin('legacy-python3-provider', s:plugin_path, [])
+
+function! provider#python3#Call(method, args)
+  if !exists('s:host')
+    let s:rpcrequest = function('rpcrequest')
+
+    " Ensure that we can load the Python3 host before bootstrapping
+    try
+      let s:host = remote#host#Require('legacy-python3-provider')
+    catch
+      echomsg v:exception
+      finish
+    endtry
+  endif
+
+  return call(s:rpcrequest, insert(insert(a:args, 'python_'.a:method), s:host))
+endfunction

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -1,0 +1,69 @@
+" The Python provider helper
+if exists('s:loaded_pythonx_provider')
+  finish
+endif
+
+let s:loaded_pythonx_provider = 1
+
+function! provider#pythonx#Detect(ver) abort
+  let host_var = (a:ver == 2) ?
+        \ 'g:python_host_prog' : 'g:python3_host_prog'
+  let skip_var = (a:ver == 2) ?
+        \ 'g:python_host_skip_check' : 'g:python3_host_skip_check'
+  let skip = exists(skip_var) ? {skip_var} : 0
+  if exists(host_var)
+    " Disable auto detection
+    let [check, err] = s:check_interpreter({host_var}, a:ver, skip)
+    return check ? [{host_var}, err] : ['', err]
+  endif
+
+  let detect_versions = (a:ver == 2) ?
+        \   ['2.7', '2.6', '2', '']
+        \ : ['3.5', '3.4', '3.3', '3.2', '3', '']
+
+  for prog in map(detect_versions, "'python' . v:val")
+    let [check, err] = s:check_interpreter(prog, a:ver, skip)
+    if check
+      let [check, err] = s:check_version(prog, a:ver, skip)
+      return [prog, err]
+    endif
+  endfor
+
+  " No Python interpreter
+  return ['', 'Neovim module installed Python'
+        \ .a:ver.' interpreter is not found.']
+endfunction
+
+function! s:check_version(prog, ver, skip) abort
+  if a:skip
+    return [1, '']
+  endif
+
+  let get_version =
+        \ ' -c "import sys; sys.stdout.write(str(sys.version_info[0]) + '.
+        \ '\".\" + str(sys.version_info[1]))"'
+  let min_version = (a:ver == 2) ? '2.6' : '3.3'
+  if system(a:prog . get_version) >= min_version
+    return [1, '']
+  endif
+  return [0, 'Python ' . get_version . ' interpreter is not supported.']
+endfunction
+
+function! s:check_interpreter(prog, ver, skip) abort
+  if !executable(a:prog)
+    return [0, 'Python'.a:ver.' interpreter is not executable.']
+  endif
+
+  if a:skip
+    return [1, '']
+  endif
+
+  " Load neovim module check
+  call system(a:prog . ' -c ' .
+        \ (a:ver == 2 ?
+        \   '''import pkgutil; exit(pkgutil.get_loader("neovim") is None)''':
+        \   '''import importlib; exit(importlib.find_loader("neovim") is None)''')
+        \ )
+  return [!v:shell_error, 'Python'.a:ver.' interpreter have not neovim module.']
+endfunction
+

--- a/runtime/doc/nvim_python.txt
+++ b/runtime/doc/nvim_python.txt
@@ -12,32 +12,72 @@ Python plugins and scripting in Nvim				  *nvim-python*
 ==============================================================================
 1. Introduction						    *nvim-python-intro*
 
-Through an external Python interpreter connected via |msgpack-rpc|, Nvim
-offers some support for the legacy |python-vim| interface. For now only the
-old Vim 7.3 API is supported.
+Through external Python 2/3 interpreters connected via |msgpack-rpc|, Nvim
+offers some support for the legacy |python-vim| and |python3| interfaces.
+
+Note: For now only the old Vim 7.3 API is supported.
 
 ==============================================================================
-2. Quickstart					       *nvim-python-quickstart*
+2. Quickstart						 *nvim-python-quickstart*
 
-If you just want to start using Vim Python plugins with Nvim quickly, here's a
-simple tutorial:
+To use Vim Python 2/3 plugins with Nvim, do the following:
 
-- Make sure Python 2.6 or 2.7 is available in your `$PATH`.
-- Install the `neovim` Python package systemwide:
->
-    # pip install neovim
+- For Python 2 plugins, make sure an interpreter for Python 2.6 or 2.7 is
+  available in your `$PATH`, then install the `neovim` Python package systemwide:
+  >
+    $ sudo pip install neovim
 <
   or for the current user:
 >
     $ pip install --user neovim
 <
-Most Python plugins created for Vim 7.3 should work after these steps.
-
+- For Python 3 plugins, make sure an interpreter for Python 3.3 or above is
+  available in your `$PATH`, then install the `neovim` Python package systemwide:
+  >
+    $ sudo pip3 install neovim
+<
+  or for the current user:
+>
+    $ pip3 install --user neovim
+<
+==============================================================================
 							   *g:python_host_prog*
 
-To point Nvim to a specific Python interpreter, set |g:python_host_prog|:
+To point Nvim to a specific Python 2 interpreter, set |g:python_host_prog|:
 >
-    let g:python_host_prog='/path/to/python'
+    let g:python_host_prog = '/path/to/python'
+<
+							   *g:python3_host_prog*
+
+To point Nvim to a specific Python 3 interpreter, set |g:python3_host_prog|:
+>
+    let g:python3_host_prog = '/path/to/python3'
+<
+						   *g:loaded_python_provider*
+
+To disable Python 2 interface, set `g:loaded_python_provider` to 1:
+>
+    let g:loaded_python_provider = 1
+<
+						   *g:loaded_python3_provider*
+
+To disable Python 3 interface, set `g:loaded_python3_provider` to 0:
+>
+    let g:loaded_python3_provider = 1
+<
+						   *g:python_host_skip_check*
+
+To disable Python 2 interpreter check, set `g:python_host_skip_check` to 1:
+Note: If you disable Python 2 check, you must install neovim module properly.
+>
+    let g:python_host_skip_check = 1
+<
+						   *g:python3_host_skip_check*
+
+To disable Python 3 interpreter check, set `g:python3_host_skip_check` to 1:
+Note: If you disable Python 3 check, you must install neovim module properly.
+>
+    let g:python3_host_skip_check = 1
 <
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6577,6 +6577,7 @@ static struct fst {
   {"prevnonblank",    1, 1, f_prevnonblank},
   {"printf",          2, 19, f_printf},
   {"pumvisible",      0, 0, f_pumvisible},
+  {"py3eval",         1, 1, f_py3eval},
   {"pyeval",          1, 1, f_pyeval},
   {"range",           1, 3, f_range},
   {"readfile",        1, 3, f_readfile},
@@ -11943,6 +11944,14 @@ static void f_pumvisible(typval_T *argvars, typval_T *rettv)
 static void f_pyeval(typval_T *argvars, typval_T *rettv)
 {
   script_host_eval("python", argvars, rettv);
+}
+
+/*
+ * "py3eval()" function
+ */
+static void f_py3eval(typval_T *argvars, typval_T *rettv)
+{
+  script_host_eval("python3", argvars, rettv);
 }
 
 /*
@@ -20458,11 +20467,14 @@ bool eval_has_provider(char *name)
     }                                                                     \
   }
 
-  static int has_clipboard = -1, has_python = -1;
+  static int has_clipboard = -1, has_python = -1, has_python3 = -1;
 
   if (!strcmp(name, "clipboard")) {
     check_provider(clipboard);
     return has_clipboard;
+  } else if (!strcmp(name, "python3")) {
+    check_provider(python3);
+    return has_python3;
   } else if (!strcmp(name, "python")) {
     check_provider(python);
     return has_python;

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1668,22 +1668,22 @@ return {
   {
     command='py3',
     flags=bit.bor(RANGE, EXTRA, NEEDARG, CMDWIN),
-    func='ex_script_ni',
+    func='ex_python3',
   },
   {
     command='py3do',
     flags=bit.bor(RANGE, DFLALL, EXTRA, NEEDARG, CMDWIN),
-    func='ex_ni',
+    func='ex_pydo3',
   },
   {
     command='python3',
     flags=bit.bor(RANGE, EXTRA, NEEDARG, CMDWIN),
-    func='ex_script_ni',
+    func='ex_python3',
   },
   {
     command='py3file',
     flags=bit.bor(RANGE, FILE1, NEEDARG, CMDWIN),
-    func='ex_ni',
+    func='ex_py3file',
   },
   {
     command='quit',

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -797,6 +797,20 @@ void ex_pydo(exarg_T *eap)
   script_host_do_range("python", eap);
 }
 
+void ex_python3(exarg_T *eap)
+{
+  script_host_execute("python3", eap);
+}
+
+void ex_py3file(exarg_T *eap)
+{
+  script_host_execute_file("python3", eap);
+}
+
+void ex_pydo3(exarg_T *eap)
+{
+  script_host_do_range("python3", eap);
+}
 
 /* Command line expansion for :profile. */
 static enum {

--- a/test/functional/runtime/autoload/provider/python3_spec.lua
+++ b/test/functional/runtime/autoload/provider/python3_spec.lua
@@ -1,0 +1,79 @@
+do
+  local proc =
+    io.popen([[python3 -c 'import neovim, sys; sys.stdout.write("ok")' 2> /dev/null]])
+  if proc:read() ~= 'ok' then
+    -- Don't run these tests if python3 is not available
+    return
+  end
+end
+
+
+local helpers = require('test.functional.helpers')
+local eval, command, feed = helpers.eval, helpers.command, helpers.feed
+local eq, clear, insert = helpers.eq, helpers.clear, helpers.insert
+local expect = helpers.expect
+
+
+describe('python3 commands and functions', function()
+  before_each(function()
+    clear()
+    command('python3 import vim')
+  end)
+
+  it('feature test', function()
+    eq(1, eval('has("python3")'))
+  end)
+
+  it('python3_execute', function()
+    command('python3 vim.vars["set_by_python3"] = [100, 0]')
+    eq({100, 0}, eval('g:set_by_python3'))
+  end)
+
+  it('python3_execute with nested commands', function()
+    command([[python3 vim.command('python3 vim.command("python3 vim.command(\'let set_by_nested_python3 = 555\')")')]])
+    eq(555, eval('g:set_by_nested_python3'))
+  end)
+
+  it('python3_execute with range', function()
+    insert([[
+      line1
+      line2
+      line3
+      line4]])
+    feed('ggjvj:python3 vim.vars["range"] = vim.current.range[:]<CR>')
+    eq({'line2', 'line3'}, eval('g:range'))
+  end)
+
+  it('py3file', function()
+    local fname = 'py3file.py'
+    local F = io.open(fname, 'w')
+    F:write('vim.command("let set_by_py3file = 123")')
+    F:close()
+    command('py3file py3file.py')
+    eq(123, eval('g:set_by_py3file'))
+    os.remove(fname)
+  end)
+
+  it('py3do', function()
+    -- :pydo3 42 returns None for all lines,
+    -- the buffer should not be changed
+    command('normal :py3do 42')
+    eq(0, eval('&mod'))
+    -- insert some text
+    insert('abc\ndef\nghi')
+    expect([[
+      abc
+      def
+      ghi]])
+    -- go to top and select and replace the first two lines
+    feed('ggvj:py3do return str(linenr)<CR>')
+    expect([[
+      1
+      2
+      ghi]])
+  end)
+
+  it('py3eval', function()
+    eq({1, 2, {['key'] = 'val'}}, eval([[py3eval('[1, 2, {"key": "val"}]')]]))
+  end)
+end)

--- a/test/functional/runtime/autoload/provider/python_spec.lua
+++ b/test/functional/runtime/autoload/provider/python_spec.lua
@@ -20,74 +20,60 @@ describe('python commands and functions', function()
     command('python import vim')
   end)
 
-  describe('feature test', function()
-    it('ok', function()
-      eq(1, eval('has("python")'))
-    end)
+  it('feature test', function()
+    eq(1, eval('has("python")'))
   end)
 
-  describe('python_execute', function()
-    it('ok', function()
-      command('python vim.vars["set_by_python"] = [100, 0]')
-      eq({100, 0}, eval('g:set_by_python'))
-    end)
+  it('python_execute', function()
+    command('python vim.vars["set_by_python"] = [100, 0]')
+    eq({100, 0}, eval('g:set_by_python'))
   end)
 
-  describe('python_execute with nested commands', function()
-    it('ok', function()
-      command([[python vim.command('python vim.command("python vim.command(\'let set_by_nested_python = 555\')")')]])
-      eq(555, eval('g:set_by_nested_python'))
-    end)
+  it('python_execute with nested commands', function()
+    command([[python vim.command('python vim.command("python vim.command(\'let set_by_nested_python = 555\')")')]])
+    eq(555, eval('g:set_by_nested_python'))
   end)
 
-  describe('python_execute with range', function()
-    it('ok', function()
-      insert([[
-        line1
-        line2
-        line3
-        line4]])
-      feed('ggjvj:python vim.vars["range"] = vim.current.range[:]<CR>')
-      eq({'line2', 'line3'}, eval('g:range'))
-    end)
+  it('python_execute with range', function()
+    insert([[
+      line1
+      line2
+      line3
+      line4]])
+    feed('ggjvj:python vim.vars["range"] = vim.current.range[:]<CR>')
+    eq({'line2', 'line3'}, eval('g:range'))
   end)
 
-  describe('pyfile', function()
-    it('ok', function()
-      local fname = 'pyfile.py'
-      local F = io.open(fname, 'w')
-      F:write('vim.command("let set_by_pyfile = 123")')
-      F:close()
-      command('pyfile pyfile.py')
-      eq(123, eval('g:set_by_pyfile'))
-      os.remove(fname)
-    end)
+  it('pyfile', function()
+    local fname = 'pyfile.py'
+    local F = io.open(fname, 'w')
+    F:write('vim.command("let set_by_pyfile = 123")')
+    F:close()
+    command('pyfile pyfile.py')
+    eq(123, eval('g:set_by_pyfile'))
+    os.remove(fname)
   end)
 
-  describe('pydo', function()
-    it('ok', function()
-      -- :pydo 42 returns None for all lines,
-      -- the buffer should not be changed
-      command('normal :pydo 42')
-      eq(0, eval('&mod'))
-      -- insert some text
-      insert('abc\ndef\nghi')
-      expect([[
-        abc
-        def
-        ghi]])
-      -- go to top and select and replace the first two lines
-      feed('ggvj:pydo return str(linenr)<CR>')
-      expect([[
-        1
-        2
-        ghi]])
-    end)
+  it('pydo', function()
+    -- :pydo 42 returns None for all lines,
+    -- the buffer should not be changed
+    command('normal :pydo 42')
+    eq(0, eval('&mod'))
+    -- insert some text
+    insert('abc\ndef\nghi')
+    expect([[
+      abc
+      def
+      ghi]])
+    -- go to top and select and replace the first two lines
+    feed('ggvj:pydo return str(linenr)<CR>')
+    expect([[
+      1
+      2
+      ghi]])
   end)
 
-  describe('pyeval', function()
-    it('ok', function()
-      eq({1, 2, {['key'] = 'val'}}, eval([[pyeval('[1, 2, {"key": "val"}]')]]))
-    end)
+  it('pyeval', function()
+    eq({1, 2, {['key'] = 'val'}}, eval([[pyeval('[1, 2, {"key": "val"}]')]]))
   end)
 end)


### PR DESCRIPTION
This is #2208 with additional adjustments for Travis.

Initial PR against @Shougo's repo: https://github.com/Shougo/neovim/pull/4

This is meant to test if the "os" feature will work, which appears to be enabled for the neovim repo, but not its forks; see http://docs.travis-ci.com/user/multi-os/

I've asked the Travis support about using the "python" and "os" matrix feature:

> First, keep in mind that the choice of the `language` value is not arbitrary. It has some profound effects, including the choice of VM image and how the build matrix is expanded. For "c", it means the "Ruby" VM image (since Ruby is the default) and only "env" and "compiler" values are considered for constructing the build matrix (see http://docs.travis-ci.com/user/languages/c/#Build-Matrix).
> 
> Second, multi-os feature is not generally available yet, so use of "os" has no effect if the feature is not enabled on the repository.
> 
> In general, if you have requirements involving multiple languages, it is a good idea to choose the language that gives the most "stuff". In your case, "python" has various Python runtimes, as well as compilers, pre-installed. It will not allow matrix expansion on "compiler", but I believe you can just set environment variable "CC", or call the compiler ("gcc" or "clang") directly.
> 
> Having said that, this is at odds with the multi-os feature (see https://github.com/travis-ci/travis-ci/issues/2312), which does not work with "language: python" at the moment. This may or may not be a deal breaker for you.
> 
> The next build environment update will include Python 3.2.3 on all Linux images (http://docs.travis-ci.com/user/build-environment-updates/2015-04-09). If this is sufficient, you can live with "language: c", and invoke "python3" where you need it. If not, installing Python 3.4 on demand might be a viable alternative.
