### PR TITLE
vim-patch:7.4.1491

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -339,10 +339,16 @@ static void shift_block(oparg_T *oap, int amount)
     total += bd.pre_whitesp;     /* all virtual WS up to & incl a split TAB */
     ws_vcol = bd.start_vcol - bd.pre_whitesp;
     if (bd.startspaces) {
-      if (has_mbyte)
-        bd.textstart += (*mb_ptr2len)(bd.textstart);
-      else
-        ++bd.textstart;
+      if (has_mbyte) {
+        if ((*mb_ptr2len)(bd.textstart) == 1) {
+          bd.textstart++;
+        } else {
+          ws_vcol = 0;
+          bd.startspaces = 0;
+        }
+      } else {
+        bd.textstart++;
+      }
     }
     for (; ascii_iswhite(*bd.textstart); ) {
       // TODO: is passing bd.textstart for start of the line OK?

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -33,16 +33,17 @@ SCRIPTS := \
 # Tests using runtest.vim.vim.
 # Keep test_alot*.res as the last one, sort the others.
 NEW_TESTS = \
-	    test_cursor_func.res \
-	    test_hardcopy.res \
-	    test_help_tagjump.res \
-	    test_langmap.res \
-	    test_menu.res \
-	    test_syntax.res \
-	    test_timers.res \
-	    test_unlet.res \
-	    test_viml.res \
-	    test_alot.res
+      test_cursor_func.res \
+      test_hardcopy.res \
+      test_help_tagjump.res \
+      test_langmap.res \
+      test_menu.res \
+      test_syntax.res \
+      test_timers.res \
+      test_unlet.res \
+      test_viml.res \
+      test_visual.res \
+      test_alot.res
 
 SCRIPTS_GUI := test16.out
 

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1,0 +1,18 @@
+" Tests for Visual mode
+if !has('multi_byte')
+  finish
+endif
+scriptencoding utf-8
+
+if !has('visual')
+  finish
+endif
+
+func Test_block_shift_multibyte()
+  split
+  call setline(1, ['xヹxxx', 'ヹxxx'])
+  exe "normal 1G0l\<C-V>jl>"
+  call assert_equal('x	 ヹxxx', getline(1))
+  call assert_equal('	ヹxxx', getline(2))
+  q!
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -208,7 +208,7 @@ static int included_patches[] = {
   // 1494,
   // 1493 NA
   1492,
-  // 1491,
+  1491,
   // 1490 NA
   // 1489 NA
   // 1488 NA


### PR DESCRIPTION
Problem:    Visual-block shift breaks multi-byte characters.
Solution:   Compute column differently. (Yasuhiro Matsumoto) Add a test.

https://github.com/vim/vim/commit/20b4f463f4ab50fa9bcc9838aa94101fa5698125
