### PR TITLE
[RFC] Makefile: add PREFIX option to set install directory on command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ ifneq (,$(findstring functionaltest-lua,$(MAKECMDGOALS)))
   $(shell [ -x .deps/usr/bin/lua ] || rm build/.ran-*)
 endif
 
+ifneq (,$(PREFIX))
+	CMAKE_EXTRA_FLAGS += "-DCMAKE_INSTALL_PREFIX=$(PREFIX)"
+endif
+
 # For use where we want to make sure only a single job is run.  This does issue 
 # a warning, but we need to keep SCRIPTS argument.
 SINGLE_MAKE = export MAKEFLAGS= ; $(MAKE)


### PR DESCRIPTION
Install neovim in other place than /usr/local might be a common requirement.
For the moment, the only way is quite verbose, and not easy to remember:
  make CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=/home/jreybert/.local/stow/neovim"

PREFIX is more straightforward:
  make PREFIX=/home/jreybert/.local/stow/neovim/

DESTDIR mechanism is not enough, as it only prepend DESTDIR to CMAKE_INSTALL_PREFIX
(see https://cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html)