### PR TITLE
[RFC] Windows: Make the os_get_uname argument portable

### DIFF
--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -42,17 +42,17 @@ int os_get_usernames(garray_T *users)
 int os_get_user_name(char *s, size_t len)
 {
 #ifdef UNIX
-  return os_get_uname(getuid(), s, len);
+  return os_get_uname((uv_uid_t)getuid(), s, len);
 #else
   // TODO(equalsraf): Windows GetUserName()
-  return os_get_uname(0, s, len);
+  return os_get_uname((uv_uid_t)0, s, len);
 #endif
 }
 
 // Insert user name for "uid" in s[len].
 // Return OK if a name found.
 // If the name is not found, write the uid into s[len] and return FAIL.
-int os_get_uname(uid_t uid, char *s, size_t len)
+int os_get_uname(uv_uid_t uid, char *s, size_t len)
 {
 #if defined(HAVE_PWD_H) && defined(HAVE_GETPWUID)
   struct passwd *pw;


### PR DESCRIPTION
We can simply use `uv_uid_t` like we do everywhere else.

The only remaining instance of `uid_t` is in [src/nvim/main.c](https://github.com/neovim/neovim/blob/7353e1d62baeaaeec38ae156cc2ea6d722154e7c/src/nvim/main.c#L1747) and is guarded by an
`#ifdef UNIX` check.

In #810 `uid_t` has been typedef'd to `uv_uid_t` but since we use `uv_uid_t` in most other places I thought this would be better. See equalsraf@5383845.
