### PR TITLE
'autoread': handle focus events (including TUI)

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -34,7 +34,7 @@ these differences.
 - ":filetype plugin indent on" is enabled by default
 
 - 'autoindent' is set by default
-- 'autoread' is set by default
+- 'autoread' is set by default (works in all UIs, including terminal)
 - 'backspace' defaults to "indent,eol,start"
 - 'backupdir' defaults to .,~/.local/share/nvim/backup (|xdg|)
 - 'complete' doesn't include "i"
@@ -86,10 +86,10 @@ delegated to external plugins/extensions.
 
 ARCHITECTURE ~
 
-External plugins run in separate processes. |remote-plugin| This improves
-stability and allows those plugins to perform tasks without blocking the
-editor. Even "legacy" Python and Ruby plugins which use the old Vim interfaces
-(|if_py| and |if_ruby|) run out-of-process.
+External plugins run in separate processes. |remote-plugin|
+This improves stability and allows those plugins to perform tasks without
+blocking the editor. Even "legacy" Python and Ruby plugins using the old Vim
+interfaces (|if_py|, |if_ruby|) run out-of-process, so they cannot crash Nvim.
 
 
 FEATURES ~
@@ -106,6 +106,7 @@ Some `CTRL-SHIFT-...` key chords are distinguished from `CTRL-...` variants
   <C-Tab>, <C-S-Tab>, <C-BS>, <C-S-BS>, <C-Enter>, <C-S-Enter>
 
 Options:
+  'autoread' works in the terminal (if it supports "focus" events)
   'inccommand' shows results while typing a |:substitute| command
   'statusline' supports unlimited alignment sections
   'tabline' %@Func@foo%X can call any function on mouse-click

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4693,18 +4693,15 @@ int vim_rename(char_u *from, char_u *to)
 
 static int already_warned = FALSE;
 
-/*
- * Check if any not hidden buffer has been changed.
- * Postpone the check if there are characters in the stuff buffer, a global
- * command is being executed, a mapping is being executed or an autocommand is
- * busy.
- * Returns TRUE if some message was written (screen should be redrawn and
- * cursor positioned).
- */
-int 
-check_timestamps (
-    int focus                      /* called for GUI focus event */
-)
+/// Check if any not hidden buffer has been changed.
+/// Postpone the check if there are characters in the stuff buffer, a global
+/// command is being executed, a mapping is being executed or autocmd is busy.
+///
+/// @param focus  called for UI focus event
+///
+/// @return true if some message was written (screen should be redrawn and
+/// cursor positioned).
+bool check_timestamps(int focus)
 {
   buf_T       *buf;
   int didit = 0;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7894,13 +7894,13 @@ static void nv_event(cmdarg_T *cap)
 /// Trigger FocusGained event.
 static void nv_focusgained(cmdarg_T *cap)
 {
-  apply_autocmds(EVENT_FOCUSGAINED, NULL, NULL, false, curbuf);
+  ui_focus_change(true);
 }
 
 /// Trigger FocusLost event.
 static void nv_focuslost(cmdarg_T *cap)
 {
-  apply_autocmds(EVENT_FOCUSLOST, NULL, NULL, false, curbuf);
+  ui_focus_change(false);
 }
 
 /*


### PR DESCRIPTION
Closes #1936
Related: #1785
Related: #1380

This "pretty much works", but it's still in POC phase. Tested with iTerm2 (which sends focus events). Also works when tmux panes are changed, even on old versions of tmux (which don't support external focus events).

Known issues:

- [ ] on focus-gain, cursor is in wrong position (bottom left) until next user input
- [ ] if different files are displayed in different windows, on focus-gain the last file to be refreshed is displayed in all windows
- [ ] per `:help FileChangedShell` , it seems that `FileChangedShell` should trigger on FocusGained
- [ ] test coverage