### PR TITLE
[RFC] vim-patch:7.4.2013, vim-patch:7.4.2014

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2385,6 +2385,7 @@ void set_completion(colnr_T startcol, list_T *list)
   } else {
     ins_complete(Ctrl_N, false);
   }
+  compl_enter_selects = compl_no_insert;
 
   // Lazily show the popup menu, unless we got interrupted.
   if (!compl_interrupted) {
@@ -3989,6 +3990,7 @@ static void ins_compl_insert(void)
   dict_add_nr_str(dict, "info", 0L,
                   EMPTY_IF_NULL(compl_shown_match->cp_text[CPT_INFO]));
   set_vim_var_dict(VV_COMPLETED_ITEM, dict);
+  compl_curr_match = compl_shown_match;
 }
 
 /*

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -4,4 +4,5 @@
 source test_assign.vim
 source test_cursor_func.vim
 source test_menu.vim
+source test_popup.vim
 source test_unlet.vim

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -1,0 +1,30 @@
+" Test for completion menu
+
+function! ComplTest() abort
+  call complete(1, ['source', 'soundfold'])
+  return ''
+endfunction
+
+function! Test() abort
+  call complete(1, ['source', 'soundfold'])
+  return ''
+endfunction
+
+func Test_noinsert_complete()
+  new
+  set completeopt+=noinsert
+  inoremap <F5>  <C-R>=ComplTest()<CR>
+  call feedkeys("i\<F5>soun\<CR>\<CR>\<ESC>.", 'tx')
+  call assert_equal('soundfold', getline(1))
+  call assert_equal('soundfold', getline(2))
+  bwipe!
+
+  new
+  inoremap <F5>  <C-R>=Test()<CR>
+  call feedkeys("i\<F5>\<CR>\<ESC>", 'tx')
+  call assert_equal('source', getline(1))
+  bwipe!
+
+  set completeopt-=noinsert
+  iunmap <F5>
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -75,6 +75,8 @@ static char *features[] = {
 
 // clang-format off
 static int included_patches[] = {
+  2014,
+  2013,
   1973,
   1960,
   1840,


### PR DESCRIPTION
vim-patch:7.4.2013

Problem:    Using "noinsert" in 'completeopt' breaks redo.
Solution:   Set compl_curr_match. (Shougo, closes vim/vim#874)

https://github.com/vim/vim/commit/67081e50616ae9546621072c5eaaa59bd0a4bed7

vim-patch:7.4.2014

Problem:    Using "noinsert" in 'completeopt' does not insert match.
Solution:   Set compl_enter_selects. (Shougo, closes #875)

https://github.com/vim/vim/commit/32b808a4bdf35b0dea63c735702a591e5869fecd
