### PR TITLE
ci: osx: Run "brew update" twice, as recommended by Homebrew docs

### DIFF
--- a/.ci/before_install.sh
+++ b/.ci/before_install.sh
@@ -9,6 +9,7 @@ fi
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   brew update
+  brew update
 fi
 
 echo "Upgrade Python 2's pip."


### PR DESCRIPTION
Running a test to see if this has any impact on the current "brew python3" failures.
