### PR TITLE
CI: install python 3.3 and enable python3_spec

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -18,5 +18,5 @@ elif [[ "${BUILD_MINGW}" == ON ]]; then
 fi
 
 pip install --user --upgrade cpp-coveralls neovim
-pip-3.3 install --user --upgrade neovim
+easy_install3 --user neovim
 

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -18,4 +18,5 @@ elif [[ "${BUILD_MINGW}" == ON ]]; then
 fi
 
 pip install --user --upgrade cpp-coveralls neovim
-pip3 install --user --upgrade neovim
+pip-3.3 install --user --upgrade neovim
+

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -18,3 +18,4 @@ elif [[ "${BUILD_MINGW}" == ON ]]; then
 fi
 
 pip install --user --upgrade cpp-coveralls neovim
+pip3 install --user --upgrade neovim

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,9 @@ addons:
       - pkg-config
       - unzip
       - xclip
+      # TODO(justinmk): use pip instead after travis upgrades ubuntu.
+      - python3-setuptools
+      - python3-dev
       # Additional compilers/tools.
       - clang-3.6
       - g++-5-multilib

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,10 @@ env:
     # available in before_cache (which is run before after_success).
     - SUCCESS_MARKER="$BUILD_DIR/.tests_successful"
 
+python:
+  - "2.7"
+  - "3.3"
+
 matrix:
   include:
     - os: linux


### PR DESCRIPTION
As mentioned in https://github.com/neovim/neovim/pull/3149 , python3_spec is not being run. ~~@fwalch I can't find where we actually `pip install neovim` for travis. I looked in bot-ci as well. Do you know?~~
