### PR TITLE
[RFC] vim-patch:7.4.656

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1862,10 +1862,10 @@ getwinposx()			Number	X coord in pixels of GUI Vim window
 getwinposy()			Number	Y coord in pixels of GUI Vim window
 getwinvar( {nr}, {varname} [, {def}])
 				any	variable {varname} in window {nr}
-glob( {expr} [, {nosuf} [, {list}]])
+glob( {expr} [, {nosuf} [, {list} [, {alllinks}]]])
 				any	expand file wildcards in {expr}
 glob2regpat( {expr})		String  convert a glob pat into a search pat
-globpath( {path}, {expr} [, {nosuf} [, {list}]])
+globpath( {path}, {expr} [, {nosuf} [, {list} [, {alllinks}]]])
 				String	do glob({expr}) for all dirs in {path}
 has( {feature})			Number	TRUE if feature {feature} supported
 has_key( {dict}, {key})		Number	TRUE if {dict} has entry {key}
@@ -3754,7 +3754,7 @@ getwinvar({winnr}, {varname} [, {def}])				*getwinvar()*
 			:let list_is_on = getwinvar(2, '&list')
 			:echo "myvar = " . getwinvar(1, 'myvar')
 <
-glob({expr} [, {nosuf} [, {list}]])				*glob()*
+glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])		*glob()*
 		Expand the file wildcards in {expr}.  See |wildcards| for the
 		use of special characters.
 
@@ -3771,8 +3771,11 @@ glob({expr} [, {nosuf} [, {list}]])				*glob()*
 		matches, they are separated by <NL> characters.
 
 		If the expansion fails, the result is an empty String or List.
+
 		A name for a non-existing file is not included.  A symbolic
 		link is only included if it points to an existing file.
+		However, when the {alllinks} argument is present and it is
+		non-zero then all symbolic links are included.
 
 		For most systems backticks can be used to get files names from
 		any external command.  Example: >
@@ -3792,7 +3795,8 @@ glob2regpat({expr})					 *glob2regpat()*
 <		This is equivalent to: >
 			if filename =~ '^Make.*\.mak$'
 <
-globpath({path}, {expr} [, {nosuf} [, {list}]])			*globpath()*
+								*globpath()*
+globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])
 		Perform glob() on all directories in {path} and concatenate
 		the results.  Example: >
 			:echo globpath(&rtp, "syntax/c.vim")
@@ -3818,6 +3822,8 @@ globpath({path}, {expr} [, {nosuf} [, {list}]])			*globpath()*
 		they are separated by <NL> characters.  Example: >
 			:echo globpath(&rtp, "syntax/c.vim", 0, 1)
 <
+		{allinks} is used as with |glob()|.
+
 		The "**" item can be used to search in a directory tree.
 		For example, to find all "README.txt" files in the directories
 		in 'runtimepath' and below: >

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	C
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2015 Feb 27
+" Last Change:	2015 Mar 05
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -47,16 +47,17 @@ if !exists("c_no_cformat")
 endif
 
 " cCppString: same as cString, but ends at end of line
-if s:ft ==# "cpp" && !exists("cpp_no_cpp11")
+if s:ft ==# "cpp" && !exists("cpp_no_cpp11") && !exists("c_no_cformat")
   " ISO C++11
   syn region	cString		start=+\(L\|u\|u8\|U\|R\|LR\|u8R\|uR\|UR\)\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell extend
   syn region 	cCppString	start=+\(L\|u\|u8\|U\|R\|LR\|u8R\|uR\|UR\)\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
-elseif s:ft ==# "c" && !exists("c_no_c11")
+elseif s:ft ==# "c" && !exists("c_no_c11") && !exists("c_no_cformat")
   " ISO C99
   syn region	cString		start=+\%(L\|U\|u8\)\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell extend
   syn region	cCppString	start=+\%(L\|U\|u8\)\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
 else
   " older C or C++
+  syn match	cFormat		display "%%" contained
   syn region	cString		start=+L\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell extend
   syn region	cCppString	start=+L\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
 endif
