### PR TITLE
[RDY] vim-patch:5d89d9b

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -569,7 +569,10 @@ list of the current window.
 			Also see |++opt| and |+cmd|.
 
 :[count]arga[dd] {name} ..			*:arga* *:argadd* *E479*
-			Add the {name}s to the argument list.
+:[count]arga[dd]
+			Add the {name}s to the argument list.  When {name} is
+			omitted add the current buffer name to the argument
+			list.
 			If [count] is omitted, the {name}s are added just
 			after the current entry in the argument list.
 			Otherwise they are added after the [count]'th file.
@@ -579,7 +582,8 @@ list of the current window.
 				:argadd x	a b x c
 				:0argadd x	x a b c
 				:1argadd x	a x b c
-				:99argadd x	a b c x
+				:$argadd x	a b c x
+				:+2argadd y	a b c x y
 			There is no check for duplicates, it is possible to
 			add a file to the argument list twice.
 			The currently edited file is not changed.
@@ -597,11 +601,19 @@ list of the current window.
 			Example: >
 				:argdel *.obj
 
-:{range}argd[elete]	Delete the {range} files from the argument list.
+:[range]argd[elete]	Delete the {range} files from the argument list.
+			Example: >
+				:10,$argdel
+<			Deletes arguments 10 and further, keeping 1-9. >
+				:$argd
+<			Deletes just the last one. >
+				:argd
+				:.argd
+<			Deletes the current argument. >
+				:%argd
+<			Removes all the files from the arglist.
 			When the last number in the range is too high, up to
-			the last argument is deleted.  Example: >
-				:10,1000argdel
-<			Deletes arguments 10 and further, keeping 1-9.
+			the last argument is deleted.
 
 							*:argu* *:argument*
 :[count]argu[ment] [count] [++opt] [+cmd]
@@ -1018,7 +1030,7 @@ The names can be in upper- or lowercase.
 
 :q[uit]!		Quit without writing, also when currently visible
 			buffers have changes.  Does not exit when this is the
-			last window and there are is a changed hidden buffer.
+			last window and there is a changed hidden buffer.
 			In this case, the first changed hidden buffer becomes
 			the current buffer.
 			Use ":qall!" to exit always.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 7.4.  Last change: 2014 Nov 15
+*eval.txt*	For Vim version 7.4.  Last change: 2014 Nov 27
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -3302,6 +3302,17 @@ getchar([expr])						*getchar()*
 			:    endif
 			:  endwhile
 			:endfunction
+<
+		You may also receive syntetic characters, such as
+		|<CursorHold>|. Often you will want to ignore this and get
+		another character: >
+			:function GetKey()
+			:  let c = getchar()
+			:  while c == "\<CursorHold>"
+			:    let c = getchar()
+			:  endwhile
+			:  return c
+			:endfunction
 
 getcharmod()						*getcharmod()*
 		The result is a Number which is the state of the modifiers for
@@ -3512,7 +3523,7 @@ getpos({expr})	Get the position for {expr}.  For possible values of {expr}
 		This can be used to save and restore the position of a mark: >
 			let save_a_mark = getpos("'a")
 			...
-			call setpos(''a', save_a_mark
+			call setpos("'a", save_a_mark)
 <		Also see |getcurpos()| and |setpos()|.
 
 

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -1,4 +1,4 @@
-*indent.txt*    For Vim version 7.4.  Last change: 2014 Apr 23
+*indent.txt*    For Vim version 7.4.  Last change: 2014 Dec 06
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 7.4.  Last change: 2014 Sep 27
+*syntax.txt*	For Vim version 7.4.  Last change: 2014 Nov 19
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -5056,6 +5056,7 @@ This will set the "w:current_syntax" variable to "foo".  The value of
 restoring "b:current_syntax", since the syntax files do set
 "b:current_syntax".  The value set by the syntax file is assigned to
 "w:current_syntax".
+Note: This resets the 'spell', 'spellcapcheck' and 'spellfile' options.
 
 Once a window has its own syntax, syntax commands executed from other windows
 on the same buffer (including :syntax clear) have no effect. Conversely,

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 7.4.  Last change: 2014 Nov 19
+*todo.txt*      For Vim version 7.4.  Last change: 2014 Dec 06
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -34,9 +34,23 @@ not be repeated below, unless there is extra information.
 							*known-bugs*
 -------------------- Known bugs and current work -----------------------
 
+Patch to fix list range assign crash. (Yukihiro Nakadaira, 2014 Dec 1)
+
+Patch to fix range with user command. (Marcin Szamotulski, 2014 Dec 2)
+Update Dec 6, with support for user commands.
+
+When window number in Ex range is too high, give an error?
+Only when backwards compatible.
+
+:s/\n// doesn't change anything.  Since 7.4.232? (Eliseo Martínez, 2014 Nov
+28)  Patch on Issue 287
+
+Using vim_snprintf() in window.c can be in a function.
+
 Regexp problems:
 - The NFA engine does not implement the time limit passed to
   nfa_regexec_multi()
