### PR TITLE
[RFC] Satisfy testlint.

### DIFF
--- a/cmake/RunTestsLint.cmake
+++ b/cmake/RunTestsLint.cmake
@@ -1,5 +1,7 @@
+set(IGNORE_FILES "${TEST_DIR}/*/preload.lua")
+
 execute_process(
-  COMMAND ${LUACHECK_PRG} -q ${TEST_DIR}
+  COMMAND ${LUACHECK_PRG} -q ${TEST_DIR} --exclude-files ${IGNORE_FILES}
   WORKING_DIRECTORY ${TEST_DIR}
   ERROR_VARIABLE err
   RESULT_VARIABLE res

--- a/test/functional/api/tabpage_spec.lua
+++ b/test/functional/api/tabpage_spec.lua
@@ -3,7 +3,6 @@ local helpers = require('test.functional.helpers')
 local clear, nvim, tabpage, curtab, eq, ok =
   helpers.clear, helpers.nvim, helpers.tabpage, helpers.curtab, helpers.eq,
   helpers.ok
-local wait = helpers.wait
 local curtabmeths = helpers.curtabmeths
 local funcs = helpers.funcs
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1,6 +1,7 @@
 -- Sanity checks for vim_* API calls via msgpack-rpc
 local helpers = require('test.functional.helpers')
 local Screen = require('test.functional.ui.screen')
+local NIL = helpers.NIL
 local clear, nvim, eq, neq = helpers.clear, helpers.nvim, helpers.eq, helpers.neq
 local ok, nvim_async, feed = helpers.ok, helpers.nvim_async, helpers.feed
 local os_name = helpers.os_name

--- a/test/functional/autocmd/textyankpost_spec.lua
+++ b/test/functional/autocmd/textyankpost_spec.lua
@@ -1,5 +1,5 @@
 local helpers = require('test.functional.helpers')
-local clear, eval, eq, insert = helpers.clear, helpers.eval, helpers.eq, helpers.insert
+local clear, eval, eq = helpers.clear, helpers.eval, helpers.eq
 local feed, execute, expect, command = helpers.feed, helpers.execute, helpers.expect, helpers.command
 local curbufmeths, funcs, neq = helpers.curbufmeths, helpers.funcs, helpers.neq
 

--- a/test/functional/eval/json_functions_spec.lua
+++ b/test/functional/eval/json_functions_spec.lua
@@ -7,6 +7,7 @@ local eval = helpers.eval
 local execute = helpers.execute
 local exc_exec = helpers.exc_exec
 local redir_exec = helpers.redir_exec
+local NIL = helpers.NIL
 
 describe('json_decode() function', function()
   local restart = function(cmd)

--- a/test/functional/eval/special_vars_spec.lua
+++ b/test/functional/eval/special_vars_spec.lua
@@ -1,12 +1,12 @@
 local helpers = require('test.functional.helpers')
 local exc_exec = helpers.exc_exec
 local execute = helpers.execute
-local meths = helpers.meths
 local funcs = helpers.funcs
-local meths = helpers.meths
 local clear = helpers.clear
 local eval = helpers.eval
 local eq = helpers.eq
+local meths = helpers.meths
+local NIL = helpers.NIL
 
 describe('Special values', function()
   before_each(clear)

--- a/test/functional/eval/string_spec.lua
+++ b/test/functional/eval/string_spec.lua
@@ -8,6 +8,7 @@ local exc_exec = helpers.exc_exec
 local redir_exec = helpers.redir_exec
 local funcs = helpers.funcs
 local write_file = helpers.write_file
+local NIL = helpers.NIL
 
 describe('string() function', function()
   before_each(clear)

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -3,7 +3,7 @@
 local helpers = require('test.functional.helpers')
 local execute, eq, clear, eval, exc_exec =
   helpers.execute, helpers.eq, helpers.clear, helpers.eval, helpers.exc_exec
-
+local lfs = require('lfs')
 
 -- These directories will be created for testing
 local directories = {
@@ -16,13 +16,13 @@ local directories = {
 local  cwd = function() return eval('getcwd(      )') end  -- effective working dir
 local wcwd = function() return eval('getcwd( 0    )') end  -- window dir
 local tcwd = function() return eval('getcwd(-1,  0)') end  -- tab dir
-local gcwd = function() return eval('getcwd(-1, -1)') end  -- global dir
+--local gcwd = function() return eval('getcwd(-1, -1)') end  -- global dir
 
 -- Same, except these tell us if there is a working directory at all
-local  lwd = function() return eval('haslocaldir(      )') end  -- effective working dir
+--local  lwd = function() return eval('haslocaldir(      )') end  -- effective working dir
 local wlwd = function() return eval('haslocaldir( 0    )') end  -- window dir
 local tlwd = function() return eval('haslocaldir(-1,  0)') end  -- tab dir
-local glwd = function() return eval('haslocaldir(-1, -1)') end  -- global dir
+--local glwd = function() return eval('haslocaldir(-1, -1)') end  -- global dir
 
 -- Test both the `cd` and `chdir` variants
 for _, cmd in ipairs {'cd', 'chdir'} do
@@ -112,36 +112,36 @@ end
 for _, cmd in ipairs {'getcwd', 'haslocaldir'} do
   describe(cmd..'()', function()
     -- Test invalid argument types
-    local expected = 'Vim(call):E474: Invalid argument'
+    local err474 = 'Vim(call):E474: Invalid argument'
     it('fails on string', function()
-      eq(expected, exc_exec('call ' .. cmd .. '("some string")'))
+      eq(err474, exc_exec('call ' .. cmd .. '("some string")'))
     end)
     it('fails on float', function()
-      eq(expected, exc_exec('call ' .. cmd .. '(1.0)'))
+      eq(err474, exc_exec('call ' .. cmd .. '(1.0)'))
     end)
     it('fails on list', function()
-      eq(expected, exc_exec('call ' .. cmd .. '([1, 2])'))
+      eq(err474, exc_exec('call ' .. cmd .. '([1, 2])'))
     end)
     it('fails on dictionary', function()
-      eq(expected, exc_exec('call ' .. cmd .. '({"key": "value"})'))
+      eq(err474, exc_exec('call ' .. cmd .. '({"key": "value"})'))
     end)
     it('fails on funcref', function()
-      eq(expected, exc_exec('call ' .. cmd .. '(function("tr"))'))
+      eq(err474, exc_exec('call ' .. cmd .. '(function("tr"))'))
     end)
 
     -- Test invalid numbers
     it('fails on number less than -1', function()
-      eq(expected, exc_exec('call ' .. cmd .. '(-2)'))
+      eq(err474, exc_exec('call ' .. cmd .. '(-2)'))
     end)
-    local expected = 'Vim(call):E5001: Higher scope cannot be -1 if lower scope is >= 0.'
+    local err5001 = 'Vim(call):E5001: Higher scope cannot be -1 if lower scope is >= 0.'
     it('fails on -1 if previous arg is >=0', function()
-      eq(expected, exc_exec('call ' .. cmd .. '(0, -1)'))
+      eq(err5001, exc_exec('call ' .. cmd .. '(0, -1)'))
     end)
 
     -- Test wrong number of arguments
-    local expected = 'Vim(call):E118: Too many arguments for function: ' .. cmd
+    local err118 = 'Vim(call):E118: Too many arguments for function: ' .. cmd
     it('fails to parse more than one argument', function()
-      eq(expected, exc_exec('call ' .. cmd .. '(0, 0, 0)'))
+      eq(err118, exc_exec('call ' .. cmd .. '(0, 0, 0)'))
     end)
   end)
 end

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -1,5 +1,4 @@
 require('coxpcall')
-NIL = require('mpack').NIL
 local lfs = require('lfs')
 local assert = require('luassert')
 local ChildProcessStream = require('nvim.child_process_stream')
@@ -9,6 +8,8 @@ local nvim_prog = os.getenv('NVIM_PROG') or 'build/bin/nvim'
 local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
                    '--cmd', 'set shortmess+=I background=light noswapfile noautoindent laststatus=1 undodir=. directory=. viewdir=. backupdir=.',
                    '--embed'}
+
+local mpack = require('mpack')
 
 -- Formulate a path to the directory containing nvim.  We use this to
 -- help run test executables.  It helps to keep the tests working, even
@@ -452,4 +453,5 @@ return {
   curbufmeths = curbufmeths,
   curwinmeths = curwinmeths,
   curtabmeths = curtabmeths,
+  NIL = mpack.NIL
 }

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -1,8 +1,7 @@
 local helpers = require('test.functional.helpers')
 local Screen = require('test.functional.ui.screen')
-local clear, feed = helpers.clear, helpers.feed
-local eval, eq, neq = helpers.eval, helpers.eq, helpers.neq
-local execute, source, expect = helpers.execute, helpers.source, helpers.expect
+local clear, eval, eq  = helpers.clear, helpers.eval, helpers.eq
+local execute = helpers.execute
 
 local function init_session(...)
   local args = { helpers.nvim_prog, '-i', 'NONE', '--embed',

--- a/test/functional/options/shortmess_spec.lua
+++ b/test/functional/options/shortmess_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require('test.functional.helpers')
 local Screen = require('test.functional.ui.screen')
-local clear, feed, execute = helpers.clear, helpers.feed, helpers.execute
+local clear, execute = helpers.clear, helpers.execute
 
 describe("'shortmess'", function()
   local screen

--- a/test/functional/plugin/msgpack_spec.lua
+++ b/test/functional/plugin/msgpack_spec.lua
@@ -3,6 +3,7 @@ local meths = helpers.meths
 local eq, nvim_eval, nvim_command, exc_exec =
   helpers.eq, helpers.eval, helpers.command, helpers.exc_exec
 local ok = helpers.ok
+local NIL = helpers.NIL
 
 local plugin_helpers = require('test.functional.plugin.helpers')
 local reset = plugin_helpers.reset

--- a/test/unit/eval/helpers.lua
+++ b/test/unit/eval/helpers.lua
@@ -12,7 +12,7 @@ local null_list = {[true]='NULL list'}
 local type_key = {[true]='type key'}
 local list_type = {[true]='list type'}
 
-local list = function(...)
+local function list(...)
   local ret = ffi.gc(eval.list_alloc(), eval.list_unref)
   eq(0, ret.lv_refcount)
   ret.lv_refcount = 1
@@ -47,7 +47,7 @@ local lst2tbl = function(l)
   while li ~= nil do
     local typ = li.li_tv.v_type
     if typ == eval.VAR_STRING then
-      str = li.li_tv.vval.v_string
+      local str = li.li_tv.vval.v_string
       if str == nil then
         ret[#ret + 1] = null_string
       else

--- a/test/unit/mbyte_spec.lua
+++ b/test/unit/mbyte_spec.lua
@@ -3,7 +3,6 @@ local helpers = require("test.unit.helpers")
 local ffi     = helpers.ffi
 local eq      = helpers.eq
 
-local globals = helpers.cimport("./src/nvim/globals.h")
 local mbyte = helpers.cimport("./src/nvim/mbyte.h")
 
 describe('mbyte', function()
@@ -17,7 +16,7 @@ describe('mbyte', function()
 
   -- Convert from bytes to string
   local function to_string(bytes)
-    s = {}
+    local s = {}
     for i = 1, #bytes do
       s[i] = string.char(bytes[i])
     end
@@ -59,20 +58,20 @@ describe('mbyte', function()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0x7f}), pcc, 2))
       eq(0, pcc[0])
       -- No combining characters
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0x80}), pcc, 2))
       eq(0, pcc[0])
 
       -- No UTF-8 sequence
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x00c2, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x7f}), pcc, 2))
       eq(0, pcc[0])
       -- One UTF-8 character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80}), pcc, 2))
       eq(0, pcc[0])
       -- No UTF-8 sequence
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x00c2, mbyte.utfc_ptr2char_len(to_string({0xc2, 0xc0}), pcc, 2))
       eq(0, pcc[0])
     end)
