### PR TITLE
[WIP/RFC] Windows TUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,11 +324,7 @@ if(MSGPACK_HAS_FLOAT32)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNVIM_MSGPACK_HAS_FLOAT32")
 endif()
 
-if(UNIX)
-  option(FEAT_TUI "Enable the Terminal UI" ON)
-else()
-  option(FEAT_TUI "Enable the Terminal UI" OFF)
-endif()
+option(FEAT_TUI "Enable the Terminal UI" ON)
 
 if(FEAT_TUI)
   find_package(Unibilium REQUIRED)

--- a/ci/build.bat
+++ b/ci/build.bat
@@ -17,7 +17,7 @@ set PATH=C:\Program Files (x86)\CMake\bin\cpack.exe;%PATH%
 
 :: Build third-party dependencies
 C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm -Su" || goto :error
-C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm --needed -S mingw-w64-%ARCH%-cmake mingw-w64-%ARCH%-perl mingw-w64-%ARCH%-diffutils gperf" || goto :error
+C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm --needed -S mingw-w64-%ARCH%-cmake mingw-w64-%ARCH%-perl mingw-w64-%ARCH%-diffutils mingw-w64-%ARCH%-unibilium gperf" || goto :error
 
 :: Setup python (use AppVeyor system python)
 C:\Python27\python.exe -m pip install neovim || goto :error

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -47,7 +47,13 @@ void term_input_init(TermInput *input, Loop *loop)
   int curflags = termkey_get_canonflags(input->tk);
   termkey_set_canonflags(input->tk, curflags | TERMKEY_CANON_DELBS);
   // setup input handle
+#ifdef WIN32
+  uv_tty_init(loop, &input->tty_in, 0, 1);
+  uv_tty_set_mode(&input->tty_in, UV_TTY_MODE_RAW);
+  rstream_init_stream(&input->read_stream, &input->tty_in, 0xfff);
+#else
   rstream_init_fd(loop, &input->read_stream, input->in_fd, 0xfff);
+#endif
   // initialize a timer handle for handling ESC with libtermkey
   time_watcher_init(loop, &input->timer_handle, input);
 }

