### PR TITLE
[RFC] vim-patch:4abac79

### DIFF
--- a/runtime/autoload/gzip.vim
+++ b/runtime/autoload/gzip.vim
@@ -1,6 +1,6 @@
 " Vim autoload file for editing compressed files.
 " Maintainer: Bram Moolenaar <Bram@vim.org>
-" Last Change: 2008 Jul 04
+" Last Change: 2014 Nov 05
 
 " These functions are used by the gzip plugin.
 
@@ -120,6 +120,8 @@ fun gzip#read(cmd)
     silent! exe "bwipe " . tmp_esc
     silent! exe "bwipe " . tmpe_esc
   endif
+  " Store the OK flag, so that we can use it when writing.
+  let b:uncompressOk = ok
 
   " Restore saved option values.
   let &pm = pm_save
@@ -146,8 +148,10 @@ endfun
 
 " After writing compressed file: Compress written file with "cmd"
 fun gzip#write(cmd)
+  if exists('b:uncompressOk') && !b:uncompressOk
+    echomsg "Not compressing file because uncompress failed; reset b:uncompressOk to compress anyway"
   " don't do anything if the cmd is not supported
-  if s:check(a:cmd)
+  elseif s:check(a:cmd)
     " Rename the file before compressing it.
     let nm = resolve(expand("<afile>"))
     let nmt = s:tempname(nm)

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -258,13 +258,17 @@ that the buffers will be equal within the specified range.
 		See below for [range].
 
 							*do*
