### PR TITLE
[RFC] vim-patch:7.4.2299

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4278,12 +4278,44 @@ int set_errorlist(win_T *wp, list_T *list, int action, char_u *title,
  */
 void ex_cbuffer(exarg_T *eap)
 {
-  buf_T       *buf = NULL;
-  qf_info_T   *qi = &ql_info;
+  buf_T *buf = NULL;
+  qf_info_T *qi = &ql_info;
+  const char *au_name = NULL;
 
   if (eap->cmdidx == CMD_lbuffer || eap->cmdidx == CMD_lgetbuffer
       || eap->cmdidx == CMD_laddbuffer) {
     qi = ll_get_or_alloc_list(curwin);
+  }
+
+  switch (eap->cmdidx) {
+    case CMD_cbuffer:
+      au_name = "cbuffer";
+      break;
+    case CMD_cgetbuffer:
+      au_name = "cgetbuffer";
+      break;
+    case CMD_caddbuffer:
+      au_name = "caddbuffer";
+      break;
+    case CMD_lbuffer:
+      au_name = "lbuffer";
+      break;
+    case CMD_lgetbuffer:
+      au_name = "lgetbuffer";
+      break;
+    case CMD_laddbuffer:
+      au_name = "laddbuffer";
+      break;
+    default:
+      break;
+  }
+
+  if (au_name != NULL) {
+    apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)au_name,
+                   curbuf->b_fname, true, curbuf);
+    if (did_throw || force_abort) {
+      return;
+    }
   }
 
   if (*eap->arg == NUL)
@@ -4312,13 +4344,17 @@ void ex_cbuffer(exarg_T *eap)
       }
 
       if (qf_init_ext(qi, NULL, buf, NULL, p_efm,
-              (eap->cmdidx != CMD_caddbuffer
-               && eap->cmdidx != CMD_laddbuffer),
-              eap->line1, eap->line2,
-              qf_title) > 0
-          && (eap->cmdidx == CMD_cbuffer
-              || eap->cmdidx == CMD_lbuffer))
-        qf_jump(qi, 0, 0, eap->forceit);          /* display first error */
+                      (eap->cmdidx != CMD_caddbuffer
+                       && eap->cmdidx != CMD_laddbuffer),
+                      eap->line1, eap->line2, qf_title) > 0) {
+        if (au_name != NULL) {
+          apply_autocmds(EVENT_QUICKFIXCMDPOST, (char_u *)au_name,
+                         curbuf->b_fname, true, curbuf);
+        }
+        if (eap->cmdidx == CMD_cbuffer || eap->cmdidx == CMD_lbuffer) {
+          qf_jump(qi, 0, 0, eap->forceit);  // display first error
+        }
+      }
     }
   }
 }
