### PR TITLE
[RFC] vim-patch:8.0.0379

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -801,8 +801,8 @@ static int insert_handle_key(InsertState *s)
       goto normalchar;                // insert CTRL-Z as normal char
     }
     do_cmdline_cmd("stop");
-    s->c = Ctrl_O;
-  // FALLTHROUGH
+    ui_cursor_shape();  // may need to update cursor shape
+    break;
 
   case Ctrl_O:        // execute one command
     if (ctrl_x_mode == CTRL_X_OMNI) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2696,8 +2696,6 @@ do_mouse (
   else if (((mod_mask & MOD_MASK_CTRL)
             || (mod_mask & MOD_MASK_MULTI_CLICK) == MOD_MASK_2CLICK)
            && bt_quickfix(curbuf)) {
-    if (State & INSERT)
-      stuffcharReadbuff(Ctrl_O);
     if (curwin->w_llist_ref == NULL) {          // quickfix window
       do_cmdline_cmd(".cc");
     } else {                                    // location list window


### PR DESCRIPTION
#### vim-patch:8.0.0379

Problem:    CTRL-Z and mouse click use CTRL-O unnecessary.
Solution:   Remove stuffing CTRL-O. (James McCoy, closes vim/vim#1453)

https://github.com/vim/vim/commit/74a47162a07fddb532f4bead212f6c80ef474ae7