### PR TITLE
[RFC] vim-patch:5837f1f

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1,4 +1,4 @@
-*pattern.txt*   For Vim version 7.4.  Last change: 2015 Feb 17
+*pattern.txt*   For Vim version 7.4.  Last change: 2015 Mar 16
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1052,7 +1052,10 @@ x	A single character, with no special meaning, matches itself
 								*E769*
 	When the ']' is not there Vim will not give an error message but
 	assume no collection is used.  Useful to search for '['.  However, you
-	do get E769 for internal searching.
+	do get E769 for internal searching.  And be aware that in a
+	`:substitute` command the whole command becomes the pattern.  E.g.
+	":s/[/x/" searches for "[/x" and replaces it with nothing.  It does
+	not search for "[" and replaces it with "x"!
 
 	If the sequence begins with "^", it matches any single character NOT
 	in the collection: "[^xyz]" matches anything but 'x', 'y' and 'z'.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 7.4.  Last change: 2015 Feb 22
+*syntax.txt*	For Vim version 7.4.  Last change: 2015 Mar 20
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -4631,6 +4631,8 @@ ctermbg={color-nr}				*highlight-ctermbg*
 
 	Note that for some color terminals these names may result in the wrong
 	colors!
+
+	You can also use "NONE" to remove the color.
 
 							*:hi-normal-cterm*
 	When setting the "ctermfg" or "ctermbg" colors for the Normal group,

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2015 Jan 14
+" Last Change:	2015 Mar 13
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")
@@ -1262,8 +1262,8 @@ au BufNewFile,BufRead */etc/modules.conf,*/etc/modules,*/etc/conf.modules setf m
 " Mplayer config
 au BufNewFile,BufRead mplayer.conf,*/.mplayer/config	setf mplayerconf
 
-" Moterola S record
-au BufNewFile,BufRead *.s19,*.s28,*.s37		setf srec
+" Motorola S record
+au BufNewFile,BufRead *.s19,*.s28,*.s37,*.mot,*.srec	setf srec
 
 " Mrxvtrc
 au BufNewFile,BufRead mrxvtrc,.mrxvtrc		setf mrxvtrc

--- a/runtime/syntax/hex.vim
+++ b/runtime/syntax/hex.vim
@@ -1,7 +1,29 @@
 " Vim syntax file
-" Language:	Intel hex MCS51
-" Maintainer:	Sams Ricahrd <sams@ping.at>
-" Last Change:	2003 Apr 25
+" Language:	Intel HEX
+" Maintainer:	Markus Heidelberg <markus.heidelberg@web.de>
+" Previous version:	Sams Ricahrd <sams@ping.at>
+" Last Change:	2015 Feb 24
+
+" Each record (line) is built as follows:
+"
+"    field       digits          states
+"
+"  +----------+
+"  | start    |  1 (':')         hexRecStart
+"  +----------+
+"  | count    |  2               hexDataByteCount
+"  +----------+
+"  | address  |  4               hexNoAddress, hexDataAddress, (hexAddressFieldUnknown)
+"  +----------+
+"  | type     |  2               hexRecType, (hexRecTypeUnknown)
+"  +----------+
+"  | data     |  0..510          hexDataOdd, hexDataEven, hexExtendedAddress, hexStartAddress, (hexDataFieldUnknown, hexDataUnexpected)
+"  +----------+
+"  | checksum |  2               hexChecksum
+"  +----------+
+"
+" States in parentheses in the upper format description indicate that they
+" should not appear in a valid file.
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
@@ -11,21 +33,39 @@ elseif exists("b:current_syntax")
   finish
 endif
 
-syn case ignore
+syn match hexRecStart "^:"
 
-" storage types
+syn match hexDataByteCount "^:[0-9a-fA-F]\{2}" contains=hexRecStart nextgroup=hexAddress
 
