### PR TITLE
[RFC] Make clint.py better follow our style guide

### DIFF
--- a/clint.py
+++ b/clint.py
@@ -2311,8 +2311,6 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
               'Extra space before [')
 
     # You shouldn't have a space before a semicolon at the end of the line.
-    # There's a special case for "for" since the style guide allows space before
-    # the semicolon there.
     if Search(r':\s*;\s*$', line):
         error(filename, linenum, 'whitespace/semicolon', 5,
               'Semicolon defining empty statement. Use {} instead.')
@@ -2320,8 +2318,7 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
         error(filename, linenum, 'whitespace/semicolon', 5,
               'Line contains only semicolon. If this should be an empty'
               ' statement, use {} instead.')
-    elif (Search(r'\s+;\s*$', line) and
-          not Search(r'\bfor\b', line)):
+    elif Search(r'\s+;\s*$', line):
         error(filename, linenum, 'whitespace/semicolon', 5,
               'Extra space before last semicolon. If this should be an empty '
               'statement, use {} instead.')

--- a/clint.py
+++ b/clint.py
@@ -2361,11 +2361,27 @@ def CheckBraces(filename, clean_lines, linenum, error):
                       ' of the previous line')
 
     # An else clause should be on the same line as the preceding closing brace.
+    # If there is no preceding closing brace, there should be one.
     if Match(r'\s*else\s*', line):
         prevline = GetPreviousNonBlankLine(clean_lines, linenum)[0]
         if Match(r'\s*}\s*$', prevline):
             error(filename, linenum, 'whitespace/newline', 4,
                   'An else should appear on the same line as the preceding }')
+        else:
+            error(filename, linenum, 'readability/braces', 5,
+                  'An else should always have braces before it')
+
+    # If should always have a brace
+    for blockstart in ('if', 'while', 'for'):
+        if Match(r'\s*{0}[^{{]*$'.format(blockstart), line):
+            pos = line.find(blockstart)
+            pos = line.find('(', pos)
+            if pos > 0:
+                (endline, _, endpos) = CloseExpression(
+                    clean_lines, linenum, pos)
+                if endline[endpos:].find('{') == -1:
+                    error(filename, linenum, 'readability/braces', 5,
+                          '{0} should always use braces'.format(blockstart))
 
     # If braces come on one side of an else, they should be on both.
     # However, we have to worry about "else if" that spans multiple lines!

--- a/clint.py
+++ b/clint.py
@@ -1994,7 +1994,8 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
     if/for/while/switch, no spaces around parens in function calls, two
     spaces between code and comment, don't start a block with a blank
     line, don't end a function with a blank line, don't add a blank line
-    after public/protected/private, don't have too many blank lines in a row.
+    after public/protected/private, don't have too many blank lines in a row,
+    spaces after {, spaces before }.
 
     Args:
       filename: The name of the current file.
@@ -2322,6 +2323,13 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
         error(filename, linenum, 'whitespace/semicolon', 5,
               'Extra space before last semicolon. If this should be an empty '
               'statement, use {} instead.')
+
+    if Search(r'\{(?!\})\S', line):
+        error(filename, linenum, 'whitespace/braces', 5,
+              'Missing space after {')
+    if Search(r'\S(?<!\{)\}', line):
+        error(filename, linenum, 'whitespace/braces', 5,
+              'Missing space before }')
 
 
 def GetPreviousNonBlankLine(clean_lines, linenum):


### PR DESCRIPTION
- [x] Enforce using braces with `if`, `while` and `for` always. guide: [1](https://neovim.io/develop/style-guide.xml?showone=Conditionals#Conditionals), [2](https://neovim.io/develop/style-guide.xml?showone=Loops_and_Switch_Statements#Loops_and_Switch_Statements) (note that second does not have explicit “Always use curly braces.”, just I assumed it should have it)
- [x] Enforce using `/*`-style comments everywhere, except for macros. [guide](https://neovim.io/develop/style-guide.xml?showone=Comment_Style#Comment_Style)
- [x] Make sure that `{` always have at least a space after it. [guide](https://neovim.io/develop/style-guide.xml?showone=Braced_Initializer_Lists#Braced_Initializer_Lists) (since it is hard to determine where there is braced initializer list and where there is something else, I am going to just check whether there is a space or a new line after `{` and before `}`.)
- [x] Check for proper alignment or indentation in parenthesised expressions like function calls. [guide](https://neovim.io/develop/style-guide.xml?showone=Function_Calls#Function_Calls) (extending guide for function calls to any other expression with parenthesis.)

Note that this PR will definitely fail clint test. It needs to be merged nevertheless, making then a robot update suppressions list.
