### PR TITLE
eval/typval_encode: Restore original copyID

### DIFF
--- a/src/nvim/eval/typval_encode.h
+++ b/src/nvim/eval/typval_encode.h
@@ -34,6 +34,7 @@ typedef enum {
 typedef struct {
   MPConvStackValType type;  ///< Type of the stack entry.
   typval_T *tv;  ///< Currently converted typval_T.
+  int saved_copyID;  ///< copyID item used to have.
   union {
     struct {
       dict_T *dict;    ///< Currently converted dictionary.


### PR DESCRIPTION
References https://github.com/neovim/neovim/issues/5234
References https://github.com/neovim/neovim/issues/5774
References https://github.com/neovim/neovim/issues/5817
References https://github.com/neovim/neovim/issues/5883
References https://github.com/neovim/neovim/issues/5934


- [VimFiler ASAN trace](https://gist.github.com/jamessan/7de46a04075192d0bfed5e7d8f6b98ed)
- [sample backtrace](https://gist.github.com/jamessan/d407c93d60c0ecf0ba0c55a0369bf29b) showing `dv_copyID` being overwritten by clear_tv, which allows it to be collected by `garbage_collect .. free_unref_items`