### PR TITLE
Add nvim to ":help +feature-list"

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7441,6 +7441,7 @@ multi_byte		Compiled with support for 'encoding'
 multi_byte_encoding	'encoding' is set to a multi-byte encoding.
 multi_byte_ime		Compiled with support for IME input method.
 multi_lang		Compiled with support for multiple languages.
+nvim			Always True in Neovim.
 ole			Compiled with OLE automation support for Win32.
 path_extra		Compiled with up/downwards search in 'path' and 'tags'
 persistent_undo		Compiled with support for persistent undo history.


### PR DESCRIPTION
Although this is documented in ":help nvim-from-vim", the feature list
is the expected place to find the list of recognized keys for `has()`.

I wasn't sure how to word the description, since they're supposed to be pretty
concise in that section.  I'm open to alternative wording.
