### PR TITLE
Improve ycm_extra_conf.py for the latest version of YCM.

### DIFF
--- a/contrib/YouCompleteMe/README.md
+++ b/contrib/YouCompleteMe/README.md
@@ -2,7 +2,9 @@
 
 ## What is this?
 
-This provides the code necessary to configure vim's YCM plugin to provide C semantic support (completion, go-to-definition, etc) for developers working on the Neovim project.
+This provides the code necessary to configure vim's YCM plugin to provide C
+semantic support (completion, go-to-definition, etc) for developers working on
+the Neovim project.
 
 ## Installation
 
@@ -13,10 +15,17 @@ Install [YouCompleteMe](https://github.com/Valloric/YouCompleteMe).
 ### Step 2
 
 ```bash
-cp contrib/YouCompleteMe/ycm_extra_conf.py src/.ycm_extra_conf.py
+cp contrib/YouCompleteMe/ycm_extra_conf.py .ycm_extra_conf.py
 echo .ycm_extra_conf.py >> .git/info/exclude
 make
-
-(Add the following somewhere in your vimrc)
-autocmd FileType c nnoremap <buffer> <silent> <C-]> :YcmCompleter GoTo<cr>
 ```
+
+Tip: to improve source code navigation, add something like this to your nvim
+configuration:
+
+```vim
+au FileType c,cpp nnoremap <buffer> <c-]> :YcmCompleter GoTo<CR>
+```
+
+And use `ctrl+]` when the cursor is positioned in a symbol to quickly jump to a
+definition or declaration.

--- a/contrib/YouCompleteMe/ycm_extra_conf.py
+++ b/contrib/YouCompleteMe/ycm_extra_conf.py
@@ -9,33 +9,44 @@ def DirectoryOfThisScript():
 
 def GetDatabase():
     compilation_database_folder = os.path.join(DirectoryOfThisScript(),
-                                               '..', 'build')
+                                               'build')
     if os.path.exists(compilation_database_folder):
         return ycm_core.CompilationDatabase(compilation_database_folder)
     return None
-
-
-def IsHeaderFile(filename):
-    extension = os.path.splitext(filename)[1]
-    return extension == '.h'
 
 
 def GetCompilationInfoForFile(filename):
     database = GetDatabase()
     if not database:
         return None
-    if IsHeaderFile(filename):
-        basename = os.path.splitext(filename)[0]
-        c_file = basename + '.c'
-        # for pure headers (no c file), default to main.c
-        if not os.path.exists(c_file):
-            c_file = os.path.join(DirectoryOfThisScript(), 'nvim', 'main.c')
-        if os.path.exists(c_file):
-            compilation_info = database.GetCompilationInfoForFile(c_file)
-            if compilation_info.compiler_flags_:
-                return compilation_info
-        return None
     return database.GetCompilationInfoForFile(filename)
+
+
+# It seems YCM does not resolve directories correctly. This function will
+# adjust paths in the compiler flags to be absolute
+def FixDirectories(args, compiler_working_dir):
+    def adjust_path(path):
+        return os.path.abspath(os.path.join(compiler_working_dir, path))
+
+    adjust_next_arg = False
+    new_args = []
+    for arg in args:
+        if adjust_next_arg:
+            arg = adjust_path(arg)
+            adjust_next_arg = False
+        else:
+            for dir_flag in ['-I', '-isystem', '-o', '-c']:
+                if arg.startswith(dir_flag):
+                    if arg != dir_flag:
+                        # flag and path are concatenated in same arg
+                        path = arg[len(dir_flag):]
+                        new_path = adjust_path(path)
+                        arg = '{0}{1}'.format(dir_flag, new_path)
+                    else:
+                        # path is specified in next argument
+                        adjust_next_arg = True
+        new_args.append(arg)
+    return new_args
 
 
 def FlagsForFile(filename):
@@ -44,12 +55,11 @@ def FlagsForFile(filename):
         return None
     # Add flags not needed for clang-the-binary,
     # but needed for libclang-the-library (YCM uses this last one).
-    flags = (list(compilation_info.compiler_flags_)
-             if compilation_info.compiler_flags_
-             else [])
+    flags = FixDirectories((list(compilation_info.compiler_flags_)
+                            if compilation_info.compiler_flags_
+                            else []), compilation_info.compiler_working_dir_)
     extra_flags = ['-Wno-newline-eof']
-    final_flags = flags + extra_flags
     return {
-        'flags': final_flags,
+        'flags': flags + extra_flags,
         'do_cache': True
     }


### PR DESCRIPTION
- Remove some unnecessary code: IsHeaderFile is no longer required, as the logic
  to find flags to headers is now built into YCM
- Add function to make paths in flags absolute: It seems YCM is not correctly
  resolving paths in flags to consider `build` as the compiler working
  directory.
- Update documentation.