### PR TITLE
vim-patch:8.0.0341

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3001,6 +3001,9 @@ static void ins_compl_addleader(int c)
 {
   int cc;
 
+  if (stop_arrow() == FAIL) {
+        return;
+  }
   if (has_mbyte && (cc = (*mb_char2len)(c)) > 1) {
     char_u buf[MB_MAXBYTES + 1];
 

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -482,4 +482,24 @@ func Test_completion_ctrl_e_without_autowrap()
   q!
 endfunc
 
+func CompleteUndo() abort
+  call complete(1, g:months)
+  return ''
+endfunc
+
+func Test_completion_can_undo()
+  inoremap <Right> <c-r>=CompleteUndo()<cr>
+  set completeopt+=noinsert,noselect
+
+  new
+  call feedkeys("a\<Right>a\<Esc>", 'xt')
+  call assert_equal('a', getline(1))
+  undo
+  call assert_equal('', getline(1))
+
+  bwipe!
+  set completeopt&
+  iunmap <Right>
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    When using complete() and typing a character undo is saved after
            the character was inserted. (Shougo)
Solution:   Save for undo before inserting the character.

https://github.com/vim/vim/commit/d56a79d3396cf70861b7f739a3c400db91ce7b70

Note:  It fixes https://github.com/Shougo/deoplete.nvim/issues/433 problem