### PR TITLE
[RFC] MinGW: Use POSIX compatible stdio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,10 @@ endif()
 
 add_definitions(-Wall -Wextra -pedantic -Wno-unused-parameter
     -Wstrict-prototypes -std=gnu99)
+if (MINGW)
+  # Use POSIX compatible stdio in Mingw
+  add_definitions(-D__USE_MINGW_ANSI_STDIO)
+endif()
 
 option(
   TRAVIS_CI_BUILD "Travis CI build.  Extra compilation flags will be set." OFF)


### PR DESCRIPTION
There are some differences between stdio (*printf) functions in POSIX
and the MS runtime, this commit enables MinGW compatibility for these functions.

Cherry picked from #810.

See: https://github.com/neovim/neovim/pull/810#issuecomment-47929060
