### PR TITLE
[RFC] vim-patch:7.4.1179

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -520,7 +520,7 @@ static int included_patches[] = {
   // 1182 NA
   1181,
   1180,
-  // 1179,
+  1179,
   1178,
   // 1177 NA
   // 1176 NA


### PR DESCRIPTION
Problem:    test_writefile and test_viml do not delete the tempfile.
Solution:   Delete the tempfile. (Charles Cooper)  Add DeleteTheScript().

https://github.com/vim/vim/commit/f4f79b84a5595c511f6fdbe4e3e1d188d97879a0
