### PR TITLE
[RDY] Return -1 from jobstart when cmd is non executable instead of exception

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11597,9 +11597,6 @@ static char **tv_to_argv(typval_T *cmd_tv, char **cmd)
   const char_u *exe = get_tv_string_chk(&argl->lv_first->li_tv);
   if (!exe || !os_can_exe(exe, NULL, true)) {
     // String is not executable
-    if (exe) {
-      EMSG2(e_jobexe, exe);
-    }
     return NULL;
   }
 
@@ -11635,6 +11632,7 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   char **argv = tv_to_argv(&argvars[0], NULL);
   if (!argv) {
+    rettv->vval.v_number = -1;  // Return -1 on non executable
     return;  // Did error message in tv_to_argv.
   }
 
@@ -16430,6 +16428,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   char *cmd;
   char **argv = tv_to_argv(&argvars[0], &cmd);
   if (!argv) {
+    rettv->vval.v_number = -1;  // Return -1 on non executable
     return;  // Did error message in tv_to_argv.
   }
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1125,7 +1125,6 @@ EXTERN char_u e_invcmd[] INIT(= N_("E476: Invalid command"));
 EXTERN char_u e_isadir2[] INIT(= N_("E17: \"%s\" is a directory"));
 EXTERN char_u e_invjob[] INIT(= N_("E900: Invalid job id"));
 EXTERN char_u e_jobtblfull[] INIT(= N_("E901: Job table is full"));
-EXTERN char_u e_jobexe[] INIT(= N_("E902: \"%s\" is not an executable"));
 EXTERN char_u e_jobspawn[] INIT(= N_(
       "E903: Process for command \"%s\" could not be spawned"));
 EXTERN char_u e_jobnotpty[] INIT(= N_("E904: Job is not connected to a pty"));

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -70,6 +70,11 @@ describe('jobs', function()
     ok(rv ~= nil)
   end)
 
+  it('returns -1 when target is not executable', function()
+    local rv = eval("jobstart(['./test/functional/fixtures/non_executable.txt'])")
+    eq(-1, rv)
+  end)
+
   it('invokes callbacks when the job writes and exits', function()
     nvim('command', "call jobstart(['echo'], g:job_opts)")
     eq({'notification', 'stdout', {0, {'', ''}}}, next_msg())

--- a/test/functional/fixtures/non_executable.txt
+++ b/test/functional/fixtures/non_executable.txt
@@ -1,0 +1,1 @@
+This file is not an executable


### PR DESCRIPTION
Addresses the issue here: https://github.com/neovim/neovim/issues/5465 and also specs the proper behavior.