### PR TITLE
[WIP] TermCursor* and TermTextChanged* autocmds

### DIFF
--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -80,6 +80,12 @@ return {
     'TermChanged',            -- after changing 'term'
     'TermClose',              -- after the processs exits
     'TermOpen',               -- after opening a terminal buffer
+    'TermCursorHold',         -- cursor idle in a terminal
+    'TermCursorHoldI',        -- cursor idle in a terminal while typing
+    'TermCursorMoved',        -- cursor moved in a terminal
+    'TermCursorMovedI',       -- cursor moved in a terminal while typing
+    'TermTextChanged',        -- terminal contents changed
+    'TermTextChangedI',       -- terminal contents changed while typing
     'TermResponse',           -- after setting "v:termresponse"
     'TextChanged',            -- text was modified
     'TextChangedI',           -- text was modified in Insert mode
@@ -106,5 +112,11 @@ return {
     TabNewEntered=true,
     TermClose=true,
     TermOpen=true,
+    TermCursorHold=true,
+    TermCursorHoldI=true,
+    TermCursorMoved=true,
+    TermCursorMovedI=true,
+    TermTextChanged=true,
+    TermTextChangedI=true,
   },
 }


### PR DESCRIPTION
This adds autocmds and cursor coordinates in terminal buffers:

```
b:terminal_row
b:terminal_col
TermCursorHold
TermCursorHoldI
TermCursorMoved
TermCursorMovedI
TermTextChanged
TermTextChangedI
```

I think these would be useful in scripts.  ATM, these events are fired even when the buffer is not in focus.  The `*I` events are fired while in "insert" mode.  I thought that was the best way to go since the terminal's content and cursor can change while another buffer is active, though it could lead to bad behavior in scripts.

`TextChanged` is still fired when the terminal is in normal mode but focused.  I wasn't sure how to prevent that.

Wanted to get your thoughts on whether the events should only be fired while the terminal's buffer is active.  My reason for letting them fire while not active is that a script could watch the output of a terminal and do something with it while you were working in another buffer.

Note: I didn't know #3445 existed before working on this.
