### PR TITLE
[RFC] vim-patch:8.0.0121

### DIFF
--- a/scripts/genoptions.lua
+++ b/scripts/genoptions.lua
@@ -31,6 +31,7 @@ local type_flags={
 local redraw_flags={
   statuslines='P_RSTAT',
   current_window='P_RWIN',
+  current_window_only='P_RWINONLY',
   current_buffer='P_RBUF',
   all_windows='P_RALL',
   everything='P_RCLR',

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -238,6 +238,8 @@ typedef struct vimoption {
                                    ///< when there is a redraw flag
 #define P_NO_DEF_EXP   0x8000000U  ///< Do not expand default value.
 
+#define P_RWINONLY     0x10000000U  ///< only redraw current window
+
 #define HIGHLIGHT_INIT \
   "8:SpecialKey,~:EndOfBuffer,z:TermCursor,Z:TermCursorNC,@:NonText," \
   "d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr," \
@@ -4364,6 +4366,8 @@ static void check_redraw(uint32_t flags)
     changed_window_setting();
   if (flags & P_RBUF)
     redraw_curbuf_later(NOT_VALID);
+  if (flags & P_RWINONLY)
+    redraw_later(NOT_VALID);
   if (doclear)
     redraw_all_later(CLEAR);
   else if (all)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -213,12 +213,12 @@ typedef struct vimoption {
 #define P_VI_DEF        0x400U   /* Use Vi default for Vim */
 #define P_VIM           0x800U   /* Vim option */
 
-/* when option changed, what to display: */
-#define P_RSTAT         0x1000U  /* redraw status lines */
-#define P_RWIN          0x2000U  /* redraw current window */
-#define P_RBUF          0x4000U  /* redraw current buffer */
-#define P_RALL          0x6000U  /* redraw all windows */
-#define P_RCLR          0x7000U  /* clear and redraw all */
+// when option changed, what to display:
+#define P_RSTAT         0x1000U  ///< redraw status lines
+#define P_RWIN          0x2000U  ///< redraw current window and recompute text
+#define P_RBUF          0x4000U  ///< redraw current buffer and recompute text
+#define P_RALL          0x6000U  ///< redraw all windows
+#define P_RCLR          0x7000U  ///< clear and redraw all
 
 #define P_COMMA         0x8000U    ///< comma separated list
 #define P_ONECOMMA      0x18000U   ///< P_COMMA and cannot have two consecutive
@@ -4359,19 +4359,24 @@ static void check_redraw(uint32_t flags)
   bool doclear = (flags & P_RCLR) == P_RCLR;
   bool all = ((flags & P_RALL) == P_RALL || doclear);
 
-  if ((flags & P_RSTAT) || all)         /* mark all status lines dirty */
+  if ((flags & P_RSTAT) || all) {  // mark all status lines dirty
     status_redraw_all();
+  }
 
-  if ((flags & P_RBUF) || (flags & P_RWIN) || all)
+  if ((flags & P_RBUF) || (flags & P_RWIN) || all) {
     changed_window_setting();
-  if (flags & P_RBUF)
+  }
+  if (flags & P_RBUF) {
     redraw_curbuf_later(NOT_VALID);
-  if (flags & P_RWINONLY)
+  }
+  if (flags & P_RWINONLY) {
     redraw_later(NOT_VALID);
-  if (doclear)
+  }
+  if (doclear) {
     redraw_all_later(CLEAR);
-  else if (all)
+  } else if (all) {
     redraw_all_later(NOT_VALID);
+  }
 }
 
 /// Find index for named option

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -17,8 +17,8 @@
 -- types: bool, number, string
 -- lists: (nil), comma, onecomma, flags, flagscomma
 -- scopes: global, buffer, window
--- redraw options: statuslines, current_window, current_buffer, all_windows, 
---                 everything, curswant
+-- redraw options: statuslines, current_window, curent_window_only,
+--                 current_buffer, all_windows, everything, curswant
 -- default: {vi=…[, vim=…]}
 -- defaults: {condition=#if condition, if_true=default, if_false=default}
 -- #if condition:
@@ -539,7 +539,7 @@ return {
       full_name='cursorline', abbreviation='cul',
       type='bool', scope={'window'},
       vi_def=true,
-      redraw={'current_window'},
+      redraw={'current_window_only'},
       defaults={if_true={vi=false}}
     },
     {

--- a/src/nvim/testdir/test_goto.vim
+++ b/src/nvim/testdir/test_goto.vim
@@ -18,3 +18,18 @@ func Test_gee_dee()
   call assert_equal(14, col('.'))
   quit!
 endfunc
+
+" Check that setting 'cursorline' does not change curswant
+func Test_cursorline_keep_col()
+  new
+  call setline(1, ['long long long line', 'short line'])
+  normal ggfi
+  let pos = getcurpos()
+  normal j
+  set cursorline
+  normal k
+  call assert_equal(pos, getcurpos())
+  bwipe!
+  set nocursorline
+endfunc
+


### PR DESCRIPTION
Problem:    Setting 'cursorline' changes the curswant column. (Daniel Hahler)
Solution:   Add the P_RWINONLY flag. (closes vim/vim#1297)

https://github.com/vim/vim/commit/a2477fd3490c1166522631eee53c57d34321086a

This is my first merge of a patch from Vim, and it was mostly manually.