### PR TITLE
[RFC] Some lib/kvec.h refactorings

### DIFF
--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -62,12 +62,10 @@
 #define NIL ((Object) {.type = kObjectTypeNil})
 
 #define PUT(dict, k, v)                                                       \
-  kv_push(KeyValuePair,                                                       \
-          dict,                                                               \
-          ((KeyValuePair) {.key = cstr_to_string(k), .value = v}))
+  kv_push(dict, ((KeyValuePair) { .key = cstr_to_string(k), .value = v }))
 
 #define ADD(array, item)                                                      \
-  kv_push(Object, array, item)
+  kv_push(array, item)
 
 #define STATIC_CSTR_AS_STRING(s) ((String) {.data = s, .size = sizeof(s) - 1})
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4950,7 +4950,7 @@ int bufhl_add_hl(buf_T *buf,
   bufhl_vec_T* lineinfo = map_ref(linenr_T, bufhl_vec_T)(buf->b_bufhl_info,
                                                          lnum, true);
 
-  bufhl_hl_item_T *hlentry = kv_pushp(bufhl_hl_item_T, *lineinfo);
+  bufhl_hl_item_T *hlentry = kv_pushp(*lineinfo);
   hlentry->src_id = src_id;
   hlentry->hl_id = hl_id;
   hlentry->start = col_start;

--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -101,7 +101,7 @@ static inline int json_decoder_pop(ValuesStackItem obj,
   FUNC_ATTR_NONNULL_ALL
 {
   if (kv_size(*container_stack) == 0) {
-    kv_push(ValuesStackItem, *stack, obj);
+    kv_push(*stack, obj);
     return OK;
   }
   ContainerStackItem last_container = kv_last(*container_stack);
@@ -190,7 +190,7 @@ static inline int json_decoder_pop(ValuesStackItem obj,
       *next_map_special = true;
       return OK;
     }
-    kv_push(ValuesStackItem, *stack, obj);
+    kv_push(*stack, obj);
   }
   return OK;
 }
@@ -815,13 +815,13 @@ json_decode_string_cycle_start:
           .v_lock = VAR_UNLOCKED,
           .vval = { .v_list = list },
         };
