### PR TITLE
[RDY] synIDattr(): take true colors into account

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14772,6 +14772,8 @@ static void f_synIDattr(typval_T *argvars, typval_T *rettv)
     modec = TOLOWER_ASC(mode[0]);
     if (modec != 'c' && modec != 'g')
       modec = 0;        /* replace invalid with current */
+  } else if (ui_rgb_attached()) {
+    modec = 'g';
   } else {
     modec = 'c';
   }

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -3,6 +3,7 @@ local Screen = require('test.functional.ui.screen')
 local thelpers = require('test.functional.terminal.helpers')
 local feed, clear, nvim = helpers.feed, helpers.clear, helpers.nvim
 local nvim_dir, execute = helpers.nvim_dir, helpers.execute
+local eq, eval = helpers.eq, helpers.eval
 
 
 describe('terminal window highlighting', function()
@@ -159,5 +160,29 @@ describe('terminal window highlighting with custom palette', function()
                                                         |
       -- TERMINAL --                                    |
     ]])
+  end)
+end)
+
+describe('synIDattr()', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(50, 7)
+    execute('highlight Normal ctermfg=1 guifg=#ff0000')
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  it('returns RGB number if GUI', function()
+    screen:attach(true)
+    eq('#ff0000', eval('synIDattr(hlID("Normal"), "fg")'))
+  end)
+
+  it('returns color number if non-GUI', function()
+    screen:attach(false)
+    eq('1', eval('synIDattr(hlID("Normal"), "fg")'))
   end)
 end)


### PR DESCRIPTION
In Vim, which doesn't support true colors, `synIDattr('Foo', 'fg')` returns either
`ctermfg` or `guifg` depending on whether vim or gvim is running.

True colors naturally use GUI colors, so `synIDattr()` has to be adapted to
return `guifg`, if a TUI with enabled true colors is used.

---

Someone in `#vim` had this problem, so I looked for a solution. Basically I really just stole this line from https://github.com/neovim/neovim/blob/master/src/nvim/tui/tui.c#L140

Maybe there's a better way to query the UI.

Also, since I have no true colors support, I couldn't test it myself. It would be nice, if someone could do that.
