### PR TITLE
[RFC] Travis: Use caching instead of pre-compiled deps for OSX.

### DIFF
--- a/.ci/before_script.sh
+++ b/.ci/before_script.sh
@@ -29,10 +29,10 @@ if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   # That allows to test changing the group of the file by `os_fchown`.
   sudo dscl . -create /Groups/chown_test
   sudo dscl . -append /Groups/chown_test GroupMembership "${USER}"
-else
-  # Compile dependencies.
-  build_deps
 fi
+
+# Compile dependencies.
+build_deps
 
 rm -rf "${LOG_DIR}"
 mkdir -p "${LOG_DIR}"

--- a/.ci/common/build.sh
+++ b/.ci/common/build.sh
@@ -31,7 +31,7 @@ build_deps() {
   # update CMake configuration and update to newer deps versions.
   cd "${DEPS_BUILD_DIR}"
   echo "Configuring with '${DEPS_CMAKE_FLAGS}'."
-  cmake ${DEPS_CMAKE_FLAGS} "${TRAVIS_BUILD_DIR}/third-party/"
+  CC= cmake ${DEPS_CMAKE_FLAGS} "${TRAVIS_BUILD_DIR}/third-party/"
 
   if ! ${MAKE_CMD}; then
     exit 1

--- a/.ci/common/build.sh
+++ b/.ci/common/build.sh
@@ -14,10 +14,15 @@ build_deps() {
   # If there is a valid cache and we're not forced to recompile,
   # use cached third-party dependencies.
   if [[ -f "${CACHE_MARKER}" ]] && [[ "${BUILD_NVIM_DEPS}" != true ]]; then
-    echo "Using third-party dependencies from Travis's cache (last updated: $(stat -c '%y' "${CACHE_MARKER}"))."
+    if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+      local statcmd="stat -f '%Sm'"
+    else
+      local statcmd="stat -c '%y'"
+    fi
+    echo "Using third-party dependencies from Travis's cache (last updated: $(${statcmd} "${CACHE_MARKER}"))."
 
      mkdir -p "$(dirname "${DEPS_BUILD_DIR}")"
-     mv -T "${HOME}/.cache/nvim-deps" "${DEPS_BUILD_DIR}"
+     mv "${HOME}/.cache/nvim-deps" "${DEPS_BUILD_DIR}"
   else
     mkdir -p "${DEPS_BUILD_DIR}"
   fi

--- a/.ci/common/test.sh
+++ b/.ci/common/test.sh
@@ -49,11 +49,11 @@ asan_check() {
 }
 
 run_unittests() {
-  ${MAKE_CMD} unittest
+  ${MAKE_CMD} -C "${BUILD_DIR}" unittest
 }
 
 run_functionaltests() {
-  if ! ${MAKE_CMD} ${FUNCTIONALTEST}; then
+  if ! ${MAKE_CMD} -C "${BUILD_DIR}" ${FUNCTIONALTEST}; then
     asan_check "${LOG_DIR}"
     valgrind_check "${LOG_DIR}"
     exit 1
@@ -63,7 +63,8 @@ run_functionaltests() {
 }
 
 run_oldtests() {
-  if ! make oldtest; then
+  ${MAKE_CMD} -C "${BUILD_DIR}" helptags
+  if ! make -C "${TRAVIS_BUILD_DIR}/src/nvim/testdir"; then
     reset
     asan_check "${LOG_DIR}"
     valgrind_check "${LOG_DIR}"

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -9,6 +9,7 @@ fi
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   brew install gettext
+  brew reinstall -s libtool
 elif [[ "${BUILD_MINGW}" == ON ]]; then
   # TODO: When Travis gets a recent version of Mingw-w64 use packages:
   # binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686 mingw-w64-dev mingw-w64-tools
@@ -16,7 +17,6 @@ elif [[ "${BUILD_MINGW}" == ON ]]; then
   echo "Downloading MinGW..."
   curl -sSL "https://github.com/neovim/deps/raw/master/opt/i686-w64-mingw32-gcc-4.8.0-linux64_rubenvb.tar.xz" \
     | tar xJf - -C "${HOME}/.local"
-  
 fi
 
 # Use default CC to avoid compilation problems when installing Python modules.

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -12,9 +12,6 @@ fi
 # as $USER, while retaining the environment variables defined and belonging
 # to secondary groups given above in usermod.
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
-  # Set up precompiled third-party dependencies.
-  eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) deps-x64"
-
   sudo -E su "${USER}" -c ".ci/run_tests.sh"
 else
   .ci/run_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ oldtest: | nvim helptags
 	+$(SINGLE_MAKE) -C src/nvim/testdir $(MAKEOVERRIDES)
 
 helptags: | nvim
-	+$(BUILD_CMD) -C build runtime/doc/tags
+	+$(BUILD_CMD) -C build helptags
 
 functionaltest: | nvim
 	+$(BUILD_CMD) -C build functionaltest


### PR DESCRIPTION
Since we apparently have caching for OSX builds now, we don't need to use the pre-compiled deps anymore.

After-merge TODO:
- [x] Disable bot-ci deps64 build.
- [x] Remove osx deps and commits from neovim/deps repo.
