### PR TITLE
vim-patch:7.4.871

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1946,18 +1946,20 @@ int expand_wildcards(int num_pat, char_u **pat, int *num_files, char_u ***files,
   if (*p_wig) {
     char_u  *ffname;
 
-    /* check all filess in (*files)[] */
-    for (i = 0; i < *num_files; ++i) {
-      ffname = (char_u *)FullName_save((char *)(*files)[i], FALSE);
-      if (ffname == NULL)               /* out of memory */
+    // check all filess in (*files)[]
+    for (i = 0; i < *num_files; i++) {
+      ffname = (char_u *)FullName_save((char *)(*files)[i], false);
+      if (ffname == NULL) {               // out of memory
         break;
+      }
       if (match_file_list(p_wig, (*files)[i], ffname)) {
-        /* remove this matching files from the list */
+        // remove this matching files from the list
         xfree((*files)[i]);
-        for (j = i; j + 1 < *num_files; ++j)
+        for (j = i; j + 1 < *num_files; j++) {
           (*files)[j] = (*files)[j + 1];
-        --*num_files;
-        --i;
+        }
+        (*num_files)--;
+        i--;
       }
       xfree(ffname);
     }
@@ -1968,15 +1970,16 @@ int expand_wildcards(int num_pat, char_u **pat, int *num_files, char_u ***files,
    */
   if (*num_files > 1) {
     non_suf_match = 0;
-    for (i = 0; i < *num_files; ++i) {
+    for (i = 0; i < *num_files; i++) {
       if (!match_suffix((*files)[i])) {
-        /*
-         * Move the name without matching suffix to the front
-         * of the list.
-         */
+        //
+        // Move the name without matching suffix to the front
+        // of the list.
+        //
         p = (*files)[i];
-        for (j = i; j > non_suf_match; --j)
+        for (j = i; j > non_suf_match; j--) {
           (*files)[j] = (*files)[j - 1];
+        }
         (*files)[non_suf_match++] = p;
       }
     }

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1926,7 +1926,7 @@ int expand_wildcards_eval(char_u **pat, int *num_file, char_u ***file,
 ///                      If FAIL is returned, *num_file and *file are either
 ///                      unchanged or *num_file is set to 0 and *file is set to
 ///                      NULL or points to "".
-int expand_wildcards(int num_pat, char_u **pat, int *num_file, char_u ***file,
+int expand_wildcards(int num_pat, char_u **pat, int *num_files, char_u ***files,
                      int flags)
 {
   int retval;
@@ -1934,7 +1934,7 @@ int expand_wildcards(int num_pat, char_u **pat, int *num_file, char_u ***file,
   char_u      *p;
   int non_suf_match;            /* number without matching suffix */
 
-  retval = gen_expand_wildcards(num_pat, pat, num_file, file, flags);
+  retval = gen_expand_wildcards(num_pat, pat, num_files, files, flags);
 
   /* When keeping all matches, return here */
   if ((flags & EW_KEEPALL) || retval == FAIL)
@@ -1946,17 +1946,17 @@ int expand_wildcards(int num_pat, char_u **pat, int *num_file, char_u ***file,
   if (*p_wig) {
     char_u  *ffname;
 
-    /* check all files in (*file)[] */
-    for (i = 0; i < *num_file; ++i) {
-      ffname = (char_u *)FullName_save((char *)(*file)[i], FALSE);
+    /* check all filess in (*files)[] */
+    for (i = 0; i < *num_files; ++i) {
+      ffname = (char_u *)FullName_save((char *)(*files)[i], FALSE);
       if (ffname == NULL)               /* out of memory */
         break;
-      if (match_file_list(p_wig, (*file)[i], ffname)) {
-        /* remove this matching file from the list */
-        xfree((*file)[i]);
-        for (j = i; j + 1 < *num_file; ++j)
-          (*file)[j] = (*file)[j + 1];
-        --*num_file;
+      if (match_file_list(p_wig, (*files)[i], ffname)) {
+        /* remove this matching files from the list */
+        xfree((*files)[i]);
+        for (j = i; j + 1 < *num_files; ++j)
+          (*files)[j] = (*files)[j + 1];
+        --*num_files;
         --i;
       }
       xfree(ffname);
@@ -1966,26 +1966,26 @@ int expand_wildcards(int num_pat, char_u **pat, int *num_file, char_u ***file,
   /*
    * Move the names where 'suffixes' match to the end.
    */
-  if (*num_file > 1) {
+  if (*num_files > 1) {
     non_suf_match = 0;
-    for (i = 0; i < *num_file; ++i) {
-      if (!match_suffix((*file)[i])) {
+    for (i = 0; i < *num_files; ++i) {
+      if (!match_suffix((*files)[i])) {
         /*
          * Move the name without matching suffix to the front
          * of the list.
          */
-        p = (*file)[i];
+        p = (*files)[i];
         for (j = i; j > non_suf_match; --j)
-          (*file)[j] = (*file)[j - 1];
-        (*file)[non_suf_match++] = p;
+          (*files)[j] = (*files)[j - 1];
+        (*files)[non_suf_match++] = p;
       }
     }
   }
 
   // Free empty array of matches
-  if (*num_file == 0) {
-    xfree(*file);
-    *file = NULL;
+  if (*num_files == 0) {
+    xfree(*files);
+    *files = NULL;
   }
 
   return retval;

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1986,6 +1986,7 @@ int expand_wildcards(int num_pat, char_u **pat, int *num_files, char_u ***files,
   if (*num_files == 0) {
     xfree(*files);
     *files = NULL;
+    return FAIL;
   }
 
   return retval;


### PR DESCRIPTION
```
Problem:    Vim leaks memory, when 'wildignore' filters out all matches.
Solution:   Free the files array when it becomes empty.
```

vim/vim@7b256fe

Largest part was a variable rename, split off for ease of review. Nontrivial part in the 2nd commit, though the real fix was already contained in nvim.
