### PR TITLE
[RFC] Windows : Implement os_get_hostname()

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -26,6 +26,11 @@
 #include <sys/utsname.h>
 #endif
 
+#ifdef WIN32
+#include "nvim/os/win_defs.h"
+#include "nvim/mbyte.h"  // for utf16_to_utf8
+#endif
+
 /// Like getenv(), but returns NULL if the variable is empty.
 const char *os_getenv(const char *name)
   FUNC_ATTR_NONNULL_ALL
@@ -99,7 +104,6 @@ char *os_getenvname_at_index(size_t index)
   return name;
 }
 
-
 /// Get the process ID of the Neovim process.
 ///
 /// @return the process ID.
@@ -127,11 +131,19 @@ void os_get_hostname(char *hostname, size_t len)
     strncpy(hostname, vutsname.nodename, len - 1);
     hostname[len - 1] = '\0';
   }
-#else
-  // TODO(unknown): Implement this for windows.
-  // See the implementation used in vim:
-  // https://code.google.com/p/vim/source/browse/src/os_win32.c?r=6b69d8dde19e32909f4ee3a6337e6a2ecfbb6f72#2899
-  *hostname = '\0';
+#endif
+#ifdef WIN32
+  WCHAR hostname_unicode[MAX_COMPUTERNAME_LENGTH + 1];
+  WCHAR hostname_length = (WCHAR)len;
+  if (GetComputerName(hostname_unicode, &hostname_length) == 0) {
+    *hostname = '\0';
+  } else {
+    int conversion_result = utf16_to_utf8(hostname_unicode,
+                                          &hostname);
+    if (conversion_result != 0) {
+      EMSG2("utf16_to_utf8 failed: %s", uv_strerror(conversion_result));
+    }
+  }
 #endif
 }
 


### PR DESCRIPTION
TODO : Add codes for Windows in os_get_hostname() env.c
- Call gethostname() function at Windows part
- libuv has uv_getnameinfo function but it uses socket, so It will depend on which ip address given. So I had to try on other Window APIs, and GetHostNameW and gethostname were solution. But GetHostNameW was not supported with WinSock2.h in some computer environment. (You can find it at [GetHostNameW()](https://msdn.microsoft.com/en-us/library/windows/desktop/dn793576%28v=vs.85%29.aspx)). 

But Windows still uses utf-16, so I added utf16_to_utf8 function to it. 

And I did some many silly things (like commit too much.. I just learned --amend). I'll clear that!
Any advice welcome :)
