### PR TITLE
vim-patch:7.4.1007, 7.4.1010

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -668,7 +668,7 @@ static int included_patches[] = {
   1013,
   // 1012 NA
   // 1011 NA
-  // 1010,
+  // 1010 NA,
   // 1009 NA
   // 1008 NA
   1007,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -671,7 +671,7 @@ static int included_patches[] = {
   // 1010,
   // 1009 NA
   // 1008 NA
-  // 1007,
+  1007,
   1006,
   // 1005 NA,
   // 1004 NA,


### PR DESCRIPTION
### vim-patch:7.4.1007

Problem:    When a symbolic link points to a file in the root directory, the
            swapfile is not correct.
Solution:   Do not try getting the full name of a file in the root directory.
            (Milly, closes vim/vim#501)

https://github.com/vim/vim/commit/e3303cb0817e826e3c25d5dc4ac10b569d0841e1

This was already fixed in Neovim by c708061.
### version.c: Mark 7.4.1010 as NA

7.4.1010 relies on the “:smile” command that was added in 7.4.1005,
which was also marked NA.
