### PR TITLE
vim-patch: 7.4.1401

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1294,14 +1294,15 @@ void enter_buffer(buf_T *buf)
   redraw_later(NOT_VALID);
 }
 
-/*
- * Change to the directory of the current buffer.
- */
+// Change to the directory of the current buffer.
+// Don't do this while still starting up.
 void do_autochdir(void)
 {
   if (p_acd) {
-    if (curbuf->b_ffname != NULL && vim_chdirfile(curbuf->b_ffname) == OK) {
-      shorten_fnames(TRUE);
+    if (starting == 0
+        && curbuf->b_ffname != NULL
+        && vim_chdirfile(curbuf->b_ffname) == OK) {
+      shorten_fnames(true);
     }
   }
 }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -276,7 +276,7 @@ static int included_patches[] = {
   // 1404 NA
   // 1403 NA
   // 1402 NA
-  // 1401,
+  1401,
   // 1400 NA
   // 1399 NA
   // 1398 NA


### PR DESCRIPTION
Problem:    Having 'autochdir' set during startup and using diff mode doesn't
            work. (Axel Bender)
Solution:   Don't use 'autochdir' while still starting up. (Christian
            Brabandt)

https://github.com/vim/vim/commit/6bd364e08461159ad3c153ffba4def5b896486a1
