### PR TITLE
[RFC] Move the global variable  to charset.c

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -902,7 +902,7 @@ int vim_isfilec_or_wc(int c)
   return vim_isfilec(c) || c == ']' || path_has_wildcard(buf);
 }
 
-/// return TRUE if 'c' is a printable character
+/// return true if 'c' is a printable character
 /// Assume characters above 0x100 are printable (multi-byte), except for
 /// Unicode.
 ///
@@ -917,7 +917,7 @@ bool vim_isprintc(int c) FUNC_ATTR_PURE
   return c >= 0x100 || (c > 0 && (chartab[c] & CT_PRINT_CHAR));
 }
 
-/// Strict version of vim_isprintc(c), don't return TRUE if "c" is the head
+/// Strict version of vim_isprintc(c), don't return true if "c" is the head
 /// byte of a double-byte character.
 ///
 /// @param c
@@ -926,13 +926,10 @@ bool vim_isprintc(int c) FUNC_ATTR_PURE
 bool vim_isprintc_strict(int c) FUNC_ATTR_PURE
 {
   if ((enc_dbcs != 0) && (c < 0x100) && (MB_BYTE2LEN(c) > 1)) {
-    return FALSE;
+    return false;
   }
 
-  if (enc_utf8 && (c >= 0x100)) {
-    return utf_printable(c);
-  }
-  return c >= 0x100 || (c > 0 && (chartab[c] & CT_PRINT_CHAR));
+  return vim_isprintc(c);
 }
 
 /// like chartabsize(), but also check for line breaks on the screen

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -884,9 +884,6 @@ EXTERN int KeyTyped;                    /* TRUE if user typed current char */
 EXTERN int KeyStuffed;                  /* TRUE if current char from stuffbuf */
 EXTERN int maptick INIT(= 0);           /* tick for each non-mapped char */
 
-EXTERN char_u chartab[256];             /* table used in charset.c; See
-                                           init_chartab() for explanation */
-
 EXTERN int must_redraw INIT(= 0);           /* type of redraw necessary */
 EXTERN int skip_redraw INIT(= FALSE);       /* skip redraw once */
 EXTERN int do_redraw INIT(= FALSE);         /* extra redraw once */

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -73,11 +73,6 @@
 /* Returns empty string if it is NULL. */
 #define EMPTY_IF_NULL(x) ((x) ? (x) : (char_u *)"")
 
-/* macro version of chartab().
- * Only works with values 0-255!
- * Doesn't work for UTF-8 mode with chars >= 0x80. */
-#define CHARSIZE(c)     (chartab[c] & CT_CELL_MASK)
-
 /*
  * Adjust chars in a language according to 'langmap' option.
  * NOTE that there is no noticeable overhead if 'langmap' is not set.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3372,7 +3372,7 @@ win_line (
       /*
        * Handling of non-printable characters.
        */
-      if (!(chartab[c & 0xff] & CT_PRINT_CHAR)) {
+      if (!vim_isprintc(c & 0xff)) {
         /*
          * when getting a character from the file, we may have to
          * turn it into something else on the way to putting it


### PR DESCRIPTION
One issue : is [this line](https://github.com/Yamakaky/neovim/blob/remove-global-chartab/src/nvim/screen.c#L3380) equivalent to `vim_isprintc` ? It's nearly the same function, except for the `& 0xff` part.
