### PR TITLE
[RFC] On windows don't check for exec bit in is_executable()

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2737,8 +2737,8 @@ executable({expr})					*executable()*
 		the name without an extension.	When 'shell' looks like a
 		Unix shell, then the name is also tried without adding an
 		extension.
-		On MS-DOS and MS-Windows it only checks if the file exists and
-		is not a directory, not if it's really executable.
+		On MS-DOS and MS-Windows it checks if the file exists, is not
+		a directory and is readable, not if it's really executable.
 		On MS-Windows an executable in the same directory as Vim is
 		always found.  Since this directory is added to $PATH it
 		should also work to execute it |win32-PATH|.

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -114,17 +114,19 @@ bool os_can_exe(const char_u *name, char_u **abspath)
 static bool is_executable(const char_u *name)
   FUNC_ATTR_NONNULL_ALL
 {
+#ifdef WIN32
+    // Windows does not have an executable bit.
+    // Instead check if the file exists and is readable.
+    return os_file_is_readable((char *) name);
+#else
   int32_t mode = os_getperm(name);
 
   if (mode < 0) {
     return false;
   }
 
-  if (S_ISREG(mode) && (S_IXUSR & mode)) {
-    return true;
-  }
-
-  return false;
+  return (S_ISREG(mode) && (S_IXUSR & mode));
+#endif
 }
 
 /// Checks if a file is inside the `$PATH` and is executable.


### PR DESCRIPTION
In Windows there is not equivalent to the filesystem executable bit,
the documentation states that for Windows :executable() returns
1 for all files. But this behaviour was broken because is_executable()
checked for the UNIX bit.

When WIN32 is set we now skip the S_IXUSR check.

Cherry picked from #810.
