### PR TITLE
ci: .travis.yml: Upgrade to macOS 10.11 / xcode7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: c
 
+# macOS 10.11
+osx_image: xcode7.3
+
 env:
   global:
     # To force rebuilding of third-party dependencies, set this to 'true'.


### PR DESCRIPTION
Update to a recent, but not bleeding-edge, version of macOS and xcode.
At present, travis defaults to OS X 10.9.5 / Xcode 6.1.
QuickBuild runs macOS 10.10.
