### PR TITLE
[WIP] remove minor version references to python in ci scripts

### DIFF
--- a/.ci/before_install.sh
+++ b/.ci/before_install.sh
@@ -12,7 +12,7 @@ if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
 fi
 
 echo "Upgrade Python 2's pip."
-pip2.7 install --user --upgrade pip
+pip2 install --user --upgrade pip
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   echo "Install Python 3."
@@ -24,5 +24,5 @@ else
   echo "Install pip for Python 3."
   curl -sSL https://bootstrap.pypa.io/get-pip.py -o "${HOME}/get-pip.py"
   # After this, pip in PATH will refer to Python 3's pip.
-  python3.3 "${HOME}/get-pip.py" --user --upgrade
+  python3 "${HOME}/get-pip.py" --user --upgrade
 fi

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -22,11 +22,7 @@ fi
 # Set CC to default to avoid compilation problems
 # when installing Python modules.
 echo "Install neovim module and coveralls for Python 2."
-CC=cc pip2.7 install --user --upgrade neovim cpp-coveralls
+CC=cc pip2 install --user --upgrade neovim cpp-coveralls
 
 echo "Install neovim module for Python 3."
-if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
-  CC=cc pip3 install --user --upgrade neovim
-else
-  CC=cc pip3.3 install --user --upgrade neovim
-fi
+CC=cc pip3 install --user --upgrade neovim

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,6 +115,7 @@ addons:
       - libtool
       - llvm-3.6-dev
       - pkg-config
+      - python3
       - python3-dev
       - unzip
       - valgrind

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ addons:
       - libtool
       - llvm-3.6-dev
       - pkg-config
-      - python3.3-dev
+      - python3-dev
       - unzip
       - valgrind
       - xclip


### PR DESCRIPTION
Usually pip3 and python3 are symlinks to whichever latest minor version
of python 3 are installed. Using specific minor versions like python3.3
breaks when a new minor version is released, and is not necessary unless
the particular version has to be enforced.

Current travis builds are failing because python3.3 can not be found.
The latest release is python3.5.1, and most likely the available version
from brew or repositories changed.
