### PR TITLE
'numberexpr' option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4450,6 +4450,20 @@ A jump table for the options with a short description can be found at |Q_op|.
 	    |nobody         |  3 nobody     |  0 nobody     |3   nobody
 	    |there          |  4 there      |  1 there      |  1 there
 
+						*number_hybridnumberalign*
+	The 'hybridnumberalign' option aligns the absolute number with the
+	relativenumber when both 'number' and 'relativenumber' are set
+	This combination is shown below (cursor in line 3):
+
+              	'nu'
+		'rnu'
+		'hnua'
+
+             |  2 apple
+             |  1 pear
+             |  3 nobody
+             |  1 there
+
 						*'numberwidth'* *'nuw'*
 'numberwidth' 'nuw'	number	(Vim default: 4  Vi default: 8)
 			local to window
@@ -4836,6 +4850,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The number in front of the cursor line also depends on the value of
 	'number', see |number_relativenumber| for all combinations of the two
 	options.
+
+		*'hybridnumberalign'* *'hnua'* *'nohybridnumberalign'* *'nohnua'*
+'hybridnumberalign' 'hnua'  boolean (default off)
+			    local to window
+	Show the absolute line number align with the relative line numbers
+	when both 'number' and 'relativenumber' are set. See 
+	|number_hybridnumberalign| for an example.
 
 						*'remap'* *'noremap'*
 'remap'			boolean	(default on)

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -187,6 +187,8 @@ typedef struct {
 #  define w_p_fdt w_onebuf_opt.wo_fdt   /* 'foldtext' */
   char_u      *wo_fmr;
 # define w_p_fmr w_onebuf_opt.wo_fmr    /* 'foldmarker' */
+  int wo_hnua;
+#define w_p_hnua w_onebuf_opt.wo_hnua   /* 'hybridnumberalign' */
   int wo_lbr;
 # define w_p_lbr w_onebuf_opt.wo_lbr    /* 'linebreak' */
   int wo_list;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5298,6 +5298,7 @@ static char_u *get_varp(vimoption_T *p)
   case PV_FDE:    return (char_u *)&(curwin->w_p_fde);
   case PV_FDT:    return (char_u *)&(curwin->w_p_fdt);
   case PV_FMR:    return (char_u *)&(curwin->w_p_fmr);
+  case PV_HNUA:   return (char_u *)&(curwin->w_p_hnua);
   case PV_NU:     return (char_u *)&(curwin->w_p_nu);
   case PV_RNU:    return (char_u *)&(curwin->w_p_rnu);
   case PV_NUW:    return (char_u *)&(curwin->w_p_nuw);
@@ -5413,6 +5414,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_list = from->wo_list;
   to->wo_nu = from->wo_nu;
   to->wo_rnu = from->wo_rnu;
+  to->wo_hnua = from->wo_hnua;
   to->wo_nuw = from->wo_nuw;
   to->wo_rl  = from->wo_rl;
   to->wo_rlc = vim_strsave(from->wo_rlc);

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -780,6 +780,7 @@ enum {
   , WV_FDE
   , WV_FDT
   , WV_FMR
+  , WV_HNUA
   , WV_LBR
   , WV_NU
   , WV_RNU

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1123,6 +1123,13 @@ return {
       defaults={if_true={vi=false, vim=true}}
     },
     {
+      full_name='hybridnumberalign', abbreviation='hnua',
+      type='bool', scope={'window'},
+      vi_def=true,
+      redraw={'current_window'},
+      defaults={if_true={vi=false}}
+    },
+    {
       full_name='icon',
       type='bool', scope={'global'},
       vi_def=true,

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2725,7 +2725,12 @@ win_line (
               if (num == 0 && wp->w_p_nu && wp->w_p_rnu) {
                 /* 'number' + 'relativenumber' */
                 num = lnum;
-                fmt = "%-*ld ";
+                /* if relative numbers are aligned (right justified) */
+                if (wp->w_p_hnua) 
+                  fmt = "%*ld ";
+                /* if relative numbers are not aligned (left justified) */
+                else
+                  fmt = "%-*ld ";
               }
             }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -241,6 +241,7 @@ Terminal *terminal_open(TerminalOptions opts)
   set_option_value((uint8_t *)"wrap", false, NULL, OPT_LOCAL);
   set_option_value((uint8_t *)"number", false, NULL, OPT_LOCAL);
   set_option_value((uint8_t *)"relativenumber", false, NULL, OPT_LOCAL);
+  set_option_value((uint8_t *)"hybridnumberalign", false, NULL, OPT_LOCAL);
   RESET_BINDING(curwin);
   // Apply TermOpen autocmds so the user can configure the terminal
   apply_autocmds(EVENT_TERMOPEN, NULL, NULL, false, curbuf);


### PR DESCRIPTION
As a personal preference, this option allows the absolute line number to
be aligned with the relative line numbers when both 'number' and
'relativenumber' are enabled.

This is the first time I've done any work on neovim, so any help is greatly appreciated. I'm not sure if I've followed the coding standards to the community's liking or if my update of the documentation was appropriately done. Furthermore, I don't know if anyone wants this option besides me.
