### PR TITLE
[RFC]vim-patch:7.4.1456

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -246,7 +246,7 @@ static int included_patches[] = {
   // 1459 NA
   // 1458 NA
   // 1457 NA
-  // 1456,
+  // 1456 NA
   // 1455 NA
   // 1454 NA
   // 1453 NA


### PR DESCRIPTION
Problem:    Test 87 fails with Python 3.5.
Solution:   Work around difference. (Taro Muraoka)

https://github.com/vim/vim/commit/29e1951e14907b62797554ad0cc85cbbe75a1be4
