### PR TITLE
[RFC] Add plugin management primitives

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1548,6 +1548,11 @@ v:operator	The last operator given in Normal mode.  This is a single
 		commands.
 		Read-only.
 
+					*v:plugins*
+v:plugins	Dictionary containing information about plugins registered
+		using the |:plug| command. Each entry is a dictionary, with
+		the 'path' key being the only guaranteed existing key.
+
 					*v:prevcount* *prevcount-variable*
 v:prevcount	The count given for the last but one Normal mode command.
 		This is the v:count value of the previous command.  Useful if

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4765,6 +4765,21 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	Replace the ';' with a ':' or whatever separator is used.  Note that
 	this doesn't work when $INCL contains a comma or white space.
 
+							   *'plugindir'*
+'plugindir' 'pidir'	string (default "bundle") {Nvim}
+			global
+	The name of the folder in 'runtimepath' where to look for plugin bundles.
+	The |:plug| command depends on this value to expand path specs;
+	for example >
+	    plug neovim/neovimplugin
+<	expands the bundle path to `~/config/nvim/bundle/neovimplugin`.
+	You can declare plugins in several locations by setting 'plugindir'
+	when declaring plugins: >
+	    set plugindir=plugged
+	    plug neovim/nvimplugin
+	    set plugindir=~/devel/plugins
+	    plug devel-plugin
+<
 			*'preserveindent'* *'pi'* *'nopreserveindent'* *'nopi'*
 'preserveindent' 'pi'	boolean	(default off)
 			local to buffer

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -254,8 +254,8 @@ least the ones for Normal mode.  More about mappings in section |40.1|.
 
 Vim's functionality can be extended by adding plugins.  A plugin is nothing
 more than a Vim script file that is loaded automatically when Vim starts.  You
-can add a plugin very easily by dropping it in your plugin directory.
-{not available when Vim was compiled without the |+eval| feature}
+can add a plugin very easily by dropping it in your plugin directory.  You can
+also declare where to load plugins from using the |:plug| command.
 
 There are two types of plugins:
 
@@ -386,6 +386,27 @@ The <filetype> part is the name of the filetype the plugin is to be used for.
 Only files of this filetype will use the settings from the plugin.  The <name>
 part of the plugin file doesn't matter, you can use it to have several plugins
 for the same filetype.  Note that it must end in ".vim".
+
+THE PLUG COMMAND                                                    *:plug*
+                                                                    {Nvim}
+:plug[!] {spec}	        Add the plugin bundle defined by {spec} to 'runtimepath'.
+			{spec} can be a full path, the name of a directory in
+			the plugins folder (defined as `~/.config/nvim/bundle/` by
+			default, see 'plugindir'), or it can have the form
+			`PREFIX/DIRNAME`.
+			If [!] is given, source the *.vim files in the plugin/
+			folder within {spec} (this can be used, for example, to
+			load plugins early during initiallization, while the
+			|vimrc| file is sourced).
+
+You can declare which paths to load plugins from using |:plug| from your
+|vimrc| file: >
+
+	plug ~/.config/nvim/bundle/nvim-plugin
+	plug neovim/nvim-plugin
+	plug nvim-plugin
+
+Note: All these commands are equivalent on a default setup.
 
 
 Further reading:

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -250,61 +250,87 @@ The ":map" command (with no arguments) lists your current mappings.  At
 least the ones for Normal mode.  More about mappings in section |40.1|.
 
 ==============================================================================
-*05.4*	Adding a plugin					*add-plugin* *plugin*
+*05.4*	Plugins					*add-plugin* *plugin*
 
-Vim's functionality can be extended by adding plugins.  A plugin is nothing
-more than a Vim script file that is loaded automatically when Vim starts.  You
-can add a plugin very easily by dropping it in your plugin directory.  You can
-also declare where to load plugins from using the |:plug| command.
+Vim's functionality can be extended by adding plugins.  A plugin is
+essentially a set of Vim script files that are loaded automatically when Vim
+starts or on some other event (like opening a file of a certain type).
+Plugins can be used to add support to more programming languages, extend Vim's
+command "vocabulary", simplify some use-cases, add some bling to Vim, and even
+turn it into a different sort of application.  Thankfully, the community has
+made available on the net a great ammount of plugins that any user can benefit
+from.
 
