### PR TITLE
[RFC] Vim 7.4.721

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3459,7 +3459,7 @@ win_line (
             c = ' ';
           }
         } else if (c == NUL
-                   && ((wp->w_p_list && lcs_eol > 0)
+                   && (wp->w_p_list
                        || ((fromcol >= 0 || fromcol_prev >= 0)
                            && tocol > vcol
                            && VIsual_mode != Ctrl_V
@@ -3486,10 +3486,11 @@ win_line (
               c_extra = NUL;
             }
           }
-          if (wp->w_p_list)
+          if (wp->w_p_list && lcs_eol > 0) {
             c = lcs_eol;
-          else
+          } else {
             c = ' ';
+          }
           lcs_eol_one = -1;
           --ptr;                    /* put it back at the NUL */
           if (!attr_pri) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -403,7 +403,7 @@ static int included_patches[] = {
   // 724 NA
   723,
   // 722,
-  // 721,
+  721,
   // 720 NA
   719,
   // 718,


### PR DESCRIPTION
vim-patch:7.4.721

Problem:    When 'list' is set Visual mode does not highlight anything in
            empty lines. (mgaleski)
Solution:   Check the value of lcs_eol in another place. (Christian Brabandt)

https://github.com/vim/vim/commit/d59c099120919d2d77b431308e390f86c594c825
