### PR TITLE
change numerical options types to NumOpt (alias intmax_t)

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -33,49 +33,47 @@ typedef struct file_buffer buf_T; // Forward declaration
 
 #define MODIFIABLE(buf) (!buf->terminal && buf->b_p_ma)
 
-/*
- * Flags for w_valid.
- * These are set when something in a window structure becomes invalid, except
- * when the cursor is moved.  Call check_cursor_moved() before testing one of
- * the flags.
- * These are reset when that thing has been updated and is valid again.
- *
- * Every function that invalidates one of these must call one of the
- * invalidate_* functions.
- *
- * w_valid is supposed to be used only in screen.c.  From other files, use the
- * functions that set or reset the flags.
- *
- * VALID_BOTLINE    VALID_BOTLINE_AP
- *     on		on		w_botline valid
- *     off		on		w_botline approximated
- *     off		off		w_botline not valid
- *     on		off		not possible
- */
-#define VALID_WROW      0x01    /* w_wrow (window row) is valid */
-#define VALID_WCOL      0x02    /* w_wcol (window col) is valid */
-#define VALID_VIRTCOL   0x04    /* w_virtcol (file col) is valid */
-#define VALID_CHEIGHT   0x08    /* w_cline_height and w_cline_folded valid */
-#define VALID_CROW      0x10    /* w_cline_row is valid */
-#define VALID_BOTLINE   0x20    /* w_botine and w_empty_rows are valid */
-#define VALID_BOTLINE_AP 0x40   /* w_botine is approximated */
-#define VALID_TOPLINE   0x80    /* w_topline is valid (for cursor position) */
+// Flags for w_valid.
+// These are set when something in a window structure becomes invalid, except
+// when the cursor is moved.  Call check_cursor_moved() before testing one of
+// the flags.
+// These are reset when that thing has been updated and is valid again.
+//
+// Every function that invalidates one of these must call one of the
+// invalidate_* functions.
+//
+// w_valid is supposed to be used only in screen.c.  From other files, use the
+// functions that set or reset the flags.
+//
+// VALID_BOTLINE    VALID_BOTLINE_AP
+//     on               on              w_botline valid
+//     off              on              w_botline approximated
+//     off              off             w_botline not valid
+//     on               off             not possible
+#define VALID_WROW      0x01   ///< w_wrow (window row) is valid
+#define VALID_WCOL      0x02   ///< w_wcol (window col) is valid
+#define VALID_VIRTCOL   0x04   ///< w_virtcol (file col) is valid
+#define VALID_CHEIGHT   0x08   ///< w_cline_height and w_cline_folded valid
+#define VALID_CROW      0x10   ///< w_cline_row is valid
+#define VALID_BOTLINE   0x20   ///< w_botine and w_empty_rows are valid
+#define VALID_BOTLINE_AP 0x40  ///< w_botine is approximated
+#define VALID_TOPLINE   0x80   ///< w_topline is valid (for cursor position)
 
 // flags for b_flags
-#define BF_RECOVERED    0x01    // buffer has been recovered
-#define BF_CHECK_RO     0x02    // need to check readonly when loading file
-                                // into buffer (set by ":e", may be reset by
-                                // ":buf")
-#define BF_NEVERLOADED  0x04    // file has never been loaded into buffer,
-                                // many variables still need to be set
-#define BF_NOTEDITED    0x08    // Set when file name is changed after
-                                // starting to edit, reset when file is
-                                // written out.
-#define BF_NEW          0x10    // file didn't exist when editing started
-#define BF_NEW_W        0x20    // Warned for BF_NEW and file created
-#define BF_READERR      0x40    // got errors while reading the file
-#define BF_DUMMY        0x80    // dummy buffer, only used internally
-#define BF_PRESERVED    0x100   // ":preserve" was used
+#define BF_RECOVERED    0x01   ///< buffer has been recovered
+#define BF_CHECK_RO     0x02   ///< need to check readonly when loading file
+                               ///< into buffer. It is set by ":e", may be reset
+                               ///< by ":buf"
+#define BF_NEVERLOADED  0x04   ///< file has never been loaded into buffer,
+                               ///< many variables still need to be set
+#define BF_NOTEDITED    0x08   ///< Set when file name is changed after
+                               ///< starting to edit, reset when file is
+                               ///< written out.
+#define BF_NEW          0x10   ///< file didn't exist when editing started
+#define BF_NEW_W        0x20   ///< Warned for BF_NEW and file created
+#define BF_READERR      0x40   ///< got errors while reading the file
+#define BF_DUMMY        0x80   ///< dummy buffer, only used internally
+#define BF_PRESERVED    0x100  ///< ":preserve" was used
 
 /* Mask to check for flags that prevent normal writing */
 #define BF_WRITE_MASK   (BF_NOTEDITED + BF_NEW + BF_READERR)
@@ -145,100 +143,97 @@ struct buffheader {
   size_t bh_space;          // space in bh_curr for appending
 };
 
