### PR TITLE
vim-patch:e271909

### DIFF
--- a/runtime/syntax/amiga.vim
+++ b/runtime/syntax/amiga.vim
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:	AmigaDos
-" Maintainer:	Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Sep 11, 2006
-" Version:     6
-" URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Last Change:	Oct 23, 2014
+" Version:     7
+" URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_AMIGA
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded

--- a/runtime/syntax/csh.vim
+++ b/runtime/syntax/csh.vim
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:	C-shell (csh)
-" Maintainer:	Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Version:	10
-" Last Change:	Sep 11, 2006
-" URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Version:	11
+" Last Change:	Oct 23, 2014
+" URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_CSH
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded

--- a/runtime/syntax/dcl.vim
+++ b/runtime/syntax/dcl.vim
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:	DCL (Digital Command Language - vms)
-" Maintainer:	Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Sep 11, 2006
-" Version:	6
-" URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Last Change:	Oct 23, 2014
+" Version:	7
+" URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_DCL
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded

--- a/runtime/syntax/elmfilt.vim
+++ b/runtime/syntax/elmfilt.vim
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:	Elm Filter rules
-" Maintainer:	Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Sep 11, 2006
-" Version:	5
-" URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Last Change:	Oct 23, 2014
+" Version:	6
+" URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_ELMFILT
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded

--- a/runtime/syntax/exports.vim
+++ b/runtime/syntax/exports.vim
@@ -1,10 +1,10 @@
 " Vim syntax file
 " Language:	exports
-" Maintainer:	Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Sep 06, 2005
-" Version:	4
+" Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Last Change:	Oct 23, 2014
+" Version:	5
 " Notes:		This file includes both SysV and BSD 'isms
-" URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_EXPORTS
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded

--- a/runtime/syntax/lisp.vim
+++ b/runtime/syntax/lisp.vim
@@ -1,28 +1,23 @@
 " Vim syntax file
 " Language:    Lisp
-" Maintainer:  Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change: Nov 16, 2010
-" Version:     22
-" URL:	       http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Maintainer:  Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Last Change: Oct 06, 2014
+" Version:     23
+" URL:	       http://www.drchip.org/astronaut/vim/index.html#SYNTAX_LISP
 "
-"  Thanks to F Xavier Noria for a list of 978 Common Lisp symbols
-"  taken from the HyperSpec
+"  Thanks to F Xavier Noria for a list of 978 Common Lisp symbols taken from HyperSpec
 "  Clisp additions courtesy of http://clisp.cvs.sourceforge.net/*checkout*/clisp/clisp/emacs/lisp.vim
 
 " ---------------------------------------------------------------------
 "  Load Once: {{{1
-" For vim-version 5.x: Clear all syntax items
-" For vim-version 6.x: Quit when a syntax file was already loaded
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
-  finish
+if exists("b:current_syntax")
+ finish
 endif
 
-if version >= 600
- setlocal iskeyword=38,42,43,45,47-58,60-62,64-90,97-122,_
+if exists("g:lisp_isk")
+ exe "setl isk=".g:lisp_isk
 else
- set iskeyword=38,42,43,45,47-58,60-62,64-90,97-122,_
+ setl isk=38,42,43,45,47-58,60-62,64-90,97-122,_
 endif
 
 if exists("g:lispsyntax_ignorecase") || exists("g:lispsyntax_clisp")

--- a/runtime/syntax/maple.vim
+++ b/runtime/syntax/maple.vim
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:	Maple V (based on release 4)
-" Maintainer:	Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Jan 05, 2010
-" Version:	10
-" URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Last Change:	Oct 23, 2014
+" Version:	11
+" URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_MAPLE
 "
 " Package Function Selection: {{{1
 " Because there are a lot of packages, and because of the potential for namespace

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -2,10 +2,10 @@
 " Language:		shell (sh) Korn shell (ksh) bash (sh)
 " Maintainer:		Charles E. Campbell  <NdrOchipS@PcampbellAfamily.Mbiz>
 " Previous Maintainer:	Lennart Schultz <Lennart.Schultz@ecmwf.int>
-" Last Change:		Mar 20, 2014
-" Version:		132
-" URL:		http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
-" For options and settings, please use:	:help ft-sh-syntax
+" Last Change:		Jan 08, 2015
+" Version:		134
+" URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
+" For options and settings, please use:      :help ft-sh-syntax
 " This file includes many ideas from ?ric Brunet (eric.brunet@ens.fr)
 
 " For version 5.x: Clear all syntax items {{{1
@@ -17,7 +17,7 @@ elseif exists("b:current_syntax")
 endif
 
 " AFAICT "." should be considered part of the iskeyword.  Using iskeywords in
-" syntax is dicey, so the following code permits the user to
+" syntax is dicey, so the following code permits the user to prevent/override
 "  g:sh_isk set to a string	: specify iskeyword.
 "  g:sh_noisk exists	: don't change iskeyword
 "  g:sh_noisk does not exist	: (default) append "." to iskeyword
