### PR TITLE
[RFC] vim-patch:7.4.{5a46a58 , 1300}

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1838,6 +1838,7 @@ dictwatcherdel( {dict}, {pattern}, {callback})
 did_filetype()			Number	TRUE if FileType autocommand event used
 diff_filler( {lnum})		Number	diff filler lines about {lnum}
 diff_hlID( {lnum}, {col})	Number	diff highlighting at {lnum}/{col}
+disable_char_avail_for_testing({expr})  none  test without typeahead
 empty( {expr})			Number	TRUE if {expr} is empty
 escape( {string}, {chars})	String	escape {chars} in {string} with '\'
 eval( {string})			any	evaluate {string} into its value
@@ -2852,6 +2853,13 @@ diff_hlID({lnum}, {col})				*diff_hlID()*
 		line.
 		The highlight ID can be used with |synIDattr()| to obtain
 		syntax information about the highlighting.
+
+disable_char_avail_for_testing({expr})
+		When {expr} is 1 the internal char_avail() function will
+		return FALSE.  When {expr} is 0 the char_avail() function will
+		function normally.
+		Only use this for a test where typeahead causes the test not
+		to work.  E.g., to trigger the CursorMovedI autocommand event.
 
 empty({expr})						*empty()*
 		Return the Number 1 if {expr} is empty, zero otherwise.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6707,6 +6707,7 @@ static struct fst {
   { "did_filetype",      0, 0, f_did_filetype },
   { "diff_filler",       1, 1, f_diff_filler },
   { "diff_hlID",         2, 2, f_diff_hlID },
+  {"disable_char_avail_for_testing", 1, 1, f_disable_char_avail_for_testing},
   { "empty",             1, 1, f_empty },
   { "escape",            2, 2, f_escape },
   { "eval",              1, 1, f_eval },
@@ -8582,6 +8583,15 @@ static void f_diff_hlID(typval_T *argvars, typval_T *rettv)
   rettv->vval.v_number = hlID == (hlf_T)0 ? 0 : (int)hlID;
 }
 
+//
+// "disable_char_avail_for_testing({expr})" function
+// 
+static void f_disable_char_avail_for_testing(typval_T *argvars, typval_T *rettv)
+  FUNC_ATTR_NONNULL_ARG(1)
+{
+    disable_char_avail_for_testing = get_tv_number(&argvars[0]);
+}
+
 /*
  * "empty({expr})" function
  */
