### PR TITLE
[RFC] Windows: Include <uv.h> for S_IFLNK

### DIFF
--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -5,6 +5,10 @@
 #include <sys/stat.h>
 #include <stdio.h>
 
+// Windows does not have S_IFLNK but libuv defines it
+// and sets the flag for us when calling uv_fs_stat.
+#include <uv.h>
+
 #define NAME_MAX _MAX_PATH
 
 #define TEMP_DIR_NAMES {"$TMP", "$TEMP", "$USERPROFILE", ""}


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@956e9eb.

`S_IFLNK` is not defined on Windows but libuv defines it for us.
So include `<uv.h>` in `src/nvim/os/win_defs.h` so `S_ISLNK` works.

See [here](https://github.com/libuv/libuv/blob/764877fd9e4ea67c0cbe27bf81b2b294ed33b0f5/include/uv-win.h#L65) and [here](https://github.com/libuv/libuv/blob/e76b8838e51f6e8f1944b6c6d50c3948ed764a0b/src/win/fs.c#L1086).
