### PR TITLE
[RFC] Remove old UNIX ifdef from buf_write()

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2688,7 +2688,6 @@ buf_write (
     } else if ((bkc & BKC_AUTO)) {          /* "auto" */
       int i;
 
-# ifdef UNIX
       /*
        * Don't rename the file when:
        * - it's a hard link
@@ -2699,9 +2698,7 @@ buf_write (
           || !os_fileinfo_link((char *)fname, &file_info)
           || !os_fileinfo_id_equal(&file_info, &file_info_old)) {
         backup_copy = TRUE;
-      } else
-# endif
-      {
+      } else {
         /*
          * Check if we can create a file and set the owner/group to
          * the ones from the original file.

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -1,0 +1,38 @@
+-- Specs for :write
+
+local helpers = require('test.functional.helpers')
+local eq, eval, clear, write_file, execute, source =
+	helpers.eq, helpers.eval, helpers.clear, helpers.write_file,
+	helpers.execute, helpers.source
+
+describe(':write', function()
+  it('&backupcopy=auto preserves symlinks', function()
+    clear('set backupcopy=auto')
+    os.remove('test_bkc_file.txt')
+    os.remove('test_bkc_link.txt')
+    write_file('test_bkc_file.txt', 'content0')
+    execute("silent !ln -s test_bkc_file.txt test_bkc_link.txt")
+    source([[
+      edit test_bkc_link.txt
+      call setline(1, ['content1'])
+      write
+    ]])
+    eq(eval("['content1']"), eval("readfile('test_bkc_file.txt')"))
+    eq(eval("['content1']"), eval("readfile('test_bkc_link.txt')"))
+  end)
+
+  it('&backupcopy=no replaces symlink with new file', function()
+    clear('set backupcopy=no')
+    os.remove('test_bkc_file.txt')
+    os.remove('test_bkc_link.txt')
+    write_file('test_bkc_file.txt', 'content0')
+    execute("silent !ln -s test_bkc_file.txt test_bkc_link.txt")
+    source([[
+      edit test_bkc_link.txt
+      call setline(1, ['content1'])
+      write
+    ]])
+    eq(eval("['content0']"), eval("readfile('test_bkc_file.txt')"))
+    eq(eval("['content1']"), eval("readfile('test_bkc_link.txt')"))
+  end)
+end)


### PR DESCRIPTION
When backupcopy=auto buf_write assumes backupcopy=yes when the file is a
hard/symbolic link. However this check was guarded by a UNIX ifdef. The
check itself is portable and the guard can be removed.

Added a couple tests to check the behaviour of bkc=auto and bkc=no
with a symbolic link.

Reported in #4525
