### PR TITLE
[RFC] vim-patch:7.4.537

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1455,10 +1455,10 @@ v:foldstart	Used for 'foldtext': first line of closed fold.
 		Read-only in the |sandbox|. |fold-foldtext|
 
 					*v:hlsearch* *hlsearch-variable*
-v:hlsearch	Variable that determines whether search highlighting is on. 
-		Makes sense only if 'hlsearch' is enabled which requires 
-		|+extra_search|. Setting this variable to zero acts the like 
-		|:nohlsearch| command, setting it to one acts like >
+v:hlsearch	Variable that indicates whether search highlighting is on.
+		Setting it makes sense only if 'hlsearch' is enabled. Setting
+		this variable to zero acts like the |:nohlsearch| command,
+		setting it to one acts like >
 			let &hlsearch = &hlsearch
 <
 					*v:insertmode* *insertmode-variable*

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -232,7 +232,7 @@ static int included_patches[] = {
   //540 NA
   //539,
   538,
-  //537,
+  537,
   536,
   //535,
   //534 NA

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -351,6 +351,6 @@ enum {
 #include "nvim/ex_cmds_defs.h"        /* Ex command defines */
 
 # define SET_NO_HLSEARCH(flag) no_hlsearch = (flag); set_vim_var_nr( \
-    VV_HLSEARCH, !no_hlsearch)
+    VV_HLSEARCH, !no_hlsearch && p_hls)
 
 #endif /* NVIM_VIM_H */

--- a/test/functional/legacy/101_hlsearch_spec.lua
+++ b/test/functional/legacy/101_hlsearch_spec.lua
@@ -32,6 +32,9 @@ describe('v:hlsearch', function()
     execute('AddR')
     execute('/')
     execute('AddR')
+    execute('set nohls')
+    execute('/')
+    execute('AddR')
     execute('let r1=r[0][0]')
 
     -- I guess it is not guaranteed that screenattr outputs always the same character
@@ -58,6 +61,7 @@ describe('v:hlsearch', function()
       1:highlighted
       0:not highlighted
       1:highlighted
+      0:not highlighted
       Vim(let):E706:]])
   end)
 end)


### PR DESCRIPTION
```
Problem:    Value of v:hlsearch reflects an internal variable.
Solution:   Make the value reflect whether search highlighting is actually
            displayed. (Christian Brabandt)
```

https://code.google.com/p/vim/source/detail?r=v7-4-537

Original patch:

``` diff
diff --git a/runtime/doc/eval.txt b/runtime/doc/eval.txt
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1457,10 +1457,10 @@ v:foldstart Used for 'foldtext': first l
        Read-only in the |sandbox|. |fold-foldtext|

                    *v:hlsearch* *hlsearch-variable*
-v:hlsearch Variable that determines whether search highlighting is on. 
-       Makes sense only if 'hlsearch' is enabled which requires 
-       |+extra_search|. Setting this variable to zero acts the like 
-       |:nohlsearch| command, setting it to one acts like >
+v:hlsearch Variable that indicates whether search highlighting is on. 
+       Setting it makes sense only if 'hlsearch' is enabled which
+       requires |+extra_search|. Setting this variable to zero acts
+       the like |:nohlsearch| command, setting it to one acts like >
            let &hlsearch = &hlsearch
 <
                    *v:insertmode* *insertmode-variable*
diff --git a/src/nvim/testdir/test101.in b/src/nvim/testdir/test101.in
--- a/src/nvim/testdir/test101.in
+++ b/src/nvim/testdir/test101.in
@@ -25,6 +25,9 @@ n:AddR
 :AddR
 /
 :AddR
+:set nohls
+/
+:AddR
 :let r1=r[0][0]
 :" I guess it is not guaranteed that screenattr outputs always the same character
 :call map(r, 'v:val[1].":".(v:val[0]==r1?"highlighted":"not highlighted")')
diff --git a/src/nvim/testdir/test101.ok b/src/nvim/testdir/test101.ok
--- a/src/nvim/testdir/test101.ok
+++ b/src/nvim/testdir/test101.ok
@@ -8,4 +8,5 @@ 0:not highlighted
 1:highlighted
 0:not highlighted
 1:highlighted
+0:not highlighted
 Vim(let):E706:
diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    537,
+/**/
     536,
 /**/
     535,
diff --git a/src/nvim/vim.h b/src/nvim/vim.h
--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -1998,7 +1998,7 @@ typedef int VimClipboard; /* This is req

 #ifndef FEAT_VIRTUALEDIT
 # define getvvcol(w, p, s, c, e) getvcol(w, p, s, c, e)
-# define virtual_active() 0
+# define virtual_active() FALSE
 # define virtual_op FALSE
 #endif

@@ -2277,7 +2277,7 @@ typedef int VimClipboard; /* This is req
 #define AUTOLOAD_CHAR '#'

 #ifdef FEAT_EVAL
-# define SET_NO_HLSEARCH(flag) no_hlsearch = (flag); set_vim_var_nr(VV_HLSEARCH, !no_hlsearch)
+# define SET_NO_HLSEARCH(flag) no_hlsearch = (flag); set_vim_var_nr(VV_HLSEARCH, !no_hlsearch && p_hls)
 #else
 # define SET_NO_HLSEARCH(flag) no_hlsearch = (flag)
 #endif
```
