### PR TITLE
[RFC] Clean up buffer.c build_stl_str_hl variable declarations

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2803,6 +2803,16 @@ void free_titles(void)
 
 # endif
 
+/**
+ * Enumeration specifying the valid numeric bases that can
+ * be used when printing numbers in the status line.
+ **/
+typedef enum {
+  kNumBaseDecimal = 10,
+  kNumBaseOctal = 8,
+  kNumBaseHexadecimal = 16
+} NumberBase;
+
 
 /*
  * Build a string from the status line items in "fmt".
@@ -2818,8 +2828,7 @@ void free_titles(void)
  * If maxwidth is not zero, the string will be filled at any middle marker
  * or truncated if too long, fillchar is used for all whitespace.
  */
-int
-build_stl_str_hl(
+int build_stl_str_hl(
     win_T *wp,
     char_u *out,               /* buffer to write into != NameBuff */
     size_t outlen,                  /* length of out[] */
@@ -2849,12 +2858,6 @@ build_stl_str_hl(
       Trunc
     }               type;
   }           item[STL_MAX_ITEM];
-
-  typedef enum {
-     DECIMAL     = 10,
-     OCTAL       = 8,
-     HEXIDECIMAL = 16
-  } number_base;
 
 #define TMPLEN 70
   char_u tmp[TMPLEN];
@@ -3202,7 +3205,7 @@ build_stl_str_hl(
     char_u opt = *fmt_p++;
 
     /* OK - now for the real work */
-    number_base base = DECIMAL;
+    NumberBase base = kNumBaseDecimal;
     bool itemisflag = false;
     bool fillable = true;
     long num = -1;
@@ -3359,7 +3362,7 @@ build_stl_str_hl(
       break;
 
     case STL_OFFSET_X:
-      base = HEXIDECIMAL;
+      base = kNumBaseHexadecimal;
     case STL_OFFSET:
     {
       long l = ml_find_line_or_offset(wp->w_buffer, wp->w_cursor.lnum, NULL);
@@ -3369,7 +3372,7 @@ build_stl_str_hl(
       break;
     }
     case STL_BYTEVAL_X:
-      base = HEXIDECIMAL;
+      base = kNumBaseHexadecimal;
     case STL_BYTEVAL:
       num = byteval;
       if (num == NL)
@@ -3573,7 +3576,9 @@ build_stl_str_hl(
 
       // Note: The `*` means we take the width as one of the arguments
       *t++ = '*';
-      *t++ = (char_u) (base == HEXIDECIMAL ? 'X' : (base == OCTAL ? 'o' : 'd'));
+      *t++ = (char_u) (base == kNumBaseHexadecimal ? 'X'
+                        : (base == kNumBaseOctal ? 'o'
+                        : 'd'));
       *t = 0;
       // }
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3118,6 +3118,30 @@ build_stl_str_hl(
       curitem++;
       continue;
     }
+
+    // TABPAGE pairs are used to denote a region that when clicked will
+    // either switch to or close a tab.
+    //
+    // Ex: tabline=%0Ttab\ zero%X
+    //   This tabline has a TABPAGENR item with minwid `0`,
+    //   which is then closed with a TABCLOSENR item.
+    //   Clicking on this region with mouse enabled will switch to tab 0.
+    //   Setting the minwid to a different value will switch
+    //   to that tab, if it exists
+    //
+    // Ex: tabline=%1Xtab\ one%X
+    //   This tabline has a TABCLOSENR item with minwid `1`,
+    //   which is then closed with a TABCLOSENR item.
+    //   Clicking on this region with mouse enabled will close tab 0.
+    //   This is determined by the following formula:
+    //      tab to close = (1 - minwid)
+    //   This is because for TABPAGENR we use `minwid` = `tab number`.
+    //   For TABCLOSENR we store the tab number as a negative value.
+    //   Because 0 is a valid TABPAGENR value, we have to
+    //   start our numbering at `-1`.
+    //   So, `-1` corresponds to us wanting to close tab `0`
+    //
+    // Note: These options are only valid when creating a tabline.
     if (*fmt_p == STL_TABPAGENR || *fmt_p == STL_TABCLOSENR) {
       if (*fmt_p == STL_TABCLOSENR) {
         if (minwid == 0) {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2803,10 +2803,8 @@ void free_titles(void)
 
 # endif
 
-/**
- * Enumeration specifying the valid numeric bases that can
- * be used when printing numbers in the status line.
- **/
+/// Enumeration specifying the valid numeric bases that can
+/// be used when printing numbers in the status line.
 typedef enum {
   kNumBaseDecimal = 10,
   kNumBaseOctal = 8,
@@ -2814,30 +2812,41 @@ typedef enum {
 } NumberBase;
 
 
-/*
- * Build a string from the status line items in "fmt".
- * Return length of string in screen cells.
- *
- * Normally works for window "wp", except when working for 'tabline' then it
- * is "curwin".
- *
- * Items are drawn interspersed with the text that surrounds it
- * Specials: %-<wid>(xxx%) => group, %= => middle marker, %< => truncation
- * Item: %-<minwid>.<maxwid><itemch> All but <itemch> are optional
- *
- * If maxwidth is not zero, the string will be filled at any middle marker
- * or truncated if too long, fillchar is used for all whitespace.
- */
+/// Build a string from the status line items in "fmt".
+/// Return length of string in screen cells.
+///
+/// Normally works for window "wp", except when working for 'tabline' then it
+/// is "curwin".
+///
+/// Items are drawn interspersed with the text that surrounds it
+/// Specials: %-<wid>(xxx%) => group, %= => middle marker, %< => truncation
+/// Item: %-<minwid>.<maxwid><itemch> All but <itemch> are optional
+///
+/// If maxwidth is not zero, the string will be filled at any middle marker
+/// or truncated if too long, fillchar is used for all whitespace.
+///
+/// @param wp The window to build a statusline for
+/// @param out The output buffer to write the statusline to
+///            Note: This should not be NameBuff
+/// @param outlen The length of the output buffer
+/// @param fmt The statusline format string
+/// @param use_sandbox Use a sandboxed environment when evaluating fmt
+/// @param fillchar Character to use when filling empty space in the statusline
+/// @param maxwidth The maximum width to make the statusline
+/// @param hltab HL attributes (can be NULL)
+/// @param tabtab tab page nrs (can be NULL)
+///
+/// @return The final width of the statusline
 int build_stl_str_hl(
     win_T *wp,
-    char_u *out,               /* buffer to write into != NameBuff */
-    size_t outlen,                  /* length of out[] */
+    char_u *out,
+    size_t outlen,
     char_u *fmt,
-    int use_sandbox,             /* "fmt" was set insecurely, use sandbox */
+    int use_sandbox,
     int fillchar,
     int maxwidth,
-    struct stl_hlrec *hltab,        /* return: HL attributes (can be NULL) */
-    struct stl_hlrec *tabtab       /* return: tab page nrs (can be NULL) */
+    struct stl_hlrec *hltab,
+    struct stl_hlrec *tabtab
 )
 {
   int groupitem[STL_MAX_ITEM];
@@ -2863,10 +2872,8 @@ int build_stl_str_hl(
   char_u tmp[TMPLEN];
   char_u      *usefmt = fmt;
 
-  /*
-   * When the format starts with "%!" then evaluate it as an expression and
-   * use the result as the actual format string.
-   */
+  // When the format starts with "%!" then evaluate it as an expression and
+  // use the result as the actual format string.
   if (fmt[0] == '%' && fmt[1] == '!') {
     usefmt = eval_to_string_safe(fmt + 2, NULL, use_sandbox);
     if (usefmt == NULL)
@@ -2875,16 +2882,16 @@ int build_stl_str_hl(
 
   if (fillchar == 0)
     fillchar = ' ';
-  /* Can't handle a multi-byte fill character yet. */
+  // Can't handle a multi-byte fill character yet.
   else if (mb_char2len(fillchar) > 1)
     fillchar = '-';
 
-  /* Get line & check if empty (cursorpos will show "0-1"). */
+  // Get line & check if empty (cursorpos will show "0-1").
   char_u *line_ptr = ml_get_buf(wp->w_buffer, wp->w_cursor.lnum, false);
   bool empty_line = (*line_ptr == NUL);
 
-  /* Get the byte value now, in case we need it below. This is more
-   * efficient than making a copy of the line. */
+  // Get the byte value now, in case we need it below. This is more
+  // efficient than making a copy of the line.
   int byteval;
   if (wp->w_cursor.col > (colnr_T)STRLEN(line_ptr))
     byteval = 0;
@@ -2910,8 +2917,8 @@ int build_stl_str_hl(
   // fmt_p is the current positon in the input buffer
   for (char_u *fmt_p = usefmt; *fmt_p; ) {
     if (curitem == STL_MAX_ITEM) {
-      /* There are too many items.  Add the error code to the statusline
-       * to give the user a hint about what went wrong. */
+      // There are too many items.  Add the error code to the statusline
+      // to give the user a hint about what went wrong.
       if (out_p + 5 < out_end_p) {
         memmove(out_p, " E541", (size_t)5);
         out_p += 5;
@@ -3204,7 +3211,7 @@ int build_stl_str_hl(
     // The status line item type
     char_u opt = *fmt_p++;
 
-    /* OK - now for the real work */
+    // OK - now for the real work
     NumberBase base = kNumBaseDecimal;
     bool itemisflag = false;
     bool fillable = true;
@@ -3215,7 +3222,9 @@ int build_stl_str_hl(
     case STL_FULLPATH:
     case STL_FILENAME:
     {
-      fillable = false;         /* don't change ' ' to fillchar */
+      // Set fillable to false to that ' ' in the filename will not
+      // get replaced with the fillchar
+      fillable = false;
       if (buf_spname(wp->w_buffer) != NULL) {
         STRLCPY(NameBuff, buf_spname(wp->w_buffer), MAXPATHL);
       } else {
@@ -3302,7 +3311,7 @@ int build_stl_str_hl(
     case STL_VIRTCOL:
     case STL_VIRTCOL_ALT:
     {
-      /* In list mode virtcol needs to be recomputed */
+      // In list mode virtcol needs to be recomputed
       colnr_T virtcol = wp->w_virtcol;
       if (wp->w_p_list && lcs_tab1 == NUL) {
         wp->w_p_list = FALSE;
@@ -3310,7 +3319,7 @@ int build_stl_str_hl(
         wp->w_p_list = TRUE;
       }
       ++virtcol;
-      /* Don't display %V if it's the same as %c. */
+      // Don't display %V if it's the same as %c.
       if (opt == STL_VIRTCOL_ALT
           && (virtcol == (colnr_T)(!(State & INSERT) && empty_line
                                    ? 0 : (int)wp->w_cursor.col + 1)))
@@ -3527,7 +3536,7 @@ int build_stl_str_hl(
       // pad with fill characters.
       if (minwid > 0) {
         for (; l < minwid && out_p < out_end_p; l++) {
-          /* Don't put a "-" in front of a digit. */
+          // Don't put a "-" in front of a digit.
           if (l + 1 == minwid && fillchar == '-' && ascii_isdigit(*t))
             *out_p++ = ' ';
           else
@@ -3543,8 +3552,8 @@ int build_stl_str_hl(
       // { Copy the string text into the output buffer
       while (*t && out_p < out_end_p) {
         *out_p++ = *t++;
-        /* Change a space by fillchar, unless fillchar is '-' and a
-         * digit follows. */
+        // Change a space by fillchar, unless fillchar is '-' and a
+        // digit follows.
         if (fillable && out_p[-1] == ' '
             && (!ascii_isdigit(*t) || fillchar != '-'))
           out_p[-1] = fillchar;
@@ -3664,7 +3673,7 @@ int build_stl_str_hl(
 
   int width = vim_strsize(out);
   if (maxwidth > 0 && width > maxwidth) {
-    /* Result is too long, must truncate somewhere. */
+    // Result is too long, must truncate somewhere.
     int item_idx = 0;
     char_u *trunc_p;
 
@@ -3704,7 +3713,7 @@ int build_stl_str_hl(
           //       character will fit in the available output space
           trunc_p += (*mb_ptr2len)(trunc_p);
         }
-        /* Fill up for half a double-wide character. */
+        // Fill up for half a double-wide character.
         // XXX : This seems impossible given the exit condition above?
         while (++width < maxwidth) {
           *trunc_p++ = fillchar;
@@ -3755,7 +3764,7 @@ int build_stl_str_hl(
       // Advance the pointer to the end of the string
       trunc_p = trunc_p + STRLEN(trunc_p);
 
-      /* Fill up for half a double-wide character. */
+      // Fill up for half a double-wide character.
       while (++width < maxwidth) {
         *trunc_p++ = fillchar;
         *trunc_p = NUL;
@@ -3809,7 +3818,7 @@ int build_stl_str_hl(
     }
   }
 
-  /* Store the info about highlighting. */
+  // Store the info about highlighting.
   if (hltab != NULL) {
     struct stl_hlrec *sp = hltab;
     for (long l = 0; l < itemcnt; l++) {
@@ -3823,7 +3832,7 @@ int build_stl_str_hl(
     sp->userhl = 0;
   }
 
-  /* Store the info about tab pages labels. */
+  // Store the info about tab pages labels.
   if (tabtab != NULL) {
     struct stl_hlrec *sp = tabtab;
     for (long l = 0; l < itemcnt; l++) {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2819,7 +2819,7 @@ void free_titles(void)
  * or truncated if too long, fillchar is used for all whitespace.
  */
 int
-build_stl_str_hl (
+build_stl_str_hl(
     win_T *wp,
     char_u *out,               /* buffer to write into != NameBuff */
     size_t outlen,                  /* length of out[] */
@@ -2850,11 +2850,11 @@ build_stl_str_hl (
     }               type;
   }           item[STL_MAX_ITEM];
 
-  enum number_base {
+  typedef enum {
      DECIMAL     = 10,
      OCTAL       = 8,
      HEXIDECIMAL = 16
-  };
+  } number_base;
 
 #define TMPLEN 70
   char_u tmp[TMPLEN];
@@ -2952,7 +2952,8 @@ build_stl_str_hl (
       continue;
     }
 
-    // STL_MIDDLEMARK denotes the separation place between left and right aligned items.
+    // STL_MIDDLEMARK denotes the separation place between
+    // left and right aligned items.
     if (*fmt_p == STL_MIDDLEMARK) {
       fmt_p++;
       // Ignored when we are inside of a grouping
@@ -2964,7 +2965,8 @@ build_stl_str_hl (
       continue;
     }
 
-    // STL_TRUNCMARK denotes where to begin truncating if the statusline is too long.
+    // STL_TRUNCMARK denotes where to begin truncating if the
+    // statusline is too long.
     if (*fmt_p == STL_TRUNCMARK) {
       fmt_p++;
       item[curitem].type = Trunc;
@@ -2981,17 +2983,19 @@ build_stl_str_hl (
       }
       groupdepth--;
 
-      //{ Determine how long the group is.
-      //  Note: We set the current output position to null so `vim_strsize` will work.
+      // { Determine how long the group is.
+      //   Note: We set the current output position to null
+      //         so `vim_strsize` will work.
       char_u *t = item[groupitem[groupdepth]].start;
       *out_p = NUL;
       long l = vim_strsize(t);
-      //}
+      // }
 
-      // If the group contained internal items and the group did not have a minimum width,
+      // If the group contained internal items
+      // and the group did not have a minimum width,
       // and if there were no normal items in the group,
-      // move the output pointer back to where the group started (erase the group).
-      // Note: This also erases any plaintext characters that were in the group.
+      // move the output pointer back to where the group started.
+      // Note: This erases any non-item characters that were in the group.
       //       Otherwise there would be no reason to do this step.
       if (curitem > groupitem[groupdepth] + 1
           && item[groupitem[groupdepth]].minwid == 0) {
@@ -3012,7 +3016,7 @@ build_stl_str_hl (
       // If the group is longer than it is allowed to be
       // truncate by removing bytes from the start of the group text.
       if (l > item[groupitem[groupdepth]].maxwid) {
-        //{ Determine the number of bytes to remove
+        // { Determine the number of bytes to remove
         long n;
         if (has_mbyte) {
           /* Find the first character that should be included. */
@@ -3021,20 +3025,21 @@ build_stl_str_hl (
             l -= ptr2cells(t + n);
             n += (*mb_ptr2len)(t + n);
           }
-        } else
+        } else {
           n = (long)(out_p - t) - item[groupitem[groupdepth]].maxwid + 1;
-        //}
+        }
+        // }
 
         // Prepend the `<` to indicate that the output was truncated.
         *t = '<';
 
-        //{ Move the truncated output
+        // { Move the truncated output
         memmove(t + 1, t + n, (size_t)(out_p - (t + n)));
         out_p = out_p - n + 1;
         /* Fill up space left over by half a double-wide char. */
         while (++l < item[groupitem[groupdepth]].minwid)
           *out_p++ = fillchar;
-        //}
+        // }
 
         /* correct the start of the items for the truncation */
         for (l = groupitem[groupdepth] + 1; l < curitem; l++) {
@@ -3057,14 +3062,14 @@ build_stl_str_hl (
         // If the group is right-aligned, shift everything to the right and
         // prepend with filler characters.
         } else {
-          //{ Move the group to the right
+          // { Move the group to the right
           memmove(t + min_group_width - l, t, (size_t)(out_p - t));
           l = min_group_width - l;
           if (out_p + l >= (out_end_p + 1)) {
             l = (long)(out_end_p - out_p);
           }
           out_p += l;
-          //}
+          // }
 
           // Adjust item start positions
           for (int n = groupitem[groupdepth] + 1; n < curitem; n++) {
@@ -3173,7 +3178,7 @@ build_stl_str_hl (
     char_u opt = *fmt_p++;
 
     /* OK - now for the real work */
-    enum number_base base = DECIMAL;
+    number_base base = DECIMAL;
     bool itemisflag = false;
     bool fillable = true;
     long num = -1;
@@ -3212,17 +3217,18 @@ build_stl_str_hl (
       fmt_p++;
       *out_p = 0;
 
-      // Move our position in the output buffer to the beginning of the expression
+      // Move our position in the output buffer
+      // to the beginning of the expression
       out_p = t;
 
-      //{ Evaluate the expression
+      // { Evaluate the expression
 
       // Store the current buffer number as a string variable
       vim_snprintf((char *)tmp, sizeof(tmp), "%d", curbuf->b_fnum);
       set_internal_string_var((char_u *)"actual_curbuf", tmp);
 
-      // Switch the curbuf and curwin to the buffer and window we are evaluating the
-      // statusline for.
+      // Switch the curbuf and curwin to the buffer and window we are
+      // evaluating the statusline for.
       buf_T *o_curbuf = curbuf;
       win_T *o_curwin = curwin;
       curwin = wp;
@@ -3236,9 +3242,9 @@ build_stl_str_hl (
       curbuf = o_curbuf;
 
       // Remove the variable we just stored
-      do_unlet((char_u *)"g:actual_curbuf", TRUE);
+      do_unlet((char_u *)"g:actual_curbuf", true);
 
-      //}
+      // }
 
       // Check if the evaluated result is a number.
       // If so, convert the number to an int and free the string.
@@ -3310,7 +3316,7 @@ build_stl_str_hl (
 
       // Note: The call will only return true if it actually
       //       appended data to the `tmp` buffer.
-      if (append_arg_number(wp, tmp, (int)sizeof(tmp), FALSE)) {
+      if (append_arg_number(wp, tmp, (int)sizeof(tmp), false)) {
         str = tmp;
       }
       break;
@@ -3365,7 +3371,8 @@ build_stl_str_hl (
 
     case STL_FILETYPE:
       // Copy the filetype if it is not null and the formatted string will fit
-      // in the temporary buffer (including the brackets and null terminating character)
+      // in the temporary buffer
+      // (including the brackets and null terminating character)
       if (*wp->w_buffer->b_p_ft != NUL
           && STRLEN(wp->w_buffer->b_p_ft) < TMPLEN - 3) {
         vim_snprintf((char *)tmp, sizeof(tmp), "[%s]",
@@ -3378,7 +3385,8 @@ build_stl_str_hl (
     {
       itemisflag = true;
       // Copy the filetype if it is not null and the formatted string will fit
-      // in the temporary buffer (including the comma and null terminating character)
+      // in the temporary buffer
+      // (including the comma and null terminating character)
       if (*wp->w_buffer->b_p_ft != NUL
           && STRLEN(wp->w_buffer->b_p_ft) < TMPLEN - 2) {
         vim_snprintf((char *)tmp, sizeof(tmp), ",%s",
@@ -3423,12 +3431,12 @@ build_stl_str_hl (
 
     case STL_HIGHLIGHT:
     {
-      //{ The name of the highlight is surrounded by `#`
+      // { The name of the highlight is surrounded by `#`
       char_u *t = fmt_p;
       while (*fmt_p != '#' && *fmt_p != NUL) {
         ++fmt_p;
       }
-      //}
+      // }
 
       // Create a highlight item based on the name
       if (*fmt_p == '#') {
@@ -3450,7 +3458,7 @@ build_stl_str_hl (
 
     // Copy the item string into the output buffer
     if (str != NULL && *str) {
-      //{ Skip the leading `,` or ` ` if the item is a flag
+      // { Skip the leading `,` or ` ` if the item is a flag
       //  and the proper conditions are met
       char_u *t = str;
       if (itemisflag) {
@@ -3460,7 +3468,7 @@ build_stl_str_hl (
           t++;
         prevchar_isflag = true;
       }
-      //}
+      // }
 
       long l = vim_strsize(t);
 
@@ -3488,7 +3496,8 @@ build_stl_str_hl (
         *out_p++ = '<';
       }
 
-      // If the item is right aligned and not wide enough, pad with fill characters.
+      // If the item is right aligned and not wide enough,
+      // pad with fill characters.
       if (minwid > 0) {
         for (; l < minwid && out_p < out_end_p; l++) {
           /* Don't put a "-" in front of a digit. */
@@ -3504,7 +3513,7 @@ build_stl_str_hl (
         minwid *= -1;
       }
 
-      //{ Copy the string text into the output buffer
+      // { Copy the string text into the output buffer
       while (*t && out_p < out_end_p) {
         *out_p++ = *t++;
         /* Change a space by fillchar, unless fillchar is '-' and a
@@ -3513,7 +3522,7 @@ build_stl_str_hl (
             && (!ascii_isdigit(*t) || fillchar != '-'))
           out_p[-1] = fillchar;
       }
-      //}
+      // }
 
       // For left-aligned items, fill any remaining space with the fillchar
       for (; l < minwid && out_p < out_end_p; l++) {
@@ -3526,7 +3535,7 @@ build_stl_str_hl (
         break;                  /* not sufficient space */
       prevchar_isitem = true;
 
-      //{ Build the formatting string
+      // { Build the formatting string
       char_u nstr[20];
       char_u *t = nstr;
       if (opt == STL_VIRTCOL_ALT) {
@@ -3542,9 +3551,9 @@ build_stl_str_hl (
       *t++ = '*';
       *t++ = (char_u) (base == HEXIDECIMAL ? 'X' : (base == OCTAL ? 'o' : 'd'));
       *t = 0;
-      //}
+      // }
 
-      //{ Determine how many characters the number will take up when printed
+      // { Determine how many characters the number will take up when printed
       //  Note: We have to cast the base because the compiler uses
       //        unsigned ints for the enum values.
       long num_chars = 0;
@@ -3552,11 +3561,12 @@ build_stl_str_hl (
         num_chars++;
       }
 
-      // VIRTCOL_ALT takes up an extra character because of the `-` we added above.
+      // VIRTCOL_ALT takes up an extra character because
+      // of the `-` we added above.
       if (opt == STL_VIRTCOL_ALT) {
         num_chars++;
       }
-      //}
+      // }
 
       size_t remaining_buf_len = (out_end_p - out_p) + 1;
 
@@ -3564,25 +3574,26 @@ build_stl_str_hl (
       // Figure out the approximate number in "scientific" type notation.
       // Ex: 14532 with maxwid of 4 -> '14>3'
       if (num_chars > maxwid) {
-        // Add two to the width because the power piece will take two extra characters
+        // Add two to the width because the power piece will take
+        // two extra characters
         num_chars += 2;
 
         // How many extra characters there are
         long n = num_chars - maxwid;
 
-        //{ Reduce the number by base^n
+        // { Reduce the number by base^n
         while (num_chars-- > maxwid) {
           num /= base;
         }
-        //}
+        // }
 
-        //{ Add the format string for the exponent bit
+        // { Add the format string for the exponent bit
         *t++ = '>';
         *t++ = '%';
         // Use the same base as the first number
         *t = t[-3];
         *++t = 0;
-        //}
+        // }
 
         vim_snprintf((char *)out_p, remaining_buf_len, (char *)nstr,
             0, num, n);
@@ -3591,7 +3602,8 @@ build_stl_str_hl (
             minwid, num);
       }
 
-      // Advance the output buffer position to the end of the number we just printed
+      // Advance the output buffer position to the end of the
+      // number we just printed
       out_p += STRLEN(out_p);
 
     // Otherwise, there was nothing to print so mark the item as empty
@@ -3690,7 +3702,7 @@ build_stl_str_hl (
 
     // Truncate at the truncation point we found
     } else {
-      //{ Determine how many bytes to remove
+      // { Determine how many bytes to remove
       long trunc_len;
       if (has_mbyte) {
         trunc_len = 0;
@@ -3702,9 +3714,9 @@ build_stl_str_hl (
         // Truncate an extra character so we can insert our `<`.
         trunc_len = (width - maxwidth) + 1;
       }
-      //}
+      // }
 
-      //{ Truncate the string
+      // { Truncate the string
       char_u *trunc_end_p = trunc_p + trunc_len;
       STRMOVE(trunc_p + 1, trunc_end_p);
 
@@ -3719,9 +3731,9 @@ build_stl_str_hl (
         *trunc_p++ = fillchar;
         *trunc_p = NUL;
       }
-      //}
+      // }
 
-      //{ Change the start point for items based on
+      // { Change the start point for items based on
       //  their position relative to our truncation point
 
       // Note: The offset is one less than the truncation length because
@@ -3733,17 +3745,19 @@ build_stl_str_hl (
         // to be moved backwards.
         if (item[i].start >= trunc_end_p) {
           item[i].start -= item_offset;
-        // Anything inside the truncated area is set to start at the `<` truncation character.
+        // Anything inside the truncated area is set to start
+        // at the `<` truncation character.
         } else {
           item[i].start = trunc_p;
         }
       }
-      //}
+      // }
     }
     width = maxwidth;
 
   // If there is room left in our statusline, and room left in our buffer,
-  // add characters at the middle marker (if there is one) to fill up the available space.
+  // add characters at the middle marker (if there is one) to
+  // fill up the available space.
   } else if (width < maxwidth
                && STRLEN(out) + maxwidth - width + 1 < outlen) {
     for (int item_idx = 0; item_idx < itemcnt; item_idx++) {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3580,8 +3580,8 @@ build_stl_str_hl(
       // { Determine how many characters the number will take up when printed
       //  Note: We have to cast the base because the compiler uses
       //        unsigned ints for the enum values.
-      long num_chars = 0;
-      for (long n = num, num_chars = 1; n >= (int) base; n /= (int) base) {
+      long num_chars = 1;
+      for (long n = num; n >= (int) base; n /= (int) base) {
         num_chars++;
       }
 

--- a/test/unit/buffer_spec.lua
+++ b/test/unit/buffer_spec.lua
@@ -1,9 +1,15 @@
+
+local assert = require("luassert")
 local helpers = require("test.unit.helpers")
 
 local to_cstr = helpers.to_cstr
 local eq      = helpers.eq
+local neq     = helpers.neq
 
+local globals = helpers.cimport("./src/nvim/globals.h")
 local buffer = helpers.cimport("./src/nvim/buffer.h")
+local fileio = helpers.cimport("./src/nvim/fileio.h")
+local ex_docmd = helpers.cimport("./src/nvim/ex_docmd.h")
 local window = helpers.cimport("./src/nvim/window.h")
 local option = helpers.cimport("./src/nvim/option.h")
 
@@ -204,6 +210,97 @@ describe('buffer functions', function()
 
       close_buffer(NULL, buf1, buffer.DOBUF_WIPE, 0)
       close_buffer(NULL, buf2, buffer.DOBUF_WIPE, 0)
+    end)
+  end)
+
+  describe('build_stl_str_hl', function()
+
+    output_buffer = to_cstr(string.rep(" ", 100))
+
+    local build_stl_str_hl = function(pat)
+      return buffer.build_stl_str_hl(globals.curwin,
+                                     output_buffer,
+                                     100,
+                                     to_cstr(pat),
+                                     false,
+                                     32,
+                                     80,
+                                     NULL,
+                                     NULL)
+    end
+
+    it('should copy plain text', function()
+      local width = build_stl_str_hl("this is a test")
+
+      eq(14, width)
+      eq("this is a test", helpers.ffi.string(output_buffer, width))
+
+    end)
+
+    it('should print no file name', function()
+      local width = build_stl_str_hl("%f")
+
+      eq(9, width)
+      eq("[No Name]", helpers.ffi.string(output_buffer, width))
+
+    end)
+
+    it('should print the relative file name', function()
+      buffer.setfname(globals.curbuf, to_cstr("Makefile"), NULL, 1)
+      local width = build_stl_str_hl("%f")
+
+      eq(8, width)
+      eq("Makefile", helpers.ffi.string(output_buffer, width))
+
+    end)
+
+    it('should print the full file name', function()
+      buffer.setfname(globals.curbuf, to_cstr("Makefile"), NULL, 1)
+
+      local width = build_stl_str_hl("%F")
+
+      assert.is_true(8 < width)
+      neq(NULL, string.find(helpers.ffi.string(output_buffer, width), "Makefile"))
+
+    end)
+
+    it('should print the tail file name', function()
+      buffer.setfname(globals.curbuf, to_cstr("src/nvim/buffer.c"), NULL, 1)
+
+      local width = build_stl_str_hl("%t")
+
+      eq(8, width)
+      eq("buffer.c", helpers.ffi.string(output_buffer, width))
+
+    end)
+
+    it('should print the buffer number', function()
+      buffer.setfname(globals.curbuf, to_cstr("src/nvim/buffer.c"), NULL, 1)
+
+      local width = build_stl_str_hl("%n")
+
+      eq(1, width)
+      eq("1", helpers.ffi.string(output_buffer, width))
+    end)
+
+    it('should print the current line number in the buffer', function()
+      buffer.setfname(globals.curbuf, to_cstr("test/unit/buffer_spec.lua"), NULL, 1)
+
+      local width = build_stl_str_hl("%l")
+
+      eq(1, width)
+      eq("0", helpers.ffi.string(output_buffer, width))
+
+    end)
+
+    it('should print the number of lines in the buffer', function()
+      buffer.setfname(globals.curbuf, to_cstr("test/unit/buffer_spec.lua"), NULL, 1)
+
+      local width = build_stl_str_hl("%L")
+
+      eq(1, width)
+      eq("1", helpers.ffi.string(output_buffer, width))
+
     end)
   end)
 end)


### PR DESCRIPTION
I picked this function more or less at random and decided to move the declarations closer to where the variables are used at. 

After further investigation, this is the function that builds the vim statusline.
The code was rather cryptic, so I have fully commented it. The comments may seem excessive, but that is only because after reading the comment it is obvious that the code is doing what the comment says it is. Without the comments it is quite hard to follow.

I have also written a number of tests to cover the basic items supported by statusline. It is by no means a comprehensive test suite for the function.
