### PR TITLE
[RFC] functions to notify a co-process when the current buffer is modified

### DIFF
--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -358,10 +358,10 @@ will be equivilent to the following |rpcnotify()| calls:
 
 	Indicates that live updates for the nominated buffer have been
 	disabled, either by calling the api function `live_updates(false)`, or
-	because the buffer was unloaded (see |live-update-disabling| and
-	|live-update-limitations| for more information).
+	because the buffer was unloaded (see |live-updates-disabling| and
+	|live-updates-limitations| for more information).
 
-							*live-update-examples*
+							*live-updates-examples*
 Example Events~
 
 If live updates are activated on the new empty buffer 4, the following

--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -243,4 +243,161 @@ Even for statically compiled clients it is good practice to avoid hardcoding
 the type codes, because a client may be built against one Nvim version but
 connect to another with different type codes.
 
+==============================================================================
+6. Live Updates				      *live-updates* *rpc-live-updates*
+
+A dedicated API has been created to allow co-processes to be notified in
+real-time when the user changes a buffer in any way. (It is difficult and
+innefficient to do this using |TextChanged| and other autocommands.)
+
+							*live-updates-enabling*
+Setting Up~
+
+Use |jobstart()| to start up your co-process. >
+
+	let g:myhelper = jobstart(['myhelper.py', string(bufnr(""))])
+
+Your co-process can use the msgpack API to request live updates for one or
+more buffers. >
+
+	myhelper.py:
+		import sys, neovim
+		nvim = neovim.attach('stdio')
+		bufnr = sys.argv[1]
+		nvim.buffers[bufnr].live_updates(True)
+
+After the `live_updates()` method is called, neovim will send a series of
+notifications containing the entire buffer's contents and any subsequent
+changes. The buffer's contents are sent via notifications because if you were
+to use the other API methods to retrieve the buffer contents, the buffer could
+be changed again before you call `live_updates(True)`. This can cause a delay
+if your plugin activates live updates for a very large buffer, but it is the
+the most efficient way to maintain a copy of the entire buffer's contents
+inside your plugin.
+
+						      *live-updates-disabling*
+Turning Off~
+
+You can use `live_updates(False)` to turn off notifications. One final
+notification will be sent to indicate that live updates are no longer active
+for the specified buffer. Alternatively, you can just close the channel.
+
+						    *live-updates-limitations*
+Limitations~
+
+Note that any of the following actions will also turn off live updates because
+the buffer contents are unloaded from memory:
+
+  - Closing all a buffer's windows (unless 'hidden' is enabled).
+  - Using |:edit| to reload the buffer
+  - reloading the buffer after it is changed from outside neovim.
+
+							  *live-updates-events*
+Handling Events~
+
+The co-process will start receiving the following notification events which
+will be equivilent to the following |rpcnotify()| calls:
+
+1. rpcnotify({channel}, "LiveUpdateStart",		      *LiveUpdateStart*
+             [{bufnr}, {linedata}, {more}])
+
+	Neovim will send at least one of these notifications to provide you
+	with the original buffer contents. If the buffer is very large, neovim
+	will send the contents through in multiple events to avoid loading the
+	entire buffer's contents into memory at once.
+
+	{bufnr} is the buffer number (see |bufnr()|) and will always be >= 1.
+
+	{linedata} is a list of strings containing the buffer's contents. If
+	this list contains 100 strings, then they represent lines 1-100 of the
+	buffer.  Newline characters are not included in the strings, so empty
+	lines will be given as empty strings. If you receive another
+	`"LiveUpdateStart"` notification with another {linedata} list, then
+	these lines represent the next N lines of the buffer. I.e., a second
+	notification with another list of 100 strings will represent lines
+	101-200 of the buffer.
+
+	{linedata} will always have at least 1 item, but the maximum length is
+	determined by neovim and not guaranteed to be any particular size.
+	Also the number of {linedata} items may vary between notifications, so
+	your plugin must be prepared to receive the line data in whatever size
+	lists neovim decides to split it into.
+
+	{more} is a boolean which tells you whether or not to expect more
+	`"LiveUpdateStart"` notifications. When {more} is false, you can
+	be certain that you now have the entire buffer's contents.
+
+2. rpcnotify({channel}, "LiveUpdate",				  *LiveUpdate*
+	     [{bufnr}, {firstline}, {numreplaced}, {linedata}])
+
+	Indicates that {numreplaced} lines starting at line {firstline} have
+	been replaced with the new line data contained in the {linedata} list.
+	All buffer changes (even adding single characters) will be transmitted
+	as whole-line changes.
+
+	{firstline} is the integer line number of the first line that was
+	replaced. Note that {firstline} is zero-indexed, so if line `1` was
+	replaced then {firstline} will be `0` instead of `1`. {firstline} is
+	guaranteed to always be less than or equal to the number of lines that
+	were in the buffer before the lines were replaced.
+
+	{numreplaced} is a positive integer indicating how many lines were
+	replaced. It will be `0` if new lines were added to the buffer but none
+	were replaced. If {numreplaced} is `0` then the new lines were added
+	before the zero-indexed line number in {firstline}.
+
+	{linedata} is a list of strings containing the contents of the new
+	buffer lines. Newline characters are not included in the strings, so
+	empty lines will be given as empty strings. If {numreplaced} is `1` or
+	more, then {linedata} may be an empty list (indicating that lines were
+	deleted from the buffer). But if {numreplaced} is `0` (indicating that
+	lines were added to the buffer) then {linedata} is guaranteed to
+	contain at least 1 item.
+
+3. rpcnotify({channel}, "LiveUpdateEnd", [{bufnr}])		*LiveUpdateEnd*
+
+	Indicates that live updates for the nominated buffer have been
+	disabled, either by calling the api function `live_updates(false)`, or
+	because the buffer was unloaded (see |live-update-disabling| and
+	|live-update-limitations| for more information).
+
+							*live-update-examples*
+Example Events~
+
+If live updates are activated on the new empty buffer 4, the following
+|LiveUpdateStart| event will be sent: >
+
+	rpcnotify({channel}, "LiveUpdateStart", [4, [""], v:false])
+
+If the user adds 2 new lines to the start of buffer 7, the following event
+would be generated: >
+
+	rpcnotify({channel}, "LiveUpdate", [7, 0, 0, ["line1", "line2"]])
+
+If the puts the cursor on a line containing the text `"Hello world"` and adds
+a `!` character to the end using insert mode, the following event would be
+generated: >
+
+	rpcnotify({channel}, "LiveUpdate",
+		  [{bufnr}, {linenr}, 1, ["Hello world!"]])
+
+If the user moves their cursor to line 3 of buffer 7 and deletes 20 lines
+using `20dd`, the following event will be generated: >
+
+	rpcnotify({channel}, "LiveUpdate", [7, 2, 20, []])
+
+If the user selects lines 3-5 of buffer 5 using |linewise-visual| mode and
+then presses `p` to paste in a new block of 6 lines, then the following event
+would be sent to the co-process: >
+
+	rpcnotify({channel}, "LiveUpdate",
+		  [5, 2, 3, ['pasted line 1', 'pasted line 2',
+			     'pasted line 3', 'pasted line 4',
+			     'pasted line 5', 'pasted line 6']])
+
+If the user uses :edit to reload buffer 4, then the following event would be
+generated: >
+
+	rpcnotify({channel}, "LiveUpdateEnd", [4])
+
 

--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -296,7 +296,7 @@ The co-process will start receiving the notification events which will be
 equivilent to the following |rpcnotify()| calls:
 
 1. rpcnotify({channel}, "LiveUpdateStart",		      *LiveUpdateStart*
-             [{buf}, {linedata}, {more}])
+             [{buf}, {changedtick}, {linedata}, {more}])
 
 	Neovim will send at least one of these notifications to provide you
 	with the original buffer contents. If the buffer is very large, neovim
@@ -304,6 +304,12 @@ equivilent to the following |rpcnotify()| calls:
 	entire buffer's contents into memory at once.
 
 	{buf} is an API handle for the buffer.
+
+	{changedtick} is the value of |b:changedtick| for the buffer. If you
+	send an API command back to neovim you can check the value of
+	|b:changedtick| as part of your request to ensure that no other
+	changes have been made. See |live-update-race-conditions| for more
+	information.
 
 	{linedata} is a list of strings containing the buffer's contents. If
 	this list contains 100 strings, then they represent lines 1-100 of the
@@ -325,7 +331,7 @@ equivilent to the following |rpcnotify()| calls:
 	be certain that you now have the entire buffer's contents.
 
 2. rpcnotify({channel}, "LiveUpdate",				  *LiveUpdate*
-	     [{buf}, {firstline}, {numreplaced}, {linedata}])
+	     [{buf}, {changedtick}, {firstline}, {numreplaced}, {linedata}])
 
 	Indicates that {numreplaced} lines starting at line {firstline} have
 	been replaced with the new line data contained in the {linedata} list.
@@ -333,6 +339,11 @@ equivilent to the following |rpcnotify()| calls:
 	as whole-line changes.
 
 	{buf} is an API handle for the buffer.
+
+	{changedtick} is the value of |b:changedtick| for the buffer. If you
+	send an API command back to neovim you can check the value of
+	|b:changedtick| as part of your request to ensure that no other
+	changes have been made.
 
 	{firstline} is the integer line number of the first line that was
 	replaced. Note that {firstline} is zero-indexed, so if line `1` was
@@ -354,7 +365,23 @@ equivilent to the following |rpcnotify()| calls:
 	lines were added to the buffer) then {linedata} is guaranteed to
 	contain at least 1 item.
 
-3. rpcnotify({channel}, "LiveUpdateEnd", [{buf}])		*LiveUpdateEnd*
+	Note: sometimes {changedtick} will be |v:null|, which means that the
+	buffer text *looks* like it has changed, but actually hasn't. In this
+	case the lines in {linedata} contain the modified text that is shown
+	to the user, but doesn't reflect the actual buffer contents. Currently
+	this behaviour is only used for the 'inccommand' option.
+
+3. rpcnotify({channel}, "LiveUpdateTick",		      *LiveUpdateTick*
+	     [{buf}, {changedtick}])
+
+	Indicates that |b:changedtick| was incremented for the buffer {buf},
+	but no text was changed. This is currently only used by undo/redo.
+
+	{buf} is an API handle for the buffer.
+
+	{changedtick} is the new value of |b:changedtick| for that buffer.
+
+4. rpcnotify({channel}, "LiveUpdateEnd", [{buf}])		*LiveUpdateEnd*
 
 	{buf} is an API handle for the buffer.
 

--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -247,40 +247,37 @@ connect to another with different type codes.
 6. Live Updates				      *live-updates* *rpc-live-updates*
 
 A dedicated API has been created to allow co-processes to be notified in
-real-time when the user changes a buffer in any way. (It is difficult and
-innefficient to do this using |TextChanged| and other autocommands.)
+real-time when the user changes a buffer in any way. It is difficult and
+error-prone to try and do this with autocommands such as |TextChanged|.
 
 							*live-updates-enabling*
 Setting Up~
 
-Use |jobstart()| to start up your co-process. >
+If your API client is a standalone co-process, it can use the
+`"nvim_buf_live_updates"`API method to activate Live Update events for a
+specific buffer. For example, in python >
 
-	let g:myhelper = jobstart(['myhelper.py', string(bufnr(""))])
+	import sys, neovim
+	nvim = neovim.attach('stdio')
+	bufnr = sys.argv[1]
+	nvim.buffers[bufnr].live_updates(True)
 
-Your co-process can use the msgpack API to request live updates for one or
-more buffers. >
-
-	myhelper.py:
-		import sys, neovim
-		nvim = neovim.attach('stdio')
-		bufnr = sys.argv[1]
-		nvim.buffers[bufnr].live_updates(True)
-
-After the `live_updates()` method is called, neovim will send a series of
-notifications containing the entire buffer's contents and any subsequent
-changes. The buffer's contents are sent via notifications because if you were
-to use the other API methods to retrieve the buffer contents, the buffer could
-be changed again before you call `live_updates(True)`. This can cause a delay
-if your plugin activates live updates for a very large buffer, but it is the
-the most efficient way to maintain a copy of the entire buffer's contents
-inside your plugin.
+After the `"nvim_buf_live_updates"` method is called, neovim will send a
+series of notifications containing the entire buffer's contents and any
+subsequent changes. The buffer's contents are sent via notifications because
+if you were to use the other API methods to retrieve the buffer contents, the
+buffer could be changed again before you turn on live updates. This can cause
+a delay if your plugin activates live updates for a very large buffer, but it
+is the the most efficient way to maintain a copy of the entire buffer's
+contents inside your plugin.
 
 						      *live-updates-disabling*
 Turning Off~
 
