### PR TITLE
[RFC] vim-patch:7.4.{754,755,758,760} and commit 979243b

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1,4 +1,4 @@
-*change.txt*    For Vim version 7.4.  Last change: 2015 Feb 10
+*change.txt*    For Vim version 7.4.  Last change: 2015 Jun 25
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -366,9 +366,42 @@ Adding and subtracting ~
 CTRL-A			Add [count] to the number or alphabetic character at
 			or after the cursor.
 
+                                                       *v_CTRL-A*
+{Visual}CTRL-A		Add [count] to the number or alphabetic character in
+			the highlighted text.  {not in Vi}
+
+							*v_g_CTRL-A*
+{Visual}g CTRL-A	Add [count] to the number or alphabetic character in
+			the highlighted text. If several lines are
+		        highlighted, each one will be incremented by an
+			additional [count] (so effectively creating a
+			[count] incrementing sequence).  {not in Vi}
+			For Example, if you have this list of numbers:
+				1. ~
+				1. ~
+				1. ~
+				1. ~
+			Move to the second "1." and Visually select three
+			lines, pressing g CTRL-A results in:
+				1. ~
+				2. ~
+				3. ~
+				4. ~
+
 							*CTRL-X*
 CTRL-X			Subtract [count] from the number or alphabetic
 			character at or after the cursor.
+
+							*v_CTRL-X*
+{Visual}CTRL-X		Subtract [count] from the number or alphabetic
+			character in the highlighted text.  {not in Vi}
+
+							*v_g_CTRL-X*
+{Visual}g CTRL-X	Subtract [count] from the number or alphabetic
+			character in the highlighted text. If several lines
+			are highlighted, each value will be decremented by an
+			additional [count] (so effectively creating a [count]
+			decrementing sequence).  {not in Vi}
 
 The CTRL-A and CTRL-X commands work for (signed) decimal numbers, unsigned
 binary/octal/hexadecimal numbers and alphabetic characters.  This

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2028,7 +2028,7 @@ split( {expr} [, {pat} [, {keepempty}]])
 sqrt( {expr})			Float	square root of {expr}
 str2float( {expr})		Float	convert String to Float
 str2nr( {expr} [, {base}])	Number	convert String to Number
-strchars( {expr})		Number	character length of the String {expr}
+strchars( {expr} [, {skipcc}])	Number	character length of the String {expr}
 strdisplaywidth( {expr} [, {col}]) Number display length of the String {expr}
 strftime( {format}[, {time}])	String	time in specified format
 stridx( {haystack}, {needle}[, {start}])
@@ -6229,15 +6229,11 @@ string({expr})	Return {expr} converted to a String.  If {expr} is a Number,
 							*strlen()*
 strlen({expr})	The result is a Number, which is the length of the String
 		{expr} in bytes.
-		If you want to count the number of multi-byte characters (not
-		counting composing characters) use something like this: >
-
-			:let len = strlen(substitute(str, ".", "x", "g"))
-<
 		If the argument is a Number it is first converted to a String.
 		For other types an error is given.
-		Also see |len()|, |strchars()|, |strdisplaywidth()| and
-		|strwidth()|.
+		If you want to count the number of multi-byte characters use
+		|strchars()|.
+		Also see |len()|, |strdisplaywidth()| and |strwidth()|.
 
 strpart({src}, {start}[, {len}])			*strpart()*
 		The result is a String, which is part of {src}, starting from

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 7.4.  Last change: 2015 Nov 30
+*eval.txt*	For Vim version 7.4.  Last change: 2015 Jun 26
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1003,7 +1003,7 @@ function.  Example: >
 
 
 
-string						*string* *expr-string* *E114*
+string					*string* *String* *expr-string* *E114*
 ------
 "string"		string constant		*expr-quote*
 
@@ -6155,15 +6155,17 @@ str2nr( {expr} [, {base}])				*str2nr()*
 		Text after the number is silently ignored.
 
 
-strchars({expr})					*strchars()*
+strchars({expr} [, {skipcc}])					*strchars()*
 		The result is a Number, which is the number of characters
-		String {expr} occupies.  Composing characters are counted
-		separately.
+		in String {expr}.
+		When {skipcc} is omitted or zero, composing characters are
+		counted separately.
+		When {skipcc} set to 1, Composing characters are ignored.
 		Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
 
 strdisplaywidth({expr}[, {col}])			*strdisplaywidth()*
 		The result is a Number, which is the number of display cells
