### PR TITLE
[RFC] vim-patch:{a0f849e, d7464be, b4ff518, e392eb4, d042dc8, 2c5e8e8, 256972a, cc7ff3f}

### DIFF
--- a/runtime/autoload/pythoncomplete.vim
+++ b/runtime/autoload/pythoncomplete.vim
@@ -377,6 +377,7 @@ class PyParser:
     def __init__(self):
         self.top = Scope('global',0)
         self.scope = self.top
+        self.parserline = 0
 
     def _parsedotname(self,pre=None):
         #returns (dottedname, nexttoken)

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1,4 +1,4 @@
-*autocmd.txt*   For Vim version 7.4.  Last change: 2015 Aug 18
+*autocmd.txt*   For Vim version 7.4.  Last change: 2015 Dec 05
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1161,6 +1161,9 @@ name!
 :aug[roup] {name}		Define the autocmd group name for the
 				following ":autocmd" commands.  The name "end"
 				or "END" selects the default group.
+				To avoid confusion, the name should be
+				different from existing {event} names, as this
+				most likely will not do what you intended.
 
 						*:augroup-delete* *E367*
 :aug[roup]! {name}		Delete the autocmd group {name}.  Don't use

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1,4 +1,4 @@
-*change.txt*    For Vim version 7.4.  Last change: 2015 Sep 06
+*change.txt*    For Vim version 7.4.  Last change: 2015 Oct 17
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -832,6 +832,36 @@ either the first or second pattern in parentheses did not match, so either
 \1 or \2 is empty.  Example: >
   :s/\([ab]\)\|\([cd]\)/\1x/g   modifies "a b c d"  to "ax bx x x"
 <
+
+		*:sc* *:sce* *:scg* *:sci* *:scI* *:scl* *:scp* *:sg* *:sgc*
+		*:sge* *:sgi* *:sgI* *:sgl* *:sgn* *:sgp* *:sgr* *:sI* *:si*
+		*:sic* *:sIc* *:sie* *:sIe* *:sIg* *:sIl* *:sin* *:sIn* *:sIp*
+		*:sip* *:sIr* *:sir* *:sr* *:src* *:srg* *:sri* *:srI* *:srl*
+		*:srn* *:srp*
+2-letter and 3-letter :substitute commands ~
+
+     List of :substitute commands
+     |      c    e    g    i    I    n    p    l    r
+     | c  :sc  :sce :scg :sci :scI :scn :scp :scl  ---
+     | e
+     | g  :sgc :sge :sg  :sgi :sgI :sgn :sgp :sgl :sgr
+     | i  :sic :sie  --- :si  :siI :sin :sip  --- :sir
+     | I  :sIc :sIe :sIg :sIi :sI  :sIn :sIp :sIl :sIr
+     | n
+     | p
+     | l
+     | r  :src  --- :srg :sri :srI :srn :srp :srl :sr
+
+Exceptions:
+     :scr  is  `:scriptnames`
+     :se   is  `:set`
+     :sig  is  `:sign`
+     :sil  is  `:silent`
+     :sn   is  `:snext`
+     :sp   is  `:split`
+     :sl   is  `:sleep`
+     :sre  is  `:srewind`
+
 
 Substitute with an expression			*sub-replace-expression*
 						*sub-replace-\=* *s/\=*

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1,4 +1,4 @@
-*cmdline.txt*   For Vim version 7.4.  Last change: 2015 Sep 25
+*cmdline.txt*   For Vim version 7.4.  Last change: 2015 Dec 17
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -96,6 +96,11 @@ CTRL-E or <End>					*c_CTRL-E* *c_<End>* *c_End*
 
 							*c_<LeftMouse>*
 <LeftMouse>	Move the cursor to the position of the mouse click.
+
+							*c_<MiddleMouse>*
+<MiddleMouse>	Paste the contents of the clipboard (for X11 the primary
+		selection).  This is similar to using CTRL-R *, but no CR
+		characters are inserted between lines.
 
 CTRL-H						*c_<BS>* *c_CTRL-H* *c_BS*
 <BS>		Delete the character in front of the cursor.

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -1,4 +1,4 @@
-*diff.txt*      For Vim version 7.4.  Last change: 2015 Jul 03
+*diff.txt*      For Vim version 7.4.  Last change: 2015 Nov 01
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -174,8 +174,8 @@ hidden buffers.  You can use ":hide" to close a window without unloading the
 buffer.  If you don't want a buffer to remain used for the diff do ":set
 nodiff" before hiding it.
 
-							*:diffu* *:diffupdate*
-:diffu[pdate][!]		Update the diff highlighting and folds.
+							*:dif* *:diffupdate*
+:dif[fupdate][!]		Update the diff highlighting and folds.
 
 Vim attempts to keep the differences updated when you make changes to the
 text.  This mostly takes care of inserted and deleted lines.  Changes within a

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6183,11 +6183,6 @@ sort({list} [, {func} [, {dict}]])			*sort()* *E702*
 		on numbers, text strings will sort next to each other, in the
 		same order as they were originally.
 
-		The sort is stable, items which compare equal (as number or as
-		string) will keep their relative position. E.g., when sorting
-		on numbers, text strings will sort next to each other, in the
-		same order as they were originally.
-
 		Also see |uniq()|.
 
 		Example: >

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -864,8 +864,8 @@ expr1'th single byte from expr8.  expr8 is used as a String, expr1 as a
 Number.  This doesn't recognize multi-byte encodings, see |byteidx()| for
 an alternative.
 
-Index zero gives the first character.  This is like it works in C.  Careful:
-text column numbers start with one!  Example, to get the character under the
+Index zero gives the first byte.  This is like it works in C.  Careful:
+text column numbers start with one!  Example, to get the byte under the
 cursor: >
 	:let c = getline(".")[col(".") - 1]
 

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1,4 +1,4 @@
-*filetype.txt*  For Vim version 7.4.  Last change: 2015 Nov 24
+*filetype.txt*  For Vim version 7.4.  Last change: 2015 Nov 28
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -510,7 +510,7 @@ Local mappings:
 	to the end of the file in Normal mode.  This means "> " is inserted in
 	each line.
 
-MAN							*ft-man-plugin* *:Man*
+MAN					*ft-man-plugin* *:Man* *man.vim*
 
 Displays a manual page in a nice way.  Also see the user manual
 |find-manpage|.

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1,4 +1,4 @@
-*filetype.txt*  For Vim version 7.4.  Last change: 2015 Nov 28
+*filetype.txt*  For Vim version 7.4.  Last change: 2015 Dec 06
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -539,6 +539,9 @@ q		Same as ":quit"
 
 To enable folding use this: >
   	let g:ft_man_folding_enable = 1
+If you do not like the default folding, use an autocommand to add your desired
+folding style instead.  For example: >
+        autocmd FileType man setlocal foldmethod=indent foldenable
 
 
 PDF							*ft-pdf-plugin*

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1,4 +1,4 @@
-*filetype.txt*  For Vim version 7.4.  Last change: 2013 Dec 15
+*filetype.txt*  For Vim version 7.4.  Last change: 2015 Nov 24
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -535,6 +535,10 @@ Global mapping:
 Local mappings:
 CTRL-]		Jump to the manual page for the word under the cursor.
 CTRL-T		Jump back to the previous manual page.
+q		Same as ":quit"
+
+To enable folding use this: >
+  	let g:ft_man_folding_enable = 1
 
 
 PDF							*ft-pdf-plugin*

--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -94,9 +94,9 @@ These are the conditions with which the expression is evaluated:
 			lowest.
   "="			use fold level from the previous line
   "a1", "a2", ..	add one, two, .. to the fold level of the previous
-			line
+			line, use the result for the current line
   "s1", "s2", ..	subtract one, two, .. from the fold level of the
-			previous line
+			previous line, use the result for the next line
   "<1", "<2", ..	a fold with this level ends at this line
   ">1", ">2", ..	a fold with this level starts at this line
 
@@ -118,6 +118,18 @@ method can be very slow!
 
 Try to avoid the "=", "a" and "s" return values, since Vim often has to search
 backwards for a line for which the fold level is defined.  This can be slow.
+
+An example of using "a1" and "s1": For a multi-line C comment, a line
+containing "/*" would return "a1" to start a fold, and a line containing "*/"
+would return "s1" to end the fold after that line: >
+  if match(thisline, '/\*') >= 0
+    return 'a1'
+  elseif match(thisline, '\*/') >= 0
+    return 's1'
+  else
+    return '='
+  endif
+However, this won't work for single line comments, strings, etc.
 
 |foldlevel()| can be useful to compute a fold level relative to a previous
 fold level.  But note that foldlevel() may return -1 if the level is not known

--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -385,7 +385,7 @@ detailed elsewhere: see |'mouse'|, |win32-hidden-menus|.
 You can drag and drop one or more files into the Vim window, where they will
 be opened as normal.  See |drag-n-drop|.
 
-							*:simalt* *:si*
+							*:simalt* *:sim*
 :sim[alt] {key}		simulate pressing {key} while holding Alt pressed.
 			{only for Win32 versions}
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 7.4.  Last change: 2015 Oct 15
+*options.txt*	For Vim version 7.4.  Last change: 2015 Nov 11
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -6085,7 +6085,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	become empty.  This will make a group like the following disappear
 	completely from the statusline when none of the flags are set. >
 		:set statusline=...%(\ [%M%R%H]%)...
-<
+<							*g:actual_curbuf*
 	Beware that an expression is evaluated each and every time the status
 	line is displayed.  The current buffer and current window will be set
 	temporarily to that of the window (and buffer) whose statusline is

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 7.4.  Last change: 2015 Nov 11
+*options.txt*	For Vim version 7.4.  Last change: 2015 Nov 23
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1,4 +1,4 @@
-*pattern.txt*   For Vim version 7.4.  Last change: 2015 Mar 16
+*pattern.txt*   For Vim version 7.4.  Last change: 2015 Dec 26
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -392,8 +392,8 @@ Use of "\M" makes the pattern after it be interpreted as if 'nomagic' is used.
 Use of "\v" means that in the pattern after it all ASCII characters except
 '0'-'9', 'a'-'z', 'A'-'Z' and '_' have a special meaning.  "very magic"
 
-Use of "\V" means that in the pattern after it only the backslash has a
-special meaning.  "very nomagic"
+Use of "\V" means that in the pattern after it only the backslash and the
+terminating character (/ or ?) has a special meaning.  "very nomagic"
 
 Examples:
 after:	  \v	   \m	    \M	     \V		matches ~
@@ -401,6 +401,7 @@ after:	  \v	   \m	    \M	     \V		matches ~
 	  $	   $	    $	     \$		matches end-of-line
 	  .	   .	    \.	     \.		matches any character
 	  *	   *	    \*	     \*		any number of the previous atom
+	  ~	   ~	    \~	     \~		latest substitute string
 	  ()	   \(\)     \(\)     \(\)	grouping into an atom
 	  |	   \|	    \|	     \|		separating alternatives
 	  \a	   \a	    \a	     \a		alphabetic character
@@ -477,6 +478,7 @@ More explanation and examples below, follow the links.
 |/\%v|	\%23v	\%23v	in virtual column 23 |/zero-width|
 
 Character classes:					*/character-classes*
+      magic   nomagic	matches ~
 |/\i|	\i	\i	identifier character (see 'isident' option)
 |/\I|	\I	\I	like "\i", but excluding digits
 |/\k|	\k	\k	keyword character (see 'iskeyword' option)
@@ -507,6 +509,7 @@ Character classes:					*/character-classes*
 			class with end-of-line included
 (end of character classes)
 
+      magic   nomagic	matches ~
 |/\e|	\e	\e	<Esc>
 |/\t|	\t	\t	<Tab>
 |/\r|	\r	\r	<CR>
@@ -532,6 +535,7 @@ Character classes:					*/character-classes*
 |/\Z|	\Z	\Z	ignore differences in Unicode "combining characters".
 			Useful when searching voweled Hebrew or Arabic text.
 
+      magic   nomagic	matches ~
 |/\m|	\m	\m	'magic' on for the following chars in the pattern
 |/\M|	\M	\M	'magic' off for the following chars in the pattern
 |/\v|	\v	\v	the following chars in the pattern are "very magic"

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1,4 +1,4 @@
-*pi_netrw.txt*  For Vim version 7.4.  Last change: 2015 Oct 30
+*pi_netrw.txt*  For Vim version 7.4.  Last change: 2015 Oct 31
 
 	    ------------------------------------------------
 	    NETRW REFERENCE MANUAL    by Charles E. Campbell
@@ -3436,7 +3436,7 @@ Example: Clear netrw's marked file list via a mapping on gu >
 	     You probably want netrw running as in a side window.  If so, you
 	     will likely find that ":[N]Lexplore" does what you want.  The
 	     optional "[N]" allows you to select the quantity of columns you
