### PR TITLE
msgpack_rpc: Allocate empty string in msgpack_rpc_to_object

### DIFF
--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -125,7 +125,7 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
         dest = conv(((String) { \
           .size = obj->via.attr.size, \
           .data = (obj->via.attr.ptr == NULL || obj->via.attr.size == 0 \
-                   ? NULL \
+                   ? xmemdupz("", 0) \
                    : xmemdupz(obj->via.attr.ptr, obj->via.attr.size)), \
         })); \
         break; \


### PR DESCRIPTION
STR_CASE previously used a NULL data pointer for the String object, but
this pushes the NULL checks to the rest of the code.  Instead,
allocating an empty string solves the same issue of there not being any
data but ensures that we're not passing NULL to functions that don't
expect it.

Closes #5627