### PR TITLE
[RFC] ex_eval: Fix memory leak

### DIFF
--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -378,7 +378,7 @@ char_u *get_exception_string(void *value, int type, char_u *cmdname, int *should
   char_u      *p, *val;
 
   if (type == ET_ERROR) {
-    *should_free = FALSE;
+    *should_free = true;
     mesg = ((struct msglist *)value)->throw_msg;
     if (cmdname != NULL && *cmdname != NUL) {
       size_t cmdlen = STRLEN(cmdname);


### PR DESCRIPTION
ex_eval: Fix memory leak

Parameter should_free, indicating that the caller has to  free the
returned pointer from get_exception_string(), is not set to true if
type == ET_ERROR.

Found by LeakSanitizer:

``` c
Direct leak of 60 byte(s) in 1 object(s) allocated from:
    #0 0x4e4ef8 in malloc /home/oni-link/git/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:52
    #1 0xaf58e4 in try_malloc /home/oni-link/git/neovim/src/nvim/memory.c:59:15
    #2 0xaf5aa4 in xmalloc /home/oni-link/git/neovim/src/nvim/memory.c:93:15
    #3 0xaf5ee3 in xmallocz /home/oni-link/git/neovim/src/nvim/memory.c:168:15
    #4 0x15917b8 in vim_strnsave /home/oni-link/git/neovim/src/nvim/strings.c:64:28
    #5 0x1539149 in get_exception_string /home/oni-link/git/neovim/src/nvim/ex_eval.c:390:13
    #6 0x16b18e0 in try_end /home/oni-link/git/neovim/src/nvim/api/private/helpers.c:55:25
    #7 0x16901bc in vim_eval /home/oni-link/git/neovim/src/nvim/api/vim.c:155:8
    #8 0x52caa7 in handle_vim_eval /home/oni-link/git/neovim/build/src/nvim/auto/msgpack_dispatch.c:975:15
    #9 0x17006da in on_request_event /home/oni-link/git/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #10 0x174e71f in queue_process_events /home/oni-link/git/neovim/src/nvim/event/queue.c:142:7
    #11 0x16f5857 in channel_send_call /home/oni-link/git/neovim/src/nvim/msgpack_rpc/channel.c:223:3
    #12 0xf06efa in f_rpcrequest /home/oni-link/git/neovim/src/nvim/eval.c:13533:19
    #13 0xe01353 in call_func /home/oni-link/git/neovim/src/nvim/eval.c:7241:11
    #14 0xe3ed9d in func_call /home/oni-link/git/neovim/src/nvim/eval.c:7946:9
    #15 0xeb37f5 in f_call /home/oni-link/git/neovim/src/nvim/eval.c:7987:9
    #16 0xe01353 in call_func /home/oni-link/git/neovim/src/nvim/eval.c:7241:11
    #17 0xe152f4 in get_func_tv /home/oni-link/git/neovim/src/nvim/eval.c:7090:11
    #18 0xe9d65c in eval7 /home/oni-link/git/neovim/src/nvim/eval.c:4228:15
    #19 0xe990c5 in eval6 /home/oni-link/git/neovim/src/nvim/eval.c:3949:7
    #20 0xe96249 in eval5 /home/oni-link/git/neovim/src/nvim/eval.c:3801:7
    #21 0xe91426 in eval4 /home/oni-link/git/neovim/src/nvim/eval.c:3544:7
    #22 0xe90993 in eval3 /home/oni-link/git/neovim/src/nvim/eval.c:3464:7
    #23 0xe8ff33 in eval2 /home/oni-link/git/neovim/src/nvim/eval.c:3401:7
    #24 0xdf9e52 in eval1 /home/oni-link/git/neovim/src/nvim/eval.c:3334:7
    #25 0xdf73dc in eval0 /home/oni-link/git/neovim/src/nvim/eval.c:3296:9
    #26 0xe6a90c in ex_return /home/oni-link/git/neovim/src/nvim/eval.c:20260:10
    #27 0x135de00 in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2191:5
    #28 0x133c65d in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:601:20
    #29 0xe39909 in call_user_func /home/oni-link/git/neovim/src/nvim/eval.c:20062:3

SUMMARY: AddressSanitizer: 60 byte(s) leaked in 1 allocation(s).

```
