### PR TITLE
vim-patch:7.4.1186

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -513,7 +513,7 @@ static int included_patches[] = {
   // 1189 NA
   // 1188 NA
   // 1187 NA
-  // 1186,
+  // 1186 NA
   // 1185 NA
   // 1184 NA
   // 1183 NA


### PR DESCRIPTION
Problem:    Error messages for security context are hard to translate.
Solution:   Use one string with %s. (Ken Takata)

https://github.com/vim/vim/commit/4a1314cb9c1847dc32ceeb3eebeae123ef10b16e

Marked as NA as the patch fixes a string in the SMACK mch_copy_sec function that wasn't ported to neovim, see: 238.
