### PR TITLE
[RFC] Makefile: add PREFIX variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ CLINT_ERRORS_FILE_PATH := /reports/clint/errors.json
 BUILD_TYPE ?= $(shell (type ninja > /dev/null 2>&1 && echo "Ninja") || \
     echo "Unix Makefiles")
 
+ifneq (,$(PREFIX))
+  CMAKE_FLAGS += -DCMAKE_INSTALL_PREFIX:PATH="$(PREFIX)"
+endif
+
 ifeq (,$(BUILD_TOOL))
   ifeq (Ninja,$(BUILD_TYPE))
     ifneq ($(shell cmake --help 2>/dev/null | grep Ninja),)

--- a/contrib/local.mk.example
+++ b/contrib/local.mk.example
@@ -2,7 +2,7 @@
 # Individual entries must be uncommented to take effect.
 
 # By default, the installation prefix is '/usr/local'.
-# CMAKE_EXTRA_FLAGS += -DCMAKE_INSTALL_PREFIX=/usr/local/nvim-latest
+# PREFIX := /usr/local/nvim-latest
 
 # These CFLAGS can be used in addition to those specified in CMakeLists.txt:
 # CMAKE_EXTRA_FLAGS="-DCMAKE_C_FLAGS=-ftrapv -Wlogical-op"


### PR DESCRIPTION
We use a Makefile which in turn uses cmake. If we wanted to set the install
prefix for cmake, we had to do this so far:

```
make CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=/tmp/nvim"
```

That's long and hard to remember. Following the conventions of other Makefiles,
this now works as well and is equivalent:

```
make PREFIX=/tmp/nvim
```