-	     wish the Lexplorer window to start with (see |g:netrw_winsize|
+	     wish the |:Lexplore|r window to start with (see |g:netrw_winsize|
 	     for how this parameter works).
 
 	     Previous solution:

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1,4 +1,4 @@
-*pi_netrw.txt*  For Vim version 7.4.  Last change: 2015 Jan 05
+*pi_netrw.txt*  For Vim version 7.4.  Last change: 2015 Oct 30
 
 	    ------------------------------------------------
 	    NETRW REFERENCE MANUAL    by Charles E. Campbell
@@ -365,7 +365,12 @@ settings are described below, in |netrw-browser-options|, and in
 			    fun! MyFuncRef()
 			    endfun
 			    let g:Netrw_funcref= function("MyFuncRef")
+
 <
+ *g:Netrw_UserMaps*	specifies a function or |List| of functions which can
+			be used to set up user-specified maps and functionality.
+			See |netrw-usermaps|
+
  *g:netrw_ftp*		   if it doesn't exist, use default ftp
 			=0 use default ftp		       (uid password)
 			=1 use alternate ftp method	  (user uid password)
@@ -1062,9 +1067,10 @@ QUICK REFERENCE: MAPS				*netrw-browse-maps* {{{2
 <	 <F1>	Causes Netrw to issue help
 	 <cr>	Netrw will enter the directory or read the file      |netrw-cr|
 	 <del>	Netrw will attempt to remove the file/directory      |netrw-del|
-	 <c-h>	Edit file hiding list                             |netrw-ctrl-h|
-	 <c-l>	Causes Netrw to refresh the directory listing     |netrw-ctrl-l|
-	 <c-r>	Browse using a gvim server                        |netrw-ctrl-r|
+	 <c-h>	Edit file hiding list                                |netrw-ctrl-h|
+	 <c-l>	Causes Netrw to refresh the directory listing        |netrw-ctrl-l|
+	 <c-r>	Browse using a gvim server                           |netrw-ctrl-r|
+	 <c-tab> Shrink/expand a netrw/explore window                |netrw-c-tab|
 	   -	Makes Netrw go up one directory                      |netrw--|
 	   a	Toggles between normal display,                      |netrw-a|
 	    	hiding (suppress display of files matching g:netrw_list_hide)
@@ -1077,6 +1083,7 @@ QUICK REFERENCE: MAPS				*netrw-browse-maps* {{{2
 	   gd	Force treatment as directory                         |netrw-gd|
 	   gf	Force treatment as file                              |netrw-gf|
 	   gh	Quick hide/unhide of dot-files                       |netrw-gh|
+	   gn	Make top of tree the directory below the cursor      |netrw-gn|
 	   i	Cycle between thin, long, wide, and tree listings    |netrw-i|
 	   mb	Bookmark current directory                           |netrw-mb|
 	   mc	Copy marked files to marked-file target directory    |netrw-mc|
@@ -1105,7 +1112,7 @@ QUICK REFERENCE: MAPS				*netrw-browse-maps* {{{2
 	   qf	Display information on file                          |netrw-qf|
 	   qF	Mark files using a quickfix list                     |netrw-qF|
 	   r	Reverse sorting order                                |netrw-r|
-	   R	Rename the designed file(s)/directory(ies)           |netrw-R|
+	   R	Rename the designated file(s)/directory(ies)         |netrw-R|
 	   s	Select sorting style: by name, time, or file size    |netrw-s|
 	   S	Specify suffix priority for name-sorting             |netrw-S|
 	   t	Enter the file/directory under the cursor in a new tab|netrw-t|
@@ -1174,10 +1181,10 @@ Addtionally, one may use :NetrwMB to bookmark files or directories. >
 < No bang: enters files/directories into Netrw's bookmark system
 
    No argument and in netrw buffer:
-     if there are marked files: bookmark marked files
-     otherwise                : bookmark file/directory under cursor
+     if there are marked files        : bookmark marked files
+     otherwise                        : bookmark file/directory under cursor
    No argument and not in netrw buffer: bookmarks current open file
-   Has arguments: globs them individually and bookmarks them
+   Has arguments                      : |glob()|s each arg and bookmarks them
 
  With bang: deletes files/directories from Netrw's bookmark system
 
@@ -1394,8 +1401,8 @@ list (unless |g:netrw_dirhistmax| is zero; by default, it's ten).  With the
 the opposite, see |netrw-U|.
 
 The "u" map also accepts counts to go back in the history several slots.
-For your convenience, |netrw-qb| lists the history number which can be
-re-used in that count.
+For your convenience, qb (see |netrw-qb|) lists the history number which may
+be used in that count.
 
 						*.netrwhist*
 See |g:netrw_dirhistmax| for how to control the quantity of history stack
@@ -1412,7 +1419,7 @@ CHANGING TO A SUCCESSOR DIRECTORY		*netrw-U* *netrw-downdir* {{{2
 
 With the "U" map, one can change to a later directory (successor).
 This map is the opposite of the "u" map. (see |netrw-u|)  Use the
-q map to list both the bookmarks and history. (see |netrw-qb|)
+qb map to list both the bookmarks and history. (see |netrw-qb|)
 
 The "U" map also accepts counts to go forward in the history several slots.
 
@@ -1420,7 +1427,7 @@ See |g:netrw_dirhistmax| for how to control the quantity of history stack
 slots.
 
 
-CHANGING TREE TOP				*netrw-ntree* *:Ntree* {{{2
+CHANGING TREE TOP			*netrw-ntree*  *:Ntree*  *netrw-gn* {{{2
 
 One may specify a new tree top for tree listings using >
 
@@ -1430,14 +1437,18 @@ Without a "dirname", the current line is used (and any leading depth
 information is elided).
 With a "dirname", the specified directory name is used.
 
+The "gn" map will take the word below the cursor and use that for
+changing the top of the tree listing.
+
 
 NETRW CLEAN					*netrw-clean* *:NetrwClean* {{{2
 
-With :NetrwClean one may easily remove netrw from one's home directory;
+With NetrwClean one may easily remove netrw from one's home directory;
 more precisely, from the first directory on your |'runtimepath'|.
 
-With :NetrwClean!, netrw will remove netrw from all directories on your
-|'runtimepath'|.
+With NetrwClean!, netrw will attempt to remove netrw from all directories on
+your |'runtimepath'|.  Of course, you have to have write/delete permissions
+correct to do this.
 
 With either form of the command, netrw will first ask for confirmation
 that the removal is in fact what you want to do.  If netrw doesn't have
@@ -1454,6 +1465,7 @@ operating system).  Netrw allows one to invoke such special handlers by: >
 	* when Exploring, hit the "x" key
 	* when editing, hit gx with the cursor atop the special filename
 <	  (latter not available if the |g:netrw_nogx| variable exists)
+
 Netrw determines which special handler by the following method:
 
   * if |g:netrw_browsex_viewer| exists, then it will be used to attempt to
@@ -1629,19 +1641,23 @@ DIRECTORY EXPLORATION COMMANDS  {{{2
 	  of the current tab.  It will open a netrw window on the current
 	  directory if [dir] is omitted; a :Lexplore [dir] will show the
 	  specified directory in the left-hand side browser display no matter
-	  from which window the command is issued.  By default, :Lexplore will
-	  change an uninitialized |g:netrw_chgwin| to 2; edits will thus
-	  preferentially be made in window#2.
-	    The [N] specifies a |g:netrw_winsize| just for the new :Lexplore
+	  from which window the command is issued.
+
+	  By default, :Lexplore will change an uninitialized |g:netrw_chgwin|
+	  to 2; edits will thus preferentially be made in window#2.
+
+	  The [N] specifies a |g:netrw_winsize| just for the new :Lexplore
 	  window.
-	    Those who like this method often also like tree style displays;
+
+	  Those who like this method often also often like tree style displays;
 	  see |g:netrw_liststyle|.
 
-	  Also see: |netrw-C| |g:netrw_chgwin| |g:netrw_winsize|
-		    |netrw-p| |netrw-P|        |g:netrw_browse_split|
+	  Also see: |netrw-C|           |g:netrw_browse_split|   |g:netrw_wiw|
+		    |netrw-p| |netrw-P|   |g:netrw_chgwin|
+		    |netrw-c-tab|       |g:netrw_winsize|
 
 :[N]Lexplore! is like :Lexplore, except that the full-height Explorer window
-	  will open on the right hand side, and an uninitialized |g:netrw_chgwin|
+	  will open on the right hand side and an uninitialized |g:netrw_chgwin|
 	  will be set to 1.
 
 						*netrw-:Sexplore*
@@ -2125,19 +2141,18 @@ is unlikely to be fixed.
 
 
 UNMARKING FILES							*netrw-mF* {{{2
-	(also see |netrw-mf|)
+	(also see |netrw-mf|, |netrw-mu|)
 
-This command will unmark all files in the current buffer.  One may also use
-mf (|netrw-mf|) on a specific file to unmark just that file.
+The "mF" command will unmark all files in the current buffer.  One may also use
+mf (|netrw-mf|) on a specific, already marked, file to unmark just that file.
 
 
 MARKING FILES BY QUICKFIX LIST				*netrw-qF* {{{2
 	(also see |netrw-mf|)
 
-One may convert the |quickfix-error-lists| into a marked file list using
-"qF".  You may then proceed with commands such as me (|netrw-me|) to
-edit them.  Quickfix error lists are generated, for example, by calls
-to |:vimgrep|.
+One may convert |quickfix-error-lists| into a marked file list using "qF".
+You may then proceed with commands such as me (|netrw-me|) to edit them.
+Quickfix error lists are generated, for example, by calls to |:vimgrep|.
 
 
 MARKING FILES BY REGULAR EXPRESSION				*netrw-mr* {{{2
@@ -2155,13 +2170,16 @@ MARKED FILES, ARBITRARY VIM COMMAND				*netrw-mv*  {{{2
 	    (See |netrw-mf| and |netrw-mr| for how to mark files)
 		      (uses the local marked-file list)
 
-The "mv" map causes netrw execute an arbitrary vim command on each file
-on the local marked file list, individually:
+The "mv" map causes netrw to execute an arbitrary vim command on each file on
+the local marked file list, individually:
 
 	* 1split
 	* sil! keepalt e file
 	* run vim command
 	* sil! keepalt wq!
+
+A prompt, "Enter vim command: ", will be issued to elicit the vim command
+you wish used.
 
 
 MARKED FILES, ARBITRARY SHELL COMMAND				*netrw-mx* {{{2
@@ -2194,13 +2212,13 @@ command to be applied to all marked files on the global marked file list.  The
 
 	command files
 
-It is useful, for example, to select files and make a tarball:
+This approach is useful, for example, to select files and make a tarball: >
 
 	(mark files)
 	mX
 	Enter command: tar cf mynewtarball.tar
-
-The command that will be run in this example:
+<
+The command that will be run with this example:
 
 	tar cf mynewtarball.tar 'file1' 'file2' ...
 
@@ -2253,7 +2271,7 @@ MARKED FILES: EDITING						*netrw-me* {{{2
 	    (See |netrw-mf| and |netrw-mr| for how to mark files)
 		      (uses the global marked file list)
 
-This command will place the marked files on the |arglist| and commence
+The "me" command will place the marked files on the |arglist| and commence
 editing them.  One may return the to explorer window with |:Rexplore|.
 (use |:n| and |:p| to edit next and previous files in the arglist)
 
@@ -2261,26 +2279,33 @@ MARKED FILES: GREP						*netrw-mg* {{{2
 	    (See |netrw-mf| and |netrw-mr| for how to mark files)
 		      (uses the global marked file list)
 
-This command will apply |:vimgrep| to the marked files.
+The "mg" command will apply |:vimgrep| to the marked files.
 The command will ask for the requested pattern; one may then enter: >
 
 	/pattern/[g][j]
 	! /pattern/[g][j]
 	pattern
 <
-In the cases of "j" option usage as shown above, "mg" will winnow the current
-marked file list to just those possessing the specified pattern.
-Thus, one may use >
-	mr ...file-pattern
-	mg ..contents-pattern
-to have a marked file list satisfying the file-pattern but containing the
-desired contents-pattern.
+With /pattern/, editing will start with the first item on the |quickfix| list
+that vimgrep sets up (see |:copen|, |:cnext|, |:cprevious|).  The |:vimgrep|
+command is in use, so without 'g' each line is added to quickfix list only
+once; with 'g' every match is included.
+
+With /pattern/j, "mg" will winnow the current marked file list to just those
+marked files also possessing the specified pattern.  Thus, one may use >
+
+	mr ...file-pattern...
+	mg /pattern/j
+<
+to have a marked file list satisfying the file-pattern but also restricted to
+files containing some desired pattern.
+
 
 MARKED FILES: HIDING AND UNHIDING BY SUFFIX			*netrw-mh* {{{2
 	    (See |netrw-mf| and |netrw-mr| for how to mark files)
 		      (uses the local marked file list)
 
-This command extracts the suffices of the marked files and toggles their
+The "mh" command extracts the suffices of the marked files and toggles their
 presence on the hiding list.  Please note that marking the same suffix
 this way multiple times will result in the suffix's presence being toggled
 for each file (so an even quantity of marked files having the same suffix
@@ -2309,16 +2334,16 @@ MARKED FILES: PRINTING						*netrw-mp* {{{2
 	    (See |netrw-mf| and |netrw-mr| for how to mark files)
 		      (uses the local marked file list)
 
-Netrw will apply the |:hardcopy| command to marked files.  What it does
-is open each file in a one-line window, execute hardcopy, then close the
-one-line window.
+When "mp" is used, netrw will apply the |:hardcopy| command to marked files.
+What netrw does is open each file in a one-line window, execute hardcopy, then
+close the one-line window.
 
 
 MARKED FILES: SOURCING						*netrw-ms* {{{2
 	    (See |netrw-mf| and |netrw-mr| for how to mark files)
 		      (uses the local marked file list)
 
-Netrw will source the marked files (using vim's |:source| command)
+With "ms", netrw will source the marked files (using vim's |:source| command)
 
 
 MARKED FILES: SETTING THE TARGET DIRECTORY			*netrw-mt* {{{2
@@ -2340,6 +2365,9 @@ Set the marked file copy/move-to target (see |netrw-mc| and |netrw-mm|):
   * One may use the :MT [directory] command to set the target	*netrw-:MT*
     This command uses |<q-args>|, so spaces in the directory name are
     permitted without escaping.
+
+  * With mouse-enabled vim or with gvim, one may select a target by using
+    <c-leftmouse>
 
 There is only one copy/move-to target at a time in a vim session; ie. the
 target is a script variable (see |s:var|) and is shared between all netrw
@@ -2417,9 +2445,13 @@ Related topics:
 
 
 MARKED FILES: UNMARKING						*netrw-mu* {{{2
-     (See |netrw-mf| and |netrw-mr| for how to mark files)
+     (See |netrw-mf|, |netrw-mF|)
 
-The "mu" mapping will unmark all currently marked files.
+The "mu" mapping will unmark all currently marked files.  This command differs
+from "mF" as the latter only unmarks files in the current directory whereas
+"mu" will unmark global and all buffer-local marked files.
+(see |netrw-mF|)
+
 
 				*netrw-browser-settings*
 NETRW BROWSER VARIABLES		*netrw-browser-options* *netrw-browser-var* {{{2
@@ -2724,6 +2756,11 @@ your browsing preferences.  (see also: |netrw-settings|)
 				evaluation will be suppressed
 				(see |'ballooneval'|)
 
+  *g:netrw_usetab*		if this variable exists and is non-zero, then
+				the <tab> map supporting shrinking/expanding a
+				Lexplore or netrw window will be enabled.
+				(see |netrw-c-tab|)
+
   *g:netrw_remote_mkdir*	command for making a remote directory
 				via ftp  (also see |g:netrw_mkdir_cmd|)
 				 default: "mkdir"
@@ -2760,7 +2797,8 @@ your browsing preferences.  (see also: |netrw-settings|)
 				|netrw-ctrl-r| to use for its server.
 				 default: "NETRWSERVER"
 
-  *g:netrw_sort_by*		sort by "name", "time", or "size"
+  *g:netrw_sort_by*		sort by "name", "time", "size", or
+  				"exten".
 				 default: "name"
 
   *g:netrw_sort_direction*	sorting direction: "normal" or "reverse"
@@ -2872,6 +2910,10 @@ your browsing preferences.  (see also: |netrw-settings|)
 				take effect, for example).
 				 default: 50  (for 50%)
 
+  *g:netrw_wiw*			=1 specifies the minimum window width to use
+				when shrinking a netrw/Lexplore window
+				(see |netrw-c-tab|).
+
   *g:netrw_xstrlen*		Controls how netrw computes string lengths,
 				including multi-byte characters' string
 				length. (thanks to N Weibull, T Mechelynck)
@@ -2917,7 +2959,7 @@ help on what each of the variables do.
 
 
 ==============================================================================
-OBTAINING A FILE					*netrw-O* {{{2
+OBTAINING A FILE					*netrw-obtain* *netrw-O* {{{2
 
 If there are no marked files:
 
@@ -2947,7 +2989,7 @@ Related topics:
  * To automatically make the currently browsed directory the current
    directory, see |g:netrw_keepdir|.
 
-							*netrw-createfile*
+					*netrw-newfile* *netrw-createfile*
 OPEN A NEW FILE IN NETRW'S CURRENT DIRECTORY		*netrw-%* {{{2
 
 To open a new file in netrw's current directory, press "%".  This map
@@ -2979,10 +3021,13 @@ These will:
 	   will use only 30% of the columns available; the rest of the window
 	   is used for the preview window.
 
-Also see: |g:netrw_chgwin| |netrw-P|
+	Related: if you like this idea, you may also find :Lexplore
+	         (|netrw-:Lexplore|) or |g:netrw_chgwin| of interest
+
+Also see: |g:netrw_chgwin| |netrw-P| |'previewwindow'|
 
 
-PREVIOUS WINDOW				*netrw-P* *netrw-prvwin* {{{2
+PREVIOUS WINDOW					*netrw-P* *netrw-prvwin* {{{2
 
 To edit a file or directory in the previously used (last accessed) window (see
 :he |CTRL-W_p|), press a "P".  If there's only one window, then the one window
@@ -3004,7 +3049,7 @@ Associated setting variables:
 Also see: |g:netrw_chgwin| |netrw-p|
 
 
-REFRESHING THE LISTING			*netrw-ctrl-l* *netrw-ctrl_l* {{{2
+REFRESHING THE LISTING		*netrw-refresh* *netrw-ctrl-l* *netrw-ctrl_l* {{{2
 
 To refresh either a local or remote directory listing, press ctrl-l (<c-l>) or
 hit the <cr> when atop the ./ directory entry in the listing.  One may also
@@ -3024,11 +3069,12 @@ RENAMING FILES OR DIRECTORIES	*netrw-move* *netrw-rename* *netrw-R* {{{2
 
 If there are no marked files: (see |netrw-mf|)
 
-    Renaming/moving files and directories involves moving the cursor to the
+    Renaming files and directories involves moving the cursor to the
     file/directory to be moved (renamed) and pressing "R".  You will then be
-    queried for where you want the file/directory to be moved.  You may select
+    queried for what you want the file/directory to be renamed to  You may select
     a range of lines with the "V" command (visual selection), and then
-    pressing "R".
+    press "R"; you will be queried for each file as to what you want it
+    renamed to.
 
 If there are marked files:  (see |netrw-mf|)
 
@@ -3046,6 +3092,14 @@ If there are marked files:  (see |netrw-mf|)
     This example will mark all *.c files and then rename them to *.cpp
     files.
 
+    The ctrl-X character has special meaning for renaming files: >
+
+    	<c-x>      : a single ctrl-x tells netrw to ignore the portion of the response
+	             lying between the last '/' and the ctrl-x.
+
+	<c-x><c-x> : a pair of contiguous ctrl-x's tells netrw to ignore any
+		     portion of the string preceding the double ctrl-x's.
+<
     WARNING:~
 
     Note that moving files is a dangerous operation; copies are safer.  That's
@@ -3053,13 +3107,13 @@ If there are marked files:  (see |netrw-mf|)
     the copy fails and the delete does not, you may lose the file.
     Use at your own risk.
 
-The g:netrw_rename_cmd variable is used to implement renaming.  By default its
-value is:
+The g:netrw_rename_cmd variable is used to implement remote renaming.  By
+default its value is:
 
 	ssh HOSTNAME mv
 
 One may rename a block of files and directories by selecting them with
-the V (|linewise-visual|).
+V (|linewise-visual|) when using thin style
 
 
 SELECTING SORTING STYLE			*netrw-s* *netrw-sort* {{{2
@@ -3072,18 +3126,19 @@ Related topics:               |netrw-r| |netrw-S|
 Associated setting variables: |g:netrw_sort_by| |g:netrw_sort_sequence|
 
 
-SETTING EDITING WINDOW				*netrw-C* *netrw-:NetrwC* {{{2
+SETTING EDITING WINDOW		*netrw-editwindow* *netrw-C* *netrw-:NetrwC* {{{2
 
 One may select a netrw window for editing with the "C" mapping, using the
-:NetrwC [win#] command, or by setting g:netrw_chgwin to the selected window
+:NetrwC [win#] command, or by setting |g:netrw_chgwin| to the selected window
 number.  Subsequent selection of a file to edit (|netrw-cr|) will use that
 window.
 
-	* C  by itself, will select the current window for editing via
-	  |netrw-cr|
+	* C : by itself, will select the current window holding a netrw buffer
+	  for editing via |netrw-cr|.  The C mapping is only available while in
+	  netrw buffers.
 
-	* [count]C the count will be used as the window number to be used
-	  for editing via |netrw-cr|.
+	* [count]C : the count will be used as the window number to be used
+	  for subsequent editing via |netrw-cr|.
 
 	* :NetrwC will set |g:netrw_chgwin| to the current window
 
@@ -3092,11 +3147,90 @@ window.
 
 Using >
 	let g:netrw_chgwin= -1
-will restore the default editing behavior (ie. use the current window).
+will restore the default editing behavior
+(ie. editing will use the current window).
 
 Related topics:			|netrw-cr| |g:netrw_browse_split|
 Associated setting variables:	|g:netrw_chgwin|
 
+
+SHRINKING OR EXPANDING A NETRW OR LEXPLORE WINDOW	*netrw-c-tab* {{{2
+
+The <c-tab> key will toggle a netrw or |:Lexplore| window's width,
+but only if |g:netrw_usetab| exists and is non-zero (and, of course,
+only if your terminal supports differentiating <c-tab> from a plain
+<tab>).
+
+  * If the current window is a netrw window, toggle its width
+    (between |g:netrw_wiw| and its original width)
+
+  * Else if there is a |:Lexplore| window in the current tab, toggle
+    its width
+
+  * Else bring up a |:Lexplore| window
+
+If |g:netrw_usetab| exists or is zero, or if there is a pre-existing mapping
+for <c-tab>, then the <tab> will not be mapped.  One may map something other
+than a <c-tab>, too: (but you'll still need to have had g:netrw_usetab set) >
+
+	nmap <unique> (whatever)	<Plug>NetrwShrink
+<
+Related topics:			|:Lexplore|
+Associated setting variable:	|g:netrw_usetab|
+
+
+USER SPECIFIED MAPS					*netrw-usermaps* {{{1
+
+One may make customized user maps.  Specify a variable, |g:Netrw_UserMaps|,
+to hold a |List| of lists of keymap strings and function names: >
+
+	[["keymap-sequence","ExampleUserMapFunc"],...]
+<
+When netrw is setting up maps for a netrw buffer, if |g:Netrw_UserMaps|
+exists, then the internal function netrw#UserMaps(islocal) is called.
+This function goes through all the entries in the |g:Netrw_UserMaps| list:
+
+	* sets up maps: >
+		nno <buffer> <silent> KEYMAP-SEQUENCE
+		:call s:UserMaps(islocal,"ExampleUserMapFunc")
+<	* refreshes if result from that function call is the string
+	  "refresh"
+	* if the result string is not "", then that string will be
+	  executed (:exe result)
+	* if the result is a List, then the above two actions on results
+	  will be taken for every string in the result List
+
+The user function is passed one argument; it resembles >
+
+	fun! ExampleUserMapFunc(islocal)
+<
+where a:islocal is 1 if its a local-directory system call or 0 when
+remote-directory system call.
+
+Use netrw#Expose("varname")          to access netrw-internal (script-local)
+				     variables.
+Use netrw#Modify("varname",newvalue) to change netrw-internal variables.
+Use netrw#Call("funcname"[,args])    to call a netrw-internal function with
+				     specified arguments.
+
+Example: Get a copy of netrw's marked file list: >
+
+	let netrwmarkfilelist= netrw#Expose("netrwmarkfilelist")
+<
+Example: Modify the value of netrw's marked file list: >
+
+	call netrw#Modify("netrwmarkfilelist",[])
+<
+Example: Clear netrw's marked file list via a mapping on gu >
+    " ExampleUserMap: {{{2
+    fun! ExampleUserMap(islocal)
+      call netrw#Modify("netrwmarkfilelist",[])
+      call netrw#Modify('netrwmarkfilemtch_{bufnr("%")}',"")
+      let retval= ["refresh"]
+      return retval
+    endfun
+    let g:Netrw_UserMaps= [["gu","ExampleUserMap"]]
+<
 
 10. Problems and Fixes					*netrw-problems* {{{1
 
@@ -3272,6 +3406,7 @@ Associated setting variables:	|g:netrw_chgwin|
 		The first one (|g:netrw_ssh_cmd|) is the most important; most
 		of the others will use the string in g:netrw_ssh_cmd by
 		default.
+
 						*netrw-p9* *netrw-ml_get*
 	P9. I'm browsing, changing directory, and bang!  ml_get errors
 	    appear and I have to kill vim.  Any way around this?
@@ -3298,6 +3433,14 @@ Associated setting variables:	|g:netrw_chgwin|
 	P11. I want to have two windows; a thin one on the left and my editing
 	     window on the right.  How may I accomplish this?
 
+	     You probably want netrw running as in a side window.  If so, you
+	     will likely find that ":[N]Lexplore" does what you want.  The
+	     optional "[N]" allows you to select the quantity of columns you
+	     wish the Lexplorer window to start with (see |g:netrw_winsize|
+	     for how this parameter works).
+
+	     Previous solution:
+
 		* Put the following line in your <.vimrc>:
 			let g:netrw_altv = 1
 		* Edit the current directory:  :e .
@@ -3310,6 +3453,7 @@ Associated setting variables:	|g:netrw_chgwin|
 		  and |netrw-P|).  If you're using gvim, you can press
 		  <leftmouse> in the browser window and then press the
 		  <middlemouse> to select the file.
+
 
 								*netrw-p12*
 	P12. My directory isn't sorting correctly, or unwanted letters are
@@ -3388,7 +3532,7 @@ Associated setting variables:	|g:netrw_chgwin|
 	     to open a swap file.
 
 	     (romainl) It looks like you are starting Vim from a protected
-	     directory.  Start if from your $HOME or another writable
+	     directory.  Start netrw from your $HOME or other writable
 	     directory.
 
 								*netrw-p17*
@@ -3411,6 +3555,58 @@ Associated setting variables:	|g:netrw_chgwin|
 	     See http://stackoverflow.com/questions/12469645/
 	     "Using Vim to Remotely Edit A File on ServerB Only
 	      Accessible From ServerA"
+
+								*netrw-P19*
+	P19. How do I get numbering on in directory listings?
+		With |g:netrw_bufsettings|, you can control netrw's buffer
+		settings; try putting >
+		  let g:netrw_bufsettings="noma nomod nu nobl nowrap ro nornu"
+<		in your .vimrc.  If you'd like to have relative numbering
+		instead, try >
+		  let g:netrw_bufsettings="noma nomod nonu nobl nowrap ro rnu"
+<
+								*netrw-P20*
+	P20. How may I have gvim start up showing a directory listing?
+		Try putting the following code snippet into your .vimrc: >
+		    augroup VimStartup
+		      au!
+		      au VimEnter * if expand("%") == "" && argc() == 0 &&
+		      \ (v:servername =~ 'GVIM\d*' || v:servername == "")
+		      \ | e . | endif
+		    augroup END
+<		You may use Lexplore instead of "e" if you're so inclined.
+		This snippet assumes that you have client-server enabled
+		(ie. a "huge" vim version).
+
+								*netrw-P21*
+	P21. I've made a directory (or file) with an accented character, but
+		netrw isn't letting me enter that directory/read that file:
+
+		Its likely that the shell or o/s is using a different encoding
+		than you have vim (netrw) using.  A patch to vim supporting
+		"systemencoding" may address this issue in the future; for
+		now, just have netrw use the proper encoding.  For example: >
+
+			au FileType netrw set enc=latin1
+<
+								*netrw-P22*
+	P22. I get an error message when I try to copy or move a file:
+
+		**error** (netrw) tried using g:netrw_localcopycmd<cp>; it doesn't work!
+
+	     What's wrong?
+
+	     Netrw uses several system level commands to do things (see
+
+		 |g:netrw_localcopycmd|, |g:netrw_localmovecmd|,
+		 |g:netrw_localrmdir|, |g:netrw_mkdir_cmd|).
+
+	    You may need to adjust the default commands for one or more of
+	    these commands by setting them properly in your .vimrc.  Another
+	    source of difficulty is that these commands use vim's local
+	    directory, which may not be the same as the browsing directory
+	    shown by netrw (see |g:netrw_keepdir|).
+
 
 ==============================================================================
 11. Debugging Netrw Itself				*netrw-debug* {{{1
@@ -3502,6 +3698,46 @@ netrw:
 ==============================================================================
 12. History						*netrw-history* {{{1
 
+	v154:	Feb 26, 2015	* (Yuri Kanivetsky) reported a situation where
+				  a file was not treated properly as a file
+				  due to g:netrw_keepdir == 1
+		Mar 25, 2015	* (requested by Ben Friz) one may now sort by
+				  extension
+		Mar 28, 2015	* (requested by Matt Brooks) netrw has a lot
+				  of buffer-local mappings; however, some
+				  plugins (such as vim-surround) set up
+				  conflicting mappings that cause vim to wait.
+				  The "<nowait>" modifier has been included
+				  with most of netrw's mappings to avoid that
+				  delay.
+		Jun 26, 2015	* |netrw-gn| mapping implemted
+				* :Ntree NotADir resulted in having
+				  the tree listing expand in the error messages
+				  window.  Fixed.
+		Jun 29, 2015	* Attempting to delete a file remotely caused
+				  an error with "keepsol" mentioned; fixed.
+		Jul 08, 2015	* Several changes to keep the |:jumps| table
+				  correct when working with
+				  |g:netrw_fastbrowse| set to 2
+				* wide listing with accented characters fixed
+				  (using %-S instead of %-s with a |printf()|
+		Jul 13, 2015	* (Daniel Hahler) CheckIfKde() could be true
+				  but kfmclient not installed.  Changed order
+				  in netrw#BrowseX(): checks if kde and
+				  kfmclient, then will use xdg-open on a unix
+				  system (if xdg-open is executable)
+		Aug 11, 2015	* (McDonnell) tree listing mode wouldn't
+				  select a file in a open subdirectory.
+				* (McDonnell) when multiple subdirectories
+				  were concurrently open in tree listing
+				  mode, a ctrl-L wouldn't refresh properly.
+				* The netrw:target menu showed duplicate
+				  entries
+		Oct 13, 2015	* (mattn) provided an exception to handle
+				  windows with shellslash set but no shell
+		Oct 23, 2015	* if g:netrw_usetab and <c-tab> now used
+				  to control whether NetrwShrink is used
+				  (see |netrw-c-tab|)
 	v153:	May 13, 2014	* added another |g:netrw_ffkeep| usage {{{2
 		May 14, 2014	* changed s:PerformListing() so that it
 				  always sets ft=netrw for netrw buffers

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -1,4 +1,4 @@
-*quickref.txt*  For Vim version 7.4.  Last change: 2015 Jul 21
+*quickref.txt*  For Vim version 7.4.  Last change: 2015 Nov 10
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -800,6 +800,7 @@ Short explanation of each option:		*option-list*
 'patchexpr'	  'pex'     expression used to patch a file
 'patchmode'	  'pm'	    keep the oldest version of a file
 'path'		  'pa'	    list of directories searched with "gf" et.al.
+'perldll'		    name of the Perl dynamic library
 'preserveindent'  'pi'	    preserve the indent structure when reindenting
 'previewheight'   'pvh'     height of the preview window
 'previewwindow'   'pvw'     identifies the preview window
@@ -812,6 +813,8 @@ Short explanation of each option:		*option-list*
 'printmbfont'	  'pmbfn'   font names to be used for CJK output of :hardcopy
 'printoptions'	  'popt'    controls the format of :hardcopy output
 'pumheight'	  'ph'	    maximum height of the popup menu
+'pythondll'		    name of the Python 2 dynamic library
+'pythonthreedll'	    name of the Python 3 dynamic library
 'quoteescape'	  'qe'	    escape characters used in a string
 'readonly'	  'ro'	    disallow writing the buffer
 'redrawtime'	  'rdt'     timeout for 'hlsearch' and |:match| highlighting
@@ -822,6 +825,7 @@ Short explanation of each option:		*option-list*
 'revins'	  'ri'	    inserting characters will work backwards
 'rightleft'	  'rl'	    window is right-to-left oriented
 'rightleftcmd'	  'rlc'     commands for which editing works right-to-left
+'rubydll'		    name of the Ruby dynamic library
 'ruler'		  'ru'	    show cursor line and column in the status line
 'rulerformat'	  'ruf'     custom format for the ruler
 'runtimepath'	  'rtp'     list of directories used for runtime files

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 7.4.  Last change: 2015 Sep 29
+*syntax.txt*	For Vim version 7.4.  Last change: 2015 Oct 17
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1076,7 +1076,7 @@ CPP						*cpp.vim* *ft-cpp-syntax*
 Most of things are same as |ft-c-syntax|.
 
 Variable		Highlight ~
-cpp_no_c11		don't highlight C++11 standard items
+cpp_no_cpp11		don't highlight C++11 standard items
 
 
 CSH						*csh.vim* *ft-csh-syntax*

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 7.4.  Last change: 2015 Nov 05
+*syntax.txt*	For Vim version 7.4.  Last change: 2015 Dec 19
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1433,34 +1433,28 @@ form, then >
     :let fortran_fixed_source=1
 in your vimrc prior to the :syntax on command.
 
-If the form of the source code depends upon the file extension, then it is
-most convenient to set fortran_free_source in a ftplugin file.  For more
-information on ftplugin files, see |ftplugin|.  For example, if all your
-fortran files with an .f90 extension are written in free source form and the
-rest in fixed source form, add the following code to your ftplugin file >
-    let s:extfname = expand("%:e")
-    if s:extfname ==? "f90"
-	let fortran_free_source=1
-	unlet! fortran_fixed_source
-    else
-	let fortran_fixed_source=1
-	unlet! fortran_free_source
-    endif
-Note that this will work only if the "filetype plugin indent on" command
-precedes the "syntax on" command in your vimrc file.
+If the form of the source code depends, in a non-standard way, upon the file
+extension, then it is most convenient to set fortran_free_source in a ftplugin
+file.  For more information on ftplugin files, see |ftplugin|. Note that this
+will work only if the "filetype plugin indent on" command precedes the "syntax
+on" command in your .vimrc file.
+
 
 When you edit an existing fortran file, the syntax script will assume free
 source form if the fortran_free_source variable has been set, and assumes
 fixed source form if the fortran_fixed_source variable has been set.  If
 neither of these variables have been set, the syntax script attempts to
-determine which source form has been used by examining the first five columns
-of the first 250 lines of your file.  If no signs of free source form are
-detected, then the file is assumed to be in fixed source form.  The algorithm
-should work in the vast majority of cases.  In some cases, such as a file that
-begins with 250 or more full-line comments, the script may incorrectly decide
-that the fortran code is in fixed form.  If that happens, just add a
-non-comment statement beginning anywhere in the first five columns of the
-first twenty five lines, save (:w) and then reload (:e!) the file.
+determine which source form has been used by examining the file extension
+using conventions common to the ifort, gfortran, Cray, NAG, and PathScale
+compilers (.f, .for, .f77 for fixed-source, .f90, .f95, .f03, .f08 for
+free-source). If none of this works, then the script examines the first five
+columns of the first 500 lines of your file.  If no signs of free source form
+are detected, then the file is assumed to be in fixed source form.  The
+algorithm should work in the vast majority of cases.  In some cases, such as a
+file that begins with 500 or more full-line comments, the script may
+incorrectly decide that the fortran code is in fixed form.  If that happens,
+just add a non-comment statement beginning anywhere in the first five columns
+of the first twenty five lines, save (:w) and then reload (:e!) the file.
 
 Tabs in fortran files ~
 Tabs are not recognized by the Fortran standards.  Tabs are not a good idea in

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 7.4.  Last change: 2015 Oct 17
+*syntax.txt*	For Vim version 7.4.  Last change: 2015 Nov 05
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1077,6 +1077,7 @@ Most of things are same as |ft-c-syntax|.
 
 Variable		Highlight ~
 cpp_no_cpp11		don't highlight C++11 standard items
+cpp_no_cpp14		don't highlight C++14 standard items
 
 
 CSH						*csh.vim* *ft-csh-syntax*
@@ -4148,7 +4149,7 @@ example, for instance, can be done like this: >
 
 As can be seen here, the \z actually does double duty.	In the start pattern,
 it marks the "\(\I\i*\)" sub-expression as external; in the end pattern, it
-changes the \1 back-reference into an external reference referring to the
+changes the \z1 back-reference into an external reference referring to the
 first external sub-expression in the start pattern.  External references can
 also be used in skip patterns: >
   :syn region foo start="start \(\I\i*\)" skip="not end \z1" end="end \z1"

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -1,4 +1,4 @@
-*term.txt*      For Vim version 7.4.  Last change: 2015 Feb 23
+*term.txt*      For Vim version 7.4.  Last change: 2015 Nov 24
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -744,7 +744,7 @@ Mouse clicks can be mapped.  The codes for mouse clicks are:
 
 The X1 and X2 buttons refer to the extra buttons found on some mice.  The
 'Microsoft Explorer' mouse has these buttons available to the right thumb.
-Currently X1 and X2 only work on Win32 environments.
+Currently X1 and X2 only work on Win32 and X11 environments.
 
 Examples: >
 	:noremap <MiddleMouse> <LeftMouse><MiddleMouse>

--- a/runtime/doc/usr_03.txt
+++ b/runtime/doc/usr_03.txt
@@ -1,4 +1,4 @@
-*usr_03.txt*	For Vim version 7.4.  Last change: 2006 Jun 21
+*usr_03.txt*	For Vim version 7.4.  Last change: 2015 Dec 12
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -57,8 +57,11 @@ paragraph, much faster than using "l".  "b" does the same in the other
 direction.
 
 A word ends at a non-word character, such as a ".", "-" or ")".  To change
-what Vim considers to be a word, see the 'iskeyword' option.
-   It is also possible to move by white-space separated WORDs.  This is not a
+what Vim considers to be a word, see the 'iskeyword' option.  If you try this
+out in the help directly, 'iskeyword' needs to be reset for the examples to
+work: >
+	:set iskeyword&
+It is also possible to move by white-space separated WORDs.  This is not a
 word in the normal sense, that's why the uppercase is used.  The commands for
 moving by WORDs are also uppercase, as this figure shows:
 

--- a/runtime/doc/usr_43.txt
+++ b/runtime/doc/usr_43.txt
@@ -1,4 +1,4 @@
-*usr_43.txt*	For Vim version 7.4.  Last change: 2008 Dec 28
+*usr_43.txt*	For Vim version 7.4.  Last change: 2015 Oct 23
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -45,6 +45,7 @@ three-line comment.  You do this with only two steps:
 
 	setlocal softtabstop=4
 	noremap <buffer> <LocalLeader>c o/**************<CR><CR>/<Esc>
+	let b:undo_ftplugin = "setl softtabstop< | unmap <buffer> <LocalLeader>c"
 
 Try editing a C file.  You should notice that the 'softtabstop' option is set
 to 4.  But when you edit another file it's reset to the default zero.  That is
@@ -58,6 +59,11 @@ The ":map <buffer>" command creates a mapping that is local to the current
 buffer.  This works with any mapping command: ":map!", ":vmap", etc.  The
 |<LocalLeader>| in the mapping is replaced with the value of the
 "maplocalleader" variable.
+
+The line to set b:undo_ftplugin is for when the filetype is set to another
+value.  In that case you will want to undo your preferences.  The
+b:undo_ftplugin variable is executed as a command. Watch out for characters
+with a special meaning inside a string, such as a backslash.
 
 You can find examples for filetype plugins in this directory: >
 

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -1,4 +1,4 @@
-*various.txt*   For Vim version 7.4.  Last change: 2014 Aug 06
+*various.txt*   For Vim version 7.4.  Last change: 2015 Nov 15
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -589,5 +589,13 @@ the whole screen.  But it works good enough for most uses, and you get syntax
 highlighting.
 
 The "h" key will give you a short overview of the available commands.
+
+If you want to set options differently when using less, define the
+LessInitFunc in your vimrc, for example: >
+
+	func LessInitFunc()
+	  set nocursorcolumn nocursorline
+	endfunc
+<
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -1,4 +1,4 @@
-*vi_diff.txt*   For Vim version 7.4.  Last change: 2013 Aug 22
+*vi_diff.txt*   For Vim version 7.4.  Last change: 2015 Nov 01
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1,4 +1,4 @@
-*windows.txt*   For Vim version 7.4.  Last change: 2015 Aug 29
+*windows.txt*   For Vim version 7.4.  Last change: 2015 Nov 14
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/ftplugin/changelog.vim
+++ b/runtime/ftplugin/changelog.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
-" Language:         generic Changelog file
-" Maintainer:       Nikolai Weibull <now@bitwi.se>
-" Latest Revision:  2014-01-10
+" Language:             generic Changelog file
+" Maintainer:           Martin Florian <marfl@posteo.de>
+" Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
+" Latest Revision:      2015-10-25
 " Variables:
 "   g:changelog_timeformat (deprecated: use g:changelog_dateformat instead) -
 "       description: the timeformat used in ChangeLog entries.
@@ -167,7 +168,7 @@ if &filetype == 'changelog'
       let cursor = stridx(line, '{cursor}')
       call setline(lnum, substitute(line, '{cursor}', '', ''))
     endif
-    startinsert!
+    startinsert
   endfunction
 
   " Internal function to create a new entry in the ChangeLog.
@@ -223,7 +224,8 @@ if &filetype == 'changelog'
   endfunction
 
   if exists(":NewChangelogEntry") != 2
-    noremap <buffer> <silent> <Leader>o <Esc>:call <SID>new_changelog_entry('')<CR>
+    nnoremap <buffer> <silent> <Leader>o :<C-u>call <SID>new_changelog_entry('')<CR>
+    xnoremap <buffer> <silent> <Leader>o :<C-u>call <SID>new_changelog_entry('')<CR>
     command! -nargs=0 NewChangelogEntry call s:new_changelog_entry('')
   endif
 

--- a/runtime/ftplugin/fortran.vim
+++ b/runtime/ftplugin/fortran.vim
@@ -1,9 +1,9 @@
 " Vim settings file
 " Language:	Fortran 2008 (and older: Fortran 2003, 95, 90, 77, 66)
-" Version:	0.49
-" Last Change:	2013 Oct. 01
+" Version:	0.50
+" Last Change:	2015 Nov. 30
 " Maintainer:	Ajit J. Thakkar <ajit@unb.ca>; <http://www2.unb.ca/~ajit/>
-" Usage:	Do :help fortran-plugin from Vim
+" Usage:	For instructions, do :help fortran-plugin from Vim
 " Credits:
 " Useful suggestions were made by Stefano Zacchiroli, Hendrik Merx, Ben
 " Fritz, and David Barnett.
@@ -20,7 +20,10 @@ set cpoptions&vim
 let b:did_ftplugin = 1
 
 " Determine whether this is a fixed or free format source file
-" if this hasn't been done yet
+" if this hasn't been done yet using the priority:
+" buffer-local value
+" > global value
+" > file extension as in Intel ifort, gcc (gfortran), NAG, Pathscale, and Cray compilers
 if !exists("b:fortran_fixed_source")
   if exists("fortran_free_source")
     " User guarantees free source form
@@ -28,13 +31,19 @@ if !exists("b:fortran_fixed_source")
   elseif exists("fortran_fixed_source")
     " User guarantees fixed source form
     let b:fortran_fixed_source = 1
+  elseif expand("%:e") ==? "f\<90\|95\|03\|08\>"
+    " Free-form file extension defaults as in Intel ifort, gcc(gfortran), NAG, Pathscale, and Cray compilers
+    let b:fortran_fixed_source = 0
+  elseif expand("%:e") ==? "f\|f77\|for"
+    " Fixed-form file extension defaults
+    let b:fortran_fixed_source = 1
   else
-    " Modern Fortran allows both fixed and free source form
-    " assume fixed source form unless signs of free source form
-    " are detected in the first five columns of the first s:lmax lines
+    " Modern fortran still allows both fixed and free source form
+    " Assume fixed source form unless signs of free source form
+    " are detected in the first five columns of the first s:lmax lines.
     " Detection becomes more accurate and time-consuming if more lines
     " are checked. Increase the limit below if you keep lots of comments at
-    " the very top of each file and you have a fast computer
+    " the very top of each file and you have a fast computer.
     let s:lmax = 500
     if ( s:lmax > line("$") )
       let s:lmax = line("$")

--- a/runtime/ftplugin/hog.vim
+++ b/runtime/ftplugin/hog.vim
@@ -1,0 +1,39 @@
+" Vim filetype plugin
+" Language:     hog (snort.conf)
+" Maintainer: . Victor Roemer, <vroemer@badsec.org>.
+" Last Change:  Mar 1, 2013
+
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1
+
+let s:undo_ftplugin = "setl fo< com< cms< def< inc<"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+setlocal formatoptions=croq
+setlocal comments=:#
+setlocal commentstring=\c#\ %s
+setlocal define=\c^\s\{-}var
+setlocal include=\c^\s\{-}include
+
+" Move around configurations 
+let s:hog_keyword_match = '\c^\s*\<\(preprocessor\\|config\\|output\\|include\\|ipvar\\|portvar\\|var\\|dynamicpreprocessor\\|' . 
+                        \ 'dynamicengine\\|dynamicdetection\\|activate\\|alert\\|drop\\|block\\|dynamic\\|log\\|pass\\|reject\\|sdrop\\|sblock\)\>'
+
+exec "nnoremap <buffer><silent> ]] :call search('" . s:hog_keyword_match . "', 'W' )<CR>"
+exec "nnoremap <buffer><silent> [[ :call search('" . s:hog_keyword_match . "', 'bW' )<CR>"
+
+if exists("loaded_matchit")
+    let b:match_words =
+                  \ '^\s*\<\%(preprocessor\|config\|output\|include\|ipvar\|portvar' . 
+                  \ '\|var\|dynamicpreprocessor\|dynamicengine\|dynamicdetection' . 
+                  \ '\|activate\|alert\|drop\|block\|dynamic\|log\|pass\|reject' . 
+                  \ '\|sdrop\|sblock\>\):$,\::\,:;'
+    let b:match_skip = 'r:\\.\{-}$\|^\s*#.\{-}$\|^\s*$'
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -32,6 +32,10 @@ if !exists("g:no_plugin_maps") && !exists("g:no_man_maps")
   endif
 endif
 
+if exists('g:ft_man_folding_enable') && (g:ft_man_folding_enable == 1)
+  setlocal foldmethod=indent foldnestmax=1 foldenable
+endif
+
 let b:undo_ftplugin = 'setlocal iskeyword<'
 
 " vim: set sw=2:

--- a/runtime/indent/fortran.vim
+++ b/runtime/indent/fortran.vim
@@ -1,9 +1,9 @@
 " Vim indent file
-" Language:	Fortran 2008 (and earlier versions: 2003, 95, 90, and 77)
-" Version:	0.41
-" Last Change:	2015 Jan. 15
+" Language:	Fortran 2008 (and older: Fortran 2003, 95, 90, and 77)
+" Version:	0.42
+" Last Change:	2015 Nov. 30
 " Maintainer:	Ajit J. Thakkar <ajit@unb.ca>; <http://www2.unb.ca/~ajit/>
-" Usage:	Do :help fortran-indent from Vim
+" Usage:	For instructions, do :help fortran-indent from Vim
 " Credits:
 "  Useful suggestions were made by: Albert Oliver Serra.
 
@@ -27,7 +27,10 @@ if exists("b:fortran_indent_more") || exists("g:fortran_indent_more")
 endif
 
 " Determine whether this is a fixed or free format source file
-" if this hasn't been done yet
+" if this hasn't been done yet using the priority:
+" buffer-local value
+" > global value
+" > file extension as in Intel ifort, gcc (gfortran), NAG, Pathscale, and Cray compilers
 if !exists("b:fortran_fixed_source")
   if exists("fortran_free_source")
     " User guarantees free source form
@@ -35,13 +38,19 @@ if !exists("b:fortran_fixed_source")
   elseif exists("fortran_fixed_source")
     " User guarantees fixed source form
     let b:fortran_fixed_source = 1
+  elseif expand("%:e") ==? "f\<90\|95\|03\|08\>"
+    " Free-form file extension defaults as in Intel ifort, gcc(gfortran), NAG, Pathscale, and Cray compilers
+    let b:fortran_fixed_source = 0
+  elseif expand("%:e") ==? "f\|f77\|for"
+    " Fixed-form file extension defaults
+    let b:fortran_fixed_source = 1
   else
-    " f90 and f95 allow both fixed and free source form
-    " assume fixed source form unless signs of free source form
+    " Modern fortran still allows both fixed and free source form
+    " Assume fixed source form unless signs of free source form
     " are detected in the first five columns of the first s:lmax lines.
-    " Detection becomes more accurate and more time-consuming if more lines
+    " Detection becomes more accurate and time-consuming if more lines
     " are checked. Increase the limit below if you keep lots of comments at
-    " the very top of each file and you have a fast computer
+    " the very top of each file and you have a fast computer.
     let s:lmax = 500
     if ( s:lmax > line("$") )
       let s:lmax = line("$")

--- a/runtime/indent/hog.vim
+++ b/runtime/indent/hog.vim
@@ -1,0 +1,77 @@
+" Vim indent file
+" Language:     hog (Snort.conf)
+" Maintainer:   Victor Roemer, <vroemer@badsec.org>
+" Last Change:  Mar 7, 2013
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+    finish
+endif
+let b:did_indent = 1
+let b:undo_indent = 'setlocal smartindent< indentexpr< indentkeys<'
+
+setlocal nosmartindent
+setlocal indentexpr=GetHogIndent()
+setlocal indentkeys+=!^F,o,O,0#
+
+" Only define the function once.
+if exists("*GetHogIndent")
+    finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let s:syn_blocks = '\<SnortRuleTypeBody\>'
+
+function s:IsInBlock(lnum)
+    return synIDattr(synID(a:lnum, 1, 1), 'name') =~ s:syn_blocks 
+endfunction
+
+function GetHogIndent()
+    let prevlnum = prevnonblank(v:lnum-1)
+
+    " Comment blocks have identical indent
+    if getline(v:lnum) =~ '^\s*#' && getline(prevlnum) =~ '^\s*#'
+            return indent(prevlnum)
+    endif
+
+    " Ignore comment lines when calculating indent
+    while getline(prevlnum) =~ '^\s*#'
+        let prevlnum = prevnonblank(prevlnum-1)
+        if !prevlnum
+            return previndent
+        endif
+    endwhile
+
+    " Continuation of a line that wasn't indented
+    let prevline = getline(prevlnum)
+    if prevline =~ '^\k\+.*\\\s*$'
+        return &sw 
+    endif
+
+    " Continuation of a line that was indented
+    if prevline =~ '\k\+.*\\\s*$'
+        return indent(prevlnum)
+    endif
+
+    " Indent the next line if previous line contained a start of a block
+    " definition ('{' or '(').
+    if prevline =~ '^\k\+[^#]*{}\@!\s*$' " TODO || prevline =~ '^\k\+[^#]*()\@!\s*$'
+        return &sw
+    endif
+
+    " Match inside of a block
+    if s:IsInBlock(v:lnum)
+        if prevline =~ "^\k\+.*$"
+            return &sw
+        else
+            return indent(prevlnum)
+        endif
+    endif
+
+    return 0 
+endfunction
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/indent/sh.vim
+++ b/runtime/indent/sh.vim
@@ -3,7 +3,7 @@
 " Maintainer:          Christian Brabandt <cb@256bit.org>
 " Previous Maintainer: Peter Aronoff <telemachus@arpinum.org>
 " Original Author:     Nikolai Weibull <now@bitwi.se>
-" Latest Revision:     2015-07-28
+" Latest Revision:     2015-12-15
 " License:             Vim (see :h license)
 " Repository:          https://github.com/chrisbra/vim-sh-indent
 
@@ -11,6 +11,8 @@ if exists("b:did_indent")
   finish
 endif
 let b:did_indent = 1
+
+let b:undo_indent = 'setlocal indentexpr< indentkeys< smartindent<'
 
 setlocal indentexpr=GetShIndent()
 setlocal indentkeys+=0=then,0=do,0=else,0=elif,0=fi,0=esac,0=done,0=end,),0=;;,0=;&

--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:         YAML
 " Maintainer:       Nikolai Pavlov <zyx.vim@gmail.com>
-" Last Change:	    2015 Sep 25
+" Last Change:	    2015 Nov 01
 
 " Only load this indent file when no other was loaded.
 if exists('b:did_indent')
@@ -14,7 +14,7 @@ set cpo&vim
 let b:did_indent = 1
 
 setlocal indentexpr=GetYAMLIndent(v:lnum)
-setlocal indentkeys=!^F,o,O,0#,0},0],<:>,-
+setlocal indentkeys=!^F,o,O,0#,0},0],<:>,0-
 setlocal nosmartindent
 
 let b:undo_indent = 'setlocal indentexpr< indentkeys< smartindent<'

--- a/runtime/macros/less.vim
+++ b/runtime/macros/less.vim
@@ -1,6 +1,6 @@
 " Vim script to work like "less"
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 May 13
+" Last Change:	2015 Nov 15
 
 " Avoid loading this file twice, allow the user to define his own script.
 if exists("loaded_less")
@@ -47,6 +47,12 @@ set nows
 " Inhibit screen updates while searching
 let s:lz = &lz
 set lz
+
+" Allow the user to define a function, which can set options specifically for
+" this script.
+if exists('*LessInitFunc')
+  call LessInitFunc()
+endif
 
 " Used after each command: put cursor at end and display position
 if &wrap

--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -55,14 +55,19 @@ function! s:Highlight_Matching_Pair()
   let before = 0
 
   let text = getline(c_lnum)
-  let c = text[c_col - 1]
+  let matches = matchlist(text, '\(.\)\=\%'.c_col.'c\(.\)')
+  if empty(matches)
+    let [c_before, c] = ['', '']
+  else
+    let [c_before, c] = matches[1:2]
+  endif
   let plist = split(&matchpairs, '.\zs[:,]')
   let i = index(plist, c)
   if i < 0
     " not found, in Insert mode try character before the cursor
     if c_col > 1 && (mode() == 'i' || mode() == 'R')
-      let before = 1
-      let c = text[c_col - 2]
+      let before = strlen(c_before)
+      let c = c_before
       let i = index(plist, c)
     endif
     if i < 0

--- a/runtime/plugin/netrwPlugin.vim
+++ b/runtime/plugin/netrwPlugin.vim
@@ -20,19 +20,7 @@
 if &cp || exists("g:loaded_netrwPlugin")
  finish
 endif
-let g:loaded_netrwPlugin = "v153"
-if v:version < 702
- echohl WarningMsg
- echo "***warning*** you need vim version 7.2 for this version of netrw"
- echohl None
- finish
-endif
-if v:version < 703 || (v:version == 703 && !has("patch465"))
- echohl WarningMsg
- echo "***warning*** this version of netrw needs vim 7.3.465 or later"
- echohl Normal
- finish
-endif
+let g:loaded_netrwPlugin = "v154"
 let s:keepcpo = &cpo
 set cpo&vim
 "DechoRemOn
@@ -102,6 +90,12 @@ if !exists("g:netrw_nogx")
   vno <silent> <Plug>NetrwBrowseXVis :<c-u>call netrw#BrowseXVis()<cr>
  endif
 endif
+if exists("g:netrw_usetab") && g:netrw_usetab
+ if maparg('<c-tab>','n') == ""
+  nmap <unique> <c-tab> <Plug>NetrwShrink
+ endif
+ nno <silent> <Plug>NetrwShrink :call netrw#Shrink()<cr>
+endif
 
 " ---------------------------------------------------------------------
 " LocalBrowse: invokes netrw#LocalBrowseCheck() on directory buffers {{{2
@@ -135,15 +129,19 @@ fun! s:LocalBrowse(dirname)
   elseif isdirectory(a:dirname)
 "   call Decho("(LocalBrowse) dirname<".a:dirname."> ft=".&ft."  (isdirectory, not amiga)")
 "   call Dredir("LocalBrowse ft last set: ","verbose set ft")
+"   call Decho("(s:LocalBrowse) COMBAK#23: buf#".bufnr("%")." file<".expand("%")."> line#".line(".")." col#".col("."))
    sil! call netrw#LocalBrowseCheck(a:dirname)
+"   call Decho("(s:LocalBrowse) COMBAK#24: buf#".bufnr("%")." file<".expand("%")."> line#".line(".")." col#".col("."))
    if exists("w:netrw_bannercnt") && line('.') < w:netrw_bannercnt
     exe w:netrw_bannercnt
+"    call Decho("(s:LocalBrowse) COMBAK#25: buf#".bufnr("%")." file<".expand("%")."> line#".line(".")." col#".col("."))
    endif
 
   else
    " not a directory, ignore it
 "   call Decho("(LocalBrowse) dirname<".a:dirname."> not a directory, ignoring...")
   endif
+"  call Decho("(s:LocalBrowse) COMBAK#26: buf#".bufnr("%")." file<".expand("%")."> line#".line(".")." col#".col("."))
 
 "  call Dret("s:LocalBrowse")
 endfun

--- a/runtime/syntax/autohotkey.vim
+++ b/runtime/syntax/autohotkey.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:         AutoHotkey script file
-" Maintainer:       Nikolai Weibull <now@bitwi.se>
-" Latest Revision:  2008-06-22
+" Maintainer:       SungHyun Nam <goweol@gmail.com>
+" Previous Maintainer:       Nikolai Weibull <now@bitwi.se>
+" Latest Revision:  2015-10-29
 
 if exists("b:current_syntax")
   finish
@@ -179,6 +180,7 @@ syn keyword autohotkeyRepeat
 
 syn keyword autohotkeyConditional
       \ IfExist IfNotExist If IfEqual IfLess IfGreater Else
+      \ IfWinExist IfWinNotExist
 
 syn match   autohotkeyPreProcStart
       \ nextgroup=

--- a/runtime/syntax/cmake.vim
+++ b/runtime/syntax/cmake.vim
@@ -2,10 +2,10 @@
 " Program:      CMake - Cross-Platform Makefile Generator
 " Module:       $RCSfile: cmake-syntax.vim,v $
 " Language:     CMake
-" Maintainer:   Karthik Krishnan <karthik.krishnan@kitware.com>
-" Former Maintainer:   Dimitri Merejkowsky <d.merej@gmail.com>
+" Maintainer:	Dimitri Merejkowsky <d.merej@gmail.com>
+" Former Maintainer:   Karthik Krishnan <karthik.krishnan@kitware.com>
 " Author:       Andy Cedilnik <andy.cedilnik@kitware.com>
-" Last Change:  2015 Sep 29
+" Last Change:  2015 Dec 17
 " Version:      $Revision: 1.10 $
 "
 " Licence:      The CMake license applies to this file. See

--- a/runtime/syntax/cpp.vim
+++ b/runtime/syntax/cpp.vim
@@ -2,7 +2,7 @@
 " Language:	C++
 " Current Maintainer:	vim-jp (https://github.com/vim-jp/vim-cpp)
 " Previous Maintainer:	Ken Shan <ccshan@post.harvard.edu>
-" Last Change:	2015 May 04
+" Last Change:	2015 Nov 10
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
@@ -23,7 +23,8 @@ endif
 " C++ extensions
 syn keyword cppStatement	new delete this friend using
 syn keyword cppAccess		public protected private
-syn keyword cppType		inline virtual explicit export bool wchar_t
+syn keyword cppModifier		inline virtual explicit export
+syn keyword cppType		bool wchar_t
 syn keyword cppExceptions	throw try catch
 syn keyword cppOperator		operator typeid
 syn keyword cppOperator		and bitor or xor compl bitand and_eq or_eq xor_eq not not_eq
@@ -36,7 +37,8 @@ syn keyword cppConstant		__cplusplus
 
 " C++ 11 extensions
 if !exists("cpp_no_cpp11")
-  syn keyword cppType		override final
+  syn keyword cppModifier	override final
+  syn keyword cppType		nullptr_t
   syn keyword cppExceptions	noexcept
   syn keyword cppStorageClass	constexpr decltype thread_local
   syn keyword cppConstant	nullptr
@@ -47,6 +49,11 @@ if !exists("cpp_no_cpp11")
   syn keyword cppConstant	ATOMIC_INT_LOCK_FREE ATOMIC_LONG_LOCK_FREE
   syn keyword cppConstant	ATOMIC_LLONG_LOCK_FREE ATOMIC_POINTER_LOCK_FREE
   syn region cppRawString	matchgroup=cppRawStringDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"+ contains=@Spell
+endif
+
+" C++ 14 extensions
+if !exists("cpp_no_cpp14")
+  syn match cppNumber		display "\<0b[01]\+\(u\=l\{0,2}\|ll\=u\)\>"
 endif
 
 " The minimum and maximum operators in GNU C++
@@ -65,6 +72,7 @@ if version >= 508 || !exists("did_cpp_syntax_inits")
   HiLink cppExceptions		Exception
   HiLink cppOperator		Operator
   HiLink cppStatement		Statement
+  HiLink cppModifier		Type
   HiLink cppType		Type
   HiLink cppStorageClass	StorageClass
   HiLink cppStructure		Structure

--- a/runtime/syntax/debchangelog.vim
+++ b/runtime/syntax/debchangelog.vim
@@ -3,8 +3,8 @@
 " Maintainer:  Debian Vim Maintainers <pkg-vim-maintainers@lists.alioth.debian.org>
 " Former Maintainers: Gerfried Fuchs <alfie@ist.org>
 "                     Wichert Akkerman <wakkerma@debian.org>
-" Last Change: 2015 Apr 30
-" URL: http://anonscm.debian.org/hg/pkg-vim/vim/raw-file/unstable/runtime/syntax/debchangelog.vim
+" Last Change: 2015 Oct 24
+" URL: https://anonscm.debian.org/cgit/pkg-vim/vim.git/plain/runtime/syntax/debchangelog.vim
 
 " Standard syntax initialization
 if version < 600
@@ -23,7 +23,7 @@ let binNMU='binary-only=yes'
 syn match debchangelogName	contained "^[[:alnum:]][[:alnum:].+-]\+ "
 exe 'syn match debchangelogFirstKV	contained "; \('.urgency.'\|'.binNMU.'\)"'
 exe 'syn match debchangelogOtherKV	contained ", \('.urgency.'\|'.binNMU.'\)"'
-syn match debchangelogTarget	contained "\v %(frozen|unstable|sid|%(testing|%(old)=stable)%(-proposed-updates|-security)=|experimental|squeeze-%(backports%(-sloppy)=|volatile|lts|security)|wheezy-%(backports%(-sloppy)=|security)|jessie%(-backports|-security)=|stretch|%(devel|lucid|precise|trusty|utopic)%(-%(security|proposed|updates|backports|commercial|partner))=)+"
+syn match debchangelogTarget	contained "\v %(frozen|unstable|sid|%(testing|%(old)=stable)%(-proposed-updates|-security)=|experimental|squeeze-%(backports%(-sloppy)=|volatile|lts|security)|wheezy-%(backports%(-sloppy)=|security)|jessie%(-backports|-security)=|stretch|%(devel|precise|trusty|vivid|wily|xenial)%(-%(security|proposed|updates|backports|commercial|partner))=)+"
 syn match debchangelogVersion	contained "(.\{-})"
 syn match debchangelogCloses	contained "closes:\_s*\(bug\)\=#\=\_s\=\d\+\(,\_s*\(bug\)\=#\=\_s\=\d\+\)*"
 syn match debchangelogLP	contained "\clp:\s\+#\d\+\(,\s*#\d\+\)*"

--- a/runtime/syntax/debcontrol.vim
+++ b/runtime/syntax/debcontrol.vim
@@ -3,8 +3,8 @@
 " Maintainer:  Debian Vim Maintainers <pkg-vim-maintainers@lists.alioth.debian.org>
 " Former Maintainers: Gerfried Fuchs <alfie@ist.org>
 "                     Wichert Akkerman <wakkerma@debian.org>
-" Last Change: 2014 Oct 08
-" URL: http://anonscm.debian.org/hg/pkg-vim/vim/raw-file/unstable/runtime/syntax/debcontrol.vim
+" Last Change: 2015 Oct 24
+" URL: https://anonscm.debian.org/cgit/pkg-vim/vim.git/plain/runtime/syntax/debcontrol.vim
 
 " Standard syntax initialization
 if version < 600

--- a/runtime/syntax/debsources.vim
+++ b/runtime/syntax/debsources.vim
@@ -2,8 +2,8 @@
 " Language:     Debian sources.list
 " Maintainer:   Debian Vim Maintainers <pkg-vim-maintainers@lists.alioth.debian.org>
 " Former Maintainer: Matthijs Mohlmann <matthijs@cacholong.nl>
-" Last Change: 2015 May 25
-" URL: http://anonscm.debian.org/hg/pkg-vim/vim/raw-file/unstable/runtime/syntax/debsources.vim
+" Last Change: 2015 Oct 24
+" URL: https://anonscm.debian.org/cgit/pkg-vim/vim.git/plain/runtime/syntax/debsources.vim
 
 " Standard syntax initialization
 if version < 600
@@ -27,7 +27,7 @@ let s:supported = [
       \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental',
       \ 'squeeze', 'wheezy', 'jessie', 'stretch', 'sid', 'rc-buggy',
       \
-      \ 'precise', 'trusty', 'utopic', 'vivid', 'wily', 'devel'
+      \ 'precise', 'trusty', 'vivid', 'wily', 'xenial', 'devel'
       \ ]
 let s:unsupported = [
       \ 'buzz', 'rex', 'bo', 'hamm', 'slink', 'potato',
@@ -35,7 +35,8 @@ let s:unsupported = [
       \
       \ 'warty', 'hoary', 'breezy', 'dapper', 'edgy', 'feisty',
       \ 'gutsy', 'hardy', 'intrepid', 'jaunty', 'karmic', 'lucid',
-      \ 'maverick', 'natty', 'oneiric', 'quantal', 'raring', 'saucy'
+      \ 'maverick', 'natty', 'oneiric', 'quantal', 'raring', 'saucy',
+      \ 'utopic'
       \ ]
 let &cpo=s:cpo
 

--- a/runtime/syntax/fortran.vim
+++ b/runtime/syntax/fortran.vim
@@ -1,12 +1,12 @@
 " Vim syntax file
-" Language:	Fortran 2008 (and earlier versions: 2003, 95, 90, and 77)
-" Version:	0.95
-" Last Change:	2015 Jan. 15
+" Language:	Fortran 2008 (and older: Fortran 2003, 95, 90, and 77)
+" Version:	0.96
+" Last Change:	2015 Nov. 30
 " Maintainer:	Ajit J. Thakkar <ajit@unb.ca>; <http://www2.unb.ca/~ajit/>
 " Usage:	For instructions, do :help fortran-syntax from Vim
 " Credits:
 "  Version 0.1 was based on the fortran 77 syntax file by Mario Eusebio and
-"  Preben Guldberg. Useful suggestions were made by: Andrej Panjkov,
+"  Preben Guldberg. Useful suggestions and contributions were made by: Andrej Panjkov,
 "  Bram Moolenaar, Thomas Olsen, Michael Sternberg, Christian Reile,
 "  Walter Dieudonné, Alexander Wagner, Roman Bertle, Charles Rendleman,
 "  Andrew Griffiths, Joe Krahn, Hendrik Merx, and Matt Thompson.
@@ -19,8 +19,8 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 " Choose fortran_dialect using the priority:
-" source file directive > buffer-local value > global value > default
-" try using directive in first three lines of file
+" source file directive > buffer-local value > global value > file extension
+" first try using directive in first three lines of file
 let b:fortran_retype = getline(1)." ".getline(2)." ".getline(3)
 if b:fortran_retype =~? '\<fortran_dialect\s*=\s*F\>'
   let b:fortran_dialect = "F"
@@ -51,6 +51,12 @@ if !exists("b:fortran_fixed_source")
   elseif exists("fortran_fixed_source")
     " User guarantees fixed source form for all fortran files
     let b:fortran_fixed_source = 1
+  elseif expand("%:e") ==? "f\<90\|95\|03\|08\>"
+    " Free-form file extension defaults as in Intel ifort, gcc(gfortran), NAG, Pathscale, and Cray compilers
+    let b:fortran_fixed_source = 0
+  elseif expand("%:e") ==? "f\|f77\|for"
+    " Fixed-form file extension defaults
+    let b:fortran_fixed_source = 1
   else
     " Modern fortran still allows both free and fixed source form.
     " Assume fixed source form unless signs of free source form
@@ -67,8 +73,8 @@ if !exists("b:fortran_fixed_source")
     while s:ln <= s:lmax
       let s:test = strpart(getline(s:ln),0,5)
       if s:test !~ '^[Cc*]' && s:test !~ '^ *[!#]' && s:test =~ '[^ 0-9\t]' && s:test !~ '^[ 0-9]*\t'
-	let b:fortran_fixed_source = 0
-	break
+        let b:fortran_fixed_source = 0
+        break
       endif
       let s:ln = s:ln + 1
     endwhile

--- a/runtime/syntax/hog.vim
+++ b/runtime/syntax/hog.vim
@@ -1,350 +1,200 @@
-" Snort syntax file
-" Language:	  Snort Configuration File (see: http://www.snort.org)
-" Maintainer:	  Phil Wood, cornett@arpa.net
-" Last Change:	  $Date: 2004/06/13 17:41:17 $
-" Filenames:	  *.hog *.rules snort.conf vision.conf
-" URL:		  http://home.lanl.gov/cpw/vim/syntax/hog.vim
-" Snort Version:  1.8 By Martin Roesch (roesch@clark.net, www.snort.org)
-" TODO		  include all 1.8 syntax
+" Vim syntax file
+" Language: hog (Snort.conf + .rules)
+" Maintainer: Victor Roemer, <vroemer@badsec.org>.
+" Last Change: 2015 Oct 24  -> Rename syntax items from Snort -> Hog
+"              2012 Oct 24  -> Originalish release
 
-" For version 5.x: Clear all syntax items
 if version < 600
-   syntax clear
+    syntax clear
 elseif exists("b:current_syntax")
-" For version 6.x: Quit when a syntax file was already loaded
-   finish
+    finish
 endif
 
-syn match  hogComment	+\s\#[^\-:.%#=*].*$+lc=1	contains=hogTodo,hogCommentString
-syn region hogCommentString contained oneline start='\S\s\+\#+'ms=s+1 end='\#'
+setlocal iskeyword-=:
+setlocal iskeyword+=-
+syn case ignore
 
-syn match   hogJunk "\<\a\+|\s\+$"
-syn match   hogNumber contained	"\<\d\+\>"
-syn region  hogText contained oneline start='\S' end=',' skipwhite
-syn region  hogTexts contained oneline start='\S' end=';' skipwhite
+" Hog ruletype crap
+syn keyword     HogRuleType       ruletype nextgroup=HogRuleTypeName skipwhite
+syn match       HogRuleTypeName   "[[:alnum:]_]\+" contained nextgroup=HogRuleTypeBody skipwhite
+syn region      HogRuleTypeBody   start="{" end="}" contained contains=HogRuleTypeType,HogOutput fold
+syn keyword     HogRuleTypeType   type contained
 
-" Environment Variables
-" =====================
-"syn match hogEnvvar contained	"[\!]\=\$\I\i*"
-"syn match hogEnvvar contained	"[\!]\=\${\I\i*}"
-syn match hogEnvvar contained	"\$\I\i*"
-syn match hogEnvvar contained	"[\!]\=\${\I\i*}"
+" Hog Configurables
+syn keyword     HogPreproc    preprocessor nextgroup=HogConfigName skipwhite
+syn keyword     HogConfig     config nextgroup=HogConfigName skipwhite
+syn keyword     HogOutput     output nextgroup=HogConfigName skipwhite
+syn match       HogConfigName "[[:alnum:]_-]\+" contained nextgroup=HogConfigOpts skipwhite
+syn region      HogConfigOpts start=":" skip="\\.\{-}$\|^\s*#.\{-}$\|^\s*$" end="$" fold keepend contained contains=HogSpecial,HogNumber,HogIPAddr,HogVar,HogComment
 
+" Event filter's and threshold's
+syn region      HogEvFilter         start="event_filter\|threshold" skip="\\.\{-}$\|^\s*#.\{-}$\|^\s*$" end="$" fold transparent keepend contains=HogEvFilterKeyword,HogEvFilterOptions,HogComment
+syn keyword     HogEvFilterKeyword  skipwhite event_filter threshold
+syn keyword     HogEvFilterOptions  skipwhite type nextgroup=HogEvFilterTypes
+syn keyword     HogEvFilterTypes    skipwhite limit threshold both contained
+syn keyword     HogEvFilterOptions  skipwhite track nextgroup=HogEvFilterTrack
+syn keyword     HogEvFilterTrack    skipwhite by_src by_dst contained
+syn keyword     HogEvFilterOptions  skipwhite gen_id sig_id count seconds nextgroup=HogNumber
 
-" String handling lifted from vim.vim written by Dr. Charles E. Campbell, Jr.
-" Try to catch strings, if nothing else matches (therefore it must precede the others!)
-" vmEscapeBrace handles ["]  []"] (ie. stays as string)
-syn region       hogEscapeBrace   oneline contained transparent     start="[^\\]\(\\\\\)*\[\^\=\]\=" skip="\\\\\|\\\]" end="\]"me=e-1
-syn match	 hogPatSep	  contained	   "\\[|()]"
-syn match	 hogNotPatSep	  contained	   "\\\\"
-syn region	 hogString	  oneline	   start=+[^:a-zA-Z\->!\\]"+hs=e+1 skip=+\\\\\|\\"+ end=+"\s*;+he=s-1		     contains=hogEscapeBrace,hogPatSep,hogNotPatSep oneline
-""syn region	   hogString	    oneline	     start=+[^:a-zA-Z>!\\]'+lc=1 skip=+\\\\\|\\'+ end=+'+		 contains=hogEscapeBrace,vimPatSep,hogNotPatSep
-"syn region	  hogString	   oneline	    start=+=!+lc=1   skip=+\\\\\|\\!+ end=+!+				contains=hogEscapeBrace,hogPatSep,hogNotPatSep
-"syn region	  hogString	   oneline	    start="=+"lc=1   skip="\\\\\|\\+" end="+"				contains=hogEscapeBrace,hogPatSep,hogNotPatSep
-"syn region	  hogString	   oneline	    start="[^\\]+\s*[^a-zA-Z0-9.]"lc=1 skip="\\\\\|\\+" end="+"		contains=hogEscapeBrace,hogPatSep,hogNotPatSep
-"syn region	  hogString	   oneline	    start="\s/\s*\A"lc=1 skip="\\\\\|\\+" end="/"			contains=hogEscapeBrace,hogPatSep,hogNotPatSep
-"syn match	  hogString	   contained	    +"[^"]*\\$+      skipnl nextgroup=hogStringCont
-"syn match	  hogStringCont    contained	    +\(\\\\\|.\)\{-}[^\\]"+
+" Suppressions
+syn region      HogEvFilter         start="suppress" skip="\\.\{-}$\|^\s*#.\{-}$\|^\s*$" end="$" fold transparent keepend contains=HogSuppressKeyword,HogComment
+syn keyword     HogSuppressKeyword  skipwhite suppress
+syn keyword     HogSuppressOptions  skipwhite gen_id sig_id nextgroup=HogNumber
+syn keyword     HogSuppressOptions  skipwhite track nextgroup=HogEvFilterTrack
+syn keyword     HogSuppressOptions  skipwhite ip nextgroup=HogIPAddr
 
+" Attribute table
+syn keyword     HogAttribute        attribute_table nextgroup=HogAttributeFile
+syn match       HogAttributeFile    contained ".*$" contains=HogVar,HogAttributeType,HogComment
+syn keyword     HogAttributeType    filename
 
-" Beginners - Patterns that involve ^
-"
-syn match  hogLineComment	+^[ \t]*#.*$+	contains=hogTodo,hogCommentString,hogCommentTitle
-syn match  hogCommentTitle	'#\s*\u\a*\(\s\+\u\a*\)*:'ms=s+1 contained
-syn keyword hogTodo contained	TODO
+" Hog includes
+syn keyword     HogInclude    include nextgroup=HogIncludeFile skipwhite
+syn match       HogIncludeFile ".*$" contained contains=HogVar,HogComment
 
-" Rule keywords
-syn match   hogARPCOpt contained "\d\+,\*,\*"
-syn match   hogARPCOpt contained "\d\+,\d\+,\*"
-syn match   hogARPCOpt contained "\d\+,\*,\d\+"
-syn match   hogARPCOpt contained "\d\+,\d\+,\d"
-syn match   hogATAGOpt contained "session"
-syn match   hogATAGOpt contained "host"
-syn match   hogATAGOpt contained "dst"
-syn match   hogATAGOpt contained "src"
-syn match   hogATAGOpt contained "seconds"
-syn match   hogATAGOpt contained "packets"
-syn match   hogATAGOpt contained "bytes"
-syn keyword hogARespOpt contained rst_snd rst_rcv rst_all skipwhite
-syn keyword hogARespOpt contained icmp_net icmp_host icmp_port icmp_all skipwhite
-syn keyword hogAReactOpt contained block warn msg skipwhite
-syn match   hogAReactOpt contained "proxy\d\+" skipwhite
-syn keyword hogAFOpt contained logto content_list skipwhite
-syn keyword hogAIPOptVal contained  eol nop ts sec lsrr lsrre satid ssrr rr skipwhite
-syn keyword hogARefGrps contained arachnids skipwhite
-syn keyword hogARefGrps contained bugtraq skipwhite
-syn keyword hogARefGrps contained cve skipwhite
-syn keyword hogSessionVal contained  printable all skipwhite
-syn match   hogAFlagOpt contained "[0FSRPAUfsrpau21]\+" skipwhite
-syn match   hogAFragOpt contained "[DRMdrm]\+" skipwhite
-"
-" Output syslog options
-" Facilities
-syn keyword hogSysFac contained LOG_AUTH LOG_AUTHPRIV LOG_DAEMON LOG_LOCAL0
-syn keyword hogSysFac contained LOG_LOCAL1 LOG_LOCAL2 LOG_LOCAL3 LOG_LOCAL4
-syn keyword hogSysFac contained LOG_LOCAL5 LOG_LOCAL6 LOG_LOCAL7 LOG_USER
-" Priorities
-syn keyword hogSysPri contained LOG_EMERG ALERT LOG_CRIT LOG_ERR
-syn keyword hogSysPri contained LOG_WARNING LOG_NOTICE LOG_INFO LOG_DEBUG
-" Options
-syn keyword hogSysOpt contained LOG_CONS LOG_NDELAY LOG_PERROR
-syn keyword hogSysOpt contained LOG_PID
-" RuleTypes
-syn keyword hogRuleType contained log pass alert activate dynamic
+" Hog dynamic libraries
+syn keyword     HogDylib      dynamicpreprocessor dynamicengine dynamicdetection nextgroup=HogDylibFile skipwhite
+syn match       HogDylibFile  "\s.*$" contained contains=HogVar,HogDylibType,HogComment
+syn keyword     HogDylibType  directory file contained
 
-" Output log_database arguments and parameters
-" Type of database followed by ,
-" syn keyword hogDBSQL contained mysql postgresql unixodbc
-" Parameters param=constant
-" are just various constants assigned to parameter names
+" Variable dereferenced with '$'
+syn match       HogVar        "\$[[:alnum:]_]\+"
 
-" Output log_database arguments and parameters
-" Type of database followed by ,
-syn keyword hogDBType contained alert log
-syn keyword hogDBSRV contained mysql postgresql unixodbc
-" Parameters param=constant
-" are just various constants assigned to parameter names
-syn keyword hogDBParam contained dbname host port user password sensor_name
+", Variables declared with 'var'
+syn keyword     HogVarType    var nextgroup=HogVarSet skipwhite
+syn match       HogVarSet     "[[:alnum:]_]\+" display contained nextgroup=HogVarValue skipwhite
+syn match       HogVarValue   ".*$" contained contains=HogString,HogNumber,HogVar,HogComment
 
-" Output xml arguments and parameters
-" xml args
-syn keyword hogXMLArg  contained log alert
-syn keyword hogXMLParam contained file protocol host port cert key ca server sanitize encoding detail
-"
-" hog rule handler '(.*)'
-syn region  hogAOpt contained oneline start="rpc" end=":"me=e-1 nextgroup=hogARPCOptGrp skipwhite
-syn region  hogARPCOptGrp contained oneline start="."hs=s+1 end=";"me=e-1 contains=hogARPCOpt skipwhite
+" Variables declared with 'ipvar'
+syn keyword     HogIPVarType  ipvar nextgroup=HogIPVarSet skipwhite
+syn match       HogIPVarSet   "[[:alnum:]_]\+" display contained nextgroup=HogIPVarList,HogSpecial skipwhite
+syn region      HogIPVarList  start="\[" end="]" contains=HogIPVarList,HogIPAddr,HogVar,HogOpNot
 
-syn region  hogAOpt contained oneline start="tag" end=":"me=e-1 nextgroup=hogATAGOptGrp skipwhite
-syn region  hogATAGOptGrp contained oneline start="."hs=s+1 skip="," end=";"me=e-1 contains=hogATAGOpt,hogNumber skipwhite
-"
-syn region  hogAOpt contained oneline start="nocase\|sameip" end=";"me=e-1 skipwhite oneline keepend
-"
-syn region  hogAOpt contained start="resp" end=":"me=e-1 nextgroup=hogARespOpts skipwhite
-syn region  hogARespOpts contained oneline start="." end="[,;]" contains=hogARespOpt skipwhite nextgroup=hogARespOpts
-"
-syn region  hogAOpt contained start="react" end=":"me=e-1 nextgroup=hogAReactOpts skipwhite
-syn region  hogAReactOpts contained oneline start="." end="[,;]" contains=hogAReactOpt skipwhite nextgroup=hogAReactOpts
+" Variables declared with 'portvar'
+syn keyword     HogPortVarType portvar nextgroup=HogPortVarSet skipwhite
+syn match       HogPortVarSet "[[:alnum:]_]\+" display contained nextgroup=HogPortVarList,HogPort,HogOpRange,HogOpNot,HogSpecial skipwhite
+syn region      HogPortVarList start="\[" end="]" contains=HogPortVarList,HogVar,HogOpNot,HogPort,HogOpRange,HogOpNot
+syn match       HogPort       "\<\%(\d\+\|any\)\>" display contains=HogOpRange nextgroup=HogOpRange
 
-syn region  hogAOpt contained oneline start="depth\|seq\|ttl\|ack\|icmp_seq\|activates\|activated_by\|dsize\|icode\|icmp_id\|count\|itype\|tos\|id\|offset" end=":"me=e-1 nextgroup=hogANOptGrp skipwhite
-syn region  hogANOptGrp contained oneline start="."hs=s+1 end=";"me=e-1 contains=hogNumber skipwhite oneline keepend
+" Generic stuff
+syn match       HogIPAddr     contained "\<\%(\d\{1,3}\(\.\d\{1,3}\)\{3}\|any\)\>" nextgroup=HogIPCidr
+syn match       HogIPAddr     contained "\<\d\{1,3}\(\.\d\{1,3}\)\{3}\>" nextgroup=HogIPCidr
+syn match       HogIPCidr     contained "\/\([0-2][0-9]\=\|3[0-2]\=\)"
+syn region      HogHexEsc     contained start='|' end='|' oneline
+syn region      HogString     contained start='"' end='"' extend oneline contains=HogHexEsc
+syn match       HogNumber     contained display "\<\d\+\>"
+syn match       HogNumber     contained display "\<\d\+\>"
+syn match       HogNumber     contained display "0x\x\+\>"
+syn keyword     HogSpecial    contained true false yes no default all any
+syn keyword     HogSpecialAny contained any
+syn match       HogOpNot      "!" contained
+syn match       HogOpRange    ":" contained
 
-syn region  hogAOpt contained oneline start="classtype" end=":"me=e-1 nextgroup=hogAFileGrp skipwhite
+" Rules
+syn keyword     HogRuleAction     activate alert drop block dynamic log pass reject sdrop sblock skipwhite nextgroup=HogRuleProto,HogRuleBlock
+syn keyword     HogRuleProto      ip tcp udp icmp skipwhite contained nextgroup=HogRuleSrcIP
+syn match       HogRuleSrcIP      "\S\+" transparent skipwhite contained contains=HogIPVarList,HogIPAddr,HogVar,HogOpNot nextgroup=HogRuleSrcPort
+syn match       HogRuleSrcPort    "\S\+" transparent skipwhite contained contains=HogPortVarList,HogVar,HogPort,HogOpRange,HogOpNot nextgroup=HogRuleDir
+syn match       HogRuleDir        "->\|<>" skipwhite contained nextgroup=HogRuleDstIP
+syn match       HogRuleDstIP      "\S\+" transparent skipwhite contained contains=HogIPVarList,HogIPAddr,HogVar,HogOpNot nextgroup=HogRuleDstPort
+syn match       HogRuleDstPort    "\S\+" transparent skipwhite contained contains=HogPortVarList,HogVar,HogPort,HogOpRange,HogOpNot nextgroup=HogRuleBlock
+syn region      HogRuleBlock      start="(" end=")" transparent skipwhite contained contains=HogRuleOption,HogComment fold
+",HogString,HogComment,HogVar,HogOptNot
+"syn region      HogRuleOption     start="\<gid\|sid\|rev\|depth\|offset\|distance\|within\>" end="\ze;" skipwhite contained contains=HogNumber
+syn keyword     HogRuleOption   skipwhite contained nextgroup=HogRuleSROP msg gid sid rev classtype priority metadata content nocase rawbytes
+syn keyword     HogRuleOption   skipwhite contained nextgroup=HogRuleSROP depth offset distance within http_client_body http_cookie http_raw_cookie http_header
+syn keyword     HogRuleOption   skipwhite contained nextgroup=HogRuleSROP http_raw_header http_method http_uri http_raw_uri http_stat_code http_stat_msg
+syn keyword     HogRuleOption   skipwhite contained nextgroup=HogRuleSROP fast_pattern uricontent urilen isdataat pcre pkt_data file_data base64_decode base64_data
+syn keyword     HogRuleOption   skipwhite contained nextgroup=HogRuleSROP byte_test byte_jump byte_extract ftpbounce asn1 cvs dce_iface dce_opnum dce_stub_data
+syn keyword     HogRuleOption   skipwhite contained nextgroup=HogRuleSROP sip_method sip_stat_code sip_header sip_body gtp_type gtp_info gtp_version ssl_version
+syn keyword     HogRuleOption   skipwhite contained nextgroup=HogRuleSROP ssl_state fragoffset ttl tos id ipopts fragbits dsize flags flow flowbits seq ack window
+syn keyword     HogRuleOption   skipwhite contained nextgroup=HogRuleSROP itype icode icmp_id icmp_seq rpc ip_proto sameip stream_reassemble stream_size
+syn keyword     HogRuleOption   skipwhite contained nextgroup=HogRuleSROP logto session resp react tag activates activated_by count replace detection_filter
+syn keyword     HogRuleOption   skipwhite contained nextgroup=HogRuleSROP threshold reference sd_pattern file_type file_group
 
-syn region  hogAOpt contained oneline start="regex\|msg\|content" end=":"me=e-1 nextgroup=hogAStrGrp skipwhite
-"syn region  hogAStrGrp contained oneline start=+:\s*"+hs=s+1 skip="\\;" end=+"\s*;+he=s-1 contains=hogString skipwhite oneline keepend
-syn region  hogAStrGrp contained oneline start=+:\s*"\|:"+hs=s+1 skip="\\;" end=+"\s*;+he=s-1 contains=hogString skipwhite oneline keepend
+syn region      HogRuleSROP     start=':' end=";" transparent keepend contained contains=HogRuleChars,HogString,HogNumber
+syn match       HogRuleChars    "\%(\k\|\.\|?\|=\|/\|%\|&\)\+" contained
+syn match       HogURLChars     "\%(\.\|?\|=\)\+" contained
 
-syn region  hogAOpt contained oneline start="logto\|content-list" end=":"me=e-1 nextgroup=hogAFileGrp skipwhite
-syn region  hogAFileGrp contained oneline start="."hs=s+1 end=";"me=e-1 contains=hogFileName skipwhite
-
-syn region  hogAOpt contained oneline start="reference" end=":"me=e-1 nextgroup=hogARefGrp skipwhite
-syn region  hogARefGrp contained oneline start="."hs=s+1 end=","me=e-1 contains=hogARefGrps nextgroup=hogARefName skipwhite
-syn region  hogARefName contained oneline start="."hs=s+1 end=";"me=e-1 contains=hogString,hogFileName,hogNumber skipwhite
-
-syn region  hogAOpt contained oneline start="flags" end=":"he=s-1 nextgroup=hogAFlagOpt skipwhite oneline keepend
-
-syn region  hogAOpt contained oneline start="fragbits" end=":"he=s-1 nextgroup=hogAFlagOpt skipwhite oneline keepend
-
-syn region  hogAOpt contained oneline start="ipopts" end=":"he=s-1 nextgroup=hogAIPOptVal skipwhite oneline keepend
-
-"syn region  hogAOpt contained oneline start="." end=":"he=s-1 contains=hogAFOpt nextgroup=hogFileName skipwhite
-
-syn region  hogAOpt contained oneline start="session" end=":"he=s-1 nextgroup=hogSessionVal skipwhite
-
-syn match   nothing  "$"
-syn region  hogRules oneline  contains=nothing start='$' end="$"
-syn region  hogRules oneline  contains=hogRule start='('ms=s+1 end=")\s*$" skipwhite
-syn region  hogRule  contained oneline start="." skip="\\;" end=";"he=s-1 contains=hogAOpts, skipwhite keepend
-"syn region  hogAOpts contained oneline start="." end="[;]"he=s-1 contains=hogAOpt skipwhite
-syn region  hogAOpts contained oneline start="." end="[;]"me=e-1 contains=hogAOpt skipwhite
+" Hog File Type Rules
+syn match       HogFileType   /^\s*file.*$/ transparent contains=HogFileTypeOpt,HogFileFROP
+syn keyword     HogFileTypeOpt  skipwhite contained nextgroup=HogRuleFROP file type ver category id rev content offset msg group 
+syn region      HogFileFROP  start=':' end=";" transparent keepend contained contains=NotASemicoln
+syn match       NotASemiColn   ".*$" contained
 
 
-" ruletype command
-syn keyword hogRTypeStart skipwhite ruletype nextgroup=hogRuleName skipwhite
-syn region  hogRuleName  contained  start="." end="\s" contains=hogFileName  nextgroup=hogRTypeRegion
-" type ruletype sub type
-syn region hogRtypeRegion contained start="{" end="}" nextgroup=hogRTypeStart
-syn keyword hogRTypeStart skipwhite type nextgroup=hogRuleTypes skipwhite
-syn region  hogRuleTypes  contained  start="." end="\s" contains=hogRuleType nextgroup=hogOutStart
+" Comments
+syn keyword HogTodo   XXX TODO NOTE contained
+syn match   HogTodo   "Step\s\+#\=\d\+" contained
+syn region HogComment start="#" end="$" contains=HogTodo,@Spell
 
+syn case match
 
-" var command
-syn keyword hogVarStart skipwhite var nextgroup=hogVarIdent skipwhite
-syn region  hogVarIdent contained  start="."hs=e+1 end="\s\+"he=s-1 contains=hogEnvvar nextgroup=hogVarRegion skipwhite
-syn region  hogVarRegion  contained  oneline  start="." contains=hogIPaddr,hogEnvvar,hogNumber,hogString,hogFileName end="$"he=s-1 keepend skipwhite
-
-" config command
-syn keyword hogConfigStart config skipwhite nextgroup=hogConfigType
-syn match hogConfigType contained "\<classification\>" nextgroup=hogConfigTypeRegion skipwhite
-syn region  hogConfigTypeRegion contained oneline	start=":"ms=s+1 end="$" contains=hogNumber,hogText keepend skipwhite
-
-
-" include command
-syn keyword hogIncStart	include  skipwhite nextgroup=hogIncRegion
-syn region  hogIncRegion  contained  oneline  start="\>" contains=hogFileName,hogEnvvar end="$" keepend
-
-" preprocessor command
-" http_decode, minfrag, portscan[-ignorehosts]
-syn keyword hogPPrStart	preprocessor  skipwhite nextgroup=hogPPr
-syn match hogPPr   contained  "\<spade\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<spade-homenet\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<spade-threshlearn\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<spade-adapt\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<spade-adapt2\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<spade-adapt3\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<spade-survey\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<defrag\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<telnet_decode\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<rpc_decode\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<bo\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<stream\>" nextgroup=hogStreamRegion skipwhite
-syn match hogPPr   contained  "\<stream2\>" nextgroup=hogStreamRegion skipwhite
-syn match hogPPr   contained  "\<stream3\>" nextgroup=hogStreamRegion skipwhite
-syn match hogPPr   contained  "\<http_decode\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr   contained  "\<minfrag\>" nextgroup=hogPPrRegion skipwhite
-syn match hogPPr     contained "\<portscan[-ignorehosts]*\>" nextgroup=hogPPrRegion skipwhite
-syn region  hogPPrRegion contained oneline	start="$" end="$" keepend
-syn region  hogPPrRegion contained oneline	start=":" end="$" contains=hogNumber,hogIPaddr,hogEnvvar,hogFileName keepend
-syn keyword hogStreamArgs contained timeout ports maxbytes
-syn region hogStreamRegion contained oneline start=":" end="$" contains=hogStreamArgs,hogNumber
-
-" output command
-syn keyword hogOutStart	output  nextgroup=hogOut skipwhite
-"
-" alert_syslog
-syn match hogOut   contained  "\<alert_syslog\>" nextgroup=hogSyslogRegion skipwhite
-syn region hogSyslogRegion  contained start=":" end="$" contains=hogSysFac,hogSysPri,hogSysOpt,hogEnvvar oneline skipwhite keepend
-"
-" alert_fast (full,smb,unixsock, and tcpdump)
-syn match hogOut   contained  "\<alert_fast\|alert_full\|alert_smb\|alert_unixsock\|log_tcpdump\>" nextgroup=hogLogFileRegion skipwhite
-syn region hogLogFileRegion  contained start=":" end="$" contains=hogFileName,hogEnvvar oneline skipwhite keepend
-"
-" database
-syn match hogOut  contained "\<database\>" nextgroup=hogDBTypes skipwhite
-syn region hogDBTypes contained start=":" end="," contains=hogDBType,hogEnvvar nextgroup=hogDBSRVs skipwhite
-syn region hogDBSRVs contained start="\s\+" end="," contains=hogDBSRV nextgroup=hogDBParams skipwhite
-syn region hogDBParams contained start="." end="="me=e-1 contains=hogDBParam  nextgroup=hogDBValues
-syn region hogDBValues contained start="." end="\>" contains=hogNumber,hogEnvvar,hogAscii nextgroup=hogDBParams oneline skipwhite
-syn match hogAscii contained "\<\a\+"
-"
-" log_tcpdump
-syn match hogOut   contained  "\<log_tcpdump\>" nextgroup=hogLogRegion skipwhite
-syn region  hogLogRegion  oneline	start=":" skipwhite end="$" contains=hogEnvvar,hogFileName keepend
-"
-" xml
-syn keyword hogXMLTrans contained http https tcp iap
-syn match hogOut     contained "\<xml\>" nextgroup=hogXMLRegion skipwhite
-syn region hogXMLRegion contained start=":" end="," contains=hogXMLArg,hogEnvvar nextgroup=hogXMLParams skipwhite
-"syn region hogXMLParams contained start="." end="="me=e-1 contains=hogXMLProto nextgroup=hogXMLProtos
-"syn region hogXMLProtos contained start="." end="\>" contains=hogXMLTrans nextgroup=hogXMLParams
-syn region hogXMLParams contained start="." end="="me=e-1 contains=hogXMLParam  nextgroup=hogXMLValue
-syn region hogXMLValue contained start="." end="\>" contains=hogNumber,hogIPaddr,hogEnvvar,hogAscii,hogFileName nextgroup=hogXMLParams oneline skipwhite keepend
-"
-" Filename
-syn match   hogFileName  contained "[-./[:alnum:]_~]\+"
-syn match   hogFileName  contained "[-./[:alnum:]_~]\+"
-" IP address
-syn match   hogIPaddr   "\<\d\{1,3}\.\d\{1,3}\.\d\{1,3}\.\d\{1,3}\>"
-syn match   hogIPaddr   "\<\d\{1,3}\.\d\{1,3}\.\d\{1,3}\.\d\{1,3}/\d\{1,2}\>"
-
-syn keyword hogProto	tcp TCP ICMP icmp udp UDP
-
-" hog alert address port pairs
-" hog IPaddresses
-syn match   hogIPaddrAndPort contained	"\<\d\{1,3}\.\d\{1,3}\.\d\{1,3}\.\d\{1,3}\>" skipwhite			nextgroup=hogPort
-syn match   hogIPaddrAndPort contained	"\<\d\{1,3}\.\d\{1,3}\.\d\{1,3}\.\d\{1,3}/\d\{1,2}\>" skipwhite		nextgroup=hogPort
-syn match   hogIPaddrAndPort contained "\<any\>" skipwhite nextgroup=hogPort
-syn match hogIPaddrAndPort contained	 "\$\I\i*" nextgroup=hogPort skipwhite
-syn match hogIPaddrAndPort contained     "\${\I\i*}" nextgroup=hogPort skipwhite
-"syn match   hogPort contained "[\!]\=[\:]\=\d\+L\=\>" skipwhite
-syn match   hogPort contained "[\:]\=\d\+\>"
-syn match   hogPort contained "[\!]\=\<any\>" skipwhite
-syn match   hogPort contained "[\!]\=\d\+L\=:\d\+L\=\>" skipwhite
-
-" action commands
-syn keyword hog7Functions activate skipwhite nextgroup=hogActRegion
-syn keyword hog7Functions dynamic skipwhite nextgroup=hogActRegion
-syn keyword hogActStart alert skipwhite nextgroup=hogActRegion
-syn keyword hogActStart log skipwhite nextgroup=hogActRegion
-syn keyword hogActStart pass skipwhite nextgroup=hogActRegion
-
-syn region hogActRegion contained oneline start="tcp\|TCP\|udp\|UDP\|icmp\|ICMP" end="\s\+"me=s-1 nextgroup=hogActSource oneline keepend skipwhite
-syn region hogActSource contained oneline contains=hogIPaddrAndPort start="\s\+"ms=e+1 end="->\|<>"me=e-2  oneline keepend skipwhite nextgroup=hogActDest
-syn region hogActDest contained oneline contains=hogIPaddrAndPort start="->\|<>" end="$"  oneline keepend
-syn region hogActDest contained oneline contains=hogIPaddrAndPort start="->\|<>" end="("me=e-1  oneline keepend skipwhite nextgroup=hogRules
-
-
-" ====================
-if version >= 508 || !exists("did_hog_syn_inits")
-  if version < 508
-    let did_hog_syn_inits = 1
-    command -nargs=+ HiLink hi link <args>
-  else
-    command -nargs=+ HiLink hi def link <args>
-  endif
-" The default methods for highlighting.  Can be overridden later
-  HiLink hogComment		Comment
-  HiLink hogLineComment		Comment
-  HiLink hogAscii		Constant
-  HiLink hogCommentString	Constant
-  HiLink hogFileName		Constant
-  HiLink hogIPaddr		Constant
-  HiLink hogNotPatSep		Constant
-  HiLink hogNumber		Constant
-  HiLink hogText		Constant
-  HiLink hogString		Constant
-  HiLink hogSysFac		Constant
-  HiLink hogSysOpt		Constant
-  HiLink hogSysPri		Constant
-"  HiLink hogAStrGrp		Error
-  HiLink hogJunk		Error
-  HiLink hogEnvvar		Identifier
-  HiLink hogIPaddrAndPort	Identifier
-  HiLink hogVarIdent		Identifier
-  HiLink hogATAGOpt		PreProc
-  HiLink hogAIPOptVal		PreProc
-  HiLink hogARespOpt		PreProc
-  HiLink hogAReactOpt		PreProc
-  HiLink hogAFlagOpt		PreProc
-  HiLink hogAFragOpt		PreProc
-  HiLink hogCommentTitle	PreProc
-  HiLink hogDBType		PreProc
-  HiLink hogDBSRV		PreProc
-  HiLink hogPort		PreProc
-  HiLink hogARefGrps		PreProc
-  HiLink hogSessionVal		PreProc
-  HiLink hogXMLArg		PreProc
-  HiLink hogARPCOpt		PreProc
-  HiLink hogPatSep		Special
-  HiLink hog7Functions		Statement
-  HiLink hogActStart		Statement
-  HiLink hogIncStart		Statement
-  HiLink hogConfigStart		Statement
-  HiLink hogOutStart		Statement
-  HiLink hogPPrStart		Statement
-  HiLink hogVarStart		Statement
-  HiLink hogRTypeStart		Statement
-  HiLink hogTodo		Todo
-  HiLink hogRuleType		Type
-  HiLink hogAFOpt		Type
-  HiLink hogANoVal		Type
-  HiLink hogAStrOpt		Type
-  HiLink hogANOpt		Type
-  HiLink hogAOpt		Type
-  HiLink hogDBParam		Type
-  HiLink hogStreamArgs		Type
-  HiLink hogOut			Type
-  HiLink hogPPr			Type
-  HiLink  hogConfigType		Type
-  HiLink hogActRegion		Type
-  HiLink hogProto		Type
-  HiLink hogXMLParam		Type
-  HiLink resp			Todo
-  HiLink cLabel			Label
-  delcommand HiLink
+if !exists("hog_minlines")
+    let hog_minlines = 100
 endif
+exec "syn sync minlines=" . hog_minlines
+
+hi link HogRuleType           Statement
+hi link HogRuleTypeName       Type
+hi link HogRuleTypeType       Keyword
+
+hi link HogPreproc            Statement
+hi link HogConfig             Statement
+hi link HogOutput             Statement
+hi link HogConfigName         Type
+
+"hi link HogEvFilter
+hi link HogEvFilterKeyword    Statement
+hi link HogSuppressKeyword    Statement
+hi link HogEvFilterTypes      Constant
+hi link HogEvFilterTrack      Constant
+
+hi link HogAttribute          Statement
+hi link HogAttributeFile      String
+hi link HogAttributeType      Statement
+
+hi link HogInclude            Statement
+hi link HogIncludeFile        String
+
+hi link HogDylib              Statement
+hi link HogDylibType          Statement
+hi link HogDylibFile          String
+
+" Variables
+" var
+hi link HogVar                Identifier
+hi link HogVarType            Keyword
+hi link HogVarSet             Identifier
+hi link HogVarValue           String
+" ipvar
+hi link HogIPVarType          Keyword
+hi link HogIPVarSet           Identifier
+" portvar
+hi link HogPortVarType         Keyword
+hi link HogPortVarSet          Identifier
+hi link HogPort                Constant
+
+hi link HogTodo               Todo
+hi link HogComment            Comment
+hi link HogString             String
+hi link HogHexEsc             PreProc
+hi link HogNumber             Number
+hi link HogSpecial            Constant
+hi link HogSpecialAny         Constant
+hi link HogIPAddr             Constant
+hi link HogIPCidr             Constant
+hi link HogOpNot              Operator
+hi link HogOpRange            Operator
+
+hi link HogRuleAction         Statement
+hi link HogRuleProto          Identifier
+hi link HogRuleDir            Operator
+hi link HogRuleOption         Keyword
+hi link HogRuleChars           String 
+
+hi link HogFileType    HogRuleAction
+hi link HogFileTypeOpt HogRuleOption
+hi link NotASemiColn     HogRuleChars
 
 let b:current_syntax = "hog"
-
-" hog: cpw=59

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -3,7 +3,7 @@
 " Maintainer:	SungHyun Nam <goweol@gmail.com>
 " Previous Maintainer:	Gautam H. Mudunuri <gmudunur@informatica.com>
 " Version Info:
-" Last Change:	2008 Sep 17
+" Last Change:	2015 Nov 24
 
 " Additional highlighting by Johannes Tanzler <johannes.tanzler@aon.at>:
 "	* manSubHeading
@@ -27,8 +27,8 @@ endif
 syn case ignore
 syn match  manReference       "\f\+([1-9][a-z]\=)"
 syn match  manTitle	      "^\f\+([0-9]\+[a-z]\=).*"
-syn match  manSectionHeading  "^[a-z][a-z ]*[a-z]$"
-syn match  manSubHeading      "^\s\{3\}[a-z][a-z ]*[a-z]$"
+syn match  manSectionHeading  "^[a-z][a-z -]*[a-z]$"
+syn match  manSubHeading      "^\s\{3\}[a-z][a-z -]*[a-z]$"
 syn match  manOptionDesc      "^\s*[+-][a-z0-9]\S*"
 syn match  manLongOptionDesc  "^\s*--[a-z0-9-]\S*"
 " syn match  manHistory		"^[a-z].*last change.*$"

--- a/runtime/syntax/netrw.vim
+++ b/runtime/syntax/netrw.vim
@@ -19,7 +19,6 @@ syn cluster NetrwTreeGroup	contains=netrwDir,netrwSymLink,netrwExe
 syn match  netrwPlain		"\(\S\+ \)*\S\+"					contains=netrwLink,@NoSpell
 syn match  netrwSpecial		"\%(\S\+ \)*\S\+[*|=]\ze\%(\s\{2,}\|$\)"		contains=netrwClassify,@NoSpell
 syn match  netrwDir		"\.\{1,2}/"						contains=netrwClassify,@NoSpell
-"syn match  netrwDir		"\%(\S\+ \)*\S\+/"					contains=netrwClassify,@NoSpell
 syn match  netrwDir		"\%(\S\+ \)*\S\+/\ze\%(\s\{2,}\|$\)"			contains=netrwClassify,@NoSpell
 syn match  netrwSizeDate	"\<\d\+\s\d\{1,2}/\d\{1,2}/\d\{4}\s"	skipwhite	contains=netrwDateSep,@NoSpell	nextgroup=netrwTime
 syn match  netrwSymLink		"\%(\S\+ \)*\S\+@\ze\%(\s\{2,}\|$\)"  			contains=netrwClassify,@NoSpell

--- a/runtime/syntax/objc.vim
+++ b/runtime/syntax/objc.vim
@@ -1,8 +1,7 @@
 " Vim syntax file
 " Language:     Objective-C
-" Maintainer:   Kazunobu Kuriyama <kazunobu.kuriyama@nifty.com>
-" Last Change:  2013 Jun 13
-" Remark:       Modern Objective-C Edition
+" Maintainer:   Kazunobu Kuriyama <kazunobu.kuriyama@gmail.com>
+" Last Change:  2015 Dec 14
 
 """ Preparation for loading ObjC stuff
 if exists("b:current_syntax")
@@ -25,14 +24,14 @@ syn keyword objcUsefulTerm nil Nil NO YES
 
 " Preprocessor Directives
 syn region objcImported display contained start=+"+ skip=+\\\\\|\\"+ end=+"+
-syn match objcImported display contained "<[^>]*>"
+syn match objcImported display contained "\(<\h[-a-zA-Z0-9_/]*\.h>\|<[a-z0-9]\+>\)"
 syn match objcImport display "^\s*\(%:\|#\)\s*import\>\s*["<]" contains=objcImported
 
 " ObjC Compiler Directives
 syn match objcObjDef display /@interface\>\|@implementation\>\|@end\>\|@class\>/
 syn match objcProtocol display /@protocol\>\|@optional\>\|@required\>/
 syn match objcProperty display /@property\>\|@synthesize\>\|@dynamic\>/
-syn match objcIvarScope display /@private\>\|@protected\>\|@public\>/
+syn match objcIvarScope display /@private\>\|@protected\>\|@public\>\|@package\>/
 syn match objcInternalRep display /@selector\>\|@encode\>/
 syn match objcException display /@try\>\|@throw\>\|@catch\|@finally\>/
 syn match objcThread display /@synchronized\>/
@@ -56,6 +55,17 @@ syn keyword objcTollFreeBridgeQualifier __bridge __bridge_retained __bridge_tran
 " ObjC Type Qualifiers for Remote Messaging
 syn match objcRemoteMessagingQualifier display contained /\((\s*oneway\s\+\|(\s*in\s\+\|(\s*out\s\+\|(\s*inout\s\+\|(\s*bycopy\s\+\(in\(out\)\?\|out\)\?\|(\s*byref\s\+\(in\(out\)\?\|out\)\?\)/hs=s+1
 
+" ObjC Storage Classes
+syn keyword objcStorageClass _Nullable _Nonnull _Null_unspecified
+syn keyword objcStorageClass __nullable __nonnull __null_unspecified
+syn keyword objcStorageClass nullable nonnull null_unspecified
+
+" ObjC type specifier
+syn keyword objcTypeSpecifier __kindof __covariant
+
+" ObjC Type Infomation Parameters
+syn keyword objcTypeInfoParams ObjectType KeyType
+
 " shorthand
 syn cluster objcTypeQualifier contains=objcBlocksQualifier,objcObjectLifetimeQualifier,objcTollFreeBridgeQualifier,objcRemoteMessagingQualifier
 
@@ -75,17 +85,24 @@ syn keyword objcDeclPropAccessorType readonly readwrite contained
 syn keyword objcDeclPropAssignSemantics assign retain copy contained
 syn keyword objcDeclPropAtomicity nonatomic contained
 syn keyword objcDeclPropARC strong weak contained
-syn region objcDeclProp display transparent keepend start=/@property\s*(/ end=/)/ contains=objcProperty,objcDeclPropAccessorName,objcDeclPropAccessorType,objcDeclPropAssignSemantics,objcDeclPropAtomicity,objcDeclPropARC
+syn match objcDeclPropNullable /\((\|\s\)nullable\(,\|)\)/ms=s+1,hs=s+1,me=e-1,he=e-1 contained
+syn match objcDeclPropNonnull /\((\|\s\)nonnull\(,\|)\)/ms=s+1,hs=s+1,me=e-1,he=e-1 contained
+syn match objcDeclPropNullUnspecified /\((\|\s\)null_unspecified\(,\|)\)/ms=s+1,hs=s+1,me=e-1,he=e-1 contained
+syn keyword objcDeclProcNullResettable null_resettable contained
+syn region objcDeclProp display transparent keepend start=/@property\s*(/ end=/)/ contains=objcProperty,objcDeclPropAccessorName,objcDeclPropAccessorType,objcDeclPropAssignSemantics,objcDeclPropAtomicity,objcDeclPropARC,objcDeclPropNullable,objcDeclPropNonnull,objcDeclPropNullUnspecified,objcDeclProcNullResettable
 
 " To distinguish colons in methods and dictionaries from those in C's labels.
 syn match objcColon display /^\s*\h\w*\s*\:\(\s\|.\)/me=e-1,he=e-1
 
 " To distinguish a protocol list from system header files
-syn match objcProtocolList display /<\h\w*\(\s*,\s*\h\w*\)*>/ contains=objcPrincipalType,cType,Type
+syn match objcProtocolList display /<\h\w*\(\s*,\s*\h\w*\)*>/ contains=objcPrincipalType,cType,Type,objcType,objcTypeInfoParams
+
+" Type info for collection classes
+syn match objcTypeInfo display /<\h\w*\s*<\(\h\w*\s*\**\|\h\w*\)>>/ contains=objcPrincipalType,cType,Type,objcType,objcTypeInfoParams
 
 " shorthand
 syn cluster objcCEntities contains=cType,cStructure,cStorageClass,cString,cCharacter,cSpecialCharacter,cNumbers,cConstant,cOperator,cComment,cCommentL,cStatement,cLabel,cConditional,cRepeat
-syn cluster objcObjCEntities contains=objcHiddenArgument,objcPrincipalType,objcString,objcUsefulTerm,objcProtocol,objcInternalRep,objcException,objcThread,objcPool,objcModuleImport,@objcTypeQualifier,objcLiteralSyntaxNumber,objcLiteralSyntaxOp,objcLiteralSyntaxChar,objcLiteralSyntaxSpecialChar,objcProtocolList,objcColon,objcFastEnumKeyword,objcType,objcClass,objcMacro,objcEnum,objcEnumValue,objcExceptionValue,objcNotificationValue,objcConstVar,objcPreProcMacro
+syn cluster objcObjCEntities contains=objcHiddenArgument,objcPrincipalType,objcString,objcUsefulTerm,objcProtocol,objcInternalRep,objcException,objcThread,objcPool,objcModuleImport,@objcTypeQualifier,objcLiteralSyntaxNumber,objcLiteralSyntaxOp,objcLiteralSyntaxChar,objcLiteralSyntaxSpecialChar,objcProtocolList,objcColon,objcFastEnumKeyword,objcType,objcClass,objcMacro,objcEnum,objcEnumValue,objcExceptionValue,objcNotificationValue,objcConstVar,objcPreProcMacro,objcTypeInfo
 
 " Objective-C Message Expressions
 syn region objcMethodCall start=/\[/ end=/\]/ contains=objcMethodCall,objcBlocks,@objcObjCEntities,@objcCEntities
@@ -114,13 +131,17 @@ syn keyword objcEnum NSSortOptions
 syn keyword objcEnumValue NSSortConcurrent NSSortStable
 syn keyword objcEnumValue NSNotFound
 syn keyword objcMacro NSIntegerMax NSIntegerMin NSUIntegerMax
+syn keyword objcMacro NS_INLINE NS_BLOCKS_AVAILABLE NS_NONATOMIC_IOSONLY NS_FORMAT_FUNCTION NS_FORMAT_ARGUMENT NS_RETURNS_RETAINED NS_RETURNS_NOT_RETAINED NS_RETURNS_INNER_POINTER NS_AUTOMATED_REFCOUNT_UNAVAILABLE NS_AUTOMATED_REFCOUNT_WEAK_UNAVAILABLE NS_REQUIRES_PROPERTY_DEFINITIONS NS_REPLACES_RECEIVER NS_RELEASES_ARGUMENT NS_VALID_UNTIL_END_OF_SCOPE NS_ROOT_CLASS NS_REQUIRES_SUPER NS_PROTOCOL_REQUIRES_EXPLICIT_IMPLEMENTATION NS_DESIGNATED_INITIALIZER NS_REQUIRES_NIL_TERMINATION
+syn keyword objcEnum NSQualityOfService
+syn keyword objcEnumValue NSQualityOfServiceUserInteractive NSQualityOfServiceUserInitiated NSQualityOfServiceUtility NSQualityOfServiceBackground NSQualityOfServiceDefault
 " NSRange.h
 syn keyword objcType NSRange NSRangePointer
 " NSGeometry.h
-syn keyword objcType NSPoint NSPointPointer NSPointArray NSSize NSSizePointer NSSizeArray NSRect NSRectPointer NSRectArray
+syn keyword objcType NSPoint NSPointPointer NSPointArray NSSize NSSizePointer NSSizeArray NSRect NSRectPointer NSRectArray NSEdgeInsets
 syn keyword objcEnum NSRectEdge
 syn keyword objcEnumValue NSMinXEdge NSMinYEdge NSMaxXEdge NSMaxYEdge
-syn keyword objcConstVar NSZeroPoint NSZeroSize NSZeroRect
+syn keyword objcEnumValue NSRectEdgeMinX NSRectEdgeMinY NSRectEdgeMaxX NSRectEdgeMaxY
+syn keyword objcConstVar NSZeroPoint NSZeroSize NSZeroRect NSEdgeInsetsZero
 syn keyword cType CGFloat CGPoint CGSize CGRect
 syn keyword objcEnum NSAlignmentOptions
 syn keyword objcEnumValue NSAlignMinXInward NSAlignMinYInward NSAlignMaxXInward NSAlignMaxYInward NSAlignWidthInward NSAlignHeightInward NSAlignMinXOutward NSAlignMinYOutward NSAlignMaxXOutward NSAlignMaxYOutward NSAlignWidthOutward NSAlignHeightOutward NSAlignMinXNearest NSAlignMinYNearest NSAlignMaxXNearest NSAlignMaxYNearest NSAlignWidthNearest NSAlignHeightNearest NSAlignRectFlipped NSAlignAllEdgesInward NSAlignAllEdgesOutward NSAlignAllEdgesNearest
@@ -130,6 +151,7 @@ syn keyword objcEnum  NSRoundingMode
 syn keyword objcEnumValue NSRoundPlain NSRoundDown NSRoundUp NSRoundBankers
 syn keyword objcEnum NSCalculationError
 syn keyword objcEnumValue NSCalculationNoError NSCalculationLossOfPrecision NSCalculationUnderflow NSCalculationOverflow NSCalculationDivideByZero
+syn keyword objcConstVar NSDecimalMaxSize NSDecimalNoScale
 " NSDate.h
 syn match objcClass /NSDate\s*\*/me=s+6,he=s+6
 syn keyword objcType NSTimeInterval
@@ -137,11 +159,13 @@ syn keyword objcNotificationValue NSSystemClockDidChangeNotification
 syn keyword objcMacro NSTimeIntervalSince1970
 " NSZone.h
 syn match objcType /NSZone\s*\*/me=s+6,he=s+6
+syn keyword objcEnumValue NSScannedOption NSCollectorDisabledOption
 " NSError.h
 syn match objcClass /NSError\s*\*/me=s+7,he=s+7
 syn keyword objcConstVar NSCocoaErrorDomain NSPOSIXErrorDomain NSOSStatusErrorDomain NSMachErrorDomain NSUnderlyingErrorKey NSLocalizedDescriptionKey NSLocalizedFailureReasonErrorKey NSLocalizedRecoverySuggestionErrorKey NSLocalizedRecoveryOptionsErrorKey NSRecoveryAttempterErrorKey NSHelpAnchorErrorKey NSStringEncodingErrorKey NSURLErrorKey NSFilePathErrorKey
 " NSException.h
 syn match objcClass /NSException\s*\*/me=s+11,he=s+11
+syn match objcClass /NSAssertionHandler\s*\*/me=s+18,he=s+18
 syn keyword objcType NSUncaughtExceptionHandler
 syn keyword objcConstVar NSGenericException NSRangeException NSInvalidArgumentException NSInternalInconsistencyException NSMallocException NSObjectInaccessibleException NSObjectNotAvailableException NSDestinationInvalidException NSPortTimeoutException NSInvalidSendPortException NSInvalidReceivePortException NSPortSendException NSPortReceiveException NSOldStyleException
 " NSNotification.h
@@ -153,6 +177,8 @@ syn keyword objcConstVar NSLocalNotificationCenterType
 syn keyword objcEnum NSNotificationSuspensionBehavior
 syn keyword objcEnumValue NSNotificationSuspensionBehaviorDrop NSNotificationSuspensionBehaviorCoalesce NSNotificationSuspensionBehaviorHold NSNotificationSuspensionBehaviorHold NSNotificationSuspensionBehaviorDeliverImmediately
 syn keyword objcEnumValue NSNotificationDeliverImmediately NSNotificationPostToAllSessions
+syn keyword objcEnum NSDistributedNotificationOptions
+syn keyword objcEnumValue NSDistributedNotificationDeliverImmediately NSDistributedNotificationPostToAllSessions
 " NSNotificationQueue.h
 syn match objcClass /NSNotificationQueue\s*\*/me=s+19,he=s+19
 syn keyword objcEnum NSPostingStyle
@@ -161,11 +187,15 @@ syn keyword objcEnum NSNotificationCoalescing
 syn keyword objcEnumValue NSNotificationNoCoalescing NSNotificationCoalescingOnName NSNotificationCoalescingOnSender
 " NSEnumerator.h
 syn match objcClass /NSEnumerator\s*\*/me=s+12,he=s+12
+syn match objcClass /NSEnumerator<.*>\s*\*/me=s+12,he=s+12 contains=objcTypeInfoParams
+syn keyword objcType NSFastEnumerationState
 " NSIndexSet.h
 syn match objcClass /NSIndexSet\s*\*/me=s+10,he=s+10
 syn match objcClass /NSMutableIndexSet\s*\*/me=s+17,he=s+17
 " NSCharecterSet.h
 syn match objcClass /NSCharacterSet\s*\*/me=s+14,he=s+14
+syn match objcClass /NSMutableCharacterSet\s*\*/me=s+21,he=s+21
+syn keyword objcConstVar NSOpenStepUnicodeReservedBase
 " NSURL.h
 syn match objcClass /NSURL\s*\*/me=s+5,he=s+5
 syn keyword objcEnum NSURLBookmarkCreationOptions
@@ -174,11 +204,11 @@ syn keyword objcEnum NSURLBookmarkResolutionOptions
 syn keyword objcEnumValue NSURLBookmarkResolutionWithoutUI NSURLBookmarkResolutionWithoutMounting NSURLBookmarkResolutionWithSecurityScope
 syn keyword objcType NSURLBookmarkFileCreationOptions
 syn keyword objcConstVar NSURLFileScheme NSURLKeysOfUnsetValuesKey
-syn keyword objcConstVar NSURLNameKey NSURLLocalizedNameKey NSURLIsRegularFileKey NSURLIsDirectoryKey NSURLIsSymbolicLinkKey NSURLIsVolumeKey NSURLIsPackageKey NSURLIsSystemImmutableKey NSURLIsUserImmutableKey NSURLIsHiddenKey NSURLHasHiddenExtensionKey NSURLCreationDateKey NSURLContentAccessDateKey NSURLContentModificationDateKey NSURLAttributeModificationDateKey NSURLLinkCountKey NSURLParentDirectoryURLKey NSURLVolumeURLKey NSURLTypeIdentifierKey NSURLLocalizedTypeDescriptionKey NSURLLabelNumberKey NSURLLabelColorKey NSURLLocalizedLabelKey NSURLEffectiveIconKey NSURLCustomIconKey NSURLFileResourceIdentifierKey NSURLVolumeIdentifierKey NSURLPreferredIOBlockSizeKey NSURLIsReadableKey NSURLIsWritableKey NSURLIsExecutableKey NSURLFileSecurityKey NSURLIsExcludedFromBackupKey NSURLPathKey NSURLIsMountTriggerKey NSURLFileResourceTypeKey
-syn keyword objcConstVar NSURLFileResourceTypeNamedPipe NSURLFileResourceTypeCharacterSpecial NSURLFileResourceTypeDirectory NSURLFileResourceTypeBlockSpecial NSURLFileResourceTypeRegular NSURLFileResourceTypeSymbolicLink NSURLFileResourceTypeSocket NSURLFileResourceTypeUnknown
-syn keyword objcConstVar NSURLFileSizeKey NSURLFileAllocatedSizeKey NSURLTotalFileSizeKey NSURLTotalFileAllocatedSizeKey NSURLIsAliasFileKey
+syn keyword objcConstVar NSURLNameKey NSURLLocalizedNameKey NSURLIsRegularFileKey NSURLIsDirectoryKey NSURLIsSymbolicLinkKey NSURLIsVolumeKey NSURLIsPackageKey NSURLIsApplicationKey NSURLApplicationIsScriptableKey NSURLIsSystemImmutableKey NSURLIsUserImmutableKey NSURLIsHiddenKey NSURLHasHiddenExtensionKey NSURLCreationDateKey NSURLContentAccessDateKey NSURLContentModificationDateKey NSURLAttributeModificationDateKey NSURLLinkCountKey NSURLParentDirectoryURLKey NSURLVolumeURLKey NSURLTypeIdentifierKey NSURLLocalizedTypeDescriptionKey NSURLLabelNumberKey NSURLLabelColorKey NSURLLocalizedLabelKey NSURLEffectiveIconKey NSURLCustomIconKey NSURLFileResourceIdentifierKey NSURLVolumeIdentifierKey NSURLPreferredIOBlockSizeKey NSURLIsReadableKey NSURLIsWritableKey NSURLIsExecutableKey NSURLFileSecurityKey NSURLIsExcludedFromBackupKey NSURLTagNamesKey NSURLPathKey NSURLIsMountTriggerKey NSURLGenerationIdentifierKey NSURLDocumentIdentifierKey NSURLAddedToDirectoryDateKey NSURLQuarantinePropertiesKey NSURLFileResourceTypeKey
+syn keyword objcConstVar NSURLFileResourceTypeNamedPipe NSURLFileResourceTypeCharacterSpecial NSURLFileResourceTypeDirectory NSURLFileResourceTypeBlockSpecial NSURLFileResourceTypeRegular NSURLFileResourceTypeSymbolicLink NSURLFileResourceTypeSocket NSURLFileResourceTypeUnknown NSURLThumbnailDictionaryKey NSURLThumbnailKey NSThumbnail1024x1024SizeKey
+syn keyword objcConstVar NSURLFileSizeKey NSURLFileAllocatedSizeKey NSURLTotalFileSizeKey NSURLTotalFileAllocatedSizeKey NSURLIsAliasFileKey NSURLFileProtectionKey NSURLFileProtectionNone NSURLFileProtectionComplete NSURLFileProtectionCompleteUnlessOpen NSURLFileProtectionCompleteUntilFirstUserAuthentication
 syn keyword objcConstVar NSURLVolumeLocalizedFormatDescriptionKey NSURLVolumeTotalCapacityKey NSURLVolumeAvailableCapacityKey NSURLVolumeResourceCountKey NSURLVolumeSupportsPersistentIDsKey NSURLVolumeSupportsSymbolicLinksKey NSURLVolumeSupportsHardLinksKey NSURLVolumeSupportsJournalingKey NSURLVolumeIsJournalingKey NSURLVolumeSupportsSparseFilesKey NSURLVolumeSupportsZeroRunsKey NSURLVolumeSupportsCaseSensitiveNamesKey NSURLVolumeSupportsCasePreservedNamesKey NSURLVolumeSupportsRootDirectoryDatesKey NSURLVolumeSupportsVolumeSizesKey NSURLVolumeSupportsRenamingKey NSURLVolumeSupportsAdvisoryFileLockingKey NSURLVolumeSupportsExtendedSecurityKey NSURLVolumeIsBrowsableKey NSURLVolumeMaximumFileSizeKey NSURLVolumeIsEjectableKey NSURLVolumeIsRemovableKey NSURLVolumeIsInternalKey NSURLVolumeIsAutomountedKey NSURLVolumeIsLocalKey NSURLVolumeIsReadOnlyKey NSURLVolumeCreationDateKey NSURLVolumeURLForRemountingKey NSURLVolumeUUIDStringKey NSURLVolumeNameKey NSURLVolumeLocalizedNameKey
-syn keyword objcConstVar NSURLIsUbiquitousItemKey NSURLUbiquitousItemHasUnresolvedConflictsKey NSURLUbiquitousItemIsDownloadedKey NSURLUbiquitousItemIsDownloadingKey NSURLUbiquitousItemIsUploadedKey NSURLUbiquitousItemIsUploadingKey NSURLUbiquitousItemPercentDownloadedKey NSURLUbiquitousItemPercentUploadedKey
+syn keyword objcConstVar NSURLIsUbiquitousItemKey NSURLUbiquitousItemHasUnresolvedConflictsKey NSURLUbiquitousItemIsDownloadedKey NSURLUbiquitousItemIsDownloadingKey NSURLUbiquitousItemIsUploadedKey NSURLUbiquitousItemIsUploadingKey NSURLUbiquitousItemPercentDownloadedKey NSURLUbiquitousItemPercentUploadedKey NSURLUbiquitousItemDownloadingStatusKey NSURLUbiquitousItemDownloadingErrorKey NSURLUbiquitousItemUploadingErrorKey NSURLUbiquitousItemDownloadRequestedKey NSURLUbiquitousItemContainerDisplayNameKey NSURLUbiquitousItemDownloadingStatusNotDownloaded NSURLUbiquitousItemDownloadingStatusDownloaded NSURLUbiquitousItemDownloadingStatusCurrent
 """"""""""""
 " NSString.h
 syn match objcClass /NSString\s*\*/me=s+8,he=s+8
@@ -189,11 +219,14 @@ syn keyword objcMacro NSMaximumStringLength
 syn keyword objcEnum NSStringCompareOptions
 syn keyword objcEnumValue NSCaseInsensitiveSearch NSLiteralSearch NSBackwardsSearch NSAnchoredSearch NSNumericSearch NSDiacriticInsensitiveSearch NSWidthInsensitiveSearch NSForcedOrderingSearch NSRegularExpressionSearch 
 syn keyword objcEnum NSStringEncoding
+syn keyword objcEnumValue NSProprietaryStringEncoding
 syn keyword objcEnumValue NSASCIIStringEncoding NSNEXTSTEPStringEncoding NSJapaneseEUCStringEncoding NSUTF8StringEncoding NSISOLatin1StringEncoding NSSymbolStringEncoding NSNonLossyASCIIStringEncoding NSShiftJISStringEncoding NSISOLatin2StringEncoding NSUnicodeStringEncoding NSWindowsCP1251StringEncoding NSWindowsCP1252StringEncoding NSWindowsCP1253StringEncoding NSWindowsCP1254StringEncoding NSWindowsCP1250StringEncoding NSISO2022JPStringEncoding NSMacOSRomanStringEncoding NSUTF16StringEncoding NSUTF16BigEndianStringEncoding NSUTF16LittleEndianStringEncoding NSUTF32StringEncoding NSUTF32BigEndianStringEncoding NSUTF32LittleEndianStringEncoding
 syn keyword objcEnum NSStringEncodingConversionOptions
 syn keyword objcEnumValue NSStringEncodingConversionAllowLossy NSStringEncodingConversionExternalRepresentation
 syn keyword objcEnum NSStringEnumerationOptions
 syn keyword objcEnumValue NSStringEnumerationByLines NSStringEnumerationByParagraphs NSStringEnumerationByComposedCharacterSequences NSStringEnumerationByWords NSStringEnumerationBySentences NSStringEnumerationReverse NSStringEnumerationSubstringNotRequired NSStringEnumerationLocalized
+syn keyword objcConstVar NSStringTransformLatinToKatakana NSStringTransformLatinToHiragana NSStringTransformLatinToHangul NSStringTransformLatinToArabic NSStringTransformLatinToHebrew NSStringTransformLatinToThai NSStringTransformLatinToCyrillic NSStringTransformLatinToGreek NSStringTransformToLatin NSStringTransformMandarinToLatin NSStringTransformHiraganaToKatakana NSStringTransformFullwidthToHalfwidth NSStringTransformToXMLHex NSStringTransformToUnicodeName NSStringTransformStripCombiningMarks NSStringTransformStripDiacritics
+syn keyword objcConstVar NSStringEncodingDetectionSuggestedEncodingsKey NSStringEncodingDetectionDisallowedEncodingsKey NSStringEncodingDetectionUseOnlySuggestedEncodingsKey NSStringEncodingDetectionAllowLossyKey NSStringEncodingDetectionFromWindowsKey NSStringEncodingDetectionLossySubstitutionKey NSStringEncodingDetectionLikelyLanguageKey
 " NSAttributedString.h
 syn match objcClass /NSAttributedString\s*\*/me=s+18,he=s+18
 syn match objcClass /NSMutableAttributedString\s*\*/me=s+25,he=s+25
@@ -215,21 +248,32 @@ syn keyword objcEnum NSDataWritingOptions
 syn keyword objcEnumValue NSDataWritingAtomic NSDataWritingWithoutOverwriting NSDataWritingFileProtectionNone NSDataWritingFileProtectionComplete NSDataWritingFileProtectionCompleteUnlessOpen NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication NSDataWritingFileProtectionMask NSAtomicWrite
 syn keyword objcEnum NSDataSearchOptions
 syn keyword objcEnumValue NSDataSearchBackwards NSDataSearchAnchored
+syn keyword objcEnum NSDataBase64EncodingOptions NSDataBase64DecodingOptions
+syn keyword objcEnumValue NSDataBase64Encoding64CharacterLineLength  NSDataBase64Encoding76CharacterLineLength NSDataBase64EncodingEndLineWithCarriageReturn NSDataBase64EncodingEndLineWithLineFeed NSDataBase64DecodingIgnoreUnknownCharacters
 " NSArray.h
 syn match objcClass /NSArray\s*\*/me=s+7,he=s+7
+syn match objcClass /NSArray<.*>\s*\*/me=s+7,he=s+7 contains=objcTypeInfoParams
 syn match objcClass /NSMutableArray\s*\*/me=s+14,he=s+14
+syn match objcClass /NSMutableArray<.*>\s*\*/me=s+14,he=s+14 contains=objcTypeInfoParams
 syn keyword objcEnum NSBinarySearchingOptions
 syn keyword objcEnumValue NSBinarySearchingFirstEqual NSBinarySearchingLastEqual NSBinarySearchingInsertionIndex
 " NSDictionary.h
 syn match objcClass /NSDictionary\s*\*/me=s+12,he=s+12
+syn match objcClass /NSDictionary<.*>\s*\*/me=s+12,he=s+12 contains=objcTypeInfoParams
 syn match objcClass /NSMutableDictionary\s*\*/me=s+19,he=s+19
+syn match objcClass /NSMutableDictionary<.*>\s*\*/me=s+19,he=s+19 contains=objcTypeInfoParams
 " NSSet.h
 syn match objcClass /NSSet\s*\*/me=s+5,me=s+5
+syn match objcClass /NSSet<.*>\s*\*/me=s+5,me=s+5 contains=objcTypeInfoParams
 syn match objcClass /NSMutableSet\s*\*/me=s+12,me=s+12
+syn match objcClass /NSMutableSet<.*>\s*\*/me=s+12,me=s+12 contains=objcTypeInfoParams
 syn match objcClass /NSCountedSet\s*\*/me=s+12,me=s+12
+syn match objcClass /NSCountedSet<.*>\s*\*/me=s+12,me=s+12 contains=objcTypeInfoParams
 " NSOrderedSet.h
 syn match objcClass /NSOrderedSet\s*\*/me=s+12,me=s+12
+syn match objcClass /NSOrderedSet<.*>\s*\*/me=s+12,me=s+12 contains=objcTypeInfoParams
 syn match objcClass /NSMutableOrderedSet\s*\*/me=s+19,me=s+19
+syn match objcClass /NSMutableOrderedSet<.*>\s*\*/me=s+19,me=s+19
 """""""""""""""""""
 " NSPathUtilities.h
 syn keyword objcEnum NSSearchPathDirectory
@@ -238,9 +282,15 @@ syn keyword objcEnum NSSearchPathDomainMask
 syn keyword objcEnumValue NSUserDomainMask NSLocalDomainMask NSNetworkDomainMask NSSystemDomainMask NSAllDomainsMask
 " NSFileManger.h
 syn match objcClass /NSFileManager\s*\*/me=s+13,he=s+13
-syn match objcClass /NSDirectoryEnumerator\s*\*/me=s+21,he=s+21
+syn match objcClass /NSDirectoryEnumerator\s*\*/me=s+21,he=s+21 contains=objcTypeInfoParams
+syn match objcClass /NSDirectoryEnumerator<.*>\s*\*/me=s+21,he=s+21
 syn keyword objcEnum NSVolumeEnumerationOptions
 syn keyword objcEnumValue NSVolumeEnumerationSkipHiddenVolumes NSVolumeEnumerationProduceFileReferenceURLs 
+syn keyword objcEnum NSURLRelationship
+syn keyword objcEnumValue NSURLRelationshipContains NSURLRelationshipSame NSURLRelationshipOther
+syn keyword objcEnum NSFileManagerUnmountOptions
+syn keyword objcEnumValue NSFileManagerUnmountAllPartitionsAndEjectDisk NSFileManagerUnmountWithoutUI
+syn keyword objcConstVar NSFileManagerUnmountDissentingProcessIdentifierErrorKey
 syn keyword objcEnum NSDirectoryEnumerationOptions
 syn keyword objcEnumValue NSDirectoryEnumerationSkipsSubdirectoryDescendants NSDirectoryEnumerationSkipsPackageDescendants NSDirectoryEnumerationSkipsHiddenFiles 
 syn keyword objcEnum NSFileManagerItemReplacementOptions
@@ -261,10 +311,12 @@ syn keyword objcNotificationValue NSCurrentLocaleDidChangeNotification
 syn keyword objcConstVar NSLocaleIdentifier NSLocaleLanguageCode NSLocaleCountryCode NSLocaleScriptCode NSLocaleVariantCode NSLocaleExemplarCharacterSet NSLocaleCalendar NSLocaleCollationIdentifier NSLocaleUsesMetricSystem NSLocaleMeasurementSystem NSLocaleDecimalSeparator NSLocaleGroupingSeparator NSLocaleCurrencySymbol NSLocaleCurrencyCode NSLocaleCollatorIdentifier NSLocaleQuotationBeginDelimiterKey NSLocaleQuotationEndDelimiterKey NSLocaleAlternateQuotationBeginDelimiterKey NSLocaleAlternateQuotationEndDelimiterKey NSGregorianCalendar NSBuddhistCalendar NSChineseCalendar NSHebrewCalendar NSIslamicCalendar NSIslamicCivilCalendar NSJapaneseCalendar NSRepublicOfChinaCalendar NSPersianCalendar NSIndianCalendar NSISO8601Calendar 
 " NSFormatter.h
 syn match objcClass /NSFormatter\s*\*/me=s+11,he=s+11
+syn keyword objcEnum NSFormattingContext NSFormattingUnitStyle
+syn keyword objcEnumValue NSFormattingContextUnknown NSFormattingContextDynamic NSFormattingContextStandalone NSFormattingContextListItem NSFormattingContextBeginningOfSentence NSFormattingContextMiddleOfSentence NSFormattingUnitStyleShort NSFormattingUnitStyleMedium NSFormattingUnitStyleLong
 " NSNumberFormatter.h
 syn match objcClass /NSNumberFormatter\s*\*/me=s+17,he=s+17
 syn keyword objcEnum NSNumberFormatterStyle
-syn keyword objcEnumValue NSNumberFormatterNoStyle NSNumberFormatterDecimalStyle NSNumberFormatterCurrencyStyle NSNumberFormatterPercentStyle NSNumberFormatterScientificStyle NSNumberFormatterSpellOutStyle
+syn keyword objcEnumValue NSNumberFormatterNoStyle NSNumberFormatterDecimalStyle NSNumberFormatterCurrencyStyle NSNumberFormatterPercentStyle NSNumberFormatterScientificStyle NSNumberFormatterSpellOutStyle NSNumberFormatterOrdinalStyle NSNumberFormatterCurrencyISOCodeStyle NSNumberFormatterCurrencyPluralStyle NSNumberFormatterCurrencyAccountingStyle
 syn keyword objcEnum NSNumberFormatterBehavior
 syn keyword objcEnumValue NSNumberFormatterBehaviorDefault NSNumberFormatterBehavior10_0 NSNumberFormatterBehavior10_4
 syn keyword objcEnum NSNumberFormatterPadPosition
@@ -279,10 +331,15 @@ syn keyword objcEnum NSDateFormatterBehavior
 syn keyword objcEnumValue NSDateFormatterBehaviorDefault NSDateFormatterBehavior10_0 NSDateFormatterBehavior10_4
 " NSCalendar.h
 syn match objcClass /NSCalendar\s*\*/me=s+10,he=s+10
+syn keyword objcConstVar NSCalendarIdentifierGregorian NSCalendarIdentifierBuddhist NSCalendarIdentifierChinese NSCalendarIdentifierCoptic NSCalendarIdentifierEthiopicAmeteMihret NSCalendarIdentifierEthiopicAmeteAlem NSCalendarIdentifierHebrew NSCalendarIdentifierISO8601 NSCalendarIdentifierIndian NSCalendarIdentifierIslamic NSCalendarIdentifierIslamicCivil NSCalendarIdentifierJapanese NSCalendarIdentifierPersian NSCalendarIdentifierRepublicOfChina NSCalendarIdentifierIslamicTabular NSCalendarIdentifierIslamicUmmAlQura
 syn keyword objcEnum NSCalendarUnit
+syn keyword objcEnumValue NSCalendarUnitEra NSCalendarUnitYear NSCalendarUnitMonth NSCalendarUnitDay NSCalendarUnitHour NSCalendarUnitMinute NSCalendarUnitSecond NSCalendarUnitWeekday NSCalendarUnitWeekdayOrdinal NSCalendarUnitQuarter NSCalendarUnitWeekOfMonth NSCalendarUnitWeekOfYear NSCalendarUnitYearForWeekOfYear NSCalendarUnitNanosecond NSCalendarUnitCalendar NSCalendarUnitTimeZone
 syn keyword objcEnumValue NSEraCalendarUnit NSYearCalendarUnit NSMonthCalendarUnit NSDayCalendarUnit NSHourCalendarUnit NSMinuteCalendarUnit NSSecondCalendarUnit NSWeekCalendarUnit NSWeekdayCalendarUnit NSWeekdayOrdinalCalendarUnit NSQuarterCalendarUnit NSWeekOfMonthCalendarUnit NSWeekOfYearCalendarUnit NSYearForWeekOfYearCalendarUnit NSCalendarCalendarUnit NSTimeZoneCalendarUnit
-syn keyword objcEnumValue NSWrapCalendarComponents NSUndefinedDateComponent
+syn keyword objcEnumValue NSWrapCalendarComponents NSUndefinedDateComponent NSDateComponentUndefined
 syn match objcClass /NSDateComponents\s*\*/me=s+16,he=s+16
+syn keyword objcEnum NSCalendarOptions
+syn keyword objcEnumValue NSCalendarWrapComponents NSCalendarMatchStrictly NSCalendarSearchBackwards NSCalendarMatchPreviousTimePreservingSmallerUnits NSCalendarMatchNextTimePreservingSmallerUnits NSCalendarMatchNextTime NSCalendarMatchFirst NSCalendarMatchLast
+syn keyword objcConstVar NSCalendarDayChangedNotification
 " NSTimeZone.h
 syn match objcClass /NSTimeZone\s*\*/me=s+10,he=s+10
 syn keyword objcEnum NSTimeZoneNameStyle
@@ -299,6 +356,7 @@ syn keyword objcExceptionValue NSInconsistentArchiveException
 syn match objcClass /NSKeyedArchiver\s*\*/me=s+15,he=s+15
 syn match objcClass /NSKeyedUnarchiver\s*\*/me=s+17,he=s+17
 syn keyword objcExceptionValue NSInvalidArchiveOperationException NSInvalidUnarchiveOperationException
+syn keyword objcConstVar NSKeyedArchiveRootObjectKey
 """"""""""""""""""
 " NSPropertyList.h
 syn keyword objcEnum NSPropertyListMutabilityOptions
@@ -313,11 +371,16 @@ syn keyword objcNotificationValue NSUserDefaultsDidChangeNotification
 " NSBundle.h
 syn match objcClass /NSBundle\s*\*/me=s+8,he=s+8
 syn keyword objcEnumValue NSBundleExecutableArchitectureI386 NSBundleExecutableArchitecturePPC NSBundleExecutableArchitectureX86_64 NSBundleExecutableArchitecturePPC64
-syn keyword objcNotificationValue NSBundleDidLoadNotification NSLoadedClasses
+syn keyword objcNotificationValue NSBundleDidLoadNotification NSLoadedClasses NSBundleResourceRequestLowDiskSpaceNotification
+syn keyword objcConstVar NSBundleResourceRequestLoadingPriorityUrgent
 """""""""""""""""
 " NSProcessInfo.h
 syn match objcClass /NSProcessInfo\s*\*/me=s+13,he=s+13
 syn keyword objcEnumValue NSWindowsNTOperatingSystem NSWindows95OperatingSystem NSSolarisOperatingSystem NSHPUXOperatingSystem NSMACHOperatingSystem NSSunOSOperatingSystem NSOSF1OperatingSystem
+syn keyword objcType NSOperatingSystemVersion
+syn keyword objcEnum NSActivityOptions NSProcessInfoThermalState
+syn keyword objcEnumValue NSActivityIdleDisplaySleepDisabled NSActivityIdleSystemSleepDisabled NSActivitySuddenTerminationDisabled NSActivityAutomaticTerminationDisabled NSActivityUserInitiated NSActivityUserInitiatedAllowingIdleSystemSleep NSActivityBackground NSActivityLatencyCritical NSProcessInfoThermalStateNominal NSProcessInfoThermalStateFair NSProcessInfoThermalStateSerious NSProcessInfoThermalStateCritical
+syn keyword objcNotificationValue NSProcessInfoThermalStateDidChangeNotification NSProcessInfoPowerStateDidChangeNotification
 " NSTask.h
 syn match objcClass /NSTask\s*\*/me=s+6,he=s+6
 syn keyword objcEnum NSTaskTerminationReason
@@ -352,6 +415,7 @@ syn match objcClass /NSPort\s*\*/me=s+6,he=s+6
 syn keyword objcType NSSocketNativeHandle
 syn keyword objcNotificationValue NSPortDidBecomeInvalidNotification
 syn match objcClass /NSMachPort\s*\*/me=s+10,he=s+10
+syn keyword objcEnum NSMachPortOptions
 syn keyword objcEnumValue NSMachPortDeallocateNone NSMachPortDeallocateSendRight NSMachPortDeallocateReceiveRight
 syn match objcClass /NSMessagePort\s*\*/me=s+13,he=s+13
 syn match objcClass /NSSocketPort\s*\*/me=s+12,he=s+12
@@ -386,6 +450,31 @@ syn match objcClass /NSProxy\s*\*/me=s+7,he=s+7
 " NSObject.h
 syn match objcClass /NSObject\s*\*/me=s+8,he=s+8
 
+
+" NSCache.h
+syn match objcClass /NSCache\s*\*/me=s+7,he=s+7
+syn match objcClass /NSCache<.*>\s*\*/me=s+7,he=s+7 contains=objcTypeInfoParams
+" NSHashTable.h
+syn match objcClass /NSHashTable\s*\*/me=s+11,he=s+11
+syn match objcClass /NSHashTable<.*>\s*\*/me=s+11,he=s+11 contains=objcTypeInfoParams
+syn keyword objcConstVar NSHashTableStrongMemory NSHashTableZeroingWeakMemory NSHashTableCopyIn NSHashTableObjectPointerPersonality NSHashTableWeakMemory
+syn keyword objcType NSHashTableOptions NSHashEnumerator NSHashTableCallBacks
+syn keyword objcConstVar NSIntegerHashCallBacks NSNonOwnedPointerHashCallBacks NSNonRetainedObjectHashCallBacks NSObjectHashCallBacks NSOwnedObjectIdentityHashCallBacks NSOwnedPointerHashCallBacks NSPointerToStructHashCallBacks NSOwnedObjectIdentityHashCallBacks NSOwnedObjectIdentityHashCallBacks NSIntHashCallBacks
+" NSMapTable.h
+syn match objcClass /NSMapTable\s*\*/me=s+10,he=s+10
+syn match objcClass /NSMapTable<.*>\s*\*/me=s+10,he=s+10 contains=objcTypeInfoParams
+syn keyword objcConstVar NSPointerToStructHashCallBacks NSPointerToStructHashCallBacks NSPointerToStructHashCallBacks NSPointerToStructHashCallBacks NSPointerToStructHashCallBacks
+syn keyword objcConstVar NSMapTableStrongMemory NSMapTableZeroingWeakMemory NSMapTableCopyIn NSMapTableObjectPointerPersonality NSMapTableWeakMemory
+syn keyword objcType NSMapTableOptions NSMapEnumerator NSMapTableKeyCallBacks NSMapTableValueCallBacks
+syn keyword objcMacro NSNotAnIntMapKey NSNotAnIntegerMapKey NSNotAPointerMapKey
+syn keyword objcConstVar NSIntegerMapKeyCallBacks NSNonOwnedPointerMapKeyCallBacks NSNonOwnedPointerOrNullMapKeyCallBacks NSNonRetainedObjectMapKeyCallBacks NSObjectMapKeyCallBacks NSOwnedPointerMapKeyCallBacks NSIntMapKeyCallBacks NSIntegerMapValueCallBacks NSNonOwnedPointerMapValueCallBacks NSObjectMapValueCallBacks NSNonRetainedObjectMapValueCallBacks NSOwnedPointerMapValueCallBacks NSIntMapValueCallBacks
+
+" NSPointerFunctions.h
+syn match objcClass /NSPointerFunctions\s*\*/me=s+18,he=s+18
+syn keyword objcEnum NSPointerFunctionsOptions
+syn keyword objcEnumValue NSPointerFunctionsStrongMemory NSPointerFunctionsZeroingWeakMemory NSPointerFunctionsOpaqueMemory NSPointerFunctionsMallocMemory NSPointerFunctionsMachVirtualMemory NSPointerFunctionsWeakMemory NSPointerFunctionsObjectPersonality NSPointerFunctionsOpaquePersonality NSPointerFunctionsObjectPointerPersonality NSPointerFunctionsCStringPersonality NSPointerFunctionsStructPersonality NSPointerFunctionsIntegerPersonality NSPointerFunctionsCopyIn
+
+
 """ Default Highlighting
 hi def link objcPreProcMacro                cConstant
 hi def link objcPrincipalType               cType
@@ -408,6 +497,7 @@ hi def link objcBlocksQualifier             cStorageClass
 hi def link objcObjectLifetimeQualifier     cStorageClass
 hi def link objcTollFreeBridgeQualifier     cStorageClass
 hi def link objcRemoteMessagingQualifier    cStorageClass
+hi def link objcStorageClass                cStorageClass
 hi def link objcFastEnumKeyword             cStatement
 hi def link objcLiteralSyntaxNumber         cNumber
 hi def link objcLiteralSyntaxChar           cCharacter
@@ -418,16 +508,22 @@ hi def link objcDeclPropAccessorType        cConstant
 hi def link objcDeclPropAssignSemantics     cConstant
 hi def link objcDeclPropAtomicity           cConstant
 hi def link objcDeclPropARC                 cConstant
+hi def link objcDeclPropNullable            cConstant
+hi def link objcDeclPropNonnull             cConstant
+hi def link objcDeclPropNullUnspecified     cConstant
+hi def link objcDeclProcNullResettable      cConstant
 hi def link objcInstanceMethod              Function
 hi def link objcClassMethod                 Function
 hi def link objcType                        cType
 hi def link objcClass                       cType
+hi def link objcTypeSpecifier               cType
 hi def link objcMacro                       cConstant
 hi def link objcEnum                        cType
 hi def link objcEnumValue                   cConstant
 hi def link objcExceptionValue              cConstant
 hi def link objcNotificationValue           cConstant
 hi def link objcConstVar                    cConstant
+hi def link objcTypeInfoParams              Identifier
 
 """ Final step
 let b:current_syntax = "objc"

--- a/runtime/syntax/php.vim
+++ b/runtime/syntax/php.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: php PHP 3/4/5
 " Maintainer: Jason Woofenden <jason@jasonwoof.com>
-" Last Change: Nov 23, 2015
+" Last Change: Dec 26, 2015
 " URL: https://jasonwoof.com/gitweb/?p=vim-syntax.git;a=blob;f=php.vim;hb=HEAD
 " Former Maintainers: Peter Hodge <toomuchphp-vim@yahoo.com>
 "         Debian VIM Maintainers <pkg-vim-maintainers@lists.alioth.debian.org>
@@ -515,7 +515,7 @@ syntax keyword phpStatement die contained
 
 " Highlighting for PHP5's user-definable magic class methods
 syntax keyword phpSpecialFunction containedin=ALLBUT,phpComment,phpStringDouble,phpStringSingle,phpIdentifier
-  \ __construct __destruct __call __toString __sleep __wakeup __set __get __unset __isset __clone __set_state
+  \  __construct __destruct __call __callStatic __get __set __isset __unset __sleep __wakeup __toString __invoke __set_state __clone __debugInfo
 " Highlighting for __autoload slightly different from line above
 syntax keyword phpSpecialFunction containedin=ALLBUT,phpComment,phpStringDouble,phpStringSingle,phpIdentifier,phpMethodsVar
   \ __autoload

--- a/runtime/syntax/php.vim
+++ b/runtime/syntax/php.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: php PHP 3/4/5
 " Maintainer: Jason Woofenden <jason@jasonwoof.com>
-" Last Change: Mar 24, 2015
+" Last Change: Nov 23, 2015
 " URL: https://jasonwoof.com/gitweb/?p=vim-syntax.git;a=blob;f=php.vim;hb=HEAD
 " Former Maintainers: Peter Hodge <toomuchphp-vim@yahoo.com>
 "         Debian VIM Maintainers <pkg-vim-maintainers@lists.alioth.debian.org>
@@ -280,7 +280,7 @@ syn keyword phpStatement  return break continue exit goto  contained
 syn keyword phpKeyword  var const contained
 
 " Type
-syn keyword phpType bool[ean] int[eger] real double float string array object NULL  contained
+syn keyword phpType bool boolean int integer real double float string array object NULL  contained
 
 " Structure
 syn keyword phpStructure  namespace extends implements instanceof parent self contained
@@ -393,13 +393,13 @@ endif
 
 " String
 if exists("php_parent_error_open")
-  syn region  phpStringDouble matchgroup=None start=+"+ skip=+\\\\\|\\"+ end=+"+  contains=@phpAddStrings,phpBackslashSequences,phpBackslashDoubleQuote,@phpInterpDouble contained keepend
-  syn region  phpBacktick matchgroup=None start=+`+ skip=+\\\\\|\\"+ end=+`+  contains=@phpAddStrings,phpIdentifier,phpBackslashSequences,phpIdentifierSimply,phpIdentifierComplex contained keepend
-  syn region  phpStringSingle matchgroup=None start=+'+ skip=+\\\\\|\\'+ end=+'+  contains=@phpAddStrings,phpBackslashSingleQuote contained keepend
+  syn region  phpStringDouble matchgroup=phpStringDouble start=+"+ skip=+\\\\\|\\"+ end=+"+  contains=@phpAddStrings,phpBackslashSequences,phpBackslashDoubleQuote,@phpInterpDouble contained keepend
+  syn region  phpBacktick matchgroup=phpBacktick start=+`+ skip=+\\\\\|\\"+ end=+`+  contains=@phpAddStrings,phpIdentifier,phpBackslashSequences,phpIdentifierSimply,phpIdentifierComplex contained keepend
+  syn region  phpStringSingle matchgroup=phpStringSingle start=+'+ skip=+\\\\\|\\'+ end=+'+  contains=@phpAddStrings,phpBackslashSingleQuote contained keepend
 else
-  syn region  phpStringDouble matchgroup=None start=+"+ skip=+\\\\\|\\"+ end=+"+  contains=@phpAddStrings,phpBackslashSequences,phpBackslashDoubleQuote,@phpInterpDouble contained extend keepend
-  syn region  phpBacktick matchgroup=None start=+`+ skip=+\\\\\|\\"+ end=+`+  contains=@phpAddStrings,phpIdentifier,phpBackslashSequences,phpIdentifierSimply,phpIdentifierComplex contained extend keepend
-  syn region  phpStringSingle matchgroup=None start=+'+ skip=+\\\\\|\\'+ end=+'+  contains=@phpAddStrings,phpBackslashSingleQuote contained keepend extend
+  syn region  phpStringDouble matchgroup=phpStringDouble start=+"+ skip=+\\\\\|\\"+ end=+"+  contains=@phpAddStrings,phpBackslashSequences,phpBackslashDoubleQuote,@phpInterpDouble contained extend keepend
+  syn region  phpBacktick matchgroup=phpBacktick start=+`+ skip=+\\\\\|\\"+ end=+`+  contains=@phpAddStrings,phpIdentifier,phpBackslashSequences,phpIdentifierSimply,phpIdentifierComplex contained extend keepend
+  syn region  phpStringSingle matchgroup=phpStringSingle start=+'+ skip=+\\\\\|\\'+ end=+'+  contains=@phpAddStrings,phpBackslashSingleQuote contained keepend extend
 endif
 
 " HereDoc and NowDoc

--- a/runtime/syntax/r.vim
+++ b/runtime/syntax/r.vim
@@ -3,7 +3,9 @@
 " Maintainer:	      Jakson Aquino <jalvesaq@gmail.com>
 " Former Maintainers: Vaidotas Zemlys <zemlys@gmail.com>
 " 		      Tom Payne <tom@tompayne.org>
-" Last Change:	      Wed Dec 31, 2014  12:36AM
+" Contributor:        Johannes Ranke <jranke@uni-bremen.de>
+" Homepage:           https://github.com/jalvesaq/R-Vim-runtime
+" Last Change:	      Wed Oct 21, 2015  06:33AM
 " Filenames:	      *.R *.r *.Rhistory *.Rt
 "
 " NOTE: The highlighting of R functions is defined in
@@ -30,16 +32,21 @@ syn case match
 
 " Comment
 syn match rCommentTodo contained "\(BUG\|FIXME\|NOTE\|TODO\):"
-syn match rComment contains=@Spell,rCommentTodo "#.*"
+syn match rComment contains=@Spell,rCommentTodo,rOBlock "#.*"
 
 " Roxygen
-syn match rOKeyword contained "@\(param\|return\|name\|rdname\|examples\|include\|docType\)"
+syn region rOBlock start="^\s*\n#\{1,2}' " start="\%^#\{1,2}' " end="^\(#\{1,2}'\)\@!" contains=rOTitle,rOKeyword,rOExamples,@Spell keepend
+syn region rOTitle start="^\s*\n#\{1,2}' " start="\%^#\{1,2}' " end="^\(#\{1,2}'\s*$\)\@=" contained contains=rOCommentKey
+syn match rOCommentKey "#\{1,2}'" containedin=rOTitle contained
+
+syn region rOExamples start="^#\{1,2}' @examples.*"rs=e+1,hs=e+1 end="^\(#\{1,2}' @.*\)\@=" end="^\(#\{1,2}'\)\@!" contained contains=rOKeyword
+
+syn match rOKeyword contained "@\(param\|return\|name\|rdname\|examples\|example\|include\|docType\)"
 syn match rOKeyword contained "@\(S3method\|TODO\|aliases\|alias\|assignee\|author\|callGraphDepth\|callGraph\)"
 syn match rOKeyword contained "@\(callGraphPrimitives\|concept\|exportClass\|exportMethod\|exportPattern\|export\|formals\)"
 syn match rOKeyword contained "@\(format\|importClassesFrom\|importFrom\|importMethodsFrom\|import\|keywords\|useDynLib\)"
 syn match rOKeyword contained "@\(method\|noRd\|note\|references\|seealso\|setClass\|slot\|source\|title\|usage\)"
-syn match rOKeyword contained "@\(family\|template\|templateVar\|description\|details\|inheritParams\)"
-syn match rOComment contains=@Spell,rOKeyword "#'.*"
+syn match rOKeyword contained "@\(family\|template\|templateVar\|description\|details\|inheritParams\|field\)"
 
 
 if &filetype == "rhelp"
@@ -202,7 +209,6 @@ hi def link rBoolean     Boolean
 hi def link rBraceError  Error
 hi def link rComment     Comment
 hi def link rCommentTodo Todo
-hi def link rOComment    Comment
 hi def link rComplex     Number
 hi def link rConditional Conditional
 hi def link rConstant    Constant
@@ -230,6 +236,11 @@ hi def link rString      String
 hi def link rStrError    Error
 hi def link rType        Type
 hi def link rOKeyword    Title
+hi def link rOBlock      Comment
+hi def link rOTitle      Title
+hi def link rOCommentKey Comment
+hi def link rOExamples   SpecialComment
+
 
 let b:current_syntax="r"
 

--- a/runtime/syntax/remind.vim
+++ b/runtime/syntax/remind.vim
@@ -1,13 +1,17 @@
 " Vim syntax file
 " Language:	Remind
-" Maintainer:	Davide Alberani <alberanid@libero.it>
-" Last Change:	18 Sep 2009
-" Version:	0.5
-" URL:		http://erlug.linux.it/~da/vim/syntax/remind.vim
+" Maintainer:	Davide Alberani <da@erlug.linux.it>
+" Last Change:	02 Nov 2015
+" Version:	0.7
+" URL:		http://ismito.it/vim/syntax/remind.vim
 "
-" remind is a sophisticated reminder service
-" you can download remind from:
-"   http://www.roaringpenguin.com/penguin/open_source_remind.php
+" Remind is a sophisticated calendar and alarm program.
+" You can download remind from:
+"   https://www.roaringpenguin.com/products/remind
+"
+" Changelog
+" version 0.7: updated email and link
+" version 0.6: added THROUGH keyword (courtesy of Ben Orchard)
 
 if version < 600
   syntax clear
@@ -19,7 +23,7 @@ endif
 syn case ignore
 
 syn keyword remindCommands	REM OMIT SET FSET UNSET
-syn keyword remindExpiry	UNTIL FROM SCANFROM SCAN WARN SCHED
+syn keyword remindExpiry	UNTIL FROM SCANFROM SCAN WARN SCHED THROUGH
 syn keyword remindTag		PRIORITY TAG
 syn keyword remindTimed		AT DURATION
 syn keyword remindMove		ONCE SKIP BEFORE AFTER

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -2,8 +2,8 @@
 " Language:		shell (sh) Korn shell (ksh) bash (sh)
 " Maintainer:		Charles E. Campbell  <NdrOchipS@PcampbellAfamily.Mbiz>
 " Previous Maintainer:	Lennart Schultz <Lennart.Schultz@ecmwf.int>
-" Last Change:		Oct 21, 2015
-" Version:		141
+" Last Change:		Nov 09, 2015
+" Version:		142
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
 " This file includes many ideas from Eric Brunet (eric.brunet@ens.fr)
@@ -116,7 +116,7 @@ syn cluster shArithParenList	contains=shArithmetic,shCaseEsac,shComment,shDeref,
 syn cluster shArithList	contains=@shArithParenList,shParenError
 syn cluster shCaseEsacList	contains=shCaseStart,shCase,shCaseBar,shCaseIn,shComment,shDeref,shDerefSimple,shCaseCommandSub,shCaseExSingleQuote,shCaseSingleQuote,shCaseDoubleQuote,shCtrlSeq,@shErrorList,shStringSpecial,shCaseRange
 syn cluster shCaseList	contains=@shCommandSubList,shCaseEsac,shColon,shCommandSub,shComment,shDo,shEcho,shExpr,shFor,shHereDoc,shIf,shRedir,shSetList,shSource,shStatement,shVariable,shCtrlSeq
-syn cluster shCommandSubList	contains=shAlias,shArithmetic,shCmdParenRegion,shCtrlSeq,shDeref,shDerefSimple,shDoubleQuote,shEcho,shEscape,shExDoubleQuote,shExpr,shExSingleQuote,shNumber,shOperator,shOption,shPosnParm,shSingleQuote,shSpecial,shStatement,shSubSh,shTest,shVariable
+syn cluster shCommandSubList	contains=shAlias,shArithmetic,shComment,shCmdParenRegion,shCtrlSeq,shDeref,shDerefSimple,shDoubleQuote,shEcho,shEscape,shExDoubleQuote,shExpr,shExSingleQuote,shNumber,shOperator,shOption,shPosnParm,shSingleQuote,shSpecial,shStatement,shSubSh,shTest,shVariable
 syn cluster shCurlyList	contains=shNumber,shComma,shDeref,shDerefSimple,shDerefSpecial
 syn cluster shDblQuoteList	contains=shCommandSub,shDeref,shDerefSimple,shEscape,shPosnParm,shCtrlSeq,shSpecial
 syn cluster shDerefList	contains=shDeref,shDerefSimple,shDerefVar,shDerefSpecial,shDerefWordError,shDerefPPS
@@ -414,7 +414,7 @@ endif
 if !exists("g:sh_no_error")
  syn match  shDerefWordError	"[^}$[]"	contained
 endif
-syn match  shDerefSimple	"\$\k\+\|\d"
+syn match  shDerefSimple	"\$\%(\k\+\|\d\)"
 syn region shDeref	matchgroup=PreProc start="\${" end="}"	contains=@shDerefList,shDerefVarArray
 syn match  shDerefSimple	"\$[-#*@!?]"
 syn match  shDerefSimple	"\$\$"

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -2,11 +2,11 @@
 " Language:		shell (sh) Korn shell (ksh) bash (sh)
 " Maintainer:		Charles E. Campbell  <NdrOchipS@PcampbellAfamily.Mbiz>
 " Previous Maintainer:	Lennart Schultz <Lennart.Schultz@ecmwf.int>
-" Last Change:		Oct 09, 2015
-" Version:		139
+" Last Change:		Oct 21, 2015
+" Version:		141
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
-" This file includes many ideas from ?ric Brunet (eric.brunet@ens.fr)
+" This file includes many ideas from Eric Brunet (eric.brunet@ens.fr)
 
 " For version 5.x: Clear all syntax items {{{1
 " For version 6.x: Quit when a syntax file was already loaded
@@ -14,17 +14,6 @@ if version < 600
   syntax clear
 elseif exists("b:current_syntax")
   finish
-endif
-
-" AFAICT "." should be considered part of the iskeyword for ksh.  Using iskeywords
-" in syntax is dicey, so the following code permits the user to prevent/override
-"  g:sh_isk set to a string	: specify iskeyword.
-"  g:sh_noisk exists	: don't change iskeyword
-"  g:sh_noisk does not exist	: (default) append "." to iskeyword for kornshell
-if exists("g:sh_isk") && type(g:sh_isk) == 1	" user specifying iskeyword
- exe "setl isk=".g:sh_isk
-elseif !exists("g:sh_noisk") && exists("b:is_kornshell") " append '.' to iskeyword
- setl isk+=.
 endif
 
 " trying to answer the question: which shell is /bin/sh, really?
@@ -73,6 +62,7 @@ if !exists("b:is_kornshell") && !exists("b:is_bash")
 endif
 
 " set up default g:sh_fold_enabled {{{1
+" ================================
 if !exists("g:sh_fold_enabled")
  let g:sh_fold_enabled= 0
 elseif g:sh_fold_enabled != 0 && !has("folding")
@@ -93,6 +83,24 @@ if g:sh_fold_enabled && &fdm == "manual"
  " 	AND	g:sh_fold_enabled is manual (usual default)
  " 	implies	a desire for syntax-based folding
  setl fdm=syntax
+endif
+
+" Set up folding commands for shell {{{1
+" =================================
+if s:sh_fold_functions
+ com! -nargs=* ShFoldFunctions <args> fold
+else
+ com! -nargs=* ShFoldFunctions <args>
+endif
+if s:sh_fold_heredoc
+ com! -nargs=* ShFoldHereDoc <args> fold
+else
+ com! -nargs=* ShFoldHereDoc <args>
+endif
+if s:sh_fold_ifdofor
+ com! -nargs=* ShFoldIfDoFor <args> fold
+else
+ com! -nargs=* ShFoldIfDoFor <args>
 endif
 
 " sh syntax is case sensitive {{{1
@@ -126,9 +134,10 @@ syn cluster shHereList	contains=shBeginHere,shHerePayload
 syn cluster shHereListDQ	contains=shBeginHere,@shDblQuoteList,shHerePayload
 syn cluster shIdList	contains=shCommandSub,shWrapLineOperator,shSetOption,shDeref,shDerefSimple,shRedir,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shExpr,shCtrlSeq,shStringSpecial,shAtExpr
 syn cluster shIfList	contains=@shLoopList,shDblBrace,shDblParen,shFunctionKey,shFunctionOne,shFunctionTwo
-syn cluster shLoopList	contains=@shCaseList,@shErrorList,shCaseEsac,shConditional,shDblBrace,shExpr,shFor,shForPP,shIf,shOption,shSet,shTest,shTestOpr
+syn cluster shLoopList	contains=@shCaseList,@shErrorList,shCaseEsac,shConditional,shDblBrace,shExpr,shFor,shForPP,shIf,shOption,shSet,shTest,shTestOpr,shTouch
 syn cluster shSubShList	contains=@shCommandSubList,shCaseEsac,shColon,shCommandSub,shComment,shDo,shEcho,shExpr,shFor,shIf,shRedir,shSetList,shSource,shStatement,shVariable,shCtrlSeq,shOperator
 syn cluster shTestList	contains=shCharClass,shCommandSub,shCtrlSeq,shDeref,shDerefSimple,shDoubleQuote,shExDoubleQuote,shExpr,shExSingleQuote,shNumber,shOperator,shSingleQuote,shTest,shTestOpr
+
 " Echo: {{{1
 " ====
 " This one is needed INSIDE a CommandSub, so that `echo bla` be correct
@@ -145,6 +154,11 @@ if exists("b:is_kornshell") || exists("b:is_bash")
  syn match shStatement "\<alias\>"
  syn region shAlias matchgroup=shStatement start="\<alias\>\s\+\(\h[-._[:alnum:]]\+\)\@="  skip="\\$" end="\>\|`"
  syn region shAlias matchgroup=shStatement start="\<alias\>\s\+\(\h[-._[:alnum:]]\+=\)\@=" skip="\\$" end="="
+
+ " Touch: {{{1
+ " =====
+ syn match shTouch	'\<touch\>[^;#]*'	skipwhite nextgroup=shTouchList contains=shTouchCmd
+ syn match shTouchCmd	'\<touch\>'		contained
 endif
 
 " Error Codes: {{{1
@@ -193,15 +207,16 @@ syn region shSubSh transparent matchgroup=shSubShRegion start="[^(]\zs(" end=")"
 "=======
 syn region shExpr	matchgroup=shRange start="\[" skip=+\\\\\|\\$\|\[+ end="\]" contains=@shTestList,shSpecial
 syn region shTest	transparent matchgroup=shStatement start="\<test\s" skip=+\\\\\|\\$+ matchgroup=NONE end="[;&|]"me=e-1 end="$" contains=@shExprList1
+syn region shNoQuote	start='\S'	skip='\%(\\\\\)*\\.'	end='\ze\s'	contained
 syn match  shTestOpr	contained	'[^-+/%]\zs=' skipwhite nextgroup=shTestDoubleQuote,shTestSingleQuote,shTestPattern
-syn match  shTestOpr	contained	"<=\|>=\|!=\|==\|-.\>\|-\(nt\|ot\|ef\|eq\|ne\|lt\|le\|gt\|ge\)\>\|[!<>]"
+syn match  shTestOpr	contained	"<=\|>=\|!=\|==\|=\~\|-.\>\|-\(nt\|ot\|ef\|eq\|ne\|lt\|le\|gt\|ge\)\>\|[!<>]"
 syn match  shTestPattern	contained	'\w\+'
 syn region shTestDoubleQuote	contained	start='\%(\%(\\\\\)*\\\)\@<!"' skip=+\\\\\|\\"+ end='"'
 syn match  shTestSingleQuote	contained	'\\.'
 syn match  shTestSingleQuote	contained	"'[^']*'"
 if exists("b:is_kornshell") || exists("b:is_bash")
- syn region  shDblBrace matchgroup=Delimiter start="\[\[" skip=+\\\\\|\\$+ end="\]\]"	contains=@shTestList,shComment
- syn region  shDblParen matchgroup=Delimiter start="((" skip=+\\\\\|\\$+ end="))"	contains=@shTestList,shComment
+ syn region  shDblBrace matchgroup=Delimiter start="\[\["	skip=+\%(\\\\\)*\\$+ end="\]\]"	contains=@shTestList,shNoQuote,shComment
+ syn region  shDblParen matchgroup=Delimiter start="(("	skip=+\%(\\\\\)*\\$+ end="))"	contains=@shTestList,shComment
 endif
 
 " Character Class In Range: {{{1
@@ -210,17 +225,11 @@ syn match   shCharClass	contained	"\[:\(backspace\|escape\|return\|xdigit\|alnum
 
 " Loops: do, if, while, until {{{1
 " ======
-if s:sh_fold_ifdofor
- syn region shDo	fold transparent matchgroup=shConditional start="\<do\>" matchgroup=shConditional end="\<done\>"			contains=@shLoopList
- syn region shIf	fold transparent matchgroup=shConditional start="\<if\_s" matchgroup=shConditional skip=+-fi\>+ end="\<;\_s*then\>" end="\<fi\>"	contains=@shIfList
- syn region shFor	fold matchgroup=shLoop start="\<for\ze\_s\s*\%(((\)\@!" end="\<in\_s" end="\<do\>"me=e-2				contains=@shLoopList,shDblParen skipwhite nextgroup=shCurlyIn
- syn region shForPP	fold matchgroup=shLoop start='\<for\>\_s*((' end='))' contains=shTestOpr
-else
- syn region shDo	transparent matchgroup=shConditional start="\<do\>" matchgroup=shConditional end="\<done\>"			contains=@shLoopList
- syn region shIf	transparent matchgroup=shConditional start="\<if\_s" matchgroup=shConditional skip=+-fi\>+ end="\<;\_s*then\>" end="\<fi\>"	contains=@shIfList
- syn region shFor	matchgroup=shLoop start="\<for\ze\_s\s*\%(((\)\@!" end="\<in\>" end="\<do\>"me=e-2			contains=@shLoopList,shDblParen skipwhite nextgroup=shCurlyIn
- syn region shForPP	matchgroup=shLoop start='\<for\>\_s*((' end='))' contains=shTestOpr
-endif
+ShFoldIfDoFor syn region shDo	transparent	matchgroup=shConditional start="\<do\>" matchgroup=shConditional end="\<done\>"			contains=@shLoopList
+ShFoldIfDoFor syn region shIf	transparent	matchgroup=shConditional start="\<if\_s" matchgroup=shConditional skip=+-fi\>+ end="\<;\_s*then\>" end="\<fi\>"	contains=@shIfList
+ShFoldIfDoFor syn region shFor		matchgroup=shLoop start="\<for\ze\_s\s*\%(((\)\@!" end="\<in\>" end="\<do\>"me=e-2			contains=@shLoopList,shDblParen skipwhite nextgroup=shCurlyIn
+ShFoldIfDoFor syn region shForPP	matchgroup=shLoop start='\<for\>\_s*((' end='))' contains=shTestOpr
+
 if exists("b:is_kornshell") || exists("b:is_bash")
  syn cluster shCaseList	add=shRepeat
  syn cluster shFunctionList	add=shRepeat
@@ -238,13 +247,9 @@ syn match  shComma     contained	","
 " ====
 syn match   shCaseBar	contained skipwhite "\(^\|[^\\]\)\(\\\\\)*\zs|"		nextgroup=shCase,shCaseStart,shCaseBar,shComment,shCaseExSingleQuote,shCaseSingleQuote,shCaseDoubleQuote
 syn match   shCaseStart	contained skipwhite skipnl "("			nextgroup=shCase,shCaseBar
-if s:sh_fold_ifdofor
- syn region  shCase	fold contained skipwhite skipnl matchgroup=shSnglCase start="\%(\\.\|[^#$()'" \t]\)\{-}\zs)"  end=";;" end="esac"me=s-1 contains=@shCaseList nextgroup=shCaseStart,shCase,shComment
- syn region  shCaseEsac	fold matchgroup=shConditional start="\<case\>" end="\<esac\>"	contains=@shCaseEsacList
-else
- syn region  shCase	contained skipwhite skipnl matchgroup=shSnglCase start="\%(\\.\|[^#$()'" \t]\)\{-}\zs)"  end=";;" end="esac"me=s-1 contains=@shCaseList nextgroup=shCaseStart,shCase,shComment
- syn region  shCaseEsac	matchgroup=shConditional start="\<case\>" end="\<esac\>"	contains=@shCaseEsacList
-endif
+ShFoldIfDoFor syn region  shCase	contained skipwhite skipnl matchgroup=shSnglCase start="\%(\\.\|[^#$()'" \t]\)\{-}\zs)"  end=";;" end="esac"me=s-1 contains=@shCaseList nextgroup=shCaseStart,shCase,shComment
+ShFoldIfDoFor syn region  shCaseEsac	matchgroup=shConditional start="\<case\>" end="\<esac\>"	contains=@shCaseEsacList
+
 syn keyword shCaseIn	contained skipwhite skipnl in			nextgroup=shCase,shCaseStart,shCaseBar,shComment,shCaseExSingleQuote,shCaseSingleQuote,shCaseDoubleQuote
 if exists("b:is_bash")
  syn region  shCaseExSingleQuote	matchgroup=shQuote start=+\$'+ skip=+\\\\\|\\.+ end=+'+	contains=shStringSpecial,shSpecial	skipwhite skipnl nextgroup=shCaseBar	contained
@@ -286,7 +291,7 @@ if exists("b:is_bash")
  syn cluster shCommandSubList add=bashSpecialVariables,bashStatement
  syn cluster shCaseList add=bashAdminStatement,bashStatement
  syn keyword bashSpecialVariables contained auto_resume BASH BASH_ALIASES BASH_ALIASES BASH_ARGC BASH_ARGC BASH_ARGV BASH_ARGV BASH_CMDS BASH_CMDS BASH_COMMAND BASH_COMMAND BASH_ENV BASH_EXECUTION_STRING BASH_EXECUTION_STRING BASH_LINENO BASH_LINENO BASHOPTS BASHOPTS BASHPID BASHPID BASH_REMATCH BASH_REMATCH BASH_SOURCE BASH_SOURCE BASH_SUBSHELL BASH_SUBSHELL BASH_VERSINFO BASH_VERSION BASH_XTRACEFD BASH_XTRACEFD CDPATH COLUMNS COLUMNS COMP_CWORD COMP_CWORD COMP_KEY COMP_KEY COMP_LINE COMP_LINE COMP_POINT COMP_POINT COMPREPLY COMPREPLY COMP_TYPE COMP_TYPE COMP_WORDBREAKS COMP_WORDBREAKS COMP_WORDS COMP_WORDS COPROC COPROC DIRSTACK EMACS EMACS ENV ENV EUID FCEDIT FIGNORE FUNCNAME FUNCNAME FUNCNEST FUNCNEST GLOBIGNORE GROUPS histchars HISTCMD HISTCONTROL HISTFILE HISTFILESIZE HISTIGNORE HISTSIZE HISTTIMEFORMAT HISTTIMEFORMAT HOME HOSTFILE HOSTNAME HOSTTYPE IFS IGNOREEOF INPUTRC LANG LC_ALL LC_COLLATE LC_CTYPE LC_CTYPE LC_MESSAGES LC_NUMERIC LC_NUMERIC LINENO LINES LINES MACHTYPE MAIL MAILCHECK MAILPATH MAPFILE MAPFILE OLDPWD OPTARG OPTERR OPTIND OSTYPE PATH PIPESTATUS POSIXLY_CORRECT POSIXLY_CORRECT PPID PROMPT_COMMAND PS1 PS2 PS3 PS4 PWD RANDOM READLINE_LINE READLINE_LINE READLINE_POINT READLINE_POINT REPLY SECONDS SHELL SHELL SHELLOPTS SHLVL TIMEFORMAT TIMEOUT TMPDIR TMPDIR UID
- syn keyword bashStatement chmod clear complete du egrep expr fgrep find gnufind gnugrep grep less ls mkdir mv rm rmdir rpm sed sleep sort strip tail touch
+ syn keyword bashStatement chmod clear complete du egrep expr fgrep find gnufind gnugrep grep less ls mkdir mv rm rmdir rpm sed sleep sort strip tail 
  syn keyword bashAdminStatement daemon killall killproc nice reload restart start status stop
  syn keyword bashStatement	command compgen
 endif
@@ -295,7 +300,7 @@ if exists("b:is_kornshell")
  syn cluster shCommandSubList add=kshSpecialVariables,kshStatement
  syn cluster shCaseList add=kshStatement
  syn keyword kshSpecialVariables contained CDPATH COLUMNS EDITOR ENV ERRNO FCEDIT FPATH HISTFILE HISTSIZE HOME IFS LINENO LINES MAIL MAILCHECK MAILPATH OLDPWD OPTARG OPTIND PATH PPID PS1 PS2 PS3 PS4 PWD RANDOM REPLY SECONDS SHELL TMOUT VISUAL
- syn keyword kshStatement cat chmod clear cp du egrep expr fgrep find grep killall less ls mkdir mv nice printenv rm rmdir sed sort strip stty tail touch tput
+ syn keyword kshStatement cat chmod clear cp du egrep expr fgrep find grep killall less ls mkdir mv nice printenv rm rmdir sed sort strip stty tail tput
  syn keyword kshStatement command setgroups setsenv
 endif
 
@@ -323,7 +328,6 @@ syn region  shSingleQuote	matchgroup=shQuote start=+'+ end=+'+		contains=@Spell
 syn region  shDoubleQuote	matchgroup=shQuote start=+\%(\%(\\\\\)*\\\)\@<!"+ skip=+\\"+ end=+"+	contains=@shDblQuoteList,shStringSpecial,@Spell
 syn match   shStringSpecial	"[^[:print:] \t]"		contained
 syn match   shStringSpecial	"\%(\\\\\)*\\[\\"'`$()#]"
-" COMBAK: why is ,shComment on next line???
 syn match   shSpecial	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]"
 syn match   shSpecial	"^\%(\\\\\)*\\[\\"'`$()#]"
 syn match   shMoreSpecial	"\%(\\\\\)*\\[\\"'`$()#]"		nextgroup=shMoreSpecial contained
@@ -347,35 +351,22 @@ if version < 600
  syn region shHereDoc matchgroup=shHereDoc05 start="<<\s*\**\.\**"		matchgroup=shHereDoc05 end="^\.$"	contains=@shDblQuoteList
  syn region shHereDoc matchgroup=shHereDoc06 start="<<-\s*\**\.\**"		matchgroup=shHereDoc06 end="^\s*\.$"	contains=@shDblQuoteList
 
-elseif s:sh_fold_heredoc
- syn region shHereDoc matchgroup=shHereDoc07 fold start="<<\s*\z([^ \t|]*\)"		matchgroup=shHereDoc07 end="^\z1\s*$"	contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shHereDoc08 fold start="<<\s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc08 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc09 fold start="<<\s*'\z([^ \t|]*\)'"		matchgroup=shHereDoc09 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc10 fold start="<<-\s*\z([^ \t|]*\)"		matchgroup=shHereDoc10 end="^\s*\z1\s*$"	contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shHereDoc11 fold start="<<-\s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc11 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc12 fold start="<<-\s*'\z([^ \t|]*\)'"		matchgroup=shHereDoc12 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc13 fold start="<<\s*\\\_$\_s*\z([^ \t|]*\)"	matchgroup=shHereDoc13 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc14 fold start="<<\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc14 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc15 fold start="<<-\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shHereDoc15 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc16 fold start="<<-\s*\\\_$\_s*\z([^ \t|]*\)"	matchgroup=shHereDoc16 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc17 fold start="<<-\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc17 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc18 fold start="<<\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shHereDoc18 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc19 fold start="<<\\\z([^ \t|]*\)"		matchgroup=shHereDoc19 end="^\z1\s*$"
-
 else
- syn region shHereDoc matchgroup=shHereDoc20 start="<<\s*\\\=\z([^ \t|]*\)"		matchgroup=shHereDoc20 end="^\z1\s*$"    contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shHereDoc21 start="<<\s*\"\z([^ \t|]*\)\""		matchgroup=shHereDoc21 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc22 start="<<-\s*\z([^ \t|]*\)"		matchgroup=shHereDoc22 end="^\s*\z1\s*$" contains=@shDblQuoteList
- syn region shHereDoc matchgroup=shHereDoc23 start="<<-\s*'\z([^ \t|]*\)'"		matchgroup=shHereDoc23 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc24 start="<<\s*'\z([^ \t|]*\)'"		matchgroup=shHereDoc24 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc25 start="<<-\s*\"\z([^ \t|]*\)\""		matchgroup=shHereDoc25 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc26 start="<<\s*\\\_$\_s*\z([^ \t|]*\)"	matchgroup=shHereDoc26 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc27 start="<<-\s*\\\_$\_s*\z([^ \t|]*\)"	matchgroup=shHereDoc27 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc28 start="<<-\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shHereDoc28 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc29 start="<<\s*\\\_$\_s*'\z([^ \t|]*\)'"	matchgroup=shHereDoc29 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc30 start="<<\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc30 end="^\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc31 start="<<-\s*\\\_$\_s*\"\z([^ \t|]*\)\""	matchgroup=shHereDoc31 end="^\s*\z1\s*$"
- syn region shHereDoc matchgroup=shHereDoc32 start="<<\\\z([^ \t|]*\)"		matchgroup=shHereDoc32 end="^\z1\s*$"
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc07 start="<<\s*\\\=\z([^ \t|]\+\)"		matchgroup=shHereDoc07 end="^\z1\s*$"	contains=@shDblQuoteList
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc08 start="<<\s*\"\z([^ \t|]\+\)\""		matchgroup=shHereDoc08 end="^\z1\s*$"
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc09 start="<<-\s*\z([^ \t|]\+\)"		matchgroup=shHereDoc09 end="^\s*\z1\s*$"	contains=@shDblQuoteList
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc10 start="<<-\s*'\z([^ \t|]\+\)'"		matchgroup=shHereDoc10 end="^\s*\z1\s*$"
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc11 start="<<\s*'\z([^ \t|]\+\)'"		matchgroup=shHereDoc11 end="^\z1\s*$"
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc12 start="<<-\s*\"\z([^ \t|]\+\)\""		matchgroup=shHereDoc12 end="^\s*\z1\s*$"
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc13 start="<<\s*\\\_$\_s*\z([^ \t|]\+\)"		matchgroup=shHereDoc13 end="^\z1\s*$"           contains=@shDblQuoteList
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc14 start="<<\s*\\\_$\_s*'\z([^ \t|]\+\)'"	matchgroup=shHereDoc14 end="^\z1\s*$"
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc15 start="<<\s*\\\_$\_s*\"\z([^ \t|]\+\)\""	matchgroup=shHereDoc15 end="^\z1\s*$"
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc16 start="<<-\s*\\\_$\_s*\z([^ \t|]\+\)"	matchgroup=shHereDoc16 end="^\s*\z1\s*$"	
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc17 start="<<-\s*\\\_$\_s*\\\z([^ \t|]\+\)"	matchgroup=shHereDoc17 end="^\s*\z1\s*$"	
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc18 start="<<-\s*\\\_$\_s*'\z([^ \t|]\+\)'"	matchgroup=shHereDoc18 end="^\s*\z1\s*$"
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc19 start="<<-\s*\\\_$\_s*\"\z([^ \t|]\+\)\""	matchgroup=shHereDoc19 end="^\s*\z1\s*$"
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc20 start="<<\\\z([^ \t|]\+\)"		matchgroup=shHereDoc20 end="^\z1\s*$"
+ ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc21 start="<<-\s*\\\z([^ \t|]\+\)"		matchgroup=shHereDoc21 end="^\s*\z1\s*$"
 endif
 
 " Here Strings: {{{1
@@ -407,43 +398,35 @@ if !exists("g:is_posix")
 endif
 
 if exists("b:is_bash")
- if s:sh_fold_functions
-  syn region shFunctionOne	fold	matchgroup=shFunction start="^\s*\h[-a-zA-Z_0-9]*\s*()\_s*{"		end="}"	contains=@shFunctionList			skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
-  syn region shFunctionTwo	fold	matchgroup=shFunction start="\<[^d][^o]\&\h[-a-zA-Z_0-9]*\s*\%(()\)\=\_s*{"	end="}"	contains=shFunctionKey,@shFunctionList contained	skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
-  syn region shFunctionThree	fold	matchgroup=shFunction start="^\s*\h[-a-zA-Z_0-9]*\s*()\_s*("		end=")"	contains=@shFunctionList			skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
-  syn region shFunctionFour	fold	matchgroup=shFunction start="\<[^d][^o]\&\h[-a-zA-Z_0-9]*\s*\%(()\)\=\_s*)"	end=")"	contains=shFunctionKey,@shFunctionList contained	skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
- else
-  syn region shFunctionOne		matchgroup=shFunction start="^\s*\h[-a-zA-Z_0-9]*\s*()\_s*{"		end="}"	contains=@shFunctionList
-  syn region shFunctionTwo		matchgroup=shFunction start="\<[^d][^o]\&\h[-a-zA-Z_0-9]*\s*\%(()\)\=\_s*{"	end="}"	contains=shFunctionKey,@shFunctionList contained
-  syn region shFunctionThree		matchgroup=shFunction start="^\s*\h[-a-zA-Z_0-9]*\s*()\_s*("		end=")"	contains=@shFunctionList
-  syn region shFunctionFour		matchgroup=shFunction start="\<[^d][^o]\&\h[-a-zA-Z_0-9]*\s*\%(()\)\=\_s*("	end=")"	contains=shFunctionKey,@shFunctionList contained
- endif
+ ShFoldFunctions syn region shFunctionOne	matchgroup=shFunction start="^\s*\h[-a-zA-Z_0-9]*\s*()\_s*{"		end="}"	contains=@shFunctionList			skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
+ ShFoldFunctions syn region shFunctionTwo	matchgroup=shFunction start="\<[^d][^o]\&\h[-a-zA-Z_0-9]*\s*\%(()\)\=\_s*{"	end="}"	contains=shFunctionKey,@shFunctionList contained	skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
+ ShFoldFunctions syn region shFunctionThree	matchgroup=shFunction start="^\s*\h[-a-zA-Z_0-9]*\s*()\_s*("		end=")"	contains=@shFunctionList			skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
+ ShFoldFunctions syn region shFunctionFour	matchgroup=shFunction start="\<[^d][^o]\&\h[-a-zA-Z_0-9]*\s*\%(()\)\=\_s*)"	end=")"	contains=shFunctionKey,@shFunctionList contained	skipwhite skipnl nextgroup=shFunctionStart,shQuickComment
 else
- if s:sh_fold_functions
-  syn region shFunctionOne	fold	matchgroup=shFunction start="^\s*\h\w*\s*()\_s*{"		end="}"	contains=@shFunctionList	       skipwhite skipnl		nextgroup=shFunctionStart,shQuickComment
-  syn region shFunctionTwo	fold	matchgroup=shFunction start="\<[^d][^o]\&\h\w*\s*\%(()\)\=\_s*{"	end="}"	contains=shFunctionKey,@shFunctionList contained skipwhite skipnl	nextgroup=shFunctionStart,shQuickComment
-  syn region shFunctionThree	fold	matchgroup=shFunction start="^\s*\h\w*\s*()\_s*("		end=")"	contains=@shFunctionList	       skipwhite skipnl		nextgroup=shFunctionStart,shQuickComment
-  syn region shFunctionFour	fold	matchgroup=shFunction start="\<[^d][^o]\&\h\w*\s*\%(()\)\=\_s*("	end=")"	contains=shFunctionKey,@shFunctionList contained skipwhite skipnl	nextgroup=shFunctionStart,shQuickComment
- else
-  syn region shFunctionOne		matchgroup=shFunction start="^\s*\h\w*\s*()\_s*{"		end="}"	contains=@shFunctionList
-  syn region shFunctionTwo		matchgroup=shFunction start="\<[^d][^o]\&\h\w*\s*\%(()\)\=\_s*{"	end="}"	contains=shFunctionKey,@shFunctionList contained
-  syn region shFunctionThree		matchgroup=shFunction start="^\s*\h\w*\s*()\_s*("		end=")"	contains=@shFunctionList
-  syn region shFunctionFour		matchgroup=shFunction start="\<[^d][^o]\&\h\w*\s*\%(()\)\=\_s*("	end=")"	contains=shFunctionKey,@shFunctionList contained
- endif
+ ShFoldFunctions syn region shFunctionOne	matchgroup=shFunction start="^\s*\h\w*\s*()\_s*{"		end="}"	contains=@shFunctionList	       skipwhite skipnl		nextgroup=shFunctionStart,shQuickComment
+ ShFoldFunctions syn region shFunctionTwo	matchgroup=shFunction start="\<[^d][^o]\&\h\w*\s*\%(()\)\=\_s*{"	end="}"	contains=shFunctionKey,@shFunctionList contained skipwhite skipnl	nextgroup=shFunctionStart,shQuickComment
+ ShFoldFunctions syn region shFunctionThree	matchgroup=shFunction start="^\s*\h\w*\s*()\_s*("		end=")"	contains=@shFunctionList	       skipwhite skipnl		nextgroup=shFunctionStart,shQuickComment
+ ShFoldFunctions syn region shFunctionFour	matchgroup=shFunction start="\<[^d][^o]\&\h\w*\s*\%(()\)\=\_s*("	end=")"	contains=shFunctionKey,@shFunctionList contained skipwhite skipnl	nextgroup=shFunctionStart,shQuickComment
 endif
 
 " Parameter Dereferencing: {{{1
 " ========================
-syn match  shDerefSimple	"\$\%(\k\+\|\d\)"
-syn region shDeref	matchgroup=PreProc start="\${" end="}"	contains=@shDerefList,shDerefVarArray
 if !exists("g:sh_no_error")
  syn match  shDerefWordError	"[^}$[]"	contained
 endif
+syn match  shDerefSimple	"\$\k\+\|\d"
+syn region shDeref	matchgroup=PreProc start="\${" end="}"	contains=@shDerefList,shDerefVarArray
 syn match  shDerefSimple	"\$[-#*@!?]"
 syn match  shDerefSimple	"\$\$"
 if exists("b:is_bash") || exists("b:is_kornshell")
  syn region shDeref	matchgroup=PreProc start="\${##\=" end="}"	contains=@shDerefList
  syn region shDeref	matchgroup=PreProc start="\${\$\$" end="}"	contains=@shDerefList
+endif
+
+" ksh: ${!var[*]} array index list syntax: {{{1
+" ========================================
+if exists("b:is_kornshell")
+ syn region shDeref	matchgroup=PreProc start="\${!" end="}"	contains=@shDerefVarArray
 endif
 
 " bash: ${!prefix*} and ${#parameter}: {{{1
@@ -452,10 +435,16 @@ if exists("b:is_bash")
  syn region shDeref	matchgroup=PreProc start="\${!" end="\*\=}"	contains=@shDerefList,shDerefOp
  syn match  shDerefVar	contained	"{\@<=!\k\+"		nextgroup=@shDerefVarList
 endif
+if exists("b:is_kornshell")
+ syn match  shDerefVar	contained	"{\@<=!\k[[:alnum:]_.]*"	nextgroup=@shDerefVarList
+endif
 
 syn match  shDerefSpecial	contained	"{\@<=[-*@?0]"		nextgroup=shDerefOp,shDerefOpError
 syn match  shDerefSpecial	contained	"\({[#!]\)\@<=[[:alnum:]*@_]\+"	nextgroup=@shDerefVarList,shDerefOp
 syn match  shDerefVar	contained	"{\@<=\k\+"		nextgroup=@shDerefVarList
+if exists("b:is_kornshell")
+  syn match  shDerefVar	contained	"{\@<=\k[[:alnum:]_.]*"	nextgroup=@shDerefVarList
+endif
 
 " sh ksh bash : ${var[... ]...}  array reference: {{{1
 syn region  shDerefVarArray   contained	matchgroup=shDeref start="\[" end="]"	contains=@shCommandSubList nextgroup=shDerefOp,shDerefOpError
@@ -594,6 +583,7 @@ hi def link shHereDoc	shString
 hi def link shHerePayload	shHereDoc
 hi def link shLoop	shStatement
 hi def link shMoreSpecial	shSpecial
+hi def link shNoQuote	shDoubleQuote
 hi def link shOption	shCommandSub
 hi def link shPattern	shString
 hi def link shParen	shArithmetic
@@ -611,6 +601,7 @@ hi def link shTestOpr	shConditional
 hi def link shTestPattern	shString
 hi def link shTestDoubleQuote	shString
 hi def link shTestSingleQuote	shString
+hi def link shTouchCmd	shStatement
 hi def link shVariable	shSetList
 hi def link shWrapLineOperator	shOperator
 
@@ -688,17 +679,12 @@ hi def link shHereDoc18		shRedir
 hi def link shHereDoc19		shRedir
 hi def link shHereDoc20		shRedir
 hi def link shHereDoc21		shRedir
-hi def link shHereDoc22		shRedir
-hi def link shHereDoc23		shRedir
-hi def link shHereDoc24		shRedir
-hi def link shHereDoc25		shRedir
-hi def link shHereDoc26		shRedir
-hi def link shHereDoc27		shRedir
-hi def link shHereDoc28		shRedir
-hi def link shHereDoc29		shRedir
-hi def link shHereDoc30		shRedir
-hi def link shHereDoc31		shRedir
-hi def link shHereDoc32		shRedir
+
+" Delete shell folding commands {{{1
+" =============================
+delc ShFoldFunctions
+delc ShFoldHereDoc
+delc ShFoldIfDoFor
 
 " Set Current Syntax: {{{1
 " ===================

--- a/runtime/syntax/sqloracle.vim
+++ b/runtime/syntax/sqloracle.vim
@@ -1,13 +1,12 @@
 " Vim syntax file
-" Language:	SQL, PL/SQL (Oracle 8i)
-" Maintainer:	Paul Moore <pf_moore AT yahoo.co.uk>
-" Last Change:	2005 Dec 23
+" Language:	SQL, PL/SQL (Oracle 11g)
+" Maintainer:	Christian Brabandt
+" Repository:   https://github.com/chrisbra/vim-sqloracle-syntax
+" License:      Vim
+" Previous Maintainer:	Paul Moore
+" Last Change:	2015 Nov 24
 
-" For version 5.x: Clear all syntax items
-" For version 6.x: Quit when a syntax file was already loaded
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
+if exists("b:current_syntax")
   finish
 endif
 
@@ -15,75 +14,121 @@ syn case ignore
 
 " The SQL reserved words, defined as keywords.
 
-syn keyword sqlSpecial  false null true
+syn keyword sqlSpecial	false null true
 
-syn keyword sqlKeyword	access add as asc begin by check cluster column
-syn keyword sqlKeyword	compress connect current cursor decimal default desc
+syn keyword sqlKeyword	access add as asc begin by case check cluster column
+syn keyword sqlKeyword	cache compress connect current cursor decimal default desc
 syn keyword sqlKeyword	else elsif end exception exclusive file for from
 syn keyword sqlKeyword	function group having identified if immediate increment
-syn keyword sqlKeyword	index initial into is level loop maxextents mode modify
-syn keyword sqlKeyword	nocompress nowait of offline on online start
-syn keyword sqlKeyword	successful synonym table then to trigger uid
+syn keyword sqlKeyword	index initial initrans into is level link logging loop
+syn keyword sqlKeyword	maxextents maxtrans mode modify monitoring
+syn keyword sqlKeyword	nocache nocompress nologging noparallel nowait of offline on online start
+syn keyword sqlKeyword	parallel successful synonym table tablespace then to trigger uid
 syn keyword sqlKeyword	unique user validate values view whenever
-syn keyword sqlKeyword	where with option order pctfree privileges procedure
+syn keyword sqlKeyword	where with option order pctfree pctused privileges procedure
 syn keyword sqlKeyword	public resource return row rowlabel rownum rows
 syn keyword sqlKeyword	session share size smallint type using
 
 syn keyword sqlOperator	not and or
 syn keyword sqlOperator	in any some all between exists
 syn keyword sqlOperator	like escape
-syn keyword sqlOperator union intersect minus
-syn keyword sqlOperator prior distinct
+syn keyword sqlOperator	union intersect minus
+syn keyword sqlOperator	prior distinct
 syn keyword sqlOperator	sysdate out
 
-syn keyword sqlStatement alter analyze audit comment commit create
-syn keyword sqlStatement delete drop execute explain grant insert lock noaudit
-syn keyword sqlStatement rename revoke rollback savepoint select set
-syn keyword sqlStatement truncate update
+syn keyword sqlStatement analyze audit comment commit
+syn keyword sqlStatement delete drop execute explain grant lock noaudit
+syn keyword sqlStatement rename revoke rollback savepoint set
+syn keyword sqlStatement truncate
+" next ones are contained, so folding works.
+syn keyword sqlStatement create update alter select insert contained
 
 syn keyword sqlType	boolean char character date float integer long
 syn keyword sqlType	mlslabel number raw rowid varchar varchar2 varray
 
-" Strings and characters:
-syn region sqlString		start=+"+  skip=+\\\\\|\\"+  end=+"+
-syn region sqlString		start=+'+  skip=+\\\\\|\\'+  end=+'+
+" Strings:
+syn region sqlString	start=+"+  skip=+\\\\\|\\"+  end=+"+
+syn region sqlString	start=+'+  skip=+\\\\\|\\'+  end=+'+
 
 " Numbers:
-syn match sqlNumber		"-\=\<\d*\.\=[0-9_]\>"
+syn match sqlNumber	"-\=\<\d*\.\=[0-9_]\>"
 
 " Comments:
-syn region sqlComment    start="/\*"  end="\*/" contains=sqlTodo
-syn match sqlComment	"--.*$" contains=sqlTodo
+syn region sqlComment	start="/\*"  end="\*/" contains=sqlTodo,@Spell fold 
+syn match sqlComment	"--.*$" contains=sqlTodo,@Spell
+
+" Setup Folding:
+" this is a hack, to get certain statements folded.
+" the keywords create/update/alter/select/insert need to
+" have contained option.
+syn region sqlFold start='^\s*\zs\c\(Create\|Update\|Alter\|Select\|Insert\)' end=';$\|^$' transparent fold contains=ALL
 
 syn sync ccomment sqlComment
 
-" Todo.
-syn keyword sqlTodo contained TODO FIXME XXX DEBUG NOTE
+" Functions:
+" (Oracle 11g)
+" Aggregate Functions
+syn keyword sqlFunction	avg collect corr corr_s corr_k count covar_pop covar_samp cume_dist dense_rank first
+syn keyword sqlFunction	group_id grouping grouping_id last max median min percentile_cont percentile_disc percent_rank rank
+syn keyword sqlFunction	regr_slope regr_intercept regr_count regr_r2 regr_avgx regr_avgy regr_sxx regr_syy regr_sxy
+syn keyword sqlFunction	stats_binomial_test stats_crosstab stats_f_test stats_ks_test stats_mode stats_mw_test
+syn keyword sqlFunction	stats_one_way_anova stats_t_test_one stats_t_test_paired stats_t_test_indep stats_t_test_indepu
+syn keyword sqlFunction	stats_wsr_test stddev stddev_pop stddev_samp sum
+syn keyword sqlFunction	sys_xmlagg var_pop var_samp variance xmlagg
+" Char Functions
+syn keyword sqlFunction	ascii chr concat initcap instr length lower lpad ltrim
+syn keyword sqlFunction	nls_initcap nls_lower nlssort nls_upper regexp_instr regexp_replace
+syn keyword sqlFunction	regexp_substr replace rpad rtrim soundex substr translate treat trim upper
+" Comparison Functions
+syn keyword sqlFunction	greatest least
+" Conversion Functions
+syn keyword sqlFunction	asciistr bin_to_num cast chartorowid compose convert
+syn keyword sqlFunction	decompose hextoraw numtodsinterval numtoyminterval rawtohex rawtonhex rowidtochar
+syn keyword sqlFunction	rowidtonchar scn_to_timestamp timestamp_to_scn to_binary_double to_binary_float
+syn keyword sqlFunction	to_char to_char to_char to_clob to_date to_dsinterval to_lob to_multi_byte
+syn keyword sqlFunction	to_nchar to_nchar to_nchar to_nclob to_number to_dsinterval to_single_byte
+syn keyword sqlFunction	to_timestamp to_timestamp_tz to_yminterval to_yminterval translate unistr
+" DataMining Functions
+syn keyword sqlFunction	cluster_id cluster_probability cluster_set feature_id feature_set
+syn keyword sqlFunction	feature_value prediction prediction_bounds prediction_cost
+syn keyword sqlFunction	prediction_details prediction_probability prediction_set
+" Datetime Functions
+syn keyword sqlFunction	add_months current_date current_timestamp dbtimezone extract
+syn keyword sqlFunction	from_tz last_day localtimestamp months_between new_time
+syn keyword sqlFunction	next_day numtodsinterval numtoyminterval round sessiontimezone
+syn keyword sqlFunction	sys_extract_utc sysdate systimestamp to_char to_timestamp
+syn keyword sqlFunction	to_timestamp_tz to_dsinterval to_yminterval trunc tz_offset
+" Numeric Functions
+syn keyword sqlFunction	abs acos asin atan atan2 bitand ceil cos cosh exp
+syn keyword sqlFunction	floor ln log mod nanvl power remainder round sign
+syn keyword sqlFunction	sin sinh sqrt tan tanh trunc width_bucket
+" NLS Functions
+syn keyword sqlFunction	ls_charset_decl_len nls_charset_id nls_charset_name
+" Various Functions
+syn keyword sqlFunction	bfilename cardin coalesce collect decode dump empty_blob empty_clob
+syn keyword sqlFunction	lnnvl nullif nvl nvl2 ora_hash powermultiset powermultiset_by_cardinality
+syn keyword sqlFunction	sys_connect_by_path sys_context sys_guid sys_typeid uid user userenv vsizeality
+" XML Functions
+syn keyword sqlFunction	appendchildxml deletexml depth extract existsnode extractvalue insertchildxml
+syn keyword sqlFunction	insertxmlbefore path sys_dburigen sys_xmlagg sys_xmlgen updatexml xmlagg xmlcast
+syn keyword sqlFunction	xmlcdata xmlcolattval xmlcomment xmlconcat xmldiff xmlelement xmlexists xmlforest
+syn keyword sqlFunction	xmlparse xmlpatch xmlpi xmlquery xmlroot xmlsequence xmlserialize xmltable xmltransform
+" Todo:
+syn keyword sqlTodo TODO FIXME XXX DEBUG NOTE contained
 
 " Define the default highlighting.
-" For version 5.7 and earlier: only when not done already
-" For version 5.8 and later: only when an item doesn't have highlighting yet
-if version >= 508 || !exists("did_sql_syn_inits")
-  if version < 508
-    let did_sql_syn_inits = 1
-    command -nargs=+ HiLink hi link <args>
-  else
-    command -nargs=+ HiLink hi def link <args>
-  endif
+command -nargs=+ HiLink hi def link <args>
+HiLink sqlComment	Comment
+HiLink sqlFunction	Function
+HiLink sqlKeyword	sqlSpecial
+HiLink sqlNumber	Number
+HiLink sqlOperator	sqlStatement
+HiLink sqlSpecial	Special
+HiLink sqlStatement	Statement
+HiLink sqlString	String
+HiLink sqlType		Type
+HiLink sqlTodo		Todo
 
-  HiLink sqlComment	Comment
-  HiLink sqlKeyword	sqlSpecial
-  HiLink sqlNumber	Number
-  HiLink sqlOperator	sqlStatement
-  HiLink sqlSpecial	Special
-  HiLink sqlStatement	Statement
-  HiLink sqlString	String
-  HiLink sqlType	Type
-  HiLink sqlTodo	Todo
-
-  delcommand HiLink
-endif
-
+delcommand HiLink
 let b:current_syntax = "sql"
-
 " vim: ts=8

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -1,9 +1,10 @@
 " Vim syntax file
 " Language:	OpenSSH client configuration file (ssh_config)
 " Author:	David Necas (Yeti)
-" Maintainer:   Leonard Ehrenfried <leonard.ehrenfried@web.de>	
-" Last Change:	2012 Feb 24 
-" SSH Version:	5.9p1
+" Maintainer:	Dominik Fischer <d dot f dot fischer at web dot de>
+" Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>	
+" Last Change:	2015 Dec 3 
+" SSH Version:	7.0
 "
 
 " Setup
@@ -100,6 +101,8 @@ syn case ignore
 " Keywords
 syn keyword sshconfigHostSect Host
 
+syn keyword sshconfigMatch canonical exec host originalhost user localuser all
+
 syn keyword sshconfigKeyword AddressFamily
 syn keyword sshconfigKeyword BatchMode
 syn keyword sshconfigKeyword BindAddress
@@ -138,6 +141,7 @@ syn keyword sshconfigKeyword HostKeyAlgorithms
 syn keyword sshconfigKeyword HostKeyAlias
 syn keyword sshconfigKeyword HostName
 syn keyword sshconfigKeyword HostbasedAuthentication
+syn keyword sshconfigKeyword HostbasedKeyTypes
 syn keyword sshconfigKeyword IPQoS
 syn keyword sshconfigKeyword IdentitiesOnly
 syn keyword sshconfigKeyword IdentityFile
@@ -148,6 +152,7 @@ syn keyword sshconfigKeyword LocalCommand
 syn keyword sshconfigKeyword LocalForward
 syn keyword sshconfigKeyword LogLevel
 syn keyword sshconfigKeyword MACs
+syn keyword sshconfigKeyword Match
 syn keyword sshconfigKeyword NoHostAuthenticationForLocalhost
 syn keyword sshconfigKeyword NumberOfPasswordPrompts
 syn keyword sshconfigKeyword PKCS11Provider
@@ -157,6 +162,8 @@ syn keyword sshconfigKeyword Port
 syn keyword sshconfigKeyword PreferredAuthentications
 syn keyword sshconfigKeyword Protocol
 syn keyword sshconfigKeyword ProxyCommand
+syn keyword sshconfigKeyword ProxyUseFDPass
+syn keyword sshconfigKeyword PubkeyAcceptedKeyTypes
 syn keyword sshconfigKeyword PubkeyAuthentication
 syn keyword sshconfigKeyword RSAAuthentication
 syn keyword sshconfigKeyword RekeyLimit
@@ -211,6 +218,7 @@ if version >= 508 || !exists("did_sshconfig_syntax_inits")
   HiLink sshconfigSpecial        Special
   HiLink sshconfigKeyword        Keyword
   HiLink sshconfigHostSect       Type
+  HiLink sshconfigMatch          Type
   delcommand HiLink
 endif
 

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -1,11 +1,12 @@
 " Vim syntax file
 " Language:	OpenSSH server configuration file (sshd_config)
-" Maintainer:	David Necas (Yeti)
-" Maintainer:   Leonard Ehrenfried <leonard.ehrenfried@web.de>	
-" Modified By:	Thilo Six
+" Author:	David Necas (Yeti)
+" Maintainer:	Dominik Fischer <d dot f dot fischer at web dot de>
+" Contributor:	Thilo Six
+" Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>	
 " Originally:	2009-07-09
-" Last Change:	2011 Oct 31 
-" SSH Version:	5.9p1
+" Last Change:	2015 Dec 3 
+" SSH Version:	7.0
 "
 
 " Setup
@@ -39,6 +40,12 @@ syn keyword sshdconfigYesNo yes no none
 
 syn keyword sshdconfigAddressFamily any inet inet6
 
+syn keyword sshdconfigPrivilegeSeparation sandbox
+
+syn keyword sshdconfigTcpForwarding local remote
+
+syn keyword sshdconfigRootLogin prohibit-password without-password forced-commands-only
+
 syn keyword sshdconfigCipher aes128-cbc 3des-cbc blowfish-cbc cast128-cbc
 syn keyword sshdconfigCipher aes192-cbc aes256-cbc aes128-ctr aes192-ctr aes256-ctr
 syn keyword sshdconfigCipher arcfour arcfour128 arcfour256 cast128-cbc
@@ -49,7 +56,7 @@ syn keyword sshdconfigMAC hmac-sha2-256 hmac-sha256-96 hmac-sha2-512
 syn keyword sshdconfigMAC hmac-sha2-512-96
 syn match   sshdconfigMAC "\<umac-64@openssh\.com\>"
 
-syn keyword sshdconfigRootLogin without-password forced-commands-only
+syn keyword sshdconfigRootLogin prohibit-password without-password forced-commands-only
 
 syn keyword sshdconfigLogLevel QUIET FATAL ERROR INFO VERBOSE
 syn keyword sshdconfigLogLevel DEBUG DEBUG1 DEBUG2 DEBUG3
@@ -99,9 +106,12 @@ syn keyword sshdconfigKeyword AcceptEnv
 syn keyword sshdconfigKeyword AddressFamily
 syn keyword sshdconfigKeyword AllowAgentForwarding
 syn keyword sshdconfigKeyword AllowGroups
+syn keyword sshdconfigKeyword AllowStreamLocalForwarding
 syn keyword sshdconfigKeyword AllowTcpForwarding
 syn keyword sshdconfigKeyword AllowUsers
 syn keyword sshdconfigKeyword AuthorizedKeysFile
+syn keyword sshdconfigKeyword AuthorizedKeysCommand
+syn keyword sshdconfigKeyword AuthorizedKeysCommandUser
 syn keyword sshdconfigKeyword AuthorizedPrincipalsFile
 syn keyword sshdconfigKeyword Banner
 syn keyword sshdconfigKeyword ChallengeResponseAuthentication
@@ -122,6 +132,8 @@ syn keyword sshdconfigKeyword GSSAPIStrictAcceptorCheck
 syn keyword sshdconfigKeyword GatewayPorts
 syn keyword sshdconfigKeyword HostCertificate
 syn keyword sshdconfigKeyword HostKey
+syn keyword sshdconfigKeyword HostKeyAlgorithms
+syn keyword sshdconfigKeyword HostbasedAcceptedKeyTypes
 syn keyword sshdconfigKeyword HostbasedAuthentication
 syn keyword sshdconfigKeyword HostbasedUsesNameFromPacketOnly
 syn keyword sshdconfigKeyword IPQoS
@@ -147,15 +159,19 @@ syn keyword sshdconfigKeyword PermitBlacklistedKeys
 syn keyword sshdconfigKeyword PermitEmptyPasswords
 syn keyword sshdconfigKeyword PermitOpen
 syn keyword sshdconfigKeyword PermitRootLogin
+syn keyword sshdconfigKeyword PermitTTY
 syn keyword sshdconfigKeyword PermitTunnel
 syn keyword sshdconfigKeyword PermitUserEnvironment
+syn keyword sshdconfigKeyword PermitUserRC
 syn keyword sshdconfigKeyword PidFile
 syn keyword sshdconfigKeyword Port
 syn keyword sshdconfigKeyword PrintLastLog
 syn keyword sshdconfigKeyword PrintMotd
 syn keyword sshdconfigKeyword Protocol
+syn keyword sshdconfigKeyword PubkeyAcceptedKeyTypes
 syn keyword sshdconfigKeyword PubkeyAuthentication
 syn keyword sshdconfigKeyword RSAAuthentication
+syn keyword sshdconfigKeyword RekeyLimit
 syn keyword sshdconfigKeyword RevokedKeys
 syn keyword sshdconfigKeyword RhostsRSAAuthentication
 syn keyword sshdconfigKeyword ServerKeyBits
@@ -169,6 +185,7 @@ syn keyword sshdconfigKeyword UseDNS
 syn keyword sshdconfigKeyword UseLogin
 syn keyword sshdconfigKeyword UsePAM
 syn keyword sshdconfigKeyword UsePrivilegeSeparation
+syn keyword sshdconfigKeyword VersionAddendum
 syn keyword sshdconfigKeyword X11DisplayOffset
 syn keyword sshdconfigKeyword X11Forwarding
 syn keyword sshdconfigKeyword X11UseLocalhost
@@ -184,29 +201,32 @@ if version >= 508 || !exists("did_sshdconfig_syntax_inits")
     command -nargs=+ HiLink hi def link <args>
   endif
 
-  HiLink sshdconfigComment        Comment
-  HiLink sshdconfigTodo           Todo
-  HiLink sshdconfigHostPort       sshdconfigConstant
-  HiLink sshdconfigTime           sshdconfigConstant
-  HiLink sshdconfigNumber         sshdconfigConstant
-  HiLink sshdconfigConstant       Constant
-  HiLink sshdconfigYesNo          sshdconfigEnum
-  HiLink sshdconfigAddressFamily  sshdconfigEnum
-  HiLink sshdconfigCipher         sshdconfigEnum
-  HiLink sshdconfigMAC            sshdconfigEnum
-  HiLink sshdconfigRootLogin      sshdconfigEnum
-  HiLink sshdconfigLogLevel       sshdconfigEnum
-  HiLink sshdconfigSysLogFacility sshdconfigEnum
-  HiLink sshdconfigVar		  sshdconfigEnum
-  HiLink sshdconfigCompression    sshdconfigEnum
-  HiLink sshdconfigIPQoS	  sshdconfigEnum
-  HiLink sshdconfigKexAlgo	  sshdconfigEnum
-  HiLink sshdconfigTunnel	  sshdconfigEnum
-  HiLink sshdconfigSubsystem	  sshdconfigEnum
-  HiLink sshdconfigEnum           Function
-  HiLink sshdconfigSpecial        Special
-  HiLink sshdconfigKeyword        Keyword
-  HiLink sshdconfigMatch          Type
+  HiLink sshdconfigComment              Comment
+  HiLink sshdconfigTodo                 Todo
+  HiLink sshdconfigHostPort             sshdconfigConstant
+  HiLink sshdconfigTime                 sshdconfigConstant
+  HiLink sshdconfigNumber               sshdconfigConstant
+  HiLink sshdconfigConstant             Constant
+  HiLink sshdconfigYesNo                sshdconfigEnum
+  HiLink sshdconfigAddressFamily        sshdconfigEnum
+  HiLink sshdconfigPrivilegeSeparation  sshdconfigEnum
+  HiLink sshdconfigTcpForwarding        sshdconfigEnum
+  HiLink sshdconfigRootLogin            sshdconfigEnum
+  HiLink sshdconfigCipher               sshdconfigEnum
+  HiLink sshdconfigMAC                  sshdconfigEnum
+  HiLink sshdconfigRootLogin            sshdconfigEnum
+  HiLink sshdconfigLogLevel             sshdconfigEnum
+  HiLink sshdconfigSysLogFacility       sshdconfigEnum
+  HiLink sshdconfigVar                  sshdconfigEnum
+  HiLink sshdconfigCompression          sshdconfigEnum
+  HiLink sshdconfigIPQoS                sshdconfigEnum
+  HiLink sshdconfigKexAlgo              sshdconfigEnum
+  HiLink sshdconfigTunnel               sshdconfigEnum
+  HiLink sshdconfigSubsystem            sshdconfigEnum
+  HiLink sshdconfigEnum                 Function
+  HiLink sshdconfigSpecial              Special
+  HiLink sshdconfigKeyword              Keyword
+  HiLink sshdconfigMatch                Type
   delcommand HiLink
 endif
 

--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	TeX
 " Maintainer:	Charles E. Campbell <NdrchipO@ScampbellPfamily.AbizM>
-" Last Change:	Jun 11, 2015
-" Version:	87
+" Last Change:	Oct 19, 2015
+" Version:	89
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_TEX
 "
 " Notes: {{{1
@@ -122,6 +122,11 @@ endif
 if g:tex_fold_enabled && &fdm == "manual"
  setl fdm=syntax
 endif
+if g:tex_fold_enabled && has("folding")
+ com! -nargs=* TexFold <args> fold 
+else
+ com! -nargs=* TexFold <args> 
+endif
 
 " (La)TeX keywords: uses the characters 0-9,a-z,A-Z,192-255 only... {{{1
 " but _ is the only one that causes problems.
@@ -142,7 +147,7 @@ endif
 " Clusters: {{{1
 " --------
 syn cluster texCmdGroup		contains=texCmdBody,texComment,texDefParm,texDelimiter,texDocType,texInput,texLength,texLigature,texMathDelim,texMathOper,texNewCmd,texNewEnv,texRefZone,texSection,texBeginEnd,texBeginEndName,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle
-if !exists("s:tex_no_error") || !s:tex_no_error
+if !s:tex_no_error
  syn cluster texCmdGroup	add=texMathError
 endif
 syn cluster texEnvGroup		contains=texMatcher,texMathDelim,texSpecialChar,texStatement
@@ -156,15 +161,16 @@ else
  syn cluster texMatchGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption
  syn cluster texStyleGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texStyleStatement,texStyleMatcher
 endif
-syn cluster texPreambleMatchGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texMathZoneZ
+syn cluster texPreambleMatchGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTitle,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texMathZoneZ
 syn cluster texRefGroup		contains=texMatcher,texComment,texDelimiter
 if !exists("g:tex_no_math")
+syn cluster texPreambleMatchGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTitle,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texMathZoneZ
  syn cluster texMathZones	contains=texMathZoneV,texMathZoneW,texMathZoneX,texMathZoneY,texMathZoneZ
  syn cluster texMatchGroup	add=@texMathZones
  syn cluster texMathDelimGroup	contains=texMathDelimBad,texMathDelimKey,texMathDelimSet1,texMathDelimSet2
  syn cluster texMathMatchGroup	contains=@texMathZones,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMathDelim,texMathMatcher,texMathOper,texNewCmd,texNewEnv,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone
  syn cluster texMathZoneGroup	contains=texComment,texDelimiter,texLength,texMathDelim,texMathMatcher,texMathOper,texMathSymbol,texMathText,texRefZone,texSpecialChar,texStatement,texTypeSize,texTypeStyle
- if !exists("s:tex_no_error") || !s:tex_no_error
+ if !s:tex_no_error
   syn cluster texMathMatchGroup	add=texMathError
   syn cluster texMathZoneGroup	add=texMathError
  endif
@@ -186,7 +192,7 @@ endif
 
 " Try to flag {} and () mismatches: {{{1
 if s:tex_fast =~ 'm'
-  if !exists("s:tex_no_error") || !s:tex_no_error
+  if !s:tex_no_error
    syn region texMatcher		matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"		contains=@texMatchGroup,texError
    syn region texMatcher		matchgroup=Delimiter start="\["				end="]"		contains=@texMatchGroup,texError,@NoSpell
   else
@@ -199,15 +205,15 @@ if s:tex_fast =~ 'm'
    syn region texParen		start="("						end=")"		contains=@texMatchGroup
   endif
 endif
-if !exists("s:tex_no_error") || !s:tex_no_error
+if !s:tex_no_error
  syn match  texError		"[}\])]"
 endif
 if s:tex_fast =~ 'M'
   if !exists("g:tex_no_math")
-   if !exists("s:tex_no_error") || !s:tex_no_error
+   if !s:tex_no_error
     syn match  texMathError	"}"	contained
    endif
-   syn region texMathMatcher	matchgroup=Delimiter	start="{"          skip="\(\\\\\)*\\}"     end="}" end="%stopzone\>"	contained contains=@texMathMatchGroup
+   syn region texMathMatcher	matchgroup=Delimiter	start="{"          skip="\\\\\|\\}"     end="}" end="%stopzone\>"	contained contains=@texMathMatchGroup
   endif
 endif
 
@@ -218,7 +224,7 @@ if exists("g:tex_tex") || b:tex_stylish
   syn match texStatement	"\\[a-zA-Z@]\+"
 else
   syn match texStatement	"\\\a\+"
-  if !exists("s:tex_no_error") || !s:tex_no_error
+  if !s:tex_no_error
    syn match texError		"\\\a*@[a-zA-Z@]*"
   endif
 endif
@@ -226,7 +232,7 @@ endif
 " TeX/LaTeX delimiters: {{{1
 syn match texDelimiter		"&"
 syn match texDelimiter		"\\\\"
-"%syn match texDelimiter		"[{}]"
+" syn match texDelimiter		"[{}]"
 
 " Tex/Latex Options: {{{1
 syn match texOption		"[^\\]\zs#\d\+\|^#\d\+"
@@ -247,7 +253,7 @@ syn match texLigature		"\\\([ijolL]\|ae\|oe\|ss\|AA\|AE\|OE\)$"
 " \begin{}/\end{} section markers: {{{1
 syn match  texBeginEnd		"\\begin\>\|\\end\>" nextgroup=texBeginEndName
 if s:tex_fast =~ 'm'
-  syn region texBeginEndName		matchgroup=Delimiter	start="{"		end="}"	contained	nextgroup=texBeginEndModifier	contains=texComment
+  syn region texBeginEndName	matchgroup=Delimiter	start="{"		end="}"	contained	nextgroup=texBeginEndModifier	contains=texComment
   syn region texBeginEndModifier	matchgroup=Delimiter	start="\["		end="]"	contained	contains=texComment,@NoSpell
 endif
 
@@ -337,54 +343,27 @@ syn match texSpaceCodeChar    "`\\\=.\(\^.\)\==\(\d\|\"\x\{1,6}\|`.\)"	contained
 " Sections, subsections, etc: {{{1
 if s:tex_fast =~ 'p'
   if !exists("g:tex_nospell") || !g:tex_nospell
-   if g:tex_fold_enabled && has("folding")
-    syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											fold contains=@texFoldGroup,@texDocGroup,@Spell
-    syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								fold contains=@texFoldGroup,@texPartGroup,@Spell
-    syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							fold contains=@texFoldGroup,@texChapterGroup,@Spell
-    syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					fold contains=@texFoldGroup,@texSectionGroup,@Spell
-    syn region texSubSectionZone	matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				fold contains=@texFoldGroup,@texSubSectionGroup,@Spell
-    syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				fold contains=@texFoldGroup,@texSubSubSectionGroup,@Spell
-    syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			fold contains=@texFoldGroup,@texParaGroup,@Spell
-    syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	fold contains=@texFoldGroup,@Spell
-    syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													fold contains=@texFoldGroup,@Spell
-    syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											fold contains=@texFoldGroup,@Spell
-   else
-    syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup,@Spell
-    syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								contains=@texFoldGroup,@texPartGroup,@Spell
-    syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							contains=@texFoldGroup,@texChapterGroup,@Spell
-    syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					contains=@texFoldGroup,@texSectionGroup,@Spell
-    syn region texSubSectionZone	matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup,@Spell
-    syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSubSectionGroup,@Spell
-    syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			contains=@texFoldGroup,@texParaGroup,@Spell
-    syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	contains=@texFoldGroup,@Spell
-    syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													contains=@texFoldGroup,@Spell
-    syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											contains=@texFoldGroup,@Spell
-    syn region texSpellZone		matchgroup=texSpellZone start="%spellzone_start"	 end="%spellzone_end"												contains=@Spell
-   endif
+   TexFold syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup,@Spell
+   TexFold syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								contains=@texFoldGroup,@texPartGroup,@Spell
+   TexFold syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							contains=@texFoldGroup,@texChapterGroup,@Spell
+   TexFold syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					contains=@texFoldGroup,@texSectionGroup,@Spell
+   TexFold syn region texSubSectionZone		matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup,@Spell
+   TexFold syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSubSectionGroup,@Spell
+   TexFold syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			contains=@texFoldGroup,@texParaGroup,@Spell
+   TexFold syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	contains=@texFoldGroup,@Spell
+   TexFold syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													contains=@texFoldGroup,@Spell
+   TexFold syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											contains=@texFoldGroup,@Spell
   else
-   if g:tex_fold_enabled && has("folding")
-    syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											fold contains=@texFoldGroup,@texDocGroup
-    syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								fold contains=@texFoldGroup,@texPartGroup
-    syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							fold contains=@texFoldGroup,@texChapterGroup
-    syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					fold contains=@texFoldGroup,@texSectionGroup
-    syn region texSubSectionZone	matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				fold contains=@texFoldGroup,@texSubSectionGroup
-    syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				fold contains=@texFoldGroup,@texSubSubSectionGroup
-    syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			fold contains=@texFoldGroup,@texParaGroup
-    syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	fold contains=@texFoldGroup
-    syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													fold contains=@texFoldGroup
-    syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											fold contains=@texFoldGroup
-   else
-    syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup
-    syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								contains=@texFoldGroup,@texPartGroup
-    syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							contains=@texFoldGroup,@texChapterGroup
-    syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					contains=@texFoldGroup,@texSectionGroup
-    syn region texSubSectionZone	matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup
-    syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSubSectionGroup
-    syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			contains=@texFoldGroup,@texParaGroup
-    syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	contains=@texFoldGroup
-    syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													contains=@texFoldGroup
-    syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											contains=@texFoldGroup
-   endif
+   TexFold syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup
+   TexFold syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								contains=@texFoldGroup,@texPartGroup
+   TexFold syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							contains=@texFoldGroup,@texChapterGroup
+   TexFold syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					contains=@texFoldGroup,@texSectionGroup
+   TexFold syn region texSubSectionZone		matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup
+   TexFold syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSubSectionGroup
+   TexFold syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			contains=@texFoldGroup,@texParaGroup
+   TexFold syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	contains=@texFoldGroup
+   TexFold syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													contains=@texFoldGroup
+   TexFold syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											contains=@texFoldGroup
   endif
 endif
 
@@ -406,8 +385,8 @@ if s:tex_fast =~ 'b'
 endif
 
 " Bad Math (mismatched): {{{1
-if !exists("g:tex_no_math") && (!exists("s:tex_no_error") || !s:tex_no_error)
- syn match texBadMath		"\\end\s*{\s*\(array\|gathered\|bBpvV]matrix\|split\|smallmatrix\|xxalignat\)\s*}"
+if !exists("g:tex_no_math") && !s:tex_no_error
+ syn match texBadMath		"\\end\s*{\s*\(array\|gathered\|bBpvV]matrix\|split\|subequations\|smallmatrix\|xxalignat\)\s*}"
  syn match texBadMath		"\\end\s*{\s*\(align\|alignat\|displaymath\|displaymath\|eqnarray\|equation\|flalign\|gather\|math\|multline\|xalignat\)\*\=\s*}"
  syn match texBadMath		"\\[\])]"
 endif
@@ -456,8 +435,9 @@ if !exists("g:tex_no_math")
  call TexNewMathZone("G","gather",1)
  call TexNewMathZone("H","math",1)
  call TexNewMathZone("I","multline",1)
- call TexNewMathZone("J","xalignat",1)
- call TexNewMathZone("K","xxalignat",0)
+ call TexNewMathZone("J","subequations",0)
+ call TexNewMathZone("K","xalignat",1)
+ call TexNewMathZone("L","xxalignat",0)
 
  " Inline Math Zones: {{{2
  if s:tex_fast =~ 'M'
@@ -573,25 +553,23 @@ syn case ignore
 syn keyword texTodo		contained		combak	fixme	todo	xxx
 syn case match
 if s:extfname == "dtx"
-  syn match texComment		"\^\^A.*$"	contains=@texCommentGroup
-  syn match texComment		"^%\+"		contains=@texCommentGroup
+ syn match texComment		"\^\^A.*$"	contains=@texCommentGroup
+ syn match texComment		"^%\+"		contains=@texCommentGroup
 else
-  if g:tex_fold_enabled
-   " allows syntax-folding of 2 or more contiguous comment lines
-   " single-line comments are not folded
-   syn match  texComment	"%.*$"			contains=@texCommentGroup
-   if s:tex_fast =~ 'c'
-    syn region texComment	start="^\zs\s*%.*\_s*%"	skip="^\s*%"	end='^\ze\s*[^%]' fold
-    syn region texNoSpell	contained		matchgroup=texComment start="%\s*nospell\s*{"		end="%\s*nospell\s*}"	fold contains=@texFoldGroup,@NoSpell
-    syn region texSpellZone		 		matchgroup=texComment start="%\s*spellzone_start"	end="%\s*spellzone_end"	fold contains=@Spell,@texFoldGroup
-   endif
-  else
-   syn match texComment		"%.*$"			contains=@texCommentGroup
-   if s:tex_fast =~ 'c'
-    syn region texNoSpell	contained		matchgroup=texComment start="%\s*nospell\s*{"		end="%\s*nospell\s*}"	contains=@texFoldGroup,@NoSpell
-    syn region  texSpellZone		 		matchgroup=texComment start="%\s*spellzone_start"	end="%\s*spellzone_end"	contains=@Spell,@texFoldGroup
-   endif
+ if g:tex_fold_enabled
+  " allows syntax-folding of 2 or more contiguous comment lines
+  " single-line comments are not folded
+  syn match  texComment	"%.*$"			contains=@texCommentGroup
+  if s:tex_fast =~ 'c'
+   TexFold syn region texComment						start="^\zs\s*%.*\_s*%"	skip="^\s*%"	end='^\ze\s*[^%]'
+   TexFold syn region texNoSpell	contained	matchgroup=texComment	start="%\s*nospell\s*{"	end="%\s*nospell\s*}"	contains=@texFoldGroup,@NoSpell
   endif
+ else
+  syn match texComment		"%.*$"			contains=@texCommentGroup
+  if s:tex_fast =~ 'c'
+   syn region texNoSpell	contained		matchgroup=texComment start="%\s*nospell\s*{"	end="%\s*nospell\s*}"	contains=@texFoldGroup,@NoSpell
+  endif
+ endif
 endif
 
 " Separate lines used for verb` and verb# so that the end conditions {{{1
@@ -673,7 +651,7 @@ syn match  texLength		"\<\d\+\([.,]\d\+\)\=\s*\(true\)\=\s*\(bp\|cc\|cm\|dd\|em\
 syn match texString		"\(``\|''\|,,\)"
 
 " makeatletter -- makeatother sections
-if !exists("s:tex_no_error") || !s:tex_no_error
+if !s:tex_no_error
  if s:tex_fast =~ 'S'
   syn region texStyle			matchgroup=texStatement start='\\makeatletter' end='\\makeatother'	contains=@texStyleGroup contained
  endif
@@ -1353,6 +1331,7 @@ if did_tex_syntax_inits == 1
 endif
 
 " Cleanup: {{{1
+delc TexFold
 unlet s:extfname
 let   b:current_syntax = "tex"
 let &cpo               = s:keepcpo

--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	TeX
 " Maintainer:	Charles E. Campbell <NdrchipO@ScampbellPfamily.AbizM>
-" Last Change:	Oct 19, 2015
-" Version:	89
+" Last Change:	Oct 20, 2015
+" Version:	90
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_TEX
 "
 " Notes: {{{1
@@ -62,11 +62,6 @@ if version >= 508 || !exists("did_tex_syntax_inits")
   command -nargs=+ HiLink hi def link <args>
  endif
 endif
-if exists("g:tex_no_error") && g:tex_no_error
- let s:tex_no_error= 1
-else
- let s:tex_no_error= 0
-endif
 
 " by default, enable all region-based highlighting
 let s:tex_fast= "bcmMprsSvV"
@@ -78,8 +73,6 @@ if exists("g:tex_fast")
  else
   let s:tex_fast= g:tex_fast
  endif
-else
- let s:tex_fast= "bcmMprsSvV"
 endif
 
 " let user determine which classes of concealment will be supported
@@ -114,15 +107,17 @@ endif
 
 " handle folding {{{1
 if !exists("g:tex_fold_enabled")
- let g:tex_fold_enabled= 0
+ let s:tex_fold_enabled= 0
 elseif g:tex_fold_enabled && !has("folding")
- let g:tex_fold_enabled= 0
+ let s:tex_fold_enabled= 0
  echomsg "Ignoring g:tex_fold_enabled=".g:tex_fold_enabled."; need to re-compile vim for +fold support"
+else
+ let s:tex_fold_enabled= 1
 endif
-if g:tex_fold_enabled && &fdm == "manual"
+if s:tex_fold_enabled && &fdm == "manual"
  setl fdm=syntax
 endif
-if g:tex_fold_enabled && has("folding")
+if s:tex_fold_enabled && has("folding")
  com! -nargs=* TexFold <args> fold 
 else
  com! -nargs=* TexFold <args> 
@@ -140,41 +135,53 @@ endif
 if b:tex_stylish
   setlocal isk+=@-@
 endif
-if exists("g:tex_nospell") && g:tex_nospell && !exists("g:tex_comment_nospell")
- let g:tex_comment_nospell= 1
+if exists("g:tex_no_error") && g:tex_no_error
+ let s:tex_no_error= 1
+else
+ let s:tex_no_error= 0
+endif
+if exists("g:tex_comment_nospell") && g:tex_comment_nospell
+ let s:tex_comment_nospell= 1
+else
+ let s:tex_comment_nospell= 0
+endif
+if exists("g:tex_nospell") && g:tex_nospell
+ let s:tex_nospell = 1
+else
+ let s:tex_nospell = 0
 endif
 
 " Clusters: {{{1
 " --------
-syn cluster texCmdGroup		contains=texCmdBody,texComment,texDefParm,texDelimiter,texDocType,texInput,texLength,texLigature,texMathDelim,texMathOper,texNewCmd,texNewEnv,texRefZone,texSection,texBeginEnd,texBeginEndName,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle
+syn cluster texCmdGroup			contains=texCmdBody,texComment,texDefParm,texDelimiter,texDocType,texInput,texLength,texLigature,texMathDelim,texMathOper,texNewCmd,texNewEnv,texRefZone,texSection,texBeginEnd,texBeginEndName,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle
 if !s:tex_no_error
- syn cluster texCmdGroup	add=texMathError
+ syn cluster texCmdGroup		add=texMathError
 endif
-syn cluster texEnvGroup		contains=texMatcher,texMathDelim,texSpecialChar,texStatement
-syn cluster texFoldGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texInputFile,texLength,texLigature,texMatcher,texMathZoneV,texMathZoneW,texMathZoneX,texMathZoneY,texMathZoneZ,texNewCmd,texNewEnv,texOnlyMath,texOption,texParen,texRefZone,texSection,texBeginEnd,texSectionZone,texSpaceCode,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,@texMathZones,texTitle,texAbstract,texBoldStyle,texItalStyle,texNoSpell
-syn cluster texBoldGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texInputFile,texLength,texLigature,texMatcher,texMathZoneV,texMathZoneW,texMathZoneX,texMathZoneY,texMathZoneZ,texNewCmd,texNewEnv,texOnlyMath,texOption,texParen,texRefZone,texSection,texBeginEnd,texSectionZone,texSpaceCode,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,@texMathZones,texTitle,texAbstract,texBoldStyle,texBoldItalStyle,texNoSpell
-syn cluster texItalGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texInputFile,texLength,texLigature,texMatcher,texMathZoneV,texMathZoneW,texMathZoneX,texMathZoneY,texMathZoneZ,texNewCmd,texNewEnv,texOnlyMath,texOption,texParen,texRefZone,texSection,texBeginEnd,texSectionZone,texSpaceCode,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,@texMathZones,texTitle,texAbstract,texItalStyle,texItalBoldStyle,texNoSpell
-if !exists("g:tex_nospell") || !g:tex_nospell
- syn cluster texMatchGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,@Spell
- syn cluster texStyleGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texStyleStatement,@Spell,texStyleMatcher
+syn cluster texEnvGroup			contains=texMatcher,texMathDelim,texSpecialChar,texStatement
+syn cluster texFoldGroup		contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texInputFile,texLength,texLigature,texMatcher,texMathZoneV,texMathZoneW,texMathZoneX,texMathZoneY,texMathZoneZ,texNewCmd,texNewEnv,texOnlyMath,texOption,texParen,texRefZone,texSection,texBeginEnd,texSectionZone,texSpaceCode,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,@texMathZones,texTitle,texAbstract,texBoldStyle,texItalStyle,texNoSpell
+syn cluster texBoldGroup		contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texInputFile,texLength,texLigature,texMatcher,texMathZoneV,texMathZoneW,texMathZoneX,texMathZoneY,texMathZoneZ,texNewCmd,texNewEnv,texOnlyMath,texOption,texParen,texRefZone,texSection,texBeginEnd,texSectionZone,texSpaceCode,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,@texMathZones,texTitle,texAbstract,texBoldStyle,texBoldItalStyle,texNoSpell
+syn cluster texItalGroup		contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texInputFile,texLength,texLigature,texMatcher,texMathZoneV,texMathZoneW,texMathZoneX,texMathZoneY,texMathZoneZ,texNewCmd,texNewEnv,texOnlyMath,texOption,texParen,texRefZone,texSection,texBeginEnd,texSectionZone,texSpaceCode,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,@texMathZones,texTitle,texAbstract,texItalStyle,texItalBoldStyle,texNoSpell
+if !s:tex_nospell
+ syn cluster texMatchGroup		contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,@Spell
+ syn cluster texStyleGroup		contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texStyleStatement,@Spell,texStyleMatcher
 else
- syn cluster texMatchGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption
- syn cluster texStyleGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texStyleStatement,texStyleMatcher
+ syn cluster texMatchGroup		contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption
+ syn cluster texStyleGroup		contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texStyleStatement,texStyleMatcher
 endif
 syn cluster texPreambleMatchGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTitle,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texMathZoneZ
-syn cluster texRefGroup		contains=texMatcher,texComment,texDelimiter
+syn cluster texRefGroup			contains=texMatcher,texComment,texDelimiter
 if !exists("g:tex_no_math")
-syn cluster texPreambleMatchGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTitle,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texMathZoneZ
- syn cluster texMathZones	contains=texMathZoneV,texMathZoneW,texMathZoneX,texMathZoneY,texMathZoneZ
- syn cluster texMatchGroup	add=@texMathZones
- syn cluster texMathDelimGroup	contains=texMathDelimBad,texMathDelimKey,texMathDelimSet1,texMathDelimSet2
- syn cluster texMathMatchGroup	contains=@texMathZones,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMathDelim,texMathMatcher,texMathOper,texNewCmd,texNewEnv,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone
- syn cluster texMathZoneGroup	contains=texComment,texDelimiter,texLength,texMathDelim,texMathMatcher,texMathOper,texMathSymbol,texMathText,texRefZone,texSpecialChar,texStatement,texTypeSize,texTypeStyle
+ syn cluster texPreambleMatchGroup	contains=texAccent,texBadMath,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMatcher,texNewCmd,texNewEnv,texOnlyMath,texParen,texRefZone,texSection,texSpecialChar,texStatement,texString,texTitle,texTypeSize,texTypeStyle,texZone,texInputFile,texOption,texMathZoneZ
+ syn cluster texMathZones		contains=texMathZoneV,texMathZoneW,texMathZoneX,texMathZoneY,texMathZoneZ
+ syn cluster texMatchGroup		add=@texMathZones
+ syn cluster texMathDelimGroup		contains=texMathDelimBad,texMathDelimKey,texMathDelimSet1,texMathDelimSet2
+ syn cluster texMathMatchGroup		contains=@texMathZones,texComment,texDefCmd,texDelimiter,texDocType,texInput,texLength,texLigature,texMathDelim,texMathMatcher,texMathOper,texNewCmd,texNewEnv,texRefZone,texSection,texSpecialChar,texStatement,texString,texTypeSize,texTypeStyle,texZone
+ syn cluster texMathZoneGroup		contains=texComment,texDelimiter,texLength,texMathDelim,texMathMatcher,texMathOper,texMathSymbol,texMathText,texRefZone,texSpecialChar,texStatement,texTypeSize,texTypeStyle
  if !s:tex_no_error
-  syn cluster texMathMatchGroup	add=texMathError
-  syn cluster texMathZoneGroup	add=texMathError
+  syn cluster texMathMatchGroup		add=texMathError
+  syn cluster texMathZoneGroup		add=texMathError
  endif
- syn cluster texMathZoneGroup add=@NoSpell
+ syn cluster texMathZoneGroup		add=@NoSpell
  " following used in the \part \chapter \section \subsection \subsubsection
  " \paragraph \subparagraph \author \title highlighting
  syn cluster texDocGroup		contains=texPartZone,@texPartGroup
@@ -185,24 +192,24 @@ syn cluster texPreambleMatchGroup	contains=texAccent,texBadMath,texComment,texDe
  syn cluster texSubSubSectionGroup	contains=texParaZone
  syn cluster texParaGroup		contains=texSubParaZone
  if has("conceal") && &enc == 'utf-8'
-  syn cluster texMathZoneGroup	add=texGreek,texSuperscript,texSubscript,texMathSymbol
-  syn cluster texMathMatchGroup	add=texGreek,texSuperscript,texSubscript,texMathSymbol
+  syn cluster texMathZoneGroup		add=texGreek,texSuperscript,texSubscript,texMathSymbol
+  syn cluster texMathMatchGroup		add=texGreek,texSuperscript,texSubscript,texMathSymbol
  endif
 endif
 
 " Try to flag {} and () mismatches: {{{1
 if s:tex_fast =~ 'm'
   if !s:tex_no_error
-   syn region texMatcher		matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"		contains=@texMatchGroup,texError
-   syn region texMatcher		matchgroup=Delimiter start="\["				end="]"		contains=@texMatchGroup,texError,@NoSpell
+   syn region texMatcher		matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"		transparent contains=@texMatchGroup,texError
+   syn region texMatcher		matchgroup=Delimiter start="\["				end="]"		transparent contains=@texMatchGroup,texError,@NoSpell
   else
-   syn region texMatcher		matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"		contains=@texMatchGroup
-   syn region texMatcher		matchgroup=Delimiter start="\["				end="]"		contains=@texMatchGroup
+   syn region texMatcher		matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"		transparent contains=@texMatchGroup
+   syn region texMatcher		matchgroup=Delimiter start="\["				end="]"		transparent contains=@texMatchGroup
   endif
-  if !exists("g:tex_nospell") || !g:tex_nospell
-   syn region texParen		start="("						end=")"		contains=@texMatchGroup,@Spell
+  if !s:tex_nospell
+   syn region texParen		start="("						end=")"		transparent contains=@texMatchGroup,@Spell
   else
-   syn region texParen		start="("						end=")"		contains=@texMatchGroup
+   syn region texParen		start="("						end=")"		transparent contains=@texMatchGroup
   endif
 endif
 if !s:tex_no_error
@@ -213,7 +220,7 @@ if s:tex_fast =~ 'M'
    if !s:tex_no_error
     syn match  texMathError	"}"	contained
    endif
-   syn region texMathMatcher	matchgroup=Delimiter	start="{"          skip="\\\\\|\\}"     end="}" end="%stopzone\>"	contained contains=@texMathMatchGroup
+   syn region texMathMatcher	matchgroup=Delimiter	start="{"          skip="\%(\\\\\)*\\}"     end="}" end="%stopzone\>"	contained contains=@texMathMatchGroup
   endif
 endif
 
@@ -232,7 +239,6 @@ endif
 " TeX/LaTeX delimiters: {{{1
 syn match texDelimiter		"&"
 syn match texDelimiter		"\\\\"
-" syn match texDelimiter		"[{}]"
 
 " Tex/Latex Options: {{{1
 syn match texOption		"[^\\]\zs#\d\+\|^#\d\+"
@@ -253,7 +259,7 @@ syn match texLigature		"\\\([ijolL]\|ae\|oe\|ss\|AA\|AE\|OE\)$"
 " \begin{}/\end{} section markers: {{{1
 syn match  texBeginEnd		"\\begin\>\|\\end\>" nextgroup=texBeginEndName
 if s:tex_fast =~ 'm'
-  syn region texBeginEndName	matchgroup=Delimiter	start="{"		end="}"	contained	nextgroup=texBeginEndModifier	contains=texComment
+  syn region texBeginEndName		matchgroup=Delimiter	start="{"		end="}"	contained	nextgroup=texBeginEndModifier	contains=texComment
   syn region texBeginEndModifier	matchgroup=Delimiter	start="\["		end="]"	contained	contains=texComment,@NoSpell
 endif
 
@@ -264,7 +270,7 @@ if s:tex_fast =~ 'm'
 endif
 
 " Preamble syntax-based folding support: {{{1
-if g:tex_fold_enabled && has("folding")
+if s:tex_fold_enabled && has("folding")
  syn region texPreamble	transparent fold	start='\zs\\documentclass\>' end='\ze\\begin{document}'	contains=texStyle,@texPreambleMatchGroup
 endif
 
@@ -342,28 +348,28 @@ syn match texSpaceCodeChar    "`\\\=.\(\^.\)\==\(\d\|\"\x\{1,6}\|`.\)"	contained
 
 " Sections, subsections, etc: {{{1
 if s:tex_fast =~ 'p'
-  if !exists("g:tex_nospell") || !g:tex_nospell
-   TexFold syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup,@Spell
-   TexFold syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								contains=@texFoldGroup,@texPartGroup,@Spell
-   TexFold syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							contains=@texFoldGroup,@texChapterGroup,@Spell
-   TexFold syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					contains=@texFoldGroup,@texSectionGroup,@Spell
-   TexFold syn region texSubSectionZone		matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup,@Spell
-   TexFold syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSubSectionGroup,@Spell
-   TexFold syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			contains=@texFoldGroup,@texParaGroup,@Spell
-   TexFold syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	contains=@texFoldGroup,@Spell
-   TexFold syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													contains=@texFoldGroup,@Spell
-   TexFold syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											contains=@texFoldGroup,@Spell
-  else
-   TexFold syn region texDocZone		matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup
-   TexFold syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								contains=@texFoldGroup,@texPartGroup
-   TexFold syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							contains=@texFoldGroup,@texChapterGroup
-   TexFold syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					contains=@texFoldGroup,@texSectionGroup
-   TexFold syn region texSubSectionZone		matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup
-   TexFold syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSubSectionGroup
-   TexFold syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			contains=@texFoldGroup,@texParaGroup
-   TexFold syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	contains=@texFoldGroup
-   TexFold syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													contains=@texFoldGroup
-   TexFold syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											contains=@texFoldGroup
+ if !s:tex_nospell
+  TexFold syn region texDocZone			matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup,@Spell
+  TexFold syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								contains=@texFoldGroup,@texPartGroup,@Spell
+  TexFold syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							contains=@texFoldGroup,@texChapterGroup,@Spell
+  TexFold syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					contains=@texFoldGroup,@texSectionGroup,@Spell
+  TexFold syn region texSubSectionZone		matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup,@Spell
+  TexFold syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSubSectionGroup,@Spell
+  TexFold syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			contains=@texFoldGroup,@texParaGroup,@Spell
+  TexFold syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	contains=@texFoldGroup,@Spell
+  TexFold syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													contains=@texFoldGroup,@Spell
+  TexFold syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											contains=@texFoldGroup,@Spell
+ else
+  TexFold syn region texDocZone			matchgroup=texSection start='\\begin\s*{\s*document\s*}' end='\\end\s*{\s*document\s*}'											contains=@texFoldGroup,@texDocGroup
+  TexFold syn region texPartZone		matchgroup=texSection start='\\part\>'			 end='\ze\s*\\\%(part\>\|end\s*{\s*document\s*}\)'								contains=@texFoldGroup,@texPartGroup
+  TexFold syn region texChapterZone		matchgroup=texSection start='\\chapter\>'		 end='\ze\s*\\\%(chapter\>\|part\>\|end\s*{\s*document\s*}\)'							contains=@texFoldGroup,@texChapterGroup
+  TexFold syn region texSectionZone		matchgroup=texSection start='\\section\>'		 end='\ze\s*\\\%(section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'					contains=@texFoldGroup,@texSectionGroup
+  TexFold syn region texSubSectionZone		matchgroup=texSection start='\\subsection\>'		 end='\ze\s*\\\%(\%(sub\)\=section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSectionGroup
+  TexFold syn region texSubSubSectionZone	matchgroup=texSection start='\\subsubsection\>'		 end='\ze\s*\\\%(\%(sub\)\{,2}section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'				contains=@texFoldGroup,@texSubSubSectionGroup
+  TexFold syn region texParaZone		matchgroup=texSection start='\\paragraph\>'		 end='\ze\s*\\\%(paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'			contains=@texFoldGroup,@texParaGroup
+  TexFold syn region texSubParaZone		matchgroup=texSection start='\\subparagraph\>'		 end='\ze\s*\\\%(\%(sub\)\=paragraph\>\|\%(sub\)*section\>\|chapter\>\|part\>\|end\s*{\s*document\s*}\)'	contains=@texFoldGroup
+  TexFold syn region texTitle			matchgroup=texSection start='\\\%(author\|title\)\>\s*{' end='}'													contains=@texFoldGroup
+  TexFold syn region texAbstract		matchgroup=texSection start='\\begin\s*{\s*abstract\s*}' end='\\end\s*{\s*abstract\s*}'											contains=@texFoldGroup
   endif
 endif
 
@@ -400,7 +406,7 @@ if !exists("g:tex_no_math")
  fun! TexNewMathZone(sfx,mathzone,starform)
    let grpname  = "texMathZone".a:sfx
    let syncname = "texSyncMathZone".a:sfx
-   if g:tex_fold_enabled
+   if s:tex_fold_enabled
     let foldcmd= " fold"
    else
     let foldcmd= ""
@@ -449,7 +455,7 @@ if !exists("g:tex_no_math")
   else
    syn region texMathZoneV	matchgroup=Delimiter start="\\("			matchgroup=Delimiter	end="\\)\|%stopzone\>"			keepend contains=@texMathZoneGroup
    syn region texMathZoneW	matchgroup=Delimiter start="\\\["			matchgroup=Delimiter	end="\\]\|%stopzone\>"			keepend contains=@texMathZoneGroup
-   syn region texMathZoneX	matchgroup=Delimiter start="\$" skip="\\\\\|\\\$"	matchgroup=Delimiter	end="\$"	end="%stopzone\>"		contains=@texMathZoneGroup
+   syn region texMathZoneX	matchgroup=Delimiter start="\$" skip="\%(\\\\\)*\\\$"	matchgroup=Delimiter	end="\$"	end="%stopzone\>"		contains=@texMathZoneGroup
    syn region texMathZoneY	matchgroup=Delimiter start="\$\$" 			matchgroup=Delimiter	end="\$\$"	end="%stopzone\>"	keepend	contains=@texMathZoneGroup
   endif
   syn region texMathZoneZ	matchgroup=texStatement start="\\ensuremath\s*{"	matchgroup=texStatement	end="}"		end="%stopzone\>"	contains=@texMathZoneGroup
@@ -544,7 +550,7 @@ endif
 " Comments: {{{1
 "    Normal TeX LaTeX     :   %....
 "    Documented TeX Format:  ^^A...	-and-	leading %s (only)
-if !exists("g:tex_comment_nospell") || !g:tex_comment_nospell
+if !s:tex_comment_nospell
  syn cluster texCommentGroup	contains=texTodo,@Spell
 else
  syn cluster texCommentGroup	contains=texTodo,@NoSpell
@@ -556,18 +562,18 @@ if s:extfname == "dtx"
  syn match texComment		"\^\^A.*$"	contains=@texCommentGroup
  syn match texComment		"^%\+"		contains=@texCommentGroup
 else
- if g:tex_fold_enabled
+ if s:tex_fold_enabled
   " allows syntax-folding of 2 or more contiguous comment lines
   " single-line comments are not folded
-  syn match  texComment	"%.*$"			contains=@texCommentGroup
+  syn match  texComment	"%.*$"				contains=@texCommentGroup
   if s:tex_fast =~ 'c'
-   TexFold syn region texComment						start="^\zs\s*%.*\_s*%"	skip="^\s*%"	end='^\ze\s*[^%]'
-   TexFold syn region texNoSpell	contained	matchgroup=texComment	start="%\s*nospell\s*{"	end="%\s*nospell\s*}"	contains=@texFoldGroup,@NoSpell
+   TexFold syn region texComment						start="^\zs\s*%.*\_s*%"	skip="^\s*%"	end='^\ze\s*[^%]'	contains=@texCommentGroup
+   TexFold syn region texNoSpell	contained	matchgroup=texComment	start="%\s*nospell\s*{"	end="%\s*nospell\s*}"			contains=@texFoldGroup,@NoSpell
   endif
  else
   syn match texComment		"%.*$"			contains=@texCommentGroup
   if s:tex_fast =~ 'c'
-   syn region texNoSpell	contained		matchgroup=texComment start="%\s*nospell\s*{"	end="%\s*nospell\s*}"	contains=@texFoldGroup,@NoSpell
+   syn region texNoSpell		contained	matchgroup=texComment start="%\s*nospell\s*{"	end="%\s*nospell\s*}"	contains=@texFoldGroup,@NoSpell
   endif
  endif
 endif

--- a/runtime/syntax/vhdl.vim
+++ b/runtime/syntax/vhdl.vim
@@ -4,7 +4,6 @@
 " Previous Maintainer:	Czo <Olivier.Sirol@lip6.fr>
 " Credits:	Stephan Hegel <stephan.hegel@snc.siemens.com.cn>
 " Last Changed:	2015 Oct 13 by Daniel Kho
-" $Id: vhdl.vim,v 1.1 2004/06/13 15:34:56 vimboss Exp $
 
 " VHSIC (Very High Speed Integrated Circuit) Hardware Description Language
 

--- a/runtime/syntax/vhdl.vim
+++ b/runtime/syntax/vhdl.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Daniel Kho <daniel.kho@tauhop.com>
 " Previous Maintainer:	Czo <Olivier.Sirol@lip6.fr>
 " Credits:	Stephan Hegel <stephan.hegel@snc.siemens.com.cn>
-" Last Changed:	2015 Oct 13 by Daniel Kho
+" Last Changed:	2015 Dec 4 by Daniel Kho
 
 " VHSIC (Very High Speed Integrated Circuit) Hardware Description Language
 
@@ -18,145 +18,124 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-" This is not VHDL. I use the C-Preprocessor cpp to generate different binaries
-" from one VHDL source file. Unfortunately there is no preprocessor for VHDL
-" available. If you don't like this, please remove the following lines.
-"syn match cDefine "^#ifdef[ ]\+[A-Za-z_]\+"
-"syn match cDefine "^#endif"
-
 " case is not significant
-syn case ignore
+syn case	ignore
 
 " VHDL keywords
-syn keyword vhdlStatement access after alias all assert
-syn keyword vhdlStatement architecture array attribute
-syn keyword vhdlStatement assume assume_guarantee
-syn keyword vhdlStatement begin block body buffer bus
-syn keyword vhdlStatement case component configuration constant
-syn keyword vhdlStatement context cover
-syn keyword vhdlStatement default disconnect downto
-syn keyword vhdlStatement elsif end entity exit
-syn keyword vhdlStatement file for function
-syn keyword vhdlStatement fairness force
-syn keyword vhdlStatement generate generic group guarded
-syn keyword vhdlStatement impure in inertial inout is
-syn keyword vhdlStatement label library linkage literal loop
-syn keyword vhdlStatement map
-syn keyword vhdlStatement new next null
-syn keyword vhdlStatement of on open others out
-syn keyword vhdlStatement package port postponed procedure process pure
-syn keyword vhdlStatement parameter property protected
-syn keyword vhdlStatement range record register reject report return
-syn keyword vhdlStatement release restrict restrict_guarantee
-syn keyword vhdlStatement select severity signal shared
-syn keyword vhdlStatement subtype
-syn keyword vhdlStatement sequence strong
-syn keyword vhdlStatement then to transport type
-syn keyword vhdlStatement unaffected units until use
-syn keyword vhdlStatement variable
-syn keyword vhdlStatement vmode vprop vunit
-syn keyword vhdlStatement wait when while with
-syn keyword vhdlStatement note warning error failure
+syn keyword	vhdlStatement	access after alias all assert
+syn keyword 	vhdlStatement	architecture array attribute
+syn keyword 	vhdlStatement	assume assume_guarantee
+syn keyword 	vhdlStatement	begin block body buffer bus
+syn keyword 	vhdlStatement	case component configuration constant
+syn keyword 	vhdlStatement	context cover
+syn keyword 	vhdlStatement	default disconnect downto
+syn keyword 	vhdlStatement	elsif end entity exit
+syn keyword 	vhdlStatement	file for function
+syn keyword 	vhdlStatement	fairness force
+syn keyword 	vhdlStatement	generate generic group guarded
+syn keyword 	vhdlStatement	impure in inertial inout is
+syn keyword 	vhdlStatement	label library linkage literal loop
+syn keyword 	vhdlStatement	map
+syn keyword 	vhdlStatement	new next null
+syn keyword 	vhdlStatement	of on open others out
+syn keyword 	vhdlStatement	package port postponed procedure process pure
+syn keyword 	vhdlStatement	parameter property protected
+syn keyword 	vhdlStatement	range record register reject report return
+syn keyword 	vhdlStatement	release restrict restrict_guarantee
+syn keyword 	vhdlStatement	select severity signal shared
+syn keyword 	vhdlStatement	subtype
+syn keyword 	vhdlStatement	sequence strong
+syn keyword 	vhdlStatement	then to transport type
+syn keyword 	vhdlStatement	unaffected units until use
+syn keyword 	vhdlStatement	variable
+syn keyword 	vhdlStatement	vmode vprop vunit
+syn keyword 	vhdlStatement	wait when while with
+syn keyword 	vhdlStatement	note warning error failure
 
-" Special match for "if" and "else" since "else if" shouldn't be highlighted.
-" The right keyword is "elsif"
-syn match   vhdlStatement "\<\(if\|else\)\>"
-syn match   vhdlNone      "\<else\s\+if\>$"
-syn match   vhdlNone      "\<else\s\+if\>\s"
+" Linting of conditionals.
+syn match	vhdlStatement	"\<\(if\|else\)\>"
+syn match	vhdlError	"\<else\s\+if\>"
 
 " Predefined VHDL types
-syn keyword vhdlType bit bit_vector
-syn keyword vhdlType character boolean integer real time
-syn keyword vhdlType boolean_vector integer_vector real_vector time_vector
-syn keyword vhdlType string severity_level
+syn keyword	vhdlType	bit bit_vector
+syn keyword	vhdlType	character boolean integer real time
+syn keyword	vhdlType	boolean_vector integer_vector real_vector time_vector
+syn keyword	vhdlType	string severity_level
 " Predefined standard ieee VHDL types
-syn keyword vhdlType positive natural signed unsigned
-syn keyword vhdlType unresolved_signed unresolved_unsigned u_signed u_unsigned 
-syn keyword vhdlType line text
-syn keyword vhdlType std_logic std_logic_vector
-syn keyword vhdlType std_ulogic std_ulogic_vector
-" Predefined non standard VHDL types for Mentor Graphics Sys1076/QuickHDL
-"syn keyword vhdlType qsim_state qsim_state_vector
-"syn keyword vhdlType qsim_12state qsim_12state_vector
-"syn keyword vhdlType qsim_strength
-" Predefined non standard VHDL types for Alliance VLSI CAD
-"syn keyword vhdlType mux_bit mux_vector reg_bit reg_vector wor_bit wor_vector
+syn keyword	vhdlType	positive natural signed unsigned
+syn keyword	vhdlType	unresolved_signed unresolved_unsigned u_signed u_unsigned
+syn keyword	vhdlType	line text
+syn keyword	vhdlType	std_logic std_logic_vector
+syn keyword	vhdlType	std_ulogic std_ulogic_vector
 
 " array attributes
-syn match vhdlAttribute "\'high"
-syn match vhdlAttribute "\'left"
-syn match vhdlAttribute "\'length"
-syn match vhdlAttribute "\'low"
-syn match vhdlAttribute "\'range"
-syn match vhdlAttribute "\'reverse_range"
-syn match vhdlAttribute "\'right"
-syn match vhdlAttribute "\'ascending"
+syn match	vhdlAttribute	"\'high"
+syn match	vhdlAttribute	"\'left"
+syn match	vhdlAttribute	"\'length"
+syn match	vhdlAttribute	"\'low"
+syn match	vhdlAttribute	"\'range"
+syn match	vhdlAttribute	"\'reverse_range"
+syn match	vhdlAttribute	"\'right"
+syn match	vhdlAttribute	"\'ascending"
 " block attributes
-"syn match vhdlAttribute "\'behaviour"	    " Non-standard VHDL
-"syn match vhdlAttribute "\'structure"	    " Non-standard VHDL
-syn match vhdlAttribute "\'simple_name"
-syn match vhdlAttribute "\'instance_name"
-syn match vhdlAttribute "\'path_name"
-syn match vhdlAttribute "\'foreign"	    " VHPI
+syn match	vhdlAttribute	"\'simple_name"
+syn match   	vhdlAttribute	"\'instance_name"
+syn match   	vhdlAttribute	"\'path_name"
+syn match   	vhdlAttribute	"\'foreign"	    " VHPI
 " signal attribute
-syn match vhdlAttribute "\'active"
-syn match vhdlAttribute "\'delayed"
-syn match vhdlAttribute "\'event"
-syn match vhdlAttribute "\'last_active"
-syn match vhdlAttribute "\'last_event"
-syn match vhdlAttribute "\'last_value"
-syn match vhdlAttribute "\'quiet"
-syn match vhdlAttribute "\'stable"
-syn match vhdlAttribute "\'transaction"
-syn match vhdlAttribute "\'driving"
-syn match vhdlAttribute "\'driving_value"
+syn match	vhdlAttribute	"\'active"
+syn match   	vhdlAttribute	"\'delayed"
+syn match   	vhdlAttribute	"\'event"
+syn match   	vhdlAttribute	"\'last_active"
+syn match   	vhdlAttribute	"\'last_event"
+syn match   	vhdlAttribute	"\'last_value"
+syn match   	vhdlAttribute	"\'quiet"
+syn match   	vhdlAttribute	"\'stable"
+syn match   	vhdlAttribute	"\'transaction"
+syn match   	vhdlAttribute	"\'driving"
+syn match   	vhdlAttribute	"\'driving_value"
 " type attributes
-syn match vhdlAttribute "\'base"
-syn match vhdlAttribute "\'subtype"
-syn match vhdlAttribute "\'element"
-syn match vhdlAttribute "\'leftof"
-syn match vhdlAttribute "\'pos"
-syn match vhdlAttribute "\'pred"
-syn match vhdlAttribute "\'rightof"
-syn match vhdlAttribute "\'succ"
-syn match vhdlAttribute "\'val"
-syn match vhdlAttribute "\'image"
-syn match vhdlAttribute "\'value"
+syn match	vhdlAttribute	"\'base"
+syn match   	vhdlAttribute	"\'subtype"
+syn match   	vhdlAttribute	"\'element"
+syn match   	vhdlAttribute	"\'leftof"
+syn match   	vhdlAttribute	"\'pos"
+syn match   	vhdlAttribute	"\'pred"
+syn match   	vhdlAttribute	"\'rightof"
+syn match   	vhdlAttribute	"\'succ"
+syn match   	vhdlAttribute	"\'val"
+syn match   	vhdlAttribute	"\'image"
+syn match   	vhdlAttribute	"\'value"
 
-syn keyword vhdlBoolean true false
+syn keyword	vhdlBoolean	true false
 
 " for this vector values case is significant
-syn case match
+syn case	match
 " Values for standard VHDL types
-syn match vhdlVector "\'[0L1HXWZU\-\?]\'"
-" Values for non standard VHDL types qsim_12state for Mentor Graphics Sys1076/QuickHDL
-"syn keyword vhdlVector S0S S1S SXS S0R S1R SXR S0Z S1Z SXZ S0I S1I SXI
-syn case ignore
+syn match	vhdlVector	"\'[0L1HXWZU\-\?]\'"
+syn case	ignore
 
-syn match  vhdlVector "B\"[01_]\+\""
-syn match  vhdlVector "O\"[0-7_]\+\""
-syn match  vhdlVector "X\"[0-9a-f_]\+\""
-syn match  vhdlCharacter "'.'"
-syn region vhdlString start=+"+  end=+"+
+syn match	vhdlVector	"B\"[01_]\+\""
+syn match   	vhdlVector	"O\"[0-7_]\+\""
+syn match   	vhdlVector	"X\"[0-9a-f_]\+\""
+syn match   	vhdlCharacter   "'.'"
+syn region  	vhdlString	start=+"+  end=+"+
 
 " floating numbers
-syn match vhdlNumber "-\=\<\d\+\.\d\+\(E[+\-]\=\d\+\)\>"
-syn match vhdlNumber "-\=\<\d\+\.\d\+\>"
-syn match vhdlNumber "0*2#[01_]\+\.[01_]\+#\(E[+\-]\=\d\+\)\="
-syn match vhdlNumber "0*16#[0-9a-f_]\+\.[0-9a-f_]\+#\(E[+\-]\=\d\+\)\="
+syn match	vhdlNumber	"-\=\<\d\+\.\d\+\(E[+\-]\=\d\+\)\>"
+syn match	vhdlNumber	"-\=\<\d\+\.\d\+\>"
+syn match	vhdlNumber	"0*2#[01_]\+\.[01_]\+#\(E[+\-]\=\d\+\)\="
+syn match	vhdlNumber	"0*16#[0-9a-f_]\+\.[0-9a-f_]\+#\(E[+\-]\=\d\+\)\="
 " integer numbers
-syn match vhdlNumber "-\=\<\d\+\(E[+\-]\=\d\+\)\>"
-syn match vhdlNumber "-\=\<\d\+\>"
-syn match vhdlNumber "0*2#[01_]\+#\(E[+\-]\=\d\+\)\="
-syn match vhdlNumber "0*16#[0-9a-f_]\+#\(E[+\-]\=\d\+\)\="
+syn match	vhdlNumber	"-\=\<\d\+\(E[+\-]\=\d\+\)\>"
+syn match	vhdlNumber	"-\=\<\d\+\>"
+syn match	vhdlNumber	"0*2#[01_]\+#\(E[+\-]\=\d\+\)\="
+syn match	vhdlNumber	"0*16#[0-9a-f_]\+#\(E[+\-]\=\d\+\)\="
 
 " operators
 syn keyword	vhdlOperator	and nand or nor xor xnor
 syn keyword	vhdlOperator	rol ror sla sll sra srl
 syn keyword	vhdlOperator	mod rem abs not
-" TODO remove the following line. You can't have a sequence of */=+ as an operator for example.
-"syn match	vhdlOperator	"[&><=:+\-*\/|]"
-" The following lines match valid and invalid operators.
 
 " Concatenation and math operators
 syn match	vhdlOperator	"&\|+\|-\|\*\|\/"
@@ -171,19 +150,25 @@ syn match	vhdlOperator	"=>"
 " VHDL-2008 conversion, matching equality/non-equality operators
 syn match	vhdlOperator	"??\|?=\|?\/=\|?<\|?<=\|?>\|?>="
 
+" VHDL-2008 external names
+syn match	vhdlOperator	"<<\|>>"
+
 " Linting for illegal operators
 " '='
 syn match	vhdlError	"\(=\)[<=&+\-\*\/\\]\+"
 syn match	vhdlError	"[=&+\-\*\\]\+\(=\)"
 " '>', '<'
-syn match	vhdlError	"\(>\)[<>&+\-\/\\]\+"
-syn match	vhdlError	"[>&+\-\/\\]\+\(>\)"
-syn match	vhdlError	"\(<\)[<&+\-\/\\]\+"
-syn match	vhdlError	"[<>=&+\-\/\\]\+\(<\)"
+" Allow external names: '<< ... >>'
+syn match	vhdlError	"\(>\)[<&+\-\/\\]\+"
+syn match	vhdlError	"[&+\-\/\\]\+\(>\)"
+syn match	vhdlError	"\(<\)[&+\-\/\\]\+"
+syn match	vhdlError	"[>=&+\-\/\\]\+\(<\)"
 " Covers most operators
-syn match	vhdlError	"\(&\|+\|\-\|\*\*\|\/=\|??\|?=\|?\/=\|?<=\|?>=\|>=\|<=\|:=\|=>\)[<>=&+\-\*\\?:]\+"
-syn match	vhdlError	"[<>=&+\-\*\\:]\+\(&\|+\|\-\|\*\*\|\/=\|??\|?=\|?\/=\|?<\|?<=\|?>\|?>=\|>=\|<=\|:=\|=>\)"
-syn match	vhdlError	"\(?<\|?>\)[<>&+\-\*\/\\?:]\+"
+" support negative sign after operators. E.g. q<=-b;
+syn match	vhdlError	"\(&\|+\|\-\|\*\*\|\/=\|??\|?=\|?\/=\|?<=\|?>=\|>=\|<=\|:=\|=>\)[<>=&+\*\\?:]\+"
+syn match	vhdlError	"[<>=&+\-\*\\:]\+\(&\|+\|\*\*\|\/=\|??\|?=\|?\/=\|?<\|?<=\|?>\|?>=\|>=\|<=\|:=\|=>\)"
+syn match	vhdlError	"\(?<\|?>\)[<>&+\*\/\\?:]\+"
+syn match	vhdlError	"\(<<\|>>\)[<>&+\*\/\\?:]\+"
 
 "syn match	vhdlError	"[?]\+\(&\|+\|\-\|\*\*\|??\|?=\|?\/=\|?<\|?<=\|?>\|?>=\|:=\|=>\)"
 " '/'
@@ -195,60 +180,61 @@ syn match	vhdlSpecial	"[().,;]"
 
 
 " time
-syn match vhdlTime "\<\d\+\s\+\(\([fpnum]s\)\|\(sec\)\|\(min\)\|\(hr\)\)\>"
-syn match vhdlTime "\<\d\+\.\d\+\s\+\(\([fpnum]s\)\|\(sec\)\|\(min\)\|\(hr\)\)\>"
+syn match	vhdlTime	"\<\d\+\s\+\(\([fpnum]s\)\|\(sec\)\|\(min\)\|\(hr\)\)\>"
+syn match	vhdlTime	"\<\d\+\.\d\+\s\+\(\([fpnum]s\)\|\(sec\)\|\(min\)\|\(hr\)\)\>"
 
-syn case match
-syn keyword vhdlTodo	contained TODO NOTE
-syn keyword vhdlFixme	contained FIXME
-syn case ignore
+syn case	match
+syn keyword	vhdlTodo	contained TODO NOTE
+syn keyword	vhdlFixme	contained FIXME
+syn case	ignore
 
-syn region  vhdlComment start="/\*" end="\*/"	contains=vhdlTodo,vhdlFixme,@Spell
-syn match   vhdlComment "\(^\|\s\)--.*"		contains=vhdlTodo,vhdlFixme,@Spell
+syn region	vhdlComment	start="/\*" end="\*/"	contains=vhdlTodo,vhdlFixme,@Spell
+syn match	vhdlComment	"\(^\|\s\)--.*"		contains=vhdlTodo,vhdlFixme,@Spell
 
 " Industry-standard directives. These are not standard VHDL, but are commonly
 " used in the industry.
-syn match vhdlPreProc "/\* synthesis .* \*/"
-"syn match vhdlPreProc "/\* simulation .* \*/"
-syn match vhdlPreProc "/\* pragma .* \*/"
-syn match vhdlPreProc "/\* synopsys .* \*/"
-syn match vhdlPreProc "--\s*synthesis .*"
-"syn match vhdlPreProc "--\s*simulation .*"
-syn match vhdlPreProc "--\s*pragma .*"
-syn match vhdlPreProc "--\s*synopsys .*"
+syn match	vhdlPreProc	"/\*\s*synthesis\s\+translate_\(on\|off\)\s*\*/"
+"syn match	vhdlPreProc	"/\*\s*simulation\s\+translate_\(on\|off\)\s*\*/"
+syn match	vhdlPreProc	"/\*\s*pragma\s\+synthesis_\(on\|off\)\s*\*/"
+syn match	vhdlPreProc	"/\*\s*synopsys\s\+translate_\(on\|off\)\s*\*/"
+
+syn match	vhdlPreProc	"\(^\|\s\)--\s*synthesis\s\+translate_\(on\|off\)\s*"
+"syn match	vhdlPreProc	"\(^\|\s\)--\s*simulation\s\+translate_\(on\|off\)\s*"
+syn match	vhdlPreProc	"\(^\|\s\)--\s*pragma\s\+synthesis_\(on\|off\)\s*"
+syn match	vhdlPreProc	"\(^\|\s\)--\s*synopsys\s\+translate_\(on\|off\)\s*"
 
 "Modify the following as needed.  The trade-off is performance versus functionality.
-syn sync minlines=600
+syn sync	minlines=600
 
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already
 " For version 5.8 and later: only when an item doesn't have highlighting yet
 if version >= 508 || !exists("did_vhdl_syntax_inits")
-  if version < 508
-    let did_vhdl_syntax_inits = 1
-    command -nargs=+ HiLink hi link <args>
-  else
-    command -nargs=+ HiLink hi def link <args>
-  endif
+    if version < 508
+	let did_vhdl_syntax_inits = 1
+	command -nargs=+ HiLink hi link <args>
+    else
+	command -nargs=+ HiLink hi def link <args>
+    endif
 
-  HiLink vhdlSpecial	Special
-  HiLink vhdlStatement	Statement
-  HiLink vhdlCharacter	Character
-  HiLink vhdlString	String
-  HiLink vhdlVector	Number
-  HiLink vhdlBoolean  	Number
-  HiLink vhdlTodo	Todo
-  HiLink vhdlFixme	Fixme
-  HiLink vhdlComment	Comment
-  HiLink vhdlNumber	Number
-  HiLink vhdlTime	Number
-  HiLink vhdlType	Type
-  HiLink vhdlOperator	Operator
-  HiLink vhdlError	Error
-  HiLink vhdlAttribute	Special
-  HiLink vhdlPreProc	PreProc
+    HiLink  vhdlSpecial	    Special
+    HiLink  vhdlStatement   Statement
+    HiLink  vhdlCharacter   Character
+    HiLink  vhdlString	    String
+    HiLink  vhdlVector	    Number
+    HiLink  vhdlBoolean	    Number
+    HiLink  vhdlTodo	    Todo
+    HiLink  vhdlFixme	    Fixme
+    HiLink  vhdlComment	    Comment
+    HiLink  vhdlNumber	    Number
+    HiLink  vhdlTime	    Number
+    HiLink  vhdlType	    Type
+    HiLink  vhdlOperator    Operator
+    HiLink  vhdlError	    Error
+    HiLink  vhdlAttribute   Special
+    HiLink  vhdlPreProc	    PreProc
 
-  delcommand HiLink
+    delcommand HiLink
 endif
 
 let b:current_syntax = "vhdl"


### PR DESCRIPTION
See individual comments, nothing spectacular. Last one is empty (only spell file changes), just there for the scripts to pick up.

Most notably, no change to `runtime/syntax/vim.vim` was applied, it diverged to much from vim.
