### PR TITLE
runtime: When generating helptags run NeoVim in headless mode

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -39,6 +39,7 @@ add_custom_command(OUTPUT ${GENERATED_HELP_TAGS}
     -u NONE
     -i NONE
     -esX
+    --headless
     -c "helptags ++t ."
     -c quit
   DEPENDS


### PR DESCRIPTION
I see that problem fixed by #2801 was resurrected by making help tags file
generated in a more direct way. This fixes the hang without using the empty
file.
