### PR TITLE
[RFC] fix the behavior of CTRL-F with 'scrolloff' (#6319)

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1877,6 +1877,7 @@ int onepage(int dir, long count)
     }
   }
   foldAdjustCursor();
+  cursor_correct();
   check_cursor_col();
   if (retval == OK) {
     beginline(BL_SOL | BL_FIX);

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -433,7 +433,6 @@ func! Test_normal13_help()
 endfunc
 
 func! Test_normal14_page()
-  throw "skipped: Nvim regression: CTRL-F with 'scrolloff'"
   " basic test for Ctrl-F and Ctrl-B
   call Setup_NewWindow()
   exe "norm! \<c-f>"


### PR DESCRIPTION
close https://github.com/neovim/neovim/issues/6319
when merge vim-patch 7.4.2322, we lost "cursor_correct()".

https://github.com/vim/vim/commit/bc54f3f3fed4dc3556df8c46cee6739d211b0eb2