### PR TITLE
[RFC] Remove 'octal' from default value for '&nrformats'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4695,7 +4695,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	recognized as a multi click.
 
 							*'nrformats'* *'nf'*
-'nrformats' 'nf'	string	(default "octal,hex")
+'nrformats' 'nf'	string	(default "hex")
 			local to buffer
 	This defines what bases Vim will consider for numbers when using the
 	CTRL-A and CTRL-X commands for adding to and subtracting from a number

--- a/runtime/doc/usr_26.txt
+++ b/runtime/doc/usr_26.txt
@@ -81,24 +81,15 @@ Move the cursor to "1." and type: >
 The "1." will change to "4.".  Again, you can use "." to repeat this on the
 other numbers.
 
-Another example:
-
-	006	foo bar ~
-	007	foo bar ~
-
-Using CTRL-A on these numbers results in:
-
-	007	foo bar ~
-	010	foo bar ~
-
-7 plus one is 10?  What happened here is that Vim recognized "007" as an octal
-number, because there is a leading zero.  This notation is often used in C
-programs.  If you do not want a number with leading zeros to be handled as
-octal, use this: >
-
-	:set nrformats-=octal
-
 The CTRL-X command does subtraction in a similar way.
+
+The behavior of CTRL-A and CTRL-X depends on the value of |'nrformats'|. For
+example, if you use: >
+
+        :set nrformats+=octal
+
+pressing CTRL-A over "007" will increment to "010", because "007" will be
+identified as an octal number.
 
 ==============================================================================
 *26.3*	Making a change in many files

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -32,6 +32,7 @@ these differences.
 - 'encoding' defaults to "utf-8"
 - 'formatoptions' defaults to "tcqj"
 - 'nocompatible' is always set
+- 'nrformats' defaults to "hex"
 - 'tags' defaults to "./tags;,tags"
 - 'ttyfast' is always set
 - 'wildmenu' is set by default

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1136,9 +1136,9 @@ static vimoption_T
   {"mousetime",   "mouset",   P_NUM|P_VI_DEF,
    (char_u *)&p_mouset, PV_NONE,
    {(char_u *)500L, (char_u *)0L} SCRIPTID_INIT},
-  {"nrformats",   "nf",   P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
+  {"nrformats",   "nf",   P_STRING|P_ALLOCED|P_VIM|P_COMMA|P_NODUP,
    (char_u *)&p_nf, PV_NF,
-   {(char_u *)"octal,hex", (char_u *)0L}
+   {(char_u *)"octal,hex", (char_u *)"hex"}
    SCRIPTID_INIT},
   {"number",      "nu",   P_BOOL|P_VI_DEF|P_RWIN,
    VAR_WIN, PV_NU,


### PR DESCRIPTION
`<C-A>` over "07" should increment to "08" by default.

Re: https://github.com/neovim/neovim/issues/1664
