### PR TITLE
build: `oldtest` target: TEST_FILE, NVIM_PRG

### DIFF
--- a/.ci/common/test.sh
+++ b/.ci/common/test.sh
@@ -64,7 +64,7 @@ run_functionaltests() {
 
 run_oldtests() {
   ${MAKE_CMD} -C "${BUILD_DIR}" helptags
-  if ! make -C "${TRAVIS_BUILD_DIR}/src/nvim/testdir"; then
+  if ! make oldtest; then
     reset
     asan_check "${LOG_DIR}"
     valgrind_check "${LOG_DIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,9 +152,9 @@ if(NOT MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion")
 endif()
 
-# gcc 4.0 and better turn on _FORTIFY_SOURCE=2 automatically.  This currently
+# gcc 4.0+ sets _FORTIFY_SOURCE=2 automatically.  This currently
 # does not work with Neovim due to some uses of dynamically-sized structures.
-# See https://github.com/neovim/neovim/issues/223 for details.
+# https://github.com/neovim/neovim/issues/223
 include(CheckCSourceCompiles)
 
 # Include the build type's default flags in the check for _FORTIFY_SOURCE,
@@ -424,7 +424,6 @@ if(NOT BUSTED_OUTPUT_TYPE)
 endif()
 
 find_program(LUACHECK_PRG luacheck)
-
 find_program(GPERF_PRG gperf)
 
 include(InstallHelpers)
@@ -457,7 +456,7 @@ get_compile_flags(NVIM_VERSION_CFLAGS)
 
 add_subdirectory(test/includes)
 add_subdirectory(config)
-add_subdirectory(test/functional/fixtures) # compile pty/shell test programs
+add_subdirectory(test/functional/fixtures)  # compile test programs
 add_subdirectory(runtime)
 
 # Setup some test-related bits.  We do this after going down the tree because we
@@ -522,8 +521,7 @@ if(BUSTED_PRG)
       DEPENDS ${UNITTEST_PREREQS}
       ${TEST_TARGET_ARGS})
   else()
-    message(WARNING "The Luajit ffi is not available in ${LUA_PRG}"
-	    ", disabling unit tests")
+    message(WARNING "disabling unit tests: no Luajit FFI in ${LUA_PRG}")
   endif()
 
   add_custom_target(functionaltest

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,14 @@ endif
 	mkdir -p build
 	touch $@
 
+# TODO: cmake 3.2+ add_custom_target() has a USES_TERMINAL flag.
 oldtest: | nvim helptags
-	+$(SINGLE_MAKE) -C src/nvim/testdir $(MAKEOVERRIDES)
+	+$(SINGLE_MAKE) -C src/nvim/testdir clean
+ifeq ($(strip $(TEST_FILE)),)
+	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" $(MAKEOVERRIDES)
+else
+	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" NEW_TESTS=$(TEST_FILE) SCRIPTS= $(MAKEOVERRIDES)
+endif
 
 helptags: | nvim
 	+$(BUILD_CMD) -C build helptags

--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -4,7 +4,7 @@ set(ENV{XDG_CONFIG_HOME} ${WORKING_DIR}/Xtest_xdg/config)
 set(ENV{XDG_DATA_HOME} ${WORKING_DIR}/Xtest_xdg/share)
 
 if(NVIM_PRG)
-  set(ENV{NVIM_PROG} "${NVIM_PRG}")
+  set(ENV{NVIM_PRG} "${NVIM_PRG}")
 endif()
 
 if(DEFINED ENV{TEST_FILE})

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -4,10 +4,10 @@
 
 export SHELL := sh
 
-VIMPROG := ../../../build/bin/nvim
+VIMPROG ?= $(NVIM_PRG)
 SCRIPTSOURCE := ../../../runtime
 
-SCRIPTS := \
+SCRIPTS ?= \
            test13.out             \
            test14.out             \
            test17.out             \
@@ -25,9 +25,9 @@ SCRIPTS := \
            test79.out             \
            test_marks.out         \
 
-# Tests using runtest.vim.vim.
+# Tests using runtest.vim.
 # Keep test_alot*.res as the last one, sort the others.
-NEW_TESTS = \
+NEW_TESTS ?= \
 	    test_bufwintabinfo.res \
 	    test_cmdline.res \
 	    test_cscope.res \

--- a/src/nvim/testdir/test49.vim
+++ b/src/nvim/testdir/test49.vim
@@ -456,7 +456,7 @@ function! ExtraVim(...)
     " messing up the user's viminfo file.
     let redirect = a:0 ?
 	\ " -c 'au VimLeave * redir END' -c 'redir\\! >" . a:1 . "'" : ""
-    exec "!echo '" . debug_quits . "q' | ../../../build/bin/nvim -u NONE -N -es" . redirect .
+    exec "!echo '" . debug_quits . "q' | $NVIM_PRG -u NONE -N -es" . redirect .
 	\ " -c 'debuggreedy|set viminfo+=nviminfo'" .
 	\ " -c 'let ExtraVimBegin = " . extra_begin . "'" .
 	\ " -c 'let ExtraVimResult = \"" . resultfile . "\"'" . breakpoints .

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -17,7 +17,8 @@ local map = global_helpers.map
 local filter = global_helpers.filter
 
 local start_dir = lfs.currentdir()
-local nvim_prog = os.getenv('NVIM_PROG') or 'build/bin/nvim'
+-- XXX: NVIM_PROG takes precedence, QuickBuild sets it.
+local nvim_prog = os.getenv('NVIM_PROG') or os.getenv('NVIM_PRG') or 'build/bin/nvim'
 local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
                    '--cmd', 'set shortmess+=I background=light noswapfile noautoindent laststatus=1 undodir=. directory=. viewdir=. backupdir=.',
                    '--embed'}


### PR DESCRIPTION

- Add support for TEST_FILE to the `oldtest` target, for consistency
  with the busted/lua tests.
  Caveat: with the busted/lua tests TEST_FILE takes a full path, whereas
  for `oldtest` it must be "test_foo.res".
- Add support for NVIM_PRG, again so that all test-related targets are
  consistent.