### PR TITLE
options: 'fileformats' includes "mac" by default on every platform

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2589,9 +2589,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 					*'fileformats'* *'ffs'*
 'fileformats' 'ffs'	string (default:
-				Vim+Vi	Win32: "dos,unix",
-				Vim	Unix: "unix,dos",
-				Vim	Mac: "mac,unix,dos",
+				Vim+Vi	Win32: "dos,unix,mac",
+				Vim	Unix: "unix,dos,mac",
 				Vi	others: "")
 			global
 	This gives the end-of-line (<EOL>) formats that will be tried when

--- a/runtime/doc/usr_23.txt
+++ b/runtime/doc/usr_23.txt
@@ -66,15 +66,12 @@ character halfway in a line.  Incidentally, this happens quite often in Vi
    On the Macintosh, where <CR> is the line break character, it's possible to
 have a <LF> character halfway in a line.
    The result is that it's not possible to be 100% sure whether a file
-containing both <CR> and <LF> characters is a Mac or a Unix file.  Therefore,
-Vim assumes that on Unix you probably won't edit a Mac file, and doesn't check
-for this type of file.  To check for this format anyway, add "mac" to
-'fileformats': >
+containing both <CR> and <LF> characters is a Mac or a Unix file.  Vim will
+try to take a guess at the file format. Watch out for situations where Vim
+guesses wrong. If you prefer to assume that on Unix you probably won't edit
+a Mac file, and Vim shouldn't check for it, remove "mac" from 'fileformats': >
 
-	:set fileformats+=mac
-
-Then Vim will take a guess at the file format.  Watch out for situations where
-Vim guesses wrong.
+	:set fileformats-=mac
 
 
 OVERRULING THE FORMAT

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -30,6 +30,7 @@ these differences.
 
 - 'backspace' defaults to "indent,eol,start"
 - 'encoding' defaults to "utf-8"
+- 'fileformats' includes "mac" in every platform
 - 'formatoptions' defaults to "tcqj"
 - 'nocompatible' is always set
 - 'nrformats' defaults to "hex"

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -38,11 +38,11 @@
 
 #ifdef USE_CRNL
 # define DFLT_FF        "dos"
-# define DFLT_FFS_VIM   "dos,unix"
+# define DFLT_FFS_VIM   "dos,unix,mac"
 # define DFLT_FFS_VI    "dos,unix"      /* also autodetect in compatible mode */
 #else
 #  define DFLT_FF       "unix"
-#  define DFLT_FFS_VIM  "unix,dos"
+#  define DFLT_FFS_VIM  "unix,dos,mac"
 #   define DFLT_FFS_VI  ""
 #endif
 


### PR DESCRIPTION
Re: https://github.com/neovim/neovim/issues/2676

Updated the documentation.

Reading `runtime/doc/usr_23.txt` I came upon this:

```
On Unix, <LF> is used to break a line.  It's not unusual to have a <CR>
character halfway in a line.  Incidentally, this happens quite often in Vi
(and Vim) scripts.
   On the Macintosh, where <CR> is the line break character, it's possible to
have a <LF> character halfway in a line.
   The result is that it's not possible to be 100% sure whether a file
containing both <CR> and <LF> characters is a Mac or a Unix file.  Therefore,
Vim assumes that on Unix you probably won't edit a Mac file, and doesn't check
for this type of file.  To check for this format anyway, add "mac" to
'fileformats': >

    :set fileformats+=mac

Then Vim will take a guess at the file format.  Watch out for situations where
Vim guesses wrong.
```

and I'm not sure if this is a good default now. I guess the chance of trouble is small, but I'll want a second opinion on this one.
