### PR TITLE
[RFC] make rpcrequest on host start for UpdateRemotePlugins only

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -125,6 +125,13 @@ function! s:RegistrationCommands(host) abort
     call remote#host#RegisterPlugin(host_id, path, [])
   endfor
   let channel = remote#host#Require(host_id)
+  " check the process started correctly
+  if rpcrequest(channel, 'poll') !=# 'ok'
+    " there could be host that not response for poll request
+    echoerr 'rpcrequest of 'a:host . ' host failed'
+  endif
+
+
   let lines = []
   let registered = []
   for path in paths


### PR DESCRIPTION
The rpcrequest call is slow (more than 150ms) and it should not be called every time the provider host get started.

This pr does the following: 

*  The `rpcrequest` is moved to the `remote/host.vim` file, so it only get called on `UpdateRemotePlugin`.
* ~`provider#{host_name}#ChannelError` function is added to provider files so host.vim could call it to show error message and throw error when needed.~
* `on_exit` handler is added to provider files to show error messages when the job abnormal exited, ex: the neovim package get removed by `pip uninstall neovim`
* ~Slightly changed `provider#{host_name}#Require` function signature to allow extra argument indicate the call is from `UpdateRemotePlugins`~
* better error handling for command not executable.

One more benefit of this approach is the user would always have the error noticed when the remote process get abnormal exit. 

edit: the potential break changes have been removed.