### PR TITLE
[RFC] vim-patch:7.4.1305

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1389,6 +1389,10 @@ int vim_regcomp_had_eol(void)
   return had_eol;
 }
 
+// variables for parsing reginput
+static int at_start;       // True when on the first character
+static int prev_at_start;  // True when on the second character
+
 /*
  * Parse regular expression, i.e. main body or parenthesized thing.
  *
@@ -1768,6 +1772,7 @@ static char_u *regatom(int *flagp)
   int c;
   char_u          *p;
   int extra = 0;
+  int save_prev_at_start = prev_at_start;
 
   *flagp = WORST;               /* Tentatively. */
 
@@ -2143,17 +2148,21 @@ static char_u *regatom(int *flagp)
           }
           break;
         } else if (c == 'l' || c == 'c' || c == 'v') {
-          if (c == 'l')
+          if (c == 'l') {
             ret = regnode(RE_LNUM);
-          else if (c == 'c')
+            if (save_prev_at_start) {
+              at_start = true;
+            }
+          } else if (c == 'c') {
             ret = regnode(RE_COL);
-          else
+          } else {
             ret = regnode(RE_VCOL);
-          if (ret == JUST_CALC_SIZE)
+          }
+          if (ret == JUST_CALC_SIZE) {
             regsize += 5;
-          else {
-            /* put the number and the optional
-             * comparator after the opcode */
+          } else {
+            // put the number and the optional
+            // comparator after the opcode
             regcode = re_put_uint32(regcode, n);
             *regcode++ = cmp;
           }

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1096,6 +1096,7 @@ static int nfa_regatom(void)
   int startc = -1;
   int endc = -1;
   int oldstartc = -1;
+  int save_prev_at_start = prev_at_start;
 
   c = getchr();
   switch (c) {
@@ -1412,18 +1413,22 @@ static int nfa_regatom(void)
         c = getchr();
       }
       if (c == 'l' || c == 'c' || c == 'v') {
-        if (c == 'l')
-          /* \%{n}l  \%{n}<l  \%{n}>l  */
+        if (c == 'l') {
+          // \%{n}l  \%{n}<l  \%{n}>l
           EMIT(cmp == '<' ? NFA_LNUM_LT :
-              cmp == '>' ? NFA_LNUM_GT : NFA_LNUM);
-        else if (c == 'c')
-          /* \%{n}c  \%{n}<c  \%{n}>c  */
+               cmp == '>' ? NFA_LNUM_GT : NFA_LNUM);
+          if (save_prev_at_start) {
+            at_start = true;
+          }
+        } else if (c == 'c') {
+          // \%{n}c  \%{n}<c  \%{n}>c
           EMIT(cmp == '<' ? NFA_COL_LT :
-              cmp == '>' ? NFA_COL_GT : NFA_COL);
-        else
-          /* \%{n}v  \%{n}<v  \%{n}>v  */
+               cmp == '>' ? NFA_COL_GT : NFA_COL);
+        } else {
+          // \%{n}v  \%{n}<v  \%{n}>v
           EMIT(cmp == '<' ? NFA_VCOL_LT :
-              cmp == '>' ? NFA_VCOL_GT : NFA_VCOL);
+               cmp == '>' ? NFA_VCOL_GT : NFA_VCOL);
+        }
         EMIT(n);
         break;
       } else if (c == '\'' && n == 0) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -388,7 +388,7 @@ static int included_patches[] = {
   // 1308 NA
   // 1307 NA
   // 1306 NA
-  // 1305,
+  1305,
   1304,
   // 1303 NA
   // 1302 NA

--- a/test/functional/legacy/036_regexp_character_classes_spec.lua
+++ b/test/functional/legacy/036_regexp_character_classes_spec.lua
@@ -268,4 +268,15 @@ describe('character classes in regexp', function()
       ABCDEFGHIXYZ
       ABCDEFGHIXYZ]])
   end)
+  it('"\\%1l^#.*" does not match on a line starting with "#". (vim-patch:7.4.1035)', function()
+    source([[
+      1 s/\%#=0\%1l^\t...//g
+      2 s/\%#=1\%2l^\t...//g
+      3 s/\%#=2\%3l^\t...//g
+      4 s/\%#=0\%4l^\t...//g
+      5 s/\%#=1\%5l^\t...//g
+      6 s/\%#=2\%6l^\t...//g]])
+    diff(sixlines(string.sub(punct1, 1)..digits..punct2..upper..punct3..
+      lower..punct4..ctrl2..iso_text))
+  end)
 end)


### PR DESCRIPTION
Problem:    "\%1l^#.*" does not match on a line starting with "#".
Solution:   Do not clear the start-of-line flag. (Christian Brabandt)

https://github.com/vim/vim/commit/7c29f387819b5817b003d2ba73e2b5cf3cb3d0dd
