### PR TITLE
[RFC] vim-patch:7.4.937

### DIFF
--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -6180,7 +6180,8 @@ static long nfa_regtry(nfa_regprog_T *prog, colnr_T col)
   if (prog->reghasz == REX_SET) {
     cleanup_zsubexpr();
     re_extmatch_out = make_extmatch();
-    for (i = 0; i < subs.synt.in_use; i++) {
+    // Loop over \z1, \z2, etc.  There is no \z0.
+    for (i = 1; i < subs.synt.in_use; i++) {
       if (REG_MULTI) {
         struct multipos *mpos = &subs.synt.list.multi[i];
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -351,7 +351,7 @@ static int included_patches[] = {
   // 940 NA
   // 939,
   // 938 NA
-  // 937,
+  937,
   // 936,
   // 935,
   // 934 NA


### PR DESCRIPTION
```
Problem:    Segfault reading unitialized memory.
Solution:   Do not read match \z0, it does not exist. (Marius Gedminas, closes
            vim/vim#497)
```

https://github.com/vim/vim/commit/5ad075c0735d3d8b97708d17c22de8facb15f997
