### PR TITLE
terminal: Always create new buffer for terminals.

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9419,10 +9419,16 @@ static void ex_terminal(exarg_T *eap)
     lquote = rquote = "\"";
   }
 
+  if (eap->forceit) {
+    // Prevent a "buffer modified" error by creating a new buffer. termopen()
+    // will also create a new buffer, but simply wiping or deleting this one
+    // may cause the loading of an additional buffer.
+    do_ecmd(0, NULL, NULL, NULL, 0, ECMD_FORCEIT, curwin);
+  }
+
   char ex_cmd[512];
   snprintf(ex_cmd, sizeof(ex_cmd),
-           ":enew%s | call termopen(%s%s%s) | startinsert",
-           eap->forceit==TRUE ? "!" : "", lquote, name, rquote);
+           ":call termopen(%s%s%s) | startinsert", lquote, name, rquote);
   do_cmdline_cmd((uint8_t *)ex_cmd);
 
   if (name != (char *)p_sh) {

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -56,7 +56,7 @@ local function screen_setup(extra_height)
   -- tty-test puts the terminal into raw mode and echoes all input. tests are
   -- done by feeding it with terminfo codes to control the display and
   -- verifying output with screen:expect.
-  execute('enew | call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
+  execute('call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
   -- wait for "tty ready" to be printed before each test or the terminal may
   -- still be in canonical mode(will echo characters for example)
   --

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -27,7 +27,7 @@ describe('terminal window highlighting', function()
       [8] = {background = 11}
     })
     screen:attach(false)
-    execute('enew | call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
+    execute('call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
     screen:expect([[
       tty ready                                         |
                                                         |
@@ -133,7 +133,7 @@ describe('terminal window highlighting with custom palette', function()
     })
     screen:attach(true)
     nvim('set_var', 'terminal_color_3', '#123456')
-    execute('enew | call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
+    execute('call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
     screen:expect([[
       tty ready                                         |
                                                         |


### PR DESCRIPTION
From the commit message:

> Hijacking a buffer for the terminal can cause the invalidation of static
> variables in syntax.c causing #2408. This may erase a buffer that should
> be hidden as discussed in #2368. Creating a new buffer unconditionally
> and using legacy code for managing whether to hide or delete a buffer
> ensures vim's internal state remains consistent.

Unfortunately, I'm not sure how to handle a few things, but it basically works. Please see the `FIXME` and `TODO` in the diff.
