### PR TITLE
Add check for boolean operators placement

### DIFF
--- a/clint.py
+++ b/clint.py
@@ -2305,6 +2305,13 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
     if match:
         error(filename, linenum, 'whitespace/operators', 3,
               'Missing spaces around %s' % match.group(1))
+
+    # Boolean operators should be placed on the next line.
+    if Search(r'(?:&&|\|\|)$', line):
+        error(filename, linenum, 'whitespace/operators', 4,
+              'Boolean operator should be placed on the same line as the start '
+              'of its right operand')
+
     # We allow no-spaces around << when used like this: 10<<20, but
     # not otherwise (particularly, not when used as streams)
     # Also ignore using ns::operator<<;

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -57,8 +57,8 @@ void window_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
 {
   win_T *win = find_window_by_handle(window, err);
 
-  if (pos.size != 2 || pos.items[0].type != kObjectTypeInteger ||
-      pos.items[1].type != kObjectTypeInteger) {
+  if (pos.size != 2 || pos.items[0].type != kObjectTypeInteger
+      || pos.items[1].type != kObjectTypeInteger) {
     api_set_error(err,
                   Validation,
                   _("Argument \"pos\" must be a [row, col] array"));

--- a/src/nvim/arabic.c
+++ b/src/nvim/arabic.c
@@ -1367,8 +1367,8 @@ int arabic_shape(int c, int *ccp, int *c1p, int prev_c, int prev_c1,
   int prev_laa = A_firstc_laa(prev_c, prev_c1);
 
   if (curr_laa) {
-    if (A_is_valid(prev_c) && !A_is_f(shape_c) && !A_is_s(shape_c) &&
-        !prev_laa) {
+    if (A_is_valid(prev_c) && !A_is_f(shape_c) && !A_is_s(shape_c)
+        && !prev_laa) {
       curr_c = chg_c_laa2f(curr_laa);
     } else {
       curr_c = chg_c_laa2i(curr_laa);
@@ -1454,19 +1454,19 @@ static bool A_is_harakat(int c)
 //     (alphabet/number/punctuation)
 static bool A_is_iso(int c)
 {
-  return (c >= a_HAMZA && c <= a_GHAIN) ||
-         (c >= a_TATWEEL && c <= a_HAMZA_BELOW) ||
-         c == a_MINI_ALEF;
+  return ((c >= a_HAMZA && c <= a_GHAIN)
+          || (c >= a_TATWEEL && c <= a_HAMZA_BELOW)
+          || c == a_MINI_ALEF);
 }
 
 // A_is_formb returns true if 'c' is an Arabic 10646-1 FormB character.
 //     (alphabet/number/punctuation)
 static bool A_is_formb(int c)
 {
-  return (c >= a_s_FATHATAN && c <= a_s_DAMMATAN) ||
-         c == a_s_KASRATAN ||
-         (c >= a_s_FATHA && c <= a_f_LAM_ALEF) ||
-         c == a_BYTE_ORDER_MARK;
+  return ((c >= a_s_FATHATAN && c <= a_s_DAMMATAN)
+          || c == a_s_KASRATAN
+          || (c >= a_s_FATHA && c <= a_f_LAM_ALEF)
+          || c == a_BYTE_ORDER_MARK);
 }
 
 // A_is_ok returns true if 'c' is an Arabic 10646 (8859-6 or Form-B).

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -407,10 +407,9 @@ close_buffer (
   buf->b_nwindows = nwindows;
 
   buf_freeall(buf, (del_buf ? BFA_DEL : 0) + (wipe_buf ? BFA_WIPE : 0));
-  if (
-    win_valid(win) &&
-    win->w_buffer == buf)
-    win->w_buffer = NULL;      /* make sure we don't use the buffer now */
+  if (win_valid(win) && win->w_buffer == buf) {
+    win->w_buffer = NULL;  // make sure we don't use the buffer now
+  }
 
   /* Autocommands may have deleted the buffer. */
   if (!buf_valid(buf))
@@ -1340,8 +1339,8 @@ buflist_new (
   /* We can use inode numbers when the file exists.  Works better
    * for hard links. */
   FileID file_id;
-  bool file_id_valid = (sfname != NULL &&
-                        os_fileid((char *)sfname, &file_id));
+  bool file_id_valid = (sfname != NULL
+                        && os_fileid((char *)sfname, &file_id));
   if (ffname != NULL && !(flags & BLN_DUMMY)
       && (buf = buflist_findname_file_id(ffname, &file_id,
                                          file_id_valid)) != NULL) {

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4424,11 +4424,10 @@ static int ins_complete(int c, bool enable_pum)
           prefix = (char_u *)"";
         STRCPY((char *)compl_pattern, prefix);
         (void)quote_meta(compl_pattern + STRLEN(prefix),
-            line + compl_col, compl_length);
-      } else if (--startcol < 0 ||
-                 !vim_iswordp(mb_prevptr(line, line + startcol + 1))
-                 ) {
-        /* Match any word of at least two chars */
+                         line + compl_col, compl_length);
+      } else if (--startcol < 0
+                 || !vim_iswordp(mb_prevptr(line, line + startcol + 1))) {
+        // Match any word of at least two chars
         compl_pattern = vim_strsave((char_u *)"\\<\\k\\k");
         compl_col += curs_col;
         compl_length = 0;
@@ -6684,8 +6683,8 @@ bool in_cinkeys(int keytyped, int when, bool line_is_empty)
     } else if (*look == 'e') {
       if (try_match && keytyped == 'e' && curwin->w_cursor.col >= 4) {
         p = get_cursor_line_ptr();
-        if (skipwhite(p) == p + curwin->w_cursor.col - 4 &&
-            STRNCMP(p + curwin->w_cursor.col - 4, "else", 4) == 0) {
+        if (skipwhite(p) == p + curwin->w_cursor.col - 4
+            && STRNCMP(p + curwin->w_cursor.col - 4, "else", 4) == 0) {
           return true;
         }
       }
@@ -7384,17 +7383,16 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
    * can't backup past starting point unless 'backspace' > 1
    * can backup to a previous line if 'backspace' == 0
    */
-  if (       bufempty()
-             || (
-               !revins_on &&
-               ((curwin->w_cursor.lnum == 1 && curwin->w_cursor.col == 0)
-                || (!can_bs(BS_START)
-                    && (arrow_used
-                        || (curwin->w_cursor.lnum == Insstart_orig.lnum
-                            && curwin->w_cursor.col <= Insstart_orig.col)))
-                || (!can_bs(BS_INDENT) && !arrow_used && ai_col > 0
-                    && curwin->w_cursor.col <= ai_col)
-                || (!can_bs(BS_EOL) && curwin->w_cursor.col == 0)))) {
+  if (bufempty()
+      || (!revins_on
+          && ((curwin->w_cursor.lnum == 1 && curwin->w_cursor.col == 0)
+              || (!can_bs(BS_START)
+                  && (arrow_used
+                      || (curwin->w_cursor.lnum == Insstart_orig.lnum
+                          && curwin->w_cursor.col <= Insstart_orig.col)))
+              || (!can_bs(BS_INDENT) && !arrow_used && ai_col > 0
+                  && curwin->w_cursor.col <= ai_col)
+              || (!can_bs(BS_EOL) && curwin->w_cursor.col == 0)))) {
     vim_beep(BO_BS);
     return false;
   }
@@ -7640,14 +7638,14 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
           if (revins_on && gchar_cursor() == NUL)
             break;
         }
-        /* Just a single backspace?: */
-        if (mode == BACKSPACE_CHAR)
+        // Just a single backspace?:
+        if (mode == BACKSPACE_CHAR) {
           break;
-      } while (
-        revins_on ||
-        (curwin->w_cursor.col > mincol
-         && (curwin->w_cursor.lnum != Insstart_orig.lnum
-             || curwin->w_cursor.col != Insstart_orig.col)));
+        }
+      } while (revins_on
+               || (curwin->w_cursor.col > mincol
+                   && (curwin->w_cursor.lnum != Insstart_orig.lnum
+                       || curwin->w_cursor.col != Insstart_orig.col)));
     }
     did_backspace = true;
   }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2266,8 +2266,8 @@ static void set_var_lval(lval_T *lp, char_u *endp, typval_T *rettv, int copy, ch
         if (get_var_tv(lp->ll_name, (int)STRLEN(lp->ll_name),
                        &tv, &di, true, false) == OK) {
           if ((di == NULL
-               || (!var_check_ro(di->di_flags, lp->ll_name, false) &&
-                   !tv_check_lock(di->di_tv.v_lock, lp->ll_name, false)))
+               || (!var_check_ro(di->di_flags, lp->ll_name, false)
+                   && !tv_check_lock(di->di_tv.v_lock, lp->ll_name, false)))
               && tv_op(&tv, rettv, op) == OK) {
             set_var(lp->ll_name, &tv, false);
           }
@@ -7655,8 +7655,9 @@ static void assert_bool(typval_T *argvars, bool is_true)
   int error = (int)false;
   garray_T ga;
 
-  if ((argvars[0].v_type != VAR_NUMBER ||
-       (get_tv_number_chk(&argvars[0], &error) == 0) == is_true || error)
+  if ((argvars[0].v_type != VAR_NUMBER
+       || (get_tv_number_chk(&argvars[0], &error) == 0) == is_true
+       || error)
       && (argvars[0].v_type != VAR_SPECIAL
           || (argvars[0].vval.v_special
               != (SpecialVarValue) (is_true
@@ -15140,12 +15141,12 @@ static void do_sort_uniq(typval_T *argvars, typval_T *rettv, bool sort)
     EMSG2(_(e_listarg), sort ? "sort()" : "uniq()");
   } else {
     l = argvars[0].vval.v_list;
-    if (l == NULL ||
-        tv_check_lock(l->lv_lock,
-                      (char_u *)(sort
-                                 ? N_("sort() argument")
-                                 : N_("uniq() argument")),
-                      true)) {
+    if (l == NULL
+        || tv_check_lock(l->lv_lock,
+                         (char_u *)(sort
+                                    ? N_("sort() argument")
+                                    : N_("uniq() argument")),
+                         true)) {
       return;
     }
     rettv->vval.v_list = l;
@@ -19265,9 +19266,10 @@ void ex_function(exarg_T *eap)
       if ((p[0] == 'a' && (!ASCII_ISALPHA(p[1]) || p[1] == 'p'))
           || (p[0] == 'i'
               && (!ASCII_ISALPHA(p[1]) || (p[1] == 'n'
-                                           && (!ASCII_ISALPHA(p[2]) ||
-                                               (p[2] == 's'))))))
+                                           && (!ASCII_ISALPHA(p[2])
+                                               || (p[2] == 's')))))) {
         skip_until = vim_strsave((char_u *)".");
+      }
 
       // Check for ":python <<EOF", ":lua <<EOF", etc.
       arg = skipwhite(skiptowhite(p));
@@ -19534,11 +19536,12 @@ trans_function_name (
       *pp = end;
     } else {
       if (!skip && !(flags & TFN_QUIET) && (fdp == NULL
-                                            || lv.ll_dict == NULL ||
-                                            fdp->fd_newkey == NULL))
+                                            || lv.ll_dict == NULL
+                                            || fdp->fd_newkey == NULL)) {
         EMSG(_(e_funcref));
-      else
+      } else {
         *pp = end;
+      }
       name = NULL;
     }
     goto theend;
@@ -20438,9 +20441,9 @@ call_user_func (
 
   --RedrawingDisabled;
 
-  /* when the function was aborted because of an error, return -1 */
-  if ((did_emsg &&
-       (fp->uf_flags & FC_ABORT)) || rettv->v_type == VAR_UNKNOWN) {
+  // when the function was aborted because of an error, return -1
+  if ((did_emsg
+       && (fp->uf_flags & FC_ABORT)) || rettv->v_type == VAR_UNKNOWN) {
     clear_tv(rettv);
     rettv->v_type = VAR_NUMBER;
     rettv->vval.v_number = -1;

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -187,9 +187,9 @@ int process_wait(Process *proc, int ms, Queue *events) FUNC_ATTR_NONNULL_ARG(1)
   // being freed) before we have a chance to get the status.
   proc->refcount++;
   LOOP_PROCESS_EVENTS_UNTIL(proc->loop, events, ms,
-      // Until...
-      got_int ||             // interrupted by the user
-      proc->refcount == 1);  // job exited
+                            // Until...
+                            got_int                   // interrupted by the user
+                            || proc->refcount == 1);  // job exited
 
   // we'll assume that a user frantically hitting interrupt doesn't like
   // the current job. Signal that it has to be killed.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -650,13 +650,13 @@ void ex_retab(exarg_T *eap)
             num_tabs += num_spaces / new_ts;
             num_spaces -= (num_spaces / new_ts) * new_ts;
           }
-          if (curbuf->b_p_et || got_tab ||
-              (num_spaces + num_tabs < len)) {
-            if (did_undo == FALSE) {
-              did_undo = TRUE;
+          if (curbuf->b_p_et || got_tab
+              || (num_spaces + num_tabs < len)) {
+            if (did_undo == false) {
+              did_undo = true;
               if (u_save((linenr_T)(lnum - 1),
-                      (linenr_T)(lnum + 1)) == FAIL) {
-                new_line = NULL;                        /* flag out-of-memory */
+                         (linenr_T)(lnum + 1)) == FAIL) {
+                new_line = NULL;  // flag out-of-memory
                 break;
               }
             }
@@ -1623,15 +1623,14 @@ int do_write(exarg_T *eap)
     }
   }
 
-  /*
-   * Writing to the current file is not allowed in readonly mode
-   * and a file name is required.
-   * "nofile" and "nowrite" buffers cannot be written implicitly either.
-   */
-  if (!other && (
-        bt_dontwrite_msg(curbuf) ||
-        check_fname() == FAIL || check_readonly(&eap->forceit, curbuf)))
+  // Writing to the current file is not allowed in readonly mode
+  // and a file name is required.
+  // "nofile" and "nowrite" buffers cannot be written implicitly either.
+  if (!other && (bt_dontwrite_msg(curbuf)
+                 || check_fname() == FAIL
+                 || check_readonly(&eap->forceit, curbuf))) {
     goto theend;
+  }
 
   if (!other) {
     ffname = curbuf->b_ffname;
@@ -2258,16 +2257,15 @@ do_ecmd (
           delbuf_msg(new_name);                 /* frees new_name */
           goto theend;
         }
-        if (buf == curbuf)                      /* already in new buffer */
-          auto_buf = TRUE;
-        else {
-          /*
-           * <VN> We could instead free the synblock
-           * and re-attach to buffer, perhaps.
-           */
-          if (curwin->w_buffer != NULL &&
-              curwin->w_s == &(curwin->w_buffer->b_s))
+        if (buf == curbuf) {  // already in new buffer
+          auto_buf = true;
+        } else {
+          // <VN> We could instead free the synblock
+          // and re-attach to buffer, perhaps.
+          if (curwin->w_buffer != NULL
+              && curwin->w_s == &(curwin->w_buffer->b_s)) {
             curwin->w_s = &(buf->b_s);
+          }
 
           curwin->w_buffer = buf;
           curbuf = buf;
@@ -2294,11 +2292,11 @@ do_ecmd (
 
     curwin->w_pcmark.lnum = 1;
     curwin->w_pcmark.col = 0;
-  } else { /* !other_file */
-    if (
-      (flags & ECMD_ADDBUF) ||
-      check_fname() == FAIL)
+  } else {  // !other_file
+    if ((flags & ECMD_ADDBUF)
+        || check_fname() == FAIL) {
       goto theend;
+    }
     oldbuf = (flags & ECMD_OLDBUF);
   }
 
@@ -5818,13 +5816,14 @@ void set_context_in_sign_cmd(expand_T *xp, char_u *arg)
     switch (cmd_idx)
     {
       case SIGNCMD_DEFINE:
-        if (STRNCMP(last, "texthl", p - last) == 0 ||
-            STRNCMP(last, "linehl", p - last) == 0)
+        if (STRNCMP(last, "texthl", p - last) == 0
+            || STRNCMP(last, "linehl", p - last) == 0) {
           xp->xp_context = EXPAND_HIGHLIGHT;
-        else if (STRNCMP(last, "icon", p - last) == 0)
+        } else if (STRNCMP(last, "icon", p - last) == 0) {
           xp->xp_context = EXPAND_FILES;
-        else
+        } else {
           xp->xp_context = EXPAND_NOTHING;
+        }
         break;
       case SIGNCMD_PLACE:
         if (STRNCMP(last, "name", p - last) == 0)

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -432,14 +432,12 @@ dbg_parsearg (
 
   bp = &DEBUGGY(gap, gap->ga_len);
 
-  /* Find "func" or "file". */
-  if (STRNCMP(p, "func", 4) == 0)
+  // Find "func" or "file".
+  if (STRNCMP(p, "func", 4) == 0) {
     bp->dbg_type = DBG_FUNC;
-  else if (STRNCMP(p, "file", 4) == 0)
+  } else if (STRNCMP(p, "file", 4) == 0) {
     bp->dbg_type = DBG_FILE;
-  else if (
-    gap != &prof_ga &&
-    STRNCMP(p, "here", 4) == 0) {
+  } else if (gap != &prof_ga && STRNCMP(p, "here", 4) == 0) {
     if (curbuf->b_ffname == NULL) {
       EMSG(_(e_noname));
       return FAIL;
@@ -452,16 +450,15 @@ dbg_parsearg (
   }
   p = skipwhite(p + 4);
 
-  /* Find optional line number. */
-  if (here)
+  // Find optional line number.
+  if (here) {
     bp->dbg_lnum = curwin->w_cursor.lnum;
-  else if (
-    gap != &prof_ga &&
-    ascii_isdigit(*p)) {
+  } else if (gap != &prof_ga && ascii_isdigit(*p)) {
     bp->dbg_lnum = getdigits_long(&p);
     p = skipwhite(p);
-  } else
+  } else {
     bp->dbg_lnum = 0;
+  }
 
   /* Find the function or file name.  Don't accept a function name with (). */
   if ((!here && *p == NUL)
@@ -700,14 +697,13 @@ debuggy_find (
     /* Skip entries that are not useful or are for a line that is beyond
      * an already found breakpoint. */
     bp = &DEBUGGY(gap, i);
-    if (((bp->dbg_type == DBG_FILE) == file && (
-           gap == &prof_ga ||
-           (bp->dbg_lnum > after && (lnum == 0 || bp->dbg_lnum < lnum))))) {
-      /*
-       * Save the value of got_int and reset it.  We don't want a
-       * previous interruption cancel matching, only hitting CTRL-C
-       * while matching should abort it.
-       */
+    if (((bp->dbg_type == DBG_FILE) == file
+         && (gap == &prof_ga
+             || (bp->dbg_lnum > after
+                 && (lnum == 0 || bp->dbg_lnum < lnum))))) {
+      // Save the value of got_int and reset it.  We don't want a
+      // previous interruption cancel matching, only hitting CTRL-C
+      // while matching should abort it.
       prev_got_int = got_int;
       got_int = FALSE;
       if (vim_regexec_prog(&bp->dbg_prog, false, name, (colnr_T)0)) {
@@ -1937,8 +1933,8 @@ void ex_listdo(exarg_T *eap)
       if (buf != NULL) {
         goto_buffer(eap, DOBUF_FIRST, FORWARD, buf->b_fnum);
       }
-    } else if (eap->cmdidx == CMD_cdo || eap->cmdidx == CMD_ldo ||
-               eap->cmdidx == CMD_cfdo || eap->cmdidx == CMD_lfdo) {
+    } else if (eap->cmdidx == CMD_cdo || eap->cmdidx == CMD_ldo
+               || eap->cmdidx == CMD_cfdo || eap->cmdidx == CMD_lfdo) {
       qf_size = qf_get_size(eap);
       assert(eap->line1 >= 0);
       if (qf_size == 0 || (size_t)eap->line1 > qf_size) {
@@ -2040,8 +2036,8 @@ void ex_listdo(exarg_T *eap)
         }
       }
 
-      if (eap->cmdidx == CMD_cdo || eap->cmdidx == CMD_ldo ||
-          eap->cmdidx == CMD_cfdo || eap->cmdidx == CMD_lfdo) {
+      if (eap->cmdidx == CMD_cdo || eap->cmdidx == CMD_ldo
+          || eap->cmdidx == CMD_cfdo || eap->cmdidx == CMD_lfdo) {
         assert(i >= 0);
         if ((size_t)i >= qf_size || i >= eap->line2) {
           break;

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -403,14 +403,15 @@ char_u *get_exception_string(void *value, int type, char_u *cmdname, int *should
                       && (p[3] == ':'
                           || (ascii_isdigit(p[3])
                               && p[4] == ':')))))) {
-        if (*p == NUL || p == mesg)
-          STRCAT(val, mesg);            /* 'E123' missing or at beginning */
-        else {
-          /* '"filename" E123: message text' */
-          if (mesg[0] != '"' || p-2 < &mesg[1] ||
-              p[-2] != '"' || p[-1] != ' ')
-            /* "E123:" is part of the file name. */
+        if (*p == NUL || p == mesg) {
+          STRCAT(val, mesg);  // 'E123' missing or at beginning
+        } else {
+          // '"filename" E123: message text'
+          if (mesg[0] != '"' || p-2 < &mesg[1]
+              || p[-2] != '"' || p[-1] != ' ') {
+            // "E123:" is part of the file name.
             continue;
+          }
 
           STRCAT(val, p);
           p[-2] = NUL;
@@ -1565,22 +1566,21 @@ void ex_endtry(exarg_T *eap)
   void        *rettv = NULL;
   struct condstack    *cstack = eap->cstack;
 
-  if (cstack->cs_trylevel <= 0 || cstack->cs_idx < 0)
+  if (cstack->cs_trylevel <= 0 || cstack->cs_idx < 0) {
     eap->errmsg = (char_u *)N_("E602: :endtry without :try");
-  else {
-    /*
-     * Don't do something after an error, interrupt or throw in the try
-     * block, catch clause, or finally clause preceding this ":endtry" or
-     * when an error or interrupt occurred after a ":continue", ":break",
-     * ":return", or ":finish" in a try block or catch clause preceding this
-     * ":endtry" or when the try block never got active (because of an
-     * inactive surrounding conditional or after an error or interrupt or
-     * throw) or when there is a surrounding conditional and it has been
-     * made inactive by a ":continue", ":break", ":return", or ":finish" in
-     * the finally clause.  The latter case need not be tested since then
-     * anything pending has already been discarded. */
-    skip = did_emsg || got_int || did_throw ||
-           !(cstack->cs_flags[cstack->cs_idx] & CSF_TRUE);
+  } else {
+    // Don't do something after an error, interrupt or throw in the try
+    // block, catch clause, or finally clause preceding this ":endtry" or
+    // when an error or interrupt occurred after a ":continue", ":break",
+    // ":return", or ":finish" in a try block or catch clause preceding this
+    // ":endtry" or when the try block never got active (because of an
+    // inactive surrounding conditional or after an error or interrupt or
+    // throw) or when there is a surrounding conditional and it has been
+    // made inactive by a ":continue", ":break", ":return", or ":finish" in
+    // the finally clause.  The latter case need not be tested since then
+    // anything pending has already been discarded.
+    skip = (did_emsg || got_int || did_throw
+            || !(cstack->cs_flags[cstack->cs_idx] & CSF_TRUE));
 
     if (!(cstack->cs_flags[cstack->cs_idx] & CSF_TRY)) {
       eap->errmsg = get_end_emsg(cstack);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -624,8 +624,8 @@ static int command_line_execute(VimState *state, int key)
     // CTRL-\ e doesn't work when obtaining an expression, unless it
     // is in a mapping.
     if (s->c != Ctrl_N && s->c != Ctrl_G && (s->c != 'e'
-                                       || (ccline.cmdfirstc == '=' &&
-                                           KeyTyped))) {
+                                             || (ccline.cmdfirstc == '='
+                                                 && KeyTyped))) {
       vungetc(s->c);
       s->c = Ctrl_BSL;
     } else if (s->c == 'e') {

--- a/src/nvim/farsi.c
+++ b/src/nvim/farsi.c
@@ -100,8 +100,9 @@ static char_u toF_Xor_X_(int c)
     case F_HE   :
       tempc = _HE;
 
-      if (p_ri &&
-          (curwin->w_cursor.col + 1 < (colnr_T)STRLEN(get_cursor_line_ptr()))) {
+      if (p_ri
+          && (curwin->w_cursor.col + 1
+              < (colnr_T)STRLEN(get_cursor_line_ptr()))) {
         inc_cursor();
         if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
           tempc = _HE_;
@@ -526,8 +527,8 @@ static void chg_l_toXor_X(void)
 {
   char_u tempc;
 
-  if ((curwin->w_cursor.col != 0) &&
-      (curwin->w_cursor.col + 1 == (colnr_T)STRLEN(get_cursor_line_ptr()))) {
+  if ((curwin->w_cursor.col != 0)
+      && (curwin->w_cursor.col + 1 == (colnr_T)STRLEN(get_cursor_line_ptr()))) {
     return;
   }
 
@@ -680,17 +681,17 @@ int fkmap(int c)
     }
   }
 
-  if ((c < 0x100) &&
-      (isalpha(c) ||
-       (c == '&') ||
-       (c == '^') ||
-       (c == ';') ||
-       (c == '\'') ||
-       (c == ',') ||
-       (c == '[') ||
-       (c == ']') ||
-       (c == '{') ||
-       (c == '}'))) {
+  if ((c < 0x100)
+      && (isalpha(c)
+          || (c == '&')
+          || (c == '^')
+          || (c == ';')
+          || (c == '\'')
+          || (c == ',')
+          || (c == '[')
+          || (c == ']')
+          || (c == '{')
+          || (c == '}'))) {
     chg_r_to_Xor_X_();
   }
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -605,13 +605,14 @@ readfile (
    * Don't do this for a "nofile" or "nowrite" buffer type. */
   if (!bt_dontwrite(curbuf)) {
     check_need_swap(newfile);
-    if (!read_stdin && (curbuf != old_curbuf
-                        || (using_b_ffname && (old_b_ffname != curbuf->b_ffname))
-                        || (using_b_fname &&
-                            (old_b_fname != curbuf->b_fname)))) {
+    if (!read_stdin
+        && (curbuf != old_curbuf
+            || (using_b_ffname && (old_b_ffname != curbuf->b_ffname))
+            || (using_b_fname && (old_b_fname != curbuf->b_fname)))) {
       EMSG(_(e_auchangedbuf));
-      if (!read_buffer)
+      if (!read_buffer) {
         close(fd);
+      }
       return FAIL;
     }
 #ifdef UNIX
@@ -4369,8 +4370,8 @@ char *modname(const char *fname, const char *ext, bool prepend_dot)
   // (we need the full path in case :cd is used).
   if (fname == NULL || *fname == NUL) {
     retval = xmalloc(MAXPATHL + extlen + 3);  // +3 for PATHSEP, "_" (Win), NUL
-    if (os_dirname((char_u *)retval, MAXPATHL) == FAIL ||
-        (fnamelen = strlen(retval)) == 0) {
+    if (os_dirname((char_u *)retval, MAXPATHL) == FAIL
+        || (fnamelen = strlen(retval)) == 0) {
       xfree(retval);
       return NULL;
     }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2669,13 +2669,14 @@ do_map (
   p = keys;
   do_backslash = (vim_strchr(p_cpo, CPO_BSLASH) == NULL);
   while (*p && (maptype == 1 || !ascii_iswhite(*p))) {
-    if ((p[0] == Ctrl_V || (do_backslash && p[0] == '\\')) &&
-        p[1] != NUL)
-      ++p;                      /* skip CTRL-V or backslash */
-    ++p;
+    if ((p[0] == Ctrl_V || (do_backslash && p[0] == '\\')) && p[1] != NUL) {
+      p++;  // skip CTRL-V or backslash
+    }
+    p++;
   }
-  if (*p != NUL)
+  if (*p != NUL) {
     *p++ = NUL;
+  }
 
   p = skipwhite(p);
   rhs = p;

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -2190,18 +2190,19 @@ int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
                              mbfont_opts[OPT_MBFONT_BOLDOBLIQUE].strlen);
     }
 
-    /* Check if need to use Courier for ASCII code range, and if so pick up
-     * the encoding to use */
-    prt_use_courier = mbfont_opts[OPT_MBFONT_USECOURIER].present &&
-                      (TOLOWER_ASC(mbfont_opts[OPT_MBFONT_USECOURIER].string[0])
-                       == 'y');
+    // Check if need to use Courier for ASCII code range, and if so pick up
+    // the encoding to use
+    prt_use_courier = (
+        mbfont_opts[OPT_MBFONT_USECOURIER].present
+        && (TOLOWER_ASC(mbfont_opts[OPT_MBFONT_USECOURIER].string[0]) == 'y'));
     if (prt_use_courier) {
-      /* Use national ASCII variant unless ASCII wanted */
-      if (mbfont_opts[OPT_MBFONT_ASCII].present &&
-          (TOLOWER_ASC(mbfont_opts[OPT_MBFONT_ASCII].string[0]) == 'y'))
+      // Use national ASCII variant unless ASCII wanted
+      if (mbfont_opts[OPT_MBFONT_ASCII].present
+          && (TOLOWER_ASC(mbfont_opts[OPT_MBFONT_ASCII].string[0]) == 'y')) {
         prt_ascii_encoding = "ascii";
-      else
+      } else {
         prt_ascii_encoding = prt_ps_mbfonts[cmap].ascii_enc;
+      }
     }
 
     prt_ps_font = &prt_ps_mb_font;
@@ -3029,10 +3030,10 @@ int mch_print_text_out(char_u *p, size_t len)
   prt_text_run += char_width;
   prt_pos_x += char_width;
 
-  /* The downside of fp - use relative error on right margin check */
+  // The downside of fp - use relative error on right margin check
   next_pos = prt_pos_x + prt_char_width;
-  need_break = (next_pos > prt_right_margin) &&
-               ((next_pos - prt_right_margin) > (prt_right_margin*1e-5));
+  need_break = ((next_pos > prt_right_margin)
+                && ((next_pos - prt_right_margin) > (prt_right_margin * 1e-5)));
 
   if (need_break)
     prt_flush_buffer();

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -2282,15 +2282,14 @@ int get_c_indent(void)
          * location for b_ind_open_extra.
          */
 
-        if (start_brace == BRACE_IN_COL0) {         /* '{' is in column 0 */
+        if (start_brace == BRACE_IN_COL0) {     // '{' is in column 0
           amount = curbuf->b_ind_open_left_imag;
-          lookfor_cpp_namespace = TRUE;
-        } else if (start_brace == BRACE_AT_START &&
-                   lookfor_cpp_namespace) {       /* '{' is at start */
-
-          lookfor_cpp_namespace = TRUE;
+          lookfor_cpp_namespace = true;
+        } else if (start_brace == BRACE_AT_START
+                   && lookfor_cpp_namespace) {  // '{' is at start
+          lookfor_cpp_namespace = true;
         } else {
-          if (start_brace == BRACE_AT_END) {        /* '{' is at end of line */
+          if (start_brace == BRACE_AT_END) {    // '{' is at end of line
             amount += curbuf->b_ind_open_imag;
 
             l = skipwhite(get_cursor_line_ptr());

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -786,9 +786,8 @@ void ml_recover(void)
   if (fname == NULL)                /* When there is no file name */
     fname = (char_u *)"";
   len = (int)STRLEN(fname);
-  if (len >= 4 &&
-      STRNICMP(fname + len - 4, ".s", 2)
-      == 0
+  if (len >= 4
+      && STRNICMP(fname + len - 4, ".s", 2) == 0
       && vim_strchr((char_u *)"UVWuvw", fname[len - 2]) != NULL
       && ASCII_ISALPHA(fname[len - 1])) {
     directly = TRUE;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1570,39 +1570,31 @@ static void msg_puts_display(char_u *str, int maxlen, int attr, int recurse)
   int wrap;
   int did_last_char;
 
-  did_wait_return = FALSE;
+  did_wait_return = false;
   while ((maxlen < 0 || (int)(s - str) < maxlen) && *s != NUL) {
-    /*
-     * We are at the end of the screen line when:
-     * - When outputting a newline.
-     * - When outputting a character in the last column.
-     */
-    if (!recurse && msg_row >= Rows - 1 && (*s == '\n' || (
-                                              cmdmsg_rl
-                                              ? (
-                                                msg_col <= 1
-                                                || (*s == TAB && msg_col <= 7)
-                                                || (has_mbyte &&
-                                                    (*mb_ptr2cells)(s) > 1 &&
-                                                    msg_col <= 2)
-                                                )
-                                              :
-                                              (msg_col + t_col >= Columns - 1
-                                               || (*s == TAB && msg_col +
-                                                   t_col >= ((Columns - 1) & ~7))
-                                               || (has_mbyte &&
-                                                   (*mb_ptr2cells)(s) > 1
-                                                   && msg_col + t_col >=
-                                                   Columns - 2)
-                                              )))) {
-      /*
-       * The screen is scrolled up when at the last row (some terminals
-       * scroll automatically, some don't.  To avoid problems we scroll
-       * ourselves).
-       */
-      if (t_col > 0)
-        /* output postponed text */
+    // We are at the end of the screen line when:
+    // - When outputting a newline.
+    // - When outputting a character in the last column.
+    if (!recurse && msg_row >= Rows - 1
+        && (*s == '\n' || (cmdmsg_rl
+                           ? (msg_col <= 1
+                              || (*s == TAB && msg_col <= 7)
+                              || (has_mbyte
+                                  && (*mb_ptr2cells)(s) > 1
+                                  && msg_col <= 2))
+                           : (msg_col + t_col >= Columns - 1
+                              || (*s == TAB
+                                  && msg_col + t_col >= ((Columns - 1) & ~7))
+                              || (has_mbyte
+                                  && (*mb_ptr2cells)(s) > 1
+                                  && msg_col + t_col >= Columns - 2))))) {
+      // The screen is scrolled up when at the last row (some terminals
+      // scroll automatically, some don't.  To avoid problems we scroll
+      // ourselves).
+      if (t_col > 0) {
+        // output postponed text
         t_puts(&t_col, t_s, s, attr);
+      }
 
       /* When no more prompt and no more room, truncate here */
       if (msg_no_more && lines_left == 0)
@@ -1709,18 +1701,15 @@ static void msg_puts_display(char_u *str, int maxlen, int attr, int recurse)
         cw = 1;
         l = 1;
       }
-      /* When drawing from right to left or when a double-wide character
-       * doesn't fit, draw a single character here.  Otherwise collect
-       * characters and draw them all at once later. */
-      if (
-        cmdmsg_rl
-        ||
-        (cw > 1 && msg_col + t_col >= Columns - 1)
-        ) {
-        if (l > 1)
+      // When drawing from right to left or when a double-wide character
+      // doesn't fit, draw a single character here.  Otherwise collect
+      // characters and draw them all at once later.
+      if (cmdmsg_rl || (cw > 1 && msg_col + t_col >= Columns - 1)) {
+        if (l > 1) {
           s = screen_puts_mbyte(s, l, attr) - 1;
-        else
+        } else {
           msg_screen_putchar(*s, attr);
+        }
       } else {
         /* postpone this character until later */
         if (t_col == 0)
@@ -3382,8 +3371,8 @@ int vim_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap,
           // leave negative numbers for sprintf to handle, to
           // avoid handling tricky cases like (short int)-32768
         } else if (alternate_form) {
-          if (arg_sign != 0 && (fmt_spec == 'x' || fmt_spec == 'X' ||
-                                fmt_spec == 'b' || fmt_spec == 'B')) {
+          if (arg_sign != 0 && (fmt_spec == 'x' || fmt_spec == 'X'
+                                || fmt_spec == 'b' || fmt_spec == 'B')) {
             tmp[str_arg_l++] = '0';
             tmp[str_arg_l++] = fmt_spec;
           }

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -204,15 +204,12 @@ open_line (
       else
         lead_len = 0;
       if (dir == FORWARD) {
-        /*
-         * Skip preprocessor directives, unless they are
-         * recognised as comments.
-         */
-        if (
-          lead_len == 0 &&
-          ptr[0] == '#') {
-          while (ptr[0] == '#' && curwin->w_cursor.lnum > 1)
+        // Skip preprocessor directives, unless they are
+        // recognised as comments.
+        if (lead_len == 0 && ptr[0] == '#') {
+          while (ptr[0] == '#' && curwin->w_cursor.lnum > 1) {
             ptr = ml_get(--curwin->w_cursor.lnum);
+          }
           newindent = get_indent();
         }
         if (flags & OPENLINE_DO_COM)
@@ -296,28 +293,26 @@ open_line (
                    && cin_is_cinword(ptr))
             did_si = TRUE;
         }
-      } else { /* dir == BACKWARD */
-                 /*
-                  * Skip preprocessor directives, unless they are
-                  * recognised as comments.
-                  */
-        if (
-          lead_len == 0 &&
-          ptr[0] == '#') {
-          int was_backslashed = FALSE;
+      } else {  // dir == BACKWARD
+        // Skip preprocessor directives, unless they are
+        // recognised as comments.
+        if (lead_len == 0 && ptr[0] == '#') {
+          bool was_backslashed = false;
 
-          while ((ptr[0] == '#' || was_backslashed) &&
-                 curwin->w_cursor.lnum < curbuf->b_ml.ml_line_count) {
-            if (*ptr && ptr[STRLEN(ptr) - 1] == '\\')
-              was_backslashed = TRUE;
-            else
-              was_backslashed = FALSE;
+          while ((ptr[0] == '#' || was_backslashed)
+                 && curwin->w_cursor.lnum < curbuf->b_ml.ml_line_count) {
+            if (*ptr && ptr[STRLEN(ptr) - 1] == '\\') {
+              was_backslashed = true;
+            } else {
+              was_backslashed = false;
+            }
             ptr = ml_get(++curwin->w_cursor.lnum);
           }
-          if (was_backslashed)
-            newindent = 0;                  /* Got to end of file */
-          else
+          if (was_backslashed) {
+            newindent = 0;  // Got to end of file
+          } else {
             newindent = get_indent();
+          }
         }
         p = skipwhite(ptr);
         if (*p == '}')              /* if line starts with '}': do indent */
@@ -667,16 +662,12 @@ open_line (
 
       did_si = can_si = FALSE;
     } else if (comment_end != NULL) {
-      /*
-       * We have finished a comment, so we don't use the leader.
-       * If this was a C-comment and 'ai' or 'si' is set do a normal
-       * indent to align with the line containing the start of the
-       * comment.
-       */
-      if (comment_end[0] == '*' && comment_end[1] == '/' &&
-          (curbuf->b_p_ai
-           || do_si
-          )) {
+      // We have finished a comment, so we don't use the leader.
+      // If this was a C-comment and 'ai' or 'si' is set do a normal
+      // indent to align with the line containing the start of the
+      // comment.
+      if (comment_end[0] == '*' && comment_end[1] == '/'
+          && (curbuf->b_p_ai || do_si)) {
         old_cursor = curwin->w_cursor;
         curwin->w_cursor.col = (colnr_T)(comment_end - saved_line);
         if ((pos = findmatch(NULL, NUL)) != NULL) {

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -535,9 +535,9 @@ static linenr_T find_longest_lnum(void)
   // Calculate maximum for horizontal scrollbar.  Check for reasonable
   // line numbers, topline and botline can be invalid when displaying is
   // postponed.
-  if (curwin->w_topline <= curwin->w_cursor.lnum &&
-      curwin->w_botline > curwin->w_cursor.lnum &&
-      curwin->w_botline <= curbuf->b_ml.ml_line_count + 1) {
+  if (curwin->w_topline <= curwin->w_cursor.lnum
+      && curwin->w_botline > curwin->w_cursor.lnum
+      && curwin->w_botline <= curbuf->b_ml.ml_line_count + 1) {
     long max = 0;
 
     // Use maximum of all visible lines.  Remember the lnum of the

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1010,12 +1010,9 @@ scrollup (
     int byfold              /* true: count a closed fold as one line */
 )
 {
-  if (
-    (byfold && hasAnyFolding(curwin))
-    ||
-    curwin->w_p_diff
-    ) {
-    /* count each sequence of folded lines as one logical line */
+  if ((byfold && hasAnyFolding(curwin))
+      || curwin->w_p_diff) {
+    // count each sequence of folded lines as one logical line
     linenr_T lnum = curwin->w_topline;
     while (line_count--) {
       if (curwin->w_topfill > 0)

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -419,8 +419,8 @@ void msgpack_rpc_validate(uint64_t *response_id,
     return;
   }
 
-  if ((type == kMessageTypeRequest && req->via.array.size != 4) ||
-      (type == kMessageTypeNotification && req->via.array.size != 3)) {
+  if ((type == kMessageTypeRequest && req->via.array.size != 4)
+      || (type == kMessageTypeNotification && req->via.array.size != 3)) {
     api_set_error(err, Validation, _("Request array size should be 4 (request) "
                                      "or 3 (notification)"));
     return;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2046,8 +2046,8 @@ void op_insert(oparg_T *oap, long count1)
   // When a tab was inserted, and the characters in front of the tab
   // have been converted to a tab as well, the column of the cursor
   // might have actually been reduced, so need to adjust here. */
-  if (t1.lnum == curbuf->b_op_start_orig.lnum &&
-      lt(curbuf->b_op_start_orig, t1)) {
+  if (t1.lnum == curbuf->b_op_start_orig.lnum
+      && lt(curbuf->b_op_start_orig, t1)) {
     oap->start = curbuf->b_op_start_orig;
   }
 
@@ -3189,11 +3189,9 @@ void adjust_cursor_eol(void)
  */
 int preprocs_left(void)
 {
-  return
-    (curbuf->b_p_si && !curbuf->b_p_cin) ||
-    (curbuf->b_p_cin && in_cinkeys('#', ' ', TRUE)
-     && curbuf->b_ind_hash_comment == 0)
-  ;
+  return ((curbuf->b_p_si && !curbuf->b_p_cin)
+          || (curbuf->b_p_cin && in_cinkeys('#', ' ', true)
+              && curbuf->b_ind_hash_comment == 0));
 }
 
 /* Return the character name of the register with the given number */
@@ -4399,8 +4397,7 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
     if (dobin
         && dohex
         && !((col > 0
-              && (ptr[col] == 'X' ||
-                  ptr[col] == 'x')
+              && (ptr[col] == 'X' || ptr[col] == 'x')
               && ptr[col - 1] == '0'
               && ascii_isxdigit(ptr[col + 1])))) {
         // In case of binary/hexadecimal pattern overlap match, rescan
@@ -4414,17 +4411,15 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
 
     if ((dohex
          && col > 0
-         && (ptr[col] == 'X'
-             || ptr[col] == 'x')
+         && (ptr[col] == 'X' || ptr[col] == 'x')
          && ptr[col - 1] == '0'
-         && ascii_isxdigit(ptr[col + 1])) ||
-        (dobin
-         && col > 0
-         && (ptr[col] == 'B'
-             || ptr[col] == 'b')
-         && ptr[col - 1] == '0'
-         && ascii_isbdigit(ptr[col + 1]))) {
-         // Found hexadecimal or binary number, move to its start.
+         && ascii_isxdigit(ptr[col + 1]))
+        || (dobin
+            && col > 0
+            && (ptr[col] == 'B' || ptr[col] == 'b')
+            && ptr[col - 1] == '0'
+            && ascii_isbdigit(ptr[col + 1]))) {
+      // Found hexadecimal or binary number, move to its start.
         col--;
     } else {
       // Search forward and then backward to find the start of number.
@@ -4445,8 +4440,8 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
   }
 
   if (visual) {
-    while (ptr[col] != NUL && length > 0 && !ascii_isdigit(ptr[col]) &&
-           !(doalp && ASCII_ISALPHA(ptr[col]))) {
+    while (ptr[col] != NUL && length > 0 && !ascii_isdigit(ptr[col])
+           && !(doalp && ASCII_ISALPHA(ptr[col]))) {
       col++;
       length--;
     }
@@ -4608,8 +4603,7 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
       *ptr++ = '0';
       length--;
     }
-    if (pre == 'b' || pre == 'B' ||
-        pre == 'x' || pre == 'X') {
+    if (pre == 'b' || pre == 'B' || pre == 'x' || pre == 'X') {
       *ptr++ = pre;
       length--;
     }
@@ -5035,8 +5029,8 @@ static void str_to_reg(yankreg_T *y_ptr, MotionType yank_type,
   }
 
   if (yank_type == kMTUnknown) {
-    yank_type = ((str_list ||
-                  (len > 0 && (str[len - 1] == NL || str[len - 1] == CAR)))
+    yank_type = ((str_list
+                  || (len > 0 && (str[len - 1] == NL || str[len - 1] == CAR)))
                  ? kMTLineWise : kMTCharWise);
   }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4782,9 +4782,10 @@ showoptions (
           option_value2string(p, opt_flags);
           len = (int)STRLEN(p->fullname) + vim_strsize(NameBuff) + 1;
         }
-        if ((len <= INC - GAP && run == 1) ||
-            (len > INC - GAP && run == 2))
+        if ((len <= INC - GAP && run == 1)
+            || (len > INC - GAP && run == 2)) {
           items[item_count++] = p;
+        }
       }
     }
 
@@ -4973,18 +4974,15 @@ int makeset(FILE *fd, int opt_flags, int local_only)
           } else {    /* P_STRING */
             int do_endif = FALSE;
 
-            /* Don't set 'syntax' and 'filetype' again if the value is
-             * already right, avoids reloading the syntax file. */
-            if (
-              p->indir == PV_SYN
-              ||
-              p->indir == PV_FT
-              ) {
+            // Don't set 'syntax' and 'filetype' again if the value is
+            // already right, avoids reloading the syntax file.
+            if (p->indir == PV_SYN || p->indir == PV_FT) {
               if (fprintf(fd, "if &%s != '%s'", p->fullname,
-                      *(char_u **)(varp)) < 0
-                  || put_eol(fd) < 0)
+                          *(char_u **)(varp)) < 0
+                  || put_eol(fd) < 0) {
                 return FAIL;
-              do_endif = TRUE;
+              }
+              do_endif = true;
             }
             if (put_setstring(fd, cmd, p->fullname, (char_u **)varp,
                     (p->flags & P_EXPAND) != 0) == FAIL)
@@ -6225,10 +6223,10 @@ int has_format_option(int x)
 /// 'shortmess' contains 'a' and "x" is present in SHM_ALL_ABBREVIATIONS.
 bool shortmess(int x)
 {
-  return p_shm != NULL &&
-         (vim_strchr(p_shm, x) != NULL
-          || (vim_strchr(p_shm, 'a') != NULL
-              && vim_strchr((char_u *)SHM_ALL_ABBREVIATIONS, x) != NULL));
+  return (p_shm != NULL
+          && (vim_strchr(p_shm, x) != NULL
+              || (vim_strchr(p_shm, 'a') != NULL
+                  && vim_strchr((char_u *)SHM_ALL_ABBREVIATIONS, x) != NULL)));
 }
 
 /*

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -175,9 +175,10 @@ bool os_can_exe(const char_u *name, char_u **abspath)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   // If it's an absolute or relative path don't need to use $PATH.
-  if (path_is_absolute_path(name) ||
-     (name[0] == '.' && (name[1] == '/' ||
-                        (name[1] == '.' && name[2] == '/')))) {
+  if (path_is_absolute_path(name)
+      || (name[0] == '.'
+          && (name[1] == '/'
+              || (name[1] == '.' && name[2] == '/')))) {
     if (is_executable(name)) {
       if (abspath != NULL) {
         *abspath = save_absolute_path(name);

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -403,9 +403,9 @@ static int push_event_key(uint8_t *buf, int maxlen)
 // Check if there's pending input
 static bool input_ready(void)
 {
-  return typebuf_was_filled ||                 // API call filled typeahead
-         rbuffer_size(input_buffer) ||         // Input buffer filled
-         pending_events();                     // Events must be processed
+  return (typebuf_was_filled             // API call filled typeahead
+          || rbuffer_size(input_buffer)  // Input buffer filled
+          || pending_events());          // Events must be processed
 }
 
 // Exit because of an input read error.

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1301,9 +1301,10 @@ void addfile(
   FileInfo file_info;
 
   // if the file/dir/link doesn't exist, may not add it
-  if (!(flags & EW_NOTFOUND) &&
-      ((flags & EW_ALLLINKS) ?
-       !os_fileinfo_link((char *)f, &file_info) : !os_file_exists(f))) {
+  if (!(flags & EW_NOTFOUND)
+      && ((flags & EW_ALLLINKS)
+          ? !os_fileinfo_link((char *)f, &file_info)
+          : !os_file_exists(f))) {
     return;
   }
 
@@ -1383,9 +1384,9 @@ void simplify_filename(char_u *filename)
           --p;                          /* strip preceding path separator */
         STRMOVE(p, tail);
       }
-    } else if (p[0] == '.' && p[1] == '.' &&
-               (vim_ispathsep(p[2]) || p[2] == NUL)) {
-      /* Skip to after ".." or "../" or "..///". */
+    } else if (p[0] == '.' && p[1] == '.'
+               && (vim_ispathsep(p[2]) || p[2] == NUL)) {
+      // Skip to after ".." or "../" or "..///".
       tail = p + 2;
       while (vim_ispathsep(*tail))
         mb_ptr_adv(tail);
@@ -2016,8 +2017,8 @@ int match_suffix(char_u *fname)
         break;
       }
     } else {
-      if (fnamelen >= setsuflen &&
-          fnamencmp(suf_buf, fname + fnamelen - setsuflen, setsuflen) == 0) {
+      if (fnamelen >= setsuflen
+          && fnamencmp(suf_buf, fname + fnamelen - setsuflen, setsuflen) == 0) {
         break;
       }
       setsuflen = 0;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2757,8 +2757,8 @@ void ex_cc(exarg_T *eap)
 
   // For cdo and ldo commands, jump to the nth valid error.
   // For cfdo and lfdo commands, jump to the nth valid file entry.
-  if (eap->cmdidx == CMD_cdo || eap->cmdidx == CMD_ldo ||
-      eap->cmdidx == CMD_cfdo || eap->cmdidx == CMD_lfdo) {
+  if (eap->cmdidx == CMD_cdo || eap->cmdidx == CMD_ldo
+      || eap->cmdidx == CMD_cfdo || eap->cmdidx == CMD_lfdo) {
     size_t n;
     if (eap->addr_count > 0) {
       assert(eap->line1 >= 0);
@@ -2801,9 +2801,9 @@ void ex_cnext(exarg_T *eap)
   }
 
   int errornr;
-  if (eap->addr_count > 0 &&
-        (eap->cmdidx != CMD_cdo && eap->cmdidx != CMD_ldo &&
-         eap->cmdidx != CMD_cfdo && eap->cmdidx != CMD_lfdo)) {
+  if (eap->addr_count > 0
+      && (eap->cmdidx != CMD_cdo && eap->cmdidx != CMD_ldo
+          && eap->cmdidx != CMD_cfdo && eap->cmdidx != CMD_lfdo)) {
     errornr = (int)eap->line2;
   } else {
     errornr = 1;
@@ -2972,16 +2972,18 @@ void ex_vimgrep(exarg_T *eap)
     goto theend;
   }
 
-  if ((eap->cmdidx != CMD_grepadd && eap->cmdidx != CMD_lgrepadd &&
-       eap->cmdidx != CMD_vimgrepadd && eap->cmdidx != CMD_lvimgrepadd)
-      || qi->qf_curlist == qi->qf_listcount)
-    /* make place for a new list */
+  if ((eap->cmdidx != CMD_grepadd && eap->cmdidx != CMD_lgrepadd
+       && eap->cmdidx != CMD_vimgrepadd && eap->cmdidx != CMD_lvimgrepadd)
+      || qi->qf_curlist == qi->qf_listcount) {
+    // make place for a new list
     qf_new_list(qi, *eap->cmdlinep);
-  else if (qi->qf_lists[qi->qf_curlist].qf_count > 0)
-    /* Adding to existing list, find last entry. */
+  } else if (qi->qf_lists[qi->qf_curlist].qf_count > 0) {
+    // Adding to existing list, find last entry.
     for (prevp = qi->qf_lists[qi->qf_curlist].qf_start;
-         prevp->qf_next != prevp; prevp = prevp->qf_next)
-      ;
+         prevp->qf_next != prevp;
+         prevp = prevp->qf_next) {
+    }
+  }
 
   /* parse the list of arguments */
   if (get_arglist_exp(p, &fcount, &fnames, true) == FAIL)

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -3445,13 +3445,14 @@ static long bt_regexec_both(char_u *line,
       c = regline[col];
     if (prog->regstart == NUL
         || prog->regstart == c
-        || (ireg_ic && ((
-                          (enc_utf8 && utf_fold(prog->regstart) == utf_fold(c)))
-                        || (c < 255 && prog->regstart < 255 &&
-                            vim_tolower(prog->regstart) == vim_tolower(c)))))
+        || (ireg_ic
+            && (((enc_utf8 && utf_fold(prog->regstart) == utf_fold(c)))
+                || (c < 255 && prog->regstart < 255
+                    && vim_tolower(prog->regstart) == vim_tolower(c))))) {
       retval = regtry(prog, col);
-    else
+    } else {
       retval = 0;
+    }
   } else {
     int tm_count = 0;
     /* Messy cases:  unanchored match. */
@@ -4121,15 +4122,15 @@ regmatch (
           char_u  *opnd;
 
           opnd = OPERAND(scan);
-          /* Inline the first byte, for speed. */
+          // Inline the first byte, for speed.
           if (*opnd != *reginput
-              && (!ireg_ic || (
-                    !enc_utf8 &&
-                    vim_tolower(*opnd) != vim_tolower(*reginput))))
+              && (!ireg_ic
+                  || (!enc_utf8
+                      && vim_tolower(*opnd) != vim_tolower(*reginput)))) {
             status = RA_NOMATCH;
-          else if (*opnd == NUL) {
-            /* match empty string always works; happens when "~" is
-             * empty. */
+          } else if (*opnd == NUL) {
+            // match empty string always works; happens when "~" is
+            // empty.
           } else {
             if (opnd[1] == NUL && !(enc_utf8 && ireg_ic)) {
               len = 1; /* matched a single byte above */

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -4777,8 +4777,8 @@ static long find_match_text(colnr_T startcol, int regstart, char_u *match_text)
       int c2_len = PTR2LEN(s2);
       int c2 = PTR2CHAR(s2);
 
-      if ((c1 != c2 && (!ireg_ic || vim_tolower(c1) != vim_tolower(c2))) ||
-          c1_len != c2_len) {
+      if ((c1 != c2 && (!ireg_ic || vim_tolower(c1) != vim_tolower(c2)))
+          || c1_len != c2_len) {
         match = false;
         break;
       }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -387,14 +387,15 @@ void update_screen(int type)
     if (wp->w_buffer->b_mod_set) {
       win_T       *wwp;
 
-      /* Check if we already did this buffer. */
-      for (wwp = firstwin; wwp != wp; wwp = wwp->w_next)
-        if (wwp->w_buffer == wp->w_buffer)
+      // Check if we already did this buffer.
+      for (wwp = firstwin; wwp != wp; wwp = wwp->w_next) {
+        if (wwp->w_buffer == wp->w_buffer) {
           break;
-      if (
-        wwp == wp &&
-        syntax_present(wp))
+        }
+      }
+      if (wwp == wp && syntax_present(wp)) {
         syn_stack_apply_changes(wp->w_buffer);
+      }
     }
   }
 
@@ -1231,16 +1232,16 @@ static void win_update(win_T *wp)
                         || did_update == DID_FOLD
                         || (did_update == DID_LINE
                             && syntax_present(wp)
-                            && (
-                              (foldmethodIsSyntax(wp)
-                               && hasAnyFolding(wp)) ||
-                              syntax_check_changed(lnum)))
+                            && ((foldmethodIsSyntax(wp)
+                                 && hasAnyFolding(wp))
+                                || syntax_check_changed(lnum)))
                         // match in fixed position might need redraw
                         // if lines were inserted or deleted
-                        || (wp->w_match_head != NULL && buf->b_mod_xlines != 0)
-                        ))))) {
-      if (lnum == mod_top)
-        top_to_mod = FALSE;
+                        || (wp->w_match_head != NULL
+                            && buf->b_mod_xlines != 0)))))) {
+      if (lnum == mod_top) {
+        top_to_mod = false;
+      }
 
       /*
        * When at start of changed lines: May scroll following lines
@@ -2472,21 +2473,16 @@ win_line (
       mb_ptr_adv(ptr);
     }
 
-    /* When:
-     * - 'cuc' is set, or
-     * - 'colorcolumn' is set, or
-     * - 'virtualedit' is set, or
-     * - the visual mode is active,
-     * the end of the line may be before the start of the displayed part.
-     */
-    if (vcol < v && (
-          wp->w_p_cuc
-          || draw_color_col
-          ||
-          virtual_active()
-          ||
-          (VIsual_active && wp->w_buffer == curwin->w_buffer)
-          )) {
+    // When:
+    // - 'cuc' is set, or
+    // - 'colorcolumn' is set, or
+    // - 'virtualedit' is set, or
+    // - the visual mode is active,
+    // the end of the line may be before the start of the displayed part.
+    if (vcol < v && (wp->w_p_cuc
+                     || draw_color_col
+                     || virtual_active()
+                     || (VIsual_active && wp->w_buffer == curwin->w_buffer))) {
       vcol = v;
     }
 
@@ -3273,12 +3269,12 @@ win_line (
          * contains the @Spell cluster. */
         if (has_spell && v >= word_end && v > cur_checked_col) {
           spell_attr = 0;
-          if (!attr_pri)
+          if (!attr_pri) {
             char_attr = syntax_attr;
-          if (c != 0 && (
-                !has_syntax ||
-                can_spell)) {
-            char_u  *prev_ptr, *p;
+          }
+          if (c != 0 && (!has_syntax || can_spell)) {
+            char_u *prev_ptr;
+            char_u *p;
             int len;
             hlf_T spell_hlf = HLF_COUNT;
             if (has_mbyte) {
@@ -3607,25 +3603,22 @@ win_line (
                      wp->w_p_rl ? (col >= 0) :
                      (col < wp->w_width))) {
           c = ' ';
-          --ptr;                    /* put it back at the NUL */
-        } else if ((
-                   diff_hlf != (hlf_T)0 ||
-                   line_attr != 0
-                   ) && (
-                   wp->w_p_rl ? (col >= 0) :
-                   (col
-                    - boguscols
-                    < wp->w_width))) {
-          /* Highlight until the right side of the window */
+          ptr--;  // put it back at the NUL
+        } else if ((diff_hlf != (hlf_T)0 || line_attr != 0)
+                   && (wp->w_p_rl
+                       ? (col >= 0)
+                       : (col - boguscols < wp->w_width))) {
+          // Highlight until the right side of the window
           c = ' ';
-          --ptr;                    /* put it back at the NUL */
+          ptr--;  // put it back at the NUL
 
-          /* Remember we do the char for line highlighting. */
-          ++did_line_attr;
+          // Remember we do the char for line highlighting.
+          did_line_attr++;
 
-          /* don't do search HL for the rest of the line */
-          if (line_attr != 0 && char_attr == search_attr && col > 0)
+          // don't do search HL for the rest of the line
+          if (line_attr != 0 && char_attr == search_attr && col > 0) {
             char_attr = line_attr;
+          }
           if (diff_hlf == HLF_TXD) {
             diff_hlf = HLF_CHD;
             if (attr == 0 || char_attr != attr) {
@@ -3639,8 +3632,8 @@ win_line (
       }
 
       if (wp->w_p_cole > 0
-          && (wp != curwin || lnum != wp->w_cursor.lnum ||
-              conceal_cursor_line(wp))
+          && (wp != curwin || lnum != wp->w_cursor.lnum
+              || conceal_cursor_line(wp))
           && ((syntax_flags & HL_CONCEAL) != 0 || has_match_conc)
           && !(lnum_in_visual_area
                && vim_strchr(wp->w_p_cocu, 'v') == NULL)) {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -638,9 +638,9 @@ int searchit(
                 break;
               }
 
-              if (ptr[matchcol] == NUL ||
-                  (nmatched = vim_regexec_multi(&regmatch, win, buf, lnum,
-                                                matchcol, tm)) == 0) {
+              if (ptr[matchcol] == NUL
+                  || (nmatched = vim_regexec_multi(&regmatch, win, buf, lnum,
+                                                   matchcol, tm)) == 0) {
                 match_ok = false;
                 break;
               }
@@ -1027,19 +1027,18 @@ int do_search(
       spats[0].off.line = FALSE;
       spats[0].off.end = FALSE;
       spats[0].off.off = 0;
-      /*
-       * Check for a line offset or a character offset.
-       * For get_address (echo off) we don't check for a character
-       * offset, because it is meaningless and the 's' could be a
-       * substitute command.
-       */
-      if (*p == '+' || *p == '-' || ascii_isdigit(*p))
-        spats[0].off.line = TRUE;
-      else if ((options & SEARCH_OPT) &&
-               (*p == 'e' || *p == 's' || *p == 'b')) {
-        if (*p == 'e')                  /* end */
+      // Check for a line offset or a character offset.
+      // For get_address (echo off) we don't check for a character
+      // offset, because it is meaningless and the 's' could be a
+      // substitute command.
+      if (*p == '+' || *p == '-' || ascii_isdigit(*p)) {
+        spats[0].off.line = true;
+      } else if ((options & SEARCH_OPT)
+                 && (*p == 'e' || *p == 's' || *p == 'b')) {
+        if (*p == 'e') {  // end
           spats[0].off.end = true;
-        ++p;
+        }
+        p++;
       }
       if (ascii_isdigit(*p) || *p == '+' || *p == '-') {      /* got an offset */
         /* 'nr' or '+nr' or '-nr' */
@@ -1784,14 +1783,13 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
       }
     }
 
-    /*
-     * If FM_BLOCKSTOP given, stop at a '{' or '}' in column 0.
-     */
-    if (pos.col == 0 && (flags & FM_BLOCKSTOP) &&
-        (linep[0] == '{' || linep[0] == '}')) {
-      if (linep[0] == findc && count == 0)              /* match! */
+    // If FM_BLOCKSTOP given, stop at a '{' or '}' in column 0.
+    if (pos.col == 0 && (flags & FM_BLOCKSTOP)
+        && (linep[0] == '{' || linep[0] == '}')) {
+      if (linep[0] == findc && count == 0) {  // match!
         return &pos;
-      break;                                            /* out of scope */
+      }
+      break;  // out of scope
     }
 
     if (comment_dir) {
@@ -1960,15 +1958,15 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
             if (linep[pos.col - 2] == '\'') {
               pos.col -= 2;
               break;
-            } else if (linep[pos.col - 2] == '\\' &&
-                       pos.col > 2 && linep[pos.col - 3] == '\'') {
+            } else if (linep[pos.col - 2] == '\\'
+                       && pos.col > 2 && linep[pos.col - 3] == '\'') {
               pos.col -= 3;
               break;
             }
           }
-        } else if (linep[pos.col + 1]) {      /* forward search */
-          if (linep[pos.col + 1] == '\\' &&
-              linep[pos.col + 2] && linep[pos.col + 3] == '\'') {
+        } else if (linep[pos.col + 1]) {  // forward search
+          if (linep[pos.col + 1] == '\\'
+              && linep[pos.col + 2] && linep[pos.col + 3] == '\'') {
             pos.col += 3;
             break;
           } else if (linep[pos.col + 2] == '\'') {
@@ -2185,30 +2183,32 @@ int findsent(int dir, long count)
      * if on an empty line, skip up to a non-empty line
      */
     if (gchar_pos(&pos) == NUL) {
-      do
-        if ((*func)(&pos) == -1)
+      do {
+        if ((*func)(&pos) == -1) {
           break;
-      while (gchar_pos(&pos) == NUL);
-      if (dir == FORWARD)
+        }
+      } while (gchar_pos(&pos) == NUL);
+      if (dir == FORWARD) {
         goto found;
-    }
-    /*
-     * if on the start of a paragraph or a section and searching forward,
-     * go to the next line
-     */
-    else if (dir == FORWARD && pos.col == 0 &&
-             startPS(pos.lnum, NUL, FALSE)) {
-      if (pos.lnum == curbuf->b_ml.ml_line_count)
+      }
+    // if on the start of a paragraph or a section and searching forward,
+    // go to the next line
+    } else if (dir == FORWARD && pos.col == 0
+               && startPS(pos.lnum, NUL, false)) {
+      if (pos.lnum == curbuf->b_ml.ml_line_count) {
         return FAIL;
-      ++pos.lnum;
+      }
+      pos.lnum++;
       goto found;
-    } else if (dir == BACKWARD)
+    } else if (dir == BACKWARD) {
       decl(&pos);
+    }
 
-    /* go back to the previous non-blank char */
-    found_dot = FALSE;
-    while ((c = gchar_pos(&pos)) == ' ' || c == '\t' ||
-           (dir == BACKWARD && vim_strchr((char_u *)".!?)]\"'", c) != NULL)) {
+    // go back to the previous non-blank char
+    found_dot = false;
+    while ((c = gchar_pos(&pos)) == ' ' || c == '\t'
+           || (dir == BACKWARD
+               && vim_strchr((char_u *)".!?)]\"'", c) != NULL)) {
       if (vim_strchr((char_u *)".!?", c) != NULL) {
         /* Only skip over a '.', '!' and '?' once. */
         if (found_dot)
@@ -2372,12 +2372,14 @@ int startPS(linenr_T lnum, int para, int both)
   char_u      *s;
 
   s = ml_get(lnum);
-  if (*s == para || *s == '\f' || (both && *s == '}'))
-    return TRUE;
-  if (*s == '.' && (inmacro(p_sections, s + 1) ||
-                    (!para && inmacro(p_para, s + 1))))
-    return TRUE;
-  return FALSE;
+  if (*s == para || *s == '\f' || (both && *s == '}')) {
+    return true;
+  }
+  if (*s == '.' && (inmacro(p_sections, s + 1)
+                    || (!para && inmacro(p_para, s + 1)))) {
+    return true;
+  }
+  return false;
 }
 
 /*
@@ -4151,19 +4153,20 @@ find_pattern_in_path (
             FNAME_EXP|FNAME_INCL|FNAME_REL, 1L, p_fname, NULL);
       already_searched = FALSE;
       if (new_fname != NULL) {
-        /* Check whether we have already searched in this file */
+        // Check whether we have already searched in this file
         for (i = 0;; i++) {
-          if (i == depth + 1)
+          if (i == depth + 1) {
             i = old_files;
-          if (i == max_path_depth)
+          }
+          if (i == max_path_depth) {
             break;
-          if (path_full_compare(new_fname, files[i].name, TRUE) & kEqualFiles) {
-            if (type != CHECK_PATH &&
-                action == ACTION_SHOW_ALL && files[i].matched) {
-              msg_putchar('\n');                    /* cursor below last one */
-              if (!got_int) {                       /* don't display if 'q'
-                                                       typed at "--more--"
-                                                       message */
+          }
+          if (path_full_compare(new_fname, files[i].name, true) & kEqualFiles) {
+            if (type != CHECK_PATH
+                && action == ACTION_SHOW_ALL && files[i].matched) {
+              msg_putchar('\n');  // cursor below last one */
+              if (!got_int) {  // don't display if 'q' typed at "--more--"
+                               // message
                 msg_home_replace_hl(new_fname);
                 MSG_PUTS(_(" (includes previously listed match)"));
                 prev_fname = NULL;
@@ -4178,15 +4181,15 @@ find_pattern_in_path (
       }
 
       if (type == CHECK_PATH && (action == ACTION_SHOW_ALL
-                                 || (new_fname == NULL &&
-                                     !already_searched))) {
-        if (did_show)
-          msg_putchar('\n');                /* cursor below last one */
-        else {
-          gotocmdline(TRUE);                /* cursor at status line */
+                                 || (new_fname == NULL && !already_searched))) {
+        if (did_show) {
+          msg_putchar('\n');  // cursor below last one
+        } else {
+          gotocmdline(true);  // cursor at status line
           MSG_PUTS_TITLE(_("--- Included files "));
-          if (action != ACTION_SHOW_ALL)
+          if (action != ACTION_SHOW_ALL) {
             MSG_PUTS_TITLE(_("not found "));
+          }
           MSG_PUTS_TITLE(_("in path ---\n"));
         }
         did_show = TRUE;
@@ -4345,16 +4348,15 @@ search_line:
                    && vim_regexec(&regmatch, line, (colnr_T)(p - line))) {
           matched = TRUE;
           startp = regmatch.startp[0];
-          /*
-           * Check if the line is not a comment line (unless we are
-           * looking for a define).  A line starting with "# define"
-           * is not considered to be a comment line.
-           */
+          // Check if the line is not a comment line (unless we are
+          // looking for a define).  A line starting with "# define"
+          // is not considered to be a comment line.
           if (skip_comments) {
-            if ((*line != '#' ||
-                 STRNCMP(skipwhite(line + 1), "define", 6) != 0)
-                && get_leader_len(line, NULL, FALSE, TRUE))
-              matched = FALSE;
+            if ((*line != '#'
+                 || STRNCMP(skipwhite(line + 1), "define", 6) != 0)
+                && get_leader_len(line, NULL, false, true)) {
+              matched = false;
+            }
 
             /*
              * Also check for a "/ *" or "/ /" before the match.

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4478,12 +4478,10 @@ syn_cmd_region (
   if (illegal || not_enough)
     rest = NULL;
 
-  /*
-   * Must have a "start" and "end" pattern.
-   */
-  if (rest != NULL && (pat_ptrs[ITEM_START] == NULL ||
-                       pat_ptrs[ITEM_END] == NULL)) {
-    not_enough = TRUE;
+  // Must have a "start" and "end" pattern.
+  if (rest != NULL && (pat_ptrs[ITEM_START] == NULL
+                       || pat_ptrs[ITEM_END] == NULL)) {
+    not_enough = true;
     rest = NULL;
   }
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -526,19 +526,17 @@ do_tag (
         taglen_advance(taglen);
         MSG_PUTS_ATTR(_("file\n"), hl_attr(HLF_T));
 
-        for (i = 0; i < num_matches && !got_int; ++i) {
+        for (i = 0; i < num_matches && !got_int; i++) {
           parse_match(matches[i], &tagp);
-          if (!new_tag && (
-                (g_do_tagpreview != 0
-                 && i == ptag_entry.cur_match) ||
-                (use_tagstack
-                 && i == tagstack[tagstackidx].cur_match)))
+          if (!new_tag && ((g_do_tagpreview != 0 && i == ptag_entry.cur_match)
+                           || (use_tagstack
+                               && i == tagstack[tagstackidx].cur_match))) {
             *IObuff = '>';
-          else
+          } else {
             *IObuff = ' ';
-          vim_snprintf((char *)IObuff + 1, IOSIZE - 1,
-              "%2d %s ", i + 1,
-              mt_names[matches[i][0] & MT_MASK]);
+          }
+          vim_snprintf((char *)IObuff + 1, IOSIZE - 1, "%2d %s ", i + 1,
+                       mt_names[matches[i][0] & MT_MASK]);
           msg_puts(IObuff);
           if (tagp.tagkind != NULL)
             msg_outtrans_len(tagp.tagkind,
@@ -1226,20 +1224,15 @@ find_tags (
   for (round = 1; round <= 2; ++round) {
     linear = (orgpat.headlen == 0 || !p_tbs || round == 2);
 
-    /*
-     * Try tag file names from tags option one by one.
-     */
-    for (first_file = TRUE;
-         use_cscope ||
-         get_tagfname(&tn, first_file, tag_fname) == OK;
-         first_file = FALSE) {
-      /*
-       * A file that doesn't exist is silently ignored.  Only when not a
-       * single file is found, an error message is given (further on).
-       */
-      if (use_cscope)
-        fp = NULL;          /* avoid GCC warning */
-      else {
+    // Try tag file names from tags option one by one.
+    for (first_file = true;
+         use_cscope || get_tagfname(&tn, first_file, tag_fname) == OK;
+         first_file = false) {
+      // A file that doesn't exist is silently ignored.  Only when not a
+      // single file is found, an error message is given (further on).
+      if (use_cscope) {
+        fp = NULL;  // avoid GCC warning
+      } else {
         if (curbuf->b_help) {
           /* Prefer help tags according to 'helplang'.  Put the
            * two-letter language name in help_lang[]. */

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -224,9 +224,9 @@ static void tk_getkeys(TermInput *input, bool force)
   while ((result = tk_getkey(input->tk, &key, force)) == TERMKEY_RES_KEY) {
     if (key.type == TERMKEY_TYPE_UNICODE && !key.modifiers) {
       forward_simple_utf8(input, &key);
-    } else if (key.type == TERMKEY_TYPE_UNICODE ||
-               key.type == TERMKEY_TYPE_FUNCTION ||
-               key.type == TERMKEY_TYPE_KEYSYM) {
+    } else if (key.type == TERMKEY_TYPE_UNICODE
+               || key.type == TERMKEY_TYPE_FUNCTION
+               || key.type == TERMKEY_TYPE_KEYSYM) {
       forward_modified_utf8(input, &key);
     } else if (key.type == TERMKEY_TYPE_MOUSE) {
       forward_mouse_event(input, &key);
@@ -282,9 +282,9 @@ static bool handle_focus_event(TermInput *input)
 
 static bool handle_bracketed_paste(TermInput *input)
 {
-  if (rbuffer_size(input->read_stream.buffer) > 5 &&
-      (!rbuffer_cmp(input->read_stream.buffer, "\x1b[200~", 6) ||
-       !rbuffer_cmp(input->read_stream.buffer, "\x1b[201~", 6))) {
+  if (rbuffer_size(input->read_stream.buffer) > 5
+      && (!rbuffer_cmp(input->read_stream.buffer, "\x1b[200~", 6)
+          || !rbuffer_cmp(input->read_stream.buffer, "\x1b[201~", 6))) {
     bool enable = *rbuffer_get(input->read_stream.buffer, 4) == '0';
     // Advance past the sequence
     rbuffer_consumed(input->read_stream.buffer, 6);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -628,8 +628,8 @@ static void tui_suspend(UI *ui)
 static void tui_set_title(UI *ui, char *title)
 {
   TUIData *data = ui->data;
-  if (!(title && unibi_get_str(data->ut, unibi_to_status_line) &&
-        unibi_get_str(data->ut, unibi_from_status_line))) {
+  if (!(title && unibi_get_str(data->ut, unibi_to_status_line)
+        && unibi_get_str(data->ut, unibi_from_status_line))) {
     return;
   }
   unibi_out(ui, unibi_to_status_line);
@@ -694,8 +694,8 @@ static void update_size(UI *ui)
   }
 
   // 2 - try from a system call(ioctl/TIOCGWINSZ on unix)
-  if (data->out_isatty &&
-      !uv_tty_get_winsize(&data->output_handle.tty, &width, &height)) {
+  if (data->out_isatty
+      && !uv_tty_get_winsize(&data->output_handle.tty, &width, &height)) {
     goto end;
   }
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2876,9 +2876,7 @@ static char_u *u_save_line(linenr_T lnum)
 /// @return true if the buffer has changed
 bool bufIsChanged(buf_T *buf)
 {
-  return
-    !bt_dontwrite(buf) &&
-    (buf->b_changed || file_ff_differs(buf, true));
+  return !bt_dontwrite(buf) && (buf->b_changed || file_ff_differs(buf, true));
 }
 
 /// Check if the 'modified' flag is set, or 'ff' has changed (only need to
@@ -2888,9 +2886,8 @@ bool bufIsChanged(buf_T *buf)
 /// @return true if the current buffer has changed
 bool curbufIsChanged(void)
 {
-  return
-    !bt_dontwrite(curbuf) &&
-    (curbuf->b_changed || file_ff_differs(curbuf, true));
+  return (!bt_dontwrite(curbuf)
+          && (curbuf->b_changed || file_ff_differs(curbuf, true)));
 }
 
 /*


### PR DESCRIPTION
Also fixes errors created by the new check. Originally Vim used the same style, so many of the errors arised from `#ifdef` removal.
