### PR TITLE
host.vim: Ignore empty specs

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -153,7 +153,7 @@ function! s:RegistrationCommands(host) abort
   for path in paths
     unlet! specs
     let specs = rpcrequest(channel, 'specs', path)
-    if type(specs) != type([])
+    if type(specs) != type([]) || empty(specs)
       " host didn't return a spec list, indicates a failure while loading a
       " plugin
       continue


### PR DESCRIPTION
`:UpdateRemotePlugins` should ignore empty specs.
CC: @bfredl
