### PR TITLE
[RFC] Recursive instance test: don't process vimrc

### DIFF
--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -118,7 +118,7 @@ describe('server -> client', function()
 
   describe('when the client is a recursive vim instance', function()
     before_each(function()
-      nvim('command', "let vim = rpcstart('"..nvim_prog.."', ['--embed'])")
+      nvim('command', "let vim = rpcstart('"..nvim_prog.."', ['-u', 'NONE', '--embed'])")
       neq(0, eval('vim'))
     end)
 


### PR DESCRIPTION
676133aa introduced a new test for calling a nvim instance recursively. But
without '-u NONE', the vimrc (and all plugins) get loaded too, which breaks
the test for things that do stuff on VimEnter.

---

In my case (shameless plug: https://github.com/mhinz/vim-startify) this would lead to such errors:

```
Failure → test/functional/api/server_requests_spec.lua @ 127
server -> client when the client is a recursive vim instance can send/recieve notifications and make requests
test/functional/api/server_requests_spec.lua:133: Expected objects to be the same.
Passed in:
(string) '   [0]  /data/repo/neovim/test/functional/api/server_requests_spec.lua'
Expected:
(string) 'SOME TEXT'

stack traceback:
        test/functional/api/server_requests_spec.lua:133: in function <test/functional/api/server_requests_spec.lua:127>


Failure → test/functional/api/server_requests_spec.lua @ 136
server -> client when the client is a recursive vim instance can communicate buffers, tabpages, and windows
test/functional/api/server_requests_spec.lua:146: Expected objects to be the same.
Passed in:
(string) ''
Expected:
(string) 'SOME TEXT'

stack traceback:
        test/functional/api/server_requests_spec.lua:146: in function <test/functional/api/server_requests_spec.lua:136>
```
