### PR TITLE
[RDY] eval.c: filter_map(): avoid maybe-uninitialized-warning

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9251,7 +9251,7 @@ static void filter_map(typval_T *argvars, typval_T *rettv, int map)
   dict_T      *d = NULL;
   typval_T save_val;
   typval_T save_key;
-  int rem;
+  int rem = false;
   int todo;
   char_u      *ermsg = (char_u *)(map ? "map()" : "filter()");
   char_u      *arg_errmsg = (char_u *)(map ? N_("map() argument")


### PR DESCRIPTION
If compiled with `-Ofast`, an maybe-uninitialized-warning emerges in `filter_map()`.

Although the set of optimizations which leads to this warning is not clear, it can be easily avoided if the variable in question gets initialized upon declaration.