### PR TITLE
unittests: Also remove event_teardown

### DIFF
--- a/test/unit/os/shell_spec.lua
+++ b/test/unit/os/shell_spec.lua
@@ -30,10 +30,6 @@ describe('shell functions', function()
     cimported.p_shcf = to_cstr('-c')
   end)
 
-  teardown(function()
-    cimported.event_teardown()
-  end)
-
   local function shell_build_argv(cmd, extra_args)
     local res = cimported.shell_build_argv(
         cmd and to_cstr(cmd),


### PR DESCRIPTION
`event_teardown` is there from 974752c, by @aktau. It was introduced with 
`init_homedir` and `event_init`. Then both were removed by @justinmk in 
99a9161bace8200aa611f6feefcc2ac3eda93251 (`init_homedir`) and 
49c5689f45b9f222ed58e18e55678df7fb971ee8 (`event_init`), but `event_teardown` 
was not removed. Now this may cause a crash. More details in #4852.

Note that I am not sure whether it is the _complete_ fix: maybe that unit test is supposed not to crash even after `event_teardown`.
