### PR TITLE
[RFC] os/env.c: cosmetic changes, restrict pointers <del>and removal of two globals</del>

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -456,17 +456,37 @@ static char *vim_version_dir(const char *vimdir)
   return NULL;
 }
 
-/// If the string between "p" and "pend" ends in "name/", return "pend" minus
-/// the length of "name/".  Otherwise return "pend".
-static char *remove_tail(char *p, char *pend, char *name)
+/// If `dirname + "/"` precedes `pend` in the path, return the pointer to
+/// `dirname + "/" + pend`.  Otherwise return `pend`.
+///
+/// Examples (path = /usr/local/share/nvim/runtime/doc/help.txt):
+///
+///   pend    = help.txt
+///   dirname = doc
+///   -> doc/help.txt
+///
+///   pend    = doc/help.txt
+///   dirname = runtime
+///   -> runtime/doc/help.txt
+///
+///   pend    = runtime/doc/help.txt
+///   dirname = vim74
+///   -> runtime/doc/help.txt
+///
+/// @param path    Path to a file
+/// @param pend    A suffix of the path
+/// @param dirname The immediate path fragment before the pend
+/// @return The new pend including dirname or just pend
+static char *remove_tail(char *path, char *pend, char *dirname)
 {
-  size_t len = STRLEN(name) + 1;
-  char *newend = pend - len;
+  size_t len = STRLEN(dirname);
+  char *new_tail = pend - len - 1;
 
-  if (newend >= p
-      && fnamencmp((char_u *)newend, (char_u *)name, len - 1) == 0
-      && (newend == p || after_pathsep(p, newend)))
-    return newend;
+  if (new_tail >= path
+      && fnamencmp((char_u *)new_tail, (char_u *)dirname, len) == 0
+      && (new_tail == path || after_pathsep(path, new_tail))) {
+    return new_tail;
+  }
   return pend;
 }
 

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -147,7 +147,7 @@ static char_u   *homedir = NULL;
 
 void init_homedir(void)
 {
-  /* In case we are called a second time (when 'encoding' changes). */
+  // In case we are called a second time (when 'encoding' changes).
   xfree(homedir);
   homedir = NULL;
 
@@ -176,16 +176,16 @@ void init_homedir(void)
 
   if (var != NULL) {
 #ifdef UNIX
-    /*
-     * Change to the directory and get the actual path.  This resolves
-     * links.  Don't do it when we can't return.
-     */
+    // Change to the directory and get the actual path.  This resolves
+    // links.  Don't do it when we can't return.
     if (os_dirname(NameBuff, MAXPATHL) == OK
         && os_chdir((char *)NameBuff) == 0) {
-      if (!os_chdir((char *)var) && os_dirname(IObuff, IOSIZE) == OK)
+      if (!os_chdir((char *)var) && os_dirname(IObuff, IOSIZE) == OK) {
         var = IObuff;
-      if (os_chdir((char *)NameBuff) != 0)
+      }
+      if (os_chdir((char *)NameBuff) != 0) {
         EMSG(_(e_prev_dir));
+      }
     }
 #endif
     homedir = vim_strsave(var);
@@ -745,9 +745,10 @@ void home_replace(buf_T *buf, char_u *src, char_u *dst, int dstlen, bool one)
 /// @param src Input file name
 char_u * home_replace_save(buf_T *buf, char_u *src) FUNC_ATTR_NONNULL_RET
 {
-  size_t len = 3;                      /* space for "~/" and trailing NUL */
-  if (src != NULL)              /* just in case */
+  size_t len = 3;             // space for "~/" and trailing NUL
+  if (src != NULL) {          // just in case
     len += STRLEN(src);
+  }
   char_u *dst = xmalloc(len);
   home_replace(buf, src, dst, (int)len, true);
   return dst;
@@ -783,8 +784,7 @@ char_u *get_env_name(expand_T *xp, int idx)
     STRLCPY(name, envname, ENVNAMELEN);
     xfree(envname);
     return name;
-  } else {
-    return NULL;
   }
+  return NULL;
 }
 


### PR DESCRIPTION
- declare `srcp` and `dst` as restrict in `expand_env_esc()`
- document `remove_tail()` properly
- Remove `didset_vim` and `didset_vimruntime` globals
