### PR TITLE
terminal: Fix terminal color to "correct" black color

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -174,7 +174,7 @@ void terminal_init(void)
   VTerm *vt = vterm_new(24, 80);
   VTermState *state = vterm_obtain_state(vt);
 
-  for (int color_index = 0; color_index < 256; color_index++) {
+  for (int color_index = 255; color_index >= 0; color_index--) {
     VTermColor color;
     // Some of the default 16 colors has the same color as the later
     // 240 colors. To avoid collisions, we will use the custom colors


### PR DESCRIPTION
LeoNerd on Gitter:
> please change this line to for(int color_index = 255; color_index >= 0; color_index--) so you'll find the "correct" black

Ref:
- https://github.com/neovim/neovim/issues/3601
- https://github.com/neovim/neovim/issues/3601#issue-115098903

---

I don't know it's correct, but LeoNerd is an author of libvterm, so I guess that's correct.
What do you think?