### PR TITLE
[RDY] Fix error calling nvim_buf_set_lines()

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -395,7 +395,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
 
   changed_lines((linenr_T)start, 0, (linenr_T)end, extra);
 
-  if (buf == curbuf) {
+  if (save_curbuf.br_buf == NULL) {
     fix_cursor((linenr_T)start, (linenr_T)end, extra);
   }
 

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -4,6 +4,9 @@ local curbuf, curwin, eq = helpers.curbuf, helpers.curwin, helpers.eq
 local curbufmeths, ok = helpers.curbufmeths, helpers.ok
 local funcs = helpers.funcs
 local request = helpers.request
+local exc_exec = helpers.exc_exec
+local execute = helpers.execute
+local insert = helpers.insert
 local NIL = helpers.NIL
 local meth_pcall = helpers.meth_pcall
 local command = helpers.command
@@ -242,6 +245,27 @@ describe('api/buf', function()
       eq({'e', 'a', 'b', 'c', 'd'}, get_lines(0, -1, true))
     end)
 
+    it("set_line on alternate buffer doesn't give Vim error E315", function()
+      execute('set hidden')
+      helpers.source([[
+      function! SetLines()
+        call nvim_buf_set_lines(1, 0, 1, v:false, ['test'])
+      endfunction
+      ]])
+      insert('Initial file')
+      command('enew')
+      insert([[
+      More
+      Lines
+      Than
+      In
+      The
+      Other
+      Buffer]])
+      execute('$')
+      local retval = exc_exec('call SetLines()')
+      eq(0, retval)
+    end)
   end)
 
   describe('{get,set,del}_var', function()


### PR DESCRIPTION
When the buffer that `nvim_buf_set_lines()` is changing is not in any vim
window, `fix_cursor()` leads to calling `ml_get_buf()` with an invalid line
number. The condition that `fix_cursor()` was called on is (`buf ==
curbuf`), but this is always true because of the call to
`switch_to_win_for_buf()` earlier in the function.

Instead this should be predicated on (`save_curbuf == NULL`)


## Test demonstrating the problem:

With the file `test.txt` as
```
Line of words 1
Line of words 2
Line of words 3
Line of words 4
Line of words 5
```

And the file `ml_err_test.vim` as

```vimL
" Demonstrate that the nvim_buf_set_lines() function has a bug. hello
" We need vimscript so that the msg_buf is non NULL, and hence that the error
" gets printed to screen.
" it isn't neccessary to cause the bug, just to enhance visibility.
" When the bug is triggered from a remote process it puts the cursor into
" column 3 (which is STRLEN("???") ).

function! JobHandler(job_id, data, event) dict
  if a:event == 'stdout' || a:event == 'stderr'
python3 << EOF
import vim
bufused = vim.buffers[int(vim.eval('self.buffer'))]
bufused[0] = bufused[0] + ' hello'
EOF
  endif
endfunction

let g:callbacks = {
      \ 'on_stdout': function('JobHandler'),
      \ 'on_stderr': function('JobHandler'),
      \ 'on_exit': function('JobHandler'),
      \ }

function! StartJob()
  call jobstart('sleep 5 && echo Hello', extend({'buffer': bufnr('%')}, g:callbacks))
endfunction
```

Start nvim with
`nvim -u NONE test.txt`

```
:set hidden
:source ml_err_test.vim
:e +$ src/nvim/undo.c    " Just a known large file
:b 1
:call StartJob()
:b2
```

After the 5 seconds specified in the sleep, vim will raise the error `ml_get: invalid lnum ...`.
