### PR TITLE
[RFC] vim-patch:aa3b15d,82af871,7.4.1925,c95a302

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " netrw.vim: Handles file transfer and remote directory listing across
 "            AUTOLOAD SECTION
-" Date:		Feb 16, 2016
-" Version:	155	ASTRO-ONLY
+" Date:		Apr 20, 2016
+" Version:	156
 " Maintainer:	Charles E Campbell <NdrOchip@ScampbellPfamily.AbizM-NOSPAM>
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 2016 Charles E. Campbell {{{1
@@ -13,7 +13,7 @@
 "               expressed or implied. By using this plugin, you agree that
 "               in no event will the copyright holder be liable for any damages
 "               resulting from the use of this software.
-"redraw!|call DechoSep()|call inputsave()|call input("Press <cr> to continue")|call inputrestore(,'~'.expand("<slnum>"))
+"redraw!|call DechoSep()|call inputsave()|call input("Press <cr> to continue")|call inputrestore()
 "
 "  But be doers of the Word, and not only hearers, deluding your own selves {{{1
 "  (James 1:22 RSV)
@@ -30,7 +30,7 @@ if v:version < 704 || !has("patch213")
  let s:needpatch213= 1
  finish
 endif
-let g:loaded_netrw = "v155"
+let g:loaded_netrw = "v156"
 if !exists("s:NOTE")
  let s:NOTE    = 0
  let s:WARNING = 1
@@ -444,7 +444,7 @@ call s:NetrwInit("g:netrw_markfileesc"   , '*./[\~')
 call s:NetrwInit("g:netrw_maxfilenamelen", 32)
 call s:NetrwInit("g:netrw_menu"          , 1)
 call s:NetrwInit("g:netrw_mkdir_cmd"     , g:netrw_ssh_cmd." USEPORT HOSTNAME mkdir")
-call s:NetrwInit("g:netrw_mousemaps"     , (exists("+mouse") && &mouse =~ '[anh]'))
+call s:NetrwInit("g:netrw_mousemaps"     , (exists("+mouse") && &mouse =~# '[anh]'))
 call s:NetrwInit("g:netrw_retmap"        , 0)
 if has("unix") || (exists("g:netrw_cygwin") && g:netrw_cygwin)
  call s:NetrwInit("g:netrw_chgperm"       , "chmod PERM FILENAME")
@@ -490,6 +490,7 @@ if !exists("g:netrw_sort_sequence")
 endif
 call s:NetrwInit("g:netrw_special_syntax"   , 0)
 call s:NetrwInit("g:netrw_ssh_browse_reject", '^total\s\+\d\+$')
+call s:NetrwInit("g:netrw_suppress_gx_mesg",  1)
 call s:NetrwInit("g:netrw_use_noswf"        , 1)
 call s:NetrwInit("g:netrw_sizestyle"        ,"b")
 " Default values - t-w ---------- {{{3
@@ -526,6 +527,7 @@ if has("gui_running") && (&enc == 'utf-8' || &enc == 'utf-16' || &enc == 'ucs-4'
 else
  let s:treedepthstring= "| "
 endif
+call s:NetrwInit("s:netrw_nbcd",'{}')
 
 " BufEnter event ignored by decho when following variable is true
 "  Has a side effect that doau BufReadPost doesn't work, so
@@ -551,7 +553,7 @@ if v:version >= 700 && has("balloon_eval") && !exists("s:initbeval") && !exists(
 endif
 au WinEnter *	if &ft == "netrw"|call s:NetrwInsureWinVars()|endif
 
-if g:netrw_keepj =~ "keepj"
+if g:netrw_keepj =~# "keepj"
  com! -nargs=*	NetrwKeepj	keepj <args>
 else
  let g:netrw_keepj= ""
@@ -821,7 +823,7 @@ fun! netrw#Explore(indx,dosplit,style,...)
     let dirname= curfiledir
 "    call Decho("..empty dirname, using current file's directory<".dirname.">",'~'.expand("<slnum>"))
    endif
-   if dirname =~ '^scp://' || dirname =~ '^ftp://'
+   if dirname =~# '^scp://' || dirname =~ '^ftp://'
     call netrw#Nread(2,dirname)
    else
     if dirname == ""
@@ -1560,15 +1562,7 @@ fun! s:NetrwOptionRestore(vt)
 "  call Dfunc("s:NetrwOptionRestore(vt<".a:vt.">) win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> winnr($)=".winnr("$"))
 "  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt,'~'.expand("<slnum>"))
   if !exists("{a:vt}netrw_optionsave")
-   if exists("s:nbcd_curpos_{bufnr('%')}")
-"    call Decho("restoring posn to s:nbcd_curpos_".bufnr('%')."<".string(s:nbcd_curpos_{bufnr('%')}).">",'~'.expand("<slnum>"))
-    NetrwKeepj call winrestview(s:nbcd_curpos_{bufnr('%')})
-"    call Decho("win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> winnr($)=".winnr("$"),'~'.expand("<slnum>"))
-"    call Decho("unlet s:nbcd_curpos_".bufnr('%'),'~'.expand("<slnum>"))
-    unlet s:nbcd_curpos_{bufnr('%')}
-   else
-"    call Decho("no previous position",'~'.expand("<slnum>"))
-   endif
+   call s:RestorePosn(s:netrw_nbcd)
 "   call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt,'~'.expand("<slnum>"))
 "   call Decho("ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
 "   call Dret("s:NetrwOptionRestore : ".a:vt."netrw_optionsave doesn't exist")
@@ -1656,16 +1650,7 @@ fun! s:NetrwOptionRestore(vt)
    if exists("{a:vt}netrw_regstar") |sil! let @*= {a:vt}netrw_regstar |unlet {a:vt}netrw_regstar |endif
   endif
   if exists("{a:vt}netrw_regslash")|sil! let @/= {a:vt}netrw_regslash|unlet {a:vt}netrw_regslash|endif
-  if exists("s:nbcd_curpos_{bufnr('%')}")
-"   call Decho("restoring posn to s:nbcd_curpos_".bufnr('%')."<".string(s:nbcd_curpos_{bufnr('%')}).">",'~'.expand("<slnum>"))
-   NetrwKeepj call winrestview(s:nbcd_curpos_{bufnr('%')})
-"   call Decho("unlet s:nbcd_curpos_".bufnr('%'),'~'.expand("<slnum>"))
-   if exists("s:nbcd_curpos_".bufnr('%'))
-    unlet s:nbcd_curpos_{bufnr('%')}
-   endif
-  else
-"   call Decho("no previous position",'~'.expand("<slnum>"))
-  endif
+  call s:RestorePosn(s:netrw_nbcd)
 
 "  call Decho("g:netrw_keepdir=".g:netrw_keepdir.": getcwd<".getcwd()."> acd=".&acd,'~'.expand("<slnum>"))
 "  call Decho("fo=".&fo.(exists("+acd")? " acd=".&acd : " acd doesn't exist"),'~'.expand("<slnum>"))
@@ -3016,10 +3001,10 @@ fun! s:NetrwMethod(choice)
     if exists("s:netrw_hup[host]")
      call NetUserPass("ftp:".host)
 
-    elseif (has("win32") || has("win95") || has("win64") || has("win16")) && s:netrw_ftp_cmd =~ '-[sS]:'
+    elseif (has("win32") || has("win95") || has("win64") || has("win16")) && s:netrw_ftp_cmd =~# '-[sS]:'
 "     call Decho("has -s: : s:netrw_ftp_cmd<".s:netrw_ftp_cmd.">",'~'.expand("<slnum>"))
 "     call Decho("          g:netrw_ftp_cmd<".g:netrw_ftp_cmd.">",'~'.expand("<slnum>"))
-     if g:netrw_ftp_cmd =~ '-[sS]:\S*MACHINE\>'
+     if g:netrw_ftp_cmd =~# '-[sS]:\S*MACHINE\>'
       let s:netrw_ftp_cmd= substitute(g:netrw_ftp_cmd,'\<MACHINE\>',g:netrw_machine,'')
 "      call Decho("s:netrw_ftp_cmd<".s:netrw_ftp_cmd.">",'~'.expand("<slnum>"))
      endif
@@ -3583,7 +3568,7 @@ fun! s:NetrwBrowse(islocal,dirname)
   " This is useful when one edits a local file, then :e ., then :Rex
   if a:islocal && !exists("w:netrw_rexfile") && bufname("#") != ""
    let w:netrw_rexfile= bufname("#")
-"   call Decho("setting w:netrw_rexfile<".w:netrw_rexfile."> win#".winnr())
+"   call Decho("setting w:netrw_rexfile<".w:netrw_rexfile."> win#".winnr(),'~'.expand("<slnum>"))
   endif
 
   " s:NetrwBrowse : initialize history {{{3
@@ -3773,7 +3758,7 @@ fun! s:NetrwBrowse(islocal,dirname)
 
    " analyze dirname and g:netrw_list_cmd {{{3
 "   call Decho("b:netrw_curdir<".(exists("b:netrw_curdir")? b:netrw_curdir : "doesn't exist")."> dirname<".dirname.">",'~'.expand("<slnum>"))
-   if dirname =~ "^NetrwTreeListing\>"
+   if dirname =~# "^NetrwTreeListing\>"
     let dirname= b:netrw_curdir
 "    call Decho("(dirname was <NetrwTreeListing>) dirname<".dirname.">",'~'.expand("<slnum>"))
    elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("b:netrw_curdir")
@@ -3854,15 +3839,15 @@ endfun
 " directory is used.
 fun! s:NetrwFile(fname)
 "  call Dfunc("s:NetrwFile(fname<".a:fname.">) win#".winnr())
-"  call Decho("g:netrw_keepdir  =".(exists("g:netrw_keepdir")?   g:netrw_keepdir   : 'n/a'))
-"  call Decho("g:netrw_cygwin   =".(exists("g:netrw_cygwin")?    g:netrw_cygwin    : 'n/a'))
-"  call Decho("g:netrw_liststyle=".(exists("g:netrw_liststyle")? g:netrw_liststyle : 'n/a'))
-"  call Decho("w:netrw_liststyle=".(exists("w:netrw_liststyle")? w:netrw_liststyle : 'n/a'))
+"  call Decho("g:netrw_keepdir  =".(exists("g:netrw_keepdir")?   g:netrw_keepdir   : 'n/a'),'~'.expand("<slnum>"))
+"  call Decho("g:netrw_cygwin   =".(exists("g:netrw_cygwin")?    g:netrw_cygwin    : 'n/a'),'~'.expand("<slnum>"))
+"  call Decho("g:netrw_liststyle=".(exists("g:netrw_liststyle")? g:netrw_liststyle : 'n/a'),'~'.expand("<slnum>"))
+"  call Decho("w:netrw_liststyle=".(exists("w:netrw_liststyle")? w:netrw_liststyle : 'n/a'),'~'.expand("<slnum>"))
 
   " clean up any leading treedepthstring
   if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
    let fname= substitute(a:fname,'^'.s:treedepthstring.'\+','','')
-"   call Decho("clean up any leading treedepthstring: fname<".fname.">")
+"   call Decho("clean up any leading treedepthstring: fname<".fname.">",'~'.expand("<slnum>"))
   else
    let fname= a:fname
   endif
@@ -3897,6 +3882,8 @@ fun! s:NetrwFile(fname)
    " vim and netrw agree on the current directory
    let ret= fname
 "   call Decho("vim and netrw agree on current directory (g:netrw_keepdir=".g:netrw_keepdir.")",'~'.expand("<slnum>"))
+"   call Decho("vim   directory: ".getcwd(),'~'.expand("<slnum>"))
+"   call Decho("netrw directory: ".(exists("b:netrw_curdir")? b:netrw_curdir : 'n/a'),'~'.expand("<slnum>"))
   endif
 
 "  call Dret("s:NetrwFile ".ret)
@@ -3910,9 +3897,9 @@ fun! s:NetrwFileInfo(islocal,fname)
   let ykeep= @@
   if a:islocal
    let lsopt= "-lsad"
-   if g:netrw_sizestyle =~ 'H'
+   if g:netrw_sizestyle =~# 'H'
     let lsopt= "-lsadh"
-   elseif g:netrw_sizestyle =~ 'h'
+   elseif g:netrw_sizestyle =~# 'h'
     let lsopt= "-lsadh --si"
    endif
    if (has("unix") || has("macunix")) && executable("/bin/ls")
@@ -3944,7 +3931,7 @@ fun! s:NetrwFileInfo(islocal,fname)
     endif
     let t  = getftime(s:NetrwFile(fname))
     let sz = getfsize(s:NetrwFile(fname))
-    if g:netrw_sizestyle =~ "[hH]"
+    if g:netrw_sizestyle =~# "[hH]"
      let sz= s:NetrwHumanReadable(sz)
     endif
     echo a:fname.":  ".sz."  ".strftime(g:netrw_timefmt,getftime(s:NetrwFile(fname)))
@@ -3958,108 +3945,49 @@ fun! s:NetrwFileInfo(islocal,fname)
 endfun
 
 " ---------------------------------------------------------------------
+" s:NetrwFullPath: returns the full path to a directory and/or file {{{2
+fun! s:NetrwFullPath(filename)
+"  " call Dfunc("s:NetrwFullPath(filename<".a:filename.">)")
+  let filename= a:filename
+  if filename !~ '^/'
+   let filename= resolve(getcwd().'/'.filename)
+  endif
+  if filename != "/" && filename =~ '/$'
+   let filename= substitute(filename,'/$','','')
+  endif
+"  " call Dret("s:NetrwFullPath <".filename.">")
+  return filename
+endfun
+
+" ---------------------------------------------------------------------
 " s:NetrwGetBuffer: {{{2
 "   returns 0=cleared buffer
 "           1=re-used buffer (buffer not cleared)
 fun! s:NetrwGetBuffer(islocal,dirname)
 "  call Dfunc("s:NetrwGetBuffer(islocal=".a:islocal." dirname<".a:dirname.">) liststyle=".g:netrw_liststyle)
 "  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo,'~'.expand("<slnum>"))
+"  call Decho("netrwbuf dictionary=".string(s:netrwbuf),'~'.expand("<slnum>"))
   let dirname= a:dirname
 
   " re-use buffer if possible {{{3
 "  call Decho("--re-use a buffer if possible--",'~'.expand("<slnum>"))
-  if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-   " find NetrwTreeList buffer if there is one
-"   call Decho("case liststyle=treelist: find NetrwTreeList buffer if there is one",'~'.expand("<slnum>"))
-   if exists("w:netrw_treebufnr") && w:netrw_treebufnr > 0
-"    call Decho("  re-using w:netrw_treebufnr=".w:netrw_treebufnr,'~'.expand("<slnum>"))
-    let eikeep= &ei
-    setl ei=all
-    exe "sil! keepj noswapfile keepalt b ".w:netrw_treebufnr
-    let &ei= eikeep
-    setl ma
-    sil! NetrwKeepj %d _
-"    call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo,'~'.expand("<slnum>"))
-"    call Decho("tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol(),'~'.expand("<slnum>"))
-"    call Dret("s:NetrwGetBuffer 0<buffer cleared> : bufnum#".w:netrw_treebufnr."<NetrwTreeListing>")
-    return 0
+  if !exists("s:netrwbuf")
+   let s:netrwbuf= {}
+  endif
+  if has_key(s:netrwbuf,s:NetrwFullPath(dirname))
+   let bufnum= s:netrwbuf[s:NetrwFullPath(dirname)]
+"   call Decho("lookup netrwbuf dictionary: s:netrwbuf[".s:NetrwFullPath(dirname)."]=".bufnum)
+   if !bufexists(bufnum)
+    call remove(s:netrwbuf,s:NetrwFullPath(dirname))
+    let bufnum= -1
    endif
-   let bufnum= -1
-"   call Decho("  liststyle=TREE but w:netrw_treebufnr doesn't exist",'~'.expand("<slnum>"))
-
   else
-   " find buffer number of buffer named precisely the same as dirname {{{3
-"   call Decho("case listtyle not treelist: find buffer numnber of buffer named precisely the same as dirname--",'~'.expand("<slnum>"))
-"   call Dredir("(NetrwGetBuffer) ls!","ls!")
-
-   " get dirname and associated buffer number
-   let bufnum  = bufnr(escape(dirname,'\'))
-"   call Decho("  find buffer<".dirname.">'s number ",'~'.expand("<slnum>"))
-"   call Decho("  bufnr(dirname<".escape(dirname,'\').">)=".bufnum,'~'.expand("<slnum>"))
-
-   if bufnum < 0 && dirname !~ '/$'
-    " try appending a trailing /
-"    call Decho("  try appending a trailing / to dirname<".dirname.">",'~'.expand("<slnum>"))
-    let bufnum= bufnr(escape(dirname.'/','\'))
-    if bufnum > 0
-     let dirname= dirname.'/'
-    endif
-   endif
-
-   if bufnum < 0 && dirname =~ '/$'
-    " try removing a trailing /
-"    call Decho("  try removing a trailing / from dirname<".dirname.">",'~'.expand("<slnum>"))
-    let bufnum= bufnr(escape(substitute(dirname,'/$','',''),'\'))
-    if bufnum > 0
-     let dirname= substitute(dirname,'/$','','')
-    endif
-   endif
-
-"   call Decho("  findbuf1: bufnum=bufnr('".dirname."')=".bufnum." bufname(".bufnum.")<".bufname(bufnum)."> (initial)",'~'.expand("<slnum>"))
-   " note: !~ was used just below, but that means using ../ to go back would match (ie. abc/def/  and abc/ matches)
-   if bufnum > 0 && bufname(bufnum) != dirname && bufname(bufnum) != '.'
-    " handle approximate matches
-"    call Decho("  handling approx match: bufnum#".bufnum.">0 AND bufname<".bufname(bufnum).">!=dirname<".dirname."> AND bufname(".bufnum.")!='.'",'~'.expand("<slnum>"))
-    let ibuf    = 1
-    let buflast = bufnr("$")
-"    call Decho("  findbuf2: buflast=bufnr($)=".buflast,'~'.expand("<slnum>"))
-    while ibuf <= buflast
-     let bname= substitute(bufname(ibuf),'\\','/','g')
-     let bname= substitute(bname,'.\zs/$','','')
-"     call Decho("  findbuf3: while [ibuf=",ibuf."]<=[buflast=".buflast."]: dirname<".dirname."> bname=bufname(".ibuf.")<".bname.">",'~'.expand("<slnum>"))
-     if bname != '' && dirname =~ '/'.bname.'/\=$' && dirname !~ '^/'
-      " bname is not empty
-      " dirname ends with bname,
-      " dirname doesn't start with /, so its not a absolute path
-"      call Decho("  findbuf3a: passes test 1 : dirname<".dirname.'> =~ /'.bname.'/\=$ && dirname !~ ^/','~'.expand("<slnum>"))
-      break
-     endif
-     if bname =~ '^'.dirname.'/\=$'
-      " bname begins with dirname
-"      call Decho('  findbuf3b: passes test 2 : bname<'.bname.'>=~^'.dirname.'/\=$','~'.expand("<slnum>"))
-      break
-     endif
-     if dirname =~ '^'.bname.'/$'
-"      call Decho('  findbuf3c: passes test 3 : dirname<'.dirname.'>=~^'.bname.'/$','~'.expand("<slnum>"))
-      break
-     endif
-     if bname != '' && dirname =~ '/'.bname.'$' && bname == bufname("%") && line("$") == 1
-"      call Decho('  findbuf3d: passes test 4 : dirname<'.dirname.'>=~ /'.bname.'$','~'.expand("<slnum>"))
-      break
-     endif
-     let ibuf= ibuf + 1
-    endwhile
-    if ibuf > buflast
-     let bufnum= -1
-    else
-     let bufnum= ibuf
-    endif
-"    call Decho("  findbuf4: bufnum=".bufnum." (ibuf=".ibuf." buflast=".buflast.")",'~'.expand("<slnum>"))
-   endif
+"   call Decho("lookup netrwbuf dictionary: s:netrwbuf[".s:NetrwFullPath(dirname)."] not a key")
+   let bufnum= -1
   endif
 
   " get enew buffer and name it -or- re-use buffer {{{3
-  if bufnum < 0 || !bufexists(bufnum)   " get enew buffer and name it
+  if bufnum < 0      " get enew buffer and name it
 "   call Decho("--get enew buffer and name it  (bufnum#".bufnum."<0 OR bufexists(".bufnum.")=".bufexists(bufnum)."==0)",'~'.expand("<slnum>"))
    call s:NetrwEnew(dirname)
 "   call Decho("  got enew buffer#".bufnr("%")." (altbuf<".expand("#").">)",'~'.expand("<slnum>"))
@@ -4093,6 +4021,10 @@ fun! s:NetrwGetBuffer(islocal,dirname)
 "    let v:errmsg= "" " Decho
     exe 'sil! keepj keepalt file '.escdirname
 "    call Decho("  errmsg<".v:errmsg."> bufnr(".escdirname.")=".bufnr(escdirname)."<".bufname(bufnr(escdirname)).">",'~'.expand("<slnum>"))
+    " enter the new buffer into the s:netrwbuf dictionary
+    let s:netrwbuf[s:NetrwFullPath(dirname)]= bufnr("%")
+"    call Decho("update netrwbuf dictionary: s:netrwbuf[".s:NetrwFullPath(dirname)."]=".bufnr("%"),'~'.expand("<slnum>"))
+"    call Decho("netrwbuf dictionary=".string(s:netrwbuf),'~'.expand("<slnum>"))
    endif
 "   call Decho("  named enew buffer#".bufnr("%")."<".bufname("%").">",'~'.expand("<slnum>"))
 
@@ -4100,7 +4032,7 @@ fun! s:NetrwGetBuffer(islocal,dirname)
 "   call Decho("--re-use buffer#".bufnum." (bufnum#".bufnum.">=0 AND bufexists(".bufnum.")=".bufexists(bufnum)."!=0)",'~'.expand("<slnum>"))
    let eikeep= &ei
    setl ei=all
-   if getline(2) =~ '^" Netrw Directory Listing'
+   if getline(2) =~# '^" Netrw Directory Listing'
 "    call Decho("  getline(2)<".getline(2).'> matches "Netrw Directory Listing" : using keepalt b '.bufnum,'~'.expand("<slnum>"))
     exe "sil! NetrwKeepj noswapfile keepalt b ".bufnum
    else
@@ -4215,20 +4147,20 @@ fun! s:NetrwGetWord()
    let dirname= "./"
    let curline= getline('.')
 
-   if curline =~ '"\s*Sorted by\s'
+   if curline =~# '"\s*Sorted by\s'
     NetrwKeepj norm s
     let s:netrw_skipbrowse= 1
     echo 'Pressing "s" also works'
 
-   elseif curline =~ '"\s*Sort sequence:'
+   elseif curline =~# '"\s*Sort sequence:'
     let s:netrw_skipbrowse= 1
     echo 'Press "S" to edit sorting sequence'
 
-   elseif curline =~ '"\s*Quick Help:'
+   elseif curline =~# '"\s*Quick Help:'
     NetrwKeepj norm ?
     let s:netrw_skipbrowse= 1
 
-   elseif curline =~ '"\s*\%(Hiding\|Showing\):'
+   elseif curline =~# '"\s*\%(Hiding\|Showing\):'
     NetrwKeepj norm a
     let s:netrw_skipbrowse= 1
     echo 'Pressing "a" also works'
@@ -4471,10 +4403,10 @@ fun! s:NetrwBookmark(del,...)
    let i = 1
    while i <= a:0
     if islocal
-     if v:version == 704 && has("patch656")
-      let mbfiles= glob(a:{i},0,1,1)
+     if v:version > 704 || (v:version == 704 && has("patch656"))
+      let mbfiles= glob(fnameescape(a:{i}),0,1,1)
      else
-      let mbfiles= glob(a:{i},0,1)
+      let mbfiles= glob(fnameescape(a:{i}),0,1)
      endif
     else
      let mbfiles= [a:{i}]
@@ -4578,14 +4510,13 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
 "   call Dret("s:NetrwBrowseChgDir")
    return
   endif
+"  call Decho("b:netrw_curdir<".b:netrw_curdir.">")
 
   " NetrwBrowseChgDir: save options and initialize {{{3
 "  call Decho("saving options",'~'.expand("<slnum>"))
+  call s:SavePosn(s:netrw_nbcd)
   NetrwKeepj call s:NetrwOptionSave("s:")
   NetrwKeepj call s:NetrwSafeOptions()
-  let nbcd_curpos                = winsaveview()
-"  call Decho("saving posn to nbcd_curpos<".string(nbcd_curpos).">",'~'.expand("<slnum>"))
-  let s:nbcd_curpos_{bufnr('%')} = nbcd_curpos
   if (has("win32") || has("win95") || has("win64") || has("win16"))
    let dirname = substitute(b:netrw_curdir,'\\','/','ge')
   else
@@ -4601,15 +4532,14 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
   if g:netrw_banner
 "   call Decho("w:netrw_bannercnt=".(exists("w:netrw_bannercnt")? w:netrw_bannercnt : 'n/a')." line(.)#".line('.')." line($)#".line("#"),'~'.expand("<slnum>"))
    if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt && line("$") >= w:netrw_bannercnt
-    if getline(".") =~ 'Quick Help'
+    if getline(".") =~# 'Quick Help'
 "     call Decho("#1: quickhelp=".g:netrw_quickhelp." ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
      let g:netrw_quickhelp= (g:netrw_quickhelp + 1)%len(s:QuickHelp)
 "     call Decho("#2: quickhelp=".g:netrw_quickhelp." ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
      setl ma noro nowrap
      NetrwKeepj call setline(line('.'),'"   Quick Help: <F1>:help  '.s:QuickHelp[g:netrw_quickhelp])
      setl noma nomod nowrap
-"     call Decho("restoring posn to nbcd_curpos<".string(nbcd_curpos).">",'~'.expand("<slnum>"))
-     NetrwKeepj call winrestview(nbcd_curpos)
+     call s:RestorePosn(s:netrw_nbcd)
      NetrwKeepj call s:NetrwOptionRestore("s:")
 "     call Decho("ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
     endif
@@ -4633,7 +4563,7 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
 "   call Decho("adjusting dirname<".dirname.'>  (put trailing "/" back)','~'.expand("<slnum>"))
   endif
 
-"  "  call Decho("[newdir<".newdir."> ".((newdir =~ dirpat)? "=~" : "!~")." dirpat<".dirpat.">] && [islocal=".a:islocal."] && [newdir is ".(isdirectory(s:NetrwFile(newdir))? "" : "not ")."a directory]",'~'.expand("<slnum>"))
+"  call Decho("[newdir<".newdir."> ".((newdir =~ dirpat)? "=~" : "!~")." dirpat<".dirpat.">] && [islocal=".a:islocal."] && [newdir is ".(isdirectory(s:NetrwFile(newdir))? "" : "not ")."a directory]",'~'.expand("<slnum>"))
   if newdir !~ dirpat && !(a:islocal && isdirectory(s:NetrwFile(s:ComposePath(dirname,newdir))))
    " ------------------------------
    " NetrwBrowseChgDir: edit a file {{{3
@@ -4658,7 +4588,7 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
 "    call Decho("edit-a-file: dirname<".dirname.">",'~'.expand("<slnum>"))
 "    call Decho("edit-a-file: tree listing",'~'.expand("<slnum>"))
    elseif newdir =~ '^\(/\|\a:\)'
-"    call Decho("edit-a-file: handle an url or path starting with /: <".newdir.">")
+"    call Decho("edit-a-file: handle an url or path starting with /: <".newdir.">",'~'.expand("<slnum>"))
     let dirname= newdir
    else
     let dirname= s:ComposePath(dirname,newdir)
@@ -4685,7 +4615,7 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
       if !&ea
        keepalt wincmd _
       endif
-      call s:SetRexDir(a:islocal,b:netrw_curdir)
+      call s:SetRexDir(a:islocal,curdir)
      elseif g:netrw_browse_split == 2
       " vertically splitting the window first
 "      call Decho("edit-a-file: vertically splitting window prior to edit",'~'.expand("<slnum>"))
@@ -4693,12 +4623,15 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
       if !&ea
        keepalt wincmd |
       endif
-      call s:SetRexDir(a:islocal,b:netrw_curdir)
+      call s:SetRexDir(a:islocal,curdir)
      elseif g:netrw_browse_split == 3
       " open file in new tab
 "      call Decho("edit-a-file: opening new tab prior to edit",'~'.expand("<slnum>"))
       keepalt tabnew
-      call s:SetRexDir(a:islocal,b:netrw_curdir)
+      if !exists("b:netrw_curdir")
+       let b:netrw_curdir= getcwd()
+      endif
+      call s:SetRexDir(a:islocal,curdir)
      elseif g:netrw_browse_split == 4
       " act like "P" (ie. open previous window)
 "      call Decho("edit-a-file: use previous window for edit",'~'.expand("<slnum>"))
@@ -4707,7 +4640,7 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
 "       call Dret("s:NetrwBrowseChgDir")
        return
       endif
-      call s:SetRexDir(a:islocal,b:netrw_curdir)
+      call s:SetRexDir(a:islocal,curdir)
      else
       " handling a file, didn't split, so remove menu
 "      call Decho("edit-a-file: handling a file+didn't split, so remove menu",'~'.expand("<slnum>"))
@@ -4860,7 +4793,7 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
    endif
    let treedir      = s:NetrwTreeDir(a:islocal)
 "   call Decho("tree-list: treedir<".treedir.">",'~'.expand("<slnum>"))
-   let s:treecurpos = nbcd_curpos
+   let s:treecurpos = winsaveview()
    let haskey       = 0
 "   call Decho("tree-list: w:netrw_treedict<".string(w:netrw_treedict).">",'~'.expand("<slnum>"))
 
@@ -4936,6 +4869,7 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
 "  else " Decho
 "   call Decho("skipping option restore (dorestore==0): hidden=".&hidden." bufhidden=".&bufhidden." mod=".&mod,'~'.expand("<slnum>"))
   endif
+  call s:RestorePosn(s:netrw_nbcd)
   if dolockout && dorestore
 "   call Decho("restore: filewritable(dirname<".dirname.">)=".filewritable(dirname),'~'.expand("<slnum>"))
    if filewritable(dirname)
@@ -4969,6 +4903,10 @@ fun! s:NetrwBrowseUpDir(islocal)
    " directories.
 "   call Dret("s:NetrwBrowseUpDir : cursor not in file area")
    return
+  endif
+
+  if !exists("w:netrw_liststyle") || w:netrw_liststyle != s:TREELIST
+   call s:SavePosn(s:netrw_nbcd)
   endif
 
   norm! 0
@@ -5010,7 +4948,9 @@ fun! s:NetrwBrowseUpDir(islocal)
    else
     call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,'../'))
    endif
-   if exists("w:netrw_bannercnt")
+   if has_key(s:netrw_nbcd,bufnr("%"))
+    call s:RestorePosn(s:netrw_nbcd)
+   elseif exists("w:netrw_bannercnt")
 "    call Decho("moving to line#".w:netrw_bannercnt,'~'.expand("<slnum>"))
     exe w:netrw_bannercnt
    else
@@ -5106,17 +5046,20 @@ fun! netrw#BrowseX(fname,remote)
 "  call Decho("fname<".fname.">",'~'.expand("<slnum>"))
 "  call Decho("exten<".exten."> "."netrwFileHandlers#NFH_".exten."():exists=".exists("*netrwFileHandlers#NFH_".exten),'~'.expand("<slnum>"))
 
-  " set up redirection
-  if &srr =~ "%s"
-   if (has("win32") || has("win95") || has("win64") || has("win16"))
-    let redir= substitute(&srr,"%s","nul","")
+  " set up redirection (avoids browser messages)
+  " by default, g:netrw_suppress_gx_mesg is true
+  if g:netrw_suppress_gx_mesg
+   if &srr =~ "%s"
+    if (has("win32") || has("win95") || has("win64") || has("win16"))
+     let redir= substitute(&srr,"%s","nul","")
+    else
+     let redir= substitute(&srr,"%s","/dev/null","")
+    endif
+   elseif (has("win32") || has("win95") || has("win64") || has("win16"))
+    let redir= &srr . "nul"
    else
-    let redir= substitute(&srr,"%s","/dev/null","")
+    let redir= &srr . "/dev/null"
    endif
-  elseif (has("win32") || has("win95") || has("win64") || has("win16"))
-   let redir= &srr . "nul"
-  else
-   let redir= &srr . "/dev/null"
   endif
 "  call Decho("set up redirection: redir{".redir."} srr{".&srr."}",'~'.expand("<slnum>"))
 
@@ -5377,8 +5320,12 @@ endfun
 
 " ---------------------------------------------------------------------
 " s:NetrwGlob: does glob() if local, remote listing otherwise {{{2
-fun! s:NetrwGlob(direntry,expr)
-"  call Dfunc("s:NetrwGlob(direntry<".a:direntry."> expr<".a:expr.">)")
+"     direntry: this is the name of the directory.  Will be fnameescape'd to prevent wildcard handling by glob()
+"     expr    : this is the expression to follow the directory.  Will use s:ComposePath()
+"     pare    =1: remove the current directory from the resulting glob() filelist
+"             =0: leave  the current directory   in the resulting glob() filelist
+fun! s:NetrwGlob(direntry,expr,pare)
+"  call Dfunc("s:NetrwGlob(direntry<".a:direntry."> expr<".a:expr."> pare=".a:pare.")")
   if netrw#CheckIfRemote()
    keepalt 1sp
    keepalt enew
@@ -5393,9 +5340,16 @@ fun! s:NetrwGlob(direntry,expr)
     let filelist= w:netrw_treedict[a:direntry]
    endif
    let w:netrw_liststyle= keep_liststyle
+  elseif v:version > 704 || (v:version == 704 && has("patch656"))
+   let filelist= glob(s:ComposePath(fnameescape(a:direntry),a:expr),0,1,1)
+   if a:pare
+    let filelist= map(filelist,'substitute(v:val, "^.*/", "", "")')
+   endif
   else
-   let filelist= glob(s:ComposePath(a:direntry,a:expr),0,1,1)
-   let filelist= map(filelist,'substitute(v:val, "^.*/", "", "")')
+   let filelist= glob(s:ComposePath(fnameescape(a:direntry),a:expr),0,1)
+   if a:pare
+    let filelist= map(filelist,'substitute(v:val, "^.*/", "", "")')
+   endif
   endif
 "  call Dret("s:NetrwGlob ".string(filelist))
   return filelist
@@ -6087,7 +6041,7 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <nowait> qf	:<c-u>call <SID>NetrwFileInfo(1,<SID>NetrwGetWord())<cr>
    nnoremap <buffer> <silent> <nowait> qF	:<c-u>call <SID>NetrwMarkFileQFEL(1,getqflist())<cr>
    nnoremap <buffer> <silent> <nowait> qL	:<c-u>call <SID>NetrwMarkFileQFEL(1,getloclist(v:count))<cr>
-   nnoremap <buffer> <silent> <nowait> r	:<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~ 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,'./'))<cr>
+   nnoremap <buffer> <silent> <nowait> r	:<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,'./'))<cr>
    nnoremap <buffer> <silent> <nowait> s	:call <SID>NetrwSortStyle(1)<cr>
    nnoremap <buffer> <silent> <nowait> S	:<c-u>call <SID>NetSortSequence(1)<cr>
    nnoremap <buffer> <silent> <nowait> Tb	:<c-u>call <SID>NetrwSetTgt(1,'b',v:count1)<cr>
@@ -6140,7 +6094,7 @@ fun! s:NetrwMaps(islocal)
 "   inoremap <buffer> <silent> <nowait> qf	<c-o>:<c-u>call <SID>NetrwFileInfo(1,<SID>NetrwGetWord())<cr>
 "   inoremap <buffer> <silent> <nowait> qF	:<c-u>call <SID>NetrwMarkFileQFEL(1,getqflist())<cr>
 "   inoremap <buffer> <silent> <nowait> qL	:<c-u>call <SID>NetrwMarkFileQFEL(1,getloclist(v:count))<cr>
-"   inoremap <buffer> <silent> <nowait> r	<c-o>:let g:netrw_sort_direction= (g:netrw_sort_direction =~ 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,'./'))<cr>
+"   inoremap <buffer> <silent> <nowait> r	<c-o>:let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,'./'))<cr>
 "   inoremap <buffer> <silent> <nowait> s	<c-o>:call <SID>NetrwSortStyle(1)<cr>
 "   inoremap <buffer> <silent> <nowait> S	<c-o>:call <SID>NetSortSequence(1)<cr>
 "   inoremap <buffer> <silent> <nowait> t	<c-o>:call <SID>NetrwSplit(4)<cr>
@@ -6261,7 +6215,7 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <nowait> qf	:<c-u>call <SID>NetrwFileInfo(0,<SID>NetrwGetWord())<cr>
    nnoremap <buffer> <silent> <nowait> qF	:<c-u>call <SID>NetrwMarkFileQFEL(0,getqflist())<cr>
    nnoremap <buffer> <silent> <nowait> qL	:<c-u>call <SID>NetrwMarkFileQFEL(0,getloclist(v:count))<cr>
-   nnoremap <buffer> <silent> <nowait> r	:<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~ 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,'./'))<cr>
+   nnoremap <buffer> <silent> <nowait> r	:<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,'./'))<cr>
    nnoremap <buffer> <silent> <nowait> s	:call <SID>NetrwSortStyle(0)<cr>
    nnoremap <buffer> <silent> <nowait> S	:<c-u>call <SID>NetSortSequence(0)<cr>
    nnoremap <buffer> <silent> <nowait> Tb	:<c-u>call <SID>NetrwSetTgt(0,'b',v:count1)<cr>
@@ -6311,7 +6265,7 @@ fun! s:NetrwMaps(islocal)
 "   inoremap <buffer> <silent> <nowait> qf	<c-o>:<c-u>call <SID>NetrwFileInfo(0,<SID>NetrwGetWord())<cr>
 "   inoremap <buffer> <silent> <nowait> qF	:<c-u>call <SID>NetrwMarkFileQFEL(0,getqflist())<cr>
 "   inoremap <buffer> <silent> <nowait> qL	:<c-u>call <SID>NetrwMarkFileQFEL(0,getloclist(v:count))<cr>
-"   inoremap <buffer> <silent> <nowait> r		<c-o>:let g:netrw_sort_direction= (g:netrw_sort_direction =~ 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,'./'))<cr>
+"   inoremap <buffer> <silent> <nowait> r		<c-o>:let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,'./'))<cr>
 "   inoremap <buffer> <silent> <nowait> s		<c-o>:call <SID>NetrwSortStyle(0)<cr>
 "   inoremap <buffer> <silent> <nowait> S		<c-o>:call <SID>NetSortSequence(0)<cr>
 "   inoremap <buffer> <silent> <nowait> t		<c-o>:call <SID>NetrwSplit(1)<cr>
@@ -6415,10 +6369,10 @@ fun! s:NetrwMarkFiles(islocal,...)
   let i      = 1
   while i <= a:0
    if a:islocal
-    if v:version == 704 && has("patch656")
-     let mffiles= glob(a:{i},0,1,1)
+    if v:version > 704 || (v:version == 704 && has("patch656"))
+     let mffiles= glob(fnameescape(a:{i}),0,1,1)
     else
-     let mffiles= glob(a:{i},0,1)
+     let mffiles= glob(fnameescape(a:{i}),0,1)
     endif
    else
     let mffiles= [a:{i}]
@@ -6894,6 +6848,8 @@ fun! s:NetrwMarkFileCopy(islocal,...)
   " cleanup
   " -------
 "  call Decho("cleanup",'~'.expand("<slnum>"))
+  " remove markings from local buffer
+  call s:NetrwUnmarkList(curbufnr,curdir)                   " remove markings from local buffer
 "  call Decho(" g:netrw_fastbrowse  =".g:netrw_fastbrowse,'~'.expand("<slnum>"))
 "  call Decho(" s:netrwmftgt        =".s:netrwmftgt,'~'.expand("<slnum>"))
 "  call Decho(" s:netrwmftgt_islocal=".s:netrwmftgt_islocal,'~'.expand("<slnum>"))
@@ -7373,7 +7329,7 @@ fun! s:NetrwMarkFileGrep(islocal)
   if exists("nonisi")
    " original, user-supplied pattern did not begin with a character from isident
 "   call Decho("looking for trailing nonisi<".nonisi."> followed by a j, gj, or jg",'~'.expand("<slnum>"))
-   if pat =~ nonisi.'j$\|'.nonisi.'gj$\|'.nonisi.'jg$'
+   if pat =~# nonisi.'j$\|'.nonisi.'gj$\|'.nonisi.'jg$'
     call s:NetrwMarkFileQFEL(a:islocal,getqflist())
    endif
   endif
@@ -7571,7 +7527,7 @@ fun! s:NetrwMarkFileRegexp(islocal)
    " get the matching list of files using local glob()
 "   call Decho("handle local regexp",'~'.expand("<slnum>"))
    let dirname = escape(b:netrw_curdir,g:netrw_glob_escape)
-   if v:version == 704 && has("patch656")
+   if v:version > 704 || (v:version == 704 && has("patch656"))
     let files   = glob(s:ComposePath(dirname,regexp),0,0,1)
    else
     let files   = glob(s:ComposePath(dirname,regexp),0,0)
@@ -7788,7 +7744,7 @@ fun! s:NetrwMarkFileTgt(islocal)
   " need to do refresh so that the banner will be updated
   "  s:LocalBrowseRefresh handles all local-browsing buffers when not fast browsing
   if g:netrw_fastbrowse <= 1
-"   call Decho("g:netrw_fastbrowse=".g:netrw_fastbrowse.", so refreshing all local netrw buffers")
+"   call Decho("g:netrw_fastbrowse=".g:netrw_fastbrowse.", so refreshing all local netrw buffers",'~'.expand("<slnum>"))
    call s:LocalBrowseRefresh()
   endif
 "  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
@@ -7821,10 +7777,10 @@ fun! s:NetrwGetCurdir(islocal)
 "   call Decho("set b:netrw_curdir<".b:netrw_curdir."> (used getcwd)",'~'.expand("<slnum>"))
   endif
 
-"  call Decho("b:netrw_curdir<".b:netrw_curdir."> ".((b:netrw_curdir !~ '\<\a\{3,}://')? "does not match" : "matches")." url pattern")
+"  call Decho("b:netrw_curdir<".b:netrw_curdir."> ".((b:netrw_curdir !~ '\<\a\{3,}://')? "does not match" : "matches")." url pattern",'~'.expand("<slnum>"))
   if b:netrw_curdir !~ '\<\a\{3,}://'
    let curdir= b:netrw_curdir
-"   call Decho("g:netrw_keepdir=".g:netrw_keepdir)
+"   call Decho("g:netrw_keepdir=".g:netrw_keepdir,'~'.expand("<slnum>"))
    if g:netrw_keepdir == 0
     call s:NetrwLcd(curdir)
    endif
@@ -8125,7 +8081,7 @@ fun! s:NetrwMenu(domenu)
    elseif !a:domenu
     let s:netrwcnt = 0
     let curwin     = winnr()
-    windo if getline(2) =~ "Netrw" | let s:netrwcnt= s:netrwcnt + 1 | endif
+    windo if getline(2) =~# "Netrw" | let s:netrwcnt= s:netrwcnt + 1 | endif
     exe curwin."wincmd w"
 
     if s:netrwcnt <= 1
@@ -8708,7 +8664,7 @@ fun! s:NetrwSortStyle(islocal)
   let svpos= winsaveview()
 "  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
 
-  let g:netrw_sort_by= (g:netrw_sort_by =~ '^n')? 'time' : (g:netrw_sort_by =~ '^t')? 'size' : (g:netrw_sort_by =~ '^siz')? 'exten' : 'name'
+  let g:netrw_sort_by= (g:netrw_sort_by =~# '^n')? 'time' : (g:netrw_sort_by =~# '^t')? 'size' : (g:netrw_sort_by =~# '^siz')? 'exten' : 'name'
   NetrwKeepj norm! 0
   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
 "  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
@@ -8811,7 +8767,6 @@ fun! s:NetrwSplit(mode)
    let s:didsplit= 1
    NetrwKeepj call s:RestoreWinVars()
    NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord()))
-   "call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord()))
    unlet s:didsplit
 
   else
@@ -8890,9 +8845,9 @@ endfun
 " (full path directory with trailing slash returned)
 fun! s:NetrwTreeDir(islocal)
 "  call Dfunc("s:NetrwTreeDir(islocal=".a:islocal.") getline(".line(".").")"."<".getline('.')."> b:netrw_curdir<".b:netrw_curdir."> tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> ft=".&ft)
-"  call Decho("g:netrw_keepdir  =".(exists("g:netrw_keepdir")?   g:netrw_keepdir   : 'n/a'))
-"  call Decho("w:netrw_liststyle=".(exists("w:netrw_liststyle")? w:netrw_liststyle : 'n/a'))
-"  call Decho("w:netrw_treetop  =".(exists("w:netrw_treetop")?   w:netrw_treetop   : 'n/a'))
+"  call Decho("g:netrw_keepdir  =".(exists("g:netrw_keepdir")?   g:netrw_keepdir   : 'n/a'),'~'.expand("<slnum>"))
+"  call Decho("w:netrw_liststyle=".(exists("w:netrw_liststyle")? w:netrw_liststyle : 'n/a'),'~'.expand("<slnum>"))
+"  call Decho("w:netrw_treetop  =".(exists("w:netrw_treetop")?   w:netrw_treetop   : 'n/a'),'~'.expand("<slnum>"))
 
   if exists("s:treedir")
    " s:NetrwPrevWinOpen opens a "previous" window -- and thus needs to and does call s:NetrwTreeDir early
@@ -8933,7 +8888,7 @@ fun! s:NetrwTreeDir(islocal)
    " detect user attempting to close treeroot
 "   call Decho("check if user is attempting to close treeroot",'~'.expand("<slnum>"))
 "   call Decho(".win#".winnr()." buf#".bufnr("%")."<".bufname("%").">",'~'.expand("<slnum>"))
-"   call Decho(".getline(".line(".").")<".getline('.').'> '.((getline('.') =~ '^'.s:treedepthstring)? '=~' : '!~').' ^'.s:treedepthstring,'~'.expand("<slnum>"))
+"   call Decho(".getline(".line(".").")<".getline('.').'> '.((getline('.') =~# '^'.s:treedepthstring)? '=~#' : '!~').' ^'.s:treedepthstring,'~'.expand("<slnum>"))
    if curline !~ '^'.s:treedepthstring && getline('.') != '..'
 "    call Decho(".user may have attempted to close treeroot",'~'.expand("<slnum>"))
     " now force a refresh
@@ -9040,24 +8995,24 @@ fun! s:NetrwRefreshTreeDict(dir)
    if entry =~ '/$' && has_key(w:netrw_treedict,direntry)
 "    call Decho("<".direntry."> is a key in treedict - display subtree for it",'~'.expand("<slnum>"))
     NetrwKeepj call s:NetrwRefreshTreeDict(direntry)
-    let liststar                   = s:NetrwGlob(direntry,'*')
-    let listdotstar                = s:NetrwGlob(direntry,'.*')
+    let liststar                   = s:NetrwGlob(direntry,'*',1)
+    let listdotstar                = s:NetrwGlob(direntry,'.*',1)
     let w:netrw_treedict[direntry] = liststar + listdotstar
 "    call Decho("updating w:netrw_treedict[".direntry.']='.string(w:netrw_treedict[direntry]),'~'.expand("<slnum>"))
 
    elseif entry =~ '/$' && has_key(w:netrw_treedict,direntry.'/')
 "    call Decho("<".direntry."/> is a key in treedict - display subtree for it",'~'.expand("<slnum>"))
     NetrwKeepj call s:NetrwRefreshTreeDict(direntry.'/')
-    let liststar   = s:NetrwGlob(direntry.'/','*')
-    let listdotstar= s:NetrwGlob(direntry.'/','.*')
+    let liststar   = s:NetrwGlob(direntry.'/','*',1)
+    let listdotstar= s:NetrwGlob(direntry.'/','.*',1)
     let w:netrw_treedict[direntry]= liststar + listdotstar
 "    call Decho("updating w:netrw_treedict[".direntry.']='.string(w:netrw_treedict[direntry]),'~'.expand("<slnum>"))
 
    elseif entry =~ '@$' && has_key(w:netrw_treedict,direntry.'@')
 "    call Decho("<".direntry."/> is a key in treedict - display subtree for it",'~'.expand("<slnum>"))
     NetrwKeepj call s:NetrwRefreshTreeDict(direntry.'/')
-    let liststar   = s:NetrwGlob(direntry.'/','*')
-    let listdotstar= s:NetrwGlob(direntry.'/','.*')
+    let liststar   = s:NetrwGlob(direntry.'/','*',1)
+    let listdotstar= s:NetrwGlob(direntry.'/','.*',1)
 "    call Decho("updating w:netrw_treedict[".direntry.']='.string(w:netrw_treedict[direntry]),'~'.expand("<slnum>"))
 
    else
@@ -9315,14 +9270,14 @@ fun! s:PerformListing(islocal)
 "  call Decho("tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol()." line($)=".line("$"),'~'.expand("<slnum>"))
 
   let sortby= g:netrw_sort_by
-  if g:netrw_sort_direction =~ "^r"
+  if g:netrw_sort_direction =~# "^r"
    let sortby= sortby." reversed"
   endif
 
   " Sorted by... {{{3
   if g:netrw_banner
 "   call Decho("--handle specified sorting: g:netrw_sort_by<".g:netrw_sort_by.">",'~'.expand("<slnum>"))
-   if g:netrw_sort_by =~ "^n"
+   if g:netrw_sort_by =~# "^n"
 "   call Decho("directories will be sorted by name",'~'.expand("<slnum>"))
     " sorted by name
     NetrwKeepj put ='\"   Sorted by      '.sortby
@@ -9419,13 +9374,13 @@ fun! s:PerformListing(islocal)
    if !g:netrw_banner || line("$") >= w:netrw_bannercnt
 "    call Decho("manipulate directory listing (sort) : g:netrw_sort_by<".g:netrw_sort_by.">",'~'.expand("<slnum>"))
 
-    if g:netrw_sort_by =~ "^n"
+    if g:netrw_sort_by =~# "^n"
      " sort by name
      NetrwKeepj call s:NetrwSetSort()
 
      if !g:netrw_banner || w:netrw_bannercnt < line("$")
 "      call Decho("g:netrw_sort_direction=".g:netrw_sort_direction." (bannercnt=".w:netrw_bannercnt.")",'~'.expand("<slnum>"))
-      if g:netrw_sort_direction =~ 'n'
+      if g:netrw_sort_direction =~# 'n'
        " normal direction sorting
        exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$sort'.' '.g:netrw_sort_options
       else
@@ -9438,7 +9393,7 @@ fun! s:PerformListing(islocal)
      exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^\d\{3}'.g:netrw_sepchr.'//e'
      NetrwKeepj call histdel("/",-1)
 
-    elseif g:netrw_sort_by =~ "^ext"
+    elseif g:netrw_sort_by =~# "^ext"
      " sort by extension
      exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g+/+s/^/001'.g:netrw_sepchr.'/'
      NetrwKeepj call histdel("/",-1)
@@ -9448,7 +9403,7 @@ fun! s:PerformListing(islocal)
      NetrwKeepj call histdel("/",-1)
      if !g:netrw_banner || w:netrw_bannercnt < line("$")
 "      call Decho("g:netrw_sort_direction=".g:netrw_sort_direction." (bannercnt=".w:netrw_bannercnt.")",'~'.expand("<slnum>"))
-      if g:netrw_sort_direction =~ 'n'
+      if g:netrw_sort_direction =~# 'n'
        " normal direction sorting
        exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$sort'.' '.g:netrw_sort_options
       else
@@ -9462,7 +9417,7 @@ fun! s:PerformListing(islocal)
     elseif a:islocal
      if !g:netrw_banner || w:netrw_bannercnt < line("$")
 "      call Decho("g:netrw_sort_direction=".g:netrw_sort_direction,'~'.expand("<slnum>"))
-      if g:netrw_sort_direction =~ 'n'
+      if g:netrw_sort_direction =~# 'n'
 "       call Decho('exe sil NetrwKeepj '.w:netrw_bannercnt.',$sort','~'.expand("<slnum>"))
        exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$sort'.' '.g:netrw_sort_options
       else
@@ -9474,7 +9429,7 @@ fun! s:PerformListing(islocal)
      endif
     endif
 
-   elseif g:netrw_sort_direction =~ 'r'
+   elseif g:netrw_sort_direction =~# 'r'
 "    call Decho('(s:PerformListing) reverse the sorted listing','~'.expand("<slnum>"))
     if !g:netrw_banner || w:netrw_bannercnt < line('$')
      exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$g/^/m '.w:netrw_bannercnt
@@ -9790,9 +9745,9 @@ fun! s:NetrwRemoteListing()
 "   call Decho("use ftp to get remote file listing",'~'.expand("<slnum>"))
    let s:method  = "ftp"
    let listcmd = g:netrw_ftp_list_cmd
-   if g:netrw_sort_by =~ '^t'
+   if g:netrw_sort_by =~# '^t'
     let listcmd= g:netrw_ftp_timelist_cmd
-   elseif g:netrw_sort_by =~ '^s'
+   elseif g:netrw_sort_by =~# '^s'
     let listcmd= g:netrw_ftp_sizelist_cmd
    endif
 "   call Decho("listcmd<".listcmd."> (using g:netrw_ftp_list_cmd)",'~'.expand("<slnum>"))
@@ -9899,7 +9854,7 @@ fun! s:NetrwRemoteListing()
    if s:method == "ftp"
     " cleanup
     exe "sil! NetrwKeepj ".w:netrw_bannercnt
-    while getline('.') =~ g:netrw_ftp_browse_reject
+    while getline('.') =~# g:netrw_ftp_browse_reject
      sil! NetrwKeepj d
     endwhile
     " if there's no ../ listed, then put ../ in
@@ -9952,9 +9907,9 @@ fun! s:NetrwRemoteRm(usrhost,path) range
 "   call Decho("remove all marked files with bufnr#".bufnr("%"),'~'.expand("<slnum>"))
    for fname in s:netrwmarkfilelist_{bufnr("%")}
     let ok= s:NetrwRemoteRmFile(a:path,fname,all)
-    if ok =~ 'q\%[uit]'
+    if ok =~# 'q\%[uit]'
      break
-    elseif ok =~ 'a\%[ll]'
+    elseif ok =~# 'a\%[ll]'
      let all= 1
     endif
    endfor
@@ -9973,9 +9928,9 @@ fun! s:NetrwRemoteRm(usrhost,path) range
    while ctr <= a:lastline
     exe "NetrwKeepj ".ctr
     let ok= s:NetrwRemoteRmFile(a:path,s:NetrwGetWord(),all)
-    if ok =~ 'q\%[uit]'
+    if ok =~# 'q\%[uit]'
      break
-    elseif ok =~ 'a\%[ll]'
+    elseif ok =~# 'a\%[ll]'
      let all= 1
     endif
     let ctr= ctr + 1
@@ -10014,12 +9969,12 @@ fun! s:NetrwRemoteRmFile(path,rmfile,all)
      let ok="no"
     endif
     let ok= substitute(ok,'\[{y(es)},n(o),a(ll),q(uit)]\s*','','e')
-    if ok =~ 'a\%[ll]'
+    if ok =~# 'a\%[ll]'
      let all= 1
     endif
    endif
 
-   if all || ok =~ 'y\%[es]' || ok == ""
+   if all || ok =~# 'y\%[es]' || ok == ""
 "    call Decho("case all=".all." or ok<".ok.">".(exists("w:netrw_method")? ': netrw_method='.w:netrw_method : ""),'~'.expand("<slnum>"))
     if exists("w:netrw_method") && (w:netrw_method == 2 || w:netrw_method == 3)
 "     call Decho("case ftp:",'~'.expand("<slnum>"))
@@ -10054,13 +10009,13 @@ fun! s:NetrwRemoteRmFile(path,rmfile,all)
        else
         call netrw#ErrorMsg(s:WARNING,"cmd<".netrw_rm_cmd."> failed",60)
        endif
-      else if ret != 0
+      elseif ret != 0
        call netrw#ErrorMsg(s:WARNING,"cmd<".netrw_rm_cmd."> failed",60)
       endif
 "      call Decho("returned=".ret." errcode=".v:shell_error,'~'.expand("<slnum>"))
      endif
     endif
-   elseif ok =~ 'q\%[uit]'
+   elseif ok =~# 'q\%[uit]'
 "    call Decho("ok==".ok,'~'.expand("<slnum>"))
    endif
 
@@ -10075,12 +10030,12 @@ fun! s:NetrwRemoteRmFile(path,rmfile,all)
      let ok="no"
     endif
     let ok= substitute(ok,'\[{y(es)},n(o),a(ll),q(uit)]\s*','','e')
-    if ok =~ 'a\%[ll]'
+    if ok =~# 'a\%[ll]'
      let all= 1
     endif
    endif
 
-   if all || ok =~ 'y\%[es]' || ok == ""
+   if all || ok =~# 'y\%[es]' || ok == ""
     if exists("w:netrw_method") && (w:netrw_method == 2 || w:netrw_method == 3)
      NetrwKeepj call s:NetrwRemoteFtpCmd(a:path,"rmdir ".a:rmfile)
     else
@@ -10103,7 +10058,7 @@ fun! s:NetrwRemoteRmFile(path,rmfile,all)
      endif
     endif
 
-   elseif ok =~ 'q\%[uit]'
+   elseif ok =~# 'q\%[uit]'
 "    call Decho("ok==".ok,'~'.expand("<slnum>"))
    endif
   endif
@@ -10257,7 +10212,7 @@ fun! netrw#LocalBrowseCheck(dirname)
   " would hit when re-entering netrw windows, creating unexpected
   " refreshes (and would do so in the middle of NetrwSaveOptions(), too)
 "  call Dfunc("netrw#LocalBrowseCheck(dirname<".a:dirname.">")
-"  call Decho("isdir<".a:dirname.">=".isdirectory(s:NetrwFile(a:dirname)).((exists("s:treeforceredraw")? " treeforceredraw" : "")).expand("<slnum>"))
+"  call Decho("isdir<".a:dirname."> =".isdirectory(s:NetrwFile(a:dirname)).((exists("s:treeforceredraw")? " treeforceredraw" : "")).'~'.expand("<slnum>"))
 "  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo,'~'.expand("<slnum>"))
 "  call Dredir("ls!","ls!")
 "  call Decho("tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol(),'~'.expand("<slnum>"))
@@ -10281,7 +10236,6 @@ fun! netrw#LocalBrowseCheck(dirname)
     unlet s:treeforceredraw
     sil! NetrwKeepj keepalt call s:NetrwBrowse(1,a:dirname)
    endif
-
 "   call Decho("tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol(),'~'.expand("<slnum>"))
 "   call Dret("netrw#LocalBrowseCheck")
    return
@@ -10361,7 +10315,7 @@ fun! s:LocalBrowseRefresh()
     " refresh any netrw buffer
 "    call Decho("refresh buf#".ibuf.'-> win#'.bufwinnr(ibuf),'~'.expand("<slnum>"))
     exe bufwinnr(ibuf)."wincmd w"
-    if getline(".") =~ 'Quick Help'
+    if getline(".") =~# 'Quick Help'
      " decrement g:netrw_quickhelp to prevent refresh from changing g:netrw_quickhelp
      " (counteracts s:NetrwBrowseChgDir()'s incrementing)
      let g:netrw_quickhelp= g:netrw_quickhelp - 1
@@ -10467,15 +10421,8 @@ fun! s:LocalListing()
   " get the list of files contained in the current directory
   let dirname    = b:netrw_curdir
   let dirnamelen = strlen(b:netrw_curdir)
-  if v:version == 704 && has("patch656")
-"   call Decho("using glob with patch656",'~'.expand("<slnum>"))
-   let filelist   = glob(s:ComposePath(dirname,"*"),0,1,1)
-   let filelist   = filelist + glob(s:ComposePath(dirname,".*"),0,1,1)
-  else
-"   call Decho("using glob without patch656",'~'.expand("<slnum>"))
-   let filelist   = glob(s:ComposePath(dirname,"*"),0,1)
-   let filelist   = filelist + glob(s:ComposePath(dirname,".*"),0,1)
-  endif
+  let filelist   = s:NetrwGlob(dirname,"*",0)
+  let filelist   = filelist + s:NetrwGlob(dirname,".*",0)
 "  call Decho("filelist=".string(filelist),'~'.expand("<slnum>"))
 
   if g:netrw_cygwin == 0 && (has("win32") || has("win95") || has("win64") || has("win16"))
@@ -10487,9 +10434,9 @@ fun! s:LocalListing()
 "   call Decho("filelist=".string(filelist),'~'.expand("<slnum>"))
   endif
 
-"  call Decho("before while: dirname<".dirname.">",'~'.expand("<slnum>"))
+"  call Decho("before while: dirname   <".dirname.">",'~'.expand("<slnum>"))
 "  call Decho("before while: dirnamelen<".dirnamelen.">",'~'.expand("<slnum>"))
-"  call Decho("before while: filelist=".string(filelist),'~'.expand("<slnum>"))
+"  call Decho("before while: filelist  =".string(filelist),'~'.expand("<slnum>"))
 
   if get(g:, 'netrw_dynamic_maxfilenamelen', 0)
    let filelistcopy           = map(deepcopy(filelist),'fnamemodify(v:val, ":t")')
@@ -10559,15 +10506,15 @@ fun! s:LocalListing()
 
    if w:netrw_liststyle == s:LONGLIST
     let sz   = getfsize(filename)
-    if g:netrw_sizestyle =~ "[hH]"
+    if g:netrw_sizestyle =~# "[hH]"
      let sz= s:NetrwHumanReadable(sz)
     endif
     let fsz  = strpart("               ",1,15-strlen(sz)).sz
     let pfile= pfile."\t".fsz." ".strftime(g:netrw_timefmt,getftime(filename))
-"    call Decho("sz=".sz." fsz=".fsz,'~'.expand("<slnum>"))
+"    call Decho("longlist support: sz=".sz." fsz=".fsz,'~'.expand("<slnum>"))
    endif
 
-   if     g:netrw_sort_by =~ "^t"
+   if     g:netrw_sort_by =~# "^t"
     " sort by time (handles time up to 1 quintillion seconds, US)
 "    call Decho("getftime(".filename.")=".getftime(filename),'~'.expand("<slnum>"))
     let t  = getftime(filename)
@@ -10580,7 +10527,7 @@ fun! s:LocalListing()
     " sort by size (handles file sizes up to 1 quintillion bytes, US)
 "    call Decho("getfsize(".filename.")=".getfsize(filename),'~'.expand("<slnum>"))
     let sz   = getfsize(filename)
-    if g:netrw_sizestyle =~ "[hH]"
+    if g:netrw_sizestyle =~# "[hH]"
      let sz= s:NetrwHumanReadable(sz)
     endif
     let fsz  = strpart("000000000000000000",1,18-strlen(sz)).sz
@@ -10733,9 +10680,9 @@ fun! s:NetrwLocalRm(path) range
 "   call Decho("remove all marked files",'~'.expand("<slnum>"))
    for fname in s:netrwmarkfilelist_{bufnr("%")}
     let ok= s:NetrwLocalRmFile(a:path,fname,all)
-    if ok =~ 'q\%[uit]' || ok == "no"
+    if ok =~# 'q\%[uit]' || ok == "no"
      break
-    elseif ok =~ 'a\%[ll]'
+    elseif ok =~# 'a\%[ll]'
      let all= 1
     endif
    endfor
@@ -10762,9 +10709,9 @@ fun! s:NetrwLocalRm(path) range
      continue
     endif
     let ok= s:NetrwLocalRmFile(a:path,curword,all)
-    if ok =~ 'q\%[uit]' || ok == "no"
+    if ok =~# 'q\%[uit]' || ok == "no"
      break
-    elseif ok =~ 'a\%[ll]'
+    elseif ok =~# 'a\%[ll]'
      let all= 1
     endif
     let ctr= ctr + 1
@@ -10811,12 +10758,12 @@ fun! s:NetrwLocalRmFile(path,fname,all)
 "    call Decho("response: ok<".ok.">",'~'.expand("<slnum>"))
     let ok= substitute(ok,'\[{y(es)},n(o),a(ll),q(uit)]\s*','','e')
 "    call Decho("response: ok<".ok."> (after sub)",'~'.expand("<slnum>"))
-    if ok =~ 'a\%[ll]'
+    if ok =~# 'a\%[ll]'
      let all= 1
     endif
    endif
 
-   if all || ok =~ 'y\%[es]' || ok == ""
+   if all || ok =~# 'y\%[es]' || ok == ""
     let ret= s:NetrwDelete(rmfile)
 "    call Decho("errcode=".v:shell_error." ret=".ret,'~'.expand("<slnum>"))
    endif
@@ -10832,13 +10779,13 @@ fun! s:NetrwLocalRmFile(path,fname,all)
     if ok == ""
      let ok="no"
     endif
-    if ok =~ 'a\%[ll]'
+    if ok =~# 'a\%[ll]'
      let all= 1
     endif
    endif
    let rmfile= substitute(rmfile,'[\/]$','','e')
 
-   if all || ok =~ 'y\%[es]' || ok == ""
+   if all || ok =~# 'y\%[es]' || ok == ""
     if v:version < 704 || !has("patch1109")
 " "    call Decho("1st attempt: system(netrw#WinPath(".g:netrw_localrmdir.') '.s:ShellEscape(rmfile).')','~'.expand("<slnum>"))
      call system(netrw#WinPath(g:netrw_localrmdir).' '.s:ShellEscape(rmfile))
@@ -10879,6 +10826,17 @@ endfun
 " Support Functions: {{{1
 
 " ---------------------------------------------------------------------
+" s:WinNames: COMBAK {{{2
+fun! s:WinNames(id)
+  let curwin= winnr()
+  1wincmd w
+"  call Decho("--- Windows By Name --- #".a:id)
+"  windo call Decho("win#".winnr()."<".expand("%").">")
+"  call Decho("--- --- --- --- --- ---")
+  exe curwin."wincmd w"
+endfun
+
+" ---------------------------------------------------------------------
 " netrw#Access: intended to provide access to variable values for netrw's test suite {{{2
 "   0: marked file list of current buffer
 "   1: marked file target
@@ -10905,8 +10863,6 @@ fun! netrw#Call(funcname,...)
 "  call Dret("netrw#Call")
 endfun
 
-" ------------------------------------------------------------------------
-
 " ---------------------------------------------------------------------
 " netrw#Expose: allows UserMaps and pchk to look at otherwise script-local variables {{{2
 "               I expect this function to be used in
@@ -10914,18 +10870,22 @@ endfun
 "               for example.
 fun! netrw#Expose(varname)
 "   call Dfunc("netrw#Expose(varname<".a:varname.">)")
-  exe "let retval= s:".a:varname
-  if exists("g:netrw_pchk")
-   if type(retval) == 3
-    let retval = copy(retval)
-    let i      = 0
-    while i < len(retval)
-     let retval[i]= substitute(retval[i],expand("$HOME"),'~','')
-     let i        = i + 1
-    endwhile
+  if exists("s:".a:varname)
+   exe "let retval= s:".a:varname
+   if exists("g:netrw_pchk")
+    if type(retval) == 3
+     let retval = copy(retval)
+     let i      = 0
+     while i < len(retval)
+      let retval[i]= substitute(retval[i],expand("$HOME"),'~','')
+      let i        = i + 1
+     endwhile
+    endif
+"     call Dret("netrw#Expose ".string(retval))
+    return string(retval)
    endif
-"    call Dret("netrw#Expose ".string(retval))
-   return string(retval)
+  else
+   let retval= "n/a"
   endif
 
 "  call Dret("netrw#Expose ".string(retval))
@@ -11018,9 +10978,9 @@ fun! s:ComposePath(base,subdir)
 "   call Decho("amiga",'~'.expand("<slnum>"))
    let ec = a:base[s:Strlen(a:base)-1]
    if ec != '/' && ec != ':'
-    let ret = a:base . "/" . a:subdir
+    let ret = a:base."/" . a:subdir
    else
-    let ret = a:base . a:subdir
+    let ret = a:base.a:subdir
    endif
 
   elseif a:subdir =~ '^\a:[/\\][^/\\]' && (has("win32") || has("win95") || has("win64") || has("win16"))
@@ -11248,10 +11208,10 @@ fun! s:NetrwBMShow()
   redir END
   let bmshowlist = split(bmshowraw,'\n')
   if bmshowlist != []
-   let bmshowfuncs= filter(bmshowlist,'v:val =~ "<SNR>\\d\\+_BMShow()"')
+   let bmshowfuncs= filter(bmshowlist,'v:val =~# "<SNR>\\d\\+_BMShow()"')
    if bmshowfuncs != []
     let bmshowfunc = substitute(bmshowfuncs[0],'^.*:\(call.*BMShow()\).*$','\1','')
-    if bmshowfunc =~ '^call.*BMShow()'
+    if bmshowfunc =~# '^call.*BMShow()'
      exe "sil! NetrwKeepj ".bmshowfunc
     endif
    endif
@@ -11395,11 +11355,12 @@ fun! s:NetrwEnew(...)
 "  call Decho("generate a buffer with NetrwKeepj keepalt enew!",'~'.expand("<slnum>"))
   " when tree listing uses file TreeListing... a new buffer is made.
   " Want the old buffer to be unlisted.
-  setl nobl
+  " COMBAK: this causes a problem, see P43
+"  setl nobl
   let netrw_keepdiff= &l:diff
   noswapfile NetrwKeepj keepalt enew!
   let &l:diff= netrw_keepdiff
-"  call Decho("bufnr($)=".bufnr("$")." winnr($)=".winnr("$"),'~'.expand("<slnum>"))
+"  call Decho("bufnr($)=".bufnr("$")."<".bufname(bufnr("$"))."> winnr($)=".winnr("$"),'~'.expand("<slnum>"))
   NetrwKeepj call s:NetrwOptionSave("w:")
 
   " copy function-local-variables to buffer variable equivalents
@@ -11458,8 +11419,8 @@ endfun
 " ---------------------------------------------------------------------
 " s:NetrwInsureWinVars: insure that a netrw buffer has its w: variables in spite of a wincmd v or s {{{2
 fun! s:NetrwInsureWinVars()
-"  call Dfunc("s:NetrwInsureWinVars() win#".winnr())
   if !exists("w:netrw_liststyle")
+"   call Dfunc("s:NetrwInsureWinVars() win#".winnr())
    let curbuf = bufnr("%")
    let curwin = winnr()
    let iwin   = 1
@@ -11479,8 +11440,8 @@ fun! s:NetrwInsureWinVars()
      let w:{k}= winvars[k]
     endfor
    endif
+"   call Dret("s:NetrwInsureWinVars win#".winnr())
   endif
-"  call Dret("s:NetrwInsureWinVars win#".winnr())
 endfun
 
 " ---------------------------------------------------------------------
@@ -11685,7 +11646,7 @@ endfun
 "             s:SetRexDir() sets up <2-leftmouse> maps (if g:netrw_retmap
 "             is true) and a command, :Rexplore, which call this function.
 "
-"             s:nbcd_curpos_{bufnr('%')} is set up by s:NetrwBrowseChgDir()
+"             s:netrw_nbcd is set up by s:NetrwBrowseChgDir()
 "
 "             s:rexposn_BUFNR used to save/restore cursor position
 fun! s:NetrwRexplore(islocal,dirname)
@@ -11766,6 +11727,29 @@ fun! s:SaveBufVars()
 endfun
 
 " ---------------------------------------------------------------------
+" s:SavePosn: saves position associated with current buffer into a dictionary {{{2
+fun! s:SavePosn(posndict)
+"  call Dfunc("s:SavePosn(posndict) curbuf#".bufnr("%")."<".bufname("%").">")
+
+  let a:posndict[bufnr("%")]= winsaveview()
+"  call Decho("saving posn: posndict[".bufnr("%")."]=".string(winsaveview()),'~'.expand("<slnum>"))
+
+"  call Dret("s:SavePosn posndict")
+  return a:posndict
+endfun
+
+" ---------------------------------------------------------------------
+" s:RestorePosn: restores position associated with current buffer using dictionary {{{2
+fun! s:RestorePosn(posndict)
+"  call Dfunc("s:RestorePosn(posndict) curbuf#".bufnr("%")."<".bufname("%").">")
+  if has_key(a:posndict,bufnr("%"))
+   call winrestview(a:posndict[bufnr("%")])
+"   call Decho("restoring posn: posndict[".bufnr("%")."]=".string(a:posndict[bufnr("%")]),'~'.expand("<slnum>"))
+  endif
+"  call Dret("s:RestorePosn")
+endfun
+
+" ---------------------------------------------------------------------
 " s:SaveWinVars: (used by Explore() and NetrwSplit()) {{{2
 fun! s:SaveWinVars()
 "  call Dfunc("s:SaveWinVars() win#".winnr())
@@ -11819,10 +11803,10 @@ fun! s:SetRexDir(islocal,dirname)
   let w:netrw_rexdir         = a:dirname
   let w:netrw_rexlocal       = a:islocal
   let s:rexposn_{bufnr("%")} = winsaveview()
-"  call Decho("setting w:netrw_rexdir  =".w:netrw_rexdir)
-"  call Decho("setting w:netrw_rexlocal=".w:netrw_rexlocal)
+"  call Decho("setting w:netrw_rexdir  =".w:netrw_rexdir,'~'.expand("<slnum>"))
+"  call Decho("setting w:netrw_rexlocal=".w:netrw_rexlocal,'~'.expand("<slnum>"))
 "  call Decho("saving posn to s:rexposn_".bufnr("%")."<".string(s:rexposn_{bufnr("%")}).">",'~'.expand("<slnum>"))
-"  call Decho("setting s:rexposn_".bufnr("%")."<".bufname("%")."> to SavePosn",'~'.expand("<slnum>"))
+"  call Decho("setting s:rexposn_".bufnr("%")."<".bufname("%")."> to ".string(winsaveview()),'~'.expand("<slnum>"))
 "  call Dret("s:SetRexDir : win#".winnr()." ".(a:islocal? "local" : "remote")." dir: ".a:dirname)
 endfun
 
@@ -11956,7 +11940,7 @@ fun! s:TreeListMove(dir)
 "    call Decho("regfile srch back: ".nl,'~'.expand("<slnum>"))
    elseif a:dir == '[]' && nxtline != ''
     NetrwKeepj norm! 0
-"    call Decho('srchpat<'.'^\%('.curindent.'\)\@!'.'>')
+"    call Decho('srchpat<'.'^\%('.curindent.'\)\@!'.'>','~'.expand("<slnum>"))
     let nl = search('^\%('.curindent.'\)\@!','We') " search forwards
     if nl != 0
      NetrwKeepj norm! k

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1,4 +1,4 @@
-*autocmd.txt*   For Vim version 7.4.  Last change: 2016 Mar 26
+*autocmd.txt*   For Vim version 7.4.  Last change: 2016 Apr 20
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -544,6 +544,9 @@ CursorHold			When the user doesn't press a key for the time
 
 							*CursorHoldI*
 CursorHoldI			Just like CursorHold, but in Insert mode.
+				Not triggered when waiting for another key,
+				e.g. after CTRL-V, and not when in CTRL-X mode
+				|insert_expand|.
 
 							*CursorMoved*
 CursorMoved			After the cursor was moved in Normal or Visual

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1,4 +1,4 @@
-*autocmd.txt*   For Vim version 7.4.  Last change: 2016 Apr 20
+*autocmd.txt*   For Vim version 7.4.  Last change: 2016 Jun 09
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1229,6 +1229,8 @@ option will not cause any commands to be executed.
 			argument is present. You probably want to use
 			<nomodeline> for events that are not used when loading
 			a buffer, such as |User|.
+			Processing modelines is also skipped when no
+			matching autocommands were executed.
 
 						*:doautoa* *:doautoall*
 :doautoa[ll] [<nomodeline>] [group] {event} [fname]

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1,4 +1,4 @@
-*change.txt*    For Vim version 7.4.  Last change: 2016 Mar 08
+*change.txt*    For Vim version 7.4.  Last change: 2016 Apr 12
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -813,7 +813,7 @@ Examples: >
   :s/abcde/abc^Mde/		 modifies "abcde"    to "abc", "de" (two lines)
   :s/$/\^M/			 modifies "abcde"    to "abcde^M"
   :s/\w\+/\u\0/g		 modifies "bla bla"  to "Bla Bla"
-  :s/\w\+/\L\u/g		 modifies "BLA bla"  to "Bla Bla"
+  :s/\w\+/\L\u\0/g		 modifies "BLA bla"  to "Bla Bla"
 
 Note: "\L\u" can be used to capitalize the first letter of a word.  This is
 not compatible with Vi and older versions of Vim, where the "\u" would cancel
@@ -1164,7 +1164,7 @@ which does not specify a register.  Additionally you can access it with the
 name '"'.  This means you have to type two double quotes.  Writing to the ""
 register writes to register "0.
 
-2. Numbered registers "0 to "9		*quote_number* *quote0*	*quote1*
+2. Numbered registers "0 to "9		*quote_number* *quote0* *quote1*
 					*quote2* *quote3* *quote4* *quote9*
 Vim fills these registers with text from yank and delete commands.
    Numbered register 0 contains the text from the most recent yank command,

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1152,7 +1152,7 @@ Examples: >
 
 If you want to always use ":confirm", set the 'confirm' option.
 
-			*:browse* *:bro* *E338* *E614* *E615* *E616* *E578*
+			*:browse* *:bro* *E338* *E614* *E615* *E616*
 :bro[wse] {command}	Open a file selection dialog for an argument to
 			{command}.  At present this works for |:e|, |:w|,
 			|:wall|, |:wq|, |:wqall|, |:x|, |:xall|, |:exit|,

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -783,7 +783,7 @@ A |Dictionary| can only be compared with a |Dictionary| and only "equal", "not
 equal" and "is" can be used.  This compares the key/values of the |Dictionary|
 recursively.  Ignoring case means case is ignored when comparing item values.
 
-							*E693* *E694*
+							*E694*
 A |Funcref| can only be compared with a |Funcref| and only "equal" and "not
 equal" can be used.  Case is never ignored.
 
@@ -2174,14 +2174,17 @@ sqrt({expr})			Float	square root of {expr}
 str2float({expr})		Float	convert String to Float
 str2nr({expr} [, {base}])	Number	convert String to Number
 strchars({expr} [, {skipcc}])	Number	character length of the String {expr}
+strcharpart({str}, {start}[, {len}])
+				String	{len} characters of {str} at {start}
 strdisplaywidth({expr} [, {col}]) Number display length of the String {expr}
 strftime({format}[, {time}])	String	time in specified format
+strgetchar({str}, {index})	Number	get char {index} from {str}
 stridx({haystack}, {needle}[, {start}])
 				Number	index of {needle} in {haystack}
 string({expr})			String	String representation of {expr} value
 strlen({expr})			Number	length of the String {expr}
-strpart({src}, {start}[, {len}])
-				String	{len} characters of {src} at {start}
+strpart({str}, {start}[, {len}])
+				String	{len} characters of {str} at {start}
 strridx({haystack}, {needle} [, {start}])
 				Number	last index of {needle} in {haystack}
 strtrans({expr})		String	translate string to make it printable
@@ -2591,7 +2594,9 @@ byteidx({expr}, {nr})					*byteidx()*
 		same: >
 			let s = strpart(str, byteidx(str, 3))
 			echo strpart(s, 0, byteidx(s, 1))
-<		If there are less than {nr} characters -1 is returned.
+<		Also see |strgetchar()| and |strcharpart()|.
+
+		If there are less than {nr} characters -1 is returned.
 		If there are exactly {nr} characters the length of the string
 		in bytes is returned.
 
@@ -3330,6 +3335,10 @@ feedkeys({string} [, {mode}])				*feedkeys()*
 			will behave as if <Esc> is typed, to avoid getting
 			stuck, waiting for a character to be typed before the
 			script continues.
+		'!'	When used with 'x' will not end Insert mode. Can be
+			used in a test when a timer is set to exit Insert mode
+			a little later.  Useful for testing CursorHoldI.
+
 		Return value is always 0.
 
 filereadable({file})					*filereadable()*
@@ -4088,16 +4097,21 @@ getreg([{regname} [, 1 [, {list}]]])			*getreg()*
 		The result is a String, which is the contents of register
 		{regname}.  Example: >
 			:let cliptext = getreg('*')
-<		getreg('=') returns the last evaluated value of the expression
+<		When {regname} was not set the result is a empty string.
+
+		getreg('=') returns the last evaluated value of the expression
 		register.  (For use in maps.)
 		getreg('=', 1) returns the expression itself, so that it can
 		be restored with |setreg()|.  For other registers the extra
 		argument is ignored, thus you can always give it.
-		If {list} is present and non-zero result type is changed to 
-		|List|. Each list item is one text line. Use it if you care
+
+		If {list} is present and non-zero, the result type is changed
+		to |List|. Each list item is one text line. Use it if you care
 		about zero bytes possibly present inside register: without
 		third argument both NLs and zero bytes are represented as NLs
 		(see |NL-used-for-Nul|).
+		When the register was not set an empty list is returned.
+
 		If {regname} is not specified, |v:register| is used.
 
 
@@ -5635,7 +5649,6 @@ pumvisible()						*pumvisible()*
 		This can be used to avoid some things that would remove the
 		popup menu.
 
-							*E860*
 py3eval({expr})						*py3eval()*
 		Evaluate Python expression {expr} and return its result
 		converted to Vim data structures.
@@ -6761,7 +6774,6 @@ strchars({expr} [, {skipcc}])					*strchars()*
 		counted separately.
 		When {skipcc} set to 1, Composing characters are ignored.
 		Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
-
 		
 		{skipcc} is only available after 7.4.755.  For backward
 		compatibility, you can define a wrapper function: >
@@ -6779,6 +6791,13 @@ strchars({expr} [, {skipcc}])					*strchars()*
 		      endfunction
 		    endif
 <
+strcharpart({src}, {start}[, {len}])			*strcharpart()*
+		Like |strpart()| but using character index and length instead
+		of byte index and length.
+		When a character index is used where a character does not
+		exist it is assumed to be one byte.  For example: >
+			strcharpart('abc', -1, 2)
+<		results in 'a'.
 
 strdisplaywidth({expr}[, {col}])			*strdisplaywidth()*
 		The result is a Number, which is the number of display cells
@@ -6811,6 +6830,12 @@ strftime({format} [, {time}])				*strftime()*
 						   Show mod time of file.c.
 <		Not available on all systems.  To check use: >
 			:if exists("*strftime")
+
+strgetchar({str}, {index})				*strgetchar()*
+		Get character {index} from {str}.  This uses a character
+		index, not a byte index.  Composing characters are considered
+		separate characters here.
+		Also see |strcharpart()| and |strchars()|.
 
 stridx({haystack}, {needle} [, {start}])		*stridx()*
 		The result is a Number, which gives the byte index in
@@ -6866,14 +6891,17 @@ strlen({expr})	The result is a Number, which is the length of the String
 strpart({src}, {start}[, {len}])			*strpart()*
 		The result is a String, which is part of {src}, starting from
 		byte {start}, with the byte length {len}.
-		When non-existing bytes are included, this doesn't result in
-		an error, the bytes are simply omitted.
+		To count characters instead of bytes use |strcharpart()|.
+
+		When bytes are selected which do not exist, this doesn't
+		result in an error, the bytes are simply omitted.
 		If {len} is missing, the copy continues from {start} till the
 		end of the {src}. >
 			strpart("abcdefg", 3, 2)    == "de"
 			strpart("abcdefg", -2, 4)   == "ab"
 			strpart("abcdefg", 5, 4)    == "fg"
 			strpart("abcdefg", 3)	    == "defg"
+
 <		Note: To get the first character, {start} must be 0.  For
 		example, to get three bytes under and after the cursor: >
 			strpart(getline("."), col(".") - 1, 3)
@@ -8499,14 +8527,6 @@ This does NOT work: >
 				endfor
 <			Note that reordering the list (e.g., with sort() or
 			reverse()) may have unexpected effects.
-			Note that the type of each list item should be
-			identical to avoid errors for the type of {var}
-			changing.  Unlet the variable at the end of the loop
-			to allow multiple item types: >
-				for item in ["foo", ["bar"]]
-				   echo item
-				   unlet item  " E706 without this
-				endfor
 
 :for [{var1}, {var2}, ...] in {listlist}
 :endfo[r]

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1470,7 +1470,7 @@ v:exception	The value of the exception most recently caught and not
 
 					*v:false* *false-variable*
 v:false		Special value used to put "false" in JSON and msgpack.  See 
-		|json_encode()|.  This value is converted to "false" when used 
+		|json_encode()|.  This value is converted to "v:false" when used 
 		as a String (e.g. in |expr5| with string concatenation 
 		operator) and to zero when used as a Number (e.g. in |expr5| 
 		or |expr7| when used with numeric operators).
@@ -1620,7 +1620,7 @@ v:msgpack_types	Dictionary containing msgpack types used by |msgpackparse()|
 
 					*v:null* *null-variable*
 v:null		Special value used to put "null" in JSON and NIL in msgpack.  
-		See |json_encode()|.  This value is converted to "null" when 
+		See |json_encode()|.  This value is converted to "v:null" when 
 		used as a String (e.g. in |expr5| with string concatenation 
 		operator) and to zero when used as a Number (e.g. in |expr5| 
 		or |expr7| when used with numeric operators).
@@ -1807,7 +1807,7 @@ v:throwpoint	The point where the exception most recently caught and not
 
 					*v:true* *true-variable*
 v:true		Special value used to put "true" in JSON and msgpack.  See 
-		|json_encode()|.  This value is converted to "true" when used 
+		|json_encode()|.  This value is converted to "v:true" when used 
 		as a String (e.g. in |expr5| with string concatenation 
 		operator) and to one when used as a Number (e.g. in |expr5| or 
 		|expr7| when used with numeric operators).

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3534,7 +3534,7 @@ foreground()	Move the Vim window to the foreground.	Useful when sent from
 		{only in the Win32 GUI and console version}
 
 
-				       *function()* *E700* *E922* *E929*
+				       *function()* *E700* *E922* *E923*
 function({name} [, {arglist}] [, {dict}])
 		Return a |Funcref| variable that refers to function {name}.
 		{name} can be a user defined function or an internal function.

--- a/runtime/doc/if_cscop.txt
+++ b/runtime/doc/if_cscop.txt
@@ -96,8 +96,8 @@ command does the same and also splits the window (short: "scs").
 
 The available subcommands are:
 
-			*E563* *E564* *E566* *E568* *E569* *E622* *E623*
-			*E625* *E626* *E609*
+			*E563* *E564* *E566* *E568* *E622* *E623* *E625*
+			*E626* *E609*
     add   : Add a new cscope database/connection.
 
 	USAGE	:cs add {file|dir} [pre-path] [flags]

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -699,7 +699,7 @@ if the `:py3` command is working: >
 	:py3 print("Hello")
 <							*:py3file*
 The `:py3file` command works similar to `:pyfile`.
-							*:py3do* *E863*
+							*:py3do*
 The `:py3do` command works similar to `:pydo`.
 
 							*E880*

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1,4 +1,4 @@
-*index.txt*     For Vim version 7.4.  Last change: 2016 Apr 12
+*index.txt*     For Vim version 7.4.  Last change: 2016 Jun 12
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1152,8 +1152,9 @@ tag	      command	      action ~
 |:chdir|	:chd[ir]	change directory
 |:checkpath|	:che[ckpath]	list included files
 |:checktime|	:checkt[ime]	check timestamp of loaded buffers
-|:clist|	:cl[ist]	list all errors
 |:clast|	:cla[st]	go to the specified error, default last one
+|:clearjumps|	:cle[arjumps]	clear the jump list
+|:clist|	:cl[ist]	list all errors
 |:close|	:clo[se]	close current window
 |:cmap|		:cm[ap]		like ":map" but for Command-line mode
 |:cmapclear|	:cmapc[lear]	clear all mappings for Command-line mode

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1,4 +1,4 @@
-*index.txt*     For Vim version 7.4.  Last change: 2016 Mar 12
+*index.txt*     For Vim version 7.4.  Last change: 2016 Apr 12
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -48,6 +48,7 @@ tag		char		action in Insert mode	~
 |i_CTRL-G_k|	CTRL-G k	line up, to column where inserting started
 |i_CTRL-G_k|	CTRL-G <Up>	line up, to column where inserting started
 |i_CTRL-G_u|	CTRL-G u	start new undoable edit
+|i_CTRL-G_U|	CTRL-G U	don't break undo with next cursor movement
 |i_<BS>|	<BS>		delete character before the cursor
 |i_digraph|	{char1}<BS>{char2}
 				enter digraph (only when 'digraph' option set)
@@ -857,6 +858,7 @@ tag		command	      note action in Visual mode	~
 ------------------------------------------------------------------------------
 |v_CTRL-\_CTRL-N| CTRL-\ CTRL-N	   stop Visual mode
 |v_CTRL-\_CTRL-G| CTRL-\ CTRL-G	   go to mode specified with 'insertmode'
+|v_CTRL-A|	CTRL-A		2  add N to number in highlighted text
 |v_CTRL-C|	CTRL-C		   stop Visual mode
 |v_CTRL-G|	CTRL-G		   toggle between Visual mode and Select mode
 |v_<BS>|	<BS>		2  Select mode: delete highlighted area
@@ -865,6 +867,7 @@ tag		command	      note action in Visual mode	~
 				   command
 |v_CTRL-V|	CTRL-V		   make Visual mode blockwise or stop Visual
 				   mode
+|v_CTRL-X|	CTRL-X		2  subtract N from number in highlighted text
 |v_<Esc>|	<Esc>		   stop Visual mode
 |v_CTRL-]|	CTRL-]		   jump to highlighted tag
 |v_!|		!{filter}	2  filter the highlighted lines through the
@@ -921,6 +924,8 @@ tag		command	      note action in Visual mode	~
 |v_a}|		a}		   same as aB
 |v_c|		c		2  delete highlighted area and start insert
 |v_d|		d		2  delete highlighted area
