### PR TITLE
[RFC] build: install *.mo into the "standard" directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.7)
-project(NEOVIM)
+project(nvim)
 
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -12,6 +12,9 @@
 #define ARCH_32
 #endif
 
+#define PROJECT_NAME "@PROJECT_NAME@"
+#define LOCALE_INSTALL_DIR "@CMAKE_INSTALL_FULL_LOCALEDIR@"
+
 #cmakedefine HAVE__NSGETENVIRON
 #cmakedefine HAVE_FD_CLOEXEC
 #cmakedefine HAVE_FSEEKO

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -657,6 +657,9 @@ static void init_locale(void)
   setlocale(LC_NUMERIC, "C");
 # endif
 
+# ifdef LOCALE_INSTALL_DIR    // gnu/linux standard: $prefix/share/locale
+  bindtextdomain(PROJECT_NAME, LOCALE_INSTALL_DIR);
+# else                        // old vim style: $runtime/lang
   {
     char_u  *p;
 
@@ -665,11 +668,12 @@ static void init_locale(void)
     p = (char_u *)vim_getenv("VIMRUNTIME");
     if (p != NULL && *p != NUL) {
       vim_snprintf((char *)NameBuff, MAXPATHL, "%s/lang", p);
-      bindtextdomain(VIMPACKAGE, (char *)NameBuff);
+      bindtextdomain(PROJECT_NAME, (char *)NameBuff);
     }
     xfree(p);
-    textdomain(VIMPACKAGE);
   }
+# endif
+  textdomain(PROJECT_NAME);
   TIME_MSG("locale set");
 }
 #endif

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -571,8 +571,8 @@ char_u * mb_init(void)
 #ifdef HAVE_WORKING_LIBINTL
   /* GNU gettext 0.10.37 supports this feature: set the codeset used for
    * translated messages independently from the current locale. */
-  (void)bind_textdomain_codeset(VIMPACKAGE,
-      enc_utf8 ? "utf-8" : (char *)p_enc);
+  (void)bind_textdomain_codeset(PROJECT_NAME,
+                                enc_utf8 ? "utf-8" : (char *)p_enc);
 #endif
 
 

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -742,15 +742,15 @@ char_u * home_replace_save(buf_T *buf, char_u *src) FUNC_ATTR_NONNULL_RET
 void vim_setenv(const char *name, const char *val)
 {
   os_setenv(name, val, 1);
-  /*
-   * When setting $VIMRUNTIME adjust the directory to find message
-   * translations to $VIMRUNTIME/lang.
-   */
+#ifndef LOCALE_INSTALL_DIR
+  // When setting $VIMRUNTIME adjust the directory to find message
+  // translations to $VIMRUNTIME/lang.
   if (*val != NUL && STRICMP(name, "VIMRUNTIME") == 0) {
     char *buf = (char *)concat_str((char_u *)val, (char_u *)"/lang");
-    bindtextdomain(VIMPACKAGE, buf);
+    bindtextdomain(PROJECT_NAME, buf);
     xfree(buf);
   }
+#endif
 }
 
 

--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -72,8 +72,8 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
 
     install_helper(
       FILES ${moFile}
-      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/nvim/runtime/lang/${name}/LC_MESSAGES
-      RENAME nvim.mo)
+      DESTINATION ${CMAKE_INSTALL_LOCALEDIR}/${name}/LC_MESSAGES
+      RENAME ${PROJECT_NAME}.mo)
 
     list(APPEND LANGUAGE_MO_FILES ${moFile})
   endmacro()

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -27,12 +27,6 @@ Error: configure did not run properly.Check auto/config.log.
 # endif
 #endif
 
-
-/* Can't use "PACKAGE" here, conflicts with a Perl include file. */
-#ifndef VIMPACKAGE
-# define VIMPACKAGE     "nvim"
-#endif
-
 #include "nvim/os/os_defs.h"       /* bring lots of system header files */
 
 /// length of a buffer to store a number in ASCII (64 bits binary + NUL)


### PR DESCRIPTION
Change `POROJECT_NAME` to lowercase 'neovim', and use it as the
gettext domain name. The *.mo files, previously installed as
`$runtime/lang/xx/LC_MESSAGES/nvim.mo`, are now installed as
`$prefix/locale/xx/LC_MESSAGES/neovim.mo`.

If changing the `PROJECT_NAME` has bad side effects, then we need another
cmake variable.

Old codes in main.c and env.c were left in `#ifdef HAVE_PATHDEF` block,
in case it may be used in the Windows port.

I guess gettext is not supported yet in nvim for Windows.
