### PR TITLE
[RFC] vim-patch:8.0.0056,8.0.0057

### DIFF
--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -38,3 +38,53 @@ function! Test_path_keep_commas()
 
   set path&
 endfunction
+
+func Test_filetype_valid()
+  set ft=valid_name
+  call assert_equal("valid_name", &filetype)
+  set ft=valid-name
+  call assert_equal("valid-name", &filetype)
+
+  call assert_fails(":set ft=wrong;name", "E474:")
+  call assert_fails(":set ft=wrong\\\\name", "E474:")
+  call assert_fails(":set ft=wrong\\|name", "E474:")
+  call assert_fails(":set ft=wrong/name", "E474:")
+  call assert_fails(":set ft=wrong\\\nname", "E474:")
+  call assert_equal("valid-name", &filetype)
+
+  exe "set ft=trunc\x00name"
+  call assert_equal("trunc", &filetype)
+endfunc
+
+func Test_syntax_valid()
+  set syn=valid_name
+  call assert_equal("valid_name", &syntax)
+  set syn=valid-name
+  call assert_equal("valid-name", &syntax)
+
+  call assert_fails(":set syn=wrong;name", "E474:")
+  call assert_fails(":set syn=wrong\\\\name", "E474:")
+  call assert_fails(":set syn=wrong\\|name", "E474:")
+  call assert_fails(":set syn=wrong/name", "E474:")
+  call assert_fails(":set syn=wrong\\\nname", "E474:")
+  call assert_equal("valid-name", &syntax)
+
+  exe "set syn=trunc\x00name"
+  call assert_equal("trunc", &syntax)
+endfunc
+
+func Test_keymap_valid()
+  call assert_fails(":set kmp=valid_name", "E544:")
+  call assert_fails(":set kmp=valid_name", "valid_name")
+  call assert_fails(":set kmp=valid-name", "E544:")
+  call assert_fails(":set kmp=valid-name", "valid-name")
+
+  call assert_fails(":set kmp=wrong;name", "E474:")
+  call assert_fails(":set kmp=wrong\\\\name", "E474:")
+  call assert_fails(":set kmp=wrong\\|name", "E474:")
+  call assert_fails(":set kmp=wrong/name", "E474:")
+  call assert_fails(":set kmp=wrong\\\nname", "E474:")
+
+  call assert_fails(":set kmp=trunc\x00name", "E544:")
+  call assert_fails(":set kmp=trunc\x00name", "trunc")
+endfunc

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -40,6 +40,9 @@ function! Test_path_keep_commas()
 endfunction
 
 func Test_filetype_valid()
+  if !has('autocmd')
+    return
+  endif
   set ft=valid_name
   call assert_equal("valid_name", &filetype)
   set ft=valid-name
@@ -57,6 +60,9 @@ func Test_filetype_valid()
 endfunc
 
 func Test_syntax_valid()
+  if !has('syntax')
+    return
+  endif
   set syn=valid_name
   call assert_equal("valid_name", &syntax)
   set syn=valid-name
@@ -74,6 +80,9 @@ func Test_syntax_valid()
 endfunc
 
 func Test_keymap_valid()
+  if !has('keymap')
+    return
+  endif
   call assert_fails(":set kmp=valid_name", "E544:")
   call assert_fails(":set kmp=valid_name", "valid_name")
   call assert_fails(":set kmp=valid-name", "E544:")


### PR DESCRIPTION
#### vim-patch:8.0.0056

Problem:    When setting 'filetype' there is no check for a valid name.
Solution:   Only allow valid characters in 'filetype', 'syntax' and 'keymap'.

https://github.com/vim/vim/commit/d0b5138ba4bccff8a744c99836041ef6322ed39a


#### vim-patch:8.0.0057

Problem:    Tests fail without the 'keymap' features.
Solution:   Check for feature in test.

https://github.com/vim/vim/commit/9376f5f482a4d579436bf364778c2d8ab8e2f22d