### PR TITLE
[RFC] vim-patch:7.4.901

### DIFF
--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -545,7 +545,11 @@ static int pum_set_selected(int n, int repeat)
         g_do_tagpreview = (int)p_pvh;
       }
       RedrawingDisabled++;
+      // Prevent undo sync here, if an autocommand syncs undo weird
+      // things can happen to the undo tree.
+      no_u_sync++;
       resized = prepare_tagpreview(false);
+      no_u_sync--;
       RedrawingDisabled--;
       g_do_tagpreview = 0;
 
@@ -629,7 +633,9 @@ static int pum_set_selected(int n, int repeat)
             // the window when needed, otherwise it will always be
             // redraw.
             if (resized) {
+              no_u_sync++;
               win_enter(curwin_save, true);
+              no_u_sync--;
               update_topline();
             }
 
@@ -640,7 +646,9 @@ static int pum_set_selected(int n, int repeat)
             pum_do_redraw = FALSE;
 
             if (!resized && win_valid(curwin_save)) {
+              no_u_sync++;
               win_enter(curwin_save, true);
+              no_u_sync--;
             }
 
             // May need to update the screen again when there are

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -387,7 +387,7 @@ static int included_patches[] = {
   // 904,
   // 903,
   // 902 NA
-  // 901,
+  901,
   // 900 NA
   // 899 NA
   898,


### PR DESCRIPTION
```
Problem:    When a BufLeave autocommand changes folding in a way it syncs
            undo, undo can be corrupted.
Solution:   Prevent undo sync. (Jacob Niehus)
```

https://github.com/vim/vim/commit/e7d1376b636e6c758196c3542bd2c1053f9edb75

---

see: "[bug] [patch] Setting foldmethod in WinLeave autocommand can corrupt undo state"
     https://groups.google.com/d/msg/vim_dev/xF5uMLb1vwY/Jn4RglosDgAJ
