### PR TITLE
[RFC] install *.mo files correctly

### DIFF
--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -73,7 +73,7 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
     install_helper(
       FILES ${moFile}
       DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/nvim/runtime/lang/${name}/LC_MESSAGES
-      RENAME vim.mo)
+      RENAME nvim.mo)
 
     list(APPEND LANGUAGE_MO_FILES ${moFile})
   endmacro()

--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -72,8 +72,8 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
 
     install_helper(
       FILES ${moFile}
-      DESTINATION ${CMAKE_INSTALL_LOCALEDIR}/${name}/LC_MESSAGES
-      RENAME nvim.mo)
+      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/nvim/runtime/lang/${name}/LC_MESSAGES
+      RENAME vim.mo)
 
     list(APPEND LANGUAGE_MO_FILES ${moFile})
   endmacro()

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -30,7 +30,7 @@ Error: configure did not run properly.Check auto/config.log.
 
 /* Can't use "PACKAGE" here, conflicts with a Perl include file. */
 #ifndef VIMPACKAGE
-# define VIMPACKAGE     "vim"
+# define VIMPACKAGE     "nvim"
 #endif
 
 #include "nvim/os/os_defs.h"       /* bring lots of system header files */


### PR DESCRIPTION
Currently, the gettext *.mo files are installed as
`$prefix/share/locale/xx/LC_MESSGES/nvim.mo`
but they should be installed as
`$prefix/share/nvim/runtime/lang/xx/LC_MESSAGES/vim.mo`
so that nvim can find them.

Of course we can set `VIMPACKAGE` to `"nvim"` (in vim.h) instead of
modifying the `RENAME` line (I don't know which is better).
