### PR TITLE
[RFC] mbyte.c: Fix invalid memory access in utfc_ptr2char_len

### DIFF
--- a/test/unit/mbyte_spec.lua
+++ b/test/unit/mbyte_spec.lua
@@ -11,8 +11,8 @@ describe('mbyte', function()
   -- Array for composing characters
   local intp = ffi.typeof('int[?]')
   local function to_intp()
-      -- how to get MAX_MCO from globals.h?
-      return intp(7, 1)
+    -- how to get MAX_MCO from globals.h?
+    return intp(7, 1)
   end
 
   -- Convert from bytes to string
@@ -30,7 +30,7 @@ describe('mbyte', function()
   it('utf_ptr2char', function()
     -- For strings with length 1 the first byte is returned.
     for c = 0, 255 do
-        eq(c, mbyte.utf_ptr2char(to_string({c, 0})))
+      eq(c, mbyte.utf_ptr2char(to_string({c, 0})))
     end
 
     -- Some ill formed byte sequences that should not be recognized as UTF-8
@@ -48,8 +48,8 @@ describe('mbyte', function()
     it('1-byte sequences', function()
       local pcc = to_intp()
       for c = 0, 255 do
-          eq(c, mbyte.utfc_ptr2char_len(to_string({c}), pcc, 1))
-          eq(0, pcc[0])
+        eq(c, mbyte.utfc_ptr2char_len(to_string({c}), pcc, 1))
+        eq(0, pcc[0])
       end
     end)
 
@@ -187,7 +187,7 @@ describe('mbyte', function()
       -- Combining characters U+0300, U+0301, U+0302, U+0303, U+0304
       local pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
-          {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84}), pcc, 11))
+        {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84}), pcc, 11))
       eq(0x0300, pcc[0])
       eq(0x0301, pcc[1])
       eq(0x0302, pcc[2])
@@ -198,7 +198,7 @@ describe('mbyte', function()
       -- U+0305
       local pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
-          {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84, 0xcc, 0x85}), pcc, 13))
+        {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84, 0xcc, 0x85}), pcc, 13))
       eq(0x0300, pcc[0])
       eq(0x0301, pcc[1])
       eq(0x0302, pcc[2])
@@ -211,7 +211,7 @@ describe('mbyte', function()
       -- U+0305, U+0306, but only save six (= MAX_MCO).
       local pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
-          {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84, 0xcc, 0x85, 0xcc, 0x86}), pcc, 15))
+        {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84, 0xcc, 0x85, 0xcc, 0x86}), pcc, 15))
       eq(0x0300, pcc[0])
       eq(0x0301, pcc[1])
       eq(0x0302, pcc[2])
@@ -223,7 +223,7 @@ describe('mbyte', function()
       -- Only three following combining characters U+0300, U+0301, U+0302
       local pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
-          {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xc2, 0x80, 0xcc, 0x84, 0xcc, 0x85}), pcc, 13))
+        {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xc2, 0x80, 0xcc, 0x84, 0xcc, 0x85}), pcc, 13))
       eq(0x0300, pcc[0])
       eq(0x0301, pcc[1])
       eq(0x0302, pcc[2])
@@ -266,7 +266,7 @@ describe('mbyte', function()
       -- Combining characters U+1AB0 and U+0301
       local pcc = to_intp()
       eq(0x100000, mbyte.utfc_ptr2char_len(to_string(
-          {0xf4, 0x80, 0x80, 0x80, 0xe1, 0xaa, 0xb0, 0xcc, 0x81}), pcc, 9))
+        {0xf4, 0x80, 0x80, 0x80, 0xe1, 0xaa, 0xb0, 0xcc, 0x81}), pcc, 9))
       eq(0x1ab0, pcc[0])
       eq(0x0301, pcc[1])
       eq(0x0000, pcc[2])

