### PR TITLE
[RFC] Remove references to GTK GUI support + some no-ops

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -832,13 +832,13 @@ This replaces each 'E' character with a euro sign.  Read more in |<Char->|.
 :promptf[ind] [string]
 			Put up a Search dialog.  When [string] is given, it is
 			used as the initial search string.
-			{only for Win32 and GTK GUI}
+			{only for Win32 GUI}
 
 						*:promptr* *:promptrepl*
 :promptr[epl] [string]
 			Put up a Search/Replace dialog.  When [string] is
 			given, it is used as the initial search string.
-			{only for Win32 and GTK GUI}
+			{only for Win32 GUI}
 
 
 4.4 Changing tabs					*change-tabs*
@@ -1170,18 +1170,6 @@ Use these registers for storing and retrieving the selected text for the GUI.
 See |quotestar| and |quoteplus|.  When the clipboard is not available or not
 working, the unnamed register is used instead.  For Unix systems and Mac OS X,
 see |nvim-clipboard|.
-
-						*quote_~* *quote~* *<Drop>*
-The read-only "~ register stores the dropped text from the last drag'n'drop
-operation.  When something has been dropped onto Vim, the "~ register is
-filled in and the <Drop> pseudo key is sent for notification.  You can remap
-this key if you want; the default action (for all modes) is to insert the
-contents of the "~ register at the cursor position.
-{only available when compiled with the |+dnd| feature, currently only with the
-GTK GUI}
-
-Note: The "~ register is only used when dropping plain text onto Vim.
-Drag'n'drop of URI lists is handled internally.
 
 9. Black hole register "_				*quote_*
 When writing to this register, nothing happens.  This can be used to delete

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -492,7 +492,6 @@ followed by another Vim command:
     :function
     :global
     :help
-    :helpfind
     :lcscope
     :ldo
     :lfdo

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1145,7 +1145,7 @@ If you want to always use ":confirm", set the 'confirm' option.
 			|:diffsplit|, |:diffpatch|, |:pedit|, |:redir|,
 			|:source|, |:update|, |:visual|, |:vsplit|,
 			and |:qall| if 'confirm' is set.
-			{only in Win32, GTK and Mac GUI}
+			{only in Win32 and Mac GUI}
 			When ":browse" is not possible you get an error
 			message.  If the |+browse| feature is missing or the
 			{command} doesn't support browsing, the {command} is
@@ -1173,16 +1173,13 @@ For versions of Vim where browsing is not supported, the command is executed
 unmodified.
 
 							*browsefilter*
-For MS Windows and GTK, you can modify the filters that are used in the browse
-dialog.  By setting the g:browsefilter or b:browsefilter variables, you can
-change the filters globally or locally to the buffer.  The variable is set to
-a string in the format "{filter label}\t{pattern};{pattern}\n" where {filter
-label} is the text that appears in the "Files of Type" comboBox, and {pattern}
-is the pattern which filters the filenames.  Several patterns can be given,
-separated by ';'.
-
-For Motif the same format is used, but only the very first pattern is actually
-used (Motif only offers one pattern, but you can edit it).
+For Windows you can modify the filters that are used in the browse dialog.  By
+setting the g:browsefilter or b:browsefilter variables, you can change the
+filters globally or locally to the buffer.  The variable is set to a string in
+the format "{filter label}\t{pattern};{pattern}\n" where {filter label} is the
+text that appears in the "Files of Type" comboBox, and {pattern} is the
+pattern which filters the filenames.  Several patterns can be given, separated
+by ';'.
 
 For example, to have only Vim files in the dialog, you could use the following
 command: >

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2563,7 +2563,7 @@ confirm({msg} [, {choices} [, {default} [, {type}]]])
 		{default} is omitted, 1 is used.
 
 		The optional {type} argument gives the type of dialog.  This
-		is only used for the icon of the GTK, Mac, and Win32 GUI.  It
+		is only used for the icon of the Mac and Win32 GUI.  It
 		can be one of these values: "Error", "Question", "Info",
 		"Warning" or "Generic".  Only the first character is relevant.
 		When {type} is omitted, "Generic" is used.
