### PR TITLE
[RFC] Highlight folded line with syntax

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1390,7 +1390,7 @@ static void win_update(win_T *wp)
        */
       fold_count = foldedCount(wp, lnum, &win_foldinfo);
       if (fold_count != 0) {
-        fold_line(wp, fold_count, &win_foldinfo, lnum, row);
+        win_line(wp, lnum, srow, wp->w_height, mod_top == 0);
         ++row;
         --fold_count;
         wp->w_lines[idx].wl_folded = TRUE;


### PR DESCRIPTION
Hello,

Surprisingly, this one line change enables syntax highlight on folded lines. There's a few more details to take care of, but that's basically it. 
Before proceding to any changes, I'd like to request some input on the following points, and have some tests written.

This would require:
- New option to enable/disable
- (?) New highlight group `FoldedLineNr`
  - if so, new HL_FLAG? (https://github.com/neovim/neovim/blob/master/src/nvim/globals.h#L494)
- (?) New option to compose `Folded` with syntax highlight (`hl_combine_attr()`)
- Define the behavior of `'foldtext'` (or another new option) when this option is used. 
  - is there some text-marker displayed somewhere on this line?
  - at which column? 
    eg with syntax folding, the fold starts at a defined character: `syn region cBlock start="{" end="}" transparent fold`, but could be determined otherwise with `'foldexpr'`
- Refactoring the 2148 lines long `win_line()` method in screen.c, to support the above options.

Personal thoughts:
- I would dislike to create yet another crypticly named option, same goes for highlight groups.
- I wonder if it wouldn't be better to decouple screen updates from syntax highlighting.
- This whole screen.c is the worst code I've ever read.
