### PR TITLE
[RFC] Travis: install g++-multilib

### DIFF
--- a/.ci/gcc-32.sh
+++ b/.ci/gcc-32.sh
@@ -1,6 +1,6 @@
 . "$CI_SCRIPTS/common.sh"
 
-sudo apt-get install gcc-multilib
+sudo apt-get install gcc-multilib g++-multilib
 
 setup_deps x86
 


### PR DESCRIPTION
I noticed this while working on PR #2340.

In PR #2431 `g++-multilib` was removed from the `gcc-32` target. The Travis build was successful, but only because the dependencies were fetched from `neovim/deps`. When actually building the dependencies `g++-multilib` is needed.
