### PR TITLE
[WIP] tui: query terminal for "cursor blink"

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -1,6 +1,7 @@
 
 #include "nvim/tui/input.h"
 #include "nvim/vim.h"
+#include "nvim/log.h"
 #include "nvim/api/vim.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/ascii.h"
@@ -236,6 +237,11 @@ static void tk_getkeys(TermInput *input, bool force)
       forward_modified_utf8(input, &key);
     } else if (key.type == TERMKEY_TYPE_MOUSE) {
       forward_mouse_event(input, &key);
+    } else if (key.type == TERMKEY_TYPE_MODEREPORT) {
+      int initial, mode, value;
+      termkey_interpret_modereport(input->tk, &key, &initial, &mode, &value);
+      ILOG("TERMKEY_TYPE_MODEREPORT initial=%c mode=%d value=%d",
+           initial, mode, value);
     }
   }
 


### PR DESCRIPTION
- related: [Vim patch to detect terminal types](https://github.com/vim/vim/pull/2126)
- related: need better terminal-type detection for truecolor capabilities: https://github.com/neovim/neovim/issues/7473
- term response edge-cases: https://unix.stackexchange.com/a/390797

---

This is, first, an experiment: ~~I need someone to test this~~ on a terminal (e.g. pangoterm) that responds to  DECRQM queries. To do so, just build this PR as a Debug build (that's the default if you didn't change `CMAKE_BUILD_TYPE`), then please post the results from `~/.nvimlog`.

If this works, I'll add the necessary UI hooks to pass around the response from the terminal. 

Second, minor change (cd5e4ac) changes `NVIM_TUI_ENABLE_CURSOR_SHAPE=0` to skip enabling cursor shape.

