### PR TITLE
Fix helptags generation when prefix is not /usr

### DIFF
--- a/cmake/GenerateHelptags.cmake
+++ b/cmake/GenerateHelptags.cmake
@@ -1,10 +1,12 @@
+include(GNUInstallDirs)
+
 if(DEFINED ENV{DESTDIR})
   file(TO_CMAKE_PATH
-    "$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc"
+   "$ENV{DESTDIR}/usr/share/nvim/runtime/doc"
     HELPTAGS_WORKING_DIRECTORY)
 else()
   file(TO_CMAKE_PATH
-    "${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc"
+    "/usr/share/nvim/runtime/doc"
     HELPTAGS_WORKING_DIRECTORY)
 endif()
 


### PR DESCRIPTION
full disclosure, this may not be completely correct -- I tried using CMAKE_INSTALL_DATAROOTDIR and CMAKE_INSTALL_DATAROOTDIR but they don't do what is intended.
