### PR TITLE
[RFC] Add "Don't give the file editing message" flag in shortmess option.

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5539,6 +5539,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		"-- XXX completion (YYY)", "match 1 of 2", "The only match",
 		"Pattern not found", "Back at original", etc.
 	  q     use "recording" instead of "recording @a"
+	  F     don't give the file info when editing a file, like `:silent`
+		was used for the command
 
 	This gives you the opportunity to avoid that a change between buffers
 	requires you to hit <Enter>, but still gives as useful a message as

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -143,10 +143,17 @@ open_buffer (
 
   if (curbuf->b_ffname != NULL
       ) {
+    int old_msg_silent = msg_silent;
+    if (shortmess(SHM_FILEINFO)) {
+      msg_silent = 1;
+    }
+
     retval = readfile(curbuf->b_ffname, curbuf->b_fname,
-        (linenr_T)0, (linenr_T)0, (linenr_T)MAXLNUM, eap,
-        flags | READ_NEW);
-    /* Help buffer is filtered. */
+                      (linenr_T)0, (linenr_T)0, (linenr_T)MAXLNUM, eap,
+                      flags | READ_NEW);
+    msg_silent = old_msg_silent;
+
+    // Help buffer is filtered.
     if (curbuf->b_help)
       fix_help_buffer();
   } else if (read_stdin) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1506,8 +1506,11 @@ void ex_file(exarg_T *eap)
     if (rename_buffer(eap->arg) == FAIL)
       return;
   }
-  /* print full file name if :cd used */
-  fileinfo(FALSE, FALSE, eap->forceit);
+
+  if (!shortmess(SHM_FILEINFO)) {
+    // print full file name if :cd used
+    fileinfo(false, false, eap->forceit);
+  }
 }
 
 /*
@@ -2483,7 +2486,9 @@ do_ecmd (
     msg_scroll = msg_scroll_save;
     msg_scrolled_ign = TRUE;
 
-    fileinfo(FALSE, TRUE, FALSE);
+    if (!shortmess(SHM_FILEINFO)) {
+      fileinfo(false, true, false);
+    }
 
     msg_scrolled_ign = FALSE;
   }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -172,6 +172,7 @@ enum {
   SHM_INTRO          = 'I',  ///< Intro messages.
   SHM_COMPLETIONMENU = 'c',  ///< Completion menu messages.
   SHM_RECORDING      = 'q',  ///< Short recording message.
+  SHM_FILEINFO       = 'F',  ///< No file info messages.
 };
 /// Represented by 'a' flag.
 #define SHM_ALL_ABBREVIATIONS ((char_u[]) { \
@@ -183,7 +184,7 @@ enum {
   SHM_RO, SHM_MOD, SHM_FILE, SHM_LAST, SHM_TEXT, SHM_LINES, SHM_NEW, SHM_WRI, \
   SHM_ABBREVIATIONS, SHM_WRITE, SHM_TRUNC, SHM_TRUNCALL, SHM_OVER, \
   SHM_OVERALL, SHM_SEARCH, SHM_ATTENTION, SHM_INTRO, SHM_COMPLETIONMENU, \
-  SHM_RECORDING, \
+  SHM_RECORDING, SHM_FILEINFO, \
   0, \
 })
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -69,6 +69,7 @@ static char *features[] = {
 
 // clang-format off
 static int included_patches[] = {
+  1570,
   1511,
   1366,
 

--- a/test/functional/ui/shortmess_spec.lua
+++ b/test/functional/ui/shortmess_spec.lua
@@ -1,0 +1,40 @@
+local helpers = require('test.functional.helpers')
+local Screen = require('test.functional.ui.screen')
+local clear, feed, execute = helpers.clear, helpers.feed, helpers.execute
+
+describe("'shortmess'", function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(25, 5)
+    screen:attach()
+    execute('set shortmess&')
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  describe("=F", function()
+    it(':hides messages about the files read', function()
+      execute('e test')
+      screen:expect([[
+        ^                         |
+        ~                        |
+        ~                        |
+        ~                        |
+        "test" is a directory    |
+      ]])
+      execute('set shortmess=F')
+      execute('e test')
+      screen:expect([[
+        ^                         |
+        ~                        |
+        ~                        |
+        ~                        |
+        :e test                  |
+      ]])
+    end)
+  end)
+end)


### PR DESCRIPTION
It adds F flag in shortmess option.
It is "Don't give the file editing message" flag.
Because, it is useless if you use statusline feature.

Note:  I will create the patch for Vim after it is merged.
