### PR TITLE
[RFC] doc: Remove references to unsupported GUIs

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -333,10 +333,6 @@ N  *+find_in_path*	include file searches: |[I|, |:isearch|,
 N  *+folding*		|folding|
    *+footer*		|gui-footer|
 N  *+gettext*		message translations |multi-lang|
-   *+GUI_Athena*	Unix only: Athena |GUI|
-   *+GUI_neXtaw*	Unix only: neXtaw |GUI|
-   *+GUI_GTK*		Unix only: GTK+ |GUI|
-   *+GUI_Motif*		Unix only: Motif |GUI|
    *+iconv*		Compiled with the |iconv()| function
    *+iconv/dyn*		Likewise |iconv-dynamic| |/dyn|
 N  *+insert_expand*	|insert_expand| Insert mode completion


### PR DESCRIPTION
These feature flags aren't supported.

@Pyrohh should I also remove the references to `gui_*` etc. in `runtime/doc/eval.txt` or no?

I'm not sure if or how neovim will support that in the future?
