### PR TITLE
[RFC] Add QuickFixLine highlight group

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4883,6 +4883,10 @@ PmenuSbar	Popup menu: scrollbar.
 PmenuThumb	Popup menu: Thumb of the scrollbar.
 							*hl-Question*
 Question	|hit-enter| prompt and yes/no questions
+							*hl-QuickFixLine*
+QuickFixLine	The selected |quickfix| item in the quickfix window.
+		|hl-CursorLine| is combined with this when the cursor is on
+		the currently selected quickfix item.
 							*hl-Search*
 Search		Last search pattern highlighting (see 'hlsearch').
 		Also used for highlighting the current line in the quickfix

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -53,7 +53,7 @@ syn keyword vimGroup contained	Comment Constant String Character Number Boolean 
 syn keyword vimHLGroup contained	ColorColumn Cursor CursorColumn CursorIM CursorLine CursorLineNr DiffAdd DiffChange DiffDelete DiffText Directory ErrorMsg FoldColumn Folded IncSearch LineNr MatchParen Menu ModeMsg MoreMsg NonText Normal Pmenu PmenuSbar PmenuSel PmenuThumb Question Scrollbar Search SignColumn SpecialKey SpellBad SpellCap SpellLocal SpellRare StatusLine StatusLineNC TabLine TabLineFill TabLineSel Title Tooltip VertSplit Visual WarningMsg WildMenu
 syn match vimHLGroup contained	"Conceal"
 syn keyword vimOnlyHLGroup contained	VisualNOS
