### PR TITLE
[RFC] vim-patch: 7.4.1619

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1036,8 +1036,9 @@ void set_init_3(void)
     int idx_ffs = findoption((char_u *)"ffs");
 
     // Apply the first entry of 'fileformats' to the initial buffer.
-    if (idx_ffs >= 0 && (options[idx_ffs].flags & P_WAS_SET))
+    if (idx_ffs >= 0 && (options[idx_ffs].flags & P_WAS_SET)) {
       set_fileformat(default_fileformat(), OPT_LOCAL);
+    }
   }
 
   set_title_defaults();

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1032,6 +1032,14 @@ void set_init_3(void)
     xfree(p);
   }
 
+  if (bufempty()) {
+    int idx_ffs = findoption((char_u *)"ffs");
+
+    // Apply the first entry of 'fileformats' to the initial buffer.
+    if (idx_ffs >= 0 && (options[idx_ffs].flags & P_WAS_SET))
+      set_fileformat(default_fileformat(), OPT_LOCAL);
+  }
+
   set_title_defaults();
 }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -824,7 +824,7 @@ static int included_patches[] = {
   // 1622 NA
   // 1621 NA
   1620,
-  // 1619,
+  1619,
   // 1618 NA
   // 1617 NA
   // 1616 NA


### PR DESCRIPTION
Problem:    When 'fileformats' is set in the vimrc it applies to new buffers
            but not the initial buffer.
Solution:   Set 'fileformat' when starting up. (Mike Williams)

https://github.com/vim/vim/commit/364fa5c7ec2a99a791c8f8b66fe70b0bf1dd9a41
