### PR TITLE
Add iequal to completeopt option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1526,14 +1526,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    completion in the preview window.  Only works in
 		    combination with "menu" or "menuone".
 
-	  noinsert  Do not insert any text for a match until the user selects
+	   noinsert Do not insert any text for a match until the user selects
 		    a match from the menu. Only works in combination with
 		    "menu" or "menuone". No effect if "longest" is present.
 
-	  noselect  Do not select a match in the menu, force the user to
+	   noselect Do not select a match in the menu, force the user to
 		    select one from the menu. Only works in combination with
 		    "menu" or "menuone".
 
+	   iequal   Ignore the same candidates with the user input when
+		    narrowing.
 
 						*'concealcursor'* *'cocu'*
 'concealcursor' 'cocu'	string (default: "")

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2211,9 +2211,13 @@ static bool ins_compl_equal(compl_T *match, char_u *str, size_t len)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
   if (match->cp_icase) {
-    return STRNICMP(match->cp_str, str, len) == 0;
+    return STRNICMP(match->cp_str, str, len) == 0
+            && (strstr((char *)p_cot, "iequal") == NULL
+                || STRCMP(match->cp_str, str) != 0);
   }
-  return STRNCMP(match->cp_str, str, len) == 0;
+  return STRNCMP(match->cp_str, str, len) == 0
+          && (strstr((char *)p_cot, "iequal") == NULL
+              || STRCMP(match->cp_str, str) != 0);
 }
 
 /*

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -285,8 +285,9 @@ static char *(p_bs_values[]) =        { "indent", "eol", "start", NULL };
 static char *(p_fdm_values[]) =       { "manual", "expr", "marker", "indent",
                                         "syntax",  "diff", NULL };
 static char *(p_fcl_values[]) =       { "all", NULL };
-static char *(p_cot_values[]) =       { "menu", "menuone", "longest", "preview",
-                                        "noinsert", "noselect", NULL };
+static char *(p_cot_values[]) =       { "menu", "menuone", "longest",
+                                        "preview", "noinsert", "noselect",
+                                        "iequal", NULL };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "option.c.generated.h"

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -312,6 +312,51 @@ describe('completion', function()
       feed('i<C-r>=TestComplete()<CR><ESC>')
       eq(0, eval('&l:modified'))
     end)
+    it('does not ignores the generated candidates if iequal', function()
+      execute('set completeopt+=menuone,iequal')
+      execute('set ignorecase')
+      feed('ifoo<ESC>ofoo<C-x><C-n>')
+      screen:expect([[
+        foo                                                         |
+        foo^                                                         |
+        {2:foo            }                                             |
+        ~                                                           |
+        ~                                                           |
+        ~                                                           |
+        ~                                                           |
+        {3:-- Keyword Local completion (^N^P) The only match}           |
+      ]])
+    end)
+    it('ignores the same candidate if iequal', function()
+      execute('set completeopt+=menuone,iequal')
+      execute('set ignorecase')
+      feed('ifoo<ESC>of<C-x><C-n><C-p>oo')
+      screen:expect([[
+        foo                                                         |
+        foo^                                                         |
+        ~                                                           |
+        ~                                                           |
+        ~                                                           |
+        ~                                                           |
+        ~                                                           |
+        {3:-- Keyword Local completion (^N^P) }{5:Back at original}         |
+      ]])
+    end)
+    it('does not ignore the case if iequal', function()
+      execute('set completeopt+=menuone,iequal')
+      execute('set ignorecase')
+      feed('ifoo<ESC>oF<C-x><C-n><C-p>oo')
+      screen:expect([[
+        foo                                                         |
+        Foo^                                                         |
+        {1:foo            }                                             |
+        ~                                                           |
+        ~                                                           |
+        ~                                                           |
+        ~                                                           |
+        {3:-- Keyword Local completion (^N^P) }{5:Back at original}         |
+      ]])
+    end)
   end)
 
   describe("refresh:always", function()
@@ -644,7 +689,6 @@ describe('completion', function()
       ]])
     end)
   end)
-
 
   it('disables folding during completion', function ()
     execute("set foldmethod=indent")


### PR DESCRIPTION
I have added "iequal" value to completeopt option.

It ignores the same candidates with the user input.

https://github.com/Shougo/deoplete.nvim/issues/267
