### PR TITLE
[RFC] Add support for the "special" color used for undercurls

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -503,6 +503,7 @@ EXTERN int cterm_normal_fg_bold INIT(= 0);
 EXTERN int cterm_normal_bg_color INIT(= 0);
 EXTERN RgbValue normal_fg INIT(= -1);
 EXTERN RgbValue normal_bg INIT(= -1);
+EXTERN RgbValue normal_sp INIT(= -1);
 
 EXTERN int autocmd_busy INIT(= FALSE);          /* Is apply_autocmds() busy? */
 EXTERN int autocmd_no_enter INIT(= FALSE);      /* *Enter autocmds disabled */

--- a/src/nvim/msgpack_rpc/remote_ui.c
+++ b/src/nvim/msgpack_rpc/remote_ui.c
@@ -96,6 +96,7 @@ static Object remote_ui_attach(uint64_t channel_id, uint64_t request_id,
   ui->visual_bell = remote_ui_visual_bell;
   ui->update_fg = remote_ui_update_fg;
   ui->update_bg = remote_ui_update_bg;
+  ui->update_sp = remote_ui_update_sp;
   ui->flush = remote_ui_flush;
   ui->suspend = remote_ui_suspend;
   ui->set_title = remote_ui_set_title;
@@ -285,6 +286,10 @@ static void remote_ui_highlight_set(UI *ui, HlAttrs attrs)
     PUT(hl, "background", INTEGER_OBJ(attrs.background));
   }
 
+  if (attrs.special != -1) {
+    PUT(hl, "special", INTEGER_OBJ(attrs.special));
+  }
+
   ADD(args, DICTIONARY_OBJ(hl));
   push_call(ui, "highlight_set", args);
 }
@@ -321,6 +326,13 @@ static void remote_ui_update_bg(UI *ui, int bg)
   Array args = ARRAY_DICT_INIT;
   ADD(args, INTEGER_OBJ(bg));
   push_call(ui, "update_bg", args);
+}
+
+static void remote_ui_update_sp(UI *ui, int sp)
+{
+  Array args = ARRAY_DICT_INIT;
+  ADD(args, INTEGER_OBJ(sp));
+  push_call(ui, "update_sp", args);
 }
 
 static void remote_ui_flush(UI *ui)

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -62,8 +62,10 @@ struct hl_group {
   int sg_gui;                   // "gui=" highlighting attributes
   RgbValue sg_rgb_fg;           // RGB foreground color
   RgbValue sg_rgb_bg;           // RGB background color
+  RgbValue sg_rgb_sp;           // RGB special color
   uint8_t *sg_rgb_fg_name;      // RGB foreground color name
   uint8_t *sg_rgb_bg_name;      // RGB background color name
+  uint8_t *sg_rgb_sp_name;      // RGB special color name
 };
 
 #define SG_CTERM        2       // cterm has been set
@@ -6170,8 +6172,8 @@ do_highlight (
       }
 
       /*
-       * Isolate the key ("term", "ctermfg", "ctermbg", "font", "guifg" or
-       * "guibg").
+       * Isolate the key ("term", "ctermfg", "ctermbg", "font", "guifg",
+       * "guibg" or "guisp").
        */
       while (*linep && !ascii_iswhite(*linep) && *linep != '=')
         ++linep;
