### PR TITLE
test: Fix shada/marks_spec.lua failure

### DIFF
--- a/test/functional/shada/marks_spec.lua
+++ b/test/functional/shada/marks_spec.lua
@@ -104,7 +104,7 @@ describe('ShaDa support code', function()
 
   it('is able to dump and read back mark " from a closed tab', function()
     nvim_command('edit ' .. testfilename)
-    nvim_command('edit ' .. testfilename_2)
+    nvim_command('tabedit ' .. testfilename_2)
     nvim_command('2')
     nvim_command('q!')
     nvim_command('qall')


### PR DESCRIPTION
The 'dump and read back mark " from a closed tab' test needs to actually
create a second tab.  Since it wasn't doing so, the 'q!' command caused
nvim to exit and the subsequent 'qall' command fails.
