### PR TITLE
[RFC] vim-patch:7.4.889

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -789,7 +789,7 @@ static int included_patches[] = {
   // 892 NA
   891,
   // 890 NA
-  // 889,
+  889,
   888,
   887,
   // 886 NA


### PR DESCRIPTION
https://github.com/vim/vim/commit/74b738d414b2895b3365e26ae3b7792eb82ccf47

```

Problem:    Triggering OptionSet from setwinvar() isn't tested.
Solution:   Add a test. (Christian Brabandt)
```

Merged in

https://github.com/neovim/neovim/commit/9bd8fcde1e82cb535abe46ff508de7029d8f686e

see

https://github.com/neovim/neovim/commit/9bd8fcde1e82cb535abe46ff508de7029d8f686e#diff-be8c0651553746f2f21d8c593006a113R266

Those are not _exactly_ the same tests, but really close enough.
