### PR TITLE
Push if conditionals into relevant function as a guard.

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2574,6 +2574,9 @@ static char_u *lasticon = NULL;
 
 void maketitle(void)
 {
+  // If we don't need to make the title, then don't.
+  if (!need_maketitle) return;
+
   char_u      *p;
   char_u      *t_str = NULL;
   char_u      *i_name;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7342,8 +7342,7 @@ static void ex_redraw(exarg_T *eap)
   update_screen(eap->forceit ? CLEAR :
       VIsual_active ? INVERTED :
       0);
-  if (need_maketitle)
-    maketitle();
+  maketitle();
   RedrawingDisabled = r;
   p_lz = p;
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -629,8 +629,7 @@ main_loop (
       else if (redraw_cmdline || clear_cmdline)
         showmode();
       redraw_statuslines();
-      if (need_maketitle)
-        maketitle();
+      maketitle();
       /* display message after redraw */
       if (keep_msg != NULL) {
         char_u *p;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6978,12 +6978,14 @@ void showruler(int always)
   } else
     win_redr_ruler(curwin, always);
 
-  if (need_maketitle
-      || (p_icon && (stl_syntax & STL_IN_ICON))
-      || (p_title && (stl_syntax & STL_IN_TITLE))
-      )
+  if (
+    (p_icon && (stl_syntax & STL_IN_ICON)) || 
+    (p_title && (stl_syntax & STL_IN_TITLE))
+  ) {
     maketitle();
-  /* Redraw the tab pages line if needed. */
+  }
+
+  // Redraw the tab pages line if needed.
   if (redraw_tabline)
     draw_tabline();
 }

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1022,9 +1022,7 @@ static void redraw(bool restore_cursor)
 
   redraw_statuslines();
 
-  if (need_maketitle) {
-    maketitle();
-  }
+  maketitle();
 
   showruler(false);
 


### PR DESCRIPTION
This may have been written the way it was originally as an optimization,
but it makes the code dirty; the compiler should be doing stuff like this
anyway. If its not we should yell at the folks writing gcc.
