### PR TITLE
provider/clipboard.vim: fallback if xsel is broken

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -33,6 +33,12 @@ function! s:try_cmd(cmd, ...)
   return out
 endfunction
 
+" Returns TRUE if `cmd` exits with success, else FALSE.
+function! s:cmd_ok(cmd)
+  call system(a:cmd)
+  return v:shell_error == 0
+endfunction
+
 let s:cache_enabled = 1
 let s:err = ''
 
@@ -48,7 +54,7 @@ function! provider#clipboard#Executable() abort
     let s:paste['*'] = s:paste['+']
     let s:cache_enabled = 0
     return 'pbcopy'
-  elseif exists('$DISPLAY') && executable('xsel')
+  elseif exists('$DISPLAY') && executable('xsel') && s:cmd_ok('xsel -o -b')
     let s:copy['+'] = 'xsel --nodetach -i -b'
     let s:paste['+'] = 'xsel -o -b'
     let s:copy['*'] = 'xsel --nodetach -i -p'


### PR DESCRIPTION
Old versions of `xsel` do not support some required features.
Fall back to `xclip` then.

Closes #5853