### PR TITLE
[RFC] vim-patch:7.4.1281

### DIFF
--- a/src/nvim/testdir/test_viml.vim
+++ b/src/nvim/testdir/test_viml.vim
@@ -922,6 +922,45 @@ func Test_curlies()
     call assert_equal(77, g:a['t'])
 endfunc
 
+"-------------------------------------------------------------------------------
+" Test 91:  using type().					    {{{1
+"-------------------------------------------------------------------------------
+
+func Test_type()
+    call assert_equal(0, type(0))
+    call assert_equal(1, type(""))
+    call assert_equal(2, type(function("tr")))
+    call assert_equal(3, type([]))
+    call assert_equal(4, type({}))
+    call assert_equal(5, type(0.0))
+    call assert_equal(6, type(v:false))
+    call assert_equal(6, type(v:true))
+    call assert_equal(7, type(v:null))
+endfunc
+
+"-------------------------------------------------------------------------------
+" Test 92:  skipping code                       {{{1
+"-------------------------------------------------------------------------------
+
+func Test_skip()
+    let Fn = function('Test_type')
+    call assert_false(0 && Fn[1])
+    call assert_false(0 && string(Fn))
+    call assert_false(0 && len(Fn))
+    let l = []
+    call assert_false(0 && l[1])
+    call assert_false(0 && string(l))
+    call assert_false(0 && len(l))
+    let f = 1.0
+    call assert_false(0 && f[1])
+    call assert_false(0 && string(f))
+    call assert_false(0 && len(f))
+    let sp = v:null
+    call assert_false(0 && sp[1])
+    call assert_false(0 && string(sp))
+    call assert_false(0 && len(sp))
+
+endfunc
 
 "-------------------------------------------------------------------------------
 " Modelines								    {{{1

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -397,7 +397,7 @@ static int included_patches[] = {
   1284,
   // 1283 NA
   1282,
-  // 1281,
+  1281,
   // 1280 NA
   // 1279 NA
   // 1278 NA


### PR DESCRIPTION
Problem:    No test for skipping over code that isn't evaluated.
Solution:   Add a test with code that would fail when not skipped.

https://github.com/vim/vim/commit/ea8c219ca852cc8eaf603b1bf475edf95e2850cf

---

Question:
This test relies on a specific test from 1157 which was done in a different way by ZyX...I could add the test into the test_viml file but that might be unwanted duplication...the other alternative would be converting 1281 to lua and moving it out of test_viml.vim.
