### PR TITLE
Lua test to ensure that FocusLost event does not remove tab completed commandline text

### DIFF
--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -115,3 +115,20 @@ describe('input utf sequences that contain CSI/K_SPECIAL', function()
     expect('…')
   end)
 end)
+
+describe('text in cmdline lost when tab completing then triggering focuslost event', function()
+  before_each(clear)
+  it('ok', function()
+    local screen = Screen.new(40, 4)
+    screen:attach()
+    feed(':nn<tab>')
+    nvim('command',"silent! doautoall <nomodeline> FocusLost") 
+    screen:expect([[
+                                              |
+      ~                                       |
+      [No Name]                               |
+      :nnoremap^                               |
+    ]])
+    clear()
+  end)
+end)


### PR DESCRIPTION
This PR is a modified version of the test in #3381

Added test that checks to make sure that a FocusLost event will not remove the text in the commandline that was generated by autocomplete. This was an issue back in September and has since been fixed. I am not sure what commit fixed it but this test is now passing. 
