### PR TITLE
vim_FullName(): Fix invalid memory access.

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -2163,9 +2163,12 @@ int append_path(char *path, const char *to_append, size_t max_len)
 static int path_get_absolute_path(const char_u *fname, char_u *buf,
                                   size_t len, int force)
 {
+  if (STRLEN(fname) > len) {
+    return FAIL;
+  }
+
   char_u *p;
   *buf = NUL;
-
   char *relative_directory = xmalloc(len);
   char *end_of_path = (char *) fname;
 

--- a/test/unit/path_spec.lua
+++ b/test/unit/path_spec.lua
@@ -336,6 +336,14 @@ describe('more path function', function()
       eq(FAIL, result)
     end)
 
+    it('fails safely if given length is wrong #5737', function()
+      local filename = 'foo/bar/bazzzzzzz/buz/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/a'
+      local too_short_len = 3
+      local buffer = cstr(too_short_len, '')
+      local result = path.vim_FullName(filename, buffer, too_short_len, 1)
+      eq(FAIL, result)
+    end)
+
     it('uses the filename if the filename is a URL', function()
       local force_expansion = 1
       local filename = 'http://www.neovim.org'


### PR DESCRIPTION
vim_FullName() expects path_get_absolute_path() to return FAIL if
anything goes wrong. FullName_save() calls vim_FullName() with
len=MAXPATHL, but `fname` may be much longer.