### PR TITLE
[RFC] vim-patch:7.4.1223

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -508,6 +508,7 @@ void eval_init(void)
       /* add to compat scope dict */
       hash_add(&compat_hashtab, p->vv_di.di_key);
   }
+  vimvars[VV_VERSION].vv_nr = VIM_VERSION_100;
 
   dict_T *const msgpack_types_dict = dict_alloc();
   for (size_t i = 0; i < ARRAY_SIZE(msgpack_type_names); i++) {
@@ -17720,7 +17721,8 @@ void set_vim_var_special(const VimVarIndex idx, const SpecialVarValue val)
 void set_vim_var_string(const VimVarIndex idx, const char *const val,
                         const ptrdiff_t len)
 {
-  xfree(vimvars[idx].vv_str);
+  clear_tv(&vimvars[idx].vv_di.di_tv);
+  vimvars[idx].vv_type = VAR_STRING;
   if (val == NULL) {
     vimvars[idx].vv_str = NULL;
   } else if (len == -1) {
@@ -17736,7 +17738,8 @@ void set_vim_var_string(const VimVarIndex idx, const char *const val,
 /// @param[in,out]  val  Value to set to. Reference count will be incremented.
 void set_vim_var_list(const VimVarIndex idx, list_T *const val)
 {
-  list_unref(vimvars[idx].vv_list);
+  clear_tv(&vimvars[idx].vv_di.di_tv);
+  vimvars[idx].vv_type = VAR_LIST;
   vimvars[idx].vv_list = val;
   if (val != NULL) {
     val->lv_refcount++;
@@ -17750,7 +17753,8 @@ void set_vim_var_list(const VimVarIndex idx, list_T *const val)
 ///                      Also keys of the dictionary will be made read-only.
 void set_vim_var_dict(const VimVarIndex idx, dict_T *const val)
 {
-  dict_unref(vimvars[idx].vv_dict);
+  clear_tv(&vimvars[idx].vv_di.di_tv);
+  vimvars[idx].vv_type = VAR_DICT;
   vimvars[idx].vv_dict = val;
 
   if (val != NULL) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -470,7 +470,7 @@ static int included_patches[] = {
   // 1226 NA
   // 1225 NA
   // 1224 NA
-  // 1223,
+  1223,
   // 1222 NA
   // 1221 NA
   // 1220 NA

--- a/test/functional/legacy/assert_spec.lua
+++ b/test/functional/legacy/assert_spec.lua
@@ -141,6 +141,18 @@ describe('assert function:', function()
         tmpname_two .. " line 1: 'file two'",
       })
     end)
+
+    it('is reset to a list by assert functions', function()
+      source([[
+        let save_verrors = v:errors
+        let v:['errors'] = {'foo': 3}
+        call assert_equal('yes', 'no')
+        let verrors = v:errors
+        let v:errors = save_verrors
+        call assert_equal(type([]), type(verrors))
+      ]])
+      expected_empty()
+    end)
   end)
 
   -- assert_fails({cmd}, [, {error}])
@@ -159,5 +171,5 @@ describe('assert function:', function()
       call('assert_fails', 'call empty("")')
       expected_errors({'command did not fail: call empty("")'})
     end)
-  end)
+ end)
 end)


### PR DESCRIPTION
Problem:    Crash when setting v:errors to a number.
Solution:   Free the typval without assuming its type. (Yasuhiro Matsumoto)

https://github.com/vim/vim/commit/a542c680a8b42cb766e64d4ee7374ef4dacb7832

---

Not sure if the Travis failure is related?

```
Nil error
-- Output to stderr:
2016/05/11 08:57:29 [error @ open_log_file:101] 26003 - Couldn't open USR_LOG_FILE, logging to stderr! This may be caused by attempting to LOG() before initialization functions are called (e.g. init_homedir()).
2016/05/11 08:57:29 [debug @ log_server_msg:827] 26003 - [msgpack-rpc] nvim -> client(1) 2016/05/11 08:57:29 [error @ open_log_file:101] 26003 - Couldn't open USR_LOG_FILE, logging to stderr! This may be caused by attempting to LOG() before initialization functions are called (e.g. init_homedir()).
[response]     [1, 1, nil, 0]
CMake Error at /home/travis/build/neovim/neovim/cmake/RunTests.cmake:39 (message):
  Running functional tests failed with error: 1.
```
