### PR TITLE
Silence runtime/ftplugin/man.vim `file` call

### DIFF
--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -21,7 +21,7 @@ if has('vim_starting')
   " all caps it is impossible to tell what the original capitilization was.
   let ref = tolower(matchstr(getline(1), '^\S\+'))
   let b:man_sect = man#extract_sect_and_name_ref(ref)[0]
-  execute 'file man://'.ref
+  execute 'silent file man://'.ref
 endif
 
 setlocal buftype=nofile


### PR DESCRIPTION
When a file is opened by nvim with ft=man already set, and
"has('vim_starting')", ftplugin/man.vim calls
'execute 'file man://'.ref', this causes nvim to display something like
this:

```
"<name of original file>" 977, 41017C
"man://foo(1)" [Not edited] 977 lines --0%--
Press ENTER or type command to continue
```

This is annoying, because nothing of note has actually happened.

Use cases why you might want to read a man page from a file:

`MANPAGER='bash -c "nvim -c \"set ft=man\" </dev/tty <(col -bx)"' man git`
`nvim -c 'set ft=man' <(man -P cat git)`