-		String {expr} occupies on the screen when it starts a {col}.
+		String {expr} occupies on the screen when it starts at {col}.
 		When {col} is omitted zero is used.  Otherwise it is the
 		screen column where to start.  This matters for Tab
 		characters.

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1,4 +1,4 @@
-*insert.txt*    For Vim version 7.4.  Last change: 2015 May 22
+*insert.txt*    For Vim version 7.4.  Last change: 2015 Jun 20
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -78,8 +78,8 @@ CTRL-W		Delete the word before the cursor (see |i_backspacing| about
 		|word-motions|, for the definition of a word.
 						*i_CTRL-U*
 CTRL-U		Delete all entered characters before the cursor in the current
-		line.  If there are no newly entereed characters and
-		'backspace'is not empty, delete all characters before the
+		line.  If there are no newly entered characters and
+		'backspace' is not empty, delete all characters before the
 		cursor in the current line.
 		See |i_backspacing| about joining lines.
 						*i_CTRL-I* *i_<Tab>* *i_Tab*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3045,12 +3045,13 @@ static int do_lock_var(lval_T *lp, char_u *name_end, int deep, int lock)
       li = li->li_next;
       ++lp->ll_n1;
     }
-  } else if (lp->ll_list != NULL)
-    /* (un)lock a List item. */
+  } else if (lp->ll_list != NULL) {
+    // (un)lock a List item.
     item_lock(&lp->ll_li->li_tv, deep, lock);
-  else
-    /* un(lock) a Dictionary item. */
+  } else {
+    // (un)lock a Dictionary item.
     item_lock(&lp->ll_di->di_tv, deep, lock);
+  }
 
   return ret;
 }
