### PR TITLE
test: change CI_TARGET reference to CI

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 if [[ -n "${CI_TARGET}" ]]; then
-  make lint
+  make "${CI_TARGET}"
   exit 0
 fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ env:
 matrix:
   include:
     - os: linux
-      env: CI_TARGET=clint
+      env: CI_TARGET=lint
     - os: linux
       compiler: gcc-5
     - os: linux

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -119,7 +119,7 @@ if os.getenv('VALGRIND') then
   default_screen_timeout = default_screen_timeout * 3
 end
 
-if os.getenv('CI_TARGET') then
+if os.getenv('CI') then
   default_screen_timeout = default_screen_timeout * 3
 end
 


### PR DESCRIPTION
Travis defines[1] $CI for its builds, whereas $CI_TARGET is
a Neovim-specific env var from 6483a198e4bee1e80683ba12e061616c3e6c4090
that lost prominence in d2eb4a934683b5da63000d8b79a0d4c9a314d1c0.

[1] https://docs.travis-ci.com/user/environment-variables/
