### PR TITLE
eval: learn "grepfile()"

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1836,6 +1836,8 @@ glob( {expr} [, {nosuf} [, {list}]])
 				any	expand file wildcards in {expr}
 globpath( {path}, {expr} [, {nosuf} [, {list}]])
 				String	do glob({expr}) for all dirs in {path}
+grepfile( {expr}, {path} [, {grepprg}])
+				List	grep {path} with {expr}
 has( {feature})			Number	TRUE if feature {feature} supported
 has_key( {dict}, {key})		Number	TRUE if {dict} has entry {key}
 haslocaldir()			Number	TRUE if current window executed |:lcd|
@@ -3678,6 +3680,17 @@ globpath({path}, {expr} [, {nosuf} [, {list}]])			*globpath()*
 			:echo globpath(&rtp, "**/README.txt")
 <		Upwards search and limiting the depth of "**" is not
 		supported, thus using 'path' will not always work properly.
+
+grepfile({path}, {expr} [, {grepprg}])				*grepfile()*
+		Like |readfile()|, but with the output filtered by {grepprg}.
+		If the optional {grepprg} is not given, 'grepprg' will be
+		used. If {grepprg} or 'grepprg' is "internal", the output will
+		be generated like with |:vimgrep|; otherwise, this may be used
+		to customize the output. Example: >
+			:echo grepfile('~/.nvimrc', 'SYNTAX', &grepprg + ' -i')
+<
+		{path} may be a search expression, expanded by the shell, or
+		|:vimgrep|.
 
 							*has()*
 has({feature})	The result is a Number, which is 1 if the feature {feature} is

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6510,6 +6510,7 @@ static struct fst {
   {"getwinvar",       2, 3, f_getwinvar},
   {"glob",            1, 3, f_glob},
   {"globpath",        2, 4, f_globpath},
+  {"grepfile",        2, 3, f_grepfile},
   {"has",             1, 1, f_has},
   {"has_key",         2, 2, f_has_key},
   {"haslocaldir",     0, 0, f_haslocaldir},
@@ -9801,6 +9802,61 @@ getwinvar (
     copy_tv(&argvars[off + 2], rettv);
 
   --emsg_off;
+}
+
+/// "grepfile()" function
+static void f_grepfile(typval_T *argvars, typval_T *rettv)
+{
+  char_u filebuf[MAXPATHL];
+  char_u *filepat = get_tv_string_buf_chk(&argvars[0], filebuf);
+  if (!filepat) {
+    return;
+  }
+
+  char_u *searchpat = get_tv_string_chk(&argvars[1]);
+  if (!searchpat) {
+    return;
+  }
+  searchpat = vim_strsave(searchpat);
+
+  char_u *program = p_gp;
+  if (argvars[2].v_type != VAR_UNKNOWN
+      && !(program = get_tv_string_chk(&argvars[2]))) {
+    goto theend;
+  }
+
+  if (strcmp((char *)program, "internal") == 0) {
+    list_T *retlist = rettv_list_alloc(rettv);
+    do_vimgrep(0, searchpat, filepat, MAXLNUM, 0, NULL, &retlist);
+  } else {
+    // In case searchpat contains quotes or special characters:
+    char_u *search_esc = vim_strsave_escaped(searchpat, (char_u *)"*\"\\ ");
+
+    // Copy the search string and file pattern to a string for
+    // replace_makeprg().
+    size_t size = STRLEN(search_esc) + STRLEN(filepat) + 2;
+    char_u *argstr = xmalloc(size);
+    snprintf((char *)argstr, size, "%s %s", search_esc, filepat);
+
+    char *command = (char *)replace_makeprg(argstr, program);
+    char **argv = shell_build_argv(command, NULL);
+
+    char *res;
+    size_t nread = 0;
+    (void)os_system(argv, NULL, 0, &res, &nread);
+
+    rettv->vval.v_list = string_to_list((char_u *) res, nread, false);
+    rettv->vval.v_list->lv_refcount++;
+    rettv->v_type = VAR_LIST;
+
+    xfree(search_esc);
+    xfree(argstr);
+    xfree(command);
+    xfree(res);
+  }
+
+theend:
+  xfree(searchpat);
 }
 
 /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3790,7 +3790,7 @@ bool is_makeprg_command(cmdidx_T cmdidx) FUNC_ATTR_CONST
 /// @param program program format, obtained from 'makeprg' or a similar
 ///                variable.
 /// @returns the command string for executing ":make" or ":grep" externally.
-static char_u *replace_makeprg(char_u *argstr, const char_u *program)
+char_u *replace_makeprg(char_u *argstr, const char_u *program)
 {
   char_u      *new_cmdline;
   char_u      *pos;

--- a/src/nvim/quickfix.h
+++ b/src/nvim/quickfix.h
@@ -4,6 +4,7 @@
 /* flags for skip_vimgrep_pat() */
 #define VGR_GLOBAL      1
 #define VGR_NOJUMP      2
+#define VGR_FORCEIT     4
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "quickfix.h.generated.h"


### PR DESCRIPTION
vim has some pretty neat grepping support, but `'grepprg'` can be difficult to interpret correctly, and when `grepprg="internal"`, a script writer has no way of using it, and can't do `:vimgrep` without clobbering the user's quickfix list.

The specific use-case I have in mind is this: https://github.com/lambdalisue/vim-gita/pull/18 I found that the fastest way to obtain the hash of a git branch would be to run `$ grep {branch-name} .git/packed-refs` to obtain the line with the correct hash. This enables the fallowing:

``` vim
let branch = grepfile(".git/packed-refs", "refs/remotes/{remote-name}/{branch-name}$")
let hash = split(branch[0])[0]
```

Right now, I just have to write some tests for completeness.

Unfortunately, this solution feels a bit naive at the moment. I do not know how to communicate to the caller that an error occurred in executing `&grepprg`. The user must check that a line doesn't contain "grep: {path} is a file or directory". To obtain information about the line number/column position, the caller can supply a third argument like `&grepprg + ' --lines'`, but not when `&grepprg == 'internal'`. How should we communicate to include this information in that case?

Maybe this was a bit ill-conceived, but here it is. Kinda in WIP status, but I'd like some feedback.

Sent upstream as well: https://groups.google.com/forum/#!topic/vim_dev/TOjqHKghPjI