@@ -3279,8 +3279,7 @@ foreground()	Move the Vim window to the foreground.	Useful when sent from
 		On Win32 systems this might not work, the OS does not always
 		allow a window to bring itself to the foreground.  Use
 		|remote_foreground()| instead.
-		{only in the Win32 and GTK GUI versions and the
-		Win32 console version}
+		{only in the Win32 GUI and console version}
 
 
 function({name})					*function()* *E700*
@@ -3528,8 +3527,6 @@ getfontname([{name}])					*getfontname()*
 		Only works when the GUI is running, thus not in your vimrc or
 		gvimrc file.  Use the |GUIEnter| autocommand to use this
 		function just after the GUI has started.
-		Note that the GTK 2 GUI accepts any font name, thus checking
-		for a valid name does not work.
 
 getfperm({fname})					*getfperm()*
 		The result is a String, which is the read, write, and execute
@@ -5213,8 +5210,7 @@ remote_foreground({server})				*remote_foreground()*
 		Note: This does not restore the window if it was minimized,
 		like foreground() does.
 		This function is not available in the |sandbox|.
-		{only in the Win32 and GTK GUI versions and the
-		Win32 console version}
+		{only in the Win32 GUI and the Win32 console version}
 
 
 remote_peek({serverid} [, {retvar}])		*remote_peek()*
@@ -6980,7 +6976,6 @@ debug			Compiled with "DEBUG" defined.
 dialog_con		Compiled with console dialog support.
 dialog_gui		Compiled with GUI dialog support.
 digraphs		Compiled with support for digraphs.
-dnd			Compiled with support for the "~ register |quote_~|.
 eval			Compiled with expression evaluation support.  Always
 			true, of course!
 ex_extra		Compiled with extra Ex commands |+ex_extra|.
