### PR TITLE
fix wrong indenting for class ctor caused by cin_isfuncdecl()

### DIFF
--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -766,10 +766,25 @@ static int cin_isfuncdecl(char_u **sp, linenr_T first_lnum, linenr_T min_lnum)
     return FALSE;
 
   while (*s && *s != '(' && *s != ';' && *s != '\'' && *s != '"') {
-    if (cin_iscomment(s))       /* ignore comments */
+    if (cin_iscomment(s)) {
+      /* ignore comments */
       s = cin_skipcomment(s);
-    else
+    } else if (*s == ':') {
+      if (*(s + 1) == ':') {
+        s += 2;
+      } else {
+        /* to avoid following situation
+         * A::A(int a, int b)           
+         *     : a(0)  // <--not a function decl
+         *     , b(0)                   
+         * { //...                      
+         * }                            
+         */
+        return false;
+      }
+    } else {
       ++s;
+    }
   }
   if (*s != '(')
     return FALSE;               /* ';', ' or "  before any () or no '(' */


### PR DESCRIPTION
for vi/vim and currently neovim

```
// wrong, because vim guess :aa(a) as a function decl incorrectly
// in cin_isfuncdecl()
    A::A(int a, int b)
: aa(a),
    bb(b),
    cc(c)
{}


// right
A::A(int a, int b)
    : aa(a),
    bb(b),
    cc(c)
{}
```
