### PR TITLE
[RFC] Health: rework syntax

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -2,29 +2,32 @@ function! s:enhance_syntax() abort
   syntax case match
 
   syntax keyword healthError ERROR
+        \ containedin=markdownCodeBlock,mkdListItemLine
   highlight link healthError Error
 
   syntax keyword healthWarning WARNING
+        \ containedin=markdownCodeBlock,mkdListItemLine
   highlight link healthWarning WarningMsg
 
   syntax keyword healthInfo INFO
+        \ containedin=markdownCodeBlock,mkdListItemLine
   highlight link healthInfo ModeMsg
 
   syntax keyword healthSuccess SUCCESS
+        \ containedin=markdownCodeBlock,mkdListItemLine
   highlight link healthSuccess ModeMsg
 
   syntax keyword healthSuggestion SUGGESTIONS
+        \ containedin=markdownCodeBlock,mkdListItemLine
   highlight link healthSuggestion String
 
   syntax match healthHelp "|.\{-}|" contains=healthBar
+        \ containedin=markdownCodeBlock,mkdListItemLine
   syntax match healthBar  "|" contained conceal
   highlight link healthHelp Identifier
 
   " We do not care about markdown syntax errors in :CheckHealth output.
   highlight! link markdownError Normal
-
-  " We don't need code blocks.
-  silent! syntax clear markdownCodeBlock
 endfunction
 
 " Runs the specified healthchecks.
@@ -68,6 +71,8 @@ function! health#check(plugin_names) abort
     endfor
   endif
 
+  " needed for plasticboy/vim-markdown, because it uses fdm=expr
+  normal! zR
   setlocal nomodified
   redraw|echo ''
 endfunction


### PR DESCRIPTION
- By re-enabling code blocks (every line that doesn't begin with a "-" and is
  indented by at least 4 spaces), we prevent the Markdown syntax to evaluate "_"
  as beginning for italic text.

  That's the case for `:CheckHealth deoplete` for instance. It would output:

  ```
    $ cat /tmp/log_{PID}
  ```

  Since the deoplete check gets run first, almost all of the `:CheckHealth`
  output would be italic.

- Since we re-enable code blocks, we have now tell our custom syntax that it can
  be part of markdownCodeBlock as well. Otherwise there would be no highlithing
  for our keywords ERROR, INFO, etc. after 4 spaces of indent.

- Since we do the above anyway, we make it work for mkdListItemLine as well.
  That's a highlight group from `plasticboy/vim-markdown` opposed to the shipped
  markdown syntax (which essentially is `tpope/vim-markdown`).