### PR TITLE
[RFC] vim-patch:7.4.2051

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -257,7 +257,7 @@ void trunc_string(char_u *s, char_u *buf, int room, int buflen)
       return;
     }
     n = ptr2cells(s + e);
-    if (len + n >= half)
+    if (len + n > half)
       break;
     len += n;
     buf[e] = s[e];

--- a/src/nvim/message_test.c
+++ b/src/nvim/message_test.c
@@ -1,0 +1,77 @@
+/* vi:set ts=8 sts=4 sw=4:
+ *
+ * VIM - Vi IMproved	by Bram Moolenaar
+ *
+ * Do ":help uganda"  in Vim to read copying and usage conditions.
+ * Do ":help credits" in Vim to see a list of people who contributed.
+ * See README.txt for an overview of the Vim source code.
+ */
+
+/*
+ * message_test.c: Unittests for message.c
+ */
+
+#undef NDEBUG
+#include <assert.h>
+
+/* Must include main.c because it contains much more than just main() */
+#define NO_VIM_MAIN
+#include "main.c"
+
+/* This file has to be included because some of the tested functions are
+ * static. */
+#include "message.c"
+
+/*
+ * Test trunc_string().
+ */
+    static void
+test_trunc_string(void)
+{
+    char_u  buf[40];
+
+    /* in place */
+    STRCPY(buf, "text");
+    trunc_string(buf, buf, 20, 40);
+    assert(STRCMP(buf, "text") == 0);
+
+    STRCPY(buf, "a short text");
+    trunc_string(buf, buf, 20, 40);
+    assert(STRCMP(buf, "a short text") == 0);
+
+    STRCPY(buf, "a text tha just fits");
+    trunc_string(buf, buf, 20, 40);
+    assert(STRCMP(buf, "a text tha just fits") == 0);
+
+    STRCPY(buf, "a text that nott fits");
+    trunc_string(buf, buf, 20, 40);
+    assert(STRCMP(buf, "a text t...nott fits") == 0);
+
+    /* copy from string to buf */
+    trunc_string((char_u *)"text", buf, 20, 40);
+    assert(STRCMP(buf, "text") == 0);
+
+    trunc_string((char_u *)"a short text", buf, 20, 40);
+    assert(STRCMP(buf, "a short text") == 0);
+
+    trunc_string((char_u *)"a text tha just fits", buf, 20, 40);
+    assert(STRCMP(buf, "a text tha just fits") == 0);
+
+    trunc_string((char_u *)"a text that nott fits", buf, 20, 40);
+    assert(STRCMP(buf, "a text t...nott fits") == 0);
+}
+
+    int
+main(int argc, char **argv)
+{
+    mparm_T params;
+
+    vim_memset(&params, 0, sizeof(params));
+    params.argc = argc;
+    params.argv = argv;
+    common_init(&params);
+    init_chartab();
+
+    test_trunc_string();
+    return 0;
+}

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -389,7 +389,7 @@ static int included_patches[] = {
   // 2054 NA
   // 2053 NA
   // 2052 NA
-  // 2051,
+  2051,
   2050,
   2049,
   // 2048 NA


### PR DESCRIPTION
Problem:    No proper testing of trunc_string().
Solution:   Add a unittest for message.c.

https://github.com/vim/vim/commit/502ae4ba63561c98ac69af26cd9883bfd18d225f