### PR TITLE
[RFC] allow stderr handler for rpc jobs

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -261,9 +261,8 @@ function! remote#host#LoadErrorForHost(host, log) abort
         \ 'You can try to see what happened '.
         \ 'by starting Neovim with the environment variable '.
         \ a:log . ' set to a file and opening the generated '.
-        \ 'log file. Also, the host stderr will be available '.
-        \ 'in Neovim log, so it may contain useful information. '.
-        \ 'See also ~/.nvimlog.'
+        \ 'log file. Also, the host stderr is available '.
+        \ 'in messages.'
 endfunction
 
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2043,7 +2043,6 @@ rpcnotify({channel}, {event}[, {args}...])
 				Sends an |RPC| notification to {channel}
 rpcrequest({channel}, {method}[, {args}...])
 				Sends an |RPC| request to {channel}
-rpcstart({prog}[, {argv}])	Spawns {prog} and opens an |RPC| channel
 rpcstop({channel})		Closes an |RPC| {channel}
 screenattr({row}, {col})	Number	attribute at screen position
 screenchar({row}, {col})	Number	character at screen position
@@ -4395,8 +4394,10 @@ items({dict})						*items()*
 		order.
 
 jobclose({job}[, {stream}])				{Nvim} *jobclose()*
-		Close {job}'s {stream}, which can be one "stdin", "stdout" or
-		"stderr". If {stream} is omitted, all streams are closed.
+		Close {job}'s {stream}, which can be one of "stdin", "stdout",
+		"stderr" or "rpc" (closes the rpc channel for a job started
+		with the "rpc" option.) If {stream} is omitted, all streams
+		are closed.
 
 jobpid({job})						{Nvim} *jobpid()*
 		Return the pid (process id) of {job}.
@@ -4418,6 +4419,10 @@ jobsend({job}, {data})					{Nvim} *jobsend()*
 			:call jobsend(j, ["abc", "123\n456", ""])
 < 		will send "abc<NL>123<NUL>456<NL>".
 
+		If the job was started with the rpc option this function
+		cannot be used, instead use |rpcnotify()| and |rpcrequest()|
+		to communicate with the job.
+
 jobstart({cmd}[, {opts}])				{Nvim} *jobstart()*
 		Spawns {cmd} as a job.  If {cmd} is a |List| it is run
 		directly.  If {cmd} is a |String| it is processed like this: >
@@ -4433,9 +4438,14 @@ jobstart({cmd}[, {opts}])				{Nvim} *jobstart()*
 		  on_exit  : exit event handler (function name or |Funcref|)
 		  cwd      : Working directory of the job; defaults to
 		             |current-directory|.
+		  rpc      : If set, |msgpack-rpc| will be used to communicate
+			     with the job over stdin and stdout. "on_stdout" is
+			     then ignored, but "on_stderr" can still be used.
 		  pty      : If set, the job will be connected to a new pseudo
-		             terminal, and the job streams are connected to
-		             the master file descriptor.
+			     terminal, and the job streams are connected to
+			     the master file descriptor. "on_stderr" is ignored
+			     as all output will be received on stdout.
+
 		  width    : (pty only) Width of the terminal screen
 		  height   : (pty only) Height of the terminal screen
 		  TERM     : (pty only) $TERM environment variable
@@ -4447,10 +4457,12 @@ jobstart({cmd}[, {opts}])				{Nvim} *jobstart()*
 		{opts} is passed as |self| to the callback; the caller may
 		pass arbitrary data by setting other keys.
 		Returns:
-		  - job ID on success, used by |jobsend()| and |jobstop()|
+		  - The job ID on success, which is used by |jobsend()| (or
+		    |rpcnotify()| and |rpcrequest()| if "rpc" option was used)
+		    and |jobstop()|
 		  - 0 on invalid arguments or if the job table is full
 		  - -1 if {cmd}[0] is not executable.
