### PR TITLE
vim-patch:7.4.623

### DIFF
--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1897,9 +1897,10 @@ static int nfa_regpiece(void)
       return OK;
     }
 
-    // The engine is very inefficient (uses too many states) when the maximum is
-    // much larger than the minimum. Bail out if we can use the other engine.
-    if ((nfa_re_flags & RE_AUTO) && maxval > minval + 200) {
+    // The engine is very inefficient (uses too many states) when the maximum
+    // is much larger than the minimum and when the maximum is large. Bail out
+    // if we can use the other engine.
+    if ((nfa_re_flags & RE_AUTO) && (maxval > minval + 200 || maxval > 500)) {
       return FAIL;
     }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -373,7 +373,7 @@ static int included_patches[] = {
   // 626 NA
   // 625 NA
   // 624,
-  // 623,
+  623,
   // 622 NA
   // 621 NA
   // 620,


### PR DESCRIPTION
Problem:    Crash with pattern: (){80000}  (Dominique Pelle)
Solution:   When the max limit is large fall back to the old engine.

https://github.com/vim/vim/commit/a1d2c58985584116d20fa5e132137d8ff1a535f7

I have removed the TODO message from the patch.
Because, xrealloc does not return NULL in neovim.
