### PR TITLE
[RFC] vim-patch:7.4.922

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4779,6 +4779,7 @@ void ex_helptags(exarg_T *eap)
       WILD_LIST_NOTFOUND|WILD_SILENT, WILD_EXPAND_FREE);
   if (dirname == NULL || !os_isdir(dirname)) {
     EMSG2(_("E150: Not a directory: %s"), eap->arg);
+    xfree(dirname);
     return;
   }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -366,7 +366,7 @@ static int included_patches[] = {
   // 925,
   // 924 NA
   // 923 NA
-  // 922,
+  922,
   // 921 NA
   // 920 NA
   // 919 NA


### PR DESCRIPTION
```
Problem:    Leaking memory with ":helpt {dir-not-exists}".
Solution:   Free dirname. (Dominique Pelle)
```

https://github.com/vim/vim/commit/1c2836e268ce930bca9ea1287d0d83e92ce1b3ff

---

see: "[patch] command :helpt {dir} leaks memory when directory does not exist"
     https://groups.google.com/d/msg/vim_dev/WbcIbZ9YdUA/4eow2c3_AgAJ
