### PR TITLE
[RFC] ui: add tests for ui_mode_change

### DIFF
--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -170,9 +170,9 @@ function Screen.new(width, height)
     update_menu = false,
     visual_bell = false,
     suspended = false,
+    mode = 'normal',
     _default_attr_ids = nil,
     _default_attr_ignore = nil,
-    _mode = 'normal',
     _mouse_enabled = true,
     _attrs = {},
     _cursor = {
@@ -375,7 +375,7 @@ end
 
 function Screen:_handle_mode_change(mode)
   assert(mode == 'insert' or mode == 'replace' or mode == 'normal')
-  self._mode = mode
+  self.mode = mode
 end
 
 function Screen:_handle_set_scroll_region(top, bot, left, right)
@@ -549,7 +549,7 @@ function Screen:print_snapshot(attrs, ignore)
   if attrs == nil then
     attrs = {}
     if self._default_attr_ids ~= nil then
-      for i, a in ipairs(self._default_attr_ids) do
+      for i, a in pairs(self._default_attr_ids) do
         attrs[i] = a
       end
     end

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -3,6 +3,7 @@ local Screen = require('test.functional.ui.screen')
 local spawn, set_session, clear = helpers.spawn, helpers.set_session, helpers.clear
 local feed, execute = helpers.feed, helpers.execute
 local insert = helpers.insert
+local eq = helpers.eq
 
 if helpers.pending_win32(pending) then return end
 
@@ -574,6 +575,72 @@ describe('Screen', function()
         resize      |
         :ls^         |
       ]])
+    end)
+  end)
+
+  describe('mode change', function()
+    before_each(function()
+      screen:try_resize(25, 5)
+    end)
+
+    it('works in normal mode', function()
+      screen:expect([[
+        ^                         |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
+                                 |
+      ]],nil,nil,function ()
+        eq("normal", screen.mode)
+      end)
+    end)
+
+    it('works in insert mode', function()
+      feed('i')
+      screen:expect([[
+        ^                         |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
+        {2:-- INSERT --}             |
+      ]],nil,nil,function ()
+        eq("insert", screen.mode)
+      end)
+
+      feed('word<esc>')
+      screen:expect([[
+        wor^d                     |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
+                                 |
+      ]], nil, nil, function ()
+        eq("normal", screen.mode)
+      end)
+    end)
+
+    it('works in replace mode', function()
+      feed('R')
+      screen:expect([[
+        ^                         |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
+        {2:-- REPLACE --}            |
+      ]], nil, nil, function ()
+        eq("replace", screen.mode)
+      end)
+
+      feed('word<esc>')
+      screen:expect([[
+        wor^d                     |
+        {0:~                        }|
+        {0:~                        }|
+        {0:~                        }|
+                                 |
+      ]], nil, nil, function ()
+        eq("normal", screen.mode)
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
While looking into #5661 I noticed there was no tests for the existing mode change events.

Also fix `snapshot_util()` to work even if `default_attr_ids` is not a
proper lua array.