### PR TITLE
[RFC] Don't overwrite clipboard before "+p in visual mode when cb=unnamedplus

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7278,7 +7278,10 @@ static void nv_put(cmdarg_T *cap)
        */
       was_visual = true;
       regname = cap->oap->regname;
-      if (regname == 0 || regname == '"'
+      // '+' and '*' could be the same selection
+      bool clipoverwrite = (regname == '+' || regname == '*')
+          && (cb_flags & CB_UNNAMEDMASK);
+      if (regname == 0 || regname == '"' || clipoverwrite
           || ascii_isdigit(regname) || regname == '-') {
         // The delete might overwrite the register we want to put, save it first
         savereg = copy_register(regname);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -67,8 +67,6 @@
 #define PLUS_REGISTER 38
 #define NUM_REGISTERS 39
 
-#define CB_UNNAMEDMASK (CB_UNNAMED | CB_UNNAMEDPLUS)
-
 static yankreg_T y_regs[NUM_REGISTERS];
 
 static yankreg_T   *y_previous = NULL; /* ptr to last written yankreg */

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -318,6 +318,7 @@ static char *(p_cb_values[]) = {"unnamed", "unnamedplus", NULL};
 #endif
 # define CB_UNNAMED             0x001
 # define CB_UNNAMEDPLUS         0x002
+# define CB_UNNAMEDMASK         (CB_UNNAMED | CB_UNNAMEDPLUS)
 EXTERN long p_cwh;              /* 'cmdwinheight' */
 EXTERN long p_ch;               /* 'cmdheight' */
 EXTERN int p_confirm;           /* 'confirm' */

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -253,6 +253,12 @@ describe('clipboard usage', function()
       feed("viwp")
       eq({{'visual'}, 'v'}, eval("g:test_clip['*']"))
       expect("indeed clipboard")
+
+      -- explicit "* should do the same
+      execute("let g:test_clip['*'] = [['star'], 'c']")
+      feed('viw"*p')
+      eq({{'clipboard'}, 'v'}, eval("g:test_clip['*']"))
+      expect("indeed star")
     end)
 
   end)


### PR DESCRIPTION
ref #2942 . The fix should also work on a platform where + and \* are the same.

@brettanomyces Does this branch work as intended?
