### PR TITLE
[WIP] options: set default &scrolloff to 1

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1278,7 +1278,8 @@ the current line is included.  You can then use "%" to go to the matching line.
 
 						*H*
 H			To line [count] from top (Home) of window (default:
-			first line on the window) on the first non-blank
+			second line on the window; the first only if
+			'scrolloff' is 0) on the first non-blank
 			character |linewise|.  See also 'startofline' option.
 			Cursor is adjusted for 'scrolloff' option.
 
@@ -1287,8 +1288,9 @@ M			To Middle line of window, on the first non-blank
 			character |linewise|.  See also 'startofline' option.
 
 						*L*
-L			To line [count] from bottom of window (default: Last
-			line on the window) on the first non-blank character
+L			To line [count] from bottom of window (default:
+			second-to-last line on the window; the last only if
+			'scrolloff' is 0) on the first non-blank character
 			|linewise|.  See also 'startofline' option.
 			Cursor is adjusted for 'scrolloff' option.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5336,13 +5336,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 	height.
 
 						*'scrolloff'* *'so'*
-'scrolloff' 'so'	number	(default 0)
+'scrolloff' 'so'	number	(default 1)
 			global
 	Minimal number of screen lines to keep above and below the cursor.
-	This will make some context visible around where you are working.  If
+	This makes some context visible around where you are working.  If
 	you set it to a very large value (999) the cursor line will always be
 	in the middle of the window (except at the start or end of the file or
-	when long lines wrap).
+	when long lines wrap). If you set it to 0, vim won't try to keep
+	lines above or below the cursor.
 	For scrolling horizontally see 'sidescrolloff'.
 
 						*'scrollopt'* *'sbo'*

--- a/runtime/doc/usr_03.txt
+++ b/runtime/doc/usr_03.txt
@@ -315,8 +315,8 @@ the cursor.  That's done with the "zz" command.
 	+------------------+		 +------------------+
 
 The "zt" command puts the cursor line at the top, "zb" at the bottom.  There
-are a few more scrolling commands, see |Q_sc|.  To always keep a few lines of
-context around the cursor, use the 'scrolloff' option.
+are a few more scrolling commands, see |Q_sc|.  To set how many lines of
+context to keep around the cursor, use the 'scrolloff' option.
 
 ==============================================================================
 *03.8*	Simple searches

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -31,6 +31,7 @@ these differences.
 - 'backspace' defaults to "indent,eol,start"
 - 'encoding' defaults to "utf-8"
 - 'nocompatible' is always set
+- 'scrolloff' is set to 1
 - 'ttyfast' is always set
 
 ==============================================================================

--- a/runtime/vimrc_example.vim
+++ b/runtime/vimrc_example.vim
@@ -1,7 +1,7 @@
 " An example for a vimrc file.
 "
 " Maintainer:   Bram Moolenaar <Bram@vim.org>
-" Last change:  2014 Nov 05
+" Last change:  2015 May 17
 "
 " To use it, copy it to
 "     for Unix:  ~/.vimrc
@@ -26,6 +26,11 @@ map Q gq
 " CTRL-U in insert mode deletes a lot.  Use CTRL-G u to first break undo,
 " so that you can undo CTRL-U after inserting a line break.
 inoremap <C-U> <C-G>u<C-U>
