### PR TITLE
[RFC] Fix some failing tests.

### DIFF
--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -53,7 +53,7 @@ for _, cmd in ipairs {'cd', 'chdir'} do
       eq(0, wlwd())
 
       -- Change tab-local working directory and verify it is different
-      execute('t' .. cmd .. ' ' .. directories[1])
+      execute('silent t' .. cmd .. ' ' .. directories[1])
       eq(globalDir .. '/' .. directories[1], cwd())
       eq(cwd(), tcwd())  -- working directory maches tab directory
       eq(1, tlwd())
@@ -65,7 +65,7 @@ for _, cmd in ipairs {'cd', 'chdir'} do
       eq(1, tlwd())  -- Still tab-local working directory
       eq(0, wlwd())  -- Still no window-local working directory
       eq(globalDir .. '/' .. directories[1], cwd())
-      execute('l' .. cmd .. ' ../' .. directories[2])
+      execute('silent l' .. cmd .. ' ../' .. directories[2])
       eq(globalDir .. '/' .. directories[2], cwd())
       eq(globalDir .. '/' .. directories[1], tcwd())
       eq(1, wlwd())
@@ -83,7 +83,7 @@ for _, cmd in ipairs {'cd', 'chdir'} do
       eq(0, wlwd())
 
       -- Verify global changes don't affect local ones
-      execute('' .. cmd .. ' ' .. directories[3])
+      execute('silent ' .. cmd .. ' ' .. directories[3])
       eq(globalDir .. '/' .. directories[3], cwd())
       execute('tabnext')
       eq(globalDir .. '/' .. directories[1],  cwd())
@@ -91,7 +91,7 @@ for _, cmd in ipairs {'cd', 'chdir'} do
       eq(0, wlwd())  -- Still no window-local directory in this window
 
       -- Unless the global change happened in a tab with local directory
-      execute('' .. cmd .. ' ..')
+      execute('silent ' .. cmd .. ' ..')
       eq(globalDir, cwd() )
       eq(0 , tlwd())
       eq(0 , wlwd())

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -111,6 +111,10 @@ end
 -- Test legal parameters for 'getcwd' and 'haslocaldir'
 for _, cmd in ipairs {'getcwd', 'haslocaldir'} do
   describe(cmd..'()', function()
+    before_each(function()
+      clear()
+    end)
+
     -- Test invalid argument types
     local err474 = 'Vim(call):E474: Invalid argument'
     it('fails on string', function()

--- a/test/unit/tempfile_spec.lua
+++ b/test/unit/tempfile_spec.lua
@@ -5,6 +5,9 @@ local os = helpers.cimport './src/nvim/os/os.h'
 local tempfile = helpers.cimport './src/nvim/fileio.h'
 
 describe('tempfile related functions', function()
+  before_each(function()
+    tempfile.vim_deltempdir()
+  end)
   after_each(function()
     tempfile.vim_deltempdir()
   end)


### PR DESCRIPTION
There are a couple of issues here causing the tests to hang because nvim is prompting for the user to hit enter. It'd really be nice to find a more robust way of dealing with this, and for folks to stop ignoring when the tests hang on QB and not Travis. :-(  I also found that one tempfile_spec test was failing periodically because there was cruft in there from other tests.  I fixed that too.

I believe this fixes #4637 too.
