### PR TITLE
[RDY] `jobstart()` pty file descriptors kept open in other processes

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2692,14 +2692,7 @@ static FILE *fopen_noinh_readbin(char *filename)
     return NULL;
   }
 
-#ifdef HAVE_FD_CLOEXEC
-  {
-    int fdflags = fcntl(fd_tmp, F_GETFD);
-    if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0) {
-      (void)fcntl(fd_tmp, F_SETFD, fdflags | FD_CLOEXEC);
-    }
-  }
-#endif
+  (void)os_set_cloexec(fd_tmp);
 
   return fdopen(fd_tmp, READBIN);
 }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1742,16 +1742,12 @@ failed:
   }
 # endif
 
-  if (!read_buffer && !read_stdin)
-    close(fd);                                  /* errors are ignored */
-#ifdef HAVE_FD_CLOEXEC
-  else {
-    int fdflags = fcntl(fd, F_GETFD);
-    if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0) {
-      (void)fcntl(fd, F_SETFD, fdflags | FD_CLOEXEC);
-    }
+  if (!read_buffer && !read_stdin) {
+    // errors are ignored
+    close(fd);
+  } else {
+    (void)os_set_cloexec(fd);
   }
-#endif
   xfree(buffer);
 
   if (read_stdin) {

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -909,12 +909,7 @@ static bool mf_do_open(memfile_T *mfp, char_u *fname, int flags)
     return false;
   }
 
-#ifdef HAVE_FD_CLOEXEC
-  int fdflags = fcntl(mfp->mf_fd, F_GETFD);
-  if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0) {
-    (void)fcntl(mfp->mf_fd, F_SETFD, fdflags | FD_CLOEXEC);
-  }
-#endif
+  (void)os_set_cloexec(mfp->mf_fd);
 #ifdef HAVE_SELINUX
   mch_copy_sec(fname, mfp->mf_fname);
 #endif

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -439,14 +439,7 @@ void ml_setname(buf_T *buf)
       EMSG(_("E301: Oops, lost the swap file!!!"));
       return;
     }
-#ifdef HAVE_FD_CLOEXEC
-    {
-      int fdflags = fcntl(mfp->mf_fd, F_GETFD);
-      if (fdflags >= 0 && (fdflags & FD_CLOEXEC) == 0) {
-        (void)fcntl(mfp->mf_fd, F_SETFD, fdflags | FD_CLOEXEC);
-      }
-    }
-#endif
+    (void)os_set_cloexec(mfp->mf_fd);
   }
   if (!success)
     EMSG(_("E302: Could not rename swap file"));

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -391,6 +391,37 @@ int os_open(const char* path, int flags, int mode)
   return r;
 }
 
+/// Set a file descriptor to close on exec.
+//
+// @return -1 if failed to set, 0 otherwise.
+int os_set_cloexec(const int fd)
+{
+#ifdef HAVE_FD_CLOEXEC
+  int e;
+  int fdflags = fcntl(fd, F_GETFD);
+  if (fdflags < 0) {
+    e = errno;
+    ELOG("Failed to get flags on descriptor %d: %s", fd, strerror(errno));
+    errno = e;
+    return -1;
+  }
+  if ((fdflags & FD_CLOEXEC) == 0) {
+    if (fcntl(fd, F_SETFD, fdflags | FD_CLOEXEC) == -1) {
+      e = errno;
+      ELOG("Failed to set CLOEXEC on descriptor %d: %s", fd, strerror(errno));
+      errno = e;
+      return -1;
+    }
+  }
+  return 0;
+#endif
+
+  // No FD_CLOEXEC flag -- probably because we're on windows.
+  // If we are on windows, the file should have been opened with O_NOINHERIT
+  // anyway.
+  return -1;
+}
+
 /// Close a file
 ///
 /// @return 0 or libuv error code on failure.

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -73,6 +73,13 @@ int pty_process_spawn(PtyProcess *ptyproc)
     goto error;
   }
 