-/*
- * Structure that contains all options that are local to a window.
- * Used twice in a window: for the current buffer and for all buffers.
- * Also used in wininfo_T.
- */
+/// Structure that contains all options that are local to a window.
+/// Used twice in a window: for the current buffer and for all buffers.
+/// Also used in wininfo_T.
 typedef struct {
-  int wo_arab;
-# define w_p_arab w_onebuf_opt.wo_arab  /* 'arabic' */
-  int wo_bri;
-# define w_p_bri w_onebuf_opt.wo_bri	/* 'breakindent' */
-  char_u *wo_briopt;
-# define w_p_briopt w_onebuf_opt.wo_briopt /* 'breakindentopt' */
-  int wo_diff;
-# define w_p_diff w_onebuf_opt.wo_diff  /* 'diff' */
-  long wo_fdc;
-# define w_p_fdc w_onebuf_opt.wo_fdc    /* 'foldcolumn' */
-  int wo_fdc_save;
-# define w_p_fdc_save w_onebuf_opt.wo_fdc_save  /* 'foldenable' saved for diff mode */
-  int wo_fen;
-# define w_p_fen w_onebuf_opt.wo_fen    /* 'foldenable' */
-  int wo_fen_save;
-# define w_p_fen_save w_onebuf_opt.wo_fen_save  /* 'foldenable' saved for diff mode */
-  char_u      *wo_fdi;
-# define w_p_fdi w_onebuf_opt.wo_fdi    /* 'foldignore' */
-  long wo_fdl;
-# define w_p_fdl w_onebuf_opt.wo_fdl    /* 'foldlevel' */
-  int wo_fdl_save;
-# define w_p_fdl_save w_onebuf_opt.wo_fdl_save  /* 'foldlevel' state saved for diff mode */
-  char_u      *wo_fdm;
-# define w_p_fdm w_onebuf_opt.wo_fdm    /* 'foldmethod' */
-  char_u      *wo_fdm_save;
-# define w_p_fdm_save w_onebuf_opt.wo_fdm_save  /* 'fdm' saved for diff mode */
-  long wo_fml;
-# define w_p_fml w_onebuf_opt.wo_fml    /* 'foldminlines' */
-  long wo_fdn;
-# define w_p_fdn w_onebuf_opt.wo_fdn    /* 'foldnestmax' */
-  char_u      *wo_fde;
-# define w_p_fde w_onebuf_opt.wo_fde    /* 'foldexpr' */
-  char_u      *wo_fdt;
-#  define w_p_fdt w_onebuf_opt.wo_fdt   /* 'foldtext' */
-  char_u      *wo_fmr;
-# define w_p_fmr w_onebuf_opt.wo_fmr    /* 'foldmarker' */
-  int wo_lbr;
-# define w_p_lbr w_onebuf_opt.wo_lbr    /* 'linebreak' */
-  int wo_list;
-#define w_p_list w_onebuf_opt.wo_list   /* 'list' */
-  int wo_nu;
-#define w_p_nu w_onebuf_opt.wo_nu       /* 'number' */
-  int wo_rnu;
-#define w_p_rnu w_onebuf_opt.wo_rnu     /* 'relativenumber' */
-  long wo_nuw;
-# define w_p_nuw w_onebuf_opt.wo_nuw    /* 'numberwidth' */
-  int wo_wfh;
-# define w_p_wfh w_onebuf_opt.wo_wfh    /* 'winfixheight' */
-  int wo_wfw;
-# define w_p_wfw w_onebuf_opt.wo_wfw    /* 'winfixwidth' */
-  int wo_pvw;
-# define w_p_pvw w_onebuf_opt.wo_pvw    /* 'previewwindow' */
-  int wo_rl;
-# define w_p_rl w_onebuf_opt.wo_rl      /* 'rightleft' */
-  char_u      *wo_rlc;
-# define w_p_rlc w_onebuf_opt.wo_rlc    /* 'rightleftcmd' */
-  long wo_scr;
-#define w_p_scr w_onebuf_opt.wo_scr     /* 'scroll' */
-  int wo_spell;
-# define w_p_spell w_onebuf_opt.wo_spell /* 'spell' */
-  int wo_cuc;
-# define w_p_cuc w_onebuf_opt.wo_cuc    /* 'cursorcolumn' */
-  int wo_cul;
-# define w_p_cul w_onebuf_opt.wo_cul    /* 'cursorline' */
-  char_u      *wo_cc;
-# define w_p_cc w_onebuf_opt.wo_cc      /* 'colorcolumn' */
-  char_u      *wo_stl;
-#define w_p_stl w_onebuf_opt.wo_stl     /* 'statusline' */
-  int wo_scb;
-# define w_p_scb w_onebuf_opt.wo_scb    /* 'scrollbind' */
-  int wo_diff_saved;           /* options were saved for starting diff mode */
+  int wo_arab;                ///< 'arabic'
+# define w_p_arab w_onebuf_opt.wo_arab
+  int wo_bri;                 ///< 'breakindent'
+# define w_p_bri w_onebuf_opt.wo_bri
+  char_u *wo_briopt;          ///< 'breakindentopt'
+# define w_p_briopt w_onebuf_opt.wo_briopt
+  int wo_diff;                ///< 'diff'
+# define w_p_diff w_onebuf_opt.wo_diff
+  NumOpt wo_fdc;              ///< 'foldcolumn'
+# define w_p_fdc w_onebuf_opt.wo_fdc
+  int wo_fdc_save;            ///< 'foldenable' saved for diff mode
+# define w_p_fdc_save w_onebuf_opt.wo_fdc_save
+  int wo_fen;                 ///< 'foldenable'
+# define w_p_fen w_onebuf_opt.wo_fen
+  int wo_fen_save;            ///< 'foldenable' saved for diff mode
+# define w_p_fen_save w_onebuf_opt.wo_fen_save
+  char_u *wo_fdi;             ///< 'foldignore'
+# define w_p_fdi w_onebuf_opt.wo_fdi
+  NumOpt wo_fdl;              ///< 'foldlevel'
+# define w_p_fdl w_onebuf_opt.wo_fdl
+  int wo_fdl_save;            ///< 'foldlevel' state saved for diff mode
+# define w_p_fdl_save w_onebuf_opt.wo_fdl_save
+  char_u *wo_fdm;             ///< 'foldmethod'
+# define w_p_fdm w_onebuf_opt.wo_fdm
+  char_u *wo_fdm_save;        ///< 'fdm' saved for diff mode
+# define w_p_fdm_save w_onebuf_opt.wo_fdm_save
+  NumOpt wo_fml;              ///< 'foldminlines'
+# define w_p_fml w_onebuf_opt.wo_fml
+  NumOpt wo_fdn;              ///< 'foldnestmax'
+# define w_p_fdn w_onebuf_opt.wo_fdn
+  char_u *wo_fde;             ///< 'foldexpr'
+# define w_p_fde w_onebuf_opt.wo_fde
+  char_u *wo_fdt;             ///< 'foldtext'
+#  define w_p_fdt w_onebuf_opt.wo_fdt
+  char_u *wo_fmr;             ///< 'foldmarker'
+# define w_p_fmr w_onebuf_opt.wo_fmr
+  int wo_lbr;                 ///< 'linebreak'
+# define w_p_lbr w_onebuf_opt.wo_lbr
+  int wo_list;                ///< 'list'
+#define w_p_list w_onebuf_opt.wo_list
+  int wo_nu;                  ///< 'number'
+#define w_p_nu w_onebuf_opt.wo_nu
+  int wo_rnu;                 ///< 'relativenumber'
+#define w_p_rnu w_onebuf_opt.wo_rnu
+  NumOpt wo_nuw;              ///< 'numberwidth'
+# define w_p_nuw w_onebuf_opt.wo_nuw
+  int wo_wfh;                 ///< 'winfixheight'
+# define w_p_wfh w_onebuf_opt.wo_wfh
+  int wo_wfw;                 ///< 'winfixwidth'
+# define w_p_wfw w_onebuf_opt.wo_wfw
+  int wo_pvw;                 ///< 'previewwindow'
+# define w_p_pvw w_onebuf_opt.wo_pvw
+  int wo_rl;                  ///< 'rightleft'
+# define w_p_rl w_onebuf_opt.wo_rl
+  char_u *wo_rlc;             ///< 'rightleftcmd'
+# define w_p_rlc w_onebuf_opt.wo_rlc
+  NumOpt wo_scr;              ///< 'scroll'
+#define w_p_scr w_onebuf_opt.wo_scr
+  int wo_spell;               ///< 'spell'
+# define w_p_spell w_onebuf_opt.wo_spell
+  int wo_cuc;                 ///< 'cursorcolumn'
+# define w_p_cuc w_onebuf_opt.wo_cuc
+  int wo_cul;                 ///< 'cursorline'
+# define w_p_cul w_onebuf_opt.wo_cul
+  char_u *wo_cc;              ///< 'colorcolumn'
+# define w_p_cc w_onebuf_opt.wo_cc
+  char_u *wo_stl;             ///< 'statusline'
+#define w_p_stl w_onebuf_opt.wo_stl
+  int wo_scb;                 ///< 'scrollbind'
+# define w_p_scb w_onebuf_opt.wo_scb
+  int wo_diff_saved;          ///< options were saved for starting diff mode
 # define w_p_diff_saved w_onebuf_opt.wo_diff_saved
-  int wo_scb_save;              /* 'scrollbind' saved for diff mode*/
+  int wo_scb_save;            ///< 'scrollbind' saved for diff mode
 # define w_p_scb_save w_onebuf_opt.wo_scb_save
-  int wo_wrap;
-#define w_p_wrap w_onebuf_opt.wo_wrap   /* 'wrap' */
-  int wo_wrap_save;             /* 'wrap' state saved for diff mode*/
+  int wo_wrap;                ///< 'wrap'
+#define w_p_wrap w_onebuf_opt.wo_wrap
+  int wo_wrap_save;           ///< 'wrap' state saved for diff mode
 # define w_p_wrap_save w_onebuf_opt.wo_wrap_save
-  char_u      *wo_cocu;                 /* 'concealcursor' */
+  char_u *wo_cocu;            ///< 'concealcursor'
 # define w_p_cocu w_onebuf_opt.wo_cocu
-  long wo_cole;                         /* 'conceallevel' */
+  NumOpt wo_cole;             ///< 'conceallevel'
 # define w_p_cole w_onebuf_opt.wo_cole
-  int wo_crb;
-# define w_p_crb w_onebuf_opt.wo_crb    /* 'cursorbind' */
-  int wo_crb_save;              /* 'cursorbind' state saved for diff mode*/
+  int wo_crb;                 ///< 'cursorbind'
+# define w_p_crb w_onebuf_opt.wo_crb
+  int wo_crb_save;            ///< 'cursorbind' state saved for diff mode
 # define w_p_crb_save w_onebuf_opt.wo_crb_save
-
-  int wo_scriptID[WV_COUNT];            /* SIDs for window-local options */
+  int wo_scriptID[WV_COUNT];  ///< SIDs for window-local options
 # define w_p_scriptID w_onebuf_opt.wo_scriptID
 } winopt_T;
 
