### PR TITLE
[RFC] [#3476] Add bracketedpaste option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1068,6 +1068,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 	don't see it when editing.  When you don't change the options, the BOM
 	will be restored when writing the file.
 
+						*'bracketedpaste'*
+'bracketedpaste'	boolean	(default on)
+			global
+	Use bracketed paste functionality of the terminal.  When this option is
+	enabled neovim will handle pasted input specially, e.g. paste the
+	string verbatim instead of putting it character by character.  {Nvim}
+	This option's value is used only during initialization so the option
+	should be set/unset before neovim has loaded, e.g. in the config
+	file.
+
 						*'breakat'* *'brk'*
 'breakat' 'brk'		string	(default " ^I!@*-+;:,./?")
 			global

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -124,7 +124,8 @@ Additional differences:
 
 See |nvim-intro| for a list of Nvim's largest new features.
 
-|bracketed-paste-mode| is built-in and enabled by default.
+|bracketed-paste-mode| is built-in and enabled by default.  Mode's status is
+controlled by the 'bracketedpaste' option.
 
 Meta (alt) chords are recognized (even in the terminal).
   <M-1>, <M-2>, ...

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -319,6 +319,7 @@ static char *(p_bo_values[]) = {"all", "backspace", "cursor", "complete",
 #define BO_WILD   0x40000
 
 EXTERN char_u   *p_bsk;         /* 'backupskip' */
+EXTERN int p_bracketedpaste;    ///< 'bracketedpaste'
 EXTERN char_u   *p_breakat;     /* 'breakat' */
 EXTERN char_u   *p_cmp;         /* 'casemap' */
 EXTERN unsigned cmp_flags;

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -210,6 +210,12 @@ return {
       defaults={if_true={vi=false}}
     },
     {
+      full_name='bracketedpaste',
+      type='bool', scope={'global'},
+      varname='p_bracketedpaste',
+      defaults={if_true={vi=false, vim=true}}
+    },
+    {
       full_name='breakat', abbreviation='brk',
       type='string', list='flags', scope={'global'},
       vi_def=true,

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -137,7 +137,9 @@ static void terminfo_start(UI *ui)
   unibi_out(ui, unibi_enter_ca_mode);
   unibi_out(ui, unibi_clear_screen);
   // Enable bracketed paste
-  unibi_out(ui, data->unibi_ext.enable_bracketed_paste);
+  if (p_bracketedpaste) {
+    unibi_out(ui, data->unibi_ext.enable_bracketed_paste);
+  }
   // Enable focus reporting
   unibi_out(ui, data->unibi_ext.enable_focus_reporting);
   uv_loop_init(&data->write_loop);


### PR DESCRIPTION
Bracketed paste causes [#3476](https://github.com/neovim/neovim/issues/3476). Disabling bracketed paste allows users to tentatively fix the terminal's behaviour and might be useful to others who do not want to put strings verbatim into neovim.
