### PR TITLE
[RFC] Add function to retrieve the channel identifier for the current connection

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -578,6 +578,17 @@ void vim_unsubscribe(uint64_t channel_id, String event)
   channel_unsubscribe(channel_id, e);
 }
 
+
+/// Ask neovim for the internal channel id of the current connection.
+///
+/// @param channel_id The channel id (passed automatically by the dispatcher)
+/// @return The channel id
+Integer vim_get_channel_id_for_current_connection(uint64_t channel_id)
+{
+  return channel_id;
+}
+
+
 Integer vim_name_to_color(String name)
 {
   return name_to_color((uint8_t *)name.data);


### PR DESCRIPTION
This might well be the wrong way to solve the problem that led me to create this pull request. So I will state it here first.
# Motivation

I wanted to be able to run a remote plugin provider for Haskell plugins inside a normal (ghci) REPL instead of recompiling the whole provider all the time. I have no problem running simple remote commands from such a session, it's as simple as this if you start the REPL with the builtin terminal emulator:

```
λ import Neovim.Debug

λ debug' $ vim_get_current_line

Right (Right "\955 debug' $ vim_get_current_line")
```

However, I also want to call functions from the plugin provider from the neovim instance to which I'm connected. Since I register all functions via `remote#define#functionOnHost` and I need the host/channel id as an argument for that function, I'm lost. I tried to find a way to retrieve the channel id in a non-hacky way, but I couldn't find any. I can't start the REPL with `rpcstart()` because I need _standard in_ and _standard out_ for the REPL.

These are the additional benefits for running the plugin provider in a REPL that I can currently think of:
- Crawling through log files and adding logging lines to code can be avoided during development of new featrues/plugins and instead be printed directly to the REPL.
- I can inspect and poke at all the internals of the plugin provider itself **without having to recompile it** all the time and add logging code that I will remove later anyway. 
- I don't have to recompile the plugins all the time that I am currently working on to test them. (Although this doesn't take more than one or two seconds for me at the moment.)
- Other loaded Plugins with non-trivial startup code can have a significant impact on the startup time of the plugin provider which is avoided if connected via a REPL.
# Things to iron out
- Is there already a (not too inconvenient) way to get the channel id?
- Naming things is hard, please help me! :-)
- Test code. (should be simple)
