### PR TITLE
build/OpenBSD: disable jemalloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,12 @@ if((CLANG_ASAN_UBSAN OR CLANG_MSAN OR CLANG_TSAN) AND NOT CMAKE_C_COMPILER_ID MA
   message(FATAL_ERROR "Sanitizers are only supported for Clang.")
 endif()
 
-option(ENABLE_JEMALLOC "enable jemalloc" ON)
+if(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+  message(STATUS "detected OpenBSD; disabled jemalloc. #5318")
+  option(ENABLE_JEMALLOC "enable jemalloc" OFF)
+else()
+  option(ENABLE_JEMALLOC "enable jemalloc" ON)
+endif()
 
 if (ENABLE_JEMALLOC)
   if(CLANG_ASAN_UBSAN OR CLANG_MSAN OR CLANG_TSAN)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -120,9 +120,14 @@ if(NOT MSVC)
   set_source_files_properties(
     ${CONV_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-conversion")
   # gperf generates ANSI-C with incorrect linkage, ignore it.
-  set_source_files_properties(
-    eval.c PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-static-in-inline -Wno-conversion")
-
+  check_c_compiler_flag(-Wno-static-in-inline HAS_WNO_STATIC_IN_INLINE_FLAG)
+  if(HAS_WNO_STATIC_IN_INLINE_FLAG)
+    set_source_files_properties(
+      eval.c PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-static-in-inline -Wno-conversion")
+  else()
+    set_source_files_properties(
+      eval.c PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-conversion")
+  endif()
 endif()
 
 if(DEFINED MIN_LOG_LEVEL)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -114,8 +114,8 @@ set(LIBVTERM_SHA256 1a4272be91d9614dc183a503786df83b6584e4afaab7feaaa5409f841afb
 set(JEMALLOC_URL https://github.com/jemalloc/jemalloc/releases/download/4.2.1/jemalloc-4.2.1.tar.bz2)
 set(JEMALLOC_SHA256 5630650d5c1caab95d2f0898de4fe5ab8519dc680b04963b38bb425ef6a42d57)
 
-set(LUV_URL https://github.com/luvit/luv/archive/146f1ce4c08c3b67f604c9ee1e124b1cf5c15cf3.tar.gz)
-set(LUV_SHA256 3d537f8eb9fa5adb146a083eae22af886aee324ec268e2aa0fa75f2f1c52ca7a)
+set(LUV_URL https://github.com/luvit/luv/archive/1.9.1-0.tar.gz)
+set(LUV_SHA256 86a199403856018cd8e5529c8527450c83664a3d36f52d5253cbe909ea6c5a06)
 
 set(GPERF_URL http://ftp.gnu.org/pub/gnu/gperf/gperf-3.0.4.tar.gz)
 set(GPERF_SHA256 767112a204407e62dbc3106647cf839ed544f3cf5d0f0523aaa2508623aad63e)


### PR DESCRIPTION
1. Disable default use of jemalloc for OpenBSD (#3434)
2. Guard use of compiler flag `-Wno-static-in-inline` (#5300). The wiki build requirements list gcc 4.4 as minimum. OpenBSD ships a modified 4.2. If this flag is the only reason for 4.4, then we can just guard it.
3. Bump luv dependency, earlier versions failed to build in OpenBSD.https://github.com/luvit/luv/pull/232

Fixes #4620. Ping @bonds.
