### PR TITLE
[RFC] runtime: remove 'has("python")' checks from syntax/vim.vim

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -607,7 +607,7 @@ if !filereadable(s:pythonpath)
   endif
  endfor
 endif
-if g:vimsyn_embed =~ 'P' && (has("python") || has("python3")) && filereadable(s:pythonpath)
+if g:vimsyn_embed =~ 'P' && filereadable(s:pythonpath)
  unlet! b:current_syntax
  exe "syn include @vimPythonScript ".s:pythonpath
  if exists("g:vimsyn_folding") && g:vimsyn_folding =~ 'P'


### PR DESCRIPTION
This check does not appear to be required, but only causes the Python
provider to start.

I've sent this patch to the file's maintainer (Charles E. Campbell), but
have not received a reply yet.
