### PR TITLE
[RFC] man.vim: handle empty identifier from mapping

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -30,10 +30,11 @@ function! man#open_page(count, count1, ...) abort
   if a:0 > 2
     call s:error('too many arguments')
     return
-  elseif a:0 ==# 0
-    call s:error('missing argument')
-    return
   elseif a:0 ==# 1
+    if empty(a:1)
+      call s:error('no identifier under cursor')
+      return
+    endif
     let ref = a:1
   else
     " We combine the name and sect into a manpage reference so that all

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -5,7 +5,7 @@ if exists('g:loaded_man')
 endif
 let g:loaded_man = 1
 
-command! -count=0 -complete=customlist,man#complete -nargs=* Man call man#open_page(v:count, v:count1, <f-args>)
+command! -count=0 -complete=customlist,man#complete -nargs=+ Man call man#open_page(v:count, v:count1, <f-args>)
 
 nnoremap <silent> <Plug>(Man) :<C-U>call man#open_page(v:count, v:count1, &filetype ==# 'man' ? expand('<cWORD>') : expand('<cword>'))<CR>
 


### PR DESCRIPTION
Regression from #5168. I also changed the Man command's nargs to '+' so
that man#open_page does not need to handle 0 arguments, because that
will never occur.
