### PR TITLE
[RDY] Windows: Don't build the TUI is systems where it is not supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,11 +300,19 @@ include_directories(SYSTEM ${LIBUV_INCLUDE_DIRS})
 find_package(Msgpack 1.0.0 REQUIRED)
 include_directories(SYSTEM ${MSGPACK_INCLUDE_DIRS})
 
-find_package(Unibilium REQUIRED)
-include_directories(SYSTEM ${UNIBILIUM_INCLUDE_DIRS})
+if(UNIX)
+  option(FEAT_TUI "Enable the Terminal UI" ON)
+else()
+  option(FEAT_TUI "Enable the Terminal UI" OFF)
+endif()
 
-find_package(LibTermkey REQUIRED)
-include_directories(SYSTEM ${LIBTERMKEY_INCLUDE_DIRS})
+if(FEAT_TUI)
+  find_package(Unibilium REQUIRED)
+  include_directories(SYSTEM ${UNIBILIUM_INCLUDE_DIRS})
+
+  find_package(LibTermkey REQUIRED)
+  include_directories(SYSTEM ${LIBTERMKEY_INCLUDE_DIRS})
+endif()
 
 find_package(LibVterm REQUIRED)
 include_directories(SYSTEM ${LIBVTERM_INCLUDE_DIRS})

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -50,6 +50,7 @@
 #cmakedefine USE_FNAME_CASE
 
 #define FEAT_CSCOPE
+#cmakedefine FEAT_TUI
 
 #ifndef UNIT_TESTING
 #cmakedefine HAVE_JEMALLOC

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -55,6 +55,10 @@ foreach(subdir
         event
         eval
        )
+  if(${subdir} MATCHES "tui" AND NOT FEAT_TUI)
+    continue()
+  endif()
+
   file(MAKE_DIRECTORY ${GENERATED_DIR}/${subdir})
   file(MAKE_DIRECTORY ${GENERATED_INCLUDES_DIR}/${subdir})
   file(GLOB sources ${subdir}/*.c)

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -30,7 +30,11 @@
 #include "nvim/screen.h"
 #include "nvim/syntax.h"
 #include "nvim/window.h"
-#include "nvim/tui/tui.h"
+#ifdef FEAT_TUI
+# include "nvim/tui/tui.h"
+#else
+# include "nvim/msgpack_rpc/server.h"
+#endif
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui.c.generated.h"
@@ -83,7 +87,22 @@ static int height, width;
 
 void ui_builtin_start(void)
 {
+#ifdef FEAT_TUI
   tui_start();
+#else
+  fprintf(stderr, "Neovim was built without a Terminal UI," \
+          "press Ctrl+C to exit\n");
+
+  size_t len;
+  char **addrs = server_address_list(&len);
+  if (addrs != NULL) {
+    fprintf(stderr, "currently listening on the following address(es)\n");
+    for (size_t i = 0; i < len; i++) {
+      fprintf(stderr, "\t%s\n", addrs[i]);
+    }
+    xfree(addrs);
+  }
+#endif
 }
 
 void ui_builtin_stop(void)

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -64,6 +64,12 @@ static char *features[] = {
 #else
   "-jemalloc",
 #endif
+
+#ifdef FEAT_TUI
+  "+tui",
+#else
+  "-tui",
+#endif
   NULL
 };
 


### PR DESCRIPTION
For systems where the builtin TUI does not work (i.e. Windows) print a message
to stderr, along with a list of the server endpoints. Remove dependency on
libtermkey and unibilium in non UNIX systems.

Cherry picked from #810.
