### PR TITLE
[RDY] Don't redraw the entire screen when resizing term windows

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4848,7 +4848,7 @@ void scroll_to_fraction(win_T *wp, int prev_height)
 
   if (wp->w_buffer->terminal) {
     terminal_resize(wp->w_buffer->terminal, 0, wp->w_height);
-    redraw_win_later(wp, CLEAR);
+    redraw_win_later(wp, NOT_VALID);
   }
 }
 
@@ -4872,7 +4872,6 @@ void win_new_width(win_T *wp, int width)
     if (wp->w_height != 0) {
       terminal_resize(wp->w_buffer->terminal, wp->w_width, 0);
     }
-    redraw_win_later(wp, CLEAR);
   }
 }
 

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -117,7 +117,7 @@ describe('terminal mouse', function()
           rows: 5, cols: 25        |rows: 5, cols: 25       |
           {2:^ }                        |{2: }                       |
           ==========                ==========              |
-                                                            |
+          :vsp                                              |
         ]])
         feed(':enew | set number<cr>')
         screen:expect([[

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -37,7 +37,7 @@ describe('terminal', function()
       {4:~                                                 }|
       {4:~                                                 }|
       ==========                                        |
-                                                        |
+      :2split                                           |
     ]])
     execute('wincmd p')
     screen:expect([[


### PR DESCRIPTION
This prevents the screen from redrawing/flickering when a terminal buffer is resized.

I'd also like to look into the lines being truncated when the width changes, but I'm not familiar enough with what's going on yet.  Keeping the width fixed at 999 like suggested in #5506 works well, but fullscreen programs like `top` won't be sized correctly.  Shouldn't it be as simple as retaining the lines that weren't actually changed in libvterm instead of truncating the lines to the current window width?