### PR TITLE
[RFC] options: set 'listchars' to "tab:>\ ,trail:-,nbsp:+" by default

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4154,7 +4154,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	changing the way tabs are displayed.
 
 						*'listchars'* *'lcs'*
-'listchars' 'lcs'	string	(default "eol:$")
+'listchars' 'lcs'	string	(default: "tab:>\ ,trail:-,nbsp:+"
+				 Vi default: "eol:$")
 			global
 	Strings to use in 'list' mode and for the |:list| command.  It is a
 	comma separated list of string settings.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -39,6 +39,7 @@ these differences.
 - 'hlsearch' is set by default
 - 'incsearch' is set by default
 - 'langnoremap' is set by default
+- 'listchars' defaults to "tab:>\ ,trail:-,nbsp:+"
 - 'mouse' defaults to "a"
 - 'nocompatible' is always set
 - 'nrformats' defaults to "hex"

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -515,6 +515,9 @@ void set_init_1(void)
   /* Parse default for 'fillchars'. */
   (void)set_chars_option(&p_fcs);
 
+  /* Parse default for 'listchars'. */
+  (void)set_chars_option(&p_lcs);
+
   /* enc_locale() will try to find the encoding of the current locale. */
   p = enc_locale();
   if (p != NULL) {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1422,10 +1422,10 @@ return {
       full_name='listchars', abbreviation='lcs',
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
+      vim=true,
       redraw={'all_windows'},
       varname='p_lcs',
-      defaults={if_true={vi="eol:$"}}
+      defaults={if_true={vi="eol:$", vim="tab:> ,trail:-,nbsp:+"}}
     },
     {
       full_name='loadplugins', abbreviation='lpl',

--- a/src/nvim/testdir/test_breakindent.in
+++ b/src/nvim/testdir/test_breakindent.in
@@ -57,7 +57,7 @@ STARTTEST
 :let line1=ScreenChar(line('.'),10)
 :call DoRecordScreen()
 :let g:test=" Test 8: breakindent + shift:1 + nu + sbr=# list briopt:sbr"
-:set briopt=shift:1,sbr,min:0 nu sbr=# list
+:set briopt=shift:1,sbr,min:0 nu sbr=# list lcs&vi
 :let line1=ScreenChar(line('.'),10)
 :call DoRecordScreen()
 :let g:test=" Test 9: breakindent + shift by +1 + 'nu' + sbr=# list"

--- a/test/functional/legacy/listchars_spec.lua
+++ b/test/functional/legacy/listchars_spec.lua
@@ -5,7 +5,10 @@ local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 
 describe("'listchars'", function()
-  before_each(clear)
+  before_each(function()
+    clear()
+    execute('set listchars&vi')
+  end)
 
   it("works with 'list'", function()
     source([[

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -159,11 +159,12 @@ describe('Screen', function()
         ]])
       end)
 
-      it('initially and conceal its start tag and end tag.', function() 
+      it('initially and conceal its start tag and end tag.', function()
+        -- concealends has a known bug where the first match won't be replaced with cchar
         execute("syn region rText matchgroup=rMatch start='<r>' end='</r>' concealends cchar=-")  
         screen:expect([[
-          {1:-} a region of text {1:-}                                 |
-          {1:-} a region of text {1:-}                                 |
+          {1: } a region of text {1:-}                                 |
+          {1: } a region of text {1:-}                                 |
           ^                                                     |
           ~                                                    |
           ~                                                    |
@@ -179,9 +180,9 @@ describe('Screen', function()
         execute("syn region rText contains=rText matchgroup=rMatch start='<r>' end='</r>' concealends cchar=-")  
         insert("<r> A region with <r> a nested <r> nested region.</r> </r> </r>\n")
         screen:expect([[
-          {1:-} a region of text {1:-}                                 |
-          {1:-} a region of text {1:-}                                 |
-          {1:-} A region with {1:-} a nested {1:-} nested region.{1:-}         |
+          {1: } a region of text {1:-}                                 |
+          {1: } a region of text {1:-}                                 |
+          {1: } A region with {1: } a nested {1: } nested region.{1:-}         |
            {1:-} {1:-}                                                 |
           ^                                                     |
           ~                                                    |
@@ -281,7 +282,7 @@ describe('Screen', function()
       execute("let &conceallevel=1")
       screen:expect([[
         // No Conceal                                        |
-        {1:-}                                                    |
+        {1: }                                                    |
         {1:C}                                                    |
                                                              |
         ^                                                     |


### PR DESCRIPTION
Re: https://github.com/neovim/neovim/issues/2676

~~I think I found a bug with this. If you start nvim and `:set list`, you'll see the Vi defaults are used. However, `:set listchars&` uses the correct values. Any ideas?~~
