### PR TITLE
[RDY] Remove "reading from stdin" message

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -700,16 +700,9 @@ readfile (
   wasempty = (curbuf->b_ml.ml_flags & ML_EMPTY);
 
   if (!recoverymode && !filtering && !(flags & READ_DUMMY)) {
-    /*
-     * Show the user that we are busy reading the input.  Sometimes this
-     * may take a while.  When reading from stdin another program may
-     * still be running, don't move the cursor to the last line, unless
-     * always using the GUI.
-     */
-    if (read_stdin) {
-      mch_msg(_("Nvim: Reading from stdin...\n"));
-    } else if (!read_buffer)
+    if (!read_stdin && !read_buffer) {
       filemess(curbuf, sfname, (char_u *)"", 0);
+    }
   }
 
   msg_scroll = FALSE;                   /* overwrite the file message */


### PR DESCRIPTION
How about finally (after all that years, tons of emails in the mailing lists and messages on the IRC) give users possibility to suppress that noisy message, if they know what and why they are doing (i.e. set env variable)

P.S. Variable is named `VIM_*` to interoperability with original `vim` (PR#1564), and do not force users, who use both of them to set tons of identical variables for the same thing.
// Although, it is discussable...