### PR TITLE
Immigrate Lua's download URL

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -96,8 +96,8 @@ set(MSGPACK_SHA256 afda64ca445203bb7092372b822bae8b2539fdcebbfc3f753f393628c2bcf
 set(LUAJIT_URL https://github.com/neovim/deps/raw/master/opt/LuaJIT-2.0.4.tar.gz)
 set(LUAJIT_SHA256 620fa4eb12375021bef6e4f237cbd2dd5d49e56beb414bee052c746beef1807d)
 
-set(LUA_URL https://github.com/lua/lua/archive/5.1.5.tar.gz)
-set(LUA_SHA256 1cd642c4c39778306a14e62ccddace5c7a4fb2257b0b06f43bc81cf305c7415f)
+set(LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz)
+set(LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333)
 
 set(LUAROCKS_URL https://github.com/keplerproject/luarocks/archive/5d8a16526573b36d5b22aa74866120c998466697.tar.gz)
 set(LUAROCKS_SHA256 cae709111c5701235770047dfd7169f66b82ae1c7b9b79207f9df0afb722bfd9)


### PR DESCRIPTION
Lua's git repository in Github no longer has lua 5.1.5 as release.
Since this project needs lua 5.1.5 specifically, I replaced download URL with lua's official URL.
Thanks to @jamessan on #5714.