### PR TITLE
[RFC] call TabNewEntered on :tab modifier

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4245,15 +4245,18 @@ do_arg_all (
         }
       }
     } else if (split_ret == OK) {
+      bool tab_suc = false;
       if (!use_firstwin) {              /* split current window */
         p_ea_save = p_ea;
         p_ea = true;                    /* use space from all windows */
-        split_ret = win_split(0, WSP_ROOM | WSP_BELOW);
+        split_ret = win_split_with_tab_suc(0, WSP_ROOM | WSP_BELOW, &tab_suc);
         p_ea = p_ea_save;
-        if (split_ret == FAIL)
+        if (split_ret == FAIL) {
           continue;
-      } else        /* first window: do autocmd for leaving this buffer */
+        }
+      } else {       /* first window: do autocmd for leaving this buffer */
         --autocmd_no_leave;
+      }
 
       /*
        * edit file "i"
@@ -4268,9 +4271,13 @@ do_arg_all (
           ((P_HID(curwin->w_buffer)
             || bufIsChanged(curwin->w_buffer)) ? ECMD_HIDE : 0)
           + ECMD_OLDBUF, curwin);
-      if (use_firstwin)
+      if (use_firstwin) {
         ++autocmd_no_leave;
+      }
       use_firstwin = FALSE;
+      if (tab_suc) {
+          apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, false, curbuf);
+      }
     }
     os_breakcheck();
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4403,7 +4403,8 @@ void ex_buffer_all(exarg_T *eap)
       /* Split the window and put the buffer in it */
       p_ea_save = p_ea;
       p_ea = true;                      /* use space from all windows */
-      split_ret = win_split(0, WSP_ROOM | WSP_BELOW);
+      bool tab_suc = false;
+      split_ret = win_split_with_tab_suc(0, WSP_ROOM | WSP_BELOW, &tab_suc);
       ++open_wins;
       p_ea = p_ea_save;
       if (split_ret == FAIL)
@@ -4412,6 +4413,9 @@ void ex_buffer_all(exarg_T *eap)
       /* Open the buffer in this window. */
       swap_exists_action = SEA_DIALOG;
       set_curbuf(buf, DOBUF_GOTO);
+      if (tab_suc) {
+          apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, false, curbuf);
+      }
       if (!buf_valid(buf)) {            /* autocommands deleted the buffer!!! */
         swap_exists_action = SEA_NONE;
         break;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4199,6 +4199,7 @@ void ex_help(exarg_T *eap)
   int len;
   char_u      *lang;
   int old_KeyTyped = KeyTyped;
+  bool tab_suc = false;
 
   if (eap != NULL) {
     /*
@@ -4299,8 +4300,9 @@ void ex_help(exarg_T *eap)
       if (cmdmod.split == 0 && curwin->w_width != Columns
           && curwin->w_width < 80)
         n |= WSP_TOP;
-      if (win_split(0, n) == FAIL)
+      if (win_split_with_tab_suc(0, n, &tab_suc) == FAIL) {
         goto erret;
+      }
 
       if (curwin->w_height < p_hh)
         win_setheight((int)p_hh);
@@ -4343,6 +4345,9 @@ void ex_help(exarg_T *eap)
   if (alt_fnum != 0 && curwin->w_alt_fnum == empty_fnum && !cmdmod.keepalt)
     curwin->w_alt_fnum = alt_fnum;
 
+  if (tab_suc) {
+      apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, false, curbuf);
+  }
 erret:
   xfree(tag);
 }

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1809,6 +1809,7 @@ void do_argfile(exarg_T *eap, int argn)
 {
   int other;
   char_u      *p;
+  bool tab_suc = false;
   int old_arg_idx = curwin->w_arg_idx;
 
   if (argn < 0 || argn >= ARGCOUNT) {
@@ -1824,7 +1825,7 @@ void do_argfile(exarg_T *eap, int argn)
 
     // split window or create new tab page first
     if (*eap->cmd == 's' || cmdmod.tab != 0) {
-      if (win_split(0, 0) == FAIL) {
+      if (win_split_with_tab_suc(0, 0, &tab_suc) == FAIL) {
         return;
       }
       RESET_BINDING(curwin);
@@ -1860,9 +1861,14 @@ void do_argfile(exarg_T *eap, int argn)
                 (P_HID(curwin->w_buffer) ? ECMD_HIDE : 0)
                 + (eap->forceit ? ECMD_FORCEIT : 0), curwin) == FAIL) {
       curwin->w_arg_idx = old_arg_idx;
-    } else if (eap->cmdidx != CMD_argdo) {
-      // like Vi: set the mark where the cursor is in the file.
-      setmark('\'');
+    } else {
+      if (eap->cmdidx != CMD_argdo) {
+        // like Vi: set the mark where the cursor is in the file.
+        setmark('\'');
+      }
+      if (tab_suc) {
+          apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, false, curbuf);
+      }
     }
   }
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6399,8 +6399,7 @@ void ex_splitview(exarg_T *eap)
 {
   win_T       *old_curwin = curwin;
   char_u      *fname = NULL;
-
-
+  bool         tab_suc = false;
 
   /* A ":split" in the quickfix window works like ":new".  Don't want two
    * quickfix windows.  But it's OK when doing ":tab split". */
@@ -6428,7 +6427,7 @@ void ex_splitview(exarg_T *eap)
     if (win_new_tabpage(cmdmod.tab != 0 ? cmdmod.tab : eap->addr_count == 0
                         ? 0 : (int)eap->line2 + 1, eap->arg) != FAIL) {
       do_exedit(eap, old_curwin);
-      apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, FALSE, curbuf);
+      apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, false, curbuf);
 
       /* set the alternate buffer for the window we came from */
       if (curwin != old_curwin
@@ -6437,8 +6436,8 @@ void ex_splitview(exarg_T *eap)
           && !cmdmod.keepalt)
         old_curwin->w_alt_fnum = curbuf->b_fnum;
     }