@@ -84,27 +83,27 @@ describe('mbyte', function()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0x80, 0x80}), pcc, 3))
       eq(0, pcc[0])
       -- No combining character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xc2, 0x80}), pcc, 3))
       eq(0, pcc[0])
 
       -- Combining character is U+0300
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80}), pcc, 3))
       eq(0x0300, pcc[0])
       eq(0x0000, pcc[1])
 
       -- No UTF-8 sequence
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x00c2, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x7f, 0xcc}), pcc, 3))
       eq(0, pcc[0])
       -- Incomplete combining character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc}), pcc, 3))
       eq(0, pcc[0])
 
       -- One UTF-8 character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x20d0, mbyte.utfc_ptr2char_len(to_string({0xe2, 0x83, 0x90}), pcc, 3))
       eq(0, pcc[0])
     end)
@@ -116,32 +115,32 @@ describe('mbyte', function()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0x7f, 0xcc, 0x80}), pcc, 4))
       eq(0, pcc[0])
       -- No second UTF-8 character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xc2, 0xcc, 0x80}), pcc, 4))
       eq(0, pcc[0])
 
       -- Combining character U+0300
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80, 0xcc}), pcc, 4))
       eq(0x0300, pcc[0])
       eq(0x0000, pcc[1])
 
       -- No UTF-8 sequence
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x00c2, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x7f, 0xcc, 0x80}), pcc, 4))
       eq(0, pcc[0])
       -- No following UTF-8 character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc, 0xcc}), pcc, 4))
       eq(0, pcc[0])
       -- Combining character U+0301
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc, 0x81}), pcc, 4))
       eq(0x0301, pcc[0])
       eq(0x0000, pcc[1])
 
       -- One UTF-8 character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x100000, mbyte.utfc_ptr2char_len(to_string({0xf4, 0x80, 0x80, 0x80}), pcc, 4))
       eq(0, pcc[0])
     end)
