### PR TITLE
Windows: vim_getenv(): Find runtime using executable path.

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -192,6 +192,18 @@ int os_nodetype(const char *name)
   return nodetype;
 }
 
+/// Gets the absolute path of the currently running executable.
+///
+/// @param[out] buffer Returns the path string.
+/// @param[in]  size   Size of `buffer`.
+///
+/// @return `0` on success, or libuv error code on failure.
+int os_exepath(char *buffer, size_t *size)
+  FUNC_ATTR_NONNULL_ALL
+{
+  return uv_exepath(buffer, size);
+}
+
 /// Checks if the given path represents an executable file.
 ///
 /// @param[in]  name     Name of the executable.


### PR DESCRIPTION
Rebase/continue #3303

In Windows we cannot rely on absolute install paths to point to the
location of the runtime. Vim used the path of the current binary as
a possible location for the runtime folder. In Neovim the install
locations places the runtime folder in ../share/nvim/runtime.

In Vim this logic is guarded by USE_EXE_NAME, which is defined for win32
and macOS.

**TODO:** We may need to incorporate similar logic for macOS:
https://github.com/vim/vim/blob/0cdb72aa38c4a0140c94d56bf8bc17cb30260ebf/src/misc1.c#L4287-L4308