### PR TITLE
Bump luarocks to v2.4.2

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -99,8 +99,8 @@ set(LUAJIT_SHA256 620fa4eb12375021bef6e4f237cbd2dd5d49e56beb414bee052c746beef180
 set(LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz)
 set(LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333)
 
-set(LUAROCKS_URL https://github.com/keplerproject/luarocks/archive/5d8a16526573b36d5b22aa74866120c998466697.tar.gz)
-set(LUAROCKS_SHA256 cae709111c5701235770047dfd7169f66b82ae1c7b9b79207f9df0afb722bfd9)
+set(LUAROCKS_URL https://github.com/luarocks/luarocks/archive/v2.4.0.tar.gz)
+set(LUAROCKS_SHA256 e71c4e97fb7f31ac89b9db482628dd974b321787d93bc442871157bd950581a0)
 
 set(UNIBILIUM_URL https://github.com/mauke/unibilium/archive/v1.2.0.tar.gz)
 set(UNIBILIUM_SHA256 623af1099515e673abfd3cae5f2fa808a09ca55dda1c65a7b5c9424eb304ead8)

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -79,7 +79,7 @@ elseif(MSVC OR MINGW)
     ${MINGW_FLAG}
     /LUAMOD ${DEPS_BIN_DIR}/lua)
 
-  set(LUAROCKS_BINARY ${DEPS_INSTALL_DIR}/2.2/luarocks.bat)
+  set(LUAROCKS_BINARY ${DEPS_INSTALL_DIR}/luarocks.bat)
 else()
   message(FATAL_ERROR "Trying to build luarocks in an unsupported system ${CMAKE_SYSTEM_NAME}/${CMAKE_C_COMPILER_ID}")
 endif()


### PR DESCRIPTION
Luarocks has introduced `unzip` absence detection mechanism (luarocks/luarocks@84b1b88) since v2.4.0.
This will be a help in case of missing `unzip`,  indicate "missing unzip" clearly instead of complicated and nonsense errors.