### PR TITLE
[RFC] Remove tearoff menues

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -489,18 +489,6 @@ Pressing <F4> will start the menu.  You can now use the cursor keys to select
 a menu entry.  Hit <Enter> to execute it.  Hit <Esc> if you want to cancel.
 This does require the |+menu| feature enabled at compile time.
 
-							*tear-off-menus*
-GTK+ and Motif support Tear-off menus.  These are sort of sticky menus or
-pop-up menus that are present all the time.  If the resizing does not work
-correctly, this may be caused by using something like "Vim*geometry" in the
-defaults.  Use "Vim.geometry" instead.
-
-The Win32 GUI version emulates Motif's tear-off menus.  Actually, a Motif user
-will spot the differences easily, but hopefully they're just as useful.  You
-can also use the |:tearoff| command together with |hidden-menus| to create
-floating menus that do not appear on the main menu bar.
-
-
 5.2 Creating New Menus					*creating-menus*
 
 				*:me*  *:menu*  *:noreme*  *:noremenu*
@@ -750,8 +738,7 @@ nr  Name		Normal action  ~
 
 					*hidden-menus* *win32-hidden-menus*
 In the Win32 and GTK+ GUI, starting a menu name with ']' excludes that menu
-from the main menu bar.  You must then use the |:popup| or |:tearoff| command
-to display it.
+from the main menu bar.  You must then use the |:popup| command to display it.
 
 							*popup-menu*
 You can define the special menu "PopUp".  This is the menu that is displayed

--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -353,35 +353,6 @@ changes this.
 When prepending ":browse" before file editing commands, a file requester is
 used to allow you to select an existing file.  See |:browse|.
 
-
-6.3 Tearoff Menus
-
-The Win32 GUI emulates Motif's tear-off menus.  At the top of each menu you
-will see a small graphic "rip here" sign.  Selecting it will cause a floating
-window to be created with the same menu entries on it.  The floating menu can
-then be accessed just as if it was the original (including sub-menus), but
-without having to go to the menu bar each time.
-This is most useful if you find yourself using a command buried in a sub-menu
-over and over again.
-The tearoff menus can be positioned where you like, and always stay just above
-the Main Vim window.  You can get rid of them by closing them as usual; they
-also of course close when you exit Vim.
-
-							*:tearoff* *:te*
-:te[aroff] {name}	Tear-off the menu {name}.  The menu named must have at
-			least one subentry, but need not appear on the
-			menu-bar (see |win32-hidden-menus|).
-
-Example: >
-	:tearoff File
-will make the "File" menu (if there is one) appear as a tearoff menu. >
-
-	:amenu ]Toolbar.Make	:make<CR>
-	:tearoff ]Toolbar
-This creates a floating menu that doesn't exist on the main menu-bar.
-
-Note that a menu that starts with ']' will not be displayed.
-
 ==============================================================================
 7. Command line arguments				*gui-w32-cmdargs*
 

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1522,7 +1522,7 @@ tag	      command	      action ~
 |:tab|		:tab		create new tab when opening new window
 |:tag|		:ta[g]		jump to tag
 |:tags|		:tags		show the contents of the tag stack
-|:tearoff|	:te[aroff]	tear-off a menu
+|:terminal|	:te[rminal]	open a terminal buffer
 |:tfirst|	:tf[irst]	jump to first matching tag
 |:throw|	:th[row]	throw an exception
 |:tjump|	:tj[ump]	like ":tselect", but jump directly when there

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3256,8 +3256,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	screen.
 
 						*'guioptions'* *'go'*
-'guioptions' 'go'	string	(default "egmrLtT"   (MS-Windows),
-					 "aegimrLtT" (GTK, Motif and Athena))
+'guioptions' 'go'	string	(default "egmrLT"   (MS-Windows),
+					 "aegimrLT" (GTK, Motif and Athena))
 			global
 			{only available when compiled with GUI enabled}
 	This option only has an effect in the GUI version of Vim.  It is a
@@ -3319,9 +3319,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  'g'	Grey menu items: Make menu items that are not active grey.  If
 		'g' is not included inactive menu items are not shown at all.
 		Exception: Athena will always use grey menu items.
-								*'go-t'*
-	  't'	Include tearoff menu items.  Currently only works for Win32,
-		GTK+, and Motif 1.2 GUI.
 								*'go-T'*
 	  'T'	Include Toolbar.  Currently only in Win32, GTK+, Motif,
 		and Athena GUIs.

--- a/runtime/doc/usr_09.txt
+++ b/runtime/doc/usr_09.txt
@@ -81,10 +81,6 @@ is Edit/Global Settings.  You will find these entries:
 	Toggle Left Scrollbar	make a scrollbar appear/disappear at the left
 	Toggle Right Scrollbar	make a scrollbar appear/disappear at the right
 
