### PR TITLE
[RFC] doc: Gender-neutral pronouns

### DIFF
--- a/runtime/autoload/getscript.vim
+++ b/runtime/autoload/getscript.vim
@@ -393,7 +393,7 @@ fun! s:GetOneScript(...)
 "   call Decho("fname   <".fname.">")
   endif
 
-  " plugin author protection from downloading his/her own scripts atop their latest work
+  " plugin author protection from downloading their own scripts atop their latest work
   if scriptid == 0 || srcid == 0
    " When looking for :AutoInstall: lines, skip scripts that have   0 0 scriptname
    let @a= rega

--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -7760,7 +7760,7 @@ fun! s:NetrwPrevWinOpen(islocal)
 
    " if the previous window's buffer has been changed (ie. its modified flag is set),
    " and it doesn't appear in any other extant window, then ask the
-   " user if s/he wants to abandon modifications therein.
+   " user if they want to abandon modifications therein.
    if prevmod
 "    call Decho("detected that prev window's buffer has been modified: prevbufnr=".prevbufnr." winnr()#".winnr())
     windo if winbufnr(0) == prevbufnr | let bnrcnt=bnrcnt+1 | endif
@@ -9690,7 +9690,7 @@ endfun
 " s:LocalBrowseRefresh: this function is called after a user has {{{2
 " performed any shell command.  The idea is to cause all local-browsing
 " buffers to be refreshed after a user has executed some shell command,
-" on the chance that s/he removed/created a file/directory with it.
+" on the chance that they removed/created a file/directory with it.
 fun! s:LocalBrowseRefresh()
 "  call Dfunc("s:LocalBrowseRefresh() tabpagenr($)=".tabpagenr("$"))
 "  call Decho("s:netrw_browselist =".(exists("s:netrw_browselist")?  string(s:netrw_browselist)  : '<n/a>'))

--- a/runtime/autoload/netrwSettings.vim
+++ b/runtime/autoload/netrwSettings.vim
@@ -44,7 +44,7 @@ fun! netrwSettings#NetrwSettings()
   file Netrw\ Settings
 
   " these variables have the following default effects when they don't
-  " exist (ie. have not been set by the user in his/her .vimrc)
+  " exist (ie. have not been set by the user in their .vimrc)
   if !exists("g:netrw_liststyle")
    let g:netrw_liststyle= 0
    let g:netrw_list_cmd= "ssh HOSTNAME ls -FLa"

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -33,7 +33,7 @@ balance must be found between them.
 VIM IS... VI COMPATIBLE					*design-compatible*
 
 First of all, it should be possible to use Vim as a drop-in replacement for
-Vi.  When the user wants to, he can use Vim in compatible mode and hardly
+Vi.  When the user wants to, they can use Vim in compatible mode and hardly
 notice any difference with the original Vi.
 
 Exceptions:

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1257,7 +1257,7 @@ command has not been used stick to the global current directory.  When jumping
 to another window the current directory will become the last specified local
 current directory.  If none was specified, the global current directory is
 used.
-When a |:cd| command is used, the current window will lose his local current
+When a |:cd| command is used, the current window will lose its local current
 directory and will use the global current directory from now on.
 
 After using |:cd| the full path name will be used for reading and writing

--- a/runtime/doc/mlang.txt
+++ b/runtime/doc/mlang.txt
@@ -120,7 +120,7 @@ See |45.2| for the basics, esp. using 'langmenu'.
 
 Note that if changes have been made to the menus after the translation was
 done, some of the menus may be shown in English.  Please try contacting the
-maintainer of the translation and ask him to update it.  You can find the
+maintainer of the translation and ask them to update it.  You can find the
 name and e-mail address of the translator in
 "$VIMRUNTIME/lang/menu_<lang>.vim".
 

--- a/runtime/doc/pi_getscript.txt
+++ b/runtime/doc/pi_getscript.txt
@@ -149,7 +149,7 @@ vim.sf.net; whenever it is greater than the one stored in the
 GetLatestVimScripts.dat file, the script will be downloaded
 (see |GetLatestVimScripts_dat|).
 
-If your script's author has included a special comment line in his/her plugin,
+If your script's author has included a special comment line in their plugin,
 the plugin itself will be used by GetLatestVimScripts to build your
 <GetLatestVimScripts.dat> file, including any dependencies on other scripts it
 may have.  As an example, consider: >
