### PR TITLE
[RFC] vim-patch:7.4.1691

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -392,7 +392,9 @@ void syntax_start(win_T *wp, linenr_T lnum)
    * Also do this when a change was made, the current state may be invalid
    * then.
    */
-  if (syn_block != wp->w_s || changedtick != syn_buf->b_changedtick) {
+  if (syn_block != wp->w_s
+      || syn_buf != wp->w_buffer
+      || changedtick != syn_buf->b_changedtick) {
     invalidate_current_state();
     syn_buf = wp->w_buffer;
     syn_block = wp->w_s;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -753,7 +753,7 @@ static int included_patches[] = {
   // 1694 NA
   // 1693 NA
   // 1692,
-  // 1691,
+  1691,
   // 1690 NA
   // 1689 NA
   // 1688 NA


### PR DESCRIPTION
Problem:    When switching to a new buffer and an autocommand applies syntax
            highlighting an ml_get error may occur.
Solution:   Check "syn_buf" against the buffer in the window. (Alexander von
            Buddenbrock, closes vim/vim#676)

https://github.com/vim/vim/commit/b681be175b6991cdc2b8ddd49b0e97e3fe2b201e