### PR TITLE
[RFC] cmake: Pass MIN_LOG_LEVEL as compiler definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
     - PATH="$(python2.7 -c 'import site; print(site.getuserbase())')/bin:$HOME/.local/mingw32/bin:$PATH"
     # LLVM symbolizer path.
     - LLVM_SYMBOLIZER="$(which llvm-symbolizer-3.6)"
-    # Force verification of DLOG macros.
-    - CFLAGS="-DMIN_LOG_LEVEL=0"
     # Build directory for Neovim.
     - BUILD_DIR="$TRAVIS_BUILD_DIR/build"
     # Build directory for third-party dependencies.
@@ -29,7 +27,8 @@ env:
                    -DCMAKE_BUILD_TYPE=Debug
                    -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PREFIX
                    -DBUSTED_OUTPUT_TYPE=gtest
-                   -DDEPS_PREFIX=$DEPS_BUILD_DIR/usr"
+                   -DDEPS_PREFIX=$DEPS_BUILD_DIR/usr
+                   -DMIN_LOG_LEVEL=0"
     - DEPS_CMAKE_FLAGS="-DDEPS_DOWNLOAD_DIR:PATH=$DEPS_DOWNLOAD_DIR"
     # Additional CMake flags for 32-bit builds.
     - CMAKE_FLAGS_32BIT="-DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,6 +381,16 @@ install_helper(
   FILES ${MANPAGES}
   DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
+# MIN_LOG_LEVEL for log.h
+if(DEFINED MIN_LOG_LEVEL)
+  if(NOT MIN_LOG_LEVEL MATCHES "^[0-3]$")
+    message(FATAL_ERROR "MIN_LOG_LEVEL must be a number DEBUG (0), INFO (1), WARNING (2) or ERROR (3)")
+  endif()
+  message(STATUS "Log level set to ${MIN_LOG_LEVEL}")
+else()
+  message(STATUS "Log level not specified, defaulting to INFO(1)")
+endif()
+
 # Go down the tree.
 
 add_subdirectory(src/nvim)

--- a/contrib/local.mk.example
+++ b/contrib/local.mk.example
@@ -31,6 +31,11 @@
 #
 # CMAKE_BUILD_TYPE := Debug
 
+# By default, nvim's log level is INFO (1) (unless CMAKE_BUILD_TYPE is
+# "Release", in which case logging is disabled).
+# The log level must be a number DEBUG (0), INFO (1), WARNING (2) or ERROR (3).
+# CMAKE_EXTRA_FLAGS += -DMIN_LOG_LEVEL=1
+
 # By default, nvim uses bundled versions of its required third-party
 # dependencies.
 # Uncomment these entries to instead use system-wide installations of

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -108,6 +108,10 @@ if(NOT MSVC)
     ${CONV_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-conversion")
 endif()
 
+if(DEFINED MIN_LOG_LEVEL)
+  add_definitions(-DMIN_LOG_LEVEL=${MIN_LOG_LEVEL})
+endif()
+
 get_directory_property(gen_cdefs COMPILE_DEFINITIONS)
 foreach(gen_cdef ${gen_cdefs} DO_NOT_DEFINE_EMPTY_ATTRIBUTES)
   if(NOT "${gen_cdef}" MATCHES "INCLUDE_GENERATED_DECLARATIONS")


### PR DESCRIPTION
Allow MIN_LOG_LEVEL to be set as a CMake define.

And maybe put something in local.mk and the wiki, I don't think this is documented anywhere.
