### PR TITLE
[RDY] represent api type String as msgpack type STR.

### DIFF
--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -175,7 +175,7 @@ Nil				  -> msgpack nil
 Boolean				  -> msgpack boolean
 Integer (signed 64-bit integer)	  -> msgpack integer
 Float (IEEE 754 double precision) -> msgpack float
-String				  -> msgpack binary
+String				  -> msgpack string
 Array				  -> msgpack array
 Dictionary			  -> msgpack map
 

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -225,8 +225,8 @@ void msgpack_rpc_from_float(Float result, msgpack_packer *res)
 void msgpack_rpc_from_string(String result, msgpack_packer *res)
   FUNC_ATTR_NONNULL_ARG(2)
 {
-  msgpack_pack_bin(res, result.size);
-  msgpack_pack_bin_body(res, result.data, result.size);
+  msgpack_pack_str(res, result.size);
+  msgpack_pack_str_body(res, result.data, result.size);
 }
 
 void msgpack_rpc_from_object(Object result, msgpack_packer *res)
@@ -332,8 +332,7 @@ void msgpack_rpc_serialize_request(uint64_t request_id,
     msgpack_pack_uint64(pac, request_id);
   }
 
-  msgpack_pack_bin(pac, method.size);
-  msgpack_pack_bin_body(pac, method.data, method.size);
+  msgpack_rpc_from_string(method, pac);
   msgpack_rpc_from_array(args, pac);
 }
 

--- a/test/functional/eval/msgpack_functions_spec.lua
+++ b/test/functional/eval/msgpack_functions_spec.lua
@@ -452,12 +452,12 @@ describe('msgpackparse() function', function()
   end)
 
   it('msgpackparse(systemlist(...)) does not segfault. #3135', function()
-    local cmd = "msgpackparse(systemlist('"
-      ..helpers.nvim_prog.." --api-info'))['_TYPE']['_VAL'][0][0]"
+    local cmd = "sort(keys(msgpackparse(systemlist('"
+      ..helpers.nvim_prog.." --api-info'))[0]))"
     local api_info = eval(cmd)
     api_info = eval(cmd) -- do it again (try to force segfault)
     api_info = eval(cmd) -- do it again
-    eq('functions', api_info)
+    eq({'error_types', 'functions', 'types'}, api_info)
   end)
 
   it('fails when called with no arguments', function()


### PR DESCRIPTION
This changes the msgpack representations of strings in nvim from BIN to STR, as disscussed in #1250 (Only affects strings sent from nvim to clients, nvim already accepts both BIN and STR from clients).

Note that only `encoding=utf-8` is fully supported, no conversion is done for other `&encoding`s. This is already case when recieving utf-8 STR in requests, where no conversion is done for other encodings. As decided in #1250 remote plugins/GUIs are free to always assume `encoding=utf-8`.

I have checked python-client (both py2 and py3) and lua-client still works without changes, to the extent that tests still pass (except for unrelated failure in python also on master), but it would be good to check this in more clients before merging this. A client could be made compatible with nvim both before and after this change (by doing the right thing both when BIN and STR is recieved), so they can be updated if needed before this is merged.

ping @myitcv @nhynes @equalsraf @saep @rogual and anyone else implementing an API client/GUI.
