### PR TITLE
[RFC] vim-patch:7.4.587

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -196,7 +196,7 @@ static int included_patches[] = {
   590,
   //589 NA
   588,
-  //587,
+  587,
   //586 NA
   585,
   //584 NA

--- a/test/functional/legacy/listlbr_utf8_spec.lua
+++ b/test/functional/legacy/listlbr_utf8_spec.lua
@@ -16,9 +16,9 @@ describe('linebreak', function()
       put =\"\tabcdef hijklmn\tpqrstuvwxyz\u00a01060ABCDEFGHIJKLMNOP \"
       norm! zt
       set ts=4 sw=4 sts=4 linebreak sbr=+ wrap
-      fu! ScreenChar(width)
+      fu! ScreenChar(width, lines)
       	let c=''
-      	for j in range(1,4)
+      	for j in range(1,a:lines)
       	    for i in range(1,a:width)
       	    	let c.=nr2char(screenchar(j, i))
       	    endfor
@@ -35,12 +35,12 @@ describe('linebreak', function()
       let g:test ="Test 1: set linebreak + set list + fancy listchars"
       exe "set linebreak list listchars=nbsp:\u2423,tab:\u2595\u2014,trail:\u02d1,eol:\ub6"
       redraw!
-      let line=ScreenChar(winwidth(0))
+      let line=ScreenChar(winwidth(0),4)
       call DoRecordScreen()
       let g:test ="Test 2: set nolinebreak list"
       set list nolinebreak
       redraw!
-      let line=ScreenChar(winwidth(0))
+      let line=ScreenChar(winwidth(0),4)
       call DoRecordScreen()
       let g:test ="Test 3: set linebreak nolist"
       $put =\"\t*mask = nil;\"
@@ -48,7 +48,18 @@ describe('linebreak', function()
       norm! zt
       set nolist linebreak
       redraw!
-      let line=ScreenChar(winwidth(0))
+      let line=ScreenChar(winwidth(0),4)
+      call DoRecordScreen()
+      let g:test ="Test 4: set linebreak list listchars and concealing"
+      let c_defines=['#define ABCDE		1','#define ABCDEF		1','#define ABCDEFG		1','#define ABCDEFGH	1', '#define MSG_MODE_FILE			1','#define MSG_MODE_CONSOLE		2','#define MSG_MODE_FILE_AND_CONSOLE	3','#define MSG_MODE_FILE_THEN_CONSOLE	4']
+      call append('$', c_defines)
+      vert resize 40
+      $-7
+      norm! zt
+      set list linebreak listchars=tab:>- cole=1
+      syn match Conceal conceal cchar=>'AB\|MSG_MODE'
+      redraw!
+      let line=ScreenChar(winwidth(0),7)
       call DoRecordScreen()
     ]])
 
@@ -74,6 +85,23 @@ describe('linebreak', function()
           *mask = nil;    
       ~                   
       ~                   
-      ~                   ]])
+      ~                   
+      #define ABCDE		1
+      #define ABCDEF		1
+      #define ABCDEFG		1
+      #define ABCDEFGH	1
+      #define MSG_MODE_FILE			1
+      #define MSG_MODE_CONSOLE		2
+      #define MSG_MODE_FILE_AND_CONSOLE	3
+      #define MSG_MODE_FILE_THEN_CONSOLE	4
+      
+      Test 4: set linebreak list listchars and concealing
+      #define ABCDE>-->---1                   
+      #define >CDEF>-->---1                   
+      #define >CDEFG>->---1                   
+      #define >CDEFGH>----1                   
+      #define >_FILE>--------->--->---1       
+      #define >_CONSOLE>---------->---2       
+      #define >_FILE_AND_CONSOLE>---------3   ]])
   end)
 end)


### PR DESCRIPTION
```
Problem:    Conceal does not work properly with 'linebreak'. (cs86661)
Solution:   Save and restore boguscols. (Christian Brabandt)
```

Repro steps here: https://groups.google.com/d/msg/vim_dev/5eZuGL8QV0U/ZKA8jM0WyDMJ

https://github.com/vim/vim/commit/v7-4-587

Original patch:

