### PR TITLE
syntax: Add support for JavaScript template strings

### DIFF
--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -42,6 +42,7 @@ syn region  javaScriptComment	       start="/\*"  end="\*/" contains=@Spell,java
 syn match   javaScriptSpecial	       "\\\d\d\d\|\\."
 syn region  javaScriptStringD	       start=+"+  skip=+\\\\\|\\"+  end=+"\|$+	contains=javaScriptSpecial,@htmlPreproc
 syn region  javaScriptStringS	       start=+'+  skip=+\\\\\|\\'+  end=+'\|$+	contains=javaScriptSpecial,@htmlPreproc
+syn region  javaScriptStringT	       start=+`+  skip=+\\\\\|\\`+  end=+`+	contains=javaScriptSpecial,@htmlPreproc
 
 syn match   javaScriptSpecialCharacter "'\\.'"
 syn match   javaScriptNumber	       "-\=\<\d\+L\=\>\|0[xX][0-9a-fA-F]\+\>"
@@ -102,6 +103,7 @@ if version >= 508 || !exists("did_javascript_syn_inits")
   HiLink javaScriptSpecial		Special
   HiLink javaScriptStringS		String
   HiLink javaScriptStringD		String
+  HiLink javaScriptStringT		String
   HiLink javaScriptCharacter		Character
   HiLink javaScriptSpecialCharacter	javaScriptSpecial
   HiLink javaScriptNumber		javaScriptValue


### PR DESCRIPTION
Template literals are part of JavaScript since [version ES2015](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).
They add a new way of defining multi-line strings, for example:

``` js
  `string text`

  `line 1
   line 2`

  `string text ${expression} string text`
```

This patch adds syntax support for this new standard, which is currently
not handled by Vim and results in bad `highlight` coloring.
