### PR TITLE
[RFC] docs cleanup: misc

### DIFF
--- a/runtime/doc/arabic.txt
+++ b/runtime/doc/arabic.txt
@@ -6,10 +6,6 @@
 
 Arabic Language support (options & mappings) for Vim		*Arabic*
 
-								*E800*
-In order to use right-to-left and Arabic mapping support, it is
-necessary to compile VIM with the |+arabic| feature.
-
 These functions have been created by Nadim Shaikli <nadim-at-arabeyes.org>
 
 It is best to view this file with these settings within VIM's GUI: >

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1128,8 +1128,6 @@ and ":put" commands and with CTRL-R.
 		The command-line is only stored in this register when at least
 		one character of it was typed.  Thus it remains unchanged if
 		the command was completely from a mapping.
-		{not available when compiled without the |+cmdline_hist|
-		feature}
 
 6. Expression register "=			*quote_=* *quote=* *@=*
 This is not really a register that stores text, but is a way to use an
@@ -1437,8 +1435,6 @@ Other examples: >
 By default, "b:#" is included.  This means that a line that starts with
 "#include" is not recognized as a comment line.  But a line that starts with
 "# define" is recognized.  This is a compromise.
-
-{not available when compiled without the |+comments| feature}
 
 							*fo-table*
 You can use the 'formatoptions' option  to influence how Vim formats text.

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -228,24 +228,16 @@ CTRL-C		quit command-line without executing
 							*c_<Up>* *c_Up*
 <Up>		recall older command-line from history, whose beginning
 		matches the current command-line (see below).
-		{not available when compiled without the |+cmdline_hist|
-		feature}
 							*c_<Down>* *c_Down*
 <Down>		recall more recent command-line from history, whose beginning
 		matches the current command-line (see below).
-		{not available when compiled without the |+cmdline_hist|
-		feature}
 
 							*c_<S-Up>* *c_<PageUp>*
 <S-Up> or <PageUp>
 		recall older command-line from history
-		{not available when compiled without the |+cmdline_hist|
-		feature}
 						*c_<S-Down>* *c_<PageDown>*
 <S-Down> or <PageDown>
 		recall more recent command-line from history
-		{not available when compiled without the |+cmdline_hist|
-		feature}
 
 CTRL-D		command-line completion (see |cmdline-completion|)
 'wildchar' option
@@ -260,8 +252,7 @@ CTRL-_		a - switch between Hebrew and English keyboard mode, which is
 		private to the command-line and not related to hkmap.
 		This is useful when Hebrew text entry is required in the
 		command-line, searches, abbreviations, etc.  Applies only if
-		Vim is compiled with the |+rightleft| feature and the
-		'allowrevins' option is set.
+		the 'allowrevins' option is set.
 		See |rileft.txt|.
 
 		b - switch between Farsi and English keyboard mode, which is
@@ -269,7 +260,6 @@ CTRL-_		a - switch between Hebrew and English keyboard mode, which is
 		Farsi keyboard mode the characters are inserted in reverse
 		insert manner.  This is useful when Farsi text entry is
 		required in the command-line, searches, abbreviations, etc.
-		Applies only if Vim is compiled with the |+farsi| feature.
 		See |farsi.txt|.
 
 							*c_CTRL-^*
@@ -312,8 +302,6 @@ terminals)
 
 							*:his* *:history*
 :his[tory]	Print the history of last entered commands.
-		{not available when compiled without the |+cmdline_hist|
-		feature}
 
 :his[tory] [{name}] [{first}][, [{last}]]
 		List the contents of history {name} which can be:
@@ -362,10 +350,8 @@ word before the cursor.  This is available for:
 - Mappings: Only after a ":map" or similar command.
 - Variable and function names: Only after a ":if", ":call" or similar command.
 
