### PR TITLE
Testlint.

### DIFF
--- a/test/functional/legacy/010_errorformat_spec.lua
+++ b/test/functional/legacy/010_errorformat_spec.lua
@@ -2,8 +2,8 @@
 -- disabled.
 
 local helpers = require('test.functional.helpers')
-local feed, insert, source = helpers.feed, helpers.insert, helpers.source
-local clear, execute, expect, write_file = helpers.clear, helpers.execute, helpers.expect, helpers.write_file
+local feed, clear, execute = helpers.feed, helpers.clear, helpers.execute
+local expect, write_file = helpers.expect, helpers.write_file
 
 describe('errorformat', function()
   setup(function()


### PR DESCRIPTION
Missed in https://github.com/neovim/neovim/commit/c156a182806c85a86493349bffac807b972018e8, let's keep those linters happy :)
