### PR TITLE
[RFC] Fix inconsistent paths in fname register

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1199,7 +1199,7 @@ int get_spec_reg(
   case '%':                     /* file name */
     if (errmsg)
       check_fname();            /* will give emsg if not set */
-    *argp = curbuf->b_fname;
+    *argp = curbuf->b_ffname;
     return TRUE;
 
   case '#':                     /* alternate file name */


### PR DESCRIPTION
The fname register could show different paths for the same working directory:

    $ nvim -u NORC
    :cd
    :edit ~/.config/somefile.txt
    " absolute path
    :echo @%
    :cd .config
    :cd -
    " relative path
    :echo @%

This commit makes @% always contain the absolute path instead.

---

CC @chrisbra Same in Vim.