### PR TITLE
[RFC] doc: Clarify Windows feature tests for eval()

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7023,10 +7023,9 @@ visualextra		Compiled with extra Visual mode commands.
 vreplace		Compiled with |gR| and |gr| commands.
 wildignore		Compiled with 'wildignore' option.
 wildmenu		Compiled with 'wildmenu' option.
-win32			Win32 version of Vim (MS-Windows 95 and later, 32 or
-			64 bits)
-win32unix		Win32 version of Vim, using Unix files (Cygwin)
-win64			Win64 version of Vim (MS-Windows 64 bit).
+win32			Windows version of Vim (32 or 64 bit).
+win32unix		Windows version of Vim, using Unix files (Cygwin).
+win64			Windows version of Vim (64 bit).
 winaltkeys		Compiled with 'winaltkeys' option.
 windows			Compiled with support for more than one window.
 writebackup		Compiled with 'writebackup' default on.


### PR DESCRIPTION
The documentation is horribly inconsistent to version and naming of the Windows version of Vim.

In some places we use `Win32` in others `MS-Windows` and sometimes `Windows` (and in increasingly few places `MS-DOS`).

I would prefer to just use `Windows` but regardless we don't support Windows 95 anymore so
this diff just clears up what the `win32`, `win32unix` and `win64` feature tests are actually for.
