### PR TITLE
[RFC] lib/queue: Refactor queue.h

### DIFF
--- a/src/nvim/lib/queue.h
+++ b/src/nvim/lib/queue.h
@@ -1,92 +1,100 @@
-/* Copyright (c) 2013, Ben Noordhuis <info@bnoordhuis.nl>
- *
- * Permission to use, copy, modify, and/or distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
+// Copyright (c) 2013, Ben Noordhuis <info@bnoordhuis.nl>
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-#ifndef QUEUE_H_
-#define QUEUE_H_
+#ifndef NVIM_LIB_QUEUE_H
+#define NVIM_LIB_QUEUE_H
 
-typedef void *QUEUE[2];
+#include <stddef.h>
 
-/* Private macros. */
-#define QUEUE_NEXT(q)       (*(QUEUE **) &((*(q))[0]))
-#define QUEUE_PREV(q)       (*(QUEUE **) &((*(q))[1]))
-#define QUEUE_PREV_NEXT(q)  (QUEUE_NEXT(QUEUE_PREV(q)))
-#define QUEUE_NEXT_PREV(q)  (QUEUE_PREV(QUEUE_NEXT(q)))
+#include "nvim/func_attr.h"
 
-/* Public macros. */
-#define QUEUE_DATA(ptr, type, field)                                          \
-  ((type *) ((char *) (ptr) - ((char *) &((type *) 0)->field)))
+typedef struct _queue {
+  struct _queue *next;
+  struct _queue *prev;
+} QUEUE;
 
-#define QUEUE_FOREACH(q, h)                                                   \
-  for ((q) = QUEUE_NEXT(h); (q) != (h); (q) = QUEUE_NEXT(q))
+// Private macros.
+#define _QUEUE_NEXT(q)       ((q)->next)
+#define _QUEUE_PREV(q)       ((q)->prev)
+#define _QUEUE_PREV_NEXT(q)  (_QUEUE_NEXT(_QUEUE_PREV(q)))
+#define _QUEUE_NEXT_PREV(q)  (_QUEUE_PREV(_QUEUE_NEXT(q)))
 
-#define QUEUE_EMPTY(q)                                                        \
-  ((const QUEUE *) (q) == (const QUEUE *) QUEUE_NEXT(q))
+// Public macros.
+#define QUEUE_DATA(ptr, type, field)  \
+  ((type *)((char *)(ptr) - offsetof(type, field)))
 
-#define QUEUE_HEAD(q)                                                         \
-  (QUEUE_NEXT(q))
+#define QUEUE_FOREACH(q, h) \
+  for (  /* NOLINT(readability/braces) */ \
+      (q) = _QUEUE_NEXT(h); (q) != (h); (q) = _QUEUE_NEXT(q))
 
-#define QUEUE_INIT(q)                                                         \
-  do {                                                                        \
-    QUEUE_NEXT(q) = (q);                                                      \
-    QUEUE_PREV(q) = (q);                                                      \
-  }                                                                           \
-  while (0)
+// ffi.cdef is unable to swallow `bool` in place of `int` here.
+static inline int QUEUE_EMPTY(const QUEUE *const q)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  return q == _QUEUE_NEXT(q);
+}
 
-#define QUEUE_ADD(h, n)                                                       \
-  do {                                                                        \
-    QUEUE_PREV_NEXT(h) = QUEUE_NEXT(n);                                       \
-    QUEUE_NEXT_PREV(n) = QUEUE_PREV(h);                                       \
-    QUEUE_PREV(h) = QUEUE_PREV(n);                                            \
-    QUEUE_PREV_NEXT(h) = (h);                                                 \
-  }                                                                           \
-  while (0)
+#define QUEUE_HEAD _QUEUE_NEXT
 
-#define QUEUE_SPLIT(h, q, n)                                                  \
-  do {                                                                        \
-    QUEUE_PREV(n) = QUEUE_PREV(h);                                            \
-    QUEUE_PREV_NEXT(n) = (n);                                                 \
-    QUEUE_NEXT(n) = (q);                                                      \
-    QUEUE_PREV(h) = QUEUE_PREV(q);                                            \
-    QUEUE_PREV_NEXT(h) = (h);                                                 \
-    QUEUE_PREV(q) = (n);                                                      \
-  }                                                                           \
-  while (0)
+static inline void QUEUE_INIT(QUEUE *const q) FUNC_ATTR_ALWAYS_INLINE
+{
+  _QUEUE_NEXT(q) = q;
+  _QUEUE_PREV(q) = q;
+}
 
