### PR TITLE
[RFC] Make float_op_wrapper not inline

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7102,8 +7102,11 @@ static inline int get_float_arg(typval_T *argvars, float_T *f)
 }
 
 // Apply a floating point C function on a typval with one float_T.
-static inline void float_op_wrapper(typval_T *argvars, typval_T *rettv,
-                                    float_T (*function)(float_T))
+#ifndef __i386__
+inline
+#endif
+static void float_op_wrapper(typval_T *argvars, typval_T *rettv,
+                             float_T (*function)(float_T))
 {
   float_T f;
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7102,7 +7102,12 @@ static inline int get_float_arg(typval_T *argvars, float_T *f)
 }
 
 // Apply a floating point C function on a typval with one float_T.
-#ifndef __i386__
+//
+// Some versions of glibc on i386 have an optimization that makes it harder to
+// call math functions indirectly from inside an inlined function, causing
+// compile-time errors with some versions of gcc. We avoid trying to inline
+// float_op_wrapper on that platform.
+#ifndef ARCH_32
 inline
 #endif
 static void float_op_wrapper(typval_T *argvars, typval_T *rettv,


### PR DESCRIPTION
Apparently, either some versions of gcc have trouble with function pointers being called in functions marked `inline`, or some versions of libc's math function have trouble being called indirectly (see #3071).

I'll try to find out which versions of gcc (or libc perhaps?) that are. In the meantime, this PR removes the `inline` keyword from `float_op_wrapper`.
