### PR TITLE
[RFC] add kbtree_t and use it for bufhl

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -2529,6 +2529,8 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
                    r'(?<!\bklist_t)'
                    r'(?<!\bkliter_t)'
                    r'(?<!\bkhash_t)'
+                   r'(?<!\bkbtree_t)'
+                   r'(?<!\bkbitr_t)'
                    r'\((?:const )?(?:struct )?[a-zA-Z_]\w*(?: *\*(?:const)?)*\)'
                    r' +'
                    r'-?(?:\*+|&)?(?:\w+|\+\+|--|\()', cast_line)

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -399,7 +399,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
   // Only adjust marks if we managed to switch to a window that holds
   // the buffer, otherwise line numbers will be invalid.
   if (save_curbuf.br_buf == NULL) {
-    mark_adjust((linenr_T)start, (linenr_T)(end - 1), MAXLNUM, extra);
+    mark_adjust((linenr_T)start, (linenr_T)(end - 1), MAXLNUM, extra, false);
   }
 
   changed_lines((linenr_T)start, 0, (linenr_T)end, (long)extra);

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -13,6 +13,7 @@
 #include "nvim/ascii.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/private/defs.h"
+#include "nvim/api/private/dispatch.h"
 #include "nvim/api/buffer.h"
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/lua/executor.h"

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5144,22 +5144,25 @@ void sign_mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_a
 
 // bufhl: plugin highlights associated with a buffer
 
-/// Get reference to line in kbtree_t, allocating it if neccessary.
+/// Get reference to line in kbtree_t
+///
+/// @param b the three
+/// @param line the linenumber to lookup
+/// @param put if true, put a new line when not found
+///            if false, return NULL when not found
 BufhlLine *bufhl_tree_ref(kbtree_t(bufhl) *b, linenr_T line, bool put) {
-  BufhlLine t, *p, **pp;
-  t.line = line;
+  BufhlLine t = BUFHLLINE_INIT(line);
 
-  // put() only works if key is absent
-  pp = kb_get(bufhl, b, &t);
+  // kp_put() only works if key is absent, try get first
+  BufhlLine **pp = kb_get(bufhl, b, &t);
   if (pp) {
     return *pp;
   } else if (!put) {
     return NULL;
   }
 
-  p = xcalloc(sizeof(*p), 1);
-  p->line = line;
-  // p->items zero initialized
+  BufhlLine *p = xmalloc(sizeof(*p));
+  *p = (BufhlLine)BUFHLLINE_INIT(line);
   kb_put(bufhl, b, p);
   return p;
 }