@@ -6456,7 +6458,23 @@ do_highlight (
           normal_bg = HL_TABLE()[idx].sg_rgb_bg;
         }
       } else if (STRCMP(key, "GUISP") == 0)   {
-        // Ignored for now
+        if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
+          if (!init)
+            HL_TABLE()[idx].sg_set |= SG_GUI;
+
+          xfree(HL_TABLE()[idx].sg_rgb_sp_name);
+          if (STRCMP(arg, "NONE") != 0) {
+            HL_TABLE()[idx].sg_rgb_sp_name = (uint8_t *)xstrdup((char *)arg);
+            HL_TABLE()[idx].sg_rgb_sp = name_to_color(arg);
+          } else {
+            HL_TABLE()[idx].sg_rgb_sp_name = NULL;
+            HL_TABLE()[idx].sg_rgb_sp = -1;
+          }
+        }
+
+        if (is_normal_group) {
+          normal_sp = HL_TABLE()[idx].sg_rgb_sp;
+        }
       } else if (STRCMP(key, "START") == 0 || STRCMP(key, "STOP") == 0)   {
         // Ignored for now
       } else {
@@ -6520,6 +6538,7 @@ void restore_cterm_colors(void)
 {
   normal_fg = -1;
   normal_bg = -1;
+  normal_sp = -1;
   cterm_normal_fg_color = 0;
   cterm_normal_fg_bold = 0;
   cterm_normal_bg_color = 0;
@@ -6536,6 +6555,7 @@ static int hl_has_settings(int idx, int check_link)
          || HL_TABLE()[idx].sg_cterm_bg != 0
          || HL_TABLE()[idx].sg_rgb_fg_name != NULL
          || HL_TABLE()[idx].sg_rgb_bg_name != NULL
+         || HL_TABLE()[idx].sg_rgb_sp_name != NULL
          || (check_link && (HL_TABLE()[idx].sg_set & SG_LINK));
 }
 
@@ -6552,10 +6572,13 @@ static void highlight_clear(int idx)
   HL_TABLE()[idx].sg_gui = 0;
   HL_TABLE()[idx].sg_rgb_fg = -1;
   HL_TABLE()[idx].sg_rgb_bg = -1;
+  HL_TABLE()[idx].sg_rgb_sp = -1;
   xfree(HL_TABLE()[idx].sg_rgb_fg_name);
   HL_TABLE()[idx].sg_rgb_fg_name = NULL;
   xfree(HL_TABLE()[idx].sg_rgb_bg_name);
   HL_TABLE()[idx].sg_rgb_bg_name = NULL;
+  xfree(HL_TABLE()[idx].sg_rgb_sp_name);
+  HL_TABLE()[idx].sg_rgb_sp_name = NULL;
   /* Clear the script ID only when there is no link, since that is not
    * cleared. */
   if (HL_TABLE()[idx].sg_link == 0)
@@ -6601,7 +6624,8 @@ int get_attr_entry(attrentry_T *aep)
         && aep->cterm_bg_color == taep->cterm_bg_color
         && aep->rgb_ae_attr == taep->rgb_ae_attr
         && aep->rgb_fg_color == taep->rgb_fg_color
-        && aep->rgb_bg_color == taep->rgb_bg_color) {
+        && aep->rgb_bg_color == taep->rgb_bg_color
+        && aep->rgb_sp_color == taep->rgb_sp_color) {
       return i + ATTR_OFF;
     }
   }
@@ -6639,6 +6663,7 @@ int get_attr_entry(attrentry_T *aep)
   taep->rgb_ae_attr = aep->rgb_ae_attr;
   taep->rgb_fg_color = aep->rgb_fg_color;
   taep->rgb_bg_color = aep->rgb_bg_color;
+  taep->rgb_sp_color = aep->rgb_sp_color;
 
   return table->ga_len - 1 + ATTR_OFF;
 }
@@ -6700,6 +6725,10 @@ int hl_combine_attr(int char_attr, int prim_attr)
     if (spell_aep->rgb_bg_color >= 0) {
       new_en.rgb_bg_color = spell_aep->rgb_bg_color;
     }
+
+    if (spell_aep->rgb_sp_color >= 0) {
+      new_en.rgb_sp_color = spell_aep->rgb_sp_color;
+    }
   }
   return get_attr_entry(&new_en);
 }
