### PR TITLE
[RFC] test: screen: Assert expected row count matches configured screen height

### DIFF
--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -205,6 +205,9 @@ end
 
 function Screen:try_resize(columns, rows)
   uimeths.try_resize(columns, rows)
+  -- Give ourselves a chance to _handle_resize, which requires using
+  -- self.sleep() (for the resize notification) rather than run()
+  self:sleep(0.1)
 end
 
 -- Asserts that `expected` eventually matches the screen state.
@@ -223,6 +226,11 @@ function Screen:expect(expected, attr_ids, attr_ignore, condition, any)
     -- the last character should be the screen delimiter
     row = row:sub(1, #row - 1)
     table.insert(expected_rows, row)
+  end
+  if not any then
+    assert(self._height == #expected_rows,
+      "Expected screen state's row count(" .. #expected_rows
+      .. ') differs from configured height(' .. self._height .. ') of Screen.')
   end
   local ids = attr_ids or self._default_attr_ids
   local ignore = attr_ignore or self._default_attr_ignore

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -563,11 +563,10 @@ describe('Screen', function()
       ]])
     end)
 
-    -- FIXME this has some race conditions that cause it to fail periodically
-    pending('has minimum width/height values', function()
+    it('has minimum width/height values', function()
       screen:try_resize(1, 1)
       screen:expect([[
-        -- INS^ERT --|
+        {2:-- INS^ERT --}|
                     |
       ]])
       feed('<esc>:ls')


### PR DESCRIPTION
When there is a difference in expected vs. actual row count, the user
gets a confusing message about being unable to string concat a nil value
from screen:expect.

This assert makes it clear what the problem is rather than requiring
people to dig through the code of screen:expect to determine what
happened.

Cc @teto