### PR TITLE
[RFC] config: Remove HAVE_FCNTL_H

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -15,7 +15,6 @@ check_type_size("void *" SIZEOF_VOID_PTR)
 check_symbol_exists(_NSGetEnviron crt_externs.h HAVE__NSGETENVIRON)
 
 # Headers
-check_include_files(fcntl.h HAVE_FCNTL_H)
 check_include_files(iconv.h HAVE_ICONV_H)
 check_include_files(langinfo.h HAVE_LANGINFO_H)
 check_include_files(locale.h HAVE_LOCALE_H)

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -13,7 +13,6 @@
 #endif
 
 #cmakedefine HAVE__NSGETENVIRON
-#cmakedefine HAVE_FCNTL_H
 #cmakedefine HAVE_FD_CLOEXEC
 #cmakedefine HAVE_FSEEKO
 #cmakedefine HAVE_GETPWENT


### PR DESCRIPTION
We don't use this anymore as the only use of it was removed in #4015.
Further all systems we support have `<fcntl.h>`.

cc @Pyrohh 
