### PR TITLE
[RFC] Add if_ruby.txt to doc/help.txt

### DIFF
--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -154,6 +154,7 @@ GUI ~
 Interfaces ~
 |if_cscop.txt|	using Cscope with Vim
 |if_pyth.txt|	Python interface
+|if_ruby.txt|	Ruby interface
 |debugger.txt|	Interface with a debugger
 |sign.txt|	debugging signs
 


### PR DESCRIPTION
For completeness and parity with python docs.
