### PR TITLE
[RFC] Add has('win32') for Windows builds

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10005,6 +10005,9 @@ static void f_has(typval_T *argvars, typval_T *rettv)
 #ifdef UNIX
     "unix",
 #endif
+#if defined(WIN32)
+    "win32",
+#endif
 #if defined(WIN64) || defined(_WIN64)
     "win64",
 #endif


### PR DESCRIPTION
Just pulling commits out of #810. 
