### PR TITLE
Windows: Fix Absolute path handling in find_file_in_path

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1395,6 +1395,12 @@ find_file_in_path_option (
   if (vim_isAbsName(ff_file_to_find)
       /* "..", "../path", "." and "./path": don't use the path_option */
       || rel_to_curdir
+#if defined(WIN32)
+	    /* handle "\tmp" as absolute path */
+	    || vim_ispathsep(ff_file_to_find[0])
+	    /* handle "c:name" as absolute path */
+	    || (ff_file_to_find[0] != NUL && ff_file_to_find[1] == ':')
+#endif
       ) {
     /*
      * Absolute path, no need to use "path_option".


### PR DESCRIPTION
Calling `:cd /` on Neovim on Windows resulted in an error:

`E472: Command failed`

However on Vim no error results and a corresponding call to `:pwd` reports (correctly) the root drive of
the current working directory (e.g. `C:\`).

Adding "back" the Windows-specific code to find_file_in_path from Vim fixes the issue.

This manifested itself in one of the tests (test_vim.test_chdir) for python-client failing on Windows:
Ref: https://github.com/neovim/python-client/pull/201