@@ -80,7 +81,11 @@ syn match	cSpecialCharacter display "L'\\x\x\+'"
 
 if (s:ft ==# "c" && !exists("c_no_c11")) || (s:ft ==# "cpp" && !exists("cpp_no_cpp11"))
   " ISO C11 or ISO C++ 11
-  syn region	cString		start=+\%(U\|u8\=\)"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell extend
+  if exists("c_no_cformat")
+    syn region	cString		start=+\%(U\|u8\=\)"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,@Spell extend
+  else
+    syn region	cString		start=+\%(U\|u8\=\)"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell extend
+  endif
   syn match	cCharacter	"[Uu]'[^\\]'"
   syn match	cCharacter	"[Uu]'[^']*'" contains=cSpecial
   if exists("c_gnu")
@@ -389,8 +394,13 @@ endif
 syn cluster	cLabelGroup	contains=cUserLabel
 syn match	cUserCont	display "^\s*\I\i*\s*:$" contains=@cLabelGroup
 syn match	cUserCont	display ";\s*\I\i*\s*:$" contains=@cLabelGroup
-syn match	cUserCont	display "^\s*\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
-syn match	cUserCont	display ";\s*\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+if s:ft ==# 'cpp'
+  syn match	cUserCont	display "^\s*\%(class\|struct\|enum\)\@!\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+  syn match	cUserCont	display ";\s*\%(class\|struct\|enum\)\@!\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+else
+  syn match	cUserCont	display "^\s*\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+  syn match	cUserCont	display ";\s*\I\i*\s*:[^:]"me=e-1 contains=@cLabelGroup
+endif
 
 syn match	cUserLabel	display "\I\i*" contained
 

--- a/runtime/syntax/cpp.vim
+++ b/runtime/syntax/cpp.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	C++
-" Current Maintainer:	vim-jp (https://github.com/vim-jp/cpp-vim)
+" Current Maintainer:	vim-jp (https://github.com/vim-jp/vim-cpp)
 " Previous Maintainer:	Ken Shan <ccshan@post.harvard.edu>
-" Last Change:	2014 May 14
+" Last Change:	2015 Mar 1
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
@@ -32,14 +32,21 @@ syn match cppCast		"\<\(const\|static\|dynamic\|reinterpret\)_cast\s*$"
 syn keyword cppStorageClass	mutable
 syn keyword cppStructure	class typename template namespace
 syn keyword cppBoolean		true false
+syn keyword cppConstant		__cplusplus
 
 " C++ 11 extensions
 if !exists("cpp_no_cpp11")
   syn keyword cppType		override final
   syn keyword cppExceptions	noexcept
-  syn keyword cppStorageClass	constexpr decltype
+  syn keyword cppStorageClass	constexpr decltype thread_local
   syn keyword cppConstant	nullptr
-  syn region cppRawString       matchgroup=cppRawDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"+ contains=@Spell
+  syn keyword cppConstant	ATOMIC_FLAG_INIT ATOMIC_VAR_INIT
+  syn keyword cppConstant	ATOMIC_BOOL_LOCK_FREE ATOMIC_CHAR_LOCK_FREE
+  syn keyword cppConstant	ATOMIC_CHAR16_T_LOCK_FREE ATOMIC_CHAR32_T_LOCK_FREE
+  syn keyword cppConstant	ATOMIC_WCHAR_T_LOCK_FREE ATOMIC_SHORT_LOCK_FREE
+  syn keyword cppConstant	ATOMIC_INT_LOCK_FREE ATOMIC_LONG_LOCK_FREE
+  syn keyword cppConstant	ATOMIC_LLONG_LOCK_FREE ATOMIC_POINTER_LOCK_FREE
+  syn region cppRawString	matchgroup=cppRawDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"+ contains=@Spell
 endif
 
 " The minimum and maximum operators in GNU C++

--- a/runtime/syntax/upstreamrpt.vim
+++ b/runtime/syntax/upstreamrpt.vim
@@ -1,12 +1,14 @@
 " Vim syntax file
-" Language:		Innovation Data Processing upstream.dat file
+" Language:		Innovation Data Processing upstream.rpt file
 " Maintainer:		Rob Owens <rowens@fdrinnovation.com>
-" Latest Revision:	2013-11-27
+" Latest Revision:	2014-03-13
 
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")
   finish
 endif
+
+setlocal foldmethod=syntax
 
 " Parameters:
 syn keyword upstreamdat_Parameter ACCEPTPCREMOTE 
@@ -297,6 +299,9 @@ syn match upstreamdat_Filespec /file spec\c \d\{1,3}.*/
 
 " Comments:
 syn match upstreamdat_Comment /^#.*/
+
+" List Of Parameters:
+syn region upstreamdat_Parms start="Current Parameters:" end="End Of Parameters" transparent fold
 
 hi def link upstreamdat_Parameter Type
 "hi def link upstreamdat_Filespec Underlined

--- a/runtime/syntax/usw2kagtlog.vim
+++ b/runtime/syntax/usw2kagtlog.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:             Innovation Data Processing USW2KAgt.log file
 " Maintainer:           Rob Owens <rowens@fdrinnovation.com>
-" Latest Revision:      2013-09-19
+" Latest Revision:      2014-04-01
 
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -17,8 +17,12 @@ syn match usw2kagtlog_MsgI /Msg #\(Agt\|PC\|Srv\)\d\{4,5}I/ nextgroup=usw2kagtlo
 syn match usw2kagtlog_MsgW /Msg #\(Agt\|PC\|Srv\)\d\{4,5}W/ nextgroup=usw2kagtlog_Process skipwhite
 " Processes:
 syn region usw2kagtlog_Process start="(" end=")" contained
-syn region usw2kagtlog_Process start="Starting the processing for a \zs\"" end="\ze client request"
-syn region usw2kagtlog_Process start="Ending the processing for a \zs\"" end="\ze client request"
+"syn region usw2kagtlog_Process start="Starting the processing for a \zs\"" end="\ze client request"
+"syn region usw2kagtlog_Process start="Ending the processing for a \zs\"" end="\ze client request"
+"syn region usw2kagtlog_Process start="Starting the processing for a \zs\"" end="\ze client\s\{0,1}\r\{0,1}\s\{1,9}request"
+"syn region usw2kagtlog_Process start="Ending the processing for a \zs\"" end="\ze client\s\{0,1}\r\{0,1}\s\{1,9}request"
+syn region usw2kagtlog_Process start="Starting the processing for a \zs\"" end="\ze client"
+syn region usw2kagtlog_Process start="Ending the processing for a \zs\"" end="\ze client"
 " IP Address:
 syn match usw2kagtlog_IPaddr / \d\{1,3}\.\d\{1,3}\.\d\{1,3}\.\d\{1,3}/
 " Profile:

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -468,7 +468,7 @@ static int included_patches[] = {
   659,
   658,
   // 657 NA
-  // 656,
+  656,
   655,
   654,
   653,


### PR DESCRIPTION
```
Problem:    Missing changes for glob() in one file.
Solution:   Add the missing changes.
```

https://github.com/vim/vim/commit/d8b77f7dc04e5721989df9c505b8568194261a39

In the original patch the function `mch_lstat` is used to get file info without following symbolic links. I have replaced it with `os_fileinfo_link`.

This patch also includes some completely unrelated runtime updates, which all applied cleanly.
