### PR TITLE
[RFC] vim-patch:7.4.1670

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2684,6 +2684,10 @@ void set_context_for_expression(expand_T *xp, char_u *arg, cmdidx_T cmdidx)
     } else if (c == '=') {
       got_eq = TRUE;
       xp->xp_context = EXPAND_EXPRESSION;
+    } else if (c == '#'
+               && xp->xp_context == EXPAND_EXPRESSION) {
+      // Autoload function/variable contains '#'
+      break;
     } else if ((c == '<' || c == '#')
                && xp->xp_context == EXPAND_FUNCTIONS
                && vim_strchr(xp->xp_pattern, '(') == NULL) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -773,7 +773,7 @@ static int included_patches[] = {
   1673,
   // 1672 NA
   // 1671,
-  // 1670,
+  1670,
   // 1669 NA
   // 1668 NA
   // 1667 NA


### PR DESCRIPTION
Problem:    Completion doesn't work well for a variable containing "vim/vim#".
Solution:   Recognize the "vim/vim#". (Watiko)

https://github.com/vim/vim/commit/a32095fc8fdf5fe3d487c86d9cc54adb1236731e
