### PR TITLE
CMake: Add #include in _FORTIFY_SOURCE check.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,11 @@ if(${INIT_FLAGS_NAME})
   set(CMAKE_REQUIRED_FLAGS "${${INIT_FLAGS_NAME}}")
 endif()
 
+# Include <string.h> because some toolchains define _FORTIFY_SOURCE=2 in
+# internal header files, which should in turn be #included by <string.h>.
 check_c_source_compiles("
+#include <string.h>
+
 #if defined(_FORTIFY_SOURCE) && _FORTIFY_SOURCE > 1
 #error \"_FORTIFY_SOURCE > 1\"
 #endif


### PR DESCRIPTION
Some toolchains apparently set _FORTIFY_SOURCE=2 in internal header
files. Include <string.h> (which in turn should include such internal
header files) before checking the value of _FORTIFY_SOURCE to catch
that.

Fixes #4183.
