### PR TITLE
Intercept requests/notifications via vimL

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5125,6 +5125,13 @@ rpcunsubscribe({channel}, {event})		    {Nvim} *rpcsubscribe()*
 		Unsubscribes a |msgpack-rpc| {channel} to {event} (|String|)
 		notifications.
 
+rpcunsubscribe([{expr}])			{Nvim} *rpcsubscriptions()*
+		With no arguments, returns the events that all channels
+		subscribe to. If {expr} is a |Number|, a list of events that
+		{expr} subscribes to will be returns. If {expr} is a |List|, a
+		dictionary with lists for each channel in {expr} will be
+		returned.
+
 screenattr(row, col)						*screenattr()*
 		Like screenchar(), but return the attribute.  This is a rather
 		arbitrary number that can only be used to compare to the

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5117,6 +5117,14 @@ rpcstop({channel})					    {Nvim} *rpcstop()*
 		|rpcstart()|. Also closes channels created by connections to
 		|$NVIM_LISTEN_ADDRESS|.
 
+rpcsubscribe({channel}, {event})		    {Nvim} *rpcsubscribe()*
+		Subscribes a |msgpack-rpc| {channel} to receive {event}
+		(|String|) notifications.
+
+rpcunsubscribe({channel}, {event})		    {Nvim} *rpcsubscribe()*
+		Unsubscribes a |msgpack-rpc| {channel} to {event} (|String|)
+		notifications.
+
 screenattr(row, col)						*screenattr()*
 		Like screenchar(), but return the attribute.  This is a rather
 		arbitrary number that can only be used to compare to the

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -523,7 +523,9 @@ void vim_subscribe(uint64_t channel_id, String event)
   char e[METHOD_MAXLEN + 1];
   memcpy(e, event.data, length);
   e[length] = NUL;
-  channel_subscribe(channel_id, e);
+  if (!channel_subscribe(channel_id, e)) {
+    abort();
+  }
 }
 
 /// Unsubscribes to event broadcasts
@@ -538,7 +540,9 @@ void vim_unsubscribe(uint64_t channel_id, String event)
   char e[METHOD_MAXLEN + 1];
   memcpy(e, event.data, length);
   e[length] = NUL;
-  channel_unsubscribe(channel_id, e);
+  if (!channel_unsubscribe(channel_id, e)) {
+    abort();
+  }
 }
 
 Integer vim_name_to_color(String name)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6589,6 +6589,7 @@ static struct fst {
   {"resolve",         1, 1, f_resolve},
   {"reverse",         1, 1, f_reverse},
   {"round",           1, 1, f_round},
+  {"rpcchannels",     0, 0, f_rpcchannels},
   {"rpcnotify",       2, 64, f_rpcnotify},
   {"rpcrequest",      2, 64, f_rpcrequest},
   {"rpcstart",        1, 2, f_rpcstart},
@@ -12768,6 +12769,13 @@ static void f_round(typval_T *argvars, typval_T *rettv)
     rettv->vval.v_float = round(f);
   else
     rettv->vval.v_float = 0.0;
+}
+
+// "rpcchannels()" function
+static void f_rpcchannels(typval_T *argvars, typval_T *rettv)
+{
+  rettv->v_type = VAR_LIST;
+  rettv->vval.v_list = channel_list();
 }
 
 // "rpcnotify()" function

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6593,6 +6593,8 @@ static struct fst {
   {"rpcrequest",      2, 64, f_rpcrequest},
   {"rpcstart",        1, 2, f_rpcstart},
   {"rpcstop",         1, 1, f_rpcstop},
+  {"rpcsubscribe",    2, 2, f_rpcsubscribe},
+  {"rpcunsubscribe",    2, 2, f_rpcunsubscribe},
   {"screenattr",      2, 2, f_screenattr},
   {"screenchar",      2, 2, f_screenchar},
   {"screencol",       0, 0, f_screencol},
@@ -12969,6 +12971,59 @@ static void f_rpcstop(typval_T *argvars, typval_T *rettv)
   }
 
   rettv->vval.v_number = channel_close(argvars[0].vval.v_number);
