### PR TITLE
[RDY] Fix for missing output (#4569, ...)

### DIFF
--- a/src/nvim/event/rstream.c
+++ b/src/nvim/event/rstream.c
@@ -100,6 +100,10 @@ static void read_cb(uv_stream_t *uvstream, ssize_t cnt, const uv_buf_t *buf)
 {
   Stream *stream = uvstream->data;
 
+  if (cnt > 0) {
+    stream->num_bytes += (size_t)cnt;
+  }
+
   if (cnt <= 0) {
     if (cnt != UV_ENOBUFS
         // cnt == 0 means libuv asked for a buffer and decided it wasn't needed:
@@ -185,10 +189,6 @@ static void read_event(void **argv)
 
 static void invoke_read_cb(Stream *stream, size_t count, bool eof)
 {
-  if (stream->closed) {
-    return;
-  }
-
   // Don't let the stream be closed before the event is processed.
   stream->pending_reqs++;
 

--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -71,6 +71,7 @@ void stream_init(Loop *loop, Stream *stream, int fd, uv_stream_t *uvstream,
   stream->closed = false;
   stream->buffer = NULL;
   stream->events = NULL;
+  stream->num_bytes = 0;
 }
 
 void stream_close(Stream *stream, stream_close_cb on_stream_close)

--- a/src/nvim/event/stream.h
+++ b/src/nvim/event/stream.h
@@ -49,6 +49,7 @@ struct stream {
   size_t curmem;
   size_t maxmem;
   size_t pending_reqs;
+  size_t num_bytes;
   void *data, *internal_data;
   bool closed;
   Queue *events;

--- a/src/nvim/rbuffer.c
+++ b/src/nvim/rbuffer.c
@@ -15,7 +15,7 @@ RBuffer *rbuffer_new(size_t capacity)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_RET
 {
   if (!capacity) {
-    capacity = 0xffff;
+    capacity = 0x10000;
   }
 
   RBuffer *rv = xmalloc(sizeof(RBuffer) + capacity);


### PR DESCRIPTION
 process.c: Process termination closes streams too early 
 shell.c: Fix missing output 

Some tests fail for me, but so do the tests for upstream. Not sure what is wrong. Testing with Travis CI.

Fixes #4569
