### PR TITLE
[RFC] Windows: Fix os_nodetype() default return

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -149,7 +149,7 @@ int os_nodetype(const char *name)
     case UV_UNKNOWN_HANDLE:
     default:
 #ifdef WIN32
-      nodetype = NODE_OTHER;
+      nodetype = NODE_NORMAL;
 #else
       nodetype = NODE_WRITABLE;  // Everything else is writable?
 #endif


### PR DESCRIPTION
When no file exists os_nodetype() returns NODE_WRITABLE for UNIX, do the same
Windows.

Reported by `jecxjo` on gitter. This is also in #810 - built in https://ci.appveyor.com/project/equalsraf/neovim/build/815/job/h0u2dlf2y6thrhl0/artifacts this fixes the error when opening a new file.
