### PR TITLE
[RFC] Fix tui_spec.lua for QB/Travis

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -154,9 +154,7 @@ describe('tui', function()
     for i = 1, 3000 do
       t[i] = 'item ' .. tostring(i)
     end
-    feed('i\027[200~')
-    feed(table.concat(t, '\n'))
-    feed('\027[201~')
+    feed('i\027[200~'..table.concat(t, '\n')..'\027[201~')
     screen:expect([[
       item 2997                                         |
       item 2998                                         |


### PR DESCRIPTION
This was not a problem locally, but would often/sometimes/etc. (YMMV) fail on QB
and/or travis. This seems to fix it. Quoting @justinmk: "I have a feeling this
is just a bug in the bracketed paste special-cases in the existing code".
