### PR TITLE
vim-patch:7.4.1923

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -32,6 +32,7 @@ SCRIPTS := \
 # Keep test_alot*.res as the last one, sort the others.
 NEW_TESTS = \
 	    test_cscope.res \
+		test_cmdline.res \
 	    test_hardcopy.res \
 	    test_help_tagjump.res \
 	    test_history.res \

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -8,7 +8,6 @@ source test_ex_undo.vim
 source test_expr.vim
 source test_expr_utf8.vim
 source test_feedkeys.vim
-source test_cmdline.vim
 source test_menu.vim
 source test_options.vim
 source test_popup.vim

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -519,7 +519,7 @@ static int included_patches[] = {
   // 1926 NA
   // 1925 NA
   // 1924 NA
-  // 1923,
+  1923,
   // 1922 NA
   // 1921 NA
   // 1920 NA


### PR DESCRIPTION
Problem:    Command line editing is not tested much.
Solution:   Add tests for expanding the file name and 'wildmenu'.

https://github.com/vim/vim/commit/ae3150ec8d9da4a244acffebea55416946ca23d3

The test_cmdline.vim tests were ported in 23f591dba078fee16a and thus
should have marked 1923 as applied. The test_cmdline.vim invocation
has been moved from test_alot.vim to src/nvim/testdir/Makefile to
better accord with the upstream code.