### PR TITLE
job: Consume content from rbuffer before invoking the callback again

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -23183,11 +23183,10 @@ static void on_job_output(Stream *stream, TerminalJobData *data, RBuffer *buf,
     terminal_receive(data->term, ptr, count);
   }
 
+  rbuffer_consumed(buf, count);
   if (callback->type != kCallbackNone) {
     process_job_event(data, callback, type, ptr, count, 0);
   }
-
-  rbuffer_consumed(buf, count);
 }
 
 static void eval_job_process_exit_cb(Process *proc, int status, void *d)


### PR DESCRIPTION
While a job callback is active, it may be invoked again.  Since the
data handled by the first invocation of the callback hasn't been marked
as consumed, the subsequent invocation will see the same data.

Reported-by: Daniel Hahler
Patch-by: @oni-link
Closes #5889