-You can use `live_updates(False)` to turn off notifications. One final
-notification will be sent to indicate that live updates are no longer active
-for the specified buffer. Alternatively, you can just close the channel.
+You can use `"nvim_buf_live_updates"` with an argument of `False` to turn off
+notifications. One final notification will be sent to indicate that live
+updates are no longer active for the specified buffer. Alternatively, you can
+just close the channel.
 
 						    *live-updates-limitations*
 Limitations~
@@ -295,18 +292,18 @@ the buffer contents are unloaded from memory:
 							  *live-updates-events*
 Handling Events~
 
-The co-process will start receiving the following notification events which
-will be equivilent to the following |rpcnotify()| calls:
+The co-process will start receiving the notification events which will be
+equivilent to the following |rpcnotify()| calls:
 
 1. rpcnotify({channel}, "LiveUpdateStart",		      *LiveUpdateStart*
-             [{bufnr}, {linedata}, {more}])
+             [{buf}, {linedata}, {more}])
 
 	Neovim will send at least one of these notifications to provide you
 	with the original buffer contents. If the buffer is very large, neovim
 	will send the contents through in multiple events to avoid loading the
 	entire buffer's contents into memory at once.
 
-	{bufnr} is the buffer number (see |bufnr()|) and will always be >= 1.
+	{buf} is an API handle for the buffer.
 
 	{linedata} is a list of strings containing the buffer's contents. If
 	this list contains 100 strings, then they represent lines 1-100 of the
@@ -328,12 +325,14 @@ will be equivilent to the following |rpcnotify()| calls:
 	be certain that you now have the entire buffer's contents.
 
 2. rpcnotify({channel}, "LiveUpdate",				  *LiveUpdate*
-	     [{bufnr}, {firstline}, {numreplaced}, {linedata}])
+	     [{buf}, {firstline}, {numreplaced}, {linedata}])
 
 	Indicates that {numreplaced} lines starting at line {firstline} have
 	been replaced with the new line data contained in the {linedata} list.
 	All buffer changes (even adding single characters) will be transmitted
 	as whole-line changes.
+
+	{buf} is an API handle for the buffer.
 
 	{firstline} is the integer line number of the first line that was
 	replaced. Note that {firstline} is zero-indexed, so if line `1` was
@@ -342,8 +341,9 @@ will be equivilent to the following |rpcnotify()| calls:
 	were in the buffer before the lines were replaced.
 
 	{numreplaced} is a positive integer indicating how many lines were
-	replaced. It will be `0` if new lines were added to the buffer but none
-	were replaced. If {numreplaced} is `0` then the new lines were added
+	replaced. It will be `0` if new lines were added to the buffer but
+	none were replaced. If {numreplaced} is `0` then the new lines were
+	added
 	before the zero-indexed line number in {firstline}.
 
 	{linedata} is a list of strings containing the contents of the new
@@ -354,50 +354,53 @@ will be equivilent to the following |rpcnotify()| calls:
 	lines were added to the buffer) then {linedata} is guaranteed to
 	contain at least 1 item.
 
-3. rpcnotify({channel}, "LiveUpdateEnd", [{bufnr}])		*LiveUpdateEnd*
+3. rpcnotify({channel}, "LiveUpdateEnd", [{buf}])		*LiveUpdateEnd*
+
+	{buf} is an API handle for the buffer.
 
 	Indicates that live updates for the nominated buffer have been
-	disabled, either by calling the api function `live_updates(false)`, or
-	because the buffer was unloaded (see |live-updates-disabling| and
-	|live-updates-limitations| for more information).
+	disabled, either by calling the api function `"nvim_buf_live_updates"`
+	with argument `false`, or because the buffer was unloaded (see
+	|live-updates-disabling| and |live-updates-limitations| for more
+	information).
 
 							*live-updates-examples*
 Example Events~
 
-If live updates are activated on the new empty buffer 4, the following
+If live updates are activated a new empty buffer, the following
 |LiveUpdateStart| event will be sent: >
 
-	rpcnotify({channel}, "LiveUpdateStart", [4, [""], v:false])
+	rpcnotify({channel}, "LiveUpdateStart", [{buf}, [""], v:false])
 
-If the user adds 2 new lines to the start of buffer 7, the following event
+If the user adds 2 new lines to the start of a buffer, the following event
 would be generated: >
 
-	rpcnotify({channel}, "LiveUpdate", [7, 0, 0, ["line1", "line2"]])
+	rpcnotify({channel}, "LiveUpdate", [{buf}, 0, 0, ["line1", "line2"]])
 
 If the puts the cursor on a line containing the text `"Hello world"` and adds
 a `!` character to the end using insert mode, the following event would be
 generated: >
 
 	rpcnotify({channel}, "LiveUpdate",
-		  [{bufnr}, {linenr}, 1, ["Hello world!"]])
+		  [{buf}, {linenr}, 1, ["Hello world!"]])
 
-If the user moves their cursor to line 3 of buffer 7 and deletes 20 lines
+If the user moves their cursor to line 3 of a buffer and deletes 20 lines
 using `20dd`, the following event will be generated: >
 
-	rpcnotify({channel}, "LiveUpdate", [7, 2, 20, []])
+	rpcnotify({channel}, "LiveUpdate", [{buf}, 2, 20, []])
 
-If the user selects lines 3-5 of buffer 5 using |linewise-visual| mode and
+If the user selects lines 3-5 of a buffer using |linewise-visual| mode and
 then presses `p` to paste in a new block of 6 lines, then the following event
 would be sent to the co-process: >
 
 	rpcnotify({channel}, "LiveUpdate",
-		  [5, 2, 3, ['pasted line 1', 'pasted line 2',
-			     'pasted line 3', 'pasted line 4',
-			     'pasted line 5', 'pasted line 6']])
+		  [{buf}, 2, 3, ['pasted line 1', 'pasted line 2',
+				 'pasted line 3', 'pasted line 4',
+				 'pasted line 5', 'pasted line 6']])
 
-If the user uses :edit to reload buffer 4, then the following event would be
+If the user uses :edit to reload a buffer then the following event would be
 generated: >
 
-	rpcnotify({channel}, "LiveUpdateEnd", [4])
+	rpcnotify({channel}, "LiveUpdateEnd", [{buf}])
 
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -137,6 +137,7 @@ set(CONV_SOURCES
   message.c
   regexp.c
   screen.c
+  liveupdate.c
   search.c
   spell.c
   spellfile.c

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -75,11 +75,14 @@ String buffer_get_line(Buffer buffer, Integer index, Error *err)
   return rv;
 }
 
-/// activate live updates from this buffer to the current channel
+/// Activate live updates from this buffer to the current channel.
+///
 ///
 /// @param buffer The buffer handle
 /// @param enabled True turns on live updates, False turns them off.
 /// @param[out] err Details of an error that may have occurred
+/// @return False when live updates couldn't be enabled because the buffer isn't
+///         loaded; otherwise True.
 Boolean nvim_buf_live_updates(uint64_t channel_id,
                               Buffer buffer,
                               Boolean enabled,
@@ -96,7 +99,7 @@ Boolean nvim_buf_live_updates(uint64_t channel_id,
   }
 
   liveupdate_unregister(buf, channel_id);
-  return false;
+  return true;
 }
 
 /// Sets a buffer line

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -24,6 +24,7 @@
 #include "nvim/syntax.h"
 #include "nvim/window.h"
 #include "nvim/undo.h"
+#include "nvim/liveupdate.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/buffer.c.generated.h"
@@ -72,6 +73,30 @@ String buffer_get_line(Buffer buffer, Integer index, Error *err)
   xfree(slice.items);
 
   return rv;
