### PR TITLE
[RFC] man.vim: removed <Plug> mappings

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -23,11 +23,13 @@ function! man#open_page(count, count1, mods, ...) abort
   if a:0 > 2
     call s:error('too many arguments')
     return
-  elseif a:0 ==# 1
-    if empty(a:1)
+  elseif a:0 == 0
+    let ref = &filetype ==# 'man' ? expand('<cWORD>') : expand('<cword>')
+    if empty(ref)
       call s:error('no identifier under cursor')
       return
     endif
+  elseif a:0 ==# 1
     let ref = a:1
   else
     " Combine the name and sect into a manpage reference so that all

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -9,8 +9,7 @@ endif
 let s:man_find_arg = "-w"
 
 " TODO(nhooyr) Completion may work on SunOS; I'm not sure if `man -l` displays
-" the list of searched directories. I also do not think Solaris supports the
-" '-P' flag used above and uses only $PAGER.
+" the list of searched directories.
 try
   if !has('win32') && $OSTYPE !~? 'cygwin\|linux' && system('uname -s') =~? 'SunOS' && system('uname -r') =~# '^5'
     let s:man_find_arg = '-l'

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -529,16 +529,11 @@ Man {sect} {name}({sect}) Used during completion to show the real section of
                           when the provided section is a prefix, e.g. 1m vs 1.
 Man {path}                Open the manpage specified by path. Prepend "./" if
                           page is in the current directory.
+Man                       Open the manpage for the <cWORD> (man buffers)
+                          or <cword> (non-man buffers) under the cursor.
 
 |:Man| accepts command modifiers. For example, to use a vertical split: >
      :vertical Man printf
-
-Global Mappings:
-<Plug>(man)               Jump to the manpage for the <cWORD> (man buffers)
-                          or <cword> (non-man buffers) under the cursor.
-                          Takes a count for the section.
-<Plug>(man_vsplit)        Same as <Plug>(man) but open in a vertical split.
-<Plug>(man_tab)           Same as <Plug>(man) but open in a new tab.
 
 Local mappings:
 K or CTRL-]               Jump to the manpage for the <cWORD> under the

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -43,8 +43,8 @@ setlocal nolist
 setlocal nofoldenable
 
 if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
-  nmap     <silent> <buffer> <C-]>      <Plug>(man)
-  nmap     <silent> <buffer> K          <Plug>(man)
+  nmap     <silent> <buffer> <C-]>      :Man<CR>
+  nmap     <silent> <buffer> K          :Man<CR>
   nnoremap <silent> <buffer> <C-T>      :call man#pop_tag()<CR>
   if s:pager
     nnoremap <silent> <buffer> <nowait> q :q<CR>

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -5,15 +5,7 @@ if exists('g:loaded_man')
 endif
 let g:loaded_man = 1
 
-command! -range=0 -complete=customlist,man#complete -nargs=+ Man call man#open_page(v:count, v:count1, <q-mods>, <f-args>)
-
-function! s:cword() abort
-  return &filetype ==# 'man' ? expand('<cWORD>') : expand('<cword>')
-endfunction
-
-nnoremap <silent> <Plug>(man)        :<C-U>execute 'Man '         .<SID>cword()<CR>
-nnoremap <silent> <Plug>(man_vsplit) :<C-U>execute 'vertical Man '.<SID>cword()<CR>
-nnoremap <silent> <Plug>(man_tab)    :<C-U>execute 'tab Man '     .<SID>cword()<CR>
+command! -range=0 -complete=customlist,man#complete -nargs=* Man call man#open_page(v:count, v:count1, <q-mods>, <f-args>)
 
 augroup man
   autocmd!


### PR DESCRIPTION
As discussed in #5249, if `:Man` handles the `<cWORD>`/`<cword>` dance, then there is no need for the `<Plug>` mappings.
