### PR TITLE
[RFC]fix flicker in popup menu

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2464,6 +2464,14 @@ void ins_compl_show_pum(void)
     /* Need to build the popup menu list. */
     compl_match_arraysize = 0;
     compl = compl_first_match;
+    /*
+     * If it's user complete function and refresh_always,
+     * not use "compl_leader" as prefix filter.
+     */
+    if (ins_compl_need_restart()){
+      xfree(compl_leader);
+      compl_leader = NULL;
+    }
     if (compl_leader != NULL)
       lead_len = (int)STRLEN(compl_leader);
     do {
@@ -2929,15 +2937,8 @@ static void ins_compl_new_leader(void)
     spell_bad_len = 0;          /* need to redetect bad word */
     /*
      * Matches were cleared, need to search for them now.
-     * If it's user complete function and refresh_always,
-     * not use "compl_leader" as prefix filter.
      * Set "compl_restarting" to avoid that the first match is inserted.
      */
-    if ((ctrl_x_mode == CTRL_X_FUNCTION || ctrl_x_mode == CTRL_X_OMNI)
-        && compl_opt_refresh_always){
-      xfree(compl_leader);
-      compl_leader = NULL;
-    }
     compl_restarting = TRUE;
     if (ins_complete(Ctrl_N) == FAIL)
       compl_cont_status = 0;
@@ -2949,8 +2950,9 @@ static void ins_compl_new_leader(void)
   /* Show the popup menu with a different set of matches. */
   ins_compl_show_pum();
 
-  /* Don't let Enter select the original text when there is no popup menu. */
-  if (compl_match_array == NULL)
+  /* Don't let Enter select the original text when there is no popup menu.
+   * Don't let Enter select when use user function and refresh_always is set */
+  if (compl_match_array == NULL || ins_compl_need_restart())
     compl_enter_selects = FALSE;
 }
 
@@ -2981,14 +2983,8 @@ static void ins_compl_addleader(int c)
     (*mb_char2bytes)(c, buf);
     buf[cc] = NUL;
     ins_char_bytes(buf, cc);
-    if ((ctrl_x_mode == CTRL_X_FUNCTION || ctrl_x_mode == CTRL_X_OMNI)
-        && compl_opt_refresh_always)
-      AppendToRedobuff(buf);
   } else {
     ins_char(c);
-    if ((ctrl_x_mode == CTRL_X_FUNCTION || ctrl_x_mode == CTRL_X_OMNI)
-        && compl_opt_refresh_always)
-      AppendCharToRedobuff(c);
   }
 
   /* If we didn't complete finding matches we must search again. */
