### PR TITLE
[RFC] Add path definitions for Windows.

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -48,6 +48,57 @@
 # endif
 #endif
 
+#ifdef WIN32
+# define _PATHSEPSTR "\\"
+#else
+# define _PATHSEPSTR "/"
+#endif
+
+#ifndef FILETYPE_FILE
+# define FILETYPE_FILE  "filetype.vim"
+#endif
+
+#ifndef FTPLUGIN_FILE
+# define FTPLUGIN_FILE  "ftplugin.vim"
+#endif
+
+#ifndef INDENT_FILE
+# define INDENT_FILE    "indent.vim"
+#endif
+
+#ifndef FTOFF_FILE
+# define FTOFF_FILE     "ftoff.vim"
+#endif
+
+#ifndef FTPLUGOF_FILE
+# define FTPLUGOF_FILE  "ftplugof.vim"
+#endif
+
+#ifndef INDOFF_FILE
+# define INDOFF_FILE    "indoff.vim"
+#endif
+
+#define DFLT_ERRORFILE  "errors.err"
+
+#ifndef SYS_VIMRC_FILE
+# define SYS_VIMRC_FILE "$VIM" _PATHSEPSTR "sysinit.vim"
+#endif
+
+#ifndef DFLT_HELPFILE
+# define DFLT_HELPFILE  "$VIMRUNTIME" _PATHSEPSTR "doc" _PATHSEPSTR "help.txt"
+#endif
+
+#ifndef SYNTAX_FNAME
+# define SYNTAX_FNAME   "$VIMRUNTIME" _PATHSEPSTR "syntax" _PATHSEPSTR "%s.vim"
+#endif
+
+#ifndef EXRC_FILE
+# define EXRC_FILE      ".exrc"
+#endif
+
+#ifndef VIMRC_FILE
+# define VIMRC_FILE     ".nvimrc"
+#endif
 
 /* Values for "starting" */
 #define NO_SCREEN       2       /* no screen updating yet */

--- a/src/nvim/os/os_defs.h
+++ b/src/nvim/os/os_defs.h
@@ -39,32 +39,6 @@
 # define MAXPATHL 1024
 #endif
 
-#ifndef FILETYPE_FILE
-# define FILETYPE_FILE  "filetype.vim"
-#endif
-
-#ifndef FTPLUGIN_FILE
-# define FTPLUGIN_FILE  "ftplugin.vim"
-#endif
-
-#ifndef INDENT_FILE
-# define INDENT_FILE    "indent.vim"
-#endif
-
-#ifndef FTOFF_FILE
-# define FTOFF_FILE     "ftoff.vim"
-#endif
-
-#ifndef FTPLUGOF_FILE
-# define FTPLUGOF_FILE  "ftplugof.vim"
-#endif
-
-#ifndef INDOFF_FILE
-# define INDOFF_FILE    "indoff.vim"
-#endif
-
-#define DFLT_ERRORFILE          "errors.err"
-
 // Command-processing buffer. Use large buffers for all platforms.
 #define CMDBUFFSIZE 1024
 

--- a/src/nvim/os/unix_defs.h
+++ b/src/nvim/os/unix_defs.h
@@ -9,7 +9,6 @@
 # include <sys/param.h>
 #endif
 
-
 #define TEMP_DIR_NAMES {"$TMPDIR", "/tmp", ".", "~"}
 #define TEMP_FILE_PATH_MAXLEN 256
 
@@ -17,22 +16,5 @@
 
 // Special wildcards that need to be handled by the shell.
 #define SPECIAL_WILDCHAR "`'{"
-
-// Unix system-dependent file names
-#ifndef SYS_VIMRC_FILE
-# define SYS_VIMRC_FILE "$VIM/sysinit.vim"
-#endif
-#ifndef DFLT_HELPFILE
-# define DFLT_HELPFILE  "$VIMRUNTIME/doc/help.txt"
-#endif
-#ifndef SYNTAX_FNAME
-# define SYNTAX_FNAME   "$VIMRUNTIME/syntax/%s.vim"
-#endif
-#ifndef EXRC_FILE
-# define EXRC_FILE      ".exrc"
-#endif
-#ifndef VIMRC_FILE
-# define VIMRC_FILE     ".nvimrc"
-#endif
 
 #endif  // NVIM_OS_UNIX_DEFS_H

--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -6,17 +6,6 @@
 #define TEMP_DIR_NAMES {"$TMP", "$TEMP", "$USERPROFILE", ""}
 #define TEMP_FILE_PATH_MAXLEN _MAX_PATH
 
-// Defines needed to fix the build on Windows:
-// - DFLT_DIR
-// - DFLT_BDIR
-// - DFLT_VDIR
-// - EXRC_FILE
-// - VIMRC_FILE
-// - SYNTAX_FNAME
-// - DFLT_HELPFILE
-// - SYS_VIMRC_FILE
-// - SPECIAL_WILDCHAR
-
 #define USE_CRNL
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Cherry picked from #810. Just the path definitions from equalsraf@5bdf72bd.

I left out `DFLT_MAXMEM`, `DFLT_MAXMEMTOT`, the `*_FILE` defines, and `DFLT_ERRORFILE` as those are defined in `os/os_defs.h`.

Further I changed this:

```
#if !defined(USR_EXRC_FILE2)
#    define USR_VIMRC_FILE2     "~\\_nvim\\nvimrc"
#endif
```

to:

```
#ifndef USR_VIMRC_FILE2
# define USR_VIMRC_FILE2 "$HOME\\_nvim\\nvimrc"
#endif
```

Which should be correct.