-        kv_push(ContainerStackItem, container_stack, ((ContainerStackItem) {
+        kv_push(container_stack, ((ContainerStackItem) {
           .stack_index = kv_size(stack),
           .s = p,
           .container = tv,
           .special_val = NULL,
         }));
-        kv_push(ValuesStackItem, stack, OBJ(tv, false, didcomma, didcolon));
+        kv_push(stack, OBJ(tv, false, didcomma, didcolon));
         break;
       }
       case '{': {
@@ -845,13 +845,13 @@ json_decode_string_cycle_start:
             .vval = { .v_dict = dict },
           };
         }
-        kv_push(ContainerStackItem, container_stack, ((ContainerStackItem) {
+        kv_push(container_stack, ((ContainerStackItem) {
           .stack_index = kv_size(stack),
           .s = p,
           .container = tv,
           .special_val = val_list,
         }));
-        kv_push(ValuesStackItem, stack, OBJ(tv, false, didcomma, didcolon));
+        kv_push(stack, OBJ(tv, false, didcomma, didcolon));
         break;
       }
       default: {

--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -628,10 +628,8 @@ int json_decode_string(const char *const buf, const size_t buf_len,
   convert_setup(&conv, (char_u *) "utf-8", p_enc);
   conv.vc_fail = true;
   int ret = OK;
-  ValuesStack stack;
-  kv_init(stack);
-  ContainerStack container_stack;
-  kv_init(container_stack);
+  ValuesStack stack = KV_INITIAL_VALUE;
+  ContainerStack container_stack = KV_INITIAL_VALUE;
   rettv->v_type = VAR_UNKNOWN;
   bool didcomma = false;
   bool didcolon = false;

--- a/src/nvim/eval/encode.c
+++ b/src/nvim/eval/encode.c
@@ -333,7 +333,7 @@ static int name##_convert_one_value(firstargtype firstargname, \
       } \
       CHECK_SELF_REFERENCE(tv->vval.v_list, lv_copyID, kMPConvList); \
       CONV_LIST_START(tv->vval.v_list); \
-      kv_push(MPConvStackVal, *mpstack, ((MPConvStackVal) { \
+      kv_push(*mpstack, ((MPConvStackVal) { \
         .type = kMPConvList, \
         .data = { \
           .l = { \
@@ -464,7 +464,7 @@ static int name##_convert_one_value(firstargtype firstargname, \
             CHECK_SELF_REFERENCE(val_di->di_tv.vval.v_list, lv_copyID, \
                                  kMPConvList); \
             CONV_LIST_START(val_di->di_tv.vval.v_list); \
-            kv_push(MPConvStackVal, *mpstack, ((MPConvStackVal) { \
+            kv_push(*mpstack, ((MPConvStackVal) { \
               .type = kMPConvList, \
               .data = { \
                 .l = { \
@@ -493,7 +493,7 @@ static int name##_convert_one_value(firstargtype firstargname, \
             } \
             CHECK_SELF_REFERENCE(val_list, lv_copyID, kMPConvPairs); \
             CONV_DICT_START(val_list->lv_len); \
-            kv_push(MPConvStackVal, *mpstack, ((MPConvStackVal) { \
+            kv_push(*mpstack, ((MPConvStackVal) { \
               .type = kMPConvPairs, \
               .data = { \
                 .l = { \
@@ -532,7 +532,7 @@ static int name##_convert_one_value(firstargtype firstargname, \
 name##_convert_one_value_regular_dict: \
       CHECK_SELF_REFERENCE(tv->vval.v_dict, dv_copyID, kMPConvDict); \
       CONV_DICT_START(tv->vval.v_dict->dv_hashtab.ht_used); \
-      kv_push(MPConvStackVal, *mpstack, ((MPConvStackVal) { \
+      kv_push(*mpstack, ((MPConvStackVal) { \
         .type = kMPConvDict, \
         .data = { \
           .d = { \

--- a/src/nvim/lib/kvec.h
+++ b/src/nvim/lib/kvec.h
@@ -1,57 +1,50 @@
-/* The MIT License
+// The MIT License
+//
+// Copyright (c) 2008, by Attractive Chaos <attractor@live.co.uk>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
-   Copyright (c) 2008, by Attractive Chaos <attractor@live.co.uk>
+// An example:
+//
+//     #include "kvec.h"
+//     int main() {
+//       kvec_t(int) array = KV_INITIAL_VALUE;
+//       kv_push(array, 10); // append
+//       kv_a(array, 20) = 5; // dynamic
+//       kv_A(array, 20) = 4; // static
+//       kv_destroy(array);
+//       return 0;
+//     }
 
-   Permission is hereby granted, free of charge, to any person obtaining
-   a copy of this software and associated documentation files (the
-   "Software"), to deal in the Software without restriction, including
-   without limitation the rights to use, copy, modify, merge, publish,
-   distribute, sublicense, and/or sell copies of the Software, and to
-   permit persons to whom the Software is furnished to do so, subject to
-   the following conditions:
-
-   The above copyright notice and this permission notice shall be
-   included in all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
-*/
-
-/*
-  An example:
-
-#include "kvec.h"
-int main() {
-  kvec_t(int) array = KV_INITIAL_VALUE;
-  kv_push(array, 10); // append
-  kv_a(array, 20) = 5; // dynamic
-  kv_A(array, 20) = 4; // static
-  kv_destroy(array);
-  return 0;
-}
-*/
-
-/*
-  2008-09-22 (0.1.0):
-
-  * The initial version.
-
-*/
-
-#ifndef AC_KVEC_H
-#define AC_KVEC_H
+#ifndef NVIM_LIB_KVEC_H
+#define NVIM_LIB_KVEC_H
 
 #include <stdlib.h>
 
 #include "nvim/memory.h"
 
-#define kv_roundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+#define kv_roundup32(x) \
+    ((--(x)), \
+     ((x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16), \
+     (++(x)))
 
 #define KV_INITIAL_VALUE { .size = 0, .capacity = 0, .items = NULL }
 
@@ -103,4 +96,4 @@ int main() {
          : 0)), \
      (v).items[(i)])
 
-#endif
+#endif  // NVIM_LIB_KVEC_H

--- a/src/nvim/lib/kvec.h
+++ b/src/nvim/lib/kvec.h
@@ -28,8 +28,7 @@
 
 #include "kvec.h"
 int main() {
-  kvec_t(int) array;
-  kv_init(array);
+  kvec_t(int) array = KV_INITIAL_VALUE;
   kv_push(array, 10); // append
   kv_a(array, 20) = 5; // dynamic
   kv_A(array, 20) = 4; // static
@@ -53,7 +52,14 @@ int main() {
 
 #define kv_roundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
 
-#define kvec_t(type) struct { size_t size, capacity; type *items; }
+#define KV_INITIAL_VALUE { .size = 0, .capacity = 0, .items = NULL }
+
+#define kvec_t(type) \
+    struct { \
+      size_t size; \
+      size_t capacity; \
+      type *items; \
+    }
 #define kv_init(v) ((v).size = (v).capacity = 0, (v).items = 0)
 #define kv_destroy(v) xfree((v).items)
 #define kv_A(v, i) ((v).items[(i)])

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -574,8 +574,7 @@ static void send_event(Channel *channel,
 
 static void broadcast_event(char *name, Array args)
 {
-  kvec_t(Channel *) subscribed;
-  kv_init(subscribed);
+  kvec_t(Channel *) subscribed = KV_INITIAL_VALUE;
   Channel *channel;
 
   map_foreach_value(channels, channel, {

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -179,7 +179,7 @@ bool channel_send_event(uint64_t id, char *name, Array args)
       // Pending request, queue the notification for later sending.
       String method = cstr_as_string(name);
       WBuffer *buffer = serialize_request(id, 0, method, args, &out_buffer, 1);
-      kv_push(WBuffer *, channel->delayed_notifications, buffer);
+      kv_push(channel->delayed_notifications, buffer);
     } else {
       send_event(channel, name, args);
     }
@@ -217,8 +217,8 @@ Object channel_send_call(uint64_t id,
   send_request(channel, request_id, method_name, args);
 
   // Push the frame
-  ChannelCallFrame frame = {request_id, false, false, NIL};
-  kv_push(ChannelCallFrame *, channel->call_stack, &frame);
+  ChannelCallFrame frame = { request_id, false, false, NIL };
+  kv_push(channel->call_stack, &frame);
   channel->pending_requests++;
   LOOP_PROCESS_EVENTS_UNTIL(&loop, channel->events, -1, frame.returned);
   (void)kv_pop(channel->call_stack);
@@ -580,7 +580,7 @@ static void broadcast_event(char *name, Array args)
 
   map_foreach_value(channels, channel, {
     if (pmap_has(cstr_t)(channel->subscribed_events, name)) {
-      kv_push(Channel *, subscribed, channel);
+      kv_push(subscribed, channel);
     }
   });
 
@@ -600,7 +600,7 @@ static void broadcast_event(char *name, Array args)
   for (size_t i = 0; i < kv_size(subscribed); i++) {
     Channel *channel = kv_A(subscribed, i);
     if (channel->pending_requests) {
-      kv_push(WBuffer *, channel->delayed_notifications, buffer);
+      kv_push(channel->delayed_notifications, buffer);
     } else {
       channel_write(channel, buffer);
     }

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -681,7 +681,7 @@ static void invalidate(UI *ui, int top, int bot, int left, int right)
     intersects->right = MAX(right, intersects->right);
   } else {
     // Else just add a new entry;
-    kv_push(Rect, data->invalid_regions, ((Rect){top, bot, left, right}));
+    kv_push(data->invalid_regions, ((Rect) { top, bot, left, right }));
   }
 }
 


### PR DESCRIPTION
Most notable is that many macros no longer need type argument. Also kv_init was replaced with brace initializer in some cases and functions were made more readable (actually all lib/*.h files need or used to need refactoring).
