### PR TITLE
[RFC] Fix append() with negative line numbers.

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -467,7 +467,8 @@ void buffer_insert(Buffer buffer,
                    ArrayOf(String) lines,
                    Error *err)
 {
-  buffer_set_line_slice(buffer, lnum, lnum, true, false, lines, err);
+  bool end_start = lnum < 0;
+  buffer_set_line_slice(buffer, lnum, lnum, !end_start, end_start, lines, err);
 }
 
 /// Return a tuple (row,col) representing the position of the named mark


### PR DESCRIPTION
In Vim bound checking is performed from 0 to buffer.linecount, and
returns error if trying to operate outside these bounds. Neovim allows to
use negative indexes but excludes buffer.linecount making its
implementation incompatible with Vim's one.

To see the issue in action

```
:python import vim; vim.current.buffer.append("Hello there", len(vim.currrent.buffer))
```

This fixes the incompatibility also maintaining the ability to index using
negative numbers (that would otherwise break python-client
implementation).

This also fixes https://github.com/junegunn/vim-plug/issues/278
