### PR TITLE
[RDY] open_buffer(): Raise `BufEnter` for directories.

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -193,10 +193,13 @@ open_buffer (
        * it can be changed there. */
       if (!readonlymode && !bufempty())
         changed();
-      else if (retval != FAIL)
+      else if (retval == OK) {
         unchanged(curbuf, FALSE);
-      apply_autocmds_retval(EVENT_STDINREADPOST, NULL, NULL, FALSE,
-          curbuf, &retval);
+      }
+      if (retval == OK) {
+        apply_autocmds_retval(EVENT_STDINREADPOST, NULL, NULL, FALSE,
+                              curbuf, &retval);
+      }
     }
   }
 
@@ -219,7 +222,7 @@ open_buffer (
       || (aborting() && vim_strchr(p_cpo, CPO_INTMOD) != NULL)
       )
     changed();
-  else if (retval != FAIL && !read_stdin)
+  else if (retval == OK && !read_stdin)
     unchanged(curbuf, FALSE);
   save_file_ff(curbuf);                 /* keep this fileformat */
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -189,15 +189,16 @@ open_buffer (
       curwin->w_cursor.lnum = 1;
       curwin->w_cursor.col = 0;
 
-      /* Set or reset 'modified' before executing autocommands, so that
-       * it can be changed there. */
-      if (!readonlymode && !bufempty())
+      // Set or reset 'modified' before executing autocommands, so that
+      // it can be changed there.
+      if (!readonlymode && !bufempty()) {
         changed();
-      else if (retval == OK) {
-        unchanged(curbuf, FALSE);
+      } else if (retval == OK) {
+        unchanged(curbuf, false);
       }
+
       if (retval == OK) {
-        apply_autocmds_retval(EVENT_STDINREADPOST, NULL, NULL, FALSE,
+        apply_autocmds_retval(EVENT_STDINREADPOST, NULL, NULL, false,
                               curbuf, &retval);
       }
     }
@@ -209,22 +210,21 @@ open_buffer (
     parse_cino(curbuf);
   }
 
-  /*
-   * Set/reset the Changed flag first, autocmds may change the buffer.
-   * Apply the automatic commands, before processing the modelines.
-   * So the modelines have priority over auto commands.
-   */
-  /* When reading stdin, the buffer contents always needs writing, so set
-   * the changed flag.  Unless in readonly mode: "ls | nvim -R -".
-   * When interrupted and 'cpoptions' contains 'i' set changed flag. */
+  // Set/reset the Changed flag first, autocmds may change the buffer.
+  // Apply the automatic commands, before processing the modelines.
+  // So the modelines have priority over auto commands.
+
+  // When reading stdin, the buffer contents always needs writing, so set
+  // the changed flag.  Unless in readonly mode: "ls | nvim -R -".
+  // When interrupted and 'cpoptions' contains 'i' set changed flag.
   if ((got_int && vim_strchr(p_cpo, CPO_INTMOD) != NULL)
-      || modified_was_set               /* ":set modified" used in autocmd */
-      || (aborting() && vim_strchr(p_cpo, CPO_INTMOD) != NULL)
-      )
+      || modified_was_set               // ":set modified" used in autocmd
+      || (aborting() && vim_strchr(p_cpo, CPO_INTMOD) != NULL)) {
     changed();
-  else if (retval == OK && !read_stdin)
-    unchanged(curbuf, FALSE);
-  save_file_ff(curbuf);                 /* keep this fileformat */
+  } else if (retval == OK && !read_stdin) {
+    unchanged(curbuf, false);
+  }
+  save_file_ff(curbuf);                 // keep this fileformat
 
   /* require "!" to overwrite the file, because it wasn't read completely */
   if (aborting())

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1193,8 +1193,8 @@ static void do_filter(
 
   if (do_out) {
     if (otmp != NULL) {
-      if (readfile(otmp, NULL, line2, (linenr_T)0, (linenr_T)MAXLNUM,
-              eap, READ_FILTER) == FAIL) {
+      if (readfile(otmp, NULL, line2, (linenr_T)0, (linenr_T)MAXLNUM, eap,
+                   READ_FILTER) != OK) {
         if (!aborting()) {
           msg_putchar('\n');
           EMSG2(_(e_notread), otmp);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6910,9 +6910,10 @@ static void ex_read(exarg_T *eap)
           eap->line2, (linenr_T)0, (linenr_T)MAXLNUM, eap, 0);
 
     }
-    if (i == FAIL) {
-      if (!aborting())
+    if (i != OK) {
+      if (!aborting()) {
         EMSG2(_(e_notopen), eap->arg);
+      }
     } else {
       if (empty && exmode_active) {
         /* Delete the empty line that remains.  Historically ex does

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -249,7 +249,7 @@ void filemess(buf_T *buf, char_u *name, char_u *s, int attr)
  * READ_DUMMY	read into a dummy buffer (to check if file contents changed)
  * READ_KEEP_UNDO  don't clear undo info or read it from a file
  *
- * return FAIL for failure, OK otherwise
+ * return FAIL for failure, NOTDONE for directory (failure), or OK
  */
 int 
 readfile (
@@ -258,7 +258,7 @@ readfile (
     linenr_T from,
     linenr_T lines_to_skip,
     linenr_T lines_to_read,
-    exarg_T *eap,                       /* can be NULL! */
+    exarg_T *eap,                       // can be NULL!
     int flags
 )
 {
@@ -444,13 +444,14 @@ readfile (
         // ... or a character special file named /dev/fd/<n>
 # endif
         ) {
-      if (S_ISDIR(perm))
+      if (S_ISDIR(perm)) {
         filemess(curbuf, fname, (char_u *)_("is a directory"), 0);
-      else
+      } else {
         filemess(curbuf, fname, (char_u *)_("is not a file"), 0);
+      }
       msg_end();
       msg_scroll = msg_save;
-      return FAIL;
+      return S_ISDIR(perm) ? NOTDONE : FAIL;
     }
 #endif
   }
@@ -5108,7 +5109,7 @@ void buf_reload(buf_T *buf, int orig_mode)
     keep_filetype = TRUE;                     /* don't detect 'filetype' */
     if (readfile(buf->b_ffname, buf->b_fname, (linenr_T)0,
             (linenr_T)0,
-            (linenr_T)MAXLNUM, &ea, flags) == FAIL) {
+            (linenr_T)MAXLNUM, &ea, flags) != OK) {
       if (!aborting())
         EMSG2(_("E321: Could not reload \"%s\""), buf->b_fname);
       if (savebuf != NULL && buf_valid(savebuf) && buf == curbuf) {

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5105,13 +5105,13 @@ void buf_reload(buf_T *buf, int orig_mode)
   }
 
   if (saved == OK) {
-    curbuf->b_flags |= BF_CHECK_RO;           /* check for RO again */
-    keep_filetype = TRUE;                     /* don't detect 'filetype' */
-    if (readfile(buf->b_ffname, buf->b_fname, (linenr_T)0,
-            (linenr_T)0,
-            (linenr_T)MAXLNUM, &ea, flags) != OK) {
-      if (!aborting())
+    curbuf->b_flags |= BF_CHECK_RO;           // check for RO again
+    keep_filetype = true;                     // don't detect 'filetype'
+    if (readfile(buf->b_ffname, buf->b_fname, (linenr_T)0, (linenr_T)0,
+                 (linenr_T)MAXLNUM, &ea, flags) != OK) {
+      if (!aborting()) {
         EMSG2(_("E321: Could not reload \"%s\""), buf->b_fname);
+      }
       if (savebuf != NULL && buf_valid(savebuf) && buf == curbuf) {
         /* Put the text back from the save buffer.  First
          * delete any lines that readfile() added. */

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1063,11 +1063,12 @@ void ml_recover(void)
             if (!cannot_open) {
               line_count = pp->pb_pointer[idx].pe_line_count;
               if (readfile(curbuf->b_ffname, NULL, lnum,
-                      pp->pb_pointer[idx].pe_old_lnum - 1,
-                      line_count, NULL, 0) != OK)
-                cannot_open = TRUE;
-              else
+                           pp->pb_pointer[idx].pe_old_lnum - 1, line_count,
+                           NULL, 0) != OK) {
+                cannot_open = true;
+              } else {
                 lnum += line_count;
+              }
             }
             if (cannot_open) {
               ++error;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1064,7 +1064,7 @@ void ml_recover(void)
               line_count = pp->pb_pointer[idx].pe_line_count;
               if (readfile(curbuf->b_ffname, NULL, lnum,
                       pp->pb_pointer[idx].pe_old_lnum - 1,
-                      line_count, NULL, 0) == FAIL)
+                      line_count, NULL, 0) != OK)
                 cannot_open = TRUE;
               else
                 lnum += line_count;

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -8,8 +8,6 @@ local nvim_prog, command, funcs = helpers.nvim_prog, helpers.command, helpers.fu
 local source, next_message = helpers.source, helpers.next_message
 local meths = helpers.meths
 
-if helpers.pending_win32(pending) then return end
-
 describe('server -> client', function()
   local cid
 
@@ -211,6 +209,8 @@ describe('server -> client', function()
     after_each(function()
       funcs.jobstop(jobid)
     end)
+
+    if helpers.pending_win32(pending) then return end
 
     it('rpc and text stderr can be combined', function()
       eq("ok",funcs.rpcrequest(jobid, "poll"))

--- a/test/functional/autocmd/bufenter_spec.lua
+++ b/test/functional/autocmd/bufenter_spec.lua
@@ -1,0 +1,35 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local command = helpers.command
+local eq = helpers.eq
+local eval = helpers.eval
+local execute = helpers.execute
+local request = helpers.request
+local source = helpers.source
+
+describe('autocmd BufEnter', function()
+  before_each(clear)
+
+  it("triggered by nvim_command('edit <dir>')", function()
+    command("autocmd BufEnter * if isdirectory(expand('<afile>')) | let g:dir_bufenter = 1 | endif")
+    request("nvim_command", "split .")
+    eq(1, eval("exists('g:dir_bufenter')"))  -- Did BufEnter for the directory.
+    eq(2, eval("bufnr('%')"))                -- Switched to the dir buffer.
+  end)
+
+  it('triggered by "try|:split <dir>|endtry" in a function', function()
+    command("autocmd BufEnter * if isdirectory(expand('<afile>')) | let g:dir_bufenter = 1 | endif")
+    source([[
+      function! Test()
+        try
+          exe 'split .'
+        catch
+        endtry
+      endfunction
+    ]])
+    execute("call Test()")
+    eq(1, eval("exists('g:dir_bufenter')"))  -- Did BufEnter for the directory.
+    eq(2, eval("bufnr('%')"))                -- Switched to the dir buffer.
+  end)
+end)

--- a/test/functional/autocmd/tabnew_spec.lua
+++ b/test/functional/autocmd/tabnew_spec.lua
@@ -5,8 +5,6 @@ local command = helpers.command
 local eq = helpers.eq
 local eval = helpers.eval
 
-if helpers.pending_win32(pending) then return end
-
 describe('autocmd TabNew', function()
   before_each(clear)
 
@@ -19,12 +17,11 @@ describe('autocmd TabNew', function()
   end)
 
   it('matches when opening a new tab for FILE', function()
-    local tmp_path = helpers.funcs.tempname()
     command('let g:test = "foo"')
-    command('autocmd! TabNew ' .. tmp_path .. ' let g:test = "bar"')
-    command('tabnew ' .. tmp_path ..'X')
+    command('autocmd! TabNew Xtest-tabnew let g:test = "bar"')
+    command('tabnew Xtest-tabnewX')
     eq('foo', eval('g:test'))
-    command('tabnew ' .. tmp_path)
+    command('tabnew Xtest-tabnew')
     eq('bar', eval('g:test'))
   end)
 end)

--- a/test/functional/autocmd/tabnewentered_spec.lua
+++ b/test/functional/autocmd/tabnewentered_spec.lua
@@ -1,8 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear, nvim, eq = helpers.clear, helpers.nvim, helpers.eq
 
-if helpers.pending_win32(pending) then return end
-
 describe('TabNewEntered', function()
   describe('au TabNewEntered', function()
     describe('with * as <afile>', function()
@@ -15,9 +13,9 @@ describe('TabNewEntered', function()
     end)
     describe('with FILE as <afile>', function()
       it('matches when opening a new tab for FILE', function()
-        local tmp_path = nvim('eval', 'tempname()')
-        nvim('command', 'au! TabNewEntered '..tmp_path..' echom "tabnewentered:match"')
-        eq("\n\""..tmp_path.."\" [New File]\ntabnewentered:4:4\ntabnewentered:match", nvim('command_output', 'tabnew '..tmp_path))
+        nvim('command', 'au! TabNewEntered Xtest-tabnewentered echom "tabnewentered:match"')
+        eq('\n"Xtest-tabnewentered" [New File]\ntabnewentered:4:4\ntabnewentered:match',
+          nvim('command_output', 'tabnew Xtest-tabnewentered'))
      end)
     end)
     describe('with CTRL-W T', function()

--- a/test/functional/core/job_partial_spec.lua
+++ b/test/functional/core/job_partial_spec.lua
@@ -2,13 +2,14 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear, eq, next_msg, nvim, source = helpers.clear, helpers.eq,
   helpers.next_message, helpers.nvim, helpers.source
 
-if helpers.pending_win32(pending) then return end
-
 describe('jobs with partials', function()
   local channel
 
   before_each(function()
     clear()
+    if helpers.os_name() == 'windows' then
+      helpers.set_shell_powershell()
+    end
     channel = nvim('get_api_info')[1]
     nvim('set_var', 'channel', channel)
   end)
@@ -16,12 +17,14 @@ describe('jobs with partials', function()
   it('works correctly', function()
     source([[
     function PrintArgs(a1, a2, id, data, event)
-      call rpcnotify(g:channel, '1', a:a1,  a:a2, a:data, a:event)
+      " Windows: Remove ^M char.
+      let normalized = map(a:data, 'substitute(v:val, "\r", "", "g")')
+      call rpcnotify(g:channel, '1', a:a1,  a:a2, normalized, a:event)
     endfunction
     let Callback = function('PrintArgs', ["foo", "bar"])
     let g:job_opts = {'on_stdout': Callback}
-    call jobstart(['echo'], g:job_opts)
+    call jobstart('echo "some text"', g:job_opts)
     ]])
-    eq({'notification', '1', {'foo', 'bar', {'', ''}, 'stdout'}}, next_msg())
+    eq({'notification', '1', {'foo', 'bar', {'some text', ''}, 'stdout'}}, next_msg())
   end)
 end)

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -346,6 +346,14 @@ local function source(code)
   return fname
 end
 
+local function set_shell_powershell()
+  source([[
+    set shell=powershell shellquote=\" shellpipe=\| shellredir=>
+    set shellcmdflag=\ -ExecutionPolicy\ RemoteSigned\ -Command
+    let &shellxquote=' '
+  ]])
+end
+
 local function nvim(method, ...)
   return request('nvim_'..method, ...)
 end
@@ -590,6 +598,7 @@ return function(after_each)
     curtabmeths = curtabmeths,
     pending_win32 = pending_win32,
     skip_fragile = skip_fragile,
+    set_shell_powershell = set_shell_powershell,
     tmpname = tmpname,
     NIL = mpack.NIL,
   }


### PR DESCRIPTION
Abuse NOTDONE to give some nuance to the return value of readfile(), so
that open_buffer() can distinguish between "failed, lol", and "failed
because the path is a directory".

Before this change, Vim *already* creates a new buffer when a directory
is edited. So there is no reason it should not raise BufEnter, that was
an implementation of ye olde readfile().

The explicit changes in the diff are only to preserve the old semantics. The "passive" change that we actually are interested in, is this line in `open_buffer()`, where `&retval` being non-FAIL allows EVENT_BUFENTER to be applied:

    apply_autocmds_retval(EVENT_BUFENTER, NULL, NULL, FALSE, curbuf, &retval);

---

The change has at least these benefits:

- `:try | split <dir> | endtry` lets plugins like netrw, dirvish work
- API function `call nvim_command('split <dir>')` works as expected.

todo

- [x] test coverage