### PR TITLE
vim-patch:7.4.1273

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -426,7 +426,7 @@ static int included_patches[] = {
   1276,
   // 1275 NA
   // 1274 NA
-  // 1273,
+  // 1273 NA
   // 1272 NA
   1271,
   // 1270 NA


### PR DESCRIPTION
Problem:    assert_false(v:false) still fails.
Solution:   Fix the typo.

https://github.com/vim/vim/commit/c5f98ee987ae0c369867cf6cc581c766d3c0226d

Seems NA as it fixes a typo in VV_FALSE to VVAL_FALSE in assert_bool.
This is implemented differently in neovim, the VV_FALSE isn't used and VVAL_FALSE doesn't exist...
