### PR TITLE
[RFC] vim-patch:7.4.822

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5016,7 +5016,9 @@ helptags_one (
     /*
      * Sort the tags.
      */
-    sort_strings((char_u **)ga.ga_data, ga.ga_len);
+    if (ga.ga_data != NULL) {
+      sort_strings((char_u **)ga.ga_data, ga.ga_len);
+    }
 
     /*
      * Check for duplicates.

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2374,7 +2374,7 @@ static FILE *fopen_noinh_readbin(char *filename)
   {
     int fdflags = fcntl(fd_tmp, F_GETFD);
     if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0)
-      fcntl(fd_tmp, F_SETFD, fdflags | FD_CLOEXEC);
+      (void)fcntl(fd_tmp, F_SETFD, fdflags | FD_CLOEXEC);
   }
 # endif
 

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2373,8 +2373,9 @@ static FILE *fopen_noinh_readbin(char *filename)
 # ifdef HAVE_FD_CLOEXEC
   {
     int fdflags = fcntl(fd_tmp, F_GETFD);
-    if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0)
+    if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0) {
       (void)fcntl(fd_tmp, F_SETFD, fdflags | FD_CLOEXEC);
+    }
   }
 # endif
 

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2110,7 +2110,7 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *gap, int level,
    */
   if (getlevel == foldlevelMarker && flp->start <= flp->lvl - level
       && flp->lvl > 0) {
-    foldFind(gap, startlnum - 1, &fp);
+    (void)foldFind(gap, startlnum - 1, &fp);
     if (fp >= ((fold_T *)gap->ga_data) + gap->ga_len
         || fp->fd_top >= startlnum)
       fp = NULL;
@@ -2167,7 +2167,7 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *gap, int level,
         }
       }
       if (lvl < level + i) {
-        foldFind(&fp->fd_nested, flp->lnum - fp->fd_top, &fp2);
+        (void)foldFind(&fp->fd_nested, flp->lnum - fp->fd_top, &fp2);
         if (fp2 != NULL)
           bot = fp2->fd_top + fp2->fd_len - 1 + fp->fd_top;
       } else if (fp->fd_top + fp->fd_len <= flp->lnum && lvl >= level)

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2112,8 +2112,9 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *gap, int level,
       && flp->lvl > 0) {
     (void)foldFind(gap, startlnum - 1, &fp);
     if (fp >= ((fold_T *)gap->ga_data) + gap->ga_len
-        || fp->fd_top >= startlnum)
+        || fp->fd_top >= startlnum) {
       fp = NULL;
+    }
   }
 
   /*
@@ -2168,12 +2169,14 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *gap, int level,
       }
       if (lvl < level + i) {
         (void)foldFind(&fp->fd_nested, flp->lnum - fp->fd_top, &fp2);
-        if (fp2 != NULL)
+        if (fp2 != NULL) {
           bot = fp2->fd_top + fp2->fd_len - 1 + fp->fd_top;
-      } else if (fp->fd_top + fp->fd_len <= flp->lnum && lvl >= level)
-        finish = TRUE;
-      else
+        }
+      } else if (fp->fd_top + fp->fd_len <= flp->lnum && lvl >= level) {
+        finish = true;
+      } else {
         break;
+      }
     }
 
     /* At the start of the first nested fold and at the end of the current

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1063,7 +1063,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose,
               *qfpos == '-', cmdline) > 0) {
         if (postponed_split != 0) {
           (void)win_split(postponed_split > 0 ? postponed_split : 0,
-              postponed_split_flags);
+                          postponed_split_flags);
           RESET_BINDING(curwin);
           postponed_split = 0;
         }

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1062,7 +1062,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose,
       if (qf_init(wp, tmp, (char_u *)"%f%*\\t%l%*\\t%m",
               *qfpos == '-', cmdline) > 0) {
         if (postponed_split != 0) {
-          win_split(postponed_split > 0 ? postponed_split : 0,
+          (void)win_split(postponed_split > 0 ? postponed_split : 0,
               postponed_split_flags);
           RESET_BINDING(curwin);
           postponed_split = 0;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2598,10 +2598,8 @@ do_mouse (
         end_visual.col = leftcol;
       else
         end_visual.col = rightcol;
-      if (curwin->w_cursor.lnum <
+      if (curwin->w_cursor.lnum >=
           (start_visual.lnum + end_visual.lnum) / 2)
-        end_visual.lnum = end_visual.lnum;
-      else
         end_visual.lnum = start_visual.lnum;
 
       /* move VIsual to the right column */
