### PR TITLE
Correct logic for setting NormalState.toplevel

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -459,7 +459,7 @@ void normal_enter(bool cmdwin, bool noexmode)
   normal_state_init(&state);
   state.cmdwin = cmdwin;
   state.noexmode = noexmode;
-  state.toplevel = !cmdwin && !noexmode;
+  state.toplevel = (!cmdwin || cmdwin_result == 0) && !noexmode;
   state_enter(&state.state);
 }
 
@@ -1360,7 +1360,7 @@ static int normal_check(VimState *state)
   // Dict internally somewhere.
   // "may_garbage_collect" is reset in vgetc() which is invoked through
   // do_exmode() and normal_cmd().
-  may_garbage_collect = s->toplevel;
+  may_garbage_collect = !s->cmdwin && !s->noexmode;
 
   // Update w_curswant if w_set_curswant has been set.
   // Postponed until here to avoid computing w_virtcol too often.

--- a/test/functional/normal/count_spec.lua
+++ b/test/functional/normal/count_spec.lua
@@ -1,0 +1,39 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local eq = helpers.eq
+local eval = helpers.eval
+local feed = helpers.feed
+local clear = helpers.clear
+local execute = helpers.execute
+
+describe('v:count/v:count1', function()
+  before_each(function()
+    clear()
+
+    execute('map <silent> _x :<C-u>let g:count = "v:count=". v:count .", v:count1=". v:count1<CR>')
+  end)
+
+  describe('in cmdwin', function()
+    it('equal 0/1 when no count is given', function()
+      feed('q:_x')
+      eq('v:count=0, v:count1=1', eval('g:count'))
+    end)
+
+    it('equal 2/2 when count of 2 is given', function()
+      feed('q:2_x')
+      eq('v:count=2, v:count1=2', eval('g:count'))
+    end)
+  end)
+
+  describe('in normal mode', function()
+    it('equal 0/1 when no count is given', function()
+      feed('_x')
+      eq('v:count=0, v:count1=1', eval('g:count'))
+    end)
+
+    it('equal 2/2 when count of 2 is given', function()
+      feed('2_x')
+      eq('v:count=2, v:count1=2', eval('g:count'))
+    end)
+  end)
+end)


### PR DESCRIPTION
In Vim's main_loop function, the main loop is

```
    while (!cmdwin
#ifdef FEAT_CMDWIN
            || cmdwin_result == 0
#endif
            )
    {
...
#ifdef FEAT_EVAL
        /*
         * May perform garbage collection when waiting for a character, but
         * only at the very toplevel.  Otherwise we may be using a List or
         * Dict internally somewhere.
         * "may_garbage_collect" is reset in vgetc() which is invoked through
         * do_exmode() and normal_cmd().
         */
        may_garbage_collect = (!cmdwin && !noexmode);
#endif
        /*
         * If we're invoked as ex, do a round of ex commands.
         * Otherwise, get and execute a normal mode command.
         */
        if (exmode_active)
        {
            if (noexmode)   /* End of ":global/path/visual" commands */
                return;
            do_exmode(exmode_active == EXMODE_VIM);
        }
        else
            normal_cmd(&oa, TRUE);
    }
```

cmdwin_result is set to 0 before calling main_loop to handle the cmdwin
window and gets changed when the user causes a command to execute
(either through pressing <CR> or <C-c>).  This means that when the
cmdwin isn't active OR the user is still editing their command,
main_loop runs and main_loop calls normal_cmd with toplevel true as long
as exmode isn't active.

When the normal mode state was extracted in dae006a9, the conditions for
toplevel and may_garbage_collect were combined.  Since toplevel was set
to always ignore cmdwin, the v:count(1) variables were no longer being
updated when a command was prefixed with a count in the cmdwin.

Closes #5404
