### PR TITLE
[RFC] vim-patch:7.4.961

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4096,6 +4096,7 @@ dozet:
 
   case 't':   scroll_cursor_top(0, true);
     redraw_later(VALID);
+    set_fraction(curwin);
     break;
 
   /* "z." and "zz": put cursor in middle of screen */
@@ -4104,6 +4105,7 @@ dozet:
 
   case 'z':   scroll_cursor_halfway(true);
     redraw_later(VALID);
+    set_fraction(curwin);
     break;
 
   /* "z^", "z-" and "zb": put cursor at bottom of screen */
@@ -4124,6 +4126,7 @@ dozet:
 
   case 'b':   scroll_cursor_bot(0, true);
     redraw_later(VALID);
+    set_fraction(curwin);
     break;
 
   /* "zH" - scroll screen right half-page */

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -329,7 +329,7 @@ static int included_patches[] = {
   // 964 NA
   963,
   // 962 NA
-  // 961,
+  961,
   // 960 NA
   // 959 NA
   // 958,

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4619,10 +4619,8 @@ void win_drag_vsep_line(win_T *dragwin, int offset)
 
 #define FRACTION_MULT   16384L
 
-/*
- * Set wp->w_fraction for the current w_wrow and w_height.
- */
-static void set_fraction(win_T *wp)
+// Set wp->w_fraction for the current w_wrow and w_height.
+void set_fraction(win_T *wp)
 {
   wp->w_fraction = ((long)wp->w_wrow * FRACTION_MULT + wp->w_height / 2)
                    / (long)wp->w_height;


### PR DESCRIPTION
#### vim-patch:7.4.961

Problem:    Test107 fails in some circunstances.
Solution:   When using "zt", "zb" and "z=" recompute the fraction.

https://github.com/vim/vim/commit/9dc2ce398bb3456cc8f590ef0260459798b34d2a
