### PR TITLE
[RFC] ensure that static jemalloc library is used

### DIFF
--- a/third-party/cmake/BuildJeMalloc.cmake
+++ b/third-party/cmake/BuildJeMalloc.cmake
@@ -19,6 +19,6 @@ ExternalProject_Add(jemalloc
   CONFIGURE_COMMAND ${DEPS_BUILD_DIR}/src/jemalloc/configure
      CC=${DEPS_C_COMPILER} --prefix=${DEPS_INSTALL_DIR}
   BUILD_COMMAND ""
-  INSTALL_COMMAND ${MAKE_PRG} install_include install_lib)
+  INSTALL_COMMAND ${MAKE_PRG} install_include install_lib_static)
 
 list(APPEND THIRD_PARTY_DEPS jemalloc)


### PR DESCRIPTION
Otherwise the dynamic library is built also and find_library will
prefer that over the static one.
That results in linking against the dynamic library which will not be
found when using neovim after installing it.
