### PR TITLE
[RFC] Set default register when using middle mouse to *

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2019,6 +2019,9 @@ do_mouse (
         if ((State & REPLACE_FLAG) && !yank_register_mline(regname))
           insert_reg(regname, true);
         else {
+          if (regname == 0) {
+            regname = '*';
+          }
           do_put(regname, NULL, BACKWARD, 1L, fixindent | PUT_CURSEND);
 
           /* Repeat it with CTRL-R CTRL-O r or CTRL-R CTRL-P r */


### PR DESCRIPTION
When using the middle mouse button without regname being set the register
defaults to 0. Which results in the yank register being output.

This should fix #2919

This used to be done in vim with:
 #ifdef FEAT_CLIPBOARD
            if (clip_star.available && regname == 0)
                                regname = '*';
 #endif
