### PR TITLE
term: publish TermOpen in "e term://" handler.

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -324,7 +324,8 @@ int main(int argc, char **argv)
                  "'\\c\\mterm://\\%(.\\{-}//\\%(\\d\\+:\\)\\?\\)\\?\\zs.*'), "
                  // capture the working directory
                  "{'cwd': get(matchlist(expand(\"<amatch>\"), "
-                 "'\\c\\mterm://\\(.\\{-}\\)//'), 1, '')})");
+                 "'\\c\\mterm://\\(.\\{-}\\)//'), 1, '')})"
+                 "|doautocmd TermOpen");
 
   /* Execute --cmd arguments. */
   exe_pre_commands(&params);


### PR DESCRIPTION
After 87a49405b00b38b58c4c1d8fc4069d1a254a621d, terminal_open() is not
nested by default. The default "term://" handler depended on that, but
it should instead explicitly raise TermOpen.

References #4306
