### PR TITLE
[RFC] eval.c: set_selfdict(): Fix invalid memory access.

### DIFF
--- a/runtime/doc/job_control.txt
+++ b/runtime/doc/job_control.txt
@@ -40,7 +40,7 @@ for details.
 Job control is achieved by calling a combination of the |jobstart()|,
 |jobsend()| and |jobstop()| functions. Here's an example:
 >
-    function! s:JobHandler(job_id, data, event)
+    function! s:JobHandler(job_id, data, event) dict
       if a:event == 'stdout'
         let str = self.shell.' stdout: '.join(a:data)
       elseif a:event == 'stderr'
@@ -102,23 +102,23 @@ function. Here's a more object-oriented version of the above:
 >
     let Shell = {}
 
-    function Shell.on_stdout(job_id, data)
+    function Shell.on_stdout(job_id, data) dict
       call append(line('$'), self.get_name().' stdout: '.join(a:data))
     endfunction
 
-    function Shell.on_stderr(job_id, data)
+    function Shell.on_stderr(job_id, data) dict
       call append(line('$'), self.get_name().' stderr: '.join(a:data))
     endfunction
 
-    function Shell.on_exit(job_id, data)
+    function Shell.on_exit(job_id, data) dict
       call append(line('$'), self.get_name().' exited')
     endfunction
 
-    function Shell.get_name()
+    function Shell.get_name() dict
       return 'shell '.self.name
     endfunction
 
-    function Shell.new(name, ...)
+    function Shell.new(name, ...) dict
       let instance = extend(copy(g:Shell), {'name': a:name})
       let argv = ['bash']
       if a:0 > 0

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -18665,15 +18665,17 @@ handle_subscript (
   return ret;
 }
 
-static void set_selfdict(typval_T *rettv, dict_T *selfdict) {
+static void set_selfdict(typval_T *rettv, dict_T *selfdict)
+{
   // Don't do this when "dict.Func" is already a partial that was bound
   // explicitly (pt_auto is false).
   if (rettv->v_type == VAR_PARTIAL && !rettv->vval.v_partial->pt_auto
       && rettv->vval.v_partial->pt_dict != NULL) {
     return;
   }
-  char_u *fname = rettv->v_type == VAR_FUNC ? rettv->vval.v_string
-                                  : rettv->vval.v_partial->pt_name;
+  char_u *fname = rettv->v_type == VAR_FUNC || rettv->v_type == VAR_STRING
+                  ? rettv->vval.v_string
+                  : rettv->vval.v_partial->pt_name;
   char_u *tofree = NULL;
   ufunc_T *fp;
   char_u fname_buf[FLEN_FIXED + 1];
@@ -18694,7 +18696,7 @@ static void set_selfdict(typval_T *rettv, dict_T *selfdict) {
       pt->pt_dict = selfdict;
       (selfdict->dv_refcount)++;
       pt->pt_auto = true;
-      if (rettv->v_type == VAR_FUNC) {
+      if (rettv->v_type == VAR_FUNC || rettv->v_type == VAR_STRING) {
         // Just a function: Take over the function name and use selfdict.
         pt->pt_name = rettv->vval.v_string;
       } else {

--- a/test/functional/legacy/061_undo_tree_spec.lua
+++ b/test/functional/legacy/061_undo_tree_spec.lua
@@ -98,7 +98,7 @@ describe('undo tree:', function()
         expect_line('123456abc')
       end
 
-      helpers.retry(test_earlier_later)
+      helpers.retry(2, nil, test_earlier_later)
     end)
 
     it('file-write specifications', function()


### PR DESCRIPTION
~~todo: Needs a test.~~ The test fails correctly after reverting 0f681c80e1e9.

@bfredl @jamessan @brcolow after the partials PR, this isn't allowed anymore:

```vim
        if l:output_stream ==# 'stderr'
            " Read from stderr instead of stdout.
            let l:job = jobstart(l:command, {
            \   'on_stderr': 's:GatherOutputNeoVim',
            \   'on_exit': 's:HandleExitNeoVim',
            \})
```

That results in this error:

    E120: Using <SID> not in a script context: s:HandleExitNeoVim

Instead it needs to be like this:

```vim
            \   'on_stderr': function('s:GatherOutputNeoVim'),
            \   'on_exit': function('s:HandleExitNeoVim'),
```

This matches Vim's behavior. I guess that change was intended, correct?