### PR TITLE
[RFC] Windows: Only redefine ssize_t for MSVC

### DIFF
--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -28,7 +28,9 @@
 # endif
 #endif
 
+#ifdef _MSC_VER
 typedef SSIZE_T ssize_t;
+#endif
 
 #ifndef SSIZE_MAX
 # ifdef _WIN64


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@647ef45.