+- Very slow with a long line and Ruby highlighting. (John Whitley, 2014 Dec 4)
 - Bug with pattern: '\vblock (\d+)\.\n.*\d+%(\1)@<!\.$'
   (Lech Lorens, 2014 Feb 3)
 - Issue 164: freeze on regexp search.
@@ -64,16 +78,10 @@ Breaks test_eval.  Inefficient, can we only compute y_width when needed?
 Problem that a previous silent ":throw" causes a following try/catch not to
 work. (ZyX, 2013 Sep 28)
 
+Patch to fix recognizing function name. (Ozaki Kiichi, 2014 Nov 28)
+
 ":cd C:\Windows\System32\drivers\etc*" does not work, even though the
 directory exists. (Sergio Gallelli, 2013 Dec 29)
-
-Patch by Marcin Szamotulski to add count to :close (2014 Aug 10, update Aug
-14, Aug 30)
-    Make ":1close" close the first window.
-    Make ":+1close" close the next window.
-    Make ":-1close" close the previous window.
-Doesn't look right, asked for updates.
-Update 2014 Nov 8. Replied with suggestions.
 
 The entries added by matchaddpos() are returned by getmatches() but can't be
 set with setmatches(). (lcd47, 2014 Jun 29)
@@ -84,33 +92,33 @@ Problem using ":try" inside ":execute". (ZyX, 2013 Sep 15)
 
 Python: ":py raw_input('prompt')" doesn't work. (Manu Hack)
 
-Patch to fix issue 78. (Christian Brabandt, 2014 Oct 8)
-
-Patch to fix leak in map() with error. (Christian Brabandt, 2014 Oct 11)
-
-Patch to fix incsearch for "2/pattern/e".
-
-Patch to fix memory leak in :hardcopy. (Christian Brabandt, 2014 Nov 16)
-
-Patch to fix warnings in if_ruby.c. (Ken Takata, 2014 Nov 17)
-
-Patch to make test 63 pass when in a B&W terminal. (Christian Brabandt, 2014
-Nov 15)  Other patch (better) on Nov 17.
-
 Change behavior of v:hlsearch?  Patch from Christian, 2014 Oct 22.
+
+Patch to recover from X server restart: hint on Issue 203 (2014 Nov 21 18:44)
 
 MS-Windows: When editing a file with a leading space, writing it uses the
 wrong name. (Aram, 2014 Nov 7)  Vim 7.4.
+
+Add LessCss support. (Jenoma / Alessandro Vioni, 2014 Nov 24)
+Now with updated license, Nov 24.
 
 patch to remove FEAT_OSFILETYPE from fileio.c. (Christian, 2014 Nov 12)
 
 Value returned by virtcol() changes depending on how lines wrap.  This is
 inconsistent with the documentation.
 
-Patch to fix relatie numbers. (Christian Brabandt, 2014 Nov 17)
+Ukrainian vimtutor. (Issue 288)
+
+Regenerate the Unicode tables in mbyte.c.
+Diff from ZyX, 2014 Dec 6.
+
+Patch to fix relative numbers. (Christian Brabandt, 2014 Nov 17)
+Update Nov 26.
 
 Patch to fix wrong formatting if 'linebreak' is set. (Christian Brabandt, 2014
 Nov 12)
+
+Patch to avoid recognizing polkit as hog files. (Issue 292)
 
 Patch to support hex values for setting option value.
 (Zyx, 2015 Nov 6)
@@ -122,16 +130,28 @@ Update Nov 5.
 MS-Windows: Crash opening very long file name starting with "\\".
 (Christian Brock, 2012 Jun 29)
 
