### PR TITLE
[RFC] Windows: without libintl use LC_CTYPE instead of LC_MESSAGES

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3183,8 +3183,11 @@ void set_lang_var(void)
    * back to LC_CTYPE if it's empty. */
 # ifdef HAVE_WORKING_LIBINTL
   loc = (char *) get_mess_env();
-# else
+# elif defined(LC_MESSAGES)
   loc = get_locale_val(LC_MESSAGES);
+# else
+  // In Windows LC_MESSAGES is not defined fallback to LC_CTYPE
+  loc = get_locale_val(LC_CTYPE);
 # endif
   set_vim_var_string(VV_LANG, loc, -1);
 


### PR DESCRIPTION
If libintl is not available, LC_MESSAGES is not defined. For now fallback to
using LC_CTYPE.

Neovim and Vim have diverged significantly in ex_cmds2.c concerning this logic.
In other locations the fallback is actually LC_COLLATE, but in this case Vim
calls get_mess_env() (which in turn falls back to LC_CTYPE).

In Neovim get_mess_env() is only available with libint. This means we are not
completely consistent with Vim when handling LC_ environment variables and do
not build against libintl.
