### PR TITLE
[RFC] Fix S_ISLNK definition in os_defs.h

### DIFF
--- a/src/nvim/os/os_defs.h
+++ b/src/nvim/os/os_defs.h
@@ -58,7 +58,7 @@
 # define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #endif
 #if !defined(S_ISLNK) && defined(S_IFLNK)
-# define S_IFLNK(m) (((m) & S_IFMT) == S_IFLNK)
+# define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
 #endif
 #if !defined(S_ISBLK) && defined(S_IFBLK)
 # define S_ISBLK(m) (((m) & S_IFMT) == S_IFBLK)


### PR DESCRIPTION
Should be `S_ISLNK` not `S_IFLNK`.

cc @equalsraf 
