### PR TITLE
[RFC] Add missing include limits.h in search.c

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -14,6 +14,7 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
+#include <limits.h>
 
 #include "nvim/ascii.h"
 #include "nvim/vim.h"


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@989596d.

For `INT_MAX`.
