### PR TITLE
[RDY] Remove "g" flag from 'cpoptions'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1868,8 +1868,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			argument will set the file name for the current
 			buffer, if the current buffer doesn't have a file name
 			yet.  Also see |cpo-P|.
-								*cpo-g*
-		g	Goto line 1 when using ":edit" without argument.
 								*cpo-H*
 		H	When using "I" on a line with only blanks, insert
 			before the last blank.  Without this flag insert after

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6037,10 +6037,7 @@ do_exedit (
     setpcmark();
     if (do_ecmd(0, (eap->cmdidx == CMD_enew ? NULL : eap->arg),
             NULL, eap,
-            /* ":edit" goes to first line if Vi compatible */
-            (*eap->arg == NUL && eap->do_ecmd_lnum == 0
-             && vim_strchr(p_cpo, CPO_GOTO1) != NULL)
-            ? ECMD_ONE : eap->do_ecmd_lnum,
+            eap->do_ecmd_lnum,
             (P_HID(curbuf) ? ECMD_HIDE : 0)
             + (eap->forceit ? ECMD_FORCEIT : 0)
             // After a split we can use an existing buffer.

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -95,7 +95,6 @@
 #define CPO_EMPTYREGION 'E'     /* operating on empty region is an error */
 #define CPO_FNAMER      'f'     /* set file name for ":r file" */
 #define CPO_FNAMEW      'F'     /* set file name for ":w file" */
-#define CPO_GOTO1       'g'     /* goto line 1 for ":edit" */
 #define CPO_INSEND      'H'     /* "I" inserts before last blank in line */
 #define CPO_INTMOD      'i'     /* interrupt a read makes buffer modified */
 #define CPO_INDENT      'I'     /* remove auto-indent more often */
@@ -146,9 +145,9 @@
                                  * cursor would not move */
 /* default values for Vim, Vi and POSIX */
 #define CPO_VIM         "aABceFs"
-#define CPO_VI          "aAbBcCdDeEfFgHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>;"
+#define CPO_VI          "aAbBcCdDeEfFHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>;"
 #define CPO_ALL \
-  "aAbBcCdDeEfFgHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>#{|&/\\.;"
+  "aAbBcCdDeEfFHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>#{|&/\\.;"
 
 /* characters for p_ww option: */
 #define WW_ALL          "bshl<>[],~"


### PR DESCRIPTION
This removes the vi-default "g" flag from `'cpoptions'`.

```
                                         *cpo-g*
g       Goto line 1 when using ":edit" without argument.
```

The same can be achieved with `:e +1`. I think this option can be removed. This could be the first step towards reducing complexity introduced by rarely used cpoptions.

(References #228 and #2071. I'm testing the water with this pull request.)
