### PR TITLE
[RDY] atomic multi request for async remote plugins

### DIFF
--- a/scripts/gendispatch.lua
+++ b/scripts/gendispatch.lua
@@ -246,7 +246,7 @@ for i = 1, #functions do
   if fn.impl_name == nil then
     local args = {}
 
-    output:write('Object handle_'..fn.name..'(uint64_t channel_id, uint64_t request_id, Array args, Error *error)')
+    output:write('Object handle_'..fn.name..'(uint64_t channel_id, Array args, Error *error)')
     output:write('\n{')
     output:write('\n  Object ret = NIL;')
     -- Declare/initialize variables that will hold converted arguments

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -191,7 +191,7 @@ ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
     Object str = STRING_OBJ(cstr_to_string(bufstr));
 
     // Vim represents NULs as NLs, but this may confuse clients.
-    if (channel_id != INVALID_CHANNEL) {
+    if (channel_id != INTERNAL_CALL) {
       strchrsub(str.data.string.data, '\n', '\0');
     }
 
@@ -312,7 +312,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
     // line and convert NULs to newlines to avoid truncation.
     lines[i] = xmallocz(l.size);
     for (size_t j = 0; j < l.size; j++) {
-      if (l.data[j] == '\n' && channel_id != INVALID_CHANNEL) {
+      if (l.data[j] == '\n' && channel_id != INTERNAL_CALL) {
         api_set_error(err, Exception, _("string cannot contain newlines"));
         new_len = i + 1;
         goto end;

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -33,8 +33,8 @@ typedef enum {
 /// Used as the message ID of notifications.
 #define NO_RESPONSE UINT64_MAX
 
-/// Used as channel_id when the call is local
-#define INVALID_CHANNEL UINT64_MAX
+/// Used as channel_id when the call is local.
+#define INTERNAL_CALL UINT64_MAX
 
 typedef struct {
   ErrorType type;

--- a/src/nvim/api/private/dispatch.h
+++ b/src/nvim/api/private/dispatch.h
@@ -4,7 +4,6 @@
 #include "nvim/api/private/defs.h"
 
 typedef Object (*ApiDispatchWrapper)(uint64_t channel_id,
-                                     uint64_t request_id,
                                      Array args,
                                      Error *error);
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7133,7 +7133,7 @@ static void api_wrapper(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   Error err = ERROR_INIT;
-  Object result = fn(INVALID_CHANNEL, NO_RESPONSE, args, &err);
+  Object result = fn(INTERNAL_CALL, args, &err);
 
   if (err.set) {
     nvim_err_writeln(cstr_as_string(err.msg));

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -452,7 +452,7 @@ static void on_request_event(void **argv)
   Array args = e->args;
   uint64_t request_id = e->request_id;
   Error error = ERROR_INIT;
-  Object result = handler.fn(channel->id, request_id, args, &error);
+  Object result = handler.fn(channel->id, args, &error);
   if (request_id != NO_RESPONSE) {
     // send the response
     msgpack_packer response;

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -455,7 +455,6 @@ void msgpack_rpc_from_dictionary(Dictionary result, msgpack_packer *res)
 
 /// Handler executed when an invalid method name is passed
 Object msgpack_rpc_handle_missing_method(uint64_t channel_id,
-                                         uint64_t request_id,
                                          Array args,
                                          Error *error)
 {
@@ -466,7 +465,6 @@ Object msgpack_rpc_handle_missing_method(uint64_t channel_id,
 
 /// Handler executed when malformated arguments are passed
 Object msgpack_rpc_handle_invalid_arguments(uint64_t channel_id,
-                                            uint64_t request_id,
                                             Array args,
                                             Error *error)
 {


### PR DESCRIPTION
Based on @ZyX-I:s suggestion https://github.com/neovim/neovim/pull/4411#issuecomment-205972405 this allows a rpc client to send a list of requests for evaluation at once. This allows "atomic" execution from an external async context (of course, any request that can lead to the execution of vimscript can and will have side-effects in the middle of executing the multi request). Even if `set_var` and `del_var` is changed to not return the oldvalue as suggested in #4411 the old behavior can be kept by bundling a "get_var" and "set_var" request

To support simple test-and-set behavior, it is possible to assert the return value of a request and abort the execution. For anything more complicated it is better to inject some vimscript (or lua) and let it do it.

The argument is an array of `[methodname, args, sendreturn{, assertreturn}]` entries.
simple example:

```
vim.api.multi_request([['vim_eval', ['3+3'], False, 6],
                       ['vim_get_current_line', [], True]])
```

It could be possible to do something like first

```
get_lines [buffer, -1]
get_linecount [buffer]  
get_var [buffer, "changedtick"]
```

and then

```
get_var [buffer, "changedtick"] False oldchangedtick
set_lines [buffer, linenr, oldtext+newtext]
add_highlight [buffer, linenr, ...]
```

So that the update to the buffer is only done if the buffer was unchanged. The first return value is the number of successful request to this condition can be detected.

Bikeshed of the api and return format welcome. It is quite-low level, but the intention is mainly for client/hosts implementations that can export nicer APIs like  `list.pop` and `dict.pop` in the case of python, to plugins.
