### PR TITLE
[RFC] Move recursive directory creation function to os/fs.c

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4573,15 +4573,16 @@ mkdir({name} [, {path} [, {prot}]])
 		If {prot} is given it is used to set the protection bits of
 		the new directory.  The default is 0755 (rwxr-xr-x: r/w for
 		the user readable for others).	Use 0700 to make it unreadable
-		for others.  This is only used for the last part of {name}.
-		Thus if you create /tmp/foo/bar then /tmp/foo will be created
-		with 0755.
-		Example: >
+		for others.
+									{Nvim}
+		{prot} is applied for all parts of {name}.  Thus if you create
+		/tmp/foo/bar then /tmp/foo will be created with 0700. Example: >
 			:call mkdir($HOME . "/tmp/foo/bar", "p", 0700)
 <		This function is not available in the |sandbox|.
-		Not available on all systems.  To check use: >
-			:if exists("*mkdir")
-<
+
+		If you try to create an existing directory with {path} set to 
+		"p" mkdir() will silently exit.
+
 							*mode()*
 mode([expr])	Return a string that indicates the current mode.
 		If [expr] is supplied and it evaluates to a non-zero Number or

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -64,6 +64,14 @@ are always available and may be used simultaneously in separate plugins.  The
 `neovim` pip package must be installed to use Python plugins in Nvim (see
 |nvim-python|).
 
+|mkdir()| behaviour changed:
+1. Assuming /tmp/foo does not exist and /tmp can be written to 
+   mkdir('/tmp/foo/bar', 'p', 0700) will create both /tmp/foo and /tmp/foo/bar 
+   with 0700 permissions. Vim mkdir will create /tmp/foo with 0755.
+2. If you try to create an existing directory with `'p'` (e.g. mkdir('/', 
+   'p')) mkdir() will silently exit. In Vim this was an error.
+3. mkdir() error messages now include strerror() text when mkdir fails.
+
 ==============================================================================
 4. New Features						     *nvim-features-new*
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7549,7 +7549,7 @@ int vim_mkdir_emsg(char_u *name, int prot)
 {
   int ret;
   if ((ret = os_mkdir((char *)name, prot)) != 0) {
-    EMSG3(_("E739: Cannot create directory %s: %s"), name, os_strerror(ret));
+    EMSG3(_(e_mkdir), name, os_strerror(ret));
     return FAIL;
   }
   return OK;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7547,8 +7547,9 @@ static void ex_mkrc(exarg_T *eap)
 
 int vim_mkdir_emsg(char_u *name, int prot)
 {
-  if (os_mkdir((char *)name, prot) != 0) {
-    EMSG2(_("E739: Cannot create directory: %s"), name);
+  int ret;
+  if ((ret = os_mkdir((char *)name, prot)) != 0) {
+    EMSG3(_("E739: Cannot create directory %s: %s"), name, os_strerror(ret));
     return FAIL;
   }
   return OK;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1117,6 +1117,7 @@ EXTERN char_u e_jobtblfull[] INIT(= N_("E901: Job table is full"));
 EXTERN char_u e_jobexe[] INIT(= N_("E902: \"%s\" is not an executable"));
 EXTERN char_u e_jobnotpty[] INIT(= N_("E904: Job is not connected to a pty"));
 EXTERN char_u e_libcall[] INIT(= N_("E364: Library call failed for \"%s()\""));
+EXTERN char_u e_mkdir[] INIT(= N_("E739: Cannot create directory %s: %s"));
 EXTERN char_u e_markinval[] INIT(= N_("E19: Mark has invalid line number"));
 EXTERN char_u e_marknotset[] INIT(= N_("E20: Mark not set"));
 EXTERN char_u e_modifiable[] INIT(= N_(

--- a/src/nvim/os/os_defs.h
+++ b/src/nvim/os/os_defs.h
@@ -135,4 +135,9 @@
 // For dup(3).
 #define HAVE_DUP
 
+/// Function to convert -errno error to char * error description
+///
+/// -errno errors are returned by a number of os functions.
+#define os_strerror uv_strerror
+
 #endif  // NVIM_OS_OS_DEFS_H


### PR DESCRIPTION
Also makes `uv_strerror` output appear in relevant error messages. This move is needed to automatically create `~/.nvim/shada` directory in #2506; error messages were changed because this way they are more readable. Previously recursive function is no longer recursive and uses less allocations in worst case (but always uses an allocation in the best case when previous function would not bother). Should not be the problem because best case is `mkdir('/', 'p')` (or `mkdir('c:', 'p')`).

Changes in behaviour:
1. `mkdir(existing_dir, 'p')` no longer errors out (`mkdir(existing_dir)` still will), similar to `mkdir -p`.
2. `mkdir(existing_dir . '/a/b', 'p', 0700)` will create _both_ `{existing_dir}/a` and `{existing_dir}/a/b` with 0700 permissions. Previously it created only `{existing_dir}/a/b` with 0700 and `{existing_dir}/a` with 0755.

I also removed “Not available on all systems.” warning because this function is not `#ifdef`ed.
