### PR TITLE
[RFC] Support for early plugins

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5245,6 +5245,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  colors/	color scheme files |:colorscheme|
 	  compiler/	compiler files |:compiler|
 	  doc/		documentation |write-local-help|
+	  early/	early plugins |early-plugins|
 	  ftplugin/	filetype plugins |write-filetype-plugin|
 	  indent/	indent scripts |indent-expression|
 	  keymap/	key mapping files |mbyte-keymap|

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -474,13 +474,13 @@ accordingly.  Vim proceeds in this order:
 3. Source early plugin files				    *early-plugins*
 	This does the same as >
 		:runtime! early/**/*.vim
-<	The result is that all directories in the default |'runtimepath'| will be
+<	The result is that all directories in the default 'runtimepath' will be
 	searched for the "early" sub-directory and all files ending in ".vim"
 	will be sourced (in alphabetical order per directory), also in
 	subdirectories.
-	Loading plugins won't be done if:
+	Loading these plugins won't be done if:
 	- The |--noplugin| command line argument is used.
-	- The "-u NONE" command line argument is used |-u|.
+	- The "-u NONE" command line argument is used. |-u|
 
 4. Execute Ex commands, from environment variables and/or files
 	An environment variable is read as one Ex command line, where multiple

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -471,7 +471,18 @@ accordingly.  Vim proceeds in this order:
 	The |-V| argument can be used to display or log what happens next,
 	useful for debugging the initializations.
 
-3. Execute Ex commands, from environment variables and/or files
+3. Source early plugin files				    *early-plugins*
+	This does the same as >
+		:runtime! early/**/*.vim
+<	The result is that all directories in the default |'runtimepath'| will be
+	searched for the "early" sub-directory and all files ending in ".vim"
+	will be sourced (in alphabetical order per directory), also in
+	subdirectories.
+	Loading plugins won't be done if:
+	- The |--noplugin| command line argument is used.
+	- The "-u NONE" command line argument is used |-u|.
+
+4. Execute Ex commands, from environment variables and/or files
 	An environment variable is read as one Ex command line, where multiple
 	commands must be separated with '|' or "<NL>".
 								*vimrc* *exrc*
@@ -544,7 +555,7 @@ accordingly.  Vim proceeds in this order:
 	-  The file ".exrc"  (for Unix)
 		    "_exrc"  (for Win32)
 
-4. Load the plugin scripts.					*load-plugins*
+5. Load the plugin scripts.					*load-plugins*
 	This does the same as the command: >
 		:runtime! plugin/**/*.vim
 <	The result is that all directories in the 'runtimepath' option will be
@@ -560,31 +571,31 @@ accordingly.  Vim proceeds in this order:
 	commands from the command line have not been executed yet.  You can
 	use "--cmd 'set noloadplugins'" |--cmd|.
 
-5. Set 'shellpipe' and 'shellredir'
+6. Set 'shellpipe' and 'shellredir'
 	The 'shellpipe' and 'shellredir' options are set according to the
 	value of the 'shell' option, unless they have been set before.
 	This means that Vim will figure out the values of 'shellpipe' and
 	'shellredir' for you, unless you have set them yourself.
 
-6. Set 'updatecount' to zero, if "-n" command argument used
+7. Set 'updatecount' to zero, if "-n" command argument used
 
-7. Set binary options
+8. Set binary options
 	If the "-b" flag was given to Vim, the options for binary editing will
 	be set now.  See |-b|.
 
-8. Perform GUI initializations
+9. Perform GUI initializations
 	Only when starting "gvim", the GUI initializations will be done.  See
 	|gui-init|.
 
-9. Read the viminfo file
+10. Read the viminfo file
 	If the 'viminfo' option is not empty, the viminfo file is read.  See
 	|viminfo-file|.
 
-10. Read the quickfix file
+11. Read the quickfix file
 	If the "-q" flag was given to Vim, the quickfix file is read.  If this
 	fails, Vim exits.
 
-11. Open all windows
+12. Open all windows
 	When the |-o| flag was given, windows will be opened (but not
 	displayed yet).
 	When the |-p| flag was given, tab pages will be created (but not
@@ -593,7 +604,7 @@ accordingly.  Vim proceeds in this order:
 	If the "-q" flag was given to Vim, the first error is jumped to.
 	Buffers for all windows will be loaded.
 
-12. Execute startup commands
+13. Execute startup commands
 	If a "-t" flag was given to Vim, the tag is jumped to.
 	The commands given with the |-c| and |+cmd| arguments are executed.
 	The starting flag is reset, has("vim_starting") will now return zero.

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -292,19 +292,25 @@ int main(int argc, char **argv)
                  "{'cwd': get(matchlist(expand(\"<amatch>\"), "
                  "'\\c\\mterm://\\(.\\{-}\\)//'), 1, '')})");
 
-  /* Execute --cmd arguments. */
+  // Execute --cmd arguments.
   exe_pre_commands(&params);
 
-  /* Source startup scripts. */
+  if (params.use_vimrc != NULL) {
+    if (strcmp(params.use_vimrc, "NONE") == 0) {
+      p_lpl = FALSE; // don't load plugins
+    }
+  }
+
+  // Source early plugin files.
+  load_early_plugins();
+
+  // Source startup scripts.
   source_startup_scripts(&params);
 
-  /*
-   * Read all the plugin files.
-   * Only when compiled with +eval, since most plugins need it.
-   */
+   // Read all the plugin files.
   load_plugins();
 
-  /* Decide about window layout for diff mode after reading vimrc. */
+  // Decide about window layout for diff mode after reading vimrc.
   set_window_layout(&params);
 
   /*
@@ -1396,6 +1402,17 @@ static void load_plugins(void)
 }
 
 /*
+ * Read all the early plugin files (those are sourced before the vimrc)
+ */
+static void load_early_plugins(void)
+{
+  if (p_lpl) {
+    source_runtime((char_u *)"early/**/*.vim", TRUE);
+    TIME_MSG("loading early plugins");
+  }
+}
+
+/*
  * "-q errorfile": Load the error file now.
  * If the error file can't be read, exit before doing anything else.
  */
@@ -1765,13 +1782,11 @@ static void source_startup_scripts(mparm_T *parmp)
    * nothing else.
    */
   if (parmp->use_vimrc != NULL) {
-    if (strcmp(parmp->use_vimrc, "NONE") == 0
-        || strcmp(parmp->use_vimrc, "NORC") == 0) {
-      if (parmp->use_vimrc[2] == 'N')
-        p_lpl = FALSE;                      // don't load plugins either
-    } else {
-      if (do_source((char_u *)parmp->use_vimrc, FALSE, DOSO_NONE) != OK)
+    if (!(strcmp(parmp->use_vimrc, "NONE") == 0
+        || strcmp(parmp->use_vimrc, "NORC") == 0)) {
+      if (do_source((char_u *)parmp->use_vimrc, FALSE, DOSO_NONE) != OK) {
         EMSG2(_("E282: Cannot read from \"%s\""), parmp->use_vimrc);
+      }
     }
   } else if (!silent_mode) {
 


### PR DESCRIPTION
This introduces a new step to the initialization process: files in the `runtime/early` dir are sourced before the system and user vimrcs.

These files are _not_ sourced with `-u NONE` or `-noloadplugins`.

~~This also supersedes #2720 (re: #2676), which is implemented as an early plugin now.~~
