### PR TITLE
[RFC] Fix be64toh() detection on BSDs.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -67,6 +67,14 @@ if(HAVE_LANGINFO_H)
   check_symbol_exists(CODESET "langinfo.h" HAVE_NL_LANGINFO_CODESET)
 endif()
 
+check_include_files("endian.h" HAVE_ENDIAN_H)
+check_include_files("sys/endian.h" HAVE_SYS_ENDIAN_H)
+
+set(ENDIAN_INCLUDE_FILE "endian.h")
+if(HAVE_SYS_ENDIAN_H AND NOT HAVE_ENDIAN_H)
+  set(ENDIAN_INCLUDE_FILE "sys/endian.h")
+endif()
+
 set(SI "#include <stdint.h>\n")
 set(MS "int main(int argc,char**argv)\n{\n  uint64_t i=0x0102030405060708ULL;")
 set(ME "}")
@@ -74,7 +82,7 @@ check_c_source_compiles("
   #define _BSD_SOURCE 1
   #define _DEFAULT_SOURCE 1
   ${SI}
-  #include <endian.h>
+  #include <${ENDIAN_INCLUDE_FILE}>
   #ifndef be64toh
   # error No be64toh macros
   #endif

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -57,5 +57,6 @@
 
 #cmakedefine HAVE_BE64TOH
 #cmakedefine ORDER_BIG_ENDIAN
+#define ENDIAN_INCLUDE_FILE <@ENDIAN_INCLUDE_FILE@>
 
 #endif  // AUTO_CONFIG_H

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -46,7 +46,7 @@
 #ifdef HAVE_BE64TOH
 # define _BSD_SOURCE 1
 # define _DEFAULT_SOURCE 1
-# include <endian.h>
+# include ENDIAN_INCLUDE_FILE
 #endif
 
 // Note: when using bufset hash pointers are intentionally casted to uintptr_t


### PR DESCRIPTION
This was noticed due to a user issue (#4750) when building Neovim 0.1.4
via ports.  The crux of the issue is that we did not detect the
be64toh() macro, because there is no endian.h on FreeBSD (along with
several other BSDs).  So we were defaulting to our builtin version of
be64toh().  However, it appears that sys/endian.h was being picked up by
an include (likely msgpack.h) and so be64toh() was actually defined and
corrupting our definition of it.

So the answer here was to use the correct include file in our check, and
export that information in the config.h.  Then we use that information
to include the right header in shada.c.

This fixes #4750.
