### PR TITLE
[RFC] terminal: Fix use after free

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -422,8 +422,9 @@ end:
   redraw(term->buf != curbuf);
   ui_busy_stop();
   if (close) {
+    bool wipe = term->buf != NULL;
     term->opts.close_cb(term->opts.data);
-    if (term->buf) {
+    if (wipe) {
       do_cmdline_cmd("bwipeout!");
     }
   }

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -343,6 +343,17 @@ describe('terminal prints more lines than the screen height and exits', function
       [Program exited, press any key to close]          |
       -- TERMINAL --                                    |
     ]])
+    feed('<cr>')
+    -- closes the buffer correctly after pressing a key
+    screen:expect([[
+      ^                                                  |
+      ~                                                 |
+      ~                                                 |
+      ~                                                 |
+      ~                                                 |
+      ~                                                 |
+                                                        |
+    ]])
   end)
 end)
 


### PR DESCRIPTION
Since close_cb may free the terminal structure, save the "wipe" flag before calling it.
