### PR TITLE
[RFC] Add expand() call to remote_plugins_manifest

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -1,6 +1,6 @@
 let s:hosts = {}
 let s:plugin_patterns = {}
-let s:remote_plugins_manifest = fnamemodify($MYVIMRC, ':p:h')
+let s:remote_plugins_manifest = fnamemodify(expand($MYVIMRC, 1), ':h')
       \.'/.'.fnamemodify($MYVIMRC, ':t').'-rplugin~'
 
 


### PR DESCRIPTION
According to the vim helpfile:

> fnamemodify({fname}, {mods})
>    ...
>    Note: Environment variables don't work in {fname}, use
>    expand() first then.

So this causes issues if your `$MYVIMRC` contains environment variables
(e.g. `$XDG_CONFIG_HOME`)
