### PR TITLE
[RFC] vim-patch:7.4.1511

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3014,7 +3014,7 @@ int build_stl_str_hl(
           && item[groupitem[groupdepth]].minwid == 0) {
         bool has_normal_items = false;
         for (long n = groupitem[groupdepth] + 1; n < curitem; n++) {
-          if (item[n].type == Normal) {
+          if (item[n].type == Normal || item[n].type == Highlight) {
             has_normal_items = true;
             break;
           }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -69,6 +69,7 @@ static char *features[] = {
 
 // clang-format off
 static int included_patches[] = {
+  1511,
   1366,
 
   // 1219 NA


### PR DESCRIPTION
#### vim-patch:7.4.1511

Problem:    Statusline highlighting is sometimes wrong.
Solution:   Check for Highlight type. (Christian Brabandt)

https://github.com/vim/vim/commit/af6e36ff16736106a1bc63bb4d01f51fdfeb29a2
