### PR TITLE
DirChanged: set <amatch>

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -273,10 +273,10 @@ Name			triggered by ~
 |VimLeave|		before exiting Vim, after writing the shada file
 
 	Various
-|DirChanged|		When the current working directory changed.
+|DirChanged|		after the |current-directory| was changed
 
 |FileChangedShell|	Vim notices that a file changed since editing started
-|FileChangedShellPost|	After handling a file changed since editing started
+|FileChangedShellPost|	after handling a file changed since editing started
 |FileChangedRO|		before making the first change to a read-only file
 
 |ShellCmdPost|		after executing a shell command
@@ -566,14 +566,10 @@ CursorMovedI			After the cursor was moved in Insert mode.
 				Not triggered when the popup menu is visible.
 				Otherwise the same as CursorMoved.
 							*DirChanged*
-DirChanged			When the current working directory was changed
-				using the |:cd| family of commands,
-				|nvim_set_current_dir()|, or on 'autochdir'.
-				The pattern must be * because its meaning may
-				change in the future.
-				It sets these |v:event| keys:
-				    cwd:   String (current working directory)
-				    scope: String ("global", "tab", "window")
+DirChanged			After the |current-directory| was changed.
+				Sets these |v:event| keys:
+				    cwd:   current working directory
+				    scope: "global", "tab", "window"
 				Recursion is ignored.
 							*FileAppendCmd*
 FileAppendCmd			Before appending to a file.  Should do the
@@ -739,13 +735,12 @@ InsertCharPre			When a character is typed in Insert mode,
 							*TextYankPost*
 TextYankPost			Just after a |yank| or |deleting| command, but not
 				if the black hole register |quote_| is used nor
-				for |setreg()|. Pattern must be * because its
-				meaning may change in the future.
+				for |setreg()|. Pattern must be *.
 				Sets these |v:event| keys:
-					operator
-					regcontents
-					regname
-					regtype
+				    operator
+				    regcontents
+				    regname
+				    regtype
 				Recursion is ignored.
 				It is not allowed to change the text |textlock|.
 							*InsertEnter*

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1557,7 +1557,7 @@ static void do_autocmd_dirchanged(char_u *new_dir, CdScope scope)
   dict_add_nr_str(dict, "cwd",   0L, new_dir);
   dict_set_keys_readonly(dict);
 
-  apply_autocmds(EVENT_DIRCHANGED, NULL, new_dir, false, NULL);
+  apply_autocmds(EVENT_DIRCHANGED, (char_u *)buf, new_dir, false, NULL);
 
   dict_clear(dict);
 


### PR DESCRIPTION
We decided to leave the pattern meaningless, but then `<amatch>` will be the filename, which is useless. So now the pattern is the "scope", and that is most likely what Vim will do as well.

Also:
- test that DirChanged is not recursive
- fix 'not trigger if :cd fails' test on Windows