### PR TITLE
vim-patch:7.4.649

### DIFF
--- a/src/nvim/misc2.c
+++ b/src/nvim/misc2.c
@@ -470,7 +470,7 @@ void put_time(FILE *fd, time_t time_)
 {
   uint8_t buf[8];
   time_to_bytes(time_, buf);
-  fwrite(buf, sizeof(uint8_t), ARRAY_SIZE(buf), fd);
+  (void)fwrite(buf, sizeof(uint8_t), ARRAY_SIZE(buf), fd);
 }
 
 /// Writes time_t to "buf[8]".

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -347,7 +347,7 @@ static int included_patches[] = {
   // 652 NA
   651,
   // 650 NA
-  // 649,
+  649,
   // 648 NA
   // 647 NA
   646,


### PR DESCRIPTION
Problem:    Compiler complains about ignoring return value of fwrite().
            (Michael Jarvis)
Solution:   Add (void).

https://github.com/vim/vim/commit/cf48767cd17130958a3076eed1872b6950947a0a
