### PR TITLE
[RFC] coverity/133892: Free tbuf before continuing

### DIFF
--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1677,12 +1677,18 @@ static void cs_print_tags_priv(char **matches, char **cntxts,
     tbuf = xmalloc(strlen(matches[idx]) + 1);
     (void)strcpy(tbuf, matches[idx]);
 
-    if (strtok(tbuf, (const char *)"\t") == NULL)
+    if (strtok(tbuf, (const char *)"\t") == NULL) {
+      xfree(tbuf);
       continue;
-    if ((fname = strtok(NULL, (const char *)"\t")) == NULL)
+    }
+    if ((fname = strtok(NULL, (const char *)"\t")) == NULL) {
+      xfree(tbuf);
       continue;
-    if ((lno = strtok(NULL, (const char *)"\t")) == NULL)
+    }
+    if ((lno = strtok(NULL, (const char *)"\t")) == NULL) {
+      xfree(tbuf);
       continue;
+    }
     extra = strtok(NULL, (const char *)"\t");
 
     lno[strlen(lno)-2] = '\0';      /* ignore ;" at the end */


### PR DESCRIPTION
CID 133892 identified a leak of `tbuf`.  It is allocated prior to several checks that `continue` the loop, but is not `free`'d before `continue`.  
