### PR TITLE
scripts/legacy2luatest.pl: remove modeline

### DIFF
--- a/scripts/legacy2luatest.pl
+++ b/scripts/legacy2luatest.pl
@@ -83,6 +83,10 @@ sub read_in_file {
 
       # If not an empty line, emit as Lua comment.
       if (!/^$/) {
+        # Remove modeline
+        s/vim:.*set f\w+=vim//g;
+        # Remove trailing ":"
+        s/\s*:\s*$//g;
         push @description_lines, '-- ' . $_;
       }
 


### PR DESCRIPTION
Several legacy tests have "vim: set ft=vim" modelines which causes the new lua file to be opened with filetype=vim.
