### PR TITLE
[RFC] vim-patch:7.4.693

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8368,8 +8368,7 @@ makeopens (
 {
   int only_save_windows = TRUE;
   int nr;
-  int cnr = 1;
-  int restore_size = TRUE;
+  int restore_size = true;
   win_T       *wp;
   char_u      *sname;
   win_T       *edited_win = NULL;
@@ -8486,7 +8485,8 @@ makeopens (
   tab_firstwin = firstwin;      /* first window in tab page "tabnr" */
   tab_topframe = topframe;
   for (tabnr = 1;; ++tabnr) {
-    int need_tabnew = FALSE;
+    int need_tabnew = false;
+    int cnr = 1;
 
     if ((ssop_flags & SSOP_TABPAGES)) {
       tabpage_T *tp = find_tabpage(tabnr);

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -595,7 +595,7 @@ static int included_patches[] = {
   696,
   695,
   694,
-  // 693,
+  693,
   // 692 NA
   // 691 NA
   690,


### PR DESCRIPTION
```
Problem:    Session file is not correct when there are multiple tab pages.
Solution:   Reset the current window number for each tab page. (Jacob Niehus)
```

https://github.com/vim/vim/commit/695baeefe17adcd95f91d089efee87bd96fc98db

---

see: [[patch] wincmd error during session restore](https://groups.google.com/d/msg/vim_dev/NykQ0UuOjXc/_MZi4sv9vp0J)

What I did for testing:

``` sh
mkdir /tmp/test_session
cd $_

function test_session() {
  $1 -u NONE -i NONE -N ~/.vimrc \
    -c 'wincmd s'      \
    -c 'wincmd v'      \
    -c 'wincmd T'      \
    -c 'normal 1gt'    \
    -c '2wincmd w'     \
    -c 'mks! test.vis' \
    -c 'qa'
  $1 -u NONE -i NONE -N -S test.vis
}

test_session vim
test_session nvim
test_session /path/to/your/neovim/repository/build/bin/nvim
```
