### PR TITLE
[RFC] vim-patch:7.4.2011, vim-patch:7.4.2012, vim-patch:7.4.2066

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1884,6 +1884,7 @@ getcmdline()			String	return the current command-line
 getcmdpos()			Number	return cursor position in command-line
 getcmdtype()			String	return current command-line type
 getcmdwintype()			String	return current command-line window type
+getcompletion({pat}, {type})	List	list of cmdline completion matches
 getcurpos()			List	position of the cursor
 getcwd([{winnr} [, {tabnr}]])	String	the current working directory
 getfontname([{name}])		String	name of font being used
@@ -3613,6 +3614,49 @@ getcmdwintype()						*getcmdwintype()*
 		Return the current |command-line-window| type. Possible return
 		values are the same as |getcmdtype()|. Returns an empty string
 		when not in the command-line window.
+
+getcompletion({pat}, {type})				*getcompletion()*
+		Return a list of command-line completion matches. {type}
+		specifies what for.  The following completion types are
+		supported:
+
+		augroup		autocmd groups
+		buffer		buffer names
+		behave		:behave suboptions
+		color		color schemes
+		command		Ex command (and arguments)
+		compiler	compilers
+		cscope		|:cscope| suboptions
+		dir		directory names
+		environment	environment variable names
+		event		autocommand events
+		expression	Vim expression
+		file		file and directory names
+		file_in_path	file and directory names in |'path'|
+		filetype	filetype names |'filetype'|
+		function	function name
+		help		help subjects
+		highlight	highlight groups
+		history		:history suboptions
+		locale		locale names (as output of locale -a)
+		mapping		mapping name
+		menu		menus
+		option		options
+		shellcmd	Shell command
+		sign		|:sign| suboptions
+		syntax		syntax file names |'syntax'|
+		syntime		|:syntime| suboptions
+		tag		tags
+		tag_listfiles	tags, file names
+		user		user names
+		var		user variables
+
+		If {pat} is an empty string, then all the matches are returned.
+		Otherwise only items matching {pat} are returned. See
+		|wildcards| for the use of special characters in {pat}.
+
+		If there are no matches, an empty list is returned.  An
+		invalid value for {type} produces an error.
 
 							*getcurpos()*
 getcurpos()	Get the position of the cursor.  This is like getpos('.'), but

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5597,6 +5597,19 @@ int parse_compl_arg(char_u *value, int vallen, int *complp,
   return OK;
 }
 
