### PR TITLE
[RFC] doc: Remove more references to Windows 95

### DIFF
--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -84,7 +84,6 @@ when you have got a new version):
 You can also install Vim in the "Send To" menu:
 1. Start a Windows Explorer
 2. Navigate to your sendto directory:
-   Windows 95: %windir%\sendto (e.g. "c:\windows\sendto")
    Windows NT: %windir%\profiles\%user%\sendto (e.g.
 	       "c:\winnt\profiles\mattha\sendto").
 3. Right-click in the file pane and select New->Shortcut

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4927,18 +4927,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	instead of the number of lines.
 
 			 *'restorescreen'* *'rs'* *'norestorescreen'* *'nors'*
-'restorescreen' 'rs'	boolean	(default on)
-			global
-			{only in Windows 95/NT console version}
-	When set, the screen contents is restored when exiting Vim.  This also
-	happens when executing external commands.
-
-	For non-Windows Vim: You can set or reset the 't_ti' and 't_te'
-	options in your vimrc.  To disable restoring:
-		set t_ti= t_te=
-	To enable restoring (for an xterm):
-		set t_ti=^[7^[[r^[[?47h t_te=^[[?47l^[8
-	(Where ^[ is an <Esc>, type CTRL-V <Esc> to insert it)
+'restorescreen' 'rs'	Removed. |vim-differences| {Nvim}
 
 				*'revins'* *'ri'* *'norevins'* *'nori'*
 'revins' 'ri'		boolean	(default off)

--- a/runtime/doc/os_win32.txt
+++ b/runtime/doc/os_win32.txt
@@ -14,9 +14,8 @@ The 32 bit version also runs on 64 bit MS-Windows systems.
 
 1. Known problems		|win32-problems|
 2. Startup			|win32-startup|
-3. Restore screen contents	|win32-restore|
-4. Using the mouse		|win32-mouse|
-5. Win32 mini FAQ	        |win32-faq|
+3. Using the mouse		|win32-mouse|
+4. Win32 mini FAQ	        |win32-faq|
 
 Additionally, there are a number of common Win32 and DOS items:
 File locations			|dos-locations|
@@ -77,14 +76,7 @@ make "!xxd" work, as it is in the Tools menu.  And it also means that when
 executable() returns 1 the executable can actually be executed.
 
 ==============================================================================
-3. Restore screen contents				*win32-restore*
-
-When 'restorescreen' is set (which is the default), Vim will restore the
-original contents of the console when exiting or when executing external
-commands.  If you don't want this, use ":set nors".	|'restorescreen'|
-
-==============================================================================
-4. Using the mouse					*win32-mouse*
+3. Using the mouse					*win32-mouse*
 
 The Win32 version of Vim supports using the mouse.  If you have a two-button
 mouse, the middle button can be emulated by pressing both left and right
@@ -96,7 +88,7 @@ When the mouse doesn't work, try disabling the "Quick Edit Mode" feature of
 the console.
 
 ==============================================================================
-5. Win32 mini FAQ					*win32-faq*
+4. Win32 mini FAQ					*win32-faq*
 
 Q. How do I change the font?
 A. In the GUI version, you can use the 'guifont' option.  Example: >

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -820,7 +820,6 @@ Short explanation of each option:		*option-list*
 'relativenumber'  'rnu'	    show relative line number in front of each line
 'remap'			    allow mappings to work recursively
 'report'		    threshold for reporting nr. of lines changed
-'restorescreen'   'rs'	    Win32: restore screen when exiting
 'revins'	  'ri'	    inserting characters will work backwards
 'rightleft'	  'rl'	    window is right-to-left oriented
 'rightleftcmd'	  'rlc'     commands for which editing works right-to-left

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -200,6 +200,7 @@ Other options:
   'guioptions' (only the 't' flag was removed)
   'guipty'
   'macatsui'
+  'restorescreen'
   'shelltype'
   'shortname'
   'termencoding' (Vim 7.4.852 also removed this for Windows)

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -540,10 +540,6 @@ if has("title")
   call append("$", "iconstring\twhen not empty, text for the icon of this window")
   call <SID>OptionG("iconstring", &iconstring)
 endif
-if has("win32")
-  call append("$", "restorescreen\trestore the screen contents when exiting Vim")
-  call <SID>BinOptionG("rs", &rs)
-endif
 
 
 call <SID>Header("using the mouse")

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1856,13 +1856,6 @@ return {
       defaults={if_true={vi=2}}
     },
     {
-      full_name='restorescreen', abbreviation='rs',
-      type='bool', scope={'global'},
-      vi_def=true,
-      enable_if=false,
-      defaults={if_true={vi=true}}
-    },
-    {
       full_name='revins', abbreviation='ri',
       type='bool', scope={'global'},
       vi_def=true,


### PR DESCRIPTION
Just more stuff.

I doubt we support `restorescreen` anymore though since TUI doesn't currently work or if we will need this once it does.
