### PR TITLE
[RDY] rplugin manifest should live at XDG-style path

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -2,6 +2,9 @@ get_filename_component(BUSTED_DIR ${BUSTED_PRG} PATH)
 set(ENV{PATH} "${BUSTED_DIR}:$ENV{PATH}")
 
 set(ENV{VIMRUNTIME} ${WORKING_DIR}/runtime)
+set(ENV{NVIM_RPLUGIN_MANIFEST} ${WORKING_DIR}/Xtest_rplugin_manifest)
+set(ENV{XDG_CONFIG_HOME} ${WORKING_DIR}/Xtest_xdg/config)
+set(ENV{XDG_DATA_HOME} ${WORKING_DIR}/Xtest_xdg/share)
 
 if(NVIM_PRG)
   set(ENV{NVIM_PROG} "${NVIM_PRG}")
@@ -33,6 +36,9 @@ execute_process(
   ERROR_VARIABLE err
   RESULT_VARIABLE res
   ${EXTRA_ARGS})
+
+file(REMOVE ${WORKING_DIR}/Xtest_rplugin_manifest)
+file(REMOVE_RECURSE ${WORKING_DIR}/Xtest_xdg)
 
 if(NOT res EQUAL 0)
   message(STATUS "Output to stderr:\n${err}")

--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -118,7 +118,38 @@ function! remote#host#RegisterPlugin(host, path, specs) abort
 endfunction
 
 
-function! s:GetManifest() abort
+" Get the path to the rplugin manifest file.
+function! s:GetManifestPath() abort
+  let manifest_base = ''
+
+  if exists('$NVIM_RPLUGIN_MANIFEST')
+    return fnamemodify($NVIM_RPLUGIN_MANIFEST, ':p')
+  endif
+
+  let preferred = has('win32')
+        \ ? ['$LOCALAPPDATA', '~/AppData/Local']
+        \ : ['$XDG_DATA_HOME', '~/.local/share']
+
+  for dest in preferred
+    if dest[0] == '$' && !exists(dest)
+      continue
+    endif
+
+    let dest = fnamemodify(expand(dest), ':p')
+    if !empty(dest) && isdirectory(dest)
+      let dest .= 'nvim/'
+      call mkdir(dest, 'p', 700)
+      let manifest_base = dest
+      break
+    endif
+  endfor
+
+  return manifest_base.'rplugin.vim'
+endfunction
+
+
+" Old manifest file based on known script locations.
+function! s:GetOldManifestPath() abort
   let prefix = exists('$MYVIMRC')
         \ ? $MYVIMRC
         \ : matchstr(get(split(execute('scriptnames'), '\n'), 0, ''), '\f\+$')
@@ -127,9 +158,25 @@ function! s:GetManifest() abort
 endfunction
 
 
+function! s:GetManifest() abort
+  let manifest = s:GetManifestPath()
+
+  if !filereadable(manifest)
+    " Check if an old manifest file exists and move it to the new location.
+    let old_manifest = s:GetOldManifestPath()
+    if filereadable(old_manifest)
+      call rename(old_manifest, manifest)
+    endif
+  endif
+
+  return manifest
+endfunction
+
+
 function! remote#host#LoadRemotePlugins() abort
-  if filereadable(s:GetManifest())
-    exe 'source '.s:GetManifest()
+  let manifest = s:GetManifest()
+  if filereadable(manifest)
+    execute 'source' fnameescape(manifest)
   endif
 endfunction
 
@@ -202,7 +249,7 @@ function! remote#host#UpdateRemotePlugins() abort
     endif
   endfor
   call writefile(commands, s:GetManifest())
-  echomsg printf('remote/host: generated the manifest file in "%s"',
+  echomsg printf('remote/host: generated rplugin manifest: %s',
         \ s:GetManifest())
 endfunction
 

--- a/runtime/doc/remote_plugin.txt
+++ b/runtime/doc/remote_plugin.txt
@@ -93,22 +93,22 @@ approach with |rpcnotify()|, meaning return values or exceptions raised in the
 handler function are ignored.
 
 To test the above plugin, it must be saved in "rplugin/python" in a
-'runtimepath' directory (~/.config/nvim/rplugin/python/limit.py for example). 
-Then, the remote plugin manifest must be generated with 
-`:UpdateRemotePlugins`.
+'runtimepath' directory (~/.config/nvim/rplugin/python/limit.py for example).
+Then, the remote plugin manifest must be generated with
+|:UpdateRemotePlugins|.
 
 ==============================================================================
 4. Remote plugin manifest			    *remote-plugin-manifest*
+						      *:UpdateRemotePlugins*
 
 Just installing remote plugins to "rplugin/{host}" isn't enough for them to be
-automatically loaded when required. You must execute `:UpdateRemotePlugins`
+automatically loaded when required. You must execute |:UpdateRemotePlugins|
 every time a remote plugin is installed, updated, or deleted.
 
-`:UpdateRemotePlugins` generates the remote plugin manifest, a special
+|:UpdateRemotePlugins| generates the remote plugin manifest, a special
 Vimscript file containing declarations for all Vimscript entities
 (commands/autocommands/functions) defined by all remote plugins, with each
-entity associated with the host and plugin path. The manifest is a generated
-extension to the user's vimrc (it even has the vimrc filename prepended).
+entity associated with the host and plugin path.
 
 Manifest declarations are just calls to the `remote#host#RegisterPlugin`
 function, which takes care of bootstrapping the host as soon as the declared
@@ -125,10 +125,20 @@ the example, say the Java plugin is a semantic completion engine for Java code.
 If it defines the autocommand "BufEnter *.java", then the Java host is spawned
 only when Nvim loads a buffer matching "*.java".
 
-If the explicit call to `:UpdateRemotePlugins` seems incovenient, try to see it
+If the explicit call to |:UpdateRemotePlugins| seems incovenient, try to see it
 like this: It's a way to provide IDE capabilities in Nvim while still keeping
 it fast and lightweight for general use. It's also analogous to the |:helptags|
 command.
+
+Unless a path is set in the `$NVIM_RPLUGIN_MANIFEST` environment variable, the
+manifest will be written to a file named `rplugin.vim` in one of the following
+directories:
+
+	Unix ~
+	  $XDG_DATA_HOME/nvim/ or ~/.local/share/nvim/
+
+	Windows ~
+	  $LOCALAPPDATA/nvim/ or ~/AppData/Local/nvim/
 
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -241,6 +241,7 @@ local function clear(...)
         'ASAN_OPTIONS',
         'LD_LIBRARY_PATH', 'PATH',
         'NVIM_LOG_FILE',
+        'NVIM_RPLUGIN_MANIFEST',
       }) do
         env_tbl[k] = os.getenv(k)
       end


### PR DESCRIPTION
Re: [Problem mentioned on reddit](https://www.reddit.com/r/neovim/comments/4s0uhj/how_to_updateremoteplugins_just_once_globally/)

If `$MYVIMRC` and `:scriptnames` yields an unsuitable path, fallback to `$XDG_CONFIG_HOME/nvim/init.vim` if the directory exists.  Otherwise, throw an exception before a useless manifest is written.

This also doesn't allow the manifest to be written in `$VIMRUNTIME` in case the user happens to have write permissions there.

I thought about using `$HOME/.nvim.-rplugin~` as the final fallback instead of throwing an exception, but that felt a little too presumptuous.
