### PR TITLE
Make jemalloc optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,12 +260,16 @@ if((CLANG_ASAN_UBSAN OR CLANG_MSAN OR CLANG_TSAN) AND NOT CMAKE_C_COMPILER_ID MA
   message(FATAL_ERROR "Sanitizers are only supported for Clang.")
 endif()
 
-if(CLANG_ASAN_UBSAN OR CLANG_MSAN OR CLANG_TSAN)
-  message(STATUS "Sanitizers have been enabled; don't use jemalloc.")
-else()
-  find_package(JeMalloc)
-  if(JEMALLOC_FOUND)
-    include_directories(SYSTEM ${JEMALLOC_INCLUDE_DIRS})
+option(ENABLE_JEMALLOC "enable jemalloc" OFF)
+
+if (ENABLE_JEMALLOC)
+  if(CLANG_ASAN_UBSAN OR CLANG_MSAN OR CLANG_TSAN)
+    message(STATUS "Sanitizers have been enabled; don't use jemalloc.")
+  else()
+    find_package(JeMalloc)
+    if(JEMALLOC_FOUND)
+      include_directories(SYSTEM ${JEMALLOC_INCLUDE_DIRS})
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
I am packaging neovim for Gentoo and realized that jemalloc is what Gentoo calls an [automagic dependency](https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Automagic_dependencies). This PR makes jemalloc optional even if it's installed.
