### PR TITLE
[RFC] Fix the path output by :UpdateRemotePlugins for Windows.

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -1,7 +1,8 @@
 let s:hosts = {}
 let s:plugin_patterns = {}
 let s:remote_plugins_manifest = fnamemodify(expand($MYVIMRC, 1), ':h')
-      \.'/.'.fnamemodify($MYVIMRC, ':t').'-rplugin~'
+      \.(has('win32') || has('win64') ? '\.' : '/.').fnamemodify($MYVIMRC, ':t')
+      \.'-rplugin~'
 let s:plugins_for_host = {}
 
 


### PR DESCRIPTION
This is purely a cosmetic fix. When executing :UpdateRemotePlugins
on Windows, the following is echoed:

remote/host: generated the manifest file in "C:\Users{$USER}\AppData\Local\nvim/.init.vim-rplugin~"

(Note the forward-slash after the nvim directory).

With this patch the following message is echoed:

remote/host: generated the manifest file in "C:\Users\brcolow\AppData\Local\nvim.init.vim-rplugin~"

Question(s): This is the most straight-forward way to fix this issue, but one could also use a call to `expand()` instead of the ternary statement that checks if it is on Windows or not. Also, is checking for `has('win32') || has('win64')` the best way to check that we are on Windows (if we go with this ternary approach)?

/cc @equalsraf 
