### PR TITLE
[WIP] Issue 4615: "NULL typval_T values do not always work as fixed empty lists/dictionaries/strings"

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4492,14 +4492,16 @@ void ex_buffer_all(exarg_T *eap)
   int had_tab = cmdmod.tab;
   tabpage_T   *tpnext;
 
-  if (eap->addr_count == 0)     /* make as many windows as possible */
+  if (eap->addr_count == 0) {   // make as many windows as possible
     count = 9999;
-  else
-    count = eap->line2;         /* make as many windows as specified */
-  if (eap->cmdidx == CMD_unhide || eap->cmdidx == CMD_sunhide)
-    all = FALSE;
-  else
-    all = TRUE;
+  } else {
+    count = eap->line2;         // make as many windows as specified
+  }
+  if (eap->cmdidx == CMD_unhide || eap->cmdidx == CMD_sunhide) {
+    all = false;
+  } else {
+    all = true;
+  }
 
   setpcmark();
 


### PR DESCRIPTION
Started to resolve issue #4615. The first step should be to merge all the codes @ZyX-I used to illustrate issue #4615.

Already merged as much as possible, but the origin commit of some added files were not identified, so those files are pendent to be merged. Such files are
- src/nvim/eval/typval.c
- test/functional/eval/typval_spec.lua

And, other codes with the same function as the following seem to exist already.

 test/functional/ex_cmds/dict_notifications_spec.lua
 ```
+    it("fails to add/remove if the callback doesn't exist", function()
+      eq("Vim(call):Function g:InvalidCb doesn't exist",
+        exc_exec('call dictwatcheradd(g:, "key", "g:InvalidCb")'))
+      eq("Vim(call):Function g:InvalidCb doesn't exist",
+        exc_exec('call dictwatcherdel(g:, "key", "g:InvalidCb")'))
+    end)

-   it("does not fail to add/remove if the callback doesn't exist", function()
-     command('call dictwatcheradd(g:, "key", "g:InvalidCb")')
-     command('call dictwatcherdel(g:, "key", "g:InvalidCb")')
-   end)
```