### PR TITLE
[RFC] tutor: fix location for init.vim file

### DIFF
--- a/runtime/tutor/en/vim-01-beginner.tutor
+++ b/runtime/tutor/en/vim-01-beginner.tutor
@@ -883,8 +883,7 @@ Vim has many more features than Vi, but most of them are disabled by
 default.  To start using more features you have to create a "vimrc" file.
 
   1. Start editing the "vimrc" file.  This depends on your system:
-    `:e ~/.vimrc`{vim}     for Unix-like systems
-    `:e $VIM/_vimrc`{vim}      for Microsoft Windows
+    `:e ~/config/nvim/init.vim`{vim}     for Unix-like systems
 
   2. Now read the example "vimrc" file contents:
     `:r $VIMRUNTIME/vimrc_example.vim`{vim}


### PR DESCRIPTION
The tutorial still pointed to ~/.nvimrc
