### PR TITLE
option.c: Update free_oldval after adjusting opt_idx for shada/viminfo

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2770,6 +2770,10 @@ did_set_string_option (
                   ? ((shada_idx = findoption((char_u *) "shada")))
                   : shada_idx)
                : opt_idx);
+    // Update free_oldval now that we have the opt_idx for 'shada', otherwise
+    // there would be a disconnect between the check for P_ALLOCED at the start
+    // of the function and the set of P_ALLOCED at the end of the fuction.
+    free_oldval = (options[opt_idx].flags & P_ALLOCED);
     for (s = p_shada; *s; ) {
       /* Check it's a valid character */
       if (vim_strchr((char_u *)"!\"%'/:<@cfhnrs", *s) == NULL) {


### PR DESCRIPTION
Previously, free_oldval was set immediately on entering
did_set_string_option.  However, opt_idx hadn't been adjusted to account
for diverting 'viminfo' manipulation to 'shada'.

Therefore, the code which determines whether to free the old value was
looking at the flags for 'viminfo' while the code which sets whether a
value was allocated was modifying the flags for 'shada'.  This led to a
leak of any values set for 'viminfo'.

Updating free_oldval once opt_idx has been adjusted for the
'viminfo'/'shada' handling ensures the check/set values are consistent.

Closes #5698