### PR TITLE
[RFC] Replacements for vim_iswhite, VIM_ISDIGIT, vim_isdigit, vim_isxdigit, and vim_isspace

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -186,7 +186,7 @@ strcpy()	STRCPY()	Includes cast to (char *), for char_u * args
 strchr()	vim_strchr()	Accepts special characters
 strrchr()	vim_strrchr()	Accepts special characters
 isspace()	vim_isspace()	Can handle characters > 128
-iswhite()	vim_iswhite()	Only TRUE for tab and space
+iswhite()	ascii_iswhite()	Only TRUE for tab and space
 memcpy()	mch_memmove()	Handles overlapped copies
 bcopy()		mch_memmove()	Handles overlapped copies
 memset()	vim_memset()	Uniform for all systems

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -185,7 +185,7 @@ malloc()	lalloc()	Like alloc(), but has long argument
 strcpy()	STRCPY()	Includes cast to (char *), for char_u * args
 strchr()	vim_strchr()	Accepts special characters
 strrchr()	vim_strrchr()	Accepts special characters
-isspace()	vim_isspace()	Can handle characters > 128
+isspace()	ascii_isspace()	Can handle characters > 128
 iswhite()	ascii_iswhite()	Only TRUE for tab and space
 memcpy()	mch_memmove()	Handles overlapped copies
 bcopy()		mch_memmove()	Handles overlapped copies

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -186,7 +186,7 @@ strcpy()	STRCPY()	Includes cast to (char *), for char_u * args
 strchr()	vim_strchr()	Accepts special characters
 strrchr()	vim_strrchr()	Accepts special characters
 isspace()	ascii_isspace()	Can handle characters > 128
-iswhite()	ascii_iswhite()	Only TRUE for tab and space
+iswhite()	ascii_iswhite()	Only true for tab and space
 memcpy()	mch_memmove()	Handles overlapped copies
 bcopy()		mch_memmove()	Handles overlapped copies
 memset()	vim_memset()	Uniform for all systems

--- a/src/nvim/ascii.h
+++ b/src/nvim/ascii.h
@@ -8,6 +8,9 @@
 #ifndef NVIM_ASCII_H
 #define NVIM_ASCII_H
 
+#include <stdbool.h>
+#include "func_attr.h"
+
 // Definitions of various common control characters.
 
 #define CharOrd(x)      ((x) < 'a' ? (x) - 'A' : (x) - 'a')
@@ -86,5 +89,14 @@
 # define PATHSEP        '/'
 # define PATHSEPSTR     "/"
 #endif
