### PR TITLE
[WIP] represent boolean options as bool

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3302,9 +3302,9 @@ int build_stl_str_hl(
       // In list mode virtcol needs to be recomputed
       colnr_T virtcol = wp->w_virtcol;
       if (wp->w_p_list && lcs_tab1 == NUL) {
-        wp->w_p_list = FALSE;
+        wp->w_p_list = false;
         getvcol(wp, &wp->w_cursor, NULL, &virtcol, NULL);
-        wp->w_p_list = TRUE;
+        wp->w_p_list = true;
       }
       ++virtcol;
       // Don't display %V if it's the same as %c.

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -100,7 +100,7 @@ open_buffer (
    */
   if (readonlymode && curbuf->b_ffname != NULL
       && (curbuf->b_flags & BF_NEVERLOADED))
-    curbuf->b_p_ro = TRUE;
+    curbuf->b_p_ro = true;
 
   if (ml_open(curbuf) == FAIL) {
     /*
@@ -149,7 +149,7 @@ open_buffer (
     if (curbuf->b_help)
       fix_help_buffer();
   } else if (read_stdin) {
-    int save_bin = curbuf->b_p_bin;
+    bool save_bin = curbuf->b_p_bin;
     linenr_T line_count;
 
     /*
@@ -158,7 +158,7 @@ open_buffer (
      * it possible to retry when 'fileformat' or 'fileencoding' was
      * guessed wrong.
      */
-    curbuf->b_p_bin = TRUE;
+    curbuf->b_p_bin = true;
     retval = readfile(NULL, NULL, (linenr_T)0,
         (linenr_T)0, (linenr_T)MAXLNUM, NULL,
         flags | (READ_NEW + READ_STDIN));
@@ -458,7 +458,7 @@ close_buffer (
     }
     buf_clear_file(buf);
     if (del_buf)
-      buf->b_p_bl = FALSE;
+      buf->b_p_bl = false;
   }
 }
 
@@ -469,9 +469,9 @@ void buf_clear_file(buf_T *buf)
 {
   buf->b_ml.ml_line_count = 1;
   unchanged(buf, TRUE);
-  buf->b_p_eol = TRUE;
+  buf->b_p_eol = true;
   buf->b_start_eol = TRUE;
-  buf->b_p_bomb = FALSE;
+  buf->b_p_bomb = false;
   buf->b_start_bomb = FALSE;
   buf->b_ml.ml_mfp = NULL;
   buf->b_ml.ml_flags = ML_EMPTY;                /* empty buffer */
@@ -1341,7 +1341,7 @@ buflist_new (
      * already */
     buf_copy_options(buf, 0);
     if ((flags & BLN_LISTED) && !buf->b_p_bl) {
-      buf->b_p_bl = TRUE;
+      buf->b_p_bl = true;
       if (!(flags & BLN_DUMMY)) {
         apply_autocmds(EVENT_BUFADD, NULL, NULL, FALSE, buf);
         if (!buf_valid(buf)) {
@@ -1472,7 +1472,7 @@ buflist_new (
   buf_clear_file(buf);
   clrallmarks(buf);                     /* clear marks */
   fmarks_check_names(buf);              /* check file marks for this file */
-  buf->b_p_bl = (flags & BLN_LISTED) ? TRUE : FALSE;    /* init 'buflisted' */
+  buf->b_p_bl = (flags & BLN_LISTED) ? true : false;    /* init 'buflisted' */
   if (!(flags & BLN_DUMMY)) {
     // Tricky: these autocommands may change the buffer list.  They could also
     // split the window with re-using the one empty buffer. This may result in

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1546,7 +1546,7 @@ void free_buf_options(buf_T *buf, int free_p_ff)
   clear_string_option(&buf->b_p_dict);
   clear_string_option(&buf->b_p_tsr);
   clear_string_option(&buf->b_p_qe);
-  buf->b_p_ar = -1;
+  buf->has_b_p_ar = false;
   buf->b_p_ul = NO_LOCAL_UNDOLEVEL;
   clear_string_option(&buf->b_p_lw);
   clear_string_option(&buf->b_p_bkc);

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -144,21 +144,21 @@ struct buffheader {
  * Also used in wininfo_T.
  */
 typedef struct {
-  int wo_arab;
+  bool wo_arab;
 # define w_p_arab w_onebuf_opt.wo_arab  /* 'arabic' */
-  int wo_bri;
+  bool wo_bri;
 # define w_p_bri w_onebuf_opt.wo_bri	/* 'breakindent' */
   char_u *wo_briopt;
 # define w_p_briopt w_onebuf_opt.wo_briopt /* 'breakindentopt' */
-  int wo_diff;
+  bool wo_diff;
 # define w_p_diff w_onebuf_opt.wo_diff  /* 'diff' */
   long wo_fdc;
 # define w_p_fdc w_onebuf_opt.wo_fdc    /* 'foldcolumn' */
   int wo_fdc_save;
 # define w_p_fdc_save w_onebuf_opt.wo_fdc_save  /* 'foldenable' saved for diff mode */
-  int wo_fen;
+  bool wo_fen;
 # define w_p_fen w_onebuf_opt.wo_fen    /* 'foldenable' */
-  int wo_fen_save;
+  bool wo_fen_save;
 # define w_p_fen_save w_onebuf_opt.wo_fen_save  /* 'foldenable' saved for diff mode */
   char_u      *wo_fdi;
 # define w_p_fdi w_onebuf_opt.wo_fdi    /* 'foldignore' */
@@ -180,45 +180,45 @@ typedef struct {
 #  define w_p_fdt w_onebuf_opt.wo_fdt   /* 'foldtext' */
   char_u      *wo_fmr;
 # define w_p_fmr w_onebuf_opt.wo_fmr    /* 'foldmarker' */
-  int wo_lbr;
+  bool wo_lbr;
 # define w_p_lbr w_onebuf_opt.wo_lbr    /* 'linebreak' */
-  int wo_list;
+  bool wo_list;
 #define w_p_list w_onebuf_opt.wo_list   /* 'list' */
-  int wo_nu;
+  bool wo_nu;
 #define w_p_nu w_onebuf_opt.wo_nu       /* 'number' */
-  int wo_rnu;
+  bool wo_rnu;
 #define w_p_rnu w_onebuf_opt.wo_rnu     /* 'relativenumber' */
   long wo_nuw;
 # define w_p_nuw w_onebuf_opt.wo_nuw    /* 'numberwidth' */
-  int wo_wfh;
+  bool wo_wfh;
 # define w_p_wfh w_onebuf_opt.wo_wfh    /* 'winfixheight' */
-  int wo_wfw;
+  bool wo_wfw;
 # define w_p_wfw w_onebuf_opt.wo_wfw    /* 'winfixwidth' */
-  int wo_pvw;
+  bool wo_pvw;
 # define w_p_pvw w_onebuf_opt.wo_pvw    /* 'previewwindow' */
-  int wo_rl;
+  bool wo_rl;
 # define w_p_rl w_onebuf_opt.wo_rl      /* 'rightleft' */
   char_u      *wo_rlc;
 # define w_p_rlc w_onebuf_opt.wo_rlc    /* 'rightleftcmd' */
   long wo_scr;
 #define w_p_scr w_onebuf_opt.wo_scr     /* 'scroll' */
-  int wo_spell;
+  bool wo_spell;
 # define w_p_spell w_onebuf_opt.wo_spell /* 'spell' */
-  int wo_cuc;
+  bool wo_cuc;
 # define w_p_cuc w_onebuf_opt.wo_cuc    /* 'cursorcolumn' */
-  int wo_cul;
+  bool wo_cul;
 # define w_p_cul w_onebuf_opt.wo_cul    /* 'cursorline' */
   char_u      *wo_cc;
 # define w_p_cc w_onebuf_opt.wo_cc      /* 'colorcolumn' */
   char_u      *wo_stl;
 #define w_p_stl w_onebuf_opt.wo_stl     /* 'statusline' */
-  int wo_scb;
+  bool wo_scb;
 # define w_p_scb w_onebuf_opt.wo_scb    /* 'scrollbind' */
-  int wo_diff_saved;           /* options were saved for starting diff mode */
+  bool wo_diff_saved;           /* options were saved for starting diff mode */
 # define w_p_diff_saved w_onebuf_opt.wo_diff_saved
-  int wo_scb_save;              /* 'scrollbind' saved for diff mode*/
+  bool wo_scb_save;              /* 'scrollbind' saved for diff mode*/
 # define w_p_scb_save w_onebuf_opt.wo_scb_save
-  int wo_wrap;
+  bool wo_wrap;
 #define w_p_wrap w_onebuf_opt.wo_wrap   /* 'wrap' */
   int wo_wrap_save;             /* 'wrap' state saved for diff mode*/
 # define w_p_wrap_save w_onebuf_opt.wo_wrap_save
@@ -226,9 +226,9 @@ typedef struct {
 # define w_p_cocu w_onebuf_opt.wo_cocu
   long wo_cole;                         /* 'conceallevel' */
 # define w_p_cole w_onebuf_opt.wo_cole
-  int wo_crb;
+  bool wo_crb;
 # define w_p_crb w_onebuf_opt.wo_crb    /* 'cursorbind' */
-  int wo_crb_save;              /* 'cursorbind' state saved for diff mode*/
+  bool wo_crb_save;              /* 'cursorbind' state saved for diff mode*/
 # define w_p_crb_save w_onebuf_opt.wo_crb_save
 
   int wo_scriptID[WV_COUNT];            /* SIDs for window-local options */

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -664,7 +664,8 @@ struct file_buffer {
   char_u      *b_p_efm;         /* 'errorformat' local value */
   char_u      *b_p_ep;          /* 'equalprg' local value */
   char_u      *b_p_path;        /* 'path' local value */
-  int b_p_ar;                   /* 'autoread' local value */
+  bool b_p_ar;                  // 'autoread' local value, when present
+  bool has_b_p_ar;              // whether buffer has an 'autoread' local value
   char_u      *b_p_tags;        /* 'tags' local value */
   char_u      *b_p_dict;        /* 'dictionary' local value */
   char_u      *b_p_tsr;         /* 'thesaurus' local value */

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -592,17 +592,17 @@ struct file_buffer {
 
   int b_p_scriptID[BV_COUNT];           /* SIDs for buffer-local options */
 
-  int b_p_ai;                   /* 'autoindent' */
-  int b_p_ai_nopaste;           /* b_p_ai saved for paste mode */
+  bool b_p_ai;                   /* 'autoindent' */
+  bool b_p_ai_nopaste;           /* b_p_ai saved for paste mode */
   char_u      *b_p_bkc;         ///< 'backupcopy'
   unsigned int b_bkc_flags;     ///< flags for 'backupcopy'
-  int b_p_ci;                   /* 'copyindent' */
-  int b_p_bin;                  /* 'binary' */
-  int b_p_bomb;                 /* 'bomb' */
+  bool b_p_ci;                   /* 'copyindent' */
+  bool b_p_bin;                  /* 'binary' */
+  bool b_p_bomb;                 /* 'bomb' */
   char_u      *b_p_bh;          /* 'bufhidden' */
   char_u      *b_p_bt;          /* 'buftype' */
-  int b_p_bl;                   /* 'buflisted' */
-  int b_p_cin;                  /* 'cindent' */
+  bool b_p_bl;                   /* 'buflisted' */
+  bool b_p_cin;                  /* 'cindent' */
   char_u      *b_p_cino;        /* 'cinoptions' */
   char_u      *b_p_cink;        /* 'cinkeys' */
   char_u      *b_p_cinw;        /* 'cinwords' */
@@ -611,16 +611,16 @@ struct file_buffer {
   char_u      *b_p_cpt;         /* 'complete' */
   char_u      *b_p_cfu;         /* 'completefunc' */
   char_u      *b_p_ofu;         /* 'omnifunc' */
-  int b_p_eol;                  /* 'endofline' */
-  int b_p_fixeol;               /* 'fixendofline' */
-  int b_p_et;                   /* 'expandtab' */
-  int b_p_et_nobin;             /* b_p_et saved for binary mode */
+  bool b_p_eol;                  /* 'endofline' */
+  bool b_p_fixeol;               /* 'fixendofline' */
+  bool b_p_et;                   /* 'expandtab' */
+  bool b_p_et_nobin;             /* b_p_et saved for binary mode */
   char_u      *b_p_fenc;        /* 'fileencoding' */
   char_u      *b_p_ff;          /* 'fileformat' */
   char_u      *b_p_ft;          /* 'filetype' */
   char_u      *b_p_fo;          /* 'formatoptions' */
   char_u      *b_p_flp;         /* 'formatlistpat' */
-  int b_p_inf;                  /* 'infercase' */
+  bool b_p_inf;                  /* 'infercase' */
   char_u      *b_p_isk;         /* 'iskeyword' */
   char_u      *b_p_def;         /* 'define' local value */
   char_u      *b_p_inc;         /* 'include' */
@@ -632,17 +632,17 @@ struct file_buffer {
   char_u      *b_p_fex;         /* 'formatexpr' */
   uint32_t b_p_fex_flags;       /* flags for 'formatexpr' */
   char_u      *b_p_kp;          /* 'keywordprg' */
-  int b_p_lisp;                 /* 'lisp' */
+  bool b_p_lisp;                 /* 'lisp' */
   char_u      *b_p_mps;         /* 'matchpairs' */
-  int b_p_ml;                   /* 'modeline' */
-  int b_p_ml_nobin;             /* b_p_ml saved for binary mode */
-  int b_p_ma;                   /* 'modifiable' */
+  bool b_p_ml;                   /* 'modeline' */
+  bool b_p_ml_nobin;             /* b_p_ml saved for binary mode */
+  bool b_p_ma;                   /* 'modifiable' */
   char_u      *b_p_nf;          /* 'nrformats' */
-  int b_p_pi;                   /* 'preserveindent' */
+  bool b_p_pi;                   /* 'preserveindent' */
   char_u      *b_p_qe;          /* 'quoteescape' */
-  int b_p_ro;                   /* 'readonly' */
+  bool b_p_ro;                   /* 'readonly' */
   long b_p_sw;                  /* 'shiftwidth' */
-  int b_p_si;                   /* 'smartindent' */
+  bool b_p_si;                   /* 'smartindent' */
   long b_p_sts;                 /* 'softtabstop' */
   long b_p_sts_nopaste;         /* b_p_sts saved for paste mode */
   char_u      *b_p_sua;         /* 'suffixesadd' */
@@ -669,7 +669,7 @@ struct file_buffer {
   char_u      *b_p_dict;        /* 'dictionary' local value */
   char_u      *b_p_tsr;         /* 'thesaurus' local value */
   long b_p_ul;                  /* 'undolevels' local value */
-  int b_p_udf;                  /* 'undofile' */
+  bool b_p_udf;                  /* 'undofile' */
   char_u      *b_p_lw;          // 'lispwords' local value
 
   /* end of buffer options */

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1319,10 +1319,10 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor,
 /// @retujrn The virtual cursor column.
 colnr_T getvcol_nolist(pos_T *posp)
 {
-  int list_save = curwin->w_p_list;
+  bool list_save = curwin->w_p_list;
   colnr_T vcol;
 
-  curwin->w_p_list = FALSE;
+  curwin->w_p_list = false;
   getvcol(curwin, posp, NULL, &vcol, NULL);
   curwin->w_p_list = list_save;
   return vcol;

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1014,7 +1014,7 @@ void ex_diffsplit(exarg_T *eap)
   if (win_split(0, (diff_flags & DIFF_VERTICAL) ? WSP_VERT : 0) != FAIL) {
     // Pretend it was a ":split fname" command
     eap->cmdidx = CMD_split;
-    curwin->w_p_diff = TRUE;
+    curwin->w_p_diff = true;
     do_exedit(eap, old_curwin);
 
     // split must have worked
@@ -1045,23 +1045,23 @@ void diff_win_options(win_T *wp, int addbuf)
   newFoldLevel();
   curwin = old_curwin;
 
-  wp->w_p_diff = TRUE;
+  wp->w_p_diff = true;
 
   // Use 'scrollbind' and 'cursorbind' when available
   if (!wp->w_p_diff_saved) {
     wp->w_p_scb_save = wp->w_p_scb;
   }
-  wp->w_p_scb = TRUE;
+  wp->w_p_scb = true;
 
   if (!wp->w_p_diff_saved) {
     wp->w_p_crb_save = wp->w_p_crb;
   }
-  wp->w_p_crb = TRUE;
+  wp->w_p_crb = true;
 
   if (!wp->w_p_diff_saved) {
     wp->w_p_wrap_save = wp->w_p_wrap;
   }
-  wp->w_p_wrap = FALSE;
+  wp->w_p_wrap = false;
   curwin = wp;
   curbuf = curwin->w_buffer;
 
@@ -1079,7 +1079,7 @@ void diff_win_options(win_T *wp, int addbuf)
     wp->w_p_fdl_save = wp->w_p_fdl;
   }
   wp->w_p_fdc = diff_foldcolumn;
-  wp->w_p_fen = TRUE;
+  wp->w_p_fen = true;
   wp->w_p_fdl = 0;
   foldUpdateAll(wp);
 
@@ -1090,7 +1090,7 @@ void diff_win_options(win_T *wp, int addbuf)
   }
 
   // Saved the current values, to be restored in ex_diffoff().
-  wp->w_p_diff_saved = TRUE;
+  wp->w_p_diff_saved = true;
 
   if (addbuf) {
     diff_buf_add(wp->w_buffer);
@@ -1111,18 +1111,18 @@ void ex_diffoff(exarg_T *eap)
     if (eap->forceit ? wp->w_p_diff : (wp == curwin)) {
       // Set 'diff', 'scrollbind' off and 'wrap' on. If option values
       // were saved in diff_win_options() restore them.
-      wp->w_p_diff = FALSE;
+      wp->w_p_diff = false;
 
       if (wp->w_p_scb) {
-        wp->w_p_scb = wp->w_p_diff_saved ? wp->w_p_scb_save : FALSE;
+        wp->w_p_scb = wp->w_p_diff_saved ? wp->w_p_scb_save : false;
       }
 
       if (wp->w_p_crb) {
-        wp->w_p_crb = wp->w_p_diff_saved ? wp->w_p_crb_save : FALSE;
+        wp->w_p_crb = wp->w_p_diff_saved ? wp->w_p_crb_save : false;
       }
 
       if (!wp->w_p_wrap) {
-        wp->w_p_wrap = wp->w_p_diff_saved ? wp->w_p_wrap_save : TRUE;
+        wp->w_p_wrap = wp->w_p_diff_saved ? wp->w_p_wrap_save : true;
       }
       curwin = wp;
       curbuf = curwin->w_buffer;
@@ -1151,7 +1151,7 @@ void ex_diffoff(exarg_T *eap)
         // Only restore 'foldenable' when 'foldmethod' is not
         // "manual", otherwise we continue to show the diff folds.
         if (foldmethodIsManual(wp) || !wp->w_p_diff_saved) {
-          wp->w_p_fen = FALSE;
+          wp->w_p_fen = false;
         } else {
           wp->w_p_fen = wp->w_p_fen_save;
         }
@@ -1165,7 +1165,7 @@ void ex_diffoff(exarg_T *eap)
       // Note: 'sbo' is not restored, it's a global option.
       diff_buf_adjust(wp);
 
-      wp->w_p_diff_saved = FALSE;
+      wp->w_p_diff_saved = false;
     }
     diffwin |= wp->w_p_diff;
   }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2580,7 +2580,6 @@ ins_compl_dictionaries (
   regmatch_T regmatch;
   char_u      **files;
   int count;
-  int save_p_scs;
   int dir = compl_direction;
 
   if (*dict == NUL) {
@@ -2596,9 +2595,9 @@ ins_compl_dictionaries (
   regmatch.regprog = NULL;      /* so that we can goto theend */
 
   /* If 'infercase' is set, don't use 'smartcase' here */
-  save_p_scs = p_scs;
+  bool save_p_scs = p_scs;
   if (curbuf->b_p_inf)
-    p_scs = FALSE;
+    p_scs = false;
 
   /* When invoked to match whole lines for CTRL-X CTRL-L adjust the pattern
    * to only match at the start of a line.  Otherwise just match the
@@ -3555,9 +3554,9 @@ static int ins_compl_get_exp(pos_T *ini)
 
   pos_T       *pos;
   char_u      **matches;
-  int save_p_scs;
+  bool save_p_scs;
   bool save_p_ws;
-  int save_p_ic;
+  bool save_p_ic;
   int i;
   int num_matches;
   int len;
@@ -3752,7 +3751,7 @@ static int ins_compl_get_exp(pos_T *ini)
       save_p_scs = p_scs;
       assert(ins_buf);
       if (ins_buf->b_p_inf)
-        p_scs = FALSE;
+        p_scs = false;
 
       /*	Buffers other than curbuf are scanned from the beginning or the
        *	end but never from the middle, thus setting nowrapscan in this

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1584,7 +1584,7 @@ change_indent (
 
   /* for the following tricks we don't want list mode */
   save_p_list = curwin->w_p_list;
-  curwin->w_p_list = FALSE;
+  curwin->w_p_list = false;
   vc = getvcol_nolist(&curwin->w_cursor);
   vcol = vc;
 
@@ -8089,7 +8089,7 @@ static int ins_tab(void)
 
     /* When 'L' is not in 'cpoptions' a tab always takes up 'ts' spaces. */
     if (vim_strchr(p_cpo, CPO_LISTWM) == NULL)
-      curwin->w_p_list = FALSE;
+      curwin->w_p_list = false;
 
     /* Find first white before the cursor */
     fpos = curwin->w_cursor;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8093,7 +8093,6 @@ static void f_bufloaded(typval_T *argvars, typval_T *rettv)
 static buf_T *get_buf_tv(typval_T *tv, int curtab_only)
 {
   char_u      *name = tv->vval.v_string;
-  int save_magic;
   char_u      *save_cpo;
   buf_T       *buf;
 
@@ -8107,8 +8106,8 @@ static buf_T *get_buf_tv(typval_T *tv, int curtab_only)
     return lastbuf;
 
   /* Ignore 'magic' and 'cpoptions' here to make scripts portable */
-  save_magic = p_magic;
-  p_magic = TRUE;
+  bool save_magic = p_magic;
+  p_magic = true;
   save_cpo = p_cpo;
   p_cpo = (char_u *)"";
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1616,7 +1616,7 @@ int do_write(exarg_T *eap)
       apply_autocmds(EVENT_BUFFILEPOST, NULL, NULL, FALSE, curbuf);
       apply_autocmds(EVENT_BUFFILEPOST, NULL, NULL, FALSE, alt_buf);
       if (!alt_buf->b_p_bl) {
-        alt_buf->b_p_bl = TRUE;
+        alt_buf->b_p_bl = true;
         apply_autocmds(EVENT_BUFADD, NULL, NULL, FALSE, alt_buf);
       }
       if (curbuf != was_curbuf || aborting()) {
@@ -1644,7 +1644,7 @@ int do_write(exarg_T *eap)
     /* After ":saveas fname" reset 'readonly'. */
     if (eap->cmdidx == CMD_saveas) {
       if (retval == OK) {
-        curbuf->b_p_ro = FALSE;
+        curbuf->b_p_ro = false;
         redraw_tabline = TRUE;
       }
       /* Change directories when the 'acd' option is set. */
@@ -2875,7 +2875,7 @@ void do_sub(exarg_T *eap)
   int endcolumn = FALSE;                /* cursor in last column when done */
   pos_T old_cursor = curwin->w_cursor;
   int start_nsubs;
-  int save_ma = 0;
+  bool save_ma = false;
 
   cmd = eap->arg;
   if (!global_busy) {
@@ -3442,7 +3442,7 @@ void do_sub(exarg_T *eap)
         if (do_count) {
           /* prevent accidentally changing the buffer by a function */
           save_ma = curbuf->b_p_ma;
-          curbuf->b_p_ma = FALSE;
+          curbuf->b_p_ma = false;
           sandbox++;
         }
         /* get length of substitution part */

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -552,12 +552,11 @@ void ex_retab(exarg_T *eap)
   char_u      *new_line = (char_u *)1;      /* init to non-NULL */
   int did_undo;                         /* called u_save for current line */
   int new_ts;
-  int save_list;
   linenr_T first_line = 0;              /* first changed line */
   linenr_T last_line = 0;               /* last changed line */
 
-  save_list = curwin->w_p_list;
-  curwin->w_p_list = 0;             /* don't want list mode here */
+  bool save_list = curwin->w_p_list;
+  curwin->w_p_list = false;             /* don't want list mode here */
 
   new_ts = getdigits_int(&(eap->arg));
   if (new_ts < 0) {
@@ -3313,9 +3312,9 @@ void do_sub(exarg_T *eap)
             } else {
               char_u *orig_line = NULL;
               int len_change = 0;
-              int save_p_fen = curwin->w_p_fen;
+              bool save_p_fen = curwin->w_p_fen;
 
-              curwin->w_p_fen = FALSE;
+              curwin->w_p_fen = false;
               /* Invert the matched string.
                * Remove the inversion afterwards. */
               temp = RedrawingDisabled;
@@ -4008,11 +4007,11 @@ prepare_tagpreview (
       if (win_split(g_do_tagpreview > 0 ? g_do_tagpreview : 0, 0)
           == FAIL)
         return false;
-      curwin->w_p_pvw = TRUE;
-      curwin->w_p_wfh = TRUE;
+      curwin->w_p_pvw = true;
+      curwin->w_p_wfh = true;
       RESET_BINDING(curwin);                /* don't take over 'scrollbind'
                                                and 'cursorbind' */
-      curwin->w_p_diff = FALSE;             /* no 'diff' */
+      curwin->w_p_diff = false;             /* no 'diff' */
       curwin->w_p_fdc = 0;                  /* no 'foldcolumn' */
       return true;
     }
@@ -4480,18 +4479,18 @@ static void prepare_help_buffer(void)
                            OPT_FREE|OPT_LOCAL, 0);
 
   curbuf->b_p_ts = 8;         // 'tabstop' is 8.
-  curwin->w_p_list = FALSE;   // No list mode.
+  curwin->w_p_list = false;   // No list mode.
 
-  curbuf->b_p_ma = FALSE;     // Not modifiable.
-  curbuf->b_p_bin = FALSE;    // Reset 'bin' before reading file.
-  curwin->w_p_nu = 0;         // No line numbers.
-  curwin->w_p_rnu = 0;        // No relative line numbers.
+  curbuf->b_p_ma = false;     // Not modifiable.
+  curbuf->b_p_bin = false;    // Reset 'bin' before reading file.
+  curwin->w_p_nu = false;         // No line numbers.
+  curwin->w_p_rnu = false;        // No relative line numbers.
   RESET_BINDING(curwin);      // No scroll or cursor binding.
-  curwin->w_p_arab = FALSE;   // No arabic mode.
-  curwin->w_p_rl  = FALSE;    // Help window is left-to-right.
-  curwin->w_p_fen = FALSE;    // No folding in the help window.
-  curwin->w_p_diff = FALSE;   // No 'diff'.
-  curwin->w_p_spell = FALSE;  // No spell checking.
+  curwin->w_p_arab = false;   // No arabic mode.
+  curwin->w_p_rl  = false;    // Help window is left-to-right.
+  curwin->w_p_fen = false;    // No folding in the help window.
+  curwin->w_p_diff = false;   // No 'diff'.
+  curwin->w_p_spell = false;  // No spell checking.
 
   set_buflisted(FALSE);
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7095,7 +7095,7 @@ void ex_may_print(exarg_T *eap)
  */
 static void ex_submagic(exarg_T *eap)
 {
-  int magic_save = p_magic;
+  bool magic_save = p_magic;
 
   p_magic = (eap->cmdidx == CMD_smagic);
   do_sub(eap);
@@ -7321,7 +7321,7 @@ static void ex_redraw(exarg_T *eap)
   int p = p_lz;
 
   RedrawingDisabled = 0;
-  p_lz = FALSE;
+  p_lz = false;
   update_topline();
   update_screen(eap->forceit ? CLEAR :
       VIsual_active ? INVERTED :
@@ -7350,7 +7350,7 @@ static void ex_redrawstatus(exarg_T *eap)
   int p = p_lz;
 
   RedrawingDisabled = 0;
-  p_lz = FALSE;
+  p_lz = false;
   if (eap->forceit)
     status_redraw_all();
   else
@@ -7623,7 +7623,7 @@ static void ex_normal(exarg_T *eap)
   int save_msg_didout = msg_didout;
   int save_State = State;
   tasave_T tabuf;
-  int save_insertmode = p_im;
+  bool save_insertmode = p_im;
   int save_finish_op = finish_op;
   long save_opcount = opcount;
   char_u      *arg = NULL;
@@ -7642,7 +7642,7 @@ static void ex_normal(exarg_T *eap)
 
   msg_scroll = FALSE;       /* no msg scrolling in Normal mode */
   restart_edit = 0;         /* don't go to Insert mode */
-  p_im = FALSE;             /* don't use 'insertmode' */
+  p_im = false;             /* don't use 'insertmode' */
 
   /*
    * vgetc() expects a CSI and K_SPECIAL to have been escaped.  Don't do

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6604,7 +6604,7 @@ do_exedit (
        * but the previous value is kept.  With ":view" and ":sview" we
        * want the  file to be readonly, except when another window is
        * editing the same buffer. */
-      curbuf->b_p_ro = TRUE;
+      curbuf->b_p_ro = true;
     }
     readonlymode = n;
   } else {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4986,7 +4986,7 @@ static int ex_window(void)
   set_option_value((char_u *)"bt", 0L, (char_u *)"nofile", OPT_LOCAL);
   set_option_value((char_u *)"swf", 0L, NULL, OPT_LOCAL);
   curbuf->b_p_ma = TRUE;
-  curwin->w_p_fen = FALSE;
+  curwin->w_p_fen = false;
   curwin->w_p_rl = cmdmsg_rl;
   cmdmsg_rl = FALSE;
   RESET_BINDING(curwin);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -786,8 +786,8 @@ static int command_line_execute(VimState *state, int key)
         if ((wim_flags[s->wim_index] & WIM_LIST)
             || (p_wmnu && (wim_flags[s->wim_index] & WIM_FULL) != 0)) {
           if (!(wim_flags[0] & WIM_LONGEST)) {
-            int p_wmnu_save = p_wmnu;
-            p_wmnu = 0;
+            bool p_wmnu_save = p_wmnu;
+            p_wmnu = false;
             // remove match
             nextwild(&s->xpc, WILD_PREV, 0, s->firstc != '@');
             p_wmnu = p_wmnu_save;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4985,7 +4985,7 @@ static int ex_window(void)
   (void)setfname(curbuf, (char_u *)"[Command Line]", NULL, TRUE);
   set_option_value((char_u *)"bt", 0L, (char_u *)"nofile", OPT_LOCAL);
   set_option_value((char_u *)"swf", 0L, NULL, OPT_LOCAL);
-  curbuf->b_p_ma = TRUE;
+  curbuf->b_p_ma = true;
   curwin->w_p_fen = false;
   curwin->w_p_rl = cmdmsg_rl;
   cmdmsg_rl = FALSE;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4782,7 +4782,7 @@ buf_check_timestamp (
      * exists, reload the buffer.  Use the buffer-local option value if it
      * was set, the global option value otherwise.
      */
-    else if ((buf->b_p_ar >= 0 ? buf->b_p_ar : p_ar)
+    else if ((buf->has_b_p_ar ? buf->b_p_ar : p_ar)
              && !bufIsChanged(buf) && file_info_ok)
       reload = TRUE;
     else {

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -460,7 +460,7 @@ readfile (
    */
   check_readonly = (newfile && (curbuf->b_flags & BF_CHECK_RO));
   if (check_readonly && !readonlymode)
-    curbuf->b_p_ro = FALSE;
+    curbuf->b_p_ro = false;
 
   if (newfile && !read_stdin && !read_buffer) {
     /* Remember time of file. */
@@ -521,7 +521,7 @@ readfile (
     perm = os_getperm(fname);      /* check if the file exists */
     if (os_isdir(fname)) {
       filemess(curbuf, sfname, (char_u *)_("is a directory"), 0);
-      curbuf->b_p_ro = TRUE;            /* must use "w!" now */
+      curbuf->b_p_ro = true;            /* must use "w!" now */
     } else
 #endif
     if (!newfile) {
@@ -577,7 +577,7 @@ readfile (
             (fd == -EOVERFLOW) ? _("[File too big]") :
 # endif
             _("[Permission Denied]")), 0);
-      curbuf->b_p_ro = TRUE;                  /* must use "w!" now */
+      curbuf->b_p_ro = true;                  /* must use "w!" now */
     }
 
     return FAIL;
@@ -588,16 +588,16 @@ readfile (
    * loaded.	Help files always get readonly mode
    */
   if ((check_readonly && file_readonly) || curbuf->b_help)
-    curbuf->b_p_ro = TRUE;
+    curbuf->b_p_ro = true;
 
   if (set_options) {
     /* Don't change 'eol' if reading from buffer as it will already be
      * correctly set when reading stdin. */
     if (!read_buffer) {
-      curbuf->b_p_eol = TRUE;
+      curbuf->b_p_eol = true;
       curbuf->b_start_eol = TRUE;
     }
-    curbuf->b_p_bomb = FALSE;
+    curbuf->b_p_bomb = false;
     curbuf->b_start_bomb = FALSE;
   }
 
@@ -673,7 +673,7 @@ readfile (
     if (aborting()) {       /* autocmds may abort script processing */
       --no_wait_return;
       msg_scroll = msg_save;
-      curbuf->b_p_ro = TRUE;            /* must use "w!" now */
+      curbuf->b_p_ro = true;            /* must use "w!" now */
       return FAIL;
     }
     /*
@@ -693,7 +693,7 @@ readfile (
         EMSG(_("E200: *ReadPre autocommands made the file unreadable"));
       else
         EMSG(_("E201: *ReadPre autocommands must not change current buffer"));
-      curbuf->b_p_ro = TRUE;            /* must use "w!" now */
+      curbuf->b_p_ro = true;            /* must use "w!" now */
       return FAIL;
     }
   }
@@ -822,8 +822,8 @@ retry:
       ml_delete(lnum--, FALSE);
     file_rewind = FALSE;
     if (set_options) {
-      curbuf->b_p_bomb = FALSE;
-      curbuf->b_start_bomb = FALSE;
+      curbuf->b_p_bomb = false;
+      curbuf->b_start_bomb = false;
     }
     conv_error = 0;
   }
@@ -1188,7 +1188,7 @@ retry:
           size -= blen;
           memmove(ptr, ptr + blen, (size_t)size);
           if (set_options) {
-            curbuf->b_p_bomb = TRUE;
+            curbuf->b_p_bomb = true;
             curbuf->b_start_bomb = TRUE;
           }
         }
@@ -1713,7 +1713,7 @@ failed:
            && ptr == line_start + 1)) {
     /* remember for when writing */
     if (set_options)
-      curbuf->b_p_eol = FALSE;
+      curbuf->b_p_eol = false;
     *ptr = NUL;
     len = (colnr_T)(ptr - line_start + 1);
     if (ml_append(lnum, line_start, len, newfile) == FAIL)
@@ -1803,7 +1803,7 @@ failed:
       if (!(flags & READ_DUMMY)) {
         filemess(curbuf, sfname, (char_u *)_(e_interr), 0);
         if (newfile)
-          curbuf->b_p_ro = TRUE;                /* must use "w!" now */
+          curbuf->b_p_ro = true;                /* must use "w!" now */
       }
       msg_scroll = msg_save;
       check_marks_read();
@@ -1901,7 +1901,7 @@ failed:
                     || conv_error != 0
                     || (illegal_byte > 0 && bad_char_behavior != BAD_KEEP)
                     ))
-      curbuf->b_p_ro = TRUE;
+      curbuf->b_p_ro = true;
 
     u_clearline();          /* cannot use "U" command after adding lines */
 
@@ -3043,7 +3043,7 @@ nobackup:
   /* When using ":w!" and writing to the current file, 'readonly' makes no
    * sense, reset it, unless 'Z' appears in 'cpoptions'.  */
   if (forceit && overwriting && vim_strchr(p_cpo, CPO_KEEPRO) == NULL) {
-    buf->b_p_ro = FALSE;
+    buf->b_p_ro = false;
     need_maketitle = TRUE;          /* set window title later */
     status_redraw_all();            /* redraw status lines later */
   }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5596,9 +5596,9 @@ void do_autocmd(char_u *arg, int forceit)
    * forward slashes here. */
   if (vim_strchr(pat, '$') != NULL || vim_strchr(pat, '~') != NULL) {
 #ifdef BACKSLASH_IN_FILENAME
-    int p_ssl_save = p_ssl;
+    bool p_ssl_save = p_ssl;
 
-    p_ssl = TRUE;
+    p_ssl = true;
 #endif
     envpat = expand_env_save(pat);
 #ifdef BACKSLASH_IN_FILENAME
@@ -6018,8 +6018,8 @@ aucmd_prepbuf (
 )
 {
   win_T       *win;
-  int save_ea;
-  int save_acd;
+  bool save_ea;
+  bool save_acd;
 
   /* Find a window that is for the new buffer */
   if (buf == curbuf) {          /* be quick when buf is curbuf */

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1259,14 +1259,14 @@ openscript (
     int oldcurscript;
     int save_State = State;
     int save_restart_edit = restart_edit;
-    int save_insertmode = p_im;
+    bool save_insertmode = p_im;
     int save_finish_op = finish_op;
     int save_msg_scroll = msg_scroll;
 
     State = NORMAL;
     msg_scroll = FALSE;         /* no msg scrolling in Normal mode */
     restart_edit = 0;           /* don't go to Insert mode */
-    p_im = FALSE;               /* don't use 'insertmode' */
+    p_im = false;               /* don't use 'insertmode' */
     clear_oparg(&oa);
     finish_op = FALSE;
 

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -143,7 +143,7 @@
 # define MB_CHAR2LEN(c)     (has_mbyte ? mb_char2len(c) : 1)
 # define PTR2CHAR(p)        (has_mbyte ? mb_ptr2char(p) : (int)*(p))
 
-# define RESET_BINDING(wp)  (wp)->w_p_scb = FALSE; (wp)->w_p_crb = FALSE
+# define RESET_BINDING(wp)  (wp)->w_p_scb = false; (wp)->w_p_crb = false
 
 /// Calculate the length of a C array.
 ///

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -870,7 +870,7 @@ static void command_line_scan(mparm_T *parmp)
 
         case 'R':                 /* "-R" readonly mode */
           readonlymode = TRUE;
-          curbuf->b_p_ro = TRUE;
+          curbuf->b_p_ro = true;
           p_uc = 10000;                           /* don't update very often */
           break;
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -363,9 +363,9 @@ int main(int argc, char **argv)
     p_uc = 0;
 
   if (curwin->w_p_rl && p_altkeymap) {
-    p_hkmap = FALSE;              /* Reset the Hebrew keymap mode */
+    p_hkmap = false;              /* Reset the Hebrew keymap mode */
     curwin->w_p_arab = true;       /* Reset the Arabic keymap mode */
-    p_fkmap = TRUE;               /* Set the Farsi keymap mode */
+    p_fkmap = true;               /* Set the Farsi keymap mode */
   }
 
   /*
@@ -751,7 +751,7 @@ static void command_line_scan(mparm_T *parmp)
             parmp->literal = TRUE;
 #endif
           } else if (STRNICMP(argv[0] + argv_idx, "noplugin", 8) == 0)
-            p_lpl = FALSE;
+            p_lpl = false;
           else if (STRNICMP(argv[0] + argv_idx, "cmd", 3) == 0) {
             want_argument = TRUE;
             argv_idx += 3;
@@ -795,7 +795,7 @@ static void command_line_scan(mparm_T *parmp)
           break;
 
         case 'F':                 /* "-F" start in Farsi mode: rl + fkmap set */
-          p_fkmap = TRUE;
+          p_fkmap = true;
           set_option_value((char_u *)"rl", 1L, NULL, 0);
           break;
 
@@ -804,13 +804,13 @@ static void command_line_scan(mparm_T *parmp)
           mch_exit(0);
 
         case 'H':                 /* "-H" start in Hebrew mode: rl + hkmap set */
-          p_hkmap = TRUE;
+          p_hkmap = true;
           set_option_value((char_u *)"rl", 1L, NULL, 0);
           break;
 
         case 'l':                 /* "-l" lisp mode, 'lisp' and 'showmatch' on */
           set_option_value((char_u *)"lisp", 1L, NULL, 0);
-          p_sm = TRUE;
+          p_sm = true;
           break;
 
         case 'M':                 /* "-M"  no changes or writing of files */
@@ -818,7 +818,7 @@ static void command_line_scan(mparm_T *parmp)
           /* FALLTHROUGH */
 
         case 'm':                 /* "-m"  no writing of files */
-          p_write = FALSE;
+          p_write = false;
           break;
 
         case 'N':                 /* "-N"  Nocompatible */

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -364,7 +364,7 @@ int main(int argc, char **argv)
 
   if (curwin->w_p_rl && p_altkeymap) {
     p_hkmap = FALSE;              /* Reset the Hebrew keymap mode */
-    curwin->w_p_arab = FALSE;       /* Reset the Arabic keymap mode */
+    curwin->w_p_arab = true;       /* Reset the Arabic keymap mode */
     p_fkmap = TRUE;               /* Set the Farsi keymap mode */
   }
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3409,7 +3409,7 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname,
           if (choice > 0) {
             switch (choice) {
             case 1:
-              buf->b_p_ro = TRUE;
+              buf->b_p_ro = true;
               break;
             case 2:
               break;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -957,9 +957,9 @@ void wait_return(int redraw)
  */
 static void hit_return_msg(void)
 {
-  int save_p_more = p_more;
+  bool save_p_more = p_more;
 
-  p_more = FALSE;       /* don't want see this message when scrolling back */
+  p_more = false;       /* don't want see this message when scrolling back */
   if (msg_didout)       /* start on a new line */
     msg_putchar('\n');
   if (got_int)

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -112,7 +112,7 @@ open_line (
   int first_char = NUL;                 /* init for GCC */
   int vreplace_mode;
   int did_append;                       /* appended a new line */
-  int saved_pi = curbuf->b_p_pi;           /* copy of preserveindent setting */
+  bool saved_pi = curbuf->b_p_pi;           /* copy of preserveindent setting */
 
   /*
    * make a copy of the current line so we can mess with it
@@ -802,7 +802,7 @@ open_line (
        * with the line doesn't entirely destroy our efforts to preserve
        * it.  It gets restored at the function end.
        */
-      curbuf->b_p_pi = TRUE;
+      curbuf->b_p_pi = true;
     } else
       (void)set_indent(newindent, SIN_INSERT);
     less_cols -= curwin->w_cursor.col;

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1451,16 +1451,15 @@ void ins_char_bytes(char_u *buf, int charlen)
     if (State & VREPLACE_FLAG) {
       colnr_T new_vcol = 0;             /* init for GCC */
       colnr_T vcol;
-      int old_list;
 
       /*
        * Disable 'list' temporarily, unless 'cpo' contains the 'L' flag.
        * Returns the old value of list, so when finished,
        * curwin->w_p_list should be set back to this.
        */
-      old_list = curwin->w_p_list;
+      bool old_list = curwin->w_p_list;
       if (old_list && vim_strchr(p_cpo, CPO_LISTWM) == NULL)
-        curwin->w_p_list = FALSE;
+        curwin->w_p_list = false;
 
       /*
        * In virtual replace mode each character may replace one or more

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -300,9 +300,9 @@ static void shift_block(oparg_T *oap, int amount)
   colnr_T ws_vcol;
   int i = 0, j = 0;
   int len;
-  int old_p_ri = p_ri;
+  bool old_p_ri = p_ri;
 
-  p_ri = 0;                     /* don't want revins in indent */
+  p_ri = false;                     /* don't want revins in indent */
 
   State = INSERT;               /* don't want REPLACE for State */
   block_prep(oap, &bd, curwin->w_cursor.lnum, TRUE);
@@ -3763,7 +3763,6 @@ format_lines (
   int do_number_indent;
   int do_trail_white;
   int first_par_line = TRUE;
-  int smd_save;
   long count;
   int need_set_indent = TRUE;           /* set indent of next paragraph */
   int force_format = FALSE;
@@ -3893,8 +3892,8 @@ format_lines (
 
         /* do the formatting, without 'showmode' */
         State = INSERT;         /* for open_line() */
-        smd_save = p_smd;
-        p_smd = FALSE;
+        bool smd_save = p_smd;
+        p_smd = false;
         insertchar(NUL, INSCHAR_FORMAT
             + (do_comments ? INSCHAR_DO_COM : 0)
             + (do_comments && do_comments_list

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3538,13 +3538,13 @@ set_bool_option (
     *(bool *)get_varp_scope(&(options[opt_idx]), OPT_GLOBAL) = value;
 
   // Ensure that options set to p_force_on cannot be disabled.
-  if ((int *)varp == &p_force_on && p_force_on == FALSE) {
-    p_force_on = TRUE;
+  if ((bool *)varp == &p_force_on && p_force_on == false) {
+    p_force_on = true;
     return e_unsupportedoption;
   }
   // Ensure that options set to p_force_off cannot be enabled.
-  else if ((int *)varp == &p_force_off && p_force_off == TRUE) {
-    p_force_off = FALSE;
+  else if ((bool *)varp == &p_force_off && p_force_off == true) {
+    p_force_off = false;
     return e_unsupportedoption;
   }
   /* 'undofile' */
@@ -3616,7 +3616,7 @@ set_bool_option (
       mf_close_file(curbuf, true);              /* remove the swap file */
   }
   /* when 'terse' is set change 'shortmess' */
-  else if ((int *)varp == &p_terse) {
+  else if ((bool *)varp == &p_terse) {
     char_u  *p;
 
     p = vim_strchr(p_shm, SHM_SEARCH);
@@ -3632,11 +3632,11 @@ set_bool_option (
       STRMOVE(p, p + 1);
   }
   /* when 'paste' is set or reset also change other options */
-  else if ((int *)varp == &p_paste) {
+  else if ((bool *)varp == &p_paste) {
     paste_option_changed();
   }
   /* when 'insertmode' is set from an autocommand need to do work here */
-  else if ((int *)varp == &p_im) {
+  else if ((bool *)varp == &p_im) {
     if (p_im) {
       if ((State & INSERT) == 0)
         need_start_insertmode = TRUE;
@@ -3650,11 +3650,11 @@ set_bool_option (
     }
   }
   /* when 'ignorecase' is set or reset and 'hlsearch' is set, redraw */
-  else if ((int *)varp == &p_ic && p_hls) {
+  else if ((bool *)varp == &p_ic && p_hls) {
     redraw_all_later(SOME_VALID);
   }
   /* when 'hlsearch' is set or reset: reset no_hlsearch */
-  else if ((int *)varp == &p_hls) {
+  else if ((bool *)varp == &p_hls) {
     SET_NO_HLSEARCH(FALSE);
   }
   /* when 'scrollbind' is set: snapshot the current position to avoid a jump
@@ -3685,9 +3685,9 @@ set_bool_option (
     (void)buf_init_chartab(curbuf, FALSE);          /* ignore errors */
   }
   /* when 'title' changed, may need to change the title; same for 'icon' */
-  else if ((int *)varp == &p_title) {
+  else if ((bool *)varp == &p_title) {
     did_set_title(FALSE);
-  } else if ((int *)varp == &p_icon) {
+  } else if ((bool *)varp == &p_icon) {
     did_set_title(TRUE);
   } else if ((bool *)varp == &curbuf->b_changed) {
     if (!value)
@@ -3697,7 +3697,7 @@ set_bool_option (
   }
 
 #ifdef BACKSLASH_IN_FILENAME
-  else if ((int *)varp == &p_ssl) {
+  else if ((bool *)varp == &p_ssl) {
     if (p_ssl) {
       psepc = '/';
       psepcN = '\\';
@@ -3742,7 +3742,7 @@ set_bool_option (
       if (errmsg != NULL)
         EMSG(_(errmsg));
     }
-  } else if ((int *)varp == &p_altkeymap) {
+  } else if ((bool *)varp == &p_altkeymap) {
     if (old_value != p_altkeymap) {
       if (!p_altkeymap) {
         p_hkmap = p_fkmap;
@@ -3803,7 +3803,7 @@ set_bool_option (
 
         /* Enable Arabic shaping (major part of what Arabic requires) */
         if (!p_arshape) {
-          p_arshape = TRUE;
+          p_arshape = true;
           redraw_later_clear();
         }
       }
@@ -3820,7 +3820,7 @@ set_bool_option (
       }
 
       /* set 'delcombine' */
-      p_deco = TRUE;
+      p_deco = true;
 
       /* Force-set the necessary keymap for arabic */
       set_option_value((char_u *)"keymap", 0L, (char_u *)"arabic",

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1995,9 +1995,9 @@ set_options_bin (
     if (!(opt_flags & OPT_LOCAL)) {
       p_tw = 0;
       p_wm = 0;
-      p_ml = FALSE;
-      p_et = FALSE;
-      p_bin = TRUE;             /* needed when called for the "-b" argument */
+      p_ml = false;
+      p_et = false;
+      p_bin = true;             /* needed when called for the "-b" argument */
     }
   } else if (oldval) {        /* switched off */
     if (!(opt_flags & OPT_GLOBAL)) {
@@ -5655,7 +5655,7 @@ void reset_modifiable(void)
   int opt_idx;
 
   curbuf->b_p_ma = true;
-  p_ma = FALSE;
+  p_ma = false;
   opt_idx = findoption((char_u *)"ma");
   if (opt_idx >= 0)
     options[opt_idx].def_val[VI_DEFAULT] = FALSE;
@@ -6206,10 +6206,10 @@ int shortmess(int x)
 static void paste_option_changed(void)
 {
   static int old_p_paste = FALSE;
-  static int save_sm = 0;
-  static int save_ru = 0;
-  static int save_ri = 0;
-  static int save_hkmap = 0;
+  static bool save_sm = false;
+  static bool save_ru = false;
+  static bool save_ri = false;
+  static bool save_hkmap = false;
 
   if (p_paste) {
     /*
@@ -6250,17 +6250,17 @@ static void paste_option_changed(void)
     }
 
     /* set global options */
-    p_sm = 0;                       /* no showmatch */
+    p_sm = false;                       /* no showmatch */
     if (p_ru)
       status_redraw_all();          /* redraw to remove the ruler */
-    p_ru = 0;                       /* no ruler */
-    p_ri = 0;                       /* no reverse insert */
-    p_hkmap = 0;                    /* no Hebrew keyboard */
+    p_ru = false;                       /* no ruler */
+    p_ri = false;                       /* no reverse insert */
+    p_hkmap = false;                    /* no Hebrew keyboard */
     /* set global values for local buffer options */
     p_tw = 0;
     p_wm = 0;
     p_sts = 0;
-    p_ai = 0;
+    p_ai = false;
   }
   /*
    * Paste switched from on to off: Restore saved values.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -105,14 +105,14 @@ typedef enum {
  * These are the global values for options which are also local to a buffer.
  * Only to be used in option.c!
  */
-static int p_ai;
-static int p_bin;
-static int p_bomb;
+static bool p_ai;
+static bool p_bin;
+static bool p_bomb;
 static char_u   *p_bh;
 static char_u   *p_bt;
-static int p_bl;
-static int p_ci;
-static int p_cin;
+static bool p_bl;
+static bool p_ci;
+static bool p_cin;
 static char_u   *p_cink;
 static char_u   *p_cino;
 static char_u   *p_cinw;
@@ -121,9 +121,9 @@ static char_u   *p_cms;
 static char_u   *p_cpt;
 static char_u   *p_cfu;
 static char_u   *p_ofu;
-static int p_eol;
-static int p_fixeol;
-static int p_et;
+static bool p_eol;
+static bool p_fixeol;
+static bool p_et;
 static char_u   *p_fenc;
 static char_u   *p_ff;
 static char_u   *p_fo;
@@ -135,22 +135,22 @@ static char_u   *p_inex;
 static char_u   *p_inde;
 static char_u   *p_indk;
 static char_u   *p_fex;
-static int p_inf;
+static bool p_inf;
 static char_u   *p_isk;
-static int p_lisp;
-static int p_ml;
-static int p_ma;
-static int p_mod;
+static bool p_lisp;
+static bool p_ml;
+static bool p_ma;
+static bool p_mod;
 static char_u   *p_mps;
 static char_u   *p_nf;
-static int p_pi;
+static bool p_pi;
 static char_u   *p_qe;
-static int p_ro;
-static int p_si;
+static bool p_ro;
+static bool p_si;
 static long p_sts;
 static char_u   *p_sua;
 static long p_sw;
-static int p_swf;
+static bool p_swf;
 static long p_smc;
 static char_u   *p_syn;
 static char_u   *p_spc;
@@ -158,7 +158,7 @@ static char_u   *p_spf;
 static char_u   *p_spl;
 static long p_ts;
 static long p_tw;
-static int p_udf;
+static bool p_udf;
 static long p_wm;
 static char_u   *p_keymap;
 
@@ -3548,7 +3548,7 @@ set_bool_option (
     return e_unsupportedoption;
   }
   /* 'undofile' */
-  else if ((int *)varp == &curbuf->b_p_udf || (int *)varp == &p_udf) {
+  else if ((bool *)varp == &curbuf->b_p_udf || (bool *)varp == &p_udf) {
     /* Only take action when the option was set. When reset we do not
      * delete the undo file, the option may be set again without making
      * any changes in between. */
@@ -3570,7 +3570,7 @@ set_bool_option (
       }
       curbuf = save_curbuf;
     }
-  } else if ((int *)varp == &curbuf->b_p_ro) {
+  } else if ((bool *)varp == &curbuf->b_p_ro) {
     /* when 'readonly' is reset globally, also reset readonlymode */
     if (!curbuf->b_p_ro && (opt_flags & OPT_LOCAL) == 0)
       readonlymode = FALSE;
@@ -3582,32 +3582,32 @@ set_bool_option (
     redraw_titles();
   }
   /* when 'modifiable' is changed, redraw the window title */
-  else if ((int *)varp == &curbuf->b_p_ma) {
+  else if ((bool *)varp == &curbuf->b_p_ma) {
     redraw_titles();
   }
   /* when 'endofline' is changed, redraw the window title */
-  else if ((int *)varp == &curbuf->b_p_eol) {
+  else if ((bool *)varp == &curbuf->b_p_eol) {
     redraw_titles();
-  } else if ((int *)varp == &curbuf->b_p_fixeol) {
+  } else if ((bool *)varp == &curbuf->b_p_fixeol) {
     // when 'fixeol' is changed, redraw the window title
     redraw_titles();
   }
   /* when 'bomb' is changed, redraw the window title and tab page text */
-  else if ((int *)varp == &curbuf->b_p_bomb) {
+  else if ((bool *)varp == &curbuf->b_p_bomb) {
     redraw_titles();
   }
   /* when 'bin' is set also set some other options */
-  else if ((int *)varp == &curbuf->b_p_bin) {
+  else if ((bool *)varp == &curbuf->b_p_bin) {
     set_options_bin(old_value, curbuf->b_p_bin, opt_flags);
     redraw_titles();
   }
   /* when 'buflisted' changes, trigger autocommands */
-  else if ((int *)varp == &curbuf->b_p_bl && old_value != curbuf->b_p_bl) {
+  else if ((bool *)varp == &curbuf->b_p_bl && old_value != curbuf->b_p_bl) {
     apply_autocmds(curbuf->b_p_bl ? EVENT_BUFADD : EVENT_BUFDELETE,
         NULL, NULL, TRUE, curbuf);
   }
   /* when 'swf' is set, create swapfile, when reset remove swapfile */
-  else if ((int *)varp == (int *)&curbuf->b_p_swf) {
+  else if ((bool *)varp == &curbuf->b_p_swf) {
     if (curbuf->b_p_swf && p_uc)
       ml_open_file(curbuf);                     /* create the swap file */
     else

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3659,18 +3659,18 @@ set_bool_option (
   }
   /* when 'scrollbind' is set: snapshot the current position to avoid a jump
    * at the end of normal_cmd() */
-  else if ((int *)varp == &curwin->w_p_scb) {
+  else if ((bool *)varp == &curwin->w_p_scb) {
     if (curwin->w_p_scb) {
       do_check_scrollbind(FALSE);
       curwin->w_scbind_pos = curwin->w_topline;
     }
   }
   /* There can be only one window with 'previewwindow' set. */
-  else if ((int *)varp == &curwin->w_p_pvw) {
+  else if ((bool *)varp == &curwin->w_p_pvw) {
     if (curwin->w_p_pvw) {
       FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
         if (win->w_p_pvw && win != curwin) {
-          curwin->w_p_pvw = FALSE;
+          curwin->w_p_pvw = false;
           return (char_u *)N_("E590: A preview window already exists");
         }
       }
@@ -3716,7 +3716,7 @@ set_bool_option (
 #endif
 
   /* If 'wrap' is set, set w_leftcol to zero. */
-  else if ((int *)varp == &curwin->w_p_wrap) {
+  else if ((bool *)varp == &curwin->w_p_wrap) {
     if (curwin->w_p_wrap)
       curwin->w_leftcol = 0;
   } else if ((bool *)varp == &p_ea) {
@@ -3727,7 +3727,7 @@ set_bool_option (
     do_autochdir();
   }
   /* 'diff' */
-  else if ((int *)varp == &curwin->w_p_diff) {
+  else if ((bool *)varp == &curwin->w_p_diff) {
     /* May add or remove the buffer from the list of diff buffers. */
     diff_buf_adjust(curwin);
     if (foldmethodIsDiff(curwin))
@@ -3736,7 +3736,7 @@ set_bool_option (
 
 
   /* 'spell' */
-  else if ((int *)varp == &curwin->w_p_spell) {
+  else if ((bool *)varp == &curwin->w_p_spell) {
     if (curwin->w_p_spell) {
       char_u      *errmsg = did_set_spelllang(curwin);
       if (errmsg != NULL)
@@ -3765,7 +3765,7 @@ set_bool_option (
    */
   if ((p_hkmap || p_fkmap) && p_altkeymap) {
     p_altkeymap = p_fkmap;
-    curwin->w_p_arab = FALSE;
+    curwin->w_p_arab = false;
     (void)init_chartab();
   }
 
@@ -3775,7 +3775,7 @@ set_bool_option (
   if (p_hkmap && p_altkeymap) {
     p_altkeymap = 0;
     p_fkmap = 0;
-    curwin->w_p_arab = FALSE;
+    curwin->w_p_arab = false;
     (void)init_chartab();
   }
 
@@ -3785,11 +3785,11 @@ set_bool_option (
   if (p_fkmap && !p_altkeymap) {
     p_altkeymap = 1;
     p_hkmap = 0;
-    curwin->w_p_arab = FALSE;
+    curwin->w_p_arab = false;
     (void)init_chartab();
   }
 
-  if ((int *)varp == &curwin->w_p_arab) {
+  if ((bool *)varp == &curwin->w_p_arab) {
     if (curwin->w_p_arab) {
       /*
        * 'arabic' is set, handle various sub-settings.
@@ -3797,7 +3797,7 @@ set_bool_option (
       if (!p_tbidi) {
         /* set rightleft mode */
         if (!curwin->w_p_rl) {
-          curwin->w_p_rl = TRUE;
+          curwin->w_p_rl = true;
           changed_window_setting();
         }
 
@@ -3836,7 +3836,7 @@ set_bool_option (
       if (!p_tbidi) {
         /* reset rightleft mode */
         if (curwin->w_p_rl) {
-          curwin->w_p_rl = FALSE;
+          curwin->w_p_rl = false;
           changed_window_setting();
         }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5528,7 +5528,7 @@ void buf_copy_options(buf_T *buf, int flags)
        */
       if (!buf->b_p_initialized) {
         free_buf_options(buf, TRUE);
-        buf->b_p_ro = FALSE;                    /* don't copy readonly */
+        buf->b_p_ro = false;                    /* don't copy readonly */
         buf->b_p_fenc = vim_strsave(p_fenc);
         buf->b_p_ff = vim_strsave(p_ff);
         buf->b_p_bh = empty_option;
@@ -5654,7 +5654,7 @@ void reset_modifiable(void)
 {
   int opt_idx;
 
-  curbuf->b_p_ma = FALSE;
+  curbuf->b_p_ma = true;
   p_ma = FALSE;
   opt_idx = findoption((char_u *)"ma");
   if (opt_idx >= 0)

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -269,11 +269,11 @@ EXTERN long p_aleph;            /* 'aleph' */
 EXTERN bool p_acd;              /* 'autochdir' */
 EXTERN char_u   *p_ambw;        /* 'ambiwidth' */
 EXTERN bool p_ar;                /* 'autoread' */
-EXTERN int p_aw;                /* 'autowrite' */
-EXTERN int p_awa;               /* 'autowriteall' */
+EXTERN bool p_aw;                /* 'autowrite' */
+EXTERN bool p_awa;               /* 'autowriteall' */
 EXTERN char_u   *p_bs;          /* 'backspace' */
 EXTERN char_u   *p_bg;          /* 'background' */
-EXTERN int p_bk;                /* 'backup' */
+EXTERN bool p_bk;                /* 'backup' */
 EXTERN char_u   *p_bkc;         /* 'backupcopy' */
 EXTERN unsigned int bkc_flags;  ///< flags from 'backupcopy'
 #ifdef IN_OPTION_C
@@ -328,7 +328,7 @@ static char *(p_cmp_values[]) = {"internal", "keepascii", NULL};
 # define CMP_INTERNAL           0x001
 # define CMP_KEEPASCII          0x002
 EXTERN char_u   *p_enc;         /* 'encoding' */
-EXTERN int p_deco;              /* 'delcombine' */
+EXTERN bool p_deco;              /* 'delcombine' */
 EXTERN char_u   *p_ccv;         /* 'charconvert' */
 EXTERN char_u   *p_cedit;       /* 'cedit' */
 EXTERN char_u   *p_cb;          /* 'clipboard' */
@@ -341,27 +341,27 @@ static char *(p_cb_values[]) = {"unnamed", "unnamedplus", NULL};
 # define CB_UNNAMEDMASK         (CB_UNNAMED | CB_UNNAMEDPLUS)
 EXTERN long p_cwh;              /* 'cmdwinheight' */
 EXTERN long p_ch;               /* 'cmdheight' */
-EXTERN int p_confirm;           /* 'confirm' */
-EXTERN int p_cp;                /* 'compatible' */
+EXTERN bool p_confirm;           /* 'confirm' */
+EXTERN bool p_cp;                /* 'compatible' */
 EXTERN char_u   *p_cot;         /* 'completeopt' */
 EXTERN long p_ph;               /* 'pumheight' */
 EXTERN char_u   *p_cpo;         /* 'cpoptions' */
 EXTERN char_u   *p_csprg;       /* 'cscopeprg' */
-EXTERN int p_csre;              /* 'cscoperelative' */
+EXTERN bool p_csre;              /* 'cscoperelative' */
 EXTERN char_u   *p_csqf;        /* 'cscopequickfix' */
 #  define       CSQF_CMDS   "sgdctefi"
 #  define       CSQF_FLAGS  "+-0"
-EXTERN int p_cst;               /* 'cscopetag' */
+EXTERN bool p_cst;               /* 'cscopetag' */
 EXTERN long p_csto;             /* 'cscopetagorder' */
 EXTERN long p_cspc;             /* 'cscopepathcomp' */
-EXTERN int p_csverbose;         /* 'cscopeverbose' */
+EXTERN bool p_csverbose;         /* 'cscopeverbose' */
 EXTERN char_u   *p_debug;       /* 'debug' */
 EXTERN char_u   *p_def;         /* 'define' */
 EXTERN char_u   *p_inc;
 EXTERN char_u   *p_dip;         /* 'diffopt' */
 EXTERN char_u   *p_dex;         /* 'diffexpr' */
 EXTERN char_u   *p_dict;        /* 'dictionary' */
-EXTERN int p_dg;                /* 'digraph' */
+EXTERN bool p_dg;                /* 'digraph' */
 EXTERN char_u   *p_dir;         /* 'directory' */
 EXTERN char_u   *p_dy;          /* 'display' */
 EXTERN unsigned dy_flags;
@@ -370,18 +370,18 @@ static char *(p_dy_values[]) = {"lastline", "uhex", NULL};
 #endif
 #define DY_LASTLINE             0x001
 #define DY_UHEX                 0x002
-EXTERN int p_ed;                /* 'edcompatible' */
+EXTERN bool p_ed;                /* 'edcompatible' */
 EXTERN char_u   *p_ead;         /* 'eadirection' */
 EXTERN bool p_ea;               /* 'equalalways' */
 EXTERN char_u   *p_ep;          /* 'equalprg' */
-EXTERN int p_eb;                /* 'errorbells' */
+EXTERN bool p_eb;                /* 'errorbells' */
 EXTERN char_u   *p_ef;          /* 'errorfile' */
 EXTERN char_u   *p_efm;         /* 'errorformat' */
 EXTERN char_u   *p_gefm;        /* 'grepformat' */
 EXTERN char_u   *p_gp;          /* 'grepprg' */
 EXTERN char_u   *p_ei;          /* 'eventignore' */
-EXTERN int p_ek;                /* 'esckeys' */
-EXTERN int p_exrc;              /* 'exrc' */
+EXTERN bool p_ek;                /* 'esckeys' */
+EXTERN bool p_exrc;              /* 'exrc' */
 EXTERN char_u   *p_fencs;       /* 'fileencodings' */
 EXTERN char_u   *p_ffs;         /* 'fileformats' */
 EXTERN bool p_fic;              ///< 'fileignorecase'
@@ -407,9 +407,9 @@ static char *(p_fdo_values[]) = {"all", "block", "hor", "mark", "percent",
 # define FDO_JUMP               0x400
 EXTERN char_u   *p_fp;          /* 'formatprg' */
 #ifdef HAVE_FSYNC
-EXTERN int p_fs;                /* 'fsync' */
+EXTERN bool p_fs;                /* 'fsync' */
 #endif
-EXTERN int p_gd;                /* 'gdefault' */
+EXTERN bool p_gd;                /* 'gdefault' */
 EXTERN char_u   *p_pdev;        /* 'printdevice' */
 EXTERN char_u   *p_penc;        /* 'printencoding' */
 EXTERN char_u   *p_pexpr;       /* 'printexpr' */
@@ -418,49 +418,49 @@ EXTERN char_u   *p_pmcs;        /* 'printmbcharset' */
 EXTERN char_u   *p_pfn;         /* 'printfont' */
 EXTERN char_u   *p_popt;        /* 'printoptions' */
 EXTERN char_u   *p_header;      /* 'printheader' */
-EXTERN int p_prompt;            /* 'prompt' */
+EXTERN bool p_prompt;            /* 'prompt' */
 EXTERN char_u   *p_guicursor;   /* 'guicursor' */
 EXTERN char_u   *p_hf;          /* 'helpfile' */
 EXTERN long p_hh;               /* 'helpheight' */
 EXTERN char_u   *p_hlg;         /* 'helplang' */
-EXTERN int p_hid;               /* 'hidden' */
+EXTERN bool p_hid;               /* 'hidden' */
 /* Use P_HID to check if a buffer is to be hidden when it is no longer
  * visible in a window. */
 # define P_HID(buf) (buf_hide(buf))
 EXTERN char_u   *p_hl;          /* 'highlight' */
-EXTERN int p_hls;               /* 'hlsearch' */
+EXTERN bool p_hls;               /* 'hlsearch' */
 EXTERN long p_hi;               /* 'history' */
-EXTERN int p_hkmap;             /* 'hkmap' */
-EXTERN int p_hkmapp;            /* 'hkmapp' */
-EXTERN int p_fkmap;             /* 'fkmap' */
-EXTERN int p_altkeymap;         /* 'altkeymap' */
-EXTERN int p_arshape;           /* 'arabicshape' */
-EXTERN int p_icon;              /* 'icon' */
+EXTERN bool p_hkmap;             /* 'hkmap' */
+EXTERN bool p_hkmapp;            /* 'hkmapp' */
+EXTERN bool p_fkmap;             /* 'fkmap' */
+EXTERN bool p_altkeymap;         /* 'altkeymap' */
+EXTERN bool p_arshape;           /* 'arabicshape' */
+EXTERN bool p_icon;              /* 'icon' */
 EXTERN char_u   *p_iconstring;  /* 'iconstring' */
-EXTERN int p_ic;                /* 'ignorecase' */
-EXTERN int p_is;                /* 'incsearch' */
-EXTERN int p_im;                /* 'insertmode' */
+EXTERN bool p_ic;                /* 'ignorecase' */
+EXTERN bool p_is;                /* 'incsearch' */
+EXTERN bool p_im;                /* 'insertmode' */
 EXTERN char_u   *p_isf;         /* 'isfname' */
 EXTERN char_u   *p_isi;         /* 'isident' */
 EXTERN char_u   *p_isp;         /* 'isprint' */
-EXTERN int p_js;                /* 'joinspaces' */
+EXTERN bool p_js;                /* 'joinspaces' */
 EXTERN char_u   *p_kp;          /* 'keywordprg' */
 EXTERN char_u   *p_km;          /* 'keymodel' */
 EXTERN char_u   *p_langmap;     /* 'langmap'*/
-EXTERN int p_lnr;               /* 'langnoremap'*/
+EXTERN bool p_lnr;               /* 'langnoremap'*/
 EXTERN char_u   *p_lm;          /* 'langmenu' */
 EXTERN char_u   *p_lispwords;   /* 'lispwords' */
 EXTERN long p_ls;               /* 'laststatus' */
 EXTERN long p_stal;             /* 'showtabline' */
 EXTERN char_u   *p_lcs;         /* 'listchars' */
 
-EXTERN int p_lz;                /* 'lazyredraw' */
-EXTERN int p_lpl;               /* 'loadplugins' */
-EXTERN int p_magic;             /* 'magic' */
+EXTERN bool p_lz;                /* 'lazyredraw' */
+EXTERN bool p_lpl;               /* 'loadplugins' */
+EXTERN bool p_magic;             /* 'magic' */
 EXTERN char_u   *p_mef;         /* 'makeef' */
 EXTERN char_u   *p_mp;          /* 'makeprg' */
 EXTERN char_u   *p_cc;          /* 'colorcolumn' */
-EXTERN int p_cc_cols[256];      /* array for 'colorcolumn' columns */
+EXTERN bool p_cc_cols[256];      /* array for 'colorcolumn' columns */
 EXTERN long p_mat;              /* 'matchtime' */
 EXTERN long p_mco;              /* 'maxcombine' */
 EXTERN long p_mfd;              /* 'maxfuncdepth' */
@@ -474,30 +474,30 @@ EXTERN long p_mls;              /* 'modelines' */
 EXTERN char_u   *p_mouse;       /* 'mouse' */
 EXTERN char_u   *p_mousem;      /* 'mousemodel' */
 EXTERN long p_mouset;           /* 'mousetime' */
-EXTERN int p_more;              /* 'more' */
+EXTERN bool p_more;              /* 'more' */
 EXTERN char_u   *p_opfunc;      /* 'operatorfunc' */
 EXTERN char_u   *p_para;        /* 'paragraphs' */
-EXTERN int p_paste;             /* 'paste' */
+EXTERN bool p_paste;             /* 'paste' */
 EXTERN char_u   *p_pt;          /* 'pastetoggle' */
 EXTERN char_u   *p_pex;         /* 'patchexpr' */
 EXTERN char_u   *p_pm;          /* 'patchmode' */
 EXTERN char_u   *p_path;        /* 'path' */
 EXTERN char_u   *p_cdpath;      /* 'cdpath' */
 EXTERN long p_rdt;              /* 'redrawtime' */
-EXTERN int p_remap;             /* 'remap' */
+EXTERN bool p_remap;             /* 'remap' */
 EXTERN long p_re;               /* 'regexpengine' */
 EXTERN long p_report;           /* 'report' */
 EXTERN long p_pvh;              /* 'previewheight' */
-EXTERN int p_ari;               /* 'allowrevins' */
-EXTERN int p_ri;                /* 'revins' */
-EXTERN int p_ru;                /* 'ruler' */
+EXTERN bool p_ari;               /* 'allowrevins' */
+EXTERN bool p_ri;                /* 'revins' */
+EXTERN bool p_ru;                /* 'ruler' */
 EXTERN char_u   *p_ruf;         /* 'rulerformat' */
 EXTERN char_u   *p_rtp;         /* 'runtimepath' */
 EXTERN long p_sj;               /* 'scrolljump' */
 EXTERN long p_so;               /* 'scrolloff' */
 EXTERN char_u   *p_sbo;         /* 'scrollopt' */
 EXTERN char_u   *p_sections;    /* 'sections' */
-EXTERN int p_secure;            /* 'secure' */
+EXTERN bool p_secure;            /* 'secure' */
 EXTERN char_u   *p_sel;         /* 'selection' */
 EXTERN char_u   *p_slm;         /* 'selectmode' */
 EXTERN char_u   *p_ssop;        /* 'sessionoptions' */
@@ -533,28 +533,28 @@ EXTERN char_u   *p_shq;         /* 'shellquote' */
 EXTERN char_u   *p_sxq;         /* 'shellxquote' */
 EXTERN char_u   *p_sxe;         /* 'shellxescape' */
 EXTERN char_u   *p_srr;         /* 'shellredir' */
-EXTERN int p_stmp;              /* 'shelltemp' */
+EXTERN bool p_stmp;              /* 'shelltemp' */
 #ifdef BACKSLASH_IN_FILENAME
-EXTERN int p_ssl;               /* 'shellslash' */
+EXTERN bool p_ssl;               /* 'shellslash' */
 #endif
 EXTERN char_u   *p_stl;         /* 'statusline' */
-EXTERN int p_sr;                /* 'shiftround' */
+EXTERN bool p_sr;                /* 'shiftround' */
 EXTERN char_u   *p_shm;         /* 'shortmess' */
 EXTERN char_u   *p_sbr;         /* 'showbreak' */
-EXTERN int p_sc;                /* 'showcmd' */
-EXTERN int p_sft;               /* 'showfulltag' */
-EXTERN int p_sm;                /* 'showmatch' */
-EXTERN int p_smd;               /* 'showmode' */
+EXTERN bool p_sc;                /* 'showcmd' */
+EXTERN bool p_sft;               /* 'showfulltag' */
+EXTERN bool p_sm;                /* 'showmatch' */
+EXTERN bool p_smd;               /* 'showmode' */
 EXTERN long p_ss;               /* 'sidescroll' */
 EXTERN long p_siso;             /* 'sidescrolloff' */
-EXTERN int p_scs;               /* 'smartcase' */
-EXTERN int p_sta;               /* 'smarttab' */
-EXTERN int p_sb;                /* 'splitbelow' */
+EXTERN bool p_scs;               /* 'smartcase' */
+EXTERN bool p_sta;               /* 'smarttab' */
+EXTERN bool p_sb;                /* 'splitbelow' */
 EXTERN long p_tpm;              /* 'tabpagemax' */
 EXTERN char_u   *p_tal;         /* 'tabline' */
 EXTERN char_u   *p_sps;         /* 'spellsuggest' */
-EXTERN int p_spr;               /* 'splitright' */
-EXTERN int p_sol;               /* 'startofline' */
+EXTERN bool p_spr;               /* 'splitright' */
+EXTERN bool p_sol;               /* 'startofline' */
 EXTERN char_u   *p_su;          /* 'suffixes' */
 EXTERN char_u   *p_sws;         /* 'swapsync' */
 EXTERN char_u   *p_swb;         /* 'switchbuf' */
@@ -566,22 +566,22 @@ static char *(p_swb_values[]) = {"useopen", "usetab", "split", "newtab", NULL};
 #define SWB_USETAB              0x002
 #define SWB_SPLIT               0x004
 #define SWB_NEWTAB              0x008
-EXTERN int p_tbs;               /* 'tagbsearch' */
+EXTERN bool p_tbs;               /* 'tagbsearch' */
 EXTERN long p_tl;               /* 'taglength' */
-EXTERN int p_tr;                /* 'tagrelative' */
+EXTERN bool p_tr;                /* 'tagrelative' */
 EXTERN char_u   *p_tags;        /* 'tags' */
-EXTERN int p_tgst;              /* 'tagstack' */
-EXTERN int p_tbidi;             /* 'termbidi' */
-EXTERN int p_terse;             /* 'terse' */
-EXTERN int p_to;                /* 'tildeop' */
-EXTERN int p_timeout;           /* 'timeout' */
+EXTERN bool p_tgst;              /* 'tagstack' */
+EXTERN bool p_tbidi;             /* 'termbidi' */
+EXTERN bool p_terse;             /* 'terse' */
+EXTERN bool p_to;                /* 'tildeop' */
+EXTERN bool p_timeout;           /* 'timeout' */
 EXTERN long p_tm;               /* 'timeoutlen' */
-EXTERN int p_title;             /* 'title' */
+EXTERN bool p_title;             /* 'title' */
 EXTERN long p_titlelen;         /* 'titlelen' */
 EXTERN char_u   *p_titleold;    /* 'titleold' */
 EXTERN char_u   *p_titlestring; /* 'titlestring' */
 EXTERN char_u   *p_tsr;         /* 'thesaurus' */
-EXTERN int p_ttimeout;          /* 'ttimeout' */
+EXTERN bool p_ttimeout;          /* 'ttimeout' */
 EXTERN long p_ttm;              /* 'ttimeoutlen' */
 EXTERN char_u   *p_udir;        /* 'undodir' */
 EXTERN long p_ul;               /* 'undolevels' */
@@ -593,7 +593,7 @@ EXTERN char_u   *p_shada;       /* 'shada' */
 EXTERN char_u   *p_vdir;        /* 'viewdir' */
 EXTERN char_u   *p_vop;         /* 'viewoptions' */
 EXTERN unsigned vop_flags;      /* uses SSOP_ flags */
-EXTERN int p_vb;                /* 'visualbell' */
+EXTERN bool p_vb;                /* 'visualbell' */
 EXTERN char_u   *p_ve;          /* 'virtualedit' */
 EXTERN unsigned ve_flags;
 # ifdef IN_OPTION_C
@@ -609,7 +609,7 @@ char_u  *p_vfile = (char_u *)""; /* used before options are initialized */
 #else
 extern char_u   *p_vfile;       /* 'verbosefile' */
 #endif
-EXTERN int p_warn;              /* 'warn' */
+EXTERN bool p_warn;              /* 'warn' */
 EXTERN char_u   *p_wop;         /* 'wildoptions' */
 EXTERN long p_window;           /* 'window' */
 EXTERN char_u   *p_wak;         /* 'winaltkeys' */
@@ -619,19 +619,19 @@ EXTERN long p_wc;               /* 'wildchar' */
 EXTERN long p_wcm;              /* 'wildcharm' */
 EXTERN bool p_wic;              ///< 'wildignorecase'
 EXTERN char_u   *p_wim;         /* 'wildmode' */
-EXTERN int p_wmnu;              /* 'wildmenu' */
+EXTERN bool p_wmnu;              /* 'wildmenu' */
 EXTERN long p_wh;               /* 'winheight' */
 EXTERN long p_wmh;              /* 'winminheight' */
 EXTERN long p_wmw;              /* 'winminwidth' */
 EXTERN long p_wiw;              /* 'winwidth' */
 EXTERN bool p_ws;               /* 'wrapscan' */
-EXTERN int p_write;             /* 'write' */
-EXTERN int p_wa;                /* 'writeany' */
-EXTERN int p_wb;                /* 'writebackup' */
+EXTERN bool p_write;             /* 'write' */
+EXTERN bool p_wa;                /* 'writeany' */
+EXTERN bool p_wb;                /* 'writebackup' */
 EXTERN long p_wd;               /* 'writedelay' */
 
-EXTERN int p_force_on;          ///< options that cannot be turned off.
-EXTERN int p_force_off;         ///< options that cannot be turned on.
+EXTERN bool p_force_on;          ///< options that cannot be turned off.
+EXTERN bool p_force_off;         ///< options that cannot be turned on.
 
 /*
  * "indir" values for buffer-local opions.

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -268,7 +268,7 @@
 EXTERN long p_aleph;            /* 'aleph' */
 EXTERN bool p_acd;              /* 'autochdir' */
 EXTERN char_u   *p_ambw;        /* 'ambiwidth' */
-EXTERN int p_ar;                /* 'autoread' */
+EXTERN bool p_ar;                /* 'autoread' */
 EXTERN int p_aw;                /* 'autowrite' */
 EXTERN int p_awa;               /* 'autowriteall' */
 EXTERN char_u   *p_bs;          /* 'backspace' */

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -608,7 +608,7 @@ static int pum_set_selected(int n, int repeat)
           }
 
           curbuf->b_changed = false;
-          curbuf->b_p_ma = FALSE;
+          curbuf->b_p_ma = false;
           curwin->w_cursor.lnum = 1;
           curwin->w_cursor.col = 0;
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2354,7 +2354,7 @@ static void qf_fill_buffer(qf_info_T *qi)
    * resembles reading a file into a buffer, it's more logical when using
    * autocommands. */
   set_option_value((char_u *)"ft", 0L, (char_u *)"qf", OPT_LOCAL);
-  curbuf->b_p_ma = FALSE;
+  curbuf->b_p_ma = false;
 
   keep_filetype = TRUE;                 /* don't detect 'filetype' */
   apply_autocmds(EVENT_BUFREADPOST, (char_u *)"quickfix", NULL,

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2101,7 +2101,7 @@ void ex_copen(exarg_T *eap)
           OPT_LOCAL);
       set_option_value((char_u *)"bh", 0L, (char_u *)"wipe", OPT_LOCAL);
       RESET_BINDING(curwin);
-      curwin->w_p_diff = FALSE;
+      curwin->w_p_diff = false;
       set_option_value((char_u *)"fdm", 0L, (char_u *)"manual",
           OPT_LOCAL);
     }
@@ -2112,7 +2112,7 @@ void ex_copen(exarg_T *eap)
         && curwin->w_width == Columns
         )
       win_setheight(height);
-    curwin->w_p_wfh = TRUE;         /* set 'winfixheight' */
+    curwin->w_p_wfh = true;         /* set 'winfixheight' */
     if (win_valid(win))
       prevwin = win;
   }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4981,7 +4981,7 @@ win_redr_custom (
   struct      stl_hlrec tabtab[STL_MAX_ITEM];
   int use_sandbox = FALSE;
   win_T       *ewp;
-  int p_crb_save;
+  bool p_crb_save;
 
   /* There is a tiny chance that this gets called recursively: When
    * redrawing a status line triggers redrawing the ruler or tabline.
@@ -5047,7 +5047,7 @@ win_redr_custom (
    * the cursor away and back. */
   ewp = wp == NULL ? curwin : wp;
   p_crb_save = ewp->w_p_crb;
-  ewp->w_p_crb = FALSE;
+  ewp->w_p_crb = false;
 
   /* Make a copy, because the statusline may include a function call that
    * might change the option value and free the memory. */
@@ -7073,9 +7073,9 @@ static void win_redr_ruler(win_T *wp, int always)
     /* In list mode virtcol needs to be recomputed */
     colnr_T virtcol = wp->w_virtcol;
     if (wp->w_p_list && lcs_tab1 == NUL) {
-      wp->w_p_list = FALSE;
+      wp->w_p_list = false;
       getvvcol(wp, &wp->w_cursor, NULL, &virtcol, NULL);
-      wp->w_p_list = TRUE;
+      wp->w_p_list = true;
     }
 
 #define RULER_BUF_LEN 70

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5396,7 +5396,7 @@ void ex_ownsyntax(exarg_T *eap)
     curwin->w_s = xmalloc(sizeof(synblock_T));
     memset(curwin->w_s, 0, sizeof(synblock_T));
     // TODO: Keep the spell checking as it was.
-    curwin->w_p_spell = FALSE;          /* No spell checking */
+    curwin->w_p_spell = false;          /* No spell checking */
     clear_string_option(&curwin->w_s->b_p_spc);
     clear_string_option(&curwin->w_s->b_p_spf);
     clear_string_option(&curwin->w_s->b_p_spl);

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2286,9 +2286,9 @@ jumpto_tag (
 )
 {
   int save_secure;
-  int save_magic;
+  bool save_magic;
   bool save_p_ws;
-  int save_p_scs, save_p_ic;
+  bool save_p_scs, save_p_ic;
   linenr_T save_lnum;
   int csave = 0;
   char_u      *str;
@@ -2409,7 +2409,7 @@ jumpto_tag (
     secure = 1;
     ++sandbox;
     save_magic = p_magic;
-    p_magic = FALSE;            /* always execute with 'nomagic' */
+    p_magic = false;            /* always execute with 'nomagic' */
     /* Save value of no_hlsearch, jumping to a tag is not a real search */
     save_no_hlsearch = no_hlsearch;
 
@@ -2439,8 +2439,8 @@ jumpto_tag (
       save_p_ic = p_ic;
       save_p_scs = p_scs;
       p_ws = true;              /* need 'wrapscan' for backward searches */
-      p_ic = FALSE;             /* don't ignore case now */
-      p_scs = FALSE;
+      p_ic = false;             /* don't ignore case now */
+      p_scs = false;
       save_lnum = curwin->w_cursor.lnum;
       curwin->w_cursor.lnum = 0;        /* start search before first line */
       if (do_search(NULL, pbuf[0], pbuf + 1, (long)1,
@@ -2453,7 +2453,7 @@ jumpto_tag (
         /*
          * try again, ignore case now
          */
-        p_ic = TRUE;
+        p_ic = true;
         if (!do_search(NULL, pbuf[0], pbuf + 1, (long)1,
                 search_options, NULL)) {
           /*

--- a/test/functional/ex_cmds/set_autoread_spec.lua
+++ b/test/functional/ex_cmds/set_autoread_spec.lua
@@ -1,0 +1,87 @@
+local helpers = require('test.functional.helpers')
+local Screen = require('test.functional.ui.screen')
+local clear, nvim, eq, neq = helpers.clear, helpers.nvim, helpers.eq, helpers.neq
+local ok, feed, execute = helpers.ok, helpers.feed, helpers.execute
+
+
+describe('autoread option', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(30, 6)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.White, background = Screen.colors.Red},
+      [2] = {bold = true, foreground = Screen.colors.SeaGreen}
+    })
+    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
+  end)
+
+  it('is unset locally by default', function()
+    execute('setl autoread?')
+    screen:expect([[
+      ^                              |
+      ~                             |
+      ~                             |
+      ~                             |
+      ~                             |
+      --autoread                    |
+    ]])
+  end)
+
+  it('acts as a global option per default', function()
+    execute('set autoread?')
+    screen:expect([[
+      ^                              |
+      ~                             |
+      ~                             |
+      ~                             |
+      ~                             |
+        autoread                    |
+    ]])
+    execute('new')
+    execute('set noautoread')
+    execute('quit')
+    execute('set autoread?')
+    screen:expect([[
+      ^                              |
+      ~                             |
+      ~                             |
+      ~                             |
+      ~                             |
+      noautoread                    |
+    ]])
+  end)
+
+  it('can be set locally', function()
+    execute('setl autoread')
+    execute('new')
+    execute('set noautoread')
+    execute('setl noautoread')
+    execute('quit')
+    execute('setl autoread?')
+    screen:expect([[
+      ^                              |
+      ~                             |
+      ~                             |
+      ~                             |
+      ~                             |
+        autoread                    |
+    ]])
+
+    -- revert back to global
+    execute('setl autoread<')
+    execute('setl autoread?')
+    screen:expect([[
+      ^                              |
+      ~                             |
+      ~                             |
+      ~                             |
+      ~                             |
+      --autoread                    |
+    ]])
+  end)
+
+end)
+


### PR DESCRIPTION
WIP as there will be a hella lotta lint errors to fix.

`set autoread` was actually broken, as some previous option refactor didn't take into account that this boolean option actually was tristate. The added test documents the expected (vim) behavior (except that default is different from vim)

Also changed some obvious `save_p_someboolopt` but probably is a few left.
