### PR TITLE
ui: Reset 'lazyredraw' during ui_refresh.

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7440,11 +7440,7 @@ int number_width(win_T *wp)
   return n;
 }
 
-/// Set size of the Vim shell.
-/// If 'mustset' is TRUE, we must set Rows and Columns, do not get the real
-/// window size (this is used for the :win command).
-/// If 'mustset' is FALSE, we may try to get the real window size and if
-/// it fails use 'width' and 'height'.
+/// Set dimensions of the Nvim application "shell".
 void screen_resize(int width, int height)
 {
   static int busy = FALSE;
@@ -7529,8 +7525,8 @@ void screen_resize(int width, int height)
   --busy;
 }
 
-// Check if the new shell size is valid, correct it if it's too small or way
-// too big.
+/// Check if the new Nvim application "shell" dimensions are valid.
+/// Correct it if it's too small or way too big.
 void check_shellsize(void)
 {
   if (Rows < min_rows()) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7440,13 +7440,11 @@ int number_width(win_T *wp)
   return n;
 }
 
-/*
- * Set size of the Vim shell.
- * If 'mustset' is TRUE, we must set Rows and Columns, do not get the real
- * window size (this is used for the :win command).
- * If 'mustset' is FALSE, we may try to get the real window size and if
- * it fails use 'width' and 'height'.
- */
+/// Set size of the Vim shell.
+/// If 'mustset' is TRUE, we must set Rows and Columns, do not get the real
+/// window size (this is used for the :win command).
+/// If 'mustset' is FALSE, we may try to get the real window size and if
+/// it fails use 'width' and 'height'.
 void screen_resize(int width, int height)
 {
   static int busy = FALSE;

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -193,7 +193,12 @@ void ui_refresh(void)
   }
 
   row = col = 0;
+
+  int save_p_lz = p_lz;
+  p_lz = false;  // convince redrawing() to return true ...
   screen_resize(width, height);
+  p_lz = save_p_lz;
+
   for (UIWidget i = 0; (int)i < UI_WIDGETS; i++) {
     ui_set_external(i, ext_widgets[i]);
   }


### PR DESCRIPTION
There might be a more elegant way to convince `redrawing()` during this sequence.

References #6202
References https://github.com/neovim/neovim/pull/6202#issuecomment-284379503
References #3929 #5692 #4884 #6157

@choco can you see if this fixes the resize issue for you?