### PR TITLE
jobset(), jobget(). Deprecate termopen(), jobpid(), jobresize().

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -16,13 +16,11 @@ Normal commands ~
 *]f*
 *[f*			Same as "gf".
 
-
 Commands ~
 *:rv*
 *:rviminfo*		Deprecated alias to |:rshada| command.
 *:wv*
 *:wviminfo*		Deprecated alias to |:wshada| command.
-
 
 Events ~
 *EncodingChanged*	Never fired; 'encoding' is always "utf-8".
@@ -38,9 +36,20 @@ Functions ~
 *file_readable()*	Obsolete name for |filereadable()|.
 *highlight_exists()*	Obsolete name for |hlexists()|.
 *highlightID()*		Obsolete name for |hlID()|.
+*jobpid()*		Deprecated. Use |jobget()| instead: >
+			  :let pid = jobget(job, 'pid')
+*jobresize()*		Deprecated. Use |jobset()| instead: >
+			  :call jobset(job, {'width':80,'height':20})
 *last_buffer_nr()*	Obsolete name for bufnr("$").
+*rpcstart()*		Deprecated. Replace this: >
+			  :let id = rpcstart('prog', ['arg1', 'arg2'])
+<			with this: >
+			  :let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
+*termopen()*		Deprecated.
 
 Options ~
+*b:terminal_job_id*	Use |b:job| instead.
+*b:terminal_job_pid*	Use `jobget(b:job,"pid")` instead.
 *'fe'*			'fenc'+'enc' before Vim 6.0; no longer used.
 *'vi'*
 *'viminfo'*		Deprecated alias to 'shada' option.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1962,10 +1962,9 @@ isdirectory({directory})	Number	TRUE if {directory} is a directory
 islocked({expr})		Number	TRUE if {expr} is locked
 items({dict})			List	key-value pairs in {dict}
 jobclose({job}[, {stream}])	Number	Closes a job stream(s)
-jobpid({job})			Number	Returns pid of a job.
-jobresize({job}, {width}, {height})
-				Number	Resize {job}'s pseudo terminal window
+jobget({job}[, {key}])		Dict	Returns job info/properties.
 jobsend({job}, {data})		Number	Writes {data} to {job}'s stdin
+jobset({job}, {dict})		Number	Sets job options/properties.
 jobstart({cmd}[, {opts}])	Number	Spawns {cmd} as a job
 jobstop({job})			Number	Stops a job
 jobwait({ids}[, {timeout}])	Number	Wait for a set of jobs
@@ -4407,13 +4406,7 @@ jobclose({job}[, {stream}])				{Nvim} *jobclose()*
 		with the "rpc" option.) If {stream} is omitted, all streams
 		are closed.
 
-jobpid({job})						{Nvim} *jobpid()*
-		Return the pid (process id) of {job}.
-
-jobresize({job}, {width}, {height})			{Nvim} *jobresize()*
-		Resize {job}'s pseudo terminal window to {width} and {height}.
-		This function will fail if used on jobs started without the
-		"pty" option.
+jobget({job}[, {get}])					{Nvim} *jobget()*
 
 jobsend({job}, {data})					{Nvim} *jobsend()*
 		Send data to {job} by writing it to the stdin of the process.
@@ -4430,6 +4423,8 @@ jobsend({job}, {data})					{Nvim} *jobsend()*
 		If the job was started with the rpc option this function
 		cannot be used, instead use |rpcnotify()| and |rpcrequest()|
 		to communicate with the job.
+
+jobset({job}, {properties})				{Nvim} *jobset()*
 
 jobstart({cmd}[, {opts}])				{Nvim} *jobstart()*
 		Spawns {cmd} as a job.  If {cmd} is a |List| it is run
@@ -4454,13 +4449,21 @@ jobstart({cmd}[, {opts}])				{Nvim} *jobstart()*
 			     the master file descriptor. "on_stderr" is ignored
 			     as all output will be received on stdout.
 
