### PR TITLE
[RFC] CMake: Use project directory to look for Git revision.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ endif()
 
 # Version tokens
 include(GetGitRevisionDescription)
+file(TO_NATIVE_PATH ${CMAKE_CURRENT_LIST_DIR}/.git GIT_DIR)
 get_git_head_revision(GIT_REFSPEC NVIM_VERSION_COMMIT)
 if(NOT NVIM_VERSION_COMMIT)
   set(NVIM_VERSION_COMMIT "?")


### PR DESCRIPTION
If downloading Neovim as a tarball (i.e. without Git data),
building Neovim will search parent directories for a .git directory.
Explicitly set GIT_DIR to the project directory to avoid that.
