### PR TITLE
[RFC] vim-patch:7.4.958

### DIFF
--- a/src/nvim/tempfile.c
+++ b/src/nvim/tempfile.c
@@ -32,8 +32,9 @@ static void vim_maketempdir(void)
   char_u path[TEMP_FILE_PATH_MAXLEN];
   for (size_t i = 0; i < ARRAY_SIZE(temp_dirs); ++i) {
     // Expand environment variables, leave room for "/nvimXXXXXX/999999999"
+    // Skip the directory check if the expansion fails.
     expand_env((char_u *)temp_dirs[i], template, TEMP_FILE_PATH_MAXLEN - 22);
-    if (!os_isdir(template)) {  // directory doesn't exist
+    if (template[0] == '$' || !os_isdir(template)) {
       continue;
     }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -332,7 +332,7 @@ static int included_patches[] = {
   961,
   // 960 NA
   // 959 NA
-  // 958,
+  958,
   // 957,
   // 956 NA
   955,


### PR DESCRIPTION
#### vim-patch:7.4.958

Problem:    Vim checks if the directory "$TMPDIR" exists.
Solution:   Do not check if the name starts with "$".

https://github.com/vim/vim/commit/e1a61991d9b6fd5f65636d17583f93118268cda5

---

see: "$TMPDIR bug"
     https://groups.google.com/d/msg/vim_dev/UWjbjOf9tEY/wfwnkh41AwAJ
