### PR TITLE
[RFC] vim-patch:7.4.642

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1340,6 +1340,7 @@ void free_findfile(void)
  *
  * options:
  * FNAME_MESS	    give error message when not found
+ * FNAME_UNESC      unescape backslashes
  *
  * Uses NameBuff[]!
  *
@@ -1385,6 +1386,14 @@ find_file_in_path_option (
 
     xfree(ff_file_to_find);
     ff_file_to_find = vim_strsave(NameBuff);
+    if (options & FNAME_UNESC) {
+      // Change all "\ " to " ".
+      for (ptr = ff_file_to_find; *ptr != NUL; ++ptr) {
+        if (ptr[0] == '\\' && ptr[1] == ' ') {
+          memmove(ptr, ptr + 1, STRLEN(ptr));
+        }
+      }
+    }
   }
 
   rel_to_curdir = (ff_file_to_find[0] == '.'

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -482,7 +482,7 @@ static int included_patches[] = {
   645,
   // 644 NA
   // 643,
-  // 642,
+  642,
   // 641 NA
   640,
   // 639,

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4923,10 +4923,11 @@ file_name_in_line (
       // Skip over the "\" in "\ ".
       ++len;
     }
-    if (has_mbyte)
+    if (has_mbyte) {
       len += (size_t)(*mb_ptr2len)(ptr + len);
-    else
+    } else {
       ++len;
+    }
   }
 
   /*

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4837,16 +4837,15 @@ static void frame_add_height(frame_T *frp, int n)
  */
 char_u *grab_file_name(long count, linenr_T *file_lnum)
 {
-  int options = FNAME_MESS|FNAME_EXP|FNAME_REL|FNAME_UNESC;
+  int options = FNAME_MESS | FNAME_EXP | FNAME_REL | FNAME_UNESC;
   if (VIsual_active) {
     size_t len;
     char_u  *ptr;
     if (get_visual_text(NULL, &ptr, &len) == FAIL)
       return NULL;
-    return find_file_name_in_path(ptr, len, options,
-                                  count, curbuf->b_ffname);
+    return find_file_name_in_path(ptr, len, options, count, curbuf->b_ffname);
   }
-  return file_name_at_cursor(options|FNAME_HYP, count, file_lnum);
+  return file_name_at_cursor(options | FNAME_HYP, count, file_lnum);
 }
 
 /*

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4918,7 +4918,7 @@ file_name_in_line (
   len = 0;
   while (vim_isfilec(ptr[len]) || (ptr[len] == '\\' && ptr[len + 1] == ' ')
          || ((options & FNAME_HYP) && path_is_url((char *)ptr + len))) {
-    if (ptr[len] == '\\') {
+    if (ptr[len] == '\\' && ptr[len + 1] == ' ') {
       // Skip over the "\" in "\ ".
       ++len;
     }

--- a/src/nvim/window.h
+++ b/src/nvim/window.h
@@ -10,7 +10,7 @@
 #define FNAME_INCL      8       /* apply 'includeexpr' */
 #define FNAME_REL       16      /* ".." and "./" are relative to the (current)
                                    file instead of the current directory */
-#define FNAME_UNESC     32      /* remove backslashes used for escaping */
+#define FNAME_UNESC     32      // remove backslashes used for escaping
 
 /*
  * arguments for win_split()

--- a/src/nvim/window.h
+++ b/src/nvim/window.h
@@ -10,6 +10,7 @@
 #define FNAME_INCL      8       /* apply 'includeexpr' */
 #define FNAME_REL       16      /* ".." and "./" are relative to the (current)
                                    file instead of the current directory */
+#define FNAME_UNESC     32      /* remove backslashes used for escaping */
 
 /*
  * arguments for win_split()


### PR DESCRIPTION
Problem:    When using "gf" escaped spaces are not handled.
Solution:   Recognize escaped spaces.

https://github.com/vim/vim/commit/d45c07ac7499358c5cb096cadb675ce74ae3eaf6