-		See |job-control| for more information.
+		See |job-control| and |msgpack-rpc| for more information.
 
 jobstop({job})						{Nvim} *jobstop()*
 		Stop a job created with |jobstart()| by sending a `SIGTERM`
@@ -5649,19 +5661,20 @@ rpcrequest({channel}, {method}[, {args}...])		 {Nvim} *rpcrequest()*
 			:let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
 
 rpcstart({prog}[, {argv}])				   {Nvim} *rpcstart()*
-		Spawns {prog} as a job (optionally passing the list {argv}),
-		and opens an |RPC| channel with the spawned process's
-		stdin/stdout. Returns:
-		  - channel id on success, which is used by |rpcrequest()|,
-		    |rpcnotify()| and |rpcstop()|
-		  - 0 on failure
-		Example: >
-			:let rpc_chan = rpcstart('prog', ['arg1', 'arg2'])
+		Deprecated. Replace  >
+			:let id = rpcstart('prog', ['arg1', 'arg2'])
+<		with >
+			:let id = jobstart(['prog', 'arg1', 'arg2'],
+					   {'rpc': v:true})
 
 rpcstop({channel})					    {Nvim} *rpcstop()*
-		Closes an |RPC| {channel}, possibly created via
-		|rpcstart()|. Also closes channels created by connections to
-		|v:servername|.
+		Closes an |RPC| {channel}.  If the channel is a job
+		started with |jobstart()|  the job is killed.
+		It is better to use |jobstop()| in this case, or use
+		|jobclose|(id, "rpc") to only close the channel without
+		killing the job.
+		Closes the socket connection if the channel was opened by
+		connecting to |v:servername|.
 
 screenattr(row, col)						*screenattr()*
 		Like screenchar(), but return the attribute.  This is a rather

--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -11,7 +11,6 @@ RPC API for Nvim				     *RPC* *rpc* *msgpack-rpc*
 3. Connecting			|rpc-connecting|
 4. Clients			|rpc-api-client|
 5. Types			|rpc-types|
-6. Vimscript functions		|rpc-vim-functions|
 
 ==============================================================================
 1. Introduction						            *rpc-intro*
@@ -66,12 +65,16 @@ To get a formatted dump of the API using python (requires the `pyyaml` and
 ==============================================================================
 3. Connecting						      *rpc-connecting*
 
-There are several ways to open a msgpack-rpc stream to an Nvim server:
+There are several ways to open a msgpack-rpc channel to an Nvim instance:
 
   1. Through stdin/stdout when `nvim` is started with `--embed`. This is how
      applications can embed Nvim.
 
-  2. Through stdin/stdout of some other process spawned by |rpcstart()|.
+  2. Through stdin/stdout of some other process spawned by |jobstart()|.
+     Set the "rpc" key to |v:true| in the options dict to use the job's stdin
+     and stdout as a single msgpack channel that is processed directly by
+     Nvim.  Then it is not possible to process raw data to or from the
+     process's stdin and stdout. stderr can still be used, though.
 
   3. Through the socket automatically created with each instance. The socket
      location is stored in |v:servername|.
@@ -110,11 +113,12 @@ functions can be called interactively:
     >>> nvim = attach('socket', path='[address]')
     >>> nvim.command('echo "hello world!"')
 <
-You can also embed an Nvim instance via |rpcstart()|
+You can also embed an Nvim instance via |jobstart()|, and communicate using
+|rpcrequest()| and |rpcnotify()|:
 >
-    let vim = rpcstart('nvim', ['--embed'])
+    let vim = jobstart(['nvim', '--embed'], {'rpc': v:true})
     echo rpcrequest(vim, 'vim_eval', '"Hello " . "world!"')
-    call rpcstop(vim)
+    call jobstop(vim)
 <
 ==============================================================================
 4. Implementing API clients			*rpc-api-client* *api-client*
@@ -232,24 +236,6 @@ the `types` object:
 Even for statically compiled clients it is good practice to avoid hardcoding
 the type codes, because a client may be built against one Nvim version but
 connect to another with different type codes.
-
-==============================================================================
-6. Vimscript functions				           *rpc-vim-functions*
-
-RPC functions are available in Vimscript:
-
-  1. |rpcstart()|: Similarly to |jobstart()|, this will spawn a co-process
-     with its standard handles connected to Nvim. The difference is that it's
-     not possible to process raw data to or from the process's stdin, stdout,
-     or stderr.  This is because the job's stdin and stdout are used as
-     a single msgpack channel that is processed directly by Nvim.
-  2. |rpcstop()|: Same as |jobstop()|, but operates on handles returned by
-     |rpcstart()|.
-  3. |rpcrequest()|: Sends a msgpack-rpc request to the process.
-  4. |rpcnotify()|: Sends a msgpack-rpc notification to the process.
-
-|rpcrequest()| and |rpcnotify()| can also be used with channels connected to
-a nvim server. |v:servername|
 
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -22178,11 +22178,11 @@ static inline bool common_job_start(TerminalJobData *data, typval_T *rettv)
   wstream_init(proc->in, 0);
   if (proc->out) {
     rstream_init(proc->out, 0);
-    rstream_start(proc->out, on_job_stdout);
+    rstream_start(proc->out, on_job_stdout, data);
   }
   if (proc->err) {
     rstream_init(proc->err, 0);
-    rstream_start(proc->err, on_job_stderr);
+    rstream_start(proc->err, on_job_stderr, data);
   }
   pmap_put(uint64_t)(jobs, data->id, data);
   rettv->vval.v_number = data->id;

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -25,7 +25,7 @@
 #define CLOSE_PROC_STREAM(proc, stream) \
   do { \
     if (proc->stream && !proc->stream->closed) { \
-      stream_close(proc->stream, NULL); \
+      stream_close(proc->stream, NULL, NULL); \
     } \
   } while (0)
 
@@ -78,10 +78,8 @@ bool process_spawn(Process *proc) FUNC_ATTR_NONNULL_ALL
     return false;
   }
 
