### PR TITLE
[RFC] Load remote plugins on vim start

### DIFF
--- a/runtime/plugin/rplugin.vim
+++ b/runtime/plugin/rplugin.vim
@@ -5,12 +5,14 @@ let g:loaded_remote_plugins = 1
 
 command! UpdateRemotePlugins call remote#host#UpdateRemotePlugins()
 
-augroup nvim-rplugin
-  autocmd!
-  autocmd FuncUndefined *
-        \ call remote#host#LoadRemotePluginsEvent(
-        \   'FuncUndefined', expand('<amatch>'))
-  autocmd CmdUndefined *
-        \ call remote#host#LoadRemotePluginsEvent(
-        \   'CmdUndefined', expand('<amatch>'))
-augroup END
+call remote#host#LoadRemotePlugins()
+
+"augroup nvim-rplugin
+"  autocmd!
+"  autocmd FuncUndefined *
+"        \ call remote#host#LoadRemotePluginsEvent(
+"        \   'FuncUndefined', expand('<amatch>'))
+"  autocmd CmdUndefined *
+"        \ call remote#host#LoadRemotePluginsEvent(
+"        \   'CmdUndefined', expand('<amatch>'))
+"augroup END


### PR DESCRIPTION
Fix for #5821
 
Call `remote#host#LoadRemotePlugins` at vim startup, so that autocmd would always works.
The extra benifit is `command` defined by remote plugins would able to get completed by `<tab>`
