### PR TITLE
vim-patch:f913281 (runtime/doc/)

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -770,13 +770,15 @@ OptionSet			After setting an option.  The pattern is
 				it's global or local scoped and |<amatch>|
 				indicates what option has been set.
 
-				Note: It's a bad idea, to reset an option
-				during this autocommand, since this will
-				probably break plugins. You can always use
-				|:noa| to prevent triggering this autocommand.
-				Could be used, to check for existence of the
-				'backupdir' and 'undodir' options and create
-				directories, if they don't exist yet.
+				Usage example: Check for the existence of the
+				directory in the 'backupdir' and 'undodir'
+				options, create the directory if it doesn't
+				exist yet.
+
+				Note: It's a bad idea to reset an option
+				during this autocommand, this may break a
+				plugin. You can always use `:noa` to prevent
+				triggering this autocommand.
 
 							*QuickFixCmdPre*
 QuickFixCmdPre			Before a quickfix command is run (|:make|,

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1,4 +1,4 @@
-*windows.txt*   For Vim version 7.4.  Last change: 2015 Jan 31
+*windows.txt*   For Vim version 7.4.  Last change: 2015 Jul 21
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar


### PR DESCRIPTION
Updated and new runtime files.

https://github.com/vim/vim/commit/f91328100db34996ed7e7a800bed0a30ff0890dd

This is just a few remaining changes in runtime/doc/ for completeness' sake, and I wanted to double-check that it's expected that some changes in runtime/syntax/vim.vim didn't apply.
