### PR TITLE
Make listchar override cursorline in highlight

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3727,11 +3727,9 @@ win_line (
         c = 0xc0;
       } else
         mb_utf8 = FALSE;                /* don't draw as UTF-8 */
-      if (!attr_pri) {
-        saved_attr3 = char_attr;         /* save current attr */
-        char_attr = hl_attr(HLF_AT);         /* later copied to char_attr */
-        n_attr3 = 1;
-      }
+      saved_attr3 = char_attr;  // save current attr
+      char_attr = hl_attr(HLF_AT);  // later copied to char_attr
+      n_attr3 = 1;
     }
 
     /*

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3725,8 +3725,9 @@ win_line (
         mb_utf8 = TRUE;
         u8cc[0] = 0;
         c = 0xc0;
-      } else
-        mb_utf8 = FALSE;                /* don't draw as UTF-8 */
+      } else {
+        mb_utf8 = false;  // don't draw as UTF-8
+      }
       saved_attr3 = char_attr;  // save current attr
       char_attr = hl_attr(HLF_AT);  // later copied to char_attr
       n_attr3 = 1;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3385,11 +3385,9 @@ win_line (
                  && lcs_nbsp)
                 || (c == ' ' && lcs_space && ptr - line <= trailcol))) {
           c = (c == ' ') ? lcs_space : lcs_nbsp;
-          if (area_attr == 0 && search_attr == 0) {
-            n_attr = 1;
-            extra_attr = hl_attr(HLF_8);
-            saved_attr2 = char_attr;  // save current attr
-          }
+          n_attr = 1;
+          extra_attr = hl_attr(HLF_8);
+          saved_attr2 = char_attr;  // save current attr
           mb_c = c;
           if (enc_utf8 && (*mb_char2len)(c) > 1) {
             mb_utf8 = true;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3404,7 +3404,7 @@ win_line (
           c = lcs_trail;
           n_attr = 1;
           extra_attr = hl_attr(HLF_8);
-          saved_attr2 = char_attr;             /* save current attr */
+          saved_attr2 = char_attr;  // save current attr
           mb_c = c;
           if (enc_utf8 && (*mb_char2len)(c) > 1) {
             mb_utf8 = TRUE;
@@ -3552,7 +3552,7 @@ win_line (
             c = ' ';
           }
           lcs_eol_one = -1;
-          --ptr;                    /* put it back at the NUL */
+          ptr--;  // put it back at the NUL
           extra_attr = hl_attr(HLF_AT);
           n_attr = 1;
           mb_c = c;
@@ -3585,8 +3585,8 @@ win_line (
           }
           n_attr = n_extra + 1;
           extra_attr = hl_attr(HLF_8);
-          saved_attr2 = char_attr;             /* save current attr */
-          mb_utf8 = FALSE;              /* don't draw as UTF-8 */
+          saved_attr2 = char_attr;  // save current attr
+          mb_utf8 = false;   // don't draw as UTF-8
         } else if (VIsual_active
                    && (VIsual_mode == Ctrl_V
                        || VIsual_mode == 'v')
@@ -3696,9 +3696,10 @@ win_line (
       did_wcol = true;
     }
 
-    /* Don't override visual selection highlighting. */
-    if (n_attr > 0 && draw_state == WL_LINE)
+    // Don't override visual selection highlighting.
+    if (n_attr > 0 && draw_state == WL_LINE) {
       char_attr = hl_combine_attr(char_attr, extra_attr);
+    }
 
     /*
      * Handle the case where we are in column 0 but not on the first

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3402,11 +3402,9 @@ win_line (
 
         if (trailcol != MAXCOL && ptr > line + trailcol && c == ' ') {
           c = lcs_trail;
-          if (!attr_pri) {
-            n_attr = 1;
-            extra_attr = hl_attr(HLF_8);
-            saved_attr2 = char_attr;             /* save current attr */
-          }
+          n_attr = 1;
+          extra_attr = hl_attr(HLF_8);
+          saved_attr2 = char_attr;             /* save current attr */
           mb_c = c;
           if (enc_utf8 && (*mb_char2len)(c) > 1) {
             mb_utf8 = TRUE;
@@ -3555,10 +3553,8 @@ win_line (
           }
           lcs_eol_one = -1;
           --ptr;                    /* put it back at the NUL */
-          if (!attr_pri) {
-            extra_attr = hl_attr(HLF_AT);
-            n_attr = 1;
-          }
+          extra_attr = hl_attr(HLF_AT);
+          n_attr = 1;
           mb_c = c;
           if (enc_utf8 && (*mb_char2len)(c) > 1) {
             mb_utf8 = TRUE;
@@ -3587,11 +3583,9 @@ win_line (
             n_extra = byte2cells(c) - 1;
             c = *p_extra++;
           }
-          if (!attr_pri) {
-            n_attr = n_extra + 1;
-            extra_attr = hl_attr(HLF_8);
-            saved_attr2 = char_attr;             /* save current attr */
-          }
+          n_attr = n_extra + 1;
+          extra_attr = hl_attr(HLF_8);
+          saved_attr2 = char_attr;             /* save current attr */
           mb_utf8 = FALSE;              /* don't draw as UTF-8 */
         } else if (VIsual_active
                    && (VIsual_mode == Ctrl_V
@@ -3703,10 +3697,8 @@ win_line (
     }
 
     /* Don't override visual selection highlighting. */
-    if (n_attr > 0
-        && draw_state == WL_LINE
-        && !attr_pri)
-      char_attr = extra_attr;
+    if (n_attr > 0 && draw_state == WL_LINE)
+      char_attr = hl_combine_attr(char_attr, extra_attr);
 
     /*
      * Handle the case where we are in column 0 but not on the first

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -304,9 +304,7 @@ describe('Default highlight groups', function()
   end)
 end)
 
-describe('Cursorline highlight', function()
-  -- Test the default attributes for highlight groups shown by the :highlight
-  -- command
+describe("'cursorline' with 'listchars'", function()
   local screen
 
   local hlgroup_colors = {
@@ -317,7 +315,7 @@ describe('Cursorline highlight', function()
 
   before_each(function()
     clear()
-    screen = Screen.new()
+    screen = Screen.new(20,5)
     screen:attach()
   end)
 
@@ -325,152 +323,80 @@ describe('Cursorline highlight', function()
     screen:detach()
   end)
 
-  it('cursorline and cursorcolumn', function()
+  it("'cursorline' and 'cursorcolumn'", function()
     screen:set_default_attr_ids({[1] = {background=hlgroup_colors.Cursorline}})
     screen:set_default_attr_ignore( {{bold=true, foreground=hlgroup_colors.NonText}} )
     execute('highlight clear ModeMsg')
     execute('set cursorline')
     feed('i')
     screen:expect([[
-      {1:^                                                     }|
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      -- INSERT --                                         |
+      {1:^                    }|
+      ~                   |
+      ~                   |
+      ~                   |
+      -- INSERT --        |
     ]])
     feed('abcdefg<cr>kkasdf')
     screen:expect([[
-      abcdefg                                              |
-      {1:kkasdf^                                               }|
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      -- INSERT --                                         |
+      abcdefg             |
+      {1:kkasdf^              }|
+      ~                   |
+      ~                   |
+      -- INSERT --        |
     ]])
     feed('<esc>')
     screen:expect([[
-      abcdefg                                              |
-      {1:kkasd^f                                               }|
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-                                                           |
+      abcdefg             |
+      {1:kkasd^f              }|
+      ~                   |
+      ~                   |
+                          |
     ]])
     execute('set nocursorline')
     screen:expect([[
-      abcdefg                                              |
-      kkasd^f                                               |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      :set nocursorline                                    |
+      abcdefg             |
+      kkasd^f              |
+      ~                   |
+      ~                   |
+      :set nocursorline   |
     ]])
     feed('k')
     screen:expect([[
-      abcde^fg                                              |
-      kkasdf                                               |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      :set nocursorline                                    |
+      abcde^fg             |
+      kkasdf              |
+      ~                   |
+      ~                   |
+      :set nocursorline   |
     ]])
     feed('jjji<cr><cr><cr><esc>')
     screen:expect([[
-      abcdefg                                              |
-      kkasd                                                |
-                                                           |
-                                                           |
-      ^f                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-                                                           |
+      kkasd               |
+                          |
+                          |
+      ^f                   |
+                          |
     ]])
     execute('set cursorline')
     execute('set cursorcolumn')
     feed('kkiabcdefghijk<esc>hh')
     screen:expect([[
-      abcdefg {1: }                                            |
-      kkasd   {1: }                                            |
-      {1:abcdefgh^ijk                                          }|
-              {1: }                                            |
-      f       {1: }                                            |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-                                                           |
+      kkasd   {1: }           |
+      {1:abcdefgh^ijk         }|
+              {1: }           |
+      f       {1: }           |
+                          |
     ]])
     feed('khh')
     screen:expect([[
-      ab{1:c}defg                                              |
-      {1:kk^asd                                                }|
-      ab{1:c}defghijk                                          |
-        {1: }                                                  |
-      f {1: }                                                  |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-                                                           |
+      {1:kk^asd               }|
+      ab{1:c}defghijk         |
+        {1: }                 |
+      f {1: }                 |
+                          |
     ]])
   end)
 
-  it('cursorline and listchar', function()
+  it("'cursorline' and with 'listchar' option: space, eol, tab, and trail", function()
     screen:set_default_attr_ids({
       [1] = {background=hlgroup_colors.Cursorline},
       [2] = {
@@ -495,56 +421,29 @@ describe('Cursorline highlight', function()
     execute('set cursorline')
     execute('set tabstop=8')
     execute('set listchars=space:.,eol:¬,tab:>-,extends:],precedes:[,trail:* list')
-    feed('i\t\t    abcd    <cr>\t\t    abcd    <cr><esc>k')
+    feed('i\t abcd <cr>\t abcd <cr><esc>k')
     screen:expect([[
-      {5:>------->-------....}abcd{5:****}{4:¬}                        |
-      {2:^>------->-------....}{1:abcd}{2:****}{3:¬}{1:                        }|
-      {4:¬}                                                    |
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-                                                           |
+      {5:>-------.}abcd{5:*}{4:¬}     |
+      {2:^>-------.}{1:abcd}{2:*}{3:¬}{1:     }|
+      {4:¬}                   |
+      {4:~                   }|
+                          |
     ]])
     feed('k')
     screen:expect([[
-      {2:^>------->-------....}{1:abcd}{2:****}{3:¬}{1:                        }|
-      {5:>------->-------....}abcd{5:****}{4:¬}                        |
-      {4:¬}                                                    |
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-                                                           |
+      {2:^>-------.}{1:abcd}{2:*}{3:¬}{1:     }|
+      {5:>-------.}abcd{5:*}{4:¬}     |
+      {4:¬}                   |
+      {4:~                   }|
+                          |
     ]])
     execute('set nocursorline')
     screen:expect([[
-      {5:^>------->-------....}abcd{5:****}{4:¬}                        |
-      {5:>------->-------....}abcd{5:****}{4:¬}                        |
-      {4:¬}                                                    |
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      {4:~                                                    }|
-      :set nocursorline                                    |
+      {5:^>-------.}abcd{5:*}{4:¬}     |
+      {5:>-------.}abcd{5:*}{4:¬}     |
+      {4:¬}                   |
+      {4:~                   }|
+      :set nocursorline   |
     ]])
   end)
 end)

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -311,6 +311,7 @@ describe("'cursorline' with 'listchars'", function()
     NonText = Screen.colors.Blue,
     Cursorline = Screen.colors.Grey90,
     SpecialKey = Screen.colors.Red,
+    Visual = Screen.colors.LightGrey,
   }
 
   before_each(function()
@@ -420,7 +421,7 @@ describe("'cursorline' with 'listchars'", function()
     execute('highlight SpecialKey guifg=#FF0000')
     execute('set cursorline')
     execute('set tabstop=8')
-    execute('set listchars=space:.,eol:¬,tab:>-,extends:],precedes:[,trail:* list')
+    execute('set listchars=space:.,eol:¬,tab:>-,extends:>,precedes:<,trail:* list')
     feed('i\t abcd <cr>\t abcd <cr><esc>k')
     screen:expect([[
       {5:>-------.}abcd{5:*}{4:¬}     |
@@ -444,6 +445,111 @@ describe("'cursorline' with 'listchars'", function()
       {4:¬}                   |
       {4:~                   }|
       :set nocursorline   |
+    ]])
+    execute('set nowrap')
+    feed('ALorem ipsum dolor sit amet<ESC>0')
+    screen:expect([[
+      {5:^>-------.}abcd{5:.}Lorem{4:>}|
+      {5:>-------.}abcd{5:*}{4:¬}     |
+      {4:¬}                   |
+      {4:~                   }|
+                          |
+    ]])
+    execute('set cursorline')
+    screen:expect([[
+      {2:^>-------.}{1:abcd}{2:.}{1:Lorem}{4:>}|
+      {5:>-------.}abcd{5:*}{4:¬}     |
+      {4:¬}                   |
+      {4:~                   }|
+      :set cursorline     |
+    ]])
+    feed('$')
+    screen:expect([[
+      {4:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
+      {4:<}                   |
+      {4:<}                   |
+      {4:~                   }|
+      :set cursorline     |
+    ]])
+    feed('G')
+    screen:expect([[
+      {5:>-------.}abcd{5:.}Lorem{4:>}|
+      {5:>-------.}abcd{5:*}{4:¬}     |
+      {3:^¬}{1:                   }|
+      {4:~                   }|
+      :set cursorline     |
+    ]])
+  end)
+
+  it("'listchar' in visual mode", function()
+    screen:set_default_attr_ids({
+      [1] = {background=hlgroup_colors.Cursorline},
+      [2] = {
+        foreground=hlgroup_colors.SpecialKey,
+        background=hlgroup_colors.Cursorline,
+      },
+      [3] = {
+        background=hlgroup_colors.Cursorline,
+        foreground=hlgroup_colors.NonText,
+        bold=true,
+      },
+      [4] = {
+        foreground=hlgroup_colors.NonText,
+        bold=true,
+      },
+      [5] = {
+        foreground=hlgroup_colors.SpecialKey,
+      },
+      [6] = {
+        background=hlgroup_colors.Visual,
+      },
+      [7] = {
+        background=hlgroup_colors.Visual,
+        foreground=hlgroup_colors.SpecialKey,
+      },
+      [8] = {
+        background=hlgroup_colors.Visual,
+        foreground=hlgroup_colors.NonText,
+        bold=true,
+      },
+    })
+    execute('highlight clear ModeMsg')
+    execute('highlight SpecialKey guifg=#FF0000')
+    execute('set cursorline')
+    execute('set tabstop=8')
+    execute('set nowrap')
+    execute('set listchars=space:.,eol:¬,tab:>-,extends:>,precedes:<,trail:* list')
+    feed('i\t abcd <cr>\t abcd Lorem ipsum dolor sit amet<cr><esc>kkk0')
+    screen:expect([[
+      {2:^>-------.}{1:abcd}{2:*}{3:¬}{1:     }|
+      {5:>-------.}abcd{5:.}Lorem{4:>}|
+      {4:¬}                   |
+      {4:~                   }|
+                          |
+    ]])
+    feed('lllvj')
+    screen:expect([[
+      {5:>-------.}a{6:bcd}{7:*}{8:¬}     |
+      {7:>-------.}{6:a}^bcd{5:.}Lorem{4:>}|
+      {4:¬}                   |
+      {4:~                   }|
+      -- VISUAL --        |
+    ]])
+    feed('<esc>V')
+    screen:expect([[
+      {5:>-------.}abcd{5:*}{4:¬}     |
+      {7:>-------.}{6:a}^b{6:cd}{7:.}{6:Lorem}{4:>}|
+      {4:¬}                   |
+      {4:~                   }|
+      -- VISUAL LINE --   |
+    ]])
+    feed('<esc>$')
+    screen:expect([[
+      {4:<}                   |
+      {4:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
+      {4:<}                   |
+      {4:~                   }|
+                          |
     ]])
   end)
 end)

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -23,7 +23,12 @@ describe('Mouse input', function()
     screen:attach()
     screen:set_default_attr_ids({
       [1] = {background = hlgroup_colors.Visual},
-      [2] = {bold = true}
+      [2] = {bold = true},
+      [3] = {
+        foreground = hlgroup_colors.NonText,
+        background = hlgroup_colors.Visual,
+        bold = true,
+      },
     })
     screen:set_default_attr_ignore( {{bold=true, foreground=hlgroup_colors.NonText}} )
     feed('itesting<cr>mouse<cr>support and selection<esc>')
@@ -225,14 +230,14 @@ describe('Mouse input', function()
     feed('<LeftDrag><2,2>')
     screen:expect([[
       testing                  |
-      mo{1:use }                   |
+      mo{1:use}{3: }                   |
       {1:su}^pport and selection    |
       ~                        |
       {2:-- VISUAL --}             |
     ]])
     feed('<LeftDrag><0,0>')
     screen:expect([[
-      ^t{1:esting }                 |
+      ^t{1:esting}{3: }                 |
       {1:mou}se                    |
       support and selection    |
       ~                        |
@@ -293,7 +298,7 @@ describe('Mouse input', function()
     screen:expect([[
       testing                  |
       mouse                    |
-      {1:su}^p{1:port and selection }   |
+      {1:su}^p{1:port and selection}{3: }   |
       ~                        |
       {2:-- VISUAL LINE --}        |
     ]])
@@ -321,8 +326,8 @@ describe('Mouse input', function()
     ]])
     feed('<RightMouse><2,2>')
     screen:expect([[
-      {1:testing }                 |
-      {1:mouse }                   |
+      {1:testing}{3: }                 |
+      {1:mouse}{3: }                   |
       {1:su}^pport and selection    |
       ~                        |
       {2:-- VISUAL --}             |


### PR DESCRIPTION
With this PR, the highlight of cursorline and cursorcolumn can work with
list/listchar better.  Put the following in your vim setting:

```
set listchars=space:.,eol:¬,tab:>-,extends:>,precedes:<,trail:-,nbsp:- list
set cursorline
```

and put your cursor in the first line while view the file with following content:

```
    sdfabcd asdf asdf asdf asd f asdfas df asd fa sdf asadsf asdf adf asdf a sdf df   
```

Before the patch:

http://imgur.com/E2vPlWp

After the patch:

http://imgur.com/cn6lj12

Notice the difference in the color of space, tab, and eol symbol.  This should
fix Issue #3670.
