### PR TITLE
[RFC] Source clipboard provider at start if &cb is set

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -521,6 +521,11 @@ int main(int argc, char **argv)
   if (restart_edit != 0)
     stuffcharReadbuff(K_NOP);
 
+  // WORKAROUND(mhi): #3023
+  if (cb_flags & CB_UNNAMEDMASK) {
+    (void)eval_has_provider("clipboard");
+  }
+
   TIME_MSG("before starting main loop");
 
   /*


### PR DESCRIPTION
The main problem is that <c-c> is a default mapping but also sets got_int.

Because of the former, normal_cmd() is kicked off which eventually leads to
sourcing the clipboard provider. But due to the latter, do_source() throws an
error, because got_int is set.

This is a temporary workaround and sources the clipboard provider before
main_loop(), if &clipboard is set.

References #3023.
