### PR TITLE
[RDY] Require pkg-config to build bundled libtermkey

### DIFF
--- a/third-party/cmake/BuildLibtermkey.cmake
+++ b/third-party/cmake/BuildLibtermkey.cmake
@@ -1,3 +1,5 @@
+find_package(PkgConfig REQUIRED)
+
 ExternalProject_Add(libtermkey
   PREFIX ${DEPS_BUILD_DIR}
   URL ${LIBTERMKEY_URL}


### PR DESCRIPTION
Libtermkey can be linked against unibilium or curses. For the bundled
dependencies Neovim links against static versions of libtermkey and
unibilium, after building both libraries.

However libtermkey requires pkg-config to be installed in order to detect
and link against unibilium, otherwise it falls back to curses by default.
In systems where pkg-config is not installed building Neovim against the
bundled libtermkey caused a linking error (#2484).

So pkg-config needs to be installed for the bundled libtermkey to build
properly.
