### PR TITLE
[RFC] vim-patch:85084ef

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1,4 +1,4 @@
-*editing.txt*   For Vim version 7.4.  Last change: 2016 Jan 03
+*editing.txt*   For Vim version 7.4.  Last change: 2016 Jan 17
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -596,6 +596,7 @@ list of the current window.
 				:0argadd x	x a b c
 				:1argadd x	a x b c
 				:$argadd x	a b c x
+			And after the last one:
 				:+2argadd y	a b c x y
 			There is no check for duplicates, it is possible to
 			add a file to the argument list twice.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -870,7 +870,7 @@ cursor: >
 	:let c = getline(".")[col(".") - 1]
 
 If the length of the String is less than the index, the result is an empty
-String.  A negative index always results in an empty string (reason: backwards
+String.  A negative index always results in an empty string (reason: backward
 compatibility).  Use [-1:] to get the last byte.
 
 If expr8 is a |List| then it results the item at index expr1.  See |list-index|
@@ -4746,8 +4746,8 @@ matchadd({group}, {pattern}[, {priority}[, {id} [, {dict}]]])
 		respectively.  If the {id} argument is not specified or -1,
 		|matchadd()| automatically chooses a free ID.
 
-		The optional {dict} argmument allows for further custom
-		values. Currently this is used to specify a match specifc
+		The optional {dict} argument allows for further custom
+		values. Currently this is used to specify a match specific
 		conceal character that will be shown for |hl-Conceal|
 		highlighted matches. The dict can have the following members:
 
@@ -5600,7 +5600,7 @@ search({pattern} [, {flags} [, {stopline} [, {timeout}]]])	*search()*
 
 		'ignorecase', 'smartcase' and 'magic' are used.
 		
-		When the 'z' flag is not given seaching always starts in
+		When the 'z' flag is not given, searching always starts in
 		column zero and then matches before the cursor are skipped.
 		When the 'c' flag is present in 'cpo' the next search starts
 		after the match.  Without the 'c' flag the next search starts
@@ -7994,7 +7994,7 @@ This does NOT work: >
 			From Vim version 4.5 until 5.0, every Ex command in
 			between the ":if" and ":endif" is ignored.  These two
 			commands were just to allow for future expansions in a
-			backwards compatible way.  Nesting was allowed.  Note
+			backward compatible way.  Nesting was allowed.  Note
 			that any ":else" or ":elseif" was ignored, the "else"
 			part was not executed either.
 

--- a/runtime/doc/mlang.txt
+++ b/runtime/doc/mlang.txt
@@ -1,4 +1,4 @@
-*mlang.txt*     For Vim version 7.4.  Last change: 2012 Jan 15
+*mlang.txt*     For Vim version 7.4.  Last change: 2016 Jan 16
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -94,13 +94,15 @@ If you used the self-installing .exe file, message translations should work
 already.  Otherwise get the libintl.dll file if you don't have it yet:
 
 	http://sourceforge.net/projects/gettext
+Or:
+	https://mlocati.github.io/gettext-iconv-windows/
 
 This also contains tools xgettext, msgformat and others.
 
 libintl.dll should be placed in same directory with (g)vim.exe, or some
-place where PATH environment value describe.  Message files (vim.mo)
-have to be placed in "$VIMRUNTIME/lang/xx/LC_MESSAGES", where "xx" is the
-abbreviation of the language (mostly two letters).
+place where PATH environment value describe.  Vim also finds libintl-8.dll.
+Message files (vim.mo) have to be placed in "$VIMRUNTIME/lang/xx/LC_MESSAGES",
+where "xx" is the abbreviation of the language (mostly two letters).
 
 If you write your own translations you need to generate the .po file and
 convert it to a .mo file.  You need to get the source distribution and read

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -1,4 +1,4 @@
-*usr_02.txt*	For Vim version 7.4.  Last change: 2016 Jan 15
+*usr_02.txt*	For Vim version 7.4.  Last change: 2016 Jan 16
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -543,38 +543,42 @@ Summary: 					*help-summary*  >
 8) Ex-commands always start with ":", so to go to the :s command help: >
 	:help :s
 
-9) Key combinations.  They usually start with a single letter indicating
-   the mode for which they can be used.  E.g.: >
-   	:help i_CTRL-X
-<   takes you to the family of Ctrl-X commands for insert mode which can be
-   used to auto complete different things.  Note, that certain keys will
-   always be written the same, e.g. Control will always be CTRL.
-   For normal mode commands there is no prefix and the topic is available at
-   :h CTRL-<Letter>. E.g.  >
-   	:help CTRL-W
-<   In contrast >
-	:help c_CTRL-R
-<   will describe what the Ctrl-R does when entering commands in the Command
-   line and >
-   	:help v_Ctrl-A
-<   talks about incrementing numbers in visual mode and >
-	:help g_CTRL-A
-<   talks about the g<C-A> command (e.g. you have to press "g" then <Ctrl-A>).
-   Here the "g" stand for the normal command "g" which always expects a second
-   key before doing something similar to the commands starting with "z"
+9) Commands specifically for debugging start with ">".  To go to to the help
+   for the "cont" debug command: >
+	:help >cont
 
