### PR TITLE
[RFC] Fix wrong support of USR_VIMRC_FILE4.

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1816,10 +1816,6 @@ static void source_startup_scripts(mparm_T *parmp)
           && do_source((char_u *)USR_VIMRC_FILE3, TRUE,
             DOSO_VIMRC) == FAIL
 #endif
-#ifdef USR_VIMRC_FILE4
-          && do_source((char_u *)USR_VIMRC_FILE4, TRUE,
-            DOSO_VIMRC) == FAIL
-#endif
           && process_env((char_u *)"EXINIT", FALSE) == FAIL
           && do_source((char_u *)USR_EXRC_FILE, FALSE, DOSO_NONE) == FAIL) {
 #ifdef USR_EXRC_FILE2


### PR DESCRIPTION
It was sourced, but it was not treated as USR_VIMRC[23]?.

Previously #2560
