### PR TITLE
autotags in html.vim needs to be compared against '' in order to work.

### DIFF
--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -94,7 +94,7 @@ func! HtmlIndent_CheckUserSettings()
     let autotags = g:html_indent_autotags
   endif
   let b:hi_removed_tags = {}
-  if autotags
+  if autotags != ''
     call s:RemoveITags(b:hi_removed_tags, split(autotags, ","))
   endif
 


### PR DESCRIPTION
was playing around with getting my html indenting to look the way I wanted, and it wasn't working properly. This is the line that caused the problem.

Setting

```
let g:html_indent_autotags = "html,body"
```

Did nothing, it ignored the setting because the if statement always evaluated to false.
