### PR TITLE
Add support for ranges to remote function definitions

### DIFF
--- a/runtime/autoload/remote/define.vim
+++ b/runtime/autoload/remote/define.vim
@@ -1,7 +1,7 @@
 function! remote#define#CommandOnHost(host, method, sync, name, opts)
   let prefix = ''
 
-  if has_key(a:opts, 'range') 
+  if has_key(a:opts, 'range')
     if a:opts.range == '' || a:opts.range == '%'
       " -range or -range=%, pass the line range in a list
       let prefix = '<line1>,<line2>'
@@ -157,6 +157,9 @@ endfunction
 
 function! remote#define#FunctionOnChannel(channel, method, sync, name, opts)
   let rpcargs = [a:channel, '"'.a:method.'"', 'a:000']
+  if has_key(a:opts, 'range') && a:opts.range != '0'
+    call add(rpcargs, '[a:firstline, a:lastline]')
+  endif
   call s:AddEval(rpcargs, a:opts)
 
   let function_def = s:GetFunctionPrefix(a:name, a:opts)
@@ -187,7 +190,7 @@ let s:next_gid = 1
 function! s:GetNextAutocmdGroup()
   let gid = s:next_gid
   let s:next_gid += 1
-  
+
   let group_name = 'RPC_DEFINE_AUTOCMD_GROUP_'.gid
   " Ensure the group is defined
   exe 'augroup '.group_name.' | augroup END'
@@ -218,7 +221,11 @@ endfunction
 
 
 function! s:GetFunctionPrefix(name, opts)
-  return "function! ".a:name."(...)\n"
+  let res = "function! ".a:name."(...)"
+  if has_key(a:opts, 'range') && a:opts.range != '0'
+    let res = res." range"
+  endif
+  return res."\n"
 endfunction
 
 

--- a/runtime/autoload/remote/define.vim
+++ b/runtime/autoload/remote/define.vim
@@ -157,7 +157,7 @@ endfunction
 
 function! remote#define#FunctionOnChannel(channel, method, sync, name, opts)
   let rpcargs = [a:channel, '"'.a:method.'"', 'a:000']
-  if has_key(a:opts, 'range') && a:opts.range != '0'
+  if has_key(a:opts, 'range')
     call add(rpcargs, '[a:firstline, a:lastline]')
   endif
   call s:AddEval(rpcargs, a:opts)
@@ -222,7 +222,7 @@ endfunction
 
 function! s:GetFunctionPrefix(name, opts)
   let res = "function! ".a:name."(...)"
-  if has_key(a:opts, 'range') && a:opts.range != '0'
+  if has_key(a:opts, 'range')
     let res = res." range"
   endif
   return res."\n"

--- a/test/functional/provider/define_spec.lua
+++ b/test/functional/provider/define_spec.lua
@@ -64,153 +64,137 @@ local function command_specs_for(fn, sync, first_arg_factory, init)
         args = args..', "RpcCommand"'
       end)
 
