### PR TITLE
[WIP] screen_puts_len: Ignore control chars.

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1104,20 +1104,11 @@ static void do_filter(
   }
   read_linecount = curbuf->b_ml.ml_line_count;
 
-  /*
-   * When call_shell() fails wait_return() is called to give the user a
-   * chance to read the error messages. Otherwise errors are ignored, so you
-   * can see the error messages from the command that appear on stdout; use
-   * 'u' to fix the text
-   * Switch to cooked mode when not redirecting stdin, avoids that something
-   * like ":r !cat" hangs.
-   * Pass on the kShellDoOut flag when the output is being redirected.
-   */
-  if (call_shell(
-        cmd_buf,
-        kShellOptFilter | shell_flags,
-        NULL
-        )) {
+  // When call_shell() fails wait_return() is called to give the user a
+  // chance to read the error messages. Otherwise errors are ignored, so you
+  // can see the error messages from the command that appear on stdout.
+  // Pass on the kShellDoOut flag when the output is being redirected.
+  if (call_shell(cmd_buf, kShellOptFilter | shell_flags, NULL)) {
     redraw_later_clear();
     wait_return(FALSE);
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5975,7 +5975,7 @@ static void ex_stop(exarg_T *eap)
       autowrite_all();
     }
     ui_cursor_goto((int)Rows - 1, 0);
-    ui_putc('\n');
+    ui_putc('\n', true);
     ui_flush();
     ui_suspend();               /* call machine specific function */
     maketitle();

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1253,7 +1253,7 @@ static void handle_quickfix(mparm_T *paramp)
           paramp->use_ef, OPT_FREE, SID_CARG);
     vim_snprintf((char *)IObuff, IOSIZE, "cfile %s", p_ef);
     if (qf_init(NULL, p_ef, p_efm, TRUE, IObuff) < 0) {
-      ui_putc('\n');
+      ui_putc('\n', true);
       mch_exit(3);
     }
     TIME_MSG("reading errorfile");

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2545,7 +2545,7 @@ void vim_beep(unsigned val)
       if (p_vb) {
         ui_visual_bell();
       } else {
-        ui_putc(BELL);
+        ui_putc(BELL, true);
       }
     }
 

--- a/src/nvim/misc2.c
+++ b/src/nvim/misc2.c
@@ -289,7 +289,7 @@ int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
     verbose_enter();
     smsg(_("Calling shell to execute: \"%s\""),
          cmd == NULL ? p_sh : cmd);
-    ui_putc('\n');
+    ui_putc('\n', true);
     verbose_leave();
   }
 

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -417,14 +417,10 @@ static void read_input(DynamicBuffer *buf)
 
     if (len == l) {
       // Finished a line, add a NL, unless this line should not have one.
-      // FIXME need to make this more readable
       if (lnum != curbuf->b_op_end.lnum
-          || (!curbuf->b_p_bin
-            && curbuf->b_p_fixeol)
+          || (!curbuf->b_p_bin && curbuf->b_p_fixeol)
           || (lnum != curbuf->b_no_eol_lnum
-            && (lnum !=
-              curbuf->b_ml.ml_line_count
-              || curbuf->b_p_eol))) {
+              && (lnum != curbuf->b_ml.ml_line_count || curbuf->b_p_eol))) {
         dynamic_buffer_ensure(buf, buf->len + 1);
         buf->data[buf->len++] = NL;
       }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4209,9 +4209,9 @@ win_line (
           if (has_mbyte && MB_BYTE2LEN(ScreenLines[LineOffset[
                                                      screen_row -
                                                      1] + (Columns - 1)]) > 1) {
-            ui_putc(' ');
+            ui_putc(' ', false);
           } else {
-            ui_putc(ScreenLines[LineOffset[screen_row - 1] + (Columns - 1)]);
+            ui_putc(ScreenLines[LineOffset[screen_row - 1] + (Columns - 1)], false);
           }
           /* force a redraw of the first char on the next line */
           ScreenAttrs[LineOffset[screen_row]] = (sattr_T)-1;
@@ -5797,12 +5797,12 @@ static void screen_char(unsigned off, int row, int col)
 
     // Convert UTF-8 character to bytes and write it.
     buf[utfc_char2bytes(off, buf)] = NUL;
-    ui_puts(buf);
+    ui_puts(buf, false);
   } else {
-    ui_putc(ScreenLines[off]);
+    ui_putc(ScreenLines[off], false);
     // double-byte character in single-width cell
     if (enc_dbcs == DBCS_JPNU && ScreenLines[off] == 0x8e) {
-      ui_putc(ScreenLines2[off]);
+      ui_putc(ScreenLines2[off], false);
     }
   }
 }
@@ -5829,7 +5829,7 @@ static void screen_char_2(unsigned off, int row, int col)
   /* Output the first byte normally (positions the cursor), then write the
    * second byte directly. */
   screen_char(off, row, col);
-  ui_putc(ScreenLines[off + 1]);
+  ui_putc(ScreenLines[off + 1], false);
 }
 
 /*

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -645,7 +645,7 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
 
 static int term_bell(void *data)
 {
-  ui_putc('\x07');
+  ui_putc(BELL, true);
   return 1;
 }
 

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -312,6 +312,12 @@ void ui_puts(uint8_t *str, bool control)
     } else {
       send_output(&ptr);
     }
+    if (p_wd) {
+      UI_CALL(flush);  // For testing/'writedelay' we flush each time.
+      assert(p_wd >= 0
+          && (sizeof(long) <= sizeof(uint64_t) || p_wd <= UINT64_MAX));
+      os_microdelay((uint64_t)p_wd);
+    }
   }
 }
 


### PR DESCRIPTION
TODO:
- [x] tests
- [x] handle tab chars "\t" #2958 #5100 (fixed by #7844)
- [x] handle bell chars "\x07" #4338 (with #7844, bell chars are printed as `^G`)
- [x] investigate relation to #1776 (conclusion: unrelated)

If a binary or other output is read from `:!` the screen should not be
affected by accidental (or intentional) control chars.
Legacy Vim `:!` gets scrubbed (possibly by canonical ("cooked")
mode in mch_call_shell(), see settmode(TMODE_COOK)).

Expected behavior:

```
:!echo -en '\x08'|cat -             " empty (except "Press ENTER")
:!echo -en '\x08'                   " empty (except "Press ENTER")
:!echo -en '\n'                     " extra line
:echo system('echo -en ''\x08\n''') " ^H

Issue #4338
:!echo -en '\x07\x07\x07\x07text'   " 'text' (not '    text')

Issue #2958 (Vim tputs()?)
:!echo -e "1\t2\t3"                 " '1       2       3'
```

~~Closes #5442~~ closed by #6618
~~Closes #4142~~ closed by #6618
Closes #2958 [WIP]
Closes #4338 [WIP]
