### PR TITLE
doc: minor fix for the 'u' flag in :ls

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1006,7 +1006,7 @@ list of buffers. |unlisted-buffer|
 			-	buffers with 'modifiable' off
 			=	readonly buffers
 			a	active buffers
-			u	unloaded buffers (overrides the "!")
+			u	unlisted buffers (overrides the "!")
 			h	hidden buffers
 			x	buffers with a read error
 			%	current buffer


### PR DESCRIPTION
`:ls u` actually lists _unlisted_ buffers instead of _unloaded_.
