### PR TITLE
[RDY] rplugin: pass additional info to host factory function

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -40,7 +40,11 @@ function! remote#host#Require(name)
   endif
   let host = s:hosts[a:name]
   if !host.channel && !host.initialized
-    let host.channel = call(host.factory, [a:name])
+    let host_info = {
+          \ 'name': a:name,
+          \ 'orig_name': get(host, 'orig_name', a:name)
+          \ }
+    let host.channel = call(host.factory, [host_info])
     let host.initialized = 1
   endif
   return host.channel
@@ -189,16 +193,14 @@ endfunction
 " Registration of standard hosts
 
 " Python/Python3 {{{
-function! s:RequirePythonHost(name)
-  let ver_name = has_key(s:hosts[a:name], 'orig_name') ?
-        \ s:hosts[a:name].orig_name : a:name
-  let ver = (ver_name ==# 'python') ? 2 : 3
+function! s:RequirePythonHost(host)
+  let ver = (a:host.orig_name ==# 'python') ? 2 : 3
 
   " Python host arguments
   let args = ['-c', 'import neovim; neovim.start_host()']
 
   " Collect registered Python plugins into args
-  let python_plugins = remote#host#PluginsForHost(a:name)
+  let python_plugins = remote#host#PluginsForHost(a:host.name)
   for plugin in python_plugins
     call add(args, plugin.path)
   endfor


### PR DESCRIPTION
This is a followup to #2896 that passes additional information to the host factory function.

The rationale is that most factories will want to know the original name of the host (i.e. sans "-registration-clone"). As it stands, however, this information is only easily accessible from the `s:hosts` dictionary and would otherwise need to be determined from `a:name` using calls to `match`. Passing select members of `s:hosts[name]` as the sole argument provides the required information while preventing exposure of internal state and maintaining backwards compatibility should additional information be added.

This change will not significantly affect any existing hosts due to the recency of #2898 being merged.