@@ -7337,7 +7338,7 @@ static struct fst {
   { "sqrt",              1, 1, f_sqrt },
   { "str2float",         1, 1, f_str2float },
   { "str2nr",            1, 2, f_str2nr },
-  { "strchars",          1, 1, f_strchars },
+  { "strchars",          1, 2, f_strchars },
   { "strdisplaywidth",   1, 2, f_strdisplaywidth },
   { "strftime",          1, 2, f_strftime },
   { "stridx",            2, 3, f_stridx },
@@ -16166,13 +16167,23 @@ static void f_strlen(typval_T *argvars, typval_T *rettv)
 static void f_strchars(typval_T *argvars, typval_T *rettv)
 {
   char_u              *s = get_tv_string(&argvars[0]);
+  int skipcc = 0;
   varnumber_T len = 0;
+  int (*func_mb_ptr2char_adv)(char_u **pp);
 
-  while (*s != NUL) {
-    mb_cptr2char_adv(&s);
-    ++len;
+  if (argvars[1].v_type != VAR_UNKNOWN) {
+    skipcc = get_tv_number_chk(&argvars[1], NULL);
   }
-  rettv->vval.v_number = len;
+  if (skipcc < 0 || skipcc > 1) {
+    EMSG(_(e_invarg));
+  } else {
+    func_mb_ptr2char_adv = skipcc ? mb_ptr2char_adv : mb_cptr2char_adv;
+    while (*s != NUL) {
+      func_mb_ptr2char_adv(&s);
+      ++len;
+    }
+    rettv->vval.v_number = len;
+  }
 }
 
 /*

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -5136,6 +5136,8 @@ static int ex_window(void)
 
     /* Don't execute autocommands while deleting the window. */
     block_autocmds();
+    // Avoid command-line window first character being concealed
+    curwin->w_p_cole = 0;
     wp = curwin;
     bp = curbuf;
     win_goto(old_curwin);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3503,9 +3503,17 @@ static void nv_help(cmdarg_T *cap)
  */
 static void nv_addsub(cmdarg_T *cap)
 {
-  if (!checkclearopq(cap->oap)
-      && do_addsub(cap->cmdchar, cap->count1))
+  bool visual = VIsual_active;
+  if (cap->oap->op_type == OP_NOP
+      && do_addsub(cap->cmdchar, cap->count1, cap->arg) == OK) {
     prep_redo_cmd(cap);
+  } else {
+    clearopbeep(cap->oap);
+  }
+  if (visual) {
+    VIsual_active = false;
+    redraw_later(CLEAR);
+  }
 }
 
 /*
@@ -6327,9 +6335,19 @@ static void nv_g_cmd(cmdarg_T *cap)
   bool flag = false;
 
   switch (cap->nchar) {
-  /*
-   * "gR": Enter virtual replace mode.
-   */
+    // "g^A/g^X": sequentially increment visually selected region
+    case Ctrl_A:
+    case Ctrl_X:
+      if (VIsual_active) {
+        cap->arg = true;
+        cap->cmdchar = cap->nchar;
+        nv_addsub(cap);
+      } else {
+        clearopbeep(oap);
+      }
+      break;
+
+  // "gR": Enter virtual replace mode.
   case 'R':
     cap->arg = true;
     nv_Replace(cap);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4202,9 +4202,10 @@ static void reverse_line(char_u *s)
 ///
 /// @param command CTRL-A for add, CTRL-X for subtract
 //  @param Prenum1 number to add or subtract
+//  @param g_cmd was g<c-a>/g<c-x>
 ///
 /// @return FAIL for failure, OK otherwise
-int do_addsub(int command, linenr_T Prenum1)
+int do_addsub(int command, linenr_T Prenum1, int g_cmd)
 {
   int col;
   char_u      *buf1;
@@ -4212,6 +4213,7 @@ int do_addsub(int command, linenr_T Prenum1)
   int pre;                      // 'X' or 'x': hex; '0': octal; 'B' or 'b': bin
   static int hexupper = false;  // 0xABC
   unsigned long n, oldn;
+  long offset = 0;  // line offset for Ctrl_V mode
   char_u      *ptr;
   int c;
   int length = 0;               // character length of the number
@@ -4221,252 +4223,301 @@ int do_addsub(int command, linenr_T Prenum1)
   int dobin;
   int doalp;
   int firstdigit;
-  int negative;
   int subtract;
+  int negative = false;
+  int visual = VIsual_active;
+  int i;
+  int lnum = curwin->w_cursor.lnum;
+  int lnume = curwin->w_cursor.lnum;
 
   dohex = (vim_strchr(curbuf->b_p_nf, 'x') != NULL);    // "heX"
   dooct = (vim_strchr(curbuf->b_p_nf, 'o') != NULL);    // "Octal"
   dobin = (vim_strchr(curbuf->b_p_nf, 'b') != NULL);    // "Bin"
   doalp = (vim_strchr(curbuf->b_p_nf, 'p') != NULL);    // "alPha"
 
-  ptr = get_cursor_line_ptr();
-  RLADDSUBFIX(ptr);
-
   // First check if we are on a hexadecimal number, after the "0x".
   col = curwin->w_cursor.col;
-
-  if (dobin) {
-    while (col > 0 && ascii_isbdigit(ptr[col])) {
-      col--;
+  if (VIsual_active) {
+    if (lt(curwin->w_cursor, VIsual)) {
+      pos_T t;
+      t = curwin->w_cursor;
+      curwin->w_cursor = VIsual;
+      VIsual = t;
     }
-  }
-
-  if (dohex) {
-    while (col > 0 && ascii_isxdigit(ptr[col])) {
-      col--;
+    if (VIsual_mode == 'V') {
+      VIsual.col = 0;
     }
-  }
-  if (dobin
-      && dohex
-      && !((col > 0
-            && (ptr[col] == 'X' ||
-                ptr[col] == 'x')
-            && ptr[col - 1] == '0'
-            && ascii_isxdigit(ptr[col + 1])))) {
-      // In case of binary/hexadecimal pattern overlap match, rescan
 
-      col = curwin->w_cursor.col;
+    ptr = ml_get(VIsual.lnum);
+    RLADDSUBFIX(ptr);
 
-      while (col > 0 && ascii_isdigit(ptr[col])) {
-        col--;
-      }
-  }
+    // store visual area for 'gv'
+    curbuf->b_visual.vi_start = VIsual;
+    curbuf->b_visual.vi_end = curwin->w_cursor;
+    curbuf->b_visual.vi_mode = VIsual_mode;
 
-  if ((dohex
-       && col > 0
-       && (ptr[col] == 'X'
-           || ptr[col] == 'x')
-       && ptr[col - 1] == '0'
-       && ascii_isxdigit(ptr[col + 1])) ||
-      (dobin
-       && col > 0
-       && (ptr[col] == 'B'
-           || ptr[col] == 'b')
-       && ptr[col - 1] == '0'
-       && ascii_isbdigit(ptr[col + 1]))) {
-       // Found hexadecimal or binary number, move to its start.
-      col--;
-  } else {
-    // Search forward and then backward to find the start of number.
-    col = curwin->w_cursor.col;
-
-    while (ptr[col] != NUL
-           && !ascii_isdigit(ptr[col])
-           && !(doalp && ASCII_ISALPHA(ptr[col]))) {
+    col = VIsual.col;
+    lnum = VIsual.lnum;
+    lnume = curwin->w_cursor.lnum;
+    if (ptr[col] == '-') {
+      negative = true;
       col++;
     }
-
-    while (col > 0
-           && ascii_isdigit(ptr[col - 1])
-           && !(doalp && ASCII_ISALPHA(ptr[col]))) {
-      col--;
-    }
-  }
-
-  // If a number was found, and saving for undo works, replace the number.
-  firstdigit = ptr[col];
-  RLADDSUBFIX(ptr);
-  if ((!ascii_isdigit(firstdigit) && !(doalp && ASCII_ISALPHA(firstdigit)))
-      || u_save_cursor() != OK) {
-    beep_flush();
-    return FAIL;
-  }
-
-  // get ptr again, because u_save() may have changed it
-  ptr = get_cursor_line_ptr();
-  RLADDSUBFIX(ptr);
-
-  if (doalp && ASCII_ISALPHA(firstdigit)) {
-    // decrement or increment alphabetic character
-    if (command == Ctrl_X) {
-      if (CharOrd(firstdigit) < Prenum1) {
-        if (isupper(firstdigit)) {
-          firstdigit = 'A';
-        } else {
-          firstdigit = 'a';
-        }
-      } else {
-        firstdigit -= Prenum1;
-      }
-    } else {
-      if (26 - CharOrd(firstdigit) - 1 < Prenum1) {
-        if (isupper(firstdigit)) {
-          firstdigit = 'Z';
-        } else {
-          firstdigit = 'z';
-        }
-      } else {
-        firstdigit += Prenum1;
-      }
-    }
-    curwin->w_cursor.col = col;
-    (void)del_char(false);
-    ins_char(firstdigit);
   } else {
-    negative = false;
-    if (col > 0 && ptr[col - 1] == '-') {           // negative number
-      --col;
-      negative = true;
+    ptr = get_cursor_line_ptr();
+    RLADDSUBFIX(ptr);
+
+    if (dobin) {
+      while (col > 0 && ascii_isbdigit(ptr[col])) {
+        col--;
+      }
     }
 
-    // get the number value (unsigned)
-    vim_str2nr(ptr + col, &pre, &length, dobin, dooct, dohex, NULL, &n);
-
-    // ignore leading '-' for hex, octal and bin numbers
-    if (pre && negative) {
-      ++col;
-      --length;
-      negative = false;
+    if (dohex) {
+      while (col > 0 && ascii_isxdigit(ptr[col])) {
+        col--;
+      }
     }
+    if (dobin
+        && dohex
+        && !((col > 0
+              && (ptr[col] == 'X' ||
+                  ptr[col] == 'x')
+              && ptr[col - 1] == '0'
+              && ascii_isxdigit(ptr[col + 1])))) {
+        // In case of binary/hexadecimal pattern overlap match, rescan
 
-    // add or subtract
-    subtract = false;
-    if (command == Ctrl_X) {
-      subtract ^= true;
-    }
-    if (negative) {
-      subtract ^= true;
-    }
+        col = curwin->w_cursor.col;
 
-    oldn = n;
-
-    n = subtract ? n - (unsigned long) Prenum1
-                 : n + (unsigned long) Prenum1;
-
-    // handle wraparound for decimal numbers
-    if (!pre) {
-      if (subtract) {
-        if (n > oldn) {
-          n = 1 + (n ^ (unsigned long)-1);
-          negative ^= true;
+        while (col > 0 && ascii_isdigit(ptr[col])) {
+          col--;
         }
-      } else { /* add */
-        if (n < oldn) {
-          n = (n ^ (unsigned long)-1);
-          negative ^= true;
+    }
+
+    if ((dohex
+         && col > 0
+         && (ptr[col] == 'X'
+             || ptr[col] == 'x')
+         && ptr[col - 1] == '0'
+         && ascii_isxdigit(ptr[col + 1])) ||
+        (dobin
+         && col > 0
+         && (ptr[col] == 'B'
+             || ptr[col] == 'b')
+         && ptr[col - 1] == '0'
+         && ascii_isbdigit(ptr[col + 1]))) {
+         // Found hexadecimal or binary number, move to its start.
+        col--;
+    } else {
+      // Search forward and then backward to find the start of number.
+      col = curwin->w_cursor.col;
+
+      while (ptr[col] != NUL
+             && !ascii_isdigit(ptr[col])
+             && !(doalp && ASCII_ISALPHA(ptr[col]))) {
+        col++;
+      }
+
+      while (col > 0
+             && ascii_isdigit(ptr[col - 1])
+             && !(doalp && ASCII_ISALPHA(ptr[col]))) {
+        col--;
+      }
+    }
+  }
+
+  for (i = lnum; i <= lnume; i++) {
+    curwin->w_cursor.lnum = i;
+    ptr = get_cursor_line_ptr();
+    RLADDSUBFIX(ptr);
+    if ((int)STRLEN(ptr) <= col) {
+      col = 0;
+    }
+
+    // If a number was found, and saving for undo works, replace the number.
+    firstdigit = ptr[col];
+    RLADDSUBFIX(ptr);
+    if ((!ascii_isdigit(firstdigit) && !(doalp && ASCII_ISALPHA(firstdigit)))
+        || u_save_cursor() != OK) {
+      if (lnum < lnume) {
+        // Try again on next line.
+        continue;
+      }
+      beep_flush();
+      return FAIL;
+    }
+
+    ptr = get_cursor_line_ptr();
+    RLADDSUBFIX(ptr);
+
+    if (doalp && ASCII_ISALPHA(firstdigit)) {
+      // decrement or increment alphabetic character
+      if (command == Ctrl_X) {
+        if (CharOrd(firstdigit) < Prenum1) {
+          if (isupper(firstdigit)) {
+            firstdigit = 'A';
+          } else {
+            firstdigit = 'a';
+          }
+        } else {
+          firstdigit -= Prenum1;
+        }
+      } else {
+        if (26 - CharOrd(firstdigit) - 1 < Prenum1) {
+          if (isupper(firstdigit)) {
+            firstdigit = 'Z';
+          } else {
+            firstdigit = 'z';
+          }
+        } else {
+          firstdigit += Prenum1;
         }
       }
-      if (n == 0) {
+      curwin->w_cursor.col = col;
+      (void)del_char(false);
+      ins_char(firstdigit);
+    } else {
+      if (col > 0 && ptr[col - 1] == '-' && !visual) {
+        // negative number
+        --col;
+        negative = true;
+      }
+
+      // get the number value (unsigned)
+      vim_str2nr(ptr + col, &pre, &length, dobin, dooct, dohex, NULL, &n);
+
+      // ignore leading '-' for hex, octal and bin numbers
+      if (pre && negative) {
+        ++col;
+        --length;
         negative = false;
       }
-    }
 
-    // Delete the old number.
-    curwin->w_cursor.col = col;
-    todel = length;
-    c = gchar_cursor();
+      // add or subtract
+      subtract = false;
+      if (command == Ctrl_X) {
+        subtract ^= true;
+      }
+      if (negative) {
+        subtract ^= true;
+      }
 
-    // Don't include the '-' in the length, only the length of the part
-    // after it is kept the same.
-    if (c == '-') {
-      --length;
-    }
-    while (todel-- > 0) {
-      if (c < 0x100 && isalpha(c)) {
-        if (isupper(c)) {
-          hexupper = true;
-        } else {
-          hexupper = false;
+      oldn = n;
+
+      n = subtract ? n - (unsigned long) Prenum1
+                   : n + (unsigned long) Prenum1;
+
+      // handle wraparound for decimal numbers
+      if (!pre) {
+        if (subtract) {
+          if (n > oldn) {
+            n = 1 + (n ^ (unsigned long)-1);
+            negative ^= true;
+          }
+        } else {  // add
+          if (n < oldn) {
+            n = (n ^ (unsigned long)-1);
+            negative ^= true;
+          }
+        }
+        if (n == 0) {
+          negative = false;
         }
       }
-      // del_char() will mark line needing displaying
-      (void)del_char(false);
+
+      // Delete the old number.
+      curwin->w_cursor.col = col;
+      todel = length;
       c = gchar_cursor();
-    }
 
-    // Prepare the leading characters in buf1[].
-    // When there are many leading zeros it could be very long.  Allocate
-    // a bit too much.
-    buf1 = xmalloc(length + NUMBUFLEN);
-    ptr = buf1;
-    if (negative) {
-      *ptr++ = '-';
-    }
-    if (pre) {
-      *ptr++ = '0';
-      --length;
-    }
-    if (pre == 'b' || pre == 'B' ||
-        pre == 'x' || pre == 'X') {
-      *ptr++ = pre;
-      --length;
-    }
-
-    // Put the number characters in buf2[].
-    if (pre == 'b' || pre == 'B') {
-      size_t bits = 0;
-      size_t pos = 0;
-
-      // leading zeros
-      for (bits = 8 * sizeof(unsigned long); bits > 0; bits--) {
-          if ((n >> (bits - 1)) & 0x1) { break; }
+      // Don't include the '-' in the length, only the length of the part
+      // after it is kept the same.
+      if (c == '-') {
+        --length;
+      }
+      while (todel-- > 0) {
+        if (c < 0x100 && isalpha(c)) {
+          if (isupper(c)) {
+            hexupper = true;
+          } else {
+            hexupper = false;
+          }
+        }
+        // del_char() will mark line needing displaying
+        (void)del_char(false);
+        c = gchar_cursor();
       }
 
-      while (bits > 0) {
-          buf2[pos++] = ((n >> --bits) & 0x1) ? '1' : '0';
+      // Prepare the leading characters in buf1[].
+      // When there are many leading zeros it could be very long.  Allocate
+      // a bit too much.
+      buf1 = xmalloc(length + NUMBUFLEN);
+      ptr = buf1;
+      // do not add leading '-' for visual mode
+      if (negative && !visual) {
+        *ptr++ = '-';
       }
-
-      buf2[pos] = '\0';
-
-    } else if (pre == 0) {
-      snprintf((char *)buf2, NUMBUFLEN, "%" PRIu64, (uint64_t)n);
-    } else if (pre == '0') {
-      snprintf((char *)buf2, NUMBUFLEN, "%" PRIo64, (uint64_t)n);
-    } else if (pre && hexupper) {
-      snprintf((char *)buf2, NUMBUFLEN, "%" PRIX64, (uint64_t)n);
-    } else {
-      snprintf((char *)buf2, NUMBUFLEN, "%" PRIx64, (uint64_t)n);
-    }
-    length -= (int)STRLEN(buf2);
-
-    // Adjust number of zeros to the new number of digits, so the
-    // total length of the number remains the same.
-    // Don't do this when
-    // the result may look like an octal number.
-    if (firstdigit == '0' && !(dooct && pre == 0)) {
-      while (length-- > 0) {
+      if (pre) {
         *ptr++ = '0';
+        --length;
       }
+      if (pre == 'b' || pre == 'B' ||
+          pre == 'x' || pre == 'X') {
+        *ptr++ = pre;
+        --length;
+      }
+
+      // Put the number characters in buf2[].
+      if (pre == 'b' || pre == 'B') {
+        size_t bits = 0;
+        size_t pos = 0;
+
+        // leading zeros
+        for (bits = 8 * sizeof(unsigned long); bits > 0; bits--) {
+            if ((n >> (bits - 1)) & 0x1) { break; }
+        }
+
+        while (bits > 0) {
+            buf2[pos++] = ((n >> --bits) & 0x1) ? '1' : '0';
+        }
+
+        buf2[pos] = '\0';
+
+      } else if (pre == 0) {
+        snprintf((char *)buf2, NUMBUFLEN, "%" PRIu64, (uint64_t)(n + offset));
+      } else if (pre == '0') {
+        snprintf((char *)buf2, NUMBUFLEN, "%" PRIo64, (uint64_t)(n + offset));
+      } else if (pre && hexupper) {
+        snprintf((char *)buf2, NUMBUFLEN, "%" PRIX64, (uint64_t)(n + offset));
+      } else {
+        snprintf((char *)buf2, NUMBUFLEN, "%" PRIx64, (uint64_t)(n + offset));
+      }
+      length -= (int)STRLEN(buf2);
+
+      if (g_cmd) {
+        offset = subtract ? offset - (unsigned long)Prenum1
+                          : offset + (unsigned long)Prenum1;
+      }
+
+      // Adjust number of zeros to the new number of digits, so the
+      // total length of the number remains the same.
+      // Don't do this when
+      // the result may look like an octal number.
+      if (firstdigit == '0' && !(dooct && pre == 0)) {
+        while (length-- > 0) {
+          *ptr++ = '0';
+        }
+      }
+      *ptr = NUL;
+      STRCAT(buf1, buf2);
+      ins_str(buf1);              // insert the new number
+      xfree(buf1);
     }
-    *ptr = NUL;
-    STRCAT(buf1, buf2);
-    ins_str(buf1);              /* insert the new number */
-    xfree(buf1);
+    --curwin->w_cursor.col;
+    curwin->w_set_curswant = true;
+    ptr = ml_get_buf(curbuf, curwin->w_cursor.lnum, true);
+    RLADDSUBFIX(ptr);
   }
-  --curwin->w_cursor.col;
-  curwin->w_set_curswant = true;
-  ptr = ml_get_buf(curbuf, curwin->w_cursor.lnum, true);
-  RLADDSUBFIX(ptr);
   return OK;
 }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3004,14 +3004,19 @@ static void syn_cmd_spell(exarg_T *eap, int syncing)
     return;
 
   next = skiptowhite(arg);
-  if (STRNICMP(arg, "toplevel", 8) == 0 && next - arg == 8)
+  if (STRNICMP(arg, "toplevel", 8) == 0 && next - arg == 8) {
     curwin->w_s->b_syn_spell = SYNSPL_TOP;
-  else if (STRNICMP(arg, "notoplevel", 10) == 0 && next - arg == 10)
+  } else if (STRNICMP(arg, "notoplevel", 10) == 0 && next - arg == 10) {
     curwin->w_s->b_syn_spell = SYNSPL_NOTOP;
-  else if (STRNICMP(arg, "default", 7) == 0 && next - arg == 7)
+  } else if (STRNICMP(arg, "default", 7) == 0 && next - arg == 7) {
     curwin->w_s->b_syn_spell = SYNSPL_DEFAULT;
-  else
+  } else {
     EMSG2(_("E390: Illegal argument: %s"), arg);
+    return;
+  }
+
+  // assume spell checking changed, force a redraw
+  redraw_win_later(curwin, NOT_VALID);
 }
 
 /*

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -374,7 +374,7 @@ static int included_patches[] = {
   // 763 NA
   // 762 NA
   // 761 NA
-  // 760,
+  760,
   // 759 NA
   758,
   // 757 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -379,7 +379,7 @@ static int included_patches[] = {
   // 758,
   // 757 NA
   // 756 NA
-  // 755,
+  755,
   754,
   753,
   // 752,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -380,7 +380,7 @@ static int included_patches[] = {
   // 757 NA
   // 756 NA
   // 755,
-  // 754,
+  754,
   753,
   // 752,
   // 751 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -376,7 +376,7 @@ static int included_patches[] = {
   // 761 NA
   // 760,
   // 759 NA
-  // 758,
+  758,
   // 757 NA
   // 756 NA
   755,

--- a/test/functional/legacy/increment_spec.lua
+++ b/test/functional/legacy/increment_spec.lua
@@ -1,0 +1,101 @@
+local helpers = require('test.functional.helpers')
+local clear, feed = helpers.clear, helpers.feed
+local expect, insert = helpers.expect, helpers.insert
+
+describe('increment/decrement in visual mode', function()
+  before_each(function()
+    clear()
+  end)
+
+  it('increments the number', function()
+    insert([[foobar-10]])
+    feed('gg^<c-a>')
+    expect([[foobar-9]])
+    clear()
+
+    insert([[foobar-10]])
+    feed('ggf-v$<c-a>')
+    expect([[foobar-9]])
+    clear()
+
+    insert([[foobar-10]])
+    feed('ggf1v$<c-a>')
+    expect([[foobar-11]])
+    clear()
+  end)
+
+  it('decrements the number', function()
+    insert([[foobar-10]])
+    feed('ggf-v$<c-x>')
+    expect([[foobar-11]])
+    clear()
+
+    insert([[foobar-10]])
+    feed('ggf1v$<c-x>')
+    expect([[foobar-9]])
+  end)
+
+  it('increments numbers on visually selected lines', function()
+    insert([[
+      10
+      20
+      30
+      40]])
+    feed('gg<s-v>G<c-a>')
+    expect([[
+      11
+      21
+      31
+      41]])
+  end)
+
+  it('decrements numbers on visually selected lines', function()
+    insert([[
+      10
+      20
+      30
+      40]])
+    feed('gg<s-v>G<c-x>')
+    expect([[
+      9
+      19
+      29
+      39]])
+  end)
+
+  it('increments numbers of visually selected lines, with non-numbers in betwen', function()
+    insert([[10
+
+20
+
+30
+
+40]])
+    feed('ggVG2g<c-a>')
+    expect([[12
+
+24
+
+36
+
+48]])
+  end)
+
+  it('decrements numbers of visually selected lines, with non-numbers in betwen', function()
+    insert([[10
+
+20
+
+30
+
+40]])
+    feed('ggVG2g<c-x>')
+    expect([[8
+
+16
+
+24
+
+32]])
+  end)
+end)

--- a/test/functional/legacy/utf8_spec.lua
+++ b/test/functional/legacy/utf8_spec.lua
@@ -3,6 +3,7 @@
 local helpers = require('test.functional.helpers')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
+local eq, eval = helpers.eq, helpers.eval
 
 describe('utf8', function()
   setup(clear)
@@ -26,5 +27,27 @@ describe('utf8', function()
       axaa
       xあああ
       bxbb]])
+  end)
+
+  it('tests strchars()', function()
+    eq(1, eval('strchars("a")'))
+    eq(1, eval('strchars("a", 0)'))
+    eq(1, eval('strchars("a", 1)'))
+
+    eq(3, eval('strchars("あいa")'))
+    eq(3, eval('strchars("あいa", 0)'))
+    eq(3, eval('strchars("あいa", 1)'))
+
+    eq(2, eval('strchars("A\\u20dd")'))
+    eq(2, eval('strchars("A\\u20dd", 0)'))
+    eq(1, eval('strchars("A\\u20dd", 1)'))
+
+    eq(3, eval('strchars("A\\u20dd\\u20dd")'))
+    eq(3, eval('strchars("A\\u20dd\\u20dd", 0)'))
+    eq(1, eval('strchars("A\\u20dd\\u20dd", 1)'))
+
+    eq(1, eval('strchars("\\u20dd")'))
+    eq(1, eval('strchars("\\u20dd", 0)'))
+    eq(1, eval('strchars("\\u20dd", 1)'))
   end)
 end)


### PR DESCRIPTION
```
Problem:    Using CTRL-A in Visual mode does not work well. (Gary Johnson)
Solution:   Make it increment all numbers in the Visual area. (Christian
            Brabandt)
```

https://github.com/vim/vim/commit/3a304b23823b089e499063e8211c5695d049f3ba

```
Problem:    It is not easy to count the number of characters.
Solution:   Add the skipcc argument to strchars(). (Hirohito Higashi, Ken
            Takata)
```

https://github.com/vim/vim/commit/641e48c2248ccb3c25a5cdaa3709f16152d8c77d

```
Problem:    When 'conceallevel' is 1 and quitting the command-line window with
            CTRL-C the first character ':' is erased.
Solution:   Reset 'conceallevel' in the command-line window. (Hirohito
            Higashi)
```

https://github.com/vim/vim/commit/fa67fbe6b84133207271e4ff582c3d589172efd9

```
Problem:    Spelling mistakes are not displayed after ":syn spell".
Solution:   Force a redraw after ":syn spell" command. (Christian Brabandt)
```

https://github.com/vim/vim/commit/5081d202475328a920c0bdcab990e8da84128c13

```
Update help files.
```

https://github.com/vim/vim/commit/979243b
