### PR TITLE
runtime/autoload/provider/python{,3}.vim: fix E168

### DIFF
--- a/runtime/autoload/provider/python.vim
+++ b/runtime/autoload/provider/python.vim
@@ -46,7 +46,7 @@ function! provider#python#Call(method, args)
       echohl WarningMsg
       echomsg v:exception
       echohl None
-      finish
+      return
     endtry
   endif
   return call(s:rpcrequest, insert(insert(a:args, 'python_'.a:method), s:host))

--- a/runtime/autoload/provider/python3.vim
+++ b/runtime/autoload/provider/python3.vim
@@ -46,7 +46,7 @@ function! provider#python3#Call(method, args)
       echohl WarningMsg
       echomsg v:exception
       echohl None
-      finish
+      return
     endtry
   endif
   return call(s:rpcrequest, insert(insert(a:args, 'python_'.a:method), s:host))


### PR DESCRIPTION
Do not use `finish` inside of `provider#python{,3}#Call`, but `return`.

This fixes the `E168` in this case:

```
Vim(if):Channel was closed by the client                                                      
Failed to load Python host. You can try to see what happened by starting Neovim with the envir
onment variable $NVIM_PYTHON_LOG_FILE set to a file and opening the generated log file. Also, 
the host stderr will be available in Neovim log, so it may contain useful information. See als
o ~/.nvimlog.                                                                                 
Error detected while processing function provider#python#Call:                                
line   15:                                                                                    
E168: :finish used outside of a sourced file                                                  
YouCompleteMe unavailable: YCM support libs too old, PLEASE RECOMPILE                         
Press ENTER or type command to continue
```
