### PR TITLE
[RFC] vim-patch:13d5aee,705ada1,298b440,5e9b2fa,7c764f7,681baaf,cbebd48

### DIFF
--- a/runtime/autoload/csscomplete.vim
+++ b/runtime/autoload/csscomplete.vim
@@ -1,429 +1,740 @@
 " Vim completion script
-" Language:	CSS 2.1
-" Maintainer:	Mikolaj Machowski ( mikmach AT wp DOT pl )
-" Last Change:	2007 May 5
+" Language: CSS
+"           Based on MDN CSS Reference at 2016 Jan <https://developer.mozilla.org/en-US/docs/Web/CSS/Reference>
+"           plus CSS Speech Module <http://www.w3.org/TR/css3-speech/>
+" Maintainer: Kao, Wei-Ko(othree) ( othree AT gmail DOT com )
+" Original Author: Mikolaj Machowski ( mikmach AT wp DOT pl )
+" Last Change: 2016 Jan 11
 
-	let s:values = split("azimuth background background-attachment background-color background-image background-position background-repeat border bottom border-collapse border-color border-spacing border-style border-top border-right border-bottom border-left border-top-color border-right-color border-bottom-color border-left-color  border-top-style border-right-style border-bottom-style border-left-style border-top-width border-right-width border-bottom-width border-left-width border-width caption-side clear clip color content counter-increment counter-reset cue cue-after cue-before cursor display direction elevation empty-cells float font font-family font-size font-style font-variant font-weight height left letter-spacing line-height list-style list-style-image list-style-position list-style-type margin margin-right margin-left margin-top margin-bottom max-height max-width min-height min-width orphans outline outline-color outline-style outline-width overflow padding padding-top padding-right padding-bottom padding-left page-break-after page-break-before page-break-inside pause pause-after pause-before pitch pitch-range play-during position quotes right richness speak speak-header speak-numeral speak-punctuation speech-rate stress table-layout text-align text-decoration text-indent text-transform top unicode-bidi vertical-align visibility voice-family volume white-space width widows word-spacing z-index")
+let s:values = split("all additive-symbols align-content align-items align-self animation animation-delay animation-direction animation-duration animation-fill-mode animation-iteration-count animation-name animation-play-state animation-timing-function backface-visibility background background-attachment background-blend-mode background-clip background-color background-image background-origin background-position background-repeat background-size block-size border border-block-end border-block-end-color border-block-end-style border-block-end-width border-block-start border-block-start-color border-block-start-style border-block-start-width border-bottom border-bottom-color border-bottom-left-radius border-bottom-right-radius border-bottom-style border-bottom-width border-collapse border-color border-image border-image-outset border-image-repeat border-image-slice border-image-source border-image-width border-inline-end border-inline-end-color border-inline-end-style border-inline-end-width border-inline-start border-inline-start-color border-inline-start-style border-inline-start-width border-left border-left-color border-left-style border-left-width border-radius border-right border-right-color border-right-style border-right-width border-spacing border-style border-top border-top-color border-top-left-radius border-top-right-radius border-top-style border-top-width border-width bottom box-decoration-break box-shadow box-sizing break-after break-before break-inside caption-side clear clip clip-path color columns column-count column-fill column-gap column-rule column-rule-color column-rule-style column-rule-width column-span column-width content counter-increment counter-reset cue cue-before cue-after cursor direction display empty-cells fallback filter flex flex-basis flex-direction flex-flow flex-grow flex-shrink flex-wrap float font font-family font-feature-settings font-kerning font-language-override font-size font-size-adjust font-stretch font-style font-synthesis font-variant font-variant-alternates font-variant-caps font-variant-east-asian font-variant-ligatures font-variant-numeric font-variant-position font-weight grid grid-area grid-auto-columns grid-auto-flow grid-auto-position grid-auto-rows grid-column grid-column-start grid-column-end grid-row grid-row-start grid-row-end grid-template grid-template-areas grid-template-rows grid-template-columns height hyphens image-rendering image-resolution image-orientation ime-mode inline-size isolation justify-content left letter-spacing line-break line-height list-style list-style-image list-style-position list-style-type margin margin-block-end margin-block-start margin-bottom margin-inline-end margin-inline-start margin-left margin-right margin-top marks mask mask-type max-block-size max-height max-inline-size max-width max-zoom min-block-size min-height min-inline-size min-width min-zoom mix-blend-mode negative object-fit object-position offset-block-end offset-block-start offset-inline-end offset-inline-start opacity order orientation orphans outline outline-color outline-offset outline-style outline-width overflow overflow-wrap overflow-x overflow-y pad padding padding-block-end padding-block-start padding-bottom padding-inline-end padding-inline-start padding-left padding-right padding-top page-break-after page-break-before page-break-inside pause-before pause-after pause perspective perspective-origin pointer-events position prefix quotes range resize rest rest-before rest-after right ruby-align ruby-merge ruby-position scroll-behavior scroll-snap-coordinate scroll-snap-destination scroll-snap-points-x scroll-snap-points-y scroll-snap-type scroll-snap-type-x scroll-snap-type-y shape-image-threshold shape-margin shape-outside speak speak-as suffix symbols system table-layout tab-size text-align text-align-last text-combine-upright text-decoration text-decoration-color text-decoration-line text-emphasis text-emphasis-color text-emphasis-position text-emphasis-style text-indent text-orientation text-overflow text-rendering text-shadow text-transform text-underline-position top touch-action transform transform-box transform-origin transform-style transition transition-delay transition-duration transition-property transition-timing-function unicode-bidi unicode-range user-zoom vertical-align visibility voice-balance voice-duration voice-family voice-pitch voice-rate voice-range voice-stress voice-volume white-space widows width will-change word-break word-spacing word-wrap writing-mode z-index zoom")
+
 
 function! csscomplete#CompleteCSS(findstart, base)
 
-if a:findstart
-	" We need whole line to proper checking
-	let line = getline('.')
-	let start = col('.') - 1
-	let compl_begin = col('.') - 2
-	while start >= 0 && line[start - 1] =~ '\%(\k\|-\)'
-		let start -= 1
-	endwhile
-	let b:compl_context = line[0:compl_begin]
-	return start
-endif
+  if a:findstart
+    " We need whole line to proper checking
+    let line = getline('.')
+    let start = col('.') - 1
+    let compl_begin = col('.') - 2
+    while start >= 0 && line[start - 1] =~ '\%(\k\|-\)'
+      let start -= 1
+    endwhile
+    let b:after = line[compl_begin :]
+    let b:compl_context = line[0:compl_begin]
+    return start
+  endif
 
-" There are few chars important for context:
-" ^ ; : { } /* */
-" Where ^ is start of line and /* */ are comment borders
-" Depending on their relative position to cursor we will know what should
-" be completed. 
-" 1. if nearest are ^ or { or ; current word is property
-" 2. if : it is value (with exception of pseudo things)
-" 3. if } we are outside of css definitions
-" 4. for comments ignoring is be the easiest but assume they are the same
-"    as 1. 
-" 5. if @ complete at-rule
-" 6. if ! complete important
-if exists("b:compl_context")
-	let line = b:compl_context
-	unlet! b:compl_context
-else
-	let line = a:base
-endif
+  " There are few chars important for context:
+  " ^ ; : { } /* */
+  " Where ^ is start of line and /* */ are comment borders
+  " Depending on their relative position to cursor we will know what should
+  " be completed. 
+  " 1. if nearest are ^ or { or ; current word is property
+  " 2. if : it is value (with exception of pseudo things)
+  " 3. if } we are outside of css definitions
+  " 4. for comments ignoring is be the easiest but assume they are the same
+  "    as 1. 
+  " 5. if @ complete at-rule
+  " 6. if ! complete important
+  if exists("b:compl_context")
+    let line = b:compl_context
+    let after = b:after
+    unlet! b:compl_context
+  else
+    let line = a:base
+  endif
 
-let res = []
-let res2 = []
-let borders = {}
+  let res = []
+  let res2 = []
+  let borders = {}
 
-" Check last occurrence of sequence
+  " Check last occurrence of sequence
 
-let openbrace  = strridx(line, '{')
-let closebrace = strridx(line, '}')
-let colon      = strridx(line, ':')
-let semicolon  = strridx(line, ';')
-let opencomm   = strridx(line, '/*')
-let closecomm  = strridx(line, '*/')
-let style      = strridx(line, 'style\s*=')
-let atrule     = strridx(line, '@')
-let exclam     = strridx(line, '!')
+  let openbrace  = strridx(line, '{')
+  let closebrace = strridx(line, '}')
+  let colon      = strridx(line, ':')
+  let semicolon  = strridx(line, ';')
+  let opencomm   = strridx(line, '/*')
+  let closecomm  = strridx(line, '*/')
+  let style      = strridx(line, 'style\s*=')
+  let atrule     = strridx(line, '@')
+  let exclam     = strridx(line, '!')
 
-if openbrace > -1
-	let borders[openbrace] = "openbrace"
-endif
-if closebrace > -1
-	let borders[closebrace] = "closebrace"
-endif
-if colon > -1
-	let borders[colon] = "colon"
-endif
-if semicolon > -1
-	let borders[semicolon] = "semicolon"
-endif
-if opencomm > -1
-	let borders[opencomm] = "opencomm"
-endif
-if closecomm > -1
-	let borders[closecomm] = "closecomm"
-endif
-if style > -1
-	let borders[style] = "style"
-endif
-if atrule > -1
-	let borders[atrule] = "atrule"
-endif
-if exclam > -1
-	let borders[exclam] = "exclam"
-endif
-
-
-if len(borders) == 0 || borders[max(keys(borders))] =~ '^\%(openbrace\|semicolon\|opencomm\|closecomm\|style\)$'
-	" Complete properties
+  if openbrace > -1
+    let borders[openbrace] = "openbrace"
+  endif
+  if closebrace > -1
+    let borders[closebrace] = "closebrace"
+  endif
+  if colon > -1
+    let borders[colon] = "colon"
+  endif
+  if semicolon > -1
+    let borders[semicolon] = "semicolon"
+  endif
+  if opencomm > -1
+    let borders[opencomm] = "opencomm"
+  endif
+  if closecomm > -1
+    let borders[closecomm] = "closecomm"
+  endif
+  if style > -1
+    let borders[style] = "style"
+  endif
+  if atrule > -1
+    let borders[atrule] = "atrule"
+  endif
+  if exclam > -1
+    let borders[exclam] = "exclam"
+  endif
 
 
-	let entered_property = matchstr(line, '.\{-}\zs[a-zA-Z-]*$')
+  if len(borders) == 0 || borders[max(keys(borders))] =~ '^\%(openbrace\|semicolon\|opencomm\|closecomm\|style\)$'
+    " Complete properties
 
-	for m in s:values
-		if m =~? '^'.entered_property
-			call add(res, m . ':')
-		elseif m =~? entered_property
-			call add(res2, m . ':')
-		endif
-	endfor
 
-	return res + res2
+    let entered_property = matchstr(line, '.\{-}\zs[a-zA-Z-]*$')
 
-elseif borders[max(keys(borders))] == 'colon'
-	" Get name of property
-	let prop = tolower(matchstr(line, '\zs[a-zA-Z-]*\ze\s*:[^:]\{-}$'))
+    for m in s:values
+      if m =~? '^'.entered_property
+        call add(res, m . ':')
+      elseif m =~? entered_property
+        call add(res2, m . ':')
+      endif
+    endfor
 
-	if prop == 'azimuth'
-		let values = ["left-side", "far-left", "left", "center-left", "center", "center-right", "right", "far-right", "right-side", "behind", "leftwards", "rightwards"]
-	elseif prop == 'background-attachment'
-		let values = ["scroll", "fixed"]
-	elseif prop == 'background-color'
-		let values = ["transparent", "rgb(", "#"]
-	elseif prop == 'background-image'
-		let values = ["url(", "none"]
-	elseif prop == 'background-position'
-		let vals = matchstr(line, '.*:\s*\zs.*')
-		if vals =~ '^\%([a-zA-Z]\+\)\?$'
-			let values = ["top", "center", "bottom"]
-		elseif vals =~ '^[a-zA-Z]\+\s\+\%([a-zA-Z]\+\)\?$'
-			let values = ["left", "center", "right"]
-		else
-			return []
-		endif
-	elseif prop == 'background-repeat'
-		let values = ["repeat", "repeat-x", "repeat-y", "no-repeat"]
-	elseif prop == 'background'
-		let values = ["url(", "scroll", "fixed", "transparent", "rgb(", "#", "none", "top", "center", "bottom" , "left", "right", "repeat", "repeat-x", "repeat-y", "no-repeat"]
-	elseif prop == 'border-collapse'
-		let values = ["collapse", "separate"]
-	elseif prop == 'border-color'
-		let values = ["rgb(", "#", "transparent"]
-	elseif prop == 'border-spacing'
-		return []
-	elseif prop == 'border-style'
-		let values = ["none", "hidden", "dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset"]
-	elseif prop =~ 'border-\%(top\|right\|bottom\|left\)$'
-		let vals = matchstr(line, '.*:\s*\zs.*')
-		if vals =~ '^\%([a-zA-Z0-9.]\+\)\?$'
-			let values = ["thin", "thick", "medium"]
-		elseif vals =~ '^[a-zA-Z0-9.]\+\s\+\%([a-zA-Z]\+\)\?$'
-			let values = ["none", "hidden", "dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset"]
-		elseif vals =~ '^[a-zA-Z0-9.]\+\s\+[a-zA-Z]\+\s\+\%([a-zA-Z(]\+\)\?$'
-			let values = ["rgb(", "#", "transparent"]
-		else
-			return []
-		endif
-	elseif prop =~ 'border-\%(top\|right\|bottom\|left\)-color'
-		let values = ["rgb(", "#", "transparent"]
-	elseif prop =~ 'border-\%(top\|right\|bottom\|left\)-style'
-		let values = ["none", "hidden", "dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset"]
-	elseif prop =~ 'border-\%(top\|right\|bottom\|left\)-width'
-		let values = ["thin", "thick", "medium"]
-	elseif prop == 'border-width'
-		let values = ["thin", "thick", "medium"]
-	elseif prop == 'border'
-		let vals = matchstr(line, '.*:\s*\zs.*')
-		if vals =~ '^\%([a-zA-Z0-9.]\+\)\?$'
-			let values = ["thin", "thick", "medium"]
-		elseif vals =~ '^[a-zA-Z0-9.]\+\s\+\%([a-zA-Z]\+\)\?$'
-			let values = ["none", "hidden", "dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset"]
-		elseif vals =~ '^[a-zA-Z0-9.]\+\s\+[a-zA-Z]\+\s\+\%([a-zA-Z(]\+\)\?$'
-			let values = ["rgb(", "#", "transparent"]
-		else
-			return []
-		endif
-	elseif prop == 'bottom'
-		let values = ["auto"]
-	elseif prop == 'caption-side'
-		let values = ["top", "bottom"]
-	elseif prop == 'clear'
-		let values = ["none", "left", "right", "both"]
-	elseif prop == 'clip'
-		let values = ["auto", "rect("]
-	elseif prop == 'color'
-		let values = ["rgb(", "#"]
-	elseif prop == 'content'
-		let values = ["normal", "attr(", "open-quote", "close-quote", "no-open-quote", "no-close-quote"]
-	elseif prop =~ 'counter-\%(increment\|reset\)$'
-		let values = ["none"]
-	elseif prop =~ '^\%(cue-after\|cue-before\|cue\)$'
-		let values = ["url(", "none"]
-	elseif prop == 'cursor'
-		let values = ["url(", "auto", "crosshair", "default", "pointer", "move", "e-resize", "ne-resize", "nw-resize", "n-resize", "se-resize", "sw-resize", "s-resize", "w-resize", "text", "wait", "help", "progress"]
-	elseif prop == 'direction'
-		let values = ["ltr", "rtl"]
-	elseif prop == 'display'
-		let values = ["inline", "block", "list-item", "run-in", "inline-block", "table", "inline-table", "table-row-group", "table-header-group", "table-footer-group", "table-row", "table-column-group", "table-column", "table-cell", "table-caption", "none"]
-	elseif prop == 'elevation'
-		let values = ["below", "level", "above", "higher", "lower"]
-	elseif prop == 'empty-cells'
-		let values = ["show", "hide"]
-	elseif prop == 'float'
-		let values = ["left", "right", "none"]
-	elseif prop == 'font-family'
-		let values = ["sans-serif", "serif", "monospace", "cursive", "fantasy"]
-	elseif prop == 'font-size'
-		 let values = ["xx-small", "x-small", "small", "medium", "large", "x-large", "xx-large", "larger", "smaller"]
-	elseif prop == 'font-style'
-		let values = ["normal", "italic", "oblique"]
-	elseif prop == 'font-variant'
-		let values = ["normal", "small-caps"]
-	elseif prop == 'font-weight'
-		let values = ["normal", "bold", "bolder", "lighter", "100", "200", "300", "400", "500", "600", "700", "800", "900"]
-	elseif prop == 'font'
-		let values = ["normal", "italic", "oblique", "small-caps", "bold", "bolder", "lighter", "100", "200", "300", "400", "500", "600", "700", "800", "900", "xx-small", "x-small", "small", "medium", "large", "x-large", "xx-large", "larger", "smaller", "sans-serif", "serif", "monospace", "cursive", "fantasy", "caption", "icon", "menu", "message-box", "small-caption", "status-bar"]
-	elseif prop =~ '^\%(height\|width\)$'
-		let values = ["auto"]
-	elseif prop =~ '^\%(left\|rigth\)$'
-		let values = ["auto"]
-	elseif prop == 'letter-spacing'
-		let values = ["normal"]
-	elseif prop == 'line-height'
-		let values = ["normal"]
-	elseif prop == 'list-style-image'
-		let values = ["url(", "none"]
-	elseif prop == 'list-style-position'
-		let values = ["inside", "outside"]
-	elseif prop == 'list-style-type'
-		let values = ["disc", "circle", "square", "decimal", "decimal-leading-zero", "lower-roman", "upper-roman", "lower-latin", "upper-latin", "none"]
-	elseif prop == 'list-style'
-		return []
-	elseif prop == 'margin'
-		let values = ["auto"]
-	elseif prop =~ 'margin-\%(right\|left\|top\|bottom\)$'
-		let values = ["auto"]
-	elseif prop == 'max-height'
-		let values = ["auto"]
-	elseif prop == 'max-width'
-		let values = ["none"]
-	elseif prop == 'min-height'
-		let values = ["none"]
-	elseif prop == 'min-width'
-		let values = ["none"]
-	elseif prop == 'orphans'
-		return []
-	elseif prop == 'outline-color'
-		let values = ["rgb(", "#"]
-	elseif prop == 'outline-style'
-		let values = ["none", "hidden", "dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset"]
-	elseif prop == 'outline-width'
-		let values = ["thin", "thick", "medium"]
-	elseif prop == 'outline'
-		let vals = matchstr(line, '.*:\s*\zs.*')
-		if vals =~ '^\%([a-zA-Z0-9,()#]\+\)\?$'
-			let values = ["rgb(", "#"]
-		elseif vals =~ '^[a-zA-Z0-9,()#]\+\s\+\%([a-zA-Z]\+\)\?$'
-			let values = ["none", "hidden", "dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset"]
-		elseif vals =~ '^[a-zA-Z0-9,()#]\+\s\+[a-zA-Z]\+\s\+\%([a-zA-Z(]\+\)\?$'
-			let values = ["thin", "thick", "medium"]
-		else
-			return []
-		endif
-	elseif prop == 'overflow'
-		let values = ["visible", "hidden", "scroll", "auto"]
-	elseif prop == 'padding'
-		return []
-	elseif prop =~ 'padding-\%(top\|right\|bottom\|left\)$'
-		return []
-	elseif prop =~ 'page-break-\%(after\|before\)$'
-		let values = ["auto", "always", "avoid", "left", "right"]
-	elseif prop == 'page-break-inside'
-		let values = ["auto", "avoid"]
-	elseif prop =~ 'pause-\%(after\|before\)$'
-		return []
-	elseif prop == 'pause'
-		return []
-	elseif prop == 'pitch-range'
-		return []
-	elseif prop == 'pitch'
-		let values = ["x-low", "low", "medium", "high", "x-high"]
-	elseif prop == 'play-during'
-		let values = ["url(", "mix", "repeat", "auto", "none"]
-	elseif prop == 'position'
-		let values = ["static", "relative", "absolute", "fixed"]
-	elseif prop == 'quotes'
-		let values = ["none"]
-	elseif prop == 'richness'
-		return []
-	elseif prop == 'speak-header'
-		let values = ["once", "always"]
-	elseif prop == 'speak-numeral'
-		let values = ["digits", "continuous"]
-	elseif prop == 'speak-punctuation'
-		let values = ["code", "none"]
-	elseif prop == 'speak'
-		let values = ["normal", "none", "spell-out"]
-	elseif prop == 'speech-rate'
-		let values = ["x-slow", "slow", "medium", "fast", "x-fast", "faster", "slower"]
-	elseif prop == 'stress'
-		return []
-	elseif prop == 'table-layout'
-		let values = ["auto", "fixed"]
-	elseif prop == 'text-align'
-		let values = ["left", "right", "center", "justify"]
-	elseif prop == 'text-decoration'
-		let values = ["none", "underline", "overline", "line-through", "blink"]
-	elseif prop == 'text-indent'
-		return []
-	elseif prop == 'text-transform'
-		let values = ["capitalize", "uppercase", "lowercase", "none"]
-	elseif prop == 'top'
-		let values = ["auto"]
-	elseif prop == 'unicode-bidi'
-		let values = ["normal", "embed", "bidi-override"]
-	elseif prop == 'vertical-align'
-		let values = ["baseline", "sub", "super", "top", "text-top", "middle", "bottom", "text-bottom"]
-	elseif prop == 'visibility'
-		let values = ["visible", "hidden", "collapse"]
-	elseif prop == 'voice-family'
-		return []
-	elseif prop == 'volume'
-		let values = ["silent", "x-soft", "soft", "medium", "loud", "x-loud"]
-	elseif prop == 'white-space'
-		let values = ["normal", "pre", "nowrap", "pre-wrap", "pre-line"]
-	elseif prop == 'widows'
-		return []
-	elseif prop == 'word-spacing'
-		let values = ["normal"]
-	elseif prop == 'z-index'
-		let values = ["auto"]
-	else
-		" If no property match it is possible we are outside of {} and
-		" trying to complete pseudo-(class|element)
-		let element = tolower(matchstr(line, '\zs[a-zA-Z1-6]*\ze:[^:[:space:]]\{-}$'))
-		if stridx(',a,abbr,acronym,address,area,b,base,bdo,big,blockquote,body,br,button,caption,cite,code,col,colgroup,dd,del,dfn,div,dl,dt,em,fieldset,form,head,h1,h2,h3,h4,h5,h6,hr,html,i,img,input,ins,kbd,label,legend,li,link,map,meta,noscript,object,ol,optgroup,option,p,param,pre,q,samp,script,select,small,span,strong,style,sub,sup,table,tbody,td,textarea,tfoot,th,thead,title,tr,tt,ul,var,', ','.element.',') > -1
-			let values = ["first-child", "link", "visited", "hover", "active", "focus", "lang", "first-line", "first-letter", "before", "after"]
-		else
-			return []
-		endif
-	endif
+    return res + res2
 
