### PR TITLE
[RFC] use oap->motion_type also to represent block motion type

### DIFF
--- a/src/nvim/normal.h
+++ b/src/nvim/normal.h
@@ -14,28 +14,27 @@
  * Arguments for operators.
  */
 typedef struct oparg_S {
-  int op_type;                  /* current pending operator type */
-  int regname;                  /* register to use for the operator */
-  int motion_type;              /* type of the current cursor motion */
-  int motion_force;             /* force motion type: 'v', 'V' or CTRL-V */
-  bool use_reg_one;             /* true if delete uses reg 1 even when not
-                                   linewise */
-  bool inclusive;               /* true if char motion is inclusive (only
-                                   valid when motion_type is MCHAR */
-  bool end_adjusted;            /* backuped b_op_end one char (only used by
-                                   do_format()) */
-  pos_T start;                  /* start of the operator */
-  pos_T end;                    /* end of the operator */
-  pos_T cursor_start;           /* cursor position before motion for "gw" */
+  int op_type;                  // current pending operator type
+  int regname;                  // register to use for the operator
+  int motion_type;              // type of the current cursor motion
+  int motion_force;             // force motion type: 'v', 'V' or CTRL-V
+  bool use_reg_one;             // true if delete uses reg 1 even when not
+                                // linewise
+  bool inclusive;               // true if char motion is inclusive (only
+                                // valid when motion_type is MCHAR)
+  bool end_adjusted;            // backuped b_op_end one char (only used by
+                                // do_format())
+  pos_T start;                  // start of the operator
+  pos_T end;                    // end of the operator
+  pos_T cursor_start;           // cursor position before motion for "gw"
 
-  long line_count;              /* number of lines from op_start to op_end
-                                   (inclusive) */
-  bool empty;                   /* op_start and op_end the same (only used by
-                                   op_change()) */
-  bool is_VIsual;               /* operator on Visual area */
-  bool block_mode;              /* current operator is Visual block mode */
-  colnr_T start_vcol;           /* start col for block mode operator */
-  colnr_T end_vcol;             /* end col for block mode operator */
+  long line_count;              // number of lines from op_start to op_end
+                                // (inclusive)
+  bool empty;                   // op_start and op_end the same (only used by
+                                // op_change())
+  bool is_VIsual;               // operator on Visual area
+  colnr_T start_vcol;           // start col for block mode operator
+  colnr_T end_vcol;             // end col for block mode operator
   long prev_opcount;            // ca.opcount saved for K_EVENT
   long prev_count0;             // ca.count0 saved for K_EVENT
 } oparg_T;


### PR DESCRIPTION
While working on `autoselect` I had to dive quite deeply into the implementation of visual selection and noticed this oddity. `oap->motion_type` is set to `MCHAR` or `MLINE` for char/line-wise motion/selection but for blockwise, `oap->motion_type` must be set to `MCHAR` and then `oap->block_mode` set to `true`. It seems simpler to just use `oap->motion_type == MBLOCK` to represent blockwise motion/selection.
