### PR TITLE
Make completion_spec.lua more robust

### DIFF
--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -172,6 +172,7 @@ describe('completion', function()
       [4] = {bold = true, foreground = Screen.colors.SeaGreen},
     })
 
+    execute("set complete=.")
     feed('ifoobar fooegg<cr>f<c-p>')
     screen:expect([[
       foobar fooegg                           |


### PR DESCRIPTION
Having a tags file in the calling directory of make test would make this test
fail, so disable tag file completion for it. Disable all other options except the
current buffer, to, applying the principle of least surprise.
