### PR TITLE
[RFC] Windows: Include <fcntl.h> for file constants

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -6,6 +6,7 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
+#include <fcntl.h>
 
 #include "nvim/vim.h"
 #include "nvim/ascii.h"

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <inttypes.h>
+#include <fcntl.h>
 
 #include "nvim/vim.h"
 #include "nvim/ascii.h"

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <fcntl.h>
 
 #include "nvim/vim.h"
 #include "nvim/ascii.h"

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -40,6 +40,7 @@
 #include <limits.h>
 #include <string.h>
 #include <stdbool.h>
+#include <fcntl.h>
 
 #include "nvim/vim.h"
 #include "nvim/ascii.h"

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -38,6 +38,7 @@
 #include <inttypes.h>
 #include <string.h>
 #include <stdbool.h>
+#include <fcntl.h>
 
 #include "nvim/ascii.h"
 #include "nvim/vim.h"

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <errno.h>
+#include <fcntl.h>
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>
 #endif

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -77,6 +77,7 @@
 #include <limits.h>
 #include <stdbool.h>
 #include <string.h>
+#include <fcntl.h>
 
 #include "nvim/vim.h"
 #include "nvim/ascii.h"


### PR DESCRIPTION
We used to include this in `src/nvim/vim.h` but since #4015 this was removed.

The Unix build still worked because some other header which only gets included on Unix (most probably `<unistd.h>`) was including `<fcntl.h>` as a side effect.

Regardless [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/fcntl.h.html) says that for file constants (such as `O_RDONLY`) we should include `<fcntl.h>`.

See https://github.com/neovim/neovim/pull/4024#issuecomment-172256965 for comments and
[here](https://ci.appveyor.com/project/equalsraf/neovim/build/594/job/x8w9nvijh2a561in) for breakage on Windows when not including `<fcntl.h>`.

Copy #810.
