### PR TITLE
[RFC] startup: Disable stdio inheritance ASAP.

### DIFF
--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -30,6 +30,11 @@ int stream_set_blocking(int fd, bool blocking)
   return retval;
 }
 
+void stream_disable_stdio_inheritance(void)
+{
+  uv_disable_stdio_inheritance();
+}
+
 void stream_init(Loop *loop, Stream *stream, int fd, uv_stream_t *uvstream)
   FUNC_ATTR_NONNULL_ARG(2)
 {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -227,6 +227,7 @@ int main(int argc, char **argv)
                           // main() and other functions.
   char_u *cwd = NULL;     // current workding dir on startup
   time_init();
+  stream_disable_stdio_inheritance();
 
   /* Many variables are in "params" so that we can pass them to invoked
    * functions without a lot of arguments.  "argc" and "argv" are also

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -45,7 +45,6 @@ bool pty_process_spawn(PtyProcess *ptyproc)
   assert(!proc->err);
   uv_signal_start(&proc->loop->children_watcher, chld_handler, SIGCHLD);
   ptyproc->winsize = (struct winsize){ ptyproc->height, ptyproc->width, 0, 0 };
-  uv_disable_stdio_inheritance();
   int master;
   int pid = forkpty(&master, NULL, &termios, &ptyproc->winsize);
 


### PR DESCRIPTION
libuv docs mention that this should be done as early as possible:

http://docs.libuv.org/en/v1.x/process.html?highlight=uv_disable_stdio_inheritance#c.uv_disable_stdio_inheritance

Also it is not necessary to do this more than once for the life of the nvim process. 

cc @oni-link @tarruda 
