### PR TITLE
[RFC] vim-patch:7.4.685

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -4186,7 +4186,7 @@ regmatch (
               /* When only a composing char is given match at any
                * position where that composing char appears. */
               status = RA_NOMATCH;
-              for (i = 0; reginput[i] != NUL; i += utf_char2len(inpc)) {
+              for (i = 0; reginput[i] != NUL; i += utf_ptr2len(reginput + i)) {
                 inpc = mb_ptr2char(reginput + i);
                 if (!utf_iscomposing(inpc)) {
                   if (i > 0)

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -439,7 +439,7 @@ static int included_patches[] = {
   // 688,
   // 687 NA
   686,
-  // 685,
+  685,
   // 684,
   // 683 NA
   682,


### PR DESCRIPTION
```
Problem:    When there are illegal utf-8 characters the old regexp engine may
            go past the end of a string.
Solution:   Only advance to the end of the string. (Dominique Pelle)
```

https://github.com/vim/vim/commit/0e462411cafdd908356792b2c229ab6369103bca

Original patch:

``` diff
commit 0e46241
Author: Bram Moolenaar <Bram@vim.org>
Date:   Tue Mar 31 14:17:31 2015 +0200

    updated for version 7.4.685
    Problem:    When there are illegal utf-8 characters the old regexp engine may
                go past the end of a string.
    Solution:   Only advance to the end of the string. (Dominique Pelle)

diff --git a/src/nvim/regexp.c b/src/nvim/regexp.c
index bae547c..961796b 100644
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -4782,7 +4782,8 @@ regmatch(scan)
            /* When only a composing char is given match at any
             * position where that composing char appears. */
            status = RA_NOMATCH;
-           for (i = 0; reginput[i] != NUL; i += utf_char2len(inpc))
+           for (i = 0; reginput[i] != NUL;
+                       i += utf_ptr2len(reginput + i))
            {
            inpc = mb_ptr2char(reginput + i);
            if (!utf_iscomposing(inpc))
diff --git a/src/nvim/version.c b/src/nvim/version.c
index f4ed01a..6156c37 100644
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    685,
+/**/
     684,
 /**/
     683,
```
