### PR TITLE
[RFC] Rename main loop variable from loop to main_loop

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -961,7 +961,7 @@ static int insert_handle_key(InsertState *s)
     break;
 
   case K_EVENT:       // some event
-    queue_process_events(loop.events);
+    queue_process_events(main_loop.events);
     break;
 
   case K_FOCUSGAINED:  // Neovim has been given focus

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6992,7 +6992,7 @@ void do_sleep(long msec)
   ui_flush();  // flush before waiting
   for (long left = msec; !got_int && left > 0; left -= 1000L) {
     int next = left > 1000l ? 1000 : (int)left;
-    LOOP_PROCESS_EVENTS_UNTIL(&loop, loop.events, (int)next, got_int);
+    LOOP_PROCESS_EVENTS_UNTIL(&main_loop, main_loop.events, (int)next, got_int);
     os_breakcheck();
   }
 }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -358,7 +358,7 @@ static int command_line_execute(VimState *state, int key)
   s->c = key;
 
   if (s->c == K_EVENT) {
-    queue_process_events(loop.events);
+    queue_process_events(main_loop.events);
     redrawcmdline();
     return 1;
   }

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1243,7 +1243,6 @@ EXTERN char *ignoredp;
 
 // If a msgpack-rpc channel should be started over stdin/stdout
 EXTERN bool embedded_mode INIT(= false);
