### PR TITLE
[RFC] Add missing include os/os_defs.h in ascii.h and profile.c

### DIFF
--- a/src/nvim/ascii.h
+++ b/src/nvim/ascii.h
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 
 #include "nvim/func_attr.h"
+#include "nvim/os/os_defs.h"
 
 // Definitions of various common control characters.
 

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -5,6 +5,7 @@
 #include "nvim/profile.h"
 #include "nvim/os/time.h"
 #include "nvim/func_attr.h"
+#include "nvim/os/os_defs.h"
 
 #include "nvim/globals.h"  // for the global `time_fd` (startuptime)
 


### PR DESCRIPTION
In Windows, `os/os_defs.h` needs to be included to define `inline`.

xref #3237, #3238.

Cherry picked from #810.
