### PR TITLE
vim-patch:7.4.1494

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4396,6 +4396,7 @@ static HistoryType hist_char2type(const int c)
     case '>': {
       return HIST_DEBUG;
     }
+    case NUL:
     case '/':
     case '?': {
       return HIST_SEARCH;

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -34,6 +34,7 @@ NEW_TESTS = \
 	    test_cscope.res \
 	    test_hardcopy.res \
 	    test_help_tagjump.res \
+	    test_history.res \
 	    test_langmap.res \
 	    test_syntax.res \
 	    test_usercommands.res \

--- a/src/nvim/testdir/test_history.vim
+++ b/src/nvim/testdir/test_history.vim
@@ -1,0 +1,65 @@
+" Tests for the history functions
+
+if !has('cmdline_hist')
+  finish
+endif
+
+set history=7
+
+function History_Tests(hist)
+  " First clear the history
+  call histadd(a:hist, 'dummy')
+  call assert_true(histdel(a:hist))
+  call assert_equal(-1, histnr(a:hist))
+  call assert_equal('', histget(a:hist))
+
+  call assert_true(histadd(a:hist, 'ls'))
+  call assert_true(histadd(a:hist, 'buffers'))
+  call assert_equal('buffers', histget(a:hist))
+  call assert_equal('ls', histget(a:hist, -2))
+  call assert_equal('ls', histget(a:hist, 1))
+  call assert_equal('', histget(a:hist, 5))
+  call assert_equal('', histget(a:hist, -5))
+  call assert_equal(2, histnr(a:hist))
+  call assert_true(histdel(a:hist, 2))
+  call assert_false(histdel(a:hist, 7))
+  call assert_equal(1, histnr(a:hist))
+  call assert_equal('ls', histget(a:hist, -1))
+
+  call assert_true(histadd(a:hist, 'buffers'))
+  call assert_true(histadd(a:hist, 'ls'))
+  call assert_equal('ls', histget(a:hist, -1))
+  call assert_equal(4, histnr(a:hist))
+
+  " Test for removing entries matching a pattern
+  for i in range(1, 3)
+      call histadd(a:hist, 'text_' . i)
+  endfor
+  call assert_true(histdel(a:hist, 'text_\d\+'))
+  call assert_equal('ls', histget(a:hist, -1))
+
+  " Test for freeing the entire history list
+  for i in range(1, 7)
+      call histadd(a:hist, 'text_' . i)
+  endfor
+  call histdel(a:hist)
+  for i in range(1, 7)
+    call assert_equal('', histget(a:hist, i))
+    call assert_equal('', histget(a:hist, i - 7 - 1))
+  endfor
+endfunction
+
+function Test_History()
+  for h in ['cmd', ':', '', 'search', '/', '?', 'expr', '=', 'input', '@', 'debug', '>']
+    call History_Tests(h)
+  endfor
+
+  " Negative tests
+  call assert_false(histdel('abc'))
+  call assert_equal('', histget('abc'))
+  call assert_fails('call histdel([])', 'E730:')
+  call assert_equal('', histget(10))
+  call assert_fails('call histget([])', 'E730:')
+  call assert_equal(-1, histnr('abc'))
+  call assert_fails('call histnr([])', 'E730:')
+endfunction

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -949,7 +949,7 @@ static int included_patches[] = {
   // 1497 NA
   // 1496 NA
   // 1495 NA
-  // 1494,
+  1494,
   // 1493 NA
   1492,
   1491,


### PR DESCRIPTION
Problem:    clr_history() does not work properly.
Solution:   Increment hisptr. Add a test. (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/119d4693e06e68d4f099aa7287e375ae3d265fd0

Note: Only added a test. The change to `histptr` had already been made.
