### PR TITLE
[RFC] api: handle null string in buffer_add_highlight

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -691,7 +691,7 @@ Integer buffer_add_highlight(Buffer buffer,
     col_end = MAXCOL;
   }
 
-  int hlg_id = syn_name2id((char_u*)hl_group.data);
+  int hlg_id = syn_name2id((char_u *)(hl_group.data ? hl_group.data : ""));
   src_id = bufhl_add_hl(buf, (int)src_id, hlg_id, (linenr_T)line+1,
                         (colnr_T)col_start+1, (colnr_T)col_end);
   return src_id;

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -111,12 +111,16 @@ describe('Buffer highlighting', function()
       add_hl(id1, "ImportantWord", 2, 0, 9)
       add_hl(id1, "ImportantWord", 3, 5, 14)
 
-      id2 = add_hl(0, "Special", 0, 2, 8)
+      -- add_highlight can be called like this to get a new source
+      -- without adding any highlight
+      id2 = add_hl(0, "", 0, 0, 0)
+      neq(id1, id2)
+
+      add_hl(id2, "Special", 0, 2, 8)
       add_hl(id2, "Identifier", 1, 3, 8)
       add_hl(id2, "Special", 1, 14, 20)
       add_hl(id2, "Underlined", 2, 6, 12)
       add_hl(id2, "Underlined", 3, 0, 9)
-      neq(id1, id2)
 
       screen:expect([[
         a {5:longer} example                        |


### PR DESCRIPTION
This used to be alright, but something must have changed. maybe msgpack-c used to represent empty strings as empty strings...
## steps to reproduce:

```
:python3 vim.new_highlight_source() #crash
```