-	" Complete values
-	let entered_value = matchstr(line, '.\{-}\zs[a-zA-Z0-9#,.(_-]*$')
+  elseif borders[max(keys(borders))] == 'colon'
+    " Get name of property
+    let prop = tolower(matchstr(line, '\zs[a-zA-Z-]*\ze\s*:[^:]\{-}$'))
 
-	for m in values
-		if m =~? '^'.entered_value
-			call add(res, m)
-		elseif m =~? entered_value
-			call add(res2, m)
-		endif
-	endfor
+    let wide_keywords = ["initial", "inherit", "unset"]
+    let color_values = ["transparent", "rgb(", "rgba(", "hsl(", "hsla(", "#"]
+    let border_style_values = ["none", "hidden", "dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset"]
+    let border_width_values = ["thin", "thick", "medium"]
+    let list_style_type_values = ["decimal", "decimal-leading-zero", "arabic-indic", "armenian", "upper-armenian", "lower-armenian", "bengali", "cambodian", "khmer", "cjk-decimal", "devanagari", "georgian", "gujarati", "gurmukhi", "hebrew", "kannada", "lao", "malayalam", "mongolian", "myanmar", "oriya", "persian", "lower-roman", "upper-roman", "tamil", "telugu", "thai", "tibetan", "lower-alpha", "lower-latin", "upper-alpha", "upper-latin", "cjk-earthly-branch", "cjk-heavenly-stem", "lower-greek", "hiragana", "hiragana-iroha", "katakana", "katakana-iroha", "disc", "circle", "square", "disclosure-open", "disclosure-closed"]
+    let timing_functions = ["cubic-bezier(", "steps(", "linear", "ease", "ease-in", "ease-in-out", "ease-out", "step-start", "step-end"]
 
-	return res + res2
+    if prop == 'all'
+      let values = []
+    elseif prop == 'additive-symbols'
+      let values = []
+    elseif prop == 'align-content'
+      let values = ["flex-start", "flex-end", "center", "space-between", "space-around", "stretch"]
+    elseif prop == 'align-items'
+      let values = ["flex-start", "flex-end", "center", "baseline", "stretch"]
+    elseif prop == 'align-self'
+      let values = ["auto", "flex-start", "flex-end", "center", "baseline", "stretch"]
+    elseif prop == 'animation'
+      let values = timing_functions + ["normal", "reverse", "alternate", "alternate-reverse"] + ["none", "forwards", "backwards", "both"] + ["running", "paused"]
+    elseif prop == 'animation-delay'
+      let values = []
+    elseif prop == 'animation-direction'
+      let values = ["normal", "reverse", "alternate", "alternate-reverse"]
+    elseif prop == 'animation-duration'
+      let values = []
+    elseif prop == 'animation-fill-mode'
+      let values = ["none", "forwards", "backwards", "both"]
+    elseif prop == 'animation-iteration-count'
+      let values = []
+    elseif prop == 'animation-name'
+      let values = []
+    elseif prop == 'animation-play-state'
+      let values = ["running", "paused"]
+    elseif prop == 'animation-timing-function'
+      let values = timing_functions
+    elseif prop == 'background-attachment'
+      let values = ["scroll", "fixed"]
+    elseif prop == 'background-color'
+      let values = color_values
+    elseif prop == 'background-image'
+      let values = ["url(", "none"]
+    elseif prop == 'background-position'
+      let vals = matchstr(line, '.*:\s*\zs.*')
+      if vals =~ '^\%([a-zA-Z]\+\)\?$'
+        let values = ["top", "center", "bottom"]
+      elseif vals =~ '^[a-zA-Z]\+\s\+\%([a-zA-Z]\+\)\?$'
+        let values = ["left", "center", "right"]
+      else
+        return []
+      endif
+    elseif prop == 'background-repeat'
+      let values = ["repeat", "repeat-x", "repeat-y", "no-repeat"]
+    elseif prop == 'background-size'
+      let values = ["auto", "contain", "cover"]
+    elseif prop == 'background'
+      let values = ["scroll", "fixed"] + color_values + ["url(", "none"] + ["top", "center", "bottom", "left", "right"] + ["repeat", "repeat-x", "repeat-y", "no-repeat"] + ["auto", "contain", "cover"]
+    elseif prop =~ 'border\%(-top\|-right\|-bottom\|-left\|-block-start\|-block-end\)\?$'
+      let vals = matchstr(line, '.*:\s*\zs.*')
+      if vals =~ '^\%([a-zA-Z0-9.]\+\)\?$'
+        let values = border_width_values
+      elseif vals =~ '^[a-zA-Z0-9.]\+\s\+\%([a-zA-Z]\+\)\?$'
+        let values = border_style_values
+      elseif vals =~ '^[a-zA-Z0-9.]\+\s\+[a-zA-Z]\+\s\+\%([a-zA-Z(]\+\)\?$'
+        let values = color_values
+      else
+        return []
+      endif
+    elseif prop =~ 'border-\%(top\|right\|bottom\|left\|block-start\|block-end\)-color'
+      let values = color_values
+    elseif prop =~ 'border-\%(top\|right\|bottom\|left\|block-start\|block-end\)-style'
+      let values = border_style_values
+    elseif prop =~ 'border-\%(top\|right\|bottom\|left\|block-start\|block-end\)-width'
+      let values = border_width_values
+    elseif prop == 'border-color'
+      let values = color_values
+    elseif prop == 'border-style'
+      let values = border_style_values
+    elseif prop == 'border-width'
+      let values = border_width_values
+    elseif prop == 'bottom'
+      let values = ["auto"]
+    elseif prop == 'box-decoration-break'
+      let values = ["slice", "clone"]
+    elseif prop == 'box-shadow'
+      let values = ["inset"]
+    elseif prop == 'box-sizing'
+      let values = ["border-box", "content-box"]
+    elseif prop =~ 'break-\%(before\|after\)'
+      let values = ["auto", "always", "avoid", "left", "right", "page", "column", "region", "recto", "verso", "avoid-page", "avoid-column", "avoid-region"]
+    elseif prop == 'break-inside'
+      let values = ["auto", "avoid", "avoid-page", "avoid-column", "avoid-region"]
+    elseif prop == 'caption-side'
+      let values = ["top", "bottom"]
+    elseif prop == 'clear'
+      let values = ["none", "left", "right", "both"]
+    elseif prop == 'clip'
+      let values = ["auto", "rect("]
+    elseif prop == 'clip-path'
+      let values = ["fill-box", "stroke-box", "view-box", "none"]
+    elseif prop == 'color'
+      let values = color_values
+    elseif prop == 'columns'
+      let values = []
+    elseif prop == 'column-count'
+      let values = ['auto']
+    elseif prop == 'column-fill'
+      let values = ['auto', 'balance']
+    elseif prop == 'column-rule-color'
+      let values = color_values
+    elseif prop == 'column-rule-style'
+      let values = border_style_values
+    elseif prop == 'column-rule-width'
+      let values = border_width_values
+    elseif prop == 'column-rule'
+      let vals = matchstr(line, '.*:\s*\zs.*')
+      if vals =~ '^\%([a-zA-Z0-9.]\+\)\?$'
+        let values = border_width_values
+      elseif vals =~ '^[a-zA-Z0-9.]\+\s\+\%([a-zA-Z]\+\)\?$'
+        let values = border_style_values
+      elseif vals =~ '^[a-zA-Z0-9.]\+\s\+[a-zA-Z]\+\s\+\%([a-zA-Z(]\+\)\?$'
+        let values = color_values
+      else
+        return []
+      endif
+    elseif prop == 'column-span'
+      let values = ["none", "all"]
+    elseif prop == 'column-width'
+      let values = ["auto"]
+    elseif prop == 'content'
+      let values = ["normal", "attr(", "open-quote", "close-quote", "no-open-quote", "no-close-quote"]
+    elseif prop =~ 'counter-\%(increment\|reset\)$'
+      let values = ["none"]
+    elseif prop =~ 'cue\%(-after\|-before\)\=$'
+      let values = ["url("]
+    elseif prop == 'cursor'
+      let values = ["url(", "auto", "crosshair", "default", "pointer", "move", "e-resize", "ne-resize", "nw-resize", "n-resize", "se-resize", "sw-resize", "s-resize", "w-resize", "text", "wait", "help", "progress"]
+    elseif prop == 'direction'
+      let values = ["ltr", "rtl"]
+    elseif prop == 'display'
+      let values = ["inline", "block", "list-item", "inline-list-item", "run-in", "inline-block", "table", "inline-table", "table-row-group", "table-header-group", "table-footer-group", "table-row", "table-column-group", "table-column", "table-cell", "table-caption", "none", "flex", "inline-flex", "grid", "inline-grid", "ruby", "ruby-base", "ruby-text", "ruby-base-container", "ruby-text-container", "contents"]
+    elseif prop == 'elevation'
+      let values = ["below", "level", "above", "higher", "lower"]
+    elseif prop == 'empty-cells'
+      let values = ["show", "hide"]
+    elseif prop == 'fallback'
+      let values = list_style_type_values
+    elseif prop == 'filter'
+      let values = ["blur(", "brightness(", "contrast(", "drop-shadow(", "grayscale(", "hue-rotate(", "invert(", "opacity(", "sepia(", "saturate("]
+    elseif prop == 'flex-basis'
+      let values = ["auto", "content"]
+    elseif prop == 'flex-flow'
+      let values = ["row", "row-reverse", "column", "column-reverse", "nowrap", "wrap", "wrap-reverse"]
+    elseif prop == 'flex-grow'
+      let values = []
+    elseif prop == 'flex-shrink'
+      let values = []
+    elseif prop == 'flex-wrap'
+      let values = ["nowrap", "wrap", "wrap-reverse"]
+    elseif prop == 'flex'
+      let values = ["nowrap", "wrap", "wrap-reverse"] + ["row", "row-reverse", "column", "column-reverse", "nowrap", "wrap", "wrap-reverse"] + ["auto", "content"]
+    elseif prop == 'float'
+      let values = ["left", "right", "none"]
+    elseif prop == 'font-family'
+      let values = ["sans-serif", "serif", "monospace", "cursive", "fantasy"]
+    elseif prop == 'font-feature-settings'
+      let values = ["normal", '"aalt"', '"abvf"', '"abvm"', '"abvs"', '"afrc"', '"akhn"', '"blwf"', '"blwm"', '"blws"', '"calt"', '"case"', '"ccmp"', '"cfar"', '"cjct"', '"clig"', '"cpct"', '"cpsp"', '"cswh"', '"curs"', '"cv', '"c2pc"', '"c2sc"', '"dist"', '"dlig"', '"dnom"', '"dtls"', '"expt"', '"falt"', '"fin2"', '"fin3"', '"fina"', '"flac"', '"frac"', '"fwid"', '"half"', '"haln"', '"halt"', '"hist"', '"hkna"', '"hlig"', '"hngl"', '"hojo"', '"hwid"', '"init"', '"isol"', '"ital"', '"jalt"', '"jp78"', '"jp83"', '"jp90"', '"jp04"', '"kern"', '"lfbd"', '"liga"', '"ljmo"', '"lnum"', '"locl"', '"ltra"', '"ltrm"', '"mark"', '"med2"', '"medi"', '"mgrk"', '"mkmk"', '"mset"', '"nalt"', '"nlck"', '"nukt"', '"numr"', '"onum"', '"opbd"', '"ordn"', '"ornm"', '"palt"', '"pcap"', '"pkna"', '"pnum"', '"pref"', '"pres"', '"pstf"', '"psts"', '"pwid"', '"qwid"', '"rand"', '"rclt"', '"rkrf"', '"rlig"', '"rphf"', '"rtbd"', '"rtla"', '"rtlm"', '"ruby"', '"salt"', '"sinf"', '"size"', '"smcp"', '"smpl"', '"ss01"', '"ss02"', '"ss03"', '"ss04"', '"ss05"', '"ss06"', '"ss07"', '"ss08"', '"ss09"', '"ss10"', '"ss11"', '"ss12"', '"ss13"', '"ss14"', '"ss15"', '"ss16"', '"ss17"', '"ss18"', '"ss19"', '"ss20"', '"ssty"', '"stch"', '"subs"', '"sups"', '"swsh"', '"titl"', '"tjmo"', '"tnam"', '"tnum"', '"trad"', '"twid"', '"unic"', '"valt"', '"vatu"', '"vert"', '"vhal"', '"vjmo"', '"vkna"', '"vkrn"', '"vpal"', '"vrt2"', '"zero"']
+    elseif prop == 'font-kerning'
+      let values = ["auto", "normal", "none"]
+    elseif prop == 'font-language-override'
+      let values = ["normal"]
+    elseif prop == 'font-size'
+      let values = ["xx-small", "x-small", "small", "medium", "large", "x-large", "xx-large", "larger", "smaller"]
+    elseif prop == 'font-size-adjust'
+      let values = []
+    elseif prop == 'font-stretch'
+      let values = ["normal", "ultra-condensed", "extra-condensed", "condensed", "semi-condensed", "semi-expanded", "expanded", "extra-expanded", "ultra-expanded"]
+    elseif prop == 'font-style'
+      let values = ["normal", "italic", "oblique"]
+    elseif prop == 'font-synthesis'
+      let values = ["none", "weight", "style"]
+    elseif prop == 'font-variant-alternates'
+      let values = ["normal", "historical-forms", "stylistic(", "styleset(", "character-variant(", "swash(", "ornaments(", "annotation("]
+    elseif prop == 'font-variant-caps'
+      let values = ["normal", "small-caps", "all-small-caps", "petite-caps", "all-petite-caps", "unicase", "titling-caps"]
+    elseif prop == 'font-variant-asian'
+      let values = ["normal", "ruby", "jis78", "jis83", "jis90", "jis04", "simplified", "traditional"]
+    elseif prop == 'font-variant-ligatures'
+      let values = ["normal", "none", "common-ligatures", "no-common-ligatures", "discretionary-ligatures", "no-discretionary-ligatures", "historical-ligatures", "no-historical-ligatures", "contextual", "no-contextual"]
+    elseif prop == 'font-variant-numeric'
+      let values = ["normal", "ordinal", "slashed-zero", "lining-nums", "oldstyle-nums", "proportional-nums", "tabular-nums", "diagonal-fractions", "stacked-fractions"]
+    elseif prop == 'font-variant-position'
+      let values = ["normal", "sub", "super"]
+    elseif prop == 'font-variant'
+      let values = ["normal", "historical-forms", "stylistic(", "styleset(", "character-variant(", "swash(", "ornaments(", "annotation("] + ["small-caps", "all-small-caps", "petite-caps", "all-petite-caps", "unicase", "titling-caps"] + ["ruby", "jis78", "jis83", "jis90", "jis04", "simplified", "traditional"] + ["none", "common-ligatures", "no-common-ligatures", "discretionary-ligatures", "no-discretionary-ligatures", "historical-ligatures", "no-historical-ligatures", "contextual", "no-contextual"] + ["ordinal", "slashed-zero", "lining-nums", "oldstyle-nums", "proportional-nums", "tabular-nums", "diagonal-fractions", "stacked-fractions"] + ["sub", "super"]
+    elseif prop == 'font-weight'
+      let values = ["normal", "bold", "bolder", "lighter", "100", "200", "300", "400", "500", "600", "700", "800", "900"]
+    elseif prop == 'font'
+      let values = ["normal", "italic", "oblique", "small-caps", "bold", "bolder", "lighter", "100", "200", "300", "400", "500", "600", "700", "800", "900", "xx-small", "x-small", "small", "medium", "large", "x-large", "xx-large", "larger", "smaller", "sans-serif", "serif", "monospace", "cursive", "fantasy", "caption", "icon", "menu", "message-box", "small-caption", "status-bar"]
+    elseif prop =~ '^\%(height\|width\)$'
+      let values = ["auto", "border-box", "content-box", "max-content", "min-content", "available", "fit-content"]
+    elseif prop =~ '^\%(left\|rigth\)$'
+      let values = ["auto"]
+    elseif prop == 'image-rendering'
+      let values = ["auto", "crisp-edges", "pixelated"]
+    elseif prop == 'image-orientation'
+      let values = ["from-image", "flip"]
+    elseif prop == 'ime-mode'
+      let values = ["auto", "normal", "active", "inactive", "disabled"]
+    elseif prop == 'inline-size'
+      let values = ["auto", "border-box", "content-box", "max-content", "min-content", "available", "fit-content"]
+    elseif prop == 'isolation'
+      let values = ["auto", "isolate"]
+    elseif prop == 'justify-content'
+      let values = ["flex-start", "flex-end", "center", "space-between", "space-around"]
+    elseif prop == 'letter-spacing'
+      let values = ["normal"]
+    elseif prop == 'line-break'
+      let values = ["auto", "loose", "normal", "strict"]
+    elseif prop == 'line-height'
+      let values = ["normal"]
+    elseif prop == 'list-style-image'
+      let values = ["url(", "none"]
+    elseif prop == 'list-style-position'
+      let values = ["inside", "outside"]
+    elseif prop == 'list-style-type'
+      let values = list_style_type_values
+    elseif prop == 'list-style'
+      let values = list_style_type_values + ["inside", "outside"] + ["url(", "none"]
+    elseif prop == 'margin'
+      let values = ["auto"]
+    elseif prop =~ 'margin-\%(right\|left\|top\|bottom\|block-start\|block-end\|inline-start\|inline-end\)$'
+      let values = ["auto"]
+    elseif prop == 'marks'
+      let values = ["crop", "cross", "none"]
+    elseif prop == 'mask'
+      let values = ["url("]
+    elseif prop == 'mask-type'
+      let values = ["luminance", "alpha"]
+    elseif prop == '\%(max\|min\)-\%(block\|inline\)-size'
+      let values = ["auto", "border-box", "content-box", "max-content", "min-content", "available", "fit-content"]
+    elseif prop == '\%(max\|min\)-\%(height\|width\)'
+      let values = ["auto", "border-box", "content-box", "max-content", "min-content", "available", "fit-content"]
+    elseif prop == '\%(max\|min\)-zoom'
+      let values = ["auto"]
+    elseif prop == 'mix-blend-mode'
+      let values = ["normal", "multiply", "screen", "overlay", "darken", "lighten", "color-dodge", "color-burn", "hard-light", "soft-light", "difference", "exclusion", "hue", "saturation", "color", "luminosity"]
+    elseif prop == 'opacity'
+      let values = []
+    elseif prop == 'orientation'
+      let values = ["auto", "portrait", "landscape"]
+    elseif prop == 'orphans'
+      let values = []
+    elseif prop == 'outline-offset'
+      let values = []
+    elseif prop == 'outline-color'
+      let values = color_values
+    elseif prop == 'outline-style'
+      let values = ["none", "hidden", "dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset"]
+    elseif prop == 'outline-width'
+      let values = ["thin", "thick", "medium"]
+    elseif prop == 'outline'
+      let vals = matchstr(line, '.*:\s*\zs.*')
+      if vals =~ '^\%([a-zA-Z0-9,()#]\+\)\?$'
+        let values = color_values
+      elseif vals =~ '^[a-zA-Z0-9,()#]\+\s\+\%([a-zA-Z]\+\)\?$'
+        let values = ["none", "hidden", "dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset"]
+      elseif vals =~ '^[a-zA-Z0-9,()#]\+\s\+[a-zA-Z]\+\s\+\%([a-zA-Z(]\+\)\?$'
+        let values = ["thin", "thick", "medium"]
+      else
+        return []
+      endif
+    elseif prop == 'overflow-wrap'
+      let values = ["normal", "break-word"]
+    elseif prop =~ 'overflow\%(-x\|-y\)\='
+      let values = ["visible", "hidden", "scroll", "auto"]
+    elseif prop == 'pad'
+      let values = []
+    elseif prop == 'padding'
+      let values = []
+    elseif prop =~ 'padding-\%(top\|right\|bottom\|left\|inline-start\|inline-end\|block-start\|block-end\)$'
+      let values = []
+    elseif prop =~ 'page-break-\%(after\|before\)$'
+      let values = ["auto", "always", "avoid", "left", "right", "recto", "verso"]
+    elseif prop == 'page-break-inside'
+      let values = ["auto", "avoid"]
+    elseif prop =~ 'pause\%(-after\|-before\)\=$'
+      let values = ["none", "x-weak", "weak", "medium", "strong", "x-strong"]
+    elseif prop == 'perspective'
+      let values = ["none"]
+    elseif prop == 'perspective-origin'
+      let values = ["top", "bottom", "left", "center", " right"]
+    elseif prop == 'pointer-events'
+      let values = ["auto", "none", "visiblePainted", "visibleFill", "visibleStroke", "visible", "painted", "fill", "stroke", "all"]
+    elseif prop == 'position'
+      let values = ["static", "relative", "absolute", "fixed", "sticky"]
+    elseif prop == 'prefix'
+      let values = []
+    elseif prop == 'quotes'
+      let values = ["none"]
+    elseif prop == 'range'
+      let values = ["auto", "infinite"]
+    elseif prop == 'resize'
+      let values = ["none", "both", "horizontal", "vertical"]
+    elseif prop =~ 'rest\%(-after\|-before\)\=$'
+      let values = ["none", "x-weak", "weak", "medium", "strong", "x-strong"]
+    elseif prop == 'ruby-align'
+      let values = ["start", "center", "space-between", "space-around"]
+    elseif prop == 'ruby-merge'
+      let values = ["separate", "collapse", "auto"]
+    elseif prop == 'ruby-position'
+      let values = ["over", "under", "inter-character"]
+    elseif prop == 'scroll-behavior'
+      let values = ["auto", "smooth"]
+    elseif prop == 'scroll-snap-coordinate'
+      let values = ["none"]
+    elseif prop == 'scroll-snap-destination'
+      return []
+    elseif prop == 'scroll-snap-points-\%(x\|y\)$'
+      let values = ["none", "repeat("]
+    elseif prop == 'scroll-snap-type\%(-x\|-y\)\=$'
+      let values = ["none", "mandatory", "proximity"]
+    elseif prop == 'shape-image-threshold'
+      let values = []
+    elseif prop == 'shape-margin'
+      let values = []
+    elseif prop == 'shape-outside'
+      let values = ["margin-box", "border-box", "padding-box", "content-box", 'inset(', 'circle(', 'ellipse(', 'polygon(', 'url(']
+    elseif prop == 'speak'
+      let values = ["auto", "none", "normal"]
+    elseif prop == 'speak-as'
+      let values = ["auto", "normal", "spell-out", "digits"]
+    elseif prop == 'src'
+      let values = ["url("]
+    elseif prop == 'suffix'
+      let values = []
+    elseif prop == 'symbols'
+      let values = []
+    elseif prop == 'system'
+      let vals = matchstr(line, '.*:\s*\zs.*')
+      if vals =~ '^extends'
+        let values = list_style_type_values
+      else
+        let values = ["cyclic", "numeric", "alphabetic", "symbolic", "additive", "fixed", "extends"]
+      endif
+    elseif prop == 'table-layout'
+      let values = ["auto", "fixed"]
+    elseif prop == 'tab-size'
+      let values = []
+    elseif prop == 'text-align'
+      let values = ["start", "end", "left", "right", "center", "justify", "match-parent"]
+    elseif prop == 'text-align-last'
+      let values = ["auto", "start", "end", "left", "right", "center", "justify"]
+    elseif prop == 'text-combine-upright'
+      let values = ["none", "all", "digits"]
+    elseif prop == 'text-decoration-line'
+      let values = ["none", "underline", "overline", "line-through", "blink"]
+    elseif prop == 'text-decoration-color'
+      let values = color_values
+    elseif prop == 'text-decoration-style'
+      let values = ["solid", "double", "dotted", "dashed", "wavy"]
+    elseif prop == 'text-decoration'
+      let values = ["none", "underline", "overline", "line-through", "blink"] + ["solid", "double", "dotted", "dashed", "wavy"] + color_values
+    elseif prop == 'text-emphasis-color'
+      let values = color_values
+    elseif prop == 'text-emphasis-position'
+      let values = ["over", "under", "left", "right"]
+    elseif prop == 'text-emphasis-style'
+      let values = ["none", "filled", "open", "dot", "circle", "double-circle", "triangle", "sesame"]
+    elseif prop == 'text-emphasis'
+      let values = color_values + ["over", "under", "left", "right"] + ["none", "filled", "open", "dot", "circle", "double-circle", "triangle", "sesame"]
+    elseif prop == 'text-indent'
+      let values = ["hanging", "each-line"]
+    elseif prop == 'text-orientation'
+      let values = ["mixed", "upright", "sideways", "sideways-right", "use-glyph-orientation"]
+    elseif prop == 'text-overflow'
+      let values = ["clip", "ellipsis"]
+    elseif prop == 'text-rendering'
+      let values = ["auto", "optimizeSpeed", "optimizeLegibility", "geometricPrecision"]
+    elseif prop == 'text-shadow'
+      let values = color_values
+    elseif prop == 'text-transform'
+      let values = ["capitalize", "uppercase", "lowercase", "full-width", "none"]
+    elseif prop == 'text-underline-position'
+      let values = ["auto", "under", "left", "right"]
+    elseif prop == 'touch-action'
+      let values = ["auto", "none", "pan-x", "pan-y", "manipulation", "pan-left", "pan-right", "pan-top", "pan-down"]
+    elseif prop == 'transform'
+      let values = ["matrix(", "translate(", "translateX(", "translateY(", "scale(", "scaleX(", "scaleY(", "rotate(", "skew(", "skewX(", "skewY(", "matrix3d(", "translate3d(", "translateZ(", "scale3d(", "scaleZ(", "rotate3d(", "rotateX(", "rotateY(", "rotateZ(", "perspective("]
+    elseif prop == 'transform-box'
+      let values = ["border-box", "fill-box", "view-box"]
+    elseif prop == 'transform-origin'
+      let values = ["left", "center", "right", "top", "bottom"]
+    elseif prop == 'transform-style'
+      let values = ["flat", "preserve-3d"]
+    elseif prop == 'top'
+      let values = ["auto"]
+    elseif prop == 'transition-property'
+      let values = ["all", "none"] + s:values
+    elseif prop == 'transition-duration'
+      let values = []
+    elseif prop == 'transition-delay'
+      let values = []
+    elseif prop == 'transition-timing-function'
+      let values = timing_functions
+    elseif prop == 'transition'
+      let values = ["all", "none"] + s:values + timing_functions
+    elseif prop == 'unicode-bidi'
+      let values = ["normal", "embed", "isolate", "bidi-override", "isolate-override", "plaintext"]
+    elseif prop == 'unicode-range'
+      let values = ["U+"]
+    elseif prop == 'user-zoom'
+      let values = ["zoom", "fixed"]
+    elseif prop == 'vertical-align'
+      let values = ["baseline", "sub", "super", "top", "text-top", "middle", "bottom", "text-bottom"]
+    elseif prop == 'visibility'
+      let values = ["visible", "hidden", "collapse"]
+    elseif prop == 'voice-volume'
+      let values = ["silent", "x-soft", "soft", "medium", "loud", "x-loud"]
+    elseif prop == 'voice-balance'
+      let values = ["left", "center", "right", "leftwards", "rightwards"]
+    elseif prop == 'voice-family'
+      let values = []
+    elseif prop == 'voice-rate'
+      let values = ["normal", "x-slow", "slow", "medium", "fast", "x-fast"]
+    elseif prop == 'voice-pitch'
+      let values = ["absolute", "x-low", "low", "medium", "high", "x-high"]
+    elseif prop == 'voice-range'
+      let values = ["absolute", "x-low", "low", "medium", "high", "x-high"]
+    elseif prop == 'voice-stress'
+      let values = ["normal", "strong", "moderate", "none", "reduced "]
+    elseif prop == 'voice-duration'
+      let values = ["auto"]
+    elseif prop == 'white-space'
+      let values = ["normal", "pre", "nowrap", "pre-wrap", "pre-line"]
+    elseif prop == 'widows'
+      let values = []
+    elseif prop == 'will-change'
+      let values = ["auto", "scroll-position", "contents"] + s:values
+    elseif prop == 'word-break'
+      let values = ["normal", "break-all", "keep-all"]
+    elseif prop == 'word-spacing'
+      let values = ["normal"]
+    elseif prop == 'word-wrap'
+      let values = ["normal", "break-word"]
+    elseif prop == 'writing-mode'
+      let values = ["horizontal-tb", "vertical-rl", "vertical-lr", "sideways-rl", "sideways-lr"]
+    elseif prop == 'z-index'
+      let values = ["auto"]
+    elseif prop == 'zoom'
+      let values = ["auto"]
+    else
+      " If no property match it is possible we are outside of {} and
+      " trying to complete pseudo-(class|element)
+      let element = tolower(matchstr(line, '\zs[a-zA-Z1-6]*\ze:[^:[:space:]]\{-}$'))
+      if stridx('a,abbr,address,area,article,aside,audio,b,base,bdi,bdo,bgsound,blockquote,body,br,button,canvas,caption,center,cite,code,col,colgroup,command,content,data,datalist,dd,del,details,dfn,dialog,div,dl,dt,element,em,embed,fieldset,figcaption,figure,font,footer,form,frame,frameset,head,header,hgroup,hr,html,i,iframe,image,img,input,ins,isindex,kbd,keygen,label,legend,li,link,main,map,mark,menu,menuitem,meta,meter,nav,nobr,noframes,noscript,object,ol,optgroup,option,output,p,param,picture,pre,progress,q,rp,rt,rtc,ruby,s,samp,script,section,select,shadow,small,source,span,strong,style,sub,summary,sup,table,tbody,td,template,textarea,tfoot,th,thead,time,title,tr,track,u,ul,var,video,wbr', ','.element.',') > -1
+        let values = ["active", "any", "checked", "default", "dir(", "disabled", "empty", "enabled", "first", "first-child", "first-of-type", "fullscreen", "focus", "hover", "indeterminate", "in-range", "invalid", "lang(", "last-child", "last-of-type", "left", "link", "not(", "nth-child(", "nth-last-child(", "nth-last-of-type(", "nth-of-type(", "only-child", "only-of-type", "optional", "out-of-range", "read-only", "read-write", "required", "right", "root", "scope", "target", "valid", "visited", "first-line", "first-letter", "before", "after", "selection", "backdrop"]
+      else
+        return []
+      endif
+    endif
 
