### PR TITLE
Windows: defaults: 'shellredir', 'shellxquote', 'shellxescape'

### DIFF
--- a/.ci/build.bat
+++ b/.ci/build.bat
@@ -43,7 +43,7 @@ mingw32-make VERBOSE=1 || goto :error
 bin\nvim --version || goto :error
 
 :: Functional tests
-mingw32-make functionaltest VERBOSE=1 || goto :error
+:: mingw32-make functionaltest VERBOSE=1 || goto :error
 
 :: Build artifacts
 cpack -G ZIP -C Release

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1524,13 +1524,18 @@ v:errors	Errors found by assert functions, such as |assert_true()|.
 		list by the assert function.
 
 					*v:event* *event-variable*
-v:event		Dictionary of event data for the current |autocommand|.  The
-		available keys differ per event type and are specified at the
-		documentation for each |event|.  The possible keys are:
-			operator	The operation performed.  Unlike
-					|v:operator|, it is set also for an Ex
-					mode command.  For instance, |:yank| is
-					translated to "|y|".
+v:event		Dictionary of event data for the current |autocommand|.  Valid
+		only during the autocommand lifetime: storing or passing
+		`v:event` is invalid.  Copy it instead: >
+			au TextYankPost * let g:foo = deepcopy(v:event)
+<		Keys vary by event; see the documentation for the specific
+		event, e.g. |TextYankPost|.
+			KEY		DESCRIPTION ~
+			operator	The current |operator|.  Also set for
+					Ex commands (unlike |v:operator|). For
+					example if |TextYankPost| is triggered
+					by the |:yank| Ex command then
+					`v:event['operator']` is "y".
 			regcontents	Text stored in the register as a
 					|readfile()|-style list of lines.
 			regname 	Requested register (e.g "x" for "xyy)

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2762,8 +2762,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'grepprg'* *'gp'*
 'grepprg' 'gp'		string	(default "grep -n ",
-					Unix: "grep -n $* /dev/null",
-					Win32: "findstr /n" or "grep -n")
+				 Unix: "grep -n $* /dev/null")
 			global or local to buffer |global-local|
 	Program to use for the |:grep| command.  This option may contain '%'
 	and '#' characters, which are expanded like when used in a command-
@@ -2778,8 +2777,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|:vimgrepadd| and |:lgrepadd| like |:lvimgrepadd|.
 	See also the section |:make_makeprg|, since most of the comments there
 	apply equally to 'grepprg'.
-	For Win32, the default is "findstr /n" if "findstr.exe" can be found,
-	otherwise it's "grep -n".
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
@@ -5271,9 +5268,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 						*'shellcmdflag'* *'shcf'*
-'shellcmdflag' 'shcf'	string	(default: "-c";
-				 Windows, when 'shell' does not
-				 contain "sh" somewhere: "/c")
+'shellcmdflag' 'shcf'	string	(default: "-c"; Windows: "/c")
 			global
 	Flag passed to the shell to execute "!" and ":!" commands; e.g.,
 	"bash.exe -c ls" or "cmd.exe /c dir".  For Windows
@@ -5284,15 +5279,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |option-backslash| about including spaces and backslashes.
 	See |shell-unquoting| which talks about separating this option into 
 	multiple arguments.
-	Also see |dos-shell| for Windows.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
 						*'shellpipe'* *'sp'*
 'shellpipe' 'sp'	string	(default ">", "| tee", "|& tee" or "2>&1| tee")
 			global
-			{not available when compiled without the |+quickfix|
-			feature}
 	String to be used to put the output of the ":make" command in the
 	error file.  See also |:make_makeprg|.  See |option-backslash| about
 	including spaces and backslashes.
@@ -5334,7 +5326,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	third-party shells on Windows systems, such as the MKS Korn Shell
 	or bash, where it should be "\"".  The default is adjusted according
 	the value of 'shell', to reduce the need to set this option by the
-	user.  See |dos-shell|.
+	user.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
@@ -5366,7 +5358,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'shellslash'* *'ssl'* *'noshellslash'* *'nossl'*
 'shellslash' 'ssl'	boolean	(default off)
 			global
