### PR TITLE
[RFC] tui: don't resize again on SIGWINCH.

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -66,6 +66,8 @@ typedef struct {
   } unibi_ext;
 } TUIData;
 
+static bool volatile got_winch = false;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "tui/tui.c.generated.h"
 #endif
@@ -212,6 +214,7 @@ static void try_resize(Event ev)
 
 static void sigwinch_cb(SignalWatcher *watcher, int signum, void *data)
 {
+  got_winch = true;
   // Queue the event because resizing can result in recursive event_poll calls
   // FIXME(blueyed): TUI does not resize properly when not deferred. Why? #2322
   loop_push_event(&loop, (Event) {
@@ -354,10 +357,15 @@ static void tui_resize(UI *ui, int width, int height)
   data->scroll_region.right = width - 1;
   data->row = data->col = 0;
 
-  // try to resize the terminal window
-  char r[16];  // enough for 9999x9999
-  snprintf(r, sizeof(r), "\x1b[8;%d;%dt", height, width);
-  out(ui, r, strlen(r));
+  // Try to resize the terminal window
+  // (only if not being resized already on SIGWINCH)
+  if (got_winch == false) {
+    char r[16];  // enough for 9999x9999
+    snprintf(r, sizeof(r), "\x1b[8;%d;%dt", height, width);
+    out(ui, r, strlen(r));
+  } else {  // already acted on the SIGWINCH signal
+    got_winch = false;
+  }
 }
 
 static void tui_clear(UI *ui)


### PR DESCRIPTION
I noticed the TUI tried to resize twice on SIGWINCH with #3048, causing weird behavior. See gif below for a demo of nvim without and with this fix:

![resize](https://cloud.githubusercontent.com/assets/221465/9151813/c35f4860-3de7-11e5-84e7-279875d2c2d9.gif)
