### PR TITLE
[RFC] man.vim: revert "completion now respects 'wildignorecase'"

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -290,10 +290,7 @@ function! s:complete(sect, psect, name) abort
     call s:error(v:exception)
     return
   endtry
-  let old_fic = &fileignorecase
-  let &fileignorecase = &wildignorecase
   let pages = globpath(mandirs,'man?/'.a:name.'*.'.a:sect.'*', 0, 1)
-  let &fileignorecase = old_fic
   " We remove duplicates in case the same manpage in different languages was found.
   return uniq(sort(map(pages, 's:format_candidate(v:val, a:psect)'), 'i'))
 endfunction

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -521,6 +521,8 @@ To use Nvim as a manpager: >
 man.vim will always attempt to reuse the closest man window (above/left) but
 otherwise create a split.
 
+The case sensitivity of completion is controlled by 'fileignorecase'.
+
 Commands:
 Man {name}                Display the manpage for {name}.
 Man {sect} {name}         Display the manpage for {name} and section {sect}.


### PR DESCRIPTION
Instead, a note was added to `:h man.vim` on how 'fileignorecase'
controls the case sensitivity of completion.