### PR TITLE
[RFC] terminal.c: temporary fix for incorrect paste handling

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -411,6 +411,10 @@ static int terminal_execute(VimState *state, int key)
       apply_autocmds(EVENT_FOCUSLOST, NULL, NULL, false, curbuf);
       break;
 
+    // Temporary fix until paste events gets implemented
+    case K_PASTE:
+      break;
+
     case K_LEFTMOUSE:
     case K_LEFTDRAG:
     case K_LEFTRELEASE:


### PR DESCRIPTION
A quick fix for #3476 that just ignores K_PASTE in terminal mode, until #4448 gets ready (the proper solution which will enable passing paste sequences through and so on). As the current behavior transmits invalid unicode into the PTY it is positively useless (Before, I somehow thought it just sent through the sequence unconditionally which would be kinda useful in some cases).
