### PR TITLE
[RFC] Fix lint errors

### DIFF
--- a/clint-ignored-files.txt
+++ b/clint-ignored-files.txt
@@ -1,5 +1,3 @@
-src/nvim/arabic.c
-src/nvim/arabic.h
 src/nvim/ascii.h
 src/nvim/assert.h
 src/nvim/buffer.c
@@ -7,8 +5,6 @@ src/nvim/buffer.h
 src/nvim/buffer_defs.h
 src/nvim/charset.c
 src/nvim/charset.h
-src/nvim/cursor_shape.c
-src/nvim/cursor_shape.h
 src/nvim/diff.c
 src/nvim/diff.h
 src/nvim/digraph.c

--- a/src/nvim/arabic.c
+++ b/src/nvim/arabic.c
@@ -441,7 +441,7 @@ static int chg_c_a2s(int cur_c)
       tempc = a_s_ZAIN;
       break;
 
-    case a_TATWEEL: // exceptions
+    case a_TATWEEL:  // exceptions
       tempc = cur_c;
       break;
 
@@ -558,59 +558,59 @@ static int chg_c_a2i(int cur_c)
       tempc = a_i_YEH_HAMZA;
       break;
 
-    case a_HAMZA: // exceptions
+    case a_HAMZA:  // exceptions
       tempc = a_s_HAMZA;
       break;
 
-    case a_ALEF_MADDA: // exceptions
+    case a_ALEF_MADDA:  // exceptions
       tempc = a_s_ALEF_MADDA;
       break;
 
-    case a_ALEF_HAMZA_ABOVE: // exceptions
+    case a_ALEF_HAMZA_ABOVE:  // exceptions
       tempc = a_s_ALEF_HAMZA_ABOVE;
       break;
 
-    case a_WAW_HAMZA: // exceptions
+    case a_WAW_HAMZA:  // exceptions
       tempc = a_s_WAW_HAMZA;
       break;
 
-    case a_ALEF_HAMZA_BELOW: // exceptions
+    case a_ALEF_HAMZA_BELOW:  // exceptions
       tempc = a_s_ALEF_HAMZA_BELOW;
       break;
 
-    case a_ALEF: // exceptions
+    case a_ALEF:  // exceptions
       tempc = a_s_ALEF;
       break;
 
-    case a_TEH_MARBUTA: // exceptions
+    case a_TEH_MARBUTA:  // exceptions
       tempc = a_s_TEH_MARBUTA;
       break;
 
-    case a_DAL: // exceptions
+    case a_DAL:  // exceptions
       tempc = a_s_DAL;
       break;
 
-    case a_THAL: // exceptions
+    case a_THAL:  // exceptions
       tempc = a_s_THAL;
       break;
 
-    case a_REH: // exceptions
+    case a_REH:  // exceptions
       tempc = a_s_REH;
       break;
 
-    case a_ZAIN: // exceptions
+    case a_ZAIN:  // exceptions
       tempc = a_s_ZAIN;
       break;
 
-    case a_TATWEEL: // exceptions
+    case a_TATWEEL:  // exceptions
       tempc = cur_c;
       break;
 
-    case a_WAW: // exceptions
+    case a_WAW:  // exceptions
       tempc = a_s_WAW;
       break;
 
-    case a_ALEF_MAKSURA: // exceptions
+    case a_ALEF_MAKSURA:  // exceptions
       tempc = a_s_ALEF_MAKSURA;
       break;
 
