### PR TITLE
[RFC] Look for unzip program

### DIFF
--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -123,6 +123,11 @@ add_custom_target(inspect
 list(APPEND THIRD_PARTY_DEPS inspect)
 
 if(USE_BUNDLED_BUSTED)
+
+  find_program(UNZIP_PRG unzip)
+  if(NOT UNZIP_PRG)
+    message(FATAL_ERROR "'unzip' must be installed to allow for penlight installation")
+  endif()
   add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight/1.3.2-2
     COMMAND ${LUAROCKS_BINARY}
     ARGS build penlight 1.3.2-2 ${LUAROCKS_BUILDARGS}


### PR DESCRIPTION
Building neovim from scratch on nixos, the build kept failing when installing penlight.
Message was not that clear, similar to https://github.com/luarocks/luarocks/issues/238.

This patch checks for 'unzip' program presence via cmake.
