### PR TITLE
[RDY] make backtick-expansion work for `shell=fish`.

### DIFF
--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -62,9 +62,7 @@ static int selinux_enabled = -1;
 
 
 #if defined(HAVE_SELINUX)
-/*
- * Copy security info from "from_file" to "to_file".
- */
+// Copy security info from "from_file" to "to_file".
 void mch_copy_sec(char_u *from_file, char_u *to_file)
 {
   if (from_file == NULL)
@@ -78,11 +76,12 @@ void mch_copy_sec(char_u *from_file, char_u *to_file)
     security_context_t to_context = NULL;
 
     if (getfilecon((char *)from_file, &from_context) < 0) {
-      /* If the filesystem doesn't support extended attributes,
-         the original had no special security context and the
-         target cannot have one either.  */
-      if (errno == EOPNOTSUPP)
+      // If the filesystem doesn't support extended attributes,
+      // the original had no special security context and the
+      // target cannot have one either.
+      if (errno == EOPNOTSUPP) {
         return;
+      }
 
       MSG_PUTS(_("\nCould not get security context for "));
       msg_outtrans(from_file);
@@ -107,21 +106,17 @@ void mch_copy_sec(char_u *from_file, char_u *to_file)
     freecon(from_context);
   }
 }
-#endif /* HAVE_SELINUX */
+#endif  // HAVE_SELINUX
 
-/*
- * Return a pointer to the ACL of file "fname" in allocated memory.
- * Return NULL if the ACL is not available for whatever reason.
- */
+// Return a pointer to the ACL of file "fname" in allocated memory.
+// Return NULL if the ACL is not available for whatever reason.
 vim_acl_T mch_get_acl(char_u *fname)
 {
   vim_acl_T ret = NULL;
   return ret;
 }
 
-/*
- * Set the ACL of file "fname" to "acl" (unless it's NULL).
- */
+// Set the ACL of file "fname" to "acl" (unless it's NULL).
 void mch_set_acl(char_u *fname, vim_acl_T aclent)
 {
   if (aclent == NULL)
@@ -141,7 +136,7 @@ void mch_exit(int r)
 
   ui_builtin_stop();
   ui_flush();
-  ml_close_all(true);           /* remove all memfiles */
+  ml_close_all(true);           // remove all memfiles
 
   event_teardown();
   stream_set_blocking(input_global_fd(), true);  // normalize stream (#2598)
@@ -198,7 +193,7 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
   int check_spaces;
   static bool did_find_nul = false;
   bool ampersent = false;
-  /* vimglob() function to define for Posix shell */
+  // vimglob() function to define for Posix shell
   static char *sh_vimglob_func =
     "vimglob() { while [ $# -ge 1 ]; do echo \"$1\"; shift; done }; vimglob >";
 
@@ -209,13 +204,11 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
     false;
 #endif
 
-  *num_file = 0;        /* default: no files found */
+  *num_file = 0;        // default: no files found
   *file = NULL;
 
-  /*
-   * If there are no wildcards, just copy the names to allocated memory.
-   * Saves a lot of time, because we don't have to start a new shell.
-   */
+  // If there are no wildcards, just copy the names to allocated memory.
+  // Saves a lot of time, because we don't have to start a new shell.
   if (!have_wildcard(num_pat, pat)) {
     save_patterns(num_pat, pat, num_file, file);
     return OK;
@@ -226,66 +219,65 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
     return FAIL;
   }
 
-  /*
-   * Don't allow the use of backticks in secure and restricted mode.
-   */
-  if (secure || restricted)
-    for (i = 0; i < num_pat; ++i)
+  // Don't allow the use of backticks in secure and restricted mode.
+  if (secure || restricted) {
+    for (i = 0; i < num_pat; i++) {
       if (vim_strchr(pat[i], '`') != NULL
-          && (check_restricted() || check_secure()))
+          && (check_restricted() || check_secure())) {
         return FAIL;
+      }
+    }
+  }
 
-  /*
-   * get a name for the temp file
-   */
+  // get a name for the temp file
   if ((tempname = vim_tempname()) == NULL) {
     EMSG(_(e_notmp));
     return FAIL;
   }
 