@@ -3245,8 +3243,8 @@ void clear_showcmd(void)
       bot = VIsual.lnum;
     }
     /* Include closed folds as a whole. */
-    hasFolding(top, &top, NULL);
-    hasFolding(bot, NULL, &bot);
+    (void)hasFolding(top, &top, NULL);
+    (void)hasFolding(bot, NULL, &bot);
     lines = bot - top + 1;
 
     if (VIsual_mode == Ctrl_V) {
@@ -5154,7 +5152,7 @@ static void nv_gotofile(cmdarg_T *cap)
   if (ptr != NULL) {
     /* do autowrite if necessary */
     if (curbufIsChanged() && curbuf->b_nwindows <= 1 && !P_HID(curbuf))
-      autowrite(curbuf, false);
+      (void)autowrite(curbuf, false);
     setpcmark();
     (void)do_ecmd(0, ptr, NULL, NULL, ECMD_LAST,
         P_HID(curbuf) ? ECMD_HIDE : 0, curwin);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2599,8 +2599,9 @@ do_mouse (
       else
         end_visual.col = rightcol;
       if (curwin->w_cursor.lnum >=
-          (start_visual.lnum + end_visual.lnum) / 2)
+          (start_visual.lnum + end_visual.lnum) / 2) {
         end_visual.lnum = start_visual.lnum;
+      }
 
       /* move VIsual to the right column */
       start_visual = curwin->w_cursor;              /* save the cursor pos */
@@ -3242,7 +3243,7 @@ void clear_showcmd(void)
       top = curwin->w_cursor.lnum;
       bot = VIsual.lnum;
     }
-    /* Include closed folds as a whole. */
+    // Include closed folds as a whole.
     (void)hasFolding(top, &top, NULL);
     (void)hasFolding(bot, NULL, &bot);
     lines = bot - top + 1;
@@ -5150,9 +5151,10 @@ static void nv_gotofile(cmdarg_T *cap)
   ptr = grab_file_name(cap->count1, &lnum);
 
   if (ptr != NULL) {
-    /* do autowrite if necessary */
-    if (curbufIsChanged() && curbuf->b_nwindows <= 1 && !P_HID(curbuf))
+    // do autowrite if necessary
+    if (curbufIsChanged() && curbuf->b_nwindows <= 1 && !P_HID(curbuf)) {
       (void)autowrite(curbuf, false);
+    }
     setpcmark();
     (void)do_ecmd(0, ptr, NULL, NULL, ECMD_LAST,
         P_HID(curbuf) ? ECMD_HIDE : 0, curwin);

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -855,7 +855,7 @@ static int included_patches[] = {
   825,
   // 824 NA
   823,
-  // 822,
+  822,
   // 821 NA
   820,
   819,

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -97,7 +97,7 @@ do_window (
      * don't replicate the quickfix buffer. */
     if (bt_quickfix(curbuf))
       goto newwindow;
-    win_split((int)Prenum, 0);
+    (void)win_split((int)Prenum, 0);
     break;
 
   /* split current window in two parts, vertically */
@@ -108,7 +108,7 @@ do_window (
      * don't replicate the quickfix buffer. */
     if (bt_quickfix(curbuf))
       goto newwindow;
-    win_split((int)Prenum, WSP_VERT);
+    (void)win_split((int)Prenum, WSP_VERT);
     break;
 
   /* split current window and edit alternate file */


### PR DESCRIPTION
vim-patch:7.4.822

```
Problem:    More problems reported by coverity.
Solution:   Avoid the warnings. (Christian Brabandt)
```

vim/vim@cde8854

Applied manually. The commit contains comments about why I think the changes are warranted (show up as outdated on this page, no idea why). Detailled explanation of what was left out below.
