### PR TITLE
[RFC] vim-patch:7.4.1910

### DIFF
--- a/src/nvim/testdir/test17.in
+++ b/src/nvim/testdir/test17.in
@@ -4,13 +4,7 @@ Tests for:
 
 STARTTEST
 :set isfname=@,48-57,/,.,-,_,+,,,$,:,~,{,}
-:function! DeleteDirectory(dir)
-: if has("win16") || has("win32") || has("win64") || has("dos16") || has("dos32")
-:  exec "silent !rmdir /Q /S " . a:dir
-: else
-:  exec "silent !rm -rf " . a:dir
-: endif
-:endfun
+:"
 :if has("unix")
 :let $CDIR = "."
 /CDIR
@@ -36,7 +30,7 @@ STARTTEST
 :" check for 'include' without \zs or \ze
 :lang C
 :call delete("./Xbase.a")
-:call DeleteDirectory("Xdir1")
+:call delete("Xdir1", "rf")
 :!mkdir Xdir1
 :!mkdir "Xdir1/dir2"
 :e! Xdir1/dir2/foo.a
@@ -61,7 +55,7 @@ ENDTEST
 STARTTEST
 :" check for 'include' with \zs and \ze
 :call delete("./Xbase.b")
-:call DeleteDirectory("Xdir1")
+:call delete("Xdir1", "rf")
 :!mkdir Xdir1
 :!mkdir "Xdir1/dir2"
 :let &include='^\s*%inc\s*/\zs[^/]\+\ze'
@@ -91,7 +85,7 @@ ENDTEST
 STARTTEST
 :" check for 'include' with \zs and no \ze
 :call delete("./Xbase.c")
-:call DeleteDirectory("Xdir1")
+:call delete("Xdir1", "rf")
 :!mkdir Xdir1
 :!mkdir "Xdir1/dir2"
 :let &include='^\s*%inc\s*\%([[:upper:]][^[:space:]]*\s\+\)\?\zs\S\+\ze'

--- a/src/nvim/testdir/test73.in
+++ b/src/nvim/testdir/test73.in
@@ -8,16 +8,9 @@ STARTTEST
 :" This will cause a few errors, do it silently.
 :set visualbell
 :"
-:function! DeleteDirectory(dir)
-: if has("win16") || has("win32") || has("win64") || has("dos16") || has("dos32")
-:  exec "silent !rmdir /Q /S " . a:dir
-: else
-:  exec "silent !rm -rf " . a:dir
-: endif
-:endfun
 :" On windows a stale "Xfind" directory may exist, remove it so that
 :" we start from a clean state.
-:call DeleteDirectory("Xfind")
+:call delete("Xfind", "rf")
 :new
 :let cwd=getcwd()
 :let test_out = cwd . '/test.out'
@@ -169,7 +162,7 @@ SVoyager 2:w
 :exec "w >>" . test_out
 :q
 :exec "cd " . cwd
-:call DeleteDirectory("Xfind")
+:call delete("Xfind", "rf")
 :qa!
 ENDTEST
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -530,7 +530,7 @@ static int included_patches[] = {
   1913,
   1912,
   // 1911 NA
-  // 1910,
+  1910,
   1909,
   // 1908 NA
   // 1907 NA


### PR DESCRIPTION
Problem:    Tests using external command to delete directory.
Solution:   Use delete().

https://github.com/vim/vim/commit/abc70bbf363dbbe3f2bf714102f55648a512791e