### PR TITLE
[RFC] vim-patch.sh: Only print the first neovim/neovim remote name

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -92,7 +92,7 @@ commit_message() {
 
 find_git_remote() {
   git remote -v \
-    | awk '$2 ~ /github.com[:/]neovim\/neovim/ && $3 == "(fetch)" {print $1}'
+    | awk '$2 ~ /github.com[:/]neovim\/neovim/ && $3 == "(fetch)" {print $1; exit}'
 }
 
 assign_commit_details() {


### PR DESCRIPTION
If a user has multiple remotes set for neovim/neovim, then
find_get_remote was returning 'remote1\nremote2\n', which breaks
anything trying to use it.  Since we're just using this remote to fetch
from, any one will do.

This should fix the problem you're seeing, @bfredl.
