### PR TITLE
[RDY] remote plugin: allow users to register own hosts

### DIFF
--- a/test/functional/runtime/autoload/remote/define_spec.lua
+++ b/test/functional/runtime/autoload/remote/define_spec.lua
@@ -346,7 +346,7 @@ local function host()
 end
 
 local function register()
-  eval('remote#host#Register("busted", '..channel()..')')
+  eval('remote#host#Register("busted", "busted", '..channel()..')')
 end
 
 command_specs_for('remote#define#CommandOnChannel', true, channel)


### PR DESCRIPTION
Currently, the only way to register a new plugin host is by adding its name, file patterns, and factory function to  `host.vim`, which makes it challenging to create and deploy non-standard plugin hosts.

The proposed changes allow users to register their own plugin hosts using `remote#host#Register` and then access the loaded plugins in the now-external factory by calling `remote#host#PluginsForHost`.