+|v_g_CTRL-A|	g CTRL-A	2  add N to number in highlighted text
+|v_g_CTRL-X|	g CTRL-X	2  subtract N from number in highlighted text
 |v_gJ|		gJ		2  join the highlighted lines without
 				   inserting spaces
 |v_gq|		gq		2  format the highlighted lines

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1,4 +1,4 @@
-*map.txt*       For Vim version 7.4.  Last change: 2016 Jan 10
+*map.txt*       For Vim version 7.4.  Last change: 2016 Jun 10
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1408,11 +1408,11 @@ The valid escape sequences are
 		expands to nothing.
 						*<mods>*
 	<mods>  The command modifiers, if specified. Otherwise, expands to
-		nothing. Supported modifiers are |aboveleft|, |belowright|,
-		|botright|, |browse|, |confirm|, |hide|, |keepalt|,
-		|keepjumps|, |keepmarks|, |keeppatterns|, |lockmarks|,
-		|noswapfile|, |silent|, |tab|, |topleft|, |verbose|, and
-		|vertical|.
+		nothing. Supported modifiers are |:aboveleft|, |:belowright|,
+		|:botright|, |:browse|, |:confirm|, |:hide|, |:keepalt|,
+		|:keepjumps|, |:keepmarks|, |:keeppatterns|, |:lockmarks|,
+		|:noswapfile|, |:silent|, |:tab|, |:topleft|, |:verbose|, and
+		|:vertical|.
 		Examples: >
 		    command! -nargs=+ -complete=file MyEdit
 				\ for f in expand(<q-args>, 0, 1) |

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1352,7 +1352,7 @@ Possible attributes are:
 Note that -range=N and -count=N are mutually exclusive - only one should be
 specified.
 
