### PR TITLE
[WIP] vim-patch: 7.4.1153

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -540,7 +540,7 @@ static int included_patches[] = {
   // 1156 NA
   // 1155 NA
   // 1154 NA
-  // 1153,
+  1153,
   // 1152 NA
   1151,
   1150,

--- a/test/functional/legacy/quickfix_spec.lua
+++ b/test/functional/legacy/quickfix_spec.lua
@@ -3,6 +3,8 @@
 local helpers = require('test.functional.helpers')
 local source, clear = helpers.source, helpers.clear
 local eq, nvim, call = helpers.eq, helpers.meths, helpers.call
+local eval = helpers.eval
+local execute = helpers.execute
 
 local function expected_empty()
   eq({}, nvim.get_vvar('errors'))
@@ -305,5 +307,12 @@ describe('helpgrep', function()
     expected_empty()
     call('XbufferTests', 'l')
     expected_empty()
+  end)
+
+  it('autocommands triggered by quickfix can get title', function()
+    execute('au FileType qf let g:foo = get(w:, "quickfix_title", "NONE")')
+    execute('call setqflist([])')
+    execute('copen')
+    eq(':setqflist()', eval('g:foo'))
   end)
 end)


### PR DESCRIPTION
Problem:    Autocommands triggered by quickfix cannot always get the current
            title value.
Solution:   Call qf_fill_buffer() later. (Christian Brabandt)

https://github.com/vim/vim/commit/6920c72d4d62c8dc5596e9f392e38204f561d7af
