### PR TITLE
[RFC] vim-patch:7.4.2259

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -381,10 +381,18 @@ CTRL-D		List names that match the pattern in front of the cursor.
 							*c_CTRL-N*
 CTRL-N		After using 'wildchar' which got multiple matches, go to next
 		match.  Otherwise recall more recent command-line from history.
+							*/_CTRL-N*
+		When 'incsearch' is set, entering a search pattern for "/" or
+		"?" and the current match is displayed then CTRL-N will move
+		to the next match (does not take |search-offset| into account)
 <S-Tab>							*c_CTRL-P* *c_<S-Tab>*
 CTRL-P		After using 'wildchar' which got multiple matches, go to
 		previous match.  Otherwise recall older command-line from
 		history.  <S-Tab> only works with the GUI.
+							*/_CTRL-P*
+		When 'incsearch' is set, entering a search pattern for "/" or
+		"?" and the current match is displayed then CTRL-P will move
+		to the previous match (does not take |search-offset| into account).
 							*c_CTRL-A*
 CTRL-A		All names that match the pattern in front of the cursor are
 		inserted.
@@ -394,6 +402,7 @@ CTRL-L		A match is done on the pattern in front of the cursor.  If
 		If there are multiple matches the longest common part is
 		inserted in place of the pattern.  If the result is shorter
 		than the pattern, no completion is done.
+							*/_CTRL-L*
 		When 'incsearch' is set, entering a search pattern for "/" or
 		"?" and the current match is displayed then CTRL-L will add
 		one character from the end of the current match.  If

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -72,6 +72,8 @@ NEW_TESTS ?= \
 	    test_window_id.res \
 	    test_writefile.res \
 	    test_alot.res
