### PR TITLE
[RFC] Remove g:python{,3}_host_skip_check

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -215,7 +215,6 @@ function! s:check_python(version) abort
   let pyenv_root = exists('$PYENV_ROOT') ? resolve($PYENV_ROOT) : 'n'
   let venv = exists('$VIRTUAL_ENV') ? resolve($VIRTUAL_ENV) : ''
   let host_prog_var = python_bin_name.'_host_prog'
-  let host_skip_var = python_bin_name.'_host_skip_check'
   let python_bin = ''
   let python_multiple = []
 
@@ -230,10 +229,6 @@ function! s:check_python(version) abort
     if !empty(pythonx_errs)
       call health#report_warn(pythonx_errs)
     endif
-    let old_skip = get(g:, host_skip_var, 0)
-    let g:[host_skip_var] = 1
-    let [python_bin_name, pythonx_errs] = provider#pythonx#Detect(a:version)
-    let g:[host_skip_var] = old_skip
   endif
 
   if !empty(python_bin_name)

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -48,11 +48,10 @@ Note: The `--upgrade` flag ensures you have the latest version even if
 
 PYTHON PROVIDER CONFIGURATION ~
 						*g:python_host_prog*
-Set `g:python_host_prog` to point Nvim to a specific Python 2 interpreter: >
-    let g:python_host_prog = '/path/to/python'
-<
 						*g:python3_host_prog*
-Set `g:python3_host_prog` to point Nvim to a specific Python 3 interpreter: >
+Set a specific Python interpreter. This also improves host loading time, since
+no suitable interpreter has to be searched first. >
+    let g:python_host_prog  = '/path/to/python'
     let g:python3_host_prog = '/path/to/python3'
 <
 						*g:loaded_python_provider*
@@ -62,16 +61,6 @@ To disable Python 2 support: >
 						*g:loaded_python3_provider*
 To disable Python 3 support: >
     let g:loaded_python3_provider = 1
-<
-						*g:python_host_skip_check*
-Set `g:python_host_skip_check` to disable the Python 2 interpreter check.
-Note: This requires you to install the python-neovim module properly. >
-    let g:python_host_skip_check = 1
-<
-						*g:python3_host_skip_check*
-Set `g:python3_host_skip_check` to disable the Python 3 interpreter check.
-Note: This requires you to install the python3-neovim module properly. >
-    let g:python3_host_skip_check = 1
 
 
 ==============================================================================

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -49,8 +49,7 @@ Note: The `--upgrade` flag ensures you have the latest version even if
 PYTHON PROVIDER CONFIGURATION ~
 						*g:python_host_prog*
 						*g:python3_host_prog*
-Set a specific Python interpreter. This also improves host loading time, since
-no suitable interpreter has to be searched first. >
+Program to use for evaluating Python code. Setting this makes startup faster. >
     let g:python_host_prog  = '/path/to/python'
     let g:python3_host_prog = '/path/to/python3'
 <


### PR DESCRIPTION
This option simplifies the configuration options:

1) `g:python{,3}_host_prog` is not set.

    Neovim tries its best to find a suitable interpreter. This means calling
    exepath(), potentially multiple times, and a system('python -c ...') with
    the first found interpreter, to get the Python version.

2) `g:python{,3}_host_prog` is set.

    Avoids everything of the above. No safety checks, no training wheels. Fast
    host startup time!

---

Ref: https://github.com/neovim/neovim/issues/5728