### PR TITLE
Fix generated files for in-tree build.

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -156,7 +156,7 @@ foreach(sfile ${NEOVIM_SOURCES}
               ${GENERATED_API_DISPATCH})
   get_filename_component(full_d ${sfile} PATH)
   file(RELATIVE_PATH d "${PROJECT_SOURCE_DIR}/src/nvim" "${full_d}")
-  if(${d} MATCHES "^[.][.]")
+  if(${d} MATCHES "^([.][.]|auto/)")
     file(RELATIVE_PATH d "${GENERATED_DIR}" "${full_d}")
   endif()
   get_filename_component(f ${sfile} NAME)


### PR DESCRIPTION
Don't get your hopes up yet, but this does allow an in-tree build to proceed.  The one catch is that when using the "Unix Makefiles" generator, it will clobber our top-level Makefile--so we'll need to do something more if we want to prevent that problem.  But this is a good start.  It also includes updates to .gitignore to help prevent `git status` from becoming an abomination if you try it.

Note: there really is no way to clean everything up well (outside of a `git clean -fdx`), so I don't recommend this.  But I thought we could at least fix enough of the in-tree build that if we change our minds, someone else doesn't have to tackle this particular issue.
