### PR TITLE
test: temporary workaround for QB build.

### DIFF
--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -254,7 +254,7 @@ function Screen:wait(check, timeout)
   end
 
   if failure_after_success then
-    print([[
+    io.stderr:write([[
 Warning: Screen changes have been received after the expected state was seen.
 This is probably due to an indeterminism in the test. Try adding
 `wait()` (or even a separate `screen:expect(...)`) at a point of possible
@@ -270,7 +270,7 @@ If everything else fails, use Screen:redraw_debug to help investigate what is
       ]])
     local tb = debug.traceback()
     local index = string.find(tb, '\n%s*%[C]')
-    print(string.sub(tb,1,index))
+    io.stderr:write(string.sub(tb,1,index))
   end
 
   if err then


### PR DESCRIPTION
When this warning appears in TAP output, QB build fails. Disable it
temporarily so that QB build is useful in the meantime.
