### PR TITLE
[RDY] menu_get() / export menus

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5506,6 +5506,46 @@ max({expr})	Return the maximum value of all items in {expr}.
 		items in {expr} cannot be used as a Number this results in
                 an error.  An empty |List| or |Dictionary| results in zero.
 
+menu_get({path}, {modes})				*menu_get()*
+		Returns a |Dictionary| with all the submenu of {path} (set to 
+		an empty string to match all menus). Only the commands matching {modes} are 
+		returned ('a' for all, 'i' for insert see |creating-menus|).
+
+    For instance, executing:
+>
+			nnoremenu &Test.Test inormal
+			inoremenu Test.Test insert
+			vnoremenu Test.Test x
+			echo menu_get("")
+<
+should produce an output with a similar structure:
+>
+	[ {
+		"hidden": 0,
+		"name": "Test",
+		"priority": 500,
+		"shortcut": 84,
+		"submenus": [ {
+			"hidden": 0,
+			"mappings": {
+				i": {
+					"enabled": 1,
+					"noremap": 1,
+					"rhs": "insert",
+					"sid": 1,
+					"silent": 0
+				},
+				n": { ... },
+				s": { ... },
+				v": { ... }
+			},
+			"name": "Test",
+			"priority": 500,
+			"shortcut": 0
+		} ]
+	} ]
+<
+
 							*min()*
 min({expr})	Return the minimum value of all items in {expr}.
 		{expr} can be a list or a dictionary.  For a dictionary,

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -47,6 +47,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
+#include "nvim/menu.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"
 #include "nvim/keymap.h"
@@ -8171,6 +8172,19 @@ static void f_expand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       rettv->vval.v_string = NULL;
     }
   }
+}
+
+
+/// "menu_get(path [, modes])" function
+static void f_menu_get(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  tv_list_alloc_ret(rettv);
+  int modes = MENU_ALL_MODES;
+  if (argvars[1].v_type == VAR_STRING) {
+    const char_u *const strmodes = (char_u *)tv_get_string(&argvars[1]);
+    modes = get_menu_cmd_modes(strmodes, false, NULL, NULL);
+  }
+  menu_get((char_u *)tv_get_string(&argvars[0]), modes, rettv->vval.v_list);
 }
 
 /*

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2,10 +2,10 @@
 --
 -- Keys:
 --
--- args  Number of arguments, list with maximum and minimum number of arguments 
---       or list with a minimum number of arguments only. Defaults to zero 
+-- args  Number of arguments, list with maximum and minimum number of arguments
+--       or list with a minimum number of arguments only. Defaults to zero
 --       arguments.
--- func  Name of the C function which implements the VimL function. Defaults to 
+-- func  Name of the C function which implements the VimL function. Defaults to
 --       `f_{funcname}`.
 
 local varargs = function(nr)
@@ -208,6 +208,7 @@ return {
     matchstr={args={2, 4}},
     matchstrpos={args={2,4}},
     max={args=1},
+    menu_get={args={1, 2}},
     min={args=1},
     mkdir={args={1, 3}},
     mode={args={0, 1}},

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1,4 +1,4 @@
-bit = require 'bit'
+local bit = require 'bit'
 
 -- Description of the values below is contained in ex_cmds_defs.h file.
 local RANGE      =    0x001

--- a/src/nvim/getchar.h
+++ b/src/nvim/getchar.h
@@ -5,12 +5,15 @@
 #include "nvim/buffer_defs.h"
 #include "nvim/ex_cmds_defs.h"
 
-/* Values for "noremap" argument of ins_typebuf().  Also used for
- * map->m_noremap and menu->noremap[]. */
-#define REMAP_YES       0       /* allow remapping */
-#define REMAP_NONE      -1      /* no remapping */
-#define REMAP_SCRIPT    -2      /* remap script-local mappings only */
-#define REMAP_SKIP      -3      /* no remapping for first char */
+/// Values for "noremap" argument of ins_typebuf().  Also used for
+/// map->m_noremap and menu->noremap[].
+/// @addtogroup REMAP_VALUES
+/// @{
+#define REMAP_YES       0       ///< allow remapping
+#define REMAP_NONE      -1      ///< no remapping
+#define REMAP_SCRIPT    -2      ///< remap script-local mappings only
+#define REMAP_SKIP      -3      ///< no remapping for first char
+/// @}
 
 #define KEYLEN_PART_KEY -1      /* keylen value for incomplete key-code */
 #define KEYLEN_PART_MAP -2      /* keylen value for incomplete mapping */

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -932,12 +932,13 @@ int utf_char2len(int c)
   return 6;
 }
 
