### PR TITLE
[RFC] rplugin: resolve paths in manifest commands

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -190,7 +190,7 @@ function! s:RegistrationCommands(host) abort
   call remote#host#RegisterClone(host_id, a:host)
   let pattern = s:plugin_patterns[a:host]
   let paths = globpath(&rtp, 'rplugin/'.a:host.'/'.pattern, 0, 1)
-  let paths = map(paths, 'tr(v:val,"\\","/")') " Normalize slashes #4795
+  let paths = map(paths, 'tr(resolve(v:val),"\\","/")') " Normalize slashes #4795
   let paths = uniq(sort(paths))
   if empty(paths)
     return []


### PR DESCRIPTION
In [this line](https://github.com/neovim/neovim/blob/869a9078e189ed14284fee7c341d669d8a4611d5/runtime/autoload/health/nvim.vim#L33), we compare the unresolved path written to the manifest file against a resolved path from the outer `for` loop.

Without this patch, `:CheckHealth nvim` will always report an outdated manifest, because:

```
/Users/mhi/.vim/bundle/deoplete.nvim/rplugin/python3/deoplete
!=
/Users/mhi/.dotfiles/vim/bundle/deoplete.nvim/rplugin/python3/deoplete
```
