### PR TITLE
[RFC] vim-patch.sh: do not consume submit_fn output

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -252,9 +252,7 @@ submit_pr() {
   fi
 
   echo "Creating pull request."
-  output="$(${submit_fn} "${pr_message}" 2>&1)" &&
-    echo "✔ ${output}" ||
-    (echo "✘ ${output}"; false)
+  ${submit_fn} "${pr_message}"
 
   echo
   echo "Cleaning up files."


### PR DESCRIPTION
This is so that if the user has not setup hub, it will prompt for the
username/password but if we consume the output, the user will not
understand that hub is prompting it.
