### PR TITLE
[RFC] options: 'background' defaults to 'dark'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -765,13 +765,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	been set.
 
 							*'background'* *'bg'*
-'background' 'bg'	string	(default "dark" or "light", see below)
+'background' 'bg'	string	(default "dark")
 			global
 	When set to "dark", Vim will try to use colors that look good on a
 	dark background.  When set to "light", Vim will try to use colors that
 	look good on a light background.  Any other value is illegal.
-	Vim tries to set the default value according to the terminal used.
-	This will not always be correct.
 	Setting this option does not change the background color, it tells Vim
 	what the background color looks like.  For changing the background
 	color, see |:hi-normal|.
@@ -784,25 +782,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	the color scheme adjusts to the value of 'background' this will work.
 	However, if the color scheme sets 'background' itself the effect may
 	be undone.  First delete the "g:colors_name" variable when needed.
-
-	When setting 'background' to the default value with: >
-		:set background&
-<	Vim will guess the value.  In the GUI this should work correctly,
-	in other cases Vim might not be able to guess the right value.
-
-	When starting the GUI, the default value for 'background' will be
-	"light".  When the value is not set in the .gvimrc, and Vim detects
-	that the background is actually quite dark, 'background' is set to
-	"dark".  But this happens only AFTER the .gvimrc file has been read
-	(because the window needs to be opened to find the actual background
-	color).  To get around this, force the GUI window to be opened by
-	putting a ":gui" command in the .gvimrc file, before where the value
-	of 'background' is used (e.g., before ":syntax on").
-
-	For MS-DOS and Windows the default is "dark".
-	For other systems "dark" is used when 'term' is "linux",
-	"screen.linux", "cygwin" or "putty", or $COLORFGBG suggests a dark
-	background.  Otherwise the default is "light".
 
 	Normally this option would be set in the .vimrc file.  Possibly
 	depending on the terminal name.  Example: >

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -30,6 +30,7 @@ these differences.
 
 - 'autoindent' is set by default
 - 'autoread' is set by default
+- 'background' defaults to "dark"
 - 'backspace' defaults to "indent,eol,start"
 - 'complete' doesn't include "i"
 - 'display' defaults to "lastline"

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -135,10 +135,10 @@ return {
     {
       full_name='background', abbreviation='bg',
       type='string', scope={'global'},
-      vi_def=true,
+      vim=true,
       redraw={'everything'},
       varname='p_bg',
-      defaults={if_true={vi="light"}}
+      defaults={if_true={vi="light",vim="dark"}}
     },
     {
       full_name='backspace', abbreviation='bs',


### PR DESCRIPTION
Re: https://github.com/neovim/neovim/issues/2676#issuecomment-114947570

To restore the logic in `:h 'background'` in the TUI, we'll need to implement a way to detect if the tui is running, since it is handled this way in vim's `src/option.c`:

``` c
                if ((char_u **)varp == &p_bg)
                {
                /* guess the value of 'background' */
#ifdef FEAT_GUI
                if (gui.in_use)
                    newval = gui_bg_default();
                else
#endif
                    newval = term_bg_default();
                }
```

We could also add the `term_bg_default()` logic to the `tui_start()` function. I'm currently exploring this option, but I'll wait for comments (@justinmk).
