### PR TITLE
[WIP] Patch script updates for vim's GitHub migration

### DIFF
--- a/scripts/vim-patch-helper.awk
+++ b/scripts/vim-patch-helper.awk
@@ -1,0 +1,17 @@
+#/usr/bin/env awk -f
+BEGIN {
+  FS="|";
+}
+{
+  if ($2 == "") { 
+    print($1)
+  } else {
+    n=split($2,ary,", ");
+    for (i=1;i<=n;i++) {
+      if (match(ary[i], "^tag: ")) {
+        sub(/tag: /, "", ary[i]);
+        print(ary[i]);
+      } 
+    }
+  }
+}

--- a/scripts/vim-patch-helper.awk
+++ b/scripts/vim-patch-helper.awk
@@ -8,8 +8,9 @@ BEGIN {
   } else {
     n=split($2,ary,", ");
     for (i=1;i<=n;i++) {
-      if (match(ary[i], "^tag: ")) {
-        sub(/tag: /, "", ary[i]);
+      if (match(ary[i], /tag: /)) {
+        gsub(/[()]/, "", ary[i]);
+        sub(/ *tag: /, "", ary[i]);
         print(ary[i]);
       } 
     }

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -20,7 +20,7 @@ usage() {
   echo "    -l                 Show list of Vim patches missing from Neovim."
   echo "    -p {vim-revision}  Download and apply the Vim patch vim-revision."
   echo "                       vim-revision can be a version number of the "
-  echo "                       format '7.4.xxx' or a Mercurial commit hash."
+  echo "                       format '7.4.xxx' or a Git commit hash."
   echo "    -r {pr-number}     Review a vim-patch pull request to Neovim."
   echo
   echo "Set VIM_SOURCE_DIR to change where Vim's sources are stored."
@@ -64,15 +64,15 @@ assign_commit_details() {
   if [[ ${1} =~ [0-9]\.[0-9]\.[0-9]{3,4} ]]; then
     # Interpret parameter as version number.
     vim_version="${1}"
-    vim_commit="v${1//./-}"
+    vim_commit="v${1}"
     local strip_commit_line=true
-    vim_commit_url="https://github.com/vim/vim/commit/${vim_commit}"
+    vim_commit_url="https://github.com/vim/vim/tree/${vim_commit}"
   else
     # Interpret parameter as commit hash.
     vim_version="${1:0:7}"
     vim_commit="${1}"
     local strip_commit_line=false
-    vim_commit_url="https://code.google.com/p/vim/source/detail?r=${vim_commit}"
+    vim_commit_url="https://github.com/vim/vim/commit/${vim_commit}"
   fi
   vim_message="$(hg log --template "{desc}" --rev "${vim_commit}")"
   if [[ ${strip_commit_line} == "true" ]]; then

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -41,7 +41,7 @@ get_vim_sources() {
   echo "Retrieving Vim sources."
   if [[ ! -d ${VIM_SOURCE_DIR} ]]; then
     echo "Cloning Vim sources into '${VIM_SOURCE_DIR}'."
-    git clone https://github.com/vim/vim.git "${VIM_SOURCE_DIR}"
+    git clone --depth=1000 https://github.com/vim/vim.git "${VIM_SOURCE_DIR}"
     cd "${VIM_SOURCE_DIR}"
   else
     if [[ ! -d "${VIM_SOURCE_DIR}/.git" ]]; then

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -44,6 +44,11 @@ get_vim_sources() {
     git clone https://github.com/vim/vim.git "${VIM_SOURCE_DIR}"
     cd "${VIM_SOURCE_DIR}"
   else
+    if [[ ! -d "${VIM_SOURCE_DIR}/.git" ]]; then
+      echo "✘ ${VIM_SOURCE_DIR} does not appear to be a git repository."
+      echo "  Please remove it and try again."
+      exit 1
+    fi
     echo "Updating Vim sources in '${VIM_SOURCE_DIR}'."
     cd "${VIM_SOURCE_DIR}"
     git pull &&

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -167,12 +167,12 @@ list_vim_patches() {
   # runtime patches before between 384 and 442 have already been ported
   # to Neovim as of the creation of this script.
   local vim_commits=$(cd "${VIM_SOURCE_DIR}" && \
-    git log --pretty='tformat:%H|%D' v7.4.442..HEAD | awk -f ${NEOVIM_SOURCE_DIR}/scripts/vim-patch-helper.awk)
+    git log --pretty='tformat:%H|%d' v7.4.442..HEAD | awk -f ${NEOVIM_SOURCE_DIR}/scripts/vim-patch-helper.awk)
 
   # Append remaining vim patches.
   # Start from 7.4.160, where Neovim was forked.
   local vim_old_commits=$(cd "${VIM_SOURCE_DIR}" && \
-    git log --pretty='tformat:%D' v7.4.160..v7.4.442 | awk '{ if ($1 != "") print($2); }')
+    git log --pretty='tformat:%d' v7.4.160..v7.4.442 | awk '{ if ($1 != "") { gsub(/[()]/, "", $2); print($2); } }')
 
   local vim_commit
   for vim_commit in ${vim_commits} ${vim_old_commits}; do


### PR DESCRIPTION
Upstream Vim is migrating to GitHub from Google Code, due to the latter's impending shutdown.  This PR updates the patch script for that move.
