### PR TITLE
Improve Python health check

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -393,14 +393,12 @@ function! s:check_python(version) abort
     endif
 
     if s:is_bad_response(latest)
-      call health#report_warn('Unable to contact PyPI.')
+      call health#report_warn('Could not contact PyPI to get latest version.')
       call health#report_error('HTTP request failed: '.latest)
-    endif
-
-    if s:is_bad_response(status)
+    elseif s:is_bad_response(status)
       call health#report_warn(printf('Latest %s-neovim is NOT installed: %s',
             \ python_bin_name, latest))
-    elseif !s:is_bad_response(latest) !s:is_bad_response(current)
+    elseif !s:is_bad_response(current)
       call health#report_ok(printf('Latest %s-neovim is installed: %s',
             \ python_bin_name, latest))
     endif

--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -84,8 +84,8 @@ endfunction
 " Fetch the contents of a URL.
 function! s:download(url) abort
   if executable('curl')
-    let rv = s:system(['curl', '-sL', a:url])
-    return s:shell_error ? 'curl error: '.s:shell_error : rv
+    let rv = s:system(['curl', '-sL', a:url], '', 1, 1)
+    return s:shell_error ? 'curl error with '.a:url.': '.s:shell_error : rv
   elseif executable('python')
     let script = "
           \try:\n

--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -155,13 +155,10 @@ function! s:version_info(python) abort
   endif
 
   let nvim_path = s:trim(s:system([
-        \ a:python,
-        \ '-c',
-        \ 'import neovim; print(neovim.__file__)']))
-  let nvim_path = s:shell_error ? '' : nvim_path
-
-  if empty(nvim_path)
-    return [python_version, 'unable to find nvim executable', pypi_version, 'unable to get nvim executable']
+        \ a:python, '-c', 'import neovim; print(neovim.__file__)']))
+  if s:shell_error || empty(nvim_path)
+    return [python_version, 'unable to load neovim Python module', pypi_version,
+          \ nvim_path]
   endif
 
   " Assuming that multiple versions of a package are installed, sort them
@@ -172,7 +169,7 @@ function! s:version_info(python) abort
     return a == b ? 0 : a > b ? 1 : -1
   endfunction
 
-  let nvim_version = 'unable to find nvim version'
+  let nvim_version = 'unable to find neovim Python module version'
   let base = fnamemodify(nvim_path, ':h')
   let metas = glob(base.'-*/METADATA', 1, 1)
         \ + glob(base.'-*/PKG-INFO', 1, 1)
@@ -390,7 +387,7 @@ function! s:check_python(version) abort
     if s:is_bad_response(status)
       call health#report_warn(printf('Latest %s-neovim is NOT installed: %s',
             \ python_bin_name, latest))
-    elseif !s:is_bad_response(latest)
+    elseif !s:is_bad_response(latest) !s:is_bad_response(current)
       call health#report_ok(printf('Latest %s-neovim is installed: %s',
             \ python_bin_name, latest))
     endif

--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -185,10 +185,11 @@ function! s:version_info(python) abort
     endfor
   endif
 
-  let version_status = 'unknown'
+  let nvim_path_base = fnamemodify(nvim_path, ':~:h')
+  let version_status = 'unknown; '.nvim_path_base
   if !s:is_bad_response(nvim_version) && !s:is_bad_response(pypi_version)
     if s:version_cmp(nvim_version, pypi_version) == -1
-      let version_status = 'outdated'
+      let version_status = 'outdated; from '.nvim_path_base
     else
       let version_status = 'up to date'
     endif
@@ -371,7 +372,11 @@ function! s:check_python(version) abort
     endif
 
     call health#report_info('Python'.a:version.' version: ' . pyversion)
-    call health#report_info(printf('%s-neovim version: %s', python_bin_name, current))
+    if s:is_bad_response(status)
+      call health#report_info(printf('%s-neovim version: %s (%s)', python_bin_name, current, status))
+    else
+      call health#report_info(printf('%s-neovim version: %s', python_bin_name, current))
+    endif
 
     if s:is_bad_response(current)
       call health#report_error(

--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -174,7 +174,9 @@ function! s:version_info(python) abort
 
   let nvim_version = 'unable to find nvim version'
   let base = fnamemodify(nvim_path, ':h')
-  let metas = glob(base.'-*/METADATA', 1, 1) + glob(base.'-*/PKG-INFO', 1, 1)
+  let metas = glob(base.'-*/METADATA', 1, 1)
+        \ + glob(base.'-*/PKG-INFO', 1, 1)
+        \ + glob(base.'.egg-info/PKG-INFO', 1, 1)
   let metas = sort(metas, 's:compare')
 
   if !empty(metas)


### PR DESCRIPTION
- handle version from `pip install --user -e`
- report error from the `import` failure

Side notes:
- there should probably be a `neovim.VERSION` that should be used instead of the manual parsing!
- we could report the location of the found module, e.g. via `inspect.getfile()`

TODO:
 - try to import and use `neovim.VERSION`
