### PR TITLE
Vim 541f92

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1019,7 +1019,7 @@ A string constant accepts these special characters:
 \X.	same as \x.
 \u....	character specified with up to 4 hex numbers, stored according to the
 	current value of 'encoding' (e.g., "\u02a4")
-\U....	same as \u....
+\U....	same as \u but allows up to 8 hex numbers.
 \b	backspace <BS>
 \e	escape <Esc>
 \f	formfeed <FF>

--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -2,7 +2,7 @@
 " Header: "{{{
 " Maintainer:	Bram Moolenaar
 " Original Author: Andy Wokula <anwoku@yahoo.de>
-" Last Change:	2015 Jan 11
+" Last Change:	2015 Jun 12
 " Version:	1.0
 " Description:	HTML indent script with cached state for faster indenting on a
 "		range of lines.
@@ -94,7 +94,7 @@ func! HtmlIndent_CheckUserSettings()
     let autotags = g:html_indent_autotags
   endif
   let b:hi_removed_tags = {}
-  if autotags
+  if len(autotags) > 0
     call s:RemoveITags(b:hi_removed_tags, split(autotags, ","))
   endif
 

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,9 +1,8 @@
 " Vim syntax file
 " Language:	Python
-" Maintainer:	Neil Schemenauer <nas@python.ca>
-" Last Change:	2014 Jul 16
-" Credits:	Zvezdan Petkovic <zpetkovic@acm.org>
-"		Neil Schemenauer <nas@python.ca>
+" Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
+" Last Change:	2015 Jun 19
+" Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "
 "		This version is a major rewrite by Zvezdan Petkovic.
@@ -113,7 +112,7 @@ syn match   pythonEscape	"\\\o\{1,3}" contained
 syn match   pythonEscape	"\\x\x\{2}" contained
 syn match   pythonEscape	"\%(\\u\x\{4}\|\\U\x\{8}\)" contained
 " Python allows case-insensitive Unicode IDs: http://www.unicode.org/charts/
-syn match   pythonEscape	"\\N{.\{-}}" contained
+syn match   pythonEscape	"\\N{\a\+\%(\s\a\+\)*}" contained
 syn match   pythonEscape	"\\$"
 
 if exists("python_highlight_all")
@@ -274,6 +273,8 @@ if version >= 508 || !exists("did_python_syn_inits")
   HiLink pythonTodo		Todo
   HiLink pythonString		String
   HiLink pythonRawString	String
+  HiLink pythonQuotes		String
+  HiLink pythonTripleQuotes	pythonQuotes
   HiLink pythonEscape		Special
   if !exists("python_no_number_highlight")
     HiLink pythonNumber		Number

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -2,8 +2,8 @@
 " Language:		shell (sh) Korn shell (ksh) bash (sh)
 " Maintainer:		Charles E. Campbell  <NdrOchipS@PcampbellAfamily.Mbiz>
 " Previous Maintainer:	Lennart Schultz <Lennart.Schultz@ecmwf.int>
-" Last Change:		Apr 10, 2015
-" Version:		136
+" Last Change:		May 29, 2015
+" Version:		137
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
 " This file includes many ideas from ?ric Brunet (eric.brunet@ens.fr)
@@ -17,7 +17,7 @@ elseif exists("b:current_syntax")
 endif
 
 " AFAICT "." should be considered part of the iskeyword.  Using iskeywords in
-" syntax is dicey, so the following code permits the user to prevent/override
+" syntax is dicey, so the following code permits the user to
 "  g:sh_isk set to a string	: specify iskeyword.
 "  g:sh_noisk exists	: don't change iskeyword
 "  g:sh_noisk does not exist	: (default) append "." to iskeyword
@@ -108,8 +108,7 @@ syn cluster shArithParenList	contains=shArithmetic,shCaseEsac,shComment,shDeref,
 syn cluster shArithList	contains=@shArithParenList,shParenError
 syn cluster shCaseEsacList	contains=shCaseStart,shCase,shCaseBar,shCaseIn,shComment,shDeref,shDerefSimple,shCaseCommandSub,shCaseExSingleQuote,shCaseSingleQuote,shCaseDoubleQuote,shCtrlSeq,@shErrorList,shStringSpecial,shCaseRange
 syn cluster shCaseList	contains=@shCommandSubList,shCaseEsac,shColon,shCommandSub,shComment,shDo,shEcho,shExpr,shFor,shHereDoc,shIf,shRedir,shSetList,shSource,shStatement,shVariable,shCtrlSeq
-"syn cluster shColonList	contains=@shCaseList
-syn cluster shCommandSubList	contains=shArithmetic,shDeref,shDerefSimple,shEcho,shEscape,shNumber,shOption,shPosnParm,shExSingleQuote,shSingleQuote,shExDoubleQuote,shDoubleQuote,shStatement,shVariable,shSubSh,shAlias,shTest,shCtrlSeq,shSpecial,shCmdParenRegion
+syn cluster shCommandSubList	contains=shAlias,shArithmetic,shCmdParenRegion,shCtrlSeq,shDeref,shDerefSimple,shDoubleQuote,shEcho,shEscape,shExDoubleQuote,shExpr,shExSingleQuote,shNumber,shOperator,shOption,shPosnParm,shSingleQuote,shSpecial,shStatement,shSubSh,shTest,shVariable
 syn cluster shCurlyList	contains=shNumber,shComma,shDeref,shDerefSimple,shDerefSpecial
 syn cluster shDblQuoteList	contains=shCommandSub,shDeref,shDerefSimple,shEscape,shPosnParm,shCtrlSeq,shSpecial
 syn cluster shDerefList	contains=shDeref,shDerefSimple,shDerefVar,shDerefSpecial,shDerefWordError,shDerefPPS
@@ -182,7 +181,7 @@ syn match      shRedir	"\d<<-\="
 syn match   shOperator	"<<\|>>"		contained
 syn match   shOperator	"[!&;|]"		contained
 syn match   shOperator	"\[[[^:]\|\]]"		contained
-syn match   shOperator	"!\=="		skipwhite nextgroup=shPattern
+syn match   shOperator	"[-=/*+%]\=="		skipwhite nextgroup=shPattern
 syn match   shPattern	"\<\S\+\())\)\@="	contained contains=shExSingleQuote,shSingleQuote,shExDoubleQuote,shDoubleQuote,shDeref
 
 " Subshells: {{{1
@@ -194,8 +193,8 @@ syn region shSubSh transparent matchgroup=shSubShRegion start="[^(]\zs(" end=")"
 "=======
 syn region shExpr	matchgroup=shRange start="\[" skip=+\\\\\|\\$\|\[+ end="\]" contains=@shTestList,shSpecial
 syn region shTest	transparent matchgroup=shStatement start="\<test\s" skip=+\\\\\|\\$+ matchgroup=NONE end="[;&|]"me=e-1 end="$" contains=@shExprList1
+syn match  shTestOpr	contained	'[^-+/%]\zs=' skipwhite nextgroup=shTestDoubleQuote,shTestSingleQuote,shTestPattern
 syn match  shTestOpr	contained	"<=\|>=\|!=\|==\|-.\>\|-\(nt\|ot\|ef\|eq\|ne\|lt\|le\|gt\|ge\)\>\|[!<>]"
-syn match  shTestOpr	contained	'=' skipwhite nextgroup=shTestDoubleQuote,shTestSingleQuote,shTestPattern
 syn match  shTestPattern	contained	'\w\+'
 syn region shTestDoubleQuote	contained	start='\%(\%(\\\\\)*\\\)\@<!"' skip=+\\\\\|\\"+ end='"'
 syn match  shTestSingleQuote	contained	'\\.'
@@ -322,12 +321,13 @@ elseif !exists("g:sh_no_error")
 endif
 syn region  shSingleQuote	matchgroup=shQuote start=+'+ end=+'+		contains=@Spell
 syn region  shDoubleQuote	matchgroup=shQuote start=+\%(\%(\\\\\)*\\\)\@<!"+ skip=+\\"+ end=+"+	contains=@shDblQuoteList,shStringSpecial,@Spell
-"syn region  shDoubleQuote	matchgroup=shQuote start=+"+ skip=+\\"+ end=+"+	contains=@shDblQuoteList,shStringSpecial,@Spell
-syn match   shStringSpecial	"[^[:print:] \t]"	contained
+syn region  shDoubleQuote	matchgroup=shQuote start=+"+ skip=+\\"+ end=+"+	contains=@shDblQuoteList,shStringSpecial,@Spell
+syn match   shStringSpecial	"[^[:print:] \t]"		contained
 syn match   shStringSpecial	"\%(\\\\\)*\\[\\"'`$()#]"
-syn match   shSpecial	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]" nextgroup=shMoreSpecial,shComment
-syn match   shSpecial	"^\%(\\\\\)*\\[\\"'`$()#]"	nextgroup=shComment
-syn match   shMoreSpecial	"\%(\\\\\)*\\[\\"'`$()#]" nextgroup=shMoreSpecial contained
+" COMBAK: why is ,shComment on next line???
+syn match   shSpecial	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]"	nextgroup=shMoreSpecial,shComment
+syn match   shSpecial	"^\%(\\\\\)*\\[\\"'`$()#]"		nextgroup=shComment
+syn match   shMoreSpecial	"\%(\\\\\)*\\[\\"'`$()#]"		nextgroup=shMoreSpecial contained
 
 " Comments: {{{1
 "==========
@@ -341,42 +341,42 @@ syn match	shQuickComment	contained	"#.*$"
 " Here Documents: {{{1
 " =========================================
 if version < 600
- syn region shHereDoc matchgroup=shRedir01 start="<<\s*\**END[a-zA-Z_0-9]*\**" 		matchgroup=shRedir01 end="^END[a-zA-Z_0-9]*$"	contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir02 start="<<-\s*\**END[a-zA-Z_0-9]*\**"		matchgroup=shRedir02 end="^\s*END[a-zA-Z_0-9]*$"	contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir03 start="<<\s*\**EOF\**"		matchgroup=shRedir03	end="^EOF$"	contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir04 start="<<-\s*\**EOF\**"		matchgroup=shRedir04	end="^\s*EOF$"	contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir05 start="<<\s*\**\.\**"		matchgroup=shRedir05	end="^\.$"	contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir06 start="<<-\s*\**\.\**"		matchgroup=shRedir06	end="^\s*\.$"	contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc01 start="<<\s*\**END[a-zA-Z_0-9]*\**" 	matchgroup=shHereDoc01 end="^END[a-zA-Z_0-9]*$"	contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc02 start="<<-\s*\**END[a-zA-Z_0-9]*\**"	matchgroup=shHereDoc02 end="^\s*END[a-zA-Z_0-9]*$"	contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc03 start="<<\s*\**EOF\**"		matchgroup=shHereDoc03 end="^EOF$"	contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc04 start="<<-\s*\**EOF\**"		matchgroup=shHereDoc04 end="^\s*EOF$"	contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc05 start="<<\s*\**\.\**"		matchgroup=shHereDoc05 end="^\.$"	contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc06 start="<<-\s*\**\.\**"		matchgroup=shHereDoc06 end="^\s*\.$"	contains=@shDblQuoteList
 
 elseif s:sh_fold_heredoc
- syn region shHereDoc matchgroup=shRedir07 fold start="<<\s*\z([^ \t|]*\)"		matchgroup=shRedir07 end="^\z1\s*$"	contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir08 fold start="<<\s*\"\z([^ \t|]*\)\""		matchgroup=shRedir08 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir09 fold start="<<\s*'\z([^ \t|]*\)'"		matchgroup=shRedir09 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir10 fold start="<<-\s*\z([^ \t|]*\)"		matchgroup=shRedir10 end="^\s*\z1\s*$"	contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir11 fold start="<<-\s*\"\z([^ \t|]*\)\""		matchgroup=shRedir11 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir12 fold start="<<-\s*'\z([^ \t|]*\)'"		matchgroup=shRedir12 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir13 fold start="<<\s*\\\_$\_s*\z([^ \t|]*\)"	matchgroup=shRedir13 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir14 fold start="<<\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shRedir14 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir15 fold start="<<-\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shRedir15 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir16 fold start="<<-\s*\\\_$\_s*\z([^ \t|]*\)"	matchgroup=shRedir16 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir17 fold start="<<-\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shRedir17 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir18 fold start="<<\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shRedir18 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir19 fold start="<<\\\z([^ \t|]*\)"		matchgroup=shRedir19 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc07 fold start="<<\s*\z([^ \t|]*\)"		matchgroup=shHereDoc07 end="^\z1\s*$"	contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc08 fold start="<<\s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc08 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc09 fold start="<<\s*'\z([^ \t|]*\)'"		matchgroup=shHereDoc09 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc10 fold start="<<-\s*\z([^ \t|]*\)"		matchgroup=shHereDoc10 end="^\s*\z1\s*$"	contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc11 fold start="<<-\s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc11 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc12 fold start="<<-\s*'\z([^ \t|]*\)'"		matchgroup=shHereDoc12 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc13 fold start="<<\s*\\\_$\_s*\z([^ \t|]*\)"	matchgroup=shHereDoc13 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc14 fold start="<<\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc14 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc15 fold start="<<-\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shHereDoc15 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc16 fold start="<<-\s*\\\_$\_s*\z([^ \t|]*\)"	matchgroup=shHereDoc16 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc17 fold start="<<-\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc17 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc18 fold start="<<\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shHereDoc18 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc19 fold start="<<\\\z([^ \t|]*\)"		matchgroup=shHereDoc19 end="^\z1\s*$"
 
 else
- syn region shHereDoc matchgroup=shRedir20 start="<<\s*\\\=\z([^ \t|]*\)"		matchgroup=shRedir20 end="^\z1\s*$"    contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir21 start="<<\s*\"\z([^ \t|]*\)\""		matchgroup=shRedir21 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir22 start="<<-\s*\z([^ \t|]*\)"		matchgroup=shRedir22 end="^\s*\z1\s*$" contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir23 start="<<-\s*'\z([^ \t|]*\)'"		matchgroup=shRedir23 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir24 start="<<\s*'\z([^ \t|]*\)'"		matchgroup=shRedir24 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir25 start="<<-\s*\"\z([^ \t|]*\)\""		matchgroup=shRedir25 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir26 start="<<\s*\\\_$\_s*\z([^ \t|]*\)"		matchgroup=shRedir26 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir27 start="<<-\s*\\\_$\_s*\z([^ \t|]*\)"		matchgroup=shRedir27 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir28 start="<<-\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shRedir28 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir29 start="<<\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shRedir29 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir30 start="<<\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shRedir30 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir31 start="<<-\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shRedir31 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir32 start="<<\\\z([^ \t|]*\)"		matchgroup=shRedir32 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc20 start="<<\s*\\\=\z([^ \t|]*\)"		matchgroup=shHereDoc20 end="^\z1\s*$"    contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc21 start="<<\s*\"\z([^ \t|]*\)\""		matchgroup=shHereDoc21 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc22 start="<<-\s*\z([^ \t|]*\)"		matchgroup=shHereDoc22 end="^\s*\z1\s*$" contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc23 start="<<-\s*'\z([^ \t|]*\)'"		matchgroup=shHereDoc23 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc24 start="<<\s*'\z([^ \t|]*\)'"		matchgroup=shHereDoc24 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc25 start="<<-\s*\"\z([^ \t|]*\)\""		matchgroup=shHereDoc25 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc26 start="<<\s*\\\_$\_s*\z([^ \t|]*\)"	matchgroup=shHereDoc26 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc27 start="<<-\s*\\\_$\_s*\z([^ \t|]*\)"	matchgroup=shHereDoc27 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc28 start="<<-\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shHereDoc28 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc29 start="<<\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shHereDoc29 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc30 start="<<\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc30 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc31 start="<<-\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc31 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc32 start="<<\\\z([^ \t|]*\)"		matchgroup=shHereDoc32 end="^\z1\s*$"
 endif
 
 " Here Strings: {{{1
@@ -389,8 +389,8 @@ endif
 " Identifiers: {{{1
 "=============
 syn match  shSetOption	"\s\zs[-+][a-zA-Z0-9]\+\>"	contained
-syn match  shVariable	"\<\([bwglsav]:\)\=[a-zA-Z0-9.!@_%+,]*\ze="	nextgroup=shSetIdentifier
-syn match  shSetIdentifier	"="		contained	nextgroup=shCmdParenRegion,shPattern,shDeref,shDerefSimple,shDoubleQuote,shExDoubleQuote,shSingleQuote,shExSingleQuote
+syn match  shVariable	"\<\([bwglsav]:\)\=[a-zA-Z0-9.!@_%+,]*\ze="	nextgroup=shVarAssign
+syn match  shVarAssign	"="		contained	nextgroup=shCmdParenRegion,shPattern,shDeref,shDerefSimple,shDoubleQuote,shExDoubleQuote,shSingleQuote,shExSingleQuote
 syn region shAtExpr	contained	start="@(" end=")" contains=@shIdList
 if exists("b:is_bash")
  syn region shSetList oneline matchgroup=shSet start="\<\(declare\|typeset\|local\|export\|unset\)\>\ze[^/]" end="$"	matchgroup=shSetListDelim end="\ze[}|);&]" matchgroup=NONE end="\ze\s\+#\|="	contains=@shIdList
@@ -668,38 +668,38 @@ hi def link shStatement		Statement
 hi def link shString		String
 hi def link shTodo		Todo
 hi def link shAlias		Identifier
-hi def link shRedir01		shRedir
-hi def link shRedir02		shRedir
-hi def link shRedir03		shRedir
-hi def link shRedir04		shRedir
-hi def link shRedir05		shRedir
-hi def link shRedir06		shRedir
-hi def link shRedir07		shRedir
-hi def link shRedir08		shRedir
-hi def link shRedir09		shRedir
-hi def link shRedir10		shRedir
-hi def link shRedir11		shRedir
-hi def link shRedir12		shRedir
-hi def link shRedir13		shRedir
-hi def link shRedir14		shRedir
-hi def link shRedir15		shRedir
-hi def link shRedir16		shRedir
-hi def link shRedir17		shRedir
-hi def link shRedir18		shRedir
-hi def link shRedir19		shRedir
-hi def link shRedir20		shRedir
-hi def link shRedir21		shRedir
-hi def link shRedir22		shRedir
-hi def link shRedir23		shRedir
-hi def link shRedir24		shRedir
-hi def link shRedir25		shRedir
-hi def link shRedir26		shRedir
-hi def link shRedir27		shRedir
-hi def link shRedir28		shRedir
-hi def link shRedir29		shRedir
-hi def link shRedir30		shRedir
-hi def link shRedir31		shRedir
-hi def link shRedir32		shRedir
+hi def link shHereDoc01		shRedir
+hi def link shHereDoc02		shRedir
+hi def link shHereDoc03		shRedir
+hi def link shHereDoc04		shRedir
+hi def link shHereDoc05		shRedir
+hi def link shHereDoc06		shRedir
+hi def link shHereDoc07		shRedir
+hi def link shHereDoc08		shRedir
+hi def link shHereDoc09		shRedir
+hi def link shHereDoc10		shRedir
+hi def link shHereDoc11		shRedir
+hi def link shHereDoc12		shRedir
+hi def link shHereDoc13		shRedir
+hi def link shHereDoc14		shRedir
+hi def link shHereDoc15		shRedir
+hi def link shHereDoc16		shRedir
+hi def link shHereDoc17		shRedir
+hi def link shHereDoc18		shRedir
+hi def link shHereDoc19		shRedir
+hi def link shHereDoc20		shRedir
+hi def link shHereDoc21		shRedir
+hi def link shHereDoc22		shRedir
+hi def link shHereDoc23		shRedir
+hi def link shHereDoc24		shRedir
+hi def link shHereDoc25		shRedir
+hi def link shHereDoc26		shRedir
+hi def link shHereDoc27		shRedir
+hi def link shHereDoc28		shRedir
+hi def link shHereDoc29		shRedir
+hi def link shHereDoc30		shRedir
+hi def link shHereDoc31		shRedir
+hi def link shHereDoc32		shRedir
 
 " Set Current Syntax: {{{1
 " ===================

--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	TeX
 " Maintainer:	Charles E. Campbell <NdrchipO@ScampbellPfamily.AbizM>
-" Last Change:	Apr 02, 2015
-" Version:	84
+" Last Change:	Jun 11, 2015
+" Version:	87
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_TEX
 "
 " Notes: {{{1
@@ -207,7 +207,7 @@ if s:tex_fast =~ 'M'
    if !exists("s:tex_no_error") || !s:tex_no_error
     syn match  texMathError	"}"	contained
    endif
-   syn region texMathMatcher	matchgroup=Delimiter	start="{"          skip="\\\\\|\\}"     end="}" end="%stopzone\>"	contained contains=@texMathMatchGroup
+   syn region texMathMatcher	matchgroup=Delimiter	start="{"          skip="\(\\\\\)*\\}"     end="}" end="%stopzone\>"	contained contains=@texMathMatchGroup
   endif
 endif
 
@@ -226,7 +226,7 @@ endif
 " TeX/LaTeX delimiters: {{{1
 syn match texDelimiter		"&"
 syn match texDelimiter		"\\\\"
-syn match texDelimiter		"[{}]"
+"%syn match texDelimiter		"[{}]"
 
 " Tex/Latex Options: {{{1
 syn match texOption		"[^\\]\zs#\d\+\|^#\d\+"
@@ -247,7 +247,7 @@ syn match texLigature		"\\\([ijolL]\|ae\|oe\|ss\|AA\|AE\|OE\)$"
 " \begin{}/\end{} section markers: {{{1
 syn match  texBeginEnd		"\\begin\>\|\\end\>" nextgroup=texBeginEndName
 if s:tex_fast =~ 'm'
-  syn region texBeginEndName	matchgroup=Delimiter	start="{"		end="}"	contained	nextgroup=texBeginEndModifier	contains=texComment
+  syn region texBeginEndName		matchgroup=Delimiter	start="{"		end="}"	contained	nextgroup=texBeginEndModifier	contains=texComment
   syn region texBeginEndModifier	matchgroup=Delimiter	start="\["		end="]"	contained	contains=texComment,@NoSpell
 endif
 
@@ -392,22 +392,22 @@ endif
 if s:tex_fast =~ 'b'
   if s:tex_conceal =~ 'b'
    if !exists("g:tex_nospell") || !g:tex_nospell
-    syn region texBoldStyle	matchgroup=texTypeStyle start="\\textbf\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texBoldGroup,@Spell
-    syn region texBoldItalStyle	matchgroup=texTypeStyle start="\\textit\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texItalGroup,@Spell
-    syn region texItalStyle	matchgroup=texTypeStyle start="\\textit\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texItalGroup,@Spell
-    syn region texItalBoldStyle	matchgroup=texTypeStyle start="\\textbf\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texBoldGroup,@Spell
-   else
-    syn region texBoldStyle	matchgroup=texTypeStyle start="\\textbf\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texBoldGroup
-    syn region texBoldItalStyle	matchgroup=texTypeStyle start="\\textit\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texItalGroup
-    syn region texItalStyle	matchgroup=texTypeStyle start="\\textit\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texItalGroup
-    syn region texItalBoldStyle	matchgroup=texTypeStyle start="\\textbf\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texBoldGroup
+    syn region texBoldStyle	matchgroup=texTypeStyle start="\\textbf\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texBoldGroup,@Spell
+    syn region texBoldItalStyle	matchgroup=texTypeStyle start="\\textit\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texItalGroup,@Spell
+    syn region texItalStyle	matchgroup=texTypeStyle start="\\textit\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texItalGroup,@Spell
+    syn region texItalBoldStyle	matchgroup=texTypeStyle start="\\textbf\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texBoldGroup,@Spell
+   else                                                                                              
+    syn region texBoldStyle	matchgroup=texTypeStyle start="\\textbf\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texBoldGroup
+    syn region texBoldItalStyle	matchgroup=texTypeStyle start="\\textit\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texItalGroup
+    syn region texItalStyle	matchgroup=texTypeStyle start="\\textit\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texItalGroup
+    syn region texItalBoldStyle	matchgroup=texTypeStyle start="\\textbf\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texBoldGroup
    endif
   endif
 endif
 
 " Bad Math (mismatched): {{{1
 if !exists("g:tex_no_math") && (!exists("s:tex_no_error") || !s:tex_no_error)
- syn match texBadMath		"\\end\s*{\s*\(array\|gathered\|bBpvV]matrix\|split\|subequations\|smallmatrix\|xxalignat\)\s*}"
+ syn match texBadMath		"\\end\s*{\s*\(array\|gathered\|bBpvV]matrix\|split\|smallmatrix\|xxalignat\)\s*}"
  syn match texBadMath		"\\end\s*{\s*\(align\|alignat\|displaymath\|displaymath\|eqnarray\|equation\|flalign\|gather\|math\|multline\|xalignat\)\*\=\s*}"
  syn match texBadMath		"\\[\])]"
 endif
@@ -456,24 +456,23 @@ if !exists("g:tex_no_math")
  call TexNewMathZone("G","gather",1)
  call TexNewMathZone("H","math",1)
  call TexNewMathZone("I","multline",1)
- call TexNewMathZone("J","subequations",0)
- call TexNewMathZone("K","xalignat",1)
- call TexNewMathZone("L","xxalignat",0)
+ call TexNewMathZone("J","xalignat",1)
+ call TexNewMathZone("K","xxalignat",0)
 
  " Inline Math Zones: {{{2
  if s:tex_fast =~ 'M'
   if has("conceal") && &enc == 'utf-8' && s:tex_conceal =~ 'd'
-   syn region texMathZoneV	matchgroup=Delimiter start="\\("			matchgroup=Delimiter end="\\)\|%stopzone\>"	keepend concealends contains=@texMathZoneGroup
-   syn region texMathZoneW	matchgroup=Delimiter start="\\\["			matchgroup=Delimiter end="\\]\|%stopzone\>"	keepend concealends contains=@texMathZoneGroup
-   syn region texMathZoneX	matchgroup=Delimiter start="\$" skip="\\\\\|\\\$"	matchgroup=Delimiter end="\$" end="%stopzone\>"		concealends contains=@texMathZoneGroup
-   syn region texMathZoneY	matchgroup=Delimiter start="\$\$" 			matchgroup=Delimiter end="\$\$" end="%stopzone\>"	concealends keepend		contains=@texMathZoneGroup
+   syn region texMathZoneV	matchgroup=Delimiter start="\\("			matchgroup=Delimiter	end="\\)\|%stopzone\>"			keepend concealends contains=@texMathZoneGroup
+   syn region texMathZoneW	matchgroup=Delimiter start="\\\["			matchgroup=Delimiter	end="\\]\|%stopzone\>"			keepend concealends contains=@texMathZoneGroup
+   syn region texMathZoneX	matchgroup=Delimiter start="\$" skip="\\\\\|\\\$"	matchgroup=Delimiter	end="\$"	end="%stopzone\>"		concealends contains=@texMathZoneGroup
+   syn region texMathZoneY	matchgroup=Delimiter start="\$\$" 			matchgroup=Delimiter	end="\$\$"	end="%stopzone\>"	keepend concealends contains=@texMathZoneGroup
   else
-   syn region texMathZoneV	matchgroup=Delimiter start="\\("			matchgroup=Delimiter end="\\)\|%stopzone\>"	keepend contains=@texMathZoneGroup
-   syn region texMathZoneW	matchgroup=Delimiter start="\\\["			matchgroup=Delimiter end="\\]\|%stopzone\>"	keepend contains=@texMathZoneGroup
-   syn region texMathZoneX	matchgroup=Delimiter start="\$" skip="\\\\\|\\\$"	matchgroup=Delimiter end="\$" end="%stopzone\>"	contains=@texMathZoneGroup
-   syn region texMathZoneY	matchgroup=Delimiter start="\$\$" 			matchgroup=Delimiter end="\$\$" end="%stopzone\>"	keepend		contains=@texMathZoneGroup
+   syn region texMathZoneV	matchgroup=Delimiter start="\\("			matchgroup=Delimiter	end="\\)\|%stopzone\>"			keepend contains=@texMathZoneGroup
+   syn region texMathZoneW	matchgroup=Delimiter start="\\\["			matchgroup=Delimiter	end="\\]\|%stopzone\>"			keepend contains=@texMathZoneGroup
+   syn region texMathZoneX	matchgroup=Delimiter start="\$" skip="\\\\\|\\\$"	matchgroup=Delimiter	end="\$"	end="%stopzone\>"		contains=@texMathZoneGroup
+   syn region texMathZoneY	matchgroup=Delimiter start="\$\$" 			matchgroup=Delimiter	end="\$\$"	end="%stopzone\>"	keepend	contains=@texMathZoneGroup
   endif
-  syn region texMathZoneZ	matchgroup=texStatement start="\\ensuremath\s*{"	matchgroup=texStatement end="}" end="%stopzone\>"	contains=@texMathZoneGroup
+  syn region texMathZoneZ	matchgroup=texStatement start="\\ensuremath\s*{"	matchgroup=texStatement	end="}"		end="%stopzone\>"	contains=@texMathZoneGroup
  endif
 
  syn match texMathOper		"[_^=]" contained
@@ -1062,11 +1061,12 @@ if has("conceal") && &enc == 'utf-8'
    syn region texSuperscript	matchgroup=Delimiter start='\^{'	skip="\\\\\|\\[{}]" end='}'	contained concealends contains=texSpecialChar,texSuperscripts,texStatement,texSubscript,texSuperscript,texMathMatcher
    syn region texSubscript	matchgroup=Delimiter start='_{'		skip="\\\\\|\\[{}]" end='}'	contained concealends contains=texSpecialChar,texSubscripts,texStatement,texSubscript,texSuperscript,texMathMatcher
   endif
+  " s:SuperSub:
   fun! s:SuperSub(group,leader,pat,cchar)
     if a:pat =~ '^\\' || (a:leader == '\^' && a:pat =~ g:tex_superscripts) || (a:leader == '_' && a:pat =~ g:tex_subscripts)
 "     call Decho("SuperSub: group<".a:group."> leader<".a:leader."> pat<".a:pat."> cchar<".a:cchar.">")
      exe 'syn match '.a:group." '".a:leader.a:pat."' contained conceal cchar=".a:cchar
-     exe 'syn match '.a:group."s '".a:pat."' contained conceal cchar=".a:cchar.' nextgroup='.a:group.'s'
+     exe 'syn match '.a:group."s '".a:pat        ."' contained conceal cchar=".a:cchar.' nextgroup='.a:group.'s'
     endif
   endfun
   call s:SuperSub('texSuperscript','\^','0','⁰')


### PR DESCRIPTION
Includes all changes from vim 541f92 except R changes, which were merged out of order in bd30ae.

```
Updated runtime files.
```

https://github.com/vim/vim/commit/541f92

Original patch:

`````` diff
commit 541f92d6cfdf2215e743553b5f4b6529dd9fcf31
Author: Bram Moolenaar <Bram@vim.org>
Date:   Fri Jun 19 13:27:23 2015 +0200

    Updated runtime files.

diff --git a/runtime/doc/eval.txt b/runtime/doc/eval.txt
index dd679cc..44abae6 100644
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt* For Vim version 7.4.  Last change: 2015 Apr 30
+*eval.txt* For Vim version 7.4.  Last change: 2015 Jun 19


          VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1021,7 +1021,7 @@ A string constant accepts these special characters:
 \X.    same as \x.
 \u.... character specified with up to 4 hex numbers, stored according to the
    current value of 'encoding' (e.g., "\u02a4")
-\U.... same as \u....
+\U.... same as \u but allows up to 8 hex numbers.
 \b backspace <BS>
 \e escape <Esc>
 \f formfeed <FF>
diff --git a/runtime/doc/todo.txt b/runtime/doc/todo.txt
index afd737b..754e388 100644
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 7.4.  Last change: 2015 Jun 09
+*todo.txt*      For Vim version 7.4.  Last change: 2015 Jun 19


          VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -78,12 +78,6 @@ Patch to make getregtype() return the right size for non-linux systems.
 (Yasuhiro Matsumoto, 2014 Jul 8)
 Breaks test_eval.  Inefficient, can we only compute y_width when needed?

-Patch to fix test (Christian, 2015 May 5)
-
-Patch to fix ml_get error. (Yukihiro Nakadaira, 2015 May 22)
-
-Patch for neovim. (Christian, 2015 May 5)
-
 Problem that a previous silent ":throw" causes a following try/catch not to
 work. (ZyX, 2013 Sep 28)

@@ -91,19 +85,9 @@ Problem using ":try" inside ":execute". (ZyX, 2013 Sep 15)

 Regression for v_b_A. (Ingo Karkat, 2015 May 18)

-Patch for memory access problem. (Dominique Pelle, 2015 May 5)
-
-R indent files update. (Jakson Alves de Aquino, Mar 31)
-
-Updated Python syntax file. (Dmitry Vasiliev, Mar 30)
-Discucussion about what version to use, Petkovic, 2015 May 19.
-Patch for existing syntax file, Zvezdan Petkovic, 2015 May 17)
-
 ":cd C:\Windows\System32\drivers\etc*" does not work, even though the
 directory exists. (Sergio Gallelli, 2013 Dec 29)

-Patch on issue 361 by James McCoy.
-
 Patch on issue 365.

 Patch to add "vsplit" to 'switchbuf'. (Brook Hong, 2015 Jun 4)
@@ -121,6 +105,10 @@ keymap for Russian typewriter layout. (Danwerspb, 2015 May 15)
 Patch for man.vim. (SungHyun Nam, 2015 May 20)
 Doesn't work completely (Dominique Orban)

+The entries added by matchaddpos() are returned by getmatches() but can't be
+set with setmatches(). (lcd47, 2014 Jun 29)
+Patch by Christian, 2015 Jun 16.
+
 Invalid memory access in regexp.c. (Dominique Pelle, 2015 May 23)

 Using ":windo" to set options in all windows has the side effect that it
@@ -142,6 +130,7 @@ Patch for appending in Visual mode with 'linebreak' set.

 Patch to make CTRL-A in Visual mode increment all Visually selected numbers.
 Same for decrement with CTRL-X. (Christian Brabandt, 2015 Jun 8)
+Update Jun 9.

 C indent: should recognize C11 raw strings. (Mark Lodato, 2015 Mar 1)
 Need to recognize R"string" for 'cindent'.
@@ -154,6 +143,11 @@ Patch to detect background terminal color in xterm. (Lubomir Rintel, 2015 Jun
 Patch to fix that in command-line window first character is erased
 when conceallevel is set. (Hirohito Higashi, 2015 May 12)

+Patch to make Lua 5.3 and later work. (Felix Schnizlein, 2015 Jun 11)
+
+Patch to make \U in a string accept up to 8 characters. (Christian Brabandt,
+2015 Jun 12)  Does this break existing scripts?
+
 Crash when changing the 'tags' option from a remote command.
 (Benjamin Fritz, 2015 Mar 18, stack trace Mar 20)

@@ -176,6 +170,13 @@ specifically?  First try with the parens, then without.

 Patch to force redraw after ":syn spell" command. (Christian, 2015 May 8)

+Patch for multi-byte characters in langmap and applying a mapping on them.
+(Christian Brabandt, 2015 Jun 12)
+Is this the right solution?
+
+Patch for langmap not working properly with mapping in Command-line mode.
+Issue 376.
+
 Value returned by virtcol() changes depending on how lines wrap.  This is
 inconsistent with the documentation.

@@ -184,6 +185,7 @@ Better greek spell checking.  Issue 299.
 Patch to add 'completeselect' option.  Specifies how to select a candidate in
 insert completion. (Shougo, 2013 May 29)
 Update to add to existing 'completeopt'. 2013 May 30
+Updated update: Shougo 2015 Jun 12

 When complete() first argument is before where insert started and 'backspace'
 is Vi compatible, the completion fails. (Hirohito Higashi, 2015 Feb 19)
@@ -336,9 +338,6 @@ Patch to add argument to :cquit. (Thinca, 2014 Oct 12)

 No error for missing endwhile. (ZyX, 2014 Mar 20)

-The entries added by matchaddpos() are returned by getmatches() but can't be
-set with setmatches(). (lcd47, 2014 Jun 29)
-
 Patch to make extend() fail early when it might fail at some point.
 (Olaf Dabrunz, 2015 May 2)  Makes extend() slower, do we still want it?
 Perhaps only the checks that can be done without looping over the dict or
diff --git a/runtime/indent/html.vim b/runtime/indent/html.vim
index 71443ab..7eb963b 100644
--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -2,7 +2,7 @@
 " Header: "{{{
 " Maintainer:  Bram Moolenaar
 " Original Author: Andy Wokula <anwoku@yahoo.de>
-" Last Change: 2015 Jan 11
+" Last Change: 2015 Jun 12
 " Version: 1.0
 " Description: HTML indent script with cached state for faster indenting on a
 "      range of lines.
@@ -94,7 +94,7 @@ func! HtmlIndent_CheckUserSettings()
     let autotags = g:html_indent_autotags
   endif
   let b:hi_removed_tags = {}
-  if autotags
+  if len(autotags) > 0
     call s:RemoveITags(b:hi_removed_tags, split(autotags, ","))
   endif

diff --git a/runtime/indent/r.vim b/runtime/indent/r.vim
index 82bdc8b..105f0cd 100644
--- a/runtime/indent/r.vim
+++ b/runtime/indent/r.vim
@@ -1,12 +1,12 @@
 " Vim indent file
 " Language:    R
 " Author:  Jakson Alves de Aquino <jalvesaq@gmail.com>
-" Last Change: Fri Feb 15, 2013  08:11PM
+" Last Change: Thu Mar 26, 2015  05:36PM


 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
-    finish
+  finish
 endif
 let b:did_indent = 1

@@ -15,478 +15,501 @@ setlocal indentexpr=GetRIndent()

 " Only define the function once.
 if exists("*GetRIndent")
-    finish
+  finish
 endif

 " Options to make the indentation more similar to Emacs/ESS:
 if !exists("g:r_indent_align_args")
-    let g:r_indent_align_args = 1
+  let g:r_indent_align_args = 1
 endif
 if !exists("g:r_indent_ess_comments")
-    let g:r_indent_ess_comments = 0
+  let g:r_indent_ess_comments = 0
 endif
 if !exists("g:r_indent_comment_column")
-    let g:r_indent_comment_column = 40
+  let g:r_indent_comment_column = 40
 endif
 if ! exists("g:r_indent_ess_compatible")
-    let g:r_indent_ess_compatible = 0
+  let g:r_indent_ess_compatible = 0
+endif
+if ! exists("g:r_indent_op_pattern")
+  let g:r_indent_op_pattern = '\(+\|-\|\*\|/\|=\|\~\|%\)$'
 endif

 function s:RDelete_quotes(line)
-    let i = 0
-    let j = 0
-    let line1 = ""
-    let llen = strlen(a:line)
-    while i < llen
-        if a:line[i] == '"'
-            let i += 1
-            let line1 = line1 . 's'
-            while !(a:line[i] == '"' && ((i > 1 && a:line[i-1] == '\' && a:line[i-2] == '\') || a:line[i-1] != '\')) && i < llen
-                let i += 1
-            endwhile
-            if a:line[i] == '"'
-                let i += 1
-            endif
-        else
-            if a:line[i] == "'"
-                let i += 1
-                let line1 = line1 . 's'
-                while !(a:line[i] == "'" && ((i > 1 && a:line[i-1] == '\' && a:line[i-2] == '\') || a:line[i-1] != '\')) && i < llen
-                    let i += 1
-                endwhile
-                if a:line[i] == "'"
-                    let i += 1
-                endif
-            else
-                if a:line[i] == "`"
-                    let i += 1
-                    let line1 = line1 . 's'
-                    while a:line[i] != "`" && i < llen
-                        let i += 1
-                    endwhile
-                    if a:line[i] == "`"
-                        let i += 1
-                    endif
-                endif
-            endif
+  let i = 0
+  let j = 0
+  let line1 = ""
+  let llen = strlen(a:line)
+  while i < llen
+    if a:line[i] == '"'
+      let i += 1
+      let line1 = line1 . 's'
+      while !(a:line[i] == '"' && ((i > 1 && a:line[i-1] == '\' && a:line[i-2] == '\') || a:line[i-1] != '\')) && i < llen
+        let i += 1
+      endwhile
+      if a:line[i] == '"'
+        let i += 1
+      endif
+    else
+      if a:line[i] == "'"
+        let i += 1
+        let line1 = line1 . 's'
+        while !(a:line[i] == "'" && ((i > 1 && a:line[i-1] == '\' && a:line[i-2] == '\') || a:line[i-1] != '\')) && i < llen
+          let i += 1
+        endwhile
+        if a:line[i] == "'"
+          let i += 1
         endif
-        if i == llen
-            break
+      else
+        if a:line[i] == "`"
+          let i += 1
+          let line1 = line1 . 's'
+          while a:line[i] != "`" && i < llen
+            let i += 1
+          endwhile
+          if a:line[i] == "`"
+            let i += 1
+          endif
         endif
-        let line1 = line1 . a:line[i]
-        let j += 1
-        let i += 1
-    endwhile
-    return line1
+      endif
+    endif
+    if i == llen
+      break
+    endif
+    let line1 = line1 . a:line[i]
+    let j += 1
+    let i += 1
+  endwhile
+  return line1
 endfunction

 " Convert foo(bar()) int foo()
 function s:RDelete_parens(line)
-    if s:Get_paren_balance(a:line, "(", ")") != 0
-        return a:line
-    endif
-    let i = 0
-    let j = 0
-    let line1 = ""
-    let llen = strlen(a:line)
-    while i < llen
-        let line1 = line1 . a:line[i]
-        if a:line[i] == '('
-            let nop = 1
-            while nop > 0 && i < llen
-                let i += 1
-                if a:line[i] == ')'
-                    let nop -= 1
-                else
-                    if a:line[i] == '('
-                        let nop += 1 
-                    endif
-                endif
-            endwhile
-            let line1 = line1 . a:line[i]
-        endif
+  if s:Get_paren_balance(a:line, "(", ")") != 0
+    return a:line
+  endif
+  let i = 0
+  let j = 0
+  let line1 = ""
+  let llen = strlen(a:line)
+  while i < llen
+    let line1 = line1 . a:line[i]
+    if a:line[i] == '('
+      let nop = 1
+      while nop > 0 && i < llen
         let i += 1
-    endwhile
-    return line1
+        if a:line[i] == ')'
+          let nop -= 1
+        else
+          if a:line[i] == '('
+            let nop += 1
+          endif
+        endif
+      endwhile
+      let line1 = line1 . a:line[i]
+    endif
+    let i += 1
+  endwhile
+  return line1
 endfunction

 function! s:Get_paren_balance(line, o, c)
-    let line2 = substitute(a:line, a:o, "", "g")
-    let openp = strlen(a:line) - strlen(line2)
-    let line3 = substitute(line2, a:c, "", "g")
-    let closep = strlen(line2) - strlen(line3)
-    return openp - closep
+  let line2 = substitute(a:line, a:o, "", "g")
+  let openp = strlen(a:line) - strlen(line2)
+  let line3 = substitute(line2, a:c, "", "g")
+  let closep = strlen(line2) - strlen(line3)
+  return openp - closep
 endfunction

 function! s:Get_matching_brace(linenr, o, c, delbrace)
-    let line = SanitizeRLine(getline(a:linenr))
-    if a:delbrace == 1
-        let line = substitute(line, '{$', "", "")
-    endif
-    let pb = s:Get_paren_balance(line, a:o, a:c)
-    let i = a:linenr
-    while pb != 0 && i > 1
-        let i -= 1
-        let pb += s:Get_paren_balance(SanitizeRLine(getline(i)), a:o, a:c)
-    endwhile
-    return i
+  let line = SanitizeRLine(getline(a:linenr))
+  if a:delbrace == 1
+    let line = substitute(line, '{$', "", "")
+  endif
+  let pb = s:Get_paren_balance(line, a:o, a:c)
+  let i = a:linenr
+  while pb != 0 && i > 1
+    let i -= 1
+    let pb += s:Get_paren_balance(SanitizeRLine(getline(i)), a:o, a:c)
+  endwhile
+  return i
 endfunction

 " This function is buggy because there 'if's without 'else'
 " It must be rewritten relying more on indentation
 function! s:Get_matching_if(linenr, delif)
-"    let filenm = expand("%")
-"    call writefile([filenm], "/tmp/matching_if_" . a:linenr)
-    let line = SanitizeRLine(getline(a:linenr))
-    if a:delif
-        let line = substitute(line, "if", "", "g")
-    endif
-    let elsenr = 0
-    let i = a:linenr
-    let ifhere = 0
-    while i > 0
-        let line2 = substitute(line, '\<else\>', "xxx", "g")
-        let elsenr += strlen(line) - strlen(line2)
-        if line =~ '.*\s*if\s*()' || line =~ '.*\s*if\s*()'
-            let elsenr -= 1
-            if elsenr == 0
-                let ifhere = i
-                break
-            endif
-        endif
-        let i -= 1
-        let line = SanitizeRLine(getline(i))
-    endwhile
-    if ifhere
-        return ifhere
-    else
-        return a:linenr
+  let line = SanitizeRLine(getline(a:linenr))
+  if a:delif
+    let line = substitute(line, "if", "", "g")
+  endif
+  let elsenr = 0
+  let i = a:linenr
+  let ifhere = 0
+  while i > 0
+    let line2 = substitute(line, '\<else\>', "xxx", "g")
+    let elsenr += strlen(line) - strlen(line2)
+    if line =~ '.*\s*if\s*()' || line =~ '.*\s*if\s*()'
+      let elsenr -= 1
+      if elsenr == 0
+        let ifhere = i
+        break
+      endif
     endif
+    let i -= 1
+    let line = SanitizeRLine(getline(i))
+  endwhile
+  if ifhere
+    return ifhere
+  else
+    return a:linenr
+  endif
 endfunction

 function! s:Get_last_paren_idx(line, o, c, pb)
-    let blc = a:pb
-    let line = substitute(a:line, '\t', s:curtabstop, "g")
-    let theidx = -1
-    let llen = strlen(line)
-    let idx = 0
-    while idx < llen
-        if line[idx] == a:o
-            let blc -= 1
-            if blc == 0
-                let theidx = idx
-            endif
-        else
-            if line[idx] == a:c
-                let blc += 1
-            endif
-        endif
-        let idx += 1
-    endwhile
-    return theidx + 1
+  let blc = a:pb
+  let line = substitute(a:line, '\t', s:curtabstop, "g")
+  let theidx = -1
+  let llen = strlen(line)
+  let idx = 0
+  while idx < llen
+    if line[idx] == a:o
+      let blc -= 1
+      if blc == 0
+        let theidx = idx
+      endif
+    else
+      if line[idx] == a:c
+        let blc += 1
+      endif
+    endif
+    let idx += 1
+  endwhile
+  return theidx + 1
 endfunction

 " Get previous relevant line. Search back until getting a line that isn't
 " comment or blank
 function s:Get_prev_line(lineno)
-    let lnum = a:lineno - 1
+  let lnum = a:lineno - 1
+  let data = getline( lnum )
+  while lnum > 0 && (data =~ '^\s*#' || data =~ '^\s*$')
+    let lnum = lnum - 1
     let data = getline( lnum )
-    while lnum > 0 && (data =~ '^\s*#' || data =~ '^\s*$')
-        let lnum = lnum - 1
-        let data = getline( lnum )
-    endwhile
-    return lnum
+  endwhile
+  return lnum
 endfunction

 " This function is also used by r-plugin/common_global.vim
 " Delete from '#' to the end of the line, unless the '#' is inside a string.
 function SanitizeRLine(line)
-    let newline = s:RDelete_quotes(a:line)
-    let newline = s:RDelete_parens(newline)
-    let newline = substitute(newline, '#.*', "", "")
-    let newline = substitute(newline, '\s*$', "", "")
-    return newline
+  let newline = s:RDelete_quotes(a:line)
+  let newline = s:RDelete_parens(newline)
+  let newline = substitute(newline, '#.*', "", "")
+  let newline = substitute(newline, '\s*$', "", "")
+  if &filetype == "rhelp" && newline =~ '^\\method{.*}{.*}(.*'
+    let newline = substitute(newline, '^\\method{\(.*\)}{.*}', '\1', "")
+  endif
+  return newline
 endfunction

 function GetRIndent()

-    let clnum = line(".")    " current line
+  let clnum = line(".")    " current line

-    let cline = getline(clnum)
-    if cline =~ '^\s*#'
-        if g:r_indent_ess_comments == 1
-            if cline =~ '^\s*###'
-                return 0
-            endif
-            if cline !~ '^\s*##'
-                return g:r_indent_comment_column
-            endif
-        endif
+  let cline = getline(clnum)
+  if cline =~ '^\s*#'
+    if g:r_indent_ess_comments == 1
+      if cline =~ '^\s*###'
+        return 0
+      endif
+      if cline !~ '^\s*##'
+        return g:r_indent_comment_column
+      endif
     endif
+  endif

-    let cline = SanitizeRLine(cline)
+  let cline = SanitizeRLine(cline)

-    if cline =~ '^\s*}' || cline =~ '^\s*}\s*)$'
-        let indline = s:Get_matching_brace(clnum, '{', '}', 1)
-        if indline > 0 && indline != clnum
-            let iline = SanitizeRLine(getline(indline))
-            if s:Get_paren_balance(iline, "(", ")") == 0 || iline =~ '(\s*{$'
-                return indent(indline)
-            else
-                let indline = s:Get_matching_brace(indline, '(', ')', 1)
-                return indent(indline)
-            endif
-        endif
+  if cline =~ '^\s*}' || cline =~ '^\s*}\s*)$'
+    let indline = s:Get_matching_brace(clnum, '{', '}', 1)
+    if indline > 0 && indline != clnum
+      let iline = SanitizeRLine(getline(indline))
+      if s:Get_paren_balance(iline, "(", ")") == 0 || iline =~ '(\s*{$'
+        return indent(indline)
+      else
+        let indline = s:Get_matching_brace(indline, '(', ')', 1)
+        return indent(indline)
+      endif
     endif
+  endif

-    " Find the first non blank line above the current line
-    let lnum = s:Get_prev_line(clnum)
-    " Hit the start of the file, use zero indent.
-    if lnum == 0
-        return 0
-    endif
+  " Find the first non blank line above the current line
+  let lnum = s:Get_prev_line(clnum)
+  " Hit the start of the file, use zero indent.
+  if lnum == 0
+    return 0
+  endif

-    let line = SanitizeRLine(getline(lnum))
+  let line = SanitizeRLine(getline(lnum))

-    if &filetype == "rhelp"
-        if cline =~ '^\\dontshow{' || cline =~ '^\\dontrun{' || cline =~ '^\\donttest{' || cline =~ '^\\testonly{'
-            return 0
-        endif
-        if line =~ '^\\examples{' || line =~ '^\\usage{' || line =~ '^\\dontshow{' || line =~ '^\\dontrun{' || line =~ '^\\donttest{' || line =~ '^\\testonly{'
-            return 0
-        endif
-        if line =~ '^\\method{.*}{.*}(.*'
-            let line = substitute(line, '^\\method{\(.*\)}{.*}', '\1', "")
-        endif
+  if &filetype == "rhelp"
+    if cline =~ '^\\dontshow{' || cline =~ '^\\dontrun{' || cline =~ '^\\donttest{' || cline =~ '^\\testonly{'
+      return 0
     endif
-
-    if cline =~ '^\s*{'
-        if g:r_indent_ess_compatible && line =~ ')$'
-            let nlnum = lnum
-            let nline = line
-            while s:Get_paren_balance(nline, '(', ')') < 0
-                let nlnum = s:Get_prev_line(nlnum)
-                let nline = SanitizeRLine(getline(nlnum)) . nline
-            endwhile
-            if nline =~ '^\s*function\s*(' && indent(nlnum) == &sw
-                return 0
-            endif
-        endif
-        if s:Get_paren_balance(line, "(", ")") == 0
-            return indent(lnum)
-        endif
+    if line =~ '^\\examples{' || line =~ '^\\usage{' || line =~ '^\\dontshow{' || line =~ '^\\dontrun{' || line =~ '^\\donttest{' || line =~ '^\\testonly{'
+      return 0
     endif
+  endif
+
+  if &filetype == "rnoweb" && line =~ "^<<.*>>="
+    return 0
+  endif

-    " line is an incomplete command:
-    if line =~ '\<\(if\|while\|for\|function\)\s*()$' || line =~ '\<else$' || line =~ '<-$'
-        return indent(lnum) + &sw
+  if cline =~ '^\s*{'
+    if g:r_indent_ess_compatible && line =~ ')$'
+      let nlnum = lnum
+      let nline = line
+      while s:Get_paren_balance(nline, '(', ')') < 0
+        let nlnum = s:Get_prev_line(nlnum)
+        let nline = SanitizeRLine(getline(nlnum)) . nline
+      endwhile
+      if nline =~ '^\s*function\s*(' && indent(nlnum) == &sw
+        return 0
+      endif
+    endif
+    if s:Get_paren_balance(line, "(", ")") == 0
+      return indent(lnum)
     endif
+  endif
+
+  " line is an incomplete command:
+  if line =~ '\<\(if\|while\|for\|function\)\s*()$' || line =~ '\<else$' || line =~ '<-$'
+    return indent(lnum) + &sw
+  endif
+
+  " Deal with () and []
+
+  let pb = s:Get_paren_balance(line, '(', ')')

-    " Deal with () and []
+  if line =~ '^\s*{$' || line =~ '(\s*{' || (pb == 0 && (line =~ '{$' || line =~ '(\s*{$'))
+    return indent(lnum) + &sw
+  endif

-    let pb = s:Get_paren_balance(line, '(', ')')
+  let s:curtabstop = repeat(' ', &tabstop)

-    if line =~ '^\s*{$' || line =~ '(\s*{' || (pb == 0 && (line =~ '{$' || line =~ '(\s*{$'))
-        return indent(lnum) + &sw
+  if g:r_indent_align_args == 1
+    if pb > 0 && line =~ '{$'
+      return s:Get_last_paren_idx(line, '(', ')', pb) + &sw
     endif

     let bb = s:Get_paren_balance(line, '[', ']')

-    let s:curtabstop = repeat(' ', &tabstop)
-    if g:r_indent_align_args == 1
-
-        if pb == 0 && bb == 0 && (line =~ '.*[,&|\-\*+<>]$' || cline =~ '^\s*[,&|\-\*+<>]')
-            return indent(lnum)
-        endif
-
-        if pb > 0
-            if &filetype == "rhelp"
-                let ind = s:Get_last_paren_idx(line, '(', ')', pb)
-            else
-                let ind = s:Get_last_paren_idx(getline(lnum), '(', ')', pb)
-            endif
-            return ind
-        endif
-
-        if pb < 0 && line =~ '.*[,&|\-\*+<>]$'
-            let lnum = s:Get_prev_line(lnum)
-            while pb < 1 && lnum > 0
-                let line = SanitizeRLine(getline(lnum))
-                let line = substitute(line, '\t', s:curtabstop, "g")
-                let ind = strlen(line)
-                while ind > 0
-                    if line[ind] == ')'
-                        let pb -= 1
-                    else
-                        if line[ind] == '('
-                            let pb += 1
-                        endif
-                    endif
-                    if pb == 1
-                        return ind + 1
-                    endif
-                    let ind -= 1
-                endwhile
-                let lnum -= 1
-            endwhile
-            return 0
-        endif
-
-        if bb > 0
-            let ind = s:Get_last_paren_idx(getline(lnum), '[', ']', bb)
-            return ind
-        endif
+    if pb > 0
+      if &filetype == "rhelp"
+        let ind = s:Get_last_paren_idx(line, '(', ')', pb)
+      else
+        let ind = s:Get_last_paren_idx(getline(lnum), '(', ')', pb)
+      endif
+      return ind
     endif

-    let post_block = 0
-    if line =~ '}$'
-        let lnum = s:Get_matching_brace(lnum, '{', '}', 0)
+    if pb < 0 && line =~ '.*[,&|\-\*+<>]$'
+      let lnum = s:Get_prev_line(lnum)
+      while pb < 1 && lnum > 0
         let line = SanitizeRLine(getline(lnum))
-        if lnum > 0 && line =~ '^\s*{'
-            let lnum = s:Get_prev_line(lnum)
-            let line = SanitizeRLine(getline(lnum))
-        endif
-        let pb = s:Get_paren_balance(line, '(', ')')
-        let post_block = 1
-    endif
-
-    let post_fun = 0
-    if pb < 0 && line !~ ')\s*[,&|\-\*+<>]$'
-        let post_fun = 1
-        while pb < 0 && lnum > 0
-            let lnum -= 1
-            let linepiece = SanitizeRLine(getline(lnum))
-            let pb += s:Get_paren_balance(linepiece, "(", ")")
-            let line = linepiece . line
-        endwhile
-        if line =~ '{$' && post_block == 0
-            return indent(lnum) + &sw
-        endif
-
-        " Now we can do some tests again
-        if cline =~ '^\s*{'
-            return indent(lnum)
-        endif
-        if post_block == 0
-            let newl = SanitizeRLine(line)
-            if newl =~ '\<\(if\|while\|for\|function\)\s*()$' || newl =~ '\<else$' || newl =~ '<-$'
-                return indent(lnum) + &sw
+        let line = substitute(line, '\t', s:curtabstop, "g")
+        let ind = strlen(line)
+        while ind > 0
+          if line[ind] == ')'
+            let pb -= 1
+          else
+            if line[ind] == '('
+              let pb += 1
             endif
-        endif
+          endif
+          if pb == 1
+            return ind + 1
+          endif
+          let ind -= 1
+        endwhile
+        let lnum -= 1
+      endwhile
+      return 0
     endif

-    if cline =~ '^\s*else'
-        if line =~ '<-\s*if\s*()'
-            return indent(lnum) + &sw
-        else
-            if line =~ '\<if\s*()'
-                return indent(lnum)
-            else
-                return indent(lnum) - &sw
-            endif
-        endif
+    if bb > 0
+      let ind = s:Get_last_paren_idx(getline(lnum), '[', ']', bb)
+      return ind
     endif
+  endif

-    if bb < 0 && line =~ '.*]'
-        while bb < 0 && lnum > 0
-            let lnum -= 1
-            let linepiece = SanitizeRLine(getline(lnum))
-            let bb += s:Get_paren_balance(linepiece, "[", "]")
-            let line = linepiece . line
-        endwhile
-        let line = s:RDelete_parens(line)
+  let post_block = 0
+  if line =~ '}$'
+    let lnum = s:Get_matching_brace(lnum, '{', '}', 0)
+    let line = SanitizeRLine(getline(lnum))
+    if lnum > 0 && line =~ '^\s*{'
+      let lnum = s:Get_prev_line(lnum)
+      let line = SanitizeRLine(getline(lnum))
+    endif
+    let pb = s:Get_paren_balance(line, '(', ')')
+    let post_block = 1
+  endif
+
+  " Indent after operator pattern
+  let olnum = s:Get_prev_line(lnum)
+  let oline = getline(olnum)
+  if olnum > 0
+    if line =~ g:r_indent_op_pattern
+      if oline =~ g:r_indent_op_pattern
+        return indent(lnum)
+      else
+        return indent(lnum) + &sw
+      endif
+    else
+      if oline =~ g:r_indent_op_pattern
+        return indent(lnum) - &sw
+      endif
+    endif
+  endif
+
+  let post_fun = 0
+  if pb < 0 && line !~ ')\s*[,&|\-\*+<>]$'
+    let post_fun = 1
+    while pb < 0 && lnum > 0
+      let lnum -= 1
+      let linepiece = SanitizeRLine(getline(lnum))
+      let pb += s:Get_paren_balance(linepiece, "(", ")")
+      let line = linepiece . line
+    endwhile
+    if line =~ '{$' && post_block == 0
+      return indent(lnum) + &sw
+    endif
+
+    " Now we can do some tests again
+    if cline =~ '^\s*{'
+      return indent(lnum)
+    endif
+    if post_block == 0
+      let newl = SanitizeRLine(line)
+      if newl =~ '\<\(if\|while\|for\|function\)\s*()$' || newl =~ '\<else$' || newl =~ '<-$'
+        return indent(lnum) + &sw
+      endif
     endif
+  endif
+
+  if cline =~ '^\s*else'
+    if line =~ '<-\s*if\s*()'
+      return indent(lnum) + &sw
+    else
+      if line =~ '\<if\s*()'
+        return indent(lnum)
+      else
+        return indent(lnum) - &sw
+      endif
+    endif
+  endif
+
+  let bb = s:Get_paren_balance(line, '[', ']')
+  if bb < 0 && line =~ '.*]'
+    while bb < 0 && lnum > 0
+      let lnum -= 1
+      let linepiece = SanitizeRLine(getline(lnum))
+      let bb += s:Get_paren_balance(linepiece, "[", "]")
+      let line = linepiece . line
+    endwhile
+    let line = s:RDelete_parens(line)
+  endif

-    let plnum = s:Get_prev_line(lnum)
-    let ppost_else = 0
-    if plnum > 0
+  let plnum = s:Get_prev_line(lnum)
+  let ppost_else = 0
+  if plnum > 0
+    let pline = SanitizeRLine(getline(plnum))
+    let ppost_block = 0
+    if pline =~ '}$'
+      let ppost_block = 1
+      let plnum = s:Get_matching_brace(plnum, '{', '}', 0)
+      let pline = SanitizeRLine(getline(plnum))
+      if pline =~ '^\s*{$' && plnum > 0
+        let plnum = s:Get_prev_line(plnum)
         let pline = SanitizeRLine(getline(plnum))
-        let ppost_block = 0
-        if pline =~ '}$'
-            let ppost_block = 1
-            let plnum = s:Get_matching_brace(plnum, '{', '}', 0)
-            let pline = SanitizeRLine(getline(plnum))
-            if pline =~ '^\s*{$' && plnum > 0
-                let plnum = s:Get_prev_line(plnum)
-                let pline = SanitizeRLine(getline(plnum))
-            endif
-        endif
-
-        if pline =~ 'else$'
-            let ppost_else = 1
-            let plnum = s:Get_matching_if(plnum, 0)
-            let pline = SanitizeRLine(getline(plnum))
-        endif
-
-        if pline =~ '^\s*else\s*if\s*('
-            let pplnum = s:Get_prev_line(plnum)
-            let ppline = SanitizeRLine(getline(pplnum))
-            while ppline =~ '^\s*else\s*if\s*(' || ppline =~ '^\s*if\s*()\s*\S$'
-                let plnum = pplnum
-                let pline = ppline
-                let pplnum = s:Get_prev_line(plnum)
-                let ppline = SanitizeRLine(getline(pplnum))
-            endwhile
-            while ppline =~ '\<\(if\|while\|for\|function\)\s*()$' || ppline =~ '\<else$' || ppline =~ '<-$'
-                let plnum = pplnum
-                let pline = ppline
-                let pplnum = s:Get_prev_line(plnum)
-                let ppline = SanitizeRLine(getline(pplnum))
-            endwhile
-        endif
-
-        let ppb = s:Get_paren_balance(pline, '(', ')')
-        if ppb < 0 && (pline =~ ')\s*{$' || pline =~ ')$')
-            while ppb < 0 && plnum > 0
-                let plnum -= 1
-                let linepiece = SanitizeRLine(getline(plnum))
-                let ppb += s:Get_paren_balance(linepiece, "(", ")")
-                let pline = linepiece . pline
-            endwhile
-            let pline = s:RDelete_parens(pline)
-        endif
+      endif
     endif

-    let ind = indent(lnum)
-    let pind = indent(plnum)
-
-    if g:r_indent_align_args == 0 && pb != 0
-        let ind += pb * &sw
-        return ind
+    if pline =~ 'else$'
+      let ppost_else = 1
+      let plnum = s:Get_matching_if(plnum, 0)
+      let pline = SanitizeRLine(getline(plnum))
     endif

-    if g:r_indent_align_args == 0 && bb != 0
-        let ind += bb * &sw
-        return ind
+    if pline =~ '^\s*else\s*if\s*('
+      let pplnum = s:Get_prev_line(plnum)
+      let ppline = SanitizeRLine(getline(pplnum))
+      while ppline =~ '^\s*else\s*if\s*(' || ppline =~ '^\s*if\s*()\s*\S$'
+        let plnum = pplnum
+        let pline = ppline
+        let pplnum = s:Get_prev_line(plnum)
+        let ppline = SanitizeRLine(getline(pplnum))
+      endwhile
+      while ppline =~ '\<\(if\|while\|for\|function\)\s*()$' || ppline =~ '\<else$' || ppline =~ '<-$'
+        let plnum = pplnum
+        let pline = ppline
+        let pplnum = s:Get_prev_line(plnum)
+        let ppline = SanitizeRLine(getline(pplnum))
+      endwhile
     endif

-    if ind == pind || (ind == (pind  + &sw) && pline =~ '{$' && ppost_else == 0)
-        return ind
+    let ppb = s:Get_paren_balance(pline, '(', ')')
+    if ppb < 0 && (pline =~ ')\s*{$' || pline =~ ')$')
+      while ppb < 0 && plnum > 0
+        let plnum -= 1
+        let linepiece = SanitizeRLine(getline(plnum))
+        let ppb += s:Get_paren_balance(linepiece, "(", ")")
+        let pline = linepiece . pline
+      endwhile
+      let pline = s:RDelete_parens(pline)
     endif
+  endif
+
+  let ind = indent(lnum)
+  let pind = indent(plnum)
+
+  if g:r_indent_align_args == 0 && pb != 0
+    let ind += pb * &sw
+    return ind
+  endif
+
+  if g:r_indent_align_args == 0 && bb != 0
+    let ind += bb * &sw
+    return ind
+  endif
+
+  if ind == pind || (ind == (pind  + &sw) && pline =~ '{$' && ppost_else == 0)
+    return ind
+  endif
+
+  let pline = getline(plnum)
+  let pbb = s:Get_paren_balance(pline, '[', ']')

+  while pind < ind && plnum > 0 && ppb == 0 && pbb == 0
+    let ind = pind
+    let plnum = s:Get_prev_line(plnum)
     let pline = getline(plnum)
+    let ppb = s:Get_paren_balance(pline, '(', ')')
     let pbb = s:Get_paren_balance(pline, '[', ']')
-
-    while pind < ind && plnum > 0 && ppb == 0 && pbb == 0
-        let ind = pind
-        let plnum = s:Get_prev_line(plnum)
-        let pline = getline(plnum)
-        let ppb = s:Get_paren_balance(pline, '(', ')')
-        let pbb = s:Get_paren_balance(pline, '[', ']')
-        while pline =~ '^\s*else'
-            let plnum = s:Get_matching_if(plnum, 1)
-            let pline = getline(plnum)
-            let ppb = s:Get_paren_balance(pline, '(', ')')
-            let pbb = s:Get_paren_balance(pline, '[', ']')
-        endwhile
-        let pind = indent(plnum)
-        if ind == (pind  + &sw) && pline =~ '{$'
-            return ind
-        endif
+    while pline =~ '^\s*else'
+      let plnum = s:Get_matching_if(plnum, 1)
+      let pline = getline(plnum)
+      let ppb = s:Get_paren_balance(pline, '(', ')')
+      let pbb = s:Get_paren_balance(pline, '[', ']')
     endwhile
+    let pind = indent(plnum)
+    if ind == (pind  + &sw) && pline =~ '{$'
+      return ind
+    endif
+  endwhile

-    return ind
+  return ind

 endfunction

-" vim: sw=4
+" vim: sw=2
diff --git a/runtime/indent/rhelp.vim b/runtime/indent/rhelp.vim
index 8cc5fda..3b37128 100644
--- a/runtime/indent/rhelp.vim
+++ b/runtime/indent/rhelp.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:    R Documentation (Help), *.Rd
 " Author:  Jakson Alves de Aquino <jalvesaq@gmail.com>
-" Last Change: Wed Jul 09, 2014  07:34PM
+" Last Change: Thu Oct 16, 2014  07:07AM


 " Only load this indent file when no other was loaded.
@@ -12,22 +12,18 @@ runtime indent/r.vim
 let s:RIndent = function(substitute(&indentexpr, "()", "", ""))
 let b:did_indent = 1

-setlocal indentkeys=0{,0},:,!^F,o,O,e
-setlocal indentexpr=GetRHelpIndent()
-
-" Only define the function once.
-if exists("*GetRHelpIndent")
-  finish
-endif
-
 setlocal noautoindent
 setlocal nocindent
 setlocal nosmartindent
 setlocal nolisp
-
 setlocal indentkeys=0{,0},:,!^F,o,O,e
 setlocal indentexpr=GetCorrectRHelpIndent()

+" Only define the functions once.
+if exists("*GetRHelpIndent")
+  finish
+endif
+
 function s:SanitizeRHelpLine(line)
   let newline = substitute(a:line, '\\\\', "x", "g")
   let newline = substitute(newline, '\\{', "x", "g")
diff --git a/runtime/indent/rmd.vim b/runtime/indent/rmd.vim
index 872790e..9a8a3cb 100644
--- a/runtime/indent/rmd.vim
+++ b/runtime/indent/rmd.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:    Rmd
 " Author:  Jakson Alves de Aquino <jalvesaq@gmail.com>
-" Last Change: Wed Jul 09, 2014  07:33PM
+" Last Change: Thu Jul 10, 2014  07:11PM


 " Only load this indent file when no other was loaded.
@@ -33,10 +33,10 @@ function GetMdIndent()
 endfunction

 function GetRmdIndent()
-  if getline(".") =~ '^```{r .*}$' || getline(".") =~ '^```$'
+  if getline(".") =~ '^[ \t]*```{r .*}$' || getline(".") =~ '^[ \t]*```$'
     return 0
   endif
-  if search('^```{r', "bncW") > search('^```$', "bncW")
+  if search('^[ \t]*```{r', "bncW") > search('^[ \t]*```$', "bncW")
     return s:RIndent()
   else
     return GetMdIndent()
diff --git a/runtime/indent/rnoweb.vim b/runtime/indent/rnoweb.vim
index e69542b..d0cad3d 100644
--- a/runtime/indent/rnoweb.vim
+++ b/runtime/indent/rnoweb.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:    Rnoweb
 " Author:  Jakson Alves de Aquino <jalvesaq@gmail.com>
-" Last Change: Wed Jul 09, 2014  07:28PM
+" Last Change: Sun Mar 22, 2015  09:28AM


 " Only load this indent file when no other was loaded.
@@ -23,7 +23,8 @@ if exists("*GetRnowebIndent")
 endif

 function GetRnowebIndent()
-  if getline(".") =~ "^<<.*>>=$"
+  let curline = getline(".")
+  if curline =~ '^<<.*>>=$' || curline =~ '^\s*@$'
     return 0
   endif
   if search("^<<", "bncW") > search("^@", "bncW")
diff --git a/runtime/syntax/python.vim b/runtime/syntax/python.vim
index a4ffcd4..b018280 100644
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,9 +1,8 @@
 " Vim syntax file
 " Language:    Python
-" Maintainer:  Neil Schemenauer <nas@python.ca>
-" Last Change: 2014 Jul 16
-" Credits: Zvezdan Petkovic <zpetkovic@acm.org>
-"      Neil Schemenauer <nas@python.ca>
+" Maintainer:  Zvezdan Petkovic <zpetkovic@acm.org>
+" Last Change: 2015 Jun 19
+" Credits: Neil Schemenauer <nas@python.ca>
 "      Dmitry Vasiliev
 "
 "      This version is a major rewrite by Zvezdan Petkovic.
@@ -95,16 +94,16 @@ syn match   pythonComment   "#.*$" contains=pythonTodo,@Spell
 syn keyword pythonTodo     FIXME NOTE NOTES TODO XXX contained

 " Triple-quoted strings can contain doctests.
-syn region  pythonString
+syn region  pythonString matchgroup=pythonQuotes
       \ start=+[uU]\=\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"
       \ contains=pythonEscape,@Spell
-syn region  pythonString
+syn region  pythonString matchgroup=pythonTripleQuotes
       \ start=+[uU]\=\z('''\|"""\)+ end="\z1" keepend
       \ contains=pythonEscape,pythonSpaceError,pythonDoctest,@Spell
-syn region  pythonRawString
+syn region  pythonRawString matchgroup=pythonQuotes
       \ start=+[uU]\=[rR]\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"
       \ contains=@Spell
-syn region  pythonRawString
+syn region  pythonRawString matchgroup=pythonTripleQuotes
       \ start=+[uU]\=[rR]\z('''\|"""\)+ end="\z1" keepend
       \ contains=pythonSpaceError,pythonDoctest,@Spell

@@ -113,7 +112,7 @@ syn match   pythonEscape    "\\\o\{1,3}" contained
 syn match   pythonEscape   "\\x\x\{2}" contained
 syn match   pythonEscape   "\%(\\u\x\{4}\|\\U\x\{8}\)" contained
 " Python allows case-insensitive Unicode IDs: http://www.unicode.org/charts/
-syn match   pythonEscape   "\\N{.\{-}}" contained
+syn match   pythonEscape   "\\N{\a\+\%(\s\a\+\)*}" contained
 syn match   pythonEscape   "\\$"

 if exists("python_highlight_all")
@@ -274,6 +273,8 @@ if version >= 508 || !exists("did_python_syn_inits")
   HiLink pythonTodo        Todo
   HiLink pythonString      String
   HiLink pythonRawString   String
+  HiLink pythonQuotes      String
+  HiLink pythonTripleQuotes    pythonQuotes
   HiLink pythonEscape      Special
   if !exists("python_no_number_highlight")
     HiLink pythonNumber        Number
diff --git a/runtime/syntax/sh.vim b/runtime/syntax/sh.vim
index ad0df1f..4087aff 100644
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -2,8 +2,8 @@
 " Language:        shell (sh) Korn shell (ksh) bash (sh)
 " Maintainer:      Charles E. Campbell  <NdrOchipS@PcampbellAfamily.Mbiz>
 " Previous Maintainer: Lennart Schultz <Lennart.Schultz@ecmwf.int>
-" Last Change:     Apr 10, 2015
-" Version:     136
+" Last Change:     May 29, 2015
+" Version:     137
 " URL:     http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
 " This file includes many ideas from ?ric Brunet (eric.brunet@ens.fr)
@@ -17,7 +17,7 @@ elseif exists("b:current_syntax")
 endif

 " AFAICT "." should be considered part of the iskeyword.  Using iskeywords in
-" syntax is dicey, so the following code permits the user to prevent/override
+" syntax is dicey, so the following code permits the user to
 "  g:sh_isk set to a string    : specify iskeyword.
 "  g:sh_noisk exists   : don't change iskeyword
 "  g:sh_noisk does not exist   : (default) append "." to iskeyword
@@ -108,8 +108,7 @@ syn cluster shArithParenList    contains=shArithmetic,shCaseEsac,shComment,shDeref,
 syn cluster shArithList    contains=@shArithParenList,shParenError
 syn cluster shCaseEsacList contains=shCaseStart,shCase,shCaseBar,shCaseIn,shComment,shDeref,shDerefSimple,shCaseCommandSub,shCaseExSingleQuote,shCaseSingleQuote,shCaseDoubleQuote,shCtrlSeq,@shErrorList,shStringSpecial,shCaseRange
 syn cluster shCaseList contains=@shCommandSubList,shCaseEsac,shColon,shCommandSub,shComment,shDo,shEcho,shExpr,shFor,shHereDoc,shIf,shRedir,shSetList,shSource,shStatement,shVariable,shCtrlSeq
-"syn cluster shColonList   contains=@shCaseList
-syn cluster shCommandSubList   contains=shArithmetic,shDeref,shDerefSimple,shEcho,shEscape,shNumber,shOption,shPosnParm,shExSingleQuote,shSingleQuote,shExDoubleQuote,shDoubleQuote,shStatement,shVariable,shSubSh,shAlias,shTest,shCtrlSeq,shSpecial,shCmdParenRegion
+syn cluster shCommandSubList   contains=shAlias,shArithmetic,shCmdParenRegion,shCtrlSeq,shDeref,shDerefSimple,shDoubleQuote,shEcho,shEscape,shExDoubleQuote,shExpr,shExSingleQuote,shNumber,shOperator,shOption,shPosnParm,shSingleQuote,shSpecial,shStatement,shSubSh,shTest,shVariable
 syn cluster shCurlyList    contains=shNumber,shComma,shDeref,shDerefSimple,shDerefSpecial
 syn cluster shDblQuoteList contains=shCommandSub,shDeref,shDerefSimple,shEscape,shPosnParm,shCtrlSeq,shSpecial
 syn cluster shDerefList    contains=shDeref,shDerefSimple,shDerefVar,shDerefSpecial,shDerefWordError,shDerefPPS
@@ -182,7 +181,7 @@ syn match      shRedir  "\d<<-\="
 syn match   shOperator "<<\|>>"        contained
 syn match   shOperator "[!&;|]"        contained
 syn match   shOperator "\[[[^:]\|\]]"      contained
-syn match   shOperator "!\=="      skipwhite nextgroup=shPattern
+syn match   shOperator "[-=/*+%]\=="       skipwhite nextgroup=shPattern
 syn match   shPattern  "\<\S\+\())\)\@="   contained contains=shExSingleQuote,shSingleQuote,shExDoubleQuote,shDoubleQuote,shDeref

 " Subshells: {{{1
@@ -194,8 +193,8 @@ syn region shSubSh transparent matchgroup=shSubShRegion start="[^(]\zs(" end=")"
 "=======
 syn region shExpr  matchgroup=shRange start="\[" skip=+\\\\\|\\$\|\[+ end="\]" contains=@shTestList,shSpecial
 syn region shTest  transparent matchgroup=shStatement start="\<test\s" skip=+\\\\\|\\$+ matchgroup=NONE end="[;&|]"me=e-1 end="$" contains=@shExprList1
+syn match  shTestOpr   contained   '[^-+/%]\zs=' skipwhite nextgroup=shTestDoubleQuote,shTestSingleQuote,shTestPattern
 syn match  shTestOpr   contained   "<=\|>=\|!=\|==\|-.\>\|-\(nt\|ot\|ef\|eq\|ne\|lt\|le\|gt\|ge\)\>\|[!<>]"
-syn match  shTestOpr   contained   '=' skipwhite nextgroup=shTestDoubleQuote,shTestSingleQuote,shTestPattern
 syn match  shTestPattern   contained   '\w\+'
 syn region shTestDoubleQuote   contained   start='\%(\%(\\\\\)*\\\)\@<!"' skip=+\\\\\|\\"+ end='"'
 syn match  shTestSingleQuote   contained   '\\.'
@@ -322,12 +321,13 @@ elseif !exists("g:sh_no_error")
 endif
 syn region  shSingleQuote  matchgroup=shQuote start=+'+ end=+'+        contains=@Spell
 syn region  shDoubleQuote  matchgroup=shQuote start=+\%(\%(\\\\\)*\\\)\@<!"+ skip=+\\"+ end=+"+    contains=@shDblQuoteList,shStringSpecial,@Spell
-"syn region  shDoubleQuote matchgroup=shQuote start=+"+ skip=+\\"+ end=+"+ contains=@shDblQuoteList,shStringSpecial,@Spell
-syn match   shStringSpecial    "[^[:print:] \t]"   contained
+syn region  shDoubleQuote  matchgroup=shQuote start=+"+ skip=+\\"+ end=+"+ contains=@shDblQuoteList,shStringSpecial,@Spell
+syn match   shStringSpecial    "[^[:print:] \t]"       contained
 syn match   shStringSpecial    "\%(\\\\\)*\\[\\"'`$()#]"
-syn match   shSpecial  "[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]" nextgroup=shMoreSpecial,shComment
-syn match   shSpecial  "^\%(\\\\\)*\\[\\"'`$()#]"  nextgroup=shComment
-syn match   shMoreSpecial  "\%(\\\\\)*\\[\\"'`$()#]" nextgroup=shMoreSpecial contained
+" COMBAK: why is ,shComment on next line???
+syn match   shSpecial  "[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]"   nextgroup=shMoreSpecial,shComment
+syn match   shSpecial  "^\%(\\\\\)*\\[\\"'`$()#]"      nextgroup=shComment
+syn match   shMoreSpecial  "\%(\\\\\)*\\[\\"'`$()#]"       nextgroup=shMoreSpecial contained

 " Comments: {{{1
 "==========
@@ -341,42 +341,42 @@ syn match shQuickComment  contained   "#.*$"
 " Here Documents: {{{1
 " =========================================
 if version < 600
- syn region shHereDoc matchgroup=shRedir01 start="<<\s*\**END[a-zA-Z_0-9]*\**"         matchgroup=shRedir01 end="^END[a-zA-Z_0-9]*$"   contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir02 start="<<-\s*\**END[a-zA-Z_0-9]*\**"        matchgroup=shRedir02 end="^\s*END[a-zA-Z_0-9]*$"    contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir03 start="<<\s*\**EOF\**"      matchgroup=shRedir03    end="^EOF$" contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir04 start="<<-\s*\**EOF\**"     matchgroup=shRedir04    end="^\s*EOF$"  contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir05 start="<<\s*\**\.\**"       matchgroup=shRedir05    end="^\.$"  contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir06 start="<<-\s*\**\.\**"      matchgroup=shRedir06    end="^\s*\.$"   contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc01 start="<<\s*\**END[a-zA-Z_0-9]*\**"   matchgroup=shHereDoc01 end="^END[a-zA-Z_0-9]*$" contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc02 start="<<-\s*\**END[a-zA-Z_0-9]*\**"  matchgroup=shHereDoc02 end="^\s*END[a-zA-Z_0-9]*$"  contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc03 start="<<\s*\**EOF\**"        matchgroup=shHereDoc03 end="^EOF$"  contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc04 start="<<-\s*\**EOF\**"       matchgroup=shHereDoc04 end="^\s*EOF$"   contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc05 start="<<\s*\**\.\**"     matchgroup=shHereDoc05 end="^\.$"   contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc06 start="<<-\s*\**\.\**"        matchgroup=shHereDoc06 end="^\s*\.$"    contains=@shDblQuoteList

 elseif s:sh_fold_heredoc
- syn region shHereDoc matchgroup=shRedir07 fold start="<<\s*\z([^ \t|]*\)"     matchgroup=shRedir07 end="^\z1\s*$" contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir08 fold start="<<\s*\"\z([^ \t|]*\)\""     matchgroup=shRedir08 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir09 fold start="<<\s*'\z([^ \t|]*\)'"       matchgroup=shRedir09 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir10 fold start="<<-\s*\z([^ \t|]*\)"        matchgroup=shRedir10 end="^\s*\z1\s*$"  contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir11 fold start="<<-\s*\"\z([^ \t|]*\)\""        matchgroup=shRedir11 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir12 fold start="<<-\s*'\z([^ \t|]*\)'"      matchgroup=shRedir12 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir13 fold start="<<\s*\\\_$\_s*\z([^ \t|]*\)"    matchgroup=shRedir13 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir14 fold start="<<\s*\\\_$\_s*\"\z([^ \t|]*\)\""    matchgroup=shRedir14 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir15 fold start="<<-\s*\\\_$\_s*'\z([^ \t|]*\)'" matchgroup=shRedir15 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir16 fold start="<<-\s*\\\_$\_s*\z([^ \t|]*\)"   matchgroup=shRedir16 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir17 fold start="<<-\s*\\\_$\_s*\"\z([^ \t|]*\)\""   matchgroup=shRedir17 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir18 fold start="<<\s*\\\_$\_s*'\z([^ \t|]*\)'"  matchgroup=shRedir18 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir19 fold start="<<\\\z([^ \t|]*\)"      matchgroup=shRedir19 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc07 fold start="<<\s*\z([^ \t|]*\)"       matchgroup=shHereDoc07 end="^\z1\s*$"   contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc08 fold start="<<\s*\"\z([^ \t|]*\)\""   matchgroup=shHereDoc08 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc09 fold start="<<\s*'\z([^ \t|]*\)'"     matchgroup=shHereDoc09 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc10 fold start="<<-\s*\z([^ \t|]*\)"      matchgroup=shHereDoc10 end="^\s*\z1\s*$"    contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc11 fold start="<<-\s*\"\z([^ \t|]*\)\""  matchgroup=shHereDoc11 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc12 fold start="<<-\s*'\z([^ \t|]*\)'"        matchgroup=shHereDoc12 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc13 fold start="<<\s*\\\_$\_s*\z([^ \t|]*\)"  matchgroup=shHereDoc13 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc14 fold start="<<\s*\\\_$\_s*\"\z([^ \t|]*\)\""  matchgroup=shHereDoc14 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc15 fold start="<<-\s*\\\_$\_s*'\z([^ \t|]*\)'"   matchgroup=shHereDoc15 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc16 fold start="<<-\s*\\\_$\_s*\z([^ \t|]*\)" matchgroup=shHereDoc16 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc17 fold start="<<-\s*\\\_$\_s*\"\z([^ \t|]*\)\"" matchgroup=shHereDoc17 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc18 fold start="<<\s*\\\_$\_s*'\z([^ \t|]*\)'"    matchgroup=shHereDoc18 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc19 fold start="<<\\\z([^ \t|]*\)"        matchgroup=shHereDoc19 end="^\z1\s*$"

 else
- syn region shHereDoc matchgroup=shRedir20 start="<<\s*\\\=\z([^ \t|]*\)"      matchgroup=shRedir20 end="^\z1\s*$"    contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir21 start="<<\s*\"\z([^ \t|]*\)\""      matchgroup=shRedir21 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir22 start="<<-\s*\z([^ \t|]*\)"     matchgroup=shRedir22 end="^\s*\z1\s*$" contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shRedir23 start="<<-\s*'\z([^ \t|]*\)'"       matchgroup=shRedir23 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir24 start="<<\s*'\z([^ \t|]*\)'"        matchgroup=shRedir24 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir25 start="<<-\s*\"\z([^ \t|]*\)\""     matchgroup=shRedir25 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir26 start="<<\s*\\\_$\_s*\z([^ \t|]*\)"     matchgroup=shRedir26 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir27 start="<<-\s*\\\_$\_s*\z([^ \t|]*\)"        matchgroup=shRedir27 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir28 start="<<-\s*\\\_$\_s*'\z([^ \t|]*\)'"  matchgroup=shRedir28 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir29 start="<<\s*\\\_$\_s*'\z([^ \t|]*\)'"   matchgroup=shRedir29 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir30 start="<<\s*\\\_$\_s*\"\z([^ \t|]*\)\"" matchgroup=shRedir30 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shRedir31 start="<<-\s*\\\_$\_s*\"\z([^ \t|]*\)\""    matchgroup=shRedir31 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shRedir32 start="<<\\\z([^ \t|]*\)"       matchgroup=shRedir32 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc20 start="<<\s*\\\=\z([^ \t|]*\)"        matchgroup=shHereDoc20 end="^\z1\s*$"    contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc21 start="<<\s*\"\z([^ \t|]*\)\""        matchgroup=shHereDoc21 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc22 start="<<-\s*\z([^ \t|]*\)"       matchgroup=shHereDoc22 end="^\s*\z1\s*$" contains=@shDblQuoteList
+ syn region shHereDoc matchgroup=shHereDoc23 start="<<-\s*'\z([^ \t|]*\)'"     matchgroup=shHereDoc23 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc24 start="<<\s*'\z([^ \t|]*\)'"      matchgroup=shHereDoc24 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc25 start="<<-\s*\"\z([^ \t|]*\)\""       matchgroup=shHereDoc25 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc26 start="<<\s*\\\_$\_s*\z([^ \t|]*\)"   matchgroup=shHereDoc26 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc27 start="<<-\s*\\\_$\_s*\z([^ \t|]*\)"  matchgroup=shHereDoc27 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc28 start="<<-\s*\\\_$\_s*'\z([^ \t|]*\)'"    matchgroup=shHereDoc28 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc29 start="<<\s*\\\_$\_s*'\z([^ \t|]*\)'" matchgroup=shHereDoc29 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc30 start="<<\s*\\\_$\_s*\"\z([^ \t|]*\)\""   matchgroup=shHereDoc30 end="^\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc31 start="<<-\s*\\\_$\_s*\"\z([^ \t|]*\)\""  matchgroup=shHereDoc31 end="^\s*\z1\s*$"
+ syn region shHereDoc matchgroup=shHereDoc32 start="<<\\\z([^ \t|]*\)"     matchgroup=shHereDoc32 end="^\z1\s*$"
 endif

 " Here Strings: {{{1
@@ -389,8 +389,8 @@ endif
 " Identifiers: {{{1
 "=============
 syn match  shSetOption "\s\zs[-+][a-zA-Z0-9]\+\>"  contained
-syn match  shVariable  "\<\([bwglsav]:\)\=[a-zA-Z0-9.!@_%+,]*\ze=" nextgroup=shSetIdentifier
-syn match  shSetIdentifier "="     contained   nextgroup=shCmdParenRegion,shPattern,shDeref,shDerefSimple,shDoubleQuote,shExDoubleQuote,shSingleQuote,shExSingleQuote
+syn match  shVariable  "\<\([bwglsav]:\)\=[a-zA-Z0-9.!@_%+,]*\ze=" nextgroup=shVarAssign
+syn match  shVarAssign "="     contained   nextgroup=shCmdParenRegion,shPattern,shDeref,shDerefSimple,shDoubleQuote,shExDoubleQuote,shSingleQuote,shExSingleQuote
 syn region shAtExpr    contained   start="@(" end=")" contains=@shIdList
 if exists("b:is_bash")
  syn region shSetList oneline matchgroup=shSet start="\<\(declare\|typeset\|local\|export\|unset\)\>\ze[^/]" end="$"   matchgroup=shSetListDelim end="\ze[}|);&]" matchgroup=NONE end="\ze\s\+#\|="    contains=@shIdList
@@ -668,38 +668,38 @@ hi def link shStatement       Statement
 hi def link shString       String
 hi def link shTodo     Todo
 hi def link shAlias        Identifier
-hi def link shRedir01      shRedir
-hi def link shRedir02      shRedir
-hi def link shRedir03      shRedir
-hi def link shRedir04      shRedir
-hi def link shRedir05      shRedir
-hi def link shRedir06      shRedir
-hi def link shRedir07      shRedir
-hi def link shRedir08      shRedir
-hi def link shRedir09      shRedir
-hi def link shRedir10      shRedir
-hi def link shRedir11      shRedir
-hi def link shRedir12      shRedir
-hi def link shRedir13      shRedir
-hi def link shRedir14      shRedir
-hi def link shRedir15      shRedir
-hi def link shRedir16      shRedir
-hi def link shRedir17      shRedir
-hi def link shRedir18      shRedir
-hi def link shRedir19      shRedir
-hi def link shRedir20      shRedir
-hi def link shRedir21      shRedir
-hi def link shRedir22      shRedir
-hi def link shRedir23      shRedir
-hi def link shRedir24      shRedir
-hi def link shRedir25      shRedir
-hi def link shRedir26      shRedir
-hi def link shRedir27      shRedir
-hi def link shRedir28      shRedir
-hi def link shRedir29      shRedir
-hi def link shRedir30      shRedir
-hi def link shRedir31      shRedir
-hi def link shRedir32      shRedir
+hi def link shHereDoc01        shRedir
+hi def link shHereDoc02        shRedir
+hi def link shHereDoc03        shRedir
+hi def link shHereDoc04        shRedir
+hi def link shHereDoc05        shRedir
+hi def link shHereDoc06        shRedir
+hi def link shHereDoc07        shRedir
+hi def link shHereDoc08        shRedir
+hi def link shHereDoc09        shRedir
+hi def link shHereDoc10        shRedir
+hi def link shHereDoc11        shRedir
+hi def link shHereDoc12        shRedir
+hi def link shHereDoc13        shRedir
+hi def link shHereDoc14        shRedir
+hi def link shHereDoc15        shRedir
+hi def link shHereDoc16        shRedir
+hi def link shHereDoc17        shRedir
+hi def link shHereDoc18        shRedir
+hi def link shHereDoc19        shRedir
+hi def link shHereDoc20        shRedir
+hi def link shHereDoc21        shRedir
+hi def link shHereDoc22        shRedir
+hi def link shHereDoc23        shRedir
+hi def link shHereDoc24        shRedir
+hi def link shHereDoc25        shRedir
+hi def link shHereDoc26        shRedir
+hi def link shHereDoc27        shRedir
+hi def link shHereDoc28        shRedir
+hi def link shHereDoc29        shRedir
+hi def link shHereDoc30        shRedir
+hi def link shHereDoc31        shRedir
+hi def link shHereDoc32        shRedir

 " Set Current Syntax: {{{1
 " ===================
diff --git a/runtime/syntax/tex.vim b/runtime/syntax/tex.vim
index f704766..b95ff4d 100644
--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:    TeX
 " Maintainer:  Charles E. Campbell <NdrchipO@ScampbellPfamily.AbizM>
-" Last Change: Apr 02, 2015
-" Version: 84
+" Last Change: Jun 11, 2015
+" Version: 87
 " URL:     http://www.drchip.org/astronaut/vim/index.html#SYNTAX_TEX
 "
 " Notes: {{{1
@@ -207,7 +207,7 @@ if s:tex_fast =~ 'M'
    if !exists("s:tex_no_error") || !s:tex_no_error
     syn match  texMathError    "}" contained
    endif
-   syn region texMathMatcher   matchgroup=Delimiter    start="{"          skip="\\\\\|\\}"     end="}" end="%stopzone\>"   contained contains=@texMathMatchGroup
+   syn region texMathMatcher   matchgroup=Delimiter    start="{"          skip="\(\\\\\)*\\}"     end="}" end="%stopzone\>"    contained contains=@texMathMatchGroup
   endif
 endif

@@ -226,7 +226,7 @@ endif
 " TeX/LaTeX delimiters: {{{1
 syn match texDelimiter     "&"
 syn match texDelimiter     "\\\\"
-syn match texDelimiter     "[{}]"
+"%syn match texDelimiter       "[{}]"

 " Tex/Latex Options: {{{1
 syn match texOption        "[^\\]\zs#\d\+\|^#\d\+"
@@ -247,7 +247,7 @@ syn match texLigature       "\\\([ijolL]\|ae\|oe\|ss\|AA\|AE\|OE\)$"
 " \begin{}/\end{} section markers: {{{1
 syn match  texBeginEnd     "\\begin\>\|\\end\>" nextgroup=texBeginEndName
 if s:tex_fast =~ 'm'
-  syn region texBeginEndName   matchgroup=Delimiter    start="{"       end="}" contained   nextgroup=texBeginEndModifier   contains=texComment
+  syn region texBeginEndName       matchgroup=Delimiter    start="{"       end="}" contained   nextgroup=texBeginEndModifier   contains=texComment
   syn region texBeginEndModifier   matchgroup=Delimiter    start="\["      end="]" contained   contains=texComment,@NoSpell
 endif

@@ -392,22 +392,22 @@ endif
 if s:tex_fast =~ 'b'
   if s:tex_conceal =~ 'b'
    if !exists("g:tex_nospell") || !g:tex_nospell
-    syn region texBoldStyle    matchgroup=texTypeStyle start="\\textbf\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texBoldGroup,@Spell
-    syn region texBoldItalStyle    matchgroup=texTypeStyle start="\\textit\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texItalGroup,@Spell
-    syn region texItalStyle    matchgroup=texTypeStyle start="\\textit\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texItalGroup,@Spell
-    syn region texItalBoldStyle    matchgroup=texTypeStyle start="\\textbf\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texBoldGroup,@Spell
-   else
-    syn region texBoldStyle    matchgroup=texTypeStyle start="\\textbf\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texBoldGroup
-    syn region texBoldItalStyle    matchgroup=texTypeStyle start="\\textit\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texItalGroup
-    syn region texItalStyle    matchgroup=texTypeStyle start="\\textit\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texItalGroup
-    syn region texItalBoldStyle    matchgroup=texTypeStyle start="\\textbf\s*\ze{" matchgroup=Delimiter end="}" concealends contains=@texBoldGroup
+    syn region texBoldStyle    matchgroup=texTypeStyle start="\\textbf\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texBoldGroup,@Spell
+    syn region texBoldItalStyle    matchgroup=texTypeStyle start="\\textit\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texItalGroup,@Spell
+    syn region texItalStyle    matchgroup=texTypeStyle start="\\textit\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texItalGroup,@Spell
+    syn region texItalBoldStyle    matchgroup=texTypeStyle start="\\textbf\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texBoldGroup,@Spell
+   else                                                                                              
+    syn region texBoldStyle    matchgroup=texTypeStyle start="\\textbf\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texBoldGroup
+    syn region texBoldItalStyle    matchgroup=texTypeStyle start="\\textit\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texItalGroup
+    syn region texItalStyle    matchgroup=texTypeStyle start="\\textit\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texItalGroup
+    syn region texItalBoldStyle    matchgroup=texTypeStyle start="\\textbf\s*{" matchgroup=texTypeStyle  end="}" concealends contains=@texBoldGroup
    endif
   endif
 endif

 " Bad Math (mismatched): {{{1
 if !exists("g:tex_no_math") && (!exists("s:tex_no_error") || !s:tex_no_error)
- syn match texBadMath      "\\end\s*{\s*\(array\|gathered\|bBpvV]matrix\|split\|subequations\|smallmatrix\|xxalignat\)\s*}"
+ syn match texBadMath      "\\end\s*{\s*\(array\|gathered\|bBpvV]matrix\|split\|smallmatrix\|xxalignat\)\s*}"
  syn match texBadMath      "\\end\s*{\s*\(align\|alignat\|displaymath\|displaymath\|eqnarray\|equation\|flalign\|gather\|math\|multline\|xalignat\)\*\=\s*}"
  syn match texBadMath      "\\[\])]"
 endif
@@ -456,24 +456,23 @@ if !exists("g:tex_no_math")
  call TexNewMathZone("G","gather",1)
  call TexNewMathZone("H","math",1)
  call TexNewMathZone("I","multline",1)
- call TexNewMathZone("J","subequations",0)
- call TexNewMathZone("K","xalignat",1)
- call TexNewMathZone("L","xxalignat",0)
+ call TexNewMathZone("J","xalignat",1)
+ call TexNewMathZone("K","xxalignat",0)

  " Inline Math Zones: {{{2
  if s:tex_fast =~ 'M'
   if has("conceal") && &enc == 'utf-8' && s:tex_conceal =~ 'd'
-   syn region texMathZoneV matchgroup=Delimiter start="\\("            matchgroup=Delimiter end="\\)\|%stopzone\>" keepend concealends contains=@texMathZoneGroup
-   syn region texMathZoneW matchgroup=Delimiter start="\\\["           matchgroup=Delimiter end="\\]\|%stopzone\>" keepend concealends contains=@texMathZoneGroup
-   syn region texMathZoneX matchgroup=Delimiter start="\$" skip="\\\\\|\\\$"   matchgroup=Delimiter end="\$" end="%stopzone\>"     concealends contains=@texMathZoneGroup
-   syn region texMathZoneY matchgroup=Delimiter start="\$\$"           matchgroup=Delimiter end="\$\$" end="%stopzone\>"   concealends keepend     contains=@texMathZoneGroup
+   syn region texMathZoneV matchgroup=Delimiter start="\\("            matchgroup=Delimiter    end="\\)\|%stopzone\>"          keepend concealends contains=@texMathZoneGroup
+   syn region texMathZoneW matchgroup=Delimiter start="\\\["           matchgroup=Delimiter    end="\\]\|%stopzone\>"          keepend concealends contains=@texMathZoneGroup
+   syn region texMathZoneX matchgroup=Delimiter start="\$" skip="\\\\\|\\\$"   matchgroup=Delimiter    end="\$"    end="%stopzone\>"       concealends contains=@texMathZoneGroup
+   syn region texMathZoneY matchgroup=Delimiter start="\$\$"           matchgroup=Delimiter    end="\$\$"  end="%stopzone\>"   keepend concealends contains=@texMathZoneGroup
   else
-   syn region texMathZoneV matchgroup=Delimiter start="\\("            matchgroup=Delimiter end="\\)\|%stopzone\>" keepend contains=@texMathZoneGroup
-   syn region texMathZoneW matchgroup=Delimiter start="\\\["           matchgroup=Delimiter end="\\]\|%stopzone\>" keepend contains=@texMathZoneGroup
-   syn region texMathZoneX matchgroup=Delimiter start="\$" skip="\\\\\|\\\$"   matchgroup=Delimiter end="\$" end="%stopzone\>" contains=@texMathZoneGroup
-   syn region texMathZoneY matchgroup=Delimiter start="\$\$"           matchgroup=Delimiter end="\$\$" end="%stopzone\>"   keepend     contains=@texMathZoneGroup
+   syn region texMathZoneV matchgroup=Delimiter start="\\("            matchgroup=Delimiter    end="\\)\|%stopzone\>"          keepend contains=@texMathZoneGroup
+   syn region texMathZoneW matchgroup=Delimiter start="\\\["           matchgroup=Delimiter    end="\\]\|%stopzone\>"          keepend contains=@texMathZoneGroup
+   syn region texMathZoneX matchgroup=Delimiter start="\$" skip="\\\\\|\\\$"   matchgroup=Delimiter    end="\$"    end="%stopzone\>"       contains=@texMathZoneGroup
+   syn region texMathZoneY matchgroup=Delimiter start="\$\$"           matchgroup=Delimiter    end="\$\$"  end="%stopzone\>"   keepend contains=@texMathZoneGroup
   endif
-  syn region texMathZoneZ  matchgroup=texStatement start="\\ensuremath\s*{"    matchgroup=texStatement end="}" end="%stopzone\>"   contains=@texMathZoneGroup
+  syn region texMathZoneZ  matchgroup=texStatement start="\\ensuremath\s*{"    matchgroup=texStatement end="}"     end="%stopzone\>"   contains=@texMathZoneGroup
  endif

  syn match texMathOper     "[_^=]" contained
@@ -1062,11 +1061,12 @@ if has("conceal") && &enc == 'utf-8'
    syn region texSuperscript   matchgroup=Delimiter start='\^{'    skip="\\\\\|\\[{}]" end='}' contained concealends contains=texSpecialChar,texSuperscripts,texStatement,texSubscript,texSuperscript,texMathMatcher
    syn region texSubscript matchgroup=Delimiter start='_{'     skip="\\\\\|\\[{}]" end='}' contained concealends contains=texSpecialChar,texSubscripts,texStatement,texSubscript,texSuperscript,texMathMatcher
   endif
+  " s:SuperSub:
   fun! s:SuperSub(group,leader,pat,cchar)
     if a:pat =~ '^\\' || (a:leader == '\^' && a:pat =~ g:tex_superscripts) || (a:leader == '_' && a:pat =~ g:tex_subscripts)
 "     call Decho("SuperSub: group<".a:group."> leader<".a:leader."> pat<".a:pat."> cchar<".a:cchar.">")
      exe 'syn match '.a:group." '".a:leader.a:pat."' contained conceal cchar=".a:cchar
-     exe 'syn match '.a:group."s '".a:pat."' contained conceal cchar=".a:cchar.' nextgroup='.a:group.'s'
+     exe 'syn match '.a:group."s '".a:pat        ."' contained conceal cchar=".a:cchar.' nextgroup='.a:group.'s'
     endif
   endfun
   call s:SuperSub('texSuperscript','\^','0','⁰')
``````
