### PR TITLE
[RFC] vim-patch:7.4.2043

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -397,7 +397,7 @@ static int included_patches[] = {
   // 2046,
   // 2045 NA
   // 2044,
-  // 2043,
+  2043,
   // 2042 NA
   // 2041 NA
   // 2040 NA


### PR DESCRIPTION
**vim-patch:7.4.2043**

Problem:    setbuvfar() causes a screen redraw.
Solution:   Only use aucmd_prepbuf() for options.

https://github.com/vim/vim/commit/93431df9eb02f7cf3d7f2142bb1bef24c5f325b2