### PR TITLE
vim-patch:7.4.1533

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -59,10 +59,6 @@ void nvim_feedkeys(String keys, String mode, Boolean escape_csi)
   bool typed = false;
   bool execute = false;
 
-  if (keys.size == 0) {
-    return;
-  }
-
   for (size_t i = 0; i < mode.size; ++i) {
     switch (mode.data[i]) {
     case 'n': remap = false; break;
@@ -71,6 +67,10 @@ void nvim_feedkeys(String keys, String mode, Boolean escape_csi)
     case 'i': insert = true; break;
     case 'x': execute = true; break;
     }
+  }
+
+  if (keys.size == 0 && !execute) {
+    return;
   }
 
   char *keys_esc;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8831,14 +8831,13 @@ static void f_feedkeys(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
 
   keys = get_tv_string(&argvars[0]);
-  if (*keys != NUL) {
-    if (argvars[1].v_type != VAR_UNKNOWN) {
-      flags = get_tv_string_buf(&argvars[1], nbuf);
-    }
 
-    nvim_feedkeys(cstr_as_string((char *)keys),
-                  cstr_as_string((char *)flags), true);
+  if (argvars[1].v_type != VAR_UNKNOWN) {
+    flags = get_tv_string_buf(&argvars[1], nbuf);
   }
+
+  nvim_feedkeys(cstr_as_string((char *)keys),
+                cstr_as_string((char *)flags), true);
 }
 
 /// "filereadable()" function

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -3,6 +3,7 @@
 
 source test_assign.vim
 source test_cursor_func.vim
+source test_feedkeys.vim
 source test_cmdline.vim
 source test_menu.vim
 source test_popup.vim

--- a/src/nvim/testdir/test_feedkeys.vim
+++ b/src/nvim/testdir/test_feedkeys.vim
@@ -1,0 +1,10 @@
+" Test feedkeys() function.
+
+func Test_feedkeys_x_with_empty_string()
+  new
+  call feedkeys("ifoo\<Esc>")
+  call assert_equal('', getline('.'))
+  call feedkeys('', 'x')
+  call assert_equal('foo', getline('.'))
+  quit!
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -745,7 +745,7 @@ static int included_patches[] = {
   // 1536 NA
   // 1535,
   // 1534 NA
-  // 1533,
+  1533,
   // 1532 NA
   // 1531 NA
   // 1530 NA


### PR DESCRIPTION
Problem:    Using feedkeys() with an empty string disregards 'x' option.
Solution:   Make 'x' work with an empty string. (Thinca)

When integrating the patch to nvim, used same logic but different code
based on nvim codebase. New test passed.

https://github.com/vim/vim/commit/74c5bbf13435a7ab1e3461078bbcb1200f0451e1
