### PR TITLE
[RFC] Enable -Wconversion: menu.c

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -66,7 +66,6 @@ set(CONV_SOURCES
   if_cscope.c
   mbyte.c
   memline.c
-  menu.c
   message.c
   misc1.c
   ops.c

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7779,7 +7779,7 @@ static void ex_stopinsert(exarg_T *eap)
  * Execute normal mode command "cmd".
  * "remap" can be REMAP_NONE or REMAP_YES.
  */
-void exec_normal_cmd(char_u *cmd, int remap, int silent)
+void exec_normal_cmd(char_u *cmd, int remap, bool silent)
 {
   oparg_T oa;
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -848,11 +848,11 @@ static void init_typebuf(void)
  * If nottyped is TRUE, the string does not return KeyTyped (don't use when
  * offset is non-zero!).
  *
- * If silent is TRUE, cmd_silent is set when the characters are obtained.
+ * If silent is true, cmd_silent is set when the characters are obtained.
  *
  * return FAIL for failure, OK otherwise
  */
-int ins_typebuf(char_u *str, int noremap, int offset, int nottyped, int silent)
+int ins_typebuf(char_u *str, int noremap, int offset, int nottyped, bool silent)
 {
   char_u      *s1, *s2;
   int newlen;

--- a/src/nvim/menu.h
+++ b/src/nvim/menu.h
@@ -39,10 +39,10 @@ struct VimMenu {
                                      * was not translated */
   int mnemonic;                     /* mnemonic key (after '&') */
   char_u      *actext;              /* accelerator text (after TAB) */
-  int priority;                     /* Menu order priority */
+  long priority;                     /* Menu order priority */
   char_u      *strings[MENU_MODES];   /* Mapped string for each mode */
   int noremap[MENU_MODES];           /* A REMAP_ flag for each mode */
-  char silent[MENU_MODES];          /* A silent flag for each mode */
+  bool silent[MENU_MODES];          /* A silent flag for each mode */
   vimmenu_T   *children;            /* Children of sub-menu */
   vimmenu_T   *parent;              /* Parent of menu */
   vimmenu_T   *next;                /* Next item in menu */


### PR DESCRIPTION
Enable `-Wconversion` for `menu.c` (ref #567).

I did this:
- change the `silent` field on `vimmenu_T` to be a `bool`. This is the change I'm least confident about because there are lots of `silent` flags in many places -- I ended up changing the signature of a couple of functions outside `menu.c` but I wasn't sure how far to go with that.
- change the `pri_tab` (priority table) to be an array of longs, rather than ints, because at one point it gets assigned a `linenr_T`.
- the rest are straightforward fixes -- in a couple of places just change the type of a variable used once, and fix some pointer subtractions that were cast to int rather than size_t. (I verified the pointer subtractions and they all seem obviously correct -- could add some asserts here but I didn't think it was necessary).
  
  (There are other ints in this file that could be bools that I didn't change, e.g. because some of them take the `MAYBE` value and I wasn't sure what to do with that.)
