### PR TITLE
[RFC] Windows: Remove UNIX guard for pstrcmp()

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -467,16 +467,13 @@ bool path_has_wildcard(const char_u *p)
   return false;
 }
 
-#if defined(UNIX)
 /*
  * Unix style wildcard expansion code.
- * It's here because it's used both for Unix and Mac.
  */
 static int pstrcmp(const void *a, const void *b)
 {
   return pathcmp(*(char **)a, *(char **)b, -1);
 }
-#endif
 
 /// Checks if a path has a character path_expand can expand.
 /// @param p  The path to expand.


### PR DESCRIPTION
Cherry picked from #810.  From equalsraf@3c1d85f.

This was marked as investigate but @equalsraf seems to have sorted it already. :)

You can see that `pstrcmp()` is the same on Unix and Windows in Vim:
- [Unix](https://github.com/vim/vim/blob/master/src/misc1.c#L10220)
- [Windows](https://github.com/vim/vim/blob/master/src/misc1.c#L9884)
