### PR TITLE
[RFC] Reset libuv stop_flag after terminal_teardown()

### DIFF
--- a/src/nvim/os/event.c
+++ b/src/nvim/os/event.c
@@ -69,16 +69,16 @@ void event_teardown(void)
 
   process_events_from(immediate_events);
   process_events_from(deferred_events);
-  // reset the stop_flag to ensure `uv_run` below won't exit early. This hack
-  // is required because the `process_events_from` above may call `event_push`
-  // which will set the stop_flag to 1(uv_stop)
-  uv_default_loop()->stop_flag = 0;
   input_stop();
   channel_teardown();
   job_teardown();
   server_teardown();
   signal_teardown();
   terminal_teardown();
+  // reset the stop_flag to ensure `uv_run` below won't exit early. This hack
+  // is required because the `process_events_from` above may call `event_push`
+  // which will set the stop_flag to 1(uv_stop)
+  uv_default_loop()->stop_flag = 0;
   // this last `uv_run` will return after all handles are stopped, it will
   // also take care of finishing any uv_close calls made by other *_teardown
   // functions.


### PR DESCRIPTION
When shutting down, in event_teardown(), the event loop stop_flag
is set to 0 to prevent the final call to uv_run() to exit early.
However the later call to terminal_teardown() calls tui_stop()
that can also call uv_stop() setting the flag again.

Failling to properly terminate the loop triggers an abort in
event_teardown(), moved the flag reset after the call to
terminal_teardown() to avoid it - #2466, #2648.
