### PR TITLE
[RFC] Do not use TMUX_WRAP for DECSCUSR sequence

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -1,4 +1,4 @@
-.Dd November 11, 2015
+.Dd January 28, 2016
 .Dt NVIM 1
 .Os
 .Sh NAME
@@ -373,8 +373,24 @@ Used to set the 'shell' option, which determines the shell used by the
 command.
 .It Ev NVIM_TUI_ENABLE_CURSOR_SHAPE
 If defined, change the cursor shape to a vertical bar while in insert mode.
-Requires that the host terminal support the DECSCUSR CSI escape sequence.
+Requires that the host terminal supports the DECSCUSR CSI escape sequence.
 Has no effect in GUIs.
+.Pp
+Depending on the terminal emulator, using this option with
+.Nm
+under
+.Xr tmux 1
+might require adding the following to
+.Pa ~/.tmux.conf :
+.Bd -literal -offset indent
+set -ga terminal-overrides ',*:Ss=\eE[%p1%d q:Se=\eE[2 q'
+.Ed
+.Pp
+See
+.Ic terminal-overrides
+in the
+.Xr tmux 1
+manual page for more information.
 .It Ev NVIM_TUI_ENABLE_TRUE_COLOR
 If defined, assume the host terminal supports 24 bit colors.
 Has no effect in GUIs.

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -845,7 +845,7 @@ static void fix_terminfo(TUIData *data)
   if ((term_prog && !strcmp(term_prog, "Konsole"))
       || os_getenv("KONSOLE_DBUS_SESSION") != NULL) {
     // Konsole uses a proprietary escape code to set the cursor shape
-    // and does not suppport DECSCUSR.
+    // and does not support DECSCUSR.
     data->unibi_ext.enter_insert_mode = (int)unibi_add_ext_str(ut, NULL,
         TMUX_WRAP("\x1b]50;CursorShape=1;BlinkingCursorEnabled=1\x07"));
     data->unibi_ext.enter_replace_mode = (int)unibi_add_ext_str(ut, NULL,
@@ -854,13 +854,15 @@ static void fix_terminfo(TUIData *data)
         TMUX_WRAP("\x1b]50;CursorShape=0;BlinkingCursorEnabled=0\x07"));
   } else if (!vte_version || atoi(vte_version) >= 3900) {
     // Assume that the terminal supports DECSCUSR unless it is an
-    // old VTE based terminal
+    // old VTE based terminal.  This should not get wrapped for tmux,
+    // which will handle it via its Ss/Se terminfo extension - usually
+    // according to its terminal-overrides.
     data->unibi_ext.enter_insert_mode = (int)unibi_add_ext_str(ut, NULL,
-        TMUX_WRAP("\x1b[5 q"));
+                                                               "\x1b[5 q");
     data->unibi_ext.enter_replace_mode = (int)unibi_add_ext_str(ut, NULL,
-        TMUX_WRAP("\x1b[3 q"));
+                                                                "\x1b[3 q");
     data->unibi_ext.exit_insert_mode = (int)unibi_add_ext_str(ut, NULL,
-        TMUX_WRAP("\x1b[2 q"));
+                                                              "\x1b[2 q");
   }
 
 end:


### PR DESCRIPTION
Wrapping it will send it to the terminal "directly", which might change the
cursor of another pane, e.g. when starting Neovim and changing to
another pane directly.

tmux has a terminfo extension (Ss/Se) to handle and translate the
DECSCUSR sequences internally.  This can be controlled through
`terminal-overrides`, but does not appear to be able to handle the
uncommon sequences for Konsole.