+int cmdcomplete_str_to_type(char_u *complete_str)
+{
+    int i;
+
+    for (i = 0; command_complete[i].expand != 0; i++) {
+      if (STRCMP(complete_str, command_complete[i].name) == 0) {
+        return command_complete[i].expand;
+      }
+    }
+
+    return EXPAND_NOTHING;
+}
+
 static void ex_colorscheme(exarg_T *eap)
 {
   if (*eap->arg == NUL) {

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -3,5 +3,6 @@
 
 source test_assign.vim
 source test_cursor_func.vim
+source test_cmdline.vim
 source test_menu.vim
 source test_unlet.vim

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1,0 +1,120 @@
+" Tests for editing the command line.
+
+func Test_complete_tab()
+  call writefile(['testfile'], 'Xtestfile')
+  call feedkeys(":e Xtest\t\r", "tx")
+  call assert_equal('testfile', getline(1))
+  call delete('Xtestfile')
+endfunc
+
+func Test_complete_list()
+  " We can't see the output, but at least we check the code runs properly.
+  call feedkeys(":e test\<C-D>\r", "tx")
+  call assert_equal('test', expand('%:t'))
+endfunc
+
+func Test_complete_wildmenu()
+  call writefile(['testfile1'], 'Xtestfile1')
+  call writefile(['testfile2'], 'Xtestfile2')
+  set wildmenu
+  call feedkeys(":e Xtest\t\t\r", "tx")
+  call assert_equal('testfile2', getline(1))
+
+  call delete('Xtestfile1')
+  call delete('Xtestfile2')
+  set nowildmenu
+endfunc
+
+func Test_getcompletion()
+  if !has('cmdline_compl')
+    return
+  endif
+  let groupcount = len(getcompletion('', 'event'))
+  call assert_true(groupcount > 0)
+  let matchcount = len(getcompletion('File', 'event'))
+  call assert_true(matchcount > 0)
+  call assert_true(groupcount > matchcount)
+
+  if has('menu')
+    source $VIMRUNTIME/menu.vim
+    let matchcount = len(getcompletion('', 'menu'))
+    call assert_true(matchcount > 0)
+    call assert_equal(['File.'], getcompletion('File', 'menu'))
+    call assert_true(matchcount > 0)
+    let matchcount = len(getcompletion('File.', 'menu'))
+    call assert_true(matchcount > 0)
+  endif
+
+  let l = getcompletion('v:n', 'var')
+  call assert_true(index(l, 'v:null') >= 0)
+
+  let l = getcompletion('', 'augroup')
+  call assert_true(index(l, 'END') >= 0)
+
+  let l = getcompletion('', 'behave')
+  call assert_true(index(l, 'mswin') >= 0)
+
+  let l = getcompletion('', 'color')
+  call assert_true(index(l, 'default') >= 0)
+
+  let l = getcompletion('', 'command')
+  call assert_true(index(l, 'sleep') >= 0)
+
+  let l = getcompletion('', 'dir')
+  call assert_true(index(l, 'sautest') >= 0)
+
+  let l = getcompletion('exe', 'expression')
+  call assert_true(index(l, 'executable(') >= 0)
+
+  let l = getcompletion('tag', 'function')
+  call assert_true(index(l, 'taglist(') >= 0)
+
+  let l = getcompletion('run', 'file')
+  call assert_true(index(l, 'runtest.vim') >= 0)
+
+  let l = getcompletion('ha', 'filetype')
+  call assert_true(index(l, 'hamster') >= 0)
+
+  let l = getcompletion('z', 'syntax')
+  call assert_true(index(l, 'zimbu') >= 0)
+
+  let l = getcompletion('jikes', 'compiler')
+  call assert_true(index(l, 'jikes') >= 0)
+
+  let l = getcompletion('time', 'option')
+  call assert_true(index(l, 'timeoutlen') >= 0)
+
+  let l = getcompletion('er', 'highlight')
+  call assert_true(index(l, 'ErrorMsg') >= 0)
+
+  " For others test if the name is recognized.
+  let names = ['buffer', 'environment', 'file_in_path',
+	\ 'mapping', 'shellcmd', 'tag', 'tag_listfiles', 'user']
+  if has('cscope')
+    call add(names, 'cscope')
+  endif
+  if has('cmdline_hist')
+    call add(names, 'history')
+  endif
+  if has('gettext')
+    call add(names, 'locale')
+  endif
+  if has('profile')
+    call add(names, 'syntime')
+  endif
+  if has('signs')
+    call add(names, 'sign')
+  endif
+
+  set tags=Xtags
+  call writefile(["!_TAG_FILE_ENCODING\tutf-8\t//", "word\tfile\tcmd"], 'Xtags')
+
+  for name in names
+    let matchcount = len(getcompletion('', name))
+    call assert_true(matchcount >= 0, 'No matches for ' . name)
+  endfor
+
+  call delete('Xtags')
+
+  call assert_fails('call getcompletion("", "burp")', 'E475:')
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -75,6 +75,9 @@ static char *features[] = {
 
 // clang-format off
 static int included_patches[] = {
+  2066,
+  2012,
+  2011,
   1973,
   1960,
   1840,


### PR DESCRIPTION
vim-patch:7.4.2011

Problem:    It is not easy to get a list of command arguments.
Solution:   Add getcompletion(). (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/aa4d73235bf4deee167aa5314b89ae3d3db334b7

vim-patch:7.4.2012

Problem:    Test for getcompletion() does not pass on all systems.
Solution:   Only test what is supported.

https://github.com/vim/vim/commit/0d3e24be5686c0710aa3c6671e4c626d6cb21a5f

vim-patch:7.4.2066

Problem:    getcompletion() not well tested.
Solution:   Add more testing.

https://github.com/vim/vim/commit/c1fb763184c8ae82300357867fa2070aa94366e9