@@ -10173,6 +10183,7 @@ static void getpos_both(typval_T *argvars, typval_T *rettv, bool getcurpos)
   list_append_number(l,
                      (fp != NULL) ? (varnumber_T)fp->coladd : (varnumber_T)0);
   if (getcurpos) {
+    update_curswant();
     list_append_number(l, curwin->w_curswant == MAXCOL
                               ? (varnumber_T)MAXCOL
                               : (varnumber_T)curwin->w_curswant + 1);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6707,7 +6707,7 @@ static struct fst {
   { "did_filetype",      0, 0, f_did_filetype },
   { "diff_filler",       1, 1, f_diff_filler },
   { "diff_hlID",         2, 2, f_diff_hlID },
-  {"disable_char_avail_for_testing", 1, 1, f_disable_char_avail_for_testing},
+  { "disable_char_avail_for_testing", 1, 1, f_disable_char_avail_for_testing },
   { "empty",             1, 1, f_empty },
   { "escape",            2, 2, f_escape },
   { "eval",              1, 1, f_eval },
@@ -8585,7 +8585,7 @@ static void f_diff_hlID(typval_T *argvars, typval_T *rettv)
 
 //
 // "disable_char_avail_for_testing({expr})" function
-// 
+//
 static void f_disable_char_avail_for_testing(typval_T *argvars, typval_T *rettv)
   FUNC_ATTR_NONNULL_ARG(1)
 {

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1562,6 +1562,11 @@ int char_avail(void)
 {
   int retval;
 
+  // When disable_char_avail_for_testing(1) was called pretend
+  // there is no typeahead
+  if (disable_char_avail_for_testing) {
+    return FALSE;
+  }
   ++no_mapping;
   retval = vpeekc();
   --no_mapping;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1565,9 +1565,9 @@ int char_avail(void)
   // When disable_char_avail_for_testing(1) was called pretend
   // there is no typeahead
   if (disable_char_avail_for_testing) {
-    return FALSE;
+    return false;
   }
-  ++no_mapping;
+  no_mapping++;
   retval = vpeekc();
   --no_mapping;
   return retval != NUL;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1239,6 +1239,8 @@ EXTERN FILE *time_fd INIT(= NULL);  /* where to write startup timing */
 EXTERN int ignored;
 EXTERN char *ignoredp;
 
+EXTERN int  disable_char_avail_for_testing INIT(= 0);
+
 // If a msgpack-rpc channel should be started over stdin/stdout
 EXTERN bool embedded_mode INIT(= false);
 EXTERN Loop loop;

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -1,0 +1,35 @@
+" Tests for cursor().
+
+func Test_wrong_arguments()
+  try
+    call cursor(1. 3)
+    " not reached
+    call assert_false(1)
+  catch
+    call assert_exception('E474:')
+  endtry
+endfunc
+
+func Test_move_cursor()
+  new
+  call setline(1, ['aaa', 'bbb', 'ccc', 'ddd'])
+
+  call cursor([1, 1, 0, 1])
+  call assert_equal([1, 1, 0, 1], getcurpos()[1:])
+  call cursor([4, 3, 0, 3])
+  call assert_equal([4, 3, 0, 3], getcurpos()[1:])
+
+  call cursor(2, 2)
+  call assert_equal([2, 2, 0, 3], getcurpos()[1:])
+  " line number zero keeps the line number
+  call cursor(0, 1)
+  call assert_equal([2, 1, 0, 3], getcurpos()[1:])
+  " col number zero keeps the column
+  call cursor(3, 0)
+  call assert_equal([3, 1, 0, 3], getcurpos()[1:])
+  " below last line goes to last line
+  call cursor(9, 1)
+  call assert_equal([4, 1, 0, 3], getcurpos()[1:])
+
+  quit!
+endfunc

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -20,16 +20,35 @@ func Test_move_cursor()
   call assert_equal([4, 3, 0, 3], getcurpos()[1:])
 
   call cursor(2, 2)
-  call assert_equal([2, 2, 0, 3], getcurpos()[1:])
+  call assert_equal([2, 2, 0, 2], getcurpos()[1:])
   " line number zero keeps the line number
   call cursor(0, 1)
-  call assert_equal([2, 1, 0, 3], getcurpos()[1:])
+  call assert_equal([2, 1, 0, 1], getcurpos()[1:])
   " col number zero keeps the column
   call cursor(3, 0)
-  call assert_equal([3, 1, 0, 3], getcurpos()[1:])
+  call assert_equal([3, 1, 0, 1], getcurpos()[1:])
   " below last line goes to last line
   call cursor(9, 1)
-  call assert_equal([4, 1, 0, 3], getcurpos()[1:])
+  call assert_equal([4, 1, 0, 1], getcurpos()[1:])
 
   quit!
 endfunc
+
+" Very short version of what matchparen does.
+function s:Highlight_Matching_Pair()
+  let save_cursor = getcurpos()
+  call setpos('.', save_cursor)
+endfunc
+
+func Test_curswant_with_autocommand()
+  new
+  call setline(1, ['func()', '{', '}', '----'])
+  autocmd! CursorMovedI * call s:Highlight_Matching_Pair()
+  call disable_char_avail_for_testing(1)
+  exe "normal! 3Ga\<Down>X\<Esc>"
+  call disable_char_avail_for_testing(0)
+  call assert_equal('-X---', getline(4))
+  autocmd! CursorMovedI *
+  quit!
+endfunc
+

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -377,7 +377,7 @@ static int included_patches[] = {
   // 1303 NA
   // 1302 NA
   // 1301 NA
-  // 1300,
+  1300,
   // 1299 NA
   // 1298 NA
   // 1297 NA


### PR DESCRIPTION
Started off as a port of 7.4.1300, but more  was to be included to stay somewhat consistent.
### vim-patch:5a46a58

`Add missing test file.`

vim/vim@5a46a58
### vim-patch:7.4.1300

```
Problem:    Cannot test CursorMovedI because there is typeahead.
Solution:   Add disable_char_avail_for_testing().
```

vim/vim@2ab375e

Most of it manually applied.
### Add documentation for disable_char_avail_for_testing

... handpicked from

```
vim/vim@6463ca2
vim/vim@7823a3b
```
