### PR TITLE
[RDY] Make synIDattr() return #RRGGBB value for '[fg|bg|sp]#'

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6952,8 +6952,23 @@ highlight_color (
   else if (!(TOLOWER_ASC(what[0]) == 'b' && TOLOWER_ASC(what[1]) == 'g'))
     return NULL;
   if (modec == 'g') {
-    if (fg)
+    if (what[2] == '#' && ui_rgb_attached()) {
+      if (fg) {
+          n = HL_TABLE()[id - 1].sg_rgb_fg;
+      } else if (sp) {
+          n = HL_TABLE()[id - 1].sg_rgb_sp;
+      } else {
+          n = HL_TABLE()[id - 1].sg_rgb_bg;
+      }
+      if (n < 0 || n > 0xffffff) {
+        return NULL;
+      }
+      snprintf((char *)name, sizeof(name), "#%06x", n);
+      return name;
+    }
+    if (fg) {
       return HL_TABLE()[id - 1].sg_rgb_fg_name;
+    }
     if (sp) {
       return HL_TABLE()[id - 1].sg_rgb_sp_name;
     }

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -165,24 +165,49 @@ end)
 
 describe('synIDattr()', function()
   local screen
-
   before_each(function()
     clear()
     screen = Screen.new(50, 7)
-    execute('highlight Normal ctermfg=1 guifg=#ff0000')
+    execute('highlight Normal ctermfg=1 guifg=#ff0000 guibg=Black')
+    -- Salmon #fa8072 Maroon #800000
+    execute('highlight Keyword ctermfg=2 guifg=Salmon guisp=Maroon')
   end)
 
   after_each(function()
     screen:detach()
   end)
 
-  it('returns RGB number if GUI', function()
+  it('returns gui-color if GUI', function()
+    eq('1', eval('synIDattr(hlID("Normal"), "fg")'))
+    eq('-1', eval('synIDattr(hlID("Normal"), "bg")'))
+
+    eq('2', eval('synIDattr(hlID("Keyword"), "fg")'))
+    eq('', eval('synIDattr(hlID("Keyword"), "sp")'))
     screen:attach(true)
     eq('#ff0000', eval('synIDattr(hlID("Normal"), "fg")'))
+    eq('Black', eval('synIDattr(hlID("Normal"), "bg")'))
+
+    eq('Salmon', eval('synIDattr(hlID("Keyword"), "fg")'))
+    eq('Maroon', eval('synIDattr(hlID("Keyword"), "sp")'))
+  end)
+
+  it('returns #RRGGBB value for [fg|bg|sp]#', function()
+    eq('1', eval('synIDattr(hlID("Normal"), "fg#")'))
+    eq('-1', eval('synIDattr(hlID("Normal"), "bg#")'))
+
+    eq('2', eval('synIDattr(hlID("Keyword"), "fg#")'))
+    eq('', eval('synIDattr(hlID("Keyword"), "sp#")'))
+    screen:attach(true)
+    eq('#ff0000', eval('synIDattr(hlID("Normal"), "fg#")'))
+    eq('#000000', eval('synIDattr(hlID("Normal"), "bg#")'))
+
+    eq('#fa8072', eval('synIDattr(hlID("Keyword"), "fg#")'))
+    eq('#800000', eval('synIDattr(hlID("Keyword"), "sp#")'))
   end)
 
   it('returns color number if non-GUI', function()
     screen:attach(false)
     eq('1', eval('synIDattr(hlID("Normal"), "fg")'))
+    eq('2', eval('synIDattr(hlID("Keyword"), "fg")'))
   end)
 end)


### PR DESCRIPTION
Fixes: https://github.com/neovim/neovim/issues/3189

`synIDattr(id, what)` should return the value in `#RRGGBB` format when passed `what=[fg|bg|sp]#` and GUI-colors are being used. Currently returns the string that was used to set the gui-color. (Can be either a string in #RRGGBB format, e.g. `"#fa8072"`, or a color name, e.g. `"Salmon"`).

Related documentation:

```
synIDattr({synID}, {what} [, {mode}])           *synIDattr()*
                […]
        "fg"        foreground color (GUI: color name used to set
                the color, cterm: color number as a string,
                term: empty string)
                […]
        "fg#"       like "fg", but for the GUI and the GUI is
                running the name in "#RRGGBB" form
```

Related/Previous PR: https://github.com/neovim/neovim/pull/3005 (implementing support for truecolor)

Note: Implementation ignores the `#` prefix when not using GUI-colors.
Note: First PR, point out anything that you see unfit.
