### PR TITLE
[RFC] clipboard: handle middle-click paste correctly.

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2016,6 +2016,9 @@ do_mouse (
       if (regname == '.')
         insert_reg(regname, true);
       else {
+        if (regname == 0 && eval_has_provider("clipboard")) {
+          regname = '*';
+        }
         if ((State & REPLACE_FLAG) && !yank_register_mline(regname))
           insert_reg(regname, true);
         else {
@@ -2284,6 +2287,9 @@ do_mouse (
    * Middle mouse click: Put text before cursor.
    */
   if (which_button == MOUSE_MIDDLE) {
+    if (regname == 0 && eval_has_provider("clipboard")) {
+      regname = '*';
+    }
     if (yank_register_mline(regname)) {
       if (mouse_past_bottom)
         dir = FORWARD;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -765,7 +765,10 @@ yankreg_T *get_yank_register(int regname, int mode)
   if (mode == YREG_PASTE && get_clipboard(regname, &reg, false)) {
     // reg is set to clipboard contents.
     return reg;
-  } else if (mode != YREG_YANK && (regname == 0 || regname == '"') && y_previous != NULL) {
+  } else if (mode != YREG_YANK
+      && (regname == 0 || regname == '"' || regname == '*' || regname == '+')
+      && y_previous != NULL) {
+    // in case clipboard not available, paste from previous used register
     return y_previous;
   }
 

--- a/test/functional/fixtures/autoload/provider/clipboard.vim
+++ b/test/functional/fixtures/autoload/provider/clipboard.vim
@@ -3,8 +3,12 @@ let g:test_clip = { '+': [''], '*': [''], }
 let s:methods = {}
 
 let g:cliplossy = 0
+let g:cliperror = 0
 
 function! s:methods.get(reg)
+  if g:cliperror
+    return 0
+  end
   if g:cliplossy
     " behave like pure text clipboard
     return g:test_clip[a:reg][0]


### PR DESCRIPTION
Fixes #2919 

Also handle clipboard errors more like vim: paste from unnamed register
if clipboard provider fails.
Setting as WIP, as it should have a test as well.
