### PR TITLE
runtime: clipboard: start daemons in /

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -94,6 +94,7 @@ function! s:clipboard.set(lines, regtype, reg)
   let selection.data = [a:lines, a:regtype]
   let argv = split(s:copy[a:reg], " ")
   let selection.detach = s:cache_enabled
+  let selection.cwd = "/"
   let jobid = jobstart(argv, selection)
   if jobid <= 0
     echohl WarningMsg

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4305,6 +4305,9 @@ jobstart({cmd}[, {opts}])				{Nvim} *jobstart()*
 		  - on_stdout: stdout event handler
 		  - on_stderr: stderr event handler
 		  - on_exit: exit event handler
+		  - cwd: Working directory the job will be started from
+		    (defaults to the current working directory of nvim, as given
+		    by |getcwd()|).
 		  - pty: If set, the job will be connected to a new pseudo
 		    terminal, and the job streams are connected to the master
 		    file descriptor.

--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -25,7 +25,7 @@ bool libuv_process_spawn(LibuvProcess *uvproc)
       uvproc->uvopts.flags |= UV_PROCESS_DETACHED;
   }
   uvproc->uvopts.exit_cb = exit_cb;
-  uvproc->uvopts.cwd = NULL;
+  uvproc->uvopts.cwd = proc->cwd;
   uvproc->uvopts.env = NULL;
   uvproc->uvopts.stdio = uvproc->uvstdio;
   uvproc->uvopts.stdio_count = 3;

--- a/src/nvim/event/process.h
+++ b/src/nvim/event/process.h
@@ -21,6 +21,7 @@ struct process {
   int pid, status, refcount;
   // set to the hrtime of when process_stop was called for the process.
   uint64_t stopped_time;
+  char *cwd;
   char **argv;
   Stream *in, *out, *err;
   process_exit_cb cb;
@@ -40,6 +41,7 @@ static inline Process process_init(Loop *loop, ProcessType type, void *data)
     .status = 0,
     .refcount = 0,
     .stopped_time = 0,
+    .cwd = NULL,
     .argv = NULL,
     .in = NULL,
     .out = NULL,

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -28,6 +28,7 @@
 #include "nvim/event/process.h"
 #include "nvim/os/pty_process_unix.h"
 #include "nvim/log.h"
+#include "nvim/os/os.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/pty_process_unix.c.generated.h"
@@ -130,6 +131,12 @@ static void init_child(PtyProcess *ptyproc) FUNC_ATTR_NONNULL_ALL
   signal(SIGQUIT, SIG_DFL);
   signal(SIGTERM, SIG_DFL);
   signal(SIGALRM, SIG_DFL);
+
+  Process *proc = (Process *)ptyproc;
+  if (proc->cwd && os_chdir(proc->cwd) != 0) {
+    fprintf(stderr, "chdir failed: %s\n", strerror(errno));
+    return;
+  }
 
   setenv("TERM", ptyproc->term_name ? ptyproc->term_name : "ansi", 1);
   execvp(ptyproc->process.argv[0], ptyproc->process.argv);

--- a/test/functional/job/job_spec.lua
+++ b/test/functional/job/job_spec.lua
@@ -1,11 +1,11 @@
 
 local helpers = require('test.functional.helpers')
 local clear, eq, eval, execute, feed, insert, neq, next_msg, nvim,
-  nvim_dir, ok, source, write_file = helpers.clear,
+  nvim_dir, ok, source, write_file, mkdir, rmdir = helpers.clear,
   helpers.eq, helpers.eval, helpers.execute, helpers.feed,
   helpers.insert, helpers.neq, helpers.next_message, helpers.nvim,
   helpers.nvim_dir, helpers.ok, helpers.source,
-  helpers.write_file
+  helpers.write_file, helpers.mkdir, helpers.rmdir
 local Screen = require('test.functional.ui.screen')
 
 
@@ -35,6 +35,31 @@ describe('jobs', function()
     nvim('command', "let j = jobstart('echo $VAR', g:job_opts)")
     eq({'notification', 'stdout', {0, {'abc', ''}}}, next_msg())
     eq({'notification', 'exit', {0, 0}}, next_msg())
+  end)
+
+  it('changes to / when cwd provided', function()
+    nvim('command', "let g:job_opts.cwd = '/'")
+    nvim('command', "let j = jobstart('pwd', g:job_opts)")
+    eq({'notification', 'stdout', {0, {'/', ''}}}, next_msg())
+    eq({'notification', 'exit', {0, 0}}, next_msg())
+  end)
+
+  it('changes to random directory when cwd provided', function()
+    local dir = eval('resolve(tempname())')
+    mkdir(dir)
+    nvim('command', "let g:job_opts.cwd = '" .. dir .. "'")
+    nvim('command', "let j = jobstart('pwd', g:job_opts)")
+    eq({'notification', 'stdout', {0, {dir, ''}}}, next_msg())
+    eq({'notification', 'exit', {0, 0}}, next_msg())
+    rmdir(dir)
+  end)
+
+  it('fails to change to non-existent directory when provided', function()
+    local _, err = pcall(function()
+      nvim('command', "let g:job_opts.cwd = '/NONEXISTENT'")
+      nvim('command', "let j = jobstart('pwd', g:job_opts)")
+    end)
+    ok(string.find(err, "E475: Invalid argument: expected valid directory$") ~= nil)
   end)
 
   it('returns 0 when it fails to start', function()


### PR DESCRIPTION
Processes in vim are always started in the current directory, which
causes issues when the process is a daemon and the current directory is
a mountpoint. Fix this by adding an option to set the cwd of the new
process with jobstart(), and make termstart() actually set the cwd of
the new process.

This avoids the issue of nvim started daemons causing mountpoints to be
unmountable.

Signed-off-by: Aleksa Sarai cyphar@cyphar.com
