### PR TITLE
[RFC] vim-patch:e3faf44

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2415,6 +2415,10 @@ col({expr})	The result is a Number, which is the byte index of the column
 			    number of bytes in the cursor line plus one)
 		    'x	    position of mark x (if the mark is not set, 0 is
 			    returned)
+		    v       In Visual mode: the start of the Visual area (the
+			    cursor is the end).  When not in Visual mode
+			    returns the cursor position.  Differs from |'<| in
+			    that it's updated right away.
 		Additionally {expr} can be [lnum, col]: a |List| with the line
 		and column number. Most useful when the column is "$", to get
 		the last column of a specific line.  When "lnum" or "col" is
@@ -6695,6 +6699,10 @@ virtcol({expr})						*virtcol()*
 			    plus one)
 		    'x	    position of mark x (if the mark is not set, 0 is
 			    returned)
+		    v       In Visual mode: the start of the Visual area (the
+			    cursor is the end).  When not in Visual mode
+			    returns the cursor position.  Differs from |'<| in
+			    that it's updated right away.
 		Note that only marks in the current file can be used.
 		Examples: >
   virtcol(".")	   with text "foo^Lbar", with cursor on the "^L", returns 5

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1,4 +1,4 @@
-*map.txt*       For Vim version 7.4.  Last change: 2014 Oct 03
+*map.txt*       For Vim version 7.4.  Last change: 2014 Dec 08
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/indent/vim.vim
+++ b/runtime/indent/vim.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:	Vim script
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Sep 19
+" Last Change:	2014 Dec 12
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -89,7 +89,7 @@ function GetVimIndentIntern()
 
   " Subtract a 'shiftwidth' on a :endif, :endwhile, :catch, :finally, :endtry,
   " :endfun, :else and :augroup END.
-  if cur_text =~ '^\s*\(ene\@!\|cat\|fina\|el\|aug\%[roup]\s*!\=\s\+END\)'
+  if cur_text =~ '^\s*\(ene\@!\|cat\|fina\|el\|aug\%[roup]\s*!\=\s\+[eE][nN][dD]\)'
     let ind = ind - &sw
   endif
 


### PR DESCRIPTION
Updated runtime files.

https://github.com/vim/vim/commit/e3faf44bef029d07f37a457bd0050653b628058f

For an explanation why this patch is not reported as missing by `vim-patch.sh` see #3964.

Output of `patch -p1 < vim-e3faf44.diff`:

```
patching file runtime/doc/eval.txt
Hunk #1 FAILED at 1.
Hunk #2 succeeded at 2415 (offset 20 lines).
Hunk #3 succeeded at 6699 (offset 277 lines).
1 out of 3 hunks FAILED -- saving rejects to file runtime/doc/eval.txt.rej
patching file runtime/doc/map.txt
can't find file to patch at input line 53
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/tags b/runtime/doc/tags
|index 9a23ce4..ae7e22f 100644
|--- a/runtime/doc/tags
|+++ b/runtime/doc/tags
--------------------------
File to patch: 
Skip this patch? [y] y
Skipping patch.
2 out of 2 hunks ignored
can't find file to patch at input line 73
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/todo.txt b/runtime/doc/todo.txt
|index 04f9a44..d114d36 100644
|--- a/runtime/doc/todo.txt
|+++ b/runtime/doc/todo.txt
--------------------------
File to patch: 
Skip this patch? [y] y
Skipping patch.
10 out of 10 hunks ignored
patching file runtime/indent/vim.vim
```
## Rejected hunks
### runtime/doc/eval.txt

``` diff
@@ -1,4 +1,4 @@
-*eval.txt* For Vim version 7.4.  Last change: 2014 Nov 27
+*eval.txt* For Vim version 7.4.  Last change: 2014 Dec 07


          VIM REFERENCE MANUAL    by Bram Moolenaar
```

Diagnosis: There have been more recent changes.
Solution: Discard this hunk.