@@ -3009,7 +3005,7 @@ static void ins_compl_restart(void)
 {
   /* update screen before restart.
    * so if complete is blocked,
-   * will stay to the last popup menu and reduce flick */  
+   * will stay to the last popup menu and reduce flicker */
   update_screen(0);
   ins_compl_free();
   compl_started = FALSE;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2928,11 +2928,16 @@ static void ins_compl_new_leader(void)
   else {
     spell_bad_len = 0;          /* need to redetect bad word */
     /*
-     * Matches were cleared, need to search for them now.  First display
-     * the changed text before the cursor.  Set "compl_restarting" to
-     * avoid that the first match is inserted.
+     * Matches were cleared, need to search for them now.
+     * If it's user complete function and refresh_always,
+     * not use "compl_leader" as prefix filter.
+     * Set "compl_restarting" to avoid that the first match is inserted.
      */
-    update_screen(0);
+    if ((ctrl_x_mode == CTRL_X_FUNCTION || ctrl_x_mode == CTRL_X_OMNI)
+        && compl_opt_refresh_always){
+      xfree(compl_leader);
+      compl_leader = NULL;
+    }
     compl_restarting = TRUE;
     if (ins_complete(Ctrl_N) == FAIL)
       compl_cont_status = 0;
@@ -2976,11 +2981,13 @@ static void ins_compl_addleader(int c)
     (*mb_char2bytes)(c, buf);
     buf[cc] = NUL;
     ins_char_bytes(buf, cc);
-    if (compl_opt_refresh_always)
+    if ((ctrl_x_mode == CTRL_X_FUNCTION || ctrl_x_mode == CTRL_X_OMNI)
+        && compl_opt_refresh_always)
       AppendToRedobuff(buf);
   } else {
     ins_char(c);
-    if (compl_opt_refresh_always)
+    if ((ctrl_x_mode == CTRL_X_FUNCTION || ctrl_x_mode == CTRL_X_OMNI)
+        && compl_opt_refresh_always)
       AppendCharToRedobuff(c);
   }
 
@@ -2988,15 +2995,10 @@ static void ins_compl_addleader(int c)
   if (ins_compl_need_restart())
     ins_compl_restart();
 
-  /* When 'always' is set, don't reset compl_leader. While completing,
-   * cursor doesn't point original position, changing compl_leader would
-   * break redo. */
-  if (!compl_opt_refresh_always) {
-    xfree(compl_leader);
-    compl_leader = vim_strnsave(get_cursor_line_ptr() + compl_col,
-        (int)(curwin->w_cursor.col - compl_col));
-    ins_compl_new_leader();
-  }
+  xfree(compl_leader);
+  compl_leader = vim_strnsave(get_cursor_line_ptr() + compl_col,
+      (int)(curwin->w_cursor.col - compl_col));
+  ins_compl_new_leader();
 }
 
 /*
@@ -3005,6 +3007,10 @@ static void ins_compl_addleader(int c)
  */
 static void ins_compl_restart(void)
 {
+  /* update screen before restart.
+   * so if complete is blocked,
+   * will stay to the last popup menu and reduce flick */  
+  update_screen(0);
   ins_compl_free();
   compl_started = FALSE;
   compl_matches = 0;

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -100,4 +100,43 @@ describe('completion', function()
       eq('', eval('getline(3)'))
     end)
   end)
+  describe('with always option', function ()
+    before_each(function ()
+      source([[
+function! TestCompletion(findstart, base) abort
+  if a:findstart
+    let line = getline('.')
+    let start = col('.') - 1
+    while start > 0 && line[start - 1] =~ '\a'
+      let start -= 1
+    endwhile
+    return start
+  else
+    let ret = []
+    for m in split("January February March April May June July Auguest September October November December")
+      if m =~ a:base            " match by regex
+        call add(ret, m)
+      endif
+    endfor
+    return {'words':ret, 'refresh':'always'}
+  endif
+endfunction
+
+set completeopt=menuone,noselect
+set completefunc=TestCompletion
+      ]])
+    end )
+
+    it('should complete when add more char', function ()
+      -- to select first word after input char:
+      -- <Down><C-y> work, <C-n> not work.
+      -- but <C-n><C-n>work. there may have some bugs with <C-n>
+      feed('i<C-x><C-u>gu<Down><C-y><ESC>')
+      eq('Auguest', eval('getline(1)'))
+    end)
+    it("shouldn't break repeat", function ()
+      feed('o<C-x><C-u>Ja<BS>un<Down><C-y><ESC>', '.')
+      eq('June', eval('getline(3)'))
+    end)
+  end)
 end)


### PR DESCRIPTION
as #2661 says, I spend a day to fix the annoying flicker.

In detail, I `update_screen` before restart_complete, and remove `update_screen` in `ins_compl_new_leader`, so the screen will stay with last popup menu, until the complete function returns  and update screen. Instead of block without popup menu, which disappear and reappear, causing flicker.

Another change is when typed char, call the `ins_compl_new_leader` even `refresh_always` is setted. So complete func can immediately get called after change leader char. Instead of have to waiting for `CursorMoved` event and reinvoke complete function by feedkeys, which also cause flicker. 

The last change is if restart_complete with new_leader, and in user complete func, refresh_always is set, free `compl_leader`, so popup menu doesn't use prefix as a filter. this cause all the result returned by complete func valid. This make more sense for fuzzy complete func, which need completely control complete and filter. The return candidate certainly may not match with the prefix, since it use itself match rule. 