@@ -6998,9 +6993,6 @@ fname_case		Case in file names matters (for Windows this is not
 folding			Compiled with |folding| support.
 gettext			Compiled with message translation |multi-lang|
 gui			Compiled with GUI enabled.
-gui_gnome		Compiled with Gnome support (gui_gtk is also defined).
-gui_gtk			Compiled with GTK+ GUI (any version).
-gui_gtk2		Compiled with GTK+ 2 GUI (gui_gtk is also defined).
 gui_mac			Compiled with Macintosh GUI.
 gui_running		Vim is running in the GUI, or it will start soon.
 gui_win32		Compiled with MS Windows Win32 GUI.

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -593,10 +593,6 @@ The default menus have these priorities:
 When no or zero priority is given, 500 is used.
 The priority for the PopUp menu is not used.
 
-The Help menu will be placed on the far right side of the menu bar on systems
-which support this (GTK+).  For GTK+ 2, this is not done anymore
-because right-aligning the Help menu is now discouraged UI design.
-
 You can use a priority higher than 9999, to make it go after the Help menu,
 but that is non-standard and is discouraged.  The highest possible priority is
 about 32000.  The lowest is 1.
@@ -665,10 +661,8 @@ level.  Vim interprets the items in this menu as follows:
     toolbar button image.  Note that the exact filename is OS-specific: For
     example, under Win32 the command >
 	:amenu ToolBar.Hello :echo "hello"<CR>
-<   would find the file 'hello.bmp'.  Under GTK+/X11 it is 'Hello.xpm'.  With
-    GTK+ 2 the files 'Hello.png', 'Hello.xpm' and 'Hello.bmp' are checked for
-    existence, and the first one found would be used.
-    For MS-Windows and GTK+ 2 the bitmap is scaled to fit the button.  For
+<   would find the file 'hello.bmp'.  Under X11 it is 'Hello.xpm'.
+    For MS-Windows and the bitmap is scaled to fit the button.  For
     MS-Windows a size of 18 by 18 pixels works best.
     For MS-Windows the bitmap should have 16 colors with the standard palette.
     The light grey pixels will be changed to the Window frame color and the
@@ -717,8 +711,8 @@ nr  Name		Normal action  ~
 30  WinMinWidth		make current window use few columns
 
 					*hidden-menus* *win32-hidden-menus*
-In the Win32 and GTK+ GUI, starting a menu name with ']' excludes that menu
-from the main menu bar.  You must then use the |:popup| command to display it.
+In the Win32 GUI, starting a menu name with ']' excludes that menu from the
+main menu bar.  You must then use the |:popup| command to display it.
 
 							*popup-menu*
 You can define the special menu "PopUp".  This is the menu that is displayed
@@ -871,9 +865,8 @@ a menu item - you don't need to do a :tunmenu as well.
 
 5.9 Popup Menus
 
-In the Win32 and GTK+ GUI, you can cause a menu to popup at the cursor.
-This behaves similarly to the PopUp menus except that any menu tree can
-be popped up.
+In the Win32 GUI, you can cause a menu to popup at the cursor.  This behaves
+similarly to the PopUp menus except that any menu tree can be popped up.
 
 This command is for backwards compatibility, using it is discouraged, because
 it behaves in a strange way.
@@ -882,7 +875,7 @@ it behaves in a strange way.
 :popu[p] {name}			Popup the menu {name}.  The menu named must
 				have at least one subentry, but need not
 				appear on the menu-bar (see |hidden-menus|).
-				{only available for Win32 and GTK GUI}
+				{only available for Win32 GUI}
 
 :popu[p]! {name}		Like above, but use the position of the mouse
 				pointer instead of the cursor.

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -184,12 +184,6 @@ command: >
 	:!xterm -e vim +help &
 <
 
-			*:helpfind* *:helpf*
-:helpf[ind]		Like |:help|, but use a dialog to enter the argument.
-			Only for backwards compatibility.  It now executes the
-			ToolBar.FindHelp menu entry instead of using a builtin
-			dialog.  {only when compiled with |+GUI_GTK|}
-
 					*:helpt* *:helptags*
 				*E154* *E150* *E151* *E152* *E153* *E670*
 :helpt[ags] [++t] {dir}

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1241,7 +1241,6 @@ tag	      command	      action ~
 |:hardcopy|	:ha[rdcopy]	send text to the printer
 |:help|		:h[elp]		open a help window
 |:helpclose|	:helpc[lose]	close one help window
-|:helpfind|	:helpf[ind]	dialog to open a help window
 |:helpgrep|	:helpg[rep]	like ":grep" but searches help files
 |:helptags|	:helpt[ags]	generate help tags for a directory
 |:highlight|	:hi[ghlight]	specify highlighting methods

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -97,14 +97,6 @@ is the difficult part.  It depends on the system you are using, the locale and
 a few other things.  See the chapters on fonts: |mbyte-fonts-X11| for
 X-Windows and |mbyte-fonts-MSwin| for MS-Windows.
 
-For GTK+ 2, you can skip most of this section.  The option 'guifontset' does
-no longer exist.  You only need to set 'guifont' and everything should "just
-work".  If your system comes with Xft2 and fontconfig and the current font
-does not contain a certain glyph, a different font will be used automatically
-if available.  The 'guifontwide' option is still supported but usually you do
-not need to set it.  It is only necessary if the automatic font selection does
-not suit your needs.
-
 For X11 you can set the 'guifontset' option to a list of fonts that together
 cover the characters that are used.  Example for Korean: >
 
@@ -484,11 +476,6 @@ For Vim you may need to set 'encoding' to "utf-8".
 Unfortunately, using fonts in X11 is complicated.  The name of a single-byte
 font is a long string.  For multi-byte fonts we need several of these...
 
-Note: Most of this is no longer relevant for GTK+ 2.  Selecting a font via
-its XLFD is not supported; see 'guifont' for an example of how to
-set the font.  Do yourself a favor and ignore the |XLFD| and |xfontset|
-sections below.
-
 First of all, Vim only accepts fixed-width fonts for displaying text.  You
 cannot use proportionally spaced fonts.  This excludes many of the available
 (and nicer looking) fonts.  However, for menus and tooltips any font can be
@@ -790,20 +777,6 @@ For example, when you are using kinput2 as |IM-server| and sh, >
 
 	export XMODIFIERS="@im=kinput2"
 <
-
-FULLY CONTROLLED XIM
-
-You can fully control XIM, like with IME of MS-Windows (see |multibyte-ime|).
-This is currently only available for the GTK GUI.
-
-Before using fully controlled XIM, one setting is required.  Set the
-'imactivatekey' option to the key that is used for the activation of the input
-method.  For example, when you are using kinput2 + canna as IM Server, the
-activation key is probably Shift+Space: >
-
-	:set imactivatekey=S-space
-
-See 'imactivatekey' for the format.
 
 ==============================================================================
 8.  Input on MS-Windows					*mbyte-IME*
@@ -1142,14 +1115,12 @@ internally.
 
 Vim has comprehensive UTF-8 support.  It works well in:
 - xterm with utf-8 support enabled
-- Motif and GTK GUI
 - MS-Windows GUI
 - several other platforms
 
 Double-width characters are supported.  This works best with 'guifontwide' or
 'guifontset'.  When using only 'guifont' the wide characters are drawn in the
-normal width and a space to fill the gap.  Note that the 'guifontset' option
-is no longer relevant in the GTK+ 2 GUI.
+normal width and a space to fill the gap.
 
 							*bom-bytes*
 When reading a file a BOM (Byte Order Mark) can be used to recognize the
@@ -1218,8 +1189,6 @@ doesn't always work.  See the system specific remarks below, and 'langmenu'.
 
 
 USING UTF-8 IN X-Windows				*utf-8-in-xwindows*
-
-Note: This section does not apply to the GTK+ 2 GUI.
 
 You need to specify a font to be used.  For double-wide characters another
 font is required, which is exactly twice as wide.  There are three ways to do

--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -401,12 +401,6 @@ You have used an ":unabbreviate" command with an argument which is not an
 existing abbreviation.  All variations of this command give the same message:
 ":cunabbrev", ":iunabbrev", etc.  Check for trailing white space.
 
->
-  /dev/dsp: No such file or directory
-
-Only given for GTK GUI with Gnome support.  Gnome tries to use the audio
-device and it isn't present.  You can ignore this error.
-
 							*E31*  >
   No such mapping
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1110,7 +1110,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'browsedir'* *'bsdir'*
 'browsedir' 'bsdir'	string	(default: "last")
 			global
-			{only for Motif, GTK, Mac and Win32 GUI}
+			{only for Mac and Win32 GUI}
 	Which directory to use for the file browser:
 	   last		Use same directory as with last file browser, where a
 			file was opened or saved.
@@ -2971,28 +2971,18 @@ A jump table for the options with a short description can be found at |Q_op|.
 	the case of X).  The font names given should be "normal" fonts.  Vim
 	will try to find the related bold and italic fonts.
 
