### PR TITLE
[RFC] Defer setting CMAKE_BUILD_TYPE CACHE property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,16 +40,16 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   set(USE_FNAME_CASE TRUE)
 endif()
 
-# Set available build types for CMake GUIs.
-# A different build type can still be set by -DCMAKE_BUILD_TYPE=...
-set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
-  STRINGS "Debug" "Dev" "Release" "MinSizeRel" "RelWithDebInfo")
-
 # Set default build type.
 if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "CMAKE_BUILD_TYPE not given, defaulting to 'Dev'.")
   set(CMAKE_BUILD_TYPE "Dev" CACHE STRING "Choose the type of build." FORCE)
 endif()
+
+# Set available build types for CMake GUIs.
+# A different build type can still be set by -DCMAKE_BUILD_TYPE=...
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
+  STRINGS "Debug" "Dev" "Release" "MinSizeRel" "RelWithDebInfo")
 
 # If not in a git repo (e.g., a tarball) these tokens define the complete
 # version string, else it is combined with the result of `git describe`.


### PR DESCRIPTION
Cherry picked from #810. From equalsraf@dc64f5f.

I have no idea why but it CMake won't configure otherwise.
