### PR TITLE
[RFC] - Extended Marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,14 @@ See `LICENSE` for details.
 [Gentoo]: https://packages.gentoo.org/packages/app-editors/neovim
 
 <!-- vim: set tw=80: -->
+
+
+CC=clang make functionaltest CMAKE_EXTRA_FLAGS="-DCLANG_ASAN_UBSAN=ON" TEST_FILE=test/functional/api TEST_TAG=extmarks
+
+CC=clang make functionaltest CMAKE_EXTRA_FLAGS="-DCLANG_ASAN_UBSAN=ON" TEST_FILE=test/functional/ui/mouse_spec.lua TEST_TAG=blah
+CC=clang make functionaltest CMAKE_EXTRA_FLAGS="-DCLANG_ASAN_UBSAN=ON"
+
+CC=clang make functionaltest CMAKE_EXTRA_FLAGS="-DCLANG_ASAN_UBSAN=OFF" TEST_FILE=test/functional/api/mark_extended_spec.lua TEST_TAG=broken
+
+# TODO debug in container with clion...
+https://github.com/shuhaoliu/docker-clion-dev

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -439,6 +439,36 @@ Example: create a float with scratch buffer: >
 >
 
 ==============================================================================
+Buffer extended marks	                                  *api-extended-marks*
+
+An extended mark represents a buffer annotation that remains logically
+stationary even as the buffer changes. They could be used to represent cursors,
+folds, misspelled words, and anything else that needs to track a logical
+location in the buffer over time.
+
+Example:
+
+We will set an extmark at row 1, column three.
+
+`let g:mark_ns = nvim_create_namespace('myplugin')`
+`let g:mark_id = nvim_buf_set_mark(0, :g:mark_ns, 0, 1, 3)`
+
+Note: the mark id was randomly generated because we used an inital value of 0
+
+`echo nvim_buf_lookup_mark(0, g:mark_ns, g:mark_id)`
+=> [1, 1, 3]
+`echo nvim_buf_get_marks(0, g:mark_ns, [1, 1], [1, 3], -1, 0)`
+=> [[1, 1, 3]]
+
+Deleting the text all around an extended mark does not remove it. If you want
+to remove an extended mark, use the |nvim_buf_unset_mark()| function.
+
+The namepsace ensures you only ever work with the extended marks you mean to.
+
+Calling set and unset of marks will not automatically prop a new undo.
+
+
+==============================================================================
 Global Functions                                                  *api-global*
 
 nvim_command({command})                                       *nvim_command()*
@@ -1448,6 +1478,22 @@ nvim_select_popupmenu_item({item}, {insert}, {finish}, {opts})
 
 nvim__inspect_cell({grid}, {row}, {col})                *nvim__inspect_cell()*
                 TODO: Documentation
+
+                                                        *nvim_init_mark_ns()*
+nvim_init_mark_ns({namespace})
+                Create a new namepsace for holding extended marks. The id
+                of the namespace is returned, this namespace id is required
+                for using the rest of the extended marks api.
+
+                Parameters:~
+                    {namespace} String name to be assigned to the namespace
+
+
+                                                     *nvim_mark_get_ns_ids()*
+nvim_mark_get_ns_ids()
+                Returns a list of extended mark namespaces.
+                Pairs of ids and string names are returned.
+                An empty list will be returned if no namespaces are set.
 
 
 ==============================================================================

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -24,6 +24,7 @@
 #include "nvim/eval/typval.h"
 #include "nvim/map_defs.h"
 #include "nvim/map.h"
+#include "nvim/mark_extended.h"
 #include "nvim/option.h"
 #include "nvim/option_defs.h"
 #include "nvim/version.h"
@@ -1507,6 +1508,63 @@ ArrayOf(Dictionary) keymap_array(String mode, buf_T *buf)
   return mappings;
 }
 
+// Returns an extmark given an id or a positional index
+// If throw == true then an error will be raised if nothing
+// was found
+// Returns NULL if something went wrong
+ExtendedMark *extmark_from_id_or_pos(Buffer buffer,
+                                     Integer namespace,
+                                     Object id,
+                                     Error *err,
+                                     bool throw)
+{
+  buf_T *buf = find_buffer_by_handle(buffer, err);
+
+  if (!buf) {
+    return NULL;
+  }
+
+  ExtendedMark *extmark = NULL;
+  if (id.type == kObjectTypeArray) {
+    if (id.data.array.size != 2) {
+      api_set_error(err, kErrorTypeValidation,
+                    _("Position must have 2 elements"));
+      return NULL;
+    }
+    linenr_T row = (linenr_T)id.data.array.items[0].data.integer;
+    colnr_T col = (colnr_T)id.data.array.items[1].data.integer;
+    if (row < 1 || col < 1) {
+      if (throw) {
+      api_set_error(err, kErrorTypeValidation, _("Row and column MUST be > 0"));
+      }
+      return NULL;
+    }
+    extmark = extmark_from_pos(buf, (uint64_t)namespace, row, col);
+  } else if (id.type != kObjectTypeInteger) {
+    if (throw) {
+      api_set_error(err, kErrorTypeValidation,
+                    _("Mark id must be an int or [row, col]"));
+    }
+    return NULL;
+  } else if (id.data.integer < 0) {
+    if (throw) {
+      api_set_error(err, kErrorTypeValidation, _("Mark id must be positive"));
+    }
+    return NULL;
+  } else {
+    extmark = extmark_from_id(buf,
+                              (uint64_t)namespace,
+                              (uint64_t)id.data.integer);
+  }
+
+  if (!extmark) {
+    if (throw) {
+      api_set_error(err, kErrorTypeValidation, _("Mark doesn't exist"));
+    }
+    return NULL;
+  }
+  return extmark;
+}
 
 // Is the Namespace in use?
 bool ns_initialized(uint64_t ns)
@@ -1515,4 +1573,63 @@ bool ns_initialized(uint64_t ns)
     return false;
   }
   return ns < (uint64_t)next_namespace_id;
+}
+
+// Extmarks may be queried from position or name or even special names
+// in the future such as "cursor". This macro sets the line and col
+// to make the extmark functions recognize what's required
+//
+// *lnum: linenr_T, lnum to be set
+// *col: colnr_T, col to be set
+bool set_extmark_index_from_obj(buf_T *buf, Integer namespace,
+                                Object obj, linenr_T *lnum, colnr_T *colnr,
+                                Error *err)
+{
+  // Check if it is mark id
+  if (obj.type == kObjectTypeInteger) {
+    Integer id = obj.data.integer;
+    if (id == 0) {
+        *lnum = 1;
+        *colnr = 1;
+        return true;
+    } else if (id == -1) {
+        *lnum = MAXLNUM;
+        *colnr = MAXCOL;
+        return true;
+    } else if (id < 0) {
+      api_set_error(err, kErrorTypeValidation, _("Mark id must be positive"));
+      return false;
+    }
+
+    ExtendedMark *extmark = extmark_from_id(buf, (uint64_t)namespace,
+                                            (uint64_t)id);
+    if (extmark) {
+      *lnum = extmark->line->lnum;
+      *colnr = extmark->col;
+      return true;
+    } else {
+      api_set_error(err, kErrorTypeValidation, _("No mark with requested id"));
+      return false;
+    }
+
+  // Check if it is a position
+  } else if (obj.type == kObjectTypeArray) {
+    Array pos = obj.data.array;
+    if (pos.size != 2
+        || pos.items[0].type != kObjectTypeInteger
+        || pos.items[1].type != kObjectTypeInteger) {
+      api_set_error(err, kErrorTypeValidation,
+                    _("Position must have 2 integer elements"));
+      return false;
+    }
+    Integer line = pos.items[0].data.integer;
+    Integer col = pos.items[1].data.integer;
+    *lnum = (linenr_T)(line >= 0 ? line + 1 : MAXLNUM);
+    *colnr = (colnr_T)(col >= 0 ? col + 1 : MAXCOL);
+    return true;
+  } else {
+    api_set_error(err, kErrorTypeValidation,
+                  _("Position must be a mark id Integer or position Array"));
+    return false;
+  }
 }

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -10,6 +10,7 @@
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/handle.h"
+#include "nvim/api/vim.h"
 #include "nvim/msgpack_rpc/helpers.h"
 #include "nvim/lua/executor.h"
 #include "nvim/ascii.h"
@@ -1504,4 +1505,14 @@ ArrayOf(Dictionary) keymap_array(String mode, buf_T *buf)
   tv_dict_free(dict);
 
   return mappings;
+}
+
+
+// Is the Namespace in use?
+bool ns_initialized(uint64_t ns)
+{
+  if (ns < 1) {
+    return false;
+  }
+  return ns < (uint64_t)next_namespace_id;
 }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -39,6 +39,7 @@
 #include "nvim/ops.h"
 #include "nvim/option.h"
 #include "nvim/state.h"
+#include "nvim/mark_extended.h"
 #include "nvim/syntax.h"
 #include "nvim/getchar.h"
 #include "nvim/os/input.h"

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -53,6 +53,7 @@
 #include "nvim/indent_c.h"
 #include "nvim/main.h"
 #include "nvim/mark.h"
+#include "nvim/mark_extended.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
@@ -816,6 +817,7 @@ static void free_buffer_stuff(buf_T *buf, int free_flags)
   }
   uc_clear(&buf->b_ucmds);               // clear local user commands
   buf_delete_signs(buf, (char_u *)"*");  // delete any signs
+  extmark_free_all(buf);                 // delete any extmarks
   bufhl_clear_all(buf);                  // delete any highligts
   map_clear_int(buf, MAP_ALL_MODES, true, false);    // clear local mappings
   map_clear_int(buf, MAP_ALL_MODES, true, true);     // clear local abbrevs
