### PR TITLE
vim-patch: Allow skipping non-"vim-patch" commits during review

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -366,6 +366,14 @@ review_commit() {
     echo "✘ Could not detect the Vim patch number."
     echo "  This script assumes that the PR contains only commits"
     echo "  with 'vim-patch:XXX' in their title."
+    echo
+    printf -- "$(head -n 4 <<< "${nvim_patch}")\n\n"
+    local reply
+    read -p "Continue reviewing (y/N)? " -n 1 -r reply
+    if [[ ! "${reply}" =~ ^[Nn]$ ]]; then
+      echo
+      return
+    fi
     exit 1
   fi
 


### PR DESCRIPTION
It's not atypical to have extra, non-"vim-patch" commits in a PR merging
a bigger or set of related patches from Vim.  Rather than immediately
aborting, display the patch header to the user and let them decide
whether to continue reviewing.