### PR TITLE
[WIP] switch location of the status- and command line

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6112,7 +6112,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  :function VarExists(var, val)
 	  :    if exists(a:var) | return a:val | else | return '' | endif
 	  :endfunction
-<
+
+<			*'statusframe'* *'stf'* *'nostatusframe'* *'nostf'*
+'statusframe' 'stf'	boolean	(default off)
+			global
+	When on, the statusline is moved to the bottom of the window
+	freeing up 'cmdheight' lines for text.
+
 						*'suffixes'* *'su'*
 'suffixes' 'su'		string	(default ".bak,~,.o,.h,.info,.swp,.obj")
 			global

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2162,6 +2162,7 @@ void buflist_list(exarg_T *eap)
   int len;
   int i;
 
+  msg_row = default_msg_row();
   for (buf = firstbuf; buf != NULL && !got_int; buf = buf->b_next) {
     // skip unspecified buffers
     if ((!buf->b_p_bl && !eap->forceit && !strchr((char *)eap->arg, 'u'))

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11463,7 +11463,7 @@ static void f_inputlist(typval_T *argvars, typval_T *rettv)
   }
 
   msg_start();
-  msg_row = Rows - 1;   /* for when 'cmdheight' > 1 */
+  msg_row = default_cmd_row();   /* for when 'cmdheight' > 1 */
   lines_left = Rows;    /* avoid more prompt */
   msg_scroll = TRUE;
   msg_clr_eos();

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1084,7 +1084,7 @@ static void do_filter(
 
   /* Create the shell command in allocated memory. */
   cmd_buf = make_filter_cmd(cmd, itmp, otmp);
-  ui_cursor_goto((int)Rows - 1, 0);
+  ui_cursor_goto(default_cmd_row(), 0);
 
   /*
    * When not redirecting the output the command can write anything to the

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5971,7 +5971,7 @@ static void ex_stop(exarg_T *eap)
     if (!eap->forceit) {
       autowrite_all();
     }
-    ui_cursor_goto((int)Rows - 1, 0);
+    ui_cursor_goto(default_cmd_row(), 0);
     ui_putc('\n');
     ui_flush();
     ui_suspend();               /* call machine specific function */

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1888,7 +1888,7 @@ static int vgetorpeek(int advance)
                   (long)!p_paste, NULL, 0);
               if (!(State & INSERT)) {
                 msg_col = 0;
-                msg_row = Rows - 1;
+                msg_row = default_msg_row();
                 msg_clr_eos();                          /* clear ruler */
               }
               status_redraw_all();

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -27,6 +27,7 @@
 #include "nvim/garray.h"
 #include "nvim/option.h"
 #include "nvim/path.h"
+#include "nvim/ex_getln.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"
 #include "nvim/syntax.h"
@@ -560,8 +561,8 @@ static void prt_header(prt_settings_T *psettings, int pagenum, linenr_T lnum)
  */
 static void prt_message(char_u *s)
 {
-  screen_fill((int)Rows - 1, (int)Rows, 0, (int)Columns, ' ', ' ', 0);
-  screen_puts(s, (int)Rows - 1, 0, hl_attr(HLF_R));
+  screen_fill(default_msg_row(), default_msg_row() + 1, 0, (int)Columns, ' ', ' ', 0);
+  screen_puts(s, default_msg_row(), 0, hl_attr(HLF_R));
   ui_flush();
 }
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -44,6 +44,7 @@
 #include "nvim/path.h"
 #include "nvim/profile.h"
 #include "nvim/quickfix.h"
+#include "nvim/ex_getln.h"
 #include "nvim/screen.h"
 #include "nvim/state.h"
 #include "nvim/strings.h"
@@ -286,7 +287,7 @@ int main(int argc, char **argv)
     diff_win_options(firstwin, FALSE);
 
   assert(p_ch >= 0 && Rows >= p_ch && Rows - p_ch <= INT_MAX);
-  cmdline_row = (int)(Rows - p_ch);
+  cmdline_row = default_cmd_row();
   msg_row = cmdline_row;
   screenalloc(false);           /* allocate screen buffers */
   set_init_2();

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2315,7 +2315,7 @@ void msg_moremsg(int full)
   char_u      *s = (char_u *)_("-- More --");
 
   attr = hl_attr(HLF_M);
-  screen_puts(s, default_msg_row(), 0, attr);
+  screen_puts(s, Rows - 1, 0, attr);
   if (full)
     screen_puts((char_u *)
         _(" SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "),

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2246,7 +2246,7 @@ change_warning (
      * be after the mode message.
      */
     msg_start();
-    if (msg_row == Rows - 1)
+    if (msg_row == default_msg_row())
       msg_col = col;
     msg_source(hl_attr(HLF_W));
     MSG_PUTS_ATTR(_(w_readonly), hl_attr(HLF_W) | MSG_HIST);
@@ -2259,7 +2259,7 @@ change_warning (
     }
     curbuf->b_did_warn = true;
     redraw_cmdline = FALSE;     /* don't redraw and erase the message */
-    if (msg_row < Rows - 1)
+    if (msg_row < default_msg_row())
       showmode();
   }
 }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3409,7 +3409,7 @@ static void display_showcmd(void)
   if (len == 0)
     showcmd_is_clear = true;
   else {
-    screen_puts(showcmd_buf, (int)Rows - 1, sc_col, 0);
+    screen_puts(showcmd_buf, default_cmd_row(), sc_col, 0);
     showcmd_is_clear = false;
   }
 
@@ -3417,7 +3417,7 @@ static void display_showcmd(void)
    * clear the rest of an old message by outputting up to SHOWCMD_COLS
    * spaces
    */
-  screen_puts((char_u *)"          " + len, (int)Rows - 1, sc_col + len, 0);
+  screen_puts((char_u *)"          " + len, default_cmd_row(), sc_col + len, 0);
 
   setcursor();              /* put cursor back where it belongs */
 }