@@ -5231,7 +5234,7 @@ void bufhl_clear_line_range(buf_T *buf,
   linenr_T first_changed = MAXLNUM, last_changed = -1;
 
   kbitr_t(bufhl) itr;
-  BufhlLine *l, t = {line_start};
+  BufhlLine *l, t = BUFHLLINE_INIT(line_start);
   if (!kb_itr_get(bufhl, &buf->b_bufhl_info, &t, &itr)) {
     kb_itr_next(bufhl, &buf->b_bufhl_info, &itr);
   }
@@ -5313,7 +5316,7 @@ void bufhl_mark_adjust(buf_T* buf,
   // we need to detect this case and
 
   kbitr_t(bufhl) itr;
-  BufhlLine *l, t = {line1};
+  BufhlLine *l, t = BUFHLLINE_INIT(line1);
   if (!kb_itr_get(bufhl, &buf->b_bufhl_info, &t, &itr)) {
     kb_itr_next(bufhl, &buf->b_bufhl_info, &itr);
   }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5202,7 +5202,7 @@ int bufhl_add_hl(buf_T *buf,
       return src_id;
   }
   if (!buf->b_bufhl_info) {
-    buf->b_bufhl_info = kb_init(bufhl, KB_DEFAULT_SIZE);
+    buf->b_bufhl_info = kb_init(bufhl);
   }
 
   BufhlLine *lineinfo = bufhl_tree_ref(buf->b_bufhl_info, lnum, true);
@@ -5235,13 +5235,13 @@ void bufhl_clear_line_range(buf_T *buf,
   }
   linenr_T first_changed = MAXLNUM, last_changed = -1;
 
-  kbitr_t itr;
+  kbitr_t(bufhl) itr;
   BufhlLine *l, t = {line_start};
   if (!kb_itr_get(bufhl, buf->b_bufhl_info, &t, &itr)) {
     kb_itr_next(bufhl, buf->b_bufhl_info, &itr);
   }
   for (; kb_itr_valid(&itr); kb_itr_next(bufhl, buf->b_bufhl_info, &itr)) {
-    l = kb_itr_key(BufhlLine *, &itr);
+    l = kb_itr_key(&itr);
     linenr_T line = l->line;
     if (line > line_end) {
       break;
@@ -5323,13 +5323,13 @@ void bufhl_mark_adjust(buf_T* buf,
   // XXX: does not support move
   // we need to detect this case and
 
-  kbitr_t itr;
+  kbitr_t(bufhl) itr;
   BufhlLine *l, t = {line1};
   if (!kb_itr_get(bufhl, buf->b_bufhl_info, &t, &itr)) {
     kb_itr_next(bufhl, buf->b_bufhl_info, &itr);
   }
   for (; kb_itr_valid(&itr); kb_itr_next(bufhl, buf->b_bufhl_info, &itr)) {
-    l = kb_itr_key(BufhlLine *, &itr);
+    l = kb_itr_key(&itr);
     if (l->line >= line1 && l->line <= line2) {
       if (amount == MAXLNUM) {
         if (bufhl_clear_line(buf->b_bufhl_info, -1, l->line) == kBLSDeleted) {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -74,6 +74,12 @@
 #include "nvim/os/time.h"
 #include "nvim/os/input.h"
 
+typedef enum {
+  kBLSUnchanged = 0,
+  kBLSChanged = 1,
+  kBLSDeleted = 2,
+} BufhlLineStatus;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "buffer.c.generated.h"
 #endif
@@ -5228,27 +5234,30 @@ void bufhl_clear_line_range(buf_T *buf,
     return;
   }
   linenr_T first_changed = MAXLNUM, last_changed = -1;
-  // TODO: implement kb_itr_interval and jump directly to the first line
+
   kbitr_t itr;
-  BufhlLine *l;
-  for (kb_itr_first(bufhl, buf->b_bufhl_info, &itr);
-       kb_itr_valid(&itr);
-       kb_itr_next(bufhl, buf->b_bufhl_info, &itr)) {
+  BufhlLine *l, t = {line_start};
+  if (!kb_itr_get(bufhl, buf->b_bufhl_info, &t, &itr)) {
+    kb_itr_next(bufhl, buf->b_bufhl_info, &itr);
+  }
+  for (; kb_itr_valid(&itr); kb_itr_next(bufhl, buf->b_bufhl_info, &itr)) {
     l = kb_itr_key(BufhlLine *, &itr);
     linenr_T line = l->line;
-    if (line < line_start) {
-      continue;
-    } else if (line > line_end) {
+    if (line > line_end) {
       break;
     }
     if (line_start <= line && line <= line_end) {
-      if (bufhl_clear_line(buf->b_bufhl_info, src_id, line)) {
+      BufhlLineStatus status = bufhl_clear_line(buf->b_bufhl_info, src_id, line);
+      if (status != kBLSUnchanged) {
         if (line > last_changed) {
           last_changed = line;
         }
         if (line < first_changed) {
           first_changed = line;
         }
+      }
+      if (status == kBLSDeleted) {
+        kb_del_itr(bufhl, buf->b_bufhl_info, &itr);
       }
     }
   }
@@ -5264,8 +5273,8 @@ void bufhl_clear_line_range(buf_T *buf,
 /// @param bufhl_info The highlight info for the buffer
 /// @param src_id Highlight source group to clear, or -1 to clear all groups.
 /// @param lnum Linenr where the highlight should be cleared
-static bool bufhl_clear_line(bufhl_info_T *bufhl_info, int src_id,
-                             linenr_T lnum)
+static BufhlLineStatus bufhl_clear_line(bufhl_info_T *bufhl_info, int src_id,
+                                        linenr_T lnum)
 {
   BufhlLine *lineinfo = bufhl_tree_ref(bufhl_info, lnum, false);
   size_t oldsize = kv_size(lineinfo->items);
@@ -5286,9 +5295,9 @@ static bool bufhl_clear_line(bufhl_info_T *bufhl_info, int src_id,
 
   if (kv_size(lineinfo->items) == 0) {
     kv_destroy(lineinfo->items);
-    kb_del(bufhl, bufhl_info, lineinfo);
+    return kBLSDeleted;
   }
-  return kv_size(lineinfo->items) != oldsize;
+  return kv_size(lineinfo->items) != oldsize ? kBLSChanged : kBLSUnchanged;
 }
 
 /// Remove all highlights and free the highlight data
@@ -5315,15 +5324,19 @@ void bufhl_mark_adjust(buf_T* buf,
   // we need to detect this case and
 
   kbitr_t itr;
-  BufhlLine *l;
-  for (kb_itr_first(bufhl, buf->b_bufhl_info, &itr);
-       kb_itr_valid(&itr);
-       kb_itr_next(bufhl, buf->b_bufhl_info, &itr)) {
+  BufhlLine *l, t = {line1};
+  if (!kb_itr_get(bufhl, buf->b_bufhl_info, &t, &itr)) {
+    kb_itr_next(bufhl, buf->b_bufhl_info, &itr);
+  }
+  for (; kb_itr_valid(&itr); kb_itr_next(bufhl, buf->b_bufhl_info, &itr)) {
     l = kb_itr_key(BufhlLine *, &itr);
     if (l->line >= line1 && l->line <= line2) {
       if (amount == MAXLNUM) {
-        bufhl_clear_line(buf->b_bufhl_info, -1, l->line);
-        continue;
+        if (bufhl_clear_line(buf->b_bufhl_info, -1, l->line) == kBLSDeleted) {
+          kb_del_itr(bufhl, buf->b_bufhl_info, &itr);
+        } else {
+          assert(false);
+        }
       } else {
         l->line += amount;
       }

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -106,8 +106,6 @@ typedef struct frame_S frame_T;
 // for bufhl_*_T
 #include "nvim/bufhl_defs.h"
 
-typedef Map(linenr_T, bufhl_vec_T) bufhl_info_T;
-
 #include "nvim/os/fs_defs.h"    // for FileID
 #include "nvim/terminal.h"      // for Terminal
 

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -760,7 +760,7 @@ struct file_buffer {
 
   int b_mapped_ctrl_c;          // modes where CTRL-C is mapped
 
-  bufhl_info_T *b_bufhl_info;   // buffer stored highlights
+  bufhl_info_T b_bufhl_info;   // buffer stored highlights
 };
 
 /*

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -761,6 +761,8 @@ struct file_buffer {
   int b_mapped_ctrl_c;          // modes where CTRL-C is mapped
 
   BufhlInfo b_bufhl_info;       // buffer stored highlights
+
+  kvec_t(BufhlLine *) b_bufhl_move_space;  // temporary space for highlights
 };
 
 /*

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -760,7 +760,7 @@ struct file_buffer {
 
   int b_mapped_ctrl_c;          // modes where CTRL-C is mapped
 
-  bufhl_info_T b_bufhl_info;   // buffer stored highlights
+  BufhlInfo b_bufhl_info;       // buffer stored highlights
 };
 
 /*

--- a/src/nvim/bufhl_defs.h
+++ b/src/nvim/bufhl_defs.h
@@ -29,6 +29,6 @@ typedef struct {
 } bufhl_lineinfo_T;
 
 #define BUFHL_CMP(a, b) (((a)->line - (b)->line))
-KBTREE_INIT(bufhl, BufhlLine *, BUFHL_CMP)
+KBTREE_INIT(bufhl, BufhlLine *, BUFHL_CMP, 10)
 typedef kbtree_t(bufhl) bufhl_info_T;
 #endif  // NVIM_BUFHL_DEFS_H

--- a/src/nvim/bufhl_defs.h
+++ b/src/nvim/bufhl_defs.h
@@ -4,32 +4,31 @@
 #include "nvim/pos.h"
 #include "nvim/lib/kvec.h"
 #include "nvim/lib/kbtree.h"
+
 // bufhl: buffer specific highlighting
 
-struct bufhl_hl_item
-{
+typedef struct {
   int src_id;
   int hl_id;  // highlight group
   colnr_T start;  // first column to highlight
   colnr_T stop;  // last column to highlight
-};
-typedef struct bufhl_hl_item bufhl_hl_item_T;
+} BufhlItem;
 
-typedef kvec_t(struct bufhl_hl_item) bufhl_vec_T;
+typedef kvec_t(BufhlItem) BufhlItemVec;
 
 typedef struct {
   linenr_T line;
-  bufhl_vec_T items;
+  BufhlItemVec items;
 } BufhlLine;
 #define BUFHLLINE_INIT(l) { l, KV_INITIAL_VALUE }
 
 typedef struct {
-  bufhl_vec_T entries;
+  BufhlItemVec entries;
   int current;
   colnr_T valid_to;
-} bufhl_lineinfo_T;
+} BufhlLineInfo;
 
 #define BUFHL_CMP(a, b) ((int)(((a)->line - (b)->line)))
 KBTREE_INIT(bufhl, BufhlLine *, BUFHL_CMP, 10)
-typedef kbtree_t(bufhl) bufhl_info_T;
+typedef kbtree_t(bufhl) BufhlInfo;
 #endif  // NVIM_BUFHL_DEFS_H

--- a/src/nvim/bufhl_defs.h
+++ b/src/nvim/bufhl_defs.h
@@ -28,7 +28,7 @@ typedef struct {
   colnr_T valid_to;
 } bufhl_lineinfo_T;
 
-#define BUFHL_CMP(a, b) (((b)->line - (a)->line))
+#define BUFHL_CMP(a, b) (((a)->line - (b)->line))
 KBTREE_INIT(bufhl, BufhlLine *, BUFHL_CMP)
 typedef kbtree_t(bufhl) bufhl_info_T;
 #endif  // NVIM_BUFHL_DEFS_H

--- a/src/nvim/bufhl_defs.h
+++ b/src/nvim/bufhl_defs.h
@@ -3,6 +3,7 @@
 
 #include "nvim/pos.h"
 #include "nvim/lib/kvec.h"
+#include "nvim/lib/kbtree.h"
 // bufhl: buffer specific highlighting
 
 struct bufhl_hl_item
@@ -17,9 +18,17 @@ typedef struct bufhl_hl_item bufhl_hl_item_T;
 typedef kvec_t(struct bufhl_hl_item) bufhl_vec_T;
 
 typedef struct {
+  linenr_T line;
+  bufhl_vec_T items;
+} BufhlLine;
+
+typedef struct {
   bufhl_vec_T entries;
   int current;
   colnr_T valid_to;
 } bufhl_lineinfo_T;
 
+#define BUFHL_CMP(a, b) (((b)->line - (a)->line))
+KBTREE_INIT(bufhl, BufhlLine *, BUFHL_CMP)
+typedef kbtree_t(bufhl) bufhl_info_T;
 #endif  // NVIM_BUFHL_DEFS_H

--- a/src/nvim/bufhl_defs.h
+++ b/src/nvim/bufhl_defs.h
@@ -21,6 +21,7 @@ typedef struct {
   linenr_T line;
   bufhl_vec_T items;
 } BufhlLine;
+#define BUFHLLINE_INIT(l) { l, KV_INITIAL_VALUE }
 
 typedef struct {
   bufhl_vec_T entries;
@@ -28,7 +29,7 @@ typedef struct {
   colnr_T valid_to;
 } bufhl_lineinfo_T;
 
-#define BUFHL_CMP(a, b) (((a)->line - (b)->line))
+#define BUFHL_CMP(a, b) ((int)(((a)->line - (b)->line)))
 KBTREE_INIT(bufhl, BufhlLine *, BUFHL_CMP, 10)
 typedef kbtree_t(bufhl) bufhl_info_T;
 #endif  // NVIM_BUFHL_DEFS_H

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -2311,7 +2311,7 @@ void ex_diffgetput(exarg_T *eap)
 
       // Adjust marks.  This will change the following entries!
       if (added != 0) {
-        mark_adjust(lnum, lnum + count - 1, (long)MAXLNUM, (long)added);
+        mark_adjust(lnum, lnum + count - 1, (long)MAXLNUM, (long)added, false);
         if (curwin->w_cursor.lnum >= lnum) {
           // Adjust the cursor position if it's in/after the changed
           // lines.

--- a/src/nvim/lib/kbtree.h
+++ b/src/nvim/lib/kbtree.h
@@ -1,0 +1,423 @@
+/*-
+ * Copyright 1997-1999, 2001, John-Mark Gurney.
+ *           2008-2009, Attractive Chaos <attractor@live.co.uk>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef NVIM_LIB_KBTREE_H
+#define NVIM_LIB_KBTREE_H
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#define KB_MAX_DEPTH 64
+
+typedef struct {
+  int32_t is_internal:1, n:31;
+} kbnode_t;
+
+
+typedef struct {
+	kbnode_t *x;
+	int i;
+} kbpos_t;
+
+typedef struct {
+	kbpos_t stack[KB_MAX_DEPTH], *p;
+} kbitr_t;
+
+#define	__KB_KEY(type, x)	((type*)((char*)x + 4))
+#define __KB_PTR(btr, x)	((kbnode_t**)((char*)x + btr->off_ptr))
+
+#define __KB_TREE_T(name)						\
+	typedef struct {							\
+		kbnode_t *root;							\
+		int	off_key, off_ptr, ilen, elen;		\
+		int	n, t;								\
+		int	n_keys, n_nodes;					\
+	} kbtree_##name##_t;
+
+#define __KB_INIT(name, key_t)											\
+	static inline kbtree_##name##_t *kb_init_##name(unsigned int size)							\
+	{																	\
+		kbtree_##name##_t *b;											\
+		b = (kbtree_##name##_t*)calloc(1, sizeof(kbtree_##name##_t));	\
+		b->t = (int)((size - 4 - sizeof(void*)) / (sizeof(void*) + sizeof(key_t)) + 1) >> 1; \
+		if (b->t < 2) {													\
+			free(b); return 0;											\
+		}																\
+		b->n = 2 * b->t - 1;											\
+		b->off_ptr = (int)(4 + (unsigned int)b->n * sizeof(key_t));							\
+		b->ilen = (int)(4 + sizeof(void*) + (unsigned int)b->n * (sizeof(void*) + sizeof(key_t)) + 3) >> 2 << 2; \
+		b->elen = (b->off_ptr + 3) >> 2 << 2;							\
+		b->root = (kbnode_t*)calloc(1, (unsigned int)b->ilen);						\
+		++b->n_nodes;													\
+		return b;														\
+	}
+
+#define __kb_destroy(b) do {											\
+		int i;                                                          \
+        unsigned int max = 8;											\
+		kbnode_t *x, **top, **stack = 0;								\
+		if (b) {														\
+			top = stack = (kbnode_t**)calloc(max, sizeof(kbnode_t*));	\
+			*top++ = (b)->root;											\
+			while (top != stack) {										\
+				x = *--top;												\
+				if (x->is_internal == 0) { free(x); continue; }			\
+				for (i = 0; i <= x->n; ++i)								\
+					if (__KB_PTR(b, x)[i]) {							\
+						if (top - stack == (int)max) {		        	\
+							max <<= 1;									\
+							stack = (kbnode_t**)realloc(stack, max * sizeof(kbnode_t*)); \
+							top = stack + (max>>1);						\
+						}												\
+						*top++ = __KB_PTR(b, x)[i];						\
+					}													\
+				free(x);												\
+			}															\
+		}																\
+		free(b); free(stack);											\
+	} while (0)
+
+#define __KB_GET_AUX1(name, key_t, __cmp)								\
+	static inline int __kb_getp_aux_##name(const kbnode_t * __restrict x, const key_t * __restrict k, int *r) \
+	{																	\
+		int tr, *rr, begin = 0, end = x->n;								\
+		if (x->n == 0) return -1;										\
+		rr = r? r : &tr;												\
+		while (begin < end) {											\
+			int mid = (begin + end) >> 1;								\
+			if (__cmp(__KB_KEY(key_t, x)[mid], *k) < 0) begin = mid + 1; \
+			else end = mid;												\
+		}																\
+		if (begin == x->n) { *rr = 1; return x->n - 1; }				\
+		if ((*rr = __cmp(*k, __KB_KEY(key_t, x)[begin])) < 0) --begin;	\
+		return begin;													\
+	}
+
+#define __KB_GET(name, key_t)											\
+	static key_t *kb_getp_##name(kbtree_##name##_t *b, const key_t * __restrict k) \
+	{																	\
+		int i, r = 0;													\
+		kbnode_t *x = b->root;											\
+		while (x) {														\
+			i = __kb_getp_aux_##name(x, k, &r);							\
+			if (i >= 0 && r == 0) return &__KB_KEY(key_t, x)[i];		\
+			if (x->is_internal == 0) return 0;							\
+			x = __KB_PTR(b, x)[i + 1];									\
+		}																\
+		return 0;														\
+	}																	\
+	static inline key_t *kb_get_##name(kbtree_##name##_t *b, const key_t k) \
+	{																	\
+		return kb_getp_##name(b, &k);									\
+	}
+
+#define __KB_INTERVAL(name, key_t)										\
+	static void kb_intervalp_##name(kbtree_##name##_t *b, const key_t * __restrict k, key_t **lower, key_t **upper)	\
+	{																	\
+		int i, r = 0;													\
+		kbnode_t *x = b->root;											\
+		*lower = *upper = 0;											\
+		while (x) {														\
+			i = __kb_getp_aux_##name(x, k, &r);							\
+			if (i >= 0 && r == 0) {										\
+				*lower = *upper = &__KB_KEY(key_t, x)[i];				\
+				return;													\
+			}															\
+			if (i >= 0) *lower = &__KB_KEY(key_t, x)[i];				\
+			if (i < x->n - 1) *upper = &__KB_KEY(key_t, x)[i + 1];		\
+			if (x->is_internal == 0) return;							\
+			x = __KB_PTR(b, x)[i + 1];									\
+		}																\
+	}																	\
+	static inline void kb_interval_##name(kbtree_##name##_t *b, const key_t k, key_t **lower, key_t **upper) \
+	{																	\
+		kb_intervalp_##name(b, &k, lower, upper);						\
+	}
+
+#define __KB_PUT(name, key_t, __cmp)									\
+	/* x must be an internal node */									\
+	static void __kb_split_##name(kbtree_##name##_t *b, kbnode_t *x, int i, kbnode_t *y) \
+	{																	\
+		kbnode_t *z;													\
+		z = (kbnode_t*)calloc(1, y->is_internal? (unsigned int)b->ilen : (unsigned int)b->elen);	\
+		++b->n_nodes;													\
+		z->is_internal = y->is_internal;								\
+		z->n = b->t - 1;												\
+		memcpy(__KB_KEY(key_t, z), __KB_KEY(key_t, y) + b->t, sizeof(key_t) * (unsigned int)(b->t - 1)); \
+		if (y->is_internal) memcpy(__KB_PTR(b, z), __KB_PTR(b, y) + (unsigned int)b->t, sizeof(void*) * (unsigned int)b->t); \
+		y->n = b->t - 1;												\
+		memmove(__KB_PTR(b, x) + i + 2, __KB_PTR(b, x) + i + 1, sizeof(void*) * (unsigned int)(x->n - i)); \
+		__KB_PTR(b, x)[i + 1] = z;										\
+		memmove(__KB_KEY(key_t, x) + i + 1, __KB_KEY(key_t, x) + i, sizeof(key_t) * (unsigned int)(x->n - i)); \
+		__KB_KEY(key_t, x)[i] = __KB_KEY(key_t, y)[b->t - 1];			\
+		++x->n;															\
+	}																	\
+	static key_t *__kb_putp_aux_##name(kbtree_##name##_t *b, kbnode_t *x, const key_t * __restrict k) \
+	{																	\
+		int i = x->n - 1;												\
+		key_t *ret;														\
+		if (x->is_internal == 0) {										\
+			i = __kb_getp_aux_##name(x, k, 0);							\
+			if (i != x->n - 1)											\
+				memmove(__KB_KEY(key_t, x) + i + 2, __KB_KEY(key_t, x) + i + 1, (unsigned int)(x->n - i - 1) * sizeof(key_t)); \
+			ret = &__KB_KEY(key_t, x)[i + 1];							\
+			*ret = *k;													\
+			++x->n;														\
+		} else {														\
+			i = __kb_getp_aux_##name(x, k, 0) + 1;						\
+			if (__KB_PTR(b, x)[i]->n == 2 * b->t - 1) {					\
+				__kb_split_##name(b, x, i, __KB_PTR(b, x)[i]);			\
+				if (__cmp(*k, __KB_KEY(key_t, x)[i]) > 0) ++i;			\
+			}															\
+			ret = __kb_putp_aux_##name(b, __KB_PTR(b, x)[i], k);		\
+		}																\
+		return ret; 													\
+	}																	\
+	static key_t *kb_putp_##name(kbtree_##name##_t *b, const key_t * __restrict k) \
+	{																	\
+		kbnode_t *r, *s;												\
+		++b->n_keys;													\
+		r = b->root;													\
+		if (r->n == 2 * b->t - 1) {										\
+			++b->n_nodes;												\
+			s = (kbnode_t*)calloc(1, (unsigned int)b->ilen);							\
+			b->root = s; s->is_internal = 1; s->n = 0;					\
+			__KB_PTR(b, s)[0] = r;										\
+			__kb_split_##name(b, s, 0, r);								\
+			r = s;														\
+		}																\
+		return __kb_putp_aux_##name(b, r, k);							\
+	}																	\
+	static inline void kb_put_##name(kbtree_##name##_t *b, const key_t k) \
+	{																	\
+		kb_putp_##name(b, &k);											\
+	}
+
+
+#define __KB_DEL(name, key_t)											\
+	static key_t __kb_delp_aux_##name(kbtree_##name##_t *b, kbnode_t *x, const key_t * __restrict k, int s) \
+	{																	\
+		int yn, zn, i, r = 0;											\
+		kbnode_t *xp, *y, *z;											\
+		key_t kp;														\
+		if (x == 0) return *k;											\
+		if (s) { /* s can only be 0, 1 or 2 */							\
+			r = x->is_internal == 0? 0 : s == 1? 1 : -1;				\
+			i = s == 1? x->n - 1 : -1;									\
+		} else i = __kb_getp_aux_##name(x, k, &r);						\
+		if (x->is_internal == 0) {										\
+			if (s == 2) ++i;											\
+			kp = __KB_KEY(key_t, x)[i];									\
+			memmove(__KB_KEY(key_t, x) + i, __KB_KEY(key_t, x) + i + 1, (unsigned int)(x->n - i - 1) * sizeof(key_t)); \
+			--x->n;														\
+			return kp;													\
+		}																\
+		if (r == 0) {													\
+			if ((yn = __KB_PTR(b, x)[i]->n) >= b->t) {					\
+				xp = __KB_PTR(b, x)[i];									\
+				kp = __KB_KEY(key_t, x)[i];								\
+				__KB_KEY(key_t, x)[i] = __kb_delp_aux_##name(b, xp, 0, 1); \
+				return kp;												\
+			} else if ((zn = __KB_PTR(b, x)[i + 1]->n) >= b->t) {		\
+				xp = __KB_PTR(b, x)[i + 1];								\
+				kp = __KB_KEY(key_t, x)[i];								\
+				__KB_KEY(key_t, x)[i] = __kb_delp_aux_##name(b, xp, 0, 2); \
+				return kp;												\
+			} else if (yn == b->t - 1 && zn == b->t - 1) {				\
+				y = __KB_PTR(b, x)[i]; z = __KB_PTR(b, x)[i + 1];		\
+				__KB_KEY(key_t, y)[y->n++] = *k;						\
+				memmove(__KB_KEY(key_t, y) + y->n, __KB_KEY(key_t, z), (unsigned int)z->n * sizeof(key_t)); \
+				if (y->is_internal) memmove(__KB_PTR(b, y) + y->n, __KB_PTR(b, z), (unsigned int)(z->n + 1) * sizeof(void*)); \
+				y->n += z->n;											\
+				memmove(__KB_KEY(key_t, x) + i, __KB_KEY(key_t, x) + i + 1, (unsigned int)(x->n - i - 1) * sizeof(key_t)); \
+				memmove(__KB_PTR(b, x) + i + 1, __KB_PTR(b, x) + i + 2, (unsigned int)(x->n - i - 1) * sizeof(void*)); \
+				--x->n;													\
+				free(z);												\
+				return __kb_delp_aux_##name(b, y, k, s);				\
+			}															\
+		}																\
+		++i;															\
+		if ((xp = __KB_PTR(b, x)[i])->n == b->t - 1) {					\
+			if (i > 0 && (y = __KB_PTR(b, x)[i - 1])->n >= b->t) {		\
+				memmove(__KB_KEY(key_t, xp) + 1, __KB_KEY(key_t, xp), (unsigned int)xp->n * sizeof(key_t)); \
+				if (xp->is_internal) memmove(__KB_PTR(b, xp) + 1, __KB_PTR(b, xp), (unsigned int)(xp->n + 1) * sizeof(void*)); \
+				__KB_KEY(key_t, xp)[0] = __KB_KEY(key_t, x)[i - 1];		\
+				__KB_KEY(key_t, x)[i - 1] = __KB_KEY(key_t, y)[y->n - 1]; \
+				if (xp->is_internal) __KB_PTR(b, xp)[0] = __KB_PTR(b, y)[y->n]; \
+				--y->n; ++xp->n;										\
+			} else if (i < x->n && (y = __KB_PTR(b, x)[i + 1])->n >= b->t) { \
+				__KB_KEY(key_t, xp)[xp->n++] = __KB_KEY(key_t, x)[i];	\
+				__KB_KEY(key_t, x)[i] = __KB_KEY(key_t, y)[0];			\
+				if (xp->is_internal) __KB_PTR(b, xp)[xp->n] = __KB_PTR(b, y)[0]; \
+				--y->n;													\
+				memmove(__KB_KEY(key_t, y), __KB_KEY(key_t, y) + 1, (unsigned int)y->n * sizeof(key_t)); \
+				if (y->is_internal) memmove(__KB_PTR(b, y), __KB_PTR(b, y) + 1, (unsigned int)(y->n + 1) * sizeof(void*)); \
+			} else if (i > 0 && (y = __KB_PTR(b, x)[i - 1])->n == b->t - 1) { \
+				__KB_KEY(key_t, y)[y->n++] = __KB_KEY(key_t, x)[i - 1];	\
+				memmove(__KB_KEY(key_t, y) + y->n, __KB_KEY(key_t, xp), (unsigned int)xp->n * sizeof(key_t));	\
+				if (y->is_internal) memmove(__KB_PTR(b, y) + y->n, __KB_PTR(b, xp), (unsigned int)(xp->n + 1) * sizeof(void*)); \
+				y->n += xp->n;											\
+				memmove(__KB_KEY(key_t, x) + i - 1, __KB_KEY(key_t, x) + i, (unsigned int)(x->n - i) * sizeof(key_t)); \
+				memmove(__KB_PTR(b, x) + i, __KB_PTR(b, x) + i + 1, (unsigned int)(x->n - i) * sizeof(void*)); \
+				--x->n;													\
+				free(xp);												\
+				xp = y;													\
+			} else if (i < x->n && (y = __KB_PTR(b, x)[i + 1])->n == b->t - 1) { \
+				__KB_KEY(key_t, xp)[xp->n++] = __KB_KEY(key_t, x)[i];	\
+				memmove(__KB_KEY(key_t, xp) + xp->n, __KB_KEY(key_t, y), (unsigned int)y->n * sizeof(key_t));	\
+				if (xp->is_internal) memmove(__KB_PTR(b, xp) + xp->n, __KB_PTR(b, y), (unsigned int)(y->n + 1) * sizeof(void*)); \
+				xp->n += y->n;											\
+				memmove(__KB_KEY(key_t, x) + i, __KB_KEY(key_t, x) + i + 1, (unsigned int)(x->n - i - 1) * sizeof(key_t)); \
+				memmove(__KB_PTR(b, x) + i + 1, __KB_PTR(b, x) + i + 2, (unsigned int)(x->n - i - 1) * sizeof(void*)); \
+				--x->n;													\
+				free(y);												\
+			}															\
+		}																\
+		return __kb_delp_aux_##name(b, xp, k, s);						\
+	}																	\
+	static key_t kb_delp_##name(kbtree_##name##_t *b, const key_t * __restrict k) \
+	{																	\
+		kbnode_t *x;													\
+		key_t ret;														\
+		ret = __kb_delp_aux_##name(b, b->root, k, 0);					\
+		--b->n_keys;													\
+		if (b->root->n == 0 && b->root->is_internal) {					\
+			--b->n_nodes;												\
+			x = b->root;												\
+			b->root = __KB_PTR(b, x)[0];								\
+			free(x);													\
+		}																\
+		return ret;														\
+	}																	\
+	static inline key_t kb_del_##name(kbtree_##name##_t *b, const key_t k) \
+	{																	\
+		return kb_delp_##name(b, &k);									\
+	}
+
+#define __KB_ITR(name, key_t) \
+	static inline void kb_itr_first_##name(kbtree_##name##_t *b, kbitr_t *itr) \
+	{ \
+		itr->p = 0; \
+		if (b->n_keys == 0) return; \
+		itr->p = itr->stack; \
+		itr->p->x = b->root; itr->p->i = 0; \
+		while (itr->p->x->is_internal && __KB_PTR(b, itr->p->x)[0] != 0) { \
+			kbnode_t *x = itr->p->x; \
+			++itr->p; \
+			itr->p->x = __KB_PTR(b, x)[0]; itr->p->i = 0; \
+		} \
+	} \
+	static inline int kb_itr_next_##name(kbtree_##name##_t *b, kbitr_t *itr) \
+	{ \
+		if (itr->p < itr->stack) return 0; \
+		for (;;) { \
+			++itr->p->i; \
+			while (itr->p->x && itr->p->i <= itr->p->x->n) { \
+				itr->p[1].i = 0; \
+				itr->p[1].x = itr->p->x->is_internal? __KB_PTR(b, itr->p->x)[itr->p->i] : 0; \
+				++itr->p; \
+			} \
+			--itr->p; \
+			if (itr->p < itr->stack) return 0; \
+			if (itr->p->x && itr->p->i < itr->p->x->n) return 1; \
+		} \
+	}
+
+#define KBTREE_INIT(name, key_t, __cmp)			\
+	__KB_TREE_T(name)							\
+	__KB_INIT(name, key_t)						\
+	__KB_GET_AUX1(name, key_t, __cmp)			\
+	__KB_GET(name, key_t)						\
+	__KB_INTERVAL(name, key_t)					\
+	__KB_PUT(name, key_t, __cmp)				\
+	__KB_DEL(name, key_t) \
+	__KB_ITR(name, key_t)
+
+#define KB_DEFAULT_SIZE 512
+
+#define kbtree_t(name) kbtree_##name##_t
+#define kb_init(name, s) kb_init_##name(s)
+#define kb_destroy(name, b) __kb_destroy(b)
+#define kb_get(name, b, k) kb_get_##name(b, k)
+#define kb_put(name, b, k) kb_put_##name(b, k)
+#define kb_del(name, b, k) kb_del_##name(b, k)
+#define kb_interval(name, b, k, l, u) kb_interval_##name(b, k, l, u)
+#define kb_getp(name, b, k) kb_getp_##name(b, k)
+#define kb_putp(name, b, k) kb_putp_##name(b, k)
+#define kb_delp(name, b, k) kb_delp_##name(b, k)
+#define kb_intervalp(name, b, k, l, u) kb_intervalp_##name(b, k, l, u)
+
+#define kb_itr_first(name, b, i) kb_itr_first_##name(b, i)
+#define kb_itr_next(name, b, i) kb_itr_next_##name(b, i)
+#define kb_itr_key(type, itr) __KB_KEY(type, (itr)->p->x)[(itr)->p->i]
+#define kb_itr_valid(itr) ((itr)->p >= (itr)->stack)
+
+#define kb_size(b) ((b)->n_keys)
+
+#define kb_generic_cmp(a, b) (((b) < (a)) - ((a) < (b)))
+#define kb_str_cmp(a, b) strcmp(a, b)
+
+/* The following is *DEPRECATED*!!! Use the iterator interface instead! */
+
+typedef struct {
+	kbnode_t *x;
+	int i;
+} __kbstack_t;
+
+#define __kb_traverse(key_t, b, __func) do {							\
+		int __kmax = 8;													\
+		__kbstack_t *__kstack, *__kp;									\
+		__kp = __kstack = (__kbstack_t*)calloc(__kmax, sizeof(__kbstack_t)); \
+		__kp->x = (b)->root; __kp->i = 0;								\
+		for (;;) {														\
+			while (__kp->x && __kp->i <= __kp->x->n) {					\
+				if (__kp - __kstack == __kmax - 1) {					\
+					__kmax <<= 1;										\
+					__kstack = (__kbstack_t*)realloc(__kstack, __kmax * sizeof(__kbstack_t)); \
+					__kp = __kstack + (__kmax>>1) - 1;					\
+				}														\
+				(__kp+1)->i = 0; (__kp+1)->x = __kp->x->is_internal? __KB_PTR(b, __kp->x)[__kp->i] : 0; \
+				++__kp;													\
+			}															\
+			--__kp;														\
+			if (__kp >= __kstack) {										\
+				if (__kp->x && __kp->i < __kp->x->n) __func(&__KB_KEY(key_t, __kp->x)[__kp->i]); \
+				++__kp->i;												\
+			} else break;												\
+		}																\
+		free(__kstack);													\
+	} while (0)
+
+#define __kb_get_first(key_t, b, ret) do {	\
+		kbnode_t *__x = (b)->root;			\
+		while (__KB_PTR(b, __x)[0] != 0)	\
+			__x = __KB_PTR(b, __x)[0];		\
+		(ret) = __KB_KEY(key_t, __x)[0];	\
+	} while (0)
+
+#endif  // NVIM_LIB_KBTREE_H

--- a/src/nvim/lib/kbtree.h
+++ b/src/nvim/lib/kbtree.h
@@ -40,18 +40,19 @@
 #define __KB_PTR(btr, x)	(x->ptr)
 
 #define __KB_TREE_T(name,key_t,T)						\
-typedef struct kbnode_##name##_s kbnode_##name##_t;     \
-struct kbnode_##name##_s {              \
-  int32_t n; \
-  bool is_internal; \
-  key_t key[2*T-1]; \
-  kbnode_##name##_t *ptr[0]; \
-} ;                   \
-                              \
-	typedef struct {							\
-		kbnode_##name##_t *root;							\
-		int	n_keys, n_nodes;					\
-	} kbtree_##name##_t; \
+    typedef struct kbnode_##name##_s kbnode_##name##_t;     \
+    struct kbnode_##name##_s {              \
+      int32_t n; \
+      bool is_internal; \
+      key_t key[2*T-1]; \
+      kbnode_##name##_t *ptr[0]; \
+    } ; \
+    \
+    typedef struct { \
+        kbnode_##name##_t *root; \
+        int	n_keys, n_nodes; \
+    } kbtree_##name##_t; \
+    \
     typedef struct { \
         kbnode_##name##_t *x; \
         int i; \
@@ -61,21 +62,11 @@ struct kbnode_##name##_s {              \
     } kbitr_##name##_t; \
 
 
-#define __KB_INIT(name, key_t, kbnode_t, T, ILEN)											\
-	static inline kbtree_##name##_t *kb_init_##name()							\
-	{																	\
-		kbtree_##name##_t *b;											\
-		b = (kbtree_##name##_t*)xcalloc(1, sizeof(kbtree_##name##_t));	\
-		b->root = (kbnode_t*)xcalloc(1, ILEN);						\
-		++b->n_nodes;													\
-		return b;														\
-	} \
-
 #define __kb_destroy(kbnode_t,b) do {											\
 		int i;                                                          \
         unsigned int max = 8;											\
 		kbnode_t *x, **top, **stack = 0;								\
-		if (b) {														\
+		if (b->root) {													\
 			top = stack = (kbnode_t**)xcalloc(max, sizeof(kbnode_t*));	\
 			*top++ = (b)->root;											\
 			while (top != stack) {										\
@@ -93,7 +84,7 @@ struct kbnode_##name##_s {              \
 				xfree(x);												\
 			}															\
 		}																\
-		xfree(b); xfree(stack);											\
+		xfree(stack);											\
 	} while (0)
 
 #define __KB_GET_AUX1(name, key_t, kbnode_t, __cmp)								\
@@ -115,6 +106,9 @@ struct kbnode_##name##_s {              \
 #define __KB_GET(name, key_t, kbnode_t)											\
 	static key_t *kb_getp_##name(kbtree_##name##_t *b, const key_t * __restrict k) \
 	{																	\
+		if (!b->root) { \
+		    return 0; \
+		} \
 		int i, r = 0;													\
 		kbnode_t *x = b->root;											\
 		while (x) {														\
@@ -133,6 +127,9 @@ struct kbnode_##name##_s {              \
 #define __KB_INTERVAL(name, key_t, kbnode_t)										\
 	static void kb_intervalp_##name(kbtree_##name##_t *b, const key_t * __restrict k, key_t **lower, key_t **upper)	\
 	{																	\
+		if (!b->root) { \
+		    return; \
+		} \
 		int i, r = 0;													\
 		kbnode_t *x = b->root;											\
 		*lower = *upper = 0;											\
@@ -194,6 +191,10 @@ struct kbnode_##name##_s {              \
 	}																	\
 	static key_t *kb_putp_##name(kbtree_##name##_t *b, const key_t * __restrict k) \
 	{																	\
+		if (!b->root) { \
+			b->root = (kbnode_t*)xcalloc(1, ILEN);						\
+			++b->n_nodes;													\
+		} \
 		kbnode_t *r, *s;												\
 		++b->n_keys;													\
 		r = b->root;													\
@@ -358,6 +359,7 @@ struct kbnode_##name##_s {              \
 	} \
 	static int kb_itr_getp_##name(kbtree_##name##_t *b, const key_t * __restrict k, kbitr_##name##_t *itr) \
 	{ \
+		if (b->n_keys == 0) return 0; \
 		int i, r = 0; \
 		itr->p = itr->stack; \
 		itr->p->x = b->root; \
@@ -388,7 +390,6 @@ struct kbnode_##name##_s {              \
 
 #define KBTREE_INIT_IMPL(name, key_t, kbnode_t, __cmp, T, ILEN)			\
 	__KB_TREE_T(name, key_t, T)							\
-	__KB_INIT(name, key_t, kbnode_t, T, ILEN)						\
 	__KB_GET_AUX1(name, key_t, kbnode_t, __cmp)			\
 	__KB_GET(name, key_t, kbnode_t)						\
 	__KB_INTERVAL(name, key_t, kbnode_t)					\
@@ -400,7 +401,6 @@ struct kbnode_##name##_s {              \
 
 #define kbtree_t(name) kbtree_##name##_t
 #define kbitr_t(name) kbitr_##name##_t
-#define kb_init(name) kb_init_##name()
 #define kb_destroy(name, b) __kb_destroy(kbnode_##name##_t, b)
 #define kb_get(name, b, k) kb_get_##name(b, k)
 #define kb_put(name, b, k) kb_put_##name(b, k)

--- a/src/nvim/lib/kbtree.h
+++ b/src/nvim/lib/kbtree.h
@@ -359,7 +359,10 @@
 	} \
 	static inline int kb_itr_getp_##name(kbtree_##name##_t *b, key_t * __restrict k, kbitr_##name##_t *itr) \
 	{ \
-		if (b->n_keys == 0) return 0; \
+		if (b->n_keys == 0) { \
+            itr->p = NULL; \
+            return 0; \
+        } \
 		int i, r = 0; \
 		itr->p = itr->stack; \
 		itr->p->x = b->root; \
@@ -420,6 +423,7 @@
 
 #define kbtree_t(name) kbtree_##name##_t
 #define kbitr_t(name) kbitr_##name##_t
+#define kb_init(b) ((b)->n_keys = (b)->n_nodes = 0, (b)->root = 0)
 #define kb_destroy(name, b) __kb_destroy(kbnode_##name##_t, b)
 #define kb_get(name, b, k) kb_get_##name(b, k)
 #define kb_put(name, b, k) kb_put_##name(b, k)

--- a/src/nvim/lib/kbtree.h
+++ b/src/nvim/lib/kbtree.h
@@ -45,7 +45,7 @@
       int32_t n; \
       bool is_internal; \
       key_t key[2*T-1]; \
-      kbnode_##name##_t *ptr[0]; \
+      kbnode_##name##_t *ptr[]; \
     } ; \
     \
     typedef struct { \
@@ -88,7 +88,7 @@
 	} while (0)
 
 #define __KB_GET_AUX1(name, key_t, kbnode_t, __cmp)								\
-	static inline int __kb_getp_aux_##name(const kbnode_t * __restrict x, const key_t * __restrict k, int *r) \
+	static inline int __kb_getp_aux_##name(const kbnode_t * __restrict x, key_t * __restrict k, int *r) \
 	{																	\
 		int tr, *rr, begin = 0, end = x->n;								\
 		if (x->n == 0) return -1;										\
@@ -104,7 +104,7 @@
 	}
 
 #define __KB_GET(name, key_t, kbnode_t)											\
-	static key_t *kb_getp_##name(kbtree_##name##_t *b, const key_t * __restrict k) \
+	static key_t *kb_getp_##name(kbtree_##name##_t *b, key_t * __restrict k) \
 	{																	\
 		if (!b->root) { \
 		    return 0; \
@@ -119,13 +119,13 @@
 		}																\
 		return 0;														\
 	}																	\
-	static inline key_t *kb_get_##name(kbtree_##name##_t *b, const key_t k) \
+	static inline key_t *kb_get_##name(kbtree_##name##_t *b, key_t k) \
 	{																	\
 		return kb_getp_##name(b, &k);									\
 	}
 
 #define __KB_INTERVAL(name, key_t, kbnode_t)										\
-	static void kb_intervalp_##name(kbtree_##name##_t *b, const key_t * __restrict k, key_t **lower, key_t **upper)	\
+	static inline void kb_intervalp_##name(kbtree_##name##_t *b, key_t * __restrict k, key_t **lower, key_t **upper)	\
 	{																	\
 		if (!b->root) { \
 		    return; \
@@ -145,14 +145,14 @@
 			x = __KB_PTR(b, x)[i + 1];									\
 		}																\
 	}																	\
-	static inline void kb_interval_##name(kbtree_##name##_t *b, const key_t k, key_t **lower, key_t **upper) \
+	static inline void kb_interval_##name(kbtree_##name##_t *b, key_t k, key_t **lower, key_t **upper) \
 	{																	\
 		kb_intervalp_##name(b, &k, lower, upper);						\
 	}
 
 #define __KB_PUT(name, key_t, kbnode_t, __cmp, T, ILEN)									\
 	/* x must be an internal node */									\
-	static void __kb_split_##name(kbtree_##name##_t *b, kbnode_t *x, int i, kbnode_t *y) \
+	static inline void __kb_split_##name(kbtree_##name##_t *b, kbnode_t *x, int i, kbnode_t *y) \
 	{																	\
 		kbnode_t *z;													\
 		z = (kbnode_t*)xcalloc(1, y->is_internal? ILEN : sizeof(kbnode_##name##_t));	\
@@ -168,7 +168,7 @@
 		__KB_KEY(key_t, x)[i] = __KB_KEY(key_t, y)[T - 1];			\
 		++x->n;															\
 	}																	\
-	static key_t *__kb_putp_aux_##name(kbtree_##name##_t *b, kbnode_t *x, const key_t * __restrict k) \
+	static inline key_t *__kb_putp_aux_##name(kbtree_##name##_t *b, kbnode_t *x, key_t * __restrict k) \
 	{																	\
 		int i = x->n - 1;												\
 		key_t *ret;														\
@@ -189,7 +189,7 @@
 		}																\
 		return ret; 													\
 	}																	\
-	static key_t *kb_putp_##name(kbtree_##name##_t *b, const key_t * __restrict k) \
+	static inline key_t *kb_putp_##name(kbtree_##name##_t *b, key_t * __restrict k) \
 	{																	\
 		if (!b->root) { \
 			b->root = (kbnode_t*)xcalloc(1, ILEN);						\
@@ -208,14 +208,14 @@
 		}																\
 		return __kb_putp_aux_##name(b, r, k);							\
 	}																	\
-	static inline void kb_put_##name(kbtree_##name##_t *b, const key_t k) \
+	static inline void kb_put_##name(kbtree_##name##_t *b, key_t k) \
 	{																	\
 		kb_putp_##name(b, &k);											\
 	}
 
 
 #define __KB_DEL(name, key_t, kbnode_t, T)											\
-	static key_t __kb_delp_aux_##name(kbtree_##name##_t *b, kbnode_t *x, const key_t * __restrict k, int s) \
+	static inline key_t __kb_delp_aux_##name(kbtree_##name##_t *b, kbnode_t *x, key_t * __restrict k, int s) \
 	{																	\
 		int yn, zn, i, r = 0;											\
 		kbnode_t *xp, *y, *z;											\
@@ -295,7 +295,7 @@
 		}																\
 		return __kb_delp_aux_##name(b, xp, k, s);						\
 	}																	\
-	static key_t kb_delp_##name(kbtree_##name##_t *b, const key_t * __restrict k) \
+	static inline key_t kb_delp_##name(kbtree_##name##_t *b, key_t * __restrict k) \
 	{																	\
 		kbnode_t *x;													\
 		key_t ret;														\
@@ -309,7 +309,7 @@
 		}																\
 		return ret;														\
 	}																	\
-	static inline key_t kb_del_##name(kbtree_##name##_t *b, const key_t k) \
+	static inline key_t kb_del_##name(kbtree_##name##_t *b, key_t k) \
 	{																	\
 		return kb_delp_##name(b, &k);									\
 	}
@@ -357,7 +357,7 @@
 			if (itr->p->x && itr->p->i >= 0) return 1; \
 		} \
 	} \
-	static int kb_itr_getp_##name(kbtree_##name##_t *b, const key_t * __restrict k, kbitr_##name##_t *itr) \
+	static inline int kb_itr_getp_##name(kbtree_##name##_t *b, key_t * __restrict k, kbitr_##name##_t *itr) \
 	{ \
 		if (b->n_keys == 0) return 0; \
 		int i, r = 0; \
@@ -373,13 +373,13 @@
 		} \
 		return 0; \
 	} \
-	static int kb_itr_get_##name(kbtree_##name##_t *b, const key_t k, kbitr_##name##_t *itr) \
+	static inline int kb_itr_get_##name(kbtree_##name##_t *b, key_t k, kbitr_##name##_t *itr) \
 	{																	\
 		return kb_itr_getp_##name(b,&k,itr); \
 	} \
 	static inline void kb_del_itr_##name(kbtree_##name##_t *b, kbitr_##name##_t *itr) \
 	{ \
-		const key_t k = kb_itr_key(itr); \
+		key_t k = kb_itr_key(itr); \
 		kb_delp_##name(b, &k); \
 		kb_itr_getp_##name(b, &k, itr); \
 	} 
@@ -387,15 +387,34 @@
 #define KBTREE_INIT(name, key_t, __cmp, T) \
   KBTREE_INIT_IMPL(name, key_t, kbnode_##name##_t, __cmp, T, (sizeof(kbnode_##name##_t)+(2*T)*sizeof(void *)))
 
+#if (!defined(__clang__) && !defined(__INTEL_COMPILER)) &&  (__GNUC__ > 4 )
+
+// The index trickery shouldn't be UB anymore,
+// still it is to much for gcc:s -Werror=array-bounds
+# define __KB_PRAGMA_START \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
+
+# define __KB_PRAGMA_END \
+    _Pragma("GCC diagnostic pop") \
+
+#else
+
+# define __KB_PRAGMA_START
+# define __KB_PRAGMA_END
+
+#endif
 
 #define KBTREE_INIT_IMPL(name, key_t, kbnode_t, __cmp, T, ILEN)			\
+	__KB_PRAGMA_START \
 	__KB_TREE_T(name, key_t, T)							\
 	__KB_GET_AUX1(name, key_t, kbnode_t, __cmp)			\
 	__KB_GET(name, key_t, kbnode_t)						\
 	__KB_INTERVAL(name, key_t, kbnode_t)					\
 	__KB_PUT(name, key_t, kbnode_t, __cmp, T, ILEN)				\
 	__KB_DEL(name, key_t, kbnode_t, T) \
-	__KB_ITR(name, key_t, kbnode_t)
+	__KB_ITR(name, key_t, kbnode_t) \
+	__KB_PRAGMA_END
 
 #define KB_DEFAULT_SIZE 512
 
@@ -424,47 +443,5 @@
 
 #define kb_generic_cmp(a, b) (((b) < (a)) - ((a) < (b)))
 #define kb_str_cmp(a, b) strcmp(a, b)
-
-/* The following is *DEPRECATED*!!! Use the iterator interface instead! */
-
-#if 0
-
-typedef struct {
-	kbnode_t *x;
-	int i;
-} __kbstack_t;
-
-#define __kb_traverse(key_t, b, __func) do {							\
-		int __kmax = 8;													\
-		__kbstack_t *__kstack, *__kp;									\
-		__kp = __kstack = (__kbstack_t*)calloc(__kmax, sizeof(__kbstack_t)); \
-		__kp->x = (b)->root; __kp->i = 0;								\
-		for (;;) {														\
-			while (__kp->x && __kp->i <= __kp->x->n) {					\
-				if (__kp - __kstack == __kmax - 1) {					\
-					__kmax <<= 1;										\
-					__kstack = (__kbstack_t*)realloc(__kstack, __kmax * sizeof(__kbstack_t)); \
-					__kp = __kstack + (__kmax>>1) - 1;					\
-				}														\
-				(__kp+1)->i = 0; (__kp+1)->x = __kp->x->is_internal? __KB_PTR(b, __kp->x)[__kp->i] : 0; \
-				++__kp;													\
-			}															\
-			--__kp;														\
-			if (__kp >= __kstack) {										\
-				if (__kp->x && __kp->i < __kp->x->n) __func(&__KB_KEY(key_t, __kp->x)[__kp->i]); \
-				++__kp->i;												\
-			} else break;												\
-		}																\
-		free(__kstack);													\
-	} while (0)
-
-#define __kb_get_first(key_t, b, ret) do {	\
-		kbnode_t *__x = (b)->root;			\
-		while (__KB_PTR(b, __x)[0] != 0)	\
-			__x = __KB_PTR(b, __x)[0];		\
-		(ret) = __KB_KEY(key_t, __x)[0];	\
-	} while (0)
-
-#endif
 
 #endif  // NVIM_LIB_KBTREE_H

--- a/src/nvim/lib/kbtree.h
+++ b/src/nvim/lib/kbtree.h
@@ -57,7 +57,9 @@ typedef struct {
 		int	off_key, off_ptr, ilen, elen;		\
 		int	n, t;								\
 		int	n_keys, n_nodes;					\
-	} kbtree_##name##_t;
+	} kbtree_##name##_t; \
+
+
 
 #define __KB_INIT(name, key_t)											\
 	static inline kbtree_##name##_t *kb_init_##name(unsigned int size)							\
@@ -75,7 +77,7 @@ typedef struct {
 		b->root = (kbnode_t*)calloc(1, (unsigned int)b->ilen);						\
 		++b->n_nodes;													\
 		return b;														\
-	}
+	} \
 
 #define __kb_destroy(b) do {											\
 		int i;                                                          \
@@ -346,7 +348,48 @@ typedef struct {
 			if (itr->p < itr->stack) return 0; \
 			if (itr->p->x && itr->p->i < itr->p->x->n) return 1; \
 		} \
-	}
+	} \
+	static inline int kb_itr_prev_##name(kbtree_##name##_t *b, kbitr_t *itr) \
+	{ \
+		if (itr->p < itr->stack) return 0; \
+		for (;;) { \
+			while (itr->p->x && itr->p->i >= 0) { \
+				itr->p[1].x = itr->p->x->is_internal? __KB_PTR(b, itr->p->x)[itr->p->i] : 0; \
+				itr->p[1].i = itr->p[1].x ? itr->p[1].x->n : -1; \
+				++itr->p; \
+			} \
+			--itr->p; \
+			if (itr->p < itr->stack) return 0; \
+			--itr->p->i; \
+			if (itr->p->x && itr->p->i >= 0) return 1; \
+		} \
+	} \
+	static int kb_itr_getp_##name(kbtree_##name##_t *b, const key_t * __restrict k, kbitr_t *itr) \
+	{ \
+		int i, r = 0; \
+		itr->p = itr->stack; \
+		itr->p->x = b->root; \
+		while (itr->p->x) { \
+			i = __kb_getp_aux_##name(itr->p->x, k, &r); \
+			itr->p->i = i; \
+			if (i >= 0 && r == 0) return 1; \
+			++itr->p->i; \
+			itr->p[1].x = itr->p->x->is_internal? __KB_PTR(b, itr->p->x)[i + 1] : 0; \
+			++itr->p; \
+		} \
+		return 0; \
+	} \
+	static int kb_itr_get_##name(kbtree_##name##_t *b, const key_t k, kbitr_t *itr) \
+	{																	\
+		return kb_itr_getp_##name(b,&k,itr); \
+	} \
+	static inline void kb_del_itr_##name(kbtree_##name##_t *b, kbitr_t *itr) \
+	{ \
+		key_t k = kb_itr_key(key_t, itr); \
+		kb_delp_##name(b, &k); \
+		kb_itr_getp_##name(b, &k, itr); \
+	} 
+
 
 #define KBTREE_INIT(name, key_t, __cmp)			\
 	__KB_TREE_T(name)							\
@@ -373,7 +416,11 @@ typedef struct {
 #define kb_intervalp(name, b, k, l, u) kb_intervalp_##name(b, k, l, u)
 
 #define kb_itr_first(name, b, i) kb_itr_first_##name(b, i)
+#define kb_itr_get(name, b, k, i) kb_itr_get_##name(b, k, i)
+#define kb_itr_getp(name, b, k, i) kb_itr_getp_##name(b, k, i)
 #define kb_itr_next(name, b, i) kb_itr_next_##name(b, i)
+#define kb_itr_prev(name, b, i) kb_itr_prev_##name(b, i)
+#define kb_del_itr(name, b, i) kb_del_itr_##name(b, i)
 #define kb_itr_key(type, itr) __KB_KEY(type, (itr)->p->x)[(itr)->p->i]
 #define kb_itr_valid(itr) ((itr)->p >= (itr)->stack)
 

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -149,4 +149,3 @@ MAP_IMPL(handle_T, ptr_t, DEFAULT_INITIALIZER)
 #define MSGPACK_HANDLER_INITIALIZER { .fn = NULL, .async = false }
 MAP_IMPL(String, MsgpackRpcRequestHandler, MSGPACK_HANDLER_INITIALIZER)
 #define KVEC_INITIALIZER { .size = 0, .capacity = 0, .items = NULL }
-MAP_IMPL(linenr_T, bufhl_vec_T, KVEC_INITIALIZER)

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -30,7 +30,6 @@ MAP_DECLS(ptr_t, ptr_t)
 MAP_DECLS(uint64_t, ptr_t)
 MAP_DECLS(handle_T, ptr_t)
 MAP_DECLS(String, MsgpackRpcRequestHandler)
-MAP_DECLS(linenr_T, bufhl_vec_T)
 
 #define map_new(T, U) map_##T##_##U##_new
 #define map_free(T, U) map_##T##_##U##_free

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -888,9 +888,13 @@ void ex_changes(exarg_T *eap)
  * Example: Insert two lines below 55: mark_adjust(56, MAXLNUM, 2, 0);
  *				   or: mark_adjust(56, 55, MAXLNUM, 2);
  */
-void mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_after)
+void mark_adjust(linenr_T line1,
+                 linenr_T line2,
+                 long amount,
+                 long amount_after,
+                 bool end_temp)
 {
-  mark_adjust_internal(line1, line2, amount, amount_after, true);
+  mark_adjust_internal(line1, line2, amount, amount_after, true, end_temp);
 }
 
 // mark_adjust_nofold() does the same as mark_adjust() but without adjusting
@@ -899,13 +903,14 @@ void mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_after)
 // calling foldMarkAdjust() with arguments line1, line2, amount, amount_after,
 // for an example of why this may be necessary, see do_move().
 void mark_adjust_nofold(linenr_T line1, linenr_T line2, long amount,
-                        long amount_after)
+                        long amount_after, bool end_temp)
 {
-  mark_adjust_internal(line1, line2, amount, amount_after, false);
+  mark_adjust_internal(line1, line2, amount, amount_after, false, end_temp);
 }
 
-static void mark_adjust_internal(linenr_T line1, linenr_T line2, long amount,
-                                 long amount_after, bool adjust_folds)
+static void mark_adjust_internal(linenr_T line1, linenr_T line2,
+                                 long amount, long amount_after,
+                                 bool adjust_folds, bool end_temp)
 {
   int i;
   int fnum = curbuf->b_fnum;
@@ -954,7 +959,7 @@ static void mark_adjust_internal(linenr_T line1, linenr_T line2, long amount,
     }
 
     sign_mark_adjust(line1, line2, amount, amount_after);
-    bufhl_mark_adjust(curbuf, line1, line2, amount, amount_after);
+    bufhl_mark_adjust(curbuf, line1, line2, amount, amount_after, end_temp);
   }
 
   /* previous context mark */

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -751,7 +751,7 @@ open_line (
     // Skip mark_adjust when adding a line after the last one, there can't
     // be marks there.
     if (curwin->w_cursor.lnum + 1 < curbuf->b_ml.ml_line_count) {
-      mark_adjust(curwin->w_cursor.lnum + 1, (linenr_T)MAXLNUM, 1L, 0L);
+      mark_adjust(curwin->w_cursor.lnum + 1, (linenr_T)MAXLNUM, 1L, 0L, false);
     }
     did_append = true;
   } else {
@@ -1866,7 +1866,7 @@ void appended_lines_mark(linenr_T lnum, long count)
   // Skip mark_adjust when adding a line after the last one, there can't
   // be marks there.
   if (lnum + count < curbuf->b_ml.ml_line_count) {
-    mark_adjust(lnum + 1, (linenr_T)MAXLNUM, count, 0L);
+    mark_adjust(lnum + 1, (linenr_T)MAXLNUM, count, 0L, false);
   }
   changed_lines(lnum + 1, 0, lnum + 1, count);
 }
@@ -1888,7 +1888,7 @@ void deleted_lines(linenr_T lnum, long count)
  */
 void deleted_lines_mark(linenr_T lnum, long count)
 {
-  mark_adjust(lnum, (linenr_T)(lnum + count - 1), (long)MAXLNUM, -count);
+  mark_adjust(lnum, (linenr_T)(lnum + count - 1), (long)MAXLNUM, -count, false);
   changed_lines(lnum, 0, lnum + count, -count);
 }
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3182,7 +3182,7 @@ error:
       if (curbuf->b_op_start.lnum + (y_type == kMTCharWise) - 1 + nr_lines
           < curbuf->b_ml.ml_line_count) {
         mark_adjust(curbuf->b_op_start.lnum + (y_type == kMTCharWise),
-                    (linenr_T)MAXLNUM, nr_lines, 0L);
+                    (linenr_T)MAXLNUM, nr_lines, 0L, false);
       }
 
       // note changed text for displaying and folding

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2210,7 +2210,7 @@ win_line (
   bool search_attr_from_match = false;  // if search_attr is from :match
   bool has_bufhl = false;               // this buffer has highlight matches
   int bufhl_attr = 0;                   // attributes desired by bufhl
-  bufhl_lineinfo_T bufhl_info;          // bufhl data for this line
+  BufhlLineInfo bufhl_info;             // bufhl data for this line
 
   /* draw_state: items that are drawn in sequence: */
 #define WL_START        0               /* nothing done yet */

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2232,11 +2232,13 @@ static void u_undoredo(int undo)
     /* adjust marks */
     if (oldsize != newsize) {
       mark_adjust(top + 1, top + oldsize, (long)MAXLNUM,
-          (long)newsize - (long)oldsize);
-      if (curbuf->b_op_start.lnum > top + oldsize)
+                  (long)newsize - (long)oldsize, false);
+      if (curbuf->b_op_start.lnum > top + oldsize) {
         curbuf->b_op_start.lnum += newsize - oldsize;
-      if (curbuf->b_op_end.lnum > top + oldsize)
+      }
+      if (curbuf->b_op_end.lnum > top + oldsize) {
         curbuf->b_op_end.lnum += newsize - oldsize;
+      }
     }
 
     changed_lines(top + 1, 0, bot, newsize - oldsize);


### PR DESCRIPTION
As discussed in #5031 this is a separate for PR to cleanup and integrate kbtree_t. Also use it for bufhl to get some coverage. Fixed compiler warnings (though the `const` warnings might have a better solution than remove `const` everywhere, I removed them for now as make output is impossible to parse otherwise), though remaining style issues. 

@timeyyy for extmark there is two things to note:

The "eliminate unneccesary heap allocation" commit does that. kbtree_t is a zero/calloc-initializable struct just like kvec_t. The changes for extmark is hopefully analogous to the bufhl changes in the same commit. (include the struct directly in buf_T, no explicit initialization needed, kbtree functions need an extra `&`) 

bufhl_mark_adjust shows a way to handle `:move` (only operation where marks can switch order, currently)
