### PR TITLE
[RFC] vim-patch:7.4.1660

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10658,7 +10658,7 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   if (!n) {
     if (STRNICMP(name, "patch", 5) == 0) {
       if (name[5] == '-'
-          && strlen(name) > 11
+          && strlen(name) >= 11
           && ascii_isdigit(name[6])
           && ascii_isdigit(name[8])
           && ascii_isdigit(name[10])) {

--- a/src/nvim/testdir/test_expr.vim
+++ b/src/nvim/testdir/test_expr.vim
@@ -1,5 +1,20 @@
 " Tests for expressions.
 
+func Test_version()
+  call assert_true(has('patch-7.4.001'))
+  call assert_true(has('patch-7.4.01'))
+  call assert_true(has('patch-7.4.1'))
+  call assert_true(has('patch-6.9.999'))
+  call assert_true(has('patch-7.1.999'))
+  call assert_true(has('patch-7.4.123'))
+
+  call assert_false(has('patch-7'))
+  call assert_false(has('patch-7.4'))
+  call assert_false(has('patch-7.4.'))
+  call assert_false(has('patch-9.1.0'))
+  call assert_false(has('patch-9.9.1'))
+endfunc
+
 func Test_strgetchar()
   call assert_equal(char2nr('a'), strgetchar('axb', 0))
   call assert_equal(char2nr('x'), strgetchar('axb', 1))

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -784,7 +784,7 @@ static int included_patches[] = {
   1663,
   // 1662 NA
   // 1661 NA
-  // 1660,
+  1660,
   // 1659 NA
   1658,
   // 1657 NA

--- a/test/functional/legacy/060_exists_and_has_functions_spec.lua
+++ b/test/functional/legacy/060_exists_and_has_functions_spec.lua
@@ -638,15 +638,6 @@ describe('exists() and has() functions', function()
 
       call TestExists()
 
-      function TestHas()
-        redir >> test.out
-        for pl in ['6.9.999', '7.1.999', '7.4.123', '9.1.0', '9.9.1']
-          echo 'has patch ' . pl . ': ' . has('patch-' . pl)
-        endfor
-        redir END
-      endfunc
-      call TestHas()
-
       edit! test.out
       set ff=unix
     ]=])
@@ -858,12 +849,7 @@ describe('exists() and has() functions', function()
       OK
        g:footest#x = 1
          footest#F() 0
-      UndefFun() 0
-      has patch 6.9.999: 1
-      has patch 7.1.999: 1
-      has patch 7.4.123: 1
-      has patch 9.1.0: 0
-      has patch 9.9.1: 0]])
+      UndefFun() 0]])
 
   end)
 end)


### PR DESCRIPTION
Problem:    has('patch-7.4.1') doesn't work.
Solution:   Fix off-by-one error. (Thinca)

https://github.com/vim/vim/commit/819821c5a95fc60797ecbb5e5ca1302e397e3d9a