### PR TITLE
Fix fold update problem

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -462,6 +462,8 @@ static void insert_enter(InsertState *s)
     o_lnum = curwin->w_cursor.lnum;
   }
 
+  foldUpdateAll(curwin);
+  foldOpenCursor();
   if (s->cmdchar != 'r' && s->cmdchar != 'v') {
     apply_autocmds(EVENT_INSERTLEAVE, NULL, NULL, false, curbuf);
   }

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -761,16 +761,12 @@ void clearFolding(win_T *win)
  */
 void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
 {
-  if (compl_busy || State & INSERT) {
-    return;
-  }
-
-  fold_T      *fp;
-  if (wp->w_buffer->terminal) {
+  if (compl_busy || State & INSERT || wp->w_buffer->terminal) {
     return;
   }
 
   // Mark all folds from top to bot as maybe-small.
+  fold_T      *fp;
   (void)foldFind(&wp->w_folds, top, &fp);
   while (fp < (fold_T *)wp->w_folds.ga_data + wp->w_folds.ga_len
          && fp->fd_top < bot) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5924,6 +5924,9 @@ static void nv_replace(cmdarg_T *cap)
     curwin->w_set_curswant = true;
     set_last_insert(cap->nchar);
   }
+
+  foldUpdateAll(curwin);
+  foldOpenCursor();
 }
 
 /*


### PR DESCRIPTION
I have fixed fold update problem.
The fold is updated in insertleave or `nv_replace` if the update is skipped.
It fixes #5299 test failures.

Note: `nv_replace` is normal-mode `r` implementation.
It enters insert mode and change text.
So, the fix is needed...
