### PR TITLE
[RFC] test: Adding shell unit test

### DIFF
--- a/test/unit/os/shell_spec.lua
+++ b/test/unit/os/shell_spec.lua
@@ -68,5 +68,11 @@ describe('shell functions', function()
       eq(input, output)
       eq(0, status)
     end)
+
+    it ('can deal with non-existent command', function()
+      local cmd = 'this_cmd_dne12345'
+      local status, output = os_system(cmd)
+      eq(127, status)
+    end)
   end)
 end)

--- a/test/unit/os/shell_spec.lua
+++ b/test/unit/os/shell_spec.lua
@@ -69,10 +69,11 @@ describe('shell functions', function()
       eq(0, status)
     end)
 
-    it ('can deal with non-existent command', function()
-      local cmd = 'this_cmd_dne12345'
+    it ('can return non-zero command execution results', function()
+      local ret = 2
+      local cmd = 'exit' .. ' ' .. ret
       local status, output = os_system(cmd)
-      eq(127, status)
+      eq(ret, status)
     end)
   end)
 end)


### PR DESCRIPTION
It confirms that a non-existent command returns a 127 error code
(showing that system() handles non-existent commands).
