### PR TITLE
Able to run menu commands while in commandline

### DIFF
--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1262,6 +1262,9 @@ void ex_emenu(exarg_T *eap)
   if (((State & INSERT) || restart_edit) && !current_SID) {
     mode = (char_u *)"Insert";
     idx = MENU_INDEX_INSERT;
+  } else if (State & CMDLINE) {
+      mode = (char_u *)"Command";
+      idx = MENU_INDEX_CMDLINE;
   } else if (get_real_state() & VISUAL) {
     /* Detect real visual mode -- if we are really in visual mode we
      * don't need to do any guesswork to figure out what the selection
@@ -1308,9 +1311,6 @@ void ex_emenu(exarg_T *eap)
      * for exclusive mode */
     if (*p_sel == 'e' && gchar_cursor() != NUL)
       ++curwin->w_cursor.col;
-  } else if (State & CMDLINE) {
-      mode = (char_u *)"Command";
-      idx = MENU_INDEX_CMDLINE;
   } else {
     mode = (char_u *)"Normal";
     idx = MENU_INDEX_NORMAL;

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1308,6 +1308,9 @@ void ex_emenu(exarg_T *eap)
      * for exclusive mode */
     if (*p_sel == 'e' && gchar_cursor() != NUL)
       ++curwin->w_cursor.col;
+  } else if((State & CMDLINE)) {
+      mode = (char_u *)"Command";
+      idx = MENU_INDEX_CMDLINE;
   } else {
     mode = (char_u *)"Normal";
     idx = MENU_INDEX_NORMAL;

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1308,7 +1308,7 @@ void ex_emenu(exarg_T *eap)
      * for exclusive mode */
     if (*p_sel == 'e' && gchar_cursor() != NUL)
       ++curwin->w_cursor.col;
-  } else if((State & CMDLINE)) {
+  } else if ((State & CMDLINE)) {
       mode = (char_u *)"Command";
       idx = MENU_INDEX_CMDLINE;
   } else {

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1308,7 +1308,7 @@ void ex_emenu(exarg_T *eap)
      * for exclusive mode */
     if (*p_sel == 'e' && gchar_cursor() != NUL)
       ++curwin->w_cursor.col;
-  } else if ((State & CMDLINE)) {
+  } else if (State & CMDLINE) {
       mode = (char_u *)"Command";
       idx = MENU_INDEX_CMDLINE;
   } else {

--- a/test/functional/ex_cmds/menu_spec.lua
+++ b/test/functional/ex_cmds/menu_spec.lua
@@ -36,3 +36,37 @@ describe(':emenu', function()
   end)
 
 end)
+
+describe('emenu Edit.Paste while in commandline', function()
+    before_each(clear)
+
+    it('ok', function()
+        local screen = require('test.functional.ui.screen').new()
+        screen:attach()
+        nvim('command', 'runtime menu.vim')
+        feed('ithis is a sentence<esc>^"+yiwo<esc>')
+        nvim('command', 'emenu Edit.Paste')
+        feed(':')
+        nvim('command', 'emenu Edit.Paste')
+        screen:expect([[
+          this is a sentence                                   |
+          this                                                 |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          ~                                                    |
+          :this^                                                |
+        ]])
+
+        screen:detach()
+        clear()
+    end)
+end)
+

--- a/test/functional/ex_cmds/menu_spec.lua
+++ b/test/functional/ex_cmds/menu_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require('test.functional.helpers')
+local Screen = require('test.functional.ui.screen').new(40,4)
 local clear, execute, nvim = helpers.clear, helpers.execute, helpers.nvim
 local expect = helpers.expect
 local feed = helpers.feed
@@ -38,35 +39,23 @@ describe(':emenu', function()
 end)
 
 describe('emenu Edit.Paste while in commandline', function()
-    before_each(clear)
+    before_each(function()
+      clear()
+      screen = Screen.new(40, 4)
+      screen:attach()
+    end)
 
     it('ok', function()
-        local screen = require('test.functional.ui.screen').new()
-        screen:attach()
         nvim('command', 'runtime menu.vim')
         feed('ithis is a sentence<esc>^"+yiwo<esc>')
         nvim('command', 'emenu Edit.Paste')
         feed(':')
         nvim('command', 'emenu Edit.Paste')
         screen:expect([[
-          this is a sentence                                   |
-          this                                                 |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          :this^                                                |
+          this is a sentence                      |
+          this                                    |
+          ~                                       |
+          :this^                                   |
         ]])
-
-        screen:detach()
-        clear()
     end)
 end)
-


### PR DESCRIPTION
Running `:emenu` while in commandline does not run the `cmenu` mapping, it runs the normal mode mapping instead. Added a check to the state to make set the `MENU_INDEX_CMDLINE` when in the CMDLINE state. 

This should resolve #3386. 
