### PR TITLE
[WIP] vim-patch:7.4.613

### DIFF
--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -4846,10 +4846,12 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
   /* Some patterns may take a long time to match, especially when using
    * recursive_regmatch(). Allow interrupting them with CTRL-C. */
   fast_breakcheck();
-  if (got_int)
-    return FALSE;
-  if (nfa_time_limit != NULL && profile_passed_limit(*nfa_time_limit))
-      return FALSE;
+  if (got_int) {
+    return FALSE;  // NOLINT(readability/bool)
+  }
+  if (nfa_time_limit != NULL && profile_passed_limit(*nfa_time_limit)) {
+      return FALSE;  // NOLINT(readability/bool)
+  }
 
   nfa_match = FALSE;
 
@@ -6074,8 +6076,9 @@ nextchar:
     }
     if (nfa_time_limit != NULL && ++nfa_time_count == 20) {
       nfa_time_count = 0;
-      if (profile_passed_limit(*nfa_time_limit))
+      if (profile_passed_limit(*nfa_time_limit)) {
         break;
+      }
     }
   }
 
@@ -6220,8 +6223,8 @@ static long nfa_regtry(nfa_regprog_T *prog, colnr_T col, proftime_T *tm)
 static long 
 nfa_regexec_both (
     char_u *line,
-    colnr_T startcol               /* column to start looking for match */,
-    proftime_T *tm                 /* timeout limit or NULL */
+    colnr_T startcol,              // column to start looking for match
+    proftime_T *tm                 // timeout limit or NULL
 )
 {
   nfa_regprog_T   *prog;

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -3466,6 +3466,8 @@ static char *pim_info(nfa_pim_T *pim)
 
 /* Used during execution: whether a match has been found. */
 static int nfa_match;
+static proftime_T *nfa_time_limit;
+static int nfa_time_count;
 
 
 /*
@@ -4846,6 +4848,8 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
   fast_breakcheck();
   if (got_int)
     return FALSE;
+  if (nfa_time_limit != NULL && profile_passed_limit(*nfa_time_limit))
+      return FALSE;
 
   nfa_match = FALSE;
 
@@ -6064,9 +6068,14 @@ nextchar:
       break;
 
     // Allow interrupting with CTRL-C.
-    fast_breakcheck();
+    line_breakcheck();
     if (got_int) {
       break;
+    }
+    if (nfa_time_limit != NULL && ++nfa_time_count == 20) {
+      nfa_time_count = 0;
+      if (profile_passed_limit(*nfa_time_limit))
+        break;
     }
   }
 
@@ -6093,7 +6102,7 @@ theend:
  * Try match of "prog" with at regline["col"].
  * Returns <= 0 for failure, number of lines contained in the match otherwise.
  */
-static long nfa_regtry(nfa_regprog_T *prog, colnr_T col)
+static long nfa_regtry(nfa_regprog_T *prog, colnr_T col, proftime_T *tm)
 {
   int i;
   regsubs_T subs, m;
@@ -6103,6 +6112,9 @@ static long nfa_regtry(nfa_regprog_T *prog, colnr_T col)
 #endif
 
   reginput = regline + col;
+
+  nfa_time_limit = tm;
+  nfa_time_count = 0;
 
 #ifdef REGEXP_DEBUG
   f = fopen(NFA_REGEXP_RUN_LOG, "a");
@@ -6208,7 +6220,8 @@ static long nfa_regtry(nfa_regprog_T *prog, colnr_T col)
 static long 
 nfa_regexec_both (
     char_u *line,
-    colnr_T startcol               /* column to start looking for match */
+    colnr_T startcol               /* column to start looking for match */,
+    proftime_T *tm                 /* timeout limit or NULL */
 )
 {
   nfa_regprog_T   *prog;
@@ -6289,7 +6302,7 @@ nfa_regexec_both (
     prog->state[i].lastlist[1] = 0;
   }
 
-  retval = nfa_regtry(prog, col);
+  retval = nfa_regtry(prog, col, tm);
 
   nfa_regengine.expr = NULL;
 
@@ -6441,7 +6454,7 @@ nfa_regexec_nl (
   ireg_ic = rmp->rm_ic;
   ireg_icombine = FALSE;
   ireg_maxcol = 0;
-  return nfa_regexec_both(line, col);
+  return nfa_regexec_both(line, col, NULL);
 }
 
 /// Matches a regexp against multiple lines.
@@ -6492,5 +6505,5 @@ static long nfa_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf,
   ireg_icombine = FALSE;
   ireg_maxcol = rmp->rmm_maxcol;
 
-  return nfa_regexec_both(NULL, col);
+  return nfa_regexec_both(NULL, col, tm);
 }

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -6074,6 +6074,7 @@ nextchar:
     if (got_int) {
       break;
     }
+    // Check for timeout once in a twenty times to avoid overhead.
     if (nfa_time_limit != NULL && ++nfa_time_count == 20) {
       nfa_time_count = 0;
       if (profile_passed_limit(*nfa_time_limit)) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -511,7 +511,7 @@ static int included_patches[] = {
   616,
   615,
   614,
-  // 613,
+  613,
   612,
   // 611 NA
   // 610 NA


### PR DESCRIPTION
Problem:    The NFA engine does not implement the 'redrawtime' time limit.
Solution:    Implement the time limit.

vim/vim@70781ee
