### PR TITLE
[RFC] vim-patch:7.4.1940

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3666,7 +3666,7 @@ find_decl (
     size_t len,
     bool locally,
     bool thisblock,
-    int searchflags                /* flags passed to searchit() */
+    int flags_arg                  // flags passed to searchit()
 )
 {
   char_u      *pat;
@@ -3678,6 +3678,7 @@ find_decl (
   bool save_p_scs;
   bool retval = true;
   bool incll;
+  int searchflags = flags_arg;
 
   pat = xmalloc(len + 7);
 
@@ -3751,10 +3752,12 @@ find_decl (
       break;
     }
 
-    /* For finding a local variable and the match is before the "{" search
-     * to find a later match.  For K&R style function declarations this
-     * skips the function header without types. */
+    // For finding a local variable and the match is before the "{" search
+    // to find a later match.  For K&R style function declarations this
+    // skips the function header without types.  Remove SEARCH_START from
+    // flags to avoid getting stuck at one position.
     found_pos = curwin->w_cursor;
+    searchflags &= ~SEARCH_START;
   }
 
   if (t == false) {

--- a/src/nvim/testdir/test_goto.vim
+++ b/src/nvim/testdir/test_goto.vim
@@ -1,10 +1,20 @@
 " Test commands that jump somewhere.
 
-func Test_geedee()
+func Test_geeDEE()
   new
   call setline(1, ["Filename x;", "", "int Filename", "int func() {", "Filename y;"])
   /y;/
   normal gD
   call assert_equal(1, line('.'))
+  quit!
+endfunc
+
+func Test_gee_dee()
+  new
+  call setline(1, ["int x;", "", "int func(int x)", "{", "  return x;", "}"])
+  /return/
+  normal $hgd
+  call assert_equal(3, line('.'))
+  call assert_equal(14, col('.'))
   quit!
 endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -500,7 +500,7 @@ static int included_patches[] = {
   // 1943 NA
   // 1942 NA
   1941,
-  // 1940,
+  1940,
   // 1939 NA
   // 1938 NA
   1937,


### PR DESCRIPTION
vim-patch:7.4.1940

Problem:    "gd" hangs in some situations. (Eric Biggers)
Solution:   Remove the SEARCH_START flag when looping.  Add a test.

https://github.com/vim/vim/commit/23c60f21b07b04351d846e6fbf4f4abd9aa09345