### PR TITLE
[RFC] vim-patch:345efa0

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3582,7 +3582,7 @@ getcmdwintype()						*getcmdwintype()*
 							*getcurpos()*
 getcurpos()	Get the position of the cursor.  This is like getpos('.'), but
 		includes an extra item in the list:
-		    [bufnum, lnum, col, off, curswant]
+		    [bufnum, lnum, col, off, curswant] ~
 		The "curswant" number is the preferred column when moving the
 		cursor vertically.
 		This can be used to save and restore the cursor position: >

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -1,4 +1,4 @@
-*help.txt*	For Vim version 7.4.  Last change: 2016 Jan 09
+*help.txt*	For Vim version 7.4.  Last change: 2016 Jan 10
 
 			VIM - main help file
 									 k
@@ -9,14 +9,14 @@ Close this window:  Use ":q<Enter>".
 
 Jump to a subject:  Position the cursor on a tag (e.g. |bars|) and hit CTRL-].
    With the mouse:  Double-click the left mouse button on a tag, e.g. |bars|.
-	Jump back:  Type CTRL-T or CTRL-O (repeat to go further back).
+	Jump back:  Type CTRL-T or CTRL-O.  Repeat to go further back.
 
 Get specific help:  It is possible to go directly to whatever you want help
 		    on, by giving an argument to the |:help| command.
-		    It is possible to further specify the context:
-							*help-context*
+		    Prepend something to specify the context:  *help-context*
+
 			  WHAT			PREPEND    EXAMPLE	~
-		      Normal mode command      (nothing)   :help x
+		      Normal mode command		   :help x
 		      Visual mode command	  v_	   :help v_u
 		      Insert mode command	  i_	   :help i_<Esc>
 		      Command-line command	  :	   :help :quit
