### PR TITLE
[RFC] MSVC: Define inline and restrict since MSVC doesn't.

### DIFF
--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -21,6 +21,15 @@
 // - SYS_VIMRC_FILE
 // - SPECIAL_WILDCHAR
 
+#ifdef _MSC_VER
+# ifndef inline
+#  define inline __inline
+# endif
+# ifndef restrict
+#  define restrict __restrict
+# endif
+#endif
+
 typedef SSIZE_T ssize_t;
 
 #ifndef SSIZE_MAX


### PR DESCRIPTION
From #810 with the reduction of `__func__`.

MSVC defines `__func__` since it's in C++11
(but requires MSVC 2015).

See [here](https://msdn.microsoft.com/en-us/library/dn919276.aspx).

We do need `inline` and `restrict` though since MSVC only allows `inline` in C++ and requires `__inline` in C instead. See [here](https://msdn.microsoft.com/en-us/library/bw1hbe6y.aspx).
