### PR TITLE
[RFC] vim-patch:7.4.1876

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2030,9 +2030,10 @@ static int do_more_prompt(int typed_char)
   int i;
 
   // We get called recursively when a timer callback outputs a message. In
-  // that case don't show another prompt. Also when at the hit-Enter prompt.
-  if (entered || State == HITRETURN) {
-      return false;
+  // that case don't show another prompt. Also when at the hit-Enter prompt
+  // and nothing was typed.
+  if (entered || (State == HITRETURN && typed_char == 0)) {
+    return false;
   }
   entered = true;
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -564,7 +564,7 @@ static int included_patches[] = {
   // 1879 NA
   // 1878 NA
   // 1877 NA
-  // 1876,
+  1876,
   1875,
   // 1874 NA
   // 1873 NA


### PR DESCRIPTION
vim-patch:7.4.1876

Problem:    Typing "k" at the hit-enter prompt has no effect.
Solution:   Don't assume recursive use of the prompt if a character was typed.
            (Hirohito Higashi)

https://github.com/vim/vim/commit/a0055ad3a789b8eeb0c983d8a18d4bcaeaf456b8