### PR TITLE
[RDY] Fix condition for lazy loading remote plugins defintions

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -36,7 +36,7 @@ endfunction
 
 " Get a host channel, bootstrapping it if necessary
 function! remote#host#Require(name) abort
-  if empty(s:hosts)
+  if empty(s:plugins_for_host)
     call remote#host#LoadRemotePlugins()
   endif
   if !has_key(s:hosts, a:name)


### PR DESCRIPTION
Original condition is checking if hosts variable is empty and then calls method to include remote plugins manifest file.
Hosts variable is empty only when no hosts are defined, so that condition is either always false or makes no sense in the absence of any hosts.
Considering that plugins manifest file is full of calls to `remote#host#RegisterPlugin()`, which modifies content of `s:plugins_for_host`, i believe it is the variable that conditional should check.