+}
+
+// "rpcsubscribe()" function
+static void f_rpcsubscribe(typval_T *argvars, typval_T *rettv)
+{
+  rettv->v_type = VAR_NUMBER;
+  rettv->vval.v_number = 0;
+
+  if (check_restricted() || check_secure()) {
+    return;
+  }
+
+  if (argvars[0].v_type != VAR_NUMBER || argvars[0].vval.v_number <= 0) {
+    EMSG2(_(e_invarg2), "channel must be a positive integer");
+    return;
+  }
+
+  const char *method = (char *)get_tv_string_chk(&argvars[1]);
+  if (!method) {
+    return;  // did emsg in get_tv_string_chk
+  }
+
+  rettv->vval.v_number = channel_subscribe(argvars[0].vval.v_number, method);
+  if (!rettv->vval.v_number) {
+    EMSG2(_(e_invarg2), "Channel doesn't exist");
+  }
+}
+
+// "rpcunsubscribe()" function
+static void f_rpcunsubscribe(typval_T *argvars, typval_T *rettv)
+{
+  rettv->v_type = VAR_NUMBER;
+  rettv->vval.v_number = 0;
+
+  if (check_restricted() || check_secure()) {
+    return;
+  }
+
+  if (argvars[0].v_type != VAR_NUMBER || argvars[0].vval.v_number <= 0) {
+    // Wrong argument types
+    EMSG2(_(e_invarg2), "channel must be a number greater than zero");
+    return;
+  }
+
+  const char *method = (char *)get_tv_string_chk(&argvars[1]);
+  if (!method) {
+    return;  // did emsg in get_tv_string_chk
+  }
+
+  rettv->vval.v_number = channel_unsubscribe(argvars[0].vval.v_number, method);
+  if (!rettv->vval.v_number) {
+    EMSG2(_(e_invarg2), "Channel doesn't exist");
+  }
 }
 
 /*

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <msgpack.h>
 
 #define DEBUG_LOG_LEVEL 0
 #define INFO_LOG_LEVEL 1

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -27,7 +27,7 @@
 // MIN_LOG_LEVEL can be defined during compilation to adjust the desired level
 // of logging. INFO_LOG_LEVEL is used by default.
 #ifndef MIN_LOG_LEVEL
-#  define MIN_LOG_LEVEL INFO_LOG_LEVEL
+#  define MIN_LOG_LEVEL DEBUG_LOG_LEVEL
 #endif
 
 #ifndef DISABLE_LOG

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -45,6 +45,7 @@
 #include "nvim/os/os.h"
 #include "nvim/os/input.h"
 #include "nvim/os/time.h"
+#include "nvim/api/private/helpers.h"
 
 /*
  * To be able to scroll back at the "more" and "hit-enter" prompts we need to
@@ -488,6 +489,17 @@ int emsg(char_u *s)
   /* Skip this if not giving error messages at the moment. */
   if (emsg_not_now())
     return TRUE;
+
+  {
+    // Inform subscribed clients about the emsg.
+    Array args = ARRAY_DICT_INIT;
+    Object message = {
+      .type = kObjectTypeString,
+      .data.string = cstr_to_string((char *)s)
+    };
+    ADD(args, message);
+    channel_send_event(0, "emsg", args);
+  }
 
   called_emsg = TRUE;
   ex_exitval = 1;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -32,6 +32,7 @@
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
 #include "nvim/misc2.h"
+#include "nvim/msgpack_rpc/channel.h"
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/ops.h"
@@ -806,6 +807,8 @@ void wait_return(int redraw)
       cmdline_row = msg_row;
     return;
   }
+
+  channel_send_event(0, "PressEnter", (Array)ARRAY_DICT_INIT);
 
   redir_off = TRUE;             /* don't redirect this message */
   oldState = State;
@@ -2325,6 +2328,8 @@ static void msg_screen_putchar(int c, int attr)
 
 void msg_moremsg(int full)
 {
+  channel_send_event(0, "More", (Array)ARRAY_DICT_INIT);
+
   int attr;
   char_u      *s = (char_u *)_("-- More --");
 

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -105,6 +105,16 @@ void channel_teardown(void)
   });
 }
 
+list_T *channel_list(void)
+{
+  list_T *chans = list_alloc();
+  Channel *channel;
+  map_foreach_value(channels, channel, {
+    list_append_number(chans, (varnumber_T)channel->id);
+  });
+  return chans;
+}
+
 /// Creates an API channel by starting a job and connecting to its
 /// stdin/stdout. stderr is forwarded to the editor error stream.
 ///

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -812,8 +812,7 @@ static void decref(Channel *channel)
 #define RES "[response]     "
 #define NOT "[notification] "
 
