### PR TITLE
[RFC] vim-patch: 8.0.0319, 8.0.0347

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2914,11 +2914,14 @@ static int ins_compl_bs(void)
   p = line + curwin->w_cursor.col;
   mb_ptr_back(line, p);
 
-  /* Stop completion when the whole word was deleted.  For Omni completion
-   * allow the word to be deleted, we won't match everything. */
+  // Stop completion when the whole word was deleted.  For Omni completion
+  // allow the word to be deleted, we won't match everything.
+  // Respect the 'backspace' option.
   if ((int)(p - line) - (int)compl_col < 0
       || ((int)(p - line) - (int)compl_col == 0
-          && ctrl_x_mode != CTRL_X_OMNI) || ctrl_x_mode == CTRL_X_EVAL) {
+          && ctrl_x_mode != CTRL_X_OMNI) || ctrl_x_mode == CTRL_X_EVAL
+      || (!can_bs(BS_START) && (int)(p - line) - (int)compl_col
+          - compl_length < 0)) {
     return K_BS;
   }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4344,6 +4344,7 @@ static int ins_complete(int c, bool enable_pum)
   int save_w_wrow;
   int save_w_leftcol;
   int insert_match;
+  int save_did_ai = did_ai;
 
   compl_direction = ins_compl_key2dir(c);
   insert_match = ins_compl_use_match(c);
@@ -4559,6 +4560,8 @@ static int ins_complete(int c, bool enable_pum)
       if (*funcname == NUL) {
         EMSG2(_(e_notset), ctrl_x_mode == CTRL_X_FUNCTION
             ? "completefunc" : "omnifunc");
+        // restore did_ai, so that adding comment leader works
+        did_ai = save_did_ai;
         return FAIL;
       }
 

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -522,4 +522,23 @@ func Test_completion_can_undo()
   iunmap <Right>
 endfunc
 
+func Test_completion_comment_formatting()
+  new
+  setl formatoptions=tcqro
+  call feedkeys("o/*\<cr>\<cr>/\<esc>", 'tx')
+  call assert_equal(['', '/*', ' *', ' */'], getline(1,4))
+  %d
+  call feedkeys("o/*\<cr>foobar\<cr>/\<esc>", 'tx')
+  call assert_equal(['', '/*', ' * foobar', ' */'], getline(1,4))
+  %d
+  try
+    call feedkeys("o/*\<cr>\<cr>\<c-x>\<c-u>/\<esc>", 'tx')
+    call assert_false(1, 'completefunc not set, should have failed')
+  catch
+    call assert_exception('E764:')
+  endtry
+  call assert_equal(['', '/*', ' *', ' */'], getline(1,4))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -482,6 +482,26 @@ func Test_completion_ctrl_e_without_autowrap()
   q!
 endfunc
 
+func Test_completion_respect_bs_option()
+  new
+  let li = ["aaa", "aaa12345", "aaaabcdef", "aaaABC"]
+
+  set bs=indent,eol
+  call setline(1, li)
+  1
+  call feedkeys("A\<C-X>\<C-N>\<C-P>\<BS>\<BS>\<BS>\<Esc>", "tx")
+  call assert_equal('aaa', getline(1))
+
+  %d
+  set bs=indent,eol,start
+  call setline(1, li)
+  1
+  call feedkeys("A\<C-X>\<C-N>\<C-P>\<BS>\<BS>\<BS>\<Esc>", "tx")
+  call assert_equal('', getline(1))
+
+  bw!
+endfunc
+
 func CompleteUndo() abort
   call complete(1, g:months)
   return ''


### PR DESCRIPTION
vim-patch:8.0.0319

Problem:    Insert mode completion does not respect "start" in 'backspace'.
Solution:   Check whether backspace can go before where insert started.
            (Hirohito Higashi)

vim/vim@190b04c

 vim-patch:8.0.0347

Problem:    When using CTRL-X CTRL-U inside a comment, the use of the comment
            leader may not work. (Klement)
Solution:   Save and restore did_ai. (Christian Brabandt, closes vim/vim#1494)

vim/vim@d099e03