+Cursorline background color not mixed with character highlight.
+Patch by Yasuhiro Matsumoto, 2014 Dec 3.
+
 Problem using diff syntax with cp932 encoding.  Idea from Yasuhiro Matsumoto,
 patch from Ken Takata (2014 Nov 6)
 
 ml_updatechunk() is slow when retrying for another encoding. (John Little,
 2014 Sep 11)
 
+Patch to add a different escape sequence for replace mode.
+(Omar Sandoval, 2014 Nov 30)
+
+Patch to allow values greater than 255 for ctermfg/ctermbg on Windows.
+(Yasuhiro Matsumoto, 2014 Dec 5)
+
 When 'balloonexpr' returns a list the result has a trailing newline.
 Just remove one trailing newline. (lcd, 2014 Oct 17)
 
 Make comments in the test Makefile silent. (Kartik Agaram, 2014 Sep 24)
+
+Result of systemlist() does not show whether text ended in line break.
+(Bjorn Linse, 2014 Nov 27)
 
 When in 'comments' "n:x" follows after three-part comment directly it repeats
 any one-character from the previous line. (Kartik Agaram, 2014 Sep 19)
@@ -146,6 +166,15 @@ Adding "~" to 'cdpath' doesn't work for completion?  (Davido, 2013 Aug 19)
 Plugins need to make a lot of effort, lots of mappings, to know what happened
 before pressing the key that triggers a plugin action.  How about keeping the
 last N pressed keys, so that they do not need to be mapped?
+
+":q!" should reset modified flag for current buffer, if another buffer is
+modified no need to abandon it again.
+Patch from Yasuhiro Matsumoto, 2014 Nov 21.
+Update from Hirohito Higashi, 2014 Nov 21.
+With test, Nov 23.
+
+Wrong scrolling when using incsearch.  Patch by Christian Brabandt, 2014 Dec 4.
+Is this a good solution?
 
 Can assign to s:type when a function s:type has been defined.
 Also the other way around: define a function while a variable with that name
@@ -175,6 +204,7 @@ Bug: Autocompleting ":tag/pat" replaces "/pat" with a match but does not
 insert a space. (Micha Mos, 2014 Nov 7)
 
 Patch to add the :bvimgrep command.  (Christian Brabandt, 2014 Nov 12)
+Update Dec 6.
 
 Patch to add argument to :cquit. (Thinca, 2014 Oct 12)
 
@@ -286,6 +316,10 @@ Patch to support expression argument to sort() instead of a function name.
 Yasuhiro Matsumoto, 2013 May 31.
 Or should we add a more general mechanism, like a lambda() function?
 Patch by Yasuhiro Matsumoto, 2014 Sep 16.
+
+Patch to fix display of listchars on the cursorline. (Nayuri Aohime, 2013)
+Update suggested by Yasuhiro Matsumoto, 2014 Nov 25:
+https://gist.github.com/presuku/d3d6b230b9b6dcfc0477
 
 Patch for XDG base directory support. (Jean François Bignolles, 2014 Mar 4)
 Remark on the docs.  Should not be a compile time feature.  But then what?
@@ -536,6 +570,14 @@ MS-Windows resizing problems:
 - Win32: When the taskbar is at the top of the screen creating the tabbar
   causes the window to move unnecessarily. (William E. Skeith III, 2012 Jan
   12) Patch: 2012 Jan 13  Needs more work (2012 Feb 2)
+
+Patch to use Modern UI 2.0 for the Nsis installer. (Guopeng Wen, 2010 Jul 30)
+Latest version: 2011 May 18 
+8   Windows install with NSIS: make it possible to do a silent install, see
+    http://nsis.sourceforge.net/Docs/Chapter4.html#4.12
+    Version from Guopeng Wen that does this (2010 Dec 27)
+Alternative: MSI installer: https://github.com/petrkle/vim-msi/
+Or the one on Issue 279
 
 'iminsert' global value set when using ":setlocal iminsert"? (Wu, 2012 Jun 23)
 
@@ -850,7 +892,7 @@ Assume the system converts between the actual encoding of the filesystem to
 the system encoding (usually utf-8).
 
 Patch to add GUI colors to the terminal, when it supports it. (ZyX, 2013 Jan
-26, update 2013 Dec 14)
+26, update 2013 Dec 14, another 2014 Nov 22)
 
 Problem producing tags file when hebrew.frx is present.  It has a BOM.
 Results in E670. (Tony Mechelynck, 2010 May 2)
