### PR TITLE
[RFC] vim-patch:7.4.887

### DIFF
--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -4048,6 +4048,7 @@ skip_add:
         sub->list.multi[subidx].start_col =
           (colnr_T)(reginput - regline + off);
       }
+      sub->list.multi[subidx].end_lnum = -1;
     } else {
       if (subidx < sub->in_use) {
         save_ptr = sub->list.line[subidx].start;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -401,7 +401,7 @@ static int included_patches[] = {
   // 890 NA
   // 889,
   // 888,
-  // 887,
+  887,
   // 886 NA
   // 885,
   // 884 NA


### PR DESCRIPTION
```
Problem:    Using uninitialized memory for regexp with back reference.
            (Dominique Pelle)
Solution:   Initialize end_lnum.
```

https://github.com/vim/vim/commit/c2b717ebd6719e722dcb5f10e4c74033a53ff7c7

---

see: "[bug] use of uninitialized memory in regexp_nfa.c with invalid back reference"
     https://groups.google.com/d/msg/vim_dev/JWmrT5-NnPQ/U_TgaRW8AwAJ
