### PR TITLE
[RFC] rplugin: Don't error if plugin is registered before host ?

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -81,7 +81,7 @@ function! remote#host#RegisterPlugin(host, path, specs)
     endif
   endfor
 
-  if remote#host#IsRunning(a:host)
+  if has_key(s:hosts, a:host) && remote#host#IsRunning(a:host)
     " For now we won't allow registration of plugins when the host is already
     " running.
     throw 'Host "'.a:host.'" is already running'


### PR DESCRIPTION
With #2896 a plugin host supporting plugin registration might be implemented in an external plugin.  changes are `runtime/plugin/rplugin.vim` will run _before_ a external host gets registered in a `&rtp/plugin/` file.  This will cause an error after `UpdateRemotePlugins` and then restarting nvim,  in `LoadRemotePlugins()` as it expect any plugin in `nvimrc-rplugin~` to already have a registered host. The easy fix is to change `remote#host#register_plugin` to allow register a plugin before its host. This was not expressively forbidden before, but caused an error inside `remote#host#IsRunning(a:host)`

if we still want this to be forbidden, one could instead add an optional flag to `register_plugin` to  allow this when loading `nvimrc-rplugin~`  (it should work as a cache, after all), but still an error per default when registering manually by a call to `register_plugin` ? 