-  void *data = proc->data;
-
   if (proc->in) {
-    stream_init(NULL, proc->in, -1, (uv_stream_t *)&proc->in->uv.pipe, data);
+    stream_init(NULL, proc->in, -1, (uv_stream_t *)&proc->in->uv.pipe);
     proc->in->events = proc->events;
     proc->in->internal_data = proc;
     proc->in->internal_close_cb = on_process_stream_close;
@@ -89,7 +87,7 @@ bool process_spawn(Process *proc) FUNC_ATTR_NONNULL_ALL
   }
 
   if (proc->out) {
-    stream_init(NULL, proc->out, -1, (uv_stream_t *)&proc->out->uv.pipe, data);
+    stream_init(NULL, proc->out, -1, (uv_stream_t *)&proc->out->uv.pipe);
     proc->out->events = proc->events;
     proc->out->internal_data = proc;
     proc->out->internal_close_cb = on_process_stream_close;
@@ -97,7 +95,7 @@ bool process_spawn(Process *proc) FUNC_ATTR_NONNULL_ALL
   }
 
   if (proc->err) {
-    stream_init(NULL, proc->err, -1, (uv_stream_t *)&proc->err->uv.pipe, data);
+    stream_init(NULL, proc->err, -1, (uv_stream_t *)&proc->err->uv.pipe);
     proc->err->events = proc->events;
     proc->err->internal_data = proc;
     proc->err->internal_close_cb = on_process_stream_close;
@@ -373,7 +371,7 @@ static void flush_stream(Process *proc, Stream *stream)
       if (stream->read_cb) {
         // Stream callback could miss EOF handling if a child keeps the stream
         // open.
-        stream->read_cb(stream, stream->buffer, 0, stream->data, true);
+        stream->read_cb(stream, stream->buffer, 0, stream->cb_data, true);
       }
       break;
     }

--- a/src/nvim/event/rstream.c
+++ b/src/nvim/event/rstream.c
@@ -17,21 +17,19 @@
 # include "event/rstream.c.generated.h"
 #endif
 