+}
+
+/// activate live updates from this buffer to the current channel
+///
+/// @param buffer The buffer handle
+/// @param enabled True turns on live updates, False turns them off.
+/// @param[out] err Details of an error that may have occurred
+Boolean nvim_buf_live_updates(uint64_t channel_id,
+                         Buffer buffer,
+                         Boolean enabled,
+                         Error *err)
+{
+  buf_T *buf = find_buffer_by_handle(buffer, err);
+
+  if (!buf) {
+    return false;
+  }
+
+  if (enabled) {
+    return liveupdate_register(buf, channel_id);
+  }
+
+  liveupdate_unregister(buf, channel_id);
+  return false;
 }
 
 /// Sets a buffer line

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -81,9 +81,9 @@ String buffer_get_line(Buffer buffer, Integer index, Error *err)
 /// @param enabled True turns on live updates, False turns them off.
 /// @param[out] err Details of an error that may have occurred
 Boolean nvim_buf_live_updates(uint64_t channel_id,
-                         Buffer buffer,
-                         Boolean enabled,
-                         Error *err)
+                              Buffer buffer,
+                              Boolean enabled,
+                              Error *err)
 {
   buf_T *buf = find_buffer_by_handle(buffer, err);
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -87,6 +87,7 @@ Boolean nvim_buf_live_updates(uint64_t channel_id,
                               Buffer buffer,
                               Boolean enabled,
                               Error *err)
+  FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY
 {
   buf_T *buf = find_buffer_by_handle(buffer, err);
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -430,7 +430,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
     mark_adjust((linenr_T)start, (linenr_T)(end - 1), MAXLNUM, extra, false);
   }
 
-  changed_lines((linenr_T)start, 0, (linenr_T)end, (long)extra);
+  changed_lines((linenr_T)start, 0, (linenr_T)end, (long)extra, true);
 
   if (save_curbuf.br_buf == NULL) {
     fix_cursor((linenr_T)start, (linenr_T)end, (linenr_T)extra);

--- a/src/nvim/api/dispatch_deprecated.lua
+++ b/src/nvim/api/dispatch_deprecated.lua
@@ -7,6 +7,7 @@ local deprecated_aliases = {
   nvim_buf_get_number="buffer_get_number",
   nvim_buf_get_option="buffer_get_option",
   nvim_buf_get_var="buffer_get_var",
+  nvim_buf_live_updates="buffer_live_updates",
   nvim_buf_is_valid="buffer_is_valid",
   nvim_buf_line_count="buffer_line_count",
   nvim_buf_set_lines="buffer_set_lines",

--- a/src/nvim/api/dispatch_deprecated.lua
+++ b/src/nvim/api/dispatch_deprecated.lua
@@ -7,7 +7,6 @@ local deprecated_aliases = {
   nvim_buf_get_number="buffer_get_number",
   nvim_buf_get_option="buffer_get_option",
   nvim_buf_get_var="buffer_get_var",
-  nvim_buf_live_updates="buffer_live_updates",
   nvim_buf_is_valid="buffer_is_valid",
   nvim_buf_line_count="buffer_line_count",
   nvim_buf_set_lines="buffer_set_lines",

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -73,6 +73,7 @@
 #include "nvim/os/os.h"
 #include "nvim/os/time.h"
 #include "nvim/os/input.h"
+#include "nvim/liveupdate.h"
 
 typedef enum {
   kBLSUnchanged = 0,
@@ -574,6 +575,9 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
   /* Change directories when the 'acd' option is set. */
   do_autochdir();
 
+  // disable live updates for the current buffer
+  liveupdate_unregister_all(buf);
+
   /*
    * Remove the buffer from the list.
    */
@@ -784,6 +788,8 @@ free_buffer_stuff (
   map_clear_int(buf, MAP_ALL_MODES, true, true);     // clear local abbrevs
   xfree(buf->b_start_fenc);
   buf->b_start_fenc = NULL;
+
+  liveupdate_unregister_all(buf);
 }
 
 /*

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1732,6 +1732,7 @@ buf_T * buflist_new(char_u *ffname, char_u *sfname, linenr_T lnum, int flags)
   clrallmarks(buf);                     /* clear marks */
   fmarks_check_names(buf);              /* check file marks for this file */
   buf->b_p_bl = (flags & BLN_LISTED) ? TRUE : FALSE;    /* init 'buflisted' */
+  buf->liveupdate_channels = NULL;
   if (!(flags & BLN_DUMMY)) {
     // Tricky: these autocommands may change the buffer list.  They could also
     // split the window with re-using the one empty buffer. This may result in

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1738,7 +1738,8 @@ buf_T * buflist_new(char_u *ffname, char_u *sfname, linenr_T lnum, int flags)
   clrallmarks(buf);                     /* clear marks */
   fmarks_check_names(buf);              /* check file marks for this file */
   buf->b_p_bl = (flags & BLN_LISTED) ? TRUE : FALSE;    /* init 'buflisted' */
-  buf->liveupdate_channels = NULL;
+  kv_destroy(buf->liveupdate_channels);
+  kv_init(buf->liveupdate_channels);
   if (!(flags & BLN_DUMMY)) {
     // Tricky: these autocommands may change the buffer list.  They could also
     // split the window with re-using the one empty buffer. This may result in

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -38,6 +38,8 @@ typedef struct {
 #include "nvim/api/private/defs.h"
 // for Map(K, V)
 #include "nvim/map.h"
+// for kvec
+#include "nvim/lib/kvec.h"
 
 #define MODIFIABLE(buf) (buf->b_p_ma)
 
@@ -765,9 +767,8 @@ struct file_buffer {
   kvec_t(BufhlLine *) b_bufhl_move_space;  // temporary space for highlights
 
   // array of channelids which have asked to receive live updates for this
-  // buffer. The last item in the array will always be LIVEUPDATE_NONE.
-  uint64_t *liveupdate_channels;
-#define LIVEUPDATE_NONE 0
+  // buffer.
+  kvec_t(uint64_t) liveupdate_channels;
 };
 
 /*

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -763,6 +763,11 @@ struct file_buffer {
   BufhlInfo b_bufhl_info;       // buffer stored highlights
 
   kvec_t(BufhlLine *) b_bufhl_move_space;  // temporary space for highlights
+
+  // array of channelids which have asked to receive live updates for this
+  // buffer. The last item in the array will always be LIVEUPDATE_NONE.
+  uint64_t *liveupdate_channels;
+#define LIVEUPDATE_NONE 0
 };
 
 /*

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -2338,7 +2338,7 @@ void ex_diffgetput(exarg_T *eap)
           }
         }
       }
-      changed_lines(lnum, 0, lnum + count, (long)added);
+      changed_lines(lnum, 0, lnum + count, (long)added, true);
 
       if (dfree != NULL) {
         // Diff is deleted, update folds in other windows.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3161,7 +3161,8 @@ static char_u *sub_parse_flags(char_u *cmd, subflags_T *subflags,
 /// The usual escapes are supported as described in the regexp docs.
 ///
 /// @return buffer used for 'inccommand' preview
-static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool send_liveupdate_changedtick)
+static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
+                     bool send_liveupdate_changedtick)
 {
   long i = 0;
   regmmatch_T regmatch;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -35,6 +35,7 @@
 #include "nvim/fold.h"
 #include "nvim/getchar.h"
 #include "nvim/indent.h"
+#include "nvim/liveupdate.h"
 #include "nvim/main.h"
 #include "nvim/mark.h"
 #include "nvim/mbyte.h"
@@ -2421,6 +2422,7 @@ int do_ecmd(
         goto theend;
       }
       u_unchanged(curbuf);
+      liveupdate_unregister_all(curbuf);
       buf_freeall(curbuf, BFA_KEEP_UNDO);
 
       // Tell readfile() not to clear or reload undo info.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -276,7 +276,7 @@ void ex_align(exarg_T *eap)
       new_indent = 0;
     (void)set_indent(new_indent, 0);                    /* set indent */
   }
-  changed_lines(eap->line1, 0, eap->line2 + 1, 0L);
+  changed_lines(eap->line1, 0, eap->line2 + 1, 0L, true);
   curwin->w_cursor = save_curpos;
   beginline(BL_WHITE | BL_FIX);
 }
@@ -609,7 +609,7 @@ void ex_sort(exarg_T *eap)
   } else if (deleted < 0) {
     mark_adjust(eap->line2, MAXLNUM, -deleted, 0L, false);
   }
-  changed_lines(eap->line1, 0, eap->line2 + 1, -deleted);
+  changed_lines(eap->line1, 0, eap->line2 + 1, -deleted, true);
 
   curwin->w_cursor.lnum = eap->line1;
   beginline(BL_WHITE | BL_FIX);
@@ -742,7 +742,7 @@ void ex_retab(exarg_T *eap)
   if (curbuf->b_p_ts != new_ts)
     redraw_curbuf_later(NOT_VALID);
   if (first_line != 0)
-    changed_lines(first_line, 0, last_line + 1, 0L);
+    changed_lines(first_line, 0, last_line + 1, 0L, true);
 
   curwin->w_p_list = save_list;         /* restore 'list' */
 
@@ -803,6 +803,7 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
    */
   last_line = curbuf->b_ml.ml_line_count;
   mark_adjust_nofold(line1, line2, last_line - line2, 0L, true);
+  changed_lines(last_line - num_lines + 1, 0, last_line + 1, num_lines, false);
   if (dest >= line2) {
     mark_adjust_nofold(line2 + 1, dest, -num_lines, 0L, false);
     FOR_ALL_TAB_WINDOWS(tab, win) {
@@ -825,6 +826,7 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
   curbuf->b_op_start.col = curbuf->b_op_end.col = 0;
   mark_adjust_nofold(last_line - num_lines + 1, last_line,
                      -(last_line - dest - extra), 0L, true);
+  changed_lines(last_line - num_lines + 1, 0, last_line + 1, -extra, false);
 
   /*
    * Now we delete the original text -- webb
@@ -855,9 +857,9 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
     last_line = curbuf->b_ml.ml_line_count;
     if (dest > last_line + 1)
       dest = last_line + 1;
-    changed_lines(line1, 0, dest, 0L);
+    changed_lines(line1, 0, dest, 0L, false);
   } else {
-    changed_lines(dest + 1, 0, line1 + num_lines, 0L);
+    changed_lines(dest + 1, 0, line1 + num_lines, 0L, false);
   }
 
   return OK;
@@ -3992,7 +3994,7 @@ skip:
      * the line number before the change (same as adding the number of
      * deleted lines). */
     i = curbuf->b_ml.ml_line_count - old_line_count;
-    changed_lines(first_line, 0, last_line - i, i);
+    changed_lines(first_line, 0, last_line - i, i, false);
   }
 
   xfree(sub_firstline);   /* may have to free allocated copy of the line */

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -20,6 +20,7 @@
 #include "nvim/ex_docmd.h"
 #include "nvim/func_attr.h"
 #include "nvim/indent.h"
+#include "nvim/liveupdate.h"
 #include "nvim/mark.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
@@ -742,8 +743,19 @@ deleteFold (
     /* Deleting markers may make cursor column invalid. */
     check_cursor_col();
 
-  if (last_lnum > 0)
-    changed_lines(first_lnum, (colnr_T)0, last_lnum, 0L);
+  if (last_lnum > 0) {
+    changed_lines(first_lnum, (colnr_T)0, last_lnum, 0L, false);
+
+    // send one LiveUpdate at the end
+    if (kv_size(curbuf->liveupdate_channels)) {
+      // last_lnum is the line *after* the last line of the outermost fold
+      // that was modified. Note also that deleting a fold might only require
+      // the modification of the *first* line of the fold, but we send through a
+      // notification that includes every line that was part of the fold
+      int64_t num_changed = last_lnum - first_lnum;
+      liveupdate_send_changes(curbuf, first_lnum, num_changed, num_changed);
+    }
+  }
 }
 
 /* clearFolding() {{{2 */
@@ -1590,7 +1602,15 @@ static void foldCreateMarkers(linenr_T start, linenr_T end)
 
   /* Update both changes here, to avoid all folds after the start are
    * changed when the start marker is inserted and the end isn't. */
-  changed_lines(start, (colnr_T)0, end, 0L);
+  changed_lines(start, (colnr_T)0, end, 0L, false);
+
+  if (kv_size(curbuf->liveupdate_channels)) {
+    // Note: foldAddMarker() may not actually change start and/or end if
+    // u_save() is unable to save the buffer line, but we send the LiveUpdate
+    // anyway since it won't do any harm.
+    int64_t num_changed = 1 + end - start;
+    liveupdate_send_changes(curbuf, start, num_changed, num_changed);
+  }
 }
 
 /* foldAddMarker() {{{2 */

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -753,7 +753,8 @@ deleteFold (
       // the modification of the *first* line of the fold, but we send through a
       // notification that includes every line that was part of the fold
       int64_t num_changed = last_lnum - first_lnum;
-      liveupdate_send_changes(curbuf, first_lnum, num_changed, num_changed);
+      liveupdate_send_changes(curbuf, first_lnum, num_changed,
+                              num_changed, true);
     }
   }
 }
@@ -1609,7 +1610,7 @@ static void foldCreateMarkers(linenr_T start, linenr_T end)
     // u_save() is unable to save the buffer line, but we send the LiveUpdate
     // anyway since it won't do any harm.
     int64_t num_changed = 1 + end - start;
-    liveupdate_send_changes(curbuf, start, num_changed, num_changed);
+    liveupdate_send_changes(curbuf, start, num_changed, num_changed, true);
   }
 }
 

--- a/src/nvim/liveupdate.c
+++ b/src/nvim/liveupdate.c
@@ -47,8 +47,8 @@ bool liveupdate_register(buf_T *buf, uint64_t channel_id) {
   args.size = 3;
   args.items = xcalloc(sizeof(Object), args.size);
 
-  // the first argument is always the buffer number
-  args.items[0] = INTEGER_OBJ(buf->handle);
+  // the first argument is always the buffer handle
+  args.items[0] = BUFFER_OBJ(buf->handle);
   args.items[1] = ARRAY_OBJ(linedata);
   args.items[2] = BOOLEAN_OBJ(false);
 
@@ -60,7 +60,7 @@ void liveupdate_send_end(buf_T *buf, uint64_t channelid) {
     Array args = ARRAY_DICT_INIT;
     args.size = 1;
     args.items = xcalloc(sizeof(Object), args.size);
-    args.items[0] = INTEGER_OBJ(buf->handle);
+    args.items[0] = BUFFER_OBJ(buf->handle);
     channel_send_event(channelid, "LiveUpdateEnd", args);
 }
 
@@ -122,8 +122,8 @@ void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
       args.size = 4;
       args.items = xcalloc(sizeof(Object), args.size);
 
-      // the first argument is always the buffer number
-      args.items[0] = INTEGER_OBJ(buf->handle);
+      // the first argument is always the buffer handle
+      args.items[0] = BUFFER_OBJ(buf->handle);
 
       // the first line that changed (zero-indexed)
       args.items[1] = INTEGER_OBJ(firstline - 1);

--- a/src/nvim/liveupdate.c
+++ b/src/nvim/liveupdate.c
@@ -3,11 +3,9 @@
 #include "nvim/api/private/helpers.h"
 #include "nvim/msgpack_rpc/channel.h"
 
-/*
- * Register a channel. Return True if the channel was added, or already added.
- * Return False if the channel couldn't be added because the buffer is
- * unloaded.
- */
+// Register a channel. Return True if the channel was added, or already added.
+// Return False if the channel couldn't be added because the buffer is
+// unloaded.
 bool liveupdate_register(buf_T *buf, uint64_t channel_id) {
   // must fail if the buffer isn't loaded
   if (buf->b_ml.ml_mfp == NULL) {
@@ -50,7 +48,7 @@ bool liveupdate_register(buf_T *buf, uint64_t channel_id) {
   for (size_t i = 0; i < line_count; i++) {
     linenr_T lnum = 1 + (linenr_T)i;
 
-    const char *bufstr = (char *) ml_get_buf(buf, lnum, false);
+    const char *bufstr = (char *)ml_get_buf(buf, lnum, false);
     Object str = STRING_OBJ(cstr_to_string(bufstr));
 
     // Vim represents NULs as NLs, but this may confuse clients.
@@ -98,7 +96,7 @@ void liveupdate_unregister(buf_T *buf, uint64_t channelid) {
   if (found_active) {
     // make a new copy of the active array without the channelid in it
     uint64_t *newlist = xmalloc((1 + active_size - found_active)
-        * sizeof channelid);
+                                * sizeof channelid);
     int i = 0;
     int j = 0;
     for (; i < active_size; i++) {
@@ -125,7 +123,8 @@ void liveupdate_unregister_all(buf_T *buf) {
   }
 }
 
-void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added, int64_t num_removed) {
+void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
+                             int64_t num_removed) {
   // if one the channels doesn't work, put its ID here so we can remove it later
   uint64_t badchannelid = LIVEUPDATE_NONE;
 
@@ -155,7 +154,7 @@ void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added, 
           linedata.items = xcalloc(sizeof(Object), num_added);
           for (int64_t i = 0; i < num_added; i++) {
             int64_t lnum = firstline + i;
-            const char *bufstr = (char *) ml_get_buf(buf, (linenr_T)lnum, false);
+            const char *bufstr = (char *)ml_get_buf(buf, (linenr_T)lnum, false);
             Object str = STRING_OBJ(cstr_to_string(bufstr));
 
             // Vim represents NULs as NLs, but this may confuse clients.

--- a/src/nvim/liveupdate.c
+++ b/src/nvim/liveupdate.c
@@ -108,7 +108,7 @@ void liveupdate_unregister_all(buf_T *buf) {
 }
 
 void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
-                             int64_t num_removed) {
+                             int64_t num_removed, bool send_tick) {
   // if one the channels doesn't work, put its ID here so we can remove it later
   uint64_t badchannelid = 0;
 
@@ -125,7 +125,7 @@ void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
     args.items[0] = BUFFER_OBJ(buf->handle);
 
     // next argument is b:changedtick
-    args.items[1] = INTEGER_OBJ(buf->b_changedtick);
+    args.items[1] = send_tick ? INTEGER_OBJ(buf->b_changedtick) : NIL;
 
     // the first line that changed (zero-indexed)
     args.items[2] = INTEGER_OBJ(firstline - 1);

--- a/src/nvim/liveupdate.c
+++ b/src/nvim/liveupdate.c
@@ -6,7 +6,8 @@
 // Register a channel. Return True if the channel was added, or already added.
 // Return False if the channel couldn't be added because the buffer is
 // unloaded.
-bool liveupdate_register(buf_T *buf, uint64_t channel_id) {
+bool liveupdate_register(buf_T *buf, uint64_t channel_id)
+{
   // must fail if the buffer isn't loaded
   if (buf->b_ml.ml_mfp == NULL) {
     return false;
@@ -57,7 +58,8 @@ bool liveupdate_register(buf_T *buf, uint64_t channel_id) {
   return true;
 }
 
-void liveupdate_send_end(buf_T *buf, uint64_t channelid) {
+void liveupdate_send_end(buf_T *buf, uint64_t channelid)
+{
     Array args = ARRAY_DICT_INIT;
     args.size = 1;
     args.items = xcalloc(sizeof(Object), args.size);
@@ -65,7 +67,8 @@ void liveupdate_send_end(buf_T *buf, uint64_t channelid) {
     channel_send_event(channelid, "LiveUpdateEnd", args);
 }
 
-void liveupdate_unregister(buf_T *buf, uint64_t channelid) {
+void liveupdate_unregister(buf_T *buf, uint64_t channelid)
+{
   size_t size = kv_size(buf->liveupdate_channels);
   if (!size) {
     return;
@@ -96,7 +99,8 @@ void liveupdate_unregister(buf_T *buf, uint64_t channelid) {
   }
 }
 
-void liveupdate_unregister_all(buf_T *buf) {
+void liveupdate_unregister_all(buf_T *buf)
+{
   size_t size = kv_size(buf->liveupdate_channels);
   if (size) {
     for (size_t i = 0; i < size; i++) {
@@ -108,7 +112,8 @@ void liveupdate_unregister_all(buf_T *buf) {
 }
 
 void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
-                             int64_t num_removed, bool send_tick) {
+                             int64_t num_removed, bool send_tick)
+{
   // if one the channels doesn't work, put its ID here so we can remove it later
   uint64_t badchannelid = 0;
 
@@ -167,7 +172,8 @@ void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
   }
 }
 
-void liveupdate_send_tick(buf_T *buf) {
+void liveupdate_send_tick(buf_T *buf)
+{
   // notify each of the active channels
   for (size_t i = 0; i < kv_size(buf->liveupdate_channels); i++) {
     uint64_t channelid = kv_A(buf->liveupdate_channels, i);

--- a/src/nvim/liveupdate.c
+++ b/src/nvim/liveupdate.c
@@ -1,0 +1,73 @@
+#include "nvim/liveupdate.h"
+#include "nvim/memline.h"
+#include "nvim/api/private/helpers.h"
+#include "nvim/msgpack_rpc/channel.h"
+
+/*
+ * Register a channel. Return True if the channel was added, or already added.
+ * Return False if the channel couldn't be added because the buffer is
+ * unloaded.
+ */
+bool liveupdate_register(buf_T *buf, uint64_t channel_id) {
+  // must fail if the buffer isn't loaded
+  if (buf->b_ml.ml_mfp == NULL) {
+    return false;
+  }
+
+  // count how many channels are currently watching the buffer
+  int active_size = 0;
+  if (buf->liveupdate_channels != NULL) {
+    while (buf->liveupdate_channels[active_size] != LIVEUPDATE_NONE) {
+      if (buf->liveupdate_channels[active_size] == channel_id) {
+        // buffer is already registered ... nothing to do
+        return true;
+      }
+      active_size++;
+    }
+  }
+
+  // add the buffer to the active array and send the full buffer contents now
+  uint64_t *newlist = xmalloc((active_size + 2) * sizeof channel_id);
+  // copy items to the new array
+  for (int i = 0; i < active_size; i++) {
+    newlist[i] = buf->liveupdate_channels[i];
+  }
+  // put the new channel on the end
+  newlist[active_size] = channel_id;
+  // terminator
+  newlist[active_size + 1] = LIVEUPDATE_NONE;
+  // free the old list and put the new one in place
+  if (active_size) {
+    xfree(buf->liveupdate_channels);
+  }
+  buf->liveupdate_channels = newlist;
+
+  // send through the full channel contents now
+  Array linedata = ARRAY_DICT_INIT;
+  size_t line_count = buf->b_ml.ml_line_count;
+  linedata.size = line_count;
+  linedata.items = xcalloc(sizeof(Object), line_count);
+  for (size_t i = 0; i < line_count; i++) {
+    linenr_T lnum = 1 + (linenr_T)i;
+
+    const char *bufstr = (char *) ml_get_buf(buf, lnum, false);
+    Object str = STRING_OBJ(cstr_to_string(bufstr));
+
+    // Vim represents NULs as NLs, but this may confuse clients.
+    strchrsub(str.data.string.data, '\n', '\0');
+
+    linedata.items[i] = str;
+  }
+
+  Array args = ARRAY_DICT_INIT;
+  args.size = 3;
+  args.items = xcalloc(sizeof(Object), args.size);
+
+  // the first argument is always the buffer number
+  args.items[0] = INTEGER_OBJ(buf->handle);
+  args.items[1] = ARRAY_OBJ(linedata);
+  args.items[2] = BOOLEAN_OBJ(false);
+
+  channel_send_event(channel_id, "LiveUpdateStart", args);
+  return true;
+}

--- a/src/nvim/liveupdate.h
+++ b/src/nvim/liveupdate.h
@@ -7,7 +7,7 @@ bool liveupdate_register(buf_T *buf, uint64_t channel_id);
 void liveupdate_unregister(buf_T *buf, uint64_t channel_id);
 void liveupdate_unregister_all(buf_T *buf);
 void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
-                             int64_t num_removed);
+                             int64_t num_removed, bool send_tick);
 void liveupdate_send_tick(buf_T *buf);
 
 #endif  // NVIM_LIVEUPDATE_H

--- a/src/nvim/liveupdate.h
+++ b/src/nvim/liveupdate.h
@@ -1,0 +1,3 @@
+#include "nvim/buffer_defs.h"
+
+bool liveupdate_register(buf_T *buf, uint64_t channel_id);

--- a/src/nvim/liveupdate.h
+++ b/src/nvim/liveupdate.h
@@ -8,5 +8,6 @@ void liveupdate_unregister(buf_T *buf, uint64_t channel_id);
 void liveupdate_unregister_all(buf_T *buf);
 void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
                              int64_t num_removed);
+void liveupdate_send_tick(buf_T *buf);
 
 #endif  // NVIM_LIVEUPDATE_H

--- a/src/nvim/liveupdate.h
+++ b/src/nvim/liveupdate.h
@@ -1,3 +1,5 @@
 #include "nvim/buffer_defs.h"
 
 bool liveupdate_register(buf_T *buf, uint64_t channel_id);
+void liveupdate_unregister(buf_T *buf, uint64_t channel_id);
+void liveupdate_unregister_all(buf_T *buf);

--- a/src/nvim/liveupdate.h
+++ b/src/nvim/liveupdate.h
@@ -3,3 +3,4 @@
 bool liveupdate_register(buf_T *buf, uint64_t channel_id);
 void liveupdate_unregister(buf_T *buf, uint64_t channel_id);
 void liveupdate_unregister_all(buf_T *buf);
+void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added, int64_t num_removed);

--- a/src/nvim/liveupdate.h
+++ b/src/nvim/liveupdate.h
@@ -1,6 +1,12 @@
+#ifndef NVIM_LIVEUPDATE_H
+#define NVIM_LIVEUPDATE_H
+
 #include "nvim/buffer_defs.h"
 
 bool liveupdate_register(buf_T *buf, uint64_t channel_id);
 void liveupdate_unregister(buf_T *buf, uint64_t channel_id);
 void liveupdate_unregister_all(buf_T *buf);
-void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added, int64_t num_removed);
+void liveupdate_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
+                             int64_t num_removed);
+
+#endif  // NVIM_LIVEUPDATE_H

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -835,7 +835,7 @@ open_line (
       saved_line = NULL;
       if (did_append) {
         changed_lines(curwin->w_cursor.lnum, curwin->w_cursor.col,
-            curwin->w_cursor.lnum + 1, 1L, true);
+                      curwin->w_cursor.lnum + 1, 1L, true);
         did_append = FALSE;
 
         /* Move marks after the line break to the new line. */

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1817,7 +1817,7 @@ void changed_bytes(linenr_T lnum, colnr_T col)
   changedOneline(curbuf, lnum);
   changed_common(lnum, col, lnum + 1, 0L);
   // notify any channels that are watching
-  if (curbuf->liveupdate_channels != NULL) {
+  if (kv_size(curbuf->liveupdate_channels)) {
     liveupdate_send_changes(curbuf, lnum, 1, 1);
   }
 
@@ -1939,7 +1939,7 @@ changed_lines (
 
   changed_common(lnum, col, lnume, xtra);
 
-  if (curbuf->liveupdate_channels != NULL) {
+  if (kv_size(curbuf->liveupdate_channels)) {
     int64_t num_added = (int64_t)(lnume + xtra - lnum);
     int64_t num_removed = lnume - lnum;
     liveupdate_send_changes(curbuf, lnum, num_added, num_removed);

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1819,7 +1819,7 @@ void changed_bytes(linenr_T lnum, colnr_T col)
   changed_common(lnum, col, lnum + 1, 0L);
   // notify any channels that are watching
   if (kv_size(curbuf->liveupdate_channels)) {
-    liveupdate_send_changes(curbuf, lnum, 1, 1);
+    liveupdate_send_changes(curbuf, lnum, 1, 1, true);
   }
 
   /* Diff highlighting in other diff windows may need to be updated too. */
@@ -1947,7 +1947,7 @@ changed_lines (
   if (send_liveupdate && kv_size(curbuf->liveupdate_channels)) {
     int64_t num_added = (int64_t)(lnume + xtra - lnum);
     int64_t num_removed = lnume - lnum;
-    liveupdate_send_changes(curbuf, lnum, num_added, num_removed);
+    liveupdate_send_changes(curbuf, lnum, num_added, num_removed, true);
   }
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6133,7 +6133,7 @@ static void n_swapchar(cmdarg_T *cap)
   curwin->w_set_curswant = true;
   if (did_change) {
     changed_lines(startpos.lnum, startpos.col, curwin->w_cursor.lnum + 1,
-        0L, true);
+                  0L, true);
     curbuf->b_op_start = startpos;
     curbuf->b_op_end = curwin->w_cursor;
     if (curbuf->b_op_end.col > 0)

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6133,7 +6133,7 @@ static void n_swapchar(cmdarg_T *cap)
   curwin->w_set_curswant = true;
   if (did_change) {
     changed_lines(startpos.lnum, startpos.col, curwin->w_cursor.lnum + 1,
-        0L);
+        0L, true);
     curbuf->b_op_start = startpos;
     curbuf->b_op_end = curwin->w_cursor;
     if (curbuf->b_op_end.col > 0)

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -214,7 +214,7 @@ void op_shift(oparg_T *oap, int curs_top, int amount)
     ++curwin->w_cursor.lnum;
   }
 
-  changed_lines(oap->start.lnum, 0, oap->end.lnum + 1, 0L);
+  changed_lines(oap->start.lnum, 0, oap->end.lnum + 1, 0L, true);
 
   if (oap->motion_type == kMTBlockWise) {
     curwin->w_cursor.lnum = oap->start.lnum;
@@ -570,7 +570,7 @@ static void block_insert(oparg_T *oap, char_u *s, int b_insert, struct block_def
     }
   }   /* for all lnum */
 
-  changed_lines(oap->start.lnum + 1, 0, oap->end.lnum + 1, 0L);
+  changed_lines(oap->start.lnum + 1, 0, oap->end.lnum + 1, 0L, true);
 
   State = oldstate;
 }
@@ -635,7 +635,7 @@ void op_reindent(oparg_T *oap, Indenter how)
   if (last_changed != 0)
     changed_lines(first_changed, 0,
         oap->is_VIsual ? start_lnum + oap->line_count :
-        last_changed + 1, 0L);
+        last_changed + 1, 0L, true);
   else if (oap->is_VIsual)
     redraw_curbuf_later(INVERTED);
 
@@ -1455,7 +1455,7 @@ int op_delete(oparg_T *oap)
 
     check_cursor_col();
     changed_lines(curwin->w_cursor.lnum, curwin->w_cursor.col,
-                  oap->end.lnum + 1, 0L);
+                  oap->end.lnum + 1, 0L, true);
     oap->line_count = 0;  // no lines deleted
   } else if (oap->motion_type == kMTLineWise) {
     if (oap->op_type == OP_CHANGE) {
@@ -1817,7 +1817,7 @@ int op_replace(oparg_T *oap, int c)
 
   curwin->w_cursor = oap->start;
   check_cursor();
-  changed_lines(oap->start.lnum, oap->start.col, oap->end.lnum + 1, 0L);
+  changed_lines(oap->start.lnum, oap->start.col, oap->end.lnum + 1, 0L, true);
 
   /* Set "'[" and "']" marks. */
   curbuf->b_op_start = oap->start;
@@ -1852,7 +1852,7 @@ void op_tilde(oparg_T *oap)
 
     }
     if (did_change)
-      changed_lines(oap->start.lnum, 0, oap->end.lnum + 1, 0L);
+      changed_lines(oap->start.lnum, 0, oap->end.lnum + 1, 0L, true);
   } else {  // not block mode
     if (oap->motion_type == kMTLineWise) {
       oap->start.col = 0;
@@ -1876,7 +1876,7 @@ void op_tilde(oparg_T *oap)
       }
     if (did_change) {
       changed_lines(oap->start.lnum, oap->start.col, oap->end.lnum + 1,
-          0L);
+          0L, true);
     }
   }
 
@@ -2257,7 +2257,7 @@ int op_change(oparg_T *oap)
         }
       }
       check_cursor();
-      changed_lines(oap->start.lnum + 1, 0, oap->end.lnum + 1, 0L);
+      changed_lines(oap->start.lnum + 1, 0, oap->end.lnum + 1, 0L, true);
       xfree(ins_text);
     }
   }
@@ -3020,7 +3020,7 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
         curwin->w_cursor.col += bd.startspaces;
     }
 
-    changed_lines(lnum, 0, curwin->w_cursor.lnum, nr_lines);
+    changed_lines(lnum, 0, curwin->w_cursor.lnum, nr_lines, true);
 
     /* Set '[ mark. */
     curbuf->b_op_start = curwin->w_cursor;
@@ -3187,10 +3187,10 @@ error:
       // note changed text for displaying and folding
       if (y_type == kMTCharWise) {
         changed_lines(curwin->w_cursor.lnum, col,
-                      curwin->w_cursor.lnum + 1, nr_lines);
+                      curwin->w_cursor.lnum + 1, nr_lines, true);
       } else {
         changed_lines(curbuf->b_op_start.lnum, 0,
-                      curbuf->b_op_start.lnum, nr_lines);
+                      curbuf->b_op_start.lnum, nr_lines, true);
       }
 
       /* put '] mark at last inserted character */
@@ -3671,7 +3671,7 @@ int do_join(size_t count,
   /* Only report the change in the first line here, del_lines() will report
    * the deleted line. */
   changed_lines(curwin->w_cursor.lnum, currsize,
-      curwin->w_cursor.lnum + 1, 0L);
+      curwin->w_cursor.lnum + 1, 0L, true);
 
   /*
    * Delete following lines. To do this we move the cursor there
@@ -4344,7 +4344,7 @@ void op_addsub(oparg_T *oap, linenr_T Prenum1, bool g_cmd)
     }
     change_cnt = do_addsub(oap->op_type, &pos, 0, amount);
     if (change_cnt) {
-      changed_lines(pos.lnum, 0, pos.lnum + 1, 0L);
+      changed_lines(pos.lnum, 0, pos.lnum + 1, 0L, true);
     }
   } else {
     int one_change;
@@ -4400,7 +4400,7 @@ void op_addsub(oparg_T *oap, linenr_T Prenum1, bool g_cmd)
       }
     }
     if (change_cnt) {
-      changed_lines(oap->start.lnum, 0, oap->end.lnum + 1, 0L);
+      changed_lines(oap->start.lnum, 0, oap->end.lnum + 1, 0L, true);
     }
 
     if (!change_cnt && oap->is_VIsual) {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -634,8 +634,8 @@ void op_reindent(oparg_T *oap, Indenter how)
    * there is no change still need to remove the Visual highlighting. */
   if (last_changed != 0)
     changed_lines(first_changed, 0,
-        oap->is_VIsual ? start_lnum + oap->line_count :
-        last_changed + 1, 0L, true);
+                  oap->is_VIsual ? start_lnum + oap->line_count :
+                  last_changed + 1, 0L, true);
   else if (oap->is_VIsual)
     redraw_curbuf_later(INVERTED);
 
@@ -1876,7 +1876,7 @@ void op_tilde(oparg_T *oap)
       }
     if (did_change) {
       changed_lines(oap->start.lnum, oap->start.col, oap->end.lnum + 1,
-          0L, true);
+                    0L, true);
     }
   }
 
@@ -3671,7 +3671,7 @@ int do_join(size_t count,
   /* Only report the change in the first line here, del_lines() will report
    * the deleted line. */
   changed_lines(curwin->w_cursor.lnum, currsize,
-      curwin->w_cursor.lnum + 1, 0L, true);
+                curwin->w_cursor.lnum + 1, 0L, true);
 
   /*
    * Delete following lines. To do this we move the cursor there

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1221,7 +1221,8 @@ static void refresh_screen(Terminal *term, buf_T *buf)
 
   int change_start = row_to_linenr(term, term->invalid_start);
   int change_end = change_start + changed;
-  changed_lines(change_start, 0, change_end, added);
+  // Note: don't send LiveUpdate event for a :terminal buffer
+  changed_lines(change_start, 0, change_end, added, false);
   term->invalid_start = INT_MAX;
   term->invalid_end = -1;
 }

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1673,7 +1673,7 @@ void u_undo(int count)
     undo_undoes = TRUE;
   else
     undo_undoes = !undo_undoes;
-  u_doit(count, false);
+  u_doit(count, false, true);
 }
 
 /*
@@ -1686,7 +1686,7 @@ void u_redo(int count)
     undo_undoes = false;
   }
 
-  u_doit(count, false);
+  u_doit(count, false, true);
 }
 
 /// Undo and remove the branch from the undo tree.
@@ -1698,7 +1698,9 @@ bool u_undo_and_forget(int count)
     count = 1;
   }
   undo_undoes = true;
-  u_doit(count, true);
+  // don't send a LiveUpdate for this undo is part of 'inccommand' playing with
+  // buffer contents
+  u_doit(count, true, false);
 
   if (curbuf->b_u_curhead == NULL) {
     // nothing was undone.
@@ -1733,7 +1735,7 @@ bool u_undo_and_forget(int count)
 }
 
 /// Undo or redo, depending on `undo_undoes`, `count` times.
-static void u_doit(int startcount, bool quiet)
+static void u_doit(int startcount, bool quiet, bool send_liveupdate)
 {
   int count = startcount;
 
@@ -1769,7 +1771,7 @@ static void u_doit(int startcount, bool quiet)
         break;
       }
 
-      u_undoredo(true);
+      u_undoredo(true, send_liveupdate);
     } else {
       if (curbuf->b_u_curhead == NULL || get_undolevel() <= 0) {
         beep_flush();           /* nothing to redo */
@@ -1780,7 +1782,7 @@ static void u_doit(int startcount, bool quiet)
         break;
       }
 
-      u_undoredo(FALSE);
+      u_undoredo(false, send_liveupdate);
 
       /* Advance for next redo.  Set "newhead" when at the end of the
        * redoable changes. */
@@ -2027,7 +2029,7 @@ void undo_time(long step, int sec, int file, int absolute)
           || (uhp->uh_seq == target && !above))
         break;
       curbuf->b_u_curhead = uhp;
-      u_undoredo(TRUE);
+      u_undoredo(true, true);
       uhp->uh_walk = nomark;            /* don't go back down here */
     }
 
