### PR TITLE
[RFC] Windows: Remove broken check for WIN3264

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1018,12 +1018,9 @@ void set_init_2(void)
  */
 void set_init_3(void)
 {
-#if defined(UNIX) || defined(WIN3264)
-  /*
-   * Set 'shellpipe' and 'shellredir', depending on the 'shell' option.
-   * This is done after other initializations, where 'shell' might have been
-   * set, but only if they have not been set before.
-   */
+  // Set 'shellpipe' and 'shellredir', depending on the 'shell' option.
+  // This is done after other initializations, where 'shell' might have been
+  // set, but only if they have not been set before.
   int idx_srr;
   int do_srr;
   int idx_sp;
@@ -1080,8 +1077,6 @@ void set_init_3(void)
     }
     xfree(p);
   }
-#endif
-
 
   set_title_defaults();
 }


### PR DESCRIPTION
CMake defines `UNIX` on all Unix platforms we support and the Windows check was broken.

Just remove this useless `#ifdef`.

See https://github.com/neovim/neovim/pull/810#issuecomment-164094798.

cc @equalsraf 
