### PR TITLE
[RFC] Python: fixes for sys.path_hooks handler

### DIFF
--- a/runtime/autoload/provider/script_host.py
+++ b/runtime/autoload/provider/script_host.py
@@ -17,6 +17,9 @@ IS_PYTHON3 = sys.version_info >= (3, 0)
 if IS_PYTHON3:
     basestring = str
 
+    if sys.version_info >= (3, 4):
+        from importlib.machinery import PathFinder
+
 
 @neovim.plugin
 class ScriptHost(object):
@@ -212,8 +215,9 @@ def path_hook(nvim):
             return self.module
 
     class VimPathFinder(object):
-        @classmethod
-        def find_module(cls, fullname, path=None):
+        @staticmethod
+        def find_module(fullname, path=None):
+            "Method for Python 2.7 and 3.3."
             try:
                 return VimModuleLoader(
                     _find_module(fullname, fullname, path or _get_paths()))
@@ -223,6 +227,11 @@ def path_hook(nvim):
         @classmethod
         def load_module(cls, fullname, path=None):
             return _find_module(fullname, fullname, path or _get_paths())
+
+        @staticmethod
+        def find_spec(fullname, path=None, target=None):
+            "Method for Python 3.4+."
+            return PathFinder.find_spec(fullname, path or _get_paths(), target)
 
     def hook(path):
         if path == nvim.VIM_SPECIAL_PATH:

--- a/runtime/autoload/provider/script_host.py
+++ b/runtime/autoload/provider/script_host.py
@@ -226,10 +226,6 @@ def path_hook(nvim):
             except ImportError:
                 return None
 
-        @classmethod
-        def load_module(cls, fullname, path=None):
-            return _find_module(fullname, fullname, path or _get_paths())
-
         @staticmethod
         def find_spec(fullname, path=None, target=None):
             "Method for Python 3.4+."

--- a/runtime/autoload/provider/script_host.py
+++ b/runtime/autoload/provider/script_host.py
@@ -212,6 +212,9 @@ def path_hook(nvim):
             self.module = module
 
         def load_module(self, fullname, path=None):
+            # Check sys.modules, required for reload (see PEP302).
+            if fullname in sys.modules:
+                return sys.modules[fullname]
             return self.module
 
     class VimPathFinder(object):

--- a/runtime/autoload/provider/script_host.py
+++ b/runtime/autoload/provider/script_host.py
@@ -201,11 +201,10 @@ def path_hook(nvim):
             name = oldtail[:idx]
             tail = oldtail[idx+1:]
             fmr = imp.find_module(name, path)
-            module = imp.load_module(fullname[:-len(oldtail)] + name, *fmr)
+            module = imp.find_module(fullname[:-len(oldtail)] + name, *fmr)
             return _find_module(fullname, tail, module.__path__)
         else:
-            fmr = imp.find_module(fullname, path)
-            return imp.load_module(fullname, *fmr)
+            return imp.find_module(fullname, path)
 
     class VimModuleLoader(object):
         def __init__(self, module):
@@ -215,7 +214,7 @@ def path_hook(nvim):
             # Check sys.modules, required for reload (see PEP302).
             if fullname in sys.modules:
                 return sys.modules[fullname]
-            return self.module
+            return imp.load_module(fullname, *self.module)
 
     class VimPathFinder(object):
         @staticmethod


### PR DESCRIPTION
The main fix is for Python 3.4, which loads a module twice currently (https://github.com/neovim/neovim/issues/2909).

While at it, I've fixed some more issues.