--- a/test/unit/mbyte_spec.lua
+++ b/test/unit/mbyte_spec.lua
@@ -1,0 +1,277 @@
+local helpers = require("test.unit.helpers")
+
+local ffi     = helpers.ffi
+local eq      = helpers.eq
+
+local globals = helpers.cimport("./src/nvim/globals.h")
+local mbyte = helpers.cimport("./src/nvim/mbyte.h")
+
+describe('mbyte', function()
+
+  -- Array for composing characters
+  local intp = ffi.typeof('int[?]')
+  local function to_intp()
+      -- how to get MAX_MCO from globals.h?
+      return intp(7, 1)
+  end
+
+  -- Convert from bytes to string
+  local function to_string(bytes)
+    s = {}
+    for i = 1, #bytes do
+      s[i] = string.char(bytes[i])
+    end
+    return table.concat(s)
+  end
+
+  before_each(function()
+  end)
+
+  it('utf_ptr2char', function()
+    -- For strings with length 1 the first byte is returned.
+    for c = 0, 255 do
+        eq(c, mbyte.utf_ptr2char(to_string({c, 0})))
+    end
+
+    -- Some ill formed byte sequences that should not be recognized as UTF-8
+    -- First byte: 0xc0 or 0xc1
+    -- Second byte: 0x80 .. 0xbf
+    --eq(0x00c0, mbyte.utf_ptr2char(to_string({0xc0, 0x80})))
+    --eq(0x00c1, mbyte.utf_ptr2char(to_string({0xc1, 0xbf})))
+    --
+    -- Sequences with more than four bytes
+  end)
+
+
+  describe('utfc_ptr2char_len', function()
+
+    it('1-byte sequences', function()
+      local pcc = to_intp()
+      for c = 0, 255 do
+          eq(c, mbyte.utfc_ptr2char_len(to_string({c}), pcc, 1))
+          eq(0, pcc[0])
+      end
+    end)
+
+    it('2-byte sequences', function()
+      local pcc = to_intp()
+      -- No combining characters
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0x7f}), pcc, 2))
+      eq(0, pcc[0])
+      -- No combining characters
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0x80}), pcc, 2))
+      eq(0, pcc[0])
+
+      -- No UTF-8 sequence
+      local pcc = to_intp()
+      eq(0x00c2, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x7f}), pcc, 2))
+      eq(0, pcc[0])
+      -- One UTF-8 character
+      local pcc = to_intp()
+      eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80}), pcc, 2))
+      eq(0, pcc[0])
+      -- No UTF-8 sequence
+      local pcc = to_intp()
+      eq(0x00c2, mbyte.utfc_ptr2char_len(to_string({0xc2, 0xc0}), pcc, 2))
+      eq(0, pcc[0])
+    end)
+
+    it('3-byte sequences', function()
+      local pcc = to_intp()
+
+      -- No second UTF-8 character
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0x80, 0x80}), pcc, 3))
+      eq(0, pcc[0])
+      -- No combining character
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xc2, 0x80}), pcc, 3))
+      eq(0, pcc[0])
+
+      -- Combining character is U+0300
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80}), pcc, 3))
+      eq(0x0300, pcc[0])
+      eq(0x0000, pcc[1])
+
+      -- No UTF-8 sequence
+      local pcc = to_intp()
+      eq(0x00c2, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x7f, 0xcc}), pcc, 3))
+      eq(0, pcc[0])
+      -- Incomplete combining character
+      local pcc = to_intp()
+      eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc}), pcc, 3))
+      eq(0, pcc[0])
+
+      -- One UTF-8 character
+      local pcc = to_intp()
+      eq(0x20d0, mbyte.utfc_ptr2char_len(to_string({0xe2, 0x83, 0x90}), pcc, 3))
+      eq(0, pcc[0])
+    end)
+
+    it('4-byte sequences', function()
+      local pcc = to_intp()
+
+      -- No following combining character
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0x7f, 0xcc, 0x80}), pcc, 4))
+      eq(0, pcc[0])
+      -- No second UTF-8 character
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xc2, 0xcc, 0x80}), pcc, 4))
+      eq(0, pcc[0])
+
+      -- Combining character U+0300
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80, 0xcc}), pcc, 4))
+      eq(0x0300, pcc[0])
+      eq(0x0000, pcc[1])
+
+      -- No UTF-8 sequence
+      local pcc = to_intp()
+      eq(0x00c2, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x7f, 0xcc, 0x80}), pcc, 4))
+      eq(0, pcc[0])
+      -- No following UTF-8 character
+      local pcc = to_intp()
+      eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc, 0xcc}), pcc, 4))
+      eq(0, pcc[0])
+      -- Combining character U+0301
+      local pcc = to_intp()
+      eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc, 0x81}), pcc, 4))
+      eq(0x0301, pcc[0])
+      eq(0x0000, pcc[1])
+
+      -- One UTF-8 character
+      local pcc = to_intp()
+      eq(0x100000, mbyte.utfc_ptr2char_len(to_string({0xf4, 0x80, 0x80, 0x80}), pcc, 4))
+      eq(0, pcc[0])
+    end)
+
+    it('5+-byte sequences', function()
+      local pcc = to_intp()
+
+      -- No following combining character
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0x7f, 0xcc, 0x80, 0x80}), pcc, 5))
+      eq(0, pcc[0])
+      -- No second UTF-8 character
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xc2, 0xcc, 0x80, 0x80}), pcc, 5))
+      eq(0, pcc[0])
+
+      -- Combining character U+0300
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80, 0xcc}), pcc, 5))
+      eq(0x0300, pcc[0])
+      eq(0x0000, pcc[1])
+
+      -- Combining characters U+0300 and U+0301
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80, 0xcc, 0x81}), pcc, 5))
+      eq(0x0300, pcc[0])
+      eq(0x0301, pcc[1])
+      eq(0x0000, pcc[2])
+      -- Combining characters U+0300, U+0301, U+0302
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82}), pcc, 7))
+      eq(0x0300, pcc[0])
+      eq(0x0301, pcc[1])
+      eq(0x0302, pcc[2])
+      eq(0x0000, pcc[3])
+      -- Combining characters U+0300, U+0301, U+0302, U+0303
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83}), pcc, 9))
+      eq(0x0300, pcc[0])
+      eq(0x0301, pcc[1])
+      eq(0x0302, pcc[2])
+      eq(0x0303, pcc[3])
+      eq(0x0000, pcc[4])
+      -- Combining characters U+0300, U+0301, U+0302, U+0303, U+0304
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
+          {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84}), pcc, 11))
+      eq(0x0300, pcc[0])
+      eq(0x0301, pcc[1])
+      eq(0x0302, pcc[2])
+      eq(0x0303, pcc[3])
+      eq(0x0304, pcc[4])
+      eq(0x0000, pcc[5])
+      -- Combining characters U+0300, U+0301, U+0302, U+0303, U+0304,
+      -- U+0305
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
+          {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84, 0xcc, 0x85}), pcc, 13))
+      eq(0x0300, pcc[0])
+      eq(0x0301, pcc[1])
+      eq(0x0302, pcc[2])
+      eq(0x0303, pcc[3])
+      eq(0x0304, pcc[4])
+      eq(0x0305, pcc[5])
+      eq(1, pcc[6])
+
+      -- Combining characters U+0300, U+0301, U+0302, U+0303, U+0304,
+      -- U+0305, U+0306, but only write save six.
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
+          {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84, 0xcc, 0x85, 0xcc, 0x86}), pcc, 15))
+      eq(0x0300, pcc[0])
+      eq(0x0301, pcc[1])
+      eq(0x0302, pcc[2])
+      eq(0x0303, pcc[3])
+      eq(0x0304, pcc[4])
+      eq(0x0305, pcc[5])
+      eq(0x0001, pcc[6])
+
+      -- Only three following combining characters U+0300, U+0301, U+0302
+      local pcc = to_intp()
+      eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
+          {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xc2, 0x80, 0xcc, 0x84, 0xcc, 0x85}), pcc, 13))
+      eq(0x0300, pcc[0])
+      eq(0x0301, pcc[1])
+      eq(0x0302, pcc[2])
+      eq(0x0000, pcc[3])
+
+
+      -- No UTF-8 sequence
+      local pcc = to_intp()
+      eq(0x00c2, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x7f, 0xcc, 0x80, 0x80}), pcc, 5))
+      eq(0, pcc[0])
+      -- No following UTF-8 character
+      local pcc = to_intp()
+      eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc, 0xcc, 0x80}), pcc, 5))
+      eq(0, pcc[0])
+      -- Combining character U+0301
+      local pcc = to_intp()
+      eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc, 0x81, 0x7f}), pcc, 5))
+      eq(0x0301, pcc[0])
+      eq(0x0000, pcc[1])
+      -- Combining character U+0301
+      local pcc = to_intp()
+      eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc, 0x81, 0xcc}), pcc, 5))
+      eq(0x0301, pcc[0])
+      eq(0x0000, pcc[1])
+
+      -- One UTF-8 character
+      local pcc = to_intp()
+      eq(0x100000, mbyte.utfc_ptr2char_len(to_string({0xf4, 0x80, 0x80, 0x80, 0x7f}), pcc, 5))
+      eq(0, pcc[0])
+
+      -- One UTF-8 character
+      local pcc = to_intp()
+      eq(0x100000, mbyte.utfc_ptr2char_len(to_string({0xf4, 0x80, 0x80, 0x80, 0x80}), pcc, 5))
+      eq(0, pcc[0])
+      -- One UTF-8 character
+      local pcc = to_intp()
+      eq(0x100000, mbyte.utfc_ptr2char_len(to_string({0xf4, 0x80, 0x80, 0x80, 0xcc}), pcc, 5))
+      eq(0, pcc[0])
+
+      -- Combining characters U+1AB0 and U+0301
+      local pcc = to_intp()
+      eq(0x100000, mbyte.utfc_ptr2char_len(to_string(
+          {0xf4, 0x80, 0x80, 0x80, 0xe1, 0xaa, 0xb0, 0xcc, 0x81}), pcc, 9))
+      eq(0x1ab0, pcc[0])
+      eq(0x0301, pcc[1])
+      eq(0x0000, pcc[2])
+    end)
+
+  end)
+
+end)

