### PR TITLE
[RFC] Fix new tab not inheriting local working directory.

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2978,6 +2978,9 @@ int win_new_tabpage(int after, char_u *filename)
     xfree(newtp);
     return FAIL;
   }
+
+  newtp->localdir = tp->localdir ? vim_strsave(tp->localdir) : NULL;
+
   curtab = newtp;
 
   /* Create a new empty window. */

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -140,6 +140,27 @@ for _, cmd in ipairs {'cd', 'chdir'} do
       end)
     end)
 
+    describe('Local directory gets inherited', function()
+      it('by tabs', function()
+        local globalDir = directories.start
+
+        -- Create a new tab and change directory
+        execute('tabnew')
+        execute('silent t' .. cmd .. ' ' .. directories.tab)
+        eq(globalDir .. '/' .. directories.tab, tcwd())
+
+        -- Create a new tab and verify it has inherited the directory
+        execute('tabnew')
+        eq(globalDir .. '/' .. directories.tab, tcwd())
+
+        -- Change tab and change back, verify that directories are correct
+        execute('tabnext')
+        eq(globalDir, tcwd())
+        execute('tabprevious')
+        eq(globalDir .. '/' .. directories.tab, tcwd())
+      end)
+    end)
+
     it('works', function()
       local globalDir = directories.start
       -- Create a new tab first and verify that is has the same working dir


### PR DESCRIPTION
When a new tabpage gets created it will copy the local working directory of the previous one, if there is any. Fixes #5082

This is a simple one-line fix, but there is another way to go at this: when a new tab gets allocated we could pass a reference to another tab (i.e. the current tab in our case) to the allocation function `alloc_tabpage`. If there is no other tab we pass `NULL`. Then the function can copy members from the old tab to the new tab. This is how new windows are created. However, that would mean changing the signature of the function and adjusting every call to it in the codebase. There are only two calls to it, both in `src/nvim/window.c`, so the change is not very invasive. What should I do?
