### PR TITLE
[RDY] stdpath() (#5297)

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2286,6 +2286,7 @@ split({expr} [, {pat} [, {keepempty}]])
 				List	make |List| from {pat} separated {expr}
 sqrt({expr})			Float	square root of {expr}
 stdioopen({dict})		Number	open stdio in a headless instance.
+stdpath({what})                 String/List  returns the standard path(s) for {what}
 str2float({expr})		Float	convert String to Float
 str2nr({expr} [, {base}])	Number	convert String to Number
 strchars({expr} [, {skipcc}])	Number	character length of the String {expr}
@@ -7269,6 +7270,23 @@ stdioopen({opts})			 *stdioopen()*
 		Returns:
 		  - The channel ID on success (this is always 1)
 		  - 0 on invalid arguments
+
+
+stdpath({what})					*stdpath()* *E6100*
+		Returns the standard path(s) for {what}.
+
+		These directories are the default locations for various files
+		used by Neovim.
+
+		{what}       Type    Description ~
+		cache        String  Cache directory. Useful for plugins
+		                     that need temporary files to work.
+		config       String  User configuration directory. The
+		                     |init.vim| is stored here.
+		config_dirs  List    Additional configuration directories.
+		data         String  User data directory. The |shada-file|
+		                     is stored here.
+		data_dirs    List    Additional data directories.
 
 
 str2float({expr})					*str2float()*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -15699,6 +15699,56 @@ static void f_split(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   p_cpo = save_cpo;
 }
 
+/// "stdpath()" helper for list results
+static void get_xdg_var_list(const XDGVarType xdg, typval_T *rettv)
+  FUNC_ATTR_NONNULL_ALL
+{
+  const void *iter = NULL;
+  list_T *const list = tv_list_alloc(kListLenShouldKnow);
+  rettv->v_type = VAR_LIST;
+  rettv->vval.v_list = list;
+  tv_list_ref(list);
+  char *const dirs = stdpaths_get_xdg_var(xdg);
+  do {
+    size_t dir_len;
+    const char *dir;
+    iter = vim_env_iter(':', dirs, iter, &dir, &dir_len);
+    if (dir != NULL && dir_len > 0) {
+      char *dir_with_nvim = xmemdupz(dir, dir_len);
+      dir_with_nvim = concat_fnames_realloc(dir_with_nvim, "nvim", true);
+      tv_list_append_string(list, dir_with_nvim, strlen(dir_with_nvim));
+      xfree(dir_with_nvim);
+    }
+  } while (iter != NULL);
+  xfree(dirs);
+}
+
+/// "stdpath(type)" function
+static void f_stdpath(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  rettv->v_type = VAR_STRING;
+  rettv->vval.v_string = NULL;
+
+  const char *const p = tv_get_string_chk(&argvars[0]);
+  if (p == NULL) {
+    return;  // Type error; errmsg already given.
+  }
+
+  if (strcmp(p, "config") == 0) {
+    rettv->vval.v_string = (char_u *)get_xdg_home(kXDGConfigHome);
+  } else if (strcmp(p, "data") == 0) {
+    rettv->vval.v_string = (char_u *)get_xdg_home(kXDGDataHome);
+  } else if (strcmp(p, "cache") == 0) {
+    rettv->vval.v_string = (char_u *)get_xdg_home(kXDGCacheHome);
+  } else if (strcmp(p, "config_dirs") == 0) {
+    get_xdg_var_list(kXDGConfigDirs, rettv);
+  } else if (strcmp(p, "data_dirs") == 0) {
+    get_xdg_var_list(kXDGDataDirs, rettv);
+  } else {
+    EMSG2(_("E6100: \"%s\" is not a valid stdpath"), p);
+  }
+}
+
 /*
  * "str2float()" function
  */

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -10,6 +10,7 @@
 #include "nvim/event/rstream.h"
 #include "nvim/event/wstream.h"
 #include "nvim/channel.h"
+#include "nvim/os/stdpaths_defs.h"
 
 #define COPYID_INC 2
 #define COPYID_MASK (~0x1)

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -280,6 +280,7 @@ return {
     spellsuggest={args={1, 3}},
     split={args={1, 3}},
     sqrt={args=1, func="float_op_wrapper", data="&sqrt"},
+    stdpath={args=1},
     str2float={args=1},
     str2nr={args={1, 2}},
     strcharpart={args={2, 3}},

--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -88,7 +88,7 @@ char *stdpaths_get_xdg_var(const XDGVarType idx)
 ///
 /// In WIN32 get_xdg_home(kXDGDataHome) returns `{xdg_directory}/nvim-data` to
 /// avoid storing configuration and data files in the same path.
-static char *get_xdg_home(const XDGVarType idx)
+char *get_xdg_home(const XDGVarType idx)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   char *dir = stdpaths_get_xdg_var(idx);

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -442,7 +442,7 @@ describe('stdpath()', function()
           XDG_CONFIG_HOME=alter_slashes('/home/original'),
         }})
         eq(alter_slashes('/home/original/nvim'), funcs.stdpath('config'))
