### PR TITLE
tests/ui: Stop the terminal job after testing

### DIFF
--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -30,12 +30,12 @@ describe("shell command :!", function()
     --       to avoid triggering a UI flush.
     child_session.feed_data(":!printf foo; sleep 200\n")
     screen:expect([[
-      {1: }                                                 |
-      {4:~                                                 }|
       {4:~                                                 }|
       {4:~                                                 }|
       {5:[No Name]                                         }|
+      :!printf foo; sleep 200                           |
                                                         |
+      foo                                               |
       {3:-- TERMINAL --}                                    |
     ]])
   end)

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -21,6 +21,7 @@ describe("shell command :!", function()
   end)
 
   after_each(function()
+    child_session.feed_data("\3") -- Ctrl-C
     screen:detach()
   end)
 


### PR DESCRIPTION
When running the tests in a contained environment, the lingering
terminal processes prevent the unmounting of the filesystems in the
contained environment.
