### PR TITLE
[RFC] Windows: include <io.h>

### DIFF
--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -3,6 +3,7 @@
 
 #include <windows.h>
 #include <sys/stat.h>
+#include <io.h>
 #include <stdio.h>
 
 #define NAME_MAX _MAX_PATH


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@956e9eb.

`if_csope.c` uses `_open_osfhandle` so include the necessary header.
Futher we need `<io.h>` for `read/write/close/lseek`.

See [here](https://github.com/neovim/neovim/blob/b2f9bfbff0ba9925328d2f997f73734f70c6c4cf/src/nvim/if_cscope.c#L873) for our use of `_open_osfhandle`.

See here for MSDN reference: https://msdn.microsoft.com/en-us/library/bdts1c9x.aspx
