### PR TITLE
vim-patch:7.4.1046

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -41,6 +41,7 @@ SCRIPTS := \
 NEW_TESTS = \
 	    test_cursor_func.res \
 	    test_help_tagjump.res \
+	    test_menu.res \
 	    test_viml.res \
 	    test_alot.res
 

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -1,0 +1,9 @@
+" Test that the system menu can be loaded.
+
+func Test_load_menu()
+  try
+    source $VIMRUNTIME/menu.vim
+  catch
+    call assert_false(1, 'error while loading menus: ' . v:exception)
+  endtry
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -638,7 +638,7 @@ static int included_patches[] = {
   1049,
   1048,
   1047,
-  // 1046,
+  1046,
   // 1045 NA
   // 1044 NA
   // 1043 NA


### PR DESCRIPTION
Problem:    No test coverage for menus.
Solution:   Load the standard menus and check there is no error.

https://github.com/vim/vim/commit/2d6c8002729821acc54a4de41d5c5f3d50594973
