### PR TITLE
Update to libuv 1.9.1

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -81,8 +81,8 @@ endif()
 
 include(ExternalProject)
 
-set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.8.0.tar.gz)
-set(LIBUV_SHA256 906e1a5c673c95cb261adeacdb7308a65b4a8f7c9c50d85f3021364951fa9cde)
+set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.9.1.tar.gz)
+set(LIBUV_SHA256 a6ca9f0648973d1463f46b495ce546ddcbe7cce2f04b32e802a15539e46c57ad)
 
 set(MSGPACK_URL https://github.com/msgpack/msgpack-c/archive/cpp-1.0.0.tar.gz)
 set(MSGPACK_SHA256 afda64ca445203bb7092372b822bae8b2539fdcebbfc3f753f393628c2bcfe7d)


### PR DESCRIPTION
libuv 1.9.1 was released about 11 hours ago (at time of posting):

https://github.com/libuv/libuv/releases/tag/v1.9.1
