### PR TITLE
[RFC] terminal : don't set vterm size to 0 (workaround #2732)

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -313,6 +313,10 @@ void terminal_resize(Terminal *term, uint16_t width, uint16_t height)
     return;
   }
 
+  if (height == 0 || width == 0) {
+    return;
+  }
+
   vterm_set_size(term->vt, height, width);
   vterm_screen_flush_damage(term->vts);
   term->pending_resize = true;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4745,7 +4745,9 @@ void win_new_width(win_T *wp, int width)
   wp->w_redr_status = TRUE;
 
   if (wp->w_buffer->terminal) {
-    terminal_resize(wp->w_buffer->terminal, wp->w_width, 0);
+    if (wp->w_height != 0) {
+      terminal_resize(wp->w_buffer->terminal, wp->w_width, 0);
+    }
     redraw_win_later(wp, CLEAR);
   }
 }

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -110,39 +110,39 @@ describe('terminal mouse', function()
       before_each(function()
         feed('<c-\\><c-n>:vsp<cr>')
         screen:expect([[
-          line21                   |line21                  |
-          line22                   |line22                  |
-          line23                   |line23                  |
-          line24                   |line24                  |
-          ^rows: 5, cols: 24        |rows: 5, cols: 24       |
+          line28                   |line28                  |
+          line29                   |line29                  |
+          line30                   |line30                  |
+          rows: 5, cols: 24        |rows: 5, cols: 24       |
+          {2:^ }                        |{2: }                       |
           ==========                ==========              |
                                                             |
         ]])
         feed(':enew | set number<cr>')
         screen:expect([[
-            1 ^                     |line21                  |
-          ~                        |line22                  |
-          ~                        |line23                  |
-          ~                        |line24                  |
+            1 ^                     |line28                  |
+          ~                        |line29                  |
+          ~                        |line30                  |
           ~                        |rows: 5, cols: 24       |
+          ~                        |{2: }                       |
           ==========                ==========              |
           :enew | set number                                |
         ]])
         feed('30iline\n<esc>')
         screen:expect([[
-           27 line                 |line21                  |
-           28 line                 |line22                  |
-           29 line                 |line23                  |
-           30 line                 |line24                  |
-           31 ^                     |rows: 5, cols: 24       |
+           27 line                 |line28                  |
+           28 line                 |line29                  |
+           29 line                 |line30                  |
+           30 line                 |rows: 5, cols: 24       |
+           31 ^                     |{2: }                       |
           ==========                ==========              |
                                                             |
         ]])
         feed('<c-w>li')
         screen:expect([[
-           27 line                 |line22                  |
-           28 line                 |line23                  |
-           29 line                 |line24                  |
+           27 line                 |line28                  |
+           28 line                 |line29                  |
+           29 line                 |line30                  |
            30 line                 |rows: 5, cols: 24       |
            31                      |{1: }                       |
           ==========                ==========              |
@@ -152,8 +152,8 @@ describe('terminal mouse', function()
         thelpers.enable_mouse()
         thelpers.feed_data('mouse enabled\n')
         screen:expect([[
-           27 line                 |line23                  |
-           28 line                 |line24                  |
+           27 line                 |line29                  |
+           28 line                 |line30                  |
            29 line                 |rows: 5, cols: 24       |
            30 line                 |mouse enabled           |
            31                      |{1: }                       |
@@ -165,8 +165,8 @@ describe('terminal mouse', function()
       it('wont lose focus if another window is scrolled', function()
         feed('<MouseDown><0,0><MouseDown><0,0>')
         screen:expect([[
-           21 line                 |line23                  |
-           22 line                 |line24                  |
+           21 line                 |line29                  |
+           22 line                 |line30                  |
            23 line                 |rows: 5, cols: 24       |
            24 line                 |mouse enabled           |
            25 line                 |{1: }                       |
@@ -175,8 +175,8 @@ describe('terminal mouse', function()
         ]])
         feed('<S-MouseUp><0,0>')
         screen:expect([[
-           26 line                 |line23                  |
-           27 line                 |line24                  |
+           26 line                 |line29                  |
+           27 line                 |line30                  |
            28 line                 |rows: 5, cols: 24       |
            29 line                 |mouse enabled           |
            30 line                 |{1: }                       |
@@ -188,8 +188,8 @@ describe('terminal mouse', function()
       it('will lose focus if another window is clicked', function()
         feed('<LeftMouse><5,1>')
         screen:expect([[
-           27 line                 |line23                  |
-           28 l^ine                 |line24                  |
+           27 line                 |line29                  |
+           28 l^ine                 |line30                  |
            29 line                 |rows: 5, cols: 24       |
            30 line                 |mouse enabled           |
            31                      |{2: }                       |


### PR DESCRIPTION
I've found a workaround for issue #2732. Currently, when resizing, currently we call `vterm_set_size` 3 times. First to size 0, then to the size of one of the windows, then to the size of the other.

It looks like libvterm doesn't handle a terminal of height and/or width 0 properly. And to be honest that doesn't really make a lot of sense. Just checking for that solves the most immediate problem.

Currently some tests fail since they were affected by the bug. I'll report back when I've updated those tests.