@@ -177,7 +177,7 @@ In summary:
 <   in an already-downloaded plugin constitutes the concurrence of the
     plugin author that getscript may do AutoInstall.  Not all plugins
     may be AutoInstall-able, and the plugin's author is best situated
-    to know whether or not his/her plugin will AutoInstall properly.
+    to know whether or not their plugin will AutoInstall properly.
 
   * A line such as >
 	884 1 :AutoInstall: AutoAlign.vim
@@ -334,7 +334,7 @@ after/syntax/c.vim contained in it to overwrite a user's c.vim.
 <	default= 1
 		This variable indicates whether GetLatestVimScripts is allowed
 		to attempt to automatically install scripts.  Furthermore, the
-		plugin author has to have explicitly indicated that his/her
+		plugin author has to have explicitly indicated that their
 		plugin is automatically installable (via the :AutoInstall:
 		keyword in the GetLatestVimScripts comment line).
 >

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -2991,7 +2991,7 @@ will be horizontally split (by default).
 If there's more than one window, the previous window will be re-used on
 the selected file/directory.  If the previous window's associated buffer
 has been modified, and there's only one window with that buffer, then
-the user will be asked if s/he wishes to save the buffer first (yes,
+the user will be asked if they wish to save the buffer first (yes,
 no, or cancel).
 
 Related Actions |netrw-cr| |netrw-o| |netrw-t| |netrw-v|

--- a/runtime/doc/recover.txt
+++ b/runtime/doc/recover.txt
@@ -54,7 +54,7 @@ Disadvantages:
   directories (although Vim tries to avoid that by comparing the path name).
   This will result in bogus ATTENTION warning messages.
 - When you use your home directory, and somebody else tries to edit the same
-  file, he will not see your swap file and will not get the ATTENTION warning
+  file, they will not see your swap file and will not get the ATTENTION warning
   message.
 
 If you want to put swap files in a fixed place, put a command resembling the

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -208,7 +208,7 @@ A syntax group name doesn't specify any color or attributes itself.
 The name for a highlight or syntax group must consist of ASCII letters, digits
 and the underscore.  As a regexp: "[a-zA-Z0-9_]*"
 
-To be able to allow each user to pick his favorite set of colors, there must
+To be able to allow each user to pick their favorite set of colors, there must
 be preferred names for highlight groups that are common for many languages.
 These are the suggested group names (if syntax highlighting works properly
 you can see the actual color, except for "Ignore"):
@@ -1895,7 +1895,7 @@ LEX						*lex.vim* *ft-lex-syntax*
 Lex uses brute-force synchronizing as the "^%%$" section delimiter
 gives no clue as to what section follows.  Consequently, the value for >
 	:syn sync minlines=300
-may be changed by the user if s/he is experiencing synchronization
+may be changed by the user if they are experiencing synchronization
 difficulties (such as may happen with large lex files).
 
 
@@ -2819,7 +2819,7 @@ variables in your vimrc:
 <   sh: (default) Bourne shell >
 	let g:is_sh	   = 1
 
-If there's no "#! ..." line, and the user hasn't availed himself/herself of a
+If there's no "#! ..." line, and the user hasn't availed themself of a
 default sh.vim syntax setting as just shown, then syntax/sh.vim will assume
 the Bourne shell syntax.  No need to quote RFCs or market penetration
 statistics in error reports, please -- just select the default version of the
@@ -4198,8 +4198,8 @@ two different ways:
 	  (e.g., "syntax/pod.vim") the file is searched for in 'runtimepath'.
 	  All matching files are loaded.  Using a relative path is
 	  recommended, because it allows a user to replace the included file
-	  with his own version, without replacing the file that does the ":syn
-	  include".
+	  with their own version, without replacing the file that does the
+	  ":syn include".
 
 						*E847*
 The maximum number of includes is 999.

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1557,7 +1557,7 @@ Windows installer: licence text should not use indent, causes bad word wrap.
 (Benjamin Fritz, 2010 Aug 16)
 
 Dos uninstal may delete vim.bat from the wrong directory (e.g., when someone
-makes his own wrapper).  Add a magic string with the version number to the
+makes their own wrapper).  Add a magic string with the version number to the
 .bat file and check for it in the uninstaller.  E.g.
           # uninstall key: vim7.3*
 
@@ -2365,7 +2365,7 @@ Macintosh:
     two lines at a time.  "k" doesn't do this. (Cory T. Echols)
 8   When write_viminfo() is used while there are many orphaned viminfo
     tempfiles writing the viminfo file fails.  Give a clear error message so
