### PR TITLE
[WIP] Various improvements to folding

### DIFF
--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -526,7 +526,8 @@ handles differently: Space, backslash and double-quote. |option-backslash|
 FOLDCOLUMN						*fold-foldcolumn*
 
 'foldcolumn' is a number, which sets the width for a column on the side of the
-window to indicate folds.  When it is zero, there is no foldcolumn.  A normal
+window to indicate folds.  When it is -1, the width is found automatically.
+When it is zero, there is no foldcolumn.  A normal
 value is 4 or 5.  The minimal useful value is 2, although 1 still provides
 some information.  The maximum is 12.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2389,6 +2389,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  stlnc:c	' ' or '='	statusline of the non-current windows
 	  vert:c	'│' or '|'	vertical separators |:vsplit|
 	  fold:c	'·' or '-'	filling 'foldtext'
+	  foldopen:c	'-'		mark the beginning of a fold
+	  foldclose:c	'+'		show a closed fold
+	  foldend:c	'°'		mark the end of a fold
+	  foldsep:c	'|'		open fold middle marker
 	  diff:c	'-'		deleted lines of the 'diff' option
 
 	Any one that is omitted will fall back to the default.  For "stl" and

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2452,6 +2452,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When non-zero, a column with the specified width is shown at the side
 	of the window which indicates open and closed folds.  The maximum
 	value is 12.
+  When set to -1, adopt the maximum fold level as column width.
 	See |folding|.
 
 			*'foldenable'* *'fen'* *'nofoldenable'* *'nofen'*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2391,7 +2391,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  fold:c	'·' or '-'	filling 'foldtext'
 	  foldopen:c	'-'		mark the beginning of a fold
 	  foldclose:c	'+'		show a closed fold
-	  foldend:c	'°'		mark the end of a fold
+	  foldend:c	'└'		mark the end of a fold
 	  foldsep:c	'|'		open fold middle marker
 	  diff:c	'-'		deleted lines of the 'diff' option
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -20,6 +20,7 @@
 #include "nvim/vim.h"
 #include "nvim/buffer.h"
 #include "nvim/file_search.h"
+#include "nvim/fold.h"
 #include "nvim/window.h"
 #include "nvim/types.h"
 #include "nvim/ex_docmd.h"
@@ -43,6 +44,22 @@
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/vim.c.generated.h"
 #endif
+
+/// @see foldCreate
+void nvim_fold_create(Window window, Integer start, Integer end, Error *err)
+{
+  foldCreate(start, end);
+}
+
+/// @see deleteFold
+void nvim_fold_delete(Window window, Integer start, Integer end, Boolean recursive, Error *err)
+{
+  deleteFold(
+    start,
+    end,
+    recursive,
+    false);
+}
 
 /// Executes an ex-command.
 ///

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -48,19 +48,33 @@
 
 /// Create a fold from line "start" to line "end" (inclusive) in the current
 /// window.
+/// @param window
 /// @param start starting line
 /// @param end starting end
 /// @param err
 void nvim_fold_create(Window window, Integer start, Integer end, Error *err)
 {
-  foldCreate(start, end);
+  win_T *win = find_window_by_handle(window, err);
+
+  if (!win) {
+    return;
+  }
+  // Window is 
+  foldCreate(win, start, end);
 }
 
 /// Delete a fold at line "start" in the current window.
 /// When "end" is not 0, delete all folds from "start" to "end".
 /// When "recursive" is TRUE delete recursively.
