### PR TITLE
[RFC] build system: allow linting a single file and revert #4216

### DIFF
--- a/cmake/RunLint.cmake
+++ b/cmake/RunLint.cmake
@@ -2,7 +2,11 @@ get_filename_component(LINT_DIR ${LINT_DIR} ABSOLUTE)
 get_filename_component(LINT_PREFIX ${LINT_DIR} PATH)
 set(LINT_SUPPRESS_FILE "${LINT_PREFIX}/errors.json")
 
-file(GLOB_RECURSE LINT_FILES ${LINT_DIR}/*.c ${LINT_DIR}/*.h)
+if(DEFINED ENV{LINT_FILE})
+  file(GLOB_RECURSE LINT_FILES "$ENV{LINT_FILE}")
+else()
+  file(GLOB_RECURSE LINT_FILES ${LINT_DIR}/*.c ${LINT_DIR}/*.h)
+endif()
 
 set(LINT_ARGS)
 

--- a/scripts/gendeclarations.lua
+++ b/scripts/gendeclarations.lua
@@ -239,24 +239,23 @@ end
 non_static = non_static .. footer
 static = static .. footer
 
+local F
+F = io.open(static_fname, 'w')
+F:write(static)
+F:close()
 
--- Before generating the headers, check if the current file (if exists) is
--- different from the new one. If they are the same, we won't touch the
--- current version to avoid triggering an unnecessary rebuilds of modules
+-- Before generating the non-static headers, check if the current file(if
+-- exists) is different from the new one. If they are the same, we won't touch
+-- the current version to avoid triggering an unnecessary rebuilds of modules
 -- that depend on this one
-local update_changed = function (fname, contents)
-  local F = io.open(fname, 'r')
-  if F ~= nil then
-    if F:read('*a') == contents then
-      return
-    end
-    io.close(F)
+F = io.open(non_static_fname, 'r')
+if F ~= nil then
+  if F:read('*a') == non_static then
+    os.exit(0)
   end
-
-  F = io.open(fname, 'w')
-  F:write(contents)
-  F:close()
+  io.close(F)
 end
 
-update_changed(static_fname, static)
-update_changed(non_static_fname, non_static)
+F = io.open(non_static_fname, 'w')
+F:write(non_static)
+F:close()


### PR DESCRIPTION
`make lint` takes some time, 55 s on my system. This allows
`make lint LINT_FILE=src/nvim/edit.c`
which is much quicker and useful when fighting against^W^Wworking with the linter in a specific file and one needs to run it several times.
Also patterns like `make lint LINT_FILE="src/nvim/api/*.[ch]"` are supported.

Revert #4216 which only made the build quicker on accident right after a make clean, but didn't solve the real issue which is in `src/nvim/CMakeLists.txt`, see discussion in #4326.
