### PR TITLE
[RFC] Add ‘eob’ option to fillchars

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2441,7 +2441,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Only normal file name characters can be used, "/\*?[|<>" are illegal.
 
 						*'fillchars'* *'fcs'*
-'fillchars' 'fcs'	string	(default "vert:|,fold:-")
+'fillchars' 'fcs'	string	(default "vert:|,fold:-,eob:~")
 			global
 			{not available when compiled without the |+windows|
 			and |+folding| features}
@@ -2454,6 +2454,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  vert:c	'|'		vertical separators |:vsplit|
 	  fold:c	'-'		filling 'foldtext'
 	  diff:c	'-'		deleted lines of the 'diff' option
+	  eob:c		'~'		empty lines at the end of a buffer
 
 	Any one that is omitted will fall back to the default.  For "stl" and
 	"stlnc" the space will be used when there is highlighting, '^' or '='
@@ -2473,6 +2474,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  vert:c	VertSplit		|hl-VertSplit|
 	  fold:c	Folded			|hl-Folded|
 	  diff:c	DiffDelete		|hl-DiffDelete|
+	  eob:c		EndOfBuffer		|hl-EndOfBuffer|
 
 		*'fixendofline'* *'fixeol'* *'nofixendofline'* *'nofixeol'*
 'fixendofline' 'fixeol'	boolean	(default on)

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1024,6 +1024,7 @@ EXTERN int fill_stlnc INIT(= ' ');
 EXTERN int fill_vert INIT(= ' ');
 EXTERN int fill_fold INIT(= '-');
 EXTERN int fill_diff INIT(= '-');
+EXTERN int fill_eob INIT(= '~');
 
 /* Whether 'keymodel' contains "stopsel" and "startsel". */
 EXTERN int km_stopsel INIT(= FALSE);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3357,25 +3357,23 @@ static char_u *set_chars_option(char_u **varp)
     int     *cp;
     char    *name;
   };
-  static struct charstab filltab[] =
-  {
-    {&fill_stl,     "stl"},
-    {&fill_stlnc,   "stlnc"},
-    {&fill_vert,    "vert"},
-    {&fill_fold,    "fold"},
-    {&fill_diff,    "diff"},
-    {&fill_eob,     "eob"}
+  static struct charstab filltab[] = {
+    { &fill_stl,     "stl" },
+    { &fill_stlnc,   "stlnc" },
+    { &fill_vert,    "vert" },
+    { &fill_fold,    "fold" },
+    { &fill_diff,    "diff" },
+    { &fill_eob,     "eob" }
   };
-  static struct charstab lcstab[] =
-  {
-    {&lcs_eol,      "eol"},
-    {&lcs_ext,      "extends"},
-    {&lcs_nbsp,     "nbsp"},
-    {&lcs_prec,     "precedes"},
-    {&lcs_space,    "space"},
-    {&lcs_tab2,     "tab"},
-    {&lcs_trail,    "trail"},
-    {&lcs_conceal,  "conceal"},
+  static struct charstab lcstab[] = {
+    { &lcs_eol,      "eol" },
+    { &lcs_ext,      "extends" },
+    { &lcs_nbsp,     "nbsp" },
+    { &lcs_prec,     "precedes" },
+    { &lcs_space,    "space" },
+    { &lcs_tab2,     "tab" },
+    { &lcs_trail,    "trail" },
+    { &lcs_conceal,  "conceal" },
   };
   struct charstab *tab;
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3364,6 +3364,7 @@ static char_u *set_chars_option(char_u **varp)
     {&fill_vert,    "vert"},
     {&fill_fold,    "fold"},
     {&fill_diff,    "diff"},
+    {&fill_eob,     "eob"}
   };
   static struct charstab lcstab[] =
   {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -797,7 +797,7 @@ return {
       vi_def=true,
       redraw={'all_windows'},
       varname='p_fcs',
-      defaults={if_true={vi="vert:|,fold:-"}}
+      defaults={if_true={vi="vert:|,fold:-,eob:~"}}
     },
     {
       full_name='fixendofline', abbreviation='fixeol',

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1527,9 +1527,9 @@ static void win_update(win_T *wp)
     } else if (dollar_vcol == -1)
       wp->w_botline = lnum;
 
-    /* make sure the rest of the screen is blank */
-    /* put '~'s on rows that aren't part of the file. */
-    win_draw_end(wp, '~', ' ', row, wp->w_height, HLF_EOB);
+    // make sure the rest of the screen is blank
+    // write the 'fill_eob' character to rows that aren't part of the file.
+    win_draw_end(wp, fill_eob, ' ', row, wp->w_height, HLF_EOB);
   }
 
   /* Reset the type of redrawing required, the window has been updated. */

--- a/test/functional/options/fillchars_spec.lua
+++ b/test/functional/options/fillchars_spec.lua
@@ -1,0 +1,45 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear, execute = helpers.clear, helpers.execute
+
+describe("'fillchars'", function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(25, 5)
+    screen:attach()
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  describe('"eob" flag', function()
+    it('renders empty lines at the end of the buffer with eob', function()
+      screen:expect([[
+        ^                         |
+        ~                        |
+        ~                        |
+        ~                        |
+                                 |
+      ]])
+      execute('set fillchars+=eob:\\ ')
+      screen:expect([[
+        ^                         |
+                                 |
+                                 |
+                                 |
+        :set fillchars+=eob:\    |
+      ]])
+      execute('set fillchars+=eob:ñ')
+      screen:expect([[
+        ^                         |
+        ñ                        |
+        ñ                        |
+        ñ                        |
+        :set fillchars+=eob:ñ    |
+      ]])
+    end)
+  end)
+end)


### PR DESCRIPTION
This option allows configuring what character is shown on the empty
lines at the end of a buffer, previously hardcoded to ‘~’

Fixes: https://github.com/neovim/neovim/issues/4181