### PR TITLE
[RFC] Set 'keywordprg' for vim and help filetypes.

### DIFF
--- a/runtime/autoload/help.vim
+++ b/runtime/autoload/help.vim
@@ -18,18 +18,22 @@ function! help#topic() abort
   let post = getline('.')[col : -1]
   let syn = synIDattr(synID(line('.'), col('.'), 1), 'name')
   let cword = expand('<cword>')
-  if syn ==# 'vimFuncName'
-    return cword.'()'
+  if syn ==# 'vimFuncName' && post ==# '('
+    return cword . '()'
   elseif syn ==# 'vimOption'
-    return "'".cword."'"
+    return "'" . cword . "'"
+  elseif pre =~# '&$' || pre =~# '&[lg]:$'
+    return "'" . cword . "'"
+  elseif pre =~# 'set\s\+$' || pre =~# '\vsetl(ocal)?\s+$' || pre =~# '\vsetg(lobal)?\s+$'
+    return "'" . cword . "'"
   elseif syn ==# 'vimUserAttrbKey'
-    return ':command-'.cword
+    return ':command-' . cword
   elseif pre =~# '^\s*:\=$'
-    return ':'.cword
-  elseif pre =~# '\<v:$'
-    return 'v:'.cword
-  elseif cword ==# 'v' && post =~# ':\w\+'
-    return 'v'.matchstr(post, ':\w\+')
+    return ':' . cword
+  elseif pre =~# '\<[vgbtw]:$'
+    return 'v:' . cword
+  elseif cword ==# '[vgbtw]' && post =~# ':\w\+'
+    return 'v' . matchstr(post, ':\w\+')
   else
     return cword
   endif

--- a/runtime/autoload/help.vim
+++ b/runtime/autoload/help.vim
@@ -1,0 +1,38 @@
+function! s:synnames(...) abort
+  if a:0
+    let [line, col] = [a:1, a:2]
+  else
+    let [line, col] = [line('.'), col('.')]
+  endif
+  return reverse(map(synstack(line, col), 'synIDattr(v:val,"name")'))
+endfunction
+
+function! HelpTopic()
+  let col = col('.') - 1
+  while col && getline('.')[col] =~# '\k'
+    let col -= 1
+  endwhile
+  let pre = col == 0 ? '' : getline('.')[0 : col]
+  let col = col('.') - 1
+  while col && getline('.')[col] =~# '\k'
+    let col += 1
+  endwhile
+  let post = getline('.')[col : -1]
+  let syn = get(synnames(), 0, '')
+  let cword = expand('<cword>')
+  if syn ==# 'vimFuncName'
+    return cword.'()'
+  elseif syn ==# 'vimOption'
+    return "'".cword."'"
+  elseif syn ==# 'vimUserAttrbKey'
+    return ':command-'.cword
+  elseif pre =~# '^\s*:\=$'
+    return ':'.cword
+  elseif pre =~# '\<v:$'
+    return 'v:'.cword
+  elseif cword ==# 'v' && post =~# ':\w\+'
+    return 'v'.matchstr(post, ':\w\+')
+  else
+    return cword
+  endif
+endfunction

--- a/runtime/autoload/help.vim
+++ b/runtime/autoload/help.vim
@@ -1,3 +1,8 @@
+if exists("g:loaded_help")
+  finish
+endif
+let g:loaded_help = 1
+
 function! s:synnames(...) abort
   if a:0
     let [line, col] = [a:1, a:2]

--- a/runtime/autoload/help.vim
+++ b/runtime/autoload/help.vim
@@ -12,7 +12,7 @@ function! s:synnames(...) abort
   return reverse(map(synstack(line, col), 'synIDattr(v:val,"name")'))
 endfunction
 
-function! HelpTopic()
+function! help#topic() abort
   let col = col('.') - 1
   while col && getline('.')[col] =~# '\k'
     let col -= 1

--- a/runtime/autoload/help.vim
+++ b/runtime/autoload/help.vim
@@ -3,27 +3,20 @@ if exists("g:loaded_help")
 endif
 let g:loaded_help = 1
 
-function! s:synnames(...) abort
-  if a:0
-    let [line, col] = [a:1, a:2]
-  else
-    let [line, col] = [line('.'), col('.')]
-  endif
-  return reverse(map(synstack(line, col), 'synIDattr(v:val,"name")'))
-endfunction
-
 function! help#topic() abort
   let col = col('.') - 1
   while col && getline('.')[col] =~# '\k'
     let col -= 1
   endwhile
+
   let pre = col == 0 ? '' : getline('.')[0 : col]
   let col = col('.') - 1
   while col && getline('.')[col] =~# '\k'
     let col += 1
   endwhile
+
   let post = getline('.')[col : -1]
-  let syn = get(synnames(), 0, '')
+  let syn = synIDattr(synID(line('.'), col('.'), 1), 'name')
   let cword = expand('<cword>')
   if syn ==# 'vimFuncName'
     return cword.'()'

--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -94,4 +94,4 @@ let &cpo = s:cpo_save
 unlet s:cpo_save
 
 " Open the help file when pressing 'K'.
-nnoremap <silent><buffer> K :exe 'help '.HelpTopic()<CR>
+nnoremap <silent><buffer> K :execute 'help' help#topic()<CR>

--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -92,3 +92,6 @@ endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
+
+" Open the help file when pressing 'K'.
+nnoremap <silent><buffer> K :exe 'help '.HelpTopic()<CR>

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -75,3 +75,6 @@ unlet s:cpo_save
 
 " removed this, because 'cpoptions' is a global option.
 " setlocal cpo+=M		" makes \%( match \)
+
+" Open the help file when pressing 'K'.
+nnoremap <silent><buffer> K :exe 'help '.HelpTopic()<CR>

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -77,4 +77,4 @@ unlet s:cpo_save
 " setlocal cpo+=M		" makes \%( match \)
 
 " Open the help file when pressing 'K'.
-nnoremap <silent><buffer> K :exe 'help '.HelpTopic()<CR>
+nnoremap <silent><buffer> K :execute 'help' help#topic()<CR>


### PR DESCRIPTION
Open the Vim help file instead of `man` when pressing <kbd>K</kbd> in normal mode.
