### PR TITLE
[RFC] vim-patch:f654ad9

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1016,9 +1016,12 @@ The names can be in upper- or lowercase.
 			the last file in the argument list has not been
 			edited.  See |:confirm| and 'confirm'.
 
-:q[uit]!		Quit without writing, also when visible buffers have
-			changes.  Does not exit when there are changed hidden
-			buffers.  Use ":qall!" to exit always.
+:q[uit]!		Quit without writing, also when currently visible
+			buffers have changes.  Does not exit when this is the
+			last window and there are is a changed hidden buffer.
+			In this case, the first changed hidden buffer becomes
+			the current buffer.
+			Use ":qall!" to exit always.
 
 :cq[uit]		Quit always, without writing, and return an error
 			code.  See |:cq|.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 7.4.  Last change: 2014 Nov 05
+*eval.txt*	For Vim version 7.4.  Last change: 2014 Nov 15
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1753,8 +1753,8 @@ count( {list}, {expr} [, {ic} [, {start}]])
 				Number	 count how many {expr} are in {list}
 cscope_connection( [{num} , {dbpath} [, {prepend}]])
 				Number	checks existence of cscope connection
-cursor( {lnum}, {col} [, {coladd}])
-				Number	move cursor to {lnum}, {col}, {coladd}
+cursor( {lnum}, {col} [, {off}])
+				Number	move cursor to {lnum}, {col}, {off}
 cursor( {list})			Number	move cursor to position in {list}
 deepcopy( {expr} [, {noref}])	any	make a full copy of {expr}
 delete( {fname})		Number	delete file {fname}
@@ -2621,6 +2621,7 @@ cursor({list})
 		If {col} is zero, the cursor will stay in the current column.
 		If {curswant} is given it is used to set the preferred column
 		for vertical movement.  Otherwise {col} is used.
+
 		When 'virtualedit' is used {off} specifies the offset in
 		screen columns from the start of the character.  E.g., a
 		position within a <Tab> or after the last character.
@@ -4891,7 +4892,7 @@ readfile({fname} [, {binary} [, {max}]])
 		separated with CR will result in a single long line (unless a
 		NL appears somewhere).
 		All NUL characters are replaced with a NL character.
-		When {binary/append} is contains "b" binary mode is used:
+		When {binary/append} contains "b" binary mode is used:
 		- When the last line ends in a NL an extra empty list item is
 		  added.
 		- No CR characters are removed.

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -1,4 +1,4 @@
-*quickref.txt*  For Vim version 7.4.  Last change: 2014 Oct 22
+*quickref.txt*  For Vim version 7.4.  Last change: 2014 Nov 19
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -756,6 +756,7 @@ Short explanation of each option:		*option-list*
 'keywordprg'	  'kp'	    program to use for the "K" command
 'langmap'	  'lmap'    alphabetic characters for other language mode
 'langmenu'	  'lm'	    language to be used for the menus
+'langnoremap'	  'lnr'	    do not apply 'langmap' to mapped characters
 'laststatus'	  'ls'	    tells when last window has status lines
 'lazyredraw'	  'lz'	    don't redraw while executing macros
 'linebreak'	  'lbr'     wrap long lines at a blank

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 7.4.  Last change: 2014 Nov 13
+*todo.txt*      For Vim version 7.4.  Last change: 2014 Nov 19
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -33,8 +33,6 @@ not be repeated below, unless there is extra information.
 
 							*known-bugs*
 -------------------- Known bugs and current work -----------------------
-
-Add langnoremap in quickref.txt and  optwin.vim.
 
 Regexp problems:
 - The NFA engine does not implement the time limit passed to
