### PR TITLE
cmake: use USE_BUNDLED_X instead of X_USE_BUNDLED

### DIFF
--- a/cmake/FindJeMalloc.cmake
+++ b/cmake/FindJeMalloc.cmake
@@ -4,7 +4,7 @@
 #  JEMALLOC_INCLUDE_DIRS - The jemalloc include directories
 #  JEMALLOC_LIBRARIES - The libraries needed to use jemalloc
 
-if(NOT JEMALLOC_USE_BUNDLED)
+if(NOT USE_BUNDLED_JEMALLOC)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
     pkg_check_modules(PC_JEMALLOC QUIET jemalloc)

--- a/cmake/FindLibTermkey.cmake
+++ b/cmake/FindLibTermkey.cmake
@@ -4,7 +4,7 @@
 #  LIBTERMKEY_INCLUDE_DIRS - The libtermkey include directories
 #  LIBTERMKEY_LIBRARIES - The libraries needed to use libtermkey
 
-if(NOT LIBTERMKEY_USE_BUNDLED)
+if(NOT USE_BUNDLED_LIBTERMKEY)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
     pkg_check_modules(PC_LIBTERMKEY QUIET termkey)

--- a/cmake/FindLibUV.cmake
+++ b/cmake/FindLibUV.cmake
@@ -8,7 +8,7 @@
 # Set the LIBUV_USE_STATIC variable to specify if static libraries should
 # be preferred to shared ones.
 
-if(NOT LIBUV_USE_BUNDLED)
+if(NOT USE_BUNDLED_LIBUV)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
     pkg_check_modules(PC_LIBUV QUIET libuv)

--- a/cmake/FindLibVterm.cmake
+++ b/cmake/FindLibVterm.cmake
@@ -4,7 +4,7 @@
 #  LIBVTERM_INCLUDE_DIRS - The libvterm include directories
 #  LIBVTERM_LIBRARIES - The libraries needed to use libvterm
 
-if(NOT LIBVTERM_USE_BUNDLED)
+if(NOT USE_BUNDLED_LIBVTERM)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
     pkg_check_modules(PC_LIBVTERM QUIET vterm)

--- a/cmake/FindLuaJit.cmake
+++ b/cmake/FindLuaJit.cmake
@@ -4,7 +4,7 @@
 #  LUAJIT_INCLUDE_DIRS - The luajit include directories
 #  LUAJIT_LIBRARIES - The libraries needed to use luajit
 
-if(NOT LUAJIT_USE_BUNDLED)
+if(NOT USE_BUNDLED_LUAJIT)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
     pkg_check_modules(PC_LUAJIT QUIET luajit)

--- a/cmake/FindMsgpack.cmake
+++ b/cmake/FindMsgpack.cmake
@@ -4,7 +4,7 @@
 #  MSGPACK_INCLUDE_DIRS - The msgpack include directories
 #  MSGPACK_LIBRARIES - The libraries needed to use msgpack
 
-if(NOT MSGPACK_USE_BUNDLED)
+if(NOT USE_BUNDLED_MSGPACK)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
     pkg_search_module(PC_MSGPACK QUIET

--- a/cmake/FindUnibilium.cmake
+++ b/cmake/FindUnibilium.cmake
@@ -4,7 +4,7 @@
 #  UNIBILIUM_INCLUDE_DIRS - The unibilium include directories
 #  UNIBILIUM_LIBRARIES - The libraries needed to use unibilium
 
-if(NOT UNIBILIUM_USE_BUNDLED)
+if(NOT USE_BUNDLED_UNIBILIUM)
   find_package(PkgConfig)
   if (PKG_CONFIG_FOUND)
     pkg_check_modules(PC_UNIBILIUM QUIET unibilium)


### PR DESCRIPTION
AFAICS they are defined as `USE_BUNDLED_X` in third-party/CMakeLists.txt?!