### PR TITLE
[RDY] Don't set `b_u_curhead` in `ex_undojoin()`

### DIFF
--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2549,20 +2549,20 @@ static void u_add_time(char_u *buf, size_t buflen, time_t tt)
  */
 void ex_undojoin(exarg_T *eap)
 {
-  if (curbuf->b_u_newhead == NULL)
-    return;                 /* nothing changed before */
+  if (curbuf->b_u_newhead == NULL) {
+    return;                 // nothing changed before
+  }
   if (curbuf->b_u_curhead != NULL) {
     EMSG(_("E790: undojoin is not allowed after undo"));
     return;
   }
-  if (!curbuf->b_u_synced)
-    return;                 /* already unsynced */
-  if (get_undolevel() < 0)
-    return;                 /* no entries, nothing to do */
-  else {
-    /* Go back to the last entry */
-    curbuf->b_u_curhead = curbuf->b_u_newhead;
-    curbuf->b_u_synced = false;      /* no entries, nothing to do */
+  if (!curbuf->b_u_synced) {
+    return;                 // already unsynced
+  }
+  if (get_undolevel() < 0) {
+    return;                 // no entries, nothing to do
+  } else {
+    curbuf->b_u_synced = false;  // Append next change to last entry
   }
 }
 

--- a/test/functional/ex_cmds/undojoin_spec.lua
+++ b/test/functional/ex_cmds/undojoin_spec.lua
@@ -1,0 +1,38 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local eq = helpers.eq
+local clear = helpers.clear
+local insert = helpers.insert
+local feed = helpers.feed
+local expect = helpers.expect
+local execute = helpers.execute
+local exc_exec = helpers.exc_exec
+
+describe(':undojoin command', function()
+  before_each(function()
+    clear()
+    insert([[
+    Line of text 1
+    Line of text 2]])
+    execute('goto 1')
+  end)
+  it('joins changes in a buffer', function()
+    execute('undojoin | delete')
+    expect([[
+    Line of text 2]])
+    feed('u')
+    expect([[
+    ]])
+  end)
+  it('does not corrupt undolist when connected with redo', function()
+    feed('ixx<esc>')
+    execute('undojoin | redo')
+    expect([[
+    xxLine of text 1
+    Line of text 2]])
+  end)
+  it('does not raise an error when called twice', function()
+    local ret = exc_exec('undojoin | undojoin')
+    eq(0, ret)
+  end)
+end)


### PR DESCRIPTION
As far as I can see, the setting of `b_u_curhead` causes three bugs and provides no benefit.
I've removed the line in this branch, and no extra tests fail.
Also, manual testing still works (I've yet to write automated tests).

As far as I can tell -- I checked every occurance of the `b_u_curhead` and `b_u_synced` symbols, but there's always the chance I've just missed something -- there's no difference in behaviour between setting `b_u_curhead` and not, other than fixing the three bugs I describe below and the two small changes I've noted under this paragraph.
This is because `ex_undojoin()` sets `b_u_curhead` at the same time as setting `b_u_synced` to `false`. `b_u_synced` is never set to `true` without setting `b_u_curhead` back to `NULL`.
(except in `u_savecommon()`, if we recieve an interrupt while creating the new undo entry, which is bug 3 below).
`b_u_curhead` is never used unless `b_u_synced` is `true` except in two places, which are bugs 1 and 2 below.

Hence, the only difference between setting and not setting `b_u_curhead` is the three bugs I've noticed.

The first non-bugfix difference is that the command `:undojoin | undojoin` is now exactly the same as `:undojoin`, instead of raising the error `E790 undojoin is not allowed after undo`.

The second is that this fixes another problem I'm currently working on, but isn't the root cause there, so I don't think it counts.


The three bugs this introduces are:

## 1 `:undojoin | redo`
Essentially swaps the order of things

### Test

With the file
`test.txt`
```
first line
second line
```

Run the following:
`nvim -u NONE test.txt`
```
ixx<esc>
:undojoin | redo<CR>
```

### Observe
leaves the buffer as it was opened
running undo puts the x's back into the buffer.
cannot go backwards in time from there -- undo history is false



## 2 `:undojoin | write`     breaks the    `:earlier 1f`    command
### Test
open a new file
`nvim -u NONE test.txt`
```
first write to the file<esc>
:w<CR>
osecond write to the file<esc>
osecond line not written<esc>
:undojoin | w<CR>
:earlier 1f<CR>
```

Observe in the buffer
```
first write to the file
second write to the file
```

But this text was never written to disk.

## 3 Interrupt after `:undojoin`
Artificially send an interrupt during `u_savecommon()` after calling
`ex_undojoin()`.
This leaves the undo tree with a superfluous branch, that hasn't
actually been undone but is there as if it had been.

With the file
`test.txt`
```
Test line for actions
```


```
yy
:new
:put
    attach gdb to nvim here -- run session provided below
:undojoin | delete
    artificial Ctrl-c in gdb in u_savecommon() for delete
```

### Observe in the buffer
The line was not removed
Pressing 'u' does not remove the line -- vim thinks the end of the
changelist has been reached.
Pressing 'Ctrl-r' removes the line -- vim now thinks it is a change we
have already undone.

If we make another change, that percieved available redo is moved to
an alternate branch.

#### gdb session
The below is from a plugin I've written, but should be easy to parse as a terminal session.
All lines with `vimshell: >` are commands run, multiple lines of this kind in a row are all run and their output combined below them.
Lines with `vimshell: > #` are comments.
```
vimshell: >  pgrep nvim | { while read -r curid; do if grep 'undojoin' /proc/$curid/cmdline; then echo $curid; fi; done }
Binary file /proc/19332/cmdline matches
19332
neovim [21:03:40] $ 
vimshell: > sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
[sudo] password for hardenedapple: 
vimshell: > gdb build/bin/nvim 19332
GNU gdb (GDB) 7.12
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from build/bin/nvim...done.
Attaching to program: /home/hardenedapple/share/repos/neovim/build/bin/nvim, process 19332
[New LWP 19332]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
0x00007f5a0c8faf19 in syscall () from /usr/lib/libc.so.6
(gdb) 
vimshell: > set pagination off
(gdb) 
vimshell: > break ex_undojoin
vimshell: > command 1
vimshell: > set variable $savecommon_shouldbreak = 1
vimshell: > cont
vimshell: > end
vimshell: > break u_savecommon if $savecommon_shouldbreak
vimshell: > command 2
vimshell: > set variable $savecommon_shouldbreak = 0
vimshell: > end
Breakpoint 1 at 0x64c728: file /home/hardenedapple/share/repos/neovim/src/nvim/undo.c, line 2552.
(gdb) Type commands for breakpoint(s) 1, one per line.
End with a line saying just "end".
>>>(gdb) Breakpoint 2 at 0x646fb5: file /home/hardenedapple/share/repos/neovim/src/nvim/undo.c, line 339.
(gdb) Type commands for breakpoint(s) 2, one per line.
End with a line saying just "end".
>>(gdb) 
vimshell: > cont
Continuing.

Thread 1 "nvim" hit Breakpoint 1, ex_undojoin (eap=0x7ffeda896db0) at /home/hardenedapple/share/repos/neovim/src/nvim/undo.c:2552
2552	  if (curbuf->b_u_newhead == NULL)

Thread 1 "nvim" hit Breakpoint 2, u_savecommon (top=1, bot=3, newbot=2, reload=0) at /home/hardenedapple/share/repos/neovim/src/nvim/undo.c:339
339	{
(gdb) 
vimshell: > # Here, run :undojoin | delete    in the attached process.
vimshell: > until 555
u_savecommon (top=1, bot=3, newbot=2, reload=0) at /home/hardenedapple/share/repos/neovim/src/nvim/undo.c:556
556	  uep = xmalloc(sizeof(u_entry_T));
(gdb) 
vimshell: > print curbuf->b_u_synced
$1 = true
(gdb) 
vimshell: > print curbuf->b_u_curhead
$2 = (u_header_T *) 0x7fce2617b300
(gdb) 
vimshell: > set variable got_int = 1
(gdb) 
vimshell: > cont
Continuing.
[Thread 0x7f5a0bdff700 (LWP 19332) exited]
[Inferior 1 (process 19332) exited normally]
(gdb) 

```

