### PR TITLE
term_write(): Skip writes if stream was closed.

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -366,10 +366,10 @@ void terminal_resize(Terminal *term, uint16_t width, uint16_t height)
 void terminal_enter(void)
 {
   buf_T *buf = curbuf;
+  assert(buf->terminal);  // Should only be called when curbuf has a terminal.
   TerminalState state, *s = &state;
   memset(s, 0, sizeof(TerminalState));
   s->term = buf->terminal;
-  assert(s->term && "should only be called when curbuf has a terminal");
 
   // Ensure the terminal is properly sized.
   terminal_resize(s->term, 0, 0);

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -13,13 +13,19 @@ describe(':terminal', function()
     clear()
     screen = Screen.new(50, 4)
     screen:attach({rgb=false})
+    -- shell-test.c is a fake shell that prints its arguments and exits.
     nvim('set_option', 'shell', nvim_dir..'/shell-test')
     nvim('set_option', 'shellcmdflag', 'EXE')
-
   end)
 
+  -- Invokes `:terminal {cmd}` using a fake shell (shell-test.c) which prints
+  -- the {cmd} and exits immediately .
+  local function terminal_run_fake_shell_cmd(cmd)
+    execute("terminal "..(cmd and cmd or ""))
+  end
+
   it('with no argument, acts like termopen()', function()
-    execute('terminal')
+    terminal_run_fake_shell_cmd()
     wait()
     screen:expect([[
       ready $                                           |
@@ -30,7 +36,7 @@ describe(':terminal', function()
   end)
 
   it('executes a given command through the shell', function()
-    execute('terminal echo hi')
+    terminal_run_fake_shell_cmd('echo hi')
     wait()
     screen:expect([[
       ready $ echo hi                                   |
@@ -41,7 +47,7 @@ describe(':terminal', function()
   end)
 
   it('allows quotes and slashes', function()
-    execute([[terminal echo 'hello' \ "world"]])
+    terminal_run_fake_shell_cmd([[echo 'hello' \ "world"]])
     wait()
     screen:expect([[
       ready $ echo 'hello' \ "world"                    |
@@ -58,4 +64,16 @@ describe(':terminal', function()
       -- Verify that BufNew actually fired (else the test is invalid).
     eq('foo', eval('&shell'))
   end)
+
+  it('ignores writes if the backing stream closes', function()
+      terminal_run_fake_shell_cmd()
+      helpers.feed('iiXXXXXXX')
+      wait()
+      -- Race: Though the shell exited (and streams were closed by SIGCHLD
+      -- handler), :terminal cleanup is pending on the main-loop.
+      -- This write should be ignored (not crash, #5445).
+      helpers.feed('iiYYYYYYY')
+      wait()
+  end)
+
 end)


### PR DESCRIPTION
If the backing stream for a `:terminal` was closed (e.g. if the shell exits unexpectedly) there may be pending input on the loop which will be processed before the terminal close event (which is queued on the same loop).

`terminal_send` checks `term->closed` but this does not reflect the state of the underlying streams. The `terminal.c` module in fact has no knowledge of the streams (this seems intentional: it is abstracted as `TerminalOption.write_cb`).

The SIGCHLD handler (`pty_process_unix.c`) is executed immediately, and it triggers a stream teardown so `Stream.closed=false` (`TerminalJobData.in.closed`). When the pending writes are handled by `eval.c:term_write`, `wstream_write()` aborts because it sees the closed Stream.

To avoid that, check `in.closed` in `term_write()`.

References #5445
https://github.com/neovim/neovim/pull/5445#issuecomment-252529766
