### PR TITLE
defaults: Revert 'mouse=a'

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -47,7 +47,6 @@ these differences.
 - 'langnoremap' is set by default
 - 'laststatus' defaults to 2 (statusline is always shown)
 - 'listchars' defaults to "tab:> ,trail:-,nbsp:+"
-- 'mouse' defaults to "a"
 - 'nocompatible' is always set
 - 'nrformats' defaults to "bin,hex"
 - 'sessionoptions' doesn't include "options"

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1572,7 +1572,7 @@ return {
       full_name='mouse',
       type='string', list='flags', scope={'global'},
       varname='p_mouse',
-      defaults={if_true={vi="", vim="a"}}
+      defaults={if_true={vi="", vim=""}}
     },
     {
       full_name='mousefocus', abbreviation='mousef',

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -438,6 +438,8 @@ describe('clipboard usage', function()
   end)
 
   it('handles middleclick correctly', function()
+    execute('set mouse=a')
+
     local screen = Screen.new(30, 5)
     screen:attach()
     insert([[


### PR DESCRIPTION
This default causes too much confusion for terminal users. Until
a better approach is implemented, revert to the traditional default.

Better solution would be:
- Implement a right-click menu for TUI
- Set 'mouse=a' *only* if clipboard is working.