### PR TITLE
Fix typo in nvim-python

### DIFF
--- a/runtime/doc/nvim_python.txt
+++ b/runtime/doc/nvim_python.txt
@@ -70,7 +70,7 @@ To disable Python 2 interface, set `g:loaded_python_provider` to 1:
 <
 						   *g:loaded_python3_provider*
 
-To disable Python 3 interface, set `g:loaded_python3_provider` to 0:
+To disable Python 3 interface, set `g:loaded_python3_provider` to 1:
 >
     let g:loaded_python3_provider = 1
 <


### PR DESCRIPTION
I assumed author meant 1 not 0 as the same switch is used to disable python2 interface and my brief looking at the code also supports this theory.
