### PR TITLE
deps: Download libtermkey from our mirror.

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -93,8 +93,8 @@ set(LUAROCKS_SHA256 cae709111c5701235770047dfd7169f66b82ae1c7b9b79207f9df0afb722
 set(UNIBILIUM_URL https://github.com/mauke/unibilium/archive/v1.2.0.tar.gz)
 set(UNIBILIUM_SHA256 623af1099515e673abfd3cae5f2fa808a09ca55dda1c65a7b5c9424eb304ead8)
 
-set(LIBTERMKEY_URL http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.18.tar.gz)
-set(LIBTERMKEY_SHA256 239746de41c845af52bb3c14055558f743292dd6c24ac26c2d6567a5a6093926)
+set(LIBTERMKEY_URL https://github.com/neovim/libtermkey/archive/416adba8c000bd2a70efc881283249d03a56553b.tar.gz)
+set(LIBTERMKEY_SHA256 29cb598c9afc0d306a406df4a9c9aceeb5f6a58dfe690dccc7032834d6844f86)
 
 set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/a9c7c6fd20fa35e0ad3e0e98901ca12dfca9c25c.tar.gz)
 set(LIBVTERM_SHA256 1a4272be91d9614dc183a503786df83b6584e4afaab7feaaa5409f841afbd796)


### PR DESCRIPTION
We've had at least 3 reports of failed downloads from the origin, so
let's use the mirror. The bits are identical.
