### PR TITLE
[RFC] allow external uis to render the popupmenu

### DIFF
--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -11,6 +11,7 @@ RPC API for Nvim				     *RPC* *rpc* *msgpack-rpc*
 3. Connecting			|rpc-connecting|
 4. Clients			|rpc-api-client|
 5. Types			|rpc-types|
+6. Remote UIs			|rpc-remote-ui|
 
 ==============================================================================
 1. Introduction						            *rpc-intro*
@@ -236,6 +237,171 @@ the `types` object:
 Even for statically compiled clients it is good practice to avoid hardcoding
 the type codes, because a client may be built against one Nvim version but
 connect to another with different type codes.
+
+==============================================================================
+6. Remote UIs					           *rpc-remote-ui*
+
+Nvim allows Graphical user interfaces to be implemented by separate processes
+communicating with Nvim over the RPC API. Currently the ui model conists of a
+terminal-like grid with one single, monospace font size, with a few elements
+that could be drawn separately from the grid (for the momemnt only the popup
+menu)
+
+After connecting to a nvim instance (typically a spawned, embedded instance)
+use the |nvim_ui_attach|(width, height, options) API method to tell nvim that your
+program wants to draw the nvim screen on a grid with "width" times
+"height" cells. "options" should be a dictionary with the following (all
+optional) keys:
+	`rgb`:			Controls what color format to use.
+				Set to true (default) to use 24-bit rgb
+				colors.
+				Set to false to use terminal color codes (at
+				most 256 different colors).
+	`popupmenu_external`:	Instead of drawing the completion popupmenu on
+				the grid, Nvim will send higher-level events to
+				the ui and let it draw the popupmenu.
+				Defaults to false.
+
+Nvim will then send msgpack-rpc notifications, with the method name "redraw"
+and a single argument, an array of screen updates (described below).
+These should be processed in order. Preferably the user should only be able to
+see the screen state after all updates are processed (not any intermediate
+state after processing only a part of the array).
+
+Screen updates are arrays. The first element a string describing the kind
+of update.
+
+["resize", width, height]
+	The grid is resized to `width` and `height` cells.
+
+["clear"]
+	Clear the screen.
+
+["eol_clear"]
+	Clear from the cursor position to the end of the current line.
+
+["cursor_goto", row, col]
+	Move the cursor to position (row, col). Currently, the same cursor is
+	used to define the position for text insertion and the visible cursor.
+	However, only the last cursor position, after processing the entire
+	array in the "redraw" event, is intended to be a visible cursor
+	position.
+
+["update_fg", color]
+["update_bg", color]
+["update_sp", color]
+	Set the default foreground, background and special colors
+	respectively.
+
+["highlight_set", attrs]
+	Set the attributes that the next text put on the screen will have.
+	`attrs` is a dict with the keys below. Any absent key is reset
+	to its default value. Color defaults are set by the `update_fg` etc
+	updates. All boolean keys default to false.
+
+	`foreground`:	foreground color.
+	`background`:	backround color.
+	`special`:	color to use for underline and undercurl, when present.
+	`reverse`:	reverse video. Foreground and background colors are
+			switched.
+	`italic`:	italic text.
+	`bold`:		bold text.
+	`underline`:	underlined text. The line has `special` color.
+	`undercurl`:	undercurled text. The curl has `special` color.
+
+["put", text]
+	The (utf-8 encoded) string `text` is put at the cursor position
+	(and the cursor is advanced), with the highlights as set by the
+	last `highlight_set` update.
+
+["set_scroll_region", top, bot, left, right]
+	Define the scroll region used by `scroll` below.
+
+["scroll", count]
+	Scroll the text in the scroll region. The diagrams below illustrate
+	what will happen, depending on the scroll direction. "=" is used to
+	represent the SR(scroll region) boundaries and "-" the moved rectangles.
+	Note that dst and src share a common region.
+
+	If count is bigger than 0, move a rectangle in the SR up, this can
+	happen while scrolling down.
+>
+		+-------------------------+
+		| (clipped above SR)      |            ^
+		|=========================| dst_top    |
+		| dst (still in SR)       |            |
+		+-------------------------+ src_top    |
+		| src (moved up) and dst  |            |
+		|-------------------------| dst_bot    |
+		| src (cleared)           |            |
+		+=========================+ src_bot
+<
+	If count is less than zero, move a rectangle in the SR down, this can
+	happen while scrolling up.
+>
+		+=========================+ src_top
+		| src (cleared)           |            |
+		|------------------------ | dst_top    |
+		| src (moved down) and dst|            |
+		+-------------------------+ src_bot    |
+		| dst (still in SR)       |            |
+		|=========================| dst_bot    |
+		| (clipped below SR)      |            v
+		+-------------------------+
+<
+["set_title", title]
+["set_icon", icon]
+	Set the window title, and icon (minimized) window title, respectively.
+	In windowing systems not distinguishing between the two, "set_icon"
+	can be ignored.
+
+["mouse_on"]
+["mouse_off"]
+	Tells the client whether mouse support, as determined by |'mouse'|
+	option, is considered to be active in the current mode. This is mostly
+	useful for a terminal frontend, or other situations where nvim mouse
+	would conflict with other usages of the mouse. It is safe for a client
+	to ignore this and always send mouse events.
+
+["busy_on"]
+["busy_off"]
+	Nvim started or stopped being busy, and possibly not responsible to user
+	input. This could be indicated to the user by hiding the cursor.
+
+["suspend"]
+	|:suspend| command or |Ctrl-Z| mapping is used. A terminal client (or other
+	client where it makes sense) could suspend itself.  Other clients can
+	safely ignore it.
+
+["bell"]
+["visual_bell"]
+	Notify the user with an audible or visual bell, respectively.
+
+["update_menu"]
+	The menu mappings changed.
+
+["mode_change", mode]
+	The mode changed. Currently sent when "insert", "replace" and "normal"
+	modes are entered. A client could for instance change the cursor shape.
+
+["popupmenu_show", items, selected, row, col]
+	When `popupmenu_external` is set to true, nvim will not draw the
+	popupmenu on the grid, instead when the popupmenu is to be displayed
+	this update is sent. `items` is an array of the items to show, the
+	items are themselves arrays of the form [word, kind, menu, info]
+	as defined at |complete-items|, except that `word` is replaced by
+	`abbr` if present.  `selected` is the initially selected item, either a
+	zero-based index into the array of items, or -1 if no item is
+	selected. `row` and `col` is the anchor position, where the first
+	character of the completed word will be.
+
+["popupmenu_select", selected]
+	An item in the currently displayed popupmenu is selected. `selected`
+	is either a zero-based index into the array of items from the last
+	`popupmenu_show` event, or -1 if no item is selected.
+
+["popupmenu_hide"]
+	The popupmenu is hidden.
 
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -8,6 +8,7 @@
 #include "nvim/memory.h"
 #include "nvim/map.h"
 #include "nvim/msgpack_rpc/channel.h"