+/// @param window 
 void nvim_fold_delete(Window window, Integer start, Integer end, Boolean recursive, Error *err)
 {
+  win_T *win = find_window_by_handle(window, err);
+
+  if (!win) {
+    return;
+  }
+
   deleteFold(
     start,
     end,

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -53,6 +53,7 @@
 /// @param end starting end
 /// @param err
 void nvim_fold_create(Window window, Integer start, Integer end, Error *err)
+  FUNC_API_SINCE(4)
 {
   win_T *win = find_window_by_handle(window, err);
 
@@ -68,6 +69,7 @@ void nvim_fold_create(Window window, Integer start, Integer end, Error *err)
 /// When "recursive" is TRUE delete recursively.
 /// @param window 
 void nvim_fold_delete(Window window, Integer start, Integer end, Boolean recursive, Error *err)
+  FUNC_API_SINCE(4)
 {
   win_T *win = find_window_by_handle(window, err);
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -45,13 +45,20 @@
 # include "api/vim.c.generated.h"
 #endif
 
-/// @see foldCreate
+
+/// Create a fold from line "start" to line "end" (inclusive) in the current
+/// window.
+/// @param start starting line
+/// @param end starting end
+/// @param err
 void nvim_fold_create(Window window, Integer start, Integer end, Error *err)
 {
   foldCreate(start, end);
 }
 
-/// @see deleteFold
+/// Delete a fold at line "start" in the current window.
+/// When "end" is not 0, delete all folds from "start" to "end".
+/// When "recursive" is TRUE delete recursively.
 void nvim_fold_delete(Window window, Integer start, Integer end, Boolean recursive, Error *err)
 {
   deleteFold(

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2378,8 +2378,9 @@ void get_winopts(buf_T *buf)
     curwin->w_fold_manual = wip->wi_fold_manual;
     curwin->w_foldinvalid = true;
     cloneFoldGrowArray(&wip->wi_folds, &curwin->w_folds);
-  } else
+  } else {
     copy_winopt(&curwin->w_allbuf_opt, &curwin->w_onebuf_opt);
+  }
 
   /* Set 'foldlevel' to 'foldlevelstart' if it's not negative. */
   if (p_fdls >= 0)

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1067,7 +1067,11 @@ struct window_S {
                                        manually */
   bool w_foldinvalid;               /**!< when true: folding needs to be
                                        recomputed */
-  int w_fdcwidth;                   /**!< optimal width to draw 'foldcolumn' */
+  int w_fdcwidth;                   /**!< optimal width to draw 'foldcolumn'
+
+                  int d = getDeepestNesting();
+                                     */
+  // int w_fdcwidth_current;           /**!< optimal width to draw 'foldcolumn' */
   int w_nrwidth;                    /**!< width of 'number' and 'relativenumber'
                                        column being used */
 
@@ -1167,8 +1171,6 @@ struct window_S {
   int w_fraction;
   int w_prev_fraction_row;
 
-  linenr_T w_nrwidth_line_count;        /* line count when ml_nrwidth_width
-                                         * was computed. */
   int w_nrwidth_width;                  /* nr of chars to print line count. */
 
   qf_info_T   *w_llist;                 /* Location list for this window */

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1062,12 +1062,13 @@ struct window_S {
   int w_lines_valid;                /* number of valid entries */
   wline_T     *w_lines;
 
-  garray_T w_folds;                 /* array of nested folds */
-  bool w_fold_manual;               /* when true: some folds are opened/closed
+  garray_T w_folds;                 /**!< array of nested folds */
+  bool w_fold_manual;               /**!< when true: some folds are opened/closed
                                        manually */
-  bool w_foldinvalid;               /* when true: folding needs to be
+  bool w_foldinvalid;               /**!< when true: folding needs to be
                                        recomputed */
-  int w_nrwidth;                    /* width of 'number' and 'relativenumber'
+  int w_fdcwidth;                   /**!< optimal width to draw 'foldcolumn' */
+  int w_nrwidth;                    /**!< width of 'number' and 'relativenumber'
                                        column being used */
 
   /*

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1062,14 +1062,12 @@ struct window_S {
   int w_lines_valid;                /* number of valid entries */
   wline_T     *w_lines;
 
-  garray_T w_folds;                 /**!< array of nested folds */
-  bool w_fold_manual;               /**!< when true: some folds are opened/closed
-                                       manually */
-  bool w_foldinvalid;               /**!< when true: folding needs to be
-                                       recomputed */
-  int w_fdcwidth;                   /**!< optimal width to draw 'foldcolumn' */
-  int w_nrwidth;                    /**!< width of 'number' and 'relativenumber'
-                                       column being used */
+  garray_T w_folds;         //!< array of nested folds
+  bool w_fold_manual;       //!< when true: some folds are open/closed manually
+  bool w_foldinvalid;       //!< when true: folding needs to be recomputed
+  int w_fdcwidth;           //!< optimal width to draw 'foldcolumn'
+  int w_nrwidth;            //!< width of 'number' and 'relativenumber'
+                            //!< column being used
 
   /*
    * === end of cached values ===
@@ -1167,7 +1165,7 @@ struct window_S {
   int w_fraction;
   int w_prev_fraction_row;
 
-  int w_nrwidth_width;                  /* nr of chars to print line count. */
+  int w_nrwidth_width;        //!< nr of chars to print line count. */
 
   qf_info_T   *w_llist;                 /* Location list for this window */
   /*

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1067,11 +1067,7 @@ struct window_S {
                                        manually */
   bool w_foldinvalid;               /**!< when true: folding needs to be
                                        recomputed */
-  int w_fdcwidth;                   /**!< optimal width to draw 'foldcolumn'
-
-                  int d = getDeepestNesting();
-                                     */
-  // int w_fdcwidth_current;           /**!< optimal width to draw 'foldcolumn' */
+  int w_fdcwidth;                   /**!< optimal width to draw 'foldcolumn' */
   int w_nrwidth;                    /**!< width of 'number' and 'relativenumber'
                                        column being used */
 

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -698,7 +698,7 @@ int chartabsize(char_u *p, colnr_T col)
   RET_WIN_BUF_CHARTABSIZE(curwin, curbuf, p, col)
 }
 
-static int win_chartabsize(win_T *wp, char_u *p, colnr_T col)
+static int win_chartabsize(const win_T *wp, char_u *p, colnr_T col)
 {
   RET_WIN_BUF_CHARTABSIZE(wp, wp->w_buffer, p, col)
 }
@@ -738,7 +738,7 @@ int linetabsize_col(int startcol, char_u *s)
 /// @param len
 ///
 /// @return Number of characters the string will take on the screen.
-unsigned int win_linetabsize(win_T *wp, char_u *line, colnr_T len)
+unsigned int win_linetabsize(const win_T *wp, char_u *line, colnr_T len)
 {
   colnr_T col = 0;
 
@@ -928,7 +928,7 @@ int lbr_chartabsize_adv(char_u *line, char_u **s, colnr_T col)
 /// @param headp
 ///
 /// @return The number of characters taken up on the screen.
-int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *headp)
+int win_lbr_chartabsize(const win_T *wp, char_u *line, char_u *s, colnr_T col, int *headp)
 {
   colnr_T col2;
   colnr_T col_adj = 0; /* col + screen size of tab */
@@ -1082,7 +1082,7 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
 /// @param headp
 ///
 /// @return The number of characters take up on the screen.
-static int win_nolbr_chartabsize(win_T *wp, char_u *s, colnr_T col, int *headp)
+static int win_nolbr_chartabsize(const win_T *wp, char_u *s, colnr_T col, int *headp)
 {
   int n;
 
@@ -1107,7 +1107,7 @@ static int win_nolbr_chartabsize(win_T *wp, char_u *s, colnr_T col, int *headp)
 ///
 /// @param  wp    window
 /// @param  vcol  column number
-bool in_win_border(win_T *wp, colnr_T vcol)
+bool in_win_border(const win_T *wp, colnr_T vcol)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ARG(1)
 {
   int width1;             // width of first line (after line number)

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -5776,22 +5776,25 @@ comp_textwidth (
 )
 {
   int textwidth;
+  int fdc = compute_foldcolumn(curwin, 0);
 
   textwidth = curbuf->b_p_tw;
   if (textwidth == 0 && curbuf->b_p_wm) {
     /* The width is the window width minus 'wrapmargin' minus all the
      * things that add to the margin. */
     textwidth = curwin->w_width - curbuf->b_p_wm;
-    if (cmdwin_type != 0)
+    if (cmdwin_type != 0) {
       textwidth -= 1;
-    textwidth -= curwin->w_p_fdc;
+    }
+    textwidth -= fdc;
 
     if (signcolumn_on(curwin)) {
         textwidth -= 1;
     }
 
-    if (curwin->w_p_nu || curwin->w_p_rnu)
+    if (curwin->w_p_nu || curwin->w_p_rnu) {
       textwidth -= 8;
+    }
   }
   if (textwidth < 0)
     textwidth = 0;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8861,7 +8861,10 @@ static void f_foldtextresult(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
   fold_count = foldedCount(curwin, lnum, &foldinfo);
   if (fold_count > 0) {
-    text = get_foldtext(curwin, lnum, lnum + fold_count - 1, &foldinfo, buf);
+    text = get_foldtext(curwin, lnum, lnum + fold_count - 1,
+        &foldinfo, buf);
+    text = get_foldtext(curwin, lnum, lnum + fold_count - 1,
+        foldinfo.fi_level, buf);
     if (text == buf) {
       text = vim_strsave(text);
     }
@@ -10609,6 +10612,7 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     "find_in_path",
     "float",
     "folding",
+    "folding_fillchars",
 #if defined(UNIX)
     "fork",
 #endif

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8862,9 +8862,9 @@ static void f_foldtextresult(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   fold_count = foldedCount(curwin, lnum, &foldinfo);
   if (fold_count > 0) {
     text = get_foldtext(curwin, lnum, lnum + fold_count - 1,
-        &foldinfo, buf);
+                        foldinfo.fi_level, buf);
     text = get_foldtext(curwin, lnum, lnum + fold_count - 1,
-        foldinfo.fi_level, buf);
+                        foldinfo.fi_level, buf);
     if (text == buf) {
       text = vim_strsave(text);
     }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9847,8 +9847,9 @@ static void ex_match(exarg_T *eap)
 
 static void ex_fold(exarg_T *eap)
 {
-  if (foldManualAllowed(TRUE))
-    foldCreate(eap->line1, eap->line2);
+  if (foldManualAllowed(TRUE)) {
+    foldCreate(curwin, eap->line1, eap->line2);
+  }
 }
 
 static void ex_foldopen(exarg_T *eap)

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -528,7 +528,7 @@ int foldManualAllowed(int create)
 
 /* foldCreate() {{{2 */
 /// @see nvim_fold_create
-void foldCreate(linenr_T start, linenr_T end)
+void foldCreate(win_T *wp, linenr_T start, linenr_T end)
 {
   fold_T      *fp;
   garray_T    *gap;
@@ -555,10 +555,10 @@ void foldCreate(linenr_T start, linenr_T end)
     return;
   }
 
-  checkupdate(curwin);
+  checkupdate(wp);
 
   /* Find the place to insert the new fold. */
-  gap = &curwin->w_folds;
+  gap = &wp->w_folds;
   for (;; ) {
     if (!foldFind(gap, start_rel, &fp))
       break;
@@ -569,7 +569,7 @@ void foldCreate(linenr_T start, linenr_T end)
       end_rel -= fp->fd_top;
       if (use_level || fp->fd_flags == FD_LEVEL) {
         use_level = TRUE;
-        if (level >= curwin->w_p_fdl)
+        if (level >= wp->w_p_fdl)
           closed = TRUE;
       } else if (fp->fd_flags == FD_CLOSED)
         closed = TRUE;
@@ -1093,11 +1093,12 @@ void checkupdate(win_T *wp)
   if (wp->w_foldinvalid) {
     foldUpdate(wp, (linenr_T)1, (linenr_T)MAXLNUM);     /* will update all */
 
-    int res = getDeepestNestingRecurse(&wp->w_folds);
-    if(res != wp->w_fdcwidth) {
-      fold_changed = TRUE;
-      wp->w_fdcwidth = res;
-    }
+    // TODO put dans screenupdate
+    // ce qui nous interesse c pas forcement le 
+    // int res = getDeepestNestingRecurse(&wp->w_folds);
+    // if(res != wp->w_fdcwidth) {
+    //   wp->w_fdcwidth = res;
+    // }
     wp->w_foldinvalid = false;
   }
 }

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -527,10 +527,7 @@ int foldManualAllowed(int create)
 }
 
 /* foldCreate() {{{2 */
-/*
- * Create a fold from line "start" to line "end" (inclusive) in the current
- * window.
- */
+/// @see nvim_fold_create
 void foldCreate(linenr_T start, linenr_T end)
 {
   fold_T      *fp;
@@ -643,17 +640,14 @@ void foldCreate(linenr_T start, linenr_T end)
 
 
 /* deleteFold() {{{2 */
-/*
- * Delete a fold at line "start" in the current window.
- * When "end" is not 0, delete all folds from "start" to "end".
- * When "recursive" is TRUE delete recursively.
- */
-void 
-deleteFold (
+/// @param had_visual TRUE when Visual selection used
+/// @see nvim_fold_delete
+void
+deleteFold(
     linenr_T start,
     linenr_T end,
     int recursive,
-    int had_visual                 /* TRUE when Visual selection used */
+    int had_visual
 )
 {
   garray_T    *gap;
@@ -662,7 +656,7 @@ deleteFold (
   fold_T      *found_fp = NULL;
   linenr_T found_off = 0;
   bool use_level;
-  bool maybe_small = FALSE;
+  bool maybe_small = false;
   int level = 0;
   linenr_T lnum = start;
   linenr_T lnum_off;
@@ -1868,6 +1862,7 @@ void foldtext_cleanup(char_u *str)
 /*
  * Update the folding for window "wp", at least from lines "top" to "bot".
  * Return TRUE if any folds did change.
+ * Indent Expr Marker Syntax (IEMS)
  */
 static void foldUpdateIEMS(win_T *wp, linenr_T top, linenr_T bot)
 {

--- a/src/nvim/fold.h
+++ b/src/nvim/fold.h
@@ -8,17 +8,55 @@
 #include "nvim/types.h"
 #include "nvim/buffer_defs.h"
 
-/*
- * Info used to pass info about a fold from the fold-detection code to the
- * code that displays the foldcolumn.
- */
+/// TODO REMOVE ?
 typedef struct foldinfo {
   linenr_T fi_lnum;             /* line number where fold starts */
   int fi_level;                 /* level of the fold; when this is zero the
                                    other fields are invalid */
-  int fi_low_level;             /* lowest fold level that starts in the same
-                                   line */
+  int fi_low_level;             //!< lowest fold level that starts in the same
+                                //!< line=> bigger number i.e. fi_low_level >= fi_level */
 } foldinfo_T;
+
+/* local declarations. {{{1 */
+/* typedef fold_T {{{2 */
+/*
+ * The toplevel folds for each window are stored in the w_folds growarray.
+ * Each toplevel fold can contain an array of second level folds in the
+ * fd_nested growarray.
+ * The info stored in both growarrays is the same: An array of fold_T.
+ */
+typedef struct {
+  linenr_T fd_top;              //!< first line of fold; for nested fold
+                                //!< relative to parent
+  linenr_T fd_len;              //!< number of lines in the fold
+  garray_T fd_nested;           //!< array of nested folds
+  char fd_flags;                //!< @see FD_OPEN, etc...
+  char fd_small;                //!< TRUE, FALSE or MAYBE: fold smaller than
+                                //!< 'foldminlines'; MAYBE applies to nested
+                                //!< folds too
+} fold_T;
+
+#define FD_OPEN         0       /* fold is open (nested ones can be closed) */
+#define FD_CLOSED       1       /* fold is closed */
+#define FD_LEVEL        2       /* depends on 'foldlevel' (nested folds too) */
+
+#define MAX_LEVEL       20      /* maximum fold depth */
+
+/* Define "fline_T", passed to get fold level for a line. {{{2 */
+typedef struct {
+  win_T       *wp;              /* window */
+  linenr_T lnum;                /* current line number */
+  linenr_T off;                 /* offset between lnum and real line number */
+  linenr_T lnum_save;           /* line nr used by foldUpdateIEMSRecurse() */
+  int lvl;                      /* current level (-1 for undefined) */
+  int lvl_next;                 /* level used for next line */
+  int start;                    /* number of folds that are forced to start at
+                                   this line. */
+  int end;                      /* level of fold that is forced to end below
+                                   this line */
+  int had_end;                  /* level of fold that is forced to end above
+                                   this line (copy of "end" of prev. line) */
+} fline_T;
 
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -80,6 +80,15 @@ typedef enum {
   kTrue  = 1,
 } TriState;
 
+/// enum to identify character
+/// order matters as it used to prioritize some symbols over others
+typedef enum {
+  kFoldOpenMid,     //!< vertical sep
+  kFoldOpenStart,   //!< Mark the start of an open fold
+  kFoldOpenLast,    //!< Mark the last line of an open fold
+  kFoldClosed       //!< Show a closed fold
+} kFoldChar;
+
 /* Values for "starting" */
 #define NO_SCREEN       2       /* no screen updating yet */
 #define NO_BUFFERS      1       /* not all buffers loaded yet */
@@ -947,6 +956,12 @@ EXTERN int fill_stlnc INIT(= ' ');
 EXTERN int fill_vert INIT(= 9474);  // │
 EXTERN int fill_fold INIT(= 183);   // ·
 EXTERN int fill_diff INIT(= '-');
+EXTERN int fold_chars[] INIT(= {
+  '|',     // kFoldOpenMid
+  '-',     // kFoldOpenStart
+  '^',     // kFoldOpenLast
+  '+'      // kFoldClosed
+});
 
 /* Whether 'keymodel' contains "stopsel" and "startsel". */
 EXTERN int km_stopsel INIT(= FALSE);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -959,7 +959,7 @@ EXTERN int fill_diff INIT(= '-');
 EXTERN int fold_chars[] INIT(= {
   '|',     // kFoldOpenMid
   '-',     // kFoldOpenStart
-  '^',     // kFoldOpenLast
+  9492,    // kFoldOpenLast └
   '+'      // kFoldClosed
 });
 

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -454,7 +454,7 @@ int get_number_indent(linenr_T lnum)
  * parameters into account. Window must be specified, since it is not
  * necessarily always the current one.
  */
-int get_breakindent_win(win_T *wp, char_u *line) {
+int get_breakindent_win(const win_T *wp, char_u *line) {
   static int prev_indent = 0;  /* cached indent value */
   static long prev_ts = 0; /* cached tabstop value */
   static char_u *prev_line = NULL; /* cached pointer to line */

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1186,7 +1186,7 @@ void cleanup_jumplist(void)
 /*
  * Copy the jumplist from window "from" to window "to".
  */
-void copy_jumplist(win_T *from, win_T *to)
+void copy_jumplist(const win_T *from, win_T *to)
 {
   int i;
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -285,7 +285,7 @@ int ml_open(buf_T *buf)
   buf->b_ml.ml_mfp = mfp;
   buf->b_ml.ml_flags = ML_EMPTY;
   buf->b_ml.ml_line_count = 1;
-  curwin->w_nrwidth_line_count = 0;
+  // curwin->w_nrwidth_line_count = 0;
 
 
   /*

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1252,7 +1252,7 @@ plines_win_nofill (
  * Return number of window lines physical line "lnum" will occupy in window
  * "wp".  Does not care about folding, 'wrap' or 'diff'.
  */
-int plines_win_nofold(win_T *wp, linenr_T lnum)
+int plines_win_nofold(const win_T *wp, linenr_T lnum)
 {
   char_u      *s;
   unsigned int col;

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -163,13 +163,15 @@ retnomove:
 
     // Before jumping to another buffer, or moving the cursor for a left
     // click, stop Visual mode.
+    // TODO compute foldcolumnwidth
+    int fdc = compute_foldcolumn(curwin, 0);
     if (VIsual_active
         && (wp->w_buffer != curwin->w_buffer
             || (!on_status_line
                 && !on_sep_line
                 && (
-                  wp->w_p_rl ? col < wp->w_width - wp->w_p_fdc :
-                                     col >= wp->w_p_fdc
+                  wp->w_p_rl ? col < wp->w_width - fdc :
+                                     col >= fdc
                                              + (cmdwin_type == 0 && wp ==
                                                 curwin ? 0 : 1)
                   )

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -672,7 +672,7 @@ int win_col_off(const win_T *wp)
   return ((wp->w_p_nu || wp->w_p_rnu) ? number_width(wp) + 1 : 0)
          + (cmdwin_type == 0 || wp != curwin ? 0 : 1)
          + (signcolumn_on(wp) ? win_signcol_width(wp) : 0);
-         + compute_foldcolumn(wp, 0)
+         + compute_foldcolumn(wp, 0);
 }
 
 int curwin_col_off(void)

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -667,12 +667,12 @@ void validate_cursor_col(void)
  * Compute offset of a window, occupied by absolute or relative line number,
  * fold column and sign column (these don't move when scrolling horizontally).
  */
-int win_col_off(win_T *wp)
+int win_col_off(const win_T *wp)
 {
   return ((wp->w_p_nu || wp->w_p_rnu) ? number_width(wp) + 1 : 0)
          + (cmdwin_type == 0 || wp != curwin ? 0 : 1)
-         + (int)wp->w_p_fdc
          + (signcolumn_on(wp) ? win_signcol_width(wp) : 0);
+         + compute_foldcolumn(wp, 0)
 }
 
 int curwin_col_off(void)
@@ -685,7 +685,7 @@ int curwin_col_off(void)
  * wrapped line.  It's 8 if 'number' or 'relativenumber' is on and 'n' is in
  * 'cpoptions'.
  */
-int win_col_off2(win_T *wp)
+int win_col_off2(const win_T *wp)
 {
   if ((wp->w_p_nu || wp->w_p_rnu) && vim_strchr(p_cpo, CPO_NUMCOL) != NULL)
     return number_width(wp) + 1;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1977,7 +1977,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
 
     case OP_FOLD:
       VIsual_reselect = false;          /* don't reselect now */
-      foldCreate(oap->start.lnum, oap->end.lnum);
+      foldCreate(curwin, oap->start.lnum, oap->end.lnum);
       break;
 
     case OP_FOLDOPEN:

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7113,7 +7113,7 @@ int csh_like_shell(void)
 }
 
 /// Return true when window "wp" has a column to draw signs in.
-bool signcolumn_on(win_T *wp)
+bool signcolumn_on(const win_T *wp)
 {
     if (*wp->w_p_scl == 'n') {
       return false;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3411,6 +3411,10 @@ static char_u *set_chars_option(char_u **varp)
     { &fill_vert,    "vert" , 9474 },  // │
     { &fill_fold,    "fold" , 183  },  // ·
     { &fill_diff,    "diff" , '-'  },
+    { &fold_chars[kFoldOpenStart],  "foldopen", '-' },
+    { &fold_chars[kFoldClosed],     "foldclose", '+' },
+    { &fold_chars[kFoldOpenMid],    "foldsep", '|'},
+    { &fold_chars[kFoldOpenLast],   "foldend", '^' },
   };
   static struct charstab lcstab[] = {
     { &lcs_eol,      "eol",      NUL },

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5642,7 +5642,7 @@ void win_copy_options(win_T *wp_from, win_T *wp_to)
  * The 'scroll' option is not copied, because it depends on the window height.
  * The 'previewwindow' option is reset, there can be only one preview window.
  */
-void copy_winopt(winopt_T *from, winopt_T *to)
+void copy_winopt(const winopt_T *from, winopt_T *to)
 {
   to->wo_arab = from->wo_arab;
   to->wo_list = from->wo_list;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3414,7 +3414,7 @@ static char_u *set_chars_option(char_u **varp)
     { &fold_chars[kFoldOpenStart],  "foldopen", '-' },
     { &fold_chars[kFoldClosed],     "foldclose", '+' },
     { &fold_chars[kFoldOpenMid],    "foldsep", '|' },
-    { &fold_chars[kFoldOpenLast],   "foldend", '^' },
+    { &fold_chars[kFoldOpenLast],   "foldend", 9492 },  // └
   };
   static struct charstab lcstab[] = {
     { &lcs_eol,      "eol",      NUL },
@@ -4341,7 +4341,7 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
       terminal_resize(curbuf->terminal, UINT16_MAX, UINT16_MAX);
     }
   } else if (pp == &curwin->w_p_nuw) {
-    curwin->w_nrwidth_line_count = 0;
+    // curwin->w_nrwidth_line_count = 0;
   }
 
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3413,7 +3413,7 @@ static char_u *set_chars_option(char_u **varp)
     { &fill_diff,    "diff" , '-'  },
     { &fold_chars[kFoldOpenStart],  "foldopen", '-' },
     { &fold_chars[kFoldClosed],     "foldclose", '+' },
-    { &fold_chars[kFoldOpenMid],    "foldsep", '|'},
+    { &fold_chars[kFoldOpenMid],    "foldsep", '|' },
     { &fold_chars[kFoldOpenLast],   "foldend", '^' },
   };
   static struct charstab lcstab[] = {
@@ -4194,8 +4194,8 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
     }
   } else if (pp == &curwin->w_p_fdc
              || pp == (long *)GLOBAL_WO(&curwin->w_p_fdc)) {
-    if (value < 0) {
-      errmsg = e_positive;
+    if (value < -1) {
+      errmsg = e_invarg;
     } else if (value > 12) {
       errmsg = e_invarg;
     }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1696,12 +1696,20 @@ static int advance_color_col(int vcol, int **color_cols)
 
 /// Compute the width of the foldcolumn.  Based on 'foldcolumn' and how much
 /// space is available for window "wp", minus "col".
+/// @param wp
+/// @param col 
 /// @return foldcolumn width in cell unit
 static int compute_foldcolumn(win_T *wp, int col)
 {
+  // int desired_width = wp->w_p_fdc;
   int fdc = wp->w_p_fdc;
-  int wmw = wp == curwin && p_wmw == 0 ? 1 : p_wmw;
+  int wmw = (wp == curwin && p_wmw == 0) ? 1 : p_wmw;
   int wwidth = wp->w_width;
+
+  if(wp->w_fdc == -1) {
+    // if automatic sizing, lookup in cache
+    fdc = MAX(wp->w_fdcwidth, 0);
+  }
 
   if (fdc > wwidth - (col + wmw)) {
     fdc = wwidth - (col + wmw);
@@ -2111,6 +2119,7 @@ static kFoldChar fill_foldcolumn_single(
 /// @param wrapped screen line is a wrapped continuation of absolute line
 ///
 /// Assume monocell characters
+/// @return number of cells
 static int
 fill_foldcolumn(
     char_u *p,
@@ -2123,6 +2132,7 @@ fill_foldcolumn(
   int level;
   int cell_counter = 0;
   fold_T **fp = NULL;      // Top level/parent fold
+  // TODO we should not have to recompute it
   int fdc = compute_foldcolumn(wp, 0);    // allowed width in cells
   bool maybe_small;
   bool use_level;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -352,7 +352,9 @@ void update_screen(int type)
   //     && curwin->w_nrwidth != ((curwin->w_p_nu || curwin->w_p_rnu)
   //                              ? number_width(curwin) : 0))
   int ret = compute_number_width(curwin);
-  if (curwin->w_redr_type < NOT_VALID
+  if (
+      //curwin->w_redr_type < NOT_VALID
+      true
       && (curwin->w_p_nu || curwin->w_p_rnu)
       ?? TODO revisit with number_width(curwin) : 0))
       && curwin->w_nrwidth_width != ret) {
@@ -362,7 +364,9 @@ void update_screen(int type)
 
   // fold
   int nesting = getDeepestNesting();
-  if (curwin->w_redr_type < NOT_VALID
+  if (
+      true
+      //curwin->w_redr_type < NOT_VALID
       && curwin->w_fdcwidth != nesting) {
     curwin->w_fdcwidth = nesting;
     curwin->w_redr_type = NOT_VALID;
@@ -1730,6 +1734,7 @@ int compute_foldcolumn(const win_T *wp, int col)
   if (fdc > wwidth - (col + wmw)) {
     fdc = wwidth - (col + wmw);
   }
+  ILOG("Compute fdc=", fdc );
   return fdc;
 }
 
@@ -2896,10 +2901,10 @@ win_line (
             long num;
             char *fmt = "%*ld ";
 
-            if (wp->w_p_nu && !wp->w_p_rnu)
+            if (wp->w_p_nu && !wp->w_p_rnu) {
               /* 'number' + 'norelativenumber' */
               num = (long)lnum;
-            else {
+            } else {
               /* 'relativenumber', don't use negative numbers */
               num = labs((long)get_cursor_rel_lnum(wp, lnum));
               if (num == 0 && wp->w_p_nu && wp->w_p_rnu) {
@@ -2918,8 +2923,9 @@ win_line (
               rl_mirror(extra);
             p_extra = extra;
             c_extra = NUL;
-          } else
+          } else {
             c_extra = ' ';
+          }
           n_extra = number_width(wp) + 1;
           char_attr = win_hl_attr(wp, HLF_N);
           // When 'cursorline' is set highlight the line number of

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -276,7 +276,7 @@ void update_screen(int type)
     must_redraw = 0;
   }
 
-  /* Need to update w_lines[]. */
+  // Need to update w_lines[]
   if (curwin->w_lines_valid == 0 && type < NOT_VALID) {
     type = NOT_VALID;
   }
@@ -353,10 +353,10 @@ void update_screen(int type)
   //                              ? number_width(curwin) : 0))
   int ret = compute_number_width(curwin);
   if (
-      //curwin->w_redr_type < NOT_VALID
+      // curwin->w_redr_type < NOT_VALID
       true
       && (curwin->w_p_nu || curwin->w_p_rnu)
-      // TODO revisit with number_width(curwin) : 0))
+      // TODO(teto): revisit with number_width(curwin) : 0))
       && curwin->w_nrwidth_width != ret) {
     curwin->w_nrwidth_width = ret;
     curwin->w_redr_type = NOT_VALID;
@@ -366,7 +366,7 @@ void update_screen(int type)
   int nesting = getDeepestNesting();
   if (
       true
-      //curwin->w_redr_type < NOT_VALID
+      // curwin->w_redr_type < NOT_VALID
       && curwin->w_fdcwidth != nesting) {
     curwin->w_fdcwidth = nesting;
     curwin->w_redr_type = NOT_VALID;
@@ -563,7 +563,7 @@ static void update_finish(void)
 
 void update_debug_sign(buf_T *buf, linenr_T lnum)
 {
-    int  doit = FALSE;
+    int  doit = false;
 
     /* update/delete a specific mark */
     FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
@@ -1422,7 +1422,7 @@ static void win_update(win_T *wp)
         fold_line(wp, fold_count, results.ga_len, lnum, row);
         row++;
         fold_count--;
-        wp->w_lines[idx].wl_folded = TRUE;
+        wp->w_lines[idx].wl_folded = true;
         wp->w_lines[idx].wl_lastlnum = lnum + fold_count;
         did_update = DID_FOLD;
       } else if (idx < wp->w_lines_valid
@@ -1610,8 +1610,7 @@ static void win_update(win_T *wp)
 /// @note Returns a constant for now but hopefully we can improve neovim so that
 ///       the returned value width adapts to the maximum number of marks to draw
 ///       for the window
-/// TODO(teto)
-int win_signcol_width(win_T *wp)
+int win_signcol_width(const win_T *wp)
 {
   // 2 is vim default value
   return 2;
@@ -1725,7 +1724,7 @@ int compute_foldcolumn(const win_T *wp, int col)
   int wmw = (wp == curwin && p_wmw == 0) ? 1 : p_wmw;
   int wwidth = wp->w_width;
 
-  if(wp->w_p_fdc < 0) {
+  if (wp->w_p_fdc < 0) {
     // if automatic sizing, lookup in cache
     fdc = wp->w_fdcwidth;
     // redraw_win_later(wp, NOT_VALID);
@@ -1734,7 +1733,7 @@ int compute_foldcolumn(const win_T *wp, int col)
   if (fdc > wwidth - (col + wmw)) {
     fdc = wwidth - (col + wmw);
   }
-  ILOG("Compute fdc=", fdc );
+  ILOG("Compute fdc=", fdc);
   return fdc;
 }
 
@@ -1789,18 +1788,18 @@ static void fold_line(
     int n_extra = fill_foldcolumn(buf, wp, fdc, lnum, false);
     // buf[n_extra] = '\0';
     screen_puts_len(buf, n_extra, screen_Rows, col, hl_attr(HLF_FC));
-    // TODO reestablish right/left
+    // TODO(teto): reestablish right/left
     // if (wp->w_p_rl) {
     //   int i;
     //   copy_text_attr(off + wp->w_width - fdc - col, buf, fdc,
     //       hl_attr(HLF_FC));
-    //   /* reverse the fold column */
+    //   // reverse the fold column
     //   for (i = 0; i < fdc; ++i) {
     //     ScreenLines[off + wp->w_width - i - 1 - col] = buf[i];
-			// }
+      // }
     // } else {
     //   copy_text_attr(off + col, buf, fdc, hl_attr(HLF_FC));
-		// }
+    // }
     col += fdc;
   }
 
@@ -1846,7 +1845,7 @@ static void fold_line(
         // 'number' + 'norelativenumber'
         num = (long)lnum;
       } else {
-        /* 'relativenumber', don't use negative numbers */
+        // 'relativenumber', don't use negative numbers
         num = labs((long)get_cursor_rel_lnum(wp, lnum));
         if (num == 0 && wp->w_p_nu && wp->w_p_rnu) {
           /* 'number' + 'relativenumber': cursor line shows absolute
@@ -2192,7 +2191,7 @@ fill_foldcolumn(
     if (i == fdc-1) {
       for (i++; i < results.ga_len; i++) {
         bool closed = check_closed(wp, fp[i], &use_level, i, &maybe_small,
-                                    current_line-fold_starting_line+1);
+                                   current_line-fold_starting_line+1);
         kFoldChar k = fill_foldcolumn_single(
             fp[i], current_line,
             &fold_starting_line, wrapped, closed);
@@ -2200,7 +2199,7 @@ fill_foldcolumn(
       }
     }
     int m = fold_chars[symbol];
-    // TODO use strwidth/assume monocell ?
+    // use strwidth/assume monocell ?
     int char2cells = mb_char2cells(m);
 
     mb_char2bytes(m, &p[char_counter]);
@@ -2836,7 +2835,7 @@ win_line (
         draw_state = WL_FOLD;
         if (fdc > 0) {
           // Draw the 'foldcolumn' not closed
-          // TODO double check against master
+          // TODO(teto): double check against master
           bool wrapped = true;
           if (row == startrow + filler_lines && filler_todo <= 0) {
             wrapped= false;
@@ -2844,7 +2843,8 @@ win_line (
           // not sure I undersstand but this is how it's done for
           n_extra = fill_foldcolumn(extra, wp, fdc, lnum, wrapped);
           // if(wrapped)
-          //   ILOG("screen_row=%d lnum=%d col=%d wrapped=%d", screen_row, lnum, col, filler_todo);
+          // ILOG("screen_row=%d lnum=%d col=%d wrapped=%d",
+          // screen_row, lnum, col, filler_todo);
           p_extra = extra;
           p_extra[n_extra] = NUL;
           c_extra = NUL;
@@ -2902,10 +2902,10 @@ win_line (
             char *fmt = "%*ld ";
 
             if (wp->w_p_nu && !wp->w_p_rnu) {
-              /* 'number' + 'norelativenumber' */
+              // 'number' + 'norelativenumber'
               num = (long)lnum;
             } else {
-              /* 'relativenumber', don't use negative numbers */
+              // 'relativenumber', don't use negative numbers
               num = labs((long)get_cursor_rel_lnum(wp, lnum));
               if (num == 0 && wp->w_p_nu && wp->w_p_rnu) {
                 /* 'number' + 'relativenumber' */
@@ -5499,8 +5499,7 @@ void screen_puts_len(char_u *text, int textlen, int row, int col, int attr)
          && !(l_enc_utf8 && l_enc_dbcs));
 
   // safety check
-  if (ScreenLines == NULL || row > screen_Rows)
-  {
+  if (ScreenLines == NULL || row > screen_Rows) {
     ELOG("Wrong parameters");
     return;
   }
@@ -6343,7 +6342,7 @@ retry:
   } else {
     done_outofmem_msg = FALSE;
 
-    for (new_row = 0; new_row < Rows + 1; ++new_row) {
+    for (new_row = 0; new_row < Rows + 1; new_row++) {
       new_LineOffset[new_row] = new_row * Columns;
       new_LineWraps[new_row] = FALSE;
 
@@ -7447,7 +7446,8 @@ static void win_redr_ruler(win_T *wp, int always)
  * Otherwise it depends on 'numberwidth' and the line count.
  */
 
-int number_width(const win_T *wp) {
+int number_width(const win_T *wp)
+{
   return wp->w_nrwidth_width;
 }
 
@@ -7458,12 +7458,11 @@ int compute_number_width(const win_T *wp)
 
   if (!wp->w_p_rnu && !wp->w_p_nu) {
     return 0;
-  }
-  else if (wp->w_p_rnu && !wp->w_p_nu) {
-    /* cursor line shows "0" */
+  } else if (wp->w_p_rnu && !wp->w_p_nu) {
+    // cursor line shows "0"
     lnum = wp->w_height;
   } else {
-    /* cursor line shows absolute line number */
+    // cursor line shows absolute line number
     lnum = wp->w_buffer->b_ml.ml_line_count;
   }
 
@@ -7473,11 +7472,12 @@ int compute_number_width(const win_T *wp)
     ++n;
   } while (lnum > 0);
 
-  /* 'numberwidth' gives the minimal width plus one */
+  // 'numberwidth' gives the minimal width plus one
   if (n < wp->w_p_nuw - 1) {
     n = wp->w_p_nuw - 1;
   }
-  ILOG(" compute_number_width nu=%d rnu=%d result=%d" , wp->w_p_nu, wp->w_p_rnu, n);
+  ILOG("compute_number_width nu=%d rnu=%d result=%d",
+       wp->w_p_nu, wp->w_p_rnu, n);
 
   return n;
 }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7191,10 +7191,10 @@ static int fillchar_status(int *attr, win_T *wp)
   return '=';
 }
 
-/*
- * Get the character to use in a separator between vertically split windows.
- * Get its attributes in "*attr".
- */
+
+/// Get the character to use in a separator between vertically split windows.
+/// @param[out] attr Get its attributes in "*attr".
+/// @return character to use to fill char
 static int fillchar_vsep(win_T *wp, int *attr)
 {
   *attr = win_hl_attr(wp, HLF_C);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -696,7 +696,7 @@ static void win_update(win_T *wp)
 
   /* Force redraw when width of 'number' or 'relativenumber' column
    * changes. */
-  i = (wp->w_p_nu || wp->w_p_rnu) ? number_width(wp) : 0;
+  i = (wp->w_p_nu || wp->w_p_rnu) ? compute_number_width(wp) : 0;
   if (wp->w_nrwidth != i) {
     type = NOT_VALID;
     wp->w_nrwidth = i;
@@ -1837,10 +1837,10 @@ static void fold_line(
       if (len > w + 1)
         len = w + 1;
 
-      if (wp->w_p_nu && !wp->w_p_rnu)
-        /* 'number' + 'norelativenumber' */
+      if (wp->w_p_nu && !wp->w_p_rnu) {
+        // 'number' + 'norelativenumber'
         num = (long)lnum;
-      else {
+      } else {
         /* 'relativenumber', don't use negative numbers */
         num = labs((long)get_cursor_rel_lnum(wp, lnum));
         if (num == 0 && wp->w_p_nu && wp->w_p_rnu) {
@@ -7450,7 +7450,10 @@ int compute_number_width(const win_T *wp)
   int n;
   linenr_T lnum;
 
-  if (wp->w_p_rnu && !wp->w_p_nu) {
+  if (!wp->w_p_rnu && !wp->w_p_nu) {
+    return 0;
+  }
+  else if (wp->w_p_rnu && !wp->w_p_nu) {
     /* cursor line shows "0" */
     lnum = wp->w_height;
   } else {
@@ -7468,6 +7471,7 @@ int compute_number_width(const win_T *wp)
   if (n < wp->w_p_nuw - 1) {
     n = wp->w_p_nuw - 1;
   }
+  ILOG(" compute_number_width nu=%d rnu=%d result=%d" , wp->w_p_nu, wp->w_p_rnu, n);
 
   return n;
 }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -356,7 +356,7 @@ void update_screen(int type)
       //curwin->w_redr_type < NOT_VALID
       true
       && (curwin->w_p_nu || curwin->w_p_rnu)
-      ?? TODO revisit with number_width(curwin) : 0))
+      // TODO revisit with number_width(curwin) : 0))
       && curwin->w_nrwidth_width != ret) {
     curwin->w_nrwidth_width = ret;
     curwin->w_redr_type = NOT_VALID;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -360,6 +360,14 @@ void update_screen(int type)
     curwin->w_redr_type = NOT_VALID;
   }
 
+  // fold
+  int nesting = getDeepestNesting();
+  if (curwin->w_redr_type < NOT_VALID
+      && curwin->w_fdcwidth != nesting) {
+    curwin->w_fdcwidth = nesting;
+    curwin->w_redr_type = NOT_VALID;
+  }
+
   /*
    * Only start redrawing if there is really something to do.
    */
@@ -2142,8 +2150,6 @@ fill_foldcolumn(
   int level;
   int cell_counter = 0;
   fold_T **fp = NULL;      // Top level/parent fold
-  // TODO we should not have to recompute it
-  // int fdc = compute_foldcolumn(wp, 0);    // allowed width in cells
   bool maybe_small;
   bool use_level;
   bool closed;
@@ -2153,7 +2159,6 @@ fill_foldcolumn(
 
   // Init to all spaces.
   memset(p, ' ', 18);
-  // here fp contains the valid top level fold
   // checkupdate(wp);  // don't need that ?
   getFolds(&wp->w_folds, lnum, &results);
   level = results.ga_len;
@@ -2190,6 +2195,7 @@ fill_foldcolumn(
       }
     }
     int m = fold_chars[symbol];
+    // TODO use strwidth/assume monocell ?
     int char2cells = mb_char2cells(m);
 
     mb_char2bytes(m, &p[char_counter]);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -5361,6 +5361,7 @@ theend:
 /// Output a single character directly to the screen and update ScreenLines.
 /// @see screen_puts
 /// TODO(teto) should be removed in favor of more powerful functions
+/// @see screen_getbytes
 void screen_putchar(int c, int row, int col, int attr)
 {
   char_u buf[MB_MAXBYTES + 1];
@@ -5374,10 +5375,11 @@ void screen_putchar(int c, int row, int col, int attr)
   screen_puts(buf, row, col, attr);
 }
 
-/*
- * Get a single character directly from ScreenLines into "bytes[]".
- * Also return its attribute in *attrp;
- */
+
+/// Get a single character directly from ScreenLines into "bytes[]".
+/// Also return its attribute in *attrp;
+/// @param[out] bytes
+/// @param[out] attrp must be set
 void screen_getbytes(int row, int col, char_u *bytes, int *attrp)
 {
   unsigned off;
@@ -5389,9 +5391,9 @@ void screen_getbytes(int row, int col, char_u *bytes, int *attrp)
     bytes[0] = ScreenLines[off];
     bytes[1] = NUL;
 
-    if (enc_utf8 && ScreenLinesUC[off] != 0)
+    if (enc_utf8 && ScreenLinesUC[off] != 0) {
       bytes[utfc_char2bytes(off, bytes)] = NUL;
-    else if (enc_dbcs == DBCS_JPNU && ScreenLines[off] == 0x8e) {
+    } else if (enc_dbcs == DBCS_JPNU && ScreenLines[off] == 0x8e) {
       bytes[0] = ScreenLines[off];
       bytes[1] = ScreenLines2[off];
       bytes[2] = NUL;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1026,8 +1026,9 @@ static void win_init(win_T *newp, win_T *oldp, int flags)
     /* Don't copy the location list.  */
     newp->w_llist = NULL;
     newp->w_llist_ref = NULL;
-  } else
+  } else {
     copy_loclist(oldp, newp);
+  }
   newp->w_localdir = (oldp->w_localdir == NULL)
                      ? NULL : vim_strsave(oldp->w_localdir);
 
@@ -2955,6 +2956,8 @@ static int win_alloc_firstwin(win_T *oldwin)
     RESET_BINDING(curwin);
   }
 
+  curwin->w_nrwidth_width = compute_number_width(curwin);
+  curwin->w_fdcwidth = getDeepestNesting();
   new_frame(curwin);
   topframe = curwin->w_frame;
   topframe->fr_width = Columns;

--- a/test/functional/legacy/045_folding_spec.lua
+++ b/test/functional/legacy/045_folding_spec.lua
@@ -213,5 +213,28 @@ describe('folding', function()
       Test fdm=indent and :move bug END
       line2]])
   end)
+
+  it('test fdc', function()
+    insert([[
+      Test fdm=indent and :move bug END
+      line2
+      	Test fdm=indent START
+      	line3
+      	line4]])
+
+    execute('set noai nosta')
+    execute('set fdm=indent')
+    execute('1m1')
+    feed('2jzc')
+    execute('m0')
+
+    expect([[
+      	Test fdm=indent START
+      	line3
+      	line4
+      Test fdm=indent and :move bug END
+      line2]])
+  end)
+
 end)
 

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -1,0 +1,257 @@
+-- Tests for folding.
+local Screen = require('test.functional.ui.screen')
+
+local helpers = require('test.functional.helpers')(after_each)
+local feed, insert, execute, expect_any, command =
+  helpers.feed, helpers.insert, helpers.execute, helpers.expect_any,
+  helpers.command
+
+describe('foldchars', function()
+  local screen
+
+  before_each(function()
+    helpers.clear()
+
+    screen = Screen.new(20, 11)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray},
+      [2] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey},
+      [3] = {bold = true, foreground = Screen.colors.Blue1}
+    })
+  end)
+  after_each(function()
+    screen:detach()
+  end)
+
+  it('api', function()
+    insert([[
+      1
+      2
+      3
+      4
+      5
+      6
+      7
+      8
+      last
+      ]])
+    execute("set foldcolumn=2")
+
+
+    -- TODO check
+	-- :highlight Folded guibg=grey guifg=blue
+	-- :highlight FoldColumn guibg=darkgrey guifg=white
+    -- set foldminlines
+    -- test with fillchars
+    -- test with minimum size of folds 
+    command("call nvim_fold_create(nvim_get_current_win(), 1, 4)")
+    command("call nvim_fold_create(nvim_get_current_win(), 1, 3)")
+    command("call nvim_fold_create(nvim_get_current_win(), 1, 2)")
+    command("%foldopen!")
+    command("call nvim_fold_create(nvim_get_current_win(), 6, line('$'))")
+    command("call nvim_fold_create(nvim_get_current_win(), 7, line('$'))")
+    feed("gg")
+
+    expected = [[
+      {1:--}^1                 |
+      {1:|^}2                 |
+      {1:|^}3                 |
+      {1:^ }4                 |
+      {1:  }5                 |
+      {1:+ }{2:+--  5 lines: 6---}|
+      {1:  }{3:~                 }|
+      {1:  }{3:~                 }|
+      {1:  }{3:~                 }|
+      {1:  }{3:~                 }|
+      :set foldcolumn=2   |
+    ]]
+    screen:expect(expected)
+      -- 1 => FoldColumn
+
+
+    command("set fillchars+=foldopen:▾,foldsep:│,foldclose:▸,foldend:^")
+    -- screen:snapshot_util()
+    -- foldchars = {
+    -- 'open': '▾'
+    -- '|': '│'
+    -- '-': 
+    -- }
+    screen:expect([[
+      {1:▾▾}^1                 |
+      {1:│^}2                 |
+      {1:│^}3                 |
+      {1:^ }4                 |
+      {1:  }5                 |
+      {1:▸ }{2:+--  5 lines: 6---}|
+      {1:  }{3:~                 }|
+      {1:  }{3:~                 }|
+      {1:  }{3:~                 }|
+      {1:  }{3:~                 }|
+      :set foldcolumn=2   |
+    ]])
+
+  end)
+
+  -- TODO
+  -- test single column
+  --
+  it("set foldminlines", function()
+    insert([[
+      1
+      2
+      3
+      4
+      5
+      6
+      7
+      8
+      last
+      ]])
+      local limit = 4
+      local i = 0
+      --   command("set foldminlines="..limit)
+      -- TODO echo that one nvim_get_current_win(),
+        while i < limit + 2 do
+          command("call nvim_fold_create(nvim_get_current_win(), 1, 4)")
+        end
+    screen:try_resize(20, 10)
+
+  end)
+
+  -- it("foldmethod=indent", function()
+  --   screen:try_resize(20, 8)
+  --   execute('set fdm=indent sw=2')
+  --   insert([[
+  --   aa
+  --     bb
+  --       cc
+  --   last
+  --   ]])
+  --   execute('call append("$", "foldlevel line3=" . foldlevel(3))')
+  --   execute('call append("$", foldlevel(2))')
+  --   feed('zR')
+
+  --   helpers.wait()
+  --   screen:expect([[
+  --     aa                  |
+  --       bb                |
+  --         cc              |
+  --     last                |
+  --     ^                    |
+  --     foldlevel line3=2   |
+  --     1                   |
+  --                         |
+  --   ]])
+  -- end)
+
+  -- it("foldmethod=syntax", function()
+  --   screen:try_resize(35, 15)
+  --   insert([[
+  --     1 aa
+  --     2 bb
+  --     3 cc
+  --     4 dd {{{
+  --     5 ee {{{ }}}
+  --     6 ff }}}
+  --     7 gg
+  --     8 hh
+  --     9 ii
+  --     a jj
+  --     b kk
+  --     last]])
+  --   execute('set fdm=syntax fdl=0')
+  --   execute('syn region Hup start="dd" end="ii" fold contains=Fd1,Fd2,Fd3')
+  --   execute('syn region Fd1 start="ee" end="ff" fold contained')
+  --   execute('syn region Fd2 start="gg" end="hh" fold contained')
+  --   execute('syn region Fd3 start="commentstart" end="commentend" fold contained')
+  --   feed('Gzk')
+  --   execute('call append("$", "folding " . getline("."))')
+  --   feed('k')
+  --   execute('call append("$", getline("."))')
+  --   feed('jAcommentstart  <esc>Acommentend<esc>')
+  --   execute('set fdl=1')
+  --   feed('3j')
+  --   execute('call append("$", getline("."))')
+  --   execute('set fdl=0')
+  --   feed('zO<C-L>j') -- <C-L> redraws screen
+  --   execute('call append("$", getline("."))')
+  --   execute('set fdl=0')
+  --   expect_any([[
+  --     folding 9 ii
+  --     3 cc
+  --     9 ii
+  --     a jj]])
+  -- end)
+
+  -- it("foldmethod=expression", function()
+  --   insert([[
+  --     1 aa
+  --     2 bb
+  --     3 cc
+  --     4 dd {{{
+  --     5 ee {{{ }}}
+  --     6 ff }}}
+  --     7 gg
+  --     8 hh
+  --     9 ii
+  --     a jj
+  --     b kk
+  --     last ]])
+
+  --   execute([[
+  --   fun Flvl()
+  --    let l = getline(v:lnum)
+  --    if l =~ "bb$"
+  --      return 2
+  --    elseif l =~ "gg$"
+  --      return "s1"
+  --    elseif l =~ "ii$"
+  --      return ">2"
+  --    elseif l =~ "kk$"
+  --      return "0"
+  --    endif
+  --    return "="
+  --   endfun
+  --   ]])
+  --   execute('set fdm=expr fde=Flvl()')
+  --   execute('/bb$')
+  --   execute('call append("$", "expr " . foldlevel("."))')
+  --   execute('/hh$')
+  --   execute('call append("$", foldlevel("."))')
+  --   execute('/ii$')
+  --   execute('call append("$", foldlevel("."))')
+  --   execute('/kk$')
+  --   execute('call append("$", foldlevel("."))')
+
+  --   expect_any([[
+  --     expr 2
+  --     1
+  --     2
+  --     0]])
+  -- end)
+
+  -- it('can be opened after :move', function()
+  --   -- luacheck: ignore
+  --   screen:try_resize(35, 8)
+  --   insert([[
+  --     Test fdm=indent and :move bug END
+  --     line2
+  --     	Test fdm=indent START
+  --     	line3
+  --     	line4]])
+  --   execute('set noai nosta ')
+  --   execute('set fdm=indent')
+  --   execute('1m1')
+  --   feed('2jzc')
+  --   execute('m0')
+  --   feed('zR')
+
+  --   expect_any([[
+  --     	Test fdm=indent START
+  --     	line3
+  --     	line4
+  --     Test fdm=indent and :move bug END
+  --     line2]])
+  -- end)
+end)

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -42,8 +42,7 @@ describe('foldchars', function()
     -- TODO check
 	-- :highlight Folded guibg=grey guifg=blue
 	-- :highlight FoldColumn guibg=darkgrey guifg=white
-    -- set foldminlines
-    -- test with fillchars
+    -- set foldminlines just tells about which folds to close, unrelated to their size :s
     -- test with minimum size of folds 
     command("call nvim_fold_create(nvim_get_current_win(), 1, 4)")
     command("call nvim_fold_create(nvim_get_current_win(), 1, 3)")
@@ -53,7 +52,7 @@ describe('foldchars', function()
     command("call nvim_fold_create(nvim_get_current_win(), 7, line('$'))")
     feed("gg")
 
-    expected = [[
+    local expected = [[
       {1:--}^1                 |
       {1:|^}2                 |
       {1:|^}3                 |
@@ -110,16 +109,25 @@ describe('foldchars', function()
       ]])
       local limit = 4
       local i = 0
-      --   command("set foldminlines="..limit)
+      command("set foldminlines="..limit)
       -- TODO echo that one nvim_get_current_win(),
-        while i < limit + 2 do
-          command("call nvim_fold_create(nvim_get_current_win(), 1, 4)")
-        end
-    screen:try_resize(20, 10)
 
+      command("call nvim_fold_create(nvim_get_current_win(), 1, 4)")
+      while i < limit + 2 do
+        command("")
+        local ret = command("echo foldclosed(1)")
+        if i < limit then
+          assert.is_true()
+        else
+          assert.is_false()
+        end
+      end
+    screen:try_resize(20, 10)
   end)
 
-  -- it("foldmethod=indent", function()
+  -- TODO test fdc=-1
+  --
+  -- it("fdc=-1 (adaptive width)", function()
   --   screen:try_resize(20, 8)
   --   execute('set fdm=indent sw=2')
   --   insert([[


### PR DESCRIPTION
Follow up of https://github.com/neovim/neovim/issues/5931

- use the last column of fdc (vim doesn't for some reason)
- don't repeat symbol on wrapped lines
- show the end of a fold
- fillchars for fold symbols (see below)
- support unicode characters as fold markers
- improved style some places

I still have some things to do:
- support right/left display
- get rid of foldinfo_T ?
- also fillchar parsing is a bit weird, I mean the default value for each char needs to be entered twice, you first have a variable in globals.h then each char has its own dedicated function, for instance fillchar_vsep(int *attr) for fill_vert. I believe we shoudl change that.
For now if you want to see the characters, you have to explicitly set the characters with for instance:
```
if has("folding_fillchars")
  set fillchars+=foldopen:▾,foldsep:│,foldclose:▸,foldend:^
endif
```

Appearance of folds is not well tested (foldminlines either) but I intend to improve tests after this:
https://github.com/neovim/neovim/pull/5993