### PR TITLE
terminal: 'modifiable'; 'scrollback'; follow output only if cursor is on last line

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -4,28 +4,19 @@
 		 NVIM REFERENCE MANUAL    by Thiago de Arruda
 
 
-Embedded terminal emulator				   *terminal-emulator*
+Terminal emulator					   *terminal-emulator*
 
-1. Introduction			|terminal-emulator-intro|
-2. Spawning			|terminal-emulator-spawning|
-3. Input			|terminal-emulator-input|
-4. Configuration		|terminal-emulator-configuration|
-5. Status Variables		|terminal-emulator-status|
+Nvim embeds a VT220/xterm terminal emulator based on libvterm. The terminal is
+presented as a special buffer type, asynchronously updated from the virtual
+terminal as data is received from the program connected to it.
 
-==============================================================================
-1. Introduction					     *terminal-emulator-intro*
-
-Nvim offers a mostly complete VT220/xterm terminal emulator. The terminal is
-presented as a special buffer type, asynchronously updated to mirror the
-virtual terminal display as data is received from the program connected to it.
-For most purposes, terminal buffers behave a lot like normal buffers with
-'nomodifiable' set.
-
-The implementation is powered by libvterm, a powerful abstract terminal
-emulation library. http://www.leonerd.org.uk/code/libvterm/
+Terminal buffers behave mostly like normal 'nomodifiable' buffers, except:
+- Plugins can set 'modifiable' to modify text, but lines cannot be deleted.
+- 'scrollback' controls how many off-screen lines are kept.
+- Terminal output is followed if the cursor is on the last line.
 
 ==============================================================================
-2. Spawning					  *terminal-emulator-spawning*
+Spawning					  *terminal-emulator-spawning*
 
 There are 3 ways to create a terminal buffer:
 
@@ -40,34 +31,27 @@ There are 3 ways to create a terminal buffer:
     Note: The "term://" pattern is handled by a BufReadCmd handler, so the
     |autocmd-nested| modifier is required to use it in an autocmd. >
         autocmd VimEnter * nested split term://sh
-<    This is only mentioned for reference; you should use the |:terminal|
-    command instead.
+<    This is only mentioned for reference; use |:terminal| instead.
 
 When the terminal spawns the program, the buffer will start to mirror the
-terminal display and change its name to `term://$CWD//$PID:$COMMAND`.
-Note that |:mksession| will "save" the terminal buffers by restarting all
-programs when the session is restored.
+terminal display and change its name to `term://{cwd}//{pid}:{cmd}`.
+The "term://..." scheme enables |:mksession| to "restore" a terminal buffer by
+restarting the {cmd} when the session is loaded.
 
 ==============================================================================
-3. Input					     *terminal-emulator-input*
+Input						     *terminal-emulator-input*
 
-Sending input is possible by entering terminal mode, which is achieved by
-pressing any key that would enter insert mode in a normal buffer (|i| or |a|
-for example). The |:terminal| ex command will automatically enter terminal
-mode once it's spawned. While in terminal mode, Nvim will forward all keys to
-the underlying program. The only exception is the <C-\><C-n> key combo,
-which will exit back to normal mode.
+To send input, enter terminal mode using any command that would enter "insert
+mode" in a normal buffer, such as |i| or |:startinsert|. In this mode all keys
+except <C-\><C-N> are sent to the underlying program. Use <C-\><C-N> to return
+to normal mode. |CTRL-\_CTRL-N|
 
-Terminal mode has its own namespace for mappings, which is accessed with the
-"t" prefix. It's possible to use terminal mappings to customize interaction
-with the terminal. For example, here's how to map <Esc> to exit terminal mode:
->
+Terminal mode has its own |:tnoremap| namespace for mappings, this can be used
+to automate any terminal interaction. To map <Esc> to exit terminal mode: >
     :tnoremap <Esc> <C-\><C-n>
 <
-Navigating to other windows is only possible by exiting to normal mode, which
-can be cumbersome with <C-\><C-n> keys. To improve the navigation experience,
-you could use the following mappings:
->
+Navigating to other windows is only possible in normal mode. For convenience,
+you could use these mappings: >
     :tnoremap <A-h> <C-\><C-n><C-w>h
     :tnoremap <A-j> <C-\><C-n><C-w>j
     :tnoremap <A-k> <C-\><C-n><C-w>k
@@ -77,11 +61,9 @@ you could use the following mappings:
     :nnoremap <A-k> <C-w>k
     :nnoremap <A-l> <C-w>l
 <
-This configuration allows using `Alt+{h,j,k,l}` to navigate between windows no
-matter if they are displaying a normal buffer or a terminal buffer in terminal
-mode.
+Then you can use `Alt+{h,j,k,l}` to navigate between windows from any mode.
 
-Mouse input is also fully supported, and has the following behavior:
+Mouse input is supported, and has the following behavior:
 
 - If the program has enabled mouse events, the corresponding events will be
   forwarded to the program.
@@ -93,27 +75,23 @@ Mouse input is also fully supported, and has the following behavior:
   the terminal wont lose focus and the hovered window will be scrolled.
 
 ==============================================================================
-4. Configuration			     *terminal-emulator-configuration*
+Configuration				     *terminal-emulator-configuration*
 
-Terminal buffers can be customized through the following global/buffer-local
-variables (set via the |TermOpen| autocmd):
+Options:		'scrollback'
+Events:			|TermOpen|, |TermClose|
+Highlight groups:	|hl-TermCursor|, |hl-TermCursorNC|
 
-- 'scrollback' option: Scrollback lines (output history) limit.
+Terminal colors can be customized with these variables:
+
 - `{g,b}:terminal_color_$NUM`: The terminal color palette, where `$NUM` is the
   color index, between 0 and 255 inclusive. This setting only affects UIs with
   RGB capabilities; for normal terminals the color index is simply forwarded.
 
