### PR TITLE
[RFC] Health: ignore error if markdownCodeBlock doesn't exist

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -22,7 +22,7 @@ function! s:enhance_syntax() abort
   highlight! link markdownError Normal
 
   " We don't need code blocks.
-  syntax clear markdownCodeBlock
+  silent! syntax clear markdownCodeBlock
 endfunction
 
 " Runs the specified healthchecks.


### PR DESCRIPTION
```
This is done because plugins like [1] overwrite the default Markdown syntax and
define syntax groups other than the ones ehance_syntax() expects.

[1]: https://github.com/plasticboy/vim-markdown
```

References #5569.

---

This is just a suggestion.

Not sure if that's the best way to force the use of the shipped syntax file, but it's certainly better than fighting against corner cases of non-default Markdown syntaxes.