### PR TITLE
[RFC] msgpack-rpc: handle failure to convert method arguments

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -464,7 +464,11 @@ static void handle_request(Channel *channel, msgpack_object *request)
   }
 
   Array args = ARRAY_DICT_INIT;
-  msgpack_rpc_to_array(msgpack_rpc_args(request), &args);
+  if (!msgpack_rpc_to_array(msgpack_rpc_args(request), &args)) {
+    handler.fn = msgpack_rpc_handle_invalid_arguments;
+    handler.defer = false;
+  }
+
   bool defer = (!kv_size(channel->call_stack) && handler.defer);
   RequestEvent *event_data = xmalloc(sizeof(RequestEvent));
   event_data->channel = channel;

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -306,6 +306,17 @@ Object msgpack_rpc_handle_missing_method(uint64_t channel_id,
   return NIL;
 }
 
+/// Handler executed when malformated arguments are passed
+Object msgpack_rpc_handle_invalid_arguments(uint64_t channel_id,
+                                         uint64_t request_id,
+                                         Array args,
+                                         Error *error)
+{
+  snprintf(error->msg, sizeof(error->msg), "Invalid method arguments");
+  error->set = true;
+  return NIL;
+}
+
 /// Serializes a msgpack-rpc request or notification(id == 0)
 void msgpack_rpc_serialize_request(uint64_t request_id,
                                    String method,


### PR DESCRIPTION
The conversion from msgpack rpc objects to nvim api Objects might fail, but this error is ignored, so confusing errors might instead be reported in the generated wrapper functions. (but I don't think it could lead to a crash). 

I discovered this because I sent an invalid buffer object to `buffer_get_line`, but instead nvim complained on the second `Integer` parameter.