-10) Regexp items always start with /.  So to get help for the "\+" quantifier
+10) Key combinations.  They usually start with a single letter indicating
+    the mode for which they can be used.  E.g.: >
+   	:help i_CTRL-X
+<    takes you to the family of Ctrl-X commands for insert mode which can be
+    used to auto complete different things.  Note, that certain keys will
+    always be written the same, e.g. Control will always be CTRL.
+    For normal mode commands there is no prefix and the topic is available at
+    :h CTRL-<Letter>. E.g.  >
+   	:help CTRL-W
+<    In contrast >
+	:help c_CTRL-R
+<    will describe what the Ctrl-R does when entering commands in the Command
+    line and >
+   	:help v_Ctrl-A
+<    talks about incrementing numbers in visual mode and >
+	:help g_CTRL-A
+<    talks about the g<C-A> command (e.g. you have to press "g" then <Ctrl-A>).
+    Here the "g" stand for the normal command "g" which always expects a second
+    key before doing something similar to the commands starting with "z"
+
+11) Regexp items always start with /.  So to get help for the "\+" quantifier
     in Vim regexes: >
    	:help /\+
-<   If you need to know everything about regular expressions, start reading
-   at: >
+<    If you need to know everything about regular expressions, start reading
+    at: >
    	:help pattern.txt
 
-11) Registers always start with "quote". To find out about the special ":"
+12) Registers always start with "quote". To find out about the special ":"
     register: >
    	:help quote:
 
-12) Vim Script (VimL) is available at >
+13) Vim Script (VimL) is available at >
 	:help eval.txt
 <   Certain aspects of the language are available at :h expr-X where "X" is a
    single letter. E.g.  >
@@ -589,7 +593,7 @@ Summary: 					*help-summary*  >
 <   talks about the append VimL function rather than how to append text in the
    current buffer.
 
-13) Mappings are talked about in the help page :h |map.txt|. Use >
+14) Mappings are talked about in the help page :h |map.txt|. Use >
     	:help mapmode-i
 <    to find out about the |:imap| command.  Also use :map-topic
     to find out about certain subtopics particular for mappings.  e.g: >
@@ -598,19 +602,19 @@ Summary: 					*help-summary*  >
 	:help map-bar
 <    for how the '|' is handled in mappings.
 
-14) Command definitions are talked about :h command-topic, so use >
+15) Command definitions are talked about :h command-topic, so use >
 	:help command-bar
 <    to find out about the '!' argument for custom commands.
 
-15) Window management commands always start with CTRL-W, so you find the
+16) Window management commands always start with CTRL-W, so you find the
     corresponding help at :h CTRL-W_letter.  E.g. >
    	:help CTRL-W_p
-<    for moving the previous accessed window).  You can also access >
+<    for moving the previous accessed window.  You can also access >
 	:help windows.txt
 <    and read your way through if you are looking for window handling
     commands.
 
-16) Use |:helpgrep| to search in all help pages (and also of any installed
+17) Use |:helpgrep| to search in all help pages (and also of any installed
     plugins).  See |:helpgrep| for how to use it.
     To search for a topic: >
     	:helpgrep topic
@@ -621,7 +625,7 @@ Summary: 					*help-summary*  >
     	:copen
 <    Move around to the match you like and press Enter to jump to that help.
 
-17) The user manual.  This describes help topics for beginners in a rather
+18) The user manual.  This describes help topics for beginners in a rather
     friendly way.  Start at |usr_toc.txt| to find the table of content (as you
     might have guessed): >
     	:help usr_toc.txt
@@ -634,31 +638,31 @@ Summary: 					*help-summary*  >
     	:help 10.1
 <    goes to chapter 10.1 in |usr_10.txt| and talks about recording macros.
 
-18) Highlighting groups.  Always start with hl-groupname.  E.g. >
+19) Highlighting groups.  Always start with hl-groupname.  E.g. >
     	:help hl-WarningMsg
 <    talks about the WarningMsg highlighting group.
 
-19) Syntax highlighting is namespaced to :syn-topic e.g. >
+20) Syntax highlighting is namespaced to :syn-topic e.g. >
 	:help :syn-conceal
 <    talks about the conceal argument for the :syn command.
 
-20) Quickfix commands usually start with :c while location list commands
+21) Quickfix commands usually start with :c while location list commands
     usually start with :l
 
-21) Autocommand events can be found by their name: >
+22) Autocommand events can be found by their name: >
      	:help BufWinLeave
 <    To see all possible events: >
 	:help autocommands-events
 
-22) Command-line switches always start with "-".  So for the help of the -f
+23) Command-line switches always start with "-".  So for the help of the -f
     command switch of Vim use: >
     	:help -f
 
-23) Optional features always start with "+".  To find out about the
+24) Optional features always start with "+".  To find out about the
     conceal feature use: >
     	:help +conceal
 
-24) Documentation for included filetype specific functionality is usually
+25) Documentation for included filetype specific functionality is usually
     available  in the form ft-<filetype>-<functionality>.  So >
     	:help ft-c-syntax
 <    talks about the C syntax file and the option it provides.  Sometimes,
@@ -668,7 +672,7 @@ Summary: 					*help-summary*  >
 	:help ft-tex-plugin
 <    are available.
 
-25) Error and Warning codes can be looked up directly in the help.  So >
+26) Error and Warning codes can be looked up directly in the help.  So >
 	:help E297
 <    takes you exactly to the description of the swap error message and >
 	:help W10


### PR DESCRIPTION
Update help files.

https://github.com/vim/vim/commit/85084ef1e999dcf50e8d466106a33bac24a0febb

Ignored changes to:
- doc/editing.txt related to encryption
- doc/eval.txt related to perleval()
- doc/if_mzsch.txt
- doc/tags
- doc/todo.txt
