### PR TITLE
[RFC] doc: Remove more references to MS-DOS

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1041,7 +1041,7 @@ The pattern is interpreted like mostly used in file names:
 	[^ch]   match any character but 'c' and 'h'
 
 Note that for all systems the '/' character is used for path separator (even
-MS-DOS). This was done because the backslash is difficult to use in a pattern
+Windows). This was done because the backslash is difficult to use in a pattern
 and to make the autocommands portable across different systems.
 
 							*autocmd-changes*

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -379,7 +379,7 @@ CTRL-N		After using 'wildchar' which got multiple matches, go to next
 <S-Tab>							*c_CTRL-P* *c_<S-Tab>*
 CTRL-P		After using 'wildchar' which got multiple matches, go to
 		previous match.  Otherwise recall older command-line from
-		history.  <S-Tab> only works with the GUI and with MS-DOS.
+		history.  <S-Tab> only works with the GUI.
 							*c_CTRL-A*
 CTRL-A		All names that match the pattern in front of the cursor are
 		inserted.
@@ -819,7 +819,7 @@ These modifiers can be given, in this order:
 		separator is removed.  Thus ":p:h" on a directory name results
 		on the directory name itself (without trailing slash).
 		When the file name is an absolute path (starts with "/" for
-		Unix; "x:\" for MS-DOS and WIN32), that part is not removed.
+		Unix; "x:\" for Windows), that part is not removed.
 		When there is no head (path is relative to current directory)
 		the result is empty.
 	:t	Tail of the file name (last component of the name).  Must
@@ -918,8 +918,8 @@ option contains "sh", this is done twice, to avoid the shell trying to expand
 the "!".
 
 							*filename-backslash*
-For filesystems that use a backslash as directory separator (MS-DOS and
-Windows), it's a bit difficult to recognize a backslash that is used
+For filesystems that use a backslash as directory separator (Windows
+filesystems), it's a bit difficult to recognize a backslash that is used
 to escape the special meaning of the next character.  The general rule is: If
 the backslash is followed by a normal file name character, it does not have a
 special meaning.  Therefore "\file\foo" is a valid file name, you don't have

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -130,9 +130,7 @@ You can use this file if you discover that you need the original file.  See
 also the 'patchmode' option.  The name of the backup file is normally the same
 as the original file with 'backupext' appended.  The default "~" is a bit
 strange to avoid accidentally overwriting existing files.  If you prefer ".bak"
-change the 'backupext' option.  Extra dots are replaced with '_' on MS-DOS
-machines, when Vim has detected that an MS-DOS-like filesystem is being used
-(e.g., messydos or crossdos).  The backup file can be placed in another
+change the 'backupext' option.  The backup file can be placed in another
 directory by setting 'backupdir'.
 
 When you started editing without giving a file name, "No File" is displayed in
@@ -471,9 +469,9 @@ The 'fileformat' option sets the <EOL> style for a file:
   "mac"		<CR>		   Mac format		*Mac-format*
 
 When reading a file, the mentioned characters are interpreted as the <EOL>.
-In DOS format (default for MS-DOS and Win32), <CR><NL> and <NL> are both
-interpreted as the <EOL>. Note that when writing the file in DOS format,
-<CR> characters will be added for each single <NL>.  Also see |file-read|.
+In DOS format (default for Windows), <CR><NL> and <NL> are both interpreted as
+the <EOL>. Note that when writing the file in DOS format, <CR> characters will
+be added for each single <NL>.  Also see |file-read|.
 
 When writing a file, the mentioned characters are used for <EOL>.  For DOS
 format <CR><NL> is used.  Also see |DOS-format-write|.
@@ -494,13 +492,13 @@ If you start editing a new file and the 'fileformats' option is not empty
 (which is the default), Vim will try to detect whether the lines in the file
 are separated by the specified formats.  When set to "unix,dos", Vim will
 check for lines with a single <NL> (as used on Unix) or by a <CR><NL> pair
-(MS-DOS).  Only when ALL lines end in <CR><NL>, 'fileformat' is set to "dos",
+(Windows).  Only when ALL lines end in <CR><NL>, 'fileformat' is set to "dos",
 otherwise it is set to "unix".  When 'fileformats' includes "mac", and no <NL>
 characters are found in the file, 'fileformat' is set to "mac".
 
-If the 'fileformat' option is set to "dos" on non-MS-DOS systems the message
+If the 'fileformat' option is set to "dos" on non-Windows systems the message
 "[dos format]" is shown to remind you that something unusual is happening.  On
-MS-DOS systems you get the message "[unix format]" if 'fileformat' is set to
+Windows systems you get the message "[unix format]" if 'fileformat' is set to
 "unix".  On all systems but the Macintosh you get the message "[mac format]"
 if 'fileformat' is set to "mac".
 
@@ -966,10 +964,10 @@ lost the original file.
 
 						*DOS-format-write*
 If the 'fileformat' is "dos", <CR> <NL> is used for <EOL>.  This is default
-for MS-DOS and Win32. On other systems the message "[dos format]" is shown to
+for Windows. On other systems the message "[dos format]" is shown to
 remind you that an unusual <EOL> was used.
 						*Unix-format-write*
-If the 'fileformat' is "unix", <NL> is used for <EOL>.  On MS-DOS and Win32
+If the 'fileformat' is "unix", <NL> is used for <EOL>.  On Windows
 the message "[unix format]" is shown.
 						*Mac-format-write*
 If the 'fileformat' is "mac", <CR> is used for <EOL>.  On non-Mac systems the
@@ -999,11 +997,11 @@ When the file name is actually a device name, Vim will not make a backup (that
 would be impossible).  You need to use "!", since the device already exists.
 Example for Unix: >
 	:w! /dev/lpt0
-and for MS-DOS or MS-Windows: >
+and Windows: >
 	:w! lpt0
 For Unix a device is detected when the name doesn't refer to a normal file or
 a directory.  A fifo or named pipe also looks like a device to Vim.
-For MS-DOS and MS-Windows the device is detected by its name:
+For Windows the device is detected by its name:
 	CON
 	CLOCK$
 	NUL
@@ -1224,7 +1222,7 @@ present in 'cpoptions' and "!" is not used in the command.
 			Does not change the meaning of an already opened file,
 			because its full path name is remembered.  Files from
 			the |arglist| may change though!
-			On MS-DOS this also changes the active drive.
+			On Windows this also changes the active drive.
 			To change to the directory of the current file: >
 				:cd %:h
 <

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2825,7 +2825,7 @@ executable({expr})					*executable()*
 		arguments.
 		executable() uses the value of $PATH and/or the normal
 		searchpath for programs.		*PATHEXT*
-		On MS-DOS and MS-Windows the ".exe", ".bat", etc. can
+		On Windows the ".exe", ".bat", etc. can
 		optionally be included.  Then the extensions in $PATHEXT are
 		tried.	Thus if "foo.exe" does not exist, "foo.exe.bat" can be
 		found.	If $PATHEXT is not set then ".exe;.com;.bat;.cmd" is
@@ -2833,9 +2833,9 @@ executable({expr})					*executable()*
 		the name without an extension.	When 'shell' looks like a
 		Unix shell, then the name is also tried without adding an
 		extension.
-		On MS-DOS and MS-Windows it only checks if the file exists and
+		On Windows it only checks if the file exists and
 		is not a directory, not if it's really executable.
-		On MS-Windows an executable in the same directory as Vim is
+		On Windows an executable in the same directory as Vim is
 		always found.  Since this directory is added to $PATH it
 		should also work to execute it |win32-PATH|.
 		The result is a Number:
@@ -3625,8 +3625,7 @@ getmatches()						*getmatches()*
 <
 							*getpid()*
 getpid()	Return a Number which is the process ID of the Vim process.
-		On Unix and MS-Windows this is a unique number, until Vim
-		exits.	On MS-DOS it's always zero.
+		This is a unique number, until Vim exits.
 
 							*getpos()*
 getpos({expr})	Get the position for {expr}.  For possible values of {expr}
@@ -5891,7 +5890,7 @@ sha256({string})						*sha256()*
 
 shellescape({string} [, {special}])			*shellescape()*
 		Escape {string} for use as a shell command argument.
-		On MS-Windows and MS-DOS, when 'shellslash' is not set, it
+		On Windows when 'shellslash' is not set, it
 		will enclose {string} in double quotes and double all double
 		quotes within {string}.
 		For other systems, it will enclose {string} in single quotes

--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -257,17 +257,6 @@ WARNING: If you close this window with the "X" button, and confirm the
 question if you really want to kill the application, Vim may be killed too!
 (This does not apply to commands run asynchronously with ":!start".)
 
-							*msdos-mode*
-If you get a dialog that says "This program is set to run in MS-DOS mode..."
-when you run an external program, you can solve this by changing the
-properties of the associated shortcut:
-- Use a Windows Explorer to find the command.com that is used.  It can be
-  c:\command.com, c:\dos\command.com, c:\windows\command.com, etc.
-- With the right mouse button, select properties of this command.com.
-- In the Program tab select "Advanced".
-- Unselect "MS-DOS mode".
-- Click "OK" twice.
-
 							*win32-!start*
 Normally, Vim waits for a command to complete before continuing (this makes
 sense for most shell commands which produce output for Vim to use).  If you

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1941,9 +1941,9 @@ If the 'fileformats' option is not empty Vim tries to recognize the type of
 changed, the detected format is only used while reading the file.
 A similar thing happens with 'fileencodings'.
 
-On non-MS-DOS and Win32 systems the message "[dos format]" is shown if
+On non-Windows systems the message "[dos format]" is shown if
 a file is read in DOS format, to remind you that something unusual is done.
-On Macintosh, MS-DOS, and Win32 the message "[unix format]" is shown if
+On Macintosh and Windows the message "[unix format]" is shown if
 a file is read in Unix format.
 On non-Macintosh systems, the message "[Mac format]" is shown if a file is
 read in Mac format.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -779,7 +779,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	Normally this option would be set in the vimrc file.  Possibly
 	depending on the terminal name.  Example: >
-		:if &term == "pcterm"
+		:if &term == "xterm"
 		:  set background=dark
 		:endif
 <	When this option is set, the default settings for the highlight groups
@@ -7098,6 +7098,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	The number of microseconds to wait for each character sent to the
 	screen.  When non-zero, characters are sent to the terminal one by
-	one.  For MS-DOS pcterm this does not work.  For debugging purposes.
+	one.  For debugging purposes.
 
  vim:tw=78:ts=8:ft=help:noet:norl:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5287,8 +5287,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'shell'* *'sh'* *E91*
 'shell' 'sh'		string	(default $SHELL or "sh",
-					Windows: "command.com" or
-					"cmd.exe")
+					Windows: "cmd.exe")
 			global
 	Name of the shell to use for ! and :! commands.  When changing the
 	value also check these options: 'shellpipe', 'shellslash'
