### PR TITLE
Remove "margin" from MATLAB syntax definition.

### DIFF
--- a/runtime/syntax/matlab.vim
+++ b/runtime/syntax/matlab.vim
@@ -64,7 +64,7 @@ syn match matlabComment			"%.*$"	contains=matlabTodo,matlabTab
 syn match matlabComment			"\.\.\..*$"	contains=matlabTodo,matlabTab
 syn region matlabMultilineComment	start=+%{+ end=+%}+ contains=matlabTodo,matlabTab
 
-syn keyword matlabOperator		break zeros default margin round ones rand
+syn keyword matlabOperator		break zeros default round ones rand
 syn keyword matlabOperator		ceil floor size clear zeros eye mean std cov
 
 syn keyword matlabFunction		error eval function


### PR DESCRIPTION
In MATLAB, "margin" is neither a built in function nor an operator. The word was possibly a typo intended to be "nargin", but "nargin" is not an operator or keyword either.
