### PR TITLE
[RFC] vim-patch:7.4.581: Mark as NA

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -202,7 +202,7 @@ static int included_patches[] = {
   //584 NA
   //583 NA
   //582,
-  //581,
+  //581 NA
   580,
   //579,
   578,


### PR DESCRIPTION
Does not apply, see commit message.

```
Problem:    Compiler warnings for unitinialized variables. (John Little)
Solution:   Initialize the variables.
```

https://github.com/vim/vim/commit/v7-4-581

Original patch:

``` diff
diff --git a/src/nvim/ops.c b/src/nvim/ops.c
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5663,8 +5663,8 @@ read_viminfo_register(virp, force)
     int        set_prev = FALSE;
     char_u *str;
     char_u **array = NULL;
-    int        new_type;
-    colnr_T    new_width;
+    int        new_type = MCHAR; /* init to shut up compiler */
+    colnr_T    new_width = 0; /* init to shut up compiler */

     /* We only get here (hopefully) if line[0] == '"' */
     str = virp->vir_line + 1;
@@ -5747,6 +5747,7 @@ read_viminfo_register(virp, force)
        do_it = FALSE;
    }
     }
+
     if (do_it)
     {
    /* free y_array[] */
diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    581,
+/**/
     580,
 /**/
     579,
```