-	For Win32, GTK, Motif, and Mac OS: >
+	For Win32 and Mac OS: >
 	    :set guifont=*
 <	will bring up a font requester, where you can pick the font you want.
 
 	The font name depends on the GUI used.  See |setting-guifont| for a
 	way to set 'guifont' for various systems.
 
-	For the GTK+ 2 GUI the font name looks like this: >
-	    :set guifont=Andale\ Mono\ 11
-<	That's all.  XLFDs are not used.  For Chinese this is reported to work
-	well: >
-	    if has("gui_gtk2")
-	      set guifont=Bitstream\ Vera\ Sans\ Mono\ 12,Fixed\ 12
-	      set guifontwide=Microsoft\ Yahei\ 12,WenQuanYi\ Zen\ Hei\ 12
-	    endif
-<
 	For Mac OSX you can use something like this: >
 	    :set guifont=Monaco:h10
 <								*E236*
 	Note that the fonts must be mono-spaced (all characters have the same
-	width).  An exception is GTK 2: all fonts are accepted, but
-	mono-spaced fonts look best.
+	width).
 
 	To preview a font on X11, you might be able to use the "xfontsel"
 	program.  The "xlsfonts" program gives a list of all available fonts.
@@ -3025,7 +3015,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 			{only available when compiled with GUI enabled and
 			with the |+xfontset| feature}
