### PR TITLE
[RFC] tests: fix racyness in terminal/api_spec.lua

### DIFF
--- a/test/functional/terminal/api_spec.lua
+++ b/test/functional/terminal/api_spec.lua
@@ -22,7 +22,7 @@ describe('api', function()
     -- Start the socket from the child nvim.
     child_session.feed_data(":echo serverstart('"..socket_name.."')\n")
 
-    -- Wait for socket creation by abusing expect().
+    -- Wait for socket creation.
     screen:expect([[
       {1: }                                                 |
       {4:~                                                 }|
@@ -37,6 +37,16 @@ describe('api', function()
     local socket_session2 = helpers.connect(socket_name)
 
     child_session.feed_data("i[tui] insert-mode")
+    -- Wait for stdin to be processed.
+    screen:expect([[
+      [tui] insert-mode{1: }                                |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name] [+]                                     }|
+      {3:-- INSERT --}                                      |
+      {3:-- TERMINAL --}                                    |
+    ]])
 
     ok(socket_session1:request("nvim_ui_attach", 42, 6, {rgb=true}))
     ok(socket_session2:request("nvim_ui_attach", 25, 30, {rgb=true}))


### PR DESCRIPTION
Previously, the nvim_input from the socket channels could be processed
before the input from stdin in rare cases.

ref https://github.com/neovim/neovim/pull/5393#issuecomment-254775796
