### PR TITLE
[RFC] doc: Update supported OS list

### DIFF
--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -57,10 +57,9 @@ argument when starting Vim.
 
 Support for different systems.
 	Vim can be used on:
-	- All Unix systems (it works on all systems it was tested on, although
-	  the GUI and Perl interface may not work everywhere).
-	- Windows 95 and Windows NT, with support for long file names.
-	- Macintosh
+	- Modern Unix systems (*BSD, Linux, etc.)
+	- Windows (XP SP 2 or greater)
+	- OS X
 
 Multi level undo.					|undo|
 	'u' goes backward in time, 'CTRL-R' goes forward again.  Set option


### PR DESCRIPTION
Vim supported all sorts of ancient Unixes I'm pretty sure we don't anymore.
This probably isn't the best wording but we definitely do not support "All Unix systems" AFAIK.

We don't support Windows 95 or Windows NT (before XP SP 2) just update this to be `Windows`.

To refer to the Mac OS it would be either `Classic Mac OS` (versions before OS X) or `OS X`.
We only support OS X so fix that up.
