### PR TITLE
[RDY] Fix allowing arguments as part of shell for `:term` command

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9634,7 +9634,12 @@ static void ex_terminal(exarg_T *eap)
              eap->forceit ? "!" : "", name);
     xfree(name);
   } else {
-    char **argv = build_argv((char *)p_sh);
+    if (*p_sh == 0) {
+      EMSG(_(e_shellempty));
+      return;
+    }
+
+    char **argv = shell_build_argv(NULL, NULL);
     char **p = argv;
     char tempstring[512];
     char shell_argv[512] = { 0 };

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9624,31 +9624,23 @@ static void ex_folddo(exarg_T *eap)
 
 static void ex_terminal(exarg_T *eap)
 {
-  char *name = (char *)p_sh;  // Default to 'shell' if {cmd} is not given.
-  char ex_cmd[1024] = { 0 };
-  bool mustfree = false;
+  char ex_cmd[1024];
 
   // We will call termopen() with shell as an arglist if not given a {cmd}.
   if (*eap->arg != NUL) {
-    name = (char *)vim_strsave_escaped(eap->arg, (char_u *)"\"\\");
-    mustfree = true;
+    char *name = (char *)vim_strsave_escaped(eap->arg, (char_u *)"\"\\");
     snprintf(ex_cmd, sizeof(ex_cmd),
              ":enew%s | call termopen(\"%s\") | startinsert",
              eap->forceit ? "!" : "", name);
+    xfree(name);
   } else {
     char **argv = build_argv((char *)p_sh);
     char **p = argv;
-    char tempstring[512] = { 0 };
+    char tempstring[512];
     char shell_argv[512] = { 0 };
 
-    if (*p != NULL) {
-      snprintf(tempstring, sizeof(tempstring), "\"%s\"", *p);
-      xstrlcat(shell_argv, tempstring, sizeof(shell_argv));
-      p++;
-    }
-
     while (*p != NULL) {
-      snprintf(tempstring, sizeof(tempstring), ", \"%s\"", *p);
+      snprintf(tempstring, sizeof(tempstring), ",\"%s\"", *p);
       xstrlcat(shell_argv, tempstring, sizeof(shell_argv));
       p++;
     }
@@ -9656,14 +9648,10 @@ static void ex_terminal(exarg_T *eap)
 
     snprintf(ex_cmd, sizeof(ex_cmd),
              ":enew%s | call termopen([%s]) | startinsert",
-             eap->forceit ? "!" : "", shell_argv);
+             eap->forceit ? "!" : "", shell_argv + 1);
   }
 
   do_cmdline_cmd(ex_cmd);
-
-  if (mustfree) {
-    xfree(name);
-  }
 }
 
 /// Checks if `cmd` is "previewable" (i.e. supported by 'inccommand').

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9634,7 +9634,7 @@ static void ex_terminal(exarg_T *eap)
     mustfree = true;
     snprintf(ex_cmd, sizeof(ex_cmd),
              ":enew%s | call termopen(\"%s\") | startinsert",
-             eap->forceit == true ? "!" : "", name);
+             eap->forceit ? "!" : "", name);
   } else {
     char **argv = build_argv((char *)p_sh);
     char **p = argv;
@@ -9656,7 +9656,7 @@ static void ex_terminal(exarg_T *eap)
 
     snprintf(ex_cmd, sizeof(ex_cmd),
              ":enew%s | call termopen([%s]) | startinsert",
-             eap->forceit == true ? "!" : "", shell_argv);
+             eap->forceit ? "!" : "", shell_argv);
   }
 
   do_cmdline_cmd(ex_cmd);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9638,18 +9638,18 @@ static void ex_terminal(exarg_T *eap)
   } else {
     char **argv = build_argv((char *)p_sh);
     char **p = argv;
-    char tempstring[512] = "";
+    char tempstring[512] = { 0 };
+    char shell_argv[512] = { 0 };
 
-    char shell_argv[512] = "";
     if (*p != NULL) {
       snprintf(tempstring, sizeof(tempstring), "\"%s\"", *p);
-      vim_strcat((char_u *)shell_argv, (char_u *)tempstring, 512);
+      xstrlcat(shell_argv, tempstring, sizeof(shell_argv));
       p++;
     }
 
     while (*p != NULL) {
       snprintf(tempstring, sizeof(tempstring), ", \"%s\"", *p);
-      vim_strcat((char_u *)shell_argv, (char_u *)tempstring, 512);
+      xstrlcat(shell_argv, tempstring, sizeof(shell_argv));
       p++;
     }
     shell_free_argv(argv);

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -70,6 +70,18 @@ char **shell_build_argv(const char *cmd, const char *extra_args)
   return rv;
 }
 
