### PR TITLE
[RFC] vim-patch:7.4.844

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3580,9 +3580,10 @@ static int eval4(char_u **arg, typval_T *rettv, int evaluate)
       type = TYPE_SEQUAL;
     break;
   case 'i':   if (p[1] == 's') {
-      if (p[2] == 'n' && p[3] == 'o' && p[4] == 't')
+      if (p[2] == 'n' && p[3] == 'o' && p[4] == 't') {
         len = 5;
-      if (!vim_isIDc(p[len])) {
+      }
+      if (!isalnum(p[len]) && p[len] != '_') {
         type = len == 2 ? TYPE_EQUAL : TYPE_NEQUAL;
         type_is = TRUE;
       }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -444,7 +444,7 @@ static int included_patches[] = {
   // 847,
   // 846 NA
   // 845,
-  // 844,
+  844,
   // 843,
   // 842 NA
   // 841 NA

--- a/test/functional/legacy/comparators_spec.lua
+++ b/test/functional/legacy/comparators_spec.lua
@@ -1,0 +1,14 @@
+-- " Test for expression comparators.
+
+local helpers = require('test.functional.helpers')
+local clear, eq = helpers.clear, helpers.eq
+local eval, execute = helpers.eval, helpers.execute
+
+describe('comparators', function()
+  before_each(clear)
+
+  it('is working', function()
+    execute('set isident+=#')
+    eq(1, eval('1 is#1'))
+  end)
+end)


### PR DESCRIPTION
Problem:    When '#' is in 'isident' the is# comparator doesn't work.
Solution:   Don't use vim_isIDc(). (Yasuhiro Matsumoto)

https://github.com/vim/vim/commit/37a8de17d4dfd3d463960c38a204ce399c8e19d4
