### PR TITLE
[RFC] vim-patch:7.4.1042

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -77,7 +77,8 @@ g CTRL-G		Prints the current position of the cursor in five
 			than one position on the screen (<Tab> or special
 			character), both the "real" column and the screen
 			column are shown, separated with a dash.
-			See also 'ruler' option.
+			Also see the 'ruler' option and the |wordcount()|
+			function.
 
 							*v_g_CTRL-G*
 {Visual}g CTRL-G	Similar to "g CTRL-G", but Word, Character, Line, and

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2139,6 +2139,7 @@ winrestcmd()			String	returns command to restore window sizes
 winrestview( {dict})		none	restore view of current window
 winsaveview()			Dict	save view of current window
 winwidth( {nr})			Number	width of window {nr}
+wordcount()			Dict	get byte/char/word statistics
 writefile( {list}, {fname} [, {flags}])
 				Number	write list of lines to file {fname}
 xor( {expr}, {expr})		Number  bitwise XOR
@@ -7113,6 +7114,28 @@ winwidth({nr})						*winwidth()*
   :  exe "normal 50\<C-W>|"
   :endif
 <
+wordcount()						*wordcount()*
+		The result is a dictionary of byte/chars/word statistics for
+		the current buffer.  This is the same info as provided by
+		|g_CTRL-G|
+		The return value includes:
+			bytes		Number of bytes in the buffer
+			chars		Number of chars in the buffer
+			words		Number of words in the buffer
+			cursor_bytes    Number of bytes before cursor position
+					(not in Visual mode)
+			cursor_chars    Number of chars before cursor position
+					(not in Visual mode)
+			cursor_words    Number of words before cursor position
+					(not in Visual mode)
+			visual_bytes    Number of bytes visually selected
+			                (only in Visual mode)
+			visual_chars    Number of chars visually selected
+			                (only in Visual mode)
+			visual_words    Number of chars visually selected
+			                (only in Visual mode)
+
+
 							*writefile()*
 writefile({list}, {fname} [, {flags}])
 		Write |List| {list} to file {fname}.  Each list item is

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -921,6 +921,7 @@ Various:					*various-functions*
 
 	py3eval()		evaluate Python expression (|+python3|)
 	pyeval()		evaluate Python expression (|+python|)
+	wordcount()		get byte/word/char count of buffer
 
 ==============================================================================
 *41.7*	Defining a function

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6949,6 +6949,7 @@ static struct fst {
   { "winrestview",       1, 1, f_winrestview },
   { "winsaveview",       0, 0, f_winsaveview },
   { "winwidth",          1, 1, f_winwidth },
+  { "wordcount",         0, 0, f_wordcount },
   { "writefile",         2, 3, f_writefile },
   { "xor",               2, 2, f_xor },
 };
@@ -16908,6 +16909,13 @@ static void f_winwidth(typval_T *argvars, typval_T *rettv)
     rettv->vval.v_number = -1;
   else
     rettv->vval.v_number = wp->w_width;
+}
+
+/// "wordcount()" function
+static void f_wordcount(typval_T *argvars, typval_T *rettv)
+{
+  rettv_dict_alloc(rettv);
+  cursor_pos_info(rettv->vval.v_dict);
 }
 
 /// "writefile()" function

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6737,16 +6737,12 @@ static void nv_g_cmd(cmdarg_T *cap)
       clearopbeep(oap);
     break;
 
-  /*
-   * "g CTRL-G": display info about cursor position
-   */
+  // "g CTRL-G": display info about cursor position
   case Ctrl_G:
-    cursor_pos_info();
+    cursor_pos_info(NULL);
     break;
 
