### PR TITLE
[RFC] tui: check stty/termios for kbs

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -26,6 +26,8 @@ if(NOT HAVE_SYS_WAIT_H AND UNIX)
   message(SEND_ERROR "header sys/wait.h is required for Unix")
 endif()
 check_include_files(sys/utsname.h HAVE_SYS_UTSNAME_H)
+check_include_files(termio.h HAVE_TERMIO_H)
+check_include_files(termios.h HAVE_TERMIOS_H)
 check_include_files(utime.h HAVE_UTIME_H)
 check_include_files(sys/uio.h HAVE_SYS_UIO_H)
 

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -43,6 +43,8 @@
 #cmakedefine HAVE_STRNCASECMP
 #cmakedefine HAVE_SYS_UTSNAME_H
 #cmakedefine HAVE_SYS_WAIT_H
+#cmakedefine HAVE_TERMIO_H
+#cmakedefine HAVE_TERMIOS_H
 #cmakedefine HAVE_UTIME
 #cmakedefine HAVE_UTIME_H
 #cmakedefine HAVE_UTIMES

--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -123,29 +123,23 @@ function! s:check_tmux() abort
   endif
 endfunction
 
-function! s:check_terminfo() abort
+function! s:check_terminal() abort
   if !executable('infocmp')
     return
   endif
-  call health#report_start('terminfo')
-  let suggestions = [
-        \ "Set key_backspace to \\177 (ASCII BACKSPACE). Run these commands:\n"
-        \   .'infocmp $TERM | sed ''s/kbs=^[hH]/kbs=\\177/'' > $TERM.ti'
-        \   ."\n"
-        \   .'tic $TERM.ti',
-        \ s:suggest_faq]
+  call health#report_start('terminal')
   let cmd = 'infocmp -L'
   let out = system(cmd)
-  let kbs_entry = matchstr(out, 'key_backspace=\S*')
+  let kbs_entry   = matchstr(out, 'key_backspace=[^,[:space:]]*')
+  let kdch1_entry = matchstr(out, 'key_dc=[^,[:space:]]*')
 
   if v:shell_error
     call health#report_error('command failed: '.cmd."\n".out)
-  elseif !empty(matchstr(out, '\Vkey_backspace=^H'))
-    call health#report_error('key_backspace (kbs) entry is ^H (ASCII DELETE): '
-        \ .kbs_entry, suggestions)
   else
-    call health#report_info('key_backspace terminfo entry: '
+    call health#report_info('key_backspace (kbs) terminfo entry: '
         \ .(empty(kbs_entry) ? '? (not found)' : kbs_entry))
+    call health#report_info('key_dc (kdch1) terminfo entry: '
+        \ .(empty(kbs_entry) ? '? (not found)' : kdch1_entry))
   endif
 endfunction
 
@@ -153,6 +147,6 @@ function! health#nvim#check() abort
   call s:check_config()
   call s:check_performance()
   call s:check_rplugin_manifest()
-  call s:check_terminfo()
+  call s:check_terminal()
   call s:check_tmux()
 endfunction

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -39,8 +39,6 @@ static int events_enabled = 0;
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/input.c.generated.h"
 #endif
-// Helper function used to push bytes from the 'event' key sequence partially
-// between calls to os_inchar when maxlen < 3
 
 void input_init(void)
 {
@@ -389,6 +387,8 @@ static void process_interrupts(void)
   }
 }
 
+// Helper function used to push bytes from the 'event' key sequence partially
+// between calls to os_inchar when maxlen < 3
 static int push_event_key(uint8_t *buf, int maxlen)
 {
   static const uint8_t key[3] = { K_SPECIAL, KS_EXTRA, KE_EVENT };

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -32,7 +32,14 @@ void term_input_init(TermInput *input, Loop *loop)
     term = "";  // termkey_new_abstract assumes non-null (#2745)
   }
 
+#if TERMKEY_VERSION_MAJOR > 0 || TERMKEY_VERSION_MINOR > 18
+  input->tk = termkey_new_abstract(term,
+                                   TERMKEY_FLAG_UTF8 | TERMKEY_FLAG_NOSTART);
+  termkey_hook_terminfo_getstr(input->tk, input->tk_ti_hook_fn, NULL);
+  termkey_start(input->tk);
+#else
   input->tk = termkey_new_abstract(term, TERMKEY_FLAG_UTF8);
+#endif
 
   int curflags = termkey_get_canonflags(input->tk);
   termkey_set_canonflags(input->tk, curflags | TERMKEY_CANON_DELBS);

