### PR TITLE
[RDY] third-party: update jemalloc to 4.0.2

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -92,8 +92,8 @@ set(LIBTERMKEY_SHA256 21846369081e6c9a0b615f4b3889c4cb809321c5ccc6e6c1640eb138f1
 set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/1b745d29d45623aa8d22a7b9288c7b0e331c7088.tar.gz)
 set(LIBVTERM_SHA256 3fc75908256c0d158d6c2a32d39f34e86bfd26364f5404b7d9c03bb70cdc3611)
 
-set(JEMALLOC_URL https://github.com/jemalloc/jemalloc/releases/download/3.6.0/jemalloc-3.6.0.tar.bz2)
-set(JEMALLOC_SHA256 e16c2159dd3c81ca2dc3b5c9ef0d43e1f2f45b04548f42db12e7c12d7bdf84fe)
+set(JEMALLOC_URL https://github.com/jemalloc/jemalloc/releases/download/4.0.2/jemalloc-4.0.2.tar.bz2)
+set(JEMALLOC_SHA256 0d8a9c8a98adb6983e0ccb521d45d9db1656ef3e71d0b14fb333f2c8138f4611)
 
 if(USE_BUNDLED_UNIBILIUM)
   include(BuildUnibilium)

--- a/third-party/cmake/BuildJeMalloc.cmake
+++ b/third-party/cmake/BuildJeMalloc.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(jemalloc
     -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
   BUILD_IN_SOURCE 1
-  CONFIGURE_COMMAND ${DEPS_BUILD_DIR}/src/jemalloc/configure --enable-cc-silence
+  CONFIGURE_COMMAND ${DEPS_BUILD_DIR}/src/jemalloc/configure
      CC=${DEPS_C_COMPILER} --prefix=${DEPS_INSTALL_DIR}
   BUILD_COMMAND ""
   INSTALL_COMMAND ${MAKE_PRG} install_include install_lib)


### PR DESCRIPTION
jemalloc 4.0 adds support for Bitrig, Cygwin, DragonFlyBSD, iOS, OpenBSD and OpenRISC/or1k. 
