### PR TITLE
[RFC] Fix dedent in test/functional/helpers.lua

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -176,7 +176,7 @@ local function dedent(str)
     return str
   end
   -- create a pattern for the indent
-  indent = indent:gsub('%s', '%%s')
+  indent = indent:gsub('%s', '[ \t]')
   -- strip it from the first line
   str = str:gsub('^'..indent, '')
   -- strip it from the remaining lines


### PR DESCRIPTION
The character class `%s` also matches a newline in lua, that's not really what we want here, as far as I can see (bugged me quite a bit today). It works in the other cases in this function, so I left it in, but the final gsub should preserve newlines.

Note that even now `dedent` might behave a bit surprising if you indent using a mixture of tabs and spaces, in which case you've had it coming for you anyways.

Also note that empty lines do not count towards the indenting, i.e. they are not counted as indent level 0. Nothing changed about this, I just thought I'd mention.
