### PR TITLE
test: jobclose(): Avoid indeterminism.

### DIFF
--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -508,7 +508,9 @@ describe('jobs', function()
 
     it('jobclose() sends SIGHUP', function()
       nvim('command', 'call jobclose(j)')
-      eq({'notification', 'exit', {0, 42}}, next_msg())
+      local msg = next_msg()
+      msg = (msg[2] == 'stdout') and next_msg() or msg  -- Skip stdout, if any.
+      eq({'notification', 'exit', {0, 42}}, msg)
     end)
   end)
 end)


### PR DESCRIPTION
stdout activity may reach the queue before `exit`; just discard it.

Observed on Travis CI, ubuntu "trusty" beta image:

    [ RUN      ] ...is/build/neovim/neovim/test/functional/core/job_spec.lua @ 509: jobs running tty-test program jobclose() sends SIGHUP
    ...is/build/neovim/neovim/test/functional/core/job_spec.lua:511: Expected objects to be the same.
    Passed in:
    (table) {
      [1] = 'notification'
     *[2] = 'stdout'
      [3] = {
        [1] = 0
        [2] = {
          [1] = '
    '
          [2] = '' } } }
    Expected:
    (table) {
      [1] = 'notification'
     *[2] = 'exit'
      [3] = {
        [1] = 0
        [2] = 42 } }
    stack traceback:
    	...is/build/neovim/neovim/test/functional/core/job_spec.lua:511: in function <...is/build/neovim/neovim/test/functional/core/job_spec.lua:509>
    [  FAILED  ] ...is/build/neovim/neovim/test/functional/core/job_spec.lua @ 509: jobs running tty-test program jobclose() sends SIGHUP (2.81 ms)