### PR TITLE
test: helpers.rmdir(): retry+sleep on failure

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -424,15 +424,15 @@ local function do_rmdir(path)
       end
     end
   end
-  local ret, err = os.remove(path)
+  local ret, err = lfs.rmdir(path)
   if not ret then
-    error('os.remove: '..err)
+    error('lfs.rmdir('..path..'): '..err)
   end
   return ret
 end
 
 local function rmdir(path)
-  local ret, err = pcall(do_rmdir, path)
+  local ret, _ = pcall(do_rmdir, path)
   -- During teardown, the nvim process may not exit quickly enough, then rmdir()
   -- will fail (on Windows).
   if not ret then  -- Try again.

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -376,8 +376,8 @@ local function wait()
 end
 
 -- sleeps the test runner (_not_ the nvim instance)
-local function sleep(timeout)
-  run(nil, nil, nil, timeout)
+local function sleep(ms)
+  run(nil, nil, nil, ms)
 end
 
 local function curbuf_contents()
@@ -403,7 +403,7 @@ local function expect(contents)
   return eq(dedent(contents), curbuf_contents())
 end
 
-local function rmdir(path)
+local function do_rmdir(path)
   if lfs.attributes(path, 'mode') ~= 'directory' then
     return nil
   end
@@ -411,7 +411,7 @@ local function rmdir(path)
     if file ~= '.' and file ~= '..' then
       local abspath = path..'/'..file
       if lfs.attributes(abspath, 'mode') == 'directory' then
-        local ret = rmdir(abspath)  -- recurse
+        local ret = do_rmdir(abspath)  -- recurse
         if not ret then
           return nil
         end
@@ -429,6 +429,16 @@ local function rmdir(path)
     error('os.remove: '..err)
   end
   return ret
+end
+
+local function rmdir(path)
+  local ret, err = pcall(do_rmdir, path)
+  -- During teardown, the nvim process may not exit quickly enough, then rmdir()
+  -- will fail (on Windows).
+  if not ret then  -- Try again.
+    sleep(1000)
+    do_rmdir(path)
+  end
 end
 
 local exc_exec = function(cmd)

--- a/test/functional/legacy/012_directory_spec.lua
+++ b/test/functional/legacy/012_directory_spec.lua
@@ -53,27 +53,21 @@ describe("'directory' option", function()
     execute('set dir=.,~')
 
     -- sanity check: files should not exist yet.
-    eq(nil, lfs.attributes('.Xtest1.swp')) -- unix
-    eq(nil, lfs.attributes('Xtest1.swp'))  -- non-unix
+    eq(nil, lfs.attributes('.Xtest1.swp'))
 
     execute('e! Xtest1')
     wait()
     eq('Xtest1', eval('buffer_name("%")'))
     -- Verify that the swapfile exists. In the legacy test this was done by
     -- reading the output from :!ls.
-    if eval('has("unix")') == 1 then
-      neq(nil, lfs.attributes('.Xtest1.swp'))
-    else
-      neq(nil, lfs.attributes('Xtest1.swp'))
-    end
+    neq(nil, lfs.attributes('.Xtest1.swp'))
 
     execute('set dir=./Xtest2,.,~')
     execute('e Xtest1')
     wait()
 
     -- swapfile should no longer exist in CWD.
-    eq(nil, lfs.attributes('.Xtest1.swp')) -- unix
-    eq(nil, lfs.attributes('Xtest1.swp'))  -- non-unix
+    eq(nil, lfs.attributes('.Xtest1.swp'))
 
     eq({ "Xtest1.swp", "Xtest3" }, ls_dir_sorted("Xtest2"))
 

--- a/test/functional/legacy/012_directory_spec.lua
+++ b/test/functional/legacy/012_directory_spec.lua
@@ -36,6 +36,7 @@ describe("'directory' option", function()
     clear()
   end)
   teardown(function()
+    execute('qall!')
     helpers.rmdir('Xtest.je')
     helpers.rmdir('Xtest2')
     os.remove('Xtest1')
@@ -71,15 +72,14 @@ describe("'directory' option", function()
     wait()
 
     -- swapfile should no longer exist in CWD.
-    eq(nil, lfs.attributes('.Xtest1.swp')) -- for unix
-    eq(nil, lfs.attributes('Xtest1.swp'))  -- for other systems
+    eq(nil, lfs.attributes('.Xtest1.swp')) -- unix
+    eq(nil, lfs.attributes('Xtest1.swp'))  -- non-unix
 
     eq({ "Xtest1.swp", "Xtest3" }, ls_dir_sorted("Xtest2"))
 
     execute('set dir=Xtest.je,~')
     execute('e Xtest2/Xtest3')
     eq(1, eval('&swapfile'))
-    execute('swap')
     wait()
 
     eq({ "Xtest3" }, ls_dir_sorted("Xtest2"))

--- a/test/functional/legacy/031_close_commands_spec.lua
+++ b/test/functional/legacy/031_close_commands_spec.lua
@@ -19,7 +19,18 @@ local expect = helpers.expect
 local execute = helpers.execute
 
 describe('Commands that close windows and/or buffers', function()
-  setup(clear)
+  local function cleanup()
+    os.remove('Xtest1')
+    os.remove('Xtest2')
+    os.remove('Xtest3')
+  end
+  setup(function()
+    cleanup()
+    clear()
+  end)
+  teardown(function()
+    cleanup()
+  end)
 
   it('is working', function()
     insert('testtext')
@@ -111,11 +122,5 @@ describe('Commands that close windows and/or buffers', function()
       q!
       " Now nvim should have exited
       throw "Oh, Not finished yet."]])
-  end)
-
-  teardown(function()
-    os.remove('Xtest1')
-    os.remove('Xtest2')
-    os.remove('Xtest3')
   end)
 end)


### PR DESCRIPTION
Also use `lfs.rmdir()` instead of `os.remove()`. see keplerproject/luafilesystem#4

Closes #5236

These changes attempt to avoid "Permission denied" on Windows during test teardowns.