@@ -715,23 +715,23 @@ static int chg_c_a2m(int cur_c)
   int tempc;
 
   switch (cur_c) {
-    case a_HAMZA: // exception
+    case a_HAMZA:  // exception
       tempc = a_s_HAMZA;
       break;
 
-    case a_ALEF_MADDA: // exception
+    case a_ALEF_MADDA:  // exception
       tempc = a_f_ALEF_MADDA;
       break;
 
-    case a_ALEF_HAMZA_ABOVE: // exception
+    case a_ALEF_HAMZA_ABOVE:  // exception
       tempc = a_f_ALEF_HAMZA_ABOVE;
       break;
 
-    case a_WAW_HAMZA: // exception
+    case a_WAW_HAMZA:  // exception
       tempc = a_f_WAW_HAMZA;
       break;
 
-    case a_ALEF_HAMZA_BELOW: // exception
+    case a_ALEF_HAMZA_BELOW:  // exception
       tempc = a_f_ALEF_HAMZA_BELOW;
       break;
 
@@ -739,7 +739,7 @@ static int chg_c_a2m(int cur_c)
       tempc = a_m_YEH_HAMZA;
       break;
 
-    case a_ALEF: // exception
+    case a_ALEF:  // exception
       tempc = a_f_ALEF;
       break;
 
@@ -747,7 +747,7 @@ static int chg_c_a2m(int cur_c)
       tempc = a_m_BEH;
       break;
 
-    case a_TEH_MARBUTA: // exception
+    case a_TEH_MARBUTA:  // exception
       tempc = a_f_TEH_MARBUTA;
       break;
 
@@ -771,19 +771,19 @@ static int chg_c_a2m(int cur_c)
       tempc = a_m_KHAH;
       break;
 
-    case a_DAL: // exception
+    case a_DAL:  // exception
       tempc = a_f_DAL;
       break;
 
-    case a_THAL: // exception
+    case a_THAL:  // exception
       tempc = a_f_THAL;
       break;
 
-    case a_REH: // exception
+    case a_REH:  // exception
       tempc = a_f_REH;
       break;
 
-    case a_ZAIN: // exception
+    case a_ZAIN:  // exception
       tempc = a_f_ZAIN;
       break;
 
@@ -819,7 +819,7 @@ static int chg_c_a2m(int cur_c)
       tempc = a_m_GHAIN;
       break;
 
-    case a_TATWEEL: // exception
+    case a_TATWEEL:  // exception
       tempc = cur_c;
       break;
 
@@ -851,11 +851,11 @@ static int chg_c_a2m(int cur_c)
       tempc = a_m_HEH;
       break;
 
-    case a_WAW: // exception
+    case a_WAW:  // exception
       tempc = a_f_WAW;
       break;
 
-    case a_ALEF_MAKSURA: // exception
+    case a_ALEF_MAKSURA:  // exception
       tempc = a_f_ALEF_MAKSURA;
       break;
 
@@ -885,7 +885,7 @@ static int chg_c_a2f(int cur_c)
   // a_f_LAM_ALEF_HAMZA_BELOW;
 
   switch (cur_c) {
-    case a_HAMZA: // exception
+    case a_HAMZA:  // exception
       tempc = a_s_HAMZA;
       break;
 
@@ -989,7 +989,7 @@ static int chg_c_a2f(int cur_c)
       tempc = a_f_GHAIN;
       break;
 
-    case a_TATWEEL: // exception
+    case a_TATWEEL:  // exception
       tempc = cur_c;
       break;
 
@@ -1159,7 +1159,7 @@ static int chg_c_f2m(int cur_c)
       tempc = a_m_YEH_HAMZA;
       break;
 
-    case a_f_WAW_HAMZA: // exceptions
+    case a_f_WAW_HAMZA:  // exceptions
     case a_f_ALEF:
     case a_f_TEH_MARBUTA:
     case a_f_DAL:
@@ -1347,7 +1347,7 @@ static int half_shape(int c)
 // in/out: "c1p" points to the first composing char for "c".
 // in:     "prev_c"  is the previous character (not shaped)
 // in:     "prev_c1" is the first composing char for the previous char
-//  	     (not shaped)
+//          (not shaped)
 // in:     "next_c"  is the next character (not shaped).
 int arabic_shape(int c, int *ccp, int *c1p, int prev_c, int prev_c1,
                  int next_c)

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -53,7 +53,7 @@ char_u *parse_shape_opt(int what)
   int all_idx;
   int len;
   int i;
-  int found_ve = FALSE;                 /* found "ve" flag */
+  int found_ve = false;                 /* found "ve" flag */
   int round;
 
   /*
@@ -85,18 +85,18 @@ char_u *parse_shape_opt(int what)
             len = 1;
           else
             len = 2;
-          if (len == 1 && TOLOWER_ASC(modep[0]) == 'a')
+
+          if (len == 1 && TOLOWER_ASC(modep[0]) == 'a') {
             all_idx = SHAPE_IDX_COUNT - 1;
-          else {
+          } else {
             for (idx = 0; idx < SHAPE_IDX_COUNT; ++idx)
-              if (STRNICMP(modep, shape_table[idx].name, len)
-                  == 0)
+              if (STRNICMP(modep, shape_table[idx].name, len) == 0)
                 break;
             if (idx == SHAPE_IDX_COUNT
-                || (shape_table[idx].used_for & what) == 0)
+                    || (shape_table[idx].used_for & what) == 0)
               return (char_u *)N_("E546: Illegal mode");
             if (len == 2 && modep[0] == 'v' && modep[1] == 'e')
-              found_ve = TRUE;
+              found_ve = true;
           }
           modep += len + 1;
         }
@@ -160,11 +160,12 @@ char_u *parse_shape_opt(int what)
               p += 5;
             } else {          /* must be a highlight group name then */
               endp = vim_strchr(p, '-');
-              if (commap == NULL) {                         /* last part */
+              if (commap == NULL) {                       /* last part */
                 if (endp == NULL)
-                  endp = p + STRLEN(p);                     /* find end of part */
-              } else if (endp > commap || endp == NULL)
+                  endp = p + STRLEN(p);                  /* find end of part */
+              } else if (endp > commap || endp == NULL) {
                 endp = commap;
+              }
               slashp = vim_strchr(p, '/');
               if (slashp != NULL && slashp < endp) {
                 /* "group/langmap_group" */


### PR DESCRIPTION
Remove formatting errors from arabic.c and cursor_shape.c and remove clint ignore.

NOTE: This is more than just white space since I had add some brackets and change FALSE to false.
