### PR TITLE
[RFC] Make set{qf,loc}list() take {title}

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1999,11 +1999,12 @@ setbufvar( {expr}, {varname}, {val})	set {varname} in buffer {expr} to {val}
 setcharsearch( {dict})		Dict	set character search from {dict}
 setcmdpos( {pos})		Number	set cursor position in command-line
 setline( {lnum}, {line})	Number	set line {lnum} to {line}
-setloclist( {nr}, {list}[, {action}])
+setloclist( {nr}, {list}[, {action}[, {title}]])
 				Number	modify location list using {list}
 setmatches( {list})		Number	restore a list of matches
 setpos( {expr}, {list})		Number	set the {expr} position to {list}
-setqflist( {list}[, {action}])	Number	modify quickfix list using {list}
+setqflist( {list}[, {action}[, {title}]]
+				Number	modify quickfix list using {list}
 setreg( {n}, {v}[, {opt}])	Number	set register to value and type
 settabvar( {nr}, {varname}, {val})	set {varname} in tab page {nr} to {val}
 settabwinvar( {tabnr}, {winnr}, {varname}, {val})    set {varname} in window
@@ -5732,11 +5733,13 @@ setline({lnum}, {text})					*setline()*
 			:endfor
 <		Note: The '[ and '] marks are not set.
 
-setloclist({nr}, {list} [, {action}])			*setloclist()*
+setloclist({nr}, {list} [, {action}[, {title}]])	*setloclist()*
 		Create or replace or add to the location list for window {nr}.
 		When {nr} is zero the current window is used. For a location
 		list window, the displayed location list is modified.  For an
-		invalid window number {nr}, -1 is returned.
+		invalid window number {nr}, -1 is returned. If {title} is
+		given, it will be used to set |w:quickfix_title| after opening
+		the location window.
 		Otherwise, same as |setqflist()|.
 		Also see |location-list|.
 
@@ -5793,7 +5796,7 @@ setpos({expr}, {list})
 		|winrestview()|.
 
 
-setqflist({list} [, {action}])				*setqflist()*
+setqflist({list} [, {action}[, {title}]])		*setqflist()*
 		Create or replace or add to the quickfix list using the items
 		in {list}.  Each item in {list} is a dictionary.
 		Non-dictionary items in {list} are ignored.  Each dictionary
@@ -5831,6 +5834,9 @@ setqflist({list} [, {action}])				*setqflist()*
 		then the items from the current quickfix list are replaced
 		with the items from {list}. If {action} is not present or is
 		set to ' ', then a new list is created.
+
+		If {title} is given, it will be used to set |w:quickfix_title|
+		after opening the quickfix window.
 
 		Returns zero for success, -1 for failure.
 

--- a/test/functional/viml/errorlist_spec.lua
+++ b/test/functional/viml/errorlist_spec.lua
@@ -1,0 +1,49 @@
+local helpers = require('test.functional.helpers')
+
+local clear = helpers.clear
+local command = helpers.command
+local eq = helpers.eq
+local exc_exec = helpers.exc_exec
+local get_cur_win_var = helpers.curwinmeths.get_var
+
+describe('setqflist()', function()
+  local setqflist = helpers.funcs.setqflist
+
+  before_each(clear)
+
+  it('sets w:quickfix_title', function()
+    setqflist({''}, 'r', 'foo')
+    command('copen')
+    eq(':foo', get_cur_win_var('quickfix_title'))
+  end)
+
+  it('expects a proper type for {title}', function()
+    command('copen')
+    setqflist({''}, 'r', '5')
+    eq(':5', get_cur_win_var('quickfix_title'))
+    setqflist({''}, 'r', 6)
+    eq(':6', get_cur_win_var('quickfix_title'))
+    local exc = exc_exec('call setqflist([""], "r", function("function"))')
+    eq('Vim(call):E729: using Funcref as a String', exc)
+    exc = exc_exec('call setqflist([""], "r", [])')
+    eq('Vim(call):E730: using List as a String', exc)
+    exc = exc_exec('call setqflist([""], "r", {})')
+    eq('Vim(call):E731: using Dictionary as a String', exc)
+  end)
+end)
+
+describe('setloclist()', function()
+  local setloclist = helpers.funcs.setloclist
+
+  before_each(clear)
+
+  it('sets w:quickfix_title for the correct window', function()
+    command('rightbelow vsplit')
+    setloclist(1, {''}, 'r', 'foo')
+    setloclist(2, {''}, 'r', 'bar')
+    command('lopen')
+    eq(':bar', get_cur_win_var('quickfix_title'))
+    command('lclose | wincmd w | lopen')
+    eq(':foo', get_cur_win_var('quickfix_title'))
+  end)
+end)


### PR DESCRIPTION
Follow-up to #4279.

---

Add an extra argument to these function to set `w:quickfix_title`.

This is a port of a patch from vim_dev:

  https://groups.google.com/forum/#!topic/vim_dev/X7VVPd4Do5s

Credits go to Christian "chrisbra" Brabandt and Daniel "blueyed" Hahler.
