### PR TITLE
main.c: use 8 (i.e. 16) colors on virtual consoles

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -226,6 +226,7 @@ int main(int argc, char **argv)
   mparm_T params;         // various parameters passed between
                           // main() and other functions.
   char_u *cwd = NULL;     // current workding dir on startup
+  char *term = getenv("TERM");
   time_init();
 
   /* Many variables are in "params" so that we can pass them to invoked
@@ -277,6 +278,10 @@ int main(int argc, char **argv)
 
   full_screen = true;
   t_colors = 256;
+  if (term && strcmp(term, "linux")==0) {
+    // TODO: instead, in tui.c detect if `tput colors`==8, then scramble to translate 256->16 colors?
+    t_colors = 8;
+  }
   check_tty(&params);
 
   /*


### PR DESCRIPTION
Partial fix to #3428. (Most probably it won't fix situation for
screen/tmux users.) Original idea by Jakson Alves de Aquino (@jalvesaq).

The Linux "virtual consoles" available on Alt-F1...Alt-F7 (i.e.
tty1-tty7) support only 8 colors (actually, it's 16 colors when counted
together with "bold/bright" attribute) and 8 background colors (those in
some cases can be upped to 16 too, by using "blink" attribute - but this
might be more risky, in case some legacy consoles really show it as
blinking? I'm not sure about that.) This limit is buried deep in kernel
sources for default tty drivers. Trying to use the Neovim's default 256
colors in this case gives totally bad colors, breaking all color schemes
and sometimes rendering parts of the text invisible. A simple change
enables code paths for handling 8/16 colors, which are still present in
Neovim codebase.

A proposed idea for a long-term, possibly cleaner solution, could be to
try and keep 256 colors in main Neovim processing, and then try to
translate them back to 8/16 colors only in the final UI-handling code
(tui.c). But this would be much, much more work, with uncertain
potential for success, so I'm leaving this as a TODO for future as of
now. The current quick solution seems to be solving the main case of
trouble on virtual consoles.
