### PR TITLE
[RFC] ex_docmd.c: Save and restore winmin height/width

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8761,7 +8761,8 @@ makeopens (
      * Do this before restoring the view, so that the topline and the
      * cursor can be set.  This is done again below.
      */
-    if (put_line(fd, "set winheight=1 winwidth=1") == FAIL)
+    if (put_line(fd, "set winminheight=1 winminwidth=1 winheight=1 winwidth=1")
+        == FAIL)
       return FAIL;
     if (nr > 1 && ses_winsizes(fd, restore_size, tab_firstwin) == FAIL)
       return FAIL;
@@ -8829,8 +8830,15 @@ makeopens (
     return FAIL;
 
   /* Re-apply 'winheight', 'winwidth' and 'shortmess'. */
-  if (fprintf(fd, "set winheight=%" PRId64 " winwidth=%" PRId64 " shortmess=%s",
-          (int64_t)p_wh, (int64_t)p_wiw, p_shm) < 0
+  if (fprintf(fd, "set winheight=%" PRId64 " winwidth=%" PRId64
+                    " winminheight=%" PRId64 " winminwidth=%" PRId64
+                    " shortmess=%s",
+              (int64_t)p_wh,
+              (int64_t)p_wiw,
+              (int64_t)p_wmh,
+              (int64_t)p_wmw,
+              p_shm
+      ) < 0
       || put_eol(fd) == FAIL)
     return FAIL;
 


### PR DESCRIPTION
Solve errors during session load when window minimum sizes are higher than `1`.

Vim temporarily sets `winheight`/`winwidth` to `1` while loading session. However, if user has his minimum window size set higher, he will get an error during loading.
This change temporarily sets `winminheight`/`winminwidth` as-well, and restores its original values (_in the right order_) when finishing session read.