### PR TITLE
[RFC] vim-patch:7.4.896

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5097,13 +5097,15 @@ void write_lnum_adjust(linenr_T offset)
 }
 
 #if defined(BACKSLASH_IN_FILENAME)
-/*
- * Convert all backslashes in fname to forward slashes in-place.
- */
+/// Convert all backslashes in fname to forward slashes in-place,
+/// unless when it looks like a URL.
 void forward_slash(char_u *fname)
 {
   char_u      *p;
 
+  if (path_with_url(fname)) {
+    return;
+  }
   for (p = fname; *p != NUL; ++p)
     /* The Big5 encoding can have '\' in the trail byte. */
     if (enc_dbcs != 0 && (*mb_ptr2len)(p) > 1)

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5106,12 +5106,14 @@ void forward_slash(char_u *fname)
   if (path_with_url(fname)) {
     return;
   }
-  for (p = fname; *p != NUL; ++p)
-    /* The Big5 encoding can have '\' in the trail byte. */
-    if (enc_dbcs != 0 && (*mb_ptr2len)(p) > 1)
-      ++p;
-    else if (*p == '\\')
+  for (p = fname; *p != NUL; p++) {
+    // The Big5 encoding can have '\' in the trail byte.
+    if (enc_dbcs != 0 && (*mb_ptr2len)(p) > 1) {
+      p++;
+    } else if (*p == '\\') {
       *p = '/';
+    }
+  }
 }
 #endif
 

--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -46,6 +46,8 @@
 # endif
 #endif
 
+#define BACKSLASH_IN_FILENAME
+
 #ifdef _MSC_VER
 typedef SSIZE_T ssize_t;
 #endif

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1284,6 +1284,29 @@ static int expand_backtick(
   return cnt;
 }
 
+#ifdef BACKSLASH_IN_FILENAME
+/// Replace all slashes by backslashes.
+/// This used to be the other way around, but MS-DOS sometimes has problems
+/// with slashes (e.g. in a command name).  We can't have mixed slashes and
+/// backslashes, because comparing file names will not work correctly.  The
+/// commands that use a file name should try to avoid the need to type a
+/// backslash twice.
+/// When 'shellslash' set do it the other way around.
+/// When the path looks like a URL leave it unmodified.
+void slash_adjust(char_u *p)
+{
+  if (path_with_url(p)) {
+    return;
+  }
+  while (*p) {
+    if (*p == psepcN) {
+      *p = psepc;
+    }
+    mb_ptr_adv(p);
+  }
+}
+#endif
+
 // Add a file to a file list.  Accepted flags:
 // EW_DIR      add directories
 // EW_FILE     add files

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -782,7 +782,7 @@ static int included_patches[] = {
   // 899 NA
   898,
   // 897 NA
-  // 896,
+  896,
   895,
   // 894 NA
   893,


### PR DESCRIPTION
```
Problem:    Editing a URL, which netrw should handle, doesn't work.
Solution:   Avoid changing slashes to backslashes. (Yasuhiro Matsumoto)
```

vim/vim@b4f6a46

Cherry-picked from #810, rebased.
