### PR TITLE
[RFC] spell.c: Fix memory leak

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -8583,6 +8583,7 @@ void spell_suggest(int count)
     curwin->w_cursor = prev_cursor;
 
   spell_find_cleanup(&sug);
+  xfree(line);
 }
 
 // Check if the word at line "lnum" column "col" is required to start with a


### PR DESCRIPTION
spell.c: Fix memory leak

Found by ASAN when using spell checking and `z=`:

``` c
==24300==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x4d96d8 in malloc /home/oni-link/git/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:40
    #1 0xabd954 in try_malloc /home/oni-link/git/neovim/src/nvim/memory.c:62:15
    #2 0xabdb94 in xmalloc /home/oni-link/git/neovim/src/nvim/memory.c:96:15
    #3 0xabdfd3 in xmallocz /home/oni-link/git/neovim/src/nvim/memory.c:171:15
    #4 0xabe098 in xmemdupz /home/oni-link/git/neovim/src/nvim/memory.c:189:17
    #5 0xabeb52 in xstrdup /home/oni-link/git/neovim/src/nvim/memory.c:381:10
    #6 0x1482e14 in vim_strsave /home/oni-link/git/neovim/src/nvim/strings.c:54:20
    #7 0x6e62bb in spell_suggest /home/oni-link/git/neovim/src/nvim/spell.c:8448:10
    #8 0xf93367 in nv_zet /home/oni-link/git/neovim/src/nvim/normal.c:4008:7
    #9 0xef68d3 in normal_cmd /home/oni-link/git/neovim/src/nvim/normal.c:912:3
    #10 0xec9285 in main_loop /home/oni-link/git/neovim/src/nvim/main.c:748:7
    #11 0xeb4dd8 in main /home/oni-link/git/neovim/src/nvim/main.c:535:3
    #12 0x7fdd0b593f9f in __libc_start_main (/lib64/libc.so.6+0x1ff9f)

SUMMARY: AddressSanitizer: 5 byte(s) leaked in 1 allocation(s).

```
