### PR TITLE
Correct documention on order autocmds

### DIFF
--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -273,8 +273,8 @@ window on the same buffer and then edit another buffer.  Thus ":tabnew"
 triggers:
 	WinLeave		leave current window
 	TabLeave		leave current tab page
-	TabEnter		enter new tab page
 	WinEnter		enter window in new tab page
+	TabEnter		enter new tab page
 	BufLeave		leave current buffer
 	BufEnter		enter new empty buffer
 
@@ -282,8 +282,8 @@ When switching to another tab page the order is:
 	BufLeave
 	WinLeave
 	TabLeave
-	TabEnter
 	WinEnter
+	TabEnter
 	BufEnter
 
 When entering a new tab page (|:tabnew|), TabNew is triggered before TabEnter


### PR DESCRIPTION
The first (upper) error was already corrected in vim patch 7.4.566, but somehow was forgotten in the Neovim inclusion of this patch. To be more specific, it was included in https://github.com/neovim/neovim/pull/1793 but not any more in https://github.com/neovim/neovim/pull/2041/.

The second error still exists in the current plain vim documentation, and should also be corrected there.
