### PR TITLE
[RFC] python: remove current working directory from path

### DIFF
--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -54,7 +54,7 @@ function! s:check_interpreter(prog, major_ver, skip) abort
 
   " Try to load neovim module, and output Python version.
   let prog_ver = system([ a:prog , '-c' ,
-        \ 'import sys; sys.stdout.write(str(sys.version_info[0]) + '.
+        \ 'import sys; sys.path.remove(""); sys.stdout.write(str(sys.version_info[0]) + '.
         \ '"." + str(sys.version_info[1])); '.
         \ (a:major_ver == 2
         \   ? 'import pkgutil; exit(pkgutil.get_loader("neovim") is None)'

--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -197,7 +197,7 @@ function! s:RequirePythonHost(host)
   let ver = (a:host.orig_name ==# 'python') ? 2 : 3
 
   " Python host arguments
-  let args = ['-c', 'import neovim; neovim.start_host()']
+  let args = ['-c', 'import sys; sys.path.remove(""); import neovim; neovim.start_host()']
 
   " Collect registered Python plugins into args
   let python_plugins = remote#host#PluginsForHost(a:host.name)


### PR DESCRIPTION
Before, running Nvim in a directory containing a Python module `neovim`,
or one that is imported by it or a plugin, will load that module and not
the system one. So Nvim might be tricked into running arbitrary scripts
from the current working directory.

In a recent Vim on OS X, `:python print(sys.path)` also doesn't contain the current directory so this restores some more compatibility with Vim and shouldn't break any plugins.

Fixes #1665
Fixes #2530

(This should also resolve neovim/python-client#55)
