### PR TITLE
scripts/vim-patch.sh: use "set -p"

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -3,6 +3,8 @@
 set -e
 set -u
 set -o pipefail
+# Use priviledged mode, which e.g. skips using CDPATH.
+set -p
 
 readonly NEOVIM_SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly VIM_SOURCE_DIR_DEFAULT="${NEOVIM_SOURCE_DIR}/.vim-src"


### PR DESCRIPTION
Without this the "cd scripts/.." might change to another dir (since
CDPATH is looked at before a local path), and then NEOVIM_SOURCE_DIR
might end up being "/somewhere/else\n/somewhere/else" (since the "cd"
prints the dir already in that case).