@@ -104,7 +104,7 @@ syn cluster shErrorList	contains=shDoError,shIfError,shInError,shCaseError,shEsa
 if exists("b:is_kornshell")
  syn cluster ErrorList add=shDTestError
 endif
-syn cluster shArithParenList	contains=shArithmetic,shCaseEsac,shDeref,shDerefSimple,shEcho,shEscape,shNumber,shOperator,shPosnParm,shExSingleQuote,shExDoubleQuote,shRedir,shSingleQuote,shDoubleQuote,shStatement,shVariable,shAlias,shTest,shCtrlSeq,shSpecial,shParen,bashSpecialVariables,bashStatement
+syn cluster shArithParenList	contains=shArithmetic,shCaseEsac,shComment,shDeref,shDerefSimple,shDo,shEcho,shEscape,shIf,shFor,shNumber,shOperator,shPosnParm,shExSingleQuote,shExDoubleQuote,shRedir,shSingleQuote,shDoubleQuote,shStatement,shVariable,shAlias,shTest,shCtrlSeq,shSpecial,shParen,bashSpecialVariables,bashStatement
 syn cluster shArithList	contains=@shArithParenList,shParenError
 syn cluster shCaseEsacList	contains=shCaseStart,shCase,shCaseBar,shCaseIn,shComment,shDeref,shDerefSimple,shCaseCommandSub,shCaseExSingleQuote,shCaseSingleQuote,shCaseDoubleQuote,shCtrlSeq,@shErrorList,shStringSpecial,shCaseRange
 syn cluster shCaseList	contains=@shCommandSubList,shCaseEsac,shColon,shCommandSub,shComment,shDo,shEcho,shExpr,shFor,shHereDoc,shIf,shRedir,shSetList,shSource,shStatement,shVariable,shCtrlSeq
@@ -127,7 +127,7 @@ syn cluster shHereList	contains=shBeginHere,shHerePayload
 syn cluster shHereListDQ	contains=shBeginHere,@shDblQuoteList,shHerePayload
 syn cluster shIdList	contains=shCommandSub,shWrapLineOperator,shSetOption,shDeref,shDerefSimple,shRedir,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shExpr,shCtrlSeq,shStringSpecial,shAtExpr
 syn cluster shIfList	contains=@shLoopList,shDblBrace,shDblParen,shFunctionKey,shFunctionOne,shFunctionTwo
-syn cluster shLoopList	contains=@shCaseList,shTestOpr,shExpr,shDblBrace,shConditional,shCaseEsac,shTest,@shErrorList,shSet,shOption
+syn cluster shLoopList	contains=@shCaseList,shIf,shFor,shForPP,shTestOpr,shExpr,shDblBrace,shConditional,shCaseEsac,shTest,@shErrorList,shSet,shOption
 syn cluster shSubShList	contains=@shCommandSubList,shCaseEsac,shColon,shCommandSub,shComment,shDo,shEcho,shExpr,shFor,shIf,shRedir,shSetList,shSource,shStatement,shVariable,shCtrlSeq,shOperator
 syn cluster shTestList	contains=shCharClass,shComment,shCommandSub,shDeref,shDerefSimple,shExDoubleQuote,shDoubleQuote,shExpr,shNumber,shOperator,shExSingleQuote,shSingleQuote,shTestOpr,shTest,shCtrlSeq
 " Echo: {{{1
@@ -151,18 +151,18 @@ endif
 " Error Codes: {{{1
 " ============
 if !exists("g:sh_no_error")
- syn match	shDoError	"\<done\>"
- syn match	shIfError	"\<fi\>"
- syn match	shInError	"\<in\>"
- syn match	shCaseError	";;"
- syn match	shEsacError	"\<esac\>"
- syn match	shCurlyError	"}"
- syn match	shParenError	")"
- syn match	shOK	'\.\(done\|fi\|in\|esac\)'
+ syn match   shDoError "\<done\>"
+ syn match   shIfError "\<fi\>"
+ syn match   shInError "\<in\>"
+ syn match   shCaseError ";;"
+ syn match   shEsacError "\<esac\>"
+ syn match   shCurlyError "}"
+ syn match   shParenError ")"
+ syn match   shOK	'\.\(done\|fi\|in\|esac\)'
  if exists("b:is_kornshell")
-   syn match	shDTestError	"]]"
+  syn match     shDTestError "]]"
  endif
- syn match	shTestError	"]"
+ syn match     shTestError "]"
 endif
 
 " Options: {{{1
@@ -197,9 +197,10 @@ syn region shTest	transparent matchgroup=shStatement start="\<test\s" skip=+\\\\
 syn match  shTestOpr	contained	"<=\|>=\|!=\|==\|-.\>\|-\(nt\|ot\|ef\|eq\|ne\|lt\|le\|gt\|ge\)\>\|[!<>]"
 syn match  shTestOpr	contained	'=' skipwhite nextgroup=shTestDoubleQuote,shTestSingleQuote,shTestPattern
 syn match  shTestPattern	contained	'\w\+'
