### PR TITLE
[RFC] Fix :emenu when run from insert or visual mode

### DIFF
--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1301,11 +1301,15 @@ void ex_emenu(exarg_T *eap)
 
   /* Found the menu, so execute.
    * Use the Insert mode entry when returning to Insert mode. */
-  if (restart_edit
-      && !current_SID
-      ) {
+  if (((State & INSERT) || restart_edit) && !current_SID) {
     mode = (char_u *)"Insert";
     idx = MENU_INDEX_INSERT;
+  } else if (get_real_state() & VISUAL) {
+    /* Detect real visual mode -- if we are really in visual mode we
+     * don't need to do any guesswork to figure out what the selection
+     * is. Just execute the visual binding for the menu. */
+    mode = (char_u *)"Visual";
+    idx = MENU_INDEX_VISUAL;
   } else if (eap->addr_count) {
     pos_T tpos;
 

--- a/test/functional/ex_cmds/menu_spec.lua
+++ b/test/functional/ex_cmds/menu_spec.lua
@@ -1,0 +1,38 @@
+local helpers = require('test.functional.helpers')
+local clear, execute, nvim = helpers.clear, helpers.execute, helpers.nvim
+local expect = helpers.expect
+local feed = helpers.feed
+local command = helpers.command
+
+describe(':emenu', function()
+
+  before_each(function()
+    clear()
+    execute('nnoremenu Test.Test inormal<ESC>')
+    execute('inoremenu Test.Test insert')
+    execute('vnoremenu Test.Test x')
+  end)
+
+  it('executes correct bindings in normal mode without using API', function()
+    execute('emenu Test.Test')
+    expect('normal')
+  end)
+
+  it('executes correct bindings in normal mode', function()
+    command('emenu Test.Test')
+    expect('normal')
+  end)
+
+  it('executes correct bindings in insert mode', function()
+    feed('i')
+    command('emenu Test.Test')
+    expect('insert')
+  end)
+
+  it('executes correct bindings in visual mode', function()
+    feed('iabcde<ESC>0lvll')
+    command('emenu Test.Test')
+    expect('ae')
+  end)
+
+end)


### PR DESCRIPTION
A menu item can have separate bindings for each Vim mode.

:emenu checks to see which binding it should execute. But, it assumes
it can only be called from Normal mode, so its mode detection is based
on some guesswork. For instance, it detects if you've just used C-O
and, if so, uses the Insert mode binding.

Now that :emenu can be called from any mode (via vim_command), this
commit has it check the actual mode we're in, and simply use the
binding for that mode if we aren't in Normal mode.
