### PR TITLE
[RDY] Remove WIFCONTINUED call which never returns true

### DIFF
--- a/src/nvim/os/job.c
+++ b/src/nvim/os/job.c
@@ -445,11 +445,6 @@ static void chld_handler(uv_signal_t *handle, int signum)
     return;
   }
 
-  if (WIFSTOPPED(stat) || WIFCONTINUED(stat)) {
-    // Only care for processes that exited
-    return;
-  }
-
   Job *job = NULL;
   // find the job corresponding to the exited pid
   for (int i = 0; i < MAX_RUNNING_JOBS; i++) {


### PR DESCRIPTION
This macro would never return true since the preceding waitpid() call
did not specify the WCONTINUED option (which is correct since we only
care for processes that exited here).

Besides removing dead code, this improves portability since WCONTINUED
is not defined on all platforms.
