### PR TITLE
cmake: remove unused includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,9 +291,6 @@ endif()
 include_directories("${PROJECT_BINARY_DIR}/config")
 include_directories("${PROJECT_SOURCE_DIR}/src")
 
-# Modules used by platform auto-detection
-include(CheckLibraryExists)
-
 find_package(LibUV REQUIRED)
 include_directories(SYSTEM ${LIBUV_INCLUDE_DIRS})
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -1,6 +1,3 @@
-include(CheckLibraryExists)
-include(CheckCCompilerFlag)
-
 option(USE_GCOV "Enable gcov support" OFF)
 
 if(NOT CLANG_TSAN)


### PR DESCRIPTION
As briefly discussed in the Gitter chat just now, these three includes are leftovers that should have been cleaned up already.
