### PR TITLE
[RFC] Fix #2791 [s spell search not working

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2173,11 +2173,12 @@ spell_move_to (
                 if (attrp != NULL)
                   *attrp = attr;
                 return len;
-              } else if (curline)
+              } else if (curline) {
                 // Insert mode completion: put cursor after
                 // the bad word.
                 assert(len <= INT_MAX);
                 found_pos.col += (int)len;
+              }
               found_len = len;
             }
           } else


### PR DESCRIPTION
Hello, This is my first contribution, and it's an easy one. This is a good example of why you should always put curly brackets after an if statement, even if the block is only a single statement (at the time).
