### PR TITLE
[RFC] remove references to <sys/time.h>

### DIFF
--- a/config/config.h.in
+++ b/config/config.h.in
@@ -44,7 +44,6 @@
 #cmakedefine HAVE_STRNCASECMP
 #cmakedefine HAVE_STROPTS_H
 #cmakedefine HAVE_SYS_PARAM_H
-#cmakedefine HAVE_SYS_TIME_H
 #cmakedefine HAVE_SYS_UTSNAME_H
 #cmakedefine HAVE_SYS_WAIT_H
 #cmakedefine HAVE_UNISTD_H
@@ -54,7 +53,6 @@
 #cmakedefine HAVE_WORKING_LIBINTL
 #define RETSIGTYPE void
 #define SIGRETURN return
-#define TIME_WITH_SYS_TIME 1
 #cmakedefine UNIX
 #cmakedefine USE_FNAME_CASE
 #define USEMAN_S 1

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -10,9 +10,6 @@
 #include "nvim/os/os.h"
 #include "nvim/os/time.h"
 
-#ifdef HAVE_SYS_TIME_H
-# include <sys/time.h>
-#endif
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>
 #endif

--- a/src/nvim/os/os_defs.h
+++ b/src/nvim/os/os_defs.h
@@ -33,14 +33,7 @@
 # define SIGDUMMYARG
 #endif
 
-// On some systems, time.h should not be included together with sys/time.h.
-#if !defined(HAVE_SYS_TIME_H) || defined(TIME_WITH_SYS_TIME)
 # include <time.h>
-#endif
-
-#ifdef HAVE_SYS_TIME_H
-# include <sys/time.h>
-#endif
 
 #if defined(DIRSIZ) && !defined(MAXNAMLEN)
 # define MAXNAMLEN DIRSIZ


### PR DESCRIPTION
Since gettimeofday() was replaced by os_time in
fb5a786bdb5b7b52b9c36b3eb8b6d2cc002aa8f3 we do not need sys/time.h.
