### PR TITLE
options: prefix "!" to 'viminfo' by default

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6900,8 +6900,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 				*'viminfo'* *'vi'* *E526* *E527* *E528*
 'viminfo' 'vi'		string	(Vim default for
-				   Win32:  '100,<50,s10,h,rA:,rB:
-				   others: '100,<50,s10,h
+				   Win32:  '!,100,<50,s10,h,rA:,rB:
+				   others: '!,100,<50,s10,h
 				 Vi default: "")
 			global
 			{not available when compiled without the |+viminfo|

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -41,6 +41,7 @@ these differences.
 - 'smarttab' is set by default
 - 'tags' defaults to "./tags;,tags"
 - 'ttyfast' is always set
+- 'viminfo' includes "!"
 - 'wildmenu' is set by default
 - 'wildmode' defaults to "list:longest,full"
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1587,7 +1587,7 @@ static vimoption_T
    SCRIPTID_INIT},
   {"viminfo",     "vi",   P_STRING|P_COMMA|P_NODUP|P_SECURE,
    (char_u *)&p_viminfo, PV_NONE,
-   {(char_u *)"", (char_u *)"'100,<50,s10,h"}
+   {(char_u *)"", (char_u *)"!,'100,<50,s10,h"}
    SCRIPTID_INIT},
   {"virtualedit", "ve",   P_STRING|P_COMMA|P_NODUP|P_VI_DEF|P_VIM|P_CURSWANT,
    (char_u *)&p_ve, PV_NONE,


### PR DESCRIPTION
Re: https://github.com/neovim/neovim/issues/2676
