### PR TITLE
[RFC] path.c: Fix memory leak in expand_wildcards().

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4112,10 +4112,11 @@ void globpath(char_u *path, char_u *file, garray_T *ga, int expand_options)
       STRCAT(buf, file);  // NOLINT
 
       char_u **p;
-      int num_p;
-      if (ExpandFromContext(&xpc, buf, &num_p, &p,
-              WILD_SILENT|expand_options) != FAIL && num_p > 0) {
-        ExpandEscape(&xpc, buf, num_p, p, WILD_SILENT|expand_options);
+      int num_p = 0;
+      (void)ExpandFromContext(&xpc, buf, &num_p, &p,
+                              WILD_SILENT | expand_options);
+      if (num_p > 0) {
+        ExpandEscape(&xpc, buf, num_p, p, WILD_SILENT | expand_options);
 
         // Concatenate new results to previous ones.
         ga_grow(ga, num_p);

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1843,7 +1843,11 @@ char_u *path_shorten_fname(char_u *full_path, char_u *dir_name)
 /// @param[out]  file      Array of resulting files.
 /// @param[in]   flags     Flags passed to expand_wildcards().
 ///
-/// @return OK or FAIL.
+/// @returns               OK when *file is set to allocated array of matches
+///                        and *num_file(can be zero) to the number of matches.
+///                        If FAIL is returned, *num_file and *file are either
+///                        unchanged or *num_file is set to 0 and *file is set
+///                        to NULL or points to "".
 int expand_wildcards_eval(char_u **pat, int *num_file, char_u ***file,
                           int flags)
 {
@@ -1882,9 +1886,8 @@ int expand_wildcards_eval(char_u **pat, int *num_file, char_u ***file,
 /// @param[out] file     is pointer to array of pointers to matched file names.
 /// @param      flags    is a combination of EW_* flags.
 ///
-/// @returns             OK when some files were found. *num_file is set to the
-///                      number of matches, *file to the allocated array of
-///                      matches.
+/// @returns             OK when *file is set to allocated array of matches
+///                      and *num_file (can be zero) to the number of matches.
 ///                      If FAIL is returned, *num_file and *file are either
 ///                      unchanged or *num_file is set to 0 and *file is set to
 ///                      NULL or points to "".
@@ -1942,6 +1945,12 @@ int expand_wildcards(int num_pat, char_u **pat, int *num_file, char_u ***file,
         (*file)[non_suf_match++] = p;
       }
     }
+  }
+
+  // Free empty array of matches
+  if (*num_file == 0) {
+    xfree(*file);
+    *file = NULL;
   }
 
   return retval;


### PR DESCRIPTION
path.c: Fix memory leak in expand_wildcards().

A file that matches with one of the patterns in 'wildignore' is ignored
when using expand_wildcards(). After removing ignored files, the array
of (file name) matches can be empty. But an empty array is never freed.

Problem was found by ASAN, `:set wildignore=*` and `:!dir *<Tab>`:

```

=================================================================
==30608==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 720 byte(s) in 1 object(s) allocated from:
    #0 0x4dd5a0 in realloc /home/oni-link/git/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:61
    #1 0xac248c in xrealloc /home/oni-link/git/neovim/src/nvim/memory.c:144:15
    #2 0x1547b23 in ga_grow /home/oni-link/git/neovim/src/nvim/garray.c:96:14
    #3 0x10e036c in addfile /home/oni-link/git/neovim/src/nvim/path.c:1303:3
    #4 0x10ee6f5 in do_path_expand /home/oni-link/git/neovim/src/nvim/path.c:649:13
    #5 0x10dffeb in path_expand /home/oni-link/git/neovim/src/nvim/path.c:481:10
    #6 0x10ddbb3 in gen_expand_wildcards /home/oni-link/git/neovim/src/nvim/path.c:1164:21
    #7 0x10e84b5 in expand_wildcards /home/oni-link/git/neovim/src/nvim/path.c:1899:12
    #8 0x10e838a in expand_wildcards_eval /home/oni-link/git/neovim/src/nvim/path.c:1866:11
    #9 0x112b6b6 in ExpandFromContext /home/oni-link/git/neovim/src/nvim/ex_getln.c:3627:11
    #10 0x110dce5 in ExpandOne /home/oni-link/git/neovim/src/nvim/ex_getln.c:2790:9
    #11 0x111d445 in nextwild /home/oni-link/git/neovim/src/nvim/ex_getln.c:2632:12
    #12 0x10fb16b in getcmdline /home/oni-link/git/neovim/src/nvim/ex_getln.c:694:17
    #13 0x11246e5 in getexline /home/oni-link/git/neovim/src/nvim/ex_getln.c:1681:10
    #14 0x122c677 in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:540:47
    #15 0xf40bfb in nv_colon /home/oni-link/git/neovim/src/nvim/normal.c:4080:18
    #16 0xee5387 in normal_cmd /home/oni-link/git/neovim/src/nvim/normal.c:912:3
    #17 0xeb7d15 in main_loop /home/oni-link/git/neovim/src/nvim/main.c:748:7
    #18 0xea3868 in main /home/oni-link/git/neovim/src/nvim/main.c:535:3
    #19 0x7ff8ab15cf9f in __libc_start_main (/lib64/libc.so.6+0x1ff9f)

SUMMARY: AddressSanitizer: 720 byte(s) leaked in 1 allocation(s).
```
