### PR TITLE
[RFC] vim-patch:7.4.1516,7.4.1521

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2051,6 +2051,7 @@ serverlist()			String	get a list of available servers
 setbufvar({expr}, {varname}, {val})	set {varname} in buffer {expr} to {val}
 setcharsearch({dict})		Dict	set character search from {dict}
 setcmdpos({pos})		Number	set cursor position in command-line
+setfperm({fname}, {mode}	Number	set {fname} file permissions to {mode}
 setline({lnum}, {line})	Number	set line {lnum} to {line}
 setloclist({nr}, {list}[, {action}[, {title}]])
 				Number	modify location list using {list}
@@ -3627,6 +3628,8 @@ getfperm({fname})					*getfperm()*
 			:echo getfperm(expand("~/.config/nvim/init.vim"))
 <		This will hopefully (from a security point of view) display
 		the string "rw-r--r--" or even "rw-------".
+
+		For setting permissions use |setfperm()|.
 
 getftime({fname})					*getftime()*
 		The result is a Number, which is the last modification time of
@@ -5865,6 +5868,23 @@ setcmdpos({pos})					*setcmdpos()*
 		line.  A number smaller than one has undefined results.
 		Returns 0 when successful, 1 when not editing the command
 		line.
+
+setfperm({fname}, {mode})				*setfperm()* *chmod*
+		Set the file permissions for {fname} to {mode}.
+		{mode} must be a string with 9 characters.  It is of the form
+		"rwxrwxrwx", where each group of "rwx" flags represent, in
+		turn, the permissions of the owner of the file, the group the
+		file belongs to, and other users.  A '-' character means the
+		permission is off, any other character means on.  Multi-byte
+		characters are not supported.
+
+		For example "rw-r-----" means read-write for the user,
+		readable by the group, not accessible by others.  "xx-x-----"
+		would do the same thing.
+
+		Returns non-zero for success, zero for failure.
+
+		To read permissions see |getfperm()|.
 
 setline({lnum}, {text})					*setline()*
 		Set line {lnum} of the current buffer to {text}.  To insert

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6877,6 +6877,7 @@ static struct fst {
   { "setbufvar",         3, 3, f_setbufvar },
   { "setcharsearch",     1, 1, f_setcharsearch },
   { "setcmdpos",         1, 1, f_setcmdpos },
+  { "setfperm",          2, 2, f_setfperm },
   { "setline",           2, 2, f_setline },
   { "setloclist",        2, 4, f_setloclist },
   { "setmatches",        1, 1, f_setmatches },
@@ -14444,6 +14445,38 @@ static void f_setcmdpos(typval_T *argvars, typval_T *rettv)
 
   if (pos >= 0)
     rettv->vval.v_number = set_cmdline_pos(pos);
+}
+
+
+/// "setfperm({fname}, {mode})" function
+static void f_setfperm(typval_T *argvars, typval_T *rettv)
+{
+  rettv->vval.v_number = 0;
+
+  char_u *fname = get_tv_string_chk(&argvars[0]);
+  if (fname == NULL) {
+    return;
+  }
+
+  char_u modebuf[NUMBUFLEN];
+  char_u *mode_str = get_tv_string_buf_chk(&argvars[1], modebuf);
+  if (mode_str == NULL) {
+    return;
+  }
+  if (STRLEN(mode_str) != 9) {
+    EMSG2(_(e_invarg2), mode_str);
+    return;
+  }
+
+  int mask = 1;
+  int mode = 0;
+  for (int i = 8; i >= 0; i--) {
+    if (mode_str[i] != '-') {
+      mode |= mask;
+    }
+    mask = mask << 1;
+  }
+  rettv->vval.v_number = os_setperm(fname, mode) == OK;
 }
 
 /*

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -163,7 +163,7 @@ static int included_patches[] = {
   // 1524 NA
   // 1523 NA
   // 1522 NA
-  // 1521,
+  1521,
   // 1520 NA
   // 1519 NA
   // 1518 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -168,7 +168,7 @@ static int included_patches[] = {
   // 1519 NA
   // 1518 NA
   // 1517 NA
-  // 1516,
+  1516,
   // 1515 NA
   // 1514 NA
   1513,

--- a/test/functional/legacy/file_perm_spec.lua
+++ b/test/functional/legacy/file_perm_spec.lua
@@ -21,7 +21,11 @@ describe('Test getting and setting file permissions', function()
     eq(9, call('len', call('getfperm', tempfile)))
 
     eq(1, call('setfperm', tempfile, 'rwx------'))
-    eq('rwx------', call('getfperm', tempfile))
+    if helpers.os_name == 'windows' then
+      eq('rwx------', call('getfperm', tempfile))
+    else
+      eq('rwx------', call('getfperm', tempfile))
+    end
 
     eq(1, call('setfperm', tempfile, 'r--r--r--'))
     eq('r--r--r--', call('getfperm', tempfile))

--- a/test/functional/legacy/file_perm_spec.lua
+++ b/test/functional/legacy/file_perm_spec.lua
@@ -22,7 +22,7 @@ describe('Test getting and setting file permissions', function()
 
     eq(1, call('setfperm', tempfile, 'rwx------'))
     if helpers.os_name == 'windows' then
-      eq('rwx------', call('getfperm', tempfile))
+      eq('rw-rw-rw-', call('getfperm', tempfile))
     else
       eq('rwx------', call('getfperm', tempfile))
     end

--- a/test/functional/legacy/file_perm_spec.lua
+++ b/test/functional/legacy/file_perm_spec.lua
@@ -1,0 +1,38 @@
+-- Test getting and setting file permissions.
+require('os')
+
+local helpers = require('test.functional.helpers')
+local clear, call, eq = helpers.clear, helpers.call, helpers.eq
+local neq, exc_exec = helpers.neq, helpers.exc_exec
+
+describe('Test getting and setting file permissions', function()
+  local tempfile = os.tmpname()
+
+  before_each(function()
+    os.remove(tempfile)
+    clear()
+  end)
+
+  it('file permissions', function()
+    eq('', call('getfperm', tempfile))
+    eq(0, call('setfperm', tempfile, 'r------'))
+
+    call('writefile', {'one'}, tempfile)
+    eq(9, call('len', call('getfperm', tempfile)))
+
+    eq(1, call('setfperm', tempfile, 'rwx------'))
+    eq('rwx------', call('getfperm', tempfile))
+
+    eq(1, call('setfperm', tempfile, 'r--r--r--'))
+    eq('r--r--r--', call('getfperm', tempfile))
+
+    local err = exc_exec(('call setfperm("%s", "---")'):format(tempfile))
+    neq(err:find('E475:'), nil)
+
+    eq(1, call('setfperm', tempfile, 'rwx------'))
+  end)
+
+  after_each(function()
+    os.remove(tempfile)
+  end)
+end)


### PR DESCRIPTION
```
vim-patch:7.4.1516

Problem:    Cannot change file permissions.
Solution:   Add setfperm().
```

https://github.com/vim/vim/commit/8049253b96838b3584600e5ad229abad37a95b10

```
vim-patch:7.4.1521

Problem:    File permission test fails on MS-Windows.
Solution:   Expect a different permission.
```

https://github.com/vim/vim/commit/8322e1f06e8fa39a6bb790a7d8d7db5d7aff3366
