### PR TITLE
[RFC] Windows: use ';' as env $PATH separator

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -151,7 +151,7 @@ static bool is_executable_in_path(const char_u *name, char_u **abspath)
   // Walk through all entries in $PATH to check if "name" exists there and
   // is an executable file.
   for (;; ) {
-    const char *e = xstrchrnul(path, ':');
+    const char *e = xstrchrnul(path, ENV_SEPCHAR);
 
     // Glue together the given directory from $PATH with name and save into
     // buf.
@@ -169,7 +169,7 @@ static bool is_executable_in_path(const char_u *name, char_u **abspath)
       return true;
     }
 
-    if (*e != ':') {
+    if (*e != ENV_SEPCHAR) {
       // End of $PATH without finding any executable called name.
       xfree(buf);
       return false;

--- a/src/nvim/os/unix_defs.h
+++ b/src/nvim/os/unix_defs.h
@@ -17,4 +17,7 @@
 // Special wildcards that need to be handled by the shell.
 #define SPECIAL_WILDCHAR "`'{"
 
+// Separator character for environment variables.
+#define ENV_SEPCHAR ':'
+
 #endif  // NVIM_OS_UNIX_DEFS_H

--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -10,6 +10,9 @@
 
 #define FNAME_ILLEGAL "\"*?><|"
 
+// Separator character for environment variables.
+#define ENV_SEPCHAR ';'
+
 #define USE_CRNL
 
 #ifdef _MSC_VER


### PR DESCRIPTION
In Windows the separator character in the `PATH` environment is `;` instead
of `:`. Add a new define `ENV_SEPCHAR` to be used instead of hardcoding
the character literal.

Cherry picked from #810. From equalsraf@d5e8e2e.
