### PR TITLE
[RFC] vim-patch:5a5f459

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1,4 +1,4 @@
-*autocmd.txt*   For Vim version 7.4.  Last change: 2014 Sep 23
+*autocmd.txt*   For Vim version 7.4.  Last change: 2015 Mar 21
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -972,6 +972,13 @@ WinLeave			Before leaving a window.  If the window to be
 
 ==============================================================================
 6. Patterns					*autocmd-patterns* *{pat}*
+
+The {pat} argument can be a comma separated list.  This works as if the
+command was given with each pattern separately.  Thus this command: >
+	:autocmd BufRead *.txt,*.info set et
+Is equivalent to: >
+	:autocmd BufRead *.txt set et
+	:autocmd BufRead *.info set et
 
 The file pattern {pat} is tested for a match against the file name in one of
 two ways:

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -524,7 +524,7 @@ Funcref to a Dictionary, but the "self" variable is not available then.
 To avoid the extra name for the function it can be defined and directly
 assigned to a Dictionary in this way: >
 	:let mydict = {'data': [0, 1, 2, 3]}
-	:function mydict.len() dict
+	:function mydict.len()
 	:   return len(self.data)
 	:endfunction
 	:echo mydict.len()

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -1,4 +1,4 @@
-*help.txt*	For Vim version 7.4.  Last change: 2012 Dec 06
+*help.txt*	For Vim version 7.4.  Last change: 2015 Apr 11
 
 			VIM - main help file
 									 k
@@ -23,6 +23,7 @@ Get specific help:  It is possible to go directly to whatever you want help
 		      Command-line editing	  c_	   :help c_<Del>
 		      Vim command argument	  -	   :help -r
 		      Option			  '	   :help 'textwidth'
