### PR TITLE
[RFC] Add a note for partial function argument position

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -155,7 +155,10 @@ passed to the function.  Example: >
 This will invoke the function as if using: >
 	call myDict.Callback('foo')
 
-Note that binding a function to a Dictionary also happens when the function is
+Note the arguments passed to Funcref would prepend(not append) to the argument
+list.
+
+Also note that binding a function to a Dictionary also happens when the function is
 a member of the Dictionary: >
 
 	let myDict.myFunction = MyFunction


### PR DESCRIPTION
**Problem** extra arguments for partial function would prepend to argument list, and it would result in the orignal handler not working as expected, for example: the `timer_start` would have a id as first callback argument, if user use partial feature to add argument(s), the id would be the last function argument.

**Solution** add a note in the documentation.

~It would feels much nature if the argument append to the arguments, however, this is life.~