+  // Other jobs and providers shouldn't get an copy of this file descriptor.
+  if (os_set_cloexec(master) == -1) {
+    status = -errno;
+    ELOG("Failed to set ptmx file descriptor CLOEXEC");
+    goto error;
+  }
+
   if (proc->in
       && (status = set_duplicating_descriptor(master, &proc->in->uv.pipe))) {
     goto error;
@@ -215,13 +222,23 @@ static int set_duplicating_descriptor(int fd, uv_pipe_t *pipe)
     ELOG("Failed to dup descriptor %d: %s", fd, strerror(errno));
     return status;
   }
+
+  if (os_set_cloexec(fd_dup) == -1) {
+    status = -errno;
+    ELOG("Failed to set FD_CLOEXEC on duplicate fd");
+    goto error;
+  }
+
   status = uv_pipe_open(pipe, fd_dup);
   if (status) {
     ELOG("Failed to set pipe to descriptor %d: %s",
          fd_dup, uv_strerror(status));
-    close(fd_dup);
-    return status;
+    goto error;
   }
+  return status;
+
+error:
+  close(fd_dup);
   return status;
 }
 

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require('test.functional.helpers')(after_each)
-local clear, eq, eval, execute, feed, insert, neq, next_msg, nvim,
+local clear, eq, eval, exc_exec, execute, feed, insert, neq, next_msg, nvim,
   nvim_dir, ok, source, write_file, mkdir, rmdir = helpers.clear,
-  helpers.eq, helpers.eval, helpers.execute, helpers.feed,
+  helpers.eq, helpers.eval, helpers.exc_exec, helpers.execute, helpers.feed,
   helpers.insert, helpers.neq, helpers.next_message, helpers.nvim,
   helpers.nvim_dir, helpers.ok, helpers.source,
   helpers.write_file, helpers.mkdir, helpers.rmdir
@@ -621,6 +621,27 @@ describe('jobs', function()
       local msg = next_msg()
       msg = (msg[2] == 'stdout') and next_msg() or msg  -- Skip stdout, if any.
       eq({'notification', 'exit', {0, 42}}, msg)
+    end)
+
+    it('jobstart() does not keep ptmx file descriptor open', function()
+      if helpers.pending_win32(pending) then return end
+      -- Start another job (using libuv)
+      nvim('command', 'let g:job_opts.pty = 0')
+      local other_jobid = eval("jobstart(['cat', '-'], g:job_opts)")
+      local other_pid = eval('jobpid(' .. other_jobid .. ')')
+
+      -- Other job doesn't block first job from recieving SIGHUP on jobclose()
+      nvim('command', 'call jobclose(j)')
+      -- Have to wait so that the SIGHUP can be processed by tty-test on time.
+      -- Can't wait for the next message in case this test fails, if it fails
+      -- there won't be any more messages, and the test would hang.
+      helpers.sleep(100)
+      local err = exc_exec('call jobpid(j)')
+      eq('Vim(call):E900: Invalid job id', err)
+
+      -- Tidy up after ourselves.
+      eq(other_pid, eval('jobpid(' .. other_jobid .. ')'))
+      nvim('command', 'call jobstop(' .. other_jobid .. ')')
     end)
   end)
 end)


### PR DESCRIPTION
When starting a job in a new pseudo terminal with `jobstart()`, the master file descriptor is opened in such a way that it is preserved when new jobs are started (as long as the new job is not in a new pty).

This means that after calling `jobclose()` on the job in the vim process, `SIGHUP` is not sent to the job's process, as the master file descriptor still has a valid reference (in the other job).

I believe I've fixed this by adding a few calls to `fcntl()`, but I'm currently having trouble writing an automated test.

### Manual test:
With the file `test_HUP_from_vim.py`