-syn match  shTestDoubleQuote	contained	'\%(\%(\\\\\)*\\\)\@<!"[^"]*"'
+syn region shTestDoubleQuote	contained	start='"' skip='\\"' end='"' contains=shBQpairs
 syn match  shTestSingleQuote	contained	'\\.'
 syn match  shTestSingleQuote	contained	"'[^']*'"
+syn match  shBQpairs	contained	'\\\\'
 if exists("b:is_kornshell") || exists("b:is_bash")
  syn region  shDblBrace matchgroup=Delimiter start="\[\[" skip=+\\\\\|\\$+ end="\]\]"	contains=@shTestList
  syn region  shDblParen matchgroup=Delimiter start="((" skip=+\\\\\|\\$+ end="))"	contains=@shTestList
@@ -216,11 +217,11 @@ if s:sh_fold_ifdofor
  syn region shIf	fold transparent matchgroup=shConditional start="\<if\_s" matchgroup=shConditional skip=+-fi\>+ end="\<;\_s*then\>" end="\<fi\>"   contains=@shIfList
  syn region shFor	fold matchgroup=shLoop start="\<for\ze\_s\s*\%(((\)\@!" end="\<in\_s" end="\<do\>"me=e-2	contains=@shLoopList,shDblParen skipwhite nextgroup=shCurlyIn
 else
- syn region shDo	transparent matchgroup=shConditional start="\<do\>" matchgroup=shConditional end="\<done\>" contains=@shLoopList
+ syn region shDo	transparent matchgroup=shConditional start="\<do\>" matchgroup=shConditional end="\<done\>"	contains=@shLoopList
  syn region shIf	transparent matchgroup=shConditional start="\<if\_s" matchgroup=shConditional skip=+-fi\>+ end="\<;\_s*then\>" end="\<fi\>"   contains=@shIfList
  syn region shFor	matchgroup=shLoop start="\<for\ze\_s\s*\%(((\)\@!" end="\<in\>" end="\<do\>"me=e-2	contains=@shLoopList,shDblParen skipwhite nextgroup=shCurlyIn
- syn match  shForPP	'\<for\>\ze\_s*(('
 endif
+syn region shForPP	matchgroup=shLoop start='\<for\>\_s*((' end='))' contains=shTestOpr
 if exists("b:is_kornshell") || exists("b:is_bash")
  syn cluster shCaseList	add=shRepeat
  syn cluster shFunctionList	add=shRepeat
@@ -280,7 +281,7 @@ if exists("b:is_kornshell") || exists("b:is_bash")
 elseif !exists("g:sh_no_error")
  syn region shCommandSub matchgroup=Error start="\$(" end=")" contains=@shCommandSubList
 endif
-syn region shCmdParenRegion matchgroup=shCmdSubRegion start="(" skip='\\\\\|\\.' end=")"	contains=@shCommandSubList
+syn region shCmdParenRegion matchgroup=shCmdSubRegion start="(\ze[^(]" skip='\\\\\|\\.' end=")" contains=@shCommandSubList
 
 if exists("b:is_bash")
  syn cluster shCommandSubList add=bashSpecialVariables,bashStatement
@@ -321,12 +322,12 @@ elseif !exists("g:sh_no_error")
 endif
 syn region  shSingleQuote	matchgroup=shQuote start=+'+ end=+'+		contains=@Spell
 syn region  shDoubleQuote	matchgroup=shQuote start=+\%(\%(\\\\\)*\\\)\@<!"+ skip=+\\"+ end=+"+	contains=@shDblQuoteList,shStringSpecial,@Spell
+"syn region  shDoubleQuote	matchgroup=shQuote start=+"+ skip=+\\"+ end=+"+	contains=@shDblQuoteList,shStringSpecial,@Spell
 syn match   shStringSpecial	"[^[:print:] \t]"	contained
 syn match   shStringSpecial	"\%(\\\\\)*\\[\\"'`$()#]"
-"syn match   shSpecial	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]"	nextgroup=shMoreSpecial,shComment
-syn match   shSpecial	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]"	nextgroup=shMoreSpecial
-syn match   shSpecial	"^\%(\\\\\)*\\[\\"'`$()#]"		nextgroup=shComment
-syn match   shMoreSpecial	"\%(\\\\\)*\\[\\"'`$()#]" 	contained	nextgroup=shMoreSpecial
+syn match   shSpecial	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]" nextgroup=shMoreSpecial,shComment
+syn match   shSpecial	"^\%(\\\\\)*\\[\\"'`$()#]"	nextgroup=shComment
+syn match   shMoreSpecial	"\%(\\\\\)*\\[\\"'`$()#]" nextgroup=shMoreSpecial contained
 
 " Comments: {{{1
 "==========
@@ -363,9 +364,9 @@ elseif s:sh_fold_heredoc
  syn region shHereDoc matchgroup=shRedir19 fold start="<<\\\z([^ \t|]*\)"		matchgroup=shRedir19 end="^\z1\s*$"
 
 else