-do		Same as ":diffget" without argument or range.  The "o" stands
-		for "obtain" ("dg" can't be used, it could be the start of
-		"dgg"!). Note: this doesn't work in Visual mode.
+[count]do	Same as ":diffget" without range.  The "o" stands for "obtain"
+		("dg" can't be used, it could be the start of "dgg"!). Note:
+		this doesn't work in Visual mode.
+		If you give a [count], it is used as the [bufspec] argument
+		for ":diffget".
 
 							*dp*
-dp		Same as ":diffput" without argument or range.
-		Note: this doesn't work in Visual mode.
+[count]dp	Same as ":diffput" without range.  Note: this doesn't work in
+		Visual mode.
+		If you give a [count], it is used as the [bufspec] argument
+		for ":diffput".
 
 
 When no [range] is given, the diff at the cursor position or just above it is

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 7.4.  Last change: 2014 Sep 23
+*options.txt*	For Vim version 7.4.  Last change: 2014 Nov 05
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -6897,6 +6897,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	current buffer: >
 		setlocal ul=-1
 <	This helps when you run out of memory for a single change.
+
+	The local value is set to -123456 when the global value is to be used.
+
 	Also see |clear-undo|.
 
 						*'undoreload'* *'ur'*

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -1,4 +1,4 @@
-*quickref.txt*  For Vim version 7.4.  Last change: 2014 Aug 06
+*quickref.txt*  For Vim version 7.4.  Last change: 2014 Oct 22
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1286,11 +1286,16 @@ Context-sensitive completion on the command-line:
 |CTRL-W_R|	CTRL-W R		rotate windows upwards
 |CTRL-W_x|	CTRL-W x		exchange current window with next one
 
-|CTRL-W_=|	CTRL-W =		make all windows equal height
+|CTRL-W_=|	CTRL-W =		make all windows equal height & width
 |CTRL-W_-|	CTRL-W -		decrease current window height
 |CTRL-W_+|	CTRL-W +		increase current window height
 |CTRL-W__|	CTRL-W _		set current window height (default:
 					   very high)
+
+|CTRL-W_<|	CTRL-W <		decrease current window width
+|CTRL-W_>|	CTRL-W >		increase current window width
+|CTRL-W_bar|	CTRL-W |		set current window width (default:
+					   widest possible)
 ------------------------------------------------------------------------------
 *Q_bu*		Buffer list commands
 

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -1,4 +1,4 @@
-*repeat.txt*    For Vim version 7.4.  Last change: 2014 Mar 25
+*repeat.txt*    For Vim version 7.4.  Last change: 2014 Oct 29
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -63,6 +63,9 @@ This is useful if you want to include a '/' in the search pattern or
 replacement string.
 
 For the definition of a pattern, see |pattern|.
+
+NOTE [cmd] may contain a range; see |collapse| and |edit-paragraph-join| for
+examples.
 
 The global commands work by first scanning through the [range] lines and
 marking each line where a match occurs (for a multi-line pattern, only the

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 7.4.  Last change: 2014 Oct 15
+*todo.txt*      For Vim version 7.4.  Last change: 2014 Nov 05
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -44,6 +44,7 @@ Regexp problems:
   2013 Dec 11)
 - Using \@> and \?. (Brett Stahlman, 2013 Dec 21) Remark from Marcin Szamotulski
   Remark from Brett 2014 Jan 6 and 7.
+- Difference in NFA and old engine. (Brett Stahlman, 2014 Nov 5)
 - Bug when using \>. (Ramel, 2014 Feb 2) (Aaron Bohannon, 2014 Feb 13)
 - NFA regexp doesn't handle \%<v correctly. (Ingo Karkat, 2014 May 12)
 - Does not work with NFA regexp engine:
@@ -63,10 +64,6 @@ Breaks test_eval.  Inefficient, can we only compute y_width when needed?
 Problem that a previous silent ":throw" causes a following try/catch not to
 work. (ZyX, 2013 Sep 28)
 
-Patch to avoid problems with encoding conversion with diff.vim.
-(Yasuhiro Matsumoto, 2014 Sep 1.
-Depends on current language, language of file can be different.
-
 ":cd C:\Windows\System32\drivers\etc*" does not work, even though the
 directory exists. (Sergio Gallelli, 2013 Dec 29)
 
@@ -77,31 +74,26 @@ Patch by Marcin Szamotulski to add count to :close (2014 Aug 10, update Aug
     Make ":-1close" close the previous window.
 Doesn't look right, asked for updates.
 
+C macro with number highlighted wrong. (Dominique Pelle, 2014 Oct 23)
+
 The entries added by matchaddpos() are returned by getmatches() but can't be
 set with setmatches(). (lcd47, 2014 Jun 29)
 
-Patch to fix that 0x80 in abbreviation isn't handled correctly.
-(Christian Brabandt, 2014 Oct 1)
-
-Check for valid yank reg seems wrong.  Patch by Zyx, 2014 Oct 12.
-
-":sign-jump" uses first window in buffer instead of current window.
-Patch by James McCoy, 2013 Nov 22.  Update 2014 Oct 5.
-
-Patch to fix issue 57, on the issue.
-
-Patch for issue 101, maintainer unreachable.
-
 Gvim: when both Tab and CTRL-I are mapped, use CTRL-I not for Tab.
 
-Patch to fix that last_changedtick is not update on saving. (Christian
-Brabandt, 2014 Oct 10, second one)
+Patch to add 'langnoremap'. (Christian Brabandt, 2014 Oct 15)
+Update Oct 20.
 
-substitute() can be slow with long strings.  Patch by Ozaki Kiichi, 2014 Oct
-12.
+Patch to add append mode to writefile(). (Yasuhiro Matsumoto, 2014 Nov 1)
 
 Remove restriction in NSIS installer that the end of the path must be "Vim".
-(Tim Lebedkov, 2014 Sep 24) Again Oct 12.
+(Tim Lebedkov, 2014 Sep 24) Again Oct 12.  Now on issue 272.
+
+Fix that on MS-Windows MAX_PATH in bytes causes problems for file names
+between MAX_PATH and double that for double-byte encodings. (Ken Takata, 2014
+Oct 15)
+
+Another problem with MAX_PATH, off-by-one. (Ken Takata, 2014 Oct 21)
 
 Problem using ":try" inside ":execute". (ZyX, 2013 Sep 15)
 
@@ -117,17 +109,25 @@ Patch to fix issue 78. (Christian Brabandt, 2014 Oct 8)
 
 Patch to fix leak in map() with error. (Christian Brabandt, 2014 Oct 11)
 
+Patch to fix incsearch for "2/pattern/e".
+
+Change behavior of v:hlsearch?  Patch from Christian, 2014 Oct 22.
+
 Value returned by virtcol() changes depending on how lines wrap.  This is
 inconsistent with the documentation.
 
 On MS-Windows running tests with Mercurial has problems when the input files
 are changed. (Ken Takata, Taro Muraoka, 2014 Sep 25)
+Update Nov 5.
 
 MS-Windows: Crash opening very long file name starting with "\\".
 (Christian Brock, 2012 Jun 29)
 
 ml_updatechunk() is slow when retrying for another encoding. (John Little,
 2014 Sep 11)
+
+When 'balloonexpr' returns a list the result has a trailing newline.
+Just remove one trailing newline. (lcd, 2014 Oct 17)
 
 Make comments in the test Makefile silent. (Kartik Agaram, 2014 Sep 24)
 
@@ -136,7 +136,15 @@ any one-character from the previous line. (Kartik Agaram, 2014 Sep 19)
 
 Syntax highlighting slow (hangs) in SASS file. (Niek Bosch, 2013 Aug 21)
 
+Patch to add the EndOfBuffer highlight group, used instead of NonText for "~"
+lines. (Marco Hinz, 2014 Nov 2)
+
 Adding "~" to 'cdpath' doesn't work for completion?  (Davido, 2013 Aug 19)
+
+Can assign to s:type when a function s:type has been defined.
+Also the other way around: define a function while a variable with that name
+was already defined.
+(Yasuhiro Matsumoto, 2014 Nov 3)
 
 Patch to make closed folds line up. (Charles Campbell, 2014 Sep 12)
 
@@ -144,6 +152,11 @@ Patch for building a 32bit Vim with 64bit MingW compiler.
 (Michael Soyka, 2014 Oct 15)
 
 Delete old code in os_msdos.c, mch_FullName().
+
+Using "." to repeat an Ex command puts that command in history.  Probably
+should not happen.  If the command is the result of a mapping it's not put in
+history either. (Jacob Niehus, 2014 Nov 2)
+Patch from Jacob, Nov 2.
 
 "hi link" does not respect groups with GUI settings only. (Mark Lodato, 2014
 Jun 8)
@@ -182,6 +195,8 @@ its height?  It's like dragging the status bar above it at the same time.
 
 Can we make ":unlet $VAR" use unsetenv() to delete the env var?
 What for systems that don't have unsetenv()?
+
+Patch to add a :domodeline command. (Christian Brabandt, 2014 Oct 21)
 
 This does not give an error: (Andre Sihera, 2014 Mar 21)
     vim -u NONE 1 2 3 -c 'bufdo if 1 | echo 1'
@@ -621,6 +636,9 @@ Syntax region with 'concealends' and a 'cchar' value, 'conceallevel' set to 2,
 only one of the two ends gets the cchar displayed. (Brett Stahlman, 2010 Aug
 21, Ben Fritz, 2010 Sep 14)
 
+The :syntax cchar value can only be a single character.  It would be useful to
+support combining characters. (Charles Campbell)
+
 'cursorline' works on a text line only.  Add 'cursorscreenline' for
 highlighting the screen line. (Christian Brabandt, 2012 Mar 31)
 
@@ -744,6 +762,10 @@ Patch by Christian Brabandt, uses ]e [e ]t and [t. 2011 Aug 9.
 Need for CursorHold that retriggers.  Use a key that doesn't do anything, or a
 function that resets did_cursorhold.
 Patch by Christian Brabandt, 2011 May 6.
+
+Add event for when the text scrolls.  A bit like CursorMoved.  Also a similar
+one for insert mode.  Use the event in matchparen to update the highlight if
+the match scrolls into view.
 
 7   Use "++--", "+++--" for different levels instead of "+---" "+----".
 Patch by Christian Brabandt, 2011 Jul 27.

--- a/runtime/doc/usr_25.txt
+++ b/runtime/doc/usr_25.txt
@@ -1,4 +1,4 @@
-*usr_25.txt*	For Vim version 7.4.  Last change: 2007 May 11
+*usr_25.txt*	For Vim version 7.4.  Last change: 2014 Oct 29
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -402,7 +402,7 @@ the cursor keys: >
 	:map <Down> gj
 
 
-TURNING A PARAGRAPH INTO ONE LINE
+TURNING A PARAGRAPH INTO ONE LINE			*edit-paragraph-join*
 
 If you want to import text into a program like MS-Word, each paragraph should
 be a single line.  If your paragraphs are currently separated with empty

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Oct 09
+" Last Change:	2014 Nov 05
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")
@@ -778,6 +778,9 @@ au BufNewFile,BufRead *.git/config,.gitconfig,.gitmodules setf gitconfig
 au BufNewFile,BufRead *.git/modules/*/COMMIT_EDITMSG setf gitcommit
 au BufNewFile,BufRead *.git/modules/*/config	setf gitconfig
 au BufNewFile,BufRead */.config/git/config	setf gitconfig
+if !empty($XDG_CONFIG_HOME)
+  au BufNewFile,BufRead $XDG_CONFIG_HOME/git/config	setf gitconfig
+endif
 au BufNewFile,BufRead git-rebase-todo		setf gitrebase
 au BufNewFile,BufRead .msg.[0-9]*
       \ if getline(1) =~ '^From.*# This line is ignored.$' |

--- a/runtime/syntax/registry.vim
+++ b/runtime/syntax/registry.vim
@@ -1,8 +1,9 @@
 " Vim syntax file
 " Language:	Windows Registry export with regedit (*.reg)
-" Maintainer:	Dominique Stéphan (dominique@mggen.com)
-" URL: http://www.mggen.com/vim/syntax/registry.zip
-" Last change:	2004 Apr 23
+" Maintainer:	Dominique StÃ©phan (dominique@mggen.com)
+" URL: 		http://www.mggen.com/vim/syntax/registry.zip (doesn't work)
+" Last change:	2014 Oct 31
+"		Included patch from Alexander A. Ulitin
 
 " clear any unwanted syntax defs
 " For version 5.x: Clear all syntax items
@@ -17,7 +18,7 @@ endif
 syn case ignore
 
 " Head of regedit .reg files, it's REGEDIT4 on Win9#/NT
-syn match registryHead		"^REGEDIT[0-9]*$"
+syn match registryHead		"^REGEDIT[0-9]*\s*$\|^Windows Registry Editor Version \d*\.\d*\s*$"
 
 " Comment
 syn match  registryComment	"^;.*$"
@@ -58,7 +59,7 @@ syn region registryRemove	start="\[\-" end="\]" contains=registryHKEY,registryGU
 " Subkey
 syn match  registrySubKey		"^\".*\"="
 " Default value
-syn match  registrySubKey		"^\@="
+syn match  registrySubKey		"^@="
 
 " Numbers
 


### PR DESCRIPTION
Update runtime files.

https://code.google.com/p/vim/source/detail?r=4abac79c0b7ae7aac0cb32d9930e155de628b63f

No manual changes.

Output of `patch -p1 < vim-4abac79.diff`:

```
patching file runtime/autoload/gzip.vim
patching file runtime/doc/diff.txt
Hunk #1 FAILED at 1.
Hunk #2 succeeded at 258 (offset -8 lines).
1 out of 2 hunks FAILED -- saving rejects to file runtime/doc/diff.txt.rej
patching file runtime/doc/options.txt
Hunk #2 FAILED at 2221.
Hunk #3 succeeded at 6897 (offset -851 lines).
1 out of 3 hunks FAILED -- saving rejects to file runtime/doc/options.txt.rej
patching file runtime/doc/quickref.txt
Hunk #2 succeeded at 1286 (offset -27 lines).
patching file runtime/doc/repeat.txt
can't find file to patch at input line 142
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/tags b/runtime/doc/tags
|--- a/runtime/doc/tags
|+++ b/runtime/doc/tags
--------------------------
File to patch: 
Skip this patch? [y] y
Skipping patch.
1 out of 1 hunk ignored
patching file runtime/doc/todo.txt
Hunk #10 succeeded at 636 (offset -14 lines).
Hunk #11 succeeded at 763 (offset -14 lines).
patching file runtime/doc/usr_25.txt
patching file runtime/filetype.vim
Hunk #2 succeeded at 778 (offset -4 lines).
patching file runtime/syntax/registry.vim
```

The two rejected hunks are:

``` diff
--- runtime/doc/diff.txt
+++ runtime/doc/diff.txt
@@ -1,4 +1,4 @@
-*diff.txt*      For Vim version 7.4.  Last change: 2014 May 20
+*diff.txt*      For Vim version 7.4.  Last change: 2014 Oct 31


          VIM REFERENCE MANUAL    by Bram Moolenaar
```

(Failed because diff.txt already has a "Last change: 2015" header)

``` diff
--- runtime/doc/options.txt
+++ runtime/doc/options.txt
@@ -2221,7 +2221,7 @@ A jump table for the options with a shor


                        *'cryptmethod'* *'cm'*
-'cryptmethod'      string  (default "zip")
+'cryptmethod' 'cm' string  (default "zip")
            global or local to buffer |global-local|
            {not in Vi}
    Method used for encryption when the buffer is written to a file:
```

(not applicable)
