### PR TITLE
[RFC] cmake: Fix search for msgpack when old system lib is installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ include(CheckLibraryExists)
 find_package(LibUV REQUIRED)
 include_directories(SYSTEM ${LIBUV_INCLUDE_DIRS})
 
-find_package(Msgpack REQUIRED)
+find_package(Msgpack 1.0.0 REQUIRED)
 include_directories(SYSTEM ${MSGPACK_INCLUDE_DIRS})
 
 find_package(LuaJit REQUIRED)

--- a/cmake/FindMsgpack.cmake
+++ b/cmake/FindMsgpack.cmake
@@ -43,6 +43,9 @@ endif()
 list(APPEND MSGPACK_NAMES msgpackc msgpack)
 
 find_library(MSGPACK_LIBRARY NAMES ${MSGPACK_NAMES}
+  # Check each directory for all names to avoid using headers/libraries from
+  # different places.
+  NAMES_PER_DIR
   HINTS ${PC_MSGPACK_LIBDIR} ${PC_MSGPACK_LIBRARY_DIRS}
   ${LIMIT_SEARCH})
 

--- a/cmake/FindMsgpack.cmake
+++ b/cmake/FindMsgpack.cmake
@@ -19,9 +19,19 @@ endif()
 
 set(MSGPACK_DEFINITIONS ${PC_MSGPACK_CFLAGS_OTHER})
 
-find_path(MSGPACK_INCLUDE_DIR msgpack.h
+find_path(MSGPACK_INCLUDE_DIR msgpack/version_master.h
   HINTS ${PC_MSGPACK_INCLUDEDIR} ${PC_MSGPACK_INCLUDE_DIRS}
   ${LIMIT_SEARCH})
+
+if(MSGPACK_INCLUDE_DIR)
+  file(READ ${MSGPACK_INCLUDE_DIR}/msgpack/version_master.h msgpack_version_h)
+  string(REGEX REPLACE ".*MSGPACK_VERSION_MAJOR +([0-9]+).*" "\\1" MSGPACK_VERSION_MAJOR "${msgpack_version_h}")
+  string(REGEX REPLACE ".*MSGPACK_VERSION_MINOR +([0-9]+).*" "\\1" MSGPACK_VERSION_MINOR "${msgpack_version_h}")
+  string(REGEX REPLACE ".*MSGPACK_VERSION_REVISION +([0-9]+).*" "\\1" MSGPACK_VERSION_REVISION "${msgpack_version_h}")
+  set(MSGPACK_VERSION_STRING "${MSGPACK_VERSION_MAJOR}.${MSGPACK_VERSION_MINOR}.${MSGPACK_VERSION_REVISION}")
+else()
+  set(MSGPACK_VERSION_STRING)
+endif()
 
 # If we're asked to use static linkage, add libmsgpack{,c}.a as a preferred library name.
 if(MSGPACK_USE_STATIC)
@@ -44,6 +54,7 @@ set(MSGPACK_INCLUDE_DIRS ${MSGPACK_INCLUDE_DIR})
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set MSGPACK_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(Msgpack DEFAULT_MSG
-                                  MSGPACK_LIBRARY MSGPACK_INCLUDE_DIR)
+find_package_handle_standard_args(Msgpack
+  REQUIRED_VARS MSGPACK_LIBRARY MSGPACK_INCLUDE_DIR
+  VERSION_VAR MSGPACK_VERSION_STRING)
 

--- a/cmake/FindMsgpack.cmake
+++ b/cmake/FindMsgpack.cmake
@@ -7,7 +7,9 @@
 if(NOT MSGPACK_USE_BUNDLED)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
-    pkg_search_module(PC_MSGPACK QUIET msgpackc>=1.0 msgpack>=1.0)
+    pkg_search_module(PC_MSGPACK QUIET
+      msgpackc>=${Msgpack_FIND_VERSION}
+      msgpack>=${Msgpack_FIND_VERSION})
   endif()
 else()
   set(PC_MSGPACK_INCLUDEDIR)


### PR DESCRIPTION
This adds the more thorough version check suggested by @fwalch in #4108.

It also ensures that the header and library built against are from the same
install, instead of picking up the header from the bundled install and the
library from the system install.

I still think it would be a better idea to build bundled dependencies only if
there isn't a sufficient system version installed, but that would require a
larger refactoring.
