### PR TITLE
tui: enable NVIM_TUI_ENABLE_CURSOR_SHAPE by default

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -372,9 +372,10 @@ Used to set the 'shell' option, which determines the shell used by the
 .Ic :terminal
 command.
 .It Ev NVIM_TUI_ENABLE_CURSOR_SHAPE
-If defined, change the cursor shape to a vertical bar while in insert mode.
-Requires that the host terminal supports the DECSCUSR CSI escape sequence.
-Has no effect in GUIs.
+Set to 0 to prevent Nvim from changing the cursor shape.
+Set to 1 to enable non-blinking mode-sensitive cursor (this is the default).
+Set to 2 to enable blinking mode-sensitive cursor.
+Host terminal must support the DECSCUSR CSI escape sequence.
 .Pp
 Depending on the terminal emulator, using this option with
 .Nm

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -844,7 +844,7 @@ static void fix_terminfo(TUIData *data)
   }
 
   if (STARTS_WITH(term, "xterm") || STARTS_WITH(term, "rxvt")) {
-    unibi_set_if_empty(ut, unibi_cursor_normal, "\x1b[?12l\x1b[?25h");
+    unibi_set_if_empty(ut, unibi_cursor_normal, "\x1b[?25h");
     unibi_set_if_empty(ut, unibi_cursor_invisible, "\x1b[?25l");
     unibi_set_if_empty(ut, unibi_flash_screen, "\x1b[?5h$<100/>\x1b[?5l");
     unibi_set_if_empty(ut, unibi_exit_attribute_mode, "\x1b(B\x1b[m");

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -877,9 +877,11 @@ static void fix_terminfo(TUIData *data)
     unibi_set_str(ut, unibi_set_a_background, XTERM_SETAB);
   }
 
-  if (os_getenv("NVIM_TUI_ENABLE_CURSOR_SHAPE") == NULL) {
+  const char * env_cusr_shape = os_getenv("NVIM_TUI_ENABLE_CURSOR_SHAPE");
+  if (env_cusr_shape && strncmp(env_cusr_shape, "0", 1) == 0) {
     goto end;
   }
+  bool cusr_blink = env_cusr_shape && strncmp(env_cusr_shape, "2", 1) == 0;
 
 #define TMUX_WRAP(seq) (inside_tmux ? "\x1bPtmux;\x1b" seq "\x1b\\" : seq)
   // Support changing cursor shape on some popular terminals.
@@ -891,22 +893,22 @@ static void fix_terminfo(TUIData *data)
     // Konsole uses a proprietary escape code to set the cursor shape
     // and does not support DECSCUSR.
     data->unibi_ext.set_cursor_shape_bar = (int)unibi_add_ext_str(ut, NULL,
-        TMUX_WRAP("\x1b]50;CursorShape=1;BlinkingCursorEnabled=1\x07"));
+        TMUX_WRAP("\x1b]50;CursorShape=1\x07"));
     data->unibi_ext.set_cursor_shape_ul = (int)unibi_add_ext_str(ut, NULL,
-        TMUX_WRAP("\x1b]50;CursorShape=2;BlinkingCursorEnabled=1\x07"));
+        TMUX_WRAP("\x1b]50;CursorShape=2\x07"));
     data->unibi_ext.set_cursor_shape_block = (int)unibi_add_ext_str(ut, NULL,
-        TMUX_WRAP("\x1b]50;CursorShape=0;BlinkingCursorEnabled=0\x07"));
+        TMUX_WRAP("\x1b]50;CursorShape=0\x07"));
   } else if (!vte_version || atoi(vte_version) >= 3900) {
     // Assume that the terminal supports DECSCUSR unless it is an
     // old VTE based terminal.  This should not get wrapped for tmux,
     // which will handle it via its Ss/Se terminfo extension - usually
     // according to its terminal-overrides.
     data->unibi_ext.set_cursor_shape_bar =
-      (int)unibi_add_ext_str(ut, NULL, "\x1b[5 q");
+      (int)unibi_add_ext_str(ut, NULL, cusr_blink ? "\x1b[5 q" : "\x1b[6 q");
     data->unibi_ext.set_cursor_shape_ul =
-      (int)unibi_add_ext_str(ut, NULL, "\x1b[3 q");
+      (int)unibi_add_ext_str(ut, NULL, cusr_blink ? "\x1b[3 q" : "\x1b[4 q");
     data->unibi_ext.set_cursor_shape_block =
-      (int)unibi_add_ext_str(ut, NULL, "\x1b[2 q");
+      (int)unibi_add_ext_str(ut, NULL, cusr_blink ? "\x1b[1 q" : "\x1b[2 q");
   }
 
 end:

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -68,7 +68,8 @@
 --    })
 --    screen:set_default_attr_ignore( {{}, {bold=true, foreground=NonText}} )
 --
--- To help write screen tests, see screen:snapshot_util().
+-- To help write screen tests, see Screen:snapshot_util().
+-- To debug screen tests, see Screen:redraw_debug().
 
 local helpers = require('test.functional.helpers')(nil)
 local request, run, uimeths = helpers.request, helpers.run, helpers.uimeths
@@ -520,9 +521,11 @@ function Screen:_current_screen()
   return table.concat(rv, '\n')
 end
 
--- Utility to generate/debug tests. Call it where screen:expect() would be.
--- Waits briefly, then dumps the current screen state in the form of
--- screen:expect(). Use snapshot_util({},true) to generate a text-only test.
+-- Generates tests. Call it where Screen:expect() would be. Waits briefly, then
+-- dumps the current screen state in the form of Screen:expect().
+-- Use snapshot_util({},true) to generate a text-only (no attributes) test.
+--
+-- @see Screen:redraw_debug()
 function Screen:snapshot_util(attrs, ignore)
   self:sleep(250)
   self:print_snapshot(attrs, ignore)


### PR DESCRIPTION
This is a temporary step until the [TUI respects 'guicursor'](https://github.com/neovim/neovim/issues/2583#issuecomment-272988384).

- `NVIM_TUI_ENABLE_CURSOR_SHAPE=0` disables cursor shape-changing.
- `NVIM_TUI_ENABLE_CURSOR_SHAPE=1` enables _non-blinking_ cursor with mode-specific shapes.
  - This is the default now.
- `NVIM_TUI_ENABLE_CURSOR_SHAPE=2` enables _blinking_ cursor with mode-specific shapes.

cc @leonerd