### PR TITLE
[RFC] Return empty string if no working directory.

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9786,12 +9786,10 @@ static void f_getcwd(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       // The `globaldir` variable is not always set.
       if (globaldir) {
         from = globaldir;
-      } else {
-        // We have to copy the OS path directly into output string.
-        if (os_dirname(cwd, MAXPATHL) == FAIL) {
-          EMSG(_("E41: Could not display path."));
-          goto end;
-        }
+      } else if (os_dirname(cwd, MAXPATHL) == FAIL) {
+        // We had to copy the OS path directly into the output string, but if
+        // that failed we return an empty string.
+        from = (char_u *)"";
       }
       break;
     case kCdScopeInvalid:
@@ -9807,7 +9805,7 @@ static void f_getcwd(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 #ifdef BACKSLASH_IN_FILENAME
   slash_adjust(rettv->vval.v_string);
 #endif
-end:
+
   xfree(cwd);
 }
 

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -269,3 +269,25 @@ for _, cmd in ipairs {'getcwd', 'haslocaldir'} do
   end)
 end
 
+-- Test what happens when a directory does not exist
+describe('Printing the working directory when it does not exist', function ()
+  local temp_dir = 'Xtest-functional-ex_cmds-cd_spec.temp'
+  before_each(function()
+    clear()
+    lfs.mkdir(temp_dir)
+  end)
+
+  after_each(function()
+    lfs.rmdir(temp_dir)
+  end)
+
+  it('returns an empty string', function()
+    execute('cd ' .. temp_dir)
+    helpers.wait()
+    lfs.rmdir(temp_dir)
+    local working_dir = cwd()
+    eq('', working_dir)
+  end)
+end)
+
+


### PR DESCRIPTION
This restores behaviour identical to Vim. If the user calls the VimScript function 'getcwd()' and the working directory cannot be found (for example because the directory has been deleted since the last time it was used) an empty string needs to be returned instead of throwing an error.

I still need to get the test working properly before this PR can be considered final.