-On most systems you can tear-off the menus.  Select the top item of the menu,
-the one that looks like a dashed line.  You will get a separate window with
-the items of the menu.  It will hang around until you close the window.
-
 
 THE TOOLBAR
 

--- a/runtime/doc/usr_42.txt
+++ b/runtime/doc/usr_42.txt
@@ -268,13 +268,6 @@ command like: >
 			but are completely removed.  (Does not work on all
 			systems.)
 
-	t		When removed the tearoff feature is not enabled.
-
-The dotted line at the top of a menu is not a separator line.  When you select
-this item, the menu is "teared-off": It is displayed in a separate window.
-This is called a tearoff menu.  This is useful when you use the same menu
-often.
-
 For translating menu items, see |:menutrans|.
 
 Since the mouse has to be used to select a menu item, it is a good idea to use

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -213,8 +213,8 @@ g8			Print the hex values of the bytes used in the
 						  *:sh* *:shell* *E371* *E360*
 :sh[ell]		Removed. |vim-differences| {Nvim}
 
-						  *:term* *:terminal*
-:term[inal][!] {cmd}	Spawns {cmd} using the current value of 'shell' and
+						  *:terminal* *:te*
+:te[rminal][!] {cmd}	Spawns {cmd} using the current value of 'shell' and
 			'shellcmdflag' in a new terminal buffer.  This is
 			equivalent to: >
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -28,13 +28,14 @@ these differences.
 ==============================================================================
 2. Option defaults					  *nvim-option-defaults*
 
-- 'autoindent' is set by default.
+- 'autoindent' is set by default
 - 'autoread' is set by default
 - 'backspace' defaults to "indent,eol,start"
 - 'complete' doesn't include "i"
 - 'display' defaults to "lastline"
 - 'encoding' defaults to "utf-8"
 - 'formatoptions' defaults to "tcqj"
+- 'guioptions' doesn't include "t"
 - 'hlsearch' is set by default
 - 'incsearch' is set by default
 - 'langnoremap' is set by default
@@ -148,8 +149,9 @@ Other options:
 
 Other commands:
   :fixdel
-  :mode no longer accepts an argument
+  :mode (no longer accepts an argument)
   :shell
