### PR TITLE
[RFC] make timers work like in vim when something is zero

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -435,6 +435,7 @@ typedef struct {
   TimeWatcher tw;
   int timer_id;
   int repeat_count;
+  long timeout;
   bool stopped;
   ufunc_T *callback;
 } timer_T;
@@ -16655,6 +16656,7 @@ static void f_timer_start(typval_T *argvars, typval_T *rettv)
   timer = xmalloc(sizeof *timer);
   timer->stopped = false;
   timer->repeat_count = repeat;
+  timer->timeout = timeout;
   timer->timer_id = last_timer_id++;
   timer->callback = func;
 
@@ -16709,6 +16711,14 @@ static void timer_due_cb(TimeWatcher *tw, void *data)
   call_user_func(timer->callback, ARRAY_SIZE(argv), argv, &rettv,
                  curwin->w_cursor.lnum, curwin->w_cursor.lnum, NULL);
   clear_tv(&rettv);
+
+  if (!timer->stopped && timer->timeout == 0) {
+    // special case: timeout=0 means the callback will be
+    // invoked again on the next event loop tick.
+    // we don't use uv_idle_t to not spin the event loop
+    // when the main loop is blocked.
+    time_watcher_start(&timer->tw, timer_due_cb, 0, 0);
+  }
 }
 
 static void timer_stop(timer_T *timer)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16639,6 +16639,9 @@ static void f_timer_start(typval_T *argvars, typval_T *rettv)
     }
     if (dict_find(dict, (char_u *)"repeat", -1) != NULL) {
       repeat = get_dict_number(dict, (char_u *)"repeat");
+      if (repeat == 0) {
+        repeat = 1;
+      }
     }
   }
 

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -22,6 +22,14 @@ describe('timers', function()
     eq(1,eval("g:val"))
   end)
 
+  it('works one-shot when repeat=0', function()
+    execute("call timer_start(50, 'MyHandler', {'repeat': 0})")
+    eq(0,eval("g:val"))
+    run(nil, nil, nil, 200)
+    eq(1,eval("g:val"))
+  end)
+
+
   it('works with repeat two', function()
     execute("call timer_start(50, 'MyHandler', {'repeat': 2})")
     eq(0,eval("g:val"))

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -37,6 +37,13 @@ describe('timers', function()
     eq(2,eval("g:val"))
   end)
 
+  it('works with zero timeout', function()
+    -- timer_start does still not invoke the callback immediately
+    eq(0,eval("[timer_start(0, 'MyHandler', {'repeat': 1000}), g:val][1]"))
+    run(nil, nil, nil, 300)
+    eq(1000,eval("g:val"))
+  end)
+
   it('can be started during sleep', function()
     nvim_async("command", "sleep 10")
     -- this also tests that remote requests works during sleep


### PR DESCRIPTION
As discussed on gitter, `timeout=0` is useful to allow basic cooperative multitasking, you can do a small amount of work on each tick to allow user input in between. This seems also consistent with vim behavior.

`repeat=0` doesn't make any sense, but be consistent with vim to avoid bugs in plugins that would happen to use it.
