### PR TITLE
[WIP] syntax.c: Avoid the 'background' adjustment when true color enabled

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6395,7 +6395,7 @@ do_highlight (
             HL_TABLE()[idx].sg_cterm_bg = color + 1;
             if (is_normal_group) {
               cterm_normal_bg_color = color + 1;
-              {
+              if (!ui_rgb_attached()) {
                 must_redraw = CLEAR;
                 if (color >= 0) {
                   if (t_colors < 16)


### PR DESCRIPTION
ref: `:h :hi-normal-cterm`
When `:hi Normal ctermbg=value` and value is recognized as a lighter
color number then 'background' is set to light. But the current
branches have lack of support for 256 colors.

---

I have no idea to decide which one is darker color. Any idea?
see: http://www.calmar.ws/vim/256-xterm-24bit-rgb-color-chart.html
