### PR TITLE
[RFC] man.vim: only set options/mappings on rendered manpages

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1143,7 +1143,7 @@ au BufNewFile,BufRead *.ist,*.mst		setf ist
 au BufNewFile,BufRead *.page			setf mallard
 
 " Manpage
-au BufNewFile,BufRead *.man			setf man
+au BufNewFile,BufRead *.man			setf nroff
 
 " Man config
 au BufNewFile,BufRead */etc/man.conf,man.config	setf manconf


### PR DESCRIPTION
fixes #5806