### PR TITLE
[RFC] api: return empty array when slicing past buffer end

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -108,7 +108,7 @@ ArrayOf(String) buffer_get_line_slice(Buffer buffer,
   Array rv = ARRAY_DICT_INIT;
   buf_T *buf = find_buffer_by_handle(buffer, err);
 
-  if (!buf) {
+  if (!buf || start >= buf->b_ml.ml_line_count) {
     return rv;
   }
 


### PR DESCRIPTION
Fixes strange behavior in client libraries that causes buf[n:n+m] to
return the last line for n > buffer_length.

Client library functions (e.g. for Python and Julia) are complicated by the fact that there's no atomic way determine whether the start index being past the end of the buffer and adjust accordingly.
