### PR TITLE
tutor: use nosuf=1 for globpath()

### DIFF
--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -258,9 +258,9 @@ endfunction
 
 function! s:GlobPath(lp, pat)
     if version >= 704 && has('patch279')
-        return globpath(a:lp, a:pat, 0, 1)
+        return globpath(a:lp, a:pat, 1, 1)
     else
-        return split(globpath(a:lp, a:pat, 0), '\n')
+        return split(globpath(a:lp, a:pat, 1), '\n')
     endif
 endfunction
 


### PR DESCRIPTION
This "feature" of expand(), globpath(), etc. is a source of endless pain.
