### PR TITLE
[RFC] Restore vim's tab drag behavior

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2110,6 +2110,20 @@ static void op_function(oparg_T *oap)
   }
 }
 
+// Move the current tab to tab in same column as mouse or to end of the
+// tabline if there is no tab there.
+static void move_tab_to_mouse(void)
+{
+  int tabnr = tab_page_click_defs[mouse_col].tabnr;
+  if (tabnr <= 0) {
+      tabpage_move(9999);
+  } else if (tabnr < tabpage_index(curtab)) {
+      tabpage_move(tabnr - 1);
+  } else {
+      tabpage_move(tabnr);
+  }
+}
+
 /*
  * Do the appropriate action for the current mouse click in the current mode.
  * Not used for Command-line mode.
@@ -2346,12 +2360,7 @@ do_mouse (
   if (mouse_row == 0 && firstwin->w_winrow > 0) {
     if (is_drag) {
       if (in_tab_line) {
-        if (tab_page_click_defs[mouse_col].type == kStlClickTabClose) {
-          tabpage_move(9999);
-        } else {
-          int tabnr = tab_page_click_defs[mouse_col].tabnr;
-          tabpage_move(tabnr < tabpage_index(curtab) ? tabnr - 1 : tabnr);
-        }
+        move_tab_to_mouse();
       }
       return false;
     }
@@ -2466,10 +2475,7 @@ do_mouse (
     }
     return true;
   } else if (is_drag && in_tab_line) {
-    tabpage_move(tab_page_click_defs[mouse_col].type == kStlClickTabClose
-                 ? 9999
-                 : tab_page_click_defs[mouse_col].tabnr - 1);
-    in_tab_line = false;
+    move_tab_to_mouse();
     return false;
   }
 

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -131,7 +131,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftMouse><4,0>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
@@ -139,7 +139,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftDrag><14,0>')
       screen:expect([[
         {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
@@ -147,7 +147,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
     end)
 
     it('in tabline to the left moves tab left', function()
@@ -161,7 +161,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftMouse><11,0>')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
@@ -169,7 +169,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftDrag><6,0>')
       screen:expect([[
         {sel: + bar }{tab: + foo }{fill:          }{tab:X}|
@@ -177,7 +177,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
     end)
 
     it('in tabline to the right moves tab right', function()
@@ -191,7 +191,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftMouse><4,0>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
@@ -199,7 +199,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftDrag><7,0>')
       screen:expect([[
         {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
@@ -207,7 +207,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
     end)
 
     it('out of tabline under filler space moves tab to the end', function()
@@ -221,7 +221,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftMouse><4,0>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
@@ -229,7 +229,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftDrag><4,1>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
@@ -237,7 +237,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftDrag><14,1>')
       screen:expect([[
         {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
@@ -245,7 +245,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
     end)
 
     it('out of tabline to the left moves tab left', function()
@@ -259,7 +259,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftMouse><11,0>')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
@@ -267,7 +267,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftDrag><11,1>')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
@@ -275,7 +275,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftDrag><6,1>')
       screen:expect([[
         {sel: + bar }{tab: + foo }{fill:          }{tab:X}|
@@ -283,7 +283,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
     end)
 
     it('out of tabline to the right moves tab right', function()
@@ -297,7 +297,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftMouse><4,0>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
@@ -305,7 +305,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftDrag><4,1>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
@@ -313,7 +313,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftDrag><7,1>')
       screen:expect([[
         {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
@@ -321,7 +321,7 @@ describe('Mouse input', function()
         {0:~                        }|
         {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
     end)
   end)
 

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -109,6 +109,222 @@ describe('Mouse input', function()
     ]])
   end)
 
+  describe('tab drag', function()
+    local tab_attrs = {
+      tab  = { background=Screen.colors.LightGrey, underline=true },
+      sel  = { bold=true },
+      fill = { reverse=true }
+    }
+
+    before_each(function()
+      screen.timeout = 15000
+    end)
+
+    it('in tabline on filler space moves tab to the end', function()
+      execute('%delete')
+      insert('this is foo')
+      execute('silent file foo | tabnew | file bar')
+      insert('this is bar')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftMouse><4,0>')
+      screen:expect([[
+        {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
+        this is fo^o              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftDrag><14,0>')
+      screen:expect([[
+        {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
+        this is fo^o              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+    end)
+
+    it('in tabline to the left moves tab left', function()
+      execute('%delete')
+      insert('this is foo')
+      execute('silent file foo | tabnew | file bar')
+      insert('this is bar')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftMouse><11,0>')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftDrag><6,0>')
+      screen:expect([[
+        {sel: + bar }{tab: + foo }{fill:          }{tab:X}|
+        this is ba^r              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+    end)
+
+    it('in tabline to the right moves tab right', function()
+      execute('%delete')
+      insert('this is foo')
+      execute('silent file foo | tabnew | file bar')
+      insert('this is bar')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftMouse><4,0>')
+      screen:expect([[
+        {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
+        this is fo^o              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftDrag><7,0>')
+      screen:expect([[
+        {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
+        this is fo^o              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+    end)
+
+    it('out of tabline under filler space moves tab to the end', function()
+      execute('%delete')
+      insert('this is foo')
+      execute('silent file foo | tabnew | file bar')
+      insert('this is bar')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftMouse><4,0>')
+      screen:expect([[
+        {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
+        this is fo^o              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftDrag><4,1>')
+      screen:expect([[
+        {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
+        this is fo^o              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftDrag><14,1>')
+      screen:expect([[
+        {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
+        this is fo^o              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+    end)
+
+    it('out of tabline to the left moves tab left', function()
+      execute('%delete')
+      insert('this is foo')
+      execute('silent file foo | tabnew | file bar')
+      insert('this is bar')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftMouse><11,0>')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftDrag><11,1>')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftDrag><6,1>')
+      screen:expect([[
+        {sel: + bar }{tab: + foo }{fill:          }{tab:X}|
+        this is ba^r              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+    end)
+
+    it('out of tabline to the right moves tab right', function()
+      execute('%delete')
+      insert('this is foo')
+      execute('silent file foo | tabnew | file bar')
+      insert('this is bar')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftMouse><4,0>')
+      screen:expect([[
+        {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
+        this is fo^o              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftDrag><4,1>')
+      screen:expect([[
+        {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
+        this is fo^o              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+      feed('<LeftDrag><7,1>')
+      screen:expect([[
+        {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
+        this is fo^o              |
+        ~                        |
+        ~                        |
+                                 |
+      ]], tab_attrs)
+    end)
+  end)
+
   describe('tabline', function()
     before_each(function()
       screen:set_default_attr_ids( {

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -110,13 +110,13 @@ describe('Mouse input', function()
   end)
 
   describe('tab drag', function()
-    local tab_attrs = {
-      tab  = { background=Screen.colors.LightGrey, underline=true },
-      sel  = { bold=true },
-      fill = { reverse=true }
-    }
-
     before_each(function()
+      screen:set_default_attr_ids( {
+        [0] = {bold=true, foreground=Screen.colors.Blue},
+        tab  = { background=Screen.colors.LightGrey, underline=true },
+        sel  = { bold=true },
+        fill = { reverse=true }
+      })
       screen.timeout = 15000
     end)
 
@@ -128,24 +128,24 @@ describe('Mouse input', function()
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftMouse><4,0>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
         this is fo^o              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftDrag><14,0>')
       screen:expect([[
         {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
         this is fo^o              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
     end)
@@ -158,24 +158,24 @@ describe('Mouse input', function()
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftMouse><11,0>')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftDrag><6,0>')
       screen:expect([[
         {sel: + bar }{tab: + foo }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
     end)
@@ -188,24 +188,24 @@ describe('Mouse input', function()
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftMouse><4,0>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
         this is fo^o              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftDrag><7,0>')
       screen:expect([[
         {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
         this is fo^o              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
     end)
@@ -218,32 +218,32 @@ describe('Mouse input', function()
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftMouse><4,0>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
         this is fo^o              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftDrag><4,1>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
         this is fo^o              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftDrag><14,1>')
       screen:expect([[
         {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
         this is fo^o              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
     end)
@@ -256,32 +256,32 @@ describe('Mouse input', function()
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftMouse><11,0>')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftDrag><11,1>')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftDrag><6,1>')
       screen:expect([[
         {sel: + bar }{tab: + foo }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
     end)
@@ -294,32 +294,32 @@ describe('Mouse input', function()
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftMouse><4,0>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
         this is fo^o              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftDrag><4,1>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
         this is fo^o              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
       feed('<LeftDrag><7,1>')
       screen:expect([[
         {tab: + bar }{sel: + foo }{fill:          }{tab:X}|
         this is fo^o              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
       ]], tab_attrs)
     end)


### PR DESCRIPTION
This fixes issue #4663.
It also depends on pull request #4873.

I just restored the tab drag behavior from vim. Since mouse release events now work, as of pull request #4873, the original tab drag implementation works correctly in neovim.
