### PR TITLE
runtime/2html.vim: check for termguicolors.

### DIFF
--- a/runtime/syntax/2html.vim
+++ b/runtime/syntax/2html.vim
@@ -71,7 +71,7 @@ endif
 
 " When not in gui we can only guess the colors.
 " TODO - is this true anymore?
-if has("gui_running")
+if has("gui_running") || has("termguicolors")
   let s:whatterm = "gui"
 else
   let s:whatterm = "cterm"


### PR DESCRIPTION
Before this commit, even when using termguicolors, 2html.vim would try
to guess the colours that should be used based on a builtin palette that
was deemed 'good enough', often resulting in hideous results.

This patch makes 2html check for either `gui_running` or `termguicolors`
before deciding to approximate colorus.