### PR TITLE
[RFC] vim-patch:7.4.1276

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1749,8 +1749,9 @@ failed:
 #ifdef HAVE_FD_CLOEXEC
   else {
     int fdflags = fcntl(fd, F_GETFD);
-    if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0)
-      fcntl(fd, F_SETFD, fdflags | FD_CLOEXEC);
+    if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0) {
+      (void)fcntl(fd, F_SETFD, fdflags | FD_CLOEXEC);
+    }
   }
 #endif
   xfree(buffer);

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -913,7 +913,7 @@ static bool mf_do_open(memfile_T *mfp, char_u *fname, int flags)
 #ifdef HAVE_FD_CLOEXEC
   int fdflags = fcntl(mfp->mf_fd, F_GETFD);
   if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0) {
-    fcntl(mfp->mf_fd, F_SETFD, fdflags | FD_CLOEXEC);
+    (void)fcntl(mfp->mf_fd, F_SETFD, fdflags | FD_CLOEXEC);
   }
 #endif
 #ifdef HAVE_SELINUX

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -443,8 +443,9 @@ void ml_setname(buf_T *buf)
 #ifdef HAVE_FD_CLOEXEC
     {
       int fdflags = fcntl(mfp->mf_fd, F_GETFD);
-      if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0)
-        fcntl(mfp->mf_fd, F_SETFD, fdflags | FD_CLOEXEC);
+      if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0) {
+        (void)fcntl(mfp->mf_fd, F_SETFD, fdflags | FD_CLOEXEC);
+      }
     }
 #endif
   }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -402,7 +402,7 @@ static int included_patches[] = {
   // 1279 NA
   // 1278 NA
   // 1277 NA
-  // 1276,
+  1276,
   // 1275 NA
   // 1274 NA
   // 1273,


### PR DESCRIPTION
vim-patch:7.4.1276
Problem:    Warning for not using return value of fcntl().
Solution:   Explicitly ignore the return value
