### PR TITLE
TUI: detect background color

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -874,7 +874,7 @@ set_options_default (
 /// @param name The name of the option
 /// @param val The value of the option
 /// @param allocated If true, do not copy default as it was already allocated.
-static void set_string_default(const char *name, char *val, bool allocated)
+void set_string_default(const char *name, char *val, bool allocated)
   FUNC_ATTR_NONNULL_ALL
 {
   int opt_idx = findoption((char_u *)name);

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -4,8 +4,10 @@
 #include "nvim/api/vim.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/ascii.h"
+#include "nvim/charset.h"
 #include "nvim/main.h"
 #include "nvim/misc2.h"
+#include "nvim/option.h"
 #include "nvim/os/os.h"
 #include "nvim/os/input.h"
 #include "nvim/event/rstream.h"
@@ -320,6 +322,66 @@ static bool handle_forced_escape(TermInput *input)
   return false;
 }
 
+static void set_bg_deferred(void **argv)
+{
+  char *bgvalue = argv[0];
+  set_string_default("bg", bgvalue, false);
+  if (!option_was_set((char_u *)"bg")) {
+    set_option_value((char_u *)"bg", 0, (char_u *)bgvalue, 0);
+  }
+}
+
+static bool handle_background_color(TermInput *input)
+{
+  size_t count = 0;
+  size_t component = 0;
+  uint16_t rgb[] = { 0, 0, 0 };
+  uint16_t rgb_max[] = { 0, 0, 0 };
+  bool eat_backslash = false;
+  bool done = false;
+  bool bad = false;
+  if (rbuffer_size(input->read_stream.buffer) >= 9
+      && !rbuffer_cmp(input->read_stream.buffer, "\x1b]11;rgb:", 9)) {
+    rbuffer_consumed(input->read_stream.buffer, 9);
+    RBUFFER_EACH(input->read_stream.buffer, c, i) {
+      count = i + 1;
+      if (eat_backslash) {
+        done = true;
+        break;
+      } else if (c == '\x07') {
+        done = true;
+        break;
+      } else if (c == '\x1b') {
+        eat_backslash = true;
+      } else if (bad) {
+        // ignore
+      } else if (c == '/') {
+        if (component < 3) {
+          component++;
+        }
+      } else if (ascii_isxdigit(c)) {
+        if (component < 3 && rgb_max[component] != 0xffff) {
+          rgb_max[component] = (uint16_t)((rgb_max[component] << 4) | 0xf);
+          rgb[component] = (uint16_t)((rgb[component] << 4) | hex2nr(c));
+        }
+      } else {
+        bad = true;
+      }
+    }
+    rbuffer_consumed(input->read_stream.buffer, count);
+    if (done && !bad && rgb_max[0] && rgb_max[1] && rgb_max[2]) {
+      double r = (double)rgb[0] / (double)rgb_max[0];
+      double g = (double)rgb[1] / (double)rgb_max[1];
+      double b = (double)rgb[2] / (double)rgb_max[2];
+      double luminance = 0.299*r + 0.587*g + 0.114*b; // CCIR 601
+      char *bgvalue = luminance < 0.5 ? "dark" : "light";
+      loop_schedule(&main_loop, event_create(1, set_bg_deferred, 1, bgvalue));
+    }
+    return true;
+  }
+  return false;
+}
+
 static void restart_reading(void **argv);
 
 static void read_cb(Stream *stream, RBuffer *buf, size_t c, void *data,
@@ -351,7 +413,8 @@ static void read_cb(Stream *stream, RBuffer *buf, size_t c, void *data,
   do {
     if (handle_focus_event(input)
         || handle_bracketed_paste(input)
-        || handle_forced_escape(input)) {
+        || handle_forced_escape(input)
+        || handle_background_color(input)) {
       continue;
     }
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -68,6 +68,7 @@ typedef struct {
     int enter_insert_mode, enter_replace_mode, exit_insert_mode;
     int set_rgb_foreground, set_rgb_background;
     int enable_focus_reporting, disable_focus_reporting;
+    int get_bg;
   } unibi_ext;
 } TUIData;
 
@@ -125,6 +126,7 @@ static void terminfo_start(UI *ui)
   data->unibi_ext.exit_insert_mode = -1;
   data->unibi_ext.enable_focus_reporting = -1;
   data->unibi_ext.disable_focus_reporting = -1;
+  data->unibi_ext.get_bg = -1;
   data->out_fd = 1;
   data->out_isatty = os_isatty(data->out_fd);
   // setup unibilium
@@ -140,6 +142,8 @@ static void terminfo_start(UI *ui)
   // Enter alternate screen and clear
   unibi_out(ui, unibi_enter_ca_mode);
   unibi_out(ui, unibi_clear_screen);
+  // Ask the terminal to send us the background color
+  unibi_out(ui, data->unibi_ext.get_bg);
   // Enable bracketed paste
   unibi_out(ui, data->unibi_ext.enable_bracketed_paste);
   // Enable focus reporting
@@ -828,6 +832,8 @@ static void fix_terminfo(TUIData *data)
       "\x1b[?1004h");
   data->unibi_ext.disable_focus_reporting = (int)unibi_add_ext_str(ut, NULL,
       "\x1b[?1004l");
+
+  data->unibi_ext.get_bg = (int)unibi_add_ext_str(ut, NULL, "\x1b]11;?\x07");
 
 #define XTERM_SETAF \
   "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m"

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -370,3 +370,66 @@ describe("tui 't_Co' (terminal colors)", function()
     assert_term_colors("xterm-256color", nil, 256)
   end)
 end)
+
+describe('tui background handling', function()
+  local screen
+
+  before_each(function()
+    helpers.clear()
+    screen = thelpers.screen_setup(0, '["'..helpers.nvim_prog..'", "-u", "NONE", "-i", "NONE", "--cmd", "set noswapfile"]')
+  end)
+
+  local function assert_bg(color, bg)
+    it('handles '..color..' as '..bg, function()
+      thelpers.feed_data('\027]11;rgb:'..color..'\007:echo &background\n')
+      screen:expect(string.format([[
+        {1: }                                                 |
+        ~                                                 |
+        ~                                                 |
+        ~                                                 |
+        [No Name]                                         |
+        %-5s                                             |
+        -- TERMINAL --                                    |
+      ]], bg))
+    end)
+  end
+
+  assert_bg('0000/0000/0000', 'dark')
+  assert_bg('ffff/ffff/ffff', 'light')
+  assert_bg('000/000/000', 'dark')
+  assert_bg('fff/fff/fff', 'light')
+  assert_bg('00/00/00', 'dark')
+  assert_bg('ff/ff/ff', 'light')
+  assert_bg('0/0/0', 'dark')
+  assert_bg('f/f/f', 'light')
+
+  assert_bg('f/0/0', 'dark')
+  assert_bg('0/f/0', 'light')
+  assert_bg('0/0/f', 'dark')
+
+  assert_bg('1/1/1', 'dark')
+  assert_bg('2/2/2', 'dark')
+  assert_bg('3/3/3', 'dark')
+  assert_bg('4/4/4', 'dark')
+  assert_bg('5/5/5', 'dark')
+  assert_bg('6/6/6', 'dark')
+  assert_bg('7/7/7', 'dark')
+  assert_bg('8/8/8', 'light')
+  assert_bg('9/9/9', 'light')
+  assert_bg('a/a/a', 'light')
+  assert_bg('b/b/b', 'light')
+  assert_bg('c/c/c', 'light')
+  assert_bg('d/d/d', 'light')
+  assert_bg('e/e/e', 'light')
+
+  assert_bg('0/e/0', 'light')
+  assert_bg('0/d/0', 'light')
+  assert_bg('0/c/0', 'dark')
+  assert_bg('0/b/0', 'dark')
+
+  assert_bg('f/0/f', 'dark')
+  assert_bg('f/1/f', 'dark')
+  assert_bg('f/2/f', 'dark')
+  assert_bg('f/3/f', 'light')
+  assert_bg('f/4/f', 'light')
+end)


### PR DESCRIPTION
(Also reported as a [vim issue](https://github.com/vim/vim/issues/869), though I have more hope of a fix here.)

Vim's automatic background color detection works in GUI mode, but not in a terminal.

On any xterm-compatible terminal, vim could detect the background color via terminal escapes (documented in http://invisible-island.net/xterm/ctlseqs/ctlseqs.html) and use that to automatically detect whether to use `bg=dark` or `bg=light` (by default or with `:set bg&`).

To detect the background color:
- Include `\e]11;?\a' during terminal initialization.
- Asynchronously, when processing input, watch for the escape sequence `\e]11;COLOR\a` (or equivalent using OSC instead of `\e]` for the escape, and ST or `\e\\` instead of `\a` for the terminator, which the existing terminal escape sequence handling probably already handles).  If the COLOR portion matches `rgb:RRRR/GGGG/BBBB` where R, G, and B are hex digits, then [compute the luminance](https://en.wikipedia.org/wiki/Luma_%28video%29) of the RGB color and classify it as light/dark accordingly.  Note that the color components may have anywhere from one to four hex digits, and require scaling accordingly as values out of 4, 8, 12, or 16 bits.