@@ -5496,6 +5498,7 @@ void bufhl_clear_line_range(buf_T *buf,
                             linenr_T line_start,
                             linenr_T line_end)
 {
+  // TODO(bfredl): implement kb_itr_interval to jump directly to the first line
   kbitr_t(bufhl) itr;
   BufhlLine *l, t = BUFHLLINE_INIT(line_start);
   if (!kb_itr_get(bufhl, &buf->b_bufhl_info, &t, &itr)) {

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -115,6 +115,9 @@ typedef uint16_t disptick_T;  // display tick type
 #include "nvim/os/fs_defs.h"    // for FileID
 #include "nvim/terminal.h"      // for Terminal
 
+#include "nvim/lib/kbtree.h"
+#include "nvim/mark_extended.h"
+
 /*
  * The taggy struct is used to store the information about a :tag command.
  */
@@ -804,6 +807,10 @@ struct file_buffer {
   BufhlInfo b_bufhl_info;       // buffer stored highlights
 
   kvec_t(BufhlLine *) b_bufhl_move_space;  // temporary space for highlights
+
+  PMap(uint64_t) *b_extmark_ns;         // extmark namespaces
+  kbtree_t(extlines) b_extlines;  // extmarks
+  kvec_t(ExtMarkLine *) b_extmark_move_space;  // temp space for extmarks
 
   // array of channel_id:s which have asked to receive updates for this
   // buffer.

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -2690,7 +2690,8 @@ void ex_diffgetput(exarg_T *eap)
 
       // Adjust marks.  This will change the following entries!
       if (added != 0) {
-        mark_adjust(lnum, lnum + count - 1, (long)MAXLNUM, (long)added, false);
+        mark_adjust(lnum, lnum + count - 1, (long)MAXLNUM, (long)added, false,
+                    kExtmarkUndo);
         if (curwin->w_cursor.lnum >= lnum) {
           // Adjust the cursor position if it's in/after the changed
           // lines.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -39,6 +39,7 @@
 #include "nvim/buffer_updates.h"
 #include "nvim/main.h"
 #include "nvim/mark.h"
+#include "nvim/mark_extended.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/message.h"
@@ -105,6 +106,8 @@ typedef struct {
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ex_cmds.c.generated.h"
+#include "mark_extended.h"
+
 #endif
 
 /// ":ascii" and "ga" implementation
@@ -658,10 +661,10 @@ void ex_sort(exarg_T *eap)
   deleted = (long)(count - (lnum - eap->line2));
   if (deleted > 0) {
     mark_adjust(eap->line2 - deleted, eap->line2, (long)MAXLNUM, -deleted,
-                false);
+                false, kExtmarkUndo);
     msgmore(-deleted);
   } else if (deleted < 0) {
-    mark_adjust(eap->line2, MAXLNUM, -deleted, 0L, false);
+    mark_adjust(eap->line2, MAXLNUM, -deleted, 0L, false, kExtmarkUndo);
   }
   if (change_occurred || deleted != 0) {
     changed_lines(eap->line1, 0, eap->line2 + 1, -deleted, true);
@@ -874,10 +877,12 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
    * their final destination at the new text position -- webb
    */
   last_line = curbuf->b_ml.ml_line_count;
-  mark_adjust_nofold(line1, line2, last_line - line2, 0L, true);
+  mark_adjust_nofold(line1, line2, last_line - line2, 0L, true, kExtmarkNoUndo);
+  extmark_adjust(curbuf, line1, line2, last_line - line2, 0L, kExtmarkNoUndo,
+                 true);
   changed_lines(last_line - num_lines + 1, 0, last_line + 1, num_lines, false);
   if (dest >= line2) {
-    mark_adjust_nofold(line2 + 1, dest, -num_lines, 0L, false);
+    mark_adjust_nofold(line2 + 1, dest, -num_lines, 0L, false, kExtmarkNoUndo);
     FOR_ALL_TAB_WINDOWS(tab, win) {
       if (win->w_buffer == curbuf) {
         foldMoveRange(&win->w_folds, line1, line2, dest);
@@ -886,7 +891,8 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
     curbuf->b_op_start.lnum = dest - num_lines + 1;
     curbuf->b_op_end.lnum = dest;
   } else {
-    mark_adjust_nofold(dest + 1, line1 - 1, num_lines, 0L, false);
+    mark_adjust_nofold(dest + 1, line1 - 1, num_lines, 0L, false,
+                       kExtmarkNoUndo);
     FOR_ALL_TAB_WINDOWS(tab, win) {
       if (win->w_buffer == curbuf) {
         foldMoveRange(&win->w_folds, dest + 1, line1 - 1, line2);
@@ -897,7 +903,9 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
   }
   curbuf->b_op_start.col = curbuf->b_op_end.col = 0;
   mark_adjust_nofold(last_line - num_lines + 1, last_line,
-                     -(last_line - dest - extra), 0L, true);
+                     -(last_line - dest - extra), 0L, true, kExtmarkNoUndo);
+
+  u_extmark_move(curbuf, line1, line2, last_line, dest, num_lines, extra);
   changed_lines(last_line - num_lines + 1, 0, last_line + 1, -extra, false);
 
   // send update regarding the new lines that were added
@@ -1281,12 +1289,14 @@ static void do_filter(
       if (cmdmod.keepmarks || vim_strchr(p_cpo, CPO_REMMARK) == NULL) {
         if (read_linecount >= linecount) {
           // move all marks from old lines to new lines
-          mark_adjust(line1, line2, linecount, 0L, false);
+          mark_adjust(line1, line2, linecount, 0L, false, kExtmarkUndo);
         } else {
           // move marks from old lines to new lines, delete marks
           // that are in deleted lines
-          mark_adjust(line1, line1 + read_linecount - 1, linecount, 0L, false);
-          mark_adjust(line1 + read_linecount, line2, MAXLNUM, 0L, false);
+          mark_adjust(line1, line1 + read_linecount - 1, linecount, 0L, false,
+                      kExtmarkUndo);
+          mark_adjust(line1 + read_linecount, line2, MAXLNUM, 0L, false,
+                      kExtmarkUndo);
         }
       }
 
@@ -3214,6 +3224,189 @@ static char_u *sub_parse_flags(char_u *cmd, subflags_T *subflags,
   return cmd;
 }
 
+static void extmark_move_regmatch_single(lpos_T startpos,
+                                         lpos_T endpos,
+                                         linenr_T lnum,
+                                         int sublen)
+{
+  colnr_T mincol;
+  colnr_T endcol;
+  colnr_T col_amount;
+
+  mincol = startpos.col + 1;
+  endcol = endpos.col + 1;
+
+  // There are cases such as :s/^/x/ where this happens
+  // a delete is simply not required.
+  if (mincol + 1 <= endcol) {
+    extmark_col_adjust_delete(curbuf,
+                              lnum, mincol + 1, endcol, kExtmarkUndo, 0);
+  }
+
+  // Insert, sublen seems to be the value we need but + 1...
+  col_amount = sublen - 1;
+  extmark_col_adjust(curbuf, lnum, mincol, 0, col_amount, kExtmarkUndo);
+}
+
+static void extmark_move_regmatch_multi(ExtmarkSubMulti s, long i)
+{
+  colnr_T mincol;
+  linenr_T u_lnum;
+  mincol = s.startpos.col + 1;
+
+  linenr_T n_u_lnum = s.lnum + s.endpos.lnum - s.startpos.lnum;
+  colnr_T n_after_newline_in_pat = s.endpos.col;
+  colnr_T n_before_newline_in_pat =  mincol - s.cm_start.col;
+  long n_after_newline_in_sub;
+  if (!s.newline_in_sub) {
+    n_after_newline_in_sub = s.cm_end.col - s.cm_start.col;
+  } else {
+    n_after_newline_in_sub = s.cm_end.col;
+  }
+
+  if (s.newline_in_pat && !s.newline_in_sub) {
+    // -- Delete Pattern --
+    // 1. Move marks in the pattern
+    mincol = s.startpos.col + 1;
+    u_lnum = n_u_lnum;
+    assert(n_u_lnum == u_lnum);
+    extmark_copy_and_place(curbuf,
+                           s.lnum, mincol,
+                           u_lnum, n_after_newline_in_pat,
+                           s.lnum, mincol,
+                           kExtmarkUndo, true, NULL);
+    // 2. Move marks on last newline
+    mincol = mincol - n_before_newline_in_pat;
+    extmark_col_adjust(curbuf,
+                       u_lnum,
+                       n_after_newline_in_pat + 1,
+                       -s.newline_in_pat,
+                       mincol - n_after_newline_in_pat,
+                       kExtmarkUndo);
+    // Take care of the lines after
+    extmark_adjust(curbuf,
+                   u_lnum,
+                   u_lnum,
+                   MAXLNUM,
+                   -s.newline_in_pat,
+                   kExtmarkUndo,
+                   false);
+    // 1. first insert the text in the substitutaion
+    extmark_col_adjust(curbuf,
+                       s.lnum,
+                       mincol + 1,
+                       s.newline_in_sub,
+                       n_after_newline_in_sub,
+                       kExtmarkUndo);
+
+  } else {
+    // The data in sub_obj is as if the substituons above had already taken
+    // place. For our extmarks they haven't as we work from the bottom of the
+    // buffer up. Readjust the data.
+    n_u_lnum = s.lnum + s.endpos.lnum - s.startpos.lnum;
+    n_u_lnum = n_u_lnum - s.lnum_added;
+
+    // adjusted = L - (i-1)N
+    // where L = lnum value, N= lnum_added and i = iteration
+    linenr_T a_l_lnum = s.cm_start.lnum - ((i -1) * s.lnum_added);
+    linenr_T a_u_lnum = a_l_lnum + s.endpos.lnum;
+    assert(s.startpos.lnum == 0);
+
+    mincol = s.startpos.col + 1;
+    u_lnum = n_u_lnum;
+
+    if (!s.newline_in_pat && s.newline_in_sub) {
+      // -- Delete Pattern --
+      // 1. Move marks in the pattern
+      extmark_col_adjust_delete(curbuf,
+                                a_l_lnum,
+                                mincol + 1,
+                                s.endpos.col + 1,
+                                kExtmarkUndo,
+                                s.eol);
+
+     extmark_adjust(curbuf,
+                    a_u_lnum + 1,
+                    MAXLNUM,
+                    (long)s.newline_in_sub,
+                    0,
+                    kExtmarkUndo,
+                    false);
+     // 3. Insert
+     extmark_col_adjust(curbuf,
+                        a_l_lnum,
+                        mincol,
+                        s.newline_in_sub,
+                        (long)-mincol + 1 + n_after_newline_in_sub,
+                        kExtmarkUndo);
+    } else if (s.newline_in_pat && s.newline_in_sub) {
+      if (s.lnum_added >= 0) {
+        linenr_T u_col = n_after_newline_in_pat == 0
+                         ? 1 : n_after_newline_in_pat;
+        extmark_copy_and_place(curbuf,
+                               a_l_lnum, mincol,
+                               a_u_lnum, u_col,
+                               a_l_lnum, mincol,
+                               kExtmarkUndo, true, NULL);
+        // 2. Move marks on last newline
+        mincol = mincol - (colnr_T)n_before_newline_in_pat;
+        extmark_col_adjust(curbuf,
+                           a_u_lnum,
+                           (colnr_T)(n_after_newline_in_pat + 1),
+                           -s.newline_in_pat,
+                           mincol - n_after_newline_in_pat,
+                           kExtmarkUndo);
+         // TODO(timeyyy): nothing to do here if lnum_added = 0
+         extmark_adjust(curbuf,
+                        a_u_lnum + 1,
+                        MAXLNUM,
+                        (long)s.lnum_added,
+                        0,
+                        kExtmarkUndo,
+                        false);
+
+         extmark_col_adjust(curbuf,
+                            a_l_lnum,
+                            mincol + 1,
+                            s.newline_in_sub,
+                            (long)-mincol + n_after_newline_in_sub,
+                            kExtmarkUndo);
+      } else {
+        mincol = s.startpos.col + 1;
+        a_l_lnum = s.startpos.lnum + 1;
+        a_u_lnum = s.endpos.lnum + 1;
+        extmark_copy_and_place(curbuf,
+                               a_l_lnum, mincol,
+                               a_u_lnum, n_after_newline_in_pat,
+                               a_l_lnum, mincol,
+                               kExtmarkUndo, true, NULL);
+        // 2. Move marks on last newline
+        mincol = mincol - (colnr_T)n_before_newline_in_pat;
+        extmark_col_adjust(curbuf,
+                           a_u_lnum,
+                           (colnr_T)(n_after_newline_in_pat + 1),
+                           -s.newline_in_pat,
+                           mincol - n_after_newline_in_pat,
+                           kExtmarkUndo);
+        extmark_adjust(curbuf,
+                       a_u_lnum,
+                       a_u_lnum,
+                       MAXLNUM,
+                       s.lnum_added,
+                       kExtmarkUndo,
+                       false);
+        // 3. Insert
+        extmark_col_adjust(curbuf,
+                           a_l_lnum,
+                           mincol + 1,
+                           s.newline_in_sub,
+                           (long)-mincol + n_after_newline_in_sub,
+                           kExtmarkUndo);
+      }
+    }
+  }
+}
+
 /// Perform a substitution from line eap->line1 to line eap->line2 using the
 /// command pointed to by eap->arg which should be of the form:
 ///
@@ -3260,6 +3453,17 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
   int save_ma = 0;
   int save_b_changed = curbuf->b_changed;
   bool preview = (State & CMDPREVIEW);
+  extmark_sub_multi_vec_t extmark_sub_multi = KV_INITIAL_VALUE;
+  extmark_sub_single_vec_t extmark_sub_single = KV_INITIAL_VALUE;
+  linenr_T no_of_lines_changed = 0;
+  linenr_T newline_in_pat = 0;
+  linenr_T newline_in_sub = 0;
+
+  // inccomand tests fail without this check
+  if (!preview) {
+    // Requried for Undo to work for nsmarks,
+    u_save_cursor();
+  }
 
   if (!global_busy) {
     sub_nsubs = 0;
@@ -3418,6 +3622,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
   // Check for a match on each line.
   // If preview: limit to max('cmdwinheight', viewport).
   linenr_T line2 = eap->line2;
+
   for (linenr_T lnum = eap->line1;
        lnum <= line2 && !got_quit && !aborting()
        && (!preview || preview_lines.lines_needed <= (linenr_T)p_cwh
@@ -3871,6 +4076,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
 
           ADJUST_SUB_FIRSTLNUM();
 
+
           // Now the trick is to replace CTRL-M chars with a real line
           // break.  This would make it impossible to insert a CTRL-M in
           // the text.  The line break can be avoided by preceding the
@@ -3885,7 +4091,9 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
                 *p1 = NUL;                            // truncate up to the CR
                 ml_append(lnum - 1, new_start,
                           (colnr_T)(p1 - new_start + 1), false);
-                mark_adjust(lnum + 1, (linenr_T)MAXLNUM, 1L, 0L, false);
+                mark_adjust(lnum + 1, (linenr_T)MAXLNUM, 1L, 0L, false,
+                            kExtmarkNOOP);
+
                 if (subflags.do_ask) {
                   appended_lines(lnum - 1, 1L);
                 } else {
@@ -3911,6 +4119,44 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
           current_match.end.col = STRLEN(new_start);
           current_match.end.lnum = lnum;
         }
+
+        // Adjust extmarks, by delete and then insert
+        if (!preview) {
+          newline_in_pat = (regmatch.endpos[0].lnum
+                            - regmatch.startpos[0].lnum);
+          newline_in_sub = current_match.end.lnum - current_match.start.lnum;
+          if (newline_in_pat || newline_in_sub) {
+            ExtmarkSubMulti sub_multi;
+            no_of_lines_changed = newline_in_sub - newline_in_pat;
+
+            sub_multi.newline_in_pat = newline_in_pat;
+            sub_multi.newline_in_sub = newline_in_sub;
+            sub_multi.lnum = lnum;
+            sub_multi.lnum_added = no_of_lines_changed;
+            sub_multi.cm_start = current_match.start;
+            sub_multi.cm_end = current_match.end;
+
+            sub_multi.startpos = regmatch.startpos[0];
+            sub_multi.endpos = regmatch.endpos[0];
+            sub_multi.eol = extmark_eol_col(curbuf, lnum);
+
+            kv_push(extmark_sub_multi, sub_multi);
+            // Collect information required for moving extmarks WITHOUT \n, \r
+          } else {
+            no_of_lines_changed = 0;
+
+            if (regmatch.startpos[0].col != -1) {
+              ExtmarkSubSingle sub_single;
+              sub_single.sublen = sublen;
+              sub_single.lnum = lnum;
+              sub_single.startpos = regmatch.startpos[0];
+              sub_single.endpos = regmatch.endpos[0];
+
+              kv_push(extmark_sub_single, sub_single);
+            }
+          }
+        }
+
 
         // 4. If subflags.do_all is set, find next match.
         // Prevent endless loop with patterns that match empty
@@ -3978,7 +4224,7 @@ skip:
                 ml_delete(lnum, false);
               }
               mark_adjust(lnum, lnum + nmatch_tl - 1,
-                          (long)MAXLNUM, -nmatch_tl, false);
+                          (long)MAXLNUM, -nmatch_tl, false, kExtmarkNOOP);
               if (subflags.do_ask) {
                 deleted_lines(lnum, nmatch_tl);
               }
@@ -4153,6 +4399,35 @@ skip:
                                kv_last(preview_lines.subresults).end.lnum);
       }
     }
+  }
+  if (newline_in_pat || newline_in_sub) {
+    long n = (long)kv_size(extmark_sub_multi);
+    ExtmarkSubMulti sub_multi;
+    if (no_of_lines_changed < 0) {
+      for (i = 0; i < n; i++) {
+        sub_multi = kv_A(extmark_sub_multi, i);
+        extmark_move_regmatch_multi(sub_multi, i);
+      }
+    } else {
+      // Move extmarks in reverse order to avoid moving marks we just moved...
+      for (i = 0; i < n; i++) {
+        sub_multi = kv_Z(extmark_sub_multi, i);
+        extmark_move_regmatch_multi(sub_multi, n - i);
+      }
+    }
+    kv_destroy(extmark_sub_multi);
+  } else {
+    long n = (long)kv_size(extmark_sub_single);
+    ExtmarkSubSingle sub_single;
+    for (i = 0; i < n; i++) {
+      sub_single = kv_Z(extmark_sub_single, i);
+      extmark_move_regmatch_single(sub_single.startpos,
+                                   sub_single.endpos,
+                                   sub_single.lnum,
+                                   sub_single.sublen);
+    }
+
+    kv_destroy(extmark_sub_single);
   }
 
   kv_destroy(preview_lines.subresults);

--- a/src/nvim/lib/kbtree.h
+++ b/src/nvim/lib/kbtree.h
@@ -25,6 +25,12 @@
  * SUCH DAMAGE.
  */
 
+// Gotchas
+// -------
+//
+// if you delete from a kbtree while iterating over it you must use
+// kb_del_itr and not kb_del otherwise the iterator might point to freed memory.
+
 #ifndef NVIM_LIB_KBTREE_H
 #define NVIM_LIB_KBTREE_H
 

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -184,6 +184,7 @@ MAP_IMPL(String, MsgpackRpcRequestHandler, MSGPACK_HANDLER_INITIALIZER)
 #define KVEC_INITIALIZER { .size = 0, .capacity = 0, .items = NULL }
 MAP_IMPL(HlEntry, int, DEFAULT_INITIALIZER)
 MAP_IMPL(String, handle_T, 0)
+MAP_IMPL(uint64_t, cstr_t, DEFAULT_INITIALIZER)
 
 
 /// Deletes a key:value pair from a string:pointer map, and frees the

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -42,6 +42,7 @@ MAP_DECLS(handle_T, ptr_t)
 MAP_DECLS(String, MsgpackRpcRequestHandler)
 MAP_DECLS(HlEntry, int)
 MAP_DECLS(String, handle_T)
+MAP_DECLS(uint64_t, cstr_t)
 
 #define map_new(T, U) map_##T##_##U##_new
 #define map_free(T, U) map_##T##_##U##_free

--- a/src/nvim/mark_extended.c
+++ b/src/nvim/mark_extended.c
@@ -1,0 +1,1262 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+// Implements extended marks for plugins
+// Each Mark exists in a btree of lines containing btrees of columns.
+//
+// The btree provides efficent range lookups.
+// A map of pointers to the marks is used for fast lookup by mark id.
+//
+// Marks are moved by calls to: extmark_col_adjust, extmark_adjust, or
+// extmark_col_adjust_delete which are based on col_adjust and mark_adjust from
+// mark.c
+//
+// Undo/Redo of marks is implemented by storing the call arguments to
+// extmark_col_adjust or extmark_adjust. The list of arguments
+// is applied in extmark_apply_undo. The only case where we have to
+// copy extmarks is for the area being effected by a delete.
+//
+// Marks live in namespaces that allow plugins/users to segregate marks
+// from other users, namespaces have to be initialized before usage
+//
+// For possible ideas for efficency improvements see:
+// http://blog.atom.io/2015/06/16/optimizing-an-important-atom-primitive.html
+// Other implementations exist in gtk and tk toolkits.
+//
+// Deleting marks only happens explicitly extmark_del, deleteing over a
+// range of marks will only move the marks.
+//
+// deleting on a mark will leave it in that same position unless it is on
+// the eol of the line.
+
+#include <assert.h>
+#include "nvim/vim.h"
+#include "charset.h"
+#include "nvim/mark_extended.h"
+#include "nvim/memline.h"
+#include "nvim/pos.h"
+#include "nvim/globals.h"
+#include "nvim/map.h"
+#include "nvim/lib/kbtree.h"
+#include "nvim/undo.h"
+#include "nvim/buffer.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "mark_extended.c.generated.h"
+#endif
+
+
+/// Create or update an extmark
+///
+/// must not be used during iteration!
+/// @returns whether a new mark was created
+int extmark_set(buf_T *buf,
+                uint64_t ns,
+                uint64_t id,
+                linenr_T lnum,
+                colnr_T col,
+                ExtmarkOp op)
+{
+  ExtendedMark *extmark = extmark_from_id(buf, ns, id);
+  if (!extmark) {
+    extmark_create(buf, ns, id, lnum, col, op);
+    return true;
+  } else {
+    ExtMarkLine *extline = extmark->line;
+    extmark_update(extmark, buf, ns, id, lnum,  col, op, NULL);
+    if (kb_size(&extline->items) == 0) {
+      kb_del(extlines, &buf->b_extlines, extline);
+      extline_free(extline);
+    }
+    return false;
+  }
+}
+
+// Remove an extmark
+// Returns 0 on missing id
+int extmark_del(buf_T *buf,
+                uint64_t ns,
+                uint64_t id,
+                ExtmarkOp op)
+{
+  ExtendedMark *extmark = extmark_from_id(buf, ns, id);
+  if (!extmark) {
+    return 0;
+  }
+  return extmark_delete(extmark, buf, ns, id, op);
+}
+
+// Free extmarks in a ns between lines
+// if ns = 0, it means clear all namespaces
+void extmark_clear(buf_T *buf,
+                   uint64_t ns,
+                   linenr_T l_lnum,
+                   linenr_T u_lnum,
+                   ExtmarkOp undo)
+{
+  if (!buf->b_extmark_ns) {
+    return;
+  }
+
+  bool marks_cleared = false;
+  if (undo == kExtmarkUndo) {
+    // Copy marks that would be effected by clear
+    u_extmark_copy(buf, ns, l_lnum, 0, u_lnum, MAXCOL);
+  }
+
+  bool all_ns = ns == 0 ? true : false;
+  ExtmarkNs *ns_obj;
+  if (!all_ns) {
+    ns_obj = pmap_get(uint64_t)(buf->b_extmark_ns, ns);
+    if (!ns_obj) {
+      // nothing to do
+      return;
+    }
+  }
+
+  FOR_ALL_EXTMARKLINES(buf, l_lnum, u_lnum, {
+    FOR_ALL_EXTMARKS_IN_LINE(extline->items, 0, MAXCOL, {
+            if (extmark->ns_id == ns || all_ns) {
+              marks_cleared = true;
+              if (all_ns) {
+                ns_obj = pmap_get(uint64_t)(buf->b_extmark_ns, extmark->ns_id);
+              } else {
+                ns_obj = pmap_get(uint64_t)(buf->b_extmark_ns, ns);
+              }
+              pmap_del(uint64_t)(ns_obj->map, extmark->mark_id);
+              kb_del_itr(markitems, &extline->items, &mitr);
+            }
+    });
+    if (kb_size(&extline->items) == 0) {
+      kb_del_itr(extlines, &buf->b_extlines, &itr);
+      extline_free(extline);
+    }
+  });
+
+  // Record the undo for the actual move
+  if (marks_cleared && undo == kExtmarkUndo) {
+    u_extmark_clear(buf, ns, l_lnum, u_lnum);
+  }
+}
+
+// Returns the position of marks between a range,
+// marks found at the start or end index will be included,
+// if upper_lnum or upper_col are negative the buffer
+// will be searched to the start, or end
+// dir can be set to control the order of the array
+// amount = amount of marks to find or -1 for all
+ExtmarkArray extmark_get(buf_T *buf,
+                         uint64_t ns,
+                         linenr_T l_lnum,
+                         colnr_T l_col,
+                         linenr_T u_lnum,
+                         colnr_T u_col,
+                         int64_t amount,
+                         bool reverse)
+{
+  ExtmarkArray array = KV_INITIAL_VALUE;
+  // Find all the marks
+  if (!reverse) {
+    FOR_ALL_EXTMARKS(buf, ns, l_lnum, l_col, u_lnum, u_col, {
+      if (extmark->ns_id == ns) {
+        kv_push(array, extmark);
+        if (kv_size(array) == (size_t)amount) {
+          return array;
+        }
+      }
+    })
+  } else {
+    FOR_ALL_EXTMARKS_PREV(buf, ns, l_lnum, l_col, u_lnum, u_col, {
+      if (extmark->ns_id == ns) {
+        kv_push(array, extmark);
+        if (kv_size(array) == (size_t)amount) {
+          return array;
+        }
+      }
+    })
+  }
+  return array;
+}
+
+static void extmark_create(buf_T *buf,
+                           uint64_t ns,
+                           uint64_t id,
+                           linenr_T lnum,
+                           colnr_T col,
+                           ExtmarkOp op)
+{
+  if (!buf->b_extmark_ns) {
+    buf->b_extmark_ns = pmap_new(uint64_t)();
+  }
+  ExtmarkNs *ns_obj = NULL;
+  ns_obj = pmap_get(uint64_t)(buf->b_extmark_ns, ns);
+  // Initialize a new namespace for this buffer
+  if (!ns_obj) {
+    ns_obj = xmalloc(sizeof(ExtmarkNs));
+    ns_obj->map = pmap_new(uint64_t)();
+    pmap_put(uint64_t)(buf->b_extmark_ns, ns, ns_obj);
+  }
+
+  // Create or get a line
+  ExtMarkLine *extline = extline_ref(buf, lnum, true);
+  // Create and put mark on the line
+  extmark_put(col, id, extline, ns);
+
+  // Marks do not have stable address so we have to look them up
+  // by using the line instead of the mark
+  pmap_put(uint64_t)(ns_obj->map, id, extline);
+  if (op != kExtmarkNoUndo) {
+    u_extmark_set(buf, ns, id, lnum, col, kExtmarkSet);
+  }
+
+  // Set a free id so extmark_free_id_get works
+  extmark_free_id_set(ns_obj, id);
+}
+
+// update the position of an extmark
+// to update while iterating pass the markitems itr
+static void extmark_update(ExtendedMark *extmark,
+                           buf_T *buf,
+                           uint64_t ns,
+                           uint64_t id,
+                           linenr_T lnum,
+                           colnr_T col,
+                           ExtmarkOp op,
+                           kbitr_t(markitems) *mitr)
+{
+  assert(op != kExtmarkNOOP);
+  if (op != kExtmarkNoUndo) {
+    u_extmark_update(buf, ns, id, extmark->line->lnum, extmark->col,
+                     lnum, col);
+  }
+  ExtMarkLine *old_line = extmark->line;
+  // Move the mark to a new line and update column
+  if (old_line->lnum != lnum) {
+    ExtMarkLine *ref_line = extline_ref(buf, lnum, true);
+    extmark_put(col, id, ref_line, ns);
+    // Update the hashmap
+    ExtmarkNs *ns_obj = pmap_get(uint64_t)(buf->b_extmark_ns, ns);
+    pmap_put(uint64_t)(ns_obj->map, id, ref_line);
+    // Delete old mark
+    if (mitr != NULL) {
+      kb_del_itr(markitems, &(old_line->items), mitr);
+    } else {
+      kb_del(markitems, &old_line->items, *extmark);
+    }
+  // Just update the column
+  } else {
+    if (mitr != NULL) {
+      // The btree stays organized during iteration with kbitr_t
+      extmark->col = col;
+    } else {
+      // Keep the btree in order
+      kb_del(markitems, &old_line->items, *extmark);
+      extmark_put(col, id, old_line, ns);
+    }
+  }
+}
+
+static int extmark_delete(ExtendedMark *extmark,
+                          buf_T *buf,
+                          uint64_t ns,
+                          uint64_t id,
+                          ExtmarkOp op)
+{
+  if (op != kExtmarkNoUndo) {
+    u_extmark_set(buf, ns, id, extmark->line->lnum, extmark->col,
+                  kExtmarkDel);
+  }
+
+  // Remove our key from the namespace
+  ExtmarkNs *ns_obj = pmap_get(uint64_t)(buf->b_extmark_ns, ns);
+  pmap_del(uint64_t)(ns_obj->map, id);
+
+  // Remove the mark mark from the line
+  ExtMarkLine *extline = extmark->line;
+  kb_del(markitems, &extline->items, *extmark);
+  // Remove the line if there are no more marks in the line
+  if (kb_size(&extline->items) == 0) {
+    kb_del(extlines, &buf->b_extlines, extline);
+    extline_free(extline);
+  }
+  return true;
+}
+
+// Lookup an extmark by id
+ExtendedMark *extmark_from_id(buf_T *buf, uint64_t ns, uint64_t id)
+{
+  if (!buf->b_extmark_ns) {
+    return NULL;
+  }
+  ExtmarkNs *ns_obj = pmap_get(uint64_t)(buf->b_extmark_ns, ns);
+  if (!ns_obj || !kh_size(ns_obj->map->table)) {
+    return NULL;
+  }
+  ExtMarkLine *extline = pmap_get(uint64_t)(ns_obj->map, id);
+  if (!extline) {
+    return NULL;
+  }
+
+  FOR_ALL_EXTMARKS_IN_LINE(extline->items, 0, MAXCOL, {
+    if (extmark->ns_id == ns
+        && extmark->mark_id == id) {
+      return extmark;
+    }
+  })
+  return NULL;
+}
+
+// Lookup an extmark by position
+ExtendedMark *extmark_from_pos(buf_T *buf,
+                               uint64_t ns, linenr_T lnum, colnr_T col)
+{
+  if (!buf->b_extmark_ns) {
+    return NULL;
+  }
+  FOR_ALL_EXTMARKS(buf, ns, lnum, col, lnum, col, {
+    if (extmark->ns_id == ns) {
+      if (extmark->col == col) {
+        return extmark;
+      }
+    }
+  })
+  return NULL;
+}
+
+// Returns an avaliable id in a namespace
+uint64_t extmark_free_id_get(buf_T *buf, uint64_t ns)
+{
+  if (!buf->b_extmark_ns) {
+    return 1;
+  }
+  ExtmarkNs *ns_obj = pmap_get(uint64_t)(buf->b_extmark_ns, ns);
+  if (!ns_obj) {
+    return 1;
+  }
+  return ns_obj->free_id;
+}
+
+// Set the next free id in a namesapce
+static void extmark_free_id_set(ExtmarkNs *ns_obj, uint64_t id)
+{
+  // Simply Heurstic, the largest id + 1
+  ns_obj->free_id = id + 1;
+}
+
+// free extmarks from the buffer
+void extmark_free_all(buf_T *buf)
+{
+  if (!buf->b_extmark_ns) {
+    return;
+  }
+
+  uint64_t ns;
+  ExtmarkNs *ns_obj;
+
+  FOR_ALL_EXTMARKLINES(buf, 1, MAXLNUM, {
+    kb_del_itr(extlines, &buf->b_extlines, &itr);
+    extline_free(extline);
+  })
+
+  map_foreach(buf->b_extmark_ns, ns, ns_obj, {
+    (void)ns;
+    pmap_free(uint64_t)(ns_obj->map);
+    xfree(ns_obj);
+  });
+
+  pmap_free(uint64_t)(buf->b_extmark_ns);
+
+  // k?_init called to set pointers to NULL
+  kb_destroy(extlines, (&buf->b_extlines));
+  kb_init(&buf->b_extlines);
+
+  kv_destroy(buf->b_extmark_move_space);
+  kv_init(buf->b_extmark_move_space);
+}
+
+
+// Save info for undo/redo of set marks
+static void u_extmark_set(buf_T *buf,
+                          uint64_t ns,
+                          uint64_t id,
+                          linenr_T lnum,
+                          colnr_T col,
+                          UndoObjectType undo_type)
+{
+  u_header_T  *uhp = force_get_undo_header(buf);
+  if (!uhp) {
+    return;
+  }
+
+  ExtmarkSet set;
+  set.ns_id = ns;
+  set.mark_id = id;
+  set.lnum = lnum;
+  set.col = col;
+
+  ExtmarkUndoObject undo = { .type = undo_type,
+                             .data.set = set };
+
+  kv_push(uhp->uh_extmark, undo);
+}
+
+// Save info for undo/redo of deleted marks
+static void u_extmark_update(buf_T *buf,
+                             uint64_t ns,
+                             uint64_t id,
+                             linenr_T old_lnum,
+                             colnr_T old_col,
+                             linenr_T lnum,
+                             colnr_T col)
+{
+  u_header_T  *uhp = force_get_undo_header(buf);
+  if (!uhp) {
+    return;
+  }
+
+  ExtmarkUpdate update;
+  update.ns_id = ns;
+  update.mark_id = id;
+  update.old_lnum = old_lnum;
+  update.old_col = old_col;
+  update.lnum = lnum;
+  update.col = col;
+
+  ExtmarkUndoObject undo = { .type = kExtmarkUpdate,
+                             .data.update = update };
+  kv_push(uhp->uh_extmark, undo);
+}
+
+// Hueristic works only for when the user is typing in insert mode
+// - Instead of 1 undo object for each char inserted,
+//   we create 1 undo objet for all text inserted before the user hits esc
+// Return True if we compacted else False
+static bool u_compact_col_adjust(buf_T *buf,
+                                 linenr_T lnum,
+                                 colnr_T mincol,
+                                 long lnum_amount,
+                                 long col_amount)
+{
+  u_header_T  *uhp = force_get_undo_header(buf);
+  if (!uhp) {
+    return false;
+  }
+
+  if (kv_size(uhp->uh_extmark) < 1) {
+    return false;
+  }
+  // Check the last action
+  ExtmarkUndoObject object = kv_last(uhp->uh_extmark);
+
+  if (object.type != kColAdjust) {
+    return false;
+  }
+  ColAdjust undo = object.data.col_adjust;
+  bool compactable = false;
+
+  if (!undo.lnum_amount && !lnum_amount) {
+    if (undo.lnum == lnum) {
+      if ((undo.mincol + undo.col_amount) >= mincol) {
+          compactable = true;
+  } } }
+
+  if (!compactable) {
+    return false;
+  }
+
+  undo.col_amount = undo.col_amount + col_amount;
+  ExtmarkUndoObject new_undo = { .type = kColAdjust,
+                                 .data.col_adjust = undo };
+  kv_last(uhp->uh_extmark) = new_undo;
+  return true;
+}
+
+// Save col_adjust info so we can undo/redo
+void u_extmark_col_adjust(buf_T *buf,
+                          linenr_T lnum,
+                          colnr_T mincol,
+                          long lnum_amount,
+                          long col_amount)
+{
+  u_header_T  *uhp = force_get_undo_header(buf);
+  if (!uhp) {
+    return;
+  }
+
+  if (!u_compact_col_adjust(buf, lnum, mincol, lnum_amount, col_amount)) {
+    ColAdjust col_adjust;
+    col_adjust.lnum = lnum;
+    col_adjust.mincol = mincol;
+    col_adjust.lnum_amount = lnum_amount;
+    col_adjust.col_amount = col_amount;
+
+    ExtmarkUndoObject undo = { .type = kColAdjust,
+                               .data.col_adjust = col_adjust };
+
+    kv_push(uhp->uh_extmark, undo);
+  }
+}
+
+// Save col_adjust_delete info so we can undo/redo
+void u_extmark_col_adjust_delete(buf_T *buf,
+                                 linenr_T lnum,
+                                 colnr_T mincol,
+                                 colnr_T endcol,
+                                 int eol)
+{
+  u_header_T  *uhp = force_get_undo_header(buf);
+  if (!uhp) {
+    return;
+  }
+
+  ColAdjustDelete col_adjust_delete;
+  col_adjust_delete.lnum = lnum;
+  col_adjust_delete.mincol = mincol;
+  col_adjust_delete.endcol = endcol;
+  col_adjust_delete.eol = eol;
+
+  ExtmarkUndoObject undo = { .type = kColAdjustDelete,
+                             .data.col_adjust_delete = col_adjust_delete };
+
+  kv_push(uhp->uh_extmark, undo);
+}
+
+// Save adjust info so we can undo/redo
+static void u_extmark_adjust(buf_T * buf,
+                             linenr_T line1,
+                             linenr_T line2,
+                             long amount,
+                             long amount_after)
+{
+  u_header_T  *uhp = force_get_undo_header(buf);
+  if (!uhp) {
+    return;
+  }
+
+  Adjust adjust;
+  adjust.line1 = line1;
+  adjust.line2 = line2;
+  adjust.amount = amount;
+  adjust.amount_after = amount_after;
+
+  ExtmarkUndoObject undo = { .type = kLineAdjust,
+                             .data.adjust = adjust };
+
+  kv_push(uhp->uh_extmark, undo);
+}
+
+// save info to undo/redo a :move
+void u_extmark_move(buf_T *buf,
+                    linenr_T line1,
+                    linenr_T line2,
+                    linenr_T last_line,
+                    linenr_T dest,
+                    linenr_T num_lines,
+                    linenr_T extra)
+{
+  u_header_T  *uhp = force_get_undo_header(buf);
+  if (!uhp) {
+    return;
+  }
+
+  AdjustMove move;
+  move.line1 = line1;
+  move.line2 = line2;
+  move.last_line = last_line;
+  move.dest = dest;
+  move.num_lines = num_lines;
+  move.extra = extra;
+
+  ExtmarkUndoObject undo = { .type = kAdjustMove,
+                             .data.move = move };
+
+  kv_push(uhp->uh_extmark, undo);
+}
+
+// copy extmarks data between range, useful when we cannot simply reverse
+// the operation. This will do nothing on redo, enforces correct position when
+// undo.
+// if ns = 0, it means copy all namespaces
+void u_extmark_copy(buf_T *buf,
+                    uint64_t ns,
+                    linenr_T l_lnum,
+                    colnr_T l_col,
+                    linenr_T u_lnum,
+                    colnr_T u_col)
+{
+  u_header_T  *uhp = force_get_undo_header(buf);
+  if (!uhp) {
+    return;
+  }
+
+  bool all_ns = ns == 0 ? true : false;
+
+  ExtmarkCopy copy;
+  ExtmarkUndoObject undo;
+  FOR_ALL_EXTMARKS(buf, 1, l_lnum, l_col, u_lnum, u_col, {
+    if (all_ns || extmark->ns_id == ns) {
+      copy.ns_id = extmark->ns_id;
+      copy.mark_id = extmark->mark_id;
+      copy.lnum = extmark->line->lnum;
+      copy.col = extmark->col;
+
+      undo.data.copy = copy;
+      undo.type = kExtmarkCopy;
+      kv_push(uhp->uh_extmark, undo);
+    }
+  });
+}
+
+void u_extmark_copy_place(buf_T *buf,
+                          linenr_T l_lnum,
+                          colnr_T l_col,
+                          linenr_T u_lnum,
+                          colnr_T u_col,
+                          linenr_T p_lnum,
+                          colnr_T p_col)
+{
+  u_header_T  *uhp = force_get_undo_header(buf);
+  if (!uhp) {
+    return;
+  }
+
+  ExtmarkCopyPlace copy_place;
+  copy_place.l_lnum = l_lnum;
+  copy_place.l_col = l_col;
+  copy_place.u_lnum = u_lnum;
+  copy_place.u_col = u_col;
+  copy_place.p_lnum = p_lnum;
+  copy_place.p_col = p_col;
+
+  ExtmarkUndoObject undo = { .type = kExtmarkCopyPlace,
+                             .data.copy_place = copy_place };
+
+  kv_push(uhp->uh_extmark, undo);
+}
+
+// Save info for undo/redo of extmark_clear
+static void u_extmark_clear(buf_T *buf,
+                            uint64_t ns,
+                            linenr_T l_lnum,
+                            linenr_T u_lnum)
+{
+  u_header_T  *uhp = force_get_undo_header(buf);
+  if (!uhp) {
+    return;
+  }
+
+  ExtmarkClear clear;
+  clear.ns_id = ns;
+  clear.l_lnum = l_lnum;
+  clear.u_lnum = u_lnum;
+
+  ExtmarkUndoObject undo = { .type = kExtmarkClear,
+                             .data.clear = clear };
+  kv_push(uhp->uh_extmark, undo);
+}
+
+// undo or redo an extmark operation
+void extmark_apply_undo(ExtmarkUndoObject undo_info, bool undo)
+{
+  linenr_T lnum;
+  colnr_T mincol;
+  long lnum_amount;
+  long col_amount;
+  linenr_T line1;
+  linenr_T line2;
+  long amount;
+  long amount_after;
+
+  // use extmark_col_adjust
+  if (undo_info.type == kColAdjust) {
+    // Undo
+    if (undo) {
+      lnum = (undo_info.data.col_adjust.lnum
+              + undo_info.data.col_adjust.lnum_amount);
+      lnum_amount = -undo_info.data.col_adjust.lnum_amount;
+      col_amount = -undo_info.data.col_adjust.col_amount;
+      mincol = (undo_info.data.col_adjust.mincol
+                + (colnr_T)undo_info.data.col_adjust.col_amount);
+    // Redo
+    } else {
+      lnum = undo_info.data.col_adjust.lnum;
+      col_amount = undo_info.data.col_adjust.col_amount;
+      lnum_amount = undo_info.data.col_adjust.lnum_amount;
+      mincol = undo_info.data.col_adjust.mincol;
+    }
+    extmark_col_adjust(curbuf,
+                       lnum, mincol, lnum_amount, col_amount, kExtmarkNoUndo);
+  // use extmark_col_adjust_delete
+  } else if (undo_info.type == kColAdjustDelete) {
+    if (undo) {
+      mincol = undo_info.data.col_adjust_delete.mincol;
+      col_amount = (undo_info.data.col_adjust_delete.endcol
+                    - undo_info.data.col_adjust_delete.mincol) + 1;
+      extmark_col_adjust(curbuf,
+                         undo_info.data.col_adjust_delete.lnum,
+                         mincol,
+                         0,
+                         col_amount,
+                         kExtmarkNoUndo);
+    // Redo
+    } else {
+      extmark_col_adjust_delete(curbuf,
+                                undo_info.data.col_adjust_delete.lnum,
+                                undo_info.data.col_adjust_delete.mincol,
+                                undo_info.data.col_adjust_delete.endcol,
+                                kExtmarkNoUndo,
+                                undo_info.data.col_adjust_delete.eol);
+    }
+  // use extmark_adjust
+  } else if (undo_info.type == kLineAdjust) {
+    if (undo) {
+      // Undo - call signature type one - insert now
+      if (undo_info.data.adjust.amount == MAXLNUM) {
+        line1 = undo_info.data.adjust.line1;
+        line2 = MAXLNUM;
+        amount = -undo_info.data.adjust.amount_after;
+        amount_after = 0;
+      // Undo - call singature type two - delete now
+      } else if (undo_info.data.adjust.line2 == MAXLNUM) {
+        line1 = undo_info.data.adjust.line1;
+        line2 = undo_info.data.adjust.line2;
+        amount = -undo_info.data.adjust.amount;
+        amount_after = undo_info.data.adjust.amount_after;
+      // Undo - call signature three - move lines
+      } else {
+        line1 = (undo_info.data.adjust.line1
+                 + undo_info.data.adjust.amount);
+        line2 = (undo_info.data.adjust.line2
+                 + undo_info.data.adjust.amount);
+        amount = -undo_info.data.adjust.amount;
+        amount_after = -undo_info.data.adjust.amount_after;
+      }
+    // redo
+    } else {
+      line1 = undo_info.data.adjust.line1;
+      line2 = undo_info.data.adjust.line2;
+      amount = undo_info.data.adjust.amount;
+      amount_after = undo_info.data.adjust.amount_after;
+    }
+    extmark_adjust(curbuf,
+                   line1, line2, amount, amount_after, kExtmarkNoUndo, false);
+  // kExtmarkCopy
+  } else if (undo_info.type == kExtmarkCopy) {
+    // Redo should be handled by kColAdjustDelete or kExtmarkCopyPlace
+    if (undo) {
+      extmark_set(curbuf,
+                  undo_info.data.copy.ns_id,
+                  undo_info.data.copy.mark_id,
+                  undo_info.data.copy.lnum,
+                  undo_info.data.copy.col,
+                  kExtmarkNoUndo);
+    }
+  // uses extmark_copy_and_place
+  } else if (undo_info.type == kExtmarkCopyPlace) {
+    // Redo, undo is handle by kExtmarkCopy
+    if (!undo) {
+      extmark_copy_and_place(curbuf,
+                             undo_info.data.copy_place.l_lnum,
+                             undo_info.data.copy_place.l_col,
+                             undo_info.data.copy_place.u_lnum,
+                             undo_info.data.copy_place.u_col,
+                             undo_info.data.copy_place.p_lnum,
+                             undo_info.data.copy_place.p_col,
+                             kExtmarkNoUndo, true, NULL);
+    }
+  // kExtmarkClear
+  } else if (undo_info.type == kExtmarkClear) {
+    // Redo, undo is handle by kExtmarkCopy
+    if (!undo) {
+      extmark_clear(curbuf,
+                    undo_info.data.clear.ns_id,
+                    undo_info.data.clear.l_lnum,
+                    undo_info.data.clear.u_lnum,
+                    kExtmarkNoUndo);
+    }
+  // kAdjustMove
+  } else if (undo_info.type == kAdjustMove) {
+    apply_undo_move(undo_info, undo);
+  // extmark_set
+  } else if (undo_info.type == kExtmarkSet) {
+    if (undo) {
+      extmark_del(curbuf,
+                  undo_info.data.set.ns_id,
+                  undo_info.data.set.mark_id,
+                  kExtmarkNoUndo);
+    // Redo
+    } else {
+      extmark_set(curbuf,
+                  undo_info.data.set.ns_id,
+                  undo_info.data.set.mark_id,
+                  undo_info.data.set.lnum,
+                  undo_info.data.set.col,
+                  kExtmarkNoUndo);
+    }
+  // extmark_set into update
+  } else if (undo_info.type == kExtmarkUpdate) {
+    if (undo) {
+      extmark_set(curbuf,
+                  undo_info.data.update.ns_id,
+                  undo_info.data.update.mark_id,
+                  undo_info.data.update.old_lnum,
+                  undo_info.data.update.old_col,
+                  kExtmarkNoUndo);
+    // Redo
+    } else {
+      extmark_set(curbuf,
+                  undo_info.data.update.ns_id,
+                  undo_info.data.update.mark_id,
+                  undo_info.data.update.lnum,
+                  undo_info.data.update.col,
+                  kExtmarkNoUndo);
+    }
+  // extmark_del
+  } else if (undo_info.type == kExtmarkDel)  {
+    if (undo) {
+      extmark_set(curbuf,
+                  undo_info.data.set.ns_id,
+                  undo_info.data.set.mark_id,
+                  undo_info.data.set.lnum,
+                  undo_info.data.set.col,
+                  kExtmarkNoUndo);
+    // Redo
+    } else {
+      extmark_del(curbuf,
+                  undo_info.data.set.ns_id,
+                  undo_info.data.set.mark_id,
+                  kExtmarkNoUndo);
+    }
+  }
+}
+
+// undo/redo an kExtmarkMove operation
+static void apply_undo_move(ExtmarkUndoObject undo_info, bool undo)
+{
+  // 3 calls are required , see comment in function do_move (ex_cmds.c)
+  linenr_T line1 = undo_info.data.move.line1;
+  linenr_T line2 = undo_info.data.move.line2;
+  linenr_T last_line = undo_info.data.move.last_line;
+  linenr_T dest = undo_info.data.move.dest;
+  linenr_T num_lines = undo_info.data.move.num_lines;
+  linenr_T extra = undo_info.data.move.extra;
+
+  if (undo) {
+    if (dest >= line2) {
+      extmark_adjust(curbuf,
+                     dest - num_lines + 1,
+                     dest,
+                     last_line - dest + num_lines - 1,
+                     0L,
+                     kExtmarkNoUndo,
+                     true);
+      extmark_adjust(curbuf,
+                     dest - line2,
+                     dest - line1,
+                     dest - line2,
+                     0L,
+                     kExtmarkNoUndo,
+                     false);
+    } else {
+      extmark_adjust(curbuf,
+                     line1-num_lines,
+                     line2-num_lines,
+                     last_line - (line1-num_lines),
+                     0L,
+                     kExtmarkNoUndo,
+                     true);
+      extmark_adjust(curbuf,
+                     (line1-num_lines) + 1,
+                     (line2-num_lines) + 1,
+                     -num_lines,
+                     0L,
+                     kExtmarkNoUndo,
+                     false);
+    }
+    extmark_adjust(curbuf,
+                   last_line,
+                   last_line + num_lines - 1,
+                   line1 - last_line,
+                   0L,
+                   kExtmarkNoUndo,
+                   true);
+  // redo
+  } else {
+    extmark_adjust(curbuf,
+                   line1,
+                   line2,
+                   last_line - line2,
+                   0L,
+                   kExtmarkNoUndo,
+                   true);
+    if (dest >= line2) {
+      extmark_adjust(curbuf,
+                     line2 + 1,
+                     dest,
+                     -num_lines,
+                     0L,
+                     kExtmarkNoUndo,
+                     false);
+    } else {
+      extmark_adjust(curbuf,
+                     dest + 1,
+                     line1 - 1,
+                     num_lines,
+                     0L,
+                     kExtmarkNoUndo,
+                     false);
+    }
+  extmark_adjust(curbuf,
+                 last_line - num_lines + 1,
+                 last_line,
+                 -(last_line - dest - extra),
+                 0L,
+                 kExtmarkNoUndo,
+                 true);
+  }
+}
+
+// for anything other than deletes
+// Return, desired col amount where the adjustment should take place
+// (not taking) eol into account
+static long update_constantly(colnr_T _, colnr_T __, long col_amount)
+{
+  return col_amount;
+}
+
+// for deletes,
+// Return, desired col amount where the adjustment should take place
+// (not taking) eol into account
+static long update_variably(colnr_T mincol, colnr_T current, long endcol)
+{
+  colnr_T start_effected_range = mincol - 1;
+  long col_amount;
+  // When mark inside range
+  if (current < endcol) {
+    col_amount = -(current - start_effected_range);
+  // Mark outside of range
+  } else {
+    // -1 because a delete of width 0 should still move marks
+    col_amount = -(endcol - mincol) - 1;
+  }
+  return col_amount;
+}
+
+
+/// Get the column position for EOL on a line
+///
+/// If the lnum doesn't exist, returns 0
+colnr_T extmark_eol_col(buf_T *buf, linenr_T lnum)
+{
+  if (lnum > buf->b_ml.ml_line_count) {
+    return 0;
+  }
+  return (colnr_T)STRLEN(ml_get_buf(buf, lnum, false)) + 1;
+}
+
+
+// Adjust columns and rows for extmarks
+// based off mark_col_adjust in mark.c
+// returns true if something was moved otherwise false
+static bool extmark_col_adjust_impl(buf_T *buf, linenr_T lnum,
+                                    colnr_T mincol, long lnum_amount,
+                                    long (*calc_amount)(colnr_T, colnr_T, long),
+                                    long func_arg)
+{
+  bool marks_exist = false;
+  colnr_T *cp;
+  long col_amount;
+
+  ExtMarkLine *extline = extline_ref(buf, lnum, false);
+  if (!extline) {
+    return false;
+  }
+
+  FOR_ALL_EXTMARKS_IN_LINE(extline->items, mincol, MAXCOL, {
+    marks_exist = true;
+    cp = &(extmark->col);
+
+    col_amount = (*calc_amount)(mincol, *cp, func_arg);
+    // No update required for this guy
+    if (col_amount == 0 && lnum_amount == 0) {
+      continue;
+    }
+
+    // Set mark to start of line
+    if (col_amount < 0
+        && *cp <= (colnr_T)-col_amount) {  // TODO(timeyyy): does mark.c
+                                           // need this line?
+      extmark_update(extmark, buf, extmark->ns_id, extmark->mark_id,
+                     extline->lnum + lnum_amount,
+                     1, kExtmarkNoUndo, &mitr);
+      // Update the mark
+    } else {
+      // Note: The undo is handled by u_extmark_col_adjust, NoUndo here
+      extmark_update(extmark, buf, extmark->ns_id, extmark->mark_id,
+                     extline->lnum + lnum_amount,
+                     *cp + (colnr_T)col_amount, kExtmarkNoUndo, &mitr);
+    }
+  })
+
+  if (kb_size(&extline->items) == 0) {
+    kb_del(extlines, &buf->b_extlines, extline);
+    extline_free(extline);
+  }
+
+  return marks_exist;
+}
+
+// Adjust columns and rows for extmarks
+//
+// based off mark_col_adjust in mark.c
+// use extmark_col_adjust_impl to move columns by inserting
+// Doesn't take the eol into consideration (possible to put marks in invalid
+// positions)
+void extmark_col_adjust(buf_T *buf, linenr_T lnum,
+                        colnr_T mincol, long lnum_amount,
+                        long col_amount, ExtmarkOp undo)
+{
+  assert(col_amount > INT_MIN && col_amount <= INT_MAX);
+
+  bool marks_moved =  extmark_col_adjust_impl(buf, lnum, mincol, lnum_amount,
+                                              &update_constantly, col_amount);
+
+  if (undo == kExtmarkUndo && marks_moved) {
+    u_extmark_col_adjust(buf, lnum, mincol, lnum_amount, col_amount);
+  }
+}
+
+// Adjust marks after a delete on a line
+//
+// Automatically readjusts to take the eol into account
+// TODO(timeyyy): change mincol to be for the mark to be copied, not moved
+//
+// @param mincol First column that needs to be moved (start of delete range) + 1
+// @param endcol Last column which needs to be copied (end of delete range + 1)
+void extmark_col_adjust_delete(buf_T *buf, linenr_T lnum,
+                               colnr_T mincol, colnr_T endcol,
+                               ExtmarkOp undo, int _eol)
+{
+  colnr_T start_effected_range = mincol;
+  // TODO(timeyyy): understand why this has to be uncommented out for the
+  // tests to pass..  shouldn't this be required?
+  // why is this even being called if it's not neeed?
+
+  // Some tests in the vim suite were hitting the assertion that was here.
+  // functional/ui/mouse_spec/
+  // We don't know what to do in this case so just bail!
+
+  // if (start_effected_range <= endcol) {
+    // return;
+  // }
+
+  bool marks_moved;
+  if (undo == kExtmarkUndo) {
+    // Copy marks that would be effected by delete
+    // -1 because we need to restore if a mark existed at the start pos
+    u_extmark_copy(buf, 0, lnum, start_effected_range, lnum, endcol);
+  }
+
+  marks_moved = extmark_col_adjust_impl(buf, lnum, mincol, 0,
+                                        &update_variably, (long)endcol);
+
+  // Deletes at the end of the line have different behaviour than the normal
+  // case when deleted.
+  // Cleanup any marks that are floating beyond the end of line.
+  // we allow this to be passed in as well because the buffer may have already
+  // been mutated.
+  int eol = _eol;
+  if (!eol) {
+    eol = extmark_eol_col(buf, lnum);
+  }
+  FOR_ALL_EXTMARKS(buf, 1, lnum, eol, lnum, -1, {
+    extmark_update(extmark, buf, extmark->ns_id, extmark->mark_id,
+                   extline->lnum, (colnr_T)eol, kExtmarkNoUndo, &mitr);
+  })
+
+  // Record the undo for the actual move
+  if (marks_moved && undo == kExtmarkUndo) {
+    u_extmark_col_adjust_delete(buf, lnum, mincol, endcol, eol);
+  }
+}
+
+// Adjust extmark row for inserted/deleted rows (columns stay fixed).
+void extmark_adjust(buf_T *buf,
+                    linenr_T line1,
+                    linenr_T line2,
+                    long amount,
+                    long amount_after,
+                    ExtmarkOp undo,
+                    bool end_temp)
+{
+  ExtMarkLine *_extline;
+
+  // btree needs to be kept ordered to work, so far only :move requires this
+  // 2nd call with end_temp =  unpack the lines from the temp position
+  if (end_temp && amount < 0) {
+    for (size_t i = 0; i < kv_size(buf->b_extmark_move_space); i++) {
+      _extline = kv_A(buf->b_extmark_move_space, i);
+      _extline->lnum += amount;
+      kb_put(extlines, &buf->b_extlines, _extline);
+    }
+    kv_size(buf->b_extmark_move_space) = 0;
+    return;
+  }
+
+  bool marks_exist = false;
+  linenr_T *lp;
+
+  linenr_T adj_start = line1;
+  if (amount == MAXLNUM) {
+    // Careful! marks from deleted region can end up on en extisting extline
+    // that is goinig to be adjusted to the target position.
+    linenr_T join_num = line1 - amount_after;
+    ExtMarkLine *joinline = join_num > line2 \
+      ? extline_ref(buf, join_num, false) : NULL;
+    // extmark_adjust is already redoable, the copy should only be for undo
+    marks_exist = extmark_copy_and_place(curbuf,
+                                         line1, 1,
+                                         line2, MAXCOL,
+                                         line1, 1,
+                                         kExtmarkUndoNoRedo, true, joinline);
+    adj_start = line2+1;
+  }
+  FOR_ALL_EXTMARKLINES(buf, adj_start, MAXLNUM, {
+    marks_exist = true;
+    lp = &(extline->lnum);
+    if (*lp <= line2) {
+      // 1st call with end_temp = true, store the lines in a temp position
+      if (end_temp && amount > 0) {
+          kb_del_itr_extlines(&buf->b_extlines, &itr);
+          kv_push(buf->b_extmark_move_space, extline);
+      }
+
+      *lp += amount;
+    } else if (amount_after && *lp > line2) {
+      *lp += amount_after;
+    }
+  })
+
+  if (undo == kExtmarkUndo && marks_exist) {
+    u_extmark_adjust(buf, line1, line2, amount, amount_after);
+  }
+}
+
+/// Range points to copy
+///
+/// if part of a larger iteration we can't delete, then the caller
+/// must check for empty lines.
+bool extmark_copy_and_place(buf_T *buf,
+                            linenr_T l_lnum,
+                            colnr_T l_col,
+                            linenr_T u_lnum,
+                            colnr_T u_col,
+                            linenr_T p_lnum,
+                            colnr_T p_col,
+                            ExtmarkOp undo,
+                            bool delete,
+                            ExtMarkLine *destline)
+
+{
+  bool marks_moved = false;
+  if (undo == kExtmarkUndo || undo == kExtmarkUndoNoRedo) {
+    // Copy marks that would be effected by delete
+    u_extmark_copy(buf, 0, l_lnum, l_col, u_lnum, u_col);
+  }
+
+  // Move extmarks to their final position
+  // Careful: if we move items within the same line, we might change order of
+  // marks within the same extline. Too keep it simple, first delete all items
+  // from the extline and put them back in the right order.
+  FOR_ALL_EXTMARKLINES(buf, l_lnum, u_lnum, {
+    kvec_t(ExtendedMark) temp_space = KV_INITIAL_VALUE;
+    bool same_line = extline == destline;
+    FOR_ALL_EXTMARKS_IN_LINE(extline->items,
+                             (extline->lnum > l_lnum) ? 0 : l_col,
+                             (extline->lnum < u_lnum) ? MAXCOL : u_col, {
+      if (!destline) {
+        destline = extline_ref(buf, p_lnum, true);
+        same_line = extline == destline;
+      }
+      marks_moved = true;
+      if (!same_line) {
+        extmark_put(p_col, extmark->mark_id, destline, extmark->ns_id);
+        ExtmarkNs *ns_obj = pmap_get(uint64_t)(buf->b_extmark_ns,
+                                               extmark->ns_id);
+        pmap_put(uint64_t)(ns_obj->map, extmark->mark_id, destline);
+      } else {
+        kv_push(temp_space, *extmark);
+      }
+      // Delete old mark
+      kb_del_itr(markitems, &extline->items, &mitr);
+    })
+    if (same_line) {
+      for (size_t i = 0; i < kv_size(temp_space); i++) {
+        ExtendedMark mark = kv_A(temp_space, i);
+        extmark_put(p_col, mark.mark_id, extline, mark.ns_id);
+      }
+      kv_destroy(temp_space);
+    } else if (delete && kb_size(&extline->items) == 0) {
+      kb_del_itr(extlines, &buf->b_extlines, &itr);
+      extline_free(extline);
+    }
+  })
+
+  // Record the undo for the actual move
+  if (marks_moved && undo == kExtmarkUndo) {
+    u_extmark_copy_place(buf, l_lnum, l_col, u_lnum, u_col, p_lnum, p_col);
+  }
+
+  return marks_moved;
+}
+
+// Get reference to line in kbtree_t, allocating it if neccessary.
+ExtMarkLine *extline_ref(buf_T *buf, linenr_T lnum, bool put)
+{
+  kbtree_t(extlines) *b = &buf->b_extlines;
+  ExtMarkLine t, **pp;
+  t.lnum = lnum;
+
+  pp = kb_get(extlines, b, &t);
+  if (!pp) {
+    if (!put) {
+      return NULL;
+    }
+    ExtMarkLine *p = xcalloc(sizeof(ExtMarkLine), 1);
+    p->lnum = lnum;
+    // p->items zero initialized
+    kb_put(extlines, b, p);
+    return p;
+  }
+  // Return existing
+  return *pp;
+}
+
+void extline_free(ExtMarkLine *extline)
+{
+  kb_destroy(markitems, (&extline->items));
+  xfree(extline);
+}
+
+/// Put an extmark into a line,
+///
+/// caller must ensure combination of id and ns_id isn't in use.
+void extmark_put(colnr_T col,
+                 uint64_t id,
+                 ExtMarkLine *extline,
+                 uint64_t ns)
+{
+  ExtendedMark t;
+  t.col = col;
+  t.mark_id = id;
+  t.line = extline;
+  t.ns_id = ns;
+
+  kbtree_t(markitems) *b = &(extline->items);
+  // kb_put requries the key to not be there
+  assert(!kb_getp(markitems, b, &t));
+
+  kb_put(markitems, b, t);
+}
+
+

--- a/src/nvim/mark_extended.h
+++ b/src/nvim/mark_extended.h
@@ -1,0 +1,267 @@
+#ifndef NVIM_MARK_EXTENDED_H
+#define NVIM_MARK_EXTENDED_H
+
+#include "nvim/mark_extended_defs.h"
+#include "nvim/buffer_defs.h"  // for buf_T
+
+
+// Macro Documentation: FOR_ALL_?
+// Search exclusively using the range values given.
+// Use MAXCOL/MAXLNUM for the start and end of the line/col.
+// The ns parameter: Unless otherwise stated, this is only a starting point
+//    for the btree to searched in, the results being itterated over will
+//    still contain extmarks from other namespaces.
+
+// see FOR_ALL_? for documentation
+#define FOR_ALL_EXTMARKLINES(buf, l_lnum, u_lnum, code)\
+  kbitr_t(extlines) itr;\
+  ExtMarkLine t;\
+  t.lnum = l_lnum;\
+  if (!kb_itr_get(extlines, &buf->b_extlines, &t, &itr)) { \
+    kb_itr_next(extlines, &buf->b_extlines, &itr);\
+  }\
+  ExtMarkLine *extline;\
+  for (; kb_itr_valid(&itr); kb_itr_next(extlines, &buf->b_extlines, &itr)) { \
+    extline = kb_itr_key(&itr);\
+    if (extline->lnum > u_lnum) { \
+      break;\
+    }\
+      code;\
+    }
+
+// see FOR_ALL_? for documentation
+#define FOR_ALL_EXTMARKLINES_PREV(buf, l_lnum, u_lnum, code)\
+  kbitr_t(extlines) itr;\
+  ExtMarkLine t;\
+  t.lnum = u_lnum;\
+  if (!kb_itr_get(extlines, &buf->b_extlines, &t, &itr)) { \
+    kb_itr_prev(extlines, &buf->b_extlines, &itr);\
+  }\
+  ExtMarkLine *extline;\
+  for (; kb_itr_valid(&itr); kb_itr_prev(extlines, &buf->b_extlines, &itr)) { \
+    extline = kb_itr_key(&itr);\
+    if (extline->lnum < l_lnum) { \
+      break;\
+    }\
+    code;\
+  }
+
+// see FOR_ALL_? for documentation
+#define FOR_ALL_EXTMARKS(buf, ns, l_lnum, l_col, u_lnum, u_col, code)\
+  kbitr_t(markitems) mitr;\
+  ExtendedMark mt;\
+  mt.ns_id = ns;\
+  mt.mark_id = 0;\
+  mt.line = NULL;\
+  FOR_ALL_EXTMARKLINES(buf, l_lnum, u_lnum, { \
+    mt.col = (extline->lnum != l_lnum) ? MINCOL : l_col;\
+    if (!kb_itr_get(markitems, &extline->items, mt, &mitr)) { \
+        kb_itr_next(markitems, &extline->items, &mitr);\
+    } \
+    ExtendedMark *extmark;\
+    for (; \
+         kb_itr_valid(&mitr); \
+         kb_itr_next(markitems, &extline->items, &mitr)) { \
+      extmark = &kb_itr_key(&mitr);\
+      if (extmark->line->lnum == u_lnum \
+          && extmark->col > u_col) { \
+        break;\
+      }\
+      code;\
+    }\
+  })
+
+
+// see FOR_ALL_? for documentation
+#define FOR_ALL_EXTMARKS_PREV(buf, ns, l_lnum, l_col, u_lnum, u_col, code)\
+  kbitr_t(markitems) mitr;\
+  ExtendedMark mt;\
+  mt.mark_id = sizeof(uint64_t);\
+  mt.ns_id = ns;\
+  FOR_ALL_EXTMARKLINES_PREV(buf, l_lnum, u_lnum, { \
+    mt.col = (extline->lnum != u_lnum) ? MAXCOL : u_col;\
+    if (!kb_itr_get(markitems, &extline->items, mt, &mitr)) { \
+        kb_itr_prev(markitems, &extline->items, &mitr);\
+    } \
+    ExtendedMark *extmark;\
+    for (; \
+         kb_itr_valid(&mitr); \
+         kb_itr_prev(markitems, &extline->items, &mitr)) { \
+      extmark = &kb_itr_key(&mitr);\
+      if (extmark->line->lnum == l_lnum \
+          && extmark->col < l_col) { \
+          break;\
+      }\
+      code;\
+    }\
+  })
+
+
+#define FOR_ALL_EXTMARKS_IN_LINE(items, l_col, u_col, code)\
+  kbitr_t(markitems) mitr;\
+  ExtendedMark mt;\
+  mt.ns_id = 0;\
+  mt.mark_id = 0;\
+  mt.line = NULL;\
+  mt.col = l_col;\
+  colnr_T extline_u_col = u_col;\
+  if (!kb_itr_get(markitems, &items, mt, &mitr)) { \
+    kb_itr_next(markitems, &items, &mitr);\
+  } \
+  ExtendedMark *extmark;\
+  for (; kb_itr_valid(&mitr); kb_itr_next(markitems, &items, &mitr)) { \
+    extmark = &kb_itr_key(&mitr);\
+    if (extmark->col > extline_u_col) { \
+      break;\
+    }\
+    code;\
+  }
+
+
+typedef struct ExtmarkNs {  // For namespacing extmarks
+  PMap(uint64_t) *map;      // For fast lookup
+  uint64_t free_id;         // For automatically assigning id's
+} ExtmarkNs;
+
+
+typedef kvec_t(ExtendedMark *) ExtmarkArray;
+typedef kvec_t(ExtMarkLine *) ExtlineArray;
+
+
+// Undo/redo extmarks
+
+typedef enum {
+  kExtmarkNOOP,        // Extmarks shouldn't be moved
+  kExtmarkUndo,        // Operation should be reversable/undoable
+  kExtmarkNoUndo,      // Operation should not be reversable
+  kExtmarkUndoNoRedo,  // Operation should be undoable, but not redoable
+} ExtmarkOp;
+
+
+typedef struct {
+  linenr_T line1;
+  linenr_T line2;
+  long amount;
+  long amount_after;
+} Adjust;
+
+typedef struct {
+  linenr_T lnum;
+  colnr_T mincol;
+  long col_amount;
+  long lnum_amount;
+} ColAdjust;
+
+typedef struct {
+    linenr_T lnum;
+    colnr_T mincol;
+    colnr_T endcol;
+    int eol;
+} ColAdjustDelete;
+
+typedef struct {
+  linenr_T line1;
+  linenr_T line2;
+  linenr_T last_line;
+  linenr_T dest;
+  linenr_T num_lines;
+  linenr_T extra;
+} AdjustMove;
+
+typedef struct {
+  uint64_t ns_id;
+  uint64_t mark_id;
+  linenr_T lnum;
+  colnr_T col;
+} ExtmarkSet;
+
+typedef struct {
+  uint64_t ns_id;
+  uint64_t mark_id;
+  linenr_T old_lnum;
+  colnr_T old_col;
+  linenr_T lnum;
+  colnr_T col;
+} ExtmarkUpdate;
+
+typedef struct {
+  uint64_t ns_id;
+  uint64_t mark_id;
+  linenr_T lnum;
+  colnr_T col;
+} ExtmarkCopy;
+
+typedef struct {
+  linenr_T l_lnum;
+  colnr_T l_col;
+  linenr_T u_lnum;
+  colnr_T u_col;
+  linenr_T p_lnum;
+  colnr_T p_col;
+} ExtmarkCopyPlace;
+
+typedef struct {
+  uint64_t ns_id;
+  linenr_T l_lnum;
+  linenr_T u_lnum;
+} ExtmarkClear;
+
+
+typedef enum {
+  kLineAdjust,
+  kColAdjust,
+  kColAdjustDelete,
+  kAdjustMove,
+  kExtmarkSet,
+  kExtmarkDel,
+  kExtmarkUpdate,
+  kExtmarkCopy,
+  kExtmarkCopyPlace,
+  kExtmarkClear,
+} UndoObjectType;
+
+struct undo_object {
+  UndoObjectType type;
+  union {
+    Adjust adjust;
+    ColAdjust col_adjust;
+    ColAdjustDelete col_adjust_delete;
+    AdjustMove move;
+    ExtmarkSet set;
+    ExtmarkUpdate update;
+    ExtmarkCopy copy;
+    ExtmarkCopyPlace copy_place;
+    ExtmarkClear clear;
+  } data;
+};
+
+
+// For doing move of extmarks in substitutions
+typedef struct {
+  lpos_T startpos;
+  lpos_T endpos;
+  linenr_T lnum;
+  int sublen;
+} ExtmarkSubSingle;
+
+// For doing move of extmarks in substitutions
+typedef struct {
+  lpos_T startpos;
+  lpos_T endpos;
+  linenr_T lnum;
+  linenr_T newline_in_pat;
+  linenr_T newline_in_sub;
+  linenr_T lnum_added;
+  lpos_T cm_start;  // start of the match
+  lpos_T cm_end;    // end of the match
+  int eol;    // end of the match
+} ExtmarkSubMulti;
+
+typedef kvec_t(ExtmarkSubSingle) extmark_sub_single_vec_t;
+typedef kvec_t(ExtmarkSubMulti) extmark_sub_multi_vec_t;
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "mark_extended.h.generated.h"
+#endif
+
+#endif  // NVIM_MARK_EXTENDED_H

--- a/src/nvim/mark_extended_defs.h
+++ b/src/nvim/mark_extended_defs.h
@@ -1,0 +1,54 @@
+#ifndef NVIM_MARK_EXTENDED_DEFS_H
+#define NVIM_MARK_EXTENDED_DEFS_H
+
+#include "nvim/pos.h"  // for colnr_T
+#include "nvim/map.h"  // for uint64_t
+#include "nvim/lib/kbtree.h"
+#include "nvim/lib/kvec.h"
+
+struct ExtMarkLine;
+
+typedef struct ExtendedMark
+{
+  uint64_t ns_id;
+  uint64_t mark_id;
+  struct ExtMarkLine *line;
+  colnr_T col;
+} ExtendedMark;
+
+
+// We only need to compare columns as rows are stored in a different tree.
+// Marks are ordered by: position, namespace, mark_id
+// This improves moving marks but slows down all other use cases (searches)
+static inline int extmark_cmp(ExtendedMark a, ExtendedMark b)
+{
+  int cmp = kb_generic_cmp(a.col, b.col);
+  if (cmp != 0) {
+    return cmp;
+  }
+  cmp = kb_generic_cmp(a.ns_id, b.ns_id);
+  if (cmp != 0) {
+    return cmp;
+  }
+  return kb_generic_cmp(a.mark_id, b.mark_id);
+}
+
+
+#define markitems_cmp(a, b) (extmark_cmp((a), (b)))
+KBTREE_INIT(markitems, ExtendedMark, markitems_cmp, 10)
+
+typedef struct ExtMarkLine
+{
+  linenr_T lnum;
+  kbtree_t(markitems) items;
+} ExtMarkLine;
+
+#define extline_cmp(a, b) (kb_generic_cmp((a)->lnum, (b)->lnum))
+KBTREE_INIT(extlines, ExtMarkLine *, extline_cmp, 10)
+
+
+typedef struct undo_object ExtmarkUndoObject;
+typedef kvec_t(ExtmarkUndoObject) extmark_undo_vec_t;
+
+
+#endif  // NVIM_MARK_EXTENDED_DEFS_H

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -30,7 +30,6 @@
 #include "nvim/indent_c.h"
 #include "nvim/buffer_updates.h"
 #include "nvim/main.h"
-#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/pos.h
+++ b/src/nvim/pos.h
@@ -14,6 +14,10 @@ typedef int colnr_T;
 enum { MAXLNUM = 0x7fffffff };
 /// Maximal column number, 31 bits
 enum { MAXCOL = 0x7fffffff };
+// Minimum line number
+enum { MINLNUM = 1 };
+// minimum column number
+enum { MINCOL = 1 };
 
 /*
  * position in file or buffer

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -91,7 +91,9 @@
 #include "nvim/fileio.h"
 #include "nvim/fold.h"
 #include "nvim/buffer_updates.h"
+#include "nvim/pos.h"  // MAXLNUM
 #include "nvim/mark.h"
+#include "nvim/mark_extended.h"
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
@@ -106,6 +108,7 @@
 #include "nvim/types.h"
 #include "nvim/os/os.h"
 #include "nvim/os/time.h"
+#include "nvim/lib/kvec.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "undo.c.generated.h"
@@ -384,6 +387,7 @@ int u_savecommon(linenr_T top, linenr_T bot, linenr_T newbot, int reload)
        * up the undo info when out of memory.
        */
       uhp = xmalloc(sizeof(u_header_T));
+      kv_init(uhp->uh_extmark);
 #ifdef U_DEBUG
       uhp->uh_magic = UH_MAGIC;
 #endif
@@ -2249,10 +2253,10 @@ static void u_undoredo(int undo, bool do_buf_event)
       xfree((char_u *)uep->ue_array);
     }
 
-    /* adjust marks */
+    // Adjust marks
     if (oldsize != newsize) {
       mark_adjust(top + 1, top + oldsize, (long)MAXLNUM,
-                  (long)newsize - (long)oldsize, false);
+                  (long)newsize - (long)oldsize, false, kExtmarkNOOP);
       if (curbuf->b_op_start.lnum > top + oldsize) {
         curbuf->b_op_start.lnum += newsize - oldsize;
       }
@@ -2284,6 +2288,23 @@ static void u_undoredo(int undo, bool do_buf_event)
     uep->ue_next = newlist;
     newlist = uep;
   }
+
+  // Adjust Extmarks
+  ExtmarkUndoObject undo_info;
+  if (undo) {
+    for (i = (int)kv_size(curhead->uh_extmark) - 1; i > -1; i--) {
+      undo_info = kv_A(curhead->uh_extmark, i);
+      extmark_apply_undo(undo_info, undo);
+    }
+  // redo
+  } else {
+    for (i = 0; i < (int)kv_size(curhead->uh_extmark); i++) {
+      undo_info = kv_A(curhead->uh_extmark, i);
+      extmark_apply_undo(undo_info, undo);
+    }
+  }
+  // finish Adjusting extmarks
+
 
   curhead->uh_entry = newlist;
   curhead->uh_flags = new_flags;
@@ -2828,6 +2849,9 @@ u_freeentries(
     u_freeentry(uep, uep->ue_size);
   }
 
+  // TODO(timeyyy): is this the correct place? ...
+  kv_destroy(uhp->uh_extmark);
+
 #ifdef U_DEBUG
   uhp->uh_magic = 0;
 #endif
@@ -3021,4 +3045,29 @@ list_T *u_eval_tree(const u_header_T *const first_uhp)
   }
 
   return list;
+}
+
+// Given the buffer, Return the undo header. If none is set, set one first.
+// NULL will be returned if e.g undolevels = -1 (undo disabled)
+u_header_T *force_get_undo_header(buf_T *buf)
+{
+  u_header_T *uhp = NULL;
+  if (buf->b_u_curhead != NULL) {
+    uhp = buf->b_u_curhead;
+  } else if (buf->b_u_newhead) {
+    uhp = buf->b_u_newhead;
+  }
+  // Create the first undo header for the buffer
+  if (!uhp) {
+    // TODO(timeyyy): there would be a better way to do this!
+    u_save_cursor();
+    uhp = buf->b_u_curhead;
+    if (!uhp) {
+      uhp = buf->b_u_newhead;
+      if (get_undolevel() > 0) {
+        assert(uhp);
+      }
+    }
+  }
+  return uhp;
 }

--- a/src/nvim/undo_defs.h
+++ b/src/nvim/undo_defs.h
@@ -4,6 +4,7 @@
 #include <time.h>  // for time_t
 
 #include "nvim/pos.h"
+#include "nvim/mark_extended_defs.h"
 #include "nvim/mark_defs.h"
 
 typedef struct u_header u_header_T;
@@ -56,14 +57,15 @@ struct u_header {
   u_entry_T   *uh_getbot_entry;   /* pointer to where ue_bot must be set */
   pos_T uh_cursor;              /* cursor position before saving */
   long uh_cursor_vcol;
-  int uh_flags;                 /* see below */
-  fmark_T uh_namedm[NMARKS];    /* marks before undo/after redo */
-  visualinfo_T uh_visual;       /* Visual areas before undo/after redo */
-  time_t uh_time;               /* timestamp when the change was made */
-  long uh_save_nr;              /* set when the file was saved after the
-                                   changes in this block */
+  int uh_flags;                 // see below
+  fmark_T uh_namedm[NMARKS];    // marks before undo/after redo
+  extmark_undo_vec_t uh_extmark;  // info to move extmarks
+  visualinfo_T uh_visual;       // Visual areas before undo/after redo
+  time_t uh_time;               // timestamp when the change was made
+  long uh_save_nr;              // set when the file was saved after the
+                                // changes in this block
 #ifdef U_DEBUG
-  int uh_magic;                 /* magic number to check allocation */
+  int uh_magic;                 // magic number to check allocation
 #endif
 };
 

--- a/test/functional/api/mark_extended_spec.lua
+++ b/test/functional/api/mark_extended_spec.lua
@@ -1,0 +1,1365 @@
+-- TODO(timeyyy): go through todo's lol
+-- change representation of stored marks to have location start at 0
+-- check with memsan, asan etc
+
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+
+local request = helpers.request
+local eq = helpers.eq
+local ok = helpers.ok
+local curbufmeths = helpers.curbufmeths
+local meth_pcall = helpers.meth_pcall
+local insert = helpers.insert
+local feed = helpers.feed
+local clear = helpers.clear
+
+local ALL = -1
+
+local rv = nil
+
+local function check_undo_redo(ns, mark, sr, sc, er, ec) --s = start, e = end
+  rv = curbufmeths.get_extmark_by_id(ns, mark)
+  eq({er, ec}, rv)
+  feed("u")
+  rv = curbufmeths.get_extmark_by_id(ns, mark)
+  eq({sr, sc}, rv)
+  feed("<c-r>")
+  rv = curbufmeths.get_extmark_by_id(ns, mark)
+  eq({er, ec}, rv)
+end
+
+describe('Extmarks buffer api', function()
+  local screen
+  local marks, positions, ns_string2, ns_string, init_text, row, col
+  local ns, ns2
+
+  before_each(function()
+    -- Initialize some namespaces and insert 12345 into a buffer
+    marks = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+    positions = {{0, 0,}, {0, 2}, {0, 3}}
+
+    ns_string = "my-fancy-plugin"
+    ns_string2 = "my-fancy-plugin2"
+    init_text = "12345"
+    row = 0
+    col = 2
+
+    clear()
+    screen = Screen.new(15, 10)
+    screen:attach()
+
+    insert(init_text)
+    ns = request('nvim_create_namespace', ns_string)
+    ns2 = request('nvim_create_namespace', ns_string2)
+  end)
+
+  it('adds, updates  and deletes marks #extmarks', function()
+    rv = curbufmeths.set_extmark(ns, marks[1], positions[1][1], positions[1][2])
+    eq(marks[1], rv)
+    rv = curbufmeths.get_extmark_by_id(ns, marks[1])
+    eq({positions[1][1], positions[1][2]}, rv)
+    -- Test adding a second mark on same row works
+    rv = curbufmeths.set_extmark(ns, marks[2], positions[2][1], positions[2][2])
+    eq(marks[2], rv)
+
+    -- Test an update, (same pos)
+    rv = curbufmeths.set_extmark(ns, marks[1], positions[1][1], positions[1][2])
+    eq(0, rv)
+    rv = curbufmeths.get_extmark_by_id(ns, marks[2])
+    eq({positions[2][1], positions[2][2]}, rv)
+    -- Test an update, (new pos)
+    row = positions[1][1]
+    col = positions[1][2] + 1
+    rv = curbufmeths.set_extmark(ns, marks[1], row, col)
+    eq(0, rv)
+    rv = curbufmeths.get_extmark_by_id(ns, marks[1])
+    eq({row, col}, rv)
+
+    -- remove the test marks
+    eq(true, curbufmeths.del_extmark(ns, marks[1]))
+    eq(false, curbufmeths.del_extmark(ns, marks[1]))
+    eq(true, curbufmeths.del_extmark(ns, marks[2]))
+    eq(false, curbufmeths.del_extmark(ns, marks[3]))
+    eq(false, curbufmeths.del_extmark(ns, 1000))
+  end)
+
+  it('can clear a specific namespace range #extmarks', function()
+    curbufmeths.set_extmark(ns, 1, 0, 1)
+    curbufmeths.set_extmark(ns2, 1, 0, 1)
+    -- force a new undo buffer
+    feed('o<esc>')
+    curbufmeths.clear_namespace(ns2, 0, -1)
+    eq({{1, 0, 1}}, curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL))
+    eq({}, curbufmeths.get_extmarks(ns2, {0, 0}, {-1, -1}, ALL))
+    feed('u')
+    eq({{1, 0, 1}}, curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL))
+    eq({{1, 0, 1}}, curbufmeths.get_extmarks(ns2, {0, 0}, {-1, -1}, ALL))
+    feed('<c-r>')
+    eq({{1, 0, 1}}, curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL))
+    eq({}, curbufmeths.get_extmarks(ns2, {0, 0}, {-1, -1}, ALL))
+  end)
+
+  it('can clear a namespace range using ALL #extmarks', function()
+    curbufmeths.set_extmark(ns, 1, 0, 1)
+    curbufmeths.set_extmark(ns2, 1, 0, 1)
+    -- force a new undo buffer
+    feed('o<esc>')
+    curbufmeths.clear_namespace(-1, 0, -1)
+    eq({}, curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL))
+    eq({}, curbufmeths.get_extmarks(ns2, {0, 0}, {-1, -1}, ALL))
+    feed('u')
+    eq({{1, 0, 1}}, curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL))
+    eq({{1, 0, 1}}, curbufmeths.get_extmarks(ns2, {0, 0}, {-1, -1}, ALL))
+    feed('<c-r>')
+    eq({}, curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL))
+    eq({}, curbufmeths.get_extmarks(ns2, {0, 0}, {-1, -1}, ALL))
+  end)
+
+  it('querying for information and ranges #extmarks', function()
+    -- add some more marks
+    for i, m in ipairs(marks) do
+      if positions[i] ~= nil then
+        rv = curbufmeths.set_extmark(ns, m, positions[i][1], positions[i][2])
+        eq(m, rv)
+      end
+    end
+
+    -- {0, 0} and {-1, -1} work as extreme values
+    eq({{1, 0, 0}}, curbufmeths.get_extmarks(ns, {0, 0}, {0, 0}, ALL))
+    eq({}, curbufmeths.get_extmarks(ns, {-1, -1}, {-1, -1}, ALL))
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL)
+    for i, m in ipairs(marks) do
+      if positions[i] ~= nil then
+        eq({m, positions[i][1], positions[i][2]}, rv[i])
+      end
+    end
+
+    -- 0 and -1 works as short hand extreme values
+    eq({{1, 0, 0}}, curbufmeths.get_extmarks(ns, 0, 0, ALL))
+    eq({}, curbufmeths.get_extmarks(ns, -1, -1, ALL))
+    rv = curbufmeths.get_extmarks(ns, 0, -1, ALL)
+    for i, m in ipairs(marks) do
+      if positions[i] ~= nil then
+        eq({m, positions[i][1], positions[i][2]}, rv[i])
+      end
+    end
+
+    -- next with mark id
+    rv = curbufmeths.get_extmarks(ns, marks[1], {-1, -1}, 1)
+    eq({{marks[1], positions[1][1], positions[1][2]}}, rv)
+    rv = curbufmeths.get_extmarks(ns, marks[2], {-1, -1}, 1)
+    eq({{marks[2], positions[2][1], positions[2][2]}}, rv)
+    -- next with positional when mark exists at position
+    rv = curbufmeths.get_extmarks(ns, positions[1], {-1, -1}, 1)
+    eq({{marks[1], positions[1][1], positions[1][2]}}, rv)
+    -- next with positional index (no mark at position)
+    rv = curbufmeths.get_extmarks(ns, {positions[1][1], positions[1][2] +1}, {-1, -1}, 1)
+    eq({{marks[2], positions[2][1], positions[2][2]}}, rv)
+    -- next with Extremity index
+    rv = curbufmeths.get_extmarks(ns, {0,0}, {-1, -1}, 1)
+    eq({{marks[1], positions[1][1], positions[1][2]}}, rv)
+
+    -- nextrange with mark id
+    rv = curbufmeths.get_extmarks(ns, marks[1], marks[3], ALL)
+    eq({marks[1], positions[1][1], positions[1][2]}, rv[1])
+    eq({marks[2], positions[2][1], positions[2][2]}, rv[2])
+    -- nextrange with amount
+    rv = curbufmeths.get_extmarks(ns, marks[1], marks[3], 2)
+    eq(2, table.getn(rv))
+    -- nextrange with positional when mark exists at position
+    rv = curbufmeths.get_extmarks(ns, positions[1], positions[3], ALL)
+    eq({marks[1], positions[1][1], positions[1][2]}, rv[1])
+    eq({marks[2], positions[2][1], positions[2][2]}, rv[2])
+    rv = curbufmeths.get_extmarks(ns, positions[2], positions[3], ALL)
+    eq(2, table.getn(rv))
+    -- nextrange with positional index (no mark at position)
+    local lower = {positions[1][1], positions[2][2] -1}
+    local upper = {positions[2][1], positions[3][2] - 1}
+    rv = curbufmeths.get_extmarks(ns, lower, upper, ALL)
+    eq({{marks[2], positions[2][1], positions[2][2]}}, rv)
+    lower = {positions[3][1], positions[3][2] + 1}
+    upper = {positions[3][1], positions[3][2] + 2}
+    rv = curbufmeths.get_extmarks(ns, lower, upper, ALL)
+    eq({}, rv)
+    -- nextrange with extremity index
+    lower = {positions[2][1], positions[2][2]+1}
+    upper = {-1, -1}
+    rv = curbufmeths.get_extmarks(ns, lower, upper, ALL)
+    eq({{marks[3], positions[3][1], positions[3][2]}}, rv)
+
+    -- prev with mark id
+    rv = curbufmeths.get_extmarks(ns, marks[3], {0, 0}, 1)
+    eq({{marks[3], positions[3][1], positions[3][2]}}, rv)
+    rv = curbufmeths.get_extmarks(ns, marks[2], {0, 0}, 1)
+    eq({{marks[2], positions[2][1], positions[2][2]}}, rv)
+    -- prev with positional when mark exists at position
+    rv = curbufmeths.get_extmarks(ns, positions[3], {0, 0}, 1)
+    eq({{marks[3], positions[3][1], positions[3][2]}}, rv)
+    -- prev with positional index (no mark at position)
+    rv = curbufmeths.get_extmarks(ns, {positions[1][1], positions[1][2] +1}, {0, 0}, 1)
+    eq({{marks[1], positions[1][1], positions[1][2]}}, rv)
+    -- prev with Extremity index
+    rv = curbufmeths.get_extmarks(ns, {-1,-1}, {0,0}, 1)
+    eq({{marks[3], positions[3][1], positions[3][2]}}, rv)
+
+    -- prevrange with mark id
+    rv = curbufmeths.get_extmarks(ns, marks[3], marks[1], ALL)
+    eq({marks[3], positions[3][1], positions[3][2]}, rv[1])
+    eq({marks[2], positions[2][1], positions[2][2]}, rv[2])
+    eq({marks[1], positions[1][1], positions[1][2]}, rv[3])
+    -- prevrange with amount
+    rv = curbufmeths.get_extmarks(ns, marks[3], marks[1], 2)
+    eq(2, table.getn(rv))
+    -- prevrange with positional when mark exists at position
+    rv = curbufmeths.get_extmarks(ns, positions[3], positions[1], ALL)
+    eq({{marks[3], positions[3][1], positions[3][2]},
+        {marks[2], positions[2][1], positions[2][2]},
+        {marks[1], positions[1][1], positions[1][2]}}, rv)
+    rv = curbufmeths.get_extmarks(ns, positions[2], positions[1], ALL)
+    eq(2, table.getn(rv))
+    -- prevrange with positional index (no mark at position)
+    lower = {positions[2][1], positions[2][2] + 1}
+    upper = {positions[3][1], positions[3][2] + 1}
+    rv = curbufmeths.get_extmarks(ns, upper, lower, ALL)
+    eq({{marks[3], positions[3][1], positions[3][2]}}, rv)
+    lower = {positions[3][1], positions[3][2] + 1}
+    upper = {positions[3][1], positions[3][2] + 2}
+    rv = curbufmeths.get_extmarks(ns, upper, lower, ALL)
+    eq({}, rv)
+    -- prevrange with extremity index
+    lower = {0,0}
+    upper = {positions[2][1], positions[2][2] - 1}
+    rv = curbufmeths.get_extmarks(ns, upper, lower, ALL)
+    eq({{marks[1], positions[1][1], positions[1][2]}}, rv)
+  end)
+
+  it('querying for information with amount #extmarks', function()
+    -- add some more marks
+    for i, m in ipairs(marks) do
+      if positions[i] ~= nil then
+        rv = curbufmeths.set_extmark(ns, m, positions[i][1], positions[i][2])
+        eq(m, rv)
+      end
+    end
+
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, 1)
+    eq(1, table.getn(rv))
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, 2)
+    eq(2, table.getn(rv))
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, 3)
+    eq(3, table.getn(rv))
+
+    -- now in reverse
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, 1)
+    eq(1, table.getn(rv))
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, 2)
+    eq(2, table.getn(rv))
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, 3)
+    eq(3, table.getn(rv))
+  end)
+
+  it('get_marks works when mark col > upper col #extmarks', function()
+    feed('A<cr>12345<esc>')
+    feed('A<cr>12345<esc>')
+    curbufmeths.set_extmark(ns, 10, 0, 2)       -- this shouldn't be found
+    curbufmeths.set_extmark(ns, 11, 2, 1)       -- this shouldn't be found
+    curbufmeths.set_extmark(ns, marks[1], 0, 4) -- check col > our upper bound
+    curbufmeths.set_extmark(ns, marks[2], 1, 1) -- check col < lower bound
+    curbufmeths.set_extmark(ns, marks[3], 2, 0) -- check is inclusive
+    eq({{marks[1], 0, 4},
+        {marks[2], 1, 1},
+        {marks[3], 2, 0}},
+       curbufmeths.get_extmarks(ns, {0, 3}, {2, 0}, -1))
+  end)
+
+  it('get_marks works in reverse when mark col < lower col #extmarks', function()
+    feed('A<cr>12345<esc>')
+    feed('A<cr>12345<esc>')
+    curbufmeths.set_extmark(ns, 10, 0, 1) -- this shouldn't be found
+    curbufmeths.set_extmark(ns, 11, 2, 4) -- this shouldn't be found
+    curbufmeths.set_extmark(ns, marks[1], 2, 1) -- check col < our lower bound
+    curbufmeths.set_extmark(ns, marks[2], 1, 4) -- check col > upper bound
+    curbufmeths.set_extmark(ns, marks[3], 0, 2) -- check is inclusive
+    rv = curbufmeths.get_extmarks(ns, {2, 3}, {0, 2}, -1)
+    eq({{marks[1], 2, 1},
+        {marks[2], 1, 4},
+        {marks[3], 0, 2}},
+       rv)
+  end)
+
+  it('get_marks amount 0 returns nothing #extmarks', function()
+    curbufmeths.set_extmark(ns, marks[1], positions[1][1], positions[1][2])
+    rv = curbufmeths.get_extmarks(ns, {-1, -1}, {-1, -1}, 0)
+    eq({}, rv)
+  end)
+
+
+  it('marks move with line insertations #extmarks', function()
+    curbufmeths.set_extmark(ns, marks[1], 0, 0)
+    feed("yyP")
+    check_undo_redo(ns, marks[1], 0, 0, 1, 0)
+  end)
+
+  it('marks move with multiline insertations #extmarks', function()
+    feed("a<cr>22<cr>33<esc>")
+    curbufmeths.set_extmark(ns, marks[1], 1, 1)
+    feed('ggVGyP')
+    check_undo_redo(ns, marks[1], 1, 1, 4, 1)
+  end)
+
+  it('marks move with line join #extmarks', function()
+    -- do_join in ops.c
+    feed("a<cr>222<esc>")
+    curbufmeths.set_extmark(ns, marks[1], 1, 0)
+    feed('ggJ')
+    check_undo_redo(ns, marks[1], 1, 0, 0, 6)
+  end)
+
+  it('join works when no marks are present #extmarks', function()
+    feed("a<cr>1<esc>")
+    feed('kJ')
+    -- This shouldn't seg fault
+    screen:expect([[
+      12345^ 1        |
+      ~              |
+      ~              |
+      ~              |
+      ~              |
+      ~              |
+      ~              |
+      ~              |
+      ~              |
+                     |
+    ]])
+  end)
+
+  it('marks move with multiline join #extmarks', function()
+    -- do_join in ops.c
+    feed("a<cr>222<cr>333<cr>444<esc>")
+    curbufmeths.set_extmark(ns, marks[1], 3, 0)
+    feed('2GVGJ')
+    check_undo_redo(ns, marks[1], 3, 0, 1, 8)
+  end)
+
+  it('marks move with line deletes #extmarks', function()
+    feed("a<cr>222<cr>333<cr>444<esc>")
+    curbufmeths.set_extmark(ns, marks[1], 2, 1)
+    feed('ggjdd')
+    check_undo_redo(ns, marks[1], 2, 1, 1, 1)
+  end)
+
+  it('marks move with multiline deletes #extmarks', function()
+    feed("a<cr>222<cr>333<cr>444<esc>")
+    curbufmeths.set_extmark(ns, marks[1], 3, 0)
+    feed('gg2dd')
+    check_undo_redo(ns, marks[1], 3, 0, 1, 0)
+    -- regression test, undoing multiline delete when mark is on row 1
+    feed('ugg3dd')
+    check_undo_redo(ns, marks[1], 3, 0, 0, 0)
+  end)
+
+  it('marks move with open line #extmarks', function()
+    -- open_line in misc1.c
+    -- testing marks below are also moved
+    feed("yyP")
+    curbufmeths.set_extmark(ns, marks[1], 0, 4)
+    curbufmeths.set_extmark(ns, marks[2], 1, 4)
+    feed('1G<s-o><esc>')
+    check_undo_redo(ns, marks[1], 0, 4, 1, 4)
+    check_undo_redo(ns, marks[2], 1, 4, 2, 4)
+    feed('2Go<esc>')
+    check_undo_redo(ns, marks[1], 1, 4, 1, 4)
+    check_undo_redo(ns, marks[2], 2, 4, 3, 4)
+  end)
+
+  -- NO idea why this doesn't work... works in program.
+  pending('marks move with char inserts #extmarks', function()
+    -- insertchar in edit.c (the ins_str branch)
+    curbufmeths.set_extmark(ns, marks[1], 1, 3)
+    feed('0')
+    insert('abc')
+    screen:expect([[
+      ab^c12345       |
+      ~              |
+      ~              |
+      ~              |
+      ~              |
+      ~              |
+      ~              |
+      ~              |
+      ~              |
+                     |
+    ]])
+    rv = curbufmeths.get_extmark_by_id(ns, marks[1])
+    eq(1, rv[2])
+    eq(6, rv[3])
+    -- check_undo_redo(ns, marks[1], 0, 2, 0, 5)
+  end)
+
+  -- gravity right as definted in tk library
+  it('marks have gravity right #extmarks', function()
+    -- insertchar in edit.c (the ins_str branch)
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    feed('03l')
+    insert("X")
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+
+    -- check multibyte chars
+    feed('03l<esc>')
+    insert("～～")
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+  end)
+
+  it('we can insert multibyte chars #extmarks', function()
+    -- insertchar in edit.c
+    feed('a<cr>12345<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 1, 2)
+    -- Insert a fullwidth (two col) tilde, NICE
+    feed('0i～<esc>')
+    check_undo_redo(ns, marks[1], 1, 2, 1, 3)
+  end)
+
+  it('marks move with blockwise inserts #extmarks', function()
+    -- op_insert in ops.c
+    feed('a<cr>12345<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 1, 2)
+    feed('0<c-v>lkI9<esc>')
+    check_undo_redo(ns, marks[1], 1, 2, 1, 3)
+  end)
+
+  it('marks move with line splits (using enter) #extmarks', function()
+    -- open_line in misc1.c
+    -- testing marks below are also moved
+    feed("yyP")
+    curbufmeths.set_extmark(ns, marks[1], 0, 4)
+    curbufmeths.set_extmark(ns, marks[2], 1, 4)
+    feed('1Gla<cr><esc>')
+    check_undo_redo(ns, marks[1], 0, 4, 1, 2)
+    check_undo_redo(ns, marks[2], 1, 4, 2, 4)
+  end)
+
+  -- TODO mark_col_adjust for normal marks fails in vim/neovim
+  -- because flags is 9 in: if (flags & OPENLINE_MARKFIX) {
+  it('marks at last line move on insert new line #extmarks', function()
+    -- open_line in misc1.c
+    curbufmeths.set_extmark(ns, marks[1], 0, 4)
+    feed('0i<cr><esc>')
+    check_undo_redo(ns, marks[1], 0, 4, 1, 4)
+  end)
+
+  it('yet again marks move with line splits #extmarks', function()
+    -- the first test above wasn't catching all errors..
+    feed("A67890<esc>")
+    curbufmeths.set_extmark(ns, marks[1], 0, 4)
+    feed("04li<cr><esc>")
+    check_undo_redo(ns, marks[1], 0, 4, 1, 0)
+  end)
+
+  it('and one last time line splits... #extmarks', function()
+    curbufmeths.set_extmark(ns, marks[1], 0, 1)
+    curbufmeths.set_extmark(ns, marks[2], 0, 2)
+    feed("02li<cr><esc>")
+    check_undo_redo(ns, marks[1], 0, 1, 0, 1)
+    check_undo_redo(ns, marks[2], 0, 2, 1, 0)
+  end)
+
+  it('multiple marks move with mark splits #extmarks', function()
+    curbufmeths.set_extmark(ns, marks[1], 0, 1)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    feed("0li<cr><esc>")
+    check_undo_redo(ns, marks[1], 0, 1, 1, 0)
+    check_undo_redo(ns, marks[2], 0, 3, 1, 2)
+  end)
+
+  it('deleting on a mark works #extmarks', function()
+    -- op_delete in ops.c
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    feed('02lx')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+  end)
+
+  it('marks move with char deletes #extmarks', function()
+    -- op_delete in ops.c
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    feed('02dl')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 0)
+    -- from the other side (nothing should happen)
+    feed('$x')
+    check_undo_redo(ns, marks[1], 0, 0, 0, 0)
+  end)
+
+  it('marks move with char deletes over a range #extmarks', function()
+    -- op_delete in ops.c
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    feed('0l3dl<esc>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 1)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 1)
+    -- delete 1, nothing should happend to our marks
+    feed('u')
+    feed('$x')
+    -- TODO do we need to test marks[1] ???
+    check_undo_redo(ns, marks[2], 0, 3, 0, 3)
+  end)
+
+  it('deleting marks at end of line works #extmarks', function()
+    -- mark_extended.c/extmark_col_adjust_delete
+    curbufmeths.set_extmark(ns, marks[1], 0, 4)
+    feed('$x')
+    check_undo_redo(ns, marks[1], 0, 4, 0, 4)
+    -- check the copy happened correctly on delete at eol
+    feed('$x')
+    check_undo_redo(ns, marks[1], 0, 4, 0, 3)
+    feed('u')
+    check_undo_redo(ns, marks[1], 0, 4, 0, 4)
+  end)
+
+  it('marks move with blockwise deletes #extmarks', function()
+    -- op_delete in ops.c
+    feed('a<cr>12345<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 1, 4)
+    feed('h<c-v>hhkd')
+    check_undo_redo(ns, marks[1], 1, 4, 1, 1)
+  end)
+
+  it('marks move with blockwise deletes over a range #extmarks', function()
+    -- op_delete in ops.c
+    feed('a<cr>12345<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 1)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    curbufmeths.set_extmark(ns, marks[3], 1, 2)
+    feed('0<c-v>k3lx')
+    check_undo_redo(ns, marks[1], 0, 1, 0, 0)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 0)
+    check_undo_redo(ns, marks[3], 1, 2, 1, 0)
+    -- delete 1, nothing should happend to our marks
+    feed('u')
+    feed('$<c-v>jx')
+    -- TODO do we need to test marks[1] ???
+    check_undo_redo(ns, marks[2], 0, 3, 0, 3)
+    check_undo_redo(ns, marks[3], 1, 2, 1, 2)
+  end)
+
+  it('works with char deletes over multilines #extmarks', function()
+    feed('a<cr>12345<cr>test-me<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 2, 5)
+    feed('gg')
+    feed('dv?-m?<cr>')
+    check_undo_redo(ns, marks[1], 2, 5, 0, 0)
+  end)
+
+  it('marks outside of deleted range move with visual char deletes #extmarks', function()
+    -- op_delete in ops.c
+    curbufmeths.set_extmark(ns, marks[1], 0, 3)
+    feed('0vx<esc>')
+    check_undo_redo(ns, marks[1], 0, 3, 0, 2)
+
+    feed("u")
+    feed('0vlx<esc>')
+    check_undo_redo(ns, marks[1], 0, 3, 0, 1)
+
+    feed("u")
+    feed('0v2lx<esc>')
+    check_undo_redo(ns, marks[1], 0, 3, 0, 0)
+
+    -- from the other side (nothing should happen)
+    feed('$vx')
+    check_undo_redo(ns, marks[1], 0, 0, 0, 0)
+  end)
+
+  it('marks outside of deleted range move with char deletes #extmarks', function()
+    -- op_delete in ops.c
+    curbufmeths.set_extmark(ns, marks[1], 0, 3)
+    feed('0x<esc>')
+    check_undo_redo(ns, marks[1], 0, 3, 0, 2)
+
+    feed("u")
+    feed('02x<esc>')
+    check_undo_redo(ns, marks[1], 0, 3, 0, 1)
+
+    feed("u")
+    feed('0v3lx<esc>')
+    check_undo_redo(ns, marks[1], 0, 3, 0, 0)
+
+    -- from the other side (nothing should happen)
+    feed("u")
+    feed('$vx')
+    check_undo_redo(ns, marks[1], 0, 3, 0, 3)
+  end)
+
+  it('marks move with P(backward) paste #extmarks', function()
+    -- do_put in ops.c
+    feed('0iabc<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 7)
+    feed('0veyP')
+    check_undo_redo(ns, marks[1], 0, 7, 0, 15)
+  end)
+
+  it('marks move with p(forward) paste #extmarks', function()
+    -- do_put in ops.c
+    feed('0iabc<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 7)
+    feed('0veyp')
+    check_undo_redo(ns, marks[1], 0, 7, 0, 14)
+  end)
+
+  it('marks move with blockwise P(backward) paste #extmarks', function()
+    -- do_put in ops.c
+    feed('a<cr>12345<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 1, 4)
+    feed('<c-v>hhkyP<esc>')
+    check_undo_redo(ns, marks[1], 1, 4, 1, 7)
+  end)
+
+  it('marks move with blockwise p(forward) paste #extmarks', function()
+    -- do_put in ops.c
+    feed('a<cr>12345<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 1, 4)
+    feed('<c-v>hhkyp<esc>')
+    check_undo_redo(ns, marks[1], 1, 4, 1, 6)
+  end)
+
+  it('replace works #extmarks', function()
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    feed('0r2')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+  end)
+
+  it('blockwise replace works #extmarks', function()
+    feed('a<cr>12345<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    feed('0<c-v>llkr1<esc>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+  end)
+
+  it('shift line #extmarks', function()
+    -- shift_line in ops.c
+    feed(':set shiftwidth=4<cr><esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    feed('0>>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 6)
+
+    feed('>>')
+    check_undo_redo(ns, marks[1], 0, 6, 0, 10)
+
+    feed('<LT><LT>') -- have to escape, same as <<
+    check_undo_redo(ns, marks[1], 0, 10, 0, 6)
+  end)
+
+  it('blockwise shift #extmarks', function()
+    -- shift_block in ops.c
+    feed(':set shiftwidth=4<cr><esc>')
+    feed('a<cr>12345<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 1, 2)
+    feed('0<c-v>k>')
+    check_undo_redo(ns, marks[1], 1, 2, 1, 6)
+    feed('<c-v>j>')
+    check_undo_redo(ns, marks[1], 1, 6, 1, 10)
+
+    feed('<c-v>j<LT>')
+    check_undo_redo(ns, marks[1], 1, 10, 1, 6)
+  end)
+
+  it('tab works with expandtab #extmarks', function()
+    -- ins_tab in edit.c
+    feed(':set expandtab<cr><esc>')
+    feed(':set shiftwidth=2<cr><esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    feed('0i<tab><tab><esc>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 6)
+  end)
+
+  it('tabs work #extmarks', function()
+    -- ins_tab in edit.c
+    feed(':set noexpandtab<cr><esc>')
+    feed(':set shiftwidth=2<cr><esc>')
+    feed(':set softtabstop=2<cr><esc>')
+    feed(':set tabstop=8<cr><esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    feed('0i<tab><esc>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 4)
+    feed('0iX<tab><esc>')
+    check_undo_redo(ns, marks[1], 0, 4, 0, 6)
+  end)
+
+  it('marks move when using :move #extmarks', function()
+    curbufmeths.set_extmark(ns, marks[1], 0, 0)
+    feed('A<cr>2<esc>:1move 2<cr><esc>')
+    check_undo_redo(ns, marks[1], 0, 0, 1, 0)
+    -- test codepath when moving lines up
+    feed(':2move 0<cr><esc>')
+    check_undo_redo(ns, marks[1], 1, 0, 0, 0)
+  end)
+
+  it('marks move when using :move part 2 #extmarks', function()
+    -- make sure we didn't get lucky with the math...
+    feed('A<cr>2<cr>3<cr>4<cr>5<cr>6<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 1, 0)
+    feed(':2,3move 5<cr><esc>')
+    check_undo_redo(ns, marks[1], 1, 0, 3, 0)
+    -- test codepath when moving lines up
+    feed(':4,5move 1<cr><esc>')
+    check_undo_redo(ns, marks[1], 3, 0, 1, 0)
+  end)
+
+  it('undo and redo of set and unset marks #extmarks', function()
+    -- Force a new undo head
+    feed('o<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 1)
+    feed('o<esc>')
+    curbufmeths.set_extmark(ns, marks[2], 0, -1)
+    curbufmeths.set_extmark(ns, marks[3], 0, -1)
+
+    feed("u")
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL)
+    eq(1, table.getn(rv))
+
+    feed("<c-r>")
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL)
+    eq(3, table.getn(rv))
+
+    -- Test updates
+    feed('o<esc>')
+    curbufmeths.set_extmark(ns, marks[1], positions[1][1], positions[1][2])
+    rv = curbufmeths.get_extmarks(ns, marks[1], marks[1], 1)
+    feed("u")
+    feed("<c-r>")
+    check_undo_redo(ns, marks[1], 0, 1, positions[1][1], positions[1][2])
+
+    -- Test unset
+    feed('o<esc>')
+    curbufmeths.del_extmark(ns, marks[3])
+    feed("u")
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL)
+    eq(3, table.getn(rv))
+    feed("<c-r>")
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL)
+    eq(2, table.getn(rv))
+  end)
+
+  it('undo and redo of marks deleted during edits #extmarks', function()
+    -- test extmark_adjust
+    feed('A<cr>12345<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 1, 2)
+    feed('dd')
+    check_undo_redo(ns, marks[1], 1, 2, 1, 0)
+  end)
+
+  it('namespaces work properly #extmarks', function()
+    rv = curbufmeths.set_extmark(ns, marks[1], positions[1][1], positions[1][2])
+    eq(1, rv)
+    rv = curbufmeths.set_extmark(ns2, marks[1], positions[1][1], positions[1][2])
+    eq(1, rv)
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL)
+    eq(1, table.getn(rv))
+    rv = curbufmeths.get_extmarks(ns2, {0, 0}, {-1, -1}, ALL)
+    eq(1, table.getn(rv))
+
+    -- Set more marks for testing the ranges
+    rv = curbufmeths.set_extmark(ns, marks[2], positions[2][1], positions[2][2])
+    rv = curbufmeths.set_extmark(ns, marks[3], positions[3][1], positions[3][2])
+    rv = curbufmeths.set_extmark(ns2, marks[2], positions[2][1], positions[2][2])
+    rv = curbufmeths.set_extmark(ns2, marks[3], positions[3][1], positions[3][2])
+
+    -- get_next (amount set)
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, positions[2], 1)
+    eq(1, table.getn(rv))
+    rv = curbufmeths.get_extmarks(ns2, {0, 0}, positions[2], 1)
+    eq(1, table.getn(rv))
+    -- get_prev (amount set)
+    rv = curbufmeths.get_extmarks(ns, positions[1], {0, 0}, 1)
+    eq(1, table.getn(rv))
+    rv = curbufmeths.get_extmarks(ns2, positions[1], {0, 0}, 1)
+    eq(1, table.getn(rv))
+
+    -- get_next (amount not set)
+    rv = curbufmeths.get_extmarks(ns, positions[1], positions[2], ALL)
+    eq(2, table.getn(rv))
+    rv = curbufmeths.get_extmarks(ns2, positions[1], positions[2], ALL)
+    eq(2, table.getn(rv))
+    -- get_prev (amount not set)
+    rv = curbufmeths.get_extmarks(ns, positions[2], positions[1], ALL)
+    eq(2, table.getn(rv))
+    rv = curbufmeths.get_extmarks(ns2, positions[2], positions[1], ALL)
+    eq(2, table.getn(rv))
+
+    curbufmeths.del_extmark(ns, marks[1])
+    rv = curbufmeths.get_extmarks(ns, {0, 0}, {-1, -1}, ALL)
+    eq(2, table.getn(rv))
+    curbufmeths.del_extmark(ns2, marks[1])
+    rv = curbufmeths.get_extmarks(ns2, {0, 0}, {-1, -1}, ALL)
+    eq(2, table.getn(rv))
+  end)
+
+  it('mark set can create unique identifiers #extmarks', function()
+    -- create mark with id 1
+    eq(1, curbufmeths.set_extmark(ns, 1, positions[1][1], positions[1][2]))
+    -- ask for unique id, it should be the next one, i e 2
+    eq(2, curbufmeths.set_extmark(ns, 0, positions[1][1], positions[1][2]))
+    eq(3, curbufmeths.set_extmark(ns, 3, positions[2][1], positions[2][2]))
+    eq(4, curbufmeths.set_extmark(ns, 0, positions[1][1], positions[1][2]))
+
+    -- mixing manual and allocated id:s are not recommened, but it should
+    -- do something reasonable
+    eq(6, curbufmeths.set_extmark(ns, 6, positions[2][1], positions[2][2]))
+    eq(7, curbufmeths.set_extmark(ns, 0, positions[1][1], positions[1][2]))
+    eq(8, curbufmeths.set_extmark(ns, 0, positions[1][1], positions[1][2]))
+  end)
+
+  it('auto indenting with enter works #extmarks', function()
+    -- op_reindent in ops.c
+    feed(':set cindent<cr><esc>')
+    feed(':set autoindent<cr><esc>')
+    feed(':set shiftwidth=2<cr><esc>')
+    feed("0iint <esc>A {1M1<esc>b<esc>")
+    -- Set the mark on the M, should move..
+    curbufmeths.set_extmark(ns, marks[1], 0, 12)
+    -- Set the mark before the cursor, should stay there
+    curbufmeths.set_extmark(ns, marks[2], 0, 10)
+    feed("i<cr><esc>")
+    rv = curbufmeths.get_extmark_by_id(ns, marks[1])
+    eq({1, 3}, rv)
+    rv = curbufmeths.get_extmark_by_id(ns, marks[2])
+    eq({0, 10}, rv)
+    check_undo_redo(ns, marks[1], 0, 12, 1, 3)
+  end)
+
+  it('auto indenting entire line works #extmarks', function()
+    feed(':set cindent<cr><esc>')
+    feed(':set autoindent<cr><esc>')
+    feed(':set shiftwidth=2<cr><esc>')
+    -- <c-f> will force an indent of 2
+    feed("0iint <esc>A {<cr><esc>0i1M1<esc>")
+    curbufmeths.set_extmark(ns, marks[1], 1, 1)
+    feed("0i<c-f><esc>")
+    rv = curbufmeths.get_extmark_by_id(ns, marks[1])
+    eq({1, 3}, rv)
+    check_undo_redo(ns, marks[1], 1, 1, 1, 3)
+    -- now check when cursor at eol
+    feed("uA<c-f><esc>")
+    rv = curbufmeths.get_extmark_by_id(ns, marks[1])
+    eq({1, 3}, rv)
+  end)
+
+  it('removing auto indenting with <C-D> works #extmarks', function()
+    feed(':set cindent<cr><esc>')
+    feed(':set autoindent<cr><esc>')
+    feed(':set shiftwidth=2<cr><esc>')
+    feed("0i<tab><esc>")
+    curbufmeths.set_extmark(ns, marks[1], 0, 3)
+    feed("bi<c-d><esc>")
+    rv = curbufmeths.get_extmark_by_id(ns, marks[1])
+    eq({0, 1}, rv)
+    check_undo_redo(ns, marks[1], 0, 3, 0, 1)
+    -- check when cursor at eol
+    feed("uA<c-d><esc>")
+    rv = curbufmeths.get_extmark_by_id(ns, marks[1])
+    eq({0, 1}, rv)
+  end)
+
+  it('indenting multiple lines with = works #extmarks', function()
+    feed(':set cindent<cr><esc>')
+    feed(':set autoindent<cr><esc>')
+    feed(':set shiftwidth=2<cr><esc>')
+    feed("0iint <esc>A {<cr><bs>1M1<cr><bs>2M2<esc>")
+    curbufmeths.set_extmark(ns, marks[1], 1, 1)
+    curbufmeths.set_extmark(ns, marks[2], 2, 1)
+    feed('=gg')
+    check_undo_redo(ns, marks[1], 1, 1, 1, 3)
+    check_undo_redo(ns, marks[2], 2, 1, 2, 5)
+  end)
+
+  it('substitutes by deleting inside the replace matches #extmarks_sub', function()
+    -- do_sub in ex_cmds.c
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    feed(':s/34/xx<cr>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 4)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 4)
+  end)
+
+  it('substitutes when insert text > deleted #extmarks_sub', function()
+    -- do_sub in ex_cmds.c
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    feed(':s/34/xxx<cr>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 5)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 5)
+  end)
+
+  it('substitutes when marks around eol #extmarks_sub', function()
+    -- do_sub in ex_cmds.c
+    curbufmeths.set_extmark(ns, marks[1], 0, 4)
+    curbufmeths.set_extmark(ns, marks[2], 0, 5)
+    feed(':s/5/xxx<cr>')
+    check_undo_redo(ns, marks[1], 0, 4, 0, 7)
+    check_undo_redo(ns, marks[2], 0, 5, 0, 7)
+  end)
+
+  it('substitutes over range insert text > deleted #extmarks_sub', function()
+    -- do_sub in ex_cmds.c
+    feed('A<cr>x34xx<esc>')
+    feed('A<cr>xxx34<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 1, 1)
+    curbufmeths.set_extmark(ns, marks[3], 2, 4)
+    feed(':1,3s/34/xxx<cr><esc>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 5)
+    check_undo_redo(ns, marks[2], 1, 1, 1, 4)
+    check_undo_redo(ns, marks[3], 2, 4, 2, 6)
+  end)
+
+  it('substitutes multiple matches in a line #extmarks_sub', function()
+    -- do_sub in ex_cmds.c
+    feed('ddi3x3x3<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 0)
+    curbufmeths.set_extmark(ns, marks[2], 0, 2)
+    curbufmeths.set_extmark(ns, marks[3], 0, 4)
+    feed(':s/3/yy/g<cr><esc>')
+    check_undo_redo(ns, marks[1], 0, 0, 0, 2)
+    check_undo_redo(ns, marks[2], 0, 2, 0, 5)
+    check_undo_redo(ns, marks[3], 0, 4, 0, 8)
+  end)
+
+  it('substitions over multiple lines with newline in pattern #extmarks_sub', function()
+    feed('A<cr>67890<cr>xx<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 3)
+    curbufmeths.set_extmark(ns, marks[2], 0, 4)
+    curbufmeths.set_extmark(ns, marks[3], 1, 0)
+    curbufmeths.set_extmark(ns, marks[4], 1, 5)
+    curbufmeths.set_extmark(ns, marks[5], 2, 0)
+    feed([[:1,2s:5\n:5 <cr>]])
+    check_undo_redo(ns, marks[1], 0, 3, 0, 3)
+    check_undo_redo(ns, marks[2], 0, 4, 0, 6)
+    check_undo_redo(ns, marks[3], 1, 0, 0, 6)
+    check_undo_redo(ns, marks[4], 1, 5, 0, 11)
+    check_undo_redo(ns, marks[5], 2, 0, 1, 0)
+  end)
+
+  it('inserting #extmarks_sub', function()
+    feed('A<cr>67890<cr>xx<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 3)
+    curbufmeths.set_extmark(ns, marks[2], 0, 4)
+    curbufmeths.set_extmark(ns, marks[3], 1, 0)
+    curbufmeths.set_extmark(ns, marks[4], 1, 5)
+    curbufmeths.set_extmark(ns, marks[5], 2, 0)
+    curbufmeths.set_extmark(ns, marks[6], 1, 2)
+    feed([[:1,2s:5\n67:X<cr>]])
+    check_undo_redo(ns, marks[1], 0, 3, 0, 3)
+    check_undo_redo(ns, marks[2], 0, 4, 0, 5)
+    check_undo_redo(ns, marks[3], 1, 0, 0, 5)
+    check_undo_redo(ns, marks[4], 1, 5, 0, 8)
+    check_undo_redo(ns, marks[5], 2, 0, 1, 0)
+    check_undo_redo(ns, marks[6], 1, 2, 0, 5)
+  end)
+
+  it('substitions with multiple newlines in pattern #extmarks_sub', function()
+    feed('A<cr>67890<cr>xx<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 4)
+    curbufmeths.set_extmark(ns, marks[2], 0, 5)
+    curbufmeths.set_extmark(ns, marks[3], 1, 0)
+    curbufmeths.set_extmark(ns, marks[4], 1, 5)
+    curbufmeths.set_extmark(ns, marks[5], 2, 0)
+    feed([[:1,2s:\n.*\n:X<cr>]])
+    check_undo_redo(ns, marks[1], 0, 4, 0, 4)
+    check_undo_redo(ns, marks[2], 0, 5, 0, 6)
+    check_undo_redo(ns, marks[3], 1, 0, 0, 6)
+    check_undo_redo(ns, marks[4], 1, 5, 0, 6)
+    check_undo_redo(ns, marks[5], 2, 0, 0, 6)
+  end)
+
+  it('substitions over multiple lines with replace in substition #extmarks_sub', function()
+    feed('A<cr>67890<cr>xx<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 1)
+    curbufmeths.set_extmark(ns, marks[2], 0, 2)
+    curbufmeths.set_extmark(ns, marks[3], 0, 4)
+    curbufmeths.set_extmark(ns, marks[4], 1, 0)
+    curbufmeths.set_extmark(ns, marks[5], 2, 0)
+    feed([[:1,2s:3:\r<cr>]])
+    check_undo_redo(ns, marks[1], 0, 1, 0, 1)
+    check_undo_redo(ns, marks[2], 0, 2, 1, 0)
+    check_undo_redo(ns, marks[3], 0, 4, 1, 1)
+    check_undo_redo(ns, marks[4], 1, 0, 2, 0)
+    check_undo_redo(ns, marks[5], 2, 0, 3, 0)
+    feed('u')
+    feed([[:1,2s:3:\rxx<cr>]])
+    eq({1, 3}, curbufmeths.get_extmark_by_id(ns, marks[3]))
+  end)
+
+  it('substitions over multiple lines with replace in substition #extmarks_sub', function()
+    feed('A<cr>x3<cr>xx<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 1, 0)
+    curbufmeths.set_extmark(ns, marks[2], 1, 1)
+    curbufmeths.set_extmark(ns, marks[3], 1, 2)
+    feed([[:2,2s:3:\r<cr>]])
+    check_undo_redo(ns, marks[1], 1, 0, 1, 0)
+    check_undo_redo(ns, marks[2], 1, 1, 2, 0)
+    check_undo_redo(ns, marks[3], 1, 2, 2, 0)
+  end)
+
+  it('substitions over multiple lines with replace in substition #extmarks_sub', function()
+    feed('A<cr>x3<cr>xx<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 1)
+    curbufmeths.set_extmark(ns, marks[2], 0, 2)
+    curbufmeths.set_extmark(ns, marks[3], 0, 4)
+    curbufmeths.set_extmark(ns, marks[4], 1, 1)
+    curbufmeths.set_extmark(ns, marks[5], 2, 0)
+    feed([[:1,2s:3:\r<cr>]])
+    check_undo_redo(ns, marks[1], 0, 1, 0, 1)
+    check_undo_redo(ns, marks[2], 0, 2, 1, 0)
+    check_undo_redo(ns, marks[3], 0, 4, 1, 1)
+    check_undo_redo(ns, marks[4], 1, 1, 3, 0)
+    check_undo_redo(ns, marks[5], 2, 0, 4, 0)
+    feed('u')
+    feed([[:1,2s:3:\rxx<cr>]])
+    check_undo_redo(ns, marks[3], 0, 4, 1, 3)
+  end)
+
+  it('substitions with newline in match and sub, delta is 0 #extmarks_sub', function()
+    feed('A<cr>67890<cr>xx<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 3)
+    curbufmeths.set_extmark(ns, marks[2], 0, 4)
+    curbufmeths.set_extmark(ns, marks[3], 0, 5)
+    curbufmeths.set_extmark(ns, marks[4], 1, 0)
+    curbufmeths.set_extmark(ns, marks[5], 1, 5)
+    curbufmeths.set_extmark(ns, marks[6], 2, 0)
+    feed([[:1,1s:5\n:\r<cr>]])
+    check_undo_redo(ns, marks[1], 0, 3, 0, 3)
+    check_undo_redo(ns, marks[2], 0, 4, 1, 0)
+    check_undo_redo(ns, marks[3], 0, 5, 1, 0)
+    check_undo_redo(ns, marks[4], 1, 0, 1, 0)
+    check_undo_redo(ns, marks[5], 1, 5, 1, 5)
+    check_undo_redo(ns, marks[6], 2, 0, 2, 0)
+  end)
+
+  it('substitions with newline in match and sub, delta > 0 #extmarks_sub', function()
+    feed('A<cr>67890<cr>xx<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 3)
+    curbufmeths.set_extmark(ns, marks[2], 0, 4)
+    curbufmeths.set_extmark(ns, marks[3], 0, 5)
+    curbufmeths.set_extmark(ns, marks[4], 1, 0)
+    curbufmeths.set_extmark(ns, marks[5], 1, 5)
+    curbufmeths.set_extmark(ns, marks[6], 2, 0)
+    feed([[:1,1s:5\n:\r\r<cr>]])
+    check_undo_redo(ns, marks[1], 0, 3, 0, 3)
+    check_undo_redo(ns, marks[2], 0, 4, 2, 0)
+    check_undo_redo(ns, marks[3], 0, 5, 2, 0)
+    check_undo_redo(ns, marks[4], 1, 0, 2, 0)
+    check_undo_redo(ns, marks[5], 1, 5, 2, 5)
+    check_undo_redo(ns, marks[6], 2, 0, 3, 0)
+  end)
+
+  it('substitions with newline in match and sub, delta < 0 #extmarks_sub', function()
+    feed('A<cr>67890<cr>xx<cr>xx<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 3)
+    curbufmeths.set_extmark(ns, marks[2], 0, 4)
+    curbufmeths.set_extmark(ns, marks[3], 0, 5)
+    curbufmeths.set_extmark(ns, marks[4], 1, 0)
+    curbufmeths.set_extmark(ns, marks[5], 1, 5)
+    curbufmeths.set_extmark(ns, marks[6], 2, 1)
+    curbufmeths.set_extmark(ns, marks[7], 3, 0)
+    feed([[:1,2s:5\n.*\n:\r<cr>]])
+    check_undo_redo(ns, marks[1], 0, 3, 0, 3)
+    check_undo_redo(ns, marks[2], 0, 4, 1, 0)
+    check_undo_redo(ns, marks[3], 0, 5, 1, 0)
+    check_undo_redo(ns, marks[4], 1, 0, 1, 0)
+    check_undo_redo(ns, marks[5], 1, 5, 1, 0)
+    check_undo_redo(ns, marks[6], 2, 1, 1, 1)
+    check_undo_redo(ns, marks[7], 3, 0, 2, 0)
+  end)
+
+  it('substitions with backrefs, newline inserted into sub #extmarks_sub', function()
+    feed('A<cr>67890<cr>xx<cr>xx<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 0, 3)
+    curbufmeths.set_extmark(ns, marks[2], 0, 4)
+    curbufmeths.set_extmark(ns, marks[3], 0, 5)
+    curbufmeths.set_extmark(ns, marks[4], 1, 0)
+    curbufmeths.set_extmark(ns, marks[5], 1, 5)
+    curbufmeths.set_extmark(ns, marks[6], 2, 0)
+    feed([[:1,1s:5\(\n\):\0\1<cr>]])
+    check_undo_redo(ns, marks[1], 0, 3, 0, 3)
+    check_undo_redo(ns, marks[2], 0, 4, 2, 0)
+    check_undo_redo(ns, marks[3], 0, 5, 2, 0)
+    check_undo_redo(ns, marks[4], 1, 0, 2, 0)
+    check_undo_redo(ns, marks[5], 1, 5, 2, 5)
+    check_undo_redo(ns, marks[6], 2, 0, 3, 0)
+  end)
+
+  it('substitions a ^ #extmarks_sub', function()
+    curbufmeths.set_extmark(ns, marks[1], 0, 0)
+    curbufmeths.set_extmark(ns, marks[2], 0, 1)
+    feed([[:s:^:x<cr>]])
+    check_undo_redo(ns, marks[1], 0, 0, 0, 1)
+    check_undo_redo(ns, marks[2], 0, 1, 0, 2)
+  end)
+
+  it('using <c-a> without increase in order of magnitude #extmarks_inc_dec', function()
+    -- do_addsub in ops.c
+    feed('ddiabc998xxx<esc>Tc')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    curbufmeths.set_extmark(ns, marks[3], 0, 5)
+    curbufmeths.set_extmark(ns, marks[4], 0, 6)
+    curbufmeths.set_extmark(ns, marks[5], 0, 7)
+    feed('<c-a>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 6)
+    check_undo_redo(ns, marks[3], 0, 5, 0, 6)
+    check_undo_redo(ns, marks[4], 0, 6, 0, 6)
+    check_undo_redo(ns, marks[5], 0, 7, 0, 7)
+  end)
+
+  it('using <c-a> when increase in order of magnitude #extmarks_inc_dec', function()
+    -- do_addsub in ops.c
+    feed('ddiabc999xxx<esc>Tc')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    curbufmeths.set_extmark(ns, marks[3], 0, 5)
+    curbufmeths.set_extmark(ns, marks[4], 0, 6)
+    curbufmeths.set_extmark(ns, marks[5], 0, 7)
+    feed('<c-a>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 7)
+    check_undo_redo(ns, marks[3], 0, 5, 0, 7)
+    check_undo_redo(ns, marks[4], 0, 6, 0, 7)
+    check_undo_redo(ns, marks[5], 0, 7, 0, 8)
+  end)
+
+  it('using <c-a> when negative and without decrease in order of magnitude #extmarks_inc_dec', function()
+    feed('ddiabc-999xxx<esc>T-')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    curbufmeths.set_extmark(ns, marks[3], 0, 6)
+    curbufmeths.set_extmark(ns, marks[4], 0, 7)
+    curbufmeths.set_extmark(ns, marks[5], 0, 8)
+    feed('<c-a>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 7)
+    check_undo_redo(ns, marks[3], 0, 6, 0, 7)
+    check_undo_redo(ns, marks[4], 0, 7, 0, 7)
+    check_undo_redo(ns, marks[5], 0, 8, 0, 8)
+  end)
+
+  it('using <c-a> when negative and decrease in order of magnitude #extmarks_inc_dec', function()
+    feed('ddiabc-1000xxx<esc>T-')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    curbufmeths.set_extmark(ns, marks[3], 0, 7)
+    curbufmeths.set_extmark(ns, marks[4], 0, 8)
+    curbufmeths.set_extmark(ns, marks[5], 0, 9)
+    feed('<c-a>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 7)
+    check_undo_redo(ns, marks[3], 0, 7, 0, 7)
+    check_undo_redo(ns, marks[4], 0, 8, 0, 7)
+    check_undo_redo(ns, marks[5], 0, 9, 0, 8)
+  end)
+
+  it('using <c-x> without decrease in order of magnitude #extmarks_inc_dec', function()
+    -- do_addsub in ops.c
+    feed('ddiabc999xxx<esc>Tc')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    curbufmeths.set_extmark(ns, marks[3], 0, 5)
+    curbufmeths.set_extmark(ns, marks[4], 0, 6)
+    curbufmeths.set_extmark(ns, marks[5], 0, 7)
+    feed('<c-x>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 6)
+    check_undo_redo(ns, marks[3], 0, 5, 0, 6)
+    check_undo_redo(ns, marks[4], 0, 6, 0, 6)
+    check_undo_redo(ns, marks[5], 0, 7, 0, 7)
+  end)
+
+  it('using <c-x> when decrease in order of magnitude #extmarks_inc_dec', function()
+    -- do_addsub in ops.c
+    feed('ddiabc1000xxx<esc>Tc')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    curbufmeths.set_extmark(ns, marks[3], 0, 6)
+    curbufmeths.set_extmark(ns, marks[4], 0, 7)
+    curbufmeths.set_extmark(ns, marks[5], 0, 8)
+    feed('<c-x>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 6)
+    check_undo_redo(ns, marks[3], 0, 6, 0, 6)
+    check_undo_redo(ns, marks[4], 0, 7, 0, 6)
+    check_undo_redo(ns, marks[5], 0, 8, 0, 7)
+  end)
+
+  it('using <c-x> when negative and without increase in order of magnitude #extmarks_inc_dec', function()
+    feed('ddiabc-998xxx<esc>T-')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    curbufmeths.set_extmark(ns, marks[3], 0, 6)
+    curbufmeths.set_extmark(ns, marks[4], 0, 7)
+    curbufmeths.set_extmark(ns, marks[5], 0, 8)
+    feed('<c-x>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 7)
+    check_undo_redo(ns, marks[3], 0, 6, 0, 7)
+    check_undo_redo(ns, marks[4], 0, 7, 0, 7)
+    check_undo_redo(ns, marks[5], 0, 8, 0, 8)
+  end)
+
+  it('using <c-x> when negative and increase in order of magnitude #extmarks_inc_dec', function()
+    feed('ddiabc-999xxx<esc>T-')
+    curbufmeths.set_extmark(ns, marks[1], 0, 2)
+    curbufmeths.set_extmark(ns, marks[2], 0, 3)
+    curbufmeths.set_extmark(ns, marks[3], 0, 6)
+    curbufmeths.set_extmark(ns, marks[4], 0, 7)
+    curbufmeths.set_extmark(ns, marks[5], 0, 8)
+    feed('<c-x>')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 2)
+    check_undo_redo(ns, marks[2], 0, 3, 0, 8)
+    check_undo_redo(ns, marks[3], 0, 6, 0, 8)
+    check_undo_redo(ns, marks[4], 0, 7, 0, 8)
+    check_undo_redo(ns, marks[5], 0, 8, 0, 9)
+  end)
+
+  -- TODO catch exceptions
+  pending('throws consistent error codes #todo', function()
+    local ns_invalid = ns2 + 1
+    rv = curbufmeths.set_extmark(ns_invalid, marks[1], positions[1][1], positions[1][2])
+    rv = curbufmeths.del_extmark(ns_invalid, marks[1])
+    rv = curbufmeths.get_extmarks(ns_invalid, positions[1], positions[2], ALL)
+    rv = curbufmeths.get_extmark_by_id(ns_invalid, marks[1])
+
+  end)
+
+  it('when col = line-length, set the mark on eol #extmarks', function()
+    curbufmeths.set_extmark(ns, marks[1], 0, -1)
+    rv = curbufmeths.get_extmark_by_id(ns, marks[1])
+    eq({0, init_text:len()}, rv)
+    -- Test another
+    curbufmeths.set_extmark(ns, marks[1], 0, -1)
+    rv = curbufmeths.get_extmark_by_id(ns, marks[1])
+    eq({0, init_text:len()}, rv)
+  end)
+
+  it('when col = line-length, set the mark on eol #extmarks', function()
+    local invalid_col = init_text:len() + 1
+    eq({false, "col value outside range"}, meth_pcall(curbufmeths.set_extmark, ns, marks[1], 0, invalid_col))
+  end)
+
+ -- TODO(bfredl): decide what to do with this
+ pending('when line > line, set the mark on end of buffer #extmarks', function()
+    local invalid_col = init_text:len() + 1
+    local invalid_lnum = 3 -- line1 ends in an eol. so line 2 contains a valid position (eol)?
+    curbufmeths.set_extmark(ns, marks[1], invalid_lnum, invalid_col)
+    rv = curbufmeths.get_extmark_by_id(ns, marks[1])
+    eq({2, 1}, rv)
+  end)
+
+  it('bug from check_col in extmark_set #extmarks_sub', function()
+    -- This bug was caused by extmark_set always using
+    -- check_col. check_col always uses the current buffer.
+    -- This wasn't working during undo so we now use
+    -- check_col and check_lnum only when they are required.
+    feed('A<cr>67890<cr>xx<esc>')
+    feed('A<cr>12345<cr>67890<cr>xx<esc>')
+    curbufmeths.set_extmark(ns, marks[1], 3, 4)
+    feed([[:1,5s:5\n:5 <cr>]])
+    check_undo_redo(ns, marks[1], 3, 4, 2, 6)
+  end)
+
+end)
+
+describe('Extmarks buffer api with many marks', function()
+  local ns1
+  local ns2
+  local ns_marks = {}
+  before_each(function()
+    clear()
+    ns1 = request('nvim_create_namespace', "ns1")
+    ns2 = request('nvim_create_namespace', "ns2")
+    ns_marks = {[ns1]={}, [ns2]={}}
+    local lines = {}
+    for i = 1,30 do
+      lines[#lines+1] = string.rep("x ",i)
+    end
+    curbufmeths.set_lines(0, -1, true, lines)
+    local ns = ns1
+    local q = 0
+    for i = 0,29 do
+      for j = 0,i do
+        local id = curbufmeths.set_extmark(ns,0, i,j)
+        eq(nil, ns_marks[ns][id])
+        ok(id > 0)
+        ns_marks[ns][id] = {i,j}
+        ns = ns1+ns2-ns
+        q = q + 1
+      end
+    end
+    eq(233, #ns_marks[ns1])
+    eq(232, #ns_marks[ns2])
+
+  end)
+
+  local function get_marks(ns)
+    local mark_list = curbufmeths.get_extmarks(ns, 0, -1, -1)
+    local marks = {}
+    for _, mark in ipairs(mark_list) do
+      local id, row, col = unpack(mark)
+      eq(nil, marks[id], "duplicate mark")
+      marks[id] = {row,col}
+    end
+    return marks
+  end
+
+  it("can get marks #extmarks", function()
+    eq(ns_marks[ns1], get_marks(ns1))
+    eq(ns_marks[ns2], get_marks(ns2))
+  end)
+
+  it("can clear all marks in ns #extmarks", function()
+    curbufmeths.clear_namespace(ns1, 0, -1)
+    eq({}, get_marks(ns1))
+    eq(ns_marks[ns2], get_marks(ns2))
+    curbufmeths.clear_namespace(ns2, 0, -1)
+    eq({}, get_marks(ns1))
+    eq({}, get_marks(ns2))
+  end)
+
+  it("can clear line range #extmarks", function()
+    curbufmeths.clear_namespace(ns1, 10, 20)
+    for id, mark in pairs(ns_marks[ns1]) do
+      if 10 <= mark[1] and mark[1] < 20 then
+        ns_marks[ns1][id] = nil
+      end
+    end
+    eq(ns_marks[ns1], get_marks(ns1))
+    eq(ns_marks[ns2], get_marks(ns2))
+  end)
+
+  it("can delete line #extmarks", function()
+    feed('10Gdd')
+    for _, marks in pairs(ns_marks) do
+      for id, mark in pairs(marks) do
+        if mark[1] == 9 then
+          marks[id] = {9,0}
+        elseif mark[1] >= 10 then
+          mark[1] = mark[1] - 1
+        end
+      end
+    end
+    eq(ns_marks[ns1], get_marks(ns1))
+    eq(ns_marks[ns2], get_marks(ns2))
+  end)
+
+  it("can delete lines #extmarks", function()
+    feed('10G10dd')
+    for _, marks in pairs(ns_marks) do
+      for id, mark in pairs(marks) do
+        if 9 <= mark[1] and mark[1] < 19 then
+          marks[id] = {9,0}
+        elseif mark[1] >= 19 then
+          mark[1] = mark[1] - 10
+        end
+      end
+    end
+    eq(ns_marks[ns1], get_marks(ns1))
+    eq(ns_marks[ns2], get_marks(ns2))
+  end)
+end)

--- a/test/functional/legacy/046_multi_line_regexps_spec.lua
+++ b/test/functional/legacy/046_multi_line_regexps_spec.lua
@@ -8,22 +8,22 @@ local expect = helpers.expect
 describe('multi-line regexp', function()
   setup(clear)
 
-  it('is working', function()
+  it('is working #fail', function()
     insert([[
-      1 aa
-      bb
-      cc
-      2 dd
-      ee
-      3 ef
-      gh
-      4 ij
-      5 a8
-      8b c9
-      9d
-      6 e7
-      77f
-      xxxxx]])
+1 aa
+bb
+cc
+2 dd
+ee
+3 ef
+gh
+4 ij
+5 a8
+8b c9
+9d
+6 e7
+77f
+xxxxx]])
 
     -- Test if replacing a line break works with a back reference
     feed([[:/^1/,/^2/s/\n\(.\)/ \1/<cr>]])

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -131,7 +131,7 @@ describe(":substitute, inccommand=split", function()
   end)
 end)
 
-describe(":substitute, 'inccommand' preserves", function()
+describe(":substitute, 'inccommand' preserves #inc", function()
   before_each(clear)
 
   it('listed buffers (:ls)', function()
@@ -293,7 +293,7 @@ describe(":substitute, 'inccommand' preserves", function()
 
 end)
 
-describe(":substitute, 'inccommand' preserves undo", function()
+describe(":substitute, 'inccommand' preserves undo #inc", function()
   local cases = { "", "split", "nosplit" }
 
   local substrings = {
@@ -1909,7 +1909,7 @@ describe(":substitute", function()
     clear()
   end)
 
-  it("inccommand=split, highlights multiline substitutions", function()
+  it("inccommand=split, highlights multiline substitutions #inc2", function()
     common_setup(screen, "split", multiline_text)
     feed("gg")
 
@@ -1971,7 +1971,7 @@ describe(":substitute", function()
     ]])
   end)
 
-  it("inccommand=nosplit, highlights multiline substitutions", function()
+  it("inccommand=nosplit, highlights multiline substitutions #inc2", function()
     common_setup(screen, "nosplit", multiline_text)
     feed("gg")
 
@@ -2064,7 +2064,7 @@ describe(":substitute", function()
     ]])
   end)
 
-  it("inccommand=split, with \\zs", function()
+  it("inccommand=split, with \\zs #inc", function()
     common_setup(screen, "split", multiline_text)
     feed("gg")
 
@@ -2088,7 +2088,7 @@ describe(":substitute", function()
     ]])
   end)
 
-  it("inccommand=nosplit, with \\zs", function()
+  it("inccommand=nosplit, with \\zs #inc", function()
     common_setup(screen, "nosplit", multiline_text)
     feed("gg")
 
@@ -2159,7 +2159,7 @@ describe(":substitute", function()
     ]])
   end)
 
-  it("inccommand=split, contraction of lines", function()
+  it("inccommand=split, contraction of lines #inc2", function()
     local text = [[
       T T123 T T123 T2T TT T23423424
       x
@@ -2208,7 +2208,7 @@ describe(":substitute", function()
     ]])
   end)
 
-  it("inccommand=nosplit, contraction of lines", function()
+  it("inccommand=nosplit, contraction of lines #inc2", function()
     local text = [[
       T T123 T T123 T2T TT T23423424
       x

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -817,7 +817,6 @@ describe('ui/mouse/input', function()
       feed_command('syntax match NonText "cats" conceal cchar=X')
       feed_command('syntax match NonText "x" conceal cchar=>')
 
-      -- First column is there to retain the tabs.
       insert([[
       |Section				*t1*
       |			  *t2* *t3* *t4*


### PR DESCRIPTION
These are marks designed for developers who want to build plugins or embed neovim. (they follow all column and line changes)
issue #4816 

- [x] line insert
- [x] line delete
- [x] line join
- [x] line break
- [x] char inserts (WAHOO)
- [x] blockwise char inserts
- [x] char delete
- [x] delete with x
- [x] blockwise char deletes
- [x] char paste
- [x] blockwise char paste
- [x] replace
- [x] blockwise replace
- [x] undo of moved marks (undo of deleted marks is deferred)
- [x] redo
- [x] `:move`
- [x] insert tab
- [x] shiftwidth
- [x] merge undo info where possible
- [x]  test multiwidth insert
- [x] [kbtree](https://github.com/neovim/neovim/pull/5266) merged 
- [x] update since field in api
- [x] docs
- [x] auto-indent
- [x] baisc substitutions
- [x] substitute with backreferences (tentative)
- [x] substitute with newline in pattern and newlin in substition (tentative)
- [x] del_bytes bug
- [x] op_reindent
- [x] use ns pr
- [x] cleanup & refactor

In app visual testing can be done with
```vimL
" Extended marks

function! LoadExtmarks()
  highlight extmark ctermbg=Blue guibg=Blue
  let g:mark_ns = nvim_create_namespace('myplugin')
  function! Testextmark(timer_id)
    " Get all the mark ids
    let a:all_marks = nvim_buf_get_marks(0, g:mark_ns, -1, -1, -1, 0)

    call clearmatches()

    for mark in a:all_marks
      let a:bytes = col([mark[1], mark[2]])
      let a:ma = matchaddpos('extmark', [[mark[1], mark[2]]])
    endfor
    call timer_start(100, 'Testextmark')
  endfunction
  call timer_start(1, 'Testextmark')
endfunction

nnoremap <leader>tm :call LoadExtmarks()<cr>
```