### PR TITLE
[WIP] vim-patch:d042dc8

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1,4 +1,4 @@
-*filetype.txt*  For Vim version 7.4.  Last change: 2013 Dec 15
+*filetype.txt*  For Vim version 7.4.  Last change: 2015 Nov 24
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -535,6 +535,10 @@ Global mapping:
 Local mappings:
 CTRL-]		Jump to the manual page for the word under the cursor.
 CTRL-T		Jump back to the previous manual page.
+q		Same as ":quit"
+
+To enable folding use this: >
+  	let g:ft_man_folding_enable = 1
 
 
 PDF							*ft-pdf-plugin*

--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -94,9 +94,9 @@ These are the conditions with which the expression is evaluated:
 			lowest.
   "="			use fold level from the previous line
   "a1", "a2", ..	add one, two, .. to the fold level of the previous
-			line
+			line, use the result for the current line
   "s1", "s2", ..	subtract one, two, .. from the fold level of the
-			previous line
+			previous line, use the result for the next line
   "<1", "<2", ..	a fold with this level ends at this line
   ">1", ">2", ..	a fold with this level starts at this line
 
@@ -118,6 +118,18 @@ method can be very slow!
 
 Try to avoid the "=", "a" and "s" return values, since Vim often has to search
 backwards for a line for which the fold level is defined.  This can be slow.
+
+An example of using "a1" and "s1": For a multi-line C comment, a line
+containing "/*" would return "a1" to start a fold, and a line containing "*/"
+would return "s1" to end the fold after that line: >
+  if match(thisline, '/\*') >= 0
+    return 'a1'
+  elseif match(thisline, '\*/') >= 0
+    return 's1'
+  else
+    return '='
+  endif
+However, this won't work for single line comments, strings, etc.
 
 |foldlevel()| can be useful to compute a fold level relative to a previous
 fold level.  But note that foldlevel() may return -1 if the level is not known

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -744,7 +744,7 @@ Mouse clicks can be mapped.  The codes for mouse clicks are:
 
 The X1 and X2 buttons refer to the extra buttons found on some mice.  The
 'Microsoft Explorer' mouse has these buttons available to the right thumb.
-Currently X1 and X2 only work on Win32 environments.
+Currently X1 and X2 only work on Win32 and X11 environments.
 
 Examples: >
 	:noremap <MiddleMouse> <LeftMouse><MiddleMouse>

--- a/runtime/ftplugin/changelog.vim
+++ b/runtime/ftplugin/changelog.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
-" Language:         generic Changelog file
-" Maintainer:       Nikolai Weibull <now@bitwi.se>
-" Latest Revision:  2014-01-10
+" Language:             generic Changelog file
+" Maintainer:           Martin Florian <marfl@posteo.de>
+" Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
+" Latest Revision:      2015-10-25
 " Variables:
 "   g:changelog_timeformat (deprecated: use g:changelog_dateformat instead) -
 "       description: the timeformat used in ChangeLog entries.
@@ -167,7 +168,7 @@ if &filetype == 'changelog'
       let cursor = stridx(line, '{cursor}')
       call setline(lnum, substitute(line, '{cursor}', '', ''))
     endif
-    startinsert!
+    startinsert
   endfunction
 
   " Internal function to create a new entry in the ChangeLog.
@@ -223,7 +224,8 @@ if &filetype == 'changelog'
   endfunction
 
   if exists(":NewChangelogEntry") != 2
-    noremap <buffer> <silent> <Leader>o <Esc>:call <SID>new_changelog_entry('')<CR>
+    nnoremap <buffer> <silent> <Leader>o :<C-u>call <SID>new_changelog_entry('')<CR>
+    xnoremap <buffer> <silent> <Leader>o :<C-u>call <SID>new_changelog_entry('')<CR>
     command! -nargs=0 NewChangelogEntry call s:new_changelog_entry('')
   endif
 

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -32,6 +32,10 @@ if !exists("g:no_plugin_maps") && !exists("g:no_man_maps")
   endif
 endif
 
