### PR TITLE
[RFC] vim-patch:7.4.1130

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -563,7 +563,7 @@ static int included_patches[] = {
   // 1133 NA
   1132,
   // 1131 NA
-  // 1130,
+  // 1130 NA
   // 1129 NA
   // 1128 NA
   // 1127 NA


### PR DESCRIPTION
Problem:    Memory leak in :vimgrep.
Solution:   Call FreeWild(). (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/61ff4dd6a4d47bd32383fe28087be2b37dec53f4
# 

It seems that there is no need to apply this patch, because `xmalloc` already prevents memory leaks in this block.
So I modify only `src/nvim/version.c`. Is it right way?
