### PR TITLE
[RFC] Fix a wrong expectation for vim_FullName() and FullName_save().

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -371,7 +371,7 @@ void add_pathsep(char *p)
 /// @return [allocated] Copy of absolute path to `fname` or NULL when
 ///                     `fname` is NULL.
 char *FullName_save(char *fname, bool force)
-  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC
 {
   if (fname == NULL) {
     return NULL;
@@ -1564,7 +1564,7 @@ int vim_isAbsName(char_u *name)
 ///
 /// @return           FAIL for failure, OK otherwise
 int vim_FullName(const char *fname, char *buf, int len, bool force)
-  FUNC_ATTR_NONNULL_ARG(1)
+  FUNC_ATTR_NONNULL_ARG(2)
 {
   int retval = OK;
   int url;


### PR DESCRIPTION
It's the second argument, buf, that cannot be NULL.  fname is allowed to
be NULL.  The issue only showed up on the release build when trying to
use NULL for fname and the test would segfault unexpectedly (because the
NULL check for fname was being optimized out due to the function
attributes).

FullName_save() also incorrectly assumes that fname cannot be NULL
(possibly because of the attribute on vim_FullName), so fix that site as
well.  This didn't have a corresponding test, so it wasn't visible as
test breakage, but did generate a tautological comparison warning in the
release build under Clang.