@@ -1481,13 +1523,6 @@ Netbeans problem.  Use "nc -l 127.0.0.1 55555" for the server, then run gvim
 with "gvim -nb:localhost:55555:foo".  From nc do: '1:editFile!0 "foo"'.  Then
 go to Insert mode and add a few lines.  Then backspacing every other time
 moves the cursor instead of deleting. (Chris Kaiser, 2007 Sep 25)
-
-Patch to use Modern UI 2.0 for the Nsis installer. (Guopeng Wen, 2010 Jul 30)
-Latest version: 2011 May 18
-8   Windows install with NSIS: make it possible to do a silent install, see
-    http://nsis.sourceforge.net/Docs/Chapter4.html#4.12
-    Version from Guopeng Wen that does this (2010 Dec 27)
-Alternative: MSI installer: https://github.com/petrkle/vim-msi/
 
 Windows installer should install 32-bit version of right-click handler also on
 64-bit systems. (Brian Cunningham, 2011 Dec 28)

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1,4 +1,4 @@
-*windows.txt*   For Vim version 7.4.  Last change: 2014 Sep 23
+*windows.txt*   For Vim version 7.4.  Last change: 2014 Dec 05
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -280,7 +280,7 @@ CTRL-W CTRL-Q						*CTRL-W_CTRL-Q*
 			    " if there are less than 9 windows opened
 		    :-quit  " quit the previous window
 		    :+quit  " quit the next window
-		    :+2quit " will also work as expected
+		    :+2quit " quit the second next window
 <
 :q[uit]!
 :{count}q[uit]!
@@ -324,9 +324,9 @@ CTRL-W CTRL-C						*CTRL-W_CTRL-C*
 		screen. For {count} see |:quit|.
 
 		The buffer becomes hidden (unless there is another window
-		editing it or 'bufhidden' is `unload` or `delete`). If the
-		window is the last one in the current tab page the tab page is
-		closed. |tab-page|
+		editing it or 'bufhidden' is `unload`, `delete` or `wipe`).
+		If the window is the last one in the current tab page the tab
+		page is closed. |tab-page|
 
 		The value of 'hidden' is irrelevant for this command.
 		Changes to the buffer are not written and won't get lost, so

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Nov 05
+" Last Change:	2014 Dec 06
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")
@@ -1852,7 +1852,7 @@ au BufNewFile,BufRead sgml.catalog*		call s:StarSetf('catalog')
 
 " Shell scripts (sh, ksh, bash, bash2, csh); Allow .profile_foo etc.
 " Gentoo ebuilds and Arch Linux PKGBUILDs are actually bash scripts
-au BufNewFile,BufRead .bashrc*,bashrc,bash.bashrc,.bash_profile*,.bash_logout*,*.bash,*.ebuild,PKGBUILD* call SetFileTypeSH("bash")
+au BufNewFile,BufRead .bashrc*,bashrc,bash.bashrc,.bash_profile*,.bash_logout*,.bash_aliases*,*.bash,*.ebuild,PKGBUILD* call SetFileTypeSH("bash")
 au BufNewFile,BufRead .kshrc*,*.ksh call SetFileTypeSH("ksh")
 au BufNewFile,BufRead */etc/profile,.profile*,*.sh,*.env call SetFileTypeSH(getline(1))
 
@@ -2506,6 +2506,8 @@ au BufNewFile,BufRead */etc/yum.conf		setf dosini
 
 " Zimbu
 au BufNewFile,BufRead *.zu			setf zimbu
+" Zimbu Templates
+au BufNewFile,BufRead *.zut			setf zimbutempl
 
 " Zope
 "   dtml (zope dynamic template markup language), pt (zope page template),

--- a/runtime/macros/editexisting.vim
+++ b/runtime/macros/editexisting.vim
@@ -1,6 +1,6 @@
 " Vim Plugin:	Edit the file with an existing Vim if possible
 " Maintainer:	Bram Moolenaar
-" Last Change:	2013 Feb 24
+" Last Change:	2014 Dec 06
 
 " This is a plugin, drop it in your (Unix) ~/.vim/plugin or (Win32)
 " $VIM/vimfiles/plugin directory.  Or make a symbolic link, so that you
@@ -112,7 +112,7 @@ func! EditExisting(fname, command)
   endif
 
   if a:command != ''
-    exe "normal " . a:command
+    exe "normal! " . a:command
   endif
 
   redraw

