### PR TITLE
[RFC] vim-patch:7.4.1513

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7648,19 +7648,25 @@ static void nv_halfpage(cmdarg_T *cap)
  */
 static void nv_join(cmdarg_T *cap)
 {
-  if (VIsual_active)    /* join the visual lines */
+  if (VIsual_active) {  // join the visual lines
     nv_operator(cap);
-  else if (!checkclearop(cap->oap)) {
-    if (cap->count0 <= 1)
-      cap->count0 = 2;              /* default for join is two lines! */
-    if (curwin->w_cursor.lnum + cap->count0 - 1 >
-        curbuf->b_ml.ml_line_count)
-      clearopbeep(cap->oap);        /* beyond last line */
-    else {
-      prep_redo(cap->oap->regname, cap->count0,
-          NUL, cap->cmdchar, NUL, NUL, cap->nchar);
-      do_join(cap->count0, cap->nchar == NUL, true, true, true);
+  } else if (!checkclearop(cap->oap)) {
+    if (cap->count0 <= 1) {
+      cap->count0 = 2;  // default for join is two lines!
     }
+    if (curwin->w_cursor.lnum + cap->count0 - 1 >
+        curbuf->b_ml.ml_line_count) {
+      // can't join when on the last line
+      if (cap->count0 <= 2) {
+        clearopbeep(cap->oap);
+        return;
+      }
+      cap->count0 = curbuf->b_ml.ml_line_count - curwin->w_cursor.lnum + 1;
+    }
+
+    prep_redo(cap->oap->regname, cap->count0,
+              NUL, cap->cmdchar, NUL, NUL, cap->nchar);
+    do_join(cap->count0, cap->nchar == NUL, true, true, true);
   }
 }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -169,7 +169,7 @@ static int included_patches[] = {
   // 1516,
   // 1515 NA
   // 1514 NA
-  // 1513,
+  1513,
   // 1512 NA
   1511,
   // 1510 NA

--- a/test/functional/legacy/join_spec.lua
+++ b/test/functional/legacy/join_spec.lua
@@ -1,0 +1,20 @@
+-- Test for joining lines
+
+local helpers = require('test.functional.helpers')
+local clear, eq = helpers.clear, helpers.eq
+local eval, execute = helpers.eval, helpers.execute
+
+describe('joining lines', function()
+  before_each(clear)
+
+  it('is working', function()
+    execute('new')
+    execute([[call setline(1, ['one', 'two', 'three', 'four'])]])
+    execute('normal J')
+    eq('one two', eval('getline(1)'))
+    execute('%del')
+    execute([[call setline(1, ['one', 'two', 'three', 'four'])]])
+    execute('normal 10J')
+    eq('one two three four', eval('getline(1)'))
+  end)
+end)


### PR DESCRIPTION
Problem:    "J" fails if there are not enough lines. (Christian Neukirchen)
Solution:   Reduce the count, only fail on the last line.

https://github.com/vim/vim/commit/41e0f2f48f541eb2c8eb5620d3f1d270eb979154