-			{not available in the GTK+ 2 GUI}
 	When not empty, specifies two (or more) fonts to be used.  The first
 	one for normal English, the second one for your special language.  See
 	|xfontset|.
@@ -3053,23 +3042,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Note: The size of these fonts must be exactly twice as wide as the one
 	specified with 'guifont' and the same height.
 
-	All GUI versions but GTK+ 2:
-
 	'guifontwide' is only used when 'encoding' is set to "utf-8" and
 	'guifontset' is empty or invalid.
 	When 'guifont' is set and a valid font is found in it and
 	'guifontwide' is empty Vim will attempt to find a matching
 	double-width font and set 'guifontwide' to it.
-
-	GTK+ 2 GUI only:			*guifontwide_gtk2*
-
-	If set and valid, 'guifontwide' is always used for double width
-	characters, even if 'encoding' is not set to "utf-8".
-	Vim does not attempt to find an appropriate value for 'guifontwide'
-	automatically.  If 'guifontwide' is empty Pango/Xft will choose the
-	font for characters not available in 'guifont'.  Thus you do not need
-	to set 'guifontwide' at all unless you want to override the choice
-	made by Pango/Xft.
 
 	Windows +multibyte only:		*guifontwide_win_mbyte*
 
@@ -3078,7 +3055,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'guiheadroom'* *'ghr'*
 'guiheadroom' 'ghr'	number	(default 50)
 			global
-			{only for GTK and X11 GUI}
+			{only for X11 GUI}
 	The number of pixels subtracted from the screen height when fitting
 	the GUI window on the screen.  Set this before the GUI is started,
 	e.g., in your |gvimrc| file.  When zero, the whole screen height will
@@ -3088,8 +3065,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	screen.
 
 						*'guioptions'* *'go'*
-'guioptions' 'go'	string	(default "egmrLT"   (MS-Windows),
-					 "aegimrLT" (GTK and Motif))
+'guioptions' 'go'	string	(default "egmrLT"   (MS-Windows))
 			global
 			{only available when compiled with GUI enabled}
 	This option only has an effect in the GUI version of Vim.  It is a
@@ -3135,10 +3111,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		'guitablabel' can be used to change the text in the labels.
 		When 'e' is missing a non-GUI tab pages line may be used.
 		The GUI tabs are only supported on some systems, currently
-		GTK, Motif, Mac OS/X and MS-Windows.
+		Mac OS/X and MS-Windows.
 								*'go-i'*
-	  'i'	Use a Vim icon.  For GTK with KDE it is used in the left-upper
-		corner of the window.
+	  'i'	Use a Vim icon.
 								*'go-m'*
 	  'm'	Menu bar is present.
 								*'go-M'*
@@ -3151,8 +3126,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  'g'	Grey menu items: Make menu items that are not active grey.  If
 		'g' is not included inactive menu items are not shown at all.
 								*'go-T'*
-	  'T'	Include Toolbar.  Currently only in Win32, GTK+, and
-		Motif GUIs.
+	  'T'	Include Toolbar.  Currently only in Win32 GUI.
 								*'go-r'*
 	  'r'	Right-hand scrollbar is always present.
 								*'go-R'*
@@ -3436,54 +3410,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|/ignorecase|.
 
 						*'imactivatefunc'* *'imaf'*
-'imactivatefunc' 'imaf'	string (default "")
-			global
-			{only available when compiled with |+xim| and
-			|+GUI_GTK|}
-	This option specifies a function that will be called to
-	activate/inactivate Input Method.
+'imactivatefunc' 'imaf'	Removed. |vim-differences| {Nvim}
 
-	Example: >
-		function ImActivateFunc(active)
-		  if a:active
-		    ... do something
-		  else
-		    ... do something
-		  endif
-		  " return value is not used
-		endfunction
-		set imactivatefunc=ImActivateFunc
-<
 						*'imactivatekey'* *'imak'*
