### PR TITLE
[RFC] Fix busted tests due to changes in penlight...

### DIFF
--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -127,10 +127,17 @@ add_custom_target(inspect
 list(APPEND THIRD_PARTY_DEPS inspect)
 
 if(USE_BUNDLED_BUSTED)
+  add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight/1.3.2-2
+    COMMAND ${LUAROCKS_BINARY}
+    ARGS build penlight 1.3.2-2 ${LUAROCKS_BUILDARGS}
+    DEPENDS inspect)
+  add_custom_target(penlight
+    DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight/1.3.2-2)
+
   add_custom_command(OUTPUT ${HOSTDEPS_BIN_DIR}/busted
     COMMAND ${LUAROCKS_BINARY}
     ARGS build https://raw.githubusercontent.com/Olivine-Labs/busted/v2.0.rc11-0/busted-2.0.rc11-0.rockspec ${LUAROCKS_BUILDARGS}
-    DEPENDS inspect)
+    DEPENDS penlight)
   add_custom_target(busted
     DEPENDS ${HOSTDEPS_BIN_DIR}/busted)
 

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -130,7 +130,7 @@ if(USE_BUNDLED_BUSTED)
   add_custom_command(OUTPUT ${HOSTDEPS_BIN_DIR}/busted
     COMMAND ${LUAROCKS_BINARY}
     ARGS build https://raw.githubusercontent.com/Olivine-Labs/busted/v2.0.rc11-0/busted-2.0.rc11-0.rockspec ${LUAROCKS_BUILDARGS}
-    DEPENDS lpeg)
+    DEPENDS inspect)
   add_custom_target(busted
     DEPENDS ${HOSTDEPS_BIN_DIR}/busted)
 


### PR DESCRIPTION
Things have been failing left and right lately, and it turns out that it's due to a change in one of busted's dependencies--penlight.  This forces the use of a good version while the matter is being sorted out.  See Olivine-Labs/busted#528 for details on the issue.

Also, I noticed that we didn't serialize the building of a couple of the the dependencies (busted and inspect could be built at the same time), so I added a fix for that too.  Traditionally, Luarocks has not liked things installing at the same time in the past.
