### PR TITLE
[RFC] restore changed ui_try_resize metadata and filter metadata attributes

### DIFF
--- a/scripts/gendispatch.lua
+++ b/scripts/gendispatch.lua
@@ -111,14 +111,20 @@ end
 local deprecated_aliases = require("api.dispatch_deprecated")
 for i,f in ipairs(shallowcopy(functions)) do
   local ismethod = false
-  if startswith(f.name, "nvim_buf_") then
-    ismethod = true
-  elseif startswith(f.name, "nvim_win_") then
-    ismethod = true
-  elseif startswith(f.name, "nvim_tabpage_") then
-    ismethod = true
-  elseif not startswith(f.name, "nvim_") then
+  if startswith(f.name, "nvim_") then
+    -- TODO(bfredl) after 0.1.6 allow method definitions
+    -- to specify the since and deprecated_since field
+    f.since = 1
+    if startswith(f.name, "nvim_buf_") then
+      ismethod = true
+    elseif startswith(f.name, "nvim_win_") then
+      ismethod = true
+    elseif startswith(f.name, "nvim_tabpage_") then
+      ismethod = true
+    end
+  else
     f.noeval = true
+    f.since = 0
     f.deprecated_since = 1
   end
   f.method = ismethod
@@ -140,6 +146,7 @@ for i,f in ipairs(shallowcopy(functions)) do
     end
     newf.impl_name = f.name
     newf.noeval = true
+    newf.since = 0
     newf.deprecated_since = 1
     functions[#functions+1] = newf
   end

--- a/scripts/gendispatch.lua
+++ b/scripts/gendispatch.lua
@@ -133,6 +133,11 @@ for i,f in ipairs(shallowcopy(functions)) do
     end
     local newf = shallowcopy(f)
     newf.name = newname
+    if newname == "ui_try_resize" then
+      -- The return type was incorrectly set to Object in 0.1.5.
+      -- Keep it that way for clients that rely on this.
+      newf.return_type = "Object"
+    end
     newf.impl_name = f.name
     newf.noeval = true
     newf.deprecated_since = 1


### PR DESCRIPTION
Fixes #5388, also I think some metadata attributes that are meant for internal use should not be exposed in `nvim_get_api_info` and `api_info()`. I don't think neither `async` nor `receives_channel_id` is interesting for an api user, but if someone is already using them, I could add them back.
