### PR TITLE
[RFC] tui: restore got_winch in sigwinch_cb

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -207,6 +207,7 @@ static void tui_stop(UI *ui)
 
 static void sigwinch_cb(SignalWatcher *watcher, int signum, void *data)
 {
+  got_winch = true;
   UI *ui = data;
   update_size(ui);
   ui_refresh();


### PR DESCRIPTION
The recent changes to the event handling caused a minor regression from #3145.