-                                                  *E889* *:command-addr*
+                                                  *:command-addr*
 It is possible that the special characters in the range like `.`, `$` or `%`
 which by default correspond to the current line, last line and the whole
 buffer, relate to arguments, (loaded) buffers, windows or tab pages.

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1013,6 +1013,9 @@ CTRL-I			Go to [count] newer cursor position in jump list
 							*:ju* *:jumps*
 :ju[mps]		Print the jump list (not a motion command).
 
+							*:cle* *:clearjumps*
+:cle[arjumps]		Clear the jump list of the current window.
+
 							*jumplist*
 Jumps are remembered in a jump list.  With the CTRL-O and CTRL-I command you
 can go to cursor positions before older jumps, and back again.  Thus you can

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2682,6 +2682,40 @@ A jump table for the options with a short description can be found at |Q_op|.
 	It is not allowed to change text or jump to another window while
 	evaluating 'foldtext' |textlock|.
 
+						*'formatexpr'* *'fex'*
+'formatexpr' 'fex'	string (default "")
+			local to buffer
+			{not available when compiled without the |+eval|
+			feature}
+	Expression which is evaluated to format a range of lines for the |gq|
+	operator or automatic formatting (see 'formatoptions').  When this
+	option is empty 'formatprg' is used.
+
+	The |v:lnum|  variable holds the first line to be formatted.
+	The |v:count| variable holds the number of lines to be formatted.
+	The |v:char|  variable holds the character that is going to be
+		      inserted if the expression is being evaluated due to
+		      automatic formatting.  This can be empty.  Don't insert
+		      it yet!
+
+	Example: >
+		:set formatexpr=mylang#Format()
+<	This will invoke the mylang#Format() function in the
+	autoload/mylang.vim file in 'runtimepath'. |autoload|
+
+	The expression is also evaluated when 'textwidth' is set and adding
+	text beyond that limit.  This happens under the same conditions as
+	when internal formatting is used.  Make sure the cursor is kept in the
+	same spot relative to the text then!  The |mode()| function will
+	return "i" or "R" in this situation.
+	
+	When the expression evaluates to non-zero Vim will fall back to using
+	the internal format mechanism.
+
+	The expression will be evaluated in the |sandbox| when set from a
+	modeline, see |sandbox-option|.  That stops the option from working,
+	since changing the buffer text is not allowed.
+
 					*'formatoptions'* *'fo'*
 'formatoptions' 'fo'	string (default: "tcqj", Vi default: "vt")
 			local to buffer
