### PR TITLE
[RFC] time: Check for input while waiting in os_microdelay()

### DIFF
--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -76,7 +76,7 @@ void os_microdelay(uint64_t microseconds, bool ignoreinput)
     // is available.
     const uint64_t nanoseconds_delta = (ignoreinput)
                                        ? nanoseconds - elapsed
-                                       : 10000000u;
+                                       : MIN(nanoseconds - elapsed, 10000000u);
 
     if ((uv_cond_timedwait(&delay_cond, &delay_mutex, nanoseconds_delta)
         == UV_ETIMEDOUT) && (ignoreinput || os_char_avail())) {

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -38,7 +38,7 @@ uint64_t os_hrtime(void)
 /// Sleeps for a certain amount of milliseconds
 ///
 /// @param milliseconds Number of milliseconds to sleep
-/// @param ignoreinput If true, allow a SIGINT to interrupt us
+/// @param ignoreinput If true, only SIGINT (CTRL-C) can interrupt.
 void os_delay(uint64_t milliseconds, bool ignoreinput)
 {
   if (ignoreinput) {
@@ -54,8 +54,8 @@ void os_delay(uint64_t milliseconds, bool ignoreinput)
 /// Sleeps for a certain amount of microseconds.
 ///
 /// @param microseconds Number of microseconds to sleep
-/// @param ignoreinput If true, ignore pressed keys during the waiting period.
-///                    If false, waiting is aborted on key press.
+/// @param ignoreinput If true, ignore all input (including SIGINT/CTRL-C).
+///                    If false, waiting is aborted on any input.
 void os_microdelay(uint64_t microseconds, bool ignoreinput)
 {
   uint64_t elapsed = 0u;

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -53,7 +53,7 @@ void os_delay(uint64_t milliseconds, bool ignoreinput)
 
 /// Sleeps for a certain amount of microseconds.
 ///
-/// @param microseconds Number of microseconds to sleep
+/// @param microseconds Number of microseconds to sleep.
 /// @param ignoreinput If true, ignore all input (including SIGINT/CTRL-C).
 ///                    If false, waiting is aborted on any input.
 void os_microdelay(uint64_t microseconds, bool ignoreinput)
@@ -71,8 +71,8 @@ void os_microdelay(uint64_t microseconds, bool ignoreinput)
 
   while (elapsed < nanoseconds) {
     // If the input is ignored, we simply wait the full delay. If not, we
-    // check every 10 milliseconds for input and break the waiting loop if input
-    // is available.
+    // check every 100 milliseconds for input and break the waiting loop if
+    // input is available.
     const uint64_t nanoseconds_delta = (ignoreinput)
                                        ? nanoseconds - elapsed
                                        : MIN(nanoseconds - elapsed, 100000000u);
@@ -91,6 +91,7 @@ void os_microdelay(uint64_t microseconds, bool ignoreinput)
   }
 
   uv_mutex_unlock(&delay_mutex);
+  return;
 }
 
 /// Portable version of POSIX localtime_r()

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -70,14 +70,13 @@ void os_microdelay(uint64_t microseconds, bool ignoreinput)
   uv_mutex_lock(&delay_mutex);
 
   while (elapsed < nanoseconds) {
-
     // If the input is ignored, we simply wait the full delay. If not, we
     // check every 10 milliseconds for input and break the waiting loop if input
     // is available.
     const uint64_t nanoseconds_delta = (ignoreinput)
                                        ? nanoseconds - elapsed
                                        : MIN(nanoseconds - elapsed, 100000000u);
-    uv_cond_timedwait(&delay_cond, &delay_mutex, nanoseconds_delta);
+    (void)uv_cond_timedwait(&delay_cond, &delay_mutex, nanoseconds_delta);
 
     // Exit the waiting loop if we do not ignore input and input is available.
     if (!ignoreinput && char_avail()) {

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -76,7 +76,7 @@ void os_microdelay(uint64_t microseconds, bool ignoreinput)
     const uint64_t nanoseconds_delta = (ignoreinput ? nanoseconds - elapsed : 10000u);
 
     if ((uv_cond_timedwait(&delay_cond, &delay_mutex, nanoseconds_delta)
-        == UV_ETIMEDOUT) && (true == os_char_avail())) {
+        == UV_ETIMEDOUT) && os_char_avail()) {
       break;
     }
 

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -76,7 +76,7 @@ void os_microdelay(uint64_t microseconds, bool ignoreinput)
     const uint64_t nanoseconds_delta = (ignoreinput ? nanoseconds - elapsed : 10000u);
 
     if ((uv_cond_timedwait(&delay_cond, &delay_mutex, nanoseconds_delta)
-        == UV_ETIMEDOUT) && os_char_avail()) {
+        == UV_ETIMEDOUT) && (ignoreinput || os_char_avail())) {
       break;
     }
 

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -63,12 +63,8 @@ void os_microdelay(uint64_t microseconds, bool ignoreinput)
 
   /* Convert microseconds to nanoseconds. If uint64_t would overflow, set
    * nanoseconds to UINT64_MAX. */
-  uint64_t nanoseconds;
-  if (microseconds < UINT64_MAX/1000u) {
-    nanoseconds = microseconds * 1000u;
-  } else {
-    nanoseconds = UINT64_MAX;
-  }
+  const uint64_t nanoseconds = (microseconds < UINT64_MAX/1000u ? microseconds * 1000u :
+      UINT64_MAX);
 
   uv_mutex_lock(&delay_mutex);
 
@@ -77,12 +73,7 @@ void os_microdelay(uint64_t microseconds, bool ignoreinput)
     /* If the key input is ignored, we simply wait the full delay. If not, we
      * check every 10 milliseconds for input and break the waiting loop if input
      * is available. */
-    uint64_t nanoseconds_delta;
-    if (true == ignoreinput) {
-      nanoseconds_delta = nanoseconds - elapsed;
-    } else {
-      nanoseconds_delta = 10000u;
-    }
+    const uint64_t nanoseconds_delta = (ignoreinput ? nanoseconds - elapsed : 10000u);
 
     if ((uv_cond_timedwait(&delay_cond, &delay_mutex, nanoseconds_delta)
         == UV_ETIMEDOUT) && (true == os_char_avail())) {

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -76,7 +76,7 @@ void os_microdelay(uint64_t microseconds, bool ignoreinput)
     // is available.
     const uint64_t nanoseconds_delta = (ignoreinput)
                                        ? nanoseconds - elapsed
-                                       : 10000u;
+                                       : 10000000u;
 
     if ((uv_cond_timedwait(&delay_cond, &delay_mutex, nanoseconds_delta)
         == UV_ETIMEDOUT) && (ignoreinput || os_char_avail())) {


### PR DESCRIPTION
Add a parameter to os_microdelay() that determines if the dalay can be aborted on key
input. Provide the according 'ignoreinput' parameter of os_delay() for that purpose.

Resolves #5397.