### PR TITLE
[RFC] Replace vim with nvim in macros

### DIFF
--- a/runtime/macros/less.bat
+++ b/runtime/macros/less.bat
@@ -4,7 +4,7 @@ rem Read stdin if no arguments were given.
 rem Written by Ken Takata.
 
 if "%1"=="" (
-  vim --cmd "let no_plugin_maps = 1" -c "runtime! macros/less.vim" -
+  nvim --cmd "let no_plugin_maps = 1" -c "runtime! macros/less.vim" -
 ) else (
-  vim --cmd "let no_plugin_maps = 1" -c "runtime! macros/less.vim" %*
+  nvim --cmd "let no_plugin_maps = 1" -c "runtime! macros/less.vim" %*
 )

--- a/runtime/macros/less.sh
+++ b/runtime/macros/less.sh
@@ -8,9 +8,9 @@ if test -t 1; then
       echo "Missing filename" 1>&2
       exit
     fi
-    vim --cmd 'let no_plugin_maps = 1' -c 'runtime! macros/less.vim' -
+    nvim --cmd 'let no_plugin_maps = 1' -c 'runtime! macros/less.vim' -
   else
-    vim --cmd 'let no_plugin_maps = 1' -c 'runtime! macros/less.vim' "$@"
+    nvim --cmd 'let no_plugin_maps = 1' -c 'runtime! macros/less.vim' "$@"
   fi
 else
   # Output is not a terminal, cat arguments or stdin


### PR DESCRIPTION
Fix for issue #4407 

Simple fix. Also edited the .bat file for windows
