### PR TITLE
[RFC] Add ability to suppress errors to clint.py

### DIFF
--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -6,7 +6,7 @@
  */
 
 #ifndef NVIM_VIM_H
-# define NVIM_VIM_H
+#define NVIM_VIM_H
 
 #define MIN(X, Y) (X < Y ? X : Y)
 #define MAX(X, Y) (X > Y ? X : Y)


### PR DESCRIPTION
Ref #3174, first stage, ready.

Second stage: run `./clint.py --record-errors="$ERRORS_FILE" src/nvim/**/*.c src/nvim/**/*.h` in bot-ci to generate the clint errors list.

Third: use generated report this repository, disable clint blacklist.

Note one of the consequences: once somebody needs to commit

``` Patch
   signlist_T *b_signlist;       /* list of signs to draw */
+
+  Terminal *terminal;           // Terminal instance associated with the buffer
 };
```

he will also need to modify `b_signlist`. (If I am not mistaking,

```
  synblock_T b_s;               /* Info related to syntax highlighting.  w_s
                                 * normally points to this, but some windows
                                 * may use a different synblock_T. */

```

in this example will not be affected because 1. its direct neighbour is a blank line and that did not change (signlint: `};` changed to blank line) and 2. linter gives error only for the first line of the comment, so direct neighbours are actually preceding blank line and `* normally …` comment.)
