### PR TITLE
[RFC] event_teardown(): retry uv_loop_close() instead of abort. 

### DIFF
--- a/src/nvim/os/event.c
+++ b/src/nvim/os/event.c
@@ -69,24 +69,19 @@ void event_teardown(void)
 
   process_events_from(immediate_events);
   process_events_from(deferred_events);
-  // reset the stop_flag to ensure `uv_run` below won't exit early. This hack
-  // is required because the `process_events_from` above may call `event_push`
-  // which will set the stop_flag to 1(uv_stop)
-  uv_default_loop()->stop_flag = 0;
   input_stop();
   channel_teardown();
   job_teardown();
   server_teardown();
   signal_teardown();
   terminal_teardown();
+
   // this last `uv_run` will return after all handles are stopped, it will
   // also take care of finishing any uv_close calls made by other *_teardown
   // functions.
-  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-  // abort that if we left unclosed handles
-  if (uv_loop_close(uv_default_loop())) {
-    abort();
-  }
+  do {
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+  } while (uv_loop_close(uv_default_loop()));
 }
 
 // Wait for some event


### PR DESCRIPTION
re https://github.com/neovim/neovim/pull/2663

Posting @oni-link patch to run against travis & QB. @equalsraf @fdinoff @osa1 may want to try this out before merge.

```
abort() causes a bad exit; retry uv_loop_close() instead.

Closes #2466
Closes #2648

Helped-by: Rui Abreu Ferreira <raf-ep@gmx.com>
```
