### PR TITLE
[RFC] fix YouCompleteMe db path in config

### DIFF
--- a/contrib/YouCompleteMe/ycm_extra_conf.py
+++ b/contrib/YouCompleteMe/ycm_extra_conf.py
@@ -9,7 +9,7 @@ def DirectoryOfThisScript():
 
 def GetDatabase():
     compilation_database_folder = os.path.join(DirectoryOfThisScript(),
-                                               '..', '..', 'build')
+                                               '..', 'build')
     if os.path.exists(compilation_database_folder):
         return ycm_core.CompilationDatabase(compilation_database_folder)
     return None


### PR DESCRIPTION
The instructions in the readme indicate the config should be places in `src/`, but the config was modified a few commits ago to try to get to the `build/` dir by going two up, instead of one up. This change fixes the YCM config to work in the `src/` dir by having it get to `../build/`.

This is also consistent with the code on line 32 of this file, which falls back to `./nvim/main.c`, which is a relative path from `src/`, not `src/nvim/`.
