### PR TITLE
tui: Do not wait for tui loop on teardown.

### DIFF
--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -76,7 +76,7 @@ void loop_on_put(Queue *queue, void *data)
   uv_stop(&loop->uv);
 }
 
-void loop_close(Loop *loop)
+void loop_close(Loop *loop, bool wait)
 {
   uv_mutex_destroy(&loop->mutex);
   uv_close((uv_handle_t *)&loop->children_watcher, NULL);
@@ -84,8 +84,8 @@ void loop_close(Loop *loop)
   uv_close((uv_handle_t *)&loop->poll_timer, NULL);
   uv_close((uv_handle_t *)&loop->async, NULL);
   do {
-    uv_run(&loop->uv, UV_RUN_DEFAULT);
-  } while (uv_loop_close(&loop->uv));
+    uv_run(&loop->uv, wait ? UV_RUN_DEFAULT : UV_RUN_NOWAIT);
+  } while (uv_loop_close(&loop->uv) && wait);
   queue_free(loop->fast_events);
   queue_free(loop->thread_events);
   queue_free(loop->events);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -165,7 +165,7 @@ void event_teardown(void)
   signal_teardown();
   terminal_teardown();
 
-  loop_close(&main_loop);
+  loop_close(&main_loop, true);
 }
 
 /// Performs early initialization.

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -237,7 +237,7 @@ static void tui_main(UIBridgeData *bridge, UI *ui)
   signal_watcher_stop(&data->cont_handle);
   signal_watcher_close(&data->cont_handle, NULL);
   signal_watcher_close(&data->winch_handle, NULL);
-  loop_close(&tui_loop);
+  loop_close(&tui_loop, false);
   kv_destroy(data->invalid_regions);
   xfree(data);
   xfree(ui);


### PR DESCRIPTION
Because terminfo_stop() already ran, there is not much reason to wait for the loop to teardown.

References #4778