--- a/src/nvim/tui/input.h
+++ b/src/nvim/tui/input.h
@@ -12,6 +12,7 @@ typedef struct term_input {
   bool paste_enabled;
   bool waiting;
   TermKey *tk;
+  TermKey_Terminfo_Getstr_Hook *tk_ti_hook_fn;  ///< libtermkey terminfo hook
   TimeWatcher timer_handle;
   Loop *loop;
   Stream read_stream;

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -6,6 +6,7 @@ local clear, eq, eval, execute, feed, insert, neq, next_msg, nvim,
   helpers.nvim_dir, helpers.ok, helpers.source,
   helpers.write_file, helpers.mkdir, helpers.rmdir
 local command = helpers.command
+local wait = helpers.wait
 local Screen = require('test.functional.ui.screen')
 
 if helpers.pending_win32(pending) then return end
@@ -271,7 +272,7 @@ describe('jobs', function()
     screen:set_default_attr_ids({
       [1] = {bold=true, foreground=Screen.colors.Blue},
     })
-    local script = [[
+    source([[
       function! g:JobHandler(job_id, data, event)
       endfunction
 
@@ -281,26 +282,14 @@ describe('jobs', function()
       \ 'on_exit': function('g:JobHandler')
       \ }
       let job = jobstart('cat -', g:callbacks)
-    ]]
-    source(script)
-    feed(':function! g:JobHandler(job_id, data, event)<cr>')
-    feed(':endfunction<cr>')
-    screen:expect([[
-      ^                                                     |
-      {1:~                                                    }|
-      {1:~                                                    }|
-      {1:~                                                    }|
-      {1:~                                                    }|
-      {1:~                                                    }|
-      {1:~                                                    }|
-      {1:~                                                    }|
-      {1:~                                                    }|
-      {1:~                                                    }|
-      {1:~                                                    }|
-      {1:~                                                    }|
-      {1:~                                                    }|
-                                                           |
     ]])
+    wait()
+    source([[
+      function! g:JobHandler(job_id, data, event)
+      endfunction
+    ]])
+
+    eq("", eval("v:errmsg"))
   end)
 
   it('requires funcrefs for script-local (s:) functions', function()

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -105,8 +105,8 @@ set(LUAROCKS_SHA256 cae709111c5701235770047dfd7169f66b82ae1c7b9b79207f9df0afb722
 set(UNIBILIUM_URL https://github.com/mauke/unibilium/archive/v1.2.0.tar.gz)
 set(UNIBILIUM_SHA256 623af1099515e673abfd3cae5f2fa808a09ca55dda1c65a7b5c9424eb304ead8)
 
-set(LIBTERMKEY_URL http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.18.tar.gz)
-set(LIBTERMKEY_SHA256 239746de41c845af52bb3c14055558f743292dd6c24ac26c2d6567a5a6093926)
+set(LIBTERMKEY_URL http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.19.tar.gz)
+set(LIBTERMKEY_SHA256 c505aa4cb48c8fa59c526265576b97a19e6ebe7b7da20f4ecaae898b727b48b7)
 
 set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/a9c7c6fd20fa35e0ad3e0e98901ca12dfca9c25c.tar.gz)
 set(LIBVTERM_SHA256 1a4272be91d9614dc183a503786df83b6584e4afaab7feaaa5409f841afbd796)


### PR DESCRIPTION
Closes #2048
Closes #5693

See https://github.com/neovim/libtermkey/compare/a9b61424aae9f7548162ff112393c5f706cf54f1%5E...c0eb4e4a05f49ad8fee0195c77f2c29d09cc36af

This is working, just need to polish it. You can test it like this:

    $ stty erase X
    $ ./build/bin/nvim

Then `X` key will perform backspace.

Useful [post](http://comp.terminals.narkive.com/i3ywh6Rv/backspace-h-vs-linux-vs-terminfo) from comp.terminals newsgroup:

```
- Secondly, in some visual programs, it won't matter which backspace
you configure, because they are smart enough to do this:

switch (input_character) {
...
case 8: case 127: /* A basta! Support both backspaces! */
erase_char(my_context);
...
}

- Some visual programs will support only one backspace character,
and they obtain its identity from the TTY driver. In other words,
whatever you configured using "stty erase <arg>" in the shell.
So it is important to inform the TTY driver of the correct character
not only for the sake of canonical input processing mode.

One program which is like this is GNU Bash. Its visual editing mode
recognizes only one erase character, and it corresponds with the
one in the TTY.

This makes it easier to fix th eproblem in Bash, because if the
setting is wrong, then your correct backspace character appears
literally. So in Bash you can do this:

bash$ stty erase <type Backspace here>

If your Backspace character appears literally, then you know it is
wrongly configured. Just hit Enter, and now it is right!

If your Backspace backspaces, then don't bother.

- Visual programs which rely on terminfo are ... screwed. Don't use
them, if possible. The idea of backspace being configured in terminfo
is quite silly, given that this is a setting that can be changed in
all the popular terminals. The purpose of terminfo is to describe fixed
properties of a terminal. In "xterm", the backspace can be flipped
between BS and DEL at run-time just like in PuTTY. (Try it: fire up an
xterm and then Ctrl-Left-Click in the window; the toggle is in the
pop-up menu).
```