-static void log_server_msg(uint64_t channel_id,
-                           msgpack_sbuffer *packed)
+void log_server_msg(uint64_t channel_id, msgpack_sbuffer *packed)
 {
   msgpack_unpacked unpacked;
   msgpack_unpacked_init(&unpacked);
@@ -826,7 +825,7 @@ static void log_server_msg(uint64_t channel_id,
   msgpack_unpacked_destroy(&unpacked);
 }
 
-static void log_client_msg(uint64_t channel_id,
+void log_client_msg(uint64_t channel_id,
                            bool is_request,
                            msgpack_object msg)
 {
@@ -836,7 +835,7 @@ static void log_client_msg(uint64_t channel_id,
   log_msg_close(f, msg);
 }
 
-static void log_msg_close(FILE *f, msgpack_object msg)
+void log_msg_close(FILE *f, msgpack_object msg)
 {
   msgpack_object_print(f, msg);
   fputc('\n', f);

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -261,12 +261,12 @@ Object channel_send_call(uint64_t id,
 ///
 /// @param id The channel id
 /// @param event The event type string
-void channel_subscribe(uint64_t id, char *event)
+bool channel_subscribe(uint64_t id, const char *event)
 {
   Channel *channel;
 
   if (!(channel = pmap_get(uint64_t)(channels, id)) || channel->closed) {
-    abort();
+    return false;
   }
 
   char *event_string = pmap_get(cstr_t)(event_strings, event);
@@ -277,21 +277,23 @@ void channel_subscribe(uint64_t id, char *event)
   }
 
   pmap_put(cstr_t)(channel->subscribed_events, event_string, event_string);
+  return true;
 }
 
 /// Unsubscribes to event broadcasts
 ///
 /// @param id The channel id
 /// @param event The event type string
-void channel_unsubscribe(uint64_t id, char *event)
+bool channel_unsubscribe(uint64_t id, const char *event)
 {
   Channel *channel;
 
   if (!(channel = pmap_get(uint64_t)(channels, id)) || channel->closed) {
-    abort();
+    return false;
   }
 
   unsubscribe(channel, event);
+  return true;
 }
 
 /// Closes a channel
@@ -687,7 +689,7 @@ end:
   kv_destroy(subscribed);
 }
 
-static void unsubscribe(Channel *channel, char *event)
+static void unsubscribe(Channel *channel, const char *event)
 {
   char *event_string = pmap_get(cstr_t)(event_strings, event);
   pmap_del(cstr_t)(channel->subscribed_events, event_string);

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -500,7 +500,7 @@ static void handle_request(Channel *channel, msgpack_object *request)
 static void on_message_event(Event event)
 {
   RequestEvent *data = event.data;
-  Error error = {0};
+  Error error = ERROR_INIT;
 
   // Add two for the channel and request id.
   size_t argc = data->args.size + 2;

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -351,7 +351,7 @@ void msgpack_rpc_serialize_response(uint64_t response_id,
   }
 }
 
-static bool msgpack_rpc_is_notification(msgpack_object *req)
+bool msgpack_rpc_is_notification(msgpack_object *req)
 {
   return req->via.array.ptr[0].via.u64 == 2;
 }

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -8,12 +8,40 @@ local next_message = helpers.next_message
 local nvim_prog = helpers.nvim_prog
 
 describe('vimL API', function()
+  before_each(function() clear() end)
+
   describe('rpcchannels()', function()
     it('gives a list of all connected channels', function()
       eq({1}, eval('rpcchannels()'))
       eval('rpcstart("sleep", ["1"])')
       eq({1, 2}, eval('rpcchannels()'))
     end)
+  end)
+
+  describe('rpcsubscriptions()', function()
+    it('with no arguments, returns a dictionary for all channels', function()
+      eval('rpcsubscribe(1, "test")')
+      local c = eval('rpcstart("sleep", ["1"])')
+      eval('rpcsubscribe('..c..', "test")')
+      local dict = eval('rpcsubscriptions()')
+      eq({'test'}, dict['1'])
+      eq({'test'}, dict[tostring(c)])
+    end)
+
+    it('with a list of channels, returns a dictionary', function()
+      eval('rpcsubscribe(1, "test")')
+      local c = eval('rpcstart("sleep", ["1"])')
+      eval('rpcsubscribe('..c..', "test")')
+      local dict = eval('rpcsubscriptions([1, '..c..'])')
+      eq({'test'}, dict['1'])
+      eq({'test'}, dict[tostring(c)])
+    end)
+
+    it('tells what events a channel has subscribed to', function()
+      eval('rpcsubscribe(1, "test")')
+      eq({'test'}, eval('rpcsubscriptions(1)'))
+    end)
+
   end)
 end)
 

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -7,6 +7,15 @@ local eq, neq, run, stop = helpers.eq, helpers.neq, helpers.run, helpers.stop
 local next_message = helpers.next_message
 local nvim_prog = helpers.nvim_prog
 
+describe('vimL API', function()
+  describe('rpcchannels()', function()
+    it('gives a list of all connected channels', function()
+      eq({1}, eval('rpcchannels()'))
+      eval('rpcstart("sleep", ["1"])')
+      eq({1, 2}, eval('rpcchannels()'))
+    end)
+  end)
+end)
 
 describe('server -> client', function()
   local cid

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -4,6 +4,7 @@
 local helpers = require('test.functional.helpers')
 local clear, nvim, eval = helpers.clear, helpers.nvim, helpers.eval
 local eq, neq, run, stop = helpers.eq, helpers.neq, helpers.run, helpers.stop
+local next_message = helpers.next_message
 local nvim_prog = helpers.nvim_prog
 
 
@@ -114,6 +115,21 @@ describe('server -> client', function()
       run(on_request, on_notification, on_setup)
       eq(expected, notified)
     end)
+  end)
+
+  it('can subscribe clients to events', function()
+    eval('rpcsubscribe('..cid..', "subscribe-test1")')
+    eval('rpcsubscribe('..cid..', "subscribe-test2")')
+    eval('rpcnotify(0, "subscribe-test1")')
+    eval('rpcnotify(0, "subscribe-test2")')
+    eq({'notification', 'subscribe-test1', {}}, next_message())
+    eq({'notification', 'subscribe-test2', {}}, next_message())
+
+    -- Check that rpcunsubscribe() works too.
+    eval('rpcunsubscribe('..cid..', "subscribe-test1")')
+    eval('rpcnotify(0, "subscribe-test1")')
+    eval('rpcnotify(0, "subscribe-test2")')
+    eq({'notification', 'subscribe-test2', {}}, next_message())
   end)
 
   describe('when the client is a recursive vim instance', function()


### PR DESCRIPTION
As discussed in #2547, a "Press Enter" prompt can make an embedded nvim without an attached GUI freeze. We can't ignore "Press Enter" because we don't know that it's not expected. One hacky solution could be making a "Press Enter" autocmd, but I thought it'd be more generic to make it a function, allow the capturing of messages via vimL, and send a message, `"PressEnter"`, when the situation occurs.

``` vim
" ~/.autoload/provider/message.vim
function! provider#message#PressEnter(chan, msgid)
  call rpcnotify(a:chan, 'vim_feedkeys', '<Cr>')
endf

" Be notified about PressEnter events
call rpcnotify(chan, 'vim_subscribe', 'PressEnter')
```

This function intercepts the method `"PressEnter"` and sends back the enter key. `a:chan` represents the channel that sent the message.

More generally, this allows one to define and implement methods by putting them in `~/autoload/provider/message.vim` and calling it `provider#message#{name}`. Another example: we can override existing methods:

``` vim
" Intercepts 'vim_get_current_line'
function! provider#message#vim_get_current_line(chan, id, text)
  return 'HAHAHA'
endfunction

" Arbitrary new methods
function! provider#message#test(chan, id, x)
  call rpcnotify(a:chan, 'test2', a:x, 10)
endfunction

function! provider#message#test2(chan, id, ...)
  echom 'GOT '.join(a:000, ', ')
endfunction
```

The choice of using `provider#message*` function names and needing to put them in `*/provider/message.vim` maybe seems a little wonky, but it works surprisingly well. Ideally, they should be definable in a `.nvimrc`, but then again maybe the same could be said of the existing providers.

I still have to write some documentation and the idea might need some refinement, being a proof of concept, so I'll keep it in WIP for now. Also, I'd like to implement some vimL functions: `rpc(un)subscribe` would allow scripter's control over whether a client gets notified under certain events rather than having clients fight over a single event. For example, at most one client should listen for `"PressEnter"`. `rpcbroadcast` would allow scripters to send arbitrary messages to all subscribed (by choice or via `rpcsubscribe`) channels.
