### PR TITLE
[RFC] vim-patch.sh: get all untagged patches 

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -170,7 +170,7 @@ list_vim_patches() {
 
   # Get "runtime update" commits since e2719096.
   local vim_runtime_commits=$(cd "${VIM_SOURCE_DIR}" && \
-    git log --format='%H' --grep='Updated' e2719096250a19ecdd9a35d13702879f163d2a50..HEAD)
+    git log --format='%H' --grep='^patch' --grep='^updated for version' --invert-grep e2719096250a19ecdd9a35d13702879f163d2a50..HEAD)
 
   local vim_commit
   for vim_commit in ${vim_tags} ${vim_runtime_commits}; do


### PR DESCRIPTION
Currently `vim-script.sh` finds untagged Vim patches ("runtime" patches) by using

```
git log --grep='Updated' e2719096250a19ecdd9a35d13702879f163d2a50..HEAD
```

with the following result:

```
88774fdd23f08355297bb8cda78856859051d3c7 Updated runtime files and Italian messages.
f91328100db34996ed7e7a800bed0a30ff0890dd Updated and new runtime files.
86ae720d7567fcbbe40f00cf136c797953f21038 Updated runtime files.
541f92d6cfdf2215e743553b5f4b6529dd9fcf31 Updated runtime files.
f2571c61d5aa05682ae4d358e625348b61adc861 Updated runtime files.
0a63dedf9921bd43cc0b4bc61cd3d0e3ec5728a7 Updated runtime files.
5a5f45917dbf542cb00617fa5ef70a14898495dd Updated runtime files.
2b8388bd0175835eb751e6c58cd0b0b69465f0d9 Updated runtime files.
83caecf31437c1e1af342186514f2a073ee1427e Updated runtime files.
9da7ff70cc22c941b7e6810c7d960d0061040436 Updated runtime files.
```

However, by manually filtering the git history for untagged patches I got:

```
88774fdd23f08355297bb8cda78856859051d3c7 Updated runtime files and Italian messages.
fc39ecf8ded5466d7e9cbde8db75517718b023d8 Update runtime files.
dd1616e6cedf798a5e6db3bf8cec1fc79a0481d0 Correct optwin script, update PHP complete.
f91328100db34996ed7e7a800bed0a30ff0890dd Updated and new runtime files.
86ae720d7567fcbbe40f00cf136c797953f21038 Updated runtime files.
efcabd6892ad89a4585fb77aa94c3b1802b784ab Add files missing from patch 7.4.771.
979243b990a68c20ea17fa26470639104e62b071 Update help files.
e2db6c975b97685ca58bd767a2b98cd8a94c1938 Add the logiPat plugin to the distribution.
541f92d6cfdf2215e743553b5f4b6529dd9fcf31 Updated runtime files.
f2571c61d5aa05682ae4d358e625348b61adc861 Updated runtime files.
ba172f2eabd3f8a98a797be6721229b49783ef69 Remove local-additions entries from help.txt.
0a63dedf9921bd43cc0b4bc61cd3d0e3ec5728a7 Updated runtime files.
83d1b19015219c7799af0a0d539ae86a41057240 More updated runtime files.
5a5f45917dbf542cb00617fa5ef70a14898495dd Updated runtime files.
dbcf19dc498cb1561c9215a3f255e81cde0c0543 Add test files for patch 7.4.680.
5837f1f447c34628268aab52476a79d57b6a7eaf Update runtime files.
f3c2afb77f8b1f2591337fcaa90ba0fb45365cbc Update a few runtime files.
2b8388bd0175835eb751e6c58cd0b0b69465f0d9 Updated runtime files.
35e7594dd429f7a8a06cefd61c3e8d48b9bd74e2 Add missing test files from 7.4.634 to the repository.
0122c4070f84e71f15a39fb20ababeffb70757c4 Update runtime files.
8a94d873aa8c753a8522ea86a049bdf2abd0c507 Update runtime files.
83caecf31437c1e1af342186514f2a073ee1427e Updated runtime files.
9da7ff70cc22c941b7e6810c7d960d0061040436 Updated runtime files.
```

Obviously, there are untagged patches that do not contain `Updated`. Tagged patches are easier to identify by their commit messages than untagged patches. They either start with `patch` (since `7.4.690`) or with `updated for version` (up to `7.4.689`). We can get the untagged patches by using `--invert-grep`.
