### PR TITLE
[RFC] man.vim: use 'eventignore' instead of noautocmd

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -46,11 +46,13 @@ function! man#open_page(count, count1, mods, ...) abort
 
   call s:push_tag()
   let bufname = 'man://'.name.(empty(sect)?'':'('.sect.')')
+  set eventignore+=BufReadCmd
   if a:mods !~# 'tab' && s:find_man()
-    noautocmd execute 'silent edit' fnameescape(bufname)
+    execute 'silent edit' fnameescape(bufname)
   else
-    noautocmd execute 'silent' a:mods 'split' fnameescape(bufname)
+    execute 'silent' a:mods 'split' fnameescape(bufname)
   endif
+  set eventignore-=BufReadCmd
 
   try
     let page = s:get_page(path)
@@ -70,12 +72,14 @@ endfunction
 function! man#read_page(ref) abort
   try
     let [sect, name] = man#extract_sect_and_name_ref(a:ref)
-    let [b:man_sect, name, path] = s:verify_exists(sect, name)
+    let [sect, name, path] = s:verify_exists(sect, name)
     let page = s:get_page(path)
   catch
-    " call to s:error() is unnecessary
+    " call to s:error() does nothing because we were
+    " called from the BufReadCmd autocmd.
     return
   endtry
+  let b:man_sect = sect
   call s:put_page(page)
 endfunction
 

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -208,15 +208,20 @@ g8			Print the hex values of the bytes used in the
 
 						  *:terminal* *:te*
 :te[rminal][!] {cmd}	Execute {cmd} with 'shell' in a |terminal-emulator|
-                        buffer.  Equivalent to: >
-			      :enew
-			      :call termopen('{cmd}')
-			      :startinsert
+			buffer.  Equivalent to: >
+				:enew
+				:call termopen('{cmd}')
+				:startinsert
 <
-                        See |jobstart()|.
+			See |jobstart()|.
 
-			To enter terminal mode automatically: >
-			      autocmd BufEnter term://* startinsert
+			To enter terminal mode automatically:
+>
+				augroup terminal_insert
+				    autocmd!
+				    autocmd BufEnter term://* startinsert
+				    autocmd BufLeave term://* stopinsert
+				augroup END
 <
 							*:!cmd* *:!* *E34*
 :!{cmd}			Execute {cmd} with 'shell'. See also |:terminal|.


### PR DESCRIPTION
Fixes #6144

I also updated the automatic terminal mode autocmd docs to also use BufLeave.