### PR TITLE
[RFC] Plugin: extra keymaps

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -403,7 +403,7 @@ steps to make a numbered list.
 
 1. Create the first list entry, make sure it starts with a number.
 2. qa	     - start recording into register 'a'
-3. Y	     - yank the entry
+3. yy	     - yank the entry
 4. p	     - put a copy of the entry below the first one
 5. CTRL-A    - increment the number
 6. q	     - stop recording
@@ -914,9 +914,10 @@ inside of strings can change!  Also see 'softtabstop' option. >
 
 							*Y*
 ["x]Y			yank [count] lines [into register x] (synonym for
-			yy, |linewise|).  If you like "Y" to work from the
-			cursor to the end of line (which is more logical,
-			but not Vi-compatible) use ":map Y y$".
+			yy, |linewise|).
+			{Nvim} By default, Y is mapped to yank text from the
+			cursor to the end of line, which is more consistent
+			with respect to, for example, |cc| and |C|.
 
 							*v_y*
 {Visual}["x]y		Yank the highlighted text [into register x] (for

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -183,6 +183,8 @@ l		or					*l*
 			in the same SCREEN column.  <Home> works like "1|",
 			which differs from "0" when the line starts with a
 			<Tab>.
+                        {Nvim} By default, <Home> is mapped so it alternates
+			between behaving like |^| and |0| (see |smart-home|).
 
 							*^*
 ^			To the first non-blank character of the line.

--- a/runtime/doc/nvim_extra_keymaps.txt
+++ b/runtime/doc/nvim_extra_keymaps.txt
@@ -1,0 +1,35 @@
+*nvim_extra_keymaps.txt*    For Nvim.                         {Nvim}
+
+EXTRA KEYMAPS FOR NVIM                                      *nvim-extra-keymaps*
+
+The `plugin/extra-keymaps.vim` script provides a few extra keymaps that might
+be useful and tries to fix some issues the community has identified with vim's
+default keymaps.
+
+This plugin can be disabled by addinf the following to your |vimrc|: >
+
+    let g:nvim#defaults#maps#use = 0
+
+Additionally, all features can be disabled separately, using the variables
+described below.
+
+The keymaps provided are:
+
+			 *t_<Esc><Esc>*  *gr:nvim#defaults#maps#leave_term_mode*
+1. <Esc><Esc> leaves terminal-mode (see |nvim-terminal-emulator|), like
+   CTRL-\ CTRL-N (see |CTRL-\_CTRL-N|).
+
+					    *Y-eol* *g:nvim#defaults#maps#Y_eol*
+2. |Y| yanks to the end of line, which is more consistent with |cc| and |C|,
+   for example.
+
+				*undo-ctrl-u* *g:nvim#defaults#maps#undo_ctrl_u*
+3. <C-u> can be undone. (see |i_CTRL-U|)
+
+				  *smart-home* *g:nvim#defaults#maps#smart_home*
+4. <Home> moves the cursor to the first non-blank character of the line on
+   first press (like |^|), and the first character of the line on second (like
+   |0|). It alternates afterwards.
+
+============================================================================
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -52,8 +52,9 @@ Sending input is possible by entering terminal mode, which is achieved by
 pressing any key that would enter insert mode in a normal buffer (|i| or |a|
 for example). The |:terminal| ex command will automatically enter terminal
 mode once it's spawned. While in terminal mode, Nvim will forward all keys to
-the underlying program. The only exception is the <C-\><C-n> key combo,
-which will exit back to normal mode.
+the underlying program. The only exceptions are <C-\><C-n>, which will exit
+back to normal mode, and <Esc><Esc>, which maps to it by default (the latter
+can be disabled, see |t_<Esc><Esc>|).
 
 Terminal mode has its own namespace for mappings, which is accessed with the
 "t" prefix. It's possible to use terminal mappings to customize interaction

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -12,10 +12,11 @@ these differences.
 
 1. Configuration		|nvim-configuration|
 2. Option defaults		|nvim-option-defaults|
-3. Changed features		|nvim-features-changed|
-4. New features			|nvim-features-new|
-5. Missing legacy features	|nvim-features-missing|
-6. Removed features		|nvim-features-removed|
+3. New keymaps			|nvim-keymaps|
+4. Changed features		|nvim-features-changed|
+5. New features			|nvim-features-new|
+6. Missing legacy features	|nvim-features-missing|
+7. Removed features		|nvim-features-removed|
 
 
 ==============================================================================
@@ -38,7 +39,19 @@ these differences.
 - 'wildmode' defaults to "list:longest,full"
 
 ==============================================================================
-3. Changed features					 *nvim-features-changed*
+3. New keymaps							  *nvim-keymaps*
+
+The behavior of some mappings has changed by default:
+
+- <esc><esc> leaves terminal mode (see |nvim-terminal-emulator|)
+- |Y| yanks from the cursor to the end of the line.
+- <C-u> can be undone.
+- <Home> alternates between behaving like |0| and |$|.
+
+See |nvim-extra-keymaps|.
+
+==============================================================================
+4. Changed features					 *nvim-features-changed*
 
 Nvim always builds with all features, in contrast to Vim which may have
 certain features removed/added at compile-time.  This is like if Vim's "HUGE"
@@ -51,7 +64,7 @@ are always available and may be used simultaneously in separate plugins.  The
 |nvim-python|).
 
 ==============================================================================
