### PR TITLE
Add g:ruby_host_prog

### DIFF
--- a/runtime/autoload/provider/ruby.vim
+++ b/runtime/autoload/provider/ruby.vim
@@ -5,7 +5,8 @@ endif
 let g:loaded_ruby_provider = 1
 
 function! provider#ruby#Detect() abort
-  return exepath('neovim-ruby-host')
+  let host_var = get(g:, 'ruby_host_prog', 'neovim-ruby-host')
+  return exepath(host_var)
 endfunction
 
 function! provider#ruby#Prog()

--- a/runtime/autoload/provider/ruby.vim
+++ b/runtime/autoload/provider/ruby.vim
@@ -5,7 +5,8 @@ endif
 let g:loaded_ruby_provider = 1
 
 function! provider#ruby#Detect() abort
-  let host_var = get(g:, 'ruby_host_prog', 'neovim-ruby-host')
+  let ruby_exe = get(g:, 'ruby_host_prog', 'ruby')
+  let host_var = systemlist([ruby_exe,'-rubygems', '-e', 'puts Gem.user_dir'])[0] . join(['','bin','neovim-ruby-host'], '/')
   return exepath(host_var)
 endfunction
 

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -105,6 +105,9 @@ RUBY PROVIDER CONFIGURATION ~
 To disable Ruby support: >
     let g:loaded_ruby_provider = 1
 
+						*g:ruby_host_prog*
+Set `g:ruby_host_prog` to point ruby to a specific neovim-ruby interpreter: >
+    let g:ruby_host_prog = 'path/to/neovim-ruby-host'
 
 ==============================================================================
 Clipboard integration 			      *provider-clipboard* *clipboard*

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -104,7 +104,7 @@ RUBY PROVIDER CONFIGURATION ~
 						*g:loaded_ruby_provider*
 To disable Ruby support: >
     let g:loaded_ruby_provider = 1
-
+<
 						*g:ruby_host_prog*
 Set `g:ruby_host_prog` to point ruby to a specific neovim-ruby interpreter: >
     let g:ruby_host_prog = 'path/to/neovim-ruby-host'


### PR DESCRIPTION
I do not have `neovim-ruby-host` in my PATH, maybe provide a glob var `g:ruby_host_prog` will be better.
