### PR TITLE
[RFC] cmdline: PATHSEP descends into directory after showing wildmenu

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -372,6 +372,8 @@ getcmdline (
         c = Ctrl_P;
       else if (c == K_RIGHT)
         c = Ctrl_N;
+      else if (c == PATHSEP)
+        c = K_DOWN;
     }
     /* Hitting CR after "emenu Name.": complete submenu */
     if (xpc.xp_context == EXPAND_MENUNAMES && p_wmnu


### PR DESCRIPTION
This change makes it so that typing the `PATHSEP` character when tabbing through the file menu descends into the selected directory. This tries to mimic the (very intuitive, IMHO) behavior of zsh.
