### PR TITLE
[RFC] Man: use non-recursive mappings for :Man

### DIFF
--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -31,8 +31,8 @@ setlocal nolist
 setlocal nofoldenable
 
 if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
-  nmap     <silent> <buffer> <C-]>      :Man<CR>
-  nmap     <silent> <buffer> K          :Man<CR>
+  nnoremap <silent> <buffer> <C-]>      :Man<CR>
+  nnoremap <silent> <buffer> K          :Man<CR>
   nnoremap <silent> <buffer> <C-T>      :call man#pop_tag()<CR>
   if s:pager
     nnoremap <silent> <buffer> <nowait> q :q<CR>


### PR DESCRIPTION
This is a regression introduced by:

  https://github.com/neovim/neovim/pull/5290/files#diff-8691c83194ea5f1342ecc9f17b4c51d8R46

When the <plug> mappings were changed to using `:Man`, they should have changed to
use `nnoremap` as well.

Fixes #5776.