### PR TITLE
[RFC] vim-patch:7.4.1237

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3166,8 +3166,7 @@ attention_message (
   /* Some of these messages are long to allow translation to
    * other languages. */
   MSG_PUTS(_(
-          "\n(1) Another program may be editing the same file.  If this is the case,\n    be careful not to end up with two different instances of the same\n    file when making changes."));
-  MSG_PUTS(_("  Quit, or continue with caution.\n"));
+          "\n(1) Another program may be editing the same file.  If this is the case,\n    be careful not to end up with two different instances of the same\n    file when making changes.  Quit, or continue with caution.\n"));
   MSG_PUTS(_("(2) An edit session for this file crashed.\n"));
   MSG_PUTS(_("    If this is the case, use \":recover\" or \"vim -r "));
   msg_outtrans(buf->b_fname);

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -465,7 +465,7 @@ static int included_patches[] = {
   // 1240 NA
   // 1239 NA
   // 1238 NA
-  // 1237,
+  1237,
   1236,
   // 1235 NA
   // 1234 NA


### PR DESCRIPTION
#### vim-patch:7.4.1237

Problem:    Can't translate message without adding a line break.
Solution:   Join the two parts of the message.

https://github.com/vim/vim/commit/d9ea9069f5ef5b8b9f9e0d0daecdd124e2dcd818
