### PR TITLE
[RFC] vim-patch:7.4.1136

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7667,7 +7667,8 @@ static void f_assert_exception(typval_T *argvars, typval_T *rettv)
     ga_concat(&ga, (char_u *)"v:exception is not set");
     assert_error(&ga);
     ga_clear(&ga);
-  } else if (strstr((char *)vimvars[VV_EXCEPTION].vv_str, error) == NULL) {
+  } else if (error != NULL
+             && strstr((char *)vimvars[VV_EXCEPTION].vv_str, error) == NULL) {
     prepare_assert_error(&ga);
     fill_assert_error(&ga, &argvars[1], NULL, &argvars[0],
                       &vimvars[VV_EXCEPTION].vv_tv);

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -558,7 +558,7 @@ static int included_patches[] = {
   // 1139 NA
   // 1138 NA
   1137,
-  // 1136,
+  1136,
   // 1135 NA
   // 1134 NA
   // 1133 NA

--- a/test/functional/legacy/assert_spec.lua
+++ b/test/functional/legacy/assert_spec.lua
@@ -172,4 +172,34 @@ describe('assert function:', function()
       expected_errors({'command did not fail: call empty("")'})
     end)
   end)
+
+  -- assert_exception({cmd}, [, {error}])
+  describe('assert_exception()', function()
+    it('should assert thrown exceptions properly', function()
+      source([[
+        try
+          nocommand
+        catch
+          call assert_exception('E492')
+        endtry
+      ]])
+      expected_empty()
+    end)
+
+    it('should work properly when nested', function()
+      source([[
+        try
+          nocommand
+        catch
+          try
+            " illegal argument, get NULL for error
+            call assert_exception([])
+          catch
+            call assert_exception('E730')
+          endtry
+        endtry
+      ]])
+      expected_empty()
+    end)
+  end)
 end)


### PR DESCRIPTION
```
Problem:    Wrong argument to assert_exception() causes a crash. (reported by
            Coverity)
Solution:   Check for NULL pointer.  Add a test.
```

https://github.com/vim/vim/commit/da5dcd936656f524dd0ae7cb2685245f07f5720f

~~**Note**: No test added, because the file (`test_assert.vim`) no longer exists.~~
