### PR TITLE
[RFC] vim-patch:7.4.672

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8692,7 +8692,11 @@ static void f_eventhandler(typval_T *argvars, typval_T *rettv)
  */
 static void f_executable(typval_T *argvars, typval_T *rettv)
 {
-  rettv->vval.v_number = os_can_exe(get_tv_string(&argvars[0]), NULL);
+  char_u *name = get_tv_string(&argvars[0]);
+
+  // Check in $PATH and also check directly if there is a directory name
+  rettv->vval.v_number = os_can_exe(name, NULL, true)
+           || (gettail_dir(name) != name && os_can_exe(name, NULL, false));
 }
 
 /// "exepath()" function
@@ -8701,7 +8705,7 @@ static void f_exepath(typval_T *argvars, typval_T *rettv)
   char_u *arg = get_tv_string(&argvars[0]);
   char_u *path = NULL;
 
-  (void)os_can_exe(arg, &path);
+  (void)os_can_exe(arg, &path, true);
 
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = path;
@@ -11606,7 +11610,7 @@ static char **tv_to_argv(typval_T *cmd_tv, char **cmd)
   assert(argl->lv_first);
 
   const char_u *exe = get_tv_string_chk(&argl->lv_first->li_tv);
-  if (!exe || !os_can_exe(exe, NULL)) {
+  if (!exe || !os_can_exe(exe, NULL, true)) {
     // String is not executable
     if (exe) {
       EMSG2(e_jobexe, exe);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3983,6 +3983,7 @@ static void expand_shellcmd(char_u *filepat, int *num_file, char_u ***file,
   char_u      *s, *e;
   int flags = flagsarg;
   int ret;
+  bool did_curdir = false;
 
   /* for ":set path=" and ":set tags=" halve backslashes for escaped
    * space */
@@ -3991,7 +3992,7 @@ static void expand_shellcmd(char_u *filepat, int *num_file, char_u ***file,
     if (pat[i] == '\\' && pat[i + 1] == ' ')
       STRMOVE(pat + i, pat + i + 1);
 
-  flags |= EW_FILE | EW_EXEC;
+  flags |= EW_FILE | EW_EXEC | EW_SHELLCMD;
 
   bool mustfree = false;  // Track memory allocation for *path.
   /* For an absolute name we don't use $PATH. */
@@ -4011,10 +4012,23 @@ static void expand_shellcmd(char_u *filepat, int *num_file, char_u ***file,
 
   /*
    * Go over all directories in $PATH.  Expand matches in that directory and
-   * collect them in "ga".
+   * collect them in "ga". When "." is not in $PATH also expaned for the
+   * current directory, to find "subdir/cmd".
    */
   ga_init(&ga, (int)sizeof(char *), 10);
-  for (s = path; *s != NUL; s = e) {
+  for (s = path; ; s = e) {
+    if (*s == NUL)
+	{
+	    if (did_curdir) {
+		  break;
+        }
+	    // Find directories in the current directory, path is empty.
+	    did_curdir = true;
+	}
+	else if (*s == '.') {
+	    did_curdir = true;
+    }
+
     if (*s == ' ')
       ++s;              /* Skip space used for absolute path name. */
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4017,20 +4017,19 @@ static void expand_shellcmd(char_u *filepat, int *num_file, char_u ***file,
    */
   ga_init(&ga, (int)sizeof(char *), 10);
   for (s = path; ; s = e) {
-    if (*s == NUL)
-	{
-	    if (did_curdir) {
-		  break;
-        }
-	    // Find directories in the current directory, path is empty.
-	    did_curdir = true;
-	}
-	else if (*s == '.') {
-	    did_curdir = true;
+    if (*s == NUL) {
+      if (did_curdir) {
+        break;
+      }
+      // Find directories in the current directory, path is empty.
+      did_curdir = true;
+    } else if (*s == '.') {
+      did_curdir = true;
     }
 
-    if (*s == ' ')
-      ++s;              /* Skip space used for absolute path name. */
+    if (*s == ' ') {
+      s++;              // Skip space used for absolute path name.
+    }
 
     e = vim_strchr(s, ':');
     if (e == NULL)

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -164,6 +164,7 @@ int os_nodetype(const char *name)
 ///
 /// @param[in]  name     Name of the executable.
 /// @param[out] abspath  Path of the executable, if found and not `NULL`.
+/// @param[in] use_path  If 'false', only check if "name" is executable
 ///
 /// @return `true` if `name` is executable and
 ///   - can be found in $PATH,
@@ -171,15 +172,18 @@ int os_nodetype(const char *name)
 ///   - is absolute.
 ///
 /// @return `false` otherwise.
-bool os_can_exe(const char_u *name, char_u **abspath)
+bool os_can_exe(const char_u *name, char_u **abspath, bool use_path)
   FUNC_ATTR_NONNULL_ARG(1)
 {
-  // If it's an absolute or relative path don't need to use $PATH.
-  if (path_is_absolute_path(name)
+  // when use_path is false or if it's an absolute or relative path don't
+  // need to use $PATH.
+  if (!use_path || path_is_absolute_path(name)
       || (name[0] == '.'
           && (name[1] == '/'
               || (name[1] == '.' && name[2] == '/')))) {
-    if (is_executable(name)) {
+    // There must be a path separator, files in the current directory
+    // can't be executed
+    if (gettail_dir(name) != name && is_executable(name)) {
       if (abspath != NULL) {
         *abspath = save_absolute_path(name);
       }

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -576,10 +576,11 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
     if ((dir && !(flags & EW_DIR)) || (!dir && !(flags & EW_FILE)))
       continue;
 
-    /* Skip files that are not executable if we check for that. */
+    // Skip files that are not executable if we check for that.
     if (!dir && (flags & EW_EXEC)
-        && !os_can_exe((*file)[i], NULL, !(flags & EW_SHELLCMD)))
+        && !os_can_exe((*file)[i], NULL, !(flags & EW_SHELLCMD))) {
       continue;
+    }
 
     p = xmalloc(STRLEN((*file)[i]) + 1 + dir);
     STRCPY(p, (*file)[i]);

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -577,7 +577,8 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
       continue;
 
     /* Skip files that are not executable if we check for that. */
-    if (!dir && (flags & EW_EXEC) && !os_can_exe((*file)[i], NULL))
+    if (!dir && (flags & EW_EXEC)
+        && !os_can_exe((*file)[i], NULL, !(flags & EW_SHELLCMD)))
       continue;
 
     p = xmalloc(STRLEN((*file)[i]) + 1 + dir);

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1321,8 +1321,9 @@ void addfile(
   // If the file isn't executable, may not add it.  Do accept directories.
   // When invoked from expand_shellcmd() do not use $PATH.
   if (!isdir && (flags & EW_EXEC)
-      && !os_can_exe(f, NULL, !(flags & EW_SHELLCMD)))
+      && !os_can_exe(f, NULL, !(flags & EW_SHELLCMD))) {
     return;
+  }
 
   char_u *p = xmalloc(STRLEN(f) + 1 + isdir);
 

--- a/src/nvim/path.h
+++ b/src/nvim/path.h
@@ -21,6 +21,8 @@
 /* Note: mostly EW_NOTFOUND and EW_SILENT are mutually exclusive: EW_NOTFOUND
 * is used when executing commands and EW_SILENT for interactive expanding. */
 #define EW_ALLLINKS     0x1000  // also links not pointing to existing file
+#define EW_SHELLCMD     0x2000  // called from expand_shellcmd(), don't check
+ 				                //  if executable is in $PATH
 #define EW_DODOT        0x4000  // also files starting with a dot
 #define EW_EMPTYOK      0x8000  // no matches is not an error
 

--- a/src/nvim/path.h
+++ b/src/nvim/path.h
@@ -22,7 +22,7 @@
 * is used when executing commands and EW_SILENT for interactive expanding. */
 #define EW_ALLLINKS     0x1000  // also links not pointing to existing file
 #define EW_SHELLCMD     0x2000  // called from expand_shellcmd(), don't check
- 				                //  if executable is in $PATH
+                                //  if executable is in $PATH
 #define EW_DODOT        0x4000  // also files starting with a dot
 #define EW_EMPTYOK      0x8000  // no matches is not an error
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -1006,7 +1006,7 @@ static int included_patches[] = {
   675,
   // 674 NA
   673,
-  // 672,
+  672,
   671,
   670,
   // 669 NA

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require('test.functional.helpers')
 local Screen = require('test.functional.ui.screen')
 local clear, feed, execute = helpers.clear, helpers.feed, helpers.execute
+local funcs = helpers.funcs
 
 describe("'wildmode'", function()
   local screen
@@ -28,5 +29,36 @@ describe("'wildmode'", function()
         :sign define^             |
       ]])
     end)
+  end)
+end)
+
+describe('command line completion', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(40, 5)
+    screen:attach()
+    screen:set_default_attr_ignore({{bold=true, foreground=Screen.colors.Blue}})
+  end)
+
+  after_each(function()
+    os.remove('Xtest-functional-viml-compl-dir')
+  end)
+
+  it('lists directories with empty PATH', function()
+    local tmp = funcs.tempname()
+    execute('e '.. tmp)
+    execute('cd %:h')
+    execute("call mkdir('Xtest-functional-viml-compl-dir')")
+    execute('let $PATH=""')
+    feed(':!<tab><bs>')
+    screen:expect([[
+                                              |
+      ~                                       |
+      ~                                       |
+      ~                                       |
+      :!Xtest-functional-viml-compl-dir^       |
+    ]])
   end)
 end)

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -1,4 +1,3 @@
-
 local helpers = require('test.functional.helpers')
 local Screen = require('test.functional.ui.screen')
 local clear, feed = helpers.clear, helpers.feed
@@ -716,4 +715,3 @@ describe('completion', function()
   end)
 
 end)
-

--- a/test/unit/os/fs_spec.lua
+++ b/test/unit/os/fs_spec.lua
@@ -148,7 +148,7 @@ describe('fs function', function()
     local function os_can_exe(name)
       local buf = ffi.new('char *[1]')
       buf[0] = NULL
-      local ok = fs.os_can_exe(to_cstr(name), buf)
+      local ok = fs.os_can_exe(to_cstr(name), buf, true)
 
       -- When os_can_exe returns true, it must set the path.
       -- When it returns false, the path must be NULL.


### PR DESCRIPTION
```
Problem:    When completing a shell command, directories in the current
            directory are not listed.
Solution:   When "." is not in $PATH also look in the current directory for
            directories.

```

https://github.com/vim/vim/commit/b5971141dff0c69355fd64196fcc0d0d071d4c82

I had to remove the `static` from [`gettail_dir`](https://github.com/neovim/neovim/pull/4678/commits/2957b8301ddf9096dcd927f2ab8d82018cb38e98#diff-d2b13f507f185cdf05782bb8265bc7c4R984) but I also had to change the argument to `const char_u *` since that is how it's called from [`os_can_exe`](https://github.com/neovim/neovim/pull/4678/commits/2957b8301ddf9096dcd927f2ab8d82018cb38e98#diff-18c107854edb477cc21ea52d4bcfa368R185). Kinda makes sense, since the argument is not modified, so it might even be `const char_u * const`. Am I going in the right direction with this?

The only tests failing now are the same as on master, see https://github.com/neovim/neovim/issues/4685.
