### PR TITLE
[RFC] Windows: Bring back code branch for if_cscope

### DIFF
--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -743,8 +743,16 @@ err_closing:
     (void)close(to_cs[1]);
     (void)close(from_cs[0]);
 #else
-  /* WIN32 */
-  /* Create pipes to communicate with cscope */
+  // Create pipes to communicate with cscope
+  int fd;
+  SECURITY_ATTRIBUTES sa;
+  PROCESS_INFORMATION pi;
+  BOOL pipe_stdin = FALSE, pipe_stdout = FALSE;  // NOLINT(readability/bool)
+  STARTUPINFO si;
+  HANDLE stdin_rd, stdout_rd;
+  HANDLE stdout_wr, stdin_wr;
+  BOOL created;
+
   sa.nLength = sizeof(SECURITY_ATTRIBUTES);
   sa.bInheritHandle = TRUE;
   sa.lpSecurityDescriptor = NULL;

--- a/src/nvim/if_cscope_defs.h
+++ b/src/nvim/if_cscope_defs.h
@@ -16,6 +16,7 @@
 # include <sys/types.h>         /* pid_t */
 #endif
 
+#include "nvim/os/os_defs.h"
 #include "nvim/os/fs_defs.h"
 
 #define CSCOPE_SUCCESS          0
@@ -50,7 +51,13 @@ typedef struct csi {
   char *          ppath;        /* path to prepend (the -P option) */
   char *          flags;        /* additional cscope flags/options (e.g, -p2) */
 #if defined(UNIX)
-  pid_t pid;                    /* PID of the connected cscope process. */
+  pid_t pid;                    // PID of the connected cscope process
+#else
+    DWORD         pid;          // PID of the connected cscope process
+    HANDLE        hProc;        // cscope process handle
+    DWORD         nVolume;      // Volume serial number, instead of st_dev
+    DWORD         nIndexHigh;   // st_ino has no meaning on Windows
+    DWORD         nIndexLow;
 #endif
   FileID file_id;
 

--- a/src/nvim/os/os_defs.h
+++ b/src/nvim/os/os_defs.h
@@ -57,6 +57,9 @@
 #if !defined(S_ISREG) && defined(S_IFREG)
 # define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #endif
+#if !defined(S_ISLNK) && defined(S_IFLNK)
+# define S_IFLNK(m) (((m) & S_IFMT) == S_IFLNK)
+#endif
 #if !defined(S_ISBLK) && defined(S_IFBLK)
 # define S_ISBLK(m) (((m) & S_IFMT) == S_IFBLK)
 #endif


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@24d3625.

Note that I did not include the definition for `S_ISLNK` from equalsraf@24d3625 since
Windows **can** have symlinks on Vista+.

Checking for symlinks is a pain with the Windows API (do a song and dance with the Windows API like usual) but is possible.

`libuv` will actually set `S_IFLNK` for us on Windows (see [here](https://github.com/libuv/libuv/blob/e76b8838e51f6e8f1944b6c6d50c3948ed764a0b/src/win/fs.c#L1086)) so since the only call to `S_IFLNK` in `if_cscope` (there is one more call to `S_ISLNK` in `src/nvim/eval.c` but it too uses `libuv`) calls `os_fileinfo` which uses `libuv` we can  just define `S_ISLNK` to be:

``` c
#if !defined(S_ISLNK) && defined(S_IFLNK)
# define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
#endif
```

which is what I did.