-4. New Features						     *nvim-features-new*
+5. New Features						     *nvim-features-new*
 
 See |nvim-intro| for a list of Nvim's largest new features.
 
@@ -78,7 +91,7 @@ Highlight groups:
   |hl-TermCursorNC|
 
 ==============================================================================
-5. Missing legacy features				 *nvim-features-missing*
+6. Missing legacy features				 *nvim-features-missing*
 
 These legacy Vim features may be implemented in the future, but they are not
 planned for the current milestone.
@@ -91,7 +104,7 @@ planned for the current milestone.
 - if_tcl
 
 ==============================================================================
-6. Removed features					 *nvim-features-removed*
+7. Removed features					 *nvim-features-removed*
 
 These features are in Vim, but have been intentionally removed from Nvim.
 

--- a/runtime/plugin/extra-keymaps.vim
+++ b/runtime/plugin/extra-keymaps.vim
@@ -1,0 +1,43 @@
+" Extra default keymaps and keyboard behavior
+
+" Exit quickly if
+" 1) the user has disabled the plugin
+" 2) this file is already loaded
+if exists('g:nvim#extra_maps#use') && g:nvim#extra_maps#use == 0
+  || exists('g:nvim#extra_maps#loaded') && g:nvim#extra_maps#loaded == 1
+  finish
+endif
+
+" Set defaults:
+" The user can disable parts of the plugin separatedly
+" by setting any of these to 0
+if !exists("g:nvim#extra_maps#leave_term_mode")
+  let g:nvim#extra_maps#leave_term_mode = 1
+endif
+if !exists("g:nvim#extra_maps#Y_eol")
+  let g:nvim#extra_maps#Y_eol = 1
+endif
+if !exists("g:nvim#extra_maps#undo_ctrl_u")
+  let g:nvim#extra_maps#undo_ctrl_u = 1
+endif
+if !exists("g:nvim#extra_maps#smart_home")
+  let g:nvim#extra_maps#smart_home = 1
+endif
+
+" Do a mapping
+function! s:DefMap(var, lhs, mode, map)
+  " We don't want to mask user defined mappings, so we check
+  if g:nvim#extra_maps#{a:var} is 1 && maparg(a:lhs, a:mode) == ''
+    exe a:mode.'noremap '. a:map
+  endif
+endfunction
+
+" Do the mappings:
+call s:DefMap('leave_term_mode', '<esc><esc>', 't', '<esc><esc> <C-\><c-n>')
+call s:DefMap('Y_eol', 'Y', '', 'Y y$')
+call s:DefMap('undo_ctrl_u', '<C-u>', 'i', '<C-u> <C-g>u<C-u>')
+call s:DefMap('smart_home', '<home>', '', '<expr> <home> virtcol(".") - 1 <= indent(".") && col(".") > 1 ? "0" : "_"')
+
+let g:nvim#extra_maps#loaded = 1
+
+" vim: set sw=2 et :


### PR DESCRIPTION
Keymaps from #2676: 
- `Y` yanks to the end of the line.
- Allow undoing `<C-u>` (delete text typed in the current line)
- `<home>` goes to the beginning of the text on first press and the beginning of the line on second. It alternates afterwards. 
- `<esc><esc>` leaves terminal mode.

The plugin can be disabled with 

``` vim
    let g:nvim#defaults#maps#use = 0
```

and all the features can be disabled separately.
