### PR TITLE
[RDY] unittest: Allow multiple indirect includes

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -21,6 +21,9 @@ local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
 
 local mpack = require('mpack')
 
+local tmpname = global_helpers.tmpname
+local uname = global_helpers.uname
+
 -- Formulate a path to the directory containing nvim.  We use this to
 -- help run test executables.  It helps to keep the tests working, even
 -- when the build is not in the default location.
@@ -332,44 +335,6 @@ local function write_file(name, text, dont_dedent)
   file:write(text)
   file:flush()
   file:close()
-end
-
--- Tries to get platform name from $SYSTEM_NAME, uname; fallback is "Windows".
-local uname = (function()
-  local platform = nil
-  return (function()
-    if platform then
-      return platform
-    end
-
-    platform = os.getenv("SYSTEM_NAME")
-    if platform then
-      return platform
-    end
-
-    local status, f = pcall(io.popen, "uname -s")
-    if status then
-      platform = f:read("*l")
-    else
-      platform = 'Windows'
-    end
-    return platform
-  end)
-end)()
-
-local function tmpname()
-  local fname = os.tmpname()
-  if uname() == 'Windows' and fname:sub(1, 2) == '\\s' then
-    -- In Windows tmpname() returns a filename starting with
-    -- special sequence \s, prepend $TEMP path
-    local tmpdir = os.getenv('TEMP')
-    return tmpdir..fname
-  elseif fname:match('^/tmp') and uname() == 'Darwin' then
-    -- In OS X /tmp links to /private/tmp
-    return '/private'..fname
-  else
-    return fname
-  end
 end
 
 local function source(code)

--- a/test/unit/formatc.lua
+++ b/test/unit/formatc.lua
@@ -219,7 +219,7 @@ local function standalone(...)  -- luacheck: ignore
   Preprocess.add_to_include_path('./../../build/include')
   Preprocess.add_to_include_path('./../../.deps/usr/include')
 
-  local raw = Preprocess.preprocess(arg[1])
+  local raw = Preprocess.preprocess('', arg[1])
 
   if raw == nil then
     print("ERROR: Preprocess.preprocess() returned empty")

--- a/test/unit/formatc.lua
+++ b/test/unit/formatc.lua
@@ -219,12 +219,10 @@ local function standalone(...)  -- luacheck: ignore
   Preprocess.add_to_include_path('./../../build/include')
   Preprocess.add_to_include_path('./../../.deps/usr/include')
 
-  local input = Preprocess.preprocess_stream(arg[1])
-  local raw = input:read('*all')
-  input:close()
+  local raw = Preprocess.preprocess(arg[1])
 
   if raw == nil then
-    print("ERROR: Preprocess.preprocess_stream():read() returned empty")
+    print("ERROR: Preprocess.preprocess() returned empty")
   end
 
   local formatted

--- a/test/unit/formatc.lua
+++ b/test/unit/formatc.lua
@@ -221,10 +221,6 @@ local function standalone(...)  -- luacheck: ignore
 
   local raw = Preprocess.preprocess('', arg[1])
 
-  if raw == nil then
-    print("ERROR: Preprocess.preprocess() returned empty")
-  end
-
   local formatted
   if #arg == 2 and arg[2] == 'no' then
       formatted = raw

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -68,14 +68,12 @@ local function cimport(...)
 
   local body = nil
   for _ = 1, 10 do
-    local stream = Preprocess.preprocess_stream(unpack(paths))
-    body = stream:read("*a")
-    stream:close()
+    body = Preprocess.preprocess(unpack(paths))
     if body ~= nil then break end
   end
 
   if body == nil then
-    print("ERROR: helpers.lua: Preprocess.preprocess_stream():read() returned empty")
+    print("ERROR: helpers.lua: Preprocess.preprocess() returned empty")
   end
 
   -- format it (so that the lines are "unique" statements), also filter out

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -69,14 +69,7 @@ local function cimport(...)
   end
 
   local body = nil
-  for _ = 1, 10 do
-    body, previous_defines = Preprocess.preprocess(previous_defines, unpack(paths))
-    if body ~= nil then break end
-  end
-
-  if body == nil then
-    print("ERROR: helpers.lua: Preprocess.preprocess() returned empty")
-  end
+  body, previous_defines = Preprocess.preprocess(previous_defines, unpack(paths))
 
   -- format it (so that the lines are "unique" statements), also filter out
   -- Objective-C blocks

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -45,6 +45,8 @@ local function filter_complex_blocks(body)
   return table.concat(result, "\n")
 end
 
+local previous_defines = ''
+
 -- use this helper to import C files, you can pass multiple paths at once,
 -- this helper will return the C namespace of the nvim library.
 local function cimport(...)
@@ -68,7 +70,7 @@ local function cimport(...)
 
   local body = nil
   for _ = 1, 10 do
-    body = Preprocess.preprocess(unpack(paths))
+    body, previous_defines = Preprocess.preprocess(previous_defines, unpack(paths))
     if body ~= nil then break end
   end
 

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -68,7 +68,7 @@ local function cimport(...)
     return libnvim
   end
 
-  local body = nil
+  local body
   body, previous_defines = Preprocess.preprocess(previous_defines, unpack(paths))
 
   -- format it (so that the lines are "unique" statements), also filter out

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -1,11 +1,7 @@
 -- helps managing loading different headers into the LuaJIT ffi. Untested on
 -- windows, will probably need quite a bit of adjustment to run there.
 
-local global_helpers = require('test.helpers')
-
 local ffi = require("ffi")
-
-local tmpname = global_helpers.tmpname
 
 local ccs = {}
 
@@ -83,7 +79,7 @@ local function headerize(headers, global)
   end
 
   local formatted = {}
-  for i, hdr in ipairs(headers) do
+  for _, hdr in ipairs(headers) do
     formatted[#formatted + 1] = "#include " ..
                                 tostring(pre) ..
                                 tostring(hdr) ..
@@ -101,7 +97,6 @@ local Gcc = {
 
 function Gcc:define(name, args, val)
   local define = '-D' .. name
-  local quoted_define = ''
   if args ~= nil then
     define = define .. '(' .. table.concat(args, ',') .. ')'
   end
@@ -116,7 +111,7 @@ function Gcc:undefine(name)
       '-U' .. name)
 end
 
-function Gcc:init_defines(name)
+function Gcc:init_defines()
   -- preprocessor flags that will hopefully make the compiler produce C
   -- declarations that the LuaJIT ffi understands.
   self:define('aligned', {'ARGS'}, '')


### PR DESCRIPTION
Works by saving all preprocessor defines and reusing them on each run. This also 
saves NVIM_HEADER_H defines. Saving other defines is needed for defines like 
`Map(foo, bar)` which are sometimes used to declare types or functions. Saving 
types or function declarations is not needed because they are recorded as luajit 
state.

Fixes #5857