### PR TITLE
[RFC] man.vim: remove newline from man errors

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -106,7 +106,7 @@ function! s:system(cmd, ...) abort
     throw printf('command interrupted: %s', join(a:cmd))
   endif
   if opts.exit_code != 0
-    throw printf("command error (%d) %s: %s", jobid, join(a:cmd), opts.stderr)
+    throw printf("command error (%d) %s: %s", jobid, join(a:cmd), substitute(opts.stderr, '\_s\+$', '', &gdefault ? '' : 'g'))
   endif
 
   return opts.stdout


### PR DESCRIPTION
Otherwise errors appear like:

<img width="1440" alt="screen shot 2017-01-01 at 1 29 48 am" src="https://cloud.githubusercontent.com/assets/10180857/21580419/d7ebd948-cfc1-11e6-9b9c-985d98e24da2.png">
