### PR TITLE
[RFC] Remove global array mb_bytelen_tab

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -114,7 +114,7 @@ int buf_init_chartab(buf_T *buf, int global)
       } else if ((enc_dbcs == DBCS_JPNU) && (c == 0x8e)) {
         // euc-jp characters starting with 0x8e are single width
         chartab[c++] = CT_PRINT_CHAR + 1;
-      } else if ((enc_dbcs != 0) && (MB_BYTE2LEN(c) == 2)) {
+      } else if ((enc_dbcs != 0) && (mb_byte2len(c) == 2)) {
         // other double-byte chars can be printable AND double-width
         chartab[c++] = CT_PRINT_CHAR + 2;
       } else {
@@ -125,7 +125,7 @@ int buf_init_chartab(buf_T *buf, int global)
 
     // Assume that every multi-byte char is a filename character.
     for (c = 1; c < 256; ++c) {
-      if (((enc_dbcs != 0) && (MB_BYTE2LEN(c) > 1))
+      if (((enc_dbcs != 0) && (mb_byte2len(c) > 1))
           || ((enc_dbcs == DBCS_JPNU) && (c == 0x8e))
           || (enc_utf8 && (c >= 0xa0))) {
         chartab[c] |= CT_FNAME_CHAR;
@@ -139,7 +139,7 @@ int buf_init_chartab(buf_T *buf, int global)
   if (enc_dbcs != 0) {
     for (c = 0; c < 256; ++c) {
       // double-byte characters are probably word characters
-      if (MB_BYTE2LEN(c) == 2) {
+      if (mb_byte2len(c) == 2) {
         SET_CHARTAB(buf, c);
       }
     }
@@ -242,7 +242,7 @@ int buf_init_chartab(buf_T *buf, int global)
             if (((c < ' ')
                  || (c > '~')
                  || (p_altkeymap && (F_isalpha(c) || F_isdigit(c))))
-                && !(enc_dbcs && (MB_BYTE2LEN(c) == 2))) {
+                && !(enc_dbcs && (mb_byte2len(c) == 2))) {
               if (tilde) {
                 chartab[c] = (chartab[c] & ~CT_CELL_MASK)
                              + ((dy_flags & DY_UHEX) ? 4 : 2);
@@ -432,7 +432,7 @@ char_u* str_foldcase(char_u *str, int orglen, char_u *buf, int buflen)
   // Make each character lower case.
   i = 0;
   while (STR_CHAR(i) != NUL) {
-    if (enc_utf8 || (has_mbyte && (MB_BYTE2LEN(STR_CHAR(i)) > 1))) {
+    if (enc_utf8 || (has_mbyte && (mb_byte2len(STR_CHAR(i)) > 1))) {
       if (enc_utf8) {
         int c = utf_ptr2char(STR_PTR(i));
         int olen = utf_ptr2len(STR_PTR(i));
@@ -845,7 +845,7 @@ int vim_iswordc_buf(int c, buf_T *buf)
 /// @return TRUE if 'p' points to a keyword character.
 int vim_iswordp(char_u *p)
 {
-  if (has_mbyte && (MB_BYTE2LEN(*p) > 1)) {
+  if (has_mbyte && (mb_byte2len(*p) > 1)) {
     return mb_get_class(p) >= 2;
   }
   return GET_CHARTAB(curbuf, *p) != 0;
@@ -853,7 +853,7 @@ int vim_iswordp(char_u *p)
 
 int vim_iswordp_buf(char_u *p, buf_T *buf)
 {
-  if (has_mbyte && (MB_BYTE2LEN(*p) > 1)) {
+  if (has_mbyte && (mb_byte2len(*p) > 1)) {
     return mb_get_class(p) >= 2;
   }
   return GET_CHARTAB(buf, *p) != 0;
@@ -909,7 +909,7 @@ int vim_isprintc(int c)
 /// @return TRUE if 'c' is a printable character.
 int vim_isprintc_strict(int c)
 {
-  if ((enc_dbcs != 0) && (c < 0x100) && (MB_BYTE2LEN(c) > 1)) {
+  if ((enc_dbcs != 0) && (c < 0x100) && (mb_byte2len(c) > 1)) {
     return FALSE;
   }
 
@@ -1035,7 +1035,7 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
     }
   } else if (has_mbyte
              && (size == 2)
-             && (MB_BYTE2LEN(*s) > 1)
+             && (mb_byte2len(*s) > 1)
              && wp->w_p_wrap
              && in_win_border(wp, col)) {
     // Count the ">" in the last column.
@@ -1135,7 +1135,7 @@ static int win_nolbr_chartabsize(win_T *wp, char_u *s, colnr_T col, int *headp)
 
   // Add one cell for a double-width character in the last column of the
   // window, displayed with a ">".
-  if ((n == 2) && (MB_BYTE2LEN(*s) > 1) && in_win_border(wp, col)) {
+  if ((n == 2) && (mb_byte2len(*s) > 1) && in_win_border(wp, col)) {
     if (headp != NULL) {
       *headp = 1;
     }
@@ -1248,7 +1248,7 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor,
           // cells wide.
           if ((incr == 2)
               && wp->w_p_wrap
-              && (MB_BYTE2LEN(*ptr) > 1)
+              && (mb_byte2len(*ptr) > 1)
               && in_win_border(wp, vcol)) {
             ++incr;
             head = 1;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4773,7 +4773,7 @@ int get_literal(void)
   for (;; ) {
     nc = plain_vgetc();
     if (!(State & CMDLINE)
-        && MB_BYTE2LEN_CHECK(nc) == 1
+        && mb_byte2len_check(nc) == 1
         )
       add_to_showcmd(nc);
     if (nc == 'x' || nc == 'X')
@@ -5053,7 +5053,7 @@ insertchar (
      */
     while (    (c = vpeekc()) != NUL
                && !ISSPECIAL(c)
-               && (!has_mbyte || MB_BYTE2LEN_CHECK(c) == 1)
+               && (!has_mbyte || mb_byte2len_check(c) == 1)
                && i < INPUT_BUFLEN
                && (textwidth == 0
                    || (virtcol += byte2cells(buf[i - 1])) < (colnr_T)textwidth)
@@ -6329,7 +6329,7 @@ static void mb_replace_pop_ins(int cc)
   int i;
   int c;
 
-  if (has_mbyte && (n = MB_BYTE2LEN(cc)) > 1) {
+  if (has_mbyte && (n = mb_byte2len(cc)) > 1) {
     buf[0] = cc;
     for (i = 1; i < n; ++i)
       buf[i] = replace_pop();
@@ -6343,7 +6343,7 @@ static void mb_replace_pop_ins(int cc)
       c = replace_pop();
       if (c == -1)                  /* stack empty */
         break;
-      if ((n = MB_BYTE2LEN(c)) == 1) {
+      if ((n = mb_byte2len(c)) == 1) {
         /* Not a multi-byte char, put it back. */
         replace_push(c);
         break;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4235,7 +4235,7 @@ static int getargopt(exarg_T *eap)
       eap->bad_char = BAD_KEEP;
     else if (STRICMP(p, "drop") == 0)
       eap->bad_char = BAD_DROP;
-    else if (MB_BYTE2LEN(*p) == 1 && p[1] == NUL)
+    else if (mb_byte2len(*p) == 1 && p[1] == NUL)
       eap->bad_char = *p;
     else
       return FAIL;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -689,7 +689,7 @@ static int read_redo(int init, int old_redo)
   /* For a multi-byte character get all the bytes and return the
    * converted character. */
   if (has_mbyte && (c != K_SPECIAL || p[1] == KS_SPECIAL))
-    n = MB_BYTE2LEN_CHECK(c);
+    n = mb_byte2len_check(c);
   else
     n = 1;
   for (i = 0;; ++i) {
@@ -1469,7 +1469,7 @@ int vgetc(void)
        * converted character.
        * Note: This will loop until enough bytes are received!
        */
-      if (has_mbyte && (n = MB_BYTE2LEN_CHECK(c)) > 1) {
+      if (has_mbyte && (n = mb_byte2len_check(c)) > 1) {
         ++no_mapping;
         buf[0] = c;
         for (i = 1; i < n; ++i) {
@@ -1812,7 +1812,7 @@ static int vgetorpeek(int advance)
                 char_u *p1 = mp->m_keys;
                 char_u *p2 = mb_unescape(&p1);
 
-                if (has_mbyte && p2 != NULL && MB_BYTE2LEN(c1) > MB_PTR2LEN(p2))
+                if (has_mbyte && p2 != NULL && mb_byte2len(c1) > MB_PTR2LEN(p2))
                   mlen = 0;
                 /*
                  * Check an entry whether it matches.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -751,13 +751,6 @@ EXTERN bool enc_utf8 INIT(= false);             /* UTF-8 encoded Unicode */
 EXTERN int enc_latin1like INIT(= TRUE);         /* 'encoding' is latin1 comp. */
 EXTERN int has_mbyte INIT(= 0);                 /* any multi-byte encoding */
 
-
-/*
- * To speed up BYTELEN() we fill a table with the byte lengths whenever
- * enc_utf8 or enc_dbcs changes.
- */
-EXTERN char mb_bytelen_tab[256];
-
 /*
  * Function pointers, used to quickly get to the right function.  Each has
  * three possible values: latin_ (8-bit), utfc_ or utf_ (utf-8) and dbcs_

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -71,7 +71,6 @@
  * some commands, like ":menutrans"
  */
 
-#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -121,15 +121,15 @@ struct interval {
 /// enc_utf8 or enc_dbcs changes.
 static uint8_t mb_bytelen_tab[256];
 
-/// @return byte length of character that starts with byte "b".
 /// Returns 1 for a single-byte character.
-/// mb_byte2len_check() can be used to count a special key as one byte.
-uint8_t mb_byte2len(uint8_t b)
+/// @return byte length of character that starts with byte "b".
+uint8_t mb_byte2len(uint8_t b) FUNC_ATTR_PURE
 {
   return mb_bytelen_tab[b];
 }
 
-uint8_t mb_byte2len_check(int b)
+/// mb_byte2len_check() can be used to count a special key as one byte.
+uint8_t mb_byte2len_check(int b) FUNC_ATTR_PURE
 {
   if (b < 0 || b > 255) {
     return 1;

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -118,30 +118,25 @@ struct interval {
 # include "mbyte.c.generated.h"
 #endif
 
-/*
- * To speed up BYTELEN() we fill a table with the byte lengths whenever
- * enc_utf8 or enc_dbcs changes.
- */
-static char mb_bytelen_tab[256];
+/// To speed up BYTELEN() we fill a table with the byte lengths whenever
+/// enc_utf8 or enc_dbcs changes.
+static uint8_t mb_bytelen_tab[256];
 
-/*
- * Return byte length of character that starts with byte "b".
- * Returns 1 for a single-byte character.
- * mb_byte2len_check() can be used to count a special key as one byte.
- * Don't call mb_byte2len(b) with b < 0 or b > 255!
- */
-char mb_byte2len(int b) {
-    assert(b >= 0);
-    assert(b <= 255);
-    return mb_bytelen_tab[b];
+/// @return byte length of character that starts with byte "b".
+/// Returns 1 for a single-byte character.
+/// mb_byte2len_check() can be used to count a special key as one byte.
+uint8_t mb_byte2len(uint8_t b)
+{
+  return mb_bytelen_tab[b];
 }
 
-char mb_byte2len_check(int b) {
-    if (b < 0 || b > 255) {
-        return 1;
-    } else {
-        return mb_bytelen_tab[b];
-    }
+uint8_t mb_byte2len_check(int b)
+{
+  if (b < 0 || b > 255) {
+    return 1;
+  } else {
+    return mb_byte2len(b);
+  }
 }
 
 /*

--- a/src/nvim/mbyte.h
+++ b/src/nvim/mbyte.h
@@ -1,17 +1,6 @@
 #ifndef NVIM_MBYTE_H
 #define NVIM_MBYTE_H
 
-#include <stdbool.h>
-
-/*
- * Return byte length of character that starts with byte "b".
- * Returns 1 for a single-byte character.
- * MB_BYTE2LEN_CHECK() can be used to count a special key as one byte.
- * Don't call MB_BYTE2LEN(b) with b < 0 or b > 255!
- */
-#define MB_BYTE2LEN(b)         mb_bytelen_tab[b]
-#define MB_BYTE2LEN_CHECK(b)   (((b) < 0 || (b) > 255) ? 1 : mb_bytelen_tab[b])
-
 /* properties used in enc_canon_table[] (first three mutually exclusive) */
 #define ENC_8BIT       0x01
 #define ENC_DBCS       0x02

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1329,7 +1329,7 @@ str2special (
     int len = (*mb_ptr2len)(str);
 
     /* For multi-byte characters check for an illegal byte. */
-    if (has_mbyte && MB_BYTE2LEN(*str) > len) {
+    if (has_mbyte && mb_byte2len(*str) > len) {
       transchar_nonprint(buf, c);
       *sp = str + 1;
       return buf;

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2423,7 +2423,7 @@ int get_keystroke(void)
       break;
     }
     if (has_mbyte) {
-      if (MB_BYTE2LEN(n) > len)
+      if (mb_byte2len(n) > len)
         continue;               /* more bytes to get */
       buf[len >= buflen ? buflen - 1 : len] = NUL;
       n = (*mb_ptr2char)(buf);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -845,8 +845,10 @@ getcount:
        * because if it's put back with vungetc() it's too late to apply
        * mapping. */
       no_mapping--;
-      while (enc_utf8 && lang && (c = vpeekc()) > 0
-             && (c >= 0x100 || mb_byte2len(c) > 1)) {
+      while (enc_utf8
+             && lang
+             && (c = vpeekc()) > 0
+             && (c >= 0x100 || mb_byte2len((uint8_t)c) > 1)) {
         c = plain_vgetc();
         if (!utf_iscomposing(c)) {
           vungetc(c);                   /* it wasn't, put it back */

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -846,7 +846,7 @@ getcount:
        * mapping. */
       no_mapping--;
       while (enc_utf8 && lang && (c = vpeekc()) > 0
-             && (c >= 0x100 || MB_BYTE2LEN(vpeekc()) > 1)) {
+             && (c >= 0x100 || mb_byte2len(vpeekc()) > 1)) {
         c = plain_vgetc();
         if (!utf_iscomposing(c)) {
           vungetc(c);                   /* it wasn't, put it back */
@@ -2505,7 +2505,7 @@ static int get_mouse_class(char_u *p)
 {
   int c;
 
-  if (has_mbyte && MB_BYTE2LEN(p[0]) > 1)
+  if (has_mbyte && mb_byte2len(p[0]) > 1)
     return mb_get_class(p);
 
   c = *p;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -846,7 +846,7 @@ getcount:
        * mapping. */
       no_mapping--;
       while (enc_utf8 && lang && (c = vpeekc()) > 0
-             && (c >= 0x100 || mb_byte2len(vpeekc()) > 1)) {
+             && (c >= 0x100 || mb_byte2len(c) > 1)) {
         c = plain_vgetc();
         if (!utf_iscomposing(c)) {
           vungetc(c);                   /* it wasn't, put it back */

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3008,7 +3008,7 @@ win_line (
             }
           } else {
             /* if this is a DBCS character, put it in "mb_c" */
-            mb_l = MB_BYTE2LEN(c);
+            mb_l = mb_byte2len(c);
             if (mb_l >= n_extra)
               mb_l = 1;
             else if (mb_l > 1)
@@ -3122,7 +3122,7 @@ win_line (
           } else
             prev_c = mb_c;
         } else {      /* enc_dbcs */
-          mb_l = MB_BYTE2LEN(c);
+          mb_l = mb_byte2len(c);
           if (mb_l == 0)            /* at the NUL at end-of-line */
             mb_l = 1;
           else if (mb_l > 1) {
@@ -4145,7 +4145,7 @@ win_line (
 
           /* When there is a multi-byte character, just output a
            * space to keep it simple. */
-          if (has_mbyte && MB_BYTE2LEN(ScreenLines[LineOffset[
+          if (has_mbyte && mb_byte2len(ScreenLines[LineOffset[
                                                      screen_row -
                                                      1] + (Columns - 1)]) > 1) {
             ui_putc(' ');
@@ -4224,7 +4224,7 @@ static int char_needs_redraw(int off_from, int off_to, int cols)
            || ScreenAttrs[off_from] != ScreenAttrs[off_to])
 
           || (enc_dbcs != 0
-              && MB_BYTE2LEN(ScreenLines[off_from]) > 1
+              && mb_byte2len(ScreenLines[off_from]) > 1
               && (enc_dbcs == DBCS_JPNU && ScreenLines[off_from] == 0x8e
                   ? ScreenLines2[off_from] != ScreenLines2[off_to]
                   : (cols > 1 && ScreenLines[off_from + 1]
@@ -5166,7 +5166,7 @@ void screen_getbytes(int row, int col, char_u *bytes, int *attrp)
       bytes[0] = ScreenLines[off];
       bytes[1] = ScreenLines2[off];
       bytes[2] = NUL;
-    } else if (enc_dbcs && MB_BYTE2LEN(bytes[0]) > 1) {
+    } else if (enc_dbcs && mb_byte2len(bytes[0]) > 1) {
       bytes[1] = ScreenLines[off + 1];
       bytes[2] = NUL;
     }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -8023,7 +8023,7 @@ void init_spell_chartab(void)
   if (enc_dbcs) {
     // DBCS: assume double-wide characters are word characters.
     for (i = 128; i <= 255; ++i)
-      if (MB_BYTE2LEN(i) == 2)
+      if (mb_byte2len(i) == 2)
         spelltab.st_isw[i] = true;
   } else if (enc_utf8)   {
     for (i = 128; i < 256; ++i) {
@@ -8183,7 +8183,7 @@ static bool spell_iswordp(char_u *p, win_T *wp)
   int c;
 
   if (has_mbyte) {
-    l = MB_BYTE2LEN(*p);
+    l = mb_byte2len(*p);
     s = p;
     if (l == 1) {
       // be quick for ASCII
@@ -9866,7 +9866,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
               int l;
 
               if (has_mbyte)
-                l = MB_BYTE2LEN(fword[sp->ts_fidx]);
+                l = mb_byte2len(fword[sp->ts_fidx]);
               else
                 l = 1;
               if (fword_ends) {
@@ -9994,7 +9994,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
             if (sp->ts_tcharlen == 0) {
               // First byte.
               sp->ts_tcharidx = 0;
-              sp->ts_tcharlen = MB_BYTE2LEN(c);
+              sp->ts_tcharlen = mb_byte2len(c);
               sp->ts_fcharstart = sp->ts_fidx - 1;
               sp->ts_isdiff = (newscore != 0)
                               ? DIFF_YES : DIFF_NONE;
@@ -10008,7 +10008,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
                 // Correct ts_fidx for the byte length of the
                 // character (we didn't check that before).
                 sp->ts_fidx = sp->ts_fcharstart
-                              + MB_BYTE2LEN(
+                              + mb_byte2len(
                     fword[sp->ts_fcharstart]);
 
                 // For changing a composing character adjust
@@ -10113,7 +10113,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
         // results.
         if (has_mbyte) {
           c = mb_ptr2char(fword + sp->ts_fidx);
-          stack[depth].ts_fidx += MB_BYTE2LEN(fword[sp->ts_fidx]);
+          stack[depth].ts_fidx += mb_byte2len(fword[sp->ts_fidx]);
           if (enc_utf8 && utf_iscomposing(c))
             stack[depth].ts_score -= SCORE_DEL - SCORE_DELCOMP;
           else if (c == mb_ptr2char(fword + stack[depth].ts_fidx))
@@ -10189,7 +10189,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
         tword[sp->ts_twordlen++] = c;
         sp->ts_arridx = idxs[n];
         if (has_mbyte) {
-          fl = MB_BYTE2LEN(c);
+          fl = mb_byte2len(c);
           if (fl > 1) {
             // There are following bytes for the same character.
             // We must find all bytes before trying
@@ -10289,9 +10289,9 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
       // Undo the STATE_SWAP swap: "21" -> "12".
       p = fword + sp->ts_fidx;
       if (has_mbyte) {
-        n = MB_BYTE2LEN(*p);
+        n = mb_byte2len(*p);
         c = mb_ptr2char(p + n);
-        memmove(p + MB_BYTE2LEN(p[n]), p, n);
+        memmove(p + mb_byte2len(p[n]), p, n);
         mb_char2bytes(c, p);
       } else {
         c = *p;
@@ -10360,11 +10360,11 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
       // Undo STATE_SWAP3: "321" -> "123"
       p = fword + sp->ts_fidx;
       if (has_mbyte) {
-        n = MB_BYTE2LEN(*p);
+        n = mb_byte2len(*p);
         c2 = mb_ptr2char(p + n);
-        fl = MB_BYTE2LEN(p[n]);
+        fl = mb_byte2len(p[n]);
         c = mb_ptr2char(p + n + fl);
-        tl = MB_BYTE2LEN(p[n + fl]);
+        tl = mb_byte2len(p[n + fl]);
         memmove(p + fl + tl, p, n);
         mb_char2bytes(c, p);
         mb_char2bytes(c2, p + tl);
@@ -10419,10 +10419,10 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
       // Undo ROT3L: "231" -> "123"
       p = fword + sp->ts_fidx;
       if (has_mbyte) {
-        n = MB_BYTE2LEN(*p);
-        n += MB_BYTE2LEN(p[n]);
+        n = mb_byte2len(*p);
+        n += mb_byte2len(p[n]);
         c = mb_ptr2char(p + n);
-        tl = MB_BYTE2LEN(p[n]);
+        tl = mb_byte2len(p[n]);
         memmove(p + tl, p, n);
         mb_char2bytes(c, p);
       } else {
@@ -10469,9 +10469,9 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
       p = fword + sp->ts_fidx;
       if (has_mbyte) {
         c = mb_ptr2char(p);
-        tl = MB_BYTE2LEN(*p);
-        n = MB_BYTE2LEN(p[tl]);
-        n += MB_BYTE2LEN(p[tl + n]);
+        tl = mb_byte2len(*p);
+        n = mb_byte2len(p[tl]);
+        n += mb_byte2len(p[tl + n]);
         memmove(p, p + tl, n);
         mb_char2bytes(c, p + n);
       } else {


### PR DESCRIPTION
MB_BYTE2LEN and MB_BYTE2LEN_CHECK: macro -> function
mb_bytelen_tab is only used in mbyte.c so it goes static.
