### PR TITLE
[RFC] python: Add missing I/O methods to RedirectStream

### DIFF
--- a/runtime/autoload/provider/script_host.py
+++ b/runtime/autoload/provider/script_host.py
@@ -1,5 +1,6 @@
 """Legacy python/python3-vim emulation."""
 import imp
+import io
 import logging
 import os
 import sys
@@ -151,7 +152,7 @@ class ScriptHost(object):
         current.range = current.buffer.range(start, stop)
 
 
-class RedirectStream(object):
+class RedirectStream(io.IOBase):
     def __init__(self, redirect_handler):
         self.redirect_handler = redirect_handler
 
@@ -160,9 +161,6 @@ class RedirectStream(object):
 
     def writelines(self, seq):
         self.redirect_handler('\n'.join(seq))
-
-    def flush(self):
-        pass
 
 
 class LegacyEvalHook(neovim.SessionHook):


### PR DESCRIPTION
`RedirectStream` is used to redirect `stdout` and `stderr`, but are
missing certain I/O methods available on other file-like objects.
This causes external plugins (like `colorama`) to crash.

Inheriting from [`io.IOBase`](https://docs.python.org/3/library/io.html#io.IOBase) adds an abstract implementation of these
methods, which will at least keep the python code running.

Fixes #4045
