### PR TITLE
[RFC] Fix linking a cleared highlight group

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6931,7 +6931,12 @@ set_hl_attr (
   // before setting attr_entry->{f,g}g_color to a other than -1
   at_en.rgb_fg_color = sgp->sg_rgb_fg_name ? sgp->sg_rgb_fg : -1;
   at_en.rgb_bg_color = sgp->sg_rgb_bg_name ? sgp->sg_rgb_bg : -1;
-  sgp->sg_attr = get_attr_entry(&at_en);
+
+  if (at_en.cterm_fg_color != 0 || at_en.cterm_bg_color != 0
+      || at_en.rgb_fg_color != -1 || at_en.rgb_bg_color != -1
+      || at_en.cterm_ae_attr != 0 || at_en.rgb_ae_attr != 0) {
+    sgp->sg_attr = get_attr_entry(&at_en);
+  }
 }
 
 /*

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -262,4 +262,44 @@ describe('Default highlight groups', function()
     ]], {[1] = {bold = true, foreground = hlgroup_colors.Question}})
     feed('<cr>') --  skip the "Press ENTER..." state or tests will hang
   end)
+  it('can be cleared and linked to other highlight groups', function()
+    execute('highlight clear ModeMsg')
+    feed('i')
+    screen:expect([[
+      ^                                                     |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      -- INSERT --                                         |
+    ]], {})
+    feed('<esc>')
+    execute('highlight CustomHLGroup guifg=red guibg=green')
+    execute('highlight link ModeMsg CustomHLGroup')
+    feed('i')
+    screen:expect([[
+      ^                                                     |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      {1:-- INSERT --}                                         |
+    ]], {[1] = {foreground = Screen.colors.Red, background = Screen.colors.Green}})
+  end)
 end)


### PR DESCRIPTION
Resolves https://github.com/neovim/neovim/issues/4549, https://github.com/neovim/neovim/issues/2756, https://github.com/neovim/neovim/issues/4236, and https://github.com/neovim/neovim/issues/2756

Does not set an attrentry_T for a highlight group if the highlight group is cleared. Vim does this for [gui attribute entries](https://github.com/vim/vim/blob/master/src/syntax.c#L9209), [term-mode attribute entries](https://github.com/vim/vim/blob/master/src/syntax.c#L9237), and [color terminal attribute entries](https://github.com/vim/vim/blob/master/src/syntax.c#L9251). The check must have gotten lost during the refactor that unified the attribute entry tables.

Additional changes will be needed when https://github.com/neovim/neovim/pull/4633 is merged to make sure that highlight groups that only have the "special" color set will be added to the list of attribute entries. Aside from any merge conflicts, [this is a diff of the needed changes](https://github.com/AdnoC/neovim/commit/3e6508aa55168977772bca6bf7b953f86b79cda4.diff)
