### PR TITLE
[RFC] eval.c: Fix cut off of terminal exit message

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -22320,7 +22320,7 @@ static void on_process_exit(Process *proc, int status, void *d)
   TerminalJobData *data = d;
   if (data->term && !data->exited) {
     data->exited = true;
-    char msg[22];
+    char msg[sizeof("\r\n[Process exited ]") + NUMBUFLEN];
     snprintf(msg, sizeof msg, "\r\n[Process exited %d]", proc->status);
     terminal_close(data->term, msg);
   }


### PR DESCRIPTION
eval.c: Fix cut off of terminal exit message

The message array in on_process_exit() is too short
for a status > 99.

For `:term exit 100` a `']'` is missing in the message.