-There are two types of plugins:
+You can add a plugin very easily by dropping it in your |vimfiles| directory,
+but there are more advanced ways to manage plugins, which will be described
+below.
 
-    global plugin: Used for all kinds of files
-  filetype plugin: Only used for a specific type of file
+KINDS OF PLUGIN                                         *plugin-types*
 
-The global plugins will be discussed first, then the filetype ones
-|add-filetype-plugin|.
+There are mainly two kinds of plugin: global and filetype-specific.
 
-
-GLOBAL PLUGINS						*standard-plugin*
-
+Global plugins are sourced on startup and usually add functionality that will
+be available regardless of the opened files. For example, the |matchparen|
+plugin can be used in any kind of file whatsoever to highlight matching
+parentheses on cursor movement.
+					                *standard-plugin*
 When you start Vim, it will automatically load a number of global plugins.
 You don't have to do anything for this.  They add functionality that most
 people will want to use, but which was implemented as a Vim script instead of
 being compiled into Vim.  You can find them listed in the help index
 |standard-plugin-list|.  Also see |load-plugins|.
 
-							*add-global-plugin*
-You can add a global plugin to add functionality that will always be present
-when you use Vim.  There are only two steps for adding a global plugin:
-1. Get a copy of the plugin.
-2. Drop it in the right directory.
+Global plugins reside under the `plugin/` |vimfiles| directory.
 
+                                                        *ftplugins*
+Filetype plugins ("ftplugins") are only used for a specific type of file, and
+usually change the buffer-local settings. For example, the standard vim C
+ftplugin sets 'formatoptions' to break comment lines but not other lines, and
+to insert the comment leader when hitting <CR> or using |o|. Filetype plugins
+are usually distributed alongside syntax files, and indent and filetype
+detection scripts to provide support for aditional programming or markup
+languages in Vim.
 
-GETTING A GLOBAL PLUGIN
+Filetype plugins reside under the `ftplugin/` |vimfiles| directory.
 
-Where can you find plugins?
+The Vim distribution comes with a set of plugins for different filetypes that
+you can start using with this command: >
+
+	:filetype plugin on
+
+See |vimrc-filetype|.
+
+GETTING PLUGINS                                         *plugins-getting*
+
+There are many places to get plugins from:
+
 - Some come with Vim.  You can find them in the directory $VIMRUNTIME/macros
   and its sub-directories.
-- Download from the net.  There is a large collection on http://www.vim.org.
+- In the net:
+  - A nicely curated list of plugins is available at http://vimawesome.com/.
+  - There is a large collection of plugins on http://www.vim.org/scripts.
+  - Github is very popular for plugin creators. See
+    https://github.com/search?q=language%3AVimL&type=Repositories
 - They are sometimes posted in a Vim |maillist|.
-- You could write one yourself, see |write-plugin|.
+- You could write one yourself ;) (see |write-plugin|).
+
+
+INSTALLING PLUGINS                   *add-global-plugin*  *add-filetype-plugin*
 
 Some plugins come as a vimball archive, see |vimball|.
 Some plugins can be updated automatically, see |getscript|.
 
+For all other cases, you should be able to follow the guidelines below (also,
+it's very likely that the plugin creators has given instructions on how to
+install the plugins, so follow those!).
 
-USING A GLOBAL PLUGIN
+INSTALLING PLUGINS MANUALLY                             *plugin-add-manually*
 
-First read the text in the plugin itself to check for any special conditions.
-Then copy the file to your plugin directory:
+For simple plugins, it should be enough to drop their files in the appropriate
+directories.
 
