### PR TITLE
[RFC] man.vim: bold and underline backspaced text

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -312,13 +312,10 @@ function! s:strip_backspaced_text(match) abort
   return s:stripped
 endfunction
 
+let s:src_id = nvim_buf_add_highlight(0, 0, '', 0, 0, 0)
 function! man#highlight_backspaced_text() abort
   set modifiable
-  if exists('b:man_src_id')
-    call nvim_buf_clear_highlight(0, b:man_src_id, 0, -1)
-  else
-    let b:man_src_id = 0
-  endif
+  call nvim_buf_clear_highlight(0, s:src_id, 0, -1)
   while 1
     let pos = searchpos('\(_\b[^_]\)\|\(\(.\)\b\3\)', 'p')
     if pos[0] == 0
@@ -333,7 +330,7 @@ function! man#highlight_backspaced_text() abort
     end
     execute 'silent keepjumps substitute/'.pattern.'/\=s:strip_backspaced_text(submatch(0))'
     let pos[1] -= 1
-    let b:man_src_id = nvim_buf_add_highlight(0, b:man_src_id, group, pos[0]-1, pos[1], pos[1]+len(s:stripped))
+    call nvim_buf_add_highlight(0, s:src_id, group, pos[0]-1, pos[1], pos[1]+len(s:stripped))
   endwhile
   keepjumps 1
   set nomodifiable

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -324,3 +324,17 @@ function! man#init_pager() abort
   endtry
   execute 'silent file man://'.fnameescape(ref)
 endfunction
+
+function! man#init_highlight_groups() abort
+  let group = 'Keyword'
+  while 1
+    let hl =  execute('highlight '.group)
+    let values = matchstr(hl, '\%(.*xxx\)\?\%(.*cleared\)\?\s*\zs.*')
+    if values !~# '^links to'
+      break
+    endif
+    let group = matchstr(values, '\w\+$')
+  endwhile
+  execute 'highlight default manBold' values 'cterm=bold gui=bold'
+  highlight default manUnderline cterm=underline gui=underline
+endfunction

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -307,6 +307,16 @@ function! s:format_candidate(path, psect) abort
   endif
 endfunction
 
+function! s:init_highlight_groups() abort
+  highlight default manBold cterm=bold gui=bold
+  highlight default manUnderline cterm=underline gui=underline
+endfunction
+augroup man_colorscheme
+ autocmd!
+ autocmd ColorScheme * call s:init_highlight_groups()
+augroup END
+call s:init_highlight_groups()
+
 function! s:strip_backspaced_text(match) abort
   let s:stripped = substitute(a:match, '.\b', '', 'g')
   return s:stripped
@@ -314,14 +324,15 @@ endfunction
 
 let s:src_id = nvim_buf_add_highlight(0, 0, '', 0, 0, 0)
 function! man#highlight_backspaced_text() abort
-  set modifiable
   call nvim_buf_clear_highlight(0, s:src_id, 0, -1)
   while 1
-    let pos = searchpos('\(_\b[^_]\)\|\(\(.\)\b\3\)', 'p')
+    let pos = searchpos('\%(_\b[^_]\)\|\%(\(.\)\b\1\)', 'p')
     if pos[0] == 0
       break
     endif
-    if pos[2] ==# 2
+    let pos[0] -= 1
+    let pos[1] -= 1
+    if pos[2] ==# 1
       let pattern = '\%(_\b[^_]\)\+'
       let group = 'manUnderline'
     else
@@ -329,11 +340,9 @@ function! man#highlight_backspaced_text() abort
       let group = 'manBold'
     end
     execute 'silent keepjumps substitute/'.pattern.'/\=s:strip_backspaced_text(submatch(0))'
-    let pos[1] -= 1
-    call nvim_buf_add_highlight(0, s:src_id, group, pos[0]-1, pos[1], pos[1]+len(s:stripped))
+    call nvim_buf_add_highlight(0, s:src_id, group, pos[0], pos[1], pos[1]+len(s:stripped))
   endwhile
   keepjumps 1
-  set nomodifiable
 endfunction
 
 function! man#init_pager() abort

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -17,7 +17,7 @@ function! man#open_page(count, count1, mods, ...) abort
     call s:error('too many arguments')
     return
   elseif a:0 == 0
