### PR TITLE
[RFC] Correctly reset qf_list_T in qf_free()

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1886,6 +1886,8 @@ static void qf_free(qf_info_T *qi, int idx)
     --qi->qf_lists[idx].qf_count;
   }
   xfree(qi->qf_lists[idx].qf_title);
+  qi->qf_lists[idx].qf_start = NULL;
+  qi->qf_lists[idx].qf_ptr = NULL;
   qi->qf_lists[idx].qf_title = NULL;
   qi->qf_lists[idx].qf_index = 0;
 }


### PR DESCRIPTION
This PR is intended to fix #4490.

In `qf_free()`, `qi->qf_lists[idx].qf_ptr` is not reset but keeps pointing to already freed memory. When a new entry is added to this list `qi->qf_lists[idx]`, the member `qf_ptr` is not set to the correct value since it already has a wrong but a non-NULL value (see line 760 in quickfix.c: https://github.com/neovim/neovim/blob/master/src/nvim/quickfix.c#L760). This eventually causes a core dump as repotted in #4490. In this PR, `qi->qf_lists[idx].qf_start` is also reset to NULL, just in case it is (or will be) used somewhere.
