### PR TITLE
[RFC] vim-patch.sh: Ignore “git describe” failures in list_vim_patches

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -256,7 +256,8 @@ list_vim_patches() {
   for vim_commit in ${vim_commits}; do
     local is_missing
     local vim_tag
-    vim_tag="$(cd "${VIM_SOURCE_DIR}" && git describe --tags --exact-match "${vim_commit}" 2>/dev/null)"
+    # This fails for untagged commits (e.g., runtime file updates) so mask the return status
+    vim_tag="$(cd "${VIM_SOURCE_DIR}" && git describe --tags --exact-match "${vim_commit}" 2>/dev/null)" || true
     if [[ -n "${vim_tag}" ]]; then
       local patch_number="${vim_tag:5}" # Remove prefix like "v7.4."
       # Tagged Vim patch, check version.c:


### PR DESCRIPTION
It's acceptable for “git describe --tags --exact-match …” to fail, since
all runtime updates commits are untagged.  All that matters is that we
get a tag when one exists.

Therefore, ignore the failure status of the git describe call, relying
on the captured output instead.
