### PR TITLE
[RFC] fix typo in doc/nvim_provider.txt

### DIFF
--- a/runtime/doc/nvim_provider.txt
+++ b/runtime/doc/nvim_provider.txt
@@ -26,7 +26,7 @@ are now decoupled from Nvim core as providers:
 
 The first example is clipboard integration: in the original Vim source code,
 clipboard functions account for more than 1k lines of C source code (and that
-is just on ui.c), all to peform two tasks that are now accomplished with
+is just on ui.c), all to perform two tasks that are now accomplished with
 simple shell commands such as xclip or pbcopy/pbpaste.
 
 The other example is Python scripting support: Vim has three files dedicated to


### PR DESCRIPTION
Found a spelling mistake - 
`peform` > `perform`
