### PR TITLE
[RFC] vim-patch:7.4.{853,856}

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1302,13 +1302,10 @@ void scroll_cursor_top(int min_scroll, int always)
   }
   new_topline = top + 1;
 
-  // used already contains the number of filler lines above, don't add it
+  // "used" already contains the number of filler lines above, don't add it
   // again.
-  // TODO: if filler lines above new top are to be considered as context for
-  // the current window, leave next statement commented, else hide filler
-  // lines above cursor line, by adding them to extra
-  // int extra += diff_check_fill(curwin, curwin->w_cursor.lnum);
-  int extra = 0;
+  // Hide filler lines above cursor line by adding them to "extra".
+  int extra = diff_check_fill(curwin, curwin->w_cursor.lnum);
 
   /*
    * Check if the lines from "top" to "bot" fit in the window.  If they do,
@@ -1317,7 +1314,7 @@ void scroll_cursor_top(int min_scroll, int always)
   while (top > 0) {
     int i = hasFolding(top, &top, NULL)
             ? 1  // count one logical line for a sequence of folded lines
-            : plines(top);
+            : plines_nofill(top);
     used += i;
     if (extra + i <= off && bot < curbuf->b_ml.ml_line_count) {
       if (hasFolding(bot, NULL, &bot))

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1288,9 +1288,10 @@ void scroll_cursor_top(int min_scroll, int always)
    * - at least 'scrolloff' lines above and below the cursor
    */
   validate_cheight();
-  int used = curwin->w_cline_height;
-  if (curwin->w_cursor.lnum < curwin->w_topline)
+  int used = curwin->w_cline_height;  // includes filler lines above
+  if (curwin->w_cursor.lnum < curwin->w_topline) {
     scrolled = used;
+  }
 
   if (hasFolding(curwin->w_cursor.lnum, &top, &bot)) {
     --top;
@@ -1301,9 +1302,13 @@ void scroll_cursor_top(int min_scroll, int always)
   }
   new_topline = top + 1;
 
-  /* count filler lines of the cursor window as context */
-  int extra = diff_check_fill(curwin, curwin->w_cursor.lnum);
-  used += extra;
+  // used already contains the number of filler lines above, don't add it
+  // again.
+  // TODO: if filler lines above new top are to be considered as context for
+  // the current window, leave next statement commented, else hide filler
+  // lines above cursor line, by adding them to extra
+  // int extra += diff_check_fill(curwin, curwin->w_cursor.lnum);
+  int extra = 0;
 
   /*
    * Check if the lines from "top" to "bot" fit in the window.  If they do,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -432,7 +432,7 @@ static int included_patches[] = {
   // 859,
   858,
   // 857,
-  // 856,
+  856,
   // 855 NA
   // 854 NA
   853,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -435,7 +435,7 @@ static int included_patches[] = {
   // 856,
   // 855 NA
   // 854 NA
-  // 853,
+  853,
   // 852 NA
   // 851 NA
   // 850 NA


### PR DESCRIPTION
```
vim-patch:7.4.853

Problem:    "zt" in diff mode does not always work properly. (Gary Johnson)
Solution:   Don't count filler lines twice. (Christian Brabandt)
```

https://github.com/vim/vim/commit/cf619daa8e0ef9a335f27f65eb74e422a17d4f92

```
vim-patch:7.4.856

Problem:    "zt" still doesn't work well with filler lines. (Gary Johnson)
Solution:   Check for filler lines above the cursor. (Christian Brabandt)
```

https://github.com/vim/vim/commit/a09a2c5857ab854f0870573b5160da1964c905a2
