### PR TITLE
xstrlcat: Match vim_strcat more closely.

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -3176,7 +3176,7 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension,
     if match:
         error(filename, linenum, 'runtime/printf', 4,
               'Use xstrlcpy or snprintf instead of %s' % match.group(1))
-    match = Search(r'\b(STRNCAT|strncat|strcat)\b', line)
+    match = Search(r'\b(STRNCAT|strncat|strcat|vim_strcat)\b', line)
     if match:
         error(filename, linenum, 'runtime/printf', 4,
               'Use xstrlcat or snprintf instead of %s' % match.group(1))

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -129,9 +129,10 @@ newwindow:
       vim_snprintf(cbuf, sizeof(cbuf) - 5, "%" PRId64, (int64_t)Prenum);
     else
       cbuf[0] = NUL;
-    if (nchar == 'v' || nchar == Ctrl_V)
-      strcat(cbuf, "v");
-    strcat(cbuf, "new");
+    if (nchar == 'v' || nchar == Ctrl_V) {
+      xstrlcat(cbuf, "v", sizeof(cbuf));
+    }
+    xstrlcat(cbuf, "new", sizeof(cbuf));
     do_cmdline_cmd(cbuf);
     break;
 

--- a/test/unit/memory_spec.lua
+++ b/test/unit/memory_spec.lua
@@ -1,0 +1,51 @@
+local helpers = require("test.unit.helpers")
+
+local cimport = helpers.cimport
+local cstr = helpers.cstr
+local eq = helpers.eq
+local ffi = helpers.ffi
+local to_cstr = helpers.to_cstr
+
+local cimp = cimport('stdlib.h', './src/nvim/memory.h')
+
+describe('xstrlcat()', function()
+  local function test_xstrlcat(dst, src, dsize)
+    assert.is_true(dsize >= 1 + string.len(dst))  -- sanity check for tests
+    local dst_cstr = cstr(dsize, dst)
+    local src_cstr = to_cstr(src)
+    eq(string.len(dst .. src), cimp.xstrlcat(dst_cstr, src_cstr, dsize))
+    return ffi.string(dst_cstr)
+  end
+
+  local function test_xstrlcat_overlap(dst, src_idx, dsize)
+    assert.is_true(dsize >= 1 + string.len(dst))  -- sanity check for tests
+    local dst_cstr = cstr(dsize, dst)
+    local src_cstr = dst_cstr + src_idx  -- pointer into `dst` (overlaps)
+    eq(string.len(dst) + string.len(dst) - src_idx,
+       cimp.xstrlcat(dst_cstr, src_cstr, dsize))
+    return ffi.string(dst_cstr)
+  end
+
+  it('concatenates strings', function()
+    eq('ab', test_xstrlcat('a', 'b', 3))
+    eq('ab', test_xstrlcat('a', 'b', 4096))
+    eq('ABCיהZdefgiיהZ',  test_xstrlcat('ABCיהZ', 'defgiיהZ',  4096))
+    eq('b',  test_xstrlcat('',  'b', 4096))
+    eq('a',  test_xstrlcat('a', '',  4096))
+  end)
+
+  it('concatenates overlapping strings', function()
+    eq('abcabc',  test_xstrlcat_overlap('abc', 0, 7))
+    eq('abca',    test_xstrlcat_overlap('abc', 0, 5))
+    eq('abcb',    test_xstrlcat_overlap('abc', 1, 5))
+    eq('abcc',    test_xstrlcat_overlap('abc', 2, 10))
+    eq('abcabc',  test_xstrlcat_overlap('abc', 0, 2343))
+  end)
+
+  it('truncates if `dsize` is too small', function()
+    eq('a', test_xstrlcat('a', 'b', 2))
+    eq('', test_xstrlcat('', 'b', 1))
+    eq('ABCיהZd',  test_xstrlcat('ABCיהZ', 'defgiיהZ',  10))
+  end)
+
+end)


### PR DESCRIPTION
memcpy is not equivalent to memmove (which is used by vim_strcat), this
could cause subtle bugs if xstrlcat is used as a replacement for
vim_strcat. But vim_strcat is inconsistent: in the `else` branch it uses
strcpy, which doesn't allow overlap.