### PR TITLE
[RFC] config: Remove HAVE_UNISTD_H

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -26,7 +26,6 @@ if(NOT HAVE_SYS_WAIT_H AND UNIX)
   message(SEND_ERROR "header sys/wait.h is required for Unix")
 endif()
 check_include_files(sys/utsname.h HAVE_SYS_UTSNAME_H)
-check_include_files(unistd.h HAVE_UNISTD_H)
 check_include_files(utime.h HAVE_UTIME_H)
 
 # Functions

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -39,7 +39,6 @@
 #cmakedefine HAVE_STRNCASECMP
 #cmakedefine HAVE_SYS_UTSNAME_H
 #cmakedefine HAVE_SYS_WAIT_H
-#cmakedefine HAVE_UNISTD_H
 #cmakedefine HAVE_UTIME
 #cmakedefine HAVE_UTIME_H
 #cmakedefine HAVE_UTIMES

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -10,10 +10,6 @@
 #include "nvim/os/os.h"
 #include "nvim/os/time.h"
 
-#ifdef HAVE_UNISTD_H
-# include <unistd.h>
-#endif
-
 #define USR_LOG_FILE "$HOME" _PATHSEPSTR ".nvimlog"
 
 static uv_mutex_t mutex;

--- a/src/nvim/os/unix_defs.h
+++ b/src/nvim/os/unix_defs.h
@@ -2,7 +2,7 @@
 #define NVIM_OS_UNIX_DEFS_H
 
 // Windows doesn't have unistd.h, so we include it here to avoid numerous
-// instances of `#ifdef HAVE_UNISTD_H'.
+// instances of `#ifdef WIN32'.
 #include <unistd.h>
 
 // POSIX.1-2008 says that NAME_MAX should be in here

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -6,9 +6,6 @@
 #include <inttypes.h>
 #include <errno.h>
 #include <fcntl.h>
-#ifdef HAVE_UNISTD_H
-# include <unistd.h>
-#endif
 #include <assert.h>
 
 #include <msgpack.h>


### PR DESCRIPTION
Unix systems must have this header but Windows does not have it at all.

Since `src/nvim/os/unix_defs.h` includes this we do not need to have this in all source files.

Remove the only two instances of this guard.