@@ -6737,7 +6766,7 @@ static void highlight_list_one(int id)
   didh = highlight_list_arg(id, didh, LIST_STRING,
       0, sgp->sg_rgb_bg_name, "guibg");
   didh = highlight_list_arg(id, didh, LIST_STRING,
-      0, NULL, "guisp");
+      0, sgp->sg_rgb_sp_name, "guisp");
 
   if (sgp->sg_link && !got_int) {
     (void)syn_list_header(didh, 9999, id);
@@ -6852,7 +6881,7 @@ highlight_color (
     if (fg)
       return HL_TABLE()[id - 1].sg_rgb_fg_name;
     if (sp)
-      return NULL;
+      return HL_TABLE()[id - 1].sg_rgb_sp_name;
     return HL_TABLE()[id - 1].sg_rgb_bg_name;
   }
   if (font || sp)
@@ -6939,10 +6968,12 @@ set_hl_attr (
   // before setting attr_entry->{f,g}g_color to a other than -1
   at_en.rgb_fg_color = sgp->sg_rgb_fg_name ? sgp->sg_rgb_fg : -1;
   at_en.rgb_bg_color = sgp->sg_rgb_bg_name ? sgp->sg_rgb_bg : -1;
+  at_en.rgb_sp_color = sgp->sg_rgb_sp_name ? sgp->sg_rgb_sp : -1;
 
   if (at_en.cterm_fg_color != 0 || at_en.cterm_bg_color != 0
       || at_en.rgb_fg_color != -1 || at_en.rgb_bg_color != -1
-      || at_en.cterm_ae_attr != 0 || at_en.rgb_ae_attr != 0) {
+      || at_en.rgb_sp_color != -1 || at_en.cterm_ae_attr != 0
+      || at_en.rgb_ae_attr != 0) {
     sgp->sg_attr = get_attr_entry(&at_en);
   }
 }
@@ -7273,6 +7304,10 @@ int highlight_changed(void)
 
       if (hlt[id - 1].sg_rgb_bg != hlt[id_S - 1].sg_rgb_bg) {
         hlt[hlcnt + i].sg_rgb_bg = hlt[id - 1].sg_rgb_bg;
+      }
+
+      if (hlt[id - 1].sg_rgb_sp != hlt[id_S - 1].sg_rgb_sp) {
+        hlt[hlcnt + i].sg_rgb_sp = hlt[id - 1].sg_rgb_sp;
       }
 
       highlight_ga.ga_len = hlcnt + i + 1;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6171,12 +6171,11 @@ do_highlight (
         break;
       }
 
-      /*
-       * Isolate the key ("term", "ctermfg", "ctermbg", "font", "guifg",
-       * "guibg" or "guisp").
-       */
-      while (*linep && !ascii_iswhite(*linep) && *linep != '=')
-        ++linep;
+      // Isolate the key ("term", "ctermfg", "ctermbg", "font", "guifg",
+      // "guibg" or "guisp").
+      while (*linep && !ascii_iswhite(*linep) && *linep != '=') {
+        linep++;
+      }
       xfree(key);
       key = vim_strnsave_up(key_start, (int)(linep - key_start));
       linep = skipwhite(linep);
@@ -6579,10 +6578,11 @@ static void highlight_clear(int idx)
   HL_TABLE()[idx].sg_rgb_bg_name = NULL;
   xfree(HL_TABLE()[idx].sg_rgb_sp_name);
   HL_TABLE()[idx].sg_rgb_sp_name = NULL;
-  /* Clear the script ID only when there is no link, since that is not
-   * cleared. */
-  if (HL_TABLE()[idx].sg_link == 0)
+  // Clear the script ID only when there is no link, since that is not
+  // cleared.
+  if (HL_TABLE()[idx].sg_link == 0) {
     HL_TABLE()[idx].sg_scriptID = 0;
+  }
 }
 
 