@@ -2719,40 +2753,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	about including spaces and backslashes.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
-
-						*'formatexpr'* *'fex'*
-'formatexpr' 'fex'	string (default "")
-			local to buffer
-			{not available when compiled without the |+eval|
-			feature}
-	Expression which is evaluated to format a range of lines for the |gq|
-	operator or automatic formatting (see 'formatoptions').  When this
-	option is empty 'formatprg' is used.
-
-	The |v:lnum|  variable holds the first line to be formatted.
-	The |v:count| variable holds the number of lines to be formatted.
-	The |v:char|  variable holds the character that is going to be
-		      inserted if the expression is being evaluated due to
-		      automatic formatting.  This can be empty.  Don't insert
-		      it yet!
-
-	Example: >
-		:set formatexpr=mylang#Format()
-<	This will invoke the mylang#Format() function in the
-	autoload/mylang.vim file in 'runtimepath'. |autoload|
-
-	The expression is also evaluated when 'textwidth' is set and adding
-	text beyond that limit.  This happens under the same conditions as
-	when internal formatting is used.  Make sure the cursor is kept in the
-	same spot relative to the text then!  The |mode()| function will
-	return "i" or "R" in this situation.
-	
-	When the expression evaluates to non-zero Vim will fall back to using
-	the internal format mechanism.
-
-	The expression will be evaluated in the |sandbox| when set from a
-	modeline, see |sandbox-option|.  That stops the option from working,
-	since changing the buffer text is not allowed.
 
 						*'fsync'* *'fs'*
 'fsync' 'fs'		boolean	(default on)

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1,4 +1,4 @@
-*pattern.txt*   For Vim version 7.4.  Last change: 2016 Apr 26
+*pattern.txt*   For Vim version 7.4.  Last change: 2016 Jun 08
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -947,14 +947,18 @@ $	At end of pattern or in front of "\|", "\)" or "\n" ('magic' on):
 <	When 'hlsearch' is set and you move the cursor around and make changes
 	this will clearly show when the match is updated or not.
 	To match the text up to column 17: >
