### PR TITLE
clipboard: support "doit" tool

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -52,6 +52,11 @@ elseif executable('lemonade')
   let s:paste['+'] = 'lemonade paste'
   let s:copy['*'] = 'lemonade copy'
   let s:paste['*'] = 'lemonade paste'
+elseif executable('doitclient')
+  let s:copy['+'] = 'doitclient wclip'
+  let s:paste['+'] = 'doitclient wclip -r'
+  let s:copy['*'] = s:copy['+']
+  let s:paste['*'] = s:paste['+']
 else
   echom 'clipboard: No clipboard tool available. See :help nvim-clipboard'
   finish

--- a/runtime/doc/nvim_clipboard.txt
+++ b/runtime/doc/nvim_clipboard.txt
@@ -24,6 +24,8 @@ is found in your `$PATH`.
 - pbcopy/pbpaste (only for Mac OS X)
 - lemonade (useful for SSH machine)
   https://github.com/pocke/lemonade
+- doitclient (another option for SSH setups from the maintainer of PuTTY)
+  http://www.chiark.greenend.org.uk/~sgtatham/doit/
 
 The presence of a suitable clipboard tool implicitly enables the '+' and '*'
 registers.


### PR DESCRIPTION
Support [doit](http://www.chiark.greenend.org.uk/~sgtatham/doit/), another clipboard provider, similar to but somewhat more mature than the already-supported [lemonade](https://github.com/pocke/lemonade/).
