### PR TITLE
man: fix description of XDG_DATA_HOME

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -353,7 +353,7 @@ Like
 but used to store data not generally edited by the user,
 namely swap, backup, and ShaDa files.
 Defaults to
-.Pa ~/.local/share/nvim
+.Pa ~/.local/share
 if not set.
 .It Ev VIMINIT
 A string of Ex commands to be executed at startup.


### PR DESCRIPTION
If not set `XDG_DATA_HOME` is defaulted to `~/.local/share`; `$XDG_DATA_HOME/nvim` is the directory where the data are stored.
