### PR TITLE
vim-patch:f2571c

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2015 Apr 06
+" Last Change:	2015 Jun 06
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")

--- a/runtime/ftplugin/spec.vim
+++ b/runtime/ftplugin/spec.vim
@@ -2,7 +2,7 @@
 " Filename: spec.vim
 " Maintainer: Igor Gnatenko i.gnatenko.brain@gmail.com
 " Former Maintainer: Gustavo Niemeyer <niemeyer@conectiva.com> (until March 2014)
-" Last Change: Fri Feb 20 16:01 MSK 2014 Igor Gnatenko
+" Last Change: Mon Jun 01 21:15 MSK 2015 Igor Gnatenko
 
 if exists("b:did_ftplugin")
 	finish

--- a/runtime/syntax/cpp.vim
+++ b/runtime/syntax/cpp.vim
@@ -2,7 +2,7 @@
 " Language:	C++
 " Current Maintainer:	vim-jp (https://github.com/vim-jp/vim-cpp)
 " Previous Maintainer:	Ken Shan <ccshan@post.harvard.edu>
-" Last Change:	2015 Mar 1
+" Last Change:	2015 May 04
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
@@ -46,7 +46,7 @@ if !exists("cpp_no_cpp11")
   syn keyword cppConstant	ATOMIC_WCHAR_T_LOCK_FREE ATOMIC_SHORT_LOCK_FREE
   syn keyword cppConstant	ATOMIC_INT_LOCK_FREE ATOMIC_LONG_LOCK_FREE
   syn keyword cppConstant	ATOMIC_LLONG_LOCK_FREE ATOMIC_POINTER_LOCK_FREE
-  syn region cppRawString	matchgroup=cppRawDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"+ contains=@Spell
+  syn region cppRawString	matchgroup=cppRawStringDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"+ contains=@Spell
 endif
 
 " The minimum and maximum operators in GNU C++

--- a/runtime/syntax/groovy.vim
+++ b/runtime/syntax/groovy.vim
@@ -2,9 +2,9 @@
 " Language:	Groovy
 " Original Author:	Alessio Pace <billy.corgan@tiscali.it>
 " Maintainer:	Tobias Rapp <yahuxo@gmx.de>
-" Version: 	0.1.13
+" Version: 	0.1.14
 " URL:	  http://www.vim.org/scripts/script.php?script_id=945
-" Last Change:	2015 Apr 13
+" Last Change:	2015 Apr 21
 
 " THE ORIGINAL AUTHOR'S NOTES:
 "


### PR DESCRIPTION
Updated runtime files.

https://github.com/vim/vim/commit/f2571c61d5aa05682ae4d358e625348b61adc861

https://github.com/neovim/neovim/commit/975a61 had merged parts of this commit out of order. This patch only includes a `cppRawString` syntax change and updates some dates in the comments.
