### PR TITLE
vim-patch: 7.4.1347

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -467,22 +467,23 @@ int emsg(char_u *s)
 {
   int attr;
   char_u      *p;
-  int ignore = FALSE;
+  int ignore = false;
   int severe;
 
-  /* Skip this if not giving error messages at the moment. */
-  if (emsg_not_now())
-    return TRUE;
+  // Skip this if not giving error messages at the moment.
+  if (emsg_not_now()) {
+    return true;
+  }
 
-  called_emsg = TRUE;
-  ex_exitval = 1;
+  called_emsg = true;
+  if (emsg_silent == 0) {
+    ex_exitval = 1;
+  }
 
-  /*
-   * If "emsg_severe" is TRUE: When an error exception is to be thrown,
-   * prefer this message over previous messages for the same command.
-   */
+  // If "emsg_severe" is TRUE: When an error exception is to be thrown,
+  // prefer this message over previous messages for the same command.
   severe = emsg_severe;
-  emsg_severe = FALSE;
+  emsg_severe = false;
 
   if (!emsg_off || vim_strchr(p_debug, 't') != NULL) {
     /*

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -330,7 +330,7 @@ static int included_patches[] = {
   // 1350 NA
   // 1349 NA
   // 1348 NA
-  // 1347,
+  1347,
   1346,
   // 1345 NA
   // 1344 NA


### PR DESCRIPTION
Problem:    When there is any error Vim will use a non-zero exit code.
Solution:   When using ":silent!" do not set the exit code. (Yasuhiro
            Matsumoto)

https://github.com/vim/vim/commit/8b778d55993d951a65f8a59843cecd177c707676
