### PR TITLE
[WIP] terminal_open leak, heap-use-after-free

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21720,7 +21720,12 @@ static void term_close(void *d)
     data->exited = true;
     process_stop((Process *)&data->proc);
   }
-  queue_put(data->events, term_delayed_free, 1, data);
+  if (exiting) {
+    terminal_destroy(data->term);
+    term_job_data_decref(d);
+  } else {
+    queue_put(data->events, term_delayed_free, 1, data);
+  }
 }
 
 static void term_job_data_decref(TerminalJobData *data)

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -309,7 +309,7 @@ void terminal_close(Terminal *term, char *msg)
   buf_T *buf = handle_get_buffer(term->buf_handle);
 
   if (!msg || exiting) {
-    // If no msg was given, this was called by close_buffer(buffer.c).  Or if
+    // If no msg was given, this was called by buffer.c/close_buffer().  Or if
     // exiting, we must inform the buffer the terminal no longer exists so that
     // close_buffer() doesn't call this again.
     term->buf_handle = 0;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -491,7 +491,7 @@ void terminal_destroy(Terminal *term)
     buf->terminal = NULL;
   }
 
-  if (!term->refcount) {
+  // if (!term->refcount) {
     if (pmap_has(ptr_t)(invalidated_terminals, term)) {
       // flush any pending changes to the buffer
       block_autocmds();
@@ -505,7 +505,7 @@ void terminal_destroy(Terminal *term)
     xfree(term->sb_buffer);
     vterm_free(term->vt);
     xfree(term);
-  }
+  // }
 }
 
 void terminal_send(Terminal *term, char *data, size_t size)

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -56,4 +56,15 @@ describe(':terminal', function()
       -- Verify that BufNew actually fired (else the test is invalid).
     eq('foo', eval('&shell'))
   end)
+
+  it('with bufhidden=delete #3958', function()
+    execute('set hidden')
+    eq(1, eval('&hidden'))
+    execute('autocmd BufNew * setlocal bufhidden=delete')
+    for _ = 1, 5 do
+      source([[
+        execute 'edit '.reltimestr(reltime())
+        terminal]])
+    end
+  end)
 end)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -75,8 +75,8 @@ endif()
 
 include(ExternalProject)
 
