### PR TITLE
Fix paths duplicates error when RemoteUpdatePlugins

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -191,6 +191,7 @@ function! s:RegistrationCommands(host) abort
   let pattern = s:plugin_patterns[a:host]
   let paths = globpath(&rtp, 'rplugin/'.a:host.'/'.pattern, 0, 1)
   let paths = map(paths, 'tr(v:val,"\\","/")') " Normalize slashes #4795
+  let paths = uniq(sort(paths))
   if empty(paths)
     return []
   endif


### PR DESCRIPTION
When the plugin path is duplicated, `RemoteUpdatePlugins` will crash like this.

```
function <SNR>366_job_handler_neovim[1]..<SNR>366_job_handler[15]..<SNR>366_install_async[9]..<SNR>366_done[9]..dein#install#_recache_runtimepath[36]..dein#remote_plugins[1]..dein#install#_remote_plugins[11]..remote#host#UpdateRemotePlugins[6]..<SNR>36_RegistrationCommands[12]..remote#host#RegisterPlugin, line 5
Plugin "/home/shougo/work/dein.vim/rplugin/python3/denite" is already registered
remote/host: generated rplugin manifest: /home/shougo/.local/share/nvim/rplugin.vim
```

It fixes the problem.
