### PR TITLE
[RDY] Windows: Remove use of literal path separators

### DIFF
--- a/.ci/msys_build.bat
+++ b/.ci/msys_build.bat
@@ -13,9 +13,7 @@ set PATH=C:\msys64\mingw%BITS%\bin;C:\Windows\System32;C:\Windows;%PATH%
 mkdir build
 cd build
 cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release .. || goto :error
-:: FIXME(equalsraf): for now just build nvim and copy DLLs.
-:: We can't generate the helptags just yet (#810 fixes this)
-mingw32-make nvim_dll_deps VERBOSE=1 || goto :error
+mingw32-make VERBOSE=1 || goto :error
 bin\nvim --version || goto :error
 cd ..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,14 +14,9 @@ install: []
 build_script:
 - if defined BUILD_DEPS_SCRIPT call %BUILD_DEPS_SCRIPT%
 - call %BUILD_SCRIPT%
-# FIXME(equalsraf): don't generate artifacts until the
-# build script builds the main target, for now pack bin/
-artifacts:
-- path: build/bin
 # Build artifacts
-#- cd build
-#- '"%CPACK%" -G NSIS -C Release'
-#- '"%CPACK%" -G ZIP -C Release'
-#artifacts:
-#- path: build/Neovim.zip
-#- path: build/Neovim.exe
+- cd build
+- '"%CPACK%" -G NSIS -C Release'
+- '"%CPACK%" -G ZIP -C Release'
+artifacts:
+- path: build/Neovim.zip

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -562,11 +562,12 @@ static size_t do_path_expand(garray_T *gap, const char_u *path,
   while (*path_end != NUL) {
     /* May ignore a wildcard that has a backslash before it; it will
      * be removed by rem_backslash() or file_pat_to_reg_pat() below. */
-    if (path_end >= path + wildoff && rem_backslash(path_end))
+    if (path_end >= path + wildoff && rem_backslash(path_end)) {
       *p++ = *path_end++;
-    else if (*path_end == '/') {
-      if (e != NULL)
+    } else if (vim_ispathsep_nocolon(*path_end)) {
+      if (e != NULL) {
         break;
+      }
       s = p + 1;
     } else if (path_end >= path + wildoff
                && (vim_strchr((char_u *)"*?[{~$", *path_end) != NULL
@@ -2099,7 +2100,6 @@ int path_full_dir_name(char *directory, char *buffer, size_t len)
 }
 
 // Append to_append to path with a slash in between.
-// Append to_append to path with a slash in between.
 int append_path(char *path, const char *to_append, size_t max_len)
 {
   size_t current_length = strlen(path);
@@ -2116,7 +2116,7 @@ int append_path(char *path, const char *to_append, size_t max_len)
   }
 
   // Glue both paths with a slash.
-  if (current_length > 0 && path[current_length-1] != '/') {
+  if (current_length > 0 && !vim_ispathsep_nocolon(path[current_length-1])) {
     current_length += 1;  // Count the trailing slash.
 
     // +1 for the NUL at the end.
@@ -2124,7 +2124,7 @@ int append_path(char *path, const char *to_append, size_t max_len)
       return FAIL;
     }
 
-    STRCAT(path, "/");
+    STRCAT(path, PATHSEPSTR);
   }
 
   // +1 for the NUL at the end.


### PR DESCRIPTION
Per #2471, some path handling functions hardcode the UNIX path
separator '/' causing them to fail in Windows.

This issue was breaking helptag generation, the second commit updates Appveyor to build the default build target and collect zip artifacts again.
