### PR TITLE
[RFC] Disable a broken functional test.

### DIFF
--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -551,7 +551,8 @@ describe('Screen', function()
       ]])
     end)
 
-    it('has minimum width/height values', function()
+    -- FIXME this has some race conditions that cause it to fail periodically
+    pending('has minimum width/height values', function()
       screen:try_resize(1, 1)
       screen:expect([[
         -- INS^ERT --|


### PR DESCRIPTION
No one has taken a real interest in fixing this, so let's disable it for
now.  The issue crops up most on the QB OS X node, but it has
periodically occurred under other nodes too.
