### PR TITLE
[RFC] Initialize call_start to prevent warnings

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -18911,7 +18911,7 @@ call_user_func (
   char_u numbuf[NUMBUFLEN];
   char_u      *name;
   proftime_T wait_start;
-  proftime_T call_start;
+  proftime_T call_start = NULL;
 
   /* If depth of calling is getting too high, don't execute the function */
   if (depth >= p_mfd) {


### PR DESCRIPTION
This is a minifix for this problem:

https://github.com/neovim/neovim/pull/2427#issuecomment-93973014
