### PR TITLE
[RFC] Allow using :Man during startup

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -562,6 +562,7 @@ void eval_init(void)
   set_vim_var_list(VV_ERRORS, list_alloc());
   set_vim_var_nr(VV_SEARCHFORWARD, 1L);
   set_vim_var_nr(VV_HLSEARCH, 1L);
+  set_vim_var_nr(VV_COUNT1, 1);
 
   set_vim_var_special(VV_FALSE, kSpecialVarFalse);
   set_vim_var_special(VV_TRUE, kSpecialVarTrue);


### PR DESCRIPTION
The man plugin uses `v:count == v:count1` to detect if a count was explicitly
given. Unfortunately v:count1 does _not_ default to 1 but 0 during startup.

Since it's very unlikely that a count is given to :Man during startup, we skip
that part of the code.

Fixes https://github.com/neovim/neovim/issues/5655