-		/.*\%17v
-<	Column 17 is included, because that's where the "\%17v" matches,
-	even though this is a |/zero-width| match.  Adding a dot to match the
-	next character has the same result: >
-		/.*\%17v.
+		/^.*\%17v
+<	Column 17 is not included, because this is a |/zero-width| match. To
+	include the column use: >
+		/^.*\%17v.
 <	This command does the same thing, but also matches when there is no
 	character in column 17: >
-		/.*\%<18v.
+		/^.*\%<18v.
+<	Note that without the "^" to anchor the match in the first column,
+	this will also highlight column 17: >
+		/.*\%17v
+<	Column 17 is highlighted by 'hlsearch' because there is another match
+	where ".*" matches zero characters.
 <
 
 Character classes:

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -573,7 +573,7 @@ An atom can be followed by an indication of how many times the atom can be
 matched and in what way.  This is called a multi.  See |/multi| for an
 overview.
 
-						*/star* */\star* *E56*
+							*/star* */\star*
 *	(use \* when 'magic' is not set)
 	Matches 0 or more of the preceding atom, as many as possible.
 	Example  'nomagic'	matches ~
@@ -593,7 +593,7 @@ overview.
 	the end of the file and then tries matching "END", backing up one
 	character at a time.
 
-							*/\+* *E57*
+							*/\+*
 \+	Matches 1 or more of the preceding atom, as many as possible.
 	Example		matches ~
 	^.\+$		any non-empty line
