### PR TITLE
Fix #5270 syntax folding optimization

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -762,7 +762,7 @@ void clearFolding(win_T *win)
  */
 void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
 {
-  if (compl_busy) {
+  if (compl_busy || State & INSERT) {
     return;
   }
 


### PR DESCRIPTION
- Add compl_busy set in `complete()`
- Ignore folding update if foldmethod is "expr" or "sytax" and in insert mode like FastFold plugin

@phuongnd08 Please test it.

Note:  I will send PR for Vim, too.
