### PR TITLE
[RFC] vim-patch:7.4.1607

### DIFF
--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -5,3 +5,4 @@ source test_assign.vim
 source test_cursor_func.vim
 source test_menu.vim
 source test_unlet.vim
+source test_expr.vim

--- a/src/nvim/testdir/test_expr.vim
+++ b/src/nvim/testdir/test_expr.vim
@@ -1,0 +1,23 @@
+" Tests for expressions.
+
+func Test_equal()
+  let base = {}
+  func base.method()
+    return 1
+  endfunc
+  func base.other() dict
+    return 1
+  endfunc
+  let instance = copy(base)
+  call assert_true(base.method == instance.method)
+  call assert_true([base.method] == [instance.method])
+  call assert_true(base.other == instance.other)
+  call assert_true([base.other] == [instance.other])
+
+  call assert_false(base.method == base.other)
+  call assert_false([base.method] == [base.other])
+  call assert_false(base.method == instance.other)
+  call assert_false([base.method] == [instance.other])
+
+  call assert_fails('echo base.method > instance.method')
+endfunc


### PR DESCRIPTION
Problem:    Comparing a function that exists on two dicts is not backwards
            compatible. (Thinca)
Solution:   Only compare the function, not what the partial adds.

https://github.com/vim/vim/commit/f0e86a0dbddc18568910e9e4aaae0cd88ca8087a
