### PR TITLE
Enable focus events in cmdline and terminal modes

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1448,6 +1448,14 @@ static int command_line_handle_key(CommandLineState *s)
     }
     return command_line_not_changed(s);
 
+  case K_FOCUSGAINED:  // Neovim has been given focus
+    apply_autocmds(EVENT_FOCUSGAINED, NULL, NULL, false, curbuf);
+    return command_line_not_changed(s);
+
+  case K_FOCUSLOST:   // Neovim has lost focus
+    apply_autocmds(EVENT_FOCUSLOST, NULL, NULL, false, curbuf);
+    return command_line_not_changed(s);
+
   default:
     // Normal character with no special meaning.  Just set mod_mask
     // to 0x0 so that typing Shift-Space in the GUI doesn't enter

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -402,6 +402,14 @@ static int terminal_execute(VimState *state, int key)
   TerminalState *s = (TerminalState *)state;
 
   switch (key) {
+    case K_FOCUSGAINED:  // Neovim has been given focus
+      apply_autocmds(EVENT_FOCUSGAINED, NULL, NULL, false, curbuf);
+      break;
+
+    case K_FOCUSLOST:   // Neovim has lost focus
+      apply_autocmds(EVENT_FOCUSLOST, NULL, NULL, false, curbuf);
+      break;
+
     case K_LEFTMOUSE:
     case K_LEFTDRAG:
     case K_LEFTRELEASE:

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -149,108 +149,6 @@ describe('tui', function()
       -- TERMINAL --                                    |
     ]])
   end)
-
-  it('can handle focus events', function()
-    execute('set noshowmode')
-    execute('autocmd FocusGained * echo "gained"')
-    execute('autocmd FocusLost * echo "lost"')
-
-    -- In normal mode
-    feed('\x1b[I')
-    screen:expect([[
-      {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
-      gained                                            |
-      -- TERMINAL --                                    |
-    ]])
-
-    feed('\x1b[O')
-    screen:expect([[
-      {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
-      lost                                              |
-      -- TERMINAL --                                    |
-    ]])
-
-    -- In insert mode
-    feed('i')
-    feed('\x1b[I')
-    screen:expect([[
-      {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
-      gained                                            |
-      -- TERMINAL --                                    |
-    ]])
-    feed('\x1b[O')
-    screen:expect([[
-      {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
-      lost                                              |
-      -- TERMINAL --                                    |
-    ]])
-
-    -- In command-line mode
-    feed('\x1b')
-    feed(':')
-    feed('\x1b[I')
-    screen:expect([[
-                                                        |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
-      g{1:a}ined                                            |
-      -- TERMINAL --                                    |
-    ]])
-    feed('\x1b[O')
-    screen:expect([[
-                                                        |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
-      l{1:o}st                                              |
-      -- TERMINAL --                                    |
-    ]])
-
-    -- In terminal mode
-    execute('set shell='..nvim_dir..'/shell-test')
-    execute('set laststatus=0')
-    feed('\x1b')
-    execute('terminal')
-    feed('\x1b[I')
-    screen:expect([[
-      ready $                                           |
-      [Process exited 0]{1: }                               |
-                                                        |
-                                                        |
-                                                        |
-      gained                                            |
-      -- TERMINAL --                                    |
-    ]])
-   feed('\x1b[O')
-    screen:expect([[
-      ready $                                           |
-      [Process exited 0]{1: }                               |
-                                                        |
-                                                        |
-                                                        |
-      lost                                              |
-      -- TERMINAL --                                    |
-    ]])
-  end)
 end)
 
 describe('tui with non-tty file descriptors', function()
@@ -272,6 +170,115 @@ describe('tui with non-tty file descriptors', function()
                                                         |
       [Process exited 0]                                |
                                                         |
+      -- TERMINAL --                                    |
+    ]])
+  end)
+end)
+
+describe('tui focus event handling', function()
+  before_each(function()
+    helpers.clear()
+    screen = thelpers.screen_setup(0, '["'..helpers.nvim_prog..'", "-u", "NONE", "-i", "NONE", "--cmd", "set noswapfile"]')
+    execute('autocmd FocusGained * echo "gained"')
+    execute('autocmd FocusLost * echo "lost"')
+  end)
+
+  it('can handle focus events in normal mode', function()
+    feed('\x1b[I')
+    screen:expect([[
+      {1: }                                                 |
+      ~                                                 |
+      ~                                                 |
+      ~                                                 |
+      [No Name]                                         |
+      gained                                            |
+      -- TERMINAL --                                    |
+    ]])
+
+    feed('\x1b[O')
+    screen:expect([[
+      {1: }                                                 |
+      ~                                                 |
+      ~                                                 |
+      ~                                                 |
+      [No Name]                                         |
+      lost                                              |
+      -- TERMINAL --                                    |
+    ]])
+  end)
+
+  it('can handle focus events in insert mode', function()
+    execute('set noshowmode')
+    feed('i')
+    feed('\x1b[I')
+    screen:expect([[
+      {1: }                                                 |
+      ~                                                 |
+      ~                                                 |
+      ~                                                 |
+      [No Name]                                         |
+      gained                                            |
+      -- TERMINAL --                                    |
+    ]])
+    feed('\x1b[O')
+    screen:expect([[
+      {1: }                                                 |
+      ~                                                 |
+      ~                                                 |
+      ~                                                 |
+      [No Name]                                         |
+      lost                                              |
+      -- TERMINAL --                                    |
+    ]])
+  end)
+
+  it('can handle focus events in cmdline mode', function()
+    feed(':')
+    feed('\x1b[I')
+    screen:expect([[
+                                                        |
+      ~                                                 |
+      ~                                                 |
+      ~                                                 |
+      [No Name]                                         |
+      g{1:a}ined                                            |
+      -- TERMINAL --                                    |
+    ]])
+    feed('\x1b[O')
+    screen:expect([[
+                                                        |
+      ~                                                 |
+      ~                                                 |
+      ~                                                 |
+      [No Name]                                         |
+      l{1:o}st                                              |
+      -- TERMINAL --                                    |
+    ]])
+  end)
+
+  it('can handle focus events in terminal mode', function()
+    execute('set shell='..nvim_dir..'/shell-test')
+    execute('set laststatus=0')
+    execute('set noshowmode')
+    execute('terminal')
+    feed('\x1b[I')
+    screen:expect([[
+      ready $                                           |
+      [Process exited 0]{1: }                               |
+                                                        |
+                                                        |
+                                                        |
+      gained                                            |
+      -- TERMINAL --                                    |
+    ]])
+   feed('\x1b[O')
+    screen:expect([[
+      ready $                                           |
+      [Process exited 0]{1: }                               |
+                                                        |
+                                                        |
+                                                        |
+      lost                                              |
       -- TERMINAL --                                    |
     ]])
   end)


### PR DESCRIPTION
This change adds switch cases for K_FOCUSGAINED and K_FOCUSLOST to the
input handling functions in ex_getln.c and terminal.c. The handling is
identical to what's found in edit.c (just calling apply_autocmds).

Fixes #3714
