### PR TITLE
Improve clipboard provider

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -1,6 +1,12 @@
 " The clipboard provider uses shell commands to communicate with the clipboard.
 " The provider function will only be registered if a supported command is
 " available.
+if exists('s:loaded_provider_clipboard')
+  finish
+endif
+
+let s:loaded_provider_clipboard = 1
+
 let s:copy = {}
 let s:paste = {}
 
@@ -37,16 +43,16 @@ if executable('pbcopy')
   let s:copy['*'] = s:copy['+']
   let s:paste['*'] = s:paste['+']
   let s:cache_enabled = 0
-elseif executable('xclip')
-  let s:copy['+'] = 'xclip -quiet -i -selection clipboard'
-  let s:paste['+'] = 'xclip -o -selection clipboard'
-  let s:copy['*'] = 'xclip -quiet -i -selection primary'
-  let s:paste['*'] = 'xclip -o -selection primary'
-elseif executable('xsel')
+elseif exists('$DISPLAY') && executable('xsel')
   let s:copy['+'] = 'xsel --nodetach -i -b'
   let s:paste['+'] = 'xsel -o -b'
   let s:copy['*'] = 'xsel --nodetach -i -p'
   let s:paste['*'] = 'xsel -o -p'
+elseif exists('$DISPLAY') && executable('xclip')
+  let s:copy['+'] = 'xclip -quiet -i -selection clipboard'
+  let s:paste['+'] = 'xclip -o -selection clipboard'
+  let s:copy['*'] = 'xclip -quiet -i -selection primary'
+  let s:paste['*'] = 'xclip -o -selection primary'
 else
   echom 'clipboard: No clipboard tool available. See :help nvim-clipboard'
   finish


### PR DESCRIPTION
- User can disable clipboard provider by `g:loaded_clipboard_provider`
- Check `$DISPLAY` exists
- xsel has higher priority than xclip.  Because, it is newer
