### PR TITLE
[WIP] vim-patch:7.4.2201

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -247,10 +247,10 @@ global value, which is used for new buffers.  With ":set" both the local and
 global value is changed.  With "setlocal" only the local value is changed,
 thus this value is not used when editing a new buffer.
 
-When editing a buffer that has been edited before, the last used window
-options are used again.  If this buffer has been edited in this window, the
-values from back then are used.  Otherwise the values from the window where
-the buffer was edited last are used.
+When editing a buffer that has been edited before, the options from the window
+that was last closed are used again.  If this buffer has been edited in this
+window, the values from back then are used.  Otherwise the values from the
+last closed window where the buffer was edited last are used.
 
 It's possible to set a local window option specifically for a type of buffer.
 When you edit another buffer in the same window, you don't want to keep
@@ -5671,10 +5671,19 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	Example: Try this together with 'sidescroll' and 'listchars' as
 		 in the following example to never allow the cursor to move
-		 onto the "extends" character:
+		 onto the "extends" character: >
 
 		 :set nowrap sidescroll=1 listchars=extends:>,precedes:<
 		 :set sidescrolloff=1
+<
+						*'signcolumn'* *'scl'*
+'signcolumn' 'scl'	string	(default "auto")
+			local to window
+			{not in Vi}
+			{not available when compiled without the |+signs|
+			feature}
+	Whether or not to draw the signcolumn. "auto" means it will only be
+	drawn when there is a sign to display.
 
 
 			*'smartcase'* *'scs'* *'nosmartcase'* *'noscs'*

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1250,6 +1250,9 @@ call append("$", "\t(local to buffer)")
 call <SID>BinOptionL("bl")
 call append("$", "debug\tset to \"msg\" to see all error messages")
 call append("$", " \tset debug=" . &debug)
