### PR TITLE
[RFC] vim-patch:7.4.553

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3067,11 +3067,11 @@ static double tv_float(typval_T *tvs, int *idxp)
  * pointer for resulting string argument if "str_m" is zero (as per ISO C99).
  *
  * The return value is the number of characters which would be generated
- * for the given input, excluding the trailing null. If this value
+ * for the given input, excluding the trailing NUL. If this value
  * is greater or equal to "str_m", not all characters from the result
  * have been stored in str, output bytes beyond the ("str_m"-1) -th character
  * are discarded. If "str_m" is greater than zero it is guaranteed
- * the resulting string will be null-terminated.
+ * the resulting string will be NUL-terminated.
  */
 
 /*

--- a/src/nvim/testdir/test39.in
+++ b/src/nvim/testdir/test39.in
@@ -88,6 +88,10 @@ bbbb
 cccc
 dddd
 
+yaaa
+¿¿¿
+bbb
+
 A23
 4567
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -216,7 +216,7 @@ static int included_patches[] = {
   //556 NA
   //555 NA
   //554,
-  //553,
+  553,
   552,
   551,
   //550,


### PR DESCRIPTION
```
Problem:    Various small issues.
Solution:   Fix those issues.
```

Only two changes applicable, typo and test. As trivial as it gets.

https://code.google.com/p/vim/source/detail?r=v7-4-553

Original patch:

``` diff
diff --git a/src/nvim/INSTALL b/src/nvim/INSTALL
--- a/src/nvim/INSTALL
+++ b/src/nvim/INSTALL
@@ -316,7 +316,7 @@ directory where you want the object file
 the `configure' script.  `configure' automatically checks for the
 source code in the directory that `configure' is in and in `..'.

-   If you have to use a `make' that does not supports the `VPATH'
+   If you have to use a `make' that does not support the `VPATH'
 variable, you have to compile the package for one architecture at a time
 in the source code directory.  After you have installed the package for
 one architecture, use `make distclean' before reconfiguring for another
diff --git a/src/nvim/Make_vms.mms b/src/nvim/Make_vms.mms
--- a/src/nvim/Make_vms.mms
+++ b/src/nvim/Make_vms.mms
@@ -2,7 +2,7 @@
 # Makefile for Vim on OpenVMS
 #
 # Maintainer:   Zoltan Arpadffy <arpadffy@polarhome.com>
-# Last change:  2014 Feb 24
+# Last change:  2014 Aug 10
 #
 # This has script been tested on VMS 6.2 to 8.2 on DEC Alpha, VAX and IA64
 # with MMS and MMK
@@ -309,7 +309,7 @@ ALL_CFLAGS_VER = /def=($(MODEL_DEF)$(DEF
 ALL_LIBS = $(LIBS) $(GUI_LIB_DIR) $(GUI_LIB) \
       $(PERL_LIB) $(PYTHON_LIB) $(TCL_LIB) $(SNIFF_LIB) $(RUBY_LIB)

-SRC =  blowfish.c buffer.c charset.c diff.c digraph.c edit.c eval.c ex_cmds.c ex_cmds2.c \
+SRC =  blowfish.c buffer.c charset.c crypt.c, crypt_zip.c diff.c digraph.c edit.c eval.c ex_cmds.c ex_cmds2.c \
    ex_docmd.c ex_eval.c ex_getln.c if_xcmdsrv.c fileio.c fold.c getchar.c \
    hardcopy.c hashtab.c main.c mark.c menu.c mbyte.c memfile.c memline.c message.c misc1.c \
    misc2.c move.c normal.c ops.c option.c popupmnu.c quickfix.c regexp.c search.c sha256.c\
@@ -318,7 +318,7 @@ SRC =   blowfish.c buffer.c charset.c diff
    $(GUI_SRC) $(PERL_SRC) $(PYTHON_SRC) $(TCL_SRC) $(SNIFF_SRC) \
    $(RUBY_SRC) $(HANGULIN_SRC) $(MZSCH_SRC)

-OBJ =  blowfish.obj buffer.obj charset.obj diff.obj digraph.obj edit.obj eval.obj \
+OBJ =  blowfish.obj buffer.obj charset.obj crypt.obj, crypt_zip.obj diff.obj digraph.obj edit.obj eval.obj \
    ex_cmds.obj ex_cmds2.obj ex_docmd.obj ex_eval.obj ex_getln.obj \
    if_xcmdsrv.obj fileio.obj fold.obj getchar.obj hardcopy.obj hashtab.obj main.obj mark.obj \
    menu.obj memfile.obj memline.obj message.obj misc1.obj misc2.obj \
diff --git a/src/nvim/ex_cmds.h b/src/nvim/ex_cmds.h
--- a/src/nvim/ex_cmds.h
+++ b/src/nvim/ex_cmds.h
@@ -63,7 +63,7 @@
 #define ADDR_WINDOWS       1
 #define ADDR_ARGUMENTS     2
 #define ADDR_LOADED_BUFFERS    3
-#define ADDR_BUFFERS   4
+#define ADDR_BUFFERS       4
 #define ADDR_TABS      5

 #ifndef DO_DECLARE_EXCMD
diff --git a/src/nvim/gui.h b/src/nvim/gui.h
--- a/src/nvim/gui.h
+++ b/src/nvim/gui.h
@@ -41,7 +41,7 @@
 # include <Events.h>
 # include <Menus.h>
 # if !(defined (TARGET_API_MAC_CARBON) && (TARGET_API_MAC_CARBON))
-#   include <Windows.h>
+#  include <Windows.h>
 # endif
 # include <Controls.h>
 /*# include <TextEdit.h>*/
