### PR TITLE
[RFC] syntax: Fix manually clearing a hi group not changing how it looks

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6972,6 +6972,9 @@ set_hl_attr (
       || at_en.rgb_sp_color != -1 || at_en.cterm_ae_attr != 0
       || at_en.rgb_ae_attr != 0) {
     sgp->sg_attr = get_attr_entry(&at_en);
+  } else {
+    // If all the fields are cleared, clear the attr field back to default value
+    sgp->sg_attr = 0;
   }
 }
 

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -302,6 +302,47 @@ describe('Default highlight groups', function()
       {1:-- INSERT --}                                         |
     ]], {[1] = {foreground = Screen.colors.Red, background = Screen.colors.Green}})
   end)
+  it('can be cleared by manually clearing their fields', function()
+    execute('syn keyword TmpKeyword neovim')
+    execute('hi link TmpKeyword ErrorMsg')
+    insert('neovim')
+    screen:expect([[
+      {1:neovi^m}                                               |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+                                                           |
+    ]], {
+      [1] = {foreground = Screen.colors.White, background = Screen.colors.Red}
+    })
+    execute("hi ErrorMsg term=NONE cterm=NONE ctermfg=NONE ctermbg=NONE"
+            .. " gui=NONE guifg=NONE guibg=NONE guisp=NONE")
+    screen:expect([[
+      neovi^m                                               |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+                                                           |
+    ]], {})
+  end)
 end)
 
 describe('guisp (special/undercurl)', function()


### PR DESCRIPTION
Closes #4767

Makes manually setting all the fields of a highlight group to "NONE" actually clear the group visually.