+  :tearoff
 
 Other compile-time features:
   EBCDIC

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2678,12 +2678,6 @@ return {
     func='ex_ni',
   },
   {
-    command='tearoff',
-    flags=bit.bor(NEEDARG, EXTRA, TRLBAR, NOTRLCOM, CMDWIN),
-    addr_type=ADDR_LINES,
-    func='ex_tearoff',
-  },
-  {
     command='terminal',
     flags=bit.bor(BANG, FILES, CMDWIN),
     addr_type=ADDR_LINES,

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -144,7 +144,6 @@ struct dbg_stuff {
 #endif
 
 # define ex_gui                 ex_nogui
-# define ex_tearoff             ex_ni
 # define ex_popup               ex_ni
 # define ex_simalt              ex_ni
 # define gui_mch_find_dialog    ex_ni
@@ -3276,7 +3275,7 @@ set_one_cmd_context (
   case CMD_imenu:     case CMD_inoremenu:     case CMD_iunmenu:
   case CMD_cmenu:     case CMD_cnoremenu:     case CMD_cunmenu:
   case CMD_tmenu:                             case CMD_tunmenu:
-  case CMD_popup:     case CMD_tearoff:       case CMD_emenu:
+  case CMD_popup:                             case CMD_emenu:
     return set_context_in_menu_cmd(xp, cmd, arg, forceit);
 
   case CMD_colorscheme:

--- a/src/nvim/keymap.h
+++ b/src/nvim/keymap.h
@@ -83,11 +83,6 @@
 #define KS_SELECT               245
 #define K_SELECT_STRING         (char_u *)"\200\365X"
 
-/*
- * Used for tearing off a menu.
- */
-#define KS_TEAROFF              244
-
 /* Used a termcap entry that produces a normal character. */
 #define KS_KEY                  242
 
@@ -396,7 +391,6 @@ enum key_extra {
 #define K_HOR_SCROLLBAR   TERMCAP2KEY(KS_HOR_SCROLLBAR, KE_FILLER)
 
 #define K_SELECT        TERMCAP2KEY(KS_SELECT, KE_FILLER)
-#define K_TEAROFF       TERMCAP2KEY(KS_TEAROFF, KE_FILLER)
 
 #define K_TABLINE       TERMCAP2KEY(KS_TABLINE, KE_FILLER)
 #define K_TABMENU       TERMCAP2KEY(KS_TABMENU, KE_FILLER)

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -417,9 +417,8 @@ add_menu_path (
         /* free any old menu */
         free_menu_string(menu, i);
 
-        /* For "amenu", may insert an extra character.
-         * Don't do this if adding a tearbar (addtearoff == FALSE).
-         * Don't do this for "<Nop>". */
+        // For "amenu", may insert an extra character.
+        // Don't do this for "<Nop>".
         c = 0;
         d = 0;
         if (amenu && call_data != NULL && *call_data != NUL
@@ -571,16 +570,6 @@ remove_menu (
         return FAIL;
       }
       if ((menu->modes & modes) != 0x0) {
-#if defined(FEAT_GUI_W32) & defined(FEAT_TEAROFF)
-        /*
-         * If we are removing all entries for this menu,MENU_ALL_MODES,
-         * Then kill any tearoff before we start
-         */
-        if (*p == NUL && modes == MENU_ALL_MODES) {
-          if (IsWindow(menu->tearoff_handle))
-            DestroyWindow(menu->tearoff_handle);
-        }
-#endif
         if (remove_menu(&menu->children, p, modes, silent) == FAIL)
           return FAIL;
       } else if (*name != NUL) {
@@ -619,11 +608,6 @@ remove_menu (
 
     /* Recalculate modes for menu based on the new updated children */
     menu->modes &= ~modes;
-#if defined(FEAT_GUI_W32) & defined(FEAT_TEAROFF)
-    if ((s_tearoffs) && (menu->children != NULL))     /* there's a tear bar.. */
-      child = menu->children->next;       /* don't count tearoff bar */
-    else
-#endif
     child = menu->children;
     for (; child != NULL; child = child->next)
       menu->modes |= child->modes;
@@ -638,10 +622,6 @@ remove_menu (
     }
     if ((menu->modes & MENU_ALL_MODES) == 0) {
       /* The menu item is no longer valid in ANY mode, so delete it */
-#if defined(FEAT_GUI_W32) & defined(FEAT_TEAROFF)
-      if (s_tearoffs && menu->children != NULL)       /* there's a tear bar.. */
-        free_menu(&menu->children);
-#endif
       *menup = menu;
       free_menu(menup);
     }
@@ -862,7 +842,7 @@ char_u *set_context_in_menu_cmd(expand_T *xp, char_u *cmd, char_u *arg, int forc
       after_dot = p + 1;
   }
 
-  /* ":tearoff" and ":popup" only use menus, not entries */
+  // ":popup" only uses menues, not entries
   expand_menus = !((*cmd == 't' && cmd[1] == 'e') || *cmd == 'p');
   expand_emenu = (*cmd == 'e');
   if (expand_menus && ascii_iswhite(*p))
@@ -938,7 +918,6 @@ char_u *get_menu_name(expand_T *xp, int idx)
   /* Skip PopUp[nvoci]. */
   while (menu != NULL && (menu_is_hidden(menu->dname)
                           || menu_is_separator(menu->dname)
-                          || menu_is_tearoff(menu->dname)
                           || menu->children == NULL))
     menu = menu->next;
 
@@ -986,7 +965,6 @@ char_u *get_menu_names(expand_T *xp, int idx)
   while (menu != NULL
          && (   menu_is_hidden(menu->dname)
                 || (expand_emenu && menu_is_separator(menu->dname))
-                || menu_is_tearoff(menu->dname)
                 || menu->dname[STRLEN(menu->dname) - 1] == '.'
                 ))
     menu = menu->next;
@@ -1243,16 +1221,6 @@ static int menu_is_hidden(char_u *name)
 {
   return (name[0] == ']') || (menu_is_popup(name) && name[5] != NUL);
 }
-
-/*
- * Return TRUE if the menu is the tearoff menu.
- */
-static int menu_is_tearoff(char_u *name)
-{
-  return FALSE;
-}
-
-
 
 /*
  * Given a menu descriptor, e.g. "File.New", find it in the menu hierarchy and

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -200,7 +200,6 @@
 #define GO_ASELPLUS     'P'             /* autoselectPlus */
 #define GO_RIGHT        'r'             /* use right scrollbar */
 #define GO_VRIGHT       'R'             /* right scrollbar with vert split */
-#define GO_TEAROFF      't'             /* add tear-off menu items */
 #define GO_TOOLBAR      'T'             /* add toolbar */
 #define GO_FOOTER       'F'             /* add footer */
 #define GO_VERTICAL     'v'             /* arrange dialog buttons vertically */


### PR DESCRIPTION
Since `:terminal` gets used on-the-fly more often than the much more specific
`:tearoff` command, we change the abbreviation of `:terminal` from `:term` to the
even shorter `:te`.

References #3003.

---

Since it's a pretty easy and quick change, I just gone ahead and did it. Please close this PR, in case there are valid reasons against it.
