### PR TITLE
shada: close_sd_reader: Check for NULL

### DIFF
--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -708,7 +708,9 @@ static ptrdiff_t write_file(ShaDaWriteDef *const sd_writer,
 static void close_sd_reader(ShaDaReadDef *const sd_reader)
   FUNC_ATTR_NONNULL_ALL
 {
-  close_file(sd_reader->cookie);
+  if (sd_reader->cookie != NULL) {
+    close_file(sd_reader->cookie);
+  }
 }
 
 /// Wrapper for closing file descriptors opened for writing


### PR DESCRIPTION
```
nvim -i /etc/shada
```

will segfault on exit if the file does not exist and user does not have
permissions to create the file at /etc/shada.

Reported in #5277
https://github.com/neovim/neovim/issues/5277#issuecomment-243937255
