### PR TITLE
[RFC] Don't use environment variables as XDG defaults

### DIFF
--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -16,20 +16,29 @@ static const char *xdg_env_vars[] = {
   [kXDGDataDirs] = "XDG_DATA_DIRS",
 };
 
+#ifdef WIN32
+static const char *xdg_env_vars_win32_alt[] = {
+  [kXDGConfigHome] = "LOCALAPPDATA",
+  [kXDGDataHome] = "LOCALAPPDATA",
+  [kXDGCacheHome] = "TEMP",
+  [kXDGRuntimeDir] = NULL,
+  [kXDGConfigDirs] = NULL,
+  [kXDGDataDirs] = NULL,
+};
+#endif
+
 /// Defaults for XDGVarType values
 ///
 /// Used in case environment variables contain nothing. Need to be expanded.
 static const char *const xdg_defaults[] = {
 #ifdef WIN32
-  // Windows
-  [kXDGConfigHome] = "$LOCALAPPDATA",
-  [kXDGDataHome]   = "$LOCALAPPDATA",
-  [kXDGCacheHome]  = "$TEMP",
+  [kXDGConfigHome] = "~\\Appdata\\Local",
+  [kXDGDataHome] = "~\\Appdata\\Local",
+  [kXDGCacheHome] = "~\\Appdata\\Local\\Temp",
   [kXDGRuntimeDir] = NULL,
   [kXDGConfigDirs] = NULL,
   [kXDGDataDirs] = NULL,
 #else
-  // Linux, BSD, CYGWIN, Apple
   [kXDGConfigHome] = "~/.config",
   [kXDGDataHome] = "~/.local/share",
   [kXDGCacheHome] = "~/.cache",
@@ -50,7 +59,14 @@ char *stdpaths_get_xdg_var(const XDGVarType idx)
   const char *const env = xdg_env_vars[idx];
   const char *const fallback = xdg_defaults[idx];
 
-  const char *const env_val = os_getenv(env);
+  const char *env_val = os_getenv(env);
+
+#ifdef WIN32
+  if (env_val == NULL) {
+    env_val = os_getenv(xdg_env_vars_win32_alt[idx]);
+  }
+#endif
+
   char *ret = NULL;
   if (env_val != NULL) {
     ret = xstrdup(env_val);

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -9,8 +9,6 @@ local eval = helpers.eval
 local eq = helpers.eq
 local neq = helpers.neq
 
-if helpers.pending_win32(pending) then return end
-
 local function init_session(...)
   local args = { helpers.nvim_prog, '-i', 'NONE', '--embed',
     '--cmd', 'set shortmess+=I background=light noswapfile noautoindent',
@@ -23,6 +21,32 @@ local function init_session(...)
 end
 
 describe('startup defaults', function()
+
+  it('work without key environment variables', function()
+    clear({env={
+      XDG_CONFIG_HOME=nil,
+      XDG_DATA_HOME=nil,
+      XDG_CACHE_HOME=nil,
+      XDG_RUNTIME_DIR=nil,
+      XDG_CONFIG_DIRS=nil,
+      XDG_DATA_DIRS=nil,
+      LOCALAPPDATA=nil,
+      HOMEPATH=nil,
+      HOMEDRIVE=nil,
+      HOME=nil,
+      TEMP=nil,
+      VIMRUNTIME=nil,
+      USER=nil,
+    }})
+
+    eq('.', meths.get_option('backupdir'))
+    eq('.', meths.get_option('viewdir'))
+    eq('.', meths.get_option('directory'))
+    eq('.', meths.get_option('undodir'))
+  end)
+
+  if helpers.pending_win32(pending) then return end
+
   describe(':filetype', function()
     local function expect_filetype(expected)
       local screen = Screen.new(48, 4)
@@ -97,6 +121,8 @@ describe('startup defaults', function()
     end)
   end)
 end)
+
+if helpers.pending_win32(pending) then return end
 
 describe('XDG-based defaults', function()
   -- Need to be in separate describe() block to not run clear() twice.

--- a/test/functional/shada/buffers_spec.lua
+++ b/test/functional/shada/buffers_spec.lua
@@ -8,8 +8,6 @@ local reset, set_additional_cmd, clear =
   shada_helpers.reset, shada_helpers.set_additional_cmd,
   shada_helpers.clear
 
-if helpers.pending_win32(pending) then return end
-
 describe('ShaDa support code', function()
   local testfilename = 'Xtestfile-functional-shada-buffers'
   local testfilename_2 = 'Xtestfile-functional-shada-buffers-2'

--- a/test/functional/shada/marks_spec.lua
+++ b/test/functional/shada/marks_spec.lua
@@ -14,8 +14,6 @@ local nvim_current_line = function()
   return curwinmeths.get_cursor()[1]
 end
 
-if helpers.pending_win32(pending) then return end
-
 describe('ShaDa support code', function()
   local testfilename = 'Xtestfile-functional-shada-marks'
   local testfilename_2 = 'Xtestfile-functional-shada-marks-2'

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -171,6 +171,7 @@ describe('ShaDa support code', function()
   end
 
   it('correctly uses shada-r option', function()
+    nvim_command('set shellslash')
     meths.set_var('__home', paths.test_source_path)
     nvim_command('let $HOME = __home')
     nvim_command('unlet __home')
@@ -194,6 +195,7 @@ describe('ShaDa support code', function()
   end)
 
   it('correctly ignores case with shada-r option', function()
+    nvim_command('set shellslash')
     local pwd = funcs.getcwd()
     local relfname = 'абв/test'
     local fname = pwd .. '/' .. relfname

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -23,8 +23,6 @@ local wshada, _, shada_fname, clean =
 local dirname = 'Xtest-functional-shada-shada.d'
 local dirshada = dirname .. '/main.shada'
 
-if helpers.pending_win32(pending) then return end
-
 describe('ShaDa support code', function()
   before_each(reset)
   after_each(function()
@@ -240,6 +238,8 @@ describe('ShaDa support code', function()
   end)
 
   it('does not crash when ShaDa file directory is not writable', function()
+    if helpers.pending_win32(pending) then return end
+
     funcs.mkdir(dirname, '', 0)
     eq(0, funcs.filewritable(dirname))
     set_additional_cmd('set shada=')


### PR DESCRIPTION
Fixes #5255 where the XDG defaults were windows environment variables, but they could not be expanded. Expand them specifically for the windows case.

I took the chance to enable some related functional tests in Windows:
- [x] shada/shada_spec.lua has one failing test (the problem here is the path separator, e.g. shellslash works around it)
- [x] check behaviour when the variables are not set https://github.com/neovim/neovim/issues/5255#issuecomment-242925931 $LOCALAPPDATA $TEMP
