### PR TITLE
[RFC] Add missing os/os_defs.h include in profile.c

### DIFF
--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -5,6 +5,7 @@
 #include "nvim/profile.h"
 #include "nvim/os/time.h"
 #include "nvim/func_attr.h"
+#include "nvim/os/os_defs.h"
 
 #include "nvim/globals.h"  // for the global `time_fd` (startuptime)
 


### PR DESCRIPTION
For `inline` once #3237 is merged.

Cherry picked from #810.