+		      Regular expression	  /	   :help /[
   Search for help:  Type ":help word", then hit CTRL-D to see matching
 		    help entries for "word".
 		    Or use ":helpgrep word". |:helpgrep|
@@ -170,6 +171,16 @@ Standard plugins ~
 |pi_zip.txt|       Zip archive explorer
 
 LOCAL ADDITIONS:				*local-additions*
+|Mines.txt|	The Mines Game 				Jul 30, 2009
+|Tabular.txt|   Configurable, flexible, intuitive text aligning
+|cecutil.txt|	DrChip's Utilities				Jun 11, 2004
+|example.txt|	Example for a locally added help file
+|matchit.txt|   Extended "%" matching
+|pi_netrw.txt|  For Vim version 7.4.  Last change: 2014 Jul 09
+|synchk.txt|	Syntax Checker    			May 15, 2013
+|test.txt|	Testing the hélp cömmånd nôw
+|typecorr.txt|	Plugin for correcting typing mistakes
+|helpp.txt|	Dummy line to avoid an error message
 
 ------------------------------------------------------------------------------
 *bars*		Bars example

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 7.4.  Last change: 2015 Mar 20
+*syntax.txt*	For Vim version 7.4.  Last change: 2015 Mar 29
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -3306,6 +3306,32 @@ must not click outside of the pixel strings, but feel free to improve it.
 
 It will look much better with a font in a quadratic cell size, e.g. for X: >
 	:set guifont=-*-clean-medium-r-*-*-8-*-*-*-*-80-*
+
+
+YAML						*yaml.vim* *ft-yaml-syntax*
+
+					*g:yaml_schema* *b:yaml_schema*
+A YAML schema is a combination of a set of tags and a mechanism for resolving 
+non-specific tags. For user this means that YAML parser may, depending on 
+plain scalar contents, treat plain scalar (which can actually be only string 
+and nothing else) as a value of the other type: null, boolean, floating-point, 
+integer. `g:yaml_schema` option determines according to which schema values 
+will be highlighted specially. Supported schemas are
+
+Schema		Description ~
+failsafe	No additional highlighting.
+json		Supports JSON-style numbers, booleans and null.
+core		Supports more number, boolean and null styles.
+pyyaml		In addition to core schema supports highlighting timestamps, 
+		but there are some differences in what is recognized as 
+		numbers and many additional boolean values not present in core 
+		schema.
+
+Default schema is `core`.
+
+Note that schemas are not actually limited to plain scalars, but this is the 
+only difference between schemas defined in YAML specification and the only 
+difference defined in the syntax file.
 
 ==============================================================================
 5. Defining a syntax					*:syn-define* *E410*

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -1,4 +1,4 @@
-*usr_02.txt*	For Vim version 7.4.  Last change: 2010 Jul 20
+*usr_02.txt*	For Vim version 7.4.  Last change: 2015 Apr 12
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -516,9 +516,11 @@ Summary: 					*help-summary*  >
 	:help subject()
 <		Function "subject". >
 	:help -subject
-<		Command-line option "-subject". >
+<		Command-line argument "-subject". >
 	:help +subject
 <		Compile-time feature "+subject". >
+	:help /*
+<		Regular expression item "*" >
 	:help EventName
 <		Autocommand event "EventName". >
 	:help digraphs.txt

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2015 Mar 13
+" Last Change:	2015 Apr 06
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")
@@ -1290,7 +1290,7 @@ au BufNewFile,BufRead *.mush			setf mush
 au BufNewFile,BufRead Mutt{ng,}rc		setf muttrc
 
 " Nano
-au BufNewFile,BufRead */etc/nanorc,.nanorc	setf nanorc
+au BufNewFile,BufRead */etc/nanorc,*.nanorc  	setf nanorc
 
 " Nastran input/DMAP
 "au BufNewFile,BufRead *.dat			setf nastran

--- a/runtime/ftplugin/j.vim
+++ b/runtime/ftplugin/j.vim
@@ -2,7 +2,7 @@
 " Language:	J
 " Maintainer:	David Bürgin <676c7473@gmail.com>
 " URL:		https://github.com/glts/vim-j
-" Last Change:	2015-01-11
+" Last Change:	2015-03-27
 
 if exists('b:did_ftplugin')
   finish
@@ -16,12 +16,9 @@ setlocal iskeyword=48-57,A-Z,_,a-z
 setlocal comments=:NB.
 setlocal commentstring=NB.\ %s
 setlocal formatoptions-=t
-setlocal shiftwidth=2
-setlocal softtabstop=2
-setlocal expandtab
 setlocal matchpairs=(:)
 
-let b:undo_ftplugin = 'setlocal matchpairs< expandtab< softtabstop< shiftwidth< formatoptions< commentstring< comments< iskeyword<'
+let b:undo_ftplugin = 'setlocal matchpairs< formatoptions< commentstring< comments< iskeyword<'
 
 " Section movement with ]] ][ [[ []. The start/end patterns below are amended
 " inside the function in order to avoid matching on the current cursor line.

--- a/runtime/syntax/yaml.vim
+++ b/runtime/syntax/yaml.vim
@@ -2,7 +2,7 @@
 " Language:         YAML (YAML Ain't Markup Language) 1.2
 " Maintainer:       Nikolai Pavlov <zyx.vim@gmail.com>
 " First author:     Nikolai Weibull <now@bitwi.se>
-" Latest Revision:  2010-10-08
+" Latest Revision:  2015-03-28
 
 if exists('b:current_syntax')
     finish
@@ -11,13 +11,40 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-let s:ns_char = '\%(\%([\n\r\uFEFF \t]\)\@!\p\)'
-let s:ns_word_char = '\%(\w\|-\)'
-let s:ns_uri_char  = '\%(%\x\x\|'.s:ns_word_char.'\|[#/;?:@&=+$,.!~*''()\[\]]\)'
+" Choose the schema to use
+" TODO: Validate schema
+if !exists('b:yaml_schema')
+  if exists('g:yaml_schema')
+    let b:yaml_schema = g:yaml_schema
+  else
+    let b:yaml_schema = 'core'
+  endif
+endif
+
+let s:ns_char = '\%([\n\r\uFEFF \t]\@!\p\)'
+let s:ns_word_char = '[[:alnum:]_\-]'
+let s:ns_uri_char  = '\%(%\x\x\|'.s:ns_word_char.'\|[#/;?:@&=+$,.!~*''()[\]]\)'
 let s:ns_tag_char  = '\%(%\x\x\|'.s:ns_word_char.'\|[#/;?:@&=+$.~*''()]\)'
-let s:c_ns_anchor_char = '\%(\%([\n\r\uFEFF \t,\[\]{}]\)\@!\p\)'
-let s:c_indicator      = '[\-?:,\[\]{}#&*!|>''"%@`]'
-let s:c_flow_indicator = '[,\[\]{}]'
+let s:c_ns_anchor_char = '\%([\n\r\uFEFF \t,[\]{}]\@!\p\)'
+let s:c_indicator      = '[\-?:,[\]{}#&*!|>''"%@`]'
+let s:c_flow_indicator = '[,[\]{}]'
+
+let s:ns_char_without_c_indicator = substitute(s:ns_char, '\v\C[\zs', '\=s:c_indicator[1:-2]', '')
+
+let s:_collection = '[^\@!\(\%(\\\.\|\[^\\\]]\)\+\)]'
+let s:_neg_collection = '[^\(\%(\\\.\|\[^\\\]]\)\+\)]'
+function s:SimplifyToAssumeAllPrintable(p)
+    return substitute(a:p, '\V\C\\%('.s:_collection.'\\@!\\p\\)', '[^\1]', '')
+endfunction
+let s:ns_char = s:SimplifyToAssumeAllPrintable(s:ns_char)
+let s:ns_char_without_c_indicator = s:SimplifyToAssumeAllPrintable(s:ns_char_without_c_indicator)
+let s:c_ns_anchor_char = s:SimplifyToAssumeAllPrintable(s:c_ns_anchor_char)
+
+function s:SimplifyAdjacentCollections(p)
+    return substitute(a:p, '\V\C'.s:_collection.'\\|'.s:_collection, '[\1\2]', 'g')
+endfunction
+let s:ns_uri_char = s:SimplifyAdjacentCollections(s:ns_uri_char)
+let s:ns_tag_char = s:SimplifyAdjacentCollections(s:ns_tag_char)
 
 let s:c_verbatim_tag = '!<'.s:ns_uri_char.'\+>'
 let s:c_named_tag_handle     = '!'.s:ns_word_char.'\+!'
@@ -46,11 +73,15 @@ let s:ns_tag_prefix = s:ns_local_tag_prefix.
 let s:ns_plain_safe_out = s:ns_char
 let s:ns_plain_safe_in  = '\%('.s:c_flow_indicator.'\@!'.s:ns_char.'\)'
 
-let s:ns_plain_first_in  = '\%('.s:c_indicator.'\@!'.s:ns_char.'\|[?:\-]\%('.s:ns_plain_safe_in.'\)\@=\)'
-let s:ns_plain_first_out = '\%('.s:c_indicator.'\@!'.s:ns_char.'\|[?:\-]\%('.s:ns_plain_safe_out.'\)\@=\)'
+let s:ns_plain_safe_in = substitute(s:ns_plain_safe_in, '\V\C\\%('.s:_collection.'\\@!'.s:_neg_collection.'\\)', '[^\1\2]', '')
+let s:ns_plain_safe_in_without_colhash = substitute(s:ns_plain_safe_in, '\V\C'.s:_neg_collection, '[^\1:#]', '')
+let s:ns_plain_safe_out_without_colhash = substitute(s:ns_plain_safe_out, '\V\C'.s:_neg_collection, '[^\1:#]', '')
 
-let s:ns_plain_char_in  = '\%('.s:ns_char.'#\|:'.s:ns_plain_safe_in.'\|[:#]\@!'.s:ns_plain_safe_in.'\)'
-let s:ns_plain_char_out = '\%('.s:ns_char.'#\|:'.s:ns_plain_safe_out.'\|[:#]\@!'.s:ns_plain_safe_out.'\)'
+let s:ns_plain_first_in  = '\%('.s:ns_char_without_c_indicator.'\|[?:\-]\%('.s:ns_plain_safe_in.'\)\@=\)'
+let s:ns_plain_first_out = '\%('.s:ns_char_without_c_indicator.'\|[?:\-]\%('.s:ns_plain_safe_out.'\)\@=\)'
+
+let s:ns_plain_char_in  = '\%('.s:ns_char.'#\|:'.s:ns_plain_safe_in.'\|'.s:ns_plain_safe_in_without_colhash.'\)'
+let s:ns_plain_char_out = '\%('.s:ns_char.'#\|:'.s:ns_plain_safe_out.'\|'.s:ns_plain_safe_out_without_colhash.'\)'
 
 let s:ns_plain_out = s:ns_plain_first_out . s:ns_plain_char_out.'*'
 let s:ns_plain_in  = s:ns_plain_first_in  . s:ns_plain_char_in.'*'
@@ -89,9 +120,11 @@ syn match  yamlSingleEscape contained "''"
 
 syn match yamlBlockScalarHeader contained '\s\+\zs[|>]\%([+-]\=[1-9]\|[1-9]\=[+-]\)\='
 
+syn cluster yamlConstant contains=yamlBool,yamlNull
+
 syn cluster yamlFlow contains=yamlFlowString,yamlFlowMapping,yamlFlowCollection
 syn cluster yamlFlow      add=yamlFlowMappingKey,yamlFlowMappingMerge
-syn cluster yamlFlow      add=yamlConstant,yamlPlainScalar,yamlFloat
+syn cluster yamlFlow      add=@yamlConstant,yamlPlainScalar,yamlFloat
 syn cluster yamlFlow      add=yamlTimestamp,yamlInteger,yamlMappingKeyStart
 syn cluster yamlFlow      add=yamlComment
 syn region yamlFlowMapping    matchgroup=yamlFlowIndicator start='{' end='}' contains=@yamlFlow
@@ -103,15 +136,15 @@ execute 'syn match yamlPlainScalar contained /'.s:ns_plain_in.'/'
 syn match yamlMappingKeyStart '?\ze\s'
 syn match yamlMappingKeyStart '?' contained
 
-execute 'syn match yamlFlowMappingKey /'.s:ns_plain_in.'\ze\s*:/ contained '.
+execute 'syn match yamlFlowMappingKey /\%#=1'.s:ns_plain_in.'\%(\s\+'.s:ns_plain_in.'\)*\ze\s*:/ contained '.
             \'nextgroup=yamlKeyValueDelimiter'
 syn match yamlFlowMappingMerge /<<\ze\s*:/ contained nextgroup=yamlKeyValueDelimiter
 
 syn match yamlBlockCollectionItemStart '^\s*\zs-\%(\s\+-\)*\s' nextgroup=yamlBlockMappingKey,yamlBlockMappingMerge
 " Use the old regexp engine, the NFA engine doesn't like all the \@ items.
-execute 'syn match yamlBlockMappingKey /\%#=1^\s*\zs'.s:ns_plain_out.'\ze\s*:\%(\s\|$\)/ '.
+execute 'syn match yamlBlockMappingKey /\%#=1^\s*\zs'.s:ns_plain_out.'\%(\s\+'.s:ns_plain_out.'\)*\ze\s*:\%(\s\|$\)/ '.
             \'nextgroup=yamlKeyValueDelimiter'
-execute 'syn match yamlBlockMappingKey /\%#=1\s*\zs'.s:ns_plain_out.'\ze\s*:\%(\s\|$\)/ contained '.
+execute 'syn match yamlBlockMappingKey /\%#=1\s*\zs'.s:ns_plain_out.'\%(\s\+'.s:ns_plain_out.'\)*\ze\s*:\%(\s\|$\)/ contained '.
             \'nextgroup=yamlKeyValueDelimiter'
 syn match yamlBlockMappingMerge /^\s*\zs<<\ze:\%(\s\|$\)/ nextgroup=yamlKeyValueDelimiter
 syn match yamlBlockMappingMerge /<<\ze\s*:\%(\s\|$\)/ nextgroup=yamlKeyValueDelimiter contained
@@ -119,14 +152,32 @@ syn match yamlBlockMappingMerge /<<\ze\s*:\%(\s\|$\)/ nextgroup=yamlKeyValueDeli
 syn match   yamlKeyValueDelimiter /\s*:/ contained
 syn match   yamlKeyValueDelimiter /\s*:/ contained
 
-syn keyword yamlConstant true True TRUE false False FALSE
-syn keyword yamlConstant null Null NULL
-syn match   yamlConstant '\<\~\>'
+syn cluster yamlScalarWithSpecials contains=yamlPlainScalar,yamlBlockMappingKey,yamlFlowMappingKey
 
-syn match   yamlTimestamp /\%([\[\]{}, \t]\@!\p\)\@<!\%(\d\{4}-\d\d\=-\d\d\=\%(\%([Tt]\|\s\+\)\%(\d\d\=\):\%(\d\d\):\%(\d\d\)\%(\.\%(\d*\)\)\=\%(\s*\%(Z\|[+-]\d\d\=\%(:\d\d\)\=\)\)\=\)\=\)\%([\[\]{}, \t]\@!\p\)\@!/
+let s:_bounder = s:SimplifyToAssumeAllPrintable('\%([[\]{}, \t]\@!\p\)')
+if b:yaml_schema is# 'json'
+    syn keyword yamlNull null contained containedin=@yamlScalarWithSpecials
+    syn keyword yamlBool true false
+    exe 'syn match   yamlInteger /'.s:_bounder.'\@1<!\%(0\|-\=[1-9][0-9]*\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlFloat   /'.s:_bounder.'\@1<!\%(-\=[1-9][0-9]*\%(\.[0-9]*\)\=\(e[-+]\=[0-9]\+\)\=\|0\|-\=\.inf\|\.nan\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+elseif b:yaml_schema is# 'core'
+    syn keyword yamlNull null Null NULL contained containedin=@yamlScalarWithSpecials
+    syn keyword yamlBool true True TRUE false False FALSE contained containedin=@yamlScalarWithSpecials
+    exe 'syn match   yamlNull /'.s:_bounder.'\@1<!\~'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlInteger /'.s:_bounder.'\@1<!\%([+-]\=\%(0\%(b[0-1_]\+\|[0-7_]\+\|x[0-9a-fA-F_]\+\)\=\|\%([1-9][0-9_]*\%(:[0-5]\=\d\)\+\)\)\|[1-9][0-9_]*\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlFloat /'.s:_bounder.'\@1<!\%([+-]\=\%(\%(\d[0-9_]*\)\.[0-9_]*\%([eE][+-]\=\d\+\)\=\|\.[0-9_]\+\%([eE][-+]\=[0-9]\+\)\=\|\d[0-9_]*\%(:[0-5]\=\d\)\+\.[0-9_]*\|\.\%(inf\|Inf\|INF\)\)\|\%(\.\%(nan\|NaN\|NAN\)\)\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+elseif b:yaml_schema is# 'pyyaml'
+    syn keyword yamlNull null Null NULL contained containedin=@yamlScalarWithSpecials
+    syn keyword yamlBool true True TRUE false False FALSE yes Yes YES no No NO on On ON off Off OFF contained containedin=@yamlScalarWithSpecials
+    exe 'syn match   yamlNull /'.s:_bounder.'\@1<!\~'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match  yamlFloat /'.s:_bounder.'\@1<!\%(\v[-+]?%(\d[0-9_]*)\.[0-9_]*%([eE][-+]\d+)?|\.[0-9_]+%([eE][-+]\d+)?|[-+]?\d[0-9_]*%(\:[0-5]?\d)+\.[0-9_]*|[-+]?\.%(inf|Inf|INF)|\.%(nan|NaN|NAN)\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match  yamlInteger /'.s:_bounder.'\@1<!\%(\v[-+]?0b[0-1_]+|[-+]?0[0-7_]+|[-+]?%(0|[1-9][0-9_]*)|[-+]?0x[0-9a-fA-F_]+|[-+]?[1-9][0-9_]*%(:[0-5]?\d)+\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match  yamlTimestamp /'.s:_bounder.'\@1<!\%(\v\d\d\d\d\-\d\d\-\d\d|\d\d\d\d \-\d\d? \-\d\d?%([Tt]|[ \t]+)\d\d?\:\d\d \:\d\d %(\.\d*)?%([ \t]*%(Z|[-+]\d\d?%(\:\d\d)?))?\m\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+elseif b:yaml_schema is# 'failsafe'
+    " Nothing
+endif
+unlet s:_bounder
 
-syn match   yamlInteger /\%([\[\]{}, \t]\@!\p\)\@<!\%([+-]\=\%(0\%(b[0-1_]\+\|[0-7_]\+\|x[0-9a-fA-F_]\+\)\=\|\%([1-9][0-9_]*\%(:[0-5]\=\d\)\+\)\)\|[1-9][0-9_]*\)\%([\[\]{}, \t]\@!\p\)\@!/
-syn match   yamlFloat   /\%([\[\]{}, \t]\@!\p\)\@<!\%([+-]\=\%(\%(\d[0-9_]*\)\.[0-9_]*\%([eE][+-]\d\+\)\=\|\.[0-9_]\+\%([eE][-+][0-9]\+\)\=\|\d[0-9_]*\%(:[0-5]\=\d\)\+\.[0-9_]*\|\.\%(inf\|Inf\|INF\)\)\|\%(\.\%(nan\|NaN\|NAN\)\)\)\%([\[\]{}, \t]\@!\p\)\@!/
 
 execute 'syn match yamlNodeTag '.string(s:c_ns_tag_property)
 execute 'syn match yamlAnchor  '.string(s:c_ns_anchor_property)
@@ -170,6 +221,9 @@ hi def link yamlKeyValueDelimiter        Special
 
 hi def link yamlConstant                 Constant
 
+hi def link yamlNull                     yamlConstant
+hi def link yamlBool                     yamlConstant
+
 hi def link yamlAnchor                   Type
 hi def link yamlAlias                    Type
 hi def link yamlNodeTag                  Type
@@ -180,8 +234,10 @@ hi def link yamlTimestamp                Number
 
 let b:current_syntax = "yaml"
 
-unlet s:ns_word_char s:ns_uri_char s:c_verbatim_tag s:c_named_tag_handle s:c_secondary_tag_handle s:c_primary_tag_handle s:c_tag_handle s:ns_tag_char s:c_ns_shorthand_tag s:c_non_specific_tag s:c_ns_tag_property s:c_ns_anchor_char s:c_ns_anchor_name s:c_ns_anchor_property s:c_ns_alias_node s:ns_char s:ns_directive_name s:ns_local_tag_prefix s:ns_global_tag_prefix s:ns_tag_prefix s:c_indicator s:ns_plain_safe_out s:c_flow_indicator s:ns_plain_safe_in s:ns_plain_first_in s:ns_plain_first_out s:ns_plain_char_in s:ns_plain_char_out s:ns_plain_out s:ns_plain_in
+unlet s:ns_word_char s:ns_uri_char s:c_verbatim_tag s:c_named_tag_handle s:c_secondary_tag_handle s:c_primary_tag_handle s:c_tag_handle s:ns_tag_char s:c_ns_shorthand_tag s:c_non_specific_tag s:c_ns_tag_property s:c_ns_anchor_char s:c_ns_anchor_name s:c_ns_anchor_property s:c_ns_alias_node s:ns_char s:ns_directive_name s:ns_local_tag_prefix s:ns_global_tag_prefix s:ns_tag_prefix s:c_indicator s:ns_plain_safe_out s:c_flow_indicator s:ns_plain_safe_in s:ns_plain_first_in s:ns_plain_first_out s:ns_plain_char_in s:ns_plain_char_out s:ns_plain_out s:ns_plain_in s:ns_char_without_c_indicator s:ns_plain_safe_in_without_colhash s:ns_plain_safe_out_without_colhash
+unlet s:_collection s:_neg_collection
+delfunction s:SimplifyAdjacentCollections
+delfunction s:SimplifyToAssumeAllPrintable
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
-

--- a/runtime/vimrc_example.vim
+++ b/runtime/vimrc_example.vim
@@ -34,10 +34,8 @@ augroup vimrcEx
 
   " When editing a file, always jump to the last known cursor position.
   " Don't do it when the position is invalid or when inside an event handler
-  " Also don't do it when the mark is in the first line, that is the default
-  " position when opening a file.
   autocmd BufReadPost *
-    \ if line("'\"") > 1 && line("'\"") <= line("$") |
+    \ if line("'\"") >= 1 && line("'\"") <= line("$") |
     \   execute "normal! g`\"" |
     \ endif
 


### PR DESCRIPTION
As far as I can tell this is the oldest commit to runtime/ that needs merging. My goal is to catch up on runtime/ backlog so that issue #4067 is easier to fix. (@dbarnett, FYI)

Note that 975a610233e05772d9c835caeede4b7ae2e1af7d by @mhinz merged a newer commit first (out-of-order). I'm not sure if it's an oversight, or intentional. Paging Marco so he can let me know if there's something I'm missing out.

```
Original commit: https://github.com/vim/vim/commit/5a5f459

commit 5a5f45917dbf542cb00617fa5ef70a14898495dd
Author: Bram Moolenaar <Bram@vim.org>
Date:   Mon Apr 13 12:43:06 2015 +0200

    Updated runtime files.

(1) Merged manually vimrc_example.vim
(2) Left out README.txt, doc/tags, doc/todo.txt, tutor/tutor.de,
tutor.de.utf-8, ga.po
```

(1) $ ./scripts/vim-patch.sh -p 5a5f459
(2) $ patch -p1 < vim-5a5f459.diff
(3) had to merge manually vimrc_example.vim

Please note, I left out the ga.po changes, since everything was conflicting. It seems to me (??) that you guys seem to anyways get independent updates to the *.po files.

Should I anyways try to do some sort of merging? It's my first attempt at porting an upstream vim commit, please feel free to send me to additional documentation if I've missed anything.

Cheers!
