### PR TITLE
[RFC] Add missing guard for HAVE_UNISTD_H

### DIFF
--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -10,7 +10,9 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <errno.h>
-#include <unistd.h>
+#ifdef HAVE_UNISTD_H
+# include <unistd.h>
+#endif
 #include <assert.h>
 
 #include <msgpack.h>


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@beb4ded.

Note that I dropped the line that moves `nvim/os/os.h` since I compiled without that locally on Windows and it works.