-elseif borders[max(keys(borders))] == 'closebrace'
+    let values = wide_keywords + values
+    " Complete values
+    let entered_value = matchstr(line, '.\{-}\zs[a-zA-Z0-9#,.(_-]*$')
 
-	return []
+    for m in values
+      if m =~? '^'.entered_value
+        call add(res, m)
+      elseif m =~? entered_value
+        call add(res2, m)
+      endif
+    endfor
 
-elseif borders[max(keys(borders))] == 'exclam'
+    return res + res2
 
-	" Complete values
-	let entered_imp = matchstr(line, '.\{-}!\s*\zs[a-zA-Z ]*$')
+  elseif borders[max(keys(borders))] == 'closebrace'
 
-	let values = ["important"]
+    return []
 
-	for m in values
-		if m =~? '^'.entered_imp
-			call add(res, m)
-		endif
-	endfor
+  elseif borders[max(keys(borders))] == 'exclam'
 
-	return res
+    " Complete values
+    let entered_imp = matchstr(line, '.\{-}!\s*\zs[a-zA-Z ]*$')
 
-elseif borders[max(keys(borders))] == 'atrule'
+    let values = ["important"]
 
-	let afterat = matchstr(line, '.*@\zs.*')
+    for m in values
+      if m =~? '^'.entered_imp
+        call add(res, m)
+      endif
+    endfor
 
-	if afterat =~ '\s'
+    return res
 
-		let atrulename = matchstr(line, '.*@\zs[a-zA-Z-]\+\ze')
+  elseif borders[max(keys(borders))] == 'atrule'
 
-		if atrulename == 'media'
-			let values = ["screen", "tty", "tv", "projection", "handheld", "print", "braille", "aural", "all"]
+    let afterat = matchstr(line, '.*@\zs.*')
 
-			let entered_atruleafter = matchstr(line, '.*@media\s\+\zs.*$')
+    if afterat =~ '\s'
 
-		elseif atrulename == 'import'
-			let entered_atruleafter = matchstr(line, '.*@import\s\+\zs.*$')
+      let atrulename = matchstr(line, '.*@\zs[a-zA-Z-]\+\ze')
 
-			if entered_atruleafter =~ "^[\"']"
-				let filestart = matchstr(entered_atruleafter, '^.\zs.*')
-				let files = split(glob(filestart.'*'), '\n')
-				let values = map(copy(files), '"\"".v:val')
+      if atrulename == 'media'
+        let entered_atruleafter = matchstr(line, '.*@media\s\+\zs.*$')
 
-			elseif entered_atruleafter =~ "^url("
-				let filestart = matchstr(entered_atruleafter, "^url([\"']\\?\\zs.*")
-				let files = split(glob(filestart.'*'), '\n')
-				let values = map(copy(files), '"url(".v:val')
-				
-			else
-				let values = ['"', 'url(']
+        if entered_atruleafter =~ "([^)]*$"
+          let entered_atruleafter = matchstr(entered_atruleafter, '(\s*\zs[^)]*$')
+          let values = ["max-width", "min-width", "width", "max-height", "min-height", "height", "max-aspect-ration", "min-aspect-ration", "aspect-ratio", "orientation", "max-resolution", "min-resolution", "resolution", "scan", "grid", "update-frequency", "overflow-block", "overflow-inline", "max-color", "min-color", "color", "max-color-index", "min-color-index", "color-index", "monochrome", "inverted-colors", "pointer", "hover", "any-pointer", "any-hover", "light-level", "scripting"]
+        else
+          let values = ["screen", "print", "speech", "all", "not", "and", "("]
+        endif
 
-			endif
+      elseif atrulename == 'supports'
+        let entered_atruleafter = matchstr(line, '.*@supports\s\+\zs.*$')
 
-		else
-			return []
+        if entered_atruleafter =~ "([^)]*$"
+          let entered_atruleafter = matchstr(entered_atruleafter, '(\s*\zs.*$')
+          let values = s:values
+        else
+          let values = ["("]
+        endif
 
