### PR TITLE
api: Ignore 'modifiable', 'readonly' buffer settings.

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -298,6 +298,11 @@ void nvim_buf_set_lines(uint64_t channel_id,
   ssize_t extra = 0;  // lines added to text, can be negative
   char **lines = (new_len != 0) ? xcalloc(new_len, sizeof(char *)) : NULL;
 
+  int save_p_ma = buf->b_p_ma;
+  int save_p_ro = buf->b_p_ro;
+  buf->b_p_ma = 1;
+  buf->b_p_ro = 0;
+
   for (size_t i = 0; i < new_len; i++) {
     if (replacement.items[i].type != kObjectTypeString) {
       api_set_error(err,
@@ -400,6 +405,8 @@ void nvim_buf_set_lines(uint64_t channel_id,
   }
 
 end:
+  buf->b_p_ma = save_p_ma;
+  buf->b_p_ro = save_p_ro;
   for (size_t i = 0; i < new_len; i++) {
     xfree(lines[i]);
   }


### PR DESCRIPTION
`nvim_buf_set_lines` addresses the Vim8 out_io="buffer" job-option.
With this change it also addresses the Vim8 out_modifiable job-option.

Instead of jamming this into `nvim_buf_set_lines` it might be better to introduce a API function e.g. `nvim_set_options_atomic` which restores options at the end of the current request (which means it only is useful during `call_atomic`).

```
call_atomic([['nvim_set_options_atomic', [
    ['wrap', 0],
    ['modifiable', 0],
    ['readonly', 0]]],
  ['nvim_buf_set_lines', ...]])
```

The options would apply to global/window-local/buf-local/tab-local indiscriminately (unless there's a problem with that I have not thought of).

It may make sense to do _both_. This has raised a philosophical/design question: I noticed that the `nvim_foo_set_option` API functions operate invisibly, i.e. `:verbose set foo?` won't show what changed the option. 

It makes sense, I think, that the API wouldn't care about `'modifiable'` and `'readonly'`: the API is lower-level than VimL. But the distinction has been blurred now that the API is callable by VimL. We can enhance `:verbose` so that API calls are associated with changed options.

The question of what to do about `nvim_buf_set_lines` is less clear. If plugins used this often, it could result in accidental edits, and it makes `'modifiable'` and `'readonly'` useless.
