### PR TITLE
[RFC] Travis: Disable Valgrind in GCC build.

### DIFF
--- a/.ci/gcc.sh
+++ b/.ci/gcc.sh
@@ -2,11 +2,12 @@
 
 sudo pip install cpp-coveralls
 
-if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-	sudo apt-get install valgrind
-	export VALGRIND=1
-	export VALGRIND_LOG="$tmpdir/valgrind-%p.log"
-fi
+# FIXME: Valgrind temporarily disabled (Timeouts on Travis).
+# if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+# 	sudo apt-get install valgrind
+# 	export VALGRIND=1
+# 	export VALGRIND_LOG="$tmpdir/valgrind-%p.log"
+# fi
 
 setup_deps x64
 


### PR DESCRIPTION
With Valgrind, the GCC build frequently passed the 50 min timeout on
Travis.

Ref #2678.

Follow-up PR: #2807.
