### PR TITLE
[RFC] vim-patch:7.4.1309

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -24,6 +24,10 @@
 "
 " If cleanup after each Test_ function is needed, define a TearDown function.
 " It will be called after each Test_ function.
+"
+" When debugging a test it can be useful to add messages to v:errors:
+" 	call add(v:errors, "this happened")
+
 
 " Check that the screen size is at least 24 x 80 characters.
 if &lines < 24 || &columns < 80 
@@ -48,17 +52,17 @@ lang mess C
 set shellslash
 
 function RunTheTest(test)
-  echo 'Executing ' . test
+  echo 'Executing ' . a:test
   if exists("*SetUp")
     call SetUp()
   endif
 
-  call add(s:messages, 'Executing ' . test)
+  call add(s:messages, 'Executing ' . a:test)
   let s:done += 1
   try
-    exe 'call ' . test
+    exe 'call ' . a:test
   catch
-    call add(v:errors, 'Caught exception in ' . test . ': ' . v:exception . ' @ ' . v:throwpoint)
+    call add(v:errors, 'Caught exception in ' . a:test . ': ' . v:exception . ' @ ' . v:throwpoint)
   endtry
 
   if exists("*TearDown")
@@ -67,21 +71,21 @@ function RunTheTest(test)
 endfunc
 
 " Source the test script.  First grab the file name, in case the script
-" navigates away.
-let testname = expand('%')
-let done = 0
-let fail = 0
-let errors = []
-let messages = []
+" navigates away.  g:testname can be used by the tests.
+let g:testname = expand('%')
+let s:done = 0
+let s:fail = 0
+let s:errors = []
+let s:messages = []
 if expand('%') =~ 'test_viml.vim'
-  " this test has intentional errors, don't use try/catch.
+  " this test has intentional s:errors, don't use try/catch.
   source %
 else
   try
     source %
   catch
-    let fail += 1
-    call add(errors, 'Caught exception: ' . v:exception . ' @ ' . v:throwpoint)
+    let s:fail += 1
+    call add(s:errors, 'Caught exception: ' . v:exception . ' @ ' . v:throwpoint)
   endtry
 endif
 
@@ -93,61 +97,62 @@ set nomore
 redir @q
 silent function /^Test_
 redir END
-let tests = split(substitute(@q, 'function \(\k*()\)', '\1', 'g'))
+let s:tests = split(substitute(@q, 'function \(\k*()\)', '\1', 'g'))
 
 " If there is an extra argument filter the function names against it.
 if argc() > 1
-  let tests = filter(tests, 'v:val =~ argv(1)')
+  let s:tests = filter(s:tests, 'v:val =~ argv(1)')
 endif
 
 " Execute the tests in alphabetical order.
-for test in sort(tests)
-  call RunTheTest(test)
+for s:test in sort(s:tests)
+  call RunTheTest(s:test)
 
-  if len(v:errors) > 0 && index(flaky, test) >= 0
+  if len(v:errors) > 0 && index(flaky, s:test) >= 0
 		call add(messages, 'Flaky test failed, running it again')
 		let v:errors = []
-		call RunTheTest(test)
+		call RunTheTest(s:test)
 	endif
 
   if len(v:errors) > 0
-    let fail += 1
-    call add(errors, 'Found errors in ' . test . ':')
-    call extend(errors, v:errors)
+    let s:fail += 1
+    call add(s:errors, 'Found errors in ' . s:test . ':')
+    call extend(s:errors, v:errors)
     let v:errors = []
   endif
 
 endfor
 
-if fail == 0
+if s:fail == 0
   " Success, create the .res file so that make knows it's done.
-  exe 'split ' . fnamemodify(testname, ':r') . '.res'
+  exe 'split ' . fnamemodify(g:testname, ':r') . '.res'
   write
 endif
 
-if len(errors) > 0
+if len(s:errors) > 0
   " Append errors to test.log
   split test.log
   call append(line('$'), '')
-  call append(line('$'), 'From ' . testname . ':')
-  call append(line('$'), errors)
+  call append(line('$'), 'From ' . g:testname . ':')
+  call append(line('$'), s:errors)
   write
 endif
 
-let message = 'Executed ' . done . (done > 1 ? ' tests': ' test')
+let message = 'Executed ' . s:done . (s:done > 1 ? ' tests': ' test')
 echo message
-call add(messages, message)
-if fail > 0
-  let message = fail . ' FAILED'
+call add(s:messages, message)
+if s:fail > 0
+  let message = s:fail . ' FAILED'
   echo message
-  call add(messages, message)
+  call add(s:messages, message)
+  call extend(s:messages, s:errors)
 endif
 
 " Append messages to "messages"
-split messages
+split s:messages
 call append(line('$'), '')
-call append(line('$'), 'From ' . testname . ':')
-call append(line('$'), messages)
+call append(line('$'), 'From ' . g:testname . ':')
+call append(line('$'), s:messages)
 write
 
 qall!


### PR DESCRIPTION
#### vim-patch:7.4.1309

Problem:    When a test fails not all relevant info is listed.
Solution:   Add the errors to the messages.

https://github.com/vim/vim/commit/00af60bbb6cc7e8ccafddb30a1964f891b800bce

7.4.1309 was incorrectly marked as applied in #4301.  7.4.1477 relies on
some of the changes that had been made in 7.4.1309, so this fixes the
build after I, pre-emptively, merged #5038.
