### PR TITLE
[RFC] terminal: variable to control bold text highlight

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -99,6 +99,8 @@ variables (set via the |TermOpen| autocmd):
 - `{g,b}:terminal_color_$NUM`: The terminal color palette, where `$NUM` is the
   color index, between 0 and 255 inclusive. This only affects UIs with RGB
   capabilities; for normal terminals the color index is simply forwarded.
+- `{g,b}:terminal_bold_highbright`: Whether to highlight bold text. Either 1
+  to enable or 0 to disable. The default is 0.
 
 The configuration variables are only processed when the terminal starts, which
 is why it needs to be done with the |TermOpen| autocmd or setting global

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -197,7 +197,6 @@ Terminal *terminal_open(TerminalOptions opts)
   vterm_set_utf8(rv->vt, 1);
   // Setup state
   VTermState *state = vterm_obtain_state(rv->vt);
-  vterm_state_set_bold_highbright(state, true);
   // Set up screen
   rv->vts = vterm_obtain_screen(rv->vt);
   vterm_screen_enable_altscreen(rv->vts, true);
@@ -257,6 +256,13 @@ Terminal *terminal_open(TerminalOptions opts)
       rv->colors[i] = RGB(color.red, color.green, color.blue);
     }
   }
+
+  // Configure whether to highlight bold text. Try to get the option from:
+  //
+  // - b:terminal_bold_highbright
+  // - g:terminal_bold_highbright
+  int bold_highbright = get_config_int(rv, "terminal_bold_highbright");
+  vterm_state_set_bold_highbright(state, bold_highbright);
 
   return rv;
 }


### PR DESCRIPTION
Added the global/buffer-local variable terminal_bold_highbright to control whether or not to highlight bold text in the terminal emulator. The default is to disable bold text highlighting. Fix #2453.