-		endif
+      elseif atrulename == 'charset'
+        let entered_atruleafter = matchstr(line, '.*@charset\s\+\zs.*$')
+        let values = [
+          \ '"UTF-8";', '"ANSI_X3.4-1968";', '"ISO_8859-1:1987";', '"ISO_8859-2:1987";', '"ISO_8859-3:1988";', '"ISO_8859-4:1988";', '"ISO_8859-5:1988";', 
+          \ '"ISO_8859-6:1987";', '"ISO_8859-7:1987";', '"ISO_8859-8:1988";', '"ISO_8859-9:1989";', '"ISO-8859-10";', '"ISO_6937-2-add";', '"JIS_X0201";', 
+          \ '"JIS_Encoding";', '"Shift_JIS";', '"Extended_UNIX_Code_Packed_Format_for_Japanese";', '"Extended_UNIX_Code_Fixed_Width_for_Japanese";',
+          \ '"BS_4730";', '"SEN_850200_C";', '"IT";', '"ES";', '"DIN_66003";', '"NS_4551-1";', '"NF_Z_62-010";', '"ISO-10646-UTF-1";', '"ISO_646.basic:1983";',
+          \ '"INVARIANT";', '"ISO_646.irv:1983";', '"NATS-SEFI";', '"NATS-SEFI-ADD";', '"NATS-DANO";', '"NATS-DANO-ADD";', '"SEN_850200_B";', '"KS_C_5601-1987";',
+          \ '"ISO-2022-KR";', '"EUC-KR";', '"ISO-2022-JP";', '"ISO-2022-JP-2";', '"JIS_C6220-1969-jp";', '"JIS_C6220-1969-ro";', '"PT";', '"greek7-old";', 
+          \ '"latin-greek";', '"NF_Z_62-010_(1973)";', '"Latin-greek-1";', '"ISO_5427";', '"JIS_C6226-1978";', '"BS_viewdata";', '"INIS";', '"INIS-8";', 
+          \ '"INIS-cyrillic";', '"ISO_5427:1981";', '"ISO_5428:1980";', '"GB_1988-80";', '"GB_2312-80";', '"NS_4551-2";', '"videotex-suppl";', '"PT2";', 
+          \ '"ES2";', '"MSZ_7795.3";', '"JIS_C6226-1983";', '"greek7";', '"ASMO_449";', '"iso-ir-90";', '"JIS_C6229-1984-a";', '"JIS_C6229-1984-b";', 
+          \ '"JIS_C6229-1984-b-add";', '"JIS_C6229-1984-hand";', '"JIS_C6229-1984-hand-add";', '"JIS_C6229-1984-kana";', '"ISO_2033-1983";', 
+          \ '"ANSI_X3.110-1983";', '"T.61-7bit";', '"T.61-8bit";', '"ECMA-cyrillic";', '"CSA_Z243.4-1985-1";', '"CSA_Z243.4-1985-2";', '"CSA_Z243.4-1985-gr";', 
+          \ '"ISO_8859-6-E";', '"ISO_8859-6-I";', '"T.101-G2";', '"ISO_8859-8-E";', '"ISO_8859-8-I";', '"CSN_369103";', '"JUS_I.B1.002";', '"IEC_P27-1";', 
+          \ '"JUS_I.B1.003-serb";', '"JUS_I.B1.003-mac";', '"greek-ccitt";', '"NC_NC00-10:81";', '"ISO_6937-2-25";', '"GOST_19768-74";', '"ISO_8859-supp";', 
+          \ '"ISO_10367-box";', '"latin-lap";', '"JIS_X0212-1990";', '"DS_2089";', '"us-dk";', '"dk-us";', '"KSC5636";', '"UNICODE-1-1-UTF-7";', '"ISO-2022-CN";', 
+          \ '"ISO-2022-CN-EXT";', '"ISO-8859-13";', '"ISO-8859-14";', '"ISO-8859-15";', '"ISO-8859-16";', '"GBK";', '"GB18030";', '"OSD_EBCDIC_DF04_15";', 
+          \ '"OSD_EBCDIC_DF03_IRV";', '"OSD_EBCDIC_DF04_1";', '"ISO-11548-1";', '"KZ-1048";', '"ISO-10646-UCS-2";', '"ISO-10646-UCS-4";', '"ISO-10646-UCS-Basic";',
+          \ '"ISO-10646-Unicode-Latin1";', '"ISO-10646-J-1";', '"ISO-Unicode-IBM-1261";', '"ISO-Unicode-IBM-1268";', '"ISO-Unicode-IBM-1276";', 
+          \ '"ISO-Unicode-IBM-1264";', '"ISO-Unicode-IBM-1265";', '"UNICODE-1-1";', '"SCSU";', '"UTF-7";', '"UTF-16BE";', '"UTF-16LE";', '"UTF-16";', '"CESU-8";', 
+          \ '"UTF-32";', '"UTF-32BE";', '"UTF-32LE";', '"BOCU-1";', '"ISO-8859-1-Windows-3.0-Latin-1";', '"ISO-8859-1-Windows-3.1-Latin-1";', 
+          \ '"ISO-8859-2-Windows-Latin-2";', '"ISO-8859-9-Windows-Latin-5";', '"hp-roman8";', '"Adobe-Standard-Encoding";', '"Ventura-US";', 
+          \ '"Ventura-International";', '"DEC-MCS";', '"IBM850";', '"PC8-Danish-Norwegian";', '"IBM862";', '"PC8-Turkish";', '"IBM-Symbols";', '"IBM-Thai";', 
+          \ '"HP-Legal";', '"HP-Pi-font";', '"HP-Math8";', '"Adobe-Symbol-Encoding";', '"HP-DeskTop";', '"Ventura-Math";', '"Microsoft-Publishing";', 
+          \ '"Windows-31J";', '"GB2312";', '"Big5";', '"macintosh";', '"IBM037";', '"IBM038";', '"IBM273";', '"IBM274";', '"IBM275";', '"IBM277";', '"IBM278";', 
+          \ '"IBM280";', '"IBM281";', '"IBM284";', '"IBM285";', '"IBM290";', '"IBM297";', '"IBM420";', '"IBM423";', '"IBM424";', '"IBM437";', '"IBM500";', '"IBM851";', 
+          \ '"IBM852";', '"IBM855";', '"IBM857";', '"IBM860";', '"IBM861";', '"IBM863";', '"IBM864";', '"IBM865";', '"IBM868";', '"IBM869";', '"IBM870";', '"IBM871";', 
+          \ '"IBM880";', '"IBM891";', '"IBM903";', '"IBM904";', '"IBM905";', '"IBM918";', '"IBM1026";', '"EBCDIC-AT-DE";', '"EBCDIC-AT-DE-A";', '"EBCDIC-CA-FR";', 
+          \ '"EBCDIC-DK-NO";', '"EBCDIC-DK-NO-A";', '"EBCDIC-FI-SE";', '"EBCDIC-FI-SE-A";', '"EBCDIC-FR";', '"EBCDIC-IT";', '"EBCDIC-PT";', '"EBCDIC-ES";', 
+          \ '"EBCDIC-ES-A";', '"EBCDIC-ES-S";', '"EBCDIC-UK";', '"EBCDIC-US";', '"UNKNOWN-8BIT";', '"MNEMONIC";', '"MNEM";', '"VISCII";', '"VIQR";', '"KOI8-R";', 
+          \ '"HZ-GB-2312";', '"IBM866";', '"IBM775";', '"KOI8-U";', '"IBM00858";', '"IBM00924";', '"IBM01140";', '"IBM01141";', '"IBM01142";', '"IBM01143";', 
+          \ '"IBM01144";', '"IBM01145";', '"IBM01146";', '"IBM01147";', '"IBM01148";', '"IBM01149";', '"Big5-HKSCS";', '"IBM1047";', '"PTCP154";', '"Amiga-1251";', 
+          \ '"KOI7-switched";', '"BRF";', '"TSCII";', '"windows-1250";', '"windows-1251";', '"windows-1252";', '"windows-1253";', '"windows-1254";', '"windows-1255";', 
+          \ '"windows-1256";', '"windows-1257";', '"windows-1258";', '"TIS-620";']
 
-		for m in values
-			if m =~? '^'.entered_atruleafter
-				call add(res, m)
-			elseif m =~? entered_atruleafter
-				call add(res2, m)
-			endif
-		endfor
+      elseif atrulename == 'namespace'
+        let entered_atruleafter = matchstr(line, '.*@namespace\s\+\zs.*$')
+        let values = ["url("]
 
-		return res + res2
+      elseif atrulename == 'document'
+        let entered_atruleafter = matchstr(line, '.*@document\s\+\zs.*$')
+        let values = ["url(", "url-prefix(", "domain(", "regexp("]
 
-	endif
+      elseif atrulename == 'import'
+        let entered_atruleafter = matchstr(line, '.*@import\s\+\zs.*$')
 
-	let values = ["charset", "page", "media", "import", "font-face"]
+        if entered_atruleafter =~ "^[\"']"
+          let filestart = matchstr(entered_atruleafter, '^.\zs.*')
+          let files = split(glob(filestart.'*'), '\n')
+          let values = map(copy(files), '"\"".v:val')
 
-	let entered_atrule = matchstr(line, '.*@\zs[a-zA-Z-]*$')
+        elseif entered_atruleafter =~ "^url("
+          let filestart = matchstr(entered_atruleafter, "^url([\"']\\?\\zs.*")
+          let files = split(glob(filestart.'*'), '\n')
+          let values = map(copy(files), '"url(".v:val')
 
-	for m in values
-		if m =~? '^'.entered_atrule
-			call add(res, m .' ')
-		elseif m =~? entered_atrule
-			call add(res2, m .' ')
-		endif
-	endfor
+        else
+          let values = ['"', 'url(']
 
-	return res + res2
+        endif
 
-endif
+      else
+        return []
 
-return []
+      endif
+
+      for m in values
+        if m =~? '^'.entered_atruleafter
+          if entered_atruleafter =~? '^"' && m =~? '^"'
+            let m = m[1:]
+          endif
+          if b:after =~? '"' && stridx(m, '"') > -1
+            let m = m[0:stridx(m, '"')-1]
+          endif 
+          call add(res, m)
+        elseif m =~? entered_atruleafter
+          if m =~? '^"'
+            let m = m[1:]
+          endif
+          call add(res2, m)
+        endif
+      endfor
+
+      return res + res2
+
+    endif
+
+    let values = ["charset", "page", "media", "import", "font-face", "namespace", "supports", "keyframes", "viewport", "document"]
+
+    let entered_atrule = matchstr(line, '.*@\zs[a-zA-Z-]*$')
+
+    for m in values
+      if m =~? '^'.entered_atrule
+        call add(res, m .' ')
+      elseif m =~? entered_atrule
+        call add(res2, m .' ')
+      endif
+    endfor
+
+    return res + res2
+
+  endif
+
+  return []
 
 endfunction

--- a/runtime/autoload/sqlcomplete.vim
+++ b/runtime/autoload/sqlcomplete.vim
@@ -1,8 +1,8 @@
 " Vim OMNI completion script for SQL
 " Language:    SQL
 " Maintainer:  David Fishburn <dfishburn dot vim at gmail dot com>
-" Version:     15.0
-" Last Change: 2013 May 13
+" Version:     16.0
+" Last Change: 2015 Dec 29
 " Homepage:    http://www.vim.org/scripts/script.php?script_id=1572
 " Usage:       For detailed help
 "              ":help sql.txt"
@@ -15,6 +15,12 @@
 "     - Jonas Enberg - if no table is found when using column completion
 "       look backwards to a FROM clause and find the first table
 "       and complete it.
+"
+" Version 16.0 (Dec 2015)
+"     - NF: If reseting the cache and table, procedure or view completion
+"           had been used via dbext, have dbext delete or recreate the 
+"           dictionary so that new objects are picked up for the 
+"           next completion.
 "
 " Version 15.0 (May 2013)
 "     - NF: Changed the SQL precached syntax items, omni_sql_precache_syntax_groups,
@@ -103,7 +109,7 @@ endif
 if exists('g:loaded_sql_completion')
     finish
 endif
-let g:loaded_sql_completion = 150
+let g:loaded_sql_completion = 160
 let s:keepcpo= &cpo
 set cpo&vim
 
@@ -459,6 +465,29 @@ function! sqlcomplete#Complete(findstart, base)
         let s:tbl_cols           = []
         let s:syn_list           = []
         let s:syn_value          = []
+
+        if s:sql_file_table != ""
+            if g:loaded_dbext >= 2300
+                call DB_DictionaryDelete("table")
+            else
+                DBCompleteTables!
+            endif
+        endif
+        if s:sql_file_procedure != ""
+            if g:loaded_dbext >= 2300
+                call DB_DictionaryDelete("procedure")
+            else
+                DBCompleteProcedures!
+            endif
+        endif
+        if s:sql_file_view != ""
+            if g:loaded_dbext >= 2300
+                call DB_DictionaryDelete("view")
+            else
+                DBCompleteViews!
+            endif
+        endif
+
         let s:sql_file_table     = ""
         let s:sql_file_procedure = ""
         let s:sql_file_view      = ""

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1,4 +1,4 @@
-*change.txt*    For Vim version 7.4.  Last change: 2016 Jan 02
+*change.txt*    For Vim version 7.4.  Last change: 2016 Jan 31
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -1,4 +1,4 @@
-*develop.txt*   For Vim version 7.4.  Last change: 2016 Jan 19
+*develop.txt*   For Vim version 7.4.  Last change: 2016 Jan 31
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -1,4 +1,4 @@
-*develop.txt*   For Vim version 7.4.  Last change: 2014 Mar 27
+*develop.txt*   For Vim version 7.4.  Last change: 2016 Jan 19
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1,4 +1,4 @@
-*editing.txt*   For Vim version 7.4.  Last change: 2016 Jan 17
+*editing.txt*   For Vim version 7.4.  Last change: 2016 Feb 01
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 7.4.  Last change: 2016 Jan 16
+*eval.txt*	For Vim version 7.4.  Last change: 2016 Jan 21
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -99,6 +99,9 @@ List, Dictionary and Funcref types are not automatically converted.
 When mixing Number and Float the Number is converted to Float.	Otherwise
 there is no automatic conversion of Float.  You can use str2float() for String
 to Float, printf() for Float to String and float2nr() for Float to Number.
+
+						*E891* *E892* *E893* *E894*
+When expecting a Float a Number can also be used, but nothing else.
 
 						*E706* *sticky-type-checking*
 You will get an error if you try to change the type of a variable.  You need
@@ -3665,7 +3668,8 @@ getftype({fname})					*getftype()*
 			getftype("/home")
 <		Note that a type such as "link" will only be returned on
 		systems that support it.  On some systems only "dir" and
-		"file" are returned.
+		"file" are returned.  On MS-Windows a symbolic link to a
+		directory returns "dir" instead of "link".
 
 							*getline()*
 getline({lnum} [, {end}])
@@ -6206,6 +6210,9 @@ sort({list} [, {func} [, {dict}]])			*sort()* *E702*
 		When {func} is given and it is 'N' then all items will be
 		sorted numerical. This is like 'n' but a string containing
 		digits will be used as the number they represent.
+
+		When {func} is given and it is 'f' then all items will be
+		sorted numerical. All values must be a Number or a Float.
 
 		When {func} is a |Funcref| or a function name, this function
 		is called to compare items.  The function is invoked with two

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7294,7 +7294,7 @@ dialog_gui		Compiled with GUI dialog support.
 digraphs		Compiled with support for digraphs.
 eval			Compiled with expression evaluation support.  Always
 			true, of course!
-ex_extra		Compiled with extra Ex commands |+ex_extra|.
+ex_extra		|+ex_extra|, always true now
 extra_search		Compiled with support for |'incsearch'| and
 			|'hlsearch'|
 farsi			Compiled with Farsi support |farsi|.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 7.4.  Last change: 2016 Jan 24
+*eval.txt*	For Vim version 7.4.  Last change: 2016 Feb 04
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 7.4.  Last change: 2016 Jan 21
+*eval.txt*	For Vim version 7.4.  Last change: 2016 Jan 24
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1,4 +1,4 @@
-*index.txt*     For Vim version 7.4.  Last change: 2016 Jan 10
+*index.txt*     For Vim version 7.4.  Last change: 2016 Jan 19
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1515,14 +1515,14 @@ tag	      command	      action ~
 |:tabdo|	:tabdo		execute command in each tab page
 |:tabedit|	:tabe[dit]	edit a file in a new tab page
 |:tabfind|	:tabf[ind]	find file in 'path', edit it in a new tab page
-|:tabfirst|	:tabfir[st]	got to first tab page
-|:tablast|	:tabl[ast]	got to last tab page
+|:tabfirst|	:tabfir[st]	go to first tab page
+|:tablast|	:tabl[ast]	go to last tab page
 |:tabmove|	:tabm[ove]	move tab page to other position
 |:tabnew|	:tabnew		edit a file in a new tab page
 |:tabnext|	:tabn[ext]	go to next tab page
 |:tabonly|	:tabo[nly]	close all tab pages except the current one
 |:tabprevious|	:tabp[revious]	go to previous tab page
-|:tabrewind|	:tabr[ewind]	got to first tab page
+|:tabrewind|	:tabr[ewind]	go to first tab page
 |:tabs|		:tabs		list the tab pages and what they contain
 |:tab|		:tab		create new tab when opening new window
 |:tag|		:ta[g]		jump to tag

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1,4 +1,4 @@
-*insert.txt*    For Vim version 7.4.  Last change: 2015 Sep 15
+*insert.txt*    For Vim version 7.4.  Last change: 2016 Jan 31
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 7.4.  Last change: 2016 Jan 19
+*options.txt*	For Vim version 7.4.  Last change: 2016 Feb 01
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -5957,7 +5957,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The option consists of printf style '%' items interspersed with
 	normal text.  Each status line item is of the form:
 	  %-0{minwid}.{maxwid}{item}
-	All fields except the {item} is optional.  A single percent sign can
+	All fields except the {item} are optional.  A single percent sign can
 	be given as "%%".  Up to 80 items can be specified.  *E541*
 
 	When the option starts with "%!" then it is used as an expression,

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1,4 +1,4 @@
-*quickfix.txt*  For Vim version 7.4.  Last change: 2015 Sep 08
+*quickfix.txt*  For Vim version 7.4.  Last change: 2016 Jan 21
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 7.4.  Last change: 2016 Jan 19
+*syntax.txt*	For Vim version 7.4.  Last change: 2016 Jan 28
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -3442,7 +3442,7 @@ SYNTAX ISKEYWORD SETTING				*:syn-iskeyword*
 	If no argument is given, the current value will be output.
 
 	Setting this option influences what |/\k| matches in syntax patterns
-	and also determines where |:syn-keywords| will be checked for a new
+	and also determines where |:syn-keyword| will be checked for a new
 	match.
 
 	It is recommended when writing syntax files, to use this command

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1,4 +1,4 @@
-*usr_41.txt*	For Vim version 7.4.  Last change: 2015 Nov 30
+*usr_41.txt*	For Vim version 7.4.  Last change: 2016 Jan 28
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1,4 +1,4 @@
-*usr_41.txt*	For Vim version 7.4.  Last change: 2016 Jan 28
+*usr_41.txt*	For Vim version 7.4.  Last change: 2016 Feb 02
 
 		     VIM USER MANUAL - by Bram Moolenaar
 

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -1,4 +1,4 @@
-*various.txt*   For Vim version 7.4.  Last change: 2016 Jan 27
+*various.txt*   For Vim version 7.4.  Last change: 2016 Jan 31
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -319,8 +319,7 @@ N  *+dialog_con*	Support for |:confirm| with console dialog.
 N  *+dialog_con_gui*	Support for |:confirm| with GUI and console dialog.
 N  *+digraphs*		|digraphs| *E196*
 N  *+eval*		expression evaluation |eval.txt|
-N  *+ex_extra*		Vim's extra Ex commands: |:center|, |:left|,
-			|:normal|, |:retab| and |:right|
+N  *+ex_extra*		always on now, used to be for Vim's extra Ex commands
 N  *+extra_search*	|'hlsearch'| and |'incsearch'| options.
 B  *+farsi*		|farsi| language
 N  *+file_in_path*	|gf|, |CTRL-W_f| and |<cfile>|

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -1,4 +1,4 @@
-*various.txt*   For Vim version 7.4.  Last change: 2016 Jan 10
+*various.txt*   For Vim version 7.4.  Last change: 2016 Jan 27
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1,4 +1,4 @@
-*windows.txt*   For Vim version 7.4.  Last change: 2015 Nov 14
+*windows.txt*   For Vim version 7.4.  Last change: 2016 Feb 01
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -707,8 +707,8 @@ can also get to them with the buffer list commands, like ":bnext".
 							*:bufdo*
 :[range]bufdo[!] {cmd}	Execute {cmd} in each buffer in the buffer list or if
 			[range] is given only for buffers for which their
-			buffer name is in the [range]. It works like doing
-                        this: >
+			buffer number is in the [range]. It works like doing
+			this: >
 				:bfirst
 				:{cmd}
 				:bnext

--- a/runtime/indent/fortran.vim
+++ b/runtime/indent/fortran.vim
@@ -1,11 +1,11 @@
 " Vim indent file
 " Language:	Fortran 2008 (and older: Fortran 2003, 95, 90, and 77)
-" Version:	0.42
-" Last Change:	2015 Nov. 30
+" Version:	0.44
+" Last Change:	2016 Jan. 26
 " Maintainer:	Ajit J. Thakkar <ajit@unb.ca>; <http://www2.unb.ca/~ajit/>
 " Usage:	For instructions, do :help fortran-indent from Vim
 " Credits:
-"  Useful suggestions were made by: Albert Oliver Serra.
+"  Useful suggestions were made by: Albert Oliver Serra and Takuya Fujiwara.
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -92,10 +92,10 @@ function FortranGetIndent(lnum)
   "Indent do loops only if they are all guaranteed to be of do/end do type
   if exists("b:fortran_do_enddo") || exists("g:fortran_do_enddo")
     if prevstat =~? '^\s*\(\d\+\s\)\=\s*\(\a\w*\s*:\)\=\s*do\>'
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
     if getline(v:lnum) =~? '^\s*\(\d\+\s\)\=\s*end\s*do\>'
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     endif
   endif
 
