### PR TITLE
[RDY] vim-patch:7.4.689

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -599,7 +599,7 @@ static int included_patches[] = {
   // 692 NA
   // 691 NA
   690,
-  // 689,
+  689,
   688,
   // 687 NA
   686,


### PR DESCRIPTION
```
Problem:    On MS-Windows, when 'autochdir' is set, diff mode with files in
            different directories does not work. (Axel Bender)
Solution:   Remember the current directory and use it where needed. (Christian
            Brabandt)
```

https://github.com/vim/vim/commit/d87c36ea5eae50580f3c733734669250cc969019

---

see: [autochdir + encoding=utf8 messes up diff](https://groups.google.com/d/msg/vim_dev/QrE4Y2LMJR8/uxigns5KGxYJ)

NOTE: I could not have checked the original issue affects neovim on windows (and be fixed by this PR). Because `neovim-qt -c "set acd" -d a\aa b\bb` does not respond. Any idea?
