### PR TITLE
[RFC] doc: remove :fixdel

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -32,9 +32,8 @@ For inserting text see |insert.txt|.
 			"dl".
 			The <Del> key does not take a [count].  Instead, it
 			deletes the last character of the count.
-			See |:fixdel| if the <Del> key does not do what you
-			want.  See |'whichwrap'| for deleting a line break
-			(join lines).  {Vi does not support <Del>}
+			See |'whichwrap'| for deleting a line break (join
+			lines).  {Vi does not support <Del>}
 
 							*X* *dh*
 ["x]X			Delete [count] characters before the cursor [into

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -102,12 +102,10 @@ CTRL-E or <End>					*c_CTRL-E* *c_<End>* *c_End*
 <LeftMouse>	Move the cursor to the position of the mouse click.
 
 CTRL-H						*c_<BS>* *c_CTRL-H* *c_BS*
-<BS>		Delete the character in front of the cursor (see |:fixdel| if
-		your <BS> key does not do what you want).
+<BS>		Delete the character in front of the cursor.
 							*c_<Del>* *c_Del*
 <Del>		Delete the character under the cursor (at end of line:
-		character before the cursor) (see |:fixdel| if your <Del>
-		key does not do what you want).
+		character before the cursor).
 							*c_CTRL-W*
 CTRL-W		Delete the |word| before the cursor.  This depends on the
 		'iskeyword' option.

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -318,6 +318,9 @@ name between two bars (|) eg. |help-writing|.
 When referring to a Vim option in the help file, place the option name between
 two single quotes, eg. 'statusline'
 
