### PR TITLE
[RFC] Convert pos_T macros into mark.h functions

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -15,6 +15,7 @@
 #include "nvim/func_attr.h"
 #include "nvim/indent.h"
 #include "nvim/main.h"
+#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
@@ -1399,7 +1400,7 @@ void getvcols(win_T *wp, pos_T *pos1, pos_T *pos2, colnr_T *left,
   colnr_T to1;
   colnr_T to2;
 
-  if (ltp(pos1, pos2)) {
+  if (lt(*pos1, *pos2)) {
     getvvcol(wp, pos1, &from1, NULL, &to1);
     getvvcol(wp, pos2, &from2, NULL, &to2);
   } else {

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -33,6 +33,7 @@
 #include "nvim/indent.h"
 #include "nvim/indent_c.h"
 #include "nvim/main.h"
+#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -38,6 +38,7 @@
 #include "nvim/if_cscope.h"
 #include "nvim/indent.h"
 #include "nvim/main.h"
+#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/menu.h"

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -7,6 +7,7 @@
 #include "nvim/eval.h"
 #include "nvim/charset.h"
 #include "nvim/cursor.h"
+#include "nvim/mark.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
@@ -599,7 +600,7 @@ int get_lisp_indent(void)
     paren = *pos;
     pos = findmatch(NULL, '[');
 
-    if ((pos == NULL) || ltp(pos, &paren)) {
+    if ((pos == NULL) || lt(*pos, paren)) {
       pos = &paren;
     }
   }

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -13,25 +13,6 @@
  */
 
 /*
- * Position comparisons
- */
-# define lt(a, b) (((a).lnum != (b).lnum) \
-                   ? (a).lnum < (b).lnum \
-                   : (a).col != (b).col \
-                   ? (a).col < (b).col \
-                   : (a).coladd < (b).coladd)
-# define ltp(a, b) (((a)->lnum != (b)->lnum) \
-                    ? (a)->lnum < (b)->lnum \
-                    : (a)->col != (b)->col \
-                    ? (a)->col < (b)->col \
-                    : (a)->coladd < (b)->coladd)
-# define equalpos(a, b) (((a).lnum == (b).lnum) && ((a).col == (b).col) && \
-                         ((a).coladd == (b).coladd))
-# define clearpos(a) {(a)->lnum = 0; (a)->col = 0; (a)->coladd = 0; }
-
-#define ltoreq(a, b) (lt(a, b) || equalpos(a, b))
-
-/*
  * lineempty() - return TRUE if the line is empty
  */
 #define lineempty(p) (*ml_get(p) == NUL)

--- a/src/nvim/mark.h
+++ b/src/nvim/mark.h
@@ -2,8 +2,46 @@
 #define NVIM_MARK_H
 
 #include "nvim/buffer_defs.h"
+#include "nvim/func_attr.h"
 #include "nvim/mark_defs.h"
 #include "nvim/pos.h"
+
+static inline bool lt(pos_T, pos_T) REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
+static inline bool equalpos(pos_T, pos_T) REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
+static inline bool ltoreq(pos_T, pos_T) REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
+static inline void clearpos(pos_T *) REAL_FATTR_ALWAYS_INLINE;
+
+/// Return true if position a is before (less than) position b.
+static inline bool lt(pos_T a, pos_T b)
+{
+  if (a.lnum != b.lnum) {
+    return a.lnum < b.lnum;
+  } else if (a.col != b.col) {
+    return a.col < b.col;
+  } else {
+    return a.coladd < b.coladd;
+  }
+}
+
+/// Return true if position a and b are equal.
+static inline bool equalpos(pos_T a, pos_T b)
+{
+  return (a.lnum == b.lnum) && (a.col == b.col) && (a.coladd == b.coladd);
+}
+
+/// Return true if position a is less than or equal to b.
+static inline bool ltoreq(pos_T a, pos_T b)
+{
+  return lt(a, b) || equalpos(a, b);
+}
+
+/// Clear the pos_T structure pointed to by a.
+static inline void clearpos(pos_T *a)
+{
+  a->lnum = 0;
+  a->col = 0;
+  a->coladd = 0;
+}
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "mark.h.generated.h"

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -111,6 +111,7 @@
 #include "nvim/indent.h"
 #include "nvim/getchar.h"
 #include "nvim/main.h"
+#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -309,6 +309,7 @@
 #include "nvim/func_attr.h"
 #include "nvim/getchar.h"
 #include "nvim/hashtab.h"
+#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"


### PR DESCRIPTION
There are a few function-like macros in `macros.h` for working with pos_T values (`lt`, `ltp`, `equalpos`, `ltoreq` and `clearpos`). These are quite useful, but because these are macros, something like...

```
ltoreq(foo(a), bar(b))
```

...would evaluate foo and bar eight times. This might be potentially confusing, especially if foo or bar have side effects. This PR replaces the macros with functions.

I've put the function definitions into `pos.c`, which I think is a nice spot, but probably means they won't be inlined. I'll move them to `pos.h` (and extern inline them in `pos.c`) if that's preferred.
