### PR TITLE
[RDY] third-party dependencies for Windows

### DIFF
--- a/.ci/mingw.sh
+++ b/.ci/mingw.sh
@@ -1,0 +1,18 @@
+. "$CI_SCRIPTS/common.sh"
+
+# FIXME: When Travis gets a recent version of Mingw-w64 use this
+#sudo apt-get install binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686 mingw-w64-dev mingw-w64-tools
+#sudo apt-get install wine
+sudo apt-get install libc6-dev-i386
+
+# mingw-w64 build from http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/rubenvb/gcc-4.8-release/
+wget "http://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/rubenvb/gcc-4.8-release/i686-w64-mingw32-gcc-4.8.0-linux64_rubenvb.tar.xz" -O mingw.tar.xz
+sudo tar -axf mingw.tar.xz -C /opt
+export PATH=$PATH:/opt/mingw32/bin
+
+# Build third-party
+mkdir .deps
+cd .deps
+cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw32-w64-cross-travis.toolchain.cmake ../third-party/
+cmake --build .
+cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - CI_TARGET=gcc
     - CI_TARGET=gcc-32
     - CI_TARGET=clint
+    - CI_TARGET=mingw
 matrix:
   include:
     - os: osx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: '{build}'
+skip_tags: true
+os: Windows Server 2012 R2
+environment:
+  GYP_MSVS_VERSION: 2013
+  matrix:
+  - GENERATOR: Visual Studio 12 Win64
+    DEPS_PATH: deps64
+  - GENERATOR: Visual Studio 12
+    DEPS_PATH: deps32
+matrix:
+  # Allow builds to fail
+  allow_failures:
+  - os: Windows Server 2012 R2
+install: []
+build_script:
+# See http://help.appveyor.com/discussions/problems/539-cloning-gyp-fails
+- git config --global url."http://".insteadOf https://
+- mkdir %DEPS_PATH%
+- cd %DEPS_PATH%
+- cmake -G "%GENERATOR%" ..\third-party\
+- cmake --build .
+- cd ..

--- a/cmake/mingw32-w64-cross-travis.toolchain.cmake
+++ b/cmake/mingw32-w64-cross-travis.toolchain.cmake
@@ -1,0 +1,53 @@
+#
+# Mingw-w64 cross compiler toolchain
+#
+# - The usual CMAKE variables will point to the cross compiler
+# - HOST_EXE_LINKER, HOST_C_COMPILER, HOST_EXE_LINKER_FLAGS,
+#   HOST_C_FLAGS point to a host compiler
+#
+
+set(MINGW_TRIPLET i686-w64-mingw32)
+# For x86_64 use
+#set(MINGW_TRIPLET x86_64-w64-mingw32)
+
+# The location of your toolchain sys-root
+set(MINGW_PREFIX_PATH /opt/mingw32/${MINGW_TRIPLET}/)
+# or sometimes like this
+#set(MINGW_PREFIX_PATH /usr/${MINGW_TRIPLET}/sys-root)
+
+# the name of the target operating system
+set(CMAKE_SYSTEM_NAME Windows)
+
+# which compilers to use for C and C++
+set(CMAKE_C_COMPILER ${MINGW_TRIPLET}-gcc)
+set(CMAKE_CXX_COMPILER ${MINGW_TRIPLET}-g++)
+set(CMAKE_RC_COMPILER ${MINGW_TRIPLET}-windres)
+set(CMAKE_C_COMPILER ${MINGW_TRIPLET}-gcc)
+set(CMAKE_CXX_COMPILER ${MINGW_TRIPLET}-g++)
+set(CMAKE_RC_COMPILER ${MINGW_TRIPLET}-windres)
+
+# Where is the target environment located
+set(CMAKE_FIND_ROOT_PATH "${MINGW_PREFIX_PATH}/mingw")
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CROSS_TARGET ${MINGW_TRIPLET})
+
+# We need a host compiler too - assuming mildly sane Unix
+# defaults here
+set(HOST_C_COMPILER cc)
+set(HOST_EXE_LINKER ld)
+
+if (MINGW_TRIPLET MATCHES "^x86_64")
+  set(HOST_C_FLAGS)
+  set(HOST_EXE_LINKER_FLAGS)
+else()
+  # In 32 bits systems have the HOST compiler generate 32 bits binaries
+  set(HOST_C_FLAGS -m32)
+  set(HOST_EXE_LINKER_FLAGS -m32)
+endif()

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -22,21 +22,21 @@ option(USE_BUNDLED_MSGPACK "Use the bundled msgpack." ${USE_BUNDLED})
 option(USE_BUNDLED_LUAJIT "Use the bundled version of luajit." ${USE_BUNDLED})
 option(USE_BUNDLED_LUAROCKS "Use the bundled version of luarocks." ${USE_BUNDLED})
 
