### PR TITLE
[RDY] Make functional tests compatible with lua

### DIFF
--- a/.ci/common/build.sh
+++ b/.ci/common/build.sh
@@ -5,6 +5,9 @@ build_deps() {
   if [[ "${BUILD_MINGW}" == ON ]]; then
     DEPS_CMAKE_FLAGS="${DEPS_CMAKE_FLAGS} ${CMAKE_FLAGS_MINGW}"
   fi
+  if [[ "${FUNCTIONALTEST}" == "functionaltest-lua" ]]; then
+    DEPS_CMAKE_FLAGS="${DEPS_CMAKE_FLAGS} -DUSE_BUNDLED_LUA=ON"
+  fi
 
   rm -rf "${DEPS_BUILD_DIR}"
 

--- a/.ci/common/test.sh
+++ b/.ci/common/test.sh
@@ -53,7 +53,7 @@ run_unittests() {
 }
 
 run_functionaltests() {
-  if ! ${MAKE_CMD} -C "${BUILD_DIR}" functionaltest; then
+  if ! ${MAKE_CMD} -C "${BUILD_DIR}" ${FUNCTIONALTEST}; then
     asan_check "${LOG_DIR}"
     valgrind_check "${LOG_DIR}"
     exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ env:
     # if the tests were successful, but don't have this information
     # available in before_cache (which is run before after_success).
     - SUCCESS_MARKER="$BUILD_DIR/.tests_successful"
+    # default target name for functional tests
+    - FUNCTIONALTEST=functionaltest
 
 matrix:
   include:
@@ -60,6 +62,9 @@ matrix:
       env: CI_TARGET=lint
     - os: linux
       compiler: gcc-5
+    - os: linux
+      compiler: gcc-5
+      env: FUNCTIONALTEST=functionaltest-lua
     - os: linux
       # Travis creates a cache per compiler.
       # Set a different value here to store 32-bit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,7 @@ message(STATUS "Using the Lua interpreter ${LUA_PRG}.")
 
 # Setup busted.
 find_program(BUSTED_PRG busted)
+find_program(BUSTED_LUA_PRG busted-lua)
 if(NOT BUSTED_OUTPUT_TYPE)
   set(BUSTED_OUTPUT_TYPE "utfTerminal")
 endif()
@@ -499,6 +500,20 @@ if(BUSTED_PRG)
       -DTEST_TYPE=benchmark
       -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
     DEPENDS ${BENCHMARK_PREREQS})
+endif()
+
+if(BUSTED_LUA_PRG)
+  add_custom_target(functionaltest-lua
+    COMMAND ${CMAKE_COMMAND}
+      -DBUSTED_PRG=${BUSTED_LUA_PRG}
+      -DNVIM_PRG=$<TARGET_FILE:nvim>
+      -DWORKING_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+      -DBUSTED_OUTPUT_TYPE=${BUSTED_OUTPUT_TYPE}
+      -DTEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test
+      -DBUILD_DIR=${CMAKE_BINARY_DIR}
+      -DTEST_TYPE=functional
+      -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
+    DEPENDS ${FUNCTIONALTEST_PREREQS})
 endif()
 
 if(LUACHECK_PRG)

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ ifneq (,$(USE_BUNDLED_DEPS))
   BUNDLED_CMAKE_FLAG := -DUSE_BUNDLED=$(USE_BUNDLED_DEPS)
 endif
 
+ifneq (,$(findstring functionaltest-lua,$(MAKECMDGOALS)))
+  BUNDLED_LUA_CMAKE_FLAG := -DUSE_BUNDLED_LUA=ON
+  $(shell [ -x .deps/usr/bin/lua ] || rm build/.ran-*)
+endif
+
 # For use where we want to make sure only a single job is run.  This does issue 
 # a warning, but we need to keep SCRIPTS argument.
 SINGLE_MAKE = export MAKEFLAGS= ; $(MAKE)
@@ -74,7 +79,7 @@ build/.ran-third-party-cmake:
 ifeq ($(call filter-true,$(USE_BUNDLED_DEPS)),)
 	mkdir -p .deps
 	cd .deps && \
-		cmake -G '$(BUILD_TYPE)' $(BUNDLED_CMAKE_FLAG) \
+		cmake -G '$(BUILD_TYPE)' $(BUNDLED_CMAKE_FLAG) $(BUNDLED_LUA_CMAKE_FLAG) \
 		$(DEPS_CMAKE_FLAGS) ../third-party
 endif
 	mkdir -p build
@@ -85,6 +90,9 @@ oldtest: | nvim
 
 functionaltest: | nvim
 	+$(BUILD_CMD) -C build functionaltest
+
+functionaltest-lua: | nvim
+	+$(BUILD_CMD) -C build functionaltest-lua
 
 testlint: | nvim
 	$(BUILD_CMD) -C build testlint

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3,7 +3,7 @@ local helpers = require('test.functional.helpers')
 local Screen = require('test.functional.ui.screen')
 local clear, nvim, eq, neq = helpers.clear, helpers.nvim, helpers.eq, helpers.neq
 local ok, nvim_async, feed = helpers.ok, helpers.nvim_async, helpers.feed
-local os_is_windows = helpers.os_is_windows
+local os_name = helpers.os_name
 
 describe('vim_* functions', function()
   before_each(clear)
@@ -17,7 +17,7 @@ describe('vim_* functions', function()
       nvim('command', 'w')
       local f = io.open(fname)
       ok(f ~= nil)
-      if os_is_windows() then
+      if os_name() == 'windows' then
         eq('testing\r\napi\r\n', f:read('*a'))
       else
         eq('testing\napi\n', f:read('*a'))

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -348,15 +348,13 @@ local function rmdir(path)
     return nil
   end
   for file in lfs.dir(path) do
-    if file == '.' or file == '..' then
-      goto continue
+    if file ~= '.' and file ~= '..' then
+      local ret, err = os.remove(path..'/'..file)
+      if not ret then
+        error('os.remove: '..err)
+        return nil
+      end
     end
-    local ret, err = os.remove(path..'/'..file)
-    if not ret then
-      error('os.remove: '..err)
-      return nil
-    end
-    ::continue::
   end
   local ret, err = os.remove(path)
   if not ret then

--- a/test/functional/legacy/036_regexp_character_classes_spec.lua
+++ b/test/functional/legacy/036_regexp_character_classes_spec.lua
@@ -30,7 +30,7 @@ local function diff(text, nodedent)
 end
 
 describe('character classes in regexp', function()
-  local ctrl1 = '\t\x0c\r'
+  local ctrl1 = '\t\012\r'
   local punct1 = " !\"#$%&'()#+'-./"
   local digits = '0123456789'
   local punct2 = ':;<=>?@'
@@ -38,8 +38,8 @@ describe('character classes in regexp', function()
   local punct3 = '[\\]^_`'
   local lower = 'abcdefghiwxyz'
   local punct4 = '{|}~'
-  local ctrl2 = '\x7f\x80\x82\x90\x9b'
-  local iso_text = '\xa6\xb1\xbc\xc7\xd3\xe9' -- "¦±¼ÇÓé" in utf-8
+  local ctrl2 = '\127\128\130\144\155'
+  local iso_text = '\166\177\188\199\211\233' -- "¦±¼ÇÓé" in utf-8
   setup(function()
     -- The original test32.in file was not in utf-8 encoding and did also
     -- contain some control characters.  We use lua escape sequences to write

--- a/test/functional/legacy/036_regexp_character_classes_spec.lua
+++ b/test/functional/legacy/036_regexp_character_classes_spec.lua
@@ -1,9 +1,9 @@
 -- Test character classes in regexp using regexpengine 0, 1, 2.
 
 local helpers = require('test.functional.helpers')
-local ffi = require('ffi')
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 local source, write_file = helpers.source, helpers.write_file
+local os_name = helpers.os_name
 
 local function sixlines(text)
     local result = ''
@@ -15,7 +15,7 @@ end
 
 local function diff(text, nodedent)
   local tmpname = os.tmpname()
-  if ffi.os == 'OSX' and string.match(tmpname, '^/tmp') then
+  if os_name() == 'osx' and string.match(tmpname, '^/tmp') then
    tmpname = '/private'..tmpname
   end
   execute('w! '..tmpname)

--- a/test/functional/legacy/039_visual_block_mode_commands_spec.lua
+++ b/test/functional/legacy/039_visual_block_mode_commands_spec.lua
@@ -187,7 +187,7 @@ describe('Visual block mode', function()
       98<Nul>65
       98<Nul>65]]
     expected = expected:gsub('<CR>', '\r')
-    expected = expected:gsub('<Nul>', '\x00')
+    expected = expected:gsub('<Nul>', '\000')
 
     expect(expected)
   end)

--- a/test/functional/legacy/061_undo_tree_spec.lua
+++ b/test/functional/legacy/061_undo_tree_spec.lua
@@ -191,7 +191,7 @@ describe('undo tree:', function()
   end)
 
   it('undo an expression-register', function()
-    local normal_commands = 'o1\x1ba2\x12=string(123)\n\x1b'
+    local normal_commands = 'o1\027a2\018=string(123)\n\027'
     write_file('Xtest.source', normal_commands)
 
     feed('oa<esc>')

--- a/test/functional/legacy/083_tag_search_with_file_encoding_spec.lua
+++ b/test/functional/legacy/083_tag_search_with_file_encoding_spec.lua
@@ -24,7 +24,7 @@ describe('tag search with !_TAG_FILE_ENCODING', function()
       ]])
     write_file('test83-tags2',
       '!_TAG_FILE_ENCODING	cp932	//\n' ..
-      '\x82`\x82a\x82b	Xtags2.txt	/\x82`\x82a\x82b\n'
+      '\130`\130a\130b	Xtags2.txt	/\130`\130a\130b\n'
       )
     -- The last file is very long but repetetive and can be generated on the
     -- fly.
@@ -32,7 +32,7 @@ describe('tag search with !_TAG_FILE_ENCODING', function()
       !_TAG_FILE_SORTED	1	//
       !_TAG_FILE_ENCODING	cp932	//
       ]])
-    local line = '	Xtags3.txt	/\x82`\x82a\x82b\n'
+    local line = '	Xtags3.txt	/\130`\130a\130b\n'
     for i = 1, 100 do
       text = text .. 'abc' .. i .. line
     end

--- a/test/functional/legacy/eval_spec.lua
+++ b/test/functional/legacy/eval_spec.lua
@@ -54,8 +54,8 @@ describe('eval', function()
     expect([[
       
       ": type v; value: abc (['abc']), expr: abc (['abc'])
-      ": type V; value: abc]].."\x00 (['abc']), expr: abc\x00"..[[ (['abc'])
-      ": type V; value: abc]].."\r\x00 (['abc\r']), expr: abc\r\x00 (['abc\r"..[['])
+      ": type V; value: abc]].."\000 (['abc']), expr: abc\000"..[[ (['abc'])
+      ": type V; value: abc]].."\r\000 (['abc\r']), expr: abc\r\000 (['abc\r"..[['])
       =: type v; value: abc (['abc']), expr: "abc" (['"abc"'])]])
   end)
 
@@ -97,29 +97,29 @@ describe('eval', function()
       ==
       =abcB=
       {{{2 setreg('c', 'abcC', 'l')
-      c: type V; value: abcC]].."\x00 (['abcC']), expr: abcC\x00"..[[ (['abcC'])
+      c: type V; value: abcC]].."\000 (['abcC']), expr: abcC\000"..[[ (['abcC'])
       ==
       abcC
       ==
       {{{2 setreg('d', 'abcD', 'V')
-      d: type V; value: abcD]].."\x00 (['abcD']), expr: abcD\x00"..[[ (['abcD'])
+      d: type V; value: abcD]].."\000 (['abcD']), expr: abcD\000"..[[ (['abcD'])
       ==
       abcD
       ==
       {{{2 setreg('e', 'abcE', 'b')
-      e: type ]]..'\x16'..[[4; value: abcE (['abcE']), expr: abcE (['abcE'])
+      e: type ]]..'\022'..[[4; value: abcE (['abcE']), expr: abcE (['abcE'])
       ==
       =abcE=
-      {{{2 setreg('f', 'abcF', ']]..'\x16'..[[')
-      f: type ]]..'\x16'..[[4; value: abcF (['abcF']), expr: abcF (['abcF'])
+      {{{2 setreg('f', 'abcF', ']]..'\022'..[[')
+      f: type ]]..'\022'..[[4; value: abcF (['abcF']), expr: abcF (['abcF'])
       ==
       =abcF=
       {{{2 setreg('g', 'abcG', 'b10')
-      g: type ]]..'\x16'..[[10; value: abcG (['abcG']), expr: abcG (['abcG'])
+      g: type ]]..'\022'..[[10; value: abcG (['abcG']), expr: abcG (['abcG'])
       ==
       =abcG      =
-      {{{2 setreg('h', 'abcH', ']]..'\x16'..[[10')
-      h: type ]]..'\x16'..[[10; value: abcH (['abcH']), expr: abcH (['abcH'])
+      {{{2 setreg('h', 'abcH', ']]..'\022'..[[10')
+      h: type ]]..'\022'..[[10; value: abcH (['abcH']), expr: abcH (['abcH'])
       ==
       =abcH      =
       {{{2 setreg('I', 'abcI')
@@ -132,12 +132,12 @@ describe('eval', function()
       ==
       =abcAabcAc=
       {{{2 setreg('A', 'abcAl', 'l')
-      A: type V; value: abcAabcAcabcAl]].."\x00 (['abcAabcAcabcAl']), expr: abcAabcAcabcAl\x00"..[[ (['abcAabcAcabcAl'])
+      A: type V; value: abcAabcAcabcAl]].."\000 (['abcAabcAcabcAl']), expr: abcAabcAcabcAl\000"..[[ (['abcAabcAcabcAl'])
       ==
       abcAabcAcabcAl
       ==
       {{{2 setreg('A', 'abcAc2', 'c')
-      A: type v; value: abcAabcAcabcAl]].."\x00abcAc2 (['abcAabcAcabcAl', 'abcAc2']), expr: abcAabcAcabcAl\x00"..[[abcAc2 (['abcAabcAcabcAl', 'abcAc2'])
+      A: type v; value: abcAabcAcabcAl]].."\000abcAc2 (['abcAabcAcabcAl', 'abcAc2']), expr: abcAabcAcabcAl\000"..[[abcAc2 (['abcAabcAcabcAl', 'abcAc2'])
       ==
       =abcAabcAcabcAl
       abcAc2=
@@ -146,50 +146,50 @@ describe('eval', function()
       ==
       =abcBabcBc=
       {{{2 setreg('b', 'abcBb', 'ba')
-      b: type ]]..'\x16'..[[5; value: abcBabcBcabcBb (['abcBabcBcabcBb']), expr: abcBabcBcabcBb (['abcBabcBcabcBb'])
+      b: type ]]..'\022'..[[5; value: abcBabcBcabcBb (['abcBabcBcabcBb']), expr: abcBabcBcabcBb (['abcBabcBcabcBb'])
       ==
       =abcBabcBcabcBb=
       {{{2 setreg('b', 'abcBc2', 'ca')
-      b: type v; value: abcBabcBcabcBb]].."\x00abcBc2 (['abcBabcBcabcBb', 'abcBc2']), expr: abcBabcBcabcBb\x00"..[[abcBc2 (['abcBabcBcabcBb', 'abcBc2'])
+      b: type v; value: abcBabcBcabcBb]].."\000abcBc2 (['abcBabcBcabcBb', 'abcBc2']), expr: abcBabcBcabcBb\000"..[[abcBc2 (['abcBabcBcabcBb', 'abcBc2'])
       ==
       =abcBabcBcabcBb
       abcBc2=
       {{{2 setreg('b', 'abcBb2', 'b50a')
-      b: type ]].."\x1650; value: abcBabcBcabcBb\x00abcBc2abcBb2 (['abcBabcBcabcBb', 'abcBc2abcBb2']), expr: abcBabcBcabcBb\x00"..[[abcBc2abcBb2 (['abcBabcBcabcBb', 'abcBc2abcBb2'])
+      b: type ]].."\02250; value: abcBabcBcabcBb\000abcBc2abcBb2 (['abcBabcBcabcBb', 'abcBc2abcBb2']), expr: abcBabcBcabcBb\000"..[[abcBc2abcBb2 (['abcBabcBcabcBb', 'abcBc2abcBb2'])
       ==
       =abcBabcBcabcBb                                    =
        abcBc2abcBb2
       {{{2 setreg('C', 'abcCl', 'l')
-      C: type V; value: abcC]].."\x00abcCl\x00 (['abcC', 'abcCl']), expr: abcC\x00abcCl\x00"..[[ (['abcC', 'abcCl'])
+      C: type V; value: abcC]].."\000abcCl\000 (['abcC', 'abcCl']), expr: abcC\000abcCl\000"..[[ (['abcC', 'abcCl'])
       ==
       abcC
       abcCl
       ==
       {{{2 setreg('C', 'abcCc', 'c')
-      C: type v; value: abcC]].."\x00abcCl\x00abcCc (['abcC', 'abcCl', 'abcCc']), expr: abcC\x00abcCl\x00"..[[abcCc (['abcC', 'abcCl', 'abcCc'])
+      C: type v; value: abcC]].."\000abcCl\000abcCc (['abcC', 'abcCl', 'abcCc']), expr: abcC\000abcCl\000"..[[abcCc (['abcC', 'abcCl', 'abcCc'])
       ==
       =abcC
       abcCl
       abcCc=
       {{{2 setreg('D', 'abcDb', 'b')
-      D: type ]].."\x165; value: abcD\x00abcDb (['abcD', 'abcDb']), expr: abcD\x00"..[[abcDb (['abcD', 'abcDb'])
+      D: type ]].."\0225; value: abcD\000abcDb (['abcD', 'abcDb']), expr: abcD\000"..[[abcDb (['abcD', 'abcDb'])
       ==
       =abcD =
        abcDb
       {{{2 setreg('E', 'abcEb', 'b')
-      E: type ]].."\x165; value: abcE\x00abcEb (['abcE', 'abcEb']), expr: abcE\x00"..[[abcEb (['abcE', 'abcEb'])
+      E: type ]].."\0225; value: abcE\000abcEb (['abcE', 'abcEb']), expr: abcE\000"..[[abcEb (['abcE', 'abcEb'])
       ==
       =abcE =
        abcEb
       {{{2 setreg('E', 'abcEl', 'l')
-      E: type V; value: abcE]].."\x00abcEb\x00abcEl\x00 (['abcE', 'abcEb', 'abcEl']), expr: abcE\x00abcEb\x00abcEl\x00"..[[ (['abcE', 'abcEb', 'abcEl'])
+      E: type V; value: abcE]].."\000abcEb\000abcEl\000 (['abcE', 'abcEb', 'abcEl']), expr: abcE\000abcEb\000abcEl\000"..[[ (['abcE', 'abcEb', 'abcEl'])
       ==
       abcE
       abcEb
       abcEl
       ==
       {{{2 setreg('F', 'abcFc', 'c')
-      F: type v; value: abcF]].."\x00abcFc (['abcF', 'abcFc']), expr: abcF\x00"..[[abcFc (['abcF', 'abcFc'])
+      F: type v; value: abcF]].."\000abcFc (['abcF', 'abcFc']), expr: abcF\000"..[[abcFc (['abcF', 'abcFc'])
       ==
       =abcF
       abcFc=]])
@@ -219,36 +219,36 @@ describe('eval', function()
     execute([[call SetReg('F', "\n", 'b')]])
     expect([[
       
-      {{{2 setreg('A', ']]..'\x00'..[[')
-      A: type V; value: abcA2]].."\x00 (['abcA2']), expr: abcA2\x00"..[[ (['abcA2'])
+      {{{2 setreg('A', ']]..'\000'..[[')
+      A: type V; value: abcA2]].."\000 (['abcA2']), expr: abcA2\000"..[[ (['abcA2'])
       ==
       abcA2
       ==
-      {{{2 setreg('B', ']]..'\x00'..[[', 'c')
-      B: type v; value: abcB2]].."\x00 (['abcB2', '']), expr: abcB2\x00"..[[ (['abcB2', ''])
+      {{{2 setreg('B', ']]..'\000'..[[', 'c')
+      B: type v; value: abcB2]].."\000 (['abcB2', '']), expr: abcB2\000"..[[ (['abcB2', ''])
       ==
       =abcB2
       =
-      {{{2 setreg('C', ']]..'\x00'..[[')
-      C: type V; value: abcC2]].."\x00\x00 (['abcC2', '']), expr: abcC2\x00\x00"..[[ (['abcC2', ''])
+      {{{2 setreg('C', ']]..'\000'..[[')
+      C: type V; value: abcC2]].."\000\000 (['abcC2', '']), expr: abcC2\000\000"..[[ (['abcC2', ''])
       ==
       abcC2
       
       ==
-      {{{2 setreg('D', ']]..'\x00'..[[', 'l')
-      D: type V; value: abcD2]].."\x00\x00 (['abcD2', '']), expr: abcD2\x00\x00"..[[ (['abcD2', ''])
+      {{{2 setreg('D', ']]..'\000'..[[', 'l')
+      D: type V; value: abcD2]].."\000\000 (['abcD2', '']), expr: abcD2\000\000"..[[ (['abcD2', ''])
       ==
       abcD2
       
       ==
-      {{{2 setreg('E', ']]..'\x00'..[[')
-      E: type V; value: abcE2]].."\x00\x00 (['abcE2', '']), expr: abcE2\x00\x00"..[[ (['abcE2', ''])
+      {{{2 setreg('E', ']]..'\000'..[[')
+      E: type V; value: abcE2]].."\000\000 (['abcE2', '']), expr: abcE2\000\000"..[[ (['abcE2', ''])
       ==
       abcE2
       
       ==
-      {{{2 setreg('F', ']]..'\x00'..[[', 'b')
-      F: type ]].."\x160; value: abcF2\x00 (['abcF2', '']), expr: abcF2\x00"..[[ (['abcF2', ''])
+      {{{2 setreg('F', ']]..'\000'..[[', 'b')
+      F: type ]].."\0220; value: abcF2\000 (['abcF2', '']), expr: abcF2\000"..[[ (['abcF2', ''])
       ==
       =abcF2=
        ]])
@@ -282,21 +282,21 @@ describe('eval', function()
       ==
       =abcA3=
       {{{2 setreg('b', ['abcB3'], 'l')
-      b: type V; value: abcB3]].."\x00 (['abcB3']), expr: abcB3\x00"..[[ (['abcB3'])
+      b: type V; value: abcB3]].."\000 (['abcB3']), expr: abcB3\000"..[[ (['abcB3'])
       ==
       abcB3
       ==
       {{{2 setreg('c', ['abcC3'], 'b')
-      c: type ]]..'\x16'..[[5; value: abcC3 (['abcC3']), expr: abcC3 (['abcC3'])
+      c: type ]]..'\022'..[[5; value: abcC3 (['abcC3']), expr: abcC3 (['abcC3'])
       ==
       =abcC3=
       {{{2 setreg('d', ['abcD3'])
-      d: type V; value: abcD3]].."\x00 (['abcD3']), expr: abcD3\x00"..[[ (['abcD3'])
+      d: type V; value: abcD3]].."\000 (['abcD3']), expr: abcD3\000"..[[ (['abcD3'])
       ==
       abcD3
       ==
       {{{2 setreg('e', [1, 2, 'abc', 3])
-      e: type V; value: 1]].."\x002\x00abc\x003\x00 (['1', '2', 'abc', '3']), expr: 1\x002\x00abc\x003\x00"..[[ (['1', '2', 'abc', '3'])
+      e: type V; value: 1]].."\0002\000abc\0003\000 (['1', '2', 'abc', '3']), expr: 1\0002\000abc\0003\000"..[[ (['1', '2', 'abc', '3'])
       ==
       1
       2
@@ -304,7 +304,7 @@ describe('eval', function()
       3
       ==
       {{{2 setreg('f', [1, 2, 3])
-      f: type V; value: 1]].."\x002\x003\x00 (['1', '2', '3']), expr: 1\x002\x003\x00"..[[ (['1', '2', '3'])
+      f: type V; value: 1]].."\0002\0003\000 (['1', '2', '3']), expr: 1\0002\0003\000"..[[ (['1', '2', '3'])
       ==
       1
       2
@@ -312,49 +312,49 @@ describe('eval', function()
       ==
       {{{1 Appending lists with setreg()
       {{{2 setreg('A', ['abcA3c'], 'c')
-      A: type v; value: abcA3]].."\x00abcA3c (['abcA3', 'abcA3c']), expr: abcA3\x00"..[[abcA3c (['abcA3', 'abcA3c'])
+      A: type v; value: abcA3]].."\000abcA3c (['abcA3', 'abcA3c']), expr: abcA3\000"..[[abcA3c (['abcA3', 'abcA3c'])
       ==
       =abcA3
       abcA3c=
       {{{2 setreg('b', ['abcB3l'], 'la')
-      b: type V; value: abcB3]].."\x00abcB3l\x00 (['abcB3', 'abcB3l']), expr: abcB3\x00abcB3l\x00"..[[ (['abcB3', 'abcB3l'])
+      b: type V; value: abcB3]].."\000abcB3l\000 (['abcB3', 'abcB3l']), expr: abcB3\000abcB3l\000"..[[ (['abcB3', 'abcB3l'])
       ==
       abcB3
       abcB3l
       ==
       {{{2 setreg('C', ['abcC3b'], 'lb')
-      C: type ]].."\x166; value: abcC3\x00abcC3b (['abcC3', 'abcC3b']), expr: abcC3\x00"..[[abcC3b (['abcC3', 'abcC3b'])
+      C: type ]].."\0226; value: abcC3\000abcC3b (['abcC3', 'abcC3b']), expr: abcC3\000"..[[abcC3b (['abcC3', 'abcC3b'])
       ==
       =abcC3 =
        abcC3b
       {{{2 setreg('D', ['abcD32'])
-      D: type V; value: abcD3]].."\x00abcD32\x00 (['abcD3', 'abcD32']), expr: abcD3\x00abcD32\x00"..[[ (['abcD3', 'abcD32'])
+      D: type V; value: abcD3]].."\000abcD32\000 (['abcD3', 'abcD32']), expr: abcD3\000abcD32\000"..[[ (['abcD3', 'abcD32'])
       ==
       abcD3
       abcD32
       ==
       {{{2 setreg('A', ['abcA32'])
-      A: type V; value: abcA3]].."\x00abcA3c\x00abcA32\x00 (['abcA3', 'abcA3c', 'abcA32']), expr: abcA3\x00abcA3c\x00abcA32\x00"..[[ (['abcA3', 'abcA3c', 'abcA32'])
+      A: type V; value: abcA3]].."\000abcA3c\000abcA32\000 (['abcA3', 'abcA3c', 'abcA32']), expr: abcA3\000abcA3c\000abcA32\000"..[[ (['abcA3', 'abcA3c', 'abcA32'])
       ==
       abcA3
       abcA3c
       abcA32
       ==
       {{{2 setreg('B', ['abcB3c'], 'c')
-      B: type v; value: abcB3]].."\x00abcB3l\x00abcB3c (['abcB3', 'abcB3l', 'abcB3c']), expr: abcB3\x00abcB3l\x00"..[[abcB3c (['abcB3', 'abcB3l', 'abcB3c'])
+      B: type v; value: abcB3]].."\000abcB3l\000abcB3c (['abcB3', 'abcB3l', 'abcB3c']), expr: abcB3\000abcB3l\000"..[[abcB3c (['abcB3', 'abcB3l', 'abcB3c'])
       ==
       =abcB3
       abcB3l
       abcB3c=
       {{{2 setreg('C', ['abcC3l'], 'l')
-      C: type V; value: abcC3]].."\x00abcC3b\x00abcC3l\x00 (['abcC3', 'abcC3b', 'abcC3l']), expr: abcC3\x00abcC3b\x00abcC3l\x00"..[[ (['abcC3', 'abcC3b', 'abcC3l'])
+      C: type V; value: abcC3]].."\000abcC3b\000abcC3l\000 (['abcC3', 'abcC3b', 'abcC3l']), expr: abcC3\000abcC3b\000abcC3l\000"..[[ (['abcC3', 'abcC3b', 'abcC3l'])
       ==
       abcC3
       abcC3b
       abcC3l
       ==
       {{{2 setreg('D', ['abcD3b'], 'b')
-      D: type ]].."\x166; value: abcD3\x00abcD32\x00abcD3b (['abcD3', 'abcD32', 'abcD3b']), expr: abcD3\x00abcD32\x00"..[[abcD3b (['abcD3', 'abcD32', 'abcD3b'])
+      D: type ]].."\0226; value: abcD3\000abcD32\000abcD3b (['abcD3', 'abcD32', 'abcD3b']), expr: abcD3\000abcD32\000"..[[abcD3b (['abcD3', 'abcD32', 'abcD3b'])
       ==
       =abcD3 =
        abcD32
@@ -370,50 +370,50 @@ describe('eval', function()
     expect(
       '\n'..
       '{{{1 Appending lists with NL with setreg()\n'..
-      "{{{2 setreg('A', ['\x00', 'abcA3l2'], 'l')\n"..
-      "A: type V; value: abcA3\x00abcA3c\x00abcA32\x00\x00\x00abcA3l2\x00 (['abcA3', 'abcA3c', 'abcA32', '\x00', 'abcA3l2']), expr: abcA3\x00abcA3c\x00abcA32\x00\x00\x00abcA3l2\x00 (['abcA3', 'abcA3c', 'abcA32', '\x00', 'abcA3l2'])\n"..
+      "{{{2 setreg('A', ['\000', 'abcA3l2'], 'l')\n"..
+      "A: type V; value: abcA3\000abcA3c\000abcA32\000\000\000abcA3l2\000 (['abcA3', 'abcA3c', 'abcA32', '\000', 'abcA3l2']), expr: abcA3\000abcA3c\000abcA32\000\000\000abcA3l2\000 (['abcA3', 'abcA3c', 'abcA32', '\000', 'abcA3l2'])\n"..
       '==\n'..
       'abcA3\n'..
       'abcA3c\n'..
       'abcA32\n'..
-      '\x00\n'..
+      '\000\n'..
       'abcA3l2\n'..
       '==')
     execute('%delete')
     execute([=[call SetReg('B', ["\n", 'abcB3c2'], 'c')]=])
     expect(
       '\n'..
-      "{{{2 setreg('B', ['\x00', 'abcB3c2'], 'c')\n"..
-      "B: type v; value: abcB3\x00abcB3l\x00abcB3c\x00\x00\x00abcB3c2 (['abcB3', 'abcB3l', 'abcB3c', '\x00', 'abcB3c2']), expr: abcB3\x00abcB3l\x00abcB3c\x00\x00\x00abcB3c2 (['abcB3', 'abcB3l', 'abcB3c', '\x00', 'abcB3c2'])\n"..
+      "{{{2 setreg('B', ['\000', 'abcB3c2'], 'c')\n"..
+      "B: type v; value: abcB3\000abcB3l\000abcB3c\000\000\000abcB3c2 (['abcB3', 'abcB3l', 'abcB3c', '\000', 'abcB3c2']), expr: abcB3\000abcB3l\000abcB3c\000\000\000abcB3c2 (['abcB3', 'abcB3l', 'abcB3c', '\000', 'abcB3c2'])\n"..
       '==\n'..
       '=abcB3\n'..
       'abcB3l\n'..
       'abcB3c\n'..
-      '\x00\n'..
+      '\000\n'..
       'abcB3c2=')
     execute('%delete')
     execute([=[call SetReg('C', ["\n", 'abcC3b2'], 'b')]=])
     expect(
       '\n'..
-      "{{{2 setreg('C', ['\x00', 'abcC3b2'], 'b')\n"..
-      "C: type \x167; value: abcC3\x00abcC3b\x00abcC3l\x00\x00\x00abcC3b2 (['abcC3', 'abcC3b', 'abcC3l', '\x00', 'abcC3b2']), expr: abcC3\x00abcC3b\x00abcC3l\x00\x00\x00abcC3b2 (['abcC3', 'abcC3b', 'abcC3l', '\x00', 'abcC3b2'])\n"..
+      "{{{2 setreg('C', ['\000', 'abcC3b2'], 'b')\n"..
+      "C: type \0227; value: abcC3\000abcC3b\000abcC3l\000\000\000abcC3b2 (['abcC3', 'abcC3b', 'abcC3l', '\000', 'abcC3b2']), expr: abcC3\000abcC3b\000abcC3l\000\000\000abcC3b2 (['abcC3', 'abcC3b', 'abcC3l', '\000', 'abcC3b2'])\n"..
       '==\n'..
       '=abcC3  =\n'..
       ' abcC3b\n'..
       ' abcC3l\n'..
-      ' \x00\n'..
+      ' \000\n'..
       ' abcC3b2')
     execute('%delete')
     execute([=[call SetReg('D', ["\n", 'abcD3b50'],'b50')]=])
     expect(
       '\n'..
-      "{{{2 setreg('D', ['\x00', 'abcD3b50'], 'b50')\n"..
-      "D: type \x1650; value: abcD3\x00abcD32\x00abcD3b\x00\x00\x00abcD3b50 (['abcD3', 'abcD32', 'abcD3b', '\x00', 'abcD3b50']), expr: abcD3\x00abcD32\x00abcD3b\x00\x00\x00abcD3b50 (['abcD3', 'abcD32', 'abcD3b', '\x00', 'abcD3b50'])\n"..
+      "{{{2 setreg('D', ['\000', 'abcD3b50'], 'b50')\n"..
+      "D: type \02250; value: abcD3\000abcD32\000abcD3b\000\000\000abcD3b50 (['abcD3', 'abcD32', 'abcD3b', '\000', 'abcD3b50']), expr: abcD3\000abcD32\000abcD3b\000\000\000abcD3b50 (['abcD3', 'abcD32', 'abcD3b', '\000', 'abcD3b50'])\n"..
       '==\n'..
       '=abcD3                                             =\n'..
       ' abcD32\n'..
       ' abcD3b\n'..
-      ' \x00\n'..
+      ' \000\n'..
       ' abcD3b50')
   end)
 
@@ -425,14 +425,14 @@ describe('eval', function()
     execute([=[call SetReg('a', ['abcA4-0', "\n", "abcA4-2\n", "\nabcA4-3", "abcA4-4\nabcA4-4-2"])]=])
     expect(
      '\n'..
-      "{{{2 setreg('a', ['abcA4-0', '\x00', 'abcA4-2\x00', '\x00abcA4-3', 'abcA4-4\x00abcA4-4-2'])\n"..
-      "a: type V; value: abcA4-0\x00\x00\x00abcA4-2\x00\x00\x00abcA4-3\x00abcA4-4\x00abcA4-4-2\x00 (['abcA4-0', '\x00', 'abcA4-2\x00', '\x00abcA4-3', 'abcA4-4\x00abcA4-4-2']), expr: abcA4-0\x00\x00\x00abcA4-2\x00\x00\x00abcA4-3\x00abcA4-4\x00abcA4-4-2\x00 (['abcA4-0', '\x00', 'abcA4-2\x00', '\x00abcA4-3', 'abcA4-4\x00abcA4-4-2'])\n"..
+      "{{{2 setreg('a', ['abcA4-0', '\000', 'abcA4-2\000', '\000abcA4-3', 'abcA4-4\000abcA4-4-2'])\n"..
+      "a: type V; value: abcA4-0\000\000\000abcA4-2\000\000\000abcA4-3\000abcA4-4\000abcA4-4-2\000 (['abcA4-0', '\000', 'abcA4-2\000', '\000abcA4-3', 'abcA4-4\000abcA4-4-2']), expr: abcA4-0\000\000\000abcA4-2\000\000\000abcA4-3\000abcA4-4\000abcA4-4-2\000 (['abcA4-0', '\000', 'abcA4-2\000', '\000abcA4-3', 'abcA4-4\000abcA4-4-2'])\n"..
       '==\n'..
       'abcA4-0\n'..
-      '\x00\n'..
-      'abcA4-2\x00\n'..
-      '\x00abcA4-3\n'..
-      'abcA4-4\x00abcA4-4-2\n'..
+      '\000\n'..
+      'abcA4-2\000\n'..
+      '\000abcA4-3\n'..
+      'abcA4-4\000abcA4-4-2\n'..
       '==')
   end)
 
@@ -441,14 +441,14 @@ describe('eval', function()
     execute([=[call SetReg('b', ['abcB4c-0', "\n", "abcB4c-2\n", "\nabcB4c-3", "abcB4c-4\nabcB4c-4-2"], 'c')]=])
     expect(
       '\n'..
-      "{{{2 setreg('b', ['abcB4c-0', '\x00', 'abcB4c-2\x00', '\x00abcB4c-3', 'abcB4c-4\x00abcB4c-4-2'], 'c')\n"..
-      "b: type v; value: abcB4c-0\x00\x00\x00abcB4c-2\x00\x00\x00abcB4c-3\x00abcB4c-4\x00abcB4c-4-2 (['abcB4c-0', '\x00', 'abcB4c-2\x00', '\x00abcB4c-3', 'abcB4c-4\x00abcB4c-4-2']), expr: abcB4c-0\x00\x00\x00abcB4c-2\x00\x00\x00abcB4c-3\x00abcB4c-4\x00abcB4c-4-2 (['abcB4c-0', '\x00', 'abcB4c-2\x00', '\x00abcB4c-3', 'abcB4c-4\x00abcB4c-4-2'])\n"..
+      "{{{2 setreg('b', ['abcB4c-0', '\000', 'abcB4c-2\000', '\000abcB4c-3', 'abcB4c-4\000abcB4c-4-2'], 'c')\n"..
+      "b: type v; value: abcB4c-0\000\000\000abcB4c-2\000\000\000abcB4c-3\000abcB4c-4\000abcB4c-4-2 (['abcB4c-0', '\000', 'abcB4c-2\000', '\000abcB4c-3', 'abcB4c-4\000abcB4c-4-2']), expr: abcB4c-0\000\000\000abcB4c-2\000\000\000abcB4c-3\000abcB4c-4\000abcB4c-4-2 (['abcB4c-0', '\000', 'abcB4c-2\000', '\000abcB4c-3', 'abcB4c-4\000abcB4c-4-2'])\n"..
       '==\n'..
       '=abcB4c-0\n'..
-      '\x00\n'..
-      'abcB4c-2\x00\n'..
-      '\x00abcB4c-3\n'..
-      'abcB4c-4\x00abcB4c-4-2=')
+      '\000\n'..
+      'abcB4c-2\000\n'..
+      '\000abcB4c-3\n'..
+      'abcB4c-4\000abcB4c-4-2=')
   end)
 
   it('setting lists with NLs with setreg(), part 3', function()
@@ -456,14 +456,14 @@ describe('eval', function()
     execute([=[call SetReg('c', ['abcC4l-0', "\n", "abcC4l-2\n", "\nabcC4l-3", "abcC4l-4\nabcC4l-4-2"], 'l')]=])
     expect(
       '\n'..
-      "{{{2 setreg('c', ['abcC4l-0', '\x00', 'abcC4l-2\x00', '\x00abcC4l-3', 'abcC4l-4\x00abcC4l-4-2'], 'l')\n"..
-      "c: type V; value: abcC4l-0\x00\x00\x00abcC4l-2\x00\x00\x00abcC4l-3\x00abcC4l-4\x00abcC4l-4-2\x00 (['abcC4l-0', '\x00', 'abcC4l-2\x00', '\x00abcC4l-3', 'abcC4l-4\x00abcC4l-4-2']), expr: abcC4l-0\x00\x00\x00abcC4l-2\x00\x00\x00abcC4l-3\x00abcC4l-4\x00abcC4l-4-2\x00 (['abcC4l-0', '\x00', 'abcC4l-2\x00', '\x00abcC4l-3', 'abcC4l-4\x00abcC4l-4-2'])\n"..
+      "{{{2 setreg('c', ['abcC4l-0', '\000', 'abcC4l-2\000', '\000abcC4l-3', 'abcC4l-4\000abcC4l-4-2'], 'l')\n"..
+      "c: type V; value: abcC4l-0\000\000\000abcC4l-2\000\000\000abcC4l-3\000abcC4l-4\000abcC4l-4-2\000 (['abcC4l-0', '\000', 'abcC4l-2\000', '\000abcC4l-3', 'abcC4l-4\000abcC4l-4-2']), expr: abcC4l-0\000\000\000abcC4l-2\000\000\000abcC4l-3\000abcC4l-4\000abcC4l-4-2\000 (['abcC4l-0', '\000', 'abcC4l-2\000', '\000abcC4l-3', 'abcC4l-4\000abcC4l-4-2'])\n"..
       '==\n'..
       'abcC4l-0\n'..
-      '\x00\n'..
-      'abcC4l-2\x00\n'..
-      '\x00abcC4l-3\n'..
-      'abcC4l-4\x00abcC4l-4-2\n'..
+      '\000\n'..
+      'abcC4l-2\000\n'..
+      '\000abcC4l-3\n'..
+      'abcC4l-4\000abcC4l-4-2\n'..
       '==')
   end)
   it('setting lists with NLs with setreg(), part 4', function()
@@ -471,28 +471,28 @@ describe('eval', function()
     execute([=[call SetReg('d', ['abcD4b-0', "\n", "abcD4b-2\n", "\nabcD4b-3", "abcD4b-4\nabcD4b-4-2"], 'b')]=])
     expect(
       '\n'..
-      "{{{2 setreg('d', ['abcD4b-0', '\x00', 'abcD4b-2\x00', '\x00abcD4b-3', 'abcD4b-4\x00abcD4b-4-2'], 'b')\n"..
-      "d: type \x1619; value: abcD4b-0\x00\x00\x00abcD4b-2\x00\x00\x00abcD4b-3\x00abcD4b-4\x00abcD4b-4-2 (['abcD4b-0', '\x00', 'abcD4b-2\x00', '\x00abcD4b-3', 'abcD4b-4\x00abcD4b-4-2']), expr: abcD4b-0\x00\x00\x00abcD4b-2\x00\x00\x00abcD4b-3\x00abcD4b-4\x00abcD4b-4-2 (['abcD4b-0', '\x00', 'abcD4b-2\x00', '\x00abcD4b-3', 'abcD4b-4\x00abcD4b-4-2'])\n"..
+      "{{{2 setreg('d', ['abcD4b-0', '\000', 'abcD4b-2\000', '\000abcD4b-3', 'abcD4b-4\000abcD4b-4-2'], 'b')\n"..
+      "d: type \02219; value: abcD4b-0\000\000\000abcD4b-2\000\000\000abcD4b-3\000abcD4b-4\000abcD4b-4-2 (['abcD4b-0', '\000', 'abcD4b-2\000', '\000abcD4b-3', 'abcD4b-4\000abcD4b-4-2']), expr: abcD4b-0\000\000\000abcD4b-2\000\000\000abcD4b-3\000abcD4b-4\000abcD4b-4-2 (['abcD4b-0', '\000', 'abcD4b-2\000', '\000abcD4b-3', 'abcD4b-4\000abcD4b-4-2'])\n"..
       '==\n'..
       '=abcD4b-0           =\n'..
-      ' \x00\n'..
-      ' abcD4b-2\x00\n'..
-      ' \x00abcD4b-3\n'..
-      ' abcD4b-4\x00abcD4b-4-2')
+      ' \000\n'..
+      ' abcD4b-2\000\n'..
+      ' \000abcD4b-3\n'..
+      ' abcD4b-4\000abcD4b-4-2')
   end)
   it('setting lists with NLs with setreg(), part 5', function()
     execute('so test_eval_setup.vim')
     execute([=[call SetReg('e', ['abcE4b10-0', "\n", "abcE4b10-2\n", "\nabcE4b10-3", "abcE4b10-4\nabcE4b10-4-2"], 'b10')]=])
     expect(
       '\n'..
-      "{{{2 setreg('e', ['abcE4b10-0', '\x00', 'abcE4b10-2\x00', '\x00abcE4b10-3', 'abcE4b10-4\x00abcE4b10-4-2'], 'b10')\n"..
-      "e: type \x1610; value: abcE4b10-0\x00\x00\x00abcE4b10-2\x00\x00\x00abcE4b10-3\x00abcE4b10-4\x00abcE4b10-4-2 (['abcE4b10-0', '\x00', 'abcE4b10-2\x00', '\x00abcE4b10-3', 'abcE4b10-4\x00abcE4b10-4-2']), expr: abcE4b10-0\x00\x00\x00abcE4b10-2\x00\x00\x00abcE4b10-3\x00abcE4b10-4\x00abcE4b10-4-2 (['abcE4b10-0', '\x00', 'abcE4b10-2\x00', '\x00abcE4b10-3', 'abcE4b10-4\x00abcE4b10-4-2'])\n"..
+      "{{{2 setreg('e', ['abcE4b10-0', '\000', 'abcE4b10-2\000', '\000abcE4b10-3', 'abcE4b10-4\000abcE4b10-4-2'], 'b10')\n"..
+      "e: type \02210; value: abcE4b10-0\000\000\000abcE4b10-2\000\000\000abcE4b10-3\000abcE4b10-4\000abcE4b10-4-2 (['abcE4b10-0', '\000', 'abcE4b10-2\000', '\000abcE4b10-3', 'abcE4b10-4\000abcE4b10-4-2']), expr: abcE4b10-0\000\000\000abcE4b10-2\000\000\000abcE4b10-3\000abcE4b10-4\000abcE4b10-4-2 (['abcE4b10-0', '\000', 'abcE4b10-2\000', '\000abcE4b10-3', 'abcE4b10-4\000abcE4b10-4-2'])\n"..
       '==\n'..
       '=abcE4b10-0=\n'..
-      ' \x00\n'..
-      ' abcE4b10-2\x00\n'..
-      ' \x00abcE4b10-3\n'..
-      ' abcE4b10-4\x00abcE4b10-4-2')
+      ' \000\n'..
+      ' abcE4b10-2\000\n'..
+      ' \000abcE4b10-3\n'..
+      ' abcE4b10-4\000abcE4b10-4-2')
   end)
 
   it('search and expressions', function()
@@ -507,14 +507,14 @@ describe('eval', function()
       /: type v; value: abc/ (['abc/']), expr: abc/ (['abc/'])
       ==
       =abc/=
-      {{{2 setreg('/', ['abc/]]..'\x00'..[['])
-      /: type v; value: abc/]].."\x00 (['abc/\x00']), expr: abc/\x00 (['abc/\x00"..[['])
+      {{{2 setreg('/', ['abc/]]..'\000'..[['])
+      /: type v; value: abc/]].."\000 (['abc/\000']), expr: abc/\000 (['abc/\000"..[['])
       ==
-      =abc/]]..'\x00'..[[=
+      =abc/]]..'\000'..[[=
       {{{2 setreg('=', ['"abc/"'])
       =: type v; value: abc/ (['abc/']), expr: "abc/" (['"abc/"'])
-      {{{2 setreg('=', ['"abc/]]..'\x00'..[["'])
-      =: type v; value: abc/]].."\x00 (['abc/\x00"..[[']), expr: "abc/]]..'\x00'..[[" (['"abc/]]..'\x00'..[["'])]])
+      {{{2 setreg('=', ['"abc/]]..'\000'..[["'])
+      =: type v; value: abc/]].."\000 (['abc/\000"..[[']), expr: "abc/]]..'\000'..[[" (['"abc/]]..'\000'..[["'])]])
   end)
 
   if has_clipboard() then

--- a/test/functional/plugin/msgpack_spec.lua
+++ b/test/functional/plugin/msgpack_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require('test.functional.helpers')
 local eq, nvim_eval, nvim_command, exc_exec =
   helpers.eq, helpers.eval, helpers.command, helpers.exc_exec
+local ok = helpers.ok
 
 local plugin_helpers = require('test.functional.plugin.helpers')
 local reset = plugin_helpers.reset
@@ -21,10 +22,8 @@ describe('In autoload/msgpack.vim', function()
   end
 
   local nan = -(1.0/0.0-1.0/0.0)
-  local minus_nan = 1.0/0.0-1.0/0.0
   local inf = 1.0/0.0
   local minus_inf = -(1.0/0.0)
-  local has_minus_nan = tostring(nan) ~= tostring(minus_nan)
 
   describe('function msgpack#equal', function()
     local msgpack_eq = function(expected, a, b)
@@ -160,9 +159,9 @@ describe('In autoload/msgpack.vim', function()
     it('compares raw floats correctly', function()
       msgpack_eq(1, '0.0', '0.0')
       msgpack_eq(1, '(1.0/0.0-1.0/0.0)', '(1.0/0.0-1.0/0.0)')
-      if has_minus_nan then
-        msgpack_eq(0, '(1.0/0.0-1.0/0.0)', '-(1.0/0.0-1.0/0.0)')
-      end
+      -- both (1.0/0.0-1.0/0.0) and -(1.0/0.0-1.0/0.0) now return
+      -- str2float('nan'). ref: @18d1ba3422d
+      msgpack_eq(1, '(1.0/0.0-1.0/0.0)', '-(1.0/0.0-1.0/0.0)')
       msgpack_eq(1, '-(1.0/0.0-1.0/0.0)', '-(1.0/0.0-1.0/0.0)')
       msgpack_eq(1, '1.0/0.0', '1.0/0.0')
       msgpack_eq(1, '-(1.0/0.0)', '-(1.0/0.0)')
@@ -178,10 +177,8 @@ describe('In autoload/msgpack.vim', function()
     it('compares float specials with raw floats correctly', function()
       msgpack_eq(1, sp('float', '0.0'), '0.0')
       msgpack_eq(1, sp('float', '(1.0/0.0-1.0/0.0)'), '(1.0/0.0-1.0/0.0)')
-      if has_minus_nan then
-        msgpack_eq(0, sp('float', '(1.0/0.0-1.0/0.0)'), '-(1.0/0.0-1.0/0.0)')
-        msgpack_eq(0, sp('float', '-(1.0/0.0-1.0/0.0)'), '(1.0/0.0-1.0/0.0)')
-      end
+      msgpack_eq(1, sp('float', '(1.0/0.0-1.0/0.0)'), '-(1.0/0.0-1.0/0.0)')
+      msgpack_eq(1, sp('float', '-(1.0/0.0-1.0/0.0)'), '(1.0/0.0-1.0/0.0)')
       msgpack_eq(1, sp('float', '-(1.0/0.0-1.0/0.0)'), '-(1.0/0.0-1.0/0.0)')
       msgpack_eq(1, sp('float', '1.0/0.0'), '1.0/0.0')
       msgpack_eq(1, sp('float', '-(1.0/0.0)'), '-(1.0/0.0)')
@@ -207,10 +204,8 @@ describe('In autoload/msgpack.vim', function()
       msgpack_eq(0, sp('float', '0.0'), sp('float', '-(1.0/0.0)'))
       msgpack_eq(0, sp('float', '1.0/0.0'), sp('float', '-(1.0/0.0)'))
       msgpack_eq(0, sp('float', '(1.0/0.0-1.0/0.0)'), sp('float', '-(1.0/0.0)'))
-      if has_minus_nan then
-        msgpack_eq(0, sp('float', '(1.0/0.0-1.0/0.0)'),
-                      sp('float', '-(1.0/0.0-1.0/0.0)'))
-      end
+      msgpack_eq(1, sp('float', '(1.0/0.0-1.0/0.0)'),
+                    sp('float', '-(1.0/0.0-1.0/0.0)'))
       msgpack_eq(1, sp('float', '-(1.0/0.0-1.0/0.0)'),
                     sp('float', '-(1.0/0.0-1.0/0.0)'))
       msgpack_eq(0, sp('float', '(1.0/0.0-1.0/0.0)'), sp('float', '1.0/0.0'))
@@ -392,9 +387,7 @@ describe('In autoload/msgpack.vim', function()
       string_eq('0.0', sp('float', '0.0'))
       string_eq('inf', sp('float', '(1.0/0.0)'))
       string_eq('-inf', sp('float', '-(1.0/0.0)'))
-      if has_minus_nan then
-        string_eq('-nan', sp('float', '(1.0/0.0-1.0/0.0)'))
-      end
+      string_eq('nan', sp('float', '(1.0/0.0-1.0/0.0)'))
       string_eq('nan', sp('float', '-(1.0/0.0-1.0/0.0)'))
       string_eq('FALSE', sp('boolean', '0'))
       string_eq('TRUE', sp('boolean', '1'))
@@ -413,9 +406,7 @@ describe('In autoload/msgpack.vim', function()
       string_eq('0.0', '0.0')
       string_eq('inf', '(1.0/0.0)')
       string_eq('-inf', '-(1.0/0.0)')
-      if has_minus_nan then
-        string_eq('-nan', '(1.0/0.0-1.0/0.0)')
-      end
+      string_eq('nan', '(1.0/0.0-1.0/0.0)')
       string_eq('nan', '-(1.0/0.0-1.0/0.0)')
     end)
   end)
@@ -547,8 +538,11 @@ describe('In autoload/msgpack.vim', function()
       end
       if expected_val_full == expected_val_full then
         eq(expected_val_full, nvim_eval('g:__val'))
-      else
-        eq(tostring(expected_val_full), tostring(nvim_eval('g:__val')))
+      else -- NaN
+        local nvim_nan = tostring(nvim_eval('g:__val'))
+        -- -NaN is a hardware-specific detail, there's no need to test for it.
+        -- Accept ether 'nan' or '-nan' as the response.
+        ok(nvim_nan == 'nan' or nvim_nan == '-nan')
       end
       nvim_command('unlet g:__val')
     end
@@ -615,7 +609,6 @@ describe('In autoload/msgpack.vim', function()
       eval_eq('float', inf, 'inf')
       eval_eq('float', minus_inf, '-inf')
       eval_eq('float', nan, 'nan')
-      eval_eq('float', minus_nan, '-nan')
       eval_eq('float', 1.0e10, '1.0e10')
       eval_eq('float', 1.0e10, '1.0e+10')
       eval_eq('float', -1.0e10, '-1.0e+10')

--- a/test/functional/preload.lua
+++ b/test/functional/preload.lua
@@ -1,5 +1,4 @@
 -- Modules loaded here will not be cleared and reloaded by Busted.
 -- Busted started doing this to help provide more isolation.  See issue #62
 -- for more information about this.
-local ffi = require('ffi')
 local helpers = require('test.functional.helpers')

--- a/test/functional/server/server_spec.lua
+++ b/test/functional/server/server_spec.lua
@@ -2,7 +2,7 @@
 local helpers = require('test.functional.helpers')
 local nvim, eq, neq, eval = helpers.nvim, helpers.eq, helpers.neq, helpers.eval
 local clear, funcs, meths = helpers.clear, helpers.funcs, helpers.meths
-local os_is_windows = helpers.os_is_windows
+local os_name = helpers.os_name
 
 describe('serverstart(), serverstop()', function()
   before_each(clear)
@@ -39,7 +39,7 @@ describe('serverstart(), serverstop()', function()
     eq('', meths.get_vvar('servername'))
 
     -- v:servername will take the next available server.
-    local servername = (os_is_windows()
+    local servername = (os_name() == 'windows'
                         and [[\\.\pipe\Xtest-functional-server-server-pipe]]
                         or 'Xtest-functional-server-server-socket')
     funcs.serverstart(servername)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -41,7 +41,7 @@ describe('tui', function()
       -- INSERT --                                      |
       -- TERMINAL --                                    |
     ]])
-    feed('\x1b')
+    feed('\027')
     screen:expect([[
       abc                                               |
       test1                                             |
@@ -57,7 +57,7 @@ describe('tui', function()
     local keys = 'dfghjkl'
     for c in keys:gmatch('.') do
       execute('nnoremap <a-'..c..'> ialt-'..c..'<cr><esc>')
-      feed('\x1b'..c)
+      feed('\027'..c)
     end
     screen:expect([[
       alt-j                                             |
@@ -87,7 +87,7 @@ describe('tui', function()
     -- Example: for input ALT+j:
     --    * Vim (Nvim prior to #3982) sets high-bit, inserts "ê".
     --    * Nvim (after #3982) inserts "j".
-    feed('i\x1bj')
+    feed('i\027j')
     screen:expect([[
       j{1: }                                                |
       ~                                                 |
@@ -101,9 +101,9 @@ describe('tui', function()
 
   it('accepts ascii control sequences', function()
     feed('i')
-    feed('\x16\x07') -- ctrl+g
-    feed('\x16\x16') -- ctrl+v
-    feed('\x16\x0d') -- ctrl+m
+    feed('\022\007') -- ctrl+g
+    feed('\022\022') -- ctrl+v
+    feed('\022\013') -- ctrl+m
     screen:expect([[
     {3:^G^V^M}{1: }                                           |
     ~                                                 |
@@ -116,7 +116,7 @@ describe('tui', function()
   end)
 
   it('automatically sends <Paste> for bracketed paste sequences', function()
-    feed('i\x1b[200~')
+    feed('i\027[200~')
     screen:expect([[
       {1: }                                                 |
       ~                                                 |
@@ -136,7 +136,7 @@ describe('tui', function()
       -- INSERT (paste) --                              |
       -- TERMINAL --                                    |
     ]])
-    feed('\x1b[201~')
+    feed('\027[201~')
     screen:expect([[
       pasted from terminal{1: }                             |
       ~                                                 |
@@ -154,9 +154,9 @@ describe('tui', function()
     for i = 1, 3000 do
       t[i] = 'item ' .. tostring(i)
     end
-    feed('i\x1b[200~')
+    feed('i\027[200~')
     feed(table.concat(t, '\n'))
-    feed('\x1b[201~')
+    feed('\027[201~')
     screen:expect([[
       item 2997                                         |
       item 2998                                         |
@@ -204,7 +204,7 @@ describe('tui focus event handling', function()
   end)
 
   it('can handle focus events in normal mode', function()
-    feed('\x1b[I')
+    feed('\027[I')
     screen:expect([[
       {1: }                                                 |
       ~                                                 |
@@ -215,7 +215,7 @@ describe('tui focus event handling', function()
       -- TERMINAL --                                    |
     ]])
 
-    feed('\x1b[O')
+    feed('\027[O')
     screen:expect([[
       {1: }                                                 |
       ~                                                 |
@@ -230,7 +230,7 @@ describe('tui focus event handling', function()
   it('can handle focus events in insert mode', function()
     execute('set noshowmode')
     feed('i')
-    feed('\x1b[I')
+    feed('\027[I')
     screen:expect([[
       {1: }                                                 |
       ~                                                 |
@@ -240,7 +240,7 @@ describe('tui focus event handling', function()
       gained                                            |
       -- TERMINAL --                                    |
     ]])
-    feed('\x1b[O')
+    feed('\027[O')
     screen:expect([[
       {1: }                                                 |
       ~                                                 |
@@ -254,7 +254,7 @@ describe('tui focus event handling', function()
 
   it('can handle focus events in cmdline mode', function()
     feed(':')
-    feed('\x1b[I')
+    feed('\027[I')
     screen:expect([[
                                                         |
       ~                                                 |
@@ -264,7 +264,7 @@ describe('tui focus event handling', function()
       g{1:a}ined                                            |
       -- TERMINAL --                                    |
     ]])
-    feed('\x1b[O')
+    feed('\027[O')
     screen:expect([[
                                                         |
       ~                                                 |
@@ -281,7 +281,7 @@ describe('tui focus event handling', function()
     execute('set laststatus=0')
     execute('set noshowmode')
     execute('terminal')
-    feed('\x1b[I')
+    feed('\027[I')
     screen:expect([[
       ready $                                           |
       [Process exited 0]{1: }                               |
@@ -291,7 +291,7 @@ describe('tui focus event handling', function()
       gained                                            |
       -- TERMINAL --                                    |
     ]])
-   feed('\x1b[O')
+   feed('\027[O')
     screen:expect([[
       ready $                                           |
       [Process exited 0]{1: }                               |

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -21,6 +21,9 @@ option(USE_BUNDLED_LIBUV "Use the bundled libuv." ${USE_BUNDLED})
 option(USE_BUNDLED_MSGPACK "Use the bundled msgpack." ${USE_BUNDLED})
 option(USE_BUNDLED_LUAJIT "Use the bundled version of luajit." ${USE_BUNDLED})
 option(USE_BUNDLED_LUAROCKS "Use the bundled version of luarocks." ${USE_BUNDLED})
+#XXX(tarruda): Lua is only used for debugging the functional test client, no
+# build it unless explicitly requested
+option(USE_BUNDLED_LUA "Use the bundled version of lua." OFF)
 
 option(USE_EXISTING_SRC_DIR "Skip download of deps sources in case of existing source directory." OFF)
 
@@ -80,6 +83,9 @@ set(MSGPACK_SHA256 afda64ca445203bb7092372b822bae8b2539fdcebbfc3f753f393628c2bcf
 set(LUAJIT_URL https://github.com/neovim/deps/raw/master/opt/LuaJIT-2.0.4.tar.gz)
 set(LUAJIT_SHA256 620fa4eb12375021bef6e4f237cbd2dd5d49e56beb414bee052c746beef1807d)
 
+set(LUA_URL https://github.com/lua/lua/archive/5.1.5.tar.gz)
+set(LUA_SHA256 1cd642c4c39778306a14e62ccddace5c7a4fb2257b0b06f43bc81cf305c7415f)
+
 set(LUAROCKS_URL https://github.com/keplerproject/luarocks/archive/5d8a16526573b36d5b22aa74866120c998466697.tar.gz)
 set(LUAROCKS_SHA256 cae709111c5701235770047dfd7169f66b82ae1c7b9b79207f9df0afb722bfd9)
 
@@ -117,6 +123,10 @@ endif()
 
 if(USE_BUNDLED_LUAJIT)
   include(BuildLuajit)
+endif()
+
+if(USE_BUNDLED_LUA AND NOT CMAKE_CROSSCOMPILING)
+  include(BuildLua)
 endif()
 
 if(USE_BUNDLED_LUAROCKS)

--- a/third-party/cmake/BuildLua.cmake
+++ b/third-party/cmake/BuildLua.cmake
@@ -1,0 +1,85 @@
+include(CMakeParseArguments)
+
+# BuildLua(CONFIGURE_COMMAND ... BUILD_COMMAND ... INSTALL_COMMAND ...)
+# Reusable function to build lua, wraps ExternalProject_Add.
+# Failing to pass a command argument will result in no command being run
+function(BuildLua)
+  cmake_parse_arguments(_lua
+    ""
+    ""
+    "CONFIGURE_COMMAND;BUILD_COMMAND;INSTALL_COMMAND"
+    ${ARGN})
+
+  if(NOT _lua_CONFIGURE_COMMAND AND NOT _lua_BUILD_COMMAND
+       AND NOT _lua_INSTALL_COMMAND)
+    message(FATAL_ERROR "Must pass at least one of CONFIGURE_COMMAND, BUILD_COMMAND, INSTALL_COMMAND")
+  endif()
+
+  ExternalProject_Add(lua
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${LUA_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/lua
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/lua
+      -DURL=${LUA_URL}
+      -DEXPECTED_SHA256=${LUA_SHA256}
+      -DTARGET=lua
+      -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    CONFIGURE_COMMAND "${_lua_CONFIGURE_COMMAND}"
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND "${_lua_BUILD_COMMAND}"
+    INSTALL_COMMAND "${_lua_INSTALL_COMMAND}")
+endfunction()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(LUA_TARGET linux)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(LUA_TARGET macosx)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  set(LUA_TARGET freebsd)
+elseif(CMAKE_SYSTEM_NAME MATCHES "BSD")
+  set(CMAKE_LUA_TARGET bsd)
+elseif(SYSTEM_NAME MATCHES "^MINGW")
+  set(CMAKE_LUA_TARGET mingw)
+else()
+  if(UNIX)
+    set(LUA_TARGET posix)
+  else()
+    set(LUA_TARGET generic)
+  endif()
+endif()
+
+set(LUA_CONFIGURE_COMMAND
+  sed -e "/^CC/s@gcc@${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_ARG1}@"
+      -e "/^CFLAGS/s@-O2@-g3@"
+      -e "s@-lreadline@@g"
+      -e "s@-lhistory@@g"
+      -e "s@-lncurses@@g"
+      -i ${DEPS_BUILD_DIR}/src/lua/src/Makefile &&
+  sed -e "/#define LUA_USE_READLINE/d"
+      -i ${DEPS_BUILD_DIR}/src/lua/src/luaconf.h)
+set(LUA_BUILD_COMMAND
+  ${MAKE_PRG} ${LUA_TARGET})
+set(LUA_INSTALL_COMMAND
+  ${MAKE_PRG} INSTALL_TOP=${DEPS_INSTALL_DIR} install)
+
+message(STATUS "Lua target is ${LUA_TARGET}")
+
+BuildLua(CONFIGURE_COMMAND ${LUA_CONFIGURE_COMMAND}
+  BUILD_COMMAND ${LUA_BUILD_COMMAND}
+  INSTALL_COMMAND ${LUA_INSTALL_COMMAND})
+list(APPEND THIRD_PARTY_DEPS lua)
+add_dependencies(lua busted)
+
+set(BUSTED ${DEPS_INSTALL_DIR}/bin/busted)
+set(BUSTED_LUA ${BUSTED}-lua)
+
+add_custom_command(OUTPUT ${BUSTED_LUA}
+  COMMAND sed -e 's/jit//g' < ${BUSTED} > ${BUSTED_LUA} && chmod +x ${BUSTED_LUA}
+  DEPENDS lua)
+add_custom_target(busted-lua
+  DEPENDS ${DEPS_INSTALL_DIR}/bin/busted-lua)
+
+list(APPEND THIRD_PARTY_DEPS busted-lua)


### PR DESCRIPTION
These changes make the functional tests compatible with Lua 5.1, simplifying the task of debugging the lua client.

Also added a `functionaltest-lua` for simplified usage and a travis build to ensure we'll maintain compatibility in the future.
