### PR TITLE
[WIP] Travis: Don't destroy cache when preparing for build.

### DIFF
--- a/.ci/before_cache.sh
+++ b/.ci/before_cache.sh
@@ -3,6 +3,9 @@
 set -e
 set -o pipefail
 
+CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CI_DIR}/common/commands.sh"
+
 # Don't cache pip's log and selfcheck.
 rm -rf "${HOME}/.cache/pip/log"
 rm -f "${HOME}/.cache/pip/selfcheck.json"
@@ -12,5 +15,5 @@ if [[ -f "${SUCCESS_MARKER}" ]]; then
   rm -rf "${HOME}/.cache/nvim-deps"
   mv "${DEPS_BUILD_DIR}" "${HOME}/.cache/nvim-deps"
   touch "${CACHE_MARKER}"
-  echo "Updated third-party dependencies (timestamp: $(stat -c '%y' "${CACHE_MARKER}"))."
+  echo "Updated third-party dependencies (timestamp: $(statcmd "${CACHE_MARKER}"))."
 fi

--- a/.ci/common/build.sh
+++ b/.ci/common/build.sh
@@ -19,7 +19,7 @@ build_deps() {
     echo "Using third-party dependencies from Travis's cache (last updated: $(${statcmd} "${CACHE_MARKER}"))."
 
      mkdir -p "$(dirname "${DEPS_BUILD_DIR}")"
-     mv "${HOME}/.cache/nvim-deps" "${DEPS_BUILD_DIR}"
+     cp -r "${HOME}/.cache/nvim-deps" "${DEPS_BUILD_DIR}"
   else
     mkdir -p "${DEPS_BUILD_DIR}"
   fi

--- a/.ci/common/build.sh
+++ b/.ci/common/build.sh
@@ -1,3 +1,6 @@
+COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${COMMON_DIR}/commands.sh"
+
 build_deps() {
   if [[ "${BUILD_32BIT}" == ON ]]; then
     DEPS_CMAKE_FLAGS="${DEPS_CMAKE_FLAGS} ${CMAKE_FLAGS_32BIT}"
@@ -11,12 +14,7 @@ build_deps() {
   # If there is a valid cache and we're not forced to recompile,
   # use cached third-party dependencies.
   if [[ -f "${CACHE_MARKER}" ]] && [[ "${BUILD_NVIM_DEPS}" != true ]]; then
-    if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
-      local statcmd="stat -f '%Sm'"
-    else
-      local statcmd="stat -c '%y'"
-    fi
-    echo "Using third-party dependencies from Travis's cache (last updated: $(${statcmd} "${CACHE_MARKER}"))."
+    echo "Using third-party dependencies from Travis's cache (last updated: $(statcmd "${CACHE_MARKER}"))."
 
      mkdir -p "$(dirname "${DEPS_BUILD_DIR}")"
      cp -r "${HOME}/.cache/nvim-deps" "${DEPS_BUILD_DIR}"

--- a/.ci/common/commands.sh
+++ b/.ci/common/commands.sh
@@ -1,0 +1,9 @@
+statcmd() {
+  if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+    local statcmd="stat -f %Sm"
+  else
+    local statcmd="stat -c %y"
+  fi
+
+  ${statcmd} "${@}"
+}


### PR DESCRIPTION
When using mv to set up the Neovim dependencies, the cache is changed when the build fails and requires a rebuild. I noticed that today on a PR build that had some error; the subsequent build had only an empty cache, tried to rebuilt the deps and failed due to https://github.com/neovim/homebrew-neovim/issues/169#issuecomment-237675119. Use cp -r to avoid that.