-  /*
-   * "gi": start Insert at the last position.
-   */
+  // "gi": start Insert at the last position.
   case 'i':
     if (curbuf->b_last_insert.mark.lnum != 0) {
       curwin->w_cursor = curbuf->b_last_insert.mark;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5165,18 +5165,18 @@ static long line_count_info(char_u *line, long *wc, long *cc, long limit, int eo
   return i;
 }
 
-/*
- * Give some info about the position of the cursor (for "g CTRL-G").
- * In Visual mode, give some info about the selected region.  (In this case,
- * the *_count_cursor variables store running totals for the selection.)
- */
-void cursor_pos_info(void)
+/// Give some info about the position of the cursor (for "g CTRL-G").
+/// In Visual mode, give some info about the selected region.  (In this case,
+/// the *_count_cursor variables store running totals for the selection.)
+/// When "dict" is not NULL store the info there instead of showing it.
+void cursor_pos_info(dict_T *dict)
 {
   char_u      *p;
   char_u buf1[50];
   char_u buf2[40];
   linenr_T lnum;
   long byte_count = 0;
+  long bom_count = 0;
   long byte_count_cursor = 0;
   long char_count = 0;
   long char_count_cursor = 0;
@@ -5191,11 +5191,12 @@ void cursor_pos_info(void)
   const int l_VIsual_active = VIsual_active;
   const int l_VIsual_mode = VIsual_mode;
 
-  /*
-   * Compute the length of the file in characters.
-   */
+  // Compute the length of the file in characters.
   if (curbuf->b_ml.ml_flags & ML_EMPTY) {
-    MSG(_(no_lines_msg));
+    if (dict == NULL) {
+      MSG(_(no_lines_msg));
+      return;
+    }
   } else {
     if (get_fileformat(curbuf) == EOL_DOS)
       eol_size = 2;
@@ -5300,78 +5301,105 @@ void cursor_pos_info(void)
           &char_count, (long)MAXCOL, eol_size);
     }
 
-    /* Correction for when last line doesn't have an EOL. */
-    if (!curbuf->b_p_eol && (curbuf->b_p_bin || !curbuf->b_p_fixeol))
+    // Correction for when last line doesn't have an EOL.
+    if (!curbuf->b_p_eol && (curbuf->b_p_bin || !curbuf->b_p_fixeol)) {
       byte_count -= eol_size;
-
-    if (l_VIsual_active) {
-      if (l_VIsual_mode == Ctrl_V && curwin->w_curswant < MAXCOL) {
-        getvcols(curwin, &min_pos, &max_pos, &min_pos.col,
-            &max_pos.col);
-        vim_snprintf((char *)buf1, sizeof(buf1), _("%" PRId64 " Cols; "),
-            (int64_t)(oparg.end_vcol - oparg.start_vcol + 1));
-      } else
-        buf1[0] = NUL;
-
-      if (char_count_cursor == byte_count_cursor
-          && char_count == byte_count)
-        vim_snprintf((char *)IObuff, IOSIZE,
-            _("Selected %s%" PRId64 " of %" PRId64 " Lines; %" PRId64
-              " of %" PRId64 " Words; %" PRId64 " of %" PRId64 " Bytes"),
-            buf1, (int64_t)line_count_selected,
-            (int64_t)curbuf->b_ml.ml_line_count,
-            (int64_t)word_count_cursor, (int64_t)word_count,
-            (int64_t)byte_count_cursor, (int64_t)byte_count);
-      else
-        vim_snprintf((char *)IObuff, IOSIZE,
-            _("Selected %s%" PRId64 " of %" PRId64 " Lines; %" PRId64
-              " of %" PRId64 " Words; %" PRId64 " of %" PRId64
-              " Chars; %" PRId64 " of %" PRId64 " Bytes"),
-            buf1, (int64_t)line_count_selected,
-            (int64_t)curbuf->b_ml.ml_line_count,
-            (int64_t)word_count_cursor, (int64_t)word_count,
-            (int64_t)char_count_cursor, (int64_t)char_count,
-            (int64_t)byte_count_cursor, (int64_t)byte_count);
-    } else {
-      p = get_cursor_line_ptr();
-      validate_virtcol();
-      col_print(buf1, sizeof(buf1), (int)curwin->w_cursor.col + 1,
-          (int)curwin->w_virtcol + 1);
-      col_print(buf2, sizeof(buf2), (int)STRLEN(p), linetabsize(p));
-
-      if (char_count_cursor == byte_count_cursor
-          && char_count == byte_count)
-        vim_snprintf((char *)IObuff, IOSIZE,
-            _("Col %s of %s; Line %" PRId64 " of %" PRId64 "; Word %" PRId64
-              " of %" PRId64 "; Byte %" PRId64 " of %" PRId64 ""),
-            (char *)buf1, (char *)buf2,
-            (int64_t)curwin->w_cursor.lnum,
-            (int64_t)curbuf->b_ml.ml_line_count,
-            (int64_t)word_count_cursor, (int64_t)word_count,
-            (int64_t)byte_count_cursor, (int64_t)byte_count);
-      else
-        vim_snprintf((char *)IObuff, IOSIZE,
-            _(
-                "Col %s of %s; Line %" PRId64 " of %" PRId64 "; Word %" PRId64
-                " of %" PRId64 "; Char %" PRId64 " of %" PRId64
-                "; Byte %" PRId64 " of %" PRId64 ""),
-            (char *)buf1, (char *)buf2,
-            (int64_t)curwin->w_cursor.lnum,
-            (int64_t)curbuf->b_ml.ml_line_count,
-            (int64_t)word_count_cursor, (int64_t)word_count,
-            (int64_t)char_count_cursor, (int64_t)char_count,
-            (int64_t)byte_count_cursor, (int64_t)byte_count);
     }
 
-    byte_count = bomb_size();
-    if (byte_count > 0)
-      sprintf((char *)IObuff + STRLEN(IObuff), _("(+%" PRId64 " for BOM)"),
-          (int64_t)byte_count);
-    /* Don't shorten this message, the user asked for it. */
-    p = p_shm;
-    p_shm = (char_u *)"";
-    msg(IObuff);
-    p_shm = p;
+    if (dict == NULL) {
+      if (l_VIsual_active) {
+        if (l_VIsual_mode == Ctrl_V && curwin->w_curswant < MAXCOL) {
+          getvcols(curwin, &min_pos, &max_pos, &min_pos.col, &max_pos.col);
+          vim_snprintf((char *)buf1, sizeof(buf1), _("%" PRId64 " Cols; "),
+                       (int64_t)(oparg.end_vcol - oparg.start_vcol + 1));
+        } else {
+          buf1[0] = NUL;
+        }
+
+        if (char_count_cursor == byte_count_cursor
+            && char_count == byte_count) {
+          vim_snprintf((char *)IObuff, IOSIZE,
+                       _("Selected %s%" PRId64 " of %" PRId64 " Lines;"
+                         " %" PRId64 " of %" PRId64 " Words;"
+                         " %" PRId64 " of %" PRId64 " Bytes"),
+                       buf1, (int64_t)line_count_selected,
+                       (int64_t)curbuf->b_ml.ml_line_count,
+                       (int64_t)word_count_cursor, (int64_t)word_count,
+                       (int64_t)byte_count_cursor, (int64_t)byte_count);
+        } else {
+          vim_snprintf((char *)IObuff, IOSIZE,
+                       _("Selected %s%" PRId64 " of %" PRId64 " Lines;"
+                         " %" PRId64 " of %" PRId64 " Words;"
+                         " %" PRId64 " of %" PRId64 " Chars;"
+                         " %" PRId64 " of %" PRId64 " Bytes"),
+                       buf1, (int64_t)line_count_selected,
+                       (int64_t)curbuf->b_ml.ml_line_count,
+                       (int64_t)word_count_cursor, (int64_t)word_count,
+                       (int64_t)char_count_cursor, (int64_t)char_count,
+                       (int64_t)byte_count_cursor, (int64_t)byte_count);
+        }
+      } else {
+        p = get_cursor_line_ptr();
+        validate_virtcol();
+        col_print(buf1, sizeof(buf1), (int)curwin->w_cursor.col + 1,
+                  (int)curwin->w_virtcol + 1);
+        col_print(buf2, sizeof(buf2), (int)STRLEN(p), linetabsize(p));
+
+        if (char_count_cursor == byte_count_cursor
+            && char_count == byte_count) {
+          vim_snprintf((char *)IObuff, IOSIZE,
+                       _("Col %s of %s; Line %" PRId64 " of %" PRId64 ";"
+                         " Word %" PRId64 " of %" PRId64 ";"
+                         " Byte %" PRId64 " of %" PRId64 ""),
+                       (char *)buf1, (char *)buf2,
+                       (int64_t)curwin->w_cursor.lnum,
+                       (int64_t)curbuf->b_ml.ml_line_count,
+                       (int64_t)word_count_cursor, (int64_t)word_count,
+                       (int64_t)byte_count_cursor, (int64_t)byte_count);
+        } else {
+          vim_snprintf((char *)IObuff, IOSIZE,
+                       _("Col %s of %s; Line %" PRId64 " of %" PRId64 ";"
+                         " Word %" PRId64 " of %" PRId64 ";"
+                         " Char %" PRId64 " of %" PRId64 ";"
+                         " Byte %" PRId64 " of %" PRId64 ""),
+                       (char *)buf1, (char *)buf2,
+                       (int64_t)curwin->w_cursor.lnum,
+                       (int64_t)curbuf->b_ml.ml_line_count,
+                       (int64_t)word_count_cursor, (int64_t)word_count,
+                       (int64_t)char_count_cursor, (int64_t)char_count,
+                       (int64_t)byte_count_cursor, (int64_t)byte_count);
+        }
+      }
+    }
+
+    // Don't shorten this message, the user asked for it.
+    bom_count = bomb_size();
+    if (bom_count > 0) {
+      vim_snprintf((char *)IObuff + STRLEN(IObuff), IOSIZE - STRLEN(IObuff),
+                   _("(+%" PRId64 " for BOM)"), (int64_t)byte_count);
+    }
+    if (dict == NULL) {
+      p = p_shm;
+      p_shm = (char_u *)"";
+      msg(IObuff);
+      p_shm = p;
+    }
+  }
+
+  if (dict != NULL) {
+    dict_add_nr_str(dict, "words", word_count, NULL);
+    dict_add_nr_str(dict, "chars", char_count, NULL);
+    dict_add_nr_str(dict, "bytes", byte_count + bom_count, NULL);
+
+    if (l_VIsual_active) {
+      dict_add_nr_str(dict, "visual_bytes", byte_count_cursor, NULL);
+      dict_add_nr_str(dict, "visual_chars", char_count_cursor, NULL);
+      dict_add_nr_str(dict, "visual_words", word_count_cursor, NULL);
+    } else {
+      dict_add_nr_str(dict, "cursor_bytes", byte_count_cursor, NULL);
+      dict_add_nr_str(dict, "cursor_chars", char_count_cursor, NULL);
+      dict_add_nr_str(dict, "cursor_words", word_count_cursor, NULL);
+    }
   }
 }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -636,7 +636,7 @@ static int included_patches[] = {
   // 1045 NA
   // 1044 NA
   // 1043 NA
-  // 1042,
+  1042,
   1041,
   // 1040 NA
   // 1039,

--- a/test/functional/legacy/wordcount_spec.lua
+++ b/test/functional/legacy/wordcount_spec.lua
@@ -1,0 +1,167 @@
+-- Test for wordcount() function
+
+local helpers = require('test.functional.helpers')
+local feed, insert, source = helpers.feed, helpers.insert, helpers.source
+local clear, execute = helpers.clear, helpers.execute
+local eq, eval = helpers.eq, helpers.eval
+
+describe('wordcount', function()
+  before_each(clear)
+
+  it('is working', function()
+    insert([=[
+      RESULT test:]=])
+
+    execute('new')
+    source([=[
+      function DoRecordWin(...)
+        wincmd k
+          if exists("a:1")
+            call cursor(a:1)
+          endif
+          let result=[]
+          call add(result, getline(1, '$'))
+          call add(result, wordcount())
+        wincmd j
+        return result
+      endfunction
+    ]=])
+
+    source([=[
+      function PutInWindow(args)
+        wincmd k
+        %d _
+        call append(1, a:args)
+        wincmd j
+      endfunction
+    ]=])
+
+    source([=[
+      function! STL()
+        if mode() =~? 'V'
+          let g:visual_stat=wordcount()
+        endif
+        return string(wordcount())
+      endfunction
+    ]=])
+
+    -- Test 1: empty window
+    eq(eval('DoRecordWin()'),
+       eval([=[
+          [[''], {'chars': 0, 'cursor_chars': 0, 'words': 0, 'cursor_words': 0, 'bytes': 0, 'cursor_bytes': 0}]
+        ]=])
+      )
+
+    -- Test 2: some words, cursor at start
+    execute([[call PutInWindow('one two three')]])
+    eq(eval('DoRecordWin([1, 1, 0])'),
+       eval([=[
+          [['', 'one two three'], {'chars': 15, 'cursor_chars': 1, 'words': 3, 'cursor_words': 0, 'bytes': 15, 'cursor_bytes': 1}]
+        ]=])
+      )
+
+    -- Test 3: some words, cursor at end
+    execute([[call PutInWindow('one two three')]])
+    eq(eval('DoRecordWin([2, 99, 0])'),
+       eval([=[
+          [['', 'one two three'], {'chars': 15, 'cursor_chars': 14, 'words': 3, 'cursor_words': 3, 'bytes': 15, 'cursor_bytes': 14}]
+        ]=])
+      )
+
+    -- Test 4: some words, cursor at end, ve=all
+    execute('set ve=all')
+    execute([[call PutInWindow('one two three')]])
+    eq(eval('DoRecordWin([2,99,0])'),
+       eval([=[
+          [['', 'one two three'], {'chars': 15, 'cursor_chars': 15, 'words': 3, 'cursor_words': 3, 'bytes': 15, 'cursor_bytes': 15}]
+        ]=])
+      )
+    execute('set ve=')
+
+    -- Test 5: several lines with words
+    execute([=[call PutInWindow(['one two three', 'one two three', 'one two three'])]=])
+    eq(eval('DoRecordWin([4,99,0])'),
+       eval([=[
+          [['', 'one two three', 'one two three', 'one two three'], {'chars': 43, 'cursor_chars': 42, 'words': 9, 'cursor_words': 9, 'bytes': 43, 'cursor_bytes': 42}]
+        ]=])
+      )
+
+    -- Test 6: one line with BOM set
+    execute([[call PutInWindow('one two three')]])
+    execute('wincmd k')
+    execute('set bomb')
+    execute('wincmd j')
+    eq(eval('DoRecordWin([2,99,0])'),
+       eval([=[
+          [['', 'one two three'], {'chars': 15, 'cursor_chars': 14, 'words': 3, 'cursor_words': 3, 'bytes': 18, 'cursor_bytes': 14}]
+        ]=])
+      )
+    execute('wincmd k')
+    execute('set nobomb')
+    execute('wincmd j')
+
+    -- Test 7: one line with multibyte words
+    execute([=[call PutInWindow(['Äne M¤ne Müh'])]=])
+    eq(eval('DoRecordWin([2,99,0])'),
+       eval([=[
+          [['', 'Äne M¤ne Müh'], {'chars': 14, 'cursor_chars': 13, 'words': 3, 'cursor_words': 3, 'bytes': 17, 'cursor_bytes': 16}]
+        ]=])
+      )
+
+    -- Test 8: several lines with multibyte words
+    execute([=[call PutInWindow(['Äne M¤ne Müh', 'und raus bist dü!'])]=])
+    eq(eval('DoRecordWin([3,99,0])'),
+       eval([=[
+          [['', 'Äne M¤ne Müh', 'und raus bist dü!'], {'chars': 32, 'cursor_chars': 31, 'words': 7, 'cursor_words': 7, 'bytes': 36, 'cursor_bytes': 35}]
+        ]=])
+      )
+
+    -- Test 9: visual mode, complete buffer
+    execute([=[call PutInWindow(['Äne M¤ne Müh', 'und raus bist dü!'])]=])
+    execute('wincmd k')
+    execute('set ls=2 stl=%{STL()}')
+    -- -- Start visual mode quickly and select complete buffer.
+    execute('0')
+    feed('V2jy<cr>')
+    execute('set stl= ls=1')
+    execute('let log=DoRecordWin([3,99,0])')
+    execute('let log[1]=g:visual_stat')
+    eq(eval('log'),
+       eval([=[
+          [['', 'Äne M¤ne Müh', 'und raus bist dü!'], {'chars': 32, 'words': 7, 'bytes': 36, 'visual_chars': 32, 'visual_words': 7, 'visual_bytes': 36}]
+        ]=])
+      )
+
+    -- Test 10: visual mode (empty)
+    execute([=[call PutInWindow(['Äne M¤ne Müh', 'und raus bist dü!'])]=])
+    execute('wincmd k')
+    execute('set ls=2 stl=%{STL()}')
+    -- Start visual mode quickly and select complete buffer.
+    execute('0')
+    feed('v$y<cr>')
+    execute('set stl= ls=1')
+    execute('let log=DoRecordWin([3,99,0])')
+    execute('let log[1]=g:visual_stat')
+    eq(eval('log'),
+       eval([=[
+          [['', 'Äne M¤ne Müh', 'und raus bist dü!'], {'chars': 32, 'words': 7, 'bytes': 36, 'visual_chars': 1, 'visual_words': 0, 'visual_bytes': 1}]
+        ]=])
+      )
+
+    -- Test 11: visual mode, single line
+    execute([=[call PutInWindow(['Äne M¤ne Müh', 'und raus bist dü!'])]=])
+    execute('wincmd k')
+    execute('set ls=2 stl=%{STL()}')
+    -- Start visual mode quickly and select complete buffer.
+    execute('2')
+    feed('0v$y<cr>')
+    execute('set stl= ls=1')
+    execute('let log=DoRecordWin([3,99,0])')
+    execute('let log[1]=g:visual_stat')
+    eq(eval('log'),
+       eval([=[
+          [['', 'Äne M¤ne Müh', 'und raus bist dü!'], {'chars': 32, 'words': 7, 'bytes': 36, 'visual_chars': 13, 'visual_words': 3, 'visual_bytes': 16}]
+        ]=])
+      )
+  end)
+end)


### PR DESCRIPTION
```
Problem:    g-CTRL-G shows the word count, but there is no way to get the word
            count in a script.
Solution:   Add the wordcount() function. (Christian Brabandt)
```

https://github.com/vim/vim/commit/ed767a2073ef150971b0439a58e7ee582af6984e