@@ -77,8 +75,6 @@ Patch by Marcin Szamotulski to add count to :close (2014 Aug 10, update Aug
 Doesn't look right, asked for updates.
 Update 2014 Nov 8. Replied with suggestions.
 
-C macro with number highlighted wrong. (Dominique Pelle, 2014 Oct 23)
-
 The entries added by matchaddpos() are returned by getmatches() but can't be
 set with setmatches(). (lcd47, 2014 Jun 29)
 
@@ -88,13 +84,18 @@ Problem using ":try" inside ":execute". (ZyX, 2013 Sep 15)
 
 Python: ":py raw_input('prompt')" doesn't work. (Manu Hack)
 
-Patch to fix issue 203. (Christian Brabandt, 2014 Oct 8)
-
 Patch to fix issue 78. (Christian Brabandt, 2014 Oct 8)
 
 Patch to fix leak in map() with error. (Christian Brabandt, 2014 Oct 11)
 
 Patch to fix incsearch for "2/pattern/e".
+
+Patch to fix memory leak in :hardcopy. (Christian Brabandt, 2014 Nov 16)
+
+Patch to fix warnings in if_ruby.c. (Ken Takata, 2014 Nov 17)
+
+Patch to make test 63 pass when in a B&W terminal. (Christian Brabandt, 2014
+Nov 15)  Other patch (better) on Nov 17.
 
 Change behavior of v:hlsearch?  Patch from Christian, 2014 Oct 22.
 
@@ -106,14 +107,16 @@ patch to remove FEAT_OSFILETYPE from fileio.c. (Christian, 2014 Nov 12)
 Value returned by virtcol() changes depending on how lines wrap.  This is
 inconsistent with the documentation.
 
-Fix for wrong formatting if 'linebreak' is set. (Christian Brabandt, 2014 Nov
-12)
+Patch to fix relatie numbers. (Christian Brabandt, 2014 Nov 17)
+
+Patch to fix wrong formatting if 'linebreak' is set. (Christian Brabandt, 2014
+Nov 12)
 
 Patch to support hex values for setting option value.
 (Zyx, 2015 Nov 6)
 
-On MS-Windows running tests with Mercurial has problems when the input files
-are changed. (Ken Takata, Taro Muraoka, 2014 Sep 25)
+On MS-Windows running tests with Mercurial has problems when the fileformat of
+the input files are changed. (Ken Takata, Taro Muraoka, 2014 Sep 25)
 Update Nov 5.
 
 MS-Windows: Crash opening very long file name starting with "\\".
@@ -140,6 +143,10 @@ lines. (Marco Hinz, 2014 Nov 2)
 
 Adding "~" to 'cdpath' doesn't work for completion?  (Davido, 2013 Aug 19)
 
+Plugins need to make a lot of effort, lots of mappings, to know what happened
+before pressing the key that triggers a plugin action.  How about keeping the
+last N pressed keys, so that they do not need to be mapped?
+
 Can assign to s:type when a function s:type has been defined.
 Also the other way around: define a function while a variable with that name
 was already defined.
@@ -151,6 +158,10 @@ Patch for building a 32bit Vim with 64bit MingW compiler.
 (Michael Soyka, 2014 Oct 15)
 
 Delete old code in os_msdos.c, mch_FullName().
+
+Redo only remembers the last change.  Could use "{count}g." to redo an older
+change.  How does the user know which change?  At least have a way to list
+them: ":repeats".
 
 Using "." to repeat an Ex command puts that command in history.  Probably
 should not happen.  If the command is the result of a mapping it's not put in
@@ -286,11 +297,7 @@ Patch to add v:completed_item. (Shougo Matsu, 2013 Nov 29).
 
 Patch to get MSVC version in a nicer way. (Ken Takata, 2014 Jul 24)
 
-Patch to make test 100 work on MS-Windows. (Taro Muraoka, 2013 Dec 12)
-
 Patch to define macros for hardcoded values. (Elias Diem, 2013 Dec 14)
-
-Perl: support for Activestate perl 5.18: Issue 170.
 
 Several syntax file match "^\s*" which may get underlined if that's in the
 highlight group.  Add a "\zs" after it?
@@ -427,9 +434,6 @@ Second one. Update May 22.
 Update by Daniel Hahler, 2014 Jul 4, Aug 14, Oct 14, Oct 15.
 
 Patch to make fold updates much faster. (Christian Brabandt, 2012 Dec)
-
-MS-Windows: Patch to make tests copy files to avoid changing the fileformat of
-the files under version control. (Taro Muraoka, 2013 Jul 5)
 
 Issue 54: document behavior of -complete, also expands arg.
 
@@ -1507,8 +1511,6 @@ Changes for Win32 makefile. (Mike Williams, 2007 Jan 22, Alexei Alexandrov,
 
 Win32: Can't complete shell command names.  Why is setting xp_context in
 set_one_cmd_context() inside #ifndef BACKSLASH_IN_FILENAME?
-
-Win32: Patch for convert_filterW(). (Taro Muraoka, 2007 Mar 2)
 
 Win32: Patch for cscope external command. (Mike Williams, 2007 Aug 7)
 

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,7 @@
 " These commands create the option window.
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Oct 09
+" Last Change:	2014 Nov 19
 
 " If there already is an option window, jump to that one.
 if bufwinnr("option-window") > 0
@@ -149,7 +149,7 @@ setlocal ts=15 tw=0 noro buftype=nofile
 call append(0, '" Each "set" line shows the current value of an option (on the left).')
 call append(1, '" Hit <CR> on a "set" line to execute it.')
 call append(2, '"            A boolean option will be toggled.')
-call append(3, '"            For other options you can edit the value.')
+call append(3, '"            For other options you can edit the value before hitting <CR>.')
 call append(4, '" Hit <CR> on a help line to open a help window on this option.')
 call append(5, '" Hit <CR> on an index line to jump there.')
 call append(6, '" Hit <Space> on a "set" line to refresh it.')
@@ -1145,8 +1145,10 @@ if has("keymap")
   call <SID>OptionL("kmp")
 endif
 if has("langmap")
-  call append("$", "langmap\ttranslate characters for Normal mode")
+  call append("$", "langmap\tlist of characters that are translated in Normal mode")
   call <SID>OptionG("lmap", &lmap)
+  call append("$", "langnoremap\tdon't apply 'langmap' to mapped characters")
+  call <SID>BinOptionG("lnr", &lnr)
 endif
 if has("xim")
   call append("$", "imdisable\twhen set never use IM; overrules following IM options")

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	C
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Sep 23
+" Last Change:	2014 Nov 13
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -61,10 +61,9 @@ else
   syn region	cCppString	start=+L\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
 endif
 
-syn region	cCppOut2	contained start="0" end="^\s*\(%:\|#\)\s*\(endif\>\|else\>\|elif\>\)" contains=cSpaceError,cCppSkip
 syn region	cCppSkip	contained start="^\s*\(%:\|#\)\s*\(if\>\|ifdef\>\|ifndef\>\)" skip="\\$" end="^\s*\(%:\|#\)\s*endif\>" contains=cSpaceError,cCppSkip
 
-syn cluster	cStringGroup	contains=cCppString,cCppOut2,cCppSkip
+syn cluster	cStringGroup	contains=cCppString,cCppSkip
 
 syn match	cCharacter	"L\='[^\\]'"
 syn match	cCharacter	"L'[^']*'" contains=cSpecial
@@ -462,8 +461,7 @@ hi def link cTodo		Todo
 hi def link cBadContinuation	Error
 hi def link cCppOutSkip		cCppOutIf2
 hi def link cCppInElse2		cCppOutIf2
-hi def link cCppOutIf2		cCppOut2  " Old syntax group for #if 0 body
-hi def link cCppOut2		cCppOut  " Old syntax group for #if of #if 0
+hi def link cCppOutIf2		cCppOut
 hi def link cCppOut		Comment
 
 let b:current_syntax = "c"


### PR DESCRIPTION
Update runtime files.

Port upstream patch f654ad9. Resolves issue #1999.

Original patch:
https://code.google.com/p/vim/source/detail?r=f654ad95fd4e

Signed-off-by: Perry Hung iperry@gmail.com

PR notes: pretty straightforward port. Left out some irrelevant todo.txt patches.

``` diff
diff --git a/runtime/doc/editing.txt b/runtime/doc/editing.txt
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1,4 +1,4 @@
-*editing.txt*   For Vim version 7.4.  Last change: 2014 Nov 12
+*editing.txt*   For Vim version 7.4.  Last change: 2014 Nov 19


          VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1080,9 +1080,12 @@ 5. Writing and quitting                  *write-quit*
            the last file in the argument list has not been
            edited.  See |:confirm| and 'confirm'.  {not in Vi}

-:q[uit]!       Quit without writing, also when visible buffers have
-           changes.  Does not exit when there are changed hidden
-           buffers.  Use ":qall!" to exit always.
+:q[uit]!       Quit without writing, also when currently visible
+           buffers have changes.  Does not exit when this is the
+           last window and there are is a changed hidden buffer.
+           In this case, the first changed hidden buffer becomes
+           the current buffer.
+           Use ":qall!" to exit always.

 :cq[uit]       Quit always, without writing, and return an error
            code.  See |:cq|.  Used for Manx's QuickFix mode (see
diff --git a/runtime/doc/eval.txt b/runtime/doc/eval.txt
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt* For Vim version 7.4.  Last change: 2014 Nov 05
+*eval.txt* For Vim version 7.4.  Last change: 2014 Nov 15


          VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1755,8 +1755,8 @@ count( {list}, {expr} [, {ic} [, {start}
                Number   count how many {expr} are in {list}
 cscope_connection( [{num} , {dbpath} [, {prepend}]])
                Number  checks existence of cscope connection
-cursor( {lnum}, {col} [, {coladd}])
-               Number  move cursor to {lnum}, {col}, {coladd}
+cursor( {lnum}, {col} [, {off}])
+               Number  move cursor to {lnum}, {col}, {off}
 cursor( {list})            Number  move cursor to position in {list}
 deepcopy( {expr} [, {noref}])  any make a full copy of {expr}
 delete( {fname})       Number  delete file {fname}
@@ -2623,6 +2623,7 @@ cursor({list})
        If {col} is zero, the cursor will stay in the current column.
        If {curswant} is given it is used to set the preferred column
        for vertical movement.  Otherwise {col} is used.
+
        When 'virtualedit' is used {off} specifies the offset in
        screen columns from the start of the character.  E.g., a
        position within a <Tab> or after the last character.
@@ -4851,7 +4852,7 @@ readfile({fname} [, {binary} [, {max}]])
        separated with CR will result in a single long line (unless a
        NL appears somewhere).
        All NUL characters are replaced with a NL character.
-       When {binary/append} is contains "b" binary mode is used:
+       When {binary/append} contains "b" binary mode is used:
        - When the last line ends in a NL an extra empty list item is
          added.
        - No CR characters are removed.
diff --git a/runtime/doc/quickref.txt b/runtime/doc/quickref.txt
--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -1,4 +1,4 @@
-*quickref.txt*  For Vim version 7.4.  Last change: 2014 Oct 22
+*quickref.txt*  For Vim version 7.4.  Last change: 2014 Nov 19


          VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -764,6 +764,7 @@ Short explanation of each option:       *opti
 'keywordprg'     'kp'      program to use for the "K" command
 'langmap'    'lmap'    alphabetic characters for other language mode
 'langmenu'   'lm'      language to be used for the menus
+'langnoremap'    'lnr'     do not apply 'langmap' to mapped characters
 'laststatus'     'ls'      tells when last window has status lines
 'lazyredraw'     'lz'      don't redraw while executing macros
 'linebreak'      'lbr'     wrap long lines at a blank
diff --git a/runtime/doc/todo.txt b/runtime/doc/todo.txt
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 7.4.  Last change: 2014 Nov 13
+*todo.txt*      For Vim version 7.4.  Last change: 2014 Nov 19


          VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -34,8 +34,6 @@ not be repeated below, unless there is e
                            *known-bugs*
 -------------------- Known bugs and current work -----------------------

-Add langnoremap in quickref.txt and  optwin.vim.
-
 Regexp problems:
 - The NFA engine does not implement the time limit passed to
   nfa_regexec_multi()
@@ -77,8 +75,6 @@ 14, Aug 30)
 Doesn't look right, asked for updates.
 Update 2014 Nov 8. Replied with suggestions.

-C macro with number highlighted wrong. (Dominique Pelle, 2014 Oct 23)
-
 The entries added by matchaddpos() are returned by getmatches() but can't be
 set with setmatches(). (lcd47, 2014 Jun 29)

@@ -88,14 +84,19 @@ Problem using ":try" inside ":execute". 

 Python: ":py raw_input('prompt')" doesn't work. (Manu Hack)

-Patch to fix issue 203. (Christian Brabandt, 2014 Oct 8)
-
 Patch to fix issue 78. (Christian Brabandt, 2014 Oct 8)

 Patch to fix leak in map() with error. (Christian Brabandt, 2014 Oct 11)

 Patch to fix incsearch for "2/pattern/e".

+Patch to fix memory leak in :hardcopy. (Christian Brabandt, 2014 Nov 16)
+
+Patch to fix warnings in if_ruby.c. (Ken Takata, 2014 Nov 17)
+
+Patch to make test 63 pass when in a B&W terminal. (Christian Brabandt, 2014
+Nov 15)  Other patch (better) on Nov 17.
+
 Change behavior of v:hlsearch?  Patch from Christian, 2014 Oct 22.

 MS-Windows: When editing a file with a leading space, writing it uses the
@@ -106,14 +107,16 @@ patch to remove FEAT_OSFILETYPE from fil
 Value returned by virtcol() changes depending on how lines wrap.  This is
 inconsistent with the documentation.

-Fix for wrong formatting if 'linebreak' is set. (Christian Brabandt, 2014 Nov
-12)
+Patch to fix relatie numbers. (Christian Brabandt, 2014 Nov 17)
+
+Patch to fix wrong formatting if 'linebreak' is set. (Christian Brabandt, 2014
+Nov 12)

 Patch to support hex values for setting option value.
 (Zyx, 2015 Nov 6)

-On MS-Windows running tests with Mercurial has problems when the input files
-are changed. (Ken Takata, Taro Muraoka, 2014 Sep 25)
+On MS-Windows running tests with Mercurial has problems when the fileformat of
+the input files are changed. (Ken Takata, Taro Muraoka, 2014 Sep 25)
 Update Nov 5.

 MS-Windows: Crash opening very long file name starting with "\\".
@@ -140,6 +143,10 @@ lines. (Marco Hinz, 2014 Nov 2)

 Adding "~" to 'cdpath' doesn't work for completion?  (Davido, 2013 Aug 19)

+Plugins need to make a lot of effort, lots of mappings, to know what happened
+before pressing the key that triggers a plugin action.  How about keeping the
+last N pressed keys, so that they do not need to be mapped?
+
 Can assign to s:type when a function s:type has been defined.
 Also the other way around: define a function while a variable with that name
 was already defined.
@@ -152,6 +159,10 @@ Patch for building a 32bit Vim with 64bi

 Delete old code in os_msdos.c, mch_FullName().

+Redo only remembers the last change.  Could use "{count}g." to redo an older
+change.  How does the user know which change?  At least have a way to list
+them: ":repeats".
+
 Using "." to repeat an Ex command puts that command in history.  Probably
 should not happen.  If the command is the result of a mapping it's not put in
 history either. (Jacob Niehus, 2014 Nov 2)
@@ -289,12 +300,8 @@ Patch to add v:completed_item. (Shougo M

 Patch to get MSVC version in a nicer way. (Ken Takata, 2014 Jul 24)

-Patch to make test 100 work on MS-Windows. (Taro Muraoka, 2013 Dec 12)
-
 Patch to define macros for hardcoded values. (Elias Diem, 2013 Dec 14)

-Perl: support for Activestate perl 5.18: Issue 170.
-
 Several syntax file match "^\s*" which may get underlined if that's in the
 highlight group.  Add a "\zs" after it?

@@ -439,9 +446,6 @@ Update by Daniel Hahler, 2014 Jul 4, Aug

 Patch to make fold updates much faster. (Christian Brabandt, 2012 Dec)

-MS-Windows: Patch to make tests copy files to avoid changing the fileformat of
-the files under version control. (Taro Muraoka, 2013 Jul 5)
-
 Issue 54: document behavior of -complete, also expands arg.

 -   Add regex for 'paragraphs' and 'sections': 'parare' and 'sectre'.  Combine
@@ -1560,8 +1564,6 @@ 2007 Feb 8)
 Win32: Can't complete shell command names.  Why is setting xp_context in
 set_one_cmd_context() inside #ifndef BACKSLASH_IN_FILENAME?

-Win32: Patch for convert_filterW(). (Taro Muraoka, 2007 Mar 2)
-
 Win32: Patch for cscope external command. (Mike Williams, 2007 Aug 7)

 Win32: XPM support only works with path without spaces.  Patch by Mathias
diff --git a/runtime/optwin.vim b/runtime/optwin.vim
--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,7 @@
 " These commands create the option window.
 "
 " Maintainer:  Bram Moolenaar <Bram@vim.org>
-" Last Change: 2014 Oct 09
+" Last Change: 2014 Nov 19

 " If there already is an option window, jump to that one.
 if bufwinnr("option-window") > 0
@@ -149,7 +149,7 @@ setlocal ts=15 tw=0 noro buftype=nofile
 call append(0, '" Each "set" line shows the current value of an option (on the left).')
 call append(1, '" Hit <CR> on a "set" line to execute it.')
 call append(2, '"            A boolean option will be toggled.')
-call append(3, '"            For other options you can edit the value.')
+call append(3, '"            For other options you can edit the value before hitting <CR>.')
 call append(4, '" Hit <CR> on a help line to open a help window on this option.')
 call append(5, '" Hit <CR> on an index line to jump there.')
 call append(6, '" Hit <Space> on a "set" line to refresh it.')
@@ -1194,8 +1194,10 @@ if has("keymap")
   call <SID>OptionL("kmp")
 endif
 if has("langmap")
-  call append("$", "langmap\ttranslate characters for Normal mode")
+  call append("$", "langmap\tlist of characters that are translated in Normal mode")
   call <SID>OptionG("lmap", &lmap)
+  call append("$", "langnoremap\tdon't apply 'langmap' to mapped characters")
+  call <SID>BinOptionG("lnr", &lnr)
 endif
 if has("xim")
   call append("$", "imdisable\twhen set never use IM; overrules following IM options")
diff --git a/runtime/syntax/c.vim b/runtime/syntax/c.vim
--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:    C
 " Maintainer:  Bram Moolenaar <Bram@vim.org>
-" Last Change: 2014 Sep 23
+" Last Change: 2014 Nov 13

 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -61,10 +61,9 @@ else
   syn region   cCppString  start=+L\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
 endif

-syn region cCppOut2    contained start="0" end="^\s*\(%:\|#\)\s*\(endif\>\|else\>\|elif\>\)" contains=cSpaceError,cCppSkip
 syn region cCppSkip    contained start="^\s*\(%:\|#\)\s*\(if\>\|ifdef\>\|ifndef\>\)" skip="\\$" end="^\s*\(%:\|#\)\s*endif\>" contains=cSpaceError,cCppSkip

-syn cluster    cStringGroup    contains=cCppString,cCppOut2,cCppSkip
+syn cluster    cStringGroup    contains=cCppString,cCppSkip

 syn match  cCharacter  "L\='[^\\]'"
 syn match  cCharacter  "L'[^']*'" contains=cSpecial
@@ -462,8 +461,7 @@ hi def link cTodo       Todo
 hi def link cBadContinuation   Error
 hi def link cCppOutSkip        cCppOutIf2
 hi def link cCppInElse2        cCppOutIf2
-hi def link cCppOutIf2     cCppOut2  " Old syntax group for #if 0 body
-hi def link cCppOut2       cCppOut  " Old syntax group for #if of #if 0
+hi def link cCppOutIf2     cCppOut
 hi def link cCppOut        Comment

 let b:current_syntax = "c"
```