+if exists('g:ft_man_folding_enable') && (g:ft_man_folding_enable == 1)
+  setlocal foldmethod=indent foldnestmax=1 foldenable
+endif
+
 let b:undo_ftplugin = 'setlocal iskeyword<'
 
 " vim: set sw=2:

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -3,7 +3,7 @@
 " Maintainer:	SungHyun Nam <goweol@gmail.com>
 " Previous Maintainer:	Gautam H. Mudunuri <gmudunur@informatica.com>
 " Version Info:
-" Last Change:	2008 Sep 17
+" Last Change:	2015 Nov 24
 
 " Additional highlighting by Johannes Tanzler <johannes.tanzler@aon.at>:
 "	* manSubHeading
@@ -27,8 +27,8 @@ endif
 syn case ignore
 syn match  manReference       "\f\+([1-9][a-z]\=)"
 syn match  manTitle	      "^\f\+([0-9]\+[a-z]\=).*"
-syn match  manSectionHeading  "^[a-z][a-z ]*[a-z]$"
-syn match  manSubHeading      "^\s\{3\}[a-z][a-z ]*[a-z]$"
+syn match  manSectionHeading  "^[a-z][a-z -]*[a-z]$"
+syn match  manSubHeading      "^\s\{3\}[a-z][a-z -]*[a-z]$"
 syn match  manOptionDesc      "^\s*[+-][a-z0-9]\S*"
 syn match  manLongOptionDesc  "^\s*--[a-z0-9-]\S*"
 " syn match  manHistory		"^[a-z].*last change.*$"

--- a/runtime/syntax/php.vim
+++ b/runtime/syntax/php.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: php PHP 3/4/5
 " Maintainer: Jason Woofenden <jason@jasonwoof.com>
-" Last Change: Mar 24, 2015
+" Last Change: Nov 23, 2015
 " URL: https://jasonwoof.com/gitweb/?p=vim-syntax.git;a=blob;f=php.vim;hb=HEAD
 " Former Maintainers: Peter Hodge <toomuchphp-vim@yahoo.com>
 "         Debian VIM Maintainers <pkg-vim-maintainers@lists.alioth.debian.org>
@@ -280,7 +280,7 @@ syn keyword phpStatement  return break continue exit goto  contained
 syn keyword phpKeyword  var const contained
 
 " Type
-syn keyword phpType bool[ean] int[eger] real double float string array object NULL  contained
+syn keyword phpType bool boolean int integer real double float string array object NULL  contained
 
 " Structure
 syn keyword phpStructure  namespace extends implements instanceof parent self contained
@@ -393,13 +393,13 @@ endif
 
 " String
 if exists("php_parent_error_open")
-  syn region  phpStringDouble matchgroup=None start=+"+ skip=+\\\\\|\\"+ end=+"+  contains=@phpAddStrings,phpBackslashSequences,phpBackslashDoubleQuote,@phpInterpDouble contained keepend
-  syn region  phpBacktick matchgroup=None start=+`+ skip=+\\\\\|\\"+ end=+`+  contains=@phpAddStrings,phpIdentifier,phpBackslashSequences,phpIdentifierSimply,phpIdentifierComplex contained keepend
-  syn region  phpStringSingle matchgroup=None start=+'+ skip=+\\\\\|\\'+ end=+'+  contains=@phpAddStrings,phpBackslashSingleQuote contained keepend
+  syn region  phpStringDouble matchgroup=phpStringDouble start=+"+ skip=+\\\\\|\\"+ end=+"+  contains=@phpAddStrings,phpBackslashSequences,phpBackslashDoubleQuote,@phpInterpDouble contained keepend
+  syn region  phpBacktick matchgroup=phpBacktick start=+`+ skip=+\\\\\|\\"+ end=+`+  contains=@phpAddStrings,phpIdentifier,phpBackslashSequences,phpIdentifierSimply,phpIdentifierComplex contained keepend
+  syn region  phpStringSingle matchgroup=phpStringSingle start=+'+ skip=+\\\\\|\\'+ end=+'+  contains=@phpAddStrings,phpBackslashSingleQuote contained keepend
 else
