### PR TITLE
Re-add ":browse" command modifier and use it with ":oldfiles"

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1200,11 +1200,10 @@ running) you have additional options:
 :wv[iminfo][!] [file]	Deprecated alias to |:wshada| command.
 
 						*:o* *:ol* *:oldfiles*
-:o[ldfiles][!]		List the files that have marks stored in the ShaDa
+:o[ldfiles]		List the files that have marks stored in the ShaDa
 			file.  This list is read on startup and only changes
 			afterwards with ":rshada!".  Also see |v:oldfiles|.
 			The number can be used with |c_#<|.
-			Use ! to get a file selection prompt.
 
 :bro[wse] o[ldfiles][!]
 			List file names as with |:oldfiles|, and then prompt

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -188,7 +188,6 @@ Additional differences:
   compatibility reasons.
 - |:wviminfo| was renamed to |:wshada|, |:rviminfo| to |:rshada|.  Old
   commands are still kept.
-- |:oldfiles| supports !.
 - When writing (|:wshada| without bang or at exit) it merges much more data,
   and does this according to the timestamp.  Vim merges only marks.
   |shada-merging|

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21722,8 +21722,8 @@ void ex_oldfiles(exarg_T *eap)
     /* Assume "got_int" was set to truncate the listing. */
     got_int = FALSE;
 
-    // File selection prompt on ":oldfiles!"
-    if (eap->forceit) {
+    // File selection prompt on ":browse oldfiles"
+    if (cmdmod.browse) {
       quit_more = false;
       nr = prompt_for_number(false);
       msg_starthere();

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -160,24 +160,22 @@ typedef struct expand {
 #define XP_BS_ONE       1       /* uses one backslash before a space */
 #define XP_BS_THREE     2       /* uses three backslashes before a space */
 
-/*
- * Command modifiers ":vertical", ":browse", ":confirm" and ":hide" set a flag.
- * This needs to be saved for recursive commands, put them in a structure for
- * easy manipulation.
- */
+/// Command modifiers ":vertical", ":browse", ":confirm", ":hide", etc. set a
+/// flag.  This needs to be saved for recursive commands, put them in a
+/// structure for easy manipulation.
 typedef struct {
-  int hide;                             /* TRUE when ":hide" was used */
-  int split;                            /* flags for win_split() */
-  int tab;                              /* > 0 when ":tab" was used */
-  int confirm;                          /* TRUE to invoke yes/no dialog */
-  int keepalt;                          /* TRUE when ":keepalt" was used */
-  int keepmarks;                        /* TRUE when ":keepmarks" was used */
-  int keepjumps;                        /* TRUE when ":keepjumps" was used */
-  int lockmarks;                        /* TRUE when ":lockmarks" was used */
-  int keeppatterns;                     /* TRUE when ":keeppatterns" was used */
-  bool noswapfile;                      /* true when ":noswapfile" was used */
-  bool browse;                          ///< TRUE to invoke file dialog
-  char_u      *save_ei;                 /* saved value of 'eventignore' */
+  int hide;          ///< TRUE when ":hide" was used
+  int split;         ///< flags for win_split()
+  int tab;           ///< > 0 when ":tab" was used
+  int confirm;       ///< TRUE to invoke yes/no dialog
+  int keepalt;       ///< TRUE when ":keepalt" was used
+  int keepmarks;     ///< TRUE when ":keepmarks" was used
+  int keepjumps;     ///< TRUE when ":keepjumps" was used
+  int lockmarks;     ///< TRUE when ":lockmarks" was used
+  int keeppatterns;  ///< TRUE when ":keeppatterns" was used
+  bool noswapfile;   ///< true when ":noswapfile" was used
+  bool browse;       ///< TRUE to invoke file dialog
+  char_u *save_ei;   ///< saved value of 'eventignore'
 } cmdmod_T;
 
 #endif  // NVIM_EX_CMDS_DEFS_H

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -176,6 +176,7 @@ typedef struct {
   int lockmarks;                        /* TRUE when ":lockmarks" was used */
   int keeppatterns;                     /* TRUE when ":keeppatterns" was used */
   bool noswapfile;                      /* true when ":noswapfile" was used */
+  bool browse;                          ///< TRUE to invoke file dialog
   char_u      *save_ei;                 /* saved value of 'eventignore' */
 } cmdmod_T;
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1313,8 +1313,9 @@ static char_u * do_one_cmd(char_u **cmdlinep,
     case 'b':   if (checkforcmd(&ea.cmd, "belowright", 3)) {
         cmdmod.split |= WSP_BELOW;
         continue;
-    }
+      }
       if (checkforcmd(&ea.cmd, "browse", 3)) {
+        cmdmod.browse = true;
         continue;
       }
       if (!checkforcmd(&ea.cmd, "botright", 2))

--- a/test/functional/ex_cmds/oldfiles_spec.lua
+++ b/test/functional/ex_cmds/oldfiles_spec.lua
@@ -47,7 +47,7 @@ describe(':oldfiles', function()
   end)
 end)
 
-describe(':oldfiles!', function()
+describe(':browse oldfiles', function()
   local filename
   local filename2
   local oldfiles
@@ -74,7 +74,7 @@ describe(':oldfiles!', function()
     ok(filename == oldfiles[1] or filename == oldfiles[2])
     ok(filename2 == oldfiles[1] or filename2 == oldfiles[2])
 
-    execute('oldfiles!')
+    execute('browse oldfiles')
   end)
 
   after_each(function()


### PR DESCRIPTION
In 3b12bb225adda2aac40a55f7009cae05311b2a43, ":oldfiles" was taught to
behave like Vim's ":browse oldfiles" if ":oldfiles!" was used.  However,
this conflates the use of ! for abandoning a modified buffer with
choosing one file out of a list of oldfiles.

Now that ":browse" is supported again, ":browse oldfiles" will allow the
user to select an old file, while still complaining if that would cause
a modified buffer to be abandoned.  ":browse oldfiles!" will just
abandon the buffer, as expected.
