### PR TITLE
[RFC] helpers.c: Handle msgpack str/bin objects with length 0 correctly

### DIFF
--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -94,10 +94,9 @@ bool msgpack_rpc_to_string(msgpack_object *obj, String *arg)
   FUNC_ATTR_NONNULL_ALL
 {
   if (obj->type == MSGPACK_OBJECT_BIN || obj->type == MSGPACK_OBJECT_STR) {
-    if (obj->via.bin.ptr == NULL) {
-      return false;
-    }
-    arg->data = xmemdupz(obj->via.bin.ptr, obj->via.bin.size);
+    arg->data = obj->via.bin.ptr != NULL
+                    ? xmemdupz(obj->via.bin.ptr, obj->via.bin.size)
+                    : NULL;
     arg->size = obj->via.bin.size;
     return true;
   }

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -32,6 +32,26 @@ describe('server -> client', function()
     end)
   end)
 
+  describe('empty string handling in arrays', function()
+    -- Because the msgpack encoding for an empty string was interpreted as an
+    -- error, msgpack arrays with an empty string looked like
+    -- [..., '', 0, ..., 0] after the conversion, regardless of the array
+    -- elements following the empty string.
+    it('works', function()
+      local function on_setup()
+        eq({1, 2, '', 3, 'asdf'}, eval('rpcrequest('..cid..', "nstring")'))
+        stop()
+      end
+
+      local function on_request(method, args)
+        -- No need to evaluate the args, we are only interested in
+        -- a response that contains an array with an empty string.
+        return {1, 2, '', 3, 'asdf'}
+      end
+      run(on_request, nil, on_setup)
+    end)
+  end)
+
   describe('recursive call', function()
     it('works', function()
       local function on_setup()


### PR DESCRIPTION
helpers.c: Handle msgpack str/bin objects with length 0 correctly

When converting a msgpack object to a String object, strings (and byte
arrays) with length 0 are handled as errors. This is fixed by
always using the msgpack data pointer as a valid pointer. For a NULL
pointer there is nothing to copy.

Test by @snoe

Fixes #3844
