### PR TITLE
[RFC] man.vim: prevent bell in ':wincmd w' when only one window

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -176,6 +176,8 @@ endfunction
 function! s:find_man() abort
   if &filetype ==# 'man'
     return 1
+  elseif winnr('$') ==# 1
+    return 0
   endif
   let thiswin = winnr()
   while 1


### PR DESCRIPTION
@HiPhish on gitter said there was a bell that rang with the new man plugin. I never noticed because I had bells disabled in my vim and I think other people did as well. He isolated the problem to `:wincmd w` when there was only one window in `s:find_man`. So now if there is only one window, we don't try to cycle through them all, instead we know that there is no man window because we already checked if the current window is a man window.
