### PR TITLE
[RFC] tui: make termkey use utf-8 mode correcty

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3710,6 +3710,7 @@ did_set_string_option (
         ml_setflags(curbuf);
       }
     }
+
     if (errmsg == NULL) {
       /* canonize the value, so that STRCMP() can be used on it */
       p = enc_canonize(*varp);
@@ -3721,13 +3722,15 @@ did_set_string_option (
       }
     }
 
-
     if (errmsg == NULL) {
       /* When 'keymap' is used and 'encoding' changes, reload the keymap
        * (with another encoding). */
       if (varp == &p_enc && *curbuf->b_p_keymap != NUL)
         (void)keymap_init();
 
+      if (varp == &p_enc) {
+        ui_update_encoding();
+      }
     }
   } else if (varp == &p_penc) {
     /* Canonize printencoding if VIM standard one */

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -161,6 +161,7 @@ UI *tui_start(void)
   ui->suspend = tui_suspend;
   ui->set_title = tui_set_title;
   ui->set_icon = tui_set_icon;
+  ui->set_encoding = tui_set_encoding;
   // Attach
   ui_attach(ui);
   return ui;
@@ -590,6 +591,12 @@ static void tui_set_title(UI *ui, char *title)
 
 static void tui_set_icon(UI *ui, char *icon)
 {
+}
+
+static void tui_set_encoding(UI *ui, char* enc)
+{
+  TUIData *data = ui->data;
+  term_input_set_encoding(data->input, enc);
 }
 
 static void invalidate(UI *ui, int top, int bot, int left, int right)

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -113,6 +113,11 @@ void ui_set_icon(char *icon)
   UI_CALL(flush);
 }
 
+void ui_update_encoding(void)
+{
+  UI_CALL(set_encoding, (char*)p_enc);
+}
+
 // May update the shape of the cursor.
 void ui_cursor_shape(void)
 {
@@ -183,6 +188,7 @@ void ui_attach(UI *ui)
   }
 
   uis[ui_count++] = ui;
+  ui_update_encoding();
   ui_refresh();
 }
 

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -38,6 +38,7 @@ struct ui_t {
   void (*suspend)(UI *ui);
   void (*set_title)(UI *ui, char *title);
   void (*set_icon)(UI *ui, char *icon);
+  void (*set_encoding)(UI *ui, char *enc);
   void (*stop)(UI *ui);
 };
 


### PR DESCRIPTION
Intends to fix #2393 . Before merging, should probably unify with existing locale logic in `ex_cmds2.c`. 

The open question is: can we rely on `locale.h` being available on all target systems? (`ex_cmds2.c` makes this configurable, currently) It is on any modern Linux or OSX, but I don't know about our windows build.
