### PR TITLE
[RFC] Windows: define MAXNAMLEN for Windows

### DIFF
--- a/src/nvim/os/os_defs.h
+++ b/src/nvim/os/os_defs.h
@@ -25,6 +25,10 @@
 # define MAXNAMLEN NAME_MAX         /* for Linux before .99p3 */
 #endif
 
+#if defined(_MAX_PATH) && !defined(MAXNAMLEN)
+# define MAXNAMLEN _MAX_PATH       /* for Windows */
+#endif
+
 // Default value.
 #ifndef MAXNAMLEN
 # define MAXNAMLEN 512


### PR DESCRIPTION
In equalsraf@53bbe24 from #810 `BASENAMELEN` was changed to use `_MAX_PATH - 5` on Windows.

Instead of doing that though we can leave `BASENAMELEN` alone and define `MAXNAMLEN` to  be `_MAX_PATH` on Windows since `BASENAMELEN` will always be `MAXNAMLEN - 5`.

For reference: https://msdn.microsoft.com/en-us/library/930f87yf.aspx

cc @equalsraf 