-The configuration variables are only processed when the terminal starts, which
-is why it needs to be done with the |TermOpen| autocmd or setting global
-variables before the terminal is started.
-
-There is also a corresponding |TermClose| event.
-
-The terminal cursor can be highlighted via |hl-TermCursor| and
-|hl-TermCursorNC|.
+The `{g,b}:terminal_color_$NUM` variables are processed only when the terminal
+starts (after |TermOpen|).
 
 ==============================================================================
-5. Status Variables				    *terminal-emulator-status*
+Status Variables				    *terminal-emulator-status*
 
 Terminal buffers maintain some information about the terminal in buffer-local
 variables:
@@ -126,11 +104,8 @@ variables:
 - *b:terminal_job_pid* The PID of the top-level process running in the
   terminal.
 
-These variables will have a value by the time the TermOpen autocmd runs, and
-will continue to have a value for the lifetime of the terminal buffer, making
-them suitable for use in 'statusline'. For example, to show the terminal title
-as the status line:
->
+These variables are initialized before TermOpen, so you can use them in
+a local 'statusline'. Example: >
     :autocmd TermOpen * setlocal statusline=%{b:term_title}
 <
 ==============================================================================

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -98,8 +98,7 @@ Mouse input is also fully supported, and has the following behavior:
 Terminal buffers can be customized through the following global/buffer-local
 variables (set via the |TermOpen| autocmd):
 
-- `{g,b}:terminal_scrollback_buffer_size`: Scrollback buffer size, between 1
-  and 100000 inclusive. The default is 1000.
+- 'scrollback' option: Scrollback lines (output history) limit.
 - `{g,b}:terminal_color_$NUM`: The terminal color palette, where `$NUM` is the
   color index, between 0 and 255 inclusive. This setting only affects UIs with
   RGB capabilities; for normal terminals the color index is simply forwarded.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4949,9 +4949,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 	be used as the new value for 'scroll'.  Reset to half the window
 	height with ":set scroll=0".
 
-			*'scrollback'* *'scbk'* *'noscrollback'* *'noscbk'*
-'scrollback' 'scbk'	boolean  (default: 1000)
-			global or local to buffer |global-local|
+						*'scrollback'* *'scbk'*
+'scrollback' 'scbk'	number	(default: 1000
+				 in normal buffers: -1)
+			local to buffer
+	Maximum number of lines kept beyond the visible screen. Lines at the
+	top are deleted if new lines exceed this limit.
+	Only in |terminal-emulator| buffers. 'buftype'
+	-1 means "unlimited" for normal buffers, 100000 otherwise.
+	Minimum is 1.
 
 			*'scrollbind'* *'scb'* *'noscrollbind'* *'noscb'*
 'scrollbind' 'scb'	boolean  (default off)

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4949,6 +4949,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	be used as the new value for 'scroll'.  Reset to half the window
 	height with ":set scroll=0".
 
+			*'scrollback'* *'scbk'* *'noscrollback'* *'noscbk'*
+'scrollback' 'scbk'	boolean  (default: 1000)
+			global or local to buffer |global-local|
+
 			*'scrollbind'* *'scb'* *'noscrollbind'* *'noscb'*
 'scrollbind' 'scb'	boolean  (default off)
 			local to window

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -207,23 +207,15 @@ g8			Print the hex values of the bytes used in the
 :sh[ell]		Removed. |vim-differences| {Nvim}
 
 						  *:terminal* *:te*
-:te[rminal][!] {cmd}	Spawns {cmd} using the current value of 'shell' and
-			'shellcmdflag' in a new terminal buffer.  This is
-			equivalent to: >
-
+:te[rminal][!] {cmd}	Execute {cmd} with 'shell' in a |terminal-emulator|
+                        buffer.  Equivalent to: >
 			      :enew
 			      :call termopen('{cmd}')
 			      :startinsert
 <
-			If no {cmd} is given, 'shellcmdflag' will not be sent
-			to |termopen()|.
+                        See |jobstart()|.
 
-			Like |:enew|, it will fail if the current buffer is
-			modified, but can be forced with "!".  See |termopen()|
-			and |terminal-emulator|.
-
-			To switch to terminal mode automatically:
->
+			To enter terminal mode automatically: >
 			      autocmd BufEnter term://* startinsert
 <
 							*:!cmd* *:!* *E34*

--- a/src/.valgrind.supp
+++ b/src/.valgrind.supp
@@ -10,7 +10,7 @@
   Memcheck:Leak
   fun:malloc
   fun:uv_spawn
