### PR TITLE
man.vim: more robust s:verify_exists

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -180,10 +180,10 @@ endfunction
 function! s:verify_exists(sect, name) abort
   try
     let path = s:get_path(a:sect, a:name)
-  catch
+  catch /^command error (/
     try
       let path = s:get_path(get(b:, 'man_default_sects', ''), a:name)
-    catch
+    catch /^command error (/
       let path = s:get_path('', a:name)
     endtry
   endtry

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -55,7 +55,10 @@ function! man#open_page(count, count1, mods, ...) abort
   try
     let page = s:get_page(path)
   catch
-    close
+    if a:mods =~# 'tab' || !s:find_man()
+      " a new window was opened
+      close
+    endif
     call s:error(v:exception)
     return
   endtry
@@ -70,7 +73,7 @@ function! man#read_page(ref) abort
     let [b:man_sect, name, path] = s:verify_exists(sect, name)
     let page = s:get_page(path)
   catch
-    " call to s:error() is unnecessary
+    " call to s:error() is unnecessary as it doesn't work.
     return
   endtry
   call s:put_page(page)
@@ -175,13 +178,15 @@ function! s:get_path(sect, name) abort
 endfunction
 
 function! s:verify_exists(sect, name) abort
-  let path = s:get_path(a:sect, a:name)
-  if path !~# '^\/'
-    let path = s:get_path(get(b:, 'man_default_sects', ''), a:name)
-    if path !~# '^\/'
+  try
+    let path = s:get_path(a:sect, a:name)
+  catch
+    try
+      let path = s:get_path(get(b:, 'man_default_sects', ''), a:name)
+    catch
       let path = s:get_path('', a:name)
-    endif
-  endif
+    endtry
+  endtry
   " We need to extract the section from the path because sometimes
   " the actual section of the manpage is more specific than the section
   " we provided to `man`. Try ':Man 3 App::CLI'.


### PR DESCRIPTION
Using try commands is more robust and also fixes #6039

Also, I added some code to close the window if we could not get
the page from man but only if we opened it ourselves.