### PR TITLE
[RDY] Free the parent queue last when destroying the loop

### DIFF
--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -86,9 +86,9 @@ void loop_close(Loop *loop)
   do {
     uv_run(&loop->uv, UV_RUN_DEFAULT);
   } while (uv_loop_close(&loop->uv));
-  queue_free(loop->events);
   queue_free(loop->fast_events);
   queue_free(loop->thread_events);
+  queue_free(loop->events);
   kl_destroy(WatcherPtr, loop->children);
 }
 

--- a/test/functional/ex_cmds/quit_spec.lua
+++ b/test/functional/ex_cmds/quit_spec.lua
@@ -1,0 +1,14 @@
+local helpers = require('test.functional.helpers')
+local execute, eq, clear = helpers.execute, helpers.eq, helpers.clear
+
+describe(':qa', function()
+  before_each(function() 
+    clear('qa')
+  end)
+
+  it('verify #3334', function()
+    -- just testing if 'qa' passed as a program argument wont result in memory
+    -- errors
+  end)
+end)
+


### PR DESCRIPTION
This avoids a heap-use-after-free ASAN error. Close #3334