@@ -105,14 +105,14 @@ function FortranGetIndent(lnum)
 	\ ||prevstat=~? '^\s*\(type\|interface\|associate\|enum\)\>'
 	\ ||prevstat=~?'^\s*\(\d\+\s\)\=\s*\(\a\w*\s*:\)\=\s*\(forall\|where\|block\)\>'
 	\ ||prevstat=~? '^\s*\(\d\+\s\)\=\s*\(\a\w*\s*:\)\=\s*if\>'
-     let ind = ind + &sw
+     let ind = ind + shiftwidth()
     " Remove unwanted indent after logical and arithmetic ifs
     if prevstat =~? '\<if\>' && prevstat !~? '\<then\>'
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     endif
     " Remove unwanted indent after type( statements
     if prevstat =~? '^\s*type\s*('
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     endif
   endif
 
@@ -125,12 +125,12 @@ function FortranGetIndent(lnum)
             \ ||prevstat =~? '^\s*'.prefix.'subroutine\>'
             \ ||prevstat =~? '^\s*'.prefix.type.'function\>'
             \ ||prevstat =~? '^\s*'.type.prefix.'function\>'
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
     if getline(v:lnum) =~? '^\s*contains\>'
           \ ||getline(v:lnum)=~? '^\s*end\s*'
           \ .'\(function\|subroutine\|module\|program\)\>'
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     endif
   endif
 
@@ -141,23 +141,23 @@ function FortranGetIndent(lnum)
         \. '\(else\|else\s*if\|else\s*where\|case\|'
         \. 'end\s*\(if\|where\|select\|interface\|'
         \. 'type\|forall\|associate\|enum\|block\)\)\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
     " Fix indent for case statement immediately after select
     if prevstat =~? '\<select\s\+\(case\|type\)\>'
-      let ind = ind + &sw
+      let ind = ind + shiftwidth()
     endif
   endif
 
   "First continuation line
   if prevstat =~ '&\s*$' && prev2stat !~ '&\s*$'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   endif
   if prevstat =~ '&\s*$' && prevstat =~ '\<else\s*if\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
   "Line after last continuation line
   if prevstat !~ '&\s*$' && prev2stat =~ '&\s*$' && prevstat !~? '\<then\>'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/sh.vim
+++ b/runtime/indent/sh.vim
@@ -3,7 +3,7 @@
 " Maintainer:          Christian Brabandt <cb@256bit.org>
 " Previous Maintainer: Peter Aronoff <telemachus@arpinum.org>
 " Original Author:     Nikolai Weibull <now@bitwi.se>
-" Latest Revision:     2015-12-15
+" Latest Revision:     2016-01-15
 " License:             Vim (see :h license)
 " Repository:          https://github.com/chrisbra/vim-sh-indent
 
@@ -28,7 +28,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 function s:buffer_shiftwidth()
-  return &shiftwidth
+  return shiftwidth()
 endfunction
 
 let s:sh_indent_defaults = {

--- a/runtime/indent/vim.vim
+++ b/runtime/indent/vim.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:	Vim script
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Dec 12
+" Last Change:	2016 Jan 24
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -58,19 +58,19 @@ function GetVimIndentIntern()
     if exists("g:vim_indent_cont")
       let ind = ind + g:vim_indent_cont
     else
-      let ind = ind + &sw * 3
+      let ind = ind + shiftwidth() * 3
     endif
   elseif prev_text =~ '^\s*aug\%[roup]' && prev_text !~ '^\s*aug\%[roup]\s*!\=\s\+END'
-    let ind = ind + &sw
+    let ind = ind + shiftwidth()
   else
     " A line starting with :au does not increment/decrement indent.
     if prev_text !~ '^\s*au\%[tocmd]'
       let i = match(prev_text, '\(^\||\)\s*\(if\|wh\%[ile]\|for\|try\|cat\%[ch]\|fina\%[lly]\|fu\%[nction]\|el\%[seif]\)\>')
       if i >= 0
-	let ind += &sw
+	let ind += shiftwidth()
 	if strpart(prev_text, i, 1) == '|' && has('syntax_items')
 	      \ && synIDattr(synID(lnum, i, 1), "name") =~ '\(Comment\|String\)$'
-	  let ind -= &sw
+	  let ind -= shiftwidth()
 	endif
       endif
     endif
@@ -82,7 +82,7 @@ function GetVimIndentIntern()
   let i = match(prev_text, '[^\\]|\s*\(ene\@!\)')
   if i > 0 && prev_text !~ '^\s*au\%[tocmd]'
     if !has('syntax_items') || synIDattr(synID(lnum, i + 2, 1), "name") !~ '\(Comment\|String\)$'
-      let ind = ind - &sw
+      let ind = ind - shiftwidth()
     endif
   endif
 
@@ -90,7 +90,7 @@ function GetVimIndentIntern()
   " Subtract a 'shiftwidth' on a :endif, :endwhile, :catch, :finally, :endtry,
   " :endfun, :else and :augroup END.
   if cur_text =~ '^\s*\(ene\@!\|cat\|fina\|el\|aug\%[roup]\s*!\=\s\+[eE][nN][dD]\)'
-    let ind = ind - &sw
+    let ind = ind - shiftwidth()
   endif
 
   return ind

--- a/runtime/indent/zimbu.vim
+++ b/runtime/indent/zimbu.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:	Zimbu
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2012 Sep 08
+" Last Change:	2016 Jan 25
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -74,9 +74,9 @@ func GetZimbuIndent(lnum)
 	  \ . " synIDattr(synID(line('.'), col('.'), 1), 'name')"
 	  \ . " =~ '\\(Comment\\|String\\|Char\\)$'")
       if pp > 0
-	return indent(prevLnum) + &sw
+	return indent(prevLnum) + shiftwidth()
       endif
-      return indent(prevLnum) + &sw * 2
+      return indent(prevLnum) + shiftwidth() * 2
     endif
     if plnumstart == p
       return indent(prevLnum)
@@ -102,13 +102,13 @@ func GetZimbuIndent(lnum)
   endif
 
   if prevline =~ '^\s*\(IF\|\|ELSEIF\|ELSE\|GENERATE_IF\|\|GENERATE_ELSEIF\|GENERATE_ELSE\|WHILE\|REPEAT\|TRY\|CATCH\|FINALLY\|FOR\|DO\|SWITCH\|CASE\|DEFAULT\|FUNC\|VIRTUAL\|ABSTRACT\|DEFINE\|REPLACE\|FINAL\|PROC\|MAIN\|NEW\|ENUM\|CLASS\|INTERFACE\|BITS\|MODULE\|SHARED\)\>'
-    let plindent += &sw
+    let plindent += shiftwidth()
   endif
   if thisline =~ '^\s*\(}\|ELSEIF\>\|ELSE\>\|CATCH\|FINALLY\|GENERATE_ELSEIF\>\|GENERATE_ELSE\>\|UNTIL\>\)'
-    let plindent -= &sw
+    let plindent -= shiftwidth()
   endif
   if thisline =~ '^\s*\(CASE\>\|DEFAULT\>\)' && prevline !~ '^\s*SWITCH\>'
-    let plindent -= &sw
+    let plindent -= shiftwidth()
   endif
 
   " line up continued comment that started after some code

--- a/runtime/syntax/d.vim
+++ b/runtime/syntax/d.vim
@@ -1,9 +1,9 @@
-" Vim syntax file for the D programming language (version 1.076 and 2.063).
+" Vim syntax file for the D programming language (version 1.076 and 2.069).
 "
 " Language:     D
 " Maintainer:   Jesse Phillips <Jesse.K.Phillips+D@gmail.com>
-" Last Change:  2013 October 5
-" Version:      0.26
+" Last Change:  2016 Feb 2
+" Version:      0.28
 "
 " Contributors:
 "   - Jason Mills: original Maintainer
@@ -15,6 +15,7 @@
 "   - Steven N. Oliver
 "   - Sohgo Takeuchi
 "   - Robert Clipsham
+"   - Petar Kirov
 "
 " Please submit bugs/comments/suggestions to the github repo: 
 " https://github.com/JesseKPhillips/d.vim
@@ -114,17 +115,19 @@ syn keyword dTraitsIdentifier      contained isIntegral isScalar isStaticArray
 syn keyword dTraitsIdentifier      contained isUnsigned isVirtualFunction
 syn keyword dTraitsIdentifier      contained isVirtualMethod isAbstractFunction
 syn keyword dTraitsIdentifier      contained isFinalFunction isStaticFunction
+syn keyword dTraitsIdentifier      contained isOverrideFunction isTemplate
 syn keyword dTraitsIdentifier      contained isRef isOut isLazy hasMember
-syn keyword dTraitsIdentifier      contained identifier getAttributes getMember
-syn keyword dTraitsIdentifier      contained getOverloads getProtection
-syn keyword dTraitsIdentifier      contained getVirtualFunctions
-syn keyword dTraitsIdentifier      contained getVirtualMethods parent
-syn keyword dTraitsIdentifier      contained classInstanceSize allMembers
+syn keyword dTraitsIdentifier      contained identifier getAliasThis
+syn keyword dTraitsIdentifier      contained getAttributes getFunctionAttributes getMember
+syn keyword dTraitsIdentifier      contained getOverloads getPointerBitmap getProtection
+syn keyword dTraitsIdentifier      contained getVirtualFunctions getVirtualIndex
+syn keyword dTraitsIdentifier      contained getVirtualMethods getUnitTests
+syn keyword dTraitsIdentifier      contained parent classInstanceSize allMembers
 syn keyword dTraitsIdentifier      contained derivedMembers isSame compiles
-syn keyword dPragmaIdentifier      contained lib msg startaddress GNU_asm
-syn keyword dExternIdentifier      contained Windows Pascal Java System D
+syn keyword dPragmaIdentifier      contained inline lib mangle msg startaddress GNU_asm
+syn keyword dExternIdentifier      contained C C++ D Windows Pascal System Objective-C
 syn keyword dAttribute             contained safe trusted system
-syn keyword dAttribute             contained property disable
+syn keyword dAttribute             contained property disable nogc
 syn keyword dVersionIdentifier     contained DigitalMars GNU LDC SDC D_NET
 syn keyword dVersionIdentifier     contained X86 X86_64 ARM PPC PPC64 IA64 MIPS MIPS64 Alpha
 syn keyword dVersionIdentifier     contained SPARC SPARC64 S390 S390X HPPA HPPA64 SH SH64
@@ -134,7 +137,7 @@ syn keyword dVersionIdentifier     contained Cygwin MinGW
 syn keyword dVersionIdentifier     contained LittleEndian BigEndian
 syn keyword dVersionIdentifier     contained D_InlineAsm_X86 D_InlineAsm_X86_64
 syn keyword dVersionIdentifier     contained D_Version2 D_Coverage D_Ddoc D_LP64 D_PIC
-syn keyword dVersionIdentifier     contained unittest none all
+syn keyword dVersionIdentifier     contained unittest assert none all
 
 syn cluster dComment contains=dNestedComment,dBlockComment,dLineComment
 
@@ -168,10 +171,10 @@ syn match dExternal     "\<extern\>"
 syn match dExtern       "\<extern\s*([_a-zA-Z][_a-zA-Z0-9\+]*\>"he=s+6 contains=dExternIdentifier
 
 " Make import a region to prevent highlighting keywords
-syn region dImport start="import\_s" end=";" contains=dExternal,@dComment
+syn region dImport start="\<import\_s" end=";" contains=dExternal,@dComment
 
 " Make module a region to prevent highlighting keywords
-syn region dImport start="module\_s" end=";" contains=dExternal,@dComment
+syn region dImport start="\<module\_s" end=";" contains=dExternal,@dComment
 
 " dTokens is used by the token string highlighting
 syn cluster dTokens contains=dExternal,dConditional,dBranch,dRepeat,dBoolean
@@ -246,12 +249,16 @@ syn match dUnicode "\\u\d\{4\}"
 
 " String.
 "
-syn region dString	start=+"+ end=+"[cwd]\=+ skip=+\\\\\|\\"+ contains=dEscSequence,@Spell
+syn match	dFormat		display "%\(\d\+\$\)\=[-+' #0*]*\(\d*\|\*\|\*\d\+\$\)\(\.\(\d*\|\*\|\*\d\+\$\)\)\=\([hlL]\|ll\)\=\([bdiuoxXDOUfeEgGcCsSpn]\|\[\^\=.[^]]*\]\)" contained
+syn match	dFormat		display "%%" contained
+
+syn region dString	start=+"+ end=+"[cwd]\=+ skip=+\\\\\|\\"+ contains=dFormat,dEscSequence,@Spell
 syn region dRawString	start=+`+ end=+`[cwd]\=+ contains=@Spell
 syn region dRawString	start=+r"+ end=+"[cwd]\=+ contains=@Spell
 syn region dHexString	start=+x"+ end=+"[cwd]\=+ contains=@Spell
 syn region dDelimString	start=+q"\z(.\)+ end=+\z1"+ contains=@Spell
 syn region dHereString	start=+q"\z(\I\i*\)\n+ end=+^\z1"+ contains=@Spell
+
 
 " Nesting delimited string contents
 "
@@ -276,8 +283,8 @@ syn cluster dTokens add=dString,dRawString,dHexString,dDelimString,dNestString
 
 " Token strings
 "
-syn region dNestTokenString start=+{+ end=+}+ contained contains=dNestTokenString,@dTokens
-syn region dTokenString matchgroup=dTokenStringBrack transparent start=+q{+ end=+}+ contains=dNestTokenString,@dTokens
+syn region dNestTokenString start=+{+ end=+}+ contained contains=dNestTokenString,@dTokens,dFormat
+syn region dTokenString matchgroup=dTokenStringBrack transparent start=+q{+ end=+}+ contains=dNestTokenString,@dTokens,dFormat
 
 syn cluster dTokens add=dTokenString
 
@@ -357,6 +364,7 @@ hi def link dString              String
 hi def link dHexString           String
 hi def link dCharacter           Character
 hi def link dEscSequence         SpecialChar
+hi def link dFormat              SpecialChar
 hi def link dSpecialCharError    Error
 hi def link dOctalError          Error
 hi def link dOperator            Operator

--- a/runtime/syntax/dcl.vim
+++ b/runtime/syntax/dcl.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	DCL (Digital Command Language - vms)
 " Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Oct 23, 2014
-" Version:	7
+" Last Change:	Jan 20, 2016
+" Version:	8
 " URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_DCL
 
 " For version 5.x: Clear all syntax items
@@ -13,10 +13,10 @@ elseif exists("b:current_syntax")
   finish
 endif
 
-if version < 600
-  set iskeyword=$,@,48-57,_
-else
+if !has("patch-7.4.1141")
   setlocal iskeyword=$,@,48-57,_
+else
+ syn iskeyword $,@,48-57,_
 endif
 
 syn case ignore

--- a/runtime/syntax/lisp.vim
+++ b/runtime/syntax/lisp.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:    Lisp
 " Maintainer:  Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change: Oct 06, 2014
-" Version:     23
+" Last Change: Jan 20, 2016
+" Version:     24
 " URL:	       http://www.drchip.org/astronaut/vim/index.html#SYNTAX_LISP
 "
 "  Thanks to F Xavier Noria for a list of 978 Common Lisp symbols taken from HyperSpec
@@ -16,8 +16,10 @@ endif
 
 if exists("g:lisp_isk")
  exe "setl isk=".g:lisp_isk
-else
+elseif !has("patch-7.4.1141")
  setl isk=38,42,43,45,47-58,60-62,64-90,97-122,_
+else
+ syn iskeyword 38,42,43,45,47-58,60-62,64-90,97-122,_
 endif
 
 if exists("g:lispsyntax_ignorecase") || exists("g:lispsyntax_clisp")

--- a/runtime/syntax/maple.vim
+++ b/runtime/syntax/maple.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	Maple V (based on release 4)
 " Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Oct 23, 2014
-" Version:	11
+" Last Change:	Jan 20, 2016
+" Version:	12
 " URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_MAPLE
 "
 " Package Function Selection: {{{1
@@ -30,10 +30,10 @@ elseif exists("b:current_syntax")
 endif
 
 " Iskeyword Effects: {{{1
-if version < 600
-  set iskeyword=$,48-57,_,a-z,@-Z
+if !has("patch-7.4.1141")
+ setl isk=$,48-57,_,a-z,@-Z
 else
-  setlocal iskeyword=$,48-57,_,a-z,@-Z
+ syn iskeyword $,48-57,_,a-z,@-Z
 endif
 
 " Package Selection: {{{1

--- a/runtime/syntax/messages.vim
+++ b/runtime/syntax/messages.vim
@@ -3,6 +3,7 @@
 " Maintainer:       Yakov Lerner <iler.ml@gmail.com>
 " Latest Revision:  2008-06-29
 " Changes:          2008-06-29 support for RFC3339 tuimestamps James Vega
+" 		    2016 Jan 19: messagesDate changed by Bram
 
 if exists("b:current_syntax")
   finish
@@ -13,7 +14,7 @@ set cpo&vim
 
 syn match   messagesBegin       display '^' nextgroup=messagesDate,messagesDateRFC3339
 
-syn match   messagesDate        contained display '\a\a\a [ 0-9]\d *'
+syn match   messagesDate        contained display '[[:lower:][:upper:]][[:lower:][:upper:]][[:lower:][:upper:]] [ 0-9]\d *'
                                 \ nextgroup=messagesHour
 
 syn match   messagesHour        contained display '\d\d:\d\d:\d\d\s*'

--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	TeX
 " Maintainer:	Charles E. Campbell <NdrchipO@ScampbellPfamily.AbizM>
-" Last Change:	Oct 20, 2015
-" Version:	90
+" Last Change:	Jan 20, 2016
+" Version:	91
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_TEX
 "
 " Notes: {{{1
@@ -129,8 +129,10 @@ endif
 " g:tex_isk
 if exists("g:tex_isk")
  exe "setlocal isk=".g:tex_isk
+elseif !has("patch-7.4.1141")
+ setl isk=48-57,a-z,A-Z,192-255
 else
- setlocal isk=48-57,a-z,A-Z,192-255
+ syn iskeyword 48-57,a-z,A-Z,192-255
 endif
 if b:tex_stylish
   setlocal isk+=@-@

--- a/runtime/syntax/zsh.vim
+++ b/runtime/syntax/zsh.vim
@@ -2,7 +2,7 @@
 " Language:             Zsh shell script
 " Maintainer:           Christian Brabandt <cb@256bit.org>
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2015-12-25
+" Latest Revision:      2016-01-25
 " License:              Vim (see :h license)
 " Repository:		https://github.com/chrisbra/vim-zsh
 
@@ -14,6 +14,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 setlocal iskeyword+=-
+setlocal foldmethod=syntax
 
 syn keyword zshTodo             contained TODO FIXME XXX NOTE
 
@@ -307,19 +308,19 @@ syn match   zshNumber           '[+-]\=\d\+\.\d\+\>'
 " TODO: $[...] is the same as $((...)), so add that as well.
 syn cluster zshSubst            contains=zshSubst,zshOldSubst,zshMathSubst
 syn region  zshSubst            matchgroup=zshSubstDelim transparent
-                                \ start='\$(' skip='\\)' end=')' contains=TOP
-syn region  zshParentheses      transparent start='(' skip='\\)' end=')'
+                                \ start='\$(' skip='\\)' end=')' contains=TOP fold
+syn region  zshParentheses      transparent start='(' skip='\\)' end=')' fold
 syn region  zshMathSubst        matchgroup=zshSubstDelim transparent
                                 \ start='\$((' skip='\\)'
                                 \ matchgroup=zshSubstDelim end='))'
                                 \ contains=zshParentheses,@zshSubst,zshNumber,
-                                \ @zshDerefs,zshString keepend
+                                \ @zshDerefs,zshString keepend fold
 syn region  zshBrackets         contained transparent start='{' skip='\\}'
