### PR TITLE
[RFC] Fix resizing on SIGWINCH when maximizing a window

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -208,10 +208,11 @@ static void try_resize(Event ev)
 static void sigwinch_cb(uv_signal_t *handle, int signum)
 {
   // Queue the event because resizing can result in recursive event_poll calls
+  // FIXME(blueyed): The TUI does not resize properly when not deferred for unknown reasons. (#2322)
   event_push((Event) {
     .data = handle->data,
     .handler = try_resize
-  }, false);
+  }, true);
 }
 
 static bool attrs_differ(HlAttrs a1, HlAttrs a2)


### PR DESCRIPTION
sigwinch_cb: queue the event deferred

This fixes a problem when maximizing the window, where often only then
lines would be detected properly with the `try_resize` handler being
called immediately.

Fixes https://github.com/neovim/neovim/issues/2322.
