### PR TITLE
[RFC] Continue #1069 and add xstrlcat function

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4587,8 +4587,11 @@ void fix_help_buffer(void)
           char_u      *cp;
 
           /* Find all "doc/ *.txt" files in this directory. */
-          add_pathsep((char *)NameBuff);
-          STRCAT(NameBuff, "doc/*.??[tx]");
+          if (add_pathsep((char *)NameBuff)
+              && STRLCAT(NameBuff, "doc/*.??[tx]", MAXPATHL) >= MAXPATHL) {
+            EMSG(_(e_pathtoolong));
+            continue;
+          }
 
           // Note: We cannot just do `&NameBuff` because it is a statically sized array
           //       so `NameBuff == &NameBuff` according to C semantics.
@@ -4758,8 +4761,8 @@ void ex_helptags(exarg_T *eap)
 
   /* Get a list of all files in the help directory and in subdirectories. */
   STRLCPY(NameBuff, dirname, MAXPATHL);
-  add_pathsep((char *)NameBuff);
-  if (STRLCAT(NameBuff, "**", MAXPATHL) >= MAXPATHL) {
+  if (add_pathsep((char *)NameBuff)
+      && STRLCAT(NameBuff, "**", MAXPATHL) >= MAXPATHL) {
     EMSG(_(e_pathtoolong));
     xfree(dirname);
     return;
@@ -4886,8 +4889,8 @@ helptags_one (
    * Do this before scanning through all the files.
    */
   memcpy(NameBuff, dir, dirlen + 1);
-  add_pathsep((char *)NameBuff);
-  if (STRLCAT(NameBuff, tagfname, MAXPATHL) >= MAXPATHL) {
+  if (add_pathsep((char *)NameBuff)
+      && STRLCAT(NameBuff, tagfname, MAXPATHL) >= MAXPATHL) {
     EMSG(_(e_pathtoolong));
     return;
   }

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -195,9 +195,6 @@ typedef struct ff_search_ctx_T {
 # include "file_search.c.generated.h"
 #endif
 
-static char_u e_pathtoolong[] = N_("E854: path too long for completion");
-
-
 /*
  * Initialization routine for vim_findfile().
  *

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1202,6 +1202,7 @@ EXTERN char_u e_bufloaded[] INIT(= N_("E139: File is loaded in another buffer"))
 EXTERN char_u e_notset[] INIT(= N_("E764: Option '%s' is not set"));
 EXTERN char_u e_invalidreg[] INIT(= N_("E850: Invalid register name"));
 EXTERN char_u e_unsupportedoption[] INIT(= N_("E519: Option not supported"));
+EXTERN char_u e_pathtoolong[] INIT(= N_("E854: path too long for completion"));
 
 
 EXTERN char top_bot_msg[] INIT(= N_("search hit TOP, continuing at BOTTOM"));

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -370,6 +370,33 @@ size_t xstrlcpy(char *restrict dst, const char *restrict src, size_t size)
     return ret;
 }
 
+/// xstrlcat - appends string src to the end of dst.
+///
+/// Compatible with *BSD strlcat: It will append at most
+/// dstsize - strlen(dst) - 1 characters.
+/// dst then will be NULL-terminate.
+///
+/// @param dst Where to copy the string to
+/// @param src Where to copy the string from
+/// @param dstsize size of destination buffer, it should be larger than 0
+/// @param size Size of destination buffer
+/// @return the initial length of dst plus the length of src.
+///         (i.e. strlen(src) + strlen(dst))
+size_t xstrlcat(char *restrict dst, const char *restrict src, size_t dstsize)
+  FUNC_ATTR_NONNULL_ALL
+{
+  assert(dstsize > 0);
+  size_t src_len = strlen(src);
+  size_t dst_len = strlen(dst);
+  size_t ret = src_len + dst_len;
+  if (src_len) {
+    size_t len = (ret >= dstsize) ? dstsize - 1 : ret;
+    memcpy(dst + dst_len, src, len - dst_len);
+    dst[len] = '\0';
+  }
+  return ret;
+}
+
 /// strdup() wrapper
 ///
 /// @see {xmalloc}

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5625,9 +5625,9 @@ option_value2string (
     long wc = 0;
 
     if (wc_use_keyname(varp, &wc))
-      STRCPY(NameBuff, get_special_key_name((int)wc, 0));
+      STRLCPY(NameBuff, get_special_key_name((int)wc, 0), MAXPATHL);
     else if (wc != 0)
-      STRCPY(NameBuff, transchar((int)wc));
+      STRLCPY(NameBuff, transchar((int)wc), MAXPATHL);
     else
       sprintf((char *)NameBuff, "%" PRId64, (int64_t)*(long *)varp);
   } else { /* P_STRING */

--- a/src/nvim/os/os_defs.h
+++ b/src/nvim/os/os_defs.h
@@ -33,7 +33,7 @@
 #define BASENAMELEN (MAXNAMLEN - 5)
 
 // Use the system path length if it makes sense.
-#if defined(PATH_MAX) && (PATH_MAX > 1000)
+#if defined(PATH_MAX) && (PATH_MAX > 1024)
 # define MAXPATHL PATH_MAX
 #else
 # define MAXPATHL 1024

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -359,8 +359,12 @@ char *concat_fnames(const char *fname1, const char *fname2, bool sep)
 void add_pathsep(char *p)
   FUNC_ATTR_NONNULL_ALL
 {
-  if (*p != NUL && !after_pathsep(p, p + strlen(p)))
-    strcat(p, PATHSEPSTR);
+  const size_t len = strlen(p);
+  const size_t pathsep_len = sizeof(PATHSEPSTR);
+  assert(len < MAXPATHL - pathsep_len);
+  if (*p != NUL && !after_pathsep(p, p + len)) {
+    memcpy(p + len, PATHSEPSTR, pathsep_len);
+  }
 }
 
 /// Get an allocated copy of the full path to a file.

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -356,15 +356,20 @@ char *concat_fnames(const char *fname1, const char *fname2, bool sep)
  * Add a path separator to a file name, unless it already ends in a path
  * separator.
  */
-void add_pathsep(char *p)
+bool add_pathsep(char *p)
   FUNC_ATTR_NONNULL_ALL
 {
   const size_t len = strlen(p);
-  const size_t pathsep_len = sizeof(PATHSEPSTR);
-  assert(len < MAXPATHL - pathsep_len);
   if (*p != NUL && !after_pathsep(p, p + len)) {
-    memcpy(p + len, PATHSEPSTR, pathsep_len);
+    const size_t pathsep_len = sizeof(PATHSEPSTR);
+    if (len < MAXPATHL - pathsep_len) {
+      memcpy(p + len, PATHSEPSTR, pathsep_len);
+      return true;
+    } else {
+      return false;
+    }
   }
+  return true;
 }
 
 /// Get an allocated copy of the full path to a file.

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -283,6 +283,7 @@ enum {
 
 #define STRCAT(d, s)        strcat((char *)(d), (char *)(s))
 #define STRNCAT(d, s, n)    strncat((char *)(d), (char *)(s), (size_t)(n))
+#define STRLCAT(d, s, n)    xstrlcat((char *)(d), (char *)(s), (size_t)(n))
 
 # define vim_strpbrk(s, cs) (char_u *)strpbrk((char *)(s), (char *)(cs))
 

--- a/test/functional/path/add_pathsep_spec.lua
+++ b/test/functional/path/add_pathsep_spec.lua
@@ -1,0 +1,22 @@
+local helpers = require('test.functional.helpers')
+local execute, eq, clear, eval, feed, ok =
+  helpers.execute, helpers.eq, helpers.clear, helpers.eval,
+  helpers.feed, helpers.ok
+
+describe('add_pathsep function', function()
+  local test_dir = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+  before_each(function()
+    clear()
+    lfs.mkdir(test_dir)
+  end)
+  after_each(function()
+    lfs.rmdir(test_dir)
+  end)
+
+  it("add_pathsep()", function()
+    execute('cd ' .. test_dir)
+    execute("echo fnamemodify('', ':p')")
+    feed('<cr>')
+  end)
+
+end)


### PR DESCRIPTION
Fix coverity issue in #988
by using STRLCPY and add STRLCAT.

coverity related/{71530,71531,71532}

Problems list there:

> If strlen(dirname) >= MAXPATHL then NameBuff would not be NUL terminated. But the next function call could be using strlen on NameBuff. We should better use STRLCPY here. by @oni-link 

done

> STRNCAT uses MAXPATHL on the src argument, not on the dst argument. So appending "**" could overflow NameBuff, because no size check was made for dst. by @oni-link

Done by add xstrlcat in memory.c, and check it.

> check when truncation happens & EMSG(e_pathtoolong) by @splinterofchaos  @philix 

done. Changes in option.c is not the same as ex_cmds.c haven't been discussed, so I don't check if truncation happens there.

> rename the commit to ' coverity/{71530,71531,71532}: ...`  by @elmart

Should I still do it now?
