### PR TITLE
eval: Remove dictwatcher from watchers queue before freeing it

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6410,8 +6410,8 @@ static void dict_free_contents(dict_T *d) {
   while (!QUEUE_EMPTY(&d->watchers)) {
     QUEUE *w = QUEUE_HEAD(&d->watchers);
     DictWatcher *watcher = dictwatcher_node_data(w);
-    dictwatcher_free(watcher);
     QUEUE_REMOVE(w);
+    dictwatcher_free(watcher);
   }
 
   hash_clear(&d->dv_hashtab);

--- a/test/functional/ex_cmds/dict_notifications_spec.lua
+++ b/test/functional/ex_cmds/dict_notifications_spec.lua
@@ -3,6 +3,7 @@ local clear, nvim, source = helpers.clear, helpers.nvim, helpers.source
 local eq, next_msg = helpers.eq, helpers.next_message
 local exc_exec = helpers.exc_exec
 local command = helpers.command
+local eval = helpers.eval
 
 
 describe('dictionary change notifications', function()
@@ -254,6 +255,22 @@ describe('dictionary change notifications', function()
       command('let g:key = "value"')
       eq({'notification', '2b', {'key', {old = 'v2', new = 'value'}}}, next_msg())
 
+    end)
+
+    it('does not crash when freeing a watched dictionary', function()
+      source([[
+        function! Watcher(dict, key, value)
+          echo a:key string(a:value)
+        endfunction
+
+        function! MakeWatch()
+          let d = {'foo': 'bar'}
+          call dictwatcheradd(d, 'foo', function('Watcher'))
+        endfunction
+      ]])
+
+      command('call MakeWatch()')
+      eq(2, eval('1+1')) -- Still alive?
     end)
   end)
 end)


### PR DESCRIPTION
This fixes a free-after-use noticed by ASAN which would occur when a
dictwatcher was still active on a dictionary when the dictionary was
freed.

    fun! MakeWatch()
      let d = {'foo': 'bar'}
      call dictwatcheradd(d, 'foo', function('...'))
    endfun

Patch-by: oni-link
Closes #5930