- syn region shHereDoc matchgroup=shRedir20 start="<<\s*\\\=\z([^ \t|]*\)"		matchgroup=shRedir20 end="^\z1\s*$"	contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shRedir20 start="<<\s*\\\=\z([^ \t|]*\)"		matchgroup=shRedir20 end="^\z1\s*$"    contains=@shDblQuoteList
  syn region shHereDoc matchgroup=shRedir21 start="<<\s*\"\z([^ \t|]*\)\""		matchgroup=shRedir21 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir22 start="<<-\s*\z([^ \t|]*\)"		matchgroup=shRedir22 end="^\s*\z1\s*$"	contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shRedir22 start="<<-\s*\z([^ \t|]*\)"		matchgroup=shRedir22 end="^\s*\z1\s*$" contains=@shDblQuoteList
  syn region shHereDoc matchgroup=shRedir23 start="<<-\s*'\z([^ \t|]*\)'"		matchgroup=shRedir23 end="^\s*\z1\s*$"
  syn region shHereDoc matchgroup=shRedir24 start="<<\s*'\z([^ \t|]*\)'"		matchgroup=shRedir24 end="^\z1\s*$"
  syn region shHereDoc matchgroup=shRedir25 start="<<-\s*\"\z([^ \t|]*\)\""		matchgroup=shRedir25 end="^\s*\z1\s*$"
@@ -450,21 +451,21 @@ syn match  shDerefSpecial	contained	"\({[#!]\)\@<=[[:alnum:]*@_]\+"	nextgroup=@s
 syn match  shDerefVar	contained	"{\@<=\k\+"		nextgroup=@shDerefVarList
 
 " sh ksh bash : ${var[... ]...}  array reference: {{{1
-syn region  shDerefVarArray	contained	matchgroup=shDeref start="\[" end="]"	contains=@shCommandSubList nextgroup=shDerefOp,shDerefOpError
+syn region  shDerefVarArray   contained	matchgroup=shDeref start="\[" end="]"	contains=@shCommandSubList nextgroup=shDerefOp,shDerefOpError
 
 " Special ${parameter OPERATOR word} handling: {{{1
-" sh ksh bash : ${parameter:-word}	word is default value
-" sh ksh bash : ${parameter:=word}	assign word as default value
-" sh ksh bash : ${parameter:?word}	display word if parameter is null
-" sh ksh bash : ${parameter:+word}	use word if parameter is not null, otherwise nothing
-"    ksh bash : ${parameter#pattern}	remove small left  pattern
-"    ksh bash : ${parameter##pattern}	remove large left  pattern
-"    ksh bash : ${parameter%pattern}	remove small right pattern
-"    ksh bash : ${parameter%%pattern}	remove large right pattern
-"        bash : ${parameter^pattern}	Case modification
-"        bash : ${parameter^^pattern}	Case modification
-"        bash : ${parameter,pattern}	Case modification
-"        bash : ${parameter,,pattern}	Case modification
+" sh ksh bash : ${parameter:-word}    word is default value
+" sh ksh bash : ${parameter:=word}    assign word as default value
+" sh ksh bash : ${parameter:?word}    display word if parameter is null
+" sh ksh bash : ${parameter:+word}    use word if parameter is not null, otherwise nothing
+"    ksh bash : ${parameter#pattern}  remove small left  pattern
+"    ksh bash : ${parameter##pattern} remove large left  pattern
+"    ksh bash : ${parameter%pattern}  remove small right pattern
+"    ksh bash : ${parameter%%pattern} remove large right pattern
+"        bash : ${parameter^pattern}  Case modification
+"        bash : ${parameter^^pattern} Case modification
+"        bash : ${parameter,pattern}  Case modification
+"        bash : ${parameter,,pattern} Case modification
 syn cluster shDerefPatternList	contains=shDerefPattern,shDerefString
 if !exists("g:sh_no_error")
  syn match shDerefOpError	contained	":[[:punct:]]"
@@ -576,7 +577,7 @@ hi def link shDoubleQuote	shString
 hi def link shEcho	shString
 hi def link shEchoDelim	shOperator
 hi def link shEchoQuote	shString
-hi def link shForPP	shLoop
+"hi def link shForPP	shLoop
 hi def link shEmbeddedEcho	shString
 hi def link shEscape	shCommandSub
 hi def link shExDoubleQuote	shDoubleQuote
@@ -598,12 +599,12 @@ hi def link shSetOption	shOption
 hi def link shSingleQuote	shString
 hi def link shSource	shOperator
 hi def link shStringSpecial	shSpecial
-hi def link shStringSpecial	Unique
 hi def link shSubShRegion	shOperator
 hi def link shTestOpr	shConditional
 hi def link shTestPattern	shString
 hi def link shTestDoubleQuote	shString
 hi def link shTestSingleQuote	shString
+hi def link shBQpairs	shString
 hi def link shVariable	shSetList
 hi def link shWrapLineOperator	shOperator
 

--- a/runtime/syntax/tags.vim
+++ b/runtime/syntax/tags.vim
@@ -1,8 +1,8 @@
 " Language:		tags
