### PR TITLE
vim-patch:7.4.1634

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4679,6 +4679,8 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
 theend:
   if (visual) {
     curwin->w_cursor = save_cursor;
+  } else if (did_change) {
+    curwin->w_set_curswant = true;
   }
 
   return did_change;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -810,7 +810,7 @@ static int included_patches[] = {
   // 1637 NA
   // 1636 NA
   // 1635 NA
-  // 1634,
+  1634,
   // 1633 NA
   // 1632 NA
   // 1631 NA

--- a/test/functional/legacy/increment_spec.lua
+++ b/test/functional/legacy/increment_spec.lua
@@ -727,6 +727,14 @@ describe('Ctrl-A/Ctrl-X on visual selections', function()
         exec "norm! gg$\<C-A>"
         call assert_equal("002", getline(1))
       endfunc
+
+      " Test a regression of patch 7.4.1087 fixed.
+      func Test_normal_increment_02()
+        call setline(1, ["hello 10", "world"])
+        exec "norm! ggl\<C-A>jx"
+        call assert_equal(["hello 11", "worl"], getline(1, '$'))
+        call assert_equal([0, 2, 4, 0], getpos('.'))
+      endfunc
     ]=])
   end)
 
@@ -743,6 +751,11 @@ describe('Ctrl-A/Ctrl-X on visual selections', function()
   it('does not drop leading zeroes', function()
     execute('set nrformats&vi') -- &vi makes Vim compatible
     call('Test_normal_increment_01')
+    eq({}, nvim.get_vvar('errors'))
+  end)
+
+  it('maintains correct column after CTRL-A', function()
+    call('Test_normal_increment_02')
     eq({}, nvim.get_vvar('errors'))
   end)
 end)


### PR DESCRIPTION
Problem:    Vertical movement after CTRL-A ends up in the wrong column.
            (Urtica Dioica)
Solution:   Set curswant when appropriate. (Hirohito Higashi)

https://github.com/vim/vim/commit/8e08125d3a9afd0b16cd84454ae9ddad0abaaab0