```python
#!/usr/bin/python

import argparse
import signal
import time
import sys
import os


def flushed_print(*args):
    print(*args)
    sys.stdout.flush()


def mention_hup(signum, frame):
    with open('hup_recieved', 'w') as outfile:
        outfile.write('Via vim hup recieved: {}\n'.format(time.time()))
    sys.exit(1)

if __name__ == "__main__":
    parser = argparse.ArgumentParser(description='Just give a timeout please')
    parser.add_argument('--timeout', type=int, default=100,
                        help='How many seconds to wait')
    args = parser.parse_args()

    flushed_print('Starting process')
    signal.signal(signal.SIGHUP, mention_hup)
    flushed_print('Installed signal handler')
    time.sleep(args.timeout)
    flushed_print('Wait time exceeded -- closing')
```

And the file `test_HUP.vim`

```vimL
" This file is to test whether jobclose() on a job started on a new pseudo
" terminal sends SIGHUP to that job/process.

function! JobHandler(job_id, data, event)
  if a:event == 'stdout'
    let str = a:job_id.' stdout: '.join(a:data)
  elseif a:event == 'stderr'
    let str = a:job_id.' stderr: '.join(a:data)
  else
    let str = a:job_id.' exited'
  endif
  call append(line('$'), str)
endfunction

let g:callbacks = {
      \ 'on_stdout': function('JobHandler'),
      \ 'on_stderr': function('JobHandler'),
      \ 'on_exit': function('JobHandler'),
      \ 'pty': 1,
      \ 'TERM': 'dumb'
      \ }

let g:callbacks_alt = {
      \ 'on_stdout': function('JobHandler'),
      \ 'on_stderr': function('JobHandler'),
      \ 'on_exit': function('JobHandler'),
      \ }


" First, observe the behaviour when the HUP is sent.
" vimcmd: source %
" vimcmd: let g:job1 = jobstart(['./test_HUP_from_vim.py'], g:callbacks)
" vimcmd: call jobclose(g:job1)
" vimcmd: r hup_recieved

" If you start a new job with jobstart(), and that job isn't in a new pty, then
" a jobclose() doesn't send a SIGHUP to the original job until the second one
" has finished.
" vimcmd: let g:job1 = jobstart(['./test_HUP_from_vim.py'], g:callbacks)
" vimcmd: let g:job2 = jobstart(['./test_HUP_from_vim.py', '--timeout', '20'], g:callbacks_alt)
" vimcmd: call jobclose(g:job1)
" vimcmd: r hup_recieved
"
" If you were to use the following, you can see that the ptmx file descriptor
" is open in the python process of job2.
" vimcmd: call append(0, systemlist('lsof -p ' . jobpid(g:job2)))

" Doesn't happen when a jobstart() call creates a new pty (I believe this is
" because forkpty() closes all file descriptors other than the pty one).
" vimcmd: let g:job1 = jobstart(['./test_HUP_from_vim.py'], g:callbacks)
" vimcmd: let g:job2 = jobstart(['./test_HUP_from_vim.py', '--timeout', '20'], g:callbacks)
" vimcmd: call jobclose(g:job1)
" vimcmd: r hup_recieved

" Accordingly, this happens in less obvious circumstances, like when a provider
" is used and that starts a new job.
" vimcmd: let g:job1 = jobstart(['./test_HUP_from_vim.py'], g:callbacks)
" vimcmd: yank +
" vimcmd: call jobclose(g:job1)
" vimcmd: r hup_recieved
```

Opening nvim with `nvim -u NONE test_HUP.vim` and running the commands listed in the order they appear in the file, you can see that `SIGHUP` isn't received when a libuv job is started in between calling `jobstart()` and `jobclose()`.


After my changes so far I've fixed this, but I want to make an automatic test for this that doesn't hang if things are broken and I want to extract the code to set `FD_CLOEXEC` into a function (it's already called in a few different places).

Also ... I remembered 2 space indent! I knew I could get it eventually.