### PR TITLE
[RFC] vim-patch:7.4.1867

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12317,6 +12317,8 @@ static void find_some_match(typval_T *argvars, typval_T *rettv, int type)
         listitem_T *li2 = li1->li_next;
         listitem_T *li3 = li2->li_next;
         listitem_T *li4 = li3->li_next;
+        xfree(li1->li_tv.vval.v_string);
+
         int rd = (int)(regmatch.endp[0] - regmatch.startp[0]);
         li1->li_tv.vval.v_string = vim_strnsave(regmatch.startp[0], rd);
         li3->li_tv.vval.v_number = (varnumber_T)(regmatch.startp[0] - expr);

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -573,7 +573,7 @@ static int included_patches[] = {
   // 1870 NA
   // 1869 NA
   // 1868,
-  // 1867,
+  1867,
   // 1866,
   // 1865 NA
   // 1864 NA


### PR DESCRIPTION
#### vim-patch:7.4.1867

Problem:    Memory leak in test_matchstrpos.
Solution:   Free the string before overwriting. (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/3c809343c72d9964475f421fd03bb892bc584a51