### PR TITLE
[RFC] CMake: Fix _FORTIFY_SOURCE detection when using hardening-wrapper.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,14 +94,15 @@ main(void)
 {
   return 0;
 }
-" _FORTIFY_SOURCE_ACCEPTABLE)
+" HAS_ACCEPTABLE_FORTIFY)
 
-if(NOT _FORTIFY_SOURCE_ACCEPTABLE)
+if(NOT HAS_ACCEPTABLE_FORTIFY)
+  message(STATUS "Unsupported _FORTIFY_SOURCE found, forcing _FORTIFY_SOURCE=1.")
   # Extract possible prefix to _FORTIFY_SOURCE (e.g. -Wp,-D_FORTIFY_SOURCE).
   STRING(REGEX MATCH "[^\ ]+-D_FORTIFY_SOURCE" _FORTIFY_SOURCE_PREFIX "${CMAKE_C_FLAGS}")
   STRING(REPLACE "-D_FORTIFY_SOURCE" "" _FORTIFY_SOURCE_PREFIX "${_FORTIFY_SOURCE_PREFIX}" )
   if (NOT _FORTIFY_SOURCE_PREFIX STREQUAL "")
-    message(STATUS "Detected _FORTIFY_SOURCE Prefix=${_FORTIFY_SOURCE_PREFIX}")
+    message(STATUS "Detected _FORTIFY_SOURCE Prefix=${_FORTIFY_SOURCE_PREFIX}.")
   endif()
   # -U in add_definitions doesn't end up in the correct spot, so we add it to
   # the flags variable instead.


### PR DESCRIPTION
From the commit message:

```
When checking code with check_c_source_compiles, the "check variable"
(for the _FORTIFY_SOURCE detection: previously _FORTIFY_SOURCE_ACCEPTABLE, now
HAS_ACCEPTABLE_FORTIFY) is passed to the compiler like
-D_FORTIFY_SOURCE_ACCEPTABLE. This throws off hardening-wrapper [1],
which then NOT sets _FORTIFY_SOURCE=2 for the check, assuming it had already
been set manually as it detected -D_FORTIFY_SOURCE*. Renaming the "check
variable" to not match this pattern works around this problem.

[1] https://github.com/thestinger/hardening-wrapper
```

I hope that manages to explain the problem :grin: I'm open for suggestions to improve the commit message.

The problematic line in hardening-wrapper is https://github.com/thestinger/hardening-wrapper/blob/master/cc-wrapper.sh#L33, which of course matches `_FORTIFY_SOURCE_ACCEPTABLE`.

Ping @jszakmeister.
