### PR TITLE
[RFC] vim-patch:7.4.1574

### DIFF
--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1782,7 +1782,13 @@ void undo_time(long step, int sec, int file, int absolute)
   /* "target" is the node below which we want to be.
    * Init "closest" to a value we can't reach. */
   if (absolute) {
-    target = step;
+    if (step == 0) {
+      // target 0 does not exist, got to 1 and above it.
+      target = 1;
+      above = true;
+    } else {
+      target = step;
+    }
     closest = -1;
   } else {
     /* When doing computations with time_t subtract starttime, because

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -69,6 +69,7 @@ static char *features[] = {
 
 // clang-format off
 static int included_patches[] = {
+  1574,
   1570,
   1511,
   1366,


### PR DESCRIPTION
Problem:    ":undo 0" does not work. (Florent Fayolle)
Solution:   Make it undo all the way. (closes vim/vim#688)

https://github.com/vim/vim/commit/d22e9465f6228207a4fe722ee84371c7817060d6
