### PR TITLE
[RFC] vim-patch:7.4.688

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2548,8 +2548,12 @@ void ins_compl_show_pum(void)
       }
   }
 
-  /* Compute the screen column of the start of the completed text.
-   * Use the cursor to get all wrapping and other settings right. */
+  // In Replace mode when a $ is displayed at the end of the line only
+  // part of the screen would be updated.  We do need to redraw here.
+  dollar_vcol = -1;
+
+  // Compute the screen column of the start of the completed text.
+  // Use the cursor to get all wrapping and other settings right.
   col = curwin->w_cursor.col;
   curwin->w_cursor.col = compl_col;
   pum_display(compl_match_array, compl_match_arraysize, cur);

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -600,7 +600,7 @@ static int included_patches[] = {
   // 691 NA
   690,
   // 689,
-  // 688,
+  688,
   // 687 NA
   686,
   685,


### PR DESCRIPTION
```
Problem:    When "$" is in 'cpo' the popup menu isn't undrawn correctly.
            (Issue 166)
Solution:   When using the popup menu remove the "$".
```

https://github.com/vim/vim/commit/478c46e50fd94f270369ec1c5f76aa65af7ee671

---

see: https://github.com/vim/vim/issues/166
NOTE: We need the following command for reproducing it.

``` sh
$ nvim -u NONE -c 'exe "norm iaaa iabbbbbb acc" | norm yyp' -c 'set cpo+=$'
```
