### PR TITLE
[RDY] Consistent indexing in [gs]et_line_slice API commands

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -108,7 +108,7 @@ ArrayOf(String) buffer_get_line_slice(Buffer buffer,
   Array rv = ARRAY_DICT_INIT;
   buf_T *buf = find_buffer_by_handle(buffer, err);
 
-  if (!buf) {
+  if (!buf || !inbounds(buf, start)) {
     return rv;
   }
 
@@ -549,4 +549,11 @@ static int64_t normalize_index(buf_T *buf, int64_t index)
   // Fix if > line_count
   index = index > buf->b_ml.ml_line_count ? buf->b_ml.ml_line_count : index;
   return index;
+}
+
+// Determines whether a 0-based index is within the bounds of the buffer
+static Boolean inbounds(buf_T *buf, int64_t index)
+{
+  linenr_T nlines = buf->b_ml.ml_line_count;
+  return index >= -nlines && index < nlines;
 }

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -179,6 +179,11 @@ void buffer_set_line_slice(Buffer buffer,
     return;
   }
 
+  if (!inbounds(buf, start)) {
+    api_set_error(err, Validation, _("Index out of bounds"));
+    return;
+  }
+
   start = normalize_index(buf, start) + (include_start ? 0 : 1);
   include_end = include_end || (end >= buf->b_ml.ml_line_count);
   end = normalize_index(buf, end) + (include_end ? 1 : 0);


### PR DESCRIPTION
Clamping the indices passed to the `_line_slice` commands to the start and end of the buffer using `normalize_index` leads to non-intuitive behavior. For instance, getting line(s) with a start index outside of the buffer's range returns the last line instead of an empty string or array, as is done by `getbufline`. Similarly, an out-of-bounds line/range set causes the last line to be clobbered instead of producing an error (c.f. `setline`).

This pull request addresses these issues by
- returning an empty string/array when the fetched start index is out of bounds,
- returning an error when setting/deleting an out-of-bounds location
