### PR TITLE
[WIP] vim-patch:7.4.1064

### DIFF
--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -1373,6 +1373,14 @@ the item name.  Case is always ignored.
 
 The Hunspell feature to use three arguments and flags is not supported.
 
+							*spell-NOCOMPOUNDSUGS*
+This item indicates that using compounding to make suggestions is not a good
+idea.  Use this when compounding is used with very short or one-character
+words.  E.g. to make numbers out of digits.  Without this flag creating
+suggestions would spend most time trying all kind of weird compound words.
+
+	NOCOMPOUNDSUGS ~
+
 							*spell-SYLLABLE*
 The SYLLABLE item defines characters or character sequences that are used to
 count the number of syllables in a word.  Example:

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -620,7 +620,7 @@ static int included_patches[] = {
   // 1067 NA
   // 1066 NA
   1065,
-  // 1064,
+  1064,
   // 1063 NA
   // 1062 NA
   // 1061,


### PR DESCRIPTION
Problem:    When a spell file has single letter compounding creating
            suggestions takes an awful long time.
Solution:   Add th eNOCOMPOUNDSUGS flag.

https://github.com/vim/vim/commit/7b877b360532713dc21a0ff3d55a76ac02eaf573

---

Currently there are 3 lint errors, but they are all rather tricky (at least for me). Any advice on them would be appreciated.
