### PR TITLE
macOS: precompose filenames found by globbing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 
   # Enable fixing case-insensitive filenames for Mac.
   set(USE_FNAME_CASE TRUE)
+  # Enable precomposing filenames
+  set(MAC_PRECOMPOSE_FNAME TRUE)
 endif()
 
 # Set default build type.

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -48,6 +48,7 @@
 #cmakedefine HAVE_WORKING_LIBINTL
 #cmakedefine UNIX
 #cmakedefine USE_FNAME_CASE
+#cmakedefine MAC_PRECOMPOSE_FNAME
 
 #define FEAT_CSCOPE
 


### PR DESCRIPTION
This should fix Issue #4476 .

This patch does the same conversion as in `src/misc1.c` of the upstream `vim` (the line 10265 and below, `#ifdef MACOS_CONVERT ... #endif`) , where `TECConvertText()` (Carbon) is used for precomposing filenames. This patch, however,  uses `iconv()` for converting from UTF-8-MAC (NFD) to UTF-8 (NFC), because it seems `iconv()` is used for most of the conversions in `nvim`.
