### PR TITLE
doc: Set XDG_CONFIG_HOME to use it multiple times

### DIFF
--- a/runtime/doc/nvim_from_vim.txt
+++ b/runtime/doc/nvim_from_vim.txt
@@ -12,7 +12,8 @@ good.
 To start the transition, link your previous configuration so Nvim can use
 it:
 >
-    mkdir -p ${XDG_CONFIG_HOME:=$HOME/.config}
+    XDG_CONFIG_HOME=${XDG_CONFIG_HOME:=$HOME/.config}
+    mkdir -p $XDG_CONFIG_HOME
     ln -s ~/.vim $XDG_CONFIG_HOME/nvim
     ln -s ~/.vimrc $XDG_CONFIG_HOME/nvim/init.vim
 <


### PR DESCRIPTION
Previously, these commands were trying to create a symlink to /nvim if
XDG_CONFIG_HOME was not set.
