### PR TITLE
[RFC] Enable CI testing of unsigned char and fix fallout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,10 @@ option(
 if(TRAVIS_CI_BUILD)
   message(STATUS "Travis CI build enabled.")
   add_definitions(-Werror)
+  if(DEFINED ENV{BUILD_32BIT})
+    # Get some test coverage for unsigned char
+    add_definitions(-funsigned-char)
+  endif()
 endif()
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/src/nvim/ex_eval.h
+++ b/src/nvim/ex_eval.h
@@ -35,7 +35,7 @@ struct condstack {
   int cs_looplevel;                     /* nr of nested ":while"s and ":for"s */
   int cs_trylevel;                      /* nr of nested ":try"s */
   eslist_T    *cs_emsg_silent_list;     /* saved values of "emsg_silent" */
-  char cs_lflags;                       /* loop flags: CSL_ flags */
+  int cs_lflags;                        /* loop flags: CSL_ flags */
 };
 # define cs_rettv       cs_pend.csp_rv
 # define cs_exception   cs_pend.csp_ex

--- a/src/nvim/ex_eval.h
+++ b/src/nvim/ex_eval.h
@@ -23,19 +23,19 @@ struct eslist_elem {
 #define CSTACK_LEN      50
 
 struct condstack {
-  short cs_flags[CSTACK_LEN];           /* CSF_ flags */
-  char cs_pending[CSTACK_LEN];          /* CSTP_: what's pending in ":finally"*/
+  int cs_flags[CSTACK_LEN];             // CSF_ flags
+  char cs_pending[CSTACK_LEN];          // CSTP_: what's pending in ":finally"
   union {
-    void    *csp_rv[CSTACK_LEN];        /* return typeval for pending return */
-    void    *csp_ex[CSTACK_LEN];        /* exception for pending throw */
+    void    *csp_rv[CSTACK_LEN];        // return typeval for pending return
+    void    *csp_ex[CSTACK_LEN];        // exception for pending throw
   }           cs_pend;
-  void        *cs_forinfo[CSTACK_LEN];   /* info used by ":for" */
-  int cs_line[CSTACK_LEN];              /* line nr of ":while"/":for" line */
-  int cs_idx;                           /* current entry, or -1 if none */
-  int cs_looplevel;                     /* nr of nested ":while"s and ":for"s */
-  int cs_trylevel;                      /* nr of nested ":try"s */
-  eslist_T    *cs_emsg_silent_list;     /* saved values of "emsg_silent" */
-  int cs_lflags;                        /* loop flags: CSL_ flags */
+  void        *cs_forinfo[CSTACK_LEN];  // info used by ":for"
+  int cs_line[CSTACK_LEN];              // line nr of ":while"/":for" line
+  int cs_idx;                           // current entry, or -1 if none
+  int cs_looplevel;                     // nr of nested ":while"s and ":for"s
+  int cs_trylevel;                      // nr of nested ":try"s
+  eslist_T    *cs_emsg_silent_list;     // saved values of "emsg_silent"
+  int cs_lflags;                        // loop flags: CSL_ flags
 };
 # define cs_rettv       cs_pend.csp_rv
 # define cs_exception   cs_pend.csp_ex

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1761,7 +1761,7 @@ static void cs_print_tags_priv(char **matches, char **cntxts,
  */
 static int cs_read_prompt(size_t i)
 {
-  char ch;
+  int ch;
   char        *buf = NULL;   /* buffer for possible error message from cscope */
   size_t bufpos = 0;
   char   *cs_emsg = _("E609: Cscope error: %s");
@@ -1774,7 +1774,7 @@ static int cs_read_prompt(size_t i)
   size_t maxlen = IOSIZE - cs_emsg_len;
 
   for (;; ) {
-    while ((ch = (char)getc(csinfo[i].fr_fp)) != EOF && ch != CSCOPE_PROMPT[0])
+    while ((ch = getc(csinfo[i].fr_fp)) != EOF && ch != CSCOPE_PROMPT[0])
       /* if there is room and char is printable */
       if (bufpos < maxlen - 1 && vim_isprintc(ch)) {
         // lazy buffer allocation
@@ -1783,7 +1783,7 @@ static int cs_read_prompt(size_t i)
         }
         {
           /* append character to the message */
-          buf[bufpos++] = ch;
+          buf[bufpos++] = (char)ch;
           buf[bufpos] = NUL;
           if (bufpos >= epromptlen
               && strcmp(&buf[bufpos - epromptlen], eprompt) == 0) {

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1762,7 +1762,7 @@ static void cs_print_tags_priv(char **matches, char **cntxts,
 static int cs_read_prompt(size_t i)
 {
   int ch;
-  char        *buf = NULL;   /* buffer for possible error message from cscope */
+  char        *buf = NULL;   // buffer for possible error message from cscope
   size_t bufpos = 0;
   char   *cs_emsg = _("E609: Cscope error: %s");
   size_t cs_emsg_len = strlen(cs_emsg);
@@ -1774,35 +1774,34 @@ static int cs_read_prompt(size_t i)
   size_t maxlen = IOSIZE - cs_emsg_len;
 
   for (;; ) {
-    while ((ch = getc(csinfo[i].fr_fp)) != EOF && ch != CSCOPE_PROMPT[0])
-      /* if there is room and char is printable */
+    while ((ch = getc(csinfo[i].fr_fp)) != EOF && ch != CSCOPE_PROMPT[0]) {
+      // if there is room and char is printable
       if (bufpos < maxlen - 1 && vim_isprintc(ch)) {
         // lazy buffer allocation
         if (buf == NULL) {
           buf = xmalloc(maxlen);
         }
-        {
-          /* append character to the message */
-          buf[bufpos++] = (char)ch;
+        // append character to the message
+        buf[bufpos++] = (char)ch;
+        buf[bufpos] = NUL;
+        if (bufpos >= epromptlen
+            && strcmp(&buf[bufpos - epromptlen], eprompt) == 0) {
+          // remove eprompt from buf
+          buf[bufpos - epromptlen] = NUL;
+
+          // print message to user
+          (void)EMSG2(cs_emsg, buf);
+
+          // send RETURN to cscope
+          (void)putc('\n', csinfo[i].to_fp);
+          (void)fflush(csinfo[i].to_fp);
+
+          // clear buf
+          bufpos = 0;
           buf[bufpos] = NUL;
-          if (bufpos >= epromptlen
-              && strcmp(&buf[bufpos - epromptlen], eprompt) == 0) {
-            /* remove eprompt from buf */
-            buf[bufpos - epromptlen] = NUL;
-
-            /* print message to user */
-            (void)EMSG2(cs_emsg, buf);
-
-            /* send RETURN to cscope */
-            (void)putc('\n', csinfo[i].to_fp);
-            (void)fflush(csinfo[i].to_fp);
-
-            /* clear buf */
-            bufpos = 0;
-            buf[bufpos] = NUL;
-          }
         }
       }
+    }
 
     for (size_t n = 0; n < strlen(CSCOPE_PROMPT); ++n) {
       if (n > 0)


### PR DESCRIPTION
ci: Force unsigned char usage for the 32bit build

Since C leaves whether char is signed or unsigned up to the implementer,
there are different defaults on different architectures.

Forcing unsigned char for one of our CI builds should help catch these
issues moving forward.

---

Change constack.cs_flags from char to int

This fixes the -Wconversion warning when char's type is unsigned.

```
../src/nvim/ex_eval.c: In function 'ex_while':
../src/nvim/ex_eval.c:1000:28: warning: conversion to 'char' from 'int' may alter its value [-Wconversion]
       cstack->cs_lflags &= ~CSL_HAD_LOOP;
                            ^
```

---

if_cscope: Fix conversion warnings when char defaults to unsigned

```
../src/nvim/if_cscope.c: In function 'cs_read_prompt':
../src/nvim/if_cscope.c:1771:47: warning: comparison is always true due to limited range of data type [-Wtype-limits]
     while ((ch = (char)getc(csinfo[i].fr_fp)) != EOF && ch != CSCOPE_PROMPT[0])
                                               ^~
../src/nvim/if_cscope.c:1804:14: warning: comparison is always false due to limited range of data type [-Wtype-limits]
       if (ch == EOF) {
              ^~
../src/nvim/if_cscope.c:1816:14: warning: negative integer implicitly converted to unsigned type [-Wsign-conversion]
         ch = EOF;
              ^~~
../src/nvim/if_cscope.c:1821:12: warning: comparison is always false due to limited range of data type [-Wtype-limits]
     if (ch == EOF)
            ^~
```

Since EOF is -1, it will be converted to a large unsigned value to
compare with unsigned char and never match.  Use an int to store the
return from getc so we can safely compare it and, once known to be
valid, cast it to char when storing it into buf.
