### PR TITLE
[RFC] vim-patch:7.4.779

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4415,7 +4415,9 @@ int do_addsub(int command, linenr_T Prenum1)
     ins_str(buf1);              /* insert the new number */
     xfree(buf1);
   }
-  --curwin->w_cursor.col;
+  if (curwin->w_cursor.col > 0) {
+    --curwin->w_cursor.col;
+  }
   curwin->w_set_curswant = TRUE;
   ptr = ml_get_buf(curbuf, curwin->w_cursor.lnum, TRUE);
   RLADDSUBFIX(ptr);

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -145,7 +145,7 @@ static int included_patches[] = {
   // 782,
   781,
   // 780 NA
-  // 779,
+  779,
   // 778 NA
   // 777 NA
   776,


### PR DESCRIPTION
```
Problem:  Using CTRL-A in a line without a number moves the cursor. May
          cause a crash when at the start of the line. (Urtica Dioica)
Solution: Do not move the cursor if no number was changed.
```

https://github.com/vim/vim/commit/3ec326198029d5a59413b3b8b33dbc9c06c4f28b