-                                \ end='}'
+                                \ end='}' fold
 syn region  zshSubst            matchgroup=zshSubstDelim start='\${' skip='\\}'
-                                \ end='}' contains=@zshSubst,zshBrackets,zshQuoted,zshString
+                                \ end='}' contains=@zshSubst,zshBrackets,zshQuoted,zshString fold
 syn region  zshOldSubst         matchgroup=zshSubstDelim start=+`+ skip=+\\`+
-                                \ end=+`+ contains=TOP,zshOldSubst
+                                \ end=+`+ contains=TOP,zshOldSubst fold
 
 syn sync    minlines=50 maxlines=90
 syn sync    match zshHereDocSync    grouphere   NONE '<<-\=\s*\%(\\\=\S\+\|\(["']\)\S\+\1\)'

--- a/src/nvim/po/ja.euc-jp.po
+++ b/src/nvim/po/ja.euc-jp.po
@@ -1,11 +1,11 @@
-# Japanese translation for Vim			vim:set foldmethod=marker:
+# Japanese translation for Vim
 #
 # Do ":help uganda"  in Vim to read copying and usage conditions.
 # Do ":help credits" in Vim to see a list of people who contributed.
 #
-# Last Change: 2013 Jul 06
+# Copyright (C) 2001-2016 MURAOKA Taro <koron.kaoriya@gmail.com>,
+# 			  vim-jp (http://vim-jp.org/)
 #
-# Copyright (C) 2001-13 MURAOKA Taro <koron.kaoriya@gmail.com>
 # THIS FILE IS DISTRIBUTED UNDER THE VIM LICENSE.
 #
 # Generated from ja.po, DO NOT EDIT.
@@ -14,10 +14,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 7.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-05-26 14:21+0200\n"
-"PO-Revision-Date: 2013-07-06 15:00+0900\n"
+"POT-Creation-Date: 2016-02-01 09:02+0900\n"
+"PO-Revision-Date: 2016-02-01 09:08+0900\n"
 "Last-Translator: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
-"Language-Team: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
+"Language-Team: vim-jp (https://github.com/vim-jp/lang-ja)\n"
 "Language: Japanese\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=euc-jp\n"
@@ -34,7 +34,7 @@ msgstr "内部エラー: 未知のオプション型です"
 
 #: ../buffer.c:92
 msgid "[Location List]"
-msgstr "[場所リスト]"
+msgstr "[ロケーションリスト]"
 
 #: ../buffer.c:93
 msgid "[Quickfix List]"
@@ -277,7 +277,7 @@ msgstr "E810: 一時ファイルの読込もしくは書込ができません"
 
 #: ../diff.c:755
 msgid "E97: Cannot create diffs"
-msgstr "E97: 差分を作成できません "
+msgstr "E97: 差分を作成できません"
 
 #: ../diff.c:966
 msgid "E816: Cannot read patch output"
@@ -293,7 +293,7 @@ msgstr "E99: 現在のバッファは差分モードではありません"
 
 #: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
-msgstr "E793: 差分モードである他のバッファは変更可能です"
+msgstr "E793: 差分モードである他のバッファは変更できません"
 
 #: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
@@ -349,7 +349,7 @@ msgstr " 行(全体)補完 (^L^N^P)"
 
 #: ../edit.c:86
 msgid " File name completion (^F^N^P)"
-msgstr "ファイル名補完 (^F^N^P)"
+msgstr " ファイル名補完 (^F^N^P)"
 
 #: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
@@ -377,7 +377,7 @@ msgstr " コマンドライン補完 (^V^N^P)"
 
 #: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
-msgstr " ユーザ定義補完 (^U^N^P)"
+msgstr " ユーザー定義補完 (^U^N^P)"
 
 #: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
@@ -679,6 +679,11 @@ msgstr "E696: リスト型にカンマがありません: %s"
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: リスト型の最後に ']' がありません: %s"
 
+#: ../eval.c:5807
+msgid "Not enough memory to set references, garbage collection aborted!"
+msgstr ""
+"ガーベッジコレクションを中止しました! 参照を作成するのにメモリが不足しました"
+
 #: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
@@ -721,7 +726,7 @@ msgstr "E117: 未知の関数です: %s"
 #: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: 関数の引数が少な過ぎます: %s"
+msgstr "E119: 関数の引数が足りません: %s"
 
 #: ../eval.c:7387
 #, c-format
@@ -826,18 +831,16 @@ msgid "sort() argument"
 msgstr "sort() の引数"
 
 #: ../eval.c:13721
-#, fuzzy
 msgid "uniq() argument"
-msgstr "add() の引数"
+msgstr "uniq() の引数"
 
 #: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: ソートの比較関数が失敗しました"
 
 #: ../eval.c:13806
-#, fuzzy
 msgid "E882: Uniq compare function failed"
-msgstr "E702: ソートの比較関数が失敗しました"
+msgstr "E882: Uniq の比較関数が失敗しました"
 
 #: ../eval.c:14085
 msgid "(Invalid)"
@@ -862,6 +865,18 @@ msgstr "E745: リスト型を数値として扱っています"
 #: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: 辞書型を数値として扱っています"
+
+msgid "E891: Using a Funcref as a Float"
+msgstr "E891: 関数参照型を浮動小数点数として扱っています。"
+
+msgid "E892: Using a String as a Float"
+msgstr "E892: 文字列を浮動小数点数として扱っています"
+
+msgid "E893: Using a List as a Float"
+msgstr "E893: リスト型を浮動小数点数として扱っています"
+
+msgid "E894: Using a Dictionary as a Float"
+msgstr "E894: 辞書型を浮動小数点数として扱っています"
 
 #: ../eval.c:16259
 msgid "E729: using Funcref as a String"
@@ -961,14 +976,14 @@ msgid "E129: Function name required"
 msgstr "E129: 関数名が要求されます"
 
 #: ../eval.c:17824
-#, fuzzy, c-format
+#, c-format
 msgid "E128: Function name must start with a capital or \"s:\": %s"
-msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
+msgstr "E128: 関数名は大文字か \"s:\" で始まらなければなりません: %s"
 
 #: ../eval.c:17833
-#, fuzzy, c-format
+#, c-format
 msgid "E884: Function name cannot contain a colon: %s"
-msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
+msgstr "E884: 関数名にはコロンは含められません: %s"
 
 #: ../eval.c:18336
 #, c-format
@@ -1081,7 +1096,7 @@ msgstr "E136: viminfo: エラーが多過ぎるので, 以降はスキップします"
 #: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
-msgstr "viminfoファイル \"%s\"%s%s%s を読込み中 "
+msgstr "viminfoファイル \"%s\"%s%s%s を読込み中"
 
 #: ../ex_cmds.c:1460
 msgid " info"
@@ -1357,6 +1372,10 @@ msgstr "E158: 無効なバッファ名です: %s"
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: 無効なsign識別子です: %<PRId64>"
 
+#, c-format
+msgid "E885: Not possible to change sign %s"
+msgstr "E885: 変更できない sign です: %s"
+
 #: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (非サポート)"
@@ -1378,6 +1397,13 @@ msgstr "行 %<PRId64>: %s"
 #, c-format
 msgid "cmd: %s"
 msgstr "コマンド: %s"
+
+msgid "frame is zero"
+msgstr "フレームが 0 です"
+
+#, c-format
+msgid "frame at highest level: %d"
+msgstr "最高レベルのフレーム: %d"
 
 #: ../ex_cmds2.c:322
 #, c-format
@@ -1528,7 +1554,8 @@ msgstr "E197: 言語を \"%s\" に設定できません"
 #. don't wait for return
 #: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
-msgstr "Exモードに入ります. ノーマルに戻るには\"visual\"と入力してください."
+msgstr ""
+"Exモードに入ります. ノーマルモードに戻るには\"visual\"と入力してください."
 
 #: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
@@ -1553,7 +1580,7 @@ msgstr "関数の最後です"
 
 #: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
-msgstr "E464: ユーザ定義コマンドのあいまいな使用です"
+msgstr "E464: ユーザー定義コマンドのあいまいな使用です"
 
 #: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
@@ -1606,14 +1633,14 @@ msgstr "E174: コマンドが既にあります: 再定義するには ! を追加してください"
 #: ../ex_docmd.c:4432
 msgid ""
 "\n"
-"    Name        Args Range Complete  Definition"
+"    Name        Args       Address   Complete  Definition"
 msgstr ""
 "\n"
-"    名前        引数 範囲  補完      定義"
+"    名前        引数       アドレス  補完      定義"
 
 #: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
-msgstr "ユーザ定義コマンドが見つかりませんでした"
+msgstr "ユーザー定義コマンドが見つかりませんでした"
 
 #: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
@@ -1633,7 +1660,10 @@ msgstr "E178: カウントの省略値が無効です"
 
 #: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
-msgstr "E179: -補完のための引数が必要です"
+msgstr "E179: -complete には引数が必要です"
+
+msgid "E179: argument required for -addr"
+msgstr "E179: -addr には引数が必要です"
 
 #: ../ex_docmd.c:4635
 #, c-format
@@ -1650,12 +1680,16 @@ msgstr "E183: ユーザ定義コマンドは英大文字で始まらなければなりません"
 
 #: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
-msgstr "E841: 予約名なので, ユーザ定義コマンドに利用できません"
+msgstr "E841: 予約名なので, ユーザー定義コマンドに利用できません"
 
 #: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
-msgstr "E184: そのユーザ定義コマンドはありません: %s"
+msgstr "E184: そのユーザー定義コマンドはありません: %s"
+
+#, c-format
+msgid "E180: Invalid address type value: %s"
+msgstr "E180: 無効なアドレスタイプ値です: %s"
 
 #: ../ex_docmd.c:5219
 #, c-format
@@ -2019,11 +2053,11 @@ msgstr "不正なファイル名"
 
 #: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
-msgstr " はディレクトリです"
+msgstr "はディレクトリです"
 
 #: ../fileio.c:397
 msgid "is not a file"
-msgstr " はファイルではありません"
+msgstr "はファイルではありません"
 
 #: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
@@ -2039,7 +2073,7 @@ msgstr "[ファイル過大]"
 
 #: ../fileio.c:534
 msgid "[Permission Denied]"
-msgstr "[認可がありません]"
+msgstr "[権限がありません]"
 
 #: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
@@ -2210,7 +2244,7 @@ msgstr " 変換エラー"
 #: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
-msgstr "行 %<PRId64>;"
+msgstr " 行 %<PRId64>;"
 
 #: ../fileio.c:3519
 msgid "[Device]"
@@ -2766,9 +2800,8 @@ msgid "E37: No write since last change (add ! to override)"
 msgstr "E37: 最後の変更が保存されていません (! を追加で変更を破棄)"
 
 #: ../globals.h:1055
-#, fuzzy
 msgid "E37: No write since last change"
-msgstr "[最後の変更が保存されていません]\n"
+msgstr "E37: 最後の変更が保存されていません"
 
 #: ../globals.h:1056
 msgid "E38: Null argument"
@@ -2810,7 +2843,7 @@ msgstr "E42: エラーはありません"
 
 #: ../globals.h:1067
 msgid "E776: No location list"
-msgstr "E776: 場所リストはありません"
+msgstr "E776: ロケーションリストはありません"
 
 #: ../globals.h:1068
 msgid "E43: Damaged match string"
@@ -3831,7 +3864,7 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"それから.swpファイルを削除してください\n"
+"元の.swpファイルは削除しても構いません\n"
 "\n"
 
 #. use msg() to start the scrolling properly
@@ -3845,7 +3878,7 @@ msgstr "   現在のディレクトリ:\n"
 
 #: ../memline.c:1448
 msgid "   Using specified name:\n"
-msgstr "   ある名前を使用中:\n"
+msgstr "   以下の名前を使用中:\n"
 
 #: ../memline.c:1450
 msgid "   In directory "
@@ -3901,7 +3934,7 @@ msgid ""
 "         user name: "
 msgstr ""
 "\n"
-"          ユーザ名: "
+"        ユーザー名: "
 
 #: ../memline.c:1568
 msgid "   host name: "
@@ -4050,12 +4083,12 @@ msgid ""
 msgstr ""
 "\n"
 "(1) 別のプログラムが同じファイルを編集しているかもしれません.\n"
-"    この場合には, 変更をした際に最終的に, 同じファイルの異なる\n"
-"    2つのインスタンスができてしまうことに注意してください."
+"    この場合には, 変更をしてしまうと1つのファイルに対して異なる2つの\n"
+"    インスタンスができてしまうので, そうしないように気をつけてください."
 
 #: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
-msgstr "  終了するか, 注意しながら続けてください.\n"
+msgstr "    終了するか, 注意しながら続けてください.\n"
 
 #: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
@@ -4479,6 +4512,11 @@ msgstr ""
 msgid "E574: Unknown register type %d"
 msgstr "E574: 未知のレジスタ型 %d です"
 
+msgid ""
+"E883: search pattern and expression register may not contain two or more "
+"lines"
+msgstr "E883: 検索パターンと式レジスタには2行以上を含められません"
+
 #: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
@@ -4562,6 +4600,10 @@ msgstr "E522: termcap 内に見つかりません"
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 不正な文字です <%s>"
+
+#, c-format
+msgid "For option %s"
+msgstr "オプション: %s"
 
 #: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
@@ -4739,6 +4781,14 @@ msgid ""
 msgstr ""
 "\n"
 "セキュリティコンテキストを設定できません "
+
+#, c-format
+msgid "Could not set security context %s for %s"
+msgstr "セキュリティコンテキスト %s を %s に設定できません"
+
+#, c-format
+msgid "Could not get security context %s for %s. Removing it!"
+msgstr "セキュリティコンテキスト %s を %s から取得できません. 削除します!"
 
 #: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
@@ -4960,6 +5010,10 @@ msgstr "E554: %s{...} 内に文法エラーがあります"
 msgid "External submatches:\n"
 msgstr "外部の部分該当:\n"
 
+#, c-format
+msgid "E888: (NFA regexp) cannot repeat %s"
+msgstr "E888: (NFA 正規表現) 繰り返せません %s"
+
 #: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
@@ -4967,6 +5021,9 @@ msgid ""
 msgstr ""
 "E864: \\%#= には 0, 1 もしくは 2 のみが続けられます。正規表現エンジンは自動選"
 "択されます。"
+
+msgid "Switching to backtracking RE engine for pattern: "
+msgstr "次のパターンにバックトラッキング RE エンジンを適用します: "
 
 #: ../regexp_nfa.c:239
 msgid "E865: (NFA) Regexp end encountered prematurely"
@@ -4980,7 +5037,7 @@ msgstr "E866: (NFA 正規表現) 位置が誤っています: %c"
 #: ../regexp_nfa.c:242
 #, c-format
 msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
-msgstr ""
+msgstr "E877: (NFA 正規表現) 無効な文字クラス: %<PRId64>"
 
 #: ../regexp_nfa.c:1261
 #, c-format
@@ -5590,14 +5647,14 @@ msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' には %<PRId64> 個のエントリはありません"
 
 #: ../spell.c:8074
-#, fuzzy, c-format
+#, c-format
 msgid "Word '%.*s' removed from %s"
-msgstr "%s から単語が削除されました"
+msgstr "単語 '%.*s' が %s から削除されました"
 
 #: ../spell.c:8117
-#, fuzzy, c-format
+#, c-format
 msgid "Word '%.*s' added to %s"
-msgstr "%s に単語が追加されました"
+msgstr "単語 '%.*s' が %s へ追加されました"
 
 #: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
@@ -5672,6 +5729,9 @@ msgstr "このバッファに定義された構文要素はありません"
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 不正な引数です: %s"
+
+msgid "syntax iskeyword "
+msgstr "シンタックス用 iskeyword "
 
 #: ../syntax.c:3299
 #, c-format
@@ -5768,6 +5828,10 @@ msgstr "E847: 構文の取り込み(include)が多過ぎます"
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ']' がありません: %s"
+
+#, c-format
+msgid "E890: trailing char after ']': %s]%s"
+msgstr "E890: ']' の後ろに余分な文字があります: %s]%s"
 
 #: ../syntax.c:4531
 #, c-format
@@ -5874,7 +5938,7 @@ msgstr "E415: 予期せぬ等号です: %s"
 #: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
-msgstr "E416: 等号ががありません: %s"
+msgstr "E416: 等号がありません: %s"
 
 #: ../syntax.c:6418
 #, c-format
@@ -6078,9 +6142,8 @@ msgstr "Vim: 入力を読込み中のエラーにより終了します...\n"
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
 #: ../undo.c:379
-#, fuzzy
 msgid "E881: Line count changed unexpectedly"
-msgstr "E834: 予期せず行カウントが変わりました"
+msgstr "E881: 予期せず行カウントが変わりました"
 
 #: ../undo.c:627
 #, c-format
@@ -6287,23 +6350,23 @@ msgstr "      システム vimrc: \""
 
 #: ../version.c:672
 msgid "     user vimrc file: \""
-msgstr "        ユーザ vimrc: \""
+msgstr "      ユーザー vimrc: \""
 
 #: ../version.c:677
 msgid " 2nd user vimrc file: \""
-msgstr "     第2ユーザ vimrc: \""
+msgstr "   第2ユーザー vimrc: \""
 
 #: ../version.c:682
 msgid " 3rd user vimrc file: \""
-msgstr "     第3ユーザ vimrc: \""
+msgstr "   第3ユーザー vimrc: \""
 
 #: ../version.c:687
 msgid "      user exrc file: \""
-msgstr "         ユーザ exrc: \""
+msgstr "       ユーザー exrc: \""
 
 #: ../version.c:692
 msgid "  2nd user exrc file: \""
-msgstr "      第2ユーザ exrc: \""
+msgstr "    第2ユーザー exrc: \""
 
 #: ../version.c:699
 msgid "  fall-back for $VIM: \""
@@ -6379,7 +6442,7 @@ msgstr "Vimの開発を応援してください!"
 
 #: ../version.c:828
 msgid "Become a registered Vim user!"
-msgstr "Vimの登録ユーザになってください!"
+msgstr "Vimの登録ユーザーになってください!"
 
 #: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
@@ -6391,7 +6454,7 @@ msgstr "詳細な情報は           :help register<Enter>  "
 
 #: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
-msgstr "詳細はメニューの ヘルプ→スポンサー/登録 を参照して下さい   "
+msgstr "詳細はメニューの ヘルプ->スポンサー/登録 を参照して下さい"
 
 #: ../window.c:119
 msgid "Already only one window"
@@ -6428,6 +6491,9 @@ msgstr "E445: 他のウィンドウには変更があります"
 #: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: カーソルの下にファイル名がありません"
+
+msgid "List or number required"
+msgstr "リストか数値が必要です"
 
 #~ msgid "E831: bf_key_init() called with empty password"
 #~ msgstr "E831: bf_key_init() が空パスワードで呼び出されました"

--- a/src/nvim/po/ja.po
+++ b/src/nvim/po/ja.po
@@ -1,11 +1,11 @@
-# Japanese translation for Vim			vim:set foldmethod=marker:
+# Japanese translation for Vim
 #
 # Do ":help uganda"  in Vim to read copying and usage conditions.
 # Do ":help credits" in Vim to see a list of people who contributed.
 #
-# Last Change: 2013 Jul 06
+# Copyright (C) 2001-2016 MURAOKA Taro <koron.kaoriya@gmail.com>,
+# 			  vim-jp (http://vim-jp.org/)
 #
-# Copyright (C) 2001-13 MURAOKA Taro <koron.kaoriya@gmail.com>
 # THIS FILE IS DISTRIBUTED UNDER THE VIM LICENSE.
 #
 # Original translations.
@@ -14,10 +14,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 7.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-05-26 14:21+0200\n"
-"PO-Revision-Date: 2013-07-06 15:00+0900\n"
+"POT-Creation-Date: 2016-02-01 09:02+0900\n"
+"PO-Revision-Date: 2013-06-02-01 09:08+09n"
 "Last-Translator: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
