### PR TITLE
Add missing translation from vim-patch:5e9b2fa

### DIFF
--- a/src/nvim/po/ja.po
+++ b/src/nvim/po/ja.po
@@ -5653,7 +5653,7 @@ msgstr "単語 '%.*s' が %s から削除されました"
 #: ../spell.c:8117
 #, c-format
 msgid "Word '%.*s' added to %s"
-msgstr "%s に単語が追加されました"
+msgstr "単語 '%.*s' が %s へ追加されました"
 
 #: ../spell.c:8381
 msgid "E763: Word characters differ between spell files"


### PR DESCRIPTION
The UTF-8 Japanese translation of "Word '%._s' added to %s" was missed
in 404dc5420b7cacd251d15f273bafe59ff008b9a6, which caused a segfault due
to the missing '%._s'.

Closes #5055
