### PR TITLE
[RFC] vim-patch:7.4.{734,743,929}

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7745,6 +7745,10 @@ static void nv_put(cmdarg_T *cap)
     if (was_visual) {
       curbuf->b_visual.vi_start = curbuf->b_op_start;
       curbuf->b_visual.vi_end = curbuf->b_op_end;
+      // need to adjust cursor position
+      if (*p_sel == 'e') {
+        inc(&curbuf->b_visual.vi_end);
+      }
     }
 
     /* When all lines were selected and deleted do_put() leaves an empty

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1555,55 +1555,31 @@ int op_delete(oparg_T *oap)
         if (gchar_cursor() != NUL)
           curwin->w_cursor.coladd = 0;
       }
-      if (oap->op_type == OP_DELETE
-          && oap->inclusive
-          && oap->end.lnum == curbuf->b_ml.ml_line_count
-          && n > (int)STRLEN(ml_get(oap->end.lnum))) {
-        /* Special case: gH<Del> deletes the last line. */
-        del_lines(1L, FALSE);
-      } else {
-        (void)del_bytes((long)n, !virtual_op, oap->op_type == OP_DELETE
-            && !oap->is_VIsual
-            );
-      }
-    } else {                          /* delete characters between lines */
+
+      (void)del_bytes((long)n, !virtual_op,
+                      oap->op_type == OP_DELETE && !oap->is_VIsual);
+    } else {
+      // delete characters between lines
       pos_T curpos;
-      int delete_last_line;
 
       /* save deleted and changed lines for undo */
       if (u_save((linenr_T)(curwin->w_cursor.lnum - 1),
               (linenr_T)(curwin->w_cursor.lnum + oap->line_count)) == FAIL)
         return FAIL;
 
-      delete_last_line = (oap->end.lnum == curbuf->b_ml.ml_line_count);
-      truncate_line(TRUE);              /* delete from cursor to end of line */
+      truncate_line(true);        // delete from cursor to end of line
 
-      curpos = curwin->w_cursor;        /* remember curwin->w_cursor */
-      ++curwin->w_cursor.lnum;
-      del_lines(oap->line_count - 2, FALSE);
+      curpos = curwin->w_cursor;  // remember curwin->w_cursor
+      curwin->w_cursor.lnum++;
+      del_lines(oap->line_count - 2, false);
 
-      if (delete_last_line)
-        oap->end.lnum = curbuf->b_ml.ml_line_count;
-
+      // delete from start of line until op_end
       n = (oap->end.col + 1 - !oap->inclusive);
-      if (oap->inclusive && delete_last_line
-          && n > (int)STRLEN(ml_get(oap->end.lnum))) {
-        /* Special case: gH<Del> deletes the last line. */
-        del_lines(1L, FALSE);
-        curwin->w_cursor = curpos;              /* restore curwin->w_cursor */
-        if (curwin->w_cursor.lnum > curbuf->b_ml.ml_line_count)
-          curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
-      } else {
-        /* delete from start of line until op_end */
-        curwin->w_cursor.col = 0;
-        (void)del_bytes((long)n, !virtual_op, oap->op_type == OP_DELETE
-            && !oap->is_VIsual
-            );
-        curwin->w_cursor = curpos;              /* restore curwin->w_cursor */
-      }
-      if (curwin->w_cursor.lnum < curbuf->b_ml.ml_line_count) {
-        do_join(2, FALSE, FALSE, FALSE, false);
-      }
+      curwin->w_cursor.col = 0;
+      (void)del_bytes((long)n, !virtual_op,
+                      oap->op_type == OP_DELETE && !oap->is_VIsual);
+      curwin->w_cursor = curpos;  // restore curwin->w_cursor
+      (void)do_join(2, false, false, false, false);
     }
   }
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2664,17 +2664,27 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
 
   if (y_type == MLINE) {
     if (flags & PUT_LINE_SPLIT) {
-      /* "p" or "P" in Visual mode: split the lines to put the text in
-       * between. */
-      if (u_save_cursor() == FAIL)
+      // "p" or "P" in Visual mode: split the lines to put the text in
+      // between.
+      if (u_save_cursor() == FAIL) {
         goto end;
-      ptr = vim_strsave(get_cursor_pos_ptr());
-      ml_append(curwin->w_cursor.lnum, ptr, (colnr_T)0, FALSE);
+      }
+      char_u *p = get_cursor_pos_ptr();
+      if (dir == FORWARD && *p != NUL) {
+        mb_ptr_adv(p);
+      }
+      ptr = vim_strsave(p);
+      ml_append(curwin->w_cursor.lnum, ptr, (colnr_T)0, false);
       xfree(ptr);
 
-      ptr = vim_strnsave(get_cursor_line_ptr(), curwin->w_cursor.col);
-      ml_replace(curwin->w_cursor.lnum, ptr, FALSE);
-      ++nr_lines;
+      oldp = get_cursor_line_ptr();
+      p = oldp + curwin->w_cursor.col;
+      if (dir == FORWARD && *p != NUL) {
+        mb_ptr_adv(p);
+      }
+      ptr = vim_strnsave(oldp, p - oldp);
+      ml_replace(curwin->w_cursor.lnum, ptr, false);
+      nr_lines++;
       dir = FORWARD;
     }
     if (flags & PUT_LINE_FORWARD) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -357,7 +357,7 @@ static int included_patches[] = {
   // 934 NA
   // 933,
   // 932,
-  // 931,
+  // 931 NA
   // 930 NA
   929,
   // 928 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -554,7 +554,7 @@ static int included_patches[] = {
   737,
   736,
   // 735 NA
-  // 734,
+  734,
   // 733,
   732,
   // 731 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -545,7 +545,7 @@ static int included_patches[] = {
   746,
   745,
   // 744 NA
-  // 743,
+  743,
   742,
   741,
   740,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -359,7 +359,7 @@ static int included_patches[] = {
   // 932,
   // 931,
   // 930 NA
-  // 929,
+  929,
   // 928 NA
   // 927 NA
   // 926,

--- a/test/functional/legacy/094_visual_mode_operators_spec.lua
+++ b/test/functional/legacy/094_visual_mode_operators_spec.lua
@@ -24,6 +24,20 @@ local function source_user_functions()
   ]])
 end
 
