### PR TITLE
Followup #5445

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -276,30 +276,25 @@ bool buf_valid(buf_T *buf)
   return false;
 }
 
-/*
- * Close the link to a buffer.
- * "action" is used when there is no longer a window for the buffer.
- * It can be:
- * 0			buffer becomes hidden
- * DOBUF_UNLOAD		buffer is unloaded
- * DOBUF_DELETE		buffer is unloaded and removed from buffer list
- * DOBUF_WIPE		buffer is unloaded and really deleted
- * When doing all but the first one on the current buffer, the caller should
- * get a new buffer very soon!
- *
- * The 'bufhidden' option can force freeing and deleting.
- *
- * When "abort_if_last" is TRUE then do not close the buffer if autocommands
- * cause there to be only one window with this buffer.  e.g. when ":quit" is
- * supposed to close the window but autocommands close all other windows.
- */
-void 
-close_buffer (
-    win_T *win,               /* if not NULL, set b_last_cursor */
-    buf_T *buf,
-    int action,
-    int abort_if_last
-)
+/// Close the link to a buffer.
+///
+/// @param win    If not NULL, set b_last_cursor.
+/// @param buf
+/// @param action Used when there is no longer a window for the buffer.
+///               Possible values:
+///                 0            buffer becomes hidden
+///                 DOBUF_UNLOAD buffer is unloaded
+///                 DOBUF_DELETE buffer is unloaded and removed from buffer list
+///                 DOBUF_WIPE   buffer is unloaded and really deleted
+///               When doing all but the first one on the current buffer, the
+///               caller should get a new buffer very soon!
+///               The 'bufhidden' option can force freeing and deleting.
+/// @param abort_if_last
+///               If TRUE, do not close the buffer if autocommands cause
+///               there to be only one window with this buffer. e.g. when
+///               ":quit" is supposed to close the window but autocommands
+///               close all other windows.
+void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
 {
   bool unload_buf = (action != 0);
   bool del_buf = (action == DOBUF_DEL || action == DOBUF_WIPE);

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1286,10 +1286,9 @@ bool edit(int cmdchar, bool startln, long count)
 {
   if (curbuf->terminal) {
     if (ex_normal_busy) {
-      // don't enter terminal mode from `ex_normal`, which can result in all
-      // kinds of havoc(such as terminal mode recursiveness). Instead, set a
-      // flag that allow us to force-set the value of `restart_edit` before
-      // `ex_normal` returns
+      // Do not enter terminal mode from ex_normal(), which would cause havoc
+      // (such as terminal-mode recursiveness). Instead set a flag to force-set
+      // the value of `restart_edit` before `ex_normal` returns.
       restart_edit = 'i';
       force_restart_edit = true;
     } else {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2116,6 +2116,16 @@ do_ecmd (
     }
   }
 
+  // Make re-editing a terminal buffer a no-op
+  if (!other_file && curbuf->terminal != NULL) {
+      // this is needed for when we are called by do_argfile() and the new
+      // argument index becomes the terminal buffer we are already editing
+      check_arg_idx(curwin);
+      maketitle();
+      retval = OK;
+      goto theend;
+  }
+
   /*
    * if the file was changed we may not be allowed to abandon it
    * - if we are going to re-edit the same file

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2116,14 +2116,12 @@ do_ecmd (
     }
   }
 
-  // Make re-editing a terminal buffer a no-op
-  if (!other_file && curbuf->terminal != NULL) {
-      // this is needed for when we are called by do_argfile() and the new
-      // argument index becomes the terminal buffer we are already editing
-      check_arg_idx(curwin);
-      maketitle();
-      retval = OK;
-      goto theend;
+  // Re-editing a terminal buffer: skip most buffer re-initialization.
+  if (!other_file && curbuf->terminal) {
+    check_arg_idx(curwin);  // Needed when called from do_argfile().
+    maketitle();            // Title may show the arg index, e.g. "(2 of 5)".
+    retval = OK;
+    goto theend;
   }
 
   /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6726,11 +6726,6 @@ do_exedit (
         old_curwin == NULL ? curwin : NULL);
   } else if ((eap->cmdidx != CMD_split && eap->cmdidx != CMD_vsplit)
              || *eap->arg != NUL) {
-    // ":edit <blank>" is a no-op in terminal buffers. #2822
-    if (curbuf->terminal != NULL && eap->cmdidx == CMD_edit && *eap->arg == NUL) {
-      return;
-    }
-
     /* Can't edit another file when "curbuf_lock" is set.  Only ":edit"
      * can bring us here, others are stopped earlier. */
     if (*eap->arg != NUL && curbuf_locked())

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7916,9 +7916,8 @@ static void ex_normal(exarg_T *eap)
   if (force_restart_edit) {
     force_restart_edit = false;
   } else {
-    // some function called was aware of ex_normal and decided to override the
-    // value of restart_edit anyway. So far only used in terminal mode(see
-    // terminal_enter() in edit.c)
+    // Some function (terminal_enter()) was aware of ex_normal and decided to
+    // override the value of restart_edit anyway.
     restart_edit = save_restart_edit;
   }
   p_im = save_insertmode;

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -320,14 +320,18 @@ int main(int argc, char **argv)
 
   // open terminals when opening files that start with term://
 #define PROTO "term://"
+  do_cmdline_cmd("augroup nvim_terminal");
+  do_cmdline_cmd("autocmd!");
   do_cmdline_cmd("autocmd BufReadCmd " PROTO "* nested "
-                 ":call termopen( "
+                 ":if !exists('b:term_title')|call termopen( "
                  // Capture the command string
                  "matchstr(expand(\"<amatch>\"), "
                  "'\\c\\m" PROTO "\\%(.\\{-}//\\%(\\d\\+:\\)\\?\\)\\?\\zs.*'), "
                  // capture the working directory
                  "{'cwd': get(matchlist(expand(\"<amatch>\"), "
-                 "'\\c\\m" PROTO "\\(.\\{-}\\)//'), 1, '')})");
+                 "'\\c\\m" PROTO "\\(.\\{-}\\)//'), 1, '')})"
+                 "|endif");
+  do_cmdline_cmd("augroup END");
 #undef PROTO
 
   /* Execute --cmd arguments. */

--- a/test/functional/ex_cmds/arg_spec.lua
+++ b/test/functional/ex_cmds/arg_spec.lua
@@ -1,0 +1,30 @@
+local helpers = require("test.functional.helpers")(after_each)
+local eq, execute, funcs = helpers.eq, helpers.execute, helpers.funcs
+local ok = helpers.ok
+local clear = helpers.clear
+
+describe(":argument", function()
+  before_each(function() 
+    clear()
+  end)
+
+  it("does not restart :terminal buffer", function()
+      execute("terminal")
+      helpers.feed([[<C-\><C-N>]])
+      execute("argadd")
+      helpers.feed([[<C-\><C-N>]])
+      local bufname_before = funcs.bufname("%")
+      local bufnr_before = funcs.bufnr("%")
+      helpers.ok(nil ~= string.find(bufname_before, "^term://"))  -- sanity
+
+      execute("argument 1")
+      helpers.feed([[<C-\><C-N>]])
+
+      local bufname_after = funcs.bufname("%")
+      local bufnr_after = funcs.bufnr("%")
+      eq("\n["..bufname_before.."] ", helpers.eval('execute("args")'))
+      ok(funcs.line('$') > 1)
+      eq(bufname_before, bufname_after)
+      eq(bufnr_before, bufnr_after)
+  end)
+end)

--- a/test/functional/ex_cmds/edit_spec.lua
+++ b/test/functional/ex_cmds/edit_spec.lua
@@ -1,0 +1,26 @@
+local helpers = require("test.functional.helpers")(after_each)
+local eq, execute, funcs = helpers.eq, helpers.execute, helpers.funcs
+local ok = helpers.ok
+local clear = helpers.clear
+
+describe(":edit", function()
+  before_each(function() 
+    clear()
+  end)
+
+  it("without arguments does not restart :terminal buffer", function()
+      execute("terminal")
+      helpers.feed([[<C-\><C-N>]])
+      local bufname_before = funcs.bufname("%")
+      local bufnr_before = funcs.bufnr("%")
+      helpers.ok(nil ~= string.find(bufname_before, "^term://"))  -- sanity
+
+      execute("edit")
+
+      local bufname_after = funcs.bufname("%")
+      local bufnr_after = funcs.bufnr("%")
+      ok(funcs.line('$') > 1)
+      eq(bufname_before, bufname_after)
+      eq(bufnr_before, bufnr_after)
+  end)
+end)

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -3,7 +3,6 @@ local Screen = require('test.functional.ui.screen')
 local clear, wait, nvim = helpers.clear, helpers.wait, helpers.nvim
 local nvim_dir, source, eq = helpers.nvim_dir, helpers.source, helpers.eq
 local execute, eval = helpers.execute, helpers.eval
-local funcs = helpers.funcs
 
 if helpers.pending_win32(pending) then return end
 

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -3,6 +3,7 @@ local Screen = require('test.functional.ui.screen')
 local clear, wait, nvim = helpers.clear, helpers.wait, helpers.nvim
 local nvim_dir, source, eq = helpers.nvim_dir, helpers.source, helpers.eq
 local execute, eval = helpers.execute, helpers.eval
+local funcs = helpers.funcs
 
 if helpers.pending_win32(pending) then return end
 


### PR DESCRIPTION
Followup #5445

In main.c, define `nvim_terminal` augroup and check `!exists('b:term_title')` to avoid the `BufReadCmd` for existing `:terminal` buffers. But still keep the change from #5445, else there is weirdness that I could not figure out.

Move test for #5445 out of the "fake shell" tests (where the shell immediately exits), we need a real shell to really test it. 
