### PR TITLE
[RFC]    os/fs.c: remove os_file_is_readonly()

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2395,7 +2395,7 @@ static int check_readonly(int *forceit, buf_T *buf)
    * the file exists and permissions are read-only. */
   if (!*forceit && (buf->b_p_ro
                     || (os_file_exists(buf->b_ffname)
-                        && os_file_is_readonly((char *)buf->b_ffname)))) {
+                        && !os_file_is_writable((char *)buf->b_ffname)))) {
     if ((p_confirm || cmdmod.confirm) && buf->b_fname != NULL) {
       char_u buff[DIALOG_MSG_SIZE];
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2623,7 +2623,7 @@ buf_write (
      * Check if the file is really writable (when renaming the file to
      * make a backup we won't discover it later).
      */
-    file_readonly = os_file_is_readonly((char *)fname);
+    file_readonly = !os_file_is_writable((char *)fname);
 
     if (!forceit && file_readonly) {
       if (vim_strchr(p_cpo, CPO_FWRITE) != NULL) {

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -270,15 +270,6 @@ bool os_file_exists(const char_u *name)
   return os_stat((char *)name, &statbuf);
 }
 
-/// Check if a file is readonly.
-///
-/// @return `true` if `name` is readonly.
-bool os_file_is_readonly(const char *name)
-  FUNC_ATTR_NONNULL_ALL
-{
-  return access(name, W_OK) != 0;
-}
-
 /// Check if a file is readable.
 ///
 /// @return true if `name` is readable, otherwise false.

--- a/test/unit/os/fs_spec.lua
+++ b/test/unit/os/fs_spec.lua
@@ -229,10 +229,6 @@ describe('fs function', function()
       return res
     end
 
-    local function os_file_is_readonly(filename)
-      return fs.os_file_is_readonly((to_cstr(filename)))
-    end
-
     local function os_file_is_readable(filename)
       return fs.os_file_is_readable((to_cstr(filename)))
     end
@@ -324,55 +320,6 @@ describe('fs function', function()
       end
     end)
 
-    describe('os_file_is_readonly', function()
-      -- pending('returns ? if the file does not exist', function() end)
-      -- pending('returns ? if the path is a directory', function() end)
-      -- pending('returns ? if the file is executable', function() end)
-
-      it('returns false if the file is non-read, non-write', function()
-        local perm = os_getperm('unit-test-directory/test.file')
-        perm = unset_bit(perm, ffi.C.kS_IWUSR)
-        perm = unset_bit(perm, ffi.C.kS_IWGRP)
-        perm = unset_bit(perm, ffi.C.kS_IWOTH)
-        perm = unset_bit(perm, ffi.C.kS_IRUSR)
-        perm = unset_bit(perm, ffi.C.kS_IRGRP)
-        perm = unset_bit(perm, ffi.C.kS_IROTH)
-
-        eq(OK, (os_setperm('unit-test-directory/test.file', perm)))
-        eq(1, os_file_is_writable('unit-test-directory/test.file'))
-        eq(false, os_file_is_readonly('unit-test-directory/test.file'))
-      end)
-
-      it('returns false if the file is write-only', function()
-        local perm = os_getperm('unit-test-directory/test.file')
-        perm = set_bit(perm, ffi.C.kS_IWUSR)
-        perm = set_bit(perm, ffi.C.kS_IWGRP)
-        perm = set_bit(perm, ffi.C.kS_IWOTH)
-        perm = unset_bit(perm, ffi.C.kS_IRUSR)
-        perm = unset_bit(perm, ffi.C.kS_IRGRP)
-        perm = unset_bit(perm, ffi.C.kS_IROTH)
-
-        eq(OK, (os_setperm('unit-test-directory/test.file', perm)))
-        eq(1, os_file_is_writable('unit-test-directory/test.file'))
-        eq(false, os_file_is_readonly('unit-test-directory/test.file'))
-      end)
-
-      it('returns true if the file is read-only', function()
-        local perm = os_getperm('unit-test-directory/test.file')
-        local perm_orig = perm
-        perm = unset_bit(perm, ffi.C.kS_IWUSR)
-        perm = unset_bit(perm, ffi.C.kS_IWGRP)
-        perm = unset_bit(perm, ffi.C.kS_IWOTH)
-
-        eq(OK, (os_setperm('unit-test-directory/test.file', perm)))
-        eq(true, os_file_is_readonly('unit-test-directory/test.file'))
-        eq(OK, (os_setperm('unit-test-directory/test.file', perm_orig)))
-      end)
-
-      it('returns false if the file is read-write', function()
-        eq(false, os_file_is_readonly('unit-test-directory/test.file'))
-      end)
-    end)
 
     describe('os_file_is_readable', function()
       it('returns false if the file is not readable', function()


### PR DESCRIPTION
`os_file_is_readonly()` in its current form is equivalent to `!os_file_is_writable()`. This does not appear to be a bug, because the Vim use-cases of the old `check_file_readonly()` are equivalent to `!os_file_is_writable()`.

`os_file_is_readonly()` also fails this test:

```
returns false if the file is non-read, non-write
```

A more useful form would define behavior under these cases:
- path is executable (but not writable)
- path is non-existent
- path is directory

Based on the above, there is no reason for `os_file_is_readonly()` to exist, so remove it.