-    that the user knows he has to delete the files.
+    that the user knows they have to delete the files.
 7   It's possible to redefine a script-local function with ":func
     <SNR>123_Test()". (Krishna)  Disallow this.
 
@@ -2508,8 +2508,8 @@ Help:
 -   Default mapping for help files: <Tab> to position cursor on next |:tag|.
 -   Implement a "sticky" help window, some help text lines that are always
     displayed in a window with fixed height. (Guckes)  Use "~/.vimhelp" file,
-    user can edit it to insert his favorite commands, new account can contain a
-    default contents.
+    user can edit it to insert their favorite commands, new account can
+    contain a default contents.
 -   Make 'winminheight' a local option, so that the user can set a minimal
     height for the help window (and other windows).
 -   ":help :s^I" should expand to ":help :substitute".
@@ -4244,7 +4244,7 @@ Modelines:
     .cpp files.
 -   Support the "abbreviate" command in modelines (Kearns).  Careful for
     characters after <Esc>, that is a security leak.
--   Add option setting to ask user if he wants to have the modelines executed
+-   Add option setting to ask user if they want to have the modelines executed
     or not.  Same for .exrc in local dir.
 
 

--- a/runtime/doc/usr_25.txt
+++ b/runtime/doc/usr_25.txt
@@ -366,7 +366,7 @@ displaying the line.  The text in the file remains unchanged.
 	|ank.  They wanted to send out a s|
 	|pecial, personalized letter to th|
 	|eir richest 1000 customers.  Unfo|
-	|rtunately for the programmer, he |
+	|rtunately for the programmer, the|
 	+---------------------------------+
 After: >
 

--- a/runtime/doc/usr_40.txt
+++ b/runtime/doc/usr_40.txt
@@ -335,7 +335,7 @@ Now when you type >
 Vim echoes "Hello World".  However, if you add a double quote, it won't work.
 For example: >
 
-	:Say he said "hello"
+	:Say she said "hello"
 
 To get special characters turned into a string, properly escaped to use as an
 expression, use "<q-args>": >
@@ -344,7 +344,7 @@ expression, use "<q-args>": >
 
 Now the above ":Say" command will result in this to be executed: >
 
-	:echo "he said \"hello\""
+	:echo "she said \"hello\""
 
 The <f-args> keyword contains the same information as the <args> keyword,
 except in a format suitable for use as function call arguments.  For example:

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1752,8 +1752,8 @@ NOT LOADING
 
 It's possible that a user doesn't always want to load this plugin.  Or the
 system administrator has dropped it in the system-wide plugin directory, but a
-user has his own plugin he wants to use.  Then the user must have a chance to
-disable loading this specific plugin.  This will make it possible: >
+user has their own plugin they want to use.  Then the user must have a chance
+to disable loading this specific plugin.  This will make it possible: >
 
   6	if exists("g:loaded_typecorr")
   7	  finish
@@ -1785,7 +1785,7 @@ item can be used: >
 
 The "<Plug>TypecorrAdd" thing will do the work, more about that further on.
 
-The user can set the "mapleader" variable to the key sequence that he wants
+The user can set the "mapleader" variable to the key sequence that they want
 this mapping to start with.  Thus if the user has done: >
 
 	let mapleader = "_"
@@ -1796,8 +1796,8 @@ will be used, which is a backslash.  Then a map for "\a" will be defined.
 Note that <unique> is used, this will cause an error message if the mapping
 already happened to exist. |:map-<unique>|
 
-But what if the user wants to define his own key sequence?  We can allow that
-with this mechanism: >
+But what if the user wants to define their own key sequence?  We can allow
+that with this mechanism: >
 
  21	if !hasmapto('<Plug>TypecorrAdd')
  22	  map <unique> <Leader>a  <Plug>TypecorrAdd
@@ -1805,7 +1805,7 @@ with this mechanism: >
 
 This checks if a mapping to "<Plug>TypecorrAdd" already exists, and only
 defines the mapping from "<Leader>a" if it doesn't.  The user then has a
-chance of putting this in his vimrc file: >
+chance of putting this in their vimrc file: >
 
 	map ,c  <Plug>TypecorrAdd
 
@@ -1910,7 +1910,7 @@ Now let's add a user command to add a correction: >
 The user command is defined only if no command with the same name already
 exists.  Otherwise we would get an error here.  Overriding the existing user
 command with ":command!" is not a good idea, this would probably make the user