-    let ref = &filetype ==# 'man' ? expand('<cWORD>') : expand('<cword>')
+    let ref = &filetype ==# 'man' ? substitute(expand('<cWORD>'), '.\b', '', 'g') : expand('<cword>')
     if empty(ref)
       call s:error('no identifier under cursor')
       return
@@ -305,44 +305,6 @@ function! s:format_candidate(path, psect) abort
     " of the actual section.
     return name.'('.sect.')'
   endif
-endfunction
-
-function! s:init_highlight_groups() abort
-  highlight default manBold cterm=bold gui=bold
-  highlight default manUnderline cterm=underline gui=underline
-endfunction
-augroup man_colorscheme
- autocmd!
- autocmd ColorScheme * call s:init_highlight_groups()
-augroup END
-call s:init_highlight_groups()
-
-function! s:strip_backspaced_text(match) abort
-  let s:stripped = substitute(a:match, '.\b', '', 'g')
-  return s:stripped
-endfunction
-
-let s:src_id = nvim_buf_add_highlight(0, 0, '', 0, 0, 0)
-function! man#highlight_backspaced_text() abort
-  call nvim_buf_clear_highlight(0, s:src_id, 0, -1)
-  while 1
-    let pos = searchpos('\%(_\b[^_]\)\|\%(\(.\)\b\1\)', 'p')
-    if pos[0] == 0
-      break
-    endif
-    let pos[0] -= 1
-    let pos[1] -= 1
-    if pos[2] ==# 1
-      let pattern = '\%(_\b[^_]\)\+'
-      let group = 'manUnderline'
-    else
-      let pattern = '\%(\(.\)\b\1\)\+'
-      let group = 'manBold'
-    end
-    execute 'silent keepjumps substitute/'.pattern.'/\=s:strip_backspaced_text(submatch(0))'
-    call nvim_buf_add_highlight(0, s:src_id, group, pos[0], pos[1], pos[1]+len(s:stripped))
-  endwhile
-  keepjumps 1
 endfunction
 
 function! man#init_pager() abort

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -34,6 +34,8 @@ setlocal nowrap
 setlocal conceallevel=2
 setlocal concealcursor=nvic
 
+execute "setlocal iskeyword+=\b"
+
 if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
   nnoremap <silent> <buffer> <C-]>      :Man<CR>
   nnoremap <silent> <buffer> K          :Man<CR>

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -12,6 +12,8 @@ if s:pager
   call man#init_pager()
 endif
 
+call man#highlight_backspaced_text()
+
 setlocal buftype=nofile
 setlocal noswapfile
 setlocal bufhidden=hide

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -12,8 +12,6 @@ if s:pager
   call man#init_pager()
 endif
 
-call man#highlight_backspaced_text()
-
 setlocal buftype=nofile
 setlocal noswapfile
 setlocal bufhidden=hide
@@ -31,6 +29,10 @@ setlocal foldcolumn=0
 setlocal colorcolumn=0
 setlocal nolist
 setlocal nofoldenable
+
+setlocal nowrap
+setlocal conceallevel=2
+setlocal concealcursor=nvic
 
 if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
   nnoremap <silent> <buffer> <C-]>      :Man<CR>

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -5,11 +5,9 @@ if exists('b:current_syntax')
   finish
 endif
 
-" Not contained because sometimes, manpages contain garbage backspaced
-" characters. See Restricted Shell at bash(1)
-syntax match manBackspacedChar display conceal '.\b'
+syntax match manBackspacedChar      display conceal contained '.\b'
 syntax match manBold                display contains=manBackspacedChar
-      \ '\%(\([[:graph:]]\)\b\1\)\+'
+      \ '\%(.\b.\)\+'
 syntax match manUnderline           display contains=manBackspacedChar
       \ '\%(_\b[^_]\)\+'
 

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -5,29 +5,20 @@ if exists('b:current_syntax')
   finish
 endif
 
-syntax match manBackspacedCharacter display conceal '.\b'
-syntax match manBold                display contains=manBackspacedCharacter '\%(\([[:graph:]]\)\b\1\)\+'
-syntax match manUnderline           display contains=manBackspacedCharacter '\%(_\b[^_]\)\+'
+" Not contained because sometimes, manpages contain garbage backspaced
+" characters. See Restricted Shell at bash(1)
+syntax match manBackspacedChar display conceal '.\b'
+syntax match manBold                display contains=manBackspacedChar
+      \ '\%(\([[:graph:]]\)\b\1\)\+'
+syntax match manUnderline           display contains=manBackspacedChar
+      \ '\%(_\b[^_]\)\+'
 
