### PR TITLE
[RFC] Enable -Wconversion: tag.c

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -77,7 +77,6 @@ set(CONV_SOURCES
   search.c
   spell.c
   syntax.c
-  tag.c
   window.c)
 
 foreach(sfile ${CONV_SOURCES})

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -546,7 +546,7 @@ static char *(p_swb_values[]) = {"useopen", "usetab", "split", "newtab", NULL};
 #define SWB_SPLIT               0x004
 #define SWB_NEWTAB              0x008
 EXTERN int p_tbs;               /* 'tagbsearch' */
-EXTERN long p_tl;               /* 'taglength' */
+EXTERN size_t p_tl;             /* 'taglength' */
 EXTERN int p_tr;                /* 'tagrelative' */
 EXTERN char_u   *p_tags;        /* 'tags' */
 EXTERN int p_tgst;              /* 'tagstack' */


### PR DESCRIPTION
I tried to tackle this one. The only doubt that I have is for lines that interact with `num_matches` (https://github.com/neovim/neovim/pull/2803/files#diff-bb67c9d81d07a0359baaea74957f649dR1968) and `mincount` (https://github.com/neovim/neovim/pull/2803/files#diff-bb67c9d81d07a0359baaea74957f649dR1905): I wanted to make them `size_t` as well but they got passed around to other functions from the outside and following their uses wasn't easy, so I would like to hear some other opinion about those.
