### PR TITLE
options: don't include "options" in 'sessionoptions' by default.

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5406,10 +5406,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'sessionoptions'* *'ssop'*
 'sessionoptions' 'ssop'	string	(default: "blank,buffers,curdir,folds,
+					       help,tabpages,winsize"
+				 Vi default: "blank,buffers,curdir,folds,
 					       help,options,tabpages,winsize")
 			global
-			{not available when compiled without the |+mksession|
-			feature}
 	Changes the effect of the |:mksession| command.  It is a comma
 	separated list of words.  Each word enables saving and restoring
 	something:

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -28,8 +28,8 @@ these differences.
 ==============================================================================
 2. Option defaults					  *nvim-option-defaults*
 
-- 'autoread' is set by default
 - 'autoindent' is set by default.
+- 'autoread' is set by default
 - 'backspace' defaults to "indent,eol,start"
 - 'complete' doesn't include "i"
 - 'display' defaults to "lastline"
@@ -41,6 +41,7 @@ these differences.
 - 'mouse' defaults to "a"
 - 'nocompatible' is always set
 - 'nrformats' defaults to "hex"
+- 'sessionoptions' doesn't include "options"
 - 'smarttab' is set by default
 - 'tabpagemax' defaults to 50
 - 'tags' defaults to "./tags;,tags"

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1305,10 +1305,10 @@ static vimoption_T
   {"selectmode",  "slm",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
    (char_u *)&p_slm, PV_NONE,
    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"sessionoptions", "ssop", P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"sessionoptions", "ssop", P_STRING|P_VIM|P_COMMA|P_NODUP,
    (char_u *)&p_ssop, PV_NONE,
    {(char_u *)"blank,buffers,curdir,folds,help,options,tabpages,winsize",
-    (char_u *)0L}
+    (char_u *)"blank,buffers,curdir,folds,help,tabpages,winsize"}
    SCRIPTID_INIT},
   {"shell",       "sh",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
    (char_u *)&p_sh, PV_NONE,


### PR DESCRIPTION
Re: https://github.com/neovim/neovim/issues/2676
