### PR TITLE
[RFC] Make matchparen_spec.lua fail if matchparen is not available

### DIFF
--- a/test/functional/plugin/matchparen_spec.lua
+++ b/test/functional/plugin/matchparen_spec.lua
@@ -1,20 +1,27 @@
 local helpers = require('test.functional.helpers')(after_each)
+local plugin_helpers = require('test.functional.plugin.helpers')
 local Screen = require('test.functional.ui.screen')
-local clear, feed, execute = helpers.clear, helpers.feed, helpers.execute
+
+local execute = helpers.execute
+local meths = helpers.meths
+local feed = helpers.feed
+local eq = helpers.eq
+
+local reset = plugin_helpers.reset
 
 describe('matchparen', function() 
   local screen
 
   before_each(function()
-    clear()
+    reset()
     screen = Screen.new(20,5)
     screen:attach()
     screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
   end)
 
   it('uses correct column after i_<Up>. Vim patch 7.4.1296', function()
-    execute('set noai nosi nocin')
-    execute('runtime plugin/matchparen.vim')
+    execute('set noautoindent nosmartindent nocindent laststatus=0')
+    eq(1, meths.get_var('loaded_matchparen'))
     feed('ivoid f_test()<cr>')
     feed('{<cr>')
     feed('}')


### PR DESCRIPTION
- `nvim --version`: a865a4b5a1e02d96de1eebed425fba9a756dcb04
### Actual behaviour

Test succeeds whether or not `plugin/matchparen.vim` file is present.
### Expected behaviour

Test should fail.
### Steps to reproduce using `nvim -u NORC`

``` Shell
mv runtime/plugin/matchparen.vim{,.}
cd build
TEST_FILE=test/functional/plugin/matchparen_spec.lua make functionaltest
```

I see the way to fix this problem as just adding `eq(1, meths.get_var('loaded_matchparen'))` check, but I would also suggest to not use `(test.functional.helpers).clear` and `runtime`, using `reset` from `test.functional.plugin.helpers` instead. Note that this changes what is actually tested: previously test checked that intended behaviour was not altered by matchparen plugin only, now it checks that intended behaviour is not altered by _any_ default plugin, yet only making sure that out of all plugins that may alter the behaviour matchparen is loaded.

// Also removed all “short” option names, they are not readable. And used “one variable per line, sorted on variable length (descending)” style.
