### PR TITLE
mouse.c: Fix mouse click on multibyte lines w/ concealed text

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -646,13 +646,11 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
   int matchid;
   int prev_matchid;
   int len = 0;
-  int prev_len = 0;
 
 #define incr() col++; ptr_end += utfc_ptr2len(ptr_end)
 #define decr() col--; ptr_end -= utfc_ptr2len(ptr_end)
 
   while (ptr < ptr_end) {
-    prev_len = len;
     len = utfc_ptr2len(ptr);
     matchid = syn_get_concealed_id(wp, wp->w_cursor.lnum,
                                    (colnr_T)(ptr - line));
@@ -660,19 +658,10 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
       if (wp->w_p_cole == 3) {
         incr();
       } else {
-        if (row > 0 && ptr == ptr_row_offset) {
-          // Check if the current concealed character is actually part of
-          // the previous wrapped row's conceal group.
-          prev_matchid = syn_get_concealed_id(wp, wp->w_cursor.lnum,
-                                              (colnr_T)((ptr - line)
-                                                        - prev_len));
-          if (prev_matchid == matchid) {
-            incr();
-          }
-        } else if (wp->w_p_cole == 1
-                   || (wp->w_p_cole == 2
-                       && (lcs_conceal != NUL
-                           || syn_get_sub_char() != NUL))) {
+        if (!(row > 0 && ptr == ptr_row_offset)
+            && (wp->w_p_cole == 1 || (wp->w_p_cole == 2
+                                      && (lcs_conceal != NUL
+                                          || syn_get_sub_char() != NUL)))) {
           // At least one placeholder character will be displayed.
           decr();
         }
@@ -681,7 +670,6 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
         do {
           incr();
           ptr += len;
-          prev_len = len;
           len = utfc_ptr2len(ptr);
           matchid = syn_get_concealed_id(wp, wp->w_cursor.lnum,
                                          (colnr_T)(ptr - line));

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -670,8 +670,8 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
 
   vcol = offset;
 
-#define incr() col++; nudge++; ptr_end += utfc_ptr2len(ptr_end)
-#define decr() col--; nudge--; ptr_end -= utfc_ptr2len(ptr_end)
+#define incr() nudge++; ptr_end += utfc_ptr2len(ptr_end)
+#define decr() nudge--; ptr_end -= utfc_ptr2len(ptr_end)
 
   while (ptr < ptr_end && *ptr != NUL) {
     cwidth = chartabsize(ptr, vcol);
@@ -712,5 +712,5 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
     ptr += utfc_ptr2len(ptr);
   }
 
-  return col;
+  return col + nudge;
 }

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -699,11 +699,12 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
         }
 
         prev_matchid = matchid;
-        do {
+
+        while (prev_matchid == matchid && *ptr != NUL) {
           incr();
           ptr += utfc_ptr2len(ptr);
           matchid = syn_get_concealed_id(wp, lnum, (colnr_T)(ptr - line));
-        } while (prev_matchid == matchid);
+        }
 
         continue;
       }

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -634,13 +634,13 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
     // When 'wrap' is enabled, only the row (of the wrapped line) needs to be
     // checked for concealed characters.
     while (offset--) {
-      ptr += utf_ptr2len(ptr);
+      ptr += utfc_ptr2len(ptr);
     }
     ptr_row_offset = ptr;
   }
 
   for (int i = 0; i < col; i++) {
-    ptr_end += utf_ptr2len(ptr_end);
+    ptr_end += utfc_ptr2len(ptr_end);
   }
 
   int matchid;
@@ -648,12 +648,12 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
   int len = 0;
   int prev_len = 0;
 
