### PR TITLE
Add short descriptions to options.lua

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1,6 +1,7 @@
 -- {
 --  {
 --    full_name='aleph', abbreviation='al',
+--    short_desc="ASCII code of the letter Aleph (Hebrew)",
 --    varname='p_aleph', pv_name=nil,
 --    type='number', list=nil, scope={'global'},
 --    deny_duplicates=nil,
@@ -52,6 +53,7 @@ return {
   options={
     {
       full_name='aleph', abbreviation='al',
+      short_desc=N_("ASCII code of the letter Aleph (Hebrew)"),
       type='number', scope={'global'},
       vi_def=true,
       redraw={'curswant'},
@@ -60,6 +62,7 @@ return {
     },
     {
       full_name='arabic', abbreviation='arab',
+      short_desc=N_("Arabic as a default second language"),
       type='bool', scope={'window'},
       vi_def=true,
       vim=true,
@@ -68,6 +71,7 @@ return {
     },
     {
       full_name='arabicshape', abbreviation='arshape',
+      short_desc=N_("do shaping for Arabic characters"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -78,6 +82,7 @@ return {
     },
     {
       full_name='allowrevins', abbreviation='ari',
+      short_desc=N_("allow CTRL-_ in Insert and Command-line mode"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -86,6 +91,7 @@ return {
     },
     {
       full_name='ambiwidth', abbreviation='ambw',
+      short_desc=N_("what to do with Unicode chars of ambiguous width"),
       type='string', scope={'global'},
       vi_def=true,
       redraw={'all_windows', 'ui_option'},
@@ -94,6 +100,7 @@ return {
     },
     {
       full_name='autochdir', abbreviation='acd',
+      short_desc=N_("change directory to the file in the current window"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_acd',
@@ -101,18 +108,21 @@ return {
     },
     {
       full_name='autoindent', abbreviation='ai',
+      short_desc=N_("take indent for new line from previous line"),
       type='bool', scope={'buffer'},
       varname='p_ai',
       defaults={if_true={vi=false, vim=true}}
     },
     {
       full_name='autoread', abbreviation='ar',
+      short_desc=N_("autom. read file when changed outside of Vim"),
       type='bool', scope={'global', 'buffer'},
       varname='p_ar',
       defaults={if_true={vi=false, vim=true}}
     },
     {
       full_name='autowrite', abbreviation='aw',
+      short_desc=N_("automatically write file if changed"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_aw',
@@ -120,6 +130,7 @@ return {
     },
     {
       full_name='autowriteall', abbreviation='awa',
+      short_desc=N_("as 'autowrite', but works with more commands"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_awa',
@@ -127,6 +138,7 @@ return {
     },
     {
       full_name='background', abbreviation='bg',
+      short_desc=N_("\"dark\" or \"light\", used for highlight colors"),
       type='string', scope={'global'},
       vim=true,
       redraw={'all_windows'},
@@ -135,6 +147,7 @@ return {
     },
     {
       full_name='backspace', abbreviation='bs',
+      short_desc=N_("how backspace works at start of line"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vim=true,
@@ -143,6 +156,7 @@ return {
     },
     {
       full_name='backup', abbreviation='bk',
+      short_desc=N_("keep backup file after overwriting a file"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -151,6 +165,7 @@ return {
     },
     {
       full_name='backupcopy', abbreviation='bkc',
+      short_desc=N_("make backup as a copy, don't rename the file"),
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
       vim=true,
@@ -163,6 +178,7 @@ return {
     },
     {
       full_name='backupdir', abbreviation='bdir',
+      short_desc=N_("list of directories for the backup file"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
@@ -173,6 +189,7 @@ return {
     },
     {
       full_name='backupext', abbreviation='bex',
+      short_desc=N_("extension used for the backup file"),
       type='string', scope={'global'},
       normal_fname_chars=true,
       vi_def=true,
@@ -181,6 +198,7 @@ return {
     },
     {
       full_name='backupskip', abbreviation='bsk',
+      short_desc=N_("no backup for files that match these patterns"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -189,6 +207,7 @@ return {
     },
     {
       full_name='belloff', abbreviation='bo',
+      short_desc=N_("do not ring the bell for these reasons"),
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -197,6 +216,7 @@ return {
     },
     {
       full_name='binary', abbreviation='bin',
+      short_desc=N_("read/write/edit file in binary mode"),
       type='bool', scope={'buffer'},
       vi_def=true,
       redraw={'statuslines'},
@@ -205,6 +225,7 @@ return {
     },
     {
       full_name='bomb',
+      short_desc=N_("a Byte Order Mark to the file"),
       type='bool', scope={'buffer'},
       no_mkrc=true,
       vi_def=true,
@@ -214,6 +235,7 @@ return {
     },
     {
       full_name='breakat', abbreviation='brk',
+      short_desc=N_("characters that may cause a line break"),
       type='string', list='flags', scope={'global'},
       vi_def=true,
       redraw={'all_windows'},
@@ -222,6 +244,7 @@ return {
     },
     {
       full_name='breakindent', abbreviation='bri',
+      short_desc=N_("wrapped line repeats indent"),
       type='bool', scope={'window'},
       vi_def=true,
       vim=true,
@@ -230,6 +253,7 @@ return {
     },
     {
       full_name='breakindentopt', abbreviation='briopt',
+      short_desc=N_("settings for 'breakindent'"),
       type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
       vi_def=true,
@@ -239,12 +263,14 @@ return {
     },
     {
       full_name='browsedir', abbreviation='bsdir',
+      short_desc=N_("which directory to start browsing in"),
       type='string', scope={'global'},
       vi_def=true,
       enable_if=false,
     },
     {
       full_name='bufhidden', abbreviation='bh',
+      short_desc=N_("what to do when buffer is no longer in window"),
       type='string', scope={'buffer'},
       noglob=true,
       vi_def=true,
@@ -254,6 +280,7 @@ return {
     },
     {
       full_name='buflisted', abbreviation='bl',
+      short_desc=N_("whether the buffer shows up in the buffer list"),
       type='bool', scope={'buffer'},
       noglob=true,
       vi_def=true,
@@ -262,6 +289,7 @@ return {
     },
     {
       full_name='buftype', abbreviation='bt',
+      short_desc=N_("special type of buffer"),
       type='string', scope={'buffer'},
       noglob=true,
       vi_def=true,
@@ -271,6 +299,7 @@ return {
     },
     {
       full_name='casemap', abbreviation='cmp',
+      short_desc=N_("specifies how case of letters is changed"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -279,6 +308,7 @@ return {
     },
     {
       full_name='cdpath', abbreviation='cd',
+      short_desc=N_("list of directories searched with \":cd\""),
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -289,12 +319,14 @@ return {
     },
     {
       full_name='cedit',
+      short_desc=N_("used to open the command-line window"),
       type='string', scope={'global'},
       varname='p_cedit',
       defaults={if_true={vi="", vim=macros('CTRL_F_STR')}}
     },
     {
       full_name='channel',
+      short_desc=N_("Channel connected to the buffer"),
       type='number', scope={'buffer'},
       no_mkrc=true,
       nodefault=true,
@@ -303,6 +335,7 @@ return {
     },
     {
       full_name='charconvert', abbreviation='ccv',
+      short_desc=N_("expression for character encoding conversion"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -311,6 +344,7 @@ return {
     },
     {
       full_name='cindent', abbreviation='cin',
+      short_desc=N_("do C program indenting"),
       type='bool', scope={'buffer'},
       vi_def=true,
       vim=true,
@@ -319,6 +353,7 @@ return {
     },
     {
       full_name='cinkeys', abbreviation='cink',
+      short_desc=N_("keys that trigger indent when 'cindent' is set"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -328,6 +363,7 @@ return {
     },
     {
       full_name='cinoptions', abbreviation='cino',
+      short_desc=N_("how to do indenting when 'cindent' is set"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -337,6 +373,7 @@ return {
     },
     {
       full_name='cinwords', abbreviation='cinw',
+      short_desc=N_("words where 'si' and 'cin' add an indent"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -346,6 +383,7 @@ return {
     },
     {
       full_name='clipboard', abbreviation='cb',
+      short_desc=N_("use the clipboard as the unnamed register"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -354,6 +392,7 @@ return {
     },
     {
       full_name='cmdheight', abbreviation='ch',
+      short_desc=N_("number of lines to use for the command-line"),
       type='number', scope={'global'},
       vi_def=true,
       redraw={'all_windows'},
@@ -362,6 +401,7 @@ return {
     },
     {
       full_name='cmdwinheight', abbreviation='cwh',
+      short_desc=N_("height of the command-line window"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_cwh',
@@ -369,6 +409,7 @@ return {
     },
     {
       full_name='colorcolumn', abbreviation='cc',
+      short_desc=N_("columns to highlight"),
       type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
       vi_def=true,
@@ -377,6 +418,7 @@ return {
     },
     {
       full_name='columns', abbreviation='co',
+      short_desc=N_("number of columns in the display"),
       type='number', scope={'global'},
       no_mkrc=true,
       vi_def=true,
@@ -386,6 +428,7 @@ return {
     },
     {
       full_name='comments', abbreviation='com',
+      short_desc=N_("patterns that can start a comment line"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -396,6 +439,7 @@ return {
     },
     {
       full_name='commentstring', abbreviation='cms',
+      short_desc=N_("template for comments; used for fold marker"),
       type='string', scope={'buffer'},
       vi_def=true,
       alloced=true,
@@ -405,6 +449,7 @@ return {
     },
     {
       full_name='compatible', abbreviation='cp',
+	  short_desc=N_("No description"),
       type='bool', scope={'global'},
       redraw={'all_windows'},
       varname='p_force_off',
@@ -414,6 +459,7 @@ return {
     },
     {
       full_name='complete', abbreviation='cpt',
+      short_desc=N_("specify how Insert mode completion works"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       alloced=true,
@@ -422,6 +468,7 @@ return {
     },
     {
       full_name='concealcursor', abbreviation='cocu',
+      short_desc=N_("whether concealable text is hidden in cursor line"),
       type='string', scope={'window'},
       vi_def=true,
       alloced=true,
@@ -430,6 +477,7 @@ return {
     },
     {
       full_name='conceallevel', abbreviation='cole',
+      short_desc=N_("whether concealable text is shown or hidden"),
       type='number', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -437,6 +485,7 @@ return {
     },
     {
       full_name='completefunc', abbreviation='cfu',
+      short_desc=N_("function to be used for Insert mode completion"),
       type='string', scope={'buffer'},
       secure=true,
       vi_def=true,
@@ -446,6 +495,7 @@ return {
     },
     {
       full_name='completeopt', abbreviation='cot',
+      short_desc=N_("options for Insert mode completion"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -463,6 +513,7 @@ return {
     },
     {
       full_name='confirm', abbreviation='cf',
+      short_desc=N_("ask what to do about unsaved/read-only files"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_confirm',
@@ -470,6 +521,7 @@ return {
     },
     {
       full_name='copyindent', abbreviation='ci',
+      short_desc=N_("make 'autoindent' use existing indent structure"),
       type='bool', scope={'buffer'},
       vi_def=true,
       vim=true,
@@ -478,6 +530,7 @@ return {
     },
     {
       full_name='cpoptions', abbreviation='cpo',
+      short_desc=N_("flags for Vi-compatible behavior"),
       type='string', list='flags', scope={'global'},
       vim=true,
       redraw={'all_windows'},
@@ -486,6 +539,7 @@ return {
     },
     {
       full_name='cscopepathcomp', abbreviation='cspc',
+      short_desc=N_("how many components of the path to show"),
       type='number', scope={'global'},
       vi_def=true,
       vim=true,
@@ -494,6 +548,7 @@ return {
     },
     {
       full_name='cscopeprg', abbreviation='csprg',
+      short_desc=N_("command to execute cscope"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -503,6 +558,7 @@ return {
     },
     {
       full_name='cscopequickfix', abbreviation='csqf',
+      short_desc=N_("use quickfix window for cscope results"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -511,6 +567,7 @@ return {
     },
     {
       full_name='cscoperelative', abbreviation='csre',
+      short_desc=N_("Use cscope.out path basename as prefix"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -519,6 +576,7 @@ return {
     },
     {
       full_name='cscopetag', abbreviation='cst',
+      short_desc=N_("use cscope for tag commands"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -527,6 +585,7 @@ return {
     },
     {
       full_name='cscopetagorder', abbreviation='csto',
+      short_desc=N_("determines \":cstag\" search order"),
       type='number', scope={'global'},
       vi_def=true,
       vim=true,
@@ -535,6 +594,7 @@ return {
     },
     {
       full_name='cscopeverbose', abbreviation='csverb',
+      short_desc=N_("give messages when adding a cscope database"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -543,6 +603,7 @@ return {
     },
     {
       full_name='cursorbind', abbreviation='crb',
+      short_desc=N_("move cursor in window as it moves in other windows"),
       type='bool', scope={'window'},
       vi_def=true,
       pv_name='p_crbind',
@@ -550,6 +611,7 @@ return {
     },
     {
       full_name='cursorcolumn', abbreviation='cuc',
+      short_desc=N_("highlight the screen column of the cursor"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'current_window_only'},
@@ -557,6 +619,7 @@ return {
     },
     {
       full_name='cursorline', abbreviation='cul',
+      short_desc=N_("highlight the screen line of the cursor"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'current_window_only'},
@@ -564,6 +627,7 @@ return {
     },
     {
       full_name='debug',
+      short_desc=N_("to \"msg\" to see all error messages"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_debug',
@@ -571,6 +635,7 @@ return {
     },
     {
       full_name='define', abbreviation='def',
+      short_desc=N_("pattern to be used to find a macro definition"),
       type='string', scope={'global', 'buffer'},
       vi_def=true,
       alloced=true,
@@ -580,6 +645,7 @@ return {
     },
     {
       full_name='delcombine', abbreviation='deco',
+      short_desc=N_("delete combining characters on their own"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -588,6 +654,7 @@ return {
     },
     {
       full_name='dictionary', abbreviation='dict',
+      short_desc=N_("list of file names used for keyword completion"),
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
       normal_dname_chars=true,
@@ -598,6 +665,7 @@ return {
     },
     {
       full_name='diff',
+      short_desc=N_("diff mode for the current window"),
       type='bool', scope={'window'},
       noglob=true,
       vi_def=true,
@@ -606,6 +674,7 @@ return {
     },
     {
       full_name='diffexpr', abbreviation='dex',
+      short_desc=N_("expression used to obtain a diff file"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -615,6 +684,7 @@ return {
     },
     {
       full_name='diffopt', abbreviation='dip',
+      short_desc=N_("options for using diff mode"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -625,6 +695,7 @@ return {
     },
     {
       full_name='digraph', abbreviation='dg',
+      short_desc=N_("enable the entering of digraphs in Insert mode"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -633,6 +704,7 @@ return {
     },
     {
       full_name='directory', abbreviation='dir',
+      short_desc=N_("list of directory names for the swap file"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
@@ -643,6 +715,7 @@ return {
     },
     {
       full_name='display', abbreviation='dy',
+      short_desc=N_("list of flags for how to display text"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vim=true,
@@ -652,6 +725,7 @@ return {
     },
     {
       full_name='eadirection', abbreviation='ead',
+      short_desc=N_("in which direction 'equalalways' works"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_ead',
@@ -659,6 +733,7 @@ return {
     },
     {
       full_name='edcompatible', abbreviation='ed',
+	  short_desc=N_("No description"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_force_off',
@@ -666,6 +741,7 @@ return {
     },
     {
       full_name='emoji', abbreviation='emo',
+	  short_desc=N_("No description"),
       type='bool', scope={'global'},
       vi_def=true,
       redraw={'all_windows', 'ui_option'},
@@ -674,6 +750,7 @@ return {
     },
     {
       full_name='encoding', abbreviation='enc',
+      short_desc=N_("encoding used internally"),
       type='string', scope={'global'},
       deny_in_modelines=true,
       vi_def=true,
@@ -682,6 +759,7 @@ return {
     },
     {
       full_name='endofline', abbreviation='eol',
+      short_desc=N_("write <EOL> for last line in file"),
       type='bool', scope={'buffer'},
       no_mkrc=true,
       vi_def=true,
@@ -691,6 +769,7 @@ return {
     },
     {
       full_name='equalalways', abbreviation='ea',
+      short_desc=N_("windows are automatically made the same size"),
       type='bool', scope={'global'},
       vi_def=true,
       redraw={'all_windows'},
@@ -699,6 +778,7 @@ return {
     },
     {
       full_name='equalprg', abbreviation='ep',
+      short_desc=N_("external program to use for \"=\" command"),
       type='string', scope={'global', 'buffer'},
       secure=true,
       vi_def=true,
@@ -708,6 +788,7 @@ return {
     },
     {
       full_name='errorbells', abbreviation='eb',
+      short_desc=N_("ring the bell for error messages"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_eb',
@@ -715,6 +796,7 @@ return {
     },
     {
       full_name='errorfile', abbreviation='ef',
+      short_desc=N_("name of the errorfile for the QuickFix mode"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -724,6 +806,7 @@ return {
     },
     {
       full_name='errorformat', abbreviation='efm',
+      short_desc=N_("description of the lines in the error file"),
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -732,6 +815,7 @@ return {
     },
     {
       full_name='eventignore', abbreviation='ei',
+      short_desc=N_("autocommand events that are ignored"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -740,6 +824,7 @@ return {
     },
     {
       full_name='expandtab', abbreviation='et',
+      short_desc=N_("use spaces when <Tab> is inserted"),
       type='bool', scope={'buffer'},
       vi_def=true,
       vim=true,
@@ -748,6 +833,7 @@ return {
     },
     {
       full_name='exrc', abbreviation='ex',
+      short_desc=N_("read .nvimrc and .exrc in the current directory"),
       type='bool', scope={'global'},
       secure=true,
       vi_def=true,
@@ -756,6 +842,7 @@ return {
     },
     {
       full_name='fileencoding', abbreviation='fenc',
+      short_desc=N_("file encoding for multi-byte text"),
       type='string', scope={'buffer'},
       no_mkrc=true,
       vi_def=true,
@@ -766,6 +853,7 @@ return {
     },
     {
       full_name='fileencodings', abbreviation='fencs',
+      short_desc=N_("automatically detected character encodings"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -774,6 +862,7 @@ return {
     },
     {
       full_name='fileformat', abbreviation='ff',
+      short_desc=N_("file format used for file I/O"),
       type='string', scope={'buffer'},
       no_mkrc=true,
       vi_def=true,
@@ -784,6 +873,7 @@ return {
     },
     {
       full_name='fileformats', abbreviation='ffs',
+      short_desc=N_("automatically detected values for 'fileformat'"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vim=true,
@@ -792,6 +882,7 @@ return {
     },
     {
       full_name='fileignorecase', abbreviation='fic',
+      short_desc=N_("ignore case when using file names"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_fic',
@@ -803,6 +894,7 @@ return {
     },
     {
       full_name='filetype', abbreviation='ft',
+      short_desc=N_("type of file, used for autocommands"),
       type='string', scope={'buffer'},
       noglob=true,
       normal_fname_chars=true,
@@ -813,6 +905,7 @@ return {
     },
     {
       full_name='fillchars', abbreviation='fcs',
+      short_desc=N_("characters to use for displaying special items"),
       type='string', list='onecomma', scope={'global', 'window'},
       deny_duplicates=true,
       vi_def=true,
@@ -823,6 +916,7 @@ return {
     },
     {
       full_name='fixendofline', abbreviation='fixeol',
+      short_desc=N_("make sure last line in file has <EOL>"),
       type='bool', scope={'buffer'},
       vi_def=true,
       redraw={'statuslines'},
@@ -831,6 +925,7 @@ return {
     },
     {
       full_name='foldclose', abbreviation='fcl',
+      short_desc=N_("close a fold when the cursor leaves it"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -840,6 +935,7 @@ return {
     },
     {
       full_name='foldcolumn', abbreviation='fdc',
+      short_desc=N_("width of the column used to indicate folds"),
       type='string', scope={'window'},
       vi_def=true,
       alloced=true,
@@ -848,6 +944,7 @@ return {
     },
     {
       full_name='foldenable', abbreviation='fen',
+      short_desc=N_("set to display all folds open"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -855,6 +952,7 @@ return {
     },
     {
       full_name='foldexpr', abbreviation='fde',
+      short_desc=N_("expression used when 'foldmethod' is \"expr\""),
       type='string', scope={'window'},
       vi_def=true,
       vim=true,
@@ -865,6 +963,7 @@ return {
     },
     {
       full_name='foldignore', abbreviation='fdi',
+      short_desc=N_("ignore lines when 'foldmethod' is \"indent\""),
       type='string', scope={'window'},
       vi_def=true,
       vim=true,
@@ -874,6 +973,7 @@ return {
     },
     {
       full_name='foldlevel', abbreviation='fdl',
+      short_desc=N_("close folds with a level higher than this"),
       type='number', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -881,6 +981,7 @@ return {
     },
     {
       full_name='foldlevelstart', abbreviation='fdls',
+      short_desc=N_("'foldlevel' when starting to edit a file"),
       type='number', scope={'global'},
       vi_def=true,
       redraw={'curswant'},
@@ -889,6 +990,7 @@ return {
     },
     {
       full_name='foldmarker', abbreviation='fmr',
+      short_desc=N_("markers used when 'foldmethod' is \"marker\""),
       type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
       vi_def=true,
@@ -899,6 +1001,7 @@ return {
     },
     {
       full_name='foldmethod', abbreviation='fdm',
+      short_desc=N_("folding type"),
       type='string', scope={'window'},
       vi_def=true,
       vim=true,
@@ -908,6 +1011,7 @@ return {
     },
     {
       full_name='foldminlines', abbreviation='fml',
+      short_desc=N_("minimum number of lines for a fold to be closed"),
       type='number', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -915,6 +1019,7 @@ return {
     },
     {
       full_name='foldnestmax', abbreviation='fdn',
+      short_desc=N_("maximum fold depth"),
       type='number', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -922,6 +1027,7 @@ return {
     },
     {
       full_name='foldopen', abbreviation='fdo',
+      short_desc=N_("for which commands a fold will be opened"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -931,6 +1037,7 @@ return {
     },
     {
       full_name='foldtext', abbreviation='fdt',
+      short_desc=N_("expression used to display for a closed fold"),
       type='string', scope={'window'},
       vi_def=true,
       vim=true,
@@ -941,6 +1048,7 @@ return {
     },
     {
       full_name='formatexpr', abbreviation='fex',
+      short_desc=N_("expression used with \"gq\" command"),
       type='string', scope={'buffer'},
       vi_def=true,
       vim=true,
@@ -951,6 +1059,7 @@ return {
     },
     {
       full_name='formatoptions', abbreviation='fo',
+      short_desc=N_("how automatic formatting is to be done"),
       type='string', list='flags', scope={'buffer'},
       vim=true,
       alloced=true,
@@ -959,6 +1068,7 @@ return {
     },
     {
       full_name='formatlistpat', abbreviation='flp',
+      short_desc=N_("pattern used to recognize a list header"),
       type='string', scope={'buffer'},
       vi_def=true,
       alloced=true,
@@ -967,6 +1077,7 @@ return {
     },
     {
       full_name='formatprg', abbreviation='fp',
+      short_desc=N_("name of external program used with \"gq\" command"),
       type='string', scope={'global', 'buffer'},
       secure=true,
       vi_def=true,
@@ -976,6 +1087,7 @@ return {
     },
     {
       full_name='fsync', abbreviation='fs',
+      short_desc=N_("whether to invoke fsync() after file write"),
       type='bool', scope={'global'},
       secure=true,
       vi_def=true,
@@ -984,6 +1096,7 @@ return {
     },
     {
       full_name='gdefault', abbreviation='gd',
+      short_desc=N_("the \":substitute\" flag 'g' is default on"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -992,6 +1105,7 @@ return {
     },
     {
       full_name='grepformat', abbreviation='gfm',
+      short_desc=N_("format of 'grepprg' output"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1000,6 +1114,7 @@ return {
     },
     {
       full_name='grepprg', abbreviation='gp',
+      short_desc=N_("program to use for \":grep\""),
       type='string', scope={'global', 'buffer'},
       secure=true,
       vi_def=true,
@@ -1015,6 +1130,7 @@ return {
     },
     {
       full_name='guicursor', abbreviation='gcr',
+      short_desc=N_("GUI: settings for cursor shape and blinking"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1023,6 +1139,7 @@ return {
     },
     {
       full_name='guifont', abbreviation='gfn',
+      short_desc=N_("GUI: Name(s) of font(s) to be used"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1032,6 +1149,7 @@ return {
     },
     {
       full_name='guifontwide', abbreviation='gfw',
+      short_desc=N_("list of font names for double-wide characters"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1041,6 +1159,7 @@ return {
     },
     {
       full_name='guioptions', abbreviation='go',
+      short_desc=N_("GUI: Which components and options are used"),
       type='string', list='flags', scope={'global'},
       vi_def=true,
       redraw={'all_windows'},
@@ -1048,6 +1167,7 @@ return {
     },
     {
       full_name='guitablabel', abbreviation='gtl',
+      short_desc=N_("GUI: custom label for a tab page"),
       type='string', scope={'global'},
       vi_def=true,
       modelineexpr=true,
@@ -1056,6 +1176,7 @@ return {
     },
     {
       full_name='guitabtooltip', abbreviation='gtt',
+      short_desc=N_("GUI: custom tooltip for a tab page"),
       type='string', scope={'global'},
       vi_def=true,
       redraw={'current_window'},
@@ -1063,6 +1184,7 @@ return {
     },
     {
       full_name='helpfile', abbreviation='hf',
+      short_desc=N_("full path name of the main help file"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -1072,6 +1194,7 @@ return {
     },
     {
       full_name='helpheight', abbreviation='hh',
+      short_desc=N_("minimum height of a new help window"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_hh',
@@ -1079,6 +1202,7 @@ return {
     },
     {
       full_name='helplang', abbreviation='hlg',
+      short_desc=N_("preferred help languages"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1087,6 +1211,7 @@ return {
     },
     {
       full_name='hidden', abbreviation='hid',
+      short_desc=N_("don't unload buffer when it is |abandon|ed"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_hid',
@@ -1094,6 +1219,7 @@ return {
     },
     {
       full_name='highlight', abbreviation='hl',
+      short_desc=N_("sets highlighting mode for various occasions"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1102,6 +1228,7 @@ return {
     },
     {
       full_name='history', abbreviation='hi',
+      short_desc=N_("number of command-lines that are remembered"),
       type='number', scope={'global'},
       vim=true,
       varname='p_hi',
@@ -1109,6 +1236,7 @@ return {
     },
     {
       full_name='hkmap', abbreviation='hk',
+      short_desc=N_("Hebrew keyboard mapping"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -1117,6 +1245,7 @@ return {
     },
     {
       full_name='hkmapp', abbreviation='hkp',
+      short_desc=N_("phonetic Hebrew keyboard mapping"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -1125,6 +1254,7 @@ return {
     },
     {
       full_name='hlsearch', abbreviation='hls',
+      short_desc=N_("highlight matches with last search pattern"),
       type='bool', scope={'global'},
       vim=true,
       redraw={'all_windows'},
@@ -1133,6 +1263,7 @@ return {
     },
     {
       full_name='icon',
+      short_desc=N_("Vim set the text of the window icon"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_icon',
@@ -1140,6 +1271,7 @@ return {
     },
     {
       full_name='iconstring',
+      short_desc=N_("to use for the Vim icon text"),
       type='string', scope={'global'},
       vi_def=true,
       modelineexpr=true,
@@ -1148,6 +1280,7 @@ return {
     },
     {
       full_name='ignorecase', abbreviation='ic',
+      short_desc=N_("ignore case in search patterns"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_ic',
@@ -1155,6 +1288,7 @@ return {
     },
     {
       full_name='imcmdline', abbreviation='imc',
+      short_desc=N_("use IM when starting to edit a command line"),
       type='bool', scope={'global'},
       vi_def=true,
       enable_if=false,
@@ -1162,6 +1296,7 @@ return {
     },
     {
       full_name='imdisable', abbreviation='imd',
+      short_desc=N_("do not use the IM in any mode"),
       type='bool', scope={'global'},
       vi_def=true,
       enable_if=false,
@@ -1169,6 +1304,7 @@ return {
     },
     {
       full_name='iminsert', abbreviation='imi',
+      short_desc=N_("use :lmap or IM in Insert mode"),
       type='number', scope={'buffer'},
       vi_def=true,
       varname='p_iminsert', pv_name='p_imi',
@@ -1178,6 +1314,7 @@ return {
     },
     {
       full_name='imsearch', abbreviation='ims',
+      short_desc=N_("use :lmap or IM when typing a search pattern"),
       type='number', scope={'buffer'},
       vi_def=true,
       varname='p_imsearch', pv_name='p_ims',
@@ -1187,6 +1324,7 @@ return {
     },
     {
       full_name='inccommand', abbreviation='icm',
+	  short_desc=N_("Live preview of substitution"),
       type='string', scope={'global'},
       vi_def=true,
       redraw={'all_windows'},
@@ -1195,6 +1333,7 @@ return {
     },
     {
       full_name='include', abbreviation='inc',
+      short_desc=N_("pattern to be used to find an include file"),
       type='string', scope={'global', 'buffer'},
       vi_def=true,
       alloced=true,
@@ -1203,6 +1342,7 @@ return {
     },
     {
       full_name='includeexpr', abbreviation='inex',
+      short_desc=N_("expression used to process an include line"),
       type='string', scope={'buffer'},
       vi_def=true,
       modelineexpr=true,
@@ -1212,6 +1352,7 @@ return {
     },
     {
       full_name='incsearch', abbreviation='is',
+      short_desc=N_("highlight match while typing search pattern"),
       type='bool', scope={'global'},
       vim=true,
       varname='p_is',
@@ -1219,6 +1360,7 @@ return {
     },
     {
       full_name='indentexpr', abbreviation='inde',
+      short_desc=N_("expression used to obtain the indent of a line"),
       type='string', scope={'buffer'},
       vi_def=true,
       vim=true,
@@ -1229,6 +1371,7 @@ return {
     },
     {
       full_name='indentkeys', abbreviation='indk',
+      short_desc=N_("keys that trigger indenting with 'indentexpr'"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -1238,6 +1381,7 @@ return {
     },
     {
       full_name='infercase', abbreviation='inf',
+      short_desc=N_("adjust case of match for keyword completion"),
       type='bool', scope={'buffer'},
       vi_def=true,
       varname='p_inf',
@@ -1245,6 +1389,7 @@ return {
     },
     {
       full_name='insertmode', abbreviation='im',
+      short_desc=N_("start the edit of a file in Insert mode"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -1253,6 +1398,7 @@ return {
     },
     {
       full_name='isfname', abbreviation='isf',
+      short_desc=N_("characters included in file names and pathnames"),
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1267,6 +1413,7 @@ return {
     },
     {
       full_name='isident', abbreviation='isi',
+      short_desc=N_("characters included in identifiers"),
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1279,6 +1426,7 @@ return {
     },
     {
       full_name='iskeyword', abbreviation='isk',
+      short_desc=N_("characters included in keywords"),
       type='string', list='comma', scope={'buffer'},
       deny_duplicates=true,
       vim=true,
@@ -1288,6 +1436,7 @@ return {
     },
     {
       full_name='isprint', abbreviation='isp',
+      short_desc=N_("printable characters"),
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1298,6 +1447,7 @@ return {
     },
     {
       full_name='joinspaces', abbreviation='js',
+      short_desc=N_("two spaces after a period with a join command"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -1306,6 +1456,7 @@ return {
     },
     {
       full_name='jumpoptions', abbreviation='jop',
+      short_desc=N_("Controls the behavior of the jumplist"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_jop',
@@ -1314,6 +1465,7 @@ return {
     },
     {
       full_name='keymap', abbreviation='kmp',
+      short_desc=N_("name of a keyboard mapping"),
       type='string', scope={'buffer'},
       normal_fname_chars=true,
       pri_mkrc=true,
@@ -1325,6 +1477,7 @@ return {
     },
     {
       full_name='keymodel', abbreviation='km',
+      short_desc=N_("enable starting/stopping selection with keys"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1333,6 +1486,7 @@ return {
     },
     {
       full_name='keywordprg', abbreviation='kp',
+      short_desc=N_("program to use for the \"K\" command"),
       type='string', scope={'global', 'buffer'},
       secure=true,
       vi_def=true,
@@ -1344,6 +1498,7 @@ return {
     },
     {
       full_name='langmap', abbreviation='lmap',
+      short_desc=N_("alphabetic characters for other language mode"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
@@ -1353,6 +1508,7 @@ return {
     },
     {
       full_name='langmenu', abbreviation='lm',
+      short_desc=N_("language to be used for the menus"),
       type='string', scope={'global'},
       normal_fname_chars=true,
       vi_def=true,
@@ -1361,18 +1517,21 @@ return {
     },
     {
       full_name='langnoremap', abbreviation='lnr',
+      short_desc=N_("do not apply 'langmap' to mapped characters"),
       type='bool', scope={'global'},
       varname='p_lnr',
       defaults={if_true={vi=false, vim=true}}
     },
     {
       full_name='langremap', abbreviation='lrm',
+      short_desc=N_('No description'),
       type='bool', scope={'global'},
       varname='p_lrm',
       defaults={if_true={vi=true, vim=false}}
     },
     {
       full_name='laststatus', abbreviation='ls',
+      short_desc=N_("tells when last window has status lines"),
       type='number', scope={'global'},
       vim=true,
       redraw={'all_windows'},
@@ -1381,6 +1540,7 @@ return {
     },
     {
       full_name='lazyredraw', abbreviation='lz',
+      short_desc=N_("don't redraw while executing macros"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_lz',
@@ -1388,6 +1548,7 @@ return {
     },
     {
       full_name='linebreak', abbreviation='lbr',
+      short_desc=N_("wrap long lines at a blank"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -1395,6 +1556,7 @@ return {
     },
     {
       full_name='lines',
+      short_desc=N_("of lines in the display"),
       type='number', scope={'global'},
       no_mkrc=true,
       vi_def=true,
@@ -1404,6 +1566,7 @@ return {
     },
     {
       full_name='linespace', abbreviation='lsp',
+      short_desc=N_("number of pixel lines to use between characters"),
       type='number', scope={'global'},
       vi_def=true,
       redraw={'ui_option'},
@@ -1412,6 +1575,7 @@ return {
     },
     {
       full_name='lisp',
+      short_desc=N_("indenting for Lisp"),
       type='bool', scope={'buffer'},
       vi_def=true,
       varname='p_lisp',
@@ -1419,6 +1583,7 @@ return {
     },
     {
       full_name='lispwords', abbreviation='lw',
+      short_desc=N_("words that change how lisp indenting works"),
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -1427,6 +1592,7 @@ return {
     },
     {
       full_name='list',
+      short_desc=N_("<Tab> and <EOL>"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -1434,6 +1600,7 @@ return {
     },
     {
       full_name='listchars', abbreviation='lcs',
+      short_desc=N_("characters for displaying in list mode"),
       type='string', list='onecomma', scope={'global', 'window'},
       deny_duplicates=true,
       vim=true,
@@ -1444,6 +1611,7 @@ return {
     },
     {
       full_name='loadplugins', abbreviation='lpl',
+      short_desc=N_("load plugin scripts when starting up"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_lpl',
@@ -1451,6 +1619,7 @@ return {
     },
     {
       full_name='magic',
+      short_desc=N_("special characters in search patterns"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_magic',
@@ -1458,6 +1627,7 @@ return {
     },
     {
       full_name='makeef', abbreviation='mef',
+      short_desc=N_("name of the errorfile for \":make\""),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -1467,6 +1637,7 @@ return {
     },
     {
       full_name='makeencoding', abbreviation='menc',
+      short_desc=N_("Converts the output of external commands"),
       type='string', scope={'global', 'buffer'},
       vi_def=true,
       varname='p_menc',
@@ -1474,6 +1645,7 @@ return {
     },
     {
       full_name='makeprg', abbreviation='mp',
+      short_desc=N_("program to use for the \":make\" command"),
       type='string', scope={'global', 'buffer'},
       secure=true,
       vi_def=true,
@@ -1483,6 +1655,7 @@ return {
     },
     {
       full_name='matchpairs', abbreviation='mps',
+      short_desc=N_("pairs of characters that \"%\" can match"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -1492,6 +1665,7 @@ return {
     },
     {
       full_name='matchtime', abbreviation='mat',
+      short_desc=N_("tenths of a second to show matching paren"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_mat',
@@ -1499,6 +1673,7 @@ return {
     },
     {
       full_name='maxcombine', abbreviation='mco',
+      short_desc=N_("maximum nr of combining characters displayed"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_mco',
@@ -1506,6 +1681,7 @@ return {
     },
     {
       full_name='maxfuncdepth', abbreviation='mfd',
+      short_desc=N_("maximum recursive depth for user functions"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_mfd',
@@ -1513,6 +1689,7 @@ return {
     },
     {
       full_name='maxmapdepth', abbreviation='mmd',
+      short_desc=N_("maximum recursive depth for mapping"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_mmd',
@@ -1520,6 +1697,7 @@ return {
     },
     {
       full_name='maxmempattern', abbreviation='mmp',
+      short_desc=N_("maximum memory (in Kbyte) used for pattern search"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_mmp',
@@ -1527,6 +1705,7 @@ return {
     },
     {
       full_name='menuitems', abbreviation='mis',
+      short_desc=N_("maximum number of items in a menu"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_mis',
@@ -1534,6 +1713,7 @@ return {
     },
     {
       full_name='mkspellmem', abbreviation='msm',
+      short_desc=N_("memory used before |:mkspell| compresses the tree"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -1543,6 +1723,7 @@ return {
     },
     {
       full_name='modeline', abbreviation='ml',
+      short_desc=N_("recognize modelines at start or end of file"),
       type='bool', scope={'buffer'},
       vim=true,
       varname='p_ml',
@@ -1550,6 +1731,7 @@ return {
     },
     {
       full_name='modelineexpr', abbreviation='mle',
+      short_desc=N_("allow some options to be set in modeline"),
       type='bool', scope={'global'},
       vi_def=true,
       secure=true,
@@ -1558,6 +1740,7 @@ return {
     },
     {
       full_name='modelines', abbreviation='mls',
+      short_desc=N_("number of lines checked for modelines"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_mls',
@@ -1565,6 +1748,7 @@ return {
     },
     {
       full_name='modifiable', abbreviation='ma',
+      short_desc=N_("changes to the text are not possible"),
       type='bool', scope={'buffer'},
       noglob=true,
       vi_def=true,
@@ -1573,6 +1757,7 @@ return {
     },
     {
       full_name='modified', abbreviation='mod',
+      short_desc=N_("buffer has been modified"),
       type='bool', scope={'buffer'},
       no_mkrc=true,
       vi_def=true,
@@ -1582,6 +1767,7 @@ return {
     },
     {
       full_name='more',
+      short_desc=N_("listings when the whole screen is filled"),
       type='bool', scope={'global'},
       vim=true,
       varname='p_more',
@@ -1589,12 +1775,14 @@ return {
     },
     {
       full_name='mouse',
+      short_desc=N_("the use of mouse clicks"),
       type='string', list='flags', scope={'global'},
       varname='p_mouse',
       defaults={if_true={vi="", vim=""}}
     },
     {
       full_name='mousefocus', abbreviation='mousef',
+      short_desc=N_("keyboard focus follows the mouse"),
       type='bool', scope={'global'},
       vi_def=true,
       redraw={'ui_option'},
@@ -1603,6 +1791,7 @@ return {
     },
     {
       full_name='mousehide', abbreviation='mh',
+      short_desc=N_("hide mouse pointer while typing"),
       type='bool', scope={'global'},
       vi_def=true,
       enable_if=false,
@@ -1610,6 +1799,7 @@ return {
     },
     {
       full_name='mousemodel', abbreviation='mousem',
+      short_desc=N_("changes meaning of mouse buttons"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_mousem',
@@ -1617,6 +1807,7 @@ return {
     },
     {
       full_name='mouseshape', abbreviation='mouses',
+      short_desc=N_("shape of the mouse pointer in different modes"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1624,6 +1815,7 @@ return {
     },
     {
       full_name='mousetime', abbreviation='mouset',
+      short_desc=N_("max time between mouse double-click"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_mouset',
@@ -1631,6 +1823,7 @@ return {
     },
     {
       full_name='nrformats', abbreviation='nf',
+      short_desc=N_("number formats recognized for CTRL-A command"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       alloced=true,
@@ -1639,6 +1832,7 @@ return {
     },
     {
       full_name='number', abbreviation='nu',
+      short_desc=N_("print the line number in front of each line"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -1646,6 +1840,7 @@ return {
     },
     {
       full_name='numberwidth', abbreviation='nuw',
+      short_desc=N_("number of columns used for the line number"),
       type='number', scope={'window'},
       vim=true,
       redraw={'current_window'},
@@ -1653,6 +1848,7 @@ return {
     },
     {
       full_name='omnifunc', abbreviation='ofu',
+      short_desc=N_("function for filetype-specific completion"),
       type='string', scope={'buffer'},
       secure=true,
       vi_def=true,
@@ -1662,6 +1858,7 @@ return {
     },
     {
       full_name='opendevice', abbreviation='odev',
+      short_desc=N_("allow reading/writing devices on MS-Windows"),
       type='bool', scope={'global'},
       vi_def=true,
       enable_if=false,
@@ -1669,6 +1866,7 @@ return {
     },
     {
       full_name='operatorfunc', abbreviation='opfunc',
+      short_desc=N_("function to be called for |g@| operator"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -1677,6 +1875,7 @@ return {
     },
     {
       full_name='packpath', abbreviation='pp',
+      short_desc=N_("list of directories used for packages"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
@@ -1687,6 +1886,7 @@ return {
     },
     {
       full_name='paragraphs', abbreviation='para',
+      short_desc=N_("nroff macros that separate paragraphs"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_para',
@@ -1694,6 +1894,7 @@ return {
     },
     {
       full_name='paste',
+      short_desc=N_("pasting text"),
       type='bool', scope={'global'},
       pri_mkrc=true,
       vi_def=true,
@@ -1702,6 +1903,7 @@ return {
     },
     {
       full_name='pastetoggle', abbreviation='pt',
+      short_desc=N_("key code that causes 'paste' to toggle"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_pt',
@@ -1709,6 +1911,7 @@ return {
     },
     {
       full_name='patchexpr', abbreviation='pex',
+      short_desc=N_("expression used to patch a file"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -1717,6 +1920,7 @@ return {
     },
     {
       full_name='patchmode', abbreviation='pm',
+      short_desc=N_("keep the oldest version of a file"),
       type='string', scope={'global'},
       normal_fname_chars=true,
       vi_def=true,
@@ -1725,6 +1929,7 @@ return {
     },
     {
       full_name='path', abbreviation='pa',
+      short_desc=N_("list of directories searched with \"gf\" et.al."),
       type='string', list='comma', scope={'global', 'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -1734,6 +1939,7 @@ return {
     },
     {
       full_name='preserveindent', abbreviation='pi',
+      short_desc=N_("preserve the indent structure when reindenting"),
       type='bool', scope={'buffer'},
       vi_def=true,
       vim=true,
@@ -1742,6 +1948,7 @@ return {
     },
     {
       full_name='previewheight', abbreviation='pvh',
+      short_desc=N_("height of the preview window"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_pvh',
@@ -1749,6 +1956,7 @@ return {
     },
     {
       full_name='previewwindow', abbreviation='pvw',
+      short_desc=N_("identifies the preview window"),
       type='bool', scope={'window'},
       noglob=true,
       vi_def=true,
@@ -1757,6 +1965,7 @@ return {
     },
     {
       full_name='printdevice', abbreviation='pdev',
+      short_desc=N_("name of the printer to be used for :hardcopy"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -1765,6 +1974,7 @@ return {
     },
     {
       full_name='printencoding', abbreviation='penc',
+      short_desc=N_("encoding to be used for printing"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_penc',
@@ -1772,6 +1982,7 @@ return {
     },
     {
       full_name='printexpr', abbreviation='pexpr',
+      short_desc=N_("expression used to print PostScript for :hardcopy"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -1780,6 +1991,7 @@ return {
     },
     {
       full_name='printfont', abbreviation='pfn',
+      short_desc=N_("name of the font to be used for :hardcopy"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_pfn',
@@ -1787,6 +1999,7 @@ return {
     },
     {
       full_name='printheader', abbreviation='pheader',
+      short_desc=N_("format of the header used for :hardcopy"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_header',
@@ -1794,6 +2007,7 @@ return {
     },
     {
       full_name='printmbcharset', abbreviation='pmbcs',
+      short_desc=N_("CJK character set to be used for :hardcopy"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_pmcs',
@@ -1801,6 +2015,7 @@ return {
     },
     {
       full_name='printmbfont', abbreviation='pmbfn',
+      short_desc=N_("font names to be used for CJK output of :hardcopy"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_pmfn',
@@ -1808,6 +2023,7 @@ return {
     },
     {
       full_name='printoptions', abbreviation='popt',
+      short_desc=N_("controls the format of :hardcopy output"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -1816,6 +2032,7 @@ return {
     },
     {
       full_name='prompt',
+      short_desc=N_("enable prompt in Ex mode"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_prompt',
@@ -1823,6 +2040,7 @@ return {
     },
     {
       full_name='pumblend', abbreviation='pb',
+      short_desc=N_("Controls transparency level of popup menu"),
       type='number', scope={'global'},
       vi_def=true,
       redraw={'ui_option'},
@@ -1831,6 +2049,7 @@ return {
     },
     {
       full_name='pumheight', abbreviation='ph',
+      short_desc=N_("maximum height of the popup menu"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_ph',
@@ -1838,6 +2057,7 @@ return {
     },
     {
       full_name='pumwidth', abbreviation='pw',
+      short_desc=N_("minimum width of the popup menu"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_pw',
@@ -1845,6 +2065,7 @@ return {
     },
     {
       full_name='pyxversion', abbreviation='pyx',
+      short_desc=N_("selects default python version to use"),
       type='number', scope={'global'},
       secure=true,
       vi_def=true,
@@ -1853,6 +2074,7 @@ return {
     },
     {
       full_name='quoteescape', abbreviation='qe',
+      short_desc=N_("escape characters used in a string"),
       type='string', scope={'buffer'},
       vi_def=true,
       alloced=true,
@@ -1861,6 +2083,7 @@ return {
     },
     {
       full_name='readonly', abbreviation='ro',
+      short_desc=N_("disallow writing the buffer"),
       type='bool', scope={'buffer'},
       noglob=true,
       vi_def=true,
@@ -1870,6 +2093,7 @@ return {
     },
     {
       full_name='redrawdebug', abbreviation='rdb',
+      short_desc=N_("Changes the way redrawing works (debug)"),
       type='string', list='onecomma', scope={'global'},
       vi_def=true,
       varname='p_rdb',
@@ -1877,6 +2101,7 @@ return {
     },
     {
       full_name='redrawtime', abbreviation='rdt',
+      short_desc=N_("timeout for 'hlsearch' and |:match| highlighting"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_rdt',
@@ -1884,6 +2109,7 @@ return {
     },
     {
       full_name='regexpengine', abbreviation='re',
+      short_desc=N_("default regexp engine to use"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_re',
@@ -1891,6 +2117,7 @@ return {
     },
     {
       full_name='relativenumber', abbreviation='rnu',
+      short_desc=N_("show relative line number in front of each line"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -1898,6 +2125,7 @@ return {
     },
     {
       full_name='remap',
+      short_desc=N_("mappings to work recursively"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_remap',
@@ -1905,6 +2133,7 @@ return {
     },
     {
       full_name='report',
+      short_desc=N_("for reporting nr. of lines changed"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_report',
@@ -1912,6 +2141,7 @@ return {
     },
     {
       full_name='revins', abbreviation='ri',
+      short_desc=N_("inserting characters will work backwards"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -1920,6 +2150,7 @@ return {
     },
     {
       full_name='rightleft', abbreviation='rl',
+      short_desc=N_("window is right-to-left oriented"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -1927,6 +2158,7 @@ return {
     },
     {
       full_name='rightleftcmd', abbreviation='rlc',
+      short_desc=N_("commands for which editing works right-to-left"),
       type='string', scope={'window'},
       vi_def=true,
       alloced=true,
@@ -1935,6 +2167,7 @@ return {
     },
     {
       full_name='ruler', abbreviation='ru',
+      short_desc=N_("show cursor line and column in the status line"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -1944,6 +2177,7 @@ return {
     },
     {
       full_name='rulerformat', abbreviation='ruf',
+      short_desc=N_("custom format for the ruler"),
       type='string', scope={'global'},
       vi_def=true,
       alloced=true,
@@ -1954,6 +2188,7 @@ return {
     },
     {
       full_name='runtimepath', abbreviation='rtp',
+      short_desc=N_("list of directories used for runtime files"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
@@ -1964,6 +2199,7 @@ return {
     },
     {
       full_name='scroll', abbreviation='scr',
+      short_desc=N_("lines to scroll with CTRL-U and CTRL-D"),
       type='number', scope={'window'},
       no_mkrc=true,
       vi_def=true,
@@ -1972,6 +2208,7 @@ return {
     },
     {
       full_name='scrollback', abbreviation='scbk',
+      short_desc=N_("lines to scroll with CTRL-U and CTRL-D"),
       type='number', scope={'buffer'},
       vi_def=true,
       varname='p_scbk',
@@ -1980,6 +2217,7 @@ return {
     },
     {
       full_name='scrollbind', abbreviation='scb',
+      short_desc=N_("scroll in window as other windows scroll"),
       type='bool', scope={'window'},
       vi_def=true,
       pv_name='p_scbind',
@@ -1987,6 +2225,7 @@ return {
     },
     {
       full_name='scrolljump', abbreviation='sj',
+      short_desc=N_("minimum number of lines to scroll"),
       type='number', scope={'global'},
       vi_def=true,
       vim=true,
@@ -1995,6 +2234,7 @@ return {
     },
     {
       full_name='scrolloff', abbreviation='so',
+      short_desc=N_("minimum nr. of lines above and below cursor"),
       type='number', scope={'global', 'window'},
       vi_def=true,
       vim=true,
@@ -2004,6 +2244,7 @@ return {
     },
     {
       full_name='scrollopt', abbreviation='sbo',
+      short_desc=N_("how 'scrollbind' should behave"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -2012,6 +2253,7 @@ return {
     },
     {
       full_name='sections', abbreviation='sect',
+      short_desc=N_("nroff macros that separate sections"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_sections',
@@ -2019,6 +2261,7 @@ return {
     },
     {
       full_name='secure',
+      short_desc=N_("mode for reading .vimrc in current dir"),
       type='bool', scope={'global'},
       secure=true,
       vi_def=true,
@@ -2027,6 +2270,7 @@ return {
     },
     {
       full_name='selection', abbreviation='sel',
+      short_desc=N_("what type of selection to use"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_sel',
@@ -2034,6 +2278,7 @@ return {
     },
     {
       full_name='selectmode', abbreviation='slm',
+      short_desc=N_("when to use Select mode instead of Visual mode"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -2042,6 +2287,7 @@ return {
     },
     {
       full_name='sessionoptions', abbreviation='ssop',
+      short_desc=N_("options for |:mksession|"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vim=true,
@@ -2053,6 +2299,7 @@ return {
     },
     {
       full_name='shada', abbreviation='sd',
+      short_desc=N_("use .shada file upon startup and exiting"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
@@ -2061,6 +2308,7 @@ return {
     },
     {
       full_name='shadafile', abbreviation='sdf',
+      short_desc=N_("overrides the filename used for shada"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -2070,6 +2318,7 @@ return {
     },
     {
       full_name='shell', abbreviation='sh',
+      short_desc=N_("name of shell to use for external commands"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -2083,6 +2332,7 @@ return {
     },
     {
       full_name='shellcmdflag', abbreviation='shcf',
+      short_desc=N_("flag to shell to execute one command"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -2095,6 +2345,7 @@ return {
     },
     {
       full_name='shellpipe', abbreviation='sp',
+      short_desc=N_("string to put output of \":make\" in error file"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -2107,6 +2358,7 @@ return {
     },
     {
       full_name='shellquote', abbreviation='shq',
+      short_desc=N_("quote character(s) for around shell command"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -2115,6 +2367,7 @@ return {
     },
     {
       full_name='shellredir', abbreviation='srr',
+      short_desc=N_("string to put output of filter in a temp file"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -2127,6 +2380,7 @@ return {
     },
     {
       full_name='shellslash', abbreviation='ssl',
+      short_desc=N_("use forward slash for shell file names"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_ssl',
@@ -2135,12 +2389,14 @@ return {
     },
     {
       full_name='shelltemp', abbreviation='stmp',
+      short_desc=N_("whether to use a temp file for shell commands"),
       type='bool', scope={'global'},
       varname='p_stmp',
       defaults={if_true={vi=false, vim=true}}
     },
     {
       full_name='shellxquote', abbreviation='sxq',
+      short_desc=N_("like 'shellquote', but include redirection"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -2153,6 +2409,7 @@ return {
     },
     {
       full_name='shellxescape', abbreviation='sxe',
+      short_desc=N_("characters to escape when 'shellxquote' is ("),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -2161,6 +2418,7 @@ return {
     },
     {
       full_name='shiftround', abbreviation='sr',
+      short_desc=N_("round indent to multiple of shiftwidth"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -2169,6 +2427,7 @@ return {
     },
     {
       full_name='shiftwidth', abbreviation='sw',
+      short_desc=N_("number of spaces to use for (auto)indent step"),
       type='number', scope={'buffer'},
       vi_def=true,
       varname='p_sw',
@@ -2176,6 +2435,7 @@ return {
     },
     {
       full_name='shortmess', abbreviation='shm',
+      short_desc=N_("list of flags, reduce length of messages"),
       type='string', list='flags', scope={'global'},
       vim=true,
       varname='p_shm',
@@ -2183,6 +2443,7 @@ return {
     },
     {
       full_name='showbreak', abbreviation='sbr',
+      short_desc=N_("string to use at the start of wrapped lines"),
       type='string', scope={'global'},
       vi_def=true,
       redraw={'all_windows'},
@@ -2191,6 +2452,7 @@ return {
     },
     {
       full_name='showcmd', abbreviation='sc',
+      short_desc=N_("show (partial) command in status line"),
       type='bool', scope={'global'},
       vim=true,
       varname='p_sc',
@@ -2198,6 +2460,7 @@ return {
     },
     {
       full_name='showfulltag', abbreviation='sft',
+      short_desc=N_("show full tag pattern when completing tag"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_sft',
@@ -2205,6 +2468,7 @@ return {
     },
     {
       full_name='showmatch', abbreviation='sm',
+      short_desc=N_("briefly jump to matching bracket if insert one"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_sm',
@@ -2212,6 +2476,7 @@ return {
     },
     {
       full_name='showmode', abbreviation='smd',
+      short_desc=N_("message on status line to show current mode"),
       type='bool', scope={'global'},
       vim=true,
       varname='p_smd',
@@ -2219,6 +2484,7 @@ return {
     },
     {
       full_name='showtabline', abbreviation='stal',
+      short_desc=N_("tells when the tab pages line is displayed"),
       type='number', scope={'global'},
       vi_def=true,
       redraw={'all_windows', 'ui_option'},
@@ -2227,6 +2493,7 @@ return {
     },
     {
       full_name='sidescroll', abbreviation='ss',
+      short_desc=N_("minimum number of columns to scroll horizontal"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_ss',
@@ -2234,6 +2501,7 @@ return {
     },
     {
       full_name='sidescrolloff', abbreviation='siso',
+      short_desc=N_("min. nr. of columns to left and right of cursor"),
       type='number', scope={'global', 'window'},
       vi_def=true,
       vim=true,
@@ -2243,6 +2511,7 @@ return {
     },
     {
       full_name='signcolumn', abbreviation='scl',
+      short_desc=N_("when to display the sign column"),
       type='string', scope={'window'},
       vi_def=true,
       alloced=true,
@@ -2251,6 +2520,7 @@ return {
     },
     {
       full_name='smartcase', abbreviation='scs',
+      short_desc=N_("no ignore case when pattern has uppercase"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -2259,6 +2529,7 @@ return {
     },
     {
       full_name='smartindent', abbreviation='si',
+      short_desc=N_("smart autoindenting for C programs"),
       type='bool', scope={'buffer'},
       vi_def=true,
       vim=true,
@@ -2267,6 +2538,7 @@ return {
     },
     {
       full_name='smarttab', abbreviation='sta',
+      short_desc=N_("use 'shiftwidth' when inserting <Tab>"),
       type='bool', scope={'global'},
       vim=true,
       varname='p_sta',
@@ -2274,6 +2546,7 @@ return {
     },
     {
       full_name='softtabstop', abbreviation='sts',
+      short_desc=N_("number of spaces that <Tab> uses while editing"),
       type='number', scope={'buffer'},
       vi_def=true,
       vim=true,
@@ -2282,6 +2555,7 @@ return {
     },
     {
       full_name='spell',
+      short_desc=N_("spell checking"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -2289,6 +2563,7 @@ return {
     },
     {
       full_name='spellcapcheck', abbreviation='spc',
+      short_desc=N_("pattern to locate end of a sentence"),
       type='string', scope={'buffer'},
       vi_def=true,
       alloced=true,
@@ -2298,6 +2573,7 @@ return {
     },
     {
       full_name='spellfile', abbreviation='spf',
+      short_desc=N_("files where |zg| and |zw| store words"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       secure=true,
@@ -2309,6 +2585,7 @@ return {
     },
     {
       full_name='spelllang', abbreviation='spl',
+      short_desc=N_("language(s) to do spell checking for"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -2320,6 +2597,7 @@ return {
     },
     {
       full_name='spellsuggest', abbreviation='sps',
+      short_desc=N_("method(s) used to suggest spelling corrections"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
@@ -2340,6 +2618,7 @@ return {
     },
     {
       full_name='splitbelow', abbreviation='sb',
+      short_desc=N_("new window from split is below the current one"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_sb',
@@ -2347,6 +2626,7 @@ return {
     },
     {
       full_name='splitright', abbreviation='spr',
+      short_desc=N_("new window is put right of the current one"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_spr',
@@ -2354,6 +2634,7 @@ return {
     },
     {
       full_name='startofline', abbreviation='sol',
+      short_desc=N_("commands move cursor to first non-blank in line"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=false,
@@ -2362,6 +2643,7 @@ return {
     },
     {
       full_name='statusline', abbreviation='stl',
+      short_desc=N_("custom format for the status line"),
       type='string', scope={'global', 'window'},
       vi_def=true,
       alloced=true,
@@ -2372,6 +2654,7 @@ return {
     },
     {
       full_name='suffixes', abbreviation='su',
+      short_desc=N_("suffixes that are ignored with multiple match"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -2380,6 +2663,7 @@ return {
     },
     {
       full_name='suffixesadd', abbreviation='sua',
+      short_desc=N_("suffixes added when searching for a file"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -2389,6 +2673,7 @@ return {
     },
     {
       full_name='swapfile', abbreviation='swf',
+      short_desc=N_("whether to use a swapfile for a buffer"),
       type='bool', scope={'buffer'},
       vi_def=true,
       redraw={'statuslines'},
@@ -2397,6 +2682,7 @@ return {
     },
     {
       full_name='switchbuf', abbreviation='swb',
+      short_desc=N_("sets behavior when switching to another buffer"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -2405,6 +2691,7 @@ return {
     },
     {
       full_name='synmaxcol', abbreviation='smc',
+      short_desc=N_("maximum column to find syntax items"),
       type='number', scope={'buffer'},
       vi_def=true,
       redraw={'current_buffer'},
@@ -2413,6 +2700,7 @@ return {
     },
     {
       full_name='syntax', abbreviation='syn',
+      short_desc=N_("syntax to be loaded for current buffer"),
       type='string', scope={'buffer'},
       noglob=true,
       normal_fname_chars=true,
@@ -2423,6 +2711,7 @@ return {
     },
     {
       full_name='tagfunc', abbreviation='tfu',
+      short_desc=N_("function used to perform tag searches"),
       type='string', scope={'buffer'},
       vim=true,
       vi_def=true,
@@ -2431,6 +2720,7 @@ return {
     },
     {
       full_name='tabline', abbreviation='tal',
+      short_desc=N_("custom format for the console tab pages line"),
       type='string', scope={'global'},
       vi_def=true,
       modelineexpr=true,
@@ -2440,6 +2730,7 @@ return {
     },
     {
       full_name='tabpagemax', abbreviation='tpm',
+      short_desc=N_("maximum number of tab pages for |-p| and \"tab all\""),
       type='number', scope={'global'},
       vim=true,
       varname='p_tpm',
@@ -2447,6 +2738,7 @@ return {
     },
     {
       full_name='tabstop', abbreviation='ts',
+      short_desc=N_("number of spaces that <Tab> in file uses"),
       type='number', scope={'buffer'},
       vi_def=true,
       redraw={'current_buffer'},
@@ -2455,6 +2747,7 @@ return {
     },
     {
       full_name='tagbsearch', abbreviation='tbs',
+      short_desc=N_("use binary searching in tags files"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_tbs',
@@ -2462,6 +2755,7 @@ return {
     },
     {
       full_name='tagcase', abbreviation='tc',
+      short_desc=N_("how to handle case when searching in tags files"),
       type='string', scope={'global', 'buffer'},
       vim=true,
       varname='p_tc',
@@ -2469,6 +2763,7 @@ return {
     },
     {
       full_name='taglength', abbreviation='tl',
+      short_desc=N_("number of significant characters for a tag"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_tl',
@@ -2476,6 +2771,7 @@ return {
     },
     {
       full_name='tagrelative', abbreviation='tr',
+      short_desc=N_("file names in tag file are relative"),
       type='bool', scope={'global'},
       vim=true,
       varname='p_tr',
@@ -2483,6 +2779,7 @@ return {
     },
     {
       full_name='tags', abbreviation='tag',
+      short_desc=N_("list of file names used by the tag command"),
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
       vi_def=true,
@@ -2492,6 +2789,7 @@ return {
     },
     {
       full_name='tagstack', abbreviation='tgst',
+      short_desc=N_("push tags onto the tag stack"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_tgst',
@@ -2499,6 +2797,7 @@ return {
     },
     {
       full_name='termbidi', abbreviation='tbidi',
+      short_desc=N_("terminal takes care of bi-directionality"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_tbidi',
@@ -2506,12 +2805,14 @@ return {
     },
     {
       full_name='termencoding', abbreviation='tenc',
+      short_desc=N_("Terminal encodig"),
       type='string', scope={'global'},
       vi_def=true,
       defaults={if_true={vi=""}}
     },
     {
       full_name='termguicolors', abbreviation='tgc',
+      short_desc=N_("Terminal true color support"),
       type='bool', scope={'global'},
       vi_def=false,
       redraw={'ui_option'},
@@ -2520,6 +2821,7 @@ return {
     },
     {
       full_name='terse',
+      short_desc=N_("hides notification of search wrap"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_terse',
@@ -2527,6 +2829,7 @@ return {
     },
     {
       full_name='textwidth', abbreviation='tw',
+      short_desc=N_("maximum width of text that is being inserted"),
       type='number', scope={'buffer'},
       vi_def=true,
       vim=true,
@@ -2536,6 +2839,7 @@ return {
     },
     {
       full_name='thesaurus', abbreviation='tsr',
+      short_desc=N_("list of thesaurus files for keyword completion"),
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
       normal_dname_chars=true,
@@ -2546,6 +2850,7 @@ return {
     },
     {
       full_name='tildeop', abbreviation='top',
+      short_desc=N_("tilde command \"~\" behaves like an operator"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -2554,6 +2859,7 @@ return {
     },
     {
       full_name='timeout', abbreviation='to',
+      short_desc=N_("time out on mappings and key codes"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_timeout',
@@ -2561,6 +2867,7 @@ return {
     },
     {
       full_name='timeoutlen', abbreviation='tm',
+      short_desc=N_("time out time in milliseconds"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_tm',
@@ -2568,6 +2875,7 @@ return {
     },
     {
       full_name='title',
+      short_desc=N_("Vim set the title of the window"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_title',
@@ -2575,6 +2883,7 @@ return {
     },
     {
       full_name='titlelen',
+      short_desc=N_("of 'columns' used for window title"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_titlelen',
@@ -2582,6 +2891,7 @@ return {
     },
     {
       full_name='titleold',
+      short_desc=N_("title, restored when exiting"),
       type='string', scope={'global'},
       secure=true,
       no_mkrc=true,
@@ -2591,6 +2901,7 @@ return {
     },
     {
       full_name='titlestring',
+      short_desc=N_("to use for the Vim window title"),
       type='string', scope={'global'},
       vi_def=true,
       modelineexpr=true,
@@ -2599,6 +2910,7 @@ return {
     },
     {
       full_name='ttimeout',
+      short_desc=N_("out on mappings"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -2608,6 +2920,7 @@ return {
     },
     {
       full_name='ttimeoutlen', abbreviation='ttm',
+      short_desc=N_("time out time for key codes in milliseconds"),
       type='number', scope={'global'},
       vi_def=true,
       redraw={'ui_option'},
@@ -2616,6 +2929,7 @@ return {
     },
     {
       full_name='ttyfast', abbreviation='tf',
+	  short_desc=N_("No description"),
       type='bool', scope={'global'},
       no_mkrc=true,
       vi_def=true,
@@ -2624,6 +2938,7 @@ return {
     },
     {
       full_name='undodir', abbreviation='udir',
+      short_desc=N_("where to store undo files"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
@@ -2634,6 +2949,7 @@ return {
     },
     {
       full_name='undofile', abbreviation='udf',
+      short_desc=N_("save undo information in a file"),
       type='bool', scope={'buffer'},
       vi_def=true,
       vim=true,
@@ -2642,6 +2958,7 @@ return {
     },
     {
       full_name='undolevels', abbreviation='ul',
+      short_desc=N_("maximum number of changes that can be undone"),
       type='number', scope={'global', 'buffer'},
       vi_def=true,
       varname='p_ul',
@@ -2649,6 +2966,7 @@ return {
     },
     {
       full_name='undoreload', abbreviation='ur',
+      short_desc=N_("max nr of lines to save for undo on a buffer reload"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_ur',
@@ -2656,6 +2974,7 @@ return {
     },
     {
       full_name='updatecount', abbreviation='uc',
+      short_desc=N_("after this many characters flush swap file"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_uc',
@@ -2663,6 +2982,7 @@ return {
     },
     {
       full_name='updatetime', abbreviation='ut',
+      short_desc=N_("after this many milliseconds flush swap file"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_ut',
@@ -2670,6 +2990,7 @@ return {
     },
     {
       full_name='verbose', abbreviation='vbs',
+      short_desc=N_("give informative messages"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_verbose',
@@ -2677,6 +2998,7 @@ return {
     },
     {
       full_name='verbosefile', abbreviation='vfile',
+      short_desc=N_("file to write messages in"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -2686,6 +3008,7 @@ return {
     },
     {
       full_name='viewdir', abbreviation='vdir',
+      short_desc=N_("directory where to store files with :mkview"),
       type='string', scope={'global'},
       secure=true,
       vi_def=true,
@@ -2695,6 +3018,7 @@ return {
     },
     {
       full_name='viewoptions', abbreviation='vop',
+      short_desc=N_("specifies what to save for :mkview"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -2704,15 +3028,18 @@ return {
     {
       -- Alias for "shada".
       full_name='viminfo', abbreviation='vi',
+      short_desc=N_("Alias for shada"),
       type='string', scope={'global'}, nodefault=true,
     },
     {
       -- Alias for "shadafile".
       full_name='viminfofile', abbreviation='vif',
+      short_desc=N_("Alias for shadafile instead"),
       type='string', scope={'global'}, nodefault=true,
     },
     {
       full_name='virtualedit', abbreviation='ve',
+      short_desc=N_("when to use virtual editing"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -2723,6 +3050,7 @@ return {
     },
     {
       full_name='visualbell', abbreviation='vb',
+      short_desc=N_("use visual bell instead of beeping"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_vb',
@@ -2730,6 +3058,7 @@ return {
     },
     {
       full_name='warn',
+      short_desc=N_("for shell command when buffer was changed"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_warn',
@@ -2737,6 +3066,7 @@ return {
     },
     {
       full_name='whichwrap', abbreviation='ww',
+      short_desc=N_("allow specified keys to cross line boundaries"),
       type='string', list='flagscomma', scope={'global'},
       vim=true,
       varname='p_ww',
@@ -2744,6 +3074,7 @@ return {
     },
     {
       full_name='wildchar', abbreviation='wc',
+      short_desc=N_("command-line character for wildcard expansion"),
       type='number', scope={'global'},
       vim=true,
       varname='p_wc',
@@ -2751,6 +3082,7 @@ return {
     },
     {
       full_name='wildcharm', abbreviation='wcm',
+      short_desc=N_("like 'wildchar' but also works when mapped"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_wcm',
@@ -2758,6 +3090,7 @@ return {
     },
     {
       full_name='wildignore', abbreviation='wig',
+      short_desc=N_("files matching these patterns are not completed"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
@@ -2766,6 +3099,7 @@ return {
     },
     {
       full_name='wildignorecase', abbreviation='wic',
+      short_desc=N_("ignore case when completing file names"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_wic',
@@ -2773,6 +3107,7 @@ return {
     },
     {
       full_name='wildmenu', abbreviation='wmnu',
+      short_desc=N_("use menu for command line completion"),
       type='bool', scope={'global'},
       vim=true,
       varname='p_wmnu',
@@ -2780,6 +3115,7 @@ return {
     },
     {
       full_name='wildmode', abbreviation='wim',
+      short_desc=N_("mode for 'wildchar' command-line expansion"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vim=true,
@@ -2788,6 +3124,7 @@ return {
     },
     {
       full_name='wildoptions', abbreviation='wop',
+      short_desc=N_("specifies how command line completion is done"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vim=true,
@@ -2796,6 +3133,7 @@ return {
     },
     {
       full_name='winaltkeys', abbreviation='wak',
+      short_desc=N_("when the windows system handles ALT keys"),
       type='string', scope={'global'},
       vi_def=true,
       varname='p_wak',
@@ -2803,6 +3141,7 @@ return {
     },
     {
       full_name='winblend', abbreviation='winbl',
+      short_desc=N_("Controls transparency level for floating windows"),
       type='number', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -2810,6 +3149,7 @@ return {
     },
     {
       full_name='winhighlight', abbreviation='winhl',
+      short_desc=N_("Setup window-local highlights");
       type='string', scope={'window'},
       vi_def=true,
       alloced=true,
@@ -2818,6 +3158,7 @@ return {
     },
     {
       full_name='window', abbreviation='wi',
+      short_desc=N_("nr of lines to scroll for CTRL-F and CTRL-B"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_window',
@@ -2825,6 +3166,7 @@ return {
     },
     {
       full_name='winheight', abbreviation='wh',
+      short_desc=N_("minimum number of lines for the current window"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_wh',
@@ -2832,6 +3174,7 @@ return {
     },
     {
       full_name='winfixheight', abbreviation='wfh',
+      short_desc=N_("keep window height when opening/closing windows"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'statuslines'},
@@ -2839,6 +3182,7 @@ return {
     },
     {
       full_name='winfixwidth', abbreviation='wfw',
+      short_desc=N_("keep window width when opening/closing windows"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'statuslines'},
@@ -2846,6 +3190,7 @@ return {
     },
     {
       full_name='winminheight', abbreviation='wmh',
+      short_desc=N_("minimum number of lines for any window"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_wmh',
@@ -2853,6 +3198,7 @@ return {
     },
     {
       full_name='winminwidth', abbreviation='wmw',
+      short_desc=N_("minimal number of columns for any window"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_wmw',
@@ -2860,6 +3206,7 @@ return {
     },
     {
       full_name='winwidth', abbreviation='wiw',
+      short_desc=N_("minimal number of columns for current window"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_wiw',
@@ -2867,6 +3214,7 @@ return {
     },
     {
       full_name='wrap',
+      short_desc=N_("lines wrap and continue on the next line"),
       type='bool', scope={'window'},
       vi_def=true,
       redraw={'current_window'},
@@ -2874,6 +3222,7 @@ return {
     },
     {
       full_name='wrapmargin', abbreviation='wm',
+      short_desc=N_("chars from the right where wrapping starts"),
       type='number', scope={'buffer'},
       vi_def=true,
       varname='p_wm',
@@ -2881,6 +3230,7 @@ return {
     },
     {
       full_name='wrapscan', abbreviation='ws',
+      short_desc=N_("searches wrap around the end of the file"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_ws',
@@ -2888,6 +3238,7 @@ return {
     },
     {
       full_name='write',
+      short_desc=N_("to a file is allowed"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_write',
@@ -2895,6 +3246,7 @@ return {
     },
     {
       full_name='writeany', abbreviation='wa',
+      short_desc=N_("write to file with no need for \"!\" override"),
       type='bool', scope={'global'},
       vi_def=true,
       varname='p_wa',
@@ -2902,6 +3254,7 @@ return {
     },
     {
       full_name='writebackup', abbreviation='wb',
+      short_desc=N_("make a backup before overwriting a file"),
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
@@ -2910,6 +3263,7 @@ return {
     },
     {
       full_name='writedelay', abbreviation='wd',
+      short_desc=N_("delay this many msec for each char (for debug)"),
       type='number', scope={'global'},
       vi_def=true,
       varname='p_wd',


### PR DESCRIPTION
In order to generate a "palette" (https://github.com/teto/nvim-palette ; related issue https://github.com/neovim/neovim/issues/6240), I moved the one-liner option descriptions from quickref.txt to options.lua so that it can be reused more easily.
In order not to have duplicated strings across the source, I generate the incriminated quickref help from options.lua.

As a summary of changes:
- options in options.lua now have a `short_desc=` member.
- genoptions.lua has 3 distinct targets: doc, csv, header
    - header generates the C header (its original role)
    - csv converts to CSV the lua table. This is what I used for nvim-palette. As such it's not critical to nvim so it could be either removed  or moved to contrib/
    - doc generates quickref.txt from quickref*.tpl (tpl=template) files. It generates quickref_10.txt and does `cat quickref_*.tpl  > quickref.txt`. That was the only thing I could think with my skillset (apart from using jinja templates). This leaves the tpl files in the runtime folder but I wanted to know if you had another idea in mind before cleaning that up. There could be value in generating other parts of the doc so if we could standardize the process that might be nice.
- I modified the xgettext cmake launcher so that it fetches these descriptions as well. vimscript (https://github.com/neovim/neovim/issues/1453) and lua gettext support look bad but for remote plugins such as python, that could be a good way to retrieve the strings.
