### PR TITLE
add description of `NVIM_LOG_FILE` environment variable to man

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -391,6 +391,9 @@ See
 in the
 .Xr tmux 1
 manual page for more information.
+.It Ev NVIM_LOG_FILE
+Path to log file, defaulted to
+.Pa ~/.nvimlog
 .El
 .Sh FILES
 .Bl -tag -width "~/.config/nvim/init.vim"


### PR DESCRIPTION
`NVIM_LOG_FILE` does not seem mentioned anywhere.