-EXTERN Loop loop;
 
 /// Used to track the status of external functions.
 /// Currently only used for iconv().

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -120,6 +120,8 @@ typedef struct {
 # include "main.c.generated.h"
 #endif
 
+Loop main_loop;
+
 static char *argv0;
 
 // Error messages
@@ -133,7 +135,7 @@ static const char *err_extra_cmd =
 
 void event_init(void)
 {
-  loop_init(&loop, NULL);
+  loop_init(&main_loop, NULL);
   // early msgpack-rpc initialization
   msgpack_rpc_init_method_table();
   msgpack_rpc_helpers_init();
@@ -151,19 +153,19 @@ void event_init(void)
 
 void event_teardown(void)
 {
-  if (!loop.events) {
+  if (!main_loop.events) {
     return;
   }
 
-  queue_process_events(loop.events);
+  queue_process_events(main_loop.events);
   input_stop();
   channel_teardown();
-  process_teardown(&loop);
+  process_teardown(&main_loop);
   server_teardown();
   signal_teardown();
   terminal_teardown();
 
-  loop_close(&loop);
+  loop_close(&main_loop);
 }
 
 /// Performs early initialization.

--- a/src/nvim/main.h
+++ b/src/nvim/main.h
@@ -2,6 +2,9 @@
 #define NVIM_MAIN_H
 
 #include "nvim/normal.h"
+#include "nvim/event/loop.h"
+
+extern Loop main_loop;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "main.h.generated.h"

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -16,6 +16,7 @@
 #include "nvim/event/socket.h"
 #include "nvim/msgpack_rpc/helpers.h"
 #include "nvim/vim.h"
+#include "nvim/main.h"
 #include "nvim/ascii.h"
 #include "nvim/memory.h"
 #include "nvim/os_unix.h"
@@ -119,7 +120,7 @@ void channel_teardown(void)
 uint64_t channel_from_process(char **argv)
 {
   Channel *channel = register_channel(kChannelTypeProc);
-  channel->data.process.uvproc = libuv_process_init(&loop, channel);
+  channel->data.process.uvproc = libuv_process_init(&main_loop, channel);
   Process *proc = &channel->data.process.uvproc.process;
   proc->argv = argv;
   proc->in = &channel->data.process.in;
@@ -127,7 +128,7 @@ uint64_t channel_from_process(char **argv)
   proc->err = &channel->data.process.err;
   proc->cb = process_exit;
   if (!process_spawn(proc)) {
-    loop_poll_events(&loop, 0);
+    loop_poll_events(&main_loop, 0);
     decref(channel);
     return 0;
   }
@@ -220,7 +221,7 @@ Object channel_send_call(uint64_t id,
   ChannelCallFrame frame = {request_id, false, false, NIL};
   kv_push(ChannelCallFrame *, channel->call_stack, &frame);
   channel->pending_requests++;
-  LOOP_PROCESS_EVENTS_UNTIL(&loop, channel->events, -1, frame.returned);
+  LOOP_PROCESS_EVENTS_UNTIL(&main_loop, channel->events, -1, frame.returned);
   (void)kv_pop(channel->call_stack);
   channel->pending_requests--;
 
@@ -316,11 +317,11 @@ void channel_from_stdio(void)
   Channel *channel = register_channel(kChannelTypeStdio);
   incref(channel);  // stdio channels are only closed on exit
   // read stream
-  rstream_init_fd(&loop, &channel->data.std.in, 0, CHANNEL_BUFFER_SIZE,
-      channel);
+  rstream_init_fd(&main_loop, &channel->data.std.in, 0, CHANNEL_BUFFER_SIZE,
+                  channel);
   rstream_start(&channel->data.std.in, parse_msgpack);
   // write stream
-  wstream_init_fd(&loop, &channel->data.std.out, 1, 0, NULL);
+  wstream_init_fd(&main_loop, &channel->data.std.out, 1, 0, NULL);
 }
 
 static void forward_stderr(Stream *stream, RBuffer *rbuf, size_t count,
@@ -647,7 +648,7 @@ static void close_channel(Channel *channel)
     case kChannelTypeStdio:
       stream_close(&channel->data.std.in, NULL);
       stream_close(&channel->data.std.out, NULL);
-      queue_put(loop.fast_events, exit_event, 1, channel);
+      queue_put(main_loop.fast_events, exit_event, 1, channel);
       return;
     default:
       abort();
@@ -692,7 +693,7 @@ static void close_cb(Stream *stream, void *data)
 static Channel *register_channel(ChannelType type)
 {
   Channel *rv = xmalloc(sizeof(Channel));
-  rv->events = queue_new_child(loop.events);
+  rv->events = queue_new_child(main_loop.events);
   rv->type = type;
   rv->refcount = 1;
   rv->closed = false;

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -12,6 +12,7 @@
 #include "nvim/eval.h"
 #include "nvim/garray.h"
 #include "nvim/vim.h"
+#include "nvim/main.h"
 #include "nvim/memory.h"
 #include "nvim/log.h"
 #include "nvim/fileio.h"
@@ -108,7 +109,7 @@ int server_start(const char *endpoint)
   }
 
   SocketWatcher *watcher = xmalloc(sizeof(SocketWatcher));
-  socket_watcher_init(&loop, watcher, endpoint, NULL);
+  socket_watcher_init(&main_loop, watcher, endpoint, NULL);
 
   // Check if a watcher for the endpoint already exists
   for (int i = 0; i < watchers.ga_len; i++) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7879,7 +7879,7 @@ static void nv_event(cmdarg_T *cap)
   // not safe to perform garbage collection because there could be unreferenced
   // lists or dicts being used.
   may_garbage_collect = false;
-  queue_process_events(loop.events);
+  queue_process_events(main_loop.events);
   cap->retval |= CA_COMMAND_BUSY;       // don't call edit() now
 }
 

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -60,7 +60,7 @@ void input_start(int fd)
   }
 
   global_fd = fd;
-  rstream_init_fd(&loop, &read_stream, fd, READ_BUFFER_SIZE, NULL);
+  rstream_init_fd(&main_loop, &read_stream, fd, READ_BUFFER_SIZE, NULL);
   rstream_start(&read_stream, read_cb);
 }
 
@@ -87,8 +87,8 @@ static void create_cursorhold_event(void)
   // have been called(inbuf_poll would return kInputAvail)
   // TODO(tarruda): Cursorhold should be implemented as a timer set during the
   // `state_check` callback for the states where it can be triggered.
-  assert(!events_enabled || queue_empty(loop.events));
-  queue_put(loop.events, cursorhold_event, 0);
+  assert(!events_enabled || queue_empty(main_loop.events));
+  queue_put(main_loop.events, cursorhold_event, 0);
 }
 
 // Low level input function
@@ -147,7 +147,7 @@ bool os_char_avail(void)
 void os_breakcheck(void)
 {
   if (!got_int) {
-    loop_poll_events(&loop, 0);
+    loop_poll_events(&main_loop, 0);
   }
 }
 
@@ -322,7 +322,7 @@ static bool input_poll(int ms)
     prof_inchar_enter();
   }
 