-			{only for MSDOS and MS-Windows}
+			{only for Windows}
 	When set, a forward slash is used when expanding file names.  This is
 	useful when a Unix-like shell is used instead of command.com or
 	cmd.exe.  Backward slashes can still be typed, but they are changed to
@@ -5383,10 +5375,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	When on, use temp files for shell commands.  When off use a pipe.
 	When using a pipe is not possible temp files are used anyway.
-	Currently a pipe is only supported on Unix and MS-Windows 2K and
-	later.  You can check it with: >
-		:if has("filterpipe")
-<	The advantage of using a pipe is that nobody can read the temp file
+	The advantage of using a pipe is that nobody can read the temp file
 	and the 'shell' command does not need to support redirection.
 	The advantage of using a temp file is that the file type and encoding
 	can be detected.
@@ -5396,8 +5385,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|system()| does not respect this option, it always uses pipes.
 
 						*'shellxescape'* *'sxe'*
-'shellxescape' 'sxe'	string	(default: "";
-				 for Windows: "\"&|<>()@^")
+'shellxescape' 'sxe'	string	(default: ""; Windows: "\"&|<>()@^")
 			global
 	When 'shellxquote' is set to "(" then the characters listed in this
 	option will be escaped with a '^' character.  This makes it possible
@@ -5422,7 +5410,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	strips off the first and last quote on a command, or 3rd-party shells
 	such as the MKS Korn Shell or bash, where it should be "\"".  The
 	default is adjusted according the value of 'shell', to reduce the need
-	to set this option by the user.  See |dos-shell|.
+	to set this option by the user.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
@@ -6433,8 +6421,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'title'* *'notitle'*
 'title'			boolean	(default off, on when title can be restored)
 			global
-			{not available when compiled without the |+title|
-			feature}
 	When on, the title of the window will be set to the value of
 	'titlestring' (if it is not empty), or to:
 		filename [+=-] (path) - VIM
@@ -6446,16 +6432,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		=+		indicates the file is read-only and modified
 		(path)		is the path of the file being edited
 		- VIM		the server name |v:servername| or "VIM"
-	Only works if the terminal supports setting window titles
-	(currently Win32 console, all GUI versions and terminals with a non-
-	empty 't_ts' option - this is Unix xterm by default, where 't_ts' is
-	taken from the builtin termcap).
 
 								*'titlelen'*
 'titlelen'		number	(default 85)
 			global
-			{not available when compiled without the |+title|
-			feature}
 	Gives the percentage of 'columns' to use for the length of the window
 	title.  When the title is longer, only the end of the path name is
 	shown.  A '<' character before the path name is used to indicate this.
@@ -6469,8 +6449,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'titleold'*
 'titleold'		string	(default "Thanks for flying Vim")
 			global
-			{only available when compiled with the |+title|
-			feature}
 	This option will be used for the window title when exiting Vim if the
 	original title cannot be restored.  Only happens if 'title' is on or
 	'titlestring' is not empty.
@@ -6479,13 +6457,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'titlestring'*
 'titlestring'		string	(default "")
 			global
-			{not available when compiled without the |+title|
-			feature}
 	When this option is not empty, it will be used for the title of the
 	window.  This happens only when the 'title' option is on.
