### PR TITLE
[RFC] eval: remove char_u in  get_dict_(string|number) key parameters

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3530,21 +3530,15 @@ int ins_compl_add_tv(typval_T *tv, int dir)
   char_u      *(cptext[CPT_COUNT]);
 
   if (tv->v_type == VAR_DICT && tv->vval.v_dict != NULL) {
-    word = get_dict_string(tv->vval.v_dict, (char_u *)"word", FALSE);
-    cptext[CPT_ABBR] = get_dict_string(tv->vval.v_dict,
-        (char_u *)"abbr", FALSE);
-    cptext[CPT_MENU] = get_dict_string(tv->vval.v_dict,
-        (char_u *)"menu", FALSE);
-    cptext[CPT_KIND] = get_dict_string(tv->vval.v_dict,
-        (char_u *)"kind", FALSE);
-    cptext[CPT_INFO] = get_dict_string(tv->vval.v_dict,
-        (char_u *)"info", FALSE);
-    if (get_dict_string(tv->vval.v_dict, (char_u *)"icase", FALSE) != NULL)
-      icase = get_dict_number(tv->vval.v_dict, (char_u *)"icase");
-    if (get_dict_string(tv->vval.v_dict, (char_u *)"dup", FALSE) != NULL)
-      adup = get_dict_number(tv->vval.v_dict, (char_u *)"dup");
-    if (get_dict_string(tv->vval.v_dict, (char_u *)"empty", FALSE) != NULL)
-      aempty = get_dict_number(tv->vval.v_dict, (char_u *)"empty");
+    word = get_dict_string(tv->vval.v_dict, "word", false);
+    cptext[CPT_ABBR] = get_dict_string(tv->vval.v_dict, "abbr", false);
+    cptext[CPT_MENU] = get_dict_string(tv->vval.v_dict, "menu", false);
+    cptext[CPT_KIND] = get_dict_string(tv->vval.v_dict, "kind", false);
+    cptext[CPT_INFO] = get_dict_string(tv->vval.v_dict, "info", false);
+
+    icase = get_dict_number(tv->vval.v_dict, "icase");
+    adup = get_dict_number(tv->vval.v_dict, "dup");
+    aempty = get_dict_number(tv->vval.v_dict, "empty");
   } else {
     word = get_tv_string_chk(tv);
     memset(cptext, 0, sizeof(cptext));

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3505,15 +3505,15 @@ int set_errorlist(win_T *wp, list_T *list, int action, char_u *title)
     if (d == NULL)
       continue;
 
-    char_u *filename = get_dict_string(d, (char_u *)"filename", true);
-    int bufnum = (int)get_dict_number(d, (char_u *)"bufnr");
-    long lnum = get_dict_number(d, (char_u *)"lnum");
-    int col = (int)get_dict_number(d, (char_u *)"col");
-    char_u vcol = (char_u)get_dict_number(d, (char_u *)"vcol");
-    int nr = (int)get_dict_number(d, (char_u *)"nr");
-    char_u *type = get_dict_string(d, (char_u *)"type", true);
-    char_u *pattern = get_dict_string(d, (char_u *)"pattern", true);
-    char_u *text = get_dict_string(d, (char_u *)"text", true);
+    char_u *filename = get_dict_string(d, "filename", true);
+    int bufnum = (int)get_dict_number(d, "bufnr");
+    long lnum = get_dict_number(d, "lnum");
+    int col = (int)get_dict_number(d, "col");
+    char_u vcol = (char_u)get_dict_number(d, "vcol");
+    int nr = (int)get_dict_number(d, "nr");
+    char_u *type = get_dict_string(d, "type", true);
+    char_u *pattern = get_dict_string(d, "pattern", true);
+    char_u *text = get_dict_string(d, "text", true);
     if (text == NULL) {
       text = vim_strsave((char_u *)"");
     }


### PR DESCRIPTION
When working on #4723 I found this opportunity to get rid of a bunch of `(char_u *)` casts.
ref #459