-  LOOP_PROCESS_EVENTS_UNTIL(&loop, NULL, ms, input_ready() || input_eof);
+  LOOP_PROCESS_EVENTS_UNTIL(&main_loop, NULL, ms, input_ready() || input_eof);
 
   if (do_profiling == PROF_YES && ms) {
     prof_inchar_exit();
@@ -419,5 +419,5 @@ static void read_error_exit(void)
 
 static bool pending_events(void)
 {
-  return events_enabled && !queue_empty(loop.events);
+  return events_enabled && !queue_empty(main_loop.events);
 }

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -14,6 +14,7 @@
 #include "nvim/os/shell.h"
 #include "nvim/os/signal.h"
 #include "nvim/types.h"
+#include "nvim/main.h"
 #include "nvim/vim.h"
 #include "nvim/message.h"
 #include "nvim/memory.h"
@@ -205,16 +206,16 @@ static int do_os_system(char **argv,
   xstrlcpy(prog, argv[0], MAXPATHL);
 
   Stream in, out, err;
-  LibuvProcess uvproc = libuv_process_init(&loop, &buf);
+  LibuvProcess uvproc = libuv_process_init(&main_loop, &buf);
   Process *proc = &uvproc.process;
-  Queue *events = queue_new_child(loop.events);
+  Queue *events = queue_new_child(main_loop.events);
   proc->events = events;
   proc->argv = argv;
   proc->in = input != NULL ? &in : NULL;
   proc->out = &out;
   proc->err = &err;
   if (!process_spawn(proc)) {
-    loop_poll_events(&loop, 0);
+    loop_poll_events(&main_loop, 0);
     // Failed, probably due to `sh` not being executable
     if (!silent) {
       MSG_PUTS(_("\nCannot execute "));

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -8,6 +8,7 @@
 #include "nvim/globals.h"
 #include "nvim/memline.h"
 #include "nvim/eval.h"
+#include "nvim/main.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
 #include "nvim/misc2.h"
@@ -28,10 +29,10 @@ static bool rejecting_deadly;
 
 void signal_init(void)
 {
-  signal_watcher_init(&loop, &spipe, NULL);
-  signal_watcher_init(&loop, &shup, NULL);
-  signal_watcher_init(&loop, &squit, NULL);
-  signal_watcher_init(&loop, &sterm, NULL);
+  signal_watcher_init(&main_loop, &spipe, NULL);
+  signal_watcher_init(&main_loop, &shup, NULL);
+  signal_watcher_init(&main_loop, &squit, NULL);
+  signal_watcher_init(&main_loop, &sterm, NULL);
 #ifdef SIGPIPE
   signal_watcher_start(&spipe, on_signal, SIGPIPE);
 #endif
@@ -41,7 +42,7 @@ void signal_init(void)
 #endif
   signal_watcher_start(&sterm, on_signal, SIGTERM);
 #ifdef SIGPWR
-  signal_watcher_init(&loop, &spwr, NULL);
+  signal_watcher_init(&main_loop, &spwr, NULL);
   signal_watcher_start(&spwr, on_signal, SIGPWR);
 #endif
 }

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -9,6 +9,7 @@
 #include "nvim/os/time.h"
 #include "nvim/event/loop.h"
 #include "nvim/vim.h"
+#include "nvim/main.h"
 
 static uv_mutex_t delay_mutex;
 static uv_cond_t delay_cond;
@@ -43,7 +44,7 @@ void os_delay(uint64_t milliseconds, bool ignoreinput)
     if (milliseconds > INT_MAX) {
       milliseconds = INT_MAX;
     }
-    LOOP_PROCESS_EVENTS_UNTIL(&loop, NULL, (int)milliseconds, got_int);
+    LOOP_PROCESS_EVENTS_UNTIL(&main_loop, NULL, (int)milliseconds, got_int);
   } else {
     os_microdelay(milliseconds * 1000);
   }

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -4,6 +4,7 @@
 
 #include "nvim/state.h"
 #include "nvim/vim.h"
+#include "nvim/main.h"
 #include "nvim/getchar.h"
 #include "nvim/ui.h"
 #include "nvim/os/input.h"
@@ -32,7 +33,7 @@ getkey:
       // processing. Characters can come from mappings, scripts and other
       // sources, so this scenario is very common.
       key = safe_vgetc();
-    } else if (!queue_empty(loop.events)) {
+    } else if (!queue_empty(main_loop.events)) {
       // Event was made available after the last queue_process_events call
       key = K_EVENT;
     } else {
@@ -45,7 +46,7 @@ getkey:
       // directly.
       (void)os_inchar(NULL, 0, -1, 0);
       input_disable_events();
-      key = !queue_empty(loop.events) ? K_EVENT : safe_vgetc();
+      key = !queue_empty(main_loop.events) ? K_EVENT : safe_vgetc();
     }
 
     if (key == K_EVENT) {

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -63,6 +63,7 @@
 #include "nvim/map.h"
 #include "nvim/misc1.h"
 #include "nvim/move.h"
+#include "nvim/main.h"
 #include "nvim/state.h"
 #include "nvim/ex_docmd.h"
 #include "nvim/ex_cmds.h"
@@ -163,9 +164,9 @@ static VTermColor default_vt_bg_rgb;
 void terminal_init(void)
 {
   invalidated_terminals = pmap_new(ptr_t)();
-  time_watcher_init(&loop, &refresh_timer, NULL);
+  time_watcher_init(&main_loop, &refresh_timer, NULL);
   // refresh_timer_cb will redraw the screen which can call vimscript
-  refresh_timer.events = queue_new_child(loop.events);
+  refresh_timer.events = queue_new_child(main_loop.events);
 
   // initialize a rgb->color index map for cterm attributes(VTermScreenCell
   // only has RGB information and we need color indexes for terminal UIs)
@@ -452,7 +453,7 @@ static int terminal_execute(VimState *state, int key)
     case K_EVENT:
       // We cannot let an event free the terminal yet. It is still needed.
       s->term->refcount++;
-      queue_process_events(loop.events);
+      queue_process_events(main_loop.events);
       s->term->refcount--;
       if (s->term->buf_handle == 0) {
         s->close = true;

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -4,6 +4,7 @@
 #include "nvim/api/vim.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/ascii.h"
+#include "nvim/main.h"
 #include "nvim/misc2.h"
 #include "nvim/os/os.h"
 #include "nvim/os/input.h"
@@ -92,7 +93,7 @@ static void flush_input(TermInput *input, bool wait_until_empty)
   size_t drain_boundary = wait_until_empty ? 0 : 0xff;
   do {
     uv_mutex_lock(&input->key_buffer_mutex);
-    loop_schedule(&loop, event_create(1, wait_input_enqueue, 1, input));
+    loop_schedule(&main_loop, event_create(1, wait_input_enqueue, 1, input));
     input->waiting = true;
     while (input->waiting) {
       uv_cond_wait(&input->key_buffer_cond, &input->key_buffer_mutex);
@@ -336,7 +337,7 @@ static void read_cb(Stream *stream, RBuffer *buf, size_t c, void *data,
       stream_close(&input->read_stream, NULL);
       queue_put(input->loop->fast_events, restart_reading, 1, input);
     } else {
-      loop_schedule(&loop, event_create(1, input_done_event, 0));
+      loop_schedule(&main_loop, event_create(1, input_done_event, 0));
     }
     return;
   }

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -11,6 +11,7 @@
 #include "nvim/vim.h"
 #include "nvim/ui.h"
 #include "nvim/map.h"
+#include "nvim/main.h"
 #include "nvim/memory.h"
 #include "nvim/api/vim.h"
 #include "nvim/api/private/helpers.h"
@@ -261,7 +262,7 @@ static void sigwinch_cb(SignalWatcher *watcher, int signum, void *data)
   UI *ui = data;
   update_size(ui);
   // run refresh_event in nvim main loop
-  loop_schedule(&loop, event_create(1, refresh_event, 0));
+  loop_schedule(&main_loop, event_create(1, refresh_event, 0));
 }
 
 static bool attrs_differ(HlAttrs a1, HlAttrs a2)

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <limits.h>
 
+#include "nvim/main.h"
 #include "nvim/vim.h"
 #include "nvim/ui.h"
 #include "nvim/memory.h"
@@ -100,7 +101,7 @@ static void ui_bridge_stop(UI *b)
     if (stopped) {
       break;
     }
-    loop_poll_events(&loop, 10);
+    loop_poll_events(&main_loop, 10);
   }
   uv_thread_join(&bridge->ui_thread);
   uv_mutex_destroy(&bridge->mutex);


### PR DESCRIPTION
Current name is inappropriate for the following reasons:
1. It is often masked by local `loop` variables.
2. It cannot be searched for. There are many `loop` variables where `loop` is 
   some local variable. There are many cases when “loop” word is used in 
   a comment.
3. It is in any case bad idea to use a generic name as a name of the global 
   variable. Best if global has module prefix: this is why it is in `main.h`: 
   `main_loop` both stands for “a main loop” and “a loop defined in `main.*`”.

Since I have no idea how to list every occurrence of this variable method used 
to rename it is “remove it from globals.h, try to compile, fix errors”. Thus if 
some occurrence was hidden under false `#if` branch it was not replaced.
