### PR TITLE
[RFC] Notify attached UIs whenever menus change

### DIFF
--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -30,6 +30,7 @@
 #include "nvim/keymap.h"
 #include "nvim/garray.h"
 #include "nvim/strings.h"
+#include "nvim/ui.h"
 
 
 #define MENUDEPTH   10          /* maximum depth of menus */
@@ -249,6 +250,7 @@ ex_menu (
     xfree(map_buf);
   }
 
+  ui_update_menu();
 
 theend:
   ;

--- a/src/nvim/msgpack_rpc/remote_ui.c
+++ b/src/nvim/msgpack_rpc/remote_ui.c
@@ -82,6 +82,7 @@ static Object remote_ui_attach(uint64_t channel_id, uint64_t request_id,
   ui->clear = remote_ui_clear;
   ui->eol_clear = remote_ui_eol_clear;
   ui->cursor_goto = remote_ui_cursor_goto;
+  ui->update_menu = remote_ui_update_menu;
   ui->busy_start = remote_ui_busy_start;
   ui->busy_stop = remote_ui_busy_stop;
   ui->mouse_on = remote_ui_mouse_on;
@@ -187,6 +188,12 @@ static void remote_ui_cursor_goto(UI *ui, int row, int col)
   ADD(args, INTEGER_OBJ(row));
   ADD(args, INTEGER_OBJ(col));
   push_call(ui, "cursor_goto", args);
+}
+
+static void remote_ui_update_menu(UI *ui)
+{
+  Array args = ARRAY_DICT_INIT;
+  push_call(ui, "update_menu", args);
 }
 
 static void remote_ui_busy_start(UI *ui)

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -149,6 +149,7 @@ UI *tui_start(void)
   ui->clear = tui_clear;
   ui->eol_clear = tui_eol_clear;
   ui->cursor_goto = tui_cursor_goto;
+  ui->update_menu = tui_update_menu;
   ui->busy_start = tui_busy_start;
   ui->busy_stop = tui_busy_stop;
   ui->mouse_on = tui_mouse_on;
@@ -376,6 +377,11 @@ static void tui_cursor_goto(UI *ui, int row, int col)
   data->row = row;
   data->col = col;
   unibi_goto(ui, row, col);
+}
+
+static void tui_update_menu(UI *ui)
+{
+    // Do nothing; menus are for GUI only
 }
 
 static void tui_busy_start(UI *ui)

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -324,6 +324,11 @@ void ui_cursor_goto(int new_row, int new_col)
   pending_cursor_update = true;
 }
 
+void ui_update_menu(void)
+{
+    UI_CALL(update_menu);
+}
+
 int ui_current_row(void)
 {
   return row;

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -20,6 +20,7 @@ struct ui_t {
   void (*clear)(UI *ui);
   void (*eol_clear)(UI *ui);
   void (*cursor_goto)(UI *ui, int row, int col);
+  void (*update_menu)(UI *ui);
   void (*busy_start)(UI *ui);
   void (*busy_stop)(UI *ui);
   void (*mouse_on)(UI *ui);

--- a/test/functional/api/menu_spec.lua
+++ b/test/functional/api/menu_spec.lua
@@ -1,0 +1,52 @@
+local helpers = require('test.functional.helpers')
+local Screen = require('test.functional.ui.screen')
+
+local clear = helpers.clear
+local command = helpers.command
+local feed = helpers.feed
+
+describe("update_menu notification", function()
+
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new()
+    screen:attach()
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  function expect_sent(expected)
+    screen:wait(function()
+      if screen.update_menu ~= expected then
+        if expected then
+          return 'update_menu was expected but not sent'
+        else
+          return 'update_menu was sent unexpectedly'
+        end
+      end
+    end)
+  end
+
+  it("should be sent when adding a menu", function()
+    command('menu Test.Test :')
+    expect_sent(true)
+  end)
+
+  it("should be sent when deleting a menu", function()
+    command('menu Test.Test :')
+    screen.update_menu = false
+
+    command('unmenu Test.Test')
+    expect_sent(true)
+  end)
+
+  it("should not be sent unnecessarily", function()
+    feed('i12345<ESC>:redraw<CR>')
+    expect_sent(false)
+  end)
+
+end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -166,6 +166,7 @@ function Screen.new(width, height)
     title = '',
     icon = '',
     bell = false,
+    update_menu = false,
     visual_bell = false,
     suspended = false,
     _default_attr_ids = nil,
@@ -414,6 +415,10 @@ end
 
 function Screen:_handle_suspend()
   self.suspended = true
+end
+
+function Screen:_handle_update_menu()
+  self.update_menu = true
 end
 
 function Screen:_handle_set_title(title)


### PR DESCRIPTION
This adds a redraw notification "update_menu" which is sent whenever
Vim's menus are changed by the :menu command and friends.
