### PR TITLE
[RFC] vim-patch:7.4.1851

### DIFF
--- a/src/nvim/testdir/test_syn_attr.vim
+++ b/src/nvim/testdir/test_syn_attr.vim
@@ -20,7 +20,7 @@ func Test_missing_attr()
     if fontname == ''
       let fontname = 'something'
     endif
-    exe 'hi Mine guifg=blue guibg=red font=' . escape(fontname, ' \')
+    exe "hi Mine guifg=blue guibg=red font='" . fontname . "'"
     call assert_equal('blue', synIDattr(hlID("Mine"), "fg", 'gui'))
     call assert_equal('red', synIDattr(hlID("Mine"), "bg", 'gui'))
     call assert_equal(fontname, synIDattr(hlID("Mine"), "font", 'gui'))

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -589,7 +589,7 @@ static int included_patches[] = {
   // 1854 NA
   // 1853 NA
   // 1852 NA
-  // 1851,
+  1851,
   // 1850 NA
   // 1849 NA
   // 1848 NA


### PR DESCRIPTION
Problem:    test_syn_attr failes when using the GUI. (Dominique Pelle)
Solution:   Escape the font name properly.

https://github.com/vim/vim/commit/180fc2d41812c49b60224a1ca89945a002a090f5