### PR TITLE
[RFC] doc: Remove references to Athena GUI support

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1144,7 +1144,7 @@ If you want to always use ":confirm", set the 'confirm' option.
 			|:diffsplit|, |:diffpatch|, |:pedit|, |:redir|,
 			|:source|, |:update|, |:visual|, |:vsplit|,
 			and |:qall| if 'confirm' is set.
-			{only in Win32, Athena, Motif, GTK and Mac GUI}
+			{only in Win32, Motif, GTK and Mac GUI}
 			When ":browse" is not possible you get an error
 			message.  If the |+browse| feature is missing or the
 			{command} doesn't support browsing, the {command} is

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3232,7 +3232,7 @@ foreground()	Move the Vim window to the foreground.	Useful when sent from
 		On Win32 systems this might not work, the OS does not always
 		allow a window to bring itself to the foreground.  Use
 		|remote_foreground()| instead.
-		{only in the Win32, Athena, Motif and GTK GUI versions and the
+		{only in the Win32, Motif and GTK GUI versions and the
 		Win32 console version}
 
 
@@ -5161,7 +5161,7 @@ remote_foreground({server})				*remote_foreground()*
 		Note: This does not restore the window if it was minimized,
 		like foreground() does.
 		This function is not available in the |sandbox|.
-		{only in the Win32, Athena, Motif and GTK GUI versions and the
+		{only in the Win32, Motif and GTK GUI versions and the
 		Win32 console version}
 
 
@@ -6945,7 +6945,6 @@ folding			Compiled with |folding| support.
 footer			Compiled with GUI footer support. |gui-footer|
 gettext			Compiled with message translation |multi-lang|
 gui			Compiled with GUI enabled.
-gui_athena		Compiled with Athena GUI.
 gui_gnome		Compiled with Gnome support (gui_gtk is also defined).
 gui_gtk			Compiled with GTK+ GUI (any version).
 gui_gtk2		Compiled with GTK+ 2 GUI (gui_gtk is also defined).

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -635,7 +635,7 @@ USING RESOURCE FILES
 Instead of specifying 'guifontset', you can set X11 resources and Vim will
 pick them up.  This is only for people who know how X resource files work.
 
-For Motif and Athena insert these three lines in your $HOME/.Xdefaults file:
+For Motif insert these three lines in your $HOME/.Xdefaults file:
 
 	Vim.font: |base_font_name_list|
 	Vim*fontSet: |base_font_name_list|
@@ -1201,7 +1201,7 @@ internally.
 
 Vim has comprehensive UTF-8 support.  It works well in:
 - xterm with utf-8 support enabled
-- Athena, Motif and GTK GUI
+- Motif and GTK GUI
 - MS-Windows GUI
 - several other platforms
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1110,8 +1110,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'browsedir'* *'bsdir'*
 'browsedir' 'bsdir'	string	(default: "last")
 			global
-			{only for Motif, Athena, GTK, Mac and
-			Win32 GUI}
+			{only for Motif, GTK, Mac and Win32 GUI}
 	Which directory to use for the file browser:
 	   last		Use same directory as with last file browser, where a
 			file was opened or saved.
@@ -3102,7 +3101,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'guioptions'* *'go'*
 'guioptions' 'go'	string	(default "egmrLT"   (MS-Windows),
-					 "aegimrLT" (GTK, Motif and Athena))
+					 "aegimrLT" (GTK and Motif))
 			global
 			{only available when compiled with GUI enabled}
 	This option only has an effect in the GUI version of Vim.  It is a
@@ -3163,10 +3162,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 								*'go-g'*
 	  'g'	Grey menu items: Make menu items that are not active grey.  If
 		'g' is not included inactive menu items are not shown at all.
-		Exception: Athena will always use grey menu items.
 								*'go-T'*
-	  'T'	Include Toolbar.  Currently only in Win32, GTK+, Motif,
-		and Athena GUIs.
+	  'T'	Include Toolbar.  Currently only in Win32, GTK+, and
+		Motif GUIs.
 								*'go-r'*
 	  'r'	Right-hand scrollbar is always present.
 								*'go-R'*
@@ -3541,8 +3539,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|i_CTRL-^|.
 	The value is set to 1 when setting 'keymap' to a valid keymap name.
 	It is also used for the argument of commands like "r" and "f".
-	The value 0 may not work correctly with Athena and Motif with some XIM
-	methods.  Use 'imdisable' to disable XIM then.
 
 						*'imsearch'* *'ims'*
 'imsearch' 'ims'	number (default 0, 2 when an input method is supported)
@@ -3558,8 +3554,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|c_CTRL-^|.
 	The value is set to 1 when it is not -1 and setting the 'keymap'
 	option to a valid keymap name.
-	The value 0 may not work correctly with Athena and Motif with some XIM
-	methods.  Use 'imdisable' to disable XIM then.
 
 						*'imstatusfunc'* *'imsf'*
 'imstatusfunc' 'imsf'	string (default "")

--- a/runtime/doc/rileft.txt
+++ b/runtime/doc/rileft.txt
@@ -106,9 +106,6 @@ o  Does not support reverse insert and rightleft modes on the command-line.
 o  Somewhat slower in right-to-left mode, because right-to-left motion is
    emulated inside Vim, not by the controlling terminal.
 
-o  When the Athena GUI is used, the bottom scrollbar works in the wrong
-   direction.  This is difficult to fix.
-
 o  When both 'rightleft' and 'revins' are on: 'textwidth' does not work.
    Lines do not wrap at all; you just get a single, long line.
 

--- a/runtime/doc/scroll.txt
+++ b/runtime/doc/scroll.txt
@@ -245,7 +245,7 @@ dragging the scrollbar of the current window.  How many lines are scrolled
 depends on your mouse driver.  If the scroll action causes input focus
 problems, see |intellimouse-wheel-problems|.
 
-For the X11 GUIs (Motif, Athena and GTK) scrolling the wheel generates key
+For the X11 GUIs (Motif and GTK) scrolling the wheel generates key
 presses <ScrollWheelUp>, <ScrollWheelDown>, <ScrollWheelLeft> and
 <ScrollWheelRight>.  For example, if you push the scroll wheel upwards a
 <ScrollWheelUp> key press is generated causing the window to scroll upwards

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4678,7 +4678,7 @@ font={font-name}					*highlight-font*
 	When setting the font for the "Normal" group, this becomes the default
 	font (until the 'guifont' option is changed; the last one set is
 	used).
-	The following only works with Motif and Athena, not with other GUIs:
+	The following only works with Motif not with other GUIs:
 	When setting the font for the "Menu" group, the menus will be changed.
 	When setting the font for the "Tooltip" group, the tooltips will be
 	changed.
@@ -4866,11 +4866,6 @@ Menu		Current font, background and foreground colors of the menus.
 		Also used for the toolbar.
 		Applicable highlight arguments: font, guibg, guifg.
 
-		NOTE: For Motif and Athena the font argument actually
-		specifies a fontset at all times, no matter if 'guifontset' is
-		empty, and as such it is tied to the current |:language| when
-		set.
-
 							*hl-Scrollbar*
 Scrollbar	Current background and foreground of the main window's
 		scrollbars.
@@ -4879,11 +4874,6 @@ Scrollbar	Current background and foreground of the main window's
 							*hl-Tooltip*
 Tooltip		Current font, background and foreground of the tooltips.
 		Applicable highlight arguments: font, guibg, guifg.
-
-		NOTE: For Motif and Athena the font argument actually
-		specifies a fontset at all times, no matter if 'guifontset' is
-		empty, and as such it is tied to the current |:language| when
-		set.
 
 ==============================================================================
 13. Linking groups		*:hi-link* *:highlight-link* *E412* *E413*

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -333,7 +333,6 @@ N  *+find_in_path*	include file searches: |[I|, |:isearch|,
 N  *+folding*		|folding|
    *+footer*		|gui-footer|
 N  *+gettext*		message translations |multi-lang|
-   *+GUI_Athena*	Unix only: Athena |GUI|
    *+GUI_neXtaw*	Unix only: neXtaw |GUI|
    *+GUI_GTK*		Unix only: GTK+ |GUI|
    *+GUI_Motif*		Unix only: Motif |GUI|

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -78,7 +78,7 @@ Graphical User Interface (GUI).				|gui|
 	Included support for GUI: menu's, mouse, scrollbars, etc.  You can
 	define your own menus.  Better support for CTRL/SHIFT/ALT keys in
 	combination with special keys and mouse.  Supported for various
-	platforms, such as X11 (with Motif and Athena interfaces), GTK, Win32
+	platforms, such as X11 (with a Motif interface), GTK, Win32
 	(Windows 95 and later), and Macintosh.
 
 Multiple windows and buffers.				|windows.txt|


### PR DESCRIPTION
We don't support Athena anymore.

Note that I've left the translation stuff alone as well as the `gui_athena` stuff in the VimL runtime files.

`git grep -n "gui_athena"`

gives:

``` shell
runtime/menu.vim:969:  if !has("gui_athena")
runtime/menu.vim:1006:  if !has("gui_athena")
runtime/syntax/doxygen.vim:416:          elseif has('gui_athena') || has('gui_gtk') || &guifont=~'^\(-[^-]\+\)\{14}'
```

I wasn't sure if those should be removed or not.
