### PR TITLE
[RFC] Disable syntax folding update in InsertLeave

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -462,8 +462,7 @@ static void insert_enter(InsertState *s)
     o_lnum = curwin->w_cursor.lnum;
   }
 
-  foldUpdateAll(curwin);
-  foldOpenCursor();
+  foldUpdateInsert();
   if (s->cmdchar != 'r' && s->cmdchar != 'v') {
     apply_autocmds(EVENT_INSERTLEAVE, NULL, NULL, false, curbuf);
   }

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -788,6 +788,22 @@ void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
   }
 }
 
+// foldUpdateInsert()
+//
+// Update folds for the insert changes in the buffer of a window.
+//
+void foldUpdateInsert(void)
+{
+  if (foldmethodIsManual(curwin)
+      || foldmethodIsSyntax(curwin)
+      || foldmethodIsExpr(curwin)) {
+    return;
+  }
+
+  foldUpdateAll(curwin);
+  foldOpenCursor();
+}
+
 /* foldUpdateAll() {{{2 */
 /*
  * Update all lines in a window for folding.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5925,8 +5925,7 @@ static void nv_replace(cmdarg_T *cap)
     set_last_insert(cap->nchar);
   }
 
-  foldUpdateAll(curwin);
-  foldOpenCursor();
+  foldUpdateInsert();
 }
 
 /*


### PR DESCRIPTION
It fixes the slowness in InsertLeave if you use syntax/expr folding.
