### PR TITLE
rplugin: Don't chain events.

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -130,7 +130,7 @@ endfunction
 function! remote#host#LoadRemotePluginsEvent(event, pattern) abort
   autocmd! nvim-rplugin
   call remote#host#LoadRemotePlugins()
-  execute 'silent doautocmd' a:event a:pattern
+  execute 'silent doautocmd <nomodeline>' a:event a:pattern
 endfunction
 
 


### PR DESCRIPTION
Removing this line doesn't seem to prevent catching undefined functions, it's apparently not needed at all.
This addresses #4471.
