### PR TITLE
[RDY] ASan: Fix "null pointer passed for argument declared to never be null".

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -426,8 +426,12 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
 
     case kObjectTypeString:
       tv->v_type = VAR_STRING;
-      tv->vval.v_string = xmemdupz(obj.data.string.data,
-                                   obj.data.string.size);
+      if (obj.data.string.data == NULL) {
+        tv->vval.v_string = NULL;
+      } else {
+        tv->vval.v_string = xmemdupz(obj.data.string.data,
+                                     obj.data.string.size);
+      }
       break;
 
     case kObjectTypeArray:

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -94,13 +94,14 @@ bool msgpack_rpc_to_string(msgpack_object *obj, String *arg)
   FUNC_ATTR_NONNULL_ALL
 {
   if (obj->type == MSGPACK_OBJECT_BIN || obj->type == MSGPACK_OBJECT_STR) {
+    if (obj->via.bin.ptr == NULL) {
+      return false;
+    }
     arg->data = xmemdupz(obj->via.bin.ptr, obj->via.bin.size);
     arg->size = obj->via.bin.size;
-  } else {
-    return false;
+    return true;
   }
-
-  return true;
+  return false;
 }
 
 bool msgpack_rpc_to_object(msgpack_object *obj, Object *arg)


### PR DESCRIPTION
Fixes a "null pointer passed for argument declared to never be null" warning given by Clang ASan. (Re-)Discovered as part of #2807, originally reported as #2533 (see there for more detailed description).