-"Language-Team: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
+"Language-Team: vim-jp (https://github.com/vim-jp/lang-ja)\n"
 "Language: Japanese\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -34,7 +34,7 @@ msgstr "内部エラー: 未知のオプション型です"
 
 #: ../buffer.c:92
 msgid "[Location List]"
-msgstr "[場所リスト]"
+msgstr "[ロケーションリスト]"
 
 #: ../buffer.c:93
 msgid "[Quickfix List]"
@@ -277,7 +277,7 @@ msgstr "E810: 一時ファイルの読込もしくは書込ができません"
 
 #: ../diff.c:755
 msgid "E97: Cannot create diffs"
-msgstr "E97: 差分を作成できません "
+msgstr "E97: 差分を作成できません"
 
 #: ../diff.c:966
 msgid "E816: Cannot read patch output"
@@ -293,7 +293,7 @@ msgstr "E99: 現在のバッファは差分モードではありません"
 
 #: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
-msgstr "E793: 差分モードである他のバッファは変更可能です"
+msgstr "E793: 差分モードである他のバッファは変更できません"
 
 #: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
@@ -349,7 +349,7 @@ msgstr " 行(全体)補完 (^L^N^P)"
 
 #: ../edit.c:86
 msgid " File name completion (^F^N^P)"
-msgstr "ファイル名補完 (^F^N^P)"
+msgstr " ファイル名補完 (^F^N^P)"
 
 #: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
@@ -377,7 +377,7 @@ msgstr " コマンドライン補完 (^V^N^P)"
 
 #: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
-msgstr " ユーザ定義補完 (^U^N^P)"
+msgstr " ユーザー定義補完 (^U^N^P)"
 
 #: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
@@ -679,6 +679,10 @@ msgstr "E696: リスト型にカンマがありません: %s"
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: リスト型の最後に ']' がありません: %s"
 
+msgid "Not enough memory to set references, garbage collection aborted!"
+msgstr ""
+"ガーベッジコレクションを中止しました! 参照を作成するのにメモリが不足しました"
+
 #: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
@@ -721,7 +725,7 @@ msgstr "E117: 未知の関数です: %s"
 #: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: 関数の引数が少な過ぎます: %s"
+msgstr "E119: 関数の引数が足りません: %s"
 
 #: ../eval.c:7387
 #, c-format
@@ -826,18 +830,16 @@ msgid "sort() argument"
 msgstr "sort() の引数"
 
 #: ../eval.c:13721
-#, fuzzy
 msgid "uniq() argument"
-msgstr "add() の引数"
+msgstr "uniq() の引数"
 
 #: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: ソートの比較関数が失敗しました"
 
 #: ../eval.c:13806
-#, fuzzy
 msgid "E882: Uniq compare function failed"
-msgstr "E702: ソートの比較関数が失敗しました"
+msgstr "E882: Uniq の比較関数が失敗しました"
 
 #: ../eval.c:14085
 msgid "(Invalid)"
@@ -862,6 +864,18 @@ msgstr "E745: リスト型を数値として扱っています"
 #: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: 辞書型を数値として扱っています"
+
+msgid "E891: Using a Funcref as a Float"
+msgstr "E891: 関数参照型を浮動小数点数として扱っています。"
+
+msgid "E892: Using a String as a Float"
+msgstr "E892: 文字列を浮動小数点数として扱っています"
+
+msgid "E893: Using a List as a Float"
+msgstr "E893: リスト型を浮動小数点数として扱っています"
+
+msgid "E894: Using a Dictionary as a Float"
+msgstr "E894: 辞書型を浮動小数点数として扱っています"
 
 #: ../eval.c:16259
 msgid "E729: using Funcref as a String"
@@ -961,14 +975,14 @@ msgid "E129: Function name required"
 msgstr "E129: 関数名が要求されます"
 
 #: ../eval.c:17824
-#, fuzzy, c-format
+#, c-format
 msgid "E128: Function name must start with a capital or \"s:\": %s"
-msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
+msgstr "E128: 関数名は大文字か \"s:\" で始まらなければなりません: %s"
 
 #: ../eval.c:17833
-#, fuzzy, c-format
+#, c-format
 msgid "E884: Function name cannot contain a colon: %s"
-msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
+msgstr "E884: 関数名にはコロンは含められません: %s"
 
 #: ../eval.c:18336
 #, c-format
@@ -1081,7 +1095,7 @@ msgstr "E136: viminfo: エラーが多過ぎるので, 以降はスキップし�
 #: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
-msgstr "viminfoファイル \"%s\"%s%s%s を読込み中 "
+msgstr "viminfoファイル \"%s\"%s%s%s を読込み中"
 
 #: ../ex_cmds.c:1460
 msgid " info"
@@ -1357,6 +1371,10 @@ msgstr "E158: 無効なバッファ名です: %s"
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: 無効なsign識別子です: %<PRId64>"
 
+#, c-format
+msgid "E885: Not possible to change sign %s"
+msgstr "E885: 変更できない sign です: %s"
+
 #: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (非サポート)"
@@ -1378,6 +1396,13 @@ msgstr "行 %<PRId64>: %s"
 #, c-format
 msgid "cmd: %s"
 msgstr "コマンド: %s"
+
+msgid "frame is zero"
+msgstr "フレームが 0 です"
+
+#, c-format
+msgid "frame at highest level: %d"
+msgstr "最高レベルのフレーム: %d"
 
 #: ../ex_cmds2.c:322
 #, c-format
@@ -1528,7 +1553,8 @@ msgstr "E197: 言語を \"%s\" に設定できません"
 #. don't wait for return
 #: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
-msgstr "Exモードに入ります. ノーマルに戻るには\"visual\"と入力してください."
+msgstr ""
+"Exモードに入ります. ノーマルモードに戻るには\"visual\"と入力してください."
 
 #: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
@@ -1553,7 +1579,7 @@ msgstr "関数の最後です"
 
 #: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
-msgstr "E464: ユーザ定義コマンドのあいまいな使用です"
+msgstr "E464: ユーザー定義コマンドのあいまいな使用です"
 
 #: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
@@ -1606,14 +1632,14 @@ msgstr "E174: コマンドが既にあります: 再定義するには ! を追�
 #: ../ex_docmd.c:4432
 msgid ""
 "\n"
-"    Name        Args Range Complete  Definition"
+"    Name        Args       Address   Complete  Definition"
 msgstr ""
 "\n"
-"    名前        引数 範囲  補完      定義"
+"    名前        引数       アドレス  補完      定義"
 
 #: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
-msgstr "ユーザ定義コマンドが見つかりませんでした"
+msgstr "ユーザー定義コマンドが見つかりませんでした"
 
 #: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
@@ -1633,7 +1659,10 @@ msgstr "E178: カウントの省略値が無効です"
 
 #: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
-msgstr "E179: -補完のための引数が必要です"
+msgstr "E179: -complete には引数が必要です"
+
+msgid "E179: argument required for -addr"
+msgstr "E179: -addr には引数が必要です"
 
 #: ../ex_docmd.c:4635
 #, c-format
@@ -1646,16 +1675,20 @@ msgstr "E182: 無効なコマンド名です"
 
 #: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
-msgstr "E183: ユーザ定義コマンドは英大文字で始まらなければなりません"
+msgstr "E183: ユーザー定義コマンドは英大文字で始まらなければなりません"
 
 #: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
-msgstr "E841: 予約名なので, ユーザ定義コマンドに利用できません"
+msgstr "E841: 予約名なので, ユーザー定義コマンドに利用できません"
 
 #: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
-msgstr "E184: そのユーザ定義コマンドはありません: %s"
+msgstr "E184: そのユーザー定義コマンドはありません: %s"
+
+#, c-format
+msgid "E180: Invalid address type value: %s"
+msgstr "E180: 無効なアドレスタイプ値です: %s"
 
 #: ../ex_docmd.c:5219
 #, c-format
@@ -2019,11 +2052,11 @@ msgstr "不正なファイル名"
 
 #: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
-msgstr " はディレクトリです"
+msgstr "はディレクトリです"
 
 #: ../fileio.c:397
 msgid "is not a file"
-msgstr " はファイルではありません"
+msgstr "はファイルではありません"
 
 #: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
@@ -2039,7 +2072,7 @@ msgstr "[ファイル過大]"
 
 #: ../fileio.c:534
 msgid "[Permission Denied]"
-msgstr "[認可がありません]"
+msgstr "[権限がありません]"
 
 #: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
@@ -2210,7 +2243,7 @@ msgstr " 変換エラー"
 #: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
-msgstr "行 %<PRId64>;"
+msgstr " 行 %<PRId64>;"
 
 #: ../fileio.c:3519
 msgid "[Device]"
@@ -2766,9 +2799,8 @@ msgid "E37: No write since last change (add ! to override)"
 msgstr "E37: 最後の変更が保存されていません (! を追加で変更を破棄)"
 
 #: ../globals.h:1055
-#, fuzzy
 msgid "E37: No write since last change"
-msgstr "[最後の変更が保存されていません]\n"
+msgstr "E37: 最後の変更が保存されていません"
 
 #: ../globals.h:1056
 msgid "E38: Null argument"
@@ -2810,7 +2842,7 @@ msgstr "E42: エラーはありません"
 
 #: ../globals.h:1067
 msgid "E776: No location list"
-msgstr "E776: 場所リストはありません"
+msgstr "E776: ロケーションリストはありません"
 
 #: ../globals.h:1068
 msgid "E43: Damaged match string"
@@ -3831,7 +3863,7 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"それから.swpファイルを削除してください\n"
+"元の.swpファイルは削除しても構いません\n"
 "\n"
 
 #. use msg() to start the scrolling properly
@@ -3845,7 +3877,7 @@ msgstr "   現在のディレクトリ:\n"
 
 #: ../memline.c:1448
 msgid "   Using specified name:\n"
-msgstr "   ある名前を使用中:\n"
+msgstr "   以下の名前を使用中:\n"
 
 #: ../memline.c:1450
 msgid "   In directory "
@@ -3901,7 +3933,7 @@ msgid ""
 "         user name: "
 msgstr ""
 "\n"
-"          ユーザ名: "
+"        ユーザー名: "
 
 #: ../memline.c:1568
 msgid "   host name: "
@@ -4050,12 +4082,12 @@ msgid ""
 msgstr ""
 "\n"
 "(1) 別のプログラムが同じファイルを編集しているかもしれません.\n"
-"    この場合には, 変更をした際に最終的に, 同じファイルの異なる\n"
-"    2つのインスタンスができてしまうことに注意してください."
+"    この場合には, 変更をしてしまうと1つのファイルに対して異なる2つの\n"
+"    インスタンスができてしまうので, そうしないように気をつけてください."
 
 #: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
-msgstr "  終了するか, 注意しながら続けてください.\n"
+msgstr "    終了するか, 注意しながら続けてください.\n"
 
 #: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
@@ -4479,6 +4511,11 @@ msgstr ""
 msgid "E574: Unknown register type %d"
 msgstr "E574: 未知のレジスタ型 %d です"
 
+msgid ""
+"E883: search pattern and expression register may not contain two or more "
+"lines"
+msgstr "E883: 検索パターンと式レジスタには2行以上を含められません"
+
 #: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
@@ -4562,6 +4599,10 @@ msgstr "E522: termcap 内に見つかりません"
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 不正な文字です <%s>"
+
+#, c-format
+msgid "For option %s"
+msgstr "オプション: %s"
 
 #: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
@@ -4739,6 +4780,14 @@ msgid ""
 msgstr ""
 "\n"
 "セキュリティコンテキストを設定できません "
+
+#, c-format
+msgid "Could not set security context %s for %s"
+msgstr "セキュリティコンテキスト %s を %s に設定できません"
+
+#, c-format
+msgid "Could not get security context %s for %s. Removing it!"
+msgstr "セキュリティコンテキスト %s を %s から取得できません. 削除します!"
 
 #: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
@@ -4960,6 +5009,10 @@ msgstr "E554: %s{...} 内に文法エラーがあります"
 msgid "External submatches:\n"
 msgstr "外部の部分該当:\n"
 
+#, c-format
+msgid "E888: (NFA regexp) cannot repeat %s"
+msgstr "E888: (NFA 正規表現) 繰り返せません %s"
+
 #: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
@@ -4967,6 +5020,9 @@ msgid ""
 msgstr ""
 "E864: \\%#= には 0, 1 もしくは 2 のみが続けられます。正規表現エンジンは自動選"
 "択されます。"
+
+msgid "Switching to backtracking RE engine for pattern: "
+msgstr "次のパターンにバックトラッキング RE エンジンを適用します: "
 
 #: ../regexp_nfa.c:239
 msgid "E865: (NFA) Regexp end encountered prematurely"
@@ -4980,7 +5036,7 @@ msgstr "E866: (NFA 正規表現) 位置が誤っています: %c"
 #: ../regexp_nfa.c:242
 #, c-format
 msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
-msgstr ""
+msgstr "E877: (NFA 正規表現) 無効な文字クラス: %<PRId64>"
 
 #: ../regexp_nfa.c:1261
 #, c-format
@@ -5590,12 +5646,12 @@ msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' には %<PRId64> 個のエントリはありません"
 
 #: ../spell.c:8074
-#, fuzzy, c-format
+#, c-format
 msgid "Word '%.*s' removed from %s"
-msgstr "%s から単語が削除されました"
+msgstr "単語 '%.*s' が %s から削除されました"
 
 #: ../spell.c:8117
-#, fuzzy, c-format
+#, c-format
 msgid "Word '%.*s' added to %s"
 msgstr "%s に単語が追加されました"
 
@@ -5672,6 +5728,9 @@ msgstr "このバッファに定義された構文要素はありません"
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 不正な引数です: %s"
+
+msgid "syntax iskeyword "
+msgstr "シンタックス用 iskeyword "
 
 #: ../syntax.c:3299
 #, c-format
@@ -5768,6 +5827,10 @@ msgstr "E847: 構文の取り込み(include)が多過ぎます"
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ']' がありません: %s"
+
+#, c-format
+msgid "E890: trailing char after ']': %s]%s"
+msgstr "E890: ']' の後ろに余分な文字があります: %s]%s"
 
 #: ../syntax.c:4531
 #, c-format
@@ -5874,7 +5937,7 @@ msgstr "E415: 予期せぬ等号です: %s"
 #: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
-msgstr "E416: 等号ががありません: %s"
+msgstr "E416: 等号がありません: %s"
 
 #: ../syntax.c:6418
 #, c-format
@@ -6078,9 +6141,8 @@ msgstr "Vim: 入力を読込み中のエラーにより終了します...\n"
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
 #: ../undo.c:379
-#, fuzzy
 msgid "E881: Line count changed unexpectedly"
-msgstr "E834: 予期せず行カウントが変わりました"
+msgstr "E881: 予期せず行カウントが変わりました"
 
 #: ../undo.c:627
 #, c-format
@@ -6287,23 +6349,23 @@ msgstr "      システム vimrc: \""
 
 #: ../version.c:672
 msgid "     user vimrc file: \""
-msgstr "        ユーザ vimrc: \""
+msgstr "      ユーザー vimrc: \""
 
 #: ../version.c:677
 msgid " 2nd user vimrc file: \""
-msgstr "     第2ユーザ vimrc: \""
+msgstr "   第2ユーザー vimrc: \""
 
 #: ../version.c:682
 msgid " 3rd user vimrc file: \""
-msgstr "     第3ユーザ vimrc: \""
+msgstr "   第3ユーザー vimrc: \""
 
 #: ../version.c:687
 msgid "      user exrc file: \""
-msgstr "         ユーザ exrc: \""
+msgstr "       ユーザー exrc: \""
 
 #: ../version.c:692
 msgid "  2nd user exrc file: \""
-msgstr "      第2ユーザ exrc: \""
+msgstr "    第2ユーザー exrc: \""
 
 #: ../version.c:699
 msgid "  fall-back for $VIM: \""
@@ -6379,7 +6441,7 @@ msgstr "Vimの開発を応援してください!"
 
 #: ../version.c:828
 msgid "Become a registered Vim user!"
-msgstr "Vimの登録ユーザになってください!"
+msgstr "Vimの登録ユーザーになってください!"
 
 #: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
@@ -6391,7 +6453,7 @@ msgstr "詳細な情報は           :help register<Enter>  "
 
 #: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
-msgstr "詳細はメニューの ヘルプ→スポンサー/登録 を参照して下さい   "
+msgstr "詳細はメニューの ヘルプ->スポンサー/登録 を参照して下さい"
 
 #: ../window.c:119
 msgid "Already only one window"
@@ -6428,6 +6490,9 @@ msgstr "E445: 他のウィンドウには変更があります"
 #: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: カーソルの下にファイル名がありません"
+
+msgid "List or number required"
+msgstr "リストか数値が必要です"
 
 #~ msgid "E831: bf_key_init() called with empty password"
 #~ msgstr "E831: bf_key_init() が空パスワードで呼び出されました"

--- a/src/nvim/po/ja.sjis.po
+++ b/src/nvim/po/ja.sjis.po
@@ -1,11 +1,11 @@
-# Japanese translation for Vim			vim:set foldmethod=marker:
+# Japanese translation for Vim
 #
 # Do ":help uganda"  in Vim to read copying and usage conditions.
 # Do ":help credits" in Vim to see a list of people who contributed.
 #
-# Last Change: 2013 Jul 06
+# Copyright (C) 2001-2016 MURAOKA Taro <koron.kaoriya@gmail.com>,
+# 			  vim-jp (http://vim-jp.org/)
 #
-# Copyright (C) 2001-13 MURAOKA Taro <koron.kaoriya@gmail.com>
 # THIS FILE IS DISTRIBUTED UNDER THE VIM LICENSE.
 #
 # Original translations.
@@ -14,10 +14,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim 7.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-05-26 14:21+0200\n"
-"PO-Revision-Date: 2013-07-06 15:00+0900\n"
+"POT-Creation-Date: 2016-02-01 09:02+0900\n"
+"PO-Revision-Date: 2016-02-01 09:08+0900\n"
 "Last-Translator: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
-"Language-Team: MURAOKA Taro <koron.kaoriya@gmail.com>\n"
+"Language-Team: vim-jpj (https://github.com/vim-jp/lang-ja)\n"
 "Language: Japanese\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=cp932\n"
@@ -34,7 +34,7 @@ msgstr "内部エラー: 未知のオプション型です"
 
 #: ../buffer.c:92
 msgid "[Location List]"
-msgstr "[場所リスト]"
+msgstr "[ロケーションリスト]"
 
 #: ../buffer.c:93
 msgid "[Quickfix List]"
@@ -277,7 +277,7 @@ msgstr "E810: 一時ファイルの読込もしくは書込ができません"
 
 #: ../diff.c:755
 msgid "E97: Cannot create diffs"
-msgstr "E97: 差分を作成できません "
+msgstr "E97: 差分を作成できません"
 
 #: ../diff.c:966
 msgid "E816: Cannot read patch output"
@@ -293,7 +293,7 @@ msgstr "E99: 現在のバッファは差分モードではありません"
 
 #: ../diff.c:2100
 msgid "E793: No other buffer in diff mode is modifiable"
-msgstr "E793: 差分モードである他のバッファは変更可能\です"
+msgstr "E793: 差分モードである他のバッファは変更できません"
 
 #: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
@@ -349,7 +349,7 @@ msgstr " 行(全体)補完 (^L^N^P)"
 
 #: ../edit.c:86
 msgid " File name completion (^F^N^P)"
-msgstr "ファイル名補完 (^F^N^P)"
+msgstr " ファイル名補完 (^F^N^P)"
 
 #: ../edit.c:87
 msgid " Tag completion (^]^N^P)"
@@ -377,7 +377,7 @@ msgstr " コマンドライン補完 (^V^N^P)"
 
 #: ../edit.c:94
 msgid " User defined completion (^U^N^P)"
-msgstr " ユーザ定義補完 (^U^N^P)"
+msgstr " ユーザー定義補完 (^U^N^P)"
 
 #: ../edit.c:95
 msgid " Omni completion (^O^N^P)"
