### PR TITLE
Ensure a hidden buffer isn't unloaded when using ":quit!"

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5704,8 +5704,8 @@ static void ex_quit(exarg_T *eap)
     if (only_one_window() && (firstwin == lastwin || eap->addr_count == 0)) {
       getout(0);
     }
-    /* close window; may free buffer */
-    win_close(wp, !P_HID(wp->w_buffer) || eap->forceit);
+    // close window; may free buffer
+    win_close(wp, !P_HID(wp->w_buffer) && eap->forceit);
   }
 }
 

--- a/test/functional/ex_cmds/quit_spec.lua
+++ b/test/functional/ex_cmds/quit_spec.lua
@@ -1,5 +1,9 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
+local nvim = helpers.nvim
+local insert = helpers.insert
+local command = helpers.command
+local expect = helpers.expect
 
 describe(':qa', function()
   before_each(function() 
@@ -12,3 +16,31 @@ describe(':qa', function()
   end)
 end)
 
+describe(':q!', function()
+  before_each(clear)
+
+  describe('does not unload hidden buffers', function()
+    local function check_buf_after(...)
+      command('new foo')
+      local buf = helpers.call('bufnr', '')
+      insert('lorem ipsum')
+      for _, v in ipairs({...}) do
+        command(v)
+      end
+      command('split +b' .. buf)
+      expect('lorem ipsum')
+    end
+
+    it('using bufhidden=hide', function()
+      check_buf_after('set bufhidden=hide', 'quit!')
+    end)
+
+    it('using :hide', function()
+      check_buf_after('hide quit!')
+    end)
+
+    it("using 'hidden'", function()
+      check_buf_after('set hidden', 'quit!')
+    end)
+  end)
+end)

--- a/test/functional/legacy/031_close_commands_spec.lua
+++ b/test/functional/legacy/031_close_commands_spec.lua
@@ -52,37 +52,37 @@ describe('Commands that close windows and/or buffers', function()
     execute('1wincmd w')
     expect('testtext 1 1 1')
 
-    -- Test abandoning changed buffer, should be unloaded even when 'hidden' set
+    -- Test abandoning changed buffer, should not be unloaded when 'hidden' set
     execute('set hidden')
     feed('A 1<Esc>:q!<CR>')
     expect('testtext 2 2')
     execute('unhide')
-    expect('testtext 2 2')
+    expect('testtext 1 1 1 1')
 
     -- Test ":hide" hides anyway when 'hidden' not set
     execute('set nohidden')
-    feed('A 2<Esc>:hide<CR>')
-    expect('testtext 3')
+    feed('A 1<Esc>:hide<CR>')
+    expect('testtext 2 2')
 
     -- Test ":edit" failing in modified buffer when 'hidden' not set
-    feed('A 3<Esc>:e Xtest1<CR>')
-    expect('testtext 3 3')
+    feed('A 2<Esc>:e Xtest1<CR>')
+    expect('testtext 2 2 2')
 
     -- Test ":edit" working in modified buffer when 'hidden' set
     execute('set hidden')
     execute('e Xtest1')
-    expect('testtext 1')
+    expect('testtext 1 1 1 1 1')
 
     -- Test ":close" not hiding when 'hidden' not set in modified buffer
     execute('sp Xtest3')
     execute('set nohidden')
     feed('A 3<Esc>:close<CR>')
-    expect('testtext 3 3 3')
+    expect('testtext 1 1 1 1 1')
 
     -- Test ":close!" does hide when 'hidden' not set in modified buffer
     feed('A 3<Esc>:close!<CR>')
     execute('set nohidden')
-    expect('testtext 1')
+    expect('testtext 3 3')
 
     -- Test ":all!" hides changed buffer
     execute('sp Xtest4')


### PR DESCRIPTION
This is going to cause upstream's test31 to fail, which I think is flawed.
I'll bring up the topic on vim_dev.

This is intended to address #5172
