### PR TITLE
[RFC] vim-patch:7.4.{708,717}

### DIFF
--- a/src/nvim/testdir/test55.in
+++ b/src/nvim/testdir/test55.in
@@ -442,6 +442,17 @@ let l = [0, 1, 2, 3]
 :unlockvar 1 b:
 :unlet! b:testvar
 :"
+:$put ='No :let += of locked list variable:'
+:let l = ['a', 'b', 3]
+:lockvar 1 l
+:try
+:  let l += ['x']
+:  $put ='did :let +='
+:catch
+:  $put =v:exception[:14]
+:endtry
+:$put =string(l)
+:"
 :unlet l
 :let l = [1, 2, 3, 4]
 :lockvar! l

--- a/src/nvim/testdir/test55.ok
+++ b/src/nvim/testdir/test55.ok
@@ -144,6 +144,9 @@ No extend() of write-protected scope-level variable:
 Vim(put):E742: 
 No :unlet of variable in locked scope:
 Vim(unlet):E741: 
+No :let += of locked list variable:
+Vim(let):E741: 
+['a', 'b', 3]
 [1, 2, 3, 4]
 [1, 2, 3, 4]
 [1, 2, 3, 4]

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -571,7 +571,7 @@ static int included_patches[] = {
   // 720 NA
   719,
   718,
-  // 717,
+  717,
   716,
   715,
   714,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -580,7 +580,7 @@ static int included_patches[] = {
   711,
   710,
   709,
-  // 708,
+  708,
   707,
   706,
   // 705 NA


### PR DESCRIPTION
```
vim-patch:7.4.708

Problem:    gettext() is called too often.
Solution:   Do not call gettext() for messages until they are actually used.
            (idea by Yasuhiro Matsumoto)
```

https://github.com/vim/vim/commit/77354e78a887e1b59ac519c5a1cb0e7fe9fc5899

```
vim-patch:7.4.717

Problem:    ":let list += list" can change a locked list.
Solution:   Check for the lock earlier. (Olaf Dabrunz)
```

https://github.com/vim/vim/commit/1cd5e613b0d8947d52762af0e17351d5e49869de
