### PR TITLE
[RFC] handle clipboard=unnamedplus,unnamed correctly

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -55,13 +55,21 @@ endif
 let s:clipboard = {}
 
 function! s:clipboard.get(reg)
-  if s:selections[a:reg].owner > 0
-    return s:selections[a:reg].data
+  let reg = a:reg == '"' ? '+' : a:reg
+  if s:selections[reg].owner > 0
+    return s:selections[reg].data
   end
-  return s:try_cmd(s:paste[a:reg])
+  return s:try_cmd(s:paste[reg])
 endfunction
 
 function! s:clipboard.set(lines, regtype, reg)
+  if a:reg == '"'
+    call s:clipboard.set(a:lines,a:regtype,'+')
+    if s:copy['*'] != s:copy['+']
+      call s:clipboard.set(a:lines,a:regtype,'*')
+    end
+    return 0
+  end
   if s:cache_enabled == 0
     call s:try_cmd(s:copy[a:reg], a:lines)
     return 0

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1427,35 +1427,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	autoselectml	Like "autoselect", but for the modeless selection
 			only.  Compare to the 'A' flag in 'guioptions'.
 
-						*clipboard-html*
-	html		When the clipboard contains HTML, use this when
-			pasting.  When putting text on the clipboard, mark it
-			as HTML.  This works to copy rendered HTML from
-			Firefox, paste it as raw HTML in Vim, select the HTML
-			in Vim and paste it in a rich edit box in Firefox.
-			You probably want to add this only temporarily,
-			possibly use BufEnter autocommands.
-			Only supported for GTK version 2 and later.
-			Only available with the |+multi_byte| feature.
-
-						*clipboard-exclude*
-	exclude:{pattern}
-			Defines a pattern that is matched against the name of
-			the terminal 'term'.  If there is a match, no
-			connection will be made to the X server.  This is
-			useful in this situation:
-			- Running Vim in a console.
-			- $DISPLAY is set to start applications on another
-			  display.
-			- You do not want to connect to the X server in the
-			  console, but do want this in a terminal emulator.
-			To never connect to the X server use: >
-				exclude:.*
-			The value of 'magic' is ignored, {pattern} is
-			interpreted as if 'magic' was on.
-			The rest of the option value will be used for
-			{pattern}, this must be the last entry.
-
 						*'cmdheight'* *'ch'*
 'cmdheight' 'ch'	number	(default 1)
 			global

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1402,8 +1402,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			register '*' for all yank, delete, change and put
 			operations which would normally go to the unnamed
 			register.  When "unnamed" is also included to the
-			option, yank operations (but not delete, change or
-			put) will additionally copy the text into register
+			option, yank and delete operations (but not put)
+			will additionally copy the text into register
 			'*'. See |nvim-clipboard|.
 <
 						*clipboard-autoselect*

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5278,7 +5278,7 @@ static yankreg_T *adjust_clipboard_name(int *name, bool quiet)
     }
     yankreg_T *target;
     if (cb_flags & CB_UNNAMEDPLUS) {
-      *name = '+';
+      *name = cb_flags & CB_UNNAMED ? '"': '+';
       target = &y_regs[PLUS_REGISTER];
     } else {
       *name = '*';

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5279,10 +5279,10 @@ static yankreg_T *adjust_clipboard_name(int *name, bool quiet)
     yankreg_T *target;
     if (cb_flags & CB_UNNAMEDPLUS) {
       *name = '+';
-      target = &y_regs[STAR_REGISTER];
+      target = &y_regs[PLUS_REGISTER];
     } else {
       *name = '*';
-      target = &y_regs[PLUS_REGISTER];
+      target = &y_regs[STAR_REGISTER];
     }
     return target; // unnamed register
   }

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -232,12 +232,15 @@ describe('clipboard usage', function()
       expect('words')
       eq({{'words'}, 'v'}, eval("g:test_clip['*']"))
 
+      -- "+ shouldn't have changed
+      eq({''}, eval("g:test_clip['+']"))
+
       execute("let g:test_clip['*'] = ['linewise stuff','']")
       feed('p')
       expect([[
         words
         linewise stuff]])
-      end)
+    end)
 
     it('does not clobber "0 when pasting', function()
       insert('a line')
@@ -282,6 +285,50 @@ describe('clipboard usage', function()
         the text]])
     end)
 
+  end)
+
+  describe('with clipboard=unnamedplus', function()
+    before_each(function()
+      execute('set clipboard=unnamedplus')
+    end)
+
+    it('links the "+ and unnamed registers', function()
+      insert("one two")
+      feed('^"+dwdw"+P')
+      expect('two')
+      eq({{'two'}, 'v'}, eval("g:test_clip['+']"))
+
+      -- "* shouldn't have changed
+      eq({''}, eval("g:test_clip['*']"))
+
+      execute("let g:test_clip['+'] = ['three']")
+      feed('p')
+      expect('twothree')
+    end)
+
+    it('and unnamed, yanks to both', function()
+      execute('set clipboard=unnamedplus,unnamed')
+      insert([[
+        really unnamed
+        text]])
+      feed('ggdd"*p"+p')
+      expect([[
+        text
+        really unnamed
+        really unnamed]])
+      eq({{'really unnamed', ''}, 'V'}, eval("g:test_clip['+']"))
+      eq({{'really unnamed', ''}, 'V'}, eval("g:test_clip['*']"))
+
+      -- unnamedplus takes predecence when pasting
+      execute("let g:test_clip['+'] = ['the plus','']")
+      execute("let g:test_clip['*'] = ['the star','']")
+      feed("p")
+      expect([[
+        text
+        really unnamed
+        really unnamed
+        the plus]])
+    end)
   end)
 
   it('supports :put', function()

--- a/test/functional/fixtures/autoload/provider/clipboard.vim
+++ b/test/functional/fixtures/autoload/provider/clipboard.vim
@@ -9,16 +9,22 @@ function! s:methods.get(reg)
   if g:cliperror
     return 0
   end
+  let reg = a:reg == '"' ? '+' : a:reg
   if g:cliplossy
     " behave like pure text clipboard
-    return g:test_clip[a:reg][0]
+    return g:test_clip[reg][0]
   else
-    "behave like VIMENC clipboard
-    return g:test_clip[a:reg]
+    " behave like VIMENC clipboard
+    return g:test_clip[reg]
   end
 endfunction
 
 function! s:methods.set(lines, regtype, reg)
+  if a:reg == '"'
+    call s:methods.set(a:lines,a:regtype,'+')
+    call s:methods.set(a:lines,a:regtype,'*')
+    return 0
+  end
   let g:test_clip[a:reg] = [a:lines, a:regtype]
 endfunction
 


### PR DESCRIPTION
Fixes #3096 . Also update documentation, I removed `html` and `exclude`, the later is simply obsolete (you could just `set clipboard` conditionally in a `if $TERM ...` block if you reeally want similar effect) while the former seems far too niche to bother reimplement. I will be away for a number of days, then I will look into #3097 as well.
