### PR TITLE
[RFC] write .nvimlog to $XDG_DATA_HOME/nvimlog

### DIFF
--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -27,9 +27,9 @@ static char * log_file_dir;
 void log_init(void)
 {
   uv_mutex_init(&mutex);
-  //determine where to save the log file
+  // determine where to save the log file
   log_file_dir = getenv("NVIM_LOG_FILE");
-  //TODO: add checks to see if NVIM_LOG_FILE is a valid path
+  // TODO(5pacetoast): add checks to see if NVIM_LOG_FILE is a valid path
   if (log_file_dir == NULL) {
       log_file_dir = stdpaths_user_data_subpath("log", 0);
   }

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -80,10 +80,11 @@ FILE *open_log_file(void)
   FILE *log_file;
   opening_log_file = true;
   {
-    char * const data_dir = stdpaths_get_xdg_var(kXDGDataHome);
-    char * const expanded_log_file_path = concat_fnames_realloc(data_dir,"nvimlog", true);
+    char * dir = stdpaths_get_xdg_var(kXDGDataHome);
+    dir = concat_fnames_realloc(dir,"nvimlog", true);
 
-    log_file = fopen(expanded_log_file_path, "a");
+    log_file = fopen(dir, "a");
+    free(dir);
     if (log_file == NULL) {
       goto open_log_file_error;
     }

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "nvim/log.h"
 #include "nvim/types.h"
@@ -25,8 +26,13 @@ static char * log_file_dir;
 void log_init(void)
 {
   uv_mutex_init(&mutex);
-  log_file_dir = stdpaths_get_xdg_var(kXDGDataHome);
-  log_file_dir = concat_fnames_realloc(log_file_dir, "nvim/log", true);
+  //determine where to save the log file
+  log_file_dir = getenv("NVIM_LOG_FILE");
+  //TODO: add checks to see if NVIM_LOG_FILE is a valid path
+  if (log_file_dir == NULL) {
+      log_file_dir = stdpaths_get_xdg_var(kXDGDataHome);
+      log_file_dir = concat_fnames_realloc(log_file_dir, "nvim/log", true);
+  }
 }
 
 void log_lock(void)

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -81,10 +81,10 @@ FILE *open_log_file(void)
   opening_log_file = true;
   {
     char * dir = stdpaths_get_xdg_var(kXDGDataHome);
-    dir = concat_fnames_realloc(dir,"nvimlog", true);
+    dir = concat_fnames_realloc(dir, "nvimlog", true);
 
     log_file = fopen(dir, "a");
-    free(dir);
+    xfree(dir);
     if (log_file == NULL) {
       goto open_log_file_error;
     }

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -81,7 +81,7 @@ FILE *open_log_file(void)
   opening_log_file = true;
   {
     char * dir = stdpaths_get_xdg_var(kXDGDataHome);
-    dir = concat_fnames_realloc(dir, "nvimlog", true);
+    dir = concat_fnames_realloc(dir, "nvim/log", true);
 
     log_file = fopen(dir, "a");
     xfree(dir);

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -18,7 +18,7 @@
 #endif
 
 static uv_mutex_t mutex;
-static char * log_file_dir;
+static char log_file_dir[MAXPATHL +1];
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "log.c.generated.h"
@@ -27,11 +27,19 @@ static char * log_file_dir;
 void log_init(void)
 {
   uv_mutex_init(&mutex);
-  // determine where to save the log file
-  log_file_dir = getenv("NVIM_LOG_FILE");
+  const char * envdir = os_getenv("NVIM_LOG_FILE");
   // TODO(5pacetoast): add checks to see if NVIM_LOG_FILE is a valid path
-  if (log_file_dir == NULL) {
-      log_file_dir = stdpaths_user_data_subpath("log", 0);
+  if (envdir == NULL) {
+      char * pathdir = stdpaths_user_data_subpath("log", 0);
+      char pathdir_glob[MAXPATHL+1];
+      if(strcmp(pathdir, pathdir_glob) == 0) {
+          // expand_env seems to always fail here
+          printf("expand_env failed!\n");
+      }
+      xfree(pathdir);
+      strncpy(log_file_dir, (char *)pathdir_glob, MAXPATHL);
+  } else {
+      strncpy(log_file_dir, envdir, MAXPATHL);
   }
 }
 

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "nvim/log.h"
 #include "nvim/types.h"
@@ -30,8 +31,7 @@ void log_init(void)
   log_file_dir = getenv("NVIM_LOG_FILE");
   //TODO: add checks to see if NVIM_LOG_FILE is a valid path
   if (log_file_dir == NULL) {
-      log_file_dir = stdpaths_get_xdg_var(kXDGDataHome);
-      log_file_dir = concat_fnames_realloc(log_file_dir, "nvim/log", true);
+      log_file_dir = stdpaths_user_data_subpath("log", 0);
   }
 }
 

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -16,6 +16,7 @@
 #endif
 
 static uv_mutex_t mutex;
+static char * log_file_dir;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "log.c.generated.h"
@@ -24,6 +25,8 @@ static uv_mutex_t mutex;
 void log_init(void)
 {
   uv_mutex_init(&mutex);
+  log_file_dir = stdpaths_get_xdg_var(kXDGDataHome);
+  log_file_dir = concat_fnames_realloc(log_file_dir, "nvim/log", true);
 }
 
 void log_lock(void)
@@ -80,11 +83,7 @@ FILE *open_log_file(void)
   FILE *log_file;
   opening_log_file = true;
   {
-    char * dir = stdpaths_get_xdg_var(kXDGDataHome);
-    dir = concat_fnames_realloc(dir, "nvim/log", true);
-
-    log_file = fopen(dir, "a");
-    xfree(dir);
+    log_file = fopen(log_file_dir, "a");
     if (log_file == NULL) {
       goto open_log_file_error;
     }


### PR DESCRIPTION
Log file is now saved into $XDG_DATA_HOME/nvimlog.

Unfortunately, we recalculate where that is every time we want to open the log file, but this shouldn't be a big problem (the expensive part is the IO operation of opening the file, the calculation itself is trivial (+ a small realloc)).
