### PR TITLE
[WIP] Variable signcolumn

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4928,26 +4928,23 @@ linenr_T buf_change_sign_type(
 }
 
 
-/// @param sign where to start
-/// @param lnum 
-/// @param type SIGN_ICON, SIGN_TEXT, SIGN_ANY, SIGN_LINEHL
+/// @param sign item to start searching from
+/// @param lnum line number
+/// @param type one of SIGN_ICON, SIGN_TEXT, SIGN_ANY, SIGN_LINEHL
 /// @return sign type
 signlist_T *buf_getsigntype(
-        // buf_T *buf,
-        signlist_T	*sign,
-        linenr_T lnum,
-        int type
-        )
+  signlist_T	*sign,
+  linenr_T lnum,
+  int type
+)
 {
-    // signlist_T	*sign;		/* a sign in a b_signlist */
-//sign = buf->b_signlist
     for (; sign != NULL; sign = sign->next) {
         if (sign->lnum == lnum
-                && (type == SIGN_ANY
-                    || (type == SIGN_TEXT
-                        && sign_get_text(sign->typenr) != NULL)
-                    || (type == SIGN_LINEHL
-                        && sign_get_attr(sign->typenr, TRUE) != 0))) {
+            && (type == SIGN_ANY
+                || (type == SIGN_TEXT
+                    && sign_get_text(sign->typenr) != NULL)
+                || (type == SIGN_LINEHL
+                    && sign_get_attr(sign->typenr, TRUE) != 0))) {
             return sign;
         }
     }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4927,22 +4927,28 @@ linenr_T buf_change_sign_type(
     return (linenr_T)0;
 }
 
-int buf_getsigntype(
-        buf_T *buf,
+
+/// @param sign where to start
+/// @param lnum 
+/// @param type SIGN_ICON, SIGN_TEXT, SIGN_ANY, SIGN_LINEHL
+/// @return sign type
+signlist_T *buf_getsigntype(
+        // buf_T *buf,
+        signlist_T	*sign,
         linenr_T lnum,
-        int type /* SIGN_ICON, SIGN_TEXT, SIGN_ANY, SIGN_LINEHL */
+        int type
         )
 {
-    signlist_T	*sign;		/* a sign in a b_signlist */
-
-    for (sign = buf->b_signlist; sign != NULL; sign = sign->next) {
+    // signlist_T	*sign;		/* a sign in a b_signlist */
+//sign = buf->b_signlist
+    for (; sign != NULL; sign = sign->next) {
         if (sign->lnum == lnum
                 && (type == SIGN_ANY
                     || (type == SIGN_TEXT
                         && sign_get_text(sign->typenr) != NULL)
                     || (type == SIGN_LINEHL
                         && sign_get_attr(sign->typenr, TRUE) != 0))) {
-            return sign->typenr;
+            return sign;
         }
     }
     return 0;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -139,11 +139,10 @@ struct buffheader {
   size_t bh_space;          // space in bh_curr for appending
 };
 
-/*
- * Structure that contains all options that are local to a window.
- * Used twice in a window: for the current buffer and for all buffers.
- * Also used in wininfo_T.
- */
+/// Structure that contains all options that are local to a window.
+/// Used twice in a window: for the current buffer and for all buffers.
+/// Also used in wininfo_T.
+/// @see check_winopt, clear_winopt
 typedef struct {
   int wo_arab;
 # define w_p_arab w_onebuf_opt.wo_arab  /* 'arabic' */
@@ -233,6 +232,8 @@ typedef struct {
 # define w_p_crb_save w_onebuf_opt.wo_crb_save
   char_u *wo_scl;
 # define w_p_scl w_onebuf_opt.wo_scl    // 'signcolumn'
+  int wo_sclmax;
+# define w_p_sclmax w_onebuf_opt.wo_sclmax    // max 'signcolumn' width TODO rename
 
   int wo_scriptID[WV_COUNT];            /* SIDs for window-local options */
 # define w_p_scriptID w_onebuf_opt.wo_scriptID

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1002,7 +1002,7 @@ struct window_S {
   int w_wincol;                     /* Leftmost column of window in screen. */
   int w_width;                      /* Width of window, excluding separation. */
   int w_vsep_width;                 /* Number of separator columns (0 or 1). */
-  int w_signcolumn_width;           //!< last value
+  int w_signcolumn_width;           ///< last value
 
   /*
    * === start of cached values ====

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1001,6 +1001,7 @@ struct window_S {
   int w_wincol;                     /* Leftmost column of window in screen. */
   int w_width;                      /* Width of window, excluding separation. */
   int w_vsep_width;                 /* Number of separator columns (0 or 1). */
+  int w_signcolumn_width;           //!< last value
 
   /*
    * === start of cached values ====

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1067,6 +1067,8 @@ struct window_S {
                                        recomputed */
   int w_nrwidth;                    /* width of 'number' and 'relativenumber'
                                        column being used */
+  int w_sclmax;                     ///< max width necessary to display signs
+  int w_sclcurrent;                 ///< current width
 
   /*
    * === end of cached values ===

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -633,7 +633,7 @@ int char2cells(int c)
 /// @param p
 ///
 /// @return number of display cells.
-int ptr2cells(char_u *p)
+int ptr2cells(const char_u *p)
 {
   // For UTF-8 we need to look at more bytes if the first byte is >= 0x80.
   if (*p >= 0x80) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5330,7 +5330,7 @@ struct sign
     int         sn_text_hl;     /* highlight ID for text */
 };
 
-static sign_T   *first_sign = NULL;
+static sign_T   *first_sign = NULL; // TODO to remove, why static ?
 static int      next_sign_typenr = 1;
 
 /*
@@ -5504,8 +5504,10 @@ void ex_sign(exarg_T *eap)
               cells += (*mb_ptr2cells)(s);
             }
             // Currently must be one or two display cells
+            // This can be configurable now
             if (s != p || cells < 1 || cells > 2) {
               *p = NUL;
+              // TODO message should be updated to be clearer
               EMSG2(_("E239: Invalid sign text: %s"), arg);
               return;
             }
@@ -5516,9 +5518,10 @@ void ex_sign(exarg_T *eap)
             len = (int)(p - arg + ((cells == 1) ? 1 : 0));
             sp->sn_text = vim_strnsave(arg, len);
 
-            if (cells == 1) {
-              STRCPY(sp->sn_text + len - 1, " ");
-            }
+            // completed with a space
+            // if (cells == 1) {
+            //   STRCPY(sp->sn_text + len - 1, " ");
+            // }
           } else if (STRNCMP(arg, "linehl=", 7) == 0) {
             arg += 7;
             sp->sn_line_hl = syn_check_group(arg, (int)(p - arg));

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -117,14 +117,17 @@ typedef unsigned short sattr_T;
  * It is a single block of characters, the size of the screen plus one line.
  * The attributes for those characters are kept in ScreenAttrs[].
  *
- * "LineOffset[n]" is the offset from ScreenLines[] for the start of line 'n'.
- * The same value is used for ScreenLinesUC[] and ScreenAttrs[].
  *
  * Note: before the screen is initialized and when out of memory these can be
  * NULL.
  */
 EXTERN schar_T  *ScreenLines INIT(= NULL);
 EXTERN sattr_T  *ScreenAttrs INIT(= NULL);
+
+
+/** "LineOffset[n]" is the offset from ScreenLines[] for the start of line 'n'.
+ * The same value is used for ScreenLinesUC[] and ScreenAttrs[].
+ */
 EXTERN unsigned *LineOffset INIT(= NULL);
 EXTERN char_u   *LineWraps INIT(= NULL);        /* line wraps to next line */
 

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -606,20 +606,25 @@ int utf_char2cells(int c)
 }
 
 /// Return the number of display cells character at "*p" occupies.
-/// This doesn't take care of unprintable characters, use ptr2cells() for that.
+/// @warn This doesn't take care of unprintable characters, use ptr2cells() for that.
+/// @see ptr2cells
 int utf_ptr2cells(const char_u *p)
 {
   int c;
 
   /* Need to convert to a wide character. */
   if (*p >= 0x80) {
+    ILOG("Converting to wide char %s", p);
     c = utf_ptr2char(p);
     /* An illegal byte is displayed as <xx>. */
     if (utf_ptr2len(p) == 1 || c == NUL)
       return 4;
     /* If the char is ASCII it must be an overlong sequence. */
-    if (c < 0x80)
+    if (c < 0x80) {
       return char2cells(c);
+    }
+
+    ILOG("utf_char2cells %d", c);
     return utf_char2cells(c);
   }
   return 1;

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -614,7 +614,7 @@ int utf_ptr2cells(const char_u *p)
 
   /* Need to convert to a wide character. */
   if (*p >= 0x80) {
-    ILOG("Converting to wide char %s", p);
+    // ILOG("Converting to wide char %s", p);
     c = utf_ptr2char(p);
     /* An illegal byte is displayed as <xx>. */
     if (utf_ptr2len(p) == 1 || c == NUL)
@@ -624,7 +624,7 @@ int utf_ptr2cells(const char_u *p)
       return char2cells(c);
     }
 
-    ILOG("utf_char2cells %d", c);
+    // ILOG("utf_char2cells %d", c);
     return utf_char2cells(c);
   }
   return 1;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -670,7 +670,7 @@ int win_col_off(win_T *wp)
   return ((wp->w_p_nu || wp->w_p_rnu) ? number_width(wp) + 1 : 0)
          + (cmdwin_type == 0 || wp != curwin ? 0 : 1)
          + (int)wp->w_p_fdc
-         + (signcolumn_on(wp) ? 2 : 0);
+         + (signcolumn_on(wp) ? win_signcol_width(wp) : 0);
 }
 
 int curwin_col_off(void)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2322,22 +2322,24 @@ set_string_option_direct (
   }
 }
 
-/*
- * Set global value for string option when it's a local option.
- */
-static void 
-set_string_option_global (
-    int opt_idx,                    /* option index */
-    char_u **varp             /* pointer to option variable */
+
+/// Set global value for string option when it's a local option.
+/// @param opt_idx option index
+/// @param varp pointer to option variable
+static void
+set_string_option_global(
+    int opt_idx,
+    char_u **varp
 )
 {
   char_u      **p, *s;
 
-  /* the global value is always allocated */
-  if (options[opt_idx].var == VAR_WIN)
+  // the global value is always allocated
+  if (options[opt_idx].var == VAR_WIN) {
     p = (char_u **)GLOBAL_WO(varp);
-  else
+  } else {
     p = (char_u **)options[opt_idx].var;
+  }
   if (options[opt_idx].indir != PV_NONE && p != varp) {
     s = vim_strsave(*varp);
     free_string_option(*p);
@@ -2409,18 +2411,24 @@ static bool valid_filetype(char_u *val)
   return true;
 }
 
-/*
- * Handle string options that need some action to perform when changed.
- * Returns NULL for success, or an error message for an error.
- */
+/// Handle string options that need some action to perform when changed.
+///
+/// @param opt_idx  index in options[] table
+/// @param varp pointer to the option variable
+/// @param new_value_alloced new value was allocated
+/// @param oldval previous value of the option
+/// @param errbuf buffer for errors, or NULL
+/// @param opt_flags OPT_LOCAL and/or OPT_GLOBAL
+///
+/// @return NULL for success, or an error message for an error.
 static char_u *
 did_set_string_option (
-    int opt_idx,                            /* index in options[] table */
-    char_u **varp,                     /* pointer to the option variable */
-    int new_value_alloced,                  /* new value was allocated */
-    char_u *oldval,                    /* previous value of the option */
-    char_u *errbuf,                    /* buffer for errors, or NULL */
-    int opt_flags                          /* OPT_LOCAL and/or OPT_GLOBAL */
+    int opt_idx,
+    char_u **varp,
+    int new_value_alloced,
+    char_u *oldval,
+    char_u *errbuf,
+    int opt_flags
 )
 {
   char_u      *errmsg = NULL;
@@ -3009,7 +3017,13 @@ did_set_string_option (
     //so for now we change nowthing
     /* if (ascii_isdigit(*p_bs)) { */
     if (check_opt_strings(*varp, p_scl_values, false) != OK) {
-      errmsg = e_invarg;
+      // TODO check it works for several digits ?
+      // if (ascii_isdigit(*varp)) {
+        // curwin->w_allbuf_opt.
+      // }
+      // else {
+        errmsg = e_invarg;
+      // }
     }
   }
   /* 'pastetoggle': translate key codes like in a mapping */
@@ -5393,6 +5407,7 @@ static char_u *get_varp(vimoption_T *p)
   case PV_CRBIND: return (char_u *)&(curwin->w_p_crb);
   case PV_COCU:    return (char_u *)&(curwin->w_p_cocu);
   case PV_COLE:    return (char_u *)&(curwin->w_p_cole);
+  case PV_SCLW:   return (char_u *)&(curwin->w_p_sclmax);
 
   case PV_AI:     return (char_u *)&(curbuf->b_p_ai);
   case PV_BIN:    return (char_u *)&(curbuf->b_p_bin);
@@ -5468,10 +5483,9 @@ char_u *get_equalprg(void)
   return curbuf->b_p_ep;
 }
 
-/*
- * Copy options from one window to another.
- * Used when splitting a window.
- */
+
+/// Copy options from one window to another.
+/// Used when splitting a window.
 void win_copy_options(win_T *wp_from, win_T *wp_to)
 {
   copy_winopt(&wp_from->w_onebuf_opt, &wp_to->w_onebuf_opt);
@@ -5530,6 +5544,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_fdt = vim_strsave(from->wo_fdt);
   to->wo_fmr = vim_strsave(from->wo_fmr);
   to->wo_scl = vim_strsave(from->wo_scl);
+  to->wo_sclmax = from->wo_sclmax;
   check_winopt(to);             // don't want NULL pointers
 }
 
@@ -6479,32 +6494,34 @@ static void fill_breakat_flags(void)
 static int check_opt_strings(
     char_u *val,
     char **values,
-    int list                   /* when TRUE: accept a list of values */
+    bool list                   /* when TRUE: accept a list of values */
 )
 {
   return opt_strings_flags(val, values, NULL, list);
 }
 
-/*
- * Handle an option that can be a range of string values.
- * Set a flag in "*flagp" for each string present.
- *
- * Return OK for correct value, FAIL otherwise.
- * Empty is always OK.
- */
+/// Handle an option that can be a range of string values.
+/// Set a flag in "*flagp" for each string present.
+/// @param val new value
+/// @param values array of valid string values
+/// @param[out] flagp set flag according to position in values
+/// @param list when true: accept a list of values
+/// @return OK for correct value, FAIL otherwise. Empty is always OK.
 static int opt_strings_flags(
-    char_u *val,             /* new value */
-    char **values,           /* array of valid string values */
+    char_u *val,
+    char **values,
     unsigned *flagp,
-    bool list                /* when TRUE: accept a list of values */
+    bool list
 )
 {
   unsigned int new_flags = 0;
 
   while (*val) {
     for (unsigned int i = 0;; ++i) {
-      if (values[i] == NULL)            /* val not found in values[] */
+      if (values[i] == NULL) {
+        // val not found in values[]
         return FAIL;
+      }
 
       size_t len = STRLEN(values[i]);
       if (STRNCMP(values[i], val, len) == 0
@@ -6516,8 +6533,9 @@ static int opt_strings_flags(
       }
     }
   }
-  if (flagp != NULL)
+  if (flagp != NULL) {
     *flagp = new_flags;
+  }
 
   return OK;
 }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3006,6 +3006,8 @@ did_set_string_option (
     }
   } else if (varp == &curwin->w_p_scl) {
     // 'signcolumn'
+    //so for now we change nowthing
+    /* if (ascii_isdigit(*p_bs)) { */
     if (check_opt_strings(*varp, p_scl_values, false) != OK) {
       errmsg = e_invarg;
     }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -677,7 +677,7 @@ EXTERN int p_force_on;          ///< options that cannot be turned off.
 EXTERN int p_force_off;         ///< options that cannot be turned on.
 
 /*
- * "indir" values for buffer-local opions.
+ * "indir" values for buffer-local options.
  * These need to be defined globally, so that the BV_COUNT can be used with
  * b_p_scriptID[].
  */
@@ -803,6 +803,7 @@ enum {
   , WV_WFW
   , WV_WRAP
   , WV_SCL
+  , WV_SCLW
   , WV_COUNT        // must be the last one
 };
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2179,6 +2179,14 @@ return {
       defaults={if_true={vi="auto"}}
     },
     {
+      full_name='signcolumnwidth', abbreviation='sclw',
+      type='number', scope={'window'},
+      vi_def=false,
+      alloced=true,
+      redraw={'current_window'},
+      defaults={if_true={vi=2}}
+    },
+    {
       full_name='smartcase', abbreviation='scs',
       type='bool', scope={'global'},
       vi_def=true,

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2181,7 +2181,7 @@ return {
     {
       full_name='signcolumnwidth', abbreviation='sclw',
       type='number', scope={'window'},
-      vi_def=false,
+      vi_def=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi=2}}

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1604,18 +1604,37 @@ static void win_update(win_T *wp)
 int win_signcol_width(win_T *wp)
 {
   // 2 is vim default value
-
+  // TODO careful I also have added int w_signcolumn_width;           //!< last value
   // int fdc = wp->w_p_sclwidth;
   // int wmw = wp == curwin && p_wmw == 0 ? 1 : p_wmw;
   // int wwidth = wp->w_width;
+  // TODO remove signcolumn_on
+  // if (signcolumn_on(wp)) {
+
+    if (*wp->w_p_scl == 'n') {
+      return 0;
+    }
+    if (*wp->w_p_scl == 'y') {
+      return wp->w_p_sclmax;
+    }
+
+    // auto mode
+    if(wp->w_buffer->b_signlist == NULL) {
+      return 0;
+    }
+    // TODO use some cache to compute the max
+    // return MIN(wp->w_p_sclw);
+    return wp->w_p_sclmax;
+}
+
 
   // if (fdc > wwidth - (col + wmw)) {
   //   fdc = wwidth - (col + wmw);
   // }
   // return fdc;
   // return MIN(wp->w_signcolumn_width, 2); // hopefully it's 2
-  return 8;
-}
+  // return 8;
+// }
 
 /*
  * Clear the rest of the window and mark the unused lines with "c1".  use "c2"
@@ -2761,7 +2780,7 @@ win_line (
               if (row == startrow + filler_lines && filler_todo <= 0) {
                   signlist_T	*sign = wp->w_buffer->b_signlist;
                   ILOG("Looking for signs ");
-                  memset(extra, 'x', sizeof(extra));
+                  memset(extra, ' ', sizeof(extra));
                   extra[0]= '\0';
 
                   for (; (sign = buf_getsigntype(sign, lnum, SIGN_TEXT)); sign= sign->next) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2795,9 +2795,7 @@ win_line (
                     if (p_extra != NULL 
                         && (symbol_clen + used_cells <= win_signcol_width(wp))) {
                         c_extra = NUL;
-                        // TODO append to extra
                         // xstrlcat ?
-                        //
                       ILOG("extra before=%s", extra);
                       /* mb_string2cells(p_extra); */
                       // screen_puts_len(char_u *text, int textlen, int row, int col, int attr)

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1572,6 +1572,20 @@ static void win_update(win_T *wp)
     got_int = save_got_int;
 }
 
+/// Returns width of the signcolumn that should be used for the whole window
+///
+/// @param wp window we want signcolumn width from
+/// @return max width of signcolumn (cell unit)
+///
+/// @note Returns a constant for now but hopefully we can improve neovim so that
+///       the returned value width adapts to the maximum number of marks to draw
+///       for the window
+/// TODO(teto)
+int win_signcol_width(win_T *wp)
+{
+  // 2 is vim default value
+  return 2;
+}
 
 /*
  * Clear the rest of the window and mark the unused lines with "c1".  use "c2"
@@ -1597,7 +1611,7 @@ static void win_draw_end(win_T *wp, int c1, int c2, int row, int endrow, hlf_T h
     }
 
     if (signcolumn_on(wp)) {
-        int nn = n + 2;
+        int nn = n + win_signcol_width(wp);
 
         /* draw the sign column left of the fold column */
         if (nn > wp->w_width) {
@@ -1638,7 +1652,7 @@ static void win_draw_end(win_T *wp, int c1, int c2, int row, int endrow, hlf_T h
     }
 
     if (signcolumn_on(wp)) {
-        int nn = n + 2;
+        int nn = n + win_signcol_width(wp);
 
         /* draw the sign column after the fold column */
         if (nn > wp->w_width) {
@@ -1749,12 +1763,13 @@ static void fold_line(win_T *wp, long fold_count, foldinfo_T *foldinfo, linenr_T
    * text */
   RL_MEMSET(col, hl_attr(HLF_FL), wp->w_width - col);
 
-  // If signs are being displayed, add two spaces.
+  // If signs are being displayed, add spaces.
   if (signcolumn_on(wp)) {
       len = wp->w_width - col;
       if (len > 0) {
-          if (len > 2) {
-              len = 2;
+          int len_max = win_signcol_width(wp);
+          if (len > len_max) {
+              len = len_max;
           }
           copy_text_attr(off + col, (char_u *)"  ", len, hl_attr(HLF_FL));
           col += len;
@@ -2700,18 +2715,25 @@ win_line (
            * buffer or when using Netbeans. */
           if (signcolumn_on(wp)) {
               int text_sign;
-              /* Draw two cells with the sign value or blank. */
+              // Draw cells with the sign value or blank.
               c_extra = ' ';
               char_attr = hl_attr(HLF_SC);
-              n_extra = 2;
+              n_extra = win_signcol_width(wp);
 
               if (row == startrow + filler_lines && filler_todo <= 0) {
                   text_sign = buf_getsigntype(wp->w_buffer, lnum, SIGN_TEXT);
                   if (text_sign != 0) {
                       p_extra = sign_get_text(text_sign);
+                      int symbol_blen = (int)STRLEN(p_extra);
                       if (p_extra != NULL) {
                           c_extra = NUL;
-                          n_extra = (int)STRLEN(p_extra);
+                          // symbol(s) bytes + (filling spaces) (one byte each)
+                          n_extra = symbol_blen +
+                            (win_signcol_width(wp) - mb_string2cells(p_extra));
+                          memset(extra, ' ', sizeof(extra));
+                          STRNCPY(extra, p_extra, STRLEN(p_extra));
+                          p_extra = extra;
+                          p_extra[n_extra] = NUL;
                       }
                       char_attr = sign_get_attr(text_sign, FALSE);
                   }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1595,7 +1595,7 @@ int win_signcol_width(win_T *wp)
   // }
   // return fdc;
   // return MIN(wp->w_signcolumn_width, 2); // hopefully it's 2
-  return 5;
+  return 8;
 }
 
 /*
@@ -2761,11 +2761,16 @@ win_line (
                         // xstrlcat ?
                         //
                       ILOG("extra before=%s", extra);
-                      STRNCAT(extra, p_extra, sizeof(extra));
+                      mb_string2cells(p_extra);
+                      // screen_puts_len(char_u *text, int textlen, int row, int col, int attr)
+                      // TODO avancer col ?
+                      char_attr = sign_get_attr(sign->typenr, FALSE);
+                      screen_puts_len(p_extra, 1, Rows, col, char_attr);
+                      // Does not take into account cell !
+                      // STRNCAT(extra, p_extra, sizeof(extra));
                       ILOG("extra after=%s", extra);
                       used_cells += symbol_clen;
                     }
-                    char_attr = sign_get_attr(sign->typenr, FALSE);
                     // }
                   }
 
@@ -2774,7 +2779,6 @@ win_line (
                     (win_signcol_width(wp) - used_cells);
                   extra[STRLEN(extra)] = ' ';
                   p_extra = extra;
-                  
                   p_extra[n_extra] = NUL;
 
               }
@@ -5335,6 +5339,7 @@ void screen_puts(char_u *text, int row, int col, int attr)
  * Like screen_puts(), but output "text[len]".  When "len" is -1 output up to
  * a NUL.
  */
+// TODO shouldreturn number of cells or newcol ?
 void screen_puts_len(char_u *text, int textlen, int row, int col, int attr)
 {
   unsigned off;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1624,7 +1624,8 @@ int win_signcol_width(win_T *wp)
     }
     // TODO use some cache to compute the max
     // return MIN(wp->w_p_sclw);
-    return wp->w_p_sclmax;
+    ILOG("Choosing min between %d (config) and %d (cache)", wp->w_p_sclmax, wp->w_sclmax );
+    return MIN(wp->w_sclmax, wp->w_p_sclmax);
 }
 
 
@@ -2770,6 +2771,7 @@ win_line (
           if (signcolumn_on(wp)) {
               // int text_sign;
               int used_cells = 0;
+              int needed_cells = 0;
               // win_signcol_width(wp);
               // Draw cells with the sign value or blank.
               c_extra = ' ';
@@ -2788,8 +2790,6 @@ win_line (
                     p_extra = sign_get_text(sign->typenr);
                     int symbol_clen = mb_string2cells(p_extra);
                     ILOG("found one %s (%d cells)", p_extra, symbol_clen );
-                    // if (sign != NULL) {
-                    // int symbol_blen = (int)STRLEN(p_extra);
                     // as long we can append symbols
                     // TODO it could change texthl here several times !
                     if (p_extra != NULL 
@@ -2808,10 +2808,13 @@ win_line (
                       //   //! adds a space after
                       //   STRNCAT(extra, " ", sizeof(extra));
                       // }
-                      ILOG("extra after=%s", extra);
                       used_cells += symbol_clen;
+                      ILOG("extra after=%s", extra);
+                    // only on auto mode ? if()
+                    } else {
+                      // TODO keep counting
                     }
-                    // }
+                    needed_cells += symbol_clen;
                   }
 
                       // symbol(s) bytes + (filling spaces) (one byte each)
@@ -2820,6 +2823,12 @@ win_line (
                   extra[STRLEN(extra)] = ' ';
                   p_extra = extra;
                   p_extra[n_extra] = NUL;
+
+                  //
+                  if(needed_cells > wp->w_sclmax) {
+                    // if in automatic require a redraw
+                    wp->w_sclmax = needed_cells;
+                  }
 
               }
           }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -985,13 +985,17 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
 }
 
 
-/*
- * Initialize window "newp" from window "oldp".
- * Used when splitting a window and when creating a new tab page.
- * The windows will both edit the same buffer.
- * WSP_NEWLOC may be specified in flags to prevent the location list from
- * being copied.
- */
+
+/// Initialize window "newp" from window "oldp".
+/// Used when splitting a window and when creating a new tab page.
+/// The windows will both edit the same buffer.
+///
+/// @param[out] newp window to initialize
+/// @param oldp
+/// @param flags Specify WSP_NEWLOC  to prevent the location list from
+/// being copied.
+///
+/// @see win_close,win_copy_options
 static void win_init(win_T *newp, win_T *oldp, int flags)
 {
   int i;
@@ -1012,14 +1016,15 @@ static void win_init(win_T *newp, win_T *oldp, int flags)
   newp->w_wrow = oldp->w_wrow;
   newp->w_fraction = oldp->w_fraction;
   newp->w_prev_fraction_row = oldp->w_prev_fraction_row;
-  newp->w_signcolumn_width = 0;
+  // newp->w_signcolumn_width = oldp->w_prev_fraction_row;
   copy_jumplist(oldp, newp);
   if (flags & WSP_NEWLOC) {
     /* Don't copy the location list.  */
     newp->w_llist = NULL;
     newp->w_llist_ref = NULL;
-  } else
+  } else {
     copy_loclist(oldp, newp);
+  }
   newp->w_localdir = (oldp->w_localdir == NULL)
                      ? NULL : vim_strsave(oldp->w_localdir);
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1012,6 +1012,7 @@ static void win_init(win_T *newp, win_T *oldp, int flags)
   newp->w_wrow = oldp->w_wrow;
   newp->w_fraction = oldp->w_fraction;
   newp->w_prev_fraction_row = oldp->w_prev_fraction_row;
+  newp->w_signcolumn_width = 0;
   copy_jumplist(oldp, newp);
   if (flags & WSP_NEWLOC) {
     /* Don't copy the location list.  */


### PR DESCRIPTION
Early WIP: it kinda works. 

Goal of the PR is to be able to set the signcolulmn width (currently stuck with 2 cells).
Follow up of https://github.com/neovim/neovim/pull/5802.

It adds a variable `signcolumnwidth` that indicates the signcolumn width when signcolumn==yes and the maximum width when signcolumn=auto.

So to test, I usually run `LC_ALL=C make && ./build/bin/nvim -S ~/test_signs.vim ~/zaza`:
with test_signs.vim:
```
:sign define a text=a
:sign define z text=z
:sign place 22 line=1 name=neomake_err buffer=1
:sign place 23 line=1 name=a buffer=1
:sign place 24 line=1 name=neomake_info buffer=1
:sign place 25 line=1 name=z buffer=1
:sign place 26 line=1 name=neomake_warn buffer=1
```
and then sets
```
set signcolumn=auto
set signcolumnwidth=6 
```
![2017-02-28-182352_478x342_scrot](https://cloud.githubusercontent.com/assets/886074/23416443/21711b24-fde3-11e6-928e-dbabbb7a606c.png)

