### PR TITLE
[RFC] Remove "w" flag from 'cpoptions'

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -249,9 +249,6 @@ Special case: When the cursor is in a word, "cw" and "cW" do not include the
 white space after a word, they only change up to the end of the word.  This is
 because Vim interprets "cw" as change-word, and a word does not include the
 following white space.
-{Vi: "cw" when on a blank followed by other blanks changes only the first
-blank; this is probably a bug, because "dw" deletes all the blanks; use the
-'w' flag in 'cpoptions' to make it work like Vi anyway}
 
 If you prefer "cw" to include the space after a word, use this mapping: >
 	:map cw dwi

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -411,9 +411,7 @@ WORD before the fold.
 
 Special case: "cw" and "cW" are treated like "ce" and "cE" if the cursor is
 on a non-blank.  This is because "cw" is interpreted as change-word, and a
-word does not include the following white space.  {Vi: "cw" when on a blank
-followed by other blanks changes only the first blank; this is probably a
-bug, because "dw" deletes all the blanks}
+word does not include the following white space.
 
 Another special case: When using the "w" motion in combination with an
 operator and the last word moved over is at the end of a line, the end of

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1981,10 +1981,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			erased from the screen right away.  With this flag the
 			screen newly typed text overwrites backspaced
 			characters.
-								*cpo-w*
-		w	When using "cw" on a blank character, only change one
-			character and not all blanks until the start of the
-			next word.
 								*cpo-W*
 		W	Don't overwrite a readonly file.  When omitted, ":w!"
 			overwrites a readonly file, if possible.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6714,35 +6714,18 @@ static void nv_wordcmd(cmdarg_T *cap)
    */
   if (!word_end && cap->oap->op_type == OP_CHANGE) {
     n = gchar_cursor();
-    if (n != NUL) {                     /* not an empty line */
-      if (ascii_iswhite(n)) {
-        /*
-         * Reproduce a funny Vi behaviour: "cw" on a blank only
-         * changes one character, not all blanks until the start of
-         * the next word.  Only do this when the 'w' flag is included
-         * in 'cpoptions'.
-         */
-        if (cap->count1 == 1 && vim_strchr(p_cpo, CPO_CW) != NULL) {
-          cap->oap->inclusive = true;
-          cap->oap->motion_type = MCHAR;
-          return;
-        }
-      } else {
-        /*
-         * This is a little strange. To match what the real Vi does,
-         * we effectively map 'cw' to 'ce', and 'cW' to 'cE', provided
-         * that we are not on a space or a TAB.  This seems impolite
-         * at first, but it's really more what we mean when we say
-         * 'cw'.
-         * Another strangeness: When standing on the end of a word
-         * "ce" will change until the end of the next word, but "cw"
-         * will change only one character! This is done by setting
-         * flag.
-         */
-        cap->oap->inclusive = true;
-        word_end = true;
-        flag = true;
-      }
+    if (n != NUL && !ascii_iswhite(n)) {
+      // This is a little strange.  To match what the real Vi does, we
+      // effectively map "cw" to "ce", and "cW" to "cE", provided that we are
+      // not on a space or a tab.  This seems impolite at first, but it's really
+      // more what we mean when we say "cw".
+      //
+      // Another strangeness: When standing on the end of a word "ce" will
+      // change until the end of the next word, but "cw" will change only one
+      // character!  This is done by setting "flag".
+      cap->oap->inclusive = true;
+      word_end = true;
+      flag = true;
     }
   }
 

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -119,7 +119,6 @@
 #define CPO_TAGPAT      't'
 #define CPO_UNDO        'u'     /* "u" undoes itself */
 #define CPO_BACKSPACE   'v'     /* "v" keep deleted text */
-#define CPO_CW          'w'     /* "cw" only changes one blank */
 #define CPO_FWRITE      'W'     /* "w!" doesn't overwrite readonly files */
 #define CPO_ESC         'x'
 #define CPO_REPLCNT     'X'     /* "R" with a count only deletes chars once */
@@ -145,9 +144,9 @@
                                  * cursor would not move */
 /* default values for Vim, Vi and POSIX */
 #define CPO_VIM         "aABceFs"
-#define CPO_VI          "aAbBcCdDeEfFHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>;"
+#define CPO_VI          "aAbBcCdDeEfFHiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%*-+<>;"
 #define CPO_ALL \
-  "aAbBcCdDeEfFHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>#{|&/\\.;"
+  "aAbBcCdDeEfFHiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%*-+<>#{|&/\\.;"
 
 /* characters for p_ww option: */
 #define WW_ALL          "bshl<>[],~"


### PR DESCRIPTION
(Couldn't resist, going to wait for feedback now.)

```
                                                                *cpo-w*
                w       When using "cw" on a blank character, only change one
                        character and not all blanks until the start of the
                        next word.
```

Seems like an ancient bug elevated to option status. Safe to remove.