--- a/runtime/syntax/zimbu.vim
+++ b/runtime/syntax/zimbu.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Zimbu
 " Maintainer:	Bram Moolenaar
-" Last Change:	2012 Jun 01
+" Last Change:	2014 Nov 23
 
 if exists("b:current_syntax")
   finish
@@ -12,7 +12,10 @@ syn include @Ccode syntax/c.vim
 syn keyword zimbuTodo		TODO FIXME XXX contained
 syn match   zimbuNoBar          "|" contained
 syn match   zimbuParam  	"|[^| ]\+|" contained contains=zimbuNoBar
-syn match   zimbuComment	"#.*$" contains=zimbuTodo,zimbuParam,@Spell
+syn match   zimbuNoBacktick     "`" contained
+syn match   zimbuCode  		"`[^`]\+`" contained contains=zimbuNoBacktick
+syn match   zimbuComment	"#.*$" contains=zimbuTodo,zimbuParam,zimbuCode,@Spell
+syn match   zimbuComment	"/\*.\{-}\*/" contains=zimbuTodo,zimbuParam,zimbuCode,@Spell
 
 syn match   zimbuChar	"'\\\=.'"
 
@@ -28,27 +31,32 @@ syn keyword zimbuBasicType	fixed1 fixed2 fixed3 fixed4 fixed5 fixed6
 syn keyword zimbuBasicType	fixed7 fixed8 fixed9 fixed10 fixed11 fixed12
 syn keyword zimbuBasicType	fixed13 fixed14 fixed15
 
-syn keyword zimbuCompType	string stringval cstring varstring
-syn keyword zimbuCompType	bytes varbytes
-syn keyword zimbuCompType	tuple array list dict multiDict set multiSet
+syn keyword zimbuCompType	string varString
+syn keyword zimbuCompType	byteString varByteString
+syn keyword zimbuCompType	tuple array list dict dictList set callback
+syn keyword zimbuCompType	sortedList multiDict multiDictList multiSet
 syn keyword zimbuCompType	complex complex32 complex64 complex80 complex128
 syn keyword zimbuCompType	proc func def thread evalThread lock cond pipe
 
-syn keyword zimbuType   VAR ANY USE GET
+syn keyword zimbuType   VAR dyn type USE GET
 syn match zimbuType	"IO.File"
 syn match zimbuType	"IO.Stat"
 
-syn keyword zimbuStatement IF ELSE ELSEIF WHILE REPEAT FOR IN TO STEP
+syn keyword zimbuStatement IF ELSE ELSEIF IFNIL WHILE REPEAT FOR IN TO STEP
 syn keyword zimbuStatement DO UNTIL SWITCH WITH
 syn keyword zimbuStatement TRY CATCH FINALLY
 syn keyword zimbuStatement GENERATE_IF GENERATE_ELSE GENERATE_ELSEIF
+syn keyword zimbuStatement GENERATE_ERROR
+syn keyword zimbuStatement BUILD_IF BUILD_ELSE BUILD_ELSEIF
 syn keyword zimbuStatement CASE DEFAULT FINAL ABSTRACT VIRTUAL DEFINE REPLACE
 syn keyword zimbuStatement IMPLEMENTS EXTENDS PARENT LOCAL
-syn keyword zimbuStatement PART ALIAS CONNECT WRAP
+syn keyword zimbuStatement PART ALIAS TYPE CONNECT WRAP
 syn keyword zimbuStatement BREAK CONTINUE PROCEED
-syn keyword zimbuStatement RETURN EXIT THROW
+syn keyword zimbuStatement RETURN EXIT THROW DEFER
 syn keyword zimbuStatement IMPORT AS OPTIONS MAIN
-syn keyword zimbuStatement INTERFACE MODULE ENUM BITS SHARED
+syn keyword zimbuStatement INTERFACE PIECE INCLUDE MODULE ENUM BITS
+syn keyword zimbuStatement SHARED STATIC
+syn keyword zimbuStatement LAMBDA
 syn match zimbuStatement "\<\(FUNC\|PROC\|DEF\)\>"
 syn match zimbuStatement "\<CLASS\>"
 syn match zimbuStatement "}"
@@ -61,10 +69,13 @@ syn match zimbuAttribute "@default\>"
 syn match zimbuAttribute "@define\>"
 syn match zimbuAttribute "@replace\>"
 syn match zimbuAttribute "@final\>"
