### PR TITLE
[WIP] screen.c refactor

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -151,10 +151,6 @@ EXTERN u8char_T *ScreenLinesC[MAX_MCO];         /* composing characters */
 EXTERN int Screen_mco INIT(= 0);                /* value of p_mco used when
                                                    allocating ScreenLinesC[] */
 
-/* Only used for euc-jp: Second byte of a character that starts with 0x8e.
- * These are single-width. */
-EXTERN schar_T  *ScreenLines2 INIT(= NULL);
-
 EXTERN int screen_Rows INIT(= 0);           /* actual size of ScreenLines[] */
 EXTERN int screen_Columns INIT(= 0);        /* actual size of ScreenLines[] */
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2333,7 +2333,11 @@ static struct VisualPos init_visual(int lnum, win_T* wp) {
   struct VisualPos res = {
     .from = -10, .to = MAXCOL,
     .in_visual = false,
-    .pos = { 0 }
+    .pos = {
+      .lnum = 0L,
+      .col = 0,
+      .coladd = 0
+    }
   };
 
   pos_T *top, *bot;
@@ -3103,15 +3107,10 @@ static int win_line (win_T *wp, linenr_T lnum, int startrow, int endrow, bool no
     if (draw_state == WL_LINE && area_highlighting) {
       /* handle Visual or match highlighting in this line */
       if (vcol == fromcol
-          || (has_mbyte && vcol + 1 == fromcol && n_extra == 0
-              && (*mb_ptr2cells)(ptr) > 1)
-          || ((int)vcol_prev == fromcol_prev
-              && vcol_prev < vcol               /* not at margin */
-              && vcol < tocol))
-        area_attr = attr;                       /* start highlighting */
-      else if (area_attr != 0
-               && (vcol == tocol
-                   || (noinvcur && (colnr_T)vcol == wp->w_virtcol)))
+          || (vcol + 1 == fromcol && n_extra == 0 && (*mb_ptr2cells)(ptr) > 1)
+          || ((int)vcol_prev == fromcol_prev && vcol_prev < vcol && vcol < tocol)) /* not at margin */
+        area_attr = main_attr;                       /* start highlighting */
+      else if (area_attr != 0 && (vcol == tocol || (noinvcur && (colnr_T)vcol == wp->w_virtcol)))
         area_attr = 0;                          /* stop highlighting */
 
       if (!n_extra) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2087,10 +2087,6 @@ static bool character_fits_at_col(int mb_c, int col, win_T* wp) {
     && (*mb_char2cells)(mb_c) == 2);
 }
 
-static int compare_lnum_to_cursor(int lnum, win_T* wp) {
-  return wp->w_cursor.lnum - lnum;
-}
-
 static bool should_conceal_line(win_T* wp, int lnum, bool in_visual_area) {
   return (wp->w_p_cole > 0
     && (wp != curwin || lnum != wp->w_cursor.lnum || conceal_cursor_line(wp))
@@ -2699,7 +2695,7 @@ static int win_line (win_T *wp, linenr_T lnum, int startrow, int endrow, bool no
       main_attr = hl_attr(HLF_V);
     }
   } else if (highlight_match && is_current_window) { // handle 'incsearch' and ":s///c" highlighting
-    int delta = compare_lnum_to_cursor(lnum, curwin);
+    int delta = lnum - wp->w_cursor.lnum;
     if (delta >= 0 && delta <= search_match_lines) {
       fromcol = 0; tocol = MAXCOL;
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2494,7 +2494,7 @@ static int win_line (win_T *wp, linenr_T lnum, int startrow, int endrow, bool no
 
   int fromcol, tocol;                   // start/end of inverting
   int fromcol_prev = -2;                // start of inverting after cursor
-  int noinvcur = FALSE;                 // don't invert the cursor
+  bool noinvcur = false;                // don't invert the cursor
 
   bool lnum_in_visual_area = false;
   pos_T pos;
@@ -2532,12 +2532,12 @@ static int win_line (win_T *wp, linenr_T lnum, int startrow, int endrow, bool no
   int nextline_idx = 0;                 // index in nextline[] where next line starts
   int word_end = 0;                     // last byte with same spell_attr
   int cur_checked_col = 0;              // checked column for current line
-  int extra_check;                      // has syntax or linebreak
+  bool extra_check;                     // has syntax or linebreak
 
   int c = 0;                            // init for GCC
   int mb_l = 1;                         // multi-byte byte length
   int mb_c = 0;                         // decoded multi-byte character
-  int mb_utf8 = FALSE;                  // screen char is UTF-8 char
+  bool mb_utf8 = false;                 // screen char is UTF-8 char
   int u8cc[MAX_MCO];                    // composing UTF-8 chars
 
   int filler_lines;                     // nr of filler lines to be drawn
@@ -2548,10 +2548,7 @@ static int win_line (win_T *wp, linenr_T lnum, int startrow, int endrow, bool no
   int change_end = -1;                  // last col of changed area
   colnr_T trailcol = MAXCOL;            // start of trailing spaces
   bool need_showbreak = false;
-  matchitem_T *cur;                     // points to the match list
-  match_T     *shl;                     // points to search_hl or a match
-  int shl_flag;                         // flag to indicate whether search_hl
-                                        // has been processed or not
+
   int prevcol_hl_flag;                  // flag to indicate whether prevcol
                       // equals startcol of search_hl or one of the matches
 
@@ -2632,6 +2629,7 @@ static int win_line (win_T *wp, linenr_T lnum, int startrow, int endrow, bool no
   extra_check = wp->w_p_lbr;
   if (init_syntax(lnum, wp)) {
     has_syntax = true;
+    extra_check = true;
   } else {
     extra_check = false;
   }
@@ -2649,7 +2647,7 @@ static int win_line (win_T *wp, linenr_T lnum, int startrow, int endrow, bool no
   if (check_can_spell(wp)) {
     /* Prepare for spell checking. */
     has_spell = true;
-    extra_check = TRUE;
+    extra_check = true;
 
     /* Get the start of the next line, so that words that wrap to the next
      * line are found too: "et<line-break>al.".

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -758,7 +758,7 @@ static void win_update(win_T *wp)
             lnumb = wp->w_lines[i].wl_lnum;
             // When there is a fold column it might need updating
             // in the next line ("J" just above an open fold).
-            if (compute_foldcolumn(wp, 0) > 0) {
+            if (foldcolumn_width(wp, 0) > 0) {
               lnumb++;
             }
           }
@@ -1572,7 +1572,7 @@ static void win_draw_end(win_T *wp, int c1, int c2, int row, int endrow, hlf_T h
 {
   int n = 0;
 # define FDC_OFF n
-  int fdc = compute_foldcolumn(wp, 0);
+  int fdc = foldcolumn_width(wp, 0);
 
   if (wp->w_p_rl) {
     // No check for cmdline window: should never be right-left.
@@ -1662,7 +1662,7 @@ static int advance_color_col(int vcol, int **color_cols)
 
 // Compute the width of the foldcolumn.  Based on 'foldcolumn' and how much
 // space is available for window "wp", minus "col".
-static int compute_foldcolumn(win_T *wp, int col)
+static int foldcolumn_width(win_T *wp, int col)
 {
   int fdc = wp->w_p_fdc;
   int wmw = wp == curwin && p_wmw == 0 ? 1 : p_wmw;
@@ -1714,7 +1714,7 @@ static void fold_line(win_T *wp, long fold_count, foldinfo_T *foldinfo, linenr_T
 
   // 2. Add the 'foldcolumn'
   // Reduce the width when there is not enough space.
-  fdc = compute_foldcolumn(wp, col);
+  fdc = foldcolumn_width(wp, col);
   if (fdc > 0) {
     fill_foldcolumn(buf, wp, TRUE, lnum);
     if (wp->w_p_rl) {
@@ -2035,7 +2035,7 @@ fill_foldcolumn (
   int level;
   int first_level;
   int empty;
-  int fdc = compute_foldcolumn(wp, 0);
+  int fdc = foldcolumn_width(wp, 0);
 
   // Init to all spaces.
   memset(p, ' ', (size_t)fdc);

--- a/test/functional/ui/screen_advanced_spec.lua
+++ b/test/functional/ui/screen_advanced_spec.lua
@@ -14,11 +14,12 @@ describe('Screen rendering', function()
     screen:set_default_attr_ids( {
       [1] = {foreground = Screen.colors.Brown},
       [2] = {bold = true, foreground = Screen.colors.Brown},
-      [3] = {foreground = Screen.colors.Message},
+      [3] = {},
+      [4] = {background = Screen.colors.LightGrey},
+      [5] = {background = Screen.colors.LightGrey, bold = true, foreground = Screen.colors.Blue},
+      [6] = {bold = true, foreground = Screen.colors.Blue},
+      [7] = {bold = true}
     })
-  end)
-
-  it('works with number and relative line number', function()
     insert("line 1\n")
     insert("line 2\n")
     insert("line 3\n")
@@ -26,6 +27,9 @@ describe('Screen rendering', function()
     insert("line 5\n")
     insert("line 6")
     feed("gg")
+  end)
+
+  it('works with number and relative line number', function()
     execute('set number')
     screen:expect([[
       {1:  1 }{3:^line 1                              }|
@@ -63,7 +67,79 @@ describe('Screen rendering', function()
     ]])
   end)
 
-  it('works with line-wise visual-mode')
+  it('works with line-wise visual-mode', function()
+    execute('set list listchars=')
+    execute('set lcs+=conceal:.,eol:¬')
+    execute('set lcs+=tab:\\ ,nbsp:―,trail:·')
+    execute('set lcs+=precedes:,extends:')
+
+    screen:expect([[
+      {3:^line 1}{6:¬}{3:                                 }|
+      {3:line 2}{6:¬}{3:                                 }|
+      {3:line 3}{6:¬}{3:                                 }|
+      {3:line 4}{6:¬}{3:                                 }|
+      {3:line 5}{6:¬}{3:                                 }|
+      {3:line 6}{6:¬}{3:                                 }|
+      {3::set lcs+=precedes:,extends:          }|
+    ]])
+
+    feed('V')
+    screen:expect([[
+      {3:^l}{4:ine 1}{5:¬}{3:                                 }|
+      {3:line 2}{6:¬}{3:                                 }|
+      {3:line 3}{6:¬}{3:                                 }|
+      {3:line 4}{6:¬}{3:                                 }|
+      {3:line 5}{6:¬}{3:                                 }|
+      {3:line 6}{6:¬}{3:                                 }|
+      {7:-- VISUAL LINE --}{3:                       }|
+    ]])
+
+    feed('dd<esc>O<esc>45a=<esc>')
+    screen:expect([[
+      {3:========================================}|
+      {3:====^=}{6:¬}{3:                                  }|
+      {3:line 2}{6:¬}{3:                                 }|
+      {3:line 3}{6:¬}{3:                                 }|
+      {3:line 4}{6:¬}{3:                                 }|
+      {3:line 5}{6:¬}{3:                                 }|
+      {3:                                        }|
+    ]])
+
+    execute('set nowrap')
+    feed('ggzl')
+
+    screen:expect([[
+      {6:^}{3:======================================}{6:}|
+      {6:}{3:ne 2}{6:¬}{3:                                  }|
+      {6:}{3:ne 3}{6:¬}{3:                                  }|
+      {6:}{3:ne 4}{6:¬}{3:                                  }|
+      {6:}{3:ne 5}{6:¬}{3:                                  }|
+      {6:}{3:ne 6}{6:¬}{3:                                  }|
+      {3::set nowrap                             }|
+    ]])
+
+    feed('10zl')
+    screen:expect([[
+      {6:^}{3:=================================}{6:¬}{3:     }|
+      {6:}{3:                                       }|
+      {6:}{3:                                       }|
+      {6:}{3:                                       }|
+      {6:}{3:                                       }|
+      {6:}{3:                                       }|
+      {3::set nowrap                             }|
+    ]])
+
+    feed('V')
+    screen:expect([[
+      {6:^}{4:=================================}{5:¬}{3:     }|
+      {6:}{3:                                       }|
+      {6:}{3:                                       }|
+      {6:}{3:                                       }|
+      {6:}{3:                                       }|
+      {6:}{3:                                       }|
+      {7:-- VISUAL LINE --}{3:                       }|
+    ]])
+  end)
 
   it('works with block-wise visual-mode')
 

--- a/test/functional/ui/screen_advanced_spec.lua
+++ b/test/functional/ui/screen_advanced_spec.lua
@@ -1,0 +1,79 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
+local execute = helpers.execute
+
+
+describe('Screen rendering', function()
+  local screen
+  local colors = Screen.colors
+  local hl_colors = {
+    NonText = colors.Blue,
+    Search = colors.Yellow,
+    Message = colors.Red,
+  }
+
+  before_each(function()
+    clear()
+    screen = Screen.new(40, 7)
+    screen:attach()
+    --ignore highligting of ~-lines
+    screen:set_default_attr_ids( {
+      [1] = {foreground = Screen.colors.Brown},
+      [2] = {bold = true, foreground = Screen.colors.Brown},
+      [3] = {foreground = hl_colors.Message},
+    })
+    screen:set_default_attr_ignore( {{bold=true, foreground=hl_colors.NonText}} )
+    insert("line 1\n")
+    insert("line 2\n")
+    insert("line 3\n")
+    insert("line 4\n")
+    insert("line 5\n")
+    insert("line 6")
+    feed("gg")
+  end)
+
+  it('works with line number', function()
+    execute('set number')
+    screen:expect([[
+      {1:  1 }^line 1                              |
+      {1:  2 }line 2                              |
+      {1:  3 }line 3                              |
+      {1:  4 }line 4                              |
+      {1:  5 }line 5                              |
+      {1:  6 }line 6                              |
+      :set number                             |
+    ]])
+  end)
+
+  it('works with relative line number', function()
+    execute('set relativenumber')
+    feed("4gg")
+    screen:expect([[
+      {1:  3 }line 1                              |
+      {1:  2 }line 2                              |
+      {1:  1 }line 3                              |
+      {2:  0 }^line 4                              |
+      {1:  1 }line 5                              |
+      {1:  2 }line 6                              |
+      :set relativenumber                     |
+    ]])
+  end)
+
+  it('works with number + relative line number', function()
+    execute('set number')
+    execute('set relativenumber')
+    feed("4gg")
+    screen:expect([[
+      {1:  3 }line 1                              |
+      {1:  2 }line 2                              |
+      {1:  1 }line 3                              |
+      {2:4   }^line 4                              |
+      {1:  1 }line 5                              |
+      {1:  2 }line 6                              |
+      :set relativenumber                     |
+    ]])
+  end)
+
+end)
+

--- a/test/functional/ui/screen_advanced_spec.lua
+++ b/test/functional/ui/screen_advanced_spec.lua
@@ -6,24 +6,19 @@ local execute = helpers.execute
 
 describe('Screen rendering', function()
   local screen
-  local colors = Screen.colors
-  local hl_colors = {
-    NonText = colors.Blue,
-    Search = colors.Yellow,
-    Message = colors.Red,
-  }
 
   before_each(function()
     clear()
     screen = Screen.new(40, 7)
     screen:attach()
-    --ignore highligting of ~-lines
     screen:set_default_attr_ids( {
       [1] = {foreground = Screen.colors.Brown},
       [2] = {bold = true, foreground = Screen.colors.Brown},
-      [3] = {foreground = hl_colors.Message},
+      [3] = {foreground = Screen.colors.Message},
     })
-    screen:set_default_attr_ignore( {{bold=true, foreground=hl_colors.NonText}} )
+  end)
+
+  it('works with number and relative line number', function()
     insert("line 1\n")
     insert("line 2\n")
     insert("line 3\n")
@@ -31,49 +26,57 @@ describe('Screen rendering', function()
     insert("line 5\n")
     insert("line 6")
     feed("gg")
-  end)
-
-  it('works with line number', function()
     execute('set number')
     screen:expect([[
-      {1:  1 }^line 1                              |
-      {1:  2 }line 2                              |
-      {1:  3 }line 3                              |
-      {1:  4 }line 4                              |
-      {1:  5 }line 5                              |
-      {1:  6 }line 6                              |
-      :set number                             |
+      {1:  1 }{3:^line 1                              }|
+      {1:  2 }{3:line 2                              }|
+      {1:  3 }{3:line 3                              }|
+      {1:  4 }{3:line 4                              }|
+      {1:  5 }{3:line 5                              }|
+      {1:  6 }{3:line 6                              }|
+      {3::set number                             }|
     ]])
-  end)
 
-  it('works with relative line number', function()
+    execute('set nonumber')
     execute('set relativenumber')
     feed("4gg")
     screen:expect([[
-      {1:  3 }line 1                              |
-      {1:  2 }line 2                              |
-      {1:  1 }line 3                              |
-      {2:  0 }^line 4                              |
-      {1:  1 }line 5                              |
-      {1:  2 }line 6                              |
-      :set relativenumber                     |
+      {1:  3 }{3:line 1                              }|
+      {1:  2 }{3:line 2                              }|
+      {1:  1 }{3:line 3                              }|
+      {2:  0 }{3:^line 4                              }|
+      {1:  1 }{3:line 5                              }|
+      {1:  2 }{3:line 6                              }|
+      {3::set relativenumber                     }|
+    ]])
+
+    execute('set number')
+    execute('set relativenumber')
+    screen:expect([[
+      {1:  3 }{3:line 1                              }|
+      {1:  2 }{3:line 2                              }|
+      {1:  1 }{3:line 3                              }|
+      {2:4   }{3:^line 4                              }|
+      {1:  1 }{3:line 5                              }|
+      {1:  2 }{3:line 6                              }|
+      {3::set relativenumber                     }|
     ]])
   end)
 
-  it('works with number + relative line number', function()
-    execute('set number')
-    execute('set relativenumber')
-    feed("4gg")
-    screen:expect([[
-      {1:  3 }line 1                              |
-      {1:  2 }line 2                              |
-      {1:  1 }line 3                              |
-      {2:4   }^line 4                              |
-      {1:  1 }line 5                              |
-      {1:  2 }line 6                              |
-      :set relativenumber                     |
-    ]])
-  end)
+  it('works with line-wise visual-mode')
+
+  it('works with block-wise visual-mode')
+
+  it('works with character-wise visual-mode')
+
+  it('conceals :match matches')
+
+  -- TODO describe sign-column
+  -- TODO describe fold-column
+  -- TODO describe diff-rendering
+  -- TODO describe syntax-rendering
+  -- TODO describe spell-rendering
+  -- TODO describe utf8-rendering
 
 end)
 


### PR DESCRIPTION
Hello,

I was wondering if a PR like this one would have any chance to be merged?
Basically, I just wanted to enable syntax coloring in folded lines, which was a 1-line switch, but the whole rendering part is just impossible to extend in the current state.
Therefore, I've reorganized the monstrosity called `win_line()`.
Main changes:
- Extract unreadable conditions into smaller functions (see example below)
- Macros to abstract away the RtoL & LtoR direction
- Macros/helpers to handle character encoding
- Except for the the line that enables syntax-coloring, it makes zero change to existing functionalities.
- Missing: move logic, initialisation & option-testing from `win_line()` to `win_update()`.
  Eg currently it calculates the columns widths, checks for Visual state, checks &cpo, etc. on each rendered line. And I still don't understand why spelling needs to be embedded in there. 

Example unreadable condition:

``` c
if (c == NUL && (wp->w_p_list
                       || ((fromcol >= 0 || fromcol_prev >= 0)
                           && tocol > vcol
                           && VIsual_mode != Ctrl_V
                           && (
                             wp->w_p_rl ? (col >= 0) :
                             (col < wp->w_width))
                           && !(noinvcur
                                && lnum == wp->w_cursor.lnum
                                && (colnr_T)vcol == wp->w_virtcol)))
                   && lcs_eol_one > 0) {
```

Result: (for the syntax-colored folded lines thing)
The slightly lighter lines are folded lines. The cursor is also on a folded line.
![screenshot from 2016-08-06 06-00-00](https://cloud.githubusercontent.com/assets/1423607/17456172/4eae49e8-5b9c-11e6-8056-c19c8422ebbe.png)
