### PR TITLE
runtime: add Python 'async' and 'await' syntax highlighting

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -74,6 +74,7 @@ set cpo&vim
 syn keyword pythonStatement	False, None, True
 syn keyword pythonStatement	as assert break continue del exec global
 syn keyword pythonStatement	lambda nonlocal pass print return with yield
+syn keyword pythonStatement	async await
 syn keyword pythonStatement	class def nextgroup=pythonFunction skipwhite
 syn keyword pythonConditional	elif else if
 syn keyword pythonRepeat	for while


### PR DESCRIPTION
Python 3.5 add two new keywords `async` & `await`.
