### PR TITLE
[RFC] Make v:windowid writeable

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1763,7 +1763,8 @@ v:version	Version number of Vim: Major version number times 100 plus
 v:warningmsg	Last given warning message.  It's allowed to set this variable.
 
 					*v:windowid* *windowid-variable* {Nvim}
-v:windowid	Is a no-op at the moment; the value is always set to 0.
+v:windowid	When a GUI is running this will be set to the window ID. It is
+		up to the GUI to set the variable, otherwise the value is zero.
 		Note: for windows inside Vim use |winnr()|.
 
 ==============================================================================

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -366,7 +366,7 @@ static struct vimvar {
   VV(VV_SEARCHFORWARD,  "searchforward",    VAR_NUMBER, 0),
   VV(VV_HLSEARCH,       "hlsearch",         VAR_NUMBER, 0),
   VV(VV_OLDFILES,       "oldfiles",         VAR_LIST, 0),
-  VV(VV_WINDOWID,       "windowid",         VAR_NUMBER, VV_RO),
+  VV(VV_WINDOWID,       "windowid",         VAR_NUMBER, VV_RO_SBX),
   VV(VV_PROGPATH,       "progpath",         VAR_STRING, VV_RO),
   VV(VV_COMMAND_OUTPUT, "command_output",   VAR_STRING, 0),
   VV(VV_COMPLETED_ITEM, "completed_item",   VAR_DICT, VV_RO),


### PR DESCRIPTION
Set v:windowid as writeable (but read only in the sandbox) and
updated the docs.

For #3626. This does not change the current behaviour v:windowid is still 0 by default, it is up to the GUI/plugin to set it.