-'imactivatekey' 'imak'	string (default "")
-			global
-			{only available when compiled with |+xim| and
-			|+GUI_GTK|}				*E599*
-	Specifies the key that your Input Method in X-Windows uses for
-	activation.  When this is specified correctly, vim can fully control
-	IM with 'imcmdline', 'iminsert' and 'imsearch'.
-	You can't use this option to change the activation key, the option
-	tells Vim what the key is.
-	Format:
-		[MODIFIER_FLAG-]KEY_STRING
-
-	These characters can be used for MODIFIER_FLAG (case is ignored):
-		S	    Shift key
-		L	    Lock key
-		C	    Control key
-		1	    Mod1 key
-		2	    Mod2 key
-		3	    Mod3 key
-		4	    Mod4 key
-		5	    Mod5 key
-	Combinations are allowed, for example "S-C-space" or "SC-space" are
-	both shift+ctrl+space.
-	See <X11/keysymdef.h> and XStringToKeysym for KEY_STRING.
-
-	Example: >
-		:set imactivatekey=S-space
-<	"S-space" means shift+space.  This is the activation key for kinput2 +
-	canna (Japanese), and ami (Korean).
+'imactivatekey' 'imak'	Removed. |vim-differences| {Nvim}
 
 				*'imcmdline'* *'imc'* *'noimcmdline'* *'noimc'*
 'imcmdline' 'imc'	boolean (default off)
@@ -3542,21 +3472,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	option to a valid keymap name.
 
 						*'imstatusfunc'* *'imsf'*
-'imstatusfunc' 'imsf'	string (default "")
-			global
-			{only available when compiled with |+xim| and
-			|+GUI_GTK|}
-	This option specifies a function that is called to obtain the status
-	of Input Method.  It must return a positive number when IME is active.
-
-	Example: >
-		function ImStatusFunc()
-		  let is_active = ...do something
-		  return is_active ? 1 : 0
-		endfunction
-		set imstatusfunc=ImStatusFunc
-<
-	NOTE: This function is invoked very often.  Keep it fast.
+'imstatusfunc' 'imsf'	Removed. |vim-differences| {Nvim}
 
 						*'include'* *'inc'*
 'include' 'inc'		string	(default "^\s*#\s*include")
@@ -5707,8 +5623,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Use the 'M' flag in 'highlight' to set the type of highlighting for
 	this message.
 	When |XIM| may be used the message will include "XIM".  But this
-	doesn't mean XIM is really active, especially when 'imactivatekey' is
-	not set.
+	doesn't mean XIM is really active.
 
 						*'showtabline'* *'stal'*
 'showtabline' 'stal'	number	(default 1)
@@ -7012,7 +6927,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'winaltkeys'* *'wak'*
 'winaltkeys' 'wak'	string	(default "menu")
 			global
-			{only used in Win32, Motif, and GTK}
+			{only used in Win32}
 	Some GUI versions allow the access to menu entries by using the ALT
 	key in combination with a character that appears underlined in the
 	menu.  This conflicts with the use of the ALT key for mappings and
@@ -7027,8 +6942,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		keys can be mapped.
 	If the menu is disabled by excluding 'm' from 'guioptions', the ALT
 	key is never used for the menu.
-	This option is not used for <F10>; on Win32 and with GTK <F10> will
-	select the menu, unless it has been mapped.
+	This option is not used for <F10>; on Win32.
 
 						*'window'* *'wi'*
 'window' 'wi'		number  (default screen height - 1)

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -730,13 +730,10 @@ Short explanation of each option:		*option-list*
 'icon'			    let Vim set the text of the window icon
 'iconstring'		    string to use for the Vim icon text
 'ignorecase'	  'ic'	    ignore case in search patterns
-'imactivatekey'   'imak'    key that activates the X input method
-'imactivatefunc'  'imaf'    function to enable/disable the X input method
 'imcmdline'	  'imc'     use IM when starting to edit a command line
 'imdisable'	  'imd'     do not use the IM in any mode
 'iminsert'	  'imi'     use :lmap or IM in Insert mode
 'imsearch'	  'ims'     use :lmap or IM when typing a search pattern
