### PR TITLE
vim-patch:7.4.1535

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -92,7 +92,12 @@ void nvim_feedkeys(String keys, String mode, Boolean escape_csi)
     typebuf_was_filled = true;
   }
   if (execute) {
+    int save_msg_scroll = msg_scroll;
+
+    /* Avoid a 1 second delay when the keys start Insert mode. */
+    msg_scroll = false;
     exec_normal(true);
+    msg_scroll |= save_msg_scroll;
   }
 }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -743,7 +743,7 @@ static int included_patches[] = {
   // 1538 NA
   // 1537 NA
   // 1536 NA
-  // 1535,
+  1535,
   // 1534 NA
   1533,
   // 1532 NA


### PR DESCRIPTION
Problem:    The feedkeys test has a one second delay.
Solution:   Avoid need_wait_return() to delay. (Hirohito Higashi)

https://github.com/vim/vim/commit/9e496854a9fe56699687a4f86003fad115b3b375
