### PR TITLE
[RFC] Add StartupSourced event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -259,6 +259,7 @@ Name			triggered by ~
 |TermChanged|		after the value of 'term' has changed
 
 	Startup and exit
+|StartupSourced|	after sourcing the |vimrc| scripts
 |VimEnter|		after doing all the startup stuff
 |GUIEnter|		after starting the GUI successfully
 |GUIFailed|		after starting the GUI failed
@@ -809,6 +810,9 @@ SpellFileMissing		When trying to load a spell checking file and
 				against the language.  <amatch> is the
 				language, 'encoding' also matters.  See
 				|spell-SpellFileMissing|.
+						 	*StartupSourced*
+StartupSourced			After sourcing the |vimrc| scripts, before
+				loading the plugins.
 							*StdinReadPost*
 StdinReadPost			After reading from the stdin into the buffer,
 				before executing the modelines.  Only used

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5198,6 +5198,7 @@ static struct event_name {
   {"SourcePre",       EVENT_SOURCEPRE},
   {"SourceCmd",       EVENT_SOURCECMD},
   {"SpellFileMissing",EVENT_SPELLFILEMISSING},
+  {"StartupSourced",  EVENT_STARTUPSOURCED},
   {"StdinReadPost",   EVENT_STDINREADPOST},
   {"StdinReadPre",    EVENT_STDINREADPRE},
   {"SwapExists",      EVENT_SWAPEXISTS},

--- a/src/nvim/fileio.h
+++ b/src/nvim/fileio.h
@@ -68,6 +68,7 @@ typedef enum auto_event {
   EVENT_QUICKFIXCMDPRE,         /* before :make, :grep etc. */
   EVENT_QUITPRE,                /* before :quit */
   EVENT_SESSIONLOADPOST,        /* after loading a session file */
+  EVENT_STARTUPSOURCED,         /* after sourcing the startup scripts */
   EVENT_STDINREADPOST,          /* after reading from stdin */
   EVENT_STDINREADPRE,           /* before reading from stdin */
   EVENT_SYNTAX,                 /* syntax selected */

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -295,6 +295,7 @@ int main(int argc, char **argv)
 
   /* Source startup scripts. */
   source_startup_scripts(&params);
+  apply_autocmds(EVENT_STARTUPSOURCED, NULL, NULL, FALSE, NULL);
 
   /*
    * Read all the plugin files.


### PR DESCRIPTION
`StartupSourced` is executed at the point after the startup scripts are sourced. It is executed regardless of any vimrc being actually sourced. This is mainly meant for "early/prerc" plugins, and for user configuration within the vimrc.

This is used in [https://github.com/fmoralesc/neovim/tree/early/pluginmanager](https://github.com/fmoralesc/neovim/blob/early/pluginmanager/runtime/early/plug.vim) to make sure vim-plug's `plug#end()` call is called after the user configuration, so she doesn't have to call it by hand unless she needs to use some autoload function.

This is inspired by [LaTeX's `\AtEndDocument`](https://en.wikibooks.org/wiki/LaTeX/Macros#LaTeX_Hooks). I thought this could be useful in a general form, as a `SourcePost` event, but that would be more complicated to implement, so I simply implemented this reduced form.