``` diff
diff --git a/src/nvim/screen.c b/src/nvim/screen.c
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3003,6 +3003,7 @@ win_line(wp, lnum, startrow, endrow, noc
                       wrapping */
     int        vcol_off    = 0;    /* offset for concealed characters */
     int        did_wcol    = FALSE;
+    int        old_boguscols   = 0;
 # define VCOL_HLC (vcol - vcol_off)
 # define FIX_FOR_BOGUSCOLS \
     { \
@@ -3010,6 +3011,7 @@ win_line(wp, lnum, startrow, endrow, noc
    vcol -= vcol_off; \
    vcol_off = 0; \
    col -= boguscols; \
+   old_boguscols = boguscols; \
    boguscols = 0; \
     }
 #else
@@ -4545,10 +4547,16 @@ win_line(wp, lnum, startrow, endrow, noc
            int saved_nextra = n_extra;

 #ifdef FEAT_CONCEAL
-           if (is_concealing && vcol_off > 0)
+           if ((is_concealing || boguscols > 0) && vcol_off > 0)
                /* there are characters to conceal */
                tab_len += vcol_off;
-#endif
+           /* boguscols before FIX_FOR_BOGUSCOLS macro from above
+            */
+           if (wp->w_p_list && lcs_tab1 && old_boguscols > 0
+                            && n_extra > tab_len)
+               tab_len += n_extra - tab_len;
+#endif
+
            /* if n_extra > 0, it gives the number of chars, to
             * use for a tab, else we need to calculate the width
             * for a tab */
@@ -4577,7 +4585,7 @@ win_line(wp, lnum, startrow, endrow, noc
 #ifdef FEAT_CONCEAL
            /* n_extra will be increased by FIX_FOX_BOGUSCOLS
             * macro below, so need to adjust for that here */
-           if (is_concealing && vcol_off > 0)
+           if ((is_concealing || boguscols > 0) && vcol_off > 0)
                n_extra -= vcol_off;
 #endif
            }
@@ -4590,6 +4598,12 @@ win_line(wp, lnum, startrow, endrow, noc
             * the tab can be longer than 'tabstop' when there
             * are concealed characters. */
            FIX_FOR_BOGUSCOLS;
+           /* Make sure, the highlighting for the tab char will be
+            * correctly set further below (effectively reverts the
+            * FIX_FOR_BOGSUCOLS macro */
+           if (old_boguscols > 0 && n_extra > tab_len && wp->w_p_list
+                                 && lcs_tab1)
+           tab_len += n_extra - tab_len;
 #endif
 #ifdef FEAT_MBYTE
            mb_utf8 = FALSE;    /* don't draw as UTF-8 */
diff --git a/src/nvim/testdir/test_listlbr_utf8.in b/src/nvim/testdir/test_listlbr_utf8.in
--- a/src/nvim/testdir/test_listlbr_utf8.in
+++ b/src/nvim/testdir/test_listlbr_utf8.in
@@ -9,9 +9,9 @@ STARTTEST
 :put =\"\tabcdef hijklmn\tpqrstuvwxyz\u00a01060ABCDEFGHIJKLMNOP \"
 :norm! zt
 :set ts=4 sw=4 sts=4 linebreak sbr=+ wrap
-:fu! ScreenChar(width)
+:fu! ScreenChar(width, lines)
 :  let c=''
-:  for j in range(1,4)
+:  for j in range(1,a:lines)
 :      for i in range(1,a:width)
 :          let c.=nr2char(screenchar(j, i))
 :      endfor
@@ -28,13 +28,13 @@ STARTTEST
 :let g:test ="Test 1: set linebreak + set list + fancy listchars"
 :exe "set linebreak list listchars=nbsp:\u2423,tab:\u2595\u2014,trail:\u02d1,eol:\ub6"
 :redraw!
-:let line=ScreenChar(winwidth(0))
+:let line=ScreenChar(winwidth(0),4)
 :call DoRecordScreen()
 :"
 :let g:test ="Test 2: set nolinebreak list"
 :set list nolinebreak
 :redraw!
-:let line=ScreenChar(winwidth(0))
+:let line=ScreenChar(winwidth(0),4)
 :call DoRecordScreen()
 :"
 :let g:test ="Test 3: set linebreak nolist"
@@ -43,9 +43,19 @@ STARTTEST
 :norm! zt
 :set nolist linebreak
 :redraw!
-:let line=ScreenChar(winwidth(0))
+:let line=ScreenChar(winwidth(0),4)
 :call DoRecordScreen()
-:"
+:let g:test ="Test 4: set linebreak list listchars and concealing"
+:let c_defines=['#define ABCDE     1','#define ABCDEF      1','#define ABCDEFG     1','#define ABCDEFGH    1', '#define MSG_MODE_FILE          1','#define MSG_MODE_CONSOLE        2','#define MSG_MODE_FILE_AND_CONSOLE   3','#define MSG_MODE_FILE_THEN_CONSOLE  4']
+:call append('$', c_defines)
+:vert resize 40
+:$-7
+:norm! zt
+:set list linebreak listchars=tab:>- cole=1
+:syn match Conceal conceal cchar=>'AB\|MSG_MODE'
+:redraw!
+:let line=ScreenChar(winwidth(0),7)
+:call DoRecordScreen()
 :%w! test.out
 :qa!
 ENDTEST
diff --git a/src/nvim/testdir/test_listlbr_utf8.ok b/src/nvim/testdir/test_listlbr_utf8.ok
--- a/src/nvim/testdir/test_listlbr_utf8.ok
+++ b/src/nvim/testdir/test_listlbr_utf8.ok
@@ -19,3 +19,20 @@ Test 3: set linebreak nolist
 ~                   
 ~                   
 ~                   
+#define ABCDE      1
+#define ABCDEF     1
+#define ABCDEFG        1
+#define ABCDEFGH   1
+#define MSG_MODE_FILE          1
+#define MSG_MODE_CONSOLE       2
+#define MSG_MODE_FILE_AND_CONSOLE  3
+#define MSG_MODE_FILE_THEN_CONSOLE 4
+
+Test 4: set linebreak list listchars and concealing
+#define ABCDE>-->---1                   
+#define >CDEF>-->---1                   
+#define >CDEFG>->---1                   
+#define >CDEFGH>----1                   
+#define >_FILE>--------->--->---1       
+#define >_CONSOLE>---------->---2       
+#define >_FILE_AND_CONSOLE>---------3   
diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    587,
+/**/
     586,
 /**/
     585,
```
