### PR TITLE
[RFC] vim-patch:7.4.524

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4058,17 +4058,16 @@ did_set_string_option (
   else if (varp == &p_cb) {
     if (opt_strings_flags(p_cb, p_cb_values, &cb_flags, TRUE) != OK)
       errmsg = e_invarg;
-  }
-  /* When 'spelllang' or 'spellfile' is set and there is a window for this
-   * buffer in which 'spell' is set load the wordlists. */
-  else if (varp == &(curbuf->b_s.b_p_spl) || varp == &(curbuf->b_s.b_p_spf)) {
-    int l;
-
-    if (varp == &(curbuf->b_s.b_p_spf)) {
-      l = (int)STRLEN(curbuf->b_s.b_p_spf);
-      if (l > 0 && (l < 4 || STRCMP(curbuf->b_s.b_p_spf + l - 4,
-                        ".add") != 0))
+  } else if (varp == &(curwin->w_s->b_p_spl)
+             || varp == &(curwin->w_s->b_p_spf)) {
+    // When 'spelllang' or 'spellfile' is set and there is a window for this
+    // buffer in which 'spell' is set load the wordlists.
+    if (varp == &(curwin->w_s->b_p_spf)) {
+      int l = (int)STRLEN(curwin->w_s->b_p_spf);
+      if (l > 0
+          && (l < 4 || STRCMP(curwin->w_s->b_p_spf + l - 4, ".add") != 0)) {
         errmsg = e_invarg;
+      }
     }
 
     if (errmsg == NULL) {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5404,11 +5404,10 @@ void ex_ownsyntax(exarg_T *eap)
   if (curwin->w_s == &curwin->w_buffer->b_s) {
     curwin->w_s = xmalloc(sizeof(synblock_T));
     memset(curwin->w_s, 0, sizeof(synblock_T));
+    // TODO: Keep the spell checking as it was.
     curwin->w_p_spell = FALSE;          /* No spell checking */
     clear_string_option(&curwin->w_s->b_p_spc);
     clear_string_option(&curwin->w_s->b_p_spf);
-    vim_regfree(curwin->w_s->b_cap_prog);
-    curwin->w_s->b_cap_prog = NULL;
     clear_string_option(&curwin->w_s->b_p_spl);
   }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -259,7 +259,7 @@ static int included_patches[] = {
   527,
   //526,
   525,
-  //524,
+  524,
   //523 NA
   //522 NA
   521,


### PR DESCRIPTION
```
Problem:    When using ":ownsyntax" spell checking is messed up. (Issue 78)
Solution:   Use the window-local option values. (Christian Brabandt)
```

https://github.com/vim/vim/commit/v7-4-524

Original patch:

``` diff
diff --git a/src/nvim/option.c b/src/nvim/option.c
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6706,15 +6706,16 @@ did_set_string_option(opt_idx, varp, new
 #ifdef FEAT_SPELL
     /* When 'spelllang' or 'spellfile' is set and there is a window for this
      * buffer in which 'spell' is set load the wordlists. */
-    else if (varp == &(curbuf->b_s.b_p_spl) || varp == &(curbuf->b_s.b_p_spf))
+    else if (varp == &(curwin->w_s->b_p_spl)
+       || varp == &(curwin->w_s->b_p_spf))
     {
    win_T       *wp;
    int     l;

-   if (varp == &(curbuf->b_s.b_p_spf))
-   {
-       l = (int)STRLEN(curbuf->b_s.b_p_spf);
-       if (l > 0 && (l < 4 || STRCMP(curbuf->b_s.b_p_spf + l - 4,
+   if (varp == &(curwin->w_s->b_p_spf))
+   {
+       l = (int)STRLEN(curwin->w_s->b_p_spf);
+       if (l > 0 && (l < 4 || STRCMP(curwin->w_s->b_p_spf + l - 4,
                                ".add") != 0))
        errmsg = e_invarg;
    }
diff --git a/src/nvim/syntax.c b/src/nvim/syntax.c
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6304,11 +6304,10 @@ ex_ownsyntax(eap)
    curwin->w_s = (synblock_T *)alloc(sizeof(synblock_T));
    memset(curwin->w_s, 0, sizeof(synblock_T));
 #ifdef FEAT_SPELL
+   /* TODO: keep the spell checking as it was. */
    curwin->w_p_spell = FALSE;  /* No spell checking */
    clear_string_option(&curwin->w_s->b_p_spc);
    clear_string_option(&curwin->w_s->b_p_spf);
-   vim_regfree(curwin->w_s->b_cap_prog);
-   curwin->w_s->b_cap_prog = NULL;
    clear_string_option(&curwin->w_s->b_p_spl);
 #endif
     }
diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    524,
+/**/
     523,
 /**/
     522,
```
