### PR TITLE
[WIP] temporary PR to test OS X builds 

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -313,10 +313,6 @@ void terminal_resize(Terminal *term, uint16_t width, uint16_t height)
     return;
   }
 
-  if (height == 0 || width == 0) {
-    return;
-  }
-
   vterm_set_size(term->vt, height, width);
   vterm_screen_flush_damage(term->vts);
   term->pending_resize = true;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4745,9 +4745,7 @@ void win_new_width(win_T *wp, int width)
   wp->w_redr_status = TRUE;
 
   if (wp->w_buffer->terminal) {
-    if (wp->w_height != 0) {
-      terminal_resize(wp->w_buffer->terminal, wp->w_width, 0);
-    }
+    terminal_resize(wp->w_buffer->terminal, wp->w_width, 0);
     redraw_win_later(wp, CLEAR);
   }
 }

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -110,39 +110,39 @@ describe('terminal mouse', function()
       before_each(function()
         feed('<c-\\><c-n>:vsp<cr>')
         screen:expect([[
-          line28                   |line28                  |
-          line29                   |line29                  |
-          line30                   |line30                  |
-          rows: 5, cols: 24        |rows: 5, cols: 24       |
-          {2:^ }                        |{2: }                       |
+          line21                   |line21                  |
+          line22                   |line22                  |
+          line23                   |line23                  |
+          line24                   |line24                  |
+          ^rows: 5, cols: 24        |rows: 5, cols: 24       |
           ==========                ==========              |
                                                             |
         ]])
         feed(':enew | set number<cr>')
         screen:expect([[
-            1 ^                     |line28                  |
-          ~                        |line29                  |
-          ~                        |line30                  |
+            1 ^                     |line21                  |
+          ~                        |line22                  |
+          ~                        |line23                  |
+          ~                        |line24                  |
           ~                        |rows: 5, cols: 24       |
-          ~                        |{2: }                       |
           ==========                ==========              |
           :enew | set number                                |
         ]])
         feed('30iline\n<esc>')
         screen:expect([[
-           27 line                 |line28                  |
-           28 line                 |line29                  |
-           29 line                 |line30                  |
-           30 line                 |rows: 5, cols: 24       |
-           31 ^                     |{2: }                       |
+           27 line                 |line21                  |
+           28 line                 |line22                  |
+           29 line                 |line23                  |
+           30 line                 |line24                  |
+           31 ^                     |rows: 5, cols: 24       |
           ==========                ==========              |
                                                             |
         ]])
         feed('<c-w>li')
         screen:expect([[
-           27 line                 |line28                  |
-           28 line                 |line29                  |
-           29 line                 |line30                  |
+           27 line                 |line22                  |
+           28 line                 |line23                  |
+           29 line                 |line24                  |
            30 line                 |rows: 5, cols: 24       |
            31                      |{1: }                       |
           ==========                ==========              |
@@ -152,8 +152,8 @@ describe('terminal mouse', function()
         thelpers.enable_mouse()
         thelpers.feed_data('mouse enabled\n')
         screen:expect([[
-           27 line                 |line29                  |
-           28 line                 |line30                  |
+           27 line                 |line23                  |
+           28 line                 |line24                  |
            29 line                 |rows: 5, cols: 24       |
            30 line                 |mouse enabled           |
            31                      |{1: }                       |
@@ -165,8 +165,8 @@ describe('terminal mouse', function()
       it('wont lose focus if another window is scrolled', function()
         feed('<MouseDown><0,0><MouseDown><0,0>')
         screen:expect([[
-           21 line                 |line29                  |
-           22 line                 |line30                  |
+           21 line                 |line23                  |
+           22 line                 |line24                  |
            23 line                 |rows: 5, cols: 24       |
            24 line                 |mouse enabled           |
            25 line                 |{1: }                       |
@@ -175,8 +175,8 @@ describe('terminal mouse', function()
         ]])
         feed('<S-MouseUp><0,0>')
         screen:expect([[
-           26 line                 |line29                  |
-           27 line                 |line30                  |
+           26 line                 |line23                  |
+           27 line                 |line24                  |
            28 line                 |rows: 5, cols: 24       |
            29 line                 |mouse enabled           |
            30 line                 |{1: }                       |
@@ -188,8 +188,8 @@ describe('terminal mouse', function()
       it('will lose focus if another window is clicked', function()
         feed('<LeftMouse><5,1>')
         screen:expect([[
-           27 line                 |line29                  |
-           28 l^ine                 |line30                  |
+           27 line                 |line23                  |
+           28 l^ine                 |line24                  |
            29 line                 |rows: 5, cols: 24       |
            30 line                 |mouse enabled           |
            31                      |{2: }                       |


### PR DESCRIPTION
This is just a test to see if #2762 really had any effect on the indeterminism of the OS X builds, or if it was coincidental with recent travis maintenance.

Results:
- attempt 1:
  - OSX clang: passed
  - OSX gcc: gcov data issue:

```
374 successes / 0 failures / 76 errors / 1 pending : 15.299879 seconds
Pending -> ...vis/build/neovim/neovim/test/functional/job/job_spec.lua @ 328
jobs will only emit the "exit" event after "stdout" and "stderr"
Error -> ...vis/build/neovim/neovim/test/functional/job/job_spec.lua @ 359
jobs running tty-test program before_each
...vis/build/neovim/neovim/test/functional/job/job_spec.lua:365: Expected objects to be the same.
Passed in:
(string) 'profiling:/Users/travis/build/neovim/neovim/build/src/nvim/CMakeFiles/nvim.dir/os/wstream.c.gcda:Merge mismatch for function 1'
```
- attempt 2:
  - OSX clang: passed
  - OSX gcc: passed
- attempt 3:
  - OSX clang: passed
  - OSX gcc: passed

Conclusion: 

The OS X build failures went away because of travis upgrades/maintenance. 
