### PR TITLE
[RFC] rbuffer: Fix for problems with escape input sequences.

### DIFF
--- a/src/nvim/rbuffer.c
+++ b/src/nvim/rbuffer.c
@@ -69,6 +69,15 @@ char *rbuffer_write_ptr(RBuffer *buf, size_t *write_count) FUNC_ATTR_NONNULL_ALL
   return buf->write_ptr;
 }
 
+// Set read and write pointer for an empty RBuffer to the beginning of the
+// buffer.
+void rbuffer_reset(RBuffer *buf) FUNC_ATTR_NONNULL_ALL
+{
+  if (buf->size == 0) {
+    buf->write_ptr = buf->read_ptr = buf->start_ptr;
+  }
+}
+
 /// Adjust `rbuffer` write pointer to reflect produced data. This is called
 /// automatically by `rbuffer_write`, but when using `rbuffer_write_ptr`
 /// directly, this needs to called after the data was copied to the internal

--- a/src/nvim/tui/term_input.inl
+++ b/src/nvim/tui/term_input.inl
@@ -243,6 +243,7 @@ static void read_cb(RStream *rstream, RBuffer *buf, void *data, bool eof)
     RBUFFER_EACH(input->read_buffer, c, i) {
       count = i + 1;
       if (c == '\x1b' && count > 1) {
+        count--;
         break;
       }
     }
@@ -262,6 +263,10 @@ static void read_cb(RStream *rstream, RBuffer *buf, void *data, bool eof)
       }
     }
   } while (rbuffer_size(input->read_buffer));
+
+  // Make sure the next input escape sequence fits into the ring buffer
+  // without wrap around, otherwise it could be misinterpreted.
+  rbuffer_reset(input->read_buffer);
 }
 
 static TermInput *term_input_new(void)


### PR DESCRIPTION
rbuffer: Fix for problems with escape input sequences.

If at least two escape sequences were read, the beginning of the
second sequence would be off by one and the sequence would be
misinterpreted.

An escape sequence could be split in two parts and be
misinterpreted, when saved in a ring buffer with wrap around.

@ping tarruda

Fixes #2936
