### PR TITLE
[RFC] clang-format configuration

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,4 +1,4 @@
-BasedOnStyle: llvm
+BasedOnStyle:  Google
 Language: Cpp
 ColumnLimit: 80
 IndentWidth: 2
@@ -10,3 +10,9 @@ AlignEscapedNewlinesLeft: false
 AllowShortFunctionsOnASingleLine: false
 SpacesBeforeTrailingComments: 2
 PenaltyReturnTypeOnItsOwnLine: 200
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: true
+ContinuationIndentWidth: 4


### PR DESCRIPTION
Recommend by @oni-link at:
https://github.com/neovim/neovim/pull/487#issuecomment-39935391

These settings seem OK based on some brief testing. If anyone knows better, let me know.
