### PR TITLE
[RFC] main: Add a warning if runtimepath doesn't point to a Neovim runtime

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -739,6 +739,14 @@ Example: >
 You tried to execute a command that is neither an Ex command nor
 a user-defined command.
 
+							*W51*  >
+  Invalid VIMRUNTIME: {runtimepath}
+
+The value of "VIMRUNTIME" doesn't point to a valid Neovim runtime. Neovim
+looks for the file "VIMRUNTIME/autoload/provider/clipboard.vim" to check if
+the runtime is valid. "VIMRUNTIME" has either been set by the user, or
+found by Neovim itself, according to the 'runtimepath' option.
+
 ==============================================================================
 3. Messages						*messages*
 


### PR DESCRIPTION
This commit let nvim show a warning if $VIMRUNTIME doesn't point to a valid Neovim runtime : 

```
[math@seattle neovim]$ export VIMRUNTIME=/usr/share/vim/vim74/
[math@seattle neovim]$ ./build/bin/nvim 
EXX: Invalid Neovim runtime from $VIMRUNTIME=/usr/share/vim/vim74/
Press ENTER or type command to continue
```

Resolves issue #2977. Just took the code of equalsraf (https://github.com/neovim/neovim/pull/1927#issuecomment-96108014) and put it in a function, so all credit goes entirely to him. The function is called before the first use of $VIMRUNTIME (by `init_locale`).

Last thing to do is picking a number error. Can I pick one myself or can someone give me one ?
