### PR TITLE
process_wait(): Avoid dereference after LOOP_PROCESS_EVENTS.

### DIFF
--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -170,8 +170,9 @@ int process_wait(Process *proc, int ms, MultiQueue *events)
   int status = -1;
   bool interrupted = false;
   if (!proc->refcount) {
+    status = proc->status;
     LOOP_PROCESS_EVENTS(proc->loop, proc->events, 0);
-    return proc->status;
+    return status;
   }
 
   if (!events) {


### PR DESCRIPTION
ASAN build passed 3 times without reporting the use-after-free.