+call append("$", "signcolumn\twhether to show the signcolumn")
+call append("$", "\t(local to window)")
+call <SID>OptionL("scl")
 
 set cpo&vim
 

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -237,6 +237,8 @@ typedef struct {
 # define w_p_crb w_onebuf_opt.wo_crb    /* 'cursorbind' */
   int wo_crb_save;              /* 'cursorbind' state saved for diff mode*/
 # define w_p_crb_save w_onebuf_opt.wo_crb_save
+  char_u	*wo_scl;
+# define w_p_scl w_onebuf_opt.wo_scl	/* 'signcolumn' */
 
   int wo_scriptID[WV_COUNT];            /* SIDs for window-local options */
 # define w_p_scriptID w_onebuf_opt.wo_scriptID

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -237,8 +237,8 @@ typedef struct {
 # define w_p_crb w_onebuf_opt.wo_crb    /* 'cursorbind' */
   int wo_crb_save;              /* 'cursorbind' state saved for diff mode*/
 # define w_p_crb_save w_onebuf_opt.wo_crb_save
-  char_u	*wo_scl;
-# define w_p_scl w_onebuf_opt.wo_scl	/* 'signcolumn' */
+  char_u *wo_scl;
+# define w_p_scl w_onebuf_opt.wo_scl    // 'signcolumn'
 
   int wo_scriptID[WV_COUNT];            /* SIDs for window-local options */
 # define w_p_scriptID w_onebuf_opt.wo_scriptID

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -5701,7 +5701,7 @@ comp_textwidth (
       textwidth -= 1;
     textwidth -= curwin->w_p_fdc;
 
-    if (curwin->w_buffer->b_signlist != NULL) {
+    if (signcolumn_on(curwin)) {
         textwidth -= 1;
     }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5611,6 +5611,11 @@ void ex_sign(exarg_T *eap)
 		}
 		else
 		{   // ... not currently in a window
+      if (buf->b_fname == NULL) {
+        EMSG(_("E934: Cannot jump to a buffer that does not have a name"));
+        return;
+      }
+
 		    char *cmd = xmalloc(STRLEN(buf->b_fname) + 25);
 		    sprintf(cmd, "e +%" PRId64 " %s",
                     (int64_t)lnum, buf->b_fname);

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -670,8 +670,7 @@ int win_col_off(win_T *wp)
   return ((wp->w_p_nu || wp->w_p_rnu) ? number_width(wp) + 1 : 0)
          + (cmdwin_type == 0 || wp != curwin ? 0 : 1)
          + (int)wp->w_p_fdc
-         + (signcolumn_on(wp) ? 2 : 0)
-  ;
+         + (signcolumn_on(wp) ? 2 : 0);
 }
 
 int curwin_col_off(void)

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -24,6 +24,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/misc1.h"
+#include "nvim/option.h"
 #include "nvim/popupmnu.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"
@@ -669,7 +670,7 @@ int win_col_off(win_T *wp)
   return ((wp->w_p_nu || wp->w_p_rnu) ? number_width(wp) + 1 : 0)
          + (cmdwin_type == 0 || wp != curwin ? 0 : 1)
          + (int)wp->w_p_fdc
-         + (wp->w_buffer->b_signlist != NULL ? 2 : 0)
+         + (signcolumn_on(wp) ? 2 : 0)
   ;
 }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -288,6 +288,7 @@ static char *(p_fdm_values[]) =       { "manual", "expr", "marker", "indent",
 static char *(p_fcl_values[]) =       { "all", NULL };
 static char *(p_cot_values[]) =       { "menu", "menuone", "longest", "preview",
                                         "noinsert", "noselect", NULL };
+static char *(p_scl_values[]) =       { "yes", "no", "auto", NULL };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "option.c.generated.h"
@@ -2985,6 +2986,13 @@ did_set_string_option (
       completeopt_was_set();
     }
   }
+  /* 'signcolumn' */
+  else if (varp == &curwin->w_p_scl)
+  {
+    if (check_opt_strings(*varp, p_scl_values, false) != OK) {
+      errmsg = e_invarg;
+    }
+  }
   /* 'pastetoggle': translate key codes like in a mapping */
   else if (varp == &p_pt) {
     if (*p_pt) {
@@ -4749,6 +4757,15 @@ static int find_key_option(const char_u *arg)
   return find_key_option_len(arg, STRLEN(arg));
 }
 
+#ifdef FEAT_SIGNS
+    /* 'signcolumn' */
+    else if (varp == &curwin->w_p_scl)
+    {
+	if (check_opt_strings(*varp, p_scl_values, FALSE) != OK)
+	    errmsg = e_invarg;
+    }
+#endif
+
 
 /*
  * if 'all' == 0: show changed options
@@ -5394,6 +5411,7 @@ static char_u *get_varp(vimoption_T *p)
   case PV_UDF:    return (char_u *)&(curbuf->b_p_udf);
   case PV_WM:     return (char_u *)&(curbuf->b_p_wm);
   case PV_KMAP:   return (char_u *)&(curbuf->b_p_keymap);
+  case PV_SCL:    return (char_u *)&(curwin->w_p_scl);
   default:        EMSG(_("E356: get_varp ERROR"));
   }
   /* always return a valid pointer to avoid a crash! */
@@ -5471,6 +5489,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_fde = vim_strsave(from->wo_fde);
   to->wo_fdt = vim_strsave(from->wo_fdt);
   to->wo_fmr = vim_strsave(from->wo_fmr);
+  to->wo_scl = vim_strsave(from->wo_scl);
   check_winopt(to);             /* don't want NULL pointers */
 }
 
@@ -5494,6 +5513,7 @@ static void check_winopt(winopt_T *wop)
   check_string_option(&wop->wo_fde);
   check_string_option(&wop->wo_fdt);
   check_string_option(&wop->wo_fmr);
+  check_string_option(&wop->wo_scl);
   check_string_option(&wop->wo_rlc);
   check_string_option(&wop->wo_stl);
   check_string_option(&wop->wo_cc);
@@ -5512,6 +5532,7 @@ void clear_winopt(winopt_T *wop)
   clear_string_option(&wop->wo_fde);
   clear_string_option(&wop->wo_fdt);
   clear_string_option(&wop->wo_fmr);
+  clear_string_option(&wop->wo_scl);
   clear_string_option(&wop->wo_rlc);
   clear_string_option(&wop->wo_stl);
   clear_string_option(&wop->wo_cc);
@@ -6868,3 +6889,12 @@ int csh_like_shell(void)
   return strstr((char *)path_tail(p_sh), "csh") != NULL;
 }
 
+int signcolumn_on(win_T *wp) {
+    if (*wp->w_p_scl == 'n') {
+      return false;
+    }
+    if (*wp->w_p_scl == 'y') {
+      return true;
+    }
+    return wp->w_buffer->b_signlist != NULL;
+}

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4757,16 +4757,6 @@ static int find_key_option(const char_u *arg)
   return find_key_option_len(arg, STRLEN(arg));
 }
 
