### PR TITLE
[RFC] build system: avoid more unneccesary recompiles

### DIFF
--- a/scripts/gendeclarations.lua
+++ b/scripts/gendeclarations.lua
@@ -239,23 +239,24 @@ end
 non_static = non_static .. footer
 static = static .. footer
 
-local F
-F = io.open(static_fname, 'w')
-F:write(static)
-F:close()
 
--- Before generating the non-static headers, check if the current file(if
--- exists) is different from the new one. If they are the same, we won't touch
--- the current version to avoid triggering an unnecessary rebuilds of modules
+-- Before generating the headers, check if the current file (if exists) is
+-- different from the new one. If they are the same, we won't touch the
+-- current version to avoid triggering an unnecessary rebuilds of modules
 -- that depend on this one
-F = io.open(non_static_fname, 'r')
-if F ~= nil then
-  if F:read('*a') == non_static then
-    os.exit(0)
+local update_changed = function (fname, contents)
+  local F = io.open(fname, 'r')
+  if F ~= nil then
+    if F:read('*a') == contents then
+      return
+    end
+    io.close(F)
   end
-  io.close(F)
+
+  F = io.open(fname, 'w')
+  F:write(contents)
+  F:close()
 end
 
-F = io.open(non_static_fname, 'w')
-F:write(non_static)
-F:close()
+update_changed(static_fname, static)
+update_changed(non_static_fname, non_static)


### PR DESCRIPTION
Problem: `touch normal.c` or edit inside some function without changing the interface and it rebuilds almost everything. It looks like `gendeclarations.lua` wants to avoid this, but apparently this logic must also cover static headers in some cases like `normal.c`. I suppose if the non-static header somehow depends on the static header...
And yes, I have tested changing the interface, and it rebuilds as needed.

Note: cmake does NOT like this script to be modified, so one MUST do `make clean` after checking out this branch (or back to master) to be able to test this. 