+local function put_abc()
+  source([[
+    $put ='a'
+    $put ='b'
+    $put ='c']])
+end
+
+local function define_select_mode_maps()
+  source([[
+    snoremap <lt>End> <End>
+    snoremap <lt>Down> <Down>
+    snoremap <lt>Del> <Del>]])
+end
+
 describe('Visual mode and operator', function()
   before_each(function()
     clear()
@@ -149,5 +163,148 @@ describe('Visual mode and operator', function()
       zzz
       ok
       ok]])
+  end)
+
+  describe('characterwise visual mode:', function()
+    it('replace last line', function()
+      source([[
+        $put ='a'
+        let @" = 'x']])
+      feed('v$p')
+
+      expect([[
+        
+        x]])
+    end)
+
+    it('delete middle line', function()
+      put_abc()
+      feed('kkv$d')
+
+      expect([[
+        
+        b
+        c]])
+    end)
+
+    it('delete middle two line', function()
+      put_abc()
+      feed('kkvj$d')
+
+      expect([[
+        
+        c]])
+    end)
+
+    it('delete last line', function()
+      put_abc()
+      feed('v$d')
+
+      expect([[
+        
+        a
+        b
+        ]])
+    end)
+
+    it('delete last two line', function()
+      put_abc()
+      feed('kvj$d')
+
+      expect([[
+        
+        a
+        ]])
+    end)
+  end)
+
+  describe('characterwise select mode:', function()
+    before_each(function()
+      define_select_mode_maps()
+    end)
+
+    it('delete middle line', function()
+      put_abc()
+      feed('kkgh<End><Del>')
+
+      expect([[
+        
+        b
+        c]])
+    end)
+
+    it('delete middle two line', function()
+      put_abc()
+      feed('kkgh<Down><End><Del>')
+
+      expect([[
+        
+        c]])
+    end)
+
+    it('delete last line', function()
+      put_abc()
+      feed('gh<End><Del>')
+
+      expect([[
+        
+        a
+        b
+        ]])
+    end)
+
+    it('delete last two line', function()
+      put_abc()
+      feed('kgh<Down><End><Del>')
+
+      expect([[
+        
+        a
+        ]])
+    end)
+  end)
+
+  describe('linewise select mode:', function()
+    before_each(function()
+      define_select_mode_maps()
+    end)
+
+    it('delete middle line', function()
+      put_abc()
+      feed(' kkgH<Del> ')
+
+      expect([[
+        
+        b
+        c]])
+    end)
+
+    it('delete middle two line', function()
+      put_abc()
+      feed('kkgH<Down><Del>')
+
+      expect([[
+        
+        c]])
+    end)
+
+    it('delete last line', function()
+      put_abc()
+      feed('gH<Del>')
+
+      expect([[
+        
+        a
+        b]])
+    end)
+
+    it('delete last two line', function()
+      put_abc()
+      feed('kgH<Down><Del>')
+
+      expect([[
+        
+        a]])
+    end)
   end)
 end)

--- a/test/functional/legacy/094_visual_mode_operators_spec.lua
+++ b/test/functional/legacy/094_visual_mode_operators_spec.lua
@@ -31,6 +31,13 @@ local function put_abc()
     $put ='c']])
 end
 
