### PR TITLE
[RFC] Remove "*" flag from 'cpoptions'

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -703,10 +703,7 @@ Visual Mode and Range					*v_:*
 		history for repeating a command on different Visually selected
 		lines.
 		When Visual mode was already ended, a short way to use the
-		Visual area for a range is `:*`.  This requires that "*" does
-		not appear in 'cpo', see |cpo-star|.  Otherwise you will have
-		to type `:'<,'>`
-
+		Visual area for a range is `:*`.
 
 ==============================================================================
 5. Ex command-line flags				*ex-flags*

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1064,7 +1064,6 @@ tag	      command	      action ~
 |:!!|		:!!		repeat last ":!" command
 |:#|		:#		same as ":number"
 |:&|		:&		repeat last ":substitute"
-|:star|		:*		execute contents of a register
 |:<|		:<		shift lines one 'shiftwidth' left
 |:=|		:=		print the cursor line number
 |:>|		:>		shift lines one 'shiftwidth' right

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1936,9 +1936,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 		+	When included, a ":write file" command will reset the
 			'modified' flag of the buffer, even though the buffer
 			itself may still be different from its file.
-								*cpo-star*
-		*	Use ":*" in the same way as ":@".  When not included,
-			":*" is an alias for ":'<,'>", select the Visual area.
 								*cpo-<*
 		<	Disable the recognition of special key codes in |<>|
 			form in mappings, abbreviations, and the "to" part of

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -128,14 +128,12 @@ q			Stops recording.
 							*@@* *E748*
 @@			Repeat the previous @{0-9a-z":*} [count] times.
 
-:[addr]*{0-9a-z".=+}						*:@* *:star*
+							*:@*
 :[addr]@{0-9a-z".=*+}	Execute the contents of register {0-9a-z".=*+} as an Ex
 			command.  First set cursor at line [addr] (default is
 			current line).  When the last line in the register does
 			not have a <CR> it will be added automatically when
 			the 'e' flag is present in 'cpoptions'.
-			Note that the ":*" command is only recognized when the
-			'*' flag is present in 'cpoptions'.
 			For ":@=" the last used expression is used.  The
 			result of evaluating the expression is executed as an
 			Ex command.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4833,18 +4833,18 @@ int find_help_tags(char_u *arg, int *num_matches, char_u ***matches, int keep_la
 {
   char_u      *s, *d;
   int i;
-  static char *(mtable[]) = {"*", "g*", "[*", "]*", ":*",
+  static char *(mtable[]) = {"*", "g*", "[*", "]*",
                              "/*", "/\\*", "\"*", "**",
-                             "cpo-*", "/\\(\\)", "/\\%(\\)",
+                             "/\\(\\)", "/\\%(\\)",
                              "?", ":?", "?<CR>", "g?", "g?g?", "g??", "z?",
                              "/\\?", "/\\z(\\)", "\\=", ":s\\=",
                              "[count]", "[quotex]", "[range]",
                              "[pattern]", "\\|", "\\%$",
                              "s/\\~", "s/\\U", "s/\\L",
                              "s/\\1", "s/\\2", "s/\\3", "s/\\9"};
-  static char *(rtable[]) = {"star", "gstar", "[star", "]star", ":star",
+  static char *(rtable[]) = {"star", "gstar", "[star", "]star",
                              "/star", "/\\\\star", "quotestar", "starstar",
-                             "cpo-star", "/\\\\(\\\\)", "/\\\\%(\\\\)",
+                             "/\\\\(\\\\)", "/\\\\%(\\\\)",
                              "?", ":?", "?<CR>", "g?", "g?g?", "g??", "z?",
                              "/\\\\?", "/\\\\z(\\\\)", "\\\\=", ":s\\\\=",
                              "\\[count]", "\\[quotex]", "\\[range]",

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -3137,13 +3137,6 @@ return {
     func='do_sub',
   },
   {
-    command='*',
-    enum='CMD_star',
-    flags=bit.bor(RANGE, WHOLEFOLD, EXTRA, TRLBAR, CMDWIN),
-    addr_type=ADDR_LINES,
-    func='ex_at',
-  },
-  {
     command='<',
     enum='CMD_lshift',
     flags=bit.bor(RANGE, WHOLEFOLD, COUNT, EXFLAGS, TRLBAR, CMDWIN, MODIFY),

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -126,7 +126,6 @@
 #define CPO_DOLLAR      '$'
 #define CPO_FILTER      '!'
 #define CPO_MATCH       '%'
-#define CPO_STAR        '*'     /* ":*" means ":@" */
 #define CPO_PLUS        '+'     /* ":write file" resets 'modified' */
 #define CPO_MINUS       '-'     /* "9-" fails at and before line 9 */
 #define CPO_SPECI       '<'     /* don't recognize <> in mappings */
@@ -143,9 +142,9 @@
                                  * cursor would not move */
 /* default values for Vim, Vi and POSIX */
 #define CPO_VIM         "aABceFs"
-#define CPO_VI          "aAbBcCdDeEfFiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%*-+<>;"
+#define CPO_VI          "aAbBcCdDeEfFiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%-+<>;"
 #define CPO_ALL \
-  "aAbBcCdDeEfFiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%*-+<>#{|&/\\.;"
+  "aAbBcCdDeEfFiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%-+<>#{|&/\\.;"
 
 /* characters for p_ww option: */
 #define WW_ALL          "bshl<>[],~"


### PR DESCRIPTION
From the commit message:

> The "`*`" flag in `'cpoptions'` makes the command `:*` execute the contents of a register. Removed because
> 1.  the same functionality exists as `:@`
> 2.  it hides `:*` as a useful command-line shortcut for `:'<,'>`
> 3.  unlike `:@` it cannot be used with the `*` register

I think this cpoption can be removed. Reviewers take care, this removes the ex command `:*`, I hope I caught everything that's related.
