### PR TITLE
[RDY] options: set 'history' to 10000 (the max) by default.

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -54,8 +54,7 @@ history tables:
 - one for debug mode commands
 These are completely separate.  Each history can only be accessed when
 entering the same type of line.
-Use the 'history' option to set the number of lines that are remembered
-(default: 50).
+Use the 'history' option to set the number of lines that are remembered.
 Notes:
 - When you enter a command-line that is exactly the same as an older one, the
   old one is removed (to avoid repeated commands moving older commands out of

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3552,12 +3552,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	with the 'h' flag in 'viminfo' |viminfo-h|.
 
 						*'history'* *'hi'*
-'history' 'hi'		number	(Vim default: 50, Vi default: 0)
+'history' 'hi'		number	(Vim default: 10000, Vi default: 0)
 			global
 	A history of ":" commands, and a history of previous search patterns
 	is remembered.  This option decides how many entries may be stored in
 	each of these histories (see |cmdline-editing|).
-	The maximum value is 10000.
+	Vim's default is the maximum value.
 
 					 *'hkmap'* *'hk'* *'nohkmap'* *'nohk'*
 'hkmap' 'hk'		boolean (default off)

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -35,6 +35,7 @@ these differences.
 - 'display' defaults to "lastline"
 - 'encoding' defaults to "utf-8"
 - 'formatoptions' defaults to "tcqj"
+- 'history' defaults to 10000 (the maximum)
 - 'hlsearch' is set by default
 - 'incsearch' is set by default
 - 'langnoremap' is set by default

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -870,7 +870,7 @@ static vimoption_T
    SCRIPTID_INIT},
   {"history",     "hi",   P_NUM|P_VIM,
    (char_u *)&p_hi, PV_NONE,
-   {(char_u *)0L, (char_u *)50L} SCRIPTID_INIT},
+   {(char_u *)0L, (char_u *)10000L} SCRIPTID_INIT},
   {"hkmap",       "hk",   P_BOOL|P_VI_DEF|P_VIM,
    (char_u *)&p_hkmap, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},


### PR DESCRIPTION
Re: https://github.com/neovim/neovim/issues/2676
