### PR TITLE
ci: .travis.yml: Minimize scope of osx_image directive.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: c
 
-# macOS 10.11
-osx_image: xcode7.3
-
 env:
   global:
     # To force rebuilding of third-party dependencies, set this to 'true'.
@@ -80,8 +77,10 @@ matrix:
       env: CLANG_SANITIZER=TSAN
     - os: osx
       compiler: clang
+      osx_image: xcode7.3  # macOS 10.11
     - os: osx
       compiler: gcc-4.9
+      osx_image: xcode7.3  # macOS 10.11
   fast_finish: true
 
 before_install: .ci/before_install.sh


### PR DESCRIPTION
The "Xcode:" parameter is showing up on all builds in the matrix, e.g. https://travis-ci.org/neovim/neovim/builds/164353369

It probably doesn't harm anything, but at least it might cause confusion. So this change avoids that.
