### PR TITLE
Use -Wimplicit-function-declaration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ MARK_AS_ADVANCED(
 
 # Enable -Wconversion.
 if(NOT MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion -Wimplicit-function-declaration")
 endif()
 
 # gcc 4.0 and better turn on _FORTIFY_SOURCE=2 automatically.  This currently


### PR DESCRIPTION
As noted in #5128, we were using a non-public libuv function.  It just
happened to match the "default" signature C gives undeclared functions,
but we should avoid this.
