### PR TITLE
vim-patch:7.4.645

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1414,7 +1414,6 @@ buflist_new (
       return NULL;
     if (aborting())             /* autocmds may abort script processing */
       return NULL;
-    /* buf->b_nwindows = 0; why was this here? */
     free_buffer_stuff(buf, FALSE);      /* delete local variables et al. */
 
     /* Init the options. */
@@ -1475,6 +1474,9 @@ buflist_new (
   fmarks_check_names(buf);              /* check file marks for this file */
   buf->b_p_bl = (flags & BLN_LISTED) ? TRUE : FALSE;    /* init 'buflisted' */
   if (!(flags & BLN_DUMMY)) {
+    // Tricky: these autocommands may change the buffer list.  They could also
+    // split the window with re-using the one empty buffer. This may result in
+    // unexpectedly losing the empty buffer.
     apply_autocmds(EVENT_BUFNEW, NULL, NULL, FALSE, buf);
     if (!buf_valid(buf)) {
       return NULL;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2112,7 +2112,6 @@ do_ecmd (
       goto theend;
     if (buf->b_ml.ml_mfp == NULL) {             /* no memfile yet */
       oldbuf = FALSE;
-      buf->b_nwindows = 0;
     } else {                                  /* existing memfile */
       oldbuf = TRUE;
       (void)buf_check_timestamp(buf, FALSE);
@@ -2138,7 +2137,7 @@ do_ecmd (
      * Make the (new) buffer the one used by the current window.
      * If the old buffer becomes unused, free it if ECMD_HIDE is FALSE.
      * If the current buffer was empty and has no file name, curbuf
-     * is returned by buflist_new().
+     * is returned by buflist_new(), nothing to do here.
      */
     if (buf != curbuf) {
       /*
@@ -2225,8 +2224,7 @@ do_ecmd (
       }
       xfree(new_name);
       au_new_curbuf = NULL;
-    } else
-      ++curbuf->b_nwindows;
+    }
 
     curwin->w_pcmark.lnum = 1;
     curwin->w_pcmark.col = 0;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -351,7 +351,7 @@ static int included_patches[] = {
   // 648 NA
   // 647 NA
   646,
-  // 645,
+  645,
   // 644 NA
   // 643,
   // 642,


### PR DESCRIPTION
Problem:    When splitting the window in a BufAdd autocommand while still in
            the first, empty buffer the window count is wrong.
Solution:   Do not reset b_nwindows to zero and don't increment it.

https://github.com/vim/vim/commit/8da9bbfd02957b79edd595c8c7397453012510b0
