### PR TITLE
test: fix the unit test build on macOS Sierra

### DIFF
--- a/test/includes/CMakeLists.txt
+++ b/test/includes/CMakeLists.txt
@@ -1,5 +1,12 @@
 file(GLOB_RECURSE PRE_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} pre/*.h)
 
+# We need to add the SDK directories on OS X, and perhaps other operating
+# systems.
+set(gen_cflags)
+foreach(gen_include ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
+  list(APPEND gen_cflags ${CMAKE_INCLUDE_FLAG_C}${gen_include})
+endforeach()
+
 foreach(hfile ${PRE_HEADERS})
   string(REGEX REPLACE ^pre/ post/ post_hfile ${hfile})
   get_filename_component(hdir ${CMAKE_CURRENT_BINARY_DIR}/${post_hfile} PATH)
@@ -8,6 +15,7 @@ foreach(hfile ${PRE_HEADERS})
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${post_hfile}
     COMMAND ${CMAKE_C_COMPILER} -std=c99 -E -P
       ${CMAKE_CURRENT_SOURCE_DIR}/${hfile}
+      ${gen_cflags}
       -I${LIBUV_INCLUDE_DIRS}
       -o ${CMAKE_CURRENT_BINARY_DIR}/${post_hfile})
   list(APPEND POST_HEADERS ${post_hfile})


### PR DESCRIPTION
We need to add the SDK includes to the preprocessing step, otherwise it
will fail to resolve the system includes such as sys/stat.h and fcntl.h.