### PR TITLE
The allow_keys global is unused in nvim, remove it

### DIFF
--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1448,10 +1448,8 @@ int get_digraph(int cmdline)
 {
   int cc;
   no_mapping++;
-  allow_keys++;
   int c = plain_vgetc();
   no_mapping--;
-  allow_keys--;
 
   if (c != ESC) {
     // ESC cancels CTRL-K
@@ -1468,10 +1466,8 @@ int get_digraph(int cmdline)
       add_to_showcmd(c);
     }
     no_mapping++;
-    allow_keys++;
     cc = plain_vgetc();
     no_mapping--;
-    allow_keys--;
 
     if (cc != ESC) {
       // ESC cancels CTRL-K

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -690,10 +690,8 @@ static int insert_execute(VimState *state, int key)
     // may need to redraw when no more chars available now
     ins_redraw(false);
     ++no_mapping;
-    ++allow_keys;
     s->c = plain_vgetc();
     --no_mapping;
-    --allow_keys;
     if (s->c != Ctrl_N && s->c != Ctrl_G && s->c != Ctrl_O) {
       // it's something else
       vungetc(s->c);
@@ -8306,10 +8304,8 @@ static int ins_digraph(void)
   /* don't map the digraph chars. This also prevents the
    * mode message to be deleted when ESC is hit */
   ++no_mapping;
-  ++allow_keys;
   c = plain_vgetc();
   --no_mapping;
-  --allow_keys;
   if (did_putchar)
     /* when the line fits in 'columns' the '?' is at the start of the next
      * line and will not be removed by the redraw */
@@ -8334,10 +8330,8 @@ static int ins_digraph(void)
       add_to_showcmd_c(c);
     }
     ++no_mapping;
-    ++allow_keys;
     cc = plain_vgetc();
     --no_mapping;
-    --allow_keys;
     if (did_putchar)
       /* when the line fits in 'columns' the '?' is at the start of the
        * next line and will not be removed by a redraw */

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -689,9 +689,9 @@ static int insert_execute(VimState *state, int key)
   if (s->c == Ctrl_BSL) {
     // may need to redraw when no more chars available now
     ins_redraw(false);
-    ++no_mapping;
+    no_mapping++;
     s->c = plain_vgetc();
-    --no_mapping;
+    no_mapping--;
     if (s->c != Ctrl_N && s->c != Ctrl_G && s->c != Ctrl_O) {
       // it's something else
       vungetc(s->c);
@@ -8301,15 +8301,16 @@ static int ins_digraph(void)
   }
 
 
-  /* don't map the digraph chars. This also prevents the
-   * mode message to be deleted when ESC is hit */
-  ++no_mapping;
+  // don't map the digraph chars. This also prevents the
+  // mode message to be deleted when ESC is hit
+  no_mapping++;
   c = plain_vgetc();
-  --no_mapping;
-  if (did_putchar)
-    /* when the line fits in 'columns' the '?' is at the start of the next
-     * line and will not be removed by the redraw */
+  no_mapping--;
+  if (did_putchar) {
+    // when the line fits in 'columns' the '?' is at the start of the next
+    // line and will not be removed by the redraw
     edit_unputchar();
+  }
 
   if (IS_SPECIAL(c) || mod_mask) {          /* special key */
     clear_showcmd();
@@ -8329,13 +8330,14 @@ static int ins_digraph(void)
       }
       add_to_showcmd_c(c);
     }
-    ++no_mapping;
+    no_mapping++;
     cc = plain_vgetc();
-    --no_mapping;
-    if (did_putchar)
-      /* when the line fits in 'columns' the '?' is at the start of the
-       * next line and will not be removed by a redraw */
+    no_mapping--;
+    if (did_putchar) {
+      // when the line fits in 'columns' the '?' is at the start of the
+      // next line and will not be removed by a redraw
       edit_unputchar();
+    }
     if (cc != ESC) {
       AppendToRedobuff((char_u *)CTRL_V_STR);
       c = getdigraph(c, cc, TRUE);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10597,7 +10597,6 @@ static void f_getchar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   int error = FALSE;
 
   ++no_mapping;
-  ++allow_keys;
   for (;; ) {
     // Position the cursor.  Needed after a message that ends in a space,
     // or if event processing caused a redraw.
@@ -10631,7 +10630,6 @@ static void f_getchar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     break;
   }
   --no_mapping;
-  --allow_keys;
 
   vimvars[VV_MOUSE_WIN].vv_nr = 0;
   vimvars[VV_MOUSE_WINID].vv_nr = 0;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10596,7 +10596,7 @@ static void f_getchar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   varnumber_T n;
   int error = FALSE;
 
-  ++no_mapping;
+  no_mapping++;
   for (;; ) {
     // Position the cursor.  Needed after a message that ends in a space,
     // or if event processing caused a redraw.
@@ -10629,7 +10629,7 @@ static void f_getchar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       continue;
     break;
   }
-  --no_mapping;
+  no_mapping--;
 
   vimvars[VV_MOUSE_WIN].vv_nr = 0;
   vimvars[VV_MOUSE_WINID].vv_nr = 0;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3578,9 +3578,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout)
               RedrawingDisabled = temp;
 
               ++no_mapping;                     /* don't map this key */
-              ++allow_keys;                     /* allow special keys */
               typed = plain_vgetc();
-              --allow_keys;
               --no_mapping;
 
               /* clear the question */

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3577,9 +3577,9 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout)
               ui_cursor_goto(msg_row, msg_col);
               RedrawingDisabled = temp;
 
-              ++no_mapping;                     /* don't map this key */
+              no_mapping++;                     // don't map this key
               typed = plain_vgetc();
-              --no_mapping;
+              no_mapping--;
 
               /* clear the question */
               msg_didout = FALSE;               /* don't scroll up */

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -622,10 +622,8 @@ static int command_line_execute(VimState *state, int key)
   // mode when 'insertmode' is set, CTRL-\ e prompts for an expression.
   if (s->c == Ctrl_BSL) {
     ++no_mapping;
-    ++allow_keys;
     s->c = plain_vgetc();
     --no_mapping;
-    --allow_keys;
     // CTRL-\ e doesn't work when obtaining an expression, unless it
     // is in a mapping.
     if (s->c != Ctrl_N && s->c != Ctrl_G && (s->c != 'e'
@@ -1888,7 +1886,6 @@ getexmodeline (
     }
   }
   ++no_mapping;
-  ++allow_keys;
 
   /*
    * Get the line, one character at a time.
@@ -2079,7 +2076,6 @@ redraw:
   }
 
   --no_mapping;
-  --allow_keys;
 
   /* make following messages go to the next line */
   msg_didout = FALSE;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -621,9 +621,9 @@ static int command_line_execute(VimState *state, int key)
   // CTRL-\ CTRL-N goes to Normal mode, CTRL-\ CTRL-G goes to Insert
   // mode when 'insertmode' is set, CTRL-\ e prompts for an expression.
   if (s->c == Ctrl_BSL) {
-    ++no_mapping;
+    no_mapping++;
     s->c = plain_vgetc();
-    --no_mapping;
+    no_mapping--;
     // CTRL-\ e doesn't work when obtaining an expression, unless it
     // is in a mapping.
     if (s->c != Ctrl_N && s->c != Ctrl_G && (s->c != 'e'
@@ -1885,7 +1885,7 @@ getexmodeline (
       msg_putchar(' ');
     }
   }
-  ++no_mapping;
+  no_mapping++;
 
   /*
    * Get the line, one character at a time.
@@ -2075,7 +2075,7 @@ redraw:
     }
   }
 
-  --no_mapping;
+  no_mapping--;
 
   /* make following messages go to the next line */
   msg_didout = FALSE;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1390,26 +1390,21 @@ int vgetc(void)
       bool did_inc = false;
       if (mod_mask) {           // no mapping after modifier has been read
         ++no_mapping;
-        ++allow_keys;
         did_inc = true;         // mod_mask may change value
       }
       c = vgetorpeek(true);
       if (did_inc) {
         --no_mapping;
-        --allow_keys;
       }
 
       /* Get two extra bytes for special keys */
       if (c == K_SPECIAL
           ) {
-        int save_allow_keys = allow_keys;
 
         ++no_mapping;
-        allow_keys = 0;                 /* make sure BS is not found */
         c2 = vgetorpeek(TRUE);          /* no mapping for these chars */
         c = vgetorpeek(TRUE);
         --no_mapping;
-        allow_keys = save_allow_keys;
         if (c2 == KS_MODIFIER) {
           mod_mask = c;
           continue;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1389,22 +1389,20 @@ int vgetc(void)
     for (;; ) {                 // this is done twice if there are modifiers
       bool did_inc = false;
       if (mod_mask) {           // no mapping after modifier has been read
-        ++no_mapping;
+        no_mapping++;
         did_inc = true;         // mod_mask may change value
       }
       c = vgetorpeek(true);
       if (did_inc) {
-        --no_mapping;
+        no_mapping--;
       }
 
-      /* Get two extra bytes for special keys */
-      if (c == K_SPECIAL
-          ) {
-
-        ++no_mapping;
-        c2 = vgetorpeek(TRUE);          /* no mapping for these chars */
-        c = vgetorpeek(TRUE);
-        --no_mapping;
+      // Get two extra bytes for special keys
+      if (c == K_SPECIAL) {
+        no_mapping++;
+        c2 = vgetorpeek(true);          // no mapping for these chars
+        c = vgetorpeek(true);
+        no_mapping--;
         if (c2 == KS_MODIFIER) {
           mod_mask = c;
           continue;
@@ -1482,7 +1480,7 @@ int vgetc(void)
               buf[i] = CSI;
           }
         }
-        --no_mapping;
+        no_mapping--;
         c = (*mb_ptr2char)(buf);
       }
 
@@ -1565,7 +1563,7 @@ int char_avail(void)
 
   no_mapping++;
   retval = vpeekc();
-  --no_mapping;
+  no_mapping--;
   return retval != NUL;
 }
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -834,8 +834,6 @@ EXTERN int Exec_reg INIT(= FALSE);      /* TRUE when executing a register */
 
 EXTERN int no_mapping INIT(= FALSE);    /* currently no mapping allowed */
 EXTERN int no_zero_mapping INIT(= 0);   /* mapping zero not allowed */
-EXTERN int allow_keys INIT(= FALSE);    /* allow key codes when no_mapping
-                                         * is set */
 EXTERN int no_u_sync INIT(= 0);         /* Don't call u_sync() */
 EXTERN int u_sync_once INIT(= 0);       /* Call u_sync() once when evaluating
                                            an expression. */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -832,11 +832,11 @@ EXTERN int ex_no_reprint INIT(= FALSE); /* no need to print after z or p */
 EXTERN int Recording INIT(= FALSE);     /* TRUE when recording into a reg. */
 EXTERN int Exec_reg INIT(= FALSE);      /* TRUE when executing a register */
 
-EXTERN int no_mapping INIT(= FALSE);    /* currently no mapping allowed */
-EXTERN int no_zero_mapping INIT(= 0);   /* mapping zero not allowed */
-EXTERN int no_u_sync INIT(= 0);         /* Don't call u_sync() */
-EXTERN int u_sync_once INIT(= 0);       /* Call u_sync() once when evaluating
-                                           an expression. */
+EXTERN int no_mapping INIT(= false);    // currently no mapping allowed
+EXTERN int no_zero_mapping INIT(= 0);   // mapping zero not allowed
+EXTERN int no_u_sync INIT(= 0);         // Don't call u_sync()
+EXTERN int u_sync_once INIT(= 0);       // Call u_sync() once when evaluating
+                                        // an expression.
 
 EXTERN bool force_restart_edit INIT(= false);  // force restart_edit after
                                                // ex_normal returns

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -850,7 +850,6 @@ void wait_return(int redraw)
       /* Don't do mappings here, we put the character back in the
        * typeahead buffer. */
       ++no_mapping;
-      ++allow_keys;
 
       /* Temporarily disable Recording. If Recording is active, the
        * character will be recorded later, since it will be added to the
@@ -863,7 +862,6 @@ void wait_return(int redraw)
       if (had_got_int && !global_busy)
         got_int = FALSE;
       --no_mapping;
-      --allow_keys;
       Recording = save_Recording;
       scriptout = save_scriptout;
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -847,21 +847,22 @@ void wait_return(int redraw)
        * CTRL-C, but we need to loop then. */
       had_got_int = got_int;
 
-      /* Don't do mappings here, we put the character back in the
-       * typeahead buffer. */
-      ++no_mapping;
+      // Don't do mappings here, we put the character back in the
+      // typeahead buffer.
+      no_mapping++;
 
-      /* Temporarily disable Recording. If Recording is active, the
-       * character will be recorded later, since it will be added to the
-       * typebuf after the loop */
+      // Temporarily disable Recording. If Recording is active, the
+      // character will be recorded later, since it will be added to the
+      // typebuf after the loop
       save_Recording = Recording;
       save_scriptout = scriptout;
       Recording = FALSE;
       scriptout = NULL;
       c = safe_vgetc();
-      if (had_got_int && !global_busy)
-        got_int = FALSE;
-      --no_mapping;
+      if (had_got_int && !global_busy) {
+        got_int = false;
+      }
+      no_mapping--;
       Recording = save_Recording;
       scriptout = save_scriptout;
 

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2225,10 +2225,10 @@ int ask_yesno(const char *str, bool direct)
   int r = ' ';
   int save_State = State;
 
-  ++no_wait_return;
-  State = CONFIRM;              /* mouse behaves like with :confirm */
-  setmouse();                   /* disables mouse for xterm */
-  ++no_mapping;
+  no_wait_return++;
+  State = CONFIRM;              // mouse behaves like with :confirm
+  setmouse();                   // disables mouse for xterm
+  no_mapping++;
 
   while (r != 'y' && r != 'n') {
     /* same highlighting as for wait_return */
@@ -2246,7 +2246,7 @@ int ask_yesno(const char *str, bool direct)
   --no_wait_return;
   State = save_State;
   setmouse();
-  --no_mapping;
+  no_mapping--;
 
   return r;
 }
@@ -2396,7 +2396,7 @@ get_number (
   if (msg_silent != 0)
     return 0;
 
-  ++no_mapping;
+  no_mapping++;
   for (;; ) {
     ui_cursor_goto(msg_row, msg_col);
     c = safe_vgetc();
@@ -2424,7 +2424,7 @@ get_number (
     } else if (c == CAR || c == NL || c == Ctrl_C || c == ESC)
       break;
   }
-  --no_mapping;
+  no_mapping--;
   return n;
 }
 

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2229,7 +2229,6 @@ int ask_yesno(const char *str, bool direct)
   State = CONFIRM;              /* mouse behaves like with :confirm */
   setmouse();                   /* disables mouse for xterm */
   ++no_mapping;
-  ++allow_keys;                 /* no mapping here, but recognize keys */
 
   while (r != 'y' && r != 'n') {
     /* same highlighting as for wait_return */
@@ -2248,7 +2247,6 @@ int ask_yesno(const char *str, bool direct)
   State = save_State;
   setmouse();
   --no_mapping;
-  --allow_keys;
 
   return r;
 }
@@ -2399,7 +2397,6 @@ get_number (
     return 0;
 
   ++no_mapping;
-  ++allow_keys;                 /* no mapping here, but recognize keys */
   for (;; ) {
     ui_cursor_goto(msg_row, msg_col);
     c = safe_vgetc();
@@ -2428,7 +2425,6 @@ get_number (
       break;
   }
   --no_mapping;
-  --allow_keys;
   return n;
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -643,7 +643,6 @@ static void normal_get_additional_char(NormalState *s)
   int lang;                     // getting a text character
 
   ++no_mapping;
-  ++allow_keys;               // no mapping for nchar, but allow key codes
   // Don't generate a CursorHold event here, most commands can't handle
   // it, e.g., nv_replace(), nv_csearch().
   did_cursorhold = true;
@@ -682,7 +681,6 @@ static void normal_get_additional_char(NormalState *s)
     if (lang && curbuf->b_p_iminsert == B_IMODE_LMAP) {
       // Allow mappings defined with ":lmap".
       --no_mapping;
-      --allow_keys;
       if (repl) {
         State = LREPLACE;
       } else {
@@ -696,7 +694,6 @@ static void normal_get_additional_char(NormalState *s)
     if (langmap_active) {
       // Undo the decrement done above
       ++no_mapping;
-      ++allow_keys;
       State = NORMAL_BUSY;
     }
     State = NORMAL_BUSY;
@@ -782,7 +779,6 @@ static void normal_get_additional_char(NormalState *s)
     no_mapping++;
   }
   --no_mapping;
-  --allow_keys;
 }
 
 static void normal_invert_horizontal(NormalState *s)
@@ -833,7 +829,6 @@ static bool normal_get_command_count(NormalState *s)
 
     if (s->ctrl_w) {
       ++no_mapping;
-      ++allow_keys;                   // no mapping for nchar, but keys
     }
 
     ++no_zero_mapping;                // don't map zero here
@@ -842,7 +837,6 @@ static bool normal_get_command_count(NormalState *s)
     --no_zero_mapping;
     if (s->ctrl_w) {
       --no_mapping;
-      --allow_keys;
     }
     s->need_flushbuf |= add_to_showcmd(s->c);
   }
@@ -853,11 +847,9 @@ static bool normal_get_command_count(NormalState *s)
     s->ca.opcount = s->ca.count0;           // remember first count
     s->ca.count0 = 0;
     ++no_mapping;
-    ++allow_keys;                     // no mapping for nchar, but keys
     s->c = plain_vgetc();                // get next character
     LANGMAP_ADJUST(s->c, true);
     --no_mapping;
-    --allow_keys;
     s->need_flushbuf |= add_to_showcmd(s->c);
     return true;
   }
@@ -4044,11 +4036,9 @@ static void nv_zet(cmdarg_T *cap)
     n = nchar - '0';
     for (;; ) {
       ++no_mapping;
-      ++allow_keys;         /* no mapping for nchar, but allow key codes */
       nchar = plain_vgetc();
       LANGMAP_ADJUST(nchar, true);
       --no_mapping;
-      --allow_keys;
       (void)add_to_showcmd(nchar);
       if (nchar == K_DEL || nchar == K_KDEL)
         n /= 10;
@@ -4378,11 +4368,9 @@ dozet:
 
   case 'u':     /* "zug" and "zuw": undo "zg" and "zw" */
     ++no_mapping;
-    ++allow_keys;               /* no mapping for nchar, but allow key codes */
     nchar = plain_vgetc();
     LANGMAP_ADJUST(nchar, true);
     --no_mapping;
-    --allow_keys;
     (void)add_to_showcmd(nchar);
     if (vim_strchr((char_u *)"gGwW", nchar) == NULL) {
       clearopbeep(cap->oap);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -642,7 +642,7 @@ static void normal_get_additional_char(NormalState *s)
   bool langmap_active = false;  // using :lmap mappings
   int lang;                     // getting a text character
 
-  ++no_mapping;
+  no_mapping++;
   // Don't generate a CursorHold event here, most commands can't handle
   // it, e.g., nv_replace(), nv_csearch().
   did_cursorhold = true;
@@ -680,7 +680,7 @@ static void normal_get_additional_char(NormalState *s)
     }
     if (lang && curbuf->b_p_iminsert == B_IMODE_LMAP) {
       // Allow mappings defined with ":lmap".
-      --no_mapping;
+      no_mapping--;
       if (repl) {
         State = LREPLACE;
       } else {
@@ -693,7 +693,7 @@ static void normal_get_additional_char(NormalState *s)
 
     if (langmap_active) {
       // Undo the decrement done above
-      ++no_mapping;
+      no_mapping++;
       State = NORMAL_BUSY;
     }
     State = NORMAL_BUSY;
@@ -778,7 +778,7 @@ static void normal_get_additional_char(NormalState *s)
     }
     no_mapping++;
   }
-  --no_mapping;
+  no_mapping--;
 }
 
 static void normal_invert_horizontal(NormalState *s)
@@ -828,7 +828,7 @@ static bool normal_get_command_count(NormalState *s)
     }
 
     if (s->ctrl_w) {
-      ++no_mapping;
+      no_mapping++;
     }
 
     ++no_zero_mapping;                // don't map zero here
@@ -836,7 +836,7 @@ static bool normal_get_command_count(NormalState *s)
     LANGMAP_ADJUST(s->c, true);
     --no_zero_mapping;
     if (s->ctrl_w) {
-      --no_mapping;
+      no_mapping--;
     }
     s->need_flushbuf |= add_to_showcmd(s->c);
   }
@@ -846,10 +846,10 @@ static bool normal_get_command_count(NormalState *s)
     s->ctrl_w = true;
     s->ca.opcount = s->ca.count0;           // remember first count
     s->ca.count0 = 0;
-    ++no_mapping;
+    no_mapping++;
     s->c = plain_vgetc();                // get next character
     LANGMAP_ADJUST(s->c, true);
-    --no_mapping;
+    no_mapping--;
     s->need_flushbuf |= add_to_showcmd(s->c);
     return true;
   }
@@ -4035,10 +4035,10 @@ static void nv_zet(cmdarg_T *cap)
       return;
     n = nchar - '0';
     for (;; ) {
-      ++no_mapping;
+      no_mapping++;
       nchar = plain_vgetc();
       LANGMAP_ADJUST(nchar, true);
-      --no_mapping;
+      no_mapping--;
       (void)add_to_showcmd(nchar);
       if (nchar == K_DEL || nchar == K_KDEL)
         n /= 10;
@@ -4366,11 +4366,11 @@ dozet:
     break;
 
 
-  case 'u':     /* "zug" and "zuw": undo "zg" and "zw" */
-    ++no_mapping;
+  case 'u':     // "zug" and "zuw": undo "zg" and "zw"
+    no_mapping++;
     nchar = plain_vgetc();
     LANGMAP_ADJUST(nchar, true);
-    --no_mapping;
+    no_mapping--;
     (void)add_to_showcmd(nchar);
     if (vim_strchr((char_u *)"gGwW", nchar) == NULL) {
       clearopbeep(cap->oap);

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -448,12 +448,10 @@ wingotofile:
   case Ctrl_G:
     CHECK_CMDWIN
     ++ no_mapping;
-    ++allow_keys;               /* no mapping for xchar, but allow key codes */
     if (xchar == NUL)
       xchar = plain_vgetc();
     LANGMAP_ADJUST(xchar, TRUE);
     --no_mapping;
-    --allow_keys;
     (void)add_to_showcmd(xchar);
     switch (xchar) {
     case '}':

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -447,11 +447,12 @@ wingotofile:
   case 'g':
   case Ctrl_G:
     CHECK_CMDWIN
-    ++ no_mapping;
-    if (xchar == NUL)
+    no_mapping++;
+    if (xchar == NUL) {
       xchar = plain_vgetc();
-    LANGMAP_ADJUST(xchar, TRUE);
-    --no_mapping;
+    }
+    LANGMAP_ADJUST(xchar, true);
+    no_mapping--;
     (void)add_to_showcmd(xchar);
     switch (xchar) {
     case '}':


### PR DESCRIPTION
It's only use (as opposed to being incremented and decremented) was removed in 10a5825b95c8072d7be5cc0ddb308b09605b6b6e