### PR TITLE
[RFC] lint: Removing dead initializations

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -368,11 +368,10 @@ static inline void typval_encode_list_start(EncodedData *const edata,
                                             const size_t len)
   FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ALL
 {
-  const Object obj = OBJECT_INIT;
   kv_push(edata->stack, ARRAY_OBJ(((Array) {
     .capacity = len,
     .size = 0,
-    .items = xmalloc(len * sizeof(*obj.data.array.items)),
+    .items = xmalloc(len * sizeof(*((Object *)NULL)->data.array.items)),
   })));
 }
 
@@ -409,11 +408,11 @@ static inline void typval_encode_dict_start(EncodedData *const edata,
                                             const size_t len)
   FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ALL
 {
-  const Object obj = OBJECT_INIT;
   kv_push(edata->stack, DICTIONARY_OBJ(((Dictionary) {
     .capacity = len,
     .size = 0,
-    .items = xmalloc(len * sizeof(*obj.data.dictionary.items)),
+    .items =
+        xmalloc(len * sizeof(*((Object *)NULL)->data.dictionary.items)),
   })));
 }
 


### PR DESCRIPTION
This is just a small refactor to eliminate the 2 clang analysis warnings.
