### PR TITLE
vim_getenv: $VIMRUNTIME fallback to ../share/runtime

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -657,14 +657,9 @@ is the order used to find the value of $VIMRUNTIME:
 3. If "$VIM/runtime" exists, it is used.
 4. The value of $VIM is used.  This is for backwards compatibility with older
    versions.
-5. When the 'helpfile' option is set and doesn't contain a '$', its value is
+5. If "../share/nvim/runtime" exists relative to |v:progpath|, it is used.
+6. When the 'helpfile' option is set and doesn't contain a '$', its value is
    used, with "doc/help.txt" removed from the end.
-
-For Unix, when there is a compiled-in default for $VIMRUNTIME (check the
-output of ":version"), steps 2, 3 and 4 are skipped, and the compiled-in
-default is used after step 5.  This means that the compiled-in default
-overrules the value of $VIM.  This is useful if $VIM is "/etc" and the runtime
-files are in "/usr/share/vim/vim54".
 
 Once Vim has done this once, it will set the $VIMRUNTIME environment variable.
 To change it later, use a ":let" command like this: >

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -615,8 +615,7 @@ char *vim_getenv(const char *name)
       vim_path = (char *)p_hf;
     }
 
-#ifdef WIN32
-    // Find runtime path relative to the nvim binary i.e. ../share/runtime
+    // Find runtime path relative to the nvim binary: ../share/nvim/runtime
     if (vim_path == NULL) {
       char exe_name[MAXPATHL];
       size_t exe_name_len = MAXPATHL;
@@ -633,7 +632,6 @@ char *vim_getenv(const char *name)
         }
       }
     }
-#endif
 
     if (vim_path != NULL) {
       // remove the file name


### PR DESCRIPTION
Do this on all systems, so that portable builds work everywhere. This allows us to ship archives with this folder structure:

```
bin/nvim
share/nvim/runtime
```

and `./bin/nvim` works without the user needing to explicitly set VIMRUNTIME.