### PR TITLE
include the apache license's appendix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -181,6 +181,33 @@ Neovim's license follows:
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
 
+	 END OF TERMS AND CONDITIONS
+
+	 APPENDIX: How to apply the Apache License to your work.
+
+	    To apply the Apache License to your work, attach the following
+	    boilerplate notice, with the fields enclosed by brackets "[]"
+	    replaced with your own identifying information. (Don't include
+	    the brackets!)  The text should be enclosed in the appropriate
+	    comment syntax for the file format. We also recommend that a
+	    file or class name and description of purpose be included on the
+	    same "printed page" as the copyright notice for easier
+	    identification within third-party archives.
+
+	 Copyright [yyyy] [name of copyright owner]
+
+	 Licensed under the Apache License, Version 2.0 (the "License");
+	 you may not use this file except in compliance with the License.
+	 You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	 Unless required by applicable law or agreed to in writing, software
+	 distributed under the License is distributed on an "AS IS" BASIS,
+	 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	 See the License for the specific language governing permissions and
+	 limitations under the License.
+
 ====
 
 The above license applies to all parts of Neovim except (1) parts that were


### PR DESCRIPTION
Its technically not an apache 2.0 license without the appendix.

Moreover, the section that defines "Work" states:

```
      "Work" shall mean the work of authorship, whether in Source or
      Object form, made available under the License, as indicated by a
      copyright notice that is included in or attached to the work
      (an example is provided in the Appendix below).
```

With this explicit mention, its odd that we do not include the appendix.
