### PR TITLE
[RFC] clipboard: set v:register after startup

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -513,6 +513,12 @@ int main(int argc, char **argv)
   apply_autocmds(EVENT_VIMENTER, NULL, NULL, false, curbuf);
   TIME_MSG("VimEnter autocommands");
 
+  // Adjust default register name for "unnamed" in 'clipboard'. Can only be
+  // done after the clipboard is available and all initial commands that may
+  // modify the 'clipboard' setting have run; i.e. just before entering the
+  // main loop.
+  set_reg_var(get_default_register_name());
+
   /* When a startup script or session file setup for diff'ing and
    * scrollbind, sync the scrollbind now. */
   if (curwin->w_p_diff && curwin->w_p_scb) {

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -89,9 +89,12 @@ describe('the unnamed register', function()
 end)
 
 describe('clipboard usage', function()
+  local function reset(...)
+    clear('--cmd', 'let &rtp = "test/functional/fixtures,".&rtp', ...)
+  end
+
   before_each(function()
-    clear()
-    execute('let &rtp = "test/functional/fixtures,".&rtp')
+    reset()
     execute('call getreg("*")') -- force load of provider
   end)
 
@@ -361,6 +364,13 @@ describe('clipboard usage', function()
       feed('<esc>')
       eq('---', eval('getreg("+")'))
     end)
+  end)
+
+  it('sets v:register after startup', function()
+    reset()
+    eq('"', eval('v:register'))
+    reset('--cmd', 'set clipboard=unnamed')
+    eq('*', eval('v:register'))
   end)
 
   it('supports :put', function()


### PR DESCRIPTION
Fixes #5697.

Location is the same as in vim, so behavior with regards to VimEnter etc should be the same. 