### PR TITLE
[RFC] vim-patch:7.4.973

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1130,7 +1130,7 @@ static int command_line_handle_key(CommandLineState *s)
     if (!mouse_has(MOUSE_COMMAND)) {
       return command_line_not_changed(s);                   // Ignore mouse
     }
-    cmdline_paste(0, true, true);
+    cmdline_paste(eval_has_provider("clipboard") ? '*' : 0, true, true);
     redrawcmd();
     return command_line_changed(s);
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2424,20 +2424,17 @@ void restore_cmdline_alloc(char_u *p)
   xfree(p);
 }
 
-/*
- * paste a yank register into the command line.
- * used by CTRL-R command in command-line mode
- * insert_reg() can't be used here, because special characters from the
- * register contents will be interpreted as commands.
- *
- * return FAIL for failure, OK otherwise
- */
-static int 
-cmdline_paste (
-    int regname,
-    int literally,          /* Insert text literally instead of "as typed" */
-    int remcr              /* remove trailing CR */
-)
+/// Paste a yank register into the command line.
+/// Used by CTRL-R command in command-line mode.
+/// insert_reg() can't be used here, because special characters from the
+/// register contents will be interpreted as commands.
+///
+/// @param regname   Register name.
+/// @param literally Insert text literally instead of "as typed".
+/// @param remcr     When true, remove trailing CR.
+///
+/// @returns FAIL for failure, OK otherwise
+static bool cmdline_paste(int regname, bool literally, bool remcr)
 {
   long i;
   char_u              *arg;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1261,21 +1261,18 @@ get_spec_reg (
   return FALSE;
 }
 
-/*
- * Paste a yank register into the command line.
- * Only for non-special registers.
- * Used by CTRL-R command in command-line mode
- * insert_reg() can't be used here, because special characters from the
- * register contents will be interpreted as commands.
- *
- * return FAIL for failure, OK otherwise
- */
-int 
-cmdline_paste_reg (
-    int regname,
-    int literally,          /* Insert text literally instead of "as typed" */
-    int remcr              /* don't add trailing CR */
-)
+/// Paste a yank register into the command line.
+/// Only for non-special registers.
+/// Used by CTRL-R command in command-line mode
+/// insert_reg() can't be used here, because special characters from the
+/// register contents will be interpreted as commands.
+///
+/// @param regname   Register name.
+/// @param literally Insert text literally instead of "as typed".
+/// @param remcr     When true, don't add CR characters.
+///
+/// @returns FAIL for failure, OK otherwise
+bool cmdline_paste_reg(int regname, bool literally, bool remcr)
 {
   long i;
 
@@ -1286,13 +1283,9 @@ cmdline_paste_reg (
   for (i = 0; i < reg->y_size; i++) {
     cmdline_paste_str(reg->y_array[i], literally);
 
-    /* Insert ^M between lines and after last line if type is MLINE.
-     * Don't do this when "remcr" is TRUE and the next line is empty. */
-    if (reg->y_type == MLINE
-        || (i < reg->y_size - 1
-            && !(remcr
-                 && i == reg->y_size - 2
-                 && *reg->y_array[i + 1] == NUL))) {
+    // Insert ^M between lines and after last line if type is MLINE.
+    // Don't do this when "remcr" is true.
+    if ((reg->y_type == MLINE || i < reg->y_size - 1) && !remcr) {
       cmdline_paste_str((char_u *)"\r", literally);
     }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -317,7 +317,7 @@ static int included_patches[] = {
   // 976 NA
   975,
   974,
-  // 973,
+  973,
   972,
   // 971 NA
   // 970 NA


### PR DESCRIPTION
#### vim-patch:7.4.973

Problem:    When pasting on the command line line breaks result in literal
            <CR> characters. This makes pasting a long file name difficult.
Solution:   Skip the characters.

https://github.com/vim/vim/commit/6f62fed349bf829da2adb02619dc9acba13c8ab6

---

NOTE: this PR enables middle click pasting in command line. fixes #2468