-" Maintainer:	Dr. Charles E. Campbell, Jr.  <NdrOchip@PcampbellAfamily.Mbiz>
-" Last Change:	Sep 06, 2005
-" Version:		3
-" URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Maintainer:	Charles E. Campbell  <NdrOchip@PcampbellAfamily.Mbiz>
+" Last Change:	Oct 23, 2014
+" Version:		4
+" URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_TAGS
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded

--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	TeX
 " Maintainer:	Charles E. Campbell <NdrchipO@ScampbellPfamily.AbizM>
-" Last Change:	Sep 09, 2014
-" Version:	82
+" Last Change:	Nov 18, 2014
+" Version:	83
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_TEX
 "
 " Notes: {{{1
@@ -64,6 +64,8 @@ if version >= 508 || !exists("did_tex_syntax_inits")
 endif
 if exists("g:tex_no_error") && g:tex_no_error
  let s:tex_no_error= 1
+else
+ let s:tex_no_error= 0
 endif
 
 " by default, enable all region-based highlighting
@@ -76,7 +78,6 @@ if exists("g:tex_fast")
  else
   let s:tex_fast= g:tex_fast
  endif
- let s:tex_no_error= 1
 else
  let s:tex_fast= "bcmMprsSvV"
 endif
@@ -141,7 +142,7 @@ endif
 " Clusters: {{{1
 " --------
 syn cluster texCmdGroup		contains=texCmdBody,texComment,texDefParm,texDelimiter,texDocType,texInput,texLength,texLigature,texMathDelim,texMathOper,texNewCmd,texNewEnv,texRefZone,texSection,texBeginEnd,texBeginEndName,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle
-if !exists("s:tex_no_error")
+if !exists("s:tex_no_error") || !s:tex_no_error
  syn cluster texCmdGroup	add=texMathError
 endif
 syn cluster texEnvGroup		contains=texMatcher,texMathDelim,texSpecialChar,texStatement
@@ -157,13 +158,13 @@ else
 endif
 syn cluster texPreambleMatchGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texMathZoneZ
 syn cluster texRefGroup		contains=texMatcher,texComment,texDelimiter
-if !exists("tex_no_math")
+if !exists("g:tex_no_math")
  syn cluster texMathZones	contains=texMathZoneV,texMathZoneW,texMathZoneX,texMathZoneY,texMathZoneZ
  syn cluster texMatchGroup	add=@texMathZones
  syn cluster texMathDelimGroup	contains=texMathDelimBad,texMathDelimKey,texMathDelimSet1,texMathDelimSet2
  syn cluster texMathMatchGroup	contains=@texMathZones,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMathDelim,texMathMatcher,texMathOper,texNewCmd,texNewEnv,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone
  syn cluster texMathZoneGroup	contains=texComment,texDelimiter,texLength,texMathDelim,texMathMatcher,texMathOper,texMathSymbol,texMathText,texRefZone,texSpecialChar,texStatement,texTypeSize,texTypeStyle
- if !exists("s:tex_no_error")
+ if !exists("s:tex_no_error") || !s:tex_no_error
   syn cluster texMathMatchGroup	add=texMathError
   syn cluster texMathZoneGroup	add=texMathError
  endif
@@ -185,7 +186,7 @@ endif
 
 " Try to flag {} and () mismatches: {{{1
 if s:tex_fast =~ 'm'
-  if !exists("s:tex_no_error")
+  if !exists("s:tex_no_error") || !s:tex_no_error
    syn region texMatcher		matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"		contains=@texMatchGroup,texError
    syn region texMatcher		matchgroup=Delimiter start="\["				end="]"		contains=@texMatchGroup,texError,@NoSpell
   else
@@ -198,12 +199,12 @@ if s:tex_fast =~ 'm'
    syn region texParen		start="("						end=")"		contains=@texMatchGroup
   endif
 endif
-if !exists("s:tex_no_error")
+if !exists("s:tex_no_error") || !s:tex_no_error
  syn match  texError		"[}\])]"
 endif
 if s:tex_fast =~ 'M'
-  if !exists("tex_no_math")
-   if !exists("s:tex_no_error")
+  if !exists("g:tex_no_math")
+   if !exists("s:tex_no_error") || !s:tex_no_error
     syn match  texMathError	"}"	contained
    endif
    syn region texMathMatcher	matchgroup=Delimiter	start="{"          skip="\\\\\|\\}"     end="}" end="%stopzone\>"	contained contains=@texMathMatchGroup
@@ -217,7 +218,7 @@ if exists("g:tex_tex") || b:tex_stylish
   syn match texStatement	"\\[a-zA-Z@]\+"
 else
   syn match texStatement	"\\\a\+"
-  if !exists("s:tex_no_error")
+  if !exists("s:tex_no_error") || !s:tex_no_error
    syn match texError		"\\\a*@[a-zA-Z@]*"
   endif
 endif
@@ -358,6 +359,7 @@ if s:tex_fast =~ 'p'
     syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	contains=@texFoldGroup,@Spell
     syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													contains=@texFoldGroup,@Spell
     syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											contains=@texFoldGroup,@Spell
+    syn region texSpellZone		matchgroup=texSpellZone start="%spellzone_start"	 end="%spellzone_end"												contains=@Spell
    endif
   else
    if g:tex_fold_enabled && has("folding")
