### PR TITLE
[RFC] remove Original patch region in sample pr message

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -83,13 +83,8 @@ ${vim_commit_url}"
 ${vim_message}
 \`\`\`
 
-${vim_commit_url}
+${vim_commit_url}"
 
-Original patch:
-
-\`\`\`diff
-${vim_diff}
-\`\`\`"
   neovim_branch="vim-${vim_version}"
 
   echo


### PR DESCRIPTION
Reason:
- The patch file is too long and hard to read and we already have the link in the message
- Too long pr message doesn't encourge people submit two or more small vim patch together
