### PR TITLE
[RFC] Add more clint checks

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# vim: set fileencoding=utf-8
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #
@@ -217,6 +218,7 @@ _ERROR_CATEGORIES = [
     'whitespace/semicolon',
     'whitespace/tab',
     'whitespace/todo',
+    'whitespace/line_continuation',
 ]
 
 # The default state of the category filter. This is overrided by the --filter=
@@ -2498,6 +2500,13 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
     if Search(r'\S(?<!\{)\}', line):
         error(filename, linenum, 'whitespace/braces', 5,
               'Missing space before }')
+
+    if Search(r'\S {2,}\\$', line):
+        error(filename, linenum, 'whitespace/line_continuation', 5,
+              'Too many spaces before \\, line continuation character must be '
+              'preceded by exactly one space. For “blank lines” '
+              'it is preferred to use the same amount of spaces as preceding '
+              'indent')
 
 
 def GetPreviousNonBlankLine(clean_lines, linenum):

--- a/src/clint.py
+++ b/src/clint.py
@@ -219,6 +219,7 @@ _ERROR_CATEGORIES = [
     'whitespace/tab',
     'whitespace/todo',
     'whitespace/line_continuation',
+    'whitespace/cast',
 ]
 
 # The default state of the category filter. This is overrided by the --filter=
@@ -2512,6 +2513,15 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
         error(filename, linenum, 'whitespace/indent', 5,
               'Must not indent preprocessor directives, use 1-space indent '
               'after the hash')
+
+    cast_line = re.sub(r'^# *define +\w+\([^)]*\)', '', line)
+    match = Search(r'\((?:const )?(?:struct )?[a-zA-Z_]\w*(?: *\*(?:const)?)*\)'
+                   r' +'
+                   r'-?(?:\*+|&)?(?:\w+|\+\+|--|\()', cast_line)
+    if match and line[0] == ' ':
+        error(filename, linenum, 'whitespace/cast', 2,
+              'Should leave no spaces after a cast: {!r}'.format(
+                  match.group(0)))
 
 
 def GetPreviousNonBlankLine(clean_lines, linenum):

--- a/src/clint.py
+++ b/src/clint.py
@@ -2508,6 +2508,11 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
               'it is preferred to use the same amount of spaces as preceding '
               'indent')
 