-syn keyword nvimHLGroup contained	EndOfBuffer TermCursor TermCursorNC
+syn keyword nvimHLGroup contained	EndOfBuffer TermCursor TermCursorNC QuickFixLine
 "}}}2
 syn case match
 " Special Vim Highlighting (not automatic) {{{1

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -442,60 +442,60 @@ EXTERN int no_check_timestamps INIT(= 0);       /* Don't check timestamps */
 typedef enum {
   HLF_8 = 0         /* Meta & special keys listed with ":map", text that is
                        displayed different from what it is */
-  , HLF_EOB         //< after the last line in the buffer
-  , HLF_TERM        //< terminal cursor focused
-  , HLF_TERMNC      //< terminal cursor unfocused
-  , HLF_AT          /* @ characters at end of screen, characters that
-                       don't really exist in the text */
-  , HLF_D           /* directories in CTRL-D listing */
-  , HLF_E           /* error messages */
-  , HLF_I           /* incremental search */
-  , HLF_L           /* last search string */
-  , HLF_M           /* "--More--" message */
-  , HLF_CM          /* Mode (e.g., "-- INSERT --") */
-  , HLF_N           /* line number for ":number" and ":#" commands */
-  , HLF_CLN         /* current line number */
-  , HLF_R           /* return to continue message and yes/no questions */
-  , HLF_S           /* status lines */
-  , HLF_SNC         /* status lines of not-current windows */
-  , HLF_C           /* column to separate vertically split windows */
-  , HLF_T           /* Titles for output from ":set all", ":autocmd" etc. */
-  , HLF_V           /* Visual mode */
-  , HLF_VNC         /* Visual mode, autoselecting and not clipboard owner */
-  , HLF_W           /* warning messages */
-  , HLF_WM          /* Wildmenu highlight */
-  , HLF_FL          /* Folded line */
-  , HLF_FC          /* Fold column */
-  , HLF_ADD         /* Added diff line */
-  , HLF_CHD         /* Changed diff line */
-  , HLF_DED         /* Deleted diff line */
-  , HLF_TXD         /* Text Changed in diff line */
-  , HLF_CONCEAL     /* Concealed text */
-  , HLF_SC          /* Sign column */
-  , HLF_SPB         /* SpellBad */
-  , HLF_SPC         /* SpellCap */
-  , HLF_SPR         /* SpellRare */
-  , HLF_SPL         /* SpellLocal */
-  , HLF_PNI         /* popup menu normal item */
-  , HLF_PSI         /* popup menu selected item */
-  , HLF_PSB         /* popup menu scrollbar */
-  , HLF_PST         /* popup menu scrollbar thumb */
-  , HLF_TP          /* tabpage line */
-  , HLF_TPS         /* tabpage line selected */
-  , HLF_TPF         /* tabpage line filler */
-  , HLF_CUC         /* 'cursurcolumn' */
-  , HLF_CUL         /* 'cursurline' */
-  , HLF_MC          /* 'colorcolumn' */
+  , HLF_EOB         // after the last line in the buffer
+  , HLF_TERM        // terminal cursor focused
+  , HLF_TERMNC      // terminal cursor unfocused
+  , HLF_AT          // @ characters at end of screen, characters that
+                    // don't really exist in the text
+  , HLF_D           // directories in CTRL-D listing
+  , HLF_E           // error messages
+  , HLF_I           // incremental search
+  , HLF_L           // last search string
+  , HLF_M           // "--More--" message
+  , HLF_CM          // Mode (e.g., "-- INSERT --")
+  , HLF_N           // line number for ":number" and ":#" commands
+  , HLF_CLN         // current line number
+  , HLF_R           // return to continue message and yes/no questions
+  , HLF_S           // status lines
+  , HLF_SNC         // status lines of not-current windows
+  , HLF_C           // column to separate vertically split windows
+  , HLF_T           // Titles for output from ":set all", ":autocmd" etc.
+  , HLF_V           // Visual mode
+  , HLF_VNC         // Visual mode, autoselecting and not clipboard owner
+  , HLF_W           // warning messages
+  , HLF_WM          // Wildmenu highlight
+  , HLF_FL          // Folded line
+  , HLF_FC          // Fold column
+  , HLF_ADD         // Added diff line
+  , HLF_CHD         // Changed diff line
+  , HLF_DED         // Deleted diff line
+  , HLF_TXD         // Text Changed in diff line
+  , HLF_CONCEAL     // Concealed text
+  , HLF_SC          // Sign column
+  , HLF_SPB         // SpellBad
+  , HLF_SPC         // SpellCap
+  , HLF_SPR         // SpellRare
+  , HLF_SPL         // SpellLocal
+  , HLF_PNI         // popup menu normal item
+  , HLF_PSI         // popup menu selected item
+  , HLF_PSB         // popup menu scrollbar
+  , HLF_PST         // popup menu scrollbar thumb
+  , HLF_TP          // tabpage line
+  , HLF_TPS         // tabpage line selected
+  , HLF_TPF         // tabpage line filler
+  , HLF_CUC         // 'cursurcolumn'
+  , HLF_CUL         // 'cursurline'
+  , HLF_MC          // 'colorcolumn'
   , HLF_QFL         // selected quickfix line
-  , HLF_COUNT       /* MUST be the last one */
+  , HLF_COUNT       // MUST be the last one
 } hlf_T;
 
 /* The HL_FLAGS must be in the same order as the HLF_ enums!
  * When changing this also adjust the default for 'highlight'. */
-#define HL_FLAGS {'8', '~', 'z', 'Z', '@', 'd', 'e', 'i', 'l', 'm', 'M', 'n', \
-                  'N', 'r', 's', 'S', 'c', 't', 'v', 'V', 'w', 'W', 'f', 'F', \
-                  'A', 'C', 'D', 'T', '-', '>', 'B', 'P', 'R', 'L', '+', '=', \
-                  'x', 'X', '*', '#', '_', '!', '.', 'o', 'q'}
+#define HL_FLAGS { '8', '~', 'z', 'Z', '@', 'd', 'e', 'i', 'l', 'm', 'M', 'n', \
+                   'N', 'r', 's', 'S', 'c', 't', 'v', 'V', 'w', 'W', 'f', 'F', \
+                   'A', 'C', 'D', 'T', '-', '>', 'B', 'P', 'R', 'L', '+', '=', \
+                   'x', 'X', '*', '#', '_', '!', '.', 'o', 'q' }
 
 EXTERN int highlight_attr[HLF_COUNT];       /* Highl. attr for each context. */
 EXTERN int highlight_user[9];                   /* User[1-9] attributes */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -486,6 +486,7 @@ typedef enum {
   , HLF_CUC         /* 'cursurcolumn' */
   , HLF_CUL         /* 'cursurline' */
   , HLF_MC          /* 'colorcolumn' */
+  , HLF_QFL         // selected quickfix line
   , HLF_COUNT       /* MUST be the last one */
 } hlf_T;
 
