### PR TITLE
Break if undo_read_byte returns -1 in bad undofile

### DIFF
--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -839,7 +839,12 @@ static u_header_T *unserialize_uhp(bufinfo_T *bi, char_u *file_name)
   for (;; ) {
     int len = undo_read_byte(bi);
 
-    if (len == 0) {
+    if (len == EOF) {
+      corruption_error("undo_read_byte EOF", file_name);
+      xfree(uhp);
+      return NULL;
+    }
+    else if (len == 0) {
       break;
     }
     int what = undo_read_byte(bi);


### PR DESCRIPTION
Fix for #2879:

It looks like its possible for the undofile to be corrupted in such a way that instead of returning 0, undo_read_byte returns -1, which causes this for loop to loop infinitely.  Switching the == 0 check to <= 0 breaks the loop and vim functions normally.

This seems like kind of an inelegant/ugly fix though.  Let me know what you all think.
