### PR TITLE
Update filetype.vim for Git 2.5 worktrees

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -774,6 +774,8 @@ au BufNewFile,BufRead *.ged,lltxxxxx.txt	setf gedcom
 " Git
 au BufNewFile,BufRead *.git/COMMIT_EDITMSG	setf gitcommit
 au BufNewFile,BufRead *.git/MERGE_MSG		setf gitcommit
+au BufNewFile,BufRead *.git/worktrees/*/COMMIT_EDITMSG	setf gitcommit
+au BufNewFile,BufRead *.git/worktrees/*/MERGE_MSG	setf gitcommit
 au BufNewFile,BufRead *.git/config,.gitconfig,.gitmodules setf gitconfig
 au BufNewFile,BufRead *.git/modules/*/COMMIT_EDITMSG setf gitcommit
 au BufNewFile,BufRead *.git/modules/*/config	setf gitconfig


### PR DESCRIPTION
Git 2.5 adds a new command `git worktree`, providing first-class
support for multiple working directories (aka worktrees) per repository.
This change updates the gitcommit filetype paths for the new secondary
worktree locations for commit and merge messages.
