### PR TITLE
test: cover :grep

### DIFF
--- a/test/functional/ex_cmds/grep_spec.lua
+++ b/test/functional/ex_cmds/grep_spec.lua
@@ -1,0 +1,22 @@
+local helpers = require('test.functional.helpers')
+local clear, execute, nvim, feed, eq, ok, eval =
+  helpers.clear, helpers.execute, helpers.nvim, helpers.feed,
+  helpers.eq, helpers.ok, helpers.eval
+
+describe(':grep', function()
+  before_each(clear)
+
+  it('does not hang on large input #2983', function()
+    if eval("executable('grep')") == 0 then
+      pending('missing "grep" command')
+      return
+    end
+
+    execute([[set grepprg=grep\ -r]])
+    -- Change to test directory so that the test does not run too long.
+    execute('cd test')
+    execute('grep a **/*')
+    feed('<cr>')  -- Press ENTER
+    ok(eval('len(getqflist())') > 9000)  -- IT'S OVER 9000!!1
+  end)
+end)

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -6,7 +6,6 @@ local AsyncSession = require('nvim.async_session')
 local Session = require('nvim.session')
 
 local nvim_prog = os.getenv('NVIM_PROG') or 'build/bin/nvim'
---- FIXME: 'autoindent' messes up the insert() function
 local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
                    '--cmd', 'set shortmess+=I background=light noswapfile noautoindent',
                    '--embed'}


### PR DESCRIPTION
References #3156

This test fails before https://github.com/neovim/neovim/pull/3156. The test actually takes less than a second, even with 9000 results.
