### PR TITLE
[RFC] Add missing include fcntl.h

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 
 #include <assert.h>
+#include <fcntl.h>
 
 #include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"


### PR DESCRIPTION
In Windows, open() flags like O_RDONLY need fcntl.h.

Followup for #1112
