### PR TITLE
vim-patch:7.4.682

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2934,14 +2934,16 @@ win_line (
         }
       }
 
-      /* Decide which of the highlight attributes to use. */
-      attr_pri = TRUE;
-      if (area_attr != 0)
-        char_attr = area_attr;
-      else if (search_attr != 0)
-        char_attr = search_attr;
-      /* Use line_attr when not in the Visual or 'incsearch' area
-       * (area_attr may be 0 when "noinvcur" is set). */
+      // Decide which of the highlight attributes to use.
+      attr_pri = true;
+
+      if (area_attr != 0) {
+        char_attr = hl_combine_attr(line_attr, area_attr);
+      } else if (search_attr != 0) {
+        char_attr = hl_combine_attr(line_attr, search_attr);
+      }
+      // Use line_attr when not in the Visual or 'incsearch' area
+      // (area_attr may be 0 when "noinvcur" is set).
       else if (line_attr != 0 && ((fromcol == -10 && tocol == MAXCOL)
                                   || vcol < fromcol || vcol_prev < fromcol_prev
                                   || vcol >= tocol))

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -311,7 +311,7 @@ static int included_patches[] = {
   // 685,
   // 684,
   // 683 NA
-  // 682,
+  682,
   // 681 NA
   // 680,
   // 679 NA


### PR DESCRIPTION
Problem: The search highlighting and match highlighting replaces the
cursorline highlighting, this doesn't look good.
Solution: Combine the highlighting. (Yasuhiro Matsumoto)

https://github.com/vim/vim/commit/09deeb7c945d2677722df5b40959f97b646b6092
