### PR TITLE
vim-patch:8.0.0499: taglist() does not prioritize tags for a buffer

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2291,7 +2291,7 @@ tabpagebuflist([{arg}])		List	list of buffer numbers in tab page
 tabpagenr([{arg}])		Number	number of current or last tab page
 tabpagewinnr({tabarg}[, {arg}])
 				Number	number of current window in tab page
-taglist({expr})		List	list of tags matching {expr}
+taglist({expr}[, {filename}])	List	list of tags matching {expr}
 tagfiles()			List	tags files used
 tan({expr})			Float	tangent of {expr}
 tanh({expr})			Float	hyperbolic tangent of {expr}
@@ -7427,8 +7427,13 @@ tagfiles()	Returns a |List| with the file names used to search for tags
 		for the current buffer.  This is the 'tags' option expanded.
 
 
-taglist({expr})							*taglist()*
+taglist({expr}[, {filename}]))				*taglist()*
 		Returns a list of tags matching the regular expression {expr}.
+
+		If {filename} is passed it is used to prioritize the results
+		in the same way that |:tselect| does. See |tag-priority|.
+		{filename} should be the full path of the file.
+
 		Each list item is a dictionary with at least the following
 		entries:
 			name		Name of the tag.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16437,7 +16437,11 @@ static void f_taglist(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
-  (void)get_tags(tv_list_alloc_ret(rettv), (char_u *)tag_pattern);
+  char_u *fname = NULL;
+  if (argvars[1].v_type != VAR_UNKNOWN) {
+    fname = tv_get_string(&argvars[1]);
+  }
+  (void)get_tags(tv_list_alloc_ret(rettv), (char_u *)tag_pattern, fname);
 }
 
 /*

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -300,7 +300,7 @@ return {
     tabpagenr={args={0, 1}},
     tabpagewinnr={args={1, 2}},
     tagfiles={},
-    taglist={args=1},
+    taglist={args={1, 2}},
     tan={args=1, func="float_op_wrapper", data="&tan"},
     tanh={args=1, func="float_op_wrapper", data="&tanh"},
     tempname={},

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2797,11 +2797,14 @@ add_tag_field (
   return retval;
 }
 
-/*
- * Add the tags matching the specified pattern to the list "list"
- * as a dictionary
- */
-int get_tags(list_T *list, char_u *pat)
+/// Adds the tags matching the specified pattern to the list "list"
+/// as a dictionary.
+///
+/// @param[in]  list  List to add tags to.
+/// @param[in]  pat   The pattern to test tags against.
+/// @param[in]  buf_fname The buffer name to prioritize matches
+///                       for unless NULL.
+int get_tags(list_T *list, char_u *pat, char_u *buf_fname)
 {
   int num_matches, i, ret;
   char_u      **matches, *p;
@@ -2811,7 +2814,7 @@ int get_tags(list_T *list, char_u *pat)
   bool is_static;
 
   ret = find_tags(pat, &num_matches, &matches,
-      TAG_REGEXP | TAG_NOIC, (int)MAXCOL, NULL);
+                  TAG_REGEXP | TAG_NOIC, (int)MAXCOL, buf_fname);
   if (ret == OK && num_matches > 0) {
     for (i = 0; i < num_matches; ++i) {
       int parse_result = parse_match(matches[i], &tp);

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -63,6 +63,7 @@ NEW_TESTS ?= \
 	    test_substitute.res \
 	    test_syntax.res \
 	    test_tabpage.res \
+            test_taglist.res \
 	    test_textobjects.res \
 	    test_timers.res \
 	    test_undo.res \

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -26,6 +26,7 @@ source test_tabline.vim
 " source test_tabpage.vim
 source test_tagcase.vim
 source test_tagjump.vim
+source test_taglist.vim
 source test_true_false.vim
 source test_unlet.vim
 source test_utf8.vim

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -1,0 +1,21 @@
+" test 'taglist' function
+
+func Test_taglist()
+  call writefile([
+	\ "FFoo\tXfoo\t1",
+	\ "FBar\tXfoo\t2",
+	\ "BFoo\tXbar\t1",
+	\ "BBar\tXbar\t2"
+	\ ], 'Xtags')
+  set tags=Xtags
+  split Xtext
+
+  call assert_equal(['FFoo', 'BFoo'], map(taglist("Foo"), {i, v -> v.name}))
+  call assert_equal(['FFoo', 'BFoo'], map(taglist("Foo", "Xtext"), {i, v -> v.name}))
+  call assert_equal(['FFoo', 'BFoo'], map(taglist("Foo", "Xfoo"), {i, v -> v.name}))
+  call assert_equal(['BFoo', 'FFoo'], map(taglist("Foo", "Xbar"), {i, v -> v.name}))
+
+  call delete('Xtags')
+  bwipe
+endfunc
+


### PR DESCRIPTION
Problem:    taglist() does not prioritize tags for a buffer.
Solution:   Add an optional buffer argument. (Duncan McDougall, closes #1194)

https://github.com/vim/vim/commit/c6aafbaf3ea755e3ab4ee2e3045911126a08b038