### PR TITLE
[RFC] test: fix command_count_spec

### DIFF
--- a/test/functional/eval/json_functions_spec.lua
+++ b/test/functional/eval/json_functions_spec.lua
@@ -10,8 +10,8 @@ local redir_exec = helpers.redir_exec
 local NIL = helpers.NIL
 
 describe('json_decode() function', function()
-  local restart = function(cmd)
-    clear(cmd)
+  local restart = function(...)
+    clear(...)
     execute('language C')
     execute([[
       function Eq(exp, act)
@@ -490,13 +490,13 @@ describe('json_decode() function', function()
   end)
 
   it('converts strings to latin1 when &encoding is latin1', function()
-    restart('set encoding=latin1')
+    restart('--cmd', 'set encoding=latin1')
     eq('\171', funcs.json_decode('"\\u00AB"'))
     sp_decode_eq({_TYPE='string', _VAL={'\n\171\n'}}, '"\\u0000\\u00AB\\u0000"')
   end)
 
   it('fails to convert string to latin1 if it is impossible', function()
-    restart('set encoding=latin1')
+    restart('--cmd', 'set encoding=latin1')
     eq('Vim(call):E474: Failed to convert string "ꯍ" from UTF-8',
        exc_exec('call json_decode(\'"\\uABCD"\')'))
   end)
@@ -532,7 +532,7 @@ describe('json_decode() function', function()
     -- When &encoding is latin1 string "«" is U+00C2 U+00AB U+00C2: Â«Â. So if
     -- '"«"' was parsed as latin1 json_decode would return three characters, and
     -- only one U+00AB when this string is parsed as latin1.
-    restart('set encoding=latin1')
+    restart('--cmd', 'set encoding=latin1')
     eq(('%c'):format(0xAB), funcs.json_decode('"«"'))
   end)
 
@@ -763,7 +763,7 @@ describe('json_encode() function', function()
   end)
 
   it('converts strings from latin1 when &encoding is latin1', function()
-    clear('set encoding=latin1')
+    clear('--cmd', 'set encoding=latin1')
     eq('"\\u00AB"', funcs.json_encode('\171'))
     eq('"\\u0000\\u00AB\\u0000"', eval('json_encode({"_TYPE": v:msgpack_types.string, "_VAL": ["\\n\171\\n"]})'))
   end)

--- a/test/functional/ex_cmds/encoding_spec.lua
+++ b/test/functional/ex_cmds/encoding_spec.lua
@@ -22,7 +22,7 @@ describe('&encoding', function()
   end)
 
   it('can be changed before startup', function()
-    clear('set enc=latin1')
+    clear('--cmd', 'set enc=latin1')
     execute('set encoding=utf-8')
     -- error message expected
     feed('<cr>')
@@ -32,7 +32,7 @@ describe('&encoding', function()
 
   it('is not changed by `set all&`', function()
     -- we need to set &encoding to something non-default. Use 'latin1'
-    clear('set enc=latin1')
+    clear('--cmd', 'set enc=latin1')
     execute('set all&')
     eq('latin1', eval('&encoding'))
     eq(4, eval('strwidth("Bär")'))

--- a/test/functional/ex_cmds/quit_spec.lua
+++ b/test/functional/ex_cmds/quit_spec.lua
@@ -3,7 +3,7 @@ local clear = helpers.clear
 
 describe(':qa', function()
   before_each(function() 
-    clear('qa')
+    clear('--cmd', 'qa')
   end)
 
   it('verify #3334', function()

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -12,7 +12,7 @@ describe(':write', function()
   end)
 
   it('&backupcopy=auto preserves symlinks', function()
-    clear('set backupcopy=auto')
+    clear('--cmd', 'set backupcopy=auto')
     write_file('test_bkc_file.txt', 'content0')
     execute("silent !ln -s test_bkc_file.txt test_bkc_link.txt")
     source([[
@@ -25,7 +25,7 @@ describe(':write', function()
   end)
 
   it('&backupcopy=no replaces symlink with new file', function()
-    clear('set backupcopy=no')
+    clear('--cmd', 'set backupcopy=no')
     write_file('test_bkc_file.txt', 'content0')
     execute("silent !ln -s test_bkc_file.txt test_bkc_link.txt")
     source([[

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -221,11 +221,10 @@ local function spawn(argv, merge)
   return Session.new(child_stream)
 end
 
-local function clear(extra_cmd)
+local function clear(...)
   local args = {unpack(nvim_argv)}
-  if extra_cmd ~= nil then
-    table.insert(args, '--cmd')
-    table.insert(args, extra_cmd)
+  for _, arg in ipairs({...}) do
+    table.insert(args, arg)
   end
   set_session(spawn(args))
 end

--- a/test/functional/legacy/command_count_spec.lua
+++ b/test/functional/legacy/command_count_spec.lua
@@ -2,24 +2,19 @@
 
 local helpers = require('test.functional.helpers')(after_each)
 local clear, source, expect = helpers.clear, helpers.source, helpers.expect
-local execute, spawn = helpers.execute, helpers.spawn
-local nvim_prog = helpers.nvim_prog
+local execute = helpers.execute
 
 describe('command_count', function()
-  setup(clear)
-  teardown(function()
-    os.remove('test.out')
-  end)
-
   it('is working', function()
     -- It is relevant for the test to load a file initially.  If this is
     -- emulated with :arg the buffer count is wrong as nvim creates an empty
     -- buffer if it was started without a filename.
-    local nvim2 = spawn({nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed',
-				    'test_command_count.in'})
-    helpers.set_session(nvim2)
+    clear('test_command_count.in')
 
     source([[
+      let g:tmpname = tempname()
+      call mkdir(g:tmpname)
+      execute "cd ".g:tmpname
       lang C
       let g:lines = []
       com -range=% RangeLines
@@ -239,5 +234,10 @@ describe('command_count', function()
       bufdo: 2 3 4 5 6 7 8 9 10 15
       bufdo: 4 5 6 7
       tabdo: 2 3 4]])
+
+    source([[
+      cd ..
+      call delete(g:tmpname, 'rf')
+    ]])
   end)
 end)


### PR DESCRIPTION
The test hit wait_return if `x` or `.x.swp` exists in the project root directory.
