### PR TITLE
[RFC] vim-patch 7.4.1266

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -1177,7 +1177,7 @@ static int included_patches[] = {
   1269,
   // 1268 NA
   1267,
-  // 1266
+  1266,
   // 1265 NA
   // 1264 NA
   // 1263 NA


### PR DESCRIPTION
Problem:    A BufAdd autocommand may cause an ml_get error (Christian
            Brabandt)
Solution:   Increment RedrawingDisabled earlier.

https://github.com/vim/vim/commit/ab9fc7e0cf22bcee119b62d3433cac60f405e645
