### PR TITLE
vim-patch:7.4.675

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1989,7 +1989,7 @@ do_ecmd (
   char_u      *free_fname = NULL;
   int retval = FAIL;
   long n;
-  linenr_T lnum;
+  pos_T orig_pos;
   linenr_T topline = 0;
   int newcol = -1;
   int solcol = -1;
@@ -2351,7 +2351,7 @@ do_ecmd (
      * Careful: open_buffer() and apply_autocmds() may change the current
      * buffer and window.
      */
-      lnum = curwin->w_cursor.lnum;
+    orig_pos = curwin->w_cursor;
     topline = curwin->w_topline;
     if (!oldbuf) {                          /* need to read the file */
       swap_exists_action = SEA_DIALOG;
@@ -2379,11 +2379,9 @@ do_ecmd (
     }
     check_arg_idx(curwin);
 
-    /*
-     * If autocommands change the cursor position or topline, we should
-     * keep it.
-     */
-    if (curwin->w_cursor.lnum != lnum) {
+    // If autocommands change the cursor position or topline, we should keep
+    // it.  Also when it moves within a line.
+    if (!equalpos(curwin->w_cursor, orig_pos)) {
       newlnum = curwin->w_cursor.lnum;
       newcol = curwin->w_cursor.col;
     }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -318,7 +318,7 @@ static int included_patches[] = {
   // 678 NA
   // 677 NA
   // 676 NA
-  // 675,
+  675,
   // 674 NA
   673,
   // 672,


### PR DESCRIPTION
Problem:    When a FileReadPost autocommand moves the cursor inside a line it
            gets moved back.
Solution:   When checking whether an autocommand moved the cursor store the
            column as well. (Christian Brabandt)

https://github.com/vim/vim/commit/eab316bdf9494eb1e076dfc5c8ec7ae000a0560f