diff --git a/src/nvim/message.c b/src/nvim/message.c
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -4030,11 +4030,11 @@ tv_float(tvs, idxp)
  * pointer for resulting string argument if "str_m" is zero (as per ISO C99).
  *
  * The return value is the number of characters which would be generated
- * for the given input, excluding the trailing null. If this value
+ * for the given input, excluding the trailing NUL. If this value
  * is greater or equal to "str_m", not all characters from the result
  * have been stored in str, output bytes beyond the ("str_m"-1) -th character
  * are discarded. If "str_m" is greater than zero it is guaranteed
- * the resulting string will be null-terminated.
+ * the resulting string will be NUL-terminated.
  */

 /*
diff --git a/src/nvim/os_unix.c b/src/nvim/os_unix.c
--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -1609,7 +1609,7 @@ x_IOerror_handler(dpy)
 /*
  * If the X11 connection was lost try to restore it.
  * Helps when the X11 server was stopped and restarted while Vim was inactive
- * (e.g. though tmux).
+ * (e.g. through tmux).
  */
     static void
 may_restore_clipboard()
diff --git a/src/nvim/proto/eval.pro b/src/nvim/proto/eval.pro
--- a/src/nvim/proto/eval.pro
+++ b/src/nvim/proto/eval.pro
@@ -59,8 +59,8 @@ int list_append_tv __ARGS((list_T *l, ty
 int list_append_dict __ARGS((list_T *list, dict_T *dict));
 int list_append_string __ARGS((list_T *l, char_u *str, int len));
 int list_insert_tv __ARGS((list_T *l, typval_T *tv, listitem_T *item));
+void list_insert __ARGS((list_T *l, listitem_T *ni, listitem_T *item));
 void vimlist_remove __ARGS((list_T *l, listitem_T *item, listitem_T *item2));
-void list_insert __ARGS((list_T *l, listitem_T *ni, listitem_T *item));
 int garbage_collect __ARGS((void));
 void set_ref_in_ht __ARGS((hashtab_T *ht, int copyID));
 void set_ref_in_list __ARGS((list_T *l, int copyID));
diff --git a/src/nvim/proto/misc1.pro b/src/nvim/proto/misc1.pro
--- a/src/nvim/proto/misc1.pro
+++ b/src/nvim/proto/misc1.pro
@@ -5,7 +5,7 @@ int get_indent_buf __ARGS((buf_T *buf, l
 int get_indent_str __ARGS((char_u *ptr, int ts, int list));
 int set_indent __ARGS((int size, int flags));
 int get_number_indent __ARGS((linenr_T lnum));
-int get_breakindent_win __ARGS((win_T *wp, char_u *ptr));
+int get_breakindent_win __ARGS((win_T *wp, char_u *line));
 int open_line __ARGS((int dir, int flags, int second_line_indent));
 int get_leader_len __ARGS((char_u *line, char_u **flags, int backward, int include_space));
 int get_last_leader_offset __ARGS((char_u *line, char_u **flags));
diff --git a/src/nvim/proto/ops.pro b/src/nvim/proto/ops.pro
--- a/src/nvim/proto/ops.pro
+++ b/src/nvim/proto/ops.pro
@@ -55,8 +55,8 @@ void dnd_yank_drag_data __ARGS((char_u *
 char_u get_reg_type __ARGS((int regname, long *reglen));
 char_u *get_reg_contents __ARGS((int regname, int flags));
 void write_reg_contents __ARGS((int name, char_u *str, int maxlen, int must_append));
+void write_reg_contents_lst __ARGS((int name, char_u **strings, int maxlen, int must_append, int yank_type, long block_len));
 void write_reg_contents_ex __ARGS((int name, char_u *str, int maxlen, int must_append, int yank_type, long block_len));
-void write_reg_contents_lst __ARGS((int name, char_u **strings, int maxlen, int must_append, int yank_type, long block_len));
 void clear_oparg __ARGS((oparg_T *oap));
 void cursor_pos_info __ARGS((void));
 /* vim: set ft=c : */
diff --git a/src/nvim/proto/os_vms.pro b/src/nvim/proto/os_vms.pro
--- a/src/nvim/proto/os_vms.pro
+++ b/src/nvim/proto/os_vms.pro
@@ -5,11 +5,12 @@ void mch_set_shellsize __ARGS((void));
 char_u *mch_getenv __ARGS((char_u *lognam));
 int mch_setenv __ARGS((char *var, char *value, int x));
 int vms_sys __ARGS((char *cmd, char *out, char *inp));
+char *vms_tolower __ARGS((char *name));
 int vms_sys_status __ARGS((int status));
 int vms_read __ARGS((char *inbuf, size_t nbytes));
-char *vms_tolower __ARGS((char *name));
 int mch_expand_wildcards __ARGS((int num_pat, char_u **pat, int *num_file, char_u ***file, int flags));
 int mch_expandpath __ARGS((garray_T *gap, char_u *path, int flags));
 void *vms_fixfilename __ARGS((void *instring));
 void vms_remove_version __ARGS((void *fname));
+int RealWaitForChar __ARGS((int fd, long msec, int *check_for_gpm));
 /* vim: set ft=c : */
diff --git a/src/nvim/proto/screen.pro b/src/nvim/proto/screen.pro
--- a/src/nvim/proto/screen.pro
+++ b/src/nvim/proto/screen.pro
@@ -26,7 +26,7 @@ int get_keymap_str __ARGS((win_T *wp, ch
 void screen_putchar __ARGS((int c, int row, int col, int attr));
 void screen_getbytes __ARGS((int row, int col, char_u *bytes, int *attrp));
 void screen_puts __ARGS((char_u *text, int row, int col, int attr));
-void screen_puts_len __ARGS((char_u *text, int len, int row, int col, int attr));
+void screen_puts_len __ARGS((char_u *text, int textlen, int row, int col, int attr));
 void screen_stop_highlight __ARGS((void));
 void reset_cterm_colors __ARGS((void));
 void screen_draw_rectangle __ARGS((int row, int col, int height, int width, int invert));
diff --git a/src/nvim/testdir/test39.in b/src/nvim/testdir/test39.in
--- a/src/nvim/testdir/test39.in
+++ b/src/nvim/testdir/test39.in
@@ -85,6 +85,10 @@ bbbb
 cccc
 dddd

+yaaa
+¿¿¿
+bbb
+
 A23
 4567

diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    553,
+/**/
     552,
 /**/
     551,
```