-void rstream_init_fd(Loop *loop, Stream *stream, int fd, size_t bufsize,
-    void *data)
+void rstream_init_fd(Loop *loop, Stream *stream, int fd, size_t bufsize)
   FUNC_ATTR_NONNULL_ARG(1)
   FUNC_ATTR_NONNULL_ARG(2)
 {
-  stream_init(loop, stream, fd, NULL, data);
+  stream_init(loop, stream, fd, NULL);
   rstream_init(stream, bufsize);
 }
 
-void rstream_init_stream(Stream *stream, uv_stream_t *uvstream, size_t bufsize,
-    void *data)
+void rstream_init_stream(Stream *stream, uv_stream_t *uvstream, size_t bufsize)
   FUNC_ATTR_NONNULL_ARG(1)
   FUNC_ATTR_NONNULL_ARG(2)
 {
-  stream_init(NULL, stream, -1, uvstream, data);
+  stream_init(NULL, stream, -1, uvstream);
   rstream_init(stream, bufsize);
 }
 
@@ -48,10 +46,11 @@ void rstream_init(Stream *stream, size_t bufsize)
 /// Starts watching for events from a `Stream` instance.
 ///
 /// @param stream The `Stream` instance
-void rstream_start(Stream *stream, stream_read_cb cb)
+void rstream_start(Stream *stream, stream_read_cb cb, void *data)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   stream->read_cb = cb;
+  stream->cb_data = data;
   if (stream->uvstream) {
     uv_read_start(stream->uvstream, alloc_cb, read_cb);
   } else {
@@ -81,7 +80,7 @@ static void on_rbuffer_nonfull(RBuffer *buf, void *data)
 {
   Stream *stream = data;
   assert(stream->read_cb);
-  rstream_start(stream, stream->read_cb);
+  rstream_start(stream, stream->read_cb, stream->cb_data);
 }
 
 // Callbacks used by libuv
@@ -179,7 +178,7 @@ static void read_event(void **argv)
   if (stream->read_cb) {
     size_t count = (uintptr_t)argv[1];
     bool eof = (uintptr_t)argv[2];
-    stream->read_cb(stream, stream->buffer, count, stream->data, eof);
+    stream->read_cb(stream, stream->buffer, count, stream->cb_data, eof);
   }
   stream->pending_reqs--;
   if (stream->closed && !stream->pending_reqs) {

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -113,7 +113,7 @@ int socket_watcher_start(SocketWatcher *watcher, int backlog, socket_cb cb)
   return 0;
 }
 
-int socket_watcher_accept(SocketWatcher *watcher, Stream *stream, void *data)
+int socket_watcher_accept(SocketWatcher *watcher, Stream *stream)
   FUNC_ATTR_NONNULL_ARG(1) FUNC_ATTR_NONNULL_ARG(2)
 {
   uv_stream_t *client;
@@ -133,7 +133,7 @@ int socket_watcher_accept(SocketWatcher *watcher, Stream *stream, void *data)
     return result;
   }
 
-  stream_init(NULL, stream, -1, client, data);
+  stream_init(NULL, stream, -1, client);
   return 0;
 }
 

--- a/src/nvim/event/stream.h
+++ b/src/nvim/event/stream.h
@@ -44,13 +44,14 @@ struct stream {
   uv_file fd;
   stream_read_cb read_cb;
   stream_write_cb write_cb;
+  void *cb_data;
   stream_close_cb close_cb, internal_close_cb;
+  void *close_cb_data, *internal_data;
   size_t fpos;
   size_t curmem;
   size_t maxmem;
   size_t pending_reqs;
   size_t num_bytes;
-  void *data, *internal_data;
   bool closed;
   Queue *events;
 };

