### PR TITLE
[RFC] Proper type checking for set{qf,loc}list()

### DIFF
--- a/test/functional/viml/errorlist_spec.lua
+++ b/test/functional/viml/errorlist_spec.lua
@@ -3,13 +3,25 @@ local helpers = require('test.functional.helpers')
 local clear = helpers.clear
 local command = helpers.command
 local eq = helpers.eq
+local exc_exec = helpers.exc_exec
 local get_cur_win_var = helpers.curwinmeths.get_var
--- local exc_exec = helpers.exc_exec
 
 describe('setqflist()', function()
   local setqflist = helpers.funcs.setqflist
 
   before_each(clear)
+
+  it('requires a list for {list}', function()
+    eq('Vim(call):E714: List required', exc_exec('call setqflist("foo")'))
+    eq('Vim(call):E714: List required', exc_exec('call setqflist(5)'))
+    eq('Vim(call):E714: List required', exc_exec('call setqflist({})'))
+  end)
+
+  it('requires a string for {action}', function()
+    eq('Vim(call):E114: String required', exc_exec('call setqflist([], 5)'))
+    eq('Vim(call):E114: String required', exc_exec('call setqflist([], [])'))
+    eq('Vim(call):E114: String required', exc_exec('call setqflist([], {})'))
+  end)
 
   it('sets w:quickfix_title', function()
     setqflist({''}, 'r', 'foo')
@@ -17,18 +29,18 @@ describe('setqflist()', function()
     eq(':foo', get_cur_win_var('quickfix_title'))
   end)
 
-  it('expects a proper type for {title}', function()
+  it('requires string or number for {title}', function()
     command('copen')
-    setqflist({''}, 'r', '5')
+    setqflist({}, 'r', '5')
     eq(':5', get_cur_win_var('quickfix_title'))
-    setqflist({''}, 'r', 6)
-    eq(':setqflist()', get_cur_win_var('quickfix_title'))
-    -- local exc = exc_exec('call setqflist([""], "r", function("function"))')
-    -- eq('Vim(call):E729: using Funcref as a String', exc)
-    -- exc = exc_exec('call setqflist([""], "r", [])')
-    -- eq('Vim(call):E730: using List as a String', exc)
-    -- exc = exc_exec('call setqflist([""], "r", {})')
-    -- eq('Vim(call):E731: using Dictionary as a String', exc)
+    setqflist({}, 'r', 6)
+    eq(':6', get_cur_win_var('quickfix_title'))
+    local exc = exc_exec('call setqflist([], "r", function("function"))')
+    eq('Vim(call):E729: using Funcref as a String', exc)
+    exc = exc_exec('call setqflist([], "r", [])')
+    eq('Vim(call):E730: using List as a String', exc)
+    exc = exc_exec('call setqflist([], "r", {})')
+    eq('Vim(call):E731: using Dictionary as a String', exc)
   end)
 end)
 
@@ -37,10 +49,22 @@ describe('setloclist()', function()
 
   before_each(clear)
 
+  it('requires a list for {list}', function()
+    eq('Vim(call):E714: List required', exc_exec('call setloclist(0, "foo")'))
+    eq('Vim(call):E714: List required', exc_exec('call setloclist(0, 5)'))
+    eq('Vim(call):E714: List required', exc_exec('call setloclist(0, {})'))
+  end)
+
+  it('requires a string for {action}', function()
+    eq('Vim(call):E114: String required', exc_exec('call setloclist(0, [], 5)'))
+    eq('Vim(call):E114: String required', exc_exec('call setloclist(0, [], [])'))
+    eq('Vim(call):E114: String required', exc_exec('call setloclist(0, [], {})'))
+  end)
+
   it('sets w:quickfix_title for the correct window', function()
     command('rightbelow vsplit')
-    setloclist(1, {''}, 'r', 'foo')
-    setloclist(2, {''}, 'r', 'bar')
+    setloclist(1, {}, 'r', 'foo')
+    setloclist(2, {}, 'r', 'bar')
     command('lopen')
     eq(':bar', get_cur_win_var('quickfix_title'))
     command('lclose | wincmd w | lopen')


### PR DESCRIPTION
```
Prior to this change, type errors were silently ignored. They're explicit now.

  setqflist(list, action, title)
  setloclist(win, list, action, title)

"list" (required) must be a list.
"action" (optional) must a string.
"title" (optional) must a string or number that gets converted to a string.

An error is thrown otherwise.
```
