### PR TITLE
[RFC] eval.c: Fix has unnamedplus always returning 0.

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11442,6 +11442,10 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 #endif
     } else if (STRICMP(name, "syntax_items") == 0) {
       n = syntax_present(curwin);
+#ifdef UNIX
+    } else if (STRICMP(name, "unnamedplus") == 0) {
+      n = eval_has_provider("clipboard");
+#endif
     }
   }
 

--- a/test/functional/eval/has_spec.lua
+++ b/test/functional/eval/has_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local eq = helpers.eq
 local clear = helpers.clear
 local funcs = helpers.funcs
+local iswin = helpers.iswin
 
 describe('has()', function()
   before_each(clear)
@@ -49,4 +50,11 @@ describe('has()', function()
     eq(1, funcs.has("nvim-00.001.05"))
   end)
 
+  it('"unnamedplus"', function()
+    if (not iswin()) and funcs.has("clipboard") == 1 then
+      eq(1, funcs.has("unnamedplus"))
+    else
+      eq(0, funcs.has("unnamedplus"))
+    end
+  end)
 end)


### PR DESCRIPTION
Adds a check for unnamedplus through "has()". Instead of always
returning 0, it will now return 1 when the os is UNIX and we have access
to clipboard provider. Added functional tests in has_spec.lua.

Fixes: https://github.com/neovim/neovim/issues/6103