### PR TITLE
[RFC] add TermRedraw autocmd

### DIFF
--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -81,6 +81,7 @@ return {
     'TermClose',              -- after the processs exits
     'TermOpen',               -- after opening a terminal buffer
     'TermResponse',           -- after setting "v:termresponse"
+    'TermRedraw',             -- after redrawing contents of terminal buffer
     'TextChanged',            -- text was modified
     'TextChangedI',           -- text was modified in Insert mode
     'User',                   -- user defined autocommand

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1097,6 +1097,8 @@ static void redraw(bool restore_cursor)
 
   unblock_autocmds();
   ui_flush();
+
+  apply_autocmds(EVENT_TERMREDRAW, NULL, NULL, false, curbuf);
 }
 
 static void adjust_topline(Terminal *term, buf_T *buf, bool force)


### PR DESCRIPTION
I would like to react to result of a command being run in a terminal buffer but there is currently no way to do so (that I know of). This PR adds an autocmd `TermRedraw` that is called each time the terminal buffer is redrawn.

An example of where this could be useful:

Currently terminal buffers have names like `term://.//23227:/usr/local/bin/fish`. Which a) is not very pretty and b) when one has multiple terminal buffers open, is hard to tell which is which. 

One possible solution to this would be to have the terminal name match the current command prompt, which may change whenever you change directory.

(Note this script assumes your prompt ends with a '>' character.)

UpdateTermName.vim

```
function! UpdateTermName()
  let l:line_number = line('$')
  while l:line_number > 0
    if match(getline(l:line_number), '>\( \|$\|\n\)') !=# -1
      let l:commandline = getline(l:line_number)
      let l:prompt_end = match(l:commandline, '\ze>\( \|$\|\n\)')
      let l:prompt = strpart(l:commandline, 0, l:prompt_end)
      break
    endif
    let l:line_number = l:line_number - 1
  endwhile

  execute 'file ' . l:prompt
  redraw!
endfunction
```

Usage:

```
nvim -u NONE -c terminal
<c-\><c-n>
:source UpdateTermName.vim
:autocmd TermRedraw <buffer> call UpdateTermName()
A
cd /home
" terminal buffer should now be named '/home'
```
