### PR TITLE
[RFC] Include 'j' in default '&formatoptions'

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1450,9 +1450,8 @@ By default, "b:#" is included.  This means that a line that starts with
 
 							*fo-table*
 You can use the 'formatoptions' option  to influence how Vim formats text.
-'formatoptions' is a string that can contain any of the letters below.  The
-default setting is "tcq".  You can separate the option letters with commas for
-readability.
+'formatoptions' is a string that can contain any of the letters below.  You
+can separate the option letters with commas for readability.
 
 letter	 meaning when present in 'formatoptions'    ~
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2912,7 +2912,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	evaluating 'foldtext' |textlock|.
 
 					*'formatoptions'* *'fo'*
-'formatoptions' 'fo'	string (Vim default: "tcq", Vi default: "vt")
+'formatoptions' 'fo'	string (default: "tcqj", Vi default: "vt")
 			local to buffer
 	This is a sequence of letters which describes how automatic
 	formatting is to be done.  See |fo-table|.  When the 'paste' option is

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -30,6 +30,7 @@ these differences.
 
 - 'backspace' defaults to "indent,eol,start"
 - 'encoding' defaults to "utf-8"
+- 'formatoptions' defaults to "tcqj"
 - 'nocompatible' is always set
 - 'ttyfast' is always set
 

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -79,7 +79,7 @@
 #define FO_REMOVE_COMS  'j'     /* remove comment leaders when joining lines */
 
 #define DFLT_FO_VI      "vt"
-#define DFLT_FO_VIM     "tcq"
+#define DFLT_FO_VIM     "tcqj"
 #define FO_ALL          "tcroq2vlb1mMBn,awj"    /* for do_set() */
 
 /* characters for the p_cpo option: */


### PR DESCRIPTION
Re: https://github.com/neovim/neovim/issues/1664
