### PR TITLE
[WIP] Reset showmode if leaving a focused terminal window

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3316,6 +3316,10 @@ void win_goto(win_T *wp)
     update_single_line(owp, owp->w_cursor.lnum);
   if (curwin->w_p_cole > 0 && !msg_scrolled)
     need_cursor_line_redraw = TRUE;
+
+  if (mode_displayed) {
+    unshowmode(false);
+  }
 }
 
 


### PR DESCRIPTION
Get rid of the "-- TERMINAL --" if leaving a focused terminal through a
mapping like given in |nvim-terminal-emulator-input|.
