### PR TITLE
[RFC] Remove some unnecessary function attributes

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1582,7 +1582,7 @@ static char_u latin1lower[257] =
 ///
 /// @param  c  character to check
 bool vim_islower(int c)
-  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (c <= '@') {
     return false;
@@ -1613,7 +1613,7 @@ bool vim_islower(int c)
 ///
 /// @param  c  character to check
 bool vim_isupper(int c)
-  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (c <= '@') {
     return false;

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -398,7 +398,6 @@ int os_setperm(const char_u *name, int perm)
 /// @note If the `owner` or `group` is specified as `-1`, then that ID is not
 /// changed.
 int os_fchown(int file_descriptor, uv_uid_t owner, uv_gid_t group)
-  FUNC_ATTR_NONNULL_ALL
 {
   uv_fs_t request;
   int result = uv_fs_fchown(&fs_loop, &request, file_descriptor,


### PR DESCRIPTION
Remove some unnecessary function attributes

This removes attribute FUNC_ATTR_NONNULL_ALL for functions without
a pointer parameter.
