### PR TITLE
[RFC] terminal: Fix program's name not always displayed

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16096,12 +16096,9 @@ static void f_termopen(typval_T *argvars, typval_T *rettv)
   }
   int pid = data->proc.pty.process.pid;
 
-  // Get the desired name of the buffer.
-  char *name = job_opts ?
-    (char *)get_dict_string(job_opts, (char_u *)"name", false) : cmd;
   char buf[1024];
-  // format the title with the pid to conform with the term:// URI 
-  snprintf(buf, sizeof(buf), "term://%s//%d:%s", cwd, pid, name);
+  // format the title with the pid to conform with the term:// URI
+  snprintf(buf, sizeof(buf), "term://%s//%d:%s", cwd, pid, cmd);
   // at this point the buffer has no terminal instance associated yet, so unset
   // the 'swapfile' option to ensure no swap file will be created
   curbuf->b_p_swf = false;


### PR DESCRIPTION
Using a command like :e term://top displayed term://.//PID:(null) instead of term://.//PID:top as the buffer's name. Fixes #3113.

The former code in eval.c assumed that if a dictionnary was given to `termopen`, it had to include the parameter `name`, while the shortcut created in main.c, which enables the "term:// protocol", only passes `cwd` as parameter.

Now `termopen` checks if `name` is indeed present before using it.