+#include "nvim/api/ui.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/popupmnu.h"
@@ -45,8 +46,8 @@ void remote_ui_disconnect(uint64_t channel_id)
   xfree(ui);
 }
 
-void ui_attach(uint64_t channel_id, Integer width, Integer height,
-               Boolean enable_rgb, Error *err)
+void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
+                    Dictionary options, Error *err)
 {
   if (pmap_has(uint64_t)(connected_uis, channel_id)) {
     api_set_error(err, Exception, _("UI already attached for channel"));
@@ -58,14 +59,11 @@ void ui_attach(uint64_t channel_id, Integer width, Integer height,
                   _("Expected width > 0 and height > 0"));
     return;
   }
-  UIData *data = xmalloc(sizeof(UIData));
-  data->channel_id = channel_id;
-  data->buffer = (Array)ARRAY_DICT_INIT;
   UI *ui = xcalloc(1, sizeof(UI));
   ui->width = (int)width;
   ui->height = (int)height;
-  ui->rgb = enable_rgb;
-  ui->data = data;
+  ui->rgb = true;
+  ui->pum_external = false;
   ui->resize = remote_ui_resize;
   ui->clear = remote_ui_clear;
   ui->eol_clear = remote_ui_eol_clear;
@@ -90,51 +88,107 @@ void ui_attach(uint64_t channel_id, Integer width, Integer height,
   ui->set_title = remote_ui_set_title;
   ui->set_icon = remote_ui_set_icon;
   ui->event = remote_ui_event;
+
+  for (size_t i = 0; i < options.size; i++) {
+    ui_set_option(ui, options.items[i].key, options.items[i].value, err);
+    if (err->set) {
+      xfree(ui);
+      return;
+    }
+  }
+
+  UIData *data = xmalloc(sizeof(UIData));
+  data->channel_id = channel_id;
+  data->buffer = (Array)ARRAY_DICT_INIT;
+  ui->data = data;
+
   pmap_put(uint64_t)(connected_uis, channel_id, ui);
   ui_attach_impl(ui);
-  return;
 }
 
-void ui_detach(uint64_t channel_id, Error *err)
+/// @deprecated
+void ui_attach(uint64_t channel_id, Integer width, Integer height,
+               Boolean enable_rgb, Error *err)
+{
+  Dictionary opts = ARRAY_DICT_INIT;
+  PUT(opts, "rgb", BOOLEAN_OBJ(enable_rgb));
+  nvim_ui_attach(channel_id, width, height, opts, err);
+  api_free_dictionary(opts);
+}
+
+void nvim_ui_detach(uint64_t channel_id, Error *err)
 {
   if (!pmap_has(uint64_t)(connected_uis, channel_id)) {
     api_set_error(err, Exception, _("UI is not attached for channel"));
+    return;
   }
   remote_ui_disconnect(channel_id);
 }
 
-Object ui_try_resize(uint64_t channel_id, Integer width,
-                     Integer height, Error *err)
+/// @deprecated
+void ui_detach(uint64_t channel_id, Error *err)
+{
+  nvim_ui_detach(channel_id, err);
+}
+
+void nvim_ui_try_resize(uint64_t channel_id, Integer width,
+                        Integer height, Error *err)
 {
   if (!pmap_has(uint64_t)(connected_uis, channel_id)) {
     api_set_error(err, Exception, _("UI is not attached for channel"));
+    return;
   }
 
   if (width <= 0 || height <= 0) {
     api_set_error(err, Validation,
                   _("Expected width > 0 and height > 0"));
-    return NIL;
+    return;
   }
 
   UI *ui = pmap_get(uint64_t)(connected_uis, channel_id);
   ui->width = (int)width;
   ui->height = (int)height;
   ui_refresh();
-  return NIL;
 }
 
-void ui_set_popupmenu_external(uint64_t channel_id, Boolean external,
-                               Error *error)
+/// @deprecated
+void ui_try_resize(uint64_t channel_id, Integer width,
+                   Integer height, Error *err)
 {
-  // Technically this is not needed right now,
-  // but futher on we might implement smarter behavior when multiple
-  // ui:s are attached with different draw modes
+  nvim_ui_try_resize(channel_id, width, height, err);
+}
+
+void nvim_ui_set_option(uint64_t channel_id, String name,
+                        Object value, Error *error) {
   if (!pmap_has(uint64_t)(connected_uis, channel_id)) {
     api_set_error(error, Exception, _("UI is not attached for channel"));
     return;
   }
+  UI *ui = pmap_get(uint64_t)(connected_uis, channel_id);
 
-  pum_set_external(external);
+  ui_set_option(ui, name, value, error);
+  if (!error->set) {
+    ui_refresh();
+  }
+}
+
+static void ui_set_option(UI *ui, String name, Object value, Error *error) {
+  if (strcmp(name.data, "rgb") == 0) {
+    if (value.type != kObjectTypeBoolean) {
+      api_set_error(error, Validation, _("rgb must be a Boolean"));
+      return;
+    }
+    ui->rgb = value.data.boolean;
+  } else if (strcmp(name.data, "popupmenu_external") == 0) {
+    if (value.type != kObjectTypeBoolean) {
+      api_set_error(error, Validation,
+                    _("popupmenu_external must be a Boolean"));
+      return;
+    }
+    ui->pum_external = value.data.boolean;
+  } else {
+    api_set_error(error, Validation, _("No such ui option"));
+  }
 }
 
 static void push_call(UI *ui, char *name, Array args)

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2472,6 +2472,7 @@ void ins_compl_show_pum(void)
   int cur = -1;
   colnr_T col;
   int lead_len = 0;
+  bool array_changed = false;
 
   if (!pum_wanted() || !pum_enough_matches())
     return;
@@ -2483,7 +2484,8 @@ void ins_compl_show_pum(void)
   update_screen(0);
 
   if (compl_match_array == NULL) {
-    /* Need to build the popup menu list. */
+    array_changed = true;
+    // Need to build the popup menu list.
     compl_match_arraysize = 0;
     compl = compl_first_match;
     /*
@@ -2586,7 +2588,7 @@ void ins_compl_show_pum(void)
   // Use the cursor to get all wrapping and other settings right.
   col = curwin->w_cursor.col;
   curwin->w_cursor.col = compl_col;
-  pum_display(compl_match_array, compl_match_arraysize, cur);
+  pum_display(compl_match_array, compl_match_arraysize, cur, array_changed);
   curwin->w_cursor.col = col;
 }
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -106,6 +106,7 @@ UI *tui_start(void)
   ui->suspend = tui_suspend;
   ui->set_title = tui_set_title;
   ui->set_icon = tui_set_icon;
+  ui->event = tui_event;
   return ui_bridge_attach(ui, tui_main, tui_scheduler);
 }
 
@@ -647,6 +648,12 @@ static void tui_set_title(UI *ui, char *title)
 }
 
 static void tui_set_icon(UI *ui, char *icon)
+{
+}
+
+// NB: if we start to use this, the ui_bridge must be updated
+// to make a copy for the tui thread
+static void tui_event(UI *ui, char *name, Array args, bool *args_consumed)
 {
 }
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -83,6 +83,7 @@ UI *tui_start(void)
   UI *ui = xcalloc(1, sizeof(UI));
   ui->stop = tui_stop;
   ui->rgb = p_tgc;
+  ui->pum_external = false;
   ui->resize = tui_resize;
   ui->clear = tui_clear;
   ui->eol_clear = tui_eol_clear;

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -35,6 +35,7 @@
 #else
 # include "nvim/msgpack_rpc/server.h"
 #endif
+#include "nvim/api/private/helpers.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui.c.generated.h"
@@ -141,6 +142,15 @@ void ui_set_icon(char *icon)
 {
   UI_CALL(set_icon, icon);
   UI_CALL(flush);
+}
+
+void ui_event(char *name, Array args)
+{
+  bool args_consumed = false;
+  UI_CALL(event, name, args, &args_consumed);
+  if (!args_consumed) {
+    api_free_array(args);
+  }
 }
 
 // May update the shape of the cursor.
@@ -519,3 +529,4 @@ static void ui_mode_change(void)
   UI_CALL(mode_change, mode);
   conceal_check_cursur_line();
 }
+

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -27,6 +27,7 @@
 #include "nvim/os/time.h"
 #include "nvim/os/input.h"
 #include "nvim/os/signal.h"
+#include "nvim/popupmnu.h"
 #include "nvim/screen.h"
 #include "nvim/syntax.h"
 #include "nvim/window.h"
@@ -166,15 +167,18 @@ void ui_refresh(void)
   }
 
   int width = INT_MAX, height = INT_MAX;
+  bool pum_external = true;
 
   for (size_t i = 0; i < ui_count; i++) {
     UI *ui = uis[i];
     width = ui->width < width ? ui->width : width;
     height = ui->height < height ? ui->height : height;
+    pum_external &= ui->pum_external;
   }
 
   row = col = 0;
   screen_resize(width, height);
+  pum_set_external(pum_external);
 }
 
 void ui_resize(int new_width, int new_height)

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "api/private/defs.h"
+
 typedef struct {
   bool bold, underline, undercurl, italic, reverse;
   int foreground, background, special;
@@ -39,6 +41,7 @@ struct ui_t {
   void (*suspend)(UI *ui);
   void (*set_title)(UI *ui, char *title);
   void (*set_icon)(UI *ui, char *icon);
+  void (*event)(UI *ui, char *name, Array args, bool *args_consumed);
   void (*stop)(UI *ui);
 };
 

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -15,7 +15,7 @@ typedef struct {
 typedef struct ui_t UI;
 
 struct ui_t {
-  bool rgb;
+  bool rgb, pum_external;
   int width, height;
   void *data;
   void (*resize)(UI *ui, int rows, int columns);

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -31,6 +31,7 @@ UI *ui_bridge_attach(UI *ui, ui_main_fn ui_main, event_scheduler scheduler)
   UIBridgeData *rv = xcalloc(1, sizeof(UIBridgeData));
   rv->ui = ui;
   rv->bridge.rgb = ui->rgb;
+  rv->bridge.pum_external = ui->pum_external;
   rv->bridge.stop = ui_bridge_stop;
   rv->bridge.resize = ui_bridge_resize;
   rv->bridge.clear = ui_bridge_clear;

--- a/test/functional/autocmd/termclose_spec.lua
+++ b/test/functional/autocmd/termclose_spec.lua
@@ -12,7 +12,7 @@ describe('TermClose event', function()
     nvim('set_option', 'shell', nvim_dir .. '/shell-test')
     nvim('set_option', 'shellcmdflag', 'EXE')
     screen = Screen.new(20, 4)
-    screen:attach(false)
+    screen:attach({rgb=false})
   end)
 
   it('works as expected', function()

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -306,6 +306,10 @@ local function nvim(method, ...)
   return request('vim_'..method, ...)
 end
 
+local function ui(method, ...)
+  return request('nvim_ui_'..method, ...)
+end
+
 local function nvim_async(method, ...)
   session:notify('vim_'..method, ...)
 end
@@ -432,6 +436,7 @@ end
 
 local funcs = create_callindex(nvim_call)
 local meths = create_callindex(nvim)
+local uimeths = create_callindex(ui)
 local bufmeths = create_callindex(buffer)
 local winmeths = create_callindex(window)
 local tabmeths = create_callindex(tabpage)
@@ -490,6 +495,7 @@ return function(after_each)
     bufmeths = bufmeths,
     winmeths = winmeths,
     tabmeths = tabmeths,
+    uimeths = uimeths,
     curbufmeths = curbufmeths,
     curwinmeths = curwinmeths,
     curtabmeths = curtabmeths,

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -135,7 +135,7 @@ describe('cursor with customized highlighting', function()
       [2] = {foreground = 55, background = 56},
       [3] = {bold = true},
     })
-    screen:attach(false)
+    screen:attach({rgb=false})
     execute('call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
   end)
 

--- a/test/functional/terminal/edit_spec.lua
+++ b/test/functional/terminal/edit_spec.lua
@@ -12,7 +12,7 @@ local eq = helpers.eq
 describe(':edit term://*', function()
   local get_screen = function(columns, lines)
     local scr = screen.new(columns, lines)
-    scr:attach(false)
+    scr:attach({rgb=false})
     return scr
   end
 

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -10,7 +10,7 @@ describe(':terminal', function()
   before_each(function()
     clear()
     screen = Screen.new(50, 4)
-    screen:attach(false)
+    screen:attach({rgb=false})
     nvim('set_option', 'shell', nvim_dir..'/shell-test')
     nvim('set_option', 'shellcmdflag', 'EXE')
 

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -53,7 +53,7 @@ local function screen_setup(extra_height, command)
     [9] = {foreground = 4},
   })
 
-  screen:attach(false)
+  screen:attach({rgb=false})
   -- tty-test puts the terminal into raw mode and echoes all input. tests are
   -- done by feeding it with terminfo codes to control the display and
   -- verifying output with screen:expect.

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -25,7 +25,7 @@ describe('terminal window highlighting', function()
       [10] = {reverse = true},
       [11] = {background = 11},
     })
-    screen:attach(false)
+    screen:attach({rgb=false})
     execute('enew | call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
     screen:expect([[
       tty ready                                         |
@@ -127,7 +127,7 @@ describe('terminal window highlighting with custom palette', function()
       [8] = {background = 11},
       [9] = {bold = true},
     })
-    screen:attach(true)
+    screen:attach({rgb=true})
     nvim('set_var', 'terminal_color_3', '#123456')
     execute('enew | call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
     screen:expect([[
@@ -185,7 +185,7 @@ describe('synIDattr()', function()
   end)
 
   it('returns gui-color if RGB-capable UI is attached', function()
-    screen:attach(true)
+    screen:attach({rgb=true})
     eq('#ff0000', eval('synIDattr(hlID("Normal"),  "fg")'))
     eq('Black',   eval('synIDattr(hlID("Normal"),  "bg")'))
     eq('Salmon',  eval('synIDattr(hlID("Keyword"), "fg")'))
@@ -193,7 +193,7 @@ describe('synIDattr()', function()
   end)
 
   it('returns #RRGGBB value for fg#/bg#/sp#', function()
-    screen:attach(true)
+    screen:attach({rgb=true})
     eq('#ff0000', eval('synIDattr(hlID("Normal"), "fg#")'))
     eq('#000000', eval('synIDattr(hlID("Normal"), "bg#")'))
     eq('#fa8072', eval('synIDattr(hlID("Keyword"), "fg#")'))
@@ -201,7 +201,7 @@ describe('synIDattr()', function()
   end)
 
   it('returns color number if non-GUI', function()
-    screen:attach(false)
+    screen:attach({rgb=false})
     eq('252', eval('synIDattr(hlID("Normal"), "fg")'))
     eq('79', eval('synIDattr(hlID("Keyword"), "fg")'))
   end)

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -331,7 +331,7 @@ describe('terminal prints more lines than the screen height and exits', function
   it('will push extra lines to scrollback', function()
     clear()
     local screen = Screen.new(50, 7)
-    screen:attach(false)
+    screen:attach({rgb=false})
     execute('call termopen(["'..nvim_dir..'/tty-test", "10"]) | startinsert')
     wait()
     screen:expect([[

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -755,4 +755,106 @@ describe('completion', function()
       ]])
     end)
   end)
+
+end)
+
+describe('External completion popupmenu', function()
+  local screen
+  local items, selected, anchor
+  before_each(function()
+    clear()
+    screen = Screen.new(60, 8)
+    screen:attach({rgb=true, popupmenu_external=true})
+    screen:set_default_attr_ids({
+      [1] = {bold=true, foreground=Screen.colors.Blue},
+      [2] = {bold = true},
+    })
+    screen:set_on_event_handler(function(name, data)
+      if name == "popupmenu_show" then
+        local row, col
+        items, selected, row, col = unpack(data)
+        anchor = {row, col}
+      elseif name == "popupmenu_select" then
+        selected = data[1]
+      elseif name == "popupmenu_hide" then
+        items = nil
+      end
+    end)
+  end)
+
+  it('works', function()
+    source([[
+      function! TestComplete() abort
+        call complete(1, ['foo', 'bar', 'spam'])
+        return ''
+      endfunction
+    ]])
+    local expected = {
+      {'foo', '', '', ''},
+      {'bar', '', '', ''},
+      {'spam', '', '', ''},
+    }
+    feed('o<C-r>=TestComplete()<CR>')
+    screen:expect([[
+                                                                  |
+      foo^                                                         |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- INSERT --}                                                |
+    ]], nil, nil, function() 
+      eq(expected, items)
+      eq(0, selected)
+      eq({1,0}, anchor)
+    end)
+
+    feed('<c-p>')
+    screen:expect([[
+                                                                  |
+      ^                                                            |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- INSERT --}                                                |
+    ]], nil, nil, function() 
+      eq(expected, items)
+      eq(-1, selected)
+      eq({1,0}, anchor)
+    end)
+
+    -- down moves the selection in the menu, but does not insert anything
+    feed('<down><down>')
+    screen:expect([[
+                                                                  |
+      ^                                                            |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- INSERT --}                                                |
+    ]], nil, nil, function()
+      eq(expected, items)
+      eq(1, selected)
+      eq({1,0}, anchor)
+    end)
+
+    feed('<cr>')
+    screen:expect([[
+                                                                  |
+      bar^                                                         |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- INSERT --}                                                |
+    ]], nil, nil, function()
+      eq(nil, items) -- popupmenu was hidden
+    end)
+  end)
 end)


### PR DESCRIPTION
This enables the internal drawing of the completion popupmenu to be switched off and the data instead sent to an external gui for it to display as it likes.

Not that I care that much about the pum specifically, but it is a good example of an ui element whose implementation is reasonally well isolated from the rest of `screen.c` and thus serves as a good prototype for externalizing ui elements in general.

Some open questions:
- It would seem unreasonable to define a member of `ui_t` for every ui event that would arise from an externalizied ui element. For the moment I just added `(*event)(name, args)` for a generic event that external gui:s care about but not the tui, but it seems like a hack over the present model. (Ref disscussion in #4322 about the distinction of ui/non-ui events).
- Similar question could be raised about ui requests like `remote_ui_try_resize`. Why don't we have `api/remote_ui.c` and just autogenerate the msgpack validation as for all other api requests? (**done** in #4817 )
- If multiple uis (including the tui) are connected they might differ in which ui elements they implement themselves or should be drawn on the grid. The "proper" solution would be to have multiple "layers" of the grid that ui:s could show or not show but that looks too complicated at this point (it should probably wait until progress is made on the  [smart ui](http://tarruda.github.io/articles/neovim-smart-ui-protocol/) protocol). A reasonable heuristic for this case could just be: the ui that sends the keypress opening the pum determines the display mode. **solution:** only use external popupmenu if all connected clients support it.

I made stupid test for the [python-gui](https://github.com/neovim/python-gui/compare/master...bfredl:pumtest?expand=1), it doesn't even draw anything but it echoes the events to stdout so one could see that they are correct.

The exposed ui events  are:

```
popupmenu_show(items, selected, row, col)
popupmenu_select(selected)
popupmenu_hide()
```

items will be a list of tuples `[text, kind, extra, info]`. `selected` will either be a 0-based index or -1 if no element is selected.
To activate this mode, instead of using `ui_attach(row, cols, true)` use `nvim_ui_attach(rows, cols, {'rgb': true, 'popupmenu_external': true})`.
Alternatively `nvim_ui_set_option('popupmenu_external', 'true')` can be set after the ui already is attached.