-  syn region  phpStringDouble matchgroup=None start=+"+ skip=+\\\\\|\\"+ end=+"+  contains=@phpAddStrings,phpBackslashSequences,phpBackslashDoubleQuote,@phpInterpDouble contained extend keepend
-  syn region  phpBacktick matchgroup=None start=+`+ skip=+\\\\\|\\"+ end=+`+  contains=@phpAddStrings,phpIdentifier,phpBackslashSequences,phpIdentifierSimply,phpIdentifierComplex contained extend keepend
-  syn region  phpStringSingle matchgroup=None start=+'+ skip=+\\\\\|\\'+ end=+'+  contains=@phpAddStrings,phpBackslashSingleQuote contained keepend extend
+  syn region  phpStringDouble matchgroup=phpStringDouble start=+"+ skip=+\\\\\|\\"+ end=+"+  contains=@phpAddStrings,phpBackslashSequences,phpBackslashDoubleQuote,@phpInterpDouble contained extend keepend
+  syn region  phpBacktick matchgroup=phpBacktick start=+`+ skip=+\\\\\|\\"+ end=+`+  contains=@phpAddStrings,phpIdentifier,phpBackslashSequences,phpIdentifierSimply,phpIdentifierComplex contained extend keepend
+  syn region  phpStringSingle matchgroup=phpStringSingle start=+'+ skip=+\\\\\|\\'+ end=+'+  contains=@phpAddStrings,phpBackslashSingleQuote contained keepend extend
 endif
 
 " HereDoc and NowDoc

--- a/runtime/syntax/sqloracle.vim
+++ b/runtime/syntax/sqloracle.vim
@@ -1,13 +1,12 @@
 " Vim syntax file
-" Language:	SQL, PL/SQL (Oracle 8i)
-" Maintainer:	Paul Moore <pf_moore AT yahoo.co.uk>
-" Last Change:	2005 Dec 23
+" Language:	SQL, PL/SQL (Oracle 11g)
+" Maintainer:	Christian Brabandt
+" Repository:   https://github.com/chrisbra/vim-sqloracle-syntax
+" License:      Vim
+" Previous Maintainer:	Paul Moore
+" Last Change:	2015 Nov 24
 
-" For version 5.x: Clear all syntax items
-" For version 6.x: Quit when a syntax file was already loaded
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
+if exists("b:current_syntax")
   finish
 endif
 
@@ -15,75 +14,121 @@ syn case ignore
 
 " The SQL reserved words, defined as keywords.
 
-syn keyword sqlSpecial  false null true
+syn keyword sqlSpecial	false null true
 
-syn keyword sqlKeyword	access add as asc begin by check cluster column
-syn keyword sqlKeyword	compress connect current cursor decimal default desc
+syn keyword sqlKeyword	access add as asc begin by case check cluster column
+syn keyword sqlKeyword	cache compress connect current cursor decimal default desc
 syn keyword sqlKeyword	else elsif end exception exclusive file for from
 syn keyword sqlKeyword	function group having identified if immediate increment
-syn keyword sqlKeyword	index initial into is level loop maxextents mode modify
-syn keyword sqlKeyword	nocompress nowait of offline on online start
-syn keyword sqlKeyword	successful synonym table then to trigger uid
+syn keyword sqlKeyword	index initial initrans into is level link logging loop
+syn keyword sqlKeyword	maxextents maxtrans mode modify monitoring
+syn keyword sqlKeyword	nocache nocompress nologging noparallel nowait of offline on online start
+syn keyword sqlKeyword	parallel successful synonym table tablespace then to trigger uid
 syn keyword sqlKeyword	unique user validate values view whenever
-syn keyword sqlKeyword	where with option order pctfree privileges procedure
+syn keyword sqlKeyword	where with option order pctfree pctused privileges procedure
 syn keyword sqlKeyword	public resource return row rowlabel rownum rows
 syn keyword sqlKeyword	session share size smallint type using
 
 syn keyword sqlOperator	not and or
 syn keyword sqlOperator	in any some all between exists
 syn keyword sqlOperator	like escape
-syn keyword sqlOperator union intersect minus
-syn keyword sqlOperator prior distinct
+syn keyword sqlOperator	union intersect minus
+syn keyword sqlOperator	prior distinct
 syn keyword sqlOperator	sysdate out
 
