### PR TITLE
[RFC] vim-patch:7.4.878

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -381,15 +381,14 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
     suppress_errthrow = FALSE;
   }
 
-  /*
-   * If requested, store and reset the global values controlling the
-   * exception handling (used when debugging).  Otherwise clear it to avoid
-   * a bogus compiler warning when the optimizer uses inline functions...
-   */
-  if (flags & DOCMD_EXCRESET)
+  // If requested, store and reset the global values controlling the
+  // exception handling (used when debugging).  Otherwise clear it to avoid
+  // a bogus compiler warning when the optimizer uses inline functions...
+  if (flags & DOCMD_EXCRESET) {
     save_dbg_stuff(&debug_saved);
-  else
-    memset(&debug_saved, 0, 1);
+  } else {
+    memset(&debug_saved, 0, sizeof(debug_saved));
+  }
 
   initial_trylevel = trylevel;
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -410,7 +410,7 @@ static int included_patches[] = {
   // 881,
   // 880 NA
   // 879,
-  // 878,
+  878,
   // 877,
   // 876 NA
   // 875 NA


### PR DESCRIPTION
```
Problem:    Coverity error for clearing only one byte of struct.
Solution:   Clear the whole struct. (Dominique Pelle)
```

https://github.com/vim/vim/commit/69b67f7e774dc212e8c97495ee81c601b8a89ac2
