### PR TITLE
[RFC] vim-patch:7.4.1723

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6888,16 +6888,17 @@ static void draw_tabline(void)
 
   /* Use the 'tabline' option if it's set. */
   if (*p_tal != NUL) {
-    int save_called_emsg = called_emsg;
+    int saved_did_emsg = did_emsg;
 
-    /* Check for an error.  If there is one we would loop in redrawing the
-     * screen.  Avoid that by making 'tabline' empty. */
-    called_emsg = FALSE;
-    win_redr_custom(NULL, FALSE);
-    if (called_emsg)
+    // Check for an error.  If there is one we would loop in redrawing the
+    // screen.  Avoid that by making 'tabline' empty.
+    did_emsg = false;
+    win_redr_custom(NULL, false);
+    if (did_emsg) {
       set_string_option_direct((char_u *)"tabline", -1,
-          (char_u *)"", OPT_FREE, SID_ERROR);
-    called_emsg |= save_called_emsg;
+                               (char_u *)"", OPT_FREE, SID_ERROR);
+    }
+    did_emsg |= saved_did_emsg;
   } else {
     FOR_ALL_TABS(tp) {
       ++tabcount;

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -13,6 +13,7 @@ source test_options.vim
 source test_popup.vim
 source test_regexp_utf8.vim
 source test_syn_attr.vim
+source test_tabline.vim
 source test_tabpage.vim
 source test_unlet.vim
 source test_matchadd_conceal_utf8.vim

--- a/src/nvim/testdir/test_tabline.vim
+++ b/src/nvim/testdir/test_tabline.vim
@@ -1,0 +1,43 @@
+function! TablineWithCaughtError()
+  let s:func_in_tabline_called = 1
+  try
+    call eval('unknown expression')
+  catch
+  endtry
+  return ''
+endfunction
+
+function! TablineWithError()
+  let s:func_in_tabline_called = 1
+  call eval('unknown expression')
+  return ''
+endfunction
+
+function! Test_caught_error_in_tabline()
+  let showtabline_save = &showtabline
+  set showtabline=2
+  let s:func_in_tabline_called = 0
+  let tabline = '%{TablineWithCaughtError()}'
+  let &tabline = tabline
+  redraw!
+  call assert_true(s:func_in_tabline_called)
+  call assert_equal(tabline, &tabline)
+  set tabline=
+  let &showtabline = showtabline_save
+endfunction
+
+function! Test_tabline_will_be_disabled_with_error()
+  let showtabline_save = &showtabline
+  set showtabline=2
+  let s:func_in_tabline_called = 0
+  let tabline = '%{TablineWithError()}'
+  try
+    let &tabline = tabline
+    redraw!
+  catch
+  endtry
+  call assert_true(s:func_in_tabline_called)
+  call assert_equal('', &tabline)
+  set tabline=
+  let &showtabline = showtabline_save
+endfunction

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -721,7 +721,7 @@ static int included_patches[] = {
   // 1726 NA
   // 1725 NA
   // 1724 NA
-  // 1723,
+  1723,
   // 1722 NA
   // 1721 NA
   // 1720,


### PR DESCRIPTION
Problem:    When using try/catch in 'tabline' it is still considered an
            error and the tabline will be disabled.
Solution:   Check did_emsg instead of called_emsg. (haya14busa, closes #746)

https://github.com/vim/vim/commit/f73d3bc253fa79ad220f52f04b93e782e95a9d43