### PR TITLE
[RFC] doc: Remove references to the Mac GUI

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1145,7 +1145,7 @@ If you want to always use ":confirm", set the 'confirm' option.
 			|:diffsplit|, |:diffpatch|, |:pedit|, |:redir|,
 			|:source|, |:update|, |:visual|, |:vsplit|,
 			and |:qall| if 'confirm' is set.
-			{only in Win32 and Mac GUI}
+			{only in Win32 GUI}
 			When ":browse" is not possible you get an error
 			message.  If the |+browse| feature is missing or the
 			{command} doesn't support browsing, the {command} is

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2563,9 +2563,9 @@ confirm({msg} [, {choices} [, {default} [, {type}]]])
 		{default} is omitted, 1 is used.
 
 		The optional {type} argument gives the type of dialog.  This
-		is only used for the icon of the Mac and Win32 GUI.  It
-		can be one of these values: "Error", "Question", "Info",
-		"Warning" or "Generic".  Only the first character is relevant.
+		is only used for the icon of the Win32 GUI.  It can be one of
+		these values: "Error", "Question", "Info", "Warning" or
+		"Generic".  Only the first character is relevant.
 		When {type} is omitted, "Generic" is used.
 
 		If the user aborts the dialog by pressing <Esc>, CTRL-C,
@@ -6993,7 +6993,6 @@ fname_case		Case in file names matters (for Windows this is not
 folding			Compiled with |folding| support.
 gettext			Compiled with message translation |multi-lang|
 gui			Compiled with GUI enabled.
-gui_mac			Compiled with Macintosh GUI.
 gui_running		Vim is running in the GUI, or it will start soon.
 gui_win32		Compiled with MS Windows Win32 GUI.
 iconv			Can use iconv() for conversion.

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -390,7 +390,7 @@ To enter debugging mode use one of these methods:
    useful to find out what is happening when Vim is starting up.  A side
    effect is that Vim will switch the terminal mode before initialisations
    have finished, with unpredictable results.
-   For a GUI-only version (Windows, Macintosh) the debugging will start as
+   For a GUI-only version (Windows) the debugging will start as
    soon as the GUI window has been opened.  To make this happen early, add a
    ":gui" command in the vimrc file.
 								*:debug*

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -77,7 +77,7 @@ Graphical User Interface (GUI).				|gui|
 	Included support for GUI: menu's, mouse, scrollbars, etc.  You can
 	define your own menus.  Better support for CTRL/SHIFT/ALT keys in
 	combination with special keys and mouse.  Supported for various
-	platforms such as Win32 and Macintosh.
+	platforms such as Win32.
 
 Multiple windows and buffers.				|windows.txt|
 	Vim can split the screen into several windows, each editing a


### PR DESCRIPTION
There are probably more references to the Mac GUI but due to Vim being entirely inconsistent in how it names the Mac GUI (sometimes it's Mac sometimes it's the Mac GUI other times it's Macintosh) it's hard to search for them in context. :(
