### PR TITLE
[RFC] vim-patch:7.4.771

### DIFF
--- a/scripts/legacy2luatest.pl
+++ b/scripts/legacy2luatest.pl
@@ -287,7 +287,7 @@ local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 
 describe('$test_name', function()
-  setup(clear)
+  before_each(clear)
 
   it('is working', function()
 @{[join "\n", map { /^$/ ? '' : '    ' . $_ } @{$test_body_lines}]}

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -497,6 +497,7 @@ int searchit(
   pos_T start_pos;
   int at_first_line;
   int extra_col;
+  int start_char_len;
   int match_ok;
   long nmatched;
   int submatch = 0;
@@ -519,16 +520,21 @@ int searchit(
     // When not accepting a match at the start position set "extra_col" to a
     // non-zero value.  Don't do that when starting at MAXCOL, since MAXCOL + 1
     // is zero.
-    if ((options & SEARCH_START) || pos->col == MAXCOL) {
-      extra_col = 0;
-    } else if (dir != BACKWARD && has_mbyte
+    if (pos->col == MAXCOL) {
+      start_char_len = 0;
+    } else if (has_mbyte
         && pos->lnum >= 1 && pos->lnum <= buf->b_ml.ml_line_count
         && pos->col < MAXCOL - 2) {
       // Watch out for the "col" being MAXCOL - 2, used in a closed fold.
       ptr = ml_get_buf(buf, pos->lnum, FALSE) + pos->col;
-      extra_col = *ptr == NUL ? 1 : (*mb_ptr2len)(ptr);
+      start_char_len = *ptr == NUL ? 1 : (*mb_ptr2len)(ptr);
     } else {
-      extra_col = 1;
+      start_char_len = 1;
+    }
+    if (dir == FORWARD) {
+      extra_col = (options & SEARCH_START) ? 0 : start_char_len;
+    } else {
+      extra_col = (options & SEARCH_START) ? start_char_len : 0;
     }
 
     start_pos = *pos;           /* remember start pos for detecting no match */
@@ -679,15 +685,13 @@ int searchit(
                          || (lnum + regmatch.endpos[0].lnum
                              == start_pos.lnum
                              && (int)regmatch.endpos[0].col - 1
-                             + extra_col
-                             <= (int)start_pos.col))
+                             < (int)start_pos.col + extra_col))
                       : (lnum + regmatch.startpos[0].lnum
                          < start_pos.lnum
                          || (lnum + regmatch.startpos[0].lnum
                              == start_pos.lnum
                              && (int)regmatch.startpos[0].col
-                             + extra_col
-                             <= (int)start_pos.col)))) {
+                             < (int)start_pos.col + extra_col)))) {
                 match_ok = TRUE;
                 matchpos = regmatch.startpos[0];
                 endpos = regmatch.endpos[0];

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -523,10 +523,10 @@ int searchit(
     if (pos->col == MAXCOL) {
       start_char_len = 0;
     } else if (has_mbyte
-        && pos->lnum >= 1 && pos->lnum <= buf->b_ml.ml_line_count
-        && pos->col < MAXCOL - 2) {
+               && pos->lnum >= 1 && pos->lnum <= buf->b_ml.ml_line_count
+               && pos->col < MAXCOL - 2) {
       // Watch out for the "col" being MAXCOL - 2, used in a closed fold.
-      ptr = ml_get_buf(buf, pos->lnum, FALSE) + pos->col;
+      ptr = ml_get_buf(buf, pos->lnum, false) + pos->col;
       start_char_len = *ptr == NUL ? 1 : (*mb_ptr2len)(ptr);
     } else {
       start_char_len = 1;
@@ -692,7 +692,7 @@ int searchit(
                              == start_pos.lnum
                              && (int)regmatch.startpos[0].col
                              < (int)start_pos.col + extra_col)))) {
-                match_ok = TRUE;
+                match_ok = true;
                 matchpos = regmatch.startpos[0];
                 endpos = regmatch.endpos[0];
                 submatch = first_submatch(&regmatch);

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -363,7 +363,7 @@ static int included_patches[] = {
   774,
   773,
   // 772 NA
-  // 771,
+  771,
   // 770 NA
   // 769,
   // 768,

--- a/test/functional/legacy/search_mbyte_spec.lua
+++ b/test/functional/legacy/search_mbyte_spec.lua
@@ -5,7 +5,7 @@ local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 
 describe('search_mbyte', function()
-  setup(clear)
+  before_each(clear)
 
   it('is working', function()
     insert([=[

--- a/test/functional/legacy/search_mbyte_spec.lua
+++ b/test/functional/legacy/search_mbyte_spec.lua
@@ -1,7 +1,7 @@
 -- Test for search('multi-byte char', 'bce')
 
 local helpers = require('test.functional.helpers')
-local feed, insert, source = helpers.feed, helpers.insert, helpers.source
+local insert = helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 
 describe('search_mbyte', function()

--- a/test/functional/legacy/search_mbyte_spec.lua
+++ b/test/functional/legacy/search_mbyte_spec.lua
@@ -1,0 +1,31 @@
+-- Test for search('multi-byte char', 'bce')
+
+local helpers = require('test.functional.helpers')
+local feed, insert, source = helpers.feed, helpers.insert, helpers.source
+local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
+
+describe('search_mbyte', function()
+  setup(clear)
+
+  it('is working', function()
+    insert([=[
+      Results:
+      
+      Test bce:
+      Ａ]=])
+
+    execute('source small.vim')
+    execute('source mbyte.vim')
+    execute('set encoding=utf-8')
+    execute('/^Test bce:/+1')
+    execute([[$put =search('Ａ', 'bce', line('.'))]])
+
+    -- Assert buffer contents.
+    expect([=[
+      Results:
+      
+      Test bce:
+      Ａ
+      4]=])
+  end)
+end)


### PR DESCRIPTION
```
Problem:    Search does not handle multi-byte character at the start position
            correctly.
Solution:   Take byte size of character into account. (Yukihiro Nakadaira)
```

https://github.com/vim/vim/commit/5f1e68b7bc241118e5dd8fc781147fdda881ada8
