### PR TITLE
[RFC] Prevent endless loop in printdigraph().

### DIFF
--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1691,8 +1691,11 @@ static void printdigraph(digr_T *dp)
       msg_putchar('\n');
     }
 
-    if (msg_col) {
-      while (msg_col % list_width != 0) {
+
+    // Make msg_col a multiple of list_width by using spaces.
+    if (msg_col % list_width != 0) {
+      int spaces = (msg_col / list_width + 1) * list_width - msg_col;
+      while (spaces--) {
         msg_putchar(' ');
       }
     }


### PR DESCRIPTION
Calling printdiagraph() with msg_silent != 0 can result in an endless
loop because the loop condition never changes, if msg_col is never
changed.

To fix this, calculate the number of iterations before the loop, which
is always smaller than list_width.

Problem was mentioned by @mhinz in the neovim Gitter channel when
 using plugin 'chrisbra/unicode.vim' with `:UnicodeTable`. 