--- a/src/nvim/event/wstream.c
+++ b/src/nvim/event/wstream.c
@@ -22,19 +22,17 @@ typedef struct {
 # include "event/wstream.c.generated.h"
 #endif
 
-void wstream_init_fd(Loop *loop, Stream *stream, int fd, size_t maxmem,
-    void *data)
+void wstream_init_fd(Loop *loop, Stream *stream, int fd, size_t maxmem)
   FUNC_ATTR_NONNULL_ARG(1) FUNC_ATTR_NONNULL_ARG(2)
 {
-  stream_init(loop, stream, fd, NULL, data);
+  stream_init(loop, stream, fd, NULL);
   wstream_init(stream, maxmem);
 }
 
-void wstream_init_stream(Stream *stream, uv_stream_t *uvstream, size_t maxmem,
-    void *data)
+void wstream_init_stream(Stream *stream, uv_stream_t *uvstream, size_t maxmem)
   FUNC_ATTR_NONNULL_ARG(1) FUNC_ATTR_NONNULL_ARG(2)
 {
-  stream_init(NULL, stream, -1, uvstream, data);
+  stream_init(NULL, stream, -1, uvstream);
   wstream_init(stream, maxmem);
 }
 
@@ -54,10 +52,11 @@ void wstream_init(Stream *stream, size_t maxmem)
 ///
 /// @param stream The `Stream` instance
 /// @param cb The callback
-void wstream_set_write_cb(Stream *stream, stream_write_cb cb)
-  FUNC_ATTR_NONNULL_ALL
+void wstream_set_write_cb(Stream *stream, stream_write_cb cb, void *data)
+  FUNC_ATTR_NONNULL_ARG(1, 2)
 {
   stream->write_cb = cb;
+  stream->cb_data = data;
 }
 
 /// Queues data for writing to the backing file descriptor of a `Stream`
@@ -138,7 +137,7 @@ static void write_cb(uv_write_t *req, int status)
   wstream_release_wbuffer(data->buffer);
 
   if (data->stream->write_cb) {
-    data->stream->write_cb(data->stream, data->stream->data, status);
+    data->stream->write_cb(data->stream, data->stream->cb_data, status);
   }
 
   data->stream->pending_reqs--;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1244,6 +1244,9 @@ EXTERN char *ignoredp;
 // If a msgpack-rpc channel should be started over stdin/stdout
 EXTERN bool embedded_mode INIT(= false);
 
+/// next free id for a job or rpc channel
+EXTERN uint64_t next_chan_id INIT(= 1);
+
 /// Used to track the status of external functions.
 /// Currently only used for iconv().
 typedef enum {

--- a/src/nvim/msgpack_rpc/channel.h
+++ b/src/nvim/msgpack_rpc/channel.h
@@ -6,6 +6,7 @@
 
 #include "nvim/api/private/defs.h"
 #include "nvim/event/socket.h"
+#include "nvim/event/process.h"
 #include "nvim/vim.h"
 
 #define METHOD_MAXLEN 512

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -60,8 +60,8 @@ void input_start(int fd)
   }
 
   global_fd = fd;
-  rstream_init_fd(&main_loop, &read_stream, fd, READ_BUFFER_SIZE, NULL);
-  rstream_start(&read_stream, read_cb);
+  rstream_init_fd(&main_loop, &read_stream, fd, READ_BUFFER_SIZE);
+  rstream_start(&read_stream, read_cb, NULL);
 }
 
 void input_stop(void)
@@ -71,7 +71,7 @@ void input_stop(void)
   }
 
   rstream_stop(&read_stream);
-  stream_close(&read_stream, NULL);
+  stream_close(&read_stream, NULL, NULL);
 }
 
 static void cursorhold_event(void **argv)

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -236,10 +236,10 @@ static int do_os_system(char **argv,
   }
   proc->out->events = NULL;
   rstream_init(proc->out, 0);
-  rstream_start(proc->out, data_cb);
+  rstream_start(proc->out, data_cb, &buf);
   proc->err->events = NULL;
   rstream_init(proc->err, 0);
