### PR TITLE
[RFC] vim-patch: 7.4.1285

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2009,6 +2009,7 @@ range( {expr} [, {max} [, {stride}]])
 readfile( {fname} [, {binary} [, {max}]])
 				List	get list of lines from file {fname}
 reltime( [{start} [, {end}]])	List	get time value
+reltimefloat( {time})		Float	turn the time value into a Float
 reltimestr( {time})		String	turn time value into a String
 remote_expr( {server}, {string} [, {idvar}])
 				String	send expression
@@ -5319,7 +5320,8 @@ readfile({fname} [, {binary} [, {max}]])
 reltime([{start} [, {end}]])				*reltime()*
 		Return an item that represents a time value.  The format of
 		the item depends on the system.  It can be passed to
-		|reltimestr()| to convert it to a string.
+		|reltimestr()| to convert it to a string or |reltimefloat()| 
+		to convert to a float.
 		Without an argument it returns the current time.
 		With one argument is returns the time passed since the time
 		specified in the argument.
@@ -5327,7 +5329,16 @@ reltime([{start} [, {end}]])				*reltime()*
 		and {end}.
 		The {start} and {end} arguments must be values returned by
 		reltime().
-		{only available when compiled with the |+reltime| feature}
+
+reltimefloat({time})				*reltimefloat()*
+		Return a Float that represents the time value of {time}.
+		Unit of time is seconds.
+		Example:
+			let start = reltime()
+			call MyFunction()
+			let seconds = reltimefloat(reltime(start))
+		See the note of reltimestr() about overhead.
+ 		Also see |profiling|.
 
 reltimestr({time})				*reltimestr()*
 		Return a String that represents the time value of {time}.
@@ -5337,12 +5348,10 @@ reltimestr({time})				*reltimestr()*
 			call MyFunction()
 			echo reltimestr(reltime(start))
 <		Note that overhead for the commands will be added to the time.
-		The accuracy depends on the system.
 		Leading spaces are used to make the string align nicely.  You
 		can use split() to remove it. >
 			echo split(reltimestr(reltime(start)))[0]
 <		Also see |profiling|.
-		{only available when compiled with the |+reltime| feature}
 
 							*remote_expr()* *E449*
 remote_expr({server}, {string} [, {idvar}])

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6850,6 +6850,7 @@ static struct fst {
   { "range",             1, 3, f_range },
   { "readfile",          1, 3, f_readfile },
   { "reltime",           0, 2, f_reltime },
+  { "reltimefloat",      1, 1, f_reltimefloat },
   { "reltimestr",        1, 1, f_reltimestr },
   { "remove",            2, 3, f_remove },
   { "rename",            2, 2, f_rename },
@@ -15294,6 +15295,21 @@ static void f_sort(typval_T *argvars, typval_T *rettv)
 static void f_uniq(typval_T *argvars, typval_T *rettv)
 {
   do_sort_uniq(argvars, rettv, false);
+}
+
+//
+// "reltimefloat()" function
+//
+static void f_reltimefloat(typval_T *argvars , typval_T *rettv)
+  FUNC_ATTR_NONNULL_ALL
+{
+  proftime_T tm;
+
+  rettv->v_type = VAR_FLOAT;
+  rettv->vval.v_float = 0;
+  if (list2proftime(&argvars[0], &tm) == OK) {
+    rettv->vval.v_float = ((float_T)tm) / 1000000000;
+  }
 }
 
 /*

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -393,7 +393,7 @@ static int included_patches[] = {
   // 1288 NA
   // 1287 NA
   // 1286 NA
-  // 1285,
+  1285,
   1284,
   // 1283 NA
   1282,

--- a/test/functional/eval/reltime_spec.lua
+++ b/test/functional/eval/reltime_spec.lua
@@ -1,0 +1,36 @@
+local helpers = require('test.functional.helpers')
+local clear, eq, ok = helpers.clear,  helpers.eq, helpers.ok
+local neq, execute, funcs  = helpers.neq, helpers.execute, helpers.funcs
+local reltime, reltimestr, reltimefloat = funcs.reltime, funcs.reltimestr, funcs.reltimefloat
+
+describe('reltimestr(), reltimefloat()', function()
+  before_each(clear)
+
+  it('Checks', function()
+    local now = reltime()
+    execute('sleep 10m')
+    local later = reltime()
+    local elapsed = reltime(now)
+
+    neq(reltimestr(elapsed), '0.0')
+    ok(reltimefloat(elapsed) > 0.0)
+    -- original vim test for < 0.1, but easily fails on travis
+    ok(nil ~= string.match(reltimestr(elapsed), "0%."))
+    ok(reltimefloat(elapsed) < 1.0)
+
+    local same = reltime(now, now)
+    local samestr = string.gsub(reltimestr(same), ' ', '')
+    samestr = string.sub(samestr, 1, 5)
+
+    eq('0.000', samestr)
+    eq(0.0, reltimefloat(same))
+
+    local differs = reltime(now, later)
+    neq(reltimestr(differs), '0.0')
+    ok(reltimefloat(differs) > 0.0)
+    -- original vim test for < 0.1, but easily fails on travis
+    ok(nil ~= string.match(reltimestr(differs), "0%."))
+    ok(reltimefloat(differs) < 1.0)
+
+  end)
+end)


### PR DESCRIPTION
### vim-patch:7.4.1285

```
Problem:    Cannot measure elapsed time.
Solution:   Add reltimefloat().
```

vim/vim@79c2c88

Applied manually. None of the ifdef's applies anymore, and proftime_T was
changed into an uint64_T, so the function profile_float to convert proftime_T to
float is not needed in nvim.
### vim-patch:cb00f03

`Add missing test file.`

vim/vim@cb00f03

Converted to a lua test.
### Add documentation for reltimefloat()

from vim/vim@03413f4

Also adjust  the entries for reltime() and reltimestr().
