### PR TITLE
[RDY] :move without closing folds

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -756,14 +756,6 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
   linenr_T num_lines;  // Num lines moved
   linenr_T last_line;  // Last line in file after adding new text
 
-  // Moving lines seems to corrupt the folds, delete folding info now
-  // and recreate it when finished.  Don't do this for manual folding, it
-  // would delete all folds.
-  bool isFolded = hasAnyFolding(curwin) && !foldmethodIsManual(curwin);
-  if (isFolded) {
-    deleteFoldRecurse(&curwin->w_folds);
-  }
-
   if (dest >= line1 && dest < line2) {
     EMSG(_("E134: Move lines into themselves"));
     return FAIL;
@@ -801,21 +793,29 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
    * their final destination at the new text position -- webb
    */
   last_line = curbuf->b_ml.ml_line_count;
-  mark_adjust(line1, line2, last_line - line2, 0L);
-  changed_lines(last_line - num_lines + 1, 0, last_line + 1, num_lines);
+  mark_adjust_nofold(line1, line2, last_line - line2, 0L);
   if (dest >= line2) {
-    mark_adjust(line2 + 1, dest, -num_lines, 0L);
+    mark_adjust_nofold(line2 + 1, dest, -num_lines, 0L);
+    FOR_ALL_TAB_WINDOWS(tab, win) {
+      if (win->w_buffer == curbuf) {
+        foldMoveRange(&win->w_folds, line1, line2, dest);
+      }
+    }
     curbuf->b_op_start.lnum = dest - num_lines + 1;
     curbuf->b_op_end.lnum = dest;
   } else {
-    mark_adjust(dest + 1, line1 - 1, num_lines, 0L);
+    mark_adjust_nofold(dest + 1, line1 - 1, num_lines, 0L);
+    FOR_ALL_TAB_WINDOWS(tab, win) {
+      if (win->w_buffer == curbuf) {
+        foldMoveRange(&win->w_folds, dest + 1, line1 - 1, line2);
+      }
+    }
     curbuf->b_op_start.lnum = dest + 1;
     curbuf->b_op_end.lnum = dest + num_lines;
   }
   curbuf->b_op_start.col = curbuf->b_op_end.col = 0;
-  mark_adjust(last_line - num_lines + 1, last_line,
-      -(last_line - dest - extra), 0L);
-  changed_lines(last_line - num_lines + 1, 0, last_line + 1, -extra);
+  mark_adjust_nofold(last_line - num_lines + 1, last_line,
+                     -(last_line - dest - extra), 0L);
 
   /*
    * Now we delete the original text -- webb
@@ -849,11 +849,6 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
     changed_lines(line1, 0, dest, 0L);
   } else {
     changed_lines(dest + 1, 0, line1 + num_lines, 0L);
-  }
-
-  // recreate folds
-  if (isFolded) {
-    foldUpdateAll(curwin);
   }
 
   return OK;

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -887,6 +887,23 @@ void ex_changes(exarg_T *eap)
  */
 void mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_after)
 {
+  mark_adjust_internal(line1, line2, amount, amount_after, true);
+}
+
+// mark_adjust_nofold() does the same as mark_adjust() but without adjusting
+// folds in any way. Folds must be adjusted manually by the caller.
+// This is only useful when folds need to be moved in a way different to
+// calling foldMarkAdjust() with arguments line1, line2, amount, amount_after,
+// for an example of why this may be necessary, see do_move().
+void mark_adjust_nofold(linenr_T line1, linenr_T line2, long amount,
+                        long amount_after)
+{
+  mark_adjust_internal(line1, line2, amount, amount_after, false);
+}
+
+static void mark_adjust_internal(linenr_T line1, linenr_T line2, long amount,
+                                 long amount_after, bool adjust_folds)
+{
   int i;
   int fnum = curbuf->b_fnum;
   linenr_T    *lp;
@@ -1011,8 +1028,9 @@ void mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_after)
         }
       }
 
-      /* adjust folds */
-      foldMarkAdjust(win, line1, line2, amount, amount_after);
+      if (adjust_folds) {
+        foldMarkAdjust(win, line1, line2, amount, amount_after);
+      }
     }
   }
 

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -120,17 +120,22 @@ func Test_manual_fold_with_filter()
   if !executable('cat')
     return
   endif
