### PR TITLE
[RFC] vim-patch:8.0.0116,8.0.0190,8.0.0195,8.0.0190,8.0.0223,8.0.0393

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -72,20 +72,18 @@ typedef struct {
   regmatch_T regmatch;          /* regexp program, may be NULL */
 } pat_T;
 
-/*
- * The matching tags are first stored in one of the hash tables.  In
- * which one depends on the priority of the match.
- * ht_match[] is used to find duplicates, ga_match[] to keep them in sequence.
- * At the end, the matches from ga_match[] are concatenated, to make a list
- * sorted on priority.
- */
-#define MT_ST_CUR       0               /* static match in current file */
-#define MT_GL_CUR       1               /* global match in current file */
-#define MT_GL_OTH       2               /* global match in other file */
-#define MT_ST_OTH       3               /* static match in other file */
-#define MT_IC_OFF       4               /* add for icase match */
-#define MT_RE_OFF       8               /* add for regexp match */
-#define MT_MASK         7               /* mask for printing priority */
+// The matching tags are first stored in one of the hash tables.  In
+// which one depends on the priority of the match.
+// ht_match[] is used to find duplicates, ga_match[] to keep them in sequence.
+// At the end, the matches from ga_match[] are concatenated, to make a list
+// sorted on priority.
+#define MT_ST_CUR       0               // static match in current file
+#define MT_GL_CUR       1               // global match in current file
+#define MT_GL_OTH       2               // global match in other file
+#define MT_ST_OTH       3               // static match in other file
+#define MT_IC_OFF       4               // add for icase match
+#define MT_RE_OFF       8               // add for regexp match
+#define MT_MASK         7               // mask for printing priority
 #define MT_COUNT        16
 
 static char     *mt_names[MT_COUNT/2] =
