### PR TITLE
[RFC] Modify vim_strbyte() to take advantage of strchr()

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -413,21 +413,18 @@ char_u *vim_strchr(const char_u *string, int c)
 }
 
 /*
- * Version of strchr() that only works for bytes and handles unsigned char
- * strings with characters above 128 correctly. It also doesn't return a
- * pointer to the NUL at the end of the string.
+ * Search for c in buf. Appropriately handles values of c in [0, 255].
+ * This function preserves backward compatibility with previous vim code.
  */
-char_u *vim_strbyte(const char_u *string, int c)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
-{
-  const char_u *p = string;
+char_u *vim_strbyte(const char_u *str, int c) {
+  /* if c == 0, then we are looking for the NUL char. The old version of this func
+   *   returned NULL in this case.
+   * if c < 0 or c > 255,  then we are looking for a byte outside the unsigned char range.
+   *   In this case, the old func returned NULL. */
+  if (c > (unsigned char) -1 || c <= 0)
+    return NULL;
 
-  while (*p != NUL) {
-    if (*p == c)
-      return (char_u *) p;
-    ++p;
-  }
-  return NULL;
+  return (char_u*) strchr((const char*) str, c);
 }
 
 /*


### PR DESCRIPTION
ref #1476

I wanted to work on an entry-level issue to get acquainted to the code. This is my first time creating a PR so hopefully this hasn't been fixed and I did everything right.

@aktau mentioned there should be tests for this change. Concept-wise, they should be unit tests, but maybe the terminology is different for this project? I'll work on the tests anyway, just wanted to confirm the change looks decent. Are there any existing tests creating weird char buffers I can look at?

I created https://gist.github.com/amaro/d5ff69fd53e7904c00ad to convince myself this would work in all cases.
