### PR TITLE
[RFC] Fix Python 2/3 health checks

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -141,7 +141,7 @@ endfunction
 function! s:check_python(version) abort
   call health#report_start('Python ' . a:version . ' provider')
 
-  let python_bin_name = 'python'.(a:version == 2 ? '2' : '3')
+  let python_bin_name = 'python'.(a:version == 2 ? '' : '3')
   let pyenv = resolve(exepath('pyenv'))
   let pyenv_root = exists('$PYENV_ROOT') ? resolve($PYENV_ROOT) : 'n'
   let venv = exists('$VIRTUAL_ENV') ? resolve($VIRTUAL_ENV) : ''

--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -100,13 +100,6 @@ function! s:version_info(python) abort
         \ 'import neovim; print(neovim.__file__)',
         \ '2>/dev/null']))
 
-  let nvim_path = s:trim(system([
-        \ 'python3',
-        \ '-c',
-        \ 'import neovim; print(neovim.__file__)'
-        \ ]))
-        " \ '2>/dev/null']))
-
   if empty(nvim_path)
     return [python_version, 'unable to find neovim executable', pypi_version, 'unable to get neovim executable']
   endif


### PR DESCRIPTION
## What bugs does this fix?
- Remove duplicate nvim_path declaration - It's the same as the declaration above it, but hardcoded to use `python3` and does not redirect stderr.
- Fix the names of the `python2` related variables to match the documentation and how they're defined in the pythonx provider.
## Reproduction steps:

I used `NVIM v0.1.5` on Debian Linux (but it's the same with master)
1. Have both python2 and python3 installed, plus virtualenv.
2. Run `virtualenv -p python2 /tmp/neovim2 && /tmp/neovim2/bin/pip install neovim`
3. Run `virtualenv -p python3 /tmp/neovim3 && /tmp/neovim3/bin/pip install neovim`
4. Run `nvim -u /tmp/minimal.vim -c CheckHealth`, where `/tmp/minimal.vim` consists of:

``` vim
let g:python_host_prog = "/tmp/neovim2/bin/python"
let g:python3_host_prog = "/tmp/neovim3/bin/python"
```
### Expected

```
## Python 2 provider
  - INFO: Using: g:python_host_prog = "/tmp/neovim2/bin/python"
  - INFO: Executable: /tmp/neovim2/bin/python
  - INFO: Python2 version: 2.7.9
  - INFO: python-neovim Version: 0.1.10
  - SUCCESS: Latest Neovim Python client is installed: (up to date)

## Python 3 provider
  - INFO: Using: g:python3_host_prog = "/tmp/neovim3/bin/python"
  - INFO: Executable: /tmp/neovim3/bin/python
  - INFO: Python3 version: 3.4.2
  - INFO: python-neovim Version: 0.1.10
  - SUCCESS: Latest Neovim Python client is installed: (up to date)
```
### Actual

```
## Python 2 provider
  - INFO: `g:python2_host_prog` is not set.  Searching for python in the environment.
  - INFO: Executable: /usr/bin/python
  - INFO: Python2 version: 2.7.9
  - INFO: python-neovim Version: unable to find neovim version
  - ERROR: Neovim Python client is not installed.
      - SUGGESTIONS:
        - Error found was: unable to find neovim version
        - Use the command `$ pip2 install neovim`
  - SUCCESS: Latest Neovim Python client is installed: (unknown)

## Python 3 provider
  - INFO: Using: g:python3_host_prog = "/tmp/neovim3/bin/python"
  - INFO: Executable: /tmp/neovim3/bin/python
  - INFO: Python3 version: 3.4.2
  - INFO: python-neovim Version: unable to find neovim version
  - ERROR: Neovim Python client is not installed.
      - SUGGESTIONS:
        - Error found was: unable to find neovim version
        - Use the command `$ pip3 install neovim`
  - SUCCESS: Latest Neovim Python client is installed: (unknown)
```
