### PR TITLE
Windows: test: enable python3_spec.lua

### DIFF
--- a/.ci/build.bat
+++ b/.ci/build.bat
@@ -3,11 +3,11 @@
 :: in MSYS2, but we cannot build inside the MSYS2 shell.
 echo on
 if "%CONFIGURATION%" == "MINGW_32" (
-	set ARCH=i686
-	set BITS=32
+  set ARCH=i686
+  set BITS=32
 ) else (
-	set ARCH=x86_64
-	set BITS=64
+  set ARCH=x86_64
+  set BITS=64
 )
 :: We cannot have sh.exe in the PATH (MinGW)
 set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
@@ -19,12 +19,15 @@ set PATH=C:\Program Files (x86)\CMake\bin\cpack.exe;%PATH%
 C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm -Su" || goto :error
 C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm --needed -S mingw-w64-%ARCH%-cmake mingw-w64-%ARCH%-perl mingw-w64-%ARCH%-diffutils gperf" || goto :error
 
-:: Use Appveyor's python
-set PATH=C:\Python27;C:\Python27\Scripts;%PATH%
-set PATH=C:\Python35;C:\Python35\Scripts;%PATH%
-copy c:\Python35\python.exe c:\Python35\python3.exe
-pip2 install neovim || goto error
-pip3 install neovim || goto error
+:: Setup python (use AppVeyor system python)
+C:\Python27\python.exe -m pip install neovim || goto :error
+C:\Python35\python.exe -m pip install neovim || goto :error
+:: Disambiguate python3
+move c:\Python35\python.exe c:\Python35\python3.exe
+set PATH=C:\Python35;C:\Python27;%PATH%
+:: Sanity check
+python  -c "import neovim; print(str(neovim))" || goto :error
+python3 -c "import neovim; print(str(neovim))" || goto :error
 
 mkdir .deps
 cd .deps


### PR DESCRIPTION
This was an attempt to enable test/functional/provider/python3_spec.lua
It actually *does* appear to work if we do this:

    mingw32-make functionaltest VERBOSE=1 PATH=C:\Python35;C:\Python27;%PATH%

Note that `%PATH%` *already* has `C:\Python35` at its start by then, so
`PATH=C:\Python35;C:\Python27;%PATH%` is _redundant_.
python3_spec.lua *does* find python3.exe in that case, and succeeds.
But it causes weird failures in unrelated tests:

    [----------] Running tests from C:/projects/neovim/test/functional\core\job_partial_spec.lua
    [ RUN      ] ...rojects/neovim/test/functional\core\job_partial_spec.lua @ 17: jobs with partials works correctly
    .\test\functional\helpers.lua:89: Vim(call):E903: Process for command "powershell" could not be spawned
    stack traceback:
        .\test\functional\helpers.lua:89: in function 'request'
        .\test\functional\helpers.lua:147: in function 'nvim_command'
        .\test\functional\helpers.lua:344: in function 'source'
        ...rojects/neovim/test/functional\core\job_partial_spec.lua:18: in function <...rojects/neovim/test/functional\core\job_partial_spec.lua:17>
    [  ERROR   ] ...rojects/neovim/test/functional\core\job_partial_spec.lua @ 17: jobs with partials works correctly (0.00 ms)

    [ RUN      ] C:/projects/neovim/test/functional\eval\execute_spec.lua @ 73: execute() does not capture shell-command output
    C:/projects/neovim/test/functional\eval\execute_spec.lua:74: Expected objects to be the same.
    Passed in:
    (string) '
    :!echo "foo"
    Cannot execute cmd.exe
    shell returned -1
    '
    Expected:
    (string) '
    :!echo "foo"
    '
    stack traceback:
        C:/projects/neovim/test/functional\eval\execute_spec.lua:74: in function <C:/projects/neovim/test/functional\eval\execute_spec.lua:73>
    [  FAILED  ] C:/projects/neovim/test/functional\eval\execute_spec.lua @ 73: execute() does not capture shell-command output (15.60 ms)

    [ RUN      ] C:/projects/neovim/test/functional\ex_cmds\arg_spec.lua @ 11: :argument does not restart :terminal buffer
    C:/projects/neovim/test/functional\ex_cmds\arg_spec.lua:18: Expected objects to be the same.
    Passed in:
    (boolean) false
    Expected:
    (boolean) true
    stack traceback:
        C:/projects/neovim/test/functional\ex_cmds\arg_spec.lua:18: in function <C:/projects/neovim/test/functional\ex_cmds\arg_spec.lua:11>
    [  FAILED  ] C:/projects/neovim/test/functional\ex_cmds\arg_spec.lua @ 11: :argument does not restart :terminal buffer (0.00 ms)

    [ RUN      ] C:/projects/neovim/test/functional\ex_cmds\edit_spec.lua @ 11: :edit without arguments does not restart :terminal buffer
    C:/projects/neovim/test/functional\ex_cmds\edit_spec.lua:16: Expected objects to be the same.
    Passed in:
    (boolean) false
    Expected:
    (boolean) true
    stack traceback:
        C:/projects/neovim/test/functional\ex_cmds\edit_spec.lua:16: in function <C:/projects/neovim/test/functional\ex_cmds\edit_spec.lua:11>
    [  FAILED  ] C:/projects/neovim/test/functional\ex_cmds\edit_spec.lua @ 11: :edit without arguments does not restart :terminal buffer (15.60 ms)

    [ RUN      ] ...s/neovim/test/functional\eval\msgpack_functions_spec.lua @ 457: msgpackparse() function msgpackparse(systemlist(...)) does not segfault. #3135
    .\test\functional\helpers.lua:89: Failed to evaluate expression
    stack traceback:
        .\test\functional\helpers.lua:89: in function 'eval'
        ...s/neovim/test/functional\eval\msgpack_functions_spec.lua:460: in function <...s/neovim/test/functional\eval\msgpack_functions_spec.lua:457>
    [  ERROR   ] ...s/neovim/test/functional\eval\msgpack_functions_spec.lua @ 457: msgpackparse() function msgpackparse(systemlist(...)) does not segfault. #3135 (15.63 ms)

    [  FAILED  ] 3 tests, listed below:
    [  FAILED  ] C:/projects/neovim/test/functional\eval\execute_spec.lua @ 73: execute() does not capture shell-command output
    [  FAILED  ] C:/projects/neovim/test/functional\ex_cmds\arg_spec.lua @ 11: :argument does not restart :terminal buffer
    [  FAILED  ] C:/projects/neovim/test/functional\ex_cmds\edit_spec.lua @ 11: :edit without arguments does not restart :terminal buffer
    [  ERROR   ] 2 errors, listed below:
    [  ERROR   ] ...rojects/neovim/test/functional\core\job_partial_spec.lua @ 17: jobs with partials works correctly
    [  ERROR   ] ...s/neovim/test/functional\eval\msgpack_functions_spec.lua @ 457: msgpackparse() function msgpackparse(systemlist(...)) does not segfault. #3135
     64 SKIPPED TESTS
     3 FAILED TESTS
     2 ERRORS
    -- Output to stderr:
    The system cannot find the path specified.
    CMake Error at C:/projects/neovim/cmake/RunTests.cmake:46 (message):
      Running functional tests failed with error: 1.