### PR TITLE
[RFC] vim-patch:7.4.847

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3140,10 +3140,12 @@ current_block (
   }
 
   if (VIsual_active) {
-    if (*p_sel == 'e')
-      ++curwin->w_cursor.col;
-    if (sol && gchar_cursor() != NUL)
-      inc(&curwin->w_cursor);           /* include the line break */
+    if (*p_sel == 'e') {
+      inc(&curwin->w_cursor);
+    }
+    if (sol && gchar_cursor() != NUL) {
+      inc(&curwin->w_cursor);  // include the line break
+    }
     VIsual = start_pos;
     VIsual_mode = 'v';
     redraw_curbuf_later(INVERTED);      /* update the inversion */

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -441,7 +441,7 @@ static int included_patches[] = {
   // 850 NA
   849,
   848,
-  // 847,
+  847,
   // 846 NA
   // 845,
   // 844,


### PR DESCRIPTION
Problem:    "vi)d" may leave a character behind.
Solution:   Skip over multi-byte character. (Christian Brabandt)

https://github.com/vim/vim/commit/8667d66ca923d361e00e6369cbff37283db5a432
