### PR TITLE
[RDY] api/buffer: introduce get/set_lines with more flexible out-of-bounds handling

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -45,6 +45,12 @@ Integer buffer_line_count(Buffer buffer, Error *err)
 
 /// Gets a buffer line
 ///
+/// @deprecated use buffer_get_lines instead.
+///             for positive indices (including 0) use
+///                 "buffer_get_lines(buffer, index, index+1, true)"
+///             for negative indices use
+///                 "buffer_get_lines(buffer, index-1, index, true)"
+///
 /// @param buffer The buffer handle
 /// @param index The line index
 /// @param[out] err Details of an error that may have occurred
@@ -67,6 +73,12 @@ String buffer_get_line(Buffer buffer, Integer index, Error *err)
 
 /// Sets a buffer line
 ///
+/// @deprecated use buffer_set_lines instead.
+///             for positive indices use
+///                 "buffer_set_lines(buffer, index, index+1, true, [line])"
+///             for negative indices use
+///                 "buffer_set_lines(buffer, index-1, index, true, [line])"
+///
 /// @param buffer The buffer handle
 /// @param index The line index
 /// @param line The new line.
@@ -81,6 +93,11 @@ void buffer_set_line(Buffer buffer, Integer index, String line, Error *err)
 
 /// Deletes a buffer line
 ///
+/// @deprecated use buffer_set_lines instead.
+///             for positive indices use
+///                 "buffer_set_lines(buffer, index, index+1, true, [])"
+///             for negative indices use
+///                 "buffer_set_lines(buffer, index-1, index, true, [])"
 /// @param buffer The buffer handle
 /// @param index The line index
 /// @param[out] err Details of an error that may have occurred
@@ -93,6 +110,10 @@ void buffer_del_line(Buffer buffer, Integer index, Error *err)
 
 /// Retrieves a line range from the buffer
 ///
+/// @deprecated use buffer_get_lines(buffer, newstart, newend, false)
+///             where newstart = start + int(not include_start) - int(start < 0)
+///                   newend = end + int(include_end) - int(end < 0)
+///                   int(bool) = 1 if bool is true else 0
 /// @param buffer The buffer handle
 /// @param start The first line index
 /// @param end The last line index
@@ -190,6 +211,11 @@ end:
 
 
 /// Replaces a line range on the buffer
+///
+/// @deprecated use buffer_set_lines(buffer, newstart, newend, false, lines)
+///             where newstart = start + int(not include_start) + int(start < 0)
+///                   newend = end + int(include_end) + int(end < 0)
+///                   int(bool) = 1 if bool is true else 0
 ///
 /// @param buffer The buffer handle
 /// @param start The first line index
@@ -525,6 +551,8 @@ Boolean buffer_is_valid(Buffer buffer)
 }
 
 /// Inserts a sequence of lines to a buffer at a certain index
