### PR TITLE
options: enable 'showcmd' by default on Unix

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5725,7 +5725,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	"n" flag to 'cpoptions'.
 
 				     *'showcmd'* *'sc'* *'noshowcmd'* *'nosc'*
-'showcmd' 'sc'		boolean	(Vim default: on (off for Unix),
+'showcmd' 'sc'		boolean	(Vim default: on,
 				 Vi default: off)
 			global
 			{not available when compiled without the

--- a/runtime/doc/os_unix.txt
+++ b/runtime/doc/os_unix.txt
@@ -27,10 +27,6 @@ system() is used, which is a bit slower.  The output of ":version" includes
 |+fork| when fork()/exec() is used, |+system()| when system() is used.  This
 can be changed at compile time.
 
-Because terminal updating under Unix is often slow (e.g. serial line
-terminal, shell window in suntools), the 'showcmd' and 'ruler' options
-are off by default.
-
 When using Vim in an xterm the mouse clicks can be used by Vim by setting
 'mouse' to "a".  If there is access to an X-server gui style copy/paste will
 be used and visual feedback will be provided while dragging with the mouse.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -39,6 +39,7 @@ these differences.
 - 'nocompatible' is always set
 - 'nrformats' defaults to "hex"
 - 'smarttab' is set by default
+- 'showcmd' is set by default on Unix
 - 'tags' defaults to "./tags;,tags"
 - 'ttyfast' is always set
 - 'wildmenu' is set by default

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1376,13 +1376,7 @@ static vimoption_T
    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
   {"showcmd",     "sc",   P_BOOL|P_VIM,
    (char_u *)&p_sc, PV_NONE,
-   {(char_u *)FALSE,
-#ifdef UNIX
-    (char_u *)FALSE
-#else
-      (char_u *) TRUE
-#endif
-   } SCRIPTID_INIT},
+   {(char_u *)FALSE, (char_u *) TRUE} SCRIPTID_INIT},
   {"showfulltag", "sft",  P_BOOL|P_VI_DEF,
    (char_u *)&p_sft, PV_NONE,
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},


### PR DESCRIPTION
Re: https://github.com/neovim/neovim/issues/2676

It seems like the warning in the docs about this being slow under Unix are not unwarranted at all: the functional tests are stalling like crazy with this. Under normal usage it is OK, though, so perhaps we could disable it for those in `test/functional/helpers.lua`:

``` lua
local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
                   '--cmd', 'set shortmess+=I background=light noswapfile noautoindent noshowcmd',
                   '--embed'}
```

See https://github.com/tpope/vim-sensible/issues/49 too.
