### PR TITLE
[RFC] tests: add tests for vim_strsave_escaped() function

### DIFF
--- a/test/unit/strings_spec.lua
+++ b/test/unit/strings_spec.lua
@@ -8,6 +8,38 @@ local to_cstr = helpers.to_cstr
 local strings = cimport('stdlib.h', './src/nvim/strings.h',
                         './src/nvim/memory.h')
 
+describe('vim_strsave_escaped()', function()
+  local vim_strsave_escaped = function(s, chars)
+    local res = strings.vim_strsave_escaped(to_cstr(s), to_cstr(chars))
+    local ret = ffi.string(res)
+
+    -- Explicitly free memory so we are sure it is allocated: if it was not it 
+    -- will crash.
+    strings.xfree(res)
+    return ret
+  end
+
+  it('precedes by a backslash all chars from second argument', function()
+    eq([[\a\b\c\d]], vim_strsave_escaped('abcd','abcd'))
+  end)
+
+  it('precedes by a backslash chars only from second argument', function()
+    eq([[\a\bcd]], vim_strsave_escaped('abcd','ab'))
+  end)
+
+  it('returns a copy of passed string if second argument is empty', function()
+    eq('text \n text', vim_strsave_escaped('text \n text',''))
+  end)
+
+  it('returns an empty string if first argument is empty string', function()
+    eq('', vim_strsave_escaped('','\r'))
+  end)
+
+  it('returns a copy of passed string if it does not contain chars from 2nd argument', function()
+    eq('some text', vim_strsave_escaped('some text', 'a'))
+  end)
+end)
+
 describe('vim_strnsave_unquoted()', function()
   local vim_strnsave_unquoted = function(s, len)
     local res = strings.vim_strnsave_unquoted(to_cstr(s), len or #s)


### PR DESCRIPTION
I added the test for a simple function called vim_strsave_escaped, but it failed. 

``` lua
it('precede all chars from second parameter by a backslash', function()
  eq('\\b', vim_strsave_escaped('\b','\b'))
end)
```

If I understood right description of that function:

```
/*
 * Same as vim_strsave(), but any characters found in esc_chars are preceded
 * by a backslash.
 */
```

it should precede all characters from  "esc_chars" which were found in a string by "\". But it doesn't.

Is it a bug or maybe I understand it wrong?