-  } else if (win_split(eap->addr_count > 0 ? (int)eap->line2 : 0,
-                 *eap->cmd == 'v' ? WSP_VERT : 0) != FAIL) {
+  } else if (win_split_with_tab_suc(eap->addr_count > 0 ? (int)eap->line2 : 0,
+             *eap->cmd == 'v' ? WSP_VERT : 0, &tab_suc) != FAIL) {
     /* Reset 'scrollbind' when editing another file, but keep it when
      * doing ":split" without arguments. */
     if (*eap->arg != NUL
@@ -6447,6 +6446,9 @@ void ex_splitview(exarg_T *eap)
     } else
       do_check_scrollbind(FALSE);
     do_exedit(eap, old_curwin);
+    if (tab_suc) {
+        apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, false, curbuf);
+    }
   }
 
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2057,6 +2057,7 @@ void ex_copen(exarg_T *eap)
   tabpage_T   *prevtab = curtab;
   buf_T       *qf_buf;
   win_T       *oldwin = curwin;
+  bool tab_suc = false;
 
   if (eap->cmdidx == CMD_lopen || eap->cmdidx == CMD_lwindow) {
     qi = GET_LOC_LIST(curwin);
@@ -2103,8 +2104,9 @@ void ex_copen(exarg_T *eap)
       /* Create the new window at the very bottom, except when
        * :belowright or :aboveleft is used. */
       win_goto(lastwin);
-    if (win_split(height, WSP_BELOW | WSP_NEWLOC) == FAIL)
+    if (win_split_with_tab_suc(height, WSP_BELOW | WSP_NEWLOC, &tab_suc) == FAIL) {
       return;                   /* not enough room for window */
+    }
     RESET_BINDING(curwin);
 
     if (eap->cmdidx == CMD_lopen || eap->cmdidx == CMD_lwindow) {
@@ -2156,6 +2158,9 @@ void ex_copen(exarg_T *eap)
   curwin->w_cursor.col = 0;
   check_cursor();
   update_topline();             /* scroll to show the line */
+  if (tab_suc) {
+      apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, false, curbuf);
+  }
 }
 
 /*

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2307,6 +2307,7 @@ jumpto_tag (
   char_u      *full_fname = NULL;
   int old_KeyTyped = KeyTyped;              /* getting the file may reset it */
   const int l_g_do_tagpreview = g_do_tagpreview;
+  bool tab_suc = false;
 
   pbuf = xmalloc(LSIZE);
 
@@ -2387,8 +2388,8 @@ jumpto_tag (
   /* If it was a CTRL-W CTRL-] command split window now.  For ":tab tag"
    * open a new tab page. */
   if (postponed_split || cmdmod.tab != 0) {
-    win_split(postponed_split > 0 ? postponed_split : 0,
-        postponed_split_flags);
+    win_split_with_tab_suc(postponed_split > 0 ? postponed_split : 0,
+                           postponed_split_flags, &tab_suc);
     RESET_BINDING(curwin);
   }
 
@@ -2543,6 +2544,9 @@ jumpto_tag (
       validate_cursor();
       redraw_later(VALID);
       win_enter(curwin_save, true);
+    }
+    if (tab_suc) {
+        apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, false, curbuf);
     }
 
     --RedrawingDisabled;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -506,11 +506,23 @@ static void cmd_with_count(char *cmd, char_u *bufp, size_t bufsize,
  *
  * return FAIL for failure, OK otherwise
  */
-int win_split(int size, int flags)
+int win_split(int size, int flags) {
+    return win_split_with_tab_suc(size, flags, NULL);
+}
+
+int win_split_with_tab_suc(int size, int flags, bool *tab_suc)
 {
-  /* When the ":tab" modifier was used open a new tab page instead. */
-  if (may_open_tabpage() == OK)
+  if (tab_suc != NULL) {
+    *tab_suc = false;
+  }
+
+  // When the ":tab" modifier was used open a new tab page instead.
+  if (may_open_tabpage() == OK) {
+    if (tab_suc != NULL) {
+      *tab_suc = true;
+    }
     return OK;
+  }
 
   /* Add flags from ":vertical", ":topleft" and ":botright". */
   flags |= cmdmod.split;


### PR DESCRIPTION
Closes #4334 

This turned out to be more difficult then I thought. Because `TabNewEntered` is a postponed event, we need to save if a tab was opened (the `:tab` modifier can fail without the whole command failing, so we cannot trust `cmdmod.tab`)
- I created a helper function so I didn't have to change `win_split` everywhere in the code, is this the preferred solution?
- I'm not 100% sure on the locations to call `TabNewEntered`, maybe someone could have a look at that.
- Will try to add some tests soon :-)
