### PR TITLE
[RFC] terminal.c: Fix memory leak

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -572,9 +572,10 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
 
     case VTERM_PROP_TITLE: {
       Error err;
-      dict_set_value(term->buf->b_vars,
-          cstr_as_string("term_title"),
-          STRING_OBJ(cstr_as_string(val->string)), &err);
+      api_free_object(dict_set_value(term->buf->b_vars,
+                                     cstr_as_string("term_title"),
+                                     STRING_OBJ(cstr_as_string(val->string)),
+                                     &err));
       break;
     }
 


### PR DESCRIPTION
terminal.c: Fix memory leak

Leak report by ASAN:

```
==6878==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 45 byte(s) in 1 object(s) allocated from:
    #0 0x4d7cd8 in malloc /home/oni-link/git/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:40
    #1 0xad2de4 in try_malloc /home/oni-link/git/neovim/src/nvim/memory.c:62:15
    #2 0xad3024 in xmalloc /home/oni-link/git/neovim/src/nvim/memory.c:96:15
    #3 0xad3463 in xmallocz /home/oni-link/git/neovim/src/nvim/memory.c:171:15
    #4 0xad3528 in xmemdupz /home/oni-link/git/neovim/src/nvim/memory.c:189:17
    #5 0x159e755 in cstr_to_string /home/oni-link/git/neovim/src/nvim/api/private/helpers.c:374:17
    #6 0x159af5f in vim_to_object_rec /home/oni-link/git/neovim/src/nvim/api/private/helpers.c:656:24
    #7 0x1590260 in vim_to_object /home/oni-link/git/neovim/src/nvim/api/private/helpers.c:320:8
    #8 0x1591a4d in dict_set_value /home/oni-link/git/neovim/src/nvim/api/private/helpers.c:149:12
    #9 0x1340571 in term_settermprop /home/oni-link/git/neovim/src/nvim/terminal.c:575:7
    #10 0x163d556 in settermprop (/home/oni-link/git/neovim/build/bin/nvim+0x163d556)
    #11 0x163b194 in vterm_state_set_termprop (/home/oni-link/git/neovim/build/bin/nvim+0x163b194)
    #12 0x16374af in settermprop_string (/home/oni-link/git/neovim/build/bin/nvim+0x16374af)
    #13 0x163a34d in on_osc (/home/oni-link/git/neovim/build/bin/nvim+0x163a34d)
    #14 0x163bac4 in do_string (/home/oni-link/git/neovim/build/bin/nvim+0x163bac4)
    #15 0x163bf64 in vterm_input_write (/home/oni-link/git/neovim/build/bin/nvim+0x163bf64)
    #16 0x1331939 in terminal_receive /home/oni-link/git/neovim/src/nvim/terminal.c:468:3
    #17 0xe5a9b1 in on_job_output /home/oni-link/git/neovim/src/nvim/eval.c:20368:7
    #18 0xe5a412 in on_job_stderr /home/oni-link/git/neovim/src/nvim/eval.c:20353:3
    #19 0x153c84b in read_cb /home/oni-link/git/neovim/src/nvim/os/job.c:417:5
    #20 0x156ce62 in read_cb /home/oni-link/git/neovim/src/nvim/os/rstream.c:205:3
    #21 0x162bc8e in uv__read /home/oni-link/git/neovim/.deps/build/src/libuv/src/unix/stream.c:1161

SUMMARY: AddressSanitizer: 45 byte(s) leaked in 1 allocation(s).
```

dict_set_value() returns the replaced Object in a dictionary. Here
the Object is unused and needs to be freed.
