### PR TITLE
Fix for pythonx provider install check

### DIFF
--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -55,10 +55,10 @@ function! s:check_interpreter(prog, major_ver, skip) abort
   " Try to load neovim module, and output Python version.
   let prog_ver = system(a:prog . ' -c ' .
         \ '''import sys; sys.stdout.write(str(sys.version_info[0]) + '.
-        \ '"." + str(sys.version_info[1])); '''.
+        \ '"." + str(sys.version_info[1])); '.
         \ (a:major_ver == 2 ?
-        \   '''import pkgutil; exit(pkgutil.get_loader("neovim") is None)''':
-        \   '''import importlib; exit(importlib.find_loader("neovim") is None)''')
+        \   'import pkgutil; exit(pkgutil.get_loader("neovim") is None)''':
+        \   'import importlib; exit(importlib.find_loader("neovim") is None)''')
         \ )
   if v:shell_error
     return [0, prog_path . ' does have not have the neovim module installed. '

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -53,13 +53,13 @@ function! s:check_interpreter(prog, major_ver, skip) abort
   endif
 
   " Try to load neovim module, and output Python version.
-  let prog_ver = system(a:prog . ' -c ' .
-        \ '''import sys; sys.stdout.write(str(sys.version_info[0]) + '.
+  let prog_ver = system([ a:prog , '-c' ,
+        \ 'import sys; sys.stdout.write(str(sys.version_info[0]) + '.
         \ '"." + str(sys.version_info[1])); '.
         \ (a:major_ver == 2 ?
-        \   'import pkgutil; exit(pkgutil.get_loader("neovim") is None)''':
-        \   'import importlib; exit(importlib.find_loader("neovim") is None)''')
-        \ )
+        \   'import pkgutil; exit(pkgutil.get_loader("neovim") is None)':
+        \   'import importlib; exit(importlib.find_loader("neovim") is None)')
+        \ ])
   if v:shell_error
     return [0, prog_path . ' does have not have the neovim module installed. '
           \ . 'See ":help nvim-python".']


### PR DESCRIPTION
When attempting to check for a valid python installation, we end up building
a command like :

```
python -c 'import sys; sys.stdout.write(...); ''import pkgutil; ...'
```

This gets rejected by python as a syntax error.
