### PR TITLE
[RFC] BugFix: vimpatch.sh cannot pull vim patches.

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -92,7 +92,7 @@ commit_message() {
 
 find_git_remote() {
   git remote -v \
-    | awk '$2 ~ /github.com[:/]neovim\/neovim/ && $3 == "(fetch)" {print $1; exit}'
+    | awk '$2 ~ /github.com[:\/]neovim\/neovim/ && $3 == "(fetch)" {print $1; exit}'
 }
 
 assign_commit_details() {


### PR DESCRIPTION
I tried to merge vim patch using `vim-patch.sh` and got following error.

``` sh
$ ./scripts/vim-patch.sh -p 7.4.1399
Updating Vim sources in '/Users/shotat/Devs/neovim/.vim-src'.
Already up-to-date.
✔ Updated Vim sources.

✔ Found Vim revision '48e330aff911be1c798c88a973af6437a8141fce'.
awk: nonterminated character class github.com[:
 source line number 1
 context is
    $2 ~ >>>  /github.com[:/ <<<
```

So I fixed regexp within awk commands in this script and now it works.