-	system		plugin directory ~
-	Unix		~/.vim/plugin/
-	Macintosh	$VIM:vimfiles:plugin
-	Mac OS X	~/.vim/plugin/
-
-Example for Unix (assuming you didn't have a plugin directory yet): >
+For example, to install the justify.vim plugin in *nix (assuming you didn't
+have a plugin directory yet): >
 
 	mkdir ~/.vim
 	mkdir ~/.vim/plugin
@@ -313,38 +339,12 @@ Example for Unix (assuming you didn't have a plugin directory yet): >
 That's all!  Now you can use the commands defined in this plugin to justify
 text.
 
-Instead of putting plugins directly into the plugin/ directory, you may
-better organize them by putting them into subdirectories under plugin/.
-As an example, consider using "~/.vim/plugin/perl/*.vim" for all your Perl
+Instead of putting plugins directly into the plugin/ directory, you may better
+organize them by putting them into subdirectories under plugin/.  As an
+example, consider using "~/.vim/plugin/git/*.vim" for all the Git-related
 plugins.
-
-
-FILETYPE PLUGINS			*add-filetype-plugin* *ftplugins*
-
-The Vim distribution comes with a set of plugins for different filetypes that
-you can start using with this command: >
-
-	:filetype plugin on
-
-That's all!  See |vimrc-filetype|.
-
-If you are missing a plugin for a filetype you are using, or you found a
-better one, you can add it.  There are two steps for adding a filetype plugin:
-1. Get a copy of the plugin.
-2. Drop it in the right directory.
-
-
-GETTING A FILETYPE PLUGIN
-
-You can find them in the same places as the global plugins.  Watch out if the
-type of file is mentioned, then you know if the plugin is a global or a
-filetype one.  The scripts in $VIMRUNTIME/macros are global ones, the filetype
-plugins are in $VIMRUNTIME/ftplugin.
-
-
-USING A FILETYPE PLUGIN					*ftplugin-name*
-
-You can add a filetype plugin by dropping it in the right directory.  The
+							*ftplugin-name*
+You can also add a filetype plugin by dropping it in the right directory.  The
 name of this directory is in the same directory mentioned above for global
 plugins, but the last part is "ftplugin".  Suppose you have found a plugin for
 the "stuff" filetype, and you are on Unix.  Then you can move this file to the
@@ -360,11 +360,7 @@ adding.  If it's OK, you can give the new one another name: >
 
 The underscore is used to separate the name of the filetype from the rest,
 which can be anything.  If you use "otherstuff.vim" it wouldn't work, it would
-be loaded for the "otherstuff" filetype.
-
-On MS-DOS you cannot use long filenames.  You would run into trouble if you
-add a second plugin and the filetype has more than six characters.  You can
-use an extra directory to get around this: >
+be loaded for the "otherstuff" filetype. You can also use an extra directory: >
 
 	mkdir $VIM/vimfiles/ftplugin/fortran
 	copy thefile $VIM/vimfiles/ftplugin/fortran/too.vim
@@ -387,8 +383,74 @@ Only files of this filetype will use the settings from the plugin.  The <name>
 part of the plugin file doesn't matter, you can use it to have several plugins
 for the same filetype.  Note that it must end in ".vim".
 
-THE PLUG COMMAND                                                    *:plug*
-                                                                    {Nvim}
+USING PLUGIN BUNDLES                                      *plugin-bundles*
+
+The manual method described above has the problem that things can get messy
+once you install a few plugins, specially if they include more than one file
+(which is common). A way to solve this is to install plugins in their own
+directories and then add the path of those to the 'runtimepath' setting (so
+Vim will use the files from those directories when looking for plugins). In
+practice, this means that instead of having a |vimfiles| tree like >
+
+	~.vim/
+	    plugin/
+		a.vim
+	    ftplugin/
+		b.vim
+		e.vim
+	    syntax/
+		b.vim
+
+you can have something like this >
+
+	~.vim/
+	    bundles/
+		a/
+		    plugin/
+			a.vim
+		b/
+		    ftplugin/
+			b.vim
+		    syntax/
+			b.vim
+		e/
+		    ftplugin/
+			e.vim
+
+This method allows the plugins to be distributed as their own trees, so they
+can be installed without affecting other plugins. This is very helpful when
+synchronizing with a version control repository.
+
+So supposing the user wants to install a plugin that's distributed as this tree: >
+
+	autoload/
+	    awesome.vim
+	plugin/
+	    awesome.vim
+	doc/
+	    awesome.txt
+
+from http://github.com/developer/awesome-vim, they can do so by (assuming there
+is no "bundles" directory)
+
+    1. creating the plugin directory >
+	$ mkdir -p ~/.vim/bundles/awesome-vim
+<    2. copying the files into the "bundles/awesome-vim/" folder >
+	$ cp awesome-vim/* ~/.vim/bundles/awesome-vim/
+<    3. adding >
+
+	set runtimepath+=~/.vim/bundles/awesome-vim
+
+<       to their |vimrc|.
+
+Most commonly, instead of steps 1-2, this should work: >
+
+    $ mkdir ~/.vim/bundles/
+    $ cd ~/.vim/bundles
+    $ git clone https://github.com/developer/awesome-vim
+
+THE PLUG COMMAND                                          *:plug*
+                                                          {Nvim}
 :plug[!] {spec}	        Add the plugin bundle defined by {spec} to 'runtimepath'.
 			{spec} can be a full path, the name of a directory in
 			the plugins folder (defined as `~/.config/nvim/bundle/` by
@@ -406,10 +468,28 @@ You can declare which paths to load plugins from using |:plug| from your
 	plug neovim/nvim-plugin
 	plug nvim-plugin
 
-Note: All these commands are equivalent on a default setup.
+On a default setup, these three commands are equivalent to >
+
+	set runtimepath+=~/.config/nvim/bundle/nvim-plugin
+
+PLUGIN MANAGERS                                            *plugin-managers*
+
+Bundle-style plugins can be handled by so-called 'plugin managers', which are
+special plugins whose purpose is to handle 'runtimepath' and help the user to
+install, update and load plugins.
+
+The most popular plugin managers are:
+
+- vim-plug https://github.com/junegunn/vim-plug
+- Vundle https://github.com/VundleVim/Vundle.vim
+- neobundle.vim https://github.com/Shougo/neobundle.vim
+- VAM https://github.com/MarcWeber/vim-addon-manager
+
+Please refer to their documentation on how to use them.
 
 
-Further reading:
+Further reading:                                           *plugins-extra*
+
 |filetype-plugins|	Documentation for the filetype plugins and information
 			about how to avoid that mappings cause problems.
 |load-plugins|		When the global plugins are loaded during startup.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -80,6 +80,9 @@ are always available and may be used simultaneously in separate plugins.  The
 
 See |nvim-intro| for a list of Nvim's largest new features.
 
+The |:plug| command provides basic facilities for using pathogen-style plugin
+bundles.
+
 |bracketed-paste-mode| is built-in and enabled by default.
 
 Meta (alt) chords are recognized (even in the terminal).

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -21,6 +21,7 @@ syn cluster vimCommentGroup	contains=vimTodo,@Spell
 syn match   vimCommand contained	"\<z[-+^.=]\="
 syn keyword vimOnlyCommand contained	fix[del] sh[ell] P[rint]
 syn keyword vimStdPlugin contained	DiffOrig Man N[ext] S TOhtml XMLent XMLns
+syn match   vimplugCommandSpec	"\(^\s*plug\s*\)\@<=.*$"
 
 " Vim-specific options {{{2
 syn keyword vimOnlyOption contained	biosk bioskey cp compatible consk conskey cm cryptmethod edcompatible guipty key macatsui mzq mzquantum osfiletype oft renderoptions rop st shelltype sn shortname tenc termencoding ta textauto tx textmode tf ttyfast ttym ttymouse tbi ttybuiltin wiv weirdinvert

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -440,6 +440,7 @@ static struct vimvar {
   {VV_NAME("command_output",   VAR_STRING), 0},
   {VV_NAME("completed_item",   VAR_DICT), VV_RO},
   {VV_NAME("msgpack_types",    VAR_DICT), VV_RO},
+  {VV_NAME("plugins",          VAR_DICT), 0}
 };
 
 /* shorthand */
@@ -600,6 +601,7 @@ void eval_init(void)
 
   set_vim_var_dict(VV_MSGPACK_TYPES, msgpack_types_dict);
   set_vim_var_dict(VV_COMPLETED_ITEM, dict_alloc());
+  set_vim_var_dict(VV_PLUGINS, dict_alloc());
   set_vim_var_nr(VV_SEARCHFORWARD, 1L);
   set_vim_var_nr(VV_HLSEARCH, 1L);
   set_reg_var(0);    /* default for v:register is not 0 but '"' */

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -66,6 +66,7 @@ enum {
     VV_COMMAND_OUTPUT,
     VV_COMPLETED_ITEM,
     VV_MSGPACK_TYPES,
+    VV_PLUGINS,
     VV_LEN, /* number of v: vars */
 };
 

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1856,6 +1856,12 @@ return {
     func='ex_pedit',
   },
   {
+    command='plug',
+    flags=bit.bor(WORD1, NEEDARG, BANG),
+    addr_type=ADDR_LINES,
+    func='ex_plug',
+  },
+  {
     command='pop',
     flags=bit.bor(RANGE, NOTADR, BANG, COUNT, TRLBAR, ZEROR),
     addr_type=ADDR_LINES,

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9459,7 +9459,7 @@ static void ex_plug(exarg_T *eap)
         if (path == NULL) {
           path = concat_fnames((char *)p_plugindir, (char *)basename, true);
         }
-      xfree(basename);
+        xfree(basename);
       }
     }
 