-syn keyword sqlStatement alter analyze audit comment commit create
-syn keyword sqlStatement delete drop execute explain grant insert lock noaudit
-syn keyword sqlStatement rename revoke rollback savepoint select set
-syn keyword sqlStatement truncate update
+syn keyword sqlStatement analyze audit comment commit
+syn keyword sqlStatement delete drop execute explain grant lock noaudit
+syn keyword sqlStatement rename revoke rollback savepoint set
+syn keyword sqlStatement truncate
+" next ones are contained, so folding works.
+syn keyword sqlStatement create update alter select insert contained
 
 syn keyword sqlType	boolean char character date float integer long
 syn keyword sqlType	mlslabel number raw rowid varchar varchar2 varray
 
-" Strings and characters:
-syn region sqlString		start=+"+  skip=+\\\\\|\\"+  end=+"+
-syn region sqlString		start=+'+  skip=+\\\\\|\\'+  end=+'+
+" Strings:
+syn region sqlString	start=+"+  skip=+\\\\\|\\"+  end=+"+
+syn region sqlString	start=+'+  skip=+\\\\\|\\'+  end=+'+
 
 " Numbers:
-syn match sqlNumber		"-\=\<\d*\.\=[0-9_]\>"
+syn match sqlNumber	"-\=\<\d*\.\=[0-9_]\>"
 
 " Comments:
-syn region sqlComment    start="/\*"  end="\*/" contains=sqlTodo
-syn match sqlComment	"--.*$" contains=sqlTodo
+syn region sqlComment	start="/\*"  end="\*/" contains=sqlTodo,@Spell fold 
+syn match sqlComment	"--.*$" contains=sqlTodo,@Spell
+
+" Setup Folding:
+" this is a hack, to get certain statements folded.
+" the keywords create/update/alter/select/insert need to
+" have contained option.
+syn region sqlFold start='^\s*\zs\c\(Create\|Update\|Alter\|Select\|Insert\)' end=';$\|^$' transparent fold contains=ALL
 
 syn sync ccomment sqlComment
 