@@ -397,14 +399,14 @@ if s:tex_fast =~ 'b'
 endif
 
 " Bad Math (mismatched): {{{1
-if !exists("g:tex_no_math") && !exists("s:tex_no_error")
+if !exists("g:tex_no_math") && (!exists("s:tex_no_error") || !s:tex_no_error)
  syn match texBadMath		"\\end\s*{\s*\(array\|gathered\|bBpvV]matrix\|split\|subequations\|smallmatrix\|xxalignat\)\s*}"
  syn match texBadMath		"\\end\s*{\s*\(align\|alignat\|displaymath\|displaymath\|eqnarray\|equation\|flalign\|gather\|math\|multline\|xalignat\)\*\=\s*}"
  syn match texBadMath		"\\[\])]"
 endif
 
 " Math Zones: {{{1
-if !exists("tex_no_math")
+if !exists("g:tex_no_math")
  " TexNewMathZone: function creates a mathzone with the given suffix and mathzone name. {{{2
  "                 Starred forms are created if starform is true.  Starred
  "                 forms have syntax group and synchronization groups with a
@@ -541,7 +543,7 @@ else
   syn match texSpecialChar	"\\[SP@]\A"me=e-1
 endif
 syn match texSpecialChar	"\\\\"
-if !exists("tex_no_math")
+if !exists("g:tex_no_math")
  syn match texOnlyMath		"[_^]"
 endif
 syn match texSpecialChar	"\^\^[0-9a-f]\{2}\|\^\^\S"
@@ -574,12 +576,14 @@ else
    syn match  texComment	"%.*$"			contains=@texCommentGroup
    if s:tex_fast =~ 'c'
     syn region texComment	start="^\zs\s*%.*\_s*%"	skip="^\s*%"	end='^\ze\s*[^%]' fold
-    syn region texNoSpell	contained fold		matchgroup=texComment start="%\s*nospell\s*{"	end="%\s*nospell\s*}"	contains=@texFoldGroup,@NoSpell
+    syn region texNoSpell	contained	matchgroup=texComment start="%\s*nospell\s*{"		end="%\s*nospell\s*}"	fold contains=@texFoldGroup,@NoSpell
+    syn region texSpellZone		 	matchgroup=texComment start="%\s*spellzone_start"	end="%\s*spellzone_end"	fold contains=@Spell,@texFoldGroup
    endif
   else
-   syn match texComment		"%.*$"			contains=@texCommentGroup
+   syn match texComment		"%.*$"		contains=@texCommentGroup
    if s:tex_fast =~ 'c'
-    syn region texNoSpell	contained		matchgroup=texComment start="%\s*nospell\s*{"	end="%\s*nospell\s*}"	contains=@texFoldGroup,@NoSpell
+    syn region texNoSpell	contained	matchgroup=texComment start="%\s*nospell\s*{"		end="%\s*nospell\s*}"	contains=@texFoldGroup,@NoSpell
+    syn region  texSpellZone		 	matchgroup=texComment start="%\s*spellzone_start"	end="%\s*spellzone_end"	contains=@Spell,@texFoldGroup
    endif
   endif
 endif
@@ -663,7 +667,7 @@ syn match  texLength		"\<\d\+\([.,]\d\+\)\=\s*\(true\)\=\s*\(bp\|cc\|cm\|dd\|em\
 syn match texString		"\(``\|''\|,,\)"
 
 " makeatletter -- makeatother sections
-if !exists("s:tex_no_error")
+if !exists("s:tex_no_error") || !s:tex_no_error
  if s:tex_fast =~ 'S'
   syn region texStyle			matchgroup=texStatement start='\\makeatletter' end='\\makeatother'	contains=@texStyleGroup contained
  endif
@@ -794,8 +798,8 @@ if has("conceal") && &enc == 'utf-8'
     \ ['left('		, '('],
     \ ['left\['		, '['],
     \ ['left\\{'	, '{'],
-    \ ['leftarrow'	, '⟵'],
-    \ ['Leftarrow'	, '⟸'],
+    \ ['leftarrow'	, '←'],
+    \ ['Leftarrow'	, '⇐'],
     \ ['leftarrowtail'	, '↢'],
     \ ['leftharpoondown', '↽'],
     \ ['leftharpoonup'	, '↼'],
@@ -881,8 +885,8 @@ if has("conceal") && &enc == 'utf-8'
     \ ['right)'		, ')'],
     \ ['right]'		, ']'],
     \ ['right\\}'	, '}'],
-    \ ['rightarrow'	, '⟶'],
-    \ ['Rightarrow'	, '⟹'],
+    \ ['rightarrow'	, '→'],
+    \ ['Rightarrow'	, '⇒'],
     \ ['rightarrowtail'	, '↣'],
     \ ['rightleftharpoons', '⇌'],
     \ ['rightsquigarrow', '↝'],