-        command('let $XDG_CONFIG_HOME="/home/new"')
+        command("let $XDG_CONFIG_HOME='"..alter_slashes('/home/new').."'")
         eq(alter_slashes('/home/new/nvim'), funcs.stdpath('config'))
       end)
 
@@ -456,7 +456,7 @@ describe('stdpath()', function()
 
       it("doesn't expand ~/", function()
         clear({env={
-          XDG_CONFIG_HOME='~/frobnitz',
+          XDG_CONFIG_HOME=alter_slashes('~/frobnitz'),
         }})
         eq(alter_slashes('~/frobnitz/nvim'), funcs.stdpath('config'))
       end)
@@ -487,7 +487,7 @@ describe('stdpath()', function()
           XDG_DATA_HOME=alter_slashes('/home/original'),
         }})
         eq(alter_slashes('/home/original' .. appended_dir), funcs.stdpath('data'))
-        command('let $XDG_DATA_HOME="/home/new"')
+        command("let $XDG_DATA_HOME='"..alter_slashes('/home/new').."'")
         eq(alter_slashes('/home/new' .. appended_dir), funcs.stdpath('data'))
       end)
 
@@ -501,7 +501,7 @@ describe('stdpath()', function()
 
       it("doesn't expand ~/", function()
         clear({env={
-          XDG_DATA_HOME='~/frobnitz',
+          XDG_DATA_HOME=alter_slashes('~/frobnitz'),
         }})
         eq(alter_slashes('~/frobnitz' .. appended_dir), funcs.stdpath('data'))
       end)
@@ -520,7 +520,7 @@ describe('stdpath()', function()
           XDG_CACHE_HOME=alter_slashes('/home/original'),
         }})
         eq(alter_slashes('/home/original/nvim'), funcs.stdpath('cache'))
-        command('let $XDG_CACHE_HOME="/home/new"')
+        command("let $XDG_CACHE_HOME='"..alter_slashes('/home/new').."'")
         eq(alter_slashes('/home/new/nvim'), funcs.stdpath('cache'))
       end)
 
