### PR TITLE
Fix C-Space insert previously inserted text

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -844,6 +844,11 @@ static int insert_handle_key(InsertState *s)
     return 0;  // exit insert mode
 
 
+  case ' ':
+    if (mod_mask != 4) {
+      goto normalchar;
+    }
+  // FALLTHROUGH
   case K_ZERO:        // Insert the previously inserted text.
   case NUL:
   case Ctrl_A:

--- a/test/functional/insert/last_inserted_spec.lua
+++ b/test/functional/insert/last_inserted_spec.lua
@@ -1,0 +1,24 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
+local expect = helpers.expect
+
+clear()
+describe('Insert mode Control Space', function()
+    it('inserts last inserted text and leaves insert mode', function()
+        insert('hello')
+        feed('i<C-@>x')
+        expect('hellhello')
+    end)
+    -- Ensure the same happens for both C-Space and C-@
+    it('inserts last inserted text and leaves insert mode', function()
+        feed('i<C-Space>x')
+        expect('hellhellhello')
+    end)
+end)
+
+describe('Insert mode Control-A', function()
+    it('inserts last inserted text', function()
+        feed('i<C-A>x')
+        expect('hellhellhellhelloxo')
+    end)
+end)


### PR DESCRIPTION
The default vim binding of `C-Space` is to insert the last inserted
text and exit insert mode, this doesn't happen in neovim.

This is because `insert_handle_key()` checks for `NUL` instead
of checking for `' '` with a control `mod_mask`.
This patch adds in a check for that.

I'm leaving the check for `NUL` there despite the fact that
at the moment that key is never seen when using the
terminal UI (not for `C-Space`, nor `C-@`).
This is because I assume it's still allowed for other
front-ends to pass `NUL`, but at the moment the terminal UI
isn't.

I also suspect that the terminal UI not passing `NUL` when `C-@` is pressed is a bug that will be fixed in the future.