@@ -24,7 +24,7 @@ Get specific help:  It is possible to go directly to whatever you want help
 		      Vim command argument	  -	   :help -r
 		      Option			  '	   :help 'textwidth'
 		      Regular expression	  /	   :help /[
-		    Also see |help-summary| for a verbose explanation.
+		    See |help-summary| for more contexts and an explanation.
 
   Search for help:  Type ":help word", then hit CTRL-D to see matching
 		    help entries for "word".

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1,4 +1,4 @@
-*map.txt*       For Vim version 7.4.  Last change: 2014 Dec 08
+*map.txt*       For Vim version 7.4.  Last change: 2016 Jan 10
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -481,7 +481,7 @@ internal code is written to the script file.
 
 
 1.6 SPECIAL CHARACTERS					*:map-special-chars*
-							*map_backslash*
+						*map_backslash* *map-backslash*
 Note that only CTRL-V is mentioned here as a special character for mappings
 and abbreviations.  When 'cpoptions' does not contain 'B', a backslash can
 also be used like CTRL-V.  The <> notation can be fully used then |<>|.  But
@@ -492,21 +492,21 @@ To map a backslash, or use a backslash literally in the {rhs}, the special
 sequence "<Bslash>" can be used.  This avoids the need to double backslashes
 when using nested mappings.
 
-							*map_CTRL-C*
+						*map_CTRL-C* *map-CTRL-C*
 Using CTRL-C in the {lhs} is possible, but it will only work when Vim is
 waiting for a key, not when Vim is busy with something.  When Vim is busy
 CTRL-C interrupts/breaks the command.
 When using the GUI version on MS-Windows CTRL-C can be mapped to allow a Copy
 command to the clipboard.  Use CTRL-Break to interrupt Vim.
 
-							*map_space_in_lhs*
+					*map_space_in_lhs* *map-space_in_lhs*
 To include a space in {lhs} precede it with a CTRL-V (type two CTRL-Vs for
 each space).
-							*map_space_in_rhs*
+					*map_space_in_rhs* *map-space_in_rhs*
 If you want a {rhs} that starts with a space, use "<Space>".  To be fully Vi
 compatible (but unreadable) don't use the |<>| notation, precede {rhs} with a
 single CTRL-V (you have to type CTRL-V two times).
-							*map_empty_rhs*
+						*map_empty_rhs* *map-empty-rhs*
 You can create an empty {rhs} by typing nothing after a single CTRL-V (you
 have to type CTRL-V two times).  Unfortunately, you cannot do this in a vimrc
 file.
@@ -581,7 +581,7 @@ Upper and lowercase differences are ignored.
 It is not possible to put a comment after these commands, because the '"'
 character is considered to be part of the {lhs} or {rhs}.
 
-							*map_bar*
+							*map_bar* *map-bar*
 Since the '|' character is used to separate a map command from the next
 command, you will have to do something special to include  a '|' in {rhs}.
 There are three methods:
@@ -599,7 +599,7 @@ When 'b' is present in 'cpoptions', "\|" will be recognized as a mapping
 ending in a '\' and then another command.  This is Vi compatible, but
 illogical when compared to other commands.
 
-							*map_return*
+						*map_return* *map-return*
 When you have a mapping that contains an Ex command, you need to put a line
 terminator after it to have it executed.  The use of <CR> is recommended for
 this (see |<>|).  Example: >

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -1,4 +1,4 @@
-*usr_02.txt*	For Vim version 7.4.  Last change: 2015 Apr 12
+*usr_02.txt*	For Vim version 7.4.  Last change: 2016 Jan 15
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -397,7 +397,15 @@ original version of the file.
 
 Everything you always wanted to know can be found in the Vim help files.
 Don't be afraid to ask!
-   To get generic help use this command: >
+
+If you know what you are looking for, it is usually easier to search for it
+using the help system, instead of using Google.  Because the subjects follow
+a certain style guide.
+
+Also the help has the advantage of belonging to your particular Vim version.
+You won't see help for commands added later.  These would not work for you.
+
+To get generic help use this command: >
 
 	:help
 
@@ -471,7 +479,7 @@ example, use the following command: >
 
 	:help 'number'
 
-The table with all mode prefixes can be found here: |help-context|.
+The table with all mode prefixes can be found below: |help-summary|.
 
 Special keys are enclosed in angle brackets.  To find help on the up-arrow key
 in Insert mode, for instance, use this command: >
@@ -488,64 +496,187 @@ You can use the error ID at the start to find help about it: >
 
 
 Summary: 					*help-summary*  >
-	:help
-<		Gives you very general help.  Scroll down to see a list of all
-		helpfiles, including those added locally (i.e. not distributed
-		with Vim). >
-	:help user-toc.txt
-<		Table of contents of the User Manual. >
-	:help :subject
-<		Ex-command "subject", for instance the following: >
-	:help :help
-<		Help on getting help. >
-	:help abc
-<		normal-mode command "abc". >
-	:help CTRL-B
-<		Control key <C-B> in Normal mode. >
-	:help i_abc
-	:help i_CTRL-B
-<		The same in Insert mode. >
-	:help v_abc
-	:help v_CTRL-B
-<		The same in Visual mode. >
-	:help c_abc
-	:help c_CTRL-B
-<		The same in Command-line mode. >
-	:help 'subject'
-<		Option 'subject'. >
-	:help subject()
-<		Function "subject". >
-	:help -subject
-<		Command-line argument "-subject". >
-	:help +subject
-<		Compile-time feature "+subject". >
-	:help /*
-<		Regular expression item "*" >
-	:help EventName
-<		Autocommand event "EventName". >
-	:help digraphs.txt
-<		The top of the helpfile "digraph.txt".
-		Similarly for any other helpfile. >
-	:help pattern<Tab>
-<		Find a help tag starting with "pattern".  Repeat <Tab> for
-		others. >
-	:help pattern<Ctrl-D>
-<		See all possible help tag matches "pattern" at once. >
-	:helpgrep pattern
-<		Search the whole text of all help files for pattern "pattern".
-		Jumps to the first match.  Jump to other matches with: >
-	    :cn
-<			next match >
-	    :cprev
-	    :cN
-<			previous match >
-	    :cfirst
-	    :clast
-<			first or last match >
-	    :copen
-	    :cclose
-<			open/close the quickfix window; press <Enter> to jump
-			to the item under the cursor
+
+1) Use Ctrl-D after typing a topic and let Vim show all available topics.
+   Or press Tab to complete: >
+    	:help some<Tab>
+<   More information on how to use the help: >
+	:help helphelp
+
+2) Follow the links in bars to related help.  You can go from the detailed
+   help to the user documentation, which describes certain commands more from
+   a user perspective and less detailed.  E.g. after: >
+   	:help pattern.txt
+<   You can see the user guide topics |03.9| and |usr_27.txt| in the
+   introduction.
+
+3) Options are enclosed in single apostrophes.  To go to the help topic for the
+   list option: >
+	:help 'list'
+<   If you only know you are looking for a certain option, you can also do: >
+	:help options.txt
+<   to open the help page which describes all option handling and then search
+   using regular expressions, e.g. textwidth.
+   Certain options have their own namespace, e.g.: >
+   	:help cpo-<letter>
+<   for the corresponding flag of the 'cpoptions' settings, substitute <letter>
+   by a specific flag, e.g.: >
+  	:help cpo-;
+<   And for the guioption flags: >
+  	:help go-<letter>
+
+4) Normal mode commands do not have a prefix. To go to the help page for the
+   "gt" command: >
+   	:help gt
+
+5) Insert mode commands start with i_.  Help for deleting a word: >
+   	:help i_CTRL-W
+
+6) Visual mode commands start with v_.  Help for jumping to the other side of
+   the Visual area: >
+   	:help v_o
+
+7) Command line editing and arguments start with c_.  Help for using the
+   command argument %: >
+   	:help c_%
+
+8) Ex-commands always start with ":", so to go to the :s command help: >
+	:help :s
+
+9) Key combinations.  They usually start with a single letter indicating
+   the mode for which they can be used.  E.g.: >
+   	:help i_CTRL-X
+<   takes you to the family of Ctrl-X commands for insert mode which can be
+   used to auto complete different things.  Note, that certain keys will
+   always be written the same, e.g. Control will always be CTRL.
+   For normal mode commands there is no prefix and the topic is available at
+   :h CTRL-<Letter>. E.g.  >
+   	:help CTRL-W
+<   In contrast >
+	:help c_CTRL-R
+<   will describe what the Ctrl-R does when entering commands in the Command
+   line and >
+   	:help v_Ctrl-A
+<   talks about incrementing numbers in visual mode and >
+	:help g_CTRL-A
+<   talks about the g<C-A> command (e.g. you have to press "g" then <Ctrl-A>).
+   Here the "g" stand for the normal command "g" which always expects a second
+   key before doing something similar to the commands starting with "z"
+
+10) Regexp items always start with /.  So to get help for the "\+" quantifier
+    in Vim regexes: >
+   	:help /\+
+<   If you need to know everything about regular expressions, start reading
+   at: >
+   	:help pattern.txt
+
+11) Registers always start with "quote". To find out about the special ":"
+    register: >
+   	:help quote:
+
+12) Vim Script (VimL) is available at >
+	:help eval.txt
+<   Certain aspects of the language are available at :h expr-X where "X" is a
+   single letter. E.g.  >
+   	:help expr-!
+<   will take you to the topic describing the "!" (Not) operator for
+   VimScript.
+   Also important is >
+   	:help function-list
+<   to find a short description of all functions available.  Help topics for
+   VimL functions always include the "()", so: >
+   	:help append()
+<   talks about the append VimL function rather than how to append text in the
+   current buffer.
+
+13) Mappings are talked about in the help page :h |map.txt|. Use >
+    	:help mapmode-i
+<    to find out about the |:imap| command.  Also use :map-topic
+    to find out about certain subtopics particular for mappings.  e.g: >
+    	:help :map-local
+<    for buffer-local mappings or >
+	:help map-bar
+<    for how the '|' is handled in mappings.
+
+14) Command definitions are talked about :h command-topic, so use >
+	:help command-bar
+<    to find out about the '!' argument for custom commands.
+
+15) Window management commands always start with CTRL-W, so you find the
+    corresponding help at :h CTRL-W_letter.  E.g. >
+   	:help CTRL-W_p
+<    for moving the previous accessed window).  You can also access >
+	:help windows.txt
+<    and read your way through if you are looking for window handling
+    commands.
+
+16) Use |:helpgrep| to search in all help pages (and also of any installed
+    plugins).  See |:helpgrep| for how to use it.
+    To search for a topic: >
+    	:helpgrep topic
+<    This takes you to the first match.  To go to the next one: >
+	:cnext
+<    All matches are available in the quickfix window which can be opened
+    with: >
+    	:copen
+<    Move around to the match you like and press Enter to jump to that help.
+
+17) The user manual.  This describes help topics for beginners in a rather
+    friendly way.  Start at |usr_toc.txt| to find the table of content (as you
+    might have guessed): >
+    	:help usr_toc.txt
+<    Skim over the contents to find interesting topics. The "Digraphs" and
+    "Entering special characters" items are in chapter 24, so to go to that
+    particular help page: >
+    	:help usr_24.txt
+<    Also if you want to access a certain chapter in the help, the chapter
+    number can be accessed directly like this: >
+    	:help 10.1
+<    goes to chapter 10.1 in |usr_10.txt| and talks about recording macros.
+
+18) Highlighting groups.  Always start with hl-groupname.  E.g. >
+    	:help hl-WarningMsg
+<    talks about the WarningMsg highlighting group.
+
+19) Syntax highlighting is namespaced to :syn-topic e.g. >
+	:help :syn-conceal
+<    talks about the conceal argument for the :syn command.
+
+20) Quickfix commands usually start with :c while location list commands
+    usually start with :l
+
+21) Autocommand events can be found by their name: >
+     	:help BufWinLeave
+<    To see all possible events: >
+	:help autocommands-events
+
+22) Command-line switches always start with "-".  So for the help of the -f
+    command switch of Vim use: >
+    	:help -f
+
+23) Optional features always start with "+".  To find out about the
+    conceal feature use: >
+    	:help +conceal
+
+24) Documentation for included filetype specific functionality is usually
+    available  in the form ft-<filetype>-<functionality>.  So >
+    	:help ft-c-syntax
+<    talks about the C syntax file and the option it provides.  Sometimes,
+    additional sections for omni completion >
+    	:help ft-php-omni
+<    or filetype plugins >
+	:help ft-tex-plugin
+<    are available.
+
+25) Error and Warning codes can be looked up directly in the help.  So >
+	:help E297
+<    takes you exactly to the description of the swap error message and >
+	:help W10
+<    talks about the warning "Changing a readonly file".
+    Sometimes however, those error codes are not described, but rather are
+    listed at the Vim command that usually causes this.  So: >
+    	:help E128
+<    takes you to the |:function| command
 
 
 ==============================================================================

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -1,4 +1,4 @@
-*various.txt*   For Vim version 7.4.  Last change: 2015 Nov 15
+*various.txt*   For Vim version 7.4.  Last change: 2016 Jan 10
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/syntax/aptconf.vim
+++ b/runtime/syntax/aptconf.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	APT config file
 " Maintainer:	Yann Amar <quidame@poivron.org>
-" Last Change:	2013 Apr 12
+" Last Change:	2015 Dec 22
 
 " For version 5.x: Clear all syntax items
 " For version 6.x and 7.x: Quit when a syntax file was already loaded
@@ -38,22 +38,22 @@ setlocal iskeyword+=/,-,.,_,+
 
 " Incomplete keywords will be treated differently than completely bad strings:
 syn keyword	aptconfGroupIncomplete
-	\ a[cquire] a[ptitude] d[ebtags] d[ebug] d[ir] d[pkg] d[select]
-	\ o[rderlist] p[ackagemanager] p[kgcachegen] q[uiet] r[pm]
-	\ u[nattended-upgrade]
+	\ a[cquire] a[dequate] a[ptitude] a[ptlistbugs] d[ebtags] d[ebug]
+	\ d[ir] d[pkg] d[select] o[rderlist] p[ackagemanager] p[kgcachegen]
+	\ q[uiet] r[pm] s[ynaptic] u[nattended-upgrade] w[hatmaps]
 
 " Only the following keywords can be used at toplevel (to begin an option):
 syn keyword	aptconfGroup
-	\ acquire apt aptitude debtags debug dir dpkg dselect
-	\ orderlist packagemanager pkgcachegen quiet rpm
-	\ unattended-upgrade
+	\ acquire adequate apt aptitude aptlistbugs debtags debug
+	\ dir dpkg dselect orderlist packagemanager pkgcachegen
+	\ quiet rpm synaptic unattended-upgrade whatmaps
 
 " Possible options for each group:
 " Acquire: {{{
 syn keyword	aptconfAcquire contained
-	\ cdrom Check-Valid-Until CompressionTypes ForceHash ftp gpgv
-	\ GzipIndexes http https Languages Max-ValidTime Min-ValidTime PDiffs
-	\ Queue-Mode Retries Source-Symlinks
+	\ cdrom Check-Valid-Until CompressionTypes ForceHash ForceIPv4
+	\ ForceIPv6 ftp gpgv GzipIndexes http https Languages Max-ValidTime
+	\ Min-ValidTime PDiffs Queue-Mode Retries Source-Symlinks
 
 syn keyword	aptconfAcquireCDROM contained
 	\ AutoDetect CdromOnly Mount UMount
@@ -62,14 +62,15 @@ syn keyword	aptconfAcquireCompressionTypes contained
 	\ bz2 lzma gz Order
 
 syn keyword	aptconfAcquireFTP contained
-	\ Passive Proxy ProxyLogin Timeout
+	\ ForceExtended Passive Proxy ProxyLogin Timeout
 
 syn keyword	aptconfAcquireHTTP contained
 	\ AllowRedirect Dl-Limit Max-Age No-Cache No-Store Pipeline-Depth
-	\ Proxy Timeout User-Agent
+	\ Proxy ProxyAutoDetect Proxy-Auto-Detect Timeout User-Agent
 
 syn keyword	aptconfAcquireHTTPS contained
-	\ CaInfo CaPath CrlFile IssuerCert SslCert SslForceVersion SslKey
+	\ AllowRedirect CaInfo CaPath CrlFile Dl-Limit IssuerCert Max-Age
+	\ No-Cache No-Store Proxy SslCert SslForceVersion SslKey Timeout
 	\ Verify-Host Verify-Peer
 
 syn keyword	aptconfAcquireMaxValidTime contained
@@ -83,14 +84,21 @@ syn cluster	aptconfAcquire_ contains=aptconfAcquire,
 	\ aptconfAcquireHTTP,aptconfAcquireHTTPS,aptconfAcquireMaxValidTime,
 	\ aptconfAcquirePDiffs
 " }}}
+" Adequate: {{{
+syn keyword	aptconfAdequate contained
+	\ Enabled
+
+syn cluster	aptconfAdequate_ contains=aptconfAdequate
+" }}}
 " Apt: {{{
 syn keyword	aptconfApt contained
 	\ Architecture Architectures Archive Authentication AutoRemove
-	\ Build-Essential Cache Cache-Grow Cache-Limit Cache-Start CDROM
-	\ Changelogs Clean-Installed Compressor Default-Release
-	\ Force-LoopBreak Get Ignore-Hold Immediate-Configure
+	\ Build-Essential Build-Profiles Cache Cache-Grow Cache-Limit
+	\ Cache-Start CDROM Changelogs Clean-Installed Compressor
+	\ Default-Release Force-LoopBreak Get Ignore-Hold Immediate-Configure
 	\ Install-Recommends Install-Suggests Keep-Fds List-Cleanup
-	\ NeverAutoRemove Never-MarkAuto-Sections Periodic Status-Fd Update
+	\ Move-Autobit-Sections NeverAutoRemove Never-MarkAuto-Sections
+	\ Periodic Status-Fd Update VersionedKernelPackages
 
 syn keyword	aptconfAptAuthentication contained
 	\ TrustCDROM
@@ -124,11 +132,12 @@ syn keyword	aptconfAptGet contained
 
 syn keyword	aptconfAptPeriodic contained
 	\ AutocleanInterval BackupArchiveInterval BackupLevel
-	\ Download-Upgradeable-Packages MaxAge MaxSize MinAge
-	\ Unattended-Upgrade Update-Package-Lists Verbose
+	\ Download-Upgradeable-Packages Download-Upgradeable-Packages-Debdelta
+	\ Enable MaxAge MaxSize MinAge Unattended-Upgrade Update-Package-Lists
+	\ Verbose
 
 syn keyword	aptconfAptUpdate contained
-	\ Pre-Invoke Post-Invoke Post-Invoke-Success
+	\ List-Refresh Pre-Invoke Post-Invoke Post-Invoke-Success
 
 syn cluster	aptconfApt_ contains=aptconfApt,
 	\ aptconfAptAuthentication,aptconfAptAutoRemove,aptconfAptCache,
@@ -240,6 +249,12 @@ syn cluster	aptconfAptitude_ contains=aptconfAptitude,
 	\ aptconfAptitudeUIKeyBindings,aptconfAptitudeUIStyles,
 	\ aptconfAptitudeUIStylesElements
 " }}}
+" AptListbugs: {{{
+syn keyword	aptconfAptListbugs contained
+	\ IgnoreRegexp Severities
+
+syn cluster	aptconfAptListbugs_ contains=aptconfAptListbugs
+" }}}
 " DebTags: {{{
 syn keyword	aptconfDebTags contained
 	\ Vocabulary
@@ -251,7 +266,8 @@ syn keyword	aptconfDebug contained
 	\ Acquire aptcdrom BuildDeps Hashes IdentCdrom Nolocking
 	\ pkgAcquire pkgAutoRemove pkgCacheGen pkgDepCache pkgDPkgPM
 	\ pkgDPkgProgressReporting pkgInitialize pkgOrderList
-	\ pkgPackageManager pkgPolicy pkgProblemResolver sourceList
+	\ pkgPackageManager pkgPolicy pkgProblemResolver RunScripts
+	\ sourceList
 
 syn keyword	aptconfDebugAcquire contained
 	\ cdrom Ftp gpgv Http Https netrc
@@ -295,7 +311,7 @@ syn keyword	aptconfDirMedia contained
 	\ MountPath
 
 syn keyword	aptconfDirState contained
-	\ cdroms extended_states Lists mirrors status
+	\ cdroms extended_states Lists mirrors preferences status
 
 syn cluster	aptconfDir_ contains=aptconfDir,
 	\ aptconfDirAptitude,aptconfDirBin,aptconfDirCache,aptconfDirEtc,
@@ -303,15 +319,16 @@ syn cluster	aptconfDir_ contains=aptconfDir,
 " }}}
 " DPkg: {{{
 syn keyword	aptconfDPkg contained
-	\ Build-Options Chroot-Directory ConfigurePending FlushSTDIN MaxArgs
-	\ MaxBytes NoTriggers options Pre-Install-Pkgs Pre-Invoke Post-Invoke
+	\ Build-Options Chroot-Directory ConfigurePending FlushSTDIN
+	\ MaxArgBytes MaxArgs MaxBytes NoTriggers options
+	\ Pre-Install-Pkgs Pre-Invoke Post-Invoke
 	\ Run-Directory StopOnError Tools TriggersPending
 
 syn keyword	aptconfDPkgTools contained
-	\ Options Version
+	\ adequate InfoFD Options Version
 
 syn cluster	aptconfDPkg_ contains=aptconfDPkg,
-	\ aptconfDPkgOrderList,aptconfDPkgOrderListScore,aptconfDPkgTools
+	\ aptconfDPkgTools
 " }}}
 " DSelect: {{{
 syn keyword	aptconfDSelect contained
@@ -353,23 +370,59 @@ syn keyword	aptconfRpm contained
 
 syn cluster	aptconfRpm_ contains=aptconfRpm
 " }}}
-" Unattened Upgrade: {{{
+" Synaptic: {{{
+syn keyword	aptconfSynaptic contained
+	\ AskQuitOnProceed AskRelated AutoCleanCache CleanCache DefaultDistro
+	\ delAction delHistory Download-Only ftpProxy ftpProxyPort httpProxy
+	\ httpProxyPort Install-Recommends LastSearchType Maximized noProxy
+	\ OneClickOnStatusActions ShowAllPkgInfoInMain showWelcomeDialog
+	\ ToolbarState undoStackSize update upgradeType useProxy UseStatusColors
+	\ UseTerminal useUserFont useUserTerminalFont ViewMode
+	\ availVerColumnPos availVerColumnVisible componentColumnPos
+	\ componentColumnVisible descrColumnPos descrColumnVisible
+	\ downloadSizeColumnPos downloadSizeColumnVisible hpanedPos
+	\ instVerColumnPos instVerColumnVisible instSizeColumnPos
+	\ instSizeColumnVisible nameColumnPos nameColumnVisible
+	\ sectionColumnPos sectionColumnVisible statusColumnPos
+	\ statusColumnVisible supportedColumnPos supportedColumnVisible
+	\ vpanedPos windowWidth windowHeight windowX windowY closeZvt
+	\ color-available color-available-locked color-broken color-downgrade
+	\ color-install color-installed-locked color-installed-outdated
+	\ color-installed-updated color-new color-purge color-reinstall
+	\ color-remove color-upgrade
+
+syn keyword	aptconfSynapticUpdate contained
+	\ last type
+
+syn cluster	aptconfSynaptic_ contains=aptconfSynaptic,
+	\ aptconfSynapticUpdate
+" }}}
+" Unattended Upgrade: {{{
 syn keyword	aptconfUnattendedUpgrade contained
-	\ AutoFixInterruptedDpkg Automatic-Reboot InstallOnShutdown Mail
-	\ MailOnlyOnError MinimalSteps Origins-Pattern Package-Blacklist
+	\ AutoFixInterruptedDpkg Automatic-Reboot Automatic-Reboot-Time
+	\ Automatic-Reboot-WithUsers InstallOnShutdown Mail MailOnlyOnError
+	\ MinimalSteps Origins-Pattern Package-Blacklist
 	\ Remove-Unused-Dependencies
 
 syn cluster	aptconfUnattendedUpgrade_ contains=aptconfUnattendedUpgrade
+" }}}
+" Whatmaps: {{{
+syn keyword	aptconfWhatmaps contained
+	\ Enable-Restart Security-Update-Origins
+
+syn cluster	aptconfWhatmaps_ contains=aptconfWhatmaps
 " }}}
 
 syn case	match
 
 " Now put all the keywords (and 'valid' options) in a single cluster:
 syn cluster	aptconfOptions contains=aptconfRegexpOpt,
-	\ @aptconfAcquire_,@aptconfApt_,@aptconfAptitude_,@aptconfDebTags_,
-	\ @aptconfDebug_,@aptconfDir_,@aptconfDPkg_,@aptconfDSelect_,
-	\ @aptconfOrderList_,@aptconfPackageManager_,@aptconfPkgCacheGen_,
-	\ @aptconfQuiet_,@aptconfRpm_,@aptconfUnattendedUpgrade_
+	\ @aptconfAcquire_,@aptconfAdequate_,@aptconfApt_,@aptconfAptitude_,
+	\ @aptconfAptListbugs_,@aptconfDebTags_,@aptconfDebug_,@aptconfDir_,
+	\ @aptconfDPkg_,@aptconfDSelect_,@aptconfOrderList_,
+	\ @aptconfPackageManager_,@aptconfPkgCacheGen_,@aptconfQuiet_,
+	\ @aptconfRpm_,@aptconfSynaptic_,@aptconfUnattendedUpgrade_,
+	\ @aptconfWhatmaps_
 
 " Syntax:
 syn match	aptconfSemiColon	';'
@@ -382,8 +435,11 @@ syn region	aptconfInclude		matchgroup=aptconfOperator start='::' end='::\|\s'me=
 
 " Basic Syntax Errors: XXX avoid to generate false positives !!!
 "
-" * Invalid comment format (seems to not cause errors, but...):
-syn match	aptconfAsError		display '^#.*'
+" * Undocumented inline comment. Since it is currently largely used, and does
+" not seem to cause trouble ('apt-config dump' never complains when # is used
+" the same way than //) it has been moved to aptconfComment group. But it
+" still needs to be defined here (i.e. before #clear and #include directives)
+syn match	aptconfComment		'#.*' contains=@aptconfCommentSpecial
 "
 " * When a semicolon is missing after a double-quoted string:
 " There are some cases (for example in the Dir group of options, but not only)
@@ -445,6 +501,8 @@ hi def link aptconfAcquireHTTPS			aptconfOption
 hi def link aptconfAcquireMaxValidTime		aptconfOption
 hi def link aptconfAcquirePDiffs		aptconfOption
 
+hi def link aptconfAdequate			aptconfOption
+
 hi def link aptconfApt				aptconfOption
 hi def link aptconfAptAuthentication		aptconfOption
 hi def link aptconfAptAutoRemove		aptconfOption
@@ -470,6 +528,8 @@ hi def link aptconfAptitudeUI			aptconfOption
 hi def link aptconfAptitudeUIKeyBindings	aptconfOption
 hi def link aptconfAptitudeUIStyles		aptconfOption
 hi def link aptconfAptitudeUIStylesElements	aptconfOption
+
+hi def link aptconfAptListbugs			aptconfOption
 
 hi def link aptconfDebTags			aptconfOption
 
@@ -504,7 +564,12 @@ hi def link aptconfQuiet			aptconfOption
 
 hi def link aptconfRpm				aptconfOption
 
+hi def link aptconfSynaptic			aptconfOption
+hi def link aptconfSynapticUpdate		aptconfOption
+
 hi def link aptconfUnattendedUpgrade		aptconfOption
+
+hi def link aptconfWhatmaps			aptconfOption
 
 let b:current_syntax = "aptconf"
 

--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -2,7 +2,7 @@
 " Language: reStructuredText documentation format
 " Maintainer: Marshall Ward <marshall.ward@gmail.com>
 " Previous Maintainer: Nikolai Weibull <now@bitwi.se>
-" Latest Revision: 2015-09-07
+" Latest Revision: 2016-01-05
 
 if exists("b:current_syntax")
   finish
@@ -12,8 +12,6 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 syn case ignore
-
-syn match   rstSections "^\%(\([=`:.'"~^_*+#-]\)\1\+\n\)\=.\+\n\([=`:.'"~^_*+#-]\)\2\+$"
 
 syn match   rstTransition  /^[=`:.'"~^_*+#-]\{4,}\s*$/
 
@@ -122,6 +120,8 @@ call s:DefineInlineMarkup('InterpretedTextOrHyperlinkReference', '`', '`', '`_\{
 call s:DefineInlineMarkup('InlineLiteral', '``', "", '``')
 call s:DefineInlineMarkup('SubstitutionReference', '|', '|', '|_\{0,2}')
 call s:DefineInlineMarkup('InlineInternalTargets', '_`', '`', '`')
+
+syn match   rstSections "^\%(\([=`:.'"~^_*+#-]\)\1\+\n\)\=.\+\n\([=`:.'"~^_*+#-]\)\2\+$"
 
 " TODO: Can’t remember why these two can’t be defined like the ones above.
 execute 'syn match rstFootnoteReference contains=@NoSpell' .

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -2,9 +2,10 @@
 " Language:	OpenSSH client configuration file (ssh_config)
 " Author:	David Necas (Yeti)
 " Maintainer:	Dominik Fischer <d dot f dot fischer at web dot de>
-" Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>	
-" Last Change:	2015 Dec 3 
-" SSH Version:	7.0
+" Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>
+" Contributor:  Karsten Hopp <karsten@redhat.com>
+" Last Change:	2016 Jan 15
+" SSH Version:	7.1
 "
 
 " Setup
@@ -69,8 +70,8 @@ syn keyword sshconfigSysLogFacility DAEMON USER AUTH AUTHPRIV LOCAL0 LOCAL1
 syn keyword sshconfigSysLogFacility LOCAL2 LOCAL3 LOCAL4 LOCAL5 LOCAL6 LOCAL7
 syn keyword sshconfigAddressFamily  inet inet6
 
-syn match   sshconfigIPQoS	"af1[1234]"
-syn match   sshconfigIPQoS	"af2[23]"
+syn match   sshconfigIPQoS	"af1[123]"
+syn match   sshconfigIPQoS	"af2[123]"
 syn match   sshconfigIPQoS	"af3[123]"
 syn match   sshconfigIPQoS	"af4[123]"
 syn match   sshconfigIPQoS	"cs[0-7]"
@@ -106,6 +107,10 @@ syn keyword sshconfigMatch canonical exec host originalhost user localuser all
 syn keyword sshconfigKeyword AddressFamily
 syn keyword sshconfigKeyword BatchMode
 syn keyword sshconfigKeyword BindAddress
+syn keyword sshconfigKeyword CanonicalDomains
+syn keyword sshconfigKeyword CanonicalizeFallbackLocal
+syn keyword sshconfigKeyword CanonicalizeHostname
+syn keyword sshconfigKeyword CanonicalizeMaxDots
 syn keyword sshconfigKeyword ChallengeResponseAuthentication
 syn keyword sshconfigKeyword CheckHostIP
 syn keyword sshconfigKeyword Cipher
@@ -145,6 +150,8 @@ syn keyword sshconfigKeyword HostbasedKeyTypes
 syn keyword sshconfigKeyword IPQoS
 syn keyword sshconfigKeyword IdentitiesOnly
 syn keyword sshconfigKeyword IdentityFile
+syn keyword sshconfigKeyword IgnoreUnknown
+syn keyword sshconfigKeyword IPQoS
 syn keyword sshconfigKeyword KbdInteractiveAuthentication
 syn keyword sshconfigKeyword KbdInteractiveDevices
 syn keyword sshconfigKeyword KexAlgorithms
@@ -182,6 +189,7 @@ syn keyword sshconfigKeyword UseBlacklistedKeys
 syn keyword sshconfigKeyword UsePrivilegedPort
 syn keyword sshconfigKeyword User
 syn keyword sshconfigKeyword UserKnownHostsFile
+syn keyword sshconfigKeyword UseRoaming
 syn keyword sshconfigKeyword VerifyHostKeyDNS
 syn keyword sshconfigKeyword VisualHostKey
 syn keyword sshconfigKeyword XAuthLocation

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -4,9 +4,10 @@
 " Maintainer:	Dominik Fischer <d dot f dot fischer at web dot de>
 " Contributor:	Thilo Six
 " Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>	
+" Contributor:  Karsten Hopp <karsten@redhat.com>
 " Originally:	2009-07-09
-" Last Change:	2015 Dec 3 
-" SSH Version:	7.0
+" Last Change:	2016 Jan 12
+" SSH Version:	7.1
 "
 
 " Setup
@@ -65,8 +66,8 @@ syn keyword sshdconfigSysLogFacility LOCAL2 LOCAL3 LOCAL4 LOCAL5 LOCAL6 LOCAL7
 
 syn keyword sshdconfigCompression    delayed
 
-syn match   sshdconfigIPQoS	"af1[1234]"
-syn match   sshdconfigIPQoS	"af2[23]"
+syn match   sshdconfigIPQoS	"af1[123]"
+syn match   sshdconfigIPQoS	"af2[123]"
 syn match   sshdconfigIPQoS	"af3[123]"
 syn match   sshdconfigIPQoS	"af4[123]"
 syn match   sshdconfigIPQoS	"cs[0-7]"
@@ -109,6 +110,7 @@ syn keyword sshdconfigKeyword AllowGroups
 syn keyword sshdconfigKeyword AllowStreamLocalForwarding
 syn keyword sshdconfigKeyword AllowTcpForwarding
 syn keyword sshdconfigKeyword AllowUsers
+syn keyword sshdconfigKeyword AuthenticationMethods
 syn keyword sshdconfigKeyword AuthorizedKeysFile
 syn keyword sshdconfigKeyword AuthorizedKeysCommand
 syn keyword sshdconfigKeyword AuthorizedKeysCommandUser
@@ -132,6 +134,7 @@ syn keyword sshdconfigKeyword GSSAPIStrictAcceptorCheck
 syn keyword sshdconfigKeyword GatewayPorts
 syn keyword sshdconfigKeyword HostCertificate
 syn keyword sshdconfigKeyword HostKey
+syn keyword sshdconfigKeyword HostKeyAgent
 syn keyword sshdconfigKeyword HostKeyAlgorithms
 syn keyword sshdconfigKeyword HostbasedAcceptedKeyTypes
 syn keyword sshdconfigKeyword HostbasedAuthentication


### PR DESCRIPTION
Update runtime files

https://github.com/vim/vim/commit/345efa013dc6d1754ba06e5596a26c48c9935937

Ignored changes to:
- doc/tags
- doc/todo.txt
- doc/various.txt, since the MEM_PROFILING #ifdef doesn't exist in
  Neovim
