### PR TITLE
[RFC] Enable syntax highlighting and filetype stuff by default

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -315,7 +315,8 @@ argument.
 		When {vimrc} is equal to "NONE" (all uppercase), all
 		initializations from files and environment variables are
 		skipped, including reading the |ginit.vim| file when the GUI
-		starts.  Loading plugins is also skipped.
+		starts.  Loading plugins and enabling syntax highlighting are
+		also skipped.
 		When {vimrc} is equal to "NORC" (all uppercase), this has the
 		same effect as "NONE", but loading plugins is not skipped.
 
@@ -394,7 +395,8 @@ accordingly.  Vim proceeds in this order:
 	All following initializations until 4. are skipped. $MYVIMRC is not
 	set.
 	"vim -u NORC" can be used to skip these initializations without
-	reading a file.  "vim -u NONE" also skips loading plugins.  |-u|
+	reading a file.  "vim -u NONE" also skips loading plugins and enabling
+	syntax highlighting.  |-u|
 
 	If Vim was started in Ex mode with the "-s" argument, all following
 	initializations until 4. are skipped.  Only the "-u" option is
@@ -427,7 +429,19 @@ accordingly.  Vim proceeds in this order:
 	-  The file ".exrc"  (for Unix)
 		    "_exrc"  (for Win32)
 
-4. Load the plugin scripts.					*load-plugins*
+4. Enable syntax highlighting.
+	This does the same as the command: >
+		:runtime! syntax/syntax.vim
+<	This can be skipped with the "-u NONE" command line argument.
+
+5. Enable filetype and indent plugins.
+	This does the same as the commands: >
+		:runtime! filetype.vim
+		:runtime! ftplugin.vim
+		:runtime! indent.vim
+<	This can be skipped with the "-u NONE" command line argument.
+
+6. Load the plugin scripts.					*load-plugins*
 	This does the same as the command: >
 		:runtime! plugin/**/*.vim
 <	The result is that all directories in the 'runtimepath' option will be
@@ -443,31 +457,30 @@ accordingly.  Vim proceeds in this order:
 	commands from the command line have not been executed yet.  You can
 	use "--cmd 'set noloadplugins'" |--cmd|.
 
-5. Set 'shellpipe' and 'shellredir'
+7. Set 'shellpipe' and 'shellredir'
 	The 'shellpipe' and 'shellredir' options are set according to the
 	value of the 'shell' option, unless they have been set before.
 	This means that Vim will figure out the values of 'shellpipe' and
 	'shellredir' for you, unless you have set them yourself.
 
-6. Set 'updatecount' to zero, if "-n" command argument used
+8. Set 'updatecount' to zero, if "-n" command argument used
 
-7. Set binary options
+9. Set binary options
 	If the "-b" flag was given to Vim, the options for binary editing will
 	be set now.  See |-b|.
 
-8. Perform GUI initializations
+10. Perform GUI initializations
 	Only when starting "gvim", the GUI initializations will be done.  See
 	|gui-init|.
 
-9. Read the ShaDa file
-	If the 'shada' option is not empty, the ShaDa file is read.  See
-	|shada-file|.
+11. Read the ShaDa file
+	See |shada-file|.
 
-10. Read the quickfix file
+12. Read the quickfix file
 	If the "-q" flag was given to Vim, the quickfix file is read.  If this
 	fails, Vim exits.
 
-11. Open all windows
+13. Open all windows
 	When the |-o| flag was given, windows will be opened (but not
 	displayed yet).
 	When the |-p| flag was given, tab pages will be created (but not
@@ -476,7 +489,7 @@ accordingly.  Vim proceeds in this order:
 	If the "-q" flag was given to Vim, the first error is jumped to.
 	Buffers for all windows will be loaded.
 
-12. Execute startup commands
+14. Execute startup commands
 	If a "-t" flag was given to Vim, the tag is jumped to.
 	The commands given with the |-c| and |+cmd| arguments are executed.
 	The starting flag is reset, has("vim_starting") will now return zero.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -11,7 +11,7 @@ the "{Nvim}" tag.  This document is a complete and centralized list of all
 these differences.
 
 1. Configuration		|nvim-configuration|
-2. Option defaults		|nvim-option-defaults|
+2. Defaults			|nvim-defaults|
 3. Changed features		|nvim-features-changed|
 4. New features			|nvim-features-new|
 5. Missing legacy features	|nvim-features-missing|
@@ -28,7 +28,12 @@ these differences.
   session information.
 
 ==============================================================================
-2. Option defaults					  *nvim-option-defaults*
+2. Defaults					            *nvim-defaults*
+
+- Syntax highlighting is enabled by default
+- Filetype-related plugins and scripts are enabled by default
+  Note: these defaults can be disabled with the "-u NONE" command line
+  argument.  |-u|
 
 - 'autoindent' is set by default
 - 'autoread' is set by default

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9224,6 +9224,24 @@ static void ex_filetype(exarg_T *eap)
     EMSG2(_(e_invarg2), arg);
 }
 
+/// Same as :filetype plugin indent enable
+/// Updates the state used for :filetype without args.
+void force_enable_filetype(void)
+{
+  if (!filetype_detect) {
+    source_runtime((char_u *)FILETYPE_FILE, true);
+    filetype_detect = true;
+  }
+  if (!filetype_plugin) {
+    source_runtime((char_u *)FTPLUGIN_FILE, true);
+    filetype_plugin = true;
+  }
+  if (!filetype_indent) {
+    source_runtime((char_u *)INDENT_FILE, true);
+    filetype_indent = true;
+  }
+}
+
 /*
  * ":setfiletype {name}"
  */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -92,6 +92,10 @@
 # define SYNTAX_FNAME   "$VIMRUNTIME" _PATHSEPSTR "syntax" _PATHSEPSTR "%s.vim"
 #endif
 
+#ifndef SYNTAX_FILE
+# define SYNTAX_FILE   "$VIMRUNTIME" _PATHSEPSTR "syntax" _PATHSEPSTR "syntax.vim"
+#endif
+
 #ifndef EXRC_FILE
 # define EXRC_FILE      ".exrc"
 #endif

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -331,6 +331,14 @@ int main(int argc, char **argv)
   /* Source startup scripts. */
   source_startup_scripts(&params);
 
+  // If using the runtime (-u is not NONE), enable syntax and filetype plugins
+  if (params.use_vimrc != NULL && strcmp(params.use_vimrc, "NONE") != 0) {
+    // Enable syntax highlighting.
+    do_source((char_u *)SYNTAX_FILE, false, DOSO_NONE);
+    // :filetype plugin indent enable
+    force_enable_filetype();
+  }
+
   /*
    * Read all the plugin files.
    * Only when compiled with +eval, since most plugins need it.

--- a/src/nvim/testdir/test45.in
+++ b/src/nvim/testdir/test45.in
@@ -27,6 +27,8 @@ kYpj:call append("$", foldlevel("."))
 i  jI    :call append("$", "indent " . foldlevel("."))
 k:call append("$", foldlevel("."))
 :" test syntax folding
+:" this test assumes the syntax is off
+:syntax off
 :set fdm=syntax fdl=0
 :syn region Hup start="dd" end="ii" fold contains=Fd1,Fd2,Fd3
 :syn region Fd1 start="ee" end="ff" fold contained


### PR DESCRIPTION
Re: https://github.com/neovim/neovim/issues/1664

This behaviour is switched off with `-u NONE`, so the tests didn't need to be changed.
