### PR TITLE
[RFC] Remove "H" flag from 'cpoptions'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1832,10 +1832,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			argument will set the file name for the current
 			buffer, if the current buffer doesn't have a file name
 			yet.  Also see |cpo-P|.
-								*cpo-H*
-		H	When using "I" on a line with only blanks, insert
-			before the last blank.  Without this flag insert after
-			the last blank.
 								*cpo-i*
 		i	When included, interrupting the reading of a file will
 			leave it modified.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7010,10 +7010,7 @@ static void nv_edit(cmdarg_T *cap)
       break;
 
     case 'I':           /* "I"nsert before the first non-blank */
-      if (vim_strchr(p_cpo, CPO_INSEND) == NULL)
-        beginline(BL_WHITE);
-      else
-        beginline(BL_WHITE|BL_FIX);
+      beginline(BL_WHITE);
       break;
 
     case 'a':           /* "a"ppend is like "i"nsert on the next character. */

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -95,7 +95,6 @@
 #define CPO_EMPTYREGION 'E'     /* operating on empty region is an error */
 #define CPO_FNAMER      'f'     /* set file name for ":r file" */
 #define CPO_FNAMEW      'F'     /* set file name for ":w file" */
-#define CPO_INSEND      'H'     /* "I" inserts before last blank in line */
 #define CPO_INTMOD      'i'     /* interrupt a read makes buffer modified */
 #define CPO_INDENT      'I'     /* remove auto-indent more often */
 #define CPO_JOINSP      'j'     /* only use two spaces for join after '.' */
@@ -144,9 +143,9 @@
                                  * cursor would not move */
 /* default values for Vim, Vi and POSIX */
 #define CPO_VIM         "aABceFs"
-#define CPO_VI          "aAbBcCdDeEfFHiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%*-+<>;"
+#define CPO_VI          "aAbBcCdDeEfFiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%*-+<>;"
 #define CPO_ALL \
-  "aAbBcCdDeEfFHiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%*-+<>#{|&/\\.;"
+  "aAbBcCdDeEfFiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%*-+<>#{|&/\\.;"
 
 /* characters for p_ww option: */
 #define WW_ALL          "bshl<>[],~"


### PR DESCRIPTION
```
                                                            *cpo-H*
            H       When using "I" on a line with only blanks, insert
                    before the last blank.  Without this flag insert after
                    the last blank.
```

Ah, this one takes the cake. Completely useless.
