### PR TITLE
[RFC] Windows clipboard support

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -78,6 +78,12 @@ function! provider#clipboard#Executable() abort
     let s:copy['*'] = s:copy['+']
     let s:paste['*'] = s:paste['+']
     return 'doitclient'
+  elseif executable('win32yank')
+    let s:copy['+'] = 'win32yank -i --crlf'
+    let s:paste['+'] = 'win32yank -o --lf'
+    let s:copy['*'] = s:copy['+']
+    let s:paste['*'] = s:paste['+']
+    return 'win32yank'
   endif
 
   let s:err = 'clipboard: No clipboard tool available. See :help clipboard'

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -292,18 +292,40 @@ target_link_libraries(nvim ${NVIM_EXEC_LINK_LIBRARIES})
 install_helper(TARGETS nvim)
 
 if(WIN32)
-  # Copy DLLs to bin/ and install them along with nvim
-  add_custom_target(nvim_dll_deps ALL DEPENDS nvim
+  # Copy DLLs and third-party tools to bin/ and install them along with nvim
+  add_custom_target(nvim_runtime_deps ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/windows_runtime_deps/
+      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+  install(DIRECTORY ${PROJECT_BINARY_DIR}/windows_runtime_deps/
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  foreach(BIN win32yank.exe)
+    unset(BIN_PATH CACHE)
+    find_program(BIN_PATH ${BIN})
+    if(NOT BIN_PATH)
+      message(FATAL_ERROR "Unable to find external dependency ${BIN}")
+    endif()
+
+    add_custom_target(external_${BIN}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/windows_runtime_deps
+      COMMAND ${CMAKE_COMMAND}
+        "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
+        -DBINARY="${BIN_PATH}"
+        -DDST=${PROJECT_BINARY_DIR}/windows_runtime_deps
+        -P ${PROJECT_SOURCE_DIR}/cmake/WindowsDllCopy.cmake
+      COMMAND ${CMAKE_COMMAND} -E copy ${BIN_PATH} ${PROJECT_BINARY_DIR}/windows_runtime_deps/
+      COMMENT "${BIN_PATH}")
+    add_dependencies(nvim_runtime_deps "external_${BIN}")
+  endforeach()
+
+  add_custom_target(nvim_dll_deps DEPENDS nvim
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/windows_runtime_deps
     COMMAND ${CMAKE_COMMAND}
       "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
       -DBINARY="${PROJECT_BINARY_DIR}/bin/nvim${CMAKE_EXECUTABLE_SUFFIX}"
       -DDST=${PROJECT_BINARY_DIR}/windows_runtime_deps
-      -P ${PROJECT_SOURCE_DIR}/cmake/WindowsDllCopy.cmake
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_BINARY_DIR}/windows_runtime_deps/
-      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-  install(DIRECTORY ${PROJECT_BINARY_DIR}/windows_runtime_deps/
-    DESTINATION ${CMAKE_INSTALL_BINDIR})
+      -P ${PROJECT_SOURCE_DIR}/cmake/WindowsDllCopy.cmake)
+  add_dependencies(nvim_runtime_deps nvim_dll_deps)
 endif()
 
 if(CLANG_ASAN_UBSAN)

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -5,8 +5,6 @@ local Screen = require('test.functional.ui.screen')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local execute, expect, eq, eval = helpers.execute, helpers.expect, helpers.eq, helpers.eval
 
-if helpers.pending_win32(pending) then return end
-
 local function basic_register_test(noblock)
   insert("some words")
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -120,6 +120,9 @@ set(LUV_SHA256 86a199403856018cd8e5529c8527450c83664a3d36f52d5253cbe909ea6c5a06)
 set(GPERF_URL http://ftp.gnu.org/pub/gnu/gperf/gperf-3.0.4.tar.gz)
 set(GPERF_SHA256 767112a204407e62dbc3106647cf839ed544f3cf5d0f0523aaa2508623aad63e)
 
+set(WIN32YANK_URL https://github.com/equalsraf/win32yank/releases/download/v0.0.2/win32yank.zip)
+set(WIN32YANK_SHA256 78869bf68565607cda1b6a3d549e2487d59d6f0f16f9b003e123c0086f90309d)
+
 if(USE_BUNDLED_UNIBILIUM)
   include(BuildUnibilium)
 endif()
@@ -162,6 +165,13 @@ endif()
 
 if(USE_BUNDLED_GPERF)
   include(BuildGperf)
+endif()
+
+include(GetBinaryDeps)
+
+if(WIN32)
+  GetBinaryDep(TARGET win32yank
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy win32yank.exe ${DEPS_INSTALL_DIR}/bin)
 endif()
 
 add_custom_target(clean-shared-libraries

--- a/third-party/cmake/GetBinaryDeps.cmake
+++ b/third-party/cmake/GetBinaryDeps.cmake
@@ -1,0 +1,46 @@
+# Download and install binary dependencies for windows
+include(CMakeParseArguments)
+
+# This is similar to the build recipes, but instead downloads a third party
+# binary and installs it under the the DEPS_PREFIX. The INSTALL_COMMAND is
+# executed in the folder where downloaded files are extracted and the
+# ${DEPS_INSTALL_DIR} holds the path to the third-party install root.
+function(GetBinaryDep)
+  cmake_parse_arguments(_gettool
+    "BUILD_IN_SOURCE"
+    "TARGET"
+    "INSTALL_COMMAND"
+    ${ARGN})
+
+  if(NOT _gettool_TARGET OR NOT _gettool_INSTALL_COMMAND)
+    message(FATAL_ERROR "Must pass INSTALL_COMMAND and TARGET")
+  endif()
+
+  string(TOUPPER "${_gettool_TARGET}_URL" URL_VARNAME)
+  string(TOUPPER "${_gettool_TARGET}_SHA256" HASH_VARNAME)
+  set(URL ${${URL_VARNAME}})
+  set(HASH ${${HASH_VARNAME}})
+  if(NOT URL OR NOT HASH )
+	  message(FATAL_ERROR "${URL_VARNAME} and ${HASH_VARNAME} must be set")
+  endif()
+
+  ExternalProject_Add(${_gettool_TARGET}
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}
+      -DURL=${URL}
+      -DEXPECTED_SHA256=${HASH}
+      -DTARGET=${_gettool_TARGET}
+      -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    CONFIGURE_COMMAND ""
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_INSTALL_DIR}/bin
+		COMMAND "${_gettool_INSTALL_COMMAND}")
+  list(APPEND THIRD_PARTY_DEPS ${__gettool_TARGET})
+endfunction()


### PR DESCRIPTION
Support clipboard provider win32yank for Windows. And reenable the clipboard tests in appveyor.

The win32yank is downloaded and installed with the neovim binary. The binary is 32 bit so no architecture checks are made.

Trying to build on a system where win32yank.exe is not present fails with a fatal error, which is not very kind on developers, but avoids generating broken releases. Perhaps checking for the build type would be ideal.

- I have yet to check in depth, appveyor seems happy and the zip file does contain the binary, for some reason cmake included vcruntime140.dll which I was not expecting at all.
- is it possible the clipboard tests would work without  a working provider?