-# TODO: add windows support
-
-find_program(MAKE_PRG NAMES gmake make)
-if(MAKE_PRG)
-  execute_process(
-    COMMAND "${MAKE_PRG}" --version
-    OUTPUT_VARIABLE MAKE_VERSION_INFO)
-  if(NOT "${OUTPUT_VARIABLE}" MATCHES ".*GNU.*")
-    unset(MAKE_PRG)
+if(UNIX)
+  find_program(MAKE_PRG NAMES gmake make)
+  if(MAKE_PRG)
+    execute_process(
+      COMMAND "${MAKE_PRG}" --version
+      OUTPUT_VARIABLE MAKE_VERSION_INFO)
+    if(NOT "${OUTPUT_VARIABLE}" MATCHES ".*GNU.*")
+      unset(MAKE_PRG)
+    endif()
   endif()
-endif()
-if(NOT MAKE_PRG)
-  message(FATAL_ERROR "GNU Make is required to build the dependencies.")
-else()
-  message(STATUS "Found GNU Make at ${MAKE_PRG}")
+  if(NOT MAKE_PRG)
+    message(FATAL_ERROR "GNU Make is required to build the dependencies.")
+  else()
+    message(STATUS "Found GNU Make at ${MAKE_PRG}")
+  endif()
 endif()
 
 # When using make, use the $(MAKE) variable to avoid warning about the job

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -51,6 +51,22 @@ else()
   set(DEPS_C_COMPILER "${CMAKE_C_COMPILER}")
 endif()
 
+# Cross compiling: use these for dependencies built for the
+# HOST system, when not crosscompiling these should be the
+# same as DEPS_*. Except when targeting UNIX in which case
+# want all the dependencies to use the same compiler.
+if(CMAKE_CROSSCOMPILING AND NOT UNIX)
+  set(HOSTDEPS_INSTALL_DIR "${CMAKE_BINARY_DIR}/host")
+  set(HOSTDEPS_BIN_DIR "${HOSTDEPS_INSTALL_DIR}/bin")
+  set(HOSTDEPS_LIB_DIR "${HOSTDEPS_INSTALL_DIR}/lib")
+  set(HOSTDEPS_C_COMPILER "${HOST_C_COMPILER}")
+else()
+  set(HOSTDEPS_INSTALL_DIR "${DEPS_INSTALL_DIR}")
+  set(HOSTDEPS_BIN_DIR "${DEPS_BIN_DIR}")
+  set(HOSTDEPS_LIB_DIR "${DEPS_LIB_DIR}")
+  set(HOSTDEPS_C_COMPILER "${DEPS_C_COMPILER}")
+endif()
+
 include(ExternalProject)
 
 set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.5.0.tar.gz)

