### PR TITLE
vim-patch:7.4.1137

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -69,6 +69,10 @@ static char *features[] = {
 
 // clang-format off
 static int included_patches[] = {
+  1137,
+
+
+
   1081,
 
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1913,9 +1913,16 @@ int win_close(win_T *win, int free_buf)
    */
   if (win->w_buffer != NULL) {
     win->w_closing = true;
-    close_buffer(win, win->w_buffer, free_buf ? DOBUF_UNLOAD : 0, TRUE);
-    if (win_valid(win))
+    close_buffer(win, win->w_buffer, free_buf ? DOBUF_UNLOAD : 0, true);
+    if (win_valid(win)) {
       win->w_closing = false;
+    }
+
+    // Make sure curbuf is valid. It can become invalid if 'bufhidden' is
+    // "wipe".
+    if (!buf_valid(curbuf)) {
+      curbuf = firstbuf;
+    }
   }
 
   if (only_one_window() && win_valid(win) && win->w_buffer == NULL

--- a/test/functional/legacy/quickfix_spec.lua
+++ b/test/functional/legacy/quickfix_spec.lua
@@ -1,0 +1,18 @@
+-- Test for the quickfix commands.
+
+local helpers = require('test.functional.helpers')
+local insert, source = helpers.insert, helpers.source
+local clear, expect = helpers.clear, helpers.expect
+
+describe('helpgrep', function()
+  before_each(clear)
+
+  it('works', function()
+    source([[
+      helpgrep quickfix
+      copen
+      " This wipes out the buffer, make sure that doesn't cause trouble.
+      cclose
+    ]])
+  end)
+end)


### PR DESCRIPTION
Problem:    Illegal memory access when using :copen and :cclose.
Solution:   Avoid that curbuf is invalid. (suggestion by Justin M. Keyes)
            Add a test.

https://github.com/vim/vim/commit/62ef797496c6243d111c596a592a8ef8c1d1e710
