### PR TITLE
eval.c: Clean up spurious FAIL checks.

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9668,12 +9668,11 @@ static void f_getcompletion(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   pat = addstar(xpc.xp_pattern, xpc.xp_pattern_len, xpc.xp_context);
-  if ((rettv_list_alloc(rettv) != FAIL) && (pat != NULL)) {
-    int i;
-
+  rettv_list_alloc(rettv);
+  if (pat != NULL) {
     ExpandOne(&xpc, pat, NULL, options, WILD_ALL_KEEP);
 
-    for (i = 0; i < xpc.xp_numfiles; i++) {
+    for (int i = 0; i < xpc.xp_numfiles; i++) {
       list_append_string(rettv->vval.v_list, xpc.xp_files[i], -1);
     }
   }
@@ -16771,9 +16770,8 @@ static void f_wildmenumode(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "win_findbuf()" function
 static void f_win_findbuf(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  if (rettv_list_alloc(rettv) != FAIL) {
-    win_findbuf(argvars, rettv->vval.v_list);
-  }
+  rettv_list_alloc(rettv);
+  win_findbuf(argvars, rettv->vval.v_list);
 }
 
 /// "win_getid()" function
@@ -16791,9 +16789,8 @@ static void f_win_gotoid(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "win_id2tabwin()" function
 static void f_win_id2tabwin(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  if (rettv_list_alloc(rettv) != FAIL) {
-    win_id2tabwin(argvars, rettv->vval.v_list);
-  }
+  rettv_list_alloc(rettv);
+  win_id2tabwin(argvars, rettv->vval.v_list);
 }
 
 /// "win_id2win()" function


### PR DESCRIPTION
rettv_list_alloc cannot fail.
