### PR TITLE
[RFC] Add support for ranges to remote function definitions

### DIFF
--- a/runtime/autoload/remote/define.vim
+++ b/runtime/autoload/remote/define.vim
@@ -1,7 +1,7 @@
 function! remote#define#CommandOnHost(host, method, sync, name, opts)
   let prefix = ''
 
-  if has_key(a:opts, 'range') 
+  if has_key(a:opts, 'range')
     if a:opts.range == '' || a:opts.range == '%'
       " -range or -range=%, pass the line range in a list
       let prefix = '<line1>,<line2>'
@@ -157,6 +157,9 @@ endfunction
 
 function! remote#define#FunctionOnChannel(channel, method, sync, name, opts)
   let rpcargs = [a:channel, '"'.a:method.'"', 'a:000']
+  if has_key(a:opts, 'range') && a:opts.range != '0'
+    call add(rpcargs, '[a:firstline, a:lastline]')
+  endif
   call s:AddEval(rpcargs, a:opts)
 
   let function_def = s:GetFunctionPrefix(a:name, a:opts)
@@ -187,7 +190,7 @@ let s:next_gid = 1
 function! s:GetNextAutocmdGroup()
   let gid = s:next_gid
   let s:next_gid += 1
-  
+
   let group_name = 'RPC_DEFINE_AUTOCMD_GROUP_'.gid
   " Ensure the group is defined
   exe 'augroup '.group_name.' | augroup END'
@@ -218,7 +221,11 @@ endfunction
 
 
 function! s:GetFunctionPrefix(name, opts)
-  return "function! ".a:name."(...)\n"
+  let res = "function! ".a:name."(...)"
+  if has_key(a:opts, 'range') && a:opts.range != '0'
+    let res = res." range"
+  endif
+  return res."\n"
 endfunction
 
 


### PR DESCRIPTION
As [`:help func-range`](http://neovim.io/doc/user/eval.html#:func-range) explains and as [`:help function-range-example`](http://neovim.io/doc/user/eval.html#function-range-example) shows, a function definition can include a `range` argument. 

``` vimscript
:function Cont() range
:  execute (a:firstline + 1) . "," . a:lastline . 's/^/\t\\ '
:endfunction
```

Similar support [exists for commands](https://github.com/neovim/neovim/blob/82296510879d6e18036ba45447d348bba41be52e/runtime/autoload/remote/define.vim#L64)