+#	    needs porting to Lua
+#	    test_search.res
 
 SCRIPTS_GUI := test16.out
 

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -1,0 +1,242 @@
+" Test for the search command
+
+func Test_search_cmdline()
+  if !exists('+incsearch')
+    return
+  endif
+  " need to disable char_avail,
+  " so that expansion of commandline works
+  call test_disable_char_avail(1)
+  new
+  call setline(1, ['  1', '  2 these', '  3 the', '  4 their', '  5 there', '  6 their', '  7 the', '  8 them', '  9 these', ' 10 foobar'])
+  " Test 1
+  " CTRL-N / CTRL-P skips through the previous search history
+  set noincsearch
+  :1
+  call feedkeys("/foobar\<cr>", 'tx')
+  call feedkeys("/the\<cr>",'tx')
+  call assert_equal('the', @/)
+  call feedkeys("/thes\<c-p>\<c-p>\<cr>",'tx')
+  call assert_equal('foobar', @/)
+
+  " Test 2
+  " Ctrl-N goes from one match to the next
+  " until the end of the buffer
+  set incsearch nowrapscan
+  :1
+  " first match
+  call feedkeys("/the\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  :1
+  " second match
+  call feedkeys("/the\<c-n>\<cr>", 'tx')
+  call assert_equal('  3 the', getline('.'))
+  :1
+  " third match
+  call feedkeys("/the".repeat("\<c-n>", 2)."\<cr>", 'tx')
+  call assert_equal('  4 their', getline('.'))
+  :1
+  " fourth match
+  call feedkeys("/the".repeat("\<c-n>", 3)."\<cr>", 'tx')
+  call assert_equal('  5 there', getline('.'))
+  :1
+  " fifth match
+  call feedkeys("/the".repeat("\<c-n>", 4)."\<cr>", 'tx')
+  call assert_equal('  6 their', getline('.'))
+  :1
+  " sixth match
+  call feedkeys("/the".repeat("\<c-n>", 5)."\<cr>", 'tx')
+  call assert_equal('  7 the', getline('.'))
+  :1
+  " seventh match
+  call feedkeys("/the".repeat("\<c-n>", 6)."\<cr>", 'tx')
+  call assert_equal('  8 them', getline('.'))
+  :1
+  " eigth match
+  call feedkeys("/the".repeat("\<c-n>", 7)."\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  :1
+  " no further match
+  call feedkeys("/the".repeat("\<c-n>", 8)."\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+
+  " Test 3
+  " Ctrl-N goes from one match to the next
+  " and continues back at the top
+  set incsearch wrapscan
+  :1
+  " first match
+  call feedkeys("/the\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  :1
+  " second match
+  call feedkeys("/the\<c-n>\<cr>", 'tx')
+  call assert_equal('  3 the', getline('.'))
+  :1
+  " third match
+  call feedkeys("/the".repeat("\<c-n>", 2)."\<cr>", 'tx')
+  call assert_equal('  4 their', getline('.'))
+  :1
+  " fourth match
+  call feedkeys("/the".repeat("\<c-n>", 3)."\<cr>", 'tx')
+  call assert_equal('  5 there', getline('.'))
+  :1
+  " fifth match
+  call feedkeys("/the".repeat("\<c-n>", 4)."\<cr>", 'tx')
+  call assert_equal('  6 their', getline('.'))
+  :1
+  " sixth match
+  call feedkeys("/the".repeat("\<c-n>", 5)."\<cr>", 'tx')
+  call assert_equal('  7 the', getline('.'))
+  :1
+  " seventh match
+  call feedkeys("/the".repeat("\<c-n>", 6)."\<cr>", 'tx')
+  call assert_equal('  8 them', getline('.'))
+  :1
+  " eigth match
+  call feedkeys("/the".repeat("\<c-n>", 7)."\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  :1
+  " back at first match
+  call feedkeys("/the".repeat("\<c-n>", 8)."\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+
+  " Test 4
+  " CTRL-P goes to the previous match
+  set incsearch nowrapscan
+  $
+  " first match
+  call feedkeys("?the\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  $
+  " first match
+  call feedkeys("?the\<c-n>\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  $
+  " second match
+  call feedkeys("?the".repeat("\<c-p>", 1)."\<cr>", 'tx')
+  call assert_equal('  8 them', getline('.'))
+  $
+  " last match
+  call feedkeys("?the".repeat("\<c-p>", 7)."\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  $
+  " last match
+  call feedkeys("?the".repeat("\<c-p>", 8)."\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+
+  " Test 5
+  " CTRL-P goes to the previous match
+  set incsearch wrapscan
+  $
+  " first match
+  call feedkeys("?the\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  $
+  " first match at the top
+  call feedkeys("?the\<c-n>\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  $
+  " second match
+  call feedkeys("?the".repeat("\<c-p>", 1)."\<cr>", 'tx')
+  call assert_equal('  8 them', getline('.'))
+  $
+  " last match
+  call feedkeys("?the".repeat("\<c-p>", 7)."\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  $
+  " back at the bottom of the buffer
+  call feedkeys("?the".repeat("\<c-p>", 8)."\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+
+  " Test 6
+  " CTRL-L adds to the search pattern
+  set incsearch wrapscan
+  1
+  " first match
+  call feedkeys("/the\<c-l>\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  1
+  " go to next match of 'thes'
+  call feedkeys("/the\<c-l>\<c-n>\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  1
+  " wrap around
+  call feedkeys("/the\<c-l>\<c-n>\<c-n>\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  1
+  " wrap around
+  set nowrapscan
+  call feedkeys("/the\<c-l>\<c-n>\<c-n>\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+
+  " Test 7
+  " <bs> remove from match, but stay at current match
+  set incsearch wrapscan
+  1
+  " first match
+  call feedkeys("/thei\<cr>", 'tx')
+  call assert_equal('  4 their', getline('.'))
+  1
+  " delete one char, add another
+  call feedkeys("/thei\<bs>s\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  1
+  " delete one char, add another,  go to previous match, add one char
+  call feedkeys("/thei\<bs>s\<bs>\<c-p>\<c-l>\<cr>", 'tx')
+  call assert_equal('  8 them', getline('.'))
+  1
+  " delete all chars, start from the beginning again
+  call feedkeys("/them". repeat("\<bs>",4).'the\>'."\<cr>", 'tx')
+  call assert_equal('  3 the', getline('.'))
+
+  " clean up
+  call test_disable_char_avail(0)
+  bw!
+endfunc
+
+func Test_search_cmdline2()
+  if !exists('+incsearch')
+    return
+  endif
+  " need to disable char_avail,
+  " so that expansion of commandline works
+  call test_disable_char_avail(1)
+  new
+  call setline(1, ['  1', '  2 these', '  3 the theother'])
+  " Test 1
+  " Ctrl-P goes correctly back and forth
+  set incsearch
+  1
+  " first match
+  call feedkeys("/the\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  1
+  " go to next match (on next line)
+  call feedkeys("/the\<c-n>\<cr>", 'tx')
+  call assert_equal('  3 the theother', getline('.'))
+  1
+  " go to next match (still on line 3)
+  call feedkeys("/the\<c-n>\<c-n>\<cr>", 'tx')
+  call assert_equal('  3 the theother', getline('.'))
+  1
+  " go to next match (still on line 3)
+  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<cr>", 'tx')
+  call assert_equal('  3 the theother', getline('.'))
+  1
+  " go to previous match (on line 3)
+  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<c-p>\<cr>", 'tx')
+  call assert_equal('  3 the theother', getline('.'))
+  1
+  " go to previous match (on line 3)
+  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<c-p>\<c-p>\<cr>", 'tx')
+  call assert_equal('  3 the theother', getline('.'))
+  1
+  " go to previous match (on line 2)
+  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<c-p>\<c-p>\<c-p>\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+
+  " clean up
+  call test_disable_char_avail(0)
+  bw!
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -182,7 +182,7 @@ static const int included_patches[] = {
   // 2262 NA
   // 2261 NA
   // 2260 NA
-  // 2259,
+  2259,
   // 2258 NA
   // 2257 NA
   2256,


### PR DESCRIPTION
Problem:    With 'incsearch' can only see the next match.
Solution:   Make CTRL-N/CTRL-P move to the previous/next match. (Christian
            Brabandt)

https://github.com/vim/vim/commit/4d6f32cbfbaf324ac4a25c0206a5db0e9f7a48f7