--- a/test/unit/mbyte_spec.lua
+++ b/test/unit/mbyte_spec.lua
@@ -208,7 +208,7 @@ describe('mbyte', function()
       eq(1, pcc[6])
 
       -- Combining characters U+0300, U+0301, U+0302, U+0303, U+0304,
-      -- U+0305, U+0306, but only write save six.
+      -- U+0305, U+0306, but only save six (= MAX_MCO).
       local pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
           {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84, 0xcc, 0x85, 0xcc, 0x86}), pcc, 15))


### PR DESCRIPTION
mbyte.c: Fix invalid memory access in utfc_ptr2char_len

To get an UTF-8 character, utf_ptr2char() is used.
But this function can read more than maxlen bytes, if an incomplete
byte sequence is used(first byte specifies a length > maxlen).

Found while using `:AgFromSearch` with search term `PRId64` and ASAN. Can be hard to reproduce the problem, because an UTF-8 byte sequence needs to be divided into two parts by the Rbuffer wrap around in `out_data_cb():316`.

``` c
==20242==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x63100059c83f at pc 0x000000d51009 bp 0x7fff71ea3dc0 sp 0x7fff71ea3db8
READ of size 1 at 0x63100059c83f thread T0
    #0 0xd51008 in utf_ptr2char /home/oni-link/git/neovim/src/nvim/mbyte.c:1134:19
    #1 0xd5aa55 in utfc_ptr2char_len /home/oni-link/git/neovim/src/nvim/mbyte.c:1312:7
    #2 0x12e00fc in screen_puts_len /home/oni-link/git/neovim/src/nvim/screen.c:5338:17
    #3 0x10f7c31 in out_data_cb /home/oni-link/git/neovim/src/nvim/os/shell.c:326:5
    #4 0x911d3b in read_event /home/oni-link/git/neovim/src/nvim/event/rstream.c:178:5
    #5 0x910d9b in invoke_read_cb /home/oni-link/git/neovim/src/nvim/event/rstream.c:195:3
    #6 0x90f42e in read_cb /home/oni-link/git/neovim/src/nvim/event/rstream.c:127:3
    #7 0x17c763e in uv__read /home/oni-link/git/neovim/.deps/build/src/libuv/src/unix/stream.c:1178
    #8 0x17c7d8b in uv__stream_io /home/oni-link/git/neovim/.deps/build/src/libuv/src/unix/stream.c:1241
    #9 0x17ccb94 in uv__io_poll /home/oni-link/git/neovim/.deps/build/src/libuv/src/unix/linux-core.c:345
    #10 0x17bf13b in uv_run /home/oni-link/git/neovim/.deps/build/src/libuv/src/unix/core.c:351
    #11 0x8efeac in loop_poll_events /home/oni-link/git/neovim/src/nvim/event/loop.c:49:3
    #12 0x8fca80 in process_wait /home/oni-link/git/neovim/src/nvim/event/process.c:189:3
    #13 0x10f5d43 in do_os_system /home/oni-link/git/neovim/src/nvim/os/shell.c:260:16
    #14 0x10f27e2 in os_call_shell /home/oni-link/git/neovim/src/nvim/os/shell.c:125:16
    #15 0xe4ddef in call_shell /home/oni-link/git/neovim/src/nvim/misc2.c:307:16
    #16 0x930716 in do_shell /home/oni-link/git/neovim/src/nvim/ex_cmds.c:1270:9
    #17 0x115f4fe in ex_make /home/oni-link/git/neovim/src/nvim/quickfix.c:2505:3
    #18 0x9ec2dd in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2191:5
    #19 0x9cb11d in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:601:20
    #20 0x7abf9e in ex_execute /home/oni-link/git/neovim/src/nvim/eval.c:19540:7
    #21 0x9ec2dd in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2191:5
    #22 0x9cb11d in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:601:20
    #23 0x771ef6 in call_user_func /home/oni-link/git/neovim/src/nvim/eval.c:21123:3
    #24 0x738b95 in call_func /home/oni-link/git/neovim/src/nvim/eval.c:7756:11
    #25 0x74d004 in get_func_tv /home/oni-link/git/neovim/src/nvim/eval.c:7622:11
    #26 0x74746b in ex_call /home/oni-link/git/neovim/src/nvim/eval.c:2778:9
    #27 0x9ec2dd in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2191:5
    #28 0x9cb11d in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:601:20
    #29 0x771ef6 in call_user_func /home/oni-link/git/neovim/src/nvim/eval.c:21123:3
    #30 0x738b95 in call_func /home/oni-link/git/neovim/src/nvim/eval.c:7756:11
    #31 0x74d004 in get_func_tv /home/oni-link/git/neovim/src/nvim/eval.c:7622:11
    #32 0x74746b in ex_call /home/oni-link/git/neovim/src/nvim/eval.c:2778:9
    #33 0x9ec2dd in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2191:5
    #34 0x9cb11d in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:601:20
    #35 0xa327a9 in do_ucmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:5428:9
    #36 0x9ec033 in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2185:5
    #37 0x9cb11d in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:601:20
    #38 0xf5f6bb in nv_colon /home/oni-link/git/neovim/src/nvim/normal.c:4485:18
    #39 0xf46c13 in normal_execute /home/oni-link/git/neovim/src/nvim/normal.c:1147:3
    #40 0x15c7170 in state_enter /home/oni-link/git/neovim/src/nvim/state.c:55:26
    #41 0xefb160 in normal_enter /home/oni-link/git/neovim/src/nvim/normal.c:464:3
    #42 0xcaf226 in main /home/oni-link/git/neovim/src/nvim/main.c:538:3
    #43 0x7fdd3e2125af in __libc_start_main (/lib64/libc.so.6+0x205af)
    #44 0x444228 in _start (/home/oni-link/git/neovim/build/bin/nvim+0x444228)

0x63100059c83f is located 0 bytes to the right of 65599-byte region [0x63100058c800,0x63100059c83f)
allocated by thread T0 here:
    #0 0x4e57e8 in malloc /home/oni-link/git/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:52
    #1 0xdd1c74 in try_malloc /home/oni-link/git/neovim/src/nvim/memory.c:59:15
    #2 0xdd1e34 in xmalloc /home/oni-link/git/neovim/src/nvim/memory.c:93:15
    #3 0x1185721 in rbuffer_new /home/oni-link/git/neovim/src/nvim/rbuffer.c:21:17
    #4 0x90e14b in rstream_init /home/oni-link/git/neovim/src/nvim/event/rstream.c:41:20
    #5 0x10f55a3 in do_os_system /home/oni-link/git/neovim/src/nvim/os/shell.c:237:3
    #6 0x10f27e2 in os_call_shell /home/oni-link/git/neovim/src/nvim/os/shell.c:125:16
    #7 0xe4ddef in call_shell /home/oni-link/git/neovim/src/nvim/misc2.c:307:16
    #8 0x930716 in do_shell /home/oni-link/git/neovim/src/nvim/ex_cmds.c:1270:9
    #9 0x115f4fe in ex_make /home/oni-link/git/neovim/src/nvim/quickfix.c:2505:3
    #10 0x9ec2dd in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2191:5
    #11 0x9cb11d in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:601:20
    #12 0x7abf9e in ex_execute /home/oni-link/git/neovim/src/nvim/eval.c:19540:7
    #13 0x9ec2dd in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2191:5
    #14 0x9cb11d in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:601:20
    #15 0x771ef6 in call_user_func /home/oni-link/git/neovim/src/nvim/eval.c:21123:3
    #16 0x738b95 in call_func /home/oni-link/git/neovim/src/nvim/eval.c:7756:11
    #17 0x74d004 in get_func_tv /home/oni-link/git/neovim/src/nvim/eval.c:7622:11
    #18 0x74746b in ex_call /home/oni-link/git/neovim/src/nvim/eval.c:2778:9
    #19 0x9ec2dd in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2191:5
    #20 0x9cb11d in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:601:20
    #21 0x771ef6 in call_user_func /home/oni-link/git/neovim/src/nvim/eval.c:21123:3
    #22 0x738b95 in call_func /home/oni-link/git/neovim/src/nvim/eval.c:7756:11
    #23 0x74d004 in get_func_tv /home/oni-link/git/neovim/src/nvim/eval.c:7622:11
    #24 0x74746b in ex_call /home/oni-link/git/neovim/src/nvim/eval.c:2778:9
    #25 0x9ec2dd in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2191:5
    #26 0x9cb11d in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:601:20
    #27 0xa327a9 in do_ucmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:5428:9
    #28 0x9ec033 in do_one_cmd /home/oni-link/git/neovim/src/nvim/ex_docmd.c:2185:5
    #29 0x9cb11d in do_cmdline /home/oni-link/git/neovim/src/nvim/ex_docmd.c:601:20

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/oni-link/git/neovim/src/nvim/mbyte.c:1134:19 in utf_ptr2char

```