+syn match zimbuAttribute "@primitive\>"
+syn match zimbuAttribute "@notOnExit\>"
 
 syn match zimbuAttribute "@private\>"
 syn match zimbuAttribute "@protected\>"
 syn match zimbuAttribute "@public\>"
+syn match zimbuAttribute "@local\>"
 syn match zimbuAttribute "@file\>"
 syn match zimbuAttribute "@directory\>"
 syn match zimbuAttribute "@read=private\>"
@@ -78,15 +89,22 @@ syn match zimbuAttribute "@items=public\>"
 syn match zimbuAttribute "@items=file\>"
 syn match zimbuAttribute "@items=directory\>"
 
-syn keyword zimbuMethod NEW EQUAL COPY COMPARE SIZE GET SET
+syn keyword zimbuMethod NEW EQUAL COPY COMPARE SIZE GET SET INIT EARLYINIT
 
 syn keyword zimbuOperator IS ISNOT ISA ISNOTA
 
-syn keyword zimbuModule  ARG CHECK E IO PROTO SYS HTTP ZC ZWT TIME THREAD
+syn keyword zimbuModule  ARG CHECK E GC IO LOG PROTO SYS HTTP ZC ZWT T TIME THREAD
 
-syn match zimbuString  +"\([^"\\]\|\\.\)*\("\|$\)+
+syn match zimbuImport  "\.\zsPROTO"
+syn match zimbuImport  "\.\zsCHEADER"
+
+"syn match zimbuString  +"\([^"\\]\|\\.\)*\("\|$\)+ contains=zimbuStringExpr
+syn region zimbuString  start=+"+  skip=+[^"\\]\|\\.+ end=+"\|$+ contains=zimbuStringExpr
 syn match zimbuString  +R"\([^"]\|""\)*\("\|$\)+
-syn region zimbuString  start=+'''+ end=+'''+
+syn region zimbuLongString  start=+''"+ end=+"''+
+syn match zimbuStringExpr +\\([^)]*)+hs=s+2,he=e-1 contained contains=zimbuString,zimbuParenPairOuter
+syn region zimbuParenPairOuter  start=+(+ms=s+1  end=+)+me=e-1 contained contains=zimbuString,zimbuParenPair
+syn region zimbuParenPair  start=+(+  end=+)+ contained contains=zimbuString,zimbuParenPair
 
 syn keyword zimbuFixed  TRUE FALSE NIL THIS THISTYPE FAIL OK
 syn keyword zimbuError  NULL
@@ -97,12 +115,18 @@ syn match   zimbuSpaceError   display excludenl "\S\s\+$"ms=s+1
 syn match   zimbuSpaceError   display " \+\t"
 syn match   zimbuSpaceError   display "\t\+ "
 
-syn match zimbuUses contained "uses([a-zA-Z_ ,]*)"
+syn match zimbuUses contained "\<uses([a-zA-Z_ ,]*)"
+syn match zimbuBlockgc contained "blockgc"
 syn match zimbuBlockComment contained " #.*"
 
-syn region zimbuCregion matchgroup=zimbuCblock start="^>>>" end="^<<<.*" contains=@Ccode,zimbuUses,zimbuBlockComment keepend
+syn region zimbuCregion matchgroup=zimbuCblock start="^>>>" end="^<<<.*" contains=@Ccode,zimbuUses,zimbuBlockgc,zimbuBlockComment keepend
 
