### PR TITLE
[RFC] Add '.' and '..' to candidates of glob() and remove spurious warnings when reading directories

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -415,14 +415,11 @@ readfile (
     msg_scroll = TRUE;          /* don't overwrite previous file message */
 
   /*
-   * If the name ends in a path separator, we can't open it.  Check here,
-   * because reading the file may actually work, but then creating the swap
-   * file may destroy it!  Reported on MS-DOS and Win 95.
    * If the name is too long we might crash further on, quit here.
    */
   if (fname != NULL && *fname != NUL) {
     p = fname + STRLEN(fname);
-    if (after_pathsep((char *)fname, (char *)p) || STRLEN(fname) >= MAXPATHL) {
+    if (STRLEN(fname) >= MAXPATHL) {
       filemess(curbuf, fname, (char_u *)_("Illegal file name"), 0);
       msg_end();
       msg_scroll = msg_save;

--- a/test/functional/eval/glob_spec.lua
+++ b/test/functional/eval/glob_spec.lua
@@ -1,0 +1,21 @@
+local helpers = require('test.functional.helpers')
+local clear, execute, eval, eq = helpers.clear, helpers.execute, helpers.eval, helpers.eq
+
+before_each(function()
+  clear()
+  lfs.mkdir('test-glob')
+  execute('cd test-glob')
+end)
+
+after_each(function()
+  lfs.rmdir('test-glob')
+end)
+
+describe('glob()', function()
+  it("glob('.*') returns . and .. ", function()
+    eq({'.', '..'}, eval("glob('.*', 0, 1)"))
+  end)
+  it("glob('*') returns an empty list ", function()
+    eq({}, eval("glob('*', 0, 1)"))
+  end)
+end)


### PR DESCRIPTION
Re: #2954 
