### PR TITLE
[RFC] garray.c: Prevent ga_concat() using memcpy(NULL,...)

### DIFF
--- a/src/nvim/garray.c
+++ b/src/nvim/garray.c
@@ -184,10 +184,12 @@ char_u* ga_concat_strings(const garray_T *gap) FUNC_ATTR_NONNULL_RET
 void ga_concat(garray_T *gap, const char_u *restrict s)
 {
   int len = (int)strlen((char *) s);
-  ga_grow(gap, len);
-  char *data = gap->ga_data;
-  memcpy(data + gap->ga_len, s, (size_t) len);
-  gap->ga_len += len;
+  if (len) {
+    ga_grow(gap, len);
+    char *data = gap->ga_data;
+    memcpy(data + gap->ga_len, s, (size_t)len);
+    gap->ga_len += len;
+  }
 }
 
 /// Append one byte to a growarray which contains bytes.


### PR DESCRIPTION
garray.c: Prevent ga_concat() using memcpy(NULL,...)

Calling ga_grow(gap, 0) does not reallocate memory for garray gap.
Because of this, gap->ga_data can be NULL after such a call, if gap does
not have memory allocated.

Found by ASAN while using #3360:

```
/home/oni-link/git/neovim/src/nvim/garray.c:189:10: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:47:28: note: nonnull attribute specified here
SUMMARY: AddressSanitizer: undefined-behavior /home/oni-link/git/neovim/src/nvim/garray.c:189:10 in 
```
