### PR TITLE
[RFC] Set the default value for 'packpath'

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -521,6 +521,8 @@ static void set_runtimepath_default(void)
 #undef SITE_SIZE
 #undef AFTER_SIZE
   set_string_default("runtimepath", rtp, true);
+  // Make a copy of 'rtp' for 'packpath'
+  set_string_default("packpath", rtp, false);
   xfree(data_dirs);
   xfree(config_dirs);
   xfree(data_home);

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -7,6 +7,7 @@ local execute = helpers.execute
 local clear = helpers.clear
 local eval = helpers.eval
 local eq = helpers.eq
+local neq = helpers.neq
 
 local function init_session(...)
   local args = { helpers.nvim_prog, '-i', 'NONE', '--embed',
@@ -78,6 +79,19 @@ describe('startup defaults', function()
     it('overridden by early `syntax off`', function()
       init_session('-u', 'NORC', '--cmd', 'syntax off')
       eq(0, eval('exists("g:syntax_on")'))
+    end)
+  end)
+
+  describe('packpath', function()
+    it('defaults to &runtimepath', function()
+      eq(meths.get_option('runtimepath'), meths.get_option('packpath'))
+    end)
+
+    it('does not follow modifications to runtimepath', function()
+      meths.command('set runtimepath+=foo')
+      neq(meths.get_option('runtimepath'), meths.get_option('packpath'))
+      meths.command('set packpath+=foo')
+      eq(meths.get_option('runtimepath'), meths.get_option('packpath'))
     end)
   end)
 end)


### PR DESCRIPTION
As noted in “:help 'packpath'”, the default value is supposed to be the
same as that for 'runtimepath'.  This was missed in the original port of
the packages functionality from Vim.

Closes #5193
