### PR TITLE
[RFC] Test: fix functional/ex_cmds/recover_spec.lua

### DIFF
--- a/test/functional/ex_cmds/recover_spec.lua
+++ b/test/functional/ex_cmds/recover_spec.lua
@@ -20,11 +20,11 @@ describe(':preserve', function()
   local swapdir = lfs.currentdir()..'/testdir_recover_spec'
   before_each(function()
     clear()
-    os.remove(swapdir)
+    helpers.rmdir(swapdir)
     lfs.mkdir(swapdir)
   end)
   after_each(function()
-    os.remove(swapdir)
+    helpers.rmdir(swapdir)
   end)
 
   it("saves to custom 'directory' and (R)ecovers (issue #1836)", function()

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -290,6 +290,28 @@ local function expect(contents)
   return eq(dedent(contents), curbuf_contents())
 end
 
+local function rmdir(path)
+  if lfs.attributes(path, 'mode') ~= 'directory' then
+    return nil
+  end
+  for file in lfs.dir(path) do
+    if file == '.' or file == '..' then
+      goto continue
+    end
+    ret, err = os.remove(path..'/'..file)
+    if not ret then
+      error('os.remove: '..err)
+      return nil
+    end
+    ::continue::
+  end
+  ret, err = os.remove(path)
+  if not ret then
+    error('os.remove: '..err)
+  end
+  return ret
+end
+
 return {
   clear = clear,
   spawn = spawn,
@@ -321,5 +343,6 @@ return {
   curbuf_contents = curbuf_contents,
   wait = wait,
   set_session = set_session,
-  write_file = write_file
+  write_file = write_file,
+  rmdir = rmdir
 }


### PR DESCRIPTION
Commit 1: add `helpers.rmdir()`
Commit 2: fix bug in `test/functional/ex_cmds/recover_spec.lua` that lead to a stray directory
