### PR TITLE
vim-patch:7.4.1558

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2148,6 +2148,7 @@ values({dict})			List	values in {dict}
 virtcol({expr})		Number	screen column of cursor or mark
 visualmode([expr])		String	last visual mode used
 wildmenumode()			Number	whether 'wildmenu' mode is active
+win_findbuf( {bufnr}) 		List	find windows containing {bufnr}
 win_getid( [{win} [, {tab}]])   Number  get window ID for {win} in {tab}
 win_gotoid( {expr})             Number  go to window with ID {expr}
 win_id2tabwin( {expr})          List    get tab window nr from window ID
@@ -7233,6 +7234,10 @@ wildmenumode()					*wildmenumode()*
 <
 		(Note, this needs the 'wildcharm' option set appropriately).
 
+
+win_findbuf({bufnr})					*win_findbuf()*
+		Returns a list with window IDs for windows that contain buffer
+		{bufnr}.  When there is none the list is empty.
 
 win_getid([{win} [, {tab}]])				*win_getid()*
 		Get the window ID for the specified window.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16768,6 +16768,14 @@ static void f_wildmenumode(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     rettv->vval.v_number = 1;
 }
 
+/// "win_findbuf()" function
+static void f_win_findbuf(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  if (rettv_list_alloc(rettv) != FAIL) {
+    win_findbuf(argvars, rettv->vval.v_list);
+  }
+}
+
 /// "win_getid()" function
 static void f_win_getid(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -310,6 +310,7 @@ return {
     virtcol={args=1},
     visualmode={args={0, 1}},
     wildmenumode={},
+    win_findbuf={args=1},
     win_getid={args={0,2}},
     win_gotoid={args=1},
     win_id2tabwin={args=1},

--- a/src/nvim/testdir/test_window_id.vim
+++ b/src/nvim/testdir/test_window_id.vim
@@ -5,6 +5,7 @@ func Test_win_getid()
   let id1 = win_getid()
   split two
   let id2 = win_getid()
+  let bufnr2 = bufnr('%')
   split three
   let id3 = win_getid()
   tabnew
@@ -12,6 +13,7 @@ func Test_win_getid()
   let id4 = win_getid()
   split five
   let id5 = win_getid()
+  let bufnr5 = bufnr('%')
   tabnext
 
   wincmd w
@@ -66,6 +68,12 @@ func Test_win_getid()
   call assert_equal([0, 0], win_id2tabwin(9999))
   call assert_equal([1, nr2], win_id2tabwin(id2))
   call assert_equal([2, nr4], win_id2tabwin(id4))
+
+  call assert_equal([], win_findbuf(9999))
+  call assert_equal([id2], win_findbuf(bufnr2))
+  call win_gotoid(id5)
+  split
+  call assert_equal(sort([id5, win_getid()]), sort(win_findbuf(bufnr5)))
 
   only!
 endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -720,7 +720,7 @@ static int included_patches[] = {
   // 1561 NA
   // 1560 NA
   // 1559,
-  // 1558,
+  1558,
   1557,
   // 1556 NA
   // 1555 NA

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5771,3 +5771,17 @@ int win_id2win(typval_T *argvars)
   }
   return 0;
 }
+
+void win_findbuf(typval_T *argvars, list_T *list)
+{
+  int bufnr = get_tv_number(&argvars[0]);
+
+  for (tabpage_T *tp = first_tabpage; tp != NULL; tp = tp->tp_next) {
+    for (win_T *wp = tp == curtab ? firstwin : tp->tp_firstwin;
+         wp != NULL; wp = wp->w_next) {
+      if (wp->w_buffer->b_fnum == bufnr) {
+        list_append_number(list, wp->handle);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Problem:    It is not easy to find out what windows display a buffer.
Solution:   Add win_findbuf().

https://github.com/vim/vim/commit/9cdf86b86f5fdb5a45b682f336846f9d9a9c6f1f