-  fun:pipe_process_spawn
+  fun:libuv_process_spawn
   fun:process_spawn
   fun:job_start
 }

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -651,6 +651,7 @@ struct file_buffer {
   char_u *b_p_qe;               ///< 'quoteescape'
   int b_p_ro;                   ///< 'readonly'
   long b_p_sw;                  ///< 'shiftwidth'
+  long b_p_scbk;                ///< 'scrollback'
   int b_p_si;                   ///< 'smartindent'
   long b_p_sts;                 ///< 'softtabstop'
   long b_p_sts_nopaste;         ///< b_p_sts saved for paste mode

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -36,7 +36,7 @@ typedef struct {
 // for Map(K, V)
 #include "nvim/map.h"
 
-#define MODIFIABLE(buf) (!buf->terminal && buf->b_p_ma)
+#define MODIFIABLE(buf) (buf->b_p_ma)
 
 /*
  * Flags for w_valid.
@@ -91,32 +91,22 @@ typedef struct frame_S frame_T;
 
 // for struct memline (it needs memfile_T)
 #include "nvim/memline_defs.h"
-
 // for struct memfile, bhdr_T, blocknr_T... (it needs buf_T)
 #include "nvim/memfile_defs.h"
 
-/*
- * This is here because regexp_defs.h needs win_T and buf_T. regprog_T is
- * used below.
- */
+// for regprog_T. Needs win_T and buf_T.
 #include "nvim/regexp_defs.h"
-
-// for  synstate_T (needs reg_extmatch_T, win_T and buf_T)
+// for synstate_T (needs reg_extmatch_T, win_T, buf_T)
 #include "nvim/syntax_defs.h"
-
 // for signlist_T
 #include "nvim/sign_defs.h"
-
 // for bufhl_*_T
 #include "nvim/bufhl_defs.h"
 
 typedef Map(linenr_T, bufhl_vec_T) bufhl_info_T;
 
-// for FileID
-#include "nvim/os/fs_defs.h"
-
-// for Terminal
-#include "nvim/terminal.h"
+#include "nvim/os/fs_defs.h"    // for FileID
+#include "nvim/terminal.h"      // for Terminal
 
 /*
  * The taggy struct is used to store the information about a :tag command.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5845,8 +5845,8 @@ bool garbage_collect(bool testing)
     garbage_collect_at_exit = false;
   }
 
-  // We advance by two because we add one for items referenced through
-  // previous_funccal.
+  // We advance by two (COPYID_INC) because we add one for items referenced
+  // through previous_funccal.
   const int copyID = get_copyID();
 
   // 1. Go through all accessible variables and mark all lists and dicts

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7435,12 +7435,10 @@ static void nv_edit(cmdarg_T *cap)
 
   /* in Visual mode and after an operator "a" and "i" are for text objects */
   else if ((cap->cmdchar == 'a' || cap->cmdchar == 'i')
-           && (cap->oap->op_type != OP_NOP
-               || VIsual_active
-               )) {
+           && (cap->oap->op_type != OP_NOP || VIsual_active)) {
     nv_object(cap);
-  } else if (!curbuf->b_p_ma && !p_im) {
-    /* Only give this error when 'insertmode' is off. */
+  } else if (!curbuf->b_p_ma && !p_im && !curbuf->terminal) {
+    // Only give this error when 'insertmode' is off.
     EMSG(_(e_modifiable));
     clearop(cap->oap);
   } else if (!checkclearopq(cap->oap)) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7420,22 +7420,20 @@ static void nv_esc(cmdarg_T *cap)
     restart_edit = 'a';
 }
 
-/*
- * Handle "A", "a", "I", "i" and <Insert> commands.
- */
+/// Handle "A", "a", "I", "i" and <Insert> commands.
 static void nv_edit(cmdarg_T *cap)
 {
-  /* <Insert> is equal to "i" */
-  if (cap->cmdchar == K_INS || cap->cmdchar == K_KINS)
+  // <Insert> is equal to "i"
+  if (cap->cmdchar == K_INS || cap->cmdchar == K_KINS) {
     cap->cmdchar = 'i';
+  }
 
-  /* in Visual mode "A" and "I" are an operator */
-  if (VIsual_active && (cap->cmdchar == 'A' || cap->cmdchar == 'I'))
+  // in Visual mode "A" and "I" are an operator
+  if (VIsual_active && (cap->cmdchar == 'A' || cap->cmdchar == 'I')) {
     v_visop(cap);
-
-  /* in Visual mode and after an operator "a" and "i" are for text objects */
-  else if ((cap->cmdchar == 'a' || cap->cmdchar == 'i')
-           && (cap->oap->op_type != OP_NOP || VIsual_active)) {
+  // in Visual mode and after an operator "a" and "i" are for text objects
+  } else if ((cap->cmdchar == 'a' || cap->cmdchar == 'i')
+             && (cap->oap->op_type != OP_NOP || VIsual_active)) {
     nv_object(cap);
   } else if (!curbuf->b_p_ma && !p_im && !curbuf->terminal) {
     // Only give this error when 'insertmode' is off.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3994,16 +3994,7 @@ set_num_option (
   /*
    * Number options that need some action when changed
    */
-  if (pp == &p_scbk) {
-    // 'scrollback'
-    if (p_scbk < 1) {
-      errmsg = e_invarg;
-      p_scbk = 0;
-    } else if (p_scbk > 100000) {
-      errmsg = e_invarg;
-      p_scbk = 100000;
-    }
-  } else if (pp == &p_wh || pp == &p_hh) {
+  if (pp == &p_wh || pp == &p_hh) {
     if (p_wh < 1) {
       errmsg = e_positive;
       p_wh = 1;
@@ -4205,7 +4196,19 @@ set_num_option (
     FOR_ALL_TAB_WINDOWS(tp, wp) {
       check_colorcolumn(wp);
     }
-
+  } else if (pp == &curbuf->b_p_scbk) {
+    // 'scrollback'
+    if (!curbuf->terminal) {
+      errmsg = e_invarg;
+      curbuf->b_p_scbk = -1;
+    } else {
+      if (curbuf->b_p_scbk < -1 || curbuf->b_p_scbk > 100000) {
+        errmsg = e_invarg;
+        curbuf->b_p_scbk = 1000;
+      }
+      // Force the scrollback to take effect.
+      terminal_resize(curbuf->terminal, UINT16_MAX, UINT16_MAX);
+    }
   }
 
   /*
@@ -5641,7 +5644,7 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_ai = p_ai;
       buf->b_p_ai_nopaste = p_ai_nopaste;
       buf->b_p_sw = p_sw;
-      buf->b_p_scbk = p_scbk;
+      buf->b_p_scbk = -1;
       buf->b_p_tw = p_tw;
       buf->b_p_tw_nopaste = p_tw_nopaste;
       buf->b_p_tw_nobin = p_tw_nobin;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1,24 +1,18 @@
-/*
- * Code to handle user-settable options. This is all pretty much table-
- * driven. Checklist for adding a new option:
- * - Put it in the options array below (copy an existing entry).
- * - For a global option: Add a variable for it in option_defs.h.
- * - For a buffer or window local option:
- *   - Add a PV_XX entry to the enum below.
- *   - Add a variable to the window or buffer struct in buffer_defs.h.
- *   - For a window option, add some code to copy_winopt().
- *   - For a buffer option, add some code to buf_copy_options().
- *   - For a buffer string option, add code to check_buf_options().
- * - If it's a numeric option, add any necessary bounds checks to do_set().
- * - If it's a list of flags, add some code in do_set(), search for WW_ALL.
- * - When adding an option with expansion (P_EXPAND), but with a different
- *   default for Vi and Vim (no P_VI_DEF), add some code at VIMEXP.
- * - Add documentation!  One line in doc/help.txt, full description in
- *   options.txt, and any other related places.
- * - Add an entry in runtime/optwin.vim.
- * When making changes:
- * - Adjust the help for the option in doc/option.txt.
- */
+// User-settable options. Checklist for adding a new option:
+// - Put it in options.lua
+// - For a global option: Add a variable for it in option_defs.h.
+// - For a buffer or window local option:
+//   - Add a BV_XX or WV_XX entry to option_defs.h
+//   - Add a variable to the window or buffer struct in buffer_defs.h.
+//   - For a window option, add some code to copy_winopt().
+//   - For a buffer option, add some code to buf_copy_options().
+//   - For a buffer string option, add code to check_buf_options().
+// - If it's a numeric option, add any necessary bounds checks to do_set().
+// - If it's a list of flags, add some code in do_set(), search for WW_ALL.
+// - When adding an option with expansion (P_EXPAND), but with a different
+//   default for Vi and Vim (no P_VI_DEF), add some code at VIMEXP.
+// - Add documentation! doc/options.txt, and any other related places.
+// - Add an entry in runtime/optwin.vim.
 
 #define IN_OPTION_C
 #include <assert.h>
@@ -161,6 +155,7 @@ static long p_ts;
 static long p_tw;
 static int p_udf;
 static long p_wm;
+static long p_scbk;
 static char_u   *p_keymap;
 
 /* Saved values for when 'bin' is set. */
@@ -3999,7 +3994,16 @@ set_num_option (
   /*
    * Number options that need some action when changed
    */
-  if (pp == &p_wh || pp == &p_hh) {
+  if (pp == &p_scbk) {
+    // 'scrollback'
+    if (p_scbk < 1) {
+      errmsg = e_invarg;
+      p_scbk = 0;
+    } else if (p_scbk > 100000) {
+      errmsg = e_invarg;
+      p_scbk = 100000;
+    }
+  } else if (pp == &p_wh || pp == &p_hh) {
     if (p_wh < 1) {
       errmsg = e_positive;
       p_wh = 1;
@@ -5426,6 +5430,7 @@ static char_u *get_varp(vimoption_T *p)
   case PV_PI:     return (char_u *)&(curbuf->b_p_pi);
   case PV_QE:     return (char_u *)&(curbuf->b_p_qe);
   case PV_RO:     return (char_u *)&(curbuf->b_p_ro);
+  case PV_SCBK:   return (char_u *)&(curbuf->b_p_scbk);
   case PV_SI:     return (char_u *)&(curbuf->b_p_si);
   case PV_STS:    return (char_u *)&(curbuf->b_p_sts);
   case PV_SUA:    return (char_u *)&(curbuf->b_p_sua);
@@ -5636,6 +5641,7 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_ai = p_ai;
       buf->b_p_ai_nopaste = p_ai_nopaste;
       buf->b_p_sw = p_sw;
+      buf->b_p_scbk = p_scbk;
       buf->b_p_tw = p_tw;
       buf->b_p_tw_nopaste = p_tw_nopaste;
       buf->b_p_tw_nobin = p_tw_nobin;

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -739,6 +739,7 @@ enum {
   , BV_PI
   , BV_QE
   , BV_RO
+  , BV_SCBK
   , BV_SI
   , BV_SMC
   , BV_SYN

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1913,6 +1913,14 @@ return {
       defaults={if_true={vi=12}}
     },
     {
+      full_name='scrollback', abbreviation='scbk',
+      type='number', scope={'buffer'},
+      vi_def=true,
+      varname='p_scbk',
+      redraw={'current_buffer'},
+      defaults={if_true={vi=1000}}
+    },
+    {
       full_name='scrollbind', abbreviation='scb',
       type='bool', scope={'window'},
       vi_def=true,

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1918,7 +1918,7 @@ return {
       vi_def=true,
       varname='p_scbk',
       redraw={'current_buffer'},
-      defaults={if_true={vi=1000}}
+      defaults={if_true={vi=-1}}
     },
     {
       full_name='scrollbind', abbreviation='scb',

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7113,8 +7113,9 @@ void showruler(int always)
   }
   if ((*p_stl != NUL || *curwin->w_p_stl != NUL) && curwin->w_status_height) {
     redraw_custom_statusline(curwin);
-  } else
+  } else {
     win_redr_ruler(curwin, always);
+  }
 
   if (need_maketitle
       || (p_icon && (stl_syntax & STL_IN_ICON))

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -237,12 +237,16 @@ Terminal *terminal_open(TerminalOptions opts)
   rv->invalid_end = opts.height;
   refresh_screen(rv, curbuf);
   set_option_value((uint8_t *)"buftype", 0, (uint8_t *)"terminal", OPT_LOCAL);
+
   // some sane settings for terminal buffers
+  curbuf->b_p_ma = false;   // 'nomodifiable'
+  curbuf->b_p_ul = -1;      // disable undo
   set_option_value((uint8_t *)"wrap", false, NULL, OPT_LOCAL);
   set_option_value((uint8_t *)"number", false, NULL, OPT_LOCAL);
   set_option_value((uint8_t *)"relativenumber", false, NULL, OPT_LOCAL);
   buf_set_term_title(curbuf, (char *)curbuf->b_ffname);
   RESET_BINDING(curwin);
+
   // Apply TermOpen autocmds so the user can configure the terminal
   apply_autocmds(EVENT_TERMOPEN, NULL, NULL, false, curbuf);
 
@@ -958,7 +962,7 @@ static void refresh_terminal(Terminal *term)
   buf_T *buf = handle_get_buffer(term->buf_handle);
   bool valid = true;
   if (!buf || !(valid = buf_valid(buf))) {
-    // destroyed by `close_buffer`. Dont do anything else
+    // Destroyed by `close_buffer`. Do not do anything else.
     if (!valid) {
       term->buf_handle = 0;
     }
@@ -1039,7 +1043,7 @@ static void refresh_scrollback(Terminal *term, buf_T *buf)
   }
 }
 
-// Refresh the screen(visible part of the buffer when the terminal is
+// Refresh the screen (visible part of the buffer when the terminal is
 // focused) of a invalidated terminal
 static void refresh_screen(Terminal *term, buf_T *buf)
 {

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1126,14 +1126,6 @@ static void redraw(bool restore_cursor)
     update_screen(0);
   }
 
-  redraw_statuslines();
-
-  if (need_maketitle) {
-    maketitle();
-  }
-
-  showruler(false);
-
   if (term && is_focused(term)) {
     curwin->w_wrow = term->cursor.row;
     curwin->w_wcol = term->cursor.col + win_col_off(curwin);

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -308,8 +308,9 @@ bool undo_allowed(void)
 /// Get the 'undolevels' value for the current buffer.
 static long get_undolevel(void)
 {
-  if (curbuf->b_p_ul == NO_LOCAL_UNDOLEVEL)
+  if (curbuf->b_p_ul == NO_LOCAL_UNDOLEVEL) {
     return p_ul;
+  }
   return curbuf->b_p_ul;
 }
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -305,14 +305,9 @@ bool undo_allowed(void)
   return true;
 }
 
-/*
- * Get the undolevle value for the current buffer.
- */
+/// Get the 'undolevels' value for the current buffer.
 static long get_undolevel(void)
 {
-  if (curbuf->terminal) {
-    return -1;
-  }
   if (curbuf->b_p_ul == NO_LOCAL_UNDOLEVEL)
     return p_ul;
   return curbuf->b_p_ul;

--- a/test/functional/terminal/edit_spec.lua
+++ b/test/functional/terminal/edit_spec.lua
@@ -31,45 +31,40 @@ describe(':edit term://*', function()
     eq(termopen_runs[1], termopen_runs[1]:match('^term://.//%d+:$'))
   end)
 
-  it('runs TermOpen early enough to respect terminal_scrollback_buffer_size', function()
+  it("runs TermOpen early enough to set buffer-local 'scrollback'", function()
     local columns, lines = 20, 4
     local scr = get_screen(columns, lines)
     local rep = 'a'
     meths.set_option('shellcmdflag', 'REP ' .. rep)
-    local rep_size = rep:byte()
+    local rep_size = rep:byte()  -- 'a' => 97
     local sb = 10
-    local gsb = 20
-    meths.set_var('terminal_scrollback_buffer_size', gsb)
-    command('autocmd TermOpen * :let b:terminal_scrollback_buffer_size = '
-            .. tostring(sb))
+    command('autocmd TermOpen * :setlocal scrollback='..tostring(sb))
     command('edit term://foobar')
+
     local bufcontents = {}
     local winheight = curwinmeths.get_height()
-    -- I have no idea why there is + 4 needed. But otherwise it works fine with
-    -- different scrollbacks.
-    local shift = -4
-    local buf_cont_start = rep_size - 1 - sb - winheight - shift
-    local bufline = function(i) return ('%d: foobar'):format(i) end
+    local buf_cont_start = rep_size - sb - winheight + 2
+    local function bufline (i)
+      return ('%d: foobar'):format(i)
+    end
     for i = buf_cont_start,(rep_size - 1) do
       bufcontents[#bufcontents + 1] = bufline(i)
     end
     bufcontents[#bufcontents + 1] = ''
     bufcontents[#bufcontents + 1] = '[Process exited 0]'
-    -- Do not ask me why displayed screen is one line *before* buffer
-    -- contents: buffer starts with 87:, screen with 86:.
+
     local exp_screen = '\n'
-    local did_cursor = false
-    for i = 0,(winheight - 1) do
-      local line = bufline(buf_cont_start + i - 1)
+    for i = 1,(winheight - 1) do
+      local line = bufcontents[#bufcontents - winheight + i]
       exp_screen = (exp_screen
-                    .. (did_cursor and '' or '^')
                     .. line
                     .. (' '):rep(columns - #line)
                     .. '|\n')
-      did_cursor = true
     end
-    exp_screen = exp_screen .. (' '):rep(columns) .. '|\n'
+    exp_screen = exp_screen..'^[Process exited 0]  |\n'
+
+    exp_screen = exp_screen..(' '):rep(columns)..'|\n'
     scr:expect(exp_screen)
-    eq(bufcontents, curbufmeths.get_lines(1, -1, true))
+    eq(bufcontents, curbufmeths.get_lines(0, -1, true))
   end)
 end)

--- a/test/functional/terminal/edit_spec.lua
+++ b/test/functional/terminal/edit_spec.lua
@@ -38,7 +38,8 @@ describe(':edit term://*', function()
     meths.set_option('shellcmdflag', 'REP ' .. rep)
     local rep_size = rep:byte()  -- 'a' => 97
     local sb = 10
-    command('autocmd TermOpen * :setlocal scrollback='..tostring(sb))
+    command('autocmd TermOpen * :setlocal scrollback='..tostring(sb)
+            ..'|call feedkeys("G", "n")')
     command('edit term://foobar')
 
     local bufcontents = {}

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -36,6 +36,18 @@ describe(':terminal', function()
     ]])
   end)
 
+  it("in normal-mode :split does not move cursor", function()
+    execute([[terminal while true; do echo foo; sleep .1; done]])
+    helpers.feed([[<C-\><C-N>M]])  -- move cursor away from last line
+    wait()
+    eq(3, eval("line('$')"))  -- window height
+    eq(2, eval("line('.')"))  -- cursor is in the middle
+    execute('vsplit')
+    eq(2, eval("line('.')"))  -- cursor stays where we put it
+    execute('split')
+    eq(2, eval("line('.')"))  -- cursor stays where we put it
+  end)
+
 end)
 
 describe(':terminal (with fake shell)', function()

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -20,22 +20,18 @@ describe(':terminal', function()
     source([[
       echomsg "msg1"
       echomsg "msg2"
+      echomsg "msg3"
     ]])
     -- Invoke a command that emits frequent terminal activity.
     execute([[terminal while true; do echo X; done]])
     helpers.feed([[<C-\><C-N>]])
-    screen:expect([[
-      X                                                 |
-      X                                                 |
-      ^X                                                 |
-                                                        |
-    ]])
+    wait()
     helpers.sleep(10)  -- Let some terminal activity happen.
     execute("messages")
     screen:expect([[
-      X                                                 |
       msg1                                              |
       msg2                                              |
+      msg3                                              |
       Press ENTER or type command to continue^           |
     ]])
   end)

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -37,7 +37,6 @@ local default_command = '["'..nvim_dir..'/tty-test'..'"]'
 local function screen_setup(extra_height, command)
   nvim('command', 'highlight TermCursor cterm=reverse')
   nvim('command', 'highlight TermCursorNC ctermbg=11')
-  nvim('set_var', 'terminal_scrollback_buffer_size', 10)
   if not extra_height then extra_height = 0 end
   if not command then command = default_command end
   local screen = Screen.new(50, 7 + extra_height)
@@ -58,7 +57,9 @@ local function screen_setup(extra_height, command)
   -- tty-test puts the terminal into raw mode and echoes all input. tests are
   -- done by feeding it with terminfo codes to control the display and
   -- verifying output with screen:expect.
-  execute('enew | call termopen('..command..') | startinsert')
+  execute('enew | call termopen('..command..')')
+  execute('setlocal scrollback=10')
+  execute('startinsert')
   if command == default_command then
     -- wait for "tty ready" to be printed before each test or the terminal may
     -- still be in canonical mode(will echo characters for example)

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -17,7 +17,7 @@ describe('terminal scrollback', function()
 
   before_each(function()
     clear()
-    screen = thelpers.screen_setup()
+    screen = thelpers.screen_setup(nil, nil, 30)
   end)
 
   after_each(function()
@@ -33,26 +33,26 @@ describe('terminal scrollback', function()
       table.insert(lines, '')
       feed_data(lines)
       screen:expect([[
-        line26                                            |
-        line27                                            |
-        line28                                            |
-        line29                                            |
-        line30                                            |
-        {1: }                                                 |
-        {3:-- TERMINAL --}                                    |
+        line26                        |
+        line27                        |
+        line28                        |
+        line29                        |
+        line30                        |
+        {1: }                             |
+        {3:-- TERMINAL --}                |
       ]])
     end)
 
     it('will delete extra lines at the top', function()
       feed('<c-\\><c-n>gg')
       screen:expect([[
-        ^line16                                            |
-        line17                                            |
-        line18                                            |
-        line19                                            |
-        line20                                            |
-        line21                                            |
-                                                          |
+        ^line16                        |
+        line17                        |
+        line18                        |
+        line19                        |
+        line20                        |
+        line21                        |
+                                      |
       ]])
     end)
   end)
@@ -61,13 +61,13 @@ describe('terminal scrollback', function()
     before_each(function()
       feed_data({'line1', 'line2', 'line3', 'line4', ''})
       screen:expect([[
-        tty ready                                         |
-        line1                                             |
-        line2                                             |
-        line3                                             |
-        line4                                             |
-        {1: }                                                 |
-        {3:-- TERMINAL --}                                    |
+        tty ready                     |
+        line1                         |
+        line2                         |
+        line3                         |
+        line4                         |
+        {1: }                             |
+        {3:-- TERMINAL --}                |
       ]])
     end)
 
@@ -76,13 +76,13 @@ describe('terminal scrollback', function()
 
       it('will hide the top line', function()
         screen:expect([[
-          line1                                             |
-          line2                                             |
-          line3                                             |
-          line4                                             |
-          line5                                             |
-          {1: }                                                 |
-          {3:-- TERMINAL --}                                    |
+          line1                         |
+          line2                         |
+          line3                         |
+          line4                         |
+          line5                         |
+          {1: }                             |
+          {3:-- TERMINAL --}                |
         ]])
         eq(7, curbuf('line_count'))
       end)
@@ -92,46 +92,46 @@ describe('terminal scrollback', function()
 
         it('will hide the top 4 lines', function()
           screen:expect([[
-            line3                                             |
-            line4                                             |
-            line5                                             |
-            line6                                             |
-            line7                                             |
-            line8{1: }                                            |
-            {3:-- TERMINAL --}                                    |
+            line3                         |
+            line4                         |
+            line5                         |
+            line6                         |
+            line7                         |
+            line8{1: }                        |
+            {3:-- TERMINAL --}                |
           ]])
 
           feed('<c-\\><c-n>6k')
           screen:expect([[
-            ^line2                                             |
-            line3                                             |
-            line4                                             |
-            line5                                             |
-            line6                                             |
-            line7                                             |
-                                                              |
+            ^line2                         |
+            line3                         |
+            line4                         |
+            line5                         |
+            line6                         |
+            line7                         |
+                                          |
           ]])
 
           feed('gg')
           screen:expect([[
-            ^tty ready                                         |
-            line1                                             |
-            line2                                             |
-            line3                                             |
-            line4                                             |
-            line5                                             |
-                                                              |
+            ^tty ready                     |
+            line1                         |
+            line2                         |
+            line3                         |
+            line4                         |
+            line5                         |
+                                          |
           ]])
 
           feed('G')
           screen:expect([[
-            line3                                             |
-            line4                                             |
-            line5                                             |
-            line6                                             |
-            line7                                             |
-            ^line8{2: }                                            |
-                                                              |
+            line3                         |
+            line4                         |
+            line5                         |
+            line6                         |
+            line7                         |
+            ^line8{2: }                        |
+                                          |
           ]])
         end)
       end)
@@ -142,12 +142,12 @@ describe('terminal scrollback', function()
       local function will_hide_top_line()
         screen:try_resize(screen._width, screen._height - 1)
         screen:expect([[
-          line2                                             |
-          line3                                             |
-          line4                                             |
-          rows: 5, cols: 50                                 |
-          {1: }                                                 |
-          {3:-- TERMINAL --}                                    |
+          line2                         |
+          line3                         |
+          line4                         |
+          rows: 5, cols: 30             |
+          {1: }                             |
+          {3:-- TERMINAL --}                |
         ]])
       end
 
@@ -161,18 +161,18 @@ describe('terminal scrollback', function()
 
         it('will hide the top 3 lines', function()
           screen:expect([[
-            rows: 5, cols: 50                                 |
-            rows: 3, cols: 50                                 |
-            {1: }                                                 |
-            {3:-- TERMINAL --}                                    |
+            rows: 5, cols: 30             |
+            rows: 3, cols: 30             |
+            {1: }                             |
+            {3:-- TERMINAL --}                |
           ]])
           eq(8, curbuf('line_count'))
           feed('<c-\\><c-n>3k')
           screen:expect([[
-            ^line4                                             |
-            rows: 5, cols: 50                                 |
-            rows: 3, cols: 50                                 |
-                                                              |
+            ^line4                         |
+            rows: 5, cols: 30             |
+            rows: 3, cols: 30             |
+                                          |
           ]])
         end)
       end)
@@ -187,11 +187,11 @@ describe('terminal scrollback', function()
 
       local function will_delete_last_two_lines()
         screen:expect([[
-          tty ready                                         |
-          rows: 4, cols: 50                                 |
-          {1: }                                                 |
-                                                            |
-          {3:-- TERMINAL --}                                    |
+          tty ready                     |
+          rows: 4, cols: 30             |
+          {1: }                             |
+                                        |
+          {3:-- TERMINAL --}                |
         ]])
         eq(4, curbuf('line_count'))
       end
@@ -206,25 +206,25 @@ describe('terminal scrollback', function()
 
         it('will delete the last line and hide the first', function()
           screen:expect([[
-            rows: 4, cols: 50                                 |
-            rows: 3, cols: 50                                 |
-            {1: }                                                 |
-            {3:-- TERMINAL --}                                    |
+            rows: 4, cols: 30             |
+            rows: 3, cols: 30             |
+            {1: }                             |
+            {3:-- TERMINAL --}                |
           ]])
           eq(4, curbuf('line_count'))
           feed('<c-\\><c-n>gg')
           screen:expect([[
-            ^tty ready                                         |
-            rows: 4, cols: 50                                 |
-            rows: 3, cols: 50                                 |
-                                                              |
+            ^tty ready                     |
+            rows: 4, cols: 30             |
+            rows: 3, cols: 30             |
+                                          |
           ]])
           feed('a')
           screen:expect([[
-            rows: 4, cols: 50                                 |
-            rows: 3, cols: 50                                 |
-            {1: }                                                 |
-            {3:-- TERMINAL --}                                    |
+            rows: 4, cols: 30             |
+            rows: 3, cols: 30             |
+            {1: }                             |
+            {3:-- TERMINAL --}                |
           ]])
         end)
       end)
@@ -235,20 +235,20 @@ describe('terminal scrollback', function()
     before_each(function()
       feed_data({'line1', 'line2', 'line3', 'line4', ''})
       screen:expect([[
-        tty ready                                         |
-        line1                                             |
-        line2                                             |
-        line3                                             |
-        line4                                             |
-        {1: }                                                 |
-        {3:-- TERMINAL --}                                    |
+        tty ready                     |
+        line1                         |
+        line2                         |
+        line3                         |
+        line4                         |
+        {1: }                             |
+        {3:-- TERMINAL --}                |
       ]])
       screen:try_resize(screen._width, screen._height - 3)
       screen:expect([[
-        line4                                             |
-        rows: 3, cols: 50                                 |
-        {1: }                                                 |
-        {3:-- TERMINAL --}                                    |
+        line4                         |
+        rows: 3, cols: 30             |
+        {1: }                             |
+        {3:-- TERMINAL --}                |
       ]])
       eq(7, curbuf('line_count'))
     end)
@@ -257,11 +257,11 @@ describe('terminal scrollback', function()
       local function pop_then_push()
         screen:try_resize(screen._width, screen._height + 1)
         screen:expect([[
-          line4                                             |
-          rows: 3, cols: 50                                 |
-          rows: 4, cols: 50                                 |
-          {1: }                                                 |
-          {3:-- TERMINAL --}                                    |
+          line4                         |
+          rows: 3, cols: 30             |
+          rows: 4, cols: 30             |
+          {1: }                             |
+          {3:-- TERMINAL --}                |
         ]])
       end
 
@@ -276,26 +276,26 @@ describe('terminal scrollback', function()
 
         local function pop3_then_push1()
           screen:expect([[
-            line2                                             |
-            line3                                             |
-            line4                                             |
-            rows: 3, cols: 50                                 |
-            rows: 4, cols: 50                                 |
-            rows: 7, cols: 50                                 |
-            {1: }                                                 |
-            {3:-- TERMINAL --}                                    |
+            line2                         |
+            line3                         |
+            line4                         |
+            rows: 3, cols: 30             |
+            rows: 4, cols: 30             |
+            rows: 7, cols: 30             |
+            {1: }                             |
+            {3:-- TERMINAL --}                |
           ]])
           eq(9, curbuf('line_count'))
           feed('<c-\\><c-n>gg')
           screen:expect([[
-            ^tty ready                                         |
-            line1                                             |
-            line2                                             |
-            line3                                             |
-            line4                                             |
-            rows: 3, cols: 50                                 |
-            rows: 4, cols: 50                                 |
-                                                              |
+            ^tty ready                     |
+            line1                         |
+            line2                         |
+            line3                         |
+            line4                         |
+            rows: 3, cols: 30             |
+            rows: 4, cols: 30             |
+                                          |
           ]])
         end
 
@@ -310,18 +310,18 @@ describe('terminal scrollback', function()
 
           it('will show all lines and leave a blank one at the end', function()
             screen:expect([[
-              tty ready                                         |
-              line1                                             |
-              line2                                             |
-              line3                                             |
-              line4                                             |
-              rows: 3, cols: 50                                 |
-              rows: 4, cols: 50                                 |
-              rows: 7, cols: 50                                 |
-              rows: 11, cols: 50                                |
-              {1: }                                                 |
-                                                                |
-              {3:-- TERMINAL --}                                    |
+              tty ready                     |
+              line1                         |
+              line2                         |
+              line3                         |
+              line4                         |
+              rows: 3, cols: 30             |
+              rows: 4, cols: 30             |
+              rows: 7, cols: 30             |
+              rows: 11, cols: 30            |
+              {1: }                             |
+                                            |
+              {3:-- TERMINAL --}                |
             ]])
             -- since there's an empty line after the cursor, the buffer line
             -- count equals the terminal screen height
@@ -336,29 +336,29 @@ end)
 describe('terminal prints more lines than the screen height and exits', function()
   it('will push extra lines to scrollback', function()
     clear()
-    local screen = Screen.new(50, 7)
+    local screen = Screen.new(30, 7)
     screen:attach({rgb=false})
     execute('call termopen(["'..nvim_dir..'/tty-test", "10"]) | startinsert')
     wait()
     screen:expect([[
-      line6                                             |
-      line7                                             |
-      line8                                             |
-      line9                                             |
-                                                        |
-      [Process exited 0]                                |
-      -- TERMINAL --                                    |
+      line6                         |
+      line7                         |
+      line8                         |
+      line9                         |
+                                    |
+      [Process exited 0]            |
+      -- TERMINAL --                |
     ]])
     feed('<cr>')
     -- closes the buffer correctly after pressing a key
     screen:expect([[
-      ^                                                  |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-      ~                                                 |
-                                                        |
+      ^                              |
+      ~                             |
+      ~                             |
+      ~                             |
+      ~                             |
+      ~                             |
+                                    |
     ]])
   end)
 end)

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -28,12 +28,12 @@ describe('terminal', function()
     feed('<c-\\><c-n>')
     execute('2split')
     screen:expect([[
-      tty ready                                         |
-      ^rows: 2, cols: 50                                 |
+      rows: 2, cols: 50                                 |
+      {2:^ }                                                 |
       ==========                                        |
-      tty ready                                         |
       rows: 2, cols: 50                                 |
       {2: }                                                 |
+      {4:~                                                 }|
       {4:~                                                 }|
       {4:~                                                 }|
       ==========                                        |
@@ -54,12 +54,12 @@ describe('terminal', function()
     ]])
     execute('wincmd p')
     screen:expect([[
-      rows: 5, cols: 50                                 |
-      ^rows: 2, cols: 50                                 |
+      rows: 2, cols: 50                                 |
+      {2:^ }                                                 |
       ==========                                        |
-      rows: 5, cols: 50                                 |
       rows: 2, cols: 50                                 |
       {2: }                                                 |
+      {4:~                                                 }|
       {4:~                                                 }|
       {4:~                                                 }|
       ==========                                        |

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -207,7 +207,9 @@ local function check_cores(app)
     out:write(('\nTests covered by this check: %u\n'):format(tests_skipped + 1))
   end
   tests_skipped = 0
-  assert(0 == found_cores)
+  if found_cores > 0 then
+    error("crash detected (see above)")
+  end
 end
 
 return {


### PR DESCRIPTION
Closes #2637. 

- Will crash if *all* lines are deleted. 
    - It's difficult to support line deletions, because scrollback is received passively from libvterm. Instead, one can safely and correctly "delete" lines by temporarily setting 'scrollback' option to a smaller value.

References #2607
References #2637
References #5431