### PR TITLE
[RFC] Fix vim_strchr() duplication

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -404,12 +404,8 @@ char_u *vim_strchr(const char_u *string, int c)
     }
     return NULL;
   }
-  while ((b = *p) != NUL) {
-    if (b == c)
-      return (char_u *) p;
-    ++p;
-  }
-  return NULL;
+
+  return vim_strbyte(p, c);
 }
 
 /*


### PR DESCRIPTION
Fix vim_strchr() duplication in string.c as per the issue #1474.
Is it true that this is all I have to do for this issue? I fear that I might have missed something.
