### PR TITLE
[RFC] api: Support getting the number of a window/tabpage

### DIFF
--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -159,6 +159,23 @@ Window nvim_tabpage_get_win(Tabpage tabpage, Error *err)
   }
 }
 
+/// Gets the tab page number
+///
+/// @param tabpage The tabpage handle
+/// @param[out] err Details of an error that may have occurred
+/// @return The tabpage number
+Integer nvim_tabpage_get_number(Tabpage tabpage, Error *err)
+{
+  Integer rv = 0;
+  tabpage_T *tab = find_tab_by_handle(tabpage, err);
+
+  if (!tab) {
+    return rv;
+  }
+
+  return tabpage_index(tab);
+}
+
 /// Checks if a tab page is valid
 ///
 /// @param tabpage The tab page handle

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -341,6 +341,26 @@ Tabpage nvim_win_get_tabpage(Window window, Error *err)
   return rv;
 }
 
+/// Gets the window number
+///
+/// @param window The window handle
+/// @param[out] err Details of an error that may have occurred
+/// @return The window number
+Integer nvim_win_get_number(Window window, Error *err)
+{
+  Integer rv = 0;
+  win_T *win = find_window_by_handle(window, err);
+
+  if (!win) {
+    return rv;
+  }
+
+  int tabnr;
+  win_get_tabwin(window, &tabnr, (int *)&rv);
+
+  return rv;
+}
+
 /// Checks if a window is valid
 ///
 /// @param window The window handle

--- a/test/functional/api/tabpage_spec.lua
+++ b/test/functional/api/tabpage_spec.lua
@@ -51,6 +51,22 @@ describe('tabpage_* functions', function()
     end)
   end)
 
+  describe('get_number', function()
+    it('works', function()
+      local tabs = nvim('list_tabpages')
+      eq(1, tabpage('get_number', tabs[1]))
+
+      nvim('command', 'tabnew')
+      local tab1, tab2 = unpack(nvim('list_tabpages'))
+      eq(1, tabpage('get_number', tab1))
+      eq(2, tabpage('get_number', tab2))
+
+      nvim('command', '-tabmove')
+      eq(2, tabpage('get_number', tab1))
+      eq(1, tabpage('get_number', tab2))
+    end)
+  end)
+
   describe('is_valid', function()
     it('works', function()
       nvim('command', 'tabnew')

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -200,6 +200,30 @@ describe('window_* functions', function()
     end)
   end)
 
+  describe('get_number', function()
+    it('works', function()
+      local wins = nvim('list_wins')
+      eq(1, window('get_number', wins[1]))
+
+      nvim('command', 'split')
+      local win1, win2 = unpack(nvim('list_wins'))
+      eq(1, window('get_number', win1))
+      eq(2, window('get_number', win2))
+
+      nvim('command', 'wincmd J')
+      eq(2, window('get_number', win1))
+      eq(1, window('get_number', win2))
+
+      nvim('command', 'tabnew')
+      local win3 = nvim('list_wins')[3]
+      -- First tab page
+      eq(2, window('get_number', win1))
+      eq(1, window('get_number', win2))
+      -- Second tab page
+      eq(1, window('get_number', win3))
+    end)
+  end)
+
   describe('is_valid', function()
     it('works', function()
       nvim('command', 'split')


### PR DESCRIPTION
In order to provide better compatibility with the classic bindings, the
API needs to provide the ability to query the number (really index) of
the window/tabpage.

This is needed for neovim/python-client#87, as discussed in
neovim/neovim#1898.