-syn match hexChecksum	"[0-9a-fA-F]\{2}$"
-syn match hexAdress  "^:[0-9a-fA-F]\{6}" contains=hexDataByteCount
-syn match hexRecType  "^:[0-9a-fA-F]\{8}" contains=hexAdress
-syn match hexDataByteCount  contained "^:[0-9a-fA-F]\{2}" contains=hexStart
-syn match hexStart contained "^:"
-syn match hexExtAdrRec "^:02000002[0-9a-fA-F]\{4}" contains=hexSpecRec
-syn match hexExtLinAdrRec "^:02000004[0-9a-fA-F]\{4}" contains=hexSpecRec
-syn match hexSpecRec contained "^:0[02]00000[124]" contains=hexStart
-syn match hexEOF "^:00000001" contains=hexStart
+syn match hexAddress "[0-9a-fA-F]\{4}" transparent contained nextgroup=hexRecTypeUnknown,hexRecType
+" The address field groups include the record type field in the last 2
+" characters, the proper match for highlighting follows below.
+syn match hexAddressFieldUnknown "^:[0-9a-fA-F]\{8}"      contains=hexDataByteCount nextgroup=hexDataFieldUnknown,hexChecksum
+syn match hexDataAddress         "^:[0-9a-fA-F]\{6}00"    contains=hexDataByteCount nextgroup=hexDataOdd,hexChecksum
+syn match hexNoAddress           "^:[0-9a-fA-F]\{6}01"    contains=hexDataByteCount nextgroup=hexDataUnexpected,hexChecksum
+syn match hexNoAddress           "^:[0-9a-fA-F]\{6}0[24]" contains=hexDataByteCount nextgroup=hexExtendedAddress
+syn match hexNoAddress           "^:[0-9a-fA-F]\{6}0[35]" contains=hexDataByteCount nextgroup=hexStartAddress
 
-syn case match
+syn match hexRecTypeUnknown "[0-9a-fA-F]\{2}" contained
+syn match hexRecType        "0[0-5]"          contained
+
+syn match hexDataFieldUnknown "[0-9a-fA-F]\{2}" contained nextgroup=hexDataFieldUnknown,hexChecksum
+" alternating highlight per byte for easier reading
+syn match hexDataOdd          "[0-9a-fA-F]\{2}" contained nextgroup=hexDataEven,hexChecksum
+syn match hexDataEven         "[0-9a-fA-F]\{2}" contained nextgroup=hexDataOdd,hexChecksum
+" data bytes which should not exist
+syn match hexDataUnexpected   "[0-9a-fA-F]\{2}" contained nextgroup=hexDataUnexpected,hexChecksum
+" Data digit pair regex usage also results in only highlighting the checksum
+" if the number of data characters is even.
+
+" special data fields
+syn match hexExtendedAddress "[0-9a-fA-F]\{4}" contained nextgroup=hexDataUnexpected,hexChecksum
+syn match hexStartAddress    "[0-9a-fA-F]\{8}" contained nextgroup=hexDataUnexpected,hexChecksum
+
+syn match hexChecksum "[0-9a-fA-F]\{2}$" contained
+
+" Folding Data Records below an Extended Segment/Linear Address Record
+syn region hexExtAdrBlock start="^:[0-9a-fA-F]\{7}[24]" skip="^:[0-9a-fA-F]\{7}0" end="^:"me=s-1 fold transparent
 
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already
@@ -38,16 +78,21 @@ if version >= 508 || !exists("did_hex_syntax_inits")
     command -nargs=+ HiLink hi def link <args>
   endif
 
-  " The default methods for highlighting.  Can be overridden later
-  HiLink hexStart		SpecialKey
-  HiLink hexDataByteCount	Constant
-  HiLink hexAdress		Comment
-  HiLink hexRecType		WarningMsg
-  HiLink hexChecksum		Search
-  HiLink hexExtAdrRec		hexAdress
-  HiLink hexEOF			hexSpecRec
-  HiLink hexExtLinAdrRec	hexAdress
-  HiLink hexSpecRec		DiffAdd
+  " The default methods for highlighting. Can be overridden later
+  HiLink hexRecStart            hexRecType
+  HiLink hexDataByteCount       Constant
+  hi def hexAddressFieldUnknown term=italic cterm=italic gui=italic
+  HiLink hexDataAddress         Comment
+  HiLink hexNoAddress           DiffAdd
+  HiLink hexRecTypeUnknown      hexRecType
+  HiLink hexRecType             WarningMsg
+  hi def hexDataFieldUnknown    term=italic cterm=italic gui=italic
+  hi def hexDataOdd             term=bold cterm=bold gui=bold
+  hi def hexDataEven            term=NONE cterm=NONE gui=NONE
+  HiLink hexDataUnexpected      Error
+  HiLink hexExtendedAddress     hexDataAddress
+  HiLink hexStartAddress        hexDataAddress
+  HiLink hexChecksum            DiffChange
 
   delcommand HiLink
 endif

