### PR TITLE
doc: Remove features from vim_diff which have been merged upstream

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -123,15 +123,12 @@ Functions:
   |msgpackdump()|, |msgpackparse()| provide msgpack de/serialization
 
 Events:
-  |TabNew|
   |TabNewEntered|
-  |TabClosed|
   |TermOpen|
   |TermClose|
   |TextYankPost|
 
 Highlight groups:
-  |hl-EndOfBuffer|
   |hl-QuickFixLine|
   |hl-TermCursor|
   |hl-TermCursorNC|


### PR DESCRIPTION
- TabNew/TabClosed: Introduced in 7.4.2075 and 7.4.2077
- hl-EndOfBuffer: Introduced in 7.4.2213