### PR TITLE
[RFC] Remove "-" flag from 'cpoptions'

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -354,10 +354,6 @@ or the last line.  The first two commands put the cursor in the same column
 except after the "$" command, then the cursor will be put on the last
 character of the line.
 
-If "k", "-" or CTRL-P is used with a [count] and there are less than [count]
-lines above the cursor and the 'cpo' option includes the "-" flag it is an
-error. |cpo--|.
-
 ==============================================================================
 4. Word motions						*word-motions*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1925,13 +1925,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			there is one).  This works very well for C programs.
 			This flag is also used for other features, such as
 			C-indenting.
-								*cpo--*
-		-	When included, a vertical movement command fails when
-			it would go above the first line or below the last
-			line.  Without it the cursor moves to the first or
-			last line, unless it already was in that line.
-			Applies to the commands "-", "k", CTRL-P, "+", "j",
-			CTRL-N, CTRL-J and ":1234".
 								*cpo-+*
 		+	When included, a ":write file" command will reset the
 			'modified' flag of the buffer, even though the buffer

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -5966,10 +5966,11 @@ cursor_up (
 
   if (n > 0) {
     lnum = curwin->w_cursor.lnum;
-    /* This fails if the cursor is already in the first line or the count
-     * is larger than the line number and '-' is in 'cpoptions' */
-    if (lnum <= 1 || (n >= lnum && vim_strchr(p_cpo, CPO_MINUS) != NULL))
+
+    // This fails if the cursor is already in the first line.
+    if (lnum <= 1) {
       return FAIL;
+    }
     if (n >= lnum)
       lnum = 1;
     else if (hasAnyFolding(curwin)) {
@@ -6021,12 +6022,11 @@ cursor_down (
     lnum = curwin->w_cursor.lnum;
     /* Move to last line of fold, will fail if it's the end-of-file. */
     (void)hasFolding(lnum, NULL, &lnum);
-    /* This fails if the cursor is already in the last line or would move
-     * beyond the last line and '-' is in 'cpoptions' */
-    if (lnum >= curbuf->b_ml.ml_line_count
-        || (lnum + n > curbuf->b_ml.ml_line_count
-            && vim_strchr(p_cpo, CPO_MINUS) != NULL))
+
+    // This fails if the cursor is already in the last line.
+    if (lnum >= curbuf->b_ml.ml_line_count) {
       return FAIL;
+    }
     if (lnum + n >= curbuf->b_ml.ml_line_count)
       lnum = curbuf->b_ml.ml_line_count;
     else if (hasAnyFolding(curwin)) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1684,12 +1684,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
       }
     } else if (ea.addr_count != 0) {
       if (ea.line2 > curbuf->b_ml.ml_line_count) {
-        /* With '-' in 'cpoptions' a line number past the file is an
-         * error, otherwise put it at the end of the file. */
-        if (vim_strchr(p_cpo, CPO_MINUS) != NULL)
-          ea.line2 = -1;
-        else
-          ea.line2 = curbuf->b_ml.ml_line_count;
+        ea.line2 = curbuf->b_ml.ml_line_count;
       }
 
       if (ea.line2 < 0)

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -127,7 +127,6 @@
 #define CPO_FILTER      '!'
 #define CPO_MATCH       '%'
 #define CPO_PLUS        '+'     /* ":write file" resets 'modified' */
-#define CPO_MINUS       '-'     /* "9-" fails at and before line 9 */
 #define CPO_SPECI       '<'     /* don't recognize <> in mappings */
 #define CPO_REGAPPEND   '>'     /* insert NL when appending to a register */
 /* POSIX flags */
@@ -142,9 +141,9 @@
                                  * cursor would not move */
 /* default values for Vim, Vi and POSIX */
 #define CPO_VIM         "aABceFs"
-#define CPO_VI          "aAbBcCdDeEfFiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%-+<>;"
+#define CPO_VI          "aAbBcCdDeEfFiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%+<>;"
 #define CPO_ALL \
-  "aAbBcCdDeEfFiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%-+<>#{|&/\\.;"
+  "aAbBcCdDeEfFiIjJkKlLmMnoOpPqrRsStuvWxXyZ$!%+<>#{|&/\\.;"
 
 /* characters for p_ww option: */
 #define WW_ALL          "bshl<>[],~"


### PR DESCRIPTION
```
                                                            *cpo--*
            -       When included, a vertical movement command fails when
                    it would go above the first line or below the last
                    line.  Without it the cursor moves to the first or
                    last line, unless it already was in that line.
                    Applies to the commands "-", "k", CTRL-P, "+", "j",
                    CTRL-N, CTRL-J and ":1234".
```

I can't see a reason to keep this compatibility option. It only makes things slightly less consistent when switched on. For example, `9999j` might not move the cursor but `9999G` does even when the buffer has less than 9999 lines.
