### PR TITLE
[RFC] Make TermClose event return the associated buffer

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -22199,7 +22199,6 @@ static void on_process_exit(Process *proc, int status, void *d)
     char msg[22];
     snprintf(msg, sizeof msg, "\r\n[Process exited %d]", proc->status);
     terminal_close(data->term, msg);
-    apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, curbuf);
   }
 
   if (data->status_ptr) {

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -288,8 +288,9 @@ void terminal_close(Terminal *term, char *msg)
 
   term->forward_mouse = false;
   term->closed = true;
+  buf_T *buf = handle_get_buffer(term->buf_handle);
+
   if (!msg || exiting) {
-    buf_T *buf = handle_get_buffer(term->buf_handle);
     // If no msg was given, this was called by close_buffer(buffer.c).  Or if
     // exiting, we must inform the buffer the terminal no longer exists so that
     // close_buffer() doesn't call this again.
@@ -303,6 +304,10 @@ void terminal_close(Terminal *term, char *msg)
     }
   } else {
     terminal_receive(term, msg, strlen(msg));
+  }
+
+  if (buf) {
+    apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, buf);
   }
 }
 

--- a/test/functional/autocmd/termclose_spec.lua
+++ b/test/functional/autocmd/termclose_spec.lua
@@ -3,6 +3,7 @@ local Screen = require('test.functional.ui.screen')
 
 local clear, execute, feed, nvim, nvim_dir = helpers.clear,
 helpers.execute, helpers.feed, helpers.nvim, helpers.nvim_dir
+local eval, eq = helpers.eval, helpers.eq
 
 describe('TermClose event', function()
   local screen
@@ -24,5 +25,20 @@ describe('TermClose event', function()
       ^                    |
       TermClose works!    |
     ]])
+  end)
+
+  it('reports the correct <abuf>', function()
+    execute('set hidden')
+    execute('autocmd TermClose * let g:abuf = expand("<abuf>")')
+    execute('edit foo')
+    execute('edit bar')
+    eq(2, eval('bufnr("%")'))
+    execute('terminal')
+    feed('<c-\\><c-n>')
+    eq(3, eval('bufnr("%")'))
+    execute('buffer 1')
+    eq(1, eval('bufnr("%")'))
+    execute('3bdelete!')
+    eq('3', eval('g:abuf'))
   end)
 end)


### PR DESCRIPTION
```
<abuf> from the TermClose event now returns the correct buffer number.

Prior to this change it would always return the buffer number of the current
buffer, which is obviously wrong in an async environment.
```

This should fix #4291.

TIL: Buffers have numbers (non-unique) and handles (unique).
- [x] fix bug
- [x] closing a buffer embedding a terminal should issue `TermClose`
- [x] add test
