### PR TITLE
[RFC] Check sanitizer results right after the test

### DIFF
--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -1,5 +1,5 @@
 -- Sanity checks for buffer_* API calls via msgpack-rpc
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, nvim, buffer = helpers.clear, helpers.nvim, helpers.buffer
 local curbuf, curwin, eq = helpers.curbuf, helpers.curwin, helpers.eq
 local curbufmeths, ok = helpers.curbufmeths, helpers.ok

--- a/test/functional/api/menu_spec.lua
+++ b/test/functional/api/menu_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 
 local clear = helpers.clear

--- a/test/functional/api/server_notifications_spec.lua
+++ b/test/functional/api/server_notifications_spec.lua
@@ -1,5 +1,5 @@
 -- Tests for nvim notifications
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local eq, clear, eval, execute, nvim, next_message =
   helpers.eq, helpers.clear, helpers.eval, helpers.execute, helpers.nvim,
   helpers.next_message

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -1,7 +1,7 @@
 -- Tests for some server->client RPC scenarios. Note that unlike with
 -- `rpcnotify`, to evaluate `rpcrequest` calls we need the client event loop to
 -- be running.
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, nvim, eval = helpers.clear, helpers.nvim, helpers.eval
 local eq, neq, run, stop = helpers.eq, helpers.neq, helpers.run, helpers.stop
 local nvim_prog = helpers.nvim_prog

--- a/test/functional/api/tabpage_spec.lua
+++ b/test/functional/api/tabpage_spec.lua
@@ -1,5 +1,5 @@
 -- Sanity checks for tabpage_* API calls via msgpack-rpc
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, nvim, tabpage, curtab, eq, ok =
   helpers.clear, helpers.nvim, helpers.tabpage, helpers.curtab, helpers.eq,
   helpers.ok

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1,5 +1,5 @@
 -- Sanity checks for vim_* API calls via msgpack-rpc
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local NIL = helpers.NIL
 local clear, nvim, eq, neq = helpers.clear, helpers.nvim, helpers.eq, helpers.neq

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -1,5 +1,5 @@
 -- Sanity checks for window_* API calls via msgpack-rpc
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, nvim, curbuf, curbuf_contents, window, curwin, eq, neq,
   ok, feed, insert, eval = helpers.clear, helpers.nvim, helpers.curbuf,
   helpers.curbuf_contents, helpers.window, helpers.curwin, helpers.eq,

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 
 local clear = helpers.clear
 local command = helpers.command

