### PR TITLE
Fix handling of CursorHoldI events

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -649,7 +649,9 @@ static int insert_execute(VimState *state, int key)
   s->c = key;
 
   // Don't want K_EVENT with cursorhold for the second key, e.g., after CTRL-V.
-  did_cursorhold = true;
+  if (key != K_EVENT) {
+    did_cursorhold = true;
+  }
 
   if (p_hkmap && KeyTyped) {
     s->c = hkmap(s->c);  // Hebrew mode mapping

--- a/test/functional/autocmd/cursorhold_spec.lua
+++ b/test/functional/autocmd/cursorhold_spec.lua
@@ -1,0 +1,31 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local eq = helpers.eq
+local eval = helpers.eval
+local feed = helpers.feed
+local retry = helpers.retry
+local source = helpers.source
+local sleep = helpers.sleep
+
+describe('CursorHoldI', function()
+  before_each(clear)
+
+  -- NOTE: since this test uses RPC it is not necessary to trigger the initial
+  --       issue (#3757) via timer's or RPC callbacks in the first place.
+  it('is triggered after input', function()
+    source([[
+    set updatetime=1
+
+    let g:cursorhold = 0
+    augroup test
+      au CursorHoldI * let g:cursorhold += 1
+    augroup END
+    ]])
+    feed('ifoo')
+    retry(5, nil, function()
+      sleep(1)
+      eq(1, eval('g:cursorhold'))
+    end)
+  end)
+end)


### PR DESCRIPTION
This does not seem to break the use case mentioned in the comment: there
is no CursorHoldI event being fired after `CTRL-V` in insert mode.

Ref: https://github.com/neovim/neovim/issues/3757#issuecomment-160353889
