### PR TITLE
[RFC] vim-patch:7.4.1658

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -940,7 +940,15 @@ VimEnter			After doing all the startup stuff, including
 				loading vimrc files, executing the "-c cmd"
 				arguments, creating all windows and loading
 				the buffers in them.
-							*VimLeave*
+				Just before this event is triggered the
+				|v:vim_did_enter| variable is set, so that you
+				can do: >
+				   if v:vim_did_enter
+				     call s:init()
+				   else
+ 	  			     au VimEnter * call s:init()
+				   endif
+<							*VimLeave*
 VimLeave			Before exiting Vim, just after writing the
 				.shada file.  Executed only once, like
 				VimLeavePre.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1765,6 +1765,10 @@ v:version	Version number of Vim: Major version number times 100 plus
 		version 5.0 and 5.1 may have a patch 123, but these are
 		completely different.
 
+				*v:vim_did_enter* *vim_did_enter-variable*
+v:vim_did_enter	Zero until most of startup is done.  It is set to one just
+		before |VimEnter| autocommands are triggered.
+
 					*v:warningmsg* *warningmsg-variable*
 v:warningmsg	Last given warning message.  It's allowed to set this variable.
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -384,6 +384,7 @@ static struct vimvar {
   VV(VV_NULL,           "null",             VAR_SPECIAL, VV_RO),
   VV(VV__NULL_LIST,     "_null_list",       VAR_LIST, VV_RO),
   VV(VV__NULL_DICT,     "_null_dict",       VAR_DICT, VV_RO),
+  VV(VV_VIM_DID_ENTER,  "vim_did_enter",    VAR_NUMBER, VV_RO),
 };
 #undef VV
 

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -124,6 +124,7 @@ typedef enum {
     VV_NULL,
     VV__NULL_LIST,  // List with NULL value. For test purposes only.
     VV__NULL_DICT,  // Dictionary with NULL value. For test purposes only.
+    VV_VIM_DID_ENTER,
 } VimVarIndex;
 
 /// All recognized msgpack types

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -512,7 +512,7 @@ int main(int argc, char **argv)
     need_start_insertmode = TRUE;
 
   set_vim_var_nr(VV_VIM_DID_ENTER, 1L);
-  apply_autocmds(EVENT_VIMENTER, NULL, NULL, FALSE, curbuf);
+  apply_autocmds(EVENT_VIMENTER, NULL, NULL, false, curbuf);
   TIME_MSG("VimEnter autocommands");
 
   /* When a startup script or session file setup for diff'ing and

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -511,6 +511,7 @@ int main(int argc, char **argv)
   if (p_im)
     need_start_insertmode = TRUE;
 
+  set_vim_var_nr(VV_VIM_DID_ENTER, 1L);
   apply_autocmds(EVENT_VIMENTER, NULL, NULL, FALSE, curbuf);
   TIME_MSG("VimEnter autocommands");
 

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -2,6 +2,7 @@
 " This makes testing go faster, since Vim doesn't need to restart.
 
 source test_assign.vim
+source test_autocmd.vim
 source test_cursor_func.vim
 source test_ex_undo.vim
 source test_expr.vim

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1,0 +1,8 @@
+" Tests for autocommands
+
+func Test_vim_did_enter()
+  call assert_false(v:vim_did_enter)
+
+  " This script will never reach the main loop, can't check if v:vim_did_enter
+  " becomes one.
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -786,7 +786,7 @@ static int included_patches[] = {
   // 1661 NA
   // 1660,
   // 1659 NA
-  // 1658,
+  1658,
   // 1657 NA
   // 1656,
   // 1655 NA

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 
 local clear = helpers.clear
 local command = helpers.command
+local eq = helpers.eq
 local eval = helpers.eval
 
 describe('autocmds:', function()
@@ -27,5 +28,9 @@ describe('autocmds:', function()
     command('autocmd WinLeave * :call add(g:foo, "WinLeave")')
     command('tabnew')
     assert.same(expected, eval('g:foo'))
+  end)
+
+  it('v:vim_did_enter is 1 after VimEnter', function()
+    eq(1, eval('v:vim_did_enter'))
   end)
 end)


### PR DESCRIPTION
#### vim-patch:7.4.1658

Problem:    A plugin does not know when VimEnter autocommands were already
            triggered.
Solution:   Add the v:vim_did_enter variable.

https://github.com/vim/vim/commit/1473551a4457d4920b235eeeb9f279e196ee7225