@@ -9510,7 +9510,7 @@ static void ex_plug(exarg_T *eap)
                ":let v:plugins['%s'] = { 'path': '%s' }", eap->arg, path);
       do_cmdline_cmd(ex_cmd);
     }
-  xfree(path);
-  xfree(rtp_copy);
+    xfree(path);
+    xfree(rtp_copy);
   }
 }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -452,6 +452,7 @@ EXTERN char_u   *p_pex;         /* 'patchexpr' */
 EXTERN char_u   *p_pm;          /* 'patchmode' */
 EXTERN char_u   *p_path;        /* 'path' */
 EXTERN char_u   *p_cdpath;      /* 'cdpath' */
+EXTERN char_u   *p_plugindir;   /* 'plugindir' */
 EXTERN long p_rdt;              /* 'redrawtime' */
 EXTERN int p_remap;             /* 'remap' */
 EXTERN long p_re;               /* 'regexpengine' */

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1705,6 +1705,13 @@ return {
       defaults={if_true={vi=".,/usr/include,,"}}
     },
     {
+      full_name='plugindir', abbreviation='pidir',
+      type='string', scope={'global'},
+      vim=true,
+      varname='p_plugindir',
+      defaults={if_true={vi="",vim="bundle"}}
+    },
+    {
       full_name='preserveindent', abbreviation='pi',
       type='bool', scope={'buffer'},
       vi_def=true,

--- a/test/functional/ex_cmds/plug_spec.lua
+++ b/test/functional/ex_cmds/plug_spec.lua
@@ -1,0 +1,37 @@
+local helpers = require('test.functional.helpers')
+local clear, execute, nvim = helpers.clear, helpers.execute, helpers.nvim
+local eq, eval = helpers.eq, helpers.eval
+local feed = helpers.feed
+local command = helpers.command
+
+describe(':plug', function()
+
+  before_each(function()
+    clear()
+    execute('set runtimepath=')
+  end)
+
+  it('adds a full path to the runtime', function()
+    execute('plug /tmp')
+    eq('/tmp', eval('&runtimepath'))
+  end)
+
+  it('adds a relative path to the runtime', function()
+      execute('plug plugin')
+      eq('bundle/plugin', eval('&runtimepath'))
+  end)
+
+  it('reacts to the value of "plugindir"', function()
+      execute('set plugindir=bundles')
+      execute('plug plugin')
+      execute('set plugindir=/tmp')
+      execute('plug plugin')
+      eq('bundles/plugin,/tmp/plugin', eval('&runtimepath'))
+  end)
+
+  it('allows a prefix in the spec', function()
+      execute('plug neovim/plugin')
+      eq('bundle/plugin', eval('&runtimepath'))
+  end)
+
+end)


### PR DESCRIPTION
One of the things that bug _me_ about the plugin management situation for *vim is the lack of a built-in way to handle pathogen-style plugin bundles. It's quite clear in the popularity of Vundle, NeoBundle and vim-plug that people enjoy having a declarative way to define plugins, and I think this capability should be available to the user right on install without further configuration. [A previous attempt](https://github.com/fmoralesc/neovim/tree/early/pluginmanager) to figure out a way to do this used #2760 and #2852; with those, the plugin initialization was made transparent to the user by starting early and cleaning up after the `vimrc` file was sourced. [This comment](https://github.com/neovim/neovim/pull/2852#issuecomment-114995753) describes the approach on more detail.

Some problems with that approach:
- The user would still need to call the plugin-manager initialization end function if he needed to call autoloadable funtions from plugins in his vimrc:

``` vim
Plug 'plugin'
call plugin#function()
```

might not work.
- It could lead to conflicts between the default plugin manager and one that was user-installed. 
- The feature would require the runtime to work.
# The new proposal

The approach in this PR tries to solve this by:
- [x] Adding a new command, `:plug`, that takes a "spec" and tries to use it as a path to load plugin files from. The spec can be either a full directory name, or a partial pathname:

``` vim
:plug ~/.config/nvim/bundles/nvimplugin
:plug nvimplugin2
```

The spec can also be prefixed, as is usual when defining plugins from a particular github repo in popular plugin managers:

``` vim
:plug neovim/nvimplugin
```

The paths are appended to `'runtimepath'`, and if required, the *.vim files in the `plugin/` subdirectory are sourced (there is special syntax for this):

``` vim
:plug! nvimplugin2
```
- [x] Adding a new option, `'bundledir'`, that is used by plug to build up full plugin paths from partial paths. In the previous example, `plug nvimplugin2` should expand to `plug ~/.config/nvim/plugged/nvimplugin2` by default, to `~/.config/nvim/bundles/nvimplugin2` if `'bundledir'` is `"bundles"`, and to `~/devel/vimplugins/nvimplugin2` if `'bundledir'` is `~/devel/vimplugins`.

This allows the user to mix and match plugins from different sources:

``` vim
plug nvimplugin
set bundledir=bundles
plug nvimplugin 
set bundledir=~/devel/testing
plug nvimplugin
echo &runtimepath
> ... ~/.config/nvim/plugged/nvimplugin,~/.config/nvim/bundles/nvimplugin,~/devel/testing/nvimplugin
```
- [x] The plugins registered using `:plug` should be appended to an internal variable `v:plugins`, that should contain information plugin managers could use to, for example, install plugins using the specs: if I have `:plug fmoralesc/vim-autochdir`, I should be able  to expect `:PlugInstall` to install it (would require support from plugin managers).

These features can be used by more complex plugin managers, so they are as dumb as possible, yet useful enough that they can be used as a "poors man plugin manager". In this sense, they are in the middle point between pathogen and Vundle. This makes no attempt to solve the issue of fetching plugins and dependencies, which is the one people have focused on #247.
# Ways to take this further
- Support enabling/disabling plugin bundles. The `:plug` command could have subcommands for this:

``` vim
:plug enable goodplugin
:plug disable badplugin
```

The `disable` subcommand could work like `:Disarm` in tpope's scriptease.
- Allow extra arguments for `:plug` that define some metadata on how the plugin should be handled. For example:

``` vim
:plug Valloric/YouCompleteMe {'dir': 'ycm, 'do': './install.sh'}
:plug scrooloose/nerdtree { 'on':  'NERDTreeToggle' }
```

This will mean the `v:plugins` variable should be a dictionary of dictionaries:

```
echo v:plugins
--> {'Valloric/YouCompleteMe' : {'dir': 'ycm', 'do': './install.sh'}, 'scroolose/nerdree': {'on': 'NERDTreeToggle'}}
```
