### PR TITLE
Please support setting terminal title in :terminal

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -10,6 +10,7 @@ Embedded terminal emulator				   *terminal-emulator*
 2. Spawning			|terminal-emulator-spawning|
 3. Input			|terminal-emulator-input|
 4. Configuration		|terminal-emulator-configuration|
+5. Status Variables		|terminal-emulator-status|
 
 ==============================================================================
 1. Introduction					     *terminal-emulator-intro*
@@ -112,5 +113,26 @@ There is also a corresponding |TermClose| event.
 The terminal cursor can be highlighted via |hl-TermCursor| and
 |hl-TermCursorNC|.
 
+==============================================================================
+5. Status Variables				    *terminal-emulator-status*
+
+Terminal buffers maintain some information about the terminal in buffer-local
+variables:
+
+- *b:term_title* The settable title of the terminal, typically displayed in
+  the window title or tab title of a graphical terminal emulator. Programs
+  running in the terminal can set this title via an escape sequence.
+- *b:terminal_job_id* The nvim job ID of the job running in the terminal. See
+  |job-control| for more information.
+- *b:terminal_job_pid* The PID of the top-level process running in the
+  terminal.
+
+These variables will have a value by the time the TermOpen autocmd runs, and
+will continue to have a value for the lifetime of the terminal buffer, making
+them suitable for use in 'statusline'. For example, to show the terminal title
+as the status line:
+>
+    :autocmd TermOpen * setlocal statusline=%{b:term_title}
+<
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
- `nvim --version`:

```
NVIM 0.1.4
Build type: None
Compilation: /usr/bin/cc -g -O2 -fPIE -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -DDISABLE_LOG -Wconversion -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1  -Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict-prototypes -std=gnu99 -Wvla -fstack-protector-strong -fdiagnostics-color=auto -DINCLUDE_GENERATED_DECLARATIONS -DHAVE_CONFIG_H -D_GNU_SOURCE -I/build/neovim-1AXpO2/neovim-0.1.4/build/config -I/build/neovim-1AXpO2/neovim-0.1.4/src -I/usr/include -I/usr/include -I/usr/include/luajit-2.0 -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/usr/include -I/build/neovim-1AXpO2/neovim-0.1.4/build/src/nvim/auto -I/build/neovim-1AXpO2/neovim-0.1.4/build/include
Compiled by buildd@babin

Optional features included (+) or not (-): +acl   +iconv    +jemalloc 
For differences from Vim, see :help vim-differences

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/share/nvim"
```
- Vim (version: ) behaves differently?

N/A; vim doesn't have :terminal.
- Operating system/version:

Latest Debian sid, with neovim package 0.1.4-1 from experimental.
- Terminal name/version:

gnome-terminal 3.20.2
- `$TERM`:

xterm-256color
### Actual behaviour

Terminal control sequences to set the terminal title get ignored.
### Expected behaviour

Terminal control sequences to set the terminal title set a buffer-local variable, and the default status line for terminal buffers includes that variable.

Many programs support setting the terminal title, as do the default shell startup files on many people's systems.
### Steps to reproduce using `nvim -u NORC`

```
nvim -u NORC
:terminal
/usr/bin/printf '\e]2;title\a' ; sleep 10
```

That escape sequence sets the terminal title to "title".  (See http://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Operating-System-Controls for details on these control sequences.)
