### PR TITLE
[RFC] Windows: disable libuv argument escaping for uv_spawn

### DIFF
--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -19,7 +19,8 @@ bool libuv_process_spawn(LibuvProcess *uvproc)
   Process *proc = (Process *)uvproc;
   uvproc->uvopts.file = proc->argv[0];
   uvproc->uvopts.args = proc->argv;
-  uvproc->uvopts.flags = UV_PROCESS_WINDOWS_HIDE;
+  uvproc->uvopts.flags = UV_PROCESS_WINDOWS_HIDE
+                  | UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
   uvproc->uvopts.exit_cb = exit_cb;
   uvproc->uvopts.cwd = NULL;
   uvproc->uvopts.env = NULL;


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@207d841.

See [here](http://docs.libuv.org/en/v1.x/process.html#c.uv_process_flags) for documentation on the flags.