-#define QUEUE_INSERT_HEAD(h, q)                                               \
-  do {                                                                        \
-    QUEUE_NEXT(q) = QUEUE_NEXT(h);                                            \
-    QUEUE_PREV(q) = (h);                                                      \
-    QUEUE_NEXT_PREV(q) = (q);                                                 \
-    QUEUE_NEXT(h) = (q);                                                      \
-  }                                                                           \
-  while (0)
+static inline void QUEUE_ADD(QUEUE *const h, QUEUE *const n)
+  FUNC_ATTR_ALWAYS_INLINE
+{
+  _QUEUE_PREV_NEXT(h) = _QUEUE_NEXT(n);
+  _QUEUE_NEXT_PREV(n) = _QUEUE_PREV(h);
+  _QUEUE_PREV(h) = _QUEUE_PREV(n);
+  _QUEUE_PREV_NEXT(h) = h;
+}
 
-#define QUEUE_INSERT_TAIL(h, q)                                               \
-  do {                                                                        \
-    QUEUE_NEXT(q) = (h);                                                      \
-    QUEUE_PREV(q) = QUEUE_PREV(h);                                            \
-    QUEUE_PREV_NEXT(q) = (q);                                                 \
-    QUEUE_PREV(h) = (q);                                                      \
-  }                                                                           \
-  while (0)
+static inline void QUEUE_SPLIT(QUEUE *const h, QUEUE *const q, QUEUE *const n)
+  FUNC_ATTR_ALWAYS_INLINE
+{
+  _QUEUE_PREV(n) = _QUEUE_PREV(h);
+  _QUEUE_PREV_NEXT(n) = n;
+  _QUEUE_NEXT(n) = q;
+  _QUEUE_PREV(h) = _QUEUE_PREV(q);
+  _QUEUE_PREV_NEXT(h) = h;
+  _QUEUE_PREV(q) = n;
+}
 
-#define QUEUE_REMOVE(q)                                                       \
-  do {                                                                        \
-    QUEUE_PREV_NEXT(q) = QUEUE_NEXT(q);                                       \
-    QUEUE_NEXT_PREV(q) = QUEUE_PREV(q);                                       \
-  }                                                                           \
-  while (0)
+static inline void QUEUE_INSERT_HEAD(QUEUE *const h, QUEUE *const q)
+  FUNC_ATTR_ALWAYS_INLINE
+{
+  _QUEUE_NEXT(q) = _QUEUE_NEXT(h);
+  _QUEUE_PREV(q) = h;
+  _QUEUE_NEXT_PREV(q) = q;
+  _QUEUE_NEXT(h) = q;
+}
 
-#endif /* QUEUE_H_ */
+static inline void QUEUE_INSERT_TAIL(QUEUE *const h, QUEUE *const q)
+  FUNC_ATTR_ALWAYS_INLINE
+{
+  _QUEUE_NEXT(q) = h;
+  _QUEUE_PREV(q) = _QUEUE_PREV(h);
+  _QUEUE_PREV_NEXT(q) = q;
+  _QUEUE_PREV(h) = q;
+}
+
+static inline void QUEUE_REMOVE(QUEUE *const q) FUNC_ATTR_ALWAYS_INLINE
+{
+  _QUEUE_PREV_NEXT(q) = _QUEUE_NEXT(q);
+  _QUEUE_NEXT_PREV(q) = _QUEUE_PREV(q);
+}
+
+#endif  // NVIM_LIB_QUEUE_H


### PR DESCRIPTION
Changes:
1. Linter finds no errors now.
2. Most of macros changed to `static inline … FUNC_ATTR_ALWAYS_INLINE` functions
      (that was the purpose: they are easier to debug).
3. Queue is now not a pair of void\* pointers, but a struct with two QUEUE
      pointers, next and prev. This should not affect anything, except that _QUEUE
      private macros can really be avoided without reducing readability and they do
      not need any casts.
