### PR TITLE
[RFC] buffer.c: Set valid curbuf after closing buffer

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -444,6 +444,9 @@ close_buffer (
     else
       buf->b_next->b_prev = buf->b_prev;
     free_buffer(buf);
+    if (!autocmd_busy && curbuf == buf) {
+      curbuf = firstbuf;
+    }
   } else {
     if (del_buf) {
       /* Free all internal variables and reset option values, to make


### PR DESCRIPTION
buffer.c: Set valid curbuf after closing buffer

After calling close_buffer(), curbuf can point to an already freed
buffer. Set it to firstbuf in this case.

This problem was found when using nvim with ASAN and
`nvim -u NONE -i NONE +"helpgrep quickfix" +copen +cclose`:

``` c
==13325==ERROR: AddressSanitizer: heap-use-after-free on address 0x6260000443aa at pc 0x0000015062ce bp 0x7ffdc2013950 sp 0x7ffdc2013948
READ of size 1 at 0x6260000443aa thread T0
    #0 0x15062cd in only_one_window /home/oni-link/git/neovim/src/nvim/window.c:5066:49
    #1 0x14cd472 in win_close /home/oni-link/git/neovim/src/nvim/window.c:1915:7
    #2 0x112f0b3 in ex_cclose /home/oni-link/git/neovim/src/nvim/quickfix.c:2016:5
    #3 0x13774f0 in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2192:5
    #4 0x1355ced in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:602:20
    #5 0x135bfe5 in do_cmdline_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:274:10
    #6 0xfa7601 in exe_commands /home/oni-link/git/neovim/src/nvim/main.c:1558:5
    #7 0xf94eaf in main /home/oni-link/git/neovim/src/nvim/main.c:490:5
    #8 0x7fdb8a69972f in __libc_start_main (/lib64/libc.so.6+0x2072f)
    #9 0x4430c8 in _start (/home/oni-link/git/neovim/build/bin/nvim+0x4430c8)

0x6260000443aa is located 8874 bytes inside of 10064-byte region [0x626000042100,0x626000044850)
freed by thread T0 here:
    #0 0x4e3070 in __interceptor_cfree.localalias.1 /home/oni-link/git/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:45
    #1 0xadd2e4 in xfree /home/oni-link/git/neovim/src/nvim/memory.c:105:3
    #2 0xbd19f5 in free_buffer /home/oni-link/git/neovim/src/nvim/buffer.c:568:5
    #3 0xbca634 in close_buffer /home/oni-link/git/neovim/src/nvim/buffer.c:446:5
    #4 0x14cd33c in win_close /home/oni-link/git/neovim/src/nvim/window.c:1910:5
    #5 0x112f0b3 in ex_cclose /home/oni-link/git/neovim/src/nvim/quickfix.c:2016:5
    #6 0x13774f0 in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2192:5
    #7 0x1355ced in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:602:20
    #8 0x135bfe5 in do_cmdline_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:274:10
    #9 0xfa7601 in exe_commands /home/oni-link/git/neovim/src/nvim/main.c:1558:5
    #10 0xf94eaf in main /home/oni-link/git/neovim/src/nvim/main.c:490:5
    #11 0x7fdb8a69972f in __libc_start_main (/lib64/libc.so.6+0x2072f)

previously allocated by thread T0 here:
    #0 0x4e3380 in calloc /home/oni-link/git/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:66
    #1 0xadd382 in xcalloc /home/oni-link/git/neovim/src/nvim/memory.c:119:15
    #2 0xbd958d in buflist_new /home/oni-link/git/neovim/src/nvim/buffer.c:1387:11
    #3 0xb811fa in do_ecmd /home/oni-link/git/neovim/src/nvim/ex_cmds.c:2101:13
    #4 0x1130f90 in ex_copen /home/oni-link/git/neovim/src/nvim/quickfix.c:2097:13
    #5 0x13774f0 in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2192:5
    #6 0x1355ced in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:602:20
    #7 0x135bfe5 in do_cmdline_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:274:10
    #8 0xfa7601 in exe_commands /home/oni-link/git/neovim/src/nvim/main.c:1558:5
    #9 0xf94eaf in main /home/oni-link/git/neovim/src/nvim/main.c:490:5
    #10 0x7fdb8a69972f in __libc_start_main (/lib64/libc.so.6+0x2072f)

SUMMARY: AddressSanitizer: heap-use-after-free /home/oni-link/git/neovim/src/nvim/window.c:5066:49 in only_one_window

```