-/*
- * Convert Unicode character "c" to UTF-8 string in "buf[]".
- * Returns the number of bytes.
- * This does not include composing characters.
- */
-int utf_char2bytes(int c, char_u *buf)
+/// Convert Unicode character to UTF-8 string
+///
+/// @param c character to convert to \p buf
+/// @param[out] buf UTF-8 string generated from \p c, does not add \0
+/// @return the number of bytes (between 1 and 6)
+/// @note This does not include composing characters.
+int utf_char2bytes(int c, char_u *const buf)
 {
   if (c < 0x80) {               /* 7 bits */
     buf[0] = c;

--- a/src/nvim/menu.h
+++ b/src/nvim/menu.h
@@ -6,7 +6,9 @@
 #include "nvim/types.h" // for char_u and expand_T
 #include "nvim/ex_cmds_defs.h" // for exarg_T
 
-/* Indices into vimmenu_T->strings[] and vimmenu_T->noremap[] for each mode */
+/// Indices into vimmenu_T->strings[] and vimmenu_T->noremap[] for each mode
+/// \addtogroup MENU_INDEX
+/// @{
 #define MENU_INDEX_INVALID      -1
 #define MENU_INDEX_NORMAL       0
 #define MENU_INDEX_VISUAL       1
@@ -16,8 +18,12 @@
 #define MENU_INDEX_CMDLINE      5
 #define MENU_INDEX_TIP          6
 #define MENU_MODES              7
+/// @}
+/// note MENU_INDEX_TIP is not a 'real' mode
 
-/* Menu modes */
+/// Menu modes
+/// \addtogroup MENU_MODES
+/// @{
 #define MENU_NORMAL_MODE        (1 << MENU_INDEX_NORMAL)
 #define MENU_VISUAL_MODE        (1 << MENU_INDEX_VISUAL)
 #define MENU_SELECT_MODE        (1 << MENU_INDEX_SELECT)
@@ -26,31 +32,30 @@
 #define MENU_CMDLINE_MODE       (1 << MENU_INDEX_CMDLINE)
 #define MENU_TIP_MODE           (1 << MENU_INDEX_TIP)
 #define MENU_ALL_MODES          ((1 << MENU_INDEX_TIP) - 1)
-/*note MENU_INDEX_TIP is not a 'real' mode*/
+/// @}
 
-/* Start a menu name with this to not include it on the main menu bar */
+/// Start a menu name with this to not include it on the main menu bar
 #define MNU_HIDDEN_CHAR         ']'
 
 typedef struct VimMenu vimmenu_T;
 
 struct VimMenu {
-  int modes;                        /* Which modes is this menu visible for? */
-  int enabled;                      /* for which modes the menu is enabled */
-  char_u      *name;                /* Name of menu, possibly translated */
-  char_u      *dname;               /* Displayed Name ("name" without '&') */
-  char_u      *en_name;             /* "name" untranslated, NULL when "name"
-                                     * was not translated */
-  char_u      *en_dname;            /* "dname" untranslated, NULL when "dname"
-                                     * was not translated */
-  int mnemonic;                     /* mnemonic key (after '&') */
-  char_u      *actext;              /* accelerator text (after TAB) */
-  long priority;                     /* Menu order priority */
-  char_u      *strings[MENU_MODES];   /* Mapped string for each mode */
-  int noremap[MENU_MODES];           /* A REMAP_ flag for each mode */
-  bool silent[MENU_MODES];          /* A silent flag for each mode */
-  vimmenu_T   *children;            /* Children of sub-menu */
-  vimmenu_T   *parent;              /* Parent of menu */
-  vimmenu_T   *next;                /* Next item in menu */
+  int modes;                         ///< Which modes is this menu visible for
+  int enabled;                       ///< for which modes the menu is enabled
+  char_u      *name;                 ///< Name of menu, possibly translated
+  char_u      *dname;                ///< Displayed Name ("name" without '&')
+  char_u      *en_name;              ///< "name" untranslated, NULL when
+                                     ///< was not translated
+  char_u      *en_dname;             ///< NULL when "dname" untranslated
+  int mnemonic;                      ///< mnemonic key (after '&')
+  char_u      *actext;               ///< accelerator text (after TAB)
+  long priority;                     ///< Menu order priority
+  char_u      *strings[MENU_MODES];  ///< Mapped string for each mode
+  int noremap[MENU_MODES];           ///< A \ref REMAP_VALUES flag for each mode
+  bool silent[MENU_MODES];           ///< A silent flag for each mode
+  vimmenu_T   *children;             ///< Children of sub-menu
+  vimmenu_T   *parent;               ///< Parent of menu
+  vimmenu_T   *next;                 ///< Next item in menu
 };
 
 

--- a/test/functional/ex_cmds/menu_spec.lua
+++ b/test/functional/ex_cmds/menu_spec.lua
@@ -2,6 +2,8 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear, command, nvim = helpers.clear, helpers.command, helpers.nvim
 local expect, feed = helpers.expect, helpers.feed
 local eq, eval = helpers.eq, helpers.eval
+local funcs = helpers.funcs
+
 
 describe(':emenu', function()
 
@@ -55,4 +57,329 @@ describe(':emenu', function()
       -- Assert that Edit.Paste pasted @" into the commandline.
       eq('thiscmdmode', eval('getcmdline()'))
   end)
+end)
+
+describe('menu_get', function()
+
+  before_each(function()
+    clear()
+    command('nnoremenu &Test.Test inormal<ESC>')
+    command('inoremenu Test.Test insert')
+    command('vnoremenu Test.Test x')
+    command('cnoremenu Test.Test cmdmode')
+    command('menu Test.Nested.test level1')
+    command('menu Test.Nested.Nested2 level2')
+
+    command('nnoremenu <script> Export.Script p')
+    command('tmenu Export.Script This is the tooltip')
+    command('menu ]Export.hidden thisoneshouldbehidden')
+
+    command('nnoremenu Edit.Paste p')
+    command('cnoremenu Edit.Paste <C-R>"')
+  end)
+
+  it('no path, all modes', function()
+    local m = funcs.menu_get("","a");
+    -- You can use the following to print the expected table
+    -- and regenerate the tests:
+    -- local pretty = require('pl.pretty');
+    -- print(pretty.dump(m))
+    local expected = {
+      {
+        shortcut = "T",
+        hidden = 0,
+        submenus = {
+          {
+            mappings = {
+              i = {
+                sid = 1,
+                noremap = 1,
+                enabled = 1,
+                rhs = "insert",
+                silent = 0
+              },
+              s = {
+                sid = 1,
+                noremap = 1,
+                enabled = 1,
+                rhs = "x",
+                silent = 0
+              },
+              n = {
+                sid = 1,
+                noremap = 1,
+                enabled = 1,
+                rhs = "inormal\27",
+                silent = 0
+              },
+              v = {
+                sid = 1,
+                noremap = 1,
+                enabled = 1,
+                rhs = "x",
+                silent = 0
+              },
+              c = {
+                sid = 1,
+                noremap = 1,
+                enabled = 1,
+                rhs = "cmdmode",
+                silent = 0
+              }
+            },
+            priority = 500,
+            name = "Test",
+            hidden = 0
+          },
+          {
+            priority = 500,
+            name = "Nested",
+            submenus = {
+              {
+                mappings = {
+                  o = {
+                    sid = 0,
+                    noremap = 0,
+                    enabled = 1,
+                    rhs = "level1",
+                    silent = 0
+                  },
+                  v = {
+                    sid = 0,
+                    noremap = 0,
+                    enabled = 1,
+                    rhs = "level1",
+                    silent = 0
+                  },
+                  s = {
+                    sid = 0,
+                    noremap = 0,
+                    enabled = 1,
+                    rhs = "level1",
+                    silent = 0
+                  },
+                  n = {
+                    sid = 0,
+                    noremap = 0,
+                    enabled = 1,
+                    rhs = "level1",
+                    silent = 0
+                  }
+                },
+                priority = 500,
+                name = "test",
+                hidden = 0
+              },
+              {
+                mappings = {
+                  o = {
+                    sid = 0,
+                    noremap = 0,
+                    enabled = 1,
+                    rhs = "level2",
+                    silent = 0
+                  },
+                  v = {
+                    sid = 0,
+                    noremap = 0,
+                    enabled = 1,
+                    rhs = "level2",
+                    silent = 0
+                  },
+                  s = {
+                    sid = 0,
+                    noremap = 0,
+                    enabled = 1,
+                    rhs = "level2",
+                    silent = 0
+                  },
+                  n = {
+                    sid = 0,
+                    noremap = 0,
+                    enabled = 1,
+                    rhs = "level2",
+                    silent = 0
+                  }
+                },
+                priority = 500,
+                name = "Nested2",
+                hidden = 0
+              }
+            },
+            hidden = 0
+          }
+        },
+        priority = 500,
+        name = "Test"
+      },
+      {
+        priority = 500,
+        name = "Export",
+        submenus = {
+          {
+            tooltip = "This is the tooltip",
+            hidden = 0,
+            name = "Script",
+            priority = 500,
+            mappings = {
+              n = {
+                sid = 1,
+                noremap = 1,
+                enabled = 1,
+                rhs = "p",
+                silent = 0
+              }
+            }
+          }
+        },
+        hidden = 0
+      },
+      {
+        priority = 500,
+        name = "Edit",
+        submenus = {
+          {
+            mappings = {
+              c = {
+                sid = 1,
+                noremap = 1,
+                enabled = 1,
+                rhs = "\18\"",
+                silent = 0
+              },
+              n = {
+                sid = 1,
+                noremap = 1,
+                enabled = 1,
+                rhs = "p",
+                silent = 0
+              }
+            },
+            priority = 500,
+            name = "Paste",
+            hidden = 0
+          }
+        },
+        hidden = 0
+      },
+      {
+        priority = 500,
+        name = "]Export",
+        submenus = {
+          {
+            mappings = {
+              o = {
+                sid = 0,
+                noremap = 0,
+                enabled = 1,
+                rhs = "thisoneshouldbehidden",
+                silent = 0
+              },
+              v = {
+                sid = 0,
+                noremap = 0,
+                enabled = 1,
+                rhs = "thisoneshouldbehidden",
+                silent = 0
+              },
+              s = {
+                sid = 0,
+                noremap = 0,
+                enabled = 1,
+                rhs = "thisoneshouldbehidden",
+                silent = 0
+              },
+              n = {
+                sid = 0,
+                noremap = 0,
+                enabled = 1,
+                rhs = "thisoneshouldbehidden",
+                silent = 0
+              }
+            },
+            priority = 500,
+            name = "hidden",
+            hidden = 0
+          }
+        },
+        hidden = 1
+      }
+    }
+    eq(expected, m)
+  end)
+
+  it('matching path, default modes', function()
+    local m = funcs.menu_get("Export", "a")
+    local expected = {
+      {
+        tooltip = "This is the tooltip",
+        hidden = 0,
+        name = "Script",
+        priority = 500,
+        mappings = {
+          n = {
+            sid = 1,
+            noremap = 1,
+            enabled = 1,
+            rhs = "p",
+            silent = 0
+          }
+        }
+      }
+    }
+    eq(expected, m)
+  end)
+
+  it('no path, matching modes', function()
+    local m = funcs.menu_get("","i")
+    local expected = {
+      {
+        shortcut = "T",
+        hidden = 0,
+        submenus = {
+          {
+            mappings = {
+              i = {
+                sid = 1,
+                noremap = 1,
+                enabled = 1,
+                rhs = "insert",
+                silent = 0
+              }
+            },
+            priority = 500,
+            name = "Test",
+            hidden = 0
+          },
+          {
+          }
+        },
+        priority = 500,
+        name = "Test"
+      }
+    }
+    eq(expected, m)
+  end)
+
+  it('matching path and modes', function()
+    local m = funcs.menu_get("Test","i")
+    local expected = {
+      {
+        mappings = {
+          i = {
+            sid = 1,
+            noremap = 1,
+            enabled = 1,
+            rhs = "insert",
+            silent = 0
+          }
+        },
+        priority = 500,
+        name = "Test",
+        hidden = 0
+      }
+    }
+    eq(expected, m)
+  end)
+
 end)


### PR DESCRIPTION
adds export_menu that saves menus to a dict.
`let l = export_menus("")`
With json_encode, this allows UIs to retrieve the menus (likewise for plugins, eg, a certain "palette")

Crashes for now.