### PR TITLE
[RFC] terminal.c: Reset cursor postion when using termopen()

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -241,7 +241,7 @@ Terminal *terminal_open(TerminalOptions opts)
   buf_set_term_title(curbuf, (char *)curbuf->b_ffname);
   RESET_BINDING(curwin);
   // Reset cursor in current window.
-  curwin->w_cursor = (pos_T){.lnum = 1, .col = 0, .coladd = 0};
+  curwin->w_cursor = (pos_T){ .lnum = 1, .col = 0, .coladd = 0 };
 
   // Apply TermOpen autocmds _before_ configuring the scrollback buffer.
   apply_autocmds(EVENT_TERMOPEN, NULL, NULL, false, curbuf);

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -240,6 +240,8 @@ Terminal *terminal_open(TerminalOptions opts)
   set_option_value((uint8_t *)"relativenumber", false, NULL, OPT_LOCAL);
   buf_set_term_title(curbuf, (char *)curbuf->b_ffname);
   RESET_BINDING(curwin);
+  // Reset cursor in current window.
+  curwin->w_cursor = (pos_T){.lnum = 1, .col = 0, .coladd = 0};
 
   // Apply TermOpen autocmds _before_ configuring the scrollback buffer.
   apply_autocmds(EVENT_TERMOPEN, NULL, NULL, false, curbuf);

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -4,6 +4,7 @@ local feed, clear, nvim = helpers.feed, helpers.clear, helpers.nvim
 local wait = helpers.wait
 local eval, execute, source = helpers.eval, helpers.execute, helpers.source
 local eq, neq = helpers.eq, helpers.neq
+local write_file = helpers.write_file
 
 if helpers.pending_win32(pending) then return end
 
@@ -207,3 +208,25 @@ describe('terminal buffer', function()
   end)
 end)
 
+describe('No heap-buffer-overflow when using', function()
+
+  local testfilename = 'Xtestfile-functional-terminal-buffers_spec'
+
+  before_each(function()
+    write_file(testfilename, "aaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+  end)
+
+  after_each(function()
+    os.remove(testfilename)
+  end)
+
+  it('termopen(echo) #3161', function()
+    execute('edit ' .. testfilename)
+    -- Move cursor away from the beginning of the line
+    feed('$')
+    -- Let termopen() modify the buffer
+    execute('call termopen("echo")')
+    wait()
+    execute('bdelete!')
+  end)
+end)


### PR DESCRIPTION
 terminal.c: Reset cursor postion when using termopen()

After using 'termopen("echo") the current buffer content is changed,
but the cursor position of the current window is not updated.
Because of this, a call to 'mb_adjust_cursor()'  can lead to a
heap-buffer-overflow.

Fix this by resetting the cursor for the current window.

Fixes #3161