### PR TITLE
perf: Disable clipboard in do_cmdline()

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4053,9 +4053,9 @@ void ex_global(exarg_T *eap)
       smsg(_("Pattern not found: %s"), pat);
     }
   } else {
-    start_global_changes();
+    start_batch_changes();
     global_exe(cmd);
-    end_global_changes();
+    end_batch_changes();
   }
   ml_clearmarked();        /* clear rest of the marks */
   vim_regfree(regmatch.regprog);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4053,9 +4053,7 @@ void ex_global(exarg_T *eap)
       smsg(_("Pattern not found: %s"), pat);
     }
   } else {
-    start_batch_changes();
     global_exe(cmd);
-    end_batch_changes();
   }
   ml_clearmarked();        /* clear rest of the marks */
   vim_regfree(regmatch.regprog);

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1983,8 +1983,6 @@ void ex_listdo(exarg_T *eap)
     save_ei = au_event_disable(",Syntax");
   }
 
-  start_batch_changes();
-
   if (eap->cmdidx == CMD_windo
       || eap->cmdidx == CMD_tabdo
       || P_HID(curbuf)
@@ -2181,7 +2179,6 @@ void ex_listdo(exarg_T *eap)
     apply_autocmds(EVENT_SYNTAX, curbuf->b_p_syn,
                    curbuf->b_fname, true, curbuf);
   }
-  end_batch_changes();
 }
 
 /// Add files[count] to the arglist of the current window after arg "after".

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1983,7 +1983,7 @@ void ex_listdo(exarg_T *eap)
     save_ei = au_event_disable(",Syntax");
   }
 
-  start_global_changes();
+  start_batch_changes();
 
   if (eap->cmdidx == CMD_windo
       || eap->cmdidx == CMD_tabdo
@@ -2181,7 +2181,7 @@ void ex_listdo(exarg_T *eap)
     apply_autocmds(EVENT_SYNTAX, curbuf->b_p_syn,
                    curbuf->b_fname, true, curbuf);
   }
-  end_global_changes();
+  end_batch_changes();
 }
 
 /// Add files[count] to the arglist of the current window after arg "after".

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9513,7 +9513,7 @@ static void ex_folddo(exarg_T *eap)
 {
   linenr_T lnum;
 
-  start_global_changes();
+  start_batch_changes();
 
   /* First set the marks for all lines closed/open. */
   for (lnum = eap->line1; lnum <= eap->line2; ++lnum)
@@ -9524,7 +9524,7 @@ static void ex_folddo(exarg_T *eap)
   global_exe(eap->arg);
   ml_clearmarked();        /* clear rest of the marks */
 
-  end_global_changes();
+  end_batch_changes();
 }
 
 static void ex_terminal(exarg_T *eap)

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -346,6 +346,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
     return FAIL;
   }
   ++call_depth;
+  start_batch_changes();
 
   cstack.cs_idx = -1;
   cstack.cs_looplevel = 0;
@@ -953,6 +954,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
   did_endif = FALSE;    /* in case do_cmdline used recursively */
 
   --call_depth;
+  end_batch_changes();
   return retval;
 }
 
@@ -9513,8 +9515,6 @@ static void ex_folddo(exarg_T *eap)
 {
   linenr_T lnum;
 
-  start_batch_changes();
-
   /* First set the marks for all lines closed/open. */
   for (lnum = eap->line1; lnum <= eap->line2; ++lnum)
     if (hasFolding(lnum, NULL, NULL) == (eap->cmdidx == CMD_folddoclosed))
@@ -9523,8 +9523,6 @@ static void ex_folddo(exarg_T *eap)
   /* Execute the command on the marked lines. */
   global_exe(eap->arg);
   ml_clearmarked();        /* clear rest of the marks */
-
-  end_batch_changes();
 }
 
 static void ex_terminal(exarg_T *eap)

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -345,7 +345,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
     msg_list = saved_msg_list;
     return FAIL;
   }
-  ++call_depth;
+  call_depth++;
   start_batch_changes();
 
   cstack.cs_idx = -1;
@@ -953,7 +953,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
 
   did_endif = FALSE;    /* in case do_cmdline used recursively */
 
-  --call_depth;
+  call_depth--;
   end_batch_changes();
   return retval;
 }
@@ -9513,16 +9513,15 @@ static void ex_foldopen(exarg_T *eap)
 
 static void ex_folddo(exarg_T *eap)
 {
-  linenr_T lnum;
-
-  /* First set the marks for all lines closed/open. */
-  for (lnum = eap->line1; lnum <= eap->line2; ++lnum)
-    if (hasFolding(lnum, NULL, NULL) == (eap->cmdidx == CMD_folddoclosed))
+  // First set the marks for all lines closed/open.
+  for (linenr_T lnum = eap->line1; lnum <= eap->line2; ++lnum) {
+    if (hasFolding(lnum, NULL, NULL) == (eap->cmdidx == CMD_folddoclosed)) {
       ml_setmarked(lnum);
+    }
+  }
 
-  /* Execute the command on the marked lines. */
-  global_exe(eap->arg);
-  ml_clearmarked();        /* clear rest of the marks */
+  global_exe(eap->arg);  // Execute the command on the marked lines.
+  ml_clearmarked();      // clear rest of the marks
 }
 
 static void ex_terminal(exarg_T *eap)

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -51,10 +51,10 @@ static yankreg_T *y_previous = NULL; /* ptr to last written yankreg */
 
 static bool clipboard_didwarn_unnamed = false;
 
-// for behavior between start_global_changes() and end_global_changes())
+// for behavior between start_batch_changes() and end_batch_changes())
 static bool clipboard_delay_update = false;  // delay clipboard update
-static int global_change_count = 0;          // if set, inside global changes
-static bool clipboard_needs_update = false;  // the clipboard was updated
+static int batch_change_count = 0;           // inside a script
+static bool clipboard_needs_update = false;  // clipboard was updated
 
 /*
  * structure used by block_prep, op_delete and op_yank for blockwise operators
@@ -5630,20 +5630,20 @@ static void set_clipboard(int name, yankreg_T *reg)
   (void)eval_call_provider("clipboard", "set", args);
 }
 
-/// Avoid clipboard (slow) during batch operations (:global).
-void start_global_changes(void)
+/// Avoid clipboard (slow) during batch operations (i.e., a script).
+void start_batch_changes(void)
 {
-  if (++global_change_count > 1) {
+  if (++batch_change_count > 1) {
     return;
   }
   clipboard_delay_update = true;
   clipboard_needs_update = false;
 }
 
-/// Update the clipboard after :global changes finished.
-void end_global_changes(void)
+/// Update the clipboard after batch changes finished.
+void end_batch_changes(void)
 {
-  if (--global_change_count > 0) {
+  if (--batch_change_count > 0) {
     // recursive
     return;
   }


### PR DESCRIPTION
For any script--not just `:global` commands--there is no reason to
update the system clipboard until the script is finished, so disable it
during do_cmdline().

Before this change, 'clipboard=unnamedplus' causes scripted editing to
be extremely slow (e.g. `:normal` in a while-loop).
