### PR TITLE
[RFC] vim-patch: 7.4.2255,7.42256

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4860,7 +4860,10 @@ static int get_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 
   }
   *name = NUL;
-  *arg = p + 1;
+  if (*p != NUL) {  // just in case
+    p++;
+  }
+  *arg = p;
 
   return OK;
 }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -185,7 +185,7 @@ static int included_patches[] = {
   // 2259,
   // 2258 NA
   // 2257 NA
-  // 2256,
+  2256,
   2255,
   // 2254 NA
   // 2253 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -186,7 +186,7 @@ static int included_patches[] = {
   // 2258 NA
   // 2257 NA
   // 2256,
-  // 2255,
+  2255,
   // 2254 NA
   // 2253 NA
   // 2252 NA


### PR DESCRIPTION
#### vim-patch:7.4.2255
Problem:    The script that checks translations can't handle plurals.
Solution:   Check for plural msgid and msgstr entries.  Leave the cursor on
                the first error.
https://github.com/vim/vim/commit/ec42059b78c1932a44f2bf36ac982109884dc7c7

#### vim-patch:7.4.2256
Problem:    Coverity complains about null pointer check.
Solution:   Remove wrong and superfluous error check.
    
https://github.com/vim/vim/commit/db249f26edf7a5f88d1f4468d08ec5b84f5ab7ad

This's a converity issue, so just update the version.c and mark it as applied.