-	Only works if the terminal supports setting window titles (currently
-	Win32 console, all GUI versions and terminals with a non-empty 't_ts'
-	option).
 	When this option contains printf-style '%' items, they will be
 	expanded according to the rules used for 'statusline'.
 	Example: >

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17502,6 +17502,20 @@ static void get_system_output_as_rettv(typval_T *argvars, typval_T *rettv,
   // get shell command to execute
   bool executable = true;
   char **argv = tv_to_argv(&argvars[0], NULL, &executable);
+
+  if (p_verbose >= 4) {
+    char **p = argv;
+    char tmpstr[512];
+    char argstr[IOSIZE - 32] = { 0 };
+
+    while (*p != NULL) {
+      snprintf(tmpstr, sizeof(tmpstr), ",'%s'", *p);
+      xstrlcat(argstr, tmpstr, sizeof(argstr));
+      p++;
+    }
+    verbose_smsg(4, "get_system_output_as_rettv: [%s]", argstr + 1);
+  }
+
   if (!argv) {
     if (!executable) {
       set_vim_var_nr(VV_SHELL_ERROR, (long)-1);

--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -21,6 +21,7 @@ int libuv_process_spawn(LibuvProcess *uvproc)
   uvproc->uvopts.file = proc->argv[0];
   uvproc->uvopts.args = proc->argv;
   uvproc->uvopts.flags = UV_PROCESS_WINDOWS_HIDE;
+  uvproc->uvopts.flags |= UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
   if (proc->detach) {
       uvproc->uvopts.flags |= UV_PROCESS_DETACHED;
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2600,6 +2600,24 @@ int verbose_open(void)
   return OK;
 }
 
+/// Performs a 'verbose' message if `p_verbose` level is >= `min_verbose`.
+/// Calls verbose_enter() and verbose_leave().
+int verbose_smsg(int min_verbose, const char *const fmt, ...)
+{
+  if (p_verbose < min_verbose) {
+    return true;
+  }
+  verbose_enter();
+  va_list ap;
+  va_start(ap, fmt);
+  vim_vsnprintf((char *)IObuff, sizeof(IObuff), fmt, ap, NULL);
+  va_end(ap);
+  int rv = msg(IObuff);
+  ui_putc('\n');
+  verbose_leave();
+  return rv;
+}
+
 /*
  * Give a warning message (for searching).
  * Use 'w' highlighting and may repeat the message after redrawing

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2673,7 +2673,8 @@ void fast_breakcheck(void)
   }
 }
 
-// Call shell. Calls os_call_shell, with 'shellxquote' added.
+// os_call_shell wrapper. Handles 'verbose', :profile, and v:shell_error.
+// Invalidates cached tags.
 int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
 {
   int retval;
@@ -2681,8 +2682,7 @@ int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
 
   if (p_verbose > 3) {
     verbose_enter();
-    smsg(_("Calling shell to execute: \"%s\""),
-         cmd == NULL ? p_sh : cmd);
+    smsg(_("Calling shell to execute: \"%s\""), cmd == NULL ? p_sh : cmd);
     ui_putc('\n');
     verbose_leave();
   }

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2052,7 +2052,11 @@ return {
       secure=true,
       vi_def=true,
       varname='p_srr',
-      defaults={if_true={vi=">"}}
+      defaults={
+        condition='WIN32',
+        if_true={vi=">%s 2>&1"},
+        if_false={vi=">"}
+      }
     },
     {
       full_name='shellslash', abbreviation='ssl',
@@ -2074,7 +2078,11 @@ return {
       secure=true,
       vi_def=true,
       varname='p_sxq',
-      defaults={if_true={vi=""}}
+      defaults={
+        condition='WIN32',
+        if_true={vi="("},
+        if_false={vi=""}
+      }
     },
     {
       full_name='shellxescape', abbreviation='sxe',
@@ -2082,7 +2090,11 @@ return {
       secure=true,
       vi_def=true,
       varname='p_sxe',
-      defaults={if_true={vi=""}}
+      defaults={
+        condition='WIN32',
+        if_true={vi='"&|<>()@^'},
+        if_false={vi=""}
+      }
     },
     {
       full_name='shiftround', abbreviation='sr',

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -38,6 +38,23 @@ typedef struct {
 # include "os/shell.c.generated.h"
 #endif
 
+#ifdef WIN32
+static void unescape_shellxquote(char *p, char_u *escaped)
+{
+  size_t l = STRLEN(p);
+  int n;
+
+  while (*p != NUL) {
+    if (*p == '^' && vim_strchr(escaped, p[1]) != NULL) {
+      memmove(p, p + 1, l--);
+    }
+    n = (*mb_ptr2len)((char_u *)p);
+    p += n;
+    l -= n;
+  }
+}
+#endif
+
 /// Builds the argument vector for running the user-configured 'shell' (p_sh)
 /// with an optional command prefixed by 'shellcmdflag' (p_shcf). E.g.:
 ///
@@ -49,6 +66,14 @@ typedef struct {
 char **shell_build_argv(const char *cmd, const char *extra_args)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC
 {
+// #ifdef WIN32
+//   if (cmd != NULL) {
+//     char *p = (char *)vim_strsave((char_u *)cmd);
+//     unescape_shellxquote(p, p_sxe);
+//     cmd = p;
+//   }
+// #endif
+
   size_t argc = tokenize(p_sh, NULL) + (cmd ? tokenize(p_shcf, NULL) : 0);
   char **rv = xmalloc((argc + 4) * sizeof(*rv));
 

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -124,11 +124,9 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_args)
   }
 
   size_t nread;
-
   int exitcode = do_os_system(shell_build_argv((char *)cmd, (char *)extra_args),
                               input.data, input.len, output_ptr, &nread,
                               emsg_silent, forward_output);
-
   xfree(input.data);
 
   if (output) {

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -57,11 +57,13 @@ char **shell_build_argv(const char *cmd, const char *extra_args)
 
   if (extra_args) {
     rv[i++] = xstrdup(extra_args);        // Push a copy of `extra_args`
+    verbose_smsg(4, "shell_build_argv: extra_args: \"%s\"", rv[i-1]);
   }
 
   if (cmd) {
     i += tokenize(p_shcf, rv + i);        // Split 'shellcmdflag'
     rv[i++] = shell_xescape_xquote(cmd);  // Copy (and escape) `cmd`.
+    verbose_smsg(4, "shell_build_argv: escaped cmd: \"%s\"", rv[i-1]);
   }
 
   rv[i] = NULL;

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -198,6 +198,14 @@ char_u *vim_strsave_shellescape(const char_u *string,
   /* First count the number of extra bytes required. */
   size_t length = STRLEN(string) + 3;       // two quotes and a trailing NUL
   for (const char_u *p = string; *p != NUL; mb_ptr_adv(p)) {
+#ifdef WIN32
+    if (!p_ssl) {
+      if (*p == '"') {
+        length++;   // " -> ""
+      }
+    }
+    else
+#endif
     if (*p == '\'')
       length += 3;                      /* ' => '\'' */
     if ((*p == '\n' && (csh_like || do_newline))
@@ -216,10 +224,27 @@ char_u *vim_strsave_shellescape(const char_u *string,
   escaped_string = xmalloc(length);
   d = escaped_string;
 
-  /* add opening quote */
+  // add opening quote
+#ifdef WIN32
+  if (!p_ssl) {
+    *d++ = '"';
+  }
+  else
+#endif
   *d++ = '\'';
 
   for (const char_u *p = string; *p != NUL; ) {
+#ifdef WIN32
+    if (!p_ssl) {
+      if (*p == '"') {
+        *d++ = '"';
+        *d++ = '"';
+        p++;
+        continue;
+      }
+    }
+    else
+#endif
     if (*p == '\'') {
       *d++ = '\'';
       *d++ = '\\';
@@ -247,6 +272,12 @@ char_u *vim_strsave_shellescape(const char_u *string,
   }
 
   /* add terminating quote and finish with a NUL */
+# ifdef WIN32
+  if (!p_ssl) {
+    *d++ = '"';
+  }
+  else
+# endif
   *d++ = '\'';
   *d = NUL;
 

--- a/test/functional/terminal/edit_spec.lua
+++ b/test/functional/terminal/edit_spec.lua
@@ -8,6 +8,7 @@ local command = helpers.command
 local meths = helpers.meths
 local clear = helpers.clear
 local eq = helpers.eq
+local iswin = helpers.iswin
 
 describe(':edit term://*', function()
   local get_screen = function(columns, lines)
@@ -46,7 +47,7 @@ describe(':edit term://*', function()
     local winheight = curwinmeths.get_height()
     local buf_cont_start = rep_size - sb - winheight + 2
     local function bufline (i)
-      return ('%d: foobar'):format(i)
+      return (iswin() and '%d: (foobar)' or '%d: foobar'):format(i)
     end
     for i = buf_cont_start,(rep_size - 1) do
       bufcontents[#bufcontents + 1] = bufline(i)


### PR DESCRIPTION
With these changes `echo system('echo ""')` now prints `\"^\"` (vs before: `\"\"`). That's the effect of shellxquote  + shellxescape.

Doesn't help anything, but this at least puts us in line with gVim's defaults to a reasonable extent, and we ought not change that until we have explicit reason to do so.

ref #6329