### PR TITLE
[RFC] test/terminal: fix indeterminism in screen test

### DIFF
--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -14,8 +14,17 @@ describe('terminal window', function()
 
   describe('with colorcolumn set', function()
     before_each(function()
-      feed('<c-\\><c-n>:set colorcolumn=20<cr>i')
-      wait()
+      feed('<c-\\><c-n>')
+      screen:expect([[
+        tty ready                                         |
+        {2: }                                                 |
+                                                          |
+                                                          |
+                                                          |
+        ^                                                  |
+                                                          |
+      ]])
+      feed(':set colorcolumn=20<cr>i')
     end)
 
     it('wont show the color column', function()


### PR DESCRIPTION
Here we're `expect`ing the screen state to be identical to the previous screen test in `thelpers.screen_setup()`, which is indeterministic. (The later screen test can accidentally still see the previous identical state). Solution is to add a test for a intermediate different state.
