### PR TITLE
[RFC] vim-patch:7.4.646

### DIFF
--- a/src/nvim/testdir/test_command_count.in
+++ b/src/nvim/testdir/test_command_count.in
@@ -141,6 +141,7 @@ STARTTEST
 :let buffers = ''
 :.,$-bufdo let buffers .= ' '.bufnr('%')
 :call add(g:lines, 'bufdo:' . buffers)
+:3bd
 :let buffers = ''
 :3,7bufdo let buffers .= ' '.bufnr('%')
 :call add(g:lines, 'bufdo:' . buffers)

--- a/src/nvim/testdir/test_command_count.ok
+++ b/src/nvim/testdir/test_command_count.ok
@@ -34,5 +34,5 @@ aaa: 0 bbb: 0 ccc: 0
 argdo: c d e
 windo: 2 3 4
 bufdo: 2 3 4 5 6 7 8 9 10 15
-bufdo: 3 4 5 6 7
+bufdo: 4 5 6 7
 tabdo: 2 3 4

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -163,7 +163,7 @@ static int included_patches[] = {
   //649,
   //648 NA
   //647 NA
-  //646,
+  646,
   //645,
   //644 NA
   //643,


### PR DESCRIPTION
```
Problem:    ":bufdo" may start at a deleted buffer.
Solution:   Find the first not deleted buffer. (Shane Harper)
```

https://github.com/vim/vim/commit/v7-4-646

Original patch:

``` diff
diff --git a/src/nvim/ex_cmds2.c b/src/nvim/ex_cmds2.c
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2440,7 +2440,7 @@ ex_listdo(eap)
     win_T  *wp;
     tabpage_T  *tp;
 #endif
-    buf_T  *buf;
+    buf_T  *buf = curbuf;
     int        next_fnum = 0;
 #if defined(FEAT_AUTOCMD) && defined(FEAT_SYN_HL)
     char_u *save_ei = NULL;
@@ -2493,20 +2493,28 @@ ex_listdo(eap)
        case CMD_argdo:
        i = eap->line1 - 1;
        break;
-       case CMD_bufdo:
-       i = eap->line1;
-       break;
        default:
        break;
    }
    /* set pcmark now */
    if (eap->cmdidx == CMD_bufdo)
-       goto_buffer(eap, DOBUF_FIRST, FORWARD, i);
+        {
+       /* Advance to the first listed buffer after "eap->line1". */
+            for (buf = firstbuf; buf != NULL && (buf->b_fnum < eap->line1
+                     || !buf->b_p_bl); buf = buf->b_next)
+       if (buf->b_fnum > eap->line2)
+       {
+           buf = NULL;
+           break;
+       }
+            if (buf != NULL)
+       goto_buffer(eap, DOBUF_FIRST, FORWARD, buf->b_fnum);
+        }
    else
        setpcmark();
    listcmd_busy = TRUE;        /* avoids setting pcmark below */

-   while (!got_int)
+   while (!got_int && buf != NULL)
    {
        if (eap->cmdidx == CMD_argdo)
        {
diff --git a/src/nvim/testdir/test_command_count.in b/src/nvim/testdir/test_command_count.in
--- a/src/nvim/testdir/test_command_count.in
+++ b/src/nvim/testdir/test_command_count.in
@@ -141,6 +141,7 @@ STARTTEST
 :let buffers = ''
 :.,$-bufdo let buffers .= ' '.bufnr('%')
 :call add(g:lines, 'bufdo:' . buffers)
+:3bd
 :let buffers = ''
 :3,7bufdo let buffers .= ' '.bufnr('%')
 :call add(g:lines, 'bufdo:' . buffers)
diff --git a/src/nvim/testdir/test_command_count.ok b/src/nvim/testdir/test_command_count.ok
--- a/src/nvim/testdir/test_command_count.ok
+++ b/src/nvim/testdir/test_command_count.ok
@@ -34,5 +34,5 @@ aaa: 0 bbb: 0 ccc: 0
 argdo: c d e
 windo: 2 3 4
 bufdo: 2 3 4 5 6 7 8 9 10 15
-bufdo: 3 4 5 6 7
+bufdo: 4 5 6 7
 tabdo: 2 3 4
diff --git a/src/nvim/version.c b/src/nvim/version.c
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    646,
+/**/
     645,
 /**/
     644,
```
