### PR TITLE
[RFC] vim-patch:7.4.1708

### DIFF
--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -723,13 +723,70 @@ static void nfa_emit_equi_class(int c)
 
   if (enc_utf8 || STRCMP(p_enc, "latin1") == 0
       || STRCMP(p_enc, "iso-8859-15") == 0) {
+#define A_grave 0xc0
+#define A_acute 0xc1
+#define A_circumflex 0xc2
+#define A_virguilla 0xc3
+#define A_diaeresis 0xc4
+#define A_ring 0xc5
+#define C_cedilla 0xc7
+#define E_grave 0xc8
+#define E_acute 0xc9
+#define E_circumflex 0xca
+#define E_diaeresis 0xcb
+#define I_grave 0xcc
+#define I_acute 0xcd
+#define I_circumflex 0xce
+#define I_diaeresis 0xcf
+#define N_virguilla 0xd1
+#define O_grave 0xd2
+#define O_acute 0xd3
+#define O_circumflex 0xd4
+#define O_virguilla 0xd5
+#define O_diaeresis 0xd6
+#define O_slash 0xd8
+#define U_grave 0xd9
+#define U_acute 0xda
+#define U_circumflex 0xdb
+#define U_diaeresis 0xdc
+#define Y_acute 0xdd
+#define a_grave 0xe0
+#define a_acute 0xe1
+#define a_circumflex 0xe2
+#define a_virguilla 0xe3
+#define a_diaeresis 0xe4
+#define a_ring 0xe5
+#define c_cedilla 0xe7
+#define e_grave 0xe8
+#define e_acute 0xe9
+#define e_circumflex 0xea
+#define e_diaeresis 0xeb
+#define i_grave 0xec
+#define i_acute 0xed
+#define i_circumflex 0xee
+#define i_diaeresis 0xef
+#define n_virguilla 0xf1
+#define o_grave 0xf2
+#define o_acute 0xf3
+#define o_circumflex 0xf4
+#define o_virguilla 0xf5
+#define o_diaeresis 0xf6
+#define o_slash 0xf8
+#define u_grave 0xf9
+#define u_acute 0xfa
+#define u_circumflex 0xfb
+#define u_diaeresis 0xfc
+#define y_acute 0xfd
+#define y_diaeresis 0xff
     switch (c) {
-    case 'A': case 0300: case 0301: case 0302:
-    case 0303: case 0304: case 0305:
-      CASEMBC(0x100) CASEMBC(0x102) CASEMBC(0x104) CASEMBC(0x1cd)
-      CASEMBC(0x1de) CASEMBC(0x1e0) CASEMBC(0x1ea2)
-      EMIT2('A'); EMIT2(0300); EMIT2(0301); EMIT2(0302);
-      EMIT2(0303); EMIT2(0304); EMIT2(0305);
+    case 'A': case A_grave: case A_acute: case A_circumflex:
+              case A_virguilla: case A_diaeresis: case A_ring:
+              CASEMBC(0x100) CASEMBC(0x102) CASEMBC(0x104)
+              CASEMBC(0x1cd) CASEMBC(0x1de) CASEMBC(0x1e0)
+              CASEMBC(0x1ea2)
+      EMIT2('A'); EMIT2(A_grave); EMIT2(A_acute);
+      EMIT2(A_circumflex); EMIT2(A_virguilla);
+      EMIT2(A_diaeresis); EMIT2(A_ring);
       EMITMBC(0x100) EMITMBC(0x102) EMITMBC(0x104)
       EMITMBC(0x1cd) EMITMBC(0x1de) EMITMBC(0x1e0)
       EMITMBC(0x1ea2)
@@ -739,23 +796,24 @@ static void nfa_emit_equi_class(int c)
       EMIT2('B'); EMITMBC(0x1e02) EMITMBC(0x1e06)
       return;
 
-    case 'C': case 0307:
-      CASEMBC(0x106) CASEMBC(0x108) CASEMBC(0x10a) CASEMBC(0x10c)
-      EMIT2('C'); EMIT2(0307); EMITMBC(0x106) EMITMBC(0x108)
+    case 'C': case C_cedilla: CASEMBC(0x106) CASEMBC(0x108) CASEMBC(0x10a)
+              CASEMBC(0x10c)
+      EMIT2('C'); EMIT2(C_cedilla); EMITMBC(0x106) EMITMBC(0x108)
       EMITMBC(0x10a) EMITMBC(0x10c)
       return;
 
     case 'D': CASEMBC(0x10e) CASEMBC(0x110) CASEMBC(0x1e0a)
-      CASEMBC(0x1e0e) CASEMBC(0x1e10)
+              CASEMBC(0x1e0e) CASEMBC(0x1e10)
       EMIT2('D'); EMITMBC(0x10e) EMITMBC(0x110) EMITMBC(0x1e0a)
       EMITMBC(0x1e0e) EMITMBC(0x1e10)
       return;
 
-    case 'E': case 0310: case 0311: case 0312: case 0313:
-      CASEMBC(0x112) CASEMBC(0x114) CASEMBC(0x116) CASEMBC(0x118)
-      CASEMBC(0x11a) CASEMBC(0x1eba) CASEMBC(0x1ebc)
-      EMIT2('E'); EMIT2(0310); EMIT2(0311); EMIT2(0312);
-      EMIT2(0313);
+    case 'E': case E_grave: case E_acute: case E_circumflex:
+              case E_diaeresis: CASEMBC(0x112) CASEMBC(0x114)
+              CASEMBC(0x116) CASEMBC(0x118) CASEMBC(0x11a)
+              CASEMBC(0x1eba) CASEMBC(0x1ebc)
+      EMIT2('E'); EMIT2(E_grave); EMIT2(E_acute);
+      EMIT2(E_circumflex); EMIT2(E_diaeresis);
       EMITMBC(0x112) EMITMBC(0x114) EMITMBC(0x116)
       EMITMBC(0x118) EMITMBC(0x11a) EMITMBC(0x1eba)
       EMITMBC(0x1ebc)
@@ -766,24 +824,26 @@ static void nfa_emit_equi_class(int c)
       return;
 
     case 'G': CASEMBC(0x11c) CASEMBC(0x11e) CASEMBC(0x120)
-      CASEMBC(0x122) CASEMBC(0x1e4) CASEMBC(0x1e6) CASEMBC(0x1f4)
-      CASEMBC(0x1e20)
+              CASEMBC(0x122) CASEMBC(0x1e4) CASEMBC(0x1e6)
+              CASEMBC(0x1f4) CASEMBC(0x1e20)
       EMIT2('G'); EMITMBC(0x11c) EMITMBC(0x11e) EMITMBC(0x120)
       EMITMBC(0x122) EMITMBC(0x1e4) EMITMBC(0x1e6)
       EMITMBC(0x1f4) EMITMBC(0x1e20)
       return;
 
     case 'H': CASEMBC(0x124) CASEMBC(0x126) CASEMBC(0x1e22)
-      CASEMBC(0x1e26) CASEMBC(0x1e28)
+              CASEMBC(0x1e26) CASEMBC(0x1e28)
       EMIT2('H'); EMITMBC(0x124) EMITMBC(0x126) EMITMBC(0x1e22)
       EMITMBC(0x1e26) EMITMBC(0x1e28)
       return;
 
-    case 'I': case 0314: case 0315: case 0316: case 0317:
-      CASEMBC(0x128) CASEMBC(0x12a) CASEMBC(0x12c) CASEMBC(0x12e)
-      CASEMBC(0x130) CASEMBC(0x1cf) CASEMBC(0x1ec8)
-      EMIT2('I'); EMIT2(0314); EMIT2(0315); EMIT2(0316);
-      EMIT2(0317); EMITMBC(0x128) EMITMBC(0x12a)
+    case 'I': case I_grave: case I_acute: case I_circumflex:
+              case I_diaeresis: CASEMBC(0x128) CASEMBC(0x12a)
+              CASEMBC(0x12c) CASEMBC(0x12e) CASEMBC(0x130)
+              CASEMBC(0x1cf) CASEMBC(0x1ec8)
+      EMIT2('I'); EMIT2(I_grave); EMIT2(I_acute);
+      EMIT2(I_circumflex); EMIT2(I_diaeresis);
+      EMITMBC(0x128) EMITMBC(0x12a)
       EMITMBC(0x12c) EMITMBC(0x12e) EMITMBC(0x130)
       EMITMBC(0x1cf) EMITMBC(0x1ec8)
       return;
@@ -793,13 +853,13 @@ static void nfa_emit_equi_class(int c)
       return;
 
     case 'K': CASEMBC(0x136) CASEMBC(0x1e8) CASEMBC(0x1e30)
-      CASEMBC(0x1e34)
+              CASEMBC(0x1e34)
       EMIT2('K'); EMITMBC(0x136) EMITMBC(0x1e8) EMITMBC(0x1e30)
       EMITMBC(0x1e34)
       return;
 
     case 'L': CASEMBC(0x139) CASEMBC(0x13b) CASEMBC(0x13d)
-      CASEMBC(0x13f) CASEMBC(0x141) CASEMBC(0x1e3a)
+              CASEMBC(0x13f) CASEMBC(0x141) CASEMBC(0x1e3a)
       EMIT2('L'); EMITMBC(0x139) EMITMBC(0x13b) EMITMBC(0x13d)
       EMITMBC(0x13f) EMITMBC(0x141) EMITMBC(0x1e3a)
       return;
@@ -808,19 +868,21 @@ static void nfa_emit_equi_class(int c)
       EMIT2('M'); EMITMBC(0x1e3e) EMITMBC(0x1e40)
       return;
 
-    case 'N': case 0321:
-      CASEMBC(0x143) CASEMBC(0x145) CASEMBC(0x147) CASEMBC(0x1e44)
-      CASEMBC(0x1e48)
-      EMIT2('N'); EMIT2(0321); EMITMBC(0x143) EMITMBC(0x145)
+    case 'N': case N_virguilla: CASEMBC(0x143) CASEMBC(0x145)
+              CASEMBC(0x147) CASEMBC(0x1e44) CASEMBC(0x1e48)
+      EMIT2('N'); EMIT2(N_virguilla);
+      EMITMBC(0x143) EMITMBC(0x145)
       EMITMBC(0x147) EMITMBC(0x1e44) EMITMBC(0x1e48)
       return;
 
-    case 'O': case 0322: case 0323: case 0324: case 0325:
-    case 0326: case 0330:
-      CASEMBC(0x14c) CASEMBC(0x14e) CASEMBC(0x150) CASEMBC(0x1a0)
-      CASEMBC(0x1d1) CASEMBC(0x1ea) CASEMBC(0x1ec) CASEMBC(0x1ece)
-      EMIT2('O'); EMIT2(0322); EMIT2(0323); EMIT2(0324);
-      EMIT2(0325); EMIT2(0326); EMIT2(0330);
+    case 'O': case O_grave: case O_acute: case O_circumflex:
+              case O_virguilla: case O_diaeresis: case O_slash:
+              CASEMBC(0x14c) CASEMBC(0x14e) CASEMBC(0x150)
+              CASEMBC(0x1a0) CASEMBC(0x1d1) CASEMBC(0x1ea)
+              CASEMBC(0x1ec) CASEMBC(0x1ece)
+      EMIT2('O'); EMIT2(O_grave); EMIT2(O_acute);
+      EMIT2(O_circumflex); EMIT2(O_virguilla);
+      EMIT2(O_diaeresis); EMIT2(O_slash);
       EMITMBC(0x14c) EMITMBC(0x14e) EMITMBC(0x150)
       EMITMBC(0x1a0) EMITMBC(0x1d1) EMITMBC(0x1ea)
       EMITMBC(0x1ec) EMITMBC(0x1ece)
@@ -831,29 +893,31 @@ static void nfa_emit_equi_class(int c)
       return;
 
     case 'R': CASEMBC(0x154) CASEMBC(0x156) CASEMBC(0x158)
-      CASEMBC(0x1e58) CASEMBC(0x1e5e)
+              CASEMBC(0x1e58) CASEMBC(0x1e5e)
       EMIT2('R'); EMITMBC(0x154) EMITMBC(0x156) EMITMBC(0x158)
       EMITMBC(0x1e58) EMITMBC(0x1e5e)
       return;
 
     case 'S': CASEMBC(0x15a) CASEMBC(0x15c) CASEMBC(0x15e)
-      CASEMBC(0x160) CASEMBC(0x1e60)
+              CASEMBC(0x160) CASEMBC(0x1e60)
       EMIT2('S'); EMITMBC(0x15a) EMITMBC(0x15c) EMITMBC(0x15e)
       EMITMBC(0x160) EMITMBC(0x1e60)
       return;
 
     case 'T': CASEMBC(0x162) CASEMBC(0x164) CASEMBC(0x166)
-      CASEMBC(0x1e6a) CASEMBC(0x1e6e)
+              CASEMBC(0x1e6a) CASEMBC(0x1e6e)
       EMIT2('T'); EMITMBC(0x162) EMITMBC(0x164) EMITMBC(0x166)
       EMITMBC(0x1e6a) EMITMBC(0x1e6e)
       return;
 
-    case 'U': case 0331: case 0332: case 0333: case 0334:
-      CASEMBC(0x168) CASEMBC(0x16a) CASEMBC(0x16c) CASEMBC(0x16e)
-      CASEMBC(0x170) CASEMBC(0x172) CASEMBC(0x1af) CASEMBC(0x1d3)
-      CASEMBC(0x1ee6)
-      EMIT2('U'); EMIT2(0331); EMIT2(0332); EMIT2(0333);
-      EMIT2(0334); EMITMBC(0x168) EMITMBC(0x16a)
+    case 'U': case U_grave: case U_acute: case U_diaeresis:
+              case U_circumflex: CASEMBC(0x168) CASEMBC(0x16a)
+              CASEMBC(0x16c) CASEMBC(0x16e) CASEMBC(0x170)
+              CASEMBC(0x172) CASEMBC(0x1af) CASEMBC(0x1d3)
+              CASEMBC(0x1ee6)
+      EMIT2('U'); EMIT2(U_grave); EMIT2(U_acute);
+      EMIT2(U_diaeresis); EMIT2(U_circumflex);
+      EMITMBC(0x168) EMITMBC(0x16a)
       EMITMBC(0x16c) EMITMBC(0x16e) EMITMBC(0x170)
       EMITMBC(0x172) EMITMBC(0x1af) EMITMBC(0x1d3)
       EMITMBC(0x1ee6)
@@ -864,7 +928,7 @@ static void nfa_emit_equi_class(int c)
       return;
 
     case 'W': CASEMBC(0x174) CASEMBC(0x1e80) CASEMBC(0x1e82)
-      CASEMBC(0x1e84) CASEMBC(0x1e86)
+              CASEMBC(0x1e84) CASEMBC(0x1e86)
       EMIT2('W'); EMITMBC(0x174) EMITMBC(0x1e80) EMITMBC(0x1e82)
       EMITMBC(0x1e84) EMITMBC(0x1e86)
       return;
@@ -873,26 +937,29 @@ static void nfa_emit_equi_class(int c)
       EMIT2('X'); EMITMBC(0x1e8a) EMITMBC(0x1e8c)
       return;
 
-    case 'Y': case 0335:
-      CASEMBC(0x176) CASEMBC(0x178) CASEMBC(0x1e8e) CASEMBC(0x1ef2)
-      CASEMBC(0x1ef6) CASEMBC(0x1ef8)
-      EMIT2('Y'); EMIT2(0335); EMITMBC(0x176) EMITMBC(0x178)
+    case 'Y': case Y_acute: CASEMBC(0x176) CASEMBC(0x178)
+              CASEMBC(0x1e8e) CASEMBC(0x1ef2) CASEMBC(0x1ef6)
+              CASEMBC(0x1ef8)
+      EMIT2('Y'); EMIT2(Y_acute);
+      EMITMBC(0x176) EMITMBC(0x178)
       EMITMBC(0x1e8e) EMITMBC(0x1ef2) EMITMBC(0x1ef6)
       EMITMBC(0x1ef8)
       return;
 
     case 'Z': CASEMBC(0x179) CASEMBC(0x17b) CASEMBC(0x17d)
-      CASEMBC(0x1b5) CASEMBC(0x1e90) CASEMBC(0x1e94)
+              CASEMBC(0x1b5) CASEMBC(0x1e90) CASEMBC(0x1e94)
       EMIT2('Z'); EMITMBC(0x179) EMITMBC(0x17b) EMITMBC(0x17d)
       EMITMBC(0x1b5) EMITMBC(0x1e90) EMITMBC(0x1e94)
       return;
 
-    case 'a': case 0340: case 0341: case 0342:
-    case 0343: case 0344: case 0345:
-      CASEMBC(0x101) CASEMBC(0x103) CASEMBC(0x105) CASEMBC(0x1ce)
-      CASEMBC(0x1df) CASEMBC(0x1e1) CASEMBC(0x1ea3)
-      EMIT2('a'); EMIT2(0340); EMIT2(0341); EMIT2(0342);
-      EMIT2(0343); EMIT2(0344); EMIT2(0345);
+    case 'a': case a_grave: case a_acute: case a_circumflex:
+              case a_virguilla: case a_diaeresis: case a_ring:
+              CASEMBC(0x101) CASEMBC(0x103) CASEMBC(0x105)
+              CASEMBC(0x1ce) CASEMBC(0x1df) CASEMBC(0x1e1)
+              CASEMBC(0x1ea3)
+      EMIT2('a'); EMIT2(a_grave); EMIT2(a_acute);
+      EMIT2(a_circumflex); EMIT2(a_virguilla);
+      EMIT2(a_diaeresis); EMIT2(a_ring);
       EMITMBC(0x101) EMITMBC(0x103) EMITMBC(0x105)
       EMITMBC(0x1ce) EMITMBC(0x1df) EMITMBC(0x1e1)
       EMITMBC(0x1ea3)
@@ -902,23 +969,26 @@ static void nfa_emit_equi_class(int c)
       EMIT2('b'); EMITMBC(0x1e03) EMITMBC(0x1e07)
       return;
 
-    case 'c': case 0347:
-      CASEMBC(0x107) CASEMBC(0x109) CASEMBC(0x10b) CASEMBC(0x10d)
-      EMIT2('c'); EMIT2(0347); EMITMBC(0x107) EMITMBC(0x109)
+    case 'c': case c_cedilla: CASEMBC(0x107) CASEMBC(0x109)
+              CASEMBC(0x10b) CASEMBC(0x10d)
+      EMIT2('c'); EMIT2(c_cedilla);
+      EMITMBC(0x107) EMITMBC(0x109)
       EMITMBC(0x10b) EMITMBC(0x10d)
       return;
 
     case 'd': CASEMBC(0x10f) CASEMBC(0x111) CASEMBC(0x1e0b)
-      CASEMBC(0x1e0f) CASEMBC(0x1e11)
+              CASEMBC(0x1e0f) CASEMBC(0x1e11)
       EMIT2('d'); EMITMBC(0x10f) EMITMBC(0x111) EMITMBC(0x1e0b)
       EMITMBC(0x1e0f) EMITMBC(0x1e11)
       return;
 
-    case 'e': case 0350: case 0351: case 0352: case 0353:
-      CASEMBC(0x113) CASEMBC(0x115) CASEMBC(0x117) CASEMBC(0x119)
-      CASEMBC(0x11b) CASEMBC(0x1ebb) CASEMBC(0x1ebd)
-      EMIT2('e'); EMIT2(0350); EMIT2(0351); EMIT2(0352);
-      EMIT2(0353); EMITMBC(0x113) EMITMBC(0x115)
+    case 'e': case e_grave: case e_acute: case e_circumflex:
+              case e_diaeresis: CASEMBC(0x113) CASEMBC(0x115)
+              CASEMBC(0x117) CASEMBC(0x119) CASEMBC(0x11b)
+              CASEMBC(0x1ebb) CASEMBC(0x1ebd)
+      EMIT2('e'); EMIT2(e_grave); EMIT2(e_acute);
+      EMIT2(e_circumflex); EMIT2(e_diaeresis);
+      EMITMBC(0x113) EMITMBC(0x115)
       EMITMBC(0x117) EMITMBC(0x119) EMITMBC(0x11b)
       EMITMBC(0x1ebb) EMITMBC(0x1ebd)
       return;
@@ -928,24 +998,26 @@ static void nfa_emit_equi_class(int c)
       return;
 
     case 'g': CASEMBC(0x11d) CASEMBC(0x11f) CASEMBC(0x121)
-      CASEMBC(0x123) CASEMBC(0x1e5) CASEMBC(0x1e7) CASEMBC(0x1f5)
-      CASEMBC(0x1e21)
+              CASEMBC(0x123) CASEMBC(0x1e5) CASEMBC(0x1e7)
+              CASEMBC(0x1f5) CASEMBC(0x1e21)
       EMIT2('g'); EMITMBC(0x11d) EMITMBC(0x11f) EMITMBC(0x121)
       EMITMBC(0x123) EMITMBC(0x1e5) EMITMBC(0x1e7)
       EMITMBC(0x1f5) EMITMBC(0x1e21)
       return;
 
     case 'h': CASEMBC(0x125) CASEMBC(0x127) CASEMBC(0x1e23)
-      CASEMBC(0x1e27) CASEMBC(0x1e29) CASEMBC(0x1e96)
+              CASEMBC(0x1e27) CASEMBC(0x1e29) CASEMBC(0x1e96)
       EMIT2('h'); EMITMBC(0x125) EMITMBC(0x127) EMITMBC(0x1e23)
       EMITMBC(0x1e27) EMITMBC(0x1e29) EMITMBC(0x1e96)
       return;
 
-    case 'i': case 0354: case 0355: case 0356: case 0357:
-      CASEMBC(0x129) CASEMBC(0x12b) CASEMBC(0x12d) CASEMBC(0x12f)
-      CASEMBC(0x1d0) CASEMBC(0x1ec9)
-      EMIT2('i'); EMIT2(0354); EMIT2(0355); EMIT2(0356);
-      EMIT2(0357); EMITMBC(0x129) EMITMBC(0x12b)
+    case 'i': case i_grave: case i_acute: case i_circumflex:
+              case i_diaeresis: CASEMBC(0x129) CASEMBC(0x12b)
+              CASEMBC(0x12d) CASEMBC(0x12f) CASEMBC(0x1d0)
+              CASEMBC(0x1ec9)
+      EMIT2('i'); EMIT2(i_grave); EMIT2(i_acute);
+      EMIT2(i_circumflex); EMIT2(i_diaeresis);
+      EMITMBC(0x129) EMITMBC(0x12b)
       EMITMBC(0x12d) EMITMBC(0x12f) EMITMBC(0x1d0)
       EMITMBC(0x1ec9)
       return;
@@ -955,13 +1027,13 @@ static void nfa_emit_equi_class(int c)
       return;
 
     case 'k': CASEMBC(0x137) CASEMBC(0x1e9) CASEMBC(0x1e31)
-      CASEMBC(0x1e35)
+              CASEMBC(0x1e35)
       EMIT2('k'); EMITMBC(0x137) EMITMBC(0x1e9) EMITMBC(0x1e31)
       EMITMBC(0x1e35)
       return;
 
     case 'l': CASEMBC(0x13a) CASEMBC(0x13c) CASEMBC(0x13e)
-      CASEMBC(0x140) CASEMBC(0x142) CASEMBC(0x1e3b)
+              CASEMBC(0x140) CASEMBC(0x142) CASEMBC(0x1e3b)
       EMIT2('l'); EMITMBC(0x13a) EMITMBC(0x13c) EMITMBC(0x13e)
       EMITMBC(0x140) EMITMBC(0x142) EMITMBC(0x1e3b)
       return;
@@ -970,20 +1042,23 @@ static void nfa_emit_equi_class(int c)
       EMIT2('m'); EMITMBC(0x1e3f) EMITMBC(0x1e41)
       return;
 
-    case 'n': case 0361:
-      CASEMBC(0x144) CASEMBC(0x146) CASEMBC(0x148) CASEMBC(0x149)
-      CASEMBC(0x1e45) CASEMBC(0x1e49)
-      EMIT2('n'); EMIT2(0361); EMITMBC(0x144) EMITMBC(0x146)
+    case 'n': case n_virguilla: CASEMBC(0x144) CASEMBC(0x146)
+              CASEMBC(0x148) CASEMBC(0x149) CASEMBC(0x1e45)
+              CASEMBC(0x1e49)
+      EMIT2('n'); EMIT2(n_virguilla);
+      EMITMBC(0x144) EMITMBC(0x146)
       EMITMBC(0x148) EMITMBC(0x149) EMITMBC(0x1e45)
       EMITMBC(0x1e49)
       return;
 
-    case 'o': case 0362: case 0363: case 0364: case 0365:
-    case 0366: case 0370:
-      CASEMBC(0x14d) CASEMBC(0x14f) CASEMBC(0x151) CASEMBC(0x1a1)
-      CASEMBC(0x1d2) CASEMBC(0x1eb) CASEMBC(0x1ed) CASEMBC(0x1ecf)
-      EMIT2('o'); EMIT2(0362); EMIT2(0363); EMIT2(0364);
-      EMIT2(0365); EMIT2(0366); EMIT2(0370);
+    case 'o': case o_grave: case o_acute: case o_circumflex:
+              case o_virguilla: case o_diaeresis: case o_slash:
+              CASEMBC(0x14d) CASEMBC(0x14f) CASEMBC(0x151)
+              CASEMBC(0x1a1) CASEMBC(0x1d2) CASEMBC(0x1eb)
+              CASEMBC(0x1ed) CASEMBC(0x1ecf)
+      EMIT2('o'); EMIT2(o_grave); EMIT2(o_acute);
+      EMIT2(o_circumflex); EMIT2(o_virguilla);
+      EMIT2(o_diaeresis); EMIT2(o_slash);
       EMITMBC(0x14d) EMITMBC(0x14f) EMITMBC(0x151)
       EMITMBC(0x1a1) EMITMBC(0x1d2) EMITMBC(0x1eb)
       EMITMBC(0x1ed) EMITMBC(0x1ecf)
@@ -994,29 +1069,31 @@ static void nfa_emit_equi_class(int c)
       return;
 
     case 'r': CASEMBC(0x155) CASEMBC(0x157) CASEMBC(0x159)
-      CASEMBC(0x1e59) CASEMBC(0x1e5f)
+              CASEMBC(0x1e59) CASEMBC(0x1e5f)
       EMIT2('r'); EMITMBC(0x155) EMITMBC(0x157) EMITMBC(0x159)
       EMITMBC(0x1e59) EMITMBC(0x1e5f)
       return;
 
     case 's': CASEMBC(0x15b) CASEMBC(0x15d) CASEMBC(0x15f)
-      CASEMBC(0x161) CASEMBC(0x1e61)
+              CASEMBC(0x161) CASEMBC(0x1e61)
       EMIT2('s'); EMITMBC(0x15b) EMITMBC(0x15d) EMITMBC(0x15f)
       EMITMBC(0x161) EMITMBC(0x1e61)
       return;
 
     case 't': CASEMBC(0x163) CASEMBC(0x165) CASEMBC(0x167)
-      CASEMBC(0x1e6b) CASEMBC(0x1e6f) CASEMBC(0x1e97)
+              CASEMBC(0x1e6b) CASEMBC(0x1e6f) CASEMBC(0x1e97)
       EMIT2('t'); EMITMBC(0x163) EMITMBC(0x165) EMITMBC(0x167)
       EMITMBC(0x1e6b) EMITMBC(0x1e6f) EMITMBC(0x1e97)
       return;
 
-    case 'u': case 0371: case 0372: case 0373: case 0374:
-      CASEMBC(0x169) CASEMBC(0x16b) CASEMBC(0x16d) CASEMBC(0x16f)
-      CASEMBC(0x171) CASEMBC(0x173) CASEMBC(0x1b0) CASEMBC(0x1d4)
-      CASEMBC(0x1ee7)
-      EMIT2('u'); EMIT2(0371); EMIT2(0372); EMIT2(0373);
-      EMIT2(0374); EMITMBC(0x169) EMITMBC(0x16b)
+    case 'u': case u_grave: case u_acute: case u_circumflex:
+              case u_diaeresis: CASEMBC(0x169) CASEMBC(0x16b)
+              CASEMBC(0x16d) CASEMBC(0x16f) CASEMBC(0x171)
+              CASEMBC(0x173) CASEMBC(0x1b0) CASEMBC(0x1d4)
+              CASEMBC(0x1ee7)
+      EMIT2('u'); EMIT2(u_grave); EMIT2(u_acute);
+      EMIT2(u_circumflex); EMIT2(u_diaeresis);
+      EMITMBC(0x169) EMITMBC(0x16b)
       EMITMBC(0x16d) EMITMBC(0x16f) EMITMBC(0x171)
       EMITMBC(0x173) EMITMBC(0x1b0) EMITMBC(0x1d4)
       EMITMBC(0x1ee7)
@@ -1027,7 +1104,7 @@ static void nfa_emit_equi_class(int c)
       return;
 
     case 'w': CASEMBC(0x175) CASEMBC(0x1e81) CASEMBC(0x1e83)
-      CASEMBC(0x1e85) CASEMBC(0x1e87) CASEMBC(0x1e98)
+              CASEMBC(0x1e85) CASEMBC(0x1e87) CASEMBC(0x1e98)
       EMIT2('w'); EMITMBC(0x175) EMITMBC(0x1e81) EMITMBC(0x1e83)
       EMITMBC(0x1e85) EMITMBC(0x1e87) EMITMBC(0x1e98)
       return;
@@ -1036,16 +1113,17 @@ static void nfa_emit_equi_class(int c)
       EMIT2('x'); EMITMBC(0x1e8b) EMITMBC(0x1e8d)
       return;
 
-    case 'y': case 0375: case 0377:
-      CASEMBC(0x177) CASEMBC(0x1e8f) CASEMBC(0x1e99)
-      CASEMBC(0x1ef3) CASEMBC(0x1ef7) CASEMBC(0x1ef9)
-      EMIT2('y'); EMIT2(0375); EMIT2(0377); EMITMBC(0x177)
+    case 'y': case y_acute: case y_diaeresis: CASEMBC(0x177)
+              CASEMBC(0x1e8f) CASEMBC(0x1e99) CASEMBC(0x1ef3)
+              CASEMBC(0x1ef7) CASEMBC(0x1ef9)
+      EMIT2('y'); EMIT2(y_acute); EMIT2(y_diaeresis);
+      EMITMBC(0x177)
       EMITMBC(0x1e8f) EMITMBC(0x1e99) EMITMBC(0x1ef3)
       EMITMBC(0x1ef7) EMITMBC(0x1ef9)
       return;
 
     case 'z': CASEMBC(0x17a) CASEMBC(0x17c) CASEMBC(0x17e)
-      CASEMBC(0x1b6) CASEMBC(0x1e91) CASEMBC(0x1e95)
+              CASEMBC(0x1b6) CASEMBC(0x1e91) CASEMBC(0x1e95)
       EMIT2('z'); EMITMBC(0x17a) EMITMBC(0x17c) EMITMBC(0x17e)
       EMITMBC(0x1b6) EMITMBC(0x1e91) EMITMBC(0x1e95)
       return;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -736,7 +736,7 @@ static int included_patches[] = {
   1711,
   // 1710 NA
   // 1709 NA
-  // 1708,
+  1708,
   1707,
   // 1706 NA
   // 1705 NA


### PR DESCRIPTION
#### vim-patch:7.4.1708

Problem:    New regexp engine does not work properly with EBCDIC.
Solution:   Define equivalence class characters. (Owen Leibman)

https://github.com/vim/vim/commit/2a6fa564a3b5061c14ff63b8b0f12801df0b0ac2

Although nvim doesn't support EBCDIC systems, this keeps us inline with
upstream code so its easier to merge future patches in this area and
improves the readability of the code.