### PR TITLE
[RFC] vim-patch:8.0.0068

### DIFF
--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -994,11 +994,12 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose,
       return FALSE;
     }
 
-    if (*qfpos != '0') {
-      apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)"cscope",
-          curbuf->b_fname, TRUE, curbuf);
-      if (did_throw || force_abort)
+    if (*qfpos != '0'
+            && apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)"cscope",
+                curbuf->b_fname, TRUE, curbuf)) {
+      if (aborting()) {
         return FALSE;
+      }
     }
   }
 

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -995,10 +995,10 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose,
     }
 
     if (*qfpos != '0'
-            && apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)"cscope",
-                curbuf->b_fname, TRUE, curbuf)) {
+        && apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)"cscope",
+                          curbuf->b_fname, true, curbuf)) {
       if (aborting()) {
-        return FALSE;
+        return false;
       }
     }
   }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3023,11 +3023,11 @@ void ex_make(exarg_T *eap)
   case CMD_lgrepadd:  au_name = (char_u *)"lgrepadd"; break;
   default: break;
   }
-  if (au_name != NULL) {
-    apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name,
-        curbuf->b_fname, TRUE, curbuf);
-    if (did_throw || force_abort)
+  if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name,
+              curbuf->b_fname, TRUE, curbuf)) {
+    if (aborting()) {
       return;
+    }
   }
 
   if (eap->cmdidx == CMD_lmake || eap->cmdidx == CMD_lgrep
@@ -3487,11 +3487,11 @@ void ex_vimgrep(exarg_T *eap)
   case CMD_lgrepadd:    au_name = (char_u *)"lgrepadd"; break;
   default: break;
   }
-  if (au_name != NULL) {
-    apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name,
-        curbuf->b_fname, TRUE, curbuf);
-    if (did_throw || force_abort)
+  if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name,
+              curbuf->b_fname, TRUE, curbuf)) {
+    if (aborting()) {
       return;
+    }
   }
 
   if (eap->cmdidx == CMD_lgrep
@@ -4310,10 +4310,9 @@ void ex_cbuffer(exarg_T *eap)
       break;
   }
 
-  if (au_name != NULL) {
-    apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)au_name,
-                   curbuf->b_fname, true, curbuf);
-    if (did_throw || force_abort) {
+  if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)au_name,
+              curbuf->b_fname, true, curbuf)) {
+    if (aborting()) {
       return;
     }
   }
@@ -4396,10 +4395,9 @@ void ex_cexpr(exarg_T *eap)
     default:
       break;
   }
-  if (au_name != NULL) {
-    apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)au_name,
-                   curbuf->b_fname, true, curbuf);
-    if (did_throw || force_abort) {
+  if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)au_name,
+              curbuf->b_fname, true, curbuf)) {
+    if (aborting()) {
       return;
     }
   }
@@ -4455,11 +4453,11 @@ void ex_helpgrep(exarg_T *eap)
   case CMD_lhelpgrep: au_name = (char_u *)"lhelpgrep"; break;
   default: break;
   }
-  if (au_name != NULL) {
-    apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name,
-        curbuf->b_fname, TRUE, curbuf);
-    if (did_throw || force_abort)
+  if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name,
+              curbuf->b_fname, TRUE, curbuf)) {
+    if (aborting()) {
       return;
+    }
   }
 
   /* Make 'cpoptions' empty, the 'l' flag should not be used here. */

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3024,7 +3024,7 @@ void ex_make(exarg_T *eap)
   default: break;
   }
   if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name,
-              curbuf->b_fname, TRUE, curbuf)) {
+                                        curbuf->b_fname, true, curbuf)) {
     if (aborting()) {
       return;
     }
@@ -3488,7 +3488,7 @@ void ex_vimgrep(exarg_T *eap)
   default: break;
   }
   if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name,
-              curbuf->b_fname, TRUE, curbuf)) {
+                                        curbuf->b_fname, true, curbuf)) {
     if (aborting()) {
       return;
     }
@@ -4311,7 +4311,7 @@ void ex_cbuffer(exarg_T *eap)
   }
 
   if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)au_name,
-              curbuf->b_fname, true, curbuf)) {
+                                        curbuf->b_fname, true, curbuf)) {
     if (aborting()) {
       return;
     }
@@ -4396,7 +4396,7 @@ void ex_cexpr(exarg_T *eap)
       break;
   }
   if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, (char_u *)au_name,
-              curbuf->b_fname, true, curbuf)) {
+                                        curbuf->b_fname, true, curbuf)) {
     if (aborting()) {
       return;
     }
@@ -4454,7 +4454,7 @@ void ex_helpgrep(exarg_T *eap)
   default: break;
   }
   if (au_name != NULL && apply_autocmds(EVENT_QUICKFIXCMDPRE, au_name,
-              curbuf->b_fname, TRUE, curbuf)) {
+                                        curbuf->b_fname, true, curbuf)) {
     if (aborting()) {
       return;
     }

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1560,3 +1560,20 @@ function Test_Autocmd()
       \ 'postcaddbuffer']
   call assert_equal(l, g:acmds)
 endfunction
+
+function! Test_Autocmd_Exception()
+  set efm=%m
+  lgetexpr '?'
+
+  try
+    call DoesNotExit()
+  catch
+    lgetexpr '1'
+  finally
+    lgetexpr '1'
+  endtry
+
+  call assert_equal('1', getloclist(0)[0].text)
+
+  set efm&vim
+endfunction


### PR DESCRIPTION
Problem:    Checking did_throw after executing autocommands is wrong. (Daniel
            Hahler)
Solution:   Call aborting() instead, and only when autocommands were executed.

https://github.com/vim/vim/commit/21662be2211675824df1771c7f169948ede40c41


Patch 7.4.2299 was added in https://github.com/neovim/neovim/pull/6232, and now causes Neovim to be affected by https://github.com/vim/vim/issues/1225.

To fix this, patch 8.0.0068 needs to be included, too.