### PR TITLE
[RFC] os_get_user_name() for non UNIX system

### DIFF
--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -41,7 +41,12 @@ int os_get_usernames(garray_T *users)
 // Return OK if a name found.
 int os_get_user_name(char *s, size_t len)
 {
+#ifdef UNIX
   return os_get_uname(getuid(), s, len);
+#else
+  // TODO(equalsraf): Windows GetUserName()
+  return os_get_uname(0, s, len);
+#endif
 }
 
 // Insert user name for "uid" in s[len].


### PR DESCRIPTION
os_get_user_name() requires getuid(), which is only available in UNIX. Return
FAIL for non UNIX systems.

On FAIL os_get_user_name() fills the buffer with the uid.  In Windows libuv
uses 0 for uid in stat structs, so 0 is used here too.
