### PR TITLE
[RFC] option: Do not expand options, obtained from XDG vars

### DIFF
--- a/scripts/genoptions.lua
+++ b/scripts/genoptions.lua
@@ -57,9 +57,14 @@ local get_flags = function(o)
       add_flag(redraw_flags[r_flag])
     end
   end
+  if o.expand then
+    add_flag('P_EXPAND')
+    if o.expand == 'nodefault' then
+      add_flag('P_NO_DEF_EXP')
+    end
+  end
   for _, flag_desc in ipairs({
     {'alloced'},
-    {'expand'},
     {'nodefault'},
     {'no_mkrc'},
     {'vi_def'},

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1477,15 +1477,18 @@ do_set (
                * default value was already expanded, only
                * required when an environment variable was set
                * later */
-              if (newval == NULL)
+              new_value_alloced = true;
+              if (newval == NULL) {
                 newval = empty_option;
-              else {
+              } else if (!(options[opt_idx].flags | P_NO_DEF_EXP)) {
                 s = option_expand(opt_idx, newval);
-                if (s == NULL)
+                if (s == NULL) {
                   s = newval;
+                }
                 newval = vim_strsave(s);
+              } else {
+                newval = (char_u *)xstrdup((char *)newval);
               }
-              new_value_alloced = TRUE;
             } else if (nextchar == '<') {             /* set to global val */
               newval = vim_strsave(*(char_u **)get_varp_scope(
                       &(options[opt_idx]), OPT_GLOBAL));

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -677,15 +677,18 @@ void set_init_1(void)
 #endif
                      false);
 
-  char *backupdir = stdpaths_user_data_subpath("backup", 0);
+  char *backupdir = stdpaths_user_data_subpath("backup", 0, true);
   const size_t backupdir_len = strlen(backupdir);
   backupdir = xrealloc(backupdir, backupdir_len + 3);
   memmove(backupdir + 2, backupdir, backupdir_len + 1);
   memmove(backupdir, ".,", 2);
-  set_string_default("viewdir", stdpaths_user_data_subpath("view", 0), true);
+  set_string_default("viewdir", stdpaths_user_data_subpath("view", 0, true),
+                     true);
   set_string_default("backupdir", backupdir, true);
-  set_string_default("directory", stdpaths_user_data_subpath("swap", 2), true);
-  set_string_default("undodir", stdpaths_user_data_subpath("undo", 0), true);
+  set_string_default("directory", stdpaths_user_data_subpath("swap", 2, true),
+                     true);
+  set_string_default("undodir", stdpaths_user_data_subpath("undo", 0, true),
+                     true);
   // Set default for &runtimepath. All necessary expansions are performed in
   // this function.
   set_runtimepath_default();

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1492,7 +1492,7 @@ do_set (
               } else {
                 newval = (char_u *)xstrdup((char *)newval);
               }
-            } else if (nextchar == '<') {             /* set to global val */
+            } else if (nextchar == '<') {  // set to global val
               newval = vim_strsave(*(char_u **)get_varp_scope(
                       &(options[opt_idx]), OPT_GLOBAL));
               new_value_alloced = TRUE;

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -6,17 +6,18 @@
 #define BCO_ALWAYS      2       /* always copy the options */
 #define BCO_NOHELP      4       /* don't touch the help related options */
 
-/*
- * "flags" values for option-setting functions.
- * When OPT_GLOBAL and OPT_LOCAL are both missing, set both local and global
- * values, get local value.
- */
-#define OPT_FREE        1       /* free old value if it was allocated */
-#define OPT_GLOBAL      2       /* use global value */
-#define OPT_LOCAL       4       /* use local value */
-#define OPT_MODELINE    8       /* option in modeline */
-#define OPT_WINONLY     16      /* only set window-local options */
-#define OPT_NOWIN       32      /* don't set window-local options */
+/// Flags for option-setting functions
+///
+/// When OPT_GLOBAL and OPT_LOCAL are both missing, set both local and global
+/// values, get local value.
+typedef enum {
+  OPT_FREE = 1,  ///< Free old value if it was allocated.
+  OPT_GLOBAL = 2,  ///< Use global value.
+  OPT_LOCAL = 4,  ///< Use local value.
+  OPT_MODELINE = 8,  ///< Option in modeline.
+  OPT_WINONLY = 16,  ///< Only set window-local options.
+  OPT_NOWIN = 32,  ///< Don’t set window-local options.
+} OptionFlags;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "option.h.generated.h"

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -165,7 +165,7 @@ return {
       deny_duplicates=true,
       secure=true,
       vi_def=true,
-      expand=true,
+      expand='nodefault',
       varname='p_bdir',
       defaults={if_true={vi=''}}
     },
@@ -616,7 +616,7 @@ return {
       deny_duplicates=true,
       secure=true,
       vi_def=true,
-      expand=true,
+      expand='nodefault',
       varname='p_dir',
       defaults={if_true={vi=''}}
     },
@@ -1891,7 +1891,7 @@ return {
       deny_duplicates=true,
       secure=true,
       vi_def=true,
-      expand=true,
+      expand='nodefault',
       varname='p_rtp',
       defaults={if_true={vi=''}}
     },
@@ -2507,7 +2507,7 @@ return {
       deny_duplicates=true,
       secure=true,
       vi_def=true,
-      expand=true,
+      expand='nodefault',
       varname='p_udir',
       defaults={if_true={vi=''}}
     },
@@ -2568,7 +2568,7 @@ return {
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
-      expand=true,
+      expand='nodefault',
       varname='p_vdir',
       defaults={if_true={vi=''}}
     },

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1524,7 +1524,7 @@ static const char *shada_get_default_file(void)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (default_shada_file == NULL) {
-    char *shada_dir = stdpaths_user_data_subpath("shada", 0);
+    char *shada_dir = stdpaths_user_data_subpath("shada", 0, false);
     default_shada_file = concat_fnames_realloc(shada_dir, "main.shada", true);
   }
   return default_shada_file;

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -189,6 +189,21 @@ describe('XDG-based defaults', function()
       eq('$XDG_CONFIG_HOME/nvim/swap//', meths.get_option('directory'))
       eq('$XDG_CONFIG_HOME/nvim/undo', meths.get_option('undodir'))
       eq('$XDG_CONFIG_HOME/nvim/view', meths.get_option('viewdir'))
+      meths.command('set all&')
+      eq(('$XDG_DATA_HOME/nvim'
+          .. ',$XDG_DATA_DIRS/nvim'
+          .. ',$XDG_CONFIG_HOME/nvim/site'
+          .. ',$XDG_CONFIG_DIRS/nvim/site'
+          .. ',' .. eval('$VIMRUNTIME')
+          .. ',$XDG_CONFIG_DIRS/nvim/site/after'
+          .. ',$XDG_CONFIG_HOME/nvim/site/after'
+          .. ',$XDG_DATA_DIRS/nvim/after'
+          .. ',$XDG_DATA_HOME/nvim/after'
+      ), meths.get_option('runtimepath'))
+      eq('.,$XDG_CONFIG_HOME/nvim/backup', meths.get_option('backupdir'))
+      eq('$XDG_CONFIG_HOME/nvim/swap//', meths.get_option('directory'))
+      eq('$XDG_CONFIG_HOME/nvim/undo', meths.get_option('undodir'))
+      eq('$XDG_CONFIG_HOME/nvim/view', meths.get_option('viewdir'))
     end)
   end)
 

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -1,7 +1,12 @@
 local helpers = require('test.functional.helpers')(after_each)
+
 local Screen = require('test.functional.ui.screen')
-local eval, eq = helpers.eval, helpers.eq
+
+local meths = helpers.meths
 local execute = helpers.execute
+local clear = helpers.clear
+local eval = helpers.eval
+local eq = helpers.eq
 
 local function init_session(...)
   local args = { helpers.nvim_prog, '-i', 'NONE', '--embed',
@@ -73,6 +78,168 @@ describe('startup defaults', function()
     it('overridden by early `syntax off`', function()
       init_session('-u', 'NORC', '--cmd', 'syntax off')
       eq(0, eval('exists("g:syntax_on")'))
+    end)
+  end)
+end)
+
+describe('XDG-based defaults', function()
+  -- Need to be in separate describe() block to not run clear() twice.
+  -- Do not put before_each() here for the same reasons.
+  describe('with too long XDG variables', function()
+    before_each(function()
+      clear({env={
+        XDG_CONFIG_HOME=('/x'):rep(4096),
+        XDG_CONFIG_DIRS=(('/a'):rep(2048)
+                         .. ':' .. ('/b'):rep(2048)
+                         .. (':/c'):rep(512)),
+        XDG_DATA_HOME=('/X'):rep(4096),
+        XDG_DATA_DIRS=(('/A'):rep(2048)
+                       .. ':' .. ('/B'):rep(2048)
+                       .. (':/C'):rep(512)),
+      }})
+    end)
+
+    it('are correctly set', function()
+      eq((('/x'):rep(4096) .. '/nvim'
+          .. ',' .. ('/a'):rep(2048) .. '/nvim'
+          .. ',' .. ('/b'):rep(2048) .. '/nvim'
+          .. (',' .. '/c/nvim'):rep(512)
+          .. ',' .. ('/X'):rep(4096) .. '/nvim/site'
+          .. ',' .. ('/A'):rep(2048) .. '/nvim/site'
+          .. ',' .. ('/B'):rep(2048) .. '/nvim/site'
+          .. (',' .. '/C/nvim/site'):rep(512)
+          .. ',' .. eval('$VIMRUNTIME')
+          .. (',' .. '/C/nvim/site/after'):rep(512)
+          .. ',' .. ('/B'):rep(2048) .. '/nvim/site/after'
+          .. ',' .. ('/A'):rep(2048) .. '/nvim/site/after'
+          .. ',' .. ('/X'):rep(4096) .. '/nvim/site/after'
+          .. (',' .. '/c/nvim/after'):rep(512)
+          .. ',' .. ('/b'):rep(2048) .. '/nvim/after'
+          .. ',' .. ('/a'):rep(2048) .. '/nvim/after'
+          .. ',' .. ('/x'):rep(4096) .. '/nvim/after'
+      ), meths.get_option('runtimepath'))
+      meths.command('set runtimepath&')
+      meths.command('set backupdir&')
+      meths.command('set directory&')
+      meths.command('set undodir&')
+      meths.command('set viewdir&')
+      eq((('/x'):rep(4096) .. '/nvim'
+          .. ',' .. ('/a'):rep(2048) .. '/nvim'
+          .. ',' .. ('/b'):rep(2048) .. '/nvim'
+          .. (',' .. '/c/nvim'):rep(512)
+          .. ',' .. ('/X'):rep(4096) .. '/nvim/site'
+          .. ',' .. ('/A'):rep(2048) .. '/nvim/site'
+          .. ',' .. ('/B'):rep(2048) .. '/nvim/site'
+          .. (',' .. '/C/nvim/site'):rep(512)
+          .. ',' .. eval('$VIMRUNTIME')
+          .. (',' .. '/C/nvim/site/after'):rep(512)
+          .. ',' .. ('/B'):rep(2048) .. '/nvim/site/after'
+          .. ',' .. ('/A'):rep(2048) .. '/nvim/site/after'
+          .. ',' .. ('/X'):rep(4096) .. '/nvim/site/after'
+          .. (',' .. '/c/nvim/after'):rep(512)
+          .. ',' .. ('/b'):rep(2048) .. '/nvim/after'
+          .. ',' .. ('/a'):rep(2048) .. '/nvim/after'
+          .. ',' .. ('/x'):rep(4096) .. '/nvim/after'
+      ), meths.get_option('runtimepath'))
+      eq('.,' .. ('/X'):rep(4096) .. '/nvim/backup',
+         meths.get_option('backupdir'))
+      eq(('/X'):rep(4096) .. '/nvim/swap//', meths.get_option('directory'))
+      eq(('/X'):rep(4096) .. '/nvim/undo', meths.get_option('undodir'))
+      eq(('/X'):rep(4096) .. '/nvim/view', meths.get_option('viewdir'))
+    end)
+  end)
+
+  describe('with XDG variables that can be expanded', function()
+    before_each(function()
+      clear({env={
+        XDG_CONFIG_HOME='$XDG_DATA_HOME',
+        XDG_CONFIG_DIRS='$XDG_DATA_DIRS',
+        XDG_DATA_HOME='$XDG_CONFIG_HOME',
+        XDG_DATA_DIRS='$XDG_CONFIG_DIRS',
+      }})
+    end)
+
+    it('are not expanded', function()
+      eq(('$XDG_DATA_HOME/nvim'
+          .. ',$XDG_DATA_DIRS/nvim'
+          .. ',$XDG_CONFIG_HOME/nvim/site'
+          .. ',$XDG_CONFIG_DIRS/nvim/site'
+          .. ',' .. eval('$VIMRUNTIME')
+          .. ',$XDG_CONFIG_DIRS/nvim/site/after'
+          .. ',$XDG_CONFIG_HOME/nvim/site/after'
+          .. ',$XDG_DATA_DIRS/nvim/after'
+          .. ',$XDG_DATA_HOME/nvim/after'
+      ), meths.get_option('runtimepath'))
+      meths.command('set runtimepath&')
+      meths.command('set backupdir&')
+      meths.command('set directory&')
+      meths.command('set undodir&')
+      meths.command('set viewdir&')
+      eq(('$XDG_DATA_HOME/nvim'
+          .. ',$XDG_DATA_DIRS/nvim'
+          .. ',$XDG_CONFIG_HOME/nvim/site'
+          .. ',$XDG_CONFIG_DIRS/nvim/site'
+          .. ',' .. eval('$VIMRUNTIME')
+          .. ',$XDG_CONFIG_DIRS/nvim/site/after'
+          .. ',$XDG_CONFIG_HOME/nvim/site/after'
+          .. ',$XDG_DATA_DIRS/nvim/after'
+          .. ',$XDG_DATA_HOME/nvim/after'
+      ), meths.get_option('runtimepath'))
+      eq('.,$XDG_CONFIG_HOME/nvim/backup', meths.get_option('backupdir'))
+      eq('$XDG_CONFIG_HOME/nvim/swap//', meths.get_option('directory'))
+      eq('$XDG_CONFIG_HOME/nvim/undo', meths.get_option('undodir'))
+      eq('$XDG_CONFIG_HOME/nvim/view', meths.get_option('viewdir'))
+    end)
+  end)
+
+  describe('with commas', function()
+    before_each(function()
+      clear({env={
+        XDG_CONFIG_HOME=', , ,',
+        XDG_CONFIG_DIRS=',-,-,:-,-,-',
+        XDG_DATA_HOME=',=,=,',
+        XDG_DATA_DIRS=',≡,≡,:≡,≡,≡',
+      }})
+    end)
+
+    it('are escaped properly', function()
+      eq(('\\, \\, \\,/nvim'
+          .. ',\\,-\\,-\\,/nvim'
+          .. ',-\\,-\\,-/nvim'
+          .. ',\\,=\\,=\\,/nvim/site'
+          .. ',\\,≡\\,≡\\,/nvim/site'
+          .. ',≡\\,≡\\,≡/nvim/site'
+          .. ',' .. eval('$VIMRUNTIME')
+          .. ',≡\\,≡\\,≡/nvim/site/after'
+          .. ',\\,≡\\,≡\\,/nvim/site/after'
+          .. ',\\,=\\,=\\,/nvim/site/after'
+          .. ',-\\,-\\,-/nvim/after'
+          .. ',\\,-\\,-\\,/nvim/after'
+          .. ',\\, \\, \\,/nvim/after'
+      ), meths.get_option('runtimepath'))
+      meths.command('set runtimepath&')
+      meths.command('set backupdir&')
+      meths.command('set directory&')
+      meths.command('set undodir&')
+      meths.command('set viewdir&')
+      eq(('\\, \\, \\,/nvim'
+          .. ',\\,-\\,-\\,/nvim'
+          .. ',-\\,-\\,-/nvim'
+          .. ',\\,=\\,=\\,/nvim/site'
+          .. ',\\,≡\\,≡\\,/nvim/site'
+          .. ',≡\\,≡\\,≡/nvim/site'
+          .. ',' .. eval('$VIMRUNTIME')
+          .. ',≡\\,≡\\,≡/nvim/site/after'
+          .. ',\\,≡\\,≡\\,/nvim/site/after'
+          .. ',\\,=\\,=\\,/nvim/site/after'
+          .. ',-\\,-\\,-/nvim/after'
+          .. ',\\,-\\,-\\,/nvim/after'
+          .. ',\\, \\, \\,/nvim/after'
+      ), meths.get_option('runtimepath'))
+      eq('.,\\,=\\,=\\,/nvim/backup', meths.get_option('backupdir'))
+      eq('\\,=\\,=\\,/nvim/swap//', meths.get_option('directory'))
+      eq('\\,=\\,=\\,/nvim/undo', meths.get_option('undodir'))
+      eq('\\,=\\,=\\,/nvim/view', meths.get_option('viewdir'))
     end)
   end)
 end)

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -76,5 +76,3 @@ describe('startup defaults', function()
     end)
   end)
 end)
-
-

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -152,7 +152,7 @@ if(USE_BUNDLED_BUSTED)
 
   add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build https://raw.githubusercontent.com/neovim/lua-client/0.0.1-24/nvim-client-0.0.1-24.rockspec ${LUAROCKS_BUILDARGS}
+    ARGS build https://raw.githubusercontent.com/neovim/lua-client/0.0.1-25/nvim-client-0.0.1-25.rockspec ${LUAROCKS_BUILDARGS}
     DEPENDS luv)
   add_custom_target(nvim-client
     DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client)


### PR DESCRIPTION
It is a wrong thing to do, this makes valid variable values be treated 
incorrectly: in

```
XDG_DATA_HOME='/home/$foo/.local/share'
```

`$foo` should be treated literally and not expanded to `foo` environment 
variable value.

Also makes option_expand not try to expand too long strings even if these too 
long strings are default values. Previously it thought that default values 
should always be expanded. Also does not try to expand NULL should it be the 
default value just in case.

Fixes #4961