--- a/src/nvim/tui/input.h
+++ b/src/nvim/tui/input.h
@@ -17,6 +17,9 @@ typedef struct term_input {
 #endif
   TimeWatcher timer_handle;
   Loop *loop;
+#ifdef WIN32
+  uv_tty_t tty_in;
+#endif
   Stream read_stream;
   RBuffer *key_buffer;
   uv_mutex_t key_buffer_mutex;

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -105,8 +105,13 @@ set(LUAROCKS_SHA256 cae709111c5701235770047dfd7169f66b82ae1c7b9b79207f9df0afb722
 set(UNIBILIUM_URL https://github.com/mauke/unibilium/archive/v1.2.0.tar.gz)
 set(UNIBILIUM_SHA256 623af1099515e673abfd3cae5f2fa808a09ca55dda1c65a7b5c9424eb304ead8)
 
-set(LIBTERMKEY_URL http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.19.tar.gz)
-set(LIBTERMKEY_SHA256 c505aa4cb48c8fa59c526265576b97a19e6ebe7b7da20f4ecaae898b727b48b7)
+if(WIN32)
+  set(LIBTERMKEY_URL https://github.com/equalsraf/libtermkey/archive/tb-windows.zip)
+  set(LIBTERMKEY_SHA256 c81e33e38662b151a49847ff4feef4f8c4b2a66f3e159a28b575cbc9bcd8ffea)
+else()
+  set(LIBTERMKEY_URL http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.19.tar.gz)
+  set(LIBTERMKEY_SHA256 c505aa4cb48c8fa59c526265576b97a19e6ebe7b7da20f4ecaae898b727b48b7)
+endif()
 
 set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/a9c7c6fd20fa35e0ad3e0e98901ca12dfca9c25c.tar.gz)
 set(LIBVTERM_SHA256 1a4272be91d9614dc183a503786df83b6584e4afaab7feaaa5409f841afbd796)

--- a/third-party/cmake/BuildLibtermkey.cmake
+++ b/third-party/cmake/BuildLibtermkey.cmake
@@ -1,29 +1,53 @@
-if(WIN32)
-  message(STATUS "Building libtermkey in Windows is not supported (skipping)")
-  return()
-endif()
 find_package(PkgConfig REQUIRED)
 
-ExternalProject_Add(libtermkey
-  PREFIX ${DEPS_BUILD_DIR}
-  URL ${LIBTERMKEY_URL}
-  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/libtermkey
-  DOWNLOAD_COMMAND ${CMAKE_COMMAND}
-    -DPREFIX=${DEPS_BUILD_DIR}
-    -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/libtermkey
-    -DURL=${LIBTERMKEY_URL}
-    -DEXPECTED_SHA256=${LIBTERMKEY_SHA256}
-    -DTARGET=libtermkey
-    -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
-    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
-  CONFIGURE_COMMAND ""
-  BUILD_IN_SOURCE 1
-  BUILD_COMMAND ""
-  INSTALL_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
-                              PREFIX=${DEPS_INSTALL_DIR}
-                              PKG_CONFIG_PATH=${DEPS_LIB_DIR}/pkgconfig
-                              CFLAGS=-fPIC
-                              install)
+if(WIN32)
+  ExternalProject_Add(libtermkey
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${LIBTERMKEY_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/libtermkey
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+  	-DPREFIX=${DEPS_BUILD_DIR}
+  	-DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/libtermkey
+  	-DURL=${LIBTERMKEY_URL}
+  	-DEXPECTED_SHA256=${LIBTERMKEY_SHA256}
+  	-DTARGET=libtermkey
+  	-DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
+  	-P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} ${DEPS_BUILD_DIR}/src/libtermkey
+      -DCMAKE_INSTALL_PREFIX=${DEPS_INSTALL_DIR}
+      # Pass toolchain
+      -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN}
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+      # Hack to avoid -rdynamic in Mingw
+      -DCMAKE_SHARED_LIBRARY_LINK_C_FLAGS=""
+      -DCMAKE_GENERATOR=${CMAKE_GENERATOR}
+    BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE}
+    INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install --config ${CMAKE_BUILD_TYPE})
+else()
+  ExternalProject_Add(libtermkey
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${LIBTERMKEY_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/libtermkey
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+  	-DPREFIX=${DEPS_BUILD_DIR}
+  	-DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/libtermkey
+  	-DURL=${LIBTERMKEY_URL}
+  	-DEXPECTED_SHA256=${LIBTERMKEY_SHA256}
+  	-DTARGET=libtermkey
+  	-DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
+  	-P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    CONFIGURE_COMMAND ""
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
+                                PREFIX=${DEPS_INSTALL_DIR}
+                                PKG_CONFIG_PATH=${DEPS_LIB_DIR}/pkgconfig
+                                CFLAGS=-fPIC
+                                install)
+endif()
 
 list(APPEND THIRD_PARTY_DEPS libtermkey)
-add_dependencies(libtermkey unibilium)
+if(NOT WIN32)
+  # There is no unibilium build recipe for Windows yet
+  add_dependencies(libtermkey unibilium)
+endif()


### PR DESCRIPTION
Enable the TUI for Windows. libuv's tty is used to get the console input, which is then passed to libtermkey. I've included a commit to enable the TUI, but we can also delay that for another PR

Main issues:

- [ ] #6659 libtermkey is being downloaded from my repo, for the windows fixes
- [x] the cursor does not seem right, it always looks the same - I think libuv does not support cursor shapes, so we would need to address it upstream
- [ ] #6660 :stop is broken, there is no implementation for suspend
- [ ] #6661 closing the window in the close button displays a message about SIGHUP, takes a while to shut down too - is there a reason for SIGHUP shutdown to take a while?
- [x] Loading a colorscheme from init.vim does not produce the same outcome as doing later on - see https://github.com/neovim/neovim/pull/6315#issuecomment-287657577
- [ ] Some text colors/attributes do not look right, it does look consistent so maybe were are sending a sequence we should not, because the terminal does not support it
- [ ] The Home/End keys do not work
- [ ] Keys F1, F2, F3, F4, F5 input A,B,C,D respectively but F6-F12 work fine. pressing `<C-V> + F1` also prints A
- [ ] terminal content scrolling seems broken in some cases. e.g. `nvim -u NONE` works but with color=wombat256mod the terminal keeps pushing data up

@justinmk I suspect it will be hard for me to follow up with this for the next couple weeks. If anyone wants to take over this, they have my blessings. Whoever can provide some testing time it would be much appreciated too.

### References

- [libuv's win/tty.c](https://github.com/libuv/libuv/blob/v1.x/src/win/tty.c)