+
+static inline bool ascii_iswhite(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
+
+/// ascii_iswhite() is used for "^" and the like. It differs from isspace()
+/// because it doesn't include <CR> and <LF> and the like.
+static inline bool ascii_iswhite(int c)
+{
+  return c == ' ' || c == '\t';
+}
 
 #endif /* NVIM_ASCII_H */

--- a/src/nvim/ascii.h
+++ b/src/nvim/ascii.h
@@ -92,6 +92,7 @@
 
 static inline bool ascii_iswhite(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
 static inline bool ascii_isdigit(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
+static inline bool ascii_isxdigit(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
 
 /// ascii_iswhite() is used for "^" and the like. It differs from isspace()
 /// because it doesn't include <CR> and <LF> and the like.
@@ -106,6 +107,19 @@ static inline bool ascii_iswhite(int c)
 static inline bool ascii_isdigit(int c)
 {
   return c >= '0' && c <= '9';
+}
+
+/// Variant of isxdigit() that can handle characters > 0x100.
+/// We don't use isxdigit() here, because on some systems it also considers
+/// superscript 1 to be a digit.
+///
+/// @param c
+/// @return TRUE if the character is a hexadecimal digit.
+static inline bool ascii_isxdigit(int c)
+{
+  return (c >= '0' && c <= '9')
+         || (c >= 'a' && c <= 'f')
+         || (c >= 'A' && c <= 'F');
 }
 
 

--- a/src/nvim/ascii.h
+++ b/src/nvim/ascii.h
@@ -9,7 +9,8 @@
 #define NVIM_ASCII_H
 
 #include <stdbool.h>
-#include "func_attr.h"
+
+#include "nvim/func_attr.h"
 
 // Definitions of various common control characters.
 
@@ -90,32 +91,36 @@
 # define PATHSEPSTR     "/"
 #endif
 
-static inline bool ascii_iswhite(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
-static inline bool ascii_isdigit(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
-static inline bool ascii_isxdigit(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
-static inline bool ascii_isspace(int x) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
+static inline bool ascii_iswhite(int) REAL_FATTR_ALWAYS_INLINE REAL_FATTR_CONST;
+static inline bool ascii_isdigit(int) REAL_FATTR_ALWAYS_INLINE REAL_FATTR_CONST;
+static inline bool ascii_isxdigit(int) REAL_FATTR_ALWAYS_INLINE REAL_FATTR_CONST;
+static inline bool ascii_isspace(int) REAL_FATTR_ALWAYS_INLINE REAL_FATTR_CONST;
 
-/// ascii_iswhite() is used for "^" and the like. It differs from isspace()
-/// because it doesn't include <CR> and <LF> and the like.
+/// Checks if `c` is a space or tab character.
+///
+/// @see {ascii_isdigit}
 static inline bool ascii_iswhite(int c)
 {
   return c == ' ' || c == '\t';
 }
 
-/// Use our own isdigit() replacement, because on MS-Windows isdigit() returns
-/// non-zero for superscript 1.  Also avoids that isdigit() crashes for numbers
-/// below 0 and above 255.
+/// Check whether character is a decimal digit.
+///
+/// Library isdigit() function is officially locale-dependent and, for
+/// example, returns true for superscript 1 (¹) in locales where encoding
+/// contains it in lower 8 bits. Also avoids crashes in case c is below
+/// 0 or above 255: library functions are officially defined as accepting
+/// only EOF and unsigned char values (otherwise it is undefined behaviour)
+/// what may be used for some optimizations (e.g. simple `return
+/// isdigit_table[c];`).
 static inline bool ascii_isdigit(int c)
 {
   return c >= '0' && c <= '9';
 }
 
-/// Variant of isxdigit() that can handle characters > 0x100.
-/// We don't use isxdigit() here, because on some systems it also considers
-/// superscript 1 to be a digit.
+/// Checks if `c` is a hexadecimal digit, that is, one of 0-9, a-f, A-F.
 ///
-/// @param c
-/// @return TRUE if the character is a hexadecimal digit.
+/// @see {ascii_isdigit}
 static inline bool ascii_isxdigit(int c)
 {
   return (c >= '0' && c <= '9')
@@ -123,12 +128,13 @@ static inline bool ascii_isxdigit(int c)
          || (c >= 'A' && c <= 'F');
 }
 
-/// Vim has its own isspace() function, because on some machines isspace()
-/// can't handle characters above 128.
-static inline bool ascii_isspace(int x)
+/// Checks if `c` is a white-space character, that is,
+/// one of \f, \n, \r, \t, \v.
+///
+/// @see {ascii_isdigit}
+static inline bool ascii_isspace(int c)
 {
-  return (x >= 9 && x <= 13) || x == ' ';
+  return (c >= 9 && c <= 13) || c == ' ';
 }
-
 
 #endif /* NVIM_ASCII_H */

--- a/src/nvim/ascii.h
+++ b/src/nvim/ascii.h
@@ -93,6 +93,7 @@
 static inline bool ascii_iswhite(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
 static inline bool ascii_isdigit(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
 static inline bool ascii_isxdigit(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
+static inline bool ascii_isspace(int x) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
 
 /// ascii_iswhite() is used for "^" and the like. It differs from isspace()
 /// because it doesn't include <CR> and <LF> and the like.
@@ -120,6 +121,13 @@ static inline bool ascii_isxdigit(int c)
   return (c >= '0' && c <= '9')
          || (c >= 'a' && c <= 'f')
          || (c >= 'A' && c <= 'F');
+}
+
+/// Vim has its own isspace() function, because on some machines isspace()
+/// can't handle characters above 128.
+static inline bool ascii_isspace(int x)
+{
+  return (x >= 9 && x <= 13) || x == ' ';
 }
 
 

--- a/src/nvim/ascii.h
+++ b/src/nvim/ascii.h
@@ -91,6 +91,7 @@
 #endif
 
 static inline bool ascii_iswhite(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
+static inline bool ascii_isdigit(int c) FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
 
 /// ascii_iswhite() is used for "^" and the like. It differs from isspace()
 /// because it doesn't include <CR> and <LF> and the like.
@@ -98,5 +99,14 @@ static inline bool ascii_iswhite(int c)
 {
   return c == ' ' || c == '\t';
 }
+
+/// Use our own isdigit() replacement, because on MS-Windows isdigit() returns
+/// non-zero for superscript 1.  Also avoids that isdigit() crashes for numbers
+/// below 0 and above 255.
+static inline bool ascii_isdigit(int c)
+{
+  return c >= '0' && c <= '9';
+}
+
 
 #endif /* NVIM_ASCII_H */

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4075,7 +4075,7 @@ chk_modeline (
 
   prev = -1;
   for (s = ml_get(lnum); *s != NUL; ++s) {
-    if (prev == -1 || vim_isspace(prev)) {
+    if (prev == -1 || ascii_isspace(prev)) {
       if ((prev != -1 && STRNCMP(s, "ex:", (size_t)3) == 0)
           || STRNCMP(s, "vi:", (size_t)3) == 0)
         break;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -752,7 +752,7 @@ do_bufdel (
         arg = skipwhite(arg);
         if (*arg == NUL)
           break;
-        if (!VIM_ISDIGIT(*arg)) {
+        if (!ascii_isdigit(*arg)) {
           p = skiptowhite_esc(arg);
           bnr = buflist_findpat(arg, p, command == DOBUF_WIPE,
               FALSE, FALSE);
@@ -3012,7 +3012,7 @@ build_stl_str_hl (
       s++;
       l = -1;
     }
-    if (VIM_ISDIGIT(*s)) {
+    if (ascii_isdigit(*s)) {
       minwid = getdigits_int(&s);
       if (minwid < 0)           /* overflow */
         minwid = 0;
@@ -3048,7 +3048,7 @@ build_stl_str_hl (
     }
     if (*s == '.') {
       s++;
-      if (VIM_ISDIGIT(*s)) {
+      if (ascii_isdigit(*s)) {
         maxwid = getdigits_int(&s);
         if (maxwid <= 0)                /* overflow */
           maxwid = 50;
@@ -3321,7 +3321,7 @@ build_stl_str_hl (
       if (minwid > 0) {
         for (; l < minwid && p + 1 < out + outlen; l++) {
           /* Don't put a "-" in front of a digit. */
-          if (l + 1 == minwid && fillchar == '-' && VIM_ISDIGIT(*t))
+          if (l + 1 == minwid && fillchar == '-' && ascii_isdigit(*t))
             *p++ = ' ';
           else
             *p++ = fillchar;
@@ -3334,7 +3334,7 @@ build_stl_str_hl (
         /* Change a space by fillchar, unless fillchar is '-' and a
          * digit follows. */
         if (fillable && p[-1] == ' '
-            && (!VIM_ISDIGIT(*t) || fillchar != '-'))
+            && (!ascii_isdigit(*t) || fillchar != '-'))
           p[-1] = fillchar;
       }
       for (; l < minwid && p + 1 < out + outlen; l++)

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1438,7 +1438,7 @@ char_u* skipdigits(char_u *q)
 char_u* skiphex(char_u *q)
 {
   char_u *p = q;
-  while (vim_isxdigit(*p)) {
+  while (ascii_isxdigit(*p)) {
     // skip to next non-digit
     p++;
   }
@@ -1468,25 +1468,11 @@ char_u* skiptodigit(char_u *q)
 char_u* skiptohex(char_u *q)
 {
   char_u *p = q;
-  while (*p != NUL && !vim_isxdigit(*p)) {
+  while (*p != NUL && !ascii_isxdigit(*p)) {
     // skip to next digit
     p++;
   }
   return p;
-}
-
-/// Variant of isxdigit() that can handle characters > 0x100.
-/// We don't use isxdigit() here, because on some systems it also considers
-/// superscript 1 to be a digit.
-///
-/// @param c
-///
-/// @return TRUE if the character is a digit.
-int vim_isxdigit(int c)
-{
-  return (c >= '0' && c <= '9')
-         || (c >= 'a' && c <= 'f')
-         || (c >= 'A' && c <= 'F');
 }
 
 // Vim's own character class functions.  These exist because many library
@@ -1751,7 +1737,7 @@ void vim_str2nr(char_u *start, int *hexp, int *len, int dooct, int dohex,
 
     if (dohex
         && ((hex == 'X') || (hex == 'x'))
-        && vim_isxdigit(ptr[2])) {
+        && ascii_isxdigit(ptr[2])) {
       // hexadecimal
       ptr += 2;
     } else {
@@ -1785,7 +1771,7 @@ void vim_str2nr(char_u *start, int *hexp, int *len, int dooct, int dohex,
     }
   } else if ((hex != 0) || (dohex > 1)) {
     // hex
-    while (vim_isxdigit(*ptr)) {
+    while (ascii_isxdigit(*ptr)) {
       un = 16 * un + (unsigned long)hex2nr(*ptr);
       ptr++;
     }

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -177,7 +177,7 @@ int buf_init_chartab(buf_T *buf, int global)
         ++p;
       }
 
-      if (VIM_ISDIGIT(*p)) {
+      if (ascii_isdigit(*p)) {
         c = getdigits_int(&p);
       } else if (has_mbyte) {
         c = mb_ptr2char_adv(&p);
@@ -189,7 +189,7 @@ int buf_init_chartab(buf_T *buf, int global)
       if ((*p == '-') && (p[1] != NUL)) {
         ++p;
 
-        if (VIM_ISDIGIT(*p)) {
+        if (ascii_isdigit(*p)) {
           c2 = getdigits_int(&p);
         } else if (has_mbyte) {
           c2 = mb_ptr2char_adv(&p);
@@ -1422,7 +1422,7 @@ char_u* skipwhite(char_u *q)
 char_u* skipdigits(char_u *q)
 {
   char_u *p = q;
-  while (VIM_ISDIGIT(*p)) {
+  while (ascii_isdigit(*p)) {
     // skip to next non-digit
     p++;
   }
@@ -1453,7 +1453,7 @@ char_u* skiphex(char_u *q)
 char_u* skiptodigit(char_u *q)
 {
   char_u *p = q;
-  while (*p != NUL && !VIM_ISDIGIT(*p)) {
+  while (*p != NUL && !ascii_isdigit(*p)) {
     // skip to next digit
     p++;
   }
@@ -1473,19 +1473,6 @@ char_u* skiptohex(char_u *q)
     p++;
   }
   return p;
-}
-
-/// Variant of isdigit() that can handle characters > 0x100.
-/// We don't use isdigit() here, because on some systems it also considers
-/// superscript 1 to be a digit.
-/// Use the VIM_ISDIGIT() macro for simple arguments.
-///
-/// @param c
-///
-/// @return TRUE if the character is a digit.
-int vim_isdigit(int c)
-{
-  return c >= '0' && c <= '9';
 }
 
 /// Variant of isxdigit() that can handle characters > 0x100.
@@ -1773,7 +1760,7 @@ void vim_str2nr(char_u *start, int *hexp, int *len, int dooct, int dohex,
 
       if (dooct) {
         // Don't interpret "0", "08" or "0129" as octal.
-        for (n = 1; VIM_ISDIGIT(ptr[n]); ++n) {
+        for (n = 1; ascii_isdigit(ptr[n]); ++n) {
           if (ptr[n] > '7') {
             // can't be octal
             hex = 0;
@@ -1804,7 +1791,7 @@ void vim_str2nr(char_u *start, int *hexp, int *len, int dooct, int dohex,
     }
   } else {
     // decimal
-    while (VIM_ISDIGIT(*ptr)) {
+    while (ascii_isdigit(*ptr)) {
       un = 10 * un + (unsigned long)(*ptr - '0');
       ptr++;
     }

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1407,7 +1407,7 @@ void getvcols(win_T *wp, pos_T *pos1, pos_T *pos2, colnr_T *left,
 char_u* skipwhite(char_u *q)
 {
   char_u *p = q;
-  while (vim_iswhite(*p)) {
+  while (ascii_iswhite(*p)) {
     // skip to next non-white
     p++;
   }

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -133,7 +133,7 @@ char_u *parse_shape_opt(int what)
               len = 8;
             if (len != 0) {
               p += len;
-              if (!VIM_ISDIGIT(*p))
+              if (!ascii_isdigit(*p))
                 return (char_u *)N_("E548: digit expected");
               int n = getdigits_int(&p);
               if (len == 3) {               /* "ver" or "hor" */

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1781,7 +1781,7 @@ int diffopt_changed(void)
     if (STRNCMP(p, "filler", 6) == 0) {
       p += 6;
       diff_flags_new |= DIFF_FILLER;
-    } else if ((STRNCMP(p, "context:", 8) == 0) && VIM_ISDIGIT(p[8])) {
+    } else if ((STRNCMP(p, "context:", 8) == 0) && ascii_isdigit(p[8])) {
       p += 8;
       diff_context_new = getdigits_int(&p);
     } else if (STRNCMP(p, "icase", 5) == 0) {
@@ -1796,7 +1796,7 @@ int diffopt_changed(void)
     } else if (STRNCMP(p, "vertical", 8) == 0) {
       p += 8;
       diff_flags_new |= DIFF_VERTICAL;
-    } else if ((STRNCMP(p, "foldcolumn:", 11) == 0) && VIM_ISDIGIT(p[11])) {
+    } else if ((STRNCMP(p, "foldcolumn:", 11) == 0) && ascii_isdigit(p[11])) {
       p += 11;
       diff_foldcolumn_new = getdigits_int(&p);
     }
@@ -2112,7 +2112,7 @@ void ex_diffgetput(exarg_T *eap)
       p--;
     }
 
-    for (i = 0; vim_isdigit(eap->arg[i]) && eap->arg + i < p; ++i) {
+    for (i = 0; ascii_isdigit(eap->arg[i]) && eap->arg + i < p; ++i) {
     }
 
     if (eap->arg + i == p) {

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1590,7 +1590,7 @@ static int diff_cmp(char_u *s1, char_u *s2)
   char_u *p2 = s2;
 
   while (*p1 != NUL && *p2 != NUL) {
-    if (vim_iswhite(*p1) && vim_iswhite(*p2)) {
+    if (ascii_iswhite(*p1) && ascii_iswhite(*p2)) {
       p1 = skipwhite(p1);
       p2 = skipwhite(p2);
     } else {
@@ -1897,8 +1897,8 @@ int diff_find_change(win_T *wp, linenr_T lnum, int *startp, int *endp)
 
       while (line_org[si_org] != NUL) {
         if ((diff_flags & DIFF_IWHITE)
-            && vim_iswhite(line_org[si_org])
-            && vim_iswhite(line_new[si_new])) {
+            && ascii_iswhite(line_org[si_org])
+            && ascii_iswhite(line_new[si_new])) {
           si_org = (int)(skipwhite(line_org + si_org) - line_org);
           si_new = (int)(skipwhite(line_new + si_new) - line_new);
         } else {
@@ -1931,13 +1931,13 @@ int diff_find_change(win_T *wp, linenr_T lnum, int *startp, int *endp)
                && ei_org >= 0
                && ei_new >= 0) {
           if ((diff_flags & DIFF_IWHITE)
-              && vim_iswhite(line_org[ei_org])
-              && vim_iswhite(line_new[ei_new])) {
-            while (ei_org >= *startp && vim_iswhite(line_org[ei_org])) {
+              && ascii_iswhite(line_org[ei_org])
+              && ascii_iswhite(line_new[ei_new])) {
+            while (ei_org >= *startp && ascii_iswhite(line_org[ei_org])) {
               ei_org--;
             }
 
-            while (ei_new >= si_new && vim_iswhite(line_new[ei_new])) {
+            while (ei_new >= si_new && ascii_iswhite(line_new[ei_new])) {
               ei_new--;
             }
           } else {
@@ -2108,7 +2108,7 @@ void ex_diffgetput(exarg_T *eap)
   } else {
     // Buffer number or pattern given. Ignore trailing white space.
     p = eap->arg + STRLEN(eap->arg);
-    while (p > eap->arg && vim_iswhite(p[-1])) {
+    while (p > eap->arg && ascii_iswhite(p[-1])) {
       p--;
     }
 

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1609,7 +1609,7 @@ void putdigraph(char_u *str)
     }
     str = skipwhite(str);
 
-    if (!VIM_ISDIGIT(*str)) {
+    if (!ascii_isdigit(*str)) {
       EMSG(_(e_number_exp));
       return;
     }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7403,13 +7403,13 @@ static int ins_bs(int c, int mode, int *inserted_space_p)
           dec_cursor();
 
         /* start of word? */
-        if (mode == BACKSPACE_WORD && !vim_isspace(gchar_cursor())) {
+        if (mode == BACKSPACE_WORD && !ascii_isspace(gchar_cursor())) {
           mode = BACKSPACE_WORD_NOT_SPACE;
           temp = vim_iswordc(gchar_cursor());
         }
         /* end of word? */
         else if (mode == BACKSPACE_WORD_NOT_SPACE
-                 && (vim_isspace(cc = gchar_cursor())
+                 && (ascii_isspace(cc = gchar_cursor())
                      || vim_iswordc(cc) != temp)) {
           if (!revins_on)
             inc_cursor();

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1662,7 +1662,7 @@ void truncate_spaces(char_u *line)
   int i;
 
   /* find start of trailing white space */
-  for (i = (int)STRLEN(line) - 1; i >= 0 && vim_iswhite(line[i]); i--) {
+  for (i = (int)STRLEN(line) - 1; i >= 0 && ascii_iswhite(line[i]); i--) {
     if (State & REPLACE_FLAG)
       replace_join(0);              /* remove a NUL from the replace stack */
   }
@@ -1838,7 +1838,7 @@ static int ins_compl_accept_char(int c)
   case CTRL_X_OMNI:
     /* Command line and Omni completion can work with just about any
      * printable character, but do stop at white space. */
-    return vim_isprintc(c) && !vim_iswhite(c);
+    return vim_isprintc(c) && !ascii_iswhite(c);
 
   case CTRL_X_WHOLE_LINE:
     /* For while line completion a space can be part of the line. */
@@ -4824,7 +4824,7 @@ insert_special (
  */
 # define ISSPECIAL(c)   ((c) < ' ' || (c) >= DEL || (c) == '0' || (c) == '^')
 
-# define WHITECHAR(cc) (vim_iswhite(cc) && \
+# define WHITECHAR(cc) (ascii_iswhite(cc) && \
                         (!enc_utf8 || \
                          !utf_iscomposing( \
                            utf_ptr2char(get_cursor_pos_ptr() + 1))))
@@ -4870,7 +4870,7 @@ insertchar (
    */
   if (textwidth > 0
       && ((flags & INSCHAR_FORMAT)
-          || (!vim_iswhite(c)
+          || (!ascii_iswhite(c)
               && !((State & REPLACE_FLAG)
                    && !(State & VREPLACE_FLAG)
                    && *get_cursor_pos_ptr() != NUL)
@@ -4915,7 +4915,7 @@ insertchar (
         ++p;
       middle_len = copy_option_part(&p, lead_end, COM_MAX_LEN, ",");
       /* Don't count trailing white space for middle_len */
-      while (middle_len > 0 && vim_iswhite(lead_end[middle_len - 1]))
+      while (middle_len > 0 && ascii_iswhite(lead_end[middle_len - 1]))
         --middle_len;
 
       /* Find the end-comment string */
@@ -4925,7 +4925,7 @@ insertchar (
 
       /* Skip white space before the cursor */
       i = curwin->w_cursor.col;
-      while (--i >= 0 && vim_iswhite(line[i]))
+      while (--i >= 0 && ascii_iswhite(line[i]))
         ;
       i++;
 
@@ -5071,7 +5071,7 @@ internal_format (
       && !(State & VREPLACE_FLAG)
       ) {
     cc = gchar_cursor();
-    if (vim_iswhite(cc)) {
+    if (ascii_iswhite(cc)) {
       save_char = cc;
       pchar_cursor('x');
     }
@@ -5682,13 +5682,13 @@ stop_insert (
       if (curwin->w_cursor.col > 0 && gchar_cursor() == NUL) {
         dec_cursor();
         cc = gchar_cursor();
-        if (!vim_iswhite(cc))
+        if (!ascii_iswhite(cc))
           curwin->w_cursor = tpos;
       }
 
       auto_format(TRUE, FALSE);
 
-      if (vim_iswhite(cc)) {
+      if (ascii_iswhite(cc)) {
         if (gchar_cursor() != NUL)
           inc_cursor();
         /* If the cursor is still at the same character, also keep
@@ -5720,7 +5720,7 @@ stop_insert (
         if (gchar_cursor() == NUL && curwin->w_cursor.col > 0)
           --curwin->w_cursor.col;
         cc = gchar_cursor();
-        if (!vim_iswhite(cc))
+        if (!ascii_iswhite(cc))
           break;
         if (del_char(TRUE) == FAIL)
           break;            /* should not happen */
@@ -5836,7 +5836,7 @@ void beginline(int flags)
     if (flags & (BL_WHITE | BL_SOL)) {
       char_u  *ptr;
 
-      for (ptr = get_cursor_line_ptr(); vim_iswhite(*ptr)
+      for (ptr = get_cursor_line_ptr(); ascii_iswhite(*ptr)
            && !((flags & BL_FIX) && ptr[1] == NUL); ++ptr)
         ++curwin->w_cursor.col;
     }
@@ -7369,7 +7369,7 @@ static int ins_bs(int c, int mode, int *inserted_space_p)
 
       /* delete characters until we are at or before want_vcol */
       while (vcol > want_vcol
-             && (cc = *(get_cursor_pos_ptr() - 1), vim_iswhite(cc)))
+             && (cc = *(get_cursor_pos_ptr() - 1), ascii_iswhite(cc)))
         ins_bs_one(&vcol);
 
       /* insert extra spaces until we are at want_vcol */
@@ -7882,7 +7882,7 @@ static int ins_tab(void)
 
     /* Find first white before the cursor */
     fpos = curwin->w_cursor;
-    while (fpos.col > 0 && vim_iswhite(ptr[-1])) {
+    while (fpos.col > 0 && ascii_iswhite(ptr[-1])) {
       --fpos.col;
       --ptr;
     }
@@ -7901,7 +7901,7 @@ static int ins_tab(void)
 
     /* Use as many TABs as possible.  Beware of 'breakindent', 'showbreak'
        and 'linebreak' adding extra virtual columns. */
-    while (vim_iswhite(*ptr)) {
+    while (ascii_iswhite(*ptr)) {
       i = lbr_chartabsize(NULL, (char_u *)"\t", vcol);
       if (vcol + i > want_vcol)
         break;
@@ -8201,7 +8201,7 @@ static void ins_try_si(int c)
       ptr = ml_get(pos->lnum);
       i = pos->col;
       if (i > 0)                /* skip blanks before '{' */
-        while (--i > 0 && vim_iswhite(ptr[i]))
+        while (--i > 0 && ascii_iswhite(ptr[i]))
           ;
       curwin->w_cursor.lnum = pos->lnum;
       curwin->w_cursor.col = i;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4722,7 +4722,7 @@ int get_literal(void)
       if (hex
           || unicode != 0
           ) {
-        if (!vim_isxdigit(nc))
+        if (!ascii_isxdigit(nc))
           break;
         cc = cc * 16 + hex2nr(nc);
       } else if (octal) {

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4730,7 +4730,7 @@ int get_literal(void)
           break;
         cc = cc * 8 + nc - '0';
       } else {
-        if (!VIM_ISDIGIT(nc))
+        if (!ascii_isdigit(nc))
           break;
         cc = cc * 10 + nc - '0';
       }
@@ -5545,7 +5545,7 @@ static void redo_literal(int c)
 
   /* Only digits need special treatment.  Translate them into a string of
    * three digits. */
-  if (VIM_ISDIGIT(c)) {
+  if (ascii_isdigit(c)) {
     vim_snprintf((char *)buf, sizeof(buf), "%03d", c);
     AppendToRedobuff(buf);
   } else

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1636,7 +1636,7 @@ static char_u *list_arg_vars(exarg_T *eap, char_u *arg, int *first)
   while (!ends_excmd(*arg) && !got_int) {
     if (error || eap->skip) {
       arg = find_name_end(arg, NULL, NULL, FNE_INCL_BR | FNE_CHECK_START);
-      if (!vim_iswhite(*arg) && !ends_excmd(*arg)) {
+      if (!ascii_iswhite(*arg) && !ends_excmd(*arg)) {
         emsg_severe = TRUE;
         EMSG(_(e_trailing));
         break;
@@ -1943,7 +1943,7 @@ get_lval (
   p = find_name_end(name, &expr_start, &expr_end, fne_flags);
   if (expr_start != NULL) {
     /* Don't expand the name when we already know there is an error. */
-    if (unlet && !vim_iswhite(*p) && !ends_excmd(*p)
+    if (unlet && !ascii_iswhite(*p) && !ends_excmd(*p)
         && *p != '[' && *p != '.') {
       EMSG(_(e_trailing));
       return NULL;
@@ -2476,7 +2476,7 @@ void *eval_for_line(char_u *arg, int *errp, char_u **nextcmdp, int skip)
     return fi;
 
   expr = skipwhite(expr);
-  if (expr[0] != 'i' || expr[1] != 'n' || !vim_iswhite(expr[2])) {
+  if (expr[0] != 'i' || expr[1] != 'n' || !ascii_iswhite(expr[2])) {
     EMSG(_("E690: Missing \"in\" after :for"));
     return fi;
   }
@@ -2556,7 +2556,7 @@ void set_context_for_expression(expand_T *xp, char_u *arg, cmdidx_T cmdidx)
       for (p = arg + STRLEN(arg); p >= arg; ) {
         xp->xp_pattern = p;
         mb_ptr_back(arg, p);
-        if (vim_iswhite(*p))
+        if (ascii_iswhite(*p))
           break;
       }
       return;
@@ -2778,7 +2778,7 @@ static void ex_unletlock(exarg_T *eap, char_u *argstart, int deep)
         FNE_CHECK_START);
     if (lv.ll_name == NULL)
       error = TRUE;                 /* error but continue parsing */
-    if (name_end == NULL || (!vim_iswhite(*name_end)
+    if (name_end == NULL || (!ascii_iswhite(*name_end)
                              && !ends_excmd(*name_end))) {
       if (name_end != NULL) {
         emsg_severe = TRUE;
@@ -16502,7 +16502,7 @@ handle_subscript (
          && (**arg == '['
              || (**arg == '.' && rettv->v_type == VAR_DICT)
              || (**arg == '(' && (!evaluate || rettv->v_type == VAR_FUNC)))
-         && !vim_iswhite(*(*arg - 1))) {
+         && !ascii_iswhite(*(*arg - 1))) {
     if (**arg == '(') {
       /* need to copy the funcref so that we can clear rettv */
       if (evaluate) {
@@ -17929,7 +17929,7 @@ void ex_function(exarg_T *eap)
       }
     } else {
       /* skip ':' and blanks*/
-      for (p = theline; vim_iswhite(*p) || *p == ':'; ++p)
+      for (p = theline; ascii_iswhite(*p) || *p == ':'; ++p)
         ;
 
       /* Check for "endfunction". */

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4551,7 +4551,7 @@ static int get_string_tv(char_u **arg, typval_T *rettv, int evaluate)
       case 'x':
       case 'u':           /* Unicode: "\u0023" */
       case 'U':
-        if (vim_isxdigit(p[1])) {
+        if (ascii_isxdigit(p[1])) {
           int n, nr;
           int c = toupper(*p);
 
@@ -4560,7 +4560,7 @@ static int get_string_tv(char_u **arg, typval_T *rettv, int evaluate)
           else
             n = 4;
           nr = 0;
-          while (--n >= 0 && vim_isxdigit(p[1])) {
+          while (--n >= 0 && ascii_isxdigit(p[1])) {
             ++p;
             nr = (nr << 4) + hex2nr(*p);
           }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1299,7 +1299,7 @@ int eval_foldexpr(char_u *arg, int *cp)
       /* If the result is a string, check if there is a non-digit before
        * the number. */
       s = tv.vval.v_string;
-      if (!VIM_ISDIGIT(*s) && *s != '-')
+      if (!ascii_isdigit(*s) && *s != '-')
         *cp = *s++;
       retval = atol((char *)s);
     }
@@ -2754,7 +2754,7 @@ void ex_lockvar(exarg_T *eap)
 
   if (eap->forceit)
     deep = -1;
-  else if (vim_isdigit(*arg)) {
+  else if (ascii_isdigit(*arg)) {
     deep = getdigits_int(&arg);
     arg = skipwhite(arg);
   }
@@ -4005,14 +4005,14 @@ eval7 (
      * strict to avoid backwards compatibility problems.
      * Don't look for a float after the "." operator, so that
      * ":let vers = 1.2.3" doesn't fail. */
-    if (!want_string && p[0] == '.' && vim_isdigit(p[1])) {
+    if (!want_string && p[0] == '.' && ascii_isdigit(p[1])) {
       get_float = TRUE;
       p = skipdigits(p + 2);
       if (*p == 'e' || *p == 'E') {
         ++p;
         if (*p == '-' || *p == '+')
           ++p;
-        if (!vim_isdigit(*p))
+        if (!ascii_isdigit(*p))
           get_float = FALSE;
         else
           p = skipdigits(p + 1);
@@ -8940,7 +8940,7 @@ static void f_function(typval_T *argvars, typval_T *rettv)
   char_u      *s;
 
   s = get_tv_string(&argvars[0]);
-  if (s == NULL || *s == NUL || VIM_ISDIGIT(*s))
+  if (s == NULL || *s == NUL || ascii_isdigit(*s))
     EMSG2(_(e_invarg2), s);
   /* Don't check an autoload name for existence here. */
   else if (vim_strchr(s, AUTOLOAD_CHAR) == NULL && !function_exists(s))
@@ -10020,9 +10020,9 @@ static void f_has(typval_T *argvars, typval_T *rettv)
     if (STRNICMP(name, "patch", 5) == 0) {
       if (name[5] == '-'
           && STRLEN(name) > 11
-          && vim_isdigit(name[6])
-          && vim_isdigit(name[8])
-          && vim_isdigit(name[10])) {
+          && ascii_isdigit(name[6])
+          && ascii_isdigit(name[8])
+          && ascii_isdigit(name[10])) {
         int major = atoi((char *)name + 6);
         int minor = atoi((char *)name + 8);
 
@@ -13663,7 +13663,7 @@ static void f_setreg(typval_T *argvars, typval_T *rettv)
         break;
       case 'b': case Ctrl_V:            /* block-wise selection */
         yank_type = MBLOCK;
-        if (VIM_ISDIGIT(stropt[1])) {
+        if (ascii_isdigit(stropt[1])) {
           ++stropt;
           block_len = getdigits_long(&stropt) - 1;
           --stropt;
@@ -17247,7 +17247,7 @@ static int valid_varname(char_u *varname)
   char_u *p;
 
   for (p = varname; *p != NUL; ++p)
-    if (!eval_isnamec1(*p) && (p == varname || !VIM_ISDIGIT(*p))
+    if (!eval_isnamec1(*p) && (p == varname || !ascii_isdigit(*p))
         && *p != AUTOLOAD_CHAR) {
       EMSG2(_(e_illvar), varname);
       return FALSE;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -266,7 +266,7 @@ static int linelen(int *has_tab)
 
   /* find the character after the last non-blank character */
   for (last = first + STRLEN(first);
-       last > first && vim_iswhite(last[-1]); --last)
+       last > first && ascii_iswhite(last[-1]); --last)
     ;
   save = *last;
   *last = NUL;
@@ -374,7 +374,7 @@ void ex_sort(exarg_T *eap)
   sort_abort = sort_ic = sort_rx = sort_nr = sort_oct = sort_hex = 0;
 
   for (p = eap->arg; *p != NUL; ++p) {
-    if (vim_iswhite(*p))
+    if (ascii_iswhite(*p))
       ;
     else if (*p == 'i')
       sort_ic = TRUE;
@@ -581,7 +581,7 @@ void ex_retab(exarg_T *eap)
     vcol = 0;
     did_undo = FALSE;
     for (;; ) {
-      if (vim_iswhite(ptr[col])) {
+      if (ascii_iswhite(ptr[col])) {
         if (!got_tab && num_spaces == 0) {
           /* First consecutive white-space */
           start_vcol = vcol;
@@ -3422,7 +3422,7 @@ void do_sub(exarg_T *eap)
     which_pat = RE_SUBST;       /* use last substitute regexp */
 
   /* new pattern and substitution */
-  if (eap->cmd[0] == 's' && *cmd != NUL && !vim_iswhite(*cmd)
+  if (eap->cmd[0] == 's' && *cmd != NUL && !ascii_iswhite(*cmd)
       && vim_strchr((char_u *)"0123456789cegriIp|\"", *cmd) == NULL) {
     /* don't accept alphanumeric for separator */
     if (isalpha(*cmd)) {
@@ -4622,7 +4622,7 @@ void ex_help(exarg_T *eap)
 
   /* remove trailing blanks */
   p = arg + STRLEN(arg) - 1;
-  while (p > arg && vim_iswhite(*p) && p[-1] != '\\')
+  while (p > arg && ascii_iswhite(*p) && p[-1] != '\\')
     *p-- = NUL;
 
   /* Check for a specified language */
@@ -5069,7 +5069,7 @@ void fix_help_buffer(void)
     for (lnum = 1; lnum <= curbuf->b_ml.ml_line_count; ++lnum) {
       line = ml_get_buf(curbuf, lnum, FALSE);
       len = (int)STRLEN(line);
-      if (in_example && len > 0 && !vim_iswhite(line[0])) {
+      if (in_example && len > 0 && !ascii_iswhite(line[0])) {
         /* End of example: non-white or '<' in first column. */
         if (line[0] == '<') {
           /* blank-out a '<' in the first column */
@@ -5281,7 +5281,7 @@ void ex_helptags(exarg_T *eap)
   int add_help_tags = FALSE;
 
   /* Check for ":helptags ++t {dir}". */
-  if (STRNCMP(eap->arg, "++t", 3) == 0 && vim_iswhite(eap->arg[3])) {
+  if (STRNCMP(eap->arg, "++t", 3) == 0 && ascii_iswhite(eap->arg[3])) {
     add_help_tags = TRUE;
     eap->arg = skipwhite(eap->arg + 3);
   }
@@ -5870,7 +5870,7 @@ void ex_sign(exarg_T *eap)
 	if (VIM_ISDIGIT(*arg))
 	{
 	    id = getdigits_int(&arg);
-	    if (!vim_iswhite(*arg) && *arg != NUL)
+	    if (!ascii_iswhite(*arg) && *arg != NUL)
 	    {
 		id = -1;
 		arg = arg1;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1858,7 +1858,7 @@ viminfo_readstring (
   char_u      *retval;
   char_u      *s, *d;
 
-  if (virp->vir_line[off] == Ctrl_V && vim_isdigit(virp->vir_line[off + 1])) {
+  if (virp->vir_line[off] == Ctrl_V && ascii_isdigit(virp->vir_line[off + 1])) {
     ssize_t len = atol((char *)virp->vir_line + off + 1);
     retval = xmalloc(len);
     // TODO(philix): change type of vim_fgets() size argument to size_t
@@ -3244,7 +3244,7 @@ void ex_z(exarg_T *eap)
     ++x;
 
   if (*x != 0) {
-    if (!VIM_ISDIGIT(*x)) {
+    if (!ascii_isdigit(*x)) {
       EMSG(_("E144: non-numeric argument to :z"));
       return;
     }
@@ -3591,7 +3591,7 @@ void do_sub(exarg_T *eap)
    * check for a trailing count
    */
   cmd = skipwhite(cmd);
-  if (VIM_ISDIGIT(*cmd)) {
+  if (ascii_isdigit(*cmd)) {
     i = getdigits_long(&cmd);
     if (i <= 0 && !eap->skip && do_error) {
       EMSG(_(e_zerocount));
@@ -5867,7 +5867,7 @@ void ex_sign(exarg_T *eap)
 
 	/* first arg could be placed sign id */
 	arg1 = arg;
-	if (VIM_ISDIGIT(*arg))
+	if (ascii_isdigit(*arg))
 	{
 	    id = getdigits_int(&arg);
 	    if (!ascii_iswhite(*arg) && *arg != NUL)

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3091,7 +3091,7 @@ void ex_language(exarg_T *eap)
    * Allow abbreviation, but require at least 3 characters to avoid
    * confusion with a two letter language name "me" or "ct". */
   p = skiptowhite(eap->arg);
-  if ((*p == NUL || vim_iswhite(*p)) && p - eap->arg >= 3) {
+  if ((*p == NUL || ascii_iswhite(*p)) && p - eap->arg >= 3) {
     if (STRNICMP(eap->arg, "messages", p - eap->arg) == 0) {
       what = VIM_LC_MESSAGES;
       name = skipwhite(p);

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1371,7 +1371,7 @@ static char_u *do_one_arg(char_u *str)
       *p++ = *str;
     } else {
       /* An item ends at a space not in backticks */
-      if (!inbacktick && vim_isspace(*str))
+      if (!inbacktick && ascii_isspace(*str))
         break;
       if (*str == '`')
         inbacktick ^= TRUE;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -465,7 +465,7 @@ dbg_parsearg (
     bp->dbg_lnum = curwin->w_cursor.lnum;
   else if (
     gap != &prof_ga &&
-    VIM_ISDIGIT(*p)) {
+    ascii_isdigit(*p)) {
     bp->dbg_lnum = getdigits_long(&p);
     p = skipwhite(p);
   } else
@@ -570,7 +570,7 @@ void ex_breakdel(exarg_T *eap)
     gap = &prof_ga;
   }
 
-  if (vim_isdigit(*eap->arg)) {
+  if (ascii_isdigit(*eap->arg)) {
     /* ":breakdel {nr}" */
     nr = atol((char *)eap->arg);
     for (int i = 0; i < gap->ga_len; ++i)
@@ -3023,7 +3023,7 @@ static char_u *get_mess_env(void)
     p = (char_u *)os_getenv("LC_MESSAGES");
     if (p == NULL || *p == NUL) {
       p = (char_u *)os_getenv("LANG");
-      if (p != NULL && VIM_ISDIGIT(*p))
+      if (p != NULL && ascii_isdigit(*p))
         p = NULL;                       /* ignore something like "1043" */
 # ifdef HAVE_GET_LOCALE_VAL
       if (p == NULL || *p == NUL)

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1251,7 +1251,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
       if (save_msg_silent == -1)
         save_msg_silent = msg_silent;
       ++msg_silent;
-      if (*ea.cmd == '!' && !vim_iswhite(ea.cmd[-1])) {
+      if (*ea.cmd == '!' && !ascii_iswhite(ea.cmd[-1])) {
         /* ":silent!", but not "silent !cmd" */
         ea.cmd = skipwhite(ea.cmd + 1);
         ++emsg_silent;
@@ -1722,7 +1722,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
    */
   if ((ea.argt & COUNT) && VIM_ISDIGIT(*ea.arg)
       && (!(ea.argt & BUFNAME) || *(p = skipdigits(ea.arg)) == NUL
-          || vim_iswhite(*p))) {
+          || ascii_iswhite(*p))) {
     n = getdigits_long(&ea.arg);
     ea.arg = skipwhite(ea.arg);
     if (n <= 0 && !ni && (ea.argt & ZEROR) == 0) {
@@ -1875,7 +1875,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
       p = skiptowhite_esc(ea.arg);
     else {
       p = ea.arg + STRLEN(ea.arg);
-      while (p > ea.arg && vim_iswhite(p[-1]))
+      while (p > ea.arg && ascii_iswhite(p[-1]))
         --p;
     }
     ea.line2 = buflist_findpat(ea.arg, p, (ea.argt & BUFUNL) != 0,
@@ -2577,7 +2577,7 @@ set_one_cmd_context (
       else if (c == '|'
             || c == '\n'
             || c == '"'
-            || vim_iswhite(c)) {
+            || ascii_iswhite(c)) {
         len = 0;          /* avoid getting stuck when space is in 'isfname' */
         while (*p != NUL) {
           if (has_mbyte)
@@ -3563,7 +3563,7 @@ int expand_filename(exarg_T *eap, char_u **cmdlinep, char_u **errormsgp)
         /* skip escaped characters */
         if (p[1] && (*p == '\\' || *p == Ctrl_V))
           ++p;
-        else if (vim_iswhite(*p)) {
+        else if (ascii_iswhite(*p)) {
           *errormsgp = (char_u *)_("E172: Only one file name allowed");
           return FAIL;
         }
@@ -4494,7 +4494,7 @@ static void ex_command(exarg_T *eap)
   if (ASCII_ISALPHA(*p))
     while (ASCII_ISALNUM(*p))
       ++p;
-  if (!ends_excmd(*p) && !vim_iswhite(*p)) {
+  if (!ends_excmd(*p) && !ascii_iswhite(*p)) {
     EMSG(_("E182: Invalid command name"));
     return;
   }
@@ -4597,13 +4597,13 @@ static char_u *uc_split_args(char_u *arg, size_t *lenp)
     if (p[0] == '\\' && p[1] == '\\') {
       len += 2;
       p += 2;
-    } else if (p[0] == '\\' && vim_iswhite(p[1])) {
+    } else if (p[0] == '\\' && ascii_iswhite(p[1])) {
       len += 1;
       p += 2;
     } else if (*p == '\\' || *p == '"') {
       len += 2;
       p += 1;
-    } else if (vim_iswhite(*p)) {
+    } else if (ascii_iswhite(*p)) {
       p = skipwhite(p);
       if (*p == NUL)
         break;
@@ -4625,13 +4625,13 @@ static char_u *uc_split_args(char_u *arg, size_t *lenp)
       *q++ = '\\';
       *q++ = '\\';
       p += 2;
-    } else if (p[0] == '\\' && vim_iswhite(p[1])) {
+    } else if (p[0] == '\\' && ascii_iswhite(p[1])) {
       *q++ = p[1];
       p += 2;
     } else if (*p == '\\' || *p == '"') {
       *q++ = '\\';
       *q++ = *p++;
-    } else if (vim_iswhite(*p)) {
+    } else if (ascii_iswhite(*p)) {
       p = skipwhite(p);
       if (*p == NUL)
         break;
@@ -8802,7 +8802,7 @@ static void ex_match(exarg_T *eap)
   if (ends_excmd(*eap->arg))
     end = eap->arg;
   else if ((STRNICMP(eap->arg, "none", 4) == 0
-            && (vim_iswhite(eap->arg[4]) || ends_excmd(eap->arg[4]))))
+            && (ascii_iswhite(eap->arg[4]) || ends_excmd(eap->arg[4]))))
     end = eap->arg + 4;
   else {
     p = skiptowhite(eap->arg);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1157,7 +1157,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
      * 2. handle command modifiers.
      */
     p = ea.cmd;
-    if (VIM_ISDIGIT(*ea.cmd))
+    if (ascii_isdigit(*ea.cmd))
       p = skipwhite(skipdigits(ea.cmd));
     switch (*p) {
     /* When adding an entry, also modify cmd_exists(). */
@@ -1260,7 +1260,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
       continue;
 
     case 't':   if (checkforcmd(&p, "tab", 3)) {
-        if (vim_isdigit(*ea.cmd))
+        if (ascii_isdigit(*ea.cmd))
           cmdmod.tab = atoi((char *)ea.cmd) + 1;
         else
           cmdmod.tab = tabpage_index(curtab) + 1;
@@ -1287,7 +1287,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
         break;
       if (verbose_save < 0)
         verbose_save = p_verbose;
-      if (vim_isdigit(*ea.cmd))
+      if (ascii_isdigit(*ea.cmd))
         p_verbose = atoi((char *)ea.cmd);
       else
         p_verbose = 1;
@@ -1703,7 +1703,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
       && *ea.arg != NUL
       /* Do not allow register = for user commands */
       && (!IS_USER_CMDIDX(ea.cmdidx) || *ea.arg != '=')
-      && !((ea.argt & COUNT) && VIM_ISDIGIT(*ea.arg))) {
+      && !((ea.argt & COUNT) && ascii_isdigit(*ea.arg))) {
     if (valid_yank_reg(*ea.arg, (ea.cmdidx != CMD_put
                                  && !IS_USER_CMDIDX(ea.cmdidx)))) {
       ea.regname = *ea.arg++;
@@ -1720,7 +1720,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
    * Check for a count.  When accepting a BUFNAME, don't use "123foo" as a
    * count, it's a buffer name.
    */
-  if ((ea.argt & COUNT) && VIM_ISDIGIT(*ea.arg)
+  if ((ea.argt & COUNT) && ascii_isdigit(*ea.arg)
       && (!(ea.argt & BUFNAME) || *(p = skipdigits(ea.arg)) == NUL
           || ascii_iswhite(*p))) {
     n = getdigits_long(&ea.arg);
@@ -2168,7 +2168,7 @@ find_ucmd (
       k = 0;
       while (k < len && *np != NUL && *cp++ == *np++)
         k++;
-      if (k == len || (*np == NUL && vim_isdigit(eap->cmd[k]))) {
+      if (k == len || (*np == NUL && ascii_isdigit(eap->cmd[k]))) {
         /* If finding a second match, the command is ambiguous.  But
          * not if a buffer-local command wasn't a full match and a
          * global command is a full match. */
@@ -2272,7 +2272,7 @@ int modifier_len(char_u *cmd)
   int i, j;
   char_u      *p = cmd;
 
-  if (VIM_ISDIGIT(*cmd))
+  if (ascii_isdigit(*cmd))
     p = skipwhite(skipdigits(cmd));
   for (i = 0; i < (int)ARRAY_SIZE(cmdmods); ++i) {
     for (j = 0; p[j] != NUL; ++j)
@@ -2314,7 +2314,7 @@ int cmd_exists(char_u *name)
   p = find_command(&ea, &full);
   if (p == NULL)
     return 3;
-  if (vim_isdigit(*name) && ea.cmdidx != CMD_match)
+  if (ascii_isdigit(*name) && ea.cmdidx != CMD_match)
     return 0;
   if (*skipwhite(p) != NUL)
     return 0;           /* trailing garbage */
@@ -3223,22 +3223,22 @@ get_address (
       break;
 
     default:
-      if (VIM_ISDIGIT(*cmd))                    /* absolute line number */
+      if (ascii_isdigit(*cmd))                    /* absolute line number */
         lnum = getdigits_long(&cmd);
     }
 
     for (;; ) {
       cmd = skipwhite(cmd);
-      if (*cmd != '-' && *cmd != '+' && !VIM_ISDIGIT(*cmd))
+      if (*cmd != '-' && *cmd != '+' && !ascii_isdigit(*cmd))
         break;
 
       if (lnum == MAXLNUM)
         lnum = curwin->w_cursor.lnum;           /* "+1" is same as ".+1" */
-      if (VIM_ISDIGIT(*cmd))
+      if (ascii_isdigit(*cmd))
         i = '+';                        /* "number" is same as "+number" */
       else
         i = *cmd++;
-      if (!VIM_ISDIGIT(*cmd))           /* '+' is '+1', but '+0' is not '+1' */
+      if (!ascii_isdigit(*cmd))           /* '+' is '+1', but '+0' is not '+1' */
         n = 1;
       else
         n = getdigits_long(&cmd);
@@ -6878,7 +6878,7 @@ static void ex_mkrc(exarg_T *eap)
   /* ":mkview" or ":mkview 9": generate file name with 'viewdir' */
   if (eap->cmdidx == CMD_mkview
       && (*eap->arg == NUL
-          || (vim_isdigit(*eap->arg) && eap->arg[1] == NUL))) {
+          || (ascii_isdigit(*eap->arg) && eap->arg[1] == NUL))) {
     eap->forceit = TRUE;
     fname = get_view_file(*eap->arg);
     if (fname == NULL)
@@ -7295,7 +7295,7 @@ static void ex_findpat(exarg_T *eap)
   }
 
   n = 1;
-  if (vim_isdigit(*eap->arg)) { /* get count */
+  if (ascii_isdigit(*eap->arg)) { /* get count */
     n = getdigits_long(&eap->arg);
     eap->arg = skipwhite(eap->arg);
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3718,7 +3718,7 @@ static char_u *getargcmd(char_u **argp)
 
   if (*arg == '+') {        /* +[command] */
     ++arg;
-    if (vim_isspace(*arg) || *arg == '\0')
+    if (ascii_isspace(*arg) || *arg == '\0')
       command = dollar_command;
     else {
       command = arg;
@@ -3742,7 +3742,7 @@ skip_cmd_arg (
     int rembs              /* TRUE to halve the number of backslashes */
 )
 {
-  while (*p && !vim_isspace(*p)) {
+  while (*p && !ascii_isspace(*p)) {
     if (*p == '\\' && p[1] != NUL) {
       if (rembs)
         STRMOVE(p, p + 1);

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -257,9 +257,9 @@ int cause_errthrow(char_u *mesg, int severe, int *ignore)
         /* Skip the extra "Vim " prefix for message "E458". */
         tmsg = elem->msg;
         if (STRNCMP(tmsg, "Vim E", 5) == 0
-            && VIM_ISDIGIT(tmsg[5])
-            && VIM_ISDIGIT(tmsg[6])
-            && VIM_ISDIGIT(tmsg[7])
+            && ascii_isdigit(tmsg[5])
+            && ascii_isdigit(tmsg[6])
+            && ascii_isdigit(tmsg[7])
             && tmsg[8] == ':'
             && tmsg[9] == ' ')
           (*msg_list)->throw_msg = &tmsg[4];
@@ -405,11 +405,11 @@ char_u *get_exception_string(void *value, int type, char_u *cmdname, int *should
     for (p = mesg;; p++) {
       if (*p == NUL
           || (*p == 'E'
-              && VIM_ISDIGIT(p[1])
+              && ascii_isdigit(p[1])
               && (p[2] == ':'
-                  || (VIM_ISDIGIT(p[2])
+                  || (ascii_isdigit(p[2])
                       && (p[3] == ':'
-                          || (VIM_ISDIGIT(p[3])
+                          || (ascii_isdigit(p[3])
                               && p[4] == ':')))))) {
         if (*p == NUL || p == mesg)
           STRCAT(val, mesg);            /* 'E123' missing or at beginning */

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4641,7 +4641,7 @@ int get_list_range(char_u **str, int *num1, int *num2)
   long num;
 
   *str = skipwhite(*str);
-  if (**str == '-' || vim_isdigit(**str)) {  /* parse "from" part of range */
+  if (**str == '-' || ascii_isdigit(**str)) {  /* parse "from" part of range */
     vim_str2nr(*str, NULL, &len, FALSE, FALSE, &num, NULL);
     *str += len;
     *num1 = (int)num;
@@ -4681,7 +4681,7 @@ void ex_history(exarg_T *eap)
     return;
   }
 
-  if (!(VIM_ISDIGIT(*arg) || *arg == '-' || *arg == ',')) {
+  if (!(ascii_isdigit(*arg) || *arg == '-' || *arg == ',')) {
     end = arg;
     while (ASCII_ISALPHA(*end)
            || vim_strchr((char_u *)":=@>/?", *end) != NULL)

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -792,7 +792,7 @@ getcmdline (
         if (has_mbyte) {
           p = mb_prevptr(ccline.cmdbuff, p);
           if (c == Ctrl_W) {
-            while (p > ccline.cmdbuff && vim_isspace(*p))
+            while (p > ccline.cmdbuff && ascii_isspace(*p))
               p = mb_prevptr(ccline.cmdbuff, p);
             i = mb_get_class(p);
             while (p > ccline.cmdbuff && mb_get_class(p) == i)
@@ -801,10 +801,10 @@ getcmdline (
               p += (*mb_ptr2len)(p);
           }
         } else if (c == Ctrl_W)  {
-          while (p > ccline.cmdbuff && vim_isspace(p[-1]))
+          while (p > ccline.cmdbuff && ascii_isspace(p[-1]))
             --p;
           i = vim_iswordc(p[-1]);
-          while (p > ccline.cmdbuff && !vim_isspace(p[-1])
+          while (p > ccline.cmdbuff && !ascii_isspace(p[-1])
                  && vim_iswordc(p[-1]) == i)
             --p;
         } else

--- a/src/nvim/farsi.c
+++ b/src/nvim/farsi.c
@@ -599,7 +599,7 @@ int fkmap(int c)
     return c;
   }
 
-  if (VIM_ISDIGIT(c)
+  if (ascii_isdigit(c)
       || ((c == '.'
            || c == '+'
            || c == '-'

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2006,7 +2006,7 @@ failed:
 static int is_dev_fd_file(char_u *fname)
 {
   return STRNCMP(fname, "/dev/fd/", 8) == 0
-         && VIM_ISDIGIT(fname[8])
+         && ascii_isdigit(fname[8])
          && *skipdigits(fname + 9) == NUL
          && (fname[9] != NUL
              || (fname[8] != '0' && fname[8] != '1' && fname[8] != '2'));

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5524,7 +5524,7 @@ static event_T event_name2nr(char_u *start, char_u **end)
   int len;
 
   /* the event name ends with end of line, a blank or a comma */
-  for (p = start; *p && !vim_iswhite(*p) && *p != ','; ++p)
+  for (p = start; *p && !ascii_iswhite(*p) && *p != ','; ++p)
     ;
   for (i = 0; event_names[i].name != NULL; ++i) {
     len = (int)STRLEN(event_names[i].name);
@@ -5565,13 +5565,13 @@ find_end_event (
   char_u  *p;
 
   if (*arg == '*') {
-    if (arg[1] && !vim_iswhite(arg[1])) {
+    if (arg[1] && !ascii_iswhite(arg[1])) {
       EMSG2(_("E215: Illegal character after *: %s"), arg);
       return NULL;
     }
     pat = arg + 1;
   } else {
-    for (pat = arg; *pat && !vim_iswhite(*pat); pat = p) {
+    for (pat = arg; *pat && !ascii_iswhite(*pat); pat = p) {
       if ((int)event_name2nr(pat, &p) >= (int)NUM_EVENTS) {
         if (have_group)
           EMSG2(_("E216: No such event: %s"), pat);
@@ -5711,7 +5711,7 @@ void do_autocmd(char_u *arg, int forceit)
    */
   pat = skipwhite(pat);
   cmd = pat;
-  while (*cmd && (!vim_iswhite(*cmd) || cmd[-1] == '\\'))
+  while (*cmd && (!ascii_iswhite(*cmd) || cmd[-1] == '\\'))
     cmd++;
   if (*cmd)
     *cmd++ = NUL;
@@ -5736,7 +5736,7 @@ void do_autocmd(char_u *arg, int forceit)
    * Check for "nested" flag.
    */
   cmd = skipwhite(cmd);
-  if (*cmd != NUL && STRNCMP(cmd, "nested", 6) == 0 && vim_iswhite(cmd[6])) {
+  if (*cmd != NUL && STRNCMP(cmd, "nested", 6) == 0 && ascii_iswhite(cmd[6])) {
     nested = TRUE;
     cmd = skipwhite(cmd + 6);
   }
@@ -5772,7 +5772,7 @@ void do_autocmd(char_u *arg, int forceit)
               nested, cmd, forceit, group) == FAIL)
         break;
   } else {
-    while (*arg && !vim_iswhite(*arg)) {
+    while (*arg && !ascii_iswhite(*arg)) {
       event_T event = event_name2nr(arg, &arg);
       assert(event < NUM_EVENTS);
       if (do_autocmd_event(event, pat, nested, cmd, forceit, group) == FAIL) {
@@ -6056,7 +6056,7 @@ do_doautocmd (
   /*
    * Loop over the events.
    */
-  while (*arg && !vim_iswhite(*arg))
+  while (*arg && !ascii_iswhite(*arg))
     if (apply_autocmds_group(event_name2nr(arg, &arg),
             fname, NULL, TRUE, group, curbuf, NULL))
       nothing_done = FALSE;
@@ -6983,13 +6983,13 @@ set_context_in_autocmd (
   group = au_get_grouparg(&arg);
 
   /* If there only is a group name that's what we expand. */
-  if (*arg == NUL && group != AUGROUP_ALL && !vim_iswhite(arg[-1])) {
+  if (*arg == NUL && group != AUGROUP_ALL && !ascii_iswhite(arg[-1])) {
     arg = p;
     group = AUGROUP_ALL;
   }
 
   /* skip over event name */
-  for (p = arg; *p != NUL && !vim_iswhite(*p); ++p)
+  for (p = arg; *p != NUL && !ascii_iswhite(*p); ++p)
     if (*p == ',')
       arg = p + 1;
   if (*p == NUL) {
@@ -7002,7 +7002,7 @@ set_context_in_autocmd (
 
   /* skip over pattern */
   arg = skipwhite(p);
-  while (*arg && (!vim_iswhite(*arg) || arg[-1] == '\\'))
+  while (*arg && (!ascii_iswhite(*arg) || arg[-1] == '\\'))
     arg++;
   if (*arg)
     return arg;                             /* expand (next) command */

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1651,7 +1651,7 @@ static void foldDelMarker(linenr_T lnum, char_u *marker, size_t markerlen)
     }
     /* Found the marker, include a digit if it's there. */
     size_t len = markerlen;
-    if (VIM_ISDIGIT(p[len]))
+    if (ascii_isdigit(p[len]))
       ++len;
     if (*cms != NUL) {
       /* Also delete 'commentstring' if it matches. */
@@ -1815,7 +1815,7 @@ void foldtext_cleanup(char_u *str)
     else if (STRNCMP(s, foldendmarker, foldendmarkerlen) == 0)
       len = foldendmarkerlen;
     if (len > 0) {
-      if (VIM_ISDIGIT(s[len]))
+      if (ascii_isdigit(s[len]))
         ++len;
 
       /* May remove 'commentstring' start.  Useful when it's a double
@@ -2799,7 +2799,7 @@ static void foldlevelMarker(fline_T *flp)
         && STRNCMP(s + 1, startmarker, foldstartmarkerlen - 1) == 0) {
       /* found startmarker: set flp->lvl */
       s += foldstartmarkerlen;
-      if (VIM_ISDIGIT(*s)) {
+      if (ascii_isdigit(*s)) {
         n = atoi((char *)s);
         if (n > 0) {
           flp->lvl = n;
@@ -2818,7 +2818,7 @@ static void foldlevelMarker(fline_T *flp)
                                      foldendmarkerlen - 1) == 0) {
       /* found endmarker: set flp->lvl_next */
       s += foldendmarkerlen;
-      if (VIM_ISDIGIT(*s)) {
+      if (ascii_isdigit(*s)) {
         n = atoi((char *)s);
         if (n > 0) {
           flp->lvl = n;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1787,7 +1787,7 @@ void foldtext_cleanup(char_u *str)
   /* Ignore leading and trailing white space in 'commentstring'. */
   char_u *cms_start = skipwhite(curbuf->b_p_cms);
   size_t cms_slen = STRLEN(cms_start);
-  while (cms_slen > 0 && vim_iswhite(cms_start[cms_slen - 1]))
+  while (cms_slen > 0 && ascii_iswhite(cms_start[cms_slen - 1]))
     --cms_slen;
 
   /* locate "%s" in 'commentstring', use the part before and after it. */
@@ -1798,7 +1798,7 @@ void foldtext_cleanup(char_u *str)
     cms_slen = (size_t)(cms_end - cms_start);
 
     /* exclude white space before "%s" */
-    while (cms_slen > 0 && vim_iswhite(cms_start[cms_slen - 1]))
+    while (cms_slen > 0 && ascii_iswhite(cms_start[cms_slen - 1]))
       --cms_slen;
 
     /* skip "%s" and white space after it */
@@ -1820,7 +1820,7 @@ void foldtext_cleanup(char_u *str)
 
       /* May remove 'commentstring' start.  Useful when it's a double
        * quote and we already removed a double quote. */
-      for (p = s; p > str && vim_iswhite(p[-1]); --p)
+      for (p = s; p > str && ascii_iswhite(p[-1]); --p)
         ;
       if (p >= str + cms_slen
           && STRNCMP(p - cms_slen, cms_start, cms_slen) == 0) {
@@ -1838,7 +1838,7 @@ void foldtext_cleanup(char_u *str)
       }
     }
     if (len != 0) {
-      while (vim_iswhite(s[len]))
+      while (ascii_iswhite(s[len]))
         ++len;
       STRMOVE(s, s + len);
     } else {

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2129,7 +2129,7 @@ static int vgetorpeek(int advance)
                 col = vcol = curwin->w_wcol = 0;
                 ptr = get_cursor_line_ptr();
                 while (col < curwin->w_cursor.col) {
-                  if (!vim_iswhite(ptr[col]))
+                  if (!ascii_iswhite(ptr[col]))
                     curwin->w_wcol = vcol;
                   vcol += lbr_chartabsize(ptr, ptr + col,
                       (colnr_T)vcol);
@@ -2672,7 +2672,7 @@ do_map (
    */
   p = keys;
   do_backslash = (vim_strchr(p_cpo, CPO_BSLASH) == NULL);
-  while (*p && (maptype == 1 || !vim_iswhite(*p))) {
+  while (*p && (maptype == 1 || !ascii_iswhite(*p))) {
     if ((p[0] == Ctrl_V || (do_backslash && p[0] == '\\')) &&
         p[1] != NUL)
       ++p;                      /* skip CTRL-V or backslash */
@@ -2761,7 +2761,7 @@ do_map (
           }
       /* An abbreviation cannot contain white space. */
       for (n = 0; n < len; ++n)
-        if (vim_iswhite(keys[n])) {
+        if (ascii_iswhite(keys[n])) {
           retval = 1;
           goto theend;
         }
@@ -4074,7 +4074,7 @@ int put_escstr(FILE *fd, char_u *strstart, int what)
      * interpreted as the start of a special key name.
      * A space in the lhs of a :map needs a CTRL-V.
      */
-    if (what == 2 && (vim_iswhite(c) || c == '"' || c == '\\')) {
+    if (what == 2 && (ascii_iswhite(c) || c == '"' || c == '\\')) {
       if (putc('\\', fd) < 0)
         return FAIL;
     } else if (c < ' ' || c > '~' || c == '|'

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3568,7 +3568,7 @@ int check_abbr(int c, char_u *ptr, int col, int mincol)
     clen = 1;
     while (p > ptr + mincol) {
       p = mb_prevptr(ptr, p);
-      if (vim_isspace(*p) || (!vim_abbr && is_id != vim_iswordp(p))) {
+      if (ascii_isspace(*p) || (!vim_abbr && is_id != vim_iswordp(p))) {
         p += (*mb_ptr2len)(p);
         break;
       }
@@ -3583,7 +3583,7 @@ int check_abbr(int c, char_u *ptr, int col, int mincol)
       if (col > 1)
         is_id = vim_iswordc(ptr[col - 2]);
     }
-    for (scol = col - 1; scol > 0 && !vim_isspace(ptr[scol - 1])
+    for (scol = col - 1; scol > 0 && !ascii_isspace(ptr[scol - 1])
          && (vim_abbr || is_id == vim_iswordc(ptr[scol - 1])); --scol)
       ;
   }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -771,7 +771,7 @@ int start_redo(long count, int old_redo)
 
   /* try to enter the count (in place of a previous count) */
   if (count) {
-    while (VIM_ISDIGIT(c))      /* skip "old" count */
+    while (ascii_isdigit(c))      /* skip "old" count */
       c = read_redo(FALSE, old_redo);
     add_num_buff(&readbuf2, count);
   }

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -317,7 +317,7 @@ static char_u *parse_list_options(char_u *option_str, option_table_T *table, int
     table[idx].present = TRUE;
 
     if (table[idx].hasnum) {
-      if (!VIM_ISDIGIT(*p))
+      if (!ascii_isdigit(*p))
         return (char_u *)N_("E552: digit expected");
 
       table[idx].number = getdigits_int(&p);
@@ -2272,7 +2272,7 @@ int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
    */
   fontsize = PRT_PS_DEFAULT_FONTSIZE;
   for (p = p_pfn; (p = vim_strchr(p, ':')) != NULL; ++p)
-    if (p[1] == 'h' && VIM_ISDIGIT(p[2]))
+    if (p[1] == 'h' && ascii_isdigit(p[2]))
       fontsize = atoi((char *)p + 2);
   prt_font_metrics(fontsize);
 

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -687,7 +687,7 @@ static char *cs_create_cmd(char *csoption, char *pattern)
    * they may want to use the leading white space. */
   pat = pattern;
   if (search != 4 && search != 6)
-    while (vim_iswhite(*pat))
+    while (ascii_iswhite(*pat))
       ++pat;
 
   cmd = xmalloc(strlen(pat) + 2);

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1273,9 +1273,9 @@ static int cs_kill(exarg_T *eap)
   }
 
   /* only single digit positive and negative integers are allowed */
-  if ((strlen(stok) < 2 && VIM_ISDIGIT((int)(stok[0])))
+  if ((strlen(stok) < 2 && ascii_isdigit((int)(stok[0])))
       || (strlen(stok) < 3 && stok[0] == '-'
-          && VIM_ISDIGIT((int)(stok[1]))))
+          && ascii_isdigit((int)(stok[1]))))
     i = atoi(stok);
   else {
     /* It must be part of a name.  We will try to find a match

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -706,7 +706,8 @@ int get_lisp_indent(void)
 
             if (vi_lisp || ((*that != '"') && (*that != '\'')
                 && (*that != '#') && ((*that < '0') || (*that > '9')))) {
-              while (*that && (!ascii_iswhite(*that) || quotecount || parencount)
+              while (*that
+                     && (!ascii_iswhite(*that) || quotecount || parencount)
                      && (!((*that == '(' || *that == '[')
                      && !quotecount && !parencount && vi_lisp))) {
                 if (*that == '"') {

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -118,7 +118,7 @@ int set_indent(int size, int flags)
       ind_done = 0;
 
       // Count as many characters as we can use.
-      while (todo > 0 && vim_iswhite(*p)) {
+      while (todo > 0 && ascii_iswhite(*p)) {
         if (*p == TAB) {
           tab_pad = (int)curbuf->b_p_ts - (ind_done % (int)curbuf->b_p_ts);
 
@@ -183,7 +183,7 @@ int set_indent(int size, int flags)
   }
 
   // Return if the indent is OK already.
-  if (!doit && !vim_iswhite(*p) && !(flags & SIN_INSERT)) {
+  if (!doit && !ascii_iswhite(*p) && !(flags & SIN_INSERT)) {
     return false;
   }
 
@@ -216,7 +216,7 @@ int set_indent(int size, int flags)
 
     // Skip over any additional white space (useful when newindent is less
     // than old).
-    while (vim_iswhite(*p)) {
+    while (ascii_iswhite(*p)) {
       p++;
     }
   } else {
@@ -235,7 +235,7 @@ int set_indent(int size, int flags)
       p = oldline;
       ind_done = 0;
 
-      while (todo > 0 && vim_iswhite(*p)) {
+      while (todo > 0 && ascii_iswhite(*p)) {
         if (*p == TAB) {
           tab_pad = (int)curbuf->b_p_ts - (ind_done % (int)curbuf->b_p_ts);
 
@@ -328,7 +328,7 @@ int copy_indent(int size, char_u *src)
     s = src;
 
     // Count/copy the usable portion of the source line.
-    while (todo > 0 && vim_iswhite(*s)) {
+    while (todo > 0 && ascii_iswhite(*s)) {
       if (*s == TAB) {
         tab_pad = (int)curbuf->b_p_ts
                   - (ind_done % (int)curbuf->b_p_ts);
@@ -502,7 +502,7 @@ int inindent(int extra)
   char_u      *ptr;
   colnr_T col;
 
-  for (col = 0, ptr = get_cursor_line_ptr(); vim_iswhite(*ptr); ++col) {
+  for (col = 0, ptr = get_cursor_line_ptr(); ascii_iswhite(*ptr); ++col) {
     ptr++;
   }
 
@@ -688,7 +688,7 @@ int get_lisp_indent(void)
           amount++;
           firsttry = amount;
 
-          while (vim_iswhite(*that)) {
+          while (ascii_iswhite(*that)) {
             amount += lbr_chartabsize(line, that, (colnr_T)amount);
             that++;
           }
@@ -706,7 +706,7 @@ int get_lisp_indent(void)
 
             if (vi_lisp || ((*that != '"') && (*that != '\'')
                 && (*that != '#') && ((*that < '0') || (*that > '9')))) {
-              while (*that && (!vim_iswhite(*that) || quotecount || parencount)
+              while (*that && (!ascii_iswhite(*that) || quotecount || parencount)
                      && (!((*that == '(' || *that == '[')
                      && !quotecount && !parencount && vi_lisp))) {
                 if (*that == '"') {
@@ -726,7 +726,7 @@ int get_lisp_indent(void)
               }
             }
 
-            while (vim_iswhite(*that)) {
+            while (ascii_iswhite(*that)) {
               amount += lbr_chartabsize(line, that, (colnr_T)amount);
               that++;
             }

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -82,7 +82,7 @@ static char_u *skip_string(char_u *p)
       i = 2;
       if (p[1] == '\\') {                   /* '\n' or '\000' */
         ++i;
-        while (vim_isdigit(p[i - 1]))           /* '\000' */
+        while (ascii_isdigit(p[i - 1]))           /* '\000' */
           ++i;
       }
       if (p[i] == '\'') {                   /* check for trailing ' */
@@ -1467,7 +1467,7 @@ void parse_cino(buf_T *buf)
     divider = 0;
     if (*p == '.') {        /* ".5s" means a fraction */
       fraction = atoi((char *)++p);
-      while (VIM_ISDIGIT(*p)) {
+      while (ascii_isdigit(*p)) {
         ++p;
         if (divider)
           divider *= 10;
@@ -1673,7 +1673,7 @@ int get_c_indent(void)
           what = *p++;
         else if (*p == COM_LEFT || *p == COM_RIGHT)
           align = *p++;
-        else if (VIM_ISDIGIT(*p) || *p == '-') {
+        else if (ascii_isdigit(*p) || *p == '-') {
           off = getdigits_int(&p);
         }
         else

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -434,7 +434,7 @@ static int cin_is_cpp_namespace(char_u *s)
   if (STRNCMP(s, "namespace", 9) == 0 && (s[9] == NUL || !vim_iswordc(s[9]))) {
     p = cin_skipcomment(skipwhite(s + 9));
     while (*p != NUL) {
-      if (vim_iswhite(*p)) {
+      if (ascii_iswhite(*p)) {
         has_name = TRUE;         /* found end of a name */
         p = cin_skipcomment(skipwhite(p));
       } else if (*p == '{') {
@@ -561,15 +561,15 @@ static int cin_first_id_amount(void)
   else if ((len == 8 && STRNCMP(p, "unsigned", 8) == 0)
            || (len == 6 && STRNCMP(p, "signed", 6) == 0)) {
     s = skipwhite(p + len);
-    if ((STRNCMP(s, "int", 3) == 0 && vim_iswhite(s[3]))
-        || (STRNCMP(s, "long", 4) == 0 && vim_iswhite(s[4]))
-        || (STRNCMP(s, "short", 5) == 0 && vim_iswhite(s[5]))
-        || (STRNCMP(s, "char", 4) == 0 && vim_iswhite(s[4])))
+    if ((STRNCMP(s, "int", 3) == 0 && ascii_iswhite(s[3]))
+        || (STRNCMP(s, "long", 4) == 0 && ascii_iswhite(s[4]))
+        || (STRNCMP(s, "short", 5) == 0 && ascii_iswhite(s[5]))
+        || (STRNCMP(s, "char", 4) == 0 && ascii_iswhite(s[4])))
       p = s;
   }
   for (len = 0; vim_isIDc(p[len]); ++len)
     ;
-  if (len == 0 || !vim_iswhite(p[len]) || cin_nocode(p))
+  if (len == 0 || !ascii_iswhite(p[len]) || cin_nocode(p))
     return 0;
 
   p = skipwhite(p + len);
@@ -889,7 +889,7 @@ static int cin_is_if_for_while_before_offset(char_u *line, int *poffset)
 
   if (offset-- < 2)
     return 0;
-  while (offset > 2 && vim_iswhite(line[offset]))
+  while (offset > 2 && ascii_iswhite(line[offset]))
     --offset;
 
   offset -= 1;
@@ -1942,7 +1942,7 @@ int get_c_indent(void)
               our_paren_pos.col++;
             else {
               col = our_paren_pos.col + 1;
-              while (vim_iswhite(l[col]))
+              while (ascii_iswhite(l[col]))
                 col++;
               if (l[col] != NUL)                /* In case of trailing space */
                 our_paren_pos.col = col;

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -601,7 +601,7 @@ find_special_key (
      */
     if (bp >= last_dash) {
       if (STRNICMP(last_dash + 1, "char-", 5) == 0
-          && VIM_ISDIGIT(last_dash[6])) {
+          && ascii_isdigit(last_dash[6])) {
         /* <Char-123> or <Char-033> or <Char-0x33> */
         vim_str2nr(last_dash + 6, NULL, NULL, TRUE, TRUE, NULL, &n);
         key = (int)n;
@@ -788,7 +788,7 @@ char_u * replace_termcodes (
   src = from;
 
   // Check for #n at start only: function key n
-  if (from_part && src[0] == '#' && VIM_ISDIGIT(src[1])) {  // function key
+  if (from_part && src[0] == '#' && ascii_isdigit(src[1])) {  // function key
     result[dlen++] = K_SPECIAL;
     result[dlen++] = 'k';
     if (src[1] == '0') {

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -56,17 +56,12 @@
 # define TOUPPER_ASC(c) (((c) < 'a' || (c) > 'z') ? (c) : (c) - ('a' - 'A'))
 # define TOLOWER_ASC(c) (((c) < 'A' || (c) > 'Z') ? (c) : (c) + ('a' - 'A'))
 
-/* Use our own isdigit() replacement, because on MS-Windows isdigit() returns
- * non-zero for superscript 1.  Also avoids that isdigit() crashes for numbers
- * below 0 and above 255.  */
-#define VIM_ISDIGIT(c) ((unsigned)(c) >= '0' && (unsigned)(c) <= '9')
-
 /* Like isalpha() but reject non-ASCII characters.  Can't be used with a
  * special key (negative value). */
 # define ASCII_ISLOWER(c) ((unsigned)(c) >= 'a' && (unsigned)(c) <= 'z')
 # define ASCII_ISUPPER(c) ((unsigned)(c) >= 'A' && (unsigned)(c) <= 'Z')
 # define ASCII_ISALPHA(c) (ASCII_ISUPPER(c) || ASCII_ISLOWER(c))
-# define ASCII_ISALNUM(c) (ASCII_ISALPHA(c) || VIM_ISDIGIT(c))
+# define ASCII_ISALNUM(c) (ASCII_ISALPHA(c) || ascii_isdigit(c))
 
 /* macro version of chartab().
  * Only works with values 0-255!

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -806,9 +806,9 @@ void getout(int exitval)
 /// @return argument's numeric value otherwise
 static int get_number_arg(const char *p, int *idx, int def)
 {
-  if (vim_isdigit(p[*idx])) {
+  if (ascii_isdigit(p[*idx])) {
     def = atoi(&(p[*idx]));
-    while (vim_isdigit(p[*idx])) {
+    while (ascii_isdigit(p[*idx])) {
       *idx = *idx + 1;
     }
   }
@@ -1096,7 +1096,7 @@ static void command_line_scan(mparm_T *parmp)
 
         case 'w':                 /* "-w{number}"	set window height */
           /* "-w {scriptout}"	write to script */
-          if (vim_isdigit(((char_u *)argv[0])[argv_idx])) {
+          if (ascii_isdigit(((char_u *)argv[0])[argv_idx])) {
             n = get_number_arg(argv[0], &argv_idx, 10);
             set_option_value((char_u *)"window", n, NULL, 0);
             break;
@@ -1240,7 +1240,7 @@ scripterror:
 
           case 'w':               /* "-w {nr}" 'window' value */
             /* "-w {scriptout}" append to script file */
-            if (vim_isdigit(*((char_u *)argv[0]))) {
+            if (ascii_isdigit(*((char_u *)argv[0]))) {
               argv_idx = 0;
               n = get_number_arg(argv[0], &argv_idx, 10);
               set_option_value((char_u *)"window", n, NULL, 0);

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -358,8 +358,8 @@ pos_T *getmark_buf_fnum(buf_T *buf, int c, int changefile, int *fnum)
     }
   } else if (ASCII_ISLOWER(c)) {      /* normal named mark */
     posp = &(buf->b_namedm[c - 'a']);
-  } else if (ASCII_ISUPPER(c) || VIM_ISDIGIT(c)) {    /* named file mark */
-    if (VIM_ISDIGIT(c))
+  } else if (ASCII_ISUPPER(c) || ascii_isdigit(c)) {    /* named file mark */
+    if (ascii_isdigit(c))
       c = c - '0' + NMARKS;
     else
       c -= 'A';
@@ -708,14 +708,14 @@ void ex_delmarks(exarg_T *eap)
     /* clear specified marks only */
     for (p = eap->arg; *p != NUL; ++p) {
       lower = ASCII_ISLOWER(*p);
-      digit = VIM_ISDIGIT(*p);
+      digit = ascii_isdigit(*p);
       if (lower || digit || ASCII_ISUPPER(*p)) {
         if (p[1] == '-') {
           /* clear range of marks */
           from = *p;
           to = p[2];
           if (!(lower ? ASCII_ISLOWER(p[2])
-                : (digit ? VIM_ISDIGIT(p[2])
+                : (digit ? ascii_isdigit(p[2])
                    : ASCII_ISUPPER(p[2])))
               || to < from) {
             EMSG2(_(e_invarg2), p);
@@ -1183,7 +1183,7 @@ int read_viminfo_filemark(vir_T *virp, int force)
   str = virp->vir_line + 1;
   if (
     *str <= 127 &&
-    ((*virp->vir_line == '\'' && (VIM_ISDIGIT(*str) || isupper(*str)))
+    ((*virp->vir_line == '\'' && (ascii_isdigit(*str) || isupper(*str)))
      || (*virp->vir_line == '-' && *str == '\''))) {
     if (*str == '\'') {
       /* If the jumplist isn't full insert fmark as oldest entry */
@@ -1198,7 +1198,7 @@ int read_viminfo_filemark(vir_T *virp, int force)
         fm->fmark.mark.lnum = 0;
         fm->fname = NULL;
       }
-    } else if (VIM_ISDIGIT(*str))
+    } else if (ascii_isdigit(*str))
       fm = &namedfm[*str - '0' + NMARKS];
     else {  // is uppercase
       assert(*str >= 'A' && *str <= 'Z');

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1430,7 +1430,7 @@ void copy_viminfo_marks(vir_T *virp, FILE *fp_out, int count, int eof, int flags
     str = skipwhite(line + 1);
     str = viminfo_readstring(virp, (int)(str - virp->vir_line), FALSE);
     p = str + STRLEN(str);
-    while (p != str && (*p == NUL || vim_isspace(*p)))
+    while (p != str && (*p == NUL || ascii_isspace(*p)))
       p--;
     if (*p)
       p++;

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -668,7 +668,7 @@ int mb_get_class(const char_u *p)
 int mb_get_class_buf(const char_u *p, buf_T *buf)
 {
   if (MB_BYTE2LEN(p[0]) == 1) {
-    if (p[0] == NUL || vim_iswhite(p[0]))
+    if (p[0] == NUL || ascii_iswhite(p[0]))
       return 0;
     if (vim_iswordc_buf(p[0], buf))
       return 2;

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -115,7 +115,7 @@ ex_menu (
    * Fill in the priority table.
    */
   for (p = arg; *p; ++p)
-    if (!VIM_ISDIGIT(*p) && *p != '.')
+    if (!ascii_isdigit(*p) && *p != '.')
       break;
   if (ascii_iswhite(*p)) {
     for (i = 0; i < MENUDEPTH && !ascii_iswhite(*arg); ++i) {
@@ -835,7 +835,7 @@ char_u *set_context_in_menu_cmd(expand_T *xp, char_u *cmd, char_u *arg, int forc
 
   /* Check for priority numbers, enable and disable */
   for (p = arg; *p; ++p)
-    if (!VIM_ISDIGIT(*p) && *p != '.')
+    if (!ascii_isdigit(*p) && *p != '.')
       break;
 
   if (!ascii_iswhite(*p)) {

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -117,8 +117,8 @@ ex_menu (
   for (p = arg; *p; ++p)
     if (!VIM_ISDIGIT(*p) && *p != '.')
       break;
-  if (vim_iswhite(*p)) {
-    for (i = 0; i < MENUDEPTH && !vim_iswhite(*arg); ++i) {
+  if (ascii_iswhite(*p)) {
+    for (i = 0; i < MENUDEPTH && !ascii_iswhite(*arg); ++i) {
       pri_tab[i] = getdigits_int(&arg);
       if (pri_tab[i] == 0)
         pri_tab[i] = 500;
@@ -138,10 +138,10 @@ ex_menu (
   /*
    * Check for "disable" or "enable" argument.
    */
-  if (STRNCMP(arg, "enable", 6) == 0 && vim_iswhite(arg[6])) {
+  if (STRNCMP(arg, "enable", 6) == 0 && ascii_iswhite(arg[6])) {
     enable = TRUE;
     arg = skipwhite(arg + 6);
-  } else if (STRNCMP(arg, "disable", 7) == 0 && vim_iswhite(arg[7])) {
+  } else if (STRNCMP(arg, "disable", 7) == 0 && ascii_iswhite(arg[7])) {
     enable = FALSE;
     arg = skipwhite(arg + 7);
   }
@@ -838,23 +838,23 @@ char_u *set_context_in_menu_cmd(expand_T *xp, char_u *cmd, char_u *arg, int forc
     if (!VIM_ISDIGIT(*p) && *p != '.')
       break;
 
-  if (!vim_iswhite(*p)) {
+  if (!ascii_iswhite(*p)) {
     if (STRNCMP(arg, "enable", 6) == 0
-        && (arg[6] == NUL ||  vim_iswhite(arg[6])))
+        && (arg[6] == NUL ||  ascii_iswhite(arg[6])))
       p = arg + 6;
     else if (STRNCMP(arg, "disable", 7) == 0
-             && (arg[7] == NUL || vim_iswhite(arg[7])))
+             && (arg[7] == NUL || ascii_iswhite(arg[7])))
       p = arg + 7;
     else
       p = arg;
   }
 
-  while (*p != NUL && vim_iswhite(*p))
+  while (*p != NUL && ascii_iswhite(*p))
     ++p;
 
   arg = after_dot = p;
 
-  for (; *p && !vim_iswhite(*p); ++p) {
+  for (; *p && !ascii_iswhite(*p); ++p) {
     if ((*p == '\\' || *p == Ctrl_V) && p[1] != NUL)
       p++;
     else if (*p == '.')
@@ -864,7 +864,7 @@ char_u *set_context_in_menu_cmd(expand_T *xp, char_u *cmd, char_u *arg, int forc
   /* ":tearoff" and ":popup" only use menus, not entries */
   expand_menus = !((*cmd == 't' && cmd[1] == 'e') || *cmd == 'p');
   expand_emenu = (*cmd == 'e');
-  if (expand_menus && vim_iswhite(*p))
+  if (expand_menus && ascii_iswhite(*p))
     return NULL;        /* TODO: check for next command? */
   if (*p == NUL) {              /* Complete the menu name */
     /*
@@ -1484,7 +1484,7 @@ void ex_menutranslate(exarg_T *eap)
  */
 static char_u *menu_skip_part(char_u *p)
 {
-  while (*p != NUL && *p != '.' && !vim_iswhite(*p)) {
+  while (*p != NUL && *p != '.' && !ascii_iswhite(*p)) {
     if ((*p == '\\' || *p == Ctrl_V) && p[1] != NUL)
       ++p;
     ++p;
@@ -1543,7 +1543,7 @@ static char_u *menu_translate_tab_and_shift(char_u *arg_start)
 {
   char_u      *arg = arg_start;
 
-  while (*arg && !vim_iswhite(*arg)) {
+  while (*arg && !ascii_iswhite(*arg)) {
     if ((*arg == '\\' || *arg == Ctrl_V) && arg[1] != NUL)
       arg++;
     else if (STRNICMP(arg, "<TAB>", 5) == 0) {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1387,7 +1387,7 @@ void msg_prt_line(char_u *s, int list)
   /* find start of trailing whitespace */
   if (list && lcs_trail) {
     trail = s + STRLEN(s);
-    while (trail > s && vim_iswhite(trail[-1]))
+    while (trail > s && ascii_iswhite(trail[-1]))
       --trail;
   }
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3204,12 +3204,12 @@ int vim_vsnprintf(char *str, size_t str_m, char *fmt, va_list ap, typval_T *tvs)
           min_field_width = -j;
           justify_left = 1;
         }
-      } else if (VIM_ISDIGIT((int)(*p))) {
+      } else if (ascii_isdigit((int)(*p))) {
         /* size_t could be wider than unsigned int; make sure we treat
          * argument like common implementations do */
         unsigned int uj = *p++ - '0';
 
-        while (VIM_ISDIGIT((int)(*p)))
+        while (ascii_isdigit((int)(*p)))
           uj = 10 * uj + (unsigned int)(*p++ - '0');
         min_field_width = uj;
       }
@@ -3229,12 +3229,12 @@ int vim_vsnprintf(char *str, size_t str_m, char *fmt, va_list ap, typval_T *tvs)
             precision_specified = 0;
             precision = 0;
           }
-        } else if (VIM_ISDIGIT((int)(*p))) {
+        } else if (ascii_isdigit((int)(*p))) {
           /* size_t could be wider than unsigned int; make sure we
            * treat argument like common implementations do */
           unsigned int uj = *p++ - '0';
 
-          while (VIM_ISDIGIT((int)(*p)))
+          while (ascii_isdigit((int)(*p)))
             uj = 10 * uj + (unsigned int)(*p++ - '0');
           precision = uj;
         }
@@ -3643,8 +3643,8 @@ int vim_vsnprintf(char *str, size_t str_m, char *fmt, va_list ap, typval_T *tvs)
                 fmt_spec == 'e' ? 'e' : 'E');
             if (tp != NULL && (tp[1] == '+' || tp[1] == '-')
                 && tp[2] == '0'
-                && vim_isdigit(tp[3])
-                && vim_isdigit(tp[4])) {
+                && ascii_isdigit(tp[3])
+                && ascii_isdigit(tp[4])) {
               STRMOVE(tp + 2, tp + 3);
               --str_arg_l;
             }

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -266,7 +266,7 @@ open_line (
         } else {      /* Not a comment line */
           /* Find last non-blank in line */
           p = ptr + STRLEN(ptr) - 1;
-          while (p > ptr && vim_iswhite(*p))
+          while (p > ptr && ascii_iswhite(*p))
             --p;
           last_char = *p;
 
@@ -276,7 +276,7 @@ open_line (
           if (last_char == '{' || last_char == ';') {
             if (p > ptr)
               --p;
-            while (p > ptr && vim_iswhite(*p))
+            while (p > ptr && ascii_iswhite(*p))
               --p;
           }
           /*
@@ -442,7 +442,7 @@ open_line (
            * comment leader, then put a space after the middle
            * comment leader on the next line.
            */
-          if (!vim_iswhite(saved_line[lead_len - 1])
+          if (!ascii_iswhite(saved_line[lead_len - 1])
               && ((p_extra != NULL
                    && (int)curwin->w_cursor.col == lead_len)
                   || (p_extra == NULL
@@ -532,7 +532,7 @@ open_line (
         if (c == COM_RIGHT) {            /* right adjusted leader */
           /* find last non-white in the leader to line up with */
           for (p = leader + lead_len - 1; p > leader
-               && vim_iswhite(*p); --p)
+               && ascii_iswhite(*p); --p)
             ;
           ++p;
 
@@ -573,7 +573,7 @@ open_line (
                   (size_t)((leader + lead_len) - (p + l + 1)));
               lead_len -= l;
               *p = ' ';
-            } else if (!vim_iswhite(*p))
+            } else if (!ascii_iswhite(*p))
               *p = ' ';
           }
         } else {                        /* left adjusted leader */
@@ -604,7 +604,7 @@ open_line (
            * leader by spaces.  Keep Tabs, the indent must
            * remain the same. */
           for (p += lead_repl_len; p < leader + lead_len; ++p)
-            if (!vim_iswhite(*p)) {
+            if (!ascii_iswhite(*p)) {
               /* Don't put a space before a TAB. */
               if (p + 1 < leader + lead_len && p[1] == TAB) {
                 --lead_len;
@@ -656,7 +656,7 @@ open_line (
 
         /* If the leader ends in white space, don't add an
          * extra space */
-        if (lead_len > 0 && vim_iswhite(leader[lead_len - 1]))
+        if (lead_len > 0 && ascii_iswhite(leader[lead_len - 1]))
           extra_space = FALSE;
         leader[lead_len] = NUL;
       }
@@ -675,7 +675,7 @@ open_line (
       if (newindent
           || did_si
           ) {
-        while (lead_len && vim_iswhite(*leader)) {
+        while (lead_len && ascii_iswhite(*leader)) {
           --lead_len;
           --newcol;
           ++leader;
@@ -966,7 +966,7 @@ int get_leader_len(char_u *line, char_u **flags, int backward, int include_space
   char_u      *saved_flags = NULL;
 
   result = i = 0;
-  while (vim_iswhite(line[i]))      /* leading white space is ignored */
+  while (ascii_iswhite(line[i]))      /* leading white space is ignored */
     ++i;
 
   /*
@@ -1009,10 +1009,10 @@ int get_leader_len(char_u *line, char_u **flags, int backward, int include_space
        * When string starts with white space, must have some white space
        * (but the amount does not need to match, there might be a mix of
        * TABs and spaces). */
-      if (vim_iswhite(string[0])) {
-        if (i == 0 || !vim_iswhite(line[i - 1]))
+      if (ascii_iswhite(string[0])) {
+        if (i == 0 || !ascii_iswhite(line[i - 1]))
           continue;            /* missing white space */
-        while (vim_iswhite(string[0]))
+        while (ascii_iswhite(string[0]))
           ++string;
       }
       for (j = 0; string[j] != NUL && string[j] == line[i + j]; ++j)
@@ -1023,7 +1023,7 @@ int get_leader_len(char_u *line, char_u **flags, int backward, int include_space
       /* When 'b' flag used, there must be white space or an
        * end-of-line after the string in the line. */
       if (vim_strchr(part_buf, COM_BLANK) != NULL
-          && !vim_iswhite(line[i + j]) && line[i + j] != NUL)
+          && !ascii_iswhite(line[i + j]) && line[i + j] != NUL)
         continue;
 
       /* We have found a match, stop searching unless this is a middle
@@ -1065,7 +1065,7 @@ int get_leader_len(char_u *line, char_u **flags, int backward, int include_space
     result = i;
 
     /* Include any trailing white space. */
-    while (vim_iswhite(line[i]))
+    while (ascii_iswhite(line[i]))
       ++i;
 
     if (include_space)
@@ -1129,10 +1129,10 @@ int get_last_leader_offset(char_u *line, char_u **flags)
        * (but the amount does not need to match, there might be a mix of
        * TABs and spaces).
        */
-      if (vim_iswhite(string[0])) {
-        if (i == 0 || !vim_iswhite(line[i - 1]))
+      if (ascii_iswhite(string[0])) {
+        if (i == 0 || !ascii_iswhite(line[i - 1]))
           continue;
-        while (vim_iswhite(string[0]))
+        while (ascii_iswhite(string[0]))
           ++string;
       }
       for (j = 0; string[j] != NUL && string[j] == line[i + j]; ++j)
@@ -1145,7 +1145,7 @@ int get_last_leader_offset(char_u *line, char_u **flags)
        * end-of-line after the string in the line.
        */
       if (vim_strchr(part_buf, COM_BLANK) != NULL
-          && !vim_iswhite(line[i + j]) && line[i + j] != NUL) {
+          && !ascii_iswhite(line[i + j]) && line[i + j] != NUL) {
         continue;
       }
 
@@ -1180,7 +1180,7 @@ int get_last_leader_offset(char_u *line, char_u **flags)
        * the comment leader correctly.
        */
 
-      while (vim_iswhite(*com_leader))
+      while (ascii_iswhite(*com_leader))
         ++com_leader;
       len1 = (int)STRLEN(com_leader);
 
@@ -1192,7 +1192,7 @@ int get_last_leader_offset(char_u *line, char_u **flags)
           continue;
         string = vim_strchr(part_buf2, ':');
         ++string;
-        while (vim_iswhite(*string))
+        while (ascii_iswhite(*string))
           ++string;
         len2 = (int)STRLEN(string);
         if (len2 == 0)

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -524,7 +524,7 @@ open_line (
         for (p = lead_flags; *p != NUL && *p != ':'; ) {
           if (*p == COM_RIGHT || *p == COM_LEFT)
             c = *p++;
-          else if (VIM_ISDIGIT(*p) || *p == '-')
+          else if (ascii_isdigit(*p) || *p == '-')
             off = getdigits_int(&p);
           else
             ++p;
@@ -2465,7 +2465,7 @@ get_number (
   for (;; ) {
     ui_cursor_goto(msg_row, msg_col);
     c = safe_vgetc();
-    if (VIM_ISDIGIT(c)) {
+    if (ascii_isdigit(c)) {
       n = n * 10 + c - '0';
       msg_putchar(c);
       ++typed;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3593,7 +3593,7 @@ static void nv_zet(cmdarg_T *cap)
   int old_fen = curwin->w_p_fen;
   bool undo = false;
 
-  if (VIM_ISDIGIT(nchar)) {
+  if (ascii_isdigit(nchar)) {
     /*
      * "z123{nchar}": edit the count before obtaining {nchar}
      */
@@ -3610,7 +3610,7 @@ static void nv_zet(cmdarg_T *cap)
       (void)add_to_showcmd(nchar);
       if (nchar == K_DEL || nchar == K_KDEL)
         n /= 10;
-      else if (VIM_ISDIGIT(nchar))
+      else if (ascii_isdigit(nchar))
         n = n * 10 + (nchar - '0');
       else if (nchar == CAR) {
         win_setheight((int)n);
@@ -7252,7 +7252,7 @@ static void nv_put(cmdarg_T *cap)
       was_visual = true;
       regname = cap->oap->regname;
       if (regname == 0 || regname == '"'
-          || VIM_ISDIGIT(regname) || regname == '-') {
+          || ascii_isdigit(regname) || regname == '-') {
         // The delete might overwrite the register we want to put, save it first
         savereg = copy_register(regname);
       }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2365,7 +2365,7 @@ do_mouse (
          * not a word character, try finding a match and select a (),
          * {}, [], #if/#endif, etc. block. */
         end_visual = curwin->w_cursor;
-        while (gc = gchar_pos(&end_visual), vim_iswhite(gc))
+        while (gc = gchar_pos(&end_visual), ascii_iswhite(gc))
           inc(&end_visual);
         if (oap != NULL)
           oap->motion_type = MCHAR;
@@ -2627,7 +2627,7 @@ int find_ident_at_pos(win_T *wp, linenr_T lnum, colnr_T startcol, char_u **strin
       }
     } else
       while (ptr[col] != NUL
-             && (i == 0 ? !vim_iswordc(ptr[col]) : vim_iswhite(ptr[col]))
+             && (i == 0 ? !vim_iswordc(ptr[col]) : ascii_iswhite(ptr[col]))
              )
         ++col;
 
@@ -2660,7 +2660,7 @@ int find_ident_at_pos(win_T *wp, linenr_T lnum, colnr_T startcol, char_u **strin
       while (col > 0
              && ((i == 0
                   ? vim_iswordc(ptr[col - 1])
-                  : (!vim_iswhite(ptr[col - 1])
+                  : (!ascii_iswhite(ptr[col - 1])
                      && (!(find_type & FIND_IDENT)
                          || !vim_iswordc(ptr[col - 1]))))
                  ))
@@ -2702,7 +2702,7 @@ int find_ident_at_pos(win_T *wp, linenr_T lnum, colnr_T startcol, char_u **strin
       col += (*mb_ptr2len)(ptr + col);
   } else
     while ((i == 0 ? vim_iswordc(ptr[col])
-            : (ptr[col] != NUL && !vim_iswhite(ptr[col])))
+            : (ptr[col] != NUL && !ascii_iswhite(ptr[col])))
            ) {
       ++col;
     }
@@ -6177,7 +6177,7 @@ static void nv_g_cmd(cmdarg_T *cap)
     if (flag) {
       do
         i = gchar_cursor();
-      while (vim_iswhite(i) && oneright());
+      while (ascii_iswhite(i) && oneright());
     }
     curwin->w_set_curswant = true;
     break;
@@ -6200,7 +6200,7 @@ static void nv_g_cmd(cmdarg_T *cap)
 
       /* Decrease the cursor column until it's on a non-blank. */
       while (curwin->w_cursor.col > 0
-             && vim_iswhite(ptr[curwin->w_cursor.col]))
+             && ascii_iswhite(ptr[curwin->w_cursor.col]))
         --curwin->w_cursor.col;
       curwin->w_set_curswant = true;
       adjust_for_sel(cap);
@@ -6715,7 +6715,7 @@ static void nv_wordcmd(cmdarg_T *cap)
   if (!word_end && cap->oap->op_type == OP_CHANGE) {
     n = gchar_cursor();
     if (n != NUL) {                     /* not an empty line */
-      if (vim_iswhite(n)) {
+      if (ascii_iswhite(n)) {
         /*
          * Reproduce a funny Vi behaviour: "cw" on a blank only
          * changes one character, not all blanks until the start of

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3901,7 +3901,7 @@ format_lines (
         /* put cursor on last non-space */
         State = NORMAL;         /* don't go past end-of-line */
         coladvance((colnr_T)MAXCOL);
-        while (curwin->w_cursor.col && vim_isspace(gchar_cursor()))
+        while (curwin->w_cursor.col && ascii_isspace(gchar_cursor()))
           dec_cursor();
 
         /* do the formatting, without 'showmode' */
@@ -5007,11 +5007,11 @@ static long line_count_info(char_u *line, long *wc, long *cc, long limit, int eo
 
   for (i = 0; i < limit && line[i] != NUL; ) {
     if (is_word) {
-      if (vim_isspace(line[i])) {
+      if (ascii_isspace(line[i])) {
         words++;
         is_word = 0;
       }
-    } else if (!vim_isspace(line[i]))
+    } else if (!ascii_isspace(line[i]))
       is_word = 1;
     ++chars;
     i += (*mb_ptr2len)(line + i);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -772,7 +772,7 @@ yankreg_T *get_yank_register(int regname, int mode)
   }
 
   int i = 0; // when not 0-9, a-z, A-Z or '-'/'+'/'*': use register 0
-  if (VIM_ISDIGIT(regname))
+  if (ascii_isdigit(regname))
     i = regname - '0';
   else if (ASCII_ISLOWER(regname))
     i = CharOrdLow(regname) + 10;
@@ -4260,12 +4260,12 @@ int do_addsub(int command, linenr_T Prenum1)
     col = curwin->w_cursor.col;
 
     while (ptr[col] != NUL
-           && !vim_isdigit(ptr[col])
+           && !ascii_isdigit(ptr[col])
            && !(doalp && ASCII_ISALPHA(ptr[col])))
       ++col;
 
     while (col > 0
-           && vim_isdigit(ptr[col - 1])
+           && ascii_isdigit(ptr[col - 1])
            && !(doalp && ASCII_ISALPHA(ptr[col])))
       --col;
   }
@@ -4275,7 +4275,7 @@ int do_addsub(int command, linenr_T Prenum1)
    */
   firstdigit = ptr[col];
   RLADDSUBFIX(ptr);
-  if ((!VIM_ISDIGIT(firstdigit) && !(doalp && ASCII_ISALPHA(firstdigit)))
+  if ((!ascii_isdigit(firstdigit) && !(doalp && ASCII_ISALPHA(firstdigit)))
       || u_save_cursor() != OK) {
     beep_flush();
     return FAIL;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -347,7 +347,7 @@ static void shift_block(oparg_T *oap, int amount)
       else
         ++bd.textstart;
     }
-    for (; vim_iswhite(*bd.textstart); ) {
+    for (; ascii_iswhite(*bd.textstart); ) {
       // TODO: is passing bd.textstart for start of the line OK?
       incr = lbr_chartabsize_adv(bd.textstart, &bd.textstart, (colnr_T)(bd.start_vcol));
       total += incr;
@@ -403,7 +403,7 @@ static void shift_block(oparg_T *oap, int amount)
     /* The character's column is in "bd.start_vcol".  */
     non_white_col = bd.start_vcol;
 
-    while (vim_iswhite(*non_white)) {
+    while (ascii_iswhite(*non_white)) {
       incr = lbr_chartabsize_adv(bd.textstart, &non_white, non_white_col);
       non_white_col += incr;
     }
@@ -3613,15 +3613,15 @@ static int same_leader(linenr_T lnum, int leader1_len, char_u *leader1_flags, in
    * The first line has to be saved, only one line can be locked at a time.
    */
   line1 = vim_strsave(ml_get(lnum));
-  for (idx1 = 0; vim_iswhite(line1[idx1]); ++idx1)
+  for (idx1 = 0; ascii_iswhite(line1[idx1]); ++idx1)
     ;
   line2 = ml_get(lnum + 1);
   for (idx2 = 0; idx2 < leader2_len; ++idx2) {
-    if (!vim_iswhite(line2[idx2])) {
+    if (!ascii_iswhite(line2[idx2])) {
       if (line1[idx1++] != line2[idx2])
         break;
     } else
-      while (vim_iswhite(line1[idx1]))
+      while (ascii_iswhite(line1[idx1]))
         ++idx1;
   }
   xfree(line1);
@@ -3979,10 +3979,10 @@ static int ends_in_white(linenr_T lnum)
 
   if (*s == NUL)
     return FALSE;
-  /* Don't use STRLEN() inside vim_iswhite(), SAS/C complains: "macro
+  /* Don't use STRLEN() inside ascii_iswhite(), SAS/C complains: "macro
    * invocation may call function multiple times". */
   l = STRLEN(s) - 1;
-  return vim_iswhite(s[l]);
+  return ascii_iswhite(s[l]);
 }
 
 /*
@@ -4103,7 +4103,7 @@ static void block_prep(oparg_T *oap, struct block_def *bdp, linenr_T lnum, int i
     /* Count a tab for what it's worth (if list mode not on) */
     incr = lbr_chartabsize(line, pstart, (colnr_T)bdp->start_vcol);
     bdp->start_vcol += incr;
-    if (vim_iswhite(*pstart)) {
+    if (ascii_iswhite(*pstart)) {
       bdp->pre_whitesp += incr;
       bdp->pre_whitesp_c++;
     } else {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4241,14 +4241,14 @@ int do_addsub(int command, linenr_T Prenum1)
    */
   col = curwin->w_cursor.col;
   if (dohex)
-    while (col > 0 && vim_isxdigit(ptr[col]))
+    while (col > 0 && ascii_isxdigit(ptr[col]))
       --col;
   if (       dohex
              && col > 0
              && (ptr[col] == 'X'
                  || ptr[col] == 'x')
              && ptr[col - 1] == '0'
-             && vim_isxdigit(ptr[col + 1])) {
+             && ascii_isxdigit(ptr[col + 1])) {
     /*
      * Found hexadecimal number, move to its start.
      */

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3979,8 +3979,6 @@ static int ends_in_white(linenr_T lnum)
 
   if (*s == NUL)
     return FALSE;
-  /* Don't use STRLEN() inside ascii_iswhite(), SAS/C complains: "macro
-   * invocation may call function multiple times". */
   l = STRLEN(s) - 1;
   return ascii_iswhite(s[l]);
 }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2671,7 +2671,7 @@ do_set (
                        && (*arg == '<'
                            || *arg == '^'
                            || ((!arg[1] || ascii_iswhite(arg[1]))
-                               && !VIM_ISDIGIT(*arg)))) {
+                               && !ascii_isdigit(*arg)))) {
               value = string_to_key(arg);
               if (value == 0 && (long *)varp != &p_wcm) {
                 errmsg = e_invarg;
@@ -2679,14 +2679,14 @@ do_set (
               }
             }
             /* allow negative numbers (for 'undolevels') */
-            else if (*arg == '-' || VIM_ISDIGIT(*arg)) {
+            else if (*arg == '-' || ascii_isdigit(*arg)) {
               i = 0;
               if (*arg == '-')
                 i = 1;
               value = strtol((char *)arg, NULL, 0);
               if (arg[i] == '0' && TOLOWER_ASC(arg[i + 1]) == 'x')
                 i += 2;
-              while (VIM_ISDIGIT(arg[i]))
+              while (ascii_isdigit(arg[i]))
                 ++i;
               if (arg[i] != NUL && !ascii_iswhite(arg[i])) {
                 errmsg = e_invarg;
@@ -2767,7 +2767,7 @@ do_set (
                * adding, prepending and removing string.
                */
               else if (varp == (char_u *)&p_bs
-                       && VIM_ISDIGIT(**(char_u **)varp)) {
+                       && ascii_isdigit(**(char_u **)varp)) {
                 i = getdigits_int((char_u **)varp);
                 switch (i) {
                 case 0:
@@ -2791,7 +2791,7 @@ do_set (
                * Misuse errbuf[] for the resulting string.
                */
               else if (varp == (char_u *)&p_ww
-                       && VIM_ISDIGIT(*arg)) {
+                       && ascii_isdigit(*arg)) {
                 *errbuf = NUL;
                 i = getdigits_int(&arg);
                 if (i & 1)
@@ -3212,7 +3212,7 @@ int get_viminfo_parameter(int type)
   char_u  *p;
 
   p = find_viminfo_parameter(type);
-  if (p != NULL && VIM_ISDIGIT(*p))
+  if (p != NULL && ascii_isdigit(*p))
     return atoi((char *)p);
   return -1;
 }
@@ -3883,7 +3883,7 @@ did_set_string_option (
     for (s = *varp; *s; ) {
       while (*s && *s != ':') {
         if (vim_strchr((char_u *)COM_ALL, *s) == NULL
-            && !VIM_ISDIGIT(*s) && *s != '-') {
+            && !ascii_isdigit(*s) && *s != '-') {
           errmsg = illegal_char(errbuf, *s);
           break;
         }
@@ -3936,15 +3936,15 @@ did_set_string_option (
           ;
       } else if (*s == '%') {
         /* optional number */
-        while (vim_isdigit(*++s))
+        while (ascii_isdigit(*++s))
           ;
       } else if (*s == '!' || *s == 'h' || *s == 'c')
         ++s;                    /* no extra chars */
       else {                    /* must have a number */
-        while (vim_isdigit(*++s))
+        while (ascii_isdigit(*++s))
           ;
 
-        if (!VIM_ISDIGIT(*(s - 1))) {
+        if (!ascii_isdigit(*(s - 1))) {
           if (errbuf != NULL) {
             sprintf((char *)errbuf,
                 _("E526: Missing number after <%s>"),
@@ -4188,7 +4188,7 @@ did_set_string_option (
   }
   /* 'backspace' */
   else if (varp == &p_bs) {
-    if (VIM_ISDIGIT(*p_bs)) {
+    if (ascii_isdigit(*p_bs)) {
       if (*p_bs >'2' || p_bs[1] != NUL)
         errmsg = e_invarg;
     } else if (check_opt_strings(p_bs, p_bs_values, TRUE) != OK)
@@ -4428,7 +4428,7 @@ char_u *check_colorcolumn(win_T *wp)
       /* -N and +N: add to 'textwidth' */
       col = (*s == '-') ? -1 : 1;
       ++s;
-      if (!VIM_ISDIGIT(*s))
+      if (!ascii_isdigit(*s))
         return e_invarg;
       col = col * getdigits_int(&s);
       if (wp->w_buffer->b_p_tw == 0)
@@ -4442,7 +4442,7 @@ char_u *check_colorcolumn(win_T *wp)
       col += (int)wp->w_buffer->b_p_tw;
       if (col < 0)
         goto skip;
-    } else if (VIM_ISDIGIT(*s))
+    } else if (ascii_isdigit(*s))
       col = getdigits_int(&s);
     else
       return e_invarg;
@@ -4603,13 +4603,13 @@ char_u *check_stl_option(char_u *s)
     }
     if (*s == '-')
       s++;
-    while (VIM_ISDIGIT(*s))
+    while (ascii_isdigit(*s))
       s++;
     if (*s == STL_USER_HL)
       continue;
     if (*s == '.') {
       s++;
-      while (*s && VIM_ISDIGIT(*s))
+      while (*s && ascii_isdigit(*s))
         s++;
     }
     if (*s == '(') {
@@ -7755,12 +7755,12 @@ static bool briopt_check(win_T *wp)
   while (*p != NUL)
   {
     if (STRNCMP(p, "shift:", 6) == 0
-        && ((p[6] == '-' && VIM_ISDIGIT(p[7])) || VIM_ISDIGIT(p[6])))
+        && ((p[6] == '-' && ascii_isdigit(p[7])) || ascii_isdigit(p[6])))
     {
       p += 6;
       bri_shift = getdigits_int(&p);
     }
-    else if (STRNCMP(p, "min:", 4) == 0 && VIM_ISDIGIT(p[4]))
+    else if (STRNCMP(p, "min:", 4) == 0 && ascii_isdigit(p[4]))
     {
       p += 4;
       bri_min = getdigits_int(&p);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2461,7 +2461,7 @@ do_set (
       afterchar = arg[len];
 
       /* skip white space, allow ":set ai  ?" */
-      while (vim_iswhite(arg[len]))
+      while (ascii_iswhite(arg[len]))
         ++len;
 
       adding = FALSE;
@@ -2549,7 +2549,7 @@ do_set (
           }
         }
         if (vim_strchr((char_u *)"?!&<", nextchar) != NULL
-            && arg[1] != NUL && !vim_iswhite(arg[1])) {
+            && arg[1] != NUL && !ascii_iswhite(arg[1])) {
           errmsg = e_trailing;
           goto skip;
         }
@@ -2590,7 +2590,7 @@ do_set (
           goto skip;
         }
         if (nextchar != '?'
-            && nextchar != NUL && !vim_iswhite(afterchar))
+            && nextchar != NUL && !ascii_iswhite(afterchar))
           errmsg = e_trailing;
       } else {
         if (flags & P_BOOL) {                       /* boolean */
@@ -2623,7 +2623,7 @@ do_set (
              * ":set invopt": invert
              * ":set opt" or ":set noopt": set or reset
              */
-            if (nextchar != NUL && !vim_iswhite(afterchar)) {
+            if (nextchar != NUL && !ascii_iswhite(afterchar)) {
               errmsg = e_trailing;
               goto skip;
             }
@@ -2670,7 +2670,7 @@ do_set (
                         || (long *)varp == &p_wcm)
                        && (*arg == '<'
                            || *arg == '^'
-                           || ((!arg[1] || vim_iswhite(arg[1]))
+                           || ((!arg[1] || ascii_iswhite(arg[1]))
                                && !VIM_ISDIGIT(*arg)))) {
               value = string_to_key(arg);
               if (value == 0 && (long *)varp != &p_wcm) {
@@ -2688,7 +2688,7 @@ do_set (
                 i += 2;
               while (VIM_ISDIGIT(arg[i]))
                 ++i;
-              if (arg[i] != NUL && !vim_iswhite(arg[i])) {
+              if (arg[i] != NUL && !ascii_iswhite(arg[i])) {
                 errmsg = e_invarg;
                 goto skip;
               }
@@ -2848,7 +2848,7 @@ do_set (
                * do remove it for "\\\\machine\\path".
                * The reverse is found in ExpandOldSetting().
                */
-              while (*arg && !vim_iswhite(*arg)) {
+              while (*arg && !ascii_iswhite(*arg)) {
                 if (*arg == '\\' && arg[1] != NUL
 #ifdef BACKSLASH_IN_FILENAME
                     && !((flags & P_EXPAND)
@@ -3004,7 +3004,7 @@ skip:
        * - skip one "=val" argument (for hidden options ":set gfn =xx")
        */
       for (i = 0; i < 2; ++i) {
-        while (*arg != NUL && !vim_iswhite(*arg))
+        while (*arg != NUL && !ascii_iswhite(*arg))
           if (*arg++ == '\\' && *arg != NUL)
             ++arg;
         arg = skipwhite(arg);

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -340,7 +340,7 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
     STRCAT(command, pat[0] + 1);                /* exclude first backtick */
     p = command + STRLEN(command) - 1;
     *p-- = ')';                                 /* remove last backtick */
-    while (p > command && vim_iswhite(*p))
+    while (p > command && ascii_iswhite(*p))
       --p;
     if (*p == '&') {                            /* remove trailing '&' */
       ampersent = TRUE;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1808,7 +1808,7 @@ static void qf_fmt_text(char_u *text, char_u *buf, int bufsize)
     if (*p == '\n') {
       buf[i] = ' ';
       while (*++p != NUL)
-        if (!vim_iswhite(*p) && *p != '\n')
+        if (!ascii_iswhite(*p) && *p != '\n')
           break;
     } else
       buf[i] = *p++;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -2359,7 +2359,7 @@ collection:
               break;
             case CLASS_XDIGIT:
               for (cu = 1; cu <= 255; cu++)
-                if (vim_isxdigit(cu))
+                if (ascii_isxdigit(cu))
                   regc(cu);
               break;
             case CLASS_TAB:
@@ -2978,7 +2978,7 @@ static int gethexchrs(int maxinputlen)
 
   for (i = 0; i < maxinputlen; ++i) {
     c = regparse[0];
-    if (!vim_isxdigit(c))
+    if (!ascii_isxdigit(c))
       break;
     nr <<= 4;
     nr |= hex2nr(c);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -2120,7 +2120,7 @@ static char_u *regatom(int *flagp)
     }
 
     default:
-      if (VIM_ISDIGIT(c) || c == '<' || c == '>'
+      if (ascii_isdigit(c) || c == '<' || c == '>'
           || c == '\'') {
         uint32_t n = 0;
         int cmp;
@@ -2128,7 +2128,7 @@ static char_u *regatom(int *flagp)
         cmp = c;
         if (cmp == '<' || cmp == '>')
           c = getchr();
-        while (VIM_ISDIGIT(c)) {
+        while (ascii_isdigit(c)) {
           n = n * 10 + (uint32_t)(c - '0');
           c = getchr();
         }
@@ -2324,7 +2324,7 @@ collection:
               break;
             case CLASS_DIGIT:
               for (cu = 1; cu <= 255; cu++)
-                if (VIM_ISDIGIT(cu))
+                if (ascii_isdigit(cu))
                   regc(cu);
               break;
             case CLASS_GRAPH:
@@ -3087,11 +3087,11 @@ static int read_limits(long *minval, long *maxval)
   first_char = regparse;
   *minval = getdigits_long(&regparse);
   if (*regparse == ',') {           /* There is a comma */
-    if (vim_isdigit(*++regparse))
+    if (ascii_isdigit(*++regparse))
       *maxval = getdigits_long(&regparse);
     else
       *maxval = MAX_LIMIT;
-  } else if (VIM_ISDIGIT(*first_char))
+  } else if (ascii_isdigit(*first_char))
     *maxval = *minval;              /* It was \{n} or \{-n} */
   else
     *maxval = MAX_LIMIT;            /* It was \{} or \{-} */
@@ -3944,7 +3944,7 @@ regmatch (
           break;
 
         case SIDENT:
-          if (VIM_ISDIGIT(*reginput) || !vim_isIDc(c))
+          if (ascii_isdigit(*reginput) || !vim_isIDc(c))
             status = RA_NOMATCH;
           else
             ADVANCE_REGINPUT();
@@ -3958,7 +3958,7 @@ regmatch (
           break;
 
         case SKWORD:
-          if (VIM_ISDIGIT(*reginput) || !vim_iswordp_buf(reginput, reg_buf))
+          if (ascii_isdigit(*reginput) || !vim_iswordp_buf(reginput, reg_buf))
             status = RA_NOMATCH;
           else
             ADVANCE_REGINPUT();
@@ -3972,7 +3972,7 @@ regmatch (
           break;
 
         case SFNAME:
-          if (VIM_ISDIGIT(*reginput) || !vim_isfilec(c))
+          if (ascii_isdigit(*reginput) || !vim_isfilec(c))
             status = RA_NOMATCH;
           else
             ADVANCE_REGINPUT();
@@ -3986,7 +3986,7 @@ regmatch (
           break;
 
         case SPRINT:
-          if (VIM_ISDIGIT(*reginput) || !vim_isprintc(PTR2CHAR(reginput)))
+          if (ascii_isdigit(*reginput) || !vim_isprintc(PTR2CHAR(reginput)))
             status = RA_NOMATCH;
           else
             ADVANCE_REGINPUT();
@@ -5112,7 +5112,7 @@ regrepeat (
   case SIDENT:
   case SIDENT + ADD_NL:
     while (count < maxcount) {
-      if (vim_isIDc(PTR2CHAR(scan)) && (testval || !VIM_ISDIGIT(*scan))) {
+      if (vim_isIDc(PTR2CHAR(scan)) && (testval || !ascii_isdigit(*scan))) {
         mb_ptr_adv(scan);
       } else if (*scan == NUL) {
         if (!REG_MULTI || !WITH_NL(OP(p)) || reglnum > reg_maxline
@@ -5138,7 +5138,7 @@ regrepeat (
   case SKWORD + ADD_NL:
     while (count < maxcount) {
       if (vim_iswordp_buf(scan, reg_buf)
-          && (testval || !VIM_ISDIGIT(*scan))) {
+          && (testval || !ascii_isdigit(*scan))) {
         mb_ptr_adv(scan);
       } else if (*scan == NUL) {
         if (!REG_MULTI || !WITH_NL(OP(p)) || reglnum > reg_maxline
@@ -5163,7 +5163,7 @@ regrepeat (
   case SFNAME:
   case SFNAME + ADD_NL:
     while (count < maxcount) {
-      if (vim_isfilec(PTR2CHAR(scan)) && (testval || !VIM_ISDIGIT(*scan))) {
+      if (vim_isfilec(PTR2CHAR(scan)) && (testval || !ascii_isdigit(*scan))) {
         mb_ptr_adv(scan);
       } else if (*scan == NUL) {
         if (!REG_MULTI || !WITH_NL(OP(p)) || reglnum > reg_maxline
@@ -5197,7 +5197,7 @@ regrepeat (
         if (got_int)
           break;
       } else if (vim_isprintc(PTR2CHAR(scan)) == 1
-                 && (testval || !VIM_ISDIGIT(*scan))) {
+                 && (testval || !ascii_isdigit(*scan))) {
         mb_ptr_adv(scan);
       } else if (reg_line_lbr && *scan == '\n' && WITH_NL(OP(p)))
         ++scan;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -3993,14 +3993,14 @@ regmatch (
           break;
 
         case WHITE:
-          if (!vim_iswhite(c))
+          if (!ascii_iswhite(c))
             status = RA_NOMATCH;
           else
             ADVANCE_REGINPUT();
           break;
 
         case NWHITE:
-          if (c == NUL || vim_iswhite(c))
+          if (c == NUL || ascii_iswhite(c))
             status = RA_NOMATCH;
           else
             ADVANCE_REGINPUT();

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -4263,7 +4263,7 @@ static int check_char_class(int class, int c)
       return OK;
     break;
   case NFA_CLASS_XDIGIT:
-    if (vim_isxdigit(c))
+    if (ascii_isxdigit(c))
       return OK;
     break;
   case NFA_CLASS_TAB:

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1401,7 +1401,7 @@ static int nfa_regatom(void)
 
       if (c == '<' || c == '>')
         c = getchr();
-      while (VIM_ISDIGIT(c)) {
+      while (ascii_isdigit(c)) {
         n = n * 10 + (c - '0');
         c = getchr();
       }
@@ -4235,7 +4235,7 @@ static int check_char_class(int class, int c)
       return OK;
     break;
   case NFA_CLASS_DIGIT:
-    if (VIM_ISDIGIT(c))
+    if (ascii_isdigit(c))
       return OK;
     break;
   case NFA_CLASS_GRAPH:
@@ -5488,7 +5488,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
         break;
 
       case NFA_SIDENT:          /*  \I	*/
-        result = !VIM_ISDIGIT(curc) && vim_isIDc(curc);
+        result = !ascii_isdigit(curc) && vim_isIDc(curc);
         ADD_STATE_IF_MATCH(t->state);
         break;
 
@@ -5498,7 +5498,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
         break;
 
       case NFA_SKWORD:          /*  \K	*/
-        result = !VIM_ISDIGIT(curc)
+        result = !ascii_isdigit(curc)
                  && vim_iswordp_buf(reginput, reg_buf);
         ADD_STATE_IF_MATCH(t->state);
         break;
@@ -5509,7 +5509,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
         break;
 
       case NFA_SFNAME:          /*  \F	*/
-        result = !VIM_ISDIGIT(curc) && vim_isfilec(curc);
+        result = !ascii_isdigit(curc) && vim_isfilec(curc);
         ADD_STATE_IF_MATCH(t->state);
         break;
 
@@ -5519,7 +5519,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
         break;
 
       case NFA_SPRINT:          /*  \P	*/
-        result = !VIM_ISDIGIT(curc) && vim_isprintc(PTR2CHAR(reginput));
+        result = !ascii_isdigit(curc) && vim_isprintc(PTR2CHAR(reginput));
         ADD_STATE_IF_MATCH(t->state);
         break;
 

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -5524,12 +5524,12 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
         break;
 
       case NFA_WHITE:           /*  \s	*/
-        result = vim_iswhite(curc);
+        result = ascii_iswhite(curc);
         ADD_STATE_IF_MATCH(t->state);
         break;
 
       case NFA_NWHITE:          /*  \S	*/
-        result = curc != NUL && !vim_iswhite(curc);
+        result = curc != NUL && !ascii_iswhite(curc);
         ADD_STATE_IF_MATCH(t->state);
         break;
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4977,7 +4977,7 @@ win_redr_custom (
         if (*++stl == '-')
           stl++;
         if (atoi((char *)stl))
-          while (VIM_ISDIGIT(*stl))
+          while (ascii_isdigit(*stl))
             stl++;
         if (*stl++ != '(')
           stl = p_ruf;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2401,7 +2401,7 @@ win_line (
   /* find start of trailing whitespace */
   if (wp->w_p_list && lcs_trail) {
     trailcol = (colnr_T)STRLEN(ptr);
-    while (trailcol > (colnr_T)0 && vim_iswhite(ptr[trailcol - 1]))
+    while (trailcol > (colnr_T)0 && ascii_iswhite(ptr[trailcol - 1]))
       --trailcol;
     trailcol += (colnr_T) (ptr - line);
     extra_check = TRUE;
@@ -3319,7 +3319,7 @@ win_line (
                       - vcol % (int)wp->w_buffer->b_p_ts - 1;
           }
           c_extra = ' ';
-          if (vim_iswhite(c)) {
+          if (ascii_iswhite(c)) {
             if (c == TAB)
               /* See "Tab alignment" below. */
               FIX_FOR_BOGUSCOLS;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1023,7 +1023,7 @@ int do_search(
         else                                /* single '+' */
           spats[0].off.off = 1;
         ++p;
-        while (ascii_isdigit(*p))             /* skip number */
+        while (ascii_isdigit(*p))           /* skip number */
           ++p;
       }
 
@@ -2921,7 +2921,7 @@ extend:
      */
     if (start_blank) {
       find_first_blank(&curwin->w_cursor);
-      c = gchar_pos(&curwin->w_cursor);         /* ascii_iswhite() is a macro */
+      c = gchar_pos(&curwin->w_cursor);
       if (ascii_iswhite(c))
         decl(&curwin->w_cursor);
     } else if (c = gchar_cursor(), !ascii_iswhite(c))

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2616,7 +2616,7 @@ static void find_first_blank(pos_T *posp)
 
   while (decl(posp) != -1) {
     c = gchar_pos(posp);
-    if (!vim_iswhite(c)) {
+    if (!ascii_iswhite(c)) {
       incl(posp);
       break;
     }
@@ -2828,7 +2828,7 @@ extend:
       decl(&pos);
       while (lt(pos, curwin->w_cursor)) {
         c = gchar_pos(&pos);
-        if (!vim_iswhite(c)) {
+        if (!ascii_iswhite(c)) {
           at_start_sent = FALSE;
           break;
         }
@@ -2848,7 +2848,7 @@ extend:
         if (at_start_sent)
           find_first_blank(&curwin->w_cursor);
         c = gchar_cursor();
-        if (!at_start_sent || (!include && !vim_iswhite(c)))
+        if (!at_start_sent || (!include && !ascii_iswhite(c)))
           findsent(BACKWARD, 1L);
         at_start_sent = !at_start_sent;
       }
@@ -2866,7 +2866,7 @@ extend:
         at_start_sent = FALSE;
         while (lt(pos, curwin->w_cursor)) {
           c = gchar_pos(&pos);
-          if (!vim_iswhite(c)) {
+          if (!ascii_iswhite(c)) {
             at_start_sent = TRUE;
             break;
           }
@@ -2891,7 +2891,7 @@ extend:
    * If the cursor started on a blank, check if it is just before the start
    * of the next sentence.
    */
-  while (c = gchar_pos(&pos), vim_iswhite(c))   /* vim_iswhite() is a macro */
+  while (c = gchar_pos(&pos), ascii_iswhite(c))
     incl(&pos);
   if (equalpos(pos, curwin->w_cursor)) {
     start_blank = TRUE;
@@ -2921,10 +2921,10 @@ extend:
      */
     if (start_blank) {
       find_first_blank(&curwin->w_cursor);
-      c = gchar_pos(&curwin->w_cursor);         /* vim_iswhite() is a macro */
-      if (vim_iswhite(c))
+      c = gchar_pos(&curwin->w_cursor);         /* ascii_iswhite() is a macro */
+      if (ascii_iswhite(c))
         decl(&curwin->w_cursor);
-    } else if (c = gchar_cursor(), !vim_iswhite(c))
+    } else if (c = gchar_cursor(), !ascii_iswhite(c))
       find_first_blank(&start_pos);
   }
 
@@ -3231,7 +3231,7 @@ again:
    */
   inc_cursor();
   p = get_cursor_pos_ptr();
-  for (cp = p; *cp != NUL && *cp != '>' && !vim_iswhite(*cp); mb_ptr_adv(cp))
+  for (cp = p; *cp != NUL && *cp != '>' && !ascii_iswhite(*cp); mb_ptr_adv(cp))
     ;
   len = (int)(cp - p);
   if (len == 0) {
@@ -3679,11 +3679,11 @@ current_quote (
   /* When "include" is TRUE, include spaces after closing quote or before
    * the starting quote. */
   if (include) {
-    if (vim_iswhite(line[col_end + 1]))
-      while (vim_iswhite(line[col_end + 1]))
+    if (ascii_iswhite(line[col_end + 1]))
+      while (ascii_iswhite(line[col_end + 1]))
         ++col_end;
     else
-      while (col_start > 0 && vim_iswhite(line[col_start - 1]))
+      while (col_start > 0 && ascii_iswhite(line[col_start - 1]))
         --col_start;
   }
 

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1006,7 +1006,7 @@ int do_search(
        * offset, because it is meaningless and the 's' could be a
        * substitute command.
        */
-      if (*p == '+' || *p == '-' || VIM_ISDIGIT(*p))
+      if (*p == '+' || *p == '-' || ascii_isdigit(*p))
         spats[0].off.line = TRUE;
       else if ((options & SEARCH_OPT) &&
                (*p == 'e' || *p == 's' || *p == 'b')) {
@@ -1014,16 +1014,16 @@ int do_search(
           spats[0].off.end = SEARCH_END;
         ++p;
       }
-      if (VIM_ISDIGIT(*p) || *p == '+' || *p == '-') {      /* got an offset */
+      if (ascii_isdigit(*p) || *p == '+' || *p == '-') {      /* got an offset */
         /* 'nr' or '+nr' or '-nr' */
-        if (VIM_ISDIGIT(*p) || VIM_ISDIGIT(*(p + 1)))
+        if (ascii_isdigit(*p) || ascii_isdigit(*(p + 1)))
           spats[0].off.off = atol((char *)p);
         else if (*p == '-')                 /* single '-' */
           spats[0].off.off = -1;
         else                                /* single '+' */
           spats[0].off.off = 1;
         ++p;
-        while (VIM_ISDIGIT(*p))             /* skip number */
+        while (ascii_isdigit(*p))             /* skip number */
           ++p;
       }
 

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -5155,7 +5155,7 @@ static unsigned get_affitem(int flagtype, char_u **pp)
   int res;
 
   if (flagtype == AFT_NUM) {
-    if (!VIM_ISDIGIT(**pp)) {
+    if (!ascii_isdigit(**pp)) {
       ++*pp;            // always advance, avoid getting stuck
       return 0;
     }
@@ -5410,7 +5410,7 @@ static int spell_read_dic(spellinfo_T *spin, char_u *fname, afffile_T *affile)
 
   // Read and ignore the first line: word count.
   (void)vim_fgets(line, MAXLINELEN, fd);
-  if (!vim_isdigit(*skipwhite(line)))
+  if (!ascii_isdigit(*skipwhite(line)))
     EMSG2(_("E760: No word count in %s"), fname);
 
   // Read all the lines in the file one by one.
@@ -6019,7 +6019,7 @@ static int spell_read_wordfile(spellinfo_T *spin, char_u *fname)
           flags |= WF_BANNED;
         else if (*p == '?')             // Rare word.
           flags |= WF_RARE;
-        else if (VIM_ISDIGIT(*p)) {       // region number(s)
+        else if (ascii_isdigit(*p)) {       // region number(s)
           if ((flags & WF_REGION) == 0)             // first one
             regionmask = 0;
           flags |= WF_REGION;
@@ -6351,20 +6351,20 @@ int spell_check_msm(void)
   long incr = 0;
   long added = 0;
 
-  if (!VIM_ISDIGIT(*p))
+  if (!ascii_isdigit(*p))
     return FAIL;
   // block count = (value * 1024) / SBLOCKSIZE (but avoid overflow)
   start = (getdigits_long(&p) * 10) / (SBLOCKSIZE / 102);
   if (*p != ',')
     return FAIL;
   ++p;
-  if (!VIM_ISDIGIT(*p))
+  if (!ascii_isdigit(*p))
     return FAIL;
   incr = (getdigits_long(&p) * 102) / (SBLOCKSIZE / 10);
   if (*p != ',')
     return FAIL;
   ++p;
-  if (!VIM_ISDIGIT(*p))
+  if (!ascii_isdigit(*p))
     return FAIL;
   added = getdigits_long(&p) * 1024;
   if (*p != NUL)
@@ -8350,10 +8350,10 @@ int spell_check_sps(void)
     copy_option_part(&p, buf, MAXPATHL, ",");
 
     f = 0;
-    if (VIM_ISDIGIT(*buf)) {
+    if (ascii_isdigit(*buf)) {
       s = buf;
       sps_limit = getdigits_int(&s);
-      if (*s != NUL && !VIM_ISDIGIT(*s))
+      if (*s != NUL && !ascii_isdigit(*s))
         f = -1;
     } else if (STRCMP(buf, "best") == 0)
       f = SPS_BEST;
@@ -11822,7 +11822,7 @@ static void spell_soundfold_sal(slang_T *slang, char_u *inword, char_u *res)
         }
         if (*s == '<')
           s++;
-        if (VIM_ISDIGIT(*s)) {
+        if (ascii_isdigit(*s)) {
           // determine priority
           pri = *s - '0';
           s++;
@@ -11883,7 +11883,7 @@ static void spell_soundfold_sal(slang_T *slang, char_u *inword, char_u *res)
               }
               if (*s == '<')
                 s++;
-              if (VIM_ISDIGIT(*s)) {
+              if (ascii_isdigit(*s)) {
                 p0 = *s - '0';
                 s++;
               }
@@ -12076,7 +12076,7 @@ static void spell_soundfold_wsal(slang_T *slang, char_u *inword, char_u *res)
         }
         if (*s == '<')
           s++;
-        if (VIM_ISDIGIT(*s)) {
+        if (ascii_isdigit(*s)) {
           // determine priority
           pri = *s - '0';
           s++;
@@ -12141,7 +12141,7 @@ static void spell_soundfold_wsal(slang_T *slang, char_u *inword, char_u *res)
               }
               if (*s == '<')
                 s++;
-              if (VIM_ISDIGIT(*s)) {
+              if (ascii_isdigit(*s)) {
                 p0 = *s - '0';
                 s++;
               }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -9501,7 +9501,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
 
       fword_ends = (fword[sp->ts_fidx] == NUL
                     || (soundfold
-                        ? vim_iswhite(fword[sp->ts_fidx])
+                        ? ascii_iswhite(fword[sp->ts_fidx])
                         : !spell_iswordp(fword + sp->ts_fidx, curwin)));
       tword[sp->ts_twordlen] = NUL;
 
@@ -10915,7 +10915,7 @@ stp_sal_score (
     // sounds like "t h" while "the" sounds like "@".  Avoid that by
     // removing the space.  Don't do it when the good word also contains a
     // space.
-    if (vim_iswhite(su->su_badptr[su->su_badlen])
+    if (ascii_iswhite(su->su_badptr[su->su_badlen])
         && *skiptowhite(stp->st_word) == NUL)
       for (p = fword; *(p = skiptowhite(p)) != NUL; )
         STRMOVE(p, p + 1);
@@ -11695,7 +11695,7 @@ static void spell_soundfold_sofo(slang_T *slang, char_u *inword, char_u *res)
     // 255, sl_sal the rest.
     for (s = inword; *s != NUL; ) {
       c = mb_cptr2char_adv(&s);
-      if (enc_utf8 ? utf_class(c) == 0 : vim_iswhite(c))
+      if (enc_utf8 ? utf_class(c) == 0 : ascii_iswhite(c))
         c = ' ';
       else if (c < 256)
         c = slang->sl_sal_first[c];
@@ -11727,7 +11727,7 @@ static void spell_soundfold_sofo(slang_T *slang, char_u *inword, char_u *res)
   } else {
     // The sl_sal_first[] table contains the translation.
     for (s = inword; (c = *s) != NUL; ++s) {
-      if (vim_iswhite(c))
+      if (ascii_iswhite(c))
         c = ' ';
       else
         c = slang->sl_sal_first[c];
@@ -11762,7 +11762,7 @@ static void spell_soundfold_sal(slang_T *slang, char_u *inword, char_u *res)
   if (slang->sl_rem_accents) {
     t = word;
     while (*s != NUL) {
-      if (vim_iswhite(*s)) {
+      if (ascii_iswhite(*s)) {
         *t++ = ' ';
         s = skipwhite(s);
       } else {
@@ -11955,7 +11955,7 @@ static void spell_soundfold_sal(slang_T *slang, char_u *inword, char_u *res)
           break;
         }
       }
-    } else if (vim_iswhite(c))   {
+    } else if (ascii_iswhite(c))   {
       c = ' ';
       k = 1;
     }
@@ -12010,7 +12010,7 @@ static void spell_soundfold_wsal(slang_T *slang, char_u *inword, char_u *res)
     t = s;
     c = mb_cptr2char_adv(&s);
     if (slang->sl_rem_accents) {
-      if (enc_utf8 ? utf_class(c) == 0 : vim_iswhite(c)) {
+      if (enc_utf8 ? utf_class(c) == 0 : ascii_iswhite(c)) {
         if (did_white)
           continue;
         c = ' ';
@@ -12221,7 +12221,7 @@ static void spell_soundfold_wsal(slang_T *slang, char_u *inword, char_u *res)
           break;
         }
       }
-    } else if (vim_iswhite(c))   {
+    } else if (ascii_iswhite(c))   {
       c = ' ';
       k = 1;
     }

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -450,16 +450,6 @@ char_u *vim_strrchr(const char_u *string, int c)
 }
 
 /*
- * Vim has its own isspace() function, because on some machines isspace()
- * can't handle characters above 128.
- */
-bool vim_isspace(int x)
-  FUNC_ATTR_CONST
-{
-  return (x >= 9 && x <= 13) || x == ' ';
-}
-
-/*
  * Sort an array of strings.
  */
 

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -295,7 +295,7 @@ void del_trailing_spaces(char_u *ptr)
   char_u      *q;
 
   q = ptr + STRLEN(ptr);
-  while (--q > ptr && vim_iswhite(q[0]) && q[-1] != '\\' && q[-1] != Ctrl_V)
+  while (--q > ptr && ascii_iswhite(q[0]) && q[-1] != '\\' && q[-1] != Ctrl_V)
     *q = NUL;
 }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4968,7 +4968,7 @@ static void syn_cmd_sync(exarg_T *eap, int syncing)
         arg_end = key + 11;
       else
         arg_end = key + 9;
-      if (arg_end[-1] != '=' || !VIM_ISDIGIT(*arg_end)) {
+      if (arg_end[-1] != '=' || !ascii_isdigit(*arg_end)) {
         illegal = TRUE;
         break;
       }
@@ -6251,7 +6251,7 @@ do_highlight (
             HL_TABLE()[idx].sg_cterm_bold = FALSE;
           }
 
-          if (VIM_ISDIGIT(*arg))
+          if (ascii_isdigit(*arg))
             color = atoi((char *)arg);
           else if (STRICMP(arg, "fg") == 0) {
             if (cterm_normal_fg_color)

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -1973,7 +1973,7 @@ syn_current_attr (
       if (!found_match) {
         line = syn_getcurline();
         if (((current_next_flags & HL_SKIPWHITE)
-             && vim_iswhite(line[current_col]))
+             && ascii_iswhite(line[current_col]))
             || ((current_next_flags & HL_SKIPEMPTY)
                 && *line == NUL))
           break;
@@ -3941,7 +3941,7 @@ get_syn_options (
       for (i = 0, len = 0; p[i] != NUL; i += 2, ++len)
         if (arg[len] != p[i] && arg[len] != p[i + 1])
           break;
-      if (p[i] == NUL && (vim_iswhite(arg[len])
+      if (p[i] == NUL && (ascii_iswhite(arg[len])
                           || (flagtab[fidx].argtype > 0
                               ? arg[len] == '='
                               : ends_excmd(arg[len])))) {
@@ -4161,7 +4161,7 @@ static void syn_cmd_keyword(exarg_T *eap, int syncing)
       if (rest == NULL || ends_excmd(*rest))
         break;
       /* Copy the keyword, removing backslashes, and add a NUL. */
-      while (*rest != NUL && !vim_iswhite(*rest)) {
+      while (*rest != NUL && !ascii_iswhite(*rest)) {
         if (*rest == '\\' && rest[1] != NUL)
           ++rest;
         *p++ = *rest++;
@@ -4386,7 +4386,7 @@ syn_cmd_region (
 
     /* must be a pattern or matchgroup then */
     key_end = rest;
-    while (*key_end && !vim_iswhite(*key_end) && *key_end != '=')
+    while (*key_end && !ascii_iswhite(*key_end) && *key_end != '=')
       ++key_end;
     xfree(key);
     key = vim_strnsave_up(rest, (int)(key_end - rest));
@@ -4791,15 +4791,15 @@ static void syn_cmd_cluster(exarg_T *eap, int syncing)
 
     for (;; ) {
       if (STRNICMP(rest, "add", 3) == 0
-          && (vim_iswhite(rest[3]) || rest[3] == '=')) {
+          && (ascii_iswhite(rest[3]) || rest[3] == '=')) {
         opt_len = 3;
         list_op = CLUSTER_ADD;
       } else if (STRNICMP(rest, "remove", 6) == 0
-                 && (vim_iswhite(rest[6]) || rest[6] == '=')) {
+                 && (ascii_iswhite(rest[6]) || rest[6] == '=')) {
         opt_len = 6;
         list_op = CLUSTER_SUBTRACT;
       } else if (STRNICMP(rest, "contains", 8) == 0
-                 && (vim_iswhite(rest[8]) || rest[8] == '=')) {
+                 && (ascii_iswhite(rest[8]) || rest[8] == '=')) {
         opt_len = 8;
         list_op = CLUSTER_REPLACE;
       } else
@@ -4916,7 +4916,7 @@ static char_u *get_syn_pattern(char_u *arg, synpat_T *ci)
     }
   } while (idx >= 0);
 
-  if (!ends_excmd(*end) && !vim_iswhite(*end)) {
+  if (!ends_excmd(*end) && !ascii_iswhite(*end)) {
     EMSG2(_("E402: Garbage after pattern: %s"), arg);
     return NULL;
   }
@@ -5098,7 +5098,7 @@ get_id_list (
      */
     count = 0;
     do {
-      for (end = p; *end && !vim_iswhite(*end) && *end != ','; ++end)
+      for (end = p; *end && !ascii_iswhite(*end) && *end != ','; ++end)
         ;
       name = xmalloc((int)(end - p + 3));             /* leave room for "^$" */
       STRLCPY(name + 1, p, end - p + 1);
@@ -6143,7 +6143,7 @@ do_highlight (
        * Isolate the key ("term", "ctermfg", "ctermbg", "font", "guifg" or
        * "guibg").
        */
-      while (*linep && !vim_iswhite(*linep) && *linep != '=')
+      while (*linep && !ascii_iswhite(*linep) && *linep != '=')
         ++linep;
       xfree(key);
       key = vim_strnsave_up(key_start, (int)(linep - key_start));
@@ -7139,7 +7139,7 @@ int highlight_changed(void)
       attr = 0;
       bool colon = false;
       for (; *p && *p != ','; ++p) {                /* parse upto comma */
-        if (vim_iswhite(*p))                        /* ignore white space */
+        if (ascii_iswhite(*p))                        /* ignore white space */
           continue;
 
         if (colon)          /* Combination with ':' is not allowed. */

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7138,9 +7138,10 @@ int highlight_changed(void)
        */
       attr = 0;
       bool colon = false;
-      for (; *p && *p != ','; ++p) {                /* parse upto comma */
-        if (ascii_iswhite(*p))                        /* ignore white space */
+      for (; *p && *p != ','; ++p) {  // parse upto comma
+        if (ascii_iswhite(*p)) {  // ignore white space
           continue;
+        }
 
         if (colon)          /* Combination with ':' is not allowed. */
           return FAIL;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -587,7 +587,7 @@ do_tag (
 
               /* skip "file:" without a value (static tag) */
               if (STRNCMP(p, "file:", 5) == 0
-                  && vim_isspace(p[5])) {
+                  && ascii_isspace(p[5])) {
                 p += 5;
                 continue;
               }
@@ -640,7 +640,7 @@ do_tag (
               ++p;
           }
           /* Remove leading whitespace from pattern */
-          while (p != command_end && vim_isspace(*p))
+          while (p != command_end && ascii_isspace(*p))
             ++p;
 
           while (p != command_end) {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2652,7 +2652,7 @@ static int find_extra(char_u **pp)
 
   /* Repeat for addresses separated with ';' */
   for (;; ) {
-    if (VIM_ISDIGIT(*str))
+    if (ascii_isdigit(*str))
       str = skipdigits(str);
     else if (*str == '/' || *str == '?') {
       str = skip_regexp(str + 1, *str, FALSE, NULL);
@@ -2663,7 +2663,7 @@ static int find_extra(char_u **pp)
     } else
       str = NULL;
     if (str == NULL || *str != ';'
-        || !(VIM_ISDIGIT(str[1]) || str[1] == '/' || str[1] == '?'))
+        || !(ascii_isdigit(str[1]) || str[1] == '/' || str[1] == '?'))
       break;
     ++str;      /* skip ';' */
   }

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2820,7 +2820,7 @@ int get_tags(list_T *list, char_u *pat)
           else if (STRNCMP(p, "file:", 5) == 0)
             /* skip "file:" (static tag) */
             p += 4;
-          else if (!vim_iswhite(*p)) {
+          else if (!ascii_iswhite(*p)) {
             char_u  *s, *n;
             int len;
 

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -328,12 +328,6 @@ enum {
 #define hl_attr(n)      highlight_attr[(int)(n)]
 #define term_str(n)     term_strings[(int)(n)]
 
-/*
- * vim_iswhite() is used for "^" and the like. It differs from isspace()
- * because it doesn't include <CR> and <LF> and the like.
- */
-#define vim_iswhite(x)  ((x) == ' ' || (x) == '\t')
-
 /* Maximum number of bytes in a multi-byte character.  It can be one 32-bit
  * character of up to 6 bytes, or one 16-bit character of up to three bytes
  * plus six following composing characters of three bytes each. */


### PR DESCRIPTION
Answer to @ZyX-I suggestion in https://github.com/neovim/neovim/pull/2246#issuecomment-89040678

> I think that PR needs to be reworked to use static inline functions defined in one header file in place of both library functions like currently and macros/functions with duplicating functionality (I mean vim_isdigit/VIM_ISDIGIT) and inconsistent names (VIM_ISDIGIT vs ASCII_ISLOWER: suggested is ascii_{library_function_name} because all classifier functions/macros only ever emit true on ASCII values).
