### PR TITLE
[WIP] Documentation: Apply new bracket style

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -531,7 +531,7 @@ followed by another Vim command:
     :vglobal
     :windo
     :write !
-    :[range]!
+    :[{range}]!
     a user defined command without the "-bar" argument |:command|
 
 Note that this is confusing (inherited from Vi): With ":g" the '|' is included
@@ -600,10 +600,10 @@ argument for the command, which has a different meaning.  For example:
 			"name"
 
 ==============================================================================
-4. Ex command-line ranges	*cmdline-ranges* *[range]* *E16*
+4. Ex command-line ranges	*cmdline-ranges* *[range]* *[{range}]* *E16*
 
 Some Ex commands accept a line range in front of them.  This is noted as
-[range].  It consists of one or more line specifiers, separated with ',' or
+[{range}].  It consists of one or more line specifiers, separated with ',' or
 ';'.
 
 The basics are explained in section |10.3| of the user manual.

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -58,30 +58,30 @@ clicking right of the labels.
 In the GUI tab pages line you can use the right mouse button to open menu.
 |tabline-menu|.
 
-:[count]tabe[dit]				*:tabe* *:tabedit* *:tabnew*
-:[count]tabnew
+:[{count}]tabe[dit]				*:tabe* *:tabedit* *:tabnew*
+:[{count}]tabnew
 		Open a new tab page with an empty window, after the current
-		tab page.  For [count] see |:tab| below.
+		tab page.  For {count} see |:tab| below.
 
-:[count]tabe[dit] [++opt] [+cmd] {file}
-:[count]tabnew [++opt] [+cmd] {file}
+:[{count}]tabe[dit] [++opt] [+cmd] {file}
+:[{count}]tabnew [++opt] [+cmd] {file}
 		Open a new tab page and edit {file}, like with |:edit|.
-		For [count] see |:tab| below.
+		For {count} see |:tab| below.
 
-:[count]tabf[ind] [++opt] [+cmd] {file}			*:tabf* *:tabfind*
+:[{count}]tabf[ind] [++opt] [+cmd] {file}			*:tabf* *:tabfind*
 		Open a new tab page and edit {file} in 'path', like with
-		|:find|.  For [count] see |:tab| below.
+		|:find|.  For {count} see |:tab| below.
 		{not available when the |+file_in_path| feature was disabled
 		at compile time}
 
-:[count]tab {cmd}					*:tab*
+:[{count}]tab {cmd}					*:tab*
 		Execute {cmd} and when it opens a new window open a new tab
 		page instead.  Doesn't work for |:diffsplit|, |:diffpatch|,
 		|:execute| and |:normal|.
-		When [count] is omitted the tab page appears after the current
+		When {count} is omitted the tab page appears after the current
 		one.
-		When [count] is specified the new tab page comes after tab
-		page [count].  Use ":0tab cmd" to get the new tab page as the
+		When {count} is specified the new tab page comes after tab
+		page {count}.  Use ":0tab cmd" to get the new tab page as the
 		first one.
 		Examples: >
 			:tab split	" opens current buffer in new tab page
@@ -112,7 +112,7 @@ something else.
 		Changes to the buffer are not written and won't get lost, so
 		this is a "safe" command.
 
-:tabc[lose][!] {count}
+:tabc[lose][!] [{count}]
 		Close tab page {count}.  Fails in the same way as `:tabclose`
 		above.
 
@@ -139,9 +139,9 @@ gt					*i_CTRL-<PageDown>* *i_<C-PageDown>*
 		Go to the next tab page.  Wraps around from the last to the
 		first one.
 
-:tabn[ext] {count}
-{count}<C-PageDown>
-{count}gt	Go to tab page {count}.  The first tab page has number one.
+:tabn[ext] [{count}]
+[{count}]<C-PageDown>
+[{count}]gt	Go to tab page {count}.  The first tab page has number one.
 
 
 :tabp[revious]				*:tabp* *:tabprevious* *gT* *:tabN*
@@ -150,10 +150,10 @@ gt					*i_CTRL-<PageDown>* *i_<C-PageDown>*
 gT		Go to the previous tab page.  Wraps around from the first one
 		to the last one.
 
