### PR TITLE
[RFC] Remove VLA from path_get_absolute_path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if(MSVC)
   add_definitions(/W3 -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
 else()
   add_definitions(-Wall -Wextra -pedantic -Wno-unused-parameter
-    -Wstrict-prototypes -std=gnu99)
+    -Wstrict-prototypes -Wvla -std=gnu99)
 endif()
 
 if(MINGW)

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -2083,7 +2083,7 @@ static int path_get_absolute_path(const char_u *fname, char_u *buf, int len, int
   char_u *p;
   *buf = NUL;
 
-  char relative_directory[len];
+  char *relative_directory = xmalloc(len);
   char *end_of_path = (char *) fname;
 
   // expand it if forced or not an absolute path
@@ -2105,9 +2105,11 @@ static int path_get_absolute_path(const char_u *fname, char_u *buf, int len, int
     }
 
     if (FAIL == path_full_dir_name(relative_directory, (char *) buf, len)) {
+      xfree(relative_directory);
       return FAIL;
     }
   }
+  xfree(relative_directory);
   return append_path((char *)buf, end_of_path, len);
 }
 


### PR DESCRIPTION
Remove the last use of Variable Length Arrays in Neovim, use xmalloc/xfree
instead.

Also relevant for #810 (because MSVC lacks support for VLAs).
