### PR TITLE
[RFC] vim-patch:7.4.1179

### DIFF
--- a/src/nvim/testdir/test_viml.vim
+++ b/src/nvim/testdir/test_viml.vim
@@ -55,15 +55,25 @@ endfunction
 " ExecAsScript - Source a temporary script made from a function.	    {{{2
 "
 " Make a temporary script file from the function a:funcname, ":source" it, and
-" delete it afterwards.
+" delete it afterwards.  However, if an exception is thrown the file may remain,
+" the caller should call DeleteTheScript() afterwards.
+let s:script_name = ''
 function! ExecAsScript(funcname)
     " Make a script from the function passed as argument.
-    let script = MakeScript(a:funcname)
+    let s:script_name = MakeScript(a:funcname)
 
     " Source and delete the script.
-    exec "source" script
-    call delete(script)
+    exec "source" s:script_name
+    call delete(s:script_name)
+    let s:script_name = ''
 endfunction
+
+function! DeleteTheScript()
+    if s:script_name
+	call delete(s:script_name)
+	let s:script_name = ''
+    endif
+endfunc
 
 com! -nargs=1 -bar ExecAsScript call ExecAsScript(<f-args>)
 
@@ -143,6 +153,7 @@ func Test_endwhile_script()
   XpathINIT
   ExecAsScript T1_F
   Xpath 'F'
+  call DeleteTheScript()
 
   try
     ExecAsScript T1_G
@@ -152,6 +163,7 @@ func Test_endwhile_script()
     Xpath 'x'
   endtry
   Xpath 'G'
+  call DeleteTheScript()
 
   call assert_equal('abcFhijxG', g:Xpath)
 endfunc
@@ -260,6 +272,7 @@ function Test_finish()
     XpathINIT
     ExecAsScript T4_F
     Xpath '5'
+    call DeleteTheScript()
 
     call assert_equal('ab3e3b2c25', g:Xpath)
 endfunction

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -520,7 +520,7 @@ static int included_patches[] = {
   // 1182 NA
   1181,
   1180,
-  // 1179,
+  1179,
   1178,
   // 1177 NA
   // 1176 NA

--- a/test/functional/legacy/writefile_spec.lua
+++ b/test/functional/legacy/writefile_spec.lua
@@ -17,6 +17,7 @@ describe('writefile', function()
     execute('bwipeout!')
     execute('$put =readfile(f)')
     execute('1 delete _')
+    execute('call delete(f)')
 
     -- Assert buffer contents.
     expect([[


### PR DESCRIPTION
Problem:    test_writefile and test_viml do not delete the tempfile.
Solution:   Delete the tempfile. (Charles Cooper)  Add DeleteTheScript().

https://github.com/vim/vim/commit/f4f79b84a5595c511f6fdbe4e3e1d188d97879a0
