### PR TITLE
[RFC] Include v:throwpoint in :CheckHealth errors

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -58,7 +58,7 @@ function! health#check(plugin_names) abort
           let output = execute(
                 \ 'call health#report_error(''Failed to run healthcheck for "'
                 \ .s:to_plugin_name(c)
-                \ .'" plugin. Exception:''."\n".v:exception)')
+                \ .'" plugin. Exception:''."\n".v:throwpoint."\n".v:exception)')
         endif
       endtry
       call append('$', split(output, "\n") + [''])

--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -26,10 +26,8 @@ endfunction
 
 " Handler for s:system() function.
 function! s:system_handler(jobid, data, event) abort
-  if a:event == 'stdout'
-    let self.stdout .= join(a:data, '')
-  elseif a:event == 'stderr'
-    let self.stderr .= join(a:data, '')
+  if a:event == 'stdout' || a:event == 'stderr'
+    let self.output .= join(a:data, '')
   elseif a:event == 'exit'
     let s:shell_error = a:data
   endif
@@ -39,8 +37,7 @@ endfunction
 function! s:system(cmd, ...) abort
   let stdin = a:0 ? a:1 : ''
   let opts = {
-        \ 'stdout': '',
-        \ 'stderr': '',
+        \ 'output': '',
         \ 'on_stdout': function('s:system_handler'),
         \ 'on_stderr': function('s:system_handler'),
         \ 'on_exit': function('s:system_handler'),
@@ -51,7 +48,7 @@ function! s:system(cmd, ...) abort
     call health#report_error(printf('Command error %d: %s', jobid,
           \ type(a:cmd) == type([]) ? join(a:cmd) : a:cmd)))
     let s:shell_error = 1
-    return ''
+    return opts.output
   endif
 
   if !empty(stdin)
@@ -66,10 +63,10 @@ function! s:system(cmd, ...) abort
   elseif s:shell_error != 0
     call health#report_error(printf("Command error (%d) %s: %s", jobid,
           \ type(a:cmd) == type([]) ? join(a:cmd) : a:cmd,
-          \ opts.stderr))
+          \ opts.output))
   endif
 
-  return opts.stdout
+  return opts.output
 endfunction
 
 function! s:systemlist(cmd, ...) abort

--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -409,7 +409,10 @@ endfunction
 
 function! s:check_ruby() abort
   call health#report_start('Ruby provider')
-  let ruby_version = s:systemlist('ruby -v')[0]
+  let ruby_version = 'not found'
+  if executable('ruby')
+    let ruby_version = s:systemlist('ruby -v')[0]
+  endif
   let ruby_prog    = provider#ruby#Detect()
   let suggestions  =
         \ ['Install or upgrade the neovim RubyGem using `gem install neovim`.']

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -68,6 +68,7 @@ describe('health.vim', function()
         health#broken#check
         ========================================================================
           - ERROR: Failed to run healthcheck for "broken" plugin. Exception:
+            function health#check[20]..health#broken#check, line 1
             caused an error
         ]])
     end)


### PR DESCRIPTION
Makes exceptions less vague.  This also includes a fix for the Ruby version check.  I think it was relying on `systemlist()` to return a `not found` message on failure, but #5565 doesn't return the stdout if job fails to start.  Should that be fixed as well?