### PR TITLE
autoload/man.vim: do not pass empty argument to env when MANWIDTH is set

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -113,10 +113,11 @@ function! s:system(cmd, ...) abort
 endfunction
 
 function! s:get_page(path) abort
+  " Respect $MANWIDTH or default to window width.
+  let manwidth = empty($MANWIDTH) ? winwidth(0) : $MANWIDTH
   " Force MANPAGER=cat to ensure Vim is not recursively invoked (by man-db).
   " http://comments.gmane.org/gmane.editors.vim.devel/29085
-  " Respect $MANWIDTH, or default to window width.
-  return s:system(['env', 'MANPAGER=cat', (empty($MANWIDTH) ? 'MANWIDTH='.winwidth(0) : ''), 'man', a:path])
+  return s:system(['env', 'MANPAGER=cat', 'MANWIDTH='.manwidth, 'man', a:path])
 endfunction
 
 function! s:put_page(page) abort


### PR DESCRIPTION
When MANWIDTH is avtually set in the environment, the argv to env will have an empty string which will lead to the following error from env:

> env: ‘’: No such file or directory

Fix this, by separating the two s:system calls.