### PR TITLE
vim-patch: 7.4.1101

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3700,9 +3700,13 @@ win_line (
         && wp == curwin && lnum == wp->w_cursor.lnum
         && conceal_cursor_line(wp)
         && (int)wp->w_virtcol <= vcol + n_skip) {
-      wp->w_wcol = col - boguscols;
+      if (wp->w_p_rl) {
+        wp->w_wcol = wp->w_width - col + boguscols - 1;
+      } else {
+        wp->w_wcol = col - boguscols;
+      }
       wp->w_wrow = row;
-      did_wcol = TRUE;
+      did_wcol = true;
     }
 
     /* Don't override visual selection highlighting. */

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -264,7 +264,7 @@ static int included_patches[] = {
   // 1104 NA
   // 1103 NA
   // 1102,
-  // 1101,
+  1101,
   // 1100 NA
   // 1099 NA
   // 1098 NA


### PR DESCRIPTION
Problem:    With 'rightleft' and concealing the cursor may move to the wrong
            position.
Solution:   Compute the column differently when 'rightleft' is set. (Hirohito
            Higashi)

https://github.com/vim/vim/commit/e39b3d9fb4e4006684c33847d1ef6a0d742699dd
