### PR TITLE
[RFC] Health: match syntax keyword case exactly

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -1,4 +1,6 @@
 function! s:enhance_syntax() abort
+  syntax case match
+
   syntax keyword healthError ERROR
   highlight link healthError Error
 


### PR DESCRIPTION
This prevents the string "error" within error messages to be highlighted as
healthError.

---

Examples:

```
$ git grep '\<error\>' runtime/autoload/provider
runtime/autoload/provider/clipboard.vim:    echo "clipboard: error: ".(len(out) ? out[0] : '')
runtime/autoload/provider/clipboard.vim:    echo "clipboard: error when invoking provider"
runtime/autoload/provider/pythonx.vim:    return [0, 'Checking ' . prog_path . ' caused an unknown error. '
```

Here we use the string "error" explicitly and of course each provider tool could output it as well.