### PR TITLE
[RFC] Define ssize_t and SSIZE_MAX on Windows.

### DIFF
--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -21,12 +21,14 @@
 // - SYS_VIMRC_FILE
 // - SPECIAL_WILDCHAR
 
-// _access(): https://msdn.microsoft.com/en-us/library/1w06ktdy.aspx
-#ifndef R_OK
-# define R_OK 4
-#endif
-#ifndef W_OK
-# define W_OK 2
+typedef SSIZE_T ssize_t;
+
+#ifndef SSIZE_MAX
+# ifdef _WIN64
+#  define SSIZE_MAX _I64_MAX
+# else
+#  define SSIZE_MAX LONG_MAX
+# endif
 #endif
 
 #endif  // NVIM_OS_WIN_DEFS_H


### PR DESCRIPTION
Including `uv.h` gives us `ssize_t` but not `SSIZE_MAX` ironically.

Further it may be possible to remove our defines of `R_OK` and `W_OK` on Windows since including `uv.h` gives us those too. See: https://github.com/libuv/libuv/blob/bb2632b339d86f69f7dd9aa7168e4b46bf4126a5/include/uv-win.h#L636
