### PR TITLE
[RFC] Make ... occurences in echo output more useful

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7809,7 +7809,20 @@ This does NOT work: >
 			postponed until you type something), force a redraw
 			with the |:redraw| command.  Example: >
 		:new | redraw | echo "there is a new window"
-<
+<							*:echo-self-refer*
+			When printing nested containers echo prints second 
+			occurrence of the self-referencing container using 
+			"[...@level]" (self-referencing |List|) or 
+			"{...@level}" (self-referencing |Dict|): >
+		:let l = []
+		:call add(l, l)
+		:let l2 = []
+		:call add(l2, [l2])
+		:echo l l2
+<			echoes "[[...@0]] [[[...@0]]]". Echoing "[l]" will 
+			echo "[[[...@1]]]" because l first occurs at second 
+			level.
+
 							*:echon*
 :echon {expr1} ..	Echoes each {expr1}, without anything added.  Also see
 			|:comment|.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -75,6 +75,24 @@ are always available and may be used simultaneously in separate plugins.  The
 
 'encoding' cannot be changed after startup.
 
+|string()| and |:echo| behaviour changed:
+1. No maximum recursion depth limit is applied to nested container 
+   structures.
+2. |string()| fails immediately on nested containers, not when recursion limit 
+   was exceeded.
+2. When |:echo| encounters duplicate containers like >
+
+       let l = []
+       echo [l, l]
+<
+   it does not use "[...]" (was: "[[], [...]]", now: "[[], []]"). "..." is 
+   only used for recursive containers.
+3. |:echo| printing nested containers adds "@level" after "..." designating 
+   the level at which recursive container was printed: |:echo-self-refer|.  
+   Same thing applies to |string()| (though it uses construct like 
+   "{E724@level}"), but this is not reliable because |string()| continues to 
+   error out.
+
 ==============================================================================
 4. New Features						     *nvim-features-new*
 

--- a/test/functional/eval/msgpack_functions_spec.lua
+++ b/test/functional/eval/msgpack_functions_spec.lua
@@ -565,6 +565,18 @@ describe('msgpackdump() function', function()
        exc_exec('call msgpackdump([todump])'))
   end)
 
+  it('can dump dict with two same dicts inside', function()
+    execute('let inter = {}')
+    execute('let todump = {"a": inter, "b": inter}')
+    eq({"\130\161a\128\161b\128"}, eval('msgpackdump([todump])'))
+  end)
+
+  it('can dump list with two same lists inside', function()
+    execute('let inter = []')
+    execute('let todump = [inter, inter]')
+    eq({"\146\144\144"}, eval('msgpackdump([todump])'))
+  end)
+
   it('fails to dump a recursive list in a special dict', function()
     execute('let todump = {"_TYPE": v:msgpack_types.array, "_VAL": []}')
     execute('call add(todump._VAL, todump)')

--- a/test/functional/legacy/074_global_var_in_viminfo_spec.lua
+++ b/test/functional/legacy/074_global_var_in_viminfo_spec.lua
@@ -12,7 +12,8 @@ describe('storing global variables in viminfo files', function()
   end)
 
   it('is working', function()
-    local nvim2 = helpers.spawn({helpers.nvim_prog, '-u', 'NONE', '--embed'})
+    local nvim2 = helpers.spawn({helpers.nvim_prog, '-u', 'NONE',
+                                 '-i', 'Xviminfo', '--embed'})
     helpers.set_session(nvim2)
 
     local test_dict = {foo = 1, bar = 0, longvarible = 1000}


### PR DESCRIPTION
This PR has the following advantages:
1. `string()` and `:echo` now use non-recursive calls and thus have no limit on nesting level.
2. `tv2string` and `echo_string` are now much easier to use because they got most their arguments removed.
3. `:echo` no longer prints `...` in most cases. And if it does print, it does not mean “this list was already displayed, but who knows where it was displayed”, it is “list is self-referencing, see the original list at level N in the current container tree branch”. This behaviour of `:echo` was rather bothersome in some cases: e.g. try to `echo` msgpack value with a few special dicts that have the same type.
