### PR TITLE
[RFC] test: explicitly set 'shell' to sh

### DIFF
--- a/test/functional/eval/server_spec.lua
+++ b/test/functional/eval/server_spec.lua
@@ -5,7 +5,9 @@ local clear, funcs, meths = helpers.clear, helpers.funcs, helpers.meths
 local os_name = helpers.os_name
 
 describe('serverstart(), serverstop()', function()
-  before_each(clear)
+  before_each(function()
+    clear({env={NVIM_LISTEN_ADDRESS=nil}})
+  end)
 
   it('sets $NVIM_LISTEN_ADDRESS on first invocation', function()
     -- Unset $NVIM_LISTEN_ADDRESS

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -178,11 +178,11 @@ describe('system()', function()
 
   describe('passing no input', function()
     it('returns the program output', function()
-      eq("echoed", eval('system("echo -n echoed")'))
+      eq("echoed", eval('system("printf echoed")'))
     end)
     it('to backgrounded command does not crash', function()
       -- This is indeterminate, just exercise the codepath. May get E5677.
-      execute('call system("echo -n echoed &")')
+      execute('call system("printf echoed &")')
       local v_errnum = string.match(eval("v:errmsg"), "^E%d*:")
       if v_errnum then
         eq("E5677:", v_errnum)

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -21,7 +21,7 @@ local start_dir = lfs.currentdir()
 -- XXX: NVIM_PROG takes precedence, QuickBuild sets it.
 local nvim_prog = os.getenv('NVIM_PROG') or os.getenv('NVIM_PRG') or 'build/bin/nvim'
 local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
-                   '--cmd', 'set shortmess+=I background=light noswapfile noautoindent laststatus=1 undodir=. directory=. viewdir=. backupdir=.',
+                   '--cmd', 'set shell=sh shortmess+=I background=light noswapfile noautoindent laststatus=1 undodir=. directory=. viewdir=. backupdir=.',
                    '--embed'}
 
 local mpack = require('mpack')

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -8,7 +8,7 @@ describe("shell command :!", function()
   before_each(function()
     session.clear()
     screen = child_session.screen_setup(0, '["'..session.nvim_prog..
-      '", "-u", "NONE", "-i", "NONE", "--cmd", "set noswapfile"]')
+      '", "-u", "NONE", "-i", "NONE", "--cmd", "set noswapfile shell=sh"]')
     screen:expect([[
       {1: }                                                 |
       {4:~                                                 }|


### PR DESCRIPTION
Though, as described in https://github.com/neovim/neovim/issues/6172#issuecomment-282515960 this still has issues.

This will probably need to be updated for windows too. See https://github.com/neovim/neovim/issues/6172#issuecomment-282442579