### PR TITLE
[RFC] Windows: Remove unused function

### DIFF
--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1146,22 +1146,6 @@ static void clear_csinfo(size_t i)
   csinfo[i].to_fp  = NULL;
 }
 
-#ifndef UNIX
-static char *GetWin32Error(void)
-{
-  char *msg = NULL;
-  FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER|FORMAT_MESSAGE_FROM_SYSTEM,
-      NULL, GetLastError(), 0, (LPSTR)&msg, 0, NULL);
-  if (msg != NULL) {
-    /* remove trailing \r\n */
-    char *pcrlf = strstr(msg, "\r\n");
-    if (pcrlf != NULL)
-      *pcrlf = '\0';
-  }
-  return msg;
-}
-#endif
-
 /*
  * PRIVATE: cs_insert_filelist
  *


### PR DESCRIPTION
This function is not used.

@equalsraf removed this in #810 in equalsraf@42950ac.

I've not submitted a PR for the `if_csope.c` stuff yet because we need to
fixup the symlink stuff. Windows supports symlinks so we shouldn't return `0` on symlinks.
