### PR TITLE
[RDY] *: Partial string handling refactoring

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1373,17 +1373,17 @@ void getvcols(win_T *wp, pos_T *pos1, pos_T *pos2, colnr_T *left,
 
 /// skipwhite: skip over ' ' and '\t'.
 ///
-/// @param q
+/// @param[in]  q  String to skip in.
 ///
 /// @return Pointer to character after the skipped whitespace.
-char_u* skipwhite(char_u *q)
+char_u *skipwhite(const char_u *q)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  char_u *p = q;
+  const char_u *p = q;
   while (ascii_iswhite(*p)) {
-    // skip to next non-white
     p++;
   }
-  return p;
+  return (char_u *)p;
 }
 
 /// skip over digits

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1859,8 +1859,9 @@ static bool check_compl_option(bool dict_opt)
       : (*curbuf->b_p_tsr == NUL && *p_tsr == NUL)) {
     ctrl_x_mode = 0;
     edit_submode = NULL;
-    msg_attr(dict_opt ? (char_u *)_("'dictionary' option is empty")
-             : (char_u *)_("'thesaurus' option is empty"), hl_attr(HLF_E));
+    msg_attr((dict_opt
+              ? _("'dictionary' option is empty")
+              : _("'thesaurus' option is empty")), hl_attr(HLF_E));
     if (emsg_silent == 0) {
       vim_beep(BO_COMPL);
       setcursor();
@@ -4801,9 +4802,9 @@ static int ins_complete(int c, bool enable_pum)
   if (!shortmess(SHM_COMPLETIONMENU)) {
     if (edit_submode_extra != NULL) {
       if (!p_smd) {
-        msg_attr(edit_submode_extra,
-                 edit_submode_highl < HLF_COUNT
-                 ? hl_attr(edit_submode_highl) : 0);
+        msg_attr((const char *)edit_submode_extra,
+                 (edit_submode_highl < HLF_COUNT
+                  ? hl_attr(edit_submode_highl) : 0));
       }
     } else {
       msg_clr_cmdline();  // necessary for "noshowmode"

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1755,7 +1755,7 @@ static const char *list_arg_vars(exarg_T *eap, const char *arg, int *first)
       // get_name_len() takes care of expanding curly braces
       name_start = name = arg;
       char *tofree;
-      len = get_name_len(&arg, &tofree, TRUE, TRUE);
+      len = get_name_len(&arg, &tofree, true, true);
       if (len <= 0) {
         /* This is mainly to keep test 49 working: when expanding
          * curly braces fails overrule the exception error message. */
@@ -1775,7 +1775,7 @@ static const char *list_arg_vars(exarg_T *eap, const char *arg, int *first)
         } else {
           // handle d.key, l[idx], f(expr)
           const char *const arg_subsc = arg;
-          if (handle_subscript(&arg, &tv, TRUE, TRUE) == FAIL) {
+          if (handle_subscript(&arg, &tv, true, true) == FAIL) {
             error = true;
           } else {
             if (arg == arg_subsc && len == 2 && name[1] == ':') {
@@ -1844,15 +1844,15 @@ ex_let_one (
     ++arg;
     name = arg;
     len = get_env_len(&arg);
-    if (len == 0)
+    if (len == 0) {
       EMSG2(_(e_invarg2), name - 1);
-    else {
-      if (op != NULL && (*op == '+' || *op == '-'))
+    } else {
+      if (op != NULL && (*op == '+' || *op == '-')) {
         EMSG2(_(e_letwrong), op);
-      else if (endchars != NULL
-               && vim_strchr(endchars, *skipwhite(arg)) == NULL)
+      } else if (endchars != NULL
+                 && vim_strchr(endchars, *skipwhite(arg)) == NULL) {
         EMSG(_(e_letunexp));
-      else if (!check_secure()) {
+      } else if (!check_secure()) {
         const char_u c1 = name[len];
         name[len] = NUL;
         char_u *p = get_tv_string_chk(tv);
@@ -1904,15 +1904,16 @@ ex_let_one (
       if (s != NULL && op != NULL && *op != '=') {
         opt_type = get_option_value(arg, &numval, &stringval, opt_flags);
         if ((opt_type == 1 && *op == '.')
-            || (opt_type == 0 && *op != '.'))
+            || (opt_type == 0 && *op != '.')) {
           EMSG2(_(e_letwrong), op);
-        else {
-          if (opt_type == 1) {          /* number */
-            if (*op == '+')
+        } else {
+          if (opt_type == 1) {  // number
+            if (*op == '+') {
               n = numval + n;
-            else
+            } else {
               n = numval - n;
-          } else if (opt_type == 0 && stringval != NULL) {     /* string */
+            }
+          } else if (opt_type == 0 && stringval != NULL) {  // string
             s = concat_str(stringval, s);
             xfree(stringval);
             stringval = s;
@@ -1963,7 +1964,7 @@ ex_let_one (
   else if (eval_isnamec1(*arg) || *arg == '{') {
     lval_T lv;
 
-    char_u *const p = get_lval(arg, tv, &lv, FALSE, FALSE, 0, FNE_CHECK_START);
+    char_u *const p = get_lval(arg, tv, &lv, false, false, 0, FNE_CHECK_START);
     if (p != NULL && lv.ll_name != NULL) {
       if (endchars != NULL && vim_strchr(endchars, *skipwhite(p)) == NULL)
         EMSG(_(e_letunexp));
@@ -2075,8 +2076,9 @@ get_lval (
   *p = NUL;
   v = find_var((const char *)lp->ll_name, STRLEN(lp->ll_name), &ht,
                flags & GLV_NO_AUTOLOAD);
-  if (v == NULL && !quiet)
+  if (v == NULL && !quiet) {
     EMSG2(_(e_undefvar), lp->ll_name);
+  }
   *p = cc;
   if (v == NULL)
     return NULL;
@@ -2850,9 +2852,10 @@ void ex_call(exarg_T *eap)
       break;
     }
 
-    /* Handle a function returning a Funcref, Dictionary or List. */
-    if (handle_subscript((const char **)&arg, &rettv, !eap->skip, TRUE) == FAIL) {
-      failed = TRUE;
+    // Handle a function returning a Funcref, Dictionary or List.
+    if (handle_subscript((const char **)&arg, &rettv, !eap->skip, true)
+        == FAIL) {
+      failed = true;
       break;
     }
 
@@ -3113,18 +3116,19 @@ static int do_lock_var(lval_T *lp, char_u *name_end, int deep, int lock)
     cc = *name_end;
     *name_end = NUL;
 
-    /* Normal name or expanded name. */
-    if (check_changedtick(lp->ll_name))
+    // Normal name or expanded name.
+    if (check_changedtick(lp->ll_name)) {
       ret = FAIL;
-    else {
+    } else {
       di = find_var((const char *)lp->ll_name, STRLEN(lp->ll_name), NULL, true);
-      if (di == NULL)
+      if (di == NULL) {
         ret = FAIL;
-      else {
-        if (lock)
+      } else {
+        if (lock) {
           di->di_flags |= DI_FLAGS_LOCK;
-        else
+        } else {
           di->di_flags &= ~DI_FLAGS_LOCK;
+        }
         item_lock(&di->di_tv, deep, lock);
       }
     }
@@ -4727,7 +4731,7 @@ static int get_option_tv(const char **const arg, typval_T *const rettv,
 
   c = *option_end;
   *option_end = NUL;
-  opt_type = get_option_value((char_u *)*arg, &numval,
+  opt_type = get_option_value((char_u *)(*arg), &numval,
                               rettv == NULL ? NULL : &stringval, opt_flags);
 
   if (opt_type == -3) {                 /* invalid name */
@@ -7011,7 +7015,7 @@ static char_u *deref_func_name(const char *name, int *lenp,
     *partialp = NULL;
   }
 
-  dictitem_T *const v = find_var(name, (size_t)*lenp, NULL, no_autoload);
+  dictitem_T *const v = find_var(name, (size_t)(*lenp), NULL, no_autoload);
   if (v != NULL && v->di_tv.v_type == VAR_FUNC) {
     if (v->di_tv.vval.v_string == NULL) {  // just in case
       *lenp = 0;
@@ -7250,9 +7254,7 @@ call_func(
     error = ERROR_UNKNOWN;
 
     if (!builtin_function((const char *)rfname, -1)) {
-      /*
-       * User defined function.
-       */
+      // User defined function.
       fp = find_func(rfname);
 
       /* Trigger FuncUndefined event, may load the function. */
@@ -7265,7 +7267,7 @@ call_func(
       // Try loading a package.
       if (fp == NULL && script_autoload((const char *)rfname, STRLEN(rfname),
                                         true) && !aborting()) {
-        /* loaded a package, search for the function again */
+        // Loaded a package, search for the function again.
         fp = find_func(rfname);
       }
 
@@ -8965,7 +8967,7 @@ static void f_exists(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     // get_name_len() takes care of expanding curly braces
     const char *name = p;
     char *tofree;
-    len = get_name_len((const char **)&p, &tofree, TRUE, FALSE);
+    len = get_name_len((const char **)&p, &tofree, true, false);
     if (len > 0) {
       if (tofree != NULL) {
         name = tofree;
@@ -11837,7 +11839,7 @@ static void get_user_input(typval_T *argvars, typval_T *rettv, int inputdialog)
       msg_start();
       msg_clr_eos();
       msg_puts_attr((const char *)prompt, echo_attr);
-      msg_didout = FALSE;
+      msg_didout = false;
       msg_starthere();
       *p = c;
     }
@@ -12899,9 +12901,9 @@ static void get_maparg(typval_T *argvars, typval_T *rettv, int exact)
     rettv_dict_alloc(rettv);
     if (rhs != NULL) {
       // Return a dictionary.
-      char_u      *lhs = str2special_save(mp->m_keys, TRUE);
+      char_u *lhs = str2special_save(mp->m_keys, true);
       char *const mapmode = map_mode_to_chars(mp->m_mode);
-      dict_T      *dict = rettv->vval.v_dict;
+      dict_T *dict = rettv->vval.v_dict;
 
       dict_add_nr_str(dict, "lhs",     0L, lhs);
       dict_add_nr_str(dict, "rhs",     0L, mp->m_orig_str);
@@ -16841,7 +16843,7 @@ static void f_synIDattr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       p = highlight_has_attr(id, HL_ITALIC, modec);
     break;
 
-  case 'n':                                             /* name */
+  case 'n':                                             // name
     p = (char_u *)get_highlight_name(NULL, id - 1);
     break;
 
@@ -18423,7 +18425,7 @@ static int get_name_len(const char **const arg,
 
   if ((*arg)[0] == (char)K_SPECIAL && (*arg)[1] == (char)KS_EXTRA
       && (*arg)[2] == (char)KE_SNR) {
-    /* hard coded <SNR>, already translated */
+    // Hard coded <SNR>, already translated.
     *arg += 3;
     return get_id_len(arg) + 3;
   }
@@ -18436,7 +18438,7 @@ static int get_name_len(const char **const arg,
   /*
    * Find the end of the name; check for {} construction.
    */
-  const char *p = (const char *)find_name_end((char_u *)*arg,
+  const char *p = (const char *)find_name_end((char_u *)(*arg),
                                               &expr_start,
                                               &expr_end,
                                               len > 0 ? 0 : FNE_CHECK_START);
@@ -18451,7 +18453,7 @@ static int get_name_len(const char **const arg,
      * Include any <SID> etc in the expanded string:
      * Thus the -len here.
      */
-    char_u *temp_string = make_expanded_name((char_u *)*arg - len, expr_start,
+    char_u *temp_string = make_expanded_name((char_u *)(*arg) - len, expr_start,
                                              expr_end, (char_u *)p);
     if (temp_string == NULL) {
       return -1;
@@ -18919,8 +18921,8 @@ static int get_var_tv(
  * Also handle function call with Funcref variable: func(expr)
  * Can all be combined: dict.func(expr)[idx]['func'](expr)
  */
-static int 
-handle_subscript (
+static int
+handle_subscript(
     const char **const arg,
     typval_T *rettv,
     int evaluate,                   /* do more than finding the end */
@@ -19786,7 +19788,7 @@ char_u *get_var_value(const char *const name)
 {
   dictitem_T  *v;
 
-  v = find_var(name, strlen(name), NULL, FALSE);
+  v = find_var(name, strlen(name), NULL, false);
   if (v == NULL) {
     return NULL;
   }
@@ -20341,7 +20343,7 @@ void ex_echo(exarg_T *eap)
         if (!aborting()) {
           EMSG2(_(e_invexpr2), p);
         }
-        need_clr_eos = FALSE;
+        need_clr_eos = false;
         break;
       }
       need_clr_eos = false;
@@ -20372,15 +20374,16 @@ void ex_echo(exarg_T *eap)
               msg_clr_eos();
               needclr = false;
             }
-            msg_putchar_attr((uint8_t)*p, echo_attr);
+            msg_putchar_attr((uint8_t)(*p), echo_attr);
           } else {
             if (has_mbyte) {
               int i = (*mb_ptr2len)((const char_u *)p);
 
               (void)msg_outtrans_len_attr((char_u *)p, i, echo_attr);
               p += i - 1;
-            } else
+            } else {
               (void)msg_outtrans_len_attr((char_u *)p, 1, echo_attr);
+            }
           }
         }
       }
@@ -20961,7 +20964,7 @@ void ex_function(exarg_T *eap)
    * If there are no errors, add the function
    */
   if (fudi.fd_dict == NULL) {
-    v = find_var((const char *)name, STRLEN(name), &ht, FALSE);
+    v = find_var((const char *)name, STRLEN(name), &ht, false);
     if (v != NULL && v->di_tv.v_type == VAR_FUNC) {
       emsg_funcname(N_("E707: Function name conflicts with variable: %s"),
           name);
@@ -21205,7 +21208,7 @@ trans_function_name (
     }
   } else {
     len = (int)(end - *pp);
-    name = deref_func_name((const char *)*pp, &len, partial,
+    name = deref_func_name((const char *)(*pp), &len, partial,
                            flags & TFN_NO_AUTOLOAD);
     if (name == *pp) {
       name = NULL;
@@ -21252,7 +21255,7 @@ trans_function_name (
   else if (lead > 0) {
     lead = 3;
     if ((lv.ll_exp_name != NULL && eval_fname_sid((const char *)lv.ll_exp_name))
-        || eval_fname_sid((const char *)*pp)) {
+        || eval_fname_sid((const char *)(*pp))) {
       // It's "s:" or "<SID>".
       if (current_SID <= 0) {
         EMSG(_(e_usingsid));
@@ -21346,7 +21349,7 @@ static void list_func_head(ufunc_T *fp, int indent)
   }
   msg_putchar('(');
   int j;
-  for (j = 0; j < fp->uf_args.ga_len; ++j) {
+  for (j = 0; j < fp->uf_args.ga_len; j++) {
     if (j) {
       msg_puts(", ");
     }
@@ -22059,7 +22062,7 @@ call_user_func (
       smsg(_("calling %s"), sourcing_name);
       if (p_verbose >= 14) {
         msg_puts("(");
-        for (int i = 0; i < argcount; ++i) {
+        for (int i = 0; i < argcount; i++) {
           if (i > 0) {
             msg_puts(", ");
           }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1474,12 +1474,12 @@ void append_redir(char *const buf, const size_t buflen,
 
 void print_line_no_prefix(linenr_T lnum, int use_number, int list)
 {
-  char_u numbuf[30];
+  char numbuf[30];
 
   if (curwin->w_p_nu || use_number) {
-    vim_snprintf((char *)numbuf, sizeof(numbuf),
-        "%*ld ", number_width(curwin), (long)lnum);
-    msg_puts_attr(numbuf, hl_attr(HLF_N));      /* Highlight line nrs */
+    vim_snprintf(numbuf, sizeof(numbuf), "%*" PRIdLINENR " ",
+                 number_width(curwin), lnum);
+    msg_puts_attr(numbuf, hl_attr(HLF_N));  // Highlight line nrs.
   }
   msg_prt_line(ml_get(lnum), list);
 }
@@ -5720,33 +5720,33 @@ void ex_sign(exarg_T *eap)
  */
 static void sign_list_defined(sign_T *sp)
 {
-  char_u  *p;
-
   smsg("sign %s", sp->sn_name);
   if (sp->sn_icon != NULL) {
-    MSG_PUTS(" icon=");
+    msg_puts(" icon=");
     msg_outtrans(sp->sn_icon);
-    MSG_PUTS(_(" (not supported)"));
+    msg_puts(_(" (not supported)"));
   }
   if (sp->sn_text != NULL) {
-    MSG_PUTS(" text=");
+    msg_puts(" text=");
     msg_outtrans(sp->sn_text);
   }
   if (sp->sn_line_hl > 0) {
-    MSG_PUTS(" linehl=");
-    p = get_highlight_name(NULL, sp->sn_line_hl - 1);
-    if (p == NULL)
-      MSG_PUTS("NONE");
-    else
+    msg_puts(" linehl=");
+    const char *const p = get_highlight_name(NULL, sp->sn_line_hl - 1);
+    if (p == NULL) {
+      msg_puts("NONE");
+    } else {
       msg_puts(p);
+    }
   }
   if (sp->sn_text_hl > 0) {
-    MSG_PUTS(" texthl=");
-    p = get_highlight_name(NULL, sp->sn_text_hl - 1);
-    if (p == NULL)
-      MSG_PUTS("NONE");
-    else
+    msg_puts(" texthl=");
+    const char *const p = get_highlight_name(NULL, sp->sn_text_hl - 1);
+    if (p == NULL) {
+      msg_puts("NONE");
+    } else {
       msg_puts(p);
+    }
   }
 }
 

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2250,7 +2250,7 @@ void ex_compiler(exarg_T *eap)
       // plugin will then skip the settings.  Afterwards set
       // "b:current_compiler" and restore "current_compiler".
       // Explicitly prepend "g:" to make it work in a function.
-      old_cur_comp = get_var_value((char_u *)"g:current_compiler");
+      old_cur_comp = get_var_value("g:current_compiler");
       if (old_cur_comp != NULL) {
         old_cur_comp = vim_strsave(old_cur_comp);
       }
@@ -2268,7 +2268,7 @@ void ex_compiler(exarg_T *eap)
     do_cmdline_cmd(":delcommand CompilerSet");
 
     // Set "b:current_compiler" from "current_compiler".
-    p = get_var_value((char_u *)"g:current_compiler");
+    p = get_var_value("g:current_compiler");
     if (p != NULL) {
       set_internal_string_var((char_u *)"b:current_compiler", p);
     }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -585,8 +585,9 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
 
       smsg(_("line %" PRId64 ": %s"),
           (int64_t)sourcing_lnum, cmdline_copy);
-      if (msg_silent == 0)
-        msg_puts((char_u *)"\n");           /* don't overwrite this */
+      if (msg_silent == 0) {
+        msg_puts("\n");  // don't overwrite this either
+      }
 
       verbose_leave_scroll();
       --no_wait_return;
@@ -2582,7 +2583,7 @@ int modifier_len(char_u *cmd)
  * Return 2 if there is an exact match.
  * Return 3 if there is an ambiguous match.
  */
-int cmd_exists(char_u *name)
+int cmd_exists(const char *const name)
 {
   exarg_T ea;
   int full = FALSE;
@@ -2591,17 +2592,20 @@ int cmd_exists(char_u *name)
   char_u      *p;
 
   /* Check command modifiers. */
-  for (i = 0; i < (int)ARRAY_SIZE(cmdmods); ++i) {
-    for (j = 0; name[j] != NUL; ++j)
-      if (name[j] != cmdmods[i].name[j])
+  for (i = 0; i < (int)ARRAY_SIZE(cmdmods); i++) {
+    for (j = 0; name[j] != NUL; j++) {
+      if (name[j] != (char)cmdmods[i].name[j]) {
         break;
-    if (name[j] == NUL && j >= cmdmods[i].minlen)
+      }
+    }
+    if (name[j] == NUL && j >= cmdmods[i].minlen) {
       return cmdmods[i].name[j] == NUL ? 2 : 1;
+    }
   }
 
   /* Check built-in commands and user defined commands.
    * For ":2match" and ":3match" we need to skip the number. */
-  ea.cmd = (*name == '2' || *name == '3') ? name + 1 : name;
+  ea.cmd = (char_u *)((*name == '2' || *name == '3') ? name + 1 : name);
   ea.cmdidx = (cmdidx_T)0;
   p = find_command(&ea, &full);
   if (p == NULL)

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -583,8 +583,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
       ++no_wait_return;
       verbose_enter_scroll();
 
-      smsg(_("line %" PRId64 ": %s"),
-          (int64_t)sourcing_lnum, cmdline_copy);
+      smsg(_("line %" PRIdLINENR ": %s"), sourcing_lnum, cmdline_copy);
       if (msg_silent == 0) {
         msg_puts("\n");  // don't overwrite this either
       }
@@ -1816,9 +1815,9 @@ static char_u * do_one_cmd(char_u **cmdlinep,
           errormsg = (char_u *)_("E493: Backwards range given");
           goto doend;
         }
-        if (ask_yesno((char_u *)
-                _("Backwards range given, OK to swap"), FALSE) != 'y')
+        if (ask_yesno(_("Backwards range given, OK to swap"), false) != 'y') {
           goto doend;
+        }
       }
       lnum = ea.line1;
       ea.line1 = ea.line2;
@@ -2586,13 +2585,11 @@ int modifier_len(char_u *cmd)
 int cmd_exists(const char *const name)
 {
   exarg_T ea;
-  int full = FALSE;
-  int i;
-  int j;
   char_u      *p;
 
-  /* Check command modifiers. */
-  for (i = 0; i < (int)ARRAY_SIZE(cmdmods); i++) {
+  // Check command modifiers.
+  for (int i = 0; i < (int)ARRAY_SIZE(cmdmods); i++) {
+    int j;
     for (j = 0; name[j] != NUL; j++) {
       if (name[j] != (char)cmdmods[i].name[j]) {
         break;
@@ -2607,6 +2604,7 @@ int cmd_exists(const char *const name)
    * For ":2match" and ":3match" we need to skip the number. */
   ea.cmd = (char_u *)((*name == '2' || *name == '3') ? name + 1 : name);
   ea.cmdidx = (cmdidx_T)0;
+  int full = false;
   p = find_command(&ea, &full);
   if (p == NULL)
     return 3;
@@ -8250,9 +8248,9 @@ eval_vars (
   char_u      *resultbuf = NULL;
   size_t resultlen;
   buf_T       *buf;
-  int valid = VALID_HEAD + VALID_PATH;              /* assume valid result */
-  int skip_mod = FALSE;
-  char_u strbuf[30];
+  int valid = VALID_HEAD | VALID_PATH;  // Assume valid result.
+  int skip_mod = false;
+  char strbuf[30];
 
   *errormsg = NULL;
   if (escaped != NULL)
@@ -8384,8 +8382,8 @@ eval_vars (
             "E496: no autocommand buffer number to substitute for \"<abuf>\"");
         return NULL;
       }
-      sprintf((char *)strbuf, "%d", autocmd_bufnr);
-      result = strbuf;
+      snprintf(strbuf, sizeof(strbuf), "%d", autocmd_bufnr);
+      result = (char_u *)strbuf;
       break;
 
     case SPEC_AMATCH:           /* match name for autocommand */
@@ -8410,8 +8408,8 @@ eval_vars (
         *errormsg = (char_u *)_("E842: no line number to use for \"<slnum>\"");
         return NULL;
       }
-      sprintf((char *)strbuf, "%" PRId64, (int64_t)sourcing_lnum);
-      result = strbuf;
+      snprintf(strbuf, sizeof(strbuf), "%" PRIdLINENR, sourcing_lnum);
+      result = (char_u *)strbuf;
       break;
     default:
       // should not happen

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -542,7 +542,7 @@ static void discard_exception(except_T *excp, int was_finished)
     } else {
       verbose_leave();
     }
-    STRNCPY(IObuff, saved_IObuff, IOSIZE);
+    xstrlcpy((char *)IObuff, (const char *)saved_IObuff, IOSIZE);
     xfree(saved_IObuff);
   }
   if (excp->type != ET_INTERRUPT)

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -482,7 +482,7 @@ static int throw_exception(void *value, int type, char_u *cmdname)
       msg_scroll = TRUE;            /* always scroll up, don't overwrite */
 
     smsg(_("Exception thrown: %s"), excp->value);
-    msg_puts((char_u *)"\n");       /* don't overwrite this either */
+    msg_puts("\n");  // don't overwrite this either
 
     if (debug_break_level > 0 || *p_vfile == NUL)
       cmdline_row = msg_row;
@@ -532,15 +532,17 @@ static void discard_exception(except_T *excp, int was_finished)
     smsg(was_finished ? _("Exception finished: %s")
                       : _("Exception discarded: %s"),
          excp->value);
-    msg_puts((char_u *)"\n");       /* don't overwrite this either */
-    if (debug_break_level > 0 || *p_vfile == NUL)
+    msg_puts("\n");  // don't overwrite this either
+    if (debug_break_level > 0 || *p_vfile == NUL) {
       cmdline_row = msg_row;
-    --no_wait_return;
-    if (debug_break_level > 0)
+    }
+    no_wait_return--;
+    if (debug_break_level > 0) {
       msg_silent = save_msg_silent;
-    else
+    } else {
       verbose_leave();
-    STRCPY(IObuff, saved_IObuff);
+    }
+    STRNCPY(IObuff, saved_IObuff, IOSIZE);
     xfree(saved_IObuff);
   }
   if (excp->type != ET_INTERRUPT)
@@ -595,7 +597,7 @@ static void catch_exception(except_T *excp)
       msg_scroll = TRUE;            /* always scroll up, don't overwrite */
 
     smsg(_("Exception caught: %s"), excp->value);
-    msg_puts((char_u *)"\n");       /* don't overwrite this either */
+    msg_puts("\n");  // don't overwrite this either
 
     if (debug_break_level > 0 || *p_vfile == NUL)
       cmdline_row = msg_row;
@@ -714,7 +716,7 @@ static void report_pending(int action, int pending, void *value)
   ++no_wait_return;
   msg_scroll = TRUE;            /* always scroll up, don't overwrite */
   smsg(mesg, s);
-  msg_puts((char_u *)"\n");     /* don't overwrite this either */
+  msg_puts("\n");  // don't overwrite this either
   cmdline_row = msg_row;
   --no_wait_return;
   if (debug_break_level > 0)

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1879,7 +1879,7 @@ getexmodeline (
     vcol = indent;
     while (indent >= 8) {
       ga_append(&line_ga, TAB);
-      msg_puts((char_u *)"        ");
+      msg_puts("        ");
       indent -= 8;
     }
     while (indent-- > 0) {
@@ -2608,7 +2608,7 @@ static void redrawcmdprompt(void)
   if (ccline.cmdfirstc != NUL)
     msg_putchar(ccline.cmdfirstc);
   if (ccline.cmdprompt != NULL) {
-    msg_puts_attr(ccline.cmdprompt, ccline.cmdattr);
+    msg_puts_attr((const char *)ccline.cmdprompt, ccline.cmdattr);
     ccline.cmdindent = msg_col + (msg_row - cmdline_row) * Columns;
     /* do the reverse of set_cmdspos() */
     if (ccline.cmdfirstc != NUL)
@@ -3317,7 +3317,7 @@ static int showmatches(expand_T *xp, int wildmenu)
           msg_outtrans_attr(files_found[k], hl_attr(HLF_D));
           p = files_found[k] + STRLEN(files_found[k]) + 1;
           msg_advance(maxlen + 1);
-          msg_puts(p);
+          msg_puts((const char *)p);
           msg_advance(maxlen + 3);
           msg_puts_long_attr(p + 2, hl_attr(HLF_D));
           break;
@@ -3759,6 +3759,8 @@ static void cleanup_help_tags(int num_file, char_u **file)
   }
 }
 
+typedef char_u *(*ExpandFunc)(expand_T *, int);
+
 /*
  * Do the expansion based on xp->xp_context and "pat".
  */
@@ -3898,7 +3900,7 @@ ExpandFromContext (
   else {
     static struct expgen {
       int context;
-      char_u      *((*func)(expand_T *, int));
+      ExpandFunc func;
       int ic;
       int escaped;
     } tab[] =
@@ -3919,7 +3921,7 @@ ExpandFromContext (
       {EXPAND_MENUNAMES, get_menu_names, FALSE, TRUE},
       {EXPAND_SYNTAX, get_syntax_name, TRUE, TRUE},
       {EXPAND_SYNTIME, get_syntime_arg, TRUE, TRUE},
-      {EXPAND_HIGHLIGHT, get_highlight_name, TRUE, TRUE},
+      {EXPAND_HIGHLIGHT, (ExpandFunc)get_highlight_name, TRUE, TRUE},
       {EXPAND_EVENTS, get_event_name, TRUE, TRUE},
       {EXPAND_AUGROUP, get_augroup_name, TRUE, TRUE},
       {EXPAND_CSCOPE, get_cscope_name, TRUE, TRUE},

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3903,36 +3903,35 @@ ExpandFromContext (
       ExpandFunc func;
       int ic;
       int escaped;
-    } tab[] =
-    {
-      {EXPAND_COMMANDS, get_command_name, FALSE, TRUE},
-      {EXPAND_BEHAVE, get_behave_arg, TRUE, TRUE},
-      {EXPAND_HISTORY, get_history_arg, TRUE, TRUE},
-      {EXPAND_USER_COMMANDS, get_user_commands, FALSE, TRUE},
-      {EXPAND_USER_ADDR_TYPE, get_user_cmd_addr_type, FALSE, TRUE},
-      {EXPAND_USER_CMD_FLAGS, get_user_cmd_flags, FALSE, TRUE},
-      {EXPAND_USER_NARGS, get_user_cmd_nargs, FALSE, TRUE},
-      {EXPAND_USER_COMPLETE, get_user_cmd_complete, FALSE, TRUE},
-      {EXPAND_USER_VARS, get_user_var_name, FALSE, TRUE},
-      {EXPAND_FUNCTIONS, get_function_name, FALSE, TRUE},
-      {EXPAND_USER_FUNC, get_user_func_name, FALSE, TRUE},
-      {EXPAND_EXPRESSION, get_expr_name, FALSE, TRUE},
-      {EXPAND_MENUS, get_menu_name, FALSE, TRUE},
-      {EXPAND_MENUNAMES, get_menu_names, FALSE, TRUE},
-      {EXPAND_SYNTAX, get_syntax_name, TRUE, TRUE},
-      {EXPAND_SYNTIME, get_syntime_arg, TRUE, TRUE},
-      {EXPAND_HIGHLIGHT, (ExpandFunc)get_highlight_name, TRUE, TRUE},
-      {EXPAND_EVENTS, get_event_name, TRUE, TRUE},
-      {EXPAND_AUGROUP, get_augroup_name, TRUE, TRUE},
-      {EXPAND_CSCOPE, get_cscope_name, TRUE, TRUE},
-      {EXPAND_SIGN, get_sign_name, TRUE, TRUE},
-      {EXPAND_PROFILE, get_profile_name, TRUE, TRUE},
+    } tab[] = {
+      { EXPAND_COMMANDS, get_command_name, false, true },
+      { EXPAND_BEHAVE, get_behave_arg, true, true },
+      { EXPAND_HISTORY, get_history_arg, true, true },
+      { EXPAND_USER_COMMANDS, get_user_commands, false, true },
+      { EXPAND_USER_ADDR_TYPE, get_user_cmd_addr_type, false, true },
+      { EXPAND_USER_CMD_FLAGS, get_user_cmd_flags, false, true },
+      { EXPAND_USER_NARGS, get_user_cmd_nargs, false, true },
+      { EXPAND_USER_COMPLETE, get_user_cmd_complete, false, true },
+      { EXPAND_USER_VARS, get_user_var_name, false, true },
+      { EXPAND_FUNCTIONS, get_function_name, false, true },
+      { EXPAND_USER_FUNC, get_user_func_name, false, true },
+      { EXPAND_EXPRESSION, get_expr_name, false, true },
+      { EXPAND_MENUS, get_menu_name, false, true },
+      { EXPAND_MENUNAMES, get_menu_names, false, true },
+      { EXPAND_SYNTAX, get_syntax_name, true, true },
+      { EXPAND_SYNTIME, get_syntime_arg, true, true },
+      { EXPAND_HIGHLIGHT, (ExpandFunc)get_highlight_name, true, true },
+      { EXPAND_EVENTS, get_event_name, true, true },
+      { EXPAND_AUGROUP, get_augroup_name, true, true },
+      { EXPAND_CSCOPE, get_cscope_name, true, true },
+      { EXPAND_SIGN, get_sign_name, true, true },
+      { EXPAND_PROFILE, get_profile_name, true, true },
 #ifdef HAVE_WORKING_LIBINTL
-      {EXPAND_LANGUAGE, get_lang_arg, TRUE, FALSE},
-      {EXPAND_LOCALES, get_locales, TRUE, FALSE},
+      { EXPAND_LANGUAGE, get_lang_arg, true, false },
+      { EXPAND_LOCALES, get_locales, true, false },
 #endif
-      {EXPAND_ENV_VARS, get_env_name, TRUE, TRUE},
-      {EXPAND_USER, get_users, TRUE, FALSE},
+      { EXPAND_ENV_VARS, get_env_name, true, true },
+      { EXPAND_USER, get_users, true, false },
     };
     int i;
 

--- a/src/nvim/farsi.c
+++ b/src/nvim/farsi.c
@@ -1593,7 +1593,7 @@ void conv_to_pvim(void)
 
   // Assume the screen has been messed up: clear it and redraw.
   redraw_later(CLEAR);
-  MSG_ATTR(farsi_text_1, hl_attr(HLF_S));
+  MSG_ATTR((const char *)farsi_text_1, hl_attr(HLF_S));
 }
 
 /// Convert the Farsi VIM into Farsi 3342 standard.
@@ -1614,7 +1614,7 @@ void conv_to_pstd(void)
 
   // Assume the screen has been messed up: clear it and redraw.
   redraw_later(CLEAR);
-  MSG_ATTR(farsi_text_2, hl_attr(HLF_S));
+  msg_attr((const char *)farsi_text_2, hl_attr(HLF_S));
 }
 
 /// left-right swap the characters in buf[len].

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -636,9 +636,8 @@ char_u *vim_findfile(void *search_ctx_arg)
         if (p_verbose >= 5) {
           verbose_enter_scroll();
           smsg("Already Searched: %s (%s)",
-              stackp->ffs_fix_path, stackp->ffs_wc_path);
-          /* don't overwrite this either */
-          msg_puts((char_u *)"\n");
+               stackp->ffs_fix_path, stackp->ffs_wc_path);
+          msg_puts("\n");  // don't overwrite this either
           verbose_leave_scroll();
         }
 #endif
@@ -650,8 +649,7 @@ char_u *vim_findfile(void *search_ctx_arg)
         verbose_enter_scroll();
         smsg("Searching: %s (%s)",
              stackp->ffs_fix_path, stackp->ffs_wc_path);
-        /* don't overwrite this either */
-        msg_puts((char_u *)"\n");
+        msg_puts("\n");  // don't overwrite this either
         verbose_leave_scroll();
       }
 #endif
@@ -809,10 +807,8 @@ char_u *vim_findfile(void *search_ctx_arg)
                         ) == FAIL) {
                   if (p_verbose >= 5) {
                     verbose_enter_scroll();
-                    smsg("Already: %s",
-                        file_path);
-                    /* don't overwrite this either */
-                    msg_puts((char_u *)"\n");
+                    smsg("Already: %s", file_path);
+                    msg_puts("\n");  // don't overwrite this either
                     verbose_leave_scroll();
                   }
                   continue;
@@ -837,8 +833,7 @@ char_u *vim_findfile(void *search_ctx_arg)
                 if (p_verbose >= 5) {
                   verbose_enter_scroll();
                   smsg("HIT: %s", file_path);
-                  /* don't overwrite this either */
-                  msg_puts((char_u *)"\n");
+                  msg_puts("\n");  // don't overwrite this either
                   verbose_leave_scroll();
                 }
 #endif
@@ -999,10 +994,8 @@ static ff_visited_list_hdr_T *ff_get_visited_list(char_u *filename, ff_visited_l
 #ifdef FF_VERBOSE
         if (p_verbose >= 5) {
           verbose_enter_scroll();
-          smsg("ff_get_visited_list: FOUND list for %s",
-              filename);
-          /* don't overwrite this either */
-          msg_puts((char_u *)"\n");
+          smsg("ff_get_visited_list: FOUND list for %s", filename);
+          msg_puts("\n");  // don't overwrite this either
           verbose_leave_scroll();
         }
 #endif
@@ -1016,8 +1009,7 @@ static ff_visited_list_hdr_T *ff_get_visited_list(char_u *filename, ff_visited_l
   if (p_verbose >= 5) {
     verbose_enter_scroll();
     smsg("ff_get_visited_list: new list for %s", filename);
-    /* don't overwrite this either */
-    msg_puts((char_u *)"\n");
+    msg_puts("\n");  // don't overwrite this either
     verbose_leave_scroll();
   }
 #endif

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3895,15 +3895,15 @@ static int check_mtime(buf_T *buf, FileInfo *file_info)
   if (buf->b_mtime_read != 0
       && time_differs(file_info->stat.st_mtim.tv_sec,
                       buf->b_mtime_read)) {
-    msg_scroll = TRUE;              /* don't overwrite messages here */
-    msg_silent = 0;                 /* must give this prompt */
+    msg_scroll = true;  // Don't overwrite messages here.
+    msg_silent = 0;     // Must give this prompt.
     // Don't use emsg() here, don't want to flush the buffers.
     msg_attr(_("WARNING: The file has been changed since reading it!!!"),
-        hl_attr(HLF_E));
-    if (ask_yesno((char_u *)_("Do you really want to write to it"),
-            TRUE) == 'n')
+             hl_attr(HLF_E));
+    if (ask_yesno(_("Do you really want to write to it"), true) == 'n') {
       return FAIL;
-    msg_scroll = FALSE;             /* always overwrite the file message now */
+    }
+    msg_scroll = false;  // Always overwrite the file message now.
   }
   return OK;
 }
@@ -5384,10 +5384,8 @@ char_u *vim_tempname(void)
 
 static AutoPatCmd *active_apc_list = NULL; /* stack of active autocommands */
 
-/*
- * augroups stores a list of autocmd group names.
- */
-static garray_T augroups = {0, 0, sizeof(char_u *), 10, NULL};
+/// List of autocmd group names
+static garray_T augroups = { 0, 0, sizeof(char_u *), 10, NULL };
 #define AUGROUP_NAME(i) (((char **)augroups.ga_data)[i])
 
 /*
@@ -5592,8 +5590,9 @@ static int au_new_group(char_u *name)
     }
 
     AUGROUP_NAME(i) = xstrdup((char *)name);
-    if (i == augroups.ga_len)
-      ++augroups.ga_len;
+    if (i == augroups.ga_len) {
+      augroups.ga_len++;
+    }
   }
 
   return i;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3897,8 +3897,8 @@ static int check_mtime(buf_T *buf, FileInfo *file_info)
                       buf->b_mtime_read)) {
     msg_scroll = TRUE;              /* don't overwrite messages here */
     msg_silent = 0;                 /* must give this prompt */
-    /* don't use emsg() here, don't want to flush the buffers */
-    MSG_ATTR(_("WARNING: The file has been changed since reading it!!!"),
+    // Don't use emsg() here, don't want to flush the buffers.
+    msg_attr(_("WARNING: The file has been changed since reading it!!!"),
         hl_attr(HLF_E));
     if (ask_yesno((char_u *)_("Do you really want to write to it"),
             TRUE) == 'n')
@@ -4778,8 +4778,8 @@ check_timestamps (
     --no_wait_return;
     need_check_timestamps = FALSE;
     if (need_wait_return && didit == 2) {
-      /* make sure msg isn't overwritten */
-      msg_puts((char_u *)"\n");
+      // make sure msg isn't overwritten
+      msg_puts("\n");
       ui_flush();
     }
   }
@@ -5006,10 +5006,9 @@ buf_check_timestamp (
     } else {
       if (!autocmd_busy) {
         msg_start();
-        msg_puts_attr((char_u *) tbuf, hl_attr(HLF_E) + MSG_HIST);
+        msg_puts_attr(tbuf, hl_attr(HLF_E) + MSG_HIST);
         if (*mesg2 != NUL) {
-          msg_puts_attr((char_u *)mesg2,
-                        hl_attr(HLF_W) + MSG_HIST);
+          msg_puts_attr(mesg2, hl_attr(HLF_W) + MSG_HIST);
         }
         msg_clr_eos();
         (void)msg_end();
@@ -5389,9 +5388,7 @@ static AutoPatCmd *active_apc_list = NULL; /* stack of active autocommands */
  * augroups stores a list of autocmd group names.
  */
 static garray_T augroups = {0, 0, sizeof(char_u *), 10, NULL};
-#define AUGROUP_NAME(i) (((char_u **)augroups.ga_data)[i])
-// use get_deleted_augroup() to get this
-static char_u *deleted_augroup = NULL;
+#define AUGROUP_NAME(i) (((char **)augroups.ga_data)[i])
 
 /*
  * The ID of the current group.  Group 0 is the default one.
@@ -5406,10 +5403,14 @@ static event_T last_event;
 static int last_group;
 static int autocmd_blocked = 0;         /* block all autocmds */
 
-static char_u *get_deleted_augroup(void)
+// use get_deleted_augroup() to get this
+static const char *deleted_augroup = NULL;
+
+static inline const char *get_deleted_augroup(void)
+  FUNC_ATTR_ALWAYS_INLINE
 {
     if (deleted_augroup == NULL) {
-      deleted_augroup = (char_u *)_("--Deleted--");
+      deleted_augroup = _("--Deleted--");
     }
     return deleted_augroup;
 }
@@ -5438,7 +5439,7 @@ static void show_autocmd(AutoPat *ap, event_T event)
       } else {
         msg_puts_attr(AUGROUP_NAME(ap->group), hl_attr(HLF_T));
       }
-      msg_puts((char_u *)"  ");
+      msg_puts("  ");
     }
     msg_puts_attr(event_nr2name(event), hl_attr(HLF_T));
     last_event = event;
@@ -5567,7 +5568,7 @@ void aubuflocal_remove(buf_T *buf)
         if (p_verbose >= 6) {
           verbose_enter();
           smsg(_("auto-removing autocommand: %s <buffer=%d>"),
-              event_nr2name(event), buf->b_fnum);
+               event_nr2name(event), buf->b_fnum);
           verbose_leave();
         }
       }
@@ -5590,7 +5591,7 @@ static int au_new_group(char_u *name)
       ga_grow(&augroups, 1);
     }
 
-    AUGROUP_NAME(i) = vim_strsave(name);
+    AUGROUP_NAME(i) = xstrdup((char *)name);
     if (i == augroups.ga_len)
       ++augroups.ga_len;
   }
@@ -5626,7 +5627,7 @@ static void au_del_group(char_u *name)
     }
     xfree(AUGROUP_NAME(i));
     if (in_use) {
-      AUGROUP_NAME(i) = get_deleted_augroup();
+      AUGROUP_NAME(i) = (char *)get_deleted_augroup();
     } else {
       AUGROUP_NAME(i) = NULL;
     }
@@ -5680,7 +5681,7 @@ void do_augroup(char_u *arg, int del_group)
     for (int i = 0; i < augroups.ga_len; ++i) {
       if (AUGROUP_NAME(i) != NULL) {
         msg_puts(AUGROUP_NAME(i));
-        msg_puts((char_u *)"  ");
+        msg_puts("  ");
       }
     }
     msg_clr_eos();
@@ -5691,23 +5692,19 @@ void do_augroup(char_u *arg, int del_group)
 #if defined(EXITFREE)
 void free_all_autocmds(void)
 {
-  int i;
-  char_u *s;
-
   for (current_augroup = -1; current_augroup < augroups.ga_len;
        current_augroup++) {
     do_autocmd((char_u *)"", true);
   }
 
-  for (i = 0; i < augroups.ga_len; i++) {
-      s = ((char_u **)(augroups.ga_data))[i];
-      if (s != get_deleted_augroup()) {
-          xfree(s);
-      }
+  for (int i = 0; i < augroups.ga_len; i++) {
+    char *const s = ((char **)(augroups.ga_data))[i];
+    if ((const char *)s != get_deleted_augroup()) {
+      xfree(s);
+    }
   }
   ga_clear(&augroups);
 }
-
 #endif
 
 /*
@@ -5715,13 +5712,13 @@ void free_all_autocmds(void)
  * Return NUM_EVENTS if the event name was not found.
  * Return a pointer to the next event name in "end".
  */
-static event_T event_name2nr(char_u *start, char_u **end)
+static event_T event_name2nr(const char_u *start, char_u **end)
 {
-  char_u      *p;
+  const char_u *p;
   int i;
   int len;
 
-  // the event name ends with end of line, '|', a blank or a comma */
+  // the event name ends with end of line, '|', a blank or a comma
   for (p = start; *p && !ascii_iswhite(*p) && *p != ',' && *p != '|'; p++) {
   }
   for (i = 0; event_names[i].name != NULL; i++) {
@@ -5730,25 +5727,32 @@ static event_T event_name2nr(char_u *start, char_u **end)
       break;
     }
   }
-  if (*p == ',')
-    ++p;
-  *end = p;
-  if (event_names[i].name == NULL)
+  if (*p == ',') {
+    p++;
+  }
+  *end = (char_u *)p;
+  if (event_names[i].name == NULL) {
     return NUM_EVENTS;
+  }
   return event_names[i].event;
 }
 
-/*
- * Return the name for event "event".
- */
-static char_u *event_nr2name(event_T event)
+/// Return the name for event
+///
+/// @param[in]  event  Event to return name for.
+///
+/// @return Event name, static string. Returns "Unknown" for unknown events.
+static const char *event_nr2name(event_T event)
+  FUNC_ATTR_NONNULL_RET FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_CONST
 {
   int i;
 
-  for (i = 0; event_names[i].name != NULL; ++i)
-    if (event_names[i].event == event)
-      return (char_u *)event_names[i].name;
-  return (char_u *)"Unknown";
+  for (i = 0; event_names[i].name != NULL; i++) {
+    if (event_names[i].event == event) {
+      return event_names[i].name;
+    }
+  }
+  return "Unknown";
 }
 
 /*
@@ -7013,7 +7017,6 @@ auto_next_pat (
 {
   AutoPat     *ap;
   AutoCmd     *cp;
-  char_u      *name;
   char        *s;
 
   xfree(sourcing_name);
@@ -7032,11 +7035,13 @@ auto_next_pat (
           ? match_file_pat(NULL, &ap->reg_prog, apc->fname, apc->sfname,
                            apc->tail, ap->allow_dirs)
           : ap->buflocal_nr == apc->arg_bufnr) {
-        name = event_nr2name(apc->event);
+        const char *const name = event_nr2name(apc->event);
         s = _("%s Auto commands for \"%s\"");
-        sourcing_name = xmalloc(STRLEN(s) + STRLEN(name) + ap->patlen + 1);
-        sprintf((char *)sourcing_name, s,
-            (char *)name, (char *)ap->pat);
+        const size_t sourcing_name_len = (STRLEN(s) + strlen(name) + ap->patlen
+                                          + 1);
+        sourcing_name = xmalloc(sourcing_name_len);
+        snprintf((char *)sourcing_name, sourcing_name_len, s, name,
+                 (char *)ap->pat);
         if (p_verbose >= 8) {
           verbose_enter();
           smsg(_("Executing %s"), sourcing_name);
@@ -7102,7 +7107,7 @@ char_u *getnextac(int c, void *cookie, int indent)
   if (p_verbose >= 9) {
     verbose_enter_scroll();
     smsg(_("autocommand %s"), ac->cmd);
-    msg_puts((char_u *)"\n");       /* don't overwrite this either */
+    msg_puts("\n");  // don't overwrite this either
     verbose_leave_scroll();
   }
   retval = vim_strsave(ac->cmd);
@@ -7168,15 +7173,17 @@ bool has_autocmd(event_T event, char_u *sfname, buf_T *buf)
  */
 char_u *get_augroup_name(expand_T *xp, int idx)
 {
-  if (idx == augroups.ga_len)           /* add "END" add the end */
+  if (idx == augroups.ga_len) {  // add "END" add the end
     return (char_u *)"END";
-  if (idx >= augroups.ga_len)           /* end of list */
+  }
+  if (idx >= augroups.ga_len) {  // end of list
     return NULL;
+  }
   if (AUGROUP_NAME(idx) == NULL || AUGROUP_NAME(idx) == get_deleted_augroup()) {
     // skip deleted entries
     return (char_u *)"";
   }
-  return AUGROUP_NAME(idx);             // return a name
+  return (char_u *)AUGROUP_NAME(idx);
 }
 
 static int include_groups = FALSE;
@@ -7238,18 +7245,22 @@ char_u *get_event_name(expand_T *xp, int idx)
         || AUGROUP_NAME(idx) == get_deleted_augroup()) {
       return (char_u *)"";              // skip deleted entries
     }
-    return AUGROUP_NAME(idx);           // return a name
+    return (char_u *)AUGROUP_NAME(idx);
   }
   return (char_u *)event_names[idx - augroups.ga_len].name;
 }
 
 
-/// Return true if autocmd "event" is supported.
-bool autocmd_supported(char_u *event)
+/// Check whether given autocommand is supported
+///
+/// @param[in]  event  Event to check.
+///
+/// @return True if it is, false otherwise.
+bool autocmd_supported(const char *const event)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   char_u *p;
-
-  return event_name2nr(event, &p) != NUM_EVENTS;
+  return event_name2nr((const char_u *)event, &p) != NUM_EVENTS;
 }
 
 /// Return true if an autocommand is defined for a group, event and
@@ -7264,26 +7275,24 @@ bool autocmd_supported(char_u *event)
 ///   exists("#Event#pat")
 ///
 /// @param arg autocommand string
-bool au_exists(const char_u *arg) FUNC_ATTR_WARN_UNUSED_RESULT
+bool au_exists(const char *const arg) FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  char_u      *arg_save;
-  char_u      *pattern = NULL;
-  char_u      *event_name;
-  char_u      *p;
   event_T event;
   AutoPat     *ap;
   buf_T       *buflocal_buf = NULL;
   int group;
   bool retval = false;
 
-  /* Make a copy so that we can change the '#' chars to a NUL. */
-  arg_save = vim_strsave(arg);
-  p = vim_strchr(arg_save, '#');
-  if (p != NULL)
+  // Make a copy so that we can change the '#' chars to a NUL.
+  char *const arg_save = xstrdup(arg);
+  char *p = strchr(arg_save, '#');
+  if (p != NULL) {
     *p++ = NUL;
+  }
 
-  /* First, look for an autocmd group name */
-  group = au_find_group(arg_save);
+  // First, look for an autocmd group name.
+  group = au_find_group((char_u *)arg_save);
+  char *event_name;
   if (group == AUGROUP_ERROR) {
     /* Didn't match a group name, assume the first argument is an event. */
     group = AUGROUP_ALL;
@@ -7295,17 +7304,18 @@ bool au_exists(const char_u *arg) FUNC_ATTR_WARN_UNUSED_RESULT
       goto theend;
     }
 
-    /* Must be "Group#Event" or "Group#Event#pat". */
+    // Must be "Group#Event" or "Group#Event#pat".
     event_name = p;
-    p = vim_strchr(event_name, '#');
-    if (p != NULL)
-      *p++ = NUL;           /* "Group#Event#pat" */
+    p = strchr(event_name, '#');
+    if (p != NULL) {
+      *p++ = NUL;  // "Group#Event#pat"
+    }
   }
 
-  pattern = p;              /* "pattern" is NULL when there is no pattern */
+  char *pattern = p;  // "pattern" is NULL when there is no pattern.
 
-  /* find the index (enum) for the event name */
-  event = event_name2nr(event_name, &p);
+  // Find the index (enum) for the event name.
+  event = event_name2nr((char_u *)event_name, (char_u **)&p);
 
   /* return FALSE if the event name is not recognized */
   if (event == NUM_EVENTS)
@@ -7331,7 +7341,7 @@ bool au_exists(const char_u *arg) FUNC_ATTR_WARN_UNUSED_RESULT
         && (group == AUGROUP_ALL || ap->group == group)
         && (pattern == NULL
             || (buflocal_buf == NULL
-                ? fnamecmp(ap->pat, pattern) == 0
+                ? fnamecmp(ap->pat, (char_u *)pattern) == 0
                 : ap->buflocal_nr == buflocal_buf->b_fnum))) {
       retval = true;
       break;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3163,11 +3163,11 @@ map_clear_int (
   }
 }
 
-/*
- * Return characters to represent the map mode in an allocated string.
- * Returns NULL when out of memory.
- */
-char_u *map_mode_to_chars(int mode)
+/// Return characters to represent the map mode in an allocated string
+///
+/// @return [allocated] NUL-terminated string with characters.
+char *map_mode_to_chars(int mode)
+  FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_RET
 {
   garray_T mapmode;
 
@@ -3200,7 +3200,7 @@ char_u *map_mode_to_chars(int mode)
   }
 
   ga_append(&mapmode, NUL);
-  return (char_u *)mapmode.ga_data;
+  return (char *)mapmode.ga_data;
 }
 
 static void 
@@ -3209,8 +3209,7 @@ showmap (
     int local                  /* TRUE for buffer-local map */
 )
 {
-  int len = 1;
-  char_u      *mapchars;
+  size_t len = 1;
 
   if (msg_didout || msg_silent != 0) {
     msg_putchar('\n');
@@ -3218,10 +3217,10 @@ showmap (
       return;
   }
 
-  mapchars = map_mode_to_chars(mp->m_mode);
-  if (mapchars != NULL) {
+  {
+    char *const mapchars = map_mode_to_chars(mp->m_mode);
     msg_puts(mapchars);
-    len = (int)STRLEN(mapchars);
+    len = strlen(mapchars);
     xfree(mapchars);
   }
 
@@ -3229,18 +3228,19 @@ showmap (
     msg_putchar(' ');
 
   /* Display the LHS.  Get length of what we write. */
-  len = msg_outtrans_special(mp->m_keys, TRUE);
+  len = (size_t)msg_outtrans_special(mp->m_keys, true);
   do {
     msg_putchar(' ');                   /* padd with blanks */
     ++len;
   } while (len < 12);
 
-  if (mp->m_noremap == REMAP_NONE)
-    msg_puts_attr((char_u *)"*", hl_attr(HLF_8));
-  else if (mp->m_noremap == REMAP_SCRIPT)
-    msg_puts_attr((char_u *)"&", hl_attr(HLF_8));
-  else
+  if (mp->m_noremap == REMAP_NONE) {
+    msg_puts_attr("*", hl_attr(HLF_8));
+  } else if (mp->m_noremap == REMAP_SCRIPT) {
+    msg_puts_attr("&", hl_attr(HLF_8));
+  } else {
     msg_putchar(' ');
+  }
 
   if (local)
     msg_putchar('@');
@@ -3249,9 +3249,9 @@ showmap (
 
   /* Use FALSE below if we only want things like <Up> to show up as such on
    * the rhs, and not M-x etc, TRUE gets both -- webb */
-  if (*mp->m_str == NUL)
-    msg_puts_attr((char_u *)"<Nop>", hl_attr(HLF_8));
-  else {
+  if (*mp->m_str == NUL) {
+    msg_puts_attr("<Nop>", hl_attr(HLF_8));
+  } else {
     /* Remove escaping of CSI, because "m_str" is in a format to be used
      * as typeahead. */
     char_u *s = vim_strsave(mp->m_str);

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3227,7 +3227,7 @@ showmap (
   while (++len <= 3)
     msg_putchar(' ');
 
-  /* Display the LHS.  Get length of what we write. */
+  // Display the LHS.  Get length of what we write.
   len = (size_t)msg_outtrans_special(mp->m_keys, true);
   do {
     msg_putchar(' ');                   /* padd with blanks */
@@ -3252,8 +3252,8 @@ showmap (
   if (*mp->m_str == NUL) {
     msg_puts_attr("<Nop>", hl_attr(HLF_8));
   } else {
-    /* Remove escaping of CSI, because "m_str" is in a format to be used
-     * as typeahead. */
+    // Remove escaping of CSI, because "m_str" is in a format to be used
+    // as typeahead.
     char_u *s = vim_strsave(mp->m_str);
     vim_unescape_csi(s);
     msg_outtrans_special(s, FALSE);

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -2008,8 +2008,9 @@ static int cs_reset(exarg_T *eap)
   xfree(pplist);
   xfree(fllist);
 
-  if (p_csverbose)
-    MSG_ATTR(_("All cscope databases reset"), hl_attr(HLF_R) | MSG_HIST);
+  if (p_csverbose) {
+    msg_attr(_("All cscope databases reset"), hl_attr(HLF_R) | MSG_HIST);
+  }
   return CSCOPE_SUCCESS;
 } /* cs_reset */
 

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -843,10 +843,10 @@ char_u *replace_termcodes(const char_u *from, const size_t from_len,
       // If "mapleader" or "maplocalleader" isn't set use a backslash.
       if (end - src >= 7 && STRNICMP(src, "<Leader>", 8) == 0) {
         len = 8;
-        p = get_var_value((char_u *)"g:mapleader");
+        p = get_var_value("g:mapleader");
       } else if (end - src >= 12 && STRNICMP(src, "<LocalLeader>", 13) == 0) {
         len = 13;
-        p = get_var_value((char_u *)"g:maplocalleader");
+        p = get_var_value("g:maplocalleader");
       } else {
         len = 0;
         p = NULL;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1410,8 +1410,8 @@ recover_names (
         for (int i = 0; i < num_files; ++i) {
           /* print the swap file name */
           msg_outnum((long)++file_count);
-          MSG_PUTS(".    ");
-          msg_puts(path_tail(files[i]));
+          msg_puts(".    ");
+          msg_puts((const char *)path_tail(files[i]));
           msg_putchar('\n');
           (void)swapfile_info(files[i]);
         }

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -755,10 +755,11 @@ static void show_menus_recursive(vimmenu_T *menu, int modes, int depth)
         else
           msg_putchar(' ');
         MSG_PUTS(" ");
-        if (*menu->strings[bit] == NUL)
-          msg_puts_attr((char_u *)"<Nop>", hl_attr(HLF_8));
-        else
+        if (*menu->strings[bit] == NUL) {
+          msg_puts_attr("<Nop>", hl_attr(HLF_8));
+        } else {
           msg_outtrans_special(menu->strings[bit], FALSE);
+        }
       }
   } else {
     if (menu == NULL) {

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -758,7 +758,7 @@ static void show_menus_recursive(vimmenu_T *menu, int modes, int depth)
         if (*menu->strings[bit] == NUL) {
           msg_puts_attr("<Nop>", hl_attr(HLF_8));
         } else {
-          msg_outtrans_special(menu->strings[bit], FALSE);
+          msg_outtrans_special(menu->strings[bit], false);
         }
       }
   } else {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1177,13 +1177,14 @@ int msg_outtrans_len_attr(char_u *msgstr, int len, int attr)
    * Normal characters are printed several at a time.
    */
   while (--len >= 0) {
-    if (enc_utf8)
-      /* Don't include composing chars after the end. */
+    if (enc_utf8) {
+      // Don't include composing chars after the end.
       mb_l = utfc_ptr2len_len((char_u *)str, len + 1);
-    else if (has_mbyte)
+    } else if (has_mbyte) {
       mb_l = (*mb_ptr2len)((char_u *)str);
-    else
+    } else {
       mb_l = 1;
+    }
     if (has_mbyte && mb_l > 1) {
       c = (*mb_ptr2char)((char_u *)str);
       if (vim_isprintc(c)) {
@@ -1680,9 +1681,10 @@ static void msg_puts_display(const char_u *str, int maxlen, int attr,
         } else {
           msg_screen_putchar(*s++, attr);
         }
-        did_last_char = TRUE;
-      } else
-        did_last_char = FALSE;
+        did_last_char = true;
+      } else {
+        did_last_char = false;
+      }
 
       if (p_more) {
         // Store text for scrolling back.
@@ -1784,7 +1786,7 @@ static void msg_puts_display(const char_u *str, int maxlen, int attr,
     ++s;
   }
 
-  /* output any postponed text */
+  // Output any postponed text.
   if (t_col > 0) {
     t_puts(&t_col, t_s, s, attr);
   }
@@ -1968,8 +1970,8 @@ static msgchunk_T *disp_sb_line(int row, msgchunk_T *smp)
  */
 static void t_puts(int *t_col, const char_u *t_s, const char_u *s, int attr)
 {
-  /* output postponed text */
-  msg_didout = TRUE;            /* remember that line is not empty */
+  // Output postponed text.
+  msg_didout = true;  // Remember that line is not empty.
   screen_puts_len((char_u *)t_s, (int)(s - t_s), msg_row, msg_col, attr);
   msg_col += *t_col;
   *t_col = 0;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -129,9 +129,9 @@ int verb_msg(char_u *s)
   return n;
 }
 
-int msg_attr(char_u *s, int attr) FUNC_ATTR_NONNULL_ARG(1)
+int msg_attr(const char *s, const int attr) FUNC_ATTR_NONNULL_ARG(1)
 {
-  return msg_attr_keep(s, attr, FALSE);
+  return msg_attr_keep((char_u *)s, attr, false);
 }
 
 int
@@ -165,8 +165,9 @@ msg_attr_keep (
       || (*s != '<'
           && last_msg_hist != NULL
           && last_msg_hist->msg != NULL
-          && STRCMP(s, last_msg_hist->msg)))
-    add_msg_hist(s, -1, attr);
+          && STRCMP(s, last_msg_hist->msg))) {
+    add_msg_hist((const char *)s, -1, attr);
+  }
 
   /* When displaying keep_msg, don't let msg_start() free it, caller must do
    * that. */
@@ -348,7 +349,7 @@ int smsg_attr(int attr, char *s, ...)
   va_start(arglist, s);
   vim_vsnprintf((char *)IObuff, IOSIZE, s, arglist, NULL);
   va_end(arglist);
-  return msg_attr(IObuff, attr);
+  return msg_attr((const char *)IObuff, attr);
 }
 
 /*
@@ -382,39 +383,40 @@ static int other_sourcing_name(void)
   return FALSE;
 }
 
-/// Get the message about the source, as used for an error message.
-/// Returns an allocated string with room for one more character.
-/// Returns NULL when no message is to be given.
-static char_u *get_emsg_source(void)
+/// Get the message about the source, as used for an error message
+///
+/// @return [allocated] String with room for one more characters. NULL when no
+///                     message is to be given.
+static char *get_emsg_source(void)
+  FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (sourcing_name != NULL && other_sourcing_name()) {
-    char_u *p = (char_u *)_("Error detected while processing %s:");
-    size_t len = STRLEN(sourcing_name) + STRLEN(p) + 1;
-    char_u *buf = xmalloc(len);
-    snprintf((char *)buf, len, (char *)p, sourcing_name);
+    const char *const p = _("Error detected while processing %s:");
+    const size_t buf_len = STRLEN(sourcing_name) + strlen(p) + 1;
+    char *const buf = xmalloc(buf_len);
+    snprintf(buf, buf_len, p, sourcing_name);
     return buf;
   }
   return NULL;
 }
 
-/*
- * Get the message about the source lnum, as used for an error message.
- * Returns an allocated string with room for one more character.
- * Returns NULL when no message is to be given.
- */
-static char_u *get_emsg_lnum(void)
+/// Get the message about the source lnum, as used for an error message.
+///
+/// @return [allocated] String with room for one more characters. NULL when no
+///                     message is to be given.
+static char *get_emsg_lnum(void)
+  FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  char_u      *Buf, *p;
-
-  /* lnum is 0 when executing a command from the command line
-   * argument, we don't want a line number then */
+  // lnum is 0 when executing a command from the command line
+  // argument, we don't want a line number then
   if (sourcing_name != NULL
       && (other_sourcing_name() || sourcing_lnum != last_sourcing_lnum)
       && sourcing_lnum != 0) {
-    p = (char_u *)_("line %4ld:");
-    Buf = xmalloc(STRLEN(p) + 20);
-    sprintf((char *)Buf, (char *)p, (long)sourcing_lnum);
-    return Buf;
+    const char *const p = _("line %4ld:");
+    const size_t buf_len = 20 + strlen(p);
+    char *const buf = xmalloc(buf_len);
+    snprintf(buf, buf_len, p, (long)sourcing_lnum);
+    return buf;
   }
   return NULL;
 }
@@ -426,10 +428,8 @@ static char_u *get_emsg_lnum(void)
  */
 void msg_source(int attr)
 {
-  char_u      *p;
-
-  ++no_wait_return;
-  p = get_emsg_source();
+  no_wait_return++;
+  char *p = get_emsg_source();
   if (p != NULL) {
     msg_attr(p, attr);
     xfree(p);
@@ -476,10 +476,10 @@ int emsg_not_now(void)
  *
  * return TRUE if wait_return not called
  */
-int emsg(char_u *s)
+int emsg(const char_u *s_)
 {
+  const char *s = (const char *)s_;
   int attr;
-  char_u      *p;
   int ignore = false;
   int severe;
 
@@ -506,7 +506,7 @@ int emsg(char_u *s)
      * when the message should be ignored completely (used for the
      * interrupt message).
      */
-    if (cause_errthrow(s, severe, &ignore) == true) {
+    if (cause_errthrow((char_u *)s, severe, &ignore) == true) {
       if (!ignore) {
         did_emsg = true;
       }
@@ -514,7 +514,7 @@ int emsg(char_u *s)
     }
 
     // set "v:errmsg", also when using ":silent! cmd"
-    set_vim_var_string(VV_ERRMSG, (char *) s, -1);
+    set_vim_var_string(VV_ERRMSG, s, -1);
 
     /*
      * When using ":silent! cmd" ignore error messages.
@@ -523,19 +523,21 @@ int emsg(char_u *s)
     if (emsg_silent != 0) {
       if (!emsg_noredir) {
         msg_start();
-        p = get_emsg_source();
+        char *p = get_emsg_source();
         if (p != NULL) {
-          STRCAT(p, "\n");
-          redir_write(p, STRLEN(p));
+          const size_t p_len = strlen(p);
+          p[p_len] = '\n';
+          redir_write(p, p_len + 1);
           xfree(p);
         }
         p = get_emsg_lnum();
         if (p != NULL) {
-          STRCAT(p, "\n");
-          redir_write(p, STRLEN(p));
+          const size_t p_len = strlen(p);
+          p[p_len] = '\n';
+          redir_write(p, p_len + 1);
           xfree(p);
         }
-        redir_write(s, STRLEN(s));
+        redir_write(s, strlen(s));
       }
       return true;
     }
@@ -570,10 +572,8 @@ int emsg(char_u *s)
    */
   msg_source(attr);
 
-  /*
-   * Display the error message itself.
-   */
-  msg_nowait = FALSE;                   /* wait for this msg */
+  // Display the error message itself.
+  msg_nowait = false;  // Wait for this msg.
   return msg_attr(s, attr);
 }
 
@@ -625,14 +625,14 @@ char_u *msg_trunc_attr(char_u *s, int force, int attr)
 {
   int n;
 
-  /* Add message to history before truncating */
-  add_msg_hist(s, -1, attr);
+  // Add message to history before truncating.
+  add_msg_hist((const char *)s, -1, attr);
 
   s = msg_may_trunc(force, s);
 
-  msg_hist_off = TRUE;
-  n = msg_attr(s, attr);
-  msg_hist_off = FALSE;
+  msg_hist_off = true;
+  n = msg_attr((const char *)s, attr);
+  msg_hist_off = false;
 
   if (n)
     return s;
@@ -671,12 +671,8 @@ char_u *msg_may_trunc(int force, char_u *s)
   return s;
 }
 
-static void
-add_msg_hist (
-    char_u *s,
-    int len,                        /* -1 for undetermined length */
-    int attr
-)
+/// @param[in]  len  Length of s or -1.
+static void add_msg_hist(const char *s, int len, int attr)
 {
   if (msg_hist_off || msg_silent != 0)
     return;
@@ -694,9 +690,10 @@ add_msg_hist (
     ++s;
     --len;
   }
-  while (len > 0 && s[len - 1] == '\n')
-    --len;
-  p->msg = vim_strnsave(s, len);
+  while (len > 0 && s[len - 1] == '\n') {
+    len--;
+  }
+  p->msg = (char_u *)xmemdupz(s, (size_t)len);
   p->next = NULL;
   p->attr = attr;
   if (last_msg_hist != NULL)
@@ -771,7 +768,7 @@ void ex_messages(exarg_T *eap)
   // Display what was not skipped.
   for (; p != NULL && !got_int; p = p->next) {
     if (p->msg != NULL) {
-      msg_attr(p->msg, p->attr);
+      msg_attr((const char *)p->msg, p->attr);
     }
   }
 
@@ -1055,9 +1052,10 @@ void msg_start(void)
     msg_didout = FALSE;                     /* no output on current line yet */
   }
 
-  /* when redirecting, may need to start a new line. */
-  if (!did_return)
-    redir_write((char_u *)"\n", -1);
+  // When redirecting, may need to start a new line.
+  if (!did_return) {
+    redir_write("\n", 1);
+  }
 }
 
 /*
@@ -1076,24 +1074,24 @@ void msg_putchar(int c)
 
 void msg_putchar_attr(int c, int attr)
 {
-  char_u buf[MB_MAXBYTES + 1];
+  char buf[MB_MAXBYTES + 1];
 
   if (IS_SPECIAL(c)) {
-    buf[0] = K_SPECIAL;
-    buf[1] = K_SECOND(c);
-    buf[2] = K_THIRD(c);
+    buf[0] = (char)K_SPECIAL;
+    buf[1] = (char)K_SECOND(c);
+    buf[2] = (char)K_THIRD(c);
     buf[3] = NUL;
   } else {
-    buf[(*mb_char2bytes)(c, buf)] = NUL;
+    buf[(*mb_char2bytes)(c, (char_u *)buf)] = NUL;
   }
   msg_puts_attr(buf, attr);
 }
 
 void msg_outnum(long n)
 {
-  char_u buf[20];
+  char buf[20];
 
-  sprintf((char *)buf, "%" PRId64, (int64_t)n);
+  snprintf(buf, sizeof(buf), "%ld", n);
   msg_puts(buf);
 }
 
@@ -1149,16 +1147,16 @@ char_u *msg_outtrans_one(char_u *p, int attr)
     msg_outtrans_len_attr(p, l, attr);
     return p + l;
   }
-  msg_puts_attr(transchar_byte(*p), attr);
+  msg_puts_attr((const char *)transchar_byte(*p), attr);
   return p + 1;
 }
 
 int msg_outtrans_len_attr(char_u *msgstr, int len, int attr)
 {
   int retval = 0;
-  char_u      *str = msgstr;
-  char_u      *plain_start = msgstr;
-  char_u      *s;
+  const char *str = (const char *)msgstr;
+  const char *plain_start = (const char *)msgstr;
+  char_u *s;
   int mb_l;
   int c;
 
@@ -1168,10 +1166,11 @@ int msg_outtrans_len_attr(char_u *msgstr, int len, int attr)
     attr &= ~MSG_HIST;
   }
 
-  /* If the string starts with a composing character first draw a space on
-   * which the composing char can be drawn. */
-  if (enc_utf8 && utf_iscomposing(utf_ptr2char(msgstr)))
-    msg_puts_attr((char_u *)" ", attr);
+  // If the string starts with a composing character first draw a space on
+  // which the composing char can be drawn.
+  if (enc_utf8 && utf_iscomposing(utf_ptr2char(msgstr))) {
+    msg_puts_attr(" ", attr);
+  }
 
   /*
    * Go over the string.  Special characters are translated and printed.
@@ -1180,24 +1179,25 @@ int msg_outtrans_len_attr(char_u *msgstr, int len, int attr)
   while (--len >= 0) {
     if (enc_utf8)
       /* Don't include composing chars after the end. */
-      mb_l = utfc_ptr2len_len(str, len + 1);
+      mb_l = utfc_ptr2len_len((char_u *)str, len + 1);
     else if (has_mbyte)
-      mb_l = (*mb_ptr2len)(str);
+      mb_l = (*mb_ptr2len)((char_u *)str);
     else
       mb_l = 1;
     if (has_mbyte && mb_l > 1) {
-      c = (*mb_ptr2char)(str);
-      if (vim_isprintc(c))
-        /* printable multi-byte char: count the cells. */
-        retval += (*mb_ptr2cells)(str);
-      else {
-        /* unprintable multi-byte char: print the printable chars so
-         * far and the translation of the unprintable char. */
-        if (str > plain_start)
-          msg_puts_attr_len(plain_start, (int)(str - plain_start),
-              attr);
+      c = (*mb_ptr2char)((char_u *)str);
+      if (vim_isprintc(c)) {
+        // Printable multi-byte char: count the cells.
+        retval += (*mb_ptr2cells)((char_u *)str);
+      } else {
+        // Unprintable multi-byte char: print the printable chars so
+        // far and the translation of the unprintable char.
+        if (str > plain_start) {
+          msg_puts_attr_len(plain_start, str - plain_start, attr);
+        }
         plain_start = str + mb_l;
-        msg_puts_attr(transchar(c), attr == 0 ? hl_attr(HLF_8) : attr);
+        msg_puts_attr((const char *)transchar(c),
+                      (attr == 0 ? hl_attr(HLF_8) : attr));
         retval += char2cells(c);
       }
       len -= mb_l - 1;
@@ -1205,23 +1205,25 @@ int msg_outtrans_len_attr(char_u *msgstr, int len, int attr)
     } else {
       s = transchar_byte(*str);
       if (s[1] != NUL) {
-        /* unprintable char: print the printable chars so far and the
-         * translation of the unprintable char. */
-        if (str > plain_start)
-          msg_puts_attr_len(plain_start, (int)(str - plain_start),
-              attr);
+        // Unprintable char: print the printable chars so far and the
+        // translation of the unprintable char.
+        if (str > plain_start) {
+          msg_puts_attr_len(plain_start, str - plain_start, attr);
+        }
         plain_start = str + 1;
-        msg_puts_attr(s, attr == 0 ? hl_attr(HLF_8) : attr);
+        msg_puts_attr((const char *)s, attr == 0 ? hl_attr(HLF_8) : attr);
         retval += (int)STRLEN(s);
-      } else
-        ++retval;
-      ++str;
+      } else {
+        retval++;
+      }
+      str++;
     }
   }
 
-  if (str > plain_start)
-    /* print the printable chars at the end */
-    msg_puts_attr_len(plain_start, (int)(str - plain_start), attr);
+  if (str > plain_start) {
+    // Print the printable chars at the end.
+    msg_puts_attr_len(plain_start, str - plain_start, attr);
+  }
 
   return retval;
 }
@@ -1264,23 +1266,23 @@ msg_outtrans_special (
 {
   char_u      *str = strstart;
   int retval = 0;
-  char_u      *string;
   int attr;
-  int len;
 
   attr = hl_attr(HLF_8);
   while (*str != NUL) {
-    /* Leading and trailing spaces need to be displayed in <> form. */
+    const char *string;
+    // Leading and trailing spaces need to be displayed in <> form.
     if ((str == strstart || str[1] == NUL) && *str == ' ') {
-      string = (char_u *)"<Space>";
-      ++str;
-    } else
-      string = str2special(&str, from);
-    len = vim_strsize(string);
-    /* Highlight special keys */
-    msg_puts_attr(string, len > 1
-        && (*mb_ptr2len)(string) <= 1
-        ? attr : 0);
+      string = "<Space>";
+      str++;
+    } else {
+      string = (const char *)str2special((char_u **)&str, from);
+    }
+    const int len = vim_strsize((char_u *)string);
+    // Highlight special keys
+    msg_puts_attr(string, (len > 1
+                           && (*mb_ptr2len)((char_u *)string) <= 1
+                           ? attr : 0));
     retval += len;
   }
   return retval;
@@ -1404,7 +1406,6 @@ void msg_prt_line(char_u *s, int list)
   int attr = 0;
   char_u      *trail = NULL;
   int l;
-  char_u buf[MB_MAXBYTES + 1];
 
   if (curwin->w_p_list)
     list = TRUE;
@@ -1430,10 +1431,11 @@ void msg_prt_line(char_u *s, int list)
         c = *p_extra++;
     } else if (has_mbyte && (l = (*mb_ptr2len)(s)) > 1) {
       col += (*mb_ptr2cells)(s);
+      char buf[MB_MAXBYTES + 1];
       if (lcs_nbsp != NUL && list
           && (mb_ptr2char(s) == 160 || mb_ptr2char(s) == 0x202f)) {
-        mb_char2bytes(lcs_nbsp, buf);
-        buf[(*mb_ptr2len)(buf)] = NUL;
+        mb_char2bytes(lcs_nbsp, (char_u *)buf);
+        buf[(*mb_ptr2len)((char_u *)buf)] = NUL;
       } else {
         memmove(buf, s, (size_t)l);
         buf[l] = NUL;
@@ -1530,12 +1532,12 @@ static char_u *screen_puts_mbyte(char_u *s, int l, int attr)
  * Output a string to the screen at position msg_row, msg_col.
  * Update msg_row and msg_col for the next message.
  */
-void msg_puts(char_u *s)
+void msg_puts(const char *s)
 {
   msg_puts_attr(s, 0);
 }
 
-void msg_puts_title(char_u *s)
+void msg_puts_title(const char *s)
 {
   msg_puts_attr(s, hl_attr(HLF_T));
 }
@@ -1559,7 +1561,7 @@ void msg_puts_long_len_attr(char_u *longstr, int len, int attr)
   if (len > room && room >= 20) {
     slen = (room - 3) / 2;
     msg_outtrans_len_attr(longstr, slen, attr);
-    msg_puts_attr((char_u *)"...", hl_attr(HLF_8));
+    msg_puts_attr("...", hl_attr(HLF_8));
   }
   msg_outtrans_len_attr(longstr + len - slen, slen, attr);
 }
@@ -1567,7 +1569,7 @@ void msg_puts_long_len_attr(char_u *longstr, int len, int attr)
 /*
  * Basic function for writing a message with highlight attributes.
  */
-void msg_puts_attr(char_u *s, int attr)
+void msg_puts_attr(const char *const s, const int attr)
 {
   msg_puts_attr_len(s, -1, attr);
 }
@@ -1575,7 +1577,7 @@ void msg_puts_attr(char_u *s, int attr)
 /// Like msg_puts_attr(), but with a maximum length "maxlen" (in bytes).
 /// When "maxlen" is -1 there is no maximum length.
 /// When "maxlen" is >= 0 the message is not put in the history.
-static void msg_puts_attr_len(char_u *str, int maxlen, int attr)
+void msg_puts_attr_len(const char *str, const ptrdiff_t maxlen, int attr)
 {
   // If redirection is on, also write to the redirection file.
   redir_write(str, maxlen);
@@ -1606,9 +1608,9 @@ static void msg_puts_attr_len(char_u *str, int maxlen, int attr)
   // different, e.g. for Win32 console) or we just don't know where the
   // cursor is.
   if (msg_use_printf()) {
-    msg_puts_printf((char *)str, maxlen);
+    msg_puts_printf(str, maxlen);
   } else {
-    msg_puts_display(str, maxlen, attr, false);
+    msg_puts_display((const char_u *)str, maxlen, attr, false);
   }
 }
 
@@ -1616,14 +1618,15 @@ static void msg_puts_attr_len(char_u *str, int maxlen, int attr)
  * The display part of msg_puts_attr_len().
  * May be called recursively to display scroll-back text.
  */
-static void msg_puts_display(char_u *str, int maxlen, int attr, int recurse)
+static void msg_puts_display(const char_u *str, int maxlen, int attr,
+                             int recurse)
 {
-  char_u      *s = str;
-  char_u      *t_s = str;       /* string from "t_s" to "s" is still todo */
-  int t_col = 0;                /* screen cells todo, 0 when "t_s" not used */
+  const char_u *s = str;
+  const char_u *t_s = str;  // String from "t_s" to "s" is still todo.
+  int t_col = 0;  // Screen cells todo, 0 when "t_s" not used.
   int l;
   int cw;
-  char_u      *sb_str = str;
+  const char_u *sb_str = str;
   int sb_col = msg_col;
   int wrap;
   int did_last_char;
@@ -1665,26 +1668,26 @@ static void msg_puts_display(char_u *str, int maxlen, int attr, int recurse)
       if (msg_col >= Columns)           /* can happen after screen resize */
         msg_col = Columns - 1;
 
-      /* Display char in last column before showing more-prompt. */
-      if (*s >= ' '
-          && !cmdmsg_rl
-          ) {
+      // Display char in last column before showing more-prompt.
+      if (*s >= ' ' && !cmdmsg_rl) {
         if (has_mbyte) {
           if (enc_utf8 && maxlen >= 0)
             /* avoid including composing chars after the end */
             l = utfc_ptr2len_len(s, (int)((str + maxlen) - s));
           else
             l = (*mb_ptr2len)(s);
-          s = screen_puts_mbyte(s, l, attr);
-        } else
+          s = screen_puts_mbyte((char_u *)s, l, attr);
+        } else {
           msg_screen_putchar(*s++, attr);
+        }
         did_last_char = TRUE;
       } else
         did_last_char = FALSE;
 
-      if (p_more)
-        /* store text for scrolling back */
-        store_sb_text(&sb_str, s, attr, &sb_col, TRUE);
+      if (p_more) {
+        // Store text for scrolling back.
+        store_sb_text((char_u **)&sb_str, (char_u *)s, attr, &sb_col, true);
+      }
 
       inc_msg_scrolled();
       need_wait_return = TRUE;       /* may need wait_return in main() */
@@ -1720,13 +1723,15 @@ static void msg_puts_display(char_u *str, int maxlen, int attr, int recurse)
                && msg_col + t_col >= Columns - 1)
     ;
     if (t_col > 0 && (wrap || *s == '\r' || *s == '\b'
-                      || *s == '\t' || *s == BELL))
-      /* output any postponed text */
+                      || *s == '\t' || *s == BELL)) {
+      // Output any postponed text.
       t_puts(&t_col, t_s, s, attr);
+    }
 
-    if (wrap && p_more && !recurse)
-      /* store text for scrolling back */
-      store_sb_text(&sb_str, s, attr, &sb_col, TRUE);
+    if (wrap && p_more && !recurse) {
+      // Store text for scrolling back.
+      store_sb_text((char_u **)&sb_str, (char_u *)s, attr, &sb_col, true);
+    }
 
     if (*s == '\n') {               /* go to next line */
       msg_didout = FALSE;           /* remember that line is empty */
@@ -1764,7 +1769,7 @@ static void msg_puts_display(char_u *str, int maxlen, int attr, int recurse)
       // characters and draw them all at once later.
       if (cmdmsg_rl || (cw > 1 && msg_col + t_col >= Columns - 1)) {
         if (l > 1) {
-          s = screen_puts_mbyte(s, l, attr) - 1;
+          s = screen_puts_mbyte((char_u *)s, l, attr) - 1;
         } else {
           msg_screen_putchar(*s, attr);
         }
@@ -1780,10 +1785,12 @@ static void msg_puts_display(char_u *str, int maxlen, int attr, int recurse)
   }
 
   /* output any postponed text */
-  if (t_col > 0)
+  if (t_col > 0) {
     t_puts(&t_col, t_s, s, attr);
-  if (p_more && !recurse)
-    store_sb_text(&sb_str, s, attr, &sb_col, FALSE);
+  }
+  if (p_more && !recurse) {
+    store_sb_text((char_u **)&sb_str, (char_u *)s, attr, &sb_col, false);
+  }
 
   msg_check();
 }
@@ -1959,11 +1966,11 @@ static msgchunk_T *disp_sb_line(int row, msgchunk_T *smp)
 /*
  * Output any postponed text for msg_puts_attr_len().
  */
-static void t_puts(int *t_col, char_u *t_s, char_u *s, int attr)
+static void t_puts(int *t_col, const char_u *t_s, const char_u *s, int attr)
 {
   /* output postponed text */
   msg_didout = TRUE;            /* remember that line is not empty */
-  screen_puts_len(t_s, (int)(s - t_s), msg_row, msg_col, attr);
+  screen_puts_len((char_u *)t_s, (int)(s - t_s), msg_row, msg_col, attr);
   msg_col += *t_col;
   *t_col = 0;
   /* If the string starts with a composing character don't increment the
@@ -1984,13 +1991,13 @@ int msg_use_printf(void)
 }
 
 /// Print a message when there is no valid screen.
-static void msg_puts_printf(char *str, int maxlen)
+static void msg_puts_printf(const char *str, const ptrdiff_t maxlen)
 {
-  char *s = str;
+  const char *s = str;
   char buf[4];
   char *p;
 
-  while (*s != NUL && (maxlen < 0 || (int)(s - str) < maxlen)) {
+  while (*s != NUL && (maxlen < 0 || s - str < maxlen)) {
     if (!(silent_mode && p_verbose == 0)) {
       // NL --> CR NL translation (for Unix, not for "--version")
       p = &buf[0];
@@ -2447,9 +2454,9 @@ void msg_check(void)
  * May write a string to the redirection file.
  * When "maxlen" is -1 write the whole string, otherwise up to "maxlen" bytes.
  */
-static void redir_write(char_u *str, int maxlen)
+static void redir_write(const char *const str, const ptrdiff_t maxlen)
 {
-  char_u      *s = str;
+  const char_u *s = (char_u *)str;
   static int cur_col = 0;
 
   if (maxlen == 0) {
@@ -2493,23 +2500,28 @@ static void redir_write(char_u *str, int maxlen)
       write_reg_contents(redir_reg, s, len, true);
     }
     if (redir_vname) {
-      var_redir_str(s, maxlen);
+      var_redir_str((char_u *)s, maxlen);
     }
 
-    /* Write and adjust the current column. */
-    while (*s != NUL && (maxlen < 0 || (int)(s - str) < maxlen)) {
-      if (!redir_reg && !redir_vname && !capture_ga)
-        if (redir_fd != NULL)
+    // Write and adjust the current column.
+    while (*s != NUL
+           && (maxlen < 0 || (int)(s - (const char_u *)str) < maxlen)) {
+      if (!redir_reg && !redir_vname && !capture_ga) {
+        if (redir_fd != NULL) {
           putc(*s, redir_fd);
-      if (verbose_fd != NULL)
+        }
+      }
+      if (verbose_fd != NULL) {
         putc(*s, verbose_fd);
-      if (*s == '\r' || *s == '\n')
+      }
+      if (*s == '\r' || *s == '\n') {
         cur_col = 0;
-      else if (*s == '\t')
+      } else if (*s == '\t') {
         cur_col += (8 - cur_col % 8);
-      else
-        ++cur_col;
-      ++s;
+      } else {
+        cur_col++;
+      }
+      s++;
     }
 
     if (msg_silent != 0)        /* should update msg_col */
@@ -2615,14 +2627,16 @@ void give_warning(char_u *message, bool hl) FUNC_ATTR_NONNULL_ARG(1)
   set_vim_var_string(VV_WARNINGMSG, (char *) message, -1);
   xfree(keep_msg);
   keep_msg = NULL;
-  if (hl)
+  if (hl) {
     keep_msg_attr = hl_attr(HLF_W);
-  else
+  } else {
     keep_msg_attr = 0;
-  if (msg_attr(message, keep_msg_attr) && msg_scrolled == 0)
+  }
+  if (msg_attr((const char *)message, keep_msg_attr) && msg_scrolled == 0) {
     set_keep_msg(message, keep_msg_attr);
-  msg_didout = FALSE;       /* overwrite this message */
-  msg_nowait = TRUE;        /* don't wait for this message */
+  }
+  msg_didout = false;  // Overwrite this message.
+  msg_nowait = true;   // Don't wait for this message.
   msg_col = 0;
 
   --no_wait_return;
@@ -2958,11 +2972,12 @@ static void copy_hotkeys_and_msg(const char_u *message, char_u *buttons,
  */
 void display_confirm_msg(void)
 {
-  /* avoid that 'q' at the more prompt truncates the message here */
-  ++confirm_msg_used;
-  if (confirm_msg != NULL)
-    msg_puts_attr(confirm_msg, hl_attr(HLF_M));
-  --confirm_msg_used;
+  // Avoid that 'q' at the more prompt truncates the message here.
+  confirm_msg_used++;
+  if (confirm_msg != NULL) {
+    msg_puts_attr((const char *)confirm_msg, hl_attr(HLF_M));
+  }
+  confirm_msg_used--;
 }
 
 int vim_dialog_yesno(int type, char_u *title, char_u *message, int dflt)

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -29,7 +29,7 @@
 #define MSG(s)                      msg((char_u *)(s))
 
 /// Show message highlighted according to the attr
-#define MSG_ATTR(s, attr)           msg_attr((char_u *)(s), (attr))
+#define MSG_ATTR(s, attr)           msg_attr((const char *)(s), (attr))
 
 /// Display error message
 ///
@@ -49,13 +49,13 @@
 #define EMSGU(s, n)                 emsgf((const char *) (s), (uint64_t)(n))
 
 /// Display message at the recorded position
-#define MSG_PUTS(s)                 msg_puts((char_u *)(s))
+#define MSG_PUTS(s)                 msg_puts((const char *)(s))
 
 /// Display message at the recorded position, highlighted
-#define MSG_PUTS_ATTR(s, a)         msg_puts_attr((char_u *)(s), (a))
+#define MSG_PUTS_ATTR(s, a)         msg_puts_attr((const char *)(s), (a))
 
 /// Like #MSG_PUTS, but highlight like title
-#define MSG_PUTS_TITLE(s)           msg_puts_title((char_u *)(s))
+#define MSG_PUTS_TITLE(s)           msg_puts_title((const char *)(s))
 
 /// Like #MSG_PUTS, but if middle part of too long messages it will be replaced
 #define MSG_PUTS_LONG(s)            msg_puts_long_attr((char_u *)(s), 0)

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2223,7 +2223,7 @@ change_warning (
  *
  * return the 'y' or 'n'
  */
-int ask_yesno(char_u *str, int direct)
+int ask_yesno(const char *str, bool direct)
 {
   int r = ' ';
   int save_State = State;

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2545,7 +2545,7 @@ void vim_beep(unsigned val)
      * function give the user a hint where the beep comes from. */
     if (vim_strchr(p_debug, 'e') != NULL) {
       msg_source(hl_attr(HLF_W));
-      msg_attr((char_u *)_("Beep!"), hl_attr(HLF_W));
+      msg_attr(_("Beep!"), hl_attr(HLF_W));
     }
   }
 }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -617,7 +617,7 @@ static void normal_redraw_mode_message(NormalState *s)
     update_screen(0);
     // now reset it, otherwise it's put in the history again
     keep_msg = kmsg;
-    msg_attr(kmsg, keep_msg_attr);
+    msg_attr((const char *)kmsg, keep_msg_attr);
     xfree(kmsg);
   }
   setcursor();
@@ -1276,7 +1276,7 @@ static void normal_redraw(NormalState *s)
     // msg_attr_keep() will set keep_msg to NULL, must free the string here.
     // Don't reset keep_msg, msg_attr_keep() uses it to check for duplicates.
     char *p = (char *)keep_msg;
-    msg_attr((uint8_t *)p, keep_msg_attr);
+    msg_attr(p, keep_msg_attr);
     xfree(p);
   }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2569,8 +2569,7 @@ did_set_string_option (
 
       init_highlight(FALSE, FALSE);
 
-      if (dark != (*p_bg == 'd')
-          && get_var_value((char_u *)"g:colors_name") != NULL) {
+      if (dark != (*p_bg == 'd') && get_var_value("g:colors_name") != NULL) {
         /* The color scheme must have set 'background' back to another
          * value, that's not what we want here.  Disable the color
          * scheme and set the colors again. */
@@ -3886,7 +3885,7 @@ set_bool_option (
             "W17: Arabic requires UTF-8, do ':set encoding=utf-8'");
 
         msg_source(hl_attr(HLF_W));
-        MSG_ATTR(_(w_arabic), hl_attr(HLF_W));
+        msg_attr(_(w_arabic), hl_attr(HLF_W));
         set_vim_var_string(VV_WARNINGMSG, _(w_arabic), -1);
       }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2570,10 +2570,10 @@ did_set_string_option (
       init_highlight(FALSE, FALSE);
 
       if (dark != (*p_bg == 'd') && get_var_value("g:colors_name") != NULL) {
-        /* The color scheme must have set 'background' back to another
-         * value, that's not what we want here.  Disable the color
-         * scheme and set the colors again. */
-        do_unlet((char_u *)"g:colors_name", TRUE);
+        // The color scheme must have set 'background' back to another
+        // value, that's not what we want here.  Disable the color
+        // scheme and set the colors again.
+        do_unlet((char_u *)"g:colors_name", true);
         free_string_option(p_bg);
         p_bg = vim_strsave((char_u *)(dark ? "dark" : "light"));
         check_string_option(&p_bg);

--- a/src/nvim/pos.h
+++ b/src/nvim/pos.h
@@ -2,6 +2,8 @@
 #define NVIM_POS_H
 
 typedef long linenr_T;         // line number type
+/// Format used to print values which have linenr_T type
+#define PRIdLINENR "ld"
 
 /// Column number type
 typedef int colnr_T;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2078,7 +2078,7 @@ void qf_list(exarg_T *eap)
       msg_puts_attr((const char *)IObuff, hl_attr(HLF_N));
       if (qfp->qf_pattern != NULL) {
         qf_fmt_text(qfp->qf_pattern, IObuff, IOSIZE);
-        STRNCAT(IObuff, ":", IOSIZE);
+        xstrlcat((char *)IObuff, ":", IOSIZE);
         msg_puts((const char *)IObuff);
       }
       msg_puts(" ");

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2068,21 +2068,20 @@ void qf_list(exarg_T *eap)
       if (qfp->qf_lnum == 0) {
         IObuff[0] = NUL;
       } else if (qfp->qf_col == 0) {
-        vim_snprintf((char *)IObuff, IOSIZE, ":%" PRId64,
-                     (int64_t)qfp->qf_lnum);
+        vim_snprintf((char *)IObuff, IOSIZE, ":%" PRIdLINENR, qfp->qf_lnum);
       } else {
-        vim_snprintf((char *)IObuff, IOSIZE, ":%" PRId64 " col %d",
-                     (int64_t)qfp->qf_lnum, qfp->qf_col);
+        vim_snprintf((char *)IObuff, IOSIZE, ":%" PRIdLINENR " col %d",
+                     qfp->qf_lnum, qfp->qf_col);
       }
       vim_snprintf((char *)IObuff + STRLEN(IObuff), IOSIZE, "%s:",
                    (char *)qf_types(qfp->qf_type, qfp->qf_nr));
-      msg_puts_attr(IObuff, hl_attr(HLF_N));
+      msg_puts_attr((const char *)IObuff, hl_attr(HLF_N));
       if (qfp->qf_pattern != NULL) {
         qf_fmt_text(qfp->qf_pattern, IObuff, IOSIZE);
-        STRCAT(IObuff, ":");
-        msg_puts(IObuff);
+        STRNCAT(IObuff, ":", IOSIZE);
+        msg_puts((const char *)IObuff);
       }
-      msg_puts((char_u *)" ");
+      msg_puts(" ");
 
       /* Remove newlines and leading whitespace from the text.  For an
        * unrecognized line keep the indent, the compiler may mark a word

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6725,7 +6725,7 @@ int showmode(void)
             msg_puts_attr((const char *)edit_submode, attr);
           }
           if (edit_submode_extra != NULL) {
-            MSG_PUTS_ATTR(" ", attr);              /* add a space in between */
+            MSG_PUTS_ATTR(" ", attr);  // Add a space in between.
             if ((int)edit_submode_highl < (int)HLF_COUNT) {
               sub_attr = hl_attr(edit_submode_highl);
             } else {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6719,17 +6719,19 @@ int showmode(void)
           if (edit_submode_pre != NULL)
             length -= vim_strsize(edit_submode_pre);
           if (length - vim_strsize(edit_submode) > 0) {
-            if (edit_submode_pre != NULL)
-              msg_puts_attr(edit_submode_pre, attr);
-            msg_puts_attr(edit_submode, attr);
+            if (edit_submode_pre != NULL) {
+              msg_puts_attr((const char *)edit_submode_pre, attr);
+            }
+            msg_puts_attr((const char *)edit_submode, attr);
           }
           if (edit_submode_extra != NULL) {
             MSG_PUTS_ATTR(" ", attr);              /* add a space in between */
-            if ((int)edit_submode_highl < (int)HLF_COUNT)
+            if ((int)edit_submode_highl < (int)HLF_COUNT) {
               sub_attr = hl_attr(edit_submode_highl);
-            else
+            } else {
               sub_attr = attr;
-            msg_puts_attr(edit_submode_extra, sub_attr);
+            }
+            msg_puts_attr((const char *)edit_submode_extra, sub_attr);
           }
         }
       } else {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4656,12 +4656,12 @@ static void show_pat_in_path(char_u *line, int type, int did_show, int action, F
       *(p + 1) = NUL;
     }
     if (action == ACTION_SHOW_ALL) {
-      sprintf((char *)IObuff, "%3ld: ", count);         /* show match nr */
-      msg_puts(IObuff);
-      sprintf((char *)IObuff, "%4ld", *lnum);           /* show line nr */
-      /* Highlight line numbers */
-      msg_puts_attr(IObuff, hl_attr(HLF_N));
-      MSG_PUTS(" ");
+      snprintf((char *)IObuff, IOSIZE, "%3ld: ", count);  // Show match nr.
+      msg_puts((const char *)IObuff);
+      snprintf((char *)IObuff, IOSIZE, "%4ld", *lnum);  // Show line nr.
+      // Highlight line numbers.
+      msg_puts_attr((const char *)IObuff, hl_attr(HLF_N));
+      msg_puts(" ");
     }
     msg_prt_line(line, FALSE);
     ui_flush();                        /* show one line at a time */

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3094,10 +3094,11 @@ count_common_word (
   }
 
   hash = hash_hash(p);
-  hi = hash_lookup(&lp->sl_wordcount, p, hash);
+  const size_t p_len = STRLEN(p);
+  hi = hash_lookup(&lp->sl_wordcount, (const char *)p, p_len, hash);
   if (HASHITEM_EMPTY(hi)) {
-    wc = xmalloc(sizeof(wordcount_T) + STRLEN(p));
-    STRCPY(wc->wc_word, p);
+    wc = xmalloc(sizeof(wordcount_T) + p_len);
+    memcpy(wc->wc_word, p, p_len + 1);
     wc->wc_count = count;
     hash_add_item(&lp->sl_wordcount, hi, wc->wc_word, hash);
   } else {
@@ -5513,7 +5514,7 @@ static int spell_read_dic(spellinfo_T *spin, char_u *fname, afffile_T *affile)
     }
 
     hash = hash_hash(dw);
-    hi = hash_lookup(&ht, dw, hash);
+    hi = hash_lookup(&ht, (const char *)dw, STRLEN(dw), hash);
     if (!HASHITEM_EMPTY(hi)) {
       if (p_verbose > 0)
         smsg(_("Duplicate word in %s line %d: %s"),
@@ -6343,7 +6344,7 @@ static int tree_add_word(spellinfo_T *spin, char_u *word, wordnode_T *root, int 
 
     if (spin->si_verbose) {
       msg_start();
-      msg_puts((char_u *)_(msg_compressing));
+      msg_puts(_(msg_compressing));
       msg_clr_eos();
       msg_didout = FALSE;
       msg_col = 0;
@@ -6519,7 +6520,8 @@ node_compress (
 
       // Try to find an identical child.
       hash = hash_hash(child->wn_u1.hashkey);
-      hi = hash_lookup(ht, child->wn_u1.hashkey, hash);
+      hi = hash_lookup(ht, (const char *)child->wn_u1.hashkey,
+                       STRLEN(child->wn_u1.hashkey), hash);
       if (!HASHITEM_EMPTY(hi)) {
         // There are children we encountered before with a hash value
         // identical to the current child.  Now check if there is one
@@ -8515,7 +8517,7 @@ void spell_suggest(int count)
       vim_snprintf((char *)IObuff, IOSIZE, ":ot \"%.*s\" egnahC",
           sug.su_badlen, sug.su_badptr);
     }
-    msg_puts(IObuff);
+    msg_puts((const char *)IObuff);
     msg_clr_eos();
     msg_putchar('\n');
 
@@ -8531,18 +8533,19 @@ void spell_suggest(int count)
             sug.su_badptr + stp->st_orglen,
             sug.su_badlen - stp->st_orglen + 1);
       vim_snprintf((char *)IObuff, IOSIZE, "%2d", i + 1);
-      if (cmdmsg_rl)
+      if (cmdmsg_rl) {
         rl_mirror(IObuff);
-      msg_puts(IObuff);
+      }
+      msg_puts((const char *)IObuff);
 
       vim_snprintf((char *)IObuff, IOSIZE, " \"%s\"", wcopy);
-      msg_puts(IObuff);
+      msg_puts((const char *)IObuff);
 
       // The word may replace more than "su_badlen".
       if (sug.su_badlen < stp->st_orglen) {
         vim_snprintf((char *)IObuff, IOSIZE, _(" < \"%.*s\""),
-            stp->st_orglen, sug.su_badptr);
-        msg_puts(IObuff);
+                     stp->st_orglen, sug.su_badptr);
+        msg_puts((const char *)IObuff);
       }
 
       if (p_verbose > 0) {
@@ -8558,7 +8561,7 @@ void spell_suggest(int count)
           // Mirror the numbers, but keep the leading space.
           rl_mirror(IObuff + 1);
         msg_advance(30);
-        msg_puts(IObuff);
+        msg_puts((const char *)IObuff);
       }
       msg_putchar('\n');
     }
@@ -11182,11 +11185,13 @@ add_sound_suggest (
   // the words that have a better score than before.  Use a hashtable to
   // remember the words that have been done.
   hash = hash_hash(goodword);
-  hi = hash_lookup(&slang->sl_sounddone, goodword, hash);
+  const size_t goodword_len = STRLEN(goodword);
+  hi = hash_lookup(&slang->sl_sounddone, (const char *)goodword, goodword_len,
+                   hash);
   if (HASHITEM_EMPTY(hi)) {
-    sft = xmalloc(sizeof(sftword_T) + STRLEN(goodword));
+    sft = xmalloc(sizeof(sftword_T) + goodword_len);
     sft->sft_score = score;
-    STRCPY(sft->sft_word, goodword);
+    memcpy(sft->sft_word, goodword, goodword_len + 1);
     hash_add_item(&slang->sl_sounddone, hi, sft->sft_word, hash);
   } else {
     sft = HI2SFT(hi);
@@ -11453,10 +11458,10 @@ static void set_map_str(slang_T *lp, char_u *map)
         mb_char2bytes(headc, b + cl + 1);
         b[cl + 1 + headcl] = NUL;
         hash = hash_hash(b);
-        hi = hash_lookup(&lp->sl_map_hash, b, hash);
-        if (HASHITEM_EMPTY(hi))
+        hi = hash_lookup(&lp->sl_map_hash, (const char *)b, STRLEN(b), hash);
+        if (HASHITEM_EMPTY(hi)) {
           hash_add_item(&lp->sl_map_hash, hi, b, hash);
-        else {
+        } else {
           // This should have been checked when generating the .spl
           // file.
           EMSG(_("E783: duplicate char in MAP entry"));
@@ -11661,9 +11666,10 @@ static void add_banned(suginfo_T *su, char_u *word)
   hashitem_T  *hi;
 
   hash = hash_hash(word);
-  hi = hash_lookup(&su->su_banned, word, hash);
+  const size_t word_len = STRLEN(word);
+  hi = hash_lookup(&su->su_banned, (const char *)word, word_len, hash);
   if (HASHITEM_EMPTY(hi)) {
-    s = vim_strsave(word);
+    s = xmemdupz(word, word_len);
     hash_add_item(&su->su_banned, hi, s, hash);
   }
 }
@@ -12995,19 +13001,17 @@ pop:
 // ":spellinfo"
 void ex_spellinfo(exarg_T *eap)
 {
-  langp_T     *lp;
-  char_u      *p;
-
-  if (no_spell_checking(curwin))
+  if (no_spell_checking(curwin)) {
     return;
+  }
 
   msg_start();
   for (int lpi = 0; lpi < curwin->w_s->b_langp.ga_len && !got_int; ++lpi) {
-    lp = LANGP_ENTRY(curwin->w_s->b_langp, lpi);
-    msg_puts((char_u *)"file: ");
-    msg_puts(lp->lp_slang->sl_fname);
+    langp_T *const lp = LANGP_ENTRY(curwin->w_s->b_langp, lpi);
+    msg_puts("file: ");
+    msg_puts((const char *)lp->lp_slang->sl_fname);
     msg_putchar('\n');
-    p = lp->lp_slang->sl_info;
+    const char *const p = (const char *)lp->lp_slang->sl_info;
     if (p != NULL) {
       msg_puts(p);
       msg_putchar('\n');

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -13006,7 +13006,7 @@ void ex_spellinfo(exarg_T *eap)
   }
 
   msg_start();
-  for (int lpi = 0; lpi < curwin->w_s->b_langp.ga_len && !got_int; ++lpi) {
+  for (int lpi = 0; lpi < curwin->w_s->b_langp.ga_len && !got_int; lpi++) {
     langp_T *const lp = LANGP_ENTRY(curwin->w_s->b_langp, lpi);
     msg_puts("file: ");
     msg_puts((const char *)lp->lp_slang->sl_fname);

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3576,22 +3576,24 @@ syn_list_one (
     }
     syn_list_flags(namelist1, spp->sp_flags, attr);
 
-    if (spp->sp_cont_list != NULL)
-      put_id_list((char_u *)"contains", spp->sp_cont_list, attr);
+    if (spp->sp_cont_list != NULL) {
+      put_id_list("contains", spp->sp_cont_list, attr);
+    }
 
-    if (spp->sp_syn.cont_in_list != NULL)
-      put_id_list((char_u *)"containedin",
-          spp->sp_syn.cont_in_list, attr);
+    if (spp->sp_syn.cont_in_list != NULL) {
+      put_id_list("containedin", spp->sp_syn.cont_in_list, attr);
+    }
 
     if (spp->sp_next_list != NULL) {
-      put_id_list((char_u *)"nextgroup", spp->sp_next_list, attr);
+      put_id_list("nextgroup", spp->sp_next_list, attr);
       syn_list_flags(namelist2, spp->sp_flags, attr);
     }
     if (spp->sp_flags & (HL_SYNC_HERE|HL_SYNC_THERE)) {
-      if (spp->sp_flags & HL_SYNC_HERE)
-        msg_puts_attr((char_u *)"grouphere", attr);
-      else
-        msg_puts_attr((char_u *)"groupthere", attr);
+      if (spp->sp_flags & HL_SYNC_HERE) {
+        msg_puts_attr("grouphere", attr);
+      } else {
+        msg_puts_attr("groupthere", attr);
+      }
       msg_putchar(' ');
       if (spp->sp_sync_idx >= 0)
         msg_outtrans(HL_TABLE()[SYN_ITEMS(curwin->w_s)
@@ -3605,7 +3607,7 @@ syn_list_one (
   /* list the link, if there is one */
   if (HL_TABLE()[id - 1].sg_link && (did_header || link_only) && !got_int) {
     (void)syn_list_header(did_header, 999, id);
-    msg_puts_attr((char_u *)"links to", attr);
+    msg_puts_attr("links to", attr);
     msg_putchar(' ');
     msg_outtrans(HL_TABLE()[HL_TABLE()[id - 1].sg_link - 1].sg_name);
   }
@@ -3617,7 +3619,7 @@ static void syn_list_flags(struct name_list *nlist, int flags, int attr)
 
   for (i = 0; nlist[i].flag != 0; ++i)
     if (flags & nlist[i].flag) {
-      msg_puts_attr((char_u *)nlist[i].name, attr);
+      msg_puts_attr(nlist[i].name, attr);
       msg_putchar(' ');
     }
 }
@@ -3640,15 +3642,14 @@ static void syn_list_cluster(int id)
 
   msg_advance(endcol);
   if (SYN_CLSTR(curwin->w_s)[id].scl_list != NULL) {
-    put_id_list((char_u *)"cluster", SYN_CLSTR(curwin->w_s)[id].scl_list,
-        hl_attr(HLF_D));
+    put_id_list("cluster", SYN_CLSTR(curwin->w_s)[id].scl_list, hl_attr(HLF_D));
   } else {
-    msg_puts_attr((char_u *)"cluster", hl_attr(HLF_D));
-    msg_puts((char_u *)"=NONE");
+    msg_puts_attr("cluster", hl_attr(HLF_D));
+    msg_puts("=NONE");
   }
 }
 
-static void put_id_list(char_u *name, short *list, int attr)
+static void put_id_list(const char *name, short *list, int attr)
 {
   short               *p;
 
@@ -3656,14 +3657,15 @@ static void put_id_list(char_u *name, short *list, int attr)
   msg_putchar('=');
   for (p = list; *p; ++p) {
     if (*p >= SYNID_ALLBUT && *p < SYNID_TOP) {
-      if (p[1])
-        MSG_PUTS("ALLBUT");
-      else
-        MSG_PUTS("ALL");
+      if (p[1]) {
+        msg_puts("ALLBUT");
+      } else {
+        msg_puts("ALL");
+      }
     } else if (*p >= SYNID_TOP && *p < SYNID_CONTAINED)   {
-      MSG_PUTS("TOP");
+      msg_puts("TOP");
     } else if (*p >= SYNID_CONTAINED && *p < SYNID_CLUSTER)   {
-      MSG_PUTS("CONTAINED");
+      msg_puts("CONTAINED");
     } else if (*p >= SYNID_CLUSTER)   {
       short scl_id = *p - SYNID_CLUSTER;
 
@@ -3688,7 +3690,7 @@ static void put_pattern(char *s, int c, synpat_T *spp, int attr)
   /* May have to write "matchgroup=group" */
   if (last_matchgroup != spp->sp_syn_match_id) {
     last_matchgroup = spp->sp_syn_match_id;
-    msg_puts_attr((char_u *)"matchgroup", attr);
+    msg_puts_attr("matchgroup", attr);
     msg_putchar('=');
     if (last_matchgroup == 0)
       msg_outtrans((char_u *)"NONE");
@@ -3697,8 +3699,8 @@ static void put_pattern(char *s, int c, synpat_T *spp, int attr)
     msg_putchar(' ');
   }
 
-  /* output the name of the pattern and an '=' or ' ' */
-  msg_puts_attr((char_u *)s, attr);
+  // Output the name of the pattern and an '=' or ' '.
+  msg_puts_attr(s, attr);
   msg_putchar(c);
 
   /* output the pattern, in between a char that is not in the pattern */
@@ -3718,9 +3720,10 @@ static void put_pattern(char *s, int c, synpat_T *spp, int attr)
     if (!(spp->sp_off_flags & (mask + (mask << SPO_COUNT)))) {
       continue;
     }
-    if (!first)
-      msg_putchar(',');               /* separate with commas */
-    msg_puts((char_u *)spo_name_tab[i]);
+    if (!first) {
+      msg_putchar(',');  // Separate with commas.
+    }
+    msg_puts(spo_name_tab[i]);
     n = spp->sp_offsets[i];
     if (i != SPO_LC_OFF) {
       if (spp->sp_off_flags & mask)
@@ -3792,32 +3795,31 @@ syn_list_keywords (
         }
         did_header = TRUE;
         if (prev_contained != (kp->flags & HL_CONTAINED)) {
-          msg_puts_attr((char_u *)"contained", attr);
+          msg_puts_attr("contained", attr);
           msg_putchar(' ');
           prev_contained = (kp->flags & HL_CONTAINED);
         }
         if (kp->k_syn.cont_in_list != prev_cont_in_list) {
-          put_id_list((char_u *)"containedin",
-              kp->k_syn.cont_in_list, attr);
+          put_id_list("containedin", kp->k_syn.cont_in_list, attr);
           msg_putchar(' ');
           prev_cont_in_list = kp->k_syn.cont_in_list;
         }
         if (kp->next_list != prev_next_list) {
-          put_id_list((char_u *)"nextgroup", kp->next_list, attr);
+          put_id_list("nextgroup", kp->next_list, attr);
           msg_putchar(' ');
           prev_next_list = kp->next_list;
           if (kp->flags & HL_SKIPNL) {
-            msg_puts_attr((char_u *)"skipnl", attr);
+            msg_puts_attr("skipnl", attr);
             msg_putchar(' ');
             prev_skipnl = (kp->flags & HL_SKIPNL);
           }
           if (kp->flags & HL_SKIPWHITE) {
-            msg_puts_attr((char_u *)"skipwhite", attr);
+            msg_puts_attr("skipwhite", attr);
             msg_putchar(' ');
             prev_skipwhite = (kp->flags & HL_SKIPWHITE);
           }
           if (kp->flags & HL_SKIPEMPTY) {
-            msg_puts_attr((char_u *)"skipempty", attr);
+            msg_puts_attr("skipempty", attr);
             msg_putchar(' ');
             prev_skipempty = (kp->flags & HL_SKIPEMPTY);
           }
@@ -3929,7 +3931,8 @@ static void add_keyword(char_u *name,
   hash_T hash = hash_hash(kp->keyword);
   hashtab_T *ht = (curwin->w_s->b_syn_ic) ? &curwin->w_s->b_keywtab_ic
                                           : &curwin->w_s->b_keywtab;
-  hashitem_T *hi = hash_lookup(ht, kp->keyword, hash);
+  hashitem_T *hi = hash_lookup(ht, (const char *)kp->keyword,
+                               STRLEN(kp->keyword), hash);
 
   // even though it looks like only the kp->keyword member is
   // being used here, vim uses some pointer trickery to get the orignal
@@ -5517,7 +5520,7 @@ void ex_ownsyntax(exarg_T *eap)
   }
 
   /* save value of b:current_syntax */
-  old_value = get_var_value((char_u *)"b:current_syntax");
+  old_value = get_var_value("b:current_syntax");
   if (old_value != NULL)
     old_value = vim_strsave(old_value);
 
@@ -5526,7 +5529,7 @@ void ex_ownsyntax(exarg_T *eap)
   apply_autocmds(EVENT_SYNTAX, eap->arg, curbuf->b_fname, TRUE, curbuf);
 
   /* move value of b:current_syntax to w:current_syntax */
-  new_value = get_var_value((char_u *)"b:current_syntax");
+  new_value = get_var_value("b:current_syntax");
   if (new_value != NULL)
     set_internal_string_var((char_u *)"w:current_syntax", new_value);
 
@@ -5988,7 +5991,7 @@ init_highlight (
    * Try finding the color scheme file.  Used when a color file was loaded
    * and 'background' or 't_Co' is changed.
    */
-  char_u *p = get_var_value((char_u *)"g:colors_name");
+  char_u *p = get_var_value("g:colors_name");
   if (p != NULL) {
     // Value of g:colors_name could be freed in load_colors() and make
     // p invalid, so copy it.
@@ -6042,7 +6045,7 @@ init_highlight (
   /*
    * If syntax highlighting is enabled load the highlighting for it.
    */
-  if (get_var_value((char_u *)"g:syntax_on") != NULL) {
+  if (get_var_value("g:syntax_on") != NULL) {
     static int recursive = 0;
 
     if (recursive >= 5) {
@@ -6871,8 +6874,8 @@ static void highlight_list_one(int id)
 
   if (sgp->sg_link && !got_int) {
     (void)syn_list_header(didh, 9999, id);
-    didh = TRUE;
-    msg_puts_attr((char_u *)"links to", hl_attr(HLF_D));
+    didh = true;
+    msg_puts_attr("links to", hl_attr(HLF_D));
     msg_putchar(' ');
     msg_outtrans(HL_TABLE()[HL_TABLE()[id - 1].sg_link - 1].sg_name);
   }
@@ -7057,7 +7060,7 @@ syn_list_header (
 
   /* Show "xxx" with the attributes. */
   if (!did_header) {
-    msg_puts_attr((char_u *)"xxx", syn_id2attr(id));
+    msg_puts_attr("xxx", syn_id2attr(id));
     msg_putchar(' ');
   }
 
@@ -7517,7 +7520,7 @@ static void highlight_list(void)
 
 static void highlight_list_two(int cnt, int attr)
 {
-  msg_puts_attr((char_u *)&("N \bI \b!  \b"[cnt / 11]), attr);
+  msg_puts_attr(&("N \bI \b!  \b"[cnt / 11]), attr);
   msg_clr_eos();
   ui_flush();
   os_delay(cnt == 99 ? 40L : (long)cnt * 50L, false);
@@ -7528,22 +7531,25 @@ static void highlight_list_two(int cnt, int attr)
  * Function given to ExpandGeneric() to obtain the list of group names.
  * Also used for synIDattr() function.
  */
-char_u *get_highlight_name(expand_T *xp, int idx)
+const char *get_highlight_name(expand_T *const xp, const int idx)
+  FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  //TODO: 'xp' is unused
-  if (idx == highlight_ga.ga_len && include_none != 0)
-    return (char_u *)"none";
-  if (idx == highlight_ga.ga_len + include_none && include_default != 0)
-    return (char_u *)"default";
-  if (idx == highlight_ga.ga_len + include_none + include_default
-      && include_link != 0)
-    return (char_u *)"link";
-  if (idx == highlight_ga.ga_len + include_none + include_default + 1
-      && include_link != 0)
-    return (char_u *)"clear";
-  if (idx < 0 || idx >= highlight_ga.ga_len)
+  // TODO: 'xp' is unused
+  if (idx == highlight_ga.ga_len && include_none != 0) {
+    return "none";
+  } else if (idx == highlight_ga.ga_len + include_none
+      && include_default != 0) {
+    return "default";
+  } else if (idx == highlight_ga.ga_len + include_none + include_default
+             && include_link != 0) {
+    return "link";
+  } else if (idx == highlight_ga.ga_len + include_none + include_default + 1
+             && include_link != 0) {
+    return "clear";
+  } else if (idx < 0 || idx >= highlight_ga.ga_len) {
     return NULL;
-  return HL_TABLE()[idx].sg_name;
+  }
+  return (const char *)HL_TABLE()[idx].sg_name;
 }
 
 color_name_table_T color_name_table[] = {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3649,7 +3649,9 @@ static void syn_list_cluster(int id)
   }
 }
 
-static void put_id_list(const char *name, short *list, int attr)
+static void put_id_list(const char *name,
+                        short *list,  // NOLINT(runtime/int)
+                        int attr)
 {
   short               *p;
 
@@ -5519,19 +5521,21 @@ void ex_ownsyntax(exarg_T *eap)
     clear_string_option(&curwin->w_s->b_syn_isk);
   }
 
-  /* save value of b:current_syntax */
+  // Save value of b:current_syntax.
   old_value = get_var_value("b:current_syntax");
-  if (old_value != NULL)
+  if (old_value != NULL) {
     old_value = vim_strsave(old_value);
+  }
 
   /* Apply the "syntax" autocommand event, this finds and loads the syntax
    * file. */
   apply_autocmds(EVENT_SYNTAX, eap->arg, curbuf->b_fname, TRUE, curbuf);
 
-  /* move value of b:current_syntax to w:current_syntax */
+  // Move value of b:current_syntax to w:current_syntax.
   new_value = get_var_value("b:current_syntax");
-  if (new_value != NULL)
+  if (new_value != NULL) {
     set_internal_string_var((char_u *)"w:current_syntax", new_value);
+  }
 
   /* restore value of b:current_syntax */
   if (old_value == NULL)
@@ -7534,11 +7538,11 @@ static void highlight_list_two(int cnt, int attr)
 const char *get_highlight_name(expand_T *const xp, const int idx)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  // TODO: 'xp' is unused
+  // TODO(justinmk): 'xp' is unused
   if (idx == highlight_ga.ga_len && include_none != 0) {
     return "none";
   } else if (idx == highlight_ga.ga_len + include_none
-      && include_default != 0) {
+             && include_default != 0) {
     return "default";
   } else if (idx == highlight_ga.ga_len + include_none + include_default
              && include_link != 0) {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -540,7 +540,7 @@ do_tag (
           }
           vim_snprintf((char *)IObuff + 1, IOSIZE - 1, "%2d %s ", i + 1,
                        mt_names[matches[i][0] & MT_MASK]);
-          msg_puts(IObuff);
+          msg_puts((const char *)IObuff);
           if (tagp.tagkind != NULL)
             msg_outtrans_len(tagp.tagkind,
                 (int)(tagp.tagkind_end - tagp.tagkind));
@@ -595,7 +595,7 @@ do_tag (
                 }
                 p = msg_outtrans_one(p, attr);
                 if (*p == TAB) {
-                  msg_puts_attr((char_u *)" ", attr);
+                  msg_puts_attr(" ", attr);
                   break;
                 }
                 if (*p == ':')
@@ -858,11 +858,12 @@ do_tag (
           STRCAT(IObuff, _("  Using tag with different case!"));
         if ((num_matches > prev_num_matches || new_tag)
             && num_matches > 1) {
-          if (ic)
-            msg_attr(IObuff, hl_attr(HLF_W));
-          else
+          if (ic) {
+            msg_attr((const char *)IObuff, hl_attr(HLF_W));
+          } else {
             msg(IObuff);
-          msg_scroll = TRUE;            /* don't overwrite this message */
+          }
+          msg_scroll = true;  // Don't overwrite this message.
         } else
           give_warning(IObuff, ic);
         if (ic && !msg_scrolled && msg_silent == 0) {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -541,9 +541,10 @@ do_tag (
           vim_snprintf((char *)IObuff + 1, IOSIZE - 1, "%2d %s ", i + 1,
                        mt_names[matches[i][0] & MT_MASK]);
           msg_puts((const char *)IObuff);
-          if (tagp.tagkind != NULL)
+          if (tagp.tagkind != NULL) {
             msg_outtrans_len(tagp.tagkind,
-                (int)(tagp.tagkind_end - tagp.tagkind));
+                             (int)(tagp.tagkind_end - tagp.tagkind));
+          }
           msg_advance(13);
           msg_outtrans_len_attr(tagp.tagname,
               (int)(tagp.tagname_end - tagp.tagname),
@@ -864,8 +865,9 @@ do_tag (
             msg(IObuff);
           }
           msg_scroll = true;  // Don't overwrite this message.
-        } else
+        } else {
           give_warning(IObuff, ic);
+        }
         if (ic && !msg_scrolled && msg_silent == 0) {
           ui_flush();
           os_delay(1000L, true);

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2512,13 +2512,14 @@ void ex_undolist(exarg_T *eap)
     sort_strings((char_u **)ga.ga_data, ga.ga_len);
 
     msg_start();
-    msg_puts_attr((char_u *)_("number changes  when               saved"),
-        hl_attr(HLF_T));
+    msg_puts_attr(_("number changes  when               saved"),
+                  hl_attr(HLF_T));
     for (int i = 0; i < ga.ga_len && !got_int; ++i) {
       msg_putchar('\n');
-      if (got_int)
+      if (got_int) {
         break;
-      msg_puts(((char_u **)ga.ga_data)[i]);
+      }
+      msg_puts(((const char **)ga.ga_data)[i]);
     }
     msg_end();
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2514,7 +2514,7 @@ void ex_undolist(exarg_T *eap)
     msg_start();
     msg_puts_attr(_("number changes  when               saved"),
                   hl_attr(HLF_T));
-    for (int i = 0; i < ga.ga_len && !got_int; ++i) {
+    for (int i = 0; i < ga.ga_len && !got_int; i++) {
       msg_putchar('\n');
       if (got_int) {
         break;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2572,7 +2572,7 @@ static void list_features(void)
     int idx = (i / ncol) + (i % ncol) * nrow;
     if (idx < nfeat) {
       int last_col = (i + 1) % ncol == 0;
-      msg_puts((char_u *)features[idx]);
+      msg_puts(features[idx]);
       if (last_col) {
         if (msg_col > 0) {
           msg_putchar('\n');

--- a/test/functional/eval/let_spec.lua
+++ b/test/functional/eval/let_spec.lua
@@ -1,0 +1,22 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local eq = helpers.eq
+local clear = helpers.clear
+local meths = helpers.meths
+local redir_exec = helpers.redir_exec
+
+before_each(clear)
+
+describe(':let command', function()
+  it('correctly lists variables with curly-braces', function()
+    meths.set_var('v', {0})
+    eq('\nv                     [0]', redir_exec('let {"v"}'))
+  end)
+
+  it('correctly lists variables with subscript', function()
+    meths.set_var('v', {0})
+    eq('\nv[0]                  #0', redir_exec('let v[0]'))
+    eq('\ng:["v"][0]            #0', redir_exec('let g:["v"][0]'))
+    eq('\n{"g:"}["v"][0]        #0', redir_exec('let {"g:"}["v"][0]'))
+  end)
+end)


### PR DESCRIPTION
Main points:

- Replace `char_u` with `char` in some cases.
- Remove `str[len] = NUL` hack in some cases when `str` may be considered
  `const`.

Part of #5119 