### PR TITLE
[RDY] Fix the ASCII-art diagram in undo.c

### DIFF
--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -4,29 +4,29 @@
  * The saved lines are stored in a list of lists (one for each buffer):
  *
  * b_u_oldhead------------------------------------------------+
- *							      |
- *							      V
- *		  +--------------+    +--------------+	  +--------------+
- * b_u_newhead--->| u_header	 |    | u_header     |	  | u_header	 |
- *		  |	uh_next------>|     uh_next------>|	uh_next---->NULL
- *	   NULL<--------uh_prev  |<---------uh_prev  |<---------uh_prev  |
- *		  |	uh_entry |    |     uh_entry |	  |	uh_entry |
- *		  +--------|-----+    +--------|-----+	  +--------|-----+
- *			   |		       |		   |
- *			   V		       V		   V
- *		  +--------------+    +--------------+	  +--------------+
- *		  | u_entry	 |    | u_entry      |	  | u_entry	 |
- *		  |	ue_next  |    |     ue_next  |	  |	ue_next  |
- *		  +--------|-----+    +--------|-----+	  +--------|-----+
- *			   |		       |		   |
- *			   V		       V		   V
- *		  +--------------+	      NULL		  NULL
- *		  | u_entry	 |
- *		  |	ue_next  |
- *		  +--------|-----+
- *			   |
- *			   V
- *			  etc.
+ *                                                            |
+ *                                                            V
+ *                +--------------+    +--------------+    +--------------+
+ * b_u_newhead--->| u_header     |    | u_header     |    | u_header     |
+ *                |     uh_next------>|     uh_next------>|     uh_next---->NULL
+ *         NULL<--------uh_prev  |<---------uh_prev  |<---------uh_prev  |
+ *                |     uh_entry |    |     uh_entry |    |     uh_entry |
+ *                +--------|-----+    +--------|-----+    +--------|-----+
+ *                         |                   |                   |
+ *                         V                   V                   V
+ *                +--------------+    +--------------+    +--------------+
+ *                | u_entry      |    | u_entry      |    | u_entry      |
+ *                |     ue_next  |    |     ue_next  |    |     ue_next  |
+ *                +--------|-----+    +--------|-----+    +--------|-----+
+ *                         |                   |                   |
+ *                         V                   V                   V
+ *                +--------------+            NULL                NULL
+ *                | u_entry      |
+ *                |     ue_next  |
+ *                +--------|-----+
+ *                         |
+ *                         V
+ *                        etc.
  *
  * Each u_entry list contains the information for one undo or redo.
  * curbuf->b_u_curhead points to the header of the last undo (the next redo),
@@ -37,30 +37,30 @@
  * uh_seq field is numbered sequentially to be able to find a newer or older
  * branch.
  *
- *		   +---------------+	+---------------+
- * b_u_oldhead --->| u_header	   |	| u_header	|
- *		   |   uh_alt_next ---->|   uh_alt_next ----> NULL
- *	   NULL <----- uh_alt_prev |<------ uh_alt_prev |
- *		   |   uh_prev	   |	|   uh_prev	|
- *		   +-----|---------+	+-----|---------+
- *			 |		      |
- *			 V		      V
- *		   +---------------+	+---------------+
- *		   | u_header	   |	| u_header	|
- *		   |   uh_alt_next |	|   uh_alt_next |
- * b_u_newhead --->|   uh_alt_prev |	|   uh_alt_prev |
- *		   |   uh_prev	   |	|   uh_prev	|
- *		   +-----|---------+	+-----|---------+
- *			 |		      |
- *			 V		      V
- *		       NULL		+---------------+    +---------------+
- *					| u_header	|    | u_header      |
- *					|   uh_alt_next ---->|	 uh_alt_next |
- *					|   uh_alt_prev |<------ uh_alt_prev |
- *					|   uh_prev	|    |	 uh_prev     |
- *					+-----|---------+    +-----|---------+
- *					      |			   |
- *					     etc.		  etc.
+ *                 +---------------+    +---------------+
+ * b_u_oldhead --->| u_header      |    | u_header      |
+ *                 |   uh_alt_next ---->|   uh_alt_next ----> NULL
+ *         NULL <----- uh_alt_prev |<------ uh_alt_prev |
+ *                 |   uh_prev     |    |   uh_prev     |
+ *                 +-----|---------+    +-----|---------+
+ *                       |                    |
+ *                       V                    V
+ *                 +---------------+    +---------------+
+ *                 | u_header      |    | u_header      |
+ *                 |   uh_alt_next |    |   uh_alt_next |
+ * b_u_newhead --->|   uh_alt_prev |    |   uh_alt_prev |
+ *                 |   uh_prev     |    |   uh_prev     |
+ *                 +-----|---------+    +-----|---------+
+ *                       |                    |
+ *                       V                    V
+ *                     NULL             +---------------+    +---------------+
+ *                                      | u_header      |    | u_header      |
+ *                                      |   uh_alt_next ---->|   uh_alt_next |
+ *                                      |   uh_alt_prev |<------ uh_alt_prev |
+ *                                      |   uh_prev     |    |   uh_prev     |
+ *                                      +-----|---------+    +-----|---------+
+ *                                            |                    |
+ *                                           etc.                 etc.
  *
  *
  * All data is allocated and will all be freed when the buffer is unloaded.


### PR DESCRIPTION
Set \t to 8 spaces and `retab`.
