### PR TITLE
foldUpdate missed a case

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2232,32 +2232,51 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *gap, int level,
              * before where we started looking, extend it.  If it
              * starts at another line, update nested folds to keep
              * their position, compensating for the new fd_top. */
-            if (fp->fd_top >= startlnum && fp->fd_top != firstlnum) {
-              if (fp->fd_top > firstlnum)
-                /* like lines are inserted */
+            if (fp->fd_top == firstlnum) {
+              // We have found a fold beginning exactly where we want one.
+            } else if (fp->fd_top >= startlnum) {
+              if (fp->fd_top > firstlnum) {
+                // We will move the start of this fold up, hence we move all
+                // nested folds (with relative line numbers) down.
                 foldMarkAdjustRecurse(&fp->fd_nested,
-                    (linenr_T)0, (linenr_T)MAXLNUM,
-                    (long)(fp->fd_top - firstlnum), 0L);
-              else
-                /* like lines are deleted */
+                                      (linenr_T)0, (linenr_T)MAXLNUM,
+                                      (long)(fp->fd_top - firstlnum), 0L);
+              } else {
+                // Will move fold down, move nested folds relatively up.
                 foldMarkAdjustRecurse(&fp->fd_nested,
-                    (linenr_T)0,
-                    (long)(firstlnum - fp->fd_top - 1),
-                    (linenr_T)MAXLNUM,
-                    (long)(fp->fd_top - firstlnum));
+                                      (linenr_T)0,
+                                      (long)(firstlnum - fp->fd_top - 1),
+                                      (linenr_T)MAXLNUM,
+                                      (long)(fp->fd_top - firstlnum));
+              }
               fp->fd_len += fp->fd_top - firstlnum;
               fp->fd_top = firstlnum;