@@ -4477,7 +4477,7 @@ static void nv_colon(cmdarg_T *cap)
 
     /* When typing, don't type below an old message */
     if (KeyTyped)
-      compute_cmdrow();
+      cmdline_row = default_cmd_row();
 
     old_p_im = p_im;
 

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -601,6 +601,7 @@ EXTERN char_u *p_tags;          ///< 'tags'
 EXTERN int p_tgst;              ///< 'tagstack'
 EXTERN int p_tbidi;             ///< 'termbidi'
 EXTERN int p_terse;             ///< 'terse'
+EXTERN bool p_stf;              ///< 'statusframe'
 EXTERN int p_to;                ///< 'tildeop'
 EXTERN int p_timeout;           ///< 'timeout'
 EXTERN long p_tm;               ///< 'timeoutlen'
@@ -782,6 +783,7 @@ enum {
   , WV_CUL
   , WV_CC
   , WV_STL
+  , WV_STF
   , WV_WFH
   , WV_WFW
   , WV_WRAP

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2251,6 +2251,14 @@ return {
       defaults={if_true={vi=""}}
     },
     {
+      full_name='statusframe', abbreviation='stf',
+      type='bool', scope={'global'},
+      vi_def=true,
+      redraw={'everything'},
+      varname='p_stf',
+      defaults={if_true={vi=true}}
+    },
+    {
       full_name='suffixes', abbreviation='su',
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -36,6 +36,9 @@ typedef struct {
 # include "os/shell.c.generated.h"
 #endif
 
+int default_msg_row(void);
+int default_cmd_row(void);
+
 /// Builds the argument vector for running the user-configured 'shell' (p_sh)
 /// with an optional command prefixed by 'shellcmdflag' (p_shcf).
 ///
@@ -323,7 +326,7 @@ static void out_data_cb(Stream *stream, RBuffer *buf, size_t count, void *data,
   // No output written, force emptying the Rbuffer if it is full.
   if (!written && rbuffer_size(buf) == rbuffer_capacity(buf)) {
     screen_del_lines(0, 0, 1, (int)Rows, NULL);
-    screen_puts_len((char_u *)ptr, (int)cnt, (int)Rows - 1, 0, 0);
+    screen_puts_len((char_u *)ptr, (int)cnt, default_msg_row(), 0, 0);
     written = cnt;
   }
   if (written) {

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -31,6 +31,7 @@
 #include "nvim/mouse.h"
 #include "nvim/garray.h"
 #include "nvim/path.h"
+#include "nvim/ex_getln.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"
 #include "nvim/syntax.h"
@@ -429,7 +430,7 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
 #if SIZEOF_LONG > SIZEOF_INT
       assert(Rows <= (long)INT_MAX + 1);
 #endif
-      cmdline_row = (int)(Rows - 1);           /* continue on last line */
+      cmdline_row = default_cmd_row();  /* continue on last line */
       MSG(_(e_wildexpand));
       msg_start();                    /* don't overwrite this message */
     }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -298,6 +298,7 @@
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_cmds2.h"
 #include "nvim/ex_docmd.h"
+#include "nvim/ex_getln.h"
 #include "nvim/fileio.h"
 #include "nvim/func_attr.h"
 #include "nvim/getchar.h"
@@ -314,6 +315,7 @@
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
 #include "nvim/regexp.h"
+#include "nvim/ex_getln.h"
 #include "nvim/screen.h"
 #include "nvim/search.h"
 #include "nvim/strings.h"
@@ -8452,8 +8454,8 @@ void spell_suggest(int count)
 
   // Get the list of suggestions.  Limit to 'lines' - 2 or the number in
   // 'spellsuggest', whatever is smaller.
-  if (sps_limit > (int)Rows - 2)
-    limit = (int)Rows - 2;
+  if (sps_limit > default_status_row(NULL))
+    limit = default_status_row(NULL);
   else
     limit = sps_limit;
   spell_find_suggest(line + curwin->w_cursor.col, badlen, &sug, limit,
@@ -8478,7 +8480,7 @@ void spell_suggest(int count)
 
     // List the suggestions.
     msg_start();
-    msg_row = Rows - 1;         // for when 'cmdheight' > 1
+    msg_row = default_msg_row();
     lines_left = Rows;          // avoid more prompt
     vim_snprintf((char *)IObuff, IOSIZE, _("Change \"%.*s\" to:"),
         sug.su_badlen, sug.su_badptr);

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -929,11 +929,11 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
   oldwin->w_redr_status = TRUE;
 
   if (need_status) {
-    msg_row = Rows - 1;
+    msg_row = default_msg_row();
     msg_col = sc_col;
     msg_clr_eos_force();        /* Old command/ruler may still be there */
     comp_col();
-    msg_row = Rows - 1;
+    msg_row = default_msg_row();
     msg_col = 0;        /* put position back at start of line */
   }
 
@@ -4514,7 +4514,7 @@ void win_drag_status_line(win_T *dragwin, int offset)
   row = win_comp_pos();
   screen_fill(row, cmdline_row, 0, (int)Columns, ' ', ' ', 0);
   cmdline_row = row;
-  p_ch = Rows - cmdline_row;
+  p_ch = default_cmd_row() - cmdline_row + 1;
   if (p_ch < 1)
     p_ch = 1;
   curtab->tp_ch_used = p_ch;
@@ -4822,7 +4822,7 @@ void command_height(void)
     frp = frp->fr_prev;
 
   if (starting != NO_SCREEN) {
-    cmdline_row = Rows - p_ch;
+    cmdline_row = default_cmd_row();
 
     if (p_ch > old_p_ch) {                  /* p_ch got bigger */
       while (p_ch > old_p_ch) {
@@ -4830,7 +4830,7 @@ void command_height(void)
           EMSG(_(e_noroom));
           p_ch = old_p_ch;
           curtab->tp_ch_used = p_ch;
-          cmdline_row = Rows - p_ch;
+          cmdline_row = p_stf ? Rows - p_ch - 1 : Rows - p_ch;
           break;
         }
         h = frp->fr_height - frame_minheight(frp, NULL);
@@ -4846,7 +4846,7 @@ void command_height(void)
 
       /* clear the lines added to cmdline */
       if (full_screen)
-        screen_fill(cmdline_row, (int)Rows, 0,
+        screen_fill(default_cmd_row(), default_cmd_row() + p_ch, 0,
             (int)Columns, ' ', ' ', 0);
       msg_row = cmdline_row;
       redraw_cmdline = TRUE;


### PR DESCRIPTION
This frees up 'cmdheight' lines for the text area, as these lines
are no longer exclusively used by the command line.

Enable this feature by setting 'statusframe':

:set stf

Note: the feature is default on in this commit for ease of testing.

Related issues: 1435, 3415, 1004
