### PR TITLE
[RFC] Cosmetic changes in doc/vim_diff.txt

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -21,10 +21,10 @@ these differences.
 ==============================================================================
 1. Configuration					    *nvim-configuration*
 
-- Use `$XDG_CONFIG_HOME/nvim/init.vim` instead of `.vimrc` for storing 
+- Use `$XDG_CONFIG_HOME/nvim/init.vim` instead of `.vimrc` for storing
   configuration.
 - Use `$XDG_CONFIG_HOME/nvim` instead of `.vim` to store configuration files.
-- Use `$XDG_DATA_HOME/nvim/shada/main.shada` instead of `.viminfo` for persistent 
+- Use `$XDG_DATA_HOME/nvim/shada/main.shada` instead of `.viminfo` for persistent
   session information.
 
 ==============================================================================
@@ -73,56 +73,56 @@ are always available and may be used simultaneously in separate plugins.  The
 |nvim-python|).
 
 |mkdir()| behaviour changed:
-1. Assuming /tmp/foo does not exist and /tmp can be written to 
+1. Assuming /tmp/foo does not exist and /tmp can be written to
    mkdir('/tmp/foo/bar', 'p', 0700) will create both /tmp/foo and /tmp/foo/bar 
    with 0700 permissions. Vim mkdir will create /tmp/foo with 0755.
-2. If you try to create an existing directory with `'p'` (e.g. mkdir('/', 
+2. If you try to create an existing directory with `'p'` (e.g. mkdir('/',
    'p')) mkdir() will silently exit. In Vim this was an error.
 3. mkdir() error messages now include strerror() text when mkdir fails.
 
 'encoding' cannot be changed after startup.
 
 |string()| and |:echo| behaviour changed:
-1. No maximum recursion depth limit is applied to nested container 
+1. No maximum recursion depth limit is applied to nested container
    structures.
-2. |string()| fails immediately on nested containers, not when recursion limit 
+2. |string()| fails immediately on nested containers, not when recursion limit
    was exceeded.
 2. When |:echo| encounters duplicate containers like >
 
        let l = []
        echo [l, l]
 <
-   it does not use "[...]" (was: "[[], [...]]", now: "[[], []]"). "..." is 
+   it does not use "[...]" (was: "[[], [...]]", now: "[[], []]"). "..." is
    only used for recursive containers.
-3. |:echo| printing nested containers adds "@level" after "..." designating 
-   the level at which recursive container was printed: |:echo-self-refer|.  
-   Same thing applies to |string()| (though it uses construct like 
-   "{E724@level}"), but this is not reliable because |string()| continues to 
+3. |:echo| printing nested containers adds "@level" after "..." designating
+   the level at which recursive container was printed: |:echo-self-refer|.
+   Same thing applies to |string()| (though it uses construct like
+   "{E724@level}"), but this is not reliable because |string()| continues to
    error out.
-4. Stringifyed infinite and NaN values now use |str2float()| and can be evaled 
+4. Stringifyed infinite and NaN values now use |str2float()| and can be evaled
    back.
 
-Viminfo text files were replaced with binary (messagepack) ShaDa files. 
+Viminfo text files were replaced with binary (messagepack) ShaDa files.
 Additional differences:
 
 - |shada-c| has no effect.
 - |shada-s| now limits size of every item and not just registers.
-- When reading ShaDa files items are merged according to the timestamp. 
+- When reading ShaDa files items are merged according to the timestamp.
   |shada-merging|
-- 'viminfo' option got renamed to 'shada'. Old option is kept as an alias for 
+- 'viminfo' option got renamed to 'shada'. Old option is kept as an alias for
   compatibility reasons.
-- |:wviminfo| was renamed to |:wshada|, |:rviminfo| to |:rshada|.  Old 
+- |:wviminfo| was renamed to |:wshada|, |:rviminfo| to |:rshada|.  Old
   commands are still kept.
 - |:oldfiles| supports !.
-- When writing (|:wshada| without bang or at exit) it merges much more data, 
-  and does this according to the timestamp.  Vim merges only marks. 
+- When writing (|:wshada| without bang or at exit) it merges much more data,
+  and does this according to the timestamp.  Vim merges only marks.
   |shada-merging|
-- ShaDa file format was designed with forward and backward compatibility in 
+- ShaDa file format was designed with forward and backward compatibility in
   mind. |shada-compatibility|
-- Some errors make ShaDa code keep temporary file in-place for user to decide 
-  what to do with it.  Vim deletes temporary file in these cases. 
+- Some errors make ShaDa code keep temporary file in-place for user to decide
+  what to do with it.  Vim deletes temporary file in these cases.
   |shada-error-handling|
-- Vim keeps no timestamps at all, neither in viminfo file nor in the instance 
+- Vim keeps no timestamps at all, neither in viminfo file nor in the instance
   itself.
 - ShaDa file keeps search direction (|v:searchforward|), viminfo does not.
 
@@ -141,8 +141,8 @@ Meta (alt) chords are recognized (even in the terminal).
 
   Note: Meta chords are case-sensitive (<M-a> is distinguished from <M-A>).
 
-Some `CTRL-SHIFT-...` key chords are distinguished from `CTRL-...` variants (even in
-the terminal). Specifically, the following are known to work:
+Some `CTRL-SHIFT-...` key chords are distinguished from `CTRL-...` variants
+(even in the terminal). Specifically, the following are known to work:
   <C-Tab>, <C-S-Tab>
   <C-BS>, <C-S-BS>
   <C-Enter>, <C-S-Enter>


### PR DESCRIPTION
Rewrapped line that was too long and removed trailing whitespace.
