### PR TITLE
[RFC] vim-patch:7.4.1753

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2319,6 +2319,22 @@ static int ins_compl_make_cyclic(void)
   return count;
 }
 
+
+// Set variables that store noselect and noinsert behavior from the
+// 'completeopt' value.
+void completeopt_was_set(void)
+{
+  compl_no_insert = false;
+  compl_no_select = false;
+  if (strstr((char *)p_cot, "noselect") != NULL) {
+    compl_no_select = true;
+  }
+  if (strstr((char *)p_cot, "noinsert") != NULL) {
+    compl_no_insert = true;
+  }
+}
+
+
 /*
  * Start completion for the complete() function.
  * "startcol" is where the matched text starts (1 is first column).
@@ -3095,17 +3111,6 @@ static bool ins_compl_prep(int c)
     compl_get_longest = (strstr((char *)p_cot, "longest") != NULL);
     compl_used_match = TRUE;
 
-  }
-
-  if (strstr((char *)p_cot, "noselect") != NULL) {
-    compl_no_insert = FALSE;
-    compl_no_select = TRUE;
-  } else if (strstr((char *)p_cot, "noinsert") != NULL) {
-    compl_no_insert = TRUE;
-    compl_no_select = FALSE;
-  } else {
-    compl_no_insert = FALSE;
-    compl_no_select = FALSE;
   }
 
   if (ctrl_x_mode == CTRL_X_NOT_DEFINED_YET) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2957,8 +2957,11 @@ did_set_string_option (
   }
   /* 'completeopt' */
   else if (varp == &p_cot) {
-    if (check_opt_strings(p_cot, p_cot_values, TRUE) != OK)
+    if (check_opt_strings(p_cot, p_cot_values, true) != OK) {
       errmsg = e_invarg;
+    } else {
+      completeopt_was_set();
+    }
   }
   /* 'pastetoggle': translate key codes like in a mapping */
   else if (varp == &p_pt) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -70,6 +70,7 @@ static char *features[] = {
 // clang-format off
 static int included_patches[] = {
   1755,
+  1753,
   1654,
   1652,
   1643,


### PR DESCRIPTION
Problem:    "noinsert" in 'completeopt' is sometimes ignored.
Solution:   Set the variables when the 'completeopt' was set. (Ozaki Kiichi)

https://github.com/vim/vim/commit/c020042083b9c0a4e932b562c3bef97c76328e18