-  new
-  call setline(1, range(1, 20))
-  4,$fold
-  %foldopen
-  10,$fold
-  %foldopen
-  " This filter command should not have an effect
-  1,8! cat
-  call feedkeys('5ggzdzMGdd', 'xt')
-  call assert_equal(['1', '2', '3', '4', '5', '6', '7', '8', '9'], getline(1, '$'))
-  bwipe!
+  for type in ['manual', 'marker']
+    exe 'set foldmethod=' . type
+    new
+    call setline(1, range(1, 20))
+    4,$fold
+    %foldopen
+    10,$fold
+    %foldopen
+    " This filter command should not have an effect
+    1,8! cat
+    call feedkeys('5ggzdzMGdd', 'xt')
+    call assert_equal(['1', '2', '3', '4', '5', '6', '7', '8', '9'], getline(1, '$'))
+
+    bwipe!
+    set foldmethod&
+  endfor
 endfunc
 
 func! Test_move_folds_around_manual()

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -1,5 +1,9 @@
 " Test for folding
 
+func! PrepIndent(arg)
+  return [a:arg] + repeat(["\t".a:arg], 5)
+endfu
+
 func! Test_address_fold()
   new
   call setline(1, ['int FuncName() {/*{{{*/', 1, 2, 3, 4, 5, '}/*}}}*/',
@@ -127,4 +131,141 @@ func Test_manual_fold_with_filter()
   call feedkeys('5ggzdzMGdd', 'xt')
   call assert_equal(['1', '2', '3', '4', '5', '6', '7', '8', '9'], getline(1, '$'))
   bwipe!
+endfunc
+
+func! Test_move_folds_around_manual()
+  new
+  let input = PrepIndent("a") + PrepIndent("b") + PrepIndent("c")
+  call setline(1, PrepIndent("a") + PrepIndent("b") + PrepIndent("c"))
+  let folds=[-1, 2, 2, 2, 2, 2, -1, 8, 8, 8, 8, 8, -1, 14, 14, 14, 14, 14]
+  " all folds closed
+  set foldenable foldlevel=0 fdm=indent
+  " needs a forced redraw
+  redraw!
+  set fdm=manual
+  call assert_equal(folds, map(range(1, line('$')), 'foldclosed(v:val)'))
+  call assert_equal(input, getline(1, '$'))
+  7,12m0
+  call assert_equal(PrepIndent("b") + PrepIndent("a") + PrepIndent("c"), getline(1, '$'))
+  call assert_equal(folds, map(range(1, line('$')), 'foldclosed(v:val)'))
+  10,12m0
+  call assert_equal(PrepIndent("a")[1:] + PrepIndent("b") + ["a"] +  PrepIndent("c"), getline(1, '$'))
+  call assert_equal([1, 1, 1, 1, 1, -1, 7, 7, 7, 7, 7, -1, -1, 14, 14, 14, 14, 14], map(range(1, line('$')), 'foldclosed(v:val)'))
+  " moving should not close the folds
+  %d
+  call setline(1, PrepIndent("a") + PrepIndent("b") + PrepIndent("c"))
+  set fdm=indent
+  redraw!
+  set fdm=manual
+  call cursor(2, 1)
+  %foldopen
+  7,12m0
+  let folds=repeat([-1], 18)
+  call assert_equal(PrepIndent("b") + PrepIndent("a") + PrepIndent("c"), getline(1, '$'))
+  call assert_equal(folds, map(range(1, line('$')), 'foldclosed(v:val)'))
+  norm! zM
+  " folds are not corrupted and all have been closed
+  call assert_equal([-1, 2, 2, 2, 2, 2, -1, 8, 8, 8, 8, 8, -1, 14, 14, 14, 14, 14], map(range(1, line('$')), 'foldclosed(v:val)'))
+  %d
+  call setline(1, ["a", "\tb", "\tc", "\td", "\te"])
+  set fdm=indent
+  redraw!
+  set fdm=manual
+  %foldopen
+  3m4
+  %foldclose
+  call assert_equal(["a", "\tb", "\td", "\tc", "\te"], getline(1, '$'))
+  call assert_equal([-1, 5, 5, 5, 5], map(range(1, line('$')), 'foldclosedend(v:val)'))
+  %d
+  call setline(1, ["a", "\tb", "\tc", "\td", "\te", "z", "\ty", "\tx", "\tw", "\tv"])
+  set fdm=indent foldlevel=0
+  set fdm=manual
+  %foldopen
+  3m1
+  %foldclose
+  call assert_equal(["a", "\tc", "\tb", "\td", "\te", "z", "\ty", "\tx", "\tw", "\tv"], getline(1, '$'))
+  call assert_equal(0, foldlevel(2))
+  call assert_equal(5, foldclosedend(3))
+  call assert_equal([-1, -1, 3, 3, 3, -1, 7, 7, 7, 7], map(range(1, line('$')), 'foldclosed(v:val)'))
+  2,6m$
+  %foldclose
+  call assert_equal(5, foldclosedend(2))
+  call assert_equal(0, foldlevel(6))
+  call assert_equal(9, foldclosedend(7))
+  call assert_equal([-1, 2, 2, 2, 2, -1, 7, 7, 7, -1], map(range(1, line('$')), 'foldclosed(v:val)'))
+  %d
+  " Ensure moving around the edges still works.
+  call setline(1, PrepIndent("a") + repeat(["a"], 3) + ["\ta"])
+  set fdm=indent foldlevel=0
+  set fdm=manual
+  %foldopen
+  6m$
+  " The first fold has been truncated to the 5'th line.
+  " Second fold has been moved up because the moved line is now below it.
+  call assert_equal([0, 1, 1, 1, 1, 0, 0, 0, 1, 0], map(range(1, line('$')), 'foldlevel(v:val)'))
+  bw!
+endfunc
+
+func! Test_move_folds_around_indent()
+  new
+  let input = PrepIndent("a") + PrepIndent("b") + PrepIndent("c")
+  call setline(1, PrepIndent("a") + PrepIndent("b") + PrepIndent("c"))
+  let folds=[-1, 2, 2, 2, 2, 2, -1, 8, 8, 8, 8, 8, -1, 14, 14, 14, 14, 14]
+  " all folds closed
+  set fdm=indent
+  call assert_equal(folds, map(range(1, line('$')), 'foldclosed(v:val)'))
+  call assert_equal(input, getline(1, '$'))
+  7,12m0
+  call assert_equal(PrepIndent("b") + PrepIndent("a") + PrepIndent("c"), getline(1, '$'))
+  call assert_equal(folds, map(range(1, line('$')), 'foldclosed(v:val)'))
+  10,12m0
+  call assert_equal(PrepIndent("a")[1:] + PrepIndent("b") + ["a"] +  PrepIndent("c"), getline(1, '$'))
+  call assert_equal([1, 1, 1, 1, 1, -1, 7, 7, 7, 7, 7, -1, -1, 14, 14, 14, 14, 14], map(range(1, line('$')), 'foldclosed(v:val)'))
+  " moving should not close the folds
+  %d
+  call setline(1, PrepIndent("a") + PrepIndent("b") + PrepIndent("c"))
+  set fdm=indent
+  call cursor(2, 1)
+  %foldopen
+  7,12m0
+  let folds=repeat([-1], 18)
+  call assert_equal(PrepIndent("b") + PrepIndent("a") + PrepIndent("c"), getline(1, '$'))
+  call assert_equal(folds, map(range(1, line('$')), 'foldclosed(v:val)'))
+  norm! zM
+  " folds are not corrupted and all have been closed
+  call assert_equal([-1, 2, 2, 2, 2, 2, -1, 8, 8, 8, 8, 8, -1, 14, 14, 14, 14, 14], map(range(1, line('$')), 'foldclosed(v:val)'))
+  %d
+  call setline(1, ["a", "\tb", "\tc", "\td", "\te"])
+  set fdm=indent
+  %foldopen
+  3m4
+  %foldclose
+  call assert_equal(["a", "\tb", "\td", "\tc", "\te"], getline(1, '$'))
+  call assert_equal([-1, 5, 5, 5, 5], map(range(1, line('$')), 'foldclosedend(v:val)'))
+  %d
+  call setline(1, ["a", "\tb", "\tc", "\td", "\te", "z", "\ty", "\tx", "\tw", "\tv"])
+  set fdm=indent foldlevel=0
+  %foldopen
+  3m1
+  %foldclose
+  call assert_equal(["a", "\tc", "\tb", "\td", "\te", "z", "\ty", "\tx", "\tw", "\tv"], getline(1, '$'))
+  call assert_equal(1, foldlevel(2))
+  call assert_equal(5, foldclosedend(3))
+  call assert_equal([-1, 2, 2, 2, 2, -1, 7, 7, 7, 7], map(range(1, line('$')), 'foldclosed(v:val)'))
+  2,6m$
+  %foldclose
+  call assert_equal(9, foldclosedend(2))
+  call assert_equal(1, foldlevel(6))
+  call assert_equal(9, foldclosedend(7))
+  call assert_equal([-1, 2, 2, 2, 2, 2, 2, 2, 2, -1], map(range(1, line('$')), 'foldclosed(v:val)'))
+  " Ensure moving around the edges still works.
+  %d
+  call setline(1, PrepIndent("a") + repeat(["a"], 3) + ["\ta"])
+  set fdm=indent foldlevel=0
+  %foldopen
+  6m$
+  " The first fold has been truncated to the 5'th line.
+  " Second fold has been moved up because the moved line is now below it.
+  call assert_equal([0, 1, 1, 1, 1, 0, 0, 0, 1, 1], map(range(1, line('$')), 'foldlevel(v:val)'))
+  bw!
 endfunc

--- a/test/functional/normal/fold_spec.lua
+++ b/test/functional/normal/fold_spec.lua
@@ -5,9 +5,13 @@ local insert = helpers.insert
 local feed = helpers.feed
 local expect = helpers.expect
 local execute = helpers.execute
+local funcs = helpers.funcs
+local foldlevel, foldclosedend = funcs.foldlevel, funcs.foldclosedend
+local eq = helpers.eq
 
 describe('Folds', function()
   clear()
+  before_each(function() execute('enew!') end)
   it('manual folding adjusts with filter', function()
     insert([[
     1
@@ -43,5 +47,187 @@ describe('Folds', function()
     7
     8
     9]])
+  end)
+  describe('adjusting folds after :move', function()
+    local function manually_fold_indent()
+      -- setting foldmethod twice is a trick to get vim to set the folds for me
+      execute('set foldmethod=indent', 'set foldmethod=manual')
+      -- Ensure that all folds will get closed (makes it easier to test the
+      -- length of folds).
+      execute('set foldminlines=0')
+      -- Start with all folds open (so :move ranges aren't affected by closed
+      -- folds).
+      execute('%foldopen!')
+    end
+
+    local function get_folds()
+      local rettab = {}
+      for i = 1, funcs.line('$') do
+        table.insert(rettab, foldlevel(i))
+      end
+      return rettab
+    end
+
+    local function test_move_indent(insert_string, move_command)
+      -- This test is easy because we just need to ensure that the resulting
+      -- fold is the same as calculated when creating folds from scratch.
+      insert(insert_string)
+      execute(move_command)
+      local after_move_folds = get_folds()
+      -- Doesn't change anything, but does call foldUpdateAll()
+      execute('set foldminlines=0')
+      eq(after_move_folds, get_folds())
+      -- Set up the buffer with insert_string for the manual fold testing.
+      execute('enew!')
+      insert(insert_string)
+      manually_fold_indent()
+      execute(move_command)
+    end
+
+    it('neither closes nor corrupts folds', function()
+      test_move_indent([[
+a
+	a
+	a
+	a
+	a
+	a
+a
+	a
+	a
+		a
+	a
+	a
+a
+	a
+	a
+	a
+	a
+	a]], '7,12m0')
+      expect([[
+a
+	a
+	a
+		a
+	a
+	a
+a
+	a
+	a
+	a
+	a
+	a
+a
+	a
+	a
+	a
+	a
+	a]])
+      -- lines are not closed, folds are correct
+      for i = 1,funcs.line('$') do
+        eq(-1, funcs.foldclosed(i))
+        if i == 1 or i == 7 or i == 13 then
+          eq(0, foldlevel(i))
+        elseif i == 4 then
+          eq(2, foldlevel(i))
+        else
+          eq(1, foldlevel(i))
+        end
+      end
+      -- folds are not corrupted
+      feed('zM')
+      eq(6, foldclosedend(2))
+      eq(12, foldclosedend(8))
+      eq(18, foldclosedend(14))
+    end)
+    it("doesn't split a fold when the move is within it", function()
+      test_move_indent([[
+a
+	a
+	a
+		a
+		a
+		a
+		a
+	a
+	a
+a]], '5m6')
+      eq({0, 1, 1, 2, 2, 2, 2, 1, 1, 0}, get_folds())
+    end)
+    it('truncates folds that end in the moved range', function()
+      test_move_indent([[
+a
+	a
+		a
+		a
+		a
+a
+a]], '4,5m6')
+      eq({0, 1, 2, 0, 0, 0, 0}, get_folds())
+    end)
+    it('moves folds that start between moved range and destination', function()
+      test_move_indent([[
+a
+	a
+	a
+	a
+	a
+a
+a
+	a
+		a
+	a
+a
+a
+	a]], '3,4m$')
+      eq({0, 1, 1, 0, 0, 1, 2, 1, 0, 0, 1, 0, 0}, get_folds())
+    end)
+    it('does not affect folds outside changed lines', function()
+      test_move_indent([[
+	a
+	a
+	a
+a
+a
+a
+	a
+	a
+	a]], '4m5')
+      eq({1, 1, 1, 0, 0, 0, 1, 1, 1}, get_folds())
+    end)
+    it('moves and truncates folds that start in moved range', function()
+      test_move_indent([[
+a
+	a
+		a
+		a
+		a
+a
+a
+a
+a
+a]], '1,3m7')
+      eq({0, 0, 0, 0, 0, 1, 2, 0, 0, 0}, get_folds())
+    end)
+    it('breaks a fold when moving text into it', function()
+      test_move_indent([[
+a
+	a
+		a
+		a
+		a
+a
+a]], '$m4')
+      eq({0, 1, 2, 2, 0, 0, 0}, get_folds())
+    end)
+    it('adjusts correctly when moving a range backwards', function()
+      test_move_indent([[
+a
+	a
+		a
+		a
+a]], '2,3m0')
+      eq({1, 2, 0, 0, 0}, get_folds())
+    end)
   end)
 end)


### PR DESCRIPTION
### Problem description
The fix [here](https://groups.google.com/forum/#!msg/vim_dev/5SD5E_hyGPk/-ojYGyeNbwYJ)
for the problem with `:move` corrupting folds doesn't account for manual folds,
and has the unfortunate side effect of closing any open folds.

I've made an alternate fix, that doesn't have either of these problems.

@chrisbra -- I believe this fix would work in vim, but I haven't checked yet.

### Underlying problem
The cause of the underlying bug was that `do_move()` calls `mark_adjust()` to move marks around.
`mark_adjust()` then calls `foldMarkAdjust()` to do the same with folds.
`foldMarkAdjust()` assumes that it is being called for a simple shift occuring
from either deletion or insertion of lines. It hence moves folds without
checking if it causes overlap or leaves folds out of order in the growarray of
folds.
Once folds are out of order, `findFold()` isn't guaranteed to find the correct
fold, and hence the `foldUpdate()` call is compromised too.
Similarly, overlapping folds breaks some assumptions in
`foldUpdateIEMSRecurse()`, but I didn't look into what problems come from what
assumptions.

`do_move()` is the only place that `mark_adjust()` is called for something
other than a simple addition or deletion of lines, and hence the only place
that this problem is observed. (`do_filter()` actually also calls
`mark_adjust()` in a way that I suspect can cause bugs -- search for 
`"if (do_in)"` and see where marks are moved _then_ deleted -- but I haven't
checked/prooved there's a bug there yet so I haven't fixed it, and the fix
would simply be to swap the order of calls to `mark_adjust()` around there)

### My changes
I'm keeping the current behaviour of `foldMarkAdjust()`, as I don't believe
there's a clear way to handle all cases of moving folds so they overlap (e.g.
what should a generalised version of `foldMarkAdjust()` do if it is told to
move a range of folds down such that the top of the next fold is now within a
fold contained in the range that has been moved).

Instead, in `do_move()` I'm moving marks around in the same way they were
before but without moving the folds (by introducing a new function called
`mark_adjust_nofold()`, and I'm directly moving the folds with a new function
called `foldSwapRange()`.

### WIP because
1) I plan on checking a suspected bug in `do_filter()`.
2) I wanted to ask others if this seems like a reasonable fix in the meantime
(to hear any faults others might see).