@@ -5334,7 +5333,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 				 contain "sh" somewhere: "/c")
 			global
 	Flag passed to the shell to execute "!" and ":!" commands; e.g.,
-	"bash.exe -c ls" or "command.com /c dir".  For Windows
+	"bash.exe -c ls" or "cmd.exe /c dir".  For Windows
 	systems, the default is set according to the value of 'shell', to
 	reduce the need to set this option by the user.
 	On Unix it can have more than one flag.  Each white space separated

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -183,7 +183,7 @@ the option value, use '\"' instead.  This example sets the 'titlestring'
 option to 'hi "there"': >
    :set titlestring=hi\ \"there\"
 
-For MS-DOS and WIN32 backslashes in file names are mostly not removed.  More
+For Windows backslashes in file names are mostly not removed.  More
 precise: For options that expect a file name (those where environment
 variables are expanded) a backslash before a normal file name character is not
 removed.  But a backslash before a special character (space, backslash, comma,
@@ -772,7 +772,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	putting a ":gui" command in the gvimrc file, before where the value
 	of 'background' is used (e.g., before ":syntax on").
 
-	For MS-DOS and Windows the default is "dark".
+	For Windows the default is "dark".
 	For other systems "dark" is used when 'term' is "linux",
 	"screen.linux", "cygwin" or "putty", or $COLORFGBG suggests a dark
 	background.  Otherwise the default is "light".
@@ -900,7 +900,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  impossible!).  Writing may fail because of this.
 	- A directory "." means to put the backup file in the same directory
 	  as the edited file.