@@ -995,6 +999,7 @@ if has("conceal") && &enc == 'utf-8'
   syn match texMathSymbol '\\hat{W}' contained conceal cchar=Ŵ
   syn match texMathSymbol '\\hat{y}' contained conceal cchar=ŷ
   syn match texMathSymbol '\\hat{Y}' contained conceal cchar=Ŷ
+"  syn match texMathSymbol '\\bar{a}' contained conceal cchar=a̅
  endif
 
  " Greek {{{2
@@ -1011,7 +1016,7 @@ if has("conceal") && &enc == 'utf-8'
   call s:Greek('texGreek','\\zeta\>'		,'ζ')
   call s:Greek('texGreek','\\eta\>'		,'η')
   call s:Greek('texGreek','\\theta\>'		,'θ')
-  call s:Greek('texGreek','\\vartheta\>'		,'ϑ')
+  call s:Greek('texGreek','\\vartheta\>'	,'ϑ')
   call s:Greek('texGreek','\\kappa\>'		,'κ')
   call s:Greek('texGreek','\\lambda\>'		,'λ')
   call s:Greek('texGreek','\\mu\>'		,'μ')
@@ -1022,11 +1027,11 @@ if has("conceal") && &enc == 'utf-8'
   call s:Greek('texGreek','\\rho\>'		,'ρ')
   call s:Greek('texGreek','\\varrho\>'		,'ϱ')
   call s:Greek('texGreek','\\sigma\>'		,'σ')
-  call s:Greek('texGreek','\\varsigma\>'		,'ς')
+  call s:Greek('texGreek','\\varsigma\>'	,'ς')
   call s:Greek('texGreek','\\tau\>'		,'τ')
   call s:Greek('texGreek','\\upsilon\>'		,'υ')
-  call s:Greek('texGreek','\\phi\>'		,'φ')
-  call s:Greek('texGreek','\\varphi\>'		,'ϕ')
+  call s:Greek('texGreek','\\phi\>'		,'ϕ')
+  call s:Greek('texGreek','\\varphi\>'		,'φ')
   call s:Greek('texGreek','\\chi\>'		,'χ')
   call s:Greek('texGreek','\\psi\>'		,'ψ')
   call s:Greek('texGreek','\\omega\>'		,'ω')
@@ -1245,7 +1250,7 @@ syn  sync match texSyncStop			groupthere NONE		"%stopzone\>"
 " (one can't tell if a "$$" starts or stops a math zone by itself)
 " The following grouptheres coupled with minlines above
 " help improve the odds of good syncing.
-if !exists("tex_no_math")
+if !exists("g:tex_no_math")
  syn sync match texSyncMathZoneA		groupthere NONE		"\\end{abstract}"
  syn sync match texSyncMathZoneA		groupthere NONE		"\\end{center}"
  syn sync match texSyncMathZoneA		groupthere NONE		"\\end{description}"
@@ -1285,7 +1290,7 @@ if did_tex_syntax_inits == 1
   HiLink texInputFileOpt	texCmdArgs
   HiLink texInputCurlies	texDelimiter
   HiLink texLigature		texSpecialChar
-  if !exists("tex_no_math")
+  if !exists("g:tex_no_math")
    HiLink texMathDelimSet1	texMathDelim
    HiLink texMathDelimSet2	texMathDelim
    HiLink texMathDelimKey	texMathDelim

--- a/runtime/syntax/xmath.vim
+++ b/runtime/syntax/xmath.vim
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:	xmath (a simulation tool)
-" Maintainer:	Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
+" Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
 " Last Change:	Sep 11, 2006
-" Version:	6
-" URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Version:	7
+" URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_XMATH
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded

--- a/runtime/syntax/xxd.vim
+++ b/runtime/syntax/xxd.vim
@@ -1,10 +1,10 @@
 " Vim syntax file
 " Language:		bin using xxd
-" Maintainer:	Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Sep 06, 2005
-" Version:		7
+" Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Last Change:	Oct 23, 2014
+" Version:		8
 " Notes:		use :help xxd   to see how to invoke it
-" URL:	http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_XXD
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded

--- a/runtime/syntax/yacc.vim
+++ b/runtime/syntax/yacc.vim
@@ -42,7 +42,7 @@ exe "syn include @yaccCode ".s:Cpath
 " ---------------------------------------------------------------------
 "  Yacc Clusters: {{{1
 syn cluster yaccInitCluster	contains=yaccKey,yaccKeyActn,yaccBrkt,yaccType,yaccString,yaccUnionStart,yaccHeader2,yaccComment,yaccDefines,yaccParseParam,yaccParseOption
-syn cluster yaccRulesCluster	contains=yaccNonterminal,yaccString,yaccComment
+syn cluster yaccRulesCluster	contains=yaccNonterminal,yaccString
 
 " ---------------------------------------------------------------------
 "  Yacc Sections: {{{1


### PR DESCRIPTION
```
Updated syntax files.
```

https://github.com/vim/vim/commit/e2719096250a19ecdd9a35d13702879f163d2a50

For an explanation why this patch is not reported as missing by `vim-patch.sh` see #3964.

All changes to `runtime/syntax/vim.vim` are ignored because it is in part auto-generated and has been updated to a more recent version separately (fb0ebb2a3a220a2e744efabed82beb08d88e158d).

