### PR TITLE
[RFC] vim-patch:8.0.0250

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1166,6 +1166,7 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor,
       pos->col = 0;
     }
     posptr = ptr + pos->col;
+    posptr -= utf_head_off(line, posptr);
   }
 
   // This function is used very often, do some speed optimizations.

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -28,4 +28,5 @@ source test_tagcase.vim
 source test_tagjump.vim
 source test_true_false.vim
 source test_unlet.vim
+source test_utf8.vim
 source test_window_cmd.vim

--- a/src/nvim/testdir/test_utf8.vim
+++ b/src/nvim/testdir/test_utf8.vim
@@ -1,0 +1,65 @@
+" Tests for Unicode manipulations
+if !has('multi_byte')
+  finish
+endif
+ 
+
+" Visual block Insert adjusts for multi-byte char
+func Test_visual_block_insert()
+  new
+  call setline(1, ["aaa", "あああ", "bbb"])
+  exe ":norm! gg0l\<C-V>jjIx\<Esc>"
+  call assert_equal(['axaa', 'xあああ', 'bxbb'], getline(1, '$'))
+  bwipeout!
+endfunc
+
+" Test for built-in function strchars()
+func Test_strchars()
+  let inp = ["a", "あいa", "A\u20dd", "A\u20dd\u20dd", "\u20dd"]
+  let exp = [[1, 1, 1], [3, 3, 3], [2, 2, 1], [3, 3, 1], [1, 1, 1]]
+  for i in range(len(inp))
+    call assert_equal(exp[i][0], strchars(inp[i]))
+    call assert_equal(exp[i][1], strchars(inp[i], 0))
+    call assert_equal(exp[i][2], strchars(inp[i], 1))
+  endfor
+endfunc
+
+" Test for customlist completion
+function! CustomComplete1(lead, line, pos)
+	return ['あ', 'い']
+endfunction
+
+function! CustomComplete2(lead, line, pos)
+	return ['あたし', 'あたま', 'あたりめ']
+endfunction
+
+function! CustomComplete3(lead, line, pos)
+	return ['Nこ', 'Nん', 'Nぶ']
+endfunction
+
+func Test_customlist_completion()
+  command -nargs=1 -complete=customlist,CustomComplete1 Test1 echo
+  call feedkeys(":Test1 \<C-L>\<C-B>\"\<CR>", 'itx')
+  call assert_equal('"Test1 ', getreg(':'))
+
+  command -nargs=1 -complete=customlist,CustomComplete2 Test2 echo
+  call feedkeys(":Test2 \<C-L>\<C-B>\"\<CR>", 'itx')
+  call assert_equal('"Test2 あた', getreg(':'))
+
+  command -nargs=1 -complete=customlist,CustomComplete3 Test3 echo
+  call feedkeys(":Test3 \<C-L>\<C-B>\"\<CR>", 'itx')
+  call assert_equal('"Test3 N', getreg(':'))
+
+  call garbagecollect(1)
+endfunc
+
+" Yank one 3 byte character and check the mark columns.
+func Test_getvcol()
+  new
+  call setline(1, "x\u2500x")
+  normal 0lvy
+  call assert_equal(2, col("'["))
+  call assert_equal(4, col("']"))
+  call assert_equal(2, virtcol("'["))
+  call assert_equal(2, virtcol("']"))
+endfunc


### PR DESCRIPTION
#### vim-patch:8.0.0250

Problem:    When virtcol() gets a column that is not the first byte of a
            multi-byte character the result is unpredictable. (Christian
            Ludwig)
Solution:   Correct the column to the first byte of a multi-byte character.
            Change the utf-8 test to new style.

https://github.com/vim/vim/commit/0c0590d9827cb07a33c1552cb3558b94bddcb4dc

Closes #6269