@@ -4329,12 +4365,43 @@ void ex_cbuffer(exarg_T *eap)
  */
 void ex_cexpr(exarg_T *eap)
 {
-  typval_T    *tv;
-  qf_info_T   *qi = &ql_info;
+  typval_T *tv;
+  qf_info_T *qi = &ql_info;
+  const char *au_name = NULL;
 
   if (eap->cmdidx == CMD_lexpr || eap->cmdidx == CMD_lgetexpr
       || eap->cmdidx == CMD_laddexpr) {
     qi = ll_get_or_alloc_list(curwin);
+  }
+
+  switch (eap->cmdidx) {
+    case CMD_cexpr:
+      au_name = "cexpr";
+      break;
+    case CMD_cgetexpr:
+      au_name = "cgetexpr";
+      break;
+    case CMD_caddexpr:
+      au_name = "caddexpr";
+      break;
+    case CMD_lexpr:
+      au_name = "lexpr";
+      break;
+    case CMD_lgetexpr:
+      au_name = "lgetexpr";
+      break;
+    case CMD_laddexpr:
+      au_name = "laddexpr";
+      break;
+    default:
+      break;
+  }
+  if (au_name != NULL) {
+    apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)au_name,
+                   curbuf->b_fname, true, curbuf);
+    if (did_throw || force_abort) {
+      return;
+    }
   }
 
   /* Evaluate the expression.  When the result is a string or a list we can
@@ -4344,14 +4411,20 @@ void ex_cexpr(exarg_T *eap)
     if ((tv->v_type == VAR_STRING && tv->vval.v_string != NULL)
         || (tv->v_type == VAR_LIST && tv->vval.v_list != NULL)) {
       if (qf_init_ext(qi, NULL, NULL, tv, p_efm,
-              (eap->cmdidx != CMD_caddexpr
-               && eap->cmdidx != CMD_laddexpr),
-              (linenr_T)0, (linenr_T)0, *eap->cmdlinep) > 0
-          && (eap->cmdidx == CMD_cexpr
-              || eap->cmdidx == CMD_lexpr))
-        qf_jump(qi, 0, 0, eap->forceit);          /* display first error */
-    } else
+                      (eap->cmdidx != CMD_caddexpr
+                       && eap->cmdidx != CMD_laddexpr),
+                      (linenr_T)0, (linenr_T)0, *eap->cmdlinep) > 0) {
+        if (au_name != NULL) {
+          apply_autocmds(EVENT_QUICKFIXCMDPOST, (char_u *)au_name,
+                         curbuf->b_fname, true, curbuf);
+        }
+        if (eap->cmdidx == CMD_cexpr || eap->cmdidx == CMD_lexpr) {
+          qf_jump(qi, 0, 0, eap->forceit);  // display first error
+        }
+      }
+    } else {
       EMSG(_("E777: String or List expected"));
+    }
     free_tv(tv);
   }
 }

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1525,3 +1525,38 @@ function Test_qf_property()
     call Xproperty_tests('c')
     call Xproperty_tests('l')
 endfunction
+
+" Tests for the QuickFixCmdPre/QuickFixCmdPost autocommands
+function QfAutoCmdHandler(loc, cmd)
+  call add(g:acmds, a:loc . a:cmd)
+endfunction
+
+function Test_Autocmd()
+  autocmd QuickFixCmdPre * call QfAutoCmdHandler('pre', expand('<amatch>'))
+  autocmd QuickFixCmdPost * call QfAutoCmdHandler('post', expand('<amatch>'))
+
+  let g:acmds = []
+  cexpr "F1:10:Line 10"
+  caddexpr "F1:20:Line 20"
+  cgetexpr "F1:30:Line 30"
+  enew! | call append(0, "F2:10:Line 10")
+  cbuffer!
+  enew! | call append(0, "F2:20:Line 20")
+  cgetbuffer
+  enew! | call append(0, "F2:30:Line 30")
+  caddbuffer
+
+  let l = ['precexpr',
+      \ 'postcexpr',
+      \ 'precaddexpr',
+      \ 'postcaddexpr',
+      \ 'precgetexpr',
+      \ 'postcgetexpr',
+      \ 'precbuffer',
+      \ 'postcbuffer',
+      \ 'precgetbuffer',
+      \ 'postcgetbuffer',
+      \ 'precaddbuffer',
+      \ 'postcaddbuffer']
+  call assert_equal(l, g:acmds)
+endfunction

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -141,7 +141,7 @@ static int included_patches[] = {
   // 2302 NA
   // 2301 NA
   2300,
-  // 2299,
+  2299,
   // 2298 NA
   // 2297 NA
   // 2296,


### PR DESCRIPTION
```
vim-patch:7.4.2299

Problem:    QuickFixCmdPre and QuickFixCmdPost autocommands are not always
            triggered.
Solution:   Also trigger on ":expr", ":cbuffer", etc. (Yegappan Lakshmanan)
```
https://github.com/vim/vim/commit/04c4ce650f9e533cd35b2aa6803f4d354d3ec7aa