### PR TITLE
[RFC] eval.c: Garbage collection frees dictionary before job cleanup

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21765,6 +21765,9 @@ static inline bool common_job_start(TerminalJobData *data, typval_T *rettv)
   Process *proc = (Process *)&data->proc;
   if (proc->type == kProcessTypePty && proc->detach) {
     EMSG2(_(e_invarg2), "terminal/pty job cannot be detached");
+    xfree(data->proc.pty.term_name);
+    shell_free_argv(proc->argv);
+    free_term_job_data_event((void **)&data);
     return false;
   }
 


### PR DESCRIPTION
 eval.c: Garbage collection frees dictionary before job cleanup

Removing a job too early from the joblist gives garbage collection the
chance to also remove the job dictionary.

Can be triggered with ASAN while waiting 'updatetime'ms (~5 seconds)
before closing the terminal window opened with:

```
nvim -u NONE +'call termopen("true",{})'
```
