### PR TITLE
defaults: remove "i" from the default 'complete'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1529,7 +1529,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'compatible' 'cp'	Removed. |vim-differences| {Nvim}
 
 						*'complete'* *'cpt'* *E535*
-'complete' 'cpt'	string	(default: ".,w,b,u,t,i")
+'complete' 'cpt'	string	(default: ".,w,b,u,t")
 			local to buffer
 	This option specifies how keyword completion |ins-completion| works
 	when CTRL-P or CTRL-N are used.  It is also used for whole-line

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -29,6 +29,7 @@ these differences.
 2. Option defaults					  *nvim-option-defaults*
 
 - 'backspace' defaults to "indent,eol,start"
+- 'complete' doesn't include "i"
 - 'encoding' defaults to "utf-8"
 - 'formatoptions' defaults to "tcqj"
 - 'nocompatible' is always set

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -553,9 +553,9 @@ static vimoption_T
   {"compatible",  "cp",   P_BOOL|P_RALL,
    (char_u *)&p_force_off, PV_NONE,
    {(char_u *)TRUE, (char_u *)FALSE} SCRIPTID_INIT},
-  {"complete",    "cpt",  P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
+  {"complete",    "cpt",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_cpt, PV_CPT,
-   {(char_u *)".,w,b,u,t,i", (char_u *)0L}
+   {(char_u *)".,w,b,u,t,i", (char_u *)".,w,b,u,t"}
    SCRIPTID_INIT},
   {"concealcursor","cocu", P_STRING|P_ALLOCED|P_RWIN|P_VI_DEF,
    VAR_WIN, PV_COCU,


### PR DESCRIPTION
"i" could slow down the completion.

Re: https://github.com/neovim/neovim/issues/2676
