### PR TITLE
[RFC] MinGW: libuv needs -D_WIN32_WINNT=0x0600

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ endif()
 if(MINGW)
   # Use POSIX compatible stdio in Mingw
   add_definitions(-D__USE_MINGW_ANSI_STDIO)
+  add_definitions(-D_WIN32_WINNT=0x0600)
 endif()
 
 # OpenBSD's GCC (4.2.1) doesn't have -Wvla


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@db9703b.
