### PR TITLE
[RFC] Don't truncate error messages

### DIFF
--- a/scripts/gendispatch.lua
+++ b/scripts/gendispatch.lua
@@ -220,8 +220,7 @@ for i = 1, #functions do
     end
     output:write('\n')
     output:write('\n  if (args.size != '..#fn.parameters..') {')
-    output:write('\n    snprintf(error->msg, sizeof(error->msg), "Wrong number of arguments: expecting '..#fn.parameters..' but got %zu", args.size);')
-    output:write('\n    error->set = true;')
+    output:write('\n    _api_set_error(error, error->type, "Wrong number of arguments: expecting '..#fn.parameters..' but got %zu", args.size);')
     output:write('\n    goto cleanup;')
     output:write('\n  }\n')
 
@@ -246,8 +245,7 @@ for i = 1, #functions do
           output:write('\n    '..converted..' = (handle_T)args.items['..(j - 1)..'].data.integer;')
         end
         output:write('\n  } else {')
-        output:write('\n    snprintf(error->msg, sizeof(error->msg), "Wrong type for argument '..j..', expecting '..param[1]..'");')
-        output:write('\n    error->set = true;')
+        output:write('\n    _api_set_error(error, error->type, "Wrong type for argument '..j..', expecting '..param[1]..'");')
         output:write('\n    goto cleanup;')
         output:write('\n  }\n')
       else

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -624,7 +624,9 @@ void nvim_buf_set_name(Buffer buffer, String name, Error *err)
 Boolean nvim_buf_is_valid(Buffer buffer)
 {
   Error stub = ERROR_INIT;
-  return find_buffer_by_handle(buffer, &stub) != NULL;
+  Boolean ret = find_buffer_by_handle(buffer, &stub) != NULL;
+  xfree(stub.msg);
+  return ret;
 }
 
 /// Inserts a sequence of lines to a buffer at a certain index

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -8,7 +8,7 @@
 #define ARRAY_DICT_INIT {.size = 0, .capacity = 0, .items = NULL}
 #define STRING_INIT {.data = NULL, .size = 0}
 #define OBJECT_INIT { .type = kObjectTypeNil }
-#define ERROR_INIT { .set = false }
+#define ERROR_INIT { .set = false, .msg = NULL }
 #define REMOTE_TYPE(type) typedef handle_T type
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -38,7 +38,7 @@ typedef enum {
 
 typedef struct {
   ErrorType type;
-  char msg[1024];
+  char *msg;
   bool set;
 } Error;
 

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -65,8 +65,7 @@ bool try_end(Error *err)
                                              ET_ERROR,
                                              NULL,
                                              &should_free);
-    xstrlcpy(err->msg, msg, sizeof(err->msg));
-    err->set = true;
+    _api_set_error(err, err->type, "%s", msg);
     free_global_msglist();
 
     if (should_free) {
@@ -970,4 +969,20 @@ static void set_option_value_err(char *key,
 
     api_set_error(err, Exception, "%s", errmsg);
   }
+}
+
+void _api_set_error(Error *err, ErrorType errType, const char *format, ...)
+{
+    va_list args1;
+    va_start(args1, format);
+    va_list args2;
+    va_copy(args2, args1);
+    int len = vsnprintf(NULL, 0, format, args1);
+    va_end(args1);
+    err->msg = xmalloc(len+1);
+    vsprintf(err->msg, format, args2);
+    va_end(args2);
+	
+    err->set = true;
+    err->type = errType;
 }

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -982,7 +982,7 @@ void _api_set_error(Error *err, ErrorType errType, const char *format, ...)
     err->msg = xmalloc(len+1);
     vsprintf(err->msg, format, args2);
     va_end(args2);
-	
+
     err->set = true;
     err->type = errType;
 }

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -979,7 +979,7 @@ void _api_set_error(Error *err, ErrorType errType, const char *format, ...)
     va_copy(args2, args1);
     int len = vsnprintf(NULL, 0, format, args1);
     va_end(args1);
-    err->msg = xmalloc(len+1);
+    err->msg = xmalloc((size_t)len + 1);
     vsprintf(err->msg, format, args2);
     va_end(args2);
 

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -8,14 +8,9 @@
 #include "nvim/memory.h"
 #include "nvim/lib/kvec.h"
 
+void _api_set_error(Error *err, ErrorType errType, const char *format, ...);
 #define api_set_error(err, errtype, ...) \
-  do { \
-    snprintf((err)->msg, \
-             sizeof((err)->msg), \
-             __VA_ARGS__); \
-    (err)->set = true; \
-    (err)->type = kErrorType##errtype; \
-  } while (0)
+	_api_set_error(err, kErrorType##errtype, __VA_ARGS__)
 
 #define OBJECT_OBJ(o) o
 

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -10,7 +10,7 @@
 
 void _api_set_error(Error *err, ErrorType errType, const char *format, ...);
 #define api_set_error(err, errtype, ...) \
-	_api_set_error(err, kErrorType##errtype, __VA_ARGS__)
+    _api_set_error(err, kErrorType##errtype, __VA_ARGS__)
 
 #define OBJECT_OBJ(o) o
 

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -183,6 +183,8 @@ Integer nvim_tabpage_get_number(Tabpage tabpage, Error *err)
 Boolean nvim_tabpage_is_valid(Tabpage tabpage)
 {
   Error stub = ERROR_INIT;
-  return find_tab_by_handle(tabpage, &stub) != NULL;
+  Boolean ret = find_tab_by_handle(tabpage, &stub) != NULL;
+  xfree(stub.msg);
+  return ret;
 }
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -757,10 +757,12 @@ Array nvim_call_atomic(uint64_t channel_id, Array calls, Error *err)
   } else {
     ADD(rv, NIL);
   }
+  xfree(nested_error.msg);
   return rv;
 
 validation_error:
   api_free_array(results);
+  xfree(nested_error.msg);
   return rv;
 }
 

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -368,6 +368,8 @@ Integer nvim_win_get_number(Window window, Error *err)
 Boolean nvim_win_is_valid(Window window)
 {
   Error stub = ERROR_INIT;
-  return find_window_by_handle(window, &stub) != NULL;
+  Boolean ret = find_window_by_handle(window, &stub) != NULL;
+  xfree(stub.msg);
+  return ret;
 }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7790,6 +7790,7 @@ static void api_wrapper(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 end:
   api_free_array(args);
   api_free_object(result);
+  xfree(err.msg);
 }
 
 /*
@@ -15068,6 +15069,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
 end:
   api_free_object(result);
+  xfree(err.msg);
 }
 
 // "rpcstart()" function (DEPRECATED)
@@ -17791,7 +17793,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   curbuf->b_p_swf = false;
   (void)setfname(curbuf, (uint8_t *)buf, NULL, true);
   // Save the job id and pid in b:terminal_job_{id,pid}
-  Error err;
+  Error err = ERROR_INIT;
   dict_set_var(curbuf->b_vars, cstr_as_string("terminal_job_id"),
                INTEGER_OBJ(rettv->vval.v_number), false, false, &err);
   dict_set_var(curbuf->b_vars, cstr_as_string("terminal_job_pid"),
@@ -17800,6 +17802,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   Terminal *term = terminal_open(topts);
   data->term = term;
   data->refcount++;
+  xfree(err.msg);
 
   return;
 }

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -217,7 +217,7 @@ Object channel_send_call(uint64_t id,
           && (array.items[0].data.integer == kErrorTypeException
               || array.items[0].data.integer == kErrorTypeValidation)
           && array.items[1].type == kObjectTypeString) {
-        _api_set_error(err, (ErrorType) array.items[0].data.integer, "%s",
+        _api_set_error(err, (ErrorType)array.items[0].data.integer, "%s",
                        array.items[1].data.string.data);
       } else {
         api_set_error(err, Exception, "%s", "unknown error");

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -461,8 +461,7 @@ Object msgpack_rpc_handle_missing_method(uint64_t channel_id,
                                          Array args,
                                          Error *error)
 {
-  snprintf(error->msg, sizeof(error->msg), "Invalid method name");
-  error->set = true;
+  _api_set_error(error, error->type, "Invalid method name");
   return NIL;
 }
 
@@ -471,8 +470,7 @@ Object msgpack_rpc_handle_invalid_arguments(uint64_t channel_id,
                                             Array args,
                                             Error *error)
 {
-  snprintf(error->msg, sizeof(error->msg), "Invalid method arguments");
-  error->set = true;
+  _api_set_error(error, error->type, "Invalid method arguments");
   return NIL;
 }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -630,13 +630,14 @@ static int term_movecursor(VTermPos new, VTermPos old, int visible,
 static void buf_set_term_title(buf_T *buf, char *title)
     FUNC_ATTR_NONNULL_ALL
 {
-  Error err;
+  Error err = ERROR_INIT;
   dict_set_var(buf->b_vars,
                STATIC_CSTR_AS_STRING("term_title"),
                STRING_OBJ(cstr_as_string(title)),
                false,
                false,
                &err);
+  xfree(err.msg);
 }
 
 static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
@@ -1217,13 +1218,14 @@ static bool is_focused(Terminal *term)
 
 #define GET_CONFIG_VALUE(k, o) \
   do { \
-    Error err; \
+    Error err = ERROR_INIT; \
     /* Only called from terminal_open where curbuf->terminal is the */ \
     /* context  */ \
     o = dict_get_value(curbuf->b_vars, cstr_as_string(k), &err); \
     if (o.type == kObjectTypeNil) { \
       o = dict_get_value(&globvardict, cstr_as_string(k), &err); \
     } \
+    xfree(err.msg); \
   } while (0)
 
 static char *get_config_string(char *key)

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -225,7 +225,7 @@ static int get_key_code_timeout(void)
   if (nvim_get_option(cstr_as_string("ttimeout"), &err).data.boolean) {
     ms = nvim_get_option(cstr_as_string("ttimeoutlen"), &err).data.integer;
   }
-
+  xfree(err.msg);
   return (int)ms;
 }
 

--- a/test/functional/provider/python3_spec.lua
+++ b/test/functional/provider/python3_spec.lua
@@ -30,6 +30,12 @@ describe('python3 commands and functions', function()
     eq({100, 0}, eval('g:set_by_python3'))
   end)
 
+  it('displays the entire error message', function()
+    helpers.execute(':silent! py3 print(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa b)')
+    -- If error messages are truncated, errmsg will not contain the final line.
+    eq('SyntaxError: invalid syntax',eval('v:errmsg'))
+  end)
+
   it('python3_execute with nested commands', function()
     command([[python3 vim.command('python3 vim.command("python3 vim.command(\'let set_by_nested_python3 = 555\')")')]])
     eq(555, eval('g:set_by_nested_python3'))


### PR DESCRIPTION
 This fixes #5984.

~~The functional test currently is not working; it freezes during execution.  I think this is because Neovim displays the `-- More -- SPACE/d/j: screen/page/line down, b/u/k: up, q: quit` line, which causes the `eval` not to be executed. I tried to do `feed('q')`, `feed('q<cr>')` and `feed('<cr>')`, but none of these help. How can I solve this?~~ The test is working properly now.

Currently, both the define `api_set_error` and the function `_api_set_error` are used from other files. Ideally, only the define would be used. However, not all code that writes to the error message actually sets the ErrorType, which is why the function is called instead. Should these occurrences be changed to actually set the correct type (in which case only the define is used from other files)?

Finally, a question about the performance. The `_api_set_error` always executes `vsnprintf` twice. Should I add a fast path for small error messages (e.g. allocate buffer on stack, print to that buffer, copy buffer to allocated space if the message actually fitted inside the temporary buffer)?