### PR TITLE
[RFC] memline: Don't call memmove() with a NULL argument in ml_add_stack().

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -2936,12 +2936,9 @@ static int ml_add_stack(buf_T *buf)
   if (top == buf->b_ml.ml_stack_size) {
     CHECK(top > 0, _("Stack size increases"));     /* more than 5 levels??? */
 
-    infoptr_T *newstack = xmalloc(sizeof(infoptr_T) *
-                                    (buf->b_ml.ml_stack_size + STACK_INCR));
-    memmove(newstack, buf->b_ml.ml_stack, (size_t)top * sizeof(infoptr_T));
-    xfree(buf->b_ml.ml_stack);
-    buf->b_ml.ml_stack = newstack;
     buf->b_ml.ml_stack_size += STACK_INCR;
+    size_t new_size = sizeof(infoptr_T) * buf->b_ml.ml_stack_size;
+    buf->b_ml.ml_stack = xrealloc(buf->b_ml.ml_stack, new_size);
   }
 
   buf->b_ml.ml_stack_top++;


### PR DESCRIPTION
Found by compiling with the SANITIZE flag:

```
/home/oni-link/git/neovim/src/nvim/memline.c:2941:23: runtime error: null pointer passed
 as argument 2, which is declared to never be null
/usr/include/string.h:51:14: note: nonnull attribute specified here
SUMMARY: AddressSanitizer: undefined-behavior 
/home/oni-link/git/neovim/src/nvim/memline.c:2941:23 in
```

memline: Don't call `memmove()` with a `NULL` argument in `ml_add_stack()`.

When `ml_add_stack()` needs to increase the size of the empty stack,
`buf->b_ml.ml_stack` is `NULL` and is used as argument in `memmove()`.
This is undefined behaviour. Declaration of `memmove()` in string.h:

``` c
extern void *memmove (void *__dest, const void *__src, size_t __n)
     __THROW __nonnull ((1, 2));
```
