### PR TITLE
reimplement clipboard=autoselect

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1431,7 +1431,7 @@ bool get_visual_selection_bounds(oparg_T *oap)
   if (VIsual_mode == Ctrl_V) {      /* block mode */
     colnr_T start, end;
 
-    oap->block_mode = true;
+    oap->motion_type = MBLOCK;
 
     getvvcol(curwin, &(oap->start),
         &oap->start_vcol, NULL, &oap->end_vcol);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -942,11 +942,6 @@ normal_end:
     do_check_cursorbind();
   }
 
-  if (VIsual_active) {
-    // probably too soon, but for testing:
-    autoselect_test();
-  }
-
   // May restart edit(), if we got here with CTRL-O in Insert mode (but not
   // if still inside a mapping that started in Visual mode).
   // May switch from Visual to Select mode after CTRL-O command.
@@ -1221,6 +1216,8 @@ static void normal_check_cursor_moved(NormalState *s)
       s->conceal_new_cursor_line = curwin->w_cursor.lnum;
       s->conceal_update_lines = true;
     }
+
+    autoselect_test();
 
     last_cursormoved = curwin->w_cursor;
   }
@@ -3045,6 +3042,8 @@ void check_visual_highlight(void)
  */
 void end_visual_mode(void)
 {
+
+  autoselect_test();
 
   VIsual_active = false;
   setmouse();
@@ -6456,6 +6455,7 @@ static void nv_visual(cmdarg_T *cap)
       }
     }
   }
+  autoselect_test();
 }
 
 /*

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2534,6 +2534,35 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
   return;
 }
 
+static bool get_visual_selection(yankreg_T* out)
+{
+  oparg_T oap;
+  if(!get_visual_selection_bounds(&oap)) {
+    return false;
+  }
+  op_yank_reg(&oap, false, out, false);
+  return true;
+}
+
+void autoselect_test(void)
+{
+  if (cb_flags & CB_AUTOSELECTPLUS) {
+    yankreg_T *reg = &y_regs[PLUS_REGISTER];
+    if (get_visual_selection(reg)) {
+      set_clipboard('+', reg);
+      if (cb_flags & CB_AUTOSELECT) {
+        set_clipboard('*', reg);
+      }
+    }
+  } else if (cb_flags & CB_AUTOSELECT) {
+    yankreg_T *reg = &y_regs[STAR_REGISTER];
+    if (get_visual_selection(reg)) {
+      set_clipboard('*', reg);
+    }
+  }
+}
+
+
 static void yank_copy_line(yankreg_T *reg, struct block_def *bd, long y_idx)
 {
   char_u *pnew = xmallocz(bd->startspaces + bd->endspaces + bd->textlen);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2536,7 +2536,7 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
 
 static bool get_visual_selection(yankreg_T* out)
 {
-  oparg_T oap;
+  oparg_T oap = {0};
   if(!get_visual_selection_bounds(&oap)) {
     return false;
   }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -348,11 +348,16 @@ EXTERN char_u   *p_cedit;       /* 'cedit' */
 EXTERN char_u   *p_cb;          /* 'clipboard' */
 EXTERN unsigned cb_flags;
 #ifdef IN_OPTION_C
-static char *(p_cb_values[]) = {"unnamed", "unnamedplus", NULL};
+static char *(p_cb_values[]) = {"unnamed", "unnamedplus", "autoselect",
+                                "autoselectplus", "autoselectml", NULL};
 #endif
 # define CB_UNNAMED             0x001
 # define CB_UNNAMEDPLUS         0x002
-# define CB_UNNAMEDMASK         (CB_UNNAMED | CB_UNNAMEDPLUS)
+# define CB_AUTOSELECT          0x004
+# define CB_AUTOSELECTPLUS      0x008
+# define CB_AUTOSELECTML        0x00a
+# define CB_UNNAMEDMASK    (CB_UNNAMED | CB_UNNAMEDPLUS)
+# define CB_AUTOSELECTMASK (CB_AUTOSELECT | CB_AUTOSELECTPLUS | CB_AUTOSELECTML)
 EXTERN long p_cwh;              /* 'cmdwinheight' */
 EXTERN long p_ch;               /* 'cmdheight' */
 EXTERN int p_confirm;           /* 'confirm' */


### PR DESCRIPTION
very much work in progress. 

Problem: there is no easy way to determine (multi-line) contents of visual selection. What vim does on an `autoselect` clipboard request is 1) store some editor state 2) do an actual `"*y`, but with a flag to leave some other editor state untouched 3) restore the first part of the editor state (cursor pos, visual mode). We could either do that as well _or_ twist `do_pending_operator` even more against it actual purpose to leave editor state completely  unchanged _or_ extract a separate function to determine full visual selection contents without touching any global state. For the moment I'm trying the third approach. (I suppose this could be exposed as well for plugins that want to monitor visual selection contents without interrupting visual mode) 

We also have the problem, since `nvim` is not the direct owner of the selection, we cannot update the `*` register on demand as `[g]vim` does. For now I check for update on every cursor movement, but we might want to be more efficient here. For instance on mouse movement it is enough to update selection on mouse release, but this requires fixing #3182 first.
