### PR TITLE
Update backer URL

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -104,7 +104,7 @@ Thank you to everyone who backed our [Bountysource fundraiser](https://www.bount
 - Michael Ulm www.mulm.at
 - Mikael Jansson http://mikaelj.se
 - Mikkel Høgh http://mikkel.hoegh.org/
-- Ming Liu http://www.codingupfengshui.io
+- Ming Liu http://ming.codes
 - Holger Peters http://www.holger-peters.de
 - Alexander Myshov http://myshov.com/
 - Darren Cheng http://sanguinerane.com/


### PR DESCRIPTION
Hi,

Not sure what the policy would be for these case, but I have moved my domain. So I'm looking to update the link in `BACKER.md`. As a way of verifying identity, http://codingupfengshui.io now redirects http://ming.codes

The old domain is set to expire in 3 weeks. So I'm hoping to get this updated before.
