### PR TITLE
[RFC] vim-patch:7.4.882

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3306,6 +3306,12 @@ static bool ins_compl_prep(int c)
         showmode();
       }
 
+      // Avoid the popup menu remains displayed when leaving the
+      // command line window.
+      if (c == Ctrl_C && cmdwin_type != 0) {
+        update_screen(0);
+      }
+
       /*
        * Indent now if a key was typed that is in 'cinkeys'.
        */

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -796,7 +796,7 @@ static int included_patches[] = {
   885,
   // 884 NA
   883,
-  // 882,
+  882,
   881,
   // 880 NA
   879,

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -3,6 +3,7 @@ local helpers = require('test.functional.helpers')
 local Screen = require('test.functional.ui.screen')
 local clear, feed = helpers.clear, helpers.feed
 local eval, eq, neq = helpers.eval, helpers.eq, helpers.neq
+local insert = helpers.insert
 local execute, source, expect = helpers.execute, helpers.source, helpers.expect
 
 describe('completion', function()
@@ -714,6 +715,53 @@ describe('completion', function()
       {3:-- Keyword completion (^N^P) }{4:match 2 of 2}                   |
     ]])
   end)
+  
+  describe('from the commandline window', function()
 
+    it('is cleared after CTRL-C', function ()
+      feed('q:')
+      feed('ifoo faa fee f')
+      screen:expect([[
+                                                                    |
+        {8:[No Name]                                                   }|
+        :foo faa fee f^                                              |
+        :~                                                          |
+        :~                                                          |
+        :~                                                          |
+        {9:[Command Line]                                              }|
+        {3:-- INSERT --}                                                |
+      ]], {[3] = {bold = true},
+           [4] = {bold = true, foreground = Screen.colors.SeaGreen},
+           [8] = {reverse = true},
+           [9] = {bold = true, reverse = true}})
+      feed('<c-x><c-n>')
+      screen:expect([[
+                                                                    |
+        {8:[No Name]                                                   }|
+        :foo faa fee foo^                                            |
+        :~          {2: foo            }                                |
+        :~          {1: faa            }                                |
+        :~          {1: fee            }                                |
+        {9:[Command Line]                                              }|
+        {3:-- Keyword Local completion (^N^P) }{4:match 1 of 3}             |
+      ]],{[1] = {background = Screen.colors.LightMagenta},
+          [2] = {background = Screen.colors.Grey},
+          [3] = {bold = true},
+          [4] = {bold = true, foreground = Screen.colors.SeaGreen},
+          [8] = {reverse = true},
+          [9] = {bold = true, reverse = true}})
+      feed('<c-c>')
+      screen:expect([[
+                                                                    |
+        {8:[No Name]                                                   }|
+        :foo faa fee foo                                            |
+        :~                                                          |
+        :~                                                          |
+        :~                                                          |
+        {9:[Command Line]                                              }|
+        :foo faa fee foo^                                            |
+      ]], {[8] = {reverse = true}, [9] = {bold = true, reverse = true}})
+    end)
+  end)
 end)
 


### PR DESCRIPTION
```
Problem:    When leaving the command line window with CTRL-C while a
            completion menu is displayed the menu isn't removed.
Solution:   Force a screen update. (Hirohito Higashi)
```

https://github.com/vim/vim/commit/5f1fea28f5bc573e2430773c49e95ae1f9cc2a25

Applied manually. I want to write a test, but I can't seem to reproduce the issue.
