### PR TITLE
[RFC] man.vim: use -range instead of -count

### DIFF
--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -5,7 +5,7 @@ if exists('g:loaded_man')
 endif
 let g:loaded_man = 1
 
-command! -count=0 -complete=customlist,man#complete -nargs=+ Man call man#open_page(v:count, v:count1, <f-args>)
+command! -range=0 -complete=customlist,man#complete -nargs=+ Man call man#open_page(v:count, v:count1, <f-args>)
 
 nnoremap <silent> <Plug>(Man) :<C-U>call man#open_page(v:count, v:count1, &filetype ==# 'man' ? expand('<cWORD>') : expand('<cword>'))<CR>
 


### PR DESCRIPTION
With -count, if the first argument is a number, it is made available
with `<count>`. Problem is, because there is always a default count, it is impossible
to tell whether the user set it.

Since v:count and v:count1 still work with 'keywordprg', the -count is
actually unnecessary. But 'keywordprg' still calls ':Man' with a count prefixed.
So it must still accept a count in the line number position, but not consume
the first argument. This is done with -range.

Fixes #5202.