-if !exists('#man_highlight_groups')
-  function! s:init_highlight_groups() abort
-    let group = 'Keyword'
-    while 1
-      let values = execute('highlight '.group)
-      if values =~# '='
-        let values = substitute(values, '.* \(\w\+=.*\)', '\1', '')
-        break
-      endif
-      let group = substitute(values, '.* to \(\w\+\)', '\1', '')
-    endwhile
-    execute 'highlight default manBold' values 'cterm=bold gui=bold'
-    highlight default manUnderline cterm=underline gui=underline
-  endfunction
-  augroup man_highlight_groups
+if !exists('#man_init_highlight_groups')
+  augroup man_init_highlight_groups
     autocmd!
-    autocmd ColorScheme * call s:init_highlight_groups()
+    autocmd ColorScheme * call man#init_highlight_groups()
   augroup END
-  call s:init_highlight_groups()
+  call man#init_highlight_groups()
 endif
 
 if !exists('b:man_sect')

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -34,6 +34,10 @@ if b:man_sect =~# '^[23]'
   highlight default link manCFuncDefinition Function
 endif
 
+highlight default manBold cterm=bold gui=bold
+highlight default manUnderline cterm=underline gui=underline
+call man#highlight_backspaced_text()
+
 " Prevent everything else from matching the last line
 execute 'syntax match manFooter display "^\%'.line('$').'l.*$"'
 

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -34,10 +34,6 @@ if b:man_sect =~# '^[23]'
   highlight default link manCFuncDefinition Function
 endif
 
-highlight default manBold cterm=bold gui=bold
-highlight default manUnderline cterm=underline gui=underline
-call man#highlight_backspaced_text()
-
 " Prevent everything else from matching the last line
 execute 'syntax match manFooter display "^\%'.line('$').'l.*$"'
 

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -5,18 +5,30 @@ if exists('b:current_syntax')
   finish
 endif
 
-syntax case  ignore
-syntax match manReference      display '[^()[:space:]]\+([0-9nx][a-z]*)'
-syntax match manSectionHeading display '^\S.*$'
-syntax match manTitle          display '^\%1l.*$'
-syntax match manSubHeading     display '^ \{3\}\S.*$'
-syntax match manOptionDesc     display '^\s\+\%(+\|-\)\S\+'
+syntax match manBackspacedCharacter display conceal '.\b'
+syntax match manBold                display contains=manBackspacedCharacter '\%(\([[:graph:]]\)\b\1\)\+'
+syntax match manUnderline           display contains=manBackspacedCharacter '\%(_\b[^_]\)\+'
 
-highlight default link manTitle          Title
-highlight default link manSectionHeading Statement
-highlight default link manOptionDesc     Constant
-highlight default link manReference      PreProc
-highlight default link manSubHeading     Function
+if !exists('#man_highlight_groups')
+  function! s:init_highlight_groups() abort
+    let group = 'Keyword'
+    while 1
+      let values = execute('highlight '.group)
+      if values =~# '='
+        let values = substitute(values, '.* \(\w\+=.*\)', '\1', '')
+        break
+      endif
+      let group = substitute(values, '.* to \(\w\+\)', '\1', '')
+    endwhile
+    execute 'highlight default manBold' values 'cterm=bold gui=bold'
+    highlight default manUnderline cterm=underline gui=underline
+  endfunction
+  augroup man_highlight_groups
+    autocmd!
+    autocmd ColorScheme * call s:init_highlight_groups()
+  augroup END
+  call s:init_highlight_groups()
+endif
 
 if !exists('b:man_sect')
   call man#init_pager()


### PR DESCRIPTION
\cc @tweekmonster @mhinz 

<img width="1440" alt="screen shot 2016-12-30 at 4 49 01 pm" src="https://cloud.githubusercontent.com/assets/10180857/21573256/4d1e0d16-ceb0-11e6-8019-b50e25657ffd.png">

Fixes #5846 

Conflicts with #5831 but it will be easy to resolve.