+
+" Make H and L jump to the first or last lines as visible before the jump,
+" and only then scroll.
+noremap <expr> H 'H' . &scrolloff . k
+noremap <expr> L 'L' . &scrolloff . 'j'
 
 " In many terminal emulators the mouse works just fine, thus enable it.
 if has('mouse')

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1284,9 +1284,9 @@ static vimoption_T
   {"scrolljump",  "sj",   P_NUM|P_VI_DEF|P_VIM,
    (char_u *)&p_sj, PV_NONE,
    {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"scrolloff",   "so",   P_NUM|P_VI_DEF|P_VIM|P_RALL,
+  {"scrolloff",   "so",   P_NUM|P_VIM|P_RALL,
    (char_u *)&p_so, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+   {(char_u *)0L, (char_u *)1L} SCRIPTID_INIT},
   {"scrollopt",   "sbo",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
    (char_u *)&p_sbo, PV_NONE,
    {(char_u *)"ver,jump", (char_u *)0L}

--- a/src/nvim/testdir/test88.in
+++ b/src/nvim/testdir/test88.in
@@ -9,6 +9,8 @@ STARTTEST
    e! test.ok
    wq! test.out
 :endif
+:" Scrolloff
+:set scrolloff=0
 :" Conceal settings.
 :set conceallevel=2
 :set concealcursor=nc

--- a/src/nvim/testdir/test_breakindent.in
+++ b/src/nvim/testdir/test_breakindent.in
@@ -78,7 +78,7 @@ STARTTEST
 :let g:str="\t\t\t\t\t{"
 :let g:test=" Test 12: breakindent + long indent"
 :wincmd p
-:set all& breakindent linebreak briopt=min:10 nu numberwidth=3 ts=4
+:set all& breakindent linebreak briopt=min:10 nu numberwidth=3 ts=4 so=0
 :$put =g:str
 zt:let line1=ScreenChar(1,10)
 :wincmd p
@@ -89,7 +89,7 @@ zt:let line1=ScreenChar(1,10)
 :" https://groups.google.com/d/msg/vim_dev/ZOdg2mc9c9Y/TT8EhFjEy0IJ
 :only
 :vert 20new
-:set all& breakindent briopt=min:10
+:set all& breakindent briopt=min:10 so=0
 :call setline(1, ["    a\tb\tc\td\te", "    z   y       x       w       v"])
 :/^\s*a
 fbgjyl:let line1 = @0
@@ -101,7 +101,7 @@ fygjyl:let line2 = @0
 :$put =line2
 :"
 :let g:test="Test 14: breakindent + visual blockwise delete #1"
-:set all& breakindent
+:set all& breakindent so=0
 :30vnew
 :normal! 3a1234567890
 :normal! a    abcde

--- a/src/nvim/testdir/test_listlbr.in
+++ b/src/nvim/testdir/test_listlbr.in
@@ -3,6 +3,7 @@ Test for linebreak and list option (non-utf8)
 STARTTEST
 :so small.vim
 :if !exists("+linebreak") | e! test.ok | w! test.out | qa! | endif
+:set scrolloff=0
 :set wildchar=^E
 :10new|:vsp|:vert resize 20
 :put =\"\tabcdef hijklmn\tpqrstuvwxyz_1060ABCDEFGHIJKLMNOP \"

--- a/test/functional/legacy/107_adjust_window_and_contents_spec.lua
+++ b/test/functional/legacy/107_adjust_window_and_contents_spec.lua
@@ -12,6 +12,7 @@ describe('107', function()
     local screen = Screen.new()
     screen:attach()
 
+    execute('set scrolloff=0')
     insert('start:')
     execute('new')
     execute('call setline(1, range(1,256))')

--- a/test/functional/legacy/listchars_spec.lua
+++ b/test/functional/legacy/listchars_spec.lua
@@ -25,6 +25,7 @@ describe("'listchars'", function()
 
     execute('let g:lines = []')
 
+    execute('set scrolloff=0')
     -- Set up 'listchars', switch on 'list', and use the "GG" mapping to record
     -- what the buffer lines look like.
     execute('set listchars+=tab:>-,space:.,trail:<')

--- a/test/functional/legacy/listlbr_utf8_spec.lua
+++ b/test/functional/legacy/listlbr_utf8_spec.lua
@@ -9,6 +9,7 @@ describe('linebreak', function()
 
   it('is working', function()
     source([[
+      set scrolloff=0
       set wildchar=^E
       10new
       vsp

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -34,6 +34,7 @@ local function disable_mouse() feed_termcode('[?1002l') end
 
 
 local function screen_setup(extra_height)
+  nvim('command', 'set scrolloff=0')
   nvim('command', 'highlight TermCursor cterm=reverse')
   nvim('command', 'highlight TermCursorNC ctermbg=11')
   nvim('set_var', 'terminal_scrollback_buffer_size', 10)

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -314,6 +314,7 @@ describe('Screen', function()
 
   describe('scrolling and clearing', function()
     before_each(function()
+      execute('set scrolloff=0')
       insert([[
       Inserting
       text


### PR DESCRIPTION
This changes the default of &scrolloff to 1, as per #2676. 

Since there is a discussion on this setting, I'm not planning to request merging right away. I opened this mainly to take care of some of the concerns about it that were brought up (documentation-wise, mostly).
- [x] Change the default of `&scrolloff` to 1.
- [x] Update the documentation (the default needed to be emphasized).
- [x] Fix functional legacy tests (simply set `&scrolloff` to 0 in those)
- [x] Fix functional tests 
- [x] Fix old tests