-syn sync minlines=2000
+" Assume long strings and C regions don't take more than 200 lines.
+syn sync minlines=200
+
+" When we find the start of a long string, without a # or " before it, we are
+" sure to be inside a long string.
+syn sync match zimbuLongStringSync grouphere zimbuLongString +^[^"#]*''\"+
 
 hi def link zimbuBasicType	Type
 hi def link zimbuCompType	Type
@@ -111,17 +135,23 @@ hi def link zimbuStatement	Statement
 hi def link zimbuOperator	Statement
 hi def link zimbuMethod		PreProc
 hi def link zimbuModule		PreProc
+hi def link zimbuImport		PreProc
 hi def link zimbuUses		PreProc
+hi def link zimbuBlockgc	PreProc
 hi def link zimbuAttribute	PreProc
 hi def link zimbuString		Constant
+hi def link zimbuLongString	Special
 hi def link zimbuChar		Constant
 hi def link zimbuFixed		Constant
 hi def link zimbuComment	Comment
+hi def link zimbuCommentStart	zimbuComment
 hi def link zimbuBlockComment	Comment
 hi def link zimbuCblock		Comment
 hi def link zimbuTodo		Todo
 hi def link zimbuParam		Constant
+hi def link zimbuCode		Statement
 hi def link zimbuNoBar		Ignore
+hi def link zimbuNoBacktick	Ignore
 hi def link zimbuSpaceError	Error
 hi def link zimbuError		Error
 


### PR DESCRIPTION
Update runtime files.

https://code.google.com/p/vim/source/detail?r=5d89d9b40499059e1a64dc35fbae94313fba0098

Output of `patch -p1 < vim-5d89d9b.diff`:

```
patching file runtime/autoload/phpcomplete.vim
patching file runtime/doc/editing.txt
Hunk #1 FAILED at 1.
Hunk #2 FAILED at 611.
Hunk #3 succeeded at 579 (offset -43 lines).
Hunk #4 FAILED at 645.
Hunk #5 succeeded at 1019 (offset -64 lines).
3 out of 5 hunks FAILED -- saving rejects to file runtime/doc/editing.txt.rej
patching file runtime/doc/eval.txt
Hunk #2 succeeded at 3302 (offset -3 lines).
Hunk #3 succeeded at 3523 (offset -3 lines).
patching file runtime/doc/indent.txt
patching file runtime/doc/syntax.txt
Hunk #2 succeeded at 5056 (offset -9 lines).
patching file runtime/doc/tabpage.txt
Hunk #1 FAILED at 1.
1 out of 1 hunk FAILED -- saving rejects to file runtime/doc/tabpage.txt.rej
patching file runtime/doc/todo.txt
Hunk #8 FAILED at 317.
Hunk #9 succeeded at 567 (offset -11 lines).
Hunk #10 succeeded at 888 (offset -24 lines).
Hunk #11 succeeded at 1520 (offset -52 lines).
1 out of 11 hunks FAILED -- saving rejects to file runtime/doc/todo.txt.rej
patching file runtime/doc/windows.txt
Hunk #2 FAILED at 278.
Hunk #3 FAILED at 332.
2 out of 3 hunks FAILED -- saving rejects to file runtime/doc/windows.txt.rej
patching file runtime/filetype.vim
Hunk #2 FAILED at 1856.
Hunk #3 succeeded at 2506 (offset 4 lines).
1 out of 3 hunks FAILED -- saving rejects to file runtime/filetype.vim.rej
patching file runtime/indent/php.vim
patching file runtime/macros/editexisting.vim
patching file runtime/syntax/zimbu.vim
```
## Rejected hunks
### runtime/doc/editing.txt

``` diff
@@ -1,4 +1,4 @@
-*editing.txt*   For Vim version 7.4.  Last change: 2014 Nov 19
+*editing.txt*   For Vim version 7.4.  Last change: 2014 Dec 05


          VIM REFERENCE MANUAL    by Bram Moolenaar
```

Diagnosis: There have been more recent changes.
Solution: Discard this hunk.

``` diff
@@ -611,7 +611,7 @@ list of the current window.
 :[count]arga[dd] {name} ..         *:arga* *:argadd* *E479*
 :[count]arga[dd]
            Add the {name}s to the argument list.  When {name} is
-           omitted at the current buffer name to the argument
+           omitted add the current buffer name to the argument
            list.
            If [count] is omitted, the {name}s are added just
            after the current entry in the argument list.
```

Diagnosis: This sentence is missing from Neovim's doc, because the changes to `editing.txt` have been forgotten in e6f3b0703ce9c9b66fe5da12c30965bc26798dcd.
Solution: Apply the missing changes and correct the typo.

``` diff
@@ -645,11 +646,19 @@ list of the current window.
 <          {not in Vi} {not available when compiled without the
            |+listcmds| feature}

-:{range}argd[elete]    Delete the {range} files from the argument list.
+:[range]argd[elete]    Delete the {range} files from the argument list.
+           Example: >
+               :10,$argdel
+<          Deletes arguments 10 and further, keeping 1-9. >
+               :$argd
+<          Deletes just the last one. >
+               :argd
+               :.argd
+<          Deletes the current argument. >
+               :%argd
+<          Removes all the files from the arglist.
            When the last number in the range is too high, up to
-           the last argument is deleted.  Example: >
-               :10,1000argdel
-<          Deletes arguments 10 and further, keeping 1-9.
+           the last argument is deleted.
            {not in Vi} {not available when compiled without the
            |+listcmds| feature}

```

Diagnosis: Only context has been changed by removing annotations.
Solution: Apply manually.
### runtime/doc/tabpage.txt

``` diff
@@ -1,4 +1,4 @@
-*tabpage.txt*   For Vim version 7.4.  Last change: 2012 Aug 08
+*tabpage.txt*   For Vim version 7.4.  Last change: 2014 Nov 27


          VIM REFERENCE MANUAL    by Bram Moolenaar
```

Diagnosis: There have been more recent changes.
Solution: Discard this hunk.
### runtime/doc/todo.txt

``` diff
@@ -317,6 +347,10 @@ Yasuhiro Matsumoto, 2013 May 31.
 Or should we add a more general mechanism, like a lambda() function?
 Patch by Yasuhiro Matsumoto, 2014 Sep 16.

+Patch to fix display of listchars on the cursorline. (Nayuri Aohime, 2013)
+Update suggested by Yasuhiro Matsumoto, 2014 Nov 25:
+https://gist.github.com/presuku/d3d6b230b9b6dcfc0477
+
 VMS: Select() doesn't work properly, typing ESC may hang Vim.  Use sys$qiow
 instead. (Samuel Ferencik, 2013 Sep 28)

```

Diagnosis: Context has been changed by removing VMS stuff.
Solution: Apply manually.
### runtime/doc/windows.txt

``` diff
@@ -278,16 +278,17 @@ CTRL-W CTRL-Q                     *CTRL-W_CTRL-Q*
        and there is only one window for the current buffer, and the
        buffer was changed, the command fails.

-       (Note: CTRL-Q does not
-       work on all terminals).  If [count] is greater than
-       the last window number the last window will be closed: >
+       (Note: CTRL-Q does not work on all terminals).
+       
+       If [count] is greater than the last window number the last
+       window will be closed: >
            :1quit  " quit the first window
            :$quit  " quit the last window
            :9quit  " quit the last window
                 " if there are less than 9 windows opened
            :-quit  " quit the previews window
            :+quit  " quit the next window
-           :+2quit " will also work as expected
+           :+2quit " quit the second next window
 <
 :q[uit]!
 :{count}q[uit]!
```

Diagnosis: The early line break has already been removed in 86330fdd3f39a8975b25b7050a3d02b77a442057.
Solution: Only change the description of `:+2quit`.

``` diff
@@ -332,9 +333,9 @@ CTRL-W CTRL-C                       *CTRL-W_CTRL-C*
        screen.  For {count} see |:quit| command.

        The buffer becomes hidden (unless there is another window
-       editing it or 'bufhidden' is "unload" or "delete").  If the
-       window is the last one in the current tab page the tab page is
-       closed.  |tab-page| 
+       editing it or 'bufhidden' is "unload", "delete" or "wipe").
+       If the window is the last one in the current tab page the tab
+       page is closed.  |tab-page| 

        The value of 'hidden' is irrelevant for this command.  Changes
        to the buffer are not written and won't get lost, so this is a
```

Diagnosis: In Neovim the `"`s have been replaced by backticks.
Solution: Apply manually.
### runtime/filetype.vim

``` diff
@@ -1856,7 +1856,7 @@ au BufNewFile,BufRead sgml.catalog*       cal

 " Shell scripts (sh, ksh, bash, bash2, csh); Allow .profile_foo etc.
 " Gentoo ebuilds are actually bash scripts
-au BufNewFile,BufRead .bashrc*,bashrc,bash.bashrc,.bash_profile*,.bash_logout*,*.bash,*.ebuild call SetFileTypeSH("bash")
+au BufNewFile,BufRead .bashrc*,bashrc,bash.bashrc,.bash_profile*,.bash_logout*,.bash_aliases*,*.bash,*.ebuild call SetFileTypeSH("bash")
 au BufNewFile,BufRead .kshrc*,*.ksh call SetFileTypeSH("ksh")
 au BufNewFile,BufRead */etc/profile,.profile*,*.sh,*.env call SetFileTypeSH(getline(1))

```

Diagnosis: Neovim added Arch Linux PKGBUILDs to the list.
Solution: Manually insert `.bash_aliases*`.