--- a/test/functional/autocmd/tabclose_spec.lua
+++ b/test/functional/autocmd/tabclose_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, nvim, eq = helpers.clear, helpers.nvim, helpers.eq
 
 describe('TabClosed', function()

--- a/test/functional/autocmd/tabnew_spec.lua
+++ b/test/functional/autocmd/tabnew_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 
 local clear = helpers.clear
 local command = helpers.command

--- a/test/functional/autocmd/tabnewentered_spec.lua
+++ b/test/functional/autocmd/tabnewentered_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, nvim, eq = helpers.clear, helpers.nvim, helpers.eq
 
 describe('TabNewEntered', function()

--- a/test/functional/autocmd/termclose_spec.lua
+++ b/test/functional/autocmd/termclose_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 
 local clear, execute, feed, nvim, nvim_dir = helpers.clear,

--- a/test/functional/autocmd/textyankpost_spec.lua
+++ b/test/functional/autocmd/textyankpost_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, eval, eq = helpers.clear, helpers.eval, helpers.eq
 local feed, execute, expect, command = helpers.feed, helpers.execute, helpers.expect, helpers.command
 local curbufmeths, funcs, neq = helpers.curbufmeths, helpers.funcs, helpers.neq

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -1,6 +1,6 @@
 -- Test clipboard provider support
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect, eq, eval = helpers.execute, helpers.expect, helpers.eq, helpers.eval

--- a/test/functional/dict_notifications_spec.lua
+++ b/test/functional/dict_notifications_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, nvim, source = helpers.clear, helpers.nvim, helpers.source
 local eq, next_msg = helpers.eq, helpers.next_message
 local exc_exec = helpers.exc_exec

--- a/test/functional/eval/glob_spec.lua
+++ b/test/functional/eval/glob_spec.lua
@@ -1,5 +1,5 @@
 local lfs = require('lfs')
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute, eval, eq = helpers.clear, helpers.execute, helpers.eval, helpers.eq
 
 before_each(function()

--- a/test/functional/eval/json_functions_spec.lua
+++ b/test/functional/eval/json_functions_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local funcs = helpers.funcs
 local meths = helpers.meths

--- a/test/functional/eval/msgpack_functions_spec.lua
+++ b/test/functional/eval/msgpack_functions_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local funcs = helpers.funcs
 local eval, eq = helpers.eval, helpers.eq

--- a/test/functional/eval/operators_spec.lua
+++ b/test/functional/eval/operators_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local eq = helpers.eq
 local eval = helpers.eval
 local clear = helpers.clear

--- a/test/functional/eval/printf_spec.lua
+++ b/test/functional/eval/printf_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local eq = helpers.eq
 local funcs = helpers.funcs

--- a/test/functional/eval/reltime_spec.lua
+++ b/test/functional/eval/reltime_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, eq, ok = helpers.clear,  helpers.eq, helpers.ok
 local neq, execute, funcs  = helpers.neq, helpers.execute, helpers.funcs
 local reltime, reltimestr, reltimefloat = funcs.reltime, funcs.reltimestr, funcs.reltimefloat

--- a/test/functional/eval/server_spec.lua
+++ b/test/functional/eval/server_spec.lua
@@ -1,5 +1,5 @@
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local nvim, eq, neq, eval = helpers.nvim, helpers.eq, helpers.neq, helpers.eval
 local clear, funcs, meths = helpers.clear, helpers.funcs, helpers.meths
 local os_name = helpers.os_name

--- a/test/functional/eval/special_vars_spec.lua
+++ b/test/functional/eval/special_vars_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local exc_exec = helpers.exc_exec
 local execute = helpers.execute
 local funcs = helpers.funcs

--- a/test/functional/eval/string_spec.lua
+++ b/test/functional/eval/string_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local eq = helpers.eq
 local command = helpers.command

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local ok, feed, eq, eval = helpers.ok, helpers.feed, helpers.eq, helpers.eval
 local source, nvim_async, run = helpers.source, helpers.nvim_async, helpers.run

--- a/test/functional/eval/vvar_event_spec.lua
+++ b/test/functional/eval/vvar_event_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, eval, eq = helpers.clear, helpers.eval, helpers.eq
 local command = helpers.command
 describe('v:event', function()

--- a/test/functional/ex_cmds/append_spec.lua
+++ b/test/functional/ex_cmds/append_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 
 local eq = helpers.eq
 local feed = helpers.feed

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -1,7 +1,7 @@
 -- Specs for :cd, :tcd, :lcd and getcwd()
 
 local lfs = require('lfs')
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 
 local eq = helpers.eq
 local call = helpers.call

--- a/test/functional/ex_cmds/encoding_spec.lua
+++ b/test/functional/ex_cmds/encoding_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute, feed = helpers.clear, helpers.execute, helpers.feed
 local eq, neq, eval = helpers.eq, helpers.neq, helpers.eval
 

--- a/test/functional/ex_cmds/grep_spec.lua
+++ b/test/functional/ex_cmds/grep_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute, feed, ok, eval =
   helpers.clear, helpers.execute, helpers.feed, helpers.ok, helpers.eval
 

--- a/test/functional/ex_cmds/menu_spec.lua
+++ b/test/functional/ex_cmds/menu_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute, nvim = helpers.clear, helpers.execute, helpers.nvim
 local expect, feed, command = helpers.expect, helpers.feed, helpers.command
 local eq, eval = helpers.eq, helpers.eval

--- a/test/functional/ex_cmds/oldfiles_spec.lua
+++ b/test/functional/ex_cmds/oldfiles_spec.lua
@@ -1,5 +1,5 @@
 local Screen = require('test.functional.ui.screen')
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 
 local buf, eq, execute = helpers.curbufmeths, helpers.eq, helpers.execute
 local feed, nvim_prog, wait = helpers.feed, helpers.nvim_prog, helpers.wait

--- a/test/functional/ex_cmds/profile_spec.lua
+++ b/test/functional/ex_cmds/profile_spec.lua
@@ -1,7 +1,7 @@
 require('os')
 local lfs = require('lfs')
 
-local helpers  = require('test.functional.helpers')
+local helpers  = require('test.functional.helpers')(after_each)
 local eval     = helpers.eval
 local command  = helpers.command
 local eq, neq  = helpers.eq, helpers.neq

--- a/test/functional/ex_cmds/quit_spec.lua
+++ b/test/functional/ex_cmds/quit_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 
 describe(':qa', function()

--- a/test/functional/ex_cmds/recover_spec.lua
+++ b/test/functional/ex_cmds/recover_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for :recover
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local lfs = require('lfs')
 local execute, eq, clear, eval, feed, expect, source =
   helpers.execute, helpers.eq, helpers.clear, helpers.eval, helpers.feed,

--- a/test/functional/ex_cmds/sign_spec.lua
+++ b/test/functional/ex_cmds/sign_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, nvim, eq = helpers.clear, helpers.nvim, helpers.eq
 
 describe('sign', function()

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -1,6 +1,6 @@
 -- Specs for :write
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local eq, eval, clear, write_file, execute, source =
 	helpers.eq, helpers.eval, helpers.clear, helpers.write_file,
 	helpers.execute, helpers.source

--- a/test/functional/ex_cmds/wundo_spec.lua
+++ b/test/functional/ex_cmds/wundo_spec.lua
@@ -1,6 +1,6 @@
 -- Specs for :wundo and underlying functions
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local execute, clear, eval, feed, spawn, nvim_prog, set_session =
   helpers.execute, helpers.clear, helpers.eval, helpers.feed, helpers.spawn,
   helpers.nvim_prog, helpers.set_session

--- a/test/functional/ex_cmds/wviminfo_spec.lua
+++ b/test/functional/ex_cmds/wviminfo_spec.lua
@@ -1,4 +1,5 @@
-local helpers, lfs = require('test.functional.helpers'), require('lfs')
+local helpers = require('test.functional.helpers')(after_each)
+local lfs = require('lfs')
 local execute, eq, neq, spawn, nvim_prog, set_session, wait, write_file
   = helpers.execute, helpers.eq, helpers.neq, helpers.spawn,
   helpers.nvim_prog, helpers.set_session, helpers.wait, helpers.write_file

--- a/test/functional/ex_getln/history_spec.lua
+++ b/test/functional/ex_getln/history_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, meths, funcs, eq =
   helpers.clear, helpers.meths, helpers.funcs, helpers.eq
 

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -1,8 +1,13 @@
 require('coxpcall')
 local lfs = require('lfs')
-local assert = require('luassert')
 local ChildProcessStream = require('nvim.child_process_stream')
 local Session = require('nvim.session')
+local global_helpers = require('test.helpers')
+
+local check_logs = global_helpers.check_logs
+local neq = global_helpers.neq
+local eq = global_helpers.eq
+local ok = global_helpers.ok
 
 local nvim_prog = os.getenv('NVIM_PROG') or 'build/bin/nvim'
 local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
@@ -267,18 +272,6 @@ local function source(code)
   return tmpname
 end
 
-local function eq(expected, actual)
-  return assert.are.same(expected, actual)
-end
-
-local function neq(expected, actual)
-  return assert.are_not.same(expected, actual)
-end
-
-local function ok(expr)
-  assert.is_true(expr)
-end
-
 local function nvim(method, ...)
   return request('vim_'..method, ...)
 end
@@ -412,54 +405,59 @@ local curbufmeths = create_callindex(curbuf)
 local curwinmeths = create_callindex(curwin)
 local curtabmeths = create_callindex(curtab)
 
-return {
-  prepend_argv = prepend_argv,
-  clear = clear,
-  spawn = spawn,
-  dedent = dedent,
-  source = source,
-  rawfeed = rawfeed,
-  insert = insert,
-  feed = feed,
-  execute = execute,
-  eval = nvim_eval,
-  call = nvim_call,
-  command = nvim_command,
-  request = request,
-  next_message = next_message,
-  run = run,
-  stop = stop,
-  eq = eq,
-  neq = neq,
-  expect = expect,
-  ok = ok,
-  nvim = nvim,
-  nvim_async = nvim_async,
-  nvim_prog = nvim_prog,
-  nvim_dir = nvim_dir,
-  buffer = buffer,
-  window = window,
-  tabpage = tabpage,
-  curbuf = curbuf,
-  curwin = curwin,
-  curtab = curtab,
-  curbuf_contents = curbuf_contents,
-  wait = wait,
-  set_session = set_session,
-  write_file = write_file,
-  os_name = os_name,
-  rmdir = rmdir,
-  mkdir = lfs.mkdir,
-  exc_exec = exc_exec,
-  redir_exec = redir_exec,
-  merge_args = merge_args,
-  funcs = funcs,
-  meths = meths,
-  bufmeths = bufmeths,
-  winmeths = winmeths,
-  tabmeths = tabmeths,
-  curbufmeths = curbufmeths,
-  curwinmeths = curwinmeths,
-  curtabmeths = curtabmeths,
-  NIL = mpack.NIL
-}
+return function(after_each)
+  if after_each then
+    after_each(check_logs)
+  end
+  return {
+    prepend_argv = prepend_argv,
+    clear = clear,
+    spawn = spawn,
+    dedent = dedent,
+    source = source,
+    rawfeed = rawfeed,
+    insert = insert,
+    feed = feed,
+    execute = execute,
+    eval = nvim_eval,
+    call = nvim_call,
+    command = nvim_command,
+    request = request,
+    next_message = next_message,
+    run = run,
+    stop = stop,
+    eq = eq,
+    neq = neq,
+    expect = expect,
+    ok = ok,
+    nvim = nvim,
+    nvim_async = nvim_async,
+    nvim_prog = nvim_prog,
+    nvim_dir = nvim_dir,
+    buffer = buffer,
+    window = window,
+    tabpage = tabpage,
+    curbuf = curbuf,
+    curwin = curwin,
+    curtab = curtab,
+    curbuf_contents = curbuf_contents,
+    wait = wait,
+    set_session = set_session,
+    write_file = write_file,
+    os_name = os_name,
+    rmdir = rmdir,
+    mkdir = lfs.mkdir,
+    exc_exec = exc_exec,
+    redir_exec = redir_exec,
+    merge_args = merge_args,
+    funcs = funcs,
+    meths = meths,
+    bufmeths = bufmeths,
+    winmeths = winmeths,
+    tabmeths = tabmeths,
+    curbufmeths = curbufmeths,
+    curwinmeths = curwinmeths,
+    curtabmeths = curtabmeths,
+    NIL = mpack.NIL,
+  }
+end

--- a/test/functional/job/job_spec.lua
+++ b/test/functional/job/job_spec.lua
@@ -1,5 +1,5 @@
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, eq, eval, execute, feed, insert, neq, next_msg, nvim,
   nvim_dir, ok, source, write_file, mkdir, rmdir = helpers.clear,
   helpers.eq, helpers.eval, helpers.execute, helpers.feed,

--- a/test/functional/legacy/002_filename_recognition_spec.lua
+++ b/test/functional/legacy/002_filename_recognition_spec.lua
@@ -1,7 +1,7 @@
 -- Test if URLs are recognized as filenames by commands such as "gf". Here
 -- we'll use `expand("<cfile>")` since "gf" would need to open the file.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/003_cindent_spec.lua
+++ b/test/functional/legacy/003_cindent_spec.lua
@@ -3,7 +3,7 @@
 -- There are 50+ test command blocks (the stuff between STARTTEST and ENDTEST)
 -- in the original test. These have been converted to "it" test cases here.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/004_bufenter_with_modelines_spec.lua
+++ b/test/functional/legacy/004_bufenter_with_modelines_spec.lua
@@ -2,7 +2,7 @@
 -- Test for autocommand that changes current buffer on BufEnter event.
 -- Check if modelines are interpreted for the correct buffer.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/005_bufleave_delete_buffer_spec.lua
+++ b/test/functional/legacy/005_bufleave_delete_buffer_spec.lua
@@ -1,7 +1,7 @@
 -- Test for autocommand that deletes the current buffer on BufLeave event.
 -- Also test deleting the last buffer, should give a new, empty buffer.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/006_argument_list_spec.lua
+++ b/test/functional/legacy/006_argument_list_spec.lua
@@ -1,6 +1,6 @@
 -- Test for autocommand that redefines the argument list, when doing ":all".
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, dedent, eq = helpers.execute, helpers.dedent, helpers.eq
 local curbuf_contents = helpers.curbuf_contents

--- a/test/functional/legacy/007_ball_buffer_list_spec.lua
+++ b/test/functional/legacy/007_ball_buffer_list_spec.lua
@@ -1,6 +1,6 @@
 -- Test for autocommand that changes the buffer list, when doing ":ball".
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/009_bufleave_autocommand_spec.lua
+++ b/test/functional/legacy/009_bufleave_autocommand_spec.lua
@@ -1,6 +1,6 @@
 -- Test for Bufleave autocommand that deletes the buffer we are about to edit.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, insert = helpers.clear, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/010_errorformat_spec.lua
+++ b/test/functional/legacy/010_errorformat_spec.lua
@@ -1,7 +1,7 @@
 -- Test for 'errorformat'.  This will fail if the quickfix feature was
 -- disabled.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, clear, execute = helpers.feed, helpers.clear, helpers.execute
 local expect, write_file = helpers.expect, helpers.write_file
 

--- a/test/functional/legacy/011_autocommands_spec.lua
+++ b/test/functional/legacy/011_autocommands_spec.lua
@@ -12,7 +12,8 @@
 -- Use a FileChangedShell autocommand to avoid a prompt for "Xtestfile.gz"
 -- being modified outside of Vim (noticed on Solaris).
 
-local helpers, lfs = require('test.functional.helpers'), require('lfs')
+local helpers= require('test.functional.helpers')(after_each)
+local lfs = require('lfs')
 local clear, execute, expect, eq, neq, dedent, write_file, feed =
   helpers.clear, helpers.execute, helpers.expect, helpers.eq, helpers.neq,
   helpers.dedent, helpers.write_file, helpers.feed

--- a/test/functional/legacy/015_alignment_spec.lua
+++ b/test/functional/legacy/015_alignment_spec.lua
@@ -2,7 +2,7 @@
 -- Also test formatting a paragraph.
 -- Also test undo after ":%s" and formatting.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/018_unset_smart_indenting_spec.lua
+++ b/test/functional/legacy/018_unset_smart_indenting_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for not doing smart indenting when it isn't set.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/019_smarttab_expandtab_spec.lua
+++ b/test/functional/legacy/019_smarttab_expandtab_spec.lua
@@ -1,7 +1,7 @@
 -- Tests for "r<Tab>" with 'smarttab' and 'expandtab' set/not set.
 -- Also test that dv_ works correctly
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/020_blockwise_visual_spec.lua
+++ b/test/functional/legacy/020_blockwise_visual_spec.lua
@@ -3,7 +3,7 @@
 -- First test for undo working properly when executing commands from a register.
 -- Also test this in an empty buffer.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/021_control_wi_spec.lua
+++ b/test/functional/legacy/021_control_wi_spec.lua
@@ -1,7 +1,7 @@
 -- vim: set foldmethod=marker foldmarker=[[,]] :
 -- Tests for [ CTRL-I with a count and CTRL-W CTRL-I with a count
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/022_line_ending_spec.lua
+++ b/test/functional/legacy/022_line_ending_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for file with some lines ending in CTRL-M, some not
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed = helpers.clear, helpers.feed
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/023_edit_arguments_spec.lua
+++ b/test/functional/legacy/023_edit_arguments_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for complicated + argument to :edit command
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, insert = helpers.clear, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/025_jump_tag_hidden_spec.lua
+++ b/test/functional/legacy/025_jump_tag_hidden_spec.lua
@@ -1,7 +1,7 @@
 -- Test for jumping to a tag with 'hidden' set, with symbolic link in path of tag.
 -- This only works for Unix, because of the symbolic link.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/026_execute_while_if_spec.lua
+++ b/test/functional/legacy/026_execute_while_if_spec.lua
@@ -1,6 +1,6 @@
 -- Test for :execute, :while and :if
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local execute, expect = helpers.execute, helpers.expect
 local source = helpers.source

--- a/test/functional/legacy/028_source_ctrl_v_spec.lua
+++ b/test/functional/legacy/028_source_ctrl_v_spec.lua
@@ -1,6 +1,6 @@
 -- Test for sourcing a file with CTRL-V's at the end of the line
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/029_join_spec.lua
+++ b/test/functional/legacy/029_join_spec.lua
@@ -1,6 +1,6 @@
 -- Test for joining lines with marks in them (and with 'joinspaces' set/reset)
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/031_close_commands_spec.lua
+++ b/test/functional/legacy/031_close_commands_spec.lua
@@ -9,9 +9,14 @@
 -- :buf
 -- :edit
 
-local helpers = require('test.functional.helpers')
-local feed, insert, source = helpers.feed, helpers.insert, helpers.source
-local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
+local helpers = require('test.functional.helpers')(after_each)
+
+local feed = helpers.feed
+local clear = helpers.clear
+local source = helpers.source
+local insert = helpers.insert
+local expect = helpers.expect
+local execute = helpers.execute
 
 describe('Commands that close windows and/or buffers', function()
   setup(clear)

--- a/test/functional/legacy/033_lisp_indent_spec.lua
+++ b/test/functional/legacy/033_lisp_indent_spec.lua
@@ -2,7 +2,7 @@
 -- Test for 'lisp'
 -- If the lisp feature is not enabled, this will fail!
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/034_user_function_spec.lua
+++ b/test/functional/legacy/034_user_function_spec.lua
@@ -3,7 +3,7 @@
 -- Also test that a builtin function cannot be replaced.
 -- Also test for regression when calling arbitrary expression.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/035_increment_and_decrement_spec.lua
+++ b/test/functional/legacy/035_increment_and_decrement_spec.lua
@@ -1,7 +1,7 @@
 -- Test Ctrl-A and Ctrl-X, which increment and decrement decimal, hexadecimal,
 -- and octal numbers.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/036_regexp_character_classes_spec.lua
+++ b/test/functional/legacy/036_regexp_character_classes_spec.lua
@@ -1,6 +1,6 @@
 -- Test character classes in regexp using regexpengine 0, 1, 2.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 local source, write_file = helpers.source, helpers.write_file
 local os_name = helpers.os_name

--- a/test/functional/legacy/038_virtual_replace_spec.lua
+++ b/test/functional/legacy/038_virtual_replace_spec.lua
@@ -1,6 +1,6 @@
 -- Test Virtual replace mode.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed = helpers.feed
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/039_visual_block_mode_commands_spec.lua
+++ b/test/functional/legacy/039_visual_block_mode_commands_spec.lua
@@ -1,7 +1,7 @@
 -- Test Visual block mode commands
 -- And test "U" in Visual mode, also on German sharp S.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local nvim, eq = helpers.meths, helpers.eq
 local insert, feed = helpers.insert, helpers.feed
 local clear, expect = helpers.clear, helpers.expect

--- a/test/functional/legacy/041_writing_and_reading_hundred_kbyte_spec.lua
+++ b/test/functional/legacy/041_writing_and_reading_hundred_kbyte_spec.lua
@@ -1,6 +1,6 @@
 -- Test for writing and reading a file of over 100 Kbyte
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/043_magic_settings_spec.lua
+++ b/test/functional/legacy/043_magic_settings_spec.lua
@@ -1,7 +1,7 @@
 -- vim: set foldmethod=marker foldmarker=[[,]] :
 -- Tests for regexp with various magic settings.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/044_099_regexp_multibyte_magic_spec.lua
+++ b/test/functional/legacy/044_099_regexp_multibyte_magic_spec.lua
@@ -3,7 +3,7 @@
 --
 -- This test contains both "test44" and "test99" from the old test suite.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/045_folding_spec.lua
+++ b/test/functional/legacy/045_folding_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for folding.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, clear, execute, expect =
   helpers.feed, helpers.insert, helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/046_multi_line_regexps_spec.lua
+++ b/test/functional/legacy/046_multi_line_regexps_spec.lua
@@ -1,7 +1,7 @@
 -- vim: set foldmethod=marker foldmarker=[[,]] :
 -- Tests for multi-line regexps with ":s"
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local expect = helpers.expect
 

--- a/test/functional/legacy/051_highlight_spec.lua
+++ b/test/functional/legacy/051_highlight_spec.lua
@@ -2,7 +2,7 @@
 -- Tests for ":highlight".
 
 local Screen = require('test.functional.ui.screen')
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed = helpers.clear, helpers.feed
 local execute, expect = helpers.execute, helpers.expect
 local wait = helpers.wait

--- a/test/functional/legacy/054_buffer_local_autocommands_spec.lua
+++ b/test/functional/legacy/054_buffer_local_autocommands_spec.lua
@@ -1,6 +1,6 @@
 -- Some tests for buffer-local autocommands
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute, eq = helpers.clear, helpers.execute, helpers.eq
 local curbuf_contents = helpers.curbuf_contents
 

--- a/test/functional/legacy/055_list_and_dict_types_spec.lua
+++ b/test/functional/legacy/055_list_and_dict_types_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for List and Dictionary types.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, source = helpers.feed, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/056_script_local_function_spec.lua
+++ b/test/functional/legacy/056_script_local_function_spec.lua
@@ -1,7 +1,7 @@
 -- vim: set foldmethod=marker foldmarker=[[,]] :
 -- Test for script-local function.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local expect = helpers.expect
 

--- a/test/functional/legacy/057_sort_spec.lua
+++ b/test/functional/legacy/057_sort_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for :sort command.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local insert, execute, clear, expect, eq, eval, source = helpers.insert,
   helpers.execute, helpers.clear, helpers.expect, helpers.eq, helpers.eval,
   helpers.source

--- a/test/functional/legacy/059_utf8_spell_checking_spec.lua
+++ b/test/functional/legacy/059_utf8_spell_checking_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for spell checking with 'encoding' set to "utf-8".
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 local write_file, call = helpers.write_file, helpers.call

--- a/test/functional/legacy/060_exists_and_has_functions_spec.lua
+++ b/test/functional/legacy/060_exists_and_has_functions_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for the exists() and has() functions.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local source = helpers.source
 local clear, expect = helpers.clear, helpers.expect
 local write_file = helpers.write_file

--- a/test/functional/legacy/061_undo_tree_spec.lua
+++ b/test/functional/legacy/061_undo_tree_spec.lua
@@ -1,9 +1,15 @@
 -- Tests for undo tree and :earlier and :later.
+local helpers = require('test.functional.helpers')(after_each)
 
-local helpers = require('test.functional.helpers')
-local expect, feed, source = helpers.expect, helpers.feed, helpers.source
-local eval, clear, execute = helpers.eval, helpers.clear, helpers.execute
-local write_file, command, eq = helpers.write_file, helpers.command, helpers.eq
+local write_file = helpers.write_file
+local execute = helpers.execute
+local command = helpers.command
+local source = helpers.source
+local expect = helpers.expect
+local clear = helpers.clear
+local feed = helpers.feed
+local eval = helpers.eval
+local eq = helpers.eq
 
 local function expect_empty_buffer()
   -- The space will be removed by helpers.dedent but is needed because dedent

--- a/test/functional/legacy/062_tab_pages_spec.lua
+++ b/test/functional/legacy/062_tab_pages_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for tab pages
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, source, clear, execute, expect, eval, eq =
   helpers.feed, helpers.insert, helpers.source, helpers.clear,
   helpers.execute, helpers.expect, helpers.eval, helpers.eq

--- a/test/functional/legacy/063_match_and_matchadd_spec.lua
+++ b/test/functional/legacy/063_match_and_matchadd_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for adjusting window and contents
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local feed, insert = helpers.feed, helpers.insert
 local eval, clear, execute = helpers.eval, helpers.clear, helpers.execute

--- a/test/functional/legacy/065_float_and_logic_operators_spec.lua
+++ b/test/functional/legacy/065_float_and_logic_operators_spec.lua
@@ -1,6 +1,6 @@
 -- Test for floating point and logical operators.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local insert, source = helpers.insert, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/066_visual_block_tab_spec.lua
+++ b/test/functional/legacy/066_visual_block_tab_spec.lua
@@ -1,7 +1,7 @@
 -- vim: set foldmethod=marker foldmarker=[[,]] :
 -- Test for visual block shift and tab characters.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/067_augroup_exists_spec.lua
+++ b/test/functional/legacy/067_augroup_exists_spec.lua
@@ -1,7 +1,7 @@
 -- Test that groups and patterns are tested correctly when calling exists() for
 -- autocommands.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/068_text_formatting_spec.lua
+++ b/test/functional/legacy/068_text_formatting_spec.lua
@@ -1,6 +1,10 @@
-local helpers = require('test.functional.helpers')
-local feed, insert = helpers.feed, helpers.insert
-local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
+local helpers = require('test.functional.helpers')(after_each)
+
+local feed = helpers.feed
+local clear = helpers.clear
+local insert = helpers.insert
+local execute = helpers.execute
+local expect = helpers.expect
 
 describe('text formatting', function()
   setup(clear)

--- a/test/functional/legacy/072_undo_file_spec.lua
+++ b/test/functional/legacy/072_undo_file_spec.lua
@@ -2,7 +2,7 @@
 -- Since this script is sourced we need to explicitly break changes up in
 -- undo-able pieces.  Do that by setting 'undolevels'.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/074_global_var_in_viminfo_spec.lua
+++ b/test/functional/legacy/074_global_var_in_viminfo_spec.lua
@@ -1,6 +1,7 @@
 -- Tests for storing global variables in the .shada file
 
-local helpers, lfs = require('test.functional.helpers'), require('lfs')
+local helpers = require('test.functional.helpers')(after_each)
+local lfs = require('lfs')
 local clear, execute, eq, neq, eval, wait, spawn =
   helpers.clear, helpers.execute, helpers.eq, helpers.neq, helpers.eval,
   helpers.wait, helpers.spawn

--- a/test/functional/legacy/075_maparg_spec.lua
+++ b/test/functional/legacy/075_maparg_spec.lua
@@ -1,7 +1,7 @@
 -- Tests for maparg().
 -- Also test utf8 map with a 0x80 byte.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed = helpers.clear, helpers.feed
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/076_completefunc_spec.lua
+++ b/test/functional/legacy/076_completefunc_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for completefunc/omnifunc.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, expect, execute = helpers.clear, helpers.expect, helpers.execute
 

--- a/test/functional/legacy/077_mf_hash_grow_spec.lua
+++ b/test/functional/legacy/077_mf_hash_grow_spec.lua
@@ -6,7 +6,7 @@
 -- cksum is part of POSIX and so should be available on most Unixes.
 -- If it isn't available then the test will be skipped.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed = helpers.feed
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/078_swapfile_recover_spec.lua
+++ b/test/functional/legacy/078_swapfile_recover_spec.lua
@@ -3,7 +3,7 @@
 -- restored. We need about 10000 lines of 100 characters to get two levels of
 -- pointer blocks.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, expect, source = helpers.clear, helpers.expect, helpers.source
 
 describe('78', function()

--- a/test/functional/legacy/080_substitute_spec.lua
+++ b/test/functional/legacy/080_substitute_spec.lua
@@ -2,7 +2,7 @@
 -- Test for submatch() on substitue().
 -- Test for *:s%* on :substitute.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 local eq, eval = helpers.eq, helpers.eval

--- a/test/functional/legacy/081_coptions_movement_spec.lua
+++ b/test/functional/legacy/081_coptions_movement_spec.lua
@@ -1,6 +1,6 @@
 -- Test for t movement command and 'cpo-;' setting
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/082_string_comparison_spec.lua
+++ b/test/functional/legacy/082_string_comparison_spec.lua
@@ -1,7 +1,7 @@
 -- Tests for case-insensitive UTF-8 comparisons (utf_strnicmp() in mbyte.c)
 -- Also test "g~ap".
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, source = helpers.feed, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/083_tag_search_with_file_encoding_spec.lua
+++ b/test/functional/legacy/083_tag_search_with_file_encoding_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for tag search with !_TAG_FILE_ENCODING.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local insert, source, clear, expect, write_file = helpers.insert,
   helpers.source, helpers.clear, helpers.expect, helpers.write_file
 

--- a/test/functional/legacy/084_curswant_spec.lua
+++ b/test/functional/legacy/084_curswant_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for curswant not changing when setting an option.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local insert, source = helpers.insert, helpers.source
 local clear, expect = helpers.clear, helpers.expect
 

--- a/test/functional/legacy/088_conceal_tabs_spec.lua
+++ b/test/functional/legacy/088_conceal_tabs_spec.lua
@@ -1,7 +1,7 @@
 -- Tests for correct display (cursor column position) with +conceal and
 -- tabulators.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, clear, execute =
   helpers.feed, helpers.insert, helpers.clear, helpers.execute
 

--- a/test/functional/legacy/089_number_relnumber_findfile_spec.lua
+++ b/test/functional/legacy/089_number_relnumber_findfile_spec.lua
@@ -2,7 +2,7 @@
 --   This is not all that useful now that the options are no longer reset when
 --   setting the other.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed = helpers.feed
 local clear, expect, source = helpers.clear, helpers.expect, helpers.source
 

--- a/test/functional/legacy/090_sha256_spec.lua
+++ b/test/functional/legacy/090_sha256_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for sha256() function.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local insert, source = helpers.insert, helpers.source
 local clear, expect = helpers.clear, helpers.expect
 

--- a/test/functional/legacy/091_context_variables_spec.lua
+++ b/test/functional/legacy/091_context_variables_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for getbufvar(), getwinvar(), gettabvar() and gettabwinvar().
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local insert, source = helpers.insert, helpers.source
 local clear, expect = helpers.clear, helpers.expect
 

--- a/test/functional/legacy/092_mksession_cursor_cols_utf8_spec.lua
+++ b/test/functional/legacy/092_mksession_cursor_cols_utf8_spec.lua
@@ -3,7 +3,7 @@
 --
 -- Same as legacy test 93 but using UTF-8 file encoding.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/093_mksession_cursor_cols_latin1_spec.lua
+++ b/test/functional/legacy/093_mksession_cursor_cols_latin1_spec.lua
@@ -3,7 +3,7 @@
 --
 -- Same as legacy test 92 but using Latin-1 file encoding.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/094_visual_mode_operators_spec.lua
+++ b/test/functional/legacy/094_visual_mode_operators_spec.lua
@@ -4,7 +4,7 @@
 -- followed by an operator and those executed via Operator-pending mode. Also
 -- part of the test are mappings, counts, and repetition with the . command.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/095_regexp_multibyte_spec.lua
+++ b/test/functional/legacy/095_regexp_multibyte_spec.lua
@@ -3,7 +3,7 @@
 -- A pattern that gives the expected result produces OK, so that we know it was
 -- actually tried.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local insert, source = helpers.insert, helpers.source
 local clear, expect = helpers.clear, helpers.expect
 

--- a/test/functional/legacy/096_location_list_spec.lua
+++ b/test/functional/legacy/096_location_list_spec.lua
@@ -6,7 +6,7 @@
 -- C. make sure that the location list window is not reused instead of the window
 --    it belongs to.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local source = helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/097_glob_path_spec.lua
+++ b/test/functional/legacy/097_glob_path_spec.lua
@@ -2,7 +2,7 @@
 -- Test whether glob()/globpath() return correct results with certain escaped
 -- characters.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/098_scrollbind_spec.lua
+++ b/test/functional/legacy/098_scrollbind_spec.lua
@@ -1,6 +1,6 @@
 -- Test for 'scrollbind' causing an unexpected scroll of one of the windows.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local source = helpers.source
 local clear, expect = helpers.clear, helpers.expect
 

--- a/test/functional/legacy/101_hlsearch_spec.lua
+++ b/test/functional/legacy/101_hlsearch_spec.lua
@@ -1,6 +1,6 @@
 -- Test for v:hlsearch
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed = helpers.clear, helpers.feed
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/102_fnameescape_spec.lua
+++ b/test/functional/legacy/102_fnameescape_spec.lua
@@ -1,6 +1,6 @@
 -- Test if fnameescape is correct for special chars like!
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/103_visual_mode_reset_spec.lua
+++ b/test/functional/legacy/103_visual_mode_reset_spec.lua
@@ -1,6 +1,6 @@
 -- Test for visual mode not being reset causing E315 error.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, source = helpers.feed, helpers.source
 local clear, expect = helpers.clear, helpers.expect
 

--- a/test/functional/legacy/104_let_assignment_spec.lua
+++ b/test/functional/legacy/104_let_assignment_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for :let.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, source = helpers.clear, helpers.source
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/106_errorformat_spec.lua
+++ b/test/functional/legacy/106_errorformat_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for errorformat.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/107_adjust_window_and_contents_spec.lua
+++ b/test/functional/legacy/107_adjust_window_and_contents_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for adjusting window and contents
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local insert = helpers.insert
 local clear, execute = helpers.clear, helpers.execute

--- a/test/functional/legacy/108_backtrace_debug_commands_spec.lua
+++ b/test/functional/legacy/108_backtrace_debug_commands_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for backtrace debug commands.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, clear = helpers.feed, helpers.clear
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/arglist_spec.lua
+++ b/test/functional/legacy/arglist_spec.lua
@@ -1,6 +1,6 @@
 -- Test argument list commands
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute, eq = helpers.clear, helpers.execute, helpers.eq
 local eval, exc_exec, neq = helpers.eval, helpers.exc_exec, helpers.neq
 

--- a/test/functional/legacy/assert_spec.lua
+++ b/test/functional/legacy/assert_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local nvim, call = helpers.meths, helpers.call
 local clear, eq = helpers.clear, helpers.eq
 local source, execute = helpers.source, helpers.execute

--- a/test/functional/legacy/autocmd_option_spec.lua
+++ b/test/functional/legacy/autocmd_option_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local nvim = helpers.meths
 local clear, eq, neq = helpers.clear, helpers.eq, helpers.neq
 local curbuf, buf = helpers.curbuf, helpers.bufmeths

--- a/test/functional/legacy/autoformat_join_spec.lua
+++ b/test/functional/legacy/autoformat_join_spec.lua
@@ -1,7 +1,7 @@
 -- vim: set foldmethod=marker foldmarker=[[,]] :
 -- Tests for setting the '[,'] marks when joining lines.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/backspace_opt_spec.lua
+++ b/test/functional/legacy/backspace_opt_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local call, clear = helpers.call, helpers.clear
 local source, eq, nvim = helpers.source, helpers.eq, helpers.meths
 

--- a/test/functional/legacy/breakindent_spec.lua
+++ b/test/functional/legacy/breakindent_spec.lua
@@ -1,6 +1,6 @@
 -- Test for breakindent
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/cdo_spec.lua
+++ b/test/functional/legacy/cdo_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for the :cdo, :cfdo, :ldo and :lfdo commands
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local nvim, clear = helpers.meths, helpers.clear
 local call, feed = helpers.call, helpers.feed
 local source, eq = helpers.source, helpers.eq

--- a/test/functional/legacy/changelist_spec.lua
+++ b/test/functional/legacy/changelist_spec.lua
@@ -1,7 +1,7 @@
 -- Test changelist position after splitting window
 -- Set 'undolevels' to make changelist for sourced file
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/charsearch_spec.lua
+++ b/test/functional/legacy/charsearch_spec.lua
@@ -1,6 +1,6 @@
 -- Test for character searches
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/close_count_spec.lua
+++ b/test/functional/legacy/close_count_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for :[count]close! and :[count]hide
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, eval, eq, clear, execute =
   helpers.feed, helpers.eval, helpers.eq, helpers.clear, helpers.execute
 

--- a/test/functional/legacy/command_count_spec.lua
+++ b/test/functional/legacy/command_count_spec.lua
@@ -1,6 +1,6 @@
 -- Test for user command counts
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, source, expect = helpers.clear, helpers.source, helpers.expect
 local execute, spawn = helpers.execute, helpers.spawn
 local nvim_prog = helpers.nvim_prog

--- a/test/functional/legacy/comparators_spec.lua
+++ b/test/functional/legacy/comparators_spec.lua
@@ -1,6 +1,6 @@
 -- " Test for expression comparators.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, eq = helpers.clear, helpers.eq
 local eval, execute = helpers.eval, helpers.execute
 

--- a/test/functional/legacy/delete_spec.lua
+++ b/test/functional/legacy/delete_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, source = helpers.clear, helpers.source
 local eq, eval, execute = helpers.eq, helpers.eval, helpers.execute
 

--- a/test/functional/legacy/erasebackword_spec.lua
+++ b/test/functional/legacy/erasebackword_spec.lua
@@ -1,6 +1,6 @@
 -- Test for CTRL-W in Insert mode
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, expect = helpers.clear, helpers.feed, helpers.expect
 
 describe('CTRL-W in Insert mode', function()

--- a/test/functional/legacy/eval_spec.lua
+++ b/test/functional/legacy/eval_spec.lua
@@ -1,6 +1,6 @@
 -- Test for various eval features.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 local eq, eval, write_file = helpers.eq, helpers.eval, helpers.write_file

--- a/test/functional/legacy/expand_spec.lua
+++ b/test/functional/legacy/expand_spec.lua
@@ -1,6 +1,6 @@
 -- Test for expanding file names
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local eq = helpers.eq
 local call = helpers.call
 local nvim = helpers.meths

--- a/test/functional/legacy/file_perm_spec.lua
+++ b/test/functional/legacy/file_perm_spec.lua
@@ -1,7 +1,7 @@
 -- Test getting and setting file permissions.
 require('os')
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, call, eq = helpers.clear, helpers.call, helpers.eq
 local neq, exc_exec = helpers.neq, helpers.exc_exec
 

--- a/test/functional/legacy/fixeol_spec.lua
+++ b/test/functional/legacy/fixeol_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for 'fixeol'
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed = helpers.feed
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/fnamemodify_spec.lua
+++ b/test/functional/legacy/fnamemodify_spec.lua
@@ -1,6 +1,6 @@
 -- Test filename modifiers.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, source = helpers.clear, helpers.source
 local call, eq, nvim = helpers.call, helpers.eq, helpers.meths
 

--- a/test/functional/legacy/function_sort_spec.lua
+++ b/test/functional/legacy/function_sort_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local eq = helpers.eq
 local eval = helpers.eval

--- a/test/functional/legacy/glob2regpat_spec.lua
+++ b/test/functional/legacy/glob2regpat_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for signs
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute = helpers.clear, helpers.execute
 local eq, neq, eval = helpers.eq, helpers.neq, helpers.eval
 

--- a/test/functional/legacy/increment_spec.lua
+++ b/test/functional/legacy/increment_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for using Ctrl-A/Ctrl-X on visual selections
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local source, execute = helpers.source, helpers.execute
 local call, clear = helpers.call, helpers.clear
 local eq, nvim = helpers.eq, helpers.meths

--- a/test/functional/legacy/insertcount_spec.lua
+++ b/test/functional/legacy/insertcount_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for repeating insert and replace.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 

--- a/test/functional/legacy/join_spec.lua
+++ b/test/functional/legacy/join_spec.lua
@@ -1,6 +1,6 @@
 -- Test for joining lines
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, eq = helpers.clear, helpers.eq
 local eval, execute = helpers.eval, helpers.execute
 

--- a/test/functional/legacy/lispwords_spec.lua
+++ b/test/functional/legacy/lispwords_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local eq = helpers.eq
 local eval = helpers.eval

--- a/test/functional/legacy/listchars_spec.lua
+++ b/test/functional/legacy/listchars_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for 'listchars' display with 'list' and :list.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/listlbr_spec.lua
+++ b/test/functional/legacy/listlbr_spec.lua
@@ -1,6 +1,6 @@
 -- Test for linebreak and list option (non-utf8)
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/listlbr_utf8_spec.lua
+++ b/test/functional/legacy/listlbr_utf8_spec.lua
@@ -1,6 +1,6 @@
 -- Test for linebreak and list option in utf-8 mode
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local source = helpers.source
 local feed = helpers.feed
 local clear, expect = helpers.clear, helpers.expect

--- a/test/functional/legacy/mapping_spec.lua
+++ b/test/functional/legacy/mapping_spec.lua
@@ -1,6 +1,6 @@
 -- Test for mappings and abbreviations
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect, wait = helpers.execute, helpers.expect, helpers.wait
 

--- a/test/functional/legacy/marks_spec.lua
+++ b/test/functional/legacy/marks_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/match_conceal_spec.lua
+++ b/test/functional/legacy/match_conceal_spec.lua
@@ -1,6 +1,6 @@
 -- Test for matchadd() and conceal feature
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local expect = helpers.expect
 local source = helpers.source

--- a/test/functional/legacy/nested_function_spec.lua
+++ b/test/functional/legacy/nested_function_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for nested function.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, insert = helpers.clear, helpers.insert
 local execute, expect, source = helpers.execute, helpers.expect, helpers.source
 

--- a/test/functional/legacy/options_spec.lua
+++ b/test/functional/legacy/options_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local command, clear = helpers.command, helpers.clear
 local source, expect = helpers.source, helpers.expect
 

--- a/test/functional/legacy/qf_title_spec.lua
+++ b/test/functional/legacy/qf_title_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for quickfix window's title
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local insert, source = helpers.insert, helpers.source
 local clear, expect = helpers.clear, helpers.expect
 

--- a/test/functional/legacy/quickfix_spec.lua
+++ b/test/functional/legacy/quickfix_spec.lua
@@ -1,6 +1,6 @@
 -- Test for the quickfix commands.
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local source, clear = helpers.source, helpers.clear
 local eq, nvim, call = helpers.eq, helpers.meths, helpers.call
 local eval = helpers.eval

--- a/test/functional/legacy/search_mbyte_spec.lua
+++ b/test/functional/legacy/search_mbyte_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local insert = helpers.insert
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 

--- a/test/functional/legacy/searchpos_spec.lua
+++ b/test/functional/legacy/searchpos_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local call = helpers.call
 local clear = helpers.clear
 local execute = helpers.execute

--- a/test/functional/legacy/set_spec.lua
+++ b/test/functional/legacy/set_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for :set
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute, eval, eq =
   helpers.clear, helpers.execute, helpers.eval, helpers.eq
 

--- a/test/functional/legacy/signs_spec.lua
+++ b/test/functional/legacy/signs_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for signs
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 
 describe('signs', function()

--- a/test/functional/legacy/tagcase_spec.lua
+++ b/test/functional/legacy/tagcase_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local eq = helpers.eq
 local eval = helpers.eval

--- a/test/functional/legacy/textobjects_spec.lua
+++ b/test/functional/legacy/textobjects_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local call = helpers.call
 local clear = helpers.clear
 local execute = helpers.execute

--- a/test/functional/legacy/undolevels_spec.lua
+++ b/test/functional/legacy/undolevels_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local source, clear = helpers.source, helpers.clear
 local eq, nvim = helpers.eq, helpers.meths
 

--- a/test/functional/legacy/utf8_spec.lua
+++ b/test/functional/legacy/utf8_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for Unicode manipulations
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect = helpers.execute, helpers.expect
 local eq, eval = helpers.eq, helpers.eval

--- a/test/functional/legacy/wordcount_spec.lua
+++ b/test/functional/legacy/wordcount_spec.lua
@@ -1,6 +1,6 @@
 -- Test for wordcount() function
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, execute = helpers.clear, helpers.execute
 local eq, eval = helpers.eq, helpers.eval

--- a/test/functional/legacy/writefile_spec.lua
+++ b/test/functional/legacy/writefile_spec.lua
@@ -1,6 +1,6 @@
 -- Tests for writefile()
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute, expect = helpers.clear, helpers.execute, helpers.expect
 
 describe('writefile', function()

--- a/test/functional/normal/K_spec.lua
+++ b/test/functional/normal/K_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local eq, clear, eval, feed =
   helpers.eq, helpers.clear, helpers.eval, helpers.feed
 

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, eval, eq  = helpers.clear, helpers.eval, helpers.eq
 local execute = helpers.execute

--- a/test/functional/options/shortmess_spec.lua
+++ b/test/functional/options/shortmess_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, execute = helpers.clear, helpers.execute
 

--- a/test/functional/plugin/helpers.lua
+++ b/test/functional/plugin/helpers.lua
@@ -1,6 +1,6 @@
 local paths = require('test.config.paths')
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(nil)
 local spawn, set_session, nvim_prog, merge_args =
   helpers.spawn, helpers.set_session, helpers.nvim_prog, helpers.merge_args
 

--- a/test/functional/plugin/matchparen_spec.lua
+++ b/test/functional/plugin/matchparen_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, execute = helpers.clear, helpers.feed, helpers.execute
 

--- a/test/functional/plugin/msgpack_spec.lua
+++ b/test/functional/plugin/msgpack_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local meths = helpers.meths
 local eq, nvim_eval, nvim_command, exc_exec =
   helpers.eq, helpers.eval, helpers.command, helpers.exc_exec

--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local eq, nvim_eval, nvim_command, nvim, exc_exec, funcs, nvim_feed, curbuf =
   helpers.eq, helpers.eval, helpers.command, helpers.nvim, helpers.exc_exec,
   helpers.funcs, helpers.feed, helpers.curbuf

--- a/test/functional/preload.lua
+++ b/test/functional/preload.lua
@@ -1,4 +1,4 @@
 -- Modules loaded here will not be cleared and reloaded by Busted.
 -- Busted started doing this to help provide more isolation.  See issue #62
 -- for more information about this.
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(nil)

--- a/test/functional/provider/define_spec.lua
+++ b/test/functional/provider/define_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local eval, command, nvim = helpers.eval, helpers.command, helpers.nvim
 local eq, run, stop = helpers.eq, helpers.run, helpers.stop
 local clear = helpers.clear

--- a/test/functional/provider/python3_spec.lua
+++ b/test/functional/provider/python3_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local eval, command, feed = helpers.eval, helpers.command, helpers.feed
 local eq, clear, insert = helpers.eq, helpers.clear, helpers.insert
 local expect, write_file = helpers.expect, helpers.write_file

--- a/test/functional/provider/python_spec.lua
+++ b/test/functional/provider/python_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 
 local eq = helpers.eq
 local neq = helpers.neq

--- a/test/functional/shada/buffers_spec.lua
+++ b/test/functional/shada/buffers_spec.lua
@@ -1,5 +1,5 @@
 -- ShaDa buffer list saving/reading support
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local nvim_command, funcs, eq, curbufmeths =
   helpers.command, helpers.funcs, helpers.eq, helpers.curbufmeths
 

--- a/test/functional/shada/compatibility_spec.lua
+++ b/test/functional/shada/compatibility_spec.lua
@@ -1,5 +1,5 @@
 -- ShaDa compatibility support
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local nvim_command, funcs, eq = helpers.command, helpers.funcs, helpers.eq
 local exc_exec = helpers.exc_exec
 

--- a/test/functional/shada/errors_spec.lua
+++ b/test/functional/shada/errors_spec.lua
@@ -1,5 +1,5 @@
 -- ShaDa errors handling support
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local nvim_command, eq, exc_exec, redir_exec =
   helpers.command, helpers.eq, helpers.exc_exec, helpers.redir_exec
 

--- a/test/functional/shada/helpers.lua
+++ b/test/functional/shada/helpers.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(nil)
 local spawn, set_session, meths, nvim_prog =
   helpers.spawn, helpers.set_session, helpers.meths, helpers.nvim_prog
 local write_file, merge_args = helpers.write_file, helpers.merge_args

--- a/test/functional/shada/history_spec.lua
+++ b/test/functional/shada/history_spec.lua
@@ -1,5 +1,5 @@
 -- ShaDa history saving/reading support
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local nvim_command, funcs, meths, nvim_feed, eq =
   helpers.command, helpers.funcs, helpers.meths, helpers.feed, helpers.eq
 

--- a/test/functional/shada/marks_spec.lua
+++ b/test/functional/shada/marks_spec.lua
@@ -1,5 +1,5 @@
 -- ShaDa marks saving/reading support
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local meths, curwinmeths, curbufmeths, nvim_command, funcs, eq =
   helpers.meths, helpers.curwinmeths, helpers.curbufmeths, helpers.command,
   helpers.funcs, helpers.eq

--- a/test/functional/shada/merging_spec.lua
+++ b/test/functional/shada/merging_spec.lua
@@ -1,5 +1,5 @@
 -- ShaDa merging data support
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local nvim_command, funcs, curbufmeths, eq =
   helpers.command, helpers.funcs,
   helpers.curbufmeths, helpers.eq

--- a/test/functional/shada/registers_spec.lua
+++ b/test/functional/shada/registers_spec.lua
@@ -1,5 +1,5 @@
 -- ShaDa registers saving/reading support
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local nvim_command, funcs, eq = helpers.command, helpers.funcs, helpers.eq
 
 local shada_helpers = require('test.functional.shada.helpers')

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -1,5 +1,5 @@
 -- Other ShaDa tests
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local meths, nvim_command, funcs, eq =
   helpers.meths, helpers.command, helpers.funcs, helpers.eq
 local write_file, spawn, set_session, nvim_prog, exc_exec =

--- a/test/functional/shada/variables_spec.lua
+++ b/test/functional/shada/variables_spec.lua
@@ -1,5 +1,5 @@
 -- ShaDa variables saving/reading support
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local meths, funcs, nvim_command, eq, exc_exec =
   helpers.meths, helpers.funcs, helpers.command, helpers.eq, helpers.exc_exec
 

--- a/test/functional/shell/bang_filter_spec.lua
+++ b/test/functional/shell/bang_filter_spec.lua
@@ -1,6 +1,6 @@
 -- Specs for bang/filter commands
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local feed, execute, clear = helpers.feed, helpers.execute, helpers.clear
 local mkdir, write_file, rmdir = helpers.mkdir, helpers.write_file, helpers.rmdir
 

--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -151,8 +151,8 @@ describe('system()', function()
   describe('with output containing NULs', function()
     local fname = 'Xtest'
 
-    setup(create_file_with_nuls(fname))
-    teardown(delete_file(fname))
+    before_each(create_file_with_nuls(fname))
+    after_each(delete_file(fname))
 
     it('replaces NULs by SOH characters', function()
       eq('part1\001part2\001part3\n', eval('system("cat '..fname..'")'))
@@ -310,8 +310,8 @@ describe('systemlist()', function()
   describe('with output containing NULs', function()
     local fname = 'Xtest'
 
-    setup(create_file_with_nuls(fname))
-    teardown(delete_file(fname))
+    before_each(create_file_with_nuls(fname))
+    after_each(delete_file(fname))
 
     it('replaces NULs by newline characters', function()
       eq({'part1\npart2\npart3'}, eval('systemlist("cat '..fname..'")'))

--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -2,7 +2,7 @@
 -- - `system()`
 -- - `systemlist()`
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local eq, clear, eval, feed, nvim =
   helpers.eq, helpers.clear, helpers.eval, helpers.feed, helpers.nvim
 

--- a/test/functional/terminal/altscreen_spec.lua
+++ b/test/functional/terminal/altscreen_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
 local clear, eq, curbuf = helpers.clear, helpers.eq, helpers.curbuf
 local feed = helpers.feed

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
 local feed, clear, nvim = helpers.feed, helpers.clear, helpers.nvim
 local wait = helpers.wait

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local thelpers = require('test.functional.terminal.helpers')
 local feed, clear, nvim = helpers.feed, helpers.clear, helpers.nvim

--- a/test/functional/terminal/edit_spec.lua
+++ b/test/functional/terminal/edit_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local screen = require('test.functional.ui.screen')
 
 local curbufmeths = helpers.curbufmeths

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, wait, nvim = helpers.clear, helpers.wait, helpers.nvim
 local nvim_dir, source, eq = helpers.nvim_dir, helpers.source, helpers.eq

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(nil)
 local Screen = require('test.functional.ui.screen')
 local nvim_dir = helpers.nvim_dir
 local execute, nvim, wait = helpers.execute, helpers.nvim, helpers.wait

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local thelpers = require('test.functional.terminal.helpers')
 local feed, clear, nvim = helpers.feed, helpers.clear, helpers.nvim

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
 local clear = helpers.clear
 local feed, nvim = helpers.feed, helpers.nvim

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -1,5 +1,5 @@
 local Screen = require('test.functional.ui.screen')
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
 local clear, eq, curbuf = helpers.clear, helpers.eq, helpers.curbuf
 local feed, nvim_dir, execute = helpers.feed, helpers.nvim_dir, helpers.execute

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1,6 +1,6 @@
 -- Some sanity checks for the TUI using the builtin terminal emulator
 -- as a simple way to send keys and assert screen state.
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
 local feed = thelpers.feed_data
 local execute = helpers.execute

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
 local feed, clear = helpers.feed, helpers.clear
 local wait = helpers.wait

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
 local clear = helpers.clear
 local feed, nvim = helpers.feed, helpers.nvim

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, request, neq = helpers.execute, helpers.request, helpers.neq

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local os = require('os')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local clear, execute, nvim = helpers.clear, helpers.execute, helpers.nvim
 local feed, next_message, eq = helpers.feed, helpers.next_message, helpers.eq
 local expect = helpers.expect

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, meths = helpers.clear, helpers.feed, helpers.meths
 local insert, execute = helpers.insert, helpers.execute

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -105,7 +105,7 @@
 -- To generate a text-only test without highlight checks,
 -- use `screen:snapshot_util({},true)`
 
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(nil)
 local request, run = helpers.request, helpers.run
 local dedent = helpers.dedent
 

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local spawn, set_session, clear = helpers.spawn, helpers.set_session, helpers.clear
 local feed, execute = helpers.feed, helpers.execute

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute = helpers.execute

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, execute = helpers.clear, helpers.feed, helpers.execute
 

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, execute = helpers.clear, helpers.feed, helpers.execute
 local insert = helpers.insert

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, execute = helpers.clear, helpers.feed, helpers.execute
 local funcs = helpers.funcs

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed = helpers.clear, helpers.feed
 local eval, eq, neq = helpers.eval, helpers.eq, helpers.neq

--- a/test/functional/viml/errorlist_spec.lua
+++ b/test/functional/viml/errorlist_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 
 local clear = helpers.clear
 local command = helpers.command

--- a/test/functional/viml/function_spec.lua
+++ b/test/functional/viml/function_spec.lua
@@ -1,4 +1,4 @@
-local helpers = require('test.functional.helpers')
+local helpers = require('test.functional.helpers')(after_each)
 
 local clear = helpers.clear
 local eq = helpers.eq

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -1,0 +1,60 @@
+local assert = require('luassert')
+local lfs = require('lfs')
+
+local check_logs_useless_lines = {
+  ['Warning: noted but unhandled ioctl']=1,
+  ['could cause spurious value errors to appear']=2,
+  ['See README_MISSING_SYSCALL_OR_IOCTL for guidance']=3,
+}
+
+local eq = function(exp, act)
+  return assert.are.same(exp, act)
+end
+local neq = function(exp, act)
+  return assert.are_not.same(exp, act)
+end
+local ok = function(res)
+  return assert.is_true(res)
+end
+
+local function check_logs()
+  local log_dir = os.getenv('LOG_DIR')
+  local runtime_errors = 0
+  if log_dir and lfs.attributes(log_dir, 'mode') == 'directory' then
+    for tail in lfs.dir(log_dir) do
+      if tail:sub(1, 30) == 'valgrind-' or tail:find('san%.') then
+        local file = log_dir .. '/' .. tail
+        local fd = io.open(file)
+        local start_msg = ('='):rep(20) .. ' File ' .. file .. ' ' .. ('='):rep(20)
+        local lines = {}
+        local warning_line = 0
+        for line in fd:lines() do
+          local cur_warning_line = check_logs_useless_lines[line]
+          if cur_warning_line == warning_line + 1 then
+            warning_line = cur_warning_line
+          else
+            lines[#lines + 1] = line
+          end
+        end
+        fd:close()
+        os.remove(file)
+        if #lines > 0 then
+          -- local out = os.getenv('TRAVIS_CI_BUILD') and io.stdout or io.stderr
+          local out = io.stdout
+          out:write(start_msg .. '\n')
+          out:write('= ' .. table.concat(lines, '\n= ') .. '\n')
+          out:write(select(1, start_msg:gsub('.', '=')) .. '\n')
+          runtime_errors = runtime_errors + 1
+        end
+      end
+    end
+  end
+  assert(0 == runtime_errors)
+end
+
+return {
+  eq = eq,
+  neq = neq,
+  ok = ok,
+  check_logs = check_logs,
+}

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -1,9 +1,12 @@
-local assert = require('luassert')
 local ffi = require('ffi')
 local formatc = require('test.unit.formatc')
 local Set = require('test.unit.set')
 local Preprocess = require('test.unit.preprocess')
 local Paths = require('test.config.paths')
+local global_helpers = require('test.helpers')
+
+local neq = global_helpers.neq
+local eq = global_helpers.eq
 
 -- add some standard header locations
 for _, p in ipairs(Paths.include_paths) do
@@ -153,12 +156,8 @@ return {
   cimport = cimport,
   cppimport = cppimport,
   internalize = internalize,
-  eq = function(expected, actual)
-    return assert.are.same(expected, actual)
-  end,
-  neq = function(expected, actual)
-    return assert.are_not.same(expected, actual)
-  end,
+  eq = eq,
+  neq = neq,
   ffi = ffi,
   lib = libnvim,
   cstr = cstr,


### PR DESCRIPTION
In the current state sanitizer is less useful then it could be: it tells that there is an error and that it is in specific subsystem, but it is unable to tell which code triggered the error. This adds checking sanitizer errors right after the test. Errors after running all tests are still checked as well just in case.

Note that sanitizer log directory is not cleared before running test, so in some cases it may wrongly attach errors from previous runs to the first test. I do not think this is much of a problem: for me this happened after running Neovim manually.
