### PR TITLE
[RFC] vim-patch:7.4.1866,7.4.1868

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21569,10 +21569,10 @@ void func_unref(char_u *name)
   if (name != NULL && isdigit(*name)) {
     fp = find_func(name);
     if (fp == NULL) {
-      // Ignore when invoked through free_all_mem().
-      if (!really_exiting) {
+#ifdef EXITFREE
+      if (!entered_free_all_mem)
+#endif
         EMSG2(_(e_intern2), "func_unref()");
-      }
     } else {
       user_func_unref(fp);
     }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21569,7 +21569,10 @@ void func_unref(char_u *name)
   if (name != NULL && isdigit(*name)) {
     fp = find_func(name);
     if (fp == NULL) {
-      EMSG2(_(e_intern2), "func_unref()");
+      // Ignore when invoked through free_all_mem().
+      if (!really_exiting) {
+        EMSG2(_(e_intern2), "func_unref()");
+      }
     } else {
       user_func_unref(fp);
     }

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -636,6 +636,10 @@ EXTERN int exiting INIT(= FALSE);
 /* TRUE when planning to exit Vim.  Might
  * still keep on running if there is a changed
  * buffer. */
+#if defined(EXITFREE)
+// true when in or after free_all_mem()
+EXTERN bool entered_free_all_mem INIT(= false);
+#endif
 /* volatile because it is used in signal handler deathtrap(). */
 EXTERN volatile int full_screen INIT(= FALSE);
 /* TRUE when doing full-screen output

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -488,16 +488,12 @@ void time_to_bytes(time_t time_, uint8_t buf[8])
 void free_all_mem(void)
 {
   buf_T       *buf, *nextbuf;
-  static bool entered = false;
 
   /* When we cause a crash here it is caught and Vim tries to exit cleanly.
    * Don't try freeing everything again. */
-  if (entered)
+  if (entered_free_all_mem)
     return;
-  entered = true;
-
-  // Set this flag to indicate some errors can be ignored.
-  really_exiting = true;
+  entered_free_all_mem = true;
 
   // Don't want to trigger autocommands from here on.
   block_autocmds();

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -496,6 +496,9 @@ void free_all_mem(void)
     return;
   entered = true;
 
+  // Set this flag to indicate some errors can be ignored.
+  really_exiting = true;
+
   // Don't want to trigger autocommands from here on.
   block_autocmds();
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -572,7 +572,7 @@ static int included_patches[] = {
   1871,
   // 1870 NA
   // 1869 NA
-  // 1868,
+  1868,
   1867,
   1866,
   // 1865 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -574,7 +574,7 @@ static int included_patches[] = {
   // 1869 NA
   // 1868,
   1867,
-  // 1866,
+  1866,
   // 1865 NA
   // 1864 NA
   // 1863 NA


### PR DESCRIPTION
#### vim-patch:7.4.1866

Problem:    Invalid memory access when exiting with EXITFREE defined.
            (Dominique Pelle)
Solution:   Set "really_exiting" and skip error messages.

https://github.com/vim/vim/commit/a96732150cda2f242133228579b05437a39b8daa

This fails to build, due to a00c2e0ecbaec366364cecb5efbdb456c8c543ef
removing really_exiting from globals.h, but the next commit fixes the
build failure.


#### vim-patch:7.4.1868

Problem:    Setting really_exiting causes memory leaks to be reported.
Solution:   Add the in_free_all_mem flag.

https://github.com/vim/vim/commit/b89a25f17e274dc308c584ea69a129ffbb26bc3d