Output of `patch -p1 < vim-e271909.diff`:

```
can't find file to patch at input line 11
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|commit e2719096250a19ecdd9a35d13702879f163d2a50
|Author: Bram Moolenaar <Bram@vim.org>
|Date:   Sat Jan 10 15:09:25 2015 +0100
|
|    Updated syntax files.
|
|diff --git a/runtime/doc/todo.txt b/runtime/doc/todo.txt
|index f0d6668..fe4b5ec 100644
|--- a/runtime/doc/todo.txt
|+++ b/runtime/doc/todo.txt
--------------------------
File to patch: 
Skip this patch? [y] y
Skipping patch.
12 out of 12 hunks ignored
patching file runtime/syntax/amiga.vim
patching file runtime/syntax/csh.vim
patching file runtime/syntax/dcl.vim
patching file runtime/syntax/elmfilt.vim
patching file runtime/syntax/exports.vim
patching file runtime/syntax/lisp.vim
patching file runtime/syntax/maple.vim
patching file runtime/syntax/rpcgen.vim
Hunk #1 FAILED at 1.
1 out of 1 hunk FAILED -- saving rejects to file runtime/syntax/rpcgen.vim.rej
patching file runtime/syntax/sh.vim
patching file runtime/syntax/sm.vim
Hunk #1 FAILED at 1.
1 out of 1 hunk FAILED -- saving rejects to file runtime/syntax/sm.vim.rej
patching file runtime/syntax/tags.vim
patching file runtime/syntax/tex.vim
patching file runtime/syntax/vim.vim
Hunk #1 FAILED at 1.
Hunk #2 FAILED at 14.
Hunk #3 FAILED at 62.
Hunk #4 FAILED at 73.
Hunk #5 FAILED at 96.
Hunk #6 FAILED at 134.
Hunk #7 FAILED at 161.
Hunk #8 FAILED at 169.
Hunk #9 succeeded at 182 (offset -21 lines).
Hunk #10 succeeded at 211 (offset -21 lines).
Hunk #11 succeeded at 224 (offset -21 lines).
Hunk #12 FAILED at 289.
Hunk #13 FAILED at 326.
Hunk #14 succeeded at 329 (offset -19 lines).
Hunk #15 FAILED at 360.
Hunk #16 FAILED at 407.
Hunk #17 FAILED at 419.
Hunk #18 FAILED at 441.
Hunk #19 FAILED at 467.
Hunk #20 FAILED at 510.
Hunk #21 succeeded at 521 (offset -19 lines).
Hunk #22 succeeded at 539 with fuzz 2 (offset -24 lines).
Hunk #23 succeeded at 549 with fuzz 2 (offset -36 lines).
Hunk #24 succeeded at 559 with fuzz 2 (offset -48 lines).
Hunk #25 FAILED at 628.
Hunk #26 succeeded at 603 with fuzz 2 (offset -59 lines).
Hunk #27 succeeded at 619 with fuzz 2 (offset -70 lines).
Hunk #28 succeeded at 643 (offset -84 lines).
Hunk #29 FAILED at 752.
Hunk #30 FAILED at 798.
19 out of 30 hunks FAILED -- saving rejects to file runtime/syntax/vim.vim.rej
patching file runtime/syntax/xmath.vim
patching file runtime/syntax/xxd.vim
patching file runtime/syntax/yacc.vim
Hunk #1 FAILED at 1.
1 out of 2 hunks FAILED -- saving rejects to file runtime/syntax/yacc.vim.rej
```
## Rejected Hunks
### runtime/syntax/rpcgen.vim.rej

``` diff
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:    rpcgen
-" Maintainer:  Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change: Sep 06, 2005
-" Version: 8
-" URL: http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Maintainer:  Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Last Change: Oct 23, 2014
+" Version: 9
+" URL: http://www.drchip.org/astronaut/vim/index.html#SYNTAX_RPCGEN

 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
```

Diagnosis: aa4cc17bb0819ae4b8461e8a2a6f2f78ed53c576 updated this file to version 10.
Solution: Discard this hunk.
### runtime/syntax/sm.vim

``` diff
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:    sendmail
-" Maintainer:  Dr. Charles E. Campbell, Jr. <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change: Sep 06, 2005
-" Version: 4
-" URL: http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
+" Maintainer:  Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
+" Last Change: Oct 23, 2014
+" Version: 5
+" URL: http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SM

 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
```

Diagnosis: aa4cc17bb0819ae4b8461e8a2a6f2f78ed53c576 updated this file to version 6.
Solution: Discard this hunk.
### runtime/syntax/yacc.vim.rej

``` diff
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:    Yacc
 " Maintainer:  Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change: Mar 20, 2014
+" Last Change: Nov 14, 2012
 " Version: 11
 " URL: http://mysite.verizon.net/astronaut/vim/index.html#vimlinks_syntax
 "
```

Diagnosis: aa4cc17bb0819ae4b8461e8a2a6f2f78ed53c576 updated this file to version 12.
Solution: Discard this hunk.
