### PR TITLE
ci: MIN_LOG_LEVEL=2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
                    -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PREFIX
                    -DBUSTED_OUTPUT_TYPE=gtest
                    -DDEPS_PREFIX=$DEPS_BUILD_DIR/usr
-                   -DMIN_LOG_LEVEL=0"
+                   -DMIN_LOG_LEVEL=2"
     - DEPS_CMAKE_FLAGS="-DDEPS_DOWNLOAD_DIR:PATH=$DEPS_DOWNLOAD_DIR"
     # Additional CMake flags for 32-bit builds.
     - CMAKE_FLAGS_32BIT="-DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,11 +439,11 @@ install_helper(
 # MIN_LOG_LEVEL for log.h
 if(DEFINED MIN_LOG_LEVEL)
   if(NOT MIN_LOG_LEVEL MATCHES "^[0-3]$")
-    message(FATAL_ERROR "MIN_LOG_LEVEL must be a number DEBUG (0), INFO (1), WARNING (2) or ERROR (3)")
+    message(FATAL_ERROR "MIN_LOG_LEVEL must be a number 0-3")
   endif()
-  message(STATUS "Log level set to ${MIN_LOG_LEVEL}")
+  message(STATUS "MIN_LOG_LEVEL set to ${MIN_LOG_LEVEL}")
 else()
-  message(STATUS "Log level not specified, defaulting to INFO(1)")
+  message(STATUS "MIN_LOG_LEVEL not specified, defaulting to INFO(1)")
 endif()
 
 # Go down the tree.


### PR DESCRIPTION
DEBUG_LOG_LEVEL is very noisy and causes a lot of disk activity.
It is not needed on CI.

See https://github.com/travis-ci/travis-ci/issues/7185