### PR TITLE
[RFC] vim-patch:7.4.680

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -444,7 +444,7 @@ static int included_patches[] = {
   // 683 NA
   682,
   // 681 NA
-  // 680,
+  680,
   // 679 NA
   // 678 NA
   // 677 NA

--- a/test/functional/legacy/erasebackword_spec.lua
+++ b/test/functional/legacy/erasebackword_spec.lua
@@ -1,0 +1,24 @@
+-- Test for CTRL-W in Insert mode
+
+local helpers = require('test.functional.helpers')
+local clear, feed, expect = helpers.clear, helpers.feed, helpers.expect
+
+describe('CTRL-W in Insert mode', function()
+  setup(clear)
+
+  it('works for multi-byte characters', function()
+
+    for i = 1, 6 do
+      feed('o wwwこんにちわ世界ワールドvim ' .. string.rep('<C-w>', i) .. '<esc>')
+    end
+
+    expect([[
+      
+       wwwこんにちわ世界ワールド
+       wwwこんにちわ世界
+       wwwこんにちわ
+       www
+       
+      ]])
+  end)
+end)


### PR DESCRIPTION
```
Problem:    CTRL-W in Insert mode does not work well for multi-byte
            characters.
Solution:   Use mb_get_class(). (Yasuhiro Matsumoto)
```

https://github.com/vim/vim/commit/310f2d59b2b20c642088feb5e6dfe323cc570923

```
Add test files for patch 7.4.680.
```

https://github.com/vim/vim/commit/dbcf19dc498cb1561c9215a3f255e81cde0c0543
