### PR TITLE
[RFC] vim-patch:7.4.573: Mark as NA

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -210,7 +210,7 @@ static int included_patches[] = {
   576,
   //575,
   574,
-  //573,
+  //573 NA
   572,
   //571 NA
   //570 NA


### PR DESCRIPTION
Not applicable. `ui.c` was refactored. Ctrl-C mappings already work in visual mode. Commit message:

```
Problem:    Mapping CTRL-C in Visual mode doesn't work. (Ingo Karkat)
Solution:   Call get_real_state() instead of using State directly.
```

https://github.com/vim/vim/commit/v7-4-573
