### PR TITLE
[RFC] Fix/spec system()/jobstart() for Windows

### DIFF
--- a/.ci/build.bat
+++ b/.ci/build.bat
@@ -17,7 +17,14 @@ set PATH=C:\Program Files (x86)\CMake\bin\cpack.exe;%PATH%
 
 :: Build third-party dependencies
 C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm -Su" || goto :error
-C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm --needed -S mingw-w64-%ARCH%-cmake mingw-w64-%ARCH%-perl mingw-w64-%ARCH%-python2 mingw-w64-%ARCH%-diffutils gperf" || goto :error
+C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm --needed -S mingw-w64-%ARCH%-cmake mingw-w64-%ARCH%-perl mingw-w64-%ARCH%-diffutils gperf" || goto :error
+
+:: Use Appveyor's python
+set PATH=C:\Python27;C:\Python27\Scripts;%PATH%
+set PATH=C:\Python35;C:\Python35\Scripts;%PATH%
+copy c:\Python35\python.exe c:\Python35\python3.exe
+pip2 install neovim || goto error
+pip3 install neovim || goto error
 
 mkdir .deps
 cd .deps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,9 +478,9 @@ if(BUSTED_PRG)
 
   set(UNITTEST_PREREQS nvim-test unittest-headers)
   if(WIN32)
-    set(FUNCTIONALTEST_PREREQS nvim shell-test)
+    set(FUNCTIONALTEST_PREREQS nvim shell-test printargs)
   else()
-    set(FUNCTIONALTEST_PREREQS nvim tty-test shell-test)
+    set(FUNCTIONALTEST_PREREQS nvim tty-test shell-test printargs)
   endif()
   set(BENCHMARK_PREREQS nvim tty-test)
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6810,19 +6810,14 @@ synstack({lnum}, {col})					*synstack()*
 		valid positions.
 
 system({cmd} [, {input}])				*system()* *E677*
-		Get the output of the shell command {cmd} as a |string|.  {cmd}
+		Get the output of the command {cmd} as a |string|.  {cmd}
 		will be run the same as in |jobstart()|.  See |systemlist()|
 		to get the output as a |List|.
 
-		When {input} is given and is a string this string is written 
-		to a file and passed as stdin to the command.  The string is 
-		written as-is, you need to take care of using the correct line 
-		separators yourself.
-		If {input} is given and is a |List| it is written to the file
-		in a way |writefile()| does with {binary} set to "b" (i.e.
-		with a newline between each list item with newlines inside
-		list items converted to NULs).  
-		Pipes are not used.
+		When {input} is given and is a string it is passed as stdin
+		to the command. If {input} is a |List| it is first converted
+		as |writefile()| does (i.e. with a newline between each list
+		item with newlines inside list items converted to NULs).
 
 		Note: Use |shellescape()| or |::S| with |expand()| or 
 		|fnamemodify()| to escape special characters in a command 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4418,6 +4418,15 @@ jobstart({cmd}[, {opts}])				{Nvim} *jobstart()*
 		only written to show the idea, one needs to perform unquoting 
 		and do split taking quotes into account.
 
+		On Windows, if {cmd} is a list, cmd[0] must be a valid
+		executable (.exe, .com).  If the executable is in your $PATH
+		it can be called by name, with or without an extension: >
+		   :call jobstart(['ping', 'neovim.io'])
+		   :call jobstart(['ping.exe', 'neovim.io'])
+<		However if cmd[0] is a path to an executable it must include
+		the file extension: >
+		   :call jobstart(['c:\Windows\System32\ping.exe', 'neovim.io'])
+<
 		{opts} is a dictionary with these keys:
 		  on_stdout: stdout event handler (function name or |Funcref|)
 		  on_stderr: stderr event handler (function name or |Funcref|)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16043,6 +16043,7 @@ static void get_system_output_as_rettv(typval_T *argvars, typval_T *rettv,
   // get shell command to execute
   char **argv = tv_to_argv(&argvars[0], NULL);
   if (!argv) {
+    set_vim_var_nr(VV_SHELL_ERROR, (long)-1);
     xfree(input);
     return;  // Already did emsg.
   }

--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -19,8 +19,7 @@ bool libuv_process_spawn(LibuvProcess *uvproc)
   Process *proc = (Process *)uvproc;
   uvproc->uvopts.file = proc->argv[0];
   uvproc->uvopts.args = proc->argv;
-  uvproc->uvopts.flags = UV_PROCESS_WINDOWS_HIDE
-                  | UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
+  uvproc->uvopts.flags = UV_PROCESS_WINDOWS_HIDE;
   if (proc->detach) {
       uvproc->uvopts.flags |= UV_PROCESS_DETACHED;
   }

--- a/test/functional/fixtures/CMakeLists.txt
+++ b/test/functional/fixtures/CMakeLists.txt
@@ -2,3 +2,4 @@ add_executable(tty-test tty-test.c)
 target_link_libraries(tty-test ${LIBUV_LIBRARIES})
 
 add_executable(shell-test shell-test.c)
+add_executable(printargs printargs.c)

--- a/test/functional/fixtures/printargs.c
+++ b/test/functional/fixtures/printargs.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+  for (int i=1; i<argc; i++) {
+    printf("arg%d=%s;", i, argv[i]);
+  }
+  return 0;
+}

