### PR TITLE
vim-patch:7.4.1928

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -514,7 +514,7 @@ static int included_patches[] = {
   // 1931 NA
   // 1930 NA
   // 1929 NA
-  // 1928,
+  1928,
   // 1927 NA
   // 1926 NA
   // 1925 NA


### PR DESCRIPTION
Problem:    Overwriting pointer argument.
Solution:   Assign to what it points to. (Dominique Pelle)# Please enter the commit message for your changes. Lines starting

https://github.com/vim/vim/commit/76ae22fef3cb224ca7fbf97517f881e825d4d0c2

The typos corrected in the original vim patch are no long present
in the neovim code base and the pointer assignment was done correctly
in the porting of patch 1913 (where the changes were introduced).

Ref https://github.com/neovim/neovim/pull/5260