### PR TITLE
[RFC] tui: don't pass NULL to termkey (#2745)

### DIFF
--- a/src/nvim/tui/term_input.inl
+++ b/src/nvim/tui/term_input.inl
@@ -269,7 +269,11 @@ static TermInput *term_input_new(void)
     flags |= TERMKEY_FLAG_RAW;
   }
 
-  rv->tk = termkey_new_abstract(os_getenv("TERM"), flags);
+  const char *term = os_getenv("TERM");
+  if (!term) {
+    term = "";  // termkey_new_abstract assumes non-null (#2745)
+  }
+  rv->tk = termkey_new_abstract(term, flags);
   int curflags = termkey_get_canonflags(rv->tk);
   termkey_set_canonflags(rv->tk, curflags | TERMKEY_CANON_DELBS);
   // setup input handle


### PR DESCRIPTION
Termkey does not handle `NULL`s, which means if `$TERM` isn't defined, and we pass it `os_getenv("TERM")`, it'll segfault, so pass an empty string instead. Actually, I'm not sure why this works since termkey decidedly does not initialize itself when `$TERM` is empty or a relative path (https://github.com/neovim/unibilium/blob/master/uniutil.c#L163). Then again, it's not like unibilium is what draws the screen.

Alternately, we could pass "xterm" by default, but would that work for macs? What about windows?