-wonder why the command he defined himself doesn't work.  |:command|
+wonder why the command they defined themself doesn't work.  |:command|
 
 
 SCRIPT VARIABLES
@@ -2162,7 +2162,7 @@ An example of how to define functionality in a filetype plugin: >
 |hasmapto()| is used to check if the user has already defined a map to
 <Plug>JavaImport.  If not, then the filetype plugin defines the default
 mapping.  This starts with |<LocalLeader>|, which allows the user to select
-the key(s) he wants filetype plugin mappings to start with.  The default is a
+the key(s) they want filetype plugin mappings to start with.  The default is a
 backslash.
 "<unique>" is used to give an error message if the mapping already exists or
 overlaps with an existing mapping.

--- a/runtime/doc/usr_42.txt
+++ b/runtime/doc/usr_42.txt
@@ -210,7 +210,7 @@ argument: >
 
 Don't use "<silent>" too often.  It is not needed for short commands.  If you
 make a menu for someone else, being able the see the executed command will
-give him a hint about what he could have typed, instead of using the mouse.
+give them a hint about what they could have typed, instead of using the mouse.
 
 
 LISTING MENUS

--- a/runtime/macros/less.vim
+++ b/runtime/macros/less.vim
@@ -2,7 +2,7 @@
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
 " Last Change:	2014 May 13
 
-" Avoid loading this file twice, allow the user to define his own script.
+" Avoid loading this file twice, allow the user to define their own script.
 if exists("loaded_less")
   finish
 endif

--- a/runtime/syntax/pyrex.vim
+++ b/runtime/syntax/pyrex.vim
@@ -27,8 +27,8 @@ syn keyword pyrexType		signed unsigned
 syn keyword pyrexStructure	struct union enum
 syn keyword pyrexInclude	include cimport
 syn keyword pyrexAccess		public private property readonly extern
-" If someome wants Python's built-ins highlighted probably he
-" also wants Pyrex's built-ins highlighted
+" If someome wants Python's built-ins highlighted probably they
+" also want Pyrex's built-ins highlighted
 if exists("python_highlight_builtins") || exists("pyrex_highlight_builtins")
     syn keyword pyrexBuiltin    NULL
 endif

--- a/runtime/tutor/tutor.tutor
+++ b/runtime/tutor/tutor.tutor
@@ -215,8 +215,8 @@ Commands to run in the system shell can be highlighted by indenting a line start
 ## INTERACTIVE ELEMENTS *interactive*
 
 As visible in this very document, vim-tutor-mode includes some interactive
-elements, to provide feedback to the user about his progress. These elements
-all have the syntax
+elements, to provide feedback to the user about their progress. These
+elements all have the syntax
 
     \---> TEXT {CLAUSE}
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19153,7 +19153,7 @@ void ex_function(exarg_T *eap)
    */
   if (KeyTyped) {
     /* Check if the function already exists, don't let the user type the
-     * whole function before telling him it doesn't work!  For a script we
+     * whole function before telling them it doesn't work!  For a script we
      * need to skip the body to be able to find what follows. */
     if (!eap->skip && !eap->forceit) {
       if (fudi.fd_dict != NULL && fudi.fd_newkey == NULL)

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3161,7 +3161,7 @@ nobackup:
    * We may try to open the file twice: If we can't write to the
    * file and forceit is TRUE we delete the existing file and try to create
    * a new one. If this still fails we may have lost the original file!
-   * (this may happen when the user reached his quotum for number of files).
+   * (this may happen when the user reached their quotum for number of files).
    * Appending will fail if the file does not exist and forceit is FALSE.
    */
   while ((fd = os_open((char *)wfname, O_WRONLY | (append

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -6349,7 +6349,7 @@ static fptr_T do_Lower(int *d, int c)
  * step further...  But we insert the previous pattern into the current one
  * and remember that.
  * This still does not handle the case where "magic" changes.  So require the
- * user to keep his hands off of "magic".
+ * user to keep their hands off of "magic".
  *
  * The tildes are parsed once before the first call to vim_regsub().
  */


### PR DESCRIPTION
Consistent and neutral pronouns throughout documentation and code
comments. Previously it was a mix of just using male pronouns, "s/he"
and "his/her".

Of the two instances of gendered pronouns used in example text, I
changed one to "she" and left one as "he".
