### PR TITLE
[RFC] Windows: Add UNIX guard for S_ISBLK in mch_nodetype

### DIFF
--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -150,8 +150,10 @@ int mch_nodetype(char_u *name)
     return NODE_NORMAL;
   if (S_ISREG(st.st_mode) || S_ISDIR(st.st_mode))
     return NODE_NORMAL;
+#ifdef UNIX
   if (S_ISBLK(st.st_mode))      /* block device isn't writable */
     return NODE_OTHER;
+#endif
   /* Everything else is writable? */
   return NODE_WRITABLE;
 }


### PR DESCRIPTION
With the refactoring of the Vim code the mch_nodetype() function in os_unix.c
can be used in windows, with the addition of a guard for the S_ISBLK case, since
there are no block devices in Windows.
