### PR TITLE
[RFC] vim-patch.sh: use the proper master remote

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -90,9 +90,8 @@ commit_message() {
     "${vim_message}" "${vim_commit_url}"
 }
 
-find_git_remote() {
-  git remote -v \
-    | awk '$2 ~ /github.com[:\/]neovim\/neovim/ && $3 == "(fetch)" {print $1; exit}'
+get_git_remote() {
+  git config branch.master.remote
 }
 
 assign_commit_details() {
@@ -143,7 +142,7 @@ get_vim_patch() {
 
   cd "${NEOVIM_SOURCE_DIR}"
   local git_remote
-  git_remote="$(find_git_remote)"
+  git_remote="$(get_git_remote)"
   local checked_out_branch
   checked_out_branch="$(git rev-parse --abbrev-ref HEAD)"
 
@@ -230,7 +229,7 @@ submit_pr() {
   fi
 
   local git_remote
-  git_remote="$(find_git_remote)"
+  git_remote="$(get_git_remote)"
   local pr_body
   pr_body="$(git log --reverse --format='#### %s%n%n%b%n' "${git_remote}"/master..HEAD)"
   local patches


### PR DESCRIPTION
```
The prior code would choose 'personal' instead of 'upstream':

      $ git remote -v
      personal   https://github.com/neovim/neovim.git (fetch)
      personal   git@github.com:mhinz/neovim.git (push)
      upstream   https://github.com/neovim/neovim.git (fetch)
      upstream   git@github.com:neovim/neovim.git (push)
```
