### PR TITLE
tui/input.c: Handle Ctrl-Z (suspend) for TERM=linux (#3100)

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -139,6 +139,9 @@ static void forward_modified_utf8(TermInput *input, TermKeyKey *key)
   if (key->type == TERMKEY_TYPE_KEYSYM
       && key->code.sym == TERMKEY_SYM_ESCAPE) {
     len = (size_t)snprintf(buf, sizeof(buf), "<Esc>");
+  } else if (key->type == TERMKEY_TYPE_KEYSYM
+      && key->code.sym == TERMKEY_SYM_SUSPEND) {
+    len = (size_t)snprintf(buf, sizeof(buf), "<C-Z>");
   } else {
     len = termkey_strfkey(input->tk, buf, sizeof(buf), key, TERMKEY_FORMAT_VIM);
   }


### PR DESCRIPTION
Fix #3100.

On virtual consoles (Alt-F1, etc.), the Ctrl-Z combination was lost.
