### PR TITLE
cmake: msgpack: Ensure at least version 1.0 is found

### DIFF
--- a/cmake/FindMsgpack.cmake
+++ b/cmake/FindMsgpack.cmake
@@ -7,7 +7,7 @@
 if(NOT MSGPACK_USE_BUNDLED)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
-    pkg_search_module(PC_MSGPACK QUIET msgpackc msgpack)
+    pkg_search_module(PC_MSGPACK QUIET msgpackc>=1.0 msgpack>=1.0)
   endif()
 else()
   set(PC_MSGPACK_INCLUDEDIR)


### PR DESCRIPTION
Neovim's code relies on functionality introduced in msgpack-c 1.0.0
(at least MSGPACK_OBJECT_FLOAT enum value), so enforce that minimum
version.
