### PR TITLE
health: Windows: Handle backslash path separators.

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -39,7 +39,7 @@ function! health#check(plugin_names) abort
 
   tabnew
   setlocal wrap breakindent
-  setlocal filetype=markdown bufhidden=wipe
+  setlocal filetype=markdown
   setlocal conceallevel=2 concealcursor=nc
   setlocal keywordprg=:help
   call s:enhance_syntax()

--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -152,8 +152,8 @@ function! health#report_error(msg, ...) abort " {{{
 endfunction " }}}
 
 function! s:filepath_to_function(name) abort
-  return substitute(substitute(substitute(a:name, ".*autoload/", "", ""),
-        \ "\\.vim", "#check", ""), "/", "#", "g")
+  return substitute(substitute(substitute(a:name, '.*autoload[\/]', '', ''),
+        \ '\.vim', '#check', ''), '[\/]', '#', 'g')
 endfunction
 
 function! s:discover_health_checks() abort

--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -41,7 +41,7 @@ function! s:check_rplugin_manifest() abort
           \ + glob(python_dir.'/*/__init__.py', 1, 1)
       let contents = join(readfile(script))
       if contents =~# '\<\%(from\|import\)\s\+neovim\>'
-        if script =~# '/__init__\.py$'
+        if script =~# '[\/]__init__\.py$'
           let script = fnamemodify(script, ':h')
         endif
 


### PR DESCRIPTION
This fixes `:CheckHealth` on Windows.