### PR TITLE
[RFC] :Man: use :split to create a new window instead of :tab

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -62,7 +62,7 @@ function man#get_page(...) abort
     endif
 
     if &filetype !=# 'man'
-      let editcmd = 'tabnew'
+      let editcmd = 'split'
     endif
   endif
 
@@ -84,7 +84,7 @@ function man#get_page(...) abort
   setlocal nomodified
   setlocal filetype=man
 
-  if invoked_from_man || editcmd ==# 'tabnew'
+  if invoked_from_man || editcmd ==# 'split'
     call s:set_window_local_options()
   endif
 endfunction


### PR DESCRIPTION
Fix #4751 

This is what vim does, so maybe we should do the same.

Or, as said in #4751, maybe we need an option for this
