### PR TITLE
ui: Fix the call to utf_ambiguous_width

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1724,7 +1724,7 @@ int utf_class(int c)
   return 2;
 }
 
-int utf_ambiguous_width(int c)
+bool utf_ambiguous_width(int c)
 {
   return c >= 0x80 && (intable(ambiguous, ARRAY_SIZE(ambiguous), c)
                        || intable(emoji_all, ARRAY_SIZE(emoji_all), c));

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -397,9 +397,8 @@ static void send_output(uint8_t **ptr)
     size_t clen = (size_t)mb_ptr2len(p);
     UI_CALL(put, p, (size_t)clen);
     col++;
-    if (utf_ambiguous_width(*p)) {
+    if (utf_ambiguous_width(utf_ptr2char(p))) {
       pending_cursor_update = true;
-      flush_cursor_update();
     } else if (mb_ptr2cells(p) > 1) {
       // double cell character, blank the next cell
       UI_CALL(put, NULL, 0);


### PR DESCRIPTION
`utf_ambiguous_width` expects the Unicode character, but in 9e1c6596 I
just passed the first UTF-8 byte to the function.  This led to various
display problems because now many multi-cell characters weren't falling
into that part of the branch.

Also, to better align with the existing Vim code, remove the forced
cursor update.  Setting the flag will cause it to happen in the next
UI_CALL.

Closes #5448
