### PR TITLE
[RFC] main: Move event_init to before command_line_scan

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -238,6 +238,8 @@ int main(int argc, char **argv)
 
   early_init();
 
+  event_init();
+
   // Check if we have an interactive window.
   check_and_set_isatty(&params);
 
@@ -275,7 +277,6 @@ int main(int argc, char **argv)
   if (GARGCOUNT > 1 && !silent_mode)
     printf(_("%d files to edit\n"), GARGCOUNT);
 
-  event_init();
   full_screen = true;
   t_colors = 256;
   check_tty(&params);


### PR DESCRIPTION
This seems to fix or at least work around a segfault that occurs when nvim is started in Arabic mode (-A).

The command_line_scan() function can cause options to be set, including
the 'arabic' option. The 'arabic' option in turn force-sets the keymap
option, which causes the keymap file to be loaded.

However, the arabic keymap file is long enough to cause a breakcheck. At
that point, the event system has not been initialized yet, so the
breakcheck fails with a segfault.
