### PR TITLE
[RFC] add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+charset = utf_8
+
+[Makefile]
+indent_style = tab
+tab_width = 4


### PR DESCRIPTION
This is an example of the top-level .editorconfig file.

I only added special rules for Makefile (tab_width could be 8), but
I haven't yet fully understood the coding convention of nvim so there
may be more special rules needed.

I didn't set trim_trailing_whitespace to true, because if it is set then
all the lines with trailing white spaces will be modified when the file is saved.
