### PR TITLE
Fix a problem when filtering manually folded lines

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1438,13 +1438,16 @@ static void foldMarkAdjustRecurse(garray_T *gap, linenr_T line1, linenr_T line2,
         } else {
           /* 5. fold is below line1 and contains line2; need to
            * correct nested folds too */
-          foldMarkAdjustRecurse(&fp->fd_nested, line1 - fp->fd_top,
-              line2 - fp->fd_top, amount,
-              amount_after + (fp->fd_top - top));
           if (amount == MAXLNUM) {
+            foldMarkAdjustRecurse(&fp->fd_nested, line1 - fp->fd_top,
+                                  line2 - fp->fd_top, amount,
+                                  amount_after + (fp->fd_top - top));
             fp->fd_len -= line2 - fp->fd_top + 1;
             fp->fd_top = line1;
           } else {
+            foldMarkAdjustRecurse(&fp->fd_nested, line1 - fp->fd_top,
+                                  line2 - fp->fd_top, amount,
+                                  amount_after - amount);
             fp->fd_len += amount_after - amount;
             fp->fd_top += amount;
           }

--- a/test/functional/normal/fold_spec.lua
+++ b/test/functional/normal/fold_spec.lua
@@ -1,0 +1,47 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local insert = helpers.insert
+local feed = helpers.feed
+local expect = helpers.expect
+local execute = helpers.execute
+
+describe('Folds', function()
+  clear()
+  it('manual folding adjusts with filter', function()
+    insert([[
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
+    9
+    10
+    11
+    12
+    13
+    14
+    15
+    16
+    17
+    18
+    19
+    20]])
+    execute('4,$fold', '%foldopen', '10,$fold', '%foldopen')
+    execute('1,8! cat')
+    feed('5ggzdzMGdd')
+    expect([[
+    1
+    2
+    3
+    4
+    5
+    6
+    7
+    8
+    9]])
+  end)
+end)


### PR DESCRIPTION
When `foldMarkAdjustRecurse()` is called to adjust folds that start inside
the range of lines that are being moved and end outside that range, it
calculates `amount_after` for its recursive call incorrectly.
The calculation assumes that folds inside the changed range are being
deleted, but this is not always the case.

This means nested folds that start after the changed range of lines are
shifted an incorrect amount.

We fix this by calculating the `amount_after` differently if the folds
inside the changed range are not being deleted.