### PR TITLE
[WIP] provider: Move Python script host into Python module.

### DIFF
--- a/runtime/autoload/provider/python.vim
+++ b/runtime/autoload/provider/python.vim
@@ -9,7 +9,7 @@ if exists('g:loaded_python_provider')
 endif
 let g:loaded_python_provider = 1
 
-let [s:prog, s:err] = provider#pythonx#Detect(2)
+let [s:prog, s:err, s:module_path] = provider#pythonx#Detect(2)
 
 function! provider#python#Prog()
   return s:prog
@@ -24,7 +24,7 @@ if s:prog == ''
   finish
 endif
 
-let s:plugin_path = expand('<sfile>:p:h').'/script_host.py'
+let s:plugin_path = s:module_path . '/provider/script_host.py'
 
 " The Python provider plugin will run in a separate instance of the Python
 " host.

--- a/runtime/autoload/provider/python3.vim
+++ b/runtime/autoload/provider/python3.vim
@@ -9,7 +9,7 @@ if exists('g:loaded_python3_provider')
 endif
 let g:loaded_python3_provider = 1
 
-let [s:prog, s:err] = provider#pythonx#Detect(3)
+let [s:prog, s:err, s:module_path] = provider#pythonx#Detect(3)
 
 function! provider#python3#Prog()
   return s:prog
@@ -24,7 +24,7 @@ if s:prog == ''
   finish
 endif
 
-let s:plugin_path = expand('<sfile>:p:h').'/script_host.py'
+let s:plugin_path = s:module_path . '/provider/script_host.py'
 
 " The Python3 provider plugin will run in a separate instance of the Python3
 " host.


### PR DESCRIPTION
Comments on this approach very welcome. I tried to explain the problem in #3349, but also put it in this PRs commit message (note that the build will fail until `neovim/python-client` has the `script_host.py`):

When a :python command is executed in an installed Neovim, script_host.py
is compiled to bytecode, resulting in a script_host.pyc file and a
`__pycache__` directory.

A distribution's package manager doesn't know about these compiled files,
though, as this only happens at runtime. The general idea is therefore to
pre-compile Python code to bytecode in the package creation step (i.e. in
or before make install). For the Python module, this is done automatically
by its setup.py. For the main neovim package, doing this is a problem, as
it would require adding a dependency on Python.

Therefore, move the script host into the neovim/python-client project to
allow precompiling.

Closes #3349.
