### PR TITLE
[RFC] build: if helptags generation fails, echo the message

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -35,7 +35,7 @@ add_custom_command(OUTPUT ${GENERATED_HELP_TAGS}
   COMMAND "${PROJECT_BINARY_DIR}/bin/nvim"
     -u NONE
     -i NONE
-    -es
+    -e
     --headless
     -c "helptags ++t ."
     -c quit


### PR DESCRIPTION
remove the "silent" flag. If tags generation succeeds, there is still no output. But if it fails, you want to see the error so you can fix it.
