### PR TITLE
[RFC] Fix append API inconsistent implementation

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -467,7 +467,7 @@ void buffer_insert(Buffer buffer,
                    ArrayOf(String) lines,
                    Error *err)
 {
-  buffer_set_line_slice(buffer, lnum, lnum, false, true, lines, err);
+  buffer_set_line_slice(buffer, lnum, lnum, true, false, lines, err);
 }
 
 /// Return a tuple (row,col) representing the position of the named mark


### PR DESCRIPTION
The python-client append function calls the buffer_insert function.
buffer_insert calls buffer_set_line_slice excluding the start
line number and including the end, but as of my understanding to
conform to the Vim implementation it should be the opposite.

Should fix https://github.com/neovim/neovim/issues/3212 and https://github.com/neovim/python-client/issues/103
