### PR TITLE
Fix #5246

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2271,7 +2271,8 @@ do_ecmd (
           }
         }
 
-        if (aborting()) {           /* autocmds may abort script processing */
+        /* autocmds may abort script processing */
+        if (aborting() && curwin->w_buffer != NULL) {
           xfree(new_name);
           goto theend;
         }


### PR DESCRIPTION
Add a check whether an erroneous execution of close_buffer has successfully
closed curwin's buffer. Do not abort do_ecmd if the buffer has been closed.
