### PR TITLE
[RFC] vim-patch:7.4.2236,7.4.2306

### DIFF
--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -94,7 +94,7 @@
   do { \
     if (*p_langmap \
         && (condition) \
-        && (!p_lnr || (p_lnr && typebuf_maplen() == 0)) \
+        && (p_lrm || (!p_lrm && KeyTyped)) \
         && !KeyStuffed \
         && (c) >= 0) \
     { \

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3630,6 +3630,12 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
   } else if ((int *)varp == &p_force_off && p_force_off == true) {
     p_force_off = false;
     return (char *)e_unsupportedoption;
+  } else if ((int *)varp == &p_lrm) {
+    // 'langremap' -> !'langnoremap'
+    p_lnr = !p_lrm;
+  } else if ((int *)varp == &p_lnr) {
+    // 'langnoremap' -> !'langremap'
+    p_lrm = !p_lnr;
   // 'undofile'
   } else if ((int *)varp == &curbuf->b_p_udf || (int *)varp == &p_udf) {
     // Only take action when the option was set. When reset we do not

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -476,8 +476,9 @@ EXTERN char_u   *p_isp;         // 'isprint'
 EXTERN int p_js;                // 'joinspaces'
 EXTERN char_u   *p_kp;          // 'keywordprg'
 EXTERN char_u   *p_km;          // 'keymodel'
-EXTERN char_u   *p_langmap;     // 'langmap'*/
-EXTERN int p_lnr;               // 'langnoremap'*/
+EXTERN char_u   *p_langmap;     // 'langmap'
+EXTERN int p_lnr;               // 'langnoremap'
+EXTERN int p_lrm;               // 'langremap'
 EXTERN char_u   *p_lm;          // 'langmenu'
 EXTERN char_u   *p_lispwords;   // 'lispwords'
 EXTERN long p_ls;               // 'laststatus'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1347,6 +1347,12 @@ return {
       defaults={if_true={vi=false, vim=true}}
     },
     {
+      full_name='langremap', abbreviation='lrm',
+      type='bool', scope={'global'},
+      varname='p_lrm',
+      defaults={if_true={vi=true, vim=false}}
+    },
+    {
       full_name='laststatus', abbreviation='ls',
       type='number', scope={'global'},
       vim=true,

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -72,6 +72,14 @@ func Test_map_langmap()
   set nolangremap
   call assert_equal(1, &langnoremap)
 
+  " check default values
+  set langnoremap&
+  call assert_equal(1, &langnoremap)
+  call assert_equal(0, &langremap)
+  set langremap&
+  call assert_equal(1, &langnoremap)
+  call assert_equal(0, &langremap)
+
   " langmap should not apply in insert mode, 'langremap' doesn't matter
   set langmap=+{ nolangremap
   call feedkeys("Go+\<Esc>", "xt")

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -205,7 +205,7 @@ static const int included_patches[] = {
   // 2239,
   // 2238 NA
   2237,
-  // 2236,
+  2236,
   2235,
   // 2234 NA
   2233,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -135,7 +135,7 @@ static const int included_patches[] = {
   2309,
   // 2308 NA
   2307,
-  // 2306,
+  2306,
   2305,
   // 2304 NA
   2303,


### PR DESCRIPTION
#### vim-patch:7.4.2236

Problem:    The 'langnoremap' option leads to double negatives.  And it does
            not work for the last character of a mapping.
Solution:   Add 'langremap' with the opposite value.  Keep 'langnoremap' for
            backwards compatibility.  Make it work for the last character of a
            mapping.  Make the test work.


#### vim-patch:7.4.2306

Problem:    Default value for 'langremap' is wrong.
Solution:   Set the right value. (Jürgen Krämer)  Add a test.

https://github.com/vim/vim/commit/da9ce2cde11ddd0e16cdfbab6d4ac4e8110218e1