### PR TITLE
[RFC] Fix warning: stream.c: stream_init(): Dead store: HI.

### DIFF
--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -56,7 +56,6 @@ void stream_init(Loop *loop, Stream *stream, int fd, uv_stream_t *uvstream,
 
   if (stream->uvstream) {
     stream->uvstream->data = stream;
-    loop = stream->uvstream->loop->data;
   }
 
   stream->data = data;


### PR DESCRIPTION
Fix warning: stream.c: stream_init(): Dead store: HI.

Problem     : Dead store @ 59.
Diagnostic  : Harmless issue.
Rationale   : loop is a function parameter that is not used anymore
              after this line.
Resolution  : Remove line.

Based on: http://neovim.io/doc/reports/clang/report-27475f.html#EndPath
