### PR TITLE
ci: Do not use `oldtest` target on Travis.

### DIFF
--- a/.ci/common/test.sh
+++ b/.ci/common/test.sh
@@ -63,8 +63,7 @@ run_functionaltests() {
 }
 
 run_oldtests() {
-  ${MAKE_CMD} -C "${BUILD_DIR}" helptags
-  if ! make oldtest; then
+  if ! make -C "${TRAVIS_BUILD_DIR}/src/nvim/testdir"; then
     reset
     asan_check "${LOG_DIR}"
     valgrind_check "${LOG_DIR}"

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -2,10 +2,11 @@
 # Makefile to run all tests for Vim
 #
 
-export SHELL := sh
-
-VIMPROG ?= $(NVIM_PRG)
+NVIM_PRG ?= ../../../build/bin/nvim
 SCRIPTSOURCE := ../../../runtime
+
+export SHELL := sh
+export NVIM_PRG := $(NVIM_PRG)
 
 SCRIPTS ?= \
            test13.out             \
@@ -101,13 +102,13 @@ report:
 	                 echo ALL DONE;        \
 	             fi"
 
-test1.out: $(VIMPROG)
+test1.out: $(NVIM_PRG)
 
-$(SCRIPTS) $(SCRIPTS_GUI): $(VIMPROG) test1.out
+$(SCRIPTS) $(SCRIPTS_GUI): $(NVIM_PRG) test1.out
 
 RM_ON_RUN   := test.out X* viminfo
 RM_ON_START := test.ok
-RUN_VIM     := VIMRUNTIME=$(SCRIPTSOURCE); export VIMRUNTIME; $(TOOL) $(VIMPROG) -u unix.vim -U NONE -i viminfo --noplugin -s dotest.in
+RUN_VIM     := VIMRUNTIME=$(SCRIPTSOURCE); export VIMRUNTIME; $(TOOL) $(NVIM_PRG) -u unix.vim -U NONE -i viminfo --noplugin -s dotest.in
 
 clean:
 	-rm -rf *.out          \
@@ -176,7 +177,7 @@ nolog:
 # New style of tests uses Vim script with assert calls.  These are easier
 # to write and a lot easier to read and debug.
 # Limitation: Only works with the +eval feature.
-RUN_VIMTEST = VIMRUNTIME=$(SCRIPTSOURCE); export VIMRUNTIME; $(VALGRIND) $(VIMPROG) -u unix.vim -U NONE --noplugin
+RUN_VIMTEST = VIMRUNTIME=$(SCRIPTSOURCE); export VIMRUNTIME; $(VALGRIND) $(NVIM_PRG) -u unix.vim -U NONE --noplugin
 
 newtests: newtestssilent
 	@/bin/sh -c "if test -f messages && grep -q 'FAILED' messages; then \


### PR DESCRIPTION
The gcc macOS travis build is failing at the libuv build step since commit 30826cb2d621615264607fbd507f6f47e6f2011e.

We must invoke src/nvim/testdir/Makefile directly.
Explained in 3d1084f:
> Running tests from the top-level Makefile will use the third-party
> dependencies from .deps instead of the ones from the Travis cache.

If we could run `oldtest` with CMake, we would not need to do this. Need
USES_TERMINAL feature (CMake 3.2+) for that.