### PR TITLE
[RFC] cscope: Fix mismatched types in ':cscope show' output

### DIFF
--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -2081,12 +2081,13 @@ static int cs_show(exarg_T *eap)
       if (csinfo[i].fname == NULL)
         continue;
 
-      if (csinfo[i].ppath != NULL)
-        (void)smsg("%2zu %-5" PRId64 "  %-34s  %-32s",
-            i, (long)csinfo[i].pid, csinfo[i].fname, csinfo[i].ppath);
-      else
-        (void)smsg("%2zu %-5" PRId64 "  %-34s  <none>",
-            i, (long)csinfo[i].pid, csinfo[i].fname);
+      if (csinfo[i].ppath != NULL) {
+        (void)smsg("%2zu %-5" PRId64 "  %-34s  %-32s", i,
+                   (int64_t)csinfo[i].pid, csinfo[i].fname, csinfo[i].ppath);
+      } else {
+        (void)smsg("%2zu %-5" PRId64 "  %-34s  <none>", i,
+                   (int64_t)csinfo[i].pid, csinfo[i].fname);
+      }
     }
   }
 


### PR DESCRIPTION
`cs_show` passes an argument of type `long` in a variable-argument function along with a format spec that expects (and fetches from the va_list) `long long`. This is a problem on 32-bit systems where long = 32 bits, and so the wrong amount of data is pulled from the va_list.

Fixes #4537
