### PR TITLE
[RFC] CMake: Workaround for hanging helptags generation.

### DIFF
--- a/cmake/GenerateHelptags.cmake
+++ b/cmake/GenerateHelptags.cmake
@@ -1,28 +1,35 @@
 if(DEFINED ENV{DESTDIR})
   file(TO_CMAKE_PATH
-    "$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc"
+    $ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc
     HELPTAGS_WORKING_DIRECTORY)
 else()
   file(TO_CMAKE_PATH
-    "${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc"
+    ${CMAKE_INSTALL_PREFIX}/share/nvim/runtime/doc
     HELPTAGS_WORKING_DIRECTORY)
 endif()
 
 message(STATUS "Generating helptags in ${HELPTAGS_WORKING_DIRECTORY}.")
-if(EXISTS "${HELPTAGS_WORKING_DIRECTORY}/")
+if(EXISTS ${HELPTAGS_WORKING_DIRECTORY}/)
   message(STATUS "${HELPTAGS_WORKING_DIRECTORY} already exists")
-  # if the doc directory already exists, helptags could fail due to duplicate
+  # If the doc directory already exists, helptags could fail due to duplicate
   # tags. Tell the user to remove the directory and try again.
-  set(TROUBLESHOOTING "\nRemove \"${HELPTAGS_WORKING_DIRECTORY}\" and try again")
+  set(TROUBLESHOOTING "\nRemove \"${HELPTAGS_WORKING_DIRECTORY}\" and try again.")
 endif()
 
+# Workaround for hanging "yes | nvim -c 'helptags ++t .'"
+# and therefore hanging "yes | make install":
+# Set INPUT_FILE to an empty file, causing execute_process
+# to disregard other standard input (such as "yes |").
+set(EMPTY_FILE ${CMAKE_CURRENT_BINARY_DIR}/.GenerateHelptags)
+file(WRITE ${EMPTY_FILE} "")
 execute_process(
-  COMMAND "${CMAKE_CURRENT_BINARY_DIR}/bin/nvim"
+  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/bin/nvim
     -u NONE
     -esX
     -c "helptags ++t ."
     -c quit
-  WORKING_DIRECTORY "${HELPTAGS_WORKING_DIRECTORY}"
+  WORKING_DIRECTORY ${HELPTAGS_WORKING_DIRECTORY}
+  INPUT_FILE ${EMPTY_FILE}
   OUTPUT_VARIABLE err
   ERROR_VARIABLE err
   RESULT_VARIABLE res)


### PR DESCRIPTION
From the commit message:

```
Piping input into nvim causes the helptags generation to hang. For
example, the following does not work:

    yes | nvim -c "helptags ."

The helptags are generated during installation with a command similar
to the one above, using CMake's execute_process to call nvim.
As execute_process does not use an intermediate shell, the following
will cause the installation to hang:

    yes | make install

pacaur, an Arch Linux package helper, uses a similar command to
install packages [1], and thus can currently not be used to install
Neovim.

This commit adds a workaround to GenerateHelptags.cmake to circumvent
this problem.

[1] https://github.com/rmarquis/pacaur/blob/22c00a3d05f6504b44dfbc2f3cbd6ab1291e3c9c/pacaur#L825
```

Also removed a few quotes around CMake variables, since I think @jszakmeister mentioned they are not needed.
