### PR TITLE
[RDY] eval.c: Fix findfile() from terminal buffer

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1370,6 +1370,10 @@ find_file_in_path_option (
   char_u              *buf = NULL;
   int rel_to_curdir;
 
+  if (rel_fname != NULL && path_with_url((const char *)rel_fname)) {
+    rel_fname = NULL;
+  }
+
   if (first == TRUE) {
     /* copy file name into NameBuff, expanding environment variables */
     save_char = ptr[len];

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -112,4 +112,46 @@ describe(':terminal (with fake shell)', function()
       eq(2, eval("1+1"))  -- Still alive?
   end)
 
+  describe('works with', function()
+    it('findfile()', function()
+      source('terminal')
+      eq(1, nvim('eval', 'bufname("%") =~# "^term://"'))
+      eq('scripts/shadacat.py', nvim('call_function',
+                                     'findfile', {'scripts/shadacat.py', '.'}))
+    end)
+
+    it(':find', function()
+      terminal_with_fake_shell()
+      wait()
+      screen:expect([[
+        ready $                                           |
+        [Process exited 0]                                |
+                                                          |
+        -- TERMINAL --                                    |
+      ]])
+      eq(1, nvim('eval', 'bufname("%") =~# "^term://"'))
+      helpers.feed([[<C-\><C-N>]])
+      wait()
+      execute([[find */shadacat.py]])
+      wait()
+      eq(1, nvim('eval', 'bufname("%") ==# "scripts/shadacat.py"'))
+    end)
+
+    it('gf', function()
+      terminal_with_fake_shell([[echo "scripts/shadacat.py"]])
+      wait()
+      screen:expect([[
+        ready $ echo "scripts/shadacat.py"                |
+                                                          |
+        [Process exited 0]                                |
+        -- TERMINAL --                                    |
+      ]])
+      helpers.feed([[<C-\><C-N>]])
+      wait()
+      eq(1, nvim('eval', 'bufname("%") =~# "^term://"'))
+      execute([[normal! ggf"lgf]])
+      eq(1, nvim('eval', 'bufname("%") ==# "scripts/shadacat.py"'))
+    end)
+  end)
+
 end)


### PR DESCRIPTION
Fixes `findfile('non_existent_file', '.')` from a terminal buffer returning something like:

```
term://.//24939:/usr/bin/non_existent_file
```

Wasn't sure if I should add a test for this in the legacy script or start a new one.