### PR TITLE
Fix #6077, distinguish between lua and lua packages in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,28 +387,25 @@ endforeach()
 
 # Find Lua interpreter
 include(LuaHelpers)
-set(LUA_DEPENDENCIES lpeg mpack bit)
 if(NOT LUA_PRG)
   foreach(CURRENT_LUA_PRG luajit lua5.1 lua5.2 lua)
     # If LUA_PRG is set find_program() will not search
     unset(LUA_PRG CACHE)
-    unset(LUA_PRG_WORKS)
     find_program(LUA_PRG ${CURRENT_LUA_PRG})
 
     if(LUA_PRG)
-      check_lua_deps(${LUA_PRG} "${LUA_DEPENDENCIES}" LUA_PRG_WORKS)
-      if(LUA_PRG_WORKS)
-        break()
-      endif()
+      break()
     endif()
   endforeach()
-else()
-  check_lua_deps(${LUA_PRG} "${LUA_DEPENDENCIES}" LUA_PRG_WORKS)
 endif()
 
-if(NOT LUA_PRG_WORKS)
+if(NOT LUA_PRG)
   message(FATAL_ERROR "A suitable Lua interpreter was not found.")
 endif()
+
+set(LUA_DEPENDENCIES lpeg mpack bit)
+
+check_lua_deps(${LUA_PRG} "${LUA_DEPENDENCIES}")
 
 message(STATUS "Using the Lua interpreter ${LUA_PRG}.")
 

--- a/cmake/LuaHelpers.cmake
+++ b/cmake/LuaHelpers.cmake
@@ -15,24 +15,29 @@ function(check_lua_module LUA_PRG_PATH MODULE RESULT_VAR)
 endfunction()
 
 # Check Lua interpreter for dependencies
-function(check_lua_deps LUA_PRG_PATH MODULES RESULT_VAR)
+function(check_lua_deps LUA_PRG_PATH MODULES)
   # Check if the lua interpreter at the given path
   # satisfies all Neovim dependencies
-  message(STATUS "Checking Lua interpreter ${LUA_PRG_PATH}")
+  message(STATUS
+    "Checking Lua interpreter ${LUA_PRG_PATH} for dependencies.")
   if(NOT EXISTS ${LUA_PRG_PATH})
     message(STATUS
       "[${LUA_PRG_PATH}] file not found")
   endif()
 
+  set(any_missing False)
   foreach(module ${MODULES})
     check_lua_module(${LUA_PRG_PATH} ${module} has_module)
     if(NOT has_module)
       message(STATUS
         "[${LUA_PRG_PATH}] The '${module}' lua package is required for building Neovim")
-      set(${RESULT_VAR} False PARENT_SCOPE)
-      return()
+      set(any_missing True)
     endif()
   endforeach()
 
-  set(${RESULT_VAR} True PARENT_SCOPE)
+  if(any_missing)
+      message(FATAL_ERROR
+        "Please install missing lua packages for ${LUA_PRG_PATH}")
+      return()
+  endif()
 endfunction()


### PR DESCRIPTION
This PR disentangles the check for a suitable Lua binary with the check for lua packages that neovim is dependent on for builds.

