### PR TITLE
[RFC] Fix crashes with very long lines

### DIFF
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1291,7 +1291,7 @@ int plines_win_nofold(win_T *wp, linenr_T lnum)
    * Add column offset for 'number', 'relativenumber' and 'foldcolumn'.
    */
   width = wp->w_width - win_col_off(wp);
-  if (width <= 0)
+  if (width <= 0 || col > 32000)
     return 32000;
   if (col <= (unsigned int)width)
     return 1;


### PR DESCRIPTION
This commit ignores virtcols after the 32000th in some computations, in
order to avoid crashing or hanging when editing a file than contains
ludicrously long lines (more than 100,000,000 virtual columns).

The change is in plines_win_nofold, which is called by wrapping and folding
code. As a result, wrapping and folding will be done incorrectly for lines longer
than 32000 virtual columns. This has zero impact if the UI cannot render more
than 32000 characters at a time (which is usually the case).

fixes #2838 (see that issue for further discussion).