-              fold_changed = TRUE;
-            } else if (flp->start != 0 && lvl == level
-                       && fp->fd_top != firstlnum) {
-              /* Existing fold that includes startlnum must stop
-               * if we find the start of a new fold at the same
-               * level.  Split it.  Delete contained folds at
-               * this point to split them too. */
-              foldRemove(&fp->fd_nested, flp->lnum - fp->fd_top,
-                  flp->lnum - fp->fd_top);
+              fold_changed = true;
+            } else if ((flp->start != 0 && lvl == level)
+                       || (firstlnum != startlnum)) {
+              // Before there was a fold spanning from above startlnum to below
+              // firstlnum. This fold is valid above startlnum (because we are
+              // not updating that range), but there is now a break in it.
+              // If the break is because we are now forced to start a new fold
+              // at the level "level" at line fline->lnum, then we need to
+              // split the fold at fline->lnum.
+              // If the break is because the range [startlnum, firstlnum) is
+              // now at a lower indent than "level", we need to split the fold
+              // in this range.
+              // Any splits have to be done recursively.
+              linenr_T breakstart;
+              linenr_T breakend;
+              if (firstlnum != startlnum) {
+                breakstart = startlnum;
+                breakend = firstlnum;
+              } else {
+                breakstart = flp->lnum;
+                breakend = flp->lnum;
+              }
+              foldRemove(&fp->fd_nested, breakstart - fp->fd_top,
+                         breakend - fp->fd_top);
               i = (int)(fp - (fold_T *)gap->ga_data);
-              foldSplit(gap, i, flp->lnum, flp->lnum - 1);
+              foldSplit(gap, i, breakstart, breakend - 1);
               fp = (fold_T *)gap->ga_data + i + 1;
               /* If using the "marker" or "syntax" method, we
                * need to continue until the end of the fold is
@@ -2266,6 +2285,16 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *gap, int level,
                   || getlevel == foldlevelExpr
                   || getlevel == foldlevelSyntax)
                 finish = TRUE;
+            }
+            if (fp->fd_top == startlnum && concat) {
+              i = (int)(fp - (fold_T *)gap->ga_data);
+              if (i != 0) {
+                fp2 = fp - 1;
+                if (fp2->fd_top + fp2->fd_len == fp->fd_top) {
+                  foldMerge(fp2, gap, fp);
+                  fp = fp2;
+                }
+              }
             }
             break;
           }

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -100,22 +100,6 @@ func! Test_indent_fold2()
     bw!
 endfunc
 
-func Test_folds_marker_in_comment()
-  new
-  call setline(1, ['" foo', 'bar', 'baz'])
-  setl fen fdm=marker
-  setl com=sO:\"\ -,mO:\"\ \ ,eO:\"\",:\" cms=\"%s
-  norm! zf2j
-  setl nofen
-  :1y
-  call assert_equal(['" foo{{{'], getreg(0,1,1))
-  :+2y
-  call assert_equal(['baz"}}}'], getreg(0,1,1))
-
-  set foldmethod&
-  bwipe!
-endfunc
-
 func Test_manual_fold_with_filter()
   if !executable('cat')
     return
@@ -136,6 +120,108 @@ func Test_manual_fold_with_filter()
     bwipe!
     set foldmethod&
   endfor
+endfunc
+
+func! Test_indent_fold_with_read()
+  new
+  set foldmethod=indent
+  call setline(1, repeat(["\<Tab>a"], 4))
+  for n in range(1, 4)
+    call assert_equal(1, foldlevel(n))
+  endfor
+
+  call writefile(["a", "", "\<Tab>a"], 'Xfile')
+  foldopen
+  2read Xfile
+  %foldclose
+  call assert_equal(1, foldlevel(1))
+  call assert_equal(2, foldclosedend(1))
+  call assert_equal(0, foldlevel(3))
+  call assert_equal(0, foldlevel(4))
+  call assert_equal(1, foldlevel(5))
+  call assert_equal(7, foldclosedend(5))
+
+  bwipe!
+  set foldmethod&
+  call delete('Xfile')
+endfunc
+
+func Test_combining_folds_indent()
+  new
+  let one = "\<Tab>a"
+  let zero = 'a'
+  call setline(1, [one, one, zero, zero, zero, one, one, one])
+  set foldmethod=indent
+  3,5d
+  %foldclose
+  call assert_equal(5, foldclosedend(1))
+
+  set foldmethod&
+  bwipe!
+endfunc
+
+func Test_combining_folds_marker()
+  new
+  call setline(1, ['{{{', '}}}', '', '', '', '{{{', '', '}}}'])
+  set foldmethod=marker
+  3,5d
+  %foldclose
+  call assert_equal(2, foldclosedend(1))
+
+  set foldmethod&
+  bwipe!
+endfunc
+
+func Test_folds_marker_in_comment()
+  new
+  call setline(1, ['" foo', 'bar', 'baz'])
+  setl fen fdm=marker
+  setl com=sO:\"\ -,mO:\"\ \ ,eO:\"\",:\" cms=\"%s
+  norm! zf2j
+  setl nofen
+  :1y
+  call assert_equal(['" foo{{{'], getreg(0,1,1))
+  :+2y
+  call assert_equal(['baz"}}}'], getreg(0,1,1))
+
+  set foldmethod&
+  bwipe!
+endfunc
+
+func s:TestFoldExpr(lnum)
+  let thisline = getline(a:lnum)
+  if thisline == 'a'
+    return 1
+  elseif thisline == 'b'
+    return 0
+  elseif thisline == 'c'
+    return '<1'
+  elseif thisline == 'd'
+    return '>1'
+  endif
+  return 0
+endfunction
+
+func Test_update_folds_expr_read()
+  new
+  call setline(1, ['a', 'a', 'a', 'a', 'a', 'a'])
+  set foldmethod=expr
+  set foldexpr=s:TestFoldExpr(v:lnum)
+  2
+  foldopen
+  call writefile(['b', 'b', 'a', 'a', 'd', 'a', 'a', 'c'], 'Xfile')
+  read Xfile
+  %foldclose
+  call assert_equal(2, foldclosedend(1))
+  call assert_equal(0, foldlevel(3))
+  call assert_equal(0, foldlevel(4))
+  call assert_equal(6, foldclosedend(5))
+  call assert_equal(10, foldclosedend(7))
+  call assert_equal(14, foldclosedend(11))
+
+  call delete('Xfile')
+  bwipe!
+  set foldmethod& foldexpr&
 endfunc
 
 func! Test_move_folds_around_manual()


### PR DESCRIPTION
When `foldUpdateIEMSRecurse()` re-uses an existing fold to fold the range
it's working on, it misses the case where the existing fold spans from
before startlnum to after firstlnum, the new fold does not span this
range, and there is no "forced start" of a fold. We add a case for this
in.

@chrisbra I believe this happens in vim too (least the symptom is there)