-:tabp[revious] {count}
-:tabN[ext] {count}
-{count}<C-PageUp>
-{count}gT	Go {count} tab pages back.  Wraps around from the first one
+:tabp[revious] [{count}]
+:tabN[ext] [{count}]
+[{count}]<C-PageUp>
+[{count}]gT	Go {count} tab pages back.  Wraps around from the first one
 		to the last one.
 
 :tabr[ewind]			*:tabfir* *:tabfirst* *:tabr* *:tabrewind*

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -385,8 +385,8 @@ position is set to keep the same Visual area selected.
 						*:winc* *:wincmd*
 These commands can also be executed with ":wincmd":
 
-:[count]winc[md] {arg}
-		Like executing CTRL-W [count] {arg}.  Example: >
+:[{count}]winc[md] {arg}
+		Like executing CTRL-W [{count}] {arg}.  Example: >
 			:wincmd j
 <		Moves to the window below the current one.
 		This command is useful when a Normal mode cannot be used (for
@@ -818,8 +818,8 @@ CTRL-W CTRL-Z					*CTRL-W_CTRL-Z* *:pc* *:pclose*
 		cannot be closed.  See also |:close|.
 
 							*:pp* *:ppop*
-:[count]pp[op][!]
-		Does ":[count]pop[!]" in the preview window.  See |:pop| and
+:[{count}]pp[op][!]
+		Does ":[{count}]pop[!]" in the preview window.  See |:pop| and
 		|:ptag|.  {not in Vi}
 
 CTRL-W }						*CTRL-W_}*
@@ -840,7 +840,7 @@ CTRL-W g }						*CTRL-W_g}*
 			:pedit +/fputc /usr/include/stdio.h
 <
 							*:ps* *:psearch*
-:[range]ps[earch][!] [count] [/]pattern[/]
+:[{range}]ps[earch][!] [{count}] [/]{pattern}[/]
 		Works like |:ijump| but shows the found match in the preview
 		window.  The preview window is opened like with |:ptag|.  The
 		current window and cursor position isn't changed.  Useful

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -64,10 +64,10 @@ syn match helpSpecial		"\s\[[-a-z^A-Z0-9_]\{2,}]"ms=s+1
 syn match helpSpecial		"<[-a-zA-Z0-9_]\+>"
 syn match helpSpecial		"<[SCM]-.>"
 syn match helpNormal		"<---*>"
-syn match helpSpecial		"\[range]"
-syn match helpSpecial		"\[line]"
-syn match helpSpecial		"\[count]"
-syn match helpSpecial		"\[offset]"
+syn match helpSpecialBad	"\[range]"
+syn match helpSpecialBad	"\[line]"
+syn match helpSpecialBad	"\[count]"
+syn match helpSpecialBad	"\[offset]"
 syn match helpSpecial		"\[cmd]"
 syn match helpSpecial		"\[num]"
 syn match helpSpecial		"\[+num]"
@@ -164,6 +164,7 @@ hi def link helpExample		Comment
 hi def link helpOption		Type
 hi def link helpNotVi		Special
 hi def link helpSpecial		Special
+hi def link helpSpecialBad      Error
 hi def link helpNote		Todo
 
 hi def link helpComment		Comment

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -59,6 +59,7 @@ syn match helpSpecial		"N  N"he=s+1
 syn match helpSpecial		"Nth"me=e-2
 syn match helpSpecial		"N-1"me=e-2
 syn match helpSpecial		"{[-a-zA-Z0-9'"*+/:%#=[\]<>.,]\+}"
+syn match helpSpecial		"\[{[-a-zA-Z0-9'"*+/:%#=[\]<>.,]\+}]"
 syn match helpSpecial		"\s\[[-a-z^A-Z0-9_]\{2,}]"ms=s+1
 syn match helpSpecial		"<[-a-zA-Z0-9_]\+>"
 syn match helpSpecial		"<[SCM]-.>"


### PR DESCRIPTION
As mentioned in passing on #2041, some items in vim's help files are not entirely unambiguous re: the usage of curly braces and square brackets.

The aim of this PR is to establish a new convention:
- Square brackets should be used for all optional items.
- Curly braces should be used for placeholders. 

Currently, there are a bunch of items which are treated specially, like `[range]`, `[count]`, etc, so curly braces are not used for those. This helps with clutter but makes things inconsistent (not a big deal imho, but it sure can be improved).
