### PR TITLE
iconv: Always include errno.h when USE_ICONV is defined

### DIFF
--- a/src/nvim/iconv.h
+++ b/src/nvim/iconv.h
@@ -24,10 +24,10 @@
 // defined, we provide a type shim (pull in errno.h and define iconv_t).
 // This enables us to still load and use iconv dynamically at runtime.
 #ifdef USE_ICONV
+#  include <errno.h>
 #  ifdef HAVE_ICONV_H
 #    include <iconv.h>
 #  else
-#    include <errno.h>
 typedef void *iconv_t;
 #  endif
 #endif


### PR DESCRIPTION
When USE_ICONV is defined, iconv.h references various errno constants,
but errno.h was only being included when HAVE_ICONV_H is defined.  This
causes build failures in certain environments.
