### PR TITLE
[RFC] Windows: Define USE_CRNL on Windows.

### DIFF
--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -21,6 +21,8 @@
 // - SYS_VIMRC_FILE
 // - SPECIAL_WILDCHAR
 
+#define USE_CRNL
+
 #ifdef _MSC_VER
 # ifndef inline
 #  define inline __inline


### PR DESCRIPTION
From #810.

equalsraf@5bdf72b put this in `os/win_defs.h` but in my opinion this is more of a feature/platform flag so I used the config system to set that up.
