### PR TITLE
[RFC] :e without a filename is disallowed in terminal buffers

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6570,6 +6570,10 @@ do_exedit (
               )
              || *eap->arg != NUL
              ) {
+    // :e is a no-op in terminal buffers
+    if (curbuf->terminal != NULL && eap->cmdidx == CMD_edit && *eap->arg == NUL) {
+      return;
+    }
     /* Can't edit another file when "curbuf_lock" is set.  Only ":edit"
      * can bring us here, others are stopped earlier. */
     if (*eap->arg != NUL && curbuf_locked())


### PR DESCRIPTION
Fixes issue #2779, throwing an error as suggested by @tarruda.