+When referring to any other technical term, such as a filename or function
+parameter, surround it in backticks (`), eg. `~/.path/to/nvimrc`.
+
 
 HIGHLIGHTING
 

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1226,7 +1226,6 @@ tag	      command	      action ~
 |:finally|	:fina[lly]	part of a :try command
 |:finish|	:fini[sh]	quit sourcing a Vim script
 |:first|	:fir[st]	go to the first file in the argument list
-|:fixdel|	:fix[del]	set key code of <Del>
 |:fold|		:fo[ld]		create a fold
 |:foldclose|	:foldc[lose]	close folds
 |:folddoopen|	:foldd[oopen]	execute command on lines not in a closed fold

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -67,15 +67,11 @@ CTRL-A		Insert previously inserted text.  {not in Vi}
 						*i_CTRL-H* *i_<BS>* *i_BS*
 <BS> or CTRL-H	Delete the character before the cursor (see |i_backspacing|
 		about joining lines).
-		See |:fixdel| if your <BS> key does not do what you want.
-		{Vi: does not delete autoindents}
 						*i_<Del>* *i_DEL*
 <Del>		Delete the character under the cursor.  If the cursor is at
 		the end of the line, and the 'backspace' option includes
 		"eol", delete the <EOL>; the next line is appended after the
 		current one.
-		See |:fixdel| if your <Del> key does not do what you want.
-		{not in Vi}
 						*i_CTRL-W*
 CTRL-W		Delete the word before the cursor (see |i_backspacing| about
 		joining lines).  See the section "word motions",

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -471,7 +471,7 @@ available on a few terminals.
 Note: There are two codes for the delete key.  127 is the decimal ASCII value
 for the delete key, which is always recognized.  Some delete keys send another
 value, in which case this value is obtained from the termcap entry "kD".  Both
-values have the same effect.  Also see |:fixdel|.
+values have the same effect.
 
 Note: The keypad keys are used in the same way as the corresponding "normal"
 keys.  For example, <kHome> has the same effect as <Home>.  If a keypad key

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -167,8 +167,6 @@ CTRL-H		or					*CTRL-H* *<BS>*
 				:map CTRL-V<BS>		X
 			(to enter "CTRL-V<BS>" type the CTRL-V key, followed
 			by the <BS> key)
-			See |:fixdel| if the <BS> key does not do what you
-			want.
 
 l		or					*l*
 <Right>		or					*<Right>* *<Space>*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -408,40 +408,6 @@ command, not when assigning a value to an option with ":let".
 Note the maximum length of an expanded option is limited.  How much depends on
 the system, mostly it is something like 256 or 1024 characters.
 
-							*:fix* *:fixdel*
-:fix[del]		Set the value of 't_kD':
-				't_kb' is     't_kD' becomes	~
-				  CTRL-?	CTRL-H
-				not CTRL-?	CTRL-?
-
-			(CTRL-? is 0177 octal, 0x7f hex) {not in Vi}
-
-			If your delete key terminal code is wrong, but the
-			code for backspace is alright, you can put this in
-			your .vimrc: >
-				:fixdel
-<			This works no matter what the actual code for
-			backspace is.
-
-			If the backspace key terminal code is wrong you can
-			use this: >
-				:if &term == "termname"
-				:  set t_kb=^V<BS>
-				:  fixdel
-				:endif
-<			Where "^V" is CTRL-V and "<BS>" is the backspace key
-			(don't type four characters!).  Replace "termname"
-			with your terminal name.
-
-			If your <Delete> key sends a strange key sequence (not
-			CTRL-? or CTRL-H) you cannot use ":fixdel".  Then use: >
-				:if &term == "termname"
-				:  set t_kD=^V<Delete>
-				:endif
-<			Where "^V" is CTRL-V and "<Delete>" is the delete key
-			(don't type eight characters!).  Replace "termname"
-			with your terminal name.
-
 							*Linux-backspace*
 			Note about Linux: By default the backspace key
 			produces CTRL-?, which is wrong.  You can fix it by
@@ -890,8 +856,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  0	same as ":set backspace=" (Vi compatible)
 	  1	same as ":set backspace=indent,eol"
 	  2	same as ":set backspace=indent,eol,start"
-
-	See |:fixdel| if your <BS> or <Del> key does not do what you want.
 
 				*'backup'* *'bk'* *'nobackup'* *'nobk'*
 'backup' 'bk'		boolean	(default off)

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -590,8 +590,6 @@ In Insert or Command-line mode:
 |:setglobal|	:setg[lobal]		  like ":set" but set the global value
 					  of a local option
 
-|:fix|		:fix[del]		  set value of 't_kD' according to
-					  value of 't_kb'
 |:options|	:opt[ions]		  open a new window to view and set
 					  options, grouped by functionality,
 					  a one line explanation and links to

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -5132,8 +5132,6 @@ Various improvements:
     sufficient.  ":setflush" resets the option stack?
     How to handle an aborted mapping?  Remember position in tag stack when
     mapping starts, restore it when an error aborts the mapping?
--   Change ":fixdel" into option 'fixdel', t_del will be adjusted each time
-    t_bs is set? (Webb)
 -   "gc": goto character, move absolute character positions forward, also
     counting newlines.  "gC" goes backwards (Weigert).
 -   When doing CTRL-^, redraw buffer with the same topline. (Demirel)  Store

--- a/runtime/doc/usr_90.txt
+++ b/runtime/doc/usr_90.txt
@@ -364,22 +364,6 @@ If the terminal type listed is not correct, fix it.  For more hints, see
 gvim.  This avoids the need for a correct terminal setup.
 
 
-Q: My Backspace And Delete Keys Don't Work Right
-
-The definition of what key sends what code is very unclear for backspace <BS>
-and Delete <Del> keys.  First of all, check your $TERM setting.  If there is
-nothing wrong with it, try this: >
-
-	:set t_kb=^V<BS>
-	:set t_kD=^V<Del>
-
-In the first line you need to press CTRL-V and then hit the backspace key.
-In the second line you need to press CTRL-V and then hit the Delete key.
-You can put these lines in your vimrc file, see |05.1|.  A disadvantage is
-that it won't work when you use another terminal some day.  Look here for
-alternate solutions: |:fixdel|.
-
-
 Q: I Am Using RedHat Linux.  Can I Use the Vim That Comes with the System?
 
 By default RedHat installs a minimal version of Vim.  Check your RPM packages

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -35,9 +35,7 @@ CTRL-L			Clear and redraw the screen.  The redraw may happen
 			Note: if you like to use <BS> for this, add this
 			mapping to your .vimrc: >
 				:map CTRL-V <BS>   CTRL-V <Del>
-<			See |:fixdel| if your <Del> key does not do what you
-			want.
-
+<
 :as[cii]	or					*ga* *:as* *:ascii*
 ga			Print the ascii value of the character under the
 			cursor in decimal, hexadecimal and octal.  For

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -21,9 +21,9 @@ these differences.
 ==============================================================================
 1. Configuration					    *nvim-configuration*
 
-- Use ".nvimrc" instead of ".vimrc" for storing configuration.
-- Use ".nvim" instead of ".vim" to store configuration files.
-- Use ".nviminfo" instead of ".viminfo" for persistent session information.
+- Use `.nvimrc` instead of `.vimrc` for storing configuration.
+- Use `.nvim` instead of `.vim` to store configuration files.
+- Use `.nviminfo` instead of `.viminfo` for persistent session information.
 
 ==============================================================================
 2. Option defaults					  *nvim-option-defaults*
@@ -49,27 +49,27 @@ are always available and may be used simultaneously in separate plugins.  The
 
 See |nvim-intro| for a list of Nvim's largest new features.
 
-Meta key chords are recognized (even in the terminal).
-- <M-1>, <M-2>, ...
-- <M-BS>, <M-Del>, <M-Ins>, ...
-- <M-/>, <M-\>, ...
-- <M-Space>, <M-Enter>, <M-=>, <M-->, <M-?>, <M-$>, ...
+Meta-key chords are recognized (even in the terminal).
+  <M-1>, <M-2>, ...
+  <M-BS>, <M-Del>, <M-Ins>, ...
+  <M-/>, <M-\>, ...
+  <M-Space>, <M-Enter>, <M-=>, <M-->, <M-?>, <M-$>, ...
 
-CTRL-SHIFT-... key chords are distinguished from CTRL-... variants (even in
+`CTRL-SHIFT-...` key chords are distinguished from `CTRL-...` variants (even in
 the terminal).
-- <C-Tab>, <C-S-Tab>
-- <C-BS>, <C-S-BS>
-- <C-Enter>, <C-S-Enter>
+  <C-Tab>, <C-S-Tab>
+  <C-BS>, <C-S-BS>
+  <C-Enter>, <C-S-Enter>
 
 Events:
-- |TabNew|
-- |TabNewEntered|
-- |TabClosed|
+  |TabNew|
+  |TabNewEntered|
+  |TabClosed|
 
 Highlight groups:
-- |hl-EndOfBuffer|
-- |hl-TermCursor|
-- |hl-TermCursorNC|
+  |hl-EndOfBuffer|
+  |hl-TermCursor|
+  |hl-TermCursorNC|
 
 ==============================================================================
 5. Missing legacy features				 *nvim-features-missing*
@@ -89,39 +89,42 @@ planned for the current milestone.
 
 These features are in Vim, but have been intentionally removed from Nvim.
 
-Vi-compatible mode
-- ":set nocompatible" is ignored
-- ":set compatible" is an error
+Vi-compatible mode:
+  ":set nocompatible" is ignored
+  ":set compatible" is an error
 
-Ed-compatible mode
-- ":set noedcompatible" is ignored
-- ":set edcompatible" is an error
+Ed-compatible mode:
+  ":set noedcompatible" is ignored
+  ":set edcompatible" is an error
 
-'ttyfast'
-- ":set ttyfast" is ignored
-- ":set nottyfast" is an error
+'ttyfast':
+  ":set ttyfast" is ignored
+  ":set nottyfast" is an error
 
-EBCDIC support
+Encryption support:
+  'cryptmethod'
+  'key'
 
-8.3 filesystem support
-- 'shortname'
+MS-DOS support:
+  'bioskey'
+  'conskey'
 
-Encryption support
-- 'cryptmethod'
-- 'key'
+Other options:
+  'shortname'
+  'shelltype'
+  'textauto'
+  'textmode'
 
-MS-DOS support
-- 'bioskey'
-- 'conskey'
+Other commands:
+  :fixdel
+  :mode no longer accepts an argument
+  :shell
 
-'shelltype'
-":shell"
-":mode", no longer accepts an argument
-'textauto'
-'textmode'
+Other compile-time features:
+  EBCDIC
 
 "Easy mode" (eview, evim, nvim -y)
-"(g)vimdiff" (solely an alias for (g)nvim -d, i.e. |diff-mode|)
+"(g)vimdiff" (alias for "(g)nvim -d" |diff-mode|)
 "Vi mode" (nvim -v)
 
 The ability to start nvim via the following aliases has been removed in favor


### PR DESCRIPTION
`:fixdel` was removed in 3baba1e7bc6698e6bc9f1d37fce88b30d6274bc9.

Possibly related: https://github.com/neovim/neovim/issues/2048
