### PR TITLE
[RFC] vim-patch:7.4.2127

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1374,7 +1374,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
         }
         continue;
       }
-      if (!checkforcmd(&ea.cmd, "noswapfile", 6)) {
+      if (!checkforcmd(&ea.cmd, "noswapfile", 3)) {
         break;
       }
       cmdmod.noswapfile = true;

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -8,31 +8,57 @@ function Test_cmdmods()
 
   MyCmd
   aboveleft MyCmd
+  abo MyCmd
   belowright MyCmd
+  bel MyCmd
   botright MyCmd
+  bo MyCmd
   browse MyCmd
+  bro MyCmd
   confirm MyCmd
+  conf MyCmd
   hide MyCmd
+  hid MyCmd
   keepalt MyCmd
+  keepa MyCmd
   keepjumps MyCmd
+  keepj MyCmd
   keepmarks MyCmd
+  kee MyCmd
   keeppatterns MyCmd
+  keepp MyCmd
+  leftabove MyCmd  " results in :aboveleft
+  lefta MyCmd
   lockmarks MyCmd
+  loc MyCmd
+  " noautocmd MyCmd
   noswapfile MyCmd
+  nos MyCmd
+  rightbelow MyCmd " results in :belowright
+  rightb MyCmd
+  " sandbox MyCmd
   silent MyCmd
+  sil MyCmd
   tab MyCmd
   topleft MyCmd
+  to MyCmd
+  " unsilent MyCmd
   verbose MyCmd
+  verb MyCmd
   vertical MyCmd
+  vert MyCmd
 
   aboveleft belowright botright browse confirm hide keepalt keepjumps
         \ keepmarks keeppatterns lockmarks noswapfile silent tab
         \ topleft verbose vertical MyCmd
 
-  call assert_equal(' aboveleft belowright botright browse confirm ' .
-        \ 'hide keepalt keepjumps keepmarks keeppatterns lockmarks ' .
-        \ 'noswapfile silent tab topleft verbose vertical aboveleft ' .
-        \ 'belowright botright browse confirm hide keepalt keepjumps ' .
+  call assert_equal(' aboveleft aboveleft belowright belowright botright ' .
+        \ 'botright browse browse confirm confirm hide hide ' .
+        \ 'keepalt keepalt keepjumps keepjumps keepmarks keepmarks ' .
+        \ 'keeppatterns keeppatterns aboveleft aboveleft lockmarks lockmarks noswapfile ' .
+        \ 'noswapfile belowright belowright silent silent tab topleft topleft verbose verbose ' .
+        \ 'vertical vertical ' .
+        \ 'aboveleft belowright botright browse confirm hide keepalt keepjumps ' .
         \ 'keepmarks keeppatterns lockmarks noswapfile silent tab topleft ' .
         \ 'verbose vertical ', g:mods)
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -313,7 +313,7 @@ static int included_patches[] = {
   // 2130 NA
   // 2129 NA
   2128,
-  // 2127,
+  2127,
   2126,
   // 2125 NA
   2124,


### PR DESCRIPTION
#### vim-patch:7.4.2127

Problem:    The short form of ":noswapfile" is ":noswap" instead of ":now".
            (Kent Sibilev)
Solution:   Only require three characters.  Add a test for the short forms.

https://github.com/vim/vim/commit/3bcfca3ab4db415d0e750e00204dd25a91fcee77