### PR TITLE
vim-patch:9da7ff7

### DIFF
--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -2,7 +2,7 @@
 " Header: "{{{
 " Maintainer:	Bram Moolenaar
 " Original Author: Andy Wokula <anwoku@yahoo.de>
-" Last Change:	2014 Aug 23
+" Last Change:	2015 Jan 11
 " Version:	1.0
 " Description:	HTML indent script with cached state for faster indenting on a
 "		range of lines.
@@ -883,7 +883,7 @@ endfunc "}}}
 " THE MAIN INDENT FUNCTION. Return the amount of indent for v:lnum.
 func! HtmlIndent()
   "{{{
-  if prevnonblank(v:lnum - 1) <= 1
+  if prevnonblank(v:lnum - 1) < 1
     " First non-blank line has no indent.
     return 0
   endif

--- a/runtime/syntax/rpcgen.vim
+++ b/runtime/syntax/rpcgen.vim
@@ -1,15 +1,11 @@
 " Vim syntax file
 " Language:	rpcgen
-" Maintainer:	Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Sep 06, 2005
-" Version:	8
-" URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Last Change:	Jan 13, 2015
+" Version:	10
+" URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_RPCGEN
 
-" For version 5.x: Clear all syntax items
-" For version 6.x: Quit when a syntax file was already loaded
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
+if exists("b:current_syntax")
   finish
 endif
 

--- a/runtime/syntax/sm.vim
+++ b/runtime/syntax/sm.vim
@@ -1,15 +1,11 @@
 " Vim syntax file
 " Language:	sendmail
-" Maintainer:	Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Sep 06, 2005
-" Version:	4
-" URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Last Change:	Jan 13, 2015
+" Version:	6
+" URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SM
 
-" For version 5.x: Clear all syntax items
-" For version 6.x: Quit when a syntax file was already loaded
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
+if exists("b:current_syntax")
   finish
 endif
 

--- a/runtime/syntax/yacc.vim
+++ b/runtime/syntax/yacc.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	Yacc
 " Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Mar 20, 2014
-" Version:	11
+" Last Change:	Jan 14, 2015
+" Version:	12
 " URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
 "
 " Options: {{{1


### PR DESCRIPTION
Updated runtime files.

https://github.com/vim/vim/commit/9da7ff70cc22c941b7e6810c7d960d0061040436

Note: we already have the `syntax/vim.vim` changes, plus we forked it anyway.
