### PR TITLE
[RFC] Replace some MAYBE usages with explicit TriState enum

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -48,9 +48,9 @@ static int diff_flags = DIFF_FILLER;
 
 #define LBUFLEN 50               // length of line in diff file
 
-// TRUE when "diff -a" works, FALSE when it doesn't work, MAYBE when not
-// checked yet
-static int diff_a_works = MAYBE;
+// kTriTrue when "diff -a" works, kTriFalse when it doesn't work, kTriMaybe
+// when not checked yet
+static TriState diff_a_works = kTriMaybe;
 
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -671,33 +671,33 @@ void ex_diffupdate(exarg_T *eap)
   // are no differences.  Can't use the return value, it's non-zero when
   // there are differences.
   // May try twice, first with "-a" and then without.
-  int io_error = FALSE;
-  int ok = FALSE;
+  bool io_error = false;
+  bool ok = false;
   for (;;) {
-    ok = FALSE;
+    ok = false;
     FILE *fd = mch_fopen((char *)tmp_orig, "w");
 
     if (fd == NULL) {
-      io_error = TRUE;
+      io_error = true;
     } else {
       if (fwrite("line1\n", (size_t)6, (size_t)1, fd) != 1) {
-        io_error = TRUE;
+        io_error = true;
       }
       fclose(fd);
       fd = mch_fopen((char *)tmp_new, "w");
 
       if (fd == NULL) {
-        io_error = TRUE;
+        io_error = true;
       } else {
         if (fwrite("line2\n", (size_t)6, (size_t)1, fd) != 1) {
-          io_error = TRUE;
+          io_error = true;
         }
         fclose(fd);
         diff_file(tmp_orig, tmp_new, tmp_diff);
         fd = mch_fopen((char *)tmp_diff, "r");
 
         if (fd == NULL) {
-          io_error = TRUE;
+          io_error = true;
         } else {
           char_u linebuf[LBUFLEN];
 
@@ -708,7 +708,7 @@ void ex_diffupdate(exarg_T *eap)
             }
 
             if (STRNCMP(linebuf, "1c1", 3) == 0) {
-              ok = TRUE;
+              ok = true;
             }
           }
           fclose(fd);
@@ -725,10 +725,10 @@ void ex_diffupdate(exarg_T *eap)
     }
 
     // If we checked if "-a" works already, break here.
-    if (diff_a_works != MAYBE) {
+    if (diff_a_works != kTriMaybe) {
       break;
     }
-    diff_a_works = ok;
+    diff_a_works = ok ? kTriTrue : kTriFalse;
 
     // If "-a" works break here, otherwise retry without "-a".
     if (ok) {
@@ -741,7 +741,7 @@ void ex_diffupdate(exarg_T *eap)
       EMSG(_("E810: Cannot read or write temp files"));
     }
     EMSG(_("E97: Cannot create diffs"));
-    diff_a_works = MAYBE;
+    diff_a_works = kTriMaybe;
     goto theend;
   }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5188,7 +5188,7 @@ void fix_help_buffer(void)
               if (IObuff[0] == '*'
                   && (s = vim_strchr(IObuff + 1, '*'))
                   != NULL) {
-                int this_utf = MAYBE;
+                TriState this_utf = kTriMaybe;
                 /* Change tag definition to a
                  * reference and remove <CR>/<NL>. */
                 IObuff[0] = '|';
@@ -5203,10 +5203,10 @@ void fix_help_buffer(void)
                   if (*s >= 0x80 && this_utf != FALSE) {
                     int l;
 
-                    this_utf = TRUE;
+                    this_utf = kTriTrue;
                     l = utf_ptr2len(s);
                     if (l == 1)
-                      this_utf = FALSE;
+                      this_utf = kTriFalse;
                     s += l - 1;
                   }
                   ++s;
@@ -5390,8 +5390,8 @@ helptags_one (
   char_u      *s;
   char_u      *fname;
   int dirlen;
-  int utf8 = MAYBE;
-  int this_utf8;
+  TriState utf8 = kTriMaybe;
+  TriState this_utf8;
   int firstline;
   int mix = FALSE;              /* detected mixed encodings */
 
@@ -5455,23 +5455,23 @@ helptags_one (
     while (!vim_fgets(IObuff, IOSIZE, fd) && !got_int) {
       if (firstline) {
         /* Detect utf-8 file by a non-ASCII char in the first line. */
-        this_utf8 = MAYBE;
+        this_utf8 = kTriMaybe;
         for (s = IObuff; *s != NUL; ++s)
           if (*s >= 0x80) {
             int l;
 
-            this_utf8 = TRUE;
+            this_utf8 = kTriTrue;
             l = utf_ptr2len(s);
             if (l == 1) {
               /* Illegal UTF-8 byte sequence. */
-              this_utf8 = FALSE;
+              this_utf8 = kTriFalse;
               break;
             }
             s += l - 1;
           }
-        if (this_utf8 == MAYBE)             /* only ASCII characters found */
-          this_utf8 = FALSE;
-        if (utf8 == MAYBE)                  /* first file */
+        if (this_utf8 == kTriMaybe)         /* only ASCII characters found */
+          this_utf8 = kTriFalse;
+        if (utf8 == kTriMaybe)              /* first file */
           utf8 = this_utf8;
         else if (utf8 != this_utf8) {
           EMSG2(_(
@@ -5549,7 +5549,7 @@ helptags_one (
       }
     }
 
-    if (utf8 == TRUE)
+    if (utf8 == kTriTrue)
       fprintf(fd_tags, "!_TAG_FILE_ENCODING\tutf-8\t//\n");
 
     /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7013,7 +7013,7 @@ static void ex_operators(exarg_T *eap)
   oa.end.lnum = eap->line2;
   oa.line_count = eap->line2 - eap->line1 + 1;
   oa.motion_type = MLINE;
-  virtual_op = FALSE;
+  virtual_op = kTriFalse;
   if (eap->cmdidx != CMD_yank) {        /* position cursor for undo */
     setpcmark();
     curwin->w_cursor.lnum = eap->line1;
@@ -7044,7 +7044,7 @@ static void ex_operators(exarg_T *eap)
     op_shift(&oa, FALSE, eap->amount);
     break;
   }
-  virtual_op = MAYBE;
+  virtual_op = kTriMaybe;
   ex_may_print(eap);
 }
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -150,7 +150,7 @@ EXTERN int cmdline_star INIT(= FALSE);          /* cmdline is crypted */
 
 EXTERN int exec_from_reg INIT(= FALSE);         /* executing register */
 
-EXTERN int screen_cleared INIT(= FALSE);        /* screen has been cleared */
+EXTERN TriState screen_cleared INIT(= kTriFalse); /* screen has been cleared */
 
 /*
  * When '$' is included in 'cpoptions' option set:
@@ -1056,7 +1056,7 @@ EXTERN char pseps[2]                    /* normal path separator string */
 
 /* Set to TRUE when an operator is being executed with virtual editing, MAYBE
  * when no operator is being executed, FALSE otherwise. */
-EXTERN int virtual_op INIT(= MAYBE);
+EXTERN TriState virtual_op INIT(= kTriMaybe);
 
 /* Display tick, incremented for each call to update_screen() */
 EXTERN disptick_T display_tick INIT(= 0);

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -71,7 +71,7 @@ ex_menu (
   char_u      *p;
   int i;
   long pri_tab[MENUDEPTH + 1];
-  int enable = MAYBE;               /* TRUE for "menu enable", FALSE for "menu
+  TriState enable = kTriMaybe;      /* True for "menu enable", false for "menu
                                      * disable */
   vimmenu_T menuarg;
 
@@ -140,10 +140,10 @@ ex_menu (
    * Check for "disable" or "enable" argument.
    */
   if (STRNCMP(arg, "enable", 6) == 0 && ascii_iswhite(arg[6])) {
-    enable = TRUE;
+    enable = kTriTrue;
     arg = skipwhite(arg + 6);
   } else if (STRNCMP(arg, "disable", 7) == 0 && ascii_iswhite(arg[7])) {
-    enable = FALSE;
+    enable = kTriFalse;
     arg = skipwhite(arg + 7);
   }
 
@@ -167,15 +167,15 @@ ex_menu (
   /*
    * If there is only a menu name, display menus with that name.
    */
-  if (*map_to == NUL && !unmenu && enable == MAYBE) {
+  if (*map_to == NUL && !unmenu && enable == kTriMaybe) {
     show_menus(menu_path, modes);
     goto theend;
-  } else if (*map_to != NUL && (unmenu || enable != MAYBE)) {
+  } else if (*map_to != NUL && (unmenu || enable != kTriMaybe)) {
     EMSG(_(e_trailing));
     goto theend;
   }
 
-  if (enable != MAYBE) {
+  if (enable != kTriMaybe) {
     /*
      * Change sensitivity of the menu.
      * For the PopUp menu, remove a menu for each mode separately.

--- a/src/nvim/misc2.c
+++ b/src/nvim/misc2.c
@@ -63,12 +63,12 @@
 /*
  * Return TRUE if in the current mode we need to use virtual.
  */
-int virtual_active(void)
+bool virtual_active(void)
 {
   /* While an operator is being executed we return "virtual_op", because
    * VIsual_active has already been reset, thus we can't check for "block"
    * being used. */
-  if (virtual_op != MAYBE)
+  if (virtual_op != kTriMaybe)
     return virtual_op;
   return ve_flags == VE_ALL
          || ((ve_flags & VE_BLOCK) && VIsual_active && VIsual_mode == Ctrl_V)

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1271,7 +1271,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
     oap->line_count = oap->end.lnum - oap->start.lnum + 1;
 
     /* Set "virtual_op" before resetting VIsual_active. */
-    virtual_op = virtual_active();
+    virtual_op = virtual_active() ? kTriTrue : kTriFalse;
 
     if (VIsual_active || redo_VIsual_busy) {
       if (VIsual_mode == Ctrl_V) {      /* block mode */
@@ -1706,7 +1706,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
     default:
       clearopbeep(oap);
     }
-    virtual_op = MAYBE;
+    virtual_op = kTriMaybe;
     if (!gui_yank) {
       /*
        * if 'sol' not set, go back to old column for some commands
@@ -1779,7 +1779,7 @@ static void op_colon(oparg_T *oap)
 static void op_function(oparg_T *oap)
 {
   char_u      *(argv[1]);
-  int save_virtual_op = virtual_op;
+  TriState save_virtual_op = virtual_op;
 
   if (*p_opfunc == NUL)
     EMSG(_("E774: 'operatorfunc' is empty"));
@@ -1800,7 +1800,7 @@ static void op_function(oparg_T *oap)
 
     /* Reset virtual_op so that 'virtualedit' can be changed in the
      * function. */
-    virtual_op = MAYBE;
+    virtual_op = kTriMaybe;
 
     (void)call_func_retnr(p_opfunc, 1, argv, false);
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5111,9 +5111,9 @@ void cursor_pos_info(void)
 
         switch (l_VIsual_mode) {
         case Ctrl_V:
-          virtual_op = virtual_active();
+          virtual_op = virtual_active() ? kTriTrue : kTriFalse;
           block_prep(&oparg, &bd, lnum, 0);
-          virtual_op = MAYBE;
+          virtual_op = kTriMaybe;
           s = bd.textstart;
           len = (long)bd.textlen;
           break;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -824,11 +824,11 @@ static void win_update(win_T *wp)
   }
 
   /* Trick: we want to avoid clearing the screen twice.  screenclear() will
-   * set "screen_cleared" to TRUE.  The special value MAYBE (which is still
-   * non-zero and thus not FALSE) will indicate that screenclear() was not
+   * set "screen_cleared" to kTriTrue. The special value kTriMaybe (which is
+   * still non-zero and thus not FALSE) will indicate that screenclear() was not
    * called. */
   if (screen_cleared)
-    screen_cleared = MAYBE;
+    screen_cleared = kTriMaybe;
 
   /*
    * If there are no changes on the screen that require a complete redraw,
@@ -990,9 +990,9 @@ static void win_update(win_T *wp)
       mid_end = wp->w_height;
       if (lastwin == firstwin) {
         /* Clear the screen when it was not done by win_del_lines() or
-         * win_ins_lines() above, "screen_cleared" is FALSE or MAYBE
+         * win_ins_lines() above, "screen_cleared" is kTriFalse or kTriMaybe
          * then. */
-        if (screen_cleared != TRUE)
+        if (screen_cleared != kTriTrue)
           screenclear();
         /* The screen was cleared, redraw the tab pages line. */
         if (redraw_tabline)
@@ -1004,7 +1004,7 @@ static void win_update(win_T *wp)
      * cleared (only happens for the first window) or when screenclear()
      * was called directly above, "must_redraw" will have been set to
      * NOT_VALID, need to reset it here to avoid redrawing twice. */
-    if (screen_cleared == TRUE)
+    if (screen_cleared == kTriTrue)
       must_redraw = 0;
   } else {
     /* Not VALID or INVERTED: redraw all lines. */
@@ -6211,7 +6211,7 @@ static void screenclear2(void)
   ui_clear();  // clear the display
   clear_cmdline = FALSE;
   mode_displayed = FALSE;
-  screen_cleared = TRUE;        /* can use contents of ScreenLines now */
+  screen_cleared = kTriTrue;    /* can use contents of ScreenLines now */
 
   win_rest_invalid(firstwin);
   redraw_cmdline = TRUE;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1447,7 +1447,7 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
   int hash_dir = 0;                     /* Direction searched for # things */
   int comment_dir = 0;                  /* Direction searched for comments */
   pos_T match_pos;                      /* Where last slash-star was found */
-  int start_in_quotes;                  /* start position is in quotes */
+  TriState start_in_quotes;             /* start position is in quotes */
   int traveled = 0;                     /* how far we've searched so far */
   int ignore_cend = FALSE;              /* ignore comment end */
   int cpo_match;                        /* vi compatible matching */
@@ -1637,7 +1637,7 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
     backwards = !backwards;
 
   do_quotes = -1;
-  start_in_quotes = MAYBE;
+  start_in_quotes = kTriMaybe;
   clearpos(&match_pos);
 
   /* backward search: Check if this line contains a single-line comment */
@@ -1793,10 +1793,10 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
         inquote = FALSE;
         if (ptr[-1] == '\\') {
           do_quotes = 1;
-          if (start_in_quotes == MAYBE) {
+          if (start_in_quotes == kTriMaybe) {
             /* Do we need to use at_start here? */
             inquote = TRUE;
-            start_in_quotes = TRUE;
+            start_in_quotes = kTriTrue;
           } else if (backwards)
             inquote = TRUE;
         }
@@ -1804,10 +1804,10 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
           ptr = ml_get(pos.lnum - 1);
           if (*ptr && *(ptr + STRLEN(ptr) - 1) == '\\') {
             do_quotes = 1;
-            if (start_in_quotes == MAYBE) {
+            if (start_in_quotes == kTriMaybe) {
               inquote = at_start;
               if (inquote)
-                start_in_quotes = TRUE;
+                start_in_quotes = kTriTrue;
             } else if (!backwards)
               inquote = TRUE;
           }
@@ -1817,8 +1817,8 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
         }
       }
     }
-    if (start_in_quotes == MAYBE)
-      start_in_quotes = FALSE;
+    if (start_in_quotes == kTriMaybe)
+      start_in_quotes = kTriFalse;
 
     /*
      * If 'smartmatch' is set:
@@ -1837,7 +1837,7 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
       /* at end of line without trailing backslash, reset inquote */
       if (pos.col == 0 || linep[pos.col - 1] != '\\') {
         inquote = FALSE;
-        start_in_quotes = FALSE;
+        start_in_quotes = kTriFalse;
       }
       break;
 
@@ -1852,7 +1852,7 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
             break;
         if ((((int)pos.col - 1 - col) & 1) == 0) {
           inquote = !inquote;
-          start_in_quotes = FALSE;
+          start_in_quotes = kTriFalse;
         }
       }
       break;

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -20,4 +20,13 @@ typedef unsigned char char_u;
 // Can hold one decoded UTF-8 character.
 typedef uint32_t u8char_T;
 
+// A three-valued 'boolean' type.
+// Note: kTriMaybe is non-zero and will therefore evaluate to true in a boolean
+// context. See also: TRUE, FALSE and MAYBE definitions in vim.h
+typedef enum {
+    kTriFalse = 0,
+    kTriTrue = 1,
+    kTriMaybe = 2,
+} TriState;
+
 #endif  // NVIM_TYPES_H

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -471,22 +471,22 @@ static void flush_cursor_update(void)
 // shape, for example.
 static void ui_change_mode(void)
 {
-  static int showing_insert_mode = MAYBE;
+  static int showing_insert_mode = kTriMaybe;
 
   if (!full_screen) {
     return;
   }
 
   if (State & INSERT) {
-    if (showing_insert_mode != TRUE) {
+    if (showing_insert_mode != kTriTrue) {
       UI_CALL(insert_mode);
     }
-    showing_insert_mode = TRUE;
+    showing_insert_mode = kTriTrue;
   } else {
-    if (showing_insert_mode != FALSE) {
+    if (showing_insert_mode != kTriFalse) {
       UI_CALL(normal_mode);
     }
-    showing_insert_mode = FALSE;
+    showing_insert_mode = kTriFalse;
   }
   conceal_check_cursur_line();
 }


### PR DESCRIPTION
The MAYBE value from vim.h is used as a kind of 'unknown' value in some optimizations. This commit makes it more explicit where the trick is used and makes it clearer that these values look like, but aren't,
boolean.

kTriFalse, kTriTrue and kTriMaybe are equal to 0, 1 and 2 (MAYBE) respectively, so behaviour should not be affected.
