### PR TITLE
[RFC] api: remove unneccessary initializations in dispatch

### DIFF
--- a/scripts/gendispatch.lua
+++ b/scripts/gendispatch.lua
@@ -218,7 +218,7 @@ for i = 1, #functions do
     for j = 1, #fn.parameters do
       local param = fn.parameters[j]
       local converted = 'arg_'..j
-      output:write('\n  '..param[1]..' '..converted..' api_init_'..string.lower(real_type(param[1]))..';')
+      output:write('\n  '..param[1]..' '..converted..';')
     end
     output:write('\n')
     output:write('\n  if (args.size != '..#fn.parameters..') {')


### PR DESCRIPTION
Left over change from https://github.com/neovim/neovim/pull/4934/commits/acb7c826b3df50bd9825baf3b2ffaaa79c8b80df. These initializations are now never
used and causes warnings in static analysis. Found by @fwalch, ref neovim/bot-ci/issues/88
