### PR TITLE
[RFC] don't wait_return in the middle of a vim_err_write message

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -629,6 +629,7 @@ static void write_msg(String message, bool to_err)
                                                                               \
   line_buf[pos++] = message.data[i];
 
+  ++no_wait_return;
   for (uint32_t i = 0; i < message.size; i++) {
     if (to_err) {
       PUSH_CHAR(i, err_pos, err_line_buf, emsg);
@@ -636,4 +637,6 @@ static void write_msg(String message, bool to_err)
       PUSH_CHAR(i, out_pos, out_line_buf, msg);
     }
   }
+  --no_wait_return;
+  msg_end();
 }

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -246,6 +246,10 @@ local function nvim(method, ...)
   return request('vim_'..method, ...)
 end
 
+local function nvim_async(method, ...)
+  session:notify('vim_'..method, ...)
+end
+
 local function buffer(method, ...)
   return request('buffer_'..method, ...)
 end
@@ -341,6 +345,7 @@ return {
   expect = expect,
   ok = ok,
   nvim = nvim,
+  nvim_async = nvim_async,
   nvim_prog = nvim_prog,
   nvim_dir = nvim_dir,
   buffer = buffer,

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -489,7 +489,7 @@ function Screen:snapshot_util(attrs, ignore)
   self:print_snapshot(attrs, ignore)
 end
 
-function Screen:redraw_debug(attrs, ignore)
+function Screen:redraw_debug(attrs, ignore, timeout)
   self:print_snapshot(attrs, ignore)
   local function notification_cb(method, args)
     assert(method == 'redraw')
@@ -500,7 +500,10 @@ function Screen:redraw_debug(attrs, ignore)
     self:print_snapshot(attrs, ignore)
     return true
   end
-  run(nil, notification_cb, nil, 250)
+  if timeout == nil then
+    timeout = 250
+  end
+  run(nil, notification_cb, nil, timeout)
 end
 
 function Screen:print_snapshot(attrs, ignore)


### PR DESCRIPTION
fixes #2547 .I don't really now if/how #1802 relates to this issue anymore, but this just fixes by reusing the existing logic e.g. used for do_cmdline.