-set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.8.0.tar.gz)
-set(LIBUV_SHA256 906e1a5c673c95cb261adeacdb7308a65b4a8f7c9c50d85f3021364951fa9cde)
+set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.9.0.tar.gz)
+set(LIBUV_SHA256 f8b8272a0d80138b709d38fad2baf771899eed61e7f9578d17898b07a1a2a5eb)
 
 set(MSGPACK_URL https://github.com/msgpack/msgpack-c/archive/cpp-1.0.0.tar.gz)
 set(MSGPACK_SHA256 afda64ca445203bb7092372b822bae8b2539fdcebbfc3f753f393628c2bcfe7d)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -75,8 +75,8 @@ endif()
 
 include(ExternalProject)
 
-set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.9.0.tar.gz)
-set(LIBUV_SHA256 f8b8272a0d80138b709d38fad2baf771899eed61e7f9578d17898b07a1a2a5eb)
+set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.8.0.tar.gz)
+set(LIBUV_SHA256 906e1a5c673c95cb261adeacdb7308a65b4a8f7c9c50d85f3021364951fa9cde)
 
 set(MSGPACK_URL https://github.com/msgpack/msgpack-c/archive/cpp-1.0.0.tar.gz)
 set(MSGPACK_SHA256 afda64ca445203bb7092372b822bae8b2539fdcebbfc3f753f393628c2bcfe7d)


### PR DESCRIPTION
References #3958

Test provokes ASAN failure:

```
=================================================================
==12124==ERROR: AddressSanitizer: heap-use-after-free on address 0x625000070928 at pc 0x000003abe56f bp 0x7fff3d320b10 sp 0x7fff3d320b08
READ of size 8 at 0x625000070928 thread T0
    #0 0x3abe56e in terminal_receive /home/travis/build/neovim/neovim/src/nvim/terminal.c:541:21
    #1 0xeaf1c3 in on_job_output /home/travis/build/neovim/neovim/src/nvim/eval.c:21664:5
    #2 0xeadbe4 in on_job_stdout /home/travis/build/neovim/neovim/src/nvim/eval.c:21639:3
    #3 0x119d6d2 in read_event /home/travis/build/neovim/neovim/src/nvim/event/rstream.c:178:5
    #4 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #5 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #6 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #7 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #8 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3
    #9 0x1cfcd37 in main /home/travis/build/neovim/neovim/src/nvim/main.c:538:3
    #10 0x2b30c093876c in __libc_start_main /build/eglibc-rrybNj/eglibc-2.15/csu/libc-start.c:226
    #11 0x46b268 in _start (/home/travis/build/neovim/neovim/build/bin/nvim+0x46b268)

0x625000070928 is located 40 bytes inside of 8328-byte region [0x625000070900,0x625000072988)
freed by thread T0 here:
    #0 0x4f1f72 in __interceptor_free (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f1f72)
    #1 0x2073ea5 in xfree /home/travis/build/neovim/neovim/src/nvim/memory.c:105:3
    #2 0x3ad386d in terminal_destroy /home/travis/build/neovim/neovim/src/nvim/terminal.c:507:5
    #3 0xea9b49 in term_close /home/travis/build/neovim/neovim/src/nvim/eval.c:21711:3
    #4 0x3abdd6b in terminal_close /home/travis/build/neovim/neovim/src/nvim/terminal.c:321:7
    #5 0x6d9355 in close_buffer /home/travis/build/neovim/neovim/src/nvim/buffer.c:393:5
    #6 0x717505 in empty_curbuf /home/travis/build/neovim/neovim/src/nvim/buffer.c:842:5
    #7 0x6f9dc5 in do_buffer /home/travis/build/neovim/neovim/src/nvim/buffer.c:988:14
    #8 0x70e054 in do_bufdel /home/travis/build/neovim/neovim/src/nvim/buffer.c:732:11
    #9 0x14b99da in ex_bunload /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:4373:17
    #10 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #11 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #12 0x2520d32 in nv_colon /home/travis/build/neovim/neovim/src/nvim/normal.c:4488:18
    #13 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #14 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #15 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3
    #16 0x1cfcd37 in main /home/travis/build/neovim/neovim/src/nvim/main.c:538:3
    #17 0x2b30c093876c in __libc_start_main /build/eglibc-rrybNj/eglibc-2.15/csu/libc-start.c:226

previously allocated by thread T0 here:
    #0 0x4f23cb in calloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f23cb)
    #1 0x2074608 in xcalloc /home/travis/build/neovim/neovim/src/nvim/memory.c:119:15
    #2 0x3ab0bb8 in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:215:18
    #3 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #4 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #5 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #6 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #7 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #8 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #9 0x2520d32 in nv_colon /home/travis/build/neovim/neovim/src/nvim/normal.c:4488:18
    #10 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #11 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #12 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3
    #13 0x1cfcd37 in main /home/travis/build/neovim/neovim/src/nvim/main.c:538:3
    #14 0x2b30c093876c in __libc_start_main /build/eglibc-rrybNj/eglibc-2.15/csu/libc-start.c:226

SUMMARY: AddressSanitizer: heap-use-after-free /home/travis/build/neovim/neovim/src/nvim/terminal.c:541 terminal_receive
Shadow bytes around the buggy address:
  0x0c4a800060d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a800060e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a800060f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a80006100: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a80006110: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c4a80006120: fd fd fd fd fd[fd]fd fd fd fd fd fd fd fd fd fd
  0x0c4a80006130: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80006140: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80006150: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80006160: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a80006170: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==12124==ABORTING

=================================================================
==12138==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 8328 byte(s) in 1 object(s) allocated from:
    #0 0x4f23cb in calloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f23cb)
    #1 0x2074608 in xcalloc /home/travis/build/neovim/neovim/src/nvim/memory.c:119:15
    #2 0x3ab0bb8 in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:215:18
    #3 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #4 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #5 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #6 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #7 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #8 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #9 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #10 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #11 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #12 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #13 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #14 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #15 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #16 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #17 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #18 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #19 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #20 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #21 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #22 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #23 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #24 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #25 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #26 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3
    #27 0x1cfcd37 in main /home/travis/build/neovim/neovim/src/nvim/main.c:538:3
    #28 0x2ba0dea5f76c in __libc_start_main /build/eglibc-rrybNj/eglibc-2.15/csu/libc-start.c:226

Indirect leak of 8000 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x20730b5 in try_malloc /home/travis/build/neovim/neovim/src/nvim/memory.c:59:15
    #2 0x2073b01 in xmalloc /home/travis/build/neovim/neovim/src/nvim/memory.c:93:15
    #3 0x3ab496c in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:257:19
    #4 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #5 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #6 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #7 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #8 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #9 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #10 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #11 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #12 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #13 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #14 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #15 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #16 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #17 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #18 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #19 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #20 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #21 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #22 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #23 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #24 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #25 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #26 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #27 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3
    #28 0x1cfcd37 in main /home/travis/build/neovim/neovim/src/nvim/main.c:538:3
    #29 0x2ba0dea5f76c in __libc_start_main /build/eglibc-rrybNj/eglibc-2.15/csu/libc-start.c:226

Indirect leak of 4800 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x3e37648 in default_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e37648)
    #2 0x3e36752 in vterm_allocator_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36752)
    #3 0x3e2c881 in realloc_buffer (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2c881)
    #4 0x3e2c834 in vterm_screen_enable_altscreen (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2c834)
    #5 0x3ab2709 in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:228:3
    #6 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #7 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #8 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #9 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #10 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #11 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #12 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #13 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #14 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #15 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #16 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #17 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #18 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #19 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #20 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #21 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #22 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #23 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #24 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #25 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #26 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #27 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #28 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #29 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3

Indirect leak of 4800 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x3e37648 in default_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e37648)
    #2 0x3e36752 in vterm_allocator_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36752)
    #3 0x3e2c881 in realloc_buffer (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2c881)
    #4 0x3e2c76f in screen_new (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2c76f)
    #5 0x3e2c677 in vterm_obtain_screen (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2c677)
    #6 0x3ab229f in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:227:13
    #7 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #8 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #9 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #10 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #11 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #12 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #13 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #14 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #15 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #16 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #17 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #18 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #19 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #20 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #21 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #22 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #23 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #24 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #25 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #26 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #27 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #28 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #29 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26

Indirect leak of 2000 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x3e37648 in default_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e37648)
    #2 0x3e36752 in vterm_allocator_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36752)
    #3 0x3e2c79e in screen_new (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2c79e)
    #4 0x3e2c677 in vterm_obtain_screen (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2c677)
    #5 0x3ab229f in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:227:13
    #6 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #7 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #8 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #9 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #10 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #11 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #12 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #13 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #14 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #15 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #16 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #17 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #18 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #19 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #20 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #21 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #22 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #23 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #24 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #25 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #26 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #27 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #28 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #29 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3

Indirect leak of 1640 byte(s) in 1 object(s) allocated from:
    #0 0x4f23cb in calloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f23cb)
    #1 0x2074608 in xcalloc /home/travis/build/neovim/neovim/src/nvim/memory.c:119:15
    #2 0xea12a6 in common_job_init /home/travis/build/neovim/neovim/src/nvim/eval.c:21486:27
    #3 0xe55aae in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16343:27
    #4 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #5 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #6 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #7 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #8 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #9 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #10 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #11 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #12 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #13 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #14 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #15 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #16 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #17 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #18 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #19 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #20 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #21 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #22 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #23 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #24 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #25 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #26 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3
    #27 0x1cfcd37 in main /home/travis/build/neovim/neovim/src/nvim/main.c:538:3
    #28 0x2ba0dea5f76c in __libc_start_main /build/eglibc-rrybNj/eglibc-2.15/csu/libc-start.c:226

Indirect leak of 384 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x3e37648 in default_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e37648)
    #2 0x3e36752 in vterm_allocator_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36752)
    #3 0x3e2f18b in vterm_state_new (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2f18b)
    #4 0x3e2f047 in vterm_obtain_state (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2f047)
    #5 0x3ab2031 in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:225:23
    #6 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #7 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #8 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #9 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #10 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #11 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #12 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #13 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #14 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #15 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #16 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #17 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #18 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #19 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #20 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #21 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #22 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #23 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #24 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #25 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #26 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #27 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #28 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #29 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3

Indirect leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x3e37648 in default_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e37648)
    #2 0x3e36752 in vterm_allocator_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36752)
    #3 0x3e2c6e3 in screen_new (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2c6e3)
    #4 0x3e2c677 in vterm_obtain_screen (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2c677)
    #5 0x3ab229f in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:227:13
    #6 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #7 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #8 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #9 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #10 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #11 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #12 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #13 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #14 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #15 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #16 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #17 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #18 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #19 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #20 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #21 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #22 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #23 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #24 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #25 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #26 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #27 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #28 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #29 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3

Indirect leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x3e37648 in default_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e37648)
    #2 0x3e3665d in vterm_new_with_allocator (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e3665d)
    #3 0x3e36623 in vterm_new (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36623)
    #4 0x3ab199a in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:222:12
    #5 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #6 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #7 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #8 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #9 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #10 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #11 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #12 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #13 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #14 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #15 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #16 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #17 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #18 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #19 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #20 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #21 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #22 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #23 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #24 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #25 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #26 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #27 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #28 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3
    #29 0x1cfcd37 in main /home/travis/build/neovim/neovim/src/nvim/main.c:538:3

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x3e37648 in default_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e37648)
    #2 0x3e36752 in vterm_allocator_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36752)
    #3 0x3e366dc in vterm_new_with_allocator (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e366dc)
    #4 0x3e36623 in vterm_new (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36623)
    #5 0x3ab199a in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:222:12
    #6 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #7 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #8 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #9 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #10 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #11 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #12 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #13 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #14 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #15 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #16 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #17 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #18 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #19 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #20 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #21 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #22 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #23 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #24 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #25 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #26 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #27 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #28 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #29 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x3e37648 in default_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e37648)
    #2 0x3e36752 in vterm_allocator_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36752)
    #3 0x3e3670d in vterm_new_with_allocator (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e3670d)
    #4 0x3e36623 in vterm_new (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36623)
    #5 0x3ab199a in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:222:12
    #6 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #7 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #8 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #9 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #10 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #11 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #12 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #13 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #14 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #15 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #16 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #17 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #18 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #19 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #20 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #21 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #22 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #23 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #24 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #25 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #26 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #27 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #28 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #29 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x3e37648 in default_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e37648)
    #2 0x3e36752 in vterm_allocator_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36752)
    #3 0x3e2f084 in vterm_obtain_state (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2f084)
    #4 0x3ab2031 in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:225:23
    #5 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #6 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #7 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #8 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #9 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #10 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #11 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #12 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #13 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #14 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #15 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #16 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #17 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #18 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #19 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #20 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #21 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #22 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #23 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #24 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #25 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #26 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #27 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #28 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3
    #29 0x1cfcd37 in main /home/travis/build/neovim/neovim/src/nvim/main.c:538:3

Indirect leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x20730b5 in try_malloc /home/travis/build/neovim/neovim/src/nvim/memory.c:59:15
    #2 0x2073b01 in xmalloc /home/travis/build/neovim/neovim/src/nvim/memory.c:93:15
    #3 0x117eb39 in queue_new /home/travis/build/neovim/neovim/src/nvim/event/queue.c:97:15
    #4 0x117fe77 in queue_new_child /home/travis/build/neovim/neovim/src/nvim/event/queue.c:92:10
    #5 0xea2077 in common_job_init /home/travis/build/neovim/neovim/src/nvim/eval.c:21492:18
    #6 0xe55aae in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16343:27
    #7 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #8 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #9 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #10 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #11 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #12 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #13 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #14 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #15 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #16 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #17 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #18 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #19 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #20 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #21 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #22 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #23 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #24 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #25 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #26 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #27 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #28 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #29 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3

Indirect leak of 12 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x3e37648 in default_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e37648)
    #2 0x3e36752 in vterm_allocator_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36752)
    #3 0x3e2f0d5 in vterm_obtain_state (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2f0d5)
    #4 0x3ab2031 in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:225:23
    #5 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #6 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #7 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #8 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #9 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #10 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #11 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #12 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #13 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #14 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #15 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #16 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #17 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #18 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #19 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #20 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #21 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #22 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #23 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #24 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #25 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #26 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #27 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #28 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3
    #29 0x1cfcd37 in main /home/travis/build/neovim/neovim/src/nvim/main.c:538:3

Indirect leak of 7 byte(s) in 1 object(s) allocated from:
    #0 0x4f2252 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x4f2252)
    #1 0x3e37648 in default_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e37648)
    #2 0x3e36752 in vterm_allocator_malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e36752)
    #3 0x3e2f0b2 in vterm_obtain_state (/home/travis/build/neovim/neovim/build/bin/nvim+0x3e2f0b2)
    #4 0x3ab2031 in terminal_open /home/travis/build/neovim/neovim/src/nvim/terminal.c:225:23
    #5 0xe59e77 in f_termopen /home/travis/build/neovim/neovim/src/nvim/eval.c:16380:20
    #6 0xb76afa in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:7256:21
    #7 0xbae096 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:7105:11
    #8 0xb9e700 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
    #9 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #10 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #11 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #12 0x1527f8d in ex_terminal /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:9515:3
    #13 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #14 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #15 0x138a55d in do_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2611:3
    #16 0x1380347 in cmd_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2323:12
    #17 0x1380853 in ex_source /home/travis/build/neovim/neovim/src/nvim/ex_cmds2.c:2301:3
    #18 0x141c2e0 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2191:15
    #19 0x13ce683 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:601:20
    #20 0x13dd51c in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:274:10
    #21 0x68414a in vim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:43:3
    #22 0x599ed9 in handle_vim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/msgpack_dispatch.c:2128:3
    #23 0x23488a5 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:481:19
    #24 0x118ff42 in queue_process_events /home/travis/build/neovim/neovim/src/nvim/event/queue.c:142:7
    #25 0x25cb680 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7876:3
    #26 0x249e003 in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1144:12
    #27 0x3822fb3 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:55:26
    #28 0x23e3a34 in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:464:3
    #29 0x1cfcd37 in main /home/travis/build/neovim/neovim/src/nvim/main.c:538:3

SUMMARY: AddressSanitizer: 30443 byte(s) leaked in 15 allocation(s).
```
