### PR TITLE
[RFC] vim-patch:7.4.654

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7188,9 +7188,9 @@ static struct fst {
   { "getwinposx",        0, 0, f_getwinposx },
   { "getwinposy",        0, 0, f_getwinposy },
   { "getwinvar",         2, 3, f_getwinvar },
-  { "glob",              1, 3, f_glob },
+  { "glob",              1, 4, f_glob },
   { "glob2regpat",       1, 1, f_glob2regpat },
-  { "globpath",          2, 4, f_globpath },
+  { "globpath",          2, 5, f_globpath },
   { "has",               1, 1, f_has },
   { "has_key",           2, 2, f_has_key },
   { "haslocaldir",       0, 0, f_haslocaldir },
@@ -10701,10 +10701,15 @@ static void f_glob(typval_T *argvars, typval_T *rettv)
   if (argvars[1].v_type != VAR_UNKNOWN) {
     if (get_tv_number_chk(&argvars[1], &error))
       options |= WILD_KEEP_ALL;
-    if (argvars[2].v_type != VAR_UNKNOWN
-        && get_tv_number_chk(&argvars[2], &error)) {
-      rettv->v_type = VAR_LIST;
-      rettv->vval.v_list = NULL;
+    if (argvars[2].v_type != VAR_UNKNOWN) {
+      if (get_tv_number_chk(&argvars[2], &error)) {
+        rettv->v_type = VAR_LIST;
+        rettv->vval.v_list = NULL;
+      }
+      if (argvars[3].v_type != VAR_UNKNOWN
+          && get_tv_number_chk(&argvars[3], &error)) {
+        options |= WILD_ALLLINKS;
+      }
     }
   }
   if (!error) {
@@ -10743,10 +10748,15 @@ static void f_globpath(typval_T *argvars, typval_T *rettv)
       flags |= WILD_KEEP_ALL;
     }
 
-    if (argvars[3].v_type != VAR_UNKNOWN
-        && get_tv_number_chk(&argvars[3], &error)) {
-      rettv->v_type = VAR_LIST;
-      rettv->vval.v_list = NULL;
+    if (argvars[3].v_type != VAR_UNKNOWN) {
+      if (get_tv_number_chk(&argvars[3], &error)) {
+        rettv->v_type = VAR_LIST;
+        rettv->vval.v_list = NULL;
+      }
+      if (argvars[4].v_type != VAR_UNKNOWN
+          && get_tv_number_chk(&argvars[4], &error)) {
+        flags |= WILD_ALLLINKS;
+      }
     }
   }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3701,6 +3701,9 @@ ExpandFromContext (
     flags |= EW_KEEPALL;
   if (options & WILD_SILENT)
     flags |= EW_SILENT;
+  if (options & WILD_ALLLINKS) {
+    flags |= EW_ALLLINKS;
+  }
 
   if (xp->xp_context == EXPAND_FILES
       || xp->xp_context == EXPAND_DIRECTORIES

--- a/src/nvim/ex_getln.h
+++ b/src/nvim/ex_getln.h
@@ -14,15 +14,16 @@
 #define WILD_LONGEST            7
 #define WILD_ALL_KEEP           8
 
-#define WILD_LIST_NOTFOUND      1
-#define WILD_HOME_REPLACE       2
-#define WILD_USE_NL             4
-#define WILD_NO_BEEP            8
-#define WILD_ADD_SLASH          16
-#define WILD_KEEP_ALL           32
-#define WILD_SILENT             64
-#define WILD_ESCAPE             128
-#define WILD_ICASE              256
+#define WILD_LIST_NOTFOUND      0x01
+#define WILD_HOME_REPLACE       0x02
+#define WILD_USE_NL             0x04
+#define WILD_NO_BEEP            0x08
+#define WILD_ADD_SLASH          0x10
+#define WILD_KEEP_ALL           0x20
+#define WILD_SILENT             0x40
+#define WILD_ESCAPE             0x80
+#define WILD_ICASE              0x100
+#define WILD_ALLLINKS           0x200
 
 /// Present history tables
 typedef enum {

--- a/src/nvim/path.h
+++ b/src/nvim/path.h
@@ -20,6 +20,7 @@
 #define EW_KEEPDOLLAR   0x800   /* do not escape $, $var is expanded */
 /* Note: mostly EW_NOTFOUND and EW_SILENT are mutually exclusive: EW_NOTFOUND
 * is used when executing commands and EW_SILENT for interactive expanding. */
+#define EW_ALLLINKS     0x1000  // also links not pointing to existing file
 
 /// Return value for the comparison of two files. Also @see path_full_compare.
 typedef enum file_comparison {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -470,7 +470,7 @@ static int included_patches[] = {
   // 657 NA
   // 656,
   655,
-  // 654,
+  654,
   653,
   // 652 NA
   651,


### PR DESCRIPTION
Problem:    glob() and globpath() cannot include links to non-existing files.
            (Charles Campbell)
Solution:   Add an argument to include all links with glob(). (James McCoy)
            Also for globpath().

https://github.com/vim/vim/commit/a245bc79b4c6b83a4b5b6cdb95c4d2165762a20b
