### PR TITLE
third-party: enable verbose builds of luajit and libuv

### DIFF
--- a/third-party/cmake/BuildLibuv.cmake
+++ b/third-party/cmake/BuildLibuv.cmake
@@ -43,18 +43,18 @@ set(UNIX_CFGCMD sh ${DEPS_BUILD_DIR}/src/libuv/autogen.sh &&
 if(UNIX)
   BuildLibUv(
     CONFIGURE_COMMAND ${UNIX_CFGCMD}
-    INSTALL_COMMAND ${MAKE_PRG} install)
+    INSTALL_COMMAND ${MAKE_PRG} V=1 install)
 
 elseif(MINGW AND CMAKE_CROSSCOMPILING)
   # Build libuv for the host
   BuildLibUv(TARGET libuv_host
     CONFIGURE_COMMAND sh ${DEPS_BUILD_DIR}/src/libuv_host/autogen.sh && ${DEPS_BUILD_DIR}/src/libuv_host/configure --with-pic --disable-shared --prefix=${HOSTDEPS_INSTALL_DIR} CC=${HOST_C_COMPILER}
-    INSTALL_COMMAND ${MAKE_PRG} install)
+    INSTALL_COMMAND ${MAKE_PRG} V=1 install)
 
   # Build libuv for the target
   BuildLibUv(
     CONFIGURE_COMMAND ${UNIX_CFGCMD} --host=${CROSS_TARGET}
-    INSTALL_COMMAND ${MAKE_PRG} install)
+    INSTALL_COMMAND ${MAKE_PRG} V=1 install)
 
 
 elseif(WIN32 AND MSVC)

--- a/third-party/cmake/BuildLuajit.cmake
+++ b/third-party/cmake/BuildLuajit.cmake
@@ -41,6 +41,7 @@ set(INSTALLCMD_UNIX ${MAKE_PRG} CFLAGS=-fPIC
                                 CFLAGS+=-DLUA_USE_ASSERT
                                 CCDEBUG+=-g
                                 BUILDMODE=static
+                                Q=
                                 install)
 
 if(UNIX)
@@ -67,6 +68,7 @@ elseif(MINGW AND CMAKE_CROSSCOMPILING)
         HOST_CC=${HOST_C_COMPILER} HOST_CFLAGS=${HOST_C_FLAGS}
         HOST_LDFLAGS=${HOST_EXE_LINKER_FLAGS}
         FILE_T=luajit.exe
+        Q=
         INSTALL_TSYMNAME=luajit.exe)
 
 elseif(WIN32 AND MSVC)


### PR DESCRIPTION
Libuv and LuaJIT like to hide the actual compilation and linking
commands behind nice text.  This change makes them spit out the actual
command line to help us with debugging issues that people are seeing.
