### PR TITLE
[RFC] man.vim: default mapping and general improvements

### DIFF
--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -25,7 +25,6 @@ endif
 setlocal buftype=nofile
 setlocal noswapfile
 setlocal bufhidden=hide
-setlocal nobuflisted
 setlocal nomodified
 setlocal readonly
 setlocal nomodifiable

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -17,9 +17,9 @@ if has('vim_starting')
   else
     keepjumps 1
   endif
-  " This is not perfect.See `man glDrawArraysInstanced`. Since the title is
+  " This is not perfect. See `man glDrawArraysInstanced`. Since the title is
   " all caps it is impossible to tell what the original capitilization was.
-  execute 'file '.'man://'.tolower(matchstr(getline(1), '^\S\+'))
+  execute 'file man://'.tolower(matchstr(getline(1), '^\S\+'))
 endif
 
 setlocal buftype=nofile

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -5,6 +5,6 @@ if exists('g:loaded_man')
 endif
 let g:loaded_man = 1
 
-command! -complete=customlist,man#complete -nargs=* Man call man#open_page_command(<f-args>)
+command! -count=0 -complete=customlist,man#complete -nargs=* Man call man#open_page_command(v:count, v:count1, <f-args>)
 
-nnoremap <silent> <Plug>(Man) :<C-U>call man#open_page_mapping(v:count, v:count1, expand('<cWORD>'))<CR>
+nnoremap <silent> <Plug>(Man) :<C-U>call man#open_page_mapping(v:count, v:count1, &filetype ==# 'man' ? expand('<cWORD>') : expand('<cword>'))<CR>

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -12,8 +12,4 @@ nnoremap <silent> <Plug>(Man) :<C-U>call man#open_page(v:count, v:count1, &filet
 augroup man
   autocmd!
   autocmd BufReadCmd man://* call man#read_page(matchstr(expand('<amatch>'), 'man://\zs.*'))
-  " Need this because without it, if you do ':Man printf(3)' and then later,
-  " open a session that contains a buffer named 'man://printf(3)', the buffer
-  " will become listed.
-  autocmd BufEnter man://* set nobuflisted
 augroup END

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -5,6 +5,15 @@ if exists('g:loaded_man')
 endif
 let g:loaded_man = 1
 
-command! -count=0 -complete=customlist,man#complete -nargs=* Man call man#open_page_command(v:count, v:count1, <f-args>)
+command! -count=0 -complete=customlist,man#complete -nargs=* Man call man#open_page(v:count, v:count1, <f-args>)
 
-nnoremap <silent> <Plug>(Man) :<C-U>call man#open_page_mapping(v:count, v:count1, &filetype ==# 'man' ? expand('<cWORD>') : expand('<cword>'))<CR>
+nnoremap <silent> <Plug>(Man) :<C-U>call man#open_page(v:count, v:count1, &filetype ==# 'man' ? expand('<cWORD>') : expand('<cword>'))<CR>
+
+augroup man
+  autocmd!
+  autocmd BufReadCmd man://* call man#read_page(matchstr(expand('<amatch>'), 'man://\zs.*'))
+  " Need this because without it, if you do ':Man printf(3)' and then later,
+  " open a session that contains a buffer named 'man://printf(3)', the buffer
+  " will become listed.
+  autocmd BufEnter man://* set nobuflisted
+augroup END


### PR DESCRIPTION
See https://github.com/neovim/neovim/pull/4449#issuecomment-237809542

All I've done thus far is make `<Plug>(Man)` use `<cword>` for non-man buffers (and some small improvements to other parts of the code), just like `keywordprg` because the syntax is unpredictable. But in man buffers, we use `<cWORD>`. I'm not sure how to continue because I am very unfamiliar with c and it looks like the default `K` mapping is hard coded in c.

Also, was man.vim the only reason `keywordprg` accepted commands? If so, I think we should remove that behaviour.
