### PR TITLE
Doc-fix: No more dos-colors

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3327,8 +3327,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 		-	no highlighting
 		:	use a highlight group
 	The default is used for occasions that are not included.
-	If you want to change what the display modes do, see |dos-colors|
-	for an example.
 	When using the ':' display mode, this must be followed by the name of
 	a highlight group.  A highlight group can be used to define any type
 	of highlighting, including using color.  See |:highlight| on how to


### PR DESCRIPTION
Trivial fix I came about during the incsub stuff. Planed to sneak it in there, but I want to get rid of it, therefore this small PR.
