### PR TITLE
[RFC] Remove redundant includes of unistd.h

### DIFF
--- a/src/nvim/os/fileio.c
+++ b/src/nvim/os/fileio.c
@@ -4,7 +4,6 @@
 /// Neovim stuctures for buffer, with autocommands, etc: just fopen/fread/fwrite
 /// replacement.
 
-#include <unistd.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdbool.h>

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -3,7 +3,6 @@
 #include <stddef.h>
 #include <assert.h>
 #include <limits.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
 

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <unistd.h>
 #include <termios.h>
 #include <sys/types.h>
 #include <sys/wait.h>


### PR DESCRIPTION
Removed a couple of unguarded includes of unistd.h (see note in [unix_defs.h](https://github.com/neovim/neovim/blob/2e2b5759cf806b5ca1d4e94316d40acb17878ae2/src/nvim/os/unix_defs.h#L6))