+char **build_argv(char *cmd)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC
+{
+  size_t argc = tokenize((char_u*)cmd, NULL);
+  char **rv = xmalloc((argc + 1) * sizeof(*rv));
+
+  tokenize((char_u*)cmd, rv);
+  assert(rv[0]);
+  rv[argc] = NULL;
+  return rv;
+}
+
 /// Releases the memory allocated by `shell_build_argv`.
 ///
 /// @param argv The argument vector.

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -41,7 +41,7 @@ typedef struct {
 /// Builds the argument vector for running the user-configured 'shell' (p_sh)
 /// with an optional command prefixed by 'shellcmdflag' (p_shcf).
 ///
-/// Creates ["shell", "-shellcommandflag", "-extra_args",
+/// Creates ["shell", "-extra_args", "-shellcmdflag",
 /// "command that has spaces"] from a command string
 ///
 /// @param cmd Command string, or NULL to run an interactive shell.
@@ -70,25 +70,6 @@ char **shell_build_argv(const char *cmd, const char *extra_args)
 
   assert(rv[0]);
 
-  return rv;
-}
-
-/// Builds the argument vector for any command with arguments.
-///
-/// Creates: ["command", "that", "has", "spaces"] from a command string
-///
-/// @param cmd Command string
-/// @return A newly allocated argument vector. It must also be freed with
-///         `shell_free_argv` when no longer needed.
-char **build_argv(char *cmd)
-  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
-{
-  size_t argc = tokenize((char_u *)cmd, NULL);
-  char **rv = xmalloc((argc + 1) * sizeof(*rv));
-
-  tokenize((char_u *)cmd, rv);
-  assert(rv[0]);
-  rv[argc] = NULL;
   return rv;
 }
 

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -73,10 +73,10 @@ char **shell_build_argv(const char *cmd, const char *extra_args)
 char **build_argv(char *cmd)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC
 {
-  size_t argc = tokenize((char_u*)cmd, NULL);
+  size_t argc = tokenize((char_u *)cmd, NULL);
   char **rv = xmalloc((argc + 1) * sizeof(*rv));
 
-  tokenize((char_u*)cmd, rv);
+  tokenize((char_u *)cmd, rv);
   assert(rv[0]);
   rv[argc] = NULL;
   return rv;

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -73,7 +73,7 @@ char **shell_build_argv(const char *cmd, const char *extra_args)
   return rv;
 }
 
-/// Builds the argument vector for any command with with arguments.
+/// Builds the argument vector for any command with arguments.
 ///
 /// Creates: ["command", "that", "has", "spaces"] from a command string
 ///
@@ -81,7 +81,7 @@ char **shell_build_argv(const char *cmd, const char *extra_args)
 /// @return A newly allocated argument vector. It must also be freed with
 ///         `shell_free_argv` when no longer needed.
 char **build_argv(char *cmd)
-  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
   size_t argc = tokenize((char_u *)cmd, NULL);
   char **rv = xmalloc((argc + 1) * sizeof(*rv));

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -41,6 +41,9 @@ typedef struct {
 /// Builds the argument vector for running the user-configured 'shell' (p_sh)
 /// with an optional command prefixed by 'shellcmdflag' (p_shcf).
 ///
+/// Creates ["shell", "-shellcommandflag", "-extra_args",
+/// "command that has spaces"] from a command string
+///
 /// @param cmd Command string, or NULL to run an interactive shell.
 /// @param extra_args Extra arguments to the shell, or NULL.
 /// @return A newly allocated argument vector. It must be freed with
@@ -70,6 +73,13 @@ char **shell_build_argv(const char *cmd, const char *extra_args)
   return rv;
 }
 
