### PR TITLE
[RDY] New event: DirChanged

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -273,6 +273,8 @@ Name			triggered by ~
 |VimLeave|		before exiting Vim, after writing the shada file
 
 	Various
+|DirChanged|		When the current working directory changed.
+
 |FileChangedShell|	Vim notices that a file changed since editing started
 |FileChangedShellPost|	After handling a file changed since editing started
 |FileChangedRO|		before making the first change to a read-only file
@@ -562,6 +564,16 @@ CursorMoved			After the cursor was moved in Normal or Visual
 CursorMovedI			After the cursor was moved in Insert mode.
 				Not triggered when the popup menu is visible.
 				Otherwise the same as CursorMoved.
+							*DirChanged*
+DirChanged			When the current working directory was changed
+				using the |:cd| family of commands,
+				|nvim_set_current_dir()|, or on 'autochdir'.
+				The pattern must be * because its meaning may
+				change in the future.
+				It sets these |v:event| keys:
+				    cwd:   String (current working directory)
+				    scope: String ("global", "tab", "window")
+				Recursion is ignored.
 							*FileAppendCmd*
 FileAppendCmd			Before appending to a file.  Should do the
 				appending to the file.  Use the '[ and ']

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -129,6 +129,7 @@ Functions:
   |msgpackdump()|, |msgpackparse()| provide msgpack de/serialization
 
 Events:
+  |DirChanged|
   |TabNewEntered|
   |TermClose|
   |TermOpen|

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -315,7 +315,7 @@ void nvim_set_current_dir(String dir, Error *err)
 
   try_start();
 
