### PR TITLE
[RFC] rplugin: let the python host identify packages

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -149,7 +149,9 @@ function! s:RegistrationCommands(host) abort
   endfor
   let channel = remote#host#Require(host_id)
   let lines = []
+  let registered = []
   for path in paths
+    unlet! specs
     let specs = rpcrequest(channel, 'specs', path)
     if type(specs) != type([])
       " host didn't return a spec list, indicates a failure while loading a
@@ -162,9 +164,10 @@ function! s:RegistrationCommands(host) abort
       call add(lines, "      \\ ".string(spec).",")
     endfor
     call add(lines, "     \\ ])")
+    call add(registered, path)
   endfor
   echomsg printf("remote/host: %s host registered plugins %s",
-        \ a:host, string(map(copy(paths), "fnamemodify(v:val, ':t')")))
+        \ a:host, string(map(registered, "fnamemodify(v:val, ':t')")))
 
   " Delete the temporary host clone
   call rpcstop(s:hosts[host_id].channel)
@@ -207,7 +210,7 @@ endfunction
 " Registration of standard hosts
 
 " Python/Python3
-call remote#host#Register('python', '*.py',
+call remote#host#Register('python', '*',
       \ function('provider#pythonx#Require'))
-call remote#host#Register('python3', '*.py',
+call remote#host#Register('python3', '*',
       \ function('provider#pythonx#Require'))


### PR DESCRIPTION
For neovim/python-client#183

Eventually I would also like to reduce the need for `:UpdateRemotePlugins`. The python-client already recalculates the specs everytime a plugin is actually used, it could send them back to neovim, and neovim could check if the specs changed and in that case update `init.vim-rplugin` in place. For that we should change that file to a machine-readable format like JSON. In the long run we should detect all rplugin update event kinds so `:URP` never is strictly needed (it can save an extra nvim restart but nvim should be fine without it after a restart or two)

Repo synchronization: neovim/python-client#183 requires this, but this patch works without that one (`:UpdateRemotePlugins` gets uglier but it still works)
