### PR TITLE
[RFC] Fix :%s/\n//

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3017,7 +3017,7 @@ void do_sub(exarg_T *eap)
     // The number of lines joined is the number of lines in the range
     linenr_T joined_lines_count = eap->line2 - eap->line1 + 1
       // plus one extra line if not at the end of file.
-      + eap->line2 < curbuf->b_ml.ml_line_count ? 1 : 0;
+      + (eap->line2 < curbuf->b_ml.ml_line_count ? 1 : 0);
     if (joined_lines_count > 1) {
       do_join(joined_lines_count, FALSE, TRUE, FALSE, true);
       sub_nsubs = joined_lines_count - 1;


### PR DESCRIPTION
Fixes #4352.

---

When patch 7.4.543 was backported, a wrong micro-optimization was introduced.

Compare https://github.com/vim/vim/commit/cc2b9d5dc08cefa0342a25ece71b21d4b4b32e00#diff-64502d25491840f7291ee96e905111c1R4424 to https://github.com/neovim/neovim/blob/master/src/nvim/ex_cmds.c#L3020

The actual issue is precedence. (Mean bug!) Adding the missing parentheses fixes this.
