### PR TITLE
[RFC] vim-patch:7.4.1748,f9660b5

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3646,10 +3646,11 @@ nv_gd (
   size_t len;
   char_u *ptr;
   if ((len = find_ident_under_cursor(&ptr, FIND_IDENT)) == 0
-      || !find_decl(ptr, len, nchar == 'd', thisblock, SEARCH_START))
+      || !find_decl(ptr, len, nchar == 'd', thisblock, SEARCH_START)) {
     clearopbeep(oap);
-  else if ((fdo_flags & FDO_SEARCH) && KeyTyped && oap->op_type == OP_NOP)
+  } else if ((fdo_flags & FDO_SEARCH) && KeyTyped && oap->op_type == OP_NOP) {
     foldOpenCursor();
+  }
 }
 
 /*

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3646,7 +3646,7 @@ nv_gd (
   size_t len;
   char_u *ptr;
   if ((len = find_ident_under_cursor(&ptr, FIND_IDENT)) == 0
-      || !find_decl(ptr, len, nchar == 'd', thisblock, 0))
+      || !find_decl(ptr, len, nchar == 'd', thisblock, SEARCH_START))
     clearopbeep(oap);
   else if ((fdo_flags & FDO_SEARCH) && KeyTyped && oap->op_type == OP_NOP)
     foldOpenCursor();

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -8,6 +8,7 @@ source test_ex_undo.vim
 source test_expr.vim
 source test_expr_utf8.vim
 source test_feedkeys.vim
+source test_goto.vim
 source test_menu.vim
 source test_messages.vim
 source test_options.vim

--- a/src/nvim/testdir/test_goto.vim
+++ b/src/nvim/testdir/test_goto.vim
@@ -1,0 +1,10 @@
+" Test commands that jump somewhere.
+
+func Test_geedee()
+  new
+  call setline(1, ["Filename x;", "", "int Filename", "int func() {", "Filename y;"])
+  /y;/
+  normal gD
+  call assert_equal(1, line('.'))
+  quit!
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -696,7 +696,7 @@ static int included_patches[] = {
   // 1751,
   // 1750 NA
   // 1749 NA
-  // 1748,
+  1748,
   // 1747 NA
   // 1746 NA
   // 1745 NA


### PR DESCRIPTION
#### vim-patch:7.4.1748

Problem:    "gD" does not find match in first column of first line. (Gary
            Johnson)
Solution:   Accept match at the cursor.

https://github.com/vim/vim/commit/1538fc34fae3fae39773ca43f6ff52401fce61d8


#### vim-patch:f9660b5

Add missing test file.

https://github.com/vim/vim/commit/f9660b59b2bdaa3ec2e7b31ab52186ad8b99f047