### PR TITLE
[RFC] reltime: Don't overflow the low bits! (#2567)

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4915,9 +4915,11 @@ readfile({fname} [, {binary} [, {max}]])
 		Also see |writefile()|.
 
 reltime([{start} [, {end}]])				*reltime()*
-		Return an item that represents a time value.  The format of
-		the item depends on the system.  It can be passed to
-		|reltimestr()| to convert it to a string.
+		Return a |List| that represents a time value that can be
+		passed to |reltimestr()| to convert it to a |String|.  In vim,
+		the result will be OS-dependent.
+		The first item represents larger increment of time and the
+		second represents a very small increment.
 		Without an argument it returns the current time.
 		With one argument is returns the time passed since the time
 		specified in the argument.
@@ -4925,7 +4927,6 @@ reltime([{start} [, {end}]])				*reltime()*
 		and {end}.
 		The {start} and {end} arguments must be values returned by
 		reltime().
-		{only available when compiled with the |+reltime| feature}
 
 reltimestr({time})				*reltimestr()*
 		Return a String that represents the time value of {time}.
@@ -4940,7 +4941,6 @@ reltimestr({time})				*reltimestr()*
 		can use split() to remove it. >
 			echo split(reltimestr(reltime(start)))[0]
 <		Also see |profiling|.
-		{only available when compiled with the |+reltime| feature}
 
 							*remote_expr()* *E449*
 remote_expr({server}, {string} [, {idvar}])

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12185,7 +12185,6 @@ static void f_readfile(typval_T *argvars, typval_T *rettv)
   fclose(fd);
 }
 
-
 /// list2proftime - convert a List to proftime_T
 ///
 /// @param arg The input list, must be of type VAR_LIST and have
@@ -12201,18 +12200,23 @@ static int list2proftime(typval_T *arg, proftime_T *tm) FUNC_ATTR_NONNULL_ALL
   }
 
   int error = false;
-  varnumber_T n1 = list_find_nr(arg->vval.v_list, 0L, &error);
-  varnumber_T n2 = list_find_nr(arg->vval.v_list, 1L, &error);
+  uint32_t high = list_find_nr(arg->vval.v_list, 0L, &error);
+  uint32_t low = list_find_nr(arg->vval.v_list, 1L, &error);
   if (error) {
     return FAIL;
   }
 
+  // When we converted the proftime_T to two 32-bit ints, we shifted the high
+  // part by one and made the sign bit of the low part 0. Undo these changes.
+  low |= (high & 1) << 31;
+  high = high >> 1;
+
   // in f_reltime() we split up the 64-bit proftime_T into two 32-bit
   // values, now we combine them again.
   union {
-    struct { varnumber_T low, high; } split;
+    struct { uint32_t low, high; } split;
     proftime_T prof;
-  } u = { .split.high = n1, .split.low = n2 };
+  } u = { .split.high = high, .split.low = low };
 
   *tm = u.prof;
 
@@ -12251,7 +12255,7 @@ static void f_reltime(typval_T *argvars, typval_T *rettv) FUNC_ATTR_NONNULL_ALL
   // (varnumber_T is defined as int). For all our supported platforms, int's
   // are at least 32-bits wide. So we'll use two 32-bit values to store it.
   union {
-    struct { varnumber_T low, high; } split;
+    struct { uint32_t low, high; } split;
     proftime_T prof;
   } u = { .prof = res };
 
@@ -12261,9 +12265,14 @@ static void f_reltime(typval_T *argvars, typval_T *rettv) FUNC_ATTR_NONNULL_ALL
   STATIC_ASSERT(sizeof(u.prof) == sizeof(u) && sizeof(u.split) == sizeof(u),
       "type punning will produce incorrect results on this platform");
 
+  // The low part must be greater than zero, so the high part must have room
+  // for the carry bit.
+  u.split.high = (u.split.high << 1) + (u.split.low > INT32_MAX);
+  u.split.low &= INT32_MAX;  // Truncate the low bits.
+
   rettv_list_alloc(rettv);
-  list_append_number(rettv->vval.v_list, u.split.high);
-  list_append_number(rettv->vval.v_list, u.split.low);
+  list_append_number(rettv->vval.v_list, (varnumber_T)u.split.high);
+  list_append_number(rettv->vval.v_list, (varnumber_T)u.split.low);
 }
 
 /// f_reltimestr - return a string that represents the value of {time}


### PR DESCRIPTION
`reltime()` returns a 64-bit number as two 32-bit components, but as noted in #2567, the low bits can sometimes be negative. A clock function with non-increasing results isn't very useful is it?

This offsets the high bits by one, carries the one from the low bits, and truncates them to positive values.