-'imstatusfunc'    'imsf'    function to obtain X input method status
 'include'	  'inc'     pattern to be used to find an include file
 'includeexpr'	  'inex'    expression used to process an include line
 'incsearch'	  'is'	    highlight match while typing search pattern

--- a/runtime/doc/scroll.txt
+++ b/runtime/doc/scroll.txt
@@ -245,26 +245,6 @@ dragging the scrollbar of the current window.  How many lines are scrolled
 depends on your mouse driver.  If the scroll action causes input focus
 problems, see |intellimouse-wheel-problems|.
 
-For the X11 GUIs (Motif and GTK) scrolling the wheel generates key
-presses <ScrollWheelUp>, <ScrollWheelDown>, <ScrollWheelLeft> and
-<ScrollWheelRight>.  For example, if you push the scroll wheel upwards a
-<ScrollWheelUp> key press is generated causing the window to scroll upwards
-(while the text is actually moving downwards).  The default action for these
-keys are:
-    <ScrollWheelUp>	    scroll three lines up	*<ScrollWheelUp>*
-    <S-ScrollWheelUp>	    scroll one page up		*<S-ScrollWheelUp>*
-    <C-ScrollWheelUp>	    scroll one page up		*<C-ScrollWheelUp>*
-    <ScrollWheelDown>	    scroll three lines down	*<ScrollWheelDown>*
-    <S-ScrollWheelDown>	    scroll one page down	*<S-ScrollWheelDown>*
-    <C-ScrollWheelDown>	    scroll one page down	*<C-ScrollWheelDown>*
-    <ScrollWheelLeft>	    scroll six columns left	*<ScrollWheelLeft>*
-    <S-ScrollWheelLeft>	    scroll one page left	*<S-ScrollWheelLeft>*
-    <C-ScrollWheelLeft>	    scroll one page left	*<C-ScrollWheelLeft>*
-    <ScrollWheelRight>	    scroll six columns right	*<ScrollWheelRight>*
-    <S-ScrollWheelRight>    scroll one page right	*<S-ScrollWheelRight>*
-    <C-ScrollWheelRight>    scroll one page right	*<C-ScrollWheelRight>*
-This should work in all modes, except when editing the command line.
-
 Note that horizontal scrolling only works if 'nowrap' is set.  Also, unless
 the "h" flag in 'guioptions' is set, the cursor moves to the longest visible
 line if the cursor line is about to be scrolled off the screen (similarly to
@@ -280,13 +260,6 @@ You can also use Alt and Ctrl modifiers.
 
 This only works when Vim gets the scroll wheel events, of course.  You can
 check if this works with the "xev" program.
-
-When using XFree86, the /etc/XF86Config file should have the correct entry for
-your mouse.  For FreeBSD, this entry works for a Logitech scrollmouse: >
-    Protocol     "MouseMan"
-    Device       "/dev/psm0"
-    ZAxisMapping 4 5
-See the XFree86 documentation for information.
 
 						*<MouseDown>* *<MouseUp>*
 The keys <MouseDown> and <MouseUp> have been deprecated.  Use <ScrollWheelUp>

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -75,12 +75,8 @@ DEFINING A SIGN.			*:sign-define* *E255* *E160* *E612*
 		Define the file name where the bitmap can be found.  Should be
 		a full path.  The bitmap should fit in the place of two
 		characters.  This is not checked.  If the bitmap is too big it
-		will cause redraw problems.  Only GTK 2 can scale the bitmap
-		to fit the space available.
+		will cause redraw problems.
 			toolkit		supports ~
-			GTK 1		pixmap (.xpm)
-			GTK 2		many
-			Motif		pixmap (.xpm)
 			Win32		.bmp, .ico, .cur
 					pixmap (.xpm) |+xpm_w32|
 

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -35,9 +35,7 @@ Vim only checks words for spelling, there is no grammar check.
 If the 'mousemodel' option is set to "popup" and the cursor is on a badly
 spelled word or it is "popup_setpos" and the mouse pointer is on a badly
 spelled word, then the popup menu will contain a submenu to replace the bad
-word.  Note: this slows down the appearance of the popup menu.  Note for GTK:
-don't release the right mouse button until the menu appears, otherwise it
-won't work.
+word.  Note: this slows down the appearance of the popup menu.
 
 To search for the next misspelled word:
 

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -314,7 +314,6 @@ N  *+dialog_gui*	Support for |:confirm| with GUI dialog.
 N  *+dialog_con*	Support for |:confirm| with console dialog.
 N  *+dialog_con_gui*	Support for |:confirm| with GUI and console dialog.
 N  *+digraphs*		|digraphs| *E196*
-   *+dnd*		Support for DnD into the "~ register |quote_~|.
 N  *+eval*		expression evaluation |eval.txt|
 N  *+ex_extra*		Vim's extra Ex commands: |:center|, |:left|,
 			|:normal|, |:retab| and |:right|
@@ -325,7 +324,6 @@ N  *+find_in_path*	include file searches: |[I|, |:isearch|,
 			|CTRL-W_CTRL-I|, |:checkpath|, etc.
 N  *+folding*		|folding|
 N  *+gettext*		message translations |multi-lang|
-   *+GUI_GTK*		Unix only: GTK+ |GUI|
    *+iconv*		Compiled with the |iconv()| function
    *+iconv/dyn*		Likewise |iconv-dynamic| |/dyn|
 N  *+insert_expand*	|insert_expand| Insert mode completion

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -77,7 +77,7 @@ Graphical User Interface (GUI).				|gui|
 	Included support for GUI: menu's, mouse, scrollbars, etc.  You can
 	define your own menus.  Better support for CTRL/SHIFT/ALT keys in
 	combination with special keys and mouse.  Supported for various
-	platforms such as GTK, Win32, and Macintosh.
+	platforms such as Win32 and Macintosh.
 
 Multiple windows and buffers.				|windows.txt|
 	Vim can split the screen into several windows, each editing a

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -199,6 +199,9 @@ Other options:
   'cpoptions' ('g', 'w', 'H', '*', '-', 'j', and all POSIX flags were removed)
   'guioptions' (only the 't' flag was removed)
   'guipty'
+  'imactivatefunc'
+  'imactivatekey'
+  'imstatusfunc'
   'macatsui'
   'restorescreen'
   'shelltype'
@@ -215,6 +218,7 @@ Other options:
 Other commands:
   :Print
   :fixdel
+  :helpfind
   :mode (no longer accepts an argument)
   :open
   :shell

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1025,12 +1025,6 @@ return {
     func='ex_helpclose',
   },
   {
-    command='helpfind',
-    flags=bit.bor(EXTRA, NOTRLCOM),
-    addr_type=ADDR_LINES,
-    func='ex_ni',
-  },
-  {
     command='helpgrep',
     flags=bit.bor(EXTRA, NOTRLCOM, NEEDARG),
     addr_type=ADDR_LINES,

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1144,20 +1144,6 @@ return {
       defaults={if_true={vi=false}}
     },
     {
-      full_name='imactivatefunc', abbreviation='imaf',
-      type='string', scope={'global'},
-      secure=true,
-      vi_def=true,
-      enable_if=false,
-    },
-    {
-      full_name='imactivatekey', abbreviation='imak',
-      type='string', scope={'global'},
-      vi_def=true,
-      enable_if=false,
-      defaults={if_true={vi=""}}
-    },
-    {
       full_name='imcmdline', abbreviation='imc',
       type='bool', scope={'global'},
       vi_def=true,
@@ -1192,13 +1178,6 @@ return {
         if_true={vi=macros('B_IMODE_IM')},
         if_false={vi=macros('B_IMODE_NONE')},
       }
-    },
-    {
-      full_name='imstatusfunc', abbreviation='imsf',
-      type='string', scope={'global'},
-      secure=true,
-      vi_def=true,
-      enable_if=false,
     },
     {
       full_name='include', abbreviation='inc',


### PR DESCRIPTION
Remove some references to Motif while here too and one to XFree86 (wow such legacy).

I'm fairly sure we don't support `has("dnd")` anymore but I'm not sure. It's not in `eval.c` that I could find.