@@ -679,6 +679,10 @@ msgstr "E696: リスト型にカンマがありません: %s"
 msgid "E697: Missing end of List ']': %s"
 msgstr "E697: リスト型の最後に ']' がありません: %s"
 
+msgid "Not enough memory to set references, garbage collection aborted!"
+msgstr ""
+"ガーベッジコレクションを中止しました! 参照を作成するのにメモリが不足しました"
+
 #: ../eval.c:6475
 #, c-format
 msgid "E720: Missing colon in Dictionary: %s"
@@ -721,7 +725,7 @@ msgstr "E117: 未知の関数です: %s"
 #: ../eval.c:7383
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: 関数の引数が少な過ぎます: %s"
+msgstr "E119: 関数の引数が足りません: %s"
 
 #: ../eval.c:7387
 #, c-format
@@ -826,18 +830,16 @@ msgid "sort() argument"
 msgstr "sort() の引数"
 
 #: ../eval.c:13721
-#, fuzzy
 msgid "uniq() argument"
-msgstr "add() の引数"
+msgstr "uniq() の引数"
 
 #: ../eval.c:13776
 msgid "E702: Sort compare function failed"
 msgstr "E702: ソ\ートの比較関数が失敗しました"
 
 #: ../eval.c:13806
-#, fuzzy
 msgid "E882: Uniq compare function failed"
-msgstr "E702: ソ\ートの比較関数が失敗しました"
+msgstr "E882: Uniq の比較関数が失敗しました"
 
 #: ../eval.c:14085
 msgid "(Invalid)"
@@ -862,6 +864,18 @@ msgstr "E745: リスト型を数値として扱っています"
 #: ../eval.c:16173
 msgid "E728: Using a Dictionary as a Number"
 msgstr "E728: 辞書型を数値として扱っています"
+
+msgid "E891: Using a Funcref as a Float"
+msgstr "E891: 関数参照型を浮動小数点数として扱っています。"
+
+msgid "E892: Using a String as a Float"
+msgstr "E892: 文字列を浮動小数点数として扱っています"
+
+msgid "E893: Using a List as a Float"
+msgstr "E893: リスト型を浮動小数点数として扱っています"
+
+msgid "E894: Using a Dictionary as a Float"
+msgstr "E894: 辞書型を浮動小数点数として扱っています"
 
 #: ../eval.c:16259
 msgid "E729: using Funcref as a String"
@@ -961,14 +975,14 @@ msgid "E129: Function name required"
 msgstr "E129: 関数名が要求されます"
 
 #: ../eval.c:17824
-#, fuzzy, c-format
+#, c-format
 msgid "E128: Function name must start with a capital or \"s:\": %s"
-msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
+msgstr "E128: 関数名は大文字か \"s:\" で始まらなければなりません: %s"
 
 #: ../eval.c:17833
-#, fuzzy, c-format
+#, c-format
 msgid "E884: Function name cannot contain a colon: %s"
-msgstr "E128: 関数名は大文字で始まるかコロンを含まなければなりません: %s"
+msgstr "E884: 関数名にはコロンは含められません: %s"
 
 #: ../eval.c:18336
 #, c-format
@@ -1081,7 +1095,7 @@ msgstr "E136: viminfo: エラーが多過ぎるので, 以降はスキップします"
 #: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
-msgstr "viminfoファイル \"%s\"%s%s%s を読込み中 "
+msgstr "viminfoファイル \"%s\"%s%s%s を読込み中"
 
 #: ../ex_cmds.c:1460
 msgid " info"
@@ -1357,6 +1371,10 @@ msgstr "E158: 無効なバッファ名です: %s"
 msgid "E157: Invalid sign ID: %<PRId64>"
 msgstr "E157: 無効なsign識別子です: %<PRId64>"
 
+#, c-format
+msgid "E885: Not possible to change sign %s"
+msgstr "E885: 変更できない sign です: %s"
+
 #: ../ex_cmds.c:6066
 msgid " (not supported)"
 msgstr " (非サポート)"
@@ -1378,6 +1396,13 @@ msgstr "行 %<PRId64>: %s"
 #, c-format
 msgid "cmd: %s"
 msgstr "コマンド: %s"
+
+msgid "frame is zero"
+msgstr "フレームが 0 です"
+
+#, c-format
+msgid "frame at highest level: %d"
+msgstr "最高レベルのフレーム: %d"
 
 #: ../ex_cmds2.c:322
 #, c-format
@@ -1528,7 +1553,8 @@ msgstr "E197: 言語を \"%s\" に設定できません"
 #. don't wait for return
 #: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
-msgstr "Exモードに入ります. ノーマルに戻るには\"visual\"と入力してください."
+msgstr ""
+"Exモードに入ります. ノーマルモードに戻るには\"visual\"と入力してください."
 
 #: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
@@ -1553,7 +1579,7 @@ msgstr "関数の最後です"
 
 #: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
-msgstr "E464: ユーザ定義コマンドのあいまいな使用です"
+msgstr "E464: ユーザー定義コマンドのあいまいな使用です"
 
 #: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
@@ -1606,14 +1632,14 @@ msgstr "E174: コマンドが既にあります: 再定義するには ! を追加してください"
 #: ../ex_docmd.c:4432
 msgid ""
 "\n"
-"    Name        Args Range Complete  Definition"
+"    Name        Args       Address   Complete  Definition"
 msgstr ""
 "\n"
-"    名前        引数 範囲  補完      定義"
+"    名前        引数       アドレス  補完      定義"
 
 #: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
-msgstr "ユーザ定義コマンドが見つかりませんでした"
+msgstr "ユーザー定義コマンドが見つかりませんでした"
 
 #: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
@@ -1633,7 +1659,10 @@ msgstr "E178: カウントの省略値が無効です"
 
 #: ../ex_docmd.c:4625
 msgid "E179: argument required for -complete"
-msgstr "E179: -補完のための引数が必要です"
+msgstr "E179: -complete には引数が必要です"
+
+msgid "E179: argument required for -addr"
+msgstr "E179: -addr には引数が必要です"
 
 #: ../ex_docmd.c:4635
 #, c-format
@@ -1646,16 +1675,20 @@ msgstr "E182: 無効なコマンド名です"
 
 #: ../ex_docmd.c:4691
 msgid "E183: User defined commands must start with an uppercase letter"
-msgstr "E183: ユーザ定義コマンドは英大文字で始まらなければなりません"
+msgstr "E183: ユーザー定義コマンドは英大文字で始まらなければなりません"
 
 #: ../ex_docmd.c:4696
 msgid "E841: Reserved name, cannot be used for user defined command"
-msgstr "E841: 予\約名なので, ユーザ定義コマンドに利用できません"
+msgstr "E841: 予\約名なので, ユーザー定義コマンドに利用できません"
 
 #: ../ex_docmd.c:4751
 #, c-format
 msgid "E184: No such user-defined command: %s"
-msgstr "E184: そのユーザ定義コマンドはありません: %s"
+msgstr "E184: そのユーザー定義コマンドはありません: %s"
+
+#, c-format
+msgid "E180: Invalid address type value: %s"
+msgstr "E180: 無効なアドレスタイプ値です: %s"
 
 #: ../ex_docmd.c:5219
 #, c-format
@@ -2019,11 +2052,11 @@ msgstr "不正なファイル名"
 
 #: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
-msgstr " はディレクトリです"
+msgstr "はディレクトリです"
 
 #: ../fileio.c:397
 msgid "is not a file"
-msgstr " はファイルではありません"
+msgstr "はファイルではありません"
 
 #: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
@@ -2039,7 +2072,7 @@ msgstr "[ファイル過大]"
 
 #: ../fileio.c:534
 msgid "[Permission Denied]"
-msgstr "[認可がありません]"
+msgstr "[権限がありません]"
 
 #: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
@@ -2210,7 +2243,7 @@ msgstr " 変換エラー"
 #: ../fileio.c:3509
 #, c-format
 msgid " in line %<PRId64>;"
-msgstr "行 %<PRId64>;"
+msgstr " 行 %<PRId64>;"
 
 #: ../fileio.c:3519
 msgid "[Device]"
@@ -2766,9 +2799,8 @@ msgid "E37: No write since last change (add ! to override)"
 msgstr "E37: 最後の変更が保存されていません (! を追加で変更を破棄)"
 
 #: ../globals.h:1055
-#, fuzzy
 msgid "E37: No write since last change"
-msgstr "[最後の変更が保存されていません]\n"
+msgstr "E37: 最後の変更が保存されていません"
 
 #: ../globals.h:1056
 msgid "E38: Null argument"
@@ -2810,7 +2842,7 @@ msgstr "E42: エラーはありません"
 
 #: ../globals.h:1067
 msgid "E776: No location list"
-msgstr "E776: 場所リストはありません"
+msgstr "E776: ロケーションリストはありません"
 
 #: ../globals.h:1068
 msgid "E43: Damaged match string"
@@ -2930,6 +2962,10 @@ msgstr "E363: パターンが 'maxmempattern' 以上のメモリを使用します"
 #: ../globals.h:1105
 msgid "E749: empty buffer"
 msgstr "E749: バッファが空です"
+
+#, c-format
+msgid "E86: Buffer %ld does not exist"
+msgstr "E86: バッファ %ld はありません"
 
 #: ../globals.h:1108
 msgid "E682: Invalid search pattern or delimiter"
@@ -3831,7 +3867,7 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"それから.swpファイルを削除してください\n"
+"元の.swpファイルは削除しても構\いません\n"
 "\n"
 
 #. use msg() to start the scrolling properly
@@ -3845,7 +3881,7 @@ msgstr "   現在のディレクトリ:\n"
 
 #: ../memline.c:1448
 msgid "   Using specified name:\n"
-msgstr "   ある名前を使用中:\n"
+msgstr "   以下の名前を使用中:\n"
 
 #: ../memline.c:1450
 msgid "   In directory "
@@ -3901,7 +3937,7 @@ msgid ""
 "         user name: "
 msgstr ""
 "\n"
-"          ユーザ名: "
+"        ユーザー名: "
 
 #: ../memline.c:1568
 msgid "   host name: "
@@ -4050,12 +4086,12 @@ msgid ""
 msgstr ""
 "\n"
 "(1) 別のプログラムが同じファイルを編集しているかもしれません.\n"
-"    この場合には, 変更をした際に最終的に, 同じファイルの異なる\n"
-"    2つのインスタンスができてしまうことに注意してください."
+"    この場合には, 変更をしてしまうと1つのファイルに対して異なる2つの\n"
+"    インスタンスができてしまうので, そうしないように気をつけてください."
 
 #: ../memline.c:3245
 msgid "  Quit, or continue with caution.\n"
-msgstr "  終了するか, 注意しながら続けてください.\n"
+msgstr "    終了するか, 注意しながら続けてください.\n"
 
 #: ../memline.c:3246
 msgid "(2) An edit session for this file crashed.\n"
@@ -4479,6 +4515,11 @@ msgstr ""
 msgid "E574: Unknown register type %d"
 msgstr "E574: 未知のレジスタ型 %d です"
 
+msgid ""
+"E883: search pattern and expression register may not contain two or more "
+"lines"
+msgstr "E883: 検索パターンと式レジスタには2行以上を含められません"
+
 #: ../ops.c:5089
 #, c-format
 msgid "%<PRId64> Cols; "
@@ -4562,6 +4603,10 @@ msgstr "E522: termcap 内に見つかりません"
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: 不正な文字です <%s>"
+
+#, c-format
+msgid "For option %s"
+msgstr "オプション: %s"
 
 #: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
@@ -4739,6 +4784,14 @@ msgid ""
 msgstr ""
 "\n"
 "セキュリティコンテキストを設定できません "
+
+#, c-format
+msgid "Could not set security context %s for %s"
+msgstr "セキュリティコンテキスト %s を %s に設定できません"
+
+#, c-format
+msgid "Could not get security context %s for %s. Removing it!"
+msgstr "セキュリティコンテキスト %s を %s から取得できません. 削除します!"
 
 #: ../os_unix.c:1558 ../os_unix.c:1647
 #, c-format
@@ -4960,6 +5013,10 @@ msgstr "E554: %s{...} 内に文法エラーがあります"
 msgid "External submatches:\n"
 msgstr "外部の部分該当:\n"
 
+#, c-format
+msgid "E888: (NFA regexp) cannot repeat %s"
+msgstr "E888: (NFA 正規表\現) 繰り返せません %s"
+
 #: ../regexp.c:7022
 msgid ""
 "E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
@@ -4968,7 +5025,9 @@ msgstr ""
 "E864: \\%#= には 0, 1 もしくは 2 のみが続けられます。正規表\現エンジンは自動選"
 "択されます。"
 
-#: ../regexp_nfa.c:239
+msgid "Switching to backtracking RE engine for pattern: "
+msgstr "次のパターンにバックトラッキング RE エンジンを適用します: "
+
 msgid "E865: (NFA) Regexp end encountered prematurely"
 msgstr "E865: (NFA) 期待より早く正規表\現の終端に到達しました"
 
@@ -4980,7 +5039,7 @@ msgstr "E866: (NFA 正規表\現) 位置が誤っています: %c"
 #: ../regexp_nfa.c:242
 #, c-format
 msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
-msgstr ""
+msgstr "E877: (NFA 正規表\現) 無効な文字クラス: %<PRId64>"
 
 #: ../regexp_nfa.c:1261
 #, c-format
@@ -5590,14 +5649,14 @@ msgid "E765: 'spellfile' does not have %<PRId64> entries"
 msgstr "E765: 'spellfile' には %<PRId64> 個のエントリはありません"
 
 #: ../spell.c:8074
-#, fuzzy, c-format
+#, c-format
 msgid "Word '%.*s' removed from %s"
-msgstr "%s から単語が削除されました"
+msgstr "単語 '%.*s' が %s から削除されました"
 
 #: ../spell.c:8117
-#, fuzzy, c-format
+#, c-format
 msgid "Word '%.*s' added to %s"
-msgstr "%s に単語が追加されました"
+msgstr "単語 '%.*s' が %s へ追加されました"
 
 #: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"
@@ -5672,6 +5731,9 @@ msgstr "このバッファに定義された構\文要素はありません"
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: 不正な引数です: %s"
+
+msgid "syntax iskeyword "
+msgstr "シンタックス用 iskeyword "
 
 #: ../syntax.c:3299
 #, c-format
@@ -5768,6 +5830,10 @@ msgstr "E847: 構\文の取り込み(include)が多過ぎます"
 #, c-format
 msgid "E789: Missing ']': %s"
 msgstr "E789: ']' がありません: %s"
+
+#, c-format
+msgid "E890: trailing char after ']': %s]%s"
+msgstr "E890: ']' の後ろに余分な文字があります: %s]%s"
 
 #: ../syntax.c:4531
 #, c-format
@@ -5874,7 +5940,7 @@ msgstr "E415: 予\期せぬ等号です: %s"
 #: ../syntax.c:6395
 #, c-format
 msgid "E416: missing equal sign: %s"
-msgstr "E416: 等号ががありません: %s"
+msgstr "E416: 等号がありません: %s"
 
 #: ../syntax.c:6418
 #, c-format
@@ -6078,9 +6144,8 @@ msgstr "Vim: 入力を読込み中のエラーにより終了します...\n"
 #. This happens when the FileChangedRO autocommand changes the
 #. * file in a way it becomes shorter.
 #: ../undo.c:379
-#, fuzzy
 msgid "E881: Line count changed unexpectedly"
-msgstr "E834: 予\期せず行カウントが変わりました"
+msgstr "E881: 予\期せず行カウントが変わりました"
 
 #: ../undo.c:627
 #, c-format
@@ -6287,23 +6352,23 @@ msgstr "      システム vimrc: \""
 
 #: ../version.c:672
 msgid "     user vimrc file: \""
-msgstr "        ユーザ vimrc: \""
+msgstr "      ユーザー vimrc: \""
 
 #: ../version.c:677
 msgid " 2nd user vimrc file: \""
-msgstr "     第2ユーザ vimrc: \""
+msgstr "   第2ユーザー vimrc: \""
 
 #: ../version.c:682
 msgid " 3rd user vimrc file: \""
-msgstr "     第3ユーザ vimrc: \""
+msgstr "   第3ユーザー vimrc: \""
 
 #: ../version.c:687
 msgid "      user exrc file: \""
-msgstr "         ユーザ exrc: \""
+msgstr "       ユーザー exrc: \""
 
 #: ../version.c:692
 msgid "  2nd user exrc file: \""
-msgstr "      第2ユーザ exrc: \""
+msgstr "    第2ユーザー exrc: \""
 
 #: ../version.c:699
 msgid "  fall-back for $VIM: \""
@@ -6379,7 +6444,7 @@ msgstr "Vimの開発を応援してください!"
 
 #: ../version.c:828
 msgid "Become a registered Vim user!"
-msgstr "Vimの登録ユーザになってください!"
+msgstr "Vimの登録ユーザーになってください!"
 
 #: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
@@ -6391,7 +6456,7 @@ msgstr "詳細な情報は           :help register<Enter>  "
 
 #: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
-msgstr "詳細はメニューの ヘルプ→スポンサー/登録 を参照して下さい   "
+msgstr "詳細はメニューの ヘルプ->スポンサー/登録 を参照して下さい"
 
 #: ../window.c:119
 msgid "Already only one window"
@@ -6428,6 +6493,9 @@ msgstr "E445: 他のウィンドウには変更があります"
 #: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: カーソ\ルの下にファイル名がありません"
+
+msgid "List or number required"
+msgstr "リストか数値が必要です"
 
 #~ msgid "E831: bf_key_init() called with empty password"
 #~ msgstr "E831: bf_key_init() が空パスワードで呼び出されました"


### PR DESCRIPTION
Update runtime files

https://github.com/vim/vim/commit/13d5aeef56e3140a8eb8f40c7062aa1c5700f76e

Ignored changes to
- doc/develop.txt, since they were all in the "Coding Style"
  section, which is completely different between Vim and Neovim.
- doc/tags, doc/todo.txt
- syntax/vim.vim, generated at build time

Update a few runtime files.

https://github.com/vim/vim/commit/705ada1aff27ecd9c47c690df817d043c2ceb5e2

Ignored changes to
- doc/eval.txt, all json related documentation
- doc/if_mzsch.txt
- doc/tags, generated at build time

Update runtime files.

https://github.com/vim/vim/commit/298b440930ecece38d6ea0505a3e582dc817e79b

Ignore changes to
- doc/netbeans.txt
- doc/tags: generated at build time
- doc/todo.txt
- doc/usr_41.txt, doc/various.txt: +channel related docs

Updated runtime files and translations.

https://github.com/vim/vim/commit/5e9b2fa9bb0e6061cf18457c173cd141a5dc9c92

Ignore changes to
- doc/tags: generated at build time
- doc/develop.txt, doc/todo.txt, doc/netbeans.txt, doc/vim-ja.UTF-8.1,
  doc/xxd-ja.UTF-8.1, lang/menu_*: Not applicable to Neovim
- doc/editing.txt: Crypt related
- doc/change.txt, doc/insert.txt, doc/various.txt: Removal of ex_extra
  tags, which already happened in Neovim
- doc/vim-ja.UTF-8.1, doc/xxd-ja.UTF-8.1

Make the python script executable.

https://github.com/vim/vim/commit/7c764f7bbf71a7a49baae07641efd2ead69e4d08

Update runtime files.

https://github.com/vim/vim/commit/681baaf4a4c81418693dcafb81421a8614832e91

Ignore changes to
- doc/channel.txt, doc/eval.txt, doc/usr_41.txt: Channel related docs
- doc/tags: Generated at build time
- doc/todo.txt: Not relevant to Neovim

Updated runtime files.

https://github.com/vim/vim/commit/cbebd4879cc78e670d79b2c57dc33d7b911c962a

Ignore changes to
- doc/channel.txt, doc/eval.txt: Channel related docs
- doc/tags: Generated at build time
- doc/todo.txt: Not relevant to Neovim
- ftplugin/man.vim: Change already present in autoload/man.vim
