### PR TITLE
[RFC] Ignore errors.json generated when running `make lint`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ local.mk
 /runtime/doc/doctags
 /runtime/doc/errors.log
 
+# clint errors
+errors.json


### PR DESCRIPTION
We should probably ignore `errors.json`.

I ran `make lint` locally and this file gets generated if there are clint errors.
