### PR TITLE
[RFC] cleanups of screen tests

### DIFF
--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -213,22 +213,22 @@ describe('vim_* functions', function()
       screen = Screen.new(40, 8)
       screen:attach()
       screen:set_default_attr_ids({
+        [0] = {bold=true, foreground=Screen.colors.Blue},
         [1] = {foreground = Screen.colors.White, background = Screen.colors.Red},
         [2] = {bold = true, foreground = Screen.colors.SeaGreen}
       })
-      screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
     end)
 
     it('can show one line', function()
       nvim_async('err_write', 'has bork\n')
       screen:expect([[
         ^                                        |
-        ~                                       |
-        ~                                       |
-        ~                                       |
-        ~                                       |
-        ~                                       |
-        ~                                       |
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
         {1:has bork}                                |
       ]])
     end)
@@ -236,11 +236,11 @@ describe('vim_* functions', function()
     it('shows return prompt when more than &cmdheight lines', function()
       nvim_async('err_write', 'something happened\nvery bad\n')
       screen:expect([[
-        ~                                       |
-        ~                                       |
-        ~                                       |
-        ~                                       |
-        ~                                       |
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
         {1:something happened}                      |
         {1:very bad}                                |
         {2:Press ENTER or type command to continue}^ |
@@ -250,9 +250,9 @@ describe('vim_* functions', function()
     it('shows return prompt after all lines are shown', function()
       nvim_async('err_write', 'FAILURE\nERROR\nEXCEPTION\nTRACEBACK\n')
       screen:expect([[
-        ~                                       |
-        ~                                       |
-        ~                                       |
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
         {1:FAILURE}                                 |
         {1:ERROR}                                   |
         {1:EXCEPTION}                               |
@@ -267,12 +267,12 @@ describe('vim_* functions', function()
       nvim_async('err_write', 'fail\n')
       screen:expect([[
         ^                                        |
-        ~                                       |
-        ~                                       |
-        ~                                       |
-        ~                                       |
-        ~                                       |
-        ~                                       |
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
         {1:very fail}                               |
       ]])
       helpers.wait()
@@ -280,11 +280,11 @@ describe('vim_* functions', function()
       -- shows up to &cmdheight lines
       nvim_async('err_write', 'more fail\ntoo fail\n')
       screen:expect([[
-        ~                                       |
-        ~                                       |
-        ~                                       |
-        ~                                       |
-        ~                                       |
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
         {1:more fail}                               |
         {1:too fail}                                |
         {2:Press ENTER or type command to continue}^ |

--- a/test/functional/eval/execute_spec.lua
+++ b/test/functional/eval/execute_spec.lua
@@ -72,13 +72,13 @@ describe('execute()', function()
   it('silences command run inside', function()
     local screen = Screen.new(20, 5)
     screen:attach()
-    screen:set_default_attr_ignore({{bold=true, foreground=255}})
+    screen:set_default_attr_ids( {[0] = {bold=true, foreground=255}} )
     feed(':let g:mes = execute("echon 42")<CR>')
     screen:expect([[
     ^                    |
-    ~                   |
-    ~                   |
-    ~                   |
+    {0:~                   }|
+    {0:~                   }|
+    {0:~                   }|
                         |
     ]])
     eq('42', eval('g:mes'))

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -137,7 +137,7 @@ describe('timers', function()
   it("doesn't mess up the cmdline", function()
     local screen = Screen.new(40, 6)
     screen:attach()
-    screen:set_default_attr_ignore({{bold=true, foreground=Screen.colors.Blue}})
+    screen:set_default_attr_ids( {[0] = {bold=true, foreground=255}} )
     source([[
       func! MyHandler(timer)
         echo "evil"
@@ -148,10 +148,10 @@ describe('timers', function()
     screen:sleep(200)
     screen:expect([[
                                               |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {0:~                                       }|
+      {0:~                                       }|
+      {0:~                                       }|
+      {0:~                                       }|
       :good^                                   |
     ]])
   end)

--- a/test/functional/ex_cmds/drop_spec.lua
+++ b/test/functional/ex_cmds/drop_spec.lua
@@ -9,8 +9,8 @@ describe(":drop", function()
     clear()
     screen = Screen.new(35, 10)
     screen:attach()
-    screen:set_default_attr_ignore({{bold=true, foreground=Screen.colors.Blue}})
     screen:set_default_attr_ids({
+      [0] = {bold=true, foreground=Screen.colors.Blue},
       [1] = {bold = true, reverse = true},
       [2] = {reverse = true},
       [3] = {bold = true},
@@ -26,13 +26,13 @@ describe(":drop", function()
     execute("drop tmp1.vim")
     screen:expect([[
       ^                                   |
-      ~                                  |
-      ~                                  |
-      ~                                  |
-      ~                                  |
-      ~                                  |
-      ~                                  |
-      ~                                  |
+      {0:~                                  }|
+      {0:~                                  }|
+      {0:~                                  }|
+      {0:~                                  }|
+      {0:~                                  }|
+      {0:~                                  }|
+      {0:~                                  }|
       {1:tmp1.vim                           }|
       "tmp1.vim" [New File]              |
     ]])
@@ -45,13 +45,13 @@ describe(":drop", function()
     execute("drop tmp1")
     screen:expect([[
                     {2:|}^                    |
-      ~             {2:|}~                   |
-      ~             {2:|}~                   |
-      ~             {2:|}~                   |
-      ~             {2:|}~                   |
-      ~             {2:|}~                   |
-      ~             {2:|}~                   |
-      ~             {2:|}~                   |
+      {0:~             }{2:|}{0:~                   }|
+      {0:~             }{2:|}{0:~                   }|
+      {0:~             }{2:|}{0:~                   }|
+      {0:~             }{2:|}{0:~                   }|
+      {0:~             }{2:|}{0:~                   }|
+      {0:~             }{2:|}{0:~                   }|
+      {0:~             }{2:|}{0:~                   }|
       {2:tmp2           }{1:tmp1                }|
       :drop tmp1                         |
     ]])
@@ -65,13 +65,13 @@ describe(":drop", function()
     execute("drop tmp3")
     screen:expect([[
       ^                    {2:|}              |
-      ~                   {2:|}~             |
-      ~                   {2:|}~             |
-      ~                   {2:|}~             |
-      {1:tmp3                }{2:|}~             |
-      ABC                 {2:|}~             |
-      ~                   {2:|}~             |
-      ~                   {2:|}~             |
+      {0:~                   }{2:|}{0:~             }|
+      {0:~                   }{2:|}{0:~             }|
+      {0:~                   }{2:|}{0:~             }|
+      {1:tmp3                }{2:|}{0:~             }|
+      ABC                 {2:|}{0:~             }|
+      {0:~                   }{2:|}{0:~             }|
+      {0:~                   }{2:|}{0:~             }|
       {2:tmp2 [+]             tmp1          }|
       "tmp3" [New File]                  |
     ]])

--- a/test/functional/legacy/packadd_spec.lua
+++ b/test/functional/legacy/packadd_spec.lua
@@ -248,14 +248,13 @@ describe('packadd', function()
       screen = Screen.new(30, 5)
       screen:attach()
       screen:set_default_attr_ids({
+        [0] = {bold=true, foreground=Screen.colors.Blue},
         [1] = {
           foreground = Screen.colors.Black,
           background = Screen.colors.Yellow,
         },
         [2] = {bold = true, reverse = true}
       })
-      local NonText = Screen.colors.Blue
-      screen:set_default_attr_ignore({{}, {bold=true, foreground=NonText}})
 
       execute([[let optdir1 = &packpath . '/pack/mine/opt']])
       execute([[let optdir2 = &packpath . '/pack/candidate/opt']])
@@ -269,32 +268,32 @@ describe('packadd', function()
       feed(':packadd <Tab>')
       screen:expect([=[
                                       |
-        ~                             |
-        ~                             |
+        {0:~                             }|
+        {0:~                             }|
         {1:pluginA}{2:  pluginB  pluginC     }|
         :packadd pluginA^              |
       ]=])
       feed('<Tab>')
       screen:expect([=[
                                       |
-        ~                             |
-        ~                             |
+        {0:~                             }|
+        {0:~                             }|
         {2:pluginA  }{1:pluginB}{2:  pluginC     }|
         :packadd pluginB^              |
       ]=])
       feed('<Tab>')
       screen:expect([=[
                                       |
-        ~                             |
-        ~                             |
+        {0:~                             }|
+        {0:~                             }|
         {2:pluginA  pluginB  }{1:pluginC}{2:     }|
         :packadd pluginC^              |
       ]=])
       feed('<Tab>')
       screen:expect([=[
                                       |
-        ~                             |
-        ~                             |
+        {0:~                             }|
+        {0:~                             }|
         {2:pluginA  pluginB  pluginC     }|
         :packadd ^                     |
       ]=])
@@ -316,32 +315,32 @@ describe('packadd', function()
       feed(':colorscheme <Tab>')
       screen:expect([=[
                                       |
-        ~                             |
-        ~                             |
+        {0:~                             }|
+        {0:~                             }|
         {1:one}{2:  three  two               }|
         :colorscheme one^              |
       ]=])
       feed('<Tab>')
       screen:expect([=[
                                       |
-        ~                             |
-        ~                             |
+        {0:~                             }|
+        {0:~                             }|
         {2:one  }{1:three}{2:  two               }|
         :colorscheme three^            |
       ]=])
       feed('<Tab>')
       screen:expect([=[
                                       |
-        ~                             |
-        ~                             |
+        {0:~                             }|
+        {0:~                             }|
         {2:one  three  }{1:two}{2:               }|
         :colorscheme two^              |
       ]=])
       feed('<Tab>')
       screen:expect([=[
                                       |
-        ~                             |
-        ~                             |
+        {0:~                             }|
+        {0:~                             }|
         {2:one  three  two               }|
         :colorscheme ^                 |
       ]=])

--- a/test/functional/plugin/matchparen_spec.lua
+++ b/test/functional/plugin/matchparen_spec.lua
@@ -16,7 +16,10 @@ describe('matchparen', function()
     reset()
     screen = Screen.new(20,5)
     screen:attach()
-    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
+    screen:set_default_attr_ids( {
+      [0] = {bold=true, foreground=255},
+      [1] = {bold=true},
+    } )
   end)
 
   it('uses correct column after i_<Up>. Vim patch 7.4.1296', function()
@@ -37,7 +40,7 @@ describe('matchparen', function()
       ^                    |
       }                   |
       {1:-- INSERT --}        |
-    ]], {[1] = {bold = true}})    
+    ]])
 
   end)
 end)

--- a/test/functional/terminal/altscreen_spec.lua
+++ b/test/functional/terminal/altscreen_spec.lua
@@ -21,7 +21,7 @@ describe('terminal altscreen', function()
       line7                                             |
       line8                                             |
       {1: }                                                 |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
     enter_altscreen()
     screen:expect([[
@@ -31,7 +31,7 @@ describe('terminal altscreen', function()
                                                         |
                                                         |
       {1: }                                                 |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
     eq(10, curbuf('line_count'))
   end)
@@ -60,7 +60,7 @@ describe('terminal altscreen', function()
         line7                                             |
         line8                                             |
         {1: }                                                 |
-        -- TERMINAL --                                    |
+        {3:-- TERMINAL --}                                    |
       ]])
       feed('<c-\\><c-n>gg')
       screen:expect([[
@@ -86,7 +86,7 @@ describe('terminal altscreen', function()
         line15                                            |
         line16                                            |
         {1: }                                                 |
-        -- TERMINAL --                                    |
+        {3:-- TERMINAL --}                                    |
       ]])
     end)
 
@@ -116,7 +116,7 @@ describe('terminal altscreen', function()
                                                           |
         rows: 4, cols: 50                                 |
         {1: }                                                 |
-        -- TERMINAL --                                    |
+        {3:-- TERMINAL --}                                    |
       ]])
     end
 
@@ -149,7 +149,7 @@ describe('terminal altscreen', function()
           line5                                             |
           line6                                             |
           line7                                             |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
       end)
     end)

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -21,11 +21,11 @@ describe('terminal buffer', function()
       feed('<c-\\><c-n>:set bufhidden=wipe<cr>:enew<cr>')
       screen:expect([[
         ^                                                  |
-        ~                                                 |
-        ~                                                 |
-        ~                                                 |
-        ~                                                 |
-        ~                                                 |
+        {4:~                                                 }|
+        {4:~                                                 }|
+        {4:~                                                 }|
+        {4:~                                                 }|
+        {4:~                                                 }|
         :enew                                             |
       ]])
     end)
@@ -34,11 +34,11 @@ describe('terminal buffer', function()
       feed(':bnext:l<esc>')
       screen:expect([[
         ^                                                  |
-        ~                                                 |
-        ~                                                 |
-        ~                                                 |
-        ~                                                 |
-        ~                                                 |
+        {4:~                                                 }|
+        {4:~                                                 }|
+        {4:~                                                 }|
+        {4:~                                                 }|
+        {4:~                                                 }|
                                                           |
       ]])
     end)
@@ -78,7 +78,7 @@ describe('terminal buffer', function()
                                                         |
                                                         |
       ^                                                  |
-      E21: Cannot make changes, 'modifiable' is off     |
+      {8:E21: Cannot make changes, 'modifiable' is off}     |
     ]])
   end)
 
@@ -138,21 +138,21 @@ describe('terminal buffer', function()
     feed('<c-\\><c-n>:bd!<cr>')
     screen:expect([[
       ^                                                  |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
       :bd!                                              |
     ]])
     execute('bnext')
     screen:expect([[
       ^                                                  |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
       :bnext                                            |
     ]])
   end)
@@ -180,8 +180,8 @@ describe('terminal buffer', function()
     -- We should be in a new buffer now.
     screen:expect([[
       ab^c                                               |
-      ~                                                 |
-      ==========                                        |
+      {4:~                                                 }|
+      {5:==========                                        }|
       rows: 2, cols: 50                                 |
       {2: }                                                 |
       {1:==========                                        }|

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -25,7 +25,7 @@ describe('terminal cursor', function()
                                                         |
                                                         |
                                                         |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -49,12 +49,12 @@ describe('terminal cursor', function()
 
     it('is positioned correctly when unfocused', function()
       screen:expect([[
-          1 tty ready                                     |
-          2 {2: }                                             |
-          3                                               |
-          4                                               |
-          5                                               |
-          6 ^                                              |
+        {7:  1 }tty ready                                     |
+        {7:  2 }{2: }                                             |
+        {7:  3 }                                              |
+        {7:  4 }                                              |
+        {7:  5 }                                              |
+        {7:  6 }^                                              |
         :set number                                       |
       ]])
     end)
@@ -83,7 +83,7 @@ describe('terminal cursor', function()
                                                           |
                                                           |
                                                           |
-        -- TERMINAL --                                    |
+        {3:-- TERMINAL --}                                    |
       ]])
       show_cursor()
       screen:expect([[
@@ -93,7 +93,7 @@ describe('terminal cursor', function()
                                                           |
                                                           |
                                                           |
-        -- TERMINAL --                                    |
+        {3:-- TERMINAL --}                                    |
       ]])
       -- same for when the terminal is unfocused
       feed('<c-\\><c-n>')
@@ -132,14 +132,8 @@ describe('cursor with customized highlighting', function()
     screen = Screen.new(50, 7)
     screen:set_default_attr_ids({
       [1] = {foreground = 45, background = 46},
-      [2] = {foreground = 55, background = 56}
-    })
-    screen:set_default_attr_ignore({
-      [1] = {bold = true},
-      [2] = {foreground = 12},
-      [3] = {bold = true, reverse = true},
-      [5] = {background = 11},
-      [6] = {foreground = 130},
+      [2] = {foreground = 55, background = 56},
+      [3] = {bold = true},
     })
     screen:attach(false)
     execute('call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
@@ -153,7 +147,7 @@ describe('cursor with customized highlighting', function()
                                                         |
                                                         |
                                                         |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
     feed('<c-\\><c-n>')
     screen:expect([[

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -44,14 +44,13 @@ local function screen_setup(extra_height, command)
   screen:set_default_attr_ids({
     [1] = {reverse = true},   -- focused cursor
     [2] = {background = 11},  -- unfocused cursor
-  })
-  screen:set_default_attr_ignore({
-    [1] = {bold = true},
-    [2] = {foreground = 12},
-    [3] = {bold = true, reverse = true},
-    [5] = {background = 11},
-    [6] = {foreground = 130},
-    [7] = {foreground = 15, background = 1}, -- error message
+    [3] = {bold = true},
+    [4] = {foreground = 12},
+    [5] = {bold = true, reverse = true},
+    [6] = {background = 11},
+    [7] = {foreground = 130},
+    [8] = {foreground = 15, background = 1}, -- error message
+    [9] = {foreground = 4},
   })
 
   screen:attach(false)
@@ -76,7 +75,7 @@ local function screen_setup(extra_height, command)
       table.insert(expected, empty_line)
     end
 
-    table.insert(expected, '-- TERMINAL --                                     ')
+    table.insert(expected, '{3:-- TERMINAL --}                                     ')
     screen:expect(table.concat(expected, '\n'))
   else
     wait()

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -16,33 +16,32 @@ describe('terminal window highlighting', function()
       [1] = {foreground = 45},
       [2] = {background = 46},
       [3] = {foreground = 45, background = 46},
-      [4] = {bold = true, italic = true, underline = true}
-    })
-    screen:set_default_attr_ignore({
-      [1] = {bold = true},
-      [2] = {foreground = 12},
-      [3] = {bold = true, reverse = true},
-      [5] = {background = 11},
-      [6] = {foreground = 130},
-      [7] = {reverse = true},
+      [4] = {bold = true, italic = true, underline = true},
+      [5] = {bold = true},
+      [6] = {foreground = 12},
+      [7] = {bold = true, reverse = true},
       [8] = {background = 11},
+      [9] = {foreground = 130},
+      [10] = {reverse = true},
+      [11] = {background = 11},
     })
     screen:attach(false)
     execute('enew | call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
     screen:expect([[
       tty ready                                         |
+      {10: }                                                 |
                                                         |
                                                         |
                                                         |
                                                         |
-                                                        |
-      -- TERMINAL --                                    |
+      {5:-- TERMINAL --}                                    |
     ]])
   end)
 
   local function descr(title, attr_num, set_attrs_fn)
     local function sub(s)
-      return s:gsub('NUM', attr_num)
+      local str = s:gsub('NUM', attr_num)
+      return str
     end
 
     describe(title, function() 
@@ -54,16 +53,15 @@ describe('terminal window highlighting', function()
       end)
 
       local function pass_attrs()
-        local s = sub([[
+        screen:expect(sub([[
           tty ready                                         |
-          {NUM:text}text                                          |
+          {NUM:text}text{10: }                                         |
                                                             |
                                                             |
                                                             |
                                                             |
-          -- TERMINAL --                                    |
-        ]])
-        screen:expect(s)
+          {5:-- TERMINAL --}                                    |
+        ]]))
       end
 
       it('will pass the corresponding attributes', pass_attrs)
@@ -82,11 +80,11 @@ describe('terminal window highlighting', function()
           line6                                             |
           line7                                             |
           line8                                             |
-                                                            |
-          -- TERMINAL --                                    |
+          {10: }                                                 |
+          {5:-- TERMINAL --}                                    |
         ]])
         feed('<c-\\><c-n>gg')
-        local s = sub([[
+        screen:expect(sub([[
           ^tty ready                                         |
           {NUM:text}textline1                                     |
           line2                                             |
@@ -94,8 +92,7 @@ describe('terminal window highlighting', function()
           line4                                             |
           line5                                             |
                                                             |
-        ]])
-        screen:expect(s)
+        ]]))
       end)
     end)
   end
@@ -121,28 +118,26 @@ describe('terminal window highlighting with custom palette', function()
     clear()
     screen = Screen.new(50, 7)
     screen:set_default_attr_ids({
-      [1] = {foreground = 1193046, special = Screen.colors.Black}
-    })
-    screen:set_default_attr_ignore({
-      [1] = {bold = true},
+      [1] = {foreground = 1193046, special = Screen.colors.Black},
       [2] = {foreground = 12},
       [3] = {bold = true, reverse = true},
       [5] = {background = 11},
       [6] = {foreground = 130},
       [7] = {reverse = true},
       [8] = {background = 11},
+      [9] = {bold = true},
     })
     screen:attach(true)
     nvim('set_var', 'terminal_color_3', '#123456')
     execute('enew | call termopen(["'..nvim_dir..'/tty-test"]) | startinsert')
     screen:expect([[
       tty ready                                         |
+      {7: }                                                 |
                                                         |
                                                         |
                                                         |
                                                         |
-                                                        |
-      -- TERMINAL --                                    |
+      {9:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -153,12 +148,12 @@ describe('terminal window highlighting with custom palette', function()
     thelpers.feed_data('text')
     screen:expect([[
       tty ready                                         |
-      {1:text}text                                          |
+      {1:text}text{7: }                                         |
                                                         |
                                                         |
                                                         |
                                                         |
-      -- TERMINAL --                                    |
+      {9:-- TERMINAL --}                                    |
     ]])
   end)
 end)

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -27,7 +27,7 @@ describe('terminal mouse', function()
       line29                                            |
       line30                                            |
       {1: }                                                 |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -74,7 +74,7 @@ describe('terminal mouse', function()
           line30                                            |
           mouse enabled                                     |
           {1: }                                                 |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
       end)
 
@@ -87,7 +87,7 @@ describe('terminal mouse', function()
           line30                                            |
           mouse enabled                                     |
            "#{1: }                                              |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
       end)
 
@@ -100,7 +100,7 @@ describe('terminal mouse', function()
           line30                                            |
           mouse enabled                                     |
           `!!{1: }                                              |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
       end)
     end)
@@ -119,79 +119,79 @@ describe('terminal mouse', function()
         ]])
         feed(':enew | set number<cr>')
         screen:expect([[
-            1 ^                     |line28                  |
-          ~                        |line29                  |
-          ~                        |line30                  |
-          ~                        |rows: 5, cols: 25       |
-          ~                        |{2: }                       |
+          {7:  1 }^                     |line28                  |
+          {4:~                        }|line29                  |
+          {4:~                        }|line30                  |
+          {4:~                        }|rows: 5, cols: 25       |
+          {4:~                        }|{2: }                       |
           ==========                ==========              |
           :enew | set number                                |
         ]])
         feed('30iline\n<esc>')
         screen:expect([[
-           27 line                 |line28                  |
-           28 line                 |line29                  |
-           29 line                 |line30                  |
-           30 line                 |rows: 5, cols: 25       |
-           31 ^                     |{2: }                       |
+          {7: 27 }line                 |line28                  |
+          {7: 28 }line                 |line29                  |
+          {7: 29 }line                 |line30                  |
+          {7: 30 }line                 |rows: 5, cols: 25       |
+          {7: 31 }^                     |{2: }                       |
           ==========                ==========              |
                                                             |
         ]])
         feed('<c-w>li')
         screen:expect([[
-           27 line                 |line29                  |
-           28 line                 |line30                  |
-           29 line                 |rows: 5, cols: 25       |
-           30 line                 |rows: 5, cols: 24       |
-           31                      |{1: }                       |
+          {7: 27 }line                 |line29                  |
+          {7: 28 }line                 |line30                  |
+          {7: 29 }line                 |rows: 5, cols: 25       |
+          {7: 30 }line                 |rows: 5, cols: 24       |
+          {7: 31 }                     |{1: }                       |
           ==========                ==========              |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
         -- enabling mouse won't affect interaction with other windows
         thelpers.enable_mouse()
         thelpers.feed_data('mouse enabled\n')
         screen:expect([[
-           27 line                 |line30                  |
-           28 line                 |rows: 5, cols: 25       |
-           29 line                 |rows: 5, cols: 24       |
-           30 line                 |mouse enabled           |
-           31                      |{1: }                       |
+          {7: 27 }line                 |line30                  |
+          {7: 28 }line                 |rows: 5, cols: 25       |
+          {7: 29 }line                 |rows: 5, cols: 24       |
+          {7: 30 }line                 |mouse enabled           |
+          {7: 31 }                     |{1: }                       |
           ==========                ==========              |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
       end)
 
       it('wont lose focus if another window is scrolled', function()
         feed('<MouseDown><0,0><MouseDown><0,0>')
         screen:expect([[
-           21 line                 |line30                  |
-           22 line                 |rows: 5, cols: 25       |
-           23 line                 |rows: 5, cols: 24       |
-           24 line                 |mouse enabled           |
-           25 line                 |{1: }                       |
+          {7: 21 }line                 |line30                  |
+          {7: 22 }line                 |rows: 5, cols: 25       |
+          {7: 23 }line                 |rows: 5, cols: 24       |
+          {7: 24 }line                 |mouse enabled           |
+          {7: 25 }line                 |{1: }                       |
           ==========                ==========              |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
         feed('<S-MouseUp><0,0>')
         screen:expect([[
-           26 line                 |line30                  |
-           27 line                 |rows: 5, cols: 25       |
-           28 line                 |rows: 5, cols: 24       |
-           29 line                 |mouse enabled           |
-           30 line                 |{1: }                       |
+          {7: 26 }line                 |line30                  |
+          {7: 27 }line                 |rows: 5, cols: 25       |
+          {7: 28 }line                 |rows: 5, cols: 24       |
+          {7: 29 }line                 |mouse enabled           |
+          {7: 30 }line                 |{1: }                       |
           ==========                ==========              |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
       end)
 
       it('will lose focus if another window is clicked', function()
         feed('<LeftMouse><5,1>')
         screen:expect([[
-           27 line                 |line30                  |
-           28 l^ine                 |rows: 5, cols: 25       |
-           29 line                 |rows: 5, cols: 24       |
-           30 line                 |mouse enabled           |
-           31                      |{2: }                       |
+          {7: 27 }line                 |line30                  |
+          {7: 28 }l^ine                 |rows: 5, cols: 25       |
+          {7: 29 }line                 |rows: 5, cols: 24       |
+          {7: 30 }line                 |mouse enabled           |
+          {7: 31 }                     |{2: }                       |
           ==========                ==========              |
                                                             |
         ]])

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -33,7 +33,7 @@ describe('terminal scrollback', function()
         line29                                            |
         line30                                            |
         {1: }                                                 |
-        -- TERMINAL --                                    |
+        {3:-- TERMINAL --}                                    |
       ]])
     end)
 
@@ -61,7 +61,7 @@ describe('terminal scrollback', function()
         line3                                             |
         line4                                             |
         {1: }                                                 |
-        -- TERMINAL --                                    |
+        {3:-- TERMINAL --}                                    |
       ]])
     end)
 
@@ -76,7 +76,7 @@ describe('terminal scrollback', function()
           line4                                             |
           line5                                             |
           {1: }                                                 |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
         eq(7, curbuf('line_count'))
       end)
@@ -92,7 +92,7 @@ describe('terminal scrollback', function()
             line6                                             |
             line7                                             |
             line8{1: }                                            |
-            -- TERMINAL --                                    |
+            {3:-- TERMINAL --}                                    |
           ]])
 
           feed('<c-\\><c-n>6k')
@@ -141,7 +141,7 @@ describe('terminal scrollback', function()
           line4                                             |
           rows: 5, cols: 50                                 |
           {1: }                                                 |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
       end
 
@@ -158,7 +158,7 @@ describe('terminal scrollback', function()
             rows: 5, cols: 50                                 |
             rows: 3, cols: 50                                 |
             {1: }                                                 |
-            -- TERMINAL --                                    |
+            {3:-- TERMINAL --}                                    |
           ]])
           eq(8, curbuf('line_count'))
           feed('<c-\\><c-n>3k')
@@ -185,7 +185,7 @@ describe('terminal scrollback', function()
           rows: 4, cols: 50                                 |
           {1: }                                                 |
                                                             |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
         eq(4, curbuf('line_count'))
       end
@@ -203,7 +203,7 @@ describe('terminal scrollback', function()
             rows: 4, cols: 50                                 |
             rows: 3, cols: 50                                 |
             {1: }                                                 |
-            -- TERMINAL --                                    |
+            {3:-- TERMINAL --}                                    |
           ]])
           eq(4, curbuf('line_count'))
           feed('<c-\\><c-n>gg')
@@ -218,7 +218,7 @@ describe('terminal scrollback', function()
             rows: 4, cols: 50                                 |
             rows: 3, cols: 50                                 |
             {1: }                                                 |
-            -- TERMINAL --                                    |
+            {3:-- TERMINAL --}                                    |
           ]])
         end)
       end)
@@ -235,14 +235,14 @@ describe('terminal scrollback', function()
         line3                                             |
         line4                                             |
         {1: }                                                 |
-        -- TERMINAL --                                    |
+        {3:-- TERMINAL --}                                    |
       ]])
       screen:try_resize(screen._width, screen._height - 3)
       screen:expect([[
         line4                                             |
         rows: 3, cols: 50                                 |
         {1: }                                                 |
-        -- TERMINAL --                                    |
+        {3:-- TERMINAL --}                                    |
       ]])
       eq(7, curbuf('line_count'))
     end)
@@ -255,7 +255,7 @@ describe('terminal scrollback', function()
           rows: 3, cols: 50                                 |
           rows: 4, cols: 50                                 |
           {1: }                                                 |
-          -- TERMINAL --                                    |
+          {3:-- TERMINAL --}                                    |
         ]])
       end
 
@@ -277,7 +277,7 @@ describe('terminal scrollback', function()
             rows: 4, cols: 50                                 |
             rows: 7, cols: 50                                 |
             {1: }                                                 |
-            -- TERMINAL --                                    |
+            {3:-- TERMINAL --}                                    |
           ]])
           eq(9, curbuf('line_count'))
           feed('<c-\\><c-n>gg')
@@ -315,7 +315,7 @@ describe('terminal scrollback', function()
               rows: 11, cols: 50                                |
               {1: }                                                 |
                                                                 |
-              -- TERMINAL --                                    |
+              {3:-- TERMINAL --}                                    |
             ]])
             -- since there's an empty line after the cursor, the buffer line
             -- count equals the terminal screen height

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -17,12 +17,12 @@ describe('tui', function()
     screen.timeout = 60000
     screen:expect([[
       {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name]                                         }|
                                                         |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -36,20 +36,20 @@ describe('tui', function()
       abc                                               |
       test1                                             |
       test2{1: }                                            |
-      ~                                                 |
-      [No Name] [+]                                     |
-      -- INSERT --                                      |
-      -- TERMINAL --                                    |
+      {4:~                                                 }|
+      {5:[No Name] [+]                                     }|
+      {3:-- INSERT --}                                      |
+      {3:-- TERMINAL --}                                    |
     ]])
     feed('\027')
     screen:expect([[
       abc                                               |
       test1                                             |
       test{1:2}                                             |
-      ~                                                 |
-      [No Name] [+]                                     |
+      {4:~                                                 }|
+      {5:[No Name] [+]                                     }|
                                                         |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -64,9 +64,9 @@ describe('tui', function()
       alt-k                                             |
       alt-l                                             |
       {1: }                                                 |
-      [No Name] [+]                                     |
+      {5:[No Name] [+]                                     }|
                                                         |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
     feed('gg')
     screen:expect([[
@@ -74,9 +74,9 @@ describe('tui', function()
       alt-f                                             |
       alt-g                                             |
       alt-h                                             |
-      [No Name] [+]                                     |
+      {5:[No Name] [+]                                     }|
                                                         |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -90,12 +90,12 @@ describe('tui', function()
     feed('i\027j')
     screen:expect([[
       j{1: }                                                |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name] [+]                                     |
-      -- INSERT --                                      |
-      -- TERMINAL --                                    |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name] [+]                                     }|
+      {3:-- INSERT --}                                      |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -105,46 +105,46 @@ describe('tui', function()
     feed('\022\022') -- ctrl+v
     feed('\022\013') -- ctrl+m
     screen:expect([[
-    {3:^G^V^M}{1: }                                           |
-    ~                                                 |
-    ~                                                 |
-    ~                                                 |
-    [No Name] [+]                                     |
-    -- INSERT --                                      |
-    -- TERMINAL --                                    |
-    ]], {[1] = {reverse = true}, [2] = {background = 11}, [3] = {foreground = 4}})
+    {9:^G^V^M}{1: }                                           |
+    {4:~                                                 }|
+    {4:~                                                 }|
+    {4:~                                                 }|
+    {5:[No Name] [+]                                     }|
+    {3:-- INSERT --}                                      |
+    {3:-- TERMINAL --}                                    |
+    ]])
   end)
 
   it('automatically sends <Paste> for bracketed paste sequences', function()
     feed('i\027[200~')
     screen:expect([[
       {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
-      -- INSERT (paste) --                              |
-      -- TERMINAL --                                    |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name]                                         }|
+      {3:-- INSERT (paste) --}                              |
+      {3:-- TERMINAL --}                                    |
     ]])
     feed('pasted from terminal')
     screen:expect([[
       pasted from terminal{1: }                             |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name] [+]                                     |
-      -- INSERT (paste) --                              |
-      -- TERMINAL --                                    |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name] [+]                                     }|
+      {3:-- INSERT (paste) --}                              |
+      {3:-- TERMINAL --}                                    |
     ]])
     feed('\027[201~')
     screen:expect([[
       pasted from terminal{1: }                             |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name] [+]                                     |
-      -- INSERT --                                      |
-      -- TERMINAL --                                    |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name] [+]                                     }|
+      {3:-- INSERT --}                                      |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -160,9 +160,9 @@ describe('tui', function()
       item 2998                                         |
       item 2999                                         |
       item 3000{1: }                                        |
-      [No Name] [+]                   3000,10        Bot|
-      -- INSERT --                                      |
-      -- TERMINAL --                                    |
+      {5:[No Name] [+]                   3000,10        Bot}|
+      {3:-- INSERT --}                                      |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 end)
@@ -176,17 +176,15 @@ describe('tui with non-tty file descriptors', function()
 
   it('can handle pipes as stdout and stderr', function()
     local screen = thelpers.screen_setup(0, '"'..helpers.nvim_prog..' -u NONE -i NONE --cmd \'set noswapfile\' --cmd \'normal iabc\' > /dev/null 2>&1 && cat testF && rm testF"')
-    screen:set_default_attr_ids({})
-    screen:set_default_attr_ignore(true)
     feed(':w testF\n:q\n')
     screen:expect([[
       :w testF                                          |
       :q                                                |
       abc                                               |
                                                         |
-      [Process exited 0]                                |
+      [Process exited 0]{1: }                               |
                                                         |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 end)
@@ -205,23 +203,23 @@ describe('tui focus event handling', function()
     feed('\027[I')
     screen:expect([[
       {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name]                                         }|
       gained                                            |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
 
     feed('\027[O')
     screen:expect([[
       {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name]                                         }|
       lost                                              |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -231,22 +229,22 @@ describe('tui focus event handling', function()
     feed('\027[I')
     screen:expect([[
       {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name]                                         }|
       gained                                            |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
     feed('\027[O')
     screen:expect([[
       {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name]                                         }|
       lost                                              |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -255,22 +253,22 @@ describe('tui focus event handling', function()
     feed('\027[I')
     screen:expect([[
                                                         |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name]                                         }|
       g{1:a}ined                                            |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
     feed('\027[O')
     screen:expect([[
                                                         |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name]                                         }|
       l{1:o}st                                              |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -287,7 +285,7 @@ describe('tui focus event handling', function()
                                                         |
                                                         |
       gained                                            |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
    feed('\027[O')
     screen:expect([[
@@ -297,7 +295,7 @@ describe('tui focus event handling', function()
                                                         |
                                                         |
       lost                                              |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 end)
@@ -319,15 +317,21 @@ describe("tui 't_Co' (terminal colors)", function()
       helpers.nvim_prog))
 
     thelpers.feed_data(":echo &t_Co\n")
+    local tline
+    if maxcolors == 8 then
+      tline = "~                                                 "
+    else
+      tline = "{4:~                                                 }"
+    end
     screen:expect(string.format([[
       {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
+      %s|
+      %s|
+      %s|
+      {5:[No Name]                                         }|
       %-3s                                               |
-      -- TERMINAL --                                    |
-    ]], tostring(maxcolors and maxcolors or "")))
+      {3:-- TERMINAL --}                                    |
+    ]], tline, tline, tline, tostring(maxcolors and maxcolors or "")))
   end
 
   it("unknown TERM sets empty 't_Co'", function()

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -52,7 +52,7 @@ describe('terminal window', function()
                                                           |
                                                           |
                                                           |
-        -- TERMINAL --                                    |
+        {3:-- TERMINAL --}                                    |
       ]])
     end)
   end)
@@ -68,7 +68,7 @@ describe('terminal window', function()
         line3                                             |
         line4                                             |
         {1: }                                                 |
-        -- TERMINAL --                                    |
+        {3:-- TERMINAL --}                                    |
       ]])
     end)
 

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -32,8 +32,8 @@ describe('terminal', function()
       tty ready                                         |
       rows: 2, cols: 50                                 |
       {2: }                                                 |
-      ~                                                 |
-      ~                                                 |
+      {4:~                                                 }|
+      {4:~                                                 }|
       ==========                                        |
                                                         |
     ]])
@@ -58,8 +58,8 @@ describe('terminal', function()
       rows: 5, cols: 50                                 |
       rows: 2, cols: 50                                 |
       {2: }                                                 |
-      ~                                                 |
-      ~                                                 |
+      {4:~                                                 }|
+      {4:~                                                 }|
       ==========                                        |
       :wincmd p                                         |
     ]])
@@ -83,7 +83,7 @@ describe('terminal', function()
                                                              |
                                                              |
                                                              |
-        -- TERMINAL --                                       |
+        {3:-- TERMINAL --}                                       |
       ]])
       screen:try_resize(screen._width - 6, screen._height - 10)
       screen:expect([[
@@ -91,7 +91,7 @@ describe('terminal', function()
         rows: 14, cols: 53                             |
         rows: 4, cols: 47                              |
         {1: }                                              |
-        -- TERMINAL --                                 |
+        {3:-- TERMINAL --}                                 |
       ]])
     end)
   end)

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -8,30 +8,21 @@ describe('Buffer highlighting', function()
   local screen
   local curbuf
 
-  local hl_colors = {
-    NonText = Screen.colors.Blue,
-    Question = Screen.colors.SeaGreen,
-    String = Screen.colors.Fuchsia,
-    Statement = Screen.colors.Brown,
-    Special = Screen.colors.SlateBlue,
-    Identifier = Screen.colors.DarkCyan
-  }
-
   before_each(function()
     clear()
     execute("syntax on")
     screen = Screen.new(40, 8)
     screen:attach()
-    screen:set_default_attr_ignore( {{bold=true, foreground=hl_colors.NonText}} )
+    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
     screen:set_default_attr_ids({
-      [1] = {foreground = hl_colors.String},
-      [2] = {foreground = hl_colors.Statement, bold = true},
-      [3] = {foreground = hl_colors.Special},
-      [4] = {bold = true, foreground = hl_colors.Special},
-      [5] = {foreground = hl_colors.Identifier},
+      [1] = {foreground = Screen.colors.Fuchsia}, -- String
+      [2] = {foreground = Screen.colors.Brown, bold = true}, -- Statement
+      [3] = {foreground = Screen.colors.SlateBlue}, -- Special
+      [4] = {bold = true, foreground = Screen.colors.SlateBlue},
+      [5] = {foreground = Screen.colors.DarkCyan}, -- Identifier
       [6] = {bold = true},
-      [7] = {underline = true, bold = true, foreground = hl_colors.Special},
-      [8] = {foreground = hl_colors.Special, underline = true}
+      [7] = {underline = true, bold = true, foreground = Screen.colors.SlateBlue},
+      [8] = {foreground = Screen.colors.SlateBlue, underline = true}
     })
     curbuf = request('vim_get_current_buffer')
   end)

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -13,16 +13,16 @@ describe('Buffer highlighting', function()
     execute("syntax on")
     screen = Screen.new(40, 8)
     screen:attach()
-    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
     screen:set_default_attr_ids({
-      [1] = {foreground = Screen.colors.Fuchsia}, -- String
-      [2] = {foreground = Screen.colors.Brown, bold = true}, -- Statement
-      [3] = {foreground = Screen.colors.SlateBlue}, -- Special
-      [4] = {bold = true, foreground = Screen.colors.SlateBlue},
-      [5] = {foreground = Screen.colors.DarkCyan}, -- Identifier
-      [6] = {bold = true},
-      [7] = {underline = true, bold = true, foreground = Screen.colors.SlateBlue},
-      [8] = {foreground = Screen.colors.SlateBlue, underline = true}
+      [1] = {bold=true, foreground=Screen.colors.Blue},
+      [2] = {foreground = Screen.colors.Fuchsia}, -- String
+      [3] = {foreground = Screen.colors.Brown, bold = true}, -- Statement
+      [4] = {foreground = Screen.colors.SlateBlue}, -- Special
+      [5] = {bold = true, foreground = Screen.colors.SlateBlue},
+      [6] = {foreground = Screen.colors.DarkCyan}, -- Identifier
+      [7] = {bold = true},
+      [8] = {underline = true, bold = true, foreground = Screen.colors.SlateBlue},
+      [9] = {foreground = Screen.colors.SlateBlue, underline = true}
     })
     curbuf = request('vim_get_current_buffer')
   end)
@@ -49,11 +49,11 @@ describe('Buffer highlighting', function()
     screen:expect([[
       these are some lines                    |
       with colorful tex^t                      |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
                                               |
     ]])
 
@@ -61,25 +61,25 @@ describe('Buffer highlighting', function()
     add_hl(-1, "Statement", 1 , 5, -1)
 
     screen:expect([[
-      these are {1:some} lines                    |
-      with {2:colorful tex^t}                      |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      these are {2:some} lines                    |
+      with {3:colorful tex^t}                      |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
                                               |
     ]])
 
     feed("ggo<esc>")
     screen:expect([[
-      these are {1:some} lines                    |
+      these are {2:some} lines                    |
       ^                                        |
-      with {2:colorful text}                      |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      with {3:colorful text}                      |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
                                               |
     ]])
 
@@ -88,10 +88,10 @@ describe('Buffer highlighting', function()
       these are some lines                    |
       ^                                        |
       with colorful text                      |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
                                               |
     ]])
   end)
@@ -119,13 +119,13 @@ describe('Buffer highlighting', function()
       neq(id1, id2)
 
       screen:expect([[
-        a {4:longer} example                        |
-        in {5:order} to {6:de}{4:monstr}{6:ate}                 |
-        {6:combin}{7:ing}{8: hi}ghlights                    |
-        {8:from }{7:diff}{6:erent} source^s                  |
-        ~                                       |
-        ~                                       |
-        ~                                       |
+        a {5:longer} example                        |
+        in {6:order} to {7:de}{5:monstr}{7:ate}                 |
+        {7:combin}{8:ing}{9: hi}ghlights                    |
+        {9:from }{8:diff}{7:erent} source^s                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
         :hi ImportantWord gui=bold cterm=bold   |
       ]])
     end)
@@ -133,13 +133,13 @@ describe('Buffer highlighting', function()
     it('and clearing the first added', function()
       clear_hl(id1, 0, -1)
       screen:expect([[
-        a {3:longer} example                        |
-        in {5:order} to de{3:monstr}ate                 |
-        combin{8:ing hi}ghlights                    |
-        {8:from diff}erent source^s                  |
-        ~                                       |
-        ~                                       |
-        ~                                       |
+        a {4:longer} example                        |
+        in {6:order} to de{4:monstr}ate                 |
+        combin{9:ing hi}ghlights                    |
+        {9:from diff}erent source^s                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
         :hi ImportantWord gui=bold cterm=bold   |
       ]])
     end)
@@ -147,13 +147,13 @@ describe('Buffer highlighting', function()
     it('and clearing the second added', function()
       clear_hl(id2, 0, -1)
       screen:expect([[
-        a {6:longer} example                        |
-        in order to {6:demonstrate}                 |
-        {6:combining} highlights                    |
-        from {6:different} source^s                  |
-        ~                                       |
-        ~                                       |
-        ~                                       |
+        a {7:longer} example                        |
+        in order to {7:demonstrate}                 |
+        {7:combining} highlights                    |
+        from {7:different} source^s                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
         :hi ImportantWord gui=bold cterm=bold   |
       ]])
     end)
@@ -164,12 +164,12 @@ describe('Buffer highlighting', function()
       clear_hl(id2, 2, -1)
       screen:expect([[
         a longer example                        |
-        in {5:order} to de{3:monstr}ate                 |
-        {6:combining} highlights                    |
-        from {6:different} source^s                  |
-        ~                                       |
-        ~                                       |
-        ~                                       |
+        in {6:order} to de{4:monstr}ate                 |
+        {7:combining} highlights                    |
+        from {7:different} source^s                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
         :hi ImportantWord gui=bold cterm=bold   |
       ]])
     end)
@@ -177,25 +177,25 @@ describe('Buffer highlighting', function()
     it('and renumbering lines', function()
       feed('3Gddggo<esc>')
       screen:expect([[
-        a {4:longer} example                        |
+        a {5:longer} example                        |
         ^                                        |
-        in {5:order} to {6:de}{4:monstr}{6:ate}                 |
-        {8:from }{7:diff}{6:erent} sources                  |
-        ~                                       |
-        ~                                       |
-        ~                                       |
+        in {6:order} to {7:de}{5:monstr}{7:ate}                 |
+        {9:from }{8:diff}{7:erent} sources                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
                                                 |
       ]])
 
       execute(':3move 4')
       screen:expect([[
-        a {4:longer} example                        |
+        a {5:longer} example                        |
                                                 |
-        {8:from }{7:diff}{6:erent} sources                  |
-        ^in {5:order} to {6:de}{4:monstr}{6:ate}                 |
-        ~                                       |
-        ~                                       |
-        ~                                       |
+        {9:from }{8:diff}{7:erent} sources                  |
+        ^in {6:order} to {7:de}{5:monstr}{7:ate}                 |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
         ::3move 4                               |
       ]])
     end)
@@ -209,25 +209,25 @@ describe('Buffer highlighting', function()
     local id = add_hl(0, "Special", 0, 0, 9)
 
     screen:expect([[
-      {3:three ove}{5:rlapp}{1:ing color}^s                |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {4:three ove}{6:rlapp}{2:ing color}^s                |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
                                               |
     ]])
 
     clear_hl(id, 0, 1)
     screen:expect([[
-      three {5:overlapp}{1:ing color}^s                |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      three {6:overlapp}{2:ing color}^s                |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
                                               |
     ]])
   end)
@@ -239,13 +239,13 @@ describe('Buffer highlighting', function()
     add_hl(-1, "String", 0, 16, 21)
 
     screen:expect([[
-      Ta {5:båten} över {1:sjön}^!                     |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      Ta {6:båten} över {2:sjön}^!                     |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
                                               |
     ]])
   end)

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -27,10 +27,11 @@ describe('manual syntax highlight', function()
     clear()
     screen = Screen.new(20,5)
     screen:attach()
-    --ignore highligting of ~-lines
-    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
     --syntax highlight for vimcscripts "echo"
-    screen:set_default_attr_ids( {[1] = {bold=true, foreground=Screen.colors.Brown}} )
+    screen:set_default_attr_ids( {
+      [0] = {bold=true, foreground=Screen.colors.Blue},
+      [1] = {bold=true, foreground=Screen.colors.Brown}
+    } )
   end)
 
   after_each(function()
@@ -53,9 +54,9 @@ describe('manual syntax highlight', function()
     execute('bp')
     screen:expect([[
       {1:^echo} 1              |
-      ~                   |
-      ~                   |
-      ~                   |
+      {0:~                   }|
+      {0:~                   }|
+      {0:~                   }|
       <f 1 --100%-- col 1 |
     ]])
   end)
@@ -75,9 +76,9 @@ describe('manual syntax highlight', function()
     execute('bp')
     screen:expect([[
       {1:^echo} 1              |
-      ~                   |
-      ~                   |
-      ~                   |
+      {0:~                   }|
+      {0:~                   }|
+      {0:~                   }|
       <ht.tmp.vim" 1L, 7C |
     ]])
   end)
@@ -93,8 +94,6 @@ describe('Default highlight groups', function()
     clear()
     screen = Screen.new()
     screen:attach()
-    --ignore highligting of ~-lines
-    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
   end)
 
   after_each(function()
@@ -103,23 +102,24 @@ describe('Default highlight groups', function()
 
   it('window status bar', function()
     screen:set_default_attr_ids({
+      [0] = {bold=true, foreground=Screen.colors.Blue},
       [1] = {reverse = true, bold = true},  -- StatusLine
       [2] = {reverse = true}                -- StatusLineNC
     })
     execute('sp', 'vsp', 'vsp')
     screen:expect([[
       ^                    {2:|}                {2:|}               |
-      ~                   {2:|}~               {2:|}~              |
-      ~                   {2:|}~               {2:|}~              |
-      ~                   {2:|}~               {2:|}~              |
-      ~                   {2:|}~               {2:|}~              |
-      ~                   {2:|}~               {2:|}~              |
+      {0:~                   }{2:|}{0:~               }{2:|}{0:~              }|
+      {0:~                   }{2:|}{0:~               }{2:|}{0:~              }|
+      {0:~                   }{2:|}{0:~               }{2:|}{0:~              }|
+      {0:~                   }{2:|}{0:~               }{2:|}{0:~              }|
+      {0:~                   }{2:|}{0:~               }{2:|}{0:~              }|
       {1:[No Name]            }{2:[No Name]        [No Name]      }|
                                                            |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
       {2:[No Name]                                            }|
                                                            |
     ]])
@@ -127,17 +127,17 @@ describe('Default highlight groups', function()
     feed('<c-w>j')
     screen:expect([[
                           {2:|}                {2:|}               |
-      ~                   {2:|}~               {2:|}~              |
-      ~                   {2:|}~               {2:|}~              |
-      ~                   {2:|}~               {2:|}~              |
-      ~                   {2:|}~               {2:|}~              |
-      ~                   {2:|}~               {2:|}~              |
+      {0:~                   }{2:|}{0:~               }{2:|}{0:~              }|
+      {0:~                   }{2:|}{0:~               }{2:|}{0:~              }|
+      {0:~                   }{2:|}{0:~               }{2:|}{0:~              }|
+      {0:~                   }{2:|}{0:~               }{2:|}{0:~              }|
+      {0:~                   }{2:|}{0:~               }{2:|}{0:~              }|
       {2:[No Name]            [No Name]        [No Name]      }|
       ^                                                     |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
       {1:[No Name]                                            }|
                                                            |
     ]])
@@ -147,51 +147,51 @@ describe('Default highlight groups', function()
     feed('<c-w>k<c-w>l')
     screen:expect([[
                           {2:|}^                    {2:|}           |
-      ~                   {2:|}~                   {2:|}~          |
-      ~                   {2:|}~                   {2:|}~          |
-      ~                   {2:|}~                   {2:|}~          |
-      ~                   {2:|}~                   {2:|}~          |
-      ~                   {2:|}~                   {2:|}~          |
+      {0:~                   }{2:|}{0:~                   }{2:|}{0:~          }|
+      {0:~                   }{2:|}{0:~                   }{2:|}{0:~          }|
+      {0:~                   }{2:|}{0:~                   }{2:|}{0:~          }|
+      {0:~                   }{2:|}{0:~                   }{2:|}{0:~          }|
+      {0:~                   }{2:|}{0:~                   }{2:|}{0:~          }|
       {2:[No Name]            }{1:[No Name]            }{2:[No Name]  }|
                                                            |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
       {2:[No Name]                                            }|
                                                            |
     ]])
     feed('<c-w>l')
     screen:expect([[
                           {2:|}           {2:|}^                    |
-      ~                   {2:|}~          {2:|}~                   |
-      ~                   {2:|}~          {2:|}~                   |
-      ~                   {2:|}~          {2:|}~                   |
-      ~                   {2:|}~          {2:|}~                   |
-      ~                   {2:|}~          {2:|}~                   |
+      {0:~                   }{2:|}{0:~          }{2:|}{0:~                   }|
+      {0:~                   }{2:|}{0:~          }{2:|}{0:~                   }|
+      {0:~                   }{2:|}{0:~          }{2:|}{0:~                   }|
+      {0:~                   }{2:|}{0:~          }{2:|}{0:~                   }|
+      {0:~                   }{2:|}{0:~          }{2:|}{0:~                   }|
       {2:[No Name]            [No Name]   }{1:[No Name]           }|
                                                            |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
       {2:[No Name]                                            }|
                                                            |
     ]])
     feed('<c-w>h<c-w>h')
     screen:expect([[
       ^                    {2:|}                    {2:|}           |
-      ~                   {2:|}~                   {2:|}~          |
-      ~                   {2:|}~                   {2:|}~          |
-      ~                   {2:|}~                   {2:|}~          |
-      ~                   {2:|}~                   {2:|}~          |
-      ~                   {2:|}~                   {2:|}~          |
+      {0:~                   }{2:|}{0:~                   }{2:|}{0:~          }|
+      {0:~                   }{2:|}{0:~                   }{2:|}{0:~          }|
+      {0:~                   }{2:|}{0:~                   }{2:|}{0:~          }|
+      {0:~                   }{2:|}{0:~                   }{2:|}{0:~          }|
+      {0:~                   }{2:|}{0:~                   }{2:|}{0:~          }|
       {1:[No Name]            }{2:[No Name]            [No Name]  }|
                                                            |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
       {2:[No Name]                                            }|
                                                            |
     ]])
@@ -201,20 +201,21 @@ describe('Default highlight groups', function()
     feed('i')
     screen:expect([[
       ^                                                     |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
       {1:-- INSERT --}                                         |
-    ]], {[1] = {bold = true}})
+    ]], {[0] = {bold=true, foreground=Screen.colors.Blue},
+    [1] = {bold = true}})
   end)
 
   it('end of file markers', function()
@@ -239,21 +240,22 @@ describe('Default highlight groups', function()
   it('"wait return" text', function()
     feed(':ls<cr>')
     screen:expect([[
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
       :ls                                                  |
         1 %a   "[No Name]"                    line 1       |
       {1:Press ENTER or type command to continue}^              |
-    ]], {[1] = {bold = true, foreground = Screen.colors.SeaGreen}})
+    ]], {[0] = {bold=true, foreground=Screen.colors.Blue},
+    [1] = {bold = true, foreground = Screen.colors.SeaGreen}})
     feed('<cr>') --  skip the "Press ENTER..." state or tests will hang
   end)
   it('can be cleared and linked to other highlight groups', function()
@@ -261,40 +263,42 @@ describe('Default highlight groups', function()
     feed('i')
     screen:expect([[
       ^                                                     |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
       -- INSERT --                                         |
-    ]], {})
+    ]], {[0] = {bold=true, foreground=Screen.colors.Blue},
+    [1] = {bold=true}})
     feed('<esc>')
     execute('highlight CustomHLGroup guifg=red guibg=green')
     execute('highlight link ModeMsg CustomHLGroup')
     feed('i')
     screen:expect([[
       ^                                                     |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
       {1:-- INSERT --}                                         |
-    ]], {[1] = {foreground = Screen.colors.Red, background = Screen.colors.Green}})
+    ]], {[0] = {bold=true, foreground=Screen.colors.Blue},
+    [1] = {foreground = Screen.colors.Red, background = Screen.colors.Green}})
   end)
   it('can be cleared by assigning NONE', function()
     execute('syn keyword TmpKeyword neovim')
@@ -302,40 +306,41 @@ describe('Default highlight groups', function()
     insert('neovim')
     screen:expect([[
       {1:neovi^m}                                               |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
                                                            |
     ]], {
+      [0] = {bold=true, foreground=Screen.colors.Blue},
       [1] = {foreground = Screen.colors.White, background = Screen.colors.Red}
     })
     execute("hi ErrorMsg term=NONE cterm=NONE ctermfg=NONE ctermbg=NONE"
             .. " gui=NONE guifg=NONE guibg=NONE guisp=NONE")
     screen:expect([[
       neovi^m                                               |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
                                                            |
-    ]], {})
+    ]], {[0] = {bold=true, foreground=Screen.colors.Blue}})
   end)
 end)
 
@@ -346,10 +351,6 @@ describe('guisp (special/undercurl)', function()
     clear()
     screen = Screen.new(25,10)
     screen:attach()
-    screen:set_default_attr_ignore({
-      [1] = {bold = true, foreground = Screen.colors.Blue},
-      [2] = {bold = true}
-    })
   end)
 
   it('can be set and is applied like foreground or background', function()
@@ -384,14 +385,16 @@ describe('guisp (special/undercurl)', function()
       {4:specialwithfg}            |
                                |
               {1:neovim} tabbed^    |
-      ~                        |
-      -- INSERT --             |
+      {0:~                        }|
+      {5:-- INSERT --}             |
     ]],{
+      [0] = {bold=true, foreground=Screen.colors.Blue},
       [1] = {background = Screen.colors.Yellow, foreground = Screen.colors.Red,
              special = Screen.colors.Red},
       [2] = {special = Screen.colors.Red},
       [3] = {special = Screen.colors.Red, background = Screen.colors.Yellow},
       [4] = {foreground = Screen.colors.Red, special = Screen.colors.Red},
+      [5] = {bold=true},
     })
 
   end)
@@ -411,48 +414,50 @@ describe("'cursorline' with 'listchars'", function()
   end)
 
   it("'cursorline' and 'cursorcolumn'", function()
-    screen:set_default_attr_ids({[1] = {background=Screen.colors.Grey90}})
-    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
+    screen:set_default_attr_ids({
+      [0] = {bold=true, foreground=Screen.colors.Blue},
+      [1] = {background=Screen.colors.Grey90}
+    })
     execute('highlight clear ModeMsg')
     execute('set cursorline')
     feed('i')
     screen:expect([[
       {1:^                    }|
-      ~                   |
-      ~                   |
-      ~                   |
+      {0:~                   }|
+      {0:~                   }|
+      {0:~                   }|
       -- INSERT --        |
     ]])
     feed('abcdefg<cr>kkasdf')
     screen:expect([[
       abcdefg             |
       {1:kkasdf^              }|
-      ~                   |
-      ~                   |
+      {0:~                   }|
+      {0:~                   }|
       -- INSERT --        |
     ]])
     feed('<esc>')
     screen:expect([[
       abcdefg             |
       {1:kkasd^f              }|
-      ~                   |
-      ~                   |
+      {0:~                   }|
+      {0:~                   }|
                           |
     ]])
     execute('set nocursorline')
     screen:expect([[
       abcdefg             |
       kkasd^f              |
-      ~                   |
-      ~                   |
+      {0:~                   }|
+      {0:~                   }|
       :set nocursorline   |
     ]])
     feed('k')
     screen:expect([[
       abcde^fg             |
       kkasdf              |
-      ~                   |
-      ~                   |
+      {0:~                   }|
+      {0:~                   }|
       :set nocursorline   |
     ]])
     feed('jjji<cr><cr><cr><esc>')

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -89,17 +89,12 @@ describe('Default highlight groups', function()
   -- command
   local screen
 
-  local hlgroup_colors = {
-    NonText = Screen.colors.Blue,
-    Question = Screen.colors.SeaGreen
-  }
-
   before_each(function()
     clear()
     screen = Screen.new()
     screen:attach()
     --ignore highligting of ~-lines
-    screen:set_default_attr_ignore( {{bold=true, foreground=hlgroup_colors.NonText}} )
+    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
   end)
 
   after_each(function()
@@ -238,7 +233,7 @@ describe('Default highlight groups', function()
       {1:~                                                    }|
       {1:~                                                    }|
                                                            |
-    ]], {[1] = {bold = true, foreground = hlgroup_colors.NonText}})
+    ]], {[1] = {bold = true, foreground = Screen.colors.Blue}})
   end)
 
   it('"wait return" text', function()
@@ -258,7 +253,7 @@ describe('Default highlight groups', function()
       :ls                                                  |
         1 %a   "[No Name]"                    line 1       |
       {1:Press ENTER or type command to continue}^              |
-    ]], {[1] = {bold = true, foreground = hlgroup_colors.Question}})
+    ]], {[1] = {bold = true, foreground = Screen.colors.SeaGreen}})
     feed('<cr>') --  skip the "Press ENTER..." state or tests will hang
   end)
   it('can be cleared and linked to other highlight groups', function()
@@ -405,13 +400,6 @@ end)
 describe("'cursorline' with 'listchars'", function()
   local screen
 
-  local hlgroup_colors = {
-    NonText = Screen.colors.Blue,
-    Cursorline = Screen.colors.Grey90,
-    SpecialKey = Screen.colors.Red,
-    Visual = Screen.colors.LightGrey,
-  }
-
   before_each(function()
     clear()
     screen = Screen.new(20,5)
@@ -423,8 +411,8 @@ describe("'cursorline' with 'listchars'", function()
   end)
 
   it("'cursorline' and 'cursorcolumn'", function()
-    screen:set_default_attr_ids({[1] = {background=hlgroup_colors.Cursorline}})
-    screen:set_default_attr_ignore( {{bold=true, foreground=hlgroup_colors.NonText}} )
+    screen:set_default_attr_ids({[1] = {background=Screen.colors.Grey90}})
+    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
     execute('highlight clear ModeMsg')
     execute('set cursorline')
     feed('i')
@@ -497,22 +485,22 @@ describe("'cursorline' with 'listchars'", function()
 
   it("'cursorline' and with 'listchar' option: space, eol, tab, and trail", function()
     screen:set_default_attr_ids({
-      [1] = {background=hlgroup_colors.Cursorline},
+      [1] = {background=Screen.colors.Grey90},
       [2] = {
-        foreground=hlgroup_colors.SpecialKey,
-        background=hlgroup_colors.Cursorline,
+        foreground=Screen.colors.Red,
+        background=Screen.colors.Grey90,
       },
       [3] = {
-        background=hlgroup_colors.Cursorline,
-        foreground=hlgroup_colors.NonText,
+        background=Screen.colors.Grey90,
+        foreground=Screen.colors.Blue,
         bold=true,
       },
       [4] = {
-        foreground=hlgroup_colors.NonText,
+        foreground=Screen.colors.Blue,
         bold=true,
       },
       [5] = {
-        foreground=hlgroup_colors.SpecialKey,
+        foreground=Screen.colors.Red,
       },
     })
     execute('highlight clear ModeMsg')
@@ -581,33 +569,33 @@ describe("'cursorline' with 'listchars'", function()
 
   it("'listchar' in visual mode", function()
     screen:set_default_attr_ids({
-      [1] = {background=hlgroup_colors.Cursorline},
+      [1] = {background=Screen.colors.Grey90},
       [2] = {
-        foreground=hlgroup_colors.SpecialKey,
-        background=hlgroup_colors.Cursorline,
+        foreground=Screen.colors.Red,
+        background=Screen.colors.Grey90,
       },
       [3] = {
-        background=hlgroup_colors.Cursorline,
-        foreground=hlgroup_colors.NonText,
+        background=Screen.colors.Grey90,
+        foreground=Screen.colors.Blue,
         bold=true,
       },
       [4] = {
-        foreground=hlgroup_colors.NonText,
+        foreground=Screen.colors.Blue,
         bold=true,
       },
       [5] = {
-        foreground=hlgroup_colors.SpecialKey,
+        foreground=Screen.colors.Red,
       },
       [6] = {
-        background=hlgroup_colors.Visual,
+        background=Screen.colors.LightGrey,
       },
       [7] = {
-        background=hlgroup_colors.Visual,
-        foreground=hlgroup_colors.SpecialKey,
+        background=Screen.colors.LightGrey,
+        foreground=Screen.colors.Red,
       },
       [8] = {
-        background=hlgroup_colors.Visual,
-        foreground=hlgroup_colors.NonText,
+        background=Screen.colors.LightGrey,
+        foreground=Screen.colors.Blue,
         bold=true,
       },
     })

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -17,6 +17,7 @@ describe('Mouse input', function()
     screen = Screen.new(25, 5)
     screen:attach()
     screen:set_default_attr_ids({
+      [0] = {bold=true, foreground=Screen.colors.Blue},
       [1] = {background = Screen.colors.LightGrey},
       [2] = {bold = true},
       [3] = {
@@ -24,14 +25,15 @@ describe('Mouse input', function()
         background = Screen.colors.LightGrey,
         bold = true,
       },
+      [4] = {reverse = true},
+      [5] = {bold = true, reverse = true},
     })
-    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
     feed('itesting<cr>mouse<cr>support and selection<esc>')
     screen:expect([[
       testing                  |
       mouse                    |
       support and selectio^n    |
-      ~                        |
+      {0:~                        }|
                                |
     ]])
   end)
@@ -46,7 +48,7 @@ describe('Mouse input', function()
       testing                  |
       mo^use                    |
       support and selection    |
-      ~                        |
+      {0:~                        }|
                                |
     ]])
     feed('<LeftMouse><0,0>')
@@ -54,7 +56,7 @@ describe('Mouse input', function()
       ^testing                  |
       mouse                    |
       support and selection    |
-      ~                        |
+      {0:~                        }|
                                |
     ]])
   end)
@@ -68,7 +70,7 @@ describe('Mouse input', function()
       {1:testin}^g                  |
       mouse                    |
       support and selection    |
-      ~                        |
+      {0:~                        }|
       {2:-- VISUAL --}             |
     ]])
   end)
@@ -84,7 +86,7 @@ describe('Mouse input', function()
       ^t{1:esting}{3: }                 |
       mouse                    |
       support and selection    |
-      ~                        |
+      {0:~                        }|
       {2:-- VISUAL LINE --}        |
     ]])
   end)
@@ -102,17 +104,20 @@ describe('Mouse input', function()
       ^testing                  |
       mouse                    |
       support and selection    |
-      ~                        |
+      {0:~                        }|
       {2:-- VISUAL BLOCK --}       |
     ]])
   end)
 
   describe('tabline', function()
-    local tab_attrs = {
-      tab  = { background=Screen.colors.LightGrey, underline=true },
-      sel  = { bold=true },
-      fill = { reverse=true }
-    }
+    before_each(function()
+      screen:set_default_attr_ids( {
+        [0] = {bold=true, foreground=Screen.colors.Blue},
+        tab  = { background=Screen.colors.LightGrey, underline=true },
+        sel  = { bold=true },
+        fill = { reverse=true }
+      })
+    end)
 
     it('left click in default tabline (position 4) switches to tab', function()
       execute('%delete')
@@ -122,18 +127,18 @@ describe('Mouse input', function()
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftMouse><4,0>')
       screen:expect([[
         {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
         this is fo^o              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
     end)
 
     it('left click in default tabline (position 24) closes tab', function()
@@ -145,18 +150,18 @@ describe('Mouse input', function()
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<LeftMouse><24,0>')
       screen:expect([[
         this is fo^o              |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
     end)
 
     it('double click in default tabline (position 4) opens new tab', function()
@@ -168,18 +173,18 @@ describe('Mouse input', function()
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
         this is ba^r              |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
       feed('<2-LeftMouse><4,0>')
       screen:expect([[
         {sel:  Name] }{tab: + foo  + bar }{fill:  }{tab:X}|
         ^                         |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], tab_attrs)
+      ]])
     end)
 
     describe('%@ label', function()
@@ -201,9 +206,9 @@ describe('Mouse input', function()
           {fill:test-test2               }|
           mouse                    |
           support and selectio^n    |
-          ~                        |
+          {0:~                        }|
                                    |
-        ]], tab_attrs)
+        ]])
         meths.set_var('reply', {})
       end)
 
@@ -259,7 +264,7 @@ describe('Mouse input', function()
       testing                  |
       mo^use                    |
       support and selection    |
-      ~                        |
+      {0:~                        }|
                                |
     ]])
     feed('<LeftDrag><4,1>')
@@ -267,7 +272,7 @@ describe('Mouse input', function()
       testing                  |
       mo{1:us}^e                    |
       support and selection    |
-      ~                        |
+      {0:~                        }|
       {2:-- VISUAL --}             |
     ]])
     feed('<LeftDrag><2,2>')
@@ -275,7 +280,7 @@ describe('Mouse input', function()
       testing                  |
       mo{1:use}{3: }                   |
       {1:su}^pport and selection    |
-      ~                        |
+      {0:~                        }|
       {2:-- VISUAL --}             |
     ]])
     feed('<LeftDrag><0,0>')
@@ -283,18 +288,19 @@ describe('Mouse input', function()
       ^t{1:esting}{3: }                 |
       {1:mou}se                    |
       support and selection    |
-      ~                        |
+      {0:~                        }|
       {2:-- VISUAL --}             |
     ]])
   end)
 
   it('left drag changes visual selection after tab click', function()
-    local tab_attrs = {
+    screen:set_default_attr_ids({
+      [0] = {bold=true, foreground=Screen.colors.Blue},
       tab  = { background=Screen.colors.LightGrey, underline=true },
       sel  = { bold=true },
       fill = { reverse=true },
       vis  = { background=Screen.colors.LightGrey }
-    }
+    })
     execute('silent file foo | tabnew | file bar')
     insert('this is bar')
     execute('tabprevious')  -- go to first tab
@@ -302,27 +308,27 @@ describe('Mouse input', function()
       {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
       mouse                    |
       support and selectio^n    |
-      ~                        |
+      {0:~                        }|
                                |
-    ]], tab_attrs)
+    ]])
     feed('<LeftMouse><10,0><LeftRelease>')  -- go to second tab
     helpers.wait()
     feed('<LeftMouse><0,1>')
     screen:expect([[
       {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
       ^this is bar              |
-      ~                        |
-      ~                        |
+      {0:~                        }|
+      {0:~                        }|
                                |
-    ]], tab_attrs)
+    ]])
     feed('<LeftDrag><4,1>')
     screen:expect([[
       {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
       {vis:this}^ is bar              |
-      ~                        |
-      ~                        |
+      {0:~                        }|
+      {0:~                        }|
       {sel:-- VISUAL --}             |
-    ]], tab_attrs)
+    ]])
   end)
 
   it('two clicks will select the word and enter VISUAL', function()
@@ -331,7 +337,7 @@ describe('Mouse input', function()
       testing                  |
       mouse                    |
       {1:suppor}^t and selection    |
-      ~                        |
+      {0:~                        }|
       {2:-- VISUAL --}             |
     ]])
   end)
@@ -342,7 +348,7 @@ describe('Mouse input', function()
       testing                  |
       mouse                    |
       {1:su}^p{1:port and selection}{3: }   |
-      ~                        |
+      {0:~                        }|
       {2:-- VISUAL LINE --}        |
     ]])
   end)
@@ -353,7 +359,7 @@ describe('Mouse input', function()
       testing                  |
       mouse                    |
       su^pport and selection    |
-      ~                        |
+      {0:~                        }|
       {2:-- VISUAL BLOCK --}       |
     ]])
   end)
@@ -364,7 +370,7 @@ describe('Mouse input', function()
       ^testing                  |
       mouse                    |
       support and selection    |
-      ~                        |
+      {0:~                        }|
                                |
     ]])
     feed('<RightMouse><2,2>')
@@ -372,7 +378,7 @@ describe('Mouse input', function()
       {1:testing}{3: }                 |
       {1:mouse}{3: }                   |
       {1:su}^pport and selection    |
-      ~                        |
+      {0:~                        }|
       {2:-- VISUAL --}             |
     ]])
   end)
@@ -404,73 +410,71 @@ describe('Mouse input', function()
     ]])
     screen:try_resize(53, 14)
     execute('sp', 'vsp')
-    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue},
-            {reverse=true}, {bold=true, reverse=true}} )
     screen:expect([[
-      lines                     |lines                     |
-      to                        |to                        |
-      test                      |test                      |
-      mouse scrolling           |mouse scrolling           |
-      ^                          |                          |
-      ~                         |~                         |
-      [No Name] [+]              [No Name] [+]             |
+      lines                     {4:|}lines                     |
+      to                        {4:|}to                        |
+      test                      {4:|}test                      |
+      mouse scrolling           {4:|}mouse scrolling           |
+      ^                          {4:|}                          |
+      {0:~                         }{4:|}{0:~                         }|
+      {5:[No Name] [+]              }{4:[No Name] [+]             }|
       to                                                   |
       test                                                 |
       mouse scrolling                                      |
                                                            |
-      ~                                                    |
-      [No Name] [+]                                        |
+      {0:~                                                    }|
+      {4:[No Name] [+]                                        }|
       :vsp                                                 |
     ]])
     feed('<MouseUp><0,0>')
     screen:expect([[
-      mouse scrolling           |lines                     |
-      ^                          |to                        |
-      ~                         |test                      |
-      ~                         |mouse scrolling           |
-      ~                         |                          |
-      ~                         |~                         |
-      [No Name] [+]              [No Name] [+]             |
+      mouse scrolling           {4:|}lines                     |
+      ^                          {4:|}to                        |
+      {0:~                         }{4:|}test                      |
+      {0:~                         }{4:|}mouse scrolling           |
+      {0:~                         }{4:|}                          |
+      {0:~                         }{4:|}{0:~                         }|
+      {5:[No Name] [+]              }{4:[No Name] [+]             }|
       to                                                   |
       test                                                 |
       mouse scrolling                                      |
                                                            |
-      ~                                                    |
-      [No Name] [+]                                        |
+      {0:~                                                    }|
+      {4:[No Name] [+]                                        }|
                                                            |
     ]])
     feed('<MouseDown><27,0>')
     screen:expect([[
-      mouse scrolling           |text                      |
-      ^                          |with                      |
-      ~                         |many                      |
-      ~                         |lines                     |
-      ~                         |to                        |
-      ~                         |test                      |
-      [No Name] [+]              [No Name] [+]             |
+      mouse scrolling           {4:|}text                      |
+      ^                          {4:|}with                      |
+      {0:~                         }{4:|}many                      |
+      {0:~                         }{4:|}lines                     |
+      {0:~                         }{4:|}to                        |
+      {0:~                         }{4:|}test                      |
+      {5:[No Name] [+]              }{4:[No Name] [+]             }|
       to                                                   |
       test                                                 |
       mouse scrolling                                      |
                                                            |
-      ~                                                    |
-      [No Name] [+]                                        |
+      {0:~                                                    }|
+      {4:[No Name] [+]                                        }|
                                                            |
     ]])
     feed('<MouseDown><27,7><MouseDown>')
     screen:expect([[
-      mouse scrolling           |text                      |
-      ^                          |with                      |
-      ~                         |many                      |
-      ~                         |lines                     |
-      ~                         |to                        |
-      ~                         |test                      |
-      [No Name] [+]              [No Name] [+]             |
+      mouse scrolling           {4:|}text                      |
+      ^                          {4:|}with                      |
+      {0:~                         }{4:|}many                      |
+      {0:~                         }{4:|}lines                     |
+      {0:~                         }{4:|}to                        |
+      {0:~                         }{4:|}test                      |
+      {5:[No Name] [+]              }{4:[No Name] [+]             }|
       Inserting                                            |
       text                                                 |
       with                                                 |
       many                                                 |
       lines                                                |
-      [No Name] [+]                                        |
+      {4:[No Name] [+]                                        }|
                                                            |
     ]])
   end)
@@ -483,7 +487,7 @@ describe('Mouse input', function()
                                |
                                |
       bbbbbbbbbbbbbbb^b         |
-      ~                        |
+      {0:~                        }|
                                |
     ]])
 
@@ -492,7 +496,7 @@ describe('Mouse input', function()
                                |
                                |
       n bbbbbbbbbbbbbbbbbbb^b   |
-      ~                        |
+      {0:~                        }|
                                |
     ]])
 
@@ -501,7 +505,7 @@ describe('Mouse input', function()
       g                        |
                                |
       ^t and selection bbbbbbbbb|
-      ~                        |
+      {0:~                        }|
                                |
     ]])
   end)
@@ -509,12 +513,13 @@ describe('Mouse input', function()
   describe('on concealed text', function()
     -- Helpful for reading the test expectations:
     -- :match Error /\^/
-    local concealed = {
-      c = { foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGray }
-    }
 
     before_each(function()
       screen:try_resize(25, 7)
+      screen:set_default_attr_ids({
+        [0] = {bold=true, foreground=Screen.colors.Blue},
+        c = { foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGray },
+      })
       feed('ggdG')
 
       execute('set concealcursor=n')
@@ -540,44 +545,44 @@ describe('Mouse input', function()
         {c:^Y}rem ip{c:X}um do{c: } {c:X}it {c: }, con|
         {c:X}tet {c: }ta ka{c:X}d {c:X}ber{c:X}en, no|
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><1,0>')
       screen:expect([[
         {c:Y}^rem ip{c:X}um do{c: } {c:X}it {c: }, con|
         {c:X}tet {c: }ta ka{c:X}d {c:X}ber{c:X}en, no|
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,0>')
       screen:expect([[
         {c:Y}rem ip{c:X}um do{c: } {c:^X}it {c: }, con|
         {c:X}tet {c: }ta ka{c:X}d {c:X}ber{c:X}en, no|
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,1>')
       screen:expect([[
         {c:Y}rem ip{c:X}um do{c: } {c:X}it {c: }, con|
         {c:X}tet {c: }ta ka{c:X}d {c:X}^ber{c:X}en, no|
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
     end) -- level 1 - non wrapped
 
     it('(level 1) click on wrapped lines', function()
@@ -592,7 +597,7 @@ describe('Mouse input', function()
         , no {c:X}ea takimata {c:X}anctu{c:X}|
          e{c:X}t.                    |
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><6,1>')
       screen:expect([[
@@ -603,7 +608,7 @@ describe('Mouse input', function()
         , no {c:X}ea takimata {c:X}anctu{c:X}|
          e{c:X}t.                    |
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,1>')
       screen:expect([[
@@ -614,7 +619,7 @@ describe('Mouse input', function()
         , no {c:X}ea takimata {c:X}anctu{c:X}|
          e{c:X}t.                    |
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,3>')
       screen:expect([[
@@ -625,7 +630,7 @@ describe('Mouse input', function()
         , no {c:X}ea takimata {c:X}anctu{c:X}|
          e{c:X}t.                    |
                                  |
-      ]], concealed)
+      ]])
     end) -- level 1 - wrapped
 
 
@@ -637,44 +642,44 @@ describe('Mouse input', function()
         {c:^Y}rem ip{c:X}um do {c:X}it , con{c:X}e|
         {c:X}tet ta ka{c:X}d {c:X}ber{c:X}en, no |
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><1,0>')
       screen:expect([[
         {c:Y}^rem ip{c:X}um do {c:X}it , con{c:X}e|
         {c:X}tet ta ka{c:X}d {c:X}ber{c:X}en, no |
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,0>')
       screen:expect([[
         {c:Y}rem ip{c:X}um do {c:X}^it , con{c:X}e|
         {c:X}tet ta ka{c:X}d {c:X}ber{c:X}en, no |
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,1>')
       screen:expect([[
         {c:Y}rem ip{c:X}um do {c:X}it , con{c:X}e|
         {c:X}tet ta ka{c:X}d {c:X}b^er{c:X}en, no |
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
     end) -- level 2 - non wrapped
 
     it('(level 2) click on wrapped lines', function()
@@ -689,7 +694,7 @@ describe('Mouse input', function()
         , no {c:X}ea takimata {c:X}anctu{c:X}|
          e{c:X}t.                    |
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><6,1>')
       screen:expect([[
@@ -700,7 +705,7 @@ describe('Mouse input', function()
         , no {c:X}ea takimata {c:X}anctu{c:X}|
          e{c:X}t.                    |
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,1>')
       screen:expect([[
@@ -711,7 +716,7 @@ describe('Mouse input', function()
         , no {c:X}ea takimata {c:X}anctu{c:X}|
          e{c:X}t.                    |
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,3>')
       screen:expect([[
@@ -722,7 +727,7 @@ describe('Mouse input', function()
         , no {c:X}ea takimata {c:X}anctu{c:X}|
          e{c:X}t.                    |
                                  |
-      ]], concealed)
+      ]])
     end) -- level 2 - wrapped
 
 
@@ -734,44 +739,44 @@ describe('Mouse input', function()
         ^rem ipum do it , conetetu|
         tet ta kad beren, no ea t|
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><1,0>')
       screen:expect([[
         r^em ipum do it , conetetu|
         tet ta kad beren, no ea t|
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,0>')
       screen:expect([[
         rem ipum do it ^, conetetu|
         tet ta kad beren, no ea t|
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,1>')
       screen:expect([[
         rem ipum do it , conetetu|
         tet ta kad bere^n, no ea t|
                                  |
-        ~                        |
-        ~                        |
-        ~                        |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
                                  |
-      ]], concealed)
+      ]])
     end) -- level 3 - non wrapped
 
     it('(level 3) click on wrapped lines', function()
@@ -786,7 +791,7 @@ describe('Mouse input', function()
         , no ea takimata anctu   |
          et.                     |
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><6,1>')
       screen:expect([[
@@ -797,7 +802,7 @@ describe('Mouse input', function()
         , no ea takimata anctu   |
          et.                     |
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,1>')
       screen:expect([[
@@ -808,7 +813,7 @@ describe('Mouse input', function()
         , no ea takimata anctu   |
          et.                     |
                                  |
-      ]], concealed)
+      ]])
 
       feed('<esc><LeftMouse><15,3>')
       screen:expect([[
@@ -819,7 +824,7 @@ describe('Mouse input', function()
         , no ea takimata anctu   |
          et.                     |
                                  |
-      ]], concealed)
+      ]])
     end) -- level 3 - wrapped
   end)
 end)

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -7,11 +7,6 @@ local eq, funcs = helpers.eq, helpers.funcs
 describe('Mouse input', function()
   local screen
 
-  local hlgroup_colors = {
-    NonText = Screen.colors.Blue,
-    Visual = Screen.colors.LightGrey
-  }
-
   before_each(function()
     clear()
     meths.set_option('mouse', 'a')
@@ -22,15 +17,15 @@ describe('Mouse input', function()
     screen = Screen.new(25, 5)
     screen:attach()
     screen:set_default_attr_ids({
-      [1] = {background = hlgroup_colors.Visual},
+      [1] = {background = Screen.colors.LightGrey},
       [2] = {bold = true},
       [3] = {
-        foreground = hlgroup_colors.NonText,
-        background = hlgroup_colors.Visual,
+        foreground = Screen.colors.Blue,
+        background = Screen.colors.LightGrey,
         bold = true,
       },
     })
-    screen:set_default_attr_ignore( {{bold=true, foreground=hlgroup_colors.NonText}} )
+    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue}} )
     feed('itesting<cr>mouse<cr>support and selection<esc>')
     screen:expect([[
       testing                  |
@@ -409,7 +404,7 @@ describe('Mouse input', function()
     ]])
     screen:try_resize(53, 14)
     execute('sp', 'vsp')
-    screen:set_default_attr_ignore( {{bold=true, foreground=hlgroup_colors.NonText},
+    screen:set_default_attr_ignore( {{bold=true, foreground=Screen.colors.Blue},
             {reverse=true}, {bold=true, reverse=true}} )
     screen:expect([[
       lines                     |lines                     |

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -9,12 +9,12 @@ describe("shell command :!", function()
       '", "-u", "NONE", "-i", "NONE", "--cmd", "set noswapfile"]')
     screen:expect([[
       {1: }                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name]                                         }|
                                                         |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 
@@ -27,13 +27,13 @@ describe("shell command :!", function()
     --       to avoid triggering a UI flush.
     child_session.feed_data(":!printf foo; sleep 200\n")
     screen:expect([[
-      ~                                                 |
-      ~                                                 |
-      [No Name]                                         |
-      :!printf foo; sleep 200                           |
+      {1: }                                                 |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name]                                         }|
                                                         |
-      foo                                               |
-      -- TERMINAL --                                    |
+      {3:-- TERMINAL --}                                    |
     ]])
   end)
 end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -234,8 +234,10 @@ function Screen:expect(expected, attr_ids, attr_ignore)
         return (
           'Row ' .. tostring(i) .. ' didn\'t match.\n'
           .. 'Expected:\n|' .. table.concat(msg_expected_rows, '|\n|') .. '|\n'
-          .. 'Actual:\n|' .. table.concat(actual_rows, '|\n|') .. '|'
-        )
+          .. 'Actual:\n|' .. table.concat(actual_rows, '|\n|') .. '|\n\n' .. [[
+To print the expect() call that would assert the current screen state, use
+screen:snaphot_util(). In case of non-deterministic failures, use
+screen:redraw_debug() to show all intermediate screen states.  ]])
       end
     end
   end)

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -15,7 +15,10 @@ describe('Initial screen', function()
     set_session(screen_nvim)
     screen = Screen.new()
     screen:attach()
-    screen:set_default_attr_ignore( {{bold=true, foreground=255}} )
+    screen:set_default_attr_ids( {
+      [0] = {bold=true, foreground=255},
+      [1] = {bold=true, reverse=true},
+    } )
   end)
 
   after_each(function()
@@ -25,18 +28,18 @@ describe('Initial screen', function()
   it('is the default initial screen', function()
       screen:expect([[
       ^                                                     |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      ~                                                    |
-      [No Name]                                            |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {1:[No Name]                                            }|
                                                            |
     ]])
   end)
@@ -49,7 +52,16 @@ describe('Screen', function()
     clear()
     screen = Screen.new()
     screen:attach()
-    screen:set_default_attr_ignore( {{bold=true, foreground=255}} )
+    screen:set_default_attr_ids( {
+      [0] = {bold=true, foreground=255},
+      [1] = {bold=true, reverse=true},
+      [2] = {bold=true},
+      [3] = {reverse=true},
+      [4] = {background = Screen.colors.LightGrey, underline = true},
+      [5] = {background = Screen.colors.LightGrey, underline = true, bold = true, foreground = Screen.colors.Fuchsia},
+      [6] = {bold = true, foreground = Screen.colors.Fuchsia},
+      [7] = {bold = true, foreground = Screen.colors.SeaGreen},
+    } )
   end)
 
   after_each(function()
@@ -147,18 +159,18 @@ describe('Screen', function()
         execute('sp')
         screen:expect([[
           ^                                                     |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          [No Name]                                            |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {1:[No Name]                                            }|
                                                                |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          [No Name]                                            |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {3:[No Name]                                            }|
           :sp                                                  |
         ]])
       end)
@@ -168,18 +180,18 @@ describe('Screen', function()
         execute('resize 8')
         screen:expect([[
           ^                                                     |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          [No Name]                                            |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {1:[No Name]                                            }|
                                                                |
-          ~                                                    |
-          ~                                                    |
-          [No Name]                                            |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {3:[No Name]                                            }|
           :resize 8                                            |
         ]])
       end)
@@ -187,36 +199,36 @@ describe('Screen', function()
       it('horizontal and vertical', function()
         execute('sp', 'vsp', 'vsp')
         screen:expect([[
-          ^                    |                |               |
-          ~                   |~               |~              |
-          ~                   |~               |~              |
-          ~                   |~               |~              |
-          ~                   |~               |~              |
-          ~                   |~               |~              |
-          [No Name]            [No Name]        [No Name]      |
+          ^                    {3:|}                {3:|}               |
+          {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+          {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+          {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+          {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+          {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+          {1:[No Name]            }{3:[No Name]        [No Name]      }|
                                                                |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          [No Name]                                            |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {3:[No Name]                                            }|
                                                                |
         ]])
         insert('hello')
         screen:expect([[
-          hell^o               |hello           |hello          |
-          ~                   |~               |~              |
-          ~                   |~               |~              |
-          ~                   |~               |~              |
-          ~                   |~               |~              |
-          ~                   |~               |~              |
-          [No Name] [+]        [No Name] [+]    [No Name] [+]  |
+          hell^o               {3:|}hello           {3:|}hello          |
+          {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+          {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+          {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+          {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+          {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+          {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
           hello                                                |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          [No Name] [+]                                        |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {3:[No Name] [+]                                        }|
                                                                |
         ]])
       end)
@@ -228,55 +240,55 @@ describe('Screen', function()
       execute('sp', 'vsp', 'vsp')
       insert('hello')
       screen:expect([[
-        hell^o               |hello           |hello          |
-        ~                   |~               |~              |
-        ~                   |~               |~              |
-        ~                   |~               |~              |
-        ~                   |~               |~              |
-        ~                   |~               |~              |
-        [No Name] [+]        [No Name] [+]    [No Name] [+]  |
+        hell^o               {3:|}hello           {3:|}hello          |
+        {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+        {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+        {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+        {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+        {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
         hello                                                |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        [No Name] [+]                                        |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {3:[No Name] [+]                                        }|
                                                              |
       ]])
       execute('tabnew')
       insert('hello2')
       feed('h')
       screen:expect([[
-         4+ [No Name]  + [No Name]                          X|
+        {4: }{5:4}{4:+ [No Name] }{2: + [No Name] }{3:                         }{4:X}|
         hell^o2                                               |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
                                                              |
       ]])
       execute('tabprevious')
       screen:expect([[
-         4+ [No Name]  + [No Name]                          X|
-        hell^o               |hello           |hello          |
-        ~                   |~               |~              |
-        ~                   |~               |~              |
-        ~                   |~               |~              |
-        ~                   |~               |~              |
-        ~                   |~               |~              |
-        [No Name] [+]        [No Name] [+]    [No Name] [+]  |
+        {2: }{6:4}{2:+ [No Name] }{4: + [No Name] }{3:                         }{4:X}|
+        hell^o               {3:|}hello           {3:|}hello          |
+        {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+        {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+        {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+        {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+        {0:~                   }{3:|}{0:~               }{3:|}{0:~              }|
+        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
         hello                                                |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        [No Name] [+]                                        |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {3:[No Name] [+]                                        }|
                                                              |
       ]])
     end)
@@ -289,17 +301,17 @@ describe('Screen', function()
         line 1                                               |
         line 2                                               |
         ^                                                     |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        -- INSERT --                                         |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {2:-- INSERT --}                                         |
       ]])
     end)
   end)
@@ -314,17 +326,17 @@ describe('Screen', function()
       screen:expect([[
         0123^456                                              |
         789                                                  |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
         :set ruler                         1,5           All |
       ]])
     end)
@@ -335,18 +347,18 @@ describe('Screen', function()
       feed(':ls')
       screen:expect([[
                                                              |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
         :ls^                                                  |
       ]])
     end)
@@ -354,20 +366,20 @@ describe('Screen', function()
     it('execute command with multi-line output', function()
       feed(':ls<cr>')
       screen:expect([[
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
         :ls                                                  |
           1 %a   "[No Name]"                    line 1       |
-        Press ENTER or type command to continue^              |
+        {7:Press ENTER or type command to continue}^              |
       ]])
       feed('<cr>') --  skip the "Press ENTER..." state or tests will hang
     end)
@@ -392,19 +404,19 @@ describe('Screen', function()
       ]])
       execute('sp', 'vsp', 'vsp')
       screen:expect([[
-        and                 |and             |and            |
-        clearing            |clearing        |clearing       |
-        in                  |in              |in             |
-        split               |split           |split          |
-        windows             |windows         |windows        |
-        ^                    |                |               |
-        [No Name] [+]        [No Name] [+]    [No Name] [+]  |
+        and                 {3:|}and             {3:|}and            |
+        clearing            {3:|}clearing        {3:|}clearing       |
+        in                  {3:|}in              {3:|}in             |
+        split               {3:|}split           {3:|}split          |
+        windows             {3:|}windows         {3:|}windows        |
+        ^                    {3:|}                {3:|}               |
+        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        [No Name] [+]                                        |
+        {3:[No Name] [+]                                        }|
                                                              |
       ]])
     end)
@@ -412,121 +424,121 @@ describe('Screen', function()
     it('only affects the current scroll region', function()
       feed('6k')
       screen:expect([[
-        ^scrolling           |and             |and            |
-        and                 |clearing        |clearing       |
-        clearing            |in              |in             |
-        in                  |split           |split          |
-        split               |windows         |windows        |
-        windows             |                |               |
-        [No Name] [+]        [No Name] [+]    [No Name] [+]  |
+        ^scrolling           {3:|}and             {3:|}and            |
+        and                 {3:|}clearing        {3:|}clearing       |
+        clearing            {3:|}in              {3:|}in             |
+        in                  {3:|}split           {3:|}split          |
+        split               {3:|}windows         {3:|}windows        |
+        windows             {3:|}                {3:|}               |
+        {1:[No Name] [+]        }{3:[No Name] [+]    [No Name] [+]  }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        [No Name] [+]                                        |
+        {3:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('<c-w>l')
       screen:expect([[
-        scrolling           |and                 |and        |
-        and                 |clearing            |clearing   |
-        clearing            |in                  |in         |
-        in                  |split               |split      |
-        split               |windows             |windows    |
-        windows             |^                    |           |
-        [No Name] [+]        [No Name] [+]        <Name] [+] |
+        scrolling           {3:|}and                 {3:|}and        |
+        and                 {3:|}clearing            {3:|}clearing   |
+        clearing            {3:|}in                  {3:|}in         |
+        in                  {3:|}split               {3:|}split      |
+        split               {3:|}windows             {3:|}windows    |
+        windows             {3:|}^                    {3:|}           |
+        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        [No Name] [+]                                        |
+        {3:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('gg')
       screen:expect([[
-        scrolling           |^Inserting           |and        |
-        and                 |text                |clearing   |
-        clearing            |with                |in         |
-        in                  |many                |split      |
-        split               |lines               |windows    |
-        windows             |to                  |           |
-        [No Name] [+]        [No Name] [+]        <Name] [+] |
+        scrolling           {3:|}^Inserting           {3:|}and        |
+        and                 {3:|}text                {3:|}clearing   |
+        clearing            {3:|}with                {3:|}in         |
+        in                  {3:|}many                {3:|}split      |
+        split               {3:|}lines               {3:|}windows    |
+        windows             {3:|}to                  {3:|}           |
+        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        [No Name] [+]                                        |
+        {3:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('7j')
       screen:expect([[
-        scrolling           |with                |and        |
-        and                 |many                |clearing   |
-        clearing            |lines               |in         |
-        in                  |to                  |split      |
-        split               |test                |windows    |
-        windows             |^scrolling           |           |
-        [No Name] [+]        [No Name] [+]        <Name] [+] |
+        scrolling           {3:|}with                {3:|}and        |
+        and                 {3:|}many                {3:|}clearing   |
+        clearing            {3:|}lines               {3:|}in         |
+        in                  {3:|}to                  {3:|}split      |
+        split               {3:|}test                {3:|}windows    |
+        windows             {3:|}^scrolling           {3:|}           |
+        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        [No Name] [+]                                        |
+        {3:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('2j')
       screen:expect([[
-        scrolling           |lines               |and        |
-        and                 |to                  |clearing   |
-        clearing            |test                |in         |
-        in                  |scrolling           |split      |
-        split               |and                 |windows    |
-        windows             |^clearing            |           |
-        [No Name] [+]        [No Name] [+]        <Name] [+] |
+        scrolling           {3:|}lines               {3:|}and        |
+        and                 {3:|}to                  {3:|}clearing   |
+        clearing            {3:|}test                {3:|}in         |
+        in                  {3:|}scrolling           {3:|}split      |
+        split               {3:|}and                 {3:|}windows    |
+        windows             {3:|}^clearing            {3:|}           |
+        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        [No Name] [+]                                        |
+        {3:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('5k')
       screen:expect([[
-        scrolling           |^lines               |and        |
-        and                 |to                  |clearing   |
-        clearing            |test                |in         |
-        in                  |scrolling           |split      |
-        split               |and                 |windows    |
-        windows             |clearing            |           |
-        [No Name] [+]        [No Name] [+]        <Name] [+] |
+        scrolling           {3:|}^lines               {3:|}and        |
+        and                 {3:|}to                  {3:|}clearing   |
+        clearing            {3:|}test                {3:|}in         |
+        in                  {3:|}scrolling           {3:|}split      |
+        split               {3:|}and                 {3:|}windows    |
+        windows             {3:|}clearing            {3:|}           |
+        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        [No Name] [+]                                        |
+        {3:[No Name] [+]                                        }|
                                                              |
       ]])
       feed('k')
       screen:expect([[
-        scrolling           |^many                |and        |
-        and                 |lines               |clearing   |
-        clearing            |to                  |in         |
-        in                  |test                |split      |
-        split               |scrolling           |windows    |
-        windows             |and                 |           |
-        [No Name] [+]        [No Name] [+]        <Name] [+] |
+        scrolling           {3:|}^many                {3:|}and        |
+        and                 {3:|}lines               {3:|}clearing   |
+        clearing            {3:|}to                  {3:|}in         |
+        in                  {3:|}test                {3:|}split      |
+        split               {3:|}scrolling           {3:|}windows    |
+        windows             {3:|}and                 {3:|}           |
+        {3:[No Name] [+]        }{1:[No Name] [+]        }{3:<Name] [+] }|
         clearing                                             |
         in                                                   |
         split                                                |
         windows                                              |
                                                              |
-        [No Name] [+]                                        |
+        {3:[No Name] [+]                                        }|
                                                              |
       ]])
     end)
@@ -541,10 +553,10 @@ describe('Screen', function()
     it('rebuilds the whole screen', function()
       screen:expect([[
         resize^                   |
-        ~                        |
-        ~                        |
-        ~                        |
-        -- INSERT --             |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
+        {2:-- INSERT --}             |
       ]])
     end)
 

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -6,23 +6,18 @@ local execute = helpers.execute
 describe('search highlighting', function()
   local screen
   local colors = Screen.colors
-  local hl_colors = {
-    NonText = colors.Blue,
-    Search = colors.Yellow,
-    Message = colors.Red,
-  }
 
   before_each(function()
     clear()
     screen = Screen.new(40, 7)
     screen:attach()
     --ignore highligting of ~-lines
+    screen:set_default_attr_ignore( {{bold=true, foreground=colors.Blue}} )
     screen:set_default_attr_ids( {
-      [1] = {background = hl_colors.Search},
+      [1] = {background = colors.Yellow}, -- Search
       [2] = {reverse = true},
-      [3] = {foreground = hl_colors.Message},
+      [3] = {foreground = colors.Red}, -- Message
     })
-    screen:set_default_attr_ignore( {{bold=true, foreground=hl_colors.NonText}} )
   end)
 
   it('is disabled by ":set nohlsearch"', function()
@@ -250,8 +245,8 @@ describe('search highlighting', function()
       ~                                       |
       ~                                       |
       {3:search hit BOTTOM, continuing at TOP}    |
-    ]], {[1] = {background = hl_colors.Search}, [2] = {reverse = true},
-    [3] = {foreground = hl_colors.Message}, [4] = {bold = true, background =
+    ]], {[1] = {background = colors.Yellow}, [2] = {reverse = true},
+    [3] = {foreground = colors.Red}, [4] = {bold = true, background =
     colors.Green}, [5] = {italic = true, background = colors.Magenta}})
 
     execute("call clearmatches()")
@@ -276,9 +271,9 @@ describe('search highlighting', function()
       ~                                       |
       ~                                       |
       :syntax keyword MyGroup special         |
-    ]], {[1] = {background =  hl_colors.Search}, [2] = {reverse = true},
-    [3] = {foreground = hl_colors.Message}, [4] = {bold = true,
-    background = colors.Green}, [5] = {bold = true, background = hl_colors.Search}})
+    ]], {[1] = {background =  colors.Yellow}, [2] = {reverse = true},
+    [3] = {foreground = colors.Red}, [4] = {bold = true,
+    background = colors.Green}, [5] = {bold = true, background = colors.Yellow}})
 
   end)
 end)

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -11,12 +11,11 @@ describe('search highlighting', function()
     clear()
     screen = Screen.new(40, 7)
     screen:attach()
-    --ignore highligting of ~-lines
-    screen:set_default_attr_ignore( {{bold=true, foreground=colors.Blue}} )
     screen:set_default_attr_ids( {
-      [1] = {background = colors.Yellow}, -- Search
-      [2] = {reverse = true},
-      [3] = {foreground = colors.Red}, -- Message
+      [1] = {bold=true, foreground=Screen.colors.Blue},
+      [2] = {background = colors.Yellow}, -- Search
+      [3] = {reverse = true},
+      [4] = {foreground = colors.Red}, -- Message
     })
   end)
 
@@ -27,10 +26,10 @@ describe('search highlighting', function()
     screen:expect([[
       some ^text                               |
       more text                               |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       /text                                   |
     ]])
   end)
@@ -46,35 +45,35 @@ describe('search highlighting', function()
     -- 'hlsearch' is enabled by default. #2859
     feed("gg/text<cr>")
     screen:expect([[
-        some {1:^text}                             |
-        more {1:text}stuff                        |
-        stupid{1:texttext}stuff                   |
-        a {1:text} word                           |
+        some {2:^text}                             |
+        more {2:text}stuff                        |
+        stupid{2:texttext}stuff                   |
+        a {2:text} word                           |
                                               |
-      ~                                       |
+      {1:~                                       }|
       /text                                   |
     ]])
 
     -- overlapping matches not allowed
     feed("3nx")
     screen:expect([[
-        some {1:text}                             |
-        more {1:text}stuff                        |
-        stupid{1:text}^extstuff                    |
-        a {1:text} word                           |
+        some {2:text}                             |
+        more {2:text}stuff                        |
+        stupid{2:text}^extstuff                    |
+        a {2:text} word                           |
                                               |
-      ~                                       |
+      {1:~                                       }|
       /text                                   |
     ]])
 
     feed("ggn*") -- search for entire word
     screen:expect([[
-        some {1:text}                             |
+        some {2:text}                             |
         more textstuff                        |
         stupidtextextstuff                    |
-        a {1:^text} word                           |
+        a {2:^text} word                           |
                                               |
-      ~                                       |
+      {1:~                                       }|
       /\<text\>                               |
     ]])
 
@@ -85,7 +84,7 @@ describe('search highlighting', function()
         stupidtextextstuff                    |
         a ^text word                           |
                                               |
-      ~                                       |
+      {1:~                                       }|
       :nohlsearch                             |
     ]])
   end)
@@ -99,45 +98,45 @@ describe('search highlighting', function()
     ]])
     feed("gg/li")
     screen:expect([[
-        the first {2:li}ne                        |
+        the first {3:li}ne                        |
         in a little file                      |
                                               |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       /li^                                     |
     ]])
 
     feed("t")
     screen:expect([[
         the first line                        |
-        in a {2:lit}tle file                      |
+        in a {3:lit}tle file                      |
                                               |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       /lit^                                    |
     ]])
 
     feed("<cr>")
     screen:expect([[
         the first line                        |
-        in a {1:^lit}tle file                      |
+        in a {2:^lit}tle file                      |
                                               |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       /lit                                    |
     ]])
 
     feed("/fir")
     screen:expect([[
-        the {2:fir}st line                        |
-        in a {1:lit}tle file                      |
+        the {3:fir}st line                        |
+        in a {2:lit}tle file                      |
                                               |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       /fir^                                    |
     ]])
 
@@ -145,11 +144,11 @@ describe('search highlighting', function()
     feed("<esc>/ttle")
     screen:expect([[
         the first line                        |
-        in a {1:li}{2:ttle} file                      |
+        in a {2:li}{3:ttle} file                      |
                                               |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       /ttle^                                   |
     ]])
   end)
@@ -163,12 +162,12 @@ describe('search highlighting', function()
 
     feed("gg/mat/e")
     screen:expect([[
-      not the {2:mat}ch you're looking for        |
+      not the {3:mat}ch you're looking for        |
       the match is here                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       /mat/e^                                  |
     ]])
 
@@ -176,22 +175,22 @@ describe('search highlighting', function()
     feed("<esc>2/mat/e")
     screen:expect([[
       not the match you're looking for        |
-      the {2:mat}ch is here                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      the {3:mat}ch is here                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       /mat/e^                                  |
     ]])
 
     feed("<cr>")
     screen:expect([[
-      not the {1:mat}ch you're looking for        |
-      the {1:ma^t}ch is here                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      not the {2:mat}ch you're looking for        |
+      the {2:ma^t}ch is here                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       /mat/e                                  |
     ]])
   end)
@@ -202,28 +201,37 @@ describe('search highlighting', function()
     feed('/line\\na<cr>')
     screen:expect([[
                                               |
-      a  repeated {1:^line}                        |
-      {1:a}  repeated {1:line}                        |
-      {1:a}  repeated {1:line}                        |
-      {1:a}  repeated line                        |
-      ~                                       |
-      {3:search hit BOTTOM, continuing at TOP}    |
+      a  repeated {2:^line}                        |
+      {2:a}  repeated {2:line}                        |
+      {2:a}  repeated {2:line}                        |
+      {2:a}  repeated line                        |
+      {1:~                                       }|
+      {4:search hit BOTTOM, continuing at TOP}    |
     ]])
 
     -- it redraws rows above the changed one
     feed('4Grb')
     screen:expect([[
                                               |
-      a  repeated {1:line}                        |
-      {1:a}  repeated line                        |
-      ^b  repeated {1:line}                        |
-      {1:a}  repeated line                        |
-      ~                                       |
-      {3:search hit BOTTOM, continuing at TOP}    |
+      a  repeated {2:line}                        |
+      {2:a}  repeated line                        |
+      ^b  repeated {2:line}                        |
+      {2:a}  repeated line                        |
+      {1:~                                       }|
+      {4:search hit BOTTOM, continuing at TOP}    |
     ]])
   end)
 
   it('works with matchadd and syntax', function()
+    screen:set_default_attr_ids( {
+        [1] = {bold=true, foreground=Screen.colors.Blue},
+        [2] = {background = colors.Yellow},
+        [3] = {reverse = true},
+        [4] = {foreground = colors.Red},
+        [5] = {bold = true, background = colors.Green},
+        [6] = {italic = true, background = colors.Magenta},
+        [7] = {bold = true, background = colors.Yellow},
+    } )
     execute('set hlsearch')
     insert([[
       very special text
@@ -238,25 +246,23 @@ describe('search highlighting', function()
     -- is used (and matches with lower priorities are not combined)
     execute("/ial te")
     screen:expect([[
-        very {4:spec^ial}{1: te}{5:xt}                     |
+        very {5:spec^ial}{2: te}{6:xt}                     |
                                               |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      {3:search hit BOTTOM, continuing at TOP}    |
-    ]], {[1] = {background = colors.Yellow}, [2] = {reverse = true},
-    [3] = {foreground = colors.Red}, [4] = {bold = true, background =
-    colors.Green}, [5] = {italic = true, background = colors.Magenta}})
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {4:search hit BOTTOM, continuing at TOP}    |
+    ]])
 
     execute("call clearmatches()")
     screen:expect([[
-        very spec{1:^ial te}xt                     |
+        very spec{2:^ial te}xt                     |
                                               |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       :call clearmatches()                    |
     ]])
 
@@ -264,16 +270,14 @@ describe('search highlighting', function()
     -- nonconflicting attributes are combined
     execute("syntax keyword MyGroup special")
     screen:expect([[
-        very {4:spec}{5:^ial}{1: te}xt                     |
+        very {5:spec}{7:^ial}{2: te}xt                     |
                                               |
-      ~                                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       :syntax keyword MyGroup special         |
-    ]], {[1] = {background =  colors.Yellow}, [2] = {reverse = true},
-    [3] = {foreground = colors.Red}, [4] = {bold = true,
-    background = colors.Green}, [5] = {bold = true, background = colors.Yellow}})
+    ]])
 
   end)
 end)

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -9,7 +9,11 @@ describe('Signs', function()
     clear()
     screen = Screen.new()
     screen:attach()
-    screen:set_default_attr_ignore( {{}, {bold=true, foreground=255}} ) 
+    screen:set_default_attr_ids( {
+      [0] = {bold=true, foreground=255},
+      [1] = {background = Screen.colors.Yellow},
+      [2] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.Grey},
+    } )
   end)
 
   after_each(function()
@@ -25,19 +29,19 @@ describe('Signs', function()
       execute('sign place 2 line=3 name=piet buffer=1')
       execute('sign place 3 line=1 name=pietx buffer=1')
       screen:expect([[
-        >!a                                                  |
-          b                                                  |
-        >>c                                                  |
-          ^                                                   |
-          ~                                                  |
-          ~                                                  |
-          ~                                                  |
-          ~                                                  |
-          ~                                                  |
-          ~                                                  |
-          ~                                                  |
-          ~                                                  |
-          ~                                                  |
+        {1:>!}a                                                  |
+        {2:  }b                                                  |
+        {1:>>}c                                                  |
+        {2:  }^                                                   |
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
         :sign place 3 line=1 name=pietx buffer=1             |
       ]])
     end)

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -10,8 +10,10 @@ describe('Screen', function()
     clear()
     screen = Screen.new(nil,10)
     screen:attach()
-    screen:set_default_attr_ignore( {{bold=true, foreground=255}} )
-    screen:set_default_attr_ids( {{foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGray}} )
+    screen:set_default_attr_ids( {
+      [0] = {bold=true, foreground=Screen.colors.Blue},
+      [1] = {foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGray}
+    } )
   end)
   
   after_each(function()
@@ -46,8 +48,8 @@ describe('Screen', function()
             {1:∧}                                                    |
             {1:∧}                                                    |
             ^                                                     |
-            ~                                                    |
-            ~                                                    |
+            {0:~                                                    }|
+            {0:~                                                    }|
             :syn match dAmpersand '[&][&]' conceal cchar=∧       |
           ]])
       end)
@@ -62,8 +64,8 @@ describe('Screen', function()
           {1:∧}                                                    |
           ^&&                                                   |
                                                                |
-          ~                                                    |
-          ~                                                    |
+          {0:~                                                    }|
+          {0:~                                                    }|
           :syn match dAmpersand '[&][&]' conceal cchar=∧       |
         ]])
       end)
@@ -78,8 +80,8 @@ describe('Screen', function()
           {1:∧}                                                    |
           {1:∧}                                                    |
                                                                |
-          ~                                                    |
-          ~                                                    |
+          {0:~                                                    }|
+          {0:~                                                    }|
           :syn match dAmpersand '[&][&]' conceal cchar=∧       |
         ]])
       end)
@@ -94,8 +96,8 @@ describe('Screen', function()
           {1:∧}                                                    |
           {1:∧}                                                    |
                                                                |
-          ~                                                    |
-          ~                                                    |
+          {0:~                                                    }|
+          {0:~                                                    }|
           :syn match dAmpersand '[&][&]' conceal cchar=∧       |
         ]])
       end)
@@ -110,8 +112,8 @@ describe('Screen', function()
           {1:∧}                                                    |
           {1:∧}                                                    |
           ^                                                     |
-          ~                                                    |
-          ~                                                    |
+          {0:~                                                    }|
+          {0:~                                                    }|
           :syn match dAmpersand '[&][&]' conceal cchar=∧       |
         ]])
       end)
@@ -125,12 +127,12 @@ describe('Screen', function()
         {1:λ}                                                    |
         {1:λ}                                                    |
         ^                                                     |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
         :syn keyword kLambda lambda conceal cchar=λ          |
       ]])
     end) -- Keyword
@@ -149,12 +151,12 @@ describe('Screen', function()
           {1:R}                                                    |
           {1:R}                                                    |
           ^                                                     |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
                                                                |
         ]])
       end)
@@ -167,12 +169,12 @@ describe('Screen', function()
           {1: } a region of text {1:-}                                 |
           {1: } a region of text {1:-}                                 |
           ^                                                     |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
                                                                |
         ]])
       end)
@@ -186,10 +188,10 @@ describe('Screen', function()
           {1: } A region with {1: } a nested {1: } nested region.{1:-}         |
            {1:-} {1:-}                                                 |
           ^                                                     |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
                                                                |
         ]])
       end)
@@ -208,12 +210,12 @@ describe('Screen', function()
           {1:-}                                                    |
           {1:-}                                                    |
           ^                                                     |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
           :syn region rText start='<r>' end='</r>' cchar=-     |
         ]])
       end)
@@ -229,10 +231,10 @@ describe('Screen', function()
           <i> italian text </i>                                |
           <i> italian text </i>                                |
           ^                                                     |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
           :syn region iText start='<i>' end='</i>' cchar=*     |
         ]])
         execute("syntax conceal on")
@@ -243,10 +245,10 @@ describe('Screen', function()
           {1:*}                                                    |
           {1:*}                                                    |
           ^                                                     |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
-          ~                                                    |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
           :syn region iText start='<i>' end='</i>' cchar=*     |
         ]])
       end)
@@ -271,10 +273,10 @@ describe('Screen', function()
         + With cchar                                         |
                                                              |
         ^                                                     |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
         :let &conceallevel=0                                 |
       ]])
     end)
@@ -287,10 +289,10 @@ describe('Screen', function()
         {1:C}                                                    |
                                                              |
         ^                                                     |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
         :let &conceallevel=1                                 |
       ]])
     end)
@@ -303,10 +305,10 @@ describe('Screen', function()
         {1:C}                                                    |
                                                              |
         ^                                                     |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
         :let &conceallevel=2                                 |
       ]])
     end)
@@ -319,10 +321,10 @@ describe('Screen', function()
                                                              |
                                                              |
         ^                                                     |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
-        ~                                                    |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
         :let &conceallevel=3                                 |
       ]])
     end)

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -39,7 +39,7 @@ describe('command line completion', function()
     clear()
     screen = Screen.new(40, 5)
     screen:attach()
-    screen:set_default_attr_ignore({{bold=true, foreground=Screen.colors.Blue}})
+    screen:set_default_attr_ids({[1]={bold=true, foreground=Screen.colors.Blue}})
   end)
 
   after_each(function()
@@ -55,9 +55,9 @@ describe('command line completion', function()
     feed(':!<tab><bs>')
     screen:expect([[
                                               |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
       :!Xtest-functional-viml-compl-dir^       |
     ]])
   end)

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -11,8 +11,8 @@ describe('completion', function()
     clear()
     screen = Screen.new(60, 8)
     screen:attach()
-    screen:set_default_attr_ignore({{bold=true, foreground=Screen.colors.Blue}})
     screen:set_default_attr_ids({
+      [0] = {bold=true, foreground=Screen.colors.Blue},
       [1] = {background = Screen.colors.LightMagenta},
       [2] = {background = Screen.colors.Grey},
       [3] = {bold = true},
@@ -20,6 +20,8 @@ describe('completion', function()
       [5] = {foreground = Screen.colors.Red},
       [6] = {background = Screen.colors.Black},
       [7] = {foreground = Screen.colors.White, background = Screen.colors.Red},
+      [8] = {reverse = true},
+      [9] = {bold = true, reverse = true},
     })
   end)
 
@@ -32,22 +34,22 @@ describe('completion', function()
       screen:expect([[
         foo                                                         |
         foo^                                                         |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- Keyword Local completion (^N^P) The only match}           |
       ]])
       feed('<C-e>')
       screen:expect([[
         foo                                                         |
         ^                                                            |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<ESC>')
@@ -95,12 +97,12 @@ describe('completion', function()
       eq('foo', eval('getline(1)'))
       screen:expect([[
         foo^                                                         |
-        {2:bar  foobaz baz  }                                           |
-        {1:abbr kind   menu }                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {2:bar  foobaz baz  }{0:                                           }|
+        {1:abbr kind   menu }{0:                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- Omni completion (^O^N^P) }{4:match 1 of 2}                    |
       ]])
       eq({word = 'foo', abbr = 'bar', menu = 'baz',
@@ -125,11 +127,11 @@ describe('completion', function()
       screen:expect([[
         foo                                                         |
         ^                                                            |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<C-x>')
@@ -137,22 +139,22 @@ describe('completion', function()
       screen:expect([[
         foo                                                         |
         ^                                                            |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)}                    |
       ]])
       feed('<C-n>')
       screen:expect([[
         foo                                                         |
         foo^                                                         |
-        {2:foo            }                                             |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {2:foo            }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- Keyword Local completion (^N^P) The only match}           |
       ]])
       feed('bar<ESC>')
@@ -162,10 +164,10 @@ describe('completion', function()
         foo                                                         |
         foobar                                                      |
         foo^                                                         |
-        {2:foo            }                                             |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {2:foo            }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- INSERT --}                                                |
       ]])
       eq('foo', eval('getline(3)'))
@@ -176,22 +178,22 @@ describe('completion', function()
       screen:expect([[
         foo                                                         |
         ^                                                            |
-        {2:foo            }                                             |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {2:foo            }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- Keyword Local completion (^N^P) The only match}           |
       ]])
       feed('<C-y>')
       screen:expect([[
         foo                                                         |
         foo^                                                         |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<ESC>')
@@ -201,10 +203,10 @@ describe('completion', function()
         foo                                                         |
         foo                                                         |
         ^                                                            |
-        {2:foo            }                                             |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {2:foo            }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<C-y><ESC>')
@@ -216,22 +218,22 @@ describe('completion', function()
       screen:expect([[
         foo                                                         |
         ^                                                            |
-        {1:foo            }                                             |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {1:foo            }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- Keyword Local completion (^N^P) }{5:Back at original}         |
       ]])
       feed('b')
       screen:expect([[
         foo                                                         |
         b^                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- Keyword Local completion (^N^P) }{5:Back at original}         |
       ]])
       feed('ar<ESC>')
@@ -241,10 +243,10 @@ describe('completion', function()
         foo                                                         |
         bar                                                         |
         ^                                                            |
-        {1:foo            }                                             |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {1:foo            }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- INSERT --}                                                |
       ]])
       feed('bar<ESC>')
@@ -256,22 +258,22 @@ describe('completion', function()
       screen:expect([[
         foo                                                         |
         ^                                                            |
-        {1:foo            }                                             |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {1:foo            }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- Keyword Local completion (^N^P) }{5:Back at original}         |
       ]])
       feed('<ESC>')
       screen:expect([[
         foo                                                         |
         ^                                                            |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
                                                                     |
       ]])
       eq('', eval('getline(2)'))
@@ -280,10 +282,10 @@ describe('completion', function()
         foo                                                         |
                                                                     |
         ^                                                            |
-        {1:foo            }                                             |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {1:foo            }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<ESC>')
@@ -291,10 +293,10 @@ describe('completion', function()
         foo                                                         |
                                                                     |
         ^                                                            |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
                                                                     |
       ]])
       eq('', eval('getline(3)'))
@@ -344,56 +346,56 @@ describe('completion', function()
       feed('i<C-x><C-u>')
       screen:expect([[
         ^                                                            |
-        {1:January        }{6: }                                            |
-        {1:February       }{6: }                                            |
-        {1:March          }{6: }                                            |
-        {1:April          }{2: }                                            |
-        {1:May            }{2: }                                            |
-        {1:June           }{2: }                                            |
+        {1:January        }{6: }{0:                                            }|
+        {1:February       }{6: }{0:                                            }|
+        {1:March          }{6: }{0:                                            }|
+        {1:April          }{2: }{0:                                            }|
+        {1:May            }{2: }{0:                                            }|
+        {1:June           }{2: }{0:                                            }|
         {3:-- User defined completion (^U^N^P) }{5:Back at original}        |
       ]])
       feed('u')
       screen:expect([[
         u^                                                           |
-        {1:January        }                                             |
-        {1:February       }                                             |
-        {1:June           }                                             |
-        {1:July           }                                             |
-        {1:August         }                                             |
-        ~                                                           |
+        {1:January        }{0:                                             }|
+        {1:February       }{0:                                             }|
+        {1:June           }{0:                                             }|
+        {1:July           }{0:                                             }|
+        {1:August         }{0:                                             }|
+        {0:~                                                           }|
         {3:-- User defined completion (^U^N^P) }{5:Back at original}        |
       ]])
       feed('g')
       screen:expect([[
         ug^                                                          |
-        {1:August         }                                             |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {1:August         }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- User defined completion (^U^N^P) }{5:Back at original}        |
       ]])
       feed('<Down>')
       screen:expect([[
         ug^                                                          |
-        {2:August         }                                             |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {2:August         }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- User defined completion (^U^N^P) The only match}          |
       ]])
       feed('<C-y>')
       screen:expect([[
         August^                                                      |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- INSERT --}                                                |
       ]])
       expect('August')
@@ -403,55 +405,55 @@ describe('completion', function()
       screen:expect([[
                                                                     |
         Ja^                                                          |
-        {1:January        }                                             |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {1:January        }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- User defined completion (^U^N^P) }{5:Back at original}        |
       ]])
       feed('<BS>')
       screen:expect([[
                                                                     |
         J^                                                           |
-        {1:January        }                                             |
-        {1:June           }                                             |
-        {1:July           }                                             |
-        ~                                                           |
-        ~                                                           |
+        {1:January        }{0:                                             }|
+        {1:June           }{0:                                             }|
+        {1:July           }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- User defined completion (^U^N^P) }{5:Back at original}        |
       ]])
       feed('<C-n>')
       screen:expect([[
                                                                     |
         January^                                                     |
-        {2:January        }                                             |
-        {1:June           }                                             |
-        {1:July           }                                             |
-        ~                                                           |
-        ~                                                           |
+        {2:January        }{0:                                             }|
+        {1:June           }{0:                                             }|
+        {1:July           }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- User defined completion (^U^N^P) }{4:match 1 of 3}            |
       ]])
       feed('<C-n>')
       screen:expect([[
                                                                     |
         June^                                                        |
-        {1:January        }                                             |
-        {2:June           }                                             |
-        {1:July           }                                             |
-        ~                                                           |
-        ~                                                           |
+        {1:January        }{0:                                             }|
+        {2:June           }{0:                                             }|
+        {1:July           }{0:                                             }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- User defined completion (^U^N^P) }{4:match 2 of 3}            |
       ]])
       feed('<Esc>')
       screen:expect([[
                                                                     |
         Jun^e                                                        |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
                                                                     |
       ]])
       feed('.')
@@ -459,10 +461,10 @@ describe('completion', function()
                                                                     |
         June                                                        |
         Jun^e                                                        |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
                                                                     |
       ]])
       expect([[
@@ -487,45 +489,45 @@ describe('completion', function()
       feed('i<C-r>=TestComplete()<CR>')
       screen:expect([[
         ^                                                            |
-        {1:0              }{6: }                                            |
-        {1:1              }{2: }                                            |
-        {1:2              }{2: }                                            |
-        {1:3              }{2: }                                            |
-        {1:4              }{2: }                                            |
-        {1:5              }{2: }                                            |
+        {1:0              }{6: }{0:                                            }|
+        {1:1              }{2: }{0:                                            }|
+        {1:2              }{2: }{0:                                            }|
+        {1:3              }{2: }{0:                                            }|
+        {1:4              }{2: }{0:                                            }|
+        {1:5              }{2: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('7')
       screen:expect([[
         7^                                                           |
-        {1:7              }{6: }                                            |
-        {1:70             }{6: }                                            |
-        {1:71             }{6: }                                            |
-        {1:72             }{2: }                                            |
-        {1:73             }{2: }                                            |
-        {1:74             }{2: }                                            |
+        {1:7              }{6: }{0:                                            }|
+        {1:70             }{6: }{0:                                            }|
+        {1:71             }{6: }{0:                                            }|
+        {1:72             }{2: }{0:                                            }|
+        {1:73             }{2: }{0:                                            }|
+        {1:74             }{2: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<c-n>')
       screen:expect([[
         7^                                                           |
-        {2:7              }{6: }                                            |
-        {1:70             }{6: }                                            |
-        {1:71             }{6: }                                            |
-        {1:72             }{2: }                                            |
-        {1:73             }{2: }                                            |
-        {1:74             }{2: }                                            |
+        {2:7              }{6: }{0:                                            }|
+        {1:70             }{6: }{0:                                            }|
+        {1:71             }{6: }{0:                                            }|
+        {1:72             }{2: }{0:                                            }|
+        {1:73             }{2: }{0:                                            }|
+        {1:74             }{2: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<c-n>')
       screen:expect([[
         70^                                                          |
-        {1:7              }{6: }                                            |
-        {2:70             }{6: }                                            |
-        {1:71             }{6: }                                            |
-        {1:72             }{2: }                                            |
-        {1:73             }{2: }                                            |
-        {1:74             }{2: }                                            |
+        {1:7              }{6: }{0:                                            }|
+        {2:70             }{6: }{0:                                            }|
+        {1:71             }{6: }{0:                                            }|
+        {1:72             }{2: }{0:                                            }|
+        {1:73             }{2: }{0:                                            }|
+        {1:74             }{2: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
     end)
@@ -534,111 +536,111 @@ describe('completion', function()
       feed('i<C-r>=TestComplete()<CR>')
       screen:expect([[
         ^                                                            |
-        {1:0              }{6: }                                            |
-        {1:1              }{2: }                                            |
-        {1:2              }{2: }                                            |
-        {1:3              }{2: }                                            |
-        {1:4              }{2: }                                            |
-        {1:5              }{2: }                                            |
+        {1:0              }{6: }{0:                                            }|
+        {1:1              }{2: }{0:                                            }|
+        {1:2              }{2: }{0:                                            }|
+        {1:3              }{2: }{0:                                            }|
+        {1:4              }{2: }{0:                                            }|
+        {1:5              }{2: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<PageDown>')
       screen:expect([[
         ^                                                            |
-        {1:0              }{6: }                                            |
-        {1:1              }{2: }                                            |
-        {1:2              }{2: }                                            |
-        {2:3               }                                            |
-        {1:4              }{2: }                                            |
-        {1:5              }{2: }                                            |
+        {1:0              }{6: }{0:                                            }|
+        {1:1              }{2: }{0:                                            }|
+        {1:2              }{2: }{0:                                            }|
+        {2:3               }{0:                                            }|
+        {1:4              }{2: }{0:                                            }|
+        {1:5              }{2: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<PageDown>')
       screen:expect([[
         ^                                                            |
-        {1:5              }{6: }                                            |
-        {1:6              }{2: }                                            |
-        {2:7               }                                            |
-        {1:8              }{2: }                                            |
-        {1:9              }{2: }                                            |
-        {1:10             }{2: }                                            |
+        {1:5              }{6: }{0:                                            }|
+        {1:6              }{2: }{0:                                            }|
+        {2:7               }{0:                                            }|
+        {1:8              }{2: }{0:                                            }|
+        {1:9              }{2: }{0:                                            }|
+        {1:10             }{2: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<Down>')
       screen:expect([[
         ^                                                            |
-        {1:5              }{6: }                                            |
-        {1:6              }{2: }                                            |
-        {1:7              }{2: }                                            |
-        {2:8               }                                            |
-        {1:9              }{2: }                                            |
-        {1:10             }{2: }                                            |
+        {1:5              }{6: }{0:                                            }|
+        {1:6              }{2: }{0:                                            }|
+        {1:7              }{2: }{0:                                            }|
+        {2:8               }{0:                                            }|
+        {1:9              }{2: }{0:                                            }|
+        {1:10             }{2: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<PageUp>')
       screen:expect([[
         ^                                                            |
-        {1:2              }{6: }                                            |
-        {1:3              }{2: }                                            |
-        {2:4               }                                            |
-        {1:5              }{2: }                                            |
-        {1:6              }{2: }                                            |
-        {1:7              }{2: }                                            |
+        {1:2              }{6: }{0:                                            }|
+        {1:3              }{2: }{0:                                            }|
+        {2:4               }{0:                                            }|
+        {1:5              }{2: }{0:                                            }|
+        {1:6              }{2: }{0:                                            }|
+        {1:7              }{2: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<PageUp>') -- stop on first item
       screen:expect([[
         ^                                                            |
-        {2:0              }{6: }                                            |
-        {1:1              }{2: }                                            |
-        {1:2              }{2: }                                            |
-        {1:3              }{2: }                                            |
-        {1:4              }{2: }                                            |
-        {1:5              }{2: }                                            |
+        {2:0              }{6: }{0:                                            }|
+        {1:1              }{2: }{0:                                            }|
+        {1:2              }{2: }{0:                                            }|
+        {1:3              }{2: }{0:                                            }|
+        {1:4              }{2: }{0:                                            }|
+        {1:5              }{2: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<PageUp>') -- when on first item, unselect
       screen:expect([[
         ^                                                            |
-        {1:0              }{6: }                                            |
-        {1:1              }{2: }                                            |
-        {1:2              }{2: }                                            |
-        {1:3              }{2: }                                            |
-        {1:4              }{2: }                                            |
-        {1:5              }{2: }                                            |
+        {1:0              }{6: }{0:                                            }|
+        {1:1              }{2: }{0:                                            }|
+        {1:2              }{2: }{0:                                            }|
+        {1:3              }{2: }{0:                                            }|
+        {1:4              }{2: }{0:                                            }|
+        {1:5              }{2: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<PageUp>') -- when unselected, select last item
       screen:expect([[
         ^                                                            |
-        {1:95             }{2: }                                            |
-        {1:96             }{2: }                                            |
-        {1:97             }{2: }                                            |
-        {1:98             }{2: }                                            |
-        {1:99             }{2: }                                            |
-        {2:100            }{6: }                                            |
+        {1:95             }{2: }{0:                                            }|
+        {1:96             }{2: }{0:                                            }|
+        {1:97             }{2: }{0:                                            }|
+        {1:98             }{2: }{0:                                            }|
+        {1:99             }{2: }{0:                                            }|
+        {2:100            }{6: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<PageUp>')
       screen:expect([[
         ^                                                            |
-        {1:94             }{2: }                                            |
-        {1:95             }{2: }                                            |
-        {2:96              }                                            |
-        {1:97             }{2: }                                            |
-        {1:98             }{2: }                                            |
-        {1:99             }{6: }                                            |
+        {1:94             }{2: }{0:                                            }|
+        {1:95             }{2: }{0:                                            }|
+        {2:96              }{0:                                            }|
+        {1:97             }{2: }{0:                                            }|
+        {1:98             }{2: }{0:                                            }|
+        {1:99             }{6: }{0:                                            }|
         {3:-- INSERT --}                                                |
       ]])
       feed('<cr>')
       screen:expect([[
         96^                                                          |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
-        ~                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
         {3:-- INSERT --}                                                |
       ]])
     end)
@@ -651,22 +653,22 @@ describe('completion', function()
     screen:expect([[
               ^foo                                                 |
               bar                                                 |
-      ~                                                           |
-      ~                                                           |
-      ~                                                           |
-      ~                                                           |
-      ~                                                           |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
                                                                   |
     ]])
     feed('A<C-x><C-l>')
     screen:expect([[
               foo^                                                 |
               bar                                                 |
-      ~                                                           |
-      ~                                                           |
-      ~                                                           |
-      ~                                                           |
-      ~                                                           |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
       {3:-- Whole line completion (^L^N^P) }{7:Pattern not found}         |
     ]])
     eq(-1, eval('foldclosed(1)'))
@@ -679,11 +681,11 @@ describe('completion', function()
     screen:expect([[
       foobar fooegg                                               |
       fooegg^                                                      |
-      {1:foobar         }                                             |
-      {2:fooegg         }                                             |
-      ~                                                           |
-      ~                                                           |
-      ~                                                           |
+      {1:foobar         }{0:                                             }|
+      {2:fooegg         }{0:                                             }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
       {3:-- Keyword completion (^N^P) }{4:match 1 of 2}                   |
     ]])
 
@@ -692,11 +694,11 @@ describe('completion', function()
     screen:expect([[
       foobar fooegg                                               |
       fooegg^                                                      |
-      {1:foobar         }                                             |
-      {2:fooegg         }                                             |
-      ~                                                           |
-      ~                                                           |
-      ~                                                           |
+      {1:foobar         }{0:                                             }|
+      {2:fooegg         }{0:                                             }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
       {3:-- Keyword completion (^N^P) }{4:match 1 of 2}                   |
     ]])
 
@@ -705,11 +707,11 @@ describe('completion', function()
     screen:expect([[
       foobar fooegg                                               |
       foobar^                                                      |
-      {2:foobar         }                                             |
-      {1:fooegg         }                                             |
-      ~                                                           |
-      ~                                                           |
-      ~                                                           |
+      {2:foobar         }{0:                                             }|
+      {1:fooegg         }{0:                                             }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
       {3:-- Keyword completion (^N^P) }{4:match 2 of 2}                   |
     ]])
   end)
@@ -722,43 +724,35 @@ describe('completion', function()
       screen:expect([[
                                                                     |
         {8:[No Name]                                                   }|
-        :foo faa fee f^                                              |
-        :~                                                          |
-        :~                                                          |
-        :~                                                          |
+        {0::}foo faa fee f^                                              |
+        {0::~                                                          }|
+        {0::~                                                          }|
+        {0::~                                                          }|
         {9:[Command Line]                                              }|
         {3:-- INSERT --}                                                |
-      ]], {[3] = {bold = true},
-           [4] = {bold = true, foreground = Screen.colors.SeaGreen},
-           [8] = {reverse = true},
-           [9] = {bold = true, reverse = true}})
+      ]] )
       feed('<c-x><c-n>')
       screen:expect([[
                                                                     |
         {8:[No Name]                                                   }|
-        :foo faa fee foo^                                            |
-        :~          {2: foo            }                                |
-        :~          {1: faa            }                                |
-        :~          {1: fee            }                                |
+        {0::}foo faa fee foo^                                            |
+        {0::~          }{2: foo            }{0:                                }|
+        {0::~          }{1: faa            }{0:                                }|
+        {0::~          }{1: fee            }{0:                                }|
         {9:[Command Line]                                              }|
         {3:-- Keyword Local completion (^N^P) }{4:match 1 of 3}             |
-      ]],{[1] = {background = Screen.colors.LightMagenta},
-          [2] = {background = Screen.colors.Grey},
-          [3] = {bold = true},
-          [4] = {bold = true, foreground = Screen.colors.SeaGreen},
-          [8] = {reverse = true},
-          [9] = {bold = true, reverse = true}})
+      ]])
       feed('<c-c>')
       screen:expect([[
                                                                     |
         {8:[No Name]                                                   }|
-        :foo faa fee foo                                            |
-        :~                                                          |
-        :~                                                          |
-        :~                                                          |
+        {0::}foo faa fee foo                                            |
+        {0::~                                                          }|
+        {0::~                                                          }|
+        {0::~                                                          }|
         {9:[Command Line]                                              }|
         :foo faa fee foo^                                            |
-      ]], {[8] = {reverse = true}, [9] = {bold = true, reverse = true}})
+      ]])
     end)
   end)
 end)


### PR DESCRIPTION
Remove `hl_colors`, people tend to copy this pattern into new screen tests which creates manual work for what should be perfectly semi-automatic: just use `snapshot_util()` and copy the attributes to `set_default_attr_ids`. One could argue it is informative, but just as well one could argue it is deceptive: it may look as the test is testing the presence of a (named) highlight group, which is not; it is only testing the final attributes and the formulation of test should reflect that. (it would not surprise me if one or more of the existing hl_group usages actually is wrong in this regard) Instead add a comment if necessary.

Also remove the widespread ignoring of `{bold=true, background=colors.Blue}`. It is more important that the tests test the actual screen state than that they look good. (This does not only disable the testing of NonText, it also disables testing against _erroneous_ NonText highlighting) This might have made sense in the pre-`snapshot_util()` days but now this will not cause any more work for _existing_ tests. For some reason I didn't think about this when implementing and documenting `snapshot_util()`, but better to fix this now than later. So far I fixed all the tests in `ui/` as these are most likely to be copied as a template for new tests, but I should fix the rest as well. ([self-modifying code](https://github.com/bfredl/neovim/commit/75ba5cf3b34edb45a6ad5ec42bcdcadcca93527d) is fun). 

Also needs a documentation update. I wonder if anyone reads the documentation in `screen.lua`, probably a page on the wiki is better.