@@ -1124,14 +1122,14 @@ find_tags (
   garray_T ga_match[MT_COUNT];   // stores matches in sequence
   hashtab_T ht_match[MT_COUNT];  // stores matches by key
   hash_T hash = 0;
-  int match_count = 0;                          /* number of matches found */
+  int match_count = 0;                          // number of matches found
   char_u      **matches;
   int mtt;
   int help_save;
   int help_pri = 0;
-  char_u      *help_lang_find = NULL;           /* lang to be found */
-  char_u help_lang[3];                          /* lang of current tags file */
-  char_u      *saved_pat = NULL;                /* copy of pat[] */
+  char_u      *help_lang_find = NULL;           // lang to be found
+  char_u help_lang[3];                          // lang of current tags file
+  char_u      *saved_pat = NULL;                // copy of pat[]
   bool is_txt = false;
 
   pat_T orgpat;                         /* holds unconverted pattern info */
@@ -1182,7 +1180,7 @@ find_tags (
    */
   lbuf = xmalloc(lbuf_size);
   tag_fname = xmalloc(MAXPATHL + 1);
-  for (mtt = 0; mtt < MT_COUNT; ++mtt) {
+  for (mtt = 0; mtt < MT_COUNT; mtt++) {
     ga_init(&ga_match[mtt], sizeof(char_u *), 100);
     hash_init(&ht_match[mtt]);
   }
@@ -1192,9 +1190,9 @@ find_tags (
   /*
    * Initialize a few variables
    */
-  if (help_only)                                /* want tags from help file */
-    curbuf->b_help = true;                      /* will be restored later */
-  else if (use_cscope) {
+  if (help_only) {                              // want tags from help file
+    curbuf->b_help = true;                      // will be restored later
+  } else if (use_cscope) {
     // Make sure we don't mix help and cscope, confuses Coverity.
     help_only = false;
     curbuf->b_help = false;
@@ -1264,13 +1262,14 @@ find_tags (
           if (is_txt) {
             STRCPY(help_lang, "en");
           } else {
-            /* Prefer help tags according to 'helplang'.  Put the
-             * two-letter language name in help_lang[]. */
+            // Prefer help tags according to 'helplang'.  Put the
+            // two-letter language name in help_lang[].
             i = (int)STRLEN(tag_fname);
-            if (i > 3 && tag_fname[i - 3] == '-')
+            if (i > 3 && tag_fname[i - 3] == '-') {
               STRCPY(help_lang, tag_fname + i - 2);
-            else
+            } else {
               STRCPY(help_lang, "en");
+            }
           }
 
           /* When searching for a specific language skip tags files
@@ -1755,9 +1754,7 @@ parse_line:
           match_re = TRUE;
         }
 
-        /*
-         * If a match is found, add it to ht_match[] and ga_match[].
-         */
+        // If a match is found, add it to ht_match[] and ga_match[].
         if (match) {
           int len = 0;
 
@@ -1795,11 +1792,9 @@ parse_line:
               mtt += MT_RE_OFF;
           }
 
-          /*
-           * Add the found match in ht_match[mtt] and ga_match[mtt].
-           * Store the info we need later, which depends on the kind of
-           * tags we are dealing with.
-           */
+          // Add the found match in ht_match[mtt] and ga_match[mtt].
+          // Store the info we need later, which depends on the kind of
+          // tags we are dealing with.
           if (help_only) {
 # define ML_EXTRA 3
             // Append the help-heuristic number after the tagname, for
@@ -1814,57 +1809,60 @@ parse_line:
             STRCPY(p, tagp.tagname);
             p[len] = '@';
             STRCPY(p + len + 1, help_lang);
-            sprintf((char *)p + len + 1 + ML_EXTRA, "%06d",
-                    help_heuristic(tagp.tagname,
-                                   match_re ? matchoff : 0, !match_no_ic)
-                    + help_pri);
+            snprintf((char *)p + len + 1 + ML_EXTRA, 10, "%06d",
+                     help_heuristic(tagp.tagname,
+                                    match_re ? matchoff : 0, !match_no_ic)
+                     + help_pri);
 
             *tagp.tagname_end = TAB;
           } else if (name_only)   {
             if (get_it_again) {
               char_u *temp_end = tagp.command;
 
-              if (*temp_end == '/')
+              if (*temp_end == '/') {
                 while (*temp_end && *temp_end != '\r'
                        && *temp_end != '\n'
-                       && *temp_end != '$')
+                       && *temp_end != '$') {
                   temp_end++;
+                }
+              }
 
               if (tagp.command + 2 < temp_end) {
                 len = (int)(temp_end - tagp.command - 2);
                 mfp = xmalloc(len + 2);
                 STRLCPY(mfp, tagp.command + 2, len + 1);
-              } else
+              } else {
                 mfp = NULL;
-              get_it_again = FALSE;
+              }
+              get_it_again = false;
             } else {
               len = (int)(tagp.tagname_end - tagp.tagname);
               mfp = xmalloc(sizeof(char_u) + len + 1);
               STRLCPY(mfp, tagp.tagname, len + 1);
 
-              /* if wanted, re-read line to get long form too */
-              if (State & INSERT)
+              // if wanted, re-read line to get long form too
+              if (State & INSERT) {
                 get_it_again = p_sft;
+              }
             }
           } else {
 #define TAG_SEP 0x01
             size_t tag_fname_len = STRLEN(tag_fname);
-            /* Save the tag in a buffer.
-             * Use 0x01 to separate fields (Can't use NUL, because the
-             * hash key is terminated by NUL).
-             * Emacs tag: <mtt><tag_fname><NUL><ebuf><NUL><lbuf>
-             * other tag: <mtt><tag_fname><NUL><NUL><lbuf>
-             * without Emacs tags: <mtt><tag_fname><NUL><lbuf>
-             * Here <mtt> is the "mtt" value plus 1 to avoid NUL.
-             */
+            // Save the tag in a buffer.
+            // Use 0x01 to separate fields (Can't use NUL, because the
+            // hash key is terminated by NUL).
+            // Emacs tag: <mtt><tag_fname><NUL><ebuf><NUL><lbuf>
+            // other tag: <mtt><tag_fname><NUL><NUL><lbuf>
+            // without Emacs tags: <mtt><tag_fname><NUL><lbuf>
+            // Here <mtt> is the "mtt" value plus 1 to avoid NUL.
             len = (int)tag_fname_len + (int)STRLEN(lbuf) + 3;
             mfp = xmalloc(sizeof(char_u) + len + 1);
             p = mfp;
             p[0] = mtt + 1;
             STRCPY(p + 1, tag_fname);
 #ifdef BACKSLASH_IN_FILENAME
-            /* Ignore differences in slashes, avoid adding
-             * both path/file and path\file. */
+            // Ignore differences in slashes, avoid adding
+            // both path/file and path\file.
             slash_adjust(p + 1);
 #endif
             p[tag_fname_len + 1] = TAG_SEP;
@@ -1881,10 +1879,11 @@ parse_line:
             // the part matters for comparing, more bytes may follow
             // after it.  E.g. help tags store the priority after the
             // NUL.
-            if (use_cscope)
+            if (use_cscope) {
               hash++;
-            else
+            } else {
               hash = hash_hash(mfp);
+            }
             hi = hash_lookup(&ht_match[mtt], (const char *)mfp,
                              STRLEN(mfp), hash);
             if (HASHITEM_EMPTY(hi)) {
@@ -1892,10 +1891,11 @@ parse_line:
               ga_grow(&ga_match[mtt], 1);
               ((char_u **)(ga_match[mtt].ga_data))
                 [ga_match[mtt].ga_len++] = mfp;
-              ++match_count;
-            } else
+              match_count++;
+            } else {
               // duplicate tag, drop it
               xfree(mfp);
+            }
           }
         }
         if (use_cscope && eof)
@@ -1969,7 +1969,7 @@ findtag_end:
   else
     matches = NULL;
   match_count = 0;
-  for (mtt = 0; mtt < MT_COUNT; ++mtt) {
+  for (mtt = 0; mtt < MT_COUNT; mtt++) {
     for (i = 0; i < ga_match[mtt].ga_len; i++) {
       mfp = ((char_u **)(ga_match[mtt].ga_data))[i];
       if (matches == NULL) {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1057,6 +1057,7 @@ static void prepare_pats(pat_T *pats, int has_re)
  * TAG_REGEXP	  use "pat" as a regexp
  * TAG_NOIC	  don't always ignore case
  * TAG_KEEP_LANG  keep language
+ * TAG_CSCOPE	  use cscope results for tags
  */
 int 
 find_tags (
@@ -1189,6 +1190,11 @@ find_tags (
    */
   if (help_only)                                /* want tags from help file */
     curbuf->b_help = true;                      /* will be restored later */
+  else if (use_cscope) {
+    // Make sure we don't mix help and cscope, confuses Coverity.
+    help_only = false;
+    curbuf->b_help = false;
+  }
 
   orgpat.len = (int)STRLEN(pat);
   if (curbuf->b_help) {

--- a/src/nvim/testdir/test_help_tagjump.vim
+++ b/src/nvim/testdir/test_help_tagjump.vim
@@ -162,4 +162,36 @@ func Test_help_complete()
   endtry
 endfunc
 
+func Test_help_respect_current_file_lang()
+  try
+    let list = []
+    call s:doc_config_setup()
+
+    if has('multi_lang')
+      function s:check_help_file_ext(help_keyword, ext)
+        exec 'help ' . a:help_keyword
+        call assert_equal(a:ext, expand('%:e'))
+        call feedkeys("\<C-]>", 'tx')
+        call assert_equal(a:ext, expand('%:e'))
+        pop
+        helpclose
+      endfunc
+
+      set rtp+=Xdir1/doc-ab
+      set rtp+=Xdir1/doc-ja
+
+      set helplang=ab
+      call s:check_help_file_ext('test-char', 'abx')
+      call s:check_help_file_ext('test-char@ja', 'jax')
+      set helplang=ab,ja
+      call s:check_help_file_ext('test-char@ja', 'jax')
+      call s:check_help_file_ext('test-char@en', 'txt')
+    endif
+  catch
+    call assert_exception('X')
+  finally
+    call s:doc_config_teardown()
+  endtry
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -35,10 +35,34 @@ func Test_static_tagjump()
   tag one
   call assert_equal(2, line('.'))
 
+  bwipe!
   set tags&
   call delete('Xtags')
   call delete('Xfile1')
+endfunc
+
+func Test_duplicate_tagjump()
+  set tags=Xtags
+  call writefile(["!_TAG_FILE_ENCODING\tutf-8\t//",
+        \ "thesame\tXfile1\t1;\"\td\tfile:",
+        \ "thesame\tXfile1\t2;\"\td\tfile:",
+        \ "thesame\tXfile1\t3;\"\td\tfile:",
+        \ ],
+        \ 'Xtags')
+  new Xfile1
+  call setline(1, ['thesame one', 'thesame two', 'thesame three'])
+  write
+  tag thesame
+  call assert_equal(1, line('.'))
+  tnext
+  call assert_equal(2, line('.'))
+  tnext
+  call assert_equal(3, line('.'))
+
   bwipe!
+  set tags&
+  call delete('Xtags')
+  call delete('Xfile1')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -23,4 +23,22 @@ func Test_cancel_ptjump()
   quit
 endfunc
 
+func Test_static_tagjump()
+  set tags=Xtags
+  call writefile(["!_TAG_FILE_ENCODING\tutf-8\t//",
+        \ "one\tXfile1\t/^one/;\"\tf\tfile:\tsignature:(void)",
+        \ "word\tXfile2\tcmd2"],
+        \ 'Xtags')
+  new Xfile1
+  call setline(1, ['empty', 'one()', 'empty'])
+  write
+  tag one
+  call assert_equal(2, line('.'))
+
+  set tags&
+  call delete('Xtags')
+  call delete('Xfile1')
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.0.0116

Problem:    When reading English help and using CTRl-] the language from
            'helplang' is used.
Solution:   Make help tag jumps keep the language. (Tatsuki, test by Hirohito
            Higashi, closes vim/vim#1249)

https://github.com/vim/vim/commit/6dbf66aa3e2197ce41f2b1cc7602bb9c15840548


#### vim-patch:8.0.0190

Problem:    Detecting duplicate tags uses a slow linear search.
Solution:   Use a much faster hash table solution. (James McCoy, closes vim/vim#1046)
            But don't add hi_keylen, it makes hash tables 50% bigger.

https://github.com/vim/vim/commit/810f9c361c83afb36b9f1cdadca2b93f1201d039


#### vim-patch:8.0.0195

Problem:    Jumping to a tag that is a static item in the current file fails.
            (Kazunobu Kuriyama)
Solution:   Make sure the first byte of the tag key is not NUL. (Suggested by
            James McCoy, closes vim/vim#1387)

https://github.com/vim/vim/commit/a9d23c20879d0dcb289a4db54b3c7df060f87c3c


#### vim-patch:8.0.0223

Problem:    Coverity gets confused by the flags passed to find_tags() and
            warnts for an uninitialized variable.
Solution:   Disallow using cscope and help tags at the same time.

https://github.com/vim/vim/commit/fffbf308dd98d1129ba4914d921ab47dc6a6c9b1


#### vim-patch:8.0.0393

Problem:    When the same tag appears more than once, the order is
            unpredictable. (Charles Campbell)
Solution:   Besides using a dict for finding duplicates, use a grow array for
            keeping the tags in sequence.

https://github.com/vim/vim/commit/98e83b295628bc29bc67bcc1adb8ae75d01b8e07