### PR TITLE
[RFC] Remove all invalid nvimrc references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ If your issue isn't mentioned there:
     - For runtime issues, see
       [Troubleshooting#runtime-issues][wiki-troubleshooting-runtime-issues].
       If your issue isn't mentioned there, try to reproduce your it using
-      `nvim` with the smallest possible `nvimrc` (or none at all via `nvim -u
+      `nvim` with the smallest possible `vimrc` (or none at all via `nvim -u
       NONE`), to rule out bugs in plugins you're using.
       If you're using a plugin manager, comment out your plugins, then add
       them back in one by one.

--- a/contrib/YouCompleteMe/README.md
+++ b/contrib/YouCompleteMe/README.md
@@ -17,6 +17,6 @@ cp contrib/YouCompleteMe/ycm_extra_conf.py src/.ycm_extra_conf.py
 echo .ycm_extra_conf.py >> .git/info/exclude
 make
 
-(Add the following somewhere in your .nvimrc files)
+(Add the following somewhere in your vimrc)
 autocmd FileType c nnoremap <buffer> <silent> <C-]> :YcmCompleter GoTo<cr>
 ```

--- a/man/nvim.1
+++ b/man/nvim.1
@@ -1,4 +1,4 @@
-.Dd October 27, 2015
+.Dd November 11, 2015
 .Dt NVIM 1
 .Os
 .Sh NAME
@@ -173,19 +173,19 @@ See
 .It Fl L Op Ar file
 Alias for
 .Fl r .
-.It Fl u Ar nvimrc
+.It Fl u Ar vimrc
 Use
-.Ar nvimrc
+.Ar vimrc
 instead of the default of
 .Pa ~/.config/nvim/init.vim .
 If
-.Ar nvimrc
+.Ar vimrc
 is
 .Cm NORC ,
 do not load any initialization files (excluding plugins),
 and do not attempt to parse environment variables.
 If
-.Ar nvimrc
+.Ar vimrc
 is
 .Cm NONE ,
 loading plugins is also skipped.
@@ -278,7 +278,7 @@ Like
 .Fl c ,
 but execute
 .Ar command
-before processing any nvimrc.
+before processing any vimrc.
 Up to 10 instances of these can be used independently from instances of
 .Fl c .
 .It Fl S Op Ar session
@@ -395,11 +395,11 @@ configuration directory.
 See
 .Ev XDG_CONFIG_HOME
 above.
-.It Pa /etc/nvim/nvimrc
+.It Pa $VIM/sysinit.vim
 The system-global
 .Nm
 configuration file.
-.It Pa /usr/share/nvim
+.It Pa /usr/local/share/nvim
 The system-global
 .Nm
 runtime directory.

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -61,10 +61,6 @@ When the GUI starts up initializations are carried out, in this order:
     ~/.config).
   The name of the first file found is stored in $MYGVIMRC, unless it was
   already set.
-- If the 'exrc' option is set (which is NOT the default) the file ./.ngvimrc
-  is sourced, if it exists and isn't the same file as the system or user
-  gvimrc file.  If this file is not owned by you, some security restrictions
-  apply.  When ".ngvimrc" is not found, "_ngvimrc" is tried too.
 
 NOTE: All but the first one are not carried out if Vim was started with
 "-u NONE" and no "-U" argument was given, or when started with "-U NONE".

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2295,13 +2295,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'exrc'* *'ex'* *'noexrc'* *'noex'*
 'exrc' 'ex'		boolean (default off)
 			global
-	Enables the reading of .nvimrc, .exrc and .ngvimrc in the current
-	directory.  If you switch this option on you should also consider
-	setting the 'secure' option (see |initialization|).  Using a local
-	.exrc, .nvimrc or .ngvimrc is a potential security leak, use with care!
-	also see |init.vim| and |gui-init|.
+	Enables the reading of .nvimrc and .exrc in the current directory.
+	If you switch this option on you should also consider setting the
+	'secure' option (see |initialization|).  Using this option comes
+	with a potential security risk, use with care!
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
+	Also see |init.vim| and |gui-init|.
 
 				*'fileencoding'* *'fenc'* *E213*
 'fileencoding' 'fenc'	string (default: "")

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2412,9 +2412,7 @@ do_source (
      */
     p = path_tail(fname_exp);
     if ((*p == '.' || *p == '_')
-        && (STRICMP(p + 1, "nvimrc") == 0
-            || STRICMP(p + 1, "ngvimrc") == 0
-            || STRICMP(p + 1, "exrc") == 0)) {
+        && (STRICMP(p + 1, "nvimrc") == 0 || STRICMP(p + 1, "exrc") == 0)) {
       if (*p == '_')
         *p = '.';
       else

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -633,7 +633,7 @@ EXTERN int silent_mode INIT(= FALSE);
 /* set to TRUE when "-s" commandline argument
  * used for ex */
 
-// Set to true when sourcing of startup scripts (nvimrc) is done.
+// Set to true when sourcing of startup scripts (init.vim) is done.
 // Used for options that cannot be changed after startup scripts.
 EXTERN bool did_source_startup_scripts INIT(= false);
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1833,7 +1833,7 @@ static void usage(void)
   mch_msg(_("  -n                    No swap file, use memory only\n"));
   mch_msg(_("  -r, -L                List swap files and exit\n"));
   mch_msg(_("  -r <file>             Recover crashed session\n"));
-  mch_msg(_("  -u <nvimrc>           Use <nvimrc> instead of the default\n"));
+  mch_msg(_("  -u <vimrc>            Use <vimrc> instead of the default\n"));
   mch_msg(_("  -i <shada>            Use <shada> instead of the default\n"));
   mch_msg(_("  --noplugin            Don't load plugin scripts\n"));
   mch_msg(_("  -o[N]                 Open N windows (default: one for each file)\n"));
@@ -1842,7 +1842,7 @@ static void usage(void)
   mch_msg(_("  +                     Start at end of file\n"));
   mch_msg(_("  +<linenum>            Start at line <linenum>\n"));
   mch_msg(_("  +/<pattern>           Start at first occurrence of <pattern>\n"));
-  mch_msg(_("  --cmd <command>       Execute <command> before loading any nvimrc\n"));
+  mch_msg(_("  --cmd <command>       Execute <command> before loading any vimrc\n"));
   mch_msg(_("  -c <command>          Execute <command> after loading the first file\n"));
   mch_msg(_("  -S <session>          Source <session> after loading the first file\n"));
   mch_msg(_("  -s <scriptin>         Read Normal mode commands from <scriptin>\n"));


### PR DESCRIPTION
"vimrc" refers to all files that are used to configure Neovim. The main
configuration file is init.vim nowadays. All nvimrc references that are left
refer to ".nvimrc" which is read if 'exrc' is set.

References #3552.
