### PR TITLE
[RFC] Windows: Undefine the Windows RGB macro

### DIFF
--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -17,6 +17,9 @@
 
 #define USE_CRNL
 
+// We have our own RGB macro in macros.h.
+#undef RGB
+
 #ifdef _MSC_VER
 # ifndef inline
 #  define inline __inline


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@956e9eb.

We have a `RGB` macro in `src/nvim/macros.h` but Windows also provides one.
So undefine the Windows one.

See: https://msdn.microsoft.com/en-us/library/dd162937%28v=vs.85%29.aspx
