### PR TITLE
[RFC] vim-patch: 8.0.0041, 8.0.0042, 8.0.0043

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -664,9 +664,10 @@ static int insert_execute(VimState *state, int key)
 
       // Pressing CTRL-Y selects the current match.  When
       // compl_enter_selects is set the Enter key does the same.
-      if (s->c == Ctrl_Y
-          || (compl_enter_selects
-            && (s->c == CAR || s->c == K_KENTER || s->c == NL))) {
+      if ((s->c == Ctrl_Y
+           || (compl_enter_selects
+               && (s->c == CAR || s->c == K_KENTER || s->c == NL)))
+          && stop_arrow() == OK) {
         ins_compl_delete();
         ins_compl_insert();
       }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2350,9 +2350,6 @@ void set_completion(colnr_T startcol, list_T *list)
   }
   ins_compl_clear();
 
-  if (stop_arrow() == FAIL)
-    return;
-
   compl_direction = FORWARD;
   if (startcol > curwin->w_cursor.col)
     startcol = curwin->w_cursor.col;
@@ -3263,14 +3260,19 @@ static bool ins_compl_prep(int c)
       } else {
         int prev_col = curwin->w_cursor.col;
 
-        /* put the cursor on the last char, for 'tw' formatting */
-        if (prev_col > 0)
+        // put the cursor on the last char, for 'tw' formatting
+        if (prev_col > 0) {
           dec_cursor();
-        if (stop_arrow() == OK)
+        }
+
+        if (!arrow_used && !ins_need_undo) {
           insertchar(NUL, 0, -1);
+        }
+
         if (prev_col > 0
-            && get_cursor_line_ptr()[curwin->w_cursor.col] != NUL)
+            && get_cursor_line_ptr()[curwin->w_cursor.col] != NUL) {
           inc_cursor();
+        }
       }
 
       // If the popup menu is displayed pressing CTRL-Y means accepting


### PR DESCRIPTION
vim-patch:8.0.0041
https://github.com/vim/vim/commit/869e35270ecffd9024958880cb03f6f0bb01ea93

```
Problem:    When using Insert mode completion but not actually inserting
            anything an undo item is still created. (Tommy Allen)
Solution:   Do not call stop_arrow() when not inserting anything.
```

vim-patch:8.0.0042
https://github.com/vim/vim/commit/cbd3bd6cbed5baf418b037b17ad46e339ff59174

```
Problem:    When using Insert mode completion with 'completeopt' containing
            "noinsert" change is not saved for undo.  (Tommy Allen)
Solution:   Call stop_arrow() before inserting for pressing Enter.
```

vim-patch:8.0.0043
https://github.com/vim/vim/commit/9ec7fa82a2c4f0283862ed704c2940959e6130ee

```
Problem:    When using Insert mode completion with 'completeopt' containing
            "noinsert" with CTRL-N the change is not saved for undo.  (Tommy
            Allen)
Solution:   Call stop_arrow() before inserting for any key.
```
