### PR TITLE
[RFC] vim-patch:7.4.{569,573}

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -756,6 +756,8 @@ struct file_buffer {
 
   signlist_T *b_signlist;       /* list of signs to draw */
 
+  int b_mapped_ctrl_c;          ///< Modes where CTRL-C is mapped.
+
   Terminal *terminal;           // Terminal instance associated with the buffer
 };
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2946,8 +2946,12 @@ do_map (
     if (!did_it) {
       retval = 2;                           /* no match */
     } else if (*keys == Ctrl_C) {
-      /* If CTRL-C has been unmapped, reuse it for Interrupting. */
-      mapped_ctrl_c = FALSE;
+      // If CTRL-C has been unmapped, reuse it for Interrupting.
+      if (map_table == curbuf->b_maphash) {
+        curbuf->b_mapped_ctrl_c &= ~mode;
+      } else {
+        mapped_ctrl_c &= ~mode;
+      }
     }
     goto theend;
   }
@@ -2972,9 +2976,14 @@ do_map (
    */
   mp = xmalloc(sizeof(mapblock_T));
 
-  /* If CTRL-C has been mapped, don't always use it for Interrupting. */
-  if (*keys == Ctrl_C)
-    mapped_ctrl_c = TRUE;
+  // If CTRL-C has been mapped, don't always use it for Interrupting.
+  if (*keys == Ctrl_C) {
+    if (map_table == curbuf->b_maphash) {
+      curbuf->b_mapped_ctrl_c |= mode;
+    } else {
+      mapped_ctrl_c |= mode;
+    }
+  }
 
   mp->m_keys = vim_strsave(keys);
   mp->m_str = vim_strsave(rhs);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -831,7 +831,7 @@ EXTERN int ctrl_x_mode INIT(= 0);       /* Which Ctrl-X mode are we in? */
 
 EXTERN int no_abbr INIT(= TRUE);        /* TRUE when no abbreviations loaded */
 
-EXTERN int mapped_ctrl_c INIT(= FALSE);      /* CTRL-C is mapped */
+EXTERN int mapped_ctrl_c INIT(= 0);  ///< Modes where CTRL-C is mapped.
 
 EXTERN cmdmod_T cmdmod;                 /* Ex command modifiers */
 

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2362,7 +2362,7 @@ int get_keystroke(void)
   int save_mapped_ctrl_c = mapped_ctrl_c;
   int waited = 0;
 
-  mapped_ctrl_c = FALSE;        /* mappings are not used here */
+  mapped_ctrl_c = 0;        /* mappings are not used here */
   for (;; ) {
     // flush output before waiting
     ui_flush();

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -21,6 +21,7 @@
 #include "nvim/getchar.h"
 #include "nvim/main.h"
 #include "nvim/misc1.h"
+#include "nvim/misc2.h"
 
 #define READ_BUFFER_SIZE 0xfff
 #define INPUT_BUFFER_SIZE (READ_BUFFER_SIZE * 4)
@@ -316,7 +317,7 @@ static void read_cb(RStream *rstream, void *data, bool at_eof)
 
 static void process_interrupts(void)
 {
-  if (mapped_ctrl_c) {
+  if ((mapped_ctrl_c | curbuf->b_mapped_ctrl_c) & get_real_state()) {
     return;
   }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -333,8 +333,8 @@ void terminal_enter(bool process_deferred)
   int save_rd = RedrawingDisabled;
   State = TERM_FOCUS;
   RedrawingDisabled = false;
-  bool save_mapped_ctrl_c = mapped_ctrl_c;
-  mapped_ctrl_c = true;
+  int save_mapped_ctrl_c = mapped_ctrl_c;
+  mapped_ctrl_c = MAP_ALL_MODES;
   // go to the bottom when the terminal is focused
   adjust_topline(term, false);
   // erase the unfocused cursor

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -231,7 +231,7 @@ static int included_patches[] = {
   572,
   //571 NA
   //570 NA
-  //569,
+  569,
   568,
   567,
   566,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -227,7 +227,7 @@ static int included_patches[] = {
   576,
   //575,
   574,
-  //573,
+  573,
   572,
   //571 NA
   //570 NA

--- a/test/functional/legacy/mapping_spec.lua
+++ b/test/functional/legacy/mapping_spec.lua
@@ -18,6 +18,15 @@ describe('mapping', function()
     execute('inoreab чкпр   vim')
     feed('GAчкпр <esc>')
 
+    -- Mapping of ctrl-c in insert mode.
+    execute('set cpo-=< cpo-=k')
+    execute('inoremap <c-c> <ctrl-c>')
+    execute('cnoremap <c-c> dummy')
+    execute('cunmap <c-c>')
+    feed('GA<cr>')
+    feed('TEST2: CTRL-C |<c-c>A|<cr><esc>')
+    execute('nunmap <c-c>')
+
     -- langmap should not get remapped in insert mode.
     execute('inoremap { FAIL_ilangmap')
     execute('set langmap=+{ langnoremap')
@@ -32,6 +41,8 @@ describe('mapping', function()
     expect([[
       test starts here:
       vim 
+      TEST2: CTRL-C |<ctrl-c>A|
+      
       +
       +]])
   end)

--- a/test/functional/legacy/mapping_spec.lua
+++ b/test/functional/legacy/mapping_spec.lua
@@ -2,12 +2,12 @@
 
 local helpers = require('test.functional.helpers')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
-local execute, expect = helpers.execute, helpers.expect
+local execute, expect, wait = helpers.execute, helpers.expect, helpers.wait
 
 describe('mapping', function()
-  setup(clear)
+  before_each(clear)
 
-  it('is working', function()
+  it('abbreviations with р (0x80)', function()
     insert([[
       test starts here:
       ]])
@@ -18,15 +18,49 @@ describe('mapping', function()
     execute('inoreab чкпр   vim')
     feed('GAчкпр <esc>')
 
-    -- Mapping of ctrl-c in insert mode.
+    expect([[
+      test starts here:
+      vim ]])
+  end)
+
+  it('works with Ctrl-c in Insert mode', function()
+    -- Mapping of ctrl-c in Insert mode.
     execute('set cpo-=< cpo-=k')
     execute('inoremap <c-c> <ctrl-c>')
     execute('cnoremap <c-c> dummy')
     execute('cunmap <c-c>')
     feed('GA<cr>')
-    feed('TEST2: CTRL-C |<c-c>A|<cr><esc>')
-    execute('nunmap <c-c>')
+    feed('TEST2: CTRL-C |')
+    wait()
+    feed('<c-c>A|<cr><esc>')
+    wait()
+    execute('unmap <c-c>')
+    execute('unmap! <c-c>')
 
+    expect([[
+      
+      TEST2: CTRL-C |<ctrl-c>A|
+      ]])
+  end)
+
+  it('works with Ctrl-c in Visual mode', function()
+    -- Mapping of ctrl-c in Visual mode.
+    execute([[vnoremap <c-c> :<C-u>$put ='vmap works']])
+    feed('GV')
+    -- For some reason the mapping is only triggered when <C-c> is entered in a
+    -- separate feed command.
+    wait()
+    feed('<c-c>')
+    wait()
+    feed('<cr>')
+    execute('vunmap <c-c>')
+
+    expect([[
+      
+      vmap works]])
+  end)
+
+  it("works in Insert mode with 'langmap'", function()
     -- langmap should not get remapped in insert mode.
     execute('inoremap { FAIL_ilangmap')
     execute('set langmap=+{ langnoremap')
@@ -36,12 +70,7 @@ describe('mapping', function()
     execute('inoremap <expr> { "FAIL_iexplangmap"')
     feed('o+<esc>')
 
-
-    -- Assert buffer contents.
     expect([[
-      test starts here:
-      vim 
-      TEST2: CTRL-C |<ctrl-c>A|
       
       +
       +]])


### PR DESCRIPTION
```
Problem:    Having CTRL-C interrupt or not does not check the mode of the
        mapping. (Ingo Karkat)
Solution:   Use a bitmask with the map mode. (Christian Brabandt)
```

https://github.com/vim/vim/commit/v7-4-569

Original patch:

``` diff
diff --git a/src/nvim/getchar.c b/src/nvim/getchar.c
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3708,8 +3708,13 @@ do_map(maptype, arg, mode, abbrev)
    if (!did_it)
        retval = 2;             /* no match */
    else if (*keys == Ctrl_C)
+   {
        /* If CTRL-C has been unmapped, reuse it for Interrupting. */
-       mapped_ctrl_c = FALSE;
+       if (map_table == curbuf->b_maphash)
+       curbuf->b_mapped_ctrl_c &= ~mode;
+       else
+       mapped_ctrl_c &= ~mode;
+   }
    goto theend;
     }

@@ -3744,7 +3749,12 @@ do_map(maptype, arg, mode, abbrev)

     /* If CTRL-C has been mapped, don't always use it for Interrupting. */
     if (*keys == Ctrl_C)
-   mapped_ctrl_c = TRUE;
+    {
+   if (map_table == curbuf->b_maphash)
+       curbuf->b_mapped_ctrl_c |= mode;
+   else
+       mapped_ctrl_c |= mode;
+    }

     mp->m_keys = vim_strsave(keys);
     mp->m_str = vim_strsave(rhs);
diff --git a/src/nvim/globals.h b/src/nvim/globals.h
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -958,7 +958,7 @@ EXTERN char_u   *exe_name;      /* the name of
 #ifdef USE_ON_FLY_SCROLL
 EXTERN int dont_scroll INIT(= FALSE);/* don't use scrollbars when TRUE */
 #endif
-EXTERN int mapped_ctrl_c INIT(= FALSE); /* CTRL-C is mapped */
+EXTERN int mapped_ctrl_c INIT(= FALSE); /* modes where CTRL-C is mapped */
 EXTERN int ctrl_c_interrupts INIT(= TRUE); /* CTRL-C sets got_int */

 EXTERN cmdmod_T    cmdmod;         /* Ex command modifiers */
diff --git a/src/nvim/structs.h b/src/nvim/structs.h
--- a/src/nvim/structs.h
+++ b/src/nvim/structs.h
@@ -1802,6 +1802,7 @@ struct file_buffer
     cryptstate_T *b_cryptstate;    /* Encryption state while reading or writing
                 * the file. NULL when not using encryption. */
 #endif
+    int        b_mapped_ctrl_c; /* modes where CTRL-C is mapped */

 }; /* file_buffer */

diff --git a/src/nvim/testdir/test_mapping.in b/src/nvim/testdir/test_mapping.in
--- a/src/nvim/testdir/test_mapping.in
+++ b/src/nvim/testdir/test_mapping.in
@@ -8,6 +8,15 @@ STARTTEST
 :inoreab чкпр   vim
 GAчкпр 
 
+:" mapping of ctrl-c in insert mode
+:set cpo-=< cpo-=k
+:inoremap <c-c> <ctrl-c>
+:cnoremap <c-c> dummy
+:cunmap <c-c>
+GA
+TEST2: CTRL-C |A|
+
+:nunmap <c-c>

 : " langmap should not get remapped in insert mode
 :inoremap { FAIL_ilangmap
diff --git a/src/nvim/testdir/test_mapping.ok b/src/nvim/testdir/test_mapping.ok
--- a/src/nvim/testdir/test_mapping.ok
+++ b/src/nvim/testdir/test_mapping.ok
@@ -1,4 +1,6 @@
 test starts here:
 vim
+TEST2: CTRL-C |<ctrl-c>A|
+
 +
 +
diff --git a/src/nvim/ui.c b/src/nvim/ui.c
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -180,7 +180,7 @@ ui_inchar(buf, maxlen, wtime, tb_change_

    /* ... there is no need for CTRL-C to interrupt something, don't let
     * it set got_int when it was mapped. */
-   if (mapped_ctrl_c)
+   if ((mapped_ctrl_c | curbuf->b_mapped_ctrl_c) & State)
        ctrl_c_interrupts = FALSE;
     }

diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    569,
+/**/
     568,
 /**/
     567,
```

---

```
Problem:    Mapping CTRL-C in Visual mode doesn't work. (Ingo Karkat)
Solution:   Call get_real_state() instead of using State directly.
```

https://github.com/vim/vim/commit/v7-4-573

Original patch:

``` diff
diff --git a/src/nvim/testdir/test_mapping.in b/src/nvim/testdir/test_mapping.in
--- a/src/nvim/testdir/test_mapping.in
+++ b/src/nvim/testdir/test_mapping.in
@@ -8,7 +8,7 @@ STARTTEST
 :inoreab чкпр   vim
 GAчкпр 
 
-:" mapping of ctrl-c in insert mode
+:" mapping of ctrl-c in Insert mode
 :set cpo-=< cpo-=k
 :inoremap <c-c> <ctrl-c>
 :cnoremap <c-c> dummy
@@ -16,9 +16,15 @@ GAчкпр
 GA
 TEST2: CTRL-C |A|
 
-:nunmap <c-c>
-
-: " langmap should not get remapped in insert mode
+:unmap <c-c>
+:unmap! <c-c>
+:"
+:" mapping of ctrl-c in Visual mode
+:vnoremap <c-c> :<C-u>$put ='vmap works'
+GV
+:vunmap <c-c>
+:"
+:" langmap should not get remapped in insert mode
 :inoremap { FAIL_ilangmap
 :set langmap=+{ langnoremap
 o+
diff --git a/src/nvim/testdir/test_mapping.ok b/src/nvim/testdir/test_mapping.ok
--- a/src/nvim/testdir/test_mapping.ok
+++ b/src/nvim/testdir/test_mapping.ok
@@ -2,5 +2,6 @@ test starts here:
 vim
 TEST2: CTRL-C |<ctrl-c>A|

+vmap works
 +
 +
diff --git a/src/nvim/ui.c b/src/nvim/ui.c
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -180,7 +180,7 @@ ui_inchar(buf, maxlen, wtime, tb_change_

    /* ... there is no need for CTRL-C to interrupt something, don't let
     * it set got_int when it was mapped. */
-   if ((mapped_ctrl_c | curbuf->b_mapped_ctrl_c) & State)
+   if ((mapped_ctrl_c | curbuf->b_mapped_ctrl_c) & get_real_state())
        ctrl_c_interrupts = FALSE;
     }

diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    573,
+/**/
     572,
 /**/
     571,
```
