### PR TITLE
[RFC] Add press and release of modifiers to the keymap

### DIFF
--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -286,6 +286,14 @@ static struct key_name_entry {
   {K_PASTE,           (char_u *)"Paste"},
   {K_FOCUSGAINED,     (char_u *)"FocusGained"},
   {K_FOCUSLOST,       (char_u *)"FocusLost"},
+  {K_SHIFT,           (char_u *)"Shift"},
+  {K_SHIFTRELEASE,    (char_u *)"ShiftRelease"},
+  {K_CTRL,            (char_u *)"Ctrl"},
+  {K_CTRLRELEASE,     (char_u *)"CtrlRelease"},
+  {K_ALT,             (char_u *)"Alt"},
+  {K_ALTRELEASE,      (char_u *)"AltRelease"},
+  {K_META,            (char_u *)"Meta"},
+  {K_METARELEASE,     (char_u *)"MetaRelease"},
   {0,                 NULL}
 };
 

--- a/src/nvim/keymap.h
+++ b/src/nvim/keymap.h
@@ -241,6 +241,14 @@ enum key_extra {
   , KE_EVENT            // event
   , KE_PASTE            // special key to toggle the 'paste' option.
                         // sent only by UIs
+  , KE_SHIFT
+  , KE_SHIFTRELEASE
+  , KE_CTRL
+  , KE_CTRLRELEASE
+  , KE_ALT
+  , KE_ALTRELEASE
+  , KE_META
+  , KE_METARELEASE
 };
 
 /*
@@ -431,6 +439,15 @@ enum key_extra {
 
 #define K_EVENT         TERMCAP2KEY(KS_EXTRA, KE_EVENT)
 #define K_PASTE         TERMCAP2KEY(KS_EXTRA, KE_PASTE)
+
+#define K_SHIFT         TERMCAP2KEY(KS_EXTRA, KE_SHIFT)
+#define K_SHIFTRELEASE  TERMCAP2KEY(KS_EXTRA, KE_SHIFTRELEASE)
+#define K_CTRL          TERMCAP2KEY(KS_EXTRA, KE_CTRL)
+#define K_CTRLRELEASE   TERMCAP2KEY(KS_EXTRA, KE_CTRLRELEASE)
+#define K_ALT           TERMCAP2KEY(KS_EXTRA, KE_ALT)
+#define K_ALTRELEASE    TERMCAP2KEY(KS_EXTRA, KE_ALTRELEASE)
+#define K_META          TERMCAP2KEY(KS_EXTRA, KE_META)
+#define K_METARELEASE   TERMCAP2KEY(KS_EXTRA, KE_METARELEASE)
 
 /* Bits for modifier mask */
 /* 0x01 cannot be used, because the modifier must be 0x02 or higher */


### PR DESCRIPTION
Ref  #3253. It seems like it would require fairly significant restructuring to accept all key release events in a reasonable way. It can't just be a modifier because then everything in vim would have to explicitly ignore releases, and I don't really want to add special key codes for every key.
However, most use-cases including the example in #3253 are solved by just supporting press and release of modifier keys.
There will be a PR in neovim-qt soon to actually send these new key codes.
