### PR TITLE
[RFC] Remove FEAT_CSCOPE

### DIFF
--- a/config/config.h.in
+++ b/config/config.h.in
@@ -49,7 +49,6 @@
 #cmakedefine UNIX
 #cmakedefine USE_FNAME_CASE
 
-#define FEAT_CSCOPE
 #cmakedefine FEAT_TUI
 
 #ifndef UNIT_TESTING

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2482,7 +2482,7 @@ int source_level(void *cookie)
 }
 
 
-#if (defined(WIN32) && defined(FEAT_CSCOPE)) || defined(HAVE_FD_CLOEXEC)
+#if defined(WIN32) || defined(HAVE_FD_CLOEXEC)
 # define USE_FOPEN_NOINH
 /*
  * Special function to open a file without handle inheritance.


### PR DESCRIPTION
The FEAT_CSCOPE guard was only being used in combination with WIN32 in
ex_cmds2.c.

~~Likely will have merge conflicts with #4827~~