--- a/third-party/cmake/BuildJeMalloc.cmake
+++ b/third-party/cmake/BuildJeMalloc.cmake
@@ -1,3 +1,8 @@
+if(WIN32)
+  message(STATUS "Building jemalloc in Windows is not supported (skipping)")
+  return()
+endif()
+
 ExternalProject_Add(jemalloc
   PREFIX ${DEPS_BUILD_DIR}
   URL ${JEMALLOC_URL}

--- a/third-party/cmake/BuildLibtermkey.cmake
+++ b/third-party/cmake/BuildLibtermkey.cmake
@@ -1,3 +1,7 @@
+if(WIN32)
+  message(STATUS "Building libtermkey in Windows is not supported (skipping)")
+  return()
+endif()
 find_package(PkgConfig REQUIRED)
 
 ExternalProject_Add(libtermkey

--- a/third-party/cmake/BuildLibuv.cmake
+++ b/third-party/cmake/BuildLibuv.cmake
@@ -1,18 +1,84 @@
-ExternalProject_Add(libuv
-  PREFIX ${DEPS_BUILD_DIR}
-  URL ${LIBUV_URL}
-  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/libuv
-  DOWNLOAD_COMMAND ${CMAKE_COMMAND}
-    -DPREFIX=${DEPS_BUILD_DIR}
-    -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/libuv
-    -DURL=${LIBUV_URL}
-    -DEXPECTED_SHA256=${LIBUV_SHA256}
-    -DTARGET=libuv
-    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
-  CONFIGURE_COMMAND sh ${DEPS_BUILD_DIR}/src/libuv/autogen.sh &&
-    ${DEPS_BUILD_DIR}/src/libuv/configure --with-pic --disable-shared
-      --prefix=${DEPS_INSTALL_DIR} --libdir=${DEPS_INSTALL_DIR}/lib
-      CC=${DEPS_C_COMPILER}
-  INSTALL_COMMAND ${MAKE_PRG} install)
+include(CMakeParseArguments)
+
+# BuildLibuv(TARGET targetname CONFIGURE_COMMAND ... BUILD_COMMAND ... INSTALL_COMMAND ...)
+# Reusable function to build libuv, wraps ExternalProject_Add.
+# Failing to pass a command argument will result in no command being run
+function(BuildLibuv)
+  cmake_parse_arguments(_libuv
+    ""
+    "TARGET"
+    "CONFIGURE_COMMAND;BUILD_COMMAND;INSTALL_COMMAND"
+    ${ARGN})
+
+  if(NOT _libuv_CONFIGURE_COMMAND AND NOT _libuv_BUILD_COMMAND
+        AND NOT _libuv_INSTALL_COMMAND)
+    message(FATAL_ERROR "Must pass at least one of CONFIGURE_COMMAND, BUILD_COMMAND, INSTALL_COMMAND")
+  endif()
+  if(NOT _libuv_TARGET)
+    set(_libuv_TARGET "libuv")
+  endif()
+
+  ExternalProject_Add(${_libuv_TARGET}
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${LIBUV_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/libuv
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/libuv
+      -DURL=${LIBUV_URL}
+      -DEXPECTED_SHA256=${LIBUV_SHA256}
+      -DTARGET=${_libuv_TARGET}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    CONFIGURE_COMMAND "${_libuv_CONFIGURE_COMMAND}"
+    BUILD_COMMAND "${_libuv_BUILD_COMMAND}"
+    INSTALL_COMMAND "${_libuv_INSTALL_COMMAND}")
+endfunction()
+
+set(UNIX_CFGCMD sh ${DEPS_BUILD_DIR}/src/libuv/autogen.sh &&
+  ${DEPS_BUILD_DIR}/src/libuv/configure --with-pic --disable-shared
+  --prefix=${DEPS_INSTALL_DIR} --libdir=${DEPS_INSTALL_DIR}/lib
+  CC=${DEPS_C_COMPILER})
+
+if(UNIX)
+  BuildLibUv(
+    CONFIGURE_COMMAND ${UNIX_CFGCMD}
+    INSTALL_COMMAND ${MAKE_PRG} install)
+
+elseif(MINGW AND CMAKE_CROSSCOMPILING)
+  # Build libuv for the host
+  BuildLibUv(TARGET libuv_host
+    CONFIGURE_COMMAND sh ${DEPS_BUILD_DIR}/src/libuv_host/autogen.sh && ${DEPS_BUILD_DIR}/src/libuv_host/configure --with-pic --disable-shared --prefix=${HOSTDEPS_INSTALL_DIR} CC=${HOST_C_COMPILER}
+    INSTALL_COMMAND ${MAKE_PRG} install)
+
+  # Build libuv for the target
+  BuildLibUv(
+    CONFIGURE_COMMAND ${UNIX_CFGCMD} --host=${CROSS_TARGET}
+    INSTALL_COMMAND ${MAKE_PRG} install)
+
+
+elseif(WIN32 AND MSVC)
+
+  find_package(PythonInterp 2.6 REQUIRED)
+  if(NOT PYTHONINTERP_FOUND OR PYTHON_VERSION_MAJOR GREATER 2)
+    message(FATAL_ERROR "Python2 is required to build libuv on windows, use -DPYTHON_EXECUTABLE to set a python interpreter")
+  endif()
+
+  string(FIND ${CMAKE_GENERATOR} Win64 VS_WIN64)
+  if(VS_WIN64 EQUAL -1)
+    set(VS_ARCH x86)
+  else()
+    set(VS_ARCH x64)
+  endif()
+  BuildLibUv(
+    # By default this creates Debug builds
+    BUILD_COMMAND set PYTHON=${PYTHON_EXECUTABLE} COMMAND ${DEPS_BUILD_DIR}/src/libuv/vcbuild.bat static debug ${VS_ARCH}
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_INSTALL_DIR}/lib
+      COMMAND ${CMAKE_COMMAND} -E copy ${DEPS_BUILD_DIR}/src/libuv/Debug/lib/libuv.lib ${DEPS_INSTALL_DIR}/lib
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_INSTALL_DIR}/include
+      COMMAND ${CMAKE_COMMAND} -E copy_directory ${DEPS_BUILD_DIR}/src/libuv/include ${DEPS_INSTALL_DIR}/include)
+
+else()
+  message(FATAL_ERROR "Trying to build libuv in an unsupported system ${CMAKE_SYSTEM_NAME}/${CMAKE_C_COMPILER_ID}")
+endif()
 
 list(APPEND THIRD_PARTY_DEPS libuv)

--- a/third-party/cmake/BuildLibvterm.cmake
+++ b/third-party/cmake/BuildLibvterm.cmake
@@ -1,3 +1,8 @@
+if(WIN32)
+  message(STATUS "Building libvterm in Windows is not supported (skipping)")
+  return()
+endif()
+
 ExternalProject_Add(libvterm
   PREFIX ${DEPS_BUILD_DIR}
   URL ${LIBVTERM_URL}

--- a/third-party/cmake/BuildLuajit.cmake
+++ b/third-party/cmake/BuildLuajit.cmake
@@ -1,25 +1,87 @@
-ExternalProject_Add(luajit
-  PREFIX ${DEPS_BUILD_DIR}
-  URL ${LUAJIT_URL}
-  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/luajit
-  DOWNLOAD_COMMAND ${CMAKE_COMMAND}
-    -DPREFIX=${DEPS_BUILD_DIR}
-    -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/luajit
-    -DURL=${LUAJIT_URL}
-    -DEXPECTED_SHA256=${LUAJIT_SHA256}
-    -DTARGET=luajit
-    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
-  CONFIGURE_COMMAND ""
-  BUILD_IN_SOURCE 1
-  BUILD_COMMAND ""
-  INSTALL_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
-                              PREFIX=${DEPS_INSTALL_DIR}
-                              CFLAGS=-fPIC
-                              CFLAGS+=-DLUAJIT_DISABLE_JIT
-                              CFLAGS+=-DLUA_USE_APICHECK
-                              CFLAGS+=-DLUA_USE_ASSERT
-                              CCDEBUG+=-g
-                              BUILDMODE=static
-                              install)
+include(CMakeParseArguments)
+
+# BuildLuajit(TARGET targetname CONFIGURE_COMMAND ... BUILD_COMMAND ... INSTALL_COMMAND ...)
+# Reusable function to build luajit, wraps ExternalProject_Add.
+# Failing to pass a command argument will result in no command being run
+function(BuildLuajit)
+  cmake_parse_arguments(_luajit
+    ""
+    "TARGET"
+    "CONFIGURE_COMMAND;BUILD_COMMAND;INSTALL_COMMAND"
+    ${ARGN})
+  if(NOT _luajit_CONFIGURE_COMMAND AND NOT _luajit_BUILD_COMMAND
+        AND NOT _luajit_INSTALL_COMMAND)
+    message(FATAL_ERROR "Must pass at least one of CONFIGURE_COMMAND, BUILD_COMMAND, INSTALL_COMMAND")
+  endif()
+  if(NOT _luajit_TARGET)
+    set(_luajit_TARGET "luajit")
+  endif()
+
+  ExternalProject_Add(${_luajit_TARGET}
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${LUAJIT_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/luajit
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/luajit
+      -DURL=${LUAJIT_URL}
+      -DEXPECTED_SHA256=${LUAJIT_SHA256}
+      -DTARGET=${_luajit_TARGET}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    CONFIGURE_COMMAND "${_luajit_CONFIGURE_COMMAND}"
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND "${_luajit_BUILD_COMMAND}"
+    INSTALL_COMMAND "${_luajit_INSTALL_COMMAND}")
+endfunction()
+
+set(INSTALLCMD_UNIX ${MAKE_PRG} CFLAGS=-fPIC
+                                CFLAGS+=-DLUAJIT_DISABLE_JIT
+                                CFLAGS+=-DLUA_USE_APICHECK
+                                CFLAGS+=-DLUA_USE_ASSERT
+                                CCDEBUG+=-g
+                                BUILDMODE=static
+                                install)
+
+if(UNIX)
+  BuildLuaJit(INSTALL_COMMAND ${INSTALLCMD_UNIX}
+    CC=${DEPS_C_COMPILER} PREFIX=${DEPS_INSTALL_DIR})
+
+elseif(MINGW AND CMAKE_CROSSCOMPILING)
+
+  # Build luajit for the host
+  BuildLuaJit(TARGET luajit_host
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ${INSTALLCMD_UNIX}
+      CC=${HOST_C_COMPILER} PREFIX=${HOSTDEPS_INSTALL_DIR})
+
+  # Build luajit for the target
+  BuildLuaJit(
+    # Similar to Unix + cross - fPIC
+    INSTALL_COMMAND
+      ${MAKE_PRG} PREFIX=${DEPS_INSTALL_DIR}
+        BUILDMODE=static install
+        TARGET_SYS=${CMAKE_SYSTEM_NAME}
+        CROSS=${CROSS_TARGET}-
+        HOST_CC=${HOST_C_COMPILER} HOST_CFLAGS=${HOST_C_FLAGS}
+        HOST_LDFLAGS=${HOST_EXE_LINKER_FLAGS}
+        FILE_T=luajit.exe
+        INSTALL_TSYMNAME=luajit.exe)
+
+elseif(WIN32 AND MSVC)
+
+  BuildLuaJit(
+    BUILD_COMMAND ${CMAKE_COMMAND} -E chdir ${DEPS_BUILD_DIR}/src/luajit/src ${DEPS_BUILD_DIR}/src/luajit/src/msvcbuild.bat static
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_INSTALL_DIR}/bin
+      COMMAND ${CMAKE_COMMAND} -E copy ${DEPS_BUILD_DIR}/src/luajit/src/luajit.exe ${DEPS_INSTALL_DIR}/bin
+      COMMAND ${CMAKE_COMMAND} -E copy ${DEPS_BUILD_DIR}/src/luajit/src/lua51.lib ${DEPS_INSTALL_DIR}/bin
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_INSTALL_DIR}/lib
+      COMMAND ${CMAKE_COMMAND} -E copy ${DEPS_BUILD_DIR}/src/luajit/src/lua51.lib ${DEPS_INSTALL_DIR}/lib
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_INSTALL_DIR}/include/luajit-2.0
+      COMMAND ${CMAKE_COMMAND} -DFROM_GLOB=${DEPS_BUILD_DIR}/src/luajit/src/*.h -DTO=${DEPS_INSTALL_DIR}/include/luajit-2.0 -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/CopyFilesGlob.cmake)
+
+else()
+  message(FATAL_ERROR "Trying to build luajit in an unsupported system ${CMAKE_SYSTEM_NAME}/${CMAKE_C_COMPILER_ID}")
+endif()
 
 list(APPEND THIRD_PARTY_DEPS luajit)

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -1,35 +1,90 @@
-option(USE_BUNDLED_BUSTED "Use the bundled version of busted to run tests." ON)
+# Luarocks recipe. Luarocks is only required when building Neovim, when
+# cross compiling we still want to build for the HOST system, whenever
+# writing a recipe than is mean for cross-compile, use the HOSTDEPS_* variables
+# instead of DEPS_* - check the main CMakeLists.txt for a list.
 
-if(USE_BUNDLED_LUAJIT)
-  list(APPEND LUAROCKS_OPTS
-    --with-lua=${DEPS_INSTALL_DIR}
-    --with-lua-include=${DEPS_INSTALL_DIR}/include/luajit-2.0)
+if(MSVC)
+  message(STATUS "Building busted in Windows is not supported (skipping)")
+else()
+  option(USE_BUNDLED_BUSTED "Use the bundled version of busted to run tests." ON)
 endif()
 
-ExternalProject_Add(luarocks
-  PREFIX ${DEPS_BUILD_DIR}
-  URL ${LUAROCKS_URL}
-  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/luarocks
-  DOWNLOAD_COMMAND ${CMAKE_COMMAND}
-    -DPREFIX=${DEPS_BUILD_DIR}
-    -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/luarocks
-    -DURL=${LUAROCKS_URL}
-    -DEXPECTED_SHA256=${LUAROCKS_SHA256}
-    -DTARGET=luarocks
-    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
-  BUILD_IN_SOURCE 1
-  CONFIGURE_COMMAND ${DEPS_BUILD_DIR}/src/luarocks/configure
-    --prefix=${DEPS_INSTALL_DIR} --force-config ${LUAROCKS_OPTS}
-    --lua-suffix=jit
-  BUILD_COMMAND ""
-  INSTALL_COMMAND ${MAKE_PRG} bootstrap)
+# BuildLuarocks(CONFIGURE_COMMAND ... BUILD_COMMAND ... INSTALL_COMMAND ...)
+# Reusable function to build luarocks, wraps ExternalProject_Add.
+# Failing to pass a command argument will result in no command being run
+function(BuildLuarocks)
+  cmake_parse_arguments(_luarocks
+    ""
+    ""
+    "CONFIGURE_COMMAND;BUILD_COMMAND;INSTALL_COMMAND"
+    ${ARGN})
+
+  if(NOT _luarocks_CONFIGURE_COMMAND AND NOT _luarocks_BUILD_COMMAND
+        AND NOT _luarocks_INSTALL_COMMAND)
+    message(FATAL_ERROR "Must pass at least one of CONFIGURE_COMMAND, BUILD_COMMAND, INSTALL_COMMAND")
+  endif()
+
+  ExternalProject_Add(luarocks
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${LUAROCKS_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/luarocks
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/luarocks
+      -DURL=${LUAROCKS_URL}
+      -DEXPECTED_SHA256=${LUAROCKS_SHA256}
+      -DTARGET=luarocks
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND "${_luarocks_CONFIGURE_COMMAND}"
+    BUILD_COMMAND "${_luarocks_BUILD_COMMAND}"
+    INSTALL_COMMAND "${_luarocks_INSTALL_COMMAND}")
+endfunction()
+
+# The luarocks binary location
+set(LUAROCKS_BINARY ${HOSTDEPS_BIN_DIR}/luarocks)
+
+# Arguments for calls to 'luarocks build'
+if(MSVC)
+  # In native Win32 don't pass the compiler/linker to luarocks, the bundled
+  # version already knows, and passing them here breaks the build
+  set(LUAROCKS_BUILDARGS CFLAGS=/MT)
+else()
+  set(LUAROCKS_BUILDARGS CC=${HOSTDEPS_C_COMPILER} LD=${HOSTDEPS_C_COMPILER})
+endif()
+
+if(UNIX OR (MINGW AND CMAKE_CROSSCOMPILING))
+
+  if(USE_BUNDLED_LUAJIT)
+    list(APPEND LUAROCKS_OPTS
+      --with-lua=${HOSTDEPS_INSTALL_DIR}
+      --with-lua-include=${HOSTDEPS_INSTALL_DIR}/include/luajit-2.0)
+  endif()
+
+  BuildLuarocks(
+    CONFIGURE_COMMAND ${DEPS_BUILD_DIR}/src/luarocks/configure
+      --prefix=${HOSTDEPS_INSTALL_DIR} --force-config ${LUAROCKS_OPTS}
+      --lua-suffix=jit
+    INSTALL_COMMAND ${MAKE_PRG} bootstrap)
+
+elseif(MSVC)
+  # Ignore USE_BUNDLED_LUAJIT - always ON for native Win32
+  BuildLuarocks(INSTALL_COMMAND install.bat /FORCECONFIG /NOREG /NOADMIN /Q /F
+    /LUA ${DEPS_INSTALL_DIR}
+    /LIB ${DEPS_LIB_DIR}
+    /BIN ${DEPS_BIN_DIR}
+    /INC ${DEPS_INSTALL_DIR}/include/luajit-2.0/
+    /P ${DEPS_INSTALL_DIR} /TREE ${DEPS_INSTALL_DIR}
+    /SCRIPTS ${DEPS_BIN_DIR}
+    /CMOD ${DEPS_BIN_DIR}
+    /LUAMOD ${DEPS_BIN_DIR}/lua)
+
+  set(LUAROCKS_BINARY ${DEPS_INSTALL_DIR}/2.2/luarocks.bat)
+else()
+  message(FATAL_ERROR "Trying to build luarocks in an unsupported system ${CMAKE_SYSTEM_NAME}/${CMAKE_C_COMPILER_ID}")
+endif()
 
 list(APPEND THIRD_PARTY_DEPS luarocks)
-
-# The path to the luarocks executable
-set(LUAROCKS_BINARY ${DEPS_BIN_DIR}/luarocks)
-# Common build arguments for luarocks build
-set(LUAROCKS_BUILDARGS CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER})
 
 if(USE_BUNDLED_LUAJIT)
   add_dependencies(luarocks luajit)
@@ -37,29 +92,30 @@ endif()
 
 # Each target depends on the previous module, this serializes all calls to
 # luarocks since it is unhappy to be called in parallel.
-add_custom_command(OUTPUT ${DEPS_LIB_DIR}/luarocks/rocks/lua-messagepack
+add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/lua-messagepack
   COMMAND ${LUAROCKS_BINARY}
   ARGS build lua-messagepack ${LUAROCKS_BUILDARGS}
   DEPENDS luarocks)
 add_custom_target(lua-messagepack
-  DEPENDS ${DEPS_LIB_DIR}/luarocks/rocks/lua-messagepack)
+  DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/lua-messagepack)
+list(APPEND THIRD_PARTY_DEPS lua-messagepack)
+
 
 # Like before, depend on lua-messagepack to ensure serialization of install
 # commands
-add_custom_command(OUTPUT ${DEPS_LIB_DIR}/luarocks/rocks/lpeg
+add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/lpeg
   COMMAND ${LUAROCKS_BINARY}
   ARGS build lpeg ${LUAROCKS_BUILDARGS}
   DEPENDS lua-messagepack)
 add_custom_target(lpeg
-  DEPENDS ${DEPS_LIB_DIR}/luarocks/rocks/lpeg)
+  DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/lpeg)
 
-list(APPEND THIRD_PARTY_DEPS lua-messagepack lpeg)
+list(APPEND THIRD_PARTY_DEPS lpeg)
 
 if(USE_BUNDLED_BUSTED)
   # The following are only required if we want to run tests
   # with busted
-
-  add_custom_command(OUTPUT ${DEPS_LIB_DIR}/luarocks/rocks/stable-busted-deps
+  add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/stable-busted-deps
     COMMAND ${LUAROCKS_BINARY}
     ARGS build lua_cliargs 2.5-1 ${LUAROCKS_BUILDARGS}
     COMMAND ${LUAROCKS_BINARY}
@@ -82,24 +138,24 @@ if(USE_BUNDLED_BUSTED)
     ARGS build xml 1.1.2-1 ${LUAROCKS_BUILDARGS}
     COMMAND ${LUAROCKS_BINARY}
     ARGS build ansicolors 1.0.2-3 ${LUAROCKS_BUILDARGS}
-    COMMAND touch ${DEPS_LIB_DIR}/luarocks/rocks/stable-busted-deps
+    COMMAND touch ${HOSTDEPS_LIB_DIR}/luarocks/rocks/stable-busted-deps
     DEPENDS lpeg)
   add_custom_target(stable-busted-deps
-    DEPENDS ${DEPS_LIB_DIR}/luarocks/rocks/stable-busted-deps)
+    DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/stable-busted-deps)
 
-  add_custom_command(OUTPUT ${DEPS_BIN_DIR}/busted
+  add_custom_command(OUTPUT ${HOSTDEPS_BIN_DIR}/busted
     COMMAND ${LUAROCKS_BINARY}
     ARGS build https://raw.githubusercontent.com/Olivine-Labs/busted/v2.0.rc8-0/busted-2.0.rc8-0.rockspec ${LUAROCKS_BUILDARGS}
     DEPENDS stable-busted-deps)
   add_custom_target(busted
-    DEPENDS ${DEPS_BIN_DIR}/busted)
+    DEPENDS ${HOSTDEPS_BIN_DIR}/busted)
 
-  add_custom_command(OUTPUT ${DEPS_LIB_DIR}/luarocks/rocks/nvim-client
+  add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build https://raw.githubusercontent.com/neovim/lua-client/0.0.1-12/nvim-client-0.0.1-12.rockspec ${LUAROCKS_BUILDARGS} LIBUV_DIR=${DEPS_INSTALL_DIR}
+    ARGS build https://raw.githubusercontent.com/neovim/lua-client/0.0.1-12/nvim-client-0.0.1-12.rockspec ${LUAROCKS_BUILDARGS} LIBUV_DIR=${HOSTDEPS_INSTALL_DIR}
     DEPENDS busted libuv)
   add_custom_target(nvim-client
-    DEPENDS ${DEPS_LIB_DIR}/luarocks/rocks/nvim-client)
+    DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client)
 
   list(APPEND THIRD_PARTY_DEPS stable-busted-deps busted nvim-client)
 endif()

--- a/third-party/cmake/BuildMsgpack.cmake
+++ b/third-party/cmake/BuildMsgpack.cmake
@@ -1,22 +1,74 @@
+include(CMakeParseArguments)
 
-ExternalProject_Add(msgpack
-  PREFIX ${DEPS_BUILD_DIR}
-  URL ${MSGPACK_URL}
-  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/msgpack
-  DOWNLOAD_COMMAND ${CMAKE_COMMAND}
-    -DPREFIX=${DEPS_BUILD_DIR}
-    -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/msgpack
-    -DURL=${MSGPACK_URL}
-    -DEXPECTED_SHA256=${MSGPACK_SHA256}
-    -DTARGET=msgpack
-    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
-  CONFIGURE_COMMAND cmake ${DEPS_BUILD_DIR}/src/msgpack
-     -DMSGPACK_ENABLE_CXX=OFF
-     -DMSGPACK_BUILD_TESTS=OFF
-     -DCMAKE_INSTALL_PREFIX=${DEPS_INSTALL_DIR}
-     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-     "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_COMPILER_ARG1} -fPIC"
-  BUILD_COMMAND ${CMAKE_COMMAND} --build .
-  INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install)
+# BuildMsgpack(CONFIGURE_COMMAND ... BUILD_COMMAND ... INSTALL_COMMAND ...)
+# Reusable function to build msgpack, wraps ExternalProject_Add.
+# Failing to pass a command argument will result in no command being run
+function(BuildMsgpack)
+  cmake_parse_arguments(_msgpack
+    ""
+    ""
+    "CONFIGURE_COMMAND;BUILD_COMMAND;INSTALL_COMMAND"
+    ${ARGN})
+
+  if(NOT _msgpack_CONFIGURE_COMMAND AND NOT _msgpack_BUILD_COMMAND
+       AND NOT _msgpack_INSTALL_COMMAND)
+    message(FATAL_ERROR "Must pass at least one of CONFIGURE_COMMAND, BUILD_COMMAND, INSTALL_COMMAND")
+  endif()
+
+  ExternalProject_Add(msgpack
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${MSGPACK_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/msgpack
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/msgpack
+      -DURL=${MSGPACK_URL}
+      -DEXPECTED_SHA256=${MSGPACK_SHA256}
+      -DTARGET=msgpack
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    CONFIGURE_COMMAND "${_msgpack_CONFIGURE_COMMAND}"
+    BUILD_COMMAND "${_msgpack_BUILD_COMMAND}"
+    INSTALL_COMMAND "${_msgpack_INSTALL_COMMAND}")
+endfunction()
+
+set(MSGPACK_CONFIGURE_COMMAND ${CMAKE_COMMAND} ${DEPS_BUILD_DIR}/src/msgpack
+  -DMSGPACK_ENABLE_CXX=OFF
+  -DMSGPACK_BUILD_TESTS=OFF
+  -DCMAKE_INSTALL_PREFIX=${DEPS_INSTALL_DIR}
+  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+  "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_COMPILER_ARG1} -fPIC")
+
+set(MSGPACK_BUILD_COMMAND ${CMAKE_COMMAND} --build .)
+set(MSGPACK_INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install)
+
+if(MINGW AND CMAKE_CROSSCOMPILING)
+  get_filename_component(TOOLCHAIN ${CMAKE_TOOLCHAIN_FILE} REALPATH)
+  set(MSGPACK_CONFIGURE_COMMAND ${CMAKE_COMMAND} ${DEPS_BUILD_DIR}/src/msgpack
+    -DMSGPACK_ENABLE_CXX=OFF
+    -DMSGPACK_BUILD_TESTS=OFF
+    -DCMAKE_INSTALL_PREFIX=${DEPS_INSTALL_DIR}
+    # Pass toolchain
+    -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN}
+    # Hack to avoid -rdynamic in Mingw
+    -DCMAKE_SHARED_LIBRARY_LINK_C_FLAGS="")
+elseif(MSVC)
+  # Same as UNIX without fPIC
+  set(MSGPACK_CONFIGURE_COMMAND ${CMAKE_COMMAND} ${DEPS_BUILD_DIR}/src/msgpack
+    -DMSGPACK_ENABLE_CXX=OFF
+    -DMSGPACK_BUILD_TESTS=OFF
+    -DCMAKE_INSTALL_PREFIX=${DEPS_INSTALL_DIR}
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_COMPILER_ARG1}"
+    # Make sure we use the same generator, otherwise we may
+    # accidentaly end up using different MSVC runtimes
+    -DCMAKE_GENERATOR=${CMAKE_GENERATOR}
+    # Use static runtime
+    -DCMAKE_C_FLAGS_DEBUG="-MTd"
+    -DCMAKE_C_FLAGS_RELEASE="-MT")
+endif()
+
+BuildMsgpack(CONFIGURE_COMMAND ${MSGPACK_CONFIGURE_COMMAND}
+  BUILD_COMMAND ${MSGPACK_BUILD_COMMAND}
+  INSTALL_COMMAND ${MSGPACK_INSTALL_COMMAND})
+
 list(APPEND THIRD_PARTY_DEPS msgpack)
-

--- a/third-party/cmake/BuildUnibilium.cmake
+++ b/third-party/cmake/BuildUnibilium.cmake
@@ -1,3 +1,8 @@
+if(WIN32)
+  message(STATUS "Building Unibilium in Windows is not supported (skipping)")
+  return()
+endif()
+
 ExternalProject_Add(unibilium
   PREFIX ${DEPS_BUILD_DIR}
   URL ${UNIBILIUM_URL}

--- a/third-party/cmake/CopyFilesGlob.cmake
+++ b/third-party/cmake/CopyFilesGlob.cmake
@@ -1,0 +1,18 @@
+# Copy multiple files to destination, based on a glob expression
+# - FROM_GLOB
+# - TO
+
+if(NOT FROM_GLOB)
+  message(FATAL_ERROR "FROM_GLOB must be set")
+endif()
+if(NOT TO)
+  message(FATAL_ERROR "TO must be set")
+endif()
+
+file(GLOB files ${FROM_GLOB})
+foreach(file ${files})
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${file} ${TO} RESULT_VARIABLE rv)
+  if(NOT rv EQUAL 0)
+    message(FATAL_ERROR "Error copying ${file}")
+  endif()
+endforeach()


### PR DESCRIPTION
These are basically the first 4 commits in #810, and everything that relates to the third-party/ recipes for windows:
- Works for MSVC and Mingw(cross compile)
- Recipes for libuv, luajit, msgpack, luarocks
- Busted is not building for MSVC yet (some of its deps are breaking and nvim-client needs fixing)
- appveyor.yaml with settings to build in appveyor
- mingw build script for Travis

I'm afraid the luarocks recipe doesn't look very clean, suggestions for more idiomatic CMake are very welcome.

Appveyor for #810 [![Build status](https://ci.appveyor.com/api/projects/status/ki4bc2v81axm36ow/branch/tb-mingw)](https://ci.appveyor.com/project/equalsraf/neovim/branch/tb-mingw) (I'm rebasing on top of this to make sure I don't break it either)