@@ -2083,7 +2085,7 @@ void undo_time(long step, int sec, int file, int absolute)
         break;
       }
 
-      u_undoredo(FALSE);
+      u_undoredo(false, true);
 
       /* Advance "curhead" to below the header we last used.  If it
       * becomes NULL then we need to set "newhead" to this leaf. */
@@ -2115,7 +2117,7 @@ void undo_time(long step, int sec, int file, int absolute)
  *
  * When "undo" is TRUE we go up in the tree, when FALSE we go down.
  */
-static void u_undoredo(int undo)
+static void u_undoredo(int undo, bool send_liveupdate)
 {
   char_u      **newarray = NULL;
   linenr_T oldsize;
@@ -2243,7 +2245,7 @@ static void u_undoredo(int undo)
       }
     }
 
-    changed_lines(top + 1, 0, bot, newsize - oldsize, true);
+    changed_lines(top + 1, 0, bot, newsize - oldsize, send_liveupdate);
 
     /* set '[ and '] mark */
     if (top + 1 < curbuf->b_op_start.lnum)
@@ -2279,7 +2281,7 @@ static void u_undoredo(int undo)
   // because the calls to changed()/unchanged() above will bump b_changedtick
   // again, we need to send a LiveUpdate with just the new value of
   // b:changedtick
