### PR TITLE
Fix regression of :drop introduced in 1a91000

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3533,5 +3533,6 @@ void ex_drop(exarg_T   *eap)
     } else {
       eap->cmdidx = CMD_first;
     }
+    ex_rewind(eap);
   }
 }


### PR DESCRIPTION
A single line was deleted from `ex_drop()` in 1a91000 when fixing clint
warnings causing the `:drop` command to not work correctly if the buffer
is not already open in a window.

Fixes #4981