@@ -153,31 +152,31 @@ describe('mbyte', function()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0x7f, 0xcc, 0x80, 0x80}), pcc, 5))
       eq(0, pcc[0])
       -- No second UTF-8 character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xc2, 0xcc, 0x80, 0x80}), pcc, 5))
       eq(0, pcc[0])
 
       -- Combining character U+0300
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80, 0xcc}), pcc, 5))
       eq(0x0300, pcc[0])
       eq(0x0000, pcc[1])
 
       -- Combining characters U+0300 and U+0301
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80, 0xcc, 0x81}), pcc, 5))
       eq(0x0300, pcc[0])
       eq(0x0301, pcc[1])
       eq(0x0000, pcc[2])
       -- Combining characters U+0300, U+0301, U+0302
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82}), pcc, 7))
       eq(0x0300, pcc[0])
       eq(0x0301, pcc[1])
       eq(0x0302, pcc[2])
       eq(0x0000, pcc[3])
       -- Combining characters U+0300, U+0301, U+0302, U+0303
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string({0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83}), pcc, 9))
       eq(0x0300, pcc[0])
       eq(0x0301, pcc[1])
@@ -185,7 +184,7 @@ describe('mbyte', function()
       eq(0x0303, pcc[3])
       eq(0x0000, pcc[4])
       -- Combining characters U+0300, U+0301, U+0302, U+0303, U+0304
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
         {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84}), pcc, 11))
       eq(0x0300, pcc[0])