-		  width    : (pty only) Width of the terminal screen
-		  height   : (pty only) Height of the terminal screen
-		  TERM     : (pty only) $TERM environment variable
-		  detach   : (non-pty only) Detach the job process from the
+		  width    : (pty/term) Width of the terminal screen. Defaults
+			     to the current window width.
+		  height   : (pty/term) Height of the terminal screen Defaults
+			     to the current window height.
+		  TERM     : (pty/term) $TERM environment variable. Defaults
+			     to "xterm-256color"
+		  detach   : (non-pty/term) Detach the job process from the
 			     nvim process. The process will not get killed
 			     when nvim exits. If the process dies before
 			     nvim exits, on_exit will still be invoked.
+		  type     : (optional)
+			     "rpc" :
+			     "pty" :
+			     "term": Spawns {cmd} in a new pseudo-terminal
+				     connected to "buf". |terminal-emulator|
 
 		{opts} is passed as |self| to the callback; the caller may
 		pass arbitrary data by setting other keys.
@@ -4476,9 +4479,8 @@ jobstop({job})						{Nvim} *jobstop()*
 		Stop a job created with |jobstart()| by sending a `SIGTERM`
 		to the corresponding process. If the process doesn't exit
 		cleanly soon, a `SIGKILL` will be sent. When the job is
-		finally closed, the exit handler provided to |jobstart()| or
-		|termopen()| will be run.
-		See |job-control| for more information.
+		finally closed, the exit handler provided to |jobstart()| will
+		be run. |job-control|
 
 jobwait({ids}[, {timeout}])				{Nvim} *jobwait()*
 		Wait for a set of jobs to finish. The {ids} argument is a list
@@ -5684,12 +5686,6 @@ rpcrequest({channel}, {method}[, {args}...])		 {Nvim} *rpcrequest()*
 		|RPC| and blocks until a response is received.
 		Example: >
 			:let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
-
-rpcstart({prog}[, {argv}])				   {Nvim} *rpcstart()*
-		Deprecated. Replace  >
-			:let id = rpcstart('prog', ['arg1', 'arg2'])
-<		with >
-			:let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
 
 rpcstop({channel})					    {Nvim} *rpcstop()*
 		Closes an |RPC| {channel}.  If the channel is a job
@@ -6983,20 +6979,6 @@ tempname()					*tempname()* *temp-file-name*
 <		For Unix, the file will be in a private directory |tempfile|.
 		For MS-Windows forward slashes are used when the 'shellslash'
 		option is set or when 'shellcmdflag' starts with '-'.
-
-termopen({cmd}[, {opts}])			{Nvim} *termopen()*
-		Spawns {cmd} in a new pseudo-terminal session connected
-		to the current buffer.  {cmd} is the same as the one passed to
-		|jobstart()|.  This function fails if the current buffer is
-		modified (all buffer contents are destroyed).
-
-		The {opts} dict is similar to the one passed to |jobstart()|,
-		but the `pty`, `width`, `height`, and `TERM` fields are
-		ignored: `height`/`width` are taken from the current window
-		and `$TERM` is set to "xterm-256color".
-		Returns the same values as |jobstart()|.
-
-		See |terminal-emulator| for more information.
 
 tan({expr})						*tan()*
 		Return the tangent of {expr}, measured in radians, as a |Float|

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -30,7 +30,7 @@ emulation library. http://www.leonerd.org.uk/code/libvterm/
 There are 3 ways to create a terminal buffer:
 
 - By invoking the |:terminal| ex command.
-- By calling the |termopen()| function.
+- By calling the |jobstart()| function.
 - By editing a file with a name matching `term://(.{-}//(\d+:)?)?\zs.*`.
   For example:
 >
@@ -119,13 +119,13 @@ The terminal cursor can be highlighted via |hl-TermCursor| and
 Terminal buffers maintain some information about the terminal in buffer-local
 variables:
 
-- *b:term_title* The settable title of the terminal, typically displayed in
-  the window title or tab title of a graphical terminal emulator. Programs
-  running in the terminal can set this title via an escape sequence.
-- *b:terminal_job_id* The nvim job ID of the job running in the terminal. See
-  |job-control| for more information.
-- *b:terminal_job_pid* The PID of the top-level process running in the
-  terminal.
+*b:term_title*	Terminal title, typically displayed in the window title of
+		a graphical terminal emulator. You can set this. Programs
+		running in the terminal can also set the title via a terminal
+		code.
+
+*b:job*		Job assigned to the process running in the terminal.
+		|job-control|
 
 These variables will have a value by the time the TermOpen autocmd runs, and
 will continue to have a value for the lifetime of the terminal buffer, making

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -212,20 +212,19 @@ g8			Print the hex values of the bytes used in the
 			equivalent to: >
 
 			      :enew