-  if (kv_size(curbuf->liveupdate_channels)) {
+  if (send_liveupdate && kv_size(curbuf->liveupdate_channels)) {
     liveupdate_send_tick(curbuf);
   }
 

--- a/test/functional/api/liveupdate_spec.lua
+++ b/test/functional/api/liveupdate_spec.lua
@@ -24,24 +24,29 @@ function open(activate, lines)
   helpers.write_file(filename, table.concat(lines, "\n").."\n")
   command('edit ' .. filename)
   local b = nvim('get_current_buf')
+  -- what is the value of b:changedtick?
+  local tick = eval('b:changedtick')
 
   -- turn on live updates, ensure that the LiveUpdateStart messages
   -- arrive as expectected
   if activate then
     ok(buffer('live_updates', b, true))
-    expectn('LiveUpdateStart', {b, lines, false})
+    expectn('LiveUpdateStart', {b, tick, lines, false})
   end
 
-  return b, filename
+  return b, tick, filename
 end
 
 function reopen(buf, expectedlines)
   ok(buffer('live_updates', buf, false))
   expectn('LiveUpdateEnd', {buf})
+  -- for some reason the :edit! increments tick by 2
   command('edit!')
+  local tick = eval('b:changedtick')
   ok(buffer('live_updates', buf, true))
-  expectn('LiveUpdateStart', {buf, origlines, false})
+  expectn('LiveUpdateStart', {buf, tick, origlines, false})
   command('normal! gg')
+  return tick
 end
 
 function expectn(name, args)
@@ -51,42 +56,52 @@ end
 
 describe('liveupdate', function()
   it('knows when you add line to a buffer', function()
-    local b, filename = editoriginal(true)
+    local b, tick = editoriginal(true)
 
     -- add a new line at the start of the buffer
     command('normal! GyyggP')
-    expectn('LiveUpdate', {b, 0, 0, {'original line 6'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 0, 0, {'original line 6'}})
 
     -- add multiple lines at the start of the file
     command('normal! GkkyGggP')
-    expectn('LiveUpdate', {b, 0, 0, {'original line 4',
-                                     'original line 5',
-                                     'original line 6'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 0, 0, {'original line 4',
+                                           'original line 5',
+                                           'original line 6'}})
 
     -- add one line to the middle of the file, several times
     command('normal! ggYjjp')
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 3, 0, {'original line 4'}})
     command('normal! p')
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 4, 0, {'original line 4'}})
     command('normal! p')
-    expectn('LiveUpdate', {b, 3, 0, {'original line 4'}})
-    expectn('LiveUpdate', {b, 4, 0, {'original line 4'}})
-    expectn('LiveUpdate', {b, 5, 0, {'original line 4'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 5, 0, {'original line 4'}})
 
     -- add multiple lines to the middle of the file
     command('normal! gg4Yjjp')
-    expectn('LiveUpdate', {b, 3, 0, {'original line 4',
-                                     'original line 5',
-                                     'original line 6',
-                                     'original line 4'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 3, 0, {'original line 4',
+                                           'original line 5',
+                                           'original line 6',
+                                           'original line 4'}})
 
     -- add one line to the end of the file
     command('normal! ggYGp')
-    expectn('LiveUpdate', {b, 17, 0, {'original line 4'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 17, 0, {'original line 4'}})
 
     -- add one line to the end of the file, several times
     command('normal! ggYGppp')
-    expectn('LiveUpdate', {b, 18, 0, {'original line 4'}})
-    expectn('LiveUpdate', {b, 19, 0, {'original line 4'}})
-    expectn('LiveUpdate', {b, 20, 0, {'original line 4'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 18, 0, {'original line 4'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 19, 0, {'original line 4'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 20, 0, {'original line 4'}})
 
     -- add several lines to the end of the file, several times
     command('normal! gg4YGp')
@@ -96,9 +111,12 @@ describe('liveupdate', function()
                  'original line 5',
                  'original line 6',
                  'original line 4'}
-    expectn('LiveUpdate', {b, 21,  0, firstfour})
-    expectn('LiveUpdate', {b, 25, 0, firstfour})
-    expectn('LiveUpdate', {b, 29, 0, firstfour})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 21, 0, firstfour})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 25, 0, firstfour})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 29, 0, firstfour})
 
     -- create a new empty buffer and wipe out the old one ... this will
     -- turn off live updates
@@ -107,11 +125,13 @@ describe('liveupdate', function()
 
     -- add a line at the start of an empty file
     command('enew')
+    local tick = eval('b:changedtick')
     b2 = nvim('get_current_buf')
     ok(buffer('live_updates', b2, true))
-    expectn('LiveUpdateStart', {b2, {""}, false})
+    expectn('LiveUpdateStart', {b2, tick, {""}, false})
     eval('append(0, ["new line 1"])')
-    expectn('LiveUpdate', {b2, 0, 0, {'new line 1'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b2, tick, 0, 0, {'new line 1'}})
 
     -- turn off live updates manually
     buffer('live_updates', b2, false)
@@ -121,137 +141,163 @@ describe('liveupdate', function()
     command('enew!')
     b3 = nvim('get_current_buf')
     ok(buffer('live_updates', b3, true))
-    expectn('LiveUpdateStart', {b3, {""}, false})
+    tick = eval('b:changedtick')
+    expectn('LiveUpdateStart', {b3, tick, {""}, false})
     eval('append(0, ["new line 1", "new line 2", "new line 3"])')
-    expectn('LiveUpdate', {b3, 0, 0, {'new line 1', 'new line 2', 'new line 3'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b3, tick, 0, 0, {'new line 1',
+                                            'new line 2',
+                                            'new line 3'}})
 
     -- use the API itself to add a line to the start of the buffer
     buffer('set_lines', b3, 0, 0, true, {'New First Line'})
-    expectn('LiveUpdate', {b3, 0, 0, {"New First Line"}})
-
-    os.remove(filename)
+    tick = tick + 1
+    expectn('LiveUpdate', {b3, tick, 0, 0, {"New First Line"}})
   end)
 
   it('knows when you remove lines from a buffer', function()
-    local b, filename = editoriginal(true)
+    local b, tick = editoriginal(true)
 
     -- remove one line from start of file
     command('normal! dd')
-    expectn('LiveUpdate', {b, 0, 1, {}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 0, 1, {}})
 
     -- remove multiple lines from the start of the file
     command('normal! 4dd')
-    expectn('LiveUpdate', {b, 0, 4, {}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 0, 4, {}})
 
     -- remove multiple lines from middle of file
-    reopen(b, origlines)
+    tick = reopen(b, origlines)
     command('normal! jj3dd')
-    expectn('LiveUpdate', {b, 2, 3, {}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 2, 3, {}})
 
     -- remove one line from the end of the file
-    reopen(b, origlines)
+    tick = reopen(b, origlines)
     command('normal! Gdd')
-    expectn('LiveUpdate', {b, 5, 1, {}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 5, 1, {}})
 
     -- remove multiple lines from the end of the file
-    reopen(b, origlines)
+    tick = reopen(b, origlines)
     command('normal! 4G3dd')
-    expectn('LiveUpdate', {b, 3, 3, {}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 3, 3, {}})
 
     -- pretend to remove heaps lines from the end of the file but really
     -- just remove two
-    reopen(b, origlines)
+    tick = reopen(b, origlines)
     command('normal! Gk5dd')
-    expectn('LiveUpdate', {b, 4, 2, {}})
-
-    os.remove(filename)
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 4, 2, {}})
   end)
 
   it('knows when you modify lines of text', function()
-    local b, filename = editoriginal(true)
+    local b, tick = editoriginal(true)
 
     -- some normal text editing
     command('normal! A555')
-    expectn('LiveUpdate', {b, 0, 1, {'original line 1555'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 0, 1, {'original line 1555'}})
     command('normal! jj8X')
-    expectn('LiveUpdate', {b, 2, 1, {'origin3'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 2, 1, {'origin3'}})
 
     -- modify multiple lines at once using visual block mode
-    reopen(b, origlines)
+    tick = reopen(b, origlines)
     command('normal! jjw')
     nvim('input', '\x16jjllx')
+    tick = tick + 1
     expectn('LiveUpdate',
-            {b, 2, 3, {'original e 3', 'original e 4', 'original e 5'}})
+            {b, tick, 2, 3, {'original e 3', 'original e 4', 'original e 5'}})
 
-    ---- replace part of a line line using :s
-    reopen(b, origlines)
+    -- replace part of a line line using :s
+    tick = reopen(b, origlines)
     command('3s/line 3/foo/')
-    expectn('LiveUpdate', {b, 2, 1, {'original foo'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 2, 1, {'original foo'}})
 
-    ---- replace parts of several lines line using :s
-    reopen(b, origlines)
+    -- replace parts of several lines line using :s
+    tick = reopen(b, origlines)
     command('%s/line [35]/foo/')
-    expectn('LiveUpdate',
-            {b, 2, 3, {'original foo', 'original line 4', 'original foo'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 2, 3, {'original foo',
+                                           'original line 4',
+                                           'original foo'}})
 
     -- type text into the first line of a blank file, one character at a time
     command('enew!')
+    tick = 2
     expectn('LiveUpdateEnd', {b})
     bnew = nvim('get_current_buf')
     ok(buffer('live_updates', bnew, true))
-    expectn('LiveUpdateStart', {bnew, {''}, false})
+    expectn('LiveUpdateStart', {bnew, tick, {''}, false})
     nvim('input', 'i')
     nvim('input', 'h')
     nvim('input', 'e')
     nvim('input', 'l')
     nvim('input', 'l')
     nvim('input', 'o')
-    expectn('LiveUpdate', {bnew, 0, 1, {'h'}})
-    expectn('LiveUpdate', {bnew, 0, 1, {'he'}})
-    expectn('LiveUpdate', {bnew, 0, 1, {'hel'}})
-    expectn('LiveUpdate', {bnew, 0, 1, {'hell'}})
-    expectn('LiveUpdate', {bnew, 0, 1, {'hello'}})
+    expectn('LiveUpdate', {bnew, tick + 1, 0, 1, {'h'}})
+    expectn('LiveUpdate', {bnew, tick + 2, 0, 1, {'he'}})
+    expectn('LiveUpdate', {bnew, tick + 3, 0, 1, {'hel'}})
+    expectn('LiveUpdate', {bnew, tick + 4, 0, 1, {'hell'}})
+    expectn('LiveUpdate', {bnew, tick + 5, 0, 1, {'hello'}})
   end)
 
   it('knows when you replace lines', function()
-    local b, filename = editoriginal(true)
+    local b, tick = editoriginal(true)
 
     -- blast away parts of some lines with visual mode
     command('normal! jjwvjjllx')
-    expectn('LiveUpdate', {b, 2, 1, {'original '}})
-    expectn('LiveUpdate', {b, 3, 1, {}})
-    expectn('LiveUpdate', {b, 3, 1, {'e 5'}})
-    expectn('LiveUpdate', {b, 2, 1, {'original e 5'}})
-    expectn('LiveUpdate', {b, 3, 1, {}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 2, 1, {'original '}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 3, 1, {}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 3, 1, {'e 5'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 2, 1, {'original e 5'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 3, 1, {}})
 
     -- blast away a few lines using :g
-    reopen(b, origlines)
+    tick = reopen(b, origlines)
     command('global/line [35]/delete')
-    expectn('LiveUpdate', {b, 2, 1, {}})
-    expectn('LiveUpdate', {b, 3, 1, {}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 2, 1, {}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 3, 1, {}})
   end)
 
   it('knows when you filter lines', function()
     -- Test filtering lines with !sort
-    local b, filename = editoriginal(true, {"A", "C", "E", "B", "D", "F"})
+    local b, tick = editoriginal(true, {"A", "C", "E", "B", "D", "F"})
 
     command('silent 2,5!sort')
     -- the change comes through as two changes:
     -- 1) addition of the new lines after the filtered lines
     -- 2) removal of the original lines
-    expectn('LiveUpdate', {b, 5, 0, {"B", "C", "D", "E"}})
-    expectn('LiveUpdate', {b, 1, 4, {}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 5, 0, {"B", "C", "D", "E"}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 1, 4, {}})
   end)
 
   it('deactivates when your buffer changes outside vim', function()
     -- Test changing file from outside vim and reloading using :edit
     local lines = {"Line 1", "Line 2"};
-    local b, filename = editoriginal(true, lines)
+    local b, tick, filename = editoriginal(true, lines)
 
     command('normal! x')
-    expectn('LiveUpdate', {b, 0, 1, {'ine 1'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 0, 1, {'ine 1'}})
     command('undo')
-    expectn('LiveUpdate', {b, 0, 1, {'Line 1'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 0, 1, {'Line 1'}})
+    tick = tick + 1
 
     -- change the file directly
     local f = io.open(filename, 'a')
@@ -267,13 +313,13 @@ describe('liveupdate', function()
   it('allows a channel to watch multiple buffers at once', function()
     -- edit 3 buffers, make sure they all have windows visible so that when we
     -- move between buffers, none of them are unloaded
-    b1, f1 = editoriginal(true, {'A1', 'A2'})
+    b1, tick1, f1 = editoriginal(true, {'A1', 'A2'})
     b1nr = eval('bufnr("")')
     command('split')
-    b2, f2 = open(true, {'B1', 'B2'})
+    b2, tick2, f2 = open(true, {'B1', 'B2'})
     b2nr = eval('bufnr("")')
     command('split')
-    b3, f3 = open(true, {'C1', 'C2'})
+    b3, tick3, f3 = open(true, {'C1', 'C2'})
     b3nr = eval('bufnr("")')
 
     -- make a new window for moving between buffers
@@ -281,27 +327,35 @@ describe('liveupdate', function()
 
     command('b'..b1nr)
     command('normal! x')
+    tick1 = tick1 + 1
+    expectn('LiveUpdate', {b1, tick1, 0, 1, {'1'}})
     command('undo')
-    expectn('LiveUpdate', {b1, 0, 1, {'1'}})
-    expectn('LiveUpdate', {b1, 0, 1, {'A1'}})
+    tick1 = tick1 + 1
+    expectn('LiveUpdate', {b1, tick1, 0, 1, {'A1'}})
+    tick1 = tick1 + 1 -- :undo causes another increment after the LiveUpdate
 
     command('b'..b2nr)
     command('normal! x')
+    tick2 = tick2 + 1
+    expectn('LiveUpdate', {b2, tick2, 0, 1, {'1'}})
     command('undo')
-    expectn('LiveUpdate', {b2, 0, 1, {'1'}})
-    expectn('LiveUpdate', {b2, 0, 1, {'B1'}})
+    tick2 = tick2 + 1
+    expectn('LiveUpdate', {b2, tick2, 0, 1, {'B1'}})
+    tick2 = tick2 + 1 -- :undo causes another increment after the LiveUpdate
 
     command('b'..b3nr)
     command('normal! x')
+    tick3 = tick3 + 1
+    expectn('LiveUpdate', {b3, tick3, 0, 1, {'1'}})
     command('undo')
-    expectn('LiveUpdate', {b3, 0, 1, {'1'}})
-    expectn('LiveUpdate', {b3, 0, 1, {'C1'}})
+    tick3 = tick3 + 1
+    expectn('LiveUpdate', {b3, tick3, 0, 1, {'C1'}})
   end)
 
   it('doesn\'t get confused when you turn watching on/off many times',
      function()
     local channel = nvim('get_api_info')[1]
-    local b, filename = editoriginal(false)
+    local b, tick = editoriginal(false)
 
     -- turn on live updates many times
     ok(buffer('live_updates', b, true))
@@ -309,33 +363,7 @@ describe('liveupdate', function()
     ok(buffer('live_updates', b, true))
     ok(buffer('live_updates', b, true))
     ok(buffer('live_updates', b, true))
-    expectn('LiveUpdateStart', {b, origlines, false})
-    eval('rpcnotify('..channel..', "Hello There")')
-    expectn('Hello There', {})
-
-    -- turn live updates off many times
-    ok(buffer('live_updates', b, false))
-    ok(buffer('live_updates', b, false))
-    ok(buffer('live_updates', b, false))
-    ok(buffer('live_updates', b, false))
-    ok(buffer('live_updates', b, false))
-    expectn('LiveUpdateEnd', {b})
-    eval('rpcnotify('..channel..', "Hello Again")')
-    expectn('Hello Again', {})
-  end)
-
-  it('doesnt get confused when you turn watching on/off many times',
-     function()
-    local channel = nvim('get_api_info')[1]
-    local b, filename = editoriginal(false)
-
-    -- turn on live updates many times
-    ok(buffer('live_updates', b, true))
-    ok(buffer('live_updates', b, true))
-    ok(buffer('live_updates', b, true))
-    ok(buffer('live_updates', b, true))
-    ok(buffer('live_updates', b, true))
-    expectn('LiveUpdateStart', {b, origlines, false})
+    expectn('LiveUpdateStart', {b, tick, origlines, false})
     eval('rpcnotify('..channel..', "Hello There")')
     expectn('Hello There', {})
 
@@ -380,21 +408,22 @@ describe('liveupdate', function()
 
     -- edit a new file, but don't turn on live updates
     local lines = {'AAA', 'BBB'}
-    local b, filename = open(false, lines)
+    local b, tick = open(false, lines)
 
     -- turn on live updates for sessions 1, 2 and 3
     ok(request(1, 'nvim_buf_live_updates', b, true))
     ok(request(2, 'nvim_buf_live_updates', b, true))
     ok(request(3, 'nvim_buf_live_updates', b, true))
-    wantn(1, 'LiveUpdateStart', {b, lines, false})
-    wantn(2, 'LiveUpdateStart', {b, lines, false})
-    wantn(3, 'LiveUpdateStart', {b, lines, false})
+    wantn(1, 'LiveUpdateStart', {b, tick, lines, false})
+    wantn(2, 'LiveUpdateStart', {b, tick, lines, false})
+    wantn(3, 'LiveUpdateStart', {b, tick, lines, false})
 
     -- make a change to the buffer
     command('normal! x')
-    wantn(1, 'LiveUpdate', {b, 0, 1, {'AA'}})
-    wantn(2, 'LiveUpdate', {b, 0, 1, {'AA'}})
-    wantn(3, 'LiveUpdate', {b, 0, 1, {'AA'}})
+    tick = tick + 1
+    wantn(1, 'LiveUpdate', {b, tick, 0, 1, {'AA'}})
+    wantn(2, 'LiveUpdate', {b, tick, 0, 1, {'AA'}})
+    wantn(3, 'LiveUpdate', {b, tick, 0, 1, {'AA'}})
 
     -- stop watching on channel 1
     ok(request(1, 'nvim_buf_live_updates', b, false))
@@ -402,8 +431,10 @@ describe('liveupdate', function()
 
     -- undo the change to buffer 1
     command('undo')
-    wantn(2, 'LiveUpdate', {b, 0, 1, {'AAA'}})
-    wantn(3, 'LiveUpdate', {b, 0, 1, {'AAA'}})
+    tick = tick + 1
+    wantn(2, 'LiveUpdate', {b, tick, 0, 1, {'AAA'}})
+    wantn(3, 'LiveUpdate', {b, tick, 0, 1, {'AAA'}})
+    tick = tick + 1
 
     -- make sure there are no other pending LiveUpdate messages going to
     -- channel 1
@@ -425,14 +456,19 @@ describe('liveupdate', function()
   end)
 
   it('turns off updates when a buffer is closed', function()
-    local b, filename = editoriginal(true, {'AAA'})
+    local b, tick = editoriginal(true, {'AAA'})
     local channel = nvim('get_api_info')[1]
 
     -- test live updates are working
     command('normal! x')
-    expectn('LiveUpdate', {b, 0, 1, {'AA'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 0, 1, {'AA'}})
     command('undo')
-    expectn('LiveUpdate', {b, 0, 1, {'AAA'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 0, 1, {'AAA'}})
+    -- undo causes another increment of b:changedtick, but after the LiveUpdate
+    -- has been sent
+    tick = tick + 1
 
     -- close our buffer by creating a new one
     command('enew')
@@ -448,14 +484,16 @@ describe('liveupdate', function()
   
   -- test what happens when a buffer is hidden
   it('keeps updates turned on if the buffer is hidden', function()
-    local b, filename = editoriginal(true, {'AAA'})
+    local b, tick = editoriginal(true, {'AAA'})
     local channel = nvim('get_api_info')[1]
 
     -- test live updates are working
     command('normal! x')
-    expectn('LiveUpdate', {b, 0, 1, {'AA'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 0, 1, {'AA'}})
     command('undo')
-    expectn('LiveUpdate', {b, 0, 1, {'AAA'}})
+    tick = tick + 1
+    expectn('LiveUpdate', {b, tick, 0, 1, {'AAA'}})
 
     -- close our buffer by creating a new one
     command('set hidden')
@@ -468,7 +506,8 @@ describe('liveupdate', function()
     -- reopen the original buffer, make sure Live Updates are still active
     command('b1')
     command('normal! x')
-    expectn('LiveUpdate', {b, 0, 1, {'AA'}})
+    tick = tick + 2
+    expectn('LiveUpdate', {b, tick, 0, 1, {'AA'}})
   end)
 
   it('turns off live updates when a buffer is unloaded, deleted, or wiped',

--- a/test/functional/api/liveupdate_spec.lua
+++ b/test/functional/api/liveupdate_spec.lua
@@ -1,0 +1,491 @@
+local helpers = require('test.functional.helpers')(after_each)
+local eq, ok = helpers.eq, helpers.ok
+local buffer, command, eval, nvim, next_message = helpers.buffer,
+  helpers.command, helpers.eval, helpers.nvim, helpers.next_message
+
+local origlines = {"original line 1",
+                   "original line 2",
+                   "original line 3",
+                   "original line 4",
+                   "original line 5",
+                   "original line 6"}
+
+function editoriginal(activate, lines)
+  if not lines then
+    lines = origlines
+  end
+  -- load up the file with the correct contents
+  helpers.clear()
+  return open(activate, lines)
+end
+
+function open(activate, lines)
+  local filename = helpers.tmpname()
+  helpers.write_file(filename, table.concat(lines, "\n").."\n")
+  command('edit ' .. filename)
+  local b = nvim('get_current_buf')
+
+  -- turn on live updates, ensure that the LiveUpdateStart messages
+  -- arrive as expectected
+  if activate then
+    ok(buffer('live_updates', b, true))
+    expectn('LiveUpdateStart', {b, lines, false})
+  end
+
+  return b, filename
+end
+
+function reopen(buf, expectedlines)
+  ok(buffer('live_updates', buf, false))
+  expectn('LiveUpdateEnd', {buf})
+  command('edit!')
+  ok(buffer('live_updates', buf, true))
+  expectn('LiveUpdateStart', {buf, origlines, false})
+  command('normal! gg')
+end
+
+function expectn(name, args)
+  -- expect the next message to be the specified notification event
+  eq({'notification', name, args}, next_message())
+end
+
+describe('liveupdate', function()
+  it('knows when you add line to a buffer', function()
+    local b, filename = editoriginal(true)
+
+    -- add a new line at the start of the buffer
+    command('normal! GyyggP')
+    expectn('LiveUpdate', {b, 0, 0, {'original line 6'}})
+
+    -- add multiple lines at the start of the file
+    command('normal! GkkyGggP')
+    expectn('LiveUpdate', {b, 0, 0, {'original line 4',
+                                     'original line 5',
+                                     'original line 6'}})
+
+    -- add one line to the middle of the file, several times
+    command('normal! ggYjjp')
+    command('normal! p')
+    command('normal! p')
+    expectn('LiveUpdate', {b, 3, 0, {'original line 4'}})
+    expectn('LiveUpdate', {b, 4, 0, {'original line 4'}})
+    expectn('LiveUpdate', {b, 5, 0, {'original line 4'}})
+
+    -- add multiple lines to the middle of the file
+    command('normal! gg4Yjjp')
+    expectn('LiveUpdate', {b, 3, 0, {'original line 4',
+                                     'original line 5',
+                                     'original line 6',
+                                     'original line 4'}})
+
+    -- add one line to the end of the file
+    command('normal! ggYGp')
+    expectn('LiveUpdate', {b, 17, 0, {'original line 4'}})
+
+    -- add one line to the end of the file, several times
+    command('normal! ggYGppp')
+    expectn('LiveUpdate', {b, 18, 0, {'original line 4'}})
+    expectn('LiveUpdate', {b, 19, 0, {'original line 4'}})
+    expectn('LiveUpdate', {b, 20, 0, {'original line 4'}})
+
+    -- add several lines to the end of the file, several times
+    command('normal! gg4YGp')
+    command('normal! Gp')
+    command('normal! Gp')
+    firstfour = {'original line 4',
+                 'original line 5',
+                 'original line 6',
+                 'original line 4'}
+    expectn('LiveUpdate', {b, 21,  0, firstfour})
+    expectn('LiveUpdate', {b, 25, 0, firstfour})
+    expectn('LiveUpdate', {b, 29, 0, firstfour})
+
+    -- create a new empty buffer and wipe out the old one ... this will
+    -- turn off live updates
+    command('enew!')
+    expectn('LiveUpdateEnd', {b})
+
+    -- add a line at the start of an empty file
+    command('enew')
+    b2 = nvim('get_current_buf')
+    ok(buffer('live_updates', b2, true))
+    expectn('LiveUpdateStart', {b2, {""}, false})
+    eval('append(0, ["new line 1"])')
+    expectn('LiveUpdate', {b2, 0, 0, {'new line 1'}})
+
+    -- turn off live updates manually
+    buffer('live_updates', b2, false)
+    expectn('LiveUpdateEnd', {b2})
+
+    -- add multiple lines to a blank file
+    command('enew!')
+    b3 = nvim('get_current_buf')
+    ok(buffer('live_updates', b3, true))
+    expectn('LiveUpdateStart', {b3, {""}, false})
+    eval('append(0, ["new line 1", "new line 2", "new line 3"])')
+    expectn('LiveUpdate', {b3, 0, 0, {'new line 1', 'new line 2', 'new line 3'}})
+
+    -- use the API itself to add a line to the start of the buffer
+    buffer('set_lines', b3, 0, 0, true, {'New First Line'})
+    expectn('LiveUpdate', {b3, 0, 0, {"New First Line"}})
+
+    os.remove(filename)
+  end)
+
+  it('knows when you remove lines from a buffer', function()
+    local b, filename = editoriginal(true)
+
+    -- remove one line from start of file
+    command('normal! dd')
+    expectn('LiveUpdate', {b, 0, 1, {}})
+
+    -- remove multiple lines from the start of the file
+    command('normal! 4dd')
+    expectn('LiveUpdate', {b, 0, 4, {}})
+
+    -- remove multiple lines from middle of file
+    reopen(b, origlines)
+    command('normal! jj3dd')
+    expectn('LiveUpdate', {b, 2, 3, {}})
+
+    -- remove one line from the end of the file
+    reopen(b, origlines)
+    command('normal! Gdd')
+    expectn('LiveUpdate', {b, 5, 1, {}})
+
+    -- remove multiple lines from the end of the file
+    reopen(b, origlines)
+    command('normal! 4G3dd')
+    expectn('LiveUpdate', {b, 3, 3, {}})
+
+    -- pretend to remove heaps lines from the end of the file but really
+    -- just remove two
+    reopen(b, origlines)
+    command('normal! Gk5dd')
+    expectn('LiveUpdate', {b, 4, 2, {}})
+
+    os.remove(filename)
+  end)
+
+  it('knows when you modify lines of text', function()
+    local b, filename = editoriginal(true)
+
+    -- some normal text editing
+    command('normal! A555')
+    expectn('LiveUpdate', {b, 0, 1, {'original line 1555'}})
+    command('normal! jj8X')
+    expectn('LiveUpdate', {b, 2, 1, {'origin3'}})
+
+    -- modify multiple lines at once using visual block mode
+    reopen(b, origlines)
+    command('normal! jjw')
+    nvim('input', '\x16jjllx')
+    expectn('LiveUpdate',
+            {b, 2, 3, {'original e 3', 'original e 4', 'original e 5'}})
+
+    ---- replace part of a line line using :s
+    reopen(b, origlines)
+    command('3s/line 3/foo/')
+    expectn('LiveUpdate', {b, 2, 1, {'original foo'}})
+
+    ---- replace parts of several lines line using :s
+    reopen(b, origlines)
+    command('%s/line [35]/foo/')
+    expectn('LiveUpdate',
+            {b, 2, 3, {'original foo', 'original line 4', 'original foo'}})
+
+    -- type text into the first line of a blank file, one character at a time
+    command('enew!')
+    expectn('LiveUpdateEnd', {b})
+    bnew = nvim('get_current_buf')
+    ok(buffer('live_updates', bnew, true))
+    expectn('LiveUpdateStart', {bnew, {''}, false})
+    nvim('input', 'i')
+    nvim('input', 'h')
+    nvim('input', 'e')
+    nvim('input', 'l')
+    nvim('input', 'l')
+    nvim('input', 'o')
+    expectn('LiveUpdate', {bnew, 0, 1, {'h'}})
+    expectn('LiveUpdate', {bnew, 0, 1, {'he'}})
+    expectn('LiveUpdate', {bnew, 0, 1, {'hel'}})
+    expectn('LiveUpdate', {bnew, 0, 1, {'hell'}})
+    expectn('LiveUpdate', {bnew, 0, 1, {'hello'}})
+  end)
+
+  it('knows when you replace lines', function()
+    local b, filename = editoriginal(true)
+
+    -- blast away parts of some lines with visual mode
+    command('normal! jjwvjjllx')
+    expectn('LiveUpdate', {b, 2, 1, {'original '}})
+    expectn('LiveUpdate', {b, 3, 1, {}})
+    expectn('LiveUpdate', {b, 3, 1, {'e 5'}})
+    expectn('LiveUpdate', {b, 2, 1, {'original e 5'}})
+    expectn('LiveUpdate', {b, 3, 1, {}})
+
+    -- blast away a few lines using :g
+    reopen(b, origlines)
+    command('global/line [35]/delete')
+    expectn('LiveUpdate', {b, 2, 1, {}})
+    expectn('LiveUpdate', {b, 3, 1, {}})
+  end)
+
+  it('knows when you filter lines', function()
+    -- Test filtering lines with !sort
+    local b, filename = editoriginal(true, {"A", "C", "E", "B", "D", "F"})
+
+    command('silent 2,5!sort')
+    -- the change comes through as two changes:
+    -- 1) addition of the new lines after the filtered lines
+    -- 2) removal of the original lines
+    expectn('LiveUpdate', {b, 5, 0, {"B", "C", "D", "E"}})
+    expectn('LiveUpdate', {b, 1, 4, {}})
+  end)
+
+  it('deactivates when your buffer changes outside vim', function()
+    -- Test changing file from outside vim and reloading using :edit
+    local lines = {"Line 1", "Line 2"};
+    local b, filename = editoriginal(true, lines)
+
+    command('normal! x')
+    expectn('LiveUpdate', {b, 0, 1, {'ine 1'}})
+    command('undo')
+    expectn('LiveUpdate', {b, 0, 1, {'Line 1'}})
+
+    -- change the file directly
+    local f = io.open(filename, 'a')
+    f:write("another line\n")
+    f:flush()
+    f:close()
+
+    -- reopen the file and watch live updates shut down
+    command('edit')
+    expectn('LiveUpdateEnd', {b})
+  end)
+
+  it('allows a channel to watch multiple buffers at once', function()
+    -- edit 3 buffers, make sure they all have windows visible so that when we
+    -- move between buffers, none of them are unloaded
+    b1, f1 = editoriginal(true, {'A1', 'A2'})
+    b1nr = eval('bufnr("")')
+    command('split')
+    b2, f2 = open(true, {'B1', 'B2'})
+    b2nr = eval('bufnr("")')
+    command('split')
+    b3, f3 = open(true, {'C1', 'C2'})
+    b3nr = eval('bufnr("")')
+
+    -- make a new window for moving between buffers
+    command('split')
+
+    command('b'..b1nr)
+    command('normal! x')
+    command('undo')
+    expectn('LiveUpdate', {b1, 0, 1, {'1'}})
+    expectn('LiveUpdate', {b1, 0, 1, {'A1'}})
+
+    command('b'..b2nr)
+    command('normal! x')
+    command('undo')
+    expectn('LiveUpdate', {b2, 0, 1, {'1'}})
+    expectn('LiveUpdate', {b2, 0, 1, {'B1'}})
+
+    command('b'..b3nr)
+    command('normal! x')
+    command('undo')
+    expectn('LiveUpdate', {b3, 0, 1, {'1'}})
+    expectn('LiveUpdate', {b3, 0, 1, {'C1'}})
+  end)
+
+  it('doesn\'t get confused when you turn watching on/off many times',
+     function()
+    local channel = nvim('get_api_info')[1]
+    local b, filename = editoriginal(false)
+
+    -- turn on live updates many times
+    ok(buffer('live_updates', b, true))
+    ok(buffer('live_updates', b, true))
+    ok(buffer('live_updates', b, true))
+    ok(buffer('live_updates', b, true))
+    ok(buffer('live_updates', b, true))
+    expectn('LiveUpdateStart', {b, origlines, false})
+    eval('rpcnotify('..channel..', "Hello There")')
+    expectn('Hello There', {})
+
+    -- turn live updates off many times
+    ok(buffer('live_updates', b, false))
+    ok(buffer('live_updates', b, false))
+    ok(buffer('live_updates', b, false))
+    ok(buffer('live_updates', b, false))
+    ok(buffer('live_updates', b, false))
+    expectn('LiveUpdateEnd', {b})
+    eval('rpcnotify('..channel..', "Hello Again")')
+    expectn('Hello Again', {})
+  end)
+
+  it('doesnt get confused when you turn watching on/off many times',
+     function()
+    local channel = nvim('get_api_info')[1]
+    local b, filename = editoriginal(false)
+
+    -- turn on live updates many times
+    ok(buffer('live_updates', b, true))
+    ok(buffer('live_updates', b, true))
+    ok(buffer('live_updates', b, true))
+    ok(buffer('live_updates', b, true))
+    ok(buffer('live_updates', b, true))
+    expectn('LiveUpdateStart', {b, origlines, false})
+    eval('rpcnotify('..channel..', "Hello There")')
+    expectn('Hello There', {})
+
+    -- turn live updates off many times
+    ok(buffer('live_updates', b, false))
+    ok(buffer('live_updates', b, false))
+    ok(buffer('live_updates', b, false))
+    ok(buffer('live_updates', b, false))
+    ok(buffer('live_updates', b, false))
+    expectn('LiveUpdateEnd', {b})
+    eval('rpcnotify('..channel..', "Hello Again")')
+    expectn('Hello Again', {})
+  end)
+
+  it('is able to notify several channels at once', function()
+    helpers.clear()
+
+    local addsession = function(where)
+      eval('serverstart("'..where..'")')
+      local session = helpers.connect(where)
+      return session
+    end
+
+    -- create several new sessions, in addition to our main API
+    sessions = {}
+    sessions[1] = addsession(helpers.tmpname()..'.1')
+    sessions[2] = addsession(helpers.tmpname()..'.2')
+    sessions[3] = addsession(helpers.tmpname()..'.3')
+
+    function request(sessionnr, method, ...)
+      local status, rv = sessions[sessionnr]:request(method, ...)
+      if not status then
+        error(rv[2])
+      end
+      return rv
+    end
+
+    function wantn(sessionid, name, args)
+      local session = sessions[sessionid]
+      eq({'notification', name, args}, session:next_message())
+    end
+
+    -- edit a new file, but don't turn on live updates
+    local lines = {'AAA', 'BBB'}
+    local b, filename = open(false, lines)
+
+    -- turn on live updates for sessions 1, 2 and 3
+    ok(request(1, 'nvim_buf_live_updates', b, true))
+    ok(request(2, 'nvim_buf_live_updates', b, true))
+    ok(request(3, 'nvim_buf_live_updates', b, true))
+    wantn(1, 'LiveUpdateStart', {b, lines, false})
+    wantn(2, 'LiveUpdateStart', {b, lines, false})
+    wantn(3, 'LiveUpdateStart', {b, lines, false})
+
+    -- make a change to the buffer
+    command('normal! x')
+    wantn(1, 'LiveUpdate', {b, 0, 1, {'AA'}})
+    wantn(2, 'LiveUpdate', {b, 0, 1, {'AA'}})
+    wantn(3, 'LiveUpdate', {b, 0, 1, {'AA'}})
+
+    -- stop watching on channel 1
+    ok(request(1, 'nvim_buf_live_updates', b, false))
+    wantn(1, 'LiveUpdateEnd', {b})
+
+    -- undo the change to buffer 1
+    command('undo')
+    wantn(2, 'LiveUpdate', {b, 0, 1, {'AAA'}})
+    wantn(3, 'LiveUpdate', {b, 0, 1, {'AAA'}})
+
+    -- make sure there are no other pending LiveUpdate messages going to
+    -- channel 1
+    local channel1 = request(1, 'nvim_get_api_info')[1]
+    eval('rpcnotify('..channel1..', "Hello")')
+    wantn(1, 'Hello', {})
+
+    -- close the buffer and channels 2 and 3 should get a LiveUpdateEnd
+    -- notification
+    command('edit')
+    wantn(2, 'LiveUpdateEnd', {b})
+    wantn(3, 'LiveUpdateEnd', {b})
+
+    -- make sure there are no other pending LiveUpdate messages going to
+    -- channel 1
+    local channel1 = request(1, 'nvim_get_api_info')[1]
+    eval('rpcnotify('..channel1..', "Hello Again")')
+    wantn(1, 'Hello Again', {})
+  end)
+
+  it('turns off updates when a buffer is closed', function()
+    local b, filename = editoriginal(true, {'AAA'})
+    local channel = nvim('get_api_info')[1]
+
+    -- test live updates are working
+    command('normal! x')
+    expectn('LiveUpdate', {b, 0, 1, {'AA'}})
+    command('undo')
+    expectn('LiveUpdate', {b, 0, 1, {'AAA'}})
+
+    -- close our buffer by creating a new one
+    command('enew')
+    expectn('LiveUpdateEnd', {b})
+
+    -- reopen the original buffer, make sure there are no Live Updates sent
+    command('b1')
+    command('normal! x')
+
+    eval('rpcnotify('..channel..', "Hello There")')
+    expectn('Hello There', {})
+  end)
+  
+  -- test what happens when a buffer is hidden
+  it('keeps updates turned on if the buffer is hidden', function()
+    local b, filename = editoriginal(true, {'AAA'})
+    local channel = nvim('get_api_info')[1]
+
+    -- test live updates are working
+    command('normal! x')
+    expectn('LiveUpdate', {b, 0, 1, {'AA'}})
+    command('undo')
+    expectn('LiveUpdate', {b, 0, 1, {'AAA'}})
+
+    -- close our buffer by creating a new one
+    command('set hidden')
+    command('enew')
+
+    -- note that no LiveUpdateEnd is sent
+    eval('rpcnotify('..channel..', "Hello There")')
+    expectn('Hello There', {})
+
+    -- reopen the original buffer, make sure Live Updates are still active
+    command('b1')
+    command('normal! x')
+    expectn('LiveUpdate', {b, 0, 1, {'AA'}})
+  end)
+
+  it('turns off live updates when a buffer is unloaded, deleted, or wiped',
+     function()
+    -- start with a blank nvim
+    helpers.clear()
+    -- need to make a new window with a buffer because :bunload doesn't let you
+    -- unload the last buffer
+    command('new')
+    for i, cmd in ipairs({'bunload', 'bdelete', 'bwipeout'}) do
+      -- open a brand spanking new file
+      local b, filename = open(true, {'AAA'})
+
+      -- call :bunload or whatever the command is, and then check that we
+      -- receive a LiveUpdateEnd
+      command(cmd)
+      expectn('LiveUpdateEnd', {b})
+    end
+  end)
+end)


### PR DESCRIPTION
Hello, I have been working on an efficient API for having neovim notify a co-process (channel?) any time a buffer is modified (because doing this with TextChanged autocmds is inefficient and difficult). This feature will make it easier to write plugins which scans the buffers contents and updates the display in real-time (e.g. syntax highlighters, linters).

The first commit in this PR contains the help text for 3 new functions and a mini-tutorial, please refer to that commit if you would like to learn how the new feature would work. The last commit contains some TODO items that I have yet to resolve.

I'm interested in collecting feedback with regards to:
1) Do others think the 3 new functions mentioned in the first commit are a sensible interface?
2) Are there any reasons why the solution I'm working on won't work?
3) Do you have any suggestions on how I should resolve the TODO items from the last commit?

Thank you for your thoughtful consideration.
Peter
