### PR TITLE
[RFC] vim-patch:acb4f22

### DIFF
--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -1,4 +1,4 @@
-*help.txt*	For Vim version 7.4.  Last change: 2015 Apr 15
+*help.txt*	For Vim version 7.4.  Last change: 2016 Jan 09
 
 			VIM - main help file
 									 k
@@ -24,6 +24,8 @@ Get specific help:  It is possible to go directly to whatever you want help
 		      Vim command argument	  -	   :help -r
 		      Option			  '	   :help 'textwidth'
 		      Regular expression	  /	   :help /[
+		    Also see |help-summary| for a verbose explanation.
+
   Search for help:  Type ":help word", then hit CTRL-D to see matching
 		    help entries for "word".
 		    Or use ":helpgrep word". |:helpgrep|

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1,4 +1,4 @@
-*index.txt*     For Vim version 7.4.  Last change: 2016 Jan 03
+*index.txt*     For Vim version 7.4.  Last change: 2016 Jan 10
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1171,7 +1171,7 @@ tag	      command	      action ~
 |:cpfile|	:cpf[ile]	go to last error in previous file
 |:cquit|	:cq[uit]	quit Vim with an error code
 |:crewind|	:cr[ewind]	go to the specified error, default first one
-|:cscope|	:cs[cope]       execute cscope command
+|:cscope|	:cs[cope]	execute cscope command
 |:cstag|	:cst[ag]	use cscope to jump to a tag
 |:cunmap|	:cu[nmap]	like ":unmap" but for Command-line mode
 |:cunabbrev|	:cuna[bbrev]	like ":unabbrev" but for Command-line mode
@@ -1290,7 +1290,7 @@ tag	      command	      action ~
 |:lcd|		:lc[d]		change directory locally
 |:lchdir|	:lch[dir]	change directory locally
 |:lclose|	:lcl[ose]	close location window
-|:lcscope|	:lcs[cope]      like ":cscope" but uses location list
+|:lcscope|	:lcs[cope]	like ":cscope" but uses location list
 |:ldo|		:ld[o]		execute command in valid location list entries
 |:lfdo|		:lfd[o]		execute command in each file in location list
 |:left|		:le[ft]		left align lines
@@ -1341,7 +1341,7 @@ tag	      command	      action ~
 |:marks|	:marks		list all marks
 |:match|	:mat[ch]	define a match to highlight
 |:menu|		:me[nu]		enter a new menu item
-|:menutranslate| :menut[ranslate] add a menu translation item
+|:menutranslate|  :menut[ranslate] add a menu translation item
 |:messages|	:mes[sages]	view previously displayed messages
 |:mkexrc|	:mk[exrc]	write current mappings and settings to a file
 |:mksession|	:mks[ession]	write session info to a file
@@ -1494,7 +1494,7 @@ tag	      command	      action ~
 |:stop|		:st[op]		suspend the editor or escape to a shell
 |:stag|		:sta[g]		split window and jump to a tag
 |:startinsert|	:star[tinsert]	start Insert mode
-|:startgreplace| :startg[replace] start Virtual Replace mode
+|:startgreplace|  :startg[replace] start Virtual Replace mode
 |:startreplace|	:startr[eplace]	start Replace mode
 |:stopinsert|	:stopi[nsert]	stop Insert mode
 |:stjump|	:stj[ump]	do ":tjump" and split window

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -1,4 +1,4 @@
-*spell.txt*	For Vim version 7.4.  Last change: 2014 Sep 19
+*spell.txt*	For Vim version 7.4.  Last change: 2016 Jan 08
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar

--- a/runtime/doc/usr_03.txt
+++ b/runtime/doc/usr_03.txt
@@ -1,4 +1,4 @@
-*usr_03.txt*	For Vim version 7.4.  Last change: 2015 Dec 12
+*usr_03.txt*	For Vim version 7.4.  Last change: 2016 Jan 05
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -414,8 +414,8 @@ in "the" use: >
 	/the\>
 
 The "\>" item is a special marker that only matches at the end of a word.
-Similarly "\<" only matches at the begin of a word.  Thus to search for the
-word "the" only: >
+Similarly "\<" only matches at the beginning of a word.  Thus to search for
+the word "the" only: >
 
 	/\<the\>
 

--- a/runtime/ftplugin/hgcommit.vim
+++ b/runtime/ftplugin/hgcommit.vim
@@ -1,0 +1,16 @@
+" Vim filetype plugin file
+" Language:	hg (Mercurial) commit file
+" Maintainer:	Ken Takata <kentkt at csc dot jp>
+" Last Change:	2016 Jan 6
+" Filenames:	hg-editor-*.txt
+" License:	VIM License
+" URL:		https://github.com/k-takata/hg-vim
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal nomodeline
+
+let b:undo_ftplugin = 'setl modeline<'

--- a/runtime/indent/lua.vim
+++ b/runtime/indent/lua.vim
@@ -2,7 +2,7 @@
 " Language:	Lua script
 " Maintainer:	Marcus Aurelius Farias <marcus.cf 'at' bol.com.br>
 " First Author:	Max Ischenko <mfi 'at' ukr.net>
-" Last Change:	2014 Nov 12
+" Last Change:	2016 Jan 10
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -52,7 +52,7 @@ function! GetLuaIndent()
     endif
   endif
 
-  " Subtract a 'shiftwidth' on end, else (and elseif), until and '}'
+  " Subtract a 'shiftwidth' on end, else, elseif, until and '}'
   " This is the part that requires 'indentkeys'.
   let midx = match(getline(v:lnum), '^\s*\%(end\>\|else\>\|elseif\>\|until\>\|}\)')
   if midx != -1 && synIDattr(synID(v:lnum, midx + 1, 1), "name") != "luaComment"

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -2,8 +2,8 @@
 " Language:		shell (sh) Korn shell (ksh) bash (sh)
 " Maintainer:		Charles E. Campbell  <NdrOchipS@PcampbellAfamily.Mbiz>
 " Previous Maintainer:	Lennart Schultz <Lennart.Schultz@ecmwf.int>
-" Last Change:		Nov 09, 2015
-" Version:		142
+" Last Change:		Dec 11, 2015
+" Version:		143
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
 " This file includes many ideas from Eric Brunet (eric.brunet@ens.fr)
@@ -119,7 +119,7 @@ syn cluster shCaseList	contains=@shCommandSubList,shCaseEsac,shColon,shCommandSu
 syn cluster shCommandSubList	contains=shAlias,shArithmetic,shComment,shCmdParenRegion,shCtrlSeq,shDeref,shDerefSimple,shDoubleQuote,shEcho,shEscape,shExDoubleQuote,shExpr,shExSingleQuote,shNumber,shOperator,shOption,shPosnParm,shSingleQuote,shSpecial,shStatement,shSubSh,shTest,shVariable
 syn cluster shCurlyList	contains=shNumber,shComma,shDeref,shDerefSimple,shDerefSpecial
 syn cluster shDblQuoteList	contains=shCommandSub,shDeref,shDerefSimple,shEscape,shPosnParm,shCtrlSeq,shSpecial
-syn cluster shDerefList	contains=shDeref,shDerefSimple,shDerefVar,shDerefSpecial,shDerefWordError,shDerefPPS
+syn cluster shDerefList	contains=shDeref,shDerefSimple,shDerefVar,shDerefSpecial,shDerefWordError,shDerefPSR,shDerefPPS
 syn cluster shDerefVarList	contains=shDerefOp,shDerefVarArray,shDerefOpError
 syn cluster shEchoList	contains=shArithmetic,shCommandSub,shDeref,shDerefSimple,shEscape,shExpr,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shCtrlSeq,shEchoQuote
 syn cluster shExprList1	contains=shCharClass,shNumber,shOperator,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shExpr,shDblBrace,shDeref,shDerefSimple,shCtrlSeq
@@ -493,6 +493,11 @@ if exists("b:is_bash")
  syn match  shDerefPPS	contained	'/\{1,2}'	nextgroup=shDerefPPSleft
  syn region shDerefPPSleft	contained	start='.'	skip=@\%(\\\\\)*\\/@ matchgroup=shDerefOp	end='/' end='\ze}' nextgroup=shDerefPPSright contains=@shCommandSubList
  syn region shDerefPPSright	contained	start='.'	skip=@\%(\\\\\)\+@		end='\ze}'	contains=@shCommandSubList
+
+ " bash : ${parameter/#substring/replacement}
+ syn match  shDerefPSR	contained	'/#'	nextgroup=shDerefPSRleft
+ syn region shDerefPSRleft	contained	start='.'	skip=@\%(\\\\\)*\\/@ matchgroup=shDerefOp	end='/' end='\ze}' nextgroup=shDerefPSRright
+ syn region shDerefPSRright	contained	start='.'	skip=@\%(\\\\\)\+@		end='\ze}'
 endif
 
 " Arithmetic Parenthesized Expressions: {{{1
@@ -563,6 +568,7 @@ hi def link shColon	shComment
 hi def link shDerefOp	shOperator
 hi def link shDerefPOL	shDerefOp
 hi def link shDerefPPS	shDerefOp
+hi def link shDerefPSR	shDerefOp
 hi def link shDeref	shShellVariables
 hi def link shDerefDelim	shOperator
 hi def link shDerefSimple	shDeref


### PR DESCRIPTION
Updated runtime files.

https://github.com/vim/vim/commit/acb4f221c715a333f4c49a2235a8006c6ac6e4d5

Ignored changes to:
- doc/eval.txt since alloc_fail isn't relevant for neovim
- doc/index.txt for unmerge :smile command
- doc/tags, syntax/vim.vim since they're generated at build time
- doc/todo.txt