-  /*
-   * Let the shell expand the patterns and write the result into the temp
-   * file.
-   * STYLE_BT:	NL separated
-   *	    If expanding `cmd` execute it directly.
-   * STYLE_GLOB:	NUL separated
-   *	    If we use *csh, "glob" will work better than "echo".
-   * STYLE_PRINT:	NL or NUL separated
-   *	    If we use *zsh, "print -N" will work better than "glob".
-   * STYLE_VIMGLOB:	NL separated
-   *	    If we use *sh*, we define "vimglob()".
-   * STYLE_ECHO:	space separated.
-   *	    A shell we don't know, stay safe and use "echo".
-   */
+  // Let the shell expand the patterns and write the result into the temp
+  // file.
+  // STYLE_BT:         NL separated
+  //       If expanding `cmd` execute it directly.
+  // STYLE_GLOB:       NUL separated
+  //       If we use *csh, "glob" will work better than "echo".
+  // STYLE_PRINT:      NL or NUL separated
+  //       If we use *zsh, "print -N" will work better than "glob".
+  // STYLE_VIMGLOB:    NL separated
+  //       If we use *sh*, we define "vimglob()".
+  // STYLE_ECHO:       space separated.
+  //       A shell we don't know, stay safe and use "echo".
   if (num_pat == 1 && *pat[0] == '`'
       && (len = STRLEN(pat[0])) > 2
-      && *(pat[0] + len - 1) == '`')
+      && *(pat[0] + len - 1) == '`') {
     shell_style = STYLE_BT;
-  else if ((len = STRLEN(p_sh)) >= 3) {
-    if (STRCMP(p_sh + len - 3, "csh") == 0)
+  } else if ((len = STRLEN(p_sh)) >= 3) {
+    if (STRCMP(p_sh + len - 3, "csh") == 0) {
       shell_style = STYLE_GLOB;
-    else if (STRCMP(p_sh + len - 3, "zsh") == 0)
+    } else if (STRCMP(p_sh + len - 3, "zsh") == 0) {
       shell_style = STYLE_PRINT;
+    }
   }
   if (shell_style == STYLE_ECHO && strstr((char *)path_tail(p_sh),
           "sh") != NULL)
     shell_style = STYLE_VIMGLOB;
 
-  /* Compute the length of the command.  We need 2 extra bytes: for the
-   * optional '&' and for the NUL.
-   * Worst case: "unset nonomatch; print -N >" plus two is 29 */
+  // Compute the length of the command.  We need 2 extra bytes: for the
+  // optional '&' and for the NUL.
+  // Worst case: "unset nonomatch; print -N >" plus two is 29
   len = STRLEN(tempname) + 29;
   if (shell_style == STYLE_VIMGLOB)
     len += STRLEN(sh_vimglob_func);
 
-  for (i = 0; i < num_pat; ++i) {
-    /* Count the length of the patterns in the same way as they are put in
-     * "command" below. */
-    ++len;                              /* add space */
-    for (j = 0; pat[i][j] != NUL; ++j) {
-      if (vim_strchr(SHELL_SPECIAL, pat[i][j]) != NULL)
-        ++len;                  /* may add a backslash */
-      ++len;
+  for (i = 0; i < num_pat; i++) {
+    // Count the length of the patterns in the same way as they are put in
+    // "command" below.
+    len++;                              // add space
+    for (j = 0; pat[i][j] != NUL; j++) {
+      if (vim_strchr(SHELL_SPECIAL, pat[i][j]) != NULL) {
+        len++;                  // may add a backslash
+      }
+      len++;
     }
   }
 
@@ -295,32 +287,31 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
 
   command = xmalloc(len);
 
-  /*
-   * Build the shell command:
-   * - Set $nonomatch depending on EW_NOTFOUND (hopefully the shell
-   *	 recognizes this).
-   * - Add the shell command to print the expanded names.
-   * - Add the temp file name.
-   * - Add the file name patterns.
-   */
+  // Build the shell command:
+  // - Set $nonomatch depending on EW_NOTFOUND (hopefully the shell
+  //    recognizes this).
+  // - Add the shell command to print the expanded names.
+  // - Add the temp file name.
+  // - Add the file name patterns.
   if (shell_style == STYLE_BT) {
-    /* change `command; command& ` to (command; command ) */
+    // change `command; command& ` to (command; command )
     if (is_fish_shell) {
       STRCPY(command, "begin; ");
     } else {
       STRCPY(command, "(");
     }
-    STRCAT(command, pat[0] + 1);                /* exclude first backtick */
+    STRCAT(command, pat[0] + 1);                // exclude first backtick
     p = command + STRLEN(command) - 1;
     if (is_fish_shell) {
       *p-- = ';';
       STRCAT(command, " end");
     } else {
-      *p-- = ')';                                 /* remove last backtick */
+      *p-- = ')';                                 // remove last backtick
     }
-    while (p > command && ascii_iswhite(*p))
-      --p;
-    if (*p == '&') {                            /* remove trailing '&' */
+    while (p > command && ascii_iswhite(*p)) {
+      p--;
+    }
+    if (*p == '&') {                            // remove trailing '&'
       ampersent = true;
       *p = ' ';
     }
@@ -342,113 +333,109 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
 
   STRCAT(command, tempname);
 
-  if (shell_style != STYLE_BT)
-    for (i = 0; i < num_pat; ++i) {
-      /* Put a backslash before special
-       * characters, except inside ``. */
+  if (shell_style != STYLE_BT) {
+    for (i = 0; i < num_pat; i++) {
+      // Put a backslash before special
+      // characters, except inside ``.
       bool intick = false;
 
       p = command + STRLEN(command);
       *p++ = ' ';
-      for (j = 0; pat[i][j] != NUL; ++j) {
-        if (pat[i][j] == '`')
+      for (j = 0; pat[i][j] != NUL; j++) {
+        if (pat[i][j] == '`') {
           intick = !intick;
-        else if (pat[i][j] == '\\' && pat[i][j + 1] != NUL) {
-          /* Remove a backslash, take char literally.  But keep
-           * backslash inside backticks, before a special character
-           * and before a backtick. */
+        } else if (pat[i][j] == '\\' && pat[i][j + 1] != NUL) {
+          // Remove a backslash, take char literally.  But keep
+          // backslash inside backticks, before a special character
+          // and before a backtick.
           if (intick
               || vim_strchr(SHELL_SPECIAL, pat[i][j + 1]) != NULL
-              || pat[i][j + 1] == '`')
+              || pat[i][j + 1] == '`') {
             *p++ = '\\';
-          ++j;
+          }
+          j++;
         } else if (!intick
-            && ((flags & EW_KEEPDOLLAR) == 0 || pat[i][j] != '$')
-            && vim_strchr(SHELL_SPECIAL, pat[i][j]) != NULL)
-          /* Put a backslash before a special character, but not
-           * when inside ``. And not for $var when EW_KEEPDOLLAR is
-           * set. */
+                   && ((flags & EW_KEEPDOLLAR) == 0 || pat[i][j] != '$')
+                   && vim_strchr(SHELL_SPECIAL, pat[i][j]) != NULL) {
+          // Put a backslash before a special character, but not
+          // when inside ``. And not for $var when EW_KEEPDOLLAR is
+          // set.
           *p++ = '\\';
+        }
 
-        /* Copy one character. */
+        // Copy one character.
         *p++ = pat[i][j];
       }
       *p = NUL;
     }
+  }
 
   if (flags & EW_SILENT) {
     shellopts |= kShellOptHideMess;
   }
 
-  if (ampersent)
-    STRCAT(command, "&");               /* put the '&' after the redirection */
+  if (ampersent) {
+    STRCAT(command, "&");               // put the '&' after the redirection
+  }
 
-  /*
-   * Using zsh -G: If a pattern has no matches, it is just deleted from
-   * the argument list, otherwise zsh gives an error message and doesn't
-   * expand any other pattern.
-   */
-  if (shell_style == STYLE_PRINT)
-    extra_shell_arg = (char_u *)"-G";       /* Use zsh NULL_GLOB option */
+  // Using zsh -G: If a pattern has no matches, it is just deleted from
+  // the argument list, otherwise zsh gives an error message and doesn't
+  // expand any other pattern.
+  if (shell_style == STYLE_PRINT) {
+    extra_shell_arg = (char_u *)"-G";       // Use zsh NULL_GLOB option
 
-  /*
-   * If we use -f then shell variables set in .cshrc won't get expanded.
-   * vi can do it, so we will too, but it is only necessary if there is a "$"
-   * in one of the patterns, otherwise we can still use the fast option.
-   */
-  else if (shell_style == STYLE_GLOB && !have_dollars(num_pat, pat))
-    extra_shell_arg = (char_u *)"-f";           /* Use csh fast option */
+  // If we use -f then shell variables set in .cshrc won't get expanded.
+  // vi can do it, so we will too, but it is only necessary if there is a "$"
+  // in one of the patterns, otherwise we can still use the fast option.
+  } else if (shell_style == STYLE_GLOB && !have_dollars(num_pat, pat)) {
+    extra_shell_arg = (char_u *)"-f";           // Use csh fast option
+  }
 
-  /*
-   * execute the shell command
-   */
+  // execute the shell command
   i = call_shell(
       command,
       shellopts,
       extra_shell_arg
       );
 
-  /* When running in the background, give it some time to create the temp
-   * file, but don't wait for it to finish. */
-  if (ampersent)
+  // When running in the background, give it some time to create the temp
+  // file, but don't wait for it to finish.
+  if (ampersent) {
     os_delay(10L, true);
+  }
 
   xfree(command);
 
-  if (i) {                         /* os_call_shell() failed */
+  if (i) {                         // os_call_shell() failed
     os_remove((char *)tempname);
     xfree(tempname);
-    /*
-     * With interactive completion, the error message is not printed.
-     */
-    if (!(flags & EW_SILENT))
-    {
-      redraw_later_clear();             /* probably messed up screen */
-      msg_putchar('\n');                /* clear bottom line quickly */
+    // With interactive completion, the error message is not printed.
+    if (!(flags & EW_SILENT)) {
+      redraw_later_clear();             // probably messed up screen
+      msg_putchar('\n');                // clear bottom line quickly
 #if SIZEOF_LONG > SIZEOF_INT
       assert(Rows <= (long)INT_MAX + 1);
 #endif
-      cmdline_row = (int)(Rows - 1);           /* continue on last line */
+      cmdline_row = (int)(Rows - 1);           // continue on last line
       MSG(_(e_wildexpand));
-      msg_start();                    /* don't overwrite this message */
+      msg_start();                    // don't overwrite this message
     }
 
-    /* If a `cmd` expansion failed, don't list `cmd` as a match, even when
-     * EW_NOTFOUND is given */
-    if (shell_style == STYLE_BT)
+    // If a `cmd` expansion failed, don't list `cmd` as a match, even when
+    // EW_NOTFOUND is given
+    if (shell_style == STYLE_BT) {
       return FAIL;
+    }
     goto notfound;
   }
 
-  /*
-   * read the names from the file into memory
-   */
+  // read the names from the file into memory
   fd = fopen((char *)tempname, READBIN);
   if (fd == NULL) {
-    /* Something went wrong, perhaps a file name with a special char. */
+    // Something went wrong, perhaps a file name with a special char.
     if (!(flags & EW_SILENT)) {
       MSG(_(e_wildexpand));
-      msg_start();                      /* don't overwrite this message */
+      msg_start();                      // don't overwrite this message
     }
     xfree(tempname);
     goto notfound;
@@ -459,7 +446,7 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
     fclose(fd);
     return FAIL;
   }
-  long long templen = ftell(fd);        /* get size of temp file */
+  int64_t templen = ftell(fd);        // get size of temp file
   if (templen < 0) {
     xfree(tempname);
     fclose(fd);
@@ -477,7 +464,7 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
   fclose(fd);
   os_remove((char *)tempname);
   if (readlen != len) {
-    /* unexpected read error */
+    // unexpected read error
     EMSG2(_(e_notread), tempname);
     xfree(tempname);
     xfree(buffer);
@@ -485,41 +472,40 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
   }
   xfree(tempname);
 
-  /* file names are separated with Space */
+  // file names are separated with Space
   if (shell_style == STYLE_ECHO) {
-    buffer[len] = '\n';                 /* make sure the buffer ends in NL */
+    buffer[len] = '\n';                 // make sure the buffer ends in NL
     p = buffer;
-    for (i = 0; *p != '\n'; ++i) {      /* count number of entries */
-      while (*p != ' ' && *p != '\n')
-        ++p;
-      p = skipwhite(p);                 /* skip to next entry */
+    for (i = 0; *p != '\n'; i++) {      // count number of entries
+      while (*p != ' ' && *p != '\n') {
+        p++;
+      }
+      p = skipwhite(p);                 // skip to next entry
     }
-  }
-  /* file names are separated with NL */
-  else if (shell_style == STYLE_BT || shell_style == STYLE_VIMGLOB) {
-    buffer[len] = NUL;                  /* make sure the buffer ends in NUL */
+  // file names are separated with NL
+  } else if (shell_style == STYLE_BT || shell_style == STYLE_VIMGLOB) {
+    buffer[len] = NUL;                  // make sure the buffer ends in NUL
     p = buffer;
-    for (i = 0; *p != NUL; ++i) {       /* count number of entries */
-      while (*p != '\n' && *p != NUL)
-        ++p;
-      if (*p != NUL)
-        ++p;
-      p = skipwhite(p);                 /* skip leading white space */
+    for (i = 0; *p != NUL; i++) {       // count number of entries
+      while (*p != '\n' && *p != NUL) {
+        p++;
+      }
+      if (*p != NUL) {
+        p++;
+      }
+      p = skipwhite(p);                 // skip leading white space
     }
-  }
-  /* file names are separated with NUL */
-  else {
-    /*
-     * Some versions of zsh use spaces instead of NULs to separate
-     * results.  Only do this when there is no NUL before the end of the
-     * buffer, otherwise we would never be able to use file names with
-     * embedded spaces when zsh does use NULs.
-     * When we found a NUL once, we know zsh is OK, set did_find_nul and
-     * don't check for spaces again.
-     */
+  // file names are separated with NUL
+  } else {
+    // Some versions of zsh use spaces instead of NULs to separate
+    // results.  Only do this when there is no NUL before the end of the
+    // buffer, otherwise we would never be able to use file names with
+    // embedded spaces when zsh does use NULs.
+    // When we found a NUL once, we know zsh is OK, set did_find_nul and
+    // don't check for spaces again.
     check_spaces = false;
     if (shell_style == STYLE_PRINT && !did_find_nul) {
-      /* If there is a NUL, set did_find_nul, else set check_spaces */
+      // If there is a NUL, set did_find_nul, else set check_spaces
       buffer[len] = NUL;
       if (len && (int)STRLEN(buffer) < (int)len)
         did_find_nul = true;
@@ -527,72 +513,69 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
         check_spaces = true;
     }
 
-    /*
-     * Make sure the buffer ends with a NUL.  For STYLE_PRINT there
-     * already is one, for STYLE_GLOB it needs to be added.
-     */
-    if (len && buffer[len - 1] == NUL)
-      --len;
-    else
+    // Make sure the buffer ends with a NUL.  For STYLE_PRINT there
+    // already is one, for STYLE_GLOB it needs to be added.
+    if (len && buffer[len - 1] == NUL) {
+      len--;
+    } else {
       buffer[len] = NUL;
+    }
     i = 0;
-    for (p = buffer; p < buffer + len; ++p)
-      if (*p == NUL || (*p == ' ' && check_spaces)) {       /* count entry */
-        ++i;
+    for (p = buffer; p < buffer + len; p++) {
+      if (*p == NUL || (*p == ' ' && check_spaces)) {       // count entry
+        i++;
         *p = NUL;
       }
-    if (len)
-      ++i;                              /* count last entry */
+    }
+    if (len) {
+      i++;                              // count last entry
+    }
   }
   assert(buffer[len] == NUL || buffer[len] == '\n');
 
   if (i == 0) {
-    /*
-     * Can happen when using /bin/sh and typing ":e $NO_SUCH_VAR^I".
-     * /bin/sh will happily expand it to nothing rather than returning an
-     * error; and hey, it's good to check anyway -- webb.
-     */
+    // Can happen when using /bin/sh and typing ":e $NO_SUCH_VAR^I".
+    // /bin/sh will happily expand it to nothing rather than returning an
+    // error; and hey, it's good to check anyway -- webb.
     xfree(buffer);
     goto notfound;
   }
   *num_file = i;
   *file = xmalloc(sizeof(char_u *) * (size_t)i);
 
-  /*
-   * Isolate the individual file names.
-   */
+  // Isolate the individual file names.
   p = buffer;
   for (i = 0; i < *num_file; ++i) {
     (*file)[i] = p;
-    /* Space or NL separates */
+    // Space or NL separates
     if (shell_style == STYLE_ECHO || shell_style == STYLE_BT
         || shell_style == STYLE_VIMGLOB) {
       while (!(shell_style == STYLE_ECHO && *p == ' ')
-             && *p != '\n' && *p != NUL)
-        ++p;
-      if (p == buffer + len)                    /* last entry */
-        *p = NUL;
-      else {
-        *p++ = NUL;
-        p = skipwhite(p);                       /* skip to next entry */
+             && *p != '\n' && *p != NUL) {
+        p++;
       }
-    } else {          /* NUL separates */
-      while (*p && p < buffer + len)            /* skip entry */
-        ++p;
-      ++p;                                      /* skip NUL */
+      if (p == buffer + len) {                  // last entry
+        *p = NUL;
+      } else {
+        *p++ = NUL;
+        p = skipwhite(p);                       // skip to next entry
+      }
+    } else {          // NUL separates
+      while (*p && p < buffer + len) {          // skip entry
+        p++;
+      }
+      p++;                                      // skip NUL
     }
   }
 
-  /*
-   * Move the file names to allocated memory.
-   */
+  // Move the file names to allocated memory.
   for (j = 0, i = 0; i < *num_file; i++) {
     // Require the files to exist. Helps when using /bin/sh
     if (!(flags & EW_NOTFOUND) && !os_path_exists((*file)[i])) {
       continue;
     }
 
-    /* check if this entry should be included */
+    // check if this entry should be included
     dir = (os_isdir((*file)[i]));
     if ((dir && !(flags & EW_DIR)) || (!dir && !(flags & EW_FILE)))
       continue;
@@ -605,14 +588,15 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
 
     p = xmalloc(STRLEN((*file)[i]) + 1 + dir);
     STRCPY(p, (*file)[i]);
-    if (dir)
-      add_pathsep((char *)p);             /* add '/' to a directory name */
+    if (dir) {
+      add_pathsep((char *)p);             // add '/' to a directory name
+    }
     (*file)[j++] = p;
   }
   xfree(buffer);
   *num_file = j;
 
-  if (*num_file == 0) {     /* rejected all entries */
+  if (*num_file == 0) {     // rejected all entries
     xfree(*file);
     *file = NULL;
     goto notfound;
@@ -640,8 +624,8 @@ static void save_patterns(int num_pat, char_u **pat, int *num_file,
 
   for (i = 0; i < num_pat; i++) {
     s = vim_strsave(pat[i]);
-    /* Be compatible with expand_filename(): halve the number of
-     * backslashes. */
+    // Be compatible with expand_filename(): halve the number of
+    // backslashes.
     backslash_halve(s);
     (*file)[i] = s;
   }


### PR DESCRIPTION
I've made a fix for #6216 which enables backtick-expansion when `shell` is set to `fish`. This allows things like
```
:args `echo ***.hs`
```
to work properly.