### PR TITLE
[RFC] Improve legacy2luatest replace hex chars

### DIFF
--- a/scripts/legacy2luatest.pl
+++ b/scripts/legacy2luatest.pl
@@ -136,11 +136,18 @@ sub read_in_file {
 
         # Replace non-printable hex characters
         s/\x00/<C-V>10<CR>/g;
+        s/\x01/<C-A>/g;
         s/\x04/<C-D>/g;
+        s/\x06/<C-F>/g;
+        s/\x08/<C-H>/g;
+        s/\x0C/<C-L>/g;
+        s/\x0E/<C-N>/g;
         s/\x10/<C-P>/g;
         s/\x14/<C-T>/g;
         s/\x16/<C-V>/g;
         s/\x17/<C-W>/g;
+        s/\x18/<C-X>/g;
+        s/\x1D/<C-]>/g;
 
         my $startstr = "'";
         my $endstr = "'";

--- a/scripts/legacy2luatest.pl
+++ b/scripts/legacy2luatest.pl
@@ -8,6 +8,16 @@ use autodie;
 use File::Basename;
 use File::Spec::Functions;
 
+sub replace_hex_chars {
+  # Replace non-printable hex characters
+  s/\x00/<C-V>10<CR>/g;
+  s/\x04/<C-D>/g;
+  s/\x10/<C-P>/g;
+  s/\x14/<C-T>/g;
+  s/\x16/<C-V>/g;
+  s/\x17/<C-W>/g;
+}
+
 sub read_in_file {
   my $in_file = $_[0];
 
@@ -178,6 +188,7 @@ sub read_in_file {
   while (<$in_file_handle>) {
     # Remove trailing newline character and process line.
     chomp;
+    replace_hex_chars \$_;
     $state = $states{$state}->($_);
   }
 

--- a/scripts/legacy2luatest.pl
+++ b/scripts/legacy2luatest.pl
@@ -8,16 +8,6 @@ use autodie;
 use File::Basename;
 use File::Spec::Functions;
 
-sub replace_hex_chars {
-  # Replace non-printable hex characters
-  s/\x00/<C-V>10<CR>/g;
-  s/\x04/<C-D>/g;
-  s/\x10/<C-P>/g;
-  s/\x14/<C-T>/g;
-  s/\x16/<C-V>/g;
-  s/\x17/<C-W>/g;
-}
-
 sub read_in_file {
   my $in_file = $_[0];
 
@@ -55,6 +45,16 @@ sub read_in_file {
     # If there are input lines, wrap with an `insert`
     # command and add before the previous command block.
     if (@{$input_lines}) {
+      foreach (@{$input_lines}) {
+        # Replace non-printable hex characters
+        s/\x00/<C-V>x00/g;
+        s/\x04/<C-V><C-D>/g;
+        s/\x10/<C-V><C-P>/g;
+        s/\x14/<C-V><C-T>/g;
+        s/\x16/<C-V><C-V>/g;
+        s/\x17/<C-V><C-W>/g;
+      }
+
       my $last_input_line = pop @{$input_lines};
       unshift @{$command_lines}, '';
       unshift @{$command_lines}, $last_input_line . ']=])';
@@ -134,6 +134,14 @@ sub read_in_file {
         # Replace terminal escape characters with <esc>.
         s/\e/<esc>/g;
 
+        # Replace non-printable hex characters
+        s/\x00/<C-V>10<CR>/g;
+        s/\x04/<C-D>/g;
+        s/\x10/<C-P>/g;
+        s/\x14/<C-T>/g;
+        s/\x16/<C-V>/g;
+        s/\x17/<C-W>/g;
+
         my $startstr = "'";
         my $endstr = "'";
 
@@ -188,7 +196,6 @@ sub read_in_file {
   while (<$in_file_handle>) {
     # Remove trailing newline character and process line.
     chomp;
-    replace_hex_chars \$_;
     $state = $states{$state}->($_);
   }
 


### PR DESCRIPTION
I'm not really sure whether this is what we want. I've added a subroutine which can replace hex chars (e.g., `^P`) with commands such as `<C-P>`. I've tested it and it seems to work. Currently it replaces both "input" and "commands", but I think one of the issues' comment read that the script should only be used to change "input". Correct me if I'm wrong, but I found it also useful to change the commands as well. It can be changed easily, though.

I have only added a few chars which I've seen from tests, maybe we need more replacements?

I must say this is the first time I'm working with perl scripts and my second contribution, so please tell me everything that's wrong.
