### PR TITLE
tui: Ignore DECRST 12 in terminfo's cursor_normal, if present

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -844,7 +844,16 @@ static void fix_terminfo(TUIData *data)
   }
 
   if (STARTS_WITH(term, "xterm") || STARTS_WITH(term, "rxvt")) {
-    unibi_set_if_empty(ut, unibi_cursor_normal, "\x1b[?25h");
+    const char *normal = unibi_get_str(ut, unibi_cursor_normal);
+    if (!normal) {
+      unibi_set_str(ut, unibi_cursor_normal, "\x1b[?25h");
+    } else if (STARTS_WITH(normal, "\x1b[?12l")) {
+      // terminfo typically includes DECRST 12 as part of setting up the normal
+      // cursor, which interferes with the user's control via
+      // NVIM_TUI_ENABLE_CURSOR_SHAPE.  When DECRST 12 is present, skip over
+      // it, but honor the rest of the TI setting.
+      unibi_set_str(ut, unibi_cursor_normal, normal + strlen("\x1b[?12l"));
+    }
     unibi_set_if_empty(ut, unibi_cursor_invisible, "\x1b[?25l");
     unibi_set_if_empty(ut, unibi_flash_screen, "\x1b[?5h$<100/>\x1b[?5l");
     unibi_set_if_empty(ut, unibi_exit_attribute_mode, "\x1b(B\x1b[m");


### PR DESCRIPTION
As discussed in neovim/neovim#5977, it's typical for the terminfo
database to disable cursor blink as part of setting up the normal
cursor.  Since this interferes with the user's control over the cursor,
we'll skip over DECRST 12 if it starts the cursor_normal entry.

Note, this doesn't handle any case where DECRST 12 is not at the start
of the entry since unibilium simply stores the given pointer.  We would
need to allocate (and somewhere free) a modified copy of what we get
back from unibi_get_str to handle that.