### PR TITLE
[WIP] slow valgrind tests

### DIFF
--- a/.ci/gcc.sh
+++ b/.ci/gcc.sh
@@ -12,7 +12,7 @@ setup_deps x64
 
 CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON \
 	-DUSE_GCOV=ON \
-	-DBUSTED_OUTPUT_TYPE=plainTerminal"
+	-DBUSTED_OUTPUT_TYPE=gtest"
 
 # Build and output version info.
 $MAKE_CMD CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS" nvim


### PR DESCRIPTION
Broken out of #2664 (and discussed before, but didn't bother find the links) the the test run on travis with valgrind frequently goes over the 50 minutes timelimit.

No "PR" yet, just running on travis with detailed output to see which individual tests take much time.
