### PR TITLE
[RFC] Update XDG paths for Windows

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -380,6 +380,8 @@ accordingly.  Vim proceeds in this order:
 	Places for your personal initializations:
 		Unix		$XDG_CONFIG_HOME/nvim/init.vim
 				(default for $XDG_CONFIG_HOME is ~/.config)
+		Windows		$XDG_CONFIG_HOME/nvim/init.vim
+				(default for $XDG_CONFIG_HOME is ~/AppData/Local)
 
 	The files are searched in the order specified above and only the first
 	one that is found is read.

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -41,6 +41,10 @@ For Unix and Macintosh this file is always used and is recommended:
 
 	~/.config/nvim/init.vim ~
 
+For Win32 this file is at
+
+	~/AppData/Local/nvim/init.vim
+
 The vimrc file can contain all the commands that you type after a colon.  The
 most simple ones are for setting options.  For example, if you want Vim to
 always start with the 'ignorecase' option on, add this line your vimrc file: >

--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -22,9 +22,9 @@ static const char *xdg_env_vars[] = {
 static const char *const xdg_defaults[] = {
 #ifdef WIN32
   // Windows
-  [kXDGConfigHome] = "$LOCALAPPDATA\\nvim\\config",
-  [kXDGDataHome]   = "$LOCALAPPDATA\\nvim\\data",
-  [kXDGCacheHome]  = "$LOCALAPPDATA\\nvim\\cache",
+  [kXDGConfigHome] = "$LOCALAPPDATA",
+  [kXDGDataHome]   = "$LOCALAPPDATA",
+  [kXDGCacheHome]  = "$TEMP",
   [kXDGRuntimeDir] = NULL,
   [kXDGConfigDirs] = NULL,
   [kXDGDataDirs] = NULL,
@@ -66,12 +66,20 @@ char *stdpaths_get_xdg_var(const XDGVarType idx)
 /// @param[in]  idx  XDG directory to use.
 ///
 /// @return [allocated] `{xdg_directory}/nvim`
+///
+/// In WIN32 get_xdg_home(kXDGDataHome) returns `{xdg_directory}/nvim-data` to
+/// avoid storing configuration and data files in the same path.
 static char *get_xdg_home(const XDGVarType idx)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   char *dir = stdpaths_get_xdg_var(idx);
   if (dir) {
+#if defined(WIN32)
+    dir = concat_fnames_realloc(dir, (idx == kXDGDataHome ? "nvim-data" : "nvim"),
+                                true);
+#else
     dir = concat_fnames_realloc(dir, "nvim", true);
+#endif
   }
   return dir;
 }


### PR DESCRIPTION
Cherry picked from #810. This was previously https://github.com/neovim/neovim/pull/4026 I've changed it with the discussion after https://github.com/neovim/neovim/pull/4026#issuecomment-172394262.

The previous defaults were including the nvim suffix, causing it to
apear twice in the final paths.

kXDGDataHome and kXDGConfigHome are now set as %LOCALAPPDATA%, kXDGCacheHome
is set as $TEMP.

In Windows there is no distinction between configuration and data
storage, but we don't want to place all files under the same path.
get_xdg_home() now appends a different path suffix for kXDGDataHome.
- Configuration files are saved under %LOCALAPPDATA%\nvim
- Data files are saved under %LOCALAPPDATA%\nvim-data
