### PR TITLE
[RFC] vim-patch:8.0.0208

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -800,7 +800,7 @@ static int insert_handle_key(InsertState *s)
     if (!p_im) {
       goto normalchar;                // insert CTRL-Z as normal char
     }
-    stuffReadbuff((char_u *)":st\r");
+    do_cmdline_cmd("stop");
     s->c = Ctrl_O;
   // FALLTHROUGH
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2699,9 +2699,9 @@ do_mouse (
     if (State & INSERT)
       stuffcharReadbuff(Ctrl_O);
     if (curwin->w_llist_ref == NULL)            /* quickfix window */
-      stuffReadbuff((char_u *)":.cc\n");
+      do_cmdline_cmd(".cc");
     else                                        /* location list window */
-      stuffReadbuff((char_u *)":.ll\n");
+      do_cmdline_cmd(".ll");
     got_click = false;                  /* ignore drag&release now */
   }
   /*

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2698,11 +2698,12 @@ do_mouse (
            && bt_quickfix(curbuf)) {
     if (State & INSERT)
       stuffcharReadbuff(Ctrl_O);
-    if (curwin->w_llist_ref == NULL)            /* quickfix window */
+    if (curwin->w_llist_ref == NULL) {          // quickfix window
       do_cmdline_cmd(".cc");
-    else                                        /* location list window */
+    } else {                                    // location list window
       do_cmdline_cmd(".ll");
-    got_click = false;                  /* ignore drag&release now */
+    }
+    got_click = false;                  // ignore drag&release now
   }
   /*
    * Ctrl-Mouse click (or double click in a help window) jumps to the tag


### PR DESCRIPTION
#### vim-patch:8.0.0208

Problem:    Internally used commands for CTRL-Z and mouse click end up in
            history. (Matthew Malcomson)
Solution:   Use do_cmdline_cmd() instead of stuffing them in the readahead
            buffer. (James McCoy, closes vim/vim#1395)

https://github.com/vim/vim/commit/25b0e6b701a7a8dfcb4f60e217360a5c75053d8c

Closes #5966
Closes #5967