+local function put_aaabbbccc()
+  source([[
+    $put ='aaa'
+    $put ='bbb'
+    $put ='ccc']])
+end
+
 local function define_select_mode_maps()
   source([[
     snoremap <lt>End> <End>
@@ -305,6 +312,63 @@ describe('Visual mode and operator', function()
       expect([[
         
         a]])
+    end)
+  end)
+
+  describe('v_p:', function()
+    it('replace last character with line register at middle line', function()
+      put_aaabbbccc()
+      execute('-2yank')
+      feed('k$vp')
+
+      expect([[
+        
+        aaa
+        bb
+        aaa
+        
+        ccc]])
+    end)
+
+    it('replace last character with line register at middle line selecting newline', function()
+      put_aaabbbccc()
+      execute('-2yank')
+      feed('k$v$p')
+
+      expect([[
+        
+        aaa
+        bb
+        aaa
+        ccc]])
+    end)
+
+    it('replace last character with line register at last line', function()
+      put_aaabbbccc()
+      execute('-2yank')
+      feed('$vp')
+
+      expect([[
+        
+        aaa
+        bbb
+        cc
+        aaa
+        ]])
+    end)
+
+    it('replace last character with line register at last line selecting newline', function()
+      put_aaabbbccc()
+      execute('-2yank')
+      feed('$v$p')
+
+      expect([[
+        
+        aaa
+        bbb
+        cc
+        aaa
+        ]])
     end)
   end)
 end)

--- a/test/functional/legacy/094_visual_mode_operators_spec.lua
+++ b/test/functional/legacy/094_visual_mode_operators_spec.lua
@@ -371,4 +371,28 @@ describe('Visual mode and operator', function()
         ]])
     end)
   end)
+
+  it('gv in exclusive select mode after operation', function()
+    source([[
+      $put ='zzz '
+      $put ='Ã¤Ã '
+      set selection=exclusive]])
+    feed('kv3lyjv3lpgvcxxx<Esc>')
+
+    expect([[
+      
+      zzz 
+      xxx ]])
+  end)
+
+  it('gv in exclusive select mode without operation', function()
+    source([[
+      $put ='zzz '
+      set selection=exclusive]])
+    feed('0v3l<Esc>gvcxxx<Esc>')
+
+    expect([[
+      
+      xxx ]])
+  end)
 end)


### PR DESCRIPTION
```
vim-patch:7.4.734

Problem:    ml_get error when using "p" in a Visual selection in the last
            line.
Solution:   Change the behavior at the last line. (Yukihiro Nakadaira)
```

https://github.com/vim/vim/commit/d009e8682686a56f7565e6e093a42cd0596e121f

```
vim-patch:7.4.743

Problem:    "p" in Visual mode causes an unexpected line split.
Solution:   Advance the cursor first. (Yukihiro Nakadaira)
```

https://github.com/vim/vim/commit/c004bc2726eafc7a56d1d9f8398a65a0a7dc8d6c

```
vim-patch:7.4.929

Problem:    "gv" after paste selects one character less if 'selection' is
            "exclusive".
Solution:   Increment the end position. (Christian Brabandt)
```

https://github.com/vim/vim/commit/d29c6fea94947b3f4b54fbd5a6f832a7d744bf27