+    if Match(r'^ +#', line):
+        error(filename, linenum, 'whitespace/indent', 5,
+              'Must not indent preprocessor directives, use 1-space indent '
+              'after the hash')
+
 
 def GetPreviousNonBlankLine(clean_lines, linenum):
     """Return the most recent non-blank line and its line number.

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -12,8 +12,8 @@
 #define REMOTE_TYPE(type) typedef uint64_t type
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-  #define ArrayOf(...) Array
-  #define DictionaryOf(...) Dictionary
+# define ArrayOf(...) Array
+# define DictionaryOf(...) Dictionary
 #endif
 
 // Basic types

--- a/src/nvim/api/private/handle.c
+++ b/src/nvim/api/private/handle.c
@@ -7,24 +7,24 @@
 
 #define HANDLE_INIT(name) name##_handles = pmap_new(uint64_t)()
 
-#define HANDLE_IMPL(type, name)                                               \
-  static PMap(uint64_t) *name##_handles = NULL;                               \
-                                                                              \
-  type *handle_get_##name(uint64_t handle)                                    \
-  {                                                                           \
-    return pmap_get(uint64_t)(name##_handles, handle);                        \
-  }                                                                           \
-                                                                              \
-  void handle_register_##name(type *name)                                     \
-  {                                                                           \
-    assert(!name->handle);                                                    \
-    name->handle = next_handle++;                                             \
-    pmap_put(uint64_t)(name##_handles, name->handle, name);                   \
-  }                                                                           \
-                                                                              \
-  void handle_unregister_##name(type *name)                                   \
-  {                                                                           \
-    pmap_del(uint64_t)(name##_handles, name->handle);                         \
+#define HANDLE_IMPL(type, name) \
+  static PMap(uint64_t) *name##_handles = NULL; \
+  \
+  type *handle_get_##name(uint64_t handle) \
+  { \
+    return pmap_get(uint64_t)(name##_handles, handle); \
+  } \
+  \
+  void handle_register_##name(type *name) \
+  { \
+    assert(!name->handle); \
+    name->handle = next_handle++; \
+    pmap_put(uint64_t)(name##_handles, name->handle, name); \
+  } \
+  \
+  void handle_unregister_##name(type *name) \
+  { \
+    pmap_del(uint64_t)(name##_handles, name->handle); \
   }
 
 static uint64_t next_handle = 1;

--- a/src/nvim/api/private/handle.h
+++ b/src/nvim/api/private/handle.h
@@ -4,9 +4,9 @@
 #include "nvim/vim.h"
 #include "nvim/buffer_defs.h"
 
-#define HANDLE_DECLS(type, name)                                              \
-  type *handle_get_##name(uint64_t handle);                                   \
-  void handle_register_##name(type *name);                                    \
+#define HANDLE_DECLS(type, name) \
+  type *handle_get_##name(uint64_t handle); \
+  void handle_register_##name(type *name); \
   void handle_unregister_##name(type *name);
 
 HANDLE_DECLS(buf_T, buffer)

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -20,44 +20,36 @@
 #define OBJECT_OBJ(o) o
 
 #define BOOLEAN_OBJ(b) ((Object) { \
-  .type = kObjectTypeBoolean, \
-  .data.boolean = b \
-  })
+    .type = kObjectTypeBoolean, \
+    .data.boolean = b })
 
 #define INTEGER_OBJ(i) ((Object) { \
-  .type = kObjectTypeInteger, \
-  .data.integer = i \
-  })
+    .type = kObjectTypeInteger, \
+    .data.integer = i })
 
 #define STRING_OBJ(s) ((Object) { \
-  .type = kObjectTypeString, \
-  .data.string = s \
-  })
+    .type = kObjectTypeString, \
+    .data.string = s })
 
 #define BUFFER_OBJ(s) ((Object) { \
-  .type = kObjectTypeBuffer, \
-  .data.buffer = s \
-  })
+    .type = kObjectTypeBuffer, \
+    .data.buffer = s })
 
 #define WINDOW_OBJ(s) ((Object) { \
-  .type = kObjectTypeWindow, \
-  .data.window = s \
-  })
+    .type = kObjectTypeWindow, \
+    .data.window = s })
 
 #define TABPAGE_OBJ(s) ((Object) { \
-  .type = kObjectTypeTabpage, \
-  .data.tabpage = s \
-  })
+    .type = kObjectTypeTabpage, \
+    .data.tabpage = s })
 
 #define ARRAY_OBJ(a) ((Object) { \
-  .type = kObjectTypeArray, \
-  .data.array = a \
-  })
+    .type = kObjectTypeArray, \
+    .data.array = a })
 
 #define DICTIONARY_OBJ(d) ((Object) { \
-  .type = kObjectTypeDictionary, \
-  .data.dictionary = d \
-  })
+    .type = kObjectTypeDictionary, \
+    .data.dictionary = d })
 
 #define NIL ((Object) {.type = kObjectTypeNil})
 

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -8,63 +8,63 @@
 #include "nvim/memory.h"
 #include "nvim/lib/kvec.h"
 
-#define api_set_error(err, errtype, ...)             \
-  do {                                               \
-    snprintf((err)->msg,                             \
-             sizeof((err)->msg),                     \
-             __VA_ARGS__);                           \
-    (err)->set = true;                               \
-    (err)->type = kErrorType##errtype;               \
+#define api_set_error(err, errtype, ...) \
+  do { \
+    snprintf((err)->msg, \
+             sizeof((err)->msg), \
+             __VA_ARGS__); \
+    (err)->set = true; \
+    (err)->type = kErrorType##errtype; \
   } while (0)
 
 #define OBJECT_OBJ(o) o
 
-#define BOOLEAN_OBJ(b) ((Object) {                                            \
-  .type = kObjectTypeBoolean,                                                 \
-  .data.boolean = b                                                           \
+#define BOOLEAN_OBJ(b) ((Object) { \
+  .type = kObjectTypeBoolean, \
+  .data.boolean = b \
   })
 
-#define INTEGER_OBJ(i) ((Object) {                                            \
-  .type = kObjectTypeInteger,                                                 \
-  .data.integer = i                                                           \
+#define INTEGER_OBJ(i) ((Object) { \
+  .type = kObjectTypeInteger, \
+  .data.integer = i \
   })
 
-#define STRING_OBJ(s) ((Object) {                                             \
-  .type = kObjectTypeString,                                                  \
-  .data.string = s                                                            \
+#define STRING_OBJ(s) ((Object) { \
+  .type = kObjectTypeString, \
+  .data.string = s \
   })
 
-#define BUFFER_OBJ(s) ((Object) {                                             \
-  .type = kObjectTypeBuffer,                                                  \
-  .data.buffer = s                                                            \
+#define BUFFER_OBJ(s) ((Object) { \
+  .type = kObjectTypeBuffer, \
+  .data.buffer = s \
   })
 
-#define WINDOW_OBJ(s) ((Object) {                                             \
-  .type = kObjectTypeWindow,                                                  \
-  .data.window = s                                                            \
+#define WINDOW_OBJ(s) ((Object) { \
+  .type = kObjectTypeWindow, \
+  .data.window = s \
   })
 
-#define TABPAGE_OBJ(s) ((Object) {                                            \
-  .type = kObjectTypeTabpage,                                                 \
-  .data.tabpage = s                                                           \
+#define TABPAGE_OBJ(s) ((Object) { \
+  .type = kObjectTypeTabpage, \
+  .data.tabpage = s \
   })
 
-#define ARRAY_OBJ(a) ((Object) {                                              \
-  .type = kObjectTypeArray,                                                   \
-  .data.array = a                                                             \
+#define ARRAY_OBJ(a) ((Object) { \
+  .type = kObjectTypeArray, \
+  .data.array = a \
   })
 
-#define DICTIONARY_OBJ(d) ((Object) {                                         \
-  .type = kObjectTypeDictionary,                                              \
-  .data.dictionary = d                                                        \
+#define DICTIONARY_OBJ(d) ((Object) { \
+  .type = kObjectTypeDictionary, \
+  .data.dictionary = d \
   })
 
 #define NIL ((Object) {.type = kObjectTypeNil})
 
-#define PUT(dict, k, v)                                                       \
+#define PUT(dict, k, v) \
   kv_push(dict, ((KeyValuePair) { .key = cstr_to_string(k), .value = v }))
 
-#define ADD(array, item)                                                      \
+#define ADD(array, item) \
   kv_push(array, item)
 
 #define STATIC_CSTR_AS_STRING(s) ((String) {.data = s, .size = sizeof(s) - 1})

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -647,14 +647,14 @@ static void write_msg(String message, bool to_err)
   static size_t out_pos = 0, err_pos = 0;
   static char out_line_buf[LINE_BUFFER_SIZE], err_line_buf[LINE_BUFFER_SIZE];
 
-#define PUSH_CHAR(i, pos, line_buf, msg)                                      \
-  if (message.data[i] == NL || pos == LINE_BUFFER_SIZE - 1) {                 \
-    line_buf[pos] = NUL;                                                      \
-    msg((uint8_t *)line_buf);                                                 \
-    pos = 0;                                                                  \
-    continue;                                                                 \
-  }                                                                           \
-                                                                              \
+#define PUSH_CHAR(i, pos, line_buf, msg) \
+  if (message.data[i] == NL || pos == LINE_BUFFER_SIZE - 1) { \
+    line_buf[pos] = NUL; \
+    msg((uint8_t *)line_buf); \
+    pos = 0; \
+    continue; \
+  } \
+  \
   line_buf[pos++] = message.data[i];
 
   ++no_wait_return;

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -76,14 +76,14 @@ static inline void restore_win_for_buf(win_T *save_curwin,
   }
 }
 
-#define WITH_BUFFER(b, code)                                              \
-  do {                                                                    \
-    buf_T *save_curbuf = NULL;                                            \
-    win_T *save_curwin = NULL;                                            \
-    tabpage_T *save_curtab = NULL;                                        \
-    switch_to_win_for_buf(b, &save_curwin, &save_curtab, &save_curbuf);   \
-    code;                                                                 \
-    restore_win_for_buf(save_curwin, save_curtab, save_curbuf);           \
+#define WITH_BUFFER(b, code) \
+  do { \
+    buf_T *save_curbuf = NULL; \
+    win_T *save_curwin = NULL; \
+    tabpage_T *save_curtab = NULL; \
+    switch_to_win_for_buf(b, &save_curwin, &save_curtab, &save_curbuf); \
+    code; \
+    restore_win_for_buf(save_curwin, save_curtab, save_curbuf); \
   } while (0)
 
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -22159,7 +22159,6 @@ typval_T eval_call_provider(char *provider, char *method, list_T *arguments)
 
 bool eval_has_provider(char *name)
 {
-
 #define check_provider(name) \
   if (has_##name == -1) { \
     has_##name = !!find_func((uint8_t *)"provider#" #name "#Call"); \

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -22160,13 +22160,13 @@ typval_T eval_call_provider(char *provider, char *method, list_T *arguments)
 bool eval_has_provider(char *name)
 {
 
-#define check_provider(name)                                              \
-  if (has_##name == -1) {                                                 \
-    has_##name = !!find_func((uint8_t *)"provider#" #name "#Call");       \
-    if (!has_##name) {                                                    \
-      script_autoload((uint8_t *)"provider#" #name "#Call", false);       \
-      has_##name = !!find_func((uint8_t *)"provider#" #name "#Call");     \
-    }                                                                     \
+#define check_provider(name) \
+  if (has_##name == -1) { \
+    has_##name = !!find_func((uint8_t *)"provider#" #name "#Call"); \
+    if (!has_##name) { \
+      script_autoload((uint8_t *)"provider#" #name "#Call", false); \
+      has_##name = !!find_func((uint8_t *)"provider#" #name "#Call"); \
+    } \
   }
 
   static int has_clipboard = -1, has_python = -1, has_python3 = -1;

--- a/src/nvim/event/defs.h
+++ b/src/nvim/event/defs.h
@@ -14,19 +14,19 @@ typedef struct message {
 } Event;
 typedef void(*event_scheduler)(Event event, void *data);
 
-#define VA_EVENT_INIT(event, p, h, a)                   \
-  do {                                                  \
-    assert(a <= EVENT_HANDLER_MAX_ARGC);                \
-    (event)->priority = p;                              \
-    (event)->handler = h;                               \
-    if (a) {                                            \
-      va_list args;                                     \
-      va_start(args, a);                                \
-      for (int i = 0; i < a; i++) {                     \
-        (event)->argv[i] = va_arg(args, void *);        \
-      }                                                 \
-      va_end(args);                                     \
-    }                                                   \
+#define VA_EVENT_INIT(event, p, h, a) \
+  do { \
+    assert(a <= EVENT_HANDLER_MAX_ARGC); \
+    (event)->priority = p; \
+    (event)->handler = h; \
+    if (a) { \
+      va_list args; \
+      va_start(args, a); \
+      for (int i = 0; i < a; i++) { \
+        (event)->argv[i] = va_arg(args, void *); \
+      } \
+      va_end(args); \
+    } \
   } while (0)
 
 static inline Event event_create(int priority, argv_callback cb, int argc, ...)

--- a/src/nvim/event/loop.h
+++ b/src/nvim/event/loop.h
@@ -31,7 +31,7 @@ typedef struct loop {
     if (queue) { \
       queue_put((queue), (handler), argc, __VA_ARGS__); \
     } else { \
-      void *argv[argc] = {__VA_ARGS__}; \
+      void *argv[argc] = { __VA_ARGS__ }; \
       (handler)(argv); \
     } \
   } while (0)

--- a/src/nvim/event/loop.h
+++ b/src/nvim/event/loop.h
@@ -26,43 +26,43 @@ typedef struct loop {
   int recursive;
 } Loop;
 
-#define CREATE_EVENT(queue, handler, argc, ...)                  \
-  do {                                                           \
-    if (queue) {                                                 \
-      queue_put((queue), (handler), argc, __VA_ARGS__);          \
-    } else {                                                     \
-      void *argv[argc] = {__VA_ARGS__};                          \
-      (handler)(argv);                                           \
-    }                                                            \
+#define CREATE_EVENT(queue, handler, argc, ...) \
+  do { \
+    if (queue) { \
+      queue_put((queue), (handler), argc, __VA_ARGS__); \
+    } else { \
+      void *argv[argc] = {__VA_ARGS__}; \
+      (handler)(argv); \
+    } \
   } while (0)
 
 // Poll for events until a condition or timeout
-#define LOOP_PROCESS_EVENTS_UNTIL(loop, queue, timeout, condition)           \
-  do {                                                                       \
-    int remaining = timeout;                                                 \
-    uint64_t before = (remaining > 0) ? os_hrtime() : 0;                     \
-    while (!(condition)) {                                                   \
-      LOOP_PROCESS_EVENTS(loop, queue, remaining);                           \
-      if (remaining == 0) {                                                  \
-        break;                                                               \
-      } else if (remaining > 0) {                                            \
-        uint64_t now = os_hrtime();                                          \
-        remaining -= (int) ((now - before) / 1000000);                       \
-        before = now;                                                        \
-        if (remaining <= 0) {                                                \
-          break;                                                             \
-        }                                                                    \
-      }                                                                      \
-    }                                                                        \
+#define LOOP_PROCESS_EVENTS_UNTIL(loop, queue, timeout, condition) \
+  do { \
+    int remaining = timeout; \
+    uint64_t before = (remaining > 0) ? os_hrtime() : 0; \
+    while (!(condition)) { \
+      LOOP_PROCESS_EVENTS(loop, queue, remaining); \
+      if (remaining == 0) { \
+        break; \
+      } else if (remaining > 0) { \
+        uint64_t now = os_hrtime(); \
+        remaining -= (int) ((now - before) / 1000000); \
+        before = now; \
+        if (remaining <= 0) { \
+          break; \
+        } \
+      } \
+    } \
   } while (0)
 
-#define LOOP_PROCESS_EVENTS(loop, queue, timeout)                            \
-  do {                                                                       \
-    if (queue && !queue_empty(queue)) {                                      \
-      queue_process_events(queue);                                           \
-    } else {                                                                 \
-      loop_poll_events(loop, timeout);                                       \
-    }                                                                        \
+#define LOOP_PROCESS_EVENTS(loop, queue, timeout) \
+  do { \
+    if (queue && !queue_empty(queue)) { \
+      queue_process_events(queue); \
+    } else { \
+      loop_poll_events(loop, timeout); \
+    } \
   } while (0)
 
 

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -22,11 +22,11 @@
 #define TERM_TIMEOUT 1000000000
 #define KILL_TIMEOUT (TERM_TIMEOUT * 2)
 
-#define CLOSE_PROC_STREAM(proc, stream)                             \
-  do {                                                              \
-    if (proc->stream && !proc->stream->closed) {                    \
-      stream_close(proc->stream, NULL);                             \
-    }                                                               \
+#define CLOSE_PROC_STREAM(proc, stream) \
+  do { \
+    if (proc->stream && !proc->stream->closed) { \
+      stream_close(proc->stream, NULL); \
+    } \
   } while (0)
 
 static bool process_is_tearing_down = false;

--- a/src/nvim/func_attr.h
+++ b/src/nvim/func_attr.h
@@ -41,6 +41,10 @@
 // $ gcc -E -dM - </dev/null
 // $ echo | clang -dM -E -
 
+#ifndef NVIM_FUNC_ATTR_H
+#define NVIM_FUNC_ATTR_H
+#undef NVIM_FUNC_ATTR_H
+
 #ifdef FUNC_ATTR_MALLOC
 # undef FUNC_ATTR_MALLOC
 #endif
@@ -92,12 +96,12 @@
 #ifndef DID_REAL_ATTR
 # define DID_REAL_ATTR
 # ifdef __GNUC__
-   // place defines for all gnulikes here, for now that's gcc, clang and
-   // intel.
+// place defines for all gnulikes here, for now that's gcc, clang and
+// intel.
 
-   // place these after the argument list of the function declaration
-   // (not definition), like so:
-   // void myfunc(void) REAL_FATTR_ALWAYS_INLINE;
+// place these after the argument list of the function declaration
+// (not definition), like so:
+// void myfunc(void) REAL_FATTR_ALWAYS_INLINE;
 #  define REAL_FATTR_MALLOC __attribute__((malloc))
 #  define REAL_FATTR_ALLOC_ALIGN(x) __attribute__((alloc_align(x)))
 #  define REAL_FATTR_PURE __attribute__ ((pure))
@@ -109,25 +113,25 @@
 #  define REAL_FATTR_NONNULL_ARG(...) __attribute__((nonnull(__VA_ARGS__)))
 
 #  ifdef __clang__
-    // clang only
+// clang only
 #  elif defined(__INTEL_COMPILER)
-    // intel only
+// intel only
 #  else
 #   define GCC_VERSION \
             (__GNUC__ * 10000 + \
              __GNUC_MINOR__ * 100 + \
              __GNUC_PATCHLEVEL__)
-    // gcc only
+// gcc only
 #   define REAL_FATTR_ALLOC_SIZE(x) __attribute__((alloc_size(x)))
-#   define REAL_FATTR_ALLOC_SIZE_PROD(x,y) __attribute__((alloc_size(x,y)))
+#   define REAL_FATTR_ALLOC_SIZE_PROD(x, y) __attribute__((alloc_size(x, y)))
 #   if GCC_VERSION >= 40900
 #    define REAL_FATTR_NONNULL_RET __attribute__((returns_nonnull))
 #   endif
 #  endif
 # endif
 
-  // define function attributes that haven't been defined for this specific
-  // compiler.
+// define function attributes that haven't been defined for this specific
+// compiler.
 
 # ifndef REAL_FATTR_MALLOC
 #  define REAL_FATTR_MALLOC
@@ -138,7 +142,7 @@
 # endif
 
 # ifndef REAL_FATTR_ALLOC_SIZE_PROD
-#  define REAL_FATTR_ALLOC_SIZE_PROD(x,y)
+#  define REAL_FATTR_ALLOC_SIZE_PROD(x, y)
 # endif
 
 # ifndef REAL_FATTR_ALLOC_ALIGN
@@ -183,7 +187,7 @@
 # define FUNC_API_NOEXPORT
 # define FUNC_ATTR_MALLOC REAL_FATTR_MALLOC
 # define FUNC_ATTR_ALLOC_SIZE(x) REAL_FATTR_ALLOC_SIZE(x)
-# define FUNC_ATTR_ALLOC_SIZE_PROD(x,y) REAL_FATTR_ALLOC_SIZE_PROD(x,y)
+# define FUNC_ATTR_ALLOC_SIZE_PROD(x, y) REAL_FATTR_ALLOC_SIZE_PROD(x, y)
 # define FUNC_ATTR_ALLOC_ALIGN(x) REAL_FATTR_ALLOC_ALIGN(x)
 # define FUNC_ATTR_PURE REAL_FATTR_PURE
 # define FUNC_ATTR_CONST REAL_FATTR_CONST
@@ -196,7 +200,7 @@
 #elif !defined(DO_NOT_DEFINE_EMPTY_ATTRIBUTES)
 # define FUNC_ATTR_MALLOC
 # define FUNC_ATTR_ALLOC_SIZE(x)
-# define FUNC_ATTR_ALLOC_SIZE_PROD(x,y)
+# define FUNC_ATTR_ALLOC_SIZE_PROD(x, y)
 # define FUNC_ATTR_ALLOC_ALIGN(x)
 # define FUNC_ATTR_PURE
 # define FUNC_ATTR_CONST
@@ -207,3 +211,4 @@
 # define FUNC_ATTR_NONNULL_ARG(...)
 # define FUNC_ATTR_NONNULL_RET
 #endif
+#endif  // NVIM_FUNC_ATTR_H

--- a/src/nvim/func_attr.h
+++ b/src/nvim/func_attr.h
@@ -42,168 +42,168 @@
 // $ echo | clang -dM -E -
 
 #ifdef FUNC_ATTR_MALLOC
-  #undef FUNC_ATTR_MALLOC
+# undef FUNC_ATTR_MALLOC
 #endif
 
 #ifdef FUNC_ATTR_ALLOC_SIZE
-  #undef FUNC_ATTR_ALLOC_SIZE
+# undef FUNC_ATTR_ALLOC_SIZE
 #endif
 
 #ifdef FUNC_ATTR_ALLOC_SIZE_PROD
-  #undef FUNC_ATTR_ALLOC_SIZE_PROD
+# undef FUNC_ATTR_ALLOC_SIZE_PROD
 #endif
 
 #ifdef FUNC_ATTR_ALLOC_ALIGN
-  #undef FUNC_ATTR_ALLOC_ALIGN
+# undef FUNC_ATTR_ALLOC_ALIGN
 #endif
 
 #ifdef FUNC_ATTR_PURE
-  #undef FUNC_ATTR_PURE
+# undef FUNC_ATTR_PURE
 #endif
 
 #ifdef FUNC_ATTR_CONST
-  #undef FUNC_ATTR_CONST
+# undef FUNC_ATTR_CONST
 #endif
 
 #ifdef FUNC_ATTR_WARN_UNUSED_RESULT
-  #undef FUNC_ATTR_WARN_UNUSED_RESULT
+# undef FUNC_ATTR_WARN_UNUSED_RESULT
 #endif
 
 #ifdef FUNC_ATTR_ALWAYS_INLINE
-  #undef FUNC_ATTR_ALWAYS_INLINE
+# undef FUNC_ATTR_ALWAYS_INLINE
 #endif
 
 #ifdef FUNC_ATTR_UNUSED
-  #undef FUNC_ATTR_UNUSED
+# undef FUNC_ATTR_UNUSED
 #endif
 
 #ifdef FUNC_ATTR_NONNULL_ALL
-  #undef FUNC_ATTR_NONNULL_ALL
+# undef FUNC_ATTR_NONNULL_ALL
 #endif
 
 #ifdef FUNC_ATTR_NONNULL_ARG
-  #undef FUNC_ATTR_NONNULL_ARG
+# undef FUNC_ATTR_NONNULL_ARG
 #endif
 
 #ifdef FUNC_ATTR_NONNULL_RET
-  #undef FUNC_ATTR_NONNULL_RET
+# undef FUNC_ATTR_NONNULL_RET
 #endif
 
 #ifndef DID_REAL_ATTR
-  #define DID_REAL_ATTR
-  #ifdef __GNUC__
-    // place defines for all gnulikes here, for now that's gcc, clang and
-    // intel.
+# define DID_REAL_ATTR
+# ifdef __GNUC__
+   // place defines for all gnulikes here, for now that's gcc, clang and
+   // intel.
 
-    // place these after the argument list of the function declaration
-    // (not definition), like so:
-    // void myfunc(void) REAL_FATTR_ALWAYS_INLINE;
-    #define REAL_FATTR_MALLOC __attribute__((malloc))
-    #define REAL_FATTR_ALLOC_ALIGN(x) __attribute__((alloc_align(x)))
-    #define REAL_FATTR_PURE __attribute__ ((pure))
-    #define REAL_FATTR_CONST __attribute__((const))
-    #define REAL_FATTR_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-    #define REAL_FATTR_ALWAYS_INLINE __attribute__((always_inline))
-    #define REAL_FATTR_UNUSED __attribute__((unused))
-    #define REAL_FATTR_NONNULL_ALL __attribute__((nonnull))
-    #define REAL_FATTR_NONNULL_ARG(...) __attribute__((nonnull(__VA_ARGS__)))
+   // place these after the argument list of the function declaration
+   // (not definition), like so:
+   // void myfunc(void) REAL_FATTR_ALWAYS_INLINE;
+#  define REAL_FATTR_MALLOC __attribute__((malloc))
+#  define REAL_FATTR_ALLOC_ALIGN(x) __attribute__((alloc_align(x)))
+#  define REAL_FATTR_PURE __attribute__ ((pure))
+#  define REAL_FATTR_CONST __attribute__((const))
+#  define REAL_FATTR_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#  define REAL_FATTR_ALWAYS_INLINE __attribute__((always_inline))
+#  define REAL_FATTR_UNUSED __attribute__((unused))
+#  define REAL_FATTR_NONNULL_ALL __attribute__((nonnull))
+#  define REAL_FATTR_NONNULL_ARG(...) __attribute__((nonnull(__VA_ARGS__)))
 
-    #ifdef __clang__
-      // clang only
-    #elif defined(__INTEL_COMPILER)
-      // intel only
-    #else
-      #define GCC_VERSION \
+#  ifdef __clang__
+    // clang only
+#  elif defined(__INTEL_COMPILER)
+    // intel only
+#  else
+#   define GCC_VERSION \
             (__GNUC__ * 10000 + \
-              __GNUC_MINOR__ * 100 + \
-              __GNUC_PATCHLEVEL__)
-      // gcc only
-      #define REAL_FATTR_ALLOC_SIZE(x) __attribute__((alloc_size(x)))
-      #define REAL_FATTR_ALLOC_SIZE_PROD(x,y) __attribute__((alloc_size(x,y)))
-      #if GCC_VERSION >= 40900
-        #define REAL_FATTR_NONNULL_RET __attribute__((returns_nonnull))
-      #endif
-    #endif
-  #endif
+             __GNUC_MINOR__ * 100 + \
+             __GNUC_PATCHLEVEL__)
+    // gcc only
+#   define REAL_FATTR_ALLOC_SIZE(x) __attribute__((alloc_size(x)))
+#   define REAL_FATTR_ALLOC_SIZE_PROD(x,y) __attribute__((alloc_size(x,y)))
+#   if GCC_VERSION >= 40900
+#    define REAL_FATTR_NONNULL_RET __attribute__((returns_nonnull))
+#   endif
+#  endif
+# endif
 
   // define function attributes that haven't been defined for this specific
   // compiler.
 
-  #ifndef REAL_FATTR_MALLOC
-    #define REAL_FATTR_MALLOC
-  #endif
+# ifndef REAL_FATTR_MALLOC
+#  define REAL_FATTR_MALLOC
+# endif
 
-  #ifndef REAL_FATTR_ALLOC_SIZE
-    #define REAL_FATTR_ALLOC_SIZE(x)
-  #endif
+# ifndef REAL_FATTR_ALLOC_SIZE
+#  define REAL_FATTR_ALLOC_SIZE(x)
+# endif
 
-  #ifndef REAL_FATTR_ALLOC_SIZE_PROD
-    #define REAL_FATTR_ALLOC_SIZE_PROD(x,y)
-  #endif
+# ifndef REAL_FATTR_ALLOC_SIZE_PROD
+#  define REAL_FATTR_ALLOC_SIZE_PROD(x,y)
+# endif
 
-  #ifndef REAL_FATTR_ALLOC_ALIGN
-    #define REAL_FATTR_ALLOC_ALIGN(x)
-  #endif
+# ifndef REAL_FATTR_ALLOC_ALIGN
+#  define REAL_FATTR_ALLOC_ALIGN(x)
+# endif
 
-  #ifndef REAL_FATTR_PURE
-    #define REAL_FATTR_PURE
-  #endif
+# ifndef REAL_FATTR_PURE
+#  define REAL_FATTR_PURE
+# endif
 
-  #ifndef REAL_FATTR_CONST
-    #define REAL_FATTR_CONST
-  #endif
+# ifndef REAL_FATTR_CONST
+#  define REAL_FATTR_CONST
+# endif
 
-  #ifndef REAL_FATTR_WARN_UNUSED_RESULT
-    #define REAL_FATTR_WARN_UNUSED_RESULT
-  #endif
+# ifndef REAL_FATTR_WARN_UNUSED_RESULT
+#  define REAL_FATTR_WARN_UNUSED_RESULT
+# endif
 
-  #ifndef REAL_FATTR_ALWAYS_INLINE
-    #define REAL_FATTR_ALWAYS_INLINE
-  #endif
+# ifndef REAL_FATTR_ALWAYS_INLINE
+#  define REAL_FATTR_ALWAYS_INLINE
+# endif
 
-  #ifndef REAL_FATTR_UNUSED
-    #define REAL_FATTR_UNUSED
-  #endif
+# ifndef REAL_FATTR_UNUSED
+#  define REAL_FATTR_UNUSED
+# endif
 
-  #ifndef REAL_FATTR_NONNULL_ALL
-    #define REAL_FATTR_NONNULL_ALL
-  #endif
+# ifndef REAL_FATTR_NONNULL_ALL
+#  define REAL_FATTR_NONNULL_ALL
+# endif
 
-  #ifndef REAL_FATTR_NONNULL_ARG
-    #define REAL_FATTR_NONNULL_ARG(...)
-  #endif
+# ifndef REAL_FATTR_NONNULL_ARG
+#  define REAL_FATTR_NONNULL_ARG(...)
+# endif
 
-  #ifndef REAL_FATTR_NONNULL_RET
-    #define REAL_FATTR_NONNULL_RET
-  #endif
+# ifndef REAL_FATTR_NONNULL_RET
+#  define REAL_FATTR_NONNULL_RET
+# endif
 #endif
 
 #ifdef DEFINE_FUNC_ATTRIBUTES
-  #define FUNC_API_ASYNC
-  #define FUNC_API_NOEXPORT
-  #define FUNC_ATTR_MALLOC REAL_FATTR_MALLOC
-  #define FUNC_ATTR_ALLOC_SIZE(x) REAL_FATTR_ALLOC_SIZE(x)
-  #define FUNC_ATTR_ALLOC_SIZE_PROD(x,y) REAL_FATTR_ALLOC_SIZE_PROD(x,y)
-  #define FUNC_ATTR_ALLOC_ALIGN(x) REAL_FATTR_ALLOC_ALIGN(x)
-  #define FUNC_ATTR_PURE REAL_FATTR_PURE
-  #define FUNC_ATTR_CONST REAL_FATTR_CONST
-  #define FUNC_ATTR_WARN_UNUSED_RESULT REAL_FATTR_WARN_UNUSED_RESULT
-  #define FUNC_ATTR_ALWAYS_INLINE REAL_FATTR_ALWAYS_INLINE
-  #define FUNC_ATTR_UNUSED REAL_FATTR_UNUSED
-  #define FUNC_ATTR_NONNULL_ALL REAL_FATTR_NONNULL_ALL
-  #define FUNC_ATTR_NONNULL_ARG(...) REAL_FATTR_NONNULL_ARG(__VA_ARGS__)
-  #define FUNC_ATTR_NONNULL_RET REAL_FATTR_NONNULL_RET
+# define FUNC_API_ASYNC
+# define FUNC_API_NOEXPORT
+# define FUNC_ATTR_MALLOC REAL_FATTR_MALLOC
+# define FUNC_ATTR_ALLOC_SIZE(x) REAL_FATTR_ALLOC_SIZE(x)
+# define FUNC_ATTR_ALLOC_SIZE_PROD(x,y) REAL_FATTR_ALLOC_SIZE_PROD(x,y)
+# define FUNC_ATTR_ALLOC_ALIGN(x) REAL_FATTR_ALLOC_ALIGN(x)
+# define FUNC_ATTR_PURE REAL_FATTR_PURE
+# define FUNC_ATTR_CONST REAL_FATTR_CONST
+# define FUNC_ATTR_WARN_UNUSED_RESULT REAL_FATTR_WARN_UNUSED_RESULT
+# define FUNC_ATTR_ALWAYS_INLINE REAL_FATTR_ALWAYS_INLINE
+# define FUNC_ATTR_UNUSED REAL_FATTR_UNUSED
+# define FUNC_ATTR_NONNULL_ALL REAL_FATTR_NONNULL_ALL
+# define FUNC_ATTR_NONNULL_ARG(...) REAL_FATTR_NONNULL_ARG(__VA_ARGS__)
+# define FUNC_ATTR_NONNULL_RET REAL_FATTR_NONNULL_RET
 #elif !defined(DO_NOT_DEFINE_EMPTY_ATTRIBUTES)
-  #define FUNC_ATTR_MALLOC
-  #define FUNC_ATTR_ALLOC_SIZE(x)
-  #define FUNC_ATTR_ALLOC_SIZE_PROD(x,y)
-  #define FUNC_ATTR_ALLOC_ALIGN(x)
-  #define FUNC_ATTR_PURE
-  #define FUNC_ATTR_CONST
-  #define FUNC_ATTR_WARN_UNUSED_RESULT
-  #define FUNC_ATTR_ALWAYS_INLINE
-  #define FUNC_ATTR_UNUSED
-  #define FUNC_ATTR_NONNULL_ALL
-  #define FUNC_ATTR_NONNULL_ARG(...)
-  #define FUNC_ATTR_NONNULL_RET
+# define FUNC_ATTR_MALLOC
+# define FUNC_ATTR_ALLOC_SIZE(x)
+# define FUNC_ATTR_ALLOC_SIZE_PROD(x,y)
+# define FUNC_ATTR_ALLOC_ALIGN(x)
+# define FUNC_ATTR_PURE
+# define FUNC_ATTR_CONST
+# define FUNC_ATTR_WARN_UNUSED_RESULT
+# define FUNC_ATTR_ALWAYS_INLINE
+# define FUNC_ATTR_UNUSED
+# define FUNC_ATTR_NONNULL_ALL
+# define FUNC_ATTR_NONNULL_ARG(...)
+# define FUNC_ATTR_NONNULL_RET
 #endif

--- a/src/nvim/garray.h
+++ b/src/nvim/garray.h
@@ -21,10 +21,10 @@ typedef struct growarray {
 
 #define GA_EMPTY(ga_ptr) ((ga_ptr)->ga_len <= 0)
 
-#define GA_APPEND(item_type, gap, item)                                    \
-  do {                                                                     \
-    ga_grow(gap, 1);                                                       \
-    ((item_type *)(gap)->ga_data)[(gap)->ga_len++] = (item);               \
+#define GA_APPEND(item_type, gap, item) \
+  do { \
+    ga_grow(gap, 1); \
+    ((item_type *)(gap)->ga_data)[(gap)->ga_len++] = (item); \
   } while (0)
 
 #define GA_APPEND_VIA_PTR(item_type, gap) \
@@ -49,16 +49,16 @@ static inline void *ga_append_via_ptr(garray_T *gap, size_t item_size)
 /// @param gap the garray to be freed
 /// @param item_type type of the item in the garray
 /// @param free_item_fn free function that takes (*item_type) as parameter
-#define GA_DEEP_CLEAR(gap, item_type, free_item_fn)             \
-  do {                                                          \
-    garray_T *_gap = (gap);                                     \
-    if (_gap->ga_data != NULL) {                                \
-      for (int i = 0; i < _gap->ga_len; i++) {                  \
-        item_type *_item = &(((item_type *)_gap->ga_data)[i]);  \
-        free_item_fn(_item);                                    \
-      }                                                         \
-    }                                                           \
-    ga_clear(_gap);                                             \
+#define GA_DEEP_CLEAR(gap, item_type, free_item_fn) \
+  do { \
+    garray_T *_gap = (gap); \
+    if (_gap->ga_data != NULL) { \
+      for (int i = 0; i < _gap->ga_len; i++) { \
+        item_type *_item = &(((item_type *)_gap->ga_data)[i]); \
+        free_item_fn(_item); \
+      } \
+    } \
+    ga_clear(_gap); \
   } while (false)
 
 #define FREE_PTR_PTR(ptr) xfree(*(ptr))

--- a/src/nvim/lib/klist.h
+++ b/src/nvim/lib/klist.h
@@ -45,20 +45,22 @@
         REAL_FATTR_UNUSED; \
     static inline void kmp_destroy_##name(kmp_##name##_t *mp) { \
         size_t k; \
-        for (k = 0; k < mp->n; ++k) { \
+        for (k = 0; k < mp->n; k++) { \
             kmpfree_f(mp->buf[k]); xfree(mp->buf[k]); \
         } \
         xfree(mp->buf); xfree(mp); \
     } \
     static inline kmptype_t *kmp_alloc_##name(kmp_##name##_t *mp) { \
-        ++mp->cnt; \
-        if (mp->n == 0) return xcalloc(1, sizeof(kmptype_t)); \
+        mp->cnt++; \
+        if (mp->n == 0) { \
+          return xcalloc(1, sizeof(kmptype_t)); \
+        } \
         return mp->buf[--mp->n]; \
     } \
     static inline void kmp_free_##name(kmp_##name##_t *mp, kmptype_t *p) { \
-        --mp->cnt; \
+        mp->cnt--; \
         if (mp->n == mp->max) { \
-            mp->max = mp->max? mp->max<<1 : 16; \
+            mp->max = mp->max ? (mp->max << 1) : 16; \
             mp->buf = xrealloc(mp->buf, sizeof(kmptype_t *) * mp->max); \
         } \
         mp->buf[mp->n++] = p; \
@@ -93,8 +95,9 @@
         REAL_FATTR_UNUSED; \
     static inline void kl_destroy_##name(kl_##name##_t *kl) { \
         kl1_##name *p; \
-        for (p = kl->head; p != kl->tail; p = p->next) \
+        for (p = kl->head; p != kl->tail; p = p->next) { \
             kmp_free(name, kl->mp, p); \
+        } \
         kmp_free(name, kl->mp, p); \
         kmp_destroy(name, kl->mp); \
         xfree(kl); \
@@ -102,22 +105,23 @@
     static inline void kl_push_##name(kl_##name##_t *kl, kltype_t d) { \
         kl1_##name *q, *p = kmp_alloc(name, kl->mp); \
         q = kl->tail; p->next = 0; kl->tail->next = p; kl->tail = p; \
-        ++kl->size; \
+        kl->size++; \
         q->data = d; \
     } \
     static inline kltype_t kl_shift_at_##name(kl_##name##_t *kl, \
                                               kl1_##name **n) { \
         assert((*n)->next); \
         kl1_##name *p; \
-        --kl->size; \
+        kl->size--; \
         p = *n; \
         *n = (*n)->next; \
-        if (p == kl->head) kl->head = *n; \
+        if (p == kl->head) { \
+          kl->head = *n; \
+        } \
         kltype_t d = p->data; \
         kmp_free(name, kl->mp, p); \
         return d; \
-    } \
-    
+    }
 
 #define kliter_t(name) kl1_##name
 #define klist_t(name) kl_##name##_t

--- a/src/nvim/lib/klist.h
+++ b/src/nvim/lib/klist.h
@@ -33,35 +33,35 @@
 #include "nvim/func_attr.h"
 
 
-#define KMEMPOOL_INIT(name, kmptype_t, kmpfree_f)                       \
-    typedef struct {                                                    \
-        size_t cnt, n, max;                                             \
-        kmptype_t **buf;                                                \
-    } kmp_##name##_t;                                                   \
-    static inline kmp_##name##_t *kmp_init_##name(void) {               \
-        return xcalloc(1, sizeof(kmp_##name##_t));                      \
-    }                                                                   \
-    static inline void kmp_destroy_##name(kmp_##name##_t *mp)           \
-        REAL_FATTR_UNUSED;                                              \
-    static inline void kmp_destroy_##name(kmp_##name##_t *mp) {         \
-        size_t k;                                                       \
-        for (k = 0; k < mp->n; ++k) {                                   \
-            kmpfree_f(mp->buf[k]); xfree(mp->buf[k]);                   \
-        }                                                               \
-        xfree(mp->buf); xfree(mp);                                      \
-    }                                                                   \
-    static inline kmptype_t *kmp_alloc_##name(kmp_##name##_t *mp) {     \
-        ++mp->cnt;                                                      \
-        if (mp->n == 0) return xcalloc(1, sizeof(kmptype_t));           \
-        return mp->buf[--mp->n];                                        \
-    }                                                                   \
+#define KMEMPOOL_INIT(name, kmptype_t, kmpfree_f) \
+    typedef struct { \
+        size_t cnt, n, max; \
+        kmptype_t **buf; \
+    } kmp_##name##_t; \
+    static inline kmp_##name##_t *kmp_init_##name(void) { \
+        return xcalloc(1, sizeof(kmp_##name##_t)); \
+    } \
+    static inline void kmp_destroy_##name(kmp_##name##_t *mp) \
+        REAL_FATTR_UNUSED; \
+    static inline void kmp_destroy_##name(kmp_##name##_t *mp) { \
+        size_t k; \
+        for (k = 0; k < mp->n; ++k) { \
+            kmpfree_f(mp->buf[k]); xfree(mp->buf[k]); \
+        } \
+        xfree(mp->buf); xfree(mp); \
+    } \
+    static inline kmptype_t *kmp_alloc_##name(kmp_##name##_t *mp) { \
+        ++mp->cnt; \
+        if (mp->n == 0) return xcalloc(1, sizeof(kmptype_t)); \
+        return mp->buf[--mp->n]; \
+    } \
     static inline void kmp_free_##name(kmp_##name##_t *mp, kmptype_t *p) { \
-        --mp->cnt;                                                      \
-        if (mp->n == mp->max) {                                         \
-            mp->max = mp->max? mp->max<<1 : 16;                         \
+        --mp->cnt; \
+        if (mp->n == mp->max) { \
+            mp->max = mp->max? mp->max<<1 : 16; \
             mp->buf = xrealloc(mp->buf, sizeof(kmptype_t *) * mp->max); \
-        }                                                               \
-        mp->buf[mp->n++] = p;                                           \
+        } \
+        mp->buf[mp->n++] = p; \
     }
 
 #define kmempool_t(name) kmp_##name##_t
@@ -70,53 +70,53 @@
 #define kmp_alloc(name, mp) kmp_alloc_##name(mp)
 #define kmp_free(name, mp, p) kmp_free_##name(mp, p)
 
-#define KLIST_INIT(name, kltype_t, kmpfree_t)                           \
-    struct __kl1_##name {                                               \
-        kltype_t data;                                                  \
-        struct __kl1_##name *next;                                      \
-    };                                                                  \
-    typedef struct __kl1_##name kl1_##name;                             \
-    KMEMPOOL_INIT(name, kl1_##name, kmpfree_t)                          \
-    typedef struct {                                                    \
-        kl1_##name *head, *tail;                                        \
-        kmp_##name##_t *mp;                                             \
-        size_t size;                                                    \
-    } kl_##name##_t;                                                    \
-    static inline kl_##name##_t *kl_init_##name(void) {                 \
-        kl_##name##_t *kl = xcalloc(1, sizeof(kl_##name##_t));          \
-        kl->mp = kmp_init(name);                                        \
-        kl->head = kl->tail = kmp_alloc(name, kl->mp);                  \
-        kl->head->next = 0;                                             \
-        return kl;                                                      \
-    }                                                                   \
-    static inline void kl_destroy_##name(kl_##name##_t *kl)             \
-        REAL_FATTR_UNUSED;                                              \
-    static inline void kl_destroy_##name(kl_##name##_t *kl) {           \
-        kl1_##name *p;                                                  \
-        for (p = kl->head; p != kl->tail; p = p->next)                  \
-            kmp_free(name, kl->mp, p);                                  \
-        kmp_free(name, kl->mp, p);                                      \
-        kmp_destroy(name, kl->mp);                                      \
-        xfree(kl);                                                      \
-    }                                                                   \
-    static inline void kl_push_##name(kl_##name##_t *kl, kltype_t d) {  \
-        kl1_##name *q, *p = kmp_alloc(name, kl->mp);                    \
-        q = kl->tail; p->next = 0; kl->tail->next = p; kl->tail = p;    \
-        ++kl->size;                                                     \
-        q->data = d;                                                    \
-    }                                                                   \
-    static inline kltype_t kl_shift_at_##name(kl_##name##_t *kl,        \
-                                              kl1_##name **n) {         \
-        assert((*n)->next);                                             \
-        kl1_##name *p;                                                  \
-        --kl->size;                                                     \
-        p = *n;                                                         \
-        *n = (*n)->next;                                                \
-        if (p == kl->head) kl->head = *n;                               \
-        kltype_t d = p->data;                                           \
-        kmp_free(name, kl->mp, p);                                      \
-        return d;                                                       \
-    }                                                                   \
+#define KLIST_INIT(name, kltype_t, kmpfree_t) \
+    struct __kl1_##name { \
+        kltype_t data; \
+        struct __kl1_##name *next; \
+    }; \
+    typedef struct __kl1_##name kl1_##name; \
+    KMEMPOOL_INIT(name, kl1_##name, kmpfree_t) \
+    typedef struct { \
+        kl1_##name *head, *tail; \
+        kmp_##name##_t *mp; \
+        size_t size; \
+    } kl_##name##_t; \
+    static inline kl_##name##_t *kl_init_##name(void) { \
+        kl_##name##_t *kl = xcalloc(1, sizeof(kl_##name##_t)); \
+        kl->mp = kmp_init(name); \
+        kl->head = kl->tail = kmp_alloc(name, kl->mp); \
+        kl->head->next = 0; \
+        return kl; \
+    } \
+    static inline void kl_destroy_##name(kl_##name##_t *kl) \
+        REAL_FATTR_UNUSED; \
+    static inline void kl_destroy_##name(kl_##name##_t *kl) { \
+        kl1_##name *p; \
+        for (p = kl->head; p != kl->tail; p = p->next) \
+            kmp_free(name, kl->mp, p); \
+        kmp_free(name, kl->mp, p); \
+        kmp_destroy(name, kl->mp); \
+        xfree(kl); \
+    } \
+    static inline void kl_push_##name(kl_##name##_t *kl, kltype_t d) { \
+        kl1_##name *q, *p = kmp_alloc(name, kl->mp); \
+        q = kl->tail; p->next = 0; kl->tail->next = p; kl->tail = p; \
+        ++kl->size; \
+        q->data = d; \
+    } \
+    static inline kltype_t kl_shift_at_##name(kl_##name##_t *kl, \
+                                              kl1_##name **n) { \
+        assert((*n)->next); \
+        kl1_##name *p; \
+        --kl->size; \
+        p = *n; \
+        *n = (*n)->next; \
+        if (p == kl->head) kl->head = *n; \
+        kltype_t d = p->data; \
+        kmp_free(name, kl->mp, p); \
+        return d; \
+    } \
     
 
 #define kliter_t(name) kl1_##name

--- a/src/nvim/lib/queue.h
+++ b/src/nvim/lib/queue.h
@@ -25,7 +25,7 @@ typedef struct _queue {
 } QUEUE;
 
 // Public macros.
-#define QUEUE_DATA(ptr, type, field)  \
+#define QUEUE_DATA(ptr, type, field) \
   ((type *)((char *)(ptr) - offsetof(type, field)))
 
 #define QUEUE_FOREACH(q, h) \

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -34,88 +34,88 @@
 #define INITIALIZER_DECLARE(T, U, ...) const U INITIALIZER(T, U) = __VA_ARGS__
 #define DEFAULT_INITIALIZER {0}
 
-#define MAP_IMPL(T, U, ...)                                                   \
-  INITIALIZER_DECLARE(T, U, __VA_ARGS__);                                     \
-  __KHASH_IMPL(T##_##U##_map,, T, U, 1, T##_hash, T##_eq)                     \
-                                                                              \
-  Map(T, U) *map_##T##_##U##_new()                                            \
-  {                                                                           \
-    Map(T, U) *rv = xmalloc(sizeof(Map(T, U)));                               \
-    rv->table = kh_init(T##_##U##_map);                                       \
-    return rv;                                                                \
-  }                                                                           \
-                                                                              \
-  void map_##T##_##U##_free(Map(T, U) *map)                                   \
-  {                                                                           \
-    kh_destroy(T##_##U##_map, map->table);                                    \
-    xfree(map);                                                               \
-  }                                                                           \
-                                                                              \
-  U map_##T##_##U##_get(Map(T, U) *map, T key)                                \
-  {                                                                           \
-    khiter_t k;                                                               \
-                                                                              \
+#define MAP_IMPL(T, U, ...) \
+  INITIALIZER_DECLARE(T, U, __VA_ARGS__); \
+  __KHASH_IMPL(T##_##U##_map,, T, U, 1, T##_hash, T##_eq) \
+  \
+  Map(T, U) *map_##T##_##U##_new() \
+  { \
+    Map(T, U) *rv = xmalloc(sizeof(Map(T, U))); \
+    rv->table = kh_init(T##_##U##_map); \
+    return rv; \
+  } \
+  \
+  void map_##T##_##U##_free(Map(T, U) *map) \
+  { \
+    kh_destroy(T##_##U##_map, map->table); \
+    xfree(map); \
+  } \
+  \
+  U map_##T##_##U##_get(Map(T, U) *map, T key) \
+  { \
+    khiter_t k; \
+    \
     if ((k = kh_get(T##_##U##_map, map->table, key)) == kh_end(map->table)) { \
-      return INITIALIZER(T, U);                                               \
-    }                                                                         \
-                                                                              \
-    return kh_val(map->table, k);                                             \
-  }                                                                           \
-                                                                              \
-  bool map_##T##_##U##_has(Map(T, U) *map, T key)                             \
-  {                                                                           \
-    return kh_get(T##_##U##_map, map->table, key) != kh_end(map->table);      \
-  }                                                                           \
-                                                                              \
-  U map_##T##_##U##_put(Map(T, U) *map, T key, U value)                       \
-  {                                                                           \
-    int ret;                                                                  \
-    U rv = INITIALIZER(T, U);                                                 \
-    khiter_t k = kh_put(T##_##U##_map, map->table, key, &ret);                \
-                                                                              \
-    if (!ret) {                                                               \
-      rv = kh_val(map->table, k);                                             \
-    }                                                                         \
-                                                                              \
-    kh_val(map->table, k) = value;                                            \
-    return rv;                                                                \
-  }                                                                           \
-                                                                              \
-  U *map_##T##_##U##_ref(Map(T, U) *map, T key, bool put)                     \
-  {                                                                           \
-    int ret;                                                                  \
-    khiter_t k;                                                               \
-    if (put) {                                                                \
-      k = kh_put(T##_##U##_map, map->table, key, &ret);                       \
-      if (ret) {                                                              \
-        kh_val(map->table, k) = INITIALIZER(T, U);                            \
-      }                                                                       \
-    } else {                                                                  \
-      k = kh_get(T##_##U##_map, map->table, key);                             \
-      if (k == kh_end(map->table)) {                                          \
-        return NULL;                                                          \
-      }                                                                       \
-    }                                                                         \
-                                                                              \
-    return &kh_val(map->table, k);                                            \
-  }                                                                           \
-                                                                              \
-  U map_##T##_##U##_del(Map(T, U) *map, T key)                                \
-  {                                                                           \
-    U rv = INITIALIZER(T, U);                                                 \
-    khiter_t k;                                                               \
-                                                                              \
+      return INITIALIZER(T, U); \
+    } \
+    \
+    return kh_val(map->table, k); \
+  } \
+  \
+  bool map_##T##_##U##_has(Map(T, U) *map, T key) \
+  { \
+    return kh_get(T##_##U##_map, map->table, key) != kh_end(map->table); \
+  } \
+  \
+  U map_##T##_##U##_put(Map(T, U) *map, T key, U value) \
+  { \
+    int ret; \
+    U rv = INITIALIZER(T, U); \
+    khiter_t k = kh_put(T##_##U##_map, map->table, key, &ret); \
+    \
+    if (!ret) { \
+      rv = kh_val(map->table, k); \
+    } \
+    \
+    kh_val(map->table, k) = value; \
+    return rv; \
+  } \
+  \
+  U *map_##T##_##U##_ref(Map(T, U) *map, T key, bool put) \
+  { \
+    int ret; \
+    khiter_t k; \
+    if (put) { \
+      k = kh_put(T##_##U##_map, map->table, key, &ret); \
+      if (ret) { \
+        kh_val(map->table, k) = INITIALIZER(T, U); \
+      } \
+    } else { \
+      k = kh_get(T##_##U##_map, map->table, key); \
+      if (k == kh_end(map->table)) { \
+        return NULL; \
+      } \
+    } \
+    \
+    return &kh_val(map->table, k); \
+  } \
+  \
+  U map_##T##_##U##_del(Map(T, U) *map, T key) \
+  { \
+    U rv = INITIALIZER(T, U); \
+    khiter_t k; \
+    \
     if ((k = kh_get(T##_##U##_map, map->table, key)) != kh_end(map->table)) { \
-      rv = kh_val(map->table, k);                                             \
-      kh_del(T##_##U##_map, map->table, k);                                   \
-    }                                                                         \
-                                                                              \
-    return rv;                                                                \
-  }                                                                           \
-                                                                              \
-  void map_##T##_##U##_clear(Map(T, U) *map)                                  \
-  {                                                                           \
-    kh_clear(T##_##U##_map, map->table);                                      \
+      rv = kh_val(map->table, k); \
+      kh_del(T##_##U##_map, map->table, k); \
+    } \
+    \
+    return rv; \
+  } \
+  \
+  void map_##T##_##U##_clear(Map(T, U) *map) \
+  { \
+    kh_clear(T##_##U##_map, map->table); \
   }
 
 static inline khint_t String_hash(String s)

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -8,20 +8,20 @@
 #include "nvim/msgpack_rpc/defs.h"
 #include "nvim/bufhl_defs.h"
 
-#define MAP_DECLS(T, U)                                                       \
-  KHASH_DECLARE(T##_##U##_map, T, U)                                          \
-                                                                              \
-  typedef struct {                                                            \
-    khash_t(T##_##U##_map) *table;                                            \
-  } Map(T, U);                                                                \
-                                                                              \
-  Map(T, U) *map_##T##_##U##_new(void);                                       \
-  void map_##T##_##U##_free(Map(T, U) *map);                                  \
-  U map_##T##_##U##_get(Map(T, U) *map, T key);                               \
-  bool map_##T##_##U##_has(Map(T, U) *map, T key);                            \
-  U map_##T##_##U##_put(Map(T, U) *map, T key, U value);                      \
-  U *map_##T##_##U##_ref(Map(T, U) *map, T key, bool put);                    \
-  U map_##T##_##U##_del(Map(T, U) *map, T key);                               \
+#define MAP_DECLS(T, U) \
+  KHASH_DECLARE(T##_##U##_map, T, U) \
+  \
+  typedef struct { \
+    khash_t(T##_##U##_map) *table; \
+  } Map(T, U); \
+  \
+  Map(T, U) *map_##T##_##U##_new(void); \
+  void map_##T##_##U##_free(Map(T, U) *map); \
+  U map_##T##_##U##_get(Map(T, U) *map, T key); \
+  bool map_##T##_##U##_has(Map(T, U) *map, T key); \
+  U map_##T##_##U##_put(Map(T, U) *map, T key, U value); \
+  U *map_##T##_##U##_ref(Map(T, U) *map, T key, bool put); \
+  U map_##T##_##U##_del(Map(T, U) *map, T key); \
   void map_##T##_##U##_clear(Map(T, U) *map);
 
 MAP_DECLS(int, int)

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1304,7 +1304,7 @@ int utfc_ptr2char(const char_u *p, int *pcc)
  */
 int utfc_ptr2char_len(const char_u *p, int *pcc, int maxlen)
 {
-#define IS_COMPOSING(s1, s2, s3)                                               \
+#define IS_COMPOSING(s1, s2, s3) \
   (i == 0 ? UTF_COMPOSINGLIKE((s1), (s2)) : utf_iscomposing((s3)))
 
   assert(maxlen > 0);

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -18,39 +18,39 @@
 static msgpack_zone zone;
 static msgpack_sbuffer sbuffer;
 
-#define HANDLE_TYPE_CONVERSION_IMPL(t, lt)                                  \
-  bool msgpack_rpc_to_##lt(msgpack_object *obj, t *arg)                     \
-    FUNC_ATTR_NONNULL_ALL                                                   \
-  {                                                                         \
-    if (obj->type != MSGPACK_OBJECT_EXT                                     \
-        || obj->via.ext.type != kObjectType##t) {                           \
-      return false;                                                         \
-    }                                                                       \
-                                                                            \
-    msgpack_object data;                                                    \
-    msgpack_unpack_return ret = msgpack_unpack(obj->via.ext.ptr,            \
-                                               obj->via.ext.size,           \
-                                               NULL,                        \
-                                               &zone,                       \
-                                               &data);                      \
-                                                                            \
-    if (ret != MSGPACK_UNPACK_SUCCESS) {                                    \
-      return false;                                                         \
-    }                                                                       \
-                                                                            \
-    *arg = data.via.u64;                                                    \
-    return true;                                                            \
-  }                                                                         \
-                                                                            \
-  void msgpack_rpc_from_##lt(t o, msgpack_packer *res)                      \
-    FUNC_ATTR_NONNULL_ARG(2)                                                \
-  {                                                                         \
-    msgpack_packer pac;                                                     \
-    msgpack_packer_init(&pac, &sbuffer, msgpack_sbuffer_write);             \
-    msgpack_pack_uint64(&pac, o);                                           \
-    msgpack_pack_ext(res, sbuffer.size, kObjectType##t);                    \
-    msgpack_pack_ext_body(res, sbuffer.data, sbuffer.size);                 \
-    msgpack_sbuffer_clear(&sbuffer);                                        \
+#define HANDLE_TYPE_CONVERSION_IMPL(t, lt) \
+  bool msgpack_rpc_to_##lt(msgpack_object *obj, t *arg) \
+    FUNC_ATTR_NONNULL_ALL \
+  { \
+    if (obj->type != MSGPACK_OBJECT_EXT \
+        || obj->via.ext.type != kObjectType##t) { \
+      return false; \
+    } \
+    \
+    msgpack_object data; \
+    msgpack_unpack_return ret = msgpack_unpack(obj->via.ext.ptr, \
+                                               obj->via.ext.size, \
+                                               NULL, \
+                                               &zone, \
+                                               &data); \
+    \
+    if (ret != MSGPACK_UNPACK_SUCCESS) { \
+      return false; \
+    } \
+    \
+    *arg = data.via.u64; \
+    return true; \
+  } \
+  \
+  void msgpack_rpc_from_##lt(t o, msgpack_packer *res) \
+    FUNC_ATTR_NONNULL_ARG(2) \
+  { \
+    msgpack_packer pac; \
+    msgpack_packer_init(&pac, &sbuffer, msgpack_sbuffer_write); \
+    msgpack_pack_uint64(&pac, o); \
+    msgpack_pack_ext(res, sbuffer.size, kObjectType##t); \
+    msgpack_pack_ext_body(res, sbuffer.data, sbuffer.size); \
+    msgpack_sbuffer_clear(&sbuffer); \
   }
 
 void msgpack_rpc_helpers_init(void)

--- a/src/nvim/rbuffer.h
+++ b/src/nvim/rbuffer.h
@@ -36,30 +36,30 @@
 //
 // Note that the rbuffer_{produced,consumed} calls are necessary or these macros
 // create infinite loops
-#define RBUFFER_UNTIL_EMPTY(buf, rptr, rcnt)                                 \
-  for (size_t rcnt = 0, _r = 1; _r; _r = 0)                                  \
-    for (char *rptr = rbuffer_read_ptr(buf, &rcnt);                          \
-         buf->size;                                                          \
+#define RBUFFER_UNTIL_EMPTY(buf, rptr, rcnt) \
+  for (size_t rcnt = 0, _r = 1; _r; _r = 0) \
+    for (char *rptr = rbuffer_read_ptr(buf, &rcnt); \
+         buf->size; \
          rptr = rbuffer_read_ptr(buf, &rcnt))
 
-#define RBUFFER_UNTIL_FULL(buf, wptr, wcnt)                                  \
-  for (size_t wcnt = 0, _r = 1; _r; _r = 0)                                  \
-    for (char *wptr = rbuffer_write_ptr(buf, &wcnt);                         \
-         rbuffer_space(buf);                                                 \
+#define RBUFFER_UNTIL_FULL(buf, wptr, wcnt) \
+  for (size_t wcnt = 0, _r = 1; _r; _r = 0) \
+    for (char *wptr = rbuffer_write_ptr(buf, &wcnt); \
+         rbuffer_space(buf); \
          wptr = rbuffer_write_ptr(buf, &wcnt))
 
 
 // Iteration
-#define RBUFFER_EACH(buf, c, i)                                              \
-  for (size_t i = 0; i < buf->size; i = buf->size)                           \
-      for (char c = 0;                                                       \
-           i < buf->size ? ((int)(c = *rbuffer_get(buf, i))) || 1 : 0;       \
+#define RBUFFER_EACH(buf, c, i) \
+  for (size_t i = 0; i < buf->size; i = buf->size) \
+      for (char c = 0; \
+           i < buf->size ? ((int)(c = *rbuffer_get(buf, i))) || 1 : 0; \
            i++)
 
-#define RBUFFER_EACH_REVERSE(buf, c, i)                                      \
-  for (size_t i = buf->size; i != SIZE_MAX; i = SIZE_MAX)                    \
-      for (char c = 0;                                                       \
-           i-- > 0 ? ((int)(c = *rbuffer_get(buf, i))) || 1 : 0;             \
+#define RBUFFER_EACH_REVERSE(buf, c, i) \
+  for (size_t i = buf->size; i != SIZE_MAX; i = SIZE_MAX) \
+      for (char c = 0; \
+           i-- > 0 ? ((int)(c = *rbuffer_get(buf, i))) || 1 : 0; \
            )
 
 typedef struct rbuffer RBuffer;

--- a/src/nvim/rbuffer.h
+++ b/src/nvim/rbuffer.h
@@ -37,28 +37,34 @@
 // Note that the rbuffer_{produced,consumed} calls are necessary or these macros
 // create infinite loops
 #define RBUFFER_UNTIL_EMPTY(buf, rptr, rcnt) \
-  for (size_t rcnt = 0, _r = 1; _r; _r = 0) \
-    for (char *rptr = rbuffer_read_ptr(buf, &rcnt); \
-         buf->size; \
-         rptr = rbuffer_read_ptr(buf, &rcnt))
+  for (size_t rcnt = 0, _r = 1; _r; _r = 0)  /* NOLINT(readability/braces) */ \
+    for (  /* NOLINT(readability/braces) */ \
+        char *rptr = rbuffer_read_ptr(buf, &rcnt); \
+        buf->size; \
+        rptr = rbuffer_read_ptr(buf, &rcnt))
 
 #define RBUFFER_UNTIL_FULL(buf, wptr, wcnt) \
-  for (size_t wcnt = 0, _r = 1; _r; _r = 0) \
-    for (char *wptr = rbuffer_write_ptr(buf, &wcnt); \
-         rbuffer_space(buf); \
-         wptr = rbuffer_write_ptr(buf, &wcnt))
+  for (size_t wcnt = 0, _r = 1; _r; _r = 0)  /* NOLINT(readability/braces) */ \
+    for (  /* NOLINT(readability/braces) */ \
+        char *wptr = rbuffer_write_ptr(buf, &wcnt); \
+        rbuffer_space(buf); \
+        wptr = rbuffer_write_ptr(buf, &wcnt))
 
 
 // Iteration
 #define RBUFFER_EACH(buf, c, i) \
-  for (size_t i = 0; i < buf->size; i = buf->size) \
-      for (char c = 0; \
+  for (size_t i = 0;  /* NOLINT(readability/braces) */ \
+       i < buf->size; \
+       i = buf->size) \
+      for (char c = 0;  /* NOLINT(readability/braces) */ \
            i < buf->size ? ((int)(c = *rbuffer_get(buf, i))) || 1 : 0; \
            i++)
 
 #define RBUFFER_EACH_REVERSE(buf, c, i) \
-  for (size_t i = buf->size; i != SIZE_MAX; i = SIZE_MAX) \
-      for (char c = 0; \
+  for (size_t i = buf->size;  /* NOLINT(readability/braces) */ \
+       i != SIZE_MAX; \
+       i = SIZE_MAX) \
+      for (char c = 0;  /* NOLINT(readability/braces) */ \
            i-- > 0 ? ((int)(c = *rbuffer_get(buf, i))) || 1 : 0; \
            )
 

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -358,11 +358,11 @@ static int nfa_ll_index = 0;
 #endif
 
 /* helper functions used when doing re2post() ... regatom() parsing */
-#define EMIT(c) do {                            \
-    if (post_ptr >= post_end) {                 \
-      realloc_post_list();                      \
-    }                                           \
-    *post_ptr++ = c;                            \
+#define EMIT(c) do { \
+    if (post_ptr >= post_end) { \
+      realloc_post_list(); \
+    } \
+    *post_ptr++ = c; \
 } while (0)
 
 /*
@@ -2892,12 +2892,12 @@ static nfa_state_T *post2nfa(int *postfix, int *end, int nfa_calc_size)
     return NULL;
 
 #define PUSH(s)     st_push((s), &stackp, stack_end)
-#define POP()       st_pop(&stackp, stack);             \
-  if (stackp < stack)                 \
-  {                                   \
-    st_error(postfix, end, p);      \
-    xfree(stack);                    \
-    return NULL;                    \
+#define POP()       st_pop(&stackp, stack); \
+  if (stackp < stack) \
+  { \
+    st_error(postfix, end, p); \
+    xfree(stack); \
+    return NULL; \
   }
 
   if (nfa_calc_size == FALSE) {
@@ -4904,10 +4904,10 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
   } else
     addstate(thislist, start, m, NULL, 0);
 
-#define ADD_STATE_IF_MATCH(state)                       \
-  if (result) {                                       \
-    add_state = state->out;                         \
-    add_off = clen;                                 \
+#define ADD_STATE_IF_MATCH(state) \
+  if (result) { \
+    add_state = state->out; \
+    add_off = clen; \
   }
 
   /*

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -357,13 +357,14 @@ static int nfa_ll_index = 0;
 # include "regexp_nfa.c.generated.h"
 #endif
 
-/* helper functions used when doing re2post() ... regatom() parsing */
-#define EMIT(c) do { \
-    if (post_ptr >= post_end) { \
-      realloc_post_list(); \
-    } \
-    *post_ptr++ = c; \
-} while (0)
+// Helper functions used when doing re2post() ... regatom() parsing
+#define EMIT(c) \
+    do { \
+      if (post_ptr >= post_end) { \
+        realloc_post_list(); \
+      } \
+      *post_ptr++ = c; \
+    } while (0)
 
 /*
  * Initialize internal variables before NFA compilation.
@@ -2893,8 +2894,7 @@ static nfa_state_T *post2nfa(int *postfix, int *end, int nfa_calc_size)
 
 #define PUSH(s)     st_push((s), &stackp, stack_end)
 #define POP()       st_pop(&stackp, stack); \
-  if (stackp < stack) \
-  { \
+  if (stackp < stack) { \
     st_error(postfix, end, p); \
     xfree(stack); \
     return NULL; \

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1159,15 +1159,15 @@ static bool is_focused(Terminal *term)
   return State & TERM_FOCUS && curbuf->terminal == term;
 }
 
-#define GET_CONFIG_VALUE(k, o)                                           \
-  do {                                                                   \
-    Error err;                                                           \
-    /* Only called from terminal_open where curbuf->terminal is the */   \
-    /* context  */                                                       \
-    o = dict_get_value(curbuf->b_vars, cstr_as_string(k), &err);         \
-    if (o.type == kObjectTypeNil) {                                      \
-      o = dict_get_value(&globvardict, cstr_as_string(k), &err);         \
-    }                                                                    \
+#define GET_CONFIG_VALUE(k, o) \
+  do { \
+    Error err; \
+    /* Only called from terminal_open where curbuf->terminal is the */ \
+    /* context  */ \
+    o = dict_get_value(curbuf->b_vars, cstr_as_string(k), &err); \
+    if (o.type == kObjectTypeNil) { \
+      o = dict_get_value(&globvardict, cstr_as_string(k), &err); \
+    } \
   } while (0)
 
 static char *get_config_string(char *key)

--- a/src/nvim/ugrid.h
+++ b/src/nvim/ugrid.h
@@ -23,16 +23,16 @@ struct ugrid {
 
 #define EMPTY_ATTRS ((HlAttrs){ false, false, false, false, false, -1, -1, -1 })
 
-#define UGRID_FOREACH_CELL(grid, top, bot, left, right, code)           \
-  do {                                                                  \
-    for (int row = top; row <= bot; ++row) {                            \
-      UCell *row_cells = (grid)->cells[row];                            \
-      for (int col = left; col <= right; ++col) {                       \
-        UCell *cell = row_cells + col;                                  \
-        (void)(cell);                                                   \
-        code;                                                           \
-      }                                                                 \
-    }                                                                   \
+#define UGRID_FOREACH_CELL(grid, top, bot, left, right, code) \
+  do { \
+    for (int row = top; row <= bot; ++row) { \
+      UCell *row_cells = (grid)->cells[row]; \
+      for (int col = left; col <= right; ++col) { \
+        UCell *cell = row_cells + col; \
+        (void)(cell); \
+        code; \
+      } \
+    } \
   } while (0)
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/ugrid.h
+++ b/src/nvim/ugrid.h
@@ -25,9 +25,9 @@ struct ugrid {
 
 #define UGRID_FOREACH_CELL(grid, top, bot, left, right, code) \
   do { \
-    for (int row = top; row <= bot; ++row) { \
+    for (int row = top; row <= bot; row++) { \
       UCell *row_cells = (grid)->cells[row]; \
-      for (int col = left; col <= right; ++col) { \
+      for (int col = left; col <= right; col++) { \
         UCell *cell = row_cells + col; \
         (void)(cell); \
         code; \

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -60,7 +60,7 @@ static int height, width;
 // See http://stackoverflow.com/a/11172679 for a better explanation of how it
 // works.
 #ifdef _MSC_VER
-  #define UI_CALL(funname, ...) \
+# define UI_CALL(funname, ...) \
     do { \
       flush_cursor_update(); \
       for (size_t i = 0; i < ui_count; i++) { \
@@ -69,7 +69,7 @@ static int height, width;
       } \
     } while (0)
 #else
-  #define UI_CALL(...) \
+# define UI_CALL(...) \
     do { \
       flush_cursor_update(); \
       for (size_t i = 0; i < ui_count; i++) { \

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -60,22 +60,22 @@ static int height, width;
 // See http://stackoverflow.com/a/11172679 for a better explanation of how it
 // works.
 #ifdef _MSC_VER
-  #define UI_CALL(funname, ...)                                     \
-    do {                                                            \
-      flush_cursor_update();                                        \
-      for (size_t i = 0; i < ui_count; i++) {                       \
-        UI *ui = uis[i];                                            \
-        UI_CALL_MORE(funname, __VA_ARGS__);                         \
-      }                                                             \
+  #define UI_CALL(funname, ...) \
+    do { \
+      flush_cursor_update(); \
+      for (size_t i = 0; i < ui_count; i++) { \
+        UI *ui = uis[i]; \
+        UI_CALL_MORE(funname, __VA_ARGS__); \
+      } \
     } while (0)
 #else
-  #define UI_CALL(...)                                              \
-    do {                                                            \
-      flush_cursor_update();                                        \
-      for (size_t i = 0; i < ui_count; i++) {                       \
-        UI *ui = uis[i];                                            \
-        UI_CALL_HELPER(CNT(__VA_ARGS__), __VA_ARGS__);              \
-      }                                                             \
+  #define UI_CALL(...) \
+    do { \
+      flush_cursor_update(); \
+      for (size_t i = 0; i < ui_count; i++) { \
+        UI *ui = uis[i]; \
+        UI_CALL_HELPER(CNT(__VA_ARGS__), __VA_ARGS__); \
+      } \
     } while (0)
 #endif
 #define CNT(...) SELECT_NTH(__VA_ARGS__, MORE, MORE, MORE, MORE, ZERO, ignore)

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -19,8 +19,8 @@
 #define UI(b) (((UIBridgeData *)b)->ui)
 
 // Call a function in the UI thread
-#define UI_CALL(ui, name, argc, ...)                                      \
-  ((UIBridgeData *)ui)->scheduler(                                        \
+#define UI_CALL(ui, name, argc, ...) \
+  ((UIBridgeData *)ui)->scheduler( \
     event_create(1, ui_bridge_##name##_event, argc, __VA_ARGS__), UI(ui))
 
 #define INT2PTR(i) ((void *)(uintptr_t)i)

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -21,7 +21,7 @@
 // Call a function in the UI thread
 #define UI_CALL(ui, name, argc, ...) \
   ((UIBridgeData *)ui)->scheduler( \
-    event_create(1, ui_bridge_##name##_event, argc, __VA_ARGS__), UI(ui))
+      event_create(1, ui_bridge_##name##_event, argc, __VA_ARGS__), UI(ui))
 
 #define INT2PTR(i) ((void *)(uintptr_t)i)
 #define PTR2INT(p) ((int)(uintptr_t)p)

--- a/src/nvim/ui_bridge.h
+++ b/src/nvim/ui_bridge.h
@@ -28,13 +28,13 @@ struct ui_bridge_data {
   bool stopped;
 };
 
-#define CONTINUE(b)                                                    \
-  do {                                                                 \
-    UIBridgeData *d = (UIBridgeData *)b;                               \
-    uv_mutex_lock(&d->mutex);                                          \
-    d->ready = true;                                                   \
-    uv_cond_signal(&d->cond);                                          \
-    uv_mutex_unlock(&d->mutex);                                        \
+#define CONTINUE(b) \
+  do { \
+    UIBridgeData *d = (UIBridgeData *)b; \
+    uv_mutex_lock(&d->mutex); \
+    d->ready = true; \
+    uv_cond_signal(&d->cond); \
+    uv_mutex_unlock(&d->mutex); \
   } while (0)
 
 


### PR DESCRIPTION
Adds three more checks:
1. Macros line continuation character alignment is now rejected.
2. Indented preprocessor directives are rejected.
3. Cast operators with spaces are rejected.

Last thing is most subjectable: I would really like to do the opposite (reject cast operators _without_ spaces), but style guide suggests otherwise. Commits are done so that new linter errors fixed and fixes to the errors which popped out because of previous fixes are separate. Last check has (and will have) no change that fixes new errors because there are too much.