-#define incr() col++; ptr_end += utf_ptr2len(ptr_end)
-#define decr() col--; ptr_end -= utf_ptr2len(ptr_end)
+#define incr() col++; ptr_end += utfc_ptr2len(ptr_end)
+#define decr() col--; ptr_end -= utfc_ptr2len(ptr_end)
 
   while (ptr < ptr_end) {
     prev_len = len;
-    len = utf_ptr2len(ptr);
+    len = utfc_ptr2len(ptr);
     matchid = syn_get_concealed_id(wp, wp->w_cursor.lnum,
                                    (colnr_T)(ptr - line));
     if (matchid != 0) {
@@ -682,7 +682,7 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
           incr();
           ptr += len;
           prev_len = len;
-          len = utf_ptr2len(ptr);
+          len = utfc_ptr2len(ptr);
           matchid = syn_get_concealed_id(wp, wp->w_cursor.lnum,
                                          (colnr_T)(ptr - line));
         } while (prev_matchid == matchid);

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -750,17 +750,19 @@ describe('ui/mouse/input', function()
 
       feed_command('set concealcursor=n')
       feed_command('set nowrap')
-      feed_command('syntax match NonText "\\<amet\\>" conceal')
-      feed_command('syntax match NonText "\\cs\\|g." conceal cchar=X')
-      feed_command('syntax match NonText "\\%(lo\\|cl\\)." conceal')
-      feed_command('syntax match NonText "Lo" conceal cchar=Y')
+      feed_command('set shiftwidth=2 tabstop=4 list listchars=tab:>-')
+      feed_command('syntax match NonText "\\*" conceal')
+      feed_command('syntax match NonText "cats" conceal cchar=X')
+      feed_command('syntax match NonText "x" conceal cchar=>')
 
+      -- First column is there to retain the tabs.
       insert([[
-      Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
-      Stet clita kasd gubergren, no sea takimata sanctus est.
+      |Section				*t1*
+      |			  *t2* *t3* *t4*
+      |x 私は猫が大好き	*cats* ✨🐈✨
       ]])
 
-      feed('gg')
+      feed('gg<c-v>Gxgg')
     end)
 
     it('(level 1) click on non-wrapped lines', function()
@@ -768,10 +770,10 @@ describe('ui/mouse/input', function()
 
       feed('<esc><LeftMouse><0,0>')
       screen:expect([[
-        {c:^Y}rem ip{c:X}um do{c: } {c:X}it {c: }, con|
-        {c:X}tet {c: }ta ka{c:X}d {c:X}ber{c:X}en, no|
+        ^Section{0:>>--->--->---}{c: }t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t3{c: } {c: }|
+        {c:>} 私は猫が大好き{0:>---}{c: X } {0:>}|
                                  |
-        {0:~                        }|
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -779,82 +781,127 @@ describe('ui/mouse/input', function()
 
       feed('<esc><LeftMouse><1,0>')
       screen:expect([[
-        {c:Y}^rem ip{c:X}um do{c: } {c:X}it {c: }, con|
-        {c:X}tet {c: }ta ka{c:X}d {c:X}ber{c:X}en, no|
+        S^ection{0:>>--->--->---}{c: }t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t3{c: } {c: }|
+        {c:>} 私は猫が大好き{0:>---}{c: X } {0:>}|
                                  |
-        {0:~                        }|
-        {0:~                        }|
-        {0:~                        }|
-                                 |
-      ]])
-
-      feed('<esc><LeftMouse><15,0>')
-      screen:expect([[
-        {c:Y}rem ip{c:X}um do{c: } {c:^X}it {c: }, con|
-        {c:X}tet {c: }ta ka{c:X}d {c:X}ber{c:X}en, no|
-                                 |
-        {0:~                        }|
         {0:~                        }|
         {0:~                        }|
                                  |
       ]])
 
-      feed('<esc><LeftMouse><15,1>')
+      feed('<esc><LeftMouse><21,0>')
       screen:expect([[
-        {c:Y}rem ip{c:X}um do{c: } {c:X}it {c: }, con|
-        {c:X}tet {c: }ta ka{c:X}d {c:X}^ber{c:X}en, no|
+        Section{0:>>--->--->---}{c: }^t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t3{c: } {c: }|
+        {c:>} 私は猫が大好き{0:>---}{c: X } {0:>}|
                                  |
-        {0:~                        }|
         {0:~                        }|
         {0:~                        }|
                                  |
       ]])
+
+      feed('<esc><LeftMouse><21,1>')
+      screen:expect([[
+        Section{0:>>--->--->---}{c: }t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t^3{c: } {c: }|
+        {c:>} 私は猫が大好き{0:>---}{c: X } {0:>}|
+                                 |
+        {0:~                        }|
+        {0:~                        }|
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><0,2>')
+      screen:expect([[
+        Section{0:>>--->--->---}{c: }t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t3{c: } {c: }|
+        {c:^>} 私は猫が大好き{0:>---}{c: X } {0:>}|
+                                 |
+        {0:~                        }|
+        {0:~                        }|
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><7,2>')
+      screen:expect([[
+        Section{0:>>--->--->---}{c: }t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t3{c: } {c: }|
+        {c:>} 私は^猫が大好き{0:>---}{c: X } {0:>}|
+                                 |
+        {0:~                        }|
+        {0:~                        }|
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><21,2>')
+      screen:expect([[
+        Section{0:>>--->--->---}{c: }t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t3{c: } {c: }|
+        {c:>} 私は猫が大好き{0:>---}{c: ^X } {0:>}|
+                                 |
+        {0:~                        }|
+        {0:~                        }|
+                                 |
+      ]])
+
     end) -- level 1 - non wrapped
 
     it('(level 1) click on wrapped lines', function()
       feed_command('let &conceallevel=1', 'let &wrap=1', 'echo')
 
-      feed('<esc><LeftMouse><0,0>')
+      feed('<esc><LeftMouse><24,1>')
       screen:expect([[
-        {c:^Y}rem ip{c:X}um do{c: } {c:X}it {c: }     |
-        , con{c:X}etetur {c:X}adip{c:X}cin{c:X}  |
-        elitr.                   |
-        {c:X}tet {c: }ta ka{c:X}d {c:X}ber{c:X}en    |
-        , no {c:X}ea takimata {c:X}anctu{c:X}|
-         e{c:X}t.                    |
+        Section{0:>>--->--->---}{c: }t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t3{c: } {c:^ }|
+        t4{c: }                      |
+        {c:>} 私は猫が大好き{0:>---}{c: X}   |
+        {c: } ✨🐈✨                 |
+                                 |
                                  |
       ]])
 
-      feed('<esc><LeftMouse><6,1>')
+      feed('<esc><LeftMouse><0,2>')
       screen:expect([[
-        {c:Y}rem ip{c:X}um do{c: } {c:X}it {c: }     |
-        , con{c:X}^etetur {c:X}adip{c:X}cin{c:X}  |
-        elitr.                   |
-        {c:X}tet {c: }ta ka{c:X}d {c:X}ber{c:X}en    |
-        , no {c:X}ea takimata {c:X}anctu{c:X}|
-         e{c:X}t.                    |
+        Section{0:>>--->--->---}{c: }t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t3{c: } {c: }|
+        ^t4{c: }                      |
+        {c:>} 私は猫が大好き{0:>---}{c: X}   |
+        {c: } ✨🐈✨                 |
+                                 |
                                  |
       ]])
 
-      feed('<esc><LeftMouse><15,1>')
+      feed('<esc><LeftMouse><8,3>')
       screen:expect([[
-        {c:Y}rem ip{c:X}um do{c: } {c:X}it {c: }     |
-        , con{c:X}etetur {c:X}a^dip{c:X}cin{c:X}  |
-        elitr.                   |
-        {c:X}tet {c: }ta ka{c:X}d {c:X}ber{c:X}en    |
-        , no {c:X}ea takimata {c:X}anctu{c:X}|
-         e{c:X}t.                    |
+        Section{0:>>--->--->---}{c: }t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t3{c: } {c: }|
+        t4{c: }                      |
+        {c:>} 私は猫^が大好き{0:>---}{c: X}   |
+        {c: } ✨🐈✨                 |
+                                 |
                                  |
       ]])
 
-      feed('<esc><LeftMouse><15,3>')
+      feed('<esc><LeftMouse><21,3>')
       screen:expect([[
-        {c:Y}rem ip{c:X}um do{c: } {c:X}it {c: }     |
-        , con{c:X}etetur {c:X}adip{c:X}cin{c:X}  |
-        elitr.                   |
-        {c:X}tet {c: }ta ka{c:X}d {c:X}^ber{c:X}en    |
-        , no {c:X}ea takimata {c:X}anctu{c:X}|
-         e{c:X}t.                    |
+        Section{0:>>--->--->---}{c: }t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t3{c: } {c: }|
+        t4{c: }                      |
+        {c:>} 私は猫が大好き{0:>---}{c: ^X}   |
+        {c: } ✨🐈✨                 |
+                                 |
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><4,4>')
+      screen:expect([[
+        Section{0:>>--->--->---}{c: }t1{c: } |
+        {0:>--->--->---}  {c: }t2{c: } {c: }t3{c: } {c: }|
+        t4{c: }                      |
+        {c:>} 私は猫が大好き{0:>---}{c: X}   |
+        {c: } ✨^🐈✨                 |
+                                 |
                                  |
       ]])
     end) -- level 1 - wrapped
@@ -863,45 +910,67 @@ describe('ui/mouse/input', function()
     it('(level 2) click on non-wrapped lines', function()
       feed_command('let &conceallevel=2', 'echo')
 
-      feed('<esc><LeftMouse><0,0>')
+      feed('<esc><LeftMouse><20,0>')
       screen:expect([[
-        {c:^Y}rem ip{c:X}um do {c:X}it , con{c:X}e|
-        {c:X}tet ta ka{c:X}d {c:X}ber{c:X}en, no |
+        Section{0:>>--->--->---}^t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+        {c:>} 私は猫が大好き{0:>---}{c:X} ✨{0:>}|
                                  |
-        {0:~                        }|
         {0:~                        }|
         {0:~                        }|
                                  |
       ]])
 
-      feed('<esc><LeftMouse><1,0>')
+      feed('<esc><LeftMouse><14,1>')
       screen:expect([[
-        {c:Y}^rem ip{c:X}um do {c:X}it , con{c:X}e|
-        {c:X}tet ta ka{c:X}d {c:X}ber{c:X}en, no |
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  ^t2 t3 t4   |
+        {c:>} 私は猫が大好き{0:>---}{c:X} ✨{0:>}|
                                  |
-        {0:~                        }|
         {0:~                        }|
         {0:~                        }|
                                  |
       ]])
 
-      feed('<esc><LeftMouse><15,0>')
+      feed('<esc><LeftMouse><18,1>')
       screen:expect([[
-        {c:Y}rem ip{c:X}um do {c:X}^it , con{c:X}e|
-        {c:X}tet ta ka{c:X}d {c:X}ber{c:X}en, no |
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t^3 t4   |
+        {c:>} 私は猫が大好き{0:>---}{c:X} ✨{0:>}|
                                  |
-        {0:~                        }|
         {0:~                        }|
         {0:~                        }|
                                  |
       ]])
 
-      feed('<esc><LeftMouse><15,1>')
+      feed('<esc><LeftMouse><0,2>')  -- Weirdness
       screen:expect([[
-        {c:Y}rem ip{c:X}um do {c:X}it , con{c:X}e|
-        {c:X}tet ta ka{c:X}d {c:X}b^er{c:X}en, no |
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+        {c:^>} 私は猫が大好き{0:>---}{c:X} ✨{0:>}|
                                  |
         {0:~                        }|
+        {0:~                        }|
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><8,2>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+        {c:>} 私は猫^が大好き{0:>---}{c:X} ✨{0:>}|
+                                 |
+        {0:~                        }|
+        {0:~                        }|
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><20,2>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+        {c:>} 私は猫が大好き{0:>---}{c:^X} ✨{0:>}|
+                                 |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -911,47 +980,108 @@ describe('ui/mouse/input', function()
     it('(level 2) click on wrapped lines', function()
       feed_command('let &conceallevel=2', 'let &wrap=1', 'echo')
 
-      feed('<esc><LeftMouse><0,0>')
+      feed('<esc><LeftMouse><20,0>')
       screen:expect([[
-        {c:^Y}rem ip{c:X}um do {c:X}it        |
-        , con{c:X}etetur {c:X}adip{c:X}cin{c:X}  |
-        elitr.                   |
-        {c:X}tet ta ka{c:X}d {c:X}ber{c:X}en     |
-        , no {c:X}ea takimata {c:X}anctu{c:X}|
-         e{c:X}t.                    |
+        Section{0:>>--->--->---}^t1   |
+        {0:>--->--->---}  t2 t3      |
+        t4                       |
+        {c:>} 私は猫が大好き{0:>---}{c:X}    |
+         ✨🐈✨                  |
+                                 |
                                  |
       ]])
 
-      feed('<esc><LeftMouse><6,1>')
+      feed('<esc><LeftMouse><14,1>')
       screen:expect([[
-        {c:Y}rem ip{c:X}um do {c:X}it        |
-        , con{c:X}^etetur {c:X}adip{c:X}cin{c:X}  |
-        elitr.                   |
-        {c:X}tet ta ka{c:X}d {c:X}ber{c:X}en     |
-        , no {c:X}ea takimata {c:X}anctu{c:X}|
-         e{c:X}t.                    |
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  ^t2 t3      |
+        t4                       |
+        {c:>} 私は猫が大好き{0:>---}{c:X}    |
+         ✨🐈✨                  |
+                                 |
                                  |
       ]])
 
-      feed('<esc><LeftMouse><15,1>')
+      feed('<esc><LeftMouse><18,1>')
       screen:expect([[
-        {c:Y}rem ip{c:X}um do {c:X}it        |
-        , con{c:X}etetur {c:X}a^dip{c:X}cin{c:X}  |
-        elitr.                   |
-        {c:X}tet ta ka{c:X}d {c:X}ber{c:X}en     |
-        , no {c:X}ea takimata {c:X}anctu{c:X}|
-         e{c:X}t.                    |
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t^3      |
+        t4                       |
+        {c:>} 私は猫が大好き{0:>---}{c:X}    |
+         ✨🐈✨                  |
+                                 |
                                  |
       ]])
 
-      feed('<esc><LeftMouse><15,3>')
+      -- NOTE: The click would ideally be on the 't' in 't4', but wrapping
+      -- caused the invisible '*' right before 't4' to remain on the previous
+      -- screen line.  This is being treated as expected because fixing this is
+      -- out of scope for mouse clicks.  Should the wrapping behavior of
+      -- concealed characters change in the future, this case should be
+      -- reevaluated.
+      feed('<esc><LeftMouse><0,2>')
       screen:expect([[
-        {c:Y}rem ip{c:X}um do {c:X}it        |
-        , con{c:X}etetur {c:X}adip{c:X}cin{c:X}  |
-        elitr.                   |
-        {c:X}tet ta ka{c:X}d {c:X}b^er{c:X}en     |
-        , no {c:X}ea takimata {c:X}anctu{c:X}|
-         e{c:X}t.                    |
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3 ^     |
+        t4                       |
+        {c:>} 私は猫が大好き{0:>---}{c:X}    |
+         ✨🐈✨                  |
+                                 |
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><1,2>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3      |
+        t^4                       |
+        {c:>} 私は猫が大好き{0:>---}{c:X}    |
+         ✨🐈✨                  |
+                                 |
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><0,3>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3      |
+        t4                       |
+        {c:^>} 私は猫が大好き{0:>---}{c:X}    |
+         ✨🐈✨                  |
+                                 |
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><20,3>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3      |
+        t4                       |
+        {c:>} 私は猫が大好き{0:>---}{c:^X}    |
+         ✨🐈✨                  |
+                                 |
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><1,4>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3      |
+        t4                       |
+        {c:>} 私は猫が大好き{0:>---}{c:X}    |
+         ^✨🐈✨                  |
+                                 |
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><5,4>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3      |
+        t4                       |
+        {c:>} 私は猫が大好き{0:>---}{c:X}    |
+         ✨🐈^✨                  |
+                                 |
                                  |
       ]])
     end) -- level 2 - wrapped
@@ -960,45 +1090,45 @@ describe('ui/mouse/input', function()
     it('(level 3) click on non-wrapped lines', function()
       feed_command('let &conceallevel=3', 'echo')
 
-      feed('<esc><LeftMouse><0,0>')
+      feed('<esc><LeftMouse><0,2>')
       screen:expect([[
-        ^rem ipum do it , conetetu|
-        tet ta kad beren, no ea t|
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+        ^ 私は猫が大好き{0:>----} ✨🐈|
                                  |
-        {0:~                        }|
         {0:~                        }|
         {0:~                        }|
                                  |
       ]])
 
-      feed('<esc><LeftMouse><1,0>')
+      feed('<esc><LeftMouse><1,2>')
       screen:expect([[
-        r^em ipum do it , conetetu|
-        tet ta kad beren, no ea t|
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+         ^私は猫が大好き{0:>----} ✨🐈|
                                  |
-        {0:~                        }|
         {0:~                        }|
         {0:~                        }|
                                  |
       ]])
 
-      feed('<esc><LeftMouse><15,0>')
+      feed('<esc><LeftMouse><13,2>')
       screen:expect([[
-        rem ipum do it ^, conetetu|
-        tet ta kad beren, no ea t|
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+         私は猫が大好^き{0:>----} ✨🐈|
                                  |
-        {0:~                        }|
         {0:~                        }|
         {0:~                        }|
                                  |
       ]])
 
-      feed('<esc><LeftMouse><15,1>')
+      feed('<esc><LeftMouse><20,2>')
       screen:expect([[
-        rem ipum do it , conetetu|
-        tet ta kad bere^n, no ea t|
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+         私は猫が大好き{0:>----}^ ✨🐈|
                                  |
-        {0:~                        }|
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -1008,49 +1138,94 @@ describe('ui/mouse/input', function()
     it('(level 3) click on wrapped lines', function()
       feed_command('let &conceallevel=3', 'let &wrap=1', 'echo')
 
-      feed('<esc><LeftMouse><0,0>')
+      feed('<esc><LeftMouse><14,1>')
       screen:expect([[
-        ^rem ipum do it           |
-        , conetetur adipcin      |
-        elitr.                   |
-        tet ta kad beren         |
-        , no ea takimata anctu   |
-         et.                     |
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  ^t2 t3      |
+        t4                       |
+         私は猫が大好き{0:>----}     |
+         ✨🐈✨                  |
+                                 |
                                  |
       ]])
 
-      feed('<esc><LeftMouse><6,1>')
+      feed('<esc><LeftMouse><18,1>')
       screen:expect([[
-        rem ipum do it           |
-        , cone^tetur adipcin      |
-        elitr.                   |
-        tet ta kad beren         |
-        , no ea takimata anctu   |
-         et.                     |
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t^3      |
+        t4                       |
+         私は猫が大好き{0:>----}     |
+         ✨🐈✨                  |
+                                 |
                                  |
       ]])
 
-      feed('<esc><LeftMouse><15,1>')
+      feed('<esc><LeftMouse><1,2>')
       screen:expect([[
-        rem ipum do it           |
-        , conetetur adi^pcin      |
-        elitr.                   |
-        tet ta kad beren         |
-        , no ea takimata anctu   |
-         et.                     |
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3      |
+        t^4                       |
+         私は猫が大好き{0:>----}     |
+         ✨🐈✨                  |
+                                 |
                                  |
       ]])
 
-      feed('<esc><LeftMouse><15,3>')
+      feed('<esc><LeftMouse><0,3>')
       screen:expect([[
-        rem ipum do it           |
-        , conetetur adipcin      |
-        elitr.                   |
-        tet ta kad bere^n         |
-        , no ea takimata anctu   |
-         et.                     |
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3      |
+        t4                       |
+        ^ 私は猫が大好き{0:>----}     |
+         ✨🐈✨                  |
+                                 |
                                  |
       ]])
+
+      feed('<esc><LeftMouse><20,3>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3      |
+        t4                       |
+         私は猫が大好き{0:>----}^     |
+         ✨🐈✨                  |
+                                 |
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><1,4>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3      |
+        t4                       |
+         私は猫が大好き{0:>----}     |
+         ^✨🐈✨                  |
+                                 |
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><3,4>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3      |
+        t4                       |
+         私は猫が大好き{0:>----}     |
+         ✨^🐈✨                  |
+                                 |
+                                 |
+      ]])
+
+      feed('<esc><LeftMouse><5,4>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3      |
+        t4                       |
+         私は猫が大好き{0:>----}     |
+         ✨🐈^✨                  |
+                                 |
+                                 |
+      ]])
+
     end) -- level 3 - wrapped
   end)
 end)


### PR DESCRIPTION
Fixes #5341, #5801

Needs tests.  Still sorting out concealed text that begins at `w_leftcol`.  There is also an issue with tab characters that come after concealed text that I can't seem to figure out.