### PR TITLE
[RFC] coverity/62611: Nesting level does not match indentation

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1878,7 +1878,8 @@ failed:
       }
       if (msg_add_fileformat(fileformat))
         c = TRUE;
-        msg_add_lines(c, (long)linecnt, filesize);
+
+      msg_add_lines(c, (long)linecnt, filesize);
 
       xfree(keep_msg);
       keep_msg = NULL;


### PR DESCRIPTION
coverity/62611: Nesting level does not match indentation

The nested line was the else-branch of an if-then-else block that dealt
with cryptography, but after commit
85338fe1d5a56f82546e16c305c2048c081771e0 (Remove cryptography) removed
the if-then part, the indentation of this line was not adjusted.