@@ -494,7 +495,7 @@ typedef enum {
 #define HL_FLAGS {'8', '~', 'z', 'Z', '@', 'd', 'e', 'i', 'l', 'm', 'M', 'n', \
                   'N', 'r', 's', 'S', 'c', 't', 'v', 'V', 'w', 'W', 'f', 'F', \
                   'A', 'C', 'D', 'T', '-', '>', 'B', 'P', 'R', 'L', '+', '=', \
-                  'x', 'X', '*', '#', '_', '!', '.', 'o'}
+                  'x', 'X', '*', '#', '_', '!', '.', 'o', 'q'}
 
 EXTERN int highlight_attr[HLF_COUNT];       /* Highl. attr for each context. */
 EXTERN int highlight_user[9];                   /* User[1-9] attributes */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -246,7 +246,7 @@ typedef struct vimoption {
   "A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal," \
   "B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel," \
   "x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill," \
-  "!:CursorColumn,.:CursorLine,o:ColorColumn"
+  "!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixLine"
 
 /*
  * options[] is initialized here.

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1764,7 +1764,7 @@ void qf_list(exarg_T *eap)
         vim_snprintf((char *)IObuff, IOSIZE, "%2d %s",
             i, (char *)fname);
       msg_outtrans_attr(IObuff, i == qi->qf_lists[qi->qf_curlist].qf_index
-          ? hl_attr(HLF_L) : hl_attr(HLF_D));
+          ? hl_attr(HLF_QFL) : hl_attr(HLF_D));
       if (qfp->qf_lnum == 0)
         IObuff[0] = NUL;
       else if (qfp->qf_col == 0)

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1764,16 +1764,18 @@ void qf_list(exarg_T *eap)
         vim_snprintf((char *)IObuff, IOSIZE, "%2d %s",
             i, (char *)fname);
       msg_outtrans_attr(IObuff, i == qi->qf_lists[qi->qf_curlist].qf_index
-          ? hl_attr(HLF_QFL) : hl_attr(HLF_D));
-      if (qfp->qf_lnum == 0)
+                        ? hl_attr(HLF_QFL) : hl_attr(HLF_D));
+      if (qfp->qf_lnum == 0) {
         IObuff[0] = NUL;
-      else if (qfp->qf_col == 0)
-        sprintf((char *)IObuff, ":%" PRId64, (int64_t)qfp->qf_lnum);
-      else
-        sprintf((char *)IObuff, ":%" PRId64 " col %d",
-                (int64_t)qfp->qf_lnum, qfp->qf_col);
-      sprintf((char *)IObuff + STRLEN(IObuff), "%s:",
-          (char *)qf_types(qfp->qf_type, qfp->qf_nr));
+      } else if (qfp->qf_col == 0) {
+        vim_snprintf((char *)IObuff, IOSIZE, ":%" PRId64,
+                     (int64_t)qfp->qf_lnum);
+      } else {
+        vim_snprintf((char *)IObuff, IOSIZE, ":%" PRId64 " col %d",
+                     (int64_t)qfp->qf_lnum, qfp->qf_col);
+      }
+      vim_snprintf((char *)IObuff + STRLEN(IObuff), IOSIZE, "%s:",
+                   (char *)qf_types(qfp->qf_type, qfp->qf_nr));
       msg_puts_attr(IObuff, hl_attr(HLF_N));
       if (qfp->qf_pattern != NULL) {
         qf_fmt_text(qfp->qf_pattern, IObuff, IOSIZE);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2403,11 +2403,14 @@ win_line (
   if (v != 0)
       line_attr = sign_get_attr((int)v, TRUE);
 
-  /* Highlight the current line in the quickfix window. */
-  if (bt_quickfix(wp->w_buffer) && qf_current_entry(wp) == lnum)
+  // Highlight the current line in the quickfix window.
+  if (bt_quickfix(wp->w_buffer) && qf_current_entry(wp) == lnum) {
     line_attr = hl_attr(HLF_QFL);
-  if (line_attr != 0)
-    area_highlighting = TRUE;
+  }
+
+  if (line_attr != 0) {
+    area_highlighting = true;
+  }
 
   line = ml_get_buf(wp->w_buffer, lnum, FALSE);
   ptr = line;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2405,7 +2405,7 @@ win_line (
 
   /* Highlight the current line in the quickfix window. */
   if (bt_quickfix(wp->w_buffer) && qf_current_entry(wp) == lnum)
-    line_attr = hl_attr(HLF_L);
+    line_attr = hl_attr(HLF_QFL);
   if (line_attr != 0)
     area_highlighting = TRUE;
 
@@ -2624,7 +2624,12 @@ win_line (
    * then. */
   if (wp->w_p_cul && lnum == wp->w_cursor.lnum
       && !(wp == curwin && VIsual_active)) {
-    line_attr = hl_attr(HLF_CUL);
+    if (line_attr != 0 && !(State & INSERT) && bt_quickfix(wp->w_buffer)
+        && qf_current_entry(wp) == lnum) {
+      line_attr = hl_combine_attr(hl_attr(HLF_CUL), line_attr);
+    } else {
+      line_attr = hl_attr(HLF_CUL);
+    }
     area_highlighting = true;
   }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5902,6 +5902,7 @@ static char *highlight_init_both[] =
   "VertSplit    cterm=reverse gui=reverse",
   "WildMenu     ctermbg=Yellow ctermfg=Black guibg=Yellow guifg=Black",
   "default link EndOfBuffer NonText",
+  "default link QuickFixLine Search",
   NULL
 };
 

--- a/test/functional/ui/quickfix_spec.lua
+++ b/test/functional/ui/quickfix_spec.lua
@@ -1,0 +1,196 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear, feed, meths = helpers.clear, helpers.feed, helpers.meths
+local insert, execute = helpers.insert, helpers.execute
+
+
+describe('quickfix selection highlight', function()
+  local screen
+
+  before_each(function()
+    clear()
+
+    screen = Screen.new(25, 10)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [1] = { bold = true, foreground = Screen.colors.Blue },
+      [2] = {reverse = true},
+      [3] = {foreground = Screen.colors.Brown},
+      [4] = {bold = true, reverse = true},
+      [5] = {background = Screen.colors.Green},
+      [6] = {foreground = Screen.colors.Brown, background = Screen.colors.Green},
+      [7] = {background = Screen.colors.Red},
+      [8] = {foreground = Screen.colors.Brown, background = Screen.colors.Red},
+      [9] = {background = Screen.colors.Fuchsia},
+      [10] = {foreground = Screen.colors.Red, background = Screen.colors.Fuchsia},
+      [11] = {foreground = Screen.colors.Red},
+      [12] = {foreground = Screen.colors.Brown, background = Screen.colors.Fuchsia},
+    })
+
+    meths.set_option('errorformat', '%m %l')
+    execute('syntax on')
+    execute('highlight Search guibg=Green')
+
+    insert([[
+    Line 1
+    Line 2
+    Line 3
+    Line 4
+    Line 5
+    ]])
+
+    execute('cad')
+    feed('gg')
+
+    screen:expect([[
+      ^Line 1                   |
+      Line 2                   |
+      Line 3                   |
+      Line 4                   |
+      Line 5                   |
+                               |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      :cad                     |
+    ]])
+  end)
+
+  it('using default Search highlight group', function()
+    execute('copen')
+
+    screen:expect([[
+      Line 1                   |
+      {2:[No Name] [+]            }|
+      {5:^|}{6:1}{5:| Line                 }|
+      |{3:2}| Line                 |
+      |{3:3}| Line                 |
+      |{3:4}| Line                 |
+      |{3:5}| Line                 |
+      ||                       |
+      {4:[Quickfix List]          }|
+      :copen                   |
+    ]])
+
+    execute('cnext')
+
+    screen:expect([[
+      Line 1                   |
+      {2:[No Name] [+]            }|
+      |{3:1}| Line                 |
+      {5:^|}{6:2}{5:| Line                 }|
+      |{3:3}| Line                 |
+      |{3:4}| Line                 |
+      |{3:5}| Line                 |
+      ||                       |
+      {4:[Quickfix List]          }|
+      :cnext                   |
+    ]])
+  end)
+
+  it('using QuickFixLine highlight group', function()
+    execute('highlight QuickFixLine guibg=Red')
+
+    execute('copen')
+
+    screen:expect([[
+      Line 1                   |
+      {2:[No Name] [+]            }|
+      {7:^|}{8:1}{7:| Line                 }|
+      |{3:2}| Line                 |
+      |{3:3}| Line                 |
+      |{3:4}| Line                 |
+      |{3:5}| Line                 |
+      ||                       |
+      {4:[Quickfix List]          }|
+      :copen                   |
+    ]])
+
+    execute('cnext')
+
+    screen:expect([[
+      Line 1                   |
+      {2:[No Name] [+]            }|
+      |{3:1}| Line                 |
+      {7:^|}{8:2}{7:| Line                 }|
+      |{3:3}| Line                 |
+      |{3:4}| Line                 |
+      |{3:5}| Line                 |
+      ||                       |
+      {4:[Quickfix List]          }|
+      :cnext                   |
+    ]])
+  end)
+
+  it('combines with CursorLine', function()
+    execute('set cursorline')
+    execute('highlight QuickFixLine guifg=Red')
+    execute('highlight CursorLine guibg=Fuchsia')
+
+    execute('copen')
+
+    screen:expect([[
+      {9:Line 1                   }|
+      {2:[No Name] [+]            }|
+      {10:^|1| Line                 }|
+      |{3:2}| Line                 |
+      |{3:3}| Line                 |
+      |{3:4}| Line                 |
+      |{3:5}| Line                 |
+      ||                       |
+      {4:[Quickfix List]          }|
+      :copen                   |
+    ]])
+
+    feed('j')
+
+    screen:expect([[
+      {9:Line 1                   }|
+      {2:[No Name] [+]            }|
+      {11:|1| Line                 }|
+      {9:^|}{12:2}{9:| Line                 }|
+      |{3:3}| Line                 |
+      |{3:4}| Line                 |
+      |{3:5}| Line                 |
+      ||                       |
+      {4:[Quickfix List]          }|
+      :copen                   |
+    ]])
+  end)
+
+  it('QuickFixLine background takes precedence over CursorLine', function()
+    execute('set cursorline')
+    execute('highlight QuickFixLine guibg=Red')
+    execute('highlight CursorLine guibg=Fuchsia')
+
+    execute('copen')
+
+    screen:expect([[
+      {9:Line 1                   }|
+      {2:[No Name] [+]            }|
+      {7:^|}{8:1}{7:| Line                 }|
+      |{3:2}| Line                 |
+      |{3:3}| Line                 |
+      |{3:4}| Line                 |
+      |{3:5}| Line                 |
+      ||                       |
+      {4:[Quickfix List]          }|
+      :copen                   |
+    ]])
+
+    feed('j')
+
+    screen:expect([[
+      {9:Line 1                   }|
+      {2:[No Name] [+]            }|
+      {7:|}{8:1}{7:| Line                 }|
+      {9:^|}{12:2}{9:| Line                 }|
+      |{3:3}| Line                 |
+      |{3:4}| Line                 |
+      |{3:5}| Line                 |
+      ||                       |
+      {4:[Quickfix List]          }|
+      :copen                   |
+    ]])
+  end)
+end)


### PR DESCRIPTION
`QuickFixLine` links to `Search` by default.

I couldn't win with clint when it came to `globals.h`.
