### PR TITLE
[RFC] Simplify UI mode change API and use underline cursor in Replace mode

### DIFF
--- a/src/nvim/msgpack_rpc/remote_ui.c
+++ b/src/nvim/msgpack_rpc/remote_ui.c
@@ -218,6 +218,8 @@ static void remote_ui_change_mode(UI *ui, int mode)
   Array args = ARRAY_DICT_INIT;
   if (mode == INSERT) {
     ADD(args, STRING_OBJ(cstr_to_string("insert")));
+  } else if (mode == REPLACE) {
+    ADD(args, STRING_OBJ(cstr_to_string("replace")));
   } else {
     assert(mode == NORMAL);
     ADD(args, STRING_OBJ(cstr_to_string("normal")));

--- a/src/nvim/msgpack_rpc/remote_ui.c
+++ b/src/nvim/msgpack_rpc/remote_ui.c
@@ -86,8 +86,7 @@ static Object remote_ui_attach(uint64_t channel_id, uint64_t request_id,
   ui->busy_stop = remote_ui_busy_stop;
   ui->mouse_on = remote_ui_mouse_on;
   ui->mouse_off = remote_ui_mouse_off;
-  ui->insert_mode = remote_ui_insert_mode;
-  ui->normal_mode = remote_ui_normal_mode;
+  ui->change_mode = remote_ui_change_mode;
   ui->set_scroll_region = remote_ui_set_scroll_region;
   ui->scroll = remote_ui_scroll;
   ui->highlight_set = remote_ui_highlight_set;
@@ -214,16 +213,16 @@ static void remote_ui_mouse_off(UI *ui)
   push_call(ui, "mouse_off", args);
 }
 
-static void remote_ui_insert_mode(UI *ui)
+static void remote_ui_change_mode(UI *ui, int mode)
 {
   Array args = ARRAY_DICT_INIT;
-  push_call(ui, "insert_mode", args);
-}
-
-static void remote_ui_normal_mode(UI *ui)
-{
-  Array args = ARRAY_DICT_INIT;
-  push_call(ui, "normal_mode", args);
+  if (mode == INSERT) {
+    ADD(args, STRING_OBJ(cstr_to_string("insert")));
+  } else {
+    assert(mode == NORMAL);
+    ADD(args, STRING_OBJ(cstr_to_string("normal")));
+  }
+  push_call(ui, "change_mode", args);
 }
 
 static void remote_ui_set_scroll_region(UI *ui, int top, int bot, int left,

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -61,7 +61,7 @@ typedef struct {
   struct {
     int enable_mouse, disable_mouse;
     int enable_bracketed_paste, disable_bracketed_paste;
-    int enter_insert_mode, exit_insert_mode;
+    int enter_insert_mode, enter_replace_mode, exit_insert_mode;
     int set_rgb_foreground, set_rgb_background;
   } unibi_ext;
 } TUIData;
@@ -105,6 +105,7 @@ UI *tui_start(void)
   data->unibi_ext.enable_bracketed_paste = -1;
   data->unibi_ext.disable_bracketed_paste = -1;
   data->unibi_ext.enter_insert_mode = -1;
+  data->unibi_ext.enter_replace_mode = -1;
   data->unibi_ext.exit_insert_mode = -1;
 
   // write output to stderr if stdout is not a tty
@@ -412,6 +413,10 @@ static void tui_change_mode(UI *ui, int mode)
   if (mode == INSERT) {
     if (data->showing_mode != INSERT) {
       unibi_out(ui, data->unibi_ext.enter_insert_mode);
+    }
+  } else if (mode == REPLACE) {
+    if (data->showing_mode != REPLACE) {
+      unibi_out(ui, data->unibi_ext.enter_replace_mode);
     }
   } else {
     assert(mode == NORMAL);
@@ -810,12 +815,16 @@ static void fix_terminfo(TUIData *data)
     // iterm
     data->unibi_ext.enter_insert_mode = (int)unibi_add_ext_str(ut, NULL,
         TMUX_WRAP("\x1b]50;CursorShape=1;BlinkingCursorEnabled=1\x07"));
+    data->unibi_ext.enter_replace_mode = (int)unibi_add_ext_str(ut, NULL,
+        TMUX_WRAP("\x1b]50;CursorShape=2;BlinkingCursorEnabled=1\x07"));
     data->unibi_ext.exit_insert_mode = (int)unibi_add_ext_str(ut, NULL,
         TMUX_WRAP("\x1b]50;CursorShape=0;BlinkingCursorEnabled=0\x07"));
   } else {
     // xterm-like sequences for blinking bar and solid block
     data->unibi_ext.enter_insert_mode = (int)unibi_add_ext_str(ut, NULL,
         TMUX_WRAP("\x1b[5 q"));
+    data->unibi_ext.enter_replace_mode = (int)unibi_add_ext_str(ut, NULL,
+        TMUX_WRAP("\x1b[3 q"));
     data->unibi_ext.exit_insert_mode = (int)unibi_add_ext_str(ut, NULL,
         TMUX_WRAP("\x1b[2 q"));
   }

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -57,6 +57,7 @@ typedef struct {
   bool busy;
   HlAttrs attrs, print_attrs;
   Cell **screen;
+  int showing_mode;
   struct {
     int enable_mouse, disable_mouse;
     int enable_bracketed_paste, disable_bracketed_paste;
@@ -98,6 +99,7 @@ UI *tui_start(void)
   data->can_use_terminal_scroll = true;
   data->bufpos = 0;
   data->bufsize = sizeof(data->buf) - CNORM_COMMAND_MAX_SIZE;
+  data->showing_mode = 0;
   data->unibi_ext.enable_mouse = -1;
   data->unibi_ext.disable_mouse = -1;
   data->unibi_ext.enable_bracketed_paste = -1;
@@ -148,8 +150,7 @@ UI *tui_start(void)
   ui->busy_stop = tui_busy_stop;
   ui->mouse_on = tui_mouse_on;
   ui->mouse_off = tui_mouse_off;
-  ui->insert_mode = tui_insert_mode;
-  ui->normal_mode = tui_normal_mode;
+  ui->change_mode = tui_change_mode;
   ui->set_scroll_region = tui_set_scroll_region;
   ui->scroll = tui_scroll;
   ui->highlight_set = tui_highlight_set;
@@ -178,7 +179,7 @@ static void tui_stop(UI *ui)
   // Destroy input stuff
   term_input_destroy(data->input);
   // Destroy output stuff
-  tui_normal_mode(ui);
+  tui_change_mode(ui, NORMAL);
   tui_mouse_off(ui);
   unibi_out(ui, unibi_exit_attribute_mode);
   // cursor should be set to normal before exiting alternate screen
@@ -404,16 +405,21 @@ static void tui_mouse_off(UI *ui)
   data->mouse_enabled = false;
 }
 
-static void tui_insert_mode(UI *ui)
+static void tui_change_mode(UI *ui, int mode)
 {
   TUIData *data = ui->data;
-  unibi_out(ui, data->unibi_ext.enter_insert_mode);
-}
 
-static void tui_normal_mode(UI *ui)
-{
-  TUIData *data = ui->data;
-  unibi_out(ui, data->unibi_ext.exit_insert_mode);
+  if (mode == INSERT) {
+    if (data->showing_mode != INSERT) {
+      unibi_out(ui, data->unibi_ext.enter_insert_mode);
+    }
+  } else {
+    assert(mode == NORMAL);
+    if (data->showing_mode != NORMAL) {
+      unibi_out(ui, data->unibi_ext.exit_insert_mode);
+    }
+  }
+  data->showing_mode = mode;
 }
 
 static void tui_set_scroll_region(UI *ui, int top, int bot, int left,

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -471,23 +471,16 @@ static void flush_cursor_update(void)
 // shape, for example.
 static void ui_change_mode(void)
 {
-  static int showing_insert_mode = MAYBE;
-
+  int mode;
   if (!full_screen) {
     return;
   }
-
-  if (State & INSERT) {
-    if (showing_insert_mode != TRUE) {
-      UI_CALL(insert_mode);
-    }
-    showing_insert_mode = TRUE;
-  } else {
-    if (showing_insert_mode != FALSE) {
-      UI_CALL(normal_mode);
-    }
-    showing_insert_mode = FALSE;
-  }
+  /* Get a simple UI mode out of State. */
+  if (State & INSERT)
+    mode = INSERT;
+  else
+    mode = NORMAL;
+  UI_CALL(change_mode, mode);
   conceal_check_cursur_line();
 }
 

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -476,7 +476,9 @@ static void ui_change_mode(void)
     return;
   }
   /* Get a simple UI mode out of State. */
-  if (State & INSERT)
+  if ((State & REPLACE) == REPLACE)
+    mode = REPLACE;
+  else if (State & INSERT)
     mode = INSERT;
   else
     mode = NORMAL;

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -24,8 +24,7 @@ struct ui_t {
   void (*busy_stop)(UI *ui);
   void (*mouse_on)(UI *ui);
   void (*mouse_off)(UI *ui);
-  void (*insert_mode)(UI *ui);
-  void (*normal_mode)(UI *ui);
+  void (*change_mode)(UI *ui, int mode);
   void (*set_scroll_region)(UI *ui, int top, int bot, int left, int right);
   void (*scroll)(UI *ui, int count);
   void (*highlight_set)(UI *ui, HlAttrs attrs);

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -341,7 +341,7 @@ function Screen:_handle_mouse_off()
 end
 
 function Screen:_handle_change_mode(mode)
-  assert(mode == 'insert' or mode == 'normal')
+  assert(mode == 'insert' or mode == 'replace' or mode == 'normal')
   self._mode = mode
 end
 

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -340,12 +340,9 @@ function Screen:_handle_mouse_off()
   self._mouse_enabled = false
 end
 
-function Screen:_handle_insert_mode()
-  self._mode = 'insert'
-end
-
-function Screen:_handle_normal_mode()
-  self._mode = 'normal'
+function Screen:_handle_change_mode(mode)
+  assert(mode == 'insert' or mode == 'normal')
+  self._mode = mode
 end
 
 function Screen:_handle_set_scroll_region(top, bot, left, right)


### PR DESCRIPTION
Vim as of recently supports having a separate cursor shape for Replace mode (e.g., an underline, like in gVim). I contributed the original patch to Vim; now that I want to try out Neovim, I missed this feature, so I figured I should contribute it. It's not a mechanical forward-port, as the TUI code is very different in Neovim.

Problem:    There is no way to use a different in Replace mode for a terminal.
Solution:   Add t_SR. (Omar Sandoval)

https://github.com/vim/vim/commit/v7-4-687

The TUI code has been heavily refactored (see esp. 25ceadab37edb ("tui:
Remove support for overriding escape sequences with nvim options")), so
this forward-port required some translation.