# CMake error message when no suitable Lua is available
```
$cmake -DCMAKE_INSTALL_PREFIX=$HOME/usr/ ..                                                                                                                                                                                                                             [252/630]
-- The C compiler identification is GNU 6.3.0
-- The CXX compiler identification is GNU 6.3.0    
-- Check for working C compiler: /usr/bin/cc                       
-- Check for working C compiler: /usr/bin/cc -- works                       
-- Detecting C compiler ABI info              
-- Detecting C compiler ABI info - done          
-- Detecting C compile features                  
-- Detecting C compile features - done                                       
-- Check for working CXX compiler: /usr/bin/c++                                                                         
-- Check for working CXX compiler: /usr/bin/c++ -- works     
-- Detecting CXX compiler ABI info                          
-- Detecting CXX compiler ABI info - done                
-- Detecting CXX compile features                          
-- Detecting CXX compile features - done           
-- CMAKE_BUILD_TYPE not given, defaulting to 'Dev'.                  
-- Replacing -O3 in CMAKE_C_FLAGS_RELEASE with -O2.          
-- Performing Test HAS_OG_FLAG         
-- Performing Test HAS_OG_FLAG - Success                                     
-- Performing Test HAS_ACCEPTABLE_FORTIFY   
-- Performing Test HAS_ACCEPTABLE_FORTIFY - Success
-- Performing Test HAS_WVLA_FLAG                    
-- Performing Test HAS_WVLA_FLAG - Success                     
-- Performing Test HAS_FSTACK_PROTECTOR_STRONG_FLAG              
-- Performing Test HAS_FSTACK_PROTECTOR_STRONG_FLAG - Success
-- Performing Test HAS_FSTACK_PROTECTOR_FLAG
-- Performing Test HAS_FSTACK_PROTECTOR_FLAG - Success                       
-- Performing Test HAS_DIAG_COLOR_FLAG                            
-- Performing Test HAS_DIAG_COLOR_FLAG - Success                   
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29")                           
-- Looking for dlopen in dl                 
-- Looking for dlopen in dl - found        
-- Looking for kstat_lookup in kstat       
-- Looking for kstat_lookup in kstat - not found                        
-- Looking for kvm_open in kvm                                         
-- Looking for kvm_open in kvm - not found                                   
-- Looking for gethostbyname in nsl                                           
-- Looking for gethostbyname in nsl - found        
-- Looking for perfstat_cpu in perfstat            
-- Looking for perfstat_cpu in perfstat - not found                
-- Looking for clock_gettime in rt                                          
-- Looking for clock_gettime in rt - found    
-- Looking for sendfile in sendfile              
-- Looking for sendfile in sendfile - not found    
-- Found LibUV: /usr/lib/x86_64-linux-gnu/libuv.so                            
-- Found Msgpack: /usr/lib/x86_64-linux-gnu/libmsgpackc.so (found suitable version "1.4.2", minimum required is "1.0.0")
-- Found unibilium: /usr/lib/x86_64-linux-gnu/libunibilium.so
-- Found LibTermkey: /usr/lib/x86_64-linux-gnu/libtermkey.so
-- Found LibVterm: /usr/lib/x86_64-linux-gnu/libvterm.so 
-- Found JeMalloc: /usr/lib/x86_64-linux-gnu/libjemalloc.so
-- Performing Test HAVE_WORKING_LIBINTL                                     
-- Performing Test HAVE_WORKING_LIBINTL - Success                    
-- Looking for _nl_msg_cat_cntr                              
-- Looking for _nl_msg_cat_cntr - found
-- Found Iconv                                                               
-- Looking for pthread.h                    
-- Looking for pthread.h - found        
-- Looking for pthread_create                       
-- Looking for pthread_create - not found                      
-- Looking for pthread_create in pthreads                        
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found                             
-- Found Threads: TRUE                                            
CMake Error at CMakeLists.txt:403 (message):                       
  A suitable Lua interpreter was not found. 
```

# CMake message when suitable Lua is available but one or more necessary lua packages are missing:
```
$cmake -DCMAKE_INSTALL_PREFIX=$HOME/usr/ ..        
-- Replacing -O3 in CMAKE_C_FLAGS_RELEASE with -O2.                  
-- Found Iconv                                               
-- Checking Lua interpreter /usr/bin/lua5.2 for dependencies: lpeg;mpack;bit
-- [/usr/bin/lua5.2] file not found                                          
-- [/usr/bin/lua5.2] The 'lpeg' lua package is required for building Neovim
-- [/usr/bin/lua5.2] The 'mpack' lua package is required for building Neovim
-- [/usr/bin/lua5.2] The 'bit' lua package is required for building Neovim
CMake Error at cmake/LuaHelpers.cmake:39 (message):            
  Please install missing lua packages for /usr/bin/lua5.2        
Call Stack (most recent call first):                         
  CMakeLists.txt:408 (check_lua_deps)       
```

And of course when both are available the configuration succeeds successfully.