-" Todo.
-syn keyword sqlTodo contained TODO FIXME XXX DEBUG NOTE
+" Functions:
+" (Oracle 11g)
+" Aggregate Functions
+syn keyword sqlFunction	avg collect corr corr_s corr_k count covar_pop covar_samp cume_dist dense_rank first
+syn keyword sqlFunction	group_id grouping grouping_id last max median min percentile_cont percentile_disc percent_rank rank
+syn keyword sqlFunction	regr_slope regr_intercept regr_count regr_r2 regr_avgx regr_avgy regr_sxx regr_syy regr_sxy
+syn keyword sqlFunction	stats_binomial_test stats_crosstab stats_f_test stats_ks_test stats_mode stats_mw_test
+syn keyword sqlFunction	stats_one_way_anova stats_t_test_one stats_t_test_paired stats_t_test_indep stats_t_test_indepu
+syn keyword sqlFunction	stats_wsr_test stddev stddev_pop stddev_samp sum
+syn keyword sqlFunction	sys_xmlagg var_pop var_samp variance xmlagg
+" Char Functions
+syn keyword sqlFunction	ascii chr concat initcap instr length lower lpad ltrim
+syn keyword sqlFunction	nls_initcap nls_lower nlssort nls_upper regexp_instr regexp_replace
+syn keyword sqlFunction	regexp_substr replace rpad rtrim soundex substr translate treat trim upper
+" Comparison Functions
+syn keyword sqlFunction	greatest least
+" Conversion Functions
+syn keyword sqlFunction	asciistr bin_to_num cast chartorowid compose convert
+syn keyword sqlFunction	decompose hextoraw numtodsinterval numtoyminterval rawtohex rawtonhex rowidtochar
+syn keyword sqlFunction	rowidtonchar scn_to_timestamp timestamp_to_scn to_binary_double to_binary_float
+syn keyword sqlFunction	to_char to_char to_char to_clob to_date to_dsinterval to_lob to_multi_byte
+syn keyword sqlFunction	to_nchar to_nchar to_nchar to_nclob to_number to_dsinterval to_single_byte
+syn keyword sqlFunction	to_timestamp to_timestamp_tz to_yminterval to_yminterval translate unistr
+" DataMining Functions
+syn keyword sqlFunction	cluster_id cluster_probability cluster_set feature_id feature_set
+syn keyword sqlFunction	feature_value prediction prediction_bounds prediction_cost
+syn keyword sqlFunction	prediction_details prediction_probability prediction_set
+" Datetime Functions
+syn keyword sqlFunction	add_months current_date current_timestamp dbtimezone extract
+syn keyword sqlFunction	from_tz last_day localtimestamp months_between new_time
+syn keyword sqlFunction	next_day numtodsinterval numtoyminterval round sessiontimezone
+syn keyword sqlFunction	sys_extract_utc sysdate systimestamp to_char to_timestamp
+syn keyword sqlFunction	to_timestamp_tz to_dsinterval to_yminterval trunc tz_offset
+" Numeric Functions
+syn keyword sqlFunction	abs acos asin atan atan2 bitand ceil cos cosh exp
+syn keyword sqlFunction	floor ln log mod nanvl power remainder round sign
+syn keyword sqlFunction	sin sinh sqrt tan tanh trunc width_bucket
+" NLS Functions
+syn keyword sqlFunction	ls_charset_decl_len nls_charset_id nls_charset_name
+" Various Functions
+syn keyword sqlFunction	bfilename cardin coalesce collect decode dump empty_blob empty_clob
+syn keyword sqlFunction	lnnvl nullif nvl nvl2 ora_hash powermultiset powermultiset_by_cardinality
+syn keyword sqlFunction	sys_connect_by_path sys_context sys_guid sys_typeid uid user userenv vsizeality
+" XML Functions
+syn keyword sqlFunction	appendchildxml deletexml depth extract existsnode extractvalue insertchildxml
+syn keyword sqlFunction	insertxmlbefore path sys_dburigen sys_xmlagg sys_xmlgen updatexml xmlagg xmlcast
+syn keyword sqlFunction	xmlcdata xmlcolattval xmlcomment xmlconcat xmldiff xmlelement xmlexists xmlforest
+syn keyword sqlFunction	xmlparse xmlpatch xmlpi xmlquery xmlroot xmlsequence xmlserialize xmltable xmltransform
+" Todo:
+syn keyword sqlTodo TODO FIXME XXX DEBUG NOTE contained
 
 " Define the default highlighting.
-" For version 5.7 and earlier: only when not done already
-" For version 5.8 and later: only when an item doesn't have highlighting yet
-if version >= 508 || !exists("did_sql_syn_inits")
-  if version < 508
-    let did_sql_syn_inits = 1
-    command -nargs=+ HiLink hi link <args>
-  else
-    command -nargs=+ HiLink hi def link <args>
-  endif
+command -nargs=+ HiLink hi def link <args>
+HiLink sqlComment	Comment
+HiLink sqlFunction	Function
+HiLink sqlKeyword	sqlSpecial
+HiLink sqlNumber	Number
+HiLink sqlOperator	sqlStatement
+HiLink sqlSpecial	Special
+HiLink sqlStatement	Statement
+HiLink sqlString	String
+HiLink sqlType		Type
+HiLink sqlTodo		Todo
 
-  HiLink sqlComment	Comment
-  HiLink sqlKeyword	sqlSpecial
-  HiLink sqlNumber	Number
-  HiLink sqlOperator	sqlStatement
-  HiLink sqlSpecial	Special
-  HiLink sqlStatement	Statement
-  HiLink sqlString	String
-  HiLink sqlType	Type
-  HiLink sqlTodo	Todo
-
-  delcommand HiLink
-endif
-
+delcommand HiLink
 let b:current_syntax = "sql"
-
 " vim: ts=8


### PR DESCRIPTION
`Update runtime files.`

https://github.com/vim/vim/commit/d042dc825c9b97dacd84d4728f88300da4d5b6b9

Missing in runtime/doc: hangulin.txt, tags, todo.txt. The changes to options.txt
do not apply for nvim. man.vim is very different in nvim, some changes applied
manually, others discarded.
