### PR TITLE
Prevent 'N files to edit' on embedded mode

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -270,11 +270,6 @@ int main(int argc, char **argv)
 
   setbuf(stdout, NULL);
 
-  /* This message comes before term inits, but after setting "silent_mode"
-   * when the input is not a tty. */
-  if (GARGCOUNT > 1 && !silent_mode)
-    printf(_("%d files to edit\n"), GARGCOUNT);
-
   full_screen = true;
   check_tty(&params);
 


### PR DESCRIPTION
## Problem

When '--embed' passed to command line arguments, stdin and stdout are used for PRC. But when multiple files are also passed to the arguments, nvim wrongly sends 'N files to edit' message to its stdout. As the result, attaching to process from frontend failed.
## Solution

Do not show the message on embedded mode.
