### PR TITLE
ftplugin/man: Finish early if &filetype is not man

### DIFF
--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -1,7 +1,7 @@
 " Maintainer:          Anmol Sethi <anmol@aubble.com>
 " Previous Maintainer: SungHyun Nam <goweol@gmail.com>
 
-if exists('b:did_ftplugin')
+if exists('b:did_ftplugin') || &filetype !=# 'man'
   finish
 endif
 let b:did_ftplugin = 1


### PR DESCRIPTION
Many people have `runtime ftplugin/man.vim` in their init file, as was
required in Vim to have the `:Man` command generally available.
7a4d069b removed the &filetype check, which caused these setups to
always create a blank `man://` buffer.

Cc @nhooyr