### PR TITLE
[RFC] vim-patch:7.4.722

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3984,8 +3984,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  conceal:c	Character to show in place of concealed text, when
 			'conceallevel' is set to 1.  A space when omitted.
 							*lcs-nbsp*
-	  nbsp:c	Character to show for a non-breakable space (character
-			0xA0, 160).  Left blank when omitted.
+	  nbsp:c	Character to show for a non-breakable space character
+			(0xA0 (160 decimal) and U+202F).  Left blank when
+			omitted.
 
 	The characters ':' and ',' should not be used.  UTF-8 characters can
 	be used when 'encoding' is "utf-8", otherwise only printable

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1396,7 +1396,8 @@ void msg_prt_line(char_u *s, int list)
         c = *p_extra++;
     } else if (has_mbyte && (l = (*mb_ptr2len)(s)) > 1) {
       col += (*mb_ptr2cells)(s);
-      if (lcs_nbsp != NUL && list && mb_ptr2char(s) == 160) {
+      if (lcs_nbsp != NUL && list
+          && (mb_ptr2char(s) == 160 || mb_ptr2char(s) == 0x202f)) {
         mb_char2bytes(lcs_nbsp, buf);
         buf[(*mb_ptr2len)(buf)] = NUL;
       } else {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3202,7 +3202,8 @@ win_line (
 
       // 'list': change char 160 to lcs_nbsp and space to lcs_space.
       if (wp->w_p_list
-          && (((c == 160 || (mb_utf8 && mb_c == 160)) && lcs_nbsp)
+          && (((c == 160 || (mb_utf8 && (mb_c == 160 || mb_c == 0x202f)))
+               && lcs_nbsp)
               || (c == ' ' && lcs_space && ptr - line <=  trailcol))) {
         c = (c == ' ') ? lcs_space : lcs_nbsp;
         if (area_attr == 0 && search_attr == 0) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -402,7 +402,7 @@ static int included_patches[] = {
   // 725,
   // 724 NA
   723,
-  // 722,
+  722,
   721,
   // 720 NA
   719,


### PR DESCRIPTION
```
Problem:    0x202f is not recognized as a non-breaking space character.
Solution:   Add 0x202f to the list. (Christian Brabandt)
```

https://github.com/vim/vim/commit/73284b973a013692dd1055cf210f3138a7f3c497

Original patch:

``` diff
commit 73284b9
Author: Bram Moolenaar <Bram@vim.org>
Date:   Mon May 4 17:28:22 2015 +0200

    patch 7.4.722
    Problem:    0x202f is not recognized as a non-breaking space character.
    Solution:   Add 0x202f to the list. (Christian Brabandt)

diff --git a/runtime/doc/options.txt b/runtime/doc/options.txt
index a3f6e12..21cf650 100644
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4746,8 +4746,9 @@ A jump table for the options with a short description can be found at |Q_op|.
      conceal:c Character to show in place of concealed text, when
            'conceallevel' is set to 1.
                            *lcs-nbsp*
-     nbsp:c    Character to show for a non-breakable space (character
-           0xA0, 160).  Left blank when omitted.
+     nbsp:c    Character to show for a non-breakable space character
+           (0xA0 (160 decimal) and U+202F).  Left blank when
+           omitted.

    The characters ':' and ',' should not be used.  UTF-8 characters can
    be used when 'encoding' is "utf-8", otherwise only printable
diff --git a/src/nvim/message.c b/src/nvim/message.c
index b046ac9..2ab0a83 100644
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1697,7 +1697,9 @@ msg_prt_line(s, list)
    else if (has_mbyte && (l = (*mb_ptr2len)(s)) > 1)
    {
        col += (*mb_ptr2cells)(s);
-       if (lcs_nbsp != NUL && list && mb_ptr2char(s) == 160)
+       if (lcs_nbsp != NUL && list
+           && (mb_ptr2char(s) == 160
+           || mb_ptr2char(s) == 0x202f))
        {
        mb_char2bytes(lcs_nbsp, buf);
        buf[(*mb_ptr2len)(buf)] = NUL;
diff --git a/src/nvim/screen.c b/src/nvim/screen.c
index e210ec8..3f3123a 100644
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4338,7 +4338,7 @@ win_line(wp, lnum, startrow, endrow, nochange)
        if (wp->w_p_list
            && (((c == 160
 #ifdef FEAT_MBYTE
-             || (mb_utf8 && mb_c == 160)
+             || (mb_utf8 && (mb_c == 160 || mb_c == 0x202f))
 #endif
             ) && lcs_nbsp)
            || (c == ' ' && lcs_space && ptr - line <= trailcol)))
diff --git a/src/nvim/version.c b/src/nvim/version.c
index 1be0134..694d844 100644
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -742,6 +742,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    722,
+/**/
     721,
 /**/
     720,
```
