### PR TITLE
[RDY] Add v:completed_item feature

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -506,6 +506,8 @@ ColorScheme			After loading a color scheme. |:colorscheme|
 CompleteDone			After Insert mode completion is done.  Either
 				when something was completed or abandoning
 				completion. |ins-completion|
+				The |v:completed_item| variable contains the
+				completed item.
 
 							*CursorHold*
 CursorHold			When the user doesn't press a key for the time

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1326,6 +1326,11 @@ v:cmdbang	Set like v:cmdarg for a file read/write command.  When a "!"
 		can only be used in autocommands.  For user commands |<bang>|
 		can be used.
 
+				*v:completed_item* *completed_item-variable*
+v:completed_item
+		Dictionary containing the most recent |complete-items| after
+		|CompleteDone|.  Empty if the completion failed.
+
 					*v:count* *count-variable*
 v:count		The count given for the last Normal mode command.  Can be used
 		to get the count before a mapping.  Read-only.	Example: >

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2734,6 +2734,8 @@ static void ins_compl_clear(void)
   xfree(compl_orig_text);
   compl_orig_text = NULL;
   compl_enter_selects = FALSE;
+  // clear v:completed_item
+  set_vim_var_dict(VV_COMPLETED_ITEM, dict_alloc());
 }
 
 /*
@@ -3815,6 +3817,8 @@ static void ins_compl_delete(void)
   // TODO: is this sufficient for redrawing?  Redrawing everything causes
   // flicker, thus we can't do that.
   changed_cline_bef_curs();
+  // clear v:completed_item
+  set_vim_var_dict(VV_COMPLETED_ITEM, dict_alloc());
 }
 
 /* Insert the new text being completed. */
@@ -3825,6 +3829,21 @@ static void ins_compl_insert(void)
     compl_used_match = FALSE;
   else
     compl_used_match = TRUE;
+
+  // Set completed item.
+  // { word, abbr, menu, kind, info }
+  dict_T *dict = dict_alloc();
+  dict_add_nr_str(dict, "word", 0L,
+                  EMPTY_IF_NULL(compl_shown_match->cp_str));
+  dict_add_nr_str(dict, "abbr", 0L,
+                  EMPTY_IF_NULL(compl_shown_match->cp_text[CPT_ABBR]));
+  dict_add_nr_str(dict, "menu", 0L,
+                  EMPTY_IF_NULL(compl_shown_match->cp_text[CPT_MENU]));
+  dict_add_nr_str(dict, "kind", 0L,
+                  EMPTY_IF_NULL(compl_shown_match->cp_text[CPT_KIND]));
+  dict_add_nr_str(dict, "info", 0L,
+                  EMPTY_IF_NULL(compl_shown_match->cp_text[CPT_INFO]));
+  set_vim_var_dict(VV_COMPLETED_ITEM, dict);
 }
 
 /*

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -64,6 +64,7 @@ enum {
     VV_WINDOWID,
     VV_PROGPATH,
     VV_COMMAND_OUTPUT,
+    VV_COMPLETED_ITEM,
     VV_LEN, /* number of v: vars */
 };
 

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -63,6 +63,9 @@
 # define ASCII_ISALPHA(c) (ASCII_ISUPPER(c) || ASCII_ISLOWER(c))
 # define ASCII_ISALNUM(c) (ASCII_ISALPHA(c) || ascii_isdigit(c))
 
+/* Returns empty string if it is NULL. */
+#define EMPTY_IF_NULL(x) ((x) ? (x) : (char_u *)"")
+
 /* macro version of chartab().
  * Only works with values 0-255!
  * Doesn't work for UTF-8 mode with chars >= 0x80. */

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -1,0 +1,56 @@
+local helpers = require('test.functional.helpers')
+local clear, feed, execute = helpers.clear, helpers.feed, helpers.execute
+local eval, eq, neq = helpers.eval, helpers.eq, helpers.neq
+local execute, source = helpers.execute, helpers.source
+
+describe("completion", function()
+  before_each(function()
+    clear()
+  end)
+
+  describe("v:completed_item", function()
+    it('returns expected dict in normal completion', function()
+      feed('ifoo<ESC>o<C-x><C-n><ESC>')
+      eq('foo', eval('getline(2)'))
+      eq({word = 'foo', abbr = '', menu = '', info = '', kind = ''},
+        eval('v:completed_item'))
+    end)
+    it('is readonly', function()
+      feed('ifoo<ESC>o<C-x><C-n><ESC>')
+
+      execute('let v:completed_item.word = "bar"')
+      neq(nil, string.find(eval('v:errmsg'), '^E46: '))
+      execute('let v:errmsg = ""')
+
+      execute('let v:completed_item.abbr = "bar"')
+      neq(nil, string.find(eval('v:errmsg'), '^E46: '))
+      execute('let v:errmsg = ""')
+
+      execute('let v:completed_item.menu = "bar"')
+      neq(nil, string.find(eval('v:errmsg'), '^E46: '))
+      execute('let v:errmsg = ""')
+
+      execute('let v:completed_item.info = "bar"')
+      neq(nil, string.find(eval('v:errmsg'), '^E46: '))
+      execute('let v:errmsg = ""')
+
+      execute('let v:completed_item.kind = "bar"')
+      neq(nil, string.find(eval('v:errmsg'), '^E46: '))
+      execute('let v:errmsg = ""')
+    end)
+    it('returns expected dict in omni completion', function()
+      source([[
+      function! TestOmni(findstart, base) abort
+        return a:findstart ? 0 : [{'word': 'foo', 'abbr': 'bar',
+        \ 'menu': 'baz', 'info': 'foobar', 'kind': 'foobaz'}]
+      endfunction
+      setlocal omnifunc=TestOmni
+      ]])
+      feed('i<C-x><C-o><ESC>')
+      eq('foo', eval('getline(1)'))
+      eq({word = 'foo', abbr = 'bar', menu = 'baz',
+          info = 'foobar', kind = 'foobaz'},
+        eval('v:completed_item'))
+    end)
+  end)
+end)


### PR DESCRIPTION
It is backport from https://groups.google.com/forum/#!searchin/vim_dev/v$3Acompleted_item/vim_dev/fhGAStSCAMg/q5BIr2EcH4YJ.
It is already in todo.txt.  But it is not merged into Vim.

This feature is useful for several completion plugins like deoplete, YouCompleteMe, ...
