### PR TITLE
[RFC] cmake: use of DEFINITIONS is deprecated

### DIFF
--- a/cmake/GetCompileFlags.cmake
+++ b/cmake/GetCompileFlags.cmake
@@ -12,7 +12,7 @@ function(get_compile_flags _compile_flags)
   # Get flags set by add_definition().
   get_directory_property(definitions
     DIRECTORY "src/nvim"
-    DEFINITIONS)
+    COMPILE_DEFINITIONS)
   string(REPLACE
     "<DEFINITIONS>"
     "${definitions}"


### PR DESCRIPTION
Users of cmake 3.4 will get this warning during `make`:

```
CMake Warning (dev) at cmake/GetCompileFlags.cmake:13 (get_directory_property):
  Policy CMP0059 is not set: Do no treat DEFINITIONS as a built-in directory
  property.  Run "cmake --help-policy CMP0059" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.
Call Stack (most recent call first):
  CMakeLists.txt:385 (get_compile_flags)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

:arrow_down: 

```
neovim:master cmake --help-policy cmp0059
CMP0059
-------

Don't treat ``DEFINITIONS`` as a built-in directory property.

CMake 3.3 and above no longer make a list of definitions available through
the ``DEFINITIONS`` directory property.  The
``COMPILE_DEFINITIONS`` directory property may be used instead.

The ``OLD`` behavior for this policy is to provide the list of flags given
so far to the ``add_definitions()`` command.  The ``NEW`` behavior is
to behave as a normal user-defined directory property.

This policy was introduced in CMake version 3.3.
CMake version 3.4.0 warns when the policy is not set and uses
``OLD`` behavior.  Use the ``cmake_policy()`` command to set
it to ``OLD`` or ``NEW`` explicitly.

.. note::
  The ``OLD`` behavior of a policy is
  ``deprecated by definition``
```