-			      :call termopen('{cmd}')
+			      :call jobstart('{cmd}', {'type':'term'})
 			      :startinsert
 <
-			If no {cmd} is given, 'shellcmdflag' will not be sent
-			to |termopen()|.
+                        If no {cmd} is given, 'shellcmdflag' will not be used.
 
 			Like |:enew|, it will fail if the current buffer is
-			modified, but can be forced with "!".  See |termopen()|
-			and |terminal-emulator|.
+			modified, but can be forced with "!".
 
-			To switch to terminal mode automatically:
->
+			To switch to terminal mode automatically: >
 			      autocmd BufEnter term://* startinsert
 <
+			Also see |terminal-emulator|.
+
 							*:!cmd* *:!* *E34*
 :!{cmd}			Execute {cmd} with 'shell'. See also |:terminal|.
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1244,9 +1244,9 @@ void enter_buffer(buf_T *buf)
   /* mark cursor position as being invalid */
   curwin->w_valid = 0;
 
-  if (buf->terminal) {
-    terminal_resize(buf->terminal, curwin->w_width, curwin->w_height);
-  }
+  // if (buf->terminal) {
+  //   terminal_resize(buf->terminal, curwin->w_width, curwin->w_height);
+  // }
 
   /* Make sure the buffer is loaded. */
   if (curbuf->b_ml.ml_mfp == NULL) {    /* need to load the file */

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -167,6 +167,7 @@ return {
     islocked={args=1},
     items={args=1},
     jobclose={args={1, 2}},
+    jobget={args={1, 2}},
     jobpid={args=1},
     jobresize={args=3},
     jobsend={args=2},

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -252,7 +252,7 @@ void process_stop(Process *proc) FUNC_ATTR_NONNULL_ALL
 }
 
 /// Iterates the process list sending SIGTERM to stopped processes and SIGKILL
-/// to those that didn't die from SIGTERM after a while(exit_timeout is 0).
+/// to those that did not die from SIGTERM after awhile.
 static void children_kill_cb(uv_timer_t *handle)
 {
   Loop *loop = handle->loop->data;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1,24 +1,22 @@
-/*
- * Code to handle user-settable options. This is all pretty much table-
- * driven. Checklist for adding a new option:
- * - Put it in the options array below (copy an existing entry).
- * - For a global option: Add a variable for it in option_defs.h.
- * - For a buffer or window local option:
- *   - Add a PV_XX entry to the enum below.
- *   - Add a variable to the window or buffer struct in buffer_defs.h.
- *   - For a window option, add some code to copy_winopt().
- *   - For a buffer option, add some code to buf_copy_options().
- *   - For a buffer string option, add code to check_buf_options().
- * - If it's a numeric option, add any necessary bounds checks to do_set().
- * - If it's a list of flags, add some code in do_set(), search for WW_ALL.
- * - When adding an option with expansion (P_EXPAND), but with a different
- *   default for Vi and Vim (no P_VI_DEF), add some code at VIMEXP.
- * - Add documentation!  One line in doc/help.txt, full description in
- *   options.txt, and any other related places.
- * - Add an entry in runtime/optwin.vim.
- * When making changes:
- * - Adjust the help for the option in doc/option.txt.
- */
+// Code to handle user-settable options. This is all pretty much table-
+// driven. Checklist for adding a new option:
+//   - Put it in the options array below (copy an existing entry).
+//   - For a global option: Add a variable for it in option_defs.h.
+//   - For a buffer or window local option:
+//     - Add an entry to options.lua.
+//     - Add a variable to the window or buffer struct in buffer_defs.h.
+//     - For a window option, add some code to copy_winopt().
+//     - For a buffer option, add some code to buf_copy_options().
+//     - For a buffer string option, add code to check_buf_options().
+//   - If it's a numeric option, add any necessary bounds checks to do_set().
+//   - If it's a list of flags, add some code in do_set(), search for WW_ALL.
+//   - When adding an option with expansion (P_EXPAND), but with a different
+//     default for Vi and Vim (no P_VI_DEF), add some code at VIMEXP.
+//   - Add documentation!  One line in doc/help.txt, full description in
+//     options.txt, and any other related places.
+//   - Add an entry in runtime/optwin.vim.
+// When making changes:
+//   - Adjust the help for the option in doc/option.txt.
 
 #define IN_OPTION_C
 #include <assert.h>

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1811,11 +1811,11 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf,
       shell_new_rows();
   }
 
-  if (term) {
-    // When a window containing a terminal buffer is closed, recalculate its
-    // size
-    terminal_resize(term, 0, 0);
-  }
+  // if (term) {
+  //   // When a window containing a terminal buffer is closed, recalculate its
+  //   // size
+  //   terminal_resize(term, 0, 0);
+  // }
 
   // Since goto_tabpage_tp above did not trigger *Enter autocommands, do
   // that now.
@@ -3625,9 +3625,9 @@ static void win_enter_ext(win_T *wp, bool undo_sync, int curwin_invalid, int tri
   /* Change directories when the 'acd' option is set. */
   do_autochdir();
 
-  if (curbuf->terminal) {
-    terminal_resize(curbuf->terminal, curwin->w_width, curwin->w_height);
-  }
+  // if (curbuf->terminal) {
+  //   terminal_resize(curbuf->terminal, curwin->w_width, curwin->w_height);
+  // }
 }
 
 
@@ -4783,10 +4783,10 @@ void win_new_height(win_T *wp, int height)
   wp->w_redr_status = TRUE;
   invalidate_botline_win(wp);
 
-  if (wp->w_buffer->terminal) {
-    terminal_resize(wp->w_buffer->terminal, 0, wp->w_height);
-    redraw_win_later(wp, CLEAR);
-  }
+  // if (wp->w_buffer->terminal) {
+  //   terminal_resize(wp->w_buffer->terminal, 0, wp->w_height);
+  //   redraw_win_later(wp, CLEAR);
+  // }
 }
 
 /*
@@ -4805,12 +4805,12 @@ void win_new_width(win_T *wp, int width)
   redraw_win_later(wp, NOT_VALID);
   wp->w_redr_status = TRUE;
 
-  if (wp->w_buffer->terminal) {
-    if (wp->w_height != 0) {
-      terminal_resize(wp->w_buffer->terminal, wp->w_width, 0);
-    }
-    redraw_win_later(wp, CLEAR);
-  }
+  // if (wp->w_buffer->terminal) {
+  //   if (wp->w_height != 0) {
+  //     terminal_resize(wp->w_buffer->terminal, wp->w_width, 0);
+  //   }
+  //   redraw_win_later(wp, CLEAR);
+  // }
 }
 
 void win_comp_scroll(win_T *wp)


### PR DESCRIPTION
Nvim has `jobpid()` and `jobresize()`. Vim8 has `job_info()` and `job_status()` for no particular reason.  What's really wanted here is a way to get and set job properties. So let's do that.

Also deprecate `termopen()`, it is confusing and unnecessary: most people don't realize how similar it is to `jobstart()`. Nudging script/plugin authors towards using `jobstart()` to spawn a terminal makes it obvious that all of the relevant mechanisms are shared and available between the two.

To satisfy the purpose of `termopen()`, `jobstart()` needs a way to connect to a buffer. This is useful for all types of jobs (and Vim8 has a cloud of related options). 

- [ ] new job option: "buf" (or something like that, maybe "out_buf", "in_buf" like Vim8)
- [x] new job option: "type" = { rpc, pty, term } 
- [ ] ~~`jobset()`~~
- [x] 'jobget()`
    - [ ] `jobget(..., 'started')` start time
    - [ ] `jobget(..., 'started_by')` function/script that started the job
    - [ ] `jobget(..., 'stopped_by')` ? (Alternative: send this to `on_exit` handler ?)
- [ ] get a list of jobs (`jobget(0)` ?) https://github.com/neovim/neovim/issues/557
- [x] documentation
- [ ] tests
- [ ] mention "cwd" in error message https://github.com/neovim/neovim/commit/2c44d9257287c3e804dcc5a2bfe073c20554c0b9#commitcomment-19445677