@@ -196,7 +195,7 @@ describe('mbyte', function()
       eq(0x0000, pcc[5])
       -- Combining characters U+0300, U+0301, U+0302, U+0303, U+0304,
       -- U+0305
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
         {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84, 0xcc, 0x85}), pcc, 13))
       eq(0x0300, pcc[0])
@@ -209,7 +208,7 @@ describe('mbyte', function()
 
       -- Combining characters U+0300, U+0301, U+0302, U+0303, U+0304,
       -- U+0305, U+0306, but only save six (= MAX_MCO).
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
         {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xcc, 0x83, 0xcc, 0x84, 0xcc, 0x85, 0xcc, 0x86}), pcc, 15))
       eq(0x0300, pcc[0])
@@ -221,7 +220,7 @@ describe('mbyte', function()
       eq(0x0001, pcc[6])
 
       -- Only three following combining characters U+0300, U+0301, U+0302
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x007f, mbyte.utfc_ptr2char_len(to_string(
         {0x7f, 0xcc, 0x80, 0xcc, 0x81, 0xcc, 0x82, 0xc2, 0x80, 0xcc, 0x84, 0xcc, 0x85}), pcc, 13))
       eq(0x0300, pcc[0])
@@ -231,40 +230,40 @@ describe('mbyte', function()
 
 
       -- No UTF-8 sequence
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x00c2, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x7f, 0xcc, 0x80, 0x80}), pcc, 5))
       eq(0, pcc[0])
       -- No following UTF-8 character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc, 0xcc, 0x80}), pcc, 5))
       eq(0, pcc[0])
       -- Combining character U+0301
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc, 0x81, 0x7f}), pcc, 5))
       eq(0x0301, pcc[0])
       eq(0x0000, pcc[1])
       -- Combining character U+0301
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x0080, mbyte.utfc_ptr2char_len(to_string({0xc2, 0x80, 0xcc, 0x81, 0xcc}), pcc, 5))
       eq(0x0301, pcc[0])
       eq(0x0000, pcc[1])
 
       -- One UTF-8 character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x100000, mbyte.utfc_ptr2char_len(to_string({0xf4, 0x80, 0x80, 0x80, 0x7f}), pcc, 5))
       eq(0, pcc[0])
 
       -- One UTF-8 character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x100000, mbyte.utfc_ptr2char_len(to_string({0xf4, 0x80, 0x80, 0x80, 0x80}), pcc, 5))
       eq(0, pcc[0])
       -- One UTF-8 character
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x100000, mbyte.utfc_ptr2char_len(to_string({0xf4, 0x80, 0x80, 0x80, 0xcc}), pcc, 5))
       eq(0, pcc[0])
 
       -- Combining characters U+1AB0 and U+0301
-      local pcc = to_intp()
+      pcc = to_intp()
       eq(0x100000, mbyte.utfc_ptr2char_len(to_string(
         {0xf4, 0x80, 0x80, 0x80, 0xe1, 0xaa, 0xb0, 0xcc, 0x81}), pcc, 9))
       eq(0x1ab0, pcc[0])


### PR DESCRIPTION
For that, make luatest ignore the preload.lua files. In
test/functional/helpers.lua, a somewhat ugly construct was used because
luacheck seems not to recognise recursive function calls. Maybe it's a better
idea to ignore this file, too?
