### PR TITLE
[RFC] Windows: define FNAME_ILLEGAL

### DIFF
--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -6,6 +6,8 @@
 #define TEMP_DIR_NAMES {"$TMP", "$TEMP", "$USERPROFILE", ""}
 #define TEMP_FILE_PATH_MAXLEN _MAX_PATH
 
+#define FNAME_ILLEGAL "\"*?><|"
+
 #define USE_CRNL
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@34eea58.

See [vim/vim/src/os_win32.h](https://github.com/vim/vim/blob/089af18d1fd0961ff504ee72db0156bbfe509cdf/src/os_win32.h#L91)