-  if (vim_chdir((char_u *)string)) {
+  if (vim_chdir((char_u *)string, kCdScopeGlobal)) {
     if (!try_end(err)) {
       api_set_error(err, Exception, _("Failed to change directory"));
     }

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -28,6 +28,7 @@ return {
     'CursorHoldI',            -- idem, in Insert mode
     'CursorMoved',            -- cursor was moved
     'CursorMovedI',           -- cursor was moved in Insert mode
+    'DirChanged',             -- directory changed
     'EncodingChanged',        -- after changing the 'encoding' option
     'FileAppendCmd',          -- append to a file using command
     'FileAppendPost',         -- after appending to a file
@@ -101,6 +102,7 @@ return {
   -- List of neovim-specific events or aliases for the purpose of generating 
   -- syntax file
   neovim_specific = {
+    DirChanged=true,
     TabClosed=true,
     TabNew=true,
     TabNewEntered=true,

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6949,7 +6949,7 @@ void free_cd_dir(void)
 
 #endif
 
-static void apply_autocmd_dirchanged(char_u *new_dir, CdScope scope)
+void apply_autocmd_dirchanged(char_u *new_dir, CdScope scope)
 {
   dict_T *dict = get_vim_var_dict(VV_EVENT);
   char buf[8];

--- a/src/nvim/ex_docmd.h
+++ b/src/nvim/ex_docmd.h
@@ -19,21 +19,6 @@
 #define EXMODE_NORMAL           1
 #define EXMODE_VIM              2
 
-/// The scope of a working-directory command like `:cd`.
-///
-/// Scopes are enumerated from lowest to highest. When adding a scope make sure
-/// to update all functions using scopes as well, such as the implementation of
-/// `getcwd()`. When using scopes as limits (e.g. in loops) don't use the scopes
-/// directly, use `MIN_CD_SCOPE` and `MAX_CD_SCOPE` instead.
-typedef enum {
-  kCdScopeInvalid = -1,
-  kCdScopeWindow,  ///< Affects one window.
-  kCdScopeTab,     ///< Affects one tab page.
-  kCdScopeGlobal,  ///< Affects the entire instance of Neovim.
-} CdScope;
-#define MIN_CD_SCOPE  kCdScopeWindow
-#define MAX_CD_SCOPE  kCdScopeGlobal
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ex_docmd.h.generated.h"
 #endif

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -51,6 +51,7 @@
 #include "nvim/ascii.h"
 #include "nvim/file_search.h"
 #include "nvim/charset.h"
+#include "nvim/ex_docmd.h"
 #include "nvim/fileio.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
@@ -1531,7 +1532,12 @@ int vim_chdirfile(char_u *fname)
 
   STRLCPY(dir, fname, MAXPATHL);
   *path_tail_with_sep(dir) = NUL;
-  return os_chdir((char *)dir) == 0 ? OK : FAIL;
+  if (os_chdir((char *)dir) != 0) {
+    return FAIL;
+  }
+  apply_autocmd_dirchanged(dir, kCdScopeWindow);
+
+  return OK;
 }
 
 /// Change directory to "new_dir". Search 'cdpath' for relative directory names.

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -6716,8 +6716,9 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
     fname = vim_strsave(fname);         /* make a copy, so we can change it */
   } else {
     sfname = vim_strsave(fname);
-    // don't try expanding the following events
+    // Don't try expanding the following events.
     if (event == EVENT_COLORSCHEME
+        || event == EVENT_DIRCHANGED
         || event == EVENT_FILETYPE
         || event == EVENT_FUNCUNDEFINED
         || event == EVENT_OPTIONSET
@@ -6726,10 +6727,11 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
         || event == EVENT_REMOTEREPLY
         || event == EVENT_SPELLFILEMISSING
         || event == EVENT_SYNTAX
-        || event == EVENT_TABCLOSED)
+        || event == EVENT_TABCLOSED) {
       fname = vim_strsave(fname);
-    else
-      fname = (char_u *)FullName_save((char *)fname, FALSE);
+    } else {
+      fname = (char_u *)FullName_save((char *)fname, false);
+    }
   }
   if (fname == NULL) {      /* out of memory */
     xfree(sfname);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1249,4 +1249,20 @@ typedef enum {
   kBroken
 } WorkingStatus;
 
+/// The scope of a working-directory command like `:cd`.
+///
+/// Scopes are enumerated from lowest to highest. When adding a scope make sure
+/// to update all functions using scopes as well, such as the implementation of
+/// `getcwd()`. When using scopes as limits (e.g. in loops) don't use the scopes
+/// directly, use `MIN_CD_SCOPE` and `MAX_CD_SCOPE` instead.
+typedef enum {
+  kCdScopeInvalid = -1,
+  kCdScopeWindow,  ///< Affects one window.
+  kCdScopeTab,     ///< Affects one tab page.
+  kCdScopeGlobal,  ///< Affects the entire instance of Neovim.
+} CdScope;
+
+#define MIN_CD_SCOPE  kCdScopeWindow
+#define MAX_CD_SCOPE  kCdScopeGlobal
+
 #endif /* NVIM_GLOBALS_H */

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1404,7 +1404,7 @@ int op_delete(oparg_T *oap)
 
     if (oap->regname == 0) {
       set_clipboard(0, reg);
-      yank_do_autocmd(oap, reg);
+      do_autocmd_textyankpost(oap, reg);
     }
 
   }
@@ -2315,7 +2315,7 @@ bool op_yank(oparg_T *oap, bool message)
   yankreg_T *reg = get_yank_register(oap->regname, YREG_YANK);
   op_yank_reg(oap, message, reg, is_append_register(oap->regname));
   set_clipboard(oap->regname, reg);
-  yank_do_autocmd(oap, reg);
+  do_autocmd_textyankpost(oap, reg);
 
   return true;
 }
@@ -2538,7 +2538,7 @@ static void yank_copy_line(yankreg_T *reg, struct block_def *bd, size_t y_idx)
 ///
 /// @param oap Operator arguments.
 /// @param reg The yank register used.
-static void yank_do_autocmd(oparg_T *oap, yankreg_T *reg)
+static void do_autocmd_textyankpost(oparg_T *oap, yankreg_T *reg)
   FUNC_ATTR_NONNULL_ALL
 {
   static bool recursive = false;

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -14,4 +14,5 @@ typedef unsigned char char_u;
 typedef uint32_t u8char_T;
 
 typedef struct expand expand_T;
+
 #endif  // NVIM_TYPES_H

--- a/test/functional/autocmd/dirchanged_spec.lua
+++ b/test/functional/autocmd/dirchanged_spec.lua
@@ -1,0 +1,88 @@
+local lfs = require('lfs')
+local h = require('test.functional.helpers')(after_each)
+
+local clear = h.clear
+local command = h.command
+local eq = h.eq
+local eval = h.eval
+local request = h.request
+
+describe('DirChanged ->', function()
+  local curdir = lfs.currentdir()
+  local dirs = {
+    curdir .. '/Xtest-functional-autocmd-dirchanged.dir1',
+    curdir .. '/Xtest-functional-autocmd-dirchanged.dir2',
+    curdir .. '/Xtest-functional-autocmd-dirchanged.dir3',
+  }
+
+  setup(function()    for _, dir in pairs(dirs) do h.mkdir(dir) end end)
+  teardown(function() for _, dir in pairs(dirs) do h.rmdir(dir) end end)
+
+  before_each(function()
+    clear()
+    command('autocmd DirChanged * let g:event = copy(v:event)')
+  end)
+
+  it('"autocmd DirChanged *" sets v:event for all :cd variants', function()
+    command('lcd '..dirs[1])
+    eq({cwd=dirs[1], scope='window'}, eval('g:event'))
+
+    command('tcd '..dirs[2])
+    eq({cwd=dirs[2], scope='tab'}, eval('g:event'))
+
+    command('cd '..dirs[3])
+    eq({cwd=dirs[3], scope='global'}, eval('g:event'))
+  end)
+
+  it('"autocmd DirChanged *" does not trigger for failing :cd variants', function()
+    command('let g:event = {}')
+
+    local status1, err1 = pcall(function()
+      command('lcd '..dirs[1] .. '/doesnotexist')
+    end)
+    eq({}, eval('g:event'))
+
+    local status2, err2 = pcall(function()
+      command('lcd '..dirs[2] .. '/doesnotexist')
+    end)
+    eq({}, eval('g:event'))
+
+    local status3, err3 = pcall(function()
+      command('lcd '..dirs[3] .. '/doesnotexist')
+    end)
+    eq({}, eval('g:event'))
+
+    eq(false, status1)
+    eq(false, status2)
+    eq(false, status3)
+
+    eq('E344', string.match(err1, 'Vim.*:(.*):'))
+    eq('E344', string.match(err2, 'Vim.*:(.*):'))
+    eq('E344', string.match(err3, 'Vim.*:(.*):'))
+  end)
+
+  it("'autochdir' triggers DirChanged", function()
+    command('set autochdir')
+
+    command('split '..dirs[1]..'/foo')
+    eq({cwd=dirs[1], scope='window'}, eval('g:event'))
+
+    command('split '..dirs[2]..'/bar')
+    eq({cwd=dirs[2], scope='window'}, eval('g:event'))
+  end)
+
+  it('nvim_set_current_dir() triggers DirChanged', function()
+    request('nvim_set_current_dir', dirs[1])
+    eq({cwd=dirs[1], scope='global'}, eval('g:event'))
+
+    request('nvim_set_current_dir', dirs[2])
+    eq({cwd=dirs[2], scope='global'}, eval('g:event'))
+
+    local status, err = pcall(function()
+      request('nvim_set_current_dir', '/doesnotexist')
+    end)
+    eq(false, status)
+    eq('Failed to change directory', string.match(err, ': (.*)'))
+    eq({cwd=dirs[2], scope='global'}, eval('g:event'))
+  end)
+end)


### PR DESCRIPTION
- `v:event.cwd` and `<afile>` are set to the new directory
- `v:event.scope` is set to either "global", "tab", "window", or "invalid" (which should never happen)

This is just a suggestion so far. What do you think?

- [x] Code
- [x] Documentation
- [x] Tests