### PR TITLE
[RFC] MSVC: Avoid variadic macro bug in STATIC_ASSERT

### DIFF
--- a/src/nvim/assert.h
+++ b/src/nvim/assert.h
@@ -46,10 +46,10 @@
 
 #define STATIC_ASSERT_PRAGMA_START
 #define STATIC_ASSERT_PRAGMA_END
-#define STATIC_ASSERT(...) \
+#define STATIC_ASSERT(cond, msg) \
     do { \
       STATIC_ASSERT_PRAGMA_START \
-      STATIC_ASSERT_STATEMENT(__VA_ARGS__); \
+      STATIC_ASSERT_STATEMENT(cond, msg); \
       STATIC_ASSERT_PRAGMA_END \
     } while (0)
 


### PR DESCRIPTION
MSVC does not handle **VA_ARGS** as expected in STATIC_ASSERT, avoid its use
to work around it since we don't need it. The underlying issue seems to be one
of

```
https://connect.microsoft.com/VisualStudio/Feedback/Details/1232378
https://connect.microsoft.com/VisualStudio/Feedback/Details/1099052
```

The bug only seems to manifest when using multiple variadic macros that call
each other.
