### PR TITLE
[RFC] window.c: Fix winframe_remove height calc

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2177,8 +2177,10 @@ winframe_remove (
         }
       }
     }
-    frame_new_height(frp2, frp2->fr_height + frp_close->fr_height,
-        frp2 == frp_close->fr_next ? TRUE : FALSE, FALSE);
+    frame_new_height(frp2,
+                     frp2->fr_height + frp_close->fr_height + (
+                         (!win->w_status_height) ? STATUS_HEIGHT : 0),
+                     frp2 == frp_close->fr_next, false);
     *dirp = 'v';
   } else {
     /* When 'winfixwidth' is set, try to find another frame in the column


### PR DESCRIPTION
When the status_height of a window is `0` make sure to add `STATUS_HEIGHT`
to the new height of the frame.

Passes `lint` and `scan-build`. Comments and critiques are always
welcome!

Fixes: #5354
