### PR TITLE
[RFC] clipboard: make v:register=='+' when clipboard=unnamed,unnamedplus

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -65,11 +65,10 @@ endif
 let s:clipboard = {}
 
 function! s:clipboard.get(reg)
-  let reg = a:reg == '"' ? '+' : a:reg
-  if s:selections[reg].owner > 0
-    return s:selections[reg].data
+  if s:selections[a:reg].owner > 0
+    return s:selections[a:reg].data
   end
-  return s:try_cmd(s:paste[reg])
+  return s:try_cmd(s:paste[a:reg])
 endfunction
 
 function! s:clipboard.set(lines, regtype, reg)

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5452,7 +5452,7 @@ static yankreg_T *adjust_clipboard_name(int *name, bool quiet, bool writing)
 
     yankreg_T *target;
     if (cb_flags & CB_UNNAMEDPLUS) {
-      *name = cb_flags & CB_UNNAMED ? '"': '+';
+      *name = (cb_flags & CB_UNNAMED && writing) ? '"': '+';
       target = &y_regs[PLUS_REGISTER];
     } else {
       *name = '*';

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -308,6 +308,7 @@ describe('clipboard usage', function()
     end)
 
     it('links the "+ and unnamed registers', function()
+      eq('+', eval('v:register'))
       insert("one two")
       feed('^"+dwdw"+P')
       expect('two')
@@ -335,6 +336,7 @@ describe('clipboard usage', function()
       eq({{'really unnamed', ''}, 'V'}, eval("g:test_clip['*']"))
 
       -- unnamedplus takes predecence when pasting
+      eq('+', eval('v:register'))
       execute("let g:test_clip['+'] = ['the plus','']")
       execute("let g:test_clip['*'] = ['the star','']")
       feed("p")

--- a/test/functional/fixtures/autoload/provider/clipboard.vim
+++ b/test/functional/fixtures/autoload/provider/clipboard.vim
@@ -9,13 +9,12 @@ function! s:methods.get(reg)
   if g:cliperror
     return 0
   end
-  let reg = a:reg == '"' ? '+' : a:reg
   if g:cliplossy
     " behave like pure text clipboard
-    return g:test_clip[reg][0]
+    return g:test_clip[a:reg][0]
   else
     " behave like VIMENC clipboard
-    return g:test_clip[reg]
+    return g:test_clip[a:reg]
   end
 endfunction
 


### PR DESCRIPTION
Vim compat, also fixes bfredl/nvim-miniyank#1