@@ -578,12 +573,12 @@ struct file_buffer {
 
   bool b_scanned;               /* ^N/^P have scanned this buffer */
 
-  /* flags for use of ":lmap" and IM control */
-  long b_p_iminsert;            /* input mode for insert */
-  long b_p_imsearch;            /* input mode for search */
-#define B_IMODE_USE_INSERT -1   /*	Use b_p_iminsert value for search */
-#define B_IMODE_NONE 0          /*	Input via none */
-#define B_IMODE_LMAP 1          /*	Input via langmap */
+  // flags for use of ":lmap" and IM control
+  NumOpt b_p_iminsert;          ///< input mode for insert
+  NumOpt b_p_imsearch;          ///< input mode for search
+#define B_IMODE_USE_INSERT -1   ///< Use b_p_iminsert value for search
+#define B_IMODE_NONE 0          ///< Input via none
+#define B_IMODE_LMAP 1          ///< Input via langmap
 # define B_IMODE_LAST 1
 
   short b_kmap_state;           /* using "lmap" mappings */
@@ -591,19 +586,15 @@ struct file_buffer {
 # define KEYMAP_LOADED  2       /* 'keymap' mappings have been loaded */
   garray_T b_kmap_ga;           /* the keymap table */
 
-  /*
-   * Options local to a buffer.
-   * They are here because their value depends on the type of file
-   * or contents of the file being edited.
-   */
-  bool b_p_initialized;                 /* set when options initialized */
-
-  int b_p_scriptID[BV_COUNT];           /* SIDs for buffer-local options */
-
+  // Options local to a buffer.
+  // They are here because their value depends on the type of file
+  // or contents of the file being edited.
+  bool b_p_initialized;         ///< set when options initialized
+  int b_p_scriptID[BV_COUNT];   ///< SIDs for buffer-local options
   int b_p_ai;                   ///< 'autoindent'
   int b_p_ai_nopaste;           ///< b_p_ai saved for paste mode
-  char_u *b_p_bkc;              ///< 'backupco
-  unsigned int b_bkc_flags;     ///< flags for 'backupco
+  char_u *b_p_bkc;              ///< 'backupcopy'
+  unsigned int b_bkc_flags;     ///< flags for 'backupcopy'
   int b_p_ci;                   ///< 'copyindent'
   int b_p_bin;                  ///< 'binary'
   int b_p_bomb;                 ///< 'bomb'
@@ -650,21 +641,21 @@ struct file_buffer {
   int b_p_pi;                   ///< 'preserveindent'
   char_u *b_p_qe;               ///< 'quoteescape'
   int b_p_ro;                   ///< 'readonly'
-  long b_p_sw;                  ///< 'shiftwidth'
+  NumOpt b_p_sw;                ///< 'shiftwidth'
   int b_p_si;                   ///< 'smartindent'
-  long b_p_sts;                 ///< 'softtabstop'
-  long b_p_sts_nopaste;         ///< b_p_sts saved for paste mode
+  NumOpt b_p_sts;               ///< 'softtabstop'
+  NumOpt b_p_sts_nopaste;       ///< b_p_sts saved for paste mode
   char_u *b_p_sua;              ///< 'suffixesadd'
   bool b_p_swf;                 ///< 'swapfile'
-  long b_p_smc;                 ///< 'synmaxcol'
+  NumOpt b_p_smc;               ///< 'synmaxcol'
   char_u *b_p_syn;              ///< 'syntax'
-  long b_p_ts;                  ///< 'tabstop'
-  long b_p_tw;                  ///< 'textwidth'
-  long b_p_tw_nobin;            ///< b_p_tw saved for binary mode
-  long b_p_tw_nopaste;          ///< b_p_tw saved for paste mode
-  long b_p_wm;                  ///< 'wrapmargin'
-  long b_p_wm_nobin;            ///< b_p_wm saved for binary mode
-  long b_p_wm_nopaste;          ///< b_p_wm saved for paste mode
+  NumOpt b_p_ts;                ///< 'tabstop'
+  NumOpt b_p_tw;                ///< 'textwidth'
+  NumOpt b_p_tw_nobin;          ///< b_p_tw saved for binary mode
+  NumOpt b_p_tw_nopaste;        ///< b_p_tw saved for paste mode
+  NumOpt b_p_wm;                ///< 'wrapmargin'
+  NumOpt b_p_wm_nobin;          ///< b_p_wm saved for binary mode
+  NumOpt b_p_wm_nopaste;        ///< b_p_wm saved for paste mode
   char_u *b_p_keymap;           ///< 'keymap'
 
   // local values for options which are normally global
@@ -679,7 +670,7 @@ struct file_buffer {
   unsigned b_tc_flags;          ///< flags for 'tagcase'
   char_u *b_p_dict;             ///< 'dictionary' local value
   char_u *b_p_tsr;              ///< 'thesaurus' local value
-  long b_p_ul;                  ///< 'undolevels' local value
+  NumOpt b_p_ul;                ///< 'undolevels' local value
   int b_p_udf;                  ///< 'undofile'
   char_u *b_p_lw;               ///< 'lispwords' local value
 

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1808,13 +1808,14 @@ bool vim_isblankline(char_u *lbuf)
 /// @param unptr Returns the unsigned result.
 /// @param maxlen Max length of string to check.
 void vim_str2nr(const char_u *const start, int *const prep, int *const len,
-                const int what, long *const nptr, unsigned long *const unptr,
+                const int what, intmax_t *const nptr, uintmax_t *const unptr,
                 const int maxlen)
+  FUNC_ATTR_NONNULL_ARG(1)
 {
   const char_u *ptr = start;
   int pre = 0;  // default is decimal
   bool negative = false;
-  unsigned long un = 0;
+  uintmax_t un = 0;
 
   if (ptr[0] == '-') {
     negative = true;
@@ -1879,7 +1880,7 @@ void vim_str2nr(const char_u *const start, int *const prep, int *const len,
   } else if ((pre == '0') || what == STR2NR_OCT + STR2NR_FORCE) {
     // octal
     while ('0' <= *ptr && *ptr <= '7') {
-      un = 8 * un + (unsigned long)(*ptr - '0');
+      un = 8 * un + (uintmax_t)(*ptr - '0');
       ptr++;
       if (n++ == maxlen) {
         break;
@@ -1892,7 +1893,7 @@ void vim_str2nr(const char_u *const start, int *const prep, int *const len,
       n += 2;  // skip over "0x"
     }
     while (ascii_isxdigit(*ptr)) {
-      un = 16 * un + (unsigned long)hex2nr(*ptr);
+      un = 16 * un + (uintmax_t)hex2nr(*ptr);
       ptr++;
       if (n++ == maxlen) {
         break;
@@ -1901,7 +1902,7 @@ void vim_str2nr(const char_u *const start, int *const prep, int *const len,
   } else {
     // decimal
     while (ascii_isdigit(*ptr)) {
-      un = 10 * un + (unsigned long)(*ptr - '0');
+      un = 10 * un + (uintmax_t)(*ptr - '0');
       ptr++;
       if (n++ == maxlen) {
         break;
@@ -1920,9 +1921,9 @@ void vim_str2nr(const char_u *const start, int *const prep, int *const len,
   if (nptr != NULL) {
     if (negative) {
       // account for leading '-' for decimal numbers
-      *nptr = -(long)un;
+      *nptr = -(intmax_t)un;
     } else {
-      *nptr = (long)un;
+      *nptr = (intmax_t)un;
     }
   }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1149,7 +1149,7 @@ int call_vim_function(
     typval_T *rettv
 )
 {
-  long n;
+  intmax_t n;
   int len;
   int doesrange;
   void        *save_funccalp = NULL;
@@ -1848,12 +1848,12 @@ ex_let_one (
     /* Find the end of the name. */
     p = find_option_end(&arg, &opt_flags);
     if (p == NULL || (endchars != NULL
-                      && vim_strchr(endchars, *skipwhite(p)) == NULL))
+                      && vim_strchr(endchars, *skipwhite(p)) == NULL)) {
       EMSG(_(e_letunexp));
-    else {
-      long n;
+    } else {
+      NumOpt n;
       int opt_type;
-      long numval;
+      NumOpt numval;
       char_u      *stringval = NULL;
       char_u      *s;
 
@@ -1863,18 +1863,17 @@ ex_let_one (
       n = get_tv_number(tv);
       s = get_tv_string_chk(tv);            /* != NULL if number or string */
       if (s != NULL && op != NULL && *op != '=') {
-        opt_type = get_option_value(arg, &numval,
-            &stringval, opt_flags);
-        if ((opt_type == 1 && *op == '.')
-            || (opt_type == 0 && *op != '.'))
+        opt_type = get_option_value(arg, &numval, &stringval, opt_flags);
+        if ((opt_type == 1 && *op == '.') || (opt_type == 0 && *op != '.')) {
           EMSG2(_(e_letwrong), op);
-        else {
-          if (opt_type == 1) {          /* number */
-            if (*op == '+')
+        } else {
+          if (opt_type == 1) {  // number
+            if (*op == '+') {
               n = numval + n;
-            else
+            } else {
               n = numval - n;
-          } else if (opt_type == 0 && stringval != NULL) {     /* string */
+            }
+          } else if (opt_type == 0 && stringval != NULL) {  // string
             s = concat_str(stringval, s);
             xfree(stringval);
             stringval = s;
@@ -4146,7 +4145,7 @@ static int eval7(
     int want_string                 // after "." operator
 )
 {
-  long n;
+  intmax_t n;
   int len;
   char_u      *s;
   char_u      *start_leader, *end_leader;
@@ -4641,7 +4640,7 @@ get_option_tv (
 )
 {
   char_u      *option_end;
-  long numval;
+  NumOpt numval;
   char_u      *stringval;
   int opt_type;
   int c;
@@ -15468,7 +15467,7 @@ static void f_str2nr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   int base = 10;
   char_u      *p;
-  long n;
+  intmax_t n;
   int what;
 
   if (argvars[1].v_type != VAR_UNKNOWN) {
@@ -18093,9 +18092,9 @@ long get_tv_number(typval_T *varp)
   return get_tv_number_chk(varp, &error);       /* return 0L on error */
 }
 
-long get_tv_number_chk(typval_T *varp, int *denote)
+intmax_t get_tv_number_chk(typval_T *varp, int *denote)
 {
-  long n = 0L;
+  intmax_t n = 0;
 
   switch (varp->v_type) {
   case VAR_NUMBER:
@@ -18108,8 +18107,7 @@ long get_tv_number_chk(typval_T *varp, int *denote)
     break;
   case VAR_STRING:
     if (varp->vval.v_string != NULL) {
-      vim_str2nr(varp->vval.v_string, NULL, NULL,
-                 STR2NR_ALL, &n, NULL, 0);
+      vim_str2nr(varp->vval.v_string, NULL, NULL, STR2NR_ALL, &n, NULL, 0);
     }
     return n;
   case VAR_LIST:

--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -360,8 +360,8 @@ static inline int parse_json_string(vimconv_T *const conv,
         case 'u': {
           const char ubuf[] = { t[1], t[2], t[3], t[4] };
           t += 4;
-          unsigned long ch;
-          vim_str2nr((char_u *) ubuf, NULL, NULL,
+          uintmax_t ch;
+          vim_str2nr((char_u *)ubuf, NULL, NULL,
                      STR2NR_HEX | STR2NR_FORCE, NULL, &ch, 4);
           if (ch == 0) {
             hasnul = true;
@@ -564,7 +564,7 @@ parse_json_number_check:
     tv.v_type = VAR_FLOAT;
   } else {
     // Convert integer
-    long nr;
+    intmax_t nr;
     int num_len;
     vim_str2nr((char_u *) s, NULL, &num_len, 0, &nr, NULL, (int) (p - s));
     if ((int) exp_num_len != num_len) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -309,7 +309,7 @@ typedef struct {
       long start_col_nr;  ///< starting column number
       long end_col_nr;    ///< ending column number
     } line;
-    long value;           ///< value if sorting by integer
+    intmax_t value;       ///< value if sorting by integer
     float_T value_flt;    ///< value if sorting by float
   } st_u;
 } sorti_T;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7112,15 +7112,15 @@ static void ex_sleep(exarg_T *eap)
   do_sleep(len);
 }
 
-/*
- * Sleep for "msec" milliseconds, but keep checking for a CTRL-C every second.
- */
-void do_sleep(long msec)
+/// Sleep for "msec" milliseconds, but keep checking for a CTRL-C every second.
+///
+/// @param  msec  number of milliseconds to sleep
+void do_sleep(intmax_t msec)
 {
   ui_flush();  // flush before waiting
-  for (long left = msec; !got_int && left > 0; left -= 1000L) {
+  for (intmax_t left = msec; !got_int && left > 0; left -= 1000L) {
     int next = left > 1000l ? 1000 : (int)left;
-    LOOP_PROCESS_EVENTS_UNTIL(&main_loop, main_loop.events, (int)next, got_int);
+    LOOP_PROCESS_EVENTS_UNTIL(&main_loop, main_loop.events, next, got_int);
     os_breakcheck();
   }
 }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -114,7 +114,7 @@ typedef struct command_line_state {
   int ignore_drag_release;
   int break_ctrl_c;
   expand_T xpc;
-  long *b_im_ptr;
+  NumOpt *b_im_ptr;
   // Everything that may work recursively should save and restore the
   // current command line in save_ccline.  That includes update_screen(), a
   // custom status line may invoke ":normal".
@@ -4902,8 +4902,8 @@ int del_history_idx(int histype, int idx)
 int get_list_range(char_u **str, int *num1, int *num2)
 {
   int len;
-  int first = false;
-  long num;
+  bool first = false;
+  intmax_t num;
 
   *str = skipwhite(*str);
   if (**str == '-' || ascii_isdigit(**str)) {  // parse "from" part of range

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1583,30 +1583,28 @@ vungetc ( /* unget one character (can only be done once!) */
   old_mouse_col = mouse_col;
 }
 
-/*
- * get a character:
- * 1. from the stuffbuffer
- *	This is used for abbreviated commands like "D" -> "d$".
- *	Also used to redo a command for ".".
- * 2. from the typeahead buffer
- *	Stores text obtained previously but not used yet.
- *	Also stores the result of mappings.
- *	Also used for the ":normal" command.
- * 3. from the user
- *	This may do a blocking wait if "advance" is TRUE.
- *
- * if "advance" is TRUE (vgetc()):
- *	really get the character.
- *	KeyTyped is set to TRUE in the case the user typed the key.
- *	KeyStuffed is TRUE if the character comes from the stuff buffer.
- * if "advance" is FALSE (vpeekc()):
- *	just look whether there is a character available.
- *
- * When "no_mapping" is zero, checks for mappings in the current mode.
- * Only returns one byte (of a multi-byte character).
- * K_SPECIAL and CSI may be escaped, need to get two more bytes then.
- */
-static int vgetorpeek(int advance)
+/// get a character:
+/// 1. from the stuffbuffer
+///     This is used for abbreviated commands like "D" -> "d$".
+///     Also used to redo a command for ".".
+/// 2. from the typeahead buffer
+///     Stores text obtained previously but not used yet.
+///     Also stores the result of mappings.
+///     Also used for the ":normal" command.
+/// 3. from the user
+///     This may do a blocking wait if "advance" is TRUE.
+///
+/// if "advance" is TRUE (vgetc()):
+///     really get the character.
+///     KeyTyped is set to TRUE in the case the user typed the key.
+///     KeyStuffed is TRUE if the character comes from the stuff buffer.
+/// if "advance" is FALSE (vpeekc()):
+///     just look whether there is a character available.
+///
+/// When "no_mapping" is zero, checks for mappings in the current mode.
+/// Only returns one byte (of a multi-byte character).
+/// K_SPECIAL and CSI may be escaped, need to get two more bytes then.
+static int vgetorpeek(bool advance)
 {
   int c, c1;
   int keylen;
@@ -2279,16 +2277,17 @@ static int vgetorpeek(int advance)
          */
         wait_tb_len = typebuf.tb_len;
         c = inchar(typebuf.tb_buf + typebuf.tb_off + typebuf.tb_len,
-            typebuf.tb_buflen - typebuf.tb_off - typebuf.tb_len - 1,
-            !advance
-            ? 0
-            : ((typebuf.tb_len == 0
-                || !(p_timeout || (p_ttimeout
-                                   && keylen == KEYLEN_PART_KEY)))
-               ? -1L
-               : ((keylen == KEYLEN_PART_KEY && p_ttm >= 0)
-                  ? p_ttm
-                  : p_tm)), typebuf.tb_change_cnt);
+                   typebuf.tb_buflen - typebuf.tb_off - typebuf.tb_len - 1,
+                   !advance
+                   ? 0
+                   : (long)((typebuf.tb_len == 0
+                             || !(p_timeout
+                                  || (p_ttimeout && keylen == KEYLEN_PART_KEY)))
+                            ? -1L
+                            : ((keylen == KEYLEN_PART_KEY && p_ttm >= 0)
+                               ? p_ttm
+                               : p_tm)),
+                   typebuf.tb_change_cnt);
 
         if (i != 0)
           pop_showcmd();

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -112,9 +112,9 @@ typedef enum {
 #define DFLT_COLS       80              /* default value for 'columns' */
 #define DFLT_ROWS       24              /* default value for 'lines' */
 
-EXTERN long Rows INIT(= DFLT_ROWS);     // nr of rows in the screen
 
-EXTERN long Columns INIT(= DFLT_COLS);  // nr of columns in the screen
+EXTERN NumOpt Rows INIT(= DFLT_ROWS);     ///< Number of rows in the screen
+EXTERN NumOpt Columns INIT(= DFLT_COLS);  ///< Number of columns in the screen
 
 /*
  * The characters and attributes cached for the screen.

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -451,12 +451,11 @@ int get_number_indent(linenr_T lnum)
  * necessarily always the current one.
  */
 int get_breakindent_win(win_T *wp, char_u *line) {
-  static int prev_indent = 0;  /* cached indent value */
-  static long prev_ts = 0; /* cached tabstop value */
-  static char_u *prev_line = NULL; /* cached pointer to line */
-  static int prev_tick = 0;  // changedtick of cached value
-  int bri = 0;
-  /* window width minus window margin space, i.e. what rests for text */
+  static int prev_indent = 0;       // cached indent value
+  static NumOpt prev_ts = 0;        // cached tabstop value
+  static char_u *prev_line = NULL;  // cached pointer to line
+  static int prev_tick = 0;         // changedtick of cached value
+  // window width minus window margin space, i.e. what rests for text
   const int eff_wwidth = wp->w_width
     - ((wp->w_p_nu || wp->w_p_rnu)
         && (vim_strchr(p_cpo, CPO_NUMCOL) == NULL)
@@ -471,7 +470,7 @@ int get_breakindent_win(win_T *wp, char_u *line) {
     prev_indent = get_indent_str(line,
             (int)wp->w_buffer->b_p_ts, wp->w_p_list);
   }
-  bri = prev_indent + wp->w_p_brishift;
+  int bri = prev_indent + wp->w_p_brishift;
 
   /* indent minus the length of the showbreak string */
   if (wp->w_p_brisbr)

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -550,7 +550,7 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
   int modifiers;
   int bit;
   int key;
-  unsigned long n;
+  uintmax_t n;
   int l;
 
   if (src_len == 0) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -739,13 +739,13 @@ static void normal_get_additional_char(NormalState *s)
         && s->ca.cmdchar == 'g') {
       s->ca.oap->op_type = get_op_type(*cp, NUL);
     } else if (*cp == Ctrl_BSL) {
-      long towait = (p_ttm >= 0 ? p_ttm : p_tm);
+      NumOpt towait = (p_ttm >= 0 ? p_ttm : p_tm);
 
       // There is a busy wait here when typing "f<C-\>" and then
       // something different from CTRL-N.  Can't be avoided.
-      while ((s->c = vpeekc()) <= 0 && towait > 0L) {
-        do_sleep(towait > 50L ? 50L : towait);
-        towait -= 50L;
+      while ((s->c = vpeekc()) <= 0 && towait > 0) {
+        do_sleep(towait > 50 ? 50 : towait);
+        towait -= 50;
       }
       if (s->c > 0) {
         s->c = plain_vgetc();
@@ -4018,7 +4018,7 @@ static void nv_zet(cmdarg_T *cap)
   int n;
   colnr_T col;
   int nchar = cap->nchar;
-  long old_fdl = curwin->w_p_fdl;
+  NumOpt old_fdl = curwin->w_p_fdl;
   int old_fen = curwin->w_p_fen;
   bool undo = false;
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4360,9 +4360,9 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
   char_u buf2[NUMBUFLEN];
   int pre;  // 'X' or 'x': hex; '0': octal; 'B' or 'b': bin
   static bool hexupper = false;  // 0xABC
-  unsigned long n;
-  unsigned long oldn;
-  char_u      *ptr;
+  uintmax_t n;
+  uintmax_t oldn;
+  char_u *ptr;
   int c;
   int todel;
   bool dohex;
@@ -4544,21 +4544,20 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
     }
 
     oldn = n;
-
-    n = subtract ? n - (unsigned long) Prenum1
-                 : n + (unsigned long) Prenum1;
+    n = subtract ? n - (uintmax_t)Prenum1
+                 : n + (uintmax_t)Prenum1;
 
     // handle wraparound for decimal numbers
     if (!pre) {
       if (subtract) {
         if (n > oldn) {
-          n = 1 + (n ^ (unsigned long)-1);
+          n = 1 + (n ^ (uintmax_t)-1);
           negative ^= true;
         }
       } else {
         // add
         if (n < oldn) {
-          n = (n ^ (unsigned long)-1);
+          n = (n ^ (uintmax_t)-1);
           negative ^= true;
         }
       }

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -1,6 +1,7 @@
 #ifndef NVIM_OPTION_H
 #define NVIM_OPTION_H
 
+#include <inttypes.h>
 #include "nvim/ex_cmds_defs.h"  // for exarg_T
 
 /* flags for buf_copy_options() */
@@ -20,6 +21,8 @@ typedef enum {
   OPT_WINONLY = 16,  ///< Only set window-local options.
   OPT_NOWIN = 32,  ///< Don’t set window-local options.
 } OptionFlags;
+
+#define PRIdOPT PRIdMAX
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "option.h.generated.h"

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -292,20 +292,20 @@ enum {
 #define LISPWORD_VALUE \
   "defun,define,defmacro,set!,lambda,if,case,let,flet,let*,letrec,do,do*,define-syntax,let-syntax,letrec-syntax,destructuring-bind,defpackage,defparameter,defstruct,deftype,defvar,do-all-symbols,do-external-symbols,do-symbols,dolist,dotimes,ecase,etypecase,eval-when,labels,macrolet,multiple-value-bind,multiple-value-call,multiple-value-prog1,multiple-value-setq,prog1,progv,typecase,unless,unwind-protect,when,with-input-from-string,with-open-file,with-open-stream,with-output-to-string,with-package-iterator,define-condition,handler-bind,handler-case,restart-bind,restart-case,with-simple-restart,store-value,use-value,muffle-warning,abort,continue,with-slots,with-slots*,with-accessors,with-accessors*,defclass,defmethod,print-unreadable-object"
 
-/*
- * The following are actual variables for the options
- */
+/// Type used for number options
+typedef intmax_t NumOpt;
 
-EXTERN long p_aleph;            /* 'aleph' */
-EXTERN bool p_acd;              /* 'autochdir' */
-EXTERN char_u   *p_ambw;        /* 'ambiwidth' */
-EXTERN int p_ar;                /* 'autoread' */
-EXTERN int p_aw;                /* 'autowrite' */
-EXTERN int p_awa;               /* 'autowriteall' */
-EXTERN char_u   *p_bs;          /* 'backspace' */
-EXTERN char_u   *p_bg;          /* 'background' */
-EXTERN int p_bk;                /* 'backup' */
-EXTERN char_u   *p_bkc;         /* 'backupcopy' */
+// The following are actual variables for the options
+EXTERN NumOpt p_aleph;          ///< 'aleph'
+EXTERN bool p_acd;              ///< 'autochdir'
+EXTERN char_u *p_ambw;          ///< 'ambiwidth'
+EXTERN int p_ar;                ///< 'autoread'
+EXTERN int p_aw;                ///< 'autowrite'
+EXTERN int p_awa;               ///< 'autowriteall'
+EXTERN char_u *p_bs;            ///< 'backspace'
+EXTERN char_u *p_bg;            ///< 'background'
+EXTERN int p_bk;                ///< 'backup'
+EXTERN char_u *p_bkc;           ///< 'backupcopy'
 EXTERN unsigned int bkc_flags;  ///< flags from 'backupcopy'
 #ifdef IN_OPTION_C
 static char *(p_bkc_values[]) =
@@ -370,55 +370,55 @@ static char *(p_cb_values[]) = {"unnamed", "unnamedplus", NULL};
 # define CB_UNNAMED             0x001
 # define CB_UNNAMEDPLUS         0x002
 # define CB_UNNAMEDMASK         (CB_UNNAMED | CB_UNNAMEDPLUS)
-EXTERN long p_cwh;              // 'cmdwinheight'
-EXTERN long p_ch;               // 'cmdheight'
-EXTERN int p_confirm;           // 'confirm'
-EXTERN int p_cp;                // 'compatible'
-EXTERN char_u   *p_cot;         // 'completeopt'
-EXTERN long p_ph;               // 'pumheight'
-EXTERN char_u   *p_cpo;         // 'cpoptions'
-EXTERN char_u   *p_csprg;       // 'cscopeprg'
-EXTERN int p_csre;              // 'cscoperelative'
-EXTERN char_u   *p_csqf;        // 'cscopequickfix'
-#  define       CSQF_CMDS   "sgdctefia"
-#  define       CSQF_FLAGS  "+-0"
-EXTERN int p_cst;               /* 'cscopetag' */
-EXTERN long p_csto;             /* 'cscopetagorder' */
-EXTERN long p_cspc;             /* 'cscopepathcomp' */
-EXTERN int p_csverbose;         /* 'cscopeverbose' */
-EXTERN char_u   *p_debug;       /* 'debug' */
-EXTERN char_u   *p_def;         /* 'define' */
-EXTERN char_u   *p_inc;
-EXTERN char_u   *p_dip;         /* 'diffopt' */
-EXTERN char_u   *p_dex;         /* 'diffexpr' */
-EXTERN char_u   *p_dict;        /* 'dictionary' */
-EXTERN int p_dg;                /* 'digraph' */
-EXTERN char_u   *p_dir;         /* 'directory' */
-EXTERN char_u   *p_dy;          /* 'display' */
+# define CSQF_CMDS              "sgdctefi"
+# define CSQF_FLAGS             "+-0"
+EXTERN NumOpt p_cwh;            ///< 'cmdwinheight'
+EXTERN NumOpt p_ch;             ///< 'cmdheight'
+EXTERN int p_confirm;           ///< 'confirm'
+EXTERN int p_cp;                ///< 'compatible'
+EXTERN char_u *p_cot;           ///< 'completeopt'
+EXTERN NumOpt p_ph;             ///< 'pumheight'
+EXTERN char_u *p_cpo;           ///< 'cpoptions'
+EXTERN char_u *p_csprg;         ///< 'cscopeprg'
+EXTERN int p_csre;              ///< 'cscoperelative'
+EXTERN char_u *p_csqf;          ///< 'cscopequickfix'
+EXTERN int p_cst;               ///< 'cscopetag'
+EXTERN NumOpt p_csto;           ///< 'cscopetagorder'
+EXTERN NumOpt p_cspc;           ///< 'cscopepathcomp'
+EXTERN int p_csverbose;         ///< 'cscopeverbose'
+EXTERN char_u *p_debug;         ///< 'debug'
+EXTERN char_u *p_def;           ///< 'define'
+EXTERN char_u *p_inc;           ///< 'include'
+EXTERN char_u *p_dip;           ///< 'diffopt'
+EXTERN char_u *p_dex;           ///< 'diffexpr'
+EXTERN char_u *p_dict;          ///< 'dictionary'
+EXTERN int p_dg;                ///< 'digraph'
+EXTERN char_u *p_dir;           ///< 'directory'
+EXTERN char_u *p_dy;            ///< 'display'
 EXTERN unsigned dy_flags;
 #ifdef IN_OPTION_C
 static char *(p_dy_values[]) = {"lastline", "uhex", NULL};
 #endif
 #define DY_LASTLINE             0x001
 #define DY_UHEX                 0x002
-EXTERN int p_ed;                /* 'edcompatible' */
-EXTERN char_u   *p_ead;         /* 'eadirection' */
-EXTERN bool p_ea;               /* 'equalalways' */
-EXTERN char_u   *p_ep;          /* 'equalprg' */
-EXTERN int p_eb;                /* 'errorbells' */
-EXTERN char_u   *p_ef;          /* 'errorfile' */
-EXTERN char_u   *p_efm;         /* 'errorformat' */
-EXTERN char_u   *p_gefm;        /* 'grepformat' */
-EXTERN char_u   *p_gp;          /* 'grepprg' */
-EXTERN char_u   *p_ei;          /* 'eventignore' */
-EXTERN int p_ek;                /* 'esckeys' */
-EXTERN int p_exrc;              /* 'exrc' */
-EXTERN char_u   *p_fencs;       /* 'fileencodings' */
-EXTERN char_u   *p_ffs;         /* 'fileformats' */
+EXTERN int p_ed;                ///< 'edcompatible'
+EXTERN char_u *p_ead;           ///< 'eadirection'
+EXTERN bool p_ea;               ///< 'equalalways'
+EXTERN char_u *p_ep;            ///< 'equalprg'
+EXTERN int p_eb;                ///< 'errorbells'
+EXTERN char_u *p_ef;            ///< 'errorfile'
+EXTERN char_u *p_efm;           ///< 'errorformat'
+EXTERN char_u *p_gefm;          ///< 'grepformat'
+EXTERN char_u *p_gp;            ///< 'grepprg'
+EXTERN char_u *p_ei;            ///< 'eventignore'
+EXTERN int p_ek;                ///< 'esckeys'
+EXTERN int p_exrc;              ///< 'exrc'
+EXTERN char_u *p_fencs;         ///< 'fileencodings'
+EXTERN char_u *p_ffs;           ///< 'fileformats'
 EXTERN bool p_fic;              ///< 'fileignorecase'
-EXTERN char_u   *p_fcl;         /* 'foldclose' */
-EXTERN long p_fdls;             /* 'foldlevelstart' */
-EXTERN char_u   *p_fdo;         /* 'foldopen' */
+EXTERN char_u *p_fcl;           ///< 'foldclose'
+EXTERN NumOpt p_fdls;           ///< 'foldlevelstart'
+EXTERN char_u *p_fdo;           ///< 'foldopen'
 EXTERN unsigned fdo_flags;
 # ifdef IN_OPTION_C
 static char *(p_fdo_values[]) = {"all", "block", "hor", "mark", "percent",
@@ -436,101 +436,100 @@ static char *(p_fdo_values[]) = {"all", "block", "hor", "mark", "percent",
 # define FDO_INSERT             0x100
 # define FDO_UNDO               0x200
 # define FDO_JUMP               0x400
-EXTERN char_u   *p_fp;          // 'formatprg'
-EXTERN int p_fs;                // 'fsync'
-EXTERN int p_gd;                // 'gdefault'
-EXTERN char_u   *p_pdev;        // 'printdevice'
-EXTERN char_u   *p_penc;        // 'printencoding'
-EXTERN char_u   *p_pexpr;       // 'printexpr'
-EXTERN char_u   *p_pmfn;        // 'printmbfont'
-EXTERN char_u   *p_pmcs;        // 'printmbcharset'
-EXTERN char_u   *p_pfn;         // 'printfont'
-EXTERN char_u   *p_popt;        // 'printoptions'
-EXTERN char_u   *p_header;      // 'printheader'
-EXTERN int p_prompt;            // 'prompt'
-EXTERN char_u   *p_guicursor;   // 'guicursor'
-EXTERN char_u   *p_hf;          // 'helpfile'
-EXTERN long p_hh;               // 'helpheight'
-EXTERN char_u   *p_hlg;         // 'helplang'
-EXTERN int p_hid;               // 'hidden'
+EXTERN char_u *p_fp;            ///< 'formatprg'
+EXTERN int p_fs;                ///< 'fsync'
+EXTERN int p_gd;                ///< 'gdefault'
+EXTERN char_u *p_pdev;          ///< 'printdevice'
+EXTERN char_u *p_penc;          ///< 'printencoding'
+EXTERN char_u *p_pexpr;         ///< 'printexpr'
+EXTERN char_u *p_pmfn;          ///< 'printmbfont'
+EXTERN char_u *p_pmcs;          ///< 'printmbcharset'
+EXTERN char_u *p_pfn;           ///< 'printfont'
+EXTERN char_u *p_popt;          ///< 'printoptions'
+EXTERN char_u *p_header;        ///< 'printheader'
+EXTERN int p_prompt;            ///< 'prompt'
+EXTERN char_u *p_guicursor;     ///< 'guicursor'
+EXTERN char_u *p_hf;            ///< 'helpfile'
+EXTERN NumOpt p_hh;             ///< 'helpheight'
+EXTERN char_u *p_hlg;           ///< 'helplang'
+EXTERN int p_hid;               ///< 'hidden'
 // Use P_HID to check if a buffer is to be hidden when it is no longer
 // visible in a window.
 # define P_HID(buf) (buf_hide(buf))
-EXTERN char_u   *p_hl;          // 'highlight'
-EXTERN int p_hls;               // 'hlsearch'
-EXTERN long p_hi;               // 'history'
-EXTERN int p_hkmap;             // 'hkmap'
-EXTERN int p_hkmapp;            // 'hkmapp'
-EXTERN int p_fkmap;             // 'fkmap'
-EXTERN int p_altkeymap;         // 'altkeymap'
-EXTERN int p_arshape;           // 'arabicshape'
-EXTERN int p_icon;              // 'icon'
-EXTERN char_u   *p_iconstring;  // 'iconstring'
-EXTERN int p_ic;                // 'ignorecase'
-EXTERN int p_is;                // 'incsearch'
-EXTERN int p_im;                // 'insertmode'
-EXTERN char_u   *p_isf;         // 'isfname'
-EXTERN char_u   *p_isi;         // 'isident'
-EXTERN char_u   *p_isp;         // 'isprint'
-EXTERN int p_js;                // 'joinspaces'
-EXTERN char_u   *p_kp;          // 'keywordprg'
-EXTERN char_u   *p_km;          // 'keymodel'
-EXTERN char_u   *p_langmap;     // 'langmap'*/
-EXTERN int p_lnr;               // 'langnoremap'*/
-EXTERN char_u   *p_lm;          // 'langmenu'
-EXTERN char_u   *p_lispwords;   // 'lispwords'
-EXTERN long p_ls;               // 'laststatus'
-EXTERN long p_stal;             // 'showtabline'
-EXTERN char_u   *p_lcs;         // 'listchars'
-
-EXTERN int p_lz;                // 'lazyredraw'
-EXTERN int p_lpl;               // 'loadplugins'
-EXTERN int p_magic;             // 'magic'
-EXTERN char_u   *p_mef;         // 'makeef'
-EXTERN char_u   *p_mp;          // 'makeprg'
-EXTERN char_u   *p_cc;          // 'colorcolumn'
-EXTERN int p_cc_cols[256];      // array for 'colorcolumn' columns
-EXTERN long p_mat;              // 'matchtime'
-EXTERN long p_mco;              // 'maxcombine'
-EXTERN long p_mfd;              // 'maxfuncdepth'
-EXTERN long p_mmd;              // 'maxmapdepth'
-EXTERN long p_mm;               // 'maxmem'
-EXTERN long p_mmp;              // 'maxmempattern'
-EXTERN long p_mmt;              // 'maxmemtot'
-EXTERN long p_mis;              // 'menuitems'
-EXTERN char_u   *p_msm;         // 'mkspellmem'
-EXTERN long p_mls;              // 'modelines'
-EXTERN char_u   *p_mouse;       // 'mouse'
-EXTERN char_u   *p_mousem;      // 'mousemodel'
-EXTERN long p_mouset;           // 'mousetime'
-EXTERN int p_more;              // 'more'
-EXTERN char_u   *p_opfunc;      // 'operatorfunc'
-EXTERN char_u   *p_para;        // 'paragraphs'
-EXTERN int p_paste;             // 'paste'
-EXTERN char_u   *p_pt;          // 'pastetoggle'
-EXTERN char_u   *p_pex;         // 'patchexpr'
-EXTERN char_u   *p_pm;          // 'patchmode'
-EXTERN char_u   *p_path;        // 'path'
-EXTERN char_u   *p_cdpath;      // 'cdpath'
-EXTERN long p_rdt;              // 'redrawtime'
-EXTERN int p_remap;             // 'remap'
-EXTERN long p_re;               // 'regexpengine'
-EXTERN long p_report;           // 'report'
-EXTERN long p_pvh;              // 'previewheight'
-EXTERN int p_ari;               // 'allowrevins'
-EXTERN int p_ri;                // 'revins'
-EXTERN int p_ru;                // 'ruler'
-EXTERN char_u   *p_ruf;         // 'rulerformat'
-EXTERN char_u   *p_pp;          // 'packpath'
-EXTERN char_u   *p_rtp;         // 'runtimepath'
-EXTERN long p_sj;               // 'scrolljump'
-EXTERN long p_so;               // 'scrolloff'
-EXTERN char_u   *p_sbo;         // 'scrollopt'
-EXTERN char_u   *p_sections;    // 'sections'
-EXTERN int p_secure;            // 'secure'
-EXTERN char_u   *p_sel;         // 'selection'
-EXTERN char_u   *p_slm;         // 'selectmode'
-EXTERN char_u   *p_ssop;        // 'sessionoptions'
+EXTERN char_u *p_hl;            ///< 'highlight'
+EXTERN int p_hls;               ///< 'hlsearch'
+EXTERN NumOpt p_hi;             ///< 'history'
+EXTERN int p_hkmap;             ///< 'hkmap'
+EXTERN int p_hkmapp;            ///< 'hkmapp'
+EXTERN int p_fkmap;             ///< 'fkmap'
+EXTERN int p_altkeymap;         ///< 'altkeymap'
+EXTERN int p_arshape;           ///< 'arabicshape'
+EXTERN int p_icon;              ///< 'icon'
+EXTERN char_u *p_iconstring;    ///< 'iconstring'
+EXTERN int p_ic;                ///< 'ignorecase'
+EXTERN int p_is;                ///< 'incsearch'
+EXTERN int p_im;                ///< 'insertmode'
+EXTERN char_u *p_isf;           ///< 'isfname'
+EXTERN char_u *p_isi;           ///< 'isident'
+EXTERN char_u *p_isp;           ///< 'isprint'
+EXTERN int p_js;                ///< 'joinspaces'
+EXTERN char_u *p_kp;            ///< 'keywordprg'
+EXTERN char_u *p_km;            ///< 'keymodel'
+EXTERN char_u *p_langmap;       ///< 'langmap
+EXTERN int p_lnr;               ///< 'langnoremap'
+EXTERN char_u *p_lm;            ///< 'langmenu'
+EXTERN char_u *p_lispwords;     ///< 'lispwords'
+EXTERN NumOpt p_ls;             ///< 'laststatus'
+EXTERN NumOpt p_stal;           ///< 'showtabline'
+EXTERN char_u *p_lcs;           ///< 'listchars'
+EXTERN int p_lz;                ///< 'lazyredraw'
+EXTERN int p_lpl;               ///< 'loadplugins'
+EXTERN int p_magic;             ///< 'magic'
+EXTERN char_u *p_mef;           ///< 'makeef'
+EXTERN char_u *p_mp;            ///< 'makeprg'
+EXTERN char_u *p_cc;            ///< 'colorcolumn'
+EXTERN int p_cc_cols[256];      ///< array for 'colorcolumn' columns
+EXTERN NumOpt p_mat;            ///< 'matchtime'
+EXTERN NumOpt p_mco;            ///< 'maxcombine'
+EXTERN NumOpt p_mfd;            ///< 'maxfuncdepth'
+EXTERN NumOpt p_mmd;            ///< 'maxmapdepth'
+EXTERN NumOpt p_mm;             ///< 'maxmem'
+EXTERN NumOpt p_mmp;            ///< 'maxmempattern'
+EXTERN NumOpt p_mmt;            ///< 'maxmemtot'
+EXTERN NumOpt p_mis;            ///< 'menuitems'
+EXTERN char_u *p_msm;           ///< 'mkspellmem'
+EXTERN NumOpt p_mls;            ///< 'modelines'
+EXTERN char_u *p_mouse;         ///< 'mouse'
+EXTERN char_u *p_mousem;        ///< 'mousemodel'
+EXTERN NumOpt p_mouset;         ///< 'mousetime'
+EXTERN int p_more;              ///< 'more'
+EXTERN char_u *p_opfunc;        ///< 'operatorfunc'
+EXTERN char_u *p_para;          ///< 'paragraphs'
+EXTERN int p_paste;             ///< 'paste'
+EXTERN char_u *p_pt;            ///< 'pastetoggle'
+EXTERN char_u *p_pex;           ///< 'patchexpr'
+EXTERN char_u *p_pm;            ///< 'patchmode'
+EXTERN char_u *p_path;          ///< 'path'
+EXTERN char_u *p_cdpath;        ///< 'cdpath'
+EXTERN NumOpt p_rdt;            ///< 'redrawtime'
+EXTERN int p_remap;             ///< 'remap'
+EXTERN NumOpt p_re;             ///< 'regexpengine'
+EXTERN NumOpt p_report;         ///< 'report'
+EXTERN NumOpt p_pvh;            ///< 'previewheight'
+EXTERN int p_ari;               ///< 'allowrevins'
+EXTERN int p_ri;                ///< 'revins'
+EXTERN int p_ru;                ///< 'ruler'
+EXTERN char_u *p_ruf;           ///< 'rulerformat'
+EXTERN char_u *p_pp;            ///< 'packpath'
+EXTERN char_u *p_rtp;           ///< 'runtimepath'
+EXTERN NumOpt p_sj;             ///< 'scrolljump'
+EXTERN NumOpt p_so;             ///< 'scrolloff'
+EXTERN char_u *p_sbo;           ///< 'scrollopt'
+EXTERN char_u *p_sections;      ///< 'sections'
+EXTERN int p_secure;            ///< 'secure'
+EXTERN char_u *p_sel;           ///< 'selection'
+EXTERN char_u *p_slm;           ///< 'selectmode'
+EXTERN char_u *p_ssop;          ///< 'sessionoptions'
 EXTERN unsigned ssop_flags;
 # ifdef IN_OPTION_C
 /* Also used for 'viewoptions'! */
@@ -556,37 +555,37 @@ static char *(p_ssop_values[]) = {"buffers", "winpos", "resize", "winsize",
 # define SSOP_FOLDS             0x2000
 # define SSOP_CURSOR            0x4000
 # define SSOP_TABPAGES          0x8000
-EXTERN char_u   *p_sh;          /* 'shell' */
-EXTERN char_u   *p_shcf;        /* 'shellcmdflag' */
-EXTERN char_u   *p_sp;          /* 'shellpipe' */
-EXTERN char_u   *p_shq;         /* 'shellquote' */
-EXTERN char_u   *p_sxq;         /* 'shellxquote' */
-EXTERN char_u   *p_sxe;         /* 'shellxescape' */
-EXTERN char_u   *p_srr;         /* 'shellredir' */
-EXTERN int p_stmp;              /* 'shelltemp' */
 #ifdef BACKSLASH_IN_FILENAME
-EXTERN int p_ssl;               /* 'shellslash' */
+EXTERN int p_ssl;               ///< 'shellslash'
 #endif
-EXTERN char_u   *p_stl;         // 'statusline'
-EXTERN int p_sr;                // 'shiftround'
-EXTERN char_u   *p_shm;         // 'shortmess'
-EXTERN char_u   *p_sbr;         // 'showbreak'
-EXTERN int p_sc;                // 'showcmd'
-EXTERN int p_sft;               // 'showfulltag'
-EXTERN int p_sm;                // 'showmatch'
-EXTERN int p_smd;               // 'showmode'
-EXTERN long p_ss;               // 'sidescroll'
-EXTERN long p_siso;             // 'sidescrolloff'
-EXTERN int p_scs;               // 'smartcase'
-EXTERN int p_sta;               // 'smarttab'
-EXTERN int p_sb;                // 'splitbelow'
-EXTERN long p_tpm;              // 'tabpagemax'
-EXTERN char_u   *p_tal;         // 'tabline'
-EXTERN char_u   *p_sps;         // 'spellsuggest'
-EXTERN int p_spr;               // 'splitright'
-EXTERN int p_sol;               // 'startofline'
-EXTERN char_u   *p_su;          // 'suffixes'
-EXTERN char_u   *p_swb;         // 'switchbuf'
+EXTERN char_u *p_sh;            ///< 'shell'
+EXTERN char_u *p_shcf;          ///< 'shellcmdflag'
+EXTERN char_u *p_sp;            ///< 'shellpipe'
+EXTERN char_u *p_shq;           ///< 'shellquote'
+EXTERN char_u *p_sxq;           ///< 'shellxquote'
+EXTERN char_u *p_sxe;           ///< 'shellxescape'
+EXTERN char_u *p_srr;           ///< 'shellredir'
+EXTERN int p_stmp;              ///< 'shelltemp'
+EXTERN char_u *p_stl;           ///< 'statusline'
+EXTERN int p_sr;                ///< 'shiftround'
+EXTERN char_u *p_shm;           ///< 'shortmess'
+EXTERN char_u *p_sbr;           ///< 'showbreak'
+EXTERN int p_sc;                ///< 'showcmd'
+EXTERN int p_sft;               ///< 'showfulltag'
+EXTERN int p_sm;                ///< 'showmatch'
+EXTERN int p_smd;               ///< 'showmode'
+EXTERN NumOpt p_ss;             ///< 'sidescroll'
+EXTERN NumOpt p_siso;           ///< 'sidescrolloff'
+EXTERN int p_scs;               ///< 'smartcase'
+EXTERN int p_sta;               ///< 'smarttab'
+EXTERN int p_sb;                ///< 'splitbelow'
+EXTERN NumOpt p_tpm;            ///< 'tabpagemax'
+EXTERN char_u *p_tal;           ///< 'tabline'
+EXTERN char_u *p_sps;           ///< 'spellsuggest'
+EXTERN int p_spr;               ///< 'splitright'
+EXTERN int p_sol;               ///< 'startofline'
+EXTERN char_u *p_su;            ///< 'suffixes'
+EXTERN char_u *p_swb;           ///< 'switchbuf'
 EXTERN unsigned swb_flags;
 #ifdef IN_OPTION_C
 static char *(p_swb_values[]) =
@@ -606,7 +605,7 @@ static char *(p_tc_values[]) = { "followic", "ignore", "match", NULL };
 #define TC_FOLLOWIC             0x01
 #define TC_IGNORE               0x02
 #define TC_MATCH                0x04
-EXTERN long p_tl;               ///< 'taglength'
+EXTERN NumOpt p_tl;             ///< 'taglength'
 EXTERN int p_tr;                ///< 'tagrelative'
 EXTERN char_u *p_tags;          ///< 'tags'
 EXTERN int p_tgst;              ///< 'tagstack'
@@ -614,20 +613,20 @@ EXTERN int p_tbidi;             ///< 'termbidi'
 EXTERN int p_terse;             ///< 'terse'
 EXTERN int p_to;                ///< 'tildeop'
 EXTERN int p_timeout;           ///< 'timeout'
-EXTERN long p_tm;               ///< 'timeoutlen'
+EXTERN NumOpt p_tm;             ///< 'timeoutlen'
 EXTERN int p_title;             ///< 'title'
-EXTERN long p_titlelen;         ///< 'titlelen'
+EXTERN NumOpt p_titlelen;       ///< 'titlelen'
 EXTERN char_u *p_titleold;      ///< 'titleold'
 EXTERN char_u *p_titlestring;   ///< 'titlestring'
 EXTERN char_u *p_tsr;           ///< 'thesaurus'
 EXTERN bool p_tgc;              ///< 'termguicolors'
 EXTERN int p_ttimeout;          ///< 'ttimeout'
-EXTERN long p_ttm;              ///< 'ttimeoutlen'
+EXTERN NumOpt p_ttm;            ///< 'ttimeoutlen'
 EXTERN char_u *p_udir;          ///< 'undodir'
-EXTERN long p_ul;               ///< 'undolevels'
-EXTERN long p_ur;               ///< 'undoreload'
-EXTERN long p_uc;               ///< 'updatecount'
-EXTERN long p_ut;               ///< 'updatetime'
+EXTERN NumOpt p_ul;             ///< 'undolevels'
+EXTERN NumOpt p_ur;             ///< 'undoreload'
+EXTERN NumOpt p_uc;             ///< 'updatecount'
+EXTERN NumOpt p_ut;             ///< 'updatetime'
 EXTERN char_u *p_fcs;           ///< 'fillchar'
 EXTERN char_u *p_shada;         ///< 'shada'
 EXTERN char_u *p_vdir;          ///< 'viewdir'
@@ -643,33 +642,32 @@ static char *(p_ve_values[]) = {"block", "insert", "all", "onemore", NULL};
 # define VE_INSERT      6       /* includes "all" */
 # define VE_ALL         4
 # define VE_ONEMORE     8
-EXTERN long p_verbose;          /* 'verbose' */
+EXTERN NumOpt p_verbose;        ///< 'verbose'
 #ifdef IN_OPTION_C
 char_u  *p_vfile = (char_u *)""; /* used before options are initialized */
 #else
 extern char_u   *p_vfile;       /* 'verbosefile' */
 #endif
-EXTERN int p_warn;              /* 'warn' */
-EXTERN char_u   *p_wop;         /* 'wildoptions' */
-EXTERN long p_window;           /* 'window' */
-EXTERN char_u   *p_wak;         /* 'winaltkeys' */
-EXTERN char_u   *p_wig;         /* 'wildignore' */
-EXTERN char_u   *p_ww;          /* 'whichwrap' */
-EXTERN long p_wc;               /* 'wildchar' */
-EXTERN long p_wcm;              /* 'wildcharm' */
+EXTERN int p_warn;              ///< 'warn'
+EXTERN char_u *p_wop;           ///< 'wildoptions'
+EXTERN NumOpt p_window;         ///< 'window'
+EXTERN char_u *p_wak;           ///< 'winaltkeys'
+EXTERN char_u *p_wig;           ///< 'wildignore'
+EXTERN char_u *p_ww;            ///< 'whichwrap'
+EXTERN NumOpt p_wc;             ///< 'wildchar'
+EXTERN NumOpt p_wcm;            ///< 'wildcharm'
 EXTERN bool p_wic;              ///< 'wildignorecase'
-EXTERN char_u   *p_wim;         /* 'wildmode' */
-EXTERN int p_wmnu;              /* 'wildmenu' */
-EXTERN long p_wh;               /* 'winheight' */
-EXTERN long p_wmh;              /* 'winminheight' */
-EXTERN long p_wmw;              /* 'winminwidth' */
-EXTERN long p_wiw;              /* 'winwidth' */
-EXTERN bool p_ws;               /* 'wrapscan' */
-EXTERN int p_write;             /* 'write' */
-EXTERN int p_wa;                /* 'writeany' */
-EXTERN int p_wb;                /* 'writebackup' */
-EXTERN long p_wd;               /* 'writedelay' */
-
+EXTERN char_u *p_wim;           ///< 'wildmode'
+EXTERN int p_wmnu;              ///< 'wildmenu'
+EXTERN NumOpt p_wh;             ///< 'winheight'
+EXTERN NumOpt p_wmh;            ///< 'winminheight'
+EXTERN NumOpt p_wmw;            ///< 'winminwidth'
+EXTERN NumOpt p_wiw;            ///< 'winwidth'
+EXTERN bool p_ws;               ///< 'wrapscan'
+EXTERN int p_write;             ///< 'write'
+EXTERN int p_wa;                ///< 'writeany'
+EXTERN int p_wb;                ///< 'writebackup'
+EXTERN NumOpt p_wd;             ///< 'writedelay'
 EXTERN int p_force_on;          ///< options that cannot be turned off.
 EXTERN int p_force_off;         ///< options that cannot be turned on.
 

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -636,7 +636,7 @@ static int pum_set_selected(int n, int repeat)
           // text, but no more than 'previewheight' lines.
           if (repeat == 0) {
             if (lnum > p_pvh) {
-              lnum = p_pvh;
+              lnum = (linenr_T)p_pvh;
             }
 
             if (curwin->w_height < lnum) {

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2925,10 +2925,9 @@ void ex_vimgrep(exarg_T *eap)
   int using_dummy;
   int redraw_for_dummy = FALSE;
   int found_match;
-  buf_T       *first_match_buf = NULL;
+  buf_T *first_match_buf = NULL;
   time_t seconds = 0;
-  long save_mls;
-  char_u      *save_ei = NULL;
+  char_u *save_ei = NULL;
   aco_save_T aco;
   int flags = 0;
   colnr_T col;
@@ -3058,11 +3057,11 @@ void ex_vimgrep(exarg_T *eap)
       using_dummy = TRUE;
       redraw_for_dummy = TRUE;
 
-      /* Don't do Filetype autocommands to avoid loading syntax and
-       * indent scripts, a great speed improvement. */
+      // Don't do Filetype autocommands to avoid loading syntax and
+      // indent scripts, a great speed improvement.
       save_ei = au_event_disable(",Filetype");
-      /* Don't use modelines here, it's useless. */
-      save_mls = p_mls;
+      // Don't use modelines here, it's useless
+      NumOpt save_mls = p_mls;
       p_mls = 0;
 
       /* Load file into a buffer, so that 'fileencoding' is detected,

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -2352,7 +2352,7 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer,
 
   // Initialize history merger
   for (uint8_t i = 0; i < HIST_COUNT; i++) {
-    long num_saved = get_shada_parameter(hist_type2char(i));
+    intmax_t num_saved = get_shada_parameter(hist_type2char(i));
     if (num_saved == -1) {
       num_saved = p_hi;
     }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -13023,7 +13023,7 @@ void ex_spellinfo(exarg_T *eap)
 void ex_spelldump(exarg_T *eap)
 {
   char_u  *spl;
-  long dummy;
+  NumOpt dummy;
 
   if (no_spell_checking(curwin))
     return;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -308,13 +308,14 @@ bool undo_allowed(void)
 /*
  * Get the undolevle value for the current buffer.
  */
-static long get_undolevel(void)
+static intmax_t get_undolevel(void)
 {
   if (curbuf->terminal) {
     return -1;
   }
-  if (curbuf->b_p_ul == NO_LOCAL_UNDOLEVEL)
+  if (curbuf->b_p_ul == NO_LOCAL_UNDOLEVEL) {
     return p_ul;
+  }
   return curbuf->b_p_ul;
 }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2644,9 +2644,6 @@ void maybe_intro_message(void)
 void intro_message(int colon)
 {
   int i;
-  long row;
-  long blanklines;
-  int sponsor;
   char *p;
   static char *(lines[]) = {
     N_(NVIM_VERSION_LONG),
@@ -2667,9 +2664,9 @@ void intro_message(int colon)
 
   // blanklines = screen height - # message lines
   size_t lines_size = ARRAY_SIZE(lines);
-  assert(lines_size <= LONG_MAX);
 
-  blanklines = Rows - ((long)lines_size - 1l);
+  assert(lines_size <= LONG_MAX);
+  intmax_t blanklines = Rows - (intmax_t)lines_size + 1;
 
   // Don't overwrite a statusline.  Depends on 'cmdheight'.
   if (p_ls > 1) {
@@ -2682,11 +2679,11 @@ void intro_message(int colon)
 
   // Show the sponsor and register message one out of four times, the Uganda
   // message two out of four times.
-  sponsor = (int)time(NULL);
+  int sponsor = (int)time(NULL);
   sponsor = ((sponsor & 2) == 0) - ((sponsor & 4) == 0);
 
   // start displaying the message lines after half of the blank lines
-  row = blanklines / 2;
+  intmax_t row = blanklines / 2;
 
   if (((row >= 2) && (Columns >= 50)) || colon) {
     for (i = 0; i < (int)ARRAY_SIZE(lines); ++i) {
@@ -2720,15 +2717,14 @@ void intro_message(int colon)
   }
 }
 
-static void do_intro_line(long row, char_u *mesg, int attr)
+static void do_intro_line(intmax_t row, char_u *mesg, int attr)
 {
-  long col;
   char_u *p;
   int l;
   int clen;
 
   // Center the message horizontally.
-  col = vim_strsize(mesg);
+  intmax_t col = vim_strsize(mesg);
 
   col = (Columns - col) / 2;
 


### PR DESCRIPTION
ref #3803 for discussion. This is a first draft at making all numerical option types from long to NumOpt (ptrdiff_t).

Edit: ptrdiff_t -> intmax_t since maxmem\* option will disappear.
