### PR TITLE
[RFC] vim-patch:7.4.870

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1380,13 +1380,15 @@ int vgetc(void)
   } else {
     mod_mask = 0x0;
     last_recorded_len = 0;
-    for (;; ) {                 /* this is done twice if there are modifiers */
-      if (mod_mask) {           /* no mapping after modifier has been read */
+    for (;; ) {                 // this is done twice if there are modifiers
+      bool did_inc = false;
+      if (mod_mask) {           // no mapping after modifier has been read
         ++no_mapping;
         ++allow_keys;
+        did_inc = true;         // mod_mask may change value
       }
-      c = vgetorpeek(TRUE);
-      if (mod_mask) {
+      c = vgetorpeek(true);
+      if (did_inc) {
         --no_mapping;
         --allow_keys;
       }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -420,7 +420,7 @@ static int included_patches[] = {
   // 873 NA
   // 872 NA
   // 871,
-  // 870,
+  870,
   // 869 NA
   868,
   // 867 NA


### PR DESCRIPTION
```
Problem:    May get into an invalid state when using getchar() in an
            expression mapping.
Solution:   Anticipate mod_mask to change. (idea by Yukihiro Nakadaira)
```

https://github.com/vim/vim/commit/2455c4ede8d4ff6f0754977b548708eec08869eb
