### PR TITLE
[RFC] vim-patch:7.4.{926,932,933}

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2969,7 +2969,7 @@ ExpandOne (
         mb_len = (* mb_ptr2len)(&xp->xp_files[0][len]);
         c0 = (* mb_ptr2char)(&xp->xp_files[0][len]);
       } else {
-        c0 = xp->xp_files[i][len];
+        c0 = xp->xp_files[0][len];
       }
       for (i = 1; i < xp->xp_numfiles; ++i) {
         if (has_mbyte) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2957,20 +2957,37 @@ ExpandOne (
     }
   }
 
-  /* Find longest common part */
+  // Find longest common part
   if (mode == WILD_LONGEST && xp->xp_numfiles > 0) {
     size_t len;
-    for (len = 0; xp->xp_files[0][len]; ++len) {
-      for (i = 0; i < xp->xp_numfiles; ++i) {
+    size_t mb_len = 1;
+    int c0;
+    int ci;
+
+    for (len = 0; xp->xp_files[0][len]; len += mb_len) {
+      if (has_mbyte) {
+        mb_len = (* mb_ptr2len)(&xp->xp_files[0][len]);
+        c0 = (* mb_ptr2char)(&xp->xp_files[0][len]);
+      } else {
+        c0 = xp->xp_files[i][len];
+      }
+      for (i = 1; i < xp->xp_numfiles; ++i) {
+        if (has_mbyte) {
+          ci =(* mb_ptr2char)(&xp->xp_files[i][len]);
+        } else {
+          ci = xp->xp_files[i][len];
+        }
+
         if (p_fic && (xp->xp_context == EXPAND_DIRECTORIES
                       || xp->xp_context == EXPAND_FILES
                       || xp->xp_context == EXPAND_SHELLCMD
                       || xp->xp_context == EXPAND_BUFFERS)) {
-          if (TOLOWER_LOC(xp->xp_files[i][len]) !=
-              TOLOWER_LOC(xp->xp_files[0][len]))
+          if (vim_tolower(c0) != vim_tolower(ci)) {
             break;
-        } else if (xp->xp_files[i][len] != xp->xp_files[0][len])
+          }
+        } else if (c0 != ci) {
           break;
+        }
       }
       if (i < xp->xp_numfiles) {
         if (!(options & WILD_NO_BEEP)) {
@@ -2979,8 +2996,9 @@ ExpandOne (
         break;
       }
     }
+
     ss = (char_u *)xstrndup((char *)xp->xp_files[0], len);
-    findex = -1;                            /* next p_wc gets first one */
+    findex = -1;  // next p_wc gets first one
   }
 
   // Concatenate all matching names

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -362,7 +362,7 @@ static int included_patches[] = {
   929,
   // 928 NA
   // 927 NA
-  // 926,
+  926,
   // 925,
   // 924 NA
   // 923 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -353,7 +353,7 @@ static int included_patches[] = {
   // 938 NA
   // 937,
   // 936,
-  // 935,
+  // 935 NA
   // 934 NA
   933,
   932,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -355,7 +355,7 @@ static int included_patches[] = {
   // 936,
   // 935,
   // 934 NA
-  // 933,
+  933,
   932,
   // 931 NA
   // 930 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -356,7 +356,7 @@ static int included_patches[] = {
   // 935,
   // 934 NA
   // 933,
-  // 932,
+  932,
   // 931 NA
   // 930 NA
   929,

--- a/test/functional/legacy/utf8_spec.lua
+++ b/test/functional/legacy/utf8_spec.lua
@@ -57,21 +57,21 @@ describe('utf8', function()
       function! CustomComplete1(lead, line, pos)
         return ['あ', 'い']
       endfunction
-      command -nargs=1 -complete=customlist,CustomComplete1 Test1 :]])
+      command -nargs=1 -complete=customlist,CustomComplete1 Test1 echo]])
     feed(":Test1 <C-L>'<C-B>$put='<CR>")
 
     source([[
       function! CustomComplete2(lead, line, pos)
         return ['あたし', 'あたま', 'あたりめ']
       endfunction
-      command -nargs=1 -complete=customlist,CustomComplete2 Test2 :]])
+      command -nargs=1 -complete=customlist,CustomComplete2 Test2 echo]])
     feed(":Test2 <C-L>'<C-B>$put='<CR>")
 
     source([[
       function! CustomComplete3(lead, line, pos)
         return ['Nこ', 'Nん', 'Nぶ']
       endfunction
-      command -nargs=1 -complete=customlist,CustomComplete3 Test3 :]])
+      command -nargs=1 -complete=customlist,CustomComplete3 Test3 echo]])
     feed(":Test3 <C-L>'<C-B>$put='<CR>")
 
     expect([[

--- a/test/functional/legacy/utf8_spec.lua
+++ b/test/functional/legacy/utf8_spec.lua
@@ -4,9 +4,10 @@ local helpers = require('test.functional.helpers')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 local eq, eval = helpers.eq, helpers.eval
+local source = helpers.source
 
 describe('utf8', function()
-  setup(clear)
+  before_each(clear)
 
   it('is working', function()
     insert('start:')
@@ -49,5 +50,34 @@ describe('utf8', function()
     eq(1, eval('strchars("\\u20dd")'))
     eq(1, eval('strchars("\\u20dd", 0)'))
     eq(1, eval('strchars("\\u20dd", 1)'))
+  end)
+
+  it('customlist completion', function()
+    source([[
+      function! CustomComplete1(lead, line, pos)
+        return ['あ', 'い']
+      endfunction
+      command -nargs=1 -complete=customlist,CustomComplete1 Test1 :]])
+    feed(":Test1 <C-L>'<C-B>$put='<CR>")
+
+    source([[
+      function! CustomComplete2(lead, line, pos)
+        return ['あたし', 'あたま', 'あたりめ']
+      endfunction
+      command -nargs=1 -complete=customlist,CustomComplete2 Test2 :]])
+    feed(":Test2 <C-L>'<C-B>$put='<CR>")
+
+    source([[
+      function! CustomComplete3(lead, line, pos)
+        return ['Nこ', 'Nん', 'Nぶ']
+      endfunction
+      command -nargs=1 -complete=customlist,CustomComplete3 Test3 :]])
+    feed(":Test3 <C-L>'<C-B>$put='<CR>")
+
+    expect([[
+      
+      Test1 
+      Test2 あた
+      Test3 N]])
   end)
 end)


### PR DESCRIPTION
```
vim-patch:7.4.926

Problem:    Completing the longest match doesn't work properly with multi-byte
            characters.
Solution:   When using multi-byte characters use another way to find the
            longest match. (Hirohito Higashi)
```

https://github.com/vim/vim/commit/4f8fa1633cdfbd09a41160c8480fe67c198067e9

```
vim-patch:7.4.932

Problem:    test_utf8 has confusing dummy command.
Solution:   Use a real command instead of a colon.
```

https://github.com/vim/vim/commit/8f08dab18df6dbf6c4b4973fd2d480e4bffb82d8

```
vim-patch:7.4.933

Problem:    Crash when using longest completion match.
Solution:   Fix array index.
```

https://github.com/vim/vim/commit/e4eda3bc7157932b0bf380fd3fdc1ba8f4438b60