-	- A directory starting with "./" (or ".\" for MS-DOS et al.) means to
+	- A directory starting with "./" (or ".\" for Windows) means to
 	  put the backup file relative to where the edited file is.  The
 	  leading "." is replaced with the path name of the edited file.
 	  ("." inside a directory name has no special meaning).
@@ -2075,7 +2075,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  the edited file.  On Unix, a dot is prepended to the file name, so
 	  it doesn't show in a directory listing.  On MS-Windows the "hidden"
 	  attribute is set and a dot prepended if possible.
-	- A directory starting with "./" (or ".\" for MS-DOS et al.) means to
+	- A directory starting with "./" (or ".\" for Windows) means to
 	  put the swap file relative to where the edited file is.  The leading
 	  "." is replaced with the path name of the edited file.
 	- For Unix and Win32, if a directory ends in two path separators "//"
@@ -2395,7 +2395,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	is read.
 
 					*'fileformat'* *'ff'*
-'fileformat' 'ff'	string (MS-DOS and MS-Windows default: "dos",
+'fileformat' 'ff'	string (Windows default: "dos",
 				Unix default: "unix",
 				Macintosh default: "mac")
 			local to buffer
@@ -2865,14 +2865,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 					r-cr:hor20-Cursor/lCursor,
 					sm:block-Cursor
 					-blinkwait175-blinkoff150-blinkon175",
-				for MS-DOS and Win32 console:
+				for Windows console:
 					"n-v-c:block,o:hor50,i-ci:hor15,
 					r-cr:hor30,sm:block")
 			global
 			{only available when compiled with GUI enabled, and
-			for MS-DOS and Win32 console}
+			for Windows console}
 	This option tells Vim what the cursor should look like in different
-	modes.  It fully works in the GUI.  In an MSDOS or Win32 console, only
+	modes.  It fully works in the GUI.  In a Windows console, only
 	the height of the cursor can be changed.  This can be done by
 	specifying a block cursor, or a percentage for a vertical or
 	horizontal cursor.
@@ -3614,7 +3614,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When executing commands with |:normal| 'insertmode' is not used.
 
 						*'isfname'* *'isf'*
-'isfname' 'isf'		string	(default for MS-DOS and Win32:
+'isfname' 'isf'		string	(default for Windows:
 			     "@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,="
 			    otherwise: "@,48-57,/,.,-,_,+,,,#,$,%,~,=")
 			global
@@ -3665,7 +3665,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |option-backslash| about including spaces and backslashes.
 
 						*'isident'* *'isi'*
-'isident' 'isi'		string	(default for MS-DOS and Win32:
+'isident' 'isi'		string	(default for Windows:
 					   "@,48-57,_,128-167,224-235"
 				otherwise: "@,48-57,_,192-255")
 			global
@@ -4288,7 +4288,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The mouse pointer is restored when the mouse is moved.
 
 						*'mousemodel'* *'mousem'*
-'mousemodel' 'mousem'	string	(default "extend", "popup" for MS-DOS and Win32)
+'mousemodel' 'mousem'	string	(default "extend", "popup" for Windows)
 			global
 	Sets the model to use for the mouse.  The name mostly specifies what
 	the right mouse button is used for:
@@ -4390,7 +4390,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'mousetime'* *'mouset'*
 'mousetime' 'mouset'	number	(default 500)
 			global
-	Only for GUI, MS-DOS, Win32 and Unix with xterm.  Defines the maximum
+	Only for GUI, Windows and Unix with xterm.  Defines the maximum
 	time in msec between two mouse clicks for the second click to be
 	recognized as a multi click.
 
@@ -4471,11 +4471,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 			    *'opendevice'* *'odev'* *'noopendevice'* *'noodev'*
 'opendevice' 'odev'	boolean	(default off)
 			global
-			{only for MS-DOS and MS-Windows}
+			{only for Windows}
 	Enable reading and writing from devices.  This may get Vim stuck on a
 	device that can be opened but doesn't actually do the I/O.  Therefore
 	it is off by default.
-	Note that on MS-Windows editing "aux.h", "lpt1.txt" and the like also
+	Note that on Windows editing "aux.h", "lpt1.txt" and the like also
 	result in editing a device.
 
 
@@ -5249,7 +5249,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	r	Removable media.  The argument is a string (up to the next
 		',').  This parameter can be given several times.  Each
 		specifies the start of a path for which no marks will be
-		stored.  This is to avoid removable media.  For MS-DOS you
+		stored.  This is to avoid removable media.  For Windows you
 		could use "ra:,rb:".  You can also use it for temp files,
 		e.g., for Unix: "r/tmp".  Case is ignored.
 							*shada-s*
@@ -5287,7 +5287,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'shell'* *'sh'* *E91*
 'shell' 'sh'		string	(default $SHELL or "sh",
-					MS-DOS and Win32: "command.com" or
+					Windows: "command.com" or
 					"cmd.exe")
 			global
 	Name of the shell to use for ! and :! commands.  When changing the
@@ -5330,11 +5330,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'shellcmdflag'* *'shcf'*
 'shellcmdflag' 'shcf'	string	(default: "-c";
-				 MS-DOS and Win32, when 'shell' does not
+				 Windows, when 'shell' does not
 				 contain "sh" somewhere: "/c")
 			global
 	Flag passed to the shell to execute "!" and ":!" commands; e.g.,
-	"bash.exe -c ls" or "command.com /c dir".  For the MS-DOS-like
+	"bash.exe -c ls" or "command.com /c dir".  For Windows
 	systems, the default is set according to the value of 'shell', to
 	reduce the need to set this option by the user.
 	On Unix it can have more than one flag.  Each white space separated
@@ -5342,7 +5342,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |option-backslash| about including spaces and backslashes.
 	See |shell-unquoting| which talks about separating this option into 
 	multiple arguments.
-	Also see |dos-shell| for MS-DOS and MS-Windows.
+	Also see |dos-shell| for Windows.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
@@ -5357,7 +5357,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The name of the temporary file can be represented by "%s" if necessary
 	(the file name is appended automatically if no %s appears in the value
 	of this option).
-	For MS-DOS the default is ">".  The output is directly saved in a file
+	For Windows the default is ">".  The output is directly saved in a file
 	and not echoed to the screen.
 	For Unix the default it "| tee".  The stdout of the compiler is saved
 	in a file and echoed to the screen.  If the 'shell' option is "csh" or
@@ -5381,7 +5381,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 						*'shellquote'* *'shq'*
-'shellquote' 'shq'	string	(default: ""; MS-DOS and Win32, when 'shell'
+'shellquote' 'shq'	string	(default: ""; Windows, when 'shell'
 					contains "sh" somewhere: "\"")
 			global
 	Quoting character(s), put around the command passed to the shell, for
@@ -5389,7 +5389,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	quoting.  See 'shellxquote' to include the redirection.  It's
 	probably not useful to set both options.
 	This is an empty string by default.  Only known to be useful for
-	third-party shells on MS-DOS-like systems, such as the MKS Korn Shell
+	third-party shells on Windows systems, such as the MKS Korn Shell
 	or bash, where it should be "\"".  The default is adjusted according
 	the value of 'shell', to reduce the need to set this option by the
 	user.  See |dos-shell|.
@@ -5454,7 +5454,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'shellxescape'* *'sxe'*
 'shellxescape' 'sxe'	string	(default: "";
-				 for MS-DOS and MS-Windows: "\"&|<>()@^")
+				 for Windows: "\"&|<>()@^")
 			global
 	When 'shellxquote' is set to "(" then the characters listed in this
 	option will be escaped with a '^' character.  This makes it possible
@@ -6342,9 +6342,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'term'			string	(default is $TERM, if that fails:
 				      in the GUI: "builtin_gui"
 					  on Mac: "mac-ansi"
-				       on MS-DOS: "pcterm"
 					 on Unix: "ansi"
-				       on Win 32: "win32")
+				       on Windows: "win32")
 			global
 	Name of the terminal.  Used for choosing the terminal control
 	characters.  Environment variables are expanded |:set_env|.

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -131,7 +131,7 @@ gD			Goto global Declaration.  When the cursor is on a
 
 							*CTRL-C*
 CTRL-C			Interrupt current (search) command.  Use CTRL-Break on
-			MS-DOS |dos-CTRL-Break|.
+			Windows |dos-CTRL-Break|.
 			In Normal mode, any pending command is aborted.
 
 							*:noh* *:nohlsearch*

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -587,11 +587,11 @@ or simpler >
 "$*" can be given multiple times, for example: >
    :set makeprg=gcc\ -o\ $*\ $*
 
-The 'shellpipe' option defaults to ">" for MS-DOS and Win32.  This means that
-the output of the compiler is saved in a file and not shown on the screen
-directly.  For Unix "| tee" is used.  The compiler output is shown on the
-screen and saved in a file the same time.  Depending on the shell used "|&
-tee" or "2>&1| tee" is the default, so stderr output will be included.
+The 'shellpipe' option defaults to ">" on Windows.  This means that the output
+of the compiler is saved in a file and not shown on the screen directly.  For
+Unix "| tee" is used.  The compiler output is shown on the screen and saved in
+a file the same time.  Depending on the shell used "|& tee" or "2>&1| tee" is
+the default, so stderr output will be included.
 
 If 'shellpipe' is empty, the {errorfile} part will be omitted.  This is useful
 for compilers that write to an errorfile themselves.
@@ -999,9 +999,9 @@ normally happens by matching following characters and items.  When nothing is
 following the rest of the line is matched.  If "%f" is followed by a '%' or a
 backslash, it will look for a sequence of 'isfname' characters.
 
-On MS-DOS and MS-Windows a leading "C:" will be included in "%f", even when
-using "%f:".  This means that a file name which is a single alphabetical
-letter will not be detected.
+On Windows a leading "C:" will be included in "%f", even when using "%f:".
+This means that a file name which is a single alphabetical letter will not be
+detected.
 
 The "%p" conversion is normally followed by a "^".  It's used for compilers
 that output a line like: >

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -980,10 +980,10 @@ Short explanation of each option:		*option-list*
 |g_CTRL-G|	   g CTRL-G	show cursor column, line, and character
 				   position
 |CTRL-C|	   CTRL-C	during searches: Interrupt the search
-|dos-CTRL-Break|   CTRL-Break	MS-DOS: during searches: Interrupt the search
+|dos-CTRL-Break|   CTRL-Break	Windows: during searches: Interrupt the search
 |<Del>|		   <Del>	while entering a count: delete last character
 |:version|	:ve[rsion]	show version information
-|:mode|		:mode N		MS-DOS: set screen mode to N (number, C80,
+|:mode|		:mode N		Windows: set screen mode to N (number, C80,
 				   C4350, etc.)
 |:normal|	:norm[al][!] {commands}
 				execute Normal mode commands

--- a/runtime/doc/recover.txt
+++ b/runtime/doc/recover.txt
@@ -60,7 +60,7 @@ Disadvantages:
 If you want to put swap files in a fixed place, put a command resembling the
 following ones in your vimrc:
 	:set dir=~/tmp		(for Unix)
-	:set dir=c:\\tmp	(for MS-DOS and Win32)
+	:set dir=c:\\tmp	(for Windows)
 This is also very handy when editing files on floppy.  Of course you will have
 to create that "tmp" directory for this to work!
 

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -287,13 +287,13 @@ with CTRL-V followed by the three digit decimal code.  This does NOT work for
 the <t_xx> termcap codes, these can only be used in mappings.
 
 							*:source_crnl* *W15*
-MS-DOS and Win32: Files that are read with ":source" normally have
-<CR><NL> <EOL>s.  These always work.  If you are using a file with <NL> <EOL>s
-(for example, a file made on Unix), this will be recognized if 'fileformats'
-is not empty and the first line does not end in a <CR>.  This fails if the
-first line has something like ":map <F1> :help^M", where "^M" is a <CR>.  If
-the first line ends in a <CR>, but following ones don't, you will get an error
-message, because the <CR> from the first lines will be lost.
+Windows: Files that are read with ":source" normally have <CR><NL> <EOL>s.
+These always work.  If you are using a file with <NL> <EOL>s (for example, a
+file made on Unix), this will be recognized if 'fileformats' is not empty and
+the first line does not end in a <CR>.  This fails if the first line has
+something like ":map <F1> :help^M", where "^M" is a <CR>.  If the first line
+ends in a <CR>, but following ones don't, you will get an error message,
+because the <CR> from the first lines will be lost.
 
 Mac Classic: Files that are read with ":source" normally have <CR> <EOL>s.
 These always work.  If you are using a file with <NL> <EOL>s (for example, a
@@ -303,7 +303,7 @@ linebreaks which has a <CR> in first line.
 
 On other systems, Vim expects ":source"ed files to end in a <NL>.  These
 always work.  If you are using a file with <CR><NL> <EOL>s (for example, a
-file made on MS-DOS), all lines will have a trailing <CR>.  This may cause
+file made on Windows), all lines will have a trailing <CR>.  This may cause
 problems for some commands (e.g., mappings).  There is no automatic <EOL>
 detection, because it's common to start with a line that defines a mapping
 that ends in a <CR>, which will confuse the automaton.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -356,7 +356,7 @@ accordingly.  Vim proceeds in this order:
 
 1. Set the 'shell' and 'term' option		*SHELL* *COMSPEC* *TERM*
 	The environment variable SHELL, if it exists, is used to set the
-	'shell' option.  On MS-DOS and Win32, the COMSPEC variable is used
+	'shell' option.  On Windows, the COMSPEC variable is used
 	if SHELL is not set.
 	The environment variable TERM, if it exists, is used to set the 'term'
 	option.  However, 'term' will change later when starting the GUI (step
@@ -494,7 +494,7 @@ sessions.  Put it in a place so that it will be found by 3b:
 Local setup:
 Put all commands that you need for editing a specific directory only into a
 vimrc file and place it in that directory under the name ".nvimrc" ("_nvimrc"
-for MS-DOS and Win32).  NOTE: To make Vim look for these special files you
+for Windows).  NOTE: To make Vim look for these special files you
 have to turn on the option 'exrc'.  See |trojan-horse| too.
 
 System setup:
@@ -516,10 +516,9 @@ interfere with Vi, then use the variable VIMINIT and the file init.vim
 instead.
 
 MS-DOS line separators:
-On MS-DOS-like systems (MS-DOS itself and Win32), Vim assumes that all
-the vimrc files have <CR> <NL> pairs as line separators.  This will give
-problems if you have a file with only <NL>s and have a line like
-":map xx yy^M".  The trailing ^M will be ignored.
+On Windows systems Vim assumes that all the vimrc files have <CR> <NL> pairs
+as line separators.  This will give problems if you have a file with only
+<NL>s and have a line like ":map xx yy^M".  The trailing ^M will be ignored.
 
 The $MYVIMRC or $MYGVIMRC file will be set to the first found vimrc and/or
 gvimrc file.
@@ -947,7 +946,7 @@ about to abandon with ":bdel", use ":wsh".  The '[' and ']' marks are not
 stored, but the '"' mark is.  The '"' mark is very useful for jumping to the
 cursor position when the file was last exited.  No marks are saved for files
 that start with any string given with the "r" flag in 'shada'.  This can be
-used to avoid saving marks for files on removable media (for MS-DOS you would
+used to avoid saving marks for files on removable media (for Windows you would
 use "ra:,rb:".
 The |v:oldfiles| variable is filled with the file names that the ShaDa file
 has marks for.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4507,7 +4507,7 @@ mentioned for the default values. See |:verbose-cmd| for more information.
 					*highlight-args* *E416* *E417* *E423*
 There are three types of terminals for highlighting:
 term	a normal terminal (vt100, xterm)
-cterm	a color terminal (Wondows console, color-xterm, these have the "Co"
+cterm	a color terminal (Windows console, color-xterm, these have the "Co"
 	termcap entry)
 gui	the GUI
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -71,10 +71,10 @@ with: >
 For a color terminal see |:hi-normal-cterm|.
 For setting up your own colors syntax highlighting see |syncolor|.
 
-NOTE: The syntax files on MS-DOS and Windows have lines that end in <CR><NL>.
-The files for Unix end in <NL>.  This means you should use the right type of
-file for your system.  Although on MS-DOS and Windows the right format is
-automatically selected if the 'fileformats' option is not empty.
+NOTE: The syntax files on Windows have lines that end in <CR><NL>.  The files
+for Unix end in <NL>.  This means you should use the right type of file for
+your system.  Although on Windows the right format is automatically selected
+if the 'fileformats' option is not empty.
 
 NOTE: When using reverse video ("gvim -fg white -bg black"), the default value
 of 'background' will not be set until the GUI window is opened, which is after
@@ -4507,7 +4507,7 @@ mentioned for the default values. See |:verbose-cmd| for more information.
 					*highlight-args* *E416* *E417* *E423*
 There are three types of terminals for highlighting:
 term	a normal terminal (vt100, xterm)
-cterm	a color terminal (MS-DOS console, color-xterm, these have the "Co"
+cterm	a color terminal (Wondows console, color-xterm, these have the "Co"
 	termcap entry)
 gui	the GUI
 
@@ -4653,7 +4653,7 @@ ctermbg={color-nr}				*highlight-ctermbg*
 							*E419* *E420*
 	When Vim knows the normal foreground and background colors, "fg" and
 	"bg" can be used as color names.  This only works after setting the
-	colors for the Normal group and for the MS-DOS console.  Example, for
+	colors for the Normal group and for the Windows console.  Example, for
 	reverse video: >
 	    :highlight Visual ctermfg=bg ctermbg=fg
 <	Note that the colors are used that are valid at the moment this

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -425,11 +425,9 @@ cleared when scrolling).
 Unfortunately it is not possible to deduce from the termcap how cursor
 positioning should be done when using a scrolling region: Relative to the
 beginning of the screen or relative to the beginning of the scrolling region.
-Most terminals use the first method.  A known exception is the MS-DOS console
-(pcterm).  The 't_CS' option should be set to any string when cursor
-positioning is relative to the start of the scrolling region.  It should be
-set to an empty string otherwise.  It defaults to "yes" when 'term' is
-"pcterm".
+Most terminals use the first method.  The 't_CS' option should be set to any
+string when cursor positioning is relative to the start of the scrolling
+region.  It should be set to an empty string otherwise.
 
 Note for xterm users: The shifted cursor keys normally don't work.  You can
 	make them work with the xmodmap command and some mappings in Vim.

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -689,8 +689,8 @@ alt key is pressed (it may move the window).
 
 							*double-click*
 Double, triple and quadruple clicks are supported when the GUI is active, for
-Windows and for an xterm (if the gettimeofday() function is available).  For
-selecting text, extra clicks extend the selection:
+Windows and for an xterm.  For selecting text, extra clicks extend the
+selection:
 	click		select ~
 	double		word or % match		*<2-LeftMouse>*
 	triple		line			*<3-LeftMouse>*

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -672,10 +672,9 @@ border, the text is scrolled.
 A selection can be started by pressing the left mouse button on the first
 character, moving the mouse to the last character, then releasing the mouse
 button.  You will not always see the selection until you release the button,
-only in some versions (GUI, MS-DOS, WIN32) will the dragging be shown
-immediately.  Note that you can make the text scroll by moving the mouse at
-least one character in the first/last line in the window when 'scrolloff' is
-non-zero.
+only in some versions (GUI, Windows) will the dragging be shown immediately.
+Note that you can make the text scroll by moving the mouse at least one
+character in the first/last line in the window when 'scrolloff' is non-zero.
 
 In Normal, Visual and Select mode clicking the right mouse button causes the
 Visual area to be extended.  When 'mousemodel' is "popup", the left button has
@@ -689,9 +688,9 @@ work on systems where the window manager consumes the mouse events when the
 alt key is pressed (it may move the window).
 
 							*double-click*
-Double, triple and quadruple clicks are supported when the GUI is active,
-for MS-DOS and Win32, and for an xterm (if the gettimeofday() function is
-available).  For selecting text, extra clicks extend the selection:
+Double, triple and quadruple clicks are supported when the GUI is active, for
+Windows and for an xterm (if the gettimeofday() function is available).  For
+selecting text, extra clicks extend the selection:
 	click		select ~
 	double		word or % match		*<2-LeftMouse>*
 	triple		line			*<3-LeftMouse>*

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -29,8 +29,8 @@ To start Vim, enter this command: >
 
 	gvim file.txt
 
-In UNIX you can type this at any command prompt.  If you are running Microsoft
-Windows, open an MS-DOS prompt window and enter the command.
+On Unix you can type this at any command prompt.  If you are running Microsoft
+Windows, open an command prompt window and enter the command.
    In either case, Vim starts editing a file called file.txt.  Because this
 is a new file, you get a blank window. This is what your screen will look
 like:
@@ -61,10 +61,9 @@ use this command: >
 
 the editing occurs inside your command window.  In other words, if you are
 running inside an xterm, the editor uses your xterm window.  If you are using
-an MS-DOS command prompt window under Microsoft Windows, the editing occurs
-inside this window.  The text in the window will look the same for both
-versions, but with gvim you have extra features, like a menu bar.  More about
-that later.
+the command prompt under Microsoft Windows, the editing occurs inside this
+window.  The text in the window will look the same for both versions, but with
+gvim you have extra features, like a menu bar.  More about that later.
 
 ==============================================================================
 *02.2*	Inserting text

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -29,11 +29,10 @@ To start Vim, enter this command: >
 
 	gvim file.txt
 
-On Unix you can type this at any command prompt.  If you are running Microsoft
-Windows, open an command prompt window and enter the command.
-   In either case, Vim starts editing a file called file.txt.  Because this
-is a new file, you get a blank window. This is what your screen will look
-like:
+On Unix you can type this at any command prompt.  If you are running Windows,
+open a command prompt window and enter the command.  In either case, Vim
+starts editing a file called file.txt.  Because this is a new file, you get a
+blank window. This is what your screen will look like:
 
 	+---------------------------------------+
 	|#					|

--- a/runtime/doc/usr_23.txt
+++ b/runtime/doc/usr_23.txt
@@ -34,7 +34,7 @@ have line-break problems.  The Vim editor automatically recognizes the
 different file formats and handles things properly behind your back.
    The option 'fileformats' contains the various formats that will be tried
 when a new file is edited.  The following command, for example, tells Vim to
-try UNIX format first and MS-DOS format second: >
+try Unix format first and MS-DOS format second: >
 
 	:set fileformats=unix,dos
 

--- a/runtime/doc/usr_24.txt
+++ b/runtime/doc/usr_24.txt
@@ -563,9 +563,9 @@ that combination.  Thus CTRL-K dP also works.  Since there is no digraph for
 "dP" Vim will also search for a "Pd" digraph.
 
 	Note:
-	The digraphs depend on the character set that Vim assumes you are
-	using.  On MS-DOS they are different from MS-Windows.  Always use
-	":digraphs" to find out which digraphs are currently available.
+	The digraphs depend on the character set that Vim assumes you
+	are using.  Always use ":digraphs" to find out which digraphs are
+	currently available.
 
 You can define your own digraphs.  Example: >
 

--- a/runtime/doc/usr_27.txt
+++ b/runtime/doc/usr_27.txt
@@ -83,7 +83,7 @@ matter if 'ignorecase' or 'smartcase' was changed.
 
 	Note:
 	If your search takes much longer than you expected, you can interrupt
-	it with CTRL-C on Unix and  CTRL-Break on MS-DOS and MS-Windows.
+	it with CTRL-C on Unix and CTRL-Break on Windows.
 
 ==============================================================================
 *27.2*	Wrapping around the file end

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1499,8 +1499,8 @@ Here is a summary of items that apply to Vim scripts.  They are also mentioned
 elsewhere, but form a nice checklist.
 
 The end-of-line character depends on the system.  For Unix a single <NL>
-character is used.  For MS-DOS, Windows and the like, <CR><LF> is used.
-This is important when using mappings that end in a <CR>.  See |:source_crnl|.
+character is used.  For Windows <CR><LF> is used.  This is important when
+using mappings that end in a <CR>.  See |:source_crnl|.
 
 
 WHITE SPACE

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -563,7 +563,7 @@ which it was defined is reported.
 			     :5sleep	     "sleep for five seconds
 			     :sleep 100m     "sleep for a hundred milliseconds
 			     10gs	     "sleep for ten seconds
-<			Can be interrupted with CTRL-C (CTRL-Break on MS-DOS).
+<			Can be interrupted with CTRL-C (CTRL-Break on Windows).
 			"gs" stands for "goto sleep".
 			While sleeping the cursor is positioned in the text,
 			if at a visible position.

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -44,8 +44,7 @@ Memory usage limits
 
 The option 'maxmem' ('mm') is used to set the maximum memory used for one
 buffer (in kilobytes).  'maxmemtot' is used to set the maximum memory used for
-all buffers (in kilobytes).  The defaults depend on the system used.  For
-MS-DOS, 'maxmemtot' is set depending on the amount of memory available.
+all buffers (in kilobytes).  The defaults depend on the system used.
 These are not hard limits, but tell Vim when to move text into a swap file.
 If you don't like Vim to swap to a file, set 'maxmem' and 'maxmemtot' to a
 very large value.  The swap file will then only be used for recovery.  If you

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -366,14 +366,13 @@ readfile (
   /* don't display the file info for another buffer now */
   need_fileinfo = FALSE;
 
-  /*
-   * For Unix: Use the short file name whenever possible.
-   * Avoids problems with networks and when directory names are changed.
-   * Don't do this for MS-DOS, a "cd" in a sub-shell may have moved us to
-   * another directory, which we don't detect.
-   */
-  if (sfname == NULL)
+  // For Unix: Use the short file name whenever possible.
+  // Avoids problems with networks and when directory names are changed.
+  // Don't do this for Windows, a "cd" in a sub-shell may have moved us to
+  // another directory, which we don't detect.
+  if (sfname == NULL) {
     sfname = fname;
+  }
 #if defined(UNIX)
   fname = sfname;
 #endif
@@ -2353,13 +2352,12 @@ buf_write (
 
   if (sfname == NULL)
     sfname = fname;
-  /*
-   * For Unix: Use the short file name whenever possible.
-   * Avoids problems with networks and when directory names are changed.
-   * Don't do this for MS-DOS, a "cd" in a sub-shell may have moved us to
-   * another directory, which we don't detect
-   */
-  ffname = fname;                           /* remember full fname */
+
+  // For Unix: Use the short file name whenever possible.
+  // Avoids problems with networks and when directory names are changed.
+  // Don't do this for Windows, a "cd" in a sub-shell may have moved us to
+  // another directory, which we don't detect.
+  ffname = fname;                           // remember full fname
 #ifdef UNIX
   fname = sfname;
 #endif
@@ -6449,12 +6447,11 @@ apply_autocmds_group (
   }
 
 #ifdef BACKSLASH_IN_FILENAME
-  /*
-   * Replace all backslashes with forward slashes.  This makes the
-   * autocommand patterns portable between Unix and MS-DOS.
-   */
-  if (sfname != NULL)
+  // Replace all backslashes with forward slashes. This makes the
+  // autocommand patterns portable between Unix and Windows.
+  if (sfname != NULL) {
     forward_slash(sfname);
+  }
   forward_slash(fname);
 #endif
 
@@ -6771,10 +6768,8 @@ int has_autocmd(event_T event, char_u *sfname, buf_T *buf)
     return FALSE;
 
 #ifdef BACKSLASH_IN_FILENAME
-  /*
-   * Replace all backslashes with forward slashes.  This makes the
-   * autocommand patterns portable between Unix and MS-DOS.
-   */
+  // Replace all backslashes with forward slashes. This makes the
+  // autocommand patterns portable between Unix and Windows.
   sfname = vim_strsave(sfname);
   forward_slash(sfname);
   forward_slash(fname);

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -142,7 +142,7 @@ void os_get_hostname(char *hostname, size_t len)
 ///   - go to that directory
 ///   - do os_dirname() to get the real name of that directory.
 /// This also works with mounts and links.
-/// Don't do this for MS-DOS, it will change the "current dir" for a drive.
+/// Don't do this for Windows, it will change the "current dir" for a drive.
 static char_u   *homedir = NULL;
 
 void init_homedir(void)


### PR DESCRIPTION
Just more MS-DOS references sent to the bit bucket.

References to MS-DOS as they refer to the file format `:set fileformat=dos` have been left as I feel that makes the most logical sense.
