### PR TITLE
[RFC] Implement handling of terminal focus events

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -977,6 +977,14 @@ static int insert_handle_key(InsertState *s)
     queue_process_events(loop.events);
     break;
 
+  case K_FOCUSGAINED:  // Neovim has been given focus
+    apply_autocmds(EVENT_FOCUSGAINED, NULL, NULL, false, curbuf);
+    break;
+
+  case K_FOCUSLOST:   // Neovim has lost focus
+    apply_autocmds(EVENT_FOCUSLOST, NULL, NULL, false, curbuf);
+    break;
+
   case K_HOME:        // <Home>
   case K_KHOME:
   case K_S_HOME:

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -284,6 +284,8 @@ static struct key_name_entry {
   {K_SNR,             (char_u *)"SNR"},
   {K_PLUG,            (char_u *)"Plug"},
   {K_PASTE,           (char_u *)"Paste"},
+  {K_FOCUSGAINED,     (char_u *)"FocusGained"},
+  {K_FOCUSLOST,       (char_u *)"FocusLost"},
   {0,                 NULL}
 };
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -349,6 +349,8 @@ static const struct nv_cmd {
   {K_F8,      farsi_fkey,     0,                      0},
   {K_F9,      farsi_fkey,     0,                      0},
   {K_EVENT,   nv_event,       NV_KEEPREG,             0},
+  {K_FOCUSGAINED, nv_focusgained, NV_KEEPREG,         0},
+  {K_FOCUSLOST,   nv_focuslost,   NV_KEEPREG,         0},
 };
 
 /* Number of commands in nv_cmds[]. */
@@ -7713,6 +7715,18 @@ static void nv_event(cmdarg_T *cap)
   may_garbage_collect = false;
   queue_process_events(loop.events);
   cap->retval |= CA_COMMAND_BUSY;       // don't call edit() now
+}
+
+/// Trigger FocusGained event.
+static void nv_focusgained(cmdarg_T *cap)
+{
+  apply_autocmds(EVENT_FOCUSGAINED, NULL, NULL, false, curbuf);
+}
+
+/// Trigger FocusLost event.
+static void nv_focuslost(cmdarg_T *cap)
+{
+  apply_autocmds(EVENT_FOCUSLOST, NULL, NULL, false, curbuf);
 }
 
 /*

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -66,6 +66,7 @@ typedef struct {
     int enable_bracketed_paste, disable_bracketed_paste;
     int enter_insert_mode, enter_replace_mode, exit_insert_mode;
     int set_rgb_foreground, set_rgb_background;
+    int enable_focus_reporting, disable_focus_reporting;
   } unibi_ext;
 } TUIData;
 
@@ -120,6 +121,8 @@ static void terminfo_start(UI *ui)
   data->unibi_ext.enter_insert_mode = -1;
   data->unibi_ext.enter_replace_mode = -1;
   data->unibi_ext.exit_insert_mode = -1;
+  data->unibi_ext.enable_focus_reporting = -1;
+  data->unibi_ext.disable_focus_reporting = -1;
   data->out_fd = 1;
   data->out_isatty = os_isatty(data->out_fd);
   // setup unibilium
@@ -135,6 +138,8 @@ static void terminfo_start(UI *ui)
   unibi_out(ui, unibi_clear_screen);
   // Enable bracketed paste
   unibi_out(ui, data->unibi_ext.enable_bracketed_paste);
+  // Enable focus reporting
+  unibi_out(ui, data->unibi_ext.enable_focus_reporting);
   uv_loop_init(&data->write_loop);
   if (data->out_isatty) {
     uv_tty_init(&data->write_loop, &data->output_handle.tty, data->out_fd, 0);
@@ -157,6 +162,8 @@ static void terminfo_stop(UI *ui)
   unibi_out(ui, unibi_exit_ca_mode);
   // Disable bracketed paste
   unibi_out(ui, data->unibi_ext.disable_bracketed_paste);
+  // Disable focus reporting
+  unibi_out(ui, data->unibi_ext.disable_focus_reporting);
   flush_buf(ui);
   uv_tty_reset_mode();
   uv_close((uv_handle_t *)&data->output_handle, NULL);
@@ -806,6 +813,11 @@ static void fix_terminfo(TUIData *data)
       "\x1b[?2004h");
   data->unibi_ext.disable_bracketed_paste = (int)unibi_add_ext_str(ut, NULL,
       "\x1b[?2004l");
+
+  data->unibi_ext.enable_focus_reporting = (int)unibi_add_ext_str(ut, NULL,
+      "\x1b[?1004h");
+  data->unibi_ext.disable_focus_reporting = (int)unibi_add_ext_str(ut, NULL,
+      "\x1b[?1004l");
 
 #define XTERM_SETAF \
   "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m"

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -148,6 +148,32 @@ describe('tui', function()
       -- TERMINAL --                                    |
     ]])
   end)
+
+  it('can handle focus events', function()
+    execute('autocmd FocusGained * echo "gained"')
+    execute('autocmd FocusLost * echo "lost"')
+    feed('\x1b[I')
+    screen:expect([[
+      {1: }                                                 |
+      ~                                                 |
+      ~                                                 |
+      ~                                                 |
+      [No Name]                                         |
+      gained                                            |
+      -- TERMINAL --                                    |
+    ]])
+
+    feed('\x1b[O')
+    screen:expect([[
+      {1: }                                                 |
+      ~                                                 |
+      ~                                                 |
+      ~                                                 |
+      [No Name]                                         |
+      lost                                              |
+      -- TERMINAL --                                    |
+    ]])
+  end)
 end)
 
 describe('tui with non-tty file descriptors', function()


### PR DESCRIPTION
Two new keys have been added to key_name_entry in keymap.c:
`FocusGained` and `FocusLost`.

Two cases have been added to the key handing switch in edit.c each
applying their respective autocmds.

In normal.c two functions have been added alongside nv_cursorhold doing
a similar job of applying the autocmd for the appropriate key.

tui/input.c has a new function `handle_focus_event` which eats either of
the control sequences for focus gained or lost. This function is checked
before handle_bracketed_paste and handle_forced_escape.

tui.c registers neovim as able to receive these control sequences in
terminfo_start and undoes that in terminfo_stop.

Closes #2302
