### PR TITLE
[RFC] vim-patch:c5d53d4

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 7.4.  Last change: 2014 Sep 27
+*eval.txt*	For Vim version 7.4.  Last change: 2014 Nov 05
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -4891,7 +4891,7 @@ readfile({fname} [, {binary} [, {max}]])
 		separated with CR will result in a single long line (unless a
 		NL appears somewhere).
 		All NUL characters are replaced with a NL character.
-		When {binary} is equal to "b" binary mode is used:
+		When {binary/append} is contains "b" binary mode is used:
 		- When the last line ends in a NL an extra empty list item is
 		  added.
 		- No CR characters are removed.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4090,6 +4090,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	be able to execute Normal mode commands.
 	This is the opposite of the 'keymap' option, where characters are
 	mapped in Insert mode.
+	Also consider setting 'langnoremap' to avoid 'langmap' applies to
+	characters resulting from a mapping.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 7.4.  Last change: 2014 Nov 05
+*todo.txt*      For Vim version 7.4.  Last change: 2014 Nov 13
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -33,6 +33,8 @@ not be repeated below, unless there is extra information.
 
 							*known-bugs*
 -------------------- Known bugs and current work -----------------------
+
+Add langnoremap in quickref.txt and  optwin.vim.
 
 Regexp problems:
 - The NFA engine does not implement the time limit passed to