@@ -534,7 +534,7 @@ describe('stdpath()', function()
 
       it("doesn't expand ~/", function()
         clear({env={
-          XDG_CACHE_HOME='~/frobnitz',
+          XDG_CACHE_HOME=alter_slashes('~/frobnitz'),
         }})
         eq(alter_slashes('~/frobnitz/nvim'), funcs.stdpath('cache'))
       end)
@@ -620,7 +620,10 @@ describe('stdpath()', function()
         "doesn't expand $VAR and $IBLES",
         'config_dirs', 'XDG_CONFIG_DIRS',
         { '$HOME', '$TMP' },
-        { '$HOME/nvim', '$TMP/nvim' })
+        {
+          alter_slashes('$HOME/nvim'),
+          alter_slashes('$TMP/nvim')
+        })
 
 
       behaves_like_dir_list_env(
@@ -663,7 +666,10 @@ describe('stdpath()', function()
         "doesn't expand $VAR and $IBLES",
         'data_dirs', 'XDG_DATA_DIRS',
         { '$HOME', '$TMP' },
-        { '$HOME/nvim', '$TMP/nvim' })
+        {
+          alter_slashes('$HOME/nvim'),
+          alter_slashes('$TMP/nvim')
+        })
 
       behaves_like_dir_list_env(
         "doesn't expand ~/",

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -5,12 +5,15 @@ local Screen = require('test.functional.ui.screen')
 local meths = helpers.meths
 local command = helpers.command
 local clear = helpers.clear
+local exc_exec = helpers.exc_exec
 local eval = helpers.eval
 local eq = helpers.eq
+local funcs = helpers.funcs
 local insert = helpers.insert
 local neq = helpers.neq
 local mkdir = helpers.mkdir
 local rmdir = helpers.rmdir
+local alter_slashes = helpers.alter_slashes
 
 describe('startup defaults', function()
   describe(':filetype', function()
@@ -419,6 +422,273 @@ describe('XDG-based defaults', function()
       eq('\\,=\\,=\\,/nvim/swap//', meths.get_option('directory'))
       eq('\\,=\\,=\\,/nvim/undo', meths.get_option('undodir'))
       eq('\\,=\\,=\\,/nvim/view', meths.get_option('viewdir'))
+    end)
+  end)
+end)
+
+
+describe('stdpath()', function()
+  context('returns a String', function()
+    describe('with "config"' , function ()
+      it('knows XDG_CONFIG_HOME', function()
+        clear({env={
+          XDG_CONFIG_HOME=alter_slashes('/home/docwhat/.config'),
+        }})
+        eq(alter_slashes('/home/docwhat/.config/nvim'), funcs.stdpath('config'))
+      end)
+
+      it('handles changes during runtime', function()
+        clear({env={
+          XDG_CONFIG_HOME=alter_slashes('/home/original'),
+        }})
+        eq(alter_slashes('/home/original/nvim'), funcs.stdpath('config'))
+        command('let $XDG_CONFIG_HOME="/home/new"')
+        eq(alter_slashes('/home/new/nvim'), funcs.stdpath('config'))
+      end)
+
+      it("doesn't expand $VARIABLES", function()
+        clear({env={
+          XDG_CONFIG_HOME='$VARIABLES',
+          VARIABLES='this-should-not-happen',
+        }})
+        eq(alter_slashes('$VARIABLES/nvim'), funcs.stdpath('config'))
+      end)
+
+      it("doesn't expand ~/", function()
+        clear({env={
+          XDG_CONFIG_HOME='~/frobnitz',
+        }})
+        eq(alter_slashes('~/frobnitz/nvim'), funcs.stdpath('config'))
+      end)
+    end)
+
+    describe('with "data"' , function ()
+      local appended_dir
+      setup(function()
+        -- Windows appends 'nvim-data' instead of just 'nvim' to
+        -- prevent collisions due to XDG_CONFIG_HOME and XDG_DATA_HOME
+        -- being the same.
+        if helpers.iswin() then
+          appended_dir = '/nvim-data'
+        else
+          appended_dir = '/nvim'
+        end
+      end)
+
+      it('knows XDG_DATA_HOME', function()
+        clear({env={
+          XDG_DATA_HOME=alter_slashes('/home/docwhat/.local'),
+        }})
+        eq(alter_slashes('/home/docwhat/.local' .. appended_dir), funcs.stdpath('data'))
+      end)
+
+      it('handles changes during runtime', function()
+        clear({env={
+          XDG_DATA_HOME=alter_slashes('/home/original'),
+        }})
+        eq(alter_slashes('/home/original' .. appended_dir), funcs.stdpath('data'))
+        command('let $XDG_DATA_HOME="/home/new"')
+        eq(alter_slashes('/home/new' .. appended_dir), funcs.stdpath('data'))
+      end)
+
+      it("doesn't expand $VARIABLES", function()
+        clear({env={
+          XDG_DATA_HOME='$VARIABLES',
+          VARIABLES='this-should-not-happen',
+        }})
+        eq(alter_slashes('$VARIABLES' .. appended_dir), funcs.stdpath('data'))
+      end)
+
+      it("doesn't expand ~/", function()
+        clear({env={
+          XDG_DATA_HOME='~/frobnitz',
+        }})
+        eq(alter_slashes('~/frobnitz' .. appended_dir), funcs.stdpath('data'))
+      end)
+    end)
+
+    describe('with "cache"' , function ()
+      it('knows XDG_CACHE_HOME', function()
+        clear({env={
+          XDG_CACHE_HOME=alter_slashes('/home/docwhat/.cache'),
+        }})
+        eq(alter_slashes('/home/docwhat/.cache/nvim'), funcs.stdpath('cache'))
+      end)
+
+      it('handles changes during runtime', function()
+        clear({env={
+          XDG_CACHE_HOME=alter_slashes('/home/original'),
+        }})
+        eq(alter_slashes('/home/original/nvim'), funcs.stdpath('cache'))
+        command('let $XDG_CACHE_HOME="/home/new"')
+        eq(alter_slashes('/home/new/nvim'), funcs.stdpath('cache'))
+      end)
+
+      it("doesn't expand $VARIABLES", function()
+        clear({env={
+          XDG_CACHE_HOME='$VARIABLES',
+          VARIABLES='this-should-not-happen',
+        }})
+        eq(alter_slashes('$VARIABLES/nvim'), funcs.stdpath('cache'))
+      end)
+
+      it("doesn't expand ~/", function()
+        clear({env={
+          XDG_CACHE_HOME='~/frobnitz',
+        }})
+        eq(alter_slashes('~/frobnitz/nvim'), funcs.stdpath('cache'))
+      end)
+    end)
+  end)
+
+  context('returns a List', function()
+    -- Some OS specific variables the system would have set.
+    local function base_env()
+      if helpers.iswin() then
+        return {
+          HOME='C:\\Users\\docwhat', -- technically, is not a usual PATH
+          HOMEDRIVE='C:',
+          HOMEPATH='\\Users\\docwhat',
+          LOCALAPPDATA='C:\\Users\\docwhat\\AppData\\Local',
+          TEMP='C:\\Users\\docwhat\\AppData\\Local\\Temp',
+          TMPDIR='C:\\Users\\docwhat\\AppData\\Local\\Temp',
+          TMP='C:\\Users\\docwhat\\AppData\\Local\\Temp',
+        }
+      else
+        return {
+          HOME='/home/docwhat',
+          HOMEDRIVE='HOMEDRIVE-should-be-ignored',
+          HOMEPATH='HOMEPATH-should-be-ignored',
+          LOCALAPPDATA='LOCALAPPDATA-should-be-ignored',
+          TEMP='TEMP-should-be-ignored',
+          TMPDIR='TMPDIR-should-be-ignored',
+          TMP='TMP-should-be-ignored',
+        }
+      end
+    end
+
+    local function set_paths_via_system(var_name, paths)
+      local env = base_env()
+      env[var_name] = table.concat(paths, ':')
+      clear({env=env})
+    end
+
+    local function set_paths_at_runtime(var_name, paths)
+      clear({env=base_env()})
+      meths.set_var('env_val', table.concat(paths, ':'))
+      command(('let $%s=g:env_val'):format(var_name))
+    end
+
+    local function behaves_like_dir_list_env(msg, stdpath_arg, env_var_name, paths, expected_paths)
+      describe(msg, function()
+        it('set via system', function()
+          set_paths_via_system(env_var_name, paths)
+          eq(expected_paths, funcs.stdpath(stdpath_arg))
+        end)
+
+        it('set at runtime', function()
+          set_paths_at_runtime(env_var_name, paths)
+          eq(expected_paths, funcs.stdpath(stdpath_arg))
+        end)
+      end)
+    end
+
+    describe('with "config_dirs"' , function ()
+      behaves_like_dir_list_env(
+        'handles XDG_CONFIG_DIRS with one path',
+        'config_dirs', 'XDG_CONFIG_DIRS',
+        {
+          alter_slashes('/home/docwhat/.config')
+        },
+        {
+          alter_slashes('/home/docwhat/.config/nvim')
+        })
+
+      behaves_like_dir_list_env(
+        'handles XDG_CONFIG_DIRS with two paths',
+        'config_dirs', 'XDG_CONFIG_DIRS',
+        {
+          alter_slashes('/home/docwhat/.config'),
+          alter_slashes('/etc/config')
+        },
+        {
+          alter_slashes('/home/docwhat/.config/nvim'),
+          alter_slashes('/etc/config/nvim')
+        })
+
+      behaves_like_dir_list_env(
+        "doesn't expand $VAR and $IBLES",
+        'config_dirs', 'XDG_CONFIG_DIRS',
+        { '$HOME', '$TMP' },
+        { '$HOME/nvim', '$TMP/nvim' })
+
+
+      behaves_like_dir_list_env(
+        "doesn't expand ~/",
+        'config_dirs', 'XDG_CONFIG_DIRS',
+        {
+          alter_slashes('~/.oldconfig'),
+          alter_slashes('~/.olderconfig')
+        },
+        {
+          alter_slashes('~/.oldconfig/nvim'),
+          alter_slashes('~/.olderconfig/nvim')
+        })
+    end)
+
+    describe('with "data_dirs"' , function ()
+      behaves_like_dir_list_env(
+        'knows XDG_DATA_DIRS with one path',
+        'data_dirs', 'XDG_DATA_DIRS',
+        {
+          alter_slashes('/home/docwhat/.data')
+        },
+        {
+          alter_slashes('/home/docwhat/.data/nvim')
+        })
+
+      behaves_like_dir_list_env(
+        'knows XDG_DATA_DIRS with two paths',
+        'data_dirs', 'XDG_DATA_DIRS',
+        {
+          alter_slashes('/home/docwhat/.data'),
+          alter_slashes('/etc/local')
+        },
+        {
+          alter_slashes('/home/docwhat/.data/nvim'),
+          alter_slashes('/etc/local/nvim'),
+        })
+
+      behaves_like_dir_list_env(
+        "doesn't expand $VAR and $IBLES",
+        'data_dirs', 'XDG_DATA_DIRS',
+        { '$HOME', '$TMP' },
+        { '$HOME/nvim', '$TMP/nvim' })
+
+      behaves_like_dir_list_env(
+        "doesn't expand ~/",
+        'data_dirs', 'XDG_DATA_DIRS',
+        {
+          alter_slashes('~/.oldconfig'),
+          alter_slashes('~/.olderconfig')
+        },
+        {
+          alter_slashes('~/.oldconfig/nvim'),
+          alter_slashes('~/.olderconfig/nvim'),
+        })
+    end)
+  end)
+
+  describe('errors', function()
+    it('on unknown strings', function()
+      eq('Vim(call):E6100: "capybara" is not a valid stdpath', exc_exec('call stdpath("capybara")'))
+      eq('Vim(call):E6100: "" is not a valid stdpath', exc_exec('call stdpath("")'))
+      eq('Vim(call):E6100: "23" is not a valid stdpath', exc_exec('call stdpath(23)'))
+    end)
+
+    it('on non-strings', function()
+      eq('Vim(call):E731: using Dictionary as a String', exc_exec('call stdpath({"eris": 23})'))
+      eq('Vim(call):E730: using List as a String', exc_exec('call stdpath([23])'))
     end)
   end)
 end)


### PR DESCRIPTION
This adds a method to access the [XDG Base Dirs](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) home values.

A future patch could add the `get_xdg_dirs()` method to return lists.

This will close issue #5297.

I apologize for my C code. The last C program I wrote was a game for the Palm Pilot.