### PR TITLE
[RFC] Add TermClose event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -251,6 +251,7 @@ Name			triggered by ~
 
 |SwapExists|		detected an existing swap file
 |TermOpen|		when a terminal buffer is starting
+|TermClose|		when a terminal buffer ends
 
 	Options
 |FileType|		when the 'filetype' option has been set
@@ -871,6 +872,8 @@ TermChanged			After the value of 'term' has changed.  Useful
 				for re-loading the syntax file to update the
 				colors, fonts and other terminal-dependent
 				settings.  Executed for all loaded buffers.
+						 {Nvim} *TermClose*
+TermClose			When a terminal buffer ends.
 						 {Nvim} *TermOpen*
 TermOpen			When a terminal buffer is starting.  This can
 				be used to configure the terminal emulator by

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -105,6 +105,8 @@ The configuration variables are only processed when the terminal starts, which
 is why it needs to be done with the |TermOpen| autocmd or setting global
 variables before the terminal is started.
 
+There is also a corresponding |TermClose| event.
+
 The terminal cursor can be highlighted via |hl-TermCursor| and
 |hl-TermCursorNC|.
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -143,6 +143,8 @@ Events:
   |TabNew|
   |TabNewEntered|
   |TabClosed|
+  |TermOpen|
+  |TermClose|
 
 Highlight groups:
   |hl-EndOfBuffer|

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -101,6 +101,6 @@ return {
     TabNew=true,
     TabNewEntered=true,
     TabClosed=true,
-    TermEnter=true,
+    TermOpen=true,
   },
 }

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -77,8 +77,9 @@ return {
     'TabNew',                 -- when creating a new tab
     'TabNewEntered',          -- after entering a new tab
     'TermChanged',            -- after changing 'term'
-    'TermResponse',           -- after setting "v:termresponse"
+    'TermClose',              -- after the processs exits
     'TermOpen',               -- after opening a terminal buffer
+    'TermResponse',           -- after setting "v:termresponse"
     'TextChanged',            -- text was modified
     'TextChangedI',           -- text was modified in Insert mode
     'User',                   -- user defined autocommand
@@ -98,9 +99,10 @@ return {
   -- List of neovim-specific events or aliases for the purpose of generating 
   -- syntax file
   neovim_specific = {
+    TabClosed=true,
     TabNew=true,
     TabNewEntered=true,
-    TabClosed=true,
+    TermClose=true,
     TermOpen=true,
   },
 }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21781,8 +21781,10 @@ static void on_process_exit(Process *proc, int status, void *d)
   TerminalJobData *data = d;
   if (data->term && !data->exited) {
     data->exited = true;
-    terminal_close(data->term,
-        _("\r\n[Program exited, press any key to close]"));
+    char msg[22];
+    snprintf(msg, sizeof msg, "\r\n[Process exited %d]", proc->status);
+    terminal_close(data->term, msg);
+    apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, curbuf);
   }
 
   if (data->status_ptr) {

--- a/test/functional/autocmd/termclose_spec.lua
+++ b/test/functional/autocmd/termclose_spec.lua
@@ -1,0 +1,28 @@
+local helpers = require('test.functional.helpers')
+local Screen = require('test.functional.ui.screen')
+
+local clear, eval, execute, feed, nvim, nvim_dir = helpers.clear, helpers.eval,
+helpers.execute, helpers.feed, helpers.nvim, helpers.nvim_dir
+local wait = helpers.wait
+
+describe('TermClose event', function()
+  before_each(function()
+    clear()
+    nvim('set_option', 'shell', nvim_dir .. '/shell-test')
+    nvim('set_option', 'shellcmdflag', 'EXE')
+    screen = Screen.new(20, 4)
+    screen:attach(false)
+  end)
+
+  it('works as expected', function()
+    execute('autocmd TermClose * echomsg "TermClose works!"')
+    execute('terminal')
+    feed('<c-\\><c-n>')
+    screen:expect([[
+      ready $             |
+      [Process exited 0]  |
+      ^                    |
+      TermClose works!    |
+    ]])
+  end)
+end)

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -22,7 +22,7 @@ describe(':terminal', function()
     wait()
     screen:expect([[
       ready $                                           |
-      [Program exited, press any key to close]          |
+      [Process exited 0]                                |
                                                         |
                                                         |
                                                         |
@@ -37,7 +37,7 @@ describe(':terminal', function()
     screen:expect([[
       ready $ echo hi                                   |
                                                         |
-      [Program exited, press any key to close]          |
+      [Process exited 0]                                |
                                                         |
                                                         |
                                                         |
@@ -51,7 +51,7 @@ describe(':terminal', function()
     screen:expect([[
       ready $ echo 'hello' \ "world"                    |
                                                         |
-      [Program exited, press any key to close]          |
+      [Process exited 0]                                |
                                                         |
                                                         |
                                                         |

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -340,7 +340,7 @@ describe('terminal prints more lines than the screen height and exits', function
       line8                                             |
       line9                                             |
                                                         |
-      [Program exited, press any key to close]          |
+      [Process exited 0]                                |
       -- TERMINAL --                                    |
     ]])
     feed('<cr>')

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -167,7 +167,7 @@ describe('tui with non-tty file descriptors', function()
       :q                                                |
       abc                                               |
                                                         |
-      [Program exited, press any key to close]          |
+      [Process exited 0]                                |
                                                         |
       -- TERMINAL --                                    |
     ]])


### PR DESCRIPTION
References https://github.com/neovim/neovim/issues/2293

A terminal buffer now exits with: `[Process exited <return value>]`.

You can hook into it, e.g. `:autocmd TermClose * call feedkeys('<cr>')`.
