### PR TITLE
[RFC] vim-patch: 0c1ff16, 939a1ab, 8067a64

### DIFF
--- a/runtime/compiler/gcc.vim
+++ b/runtime/compiler/gcc.vim
@@ -2,6 +2,7 @@
 " Compiler:         GNU C Compiler
 " Maintainer:       Nikolai Weibull <now@bitwi.se>
 " Latest Revision:  2010-10-14
+" 			added line suggested by Anton Lindqvist 2016 Mar 31
 
 if exists("current_compiler")
   finish
@@ -24,6 +25,7 @@ CompilerSet errorformat=
       \%f:%l:\ %trror:\ %m,
       \%f:%l:\ %tarning:\ %m,
       \%f:%l:\ %m,
+      \%f:\\(%*[^\\)]\\):\ %m,
       \\"%f\"\\,\ line\ %l%*\\D%c%*[^\ ]\ %m,
       \%D%*\\a[%*\\d]:\ Entering\ directory\ [`']%f',
       \%X%*\\a[%*\\d]:\ Leaving\ directory\ [`']%f',

--- a/runtime/indent/html.vim
+++ b/runtime/indent/html.vim
@@ -2,7 +2,7 @@
 " Header: "{{{
 " Maintainer:	Bram Moolenaar
 " Original Author: Andy Wokula <anwoku@yahoo.de>
-" Last Change:	2015 Sep 25
+" Last Change:	2016 Mar 30
 " Version:	1.0
 " Description:	HTML indent script with cached state for faster indenting on a
 "		range of lines.
@@ -240,13 +240,13 @@ call s:AddITags(s:indent_tags, [
     \ 'sup', 'table', 'textarea', 'title', 'tt', 'u', 'ul', 'var', 'th', 'td',
     \ 'tr', 'tbody', 'tfoot', 'thead'])
 
-" Tags added 2011 Sep 09 (especially HTML5 tags):
+" New HTML5 elements:
 call s:AddITags(s:indent_tags, [
     \ 'area', 'article', 'aside', 'audio', 'bdi', 'canvas',
-    \ 'command', 'datalist', 'details', 'embed', 'figure', 'footer',
-    \ 'header', 'group', 'keygen', 'mark', 'math', 'meter', 'nav', 'output',
-    \ 'progress', 'ruby', 'section', 'svg', 'texture', 'time', 'video',
-    \ 'wbr', 'text'])
+    \ 'command', 'data', 'datalist', 'details', 'embed', 'figcaption',
+    \ 'figure', 'footer', 'header', 'keygen', 'mark', 'meter', 'nav', 'output',
+    \ 'progress', 'rp', 'rt', 'ruby', 'section', 'source', 'summary', 'svg', 
+    \ 'time', 'track', 'video', 'wbr'])
 
 " Tags added for web components:
 call s:AddITags(s:indent_tags, [

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,7 @@
 " These commands create the option window.
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2016 Mar 19
+" Last Change:	2016 Apr 21
 
 " If there already is an option window, jump to that one.
 if bufwinnr("option-window") > 0

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -61,6 +61,7 @@ an 50.10.320 &Syntax.AB.Ascii\ Doc :cal SetSyn("asciidoc")<CR>
 an 50.10.330 &Syntax.AB.ASP\ with\ VBScript :cal SetSyn("aspvbs")<CR>
 an 50.10.340 &Syntax.AB.ASP\ with\ Perl :cal SetSyn("aspperl")<CR>
 an 50.10.350 &Syntax.AB.Assembly.680x0 :cal SetSyn("asm68k")<CR>
+an 50.10.355 &Syntax.AB.Assembly.AVR :cal SetSyn("avra")<CR>
 an 50.10.360 &Syntax.AB.Assembly.Flat :cal SetSyn("fasm")<CR>
 an 50.10.370 &Syntax.AB.Assembly.GNU :cal SetSyn("asm")<CR>
 an 50.10.380 &Syntax.AB.Assembly.GNU\ H-8300 :cal SetSyn("asmh8300")<CR>

--- a/runtime/syntax/avra.vim
+++ b/runtime/syntax/avra.vim
@@ -1,0 +1,73 @@
+" Vim syntax file
+" Language:     AVR Assembler (AVRA)
+" AVRA Home:    http://avra.sourceforge.net/index.html
+" AVRA Version: 1.3.0
+" Maintainer:	  Marius Ghita <mhitza@gmail.com>
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+setlocal iskeyword=a-z,A-Z,48-57,.,_
+" 'isident' is a global option, better not set it
+" setlocal isident=a-z,A-Z,48-57,.,_
+syn case ignore
+
+syn keyword avraRegister r0 r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14
+syn keyword avraRegister r15 r16 r17 r18 r19 r20 r21 r22 r23 r24 r25 r26 r27
+syn keyword avraRegister r28 r29 r30 r31
+
+syn keyword avraInstr add adc adiw sub subi sbc sbci sbiw and andi or ori eor
+syn keyword avraInstr com neg sbr cbr inc dec tst clr ser mul muls mulsu fmul
+syn keyword avraInstr fmuls fmulsu des rjmp ijmp eijmp jmp rcall icall eicall
+syn keyword avraInstr call ret reti cpse cp cpc cpi sbrc sbrs sbic sbis brbs
+syn keyword avraInstr brbc breq brne brcs brcc brsh brlo brmi brpl brge brlt
+syn keyword avraInstr brhs brhc brts brtc brvs brvc brie brid mov movw ldi lds
+syn keyword avraInstr ld ldd sts st std lpm elpm spm in out push pop xch las
+syn keyword avraInstr lac lat lsl lsr rol ror asr swap bset bclr sbi cbi bst bld
+syn keyword avraInstr sec clc sen cln sez clz sei cli ses cls sev clv set clt
+syn keyword avraInstr seh clh break nop sleep wdr
+
+syn keyword avraDirective .byte .cseg .db .def .device .dseg .dw .endmacro .equ
+syn keyword avraDirective .eseg .exit .include .list .listmac .macro .nolist
+syn keyword avraDirective .org .set .define .undef .ifdef .ifndef .if .else
+syn keyword avraDirective .elif .elseif .warning
+
+syn keyword avraOperator low high byte2 byte3 byte4 lwrd hwrd page exp2 log2
+
+syn match avraNumericOperator "[-*/+]"
+syn match avraUnaryOperator   "!"
+syn match avraBinaryOperator  "<<\|>>\|<\|<=\|>\|>=\|==\|!="
+syn match avraBitwiseOperator "[~&^|]\|&&\|||"
+
+syn match avraBinaryNumber    "\<0[bB][0-1]*\>"
+syn match avraHexNumber       "\<0[xX][0-9a-fA-F]\+\>"
+syn match avraDecNumber       "\<\(0\|[1-9]\d*\)\>"
+
+syn region avraComment start=";" end="$"
+syn region avraString  start="\"" end="\"\|$"
+
+syn match avraLabel "^\s*[^; \t]\+:"
+
+hi def link avraBinaryNumber    avraNumber
+hi def link avraHexNumber       avraNumber
+hi def link avraDecNumber       avraNumber
+
+hi def link avraNumericOperator avraOperator
+hi def link avraUnaryOperator   avraOperator
+hi def link avraBinaryOperator  avraOperator
+hi def link avraBitwiseOperator avraOperator
+
+
+hi def link avraOperator  operator
+hi def link avraComment   comment
+hi def link avraDirective preproc
+hi def link avraRegister  type
+hi def link avraNumber    constant
+hi def link avraString    String
+hi def link avraInstr     keyword
+hi def link avraLabel     label
+
+let b:current_syntax = "avra"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/syntax/desktop.vim
+++ b/runtime/syntax/desktop.vim
@@ -3,7 +3,8 @@
 "		according to freedesktop.org specification 0.9.4
 " http://pdx.freedesktop.org/Standards/desktop-entry-spec/desktop-entry-spec-0.9.4.html
 " Maintainer:	Mikolaj Machowski ( mikmach AT wp DOT pl )
-" Last Change:	2004 May 16
+" Last Change:	2016 Apr 02
+" 		(added "Keywords")
 " Version Info: desktop.vim 0.9.4-1.2
 
 " For version 5.x: Clear all syntax items
@@ -53,8 +54,8 @@ syn keyword dtBooleanKey StartupNotify ReadOnly Terminal Hidden NoDisplay nextgr
 syn keyword dtBooleanValue true false containedin=dtBoolean contained
 
 " String
-syn match   dtString /^\s*\<\(Encoding\|Icon\|Path\|Actions\|FSType\|MountPoint\|UnmountIcon\|URL\|Categories\|OnlyShowIn\|NotShowIn\|StartupWMClass\|FilePattern\|MimeType\)\>.*/ contains=dtStringKey,dtDelim transparent
-syn keyword dtStringKey Type Encoding TryExec Exec Path Actions FSType MountPoint URL Categories OnlyShowIn NotShowIn StartupWMClass FilePattern MimeType nextgroup=dtDelim containedin=dtString contained
+syn match   dtString /^\s*\<\(Encoding\|Icon\|Path\|Actions\|FSType\|MountPoint\|UnmountIcon\|URL\|Keywords\|Categories\|OnlyShowIn\|NotShowIn\|StartupWMClass\|FilePattern\|MimeType\)\>.*/ contains=dtStringKey,dtDelim transparent
+syn keyword dtStringKey Type Encoding TryExec Exec Path Actions FSType MountPoint URL Keywords Categories OnlyShowIn NotShowIn StartupWMClass FilePattern MimeType nextgroup=dtDelim containedin=dtString contained
 
 " Exec
 syn match   dtExec /^\s*\<\(Exec\|TryExec\|SwallowExec\)\>.*/ contains=dtExecKey,dtDelim,dtExecParam transparent

--- a/runtime/syntax/diff.vim
+++ b/runtime/syntax/diff.vim
@@ -2,7 +2,7 @@
 " Language:	Diff (context or unified)
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
 "               Translations by Jakson Alves de Aquino.
-" Last Change:	2015 Feb 03
+" Last Change:	2016 Apr 02
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -342,7 +342,7 @@ syn match diffLine	"^\<\d\+\>.*"
 syn match diffLine	"^\*\*\*\*.*"
 syn match diffLine	"^---$"
 
-"Some versions of diff have lines like "#c#" and "#d#" (where # is a number)
+" Some versions of diff have lines like "#c#" and "#d#" (where # is a number)
 syn match diffLine	"^\d\+\(,\d\+\)\=[cda]\d\+\>.*"
 
 syn match diffFile	"^diff\>.*"
@@ -352,12 +352,16 @@ syn match diffFile	"^==== .*"
 syn match diffOldFile	"^\*\*\* .*"
 syn match diffNewFile	"^--- .*"
 
+" Used by git
+syn match diffIndexLine	"^index \x\x\x\x.*"
+
 syn match diffComment	"^#.*"
 
 " Define the default highlighting.
 " Only used when an item doesn't have highlighting yet
 hi def link diffOldFile		diffFile
 hi def link diffNewFile		diffFile
+hi def link diffIndexLine	PreProc
 hi def link diffFile		Type
 hi def link diffOnly		Constant
 hi def link diffIdentical	Constant

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Vim help file
 " Maintainer:	Bram Moolenaar (Bram@vim.org)
-" Last Change:	2014 Feb 12
+" Last Change:	2016 Apr 01
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -41,6 +41,7 @@ syn match helpVim		"NVIM REFERENCE.*"
 syn match helpOption		"'[a-z]\{2,\}'"
 syn match helpOption		"'t_..'"
 syn match helpCommand		"`[^` \t]\+`"hs=s+1,he=e-1 contains=helpBacktick
+syn match helpCommand		"\(^\|[^a-z"[]\)\zs`[^`]\+`\ze\([^a-z\t."']\|$\)"hs=s+1,he=e-1 contains=helpBacktick
 syn match helpHeader		"\s*\zs.\{-}\ze\s\=\~$" nextgroup=helpIgnore
 syn match helpGraphic		".* \ze`$" nextgroup=helpIgnore
 if has("conceal")

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -4,8 +4,8 @@
 " Maintainer:	Dominik Fischer <d dot f dot fischer at web dot de>
 " Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>
 " Contributor:  Karsten Hopp <karsten@redhat.com>
-" Last Change:	2016 Mar 1
-" SSH Version:	7.2
+" Last Change:	2016 Apr 7
+" SSH Version:	7.2p2
 "
 
 " Setup
@@ -36,7 +36,7 @@ syn keyword sshconfigTodo TODO FIXME NOTE contained
 
 
 " Constants
-syn keyword sshconfigYesNo yes no ask
+syn keyword sshconfigYesNo yes no ask confirm
 syn keyword sshconfigYesNo any auto
 syn keyword sshconfigYesNo force autoask none
 
@@ -139,6 +139,7 @@ syn keyword sshconfigHostSect Host
 syn keyword sshconfigMatch canonical exec host originalhost user localuser all
 
 syn keyword sshconfigKeyword AddressFamily
+syn keyword sshconfigKeyword AddKeysToAgent
 syn keyword sshconfigKeyword BatchMode
 syn keyword sshconfigKeyword BindAddress
 syn keyword sshconfigKeyword CanonicalDomains

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	Vim 7.4 script
 " Maintainer:	Charles E. Campbell <NdrOchipS@PcampbellAfamily.Mbiz>
-" Last Change:	Apr 02, 2015
-" Version:	7.4-33
+" Last Change:	March 29, 2016
+" Version:	7.4-45
 " Automatically generated keyword lists: {{{1
 
 " Quit when a syntax file was already loaded {{{2
@@ -17,46 +17,125 @@ set cpo&vim
 syn keyword vimTodo contained	COMBAK	FIXME	TODO	XXX
 syn cluster vimCommentGroup	contains=vimTodo,@Spell
 
-" Special and plugin vim commands {{{2
-syn match   vimCommand contained	"\<z[-+^.=]\="
-syn keyword vimOnlyCommand contained	fix[del] op[en] sh[ell] P[rint]
-syn keyword vimStdPlugin contained	DiffOrig Man N[ext] S TOhtml XMLent XMLns
+" regular vim commands {{{2
+syn keyword vimCommand contained	a argd argu[ment] bf[irst] brea[k] buf cabc[lear] cc cfdo changes clo[se] cnf comc[lear] cpf[ile] cstag debugg[reedy] deletel dell diffg[et] dif[fupdate] dl ds[earch] echoe[rr] em[enu] en[dif] exu[sage] fin fo[ld] fu grepa[dd] helpc[lose] his[tory] il[ist] iuna[bbrev] keepj[umps] laddb[uffer] lat lcs lf lg[etfile] lla[st] lnew[er] lNf[ile] lockv[ar] ls lvimgrepa[dd] mat[ch] mk[exrc] mo n n[ext] nore on[ly] packl perld[o] pre[serve] promptf[ind] ptl[ast] ptr[ewind] py3do qa[ll] rec[over] reg[isters] rightb[elow] ru[ntime] sba[ll] sbp[revious] sci scr[iptnames] setl[ocal] sgi sh[ell] sIe sil[ent] sir sm[ap] sno[magic] sp spellu[ndo] sre[wind] srp star[tinsert] sun[hide] sy ta tabfir[st] tabN[ext] tags th[row] tN tr[ewind] un unl verb[ose] vimgrepa[dd] w winp[os] wqa[ll] xa[ll] xnoremenu
+syn keyword vimCommand contained	ab argd[elete] as[cii] bl[ast] breaka[dd] bufdo cad[dbuffer] ccl[ose] cf[ile] chd[ir] cmapc[lear] cNf comp[iler] cp[revious] cuna[bbrev] del deletep delm[arks] diffo[ff] dig dli[st] dsp[lit] echom[sg] en endt[ry] f fina[lly] foldc[lose] fun gui helpf[ind] i imapc[lear] j[oin] kee[pmarks] lad[dexpr] later lcscope lfdo lgr[ep] lli[st] lne[xt] lo lol[der] lt[ag] lw[indow] menut mks[ession] mod[e] nbc[lose] nmapc[lear] nos[wapfile] o[pen] packloadall po[p] prev[ious] promptr[epl] ptn pts[elect] pydo q[uit] red res[ize] ru rv[iminfo] sbf[irst] sbr[ewind] scI scs sf[ind] sgI si sig sim[alt] sIr sme snoreme spe spellw[rong] srg st startr[eplace] sunme syn tab tabl[ast] tabo[nly] tc[l] tj[ump] tn[ext] try una[bbreviate] unlo[ckvar] ve[rsion] vi[sual] wa[ll] win[size] w[rite] x[it] xprop
+syn keyword vimCommand contained	abc[lear] argdo au bm[odified] breakd[el] b[uffer] cadde[xpr] cd cfir[st] che[ckpath] cn cnf[ile] con cq[uit] cw[indow] delc[ommand] deletl delp diffp[atch] dig[raphs] do e echon endf endw[hile] f[ile] fin[d] folddoc[losed] fu[nction] gvim helpg[rep] ia in ju[mps] keepp[atterns] laddf[ile] lb[uffer] ld[o] lf[ile] lgrepa[dd] lmak[e] lN[ext] loadk lop[en] lua ma menut[ranslate] mksp[ell] m[ove] nb[key] noa nu[mber] opt[ions] pc[lose] popu p[rint] ps[earch] ptN pu[t] pyf[ile] quita[ll] redi[r] ret[ab] rub[y] sal[l] sbl[ast] sb[uffer] scl scscope sfir[st] sgl sI sIg sin sl smenu snoremenu spelld[ump] sp[lit] sri sta[g] stj[ump] sunmenu sync tabc[lose] tabm[ove] tabp[revious] tcld[o] tl[ast] tN[ext] ts[elect] u[ndo] uns[ilent] vert[ical] viu[sage] wh[ile] wn[ext] ws[verb] xmapc[lear] xunme
+syn keyword vimCommand contained	abo[veleft] arge[dit] bad[d] bn[ext] breakl[ist] buffers caddf[ile] cdo cgetb[uffer] checkt[ime] cN cNf[ile] conf[irm] cr[ewind] d delel deletp dep diffpu[t] dir doau ea e[dit] endfo[r] ene[w] files fini[sh] foldd[oopen] g h helpt[ags] iabc[lear] intro k l lan lc[d] le[ft] lfir[st] lh[elpgrep] lmapc[lear] lnf loadkeymap lpf[ile] luado mak[e] mes mkv mz nbs[tart] noautocmd o ownsyntax pe popu[p] pro pta[g] ptn[ext] pw[d] py[thon] r red[o] retu[rn] rubyd[o] san[dbox] sbm[odified] sc scp se[t] sg sgn sic sign sIn sla[st] smile so spe[llgood] spr[evious] srI star st[op] sus[pend] syncbind tabd[o] tabN tabr[ewind] tclf[ile] tm to[pleft] tu undoj[oin] up[date] vi vmapc[lear] win wN[ext] wundo xme xunmenu
+syn keyword vimCommand contained	al[l] argg[lobal] ba[ll] bN[ext] br[ewind] bun[load] cal[l] ce[nter] cgete[xpr] cl cnew[er] col[der] con[tinue] cs de delep delf di diffs[plit] di[splay] dp earlier el[se] endfun ex filet fir[st] foldo[pen] go[to] ha[rdcopy] hi if is[earch] keepa la lan[guage] lch[dir] lefta[bove] lgetb[uffer] l[ist] lN lNf lo[adview] lp[revious] luafile ma[rk] messages mkvie[w] mzf[ile] ne noh[lsearch] ol[dfiles] p ped[it] pp[op] profd[el] ptf[irst] ptN[ext] py python3 re redr[aw] rew[ind] rubyf[ile] sa[rgument] sbn[ext] sce scr setf[iletype] sgc sgp sIc sil sip sl[eep] sn[ext] sor[t] spelli[nfo] sr srl start stopi[nsert] sv[iew] syntime tabe[dit] tabnew tabs te[aroff] tm[enu] tp[revious] tu[nmenu] undol[ist] v vie[w] vne[w] winc[md] wp[revious] wv[iminfo] xmenu xwininfo
+syn keyword vimCommand contained	ar argl[ocal] bd[elete] bo[tright] bro[wse] bw[ipeout] cat[ch] cex[pr] cg[etfile] cla[st] cn[ext] colo[rscheme] cope[n] cscope debug d[elete] delf[unction] dif difft[his] dj[ump] dr[op] ec elsei[f] endf[unction] exi[t] filetype fix[del] for gr[ep] h[elp] hid[e] ij[ump] isp[lit] keepalt lad la[st] lcl[ose] lex[pr] lgete[xpr] ll lne lnf[ile] loc[kmarks] lr[ewind] lv[imgrep] marks mk mkv[imrc] mz[scheme] new nor omapc[lear] pa[ckadd] pe[rl] pr prof[ile] ptj[ump] ptp[revious] py3 q r[ead] redraws[tatus] ri[ght] rundo sav[eas] sbN[ext] scg scripte[ncoding] setg[lobal] sge sgr sie sIl sIp sm[agic] sN[ext] so[urce] spellr[epall] src srn startg[replace] sts[elect] sw[apname] t tabf[ind] tabn[ext] ta[g] tf[irst] tn tr u unh[ide] ve vim[grep] vs[plit] windo wq x xnoreme y[ank]
+syn keyword vimCommand contained	arga[dd] ar[gs] bel[owright] bp[revious] bu c cb[uffer] cf c[hange] cl[ist] cN[ext] com co[py] 
+syn match   vimCommand contained	"\<z[-+^.=]\=\>"
+syn keyword vimStdPlugin contained	DiffOrig Man N[ext] P[rint] S TOhtml XMLent XMLns 
 
-" Vim-specific options {{{2
-syn keyword vimOnlyOption contained	biosk bioskey cp compatible consk conskey cm cryptmethod edcompatible guipty key macatsui mzq mzquantum osfiletype oft renderoptions rop st shelltype sn shortname tenc termencoding ta textauto tx textmode tf ttyfast ttym ttymouse tbi ttybuiltin wiv weirdinvert
+" vimOptions are caught only when contained in a vimSet {{{2
+syn keyword vimOption contained	acd ambw arshape background ballooneval bg bl brk buftype cf cinkeys cmdwinheight com conceallevel cpoptions cscopetag csto debug dict dir eb emo equalalways eventignore fde fdt fic fillchars fmr foldlevel foldtext fsync gfs gtl guioptions hf hk hlsearch imactivatekey imi include inex isi js kp lcs listchars lsp makeef maxmapdepth mfd mmd modified mousemodel msm numberwidth operatorfunc paste perldll pm previewwindow printmbfont pythondll redrawtime revins ro ruler scb scs sessionoptions shellquote shiftround showfulltag sidescrolloff smarttab sp spf srr startofline suffixes switchbuf ta taglength tbidi termbidi tgst titleold top ttimeoutlen ttyscroll ul ur verbosefile visualbell wcm wi wildmenu winfixwidth wm wrapscan
+syn keyword vimOption contained	ai anti autochdir backspace balloonexpr bh bo browsedir casemap cfu cino cmp comments confirm cpt cscopetagorder csverb deco dictionary directory ed emoji equalprg ex fdi fen fileencoding fixendofline fo foldlevelstart formatexpr ft gfw gtt guipty hh hkmap ic imaf iminsert includeexpr inf isident key langmap linebreak lm luadll makeprg maxmem mh mmp more mouses mzq nuw opfunc pastetoggle pex pmbcs printdevice printoptions pythonthreedll regexpengine ri rop rulerformat scr sect sft shellredir shiftwidth showmatch siso smc spc spl ss statusline suffixesadd sws tabline tagrelative tbis termencoding thesaurus titlestring tpm ttm ttytype undodir ut vfile vop wd wic wildmode winheight wmh write
+syn keyword vimOption contained	akm antialias autoindent backup bdir bin bomb bs cb ch cinoptions cms commentstring consk crb cscopeverbose cuc def diff display edcompatible enc errorbells expandtab fdl fenc fileencodings fixeol foldclose foldmarker formatlistpat gcr ghr guicursor guitablabel hi hkmapp icon imak ims incsearch infercase isk keymap langmenu lines lmap lw mat maxmempattern mis mmt mouse mouseshape mzquantum odev osfiletype patchexpr pexpr pmbfn printencoding prompt qe relativenumber rightleft rs runtimepath scroll sections sh shellslash shm showmode sj smd spell splitbelow ssl stl sw sxe tabpagemax tags tbs terse tildeop tl tr tty tw undofile vb vi wa weirdinvert wig wildoptions winminheight wmnu writeany
+syn keyword vimOption contained	al ar autoread backupcopy bdlay binary breakat bsdir cc charconvert cinw co compatible conskey cryptmethod cspc cul define diffexpr dy ef encoding errorfile exrc fdls fencs fileformat fk foldcolumn foldmethod formatoptions gd go guifont guitabtooltip hid hkp iconstring imc imsearch inde insertmode iskeyword keymodel langnoremap linespace lnr lz matchpairs maxmemtot mkspellmem mod mousef mouset nf oft pa patchmode pfn popt printexpr pt quoteescape remap rightleftcmd rtp sb scrollbind secure shcf shelltemp shortmess showtabline slm sn spellcapcheck splitright ssop stmp swapfile sxq tabstop tagstack tc textauto timeout tm ts ttybuiltin tx undolevels vbs viewdir wak wfh wildchar wim winminwidth wmw writebackup
+syn keyword vimOption contained	aleph arab autowrite backupdir belloff biosk breakindent bsk ccv ci cinwords cocu complete copyindent cscopepathcomp csprg cursorbind delcombine diffopt ea efm endofline errorformat fcl fdm fex fileformats fkmap foldenable foldminlines formatprg gdefault gp guifontset helpfile hidden hl ignorecase imcmdline imsf indentexpr is isp keywordprg laststatus lisp loadplugins ma matchtime mco ml modeline mousefocus mousetime nrformats ofu packpath path ph pp printfont pumheight rdt renderoptions rl ru sbo scrolljump sel shell shelltype shortname shq sm so spellfile spr st sts swapsync syn tag tal tcldll textmode timeoutlen to tsl ttyfast uc undoreload vdir viewoptions warn wfw wildcharm winaltkeys winwidth wop writedelay
+syn keyword vimOption contained	allowrevins arabic autowriteall backupext beval bioskey breakindentopt bt cd cin clipboard cole completefunc cot cscopeprg csqf cursorcolumn dex digraph ead ei eol esckeys fcs fdn ff fileignorecase flp foldexpr foldnestmax fp gfm grepformat guifontwide helpheight highlight hlg im imd imstatusfunc indentkeys isf isprint km lazyredraw lispwords lpl macatsui maxcombine mef mls modelines mousehide mp nu omnifunc para pdev pheader preserveindent printheader pvh re report rlc rubydll sbr scrolloff selection shellcmdflag shellxescape showbreak si smartcase softtabstop spelllang sps sta su swb synmaxcol tagbsearch tb tenc textwidth title toolbar tsr ttym udf updatecount ve viminfo wb wh wildignore window wiv wrap ws
+syn keyword vimOption contained	altkeymap arabicshape aw backupskip bex bk bri bufhidden cdpath cindent cm colorcolumn completeopt cp cscopequickfix csre cursorline dg dip eadirection ek ep et fdc fdo ffs filetype fml foldignore foldopen fs gfn grepprg guiheadroom helplang history hls imactivatefunc imdisable inc indk isfname joinspaces kmp lbr list ls magic maxfuncdepth menuitems mm modifiable mousem mps number opendevice paragraphs penc pi previewheight printmbcharset pvw readonly restorescreen rnu ruf sc scrollopt selectmode shellpipe shellxquote showcmd sidescroll smartindent sol spellsuggest sr stal sua swf syntax tagcase tbi term tf titlelen toolbariconsize ttimeout ttymouse udir updatetime verbose virtualedit wc whichwrap wildignorecase winfixheight wiw wrapmargin ww
+syn keyword vimOption contained	ambiwidth ari awa balloondelay bexpr bkc briopt buflisted cedit cink cmdheight columns concealcursor cpo cscoperelative cst cwh 
 
-" Turn-off setting variants
-syn keyword vimOnlyOption contained	nobiosk nobioskey noconsk noconskey nocp nocompatible noguipty nomacatsui nosn noshortname nota notextauto notx notextmode notf nottyfast notbi nottybuiltin nowiv noweirdinvert
+" vimOptions: These are the turn-off setting variants {{{2
+syn keyword vimOption contained	noacd noallowrevins noantialias noarabic noarshape noautoread noaw noballooneval nobinary nobk nobreakindent nocf nocindent noconsk nocp nocscopetag nocst nocul nocursorline nodg noea noedcompatible noeol noesckeys noexpandtab nofic nofixeol nofoldenable nogd nohid nohkmap nohls noicon noimc noimdisable noinfercase nojoinspaces nolangnoremap nolbr nolisp nolnr nolpl noma nomagic noml nomodeline nomodified nomousef nomousehide nonumber noopendevice nopi nopreviewwindow nopvw norelativenumber norestorescreen nori norl noro noru nosb noscb noscs nosft noshelltemp noshortname noshowfulltag noshowmode nosm nosmartindent nosmd nosol nosplitbelow nospr nossl nostartofline noswapfile nota notagrelative notbi notbs noterse notextmode notgst notimeout noto notr nottybuiltin notx noundofile novisualbell nowarn noweirdinvert nowfw nowildignorecase nowinfixheight nowiv nowrap nowrite nowritebackup
+syn keyword vimOption contained	noai noaltkeymap noar noarabicshape noautochdir noautowrite noawa nobeval nobiosk nobl nobri noci nocompatible noconskey nocrb nocscopeverbose nocsverb nocursorbind nodeco nodiff noeb noek noequalalways noet noexrc nofileignorecase nofk nofs nogdefault nohidden nohkmapp nohlsearch noignorecase noimcmdline noincsearch noinsertmode nojs nolazyredraw nolinebreak nolist noloadplugins nolz nomacatsui nomh nomod nomodifiable nomore nomousefocus nonu noodev nopaste nopreserveindent noprompt noreadonly noremap norevins norightleft nornu nors noruler nosc noscrollbind nosecure noshellslash noshiftround noshowcmd noshowmatch nosi nosmartcase nosmarttab nosn nospell nosplitright nosr nosta nostmp noswf notagbsearch notagstack notbidi notermbidi notextauto notf notildeop notitle notop nottimeout nottyfast noudf novb nowa nowb nowfh nowic nowildmenu nowinfixwidth nowmnu nowrapscan nowriteany nows
+syn keyword vimOption contained	noakm noanti noarab noari noautoindent noautowriteall nobackup nobin nobioskey nobomb nobuflisted nocin noconfirm nocopyindent nocscoperelative nocsre nocuc nocursorcolumn nodelcombine nodigraph noed noendofline noerrorbells noex nofen nofixendofline nofkmap nofsync noguipty nohk nohkp noic noim noimd noinf nois 
 
-" Invertible setting variants
-syn keyword vimOnlyOption contained	invbiosk invbioskey invconsk invconskey invcp invcompatible invguipty invmacatsui invsn invshortname invta invtextauto invtx invtextmode invtf invttyfast invtbi invttybuiltin invwiv invweirdinvert
+" vimOptions: These are the invertible variants {{{2
+syn keyword vimOption contained	invacd invallowrevins invantialias invarabic invarshape invautoread invaw invballooneval invbinary invbk invbreakindent invcf invcindent invconsk invcp invcscopetag invcst invcul invcursorline invdg invea invedcompatible inveol invesckeys invexpandtab invfic invfixeol invfoldenable invgd invhid invhkmap invhls invicon invimc invimdisable invinfercase invjoinspaces invlangnoremap invlbr invlisp invlnr invlpl invma invmagic invml invmodeline invmodified invmousef invmousehide invnumber invopendevice invpi invpreviewwindow invpvw invrelativenumber invrestorescreen invri invrl invro invru invsb invscb invscs invsft invshelltemp invshortname invshowfulltag invshowmode invsm invsmartindent invsmd invsol invsplitbelow invspr invssl invstartofline invswapfile invta invtagrelative invtbi invtbs invterse invtextmode invtgst invtimeout invto invtr invttybuiltin invtx invundofile invvisualbell invwarn invweirdinvert invwfw invwildignorecase invwinfixheight invwiv invwrap invwrite invwritebackup
+syn keyword vimOption contained	invai invaltkeymap invar invarabicshape invautochdir invautowrite invawa invbeval invbiosk invbl invbri invci invcompatible invconskey invcrb invcscopeverbose invcsverb invcursorbind invdeco invdiff inveb invek invequalalways invet invexrc invfileignorecase invfk invfs invgdefault invhidden invhkmapp invhlsearch invignorecase invimcmdline invincsearch invinsertmode invjs invlazyredraw invlinebreak invlist invloadplugins invlz invmacatsui invmh invmod invmodifiable invmore invmousefocus invnu invodev invpaste invpreserveindent invprompt invreadonly invremap invrevins invrightleft invrnu invrs invruler invsc invscrollbind invsecure invshellslash invshiftround invshowcmd invshowmatch invsi invsmartcase invsmarttab invsn invspell invsplitright invsr invsta invstmp invswf invtagbsearch invtagstack invtbidi invtermbidi invtextauto invtf invtildeop invtitle invtop invttimeout invttyfast invudf invvb invwa invwb invwfh invwic invwildmenu invwinfixwidth invwmnu invwrapscan invwriteany invws
+syn keyword vimOption contained	invakm invanti invarab invari invautoindent invautowriteall invbackup invbin invbioskey invbomb invbuflisted invcin invconfirm invcopyindent invcscoperelative invcsre invcuc invcursorcolumn invdelcombine invdigraph inved invendofline inverrorbells invex invfen invfixendofline invfkmap invfsync invguipty invhk invhkp invic invim invimd invinf invis 
+
 " termcap codes (which can also be set) {{{2
-syn keyword vimTermOption contained	t_AB t_al t_bc t_ce t_cl t_Co t_Cs t_CS t_CV t_da t_db t_dl t_DL t_EI t_F1 t_F2 t_F3 t_F4 t_F5 t_F6 t_F7 t_F8 t_F9 t_fs t_IE t_IS t_k1 t_K1 t_k2 t_k3 t_K3 t_k4 t_K4 t_k5 t_K5 t_k6 t_K6 t_k7 t_K7 t_k8 t_K8 t_k9 t_K9 t_KA t_kb t_kB t_KB t_KC t_kd t_kD t_KD t_ke t_KE t_KF t_KG t_kh t_KH t_kI t_KI t_KJ t_KK t_kl t_KL t_kN t_kP t_kr t_ks t_ku t_le t_mb t_md t_me t_mr t_ms t_nd t_op t_RI t_RV t_Sb t_se t_Sf t_SI t_so t_sr t_te t_ti t_ts t_u7 t_ue t_us t_ut t_vb t_ve t_vi t_vs t_WP t_WS t_xs t_ZH t_ZR
-syn keyword vimTermOption contained	t_AF t_AL t_cd t_Ce t_cm t_cs 
-syn match   vimTermOption contained	"t_%1"
-syn match   vimTermOption contained	"t_#2"
-syn match   vimTermOption contained	"t_#4"
-syn match   vimTermOption contained	"t_@7"
-syn match   vimTermOption contained	"t_*7"
-syn match   vimTermOption contained	"t_&8"
-syn match   vimTermOption contained	"t_%i"
-syn match   vimTermOption contained	"t_k;"
+syn keyword vimOption contained	t_AB t_al t_bc t_ce t_cl t_Co t_Cs t_CV t_db t_DL t_EI t_F1 t_F2 t_F3 t_F4 t_F5 t_F6 t_F7 t_F8 t_F9 t_fs t_IE t_IS t_k1 t_K1 t_k2 t_k3 t_K3 t_k4 t_K4 t_k5 t_K5 t_k6 t_K6 t_k7 t_K7 t_k8 t_K8 t_k9 t_K9 t_KA t_kb t_kB t_KB t_KC t_kd t_kD t_KD t_ke t_KE t_KF t_KG t_kh t_KH t_kI t_KI t_KJ t_KK t_kl t_KL t_kN t_kP t_kr t_ks t_ku t_le t_mb t_md t_me t_mr t_ms t_nd t_op t_RB t_RI t_RV t_Sb t_se t_Sf t_SI t_so t_sr t_SR t_te t_ti t_ts t_u7 t_ue t_us t_ut t_vb t_ve t_vi t_vs t_WP t_WS t_xn t_xs t_ZH t_ZR
+syn keyword vimOption contained	t_AF t_AL t_cd t_Ce t_cm t_cs t_CS t_da t_dl 
+syn match   vimOption contained	"t_%1"
+syn match   vimOption contained	"t_#2"
+syn match   vimOption contained	"t_#4"
+syn match   vimOption contained	"t_@7"
+syn match   vimOption contained	"t_*7"
+syn match   vimOption contained	"t_&8"
+syn match   vimOption contained	"t_%i"
+syn match   vimOption contained	"t_k;"
 
 " unsupported settings: these are supported by vi but don't do anything in vim {{{2
 syn keyword vimErrSetting contained	hardtabs ht w1200 w300 w9600 
-"}}}2
+
+" AutoCmd Events {{{2
 syn case ignore
+syn keyword vimAutoEvent contained	BufAdd BufCreate BufDelete BufEnter BufFilePost BufFilePre BufHidden BufLeave BufNew BufNewFile BufRead BufReadCmd BufReadPost BufReadPre BufUnload BufWinEnter BufWinLeave BufWipeout BufWrite BufWriteCmd BufWritePost BufWritePre Cmd-event CmdUndefined CmdwinEnter CmdwinLeave ColorScheme CompleteDone CursorHold CursorHoldI CursorMoved CursorMovedI EncodingChanged FileAppendCmd FileAppendPost FileAppendPre FileChangedRO FileChangedShell FileChangedShellPost FileEncoding FileReadCmd FileReadPost FileReadPre FileType FileWriteCmd FileWritePost FileWritePre FilterReadPost FilterReadPre FilterWritePost FilterWritePre FocusGained FocusLost FuncUndefined GUIEnter GUIFailed InsertChange InsertCharPre InsertEnter InsertLeave MenuPopup OptionSet QuickFixCmdPost QuickFixCmdPre QuitPre RemoteReply SessionLoadPost ShellCmdPost ShellFilterPost SourceCmd SourcePre SpellFileMissing StdinReadPost StdinReadPre SwapExists Syntax TabEnter TabLeave TermChanged TermResponse TextChanged TextChangedI User UserGettingBored VimEnter VimLeave VimLeavePre VimResized WinEnter WinLeave 
+
 " Highlight commonly used Groupnames {{{2
 syn keyword vimGroup contained	Comment Constant String Character Number Boolean Float Identifier Function Statement Conditional Repeat Label Operator Keyword Exception PreProc Include Define Macro PreCondit Type StorageClass Structure Typedef Special SpecialChar Tag Delimiter SpecialComment Debug Underlined Ignore Error Todo 
 
 " Default highlighting groups {{{2
-syn keyword vimHLGroup contained	ColorColumn Cursor CursorColumn CursorIM CursorLine CursorLineNr DiffAdd DiffChange DiffDelete DiffText Directory ErrorMsg FoldColumn Folded IncSearch LineNr MatchParen Menu ModeMsg MoreMsg NonText Normal Pmenu PmenuSbar PmenuSel PmenuThumb Question Scrollbar Search SignColumn SpecialKey SpellBad SpellCap SpellLocal SpellRare StatusLine StatusLineNC TabLine TabLineFill TabLineSel Title Tooltip VertSplit Visual WarningMsg WildMenu
+syn keyword vimHLGroup contained	ColorColumn Cursor CursorColumn CursorIM CursorLine CursorLineNr DiffAdd DiffChange DiffDelete DiffText Directory ErrorMsg FoldColumn Folded IncSearch LineNr MatchParen Menu ModeMsg MoreMsg NonText Normal Pmenu PmenuSbar PmenuSel PmenuThumb Question Scrollbar Search SignColumn SpecialKey SpellBad SpellCap SpellLocal SpellRare StatusLine StatusLineNC TabLine TabLineFill TabLineSel Title Tooltip VertSplit Visual VisualNOS WarningMsg WildMenu 
 syn match vimHLGroup contained	"Conceal"
-syn keyword vimOnlyHLGroup contained	VisualNOS
-syn keyword nvimHLGroup contained	EndOfBuffer TermCursor TermCursorNC QuickFixLine
-"}}}2
 syn case match
+
+" Function Names {{{2
+syn keyword vimFuncName contained	abs and arglistid assert_exception assert_true browsedir bufname byteidx changenr ch_evalraw ch_log ch_readraw ch_status complete copy cscope_connection did_filetype empty executable exp extend filewritable findfile fmod foldclosed foldtext function getbufline getcharmod getcmdpos getcurpos getfperm getftype getmatches getqflist gettabvar getwinposy glob2regpat has_key histadd histnr hostname index inputlist inputsecret isdirectory items job_setoptions job_stop js_encode keys libcallnr lispindent log10 maparg matchadd matchdelete matchstr min mzeval or pow pumvisible range reltimestr remote_peek remove resolve screenattr screenrow searchpair server2client setcharsearch setline setpos settabvar sha256 simplify sort spellsuggest str2float strdisplaywidth string strridx submatch synID synstack tabpagebuflist tagfiles tanh timer_stop tr undofile values wildmenumode win_findbuf winheight winline winrestview wordcount
+syn keyword vimFuncName contained	acos append argv assert_fails atan bufexists bufnr byteidxcomp char2nr ch_getbufnr ch_logfile ch_sendexpr cindent complete_add cos cursor diff_filler escape exepath expand feedkeys filter float2nr fnameescape foldclosedend foldtextresult garbagecollect getbufvar getcharsearch getcmdtype getcwd getfsize getline getpid getreg gettabwinvar getwinvar globpath haslocaldir histdel hlexists iconv input inputrestore insert islocked job_getchannel job_start join json_decode len line localtime luaeval mapcheck matchaddpos matchend matchstrpos mkdir nextnonblank pathshorten prevnonblank py3eval readfile remote_expr remote_read rename reverse screenchar search searchpairpos serverlist setcmdpos setloclist setqflist settabwinvar shellescape sin soundfold split str2nr strftime strlen strtrans substitute synIDattr system tabpagenr taglist tempname tolower trunc undotree virtcol winbufnr win_getid win_id2tabwin winnr winsaveview writefile
+syn keyword vimFuncName contained	add argc asin assert_false atan2 buflisted bufwinnr call ch_close ch_getjob ch_open ch_sendraw clearmatches complete_check cosh deepcopy diff_hlID eval exists expr8 filereadable finddir floor fnamemodify foldlevel foreground get getchar getcmdline getcmdwintype getfontname getftime getloclist getpos getregtype getwinposx glob has hasmapto histget hlID indent inputdialog inputsave invert isnan job_info job_status js_decode json_encode libcall line2byte log map match matcharg matchlist max mode nr2char perleval printf pyeval reltime remote_foreground remote_send repeat round screencol searchdecl searchpos setbufvar setfperm setmatches setreg setwinvar shiftwidth sinh spellbadword sqrt strchars stridx strpart strwidth synconcealed synIDtrans systemlist tabpagewinnr tan timer_start toupper type uniq visualmode wincol win_gotoid win_id2win winrestcmd winwidth xor
+syn keyword vimFuncName contained	alloc_fail argidx assert_equal assert_match browse bufloaded byte2line ceil ch_evalexpr ch_info ch_read ch_setoptions col confirm count delete disable_char_avail_for_testing eventhandler 
+
+"--- syntax here and above generated by mkvimvim ---
 " Special Vim Highlighting (not automatic) {{{1
+
+" Set up folding commands
+if exists("g:vimsyn_folding") && g:vimsyn_folding =~# '[aflmpPrt]'
+ if g:vimsyn_folding =~# 'a' 
+  com! -nargs=* VimFolda <args> fold 
+ else 
+  com! -nargs=* VimFolda <args> 
+ endif
+ if g:vimsyn_folding =~# 'f' 
+  com! -nargs=* VimFoldf <args> fold 
+ else 
+  com! -nargs=* VimFoldf <args> 
+ endif
+ if g:vimsyn_folding =~# 'l' 
+  com! -nargs=* VimFoldl <args> fold 
+ else 
+  com! -nargs=* VimFoldl <args> 
+ endif
+ if g:vimsyn_folding =~# 'm' 
+  com! -nargs=* VimFoldm <args> fold 
+ else 
+  com! -nargs=* VimFoldm <args> 
+ endif
+ if g:vimsyn_folding =~# 'p' 
+  com! -nargs=* VimFoldp <args> fold 
+ else 
+  com! -nargs=* VimFoldp <args> 
+ endif
+ if g:vimsyn_folding =~# 'P' 
+  com! -nargs=* VimFoldP <args> fold 
+ else 
+  com! -nargs=* VimFoldP <args> 
+ endif
+ if g:vimsyn_folding =~# 'r' 
+  com! -nargs=* VimFoldr <args> fold 
+ else 
+  com! -nargs=* VimFoldr <args> 
+ endif
+ if g:vimsyn_folding =~# 't' 
+  com! -nargs=* VimFoldt <args> fold 
+ else 
+  com! -nargs=* VimFoldt <args> 
+ endif
+else
+ com! -nargs=*	VimFolda	<args>
+ com! -nargs=*	VimFoldf	<args>
+ com! -nargs=*	VimFoldl	<args>
+ com! -nargs=*	VimFoldm	<args>
+ com! -nargs=*	VimFoldp	<args>
+ com! -nargs=*	VimFoldP	<args>
+ com! -nargs=*	VimFoldr	<args>
+ com! -nargs=*	VimFoldt	<args>
+endif
 
 " commands not picked up by the generator (due to non-standard format)
 syn keyword vimCommand contained	py3
@@ -80,8 +159,8 @@ syn match vimNumber	"\<0[xX]\x\+"
 syn match vimNumber	"\%(^\|[^a-zA-Z]\)\zs#\x\{6}"
 
 " All vimCommands are contained by vimIsCommands. {{{2
-syn match vimCmdSep	"[:|]\+"	skipwhite nextgroup=vimAddress,vimAutoCmd,vimCommand,vimIsCommand,vimExtCmd,vimFilter,vimLet,vimMap,vimMark,vimSet,vimSyntax,vimUserCmd,vimOnlyCommand
-syn match vimIsCommand	"\<\h\w*\>"	contains=vimCommand,vimOnlyCommand
+syn match vimCmdSep	"[:|]\+"	skipwhite nextgroup=vimAddress,vimAutoCmd,vimIsCommand,vimExtCmd,vimFilter,vimLet,vimMap,vimMark,vimSet,vimSyntax,vimUserCmd
+syn match vimIsCommand	"\<\h\w*\>"	contains=vimCommand
 syn match vimVar        contained	"\<\h[a-zA-Z0-9#_]*\>"
 syn match vimVar		"\<[bwglsav]:\h[a-zA-Z0-9#_]*\>"
 syn match vimFBVar      contained   "\<[bwglsav]:\h[a-zA-Z0-9#_]*\>"
@@ -113,7 +192,7 @@ syn keyword vimFTOption contained	detect indent off on plugin
 " Augroup : vimAugroupError removed because long augroups caused sync'ing problems. {{{2
 " ======= : Trade-off: Increasing synclines with slower editing vs augroup END error checking.
 syn cluster vimAugroupList	contains=vimAugroup,vimIsCommand,vimCommand,vimUserCmd,vimExecute,vimNotFunc,vimFuncName,vimFunction,vimFunctionError,vimLineComment,vimMap,vimSpecFile,vimOper,vimNumber,vimOperParen,vimComment,vimString,vimSubst,vimMark,vimRegister,vimAddress,vimFilter,vimCmplxRepeat,vimComment,vimLet,vimSet,vimAutoCmd,vimRegion,vimSynLine,vimNotation,vimCtrlChar,vimFuncVar,vimContinue
-if exists("g:vimsyn_folding") && g:vimsyn_folding =~ 'a'
+if exists("g:vimsyn_folding") && g:vimsyn_folding =~# 'a'
  syn region  vimAugroup	fold matchgroup=vimAugroupKey start="\<aug\%[roup]\>\ze\s\+\K\k*" end="\<aug\%[roup]\>\ze\s\+[eE][nN][dD]\>"	contains=vimAutoCmd,@vimAugroupList
 else
  syn region  vimAugroup	matchgroup=vimAugroupKey start="\<aug\%[roup]\>\ze\s\+\K\k*" end="\<aug\%[roup]\>\ze\s\+[eE][nN][dD]\>"	contains=vimAutoCmd,@vimAugroupList
@@ -130,7 +209,7 @@ syn cluster	vimOperGroup	contains=vimEnvvar,vimFunc,vimFuncVar,vimOper,vimOperPa
 syn match	vimOper	"\(==\|!=\|>=\|<=\|=\~\|!\~\|>\|<\|=\)[?#]\{0,2}"	skipwhite nextgroup=vimString,vimSpecFile
 syn match	vimOper	"||\|&&\|[-+.]"	skipwhite nextgroup=vimString,vimSpecFile
 syn region	vimOperParen 	matchgroup=vimParenSep	start="(" end=")" contains=@vimOperGroup
-syn region	vimOperParen	matchgroup=vimSep	start="{" end="}" contains=@vimOperGroup nextgroup=vimVar,vimFuncVar
+syn region	vimOperParen	matchgroup=vimSep		start="{" end="}" contains=@vimOperGroup nextgroup=vimVar,vimFuncVar
 if !exists("g:vimsyn_noerror") && !exists("g:vimsyn_noopererror")
  syn match	vimOperError	")"
 endif
@@ -138,10 +217,10 @@ endif
 " Functions : Tag is provided for those who wish to highlight tagged functions {{{2
 " =========
 syn cluster	vimFuncList	contains=vimCommand,vimFunctionError,vimFuncKey,Tag,vimFuncSID
-syn cluster	vimFuncBodyList	contains=vimAbb,vimAddress,vimAugroupKey,vimAutoCmd,vimCmplxRepeat,vimComment,vimComment,vimContinue,vimCtrlChar,vimEcho,vimEchoHL,vimExecute,vimIf,vimIsCommand,vimFBVar,vimFunc,vimFunction,vimFuncVar,vimGlobal,vimHighlight,vimIsCommand,vimLet,vimLineComment,vimMap,vimMark,vimNorm,vimNotation,vimNotFunc,vimNumber,vimOper,vimOperParen,vimRegion,vimRegister,vimSet,vimSpecFile,vimString,vimSubst,vimSynLine,vimUnmap,vimUserCommand,nvimUnmap,nvimMap
+syn cluster	vimFuncBodyList	contains=vimAbb,vimAddress,vimAugroupKey,vimAutoCmd,vimCmplxRepeat,vimComment,vimComment,vimContinue,vimCtrlChar,vimEcho,vimEchoHL,vimExecute,vimIf,vimIsCommand,vimFBVar,vimFunc,vimFunction,vimFuncVar,vimGlobal,vimHighlight,vimIsCommand,vimLet,vimLineComment,vimMap,vimMark,vimNorm,vimNotation,vimNotFunc,vimNumber,vimOper,vimOperParen,vimRegion,vimRegister,vimSet,vimSpecFile,vimString,vimSubst,vimSynLine,vimUnmap,vimUserCommand
 syn match	vimFunction	"\<fu\%[nction]!\=\s\+\%(<[sS][iI][dD]>\|[sSgGbBwWtTlL]:\)\=\%(\i\|[#.]\|{.\{-1,}}\)*\ze\s*("	contains=@vimFuncList nextgroup=vimFuncBody
 
-if exists("g:vimsyn_folding") && g:vimsyn_folding =~ 'f'
+if exists("g:vimsyn_folding") && g:vimsyn_folding =~# 'f'
  syn region	vimFuncBody  contained	fold start="\ze\s*("	matchgroup=vimCommand end="\<\(endf\>\|endfu\%[nction]\>\)"		contains=@vimFuncBodyList
 else
  syn region	vimFuncBody  contained	start="\ze\s*("	matchgroup=vimCommand end="\<\(endf\>\|endfu\%[nction]\>\)"		contains=@vimFuncBodyList
@@ -225,7 +304,7 @@ syn cluster	vimSubstList	contains=vimPatSep,vimPatRegion,vimPatSepErr,vimSubstTw
 syn cluster	vimSubstRepList	contains=vimSubstSubstr,vimSubstTwoBS,vimNotation
 syn cluster	vimSubstList	add=vimCollection
 syn match	vimSubst	"\(:\+\s*\|^\s*\||\s*\)\<\%(s\%[ubstitute]\|sm\%[agic]\|sno\%[magic]\)[:[:alpha:]]\@!" nextgroup=vimSubstPat
-syn match	vimSubst	"s\%[ubstitute][:#[:alpha:]]\@!"	nextgroup=vimSubstPat contained
+syn match	vimSubst	"\%(^\|[^\\]\)s\%[ubstitute][:#[:alpha:]]\@!"	nextgroup=vimSubstPat contained
 syn match	vimSubst	"/\zss\%[ubstitute]\ze/"	nextgroup=vimSubstPat
 syn match	vimSubst1       contained	"s\%[ubstitute]\>"	nextgroup=vimSubstPat
 syn region	vimSubstPat     contained	matchgroup=vimSubstDelim start="\z([^a-zA-Z( \t[\]&]\)"rs=s+1 skip="\\\\\|\\\z1" end="\z1"re=e-1,me=e-1	 contains=@vimSubstList	nextgroup=vimSubstRep4	oneline
@@ -267,7 +346,7 @@ syn match	vimCmplxRepeat	'[^a-zA-Z_/\\()]q[0-9a-zA-Z"]\>'lc=1
 syn match	vimCmplxRepeat	'@[0-9a-z".=@:]\ze\($\|[^a-zA-Z]\>\)'
 
 " Set command and associated set-options (vimOptions) with comment {{{2
-syn region	vimSet		matchgroup=vimCommand start="\<\%(setl\%[ocal]\|setg\%[lobal]\|se\%[t]\)\>" skip="\%(\\\\\)*\\." end="$" matchgroup=vimNotation end="<[cC][rR]>" keepend oneline contains=vimSetEqual,vimOption,vimErrSetting,vimComment,vimSetString,vimSetMod,vimTermOption,vimOnlyOption
+syn region	vimSet		matchgroup=vimCommand start="\<\%(setl\%[ocal]\|setg\%[lobal]\|se\%[t]\)\>" skip="\%(\\\\\)*\\." end="$" matchgroup=vimNotation end="<[cC][rR]>" keepend oneline contains=vimSetEqual,vimOption,vimErrSetting,vimComment,vimSetString,vimSetMod
 syn region	vimSetEqual	contained	start="[=:]\|[-+^]=" skip="\\\\\|\\\s" end="[| \t]\|$"me=e-1 contains=vimCtrlChar,vimSetSep,vimNotation,vimEnvvar oneline
 syn region	vimSetString	contained	start=+="+hs=s+1	skip=+\\\\\|\\"+  end=+"+	contains=vimCtrlChar
 syn match	vimSetSep	contained	"[,:]" skipwhite nextgroup=vimCommand
@@ -283,7 +362,7 @@ syn keyword vimAbb	ab[breviate] ca[bbrev] inorea[bbrev] cnorea[bbrev] norea[bbre
 
 " Autocmd {{{2
 " =======
-syn match	vimAutoEventList	contained	"\(!\s\+\)\=\(\a\+,\)*\a\+"	contains=vimAutoEvent,nvimAutoEvent nextgroup=vimAutoCmdSpace
+syn match	vimAutoEventList	contained	"\(!\s\+\)\=\(\a\+,\)*\a\+"	contains=vimAutoEvent nextgroup=vimAutoCmdSpace
 syn match	vimAutoCmdSpace	contained	"\s\+"	nextgroup=vimAutoCmdSfxList
 syn match	vimAutoCmdSfxList	contained	"\S*"
 syn keyword	vimAutoCmd	au[tocmd] do[autocmd] doautoa[ll]	skipwhite nextgroup=vimAutoEventList
@@ -292,7 +371,7 @@ syn keyword	vimAutoCmd	au[tocmd] do[autocmd] doautoa[ll]	skipwhite nextgroup=vim
 " ================
 syn region	vimEcho	oneline excludenl matchgroup=vimCommand start="\<ec\%[ho]\>" skip="\(\\\\\)*\\|" end="$\||" contains=vimFunc,vimFuncVar,vimString,vimVar
 syn region	vimExecute	oneline excludenl matchgroup=vimCommand start="\<exe\%[cute]\>" skip="\(\\\\\)*\\|" end="$\||\|<[cC][rR]>" contains=vimFuncVar,vimIsCommand,vimOper,vimNotation,vimOperParen,vimString,vimVar
-syn match	vimEchoHL	"echohl\="	skipwhite nextgroup=vimGroup,vimHLGroup,vimEchoHLNone,vimOnlyHLGroup,nvimHLGroup
+syn match	vimEchoHL	"echohl\="	skipwhite nextgroup=vimGroup,vimHLGroup,vimEchoHLNone
 syn case ignore
 syn keyword	vimEchoHLNone	none
 syn case match
@@ -301,10 +380,8 @@ syn case match
 " ====
 syn match	vimMap		"\<map\>!\=\ze\s*[^(]" skipwhite nextgroup=vimMapMod,vimMapLhs
 syn keyword	vimMap		cm[ap] cno[remap] im[ap] ino[remap] lm[ap] ln[oremap] nm[ap] nn[oremap] no[remap] om[ap] ono[remap] smap snor[emap] vm[ap] vn[oremap] xm[ap] xn[oremap] skipwhite nextgroup=vimMapBang,vimMapMod,vimMapLhs
-syn keyword	nvimMap		tn[oremap] tm[ap] skipwhite nextgroup=vimMapBang,vimMapMod,vimMapLhs
 syn keyword	vimMap		mapc[lear] smapc[lear]
 syn keyword	vimUnmap		cu[nmap] iu[nmap] lu[nmap] nun[map] ou[nmap] sunm[ap] unm[ap] unm[ap] vu[nmap] xu[nmap] skipwhite nextgroup=vimMapBang,vimMapMod,vimMapLhs
-syn keyword	nvimUnmap 		tunm[ap] skipwhite nextgroup=vimMapBang,vimMapMod,vimMapLhs
 syn match	vimMapLhs	contained	"\S\+"			contains=vimNotation,vimCtrlChar skipwhite nextgroup=vimMapRhs
 syn match	vimMapBang	contained	"!"			skipwhite nextgroup=vimMapMod,vimMapLhs
 syn match	vimMapMod	contained	"\c<\(buffer\|expr\|\(local\)\=leader\|nowait\|plug\|script\|sid\|unique\|silent\)\+>" contains=vimMapModKey,vimMapModErr skipwhite nextgroup=vimMapMod,vimMapLhs
@@ -341,8 +418,8 @@ syn case match
 " User Function Highlighting {{{2
 " (following Gautam Iyer's suggestion)
 " ==========================
-syn match vimFunc		"\%(\%([sSgGbBwWtTlL]:\|<[sS][iI][dD]>\)\=\%([a-zA-Z0-9_.]\+\.\)*\I[a-zA-Z0-9_.]*\)\ze\s*("		contains=vimFuncName,vimUserFunc,vimExecute
-syn match vimUserFunc contained	"\%(\%([sSgGbBwWtTlL]:\|<[sS][iI][dD]>\)\=\%([a-zA-Z0-9_.]\+\.\)*\I[a-zA-Z0-9_.]*\)\|\<\u[a-zA-Z0-9.]*\>\|\<if\>"	contains=vimNotation
+syn match vimFunc		"\%(\%([sSgGbBwWtTlL]:\|<[sS][iI][dD]>\)\=\%([a-zA-Z0-9_]\+\.\)*\I[a-zA-Z0-9_.]*\)\ze\s*("		contains=vimFuncName,vimUserFunc,vimExecute
+syn match vimUserFunc contained	"\%(\%([sSgGbBwWtTlL]:\|<[sS][iI][dD]>\)\=\%([a-zA-Z0-9_]\+\.\)*\I[a-zA-Z0-9_.]*\)\|\<\u[a-zA-Z0-9.]*\>\|\<if\>"	contains=vimNotation
 syn match vimNotFunc	"\<if\>\|\<el\%[seif]\>\|\<return\>\|\<while\>"
 
 " Errors And Warnings: {{{2
@@ -388,10 +465,15 @@ syn keyword	vimSynType	contained	clear	skipwhite nextgroup=vimGroupList
 
 " Syntax: cluster {{{2
 syn keyword	vimSynType	contained	cluster	skipwhite nextgroup=vimClusterName
-syn region	vimClusterName	contained	matchgroup=vimGroupName start="\k\+" skip="\\\\\|\\|" matchgroup=vimSep end="$\||" contains=vimGroupAdd,vimGroupRem,vimSynContains,vimSynError
+syn region	vimClusterName	contained	matchgroup=vimGroupName start="\h\w*" skip="\\\\\|\\|" matchgroup=vimSep end="$\||" contains=vimGroupAdd,vimGroupRem,vimSynContains,vimSynError
 syn match	vimGroupAdd	contained	"add="	nextgroup=vimGroupList
 syn match	vimGroupRem	contained	"remove="	nextgroup=vimGroupList
 syn cluster vimFuncBodyList add=vimSynType,vimGroupAdd,vimGroupRem
+
+" Syntax: iskeyword {{{2
+syn keyword	vimSynType	contained	iskeyword	skipwhite nextgroup=vimIskList
+syn match	vimIskList	contained	'\S\+'	contains=vimIskSep
+syn match	vimIskSep	contained	','
 
 " Syntax: include {{{2
 syn keyword	vimSynType	contained	include	skipwhite nextgroup=vimGroupList
@@ -400,14 +482,14 @@ syn cluster vimFuncBodyList add=vimSynType
 " Syntax: keyword {{{2
 syn cluster	vimSynKeyGroup	contains=vimSynNextgroup,vimSynKeyOpt,vimSynKeyContainedin
 syn keyword	vimSynType	contained	keyword	skipwhite nextgroup=vimSynKeyRegion
-syn region	vimSynKeyRegion	contained oneline keepend	matchgroup=vimGroupName start="\k\+" skip="\\\\\|\\|" matchgroup=vimSep end="|\|$" contains=@vimSynKeyGroup
+syn region	vimSynKeyRegion	contained oneline keepend	matchgroup=vimGroupName start="\h\w*" skip="\\\\\|\\|" matchgroup=vimSep end="|\|$" contains=@vimSynKeyGroup
 syn match	vimSynKeyOpt	contained	"\<\(conceal\|contained\|transparent\|skipempty\|skipwhite\|skipnl\)\>"
 syn cluster vimFuncBodyList add=vimSynType
 
 " Syntax: match {{{2
 syn cluster	vimSynMtchGroup	contains=vimMtchComment,vimSynContains,vimSynError,vimSynMtchOpt,vimSynNextgroup,vimSynRegPat,vimNotation
 syn keyword	vimSynType	contained	match	skipwhite nextgroup=vimSynMatchRegion
-syn region	vimSynMatchRegion	contained keepend	matchgroup=vimGroupName start="\k\+" matchgroup=vimSep end="|\|$" contains=@vimSynMtchGroup
+syn region	vimSynMatchRegion	contained keepend	matchgroup=vimGroupName start="\h\w*" matchgroup=vimSep end="|\|$" contains=@vimSynMtchGroup
 syn match	vimSynMtchOpt	contained	"\<\(conceal\|transparent\|contained\|excludenl\|skipempty\|skipwhite\|display\|extend\|skipnl\|fold\)\>"
 if has("conceal")
  syn match	vimSynMtchOpt	contained	"\<cchar="	nextgroup=vimSynMtchCchar
@@ -422,10 +504,10 @@ syn keyword	vimSynType	contained	enable	list	manual	off	on	reset
 syn cluster	vimSynRegPatGroup	contains=vimPatSep,vimNotPatSep,vimSynPatRange,vimSynNotPatRange,vimSubstSubstr,vimPatRegion,vimPatSepErr,vimNotation
 syn cluster	vimSynRegGroup	contains=vimSynContains,vimSynNextgroup,vimSynRegOpt,vimSynReg,vimSynMtchGrp
 syn keyword	vimSynType	contained	region	skipwhite nextgroup=vimSynRegion
-syn region	vimSynRegion	contained keepend	matchgroup=vimGroupName start="\k\+" skip="\\\\\|\\|" end="|\|$" contains=@vimSynRegGroup
+syn region	vimSynRegion	contained keepend	matchgroup=vimGroupName start="\h\w*" skip="\\\\\|\\|" end="|\|$" contains=@vimSynRegGroup
 syn match	vimSynRegOpt	contained	"\<\(conceal\(ends\)\=\|transparent\|contained\|excludenl\|skipempty\|skipwhite\|display\|keepend\|oneline\|extend\|skipnl\|fold\)\>"
 syn match	vimSynReg	contained	"\(start\|skip\|end\)="he=e-1	nextgroup=vimSynRegPat
-syn match	vimSynMtchGrp	contained	"matchgroup="	nextgroup=vimGroup,vimHLGroup,vimOnlyHLGroup,nvimHLGroup
+syn match	vimSynMtchGrp	contained	"matchgroup="	nextgroup=vimGroup,vimHLGroup
 syn region	vimSynRegPat	contained extend	start="\z([-`~!@#$%^&*_=+;:'",./?]\)"  skip="\\\\\|\\\z1"  end="\z1"  contains=@vimSynRegPatGroup skipwhite nextgroup=vimSynPatMod,vimSynReg
 syn match	vimSynPatMod	contained	"\(hs\|ms\|me\|hs\|he\|rs\|re\)=[se]\([-+]\d\+\)\="
 syn match	vimSynPatMod	contained	"\(hs\|ms\|me\|hs\|he\|rs\|re\)=[se]\([-+]\d\+\)\=," nextgroup=vimSynPatMod
@@ -448,9 +530,9 @@ syn keyword	vimSyncRegion	contained	region	skipwhite	nextgroup=vimSynReg
 syn match	vimSyncLinebreak	contained	"\<linebreaks="	skipwhite	nextgroup=vimNumber
 syn keyword	vimSyncLinecont	contained	linecont	skipwhite	nextgroup=vimSynRegPat
 syn match	vimSyncLines	contained	"\(min\|max\)\=lines="	nextgroup=vimNumber
-syn match	vimSyncGroupName	contained	"\k\+"	skipwhite	nextgroup=vimSyncKey
+syn match	vimSyncGroupName	contained	"\h\w*"	skipwhite	nextgroup=vimSyncKey
 syn match	vimSyncKey	contained	"\<groupthere\|grouphere\>"	skipwhite nextgroup=vimSyncGroup
-syn match	vimSyncGroup	contained	"\k\+"	skipwhite	nextgroup=vimSynRegPat,vimSyncNone
+syn match	vimSyncGroup	contained	"\h\w*"	skipwhite	nextgroup=vimSynRegPat,vimSyncNone
 syn keyword	vimSyncNone	contained	NONE
 
 " Additional IsCommand, here by reasons of precedence {{{2
@@ -502,7 +584,7 @@ syn match	vimHiNmbr	contained	'\d\+'
 syn keyword	vimHiClear	contained	clear	nextgroup=vimHiGroup
 
 " Highlight: link {{{2
-syn region	vimHiLink	contained oneline matchgroup=vimCommand start="\(\<hi\%[ghlight]\s\+\)\@<=\(\(def\%[ault]\s\+\)\=link\>\|\<def\>\)" end="$"	contains=vimHiGroup,vimGroup,vimHLGroup,vimNotation,vimOnlyHLGroup,nvimHLGroup
+syn region	vimHiLink	contained oneline matchgroup=vimCommand start="\(\<hi\%[ghlight]\s\+\)\@<=\(\(def\%[ault]\s\+\)\=link\>\|\<def\>\)" end="$"	contains=vimHiGroup,vimGroup,vimHLGroup,vimNotation
 syn cluster vimFuncBodyList add=vimHiLink
 
 " Control Characters {{{2
@@ -531,9 +613,14 @@ syn region	vimGlobal	matchgroup=Statement start='\<v\%[global]!\=/' skip='\\.' e
 " Allows users to specify the type of embedded script highlighting
 " they want:  (perl/python/ruby/tcl support)
 "   g:vimsyn_embed == 0   : don't embed any scripts
-"   g:vimsyn_embed ~= 'P' : embed python   (but only if vim supports it)
+"   g:vimsyn_embed =~# 'l' : embed lua      (but only if vim supports it)
+"   g:vimsyn_embed =~# 'm' : embed mzscheme (but only if vim supports it)
+"   g:vimsyn_embed =~# 'p' : embed perl     (but only if vim supports it)
+"   g:vimsyn_embed =~# 'P' : embed python   (but only if vim supports it)
+"   g:vimsyn_embed =~# 'r' : embed ruby     (but only if vim supports it)
+"   g:vimsyn_embed =~# 't' : embed tcl      (but only if vim supports it)
 if !exists("g:vimsyn_embed")
- let g:vimsyn_embed= "P"
+ let g:vimsyn_embed= "lmpPr"
 endif
 
 " [-- lua --] {{{3
@@ -546,9 +633,16 @@ if !filereadable(s:luapath)
   endif
  endfor
 endif
-
-syn region vimEmbedError start=+lua\s*<<\s*\z(.*\)$+ end=+^\z1$+
-syn region vimEmbedError start=+lua\s*<<\s*$+ end=+\.$+
+if (g:vimsyn_embed =~# 'l' && has("lua")) && filereadable(s:luapath)
+ unlet! b:current_syntax
+ exe "syn include @vimLuaScript ".s:luapath
+ VimFoldl syn region vimLuaRegion matchgroup=vimScriptDelim start=+lua\s*<<\s*\z(.*\)$+ end=+^\z1$+	contains=@vimLuaScript
+ VimFoldl syn region vimLuaRegion matchgroup=vimScriptDelim start=+lua\s*<<\s*$+ end=+\.$+		contains=@vimLuaScript
+ syn cluster vimFuncBodyList	add=vimLuaRegion
+else
+ syn region vimEmbedError start=+lua\s*<<\s*\z(.*\)$+ end=+^\z1$+
+ syn region vimEmbedError start=+lua\s*<<\s*$+ end=+\.$+
+endif
 unlet s:luapath
 
 " [-- perl --] {{{3
@@ -561,9 +655,16 @@ if !filereadable(s:perlpath)
   endif
  endfor
 endif
-
-syn region vimEmbedError start=+pe\%[rl]\s*<<\s*\z(.*\)$+ end=+^\z1$+
-syn region vimEmbedError start=+pe\%[rl]\s*<<\s*$+ end=+\.$+
+if (g:vimsyn_embed =~# 'p' && has("perl")) && filereadable(s:perlpath)
+ unlet! b:current_syntax
+ exe "syn include @vimPerlScript ".s:perlpath
+ VimFoldp syn region vimPerlRegion  matchgroup=vimScriptDelim start=+pe\%[rl]\s*<<\s*\z(.*\)$+ end=+^\z1$+	contains=@vimPerlScript
+ VimFoldp syn region vimPerlRegion	matchgroup=vimScriptDelim start=+pe\%[rl]\s*<<\s*$+ end=+\.$+	contains=@vimPerlScript
+ syn cluster vimFuncBodyList	add=vimPerlRegion
+else
+ syn region vimEmbedError start=+pe\%[rl]\s*<<\s*\z(.*\)$+ end=+^\z1$+
+ syn region vimEmbedError start=+pe\%[rl]\s*<<\s*$+ end=+\.$+
+endif
 unlet s:perlpath
 
 " [-- ruby --] {{{3
@@ -576,9 +677,16 @@ if !filereadable(s:rubypath)
   endif
  endfor
 endif
-
-syn region vimEmbedError start=+rub[y]\s*<<\s*\z(.*\)$+ end=+^\z1$+
-syn region vimEmbedError start=+rub[y]\s*<<\s*$+ end=+\.$+
+if (g:vimsyn_embed =~# 'r' && has("ruby")) && filereadable(s:rubypath)
+ unlet! b:current_syntax
+ exe "syn include @vimRubyScript ".s:rubypath
+ VimFoldr syn region vimRubyRegion matchgroup=vimScriptDelim start=+rub[y]\s*<<\s*\z(.*\)$+ end=+^\z1$+	contains=@vimRubyScript
+ syn region vimRubyRegion matchgroup=vimScriptDelim start=+rub[y]\s*<<\s*$+ end=+\.$+		contains=@vimRubyScript
+ syn cluster vimFuncBodyList	add=vimRubyRegion
+else
+ syn region vimEmbedError start=+rub[y]\s*<<\s*\z(.*\)$+ end=+^\z1$+
+ syn region vimEmbedError start=+rub[y]\s*<<\s*$+ end=+\.$+
+endif
 unlet s:rubypath
 
 " [-- python --] {{{3
@@ -591,16 +699,13 @@ if !filereadable(s:pythonpath)
   endif
  endfor
 endif
-if g:vimsyn_embed =~ 'P' && filereadable(s:pythonpath)
+if g:vimsyn_embed =~# 'P' && (has("python") || has("python3")) && filereadable(s:pythonpath)
  unlet! b:current_syntax
  exe "syn include @vimPythonScript ".s:pythonpath
- if exists("g:vimsyn_folding") && g:vimsyn_folding =~ 'P'
-  syn region vimPythonRegion fold matchgroup=vimScriptDelim start=+py\%[thon]3\=\s*<<\s*\z(.*\)$+ end=+^\z1$+	contains=@vimPythonScript
-  syn region vimPythonRegion fold matchgroup=vimScriptDelim start=+py\%[thon]3\=\s*<<\s*$+ end=+\.$+		contains=@vimPythonScript
- else
-  syn region vimPythonRegion matchgroup=vimScriptDelim start=+py\%[thon]3\=\s*<<\s*\z(.*\)$+ end=+^\z1$+		contains=@vimPythonScript
-  syn region vimPythonRegion matchgroup=vimScriptDelim start=+py\%[thon]3\=\s*<<\s*$+ end=+\.$+		contains=@vimPythonScript
- endif
+ VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+py\%[thon]3\=\s*<<\s*\z(.*\)$+ end=+^\z1$+	contains=@vimPythonScript
+ VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+py\%[thon]3\=\s*<<\s*$+ end=+\.$+		contains=@vimPythonScript
+ VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+Py\%[thon]2or3\s*<<\s*\z(.*\)$+ end=+^\z1$+		contains=@vimPythonScript
+ VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+Py\%[thon]2or3\=\s*<<\s*$+ end=+\.$+		contains=@vimPythonScript
  syn cluster vimFuncBodyList	add=vimPythonRegion
 else
  syn region vimEmbedError start=+py\%[thon]3\=\s*<<\s*\z(.*\)$+ end=+^\z1$+
@@ -625,11 +730,17 @@ if s:trytcl
    endif
   endfor
  endif
-
- syn region vimEmbedError start=+tc[l]\=\s*<<\s*\z(.*\)$+ end=+^\z1$+
- syn region vimEmbedError start=+tc[l]\=\s*<<\s*$+ end=+\.$+
+ if (g:vimsyn_embed =~# 't' && has("tcl")) && filereadable(s:tclpath)
+  unlet! b:current_syntax
+  exe "syn include @vimTclScript ".s:tclpath
+  VimFoldt syn region vimTclRegion matchgroup=vimScriptDelim start=+tc[l]\=\s*<<\s*\z(.*\)$+ end=+^\z1$+	contains=@vimTclScript
+  VimFoldt syn region vimTclRegion matchgroup=vimScriptDelim start=+tc[l]\=\s*<<\s*$+ end=+\.$+	contains=@vimTclScript
+  syn cluster vimFuncBodyList	add=vimTclScript
+ else
+  syn region vimEmbedError start=+tc[l]\=\s*<<\s*\z(.*\)$+ end=+^\z1$+
+  syn region vimEmbedError start=+tc[l]\=\s*<<\s*$+ end=+\.$+
+ endif
  unlet s:tclpath
-
 else
  syn region vimEmbedError start=+tc[l]\=\s*<<\s*\z(.*\)$+ end=+^\z1$+
  syn region vimEmbedError start=+tc[l]\=\s*<<\s*$+ end=+\.$+
@@ -646,9 +757,18 @@ if !filereadable(s:mzschemepath)
   endif
  endfor
 endif
-
-syn region vimEmbedError start=+mz\%[scheme]\s*<<\s*\z(.*\)$+ end=+^\z1$+
-syn region vimEmbedError start=+mz\%[scheme]\s*<<\s*$+ end=+\.$+
+if (g:vimsyn_embed =~# 'm' && has("mzscheme")) && filereadable(s:mzschemepath)
+ unlet! b:current_syntax
+ let iskKeep= &isk
+ exe "syn include @vimMzSchemeScript ".s:mzschemepath
+ let &isk= iskKeep
+ VimFoldm syn region vimMzSchemeRegion matchgroup=vimScriptDelim start=+mz\%[scheme]\s*<<\s*\z(.*\)$+ end=+^\z1$+	contains=@vimMzSchemeScript
+ VimFoldm syn region vimMzSchemeRegion matchgroup=vimScriptDelim start=+mz\%[scheme]\s*<<\s*$+ end=+\.$+		contains=@vimMzSchemeScript
+ syn cluster vimFuncBodyList	add=vimMzSchemeRegion
+else
+ syn region vimEmbedError start=+mz\%[scheme]\s*<<\s*\z(.*\)$+ end=+^\z1$+
+ syn region vimEmbedError start=+mz\%[scheme]\s*<<\s*$+ end=+\.$+
+endif
 unlet s:mzschemepath
 
 " Synchronize (speed) {{{2
@@ -668,7 +788,6 @@ syn sync match vimAugroupSyncA	groupthere NONE	"\<aug\%[roup]\>\s\+[eE][nN][dD]"
 " Highlighting Settings {{{2
 " ====================
 
-
 if !exists("g:vimsyn_noerror")
  hi def link vimBehaveError	vimError
  hi def link vimCollClassErr	vimError
@@ -685,20 +804,16 @@ if !exists("g:vimsyn_noerror")
  hi def link vimSubstFlagErr	vimError
  hi def link vimSynCaseError	vimError
  hi def link vimBufnrWarn	vimWarn
- hi def link vimOnlyCommand	vimError
- hi def link vimTermOption	vimError
- hi def link vimOnlyOption	vimError
- hi def link vimOnlyHLGroup	vimError
 endif
 
 hi def link vimAbb	vimCommand
 hi def link vimAddress	vimMark
+hi def link vimAugroupError	vimError
 hi def link vimAugroupKey	vimCommand
 hi def link vimAuHighlight	vimHighlight
 hi def link vimAutoCmdOpt	vimOption
 hi def link vimAutoCmd	vimCommand
 hi def link vimAutoEvent	Type
-hi def link nvimAutoEvent	vimAutoEvent
 hi def link vimAutoSet	vimCommand
 hi def link vimBehaveModel	vimBehave
 hi def link vimBehave	vimCommand
@@ -745,9 +860,9 @@ hi def link vimHiNmbr	Number
 hi def link vimHiStartStop	vimHiTerm
 hi def link vimHiTerm	Type
 hi def link vimHLGroup	vimGroup
-hi def link nvimHLGroup	vimHLGroup
 hi def link vimHLMod	PreProc
 hi def link vimInsert	vimString
+hi def link vimIskSep	Delimiter
 hi def link vimKeyCode	vimSpecFile
 hi def link vimKeyword	Statement
 hi def link vimLet	vimCommand
@@ -756,7 +871,6 @@ hi def link vimMapBang	vimCommand
 hi def link vimMapModKey	vimFuncSID
 hi def link vimMapMod	vimBracket
 hi def link vimMap	vimCommand
-hi def link nvimMap	vimMap
 hi def link vimMark	Number
 hi def link vimMarkNumber	vimNumber
 hi def link vimMenuMod	vimMapMod
@@ -825,11 +939,11 @@ hi def link vimSyntax	vimCommand
 hi def link vimSynType	vimSpecial
 hi def link vimTodo	Todo
 hi def link vimUnmap	vimMap
-hi def link nvimUnmap	vimMap
 hi def link vimUserAttrbCmpltFunc	Special
 hi def link vimUserAttrbCmplt	vimSpecial
 hi def link vimUserAttrbKey	vimOption
 hi def link vimUserAttrb	vimSpecial
+hi def link vimUserAttrbError	Error
 hi def link vimUserCmdError	Error
 hi def link vimUserCommand	vimCommand
 hi def link vimUserFunc	Normal
@@ -841,6 +955,14 @@ let b:current_syntax = "vim"
 
 " ---------------------------------------------------------------------
 " Cleanup: {{{1
+delc VimFolda
+delc VimFoldf
+delc VimFoldl
+delc VimFoldm
+delc VimFoldp
+delc VimFoldP
+delc VimFoldr
+delc VimFoldt
 let &cpo = s:keepcpo
 unlet s:keepcpo
 " vim:ts=18  fdm=marker

--- a/src/nvim/po/eo.po
+++ b/src/nvim/po/eo.po
@@ -23,8 +23,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(Esperanto)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-13 23:42+0100\n"
-"PO-Revision-Date: 2016-02-13 23:45+0100\n"
+"POT-Creation-Date: 2016-03-29 23:03+0200\n"
+"PO-Revision-Date: 2016-03-29 23:05+0200\n"
 "Last-Translator: Dominique PELLÉ <dominique.pelle@gmail.com>\n"
 "Language-Team: \n"
 "Language: eo\n"
@@ -1348,6 +1348,10 @@ msgstr "E154: Ripetita etikedo \"%s\" en dosiero %s/%s"
 
 #: ../ex_cmds.c:5687
 #, c-format
+msgid "E150: Not a directory: %s"
+msgstr "E150: Ne estas dosierujo: %s"
+
+#, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Nekonata simbola komando: %s"
 
@@ -1482,8 +1486,8 @@ msgstr "Serĉado de \"%s\""
 
 #: ../ex_cmds2.c:2307
 #, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "ne trovita en 'runtimepath': \"%s\""
+msgid "not found in '%s': \"%s\""
+msgstr "ne trovita en '%s: \"%s\""
 
 #: ../ex_cmds2.c:2472
 #, c-format
@@ -6685,6 +6689,12 @@ msgstr "E446: Neniu dosiernomo sub la kursoro"
 
 #~ msgid "E232: Cannot create BalloonEval with both message and callback"
 #~ msgstr "E232: Ne eblas krei BalloonEval kun ambaŭ mesaĝo kaj reagfunkcio"
+
+msgid "Yes"
+msgstr "Jes"
+
+msgid "No"
+msgstr "Ne"
 
 # todo '_' is for hotkey, i guess?
 #~ msgid "Input _Methods"

--- a/src/nvim/po/fr.po
+++ b/src/nvim/po/fr.po
@@ -645,7 +645,7 @@ msgstr "E708: [:] ne peut être spécifié qu'en dernier"
 
 #: ../eval.c:2439
 msgid "E709: [:] requires a List value"
-msgstr "E709: [:] requiert une Liste"
+msgstr "E709: [:] n?cessite une Liste"
 
 #: ../eval.c:2674
 msgid "E710: List value has more items than target"
@@ -1400,6 +1400,10 @@ msgstr " sur 1 ligne"
 msgid " on %<PRId64> lines"
 msgstr " sur %<PRId64> lignes"
 
+#, c-format
+msgid "E150: Not a directory: %s"
+msgstr "E150: %s n'est pas un r?pertoire"
+
 # AB - Il faut respecter l'esprit plus que la lettre.
 # AB - Ce message devrait contenir une référence à :vglobal.
 #: ../ex_cmds.c:4438
@@ -1639,8 +1643,8 @@ msgstr "Recherche de \"%s\""
 
 #: ../ex_cmds2.c:2307
 #, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "introuvable dans 'runtimepath' : \"%s\""
+msgid "not found in '%s': \"%s\""
+msgstr "introuvable dans '%s' : \"%s\""
 
 #: ../ex_cmds2.c:2472
 #, c-format
@@ -6877,6 +6881,12 @@ msgstr "E446: Aucun nom de fichier sous le curseur"
 #~ msgid "E232: Cannot create BalloonEval with both message and callback"
 #~ msgstr "E232: Impossible de créer un BalloonEval avec message ET callback"
 
+msgid "Yes"
+msgstr "Oui"
+
+msgid "No"
+msgstr "Non"
+
 # todo '_' is for hotkey, i guess?
 #~ msgid "Input _Methods"
 #~ msgstr "_Méthodes de saisie"
@@ -7000,6 +7010,17 @@ msgstr "E446: Aucun nom de fichier sous le curseur"
 #      fichier.
 #~ msgid "Directory\t*.nothing\n"
 #~ msgstr "Répertoire\t*.rien\n"
+
+#, c-format
+msgid "E671: Cannot find window title \"%s\""
+msgstr "E671: Titre de fen?tre \"%s\" introuvable"
+
+#, c-format
+msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+msgstr "E243: Argument non support? : \"-%s\" ; Utilisez la version OLE."
+
+msgid "E672: Unable to open window inside MDI application"
+msgstr "E672: Impossible d'ouvrir une fen?tre dans une application MDI"
 
 # DB - todo : perfectible.
 #~ msgid ""

--- a/src/nvim/testdir/test_ex_undo.vim
+++ b/src/nvim/testdir/test_ex_undo.vim
@@ -1,0 +1,19 @@
+" Tests for :undo
+
+func Test_ex_undo()
+  new ex-undo
+  setlocal ul=10
+  exe "normal ione\n\<Esc>"
+  setlocal ul=10
+  exe "normal itwo\n\<Esc>"
+  setlocal ul=10
+  exe "normal ithree\n\<Esc>"
+  call assert_equal(4, line('$'))
+  undo
+  call assert_equal(3, line('$'))
+  undo 1
+  call assert_equal(2, line('$'))
+  undo 0
+  call assert_equal(1, line('$'))
+  quit!
+endfunc


### PR DESCRIPTION
```
vim-patch:0c1ff16

updated runtime files.  Add avra syntax.

https://github.com/vim/vim/commit/0c1ff16b5467f97ce08134fdbc8198127bbe492a

vim-patch:939a1ab

Updated runtime files.

https://github.com/vim/vim/commit/939a1abe935a539f2d4c90a56cb0682cbaf3bbb0

vim-patch:8067a64

Add missing test file.

https://github.com/vim/vim/commit/8067a64852d6d134b493c5674e404225ed4bbe7d
```
