### PR TITLE
window: Fix cmd_with_count's formatting when sizeof(long) != 8

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -482,7 +482,7 @@ wingotofile:
 }
 
 static void cmd_with_count(char *cmd, char_u *bufp, size_t bufsize,
-                           long Prenum)
+                           int64_t Prenum)
 {
   size_t len = xstrlcpy((char *)bufp, cmd, bufsize);
 


### PR DESCRIPTION
On architectures where `sizeof(long)` != 8, "%" PRId64 will read junk from
memory.  This was seen on various Debian builds where
test/functional/legacy/close_count_spec.lua would fail due to `1<C-w>c`
emitting an error like `E488: Trailing characters: close-87944975647104`.

Changing the `Prenum` parameter to int64_t ensures it is safe to use
`"%" PRId64`, and make another small step towards removal of the use of
`long`.