--- a/runtime/syntax/srec.vim
+++ b/runtime/syntax/srec.vim
@@ -1,0 +1,96 @@
+" Vim syntax file
+" Language:	Motorola S-Record
+" Maintainer:	Markus Heidelberg <markus.heidelberg@web.de>
+" Last Change:	2015 Feb 24
+
+" Each record (line) is built as follows:
+"
+"    field       digits          states
+"
+"  +----------+
+"  | start    |  1 ('S')         srecRecStart
+"  +----------+
+"  | type     |  1               srecRecType, (srecRecTypeUnknown)
+"  +----------+
+"  | count    |  2               srecByteCount
+"  +----------+
+"  | address  |  4/6/8           srecNoAddress, srecDataAddress, srecRecCount, srecStartAddress, (srecAddressFieldUnknown)
+"  +----------+
+"  | data     |  0..504/502/500  srecDataOdd, srecDataEven, (srecDataUnexpected)
+"  +----------+
+"  | checksum |  2               srecChecksum
+"  +----------+
+"
+" States in parentheses in the upper format description indicate that they
+" should not appear in a valid file.
+
+" For version 5.x: Clear all syntax items
+" For version 6.x: Quit when a syntax file was already loaded
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
+endif
+
+syn match srecRecStart "^S"
+
+syn match srecRecTypeUnknown "^S."        contains=srecRecStart
+syn match srecRecType        "^S[0-35-9]" contains=srecRecStart
+
+syn match srecByteCount "^S.[0-9a-fA-F]\{2}"        contains=srecRecTypeUnknown nextgroup=srecAddressFieldUnknown,srecChecksum
+syn match srecByteCount "^S[0-35-9][0-9a-fA-F]\{2}" contains=srecRecType
+
+syn match srecAddressFieldUnknown "[0-9a-fA-F]\{2}" contained nextgroup=srecAddressFieldUnknown,srecChecksum
+
+syn match srecNoAddress    "^S0[0-9a-fA-F]\{6}"  contains=srecByteCount nextgroup=srecDataOdd,srecChecksum
+syn match srecDataAddress  "^S1[0-9a-fA-F]\{6}"  contains=srecByteCount nextgroup=srecDataOdd,srecChecksum
+syn match srecDataAddress  "^S2[0-9a-fA-F]\{8}"  contains=srecByteCount nextgroup=srecDataOdd,srecChecksum
+syn match srecDataAddress  "^S3[0-9a-fA-F]\{10}" contains=srecByteCount nextgroup=srecDataOdd,srecChecksum
+syn match srecRecCount     "^S5[0-9a-fA-F]\{6}"  contains=srecByteCount nextgroup=srecDataUnexpected,srecChecksum
+syn match srecRecCount     "^S6[0-9a-fA-F]\{8}"  contains=srecByteCount nextgroup=srecDataUnexpected,srecChecksum
+syn match srecStartAddress "^S7[0-9a-fA-F]\{10}" contains=srecByteCount nextgroup=srecDataUnexpected,srecChecksum
+syn match srecStartAddress "^S8[0-9a-fA-F]\{8}"  contains=srecByteCount nextgroup=srecDataUnexpected,srecChecksum
+syn match srecStartAddress "^S9[0-9a-fA-F]\{6}"  contains=srecByteCount nextgroup=srecDataUnexpected,srecChecksum
+
+" alternating highlight per byte for easier reading
+syn match srecDataOdd        "[0-9a-fA-F]\{2}" contained nextgroup=srecDataEven,srecChecksum
+syn match srecDataEven       "[0-9a-fA-F]\{2}" contained nextgroup=srecDataOdd,srecChecksum
+" data bytes which should not exist
+syn match srecDataUnexpected "[0-9a-fA-F]\{2}" contained nextgroup=srecDataUnexpected,srecChecksum
+" Data digit pair regex usage also results in only highlighting the checksum
+" if the number of data characters is even.
+
+syn match srecChecksum "[0-9a-fA-F]\{2}$" contained
+
+" Define the default highlighting.
+" For version 5.7 and earlier: only when not done already
+" For version 5.8 and later: only when an item doesn't have highlighting yet
+if version >= 508 || !exists("did_srec_syntax_inits")
+  if version < 508
+    let did_srec_syntax_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+
+  " The default methods for highlighting. Can be overridden later
+  HiLink srecRecStart            srecRecType
+  HiLink srecRecTypeUnknown      srecRecType
+  HiLink srecRecType             WarningMsg
+  HiLink srecByteCount           Constant
+  hi def srecAddressFieldUnknown term=italic cterm=italic gui=italic
+  HiLink srecNoAddress           DiffAdd
+  HiLink srecDataAddress         Comment
+  HiLink srecRecCount            srecNoAddress
+  HiLink srecStartAddress        srecDataAddress
+  hi def srecDataOdd             term=bold cterm=bold gui=bold
+  hi def srecDataEven            term=NONE cterm=NONE gui=NONE
+  HiLink srecDataUnexpected      Error
+  HiLink srecChecksum            DiffChange
+
+  delcommand HiLink
+endif
+
+let b:current_syntax = "srec"
+
+" vim: ts=8