-When Vim was compiled without the |+cmdline_compl| feature only file names,
-directories and help items can be completed.  The number of help item matches
-is limited (currently to 300) to avoid a long delay when there are very many
-matches.
+The number of help item matches is limited (currently to 300) to avoid a long
+delay when there are very many matches.
 
 These are the commands that can be used:
 
@@ -953,8 +939,6 @@ for the file "$home" in the root directory.  A few examples:
 In the command-line window the command line can be edited just like editing
 text in any window.  It is a special kind of window, because you cannot leave
 it in a normal way.
-{not available when compiled without the |+cmdline_hist| or |+vertsplit|
-feature}
 
 
 OPEN						*c_CTRL-F* *q:* *q/* *q?*
@@ -1025,9 +1009,8 @@ command-line window open again, you may find this mapping useful: >
 
 VARIOUS
 
-The command-line window cannot be used:
-- when there already is a command-line window (no nesting)
-- when Vim was not compiled with the |+vertsplit| feature
+The command-line window cannot be used when there already is a command-line
+window (no nesting).
 
 Some options are set when the command-line window is opened:
 'filetype'	"vim", when editing an Ex command-line; this starts Vim syntax

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2307,8 +2307,6 @@ byte2line({byte})					*byte2line()*
 		for the current buffer.  The first character has byte count
 		one.
 		Also see |line2byte()|, |go| and |:goto|.
-		{not available when compiled without the |+byte_offset|
-		feature}
 
 byteidx({expr}, {nr})					*byteidx()*
 		Return byte index of the {nr}'th character in the string
@@ -2388,8 +2386,7 @@ cindent({lnum})						*cindent()*
 		indenting rules, as with 'cindent'.
 		The indent is counted in spaces, the value of 'tabstop' is
 		relevant.  {lnum} is used just like in |getline()|.
-		When {lnum} is invalid or Vim was not compiled the |+cindent|
-		feature, -1 is returned.
+		When {lnum} is invalid -1 is returned.
 		See |C-indenting|.
 
 clearmatches()						*clearmatches()*
@@ -4252,8 +4249,7 @@ line2byte({lnum})					*line2byte()*
 			line2byte(line("$") + 1)
 <		This is the buffer size plus one.  If 'fileencoding' is empty
 		it is the file size plus one.
-		When {lnum} is invalid, or the |+byte_offset| feature has been
-		disabled at compile time, -1 is returned.
+		When {lnum} is invalid -1 is returned.
 		Also see |byte2line()|, |go| and |:goto|.
 
 lispindent({lnum})					*lispindent()*

--- a/runtime/doc/farsi.txt
+++ b/runtime/doc/farsi.txt
@@ -6,10 +6,6 @@
 
 Right to Left and Farsi Mapping for Vim		*farsi* *Farsi*
 
-						*E27*
-In order to use right-to-left and Farsi mapping support, it is necessary to
-compile Vim with the |+farsi| feature.
-
 These functions have been made by Mortaza G. Shiran <shiran@jps.net>
 
 

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -22,9 +22,6 @@ indent and do not perform other formatting.  There are additional options that
 affect other kinds of formatting as well as indenting, see |format-comments|,
 |fo-table|, |gq| and |formatting| for the main ones.
 
-Note that this will not work when the |+smartindent| or |+cindent| features
-have been disabled at compile time.
-
 There are in fact four main methods available for indentation, each one
 overrides the previous if it is enabled, or non-empty for 'indentexpr':
 'autoindent'	uses the indent from the previous line.

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -100,8 +100,7 @@ tag		char		action in Insert mode	~
 |i_CTRL-]|	CTRL-]		trigger abbreviation
 |i_CTRL-^|	CTRL-^		toggle use of |:lmap| mappings
 |i_CTRL-_|	CTRL-_		When 'allowrevins' set: change language
-				(Hebrew, Farsi) {only when compiled with
-				the |+rightleft| feature}
+				(Hebrew, Farsi)
 
 		<Space> to '~'	not used, except '0' and '^' followed by
 				CTRL-D

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -373,8 +373,6 @@ Setting the filetype
 			used to set the option value in, unless this is a help
 			window, in which case the window below help window is
 			used (skipping the option-window).
-			{not available when compiled without the |+eval| or
-			|+autocmd| features}
 
 								*$HOME*
 Using "~" is like using "$HOME", but it is only recognized at the start of an
@@ -580,10 +578,8 @@ supported use something like this: >
 A jump table for the options with a short description can be found at |Q_op|.
 
 					*'aleph'* *'al'* *aleph* *Aleph*
-'aleph' 'al'		number	(default 128 for MS-DOS, 224 otherwise)
+'aleph' 'al'		number	(default 224)
 			global
-			{only available when compiled with the |+rightleft|
-			feature}
 	The ASCII code for the first letter of the Hebrew alphabet.  The
 	routine that maps the keyboard in Hebrew mode, both in Insert mode
 	(when hkmap is set) and on the command-line (when hitting CTRL-_)
@@ -594,8 +590,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'allowrevins'* *'ari'* *'noallowrevins'* *'noari'*
 'allowrevins' 'ari'	boolean	(default off)
 			global
-			{only available when compiled with the |+rightleft|
-			feature}
 	Allow CTRL-_ in Insert and Command-line mode.  This is default off, to
 	avoid that users that accidentally type CTRL-_ instead of SHIFT-_ get
 	into reverse Insert mode, and don't know how to get out.  See
@@ -604,8 +598,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			 *'altkeymap'* *'akm'* *'noaltkeymap'* *'noakm'*
 'altkeymap' 'akm'	boolean (default off)
 			global
-			{only available when compiled with the |+farsi|
-			feature}
 	When on, the second language is Farsi.  In editing mode CTRL-_ toggles
 	the keyboard map between Farsi and English, when 'allowrevins' set.
 
@@ -678,8 +670,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 				*'arabic'* *'arab'* *'noarabic'* *'noarab'*
 'arabic' 'arab'		boolean (default off)
 			local to window
-			{only available when compiled with the |+arabic|
-			feature}
 	This option can be set to start editing Arabic text.
 	Setting this option will:
 	- Set the 'rightleft' option, unless 'termbidi' is set.
@@ -700,8 +690,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'noarabicshape'* *'noarshape'*
 'arabicshape' 'arshape'	boolean (default on)
 			global
-			{only available when compiled with the |+arabic|
-			feature}
 	When on and 'termbidi' is off, the required visual character
 	corrections that need to take place for displaying the Arabic language
 	take effect.  Shaping, in essence, gets enabled; the term is a broad
@@ -1197,8 +1185,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			written
 	  nowrite	buffer which will not be written
 	  acwrite	buffer which will always be written with BufWriteCmd
-			autocommands. {not available when compiled without the
-			|+autocmd| feature}
+			autocommands.
 	  quickfix	quickfix buffer, contains list of errors |:cwindow|
 			or list of locations |:lwindow|
 	  help		help buffer (you are not supposed to set this
@@ -1276,8 +1263,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'cedit'*
 'cedit'			string	(Vim default: CTRL-F, Vi default: "")
 			global
-			{not available when compiled without the |+vertsplit|
-			feature}
 	The key used in Command-line Mode to open the command-line window.
 	Only non-printable keys are allowed.
 	The key can be specified as a single character, but it is difficult to
@@ -1331,8 +1316,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 				   *'cindent'* *'cin'* *'nocindent'* *'nocin'*
 'cindent' 'cin'		boolean	(default off)
 			local to buffer
-			{not available when compiled without the |+cindent|
-			feature}
 	Enables automatic C program indenting.  See 'cinkeys' to set the keys
 	that trigger reindenting in insert mode and 'cinoptions' to set your
 	preferred indent style.
@@ -1348,8 +1331,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 							*'cinkeys'* *'cink'*
 'cinkeys' 'cink'	string	(default "0{,0},0),:,0#,!^F,o,O,e")
 			local to buffer
-			{not available when compiled without the |+cindent|
-			feature}
 	A list of keys that, when typed in Insert mode, cause reindenting of
 	the current line.  Only used if 'cindent' is on and 'indentexpr' is
 	empty.
@@ -1359,8 +1340,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'cinoptions'* *'cino'*
 'cinoptions' 'cino'	string	(default "")
 			local to buffer
-			{not available when compiled without the |+cindent|
-			feature}
 	The 'cinoptions' affect the way 'cindent' reindents lines in a C
 	program.  See |cinoptions-values| for the values of this option, and
 	|C-indenting| for info on C indenting in general.
@@ -1369,8 +1348,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'cinwords'* *'cinw'*
 'cinwords' 'cinw'	string	(default "if,else,while,do,for,switch")
 			local to buffer
-			{not available when compiled without both the
-			|+cindent| and the |+smartindent| features}
 	These keywords start an extra indent in the next line when
 	'smartindent' or 'cindent' is set.  For 'cindent' this is only done at
 	an appropriate place (inside {}).
@@ -1436,8 +1413,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'cmdwinheight'* *'cwh'*
 'cmdwinheight' 'cwh'	number	(default 7)
 			global
-			{not available when compiled without the |+vertsplit|
-			feature}
 	Number of screen lines to use for the command-line window. |cmdwin|
 
 						*'colorcolumn'* *'cc'*
@@ -1478,8 +1453,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 'comments' 'com'	string	(default
 				"s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-")
 			local to buffer
-			{not available when compiled without the |+comments|
-			feature}
 	A comma separated list of strings that can start a comment line.  See
 	|format-comments|.  See |option-backslash| about using backslashes to
 	insert a space.
@@ -1589,8 +1562,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'concealcursor'* *'cocu'*
 'concealcursor' 'cocu'	string (default: "")
 			local to window
-			{not available when compiled without the |+conceal|
-			feature}
 	Sets the modes in which text in the cursor line can also be concealed.
 	When the current mode is listed then concealing happens just like in
 	other lines.
@@ -1611,8 +1582,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 'conceallevel' 'cole'		*'conceallevel'* *'cole'*
 			number (default 0)
 			local to window
-			{not available when compiled without the |+conceal|
-			feature}
 	Determine how text with the "conceal" syntax attribute |:syn-conceal|
 	is shown:
 
@@ -1911,16 +1880,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'cscopepathcomp'* *'cspc'*
 'cscopepathcomp' 'cspc'	number	(default 0)
 			global
-			{not available when compiled without the |+cscope|
-			feature}
 	Determines how many components of the path to show in a list of tags.
 	See |cscopepathcomp|.
 
 						*'cscopeprg'* *'csprg'*
 'cscopeprg' 'csprg'	string	(default "cscope")
 			global
-			{not available when compiled without the |+cscope|
-			feature}
 	Specifies the command to execute cscope.  See |cscopeprg|.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
@@ -1928,16 +1893,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'cscopequickfix'* *'csqf'*
 'cscopequickfix' 'csqf' string	(default "")
 			global
-			{not available when compiled without the |+cscope|
-			or |+quickfix| features}
 	Specifies whether to use quickfix window to show cscope results.
 	See |cscopequickfix|.
 
 		*'cscoperelative'* *'csre'* *'nocscoperelative'* *'nocsre'*
 'cscoperelative' 'csre' boolean (default off)
 			global
-			{not available when compiled without the |+cscope|
-			feature}
 	In the absence of a prefix (-P) for cscope. setting this option enables
 	to use the basename of cscope.out path as the prefix.
 	See |cscoperelative|.
@@ -1945,15 +1906,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 				*'cscopetag'* *'cst'* *'nocscopetag'* *'nocst'*
 'cscopetag' 'cst'	boolean (default off)
 			global
-			{not available when compiled without the |+cscope|
-			feature}
 	Use cscope for tag commands.  See |cscope-options|.
 
 						*'cscopetagorder'* *'csto'*
 'cscopetagorder' 'csto'	number	(default 0)
 			global
-			{not available when compiled without the |+cscope|
-			feature}
 	Determines the order in which ":cstag" performs a search.  See
 	|cscopetagorder|.
 
@@ -1961,15 +1918,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'nocscopeverbose'* *'nocsverb'*
 'cscopeverbose' 'csverb' boolean (default off)
 			global
-			{not available when compiled without the |+cscope|
-			feature}
 	Give messages when adding a cscope database.  See |cscopeverbose|.
 
 			*'cursorbind'* *'crb'* *'nocursorbind'* *'nocrb'*
 'cursorbind' 'crb'	boolean  (default off)
 			local to window
-			{not available when compiled without the |+cursorbind|
-			feature}
 	When this option is set, as the cursor in the current
 	window moves other cursorbound windows (windows that also have
 	this option set) move their cursors to the corresponding line and
@@ -2197,8 +2150,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'eadirection'* *'ead'*
 'eadirection' 'ead'	string	(default "both")
 			global
-			{not available when compiled without the |+vertsplit|
-			feature}
 	Tells when the 'equalalways' option applies:
 		ver	vertically, width of windows is not affected
 		hor	horizontally, height of windows is not affected
@@ -2343,8 +2294,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'eventignore'* *'ei'*
 'eventignore' 'ei'	string	(default "")
 			global
-			{not available when compiled without the |+autocmd|
-			feature}
 	A list of autocommand event names, which are to be ignored.
 	When set to "all" or when "all" is one of the items, all autocommand
 	events are ignored, autocommands will not be executed.
@@ -2565,8 +2514,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'filetype'* *'ft'*
 'filetype' 'ft'		string (default: "")
 			local to buffer
-			{not available when compiled without the |+autocmd|
-			feature}
 	When this option is set, the FileType autocommand event is triggered.
 	All autocommands that match with the value of this option will be
 	executed.  Thus the value of 'filetype' is used in place of the file
@@ -2626,8 +2573,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'fkmap'* *'fk'* *'nofkmap'* *'nofk'*
 'fkmap' 'fk'		boolean (default off)			*E198*
 			global
-			{only available when compiled with the |+rightleft|
-			feature}
 	When on, the keyboard is mapped for the Farsi character set.
 	Normally you would set 'allowrevins' and use CTRL-_ in insert mode to
 	toggle this option |i_CTRL-_|.  See |farsi.txt|.
@@ -3477,8 +3422,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 					 *'hkmap'* *'hk'* *'nohkmap'* *'nohk'*
 'hkmap' 'hk'		boolean (default off)
 			global
-			{only available when compiled with the |+rightleft|
-			feature}
 	When on, the keyboard is mapped for the Hebrew character set.
 	Normally you would set 'allowrevins' and use CTRL-_ in insert mode to
 	toggle this option.  See |rileft.txt|.
@@ -3486,8 +3429,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 				 *'hkmapp'* *'hkp'* *'nohkmapp'* *'nohkp'*
 'hkmapp' 'hkp'		boolean (default off)
 			global
-			{only available when compiled with the |+rightleft|
-			feature}
 	When on, phonetic keyboard mapping is used.  'hkmap' must also be on.
 	This is useful if you have a non-Hebrew keyboard.
 	See |rileft.txt|.
@@ -3715,8 +3656,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'indentexpr'* *'inde'*
 'indentexpr' 'inde'	string	(default "")
 			local to buffer
-			{not available when compiled without the |+cindent|
-			or |+eval| features}
 	Expression which is evaluated to obtain the proper indent for a line.
 	It is used when a new line is created, for the |=| operator and
 	in Insert mode as specified with the 'indentkeys' option.
@@ -3751,8 +3690,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'indentkeys'* *'indk'*
 'indentkeys' 'indk'	string	(default "0{,0},:,0#,!^F,o,O,e")
 			local to buffer
-			{not available when compiled without the |+cindent|
-			feature}
 	A list of keys that, when typed in Insert mode, cause reindenting of
 	the current line.  Only happens if 'indentexpr' isn't empty.
 	The format is identical to 'cinkeys', see |indentkeys-format|.
@@ -5043,8 +4980,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 				*'revins'* *'ri'* *'norevins'* *'nori'*
 'revins' 'ri'		boolean	(default off)
 			global
-			{only available when compiled with the |+rightleft|
-			feature}
 	Inserting characters in Insert mode will work backwards.  See "typing
 	backwards" |ins-reverse|.  This option can be toggled with the CTRL-_
 	command in Insert mode, when 'allowrevins' is set.
@@ -5053,8 +4988,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 				 *'rightleft'* *'rl'* *'norightleft'* *'norl'*
 'rightleft' 'rl'	boolean	(default off)
 			local to window
-			{only available when compiled with the |+rightleft|
-			feature}
 	When on, display orientation becomes right-to-left, i.e., characters
 	that are stored in the file appear from the right to the left.
 	Using this option, it is possible to edit files for languages that
@@ -5068,8 +5001,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'rightleftcmd'* *'rlc'*
 'rightleftcmd' 'rlc'	string	(default "search")
 			local to window
-			{only available when compiled with the |+rightleft|
-			feature}
 	Each word in this option enables the command line editing to work in
 	right-to-left mode for a group of commands:
 
@@ -5953,8 +5884,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'splitright'* *'spr'* *'nosplitright'* *'nospr'*
 'splitright' 'spr'	boolean	(default off)
 			global
-			{not available when compiled without the |+vertsplit|
-			feature}
 	When on, splitting a window will put the new window right of the
 	current one. |:vsplit|
 
@@ -6034,7 +5963,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	W F   Preview window flag, text is ",PRV".
 	y F   Type of file in the buffer, e.g., "[vim]".  See 'filetype'.
 	Y F   Type of file in the buffer, e.g., ",VIM".  See 'filetype'.
-	      {not available when compiled without |+autocmd| feature}
 	q S   "[Quickfix List]", "[Location List]" or empty.
 	k S   Value of "b:keymap_name" or 'keymap' when |:lmap| mappings are
 	      being used: "<keymap>"
@@ -6043,7 +5971,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	B N   As above, in hexadecimal.
 	o N   Byte number in file of byte under cursor, first byte is 1.
 	      Mnemonic: Offset from start of file (with one added)
-	      {not available when compiled without |+byte_offset| feature}
 	O N   As above, in hexadecimal.
 	N N   Printer page number.  (Only works in the 'printheader' option.)
 	l N   Line number.
@@ -6419,10 +6346,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'termbidi'* *'tbidi'*
 						*'notermbidi'* *'notbidi'*
-'termbidi' 'tbidi'	boolean (default off, on for "mlterm")
+'termbidi' 'tbidi'	boolean (default off)
 			global
-			{only available when compiled with the |+arabic|
-			feature}
 	The terminal is in charge of Bi-directionality of text (as specified
 	by Unicode).  The terminal is also expected to do the required shaping
 	that some languages (such as Arabic) require.
@@ -6430,7 +6355,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	'arabic' is set and the value of 'arabicshape' will be ignored.
 	Note that setting 'termbidi' has the immediate effect that
 	'arabicshape' is ignored, but 'rightleft' isn't changed automatically.
-	This option is reset when the GUI is started.
 	For further details see |arabic.txt|.
 
 					*'termencoding'* *'tenc'*
@@ -7220,8 +7144,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'winminwidth'* *'wmw'*
 'winminwidth' 'wmw'	number	(default 1)
 			global
-			{not available when compiled without the |+vertsplit|
-			feature}
 	The minimal width of a window, when it's not the current window.
 	This is a hard minimum, windows will never become smaller.
 	When set to zero, windows may be "squashed" to zero columns (i.e. just
@@ -7236,8 +7158,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'winwidth'* *'wiw'* *E592*
 'winwidth' 'wiw'	number	(default 20)
 			global
-			{not available when compiled without the |+vertsplit|
-			feature}
 	Minimal number of columns for the current window.  This is not a hard
 	minimum, Vim will use fewer columns if there is not enough room.  If
 	the current window is smaller, its size is increased, at the cost of

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6557,7 +6557,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When 'undofile' is turned off the undo file is NOT deleted.
 
 						*'undolevels'* *'ul'*
-'undolevels' 'ul'	number	(default 100, 1000 for Unix and Win32)
+'undolevels' 'ul'	number	(default 1000)
 			global or local to buffer |global-local|
 	Maximum number of changes that can be undone.  Since undo information
 	is kept in memory, higher numbers will cause more memory to be used

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6504,46 +6504,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	{not available when compiled without the |+statusline| feature}
 
 				*'toolbar'* *'tb'*
-'toolbar' 'tb'		string	(default "icons,tooltips")
-			global
-			{only for |+GUI_GTK|, |+GUI_Athena|, and |+GUI_Motif|}
-	The contents of this option controls various toolbar settings.  The
-	possible values are:
-		icons		Toolbar buttons are shown with icons.
-		text		Toolbar buttons shown with text.
-		horiz		Icon and text of a toolbar button are
-				horizontally arranged.  {only in GTK+ 2 GUI}
-		tooltips	Tooltips are active for toolbar buttons.
-	Tooltips refer to the popup help text which appears after the mouse
-	cursor is placed over a toolbar button for a brief moment.
-
-	If you want the toolbar to be shown with icons as well as text, do the
-	following: >
-		:set tb=icons,text
-<	Motif and Athena cannot display icons and text at the same time.  They
-	will show icons if both are requested.
-
-	If none of the strings specified in 'toolbar' are valid or if
-	'toolbar' is empty, this option is ignored.  If you want to disable
-	the toolbar, you need to set the 'guioptions' option.  For example: >
-		:set guioptions-=T
-<	Also see |gui-toolbar|.
+'toolbar' 'tb'		Removed. |vim-differences| {Nvim}
 
 						*'toolbariconsize'* *'tbis'*
-'toolbariconsize' 'tbis'	string	(default "small")
-				global
-				{only in the GTK+ 2 GUI}
-	Controls the size of toolbar icons.  The possible values are:
-		tiny		Use tiny toolbar icons.
-		small		Use small toolbar icons (default).
-		medium		Use medium-sized toolbar icons.
-		large		Use large toolbar icons.
-	The exact dimensions in pixels of the various icon sizes depend on
-	the current theme.  Common dimensions are large=32x32, medium=24x24,
-	small=20x20 and tiny=16x16.
-
-	If 'toolbariconsize' is empty, the global default size as determined
-	by user preferences or the current theme is used.
+'toolbariconsize' 'tbis'	Removed. |vim-differences| {Nvim}
 
 			     *'ttybuiltin'* *'tbi'* *'nottybuiltin'* *'notbi'*
 'ttybuiltin' 'tbi'	Removed. |vim-differences| {Nvim}

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -273,9 +273,9 @@ deleted for some reason, the message "line changed" is shown to warn you that
 the error location may not be correct.  If you quit Vim and start again the
 marks are lost and the error locations may not be correct anymore.
 
-If vim is built with |+autocmd| support, two autocommands are available for
-running commands before and after a quickfix command (':make', ':grep' and so
-on) is executed. See |QuickFixCmdPre| and |QuickFixCmdPost| for details.
+Two autocommands are available for running commands before and after a
+quickfix command (':make', ':grep' and so on) is executed. See
+|QuickFixCmdPre| and |QuickFixCmdPost| for details.
 
 						*QuickFixCmdPost-example*
 When 'encoding' differs from the locale, the error messages may have a
@@ -440,8 +440,8 @@ lists, use ":cnewer 99" first.
 4. Using :make						*:make_makeprg*
 
 							*:mak* *:make*
-:mak[e][!] [arguments]	1. If vim was built with |+autocmd|, all relevant
-			   |QuickFixCmdPre| autocommands are executed.
+:mak[e][!] [arguments]	1. All relevant |QuickFixCmdPre| autocommands are
+			   executed.
 			2. If the 'autowrite' option is on, write any changed
 			   buffers
 			3. An errorfile name is made from 'makeef'.  If
@@ -453,9 +453,8 @@ lists, use ":cnewer 99" first.
 			   errorfile (for Unix it is also echoed on the
 			   screen).
 			5. The errorfile is read using 'errorformat'.
-			6. If vim was built with |+autocmd|, all relevant
-			   |QuickFixCmdPost| autocommands are executed.
-			   See example below.
+			6. All relevant |QuickFixCmdPost| autocommands are
+			   executed. See example below.
 			7. If [!] is not given the first error is jumped to.
 			8. The errorfile is deleted.
 			9. You can now move through the errors with commands

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -898,8 +898,6 @@ Short explanation of each option:		*option-list*
 'titlelen'		    percentage of 'columns' used for window title
 'titleold'		    old title, restored when exiting
 'titlestring'		    string to use for the Vim window title
-'toolbar'	  'tb'	    GUI: which items to show in the toolbar
-'toolbariconsize' 'tbis'    size of the toolbar icons (for GTK 2 only)
 'ttimeout'		    time out on mappings
 'ttimeoutlen'	  'ttm'     time out time for key codes in milliseconds
 'ttytype'	  'tty'     alias for 'term'

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -37,8 +37,6 @@ of area is used, see |visual-repeat|.
 
 							*@:*
 @:			Repeat last command-line [count] times.
-			{not available when compiled without the
-			|+cmdline_hist| feature}
 
 
 ==============================================================================

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -392,7 +392,6 @@ Example for an xterm, this changes the color of the cursor: >
     endif
 NOTE: When Vim exits the shape for Normal mode will remain.  The shape from
 before Vim started will not be restored.
-{not available when compiled without the |+cursorshape| feature}
 
 							*termcap-title*
 The 't_ts' and 't_fs' options are used to set the window title if the terminal

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -159,6 +159,8 @@ Other options:
   'termencoding'
   'textauto'
   'textmode'
+  'toolbar'
+  'toolbariconsize'
   'ttybuiltin'
   'ttymouse'
   'weirdinvert'

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -477,7 +477,6 @@ CTRL-W H	Move the current window to be at the far left, using the
 		current window and then creating another one with
 		":vert topleft split", except that the current window contents
 		is used for the new window.
-		{not available when compiled without the |+vertsplit| feature}
 
 						*CTRL-W_L*
 CTRL-W L	Move the current window to be at the far right, using the full
@@ -485,7 +484,6 @@ CTRL-W L	Move the current window to be at the far right, using the full
 		current window and then creating another one with
 		":vert botright split", except that the current window
 		contents is used for the new window.
-		{not available when compiled without the |+vertsplit| feature}
 
 						*CTRL-W_T*
 CTRL-W T	Move the current window to a new tab page.  This fails if

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2525,11 +2525,7 @@ return {
       type='number', scope={'global', 'buffer'},
       vi_def=true,
       varname='p_ul',
-      defaults={
-        condition={'!UNIX', '!WIN3264'},
-        if_true={vi=100},
-        if_false={vi=1000},
-      }
+      defaults={if_true={vi=1000}}
     },
     {
       full_name='undoreload', abbreviation='ur',


### PR DESCRIPTION
1. Removed feature references ('not available when compiled without...') for some features that Nvim always provides.
2. Mark the two options `toolbar` and `toolbariconsize` that have already been removed from the code as removed in the appropriate places in the documentation
3. `undolevels` had a different default for (!Unix and !Windows) which doesn't seem very useful.