@@ -73,6 +75,7 @@ Patch by Marcin Szamotulski to add count to :close (2014 Aug 10, update Aug
     Make ":+1close" close the next window.
     Make ":-1close" close the previous window.
 Doesn't look right, asked for updates.
+Update 2014 Nov 8. Replied with suggestions.
 
 C macro with number highlighted wrong. (Dominique Pelle, 2014 Oct 23)
 
@@ -81,29 +84,11 @@ set with setmatches(). (lcd47, 2014 Jun 29)
 
 Gvim: when both Tab and CTRL-I are mapped, use CTRL-I not for Tab.
 
-Patch to add 'langnoremap'. (Christian Brabandt, 2014 Oct 15)
-Update Oct 20.
-
-Patch to add append mode to writefile(). (Yasuhiro Matsumoto, 2014 Nov 1)
-
-Remove restriction in NSIS installer that the end of the path must be "Vim".
-(Tim Lebedkov, 2014 Sep 24) Again Oct 12.  Now on issue 272.
-
-Fix that on MS-Windows MAX_PATH in bytes causes problems for file names
-between MAX_PATH and double that for double-byte encodings. (Ken Takata, 2014
-Oct 15)
-
-Another problem with MAX_PATH, off-by-one. (Ken Takata, 2014 Oct 21)
-
 Problem using ":try" inside ":execute". (ZyX, 2013 Sep 15)
 
 Python: ":py raw_input('prompt')" doesn't work. (Manu Hack)
 
-'foldexpr' applies to help. (Paul Marshall, 2014 Sep 24)
-
 Patch to fix issue 203. (Christian Brabandt, 2014 Oct 8)
-
-Patch to fix issue 253. (Christian Brabandt, 2014 Oct 8)
 
 Patch to fix issue 78. (Christian Brabandt, 2014 Oct 8)
 
@@ -113,8 +98,19 @@ Patch to fix incsearch for "2/pattern/e".
 
 Change behavior of v:hlsearch?  Patch from Christian, 2014 Oct 22.
 
+MS-Windows: When editing a file with a leading space, writing it uses the
+wrong name. (Aram, 2014 Nov 7)  Vim 7.4.
+
+patch to remove FEAT_OSFILETYPE from fileio.c. (Christian, 2014 Nov 12)
+
 Value returned by virtcol() changes depending on how lines wrap.  This is
 inconsistent with the documentation.
+
+Fix for wrong formatting if 'linebreak' is set. (Christian Brabandt, 2014 Nov
+12)
+
+Patch to support hex values for setting option value.
+(Zyx, 2015 Nov 6)
 
 On MS-Windows running tests with Mercurial has problems when the input files
 are changed. (Ken Takata, Taro Muraoka, 2014 Sep 25)
@@ -122,6 +118,9 @@ Update Nov 5.
 
 MS-Windows: Crash opening very long file name starting with "\\".
 (Christian Brock, 2012 Jun 29)
+
+Problem using diff syntax with cp932 encoding.  Idea from Yasuhiro Matsumoto,
+patch from Ken Takata (2014 Nov 6)
 
 ml_updatechunk() is slow when retrying for another encoding. (John Little,
 2014 Sep 11)
@@ -161,8 +160,10 @@ Patch from Jacob, Nov 2.
 "hi link" does not respect groups with GUI settings only. (Mark Lodato, 2014
 Jun 8)
 
-Patch to switch to the BT regexp engine when the NFA engine uses many states.
-(Christian Brabandt, 2014 Oct 3)
+Bug: Autocompleting ":tag/pat" replaces "/pat" with a match but does not
+insert a space. (Micha Mos, 2014 Nov 7)
+
+Patch to add the :bvimgrep command.  (Christian Brabandt, 2014 Nov 12)
 
 Patch to add argument to :cquit. (Thinca, 2014 Oct 12)
 

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	man
 " Maintainer:	SungHyun Nam <goweol@gmail.com>
-" Last Change:	2013 Jul 17
+" Last Change:	2014 Nov 12
 
 " To make the ":Man" command available before editing a manual page, source
 " this script from your startup vimrc file.
@@ -63,7 +63,9 @@ endtry
 func <SID>PreGetPage(cnt)
   if a:cnt == 0
     let old_isk = &iskeyword
-    setl iskeyword+=(,)
+    if &ft == 'man'
+      setl iskeyword+=(,)
+    endif
     let str = expand("<cword>")
     let &l:iskeyword = old_isk
     let page = substitute(str, '(*\(\k\+\).*', '\1', '')

--- a/runtime/indent/lua.vim
+++ b/runtime/indent/lua.vim
@@ -2,7 +2,7 @@
 " Language:	Lua script
 " Maintainer:	Marcus Aurelius Farias <marcus.cf 'at' bol.com.br>
 " First Author:	Max Ischenko <mfi 'at' ukr.net>
-" Last Change:	2007 Jul 23
+" Last Change:	2014 Nov 12
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -54,7 +54,7 @@ function! GetLuaIndent()
 
   " Subtract a 'shiftwidth' on end, else (and elseif), until and '}'
   " This is the part that requires 'indentkeys'.
-  let midx = match(getline(v:lnum), '^\s*\%(end\|else\|until\|}\)')
+  let midx = match(getline(v:lnum), '^\s*\%(end\>\|else\>\|until\>\|}\)')
   if midx != -1 && synIDattr(synID(v:lnum, midx + 1, 1), "name") != "luaComment"
     let ind = ind - &shiftwidth
   endif

--- a/runtime/syntax/diff.vim
+++ b/runtime/syntax/diff.vim
@@ -2,7 +2,7 @@
 " Language:	Diff (context or unified)
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
 "               Translations by Jakson Alves de Aquino.
-" Last Change:	2013 Oct 06
+" Last Change:	2014 Nov 12
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -125,7 +125,7 @@ syn match diffIdentical	"^םיהז םניה .*-ו .* םיצבקה$"
 syn match diffDiffer	"^הזמ הז םינוש `.*'-ו `.*' םיצבקה$"
 syn match diffBDiffer	"^הזמ הז םינוש `.*'-ו `.*' םיירניב םיצבק$"
 syn match diffIsA	"^.* .*-ל .* .* תוושהל ןתינ אל$"
-syn match diffNoEOL	"^\\ ץבוקה ףוסב השדח-הרוש ות רסח"
+syn match diffNoEOL	"^\\ ץבוקה ףוסב השד.-הרוש ות רס."
 syn match diffCommon	"^.*-ו .* :תוהז תויקית-תת$"
 
 " hr


### PR DESCRIPTION
Update runtime files.

https://code.google.com/p/vim/source/detail?r=c5d53d4c3e2e24e23fc4272bf91be3c031ccb598

On top of #2694, so that should be merged first.

No manual changes.

Output of `patch -p1 < vim-c5d53d4.diff`:

```
patching file runtime/doc/editing.txt
Hunk #1 FAILED at 1.
Hunk #2 FAILED at 1415.
2 out of 2 hunks FAILED -- saving rejects to file runtime/doc/editing.txt.rej
patching file runtime/doc/eval.txt
Hunk #2 succeeded at 4891 (offset 40 lines).
patching file runtime/doc/options.txt
Hunk #1 succeeded at 4090 (offset -444 lines).
can't find file to patch at input line 61
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/tags b/runtime/doc/tags
|--- a/runtime/doc/tags
|+++ b/runtime/doc/tags
--------------------------
File to patch: 
Skip this patch? [y] y
Skipping patch.
2 out of 2 hunks ignored
patching file runtime/doc/todo.txt
patching file runtime/ftplugin/man.vim
patching file runtime/indent/lua.vim
patching file runtime/syntax/diff.vim
```

Rejected hunks:

``` diff
--- runtime/doc/editing.txt
+++ runtime/doc/editing.txt
@@ -1,4 +1,4 @@
-*editing.txt*   For Vim version 7.4.  Last change: 2014 Sep 19
+*editing.txt*   For Vim version 7.4.  Last change: 2014 Nov 12


          VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1415,13 +1415,11 @@ Do this before writing the file.  When r
 set automatically to the method used when that file was written.  You can
 change 'cryptmethod' before writing that file to change the method.

-To set the default method, used for new files, use one of these in your
-|vimrc| file: >
-   set cm=zip
+To set the default method, used for new files, use this in your |vimrc| 
+file: >
    set cm=blowfish2
-Use the first one if you need to be compatible with Vim 7.2 and older.  Using
-"blowfish2" is highly recommended if you can use a Vim version that supports
-it.
+Using "blowfish2" is highly recommended.  Only use another method if you
+must use an older Vim version that does not support it.

 The message given for reading and writing a file will show "[crypted]" when
 using zip, "[blowfish]" when using blowfish, etc.
```

(header update rejected because "Last change:" is already in 2015. Cryptmethod changes are irrelevant for Neovim).