### PR DESCRIPTION
Update runtime files.

https://github.com/vim/vim/commit/5837f1f447c34628268aab52476a79d57b6a7eaf

Output of `patch -p1 < vim-5837f1f.diff`:

```
patching file runtime/doc/eval.txt
Hunk #1 FAILED at 1.
Hunk #2 FAILED at 1836.
Hunk #3 FAILED at 3671.
3 out of 3 hunks FAILED -- saving rejects to file runtime/doc/eval.txt.rej
can't find file to patch at input line 44
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/netbeans.txt b/runtime/doc/netbeans.txt
|index 82db022..19fe1a0 100644
|--- a/runtime/doc/netbeans.txt
|+++ b/runtime/doc/netbeans.txt
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
2 out of 2 hunks ignored
patching file runtime/doc/pattern.txt
Hunk #2 succeeded at 1052 (offset -8 lines).
patching file runtime/doc/syntax.txt
Hunk #2 succeeded at 4632 (offset -16 lines).
can't find file to patch at input line 109
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/tags b/runtime/doc/tags
|index c08344d..2ac1900 100644
|--- a/runtime/doc/tags
|+++ b/runtime/doc/tags
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
1 out of 1 hunk ignored
can't find file to patch at input line 121
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff --git a/runtime/doc/todo.txt b/runtime/doc/todo.txt
|index 08157be..cbc0e8d 100644
|--- a/runtime/doc/todo.txt
|+++ b/runtime/doc/todo.txt
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
6 out of 6 hunks ignored
patching file runtime/filetype.vim
Hunk #2 succeeded at 1262 (offset -5 lines).
patching file runtime/syntax/hex.vim
patching file runtime/syntax/srec.vim
```
## Rejected hunks
### runtime/doc/eval.txt

``` diff
@@ -1,4 +1,4 @@
-*eval.txt* For Vim version 7.4.  Last change: 2015 Mar 05
+*eval.txt* For Vim version 7.4.  Last change: 2015 Mar 21


          VIM REFERENCE MANUAL    by Bram Moolenaar
```

Diagnosis: There have been more recent changes.
Solution: Discard this hunk.

``` diff
@@ -1836,6 +1836,7 @@ getwinvar( {nr}, {varname} [, {def}])
                any variable {varname} in window {nr}
 glob( {expr} [, {nosuf} [, {list} [, {alllinks}]]])
                any expand file wildcards in {expr}
+glob2regpat( {expr})       String  convert a glob pat into a search pat
 globpath( {path}, {expr} [, {nosuf} [, {list} [, {alllinks}]]])
                String  do glob({expr}) for all dirs in {path}
 has( {feature})            Number  TRUE if feature {feature} supported
```

Diagnosis: This has already been merged with 59784b91dbf97388281c1eb6989e2e770eb7ecac.
Solution: Discard this hunk.

``` diff
@@ -3671,6 +3672,14 @@ glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])   *glob()*
        See |expand()| for expanding special Vim variables.  See
        |system()| for getting the raw output of an external command.

+glob2regpat({expr})                     *glob2regpat()*
+       Convert a file pattern, as used by glob(), into a search
+       pattern.  The result can be used to match with a string that
+       is a file name.  E.g. >
+           if filename =~ glob2regpat('Make*.mak')
+<      This is equivalent to: >
+           if filename =~ '^Make.*\.mak$'
+<
                                *globpath()*
 globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])
        Perform glob() on all directories in {path} and concatenate
```

Diagnosis: Ditto.
Solution: Discard this hunk.
