### PR TITLE
[RFC] resolve symlink in shada_spec test

### DIFF
--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -174,6 +174,7 @@ describe('ShaDa support code', function()
     nvim_command('set shada+=%')
     nvim_command('wshada! ' .. shada_fname)
     local readme_fname = paths.test_source_path .. '/README.md'
+    readme_fname = helpers.eval( 'resolve("' .. readme_fname .. '")' )
     eq({[7]=1, [8]=2, [9]=1, [10]=4, [11]=1}, find_file(readme_fname))
     nvim_command('set shada+=r~')
     nvim_command('wshada! ' .. shada_fname)


### PR DESCRIPTION
If symlinks exist in the pathname of the build directory, 'make functionaltest' fails. To reproduce:

```
$ git clone https://github.com/neovim/neovim.git
$ ln -s neovim sym
$ cd sym && make && make functionaltest
```

then you will get

```
Failure → /path/to/sym/test/functional/shada/shada_spec.lua @ 167
ShaDa support code correctly uses shada-r option
/path/to/sym/test/functional/shada/shada_spec.lua:177: Expected objects to be the same.
Passed in:
(table) { }
Expected:
(table) {
 *[7] = 1
  [8] = 2
  [9] = 1
  [10] = 4
  [11] = 1 }
```

The reason is simple. `readme_fname` is `/path/to/sym/README.md`, but nvim resolve it to `/path/to/neovim/REAME.md` when writing into the shada file, so `find_file()` can't find it.
