### PR TITLE
vim-patch: 7.4.1352

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -61,12 +61,13 @@ endif
 " Locate Test_ functions and execute them.
 set nomore
 redir @q
-function /^Test_
+silent function /^Test_
 redir END
 let tests = split(substitute(@q, 'function \(\k*()\)', '\1', 'g'))
 
 " Execute the tests in alphabetical order.
 for test in sort(tests)
+  echo 'Executing ' . test
   if exists("*SetUp")
     call SetUp()
   endif

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -341,7 +341,7 @@ static int included_patches[] = {
   // 1355 NA
   // 1354 NA
   // 1353 NA
-  // 1352,
+  1352,
   // 1351 NA
   // 1350 NA
   // 1349 NA


### PR DESCRIPTION
Problem:    The test script lists all functions before executing them.
Solution:   Only list the function currently being executed.

https://github.com/vim/vim/commit/93bf558caef2d507ef6baf56eaf6025b63da1e34
