### PR TITLE
vim-patch.sh: Fetch the whole vim repository and fix a regexp

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -65,7 +65,7 @@ get_vim_sources() {
 
   if [[ ! -d ${VIM_SOURCE_DIR} ]]; then
     echo "Cloning Vim sources into '${VIM_SOURCE_DIR}'."
-    git clone --depth=1000 https://github.com/vim/vim.git "${VIM_SOURCE_DIR}"
+    git clone https://github.com/vim/vim.git "${VIM_SOURCE_DIR}"
     cd "${VIM_SOURCE_DIR}"
   else
     if [[ ! -d "${VIM_SOURCE_DIR}/.git" ]]; then
@@ -243,7 +243,7 @@ list_vim_patches() {
       local patch_number="${vim_tag:5}" # Remove prefix like "v7.4."
       # Tagged Vim patch, check version.c:
       is_missing="$(sed -n '/static int included_patches/,/}/p' "${NEOVIM_SOURCE_DIR}/src/nvim/version.c" |
-        grep -x -e "[[:space:]]*//[[:space:]]${patch_number} NA" -e "[[:space:]]*${patch_number}," >/dev/null && echo "false" || echo "true")"
+        grep -x -e "[[:space:]]*//[[:space:]]${patch_number} NA.*" -e "[[:space:]]*${patch_number}," >/dev/null && echo "false" || echo "true")"
       vim_commit="${vim_tag#v}"
     else
       # Untagged Vim patch (e.g. runtime updates), check the Neovim git log:


### PR DESCRIPTION
Make get_vim_sources fetch the whole repository (it's not THAT big) so we can
pick up all the patches. The regexp didn't pick up the NA patches if there was a
comma after NA, so I extended it (I allowed arbitray things after NA, so maybe
someone can write a comment or so, should not lead to confusion).

Fixes https://github.com/neovim/neovim/issues/4539.