-  rstream_start(proc->err, data_cb);
+  rstream_start(proc->err, data_cb, &buf);
 
   // write the input, if any
   if (input) {
@@ -251,7 +251,7 @@ static int do_os_system(char **argv,
       return -1;
     }
     // close the input stream after everything is written
-    wstream_set_write_cb(&in, shell_write_cb);
+    wstream_set_write_cb(&in, shell_write_cb, NULL);
   }
 
   // invoke busy_start here so event_poll_until wont change the busy state for
@@ -546,5 +546,5 @@ static size_t write_output(char *output, size_t remaining, bool to_buffer,
 
 static void shell_write_cb(Stream *stream, void *data, int status)
 {
-  stream_close(stream, NULL);
+  stream_close(stream, NULL, NULL);
 }

--- a/test/functional/api/rpc_fixture.lua
+++ b/test/functional/api/rpc_fixture.lua
@@ -1,0 +1,38 @@
+local deps_prefix = './.deps/usr'
+if os.getenv('DEPS_PREFIX') then
+  deps_prefix = os.getenv('DEPS_PREFIX')
+end
+
+package.path = deps_prefix .. '/share/lua/5.1/?.lua;' ..
+               deps_prefix .. '/share/lua/5.1/?/init.lua;' ..
+               package.path
+
+package.cpath = deps_prefix .. '/lib/lua/5.1/?.so;' ..
+                package.cpath
+
+local mpack = require('mpack')
+local StdioStream = require('nvim.stdio_stream')
+local Session = require('nvim.session')
+
+local stdio_stream = StdioStream.open()
+local session = Session.new(stdio_stream)
+
+local function on_request(method, args)
+  if method == 'poll' then
+    return 'ok'
+  elseif method == 'write_stderr' then
+    io.stderr:write(args[1])
+    return "done!"
+  elseif method == "exit" then
+    session:stop()
+    return mpack.NIL
+  end
+end
+
+local function on_notification(event, args)
+  if event == 'ping' and #args == 0 then
+    session:notify("vim_eval", "rpcnotify(g:channel, 'pong')")
+  end
+end
+
+session:run(on_request, on_notification)

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -5,6 +5,7 @@ local clear, eq, eval, execute, feed, insert, neq, next_msg, nvim,
   helpers.insert, helpers.neq, helpers.next_message, helpers.nvim,
   helpers.nvim_dir, helpers.ok, helpers.source,
   helpers.write_file, helpers.mkdir, helpers.rmdir
+local command = helpers.command
 local Screen = require('test.functional.ui.screen')
 
 
@@ -427,6 +428,13 @@ describe('jobs', function()
     nvim('eval', 'jobstop(j)')
     eq({'notification', 'j', {0, {jobid, 'stdout', {'abcdef'}}}}, next_msg())
     eq({'notification', 'j', {0, {jobid, 'exit'}}}, next_msg())
+  end)
+
+  it('cannot have both rpc and pty options', function()
+    command("let g:job_opts.pty = v:true")
+    command("let g:job_opts.rpc = v:true")
+    local _, err = pcall(command, "let j = jobstart(['cat', '-'], g:job_opts)")
+    ok(string.find(err, "E475: Invalid argument: job cannot have both 'pty' and 'rpc' options set") ~= nil)
   end)
 
   describe('running tty-test program', function()


### PR DESCRIPTION
it seems mighty inconvenient that there is no way to get the stderr of a failed rplugin host other than looking in a log file that 1) might not exist 2) might be full of unrelated debug messages. 

This is the ugly hack/ad-hoc solution that add some job control callback logic to rpc channels. I suppose a "proper" way could be refactor channels to use `JobTerminalData` for job channels. (`Channel.data.process` would then be a pointer to this structure) This would also enable using `jobpid()`/`jobstop()` on a job channel.  (**done**)

There was an issue for this #2463 but I noticed again that `rpcstart(cmd, args)`is inconsistent with `jobstart([cmd, args...])`. We could handle this in a backwards-incompatible way by checking if the second argument is a list or a dict. Alternatively we could use `jobstart(..., {"rpc": v:true})` in analogy with `"pty"` (which also changes the available callbacks and functions)
