### PR TITLE
Ensure a session is running before attempting to do Python detection.

### DIFF
--- a/test/functional/provider/python3_spec.lua
+++ b/test/functional/provider/python3_spec.lua
@@ -4,6 +4,7 @@ local eq, clear, insert = helpers.eq, helpers.clear, helpers.insert
 local expect, write_file = helpers.expect, helpers.write_file
 
 do
+  clear()
   command('let [g:interp, g:errors] = provider#pythonx#Detect(3)')
   local errors = eval('g:errors')
   if errors ~= '' then

--- a/test/functional/provider/python_spec.lua
+++ b/test/functional/provider/python_spec.lua
@@ -4,6 +4,7 @@ local eq, clear, insert = helpers.eq, helpers.clear, helpers.insert
 local expect, write_file = helpers.expect, helpers.write_file
 
 do
+  clear()
   command('let [g:interp, g:errors] = provider#pythonx#Detect(2)')
   local errors = eval('g:errors')
   if errors ~= '' then


### PR DESCRIPTION
I discovered this while running tests on a Linux box:

``` text
not ok 482 - suite test/functional/provider/python_spec.lua
# ./test/functional/helpers.lua @ 65
# Failure message: ./test/functional/helpers.lua:65: attempt to index upvalue 'session' (a nil value)
# stack traceback:
#   ./test/functional/helpers.lua:65: in function 'request'
#   ./test/functional/helpers.lua:129: in function 'command'
#   test/functional/provider/python_spec.lua:7: in main chunk
```