+/// Builds the argument vector for any command with with arguments.
+///
+/// Creates: ["command", "that", "has", "spaces"] from a command string
+///
+/// @param cmd Command string
+/// @return A newly allocated argument vector. It must also be freed with
+///         `shell_free_argv` when no longer needed.
 char **build_argv(char *cmd)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC
 {

--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -12,6 +12,8 @@ static void help(void)
   puts("  shell-test");
   puts("  shell-test EXE");
   puts("    Prints \"ready $ \" to stderr.");
+  puts("  shell-test -t {prompt text}");
+  puts("    Prints \"{prompt text} $ \" to stderr.");
   puts("  shell-test EXE \"prog args...\"");
   puts("    Prints \"ready $ prog args...\\n\" to stderr.");
   puts("  shell-test REP {byte} \"line line line\"");
@@ -30,7 +32,14 @@ int main(int argc, char **argv)
   }
 
   if (argc >= 2) {
-    if (strcmp(argv[1], "EXE") == 0) {
+    if (strcmp(argv[1], "-t") == 0) {
+      if (argc < 3) {
+        fprintf(stderr,"Missing promt text for -t option\n");
+        return 5;
+      } else {
+        fprintf(stderr, "%s $ ", argv[2]);
+      }
+    } else if (strcmp(argv[1], "EXE") == 0) {
       fprintf(stderr, "ready $ ");
       if (argc >= 3) {
         fprintf(stderr, "%s\n", argv[2]);

--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
   if (argc >= 2) {
     if (strcmp(argv[1], "-t") == 0) {
       if (argc < 3) {
-        fprintf(stderr,"Missing promt text for -t option\n");
+        fprintf(stderr,"Missing prompt text for -t option\n");
         return 5;
       } else {
         fprintf(stderr, "%s $ ", argv[2]);

--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -16,6 +16,8 @@ static void help(void)
   puts("    Prints \"{prompt text} $ \" to stderr.");
   puts("  shell-test EXE \"prog args...\"");
   puts("    Prints \"ready $ prog args...\\n\" to stderr.");
+  puts("  shell-test -t {prompt text} EXE \"prog args...\"");
+  puts("    Prints \"{prompt text} $ progs args...\" to stderr.");
   puts("  shell-test REP {byte} \"line line line\"");
   puts("    Prints \"{lnr}: line line line\\n\" to stdout {byte} times.");
   puts("    I.e. for `shell-test REP ab \"test\"'");
@@ -38,6 +40,9 @@ int main(int argc, char **argv)
         return 5;
       } else {
         fprintf(stderr, "%s $ ", argv[2]);
+        if (argc >= 5 && (strcmp(argv[3], "EXE") == 0)) {
+          fprintf(stderr, "%s\n", argv[4]);
+        }
       }
     } else if (strcmp(argv[1], "EXE") == 0) {
       fprintf(stderr, "ready $ ");

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -50,37 +50,6 @@ describe(':terminal', function()
 
 end)
 
-describe(':terminal (with fake shell with arguments)', function()
-  local screen
-
-  before_each(function()
-    clear()
-    screen = Screen.new(50, 4)
-    screen:attach({rgb=false})
-    -- shell-test.c is a fake shell that prints its arguments and exits.
-    nvim('set_option', 'shell', nvim_dir..'/shell-test -t jeff')
-    nvim('set_option', 'shellcmdflag', 'EXE')
-  end)
-
-  -- Invokes `:terminal {cmd}` using a fake shell (shell-test.c) which prints
-  -- the {cmd} and exits immediately .
-  local function terminal_with_fake_shell(cmd)
-    execute("terminal "..(cmd and cmd or ""))
-  end
-
-  it('with no argument, acts like termopen()', function()
-    terminal_with_fake_shell()
-    wait()
-    screen:expect([[
-      jeff $                                            |
-      [Process exited 0]                                |
-                                                        |
-      -- TERMINAL --                                    |
-    ]])
-  end)
-
-end)
-
 describe(':terminal (with fake shell)', function()
   local screen
 
@@ -99,11 +68,46 @@ describe(':terminal (with fake shell)', function()
     execute("terminal "..(cmd and cmd or ""))
   end
 
+  it('with no argument, acts like termopen()', function()
+    terminal_with_fake_shell()
+    wait()
+    screen:expect([[
+      ready $                                           |
+      [Process exited 0]                                |
+                                                        |
+      -- TERMINAL --                                    |
+    ]])
+  end)
+
+  it("with no argument, but 'shell' has arguments, acts like termopen()", function()
+    nvim('set_option', 'shell', nvim_dir..'/shell-test -t jeff')
+    terminal_with_fake_shell()
+    wait()
+    screen:expect([[
+      jeff $                                            |
+      [Process exited 0]                                |
+                                                        |
+      -- TERMINAL --                                    |
+    ]])
+  end)
+
   it('executes a given command through the shell', function()
     terminal_with_fake_shell('echo hi')
     wait()
     screen:expect([[
       ready $ echo hi                                   |
+                                                        |
+      [Process exited 0]                                |
+      -- TERMINAL --                                    |
+    ]])
+  end)
+
+  it("executes a given command through the shell, when 'shell' has arguments", function()
+    nvim('set_option', 'shell', nvim_dir..'/shell-test -t jeff')
+    terminal_with_fake_shell('echo hi')
+    wait()
+    screen:expect([[
+      jeff $ echo hi                                    |
                                                         |
       [Process exited 0]                                |
       -- TERMINAL --                                    |

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -50,6 +50,37 @@ describe(':terminal', function()
 
 end)
 
+describe(':terminal (with fake shell with arguments)', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(50, 4)
+    screen:attach({rgb=false})
+    -- shell-test.c is a fake shell that prints its arguments and exits.
+    nvim('set_option', 'shell', nvim_dir..'/shell-test -t jeff')
+    nvim('set_option', 'shellcmdflag', 'EXE')
+  end)
+
+  -- Invokes `:terminal {cmd}` using a fake shell (shell-test.c) which prints
+  -- the {cmd} and exits immediately .
+  local function terminal_with_fake_shell(cmd)
+    execute("terminal "..(cmd and cmd or ""))
+  end
+
+  it('with no argument, acts like termopen()', function()
+    terminal_with_fake_shell()
+    wait()
+    screen:expect([[
+      jeff $                                            |
+      [Process exited 0]                                |
+                                                        |
+      -- TERMINAL --                                    |
+    ]])
+  end)
+
+end)
+
 describe(':terminal (with fake shell)', function()
   local screen
 
@@ -67,17 +98,6 @@ describe(':terminal (with fake shell)', function()
   local function terminal_with_fake_shell(cmd)
     execute("terminal "..(cmd and cmd or ""))
   end
-
-  it('with no argument, acts like termopen()', function()
-    terminal_with_fake_shell()
-    wait()
-    screen:expect([[
-      ready $                                           |
-      [Process exited 0]                                |
-                                                        |
-      -- TERMINAL --                                    |
-    ]])
-  end)
 
   it('executes a given command through the shell', function()
     terminal_with_fake_shell('echo hi')

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -79,6 +79,18 @@ describe(':terminal (with fake shell)', function()
     ]])
   end)
 
+  it("with no argument, and 'shell' is set to empty string", function()
+    nvim('set_option', 'shell', '')
+    terminal_with_fake_shell()
+    wait()
+    screen:expect([[
+      ^                                                  |
+      ~                                                 |
+      ~                                                 |
+      E91: 'shell' option is empty                      |
+    ]])
+  end)
+
   it("with no argument, but 'shell' has arguments, acts like termopen()", function()
     nvim('set_option', 'shell', nvim_dir..'/shell-test -t jeff')
     terminal_with_fake_shell()


### PR DESCRIPTION
Fixes the default behaviour of `:term`, especially when arguments have been set as part of the `shell` setting. Fixes https://github.com/neovim/neovim/issues/3999
