### PR TITLE
[RFC] vim-patch.sh: Support sociomatic/git-hub for submit_pr

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -33,7 +33,11 @@ usage() {
 
 # Checks if a program is in the user's PATH, and is executable.
 check_executable() {
-  if [[ ! -x $(command -v "${1}") ]]; then
+  test -x "$(command -v "${1}")"
+}
+
+require_executable() {
+  if ! check_executable "${1}"; then
     >&2 echo "${BASENAME}: '${1}' not found in PATH or not executable."
     exit 1
   fi
@@ -61,7 +65,7 @@ clean_files() {
 }
 
 get_vim_sources() {
-  check_executable git
+  require_executable git
 
   if [[ ! -d ${VIM_SOURCE_DIR} ]]; then
     echo "Cloning Vim sources into '${VIM_SOURCE_DIR}'."
@@ -195,8 +199,8 @@ get_vim_patch() {
 }
 
 submit_pr() {
-  check_executable git
-  check_executable hub
+  require_executable git
+  require_executable hub
 
   cd "${NEOVIM_SOURCE_DIR}"
   local checked_out_branch
@@ -346,9 +350,9 @@ review_commit() {
 }
 
 review_pr() {
-  check_executable curl
-  check_executable nvim
-  check_executable jq
+  require_executable curl
+  require_executable nvim
+  require_executable jq
 
   get_vim_sources
 

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -290,6 +290,9 @@ list_vim_patches() {
       is_missing="$(sed -n '/static int included_patches/,/}/p' "${NEOVIM_SOURCE_DIR}/src/nvim/version.c" |
         grep -x -e "[[:space:]]*//[[:space:]]${patch_number} NA.*" -e "[[:space:]]*${patch_number}," >/dev/null && echo "false" || echo "true")"
       vim_commit="${vim_tag#v}"
+      if (cd "${VIM_SOURCE_DIR}" && git show --name-only "v${vim_commit}" 2>/dev/null) | grep -q ^runtime; then
+        vim_commit="${vim_commit} (+runtime)"
+      fi
     else
       # Untagged Vim patch (e.g. runtime updates), check the Neovim git log:
       is_missing="$(cd "${NEOVIM_SOURCE_DIR}" &&


### PR DESCRIPTION
I use sociomatic/git-hub as my CLI interface to GitHub and thought it'd be handy to have `vim-patch.sh -s` support that.

As I've been trying to catch up the vim patches, it's been handy to know whether there were runtime changes in normal patches (to try and backtrack changes).  The 3rd commit adds a `(+runtime)` annotation to `vim-patch.sh -l` to indicate this.  If there are ideas for other ways to provide this information, or it should be handled separately, let me know.