--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -8,8 +8,6 @@ local eq, clear, eval, feed, nvim =
 
 local Screen = require('test.functional.ui.screen')
 
-if helpers.pending_win32(pending) then return end
-
 local function create_file_with_nuls(name)
   return function()
     feed('ipart1<C-V>000part2<C-V>000part3<ESC>:w '..name..'<CR>')
@@ -33,6 +31,47 @@ end
 
 describe('system()', function()
   before_each(clear)
+
+  describe('command passed as a list', function()
+
+    local printargs_exe = helpers.nvim_dir.."/printargs"
+    if helpers.os_name() == 'windows' then
+      printargs_exe = helpers.nvim_dir.."/printargs.exe"
+    end
+
+    it('quotes arguments correctly', function()
+      local out = helpers.call('system', {printargs_exe, '1', '2 "3'})
+      eq(0, eval('v:shell_error'))
+      eq([[arg1=1;arg2=2 "3;]], out)
+
+      out = helpers.call('system', {printargs_exe, "'1", '2 "3'})
+      eq(0, eval('v:shell_error'))
+      eq([[arg1='1;arg2=2 "3;]], out)
+
+      out = helpers.call('system', {printargs_exe, "A\nB"})
+      eq(0, eval('v:shell_error'))
+      eq("arg1=A\nB;", out)
+    end)
+
+    it('can call an executable in $PATH', function()
+      local cmd
+      if helpers.os_name() == "windows" then
+        cmd = "system(['ping'])"
+      else
+        cmd = "system(['ls'])"
+      end
+      eval(cmd)
+    end)
+
+    it('does not execute &shell', function()
+      if helpers.os_name() ~= 'windows' then
+        eq('* $NOTHING ~/file',
+           eval("system(['echo', '-n', '*', '$NOTHING', '~/file'])"))
+      end
+    end)
+  end)
+
+  if helpers.pending_win32(pending) then return end
 
   it('sets the v:shell_error variable', function()
     eval([[system("sh -c 'exit'")]])
@@ -195,14 +234,9 @@ describe('system()', function()
       end)
     end
   end)
-
-  describe('command passed as a list', function()
-    it('does not execute &shell', function()
-      eq('* $NOTHING ~/file',
-         eval("system(['echo', '-n', '*', '$NOTHING', '~/file'])"))
-    end)
-  end)
 end)
+
+if helpers.pending_win32(pending) then return end
 
 describe('systemlist()', function()
   -- behavior is similar to `system()` but it returns a list instead of a

--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -39,6 +39,11 @@ describe('system()', function()
       printargs_exe = helpers.nvim_dir.."/printargs.exe"
     end
 
+    it('sets the v:shell_error variable', function()
+      helpers.call('system', {'this-should-not-exist'})
+      eq(-1, eval('v:shell_error'))
+    end)
+
     it('quotes arguments correctly', function()
       local out = helpers.call('system', {printargs_exe, '1', '2 "3'})
       eq(0, eval('v:shell_error'))

--- a/test/functional/shell/viml_system_spec.lua
+++ b/test/functional/shell/viml_system_spec.lua
@@ -45,6 +45,10 @@ describe('system()', function()
     end)
 
     it('quotes arguments correctly', function()
+print(printargs_exe)
+for file in lfs.dir(helpers.nvim_dir) do
+print(file)
+end
       local out = helpers.call('system', {printargs_exe, '1', '2 "3'})
       eq(0, eval('v:shell_error'))
       eq([[arg1=1;arg2=2 "3;]], out)


### PR DESCRIPTION
I've made a mess of things with a previous patch that disabled quoting in Windows  This PR reverts it documents windows behaviour, and adds some functional tests.

The goal of the PR to specify, write test and fix system(list)//jobstart(list) in Windows.
### Background

The `system()` function has two variants
- `system(string)` takes the given string and calls the command `&shell &shellcmdflag <string> (give or tag a flag)
- `system(list)` treats the given list as argv and calls the command `list[0] list[1] ...` bypassing the shell. This variant does not exist in Vim.

the current behavior in UNIX is as follows:
- `system("jobs")` works (in a sh like shell)
- `system(["jobs"])` fails with E902: "jobs" is not an executable, because `jobs` is a shell command
- `system(['python_script'])` works because of the shebang, i.e. `execve()` at work.

In Windows, [uv_spawn()](https://github.com/libuv/libuv/blob/b12624c13693c4d29ca84b3556eadc9e9c0936a4/src/win/process.c) calls [CreateProcess()](https://github.com/libuv/libuv/blob/b12624c13693c4d29ca84b3556eadc9e9c0936a4/src/win/process.c). In particular libuv makes sure to pass in `lpApplicationName`. And verifies this value to some extent.
### system(list)

The current behavior (in this PR) of system() when passed a list is as follows.

Running an .exe or .com file in your $PATH with or without the extension works, e.g.

``` vim
system(["ipconfig"])
system(["ipconfig.exe"])
```

When trying to run a program that is not in your $PATH, you need to specify the path including the extension. For example to run `c:\a.exe`, the following examples WILL NOT WORK

```
system(["c:\\a"])
system(["c:/a"])
```

This **DOES NOT** work, because `dir` is a shell command, not a program

``` vim
system(["dir"])
```

The following works but **SHOULD NOT??**.

``` vim
system(["file.bat"])
" this one does not cause an error, but prints nothing, what is it doing?
system(["file.ps1"])
```

`CreateProcess()` states it cannot run .bat files and `uv_spawn()` states it does not check `PATHEXT`. I have found found this [SO question](http://stackoverflow.com/questions/21553379/createprocess-is-able-to-execute-batch-files-but-documentation-says-the-opposit) that runs into the same issue.

I have tried the following in a minimal program
- CreateProcess('test.bat', ...) works
- CreateProcess('test.ps1', ...) fails

At this point I think this behaviour is undocumented and unreliable. I cannot reproduce at all in Appveyor.

Present uses of `system([...])` in runtime:
- system(['lpr']
- system(['copy', v:fname_in, empty(&printdevice)?'LPT1':&printdevice])
- in pythonx.vim to run `python_prog`
- system(['curl', '-sL', "'", a:url, "'"])
- system(['python', '-c', "'", script, "'", '2>/dev/null'])
- nvim heakth
- system([pyenv, 'prefix']))
- jobstart([...]) in clipboard.vim
- similarly for the ruby provider
### system(string)

The work in fixing system('...') is being handled in #2789/ we have functional tests but those need to be fixed for Windows. A comprehensive test suite for system('...') quoting in the windows shell would be a nice addition to that PR.
### Relation to executable()

Meanwhile`os_can_exe()` used by `executable()` actually checks $PATHEXT.
Current behaviour is:
- `executable('no_such_file')` returns 0
- `executable('file')` returns 1 if file.bat or file.exe,etc exists ($PATHEXT)
- `executable('file.bat')`returns 1
- `executable('file.exe')`returns 1
- In UNIX `executable('filename')` only returns 1 if `filename` is in the $PATH
- In UNIX `executable('./filename')` returns 1 if filename has the executable bit

This could lead to the misconception that, `executable("file.bat")` being `1` implies `system(["file.bat"])` is expected to succeed, which is not true. I have not checked runtime in depth, but most of the uses of executable seem to be meant for the shell, which is the right way.

There are unit tests for `os_can_exe()` but unit tests are not working on windows. There are only couple of tests that call `executable()` (grep, terminal buffer). Well handle that in a followup PR.
### Notes
- The `printargs` helper has to be in C, a bat file is not an option, it would cause the shelll to be used, and we want avoid that.
