### PR TITLE
Lua - Fix indenting nested elseifs

### DIFF
--- a/runtime/indent/lua.vim
+++ b/runtime/indent/lua.vim
@@ -54,7 +54,7 @@ function! GetLuaIndent()
 
   " Subtract a 'shiftwidth' on end, else (and elseif), until and '}'
   " This is the part that requires 'indentkeys'.
-  let midx = match(getline(v:lnum), '^\s*\%(end\>\|else\>\|until\>\|}\)')
+  let midx = match(getline(v:lnum), '^\s*\%(end\>\|else\>\|elseif\>\|until\>\|}\)')
   if midx != -1 && synIDattr(synID(v:lnum, midx + 1, 1), "name") != "luaComment"
     let ind = ind - &shiftwidth
   endif


### PR DESCRIPTION
Currently,

```
if bool then
  --stuff
elseif bool2 then
  --morestuff
elseif bool3 then
  --more stuff
else
  --fail
end
```

Would get indented out strangely when using =. After these changes it behaves correctly.
