### PR TITLE
[RFC] Windows: Move file_info_old declaration out of UNIX block

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2563,9 +2563,9 @@ buf_write (
   /*
    * Get information about original file (if there is one).
    */
+  FileInfo file_info_old;
 #if defined(UNIX)
   perm = -1;
-  FileInfo file_info_old;
   if (!os_fileinfo((char *)fname, &file_info_old)) {
     newfile = TRUE;
   } else {


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@7c3bac8.
