### PR TITLE
doc: Update missing headers.

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -1,4 +1,4 @@
-*develop.txt*
+*develop.txt*          Nvim
 
 
                             NVIM REFERENCE MANUAL

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -1,4 +1,4 @@
-*if_ruby.txt*
+*if_ruby.txt*          Nvim
 
 
 		  VIM REFERENCE MANUAL    by Shugo Maeda

--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -1,4 +1,4 @@
-*msgpack_rpc.txt*							{Nvim}
+*msgpack_rpc.txt*	Nvim
 
 
 		 NVIM REFERENCE MANUAL    by Thiago de Arruda

--- a/runtime/doc/nvim.txt
+++ b/runtime/doc/nvim.txt
@@ -1,4 +1,4 @@
-*nvim.txt*								{Nvim}
+*nvim.txt*	Nvim
 
 
 			    NVIM REFERENCE MANUAL

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -1,4 +1,4 @@
-*spell.txt*
+*spell.txt*     Nvim
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar


### PR DESCRIPTION
pi_* docs are considered standalone plugins so they don't follow this
convention.