### PR TITLE
Refresh terminal before calling on_exit

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -323,6 +323,7 @@ void terminal_close(Terminal *term, char *msg)
       term->opts.close_cb(term->opts.data);
     }
   } else {
+    refresh_terminal(term);
     terminal_receive(term, msg, strlen(msg));
   }
 


### PR DESCRIPTION
Since the terminal is updated at an interval, it was possible for the
on_exit callback to be called with a stale terminal buffer.
