### PR TITLE
[RFC] vim-patch:7.4.849

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -363,6 +363,9 @@ CTRL-O		execute one command, return to Insert mode   *i_CTRL-O*
 CTRL-\ CTRL-O	like CTRL-O but don't move the cursor	     *i_CTRL-\_CTRL-O*
 CTRL-L		when 'insertmode' is set: go to Normal mode  *i_CTRL-L*
 CTRL-G u	break undo sequence, start new change	     *i_CTRL-G_u*
+CTRL-G U	don't break undo with next left/right cursor *i_CTRL-G_U*
+		movement (but only if the cursor stays
+		within same the line)
 -----------------------------------------------------------------------
 
 Note: If the cursor keys take you out of Insert mode, check the 'noesckeys'
@@ -401,6 +404,29 @@ that, with CTRL-O u.  Another example: >
 
 This breaks undo at each line break.  It also expands abbreviations before
 this.
+
+An example for using CTRL-G U: >
+
+	inoremap <Left>  <C-G>U<Left>
+	inoremap <Right> <C-G>U<Right>
+	inoremap <expr> <Home> col('.') == match(getline('.'), '\S') + 1 ?
+	 \ repeat('<C-G>U<Left>', col('.') - 1) :
+	 \ (col('.') < match(getline('.'), '\S') ?
+	 \     repeat('<C-G>U<Right>', match(getline('.'), '\S') + 0) :
+	 \     repeat('<C-G>U<Left>', col('.') - 1 - match(getline('.'), '\S')))
+	inoremap <expr> <End> repeat('<C-G>U<Right>', col('$') - col('.'))
+	inoremap ( ()<C-G>U<Left>
+
+This makes it possible to use the cursor keys in Insert mode, without breaking
+the undo sequence and therefore using |.| (redo) will work as expected. 
+Also entering a text like (with the "(" mapping from above): >
+
+   Lorem ipsum (dolor
+
+will be repeatable by the |.|to the expected
+
+   Lorem ipsum (dolor)
+
 
 Using CTRL-O splits undo: the text typed before and after it is undone
 separately.  If you want to avoid this (e.g., in a mapping) you might be able

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -72,7 +72,7 @@ static char *features[] = {
 // clang-format off
 static int included_patches[] = {
   // 850,
-  // 849,
+     849,
   // 848,
   // 847,
   // 846,

--- a/test/functional/legacy/mapping_spec.lua
+++ b/test/functional/legacy/mapping_spec.lua
@@ -5,7 +5,7 @@ local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 
 describe('mapping', function()
-  setup(clear)
+  before_each(clear)
 
   it('is working', function()
     insert([[
@@ -43,5 +43,31 @@ describe('mapping', function()
       +
       +
       +]])
+  end)
+
+  it('i_CTRL-G_U', function()
+    -- <c-g>U<cursor> works only within a single line
+    execute('imapclear')
+    execute('imap ( ()<c-g>U<left>')
+    feed('G2o<esc>ki<cr>Test1: text with a (here some more text<esc>k.')
+    -- test undo
+    feed('G2o<esc>ki<cr>Test2: text wit a (here some more text [und undo]<c-g>u<esc>k.u')
+    execute('imapclear')
+    execute('set whichwrap=<,>,[,]')
+    feed('G3o<esc>2k')
+    execute([[:exe ":norm! iTest3: text with a (parenthesis here\<C-G>U\<Right>new line here\<esc>\<up>\<up>."]])
+
+    expect([[
+      
+      
+      Test1: text with a (here some more text)
+      Test1: text with a (here some more text)
+      
+      
+      Test2: text wit a (here some more text [und undo])
+      new line here
+      Test3: text with a (parenthesis here
+      new line here
+      ]])
   end)
 end)


### PR DESCRIPTION
Problem:    Moving the cursor in Insert mode starts new undo sequence.
Solution:   Add CTRL-G U to keep the undo sequence for the following cursor
            movement command. (Christian Brabandt)

https://github.com/vim/vim/commit/8b5f65a527c353b9942e362e719687c3a7592309
