### PR TITLE
Use libmsgpackc instead of deprecated libmsgpack

### DIFF
--- a/cmake/FindMsgpack.cmake
+++ b/cmake/FindMsgpack.cmake
@@ -23,13 +23,13 @@ find_path(MSGPACK_INCLUDE_DIR msgpack.h
   HINTS ${PC_MSGPACK_INCLUDEDIR} ${PC_MSGPACK_INCLUDE_DIRS}
   ${LIMIT_SEARCH})
 
-# If we're asked to use static linkage, add libmsgpack.a as a preferred library name.
+# If we're asked to use static linkage, add libmsgpackc.a as a preferred library name.
 if(MSGPACK_USE_STATIC)
   list(APPEND MSGPACK_NAMES
-    "${CMAKE_STATIC_LIBRARY_PREFIX}msgpack${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    "${CMAKE_STATIC_LIBRARY_PREFIX}msgpackc${CMAKE_STATIC_LIBRARY_SUFFIX}")
 endif()
 
-list(APPEND MSGPACK_NAMES msgpack)
+list(APPEND MSGPACK_NAMES msgpackc)
 
 find_library(MSGPACK_LIBRARY NAMES ${MSGPACK_NAMES}
   HINTS ${PC_MSGPACK_LIBDIR} ${PC_MSGPACK_LIBRARY_DIRS}


### PR DESCRIPTION
msgpack 1.4.0 removed deprecated libmsgpack.so library.
Per https://github.com/msgpack/msgpack-c/issues/395#issuecomment-174019730

> neovim should be using libmsgpackc (the C library), not libmsgpack
> (historically the C++ library, but now not relevant since C++ code is all header only).