+///
+/// @deprecated use buffer_set_lines(buffer, lnum, lnum, true, lines)
 ///
 /// @param buffer The buffer handle
 /// @param lnum Insert the lines after `lnum`. If negative, it will append

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -51,8 +51,10 @@ Integer buffer_line_count(Buffer buffer, Error *err)
 /// @return The line string
 String buffer_get_line(Buffer buffer, Integer index, Error *err)
 {
-  String rv = {.size = 0};
-  Array slice = buffer_get_line_slice(buffer, index, index, true, true, err);
+  String rv = { .size = 0 };
+
+  index = convert_index(index);
+  Array slice = buffer_get_lines(buffer, index, index+1, true, err);
 
   if (!err->set && slice.size) {
     rv = slice.items[0].data.string;
@@ -72,8 +74,9 @@ String buffer_get_line(Buffer buffer, Integer index, Error *err)
 void buffer_set_line(Buffer buffer, Integer index, String line, Error *err)
 {
   Object l = STRING_OBJ(line);
-  Array array = {.items = &l, .size = 1};
-  buffer_set_line_slice(buffer, index, index, true, true, array, err);
+  Array array = { .items = &l, .size = 1 };
+  index = convert_index(index);
+  buffer_set_lines(buffer, index, index+1, true,  array, err);
 }
 
 /// Deletes a buffer line
@@ -84,7 +87,8 @@ void buffer_set_line(Buffer buffer, Integer index, String line, Error *err)
 void buffer_del_line(Buffer buffer, Integer index, Error *err)
 {
   Array array = ARRAY_DICT_INIT;
-  buffer_set_line_slice(buffer, index, index, true, true, array, err);
+  index = convert_index(index);
+  buffer_set_lines(buffer, index, index+1, true, array, err);
 }
 
 /// Retrieves a line range from the buffer
@@ -103,16 +107,48 @@ ArrayOf(String) buffer_get_line_slice(Buffer buffer,
                                  Boolean include_end,
                                  Error *err)
 {
+  start = convert_index(start) + !include_start;
+  end = convert_index(end) + include_end;
+  return buffer_get_lines(buffer, start , end, false, err);
+}
+
+
+/// Retrieves a line range from the buffer
+///
+/// Indexing is zero-based, end-exclusive. Negative indices are interpreted
+/// as length+1+index, i e -1 refers to the index past the end. So to get the
+/// last element set start=-2 and end=-1.
+///
+/// Out-of-bounds indices are clamped to the nearest valid value, unless
+/// `strict_indexing` is set.
+///
+/// @param buffer The buffer handle
+/// @param start The first line index
+/// @param end The last line index (exclusive)
+/// @param strict_indexing whether out-of-bounds should be an error.
+/// @param[out] err Details of an error that may have occurred
+/// @return An array of lines
+ArrayOf(String) buffer_get_lines(Buffer buffer,
+                                 Integer start,
+                                 Integer end,
+                                 Boolean strict_indexing,
+                                 Error *err)
+{
   Array rv = ARRAY_DICT_INIT;
   buf_T *buf = find_buffer_by_handle(buffer, err);
 
-  if (!buf || !inbounds(buf, start)) {
+  if (!buf) {
     return rv;
   }
 
-  start = normalize_index(buf, start) + (include_start ? 0 : 1);
-  include_end = include_end || (end >= buf->b_ml.ml_line_count);
-  end = normalize_index(buf, end) + (include_end ? 1 : 0);
+  bool oob = false;
+  start = normalize_index(buf, start, &oob);
+  end = normalize_index(buf, end, &oob);
+
+  if (strict_indexing && oob) {
+    api_set_error(err, Validation, _("Index out of bounds"));
+    return rv;
+  }
 
   if (start >= end) {
     // Return 0-length array
@@ -152,6 +188,7 @@ end:
   return rv;
 }
 
+
 /// Replaces a line range on the buffer
 ///
 /// @param buffer The buffer handle
@@ -170,20 +207,52 @@ void buffer_set_line_slice(Buffer buffer,
                       ArrayOf(String) replacement,
                       Error *err)
 {
+  start = convert_index(start) + !include_start;
+  end = convert_index(end) + include_end;
+  buffer_set_lines(buffer, start, end, false, replacement, err);
+}
+
+
+/// Replaces line range on the buffer
+///
+/// Indexing is zero-based, end-exclusive. Negative indices are interpreted
+/// as length+1+index, i e -1 refers to the index past the end. So to change
+/// or delete the last element set start=-2 and end=-1.
+///
+/// To insert lines at a given index, set both start and end to the same index.
+/// To delete a range of lines, set replacement to an empty array.
+///
+/// Out-of-bounds indices are clamped to the nearest valid value, unless
+/// `strict_indexing` is set.
+///
+/// @param buffer The buffer handle
+/// @param start The first line index
+/// @param end The last line index (exclusive)
+/// @param strict_indexing whether out-of-bounds should be an error.
+/// @param replacement An array of lines to use as replacement
+/// @param[out] err Details of an error that may have occurred
+void buffer_set_lines(Buffer buffer,
+                      Integer start,
+                      Integer end,
+                      Boolean strict_indexing,
+                      ArrayOf(String) replacement,
+                      Error *err)
+{
   buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
     return;
   }
 
-  if (!inbounds(buf, start)) {
+  bool oob = false;
+  start = normalize_index(buf, start, &oob);
+  end = normalize_index(buf, end, &oob);
+
+  if (strict_indexing && oob) {
     api_set_error(err, Validation, _("Index out of bounds"));
     return;
   }
 
-  start = normalize_index(buf, start) + (include_start ? 0 : 1);
-  include_end = include_end || (end >= buf->b_ml.ml_line_count);
-  end = normalize_index(buf, end) + (include_end ? 1 : 0);
 
   if (start > end) {
     api_set_error(err,
@@ -467,8 +536,9 @@ void buffer_insert(Buffer buffer,
                    ArrayOf(String) lines,
                    Error *err)
 {
-  bool end_start = lnum < 0;
-  buffer_set_line_slice(buffer, lnum, lnum, !end_start, end_start, lines, err);
+  // "lnum" will be the index of the line after inserting,
+  // no matter if it is negative or not
+  buffer_set_lines(buffer, lnum, lnum, true, lines, err);
 }
 
 /// Return a tuple (row,col) representing the position of the named mark
@@ -632,20 +702,26 @@ static void fix_cursor(linenr_T lo, linenr_T hi, linenr_T extra)
 }
 
 // Normalizes 0-based indexes to buffer line numbers
-static int64_t normalize_index(buf_T *buf, int64_t index)
+static int64_t normalize_index(buf_T *buf, int64_t index, bool *oob)
 {
+  int64_t line_count = buf->b_ml.ml_line_count;
   // Fix if < 0
-  index = index < 0 ?  buf->b_ml.ml_line_count + index : index;
+  index = index < 0 ? line_count + index +1 : index;
+
+  // Check for oob
+  if (index > line_count) {
+    *oob = true;
+    index = line_count;
+  } else if (index < 0) {
+    *oob = true;
+    index = 0;
+  }
   // Convert the index to a vim line number
   index++;
-  // Fix if > line_count
-  index = index > buf->b_ml.ml_line_count ? buf->b_ml.ml_line_count : index;
   return index;
 }
 
-// Returns true if the 0-indexed `index` is within the 1-indexed buffer bounds.
-static bool inbounds(buf_T *buf, int64_t index)
+static int64_t convert_index(int64_t index)
 {
-  linenr_T nlines = buf->b_ml.ml_line_count;
-  return index >= -nlines && index < nlines;
+  return index < 0 ? index - 1 : index;
 }

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -35,10 +35,11 @@ describe('buffer_* functions', function()
       eq('', curbuf('get_line', 0))
     end)
 
-    it('get_line: out-of-bounds returns empty string', function()
+    it('get_line: out-of-bounds is an error', function()
       curbuf('set_line', 0, 'line1.a')
-      eq('', curbuf('get_line', 1))
-      eq('', curbuf('get_line', -2))
+      eq(1, curbuf('line_count')) -- sanity
+      eq(false, pcall(curbuf, 'get_line', 1))
+      eq(false, pcall(curbuf, 'get_line', -2))
     end)
 
     it('set_line, del_line: out-of-bounds is an error', function()
@@ -68,14 +69,16 @@ describe('buffer_* functions', function()
       eq({}, curbuf('get_line_slice', -4, -5, true, true))
     end)
 
-    it('set_line_slice: out-of-bounds is an error', function()
+    it('set_line_slice: out-of-bounds extends past end', function()
       curbuf('set_line_slice', 0, 0, true, true, {'a', 'b', 'c'})
       eq({'a', 'b', 'c'}, curbuf('get_line_slice', 0, 2, true, true)) --sanity
 
       eq({'c'}, curbuf('get_line_slice', -1, 4, true, true))
       eq({'a', 'b', 'c'}, curbuf('get_line_slice', 0, 5, true, true))
-      eq(false, pcall(curbuf, 'set_line_slice', 4, 5, true, true, {'d'}))
-      eq(false, pcall(curbuf, 'set_line_slice', -4, -5, true, true, {'d'}))
+      curbuf('set_line_slice', 4, 5, true, true, {'d'})
+      eq({'a', 'b', 'c', 'd'}, curbuf('get_line_slice', 0, 5, true, true))
+      curbuf('set_line_slice', -4, -5, true, true, {'e'})
+      eq({'e', 'a', 'b', 'c', 'd'}, curbuf('get_line_slice', 0, 5, true, true))
     end)
 
     it('works', function()

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -165,8 +165,8 @@ describe('server -> client', function()
 
       eq('SOME TEXT', eval("rpcrequest(vim, 'buffer_get_line', "..buf..", 0)"))
 
-      -- Call get_line_slice(buf, range [0,0], includes start, includes end)
-      eq({'SOME TEXT'}, eval("rpcrequest(vim, 'buffer_get_line_slice', "..buf..", 0, 0, 1, 1)"))
+      -- Call get_lines(buf, range [0,0], strict_indexing)
+      eq({'SOME TEXT'}, eval("rpcrequest(vim, 'buffer_get_lines', "..buf..", 0, 1, 1)"))
     end)
 
     it('returns an error if the request failed', function()

--- a/test/functional/autocmd/textyankpost_spec.lua
+++ b/test/functional/autocmd/textyankpost_spec.lua
@@ -14,7 +14,7 @@ describe('TextYankPost', function()
     execute('autocmd TextYankPost * let g:event = copy(v:event)')
     execute('autocmd TextYankPost * let g:count += 1')
 
-    curbufmeths.set_line_slice(0, -1, true, true, {
+    curbufmeths.set_lines(0, -1, true, {
       'foo\0bar',
       'baz text',
     })

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -320,7 +320,7 @@ local function curbuf_contents()
   -- previously sent keys are processed(vim_eval is a deferred function, and
   -- only processed after all input)
   wait()
-  return table.concat(curbuf('get_line_slice', 0, -1, true, true), '\n')
+  return table.concat(curbuf('get_lines', 0, -1, true), '\n')
 end
 
 local function curwin(method, ...)

--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -2215,7 +2215,7 @@ describe('In plugin/shada.vim', function()
   describe('event BufWriteCmd', function()
     it('works', function()
       nvim('set_var', 'shada#add_own_header', 0)
-      curbuf('set_line_slice', 0, 0, true, true, {
+      curbuf('set_lines', 0, 1, true, {
         'Jump with timestamp ' .. epoch .. ':',
         '  % Key________  Description  Value',
         '  + n            name         \'A\'',
@@ -2271,7 +2271,7 @@ describe('In plugin/shada.vim', function()
   describe('event FileWriteCmd', function()
     it('works', function()
       nvim('set_var', 'shada#add_own_header', 0)
-      curbuf('set_line_slice', 0, 0, true, true, {
+      curbuf('set_lines', 0, 1, true, {
         'Jump with timestamp ' .. epoch .. ':',
         '  % Key________  Description  Value',
         '  + n            name         \'A\'',
@@ -2310,7 +2310,7 @@ describe('In plugin/shada.vim', function()
   describe('event FileAppendCmd', function()
     it('works', function()
       nvim('set_var', 'shada#add_own_header', 0)
-      curbuf('set_line_slice', 0, 0, true, true, {
+      curbuf('set_lines', 0, 1, true, {
         'Jump with timestamp ' .. epoch .. ':',
         '  % Key________  Description  Value',
         '  + n            name         \'A\'',
@@ -2512,7 +2512,7 @@ describe('syntax/shada.vim', function()
   it('works', function()
     nvim_command('syntax on')
     nvim_command('setlocal syntax=shada')
-    curbuf('set_line_slice', 0, 0, true, true, {
+    curbuf('set_lines', 0, 1, true, {
       'Header with timestamp ' .. epoch .. ':',
       '  % Key  Value',
       '  + t    "test"',

--- a/test/functional/terminal/edit_spec.lua
+++ b/test/functional/terminal/edit_spec.lua
@@ -70,6 +70,6 @@ describe(':edit term://*', function()
     end
     exp_screen = exp_screen .. (' '):rep(columns) .. '|\n'
     scr:expect(exp_screen)
-    eq(bufcontents, curbufmeths.get_line_slice(1, -1, true, true))
+    eq(bufcontents, curbufmeths.get_lines(1, -1, true))
   end)
 end)


### PR DESCRIPTION
Step one was to make things consistent with the vim python interface, so fixes neovim/python-client#155 and #4058 . Though that is probably too narrow an aim. We might to add a flag to toggle bound checking of the slice functions, to also accommodate languages with stricter range semantics.

The index handling is a confusing mixture of offset and element based indexing, with implementation arbitararily split between `[gs]et_slice` and two helper functions (not anyone's fault in particular, just a result of our fix-a-bug-at-a-time approach.) But it was not messier than the missing corner case could be inferred like so:

```
  include_start = include_start && (start < buf->b_ml.ml_line_count); // added
  start = normalize_index(buf, start) + (include_start ? 0 : 1);
  include_end = include_end || (end >= buf->b_ml.ml_line_count);
  end = normalize_index(buf, end) + (include_end ? 1 : 0);
```

Next step might be to try to simplify the implementation, or even so the API.  Do we really need to support both offset (0-based) and element (1-based) indexing at the API-level, as controlled by the include_start and include_end parameters ? This multiplies the different cases to support, and test, as highlighted by this missing corner case. The only limitation to use pure offset indexing (python-style) is that there is no numerical value for the index-past-the-end. Either we could have a magic value, like INT32_MAX to designate this index (leaks a implementation limit to the API, so a bit unclean) or we could use a slightly modified scheme, where -1 is the index-past-the-end and -2 is the last element etc (but this would make us different than anyone else, so still not 100% happy). IMHO even having a dedicated flag just for this position is cleaner than  `include_start`, but that is debatable.

Thoughts? Ideas?
