### PR TITLE
[RFC] Issue #5796

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4009,7 +4009,7 @@ static int is_one_char(char_u *pattern, bool move)
      * start and end are in the same position. */
     called_emsg = FALSE;
     nmatched = vim_regexec_multi(&regmatch, curwin, curbuf,
-        pos.lnum, (colnr_T)0, NULL);
+        pos.lnum, pos.col, NULL);
 
     if (!called_emsg)
       result = (nmatched != 0


### PR DESCRIPTION
Problem: gn misbehaved after the first match on the same line
when the match is one character wide, vice versa for gN

Proposal:  passing pos.col along with pos.lnum to
vim_regexec_multi instead of pos.lnum and (colnr_T)0 in the function
is_one_char called by current_search

However, it is unlikely (colnr_T)0 was passed without a reason (instead of the more logical pos.col).
Any ideas?

