### PR TITLE
[RFC] Windows: Include winsock2.h before windows.h

### DIFF
--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -1,6 +1,9 @@
 #ifndef NVIM_OS_WIN_DEFS_H
 #define NVIM_OS_WIN_DEFS_H
 
+// winsock2.h must be first to avoid incompatibilities
+// with winsock.h (included by windows.h)
+#include <winsock2.h>
 #include <windows.h>
 #include <sys/stat.h>
 #include <io.h>


### PR DESCRIPTION
winsock2.h is incompatible with winsock.h (included by windows.h) and must
be included first. For reference see

```
https://msdn.microsoft.com/en-us/library/windows/desktop/ms737629%28v=vs.85%29.aspx
```