@@ -608,7 +608,7 @@ overview.
 \?	Just like \=.  Cannot be used when searching backwards with the "?"
 	command.
 
-					*/\{* *E58* *E60* *E554* *E870*
+					*/\{* *E60* *E554* *E870*
 \{n,m}	Matches n to m of the preceding atom, as many as possible
 \{n}	Matches n of the preceding atom
 \{n,}	Matches at least n of the preceding atom, as many as possible

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1,4 +1,4 @@
-*pi_netrw.txt*  For Vim version 7.4.  Last change: 2016 Feb 16
+*pi_netrw.txt*  For Vim version 7.4.  Last change: 2016 Apr 20
 
 	    ------------------------------------------------
 	    NETRW REFERENCE MANUAL    by Charles E. Campbell
@@ -1523,6 +1523,7 @@ the |'isfname'| option (which is global, so netrw doesn't modify it).
 Associated setting variables:
 	|g:netrw_gx|	control how gx picks up the text under the cursor
 	|g:netrw_nogx|	prevent gx map while editing
+	|g:netrw_suppress_gx_mesg| controls gx's suppression of browser messages
 
 							*netrw_filehandler*
 
@@ -2929,6 +2930,13 @@ your browsing preferences.  (see also: |netrw-settings|)
 				such as listing, file removal, etc.
 				 default: ssh
 
+ *g:netrw_suppress_gx_mesg*	=1 : browsers sometimes produce messages
+				which are normally unwanted intermixed
+				with the page.
+				However, when using links, for example,
+				those messages are what the browser produces.
+				By setting this option to 0, netrw will not
+				suppress browser messages.
 
   *g:netrw_tmpfile_escape*	=' &;'
 				escape() is applied to all temporary files
@@ -3755,6 +3763,23 @@ netrw:
 ==============================================================================
 12. History						*netrw-history* {{{1
 
+	v156:	Feb 18, 2016	* Changed =~ to =~# where appropriate
+		Feb 23, 2016	* s:ComposePath(base,subdir) now uses
+				  fnameescape() on the base portion
+		Mar 01, 2016	* (gt_macki) reported where :Explore would
+				  make file unlisted. Fixed (tst943)
+		Apr 04, 2016	* (reported by John Little) netrw normally
+				  suppresses browser messages, but sometimes
+				  those "messages" are what is wanted.
+				  See |g:netrw_suppress_gx_mesg|
+		Apr 06, 2016	* (reported by Carlos Pita) deleting a remote
+				  file was giving an error message.  Fixed.
+		Apr 08, 2016	* (Charles Cooper) had a problem with an
+				  undefined b:netrw_curdir.  He also provided
+				  a fix.
+		Apr 20, 2016	* Changed s:NetrwGetBuffer(); now uses
+				  dictionaries.  Also fixed the "No Name"
+				  buffer problem.
 	v155:	Oct 29, 2015	* (Timur Fayzrakhmanov) reported that netrw's
 				  mapping of ctrl-l was not allowing refresh of
 				  other windows when it was done in a netrw

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -474,6 +474,9 @@ expression.
 The BufWinEnter event is also triggered, again using "quickfix" for the buffer
 name.
 
+Note: When adding to an existing quickfix list the autocommand are not
+triggered.
+
 Note: Making changes in the quickfix window has no effect on the list of
 errors.  'modifiable' is off to avoid making changes.  If you delete or insert
 lines anyway, the relation between the text and the error number is messed up.

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -529,7 +529,7 @@ whether Vim supports a feature or a dependency is missing.
 You can also load an optional plugin at startup, by putting this command in
 your |.vimrc|: >
 	:packadd! foodebug
-The extra "!" is so that the plugin isn't loaded with Vim was started with
+The extra "!" is so that the plugin isn't loaded if Vim was started with
 |--noplugin|.
 
 It is perfectly normal for a package to only have files in the "opt"
@@ -608,7 +608,7 @@ the command after changing the plugin help: >
 
 Dependencies between plugins ~
 							*packload-two-steps*
-Suppose you have a two plugins that depend on the same functionality. You can
+Suppose you have two plugins that depend on the same functionality. You can
 put the common functionality in an autoload directory, so that it will be
 found automatically.  Your package would have these files:
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1,4 +1,4 @@
-*starting.txt*  For Vim version 7.4.  Last change: 2016 Apr 05
+*starting.txt*  For Vim version 7.4.  Last change: 2016 Jun 12
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1135,7 +1135,7 @@ files for different types of files (e.g., C code) and load them based on the
 file name, using the ":autocmd" command (see |:autocmd|).  More information on 
 ShaDa file format is contained in |shada-format| section.
 
-					  *E136* *E138* *shada-error-handling*
+					  *E136* *E929* *shada-error-handling*
 Some errors make Neovim leave temporary file named `{basename}.tmp.X` (X is 
 any free letter from `a` to `z`) while normally it will create this file, 
 write to it and then rename `{basename}.tmp.X` to `{basename}`. Such errors 
@@ -1155,7 +1155,7 @@ include:
 
 Do not forget to remove the temporary file or replace the target file with 
 temporary one after getting one of the above errors or all attempts to create 
-a ShaDa file may fail with |E138|.  If you got one of them when using 
+a ShaDa file may fail with |E929|.  If you got one of them when using 
 |:wshada| (and not when exiting Neovim: i.e. when you have Neovim session 
 running) you have additional options:
 
@@ -1187,7 +1187,7 @@ running) you have additional options:
 			internal info is written (also disables safety checks 
 			described in |shada-error-handling|).  If 'shada' is 
 			empty, marks for up to 100 files will be written.
-			When you get error "E138: All .tmp.X files exist, 
+			When you get error "E929: All .tmp.X files exist, 
 			cannot write ShaDa file!" check that no old temp files 
 			were left behind (e.g. 
 			~/.local/share/nvim/shada/main.shada.tmp*).

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4770,6 +4770,10 @@ font={font-name}					*highlight-font*
 	All fonts used, except for Menu and Tooltip, should be of the same
 	character size as the default font!  Otherwise redrawing problems will
 	occur.
+	To use a font name with an embedded space or other special character,
+	put it in single quotes.  The single quote cannot be used then.
+	Example: >
+	    :hi comment font='Monospace 10'
 
 guifg={color-name}					*highlight-guifg*
 guibg={color-name}					*highlight-guibg*

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -473,7 +473,7 @@ correct values.
 
 One command can be used to set the screen size:
 
-						*:mod* *:mode* *E359* *E362*
+						*:mod* *:mode*
 :mod[e]
 
 Detects the screen size and redraws the screen.

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -602,7 +602,9 @@ String manipulation:					*string-functions*
 	strdisplaywidth()	size of string when displayed, deals with tabs
 	substitute()		substitute a pattern match with a string
 	submatch()		get a specific match in ":s" and substitute()
-	strpart()		get part of a string
+	strpart()		get part of a string using byte index
+	strcharpart()		get part of a string using char index
+	strgetchar()		get character from a string using char index
 	expand()		expand special keywords
 	iconv()			convert text from one encoding to another
 	byteidx()		byte index of a character in a string
@@ -732,11 +734,14 @@ Working with text in the current buffer:		*text-functions*
 	searchpair()		find the other end of a start/skip/end
 	searchpairpos()		find the other end of a start/skip/end
 	searchdecl()		search for the declaration of a name
+	getcharsearch()		return character search information
+	setcharsearch()		set character search information
 
 					*system-functions* *file-functions*
 System functions and manipulation of files:
 	glob()			expand wildcards
 	globpath()		expand wildcards in a number of directories
+	glob2regpat()		convert a glob pattern into a search pattern
 	findfile()		find a file in a list of directories
 	finddir()		find a directory in a list of directories
 	resolve()		find out where a shortcut points to
@@ -748,6 +753,7 @@ System functions and manipulation of files:
 	filereadable()		check if a file can be read
 	filewritable()		check if a file can be written to
 	getfperm()		get the permissions of a file
+	setfperm()		set the permissions of a file
 	getftype()		get the kind of a file
 	isdirectory()		check if a directory exists
 	getfsize()		get the size of a file
@@ -790,6 +796,11 @@ Buffers, windows and the argument list:
 	bufwinnr()		get the window number of a specific buffer
 	winbufnr()		get the buffer number of a specific window
 	getbufline()		get a list of lines from the specified buffer
+	win_findbuf()		find windows containing a buffer
+	win_getid()		get window ID of a window
+	win_gotoid()		go to window with ID
+	win_id2tabwin()		get tab and window nr from window ID
+	win_id2win()		get window nr from window ID
 	getbufinfo()		get a list with buffer information
 	gettabinfo()		get a list with tab page information
 	getwininfo()		get a list with window information
@@ -905,6 +916,10 @@ Testing:				    *test-functions*
 	assert_true()		assert that an expression is true
 	assert_exception()	assert that a command throws an exception
 	assert_fails()		assert that a function call fails
+
+Timers:						*timer-functions*
+	timer_start()		create a timer
+	timer_stop()		stop a timer
 
 Various:					*various-functions*
 	mode()			get current editing mode
@@ -1402,9 +1417,9 @@ Now we can instantiate a Dutch translation object: >
 And a German translator: >
 
 	:let uk2de = copy(transdict)
-	:let uk2de.words = {'one': 'ein', 'two': 'zwei', 'three': 'drei'}
+	:let uk2de.words = {'one': 'eins', 'two': 'zwei', 'three': 'drei'}
 	:echo uk2de.translate('three one')
-<	drei ein ~
+<	drei eins ~
 
 You see that the copy() function is used to make a copy of the "transdict"
 Dictionary and then the copy is changed to add the words.  The original

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -786,6 +786,7 @@ Buffers, windows and the argument list:
 	tabpagenr()		get the number of a tab page
 	tabpagewinnr()		like winnr() for a specified tab page
 	winnr()			get the window number for the current window
+	bufwinid()		get the window ID of a specific buffer
 	bufwinnr()		get the window number of a specific buffer
 	winbufnr()		get the buffer number of a specific window
 	getbufline()		get a list of lines from the specified buffer

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1,4 +1,4 @@
-*windows.txt*   For Vim version 7.4.  Last change: 2016 Feb 01
+*windows.txt*   For Vim version 7.4.  Last change: 2016 Jun 10
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -69,6 +69,16 @@ places where a Normal mode command can't be used or is inconvenient.
 
 The main Vim window can hold several split windows.  There are also tab pages
 |tab-page|, each of which can hold multiple windows.
+
+Each window has a unique identifier called the window ID.  This identifier
+will not change within a Vim session. The |win_getid()| and |win_id2tabwin()|
+functions can be used to convert between the window/tab number and the
+identifier.  There is also the window number, which may change whenever
+windows are opened or closed, see |winnr()|.
+
+Each buffer has a unique number and the number will not change within a Vim
+session.  The |bufnr()| and |bufname()| functions can be used to convert
+between a buffer name and the buffer number.
 
 ==============================================================================
 2. Starting Vim						*windows-starting*

--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	C
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2012 Jul 10
+" Last Change:	2016 Jun 12
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -32,7 +32,7 @@ setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 " When the matchit plugin is loaded, this makes the % command skip parens and
 " braces in comments.
 let b:match_words = &matchpairs . ',^\s*#\s*if\(\|def\|ndef\)\>:^\s*#\s*elif\>:^\s*#\s*else\>:^\s*#\s*endif\>'
-let b:match_skip = 's:comment\|string\|character'
+let b:match_skip = 's:comment\|string\|character\|special'
 
 " Win32 can filter files in the browse dialog
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")

--- a/runtime/ftplugin/python.vim
+++ b/runtime/ftplugin/python.vim
@@ -1,8 +1,9 @@
 " Vim filetype plugin file
 " Language:	python
-" Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	2014 Feb 09
-" Last Change By Johannes: Wed, 21 Apr 2004 13:13:08 CEST
+" Maintainer:	James Sully <sullyj3@gmail.com>
+" Previous Maintainer: Johannes Zellner <johannes@zellner.org>
+" Last Change:	Fri, 10 June 2016
+" https://github.com/sullyj3/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -21,10 +22,10 @@ setlocal omnifunc=pythoncomplete#Complete
 
 set wildignore+=*.pyc
 
-nnoremap <silent> <buffer> ]] :call <SID>Python_jump('/^\(class\\|def\)')<cr>
-nnoremap <silent> <buffer> [[ :call <SID>Python_jump('?^\(class\\|def\)')<cr>
-nnoremap <silent> <buffer> ]m :call <SID>Python_jump('/^\s*\(class\\|def\)')<cr>
-nnoremap <silent> <buffer> [m :call <SID>Python_jump('?^\s*\(class\\|def\)')<cr>
+nnoremap <silent> <buffer> ]] :call <SID>Python_jump('/^\(class\\|def\)\>')<cr>
+nnoremap <silent> <buffer> [[ :call <SID>Python_jump('?^\(class\\|def\)\>')<cr>
+nnoremap <silent> <buffer> ]m :call <SID>Python_jump('/^\s*\(class\\|def\)\>')<cr>
+nnoremap <silent> <buffer> [m :call <SID>Python_jump('?^\s*\(class\\|def\)\>')<cr>
 
 if !exists('*<SID>Python_jump')
   fun! <SID>Python_jump(motion) range

--- a/runtime/indent/vhdl.vim
+++ b/runtime/indent/vhdl.vim
@@ -1,8 +1,8 @@
 " VHDL indent ('93 syntax)
 " Language:    VHDL
 " Maintainer:  Gerald Lai <laigera+vim?gmail.com>
-" Version:     1.58
-" Last Change: 2011 Sep 27
+" Version:     1.60
+" Last Change: 2016 Feb 26
 " URL:         http://www.vim.org/scripts/script.php?script_id=1450
 
 " only load this indent file when no other was loaded
@@ -104,7 +104,7 @@ function GetVHDLindent()
     let pn = prevnonblank(pn - 1)
     let ps = getline(pn)
   endwhile
-  if (curs =~ '^\s*)' || curs =~? '^\s*\%(\<\%(procedure\|generic\|map\|port\)\>.*\)\@<!\w\+\s*\w*\s*\%(=>\s*\S\+\|:[^=]\@=\s*\%(\%(in\|out\|inout\|buffer\|linkage\)\>\|\w\+\s\+:=\)\)') && (prevs =~? s:NC.'\<\%(procedure\s\+\S\+\|generic\|map\|port\)\s*(\%(\s*\w\)\=' || (ps =~? s:NC.'\<\%(procedure\|generic\|map\|port\)'.s:ES && prevs =~ '^\s*('))
+  if (curs =~ '^\s*)' || curs =~? '^\s*\%(\<\%(procedure\|generic\|map\|port\)\>.*\)\@<!\w\+\s*\w*\s*\((.*)\)*\s*\%(=>\s*\S\+\|:[^=]\@=\s*\%(\%(in\|out\|inout\|buffer\|linkage\)\>\|\s\+\)\)') && (prevs =~? s:NC.'\<\%(procedure\s\+\S\+\|generic\|map\|port\)\s*(\%(\s*\w\)\=' || (ps =~? s:NC.'\<\%(procedure\|generic\|map\|port\)'.s:ES && prevs =~ '^\s*('))
     " align closing ")" with opening "("
     if curs =~ '^\s*)'
       return ind2 + stridx(prevs_noi, '(')
@@ -412,11 +412,22 @@ function GetVHDLindent()
 
   " ****************************************************************************************
   " indent:   maintain indent of previous opening statement
-  " keywords: without "procedure", "generic", "map", "port" + ":" but not ":=" + "in", "out", "inout", "buffer", "linkage", variable & ":="
+  " keywords: without "procedure", "generic", "map", "port" + ":" but not ":=" + eventually ;$
   " where:    start of current line
-  if curs =~? '^\s*\%(\<\%(procedure\|generic\|map\|port\)\>.*\)\@<!\w\+\s*\w*\s*:[^=]\@=\s*\%(\%(in\|out\|inout\|buffer\|linkage\)\>\|\w\+\s\+:=\)'
+  if curs =~? '^\s*\%(\<\%(procedure\|generic\|map\|port\)\>.*\)\@<!\w\+\s*\w*\s*:[^=].*;.*$'
     return ind2
   endif
+  " ****************************************************************************************
+  " indent:     maintain indent of previous opening statement, corner case which
+  "             does not end in ;, but is part of a mapping
+  " keywords:   without "procedure", "generic", "map", "port" + ":" but not ":=", never + ;$ and
+  "             prevline without "procedure", "generic", "map", "port" + ":" but not ":=" + eventually ;$
+  " where:      start of current line
+  if curs =~? '^\s*\%(\<\%(procedure\|generic\|map\|port\)\>.*\)\@<!\w\+\s*\w*\s*:[^=].*[^;].*$'
+      if prevs =~? '^\s*\%(\<\%(procedure\|generic\|map\|port\)\>.*\)\@<!\w\+\s*\w*\s*:[^=].*;.*$'
+         return ind2
+     endif
+ endif
 
   " return leftover filtered indent
   return ind

--- a/runtime/indent/vim.vim
+++ b/runtime/indent/vim.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:	Vim script
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2016 Jan 24
+" Last Change:	2016 Apr 19
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -60,7 +60,7 @@ function GetVimIndentIntern()
     else
       let ind = ind + shiftwidth() * 3
     endif
-  elseif prev_text =~ '^\s*aug\%[roup]' && prev_text !~ '^\s*aug\%[roup]\s*!\=\s\+END'
+  elseif prev_text =~ '^\s*aug\%[roup]' && prev_text !~ '^\s*aug\%[roup]\s*!\=\s\+[eE][nN][dD]'
     let ind = ind + shiftwidth()
   else
     " A line starting with :au does not increment/decrement indent.

--- a/runtime/plugin/netrwPlugin.vim
+++ b/runtime/plugin/netrwPlugin.vim
@@ -20,7 +20,7 @@
 if &cp || exists("g:loaded_netrwPlugin")
  finish
 endif
-let g:loaded_netrwPlugin = "v155"
+let g:loaded_netrwPlugin = "v156"
 let s:keepcpo = &cpo
 set cpo&vim
 "DechoRemOn

--- a/runtime/syntax/bib.vim
+++ b/runtime/syntax/bib.vim
@@ -2,7 +2,7 @@
 " Language:	BibTeX (bibliographic database format for (La)TeX)
 " Maintainer:	Bernd Feige <Bernd.Feige@gmx.net>
 " Filenames:	*.bib
-" Last Change:	2014 Mar 26
+" Last Change:	2016 May 31
 
 " Thanks to those who pointed out problems with this file or supplied fixes!
 
@@ -35,8 +35,40 @@ syn keyword bibEntryKw contained	crossref edition editor howpublished
 syn keyword bibEntryKw contained	institution journal key month note
 syn keyword bibEntryKw contained	number organization pages publisher
 syn keyword bibEntryKw contained	school series title type volume year
+
+" biblatex keywords, cf. http://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf
+syn keyword bibType contained	mvbook bookinbook suppbook collection mvcollection suppcollection
+syn keyword bibType contained	online patent periodical suppperiodical mvproceedings reference
+syn keyword bibType contained	mvreference inreference report set thesis xdata customa customb
+syn keyword bibType contained	customc customd custome customf electronic www artwork audio bibnote
+syn keyword bibType contained	commentary image jurisdiction legislation legal letter movie music
+syn keyword bibType contained	performance review software standard video
+
+syn keyword bibEntryKw contained	abstract isbn issn keywords url
+syn keyword bibEntryKw contained	addendum afterwordannotation annotation annotator authortype
+syn keyword bibEntryKw contained	bookauthor bookpagination booksubtitle booktitleaddon
+syn keyword bibEntryKw contained	commentator date doi editora editorb editorc editortype
+syn keyword bibEntryKw contained	editoratype editorbtype editorctype eid entrysubtype
+syn keyword bibEntryKw contained	eprint eprintclass eprinttype eventdate eventtitle
+syn keyword bibEntryKw contained	eventtitleaddon file foreword holder indextitle
+syn keyword bibEntryKw contained	introduction isan ismn isrn issue issuesubtitle
+syn keyword bibEntryKw contained	issuetitle iswc journalsubtitle journaltitle label
+syn keyword bibEntryKw contained	language library location mainsubtitle maintitle
+syn keyword bibEntryKw contained	maintitleaddon nameaddon origdate origlanguage
+syn keyword bibEntryKw contained	origlocation origpublisher origtitle pagetotal
+syn keyword bibEntryKw contained	pagination part pubstate reprinttitle shortauthor
+syn keyword bibEntryKw contained	shorteditor shorthand shorthandintro shortjournal
+syn keyword bibEntryKw contained	shortseries shorttitle subtitle titleaddon translator
+syn keyword bibEntryKw contained	urldate venue version volumes entryset execute gender
+syn keyword bibEntryKw contained	langid langidopts ids indexsorttitle options presort
+syn keyword bibEntryKw contained	related relatedoptions relatedtype relatedstring
+syn keyword bibEntryKw contained	sortkey sortname sortshorthand sorttitle sortyear xdata
+syn keyword bibEntryKw contained	xref namea nameb namec nameatype namebtype namectype
+syn keyword bibEntryKw contained	lista listb listc listd liste listf usera userb userc
+syn keyword bibEntryKw contained	userd usere userf verba verbb verbc archiveprefix pdf
+syn keyword bibEntryKw contained	primaryclass
+
 " Non-standard:
-syn keyword bibNSEntryKw contained	abstract isbn issn keywords url
 " AMS mref http://www.ams.org/mref
 syn keyword bibNSEntryKw contained	mrclass mrnumber mrreviewer fjournal coden
 

--- a/runtime/syntax/php.vim
+++ b/runtime/syntax/php.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: php PHP 3/4/5
 " Maintainer: Jason Woofenden <jason@jasonwoof.com>
-" Last Change: Dec 26, 2015
+" Last Change: Apr 18, 2016
 " URL: https://jasonwoof.com/gitweb/?p=vim-syntax.git;a=blob;f=php.vim;hb=HEAD
 " Former Maintainers: Peter Hodge <toomuchphp-vim@yahoo.com>
 "         Debian VIM Maintainers <pkg-vim-maintainers@lists.alioth.debian.org>
@@ -136,7 +136,7 @@ syn keyword phpConstant  __LINE__ __FILE__ __FUNCTION__ __METHOD__ __CLASS__ __D
 
 " Function and Methods ripped from php_manual_de.tar.gz Jan 2003
 syn keyword phpFunctions  apache_child_terminate apache_get_modules apache_get_version apache_getenv apache_lookup_uri apache_note apache_request_headers apache_response_headers apache_setenv ascii2ebcdic ebcdic2ascii getallheaders virtual contained
-syn keyword phpFunctions  array_change_key_case array_chunk array_combine array_count_values array_diff_assoc array_diff_uassoc array_diff array_fill array_filter array_flip array_intersect_assoc array_intersect array_key_exists array_keys array_map array_merge_recursive array_merge array_multisort array_pad array_pop array_push array_rand array_reduce array_reverse array_search array_shift array_slice array_splice array_sum array_udiff_assoc array_udiff_uassoc array_udiff array_unique array_unshift array_values array_walk array arsort asort compact count current each end extract in_array key krsort ksort list natcasesort natsort next pos prev range reset rsort shuffle sizeof sort uasort uksort usort contained
+syn keyword phpFunctions  array_change_key_case array_chunk array_column array_combine array_count_values array_diff_assoc array_diff_key array_diff_uassoc array_diff_ukey array_diff array_fill_keys array_fill array_filter array_flip array_intersect_assoc array_intersect_key array_intersect_uassoc array_intersect_ukey array_intersect array_key_exists array_keys array_map array_merge_recursive array_merge array_multisort array_pad array_pop array_product array_push array_rand array_reduce array_replace_recursive array_replace array_reverse array_search array_shift array_slice array_splice array_sum array_udiff_assoc array_udiff_uassoc array_udiff array_uintersect_assoc array_uintersect_uassoc array_uintersect array_unique array_unshift array_values array_walk_recursive array_walk arsort asort count current each end in_array key_exists key krsort ksort natcasesort natsort next pos prev range reset rsort shuffle sizeof sort uasort uksort usort contained
 syn keyword phpFunctions  aspell_check aspell_new aspell_suggest  contained
 syn keyword phpFunctions  bcadd bccomp bcdiv bcmod bcmul bcpow bcpowmod bcscale bcsqrt bcsub  contained
 syn keyword phpFunctions  bzclose bzcompress bzdecompress bzerrno bzerror bzerrstr bzflush bzopen bzread bzwrite  contained

--- a/runtime/syntax/spec.vim
+++ b/runtime/syntax/spec.vim
@@ -3,7 +3,7 @@
 " Language:    SPEC: Build/install scripts for Linux RPM packages
 " Maintainer:  Igor Gnatenko i.gnatenko.brain@gmail.com
 " Former Maintainer:  Donovan Rebbechi elflord@panix.com (until March 2014)
-" Last Change: Sun Mar 2 10:33 MSK 2014 Igor Gnatenko
+" Last Change: Sat Apr 9 15:30 2016 Filip Szymański
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
@@ -83,8 +83,8 @@ syn keyword specMacroNameLocal contained _arch _binary_payload _bindir _build _b
 
 "One line macros - valid in all ScriptAreas
 "tip: remember do include new items on specScriptArea's skip section
-syn region specSectionMacroArea oneline matchgroup=specSectionMacro start='^%\(define\|global\|patch\d*\|setup\|configure\|GNUconfigure\|find_lang\|makeinstall\|make_install\|include\)\>' end='$' contains=specCommandOpts,specMacroIdentifier
-syn region specSectionMacroBracketArea oneline matchgroup=specSectionMacro start='^%{\(configure\|GNUconfigure\|find_lang\|makeinstall\|make_install\)}' end='$' contains=specCommandOpts,specMacroIdentifier
+syn region specSectionMacroArea oneline matchgroup=specSectionMacro start='^%\(define\|global\|patch\d*\|setup\|autosetup\|autopatch\|configure\|GNUconfigure\|find_lang\|make_build\|makeinstall\|make_install\|include\)\>' end='$' contains=specCommandOpts,specMacroIdentifier
+syn region specSectionMacroBracketArea oneline matchgroup=specSectionMacro start='^%{\(configure\|GNUconfigure\|find_lang\|make_build\|makeinstall\|make_install\)}' end='$' contains=specCommandOpts,specMacroIdentifier
 
 "%% Files Section %%
 "TODO %config valid parameters: missingok\|noreplace
@@ -105,7 +105,7 @@ syn case ignore
 "%% PreAmble Section %%
 "Copyright and Serial were deprecated by License and Epoch
 syn region specPreAmbleDeprecated oneline matchgroup=specError start='^\(Copyright\|Serial\)' end='$' contains=specEmail,specURL,specURLMacro,specLicense,specColon,specVariables,specSpecialChar,specMacroIdentifier
-syn region specPreAmble oneline matchgroup=specCommand start='^\(Prereq\|Summary\|Name\|Version\|Packager\|Requires\|Icon\|URL\|Source\d*\|Patch\d*\|Prefix\|Packager\|Group\|License\|Release\|BuildRoot\|Distribution\|Vendor\|Provides\|ExclusiveArch\|ExcludeArch\|ExclusiveOS\|Obsoletes\|BuildArch\|BuildArchitectures\|BuildRequires\|BuildConflicts\|BuildPreReq\|Conflicts\|AutoRequires\|AutoReq\|AutoReqProv\|AutoProv\|Epoch\)' end='$' contains=specEmail,specURL,specURLMacro,specLicense,specColon,specVariables,specSpecialChar,specMacroIdentifier
+syn region specPreAmble oneline matchgroup=specCommand start='^\(Prereq\|Summary\|Name\|Version\|Packager\|Requires\|Recommends\|Suggests\|Supplements\|Enhances\|Icon\|URL\|Source\d*\|Patch\d*\|Prefix\|Packager\|Group\|License\|Release\|BuildRoot\|Distribution\|Vendor\|Provides\|ExclusiveArch\|ExcludeArch\|ExclusiveOS\|Obsoletes\|BuildArch\|BuildArchitectures\|BuildRequires\|BuildConflicts\|BuildPreReq\|Conflicts\|AutoRequires\|AutoReq\|AutoReqProv\|AutoProv\|Epoch\)' end='$' contains=specEmail,specURL,specURLMacro,specLicense,specColon,specVariables,specSpecialChar,specMacroIdentifier
 
 "%% Description Section %%
 syn region specDescriptionArea matchgroup=specSection start='^%description' end='^%'me=e-1 contains=specDescriptionOpts,specEmail,specURL,specNumber,specMacroIdentifier,specComment
@@ -114,7 +114,7 @@ syn region specDescriptionArea matchgroup=specSection start='^%description' end=
 syn region specPackageArea matchgroup=specSection start='^%package' end='^%'me=e-1 contains=specPackageOpts,specPreAmble,specComment
 
 "%% Scripts Section %%
-syn region specScriptArea matchgroup=specSection start='^%\(prep\|build\|install\|clean\|pre\|postun\|preun\|post\|posttrans\)\>' skip='^%{\|^%\(define\|patch\d*\|configure\|GNUconfigure\|setup\|find_lang\|makeinstall\|make_install\)\>' end='^%'me=e-1 contains=specSpecialVariables,specVariables,@specCommands,specVariables,shDo,shFor,shCaseEsac,specNoNumberHilite,specCommandOpts,shComment,shIf,specSpecialChar,specMacroIdentifier,specSectionMacroArea,specSectionMacroBracketArea,shOperator,shQuote1,shQuote2
+syn region specScriptArea matchgroup=specSection start='^%\(prep\|build\|install\|clean\|pre\|postun\|preun\|post\|posttrans\)\>' skip='^%{\|^%\(define\|patch\d*\|configure\|GNUconfigure\|setup\|autosetup\|autopatch\|find_lang\|make_build\|makeinstall\|make_install\)\>' end='^%'me=e-1 contains=specSpecialVariables,specVariables,@specCommands,specVariables,shDo,shFor,shCaseEsac,specNoNumberHilite,specCommandOpts,shComment,shIf,specSpecialChar,specMacroIdentifier,specSectionMacroArea,specSectionMacroBracketArea,shOperator,shQuote1,shQuote2
 
 "%% Changelog Section %%
 syn region specChangelogArea matchgroup=specSection start='^%changelog' end='^%'me=e-1 contains=specEmail,specURL,specWeekday,specMonth,specNumber,specComment,specLicense

--- a/runtime/syntax/viminfo.vim
+++ b/runtime/syntax/viminfo.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Vim .viminfo file
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2012 Feb 03
+" Last Change:	2016 Jun 05
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -30,11 +30,15 @@ syn match viminfoOptionName "\*\a*"ms=s+1 contained
 " Comments
 syn match viminfoComment "^#.*"
 
+" New style lines.  TODO: highlight numbers and strings.
+syn match viminfoNew "^|.*"
+
 " Define the default highlighting.
 " Only used when an item doesn't have highlighting yet
 hi def link viminfoComment	Comment
 hi def link viminfoError	Error
 hi def link viminfoStatement	Statement
+hi def link viminfoNew		String
 
 let b:current_syntax = "viminfo"
 

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -480,6 +480,12 @@ return {
     func='ex_close',
   },
   {
+    command='clearjumps',
+    flags=bit.bor(TRLBAR, CMDWIN),
+    addr_type=ADDR_LINES,
+    func='ex_clearjumps',
+  },
+  {
     command='cmap',
     flags=bit.bor(EXTRA, TRLBAR, NOTRLCOM, USECTRLV, CMDWIN),
     addr_type=ADDR_LINES,

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -130,17 +130,17 @@ int setmark_pos(int c, pos_T *pos, int fnum)
     return OK;
   }
 
-  if (c > 'z')              /* some islower() and isupper() cannot handle
-                                characters above 127 */
-    return FAIL;
-  if (islower(c)) {
+  if (ASCII_ISLOWER(c)) {
     i = c - 'a';
     RESET_FMARK(curbuf->b_namedm + i, *pos, curbuf->b_fnum);
     return OK;
   }
-  if (isupper(c)) {
-    assert(c >= 'A' && c <= 'Z');
-    i = c - 'A';
+  if (ASCII_ISUPPER(c) || ascii_isdigit(c)) {
+    if (ascii_isdigit(c)) {
+      i = c - '0' + NMARKS;
+    } else {
+      i = c - 'A';
+    }
     RESET_XFMARK(namedfm + i, *pos, fnum, NULL);
     return OK;
   }
@@ -796,6 +796,13 @@ void ex_jumps(exarg_T *eap)
   }
   if (curwin->w_jumplistidx == curwin->w_jumplistlen)
     MSG_PUTS("\n>");
+}
+
+void ex_clearjumps(exarg_T *eap)
+{
+  free_jumplist(curwin);
+  curwin->w_jumplistlen = 0;
+  curwin->w_jumplistidx = 0;
 }
 
 /*

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -4424,8 +4424,8 @@ msgstr ""
 "перед записом: %s"
 
 #, c-format
-msgid "E138: All %s.tmp.X files exist, cannot write ShaDa file!"
-msgstr "E138: Усі файли %s.tmp.X зайнято, неможливо записати файл ShaDa!"
+msgid "E929: All %s.tmp.X files exist, cannot write ShaDa file!"
+msgstr "E929: Усі файли %s.tmp.X зайнято, неможливо записати файл ShaDa!"
 
 #, c-format
 msgid "System error while opening temporary ShaDa file %s for writing: %s"

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -118,9 +118,10 @@ KHASH_SET_INIT_STR(strset)
 //   E576: Missing '>'
 //   E577: Illegal register name
 //   E886: Can't rename viminfo file to %s!
+//   E929: Too many viminfo temp files, like %s!
 // Now only six of them are used:
 //   E137: ShaDa file is not writeable (for pre-open checks)
-//   E138: All %s.tmp.X files exist, cannot write ShaDa file!
+//   E929: All %s.tmp.X files exist, cannot write ShaDa file!
 //   RCERR (E576) for critical read errors.
 //   RNERR (E136) for various errors when renaming.
 //   RERR (E575) for various errors inside read ShaDa file.

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -515,7 +515,7 @@ static int included_patches[] = {
   1928,
   // 1927 NA
   // 1926 NA
-  // 1925 NA
+  1925,
   // 1924 NA
   1923,
   // 1922 NA


### PR DESCRIPTION
#### vim-patch:aa3b15d

Updated runtime files.

https://github.com/vim/vim/commit/aa3b15dbebf333282503d6031e2f9ba6ee4398ed


#### vim-patch:82af871

Updated runtime files.

https://github.com/vim/vim/commit/82af8710bf8d1caeeceafb1370a052cb7d92f076


#### vim-patch:7.4.1925

Problem:    Viminfo does not merge file marks properly.
Solution:   Use a timestamp.  Add the :clearjumps command.

https://github.com/vim/vim/commit/2d35899721da0e9359a9fe1059554f8c4ea7f0c1


#### vim-patch:c95a302

Updated runtime files.

https://github.com/vim/vim/commit/c95a302a4c42ec8230473cd4a5e0064d0a143aa8