### PR TITLE
[RFC] process.c: Fix a block when in teardown mode

### DIFF
--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -126,8 +126,10 @@ void process_teardown(Loop *loop) FUNC_ATTR_NONNULL_ALL
     }
   }
 
-  // Wait until all children exit
-  LOOP_PROCESS_EVENTS_UNTIL(loop, loop->events, -1, kl_empty(loop->children));
+  // Wait until all children exit and all close events are processed.
+  LOOP_PROCESS_EVENTS_UNTIL(
+      loop, loop->events, -1,
+      kl_empty(loop->children) && queue_empty(loop->events));
   pty_process_teardown(loop);
 }
 


### PR DESCRIPTION
process.c: Fix a block when in teardown mode

nvim blocking can be tested with "nvim +te +'!xclip' +qa"

The job kill timer is not started for pty processes in teardown mode, so
we could wait forever for such processes to terminate. To fix this, make
sure every process is marked for termination and the job kill timer is
running.