-      describe('without options', function()
-        it('ok', function()
-          call(fn, args..', {}')
-          local function on_setup()
-            command('RpcCommand')
-          end
+      it('without options', function()
+        call(fn, args..', {}')
+        local function on_setup()
+          command('RpcCommand')
+        end
 
-          local function handler(method)
-            eq('test-handler', method)
-            return ''
-          end
+        local function handler(method)
+          eq('test-handler', method)
+          return ''
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
 
-      describe('with nargs', function()
-        it('ok', function()
-          call(fn, args..', {"nargs": "*"}')
-          local function on_setup()
-            command('RpcCommand arg1 arg2 arg3')
-          end
+      it('with nargs', function()
+        call(fn, args..', {"nargs": "*"}')
+        local function on_setup()
+          command('RpcCommand arg1 arg2 arg3')
+        end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq({'arg1', 'arg2', 'arg3'}, arguments[1])
-            return ''
-          end
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({'arg1', 'arg2', 'arg3'}, arguments[1])
+          return ''
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
 
-      describe('with range', function()
-        it('ok', function()
-          call(fn,args..', {"range": ""}')
-          local function on_setup()
-            command('1,1RpcCommand')
-          end
+      it('with range', function()
+        call(fn,args..', {"range": ""}')
+        local function on_setup()
+          command('1,1RpcCommand')
+        end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq({1, 1}, arguments[1])
-            return ''
-          end
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({1, 1}, arguments[1])
+          return ''
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
 
-      describe('with nargs/range', function()
-        it('ok', function()
-          call(fn, args..', {"nargs": "1", "range": ""}')
-          local function on_setup()
-            command('1,1RpcCommand arg')
-          end
+      it('with nargs/range', function()
+        call(fn, args..', {"nargs": "1", "range": ""}')
+        local function on_setup()
+          command('1,1RpcCommand arg')
+        end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq({'arg'}, arguments[1])
-            eq({1, 1}, arguments[2])
-            return ''
-          end
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({'arg'}, arguments[1])
+          eq({1, 1}, arguments[2])
+          return ''
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
 
-      describe('with nargs/count', function()
-        it('ok', function()
-          call(fn, args..', {"nargs": "1", "range": "5"}')
-          local function on_setup()
-            command('5RpcCommand arg')
-          end
+      it('with nargs/count', function()
+        call(fn, args..', {"nargs": "1", "range": "5"}')
+        local function on_setup()
+          command('5RpcCommand arg')
+        end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq({'arg'}, arguments[1])
-            eq(5, arguments[2])
-            return ''
-          end
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({'arg'}, arguments[1])
+          eq(5, arguments[2])
+          return ''
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
 
-      describe('with nargs/count/bang', function()
-        it('ok', function()
-          call(fn, args..', {"nargs": "1", "range": "5", "bang": ""}')
-          local function on_setup()
-            command('5RpcCommand! arg')
-          end
+      it('with nargs/count/bang', function()
+        call(fn, args..', {"nargs": "1", "range": "5", "bang": ""}')
+        local function on_setup()
+          command('5RpcCommand! arg')
+        end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq({'arg'}, arguments[1])
-            eq(5, arguments[2])
-            eq(1, arguments[3])
-            return ''
-          end
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({'arg'}, arguments[1])
+          eq(5, arguments[2])
+          eq(1, arguments[3])
+          return ''
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
 
-      describe('with nargs/count/bang/register', function()
-        it('ok', function()
-          call(fn, args..', {"nargs": "1", "range": "5", "bang": "",'..
-                     ' "register": ""}')
-          local function on_setup()
-            command('5RpcCommand! b arg')
-          end
+      it('with nargs/count/bang/register', function()
+        call(fn, args..', {"nargs": "1", "range": "5", "bang": "",'..
+        ' "register": ""}')
+        local function on_setup()
+          command('5RpcCommand! b arg')
+        end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq({'arg'}, arguments[1])
-            eq(5, arguments[2])
-            eq(1, arguments[3])
-            eq('b', arguments[4])
-            return ''
-          end
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({'arg'}, arguments[1])
+          eq(5, arguments[2])
+          eq(1, arguments[3])
+          eq('b', arguments[4])
+          return ''
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
 
-      describe('with nargs/count/bang/register/eval', function()
-        it('ok', function()
-          call(fn, args..', {"nargs": "1", "range": "5", "bang": "",'..
-                     ' "register": "", "eval": "@<reg>"}')
-          local function on_setup()
-            command('let @b = "regb"')
-            command('5RpcCommand! b arg')
-          end
+      it('with nargs/count/bang/register/eval', function()
+        call(fn, args..', {"nargs": "1", "range": "5", "bang": "",'..
+        ' "register": "", "eval": "@<reg>"}')
+        local function on_setup()
+          command('let @b = "regb"')
+          command('5RpcCommand! b arg')
+        end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq({'arg'}, arguments[1])
-            eq(5, arguments[2])
-            eq(1, arguments[3])
-            eq('b', arguments[4])
-            eq('regb', arguments[5])
-            return ''
-          end
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({'arg'}, arguments[1])
+          eq(5, arguments[2])
+          eq(1, arguments[3])
+          eq('b', arguments[4])
+          eq('regb', arguments[5])
+          return ''
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
     end)
   end)
@@ -236,37 +220,33 @@ local function autocmd_specs_for(fn, sync, first_arg_factory, init)
         args = args..', "BufEnter"'
       end)
 
-      describe('without options', function()
-        it('ok', function()
-          call(fn, args..', {}')
-          local function on_setup()
-            command('doautocmd BufEnter x.c')
-          end
+      it('without options', function()
+        call(fn, args..', {}')
+        local function on_setup()
+          command('doautocmd BufEnter x.c')
+        end
 
-          local function handler(method)
-            eq('test-handler', method)
-            return ''
-          end
+        local function handler(method)
+          eq('test-handler', method)
+          return ''
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
 
-      describe('with eval', function()
-        it('ok', function()
-          call(fn, args..[[, {'eval': 'expand("<afile>")'}]])
-          local function on_setup()
-            command('doautocmd BufEnter x.c')
-          end
+      it('with eval', function()
+        call(fn, args..[[, {'eval': 'expand("<afile>")'}]])
+        local function on_setup()
+          command('doautocmd BufEnter x.c')
+        end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq('x.c', arguments[1])
-            return ''
-          end
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq('x.c', arguments[1])
+          return ''
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
     end)
   end)
@@ -292,79 +272,72 @@ local function function_specs_for(fn, sync, first_arg_factory, init)
         args = args..', "TestFunction"'
       end)
 
-      describe('without options', function()
-        it('ok', function()
-          call(fn, args..', {}')
-          local function on_setup()
-            if sync then
-              eq('rv', eval('TestFunction(1, "a", ["b", "c"])'))
-            else
-              eq(1, eval('TestFunction(1, "a", ["b", "c"])'))
-            end
+      it('without options', function()
+        call(fn, args..', {}')
+        local function on_setup()
+          if sync then
+            eq('rv', eval('TestFunction(1, "a", ["b", "c"])'))
+          else
+            eq(1, eval('TestFunction(1, "a", ["b", "c"])'))
           end
+        end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq({{1, 'a', {'b', 'c'}}}, arguments)
-            return 'rv'
-          end
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({{1, 'a', {'b', 'c'}}}, arguments)
+          return 'rv'
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
 
-      describe('with eval', function()
-        it('ok', function()
-          call(fn, args..[[, {'eval': '2 + 2'}]])
-          local function on_setup()
-            if sync then
-              eq('rv', eval('TestFunction(1, "a", ["b", "c"])'))
-            else
-              eq(1, eval('TestFunction(1, "a", ["b", "c"])'))
-            end
+      it('with eval', function()
+        call(fn, args..[[, {'eval': '2 + 2'}]])
+        local function on_setup()
+          if sync then
+            eq('rv', eval('TestFunction(1, "a", ["b", "c"])'))
+          else
+            eq(1, eval('TestFunction(1, "a", ["b", "c"])'))
           end
+        end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq({{1, 'a', {'b', 'c'}}, 4}, arguments)
-            return 'rv'
-          end
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({{1, 'a', {'b', 'c'}}, 4}, arguments)
+          return 'rv'
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
 
-      describe('with range', function()
-        it('ok', function()
-          call(fn, args..[[, {'range': ''}]])
-          local function on_setup()
-            command('%call TestFunction(1, "a", ["b", "c"])')
-          end
+      it('with range', function()
+        call(fn, args..[[, {'range': ''}]])
+        local function on_setup()
+          command('%call TestFunction(1, "a", ["b", "c"])')
+        end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq({{1, 'a', {'b', 'c'}}, {1, 1}}, arguments)
-            return 'rv'
-          end
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({{1, 'a', {'b', 'c'}}, {1, 1}}, arguments)
+          return 'rv'
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        runx(sync, handler, on_setup)
       end)
-      describe('with eval/range', function()
-        it('ok', function()
-          call(fn, args..[[, {'eval': '4', 'range': ''}]])
-          local function on_setup()
-            command('%call TestFunction(1, "a", ["b", "c"])')
-          end
 
-          local function handler(method, arguments)
-            eq('test-handler', method)
-            eq({{1, 'a', {'b', 'c'}}, {1, 1}, 4}, arguments)
-            return 'rv'
-          end
+      it('with eval/range', function()
+        call(fn, args..[[, {'eval': '4', 'range': ''}]])
+        local function on_setup()
+          command('%call TestFunction(1, "a", ["b", "c"])')
+        end
 
-          runx(sync, handler, on_setup)
-        end)
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({{1, 'a', {'b', 'c'}}, {1, 1}, 4}, arguments)
+          return 'rv'
+        end
+
+        runx(sync, handler, on_setup)
       end)
     end)
   end)

--- a/test/functional/provider/define_spec.lua
+++ b/test/functional/provider/define_spec.lua
@@ -333,6 +333,39 @@ local function function_specs_for(fn, sync, first_arg_factory, init)
           runx(sync, handler, on_setup)
         end)
       end)
+
+      describe('with range', function()
+        it('ok', function()
+          call(fn, args..[[, {'range': ''}]])
+          local function on_setup()
+            command('%call TestFunction(1, "a", ["b", "c"])')
+          end
+
+          local function handler(method, arguments)
+            eq('test-handler', method)
+            eq({{1, 'a', {'b', 'c'}}, {1, 1}}, arguments)
+            return 'rv'
+          end
+
+          runx(sync, handler, on_setup)
+        end)
+      end)
+      describe('with eval/range', function()
+        it('ok', function()
+          call(fn, args..[[, {'eval': '4', 'range': ''}]])
+          local function on_setup()
+            command('%call TestFunction(1, "a", ["b", "c"])')
+          end
+
+          local function handler(method, arguments)
+            eq('test-handler', method)
+            eq({{1, 'a', {'b', 'c'}}, {1, 1}, 4}, arguments)
+            return 'rv'
+          end
+
+          runx(sync, handler, on_setup)
+        end)
+      end)
     end)
   end)
 end


### PR DESCRIPTION
Continuing the work done in #3259, this allows remote functions to handle the `range` modifier.
