### PR TITLE
[WIP] Enable -Wconversion in mbyte.c

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -828,7 +828,7 @@ int vim_iswordc_buf(int c, buf_T *buf)
 {
   if (c >= 0x100) {
     if (enc_dbcs != 0) {
-      return dbcs_class((unsigned)c >> 8, (unsigned)(c & 0xff)) >= 2;
+      return dbcs_class((uint8_t)c >> 8, (uint8_t)(c & 0xff)) >= 2;
     }
 
     if (enc_utf8) {

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -802,7 +802,7 @@ EXTERN int has_mbyte INIT(= 0);                 /* any multi-byte encoding */
  * To speed up BYTELEN() we fill a table with the byte lengths whenever
  * enc_utf8 or enc_dbcs changes.
  */
-EXTERN char mb_bytelen_tab[256];
+EXTERN uint8_t mb_bytelen_tab[256];
 
 /*
  * Function pointers, used to quickly get to the right function.  Each has

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -660,7 +660,7 @@ int mb_get_class_buf(const char_u *p, buf_T *buf)
     return 1;
   }
   if (enc_dbcs != 0 && p[0] != NUL && p[1] != NUL)
-    return dbcs_class(p[0], p[1]);
+    return dbcs_class((uint8_t)p[0], (uint8_t)p[1]);
   if (enc_utf8)
     return utf_class(utf_ptr2char(p));
   return 0;
@@ -670,7 +670,7 @@ int mb_get_class_buf(const char_u *p, buf_T *buf)
  * Get class of a double-byte character.  This always returns 3 or bigger.
  * TODO: Should return 1 for punctuation.
  */
-int dbcs_class(unsigned lead, unsigned trail)
+int dbcs_class(uint8_t lead, uint8_t trail)
 {
   switch (enc_dbcs) {
     /* please add classify routine for your language in here */
@@ -679,8 +679,8 @@ int dbcs_class(unsigned lead, unsigned trail)
     case DBCS_JPN:
       {
         /* JIS code classification */
-        unsigned char lb = lead;
-        unsigned char tb = trail;
+        uint8_t lb = lead;
+        uint8_t tb = trail;
 
         /* convert process code to JIS */
         /*
@@ -741,8 +741,8 @@ int dbcs_class(unsigned lead, unsigned trail)
     case DBCS_KOR:
       {
         /* KS code classification */
-        unsigned char c1 = lead;
-        unsigned char c2 = trail;
+        uint8_t c1 = lead;
+        uint8_t c2 = trail;
 
         /*
          * 20 : Hangul

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -399,7 +399,6 @@ int enc_canon_props(const char_u *name)
  */
 char_u * mb_init(void)
 {
-  int i;
   int idx;
   int n;
   int enc_dbcs_new = 0;
@@ -412,7 +411,7 @@ char_u * mb_init(void)
 
   if (p_enc == NULL) {
     /* Just starting up: set the whole table to one's. */
-    for (i = 0; i < 256; ++i)
+    for (int i = 0; i < 256; ++i)
       mb_bytelen_tab[i] = 1;
     return NULL;
   } else if (STRNCMP(p_enc, "8bit-", 5) == 0
@@ -424,17 +423,17 @@ char_u * mb_init(void)
     /* Unix: accept any "2byte-" name, assume current locale. */
     enc_dbcs_new = DBCS_2BYTE;
   } else if ((idx = enc_canon_search(p_enc)) >= 0) {
-    i = enc_canon_table[idx].prop;
-    if (i & ENC_UNICODE) {
+    int encoding_properties = enc_canon_table[idx].prop;
+    if (encoding_properties & ENC_UNICODE) {
       /* Unicode */
       enc_utf8 = true;
-      if (i & (ENC_2BYTE | ENC_2WORD))
+      if (encoding_properties & (ENC_2BYTE | ENC_2WORD))
         enc_unicode = 2;
-      else if (i & ENC_4BYTE)
+      else if (encoding_properties & ENC_4BYTE)
         enc_unicode = 4;
       else
         enc_unicode = 0;
-    } else if (i & ENC_DBCS) {
+    } else if (encoding_properties & ENC_DBCS) {
       /* 2byte, handle below */
       enc_dbcs_new = enc_canon_table[idx].codepage;
     } else {
@@ -512,7 +511,8 @@ char_u * mb_init(void)
   }
 #endif
 
-  for (i = 0; i < 256; ++i) {
+  uint8_t i = 0;  // Loop counter over utf8len_tab
+  do {
     /* Our own function to reliably check the length of UTF-8 characters,
      * independent of mblen(). */
     if (enc_utf8)
@@ -520,7 +520,7 @@ char_u * mb_init(void)
     else if (enc_dbcs == 0)
       n = 1;
     else {
-      char buf[MB_MAXBYTES + 1];
+      uint8_t buf[MB_MAXBYTES + 1];
       if (i == NUL)             /* just in case mblen() can't handle "" */
         n = 1;
       else {
@@ -556,7 +556,7 @@ char_u * mb_init(void)
       }
     }
     mb_bytelen_tab[i] = n;
-  }
+  } while (i++ != 255);
 
 #ifdef LEN_FROM_CONV
   convert_setup(&vimconv, NULL, NULL);

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2358,7 +2358,7 @@ static int cls(void)
       return 1;
 
     /* process code leading/trailing bytes */
-    return dbcs_class(((uint8_t)c >> 8), ((uint8_t)c & 0xFF));
+    return dbcs_class((uint8_t)(c >> 8), (uint8_t)c);
   }
   if (enc_utf8) {
     c = utf_class(c);

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2358,7 +2358,7 @@ static int cls(void)
       return 1;
 
     /* process code leading/trailing bytes */
-    return dbcs_class(((unsigned)c >> 8), (c & 0xFF));
+    return dbcs_class(((uint8_t)c >> 8), ((uint8_t)c & 0xFF));
   }
   if (enc_utf8) {
     c = utf_class(c);

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -8244,7 +8244,7 @@ static bool spell_iswordp_w(int *p, win_T *wp)
       return spell_mb_isword_class(utf_class(*s), wp);
     if (enc_dbcs)
       return spell_mb_isword_class(
-          dbcs_class((unsigned)*s >> 8, *s & 0xff), wp);
+          dbcs_class((uint8_t)*s >> 8, (uint8_t)*s & 0xff), wp);
     return false;
   }
   return spelltab.st_isw[*s];

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -8244,7 +8244,7 @@ static bool spell_iswordp_w(int *p, win_T *wp)
       return spell_mb_isword_class(utf_class(*s), wp);
     if (enc_dbcs)
       return spell_mb_isword_class(
-          dbcs_class((uint8_t)*s >> 8, (uint8_t)*s & 0xff), wp);
+          dbcs_class((uint8_t)(*s >> 8), (uint8_t)*s), wp);
     return false;
   }
   return spelltab.st_isw[*s];

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -251,6 +251,7 @@ enum {
 #define STRLCPY(d, s, n)    xstrlcpy((char *)(d), (char *)(s), (size_t)(n))
 #define STRCMP(d, s)        strcmp((char *)(d), (char *)(s))
 #define STRNCMP(d, s, n)    strncmp((char *)(d), (char *)(s), (size_t)(n))
+#define MBLEN(pmb, max)      mblen((const char*)(pmb), (size_t)(max))
 #ifdef HAVE_STRCASECMP
 # define STRICMP(d, s)      strcasecmp((char *)(d), (char *)(s))
 #else


### PR DESCRIPTION
Just getting into contributing, and the -Wconversion issue (#567) seemed like a good place to start. I am working on the warnings for the 'mbyte.c' multi-byte encodings handling file. I am addressing #459 (replace char_u with uint8_t) at the same time, where it makes sense. Please let me know if I'm on the right track.

Best,
Owen