-#ifdef FEAT_SIGNS
-    /* 'signcolumn' */
-    else if (varp == &curwin->w_p_scl)
-    {
-	if (check_opt_strings(*varp, p_scl_values, FALSE) != OK)
-	    errmsg = e_invarg;
-    }
-#endif
-
-
 /*
  * if 'all' == 0: show changed options
  * if 'all' == 1: show all normal options

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2985,10 +2985,7 @@ did_set_string_option (
     } else {
       completeopt_was_set();
     }
-  }
-  /* 'signcolumn' */
-  else if (varp == &curwin->w_p_scl)
-  {
+  } else if (varp == &curwin->w_p_scl) {  // 'signcolumn'
     if (check_opt_strings(*varp, p_scl_values, false) != OK) {
       errmsg = e_invarg;
     }
@@ -5480,7 +5477,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_fdt = vim_strsave(from->wo_fdt);
   to->wo_fmr = vim_strsave(from->wo_fmr);
   to->wo_scl = vim_strsave(from->wo_scl);
-  check_winopt(to);             /* don't want NULL pointers */
+  check_winopt(to);             // don't want NULL pointers
 }
 
 /*

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -801,7 +801,7 @@ enum {
   , WV_WFW
   , WV_WRAP
   , WV_SCL
-  , WV_COUNT        /* must be the last one */
+  , WV_COUNT        // must be the last one
 };
 
 /* Value for b_p_ul indicating the global value must be used. */

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -800,6 +800,7 @@ enum {
   , WV_WFH
   , WV_WFW
   , WV_WRAP
+  , WV_SCL
   , WV_COUNT        /* must be the last one */
 };
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2162,6 +2162,14 @@ return {
       defaults={if_true={vi=0}}
     },
     {
+      full_name='signcolumn', abbreviation='scl',
+      type='string', scope={'window'},
+      vi_def=true,
+      alloced=true,
+      redraw={'current_window'},
+      defaults={if_true={vi="auto"}}
+    },
+    {
       full_name='smartcase', abbreviation='scs',
       type='bool', scope={'global'},
       vi_def=true,

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1630,8 +1630,7 @@ static void win_draw_end(win_T *wp, int c1, int c2, int row, int endrow, hlf_T h
       n = nn;
     }
 
-    if (signcolumn_on(wp))
-    {
+    if (signcolumn_on(wp)) {
         int nn = n + 2;
 
         /* draw the sign column after the fold column */
@@ -1743,7 +1742,7 @@ static void fold_line(win_T *wp, long fold_count, foldinfo_T *foldinfo, linenr_T
    * text */
   RL_MEMSET(col, hl_attr(HLF_FL), wp->w_width - col);
 
-  /* If signs are being displayed, add two spaces. */
+  // If signs are being displayed, add two spaces.
   if (signcolumn_on(wp)) {
       len = wp->w_width - col;
       if (len > 0) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -576,15 +576,6 @@ void update_debug_sign(buf_T *buf, linenr_T lnum)
 }
 
 /*
- * Return TRUE when window "wp" has a column to draw signs in.
- */
-static int draw_signcolumn(win_T *wp)
-{
-    return (wp->w_buffer->b_signlist != NULL);
-}
-
-
-/*
  * Update a single window.
  *
  * This may cause the windows below it also to be redrawn (when clearing the
@@ -1598,7 +1589,7 @@ static void win_draw_end(win_T *wp, int c1, int c2, int row, int endrow, hlf_T h
                   ' ', ' ', hl_attr(HLF_FC));
     }
 
-    if (draw_signcolumn(wp)) {
+    if (signcolumn_on(wp)) {
         int nn = n + 2;
 
         /* draw the sign column left of the fold column */
@@ -1639,7 +1630,7 @@ static void win_draw_end(win_T *wp, int c1, int c2, int row, int endrow, hlf_T h
       n = nn;
     }
 
-    if (draw_signcolumn(wp))
+    if (signcolumn_on(wp))
     {
         int nn = n + 2;
 
@@ -1753,7 +1744,7 @@ static void fold_line(win_T *wp, long fold_count, foldinfo_T *foldinfo, linenr_T
   RL_MEMSET(col, hl_attr(HLF_FL), wp->w_width - col);
 
   /* If signs are being displayed, add two spaces. */
-  if (draw_signcolumn(wp)) {
+  if (signcolumn_on(wp)) {
       len = wp->w_width - col;
       if (len > 0) {
           if (len > 2) {
@@ -2699,7 +2690,7 @@ win_line (
           draw_state = WL_SIGN;
           /* Show the sign column when there are any signs in this
            * buffer or when using Netbeans. */
-          if (draw_signcolumn(wp)) {
+          if (signcolumn_on(wp)) {
               int text_sign;
               /* Draw two cells with the sign value or blank. */
               c_extra = ' ';

--- a/test/functional/ex_cmds/sign_spec.lua
+++ b/test/functional/ex_cmds/sign_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
-local clear, nvim, eq = helpers.clear, helpers.nvim, helpers.eq
+local clear, nvim, eq, neq, command, execute, eval
+  = helpers.clear, helpers.nvim, helpers.eq, helpers.neq, helpers.command, helpers.execute, helpers.eval
 
 describe('sign', function()
   before_each(clear)
@@ -19,6 +20,24 @@ describe('sign', function()
         eq("\n--- Signs ---\n", nvim('command_output', 'sign place buffer='..buf1))
         eq("\n--- Signs ---\n", nvim('command_output', 'sign place buffer='..buf2))
       end)
+    end)
+  end)
+end)
+
+describe('signs jump', function()
+  setup(clear)
+
+  describe('when given a missing buffer', function()
+    it('should return an error', function()
+      command('new')
+      command('sign define Sign text=x')
+      local buf1 = eval('bufnr("%")')
+      command('new')
+      command('bd '..buf1)
+      command('sign place 34 line=3 name=Sign buffer='..buf1)
+      execute('sign jump 34 buffer='..buf1)
+
+      neq(nil, string.find(eval('v:errmsg'), '^E934'))
     end)
   end)
 end)


### PR DESCRIPTION
patch 7.4.2201
Problem:    The sign column disappears when the last sign is deleted.
Solution:   Add the 'signcolumn' option. (Christian Brabandt)

https://github.com/vim/vim/commit/95ec9d6a6ab3117d60ff638670a803d43974ba51

patch 7.4.2225
Problem:    Crash when placing a sign in a deleted buffer.
Solution:   Check for missing buffer name. (Dominique Pelle). Add a test.

https://github.com/vim/vim/commit/bfd096d02087a10e8e2f4bdfb74e0435506fa8bb

patch 7.4.2294
Problem:    Sign test fails on MS-Windows when using the distributed zip archives.
Solution:   Create dummy files instead of relying on files in the pixmaps directory.

https://github.com/vim/vim/commit/64cefedfc834aa4dac54ae5f91ccbc04e2d56bc5