@@ -6766,7 +6766,7 @@ static void highlight_list_one(int id)
   didh = highlight_list_arg(id, didh, LIST_STRING,
       0, sgp->sg_rgb_bg_name, "guibg");
   didh = highlight_list_arg(id, didh, LIST_STRING,
-      0, sgp->sg_rgb_sp_name, "guisp");
+                            0, sgp->sg_rgb_sp_name, "guisp");
 
   if (sgp->sg_link && !got_int) {
     (void)syn_list_header(didh, 9999, id);
@@ -6880,8 +6880,9 @@ highlight_color (
   if (modec == 'g') {
     if (fg)
       return HL_TABLE()[id - 1].sg_rgb_fg_name;
-    if (sp)
+    if (sp) {
       return HL_TABLE()[id - 1].sg_rgb_sp_name;
+    }
     return HL_TABLE()[id - 1].sg_rgb_bg_name;
   }
   if (font || sp)

--- a/src/nvim/syntax_defs.h
+++ b/src/nvim/syntax_defs.h
@@ -70,7 +70,7 @@ struct syn_state {
 // Structure shared between syntax.c, screen.c
 typedef struct attr_entry {
   short rgb_ae_attr, cterm_ae_attr;  // HL_BOLD, etc.
-  RgbValue rgb_fg_color, rgb_bg_color;
+  RgbValue rgb_fg_color, rgb_bg_color, rgb_sp_color;
   int cterm_fg_color, cterm_bg_color;
 } attrentry_T;
 

--- a/src/nvim/syntax_defs.h
+++ b/src/nvim/syntax_defs.h
@@ -69,7 +69,7 @@ struct syn_state {
 
 // Structure shared between syntax.c, screen.c
 typedef struct attr_entry {
-  short rgb_ae_attr, cterm_ae_attr;  // HL_BOLD, etc.
+  int16_t rgb_ae_attr, cterm_ae_attr;  // HL_BOLD, etc.
   RgbValue rgb_fg_color, rgb_bg_color, rgb_sp_color;
   int cterm_fg_color, cterm_bg_color;
 } attrentry_T;

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -100,6 +100,7 @@ UI *tui_start(void)
   ui->visual_bell = tui_visual_bell;
   ui->update_fg = tui_update_fg;
   ui->update_bg = tui_update_bg;
+  ui->update_sp = tui_update_sp;
   ui->flush = tui_flush;
   ui->suspend = tui_suspend;
   ui->set_title = tui_set_title;
@@ -571,6 +572,11 @@ static void tui_update_fg(UI *ui, int fg)
 static void tui_update_bg(UI *ui, int bg)
 {
   ((TUIData *)ui->data)->grid.bg = bg;
+}
+
+static void tui_update_sp(UI *ui, int sp)
+{
+  // Do nothing; 'special' color is for GUI only
 }
 
 static void tui_flush(UI *ui)

--- a/src/nvim/ugrid.h
+++ b/src/nvim/ugrid.h
@@ -21,7 +21,7 @@ struct ugrid {
   UCell **cells;
 };
 
-#define EMPTY_ATTRS ((HlAttrs){false, false, false, false, false, -1, -1})
+#define EMPTY_ATTRS ((HlAttrs){false, false, false, false, false, -1, -1, -1})
 
 #define UGRID_FOREACH_CELL(grid, top, bot, left, right, code)           \
   do {                                                                  \

--- a/src/nvim/ugrid.h
+++ b/src/nvim/ugrid.h
@@ -21,7 +21,7 @@ struct ugrid {
   UCell **cells;
 };
 
-#define EMPTY_ATTRS ((HlAttrs){false, false, false, false, false, -1, -1, -1})
+#define EMPTY_ATTRS ((HlAttrs){ false, false, false, false, false, -1, -1, -1 })
 
 #define UGRID_FOREACH_CELL(grid, top, bot, left, right, code)           \
   do {                                                                  \

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -155,6 +155,7 @@ void ui_resize(int new_width, int new_height)
 
   UI_CALL(update_fg, (ui->rgb ? normal_fg : cterm_normal_fg_color - 1));
   UI_CALL(update_bg, (ui->rgb ? normal_bg : cterm_normal_bg_color - 1));
+  UI_CALL(update_sp, (ui->rgb ? normal_sp : -1));
 
   sr.top = 0;
   sr.bot = height - 1;
@@ -388,7 +389,7 @@ static void parse_control_character(uint8_t c)
 
 static void set_highlight_args(int attr_code)
 {
-  HlAttrs rgb_attrs = { false, false, false, false, false, -1, -1 };
+  HlAttrs rgb_attrs = { false, false, false, false, false, -1, -1, -1 };
   HlAttrs cterm_attrs = rgb_attrs;
 
   if (attr_code == HL_NORMAL) {
@@ -423,6 +424,10 @@ static void set_highlight_args(int attr_code)
 
   if (aep->rgb_bg_color != normal_bg) {
     rgb_attrs.background = aep->rgb_bg_color;
+  }
+
+  if (aep->rgb_sp_color != normal_sp) {
+    rgb_attrs.special = aep->rgb_sp_color;
   }
 
   if (cterm_normal_fg_color != aep->cterm_fg_color) {

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -7,7 +7,7 @@
 
 typedef struct {
   bool bold, underline, undercurl, italic, reverse;
-  int foreground, background;
+  int foreground, background, special;
 } HlAttrs;
 
 typedef struct ui_t UI;
@@ -35,6 +35,7 @@ struct ui_t {
   void (*flush)(UI *ui);
   void (*update_fg)(UI *ui, int fg);
   void (*update_bg)(UI *ui, int bg);
+  void (*update_sp)(UI *ui, int sp);
   void (*suspend)(UI *ui);
   void (*set_title)(UI *ui, char *title);
   void (*set_icon)(UI *ui, char *icon);

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -49,6 +49,7 @@ UI *ui_bridge_attach(UI *ui, ui_main_fn ui_main, event_scheduler scheduler)
   rv->bridge.visual_bell = ui_bridge_visual_bell;
   rv->bridge.update_fg = ui_bridge_update_fg;
   rv->bridge.update_bg = ui_bridge_update_bg;
+  rv->bridge.update_sp = ui_bridge_update_sp;
   rv->bridge.flush = ui_bridge_flush;
   rv->bridge.suspend = ui_bridge_suspend;
   rv->bridge.set_title = ui_bridge_set_title;
@@ -303,6 +304,16 @@ static void ui_bridge_update_bg_event(void **argv)
 {
   UI *ui = UI(argv[0]);
   ui->update_bg(ui, PTR2INT(argv[1]));
+}
+
+static void ui_bridge_update_sp(UI *b, int sp)
+{
+  UI_CALL(b, update_sp, 2, b, INT2PTR(sp));
+}
+static void ui_bridge_update_sp_event(void **argv)
+{
+  UI *ui = UI(argv[0]);
+  ui->update_sp(ui, PTR2INT(argv[1]));
 }
 
 static void ui_bridge_flush(UI *b)

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -25,7 +25,7 @@ describe('terminal window highlighting', function()
       [5] = {background = 11},
       [6] = {foreground = 130},
       [7] = {reverse = true},
-      [8] = {background = 11}
+      [8] = {background = 11},
     })
     screen:attach(false)
     execute('enew | call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
@@ -121,7 +121,7 @@ describe('terminal window highlighting with custom palette', function()
     clear()
     screen = Screen.new(50, 7)
     screen:set_default_attr_ids({
-      [1] = {foreground = 1193046}
+      [1] = {foreground = 1193046, special = Screen.colors.Black}
     })
     screen:set_default_attr_ignore({
       [1] = {bold = true},
@@ -130,7 +130,7 @@ describe('terminal window highlighting with custom palette', function()
       [5] = {background = 11},
       [6] = {foreground = 130},
       [7] = {reverse = true},
-      [8] = {background = 11}
+      [8] = {background = 11},
     })
     screen:attach(true)
     nvim('set_var', 'terminal_color_3', '#123456')

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require('test.functional.helpers')
 local Screen = require('test.functional.ui.screen')
 local os = require('os')
-local clear, feed = helpers.clear, helpers.feed
+local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, request, eq = helpers.execute, helpers.request, helpers.eq
 
 
@@ -301,5 +301,62 @@ describe('Default highlight groups', function()
       ~                                                    |
       {1:-- INSERT --}                                         |
     ]], {[1] = {foreground = Screen.colors.Red, background = Screen.colors.Green}})
+  end)
+end)
+
+describe('New special highlight color attribute', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(25,10)
+    screen:attach()
+    screen:set_default_attr_ignore({
+      [1] = {bold=true},
+      [2] = {bold=true, foreground=Screen.colors.Blue}
+    })
+  end)
+
+  it('used for undercurls', function()
+    execute('syntax on')
+    execute('syn keyword TmpKeyword neovim')
+    execute('syn keyword TmpKeyword1 special')
+    execute('syn keyword TmpKeyword2 specialwithbg')
+    execute('syn keyword TmpKeyword3 specialwithfg')
+    execute('hi! Awesome guifg=red guibg=yellow guisp=red')
+    execute('hi! Awesome1 guisp=red')
+    execute('hi! Awesome2 guibg=yellow guisp=red')
+    execute('hi! Awesome3 guifg=red guisp=red')
+    execute('hi link TmpKeyword Awesome')
+    execute('hi link TmpKeyword1 Awesome1')
+    execute('hi link TmpKeyword2 Awesome2')
+    execute('hi link TmpKeyword3 Awesome3')
+    insert([[
+      neovim
+      awesome neovim
+      wordcontainingneovim
+      special
+      specialwithbg
+      specialwithfg
+      ]])
+    feed('Go<tab>neovim tabbed')
+    screen:expect([[
+      {1:neovim}                   |
+      awesome {1:neovim}           |
+      wordcontainingneovim     |
+      special                  |
+      {2:specialwithbg}            |
+      {3:specialwithfg}            |
+                               |
+              {1:neovim} tabbed^    |
+      ~                        |
+      -- INSERT --             |
+      ]],{
+      [1] = {background = Screen.colors.Yellow, foreground = Screen.colors.Red,
+             special = Screen.colors.Red},
+      [2] = {special = Screen.colors.Red, background = Screen.colors.Yellow},
+      [3] = {foreground = Screen.colors.Red, special = Screen.colors.Red}
+    })
+
   end)
 end)

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -312,11 +312,12 @@ describe('New special highlight color attribute', function()
     screen = Screen.new(25,10)
     screen:attach()
     screen:set_default_attr_ignore({
-      {bold=true, foreground=Screen.colors.Blue}
+      [1] = {bold = true, foreground = Screen.colors.Blue},
+      [2] = {bold = true}
     })
   end)
 
-  it('used for undercurls', function()
+  it('can be set and is applied like foreground or background', function()
     execute('syntax on')
     execute('syn keyword TmpKeyword neovim')
     execute('syn keyword TmpKeyword1 special')
@@ -343,19 +344,19 @@ describe('New special highlight color attribute', function()
       {1:neovim}                   |
       awesome {1:neovim}           |
       wordcontainingneovim     |
-      special                  |
-      {2:specialwithbg}            |
-      {3:specialwithfg}            |
+      {2:special}                  |
+      {3:specialwithbg}            |
+      {4:specialwithfg}            |
                                |
               {1:neovim} tabbed^    |
       ~                        |
-      {4:-- INSERT --}             |
+      -- INSERT --             |
     ]],{
       [1] = {background = Screen.colors.Yellow, foreground = Screen.colors.Red,
              special = Screen.colors.Red},
-      [2] = {special = Screen.colors.Red, background = Screen.colors.Yellow},
-      [3] = {foreground = Screen.colors.Red, special = Screen.colors.Red},
-      [4] = {bold = true}
+      [2] = {special = Screen.colors.Red},
+      [3] = {special = Screen.colors.Red, background = Screen.colors.Yellow},
+      [4] = {foreground = Screen.colors.Red, special = Screen.colors.Red},
     })
 
   end)

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -312,8 +312,7 @@ describe('New special highlight color attribute', function()
     screen = Screen.new(25,10)
     screen:attach()
     screen:set_default_attr_ignore({
-      [1] = {bold=true},
-      [2] = {bold=true, foreground=Screen.colors.Blue}
+      {bold=true, foreground=Screen.colors.Blue}
     })
   end)
 
@@ -350,12 +349,13 @@ describe('New special highlight color attribute', function()
                                |
               {1:neovim} tabbed^    |
       ~                        |
-      -- INSERT --             |
-      ]],{
+      {4:-- INSERT --}             |
+    ]],{
       [1] = {background = Screen.colors.Yellow, foreground = Screen.colors.Red,
              special = Screen.colors.Red},
       [2] = {special = Screen.colors.Red, background = Screen.colors.Yellow},
-      [3] = {foreground = Screen.colors.Red, special = Screen.colors.Red}
+      [3] = {foreground = Screen.colors.Red, special = Screen.colors.Red},
+      [4] = {bold = true}
     })
 
   end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -577,7 +577,7 @@ function Screen:_pprint_attrs(attrs)
     local items = {}
     for f, v in pairs(attrs) do
       local desc = tostring(v)
-      if f == "foreground" or f == "background" then
+      if f == "foreground" or f == "background" or f == "special" then
         if Screen.colornames[v] ~= nil then
           desc = "Screen.colors."..Screen.colornames[v]
         end

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -425,6 +425,10 @@ function Screen:_handle_update_bg(bg)
   self._bg = bg
 end
 
+function Screen:_handle_update_sp(sp)
+  self._sp = sp
+end
+
 function Screen:_handle_suspend()
   self.suspended = true
 end

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -618,7 +618,8 @@ function Screen:_equal_attrs(a, b)
        a.underline == b.underline and a.undercurl == b.undercurl and
        a.italic == b.italic and a.reverse == b.reverse and
        a.foreground == b.foreground and
-       a.background == b.background
+       a.background == b.background and
+       a.special == b.special
 end
 
 function Screen:_attr_index(attrs, attr)


### PR DESCRIPTION
Tried to solve https://github.com/neovim/neovim/issues/2040.
Found that this would also resolve https://github.com/neovim/neovim/issues/3370

Adds the previously removed special color field used to specify underline/undercurl color.

Used [this branch of neovim.as](https://github.com/AdnoC/neovim.as/tree/sp_color) to make sure it worked.

&nbsp;

I'm not sure how to add functional tests for this.
