### PR TITLE
[RFC] Fix system('string') quoting in Windows

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4860,7 +4860,12 @@ jobstart({cmd}[, {opts}])				{Nvim} *jobstart()*
 		   :call jobstart(['ping', 'neovim.io'])
 <		If it is a path (not a name), it must include the extension: >
 		   :call jobstart(['System32\ping.exe', 'neovim.io'])
-<
+
+<		NOTE: On Windows the List {cmd} is converted according to the
+		standard command line argument format (used in CommandLineToArgvW).
+		Some programs such as cmd.exe do not, and may behave
+		unexpectedly by interpreting arguments differently.
+
 		{opts} is a dictionary with these keys:
 		  on_stdout: stdout event handler (function name or |Funcref|)
 		  on_stderr: stderr event handler (function name or |Funcref|)

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1524,13 +1524,18 @@ v:errors	Errors found by assert functions, such as |assert_true()|.
 		list by the assert function.
 
 					*v:event* *event-variable*
-v:event		Dictionary of event data for the current |autocommand|.  The
-		available keys differ per event type and are specified at the
-		documentation for each |event|.  The possible keys are:
-			operator	The operation performed.  Unlike
-					|v:operator|, it is set also for an Ex
-					mode command.  For instance, |:yank| is
-					translated to "|y|".
+v:event		Dictionary of event data for the current |autocommand|.  Valid
+		only during the autocommand lifetime: storing or passing
+		`v:event` is invalid.  Copy it instead: >
+			au TextYankPost * let g:foo = deepcopy(v:event)
+<		Keys vary by event; see the documentation for the specific
+		event, e.g. |TextYankPost|.
+			KEY		DESCRIPTION ~
+			operator	The current |operator|.  Also set for
+					Ex commands (unlike |v:operator|). For
+					example if |TextYankPost| is triggered
+					by the |:yank| Ex command then
+					`v:event['operator']` is "y".
 			regcontents	Text stored in the register as a
 					|readfile()|-style list of lines.
 			regname 	Requested register (e.g "x" for "xyy)

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2776,8 +2776,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'grepprg'* *'gp'*
 'grepprg' 'gp'		string	(default "grep -n ",
-					Unix: "grep -n $* /dev/null",
-					Win32: "findstr /n" or "grep -n")
+				 Unix: "grep -n $* /dev/null")
 			global or local to buffer |global-local|
 	Program to use for the |:grep| command.  This option may contain '%'
 	and '#' characters, which are expanded like when used in a command-
@@ -2792,8 +2791,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|:vimgrepadd| and |:lgrepadd| like |:lvimgrepadd|.
 	See also the section |:make_makeprg|, since most of the comments there
 	apply equally to 'grepprg'.
-	For Win32, the default is "findstr /n" if "findstr.exe" can be found,
-	otherwise it's "grep -n".
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
@@ -5285,9 +5282,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 						*'shellcmdflag'* *'shcf'*
-'shellcmdflag' 'shcf'	string	(default: "-c";
-				 Windows, when 'shell' does not
-				 contain "sh" somewhere: "/c")
+'shellcmdflag' 'shcf'	string	(default: "-c"; Windows: "/c")
 			global
 	Flag passed to the shell to execute "!" and ":!" commands; e.g.,
 	"bash.exe -c ls" or "cmd.exe /c dir".  For Windows
@@ -5298,15 +5293,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |option-backslash| about including spaces and backslashes.
 	See |shell-unquoting| which talks about separating this option into 
 	multiple arguments.
-	Also see |dos-shell| for Windows.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
 						*'shellpipe'* *'sp'*
 'shellpipe' 'sp'	string	(default ">", "| tee", "|& tee" or "2>&1| tee")
 			global
-			{not available when compiled without the |+quickfix|
-			feature}
 	String to be used to put the output of the ":make" command in the
 	error file.  See also |:make_makeprg|.  See |option-backslash| about
 	including spaces and backslashes.
@@ -5348,7 +5340,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	third-party shells on Windows systems, such as the MKS Korn Shell
 	or bash, where it should be "\"".  The default is adjusted according
 	the value of 'shell', to reduce the need to set this option by the
-	user.  See |dos-shell|.
+	user.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
@@ -5380,7 +5372,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'shellslash'* *'ssl'* *'noshellslash'* *'nossl'*
 'shellslash' 'ssl'	boolean	(default off)
 			global
-			{only for MSDOS and MS-Windows}
+			{only for Windows}
 	When set, a forward slash is used when expanding file names.  This is
 	useful when a Unix-like shell is used instead of command.com or
 	cmd.exe.  Backward slashes can still be typed, but they are changed to
@@ -5397,10 +5389,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	When on, use temp files for shell commands.  When off use a pipe.
 	When using a pipe is not possible temp files are used anyway.
-	Currently a pipe is only supported on Unix and MS-Windows 2K and
-	later.  You can check it with: >
-		:if has("filterpipe")
-<	The advantage of using a pipe is that nobody can read the temp file
+	The advantage of using a pipe is that nobody can read the temp file
 	and the 'shell' command does not need to support redirection.
 	The advantage of using a temp file is that the file type and encoding
 	can be detected.
@@ -5410,8 +5399,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|system()| does not respect this option, it always uses pipes.
 
 						*'shellxescape'* *'sxe'*
-'shellxescape' 'sxe'	string	(default: "";
-				 for Windows: "\"&|<>()@^")
+'shellxescape' 'sxe'	string	(default: ""; Windows: "\"&|<>()@^")
 			global
 	When 'shellxquote' is set to "(" then the characters listed in this
 	option will be escaped with a '^' character.  This makes it possible
@@ -5436,7 +5424,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	strips off the first and last quote on a command, or 3rd-party shells
 	such as the MKS Korn Shell or bash, where it should be "\"".  The
 	default is adjusted according the value of 'shell', to reduce the need
-	to set this option by the user.  See |dos-shell|.
+	to set this option by the user.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
@@ -6447,8 +6435,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'title'* *'notitle'*
 'title'			boolean	(default off, on when title can be restored)
 			global
-			{not available when compiled without the |+title|
-			feature}
 	When on, the title of the window will be set to the value of
 	'titlestring' (if it is not empty), or to:
 		filename [+=-] (path) - VIM
@@ -6460,16 +6446,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		=+		indicates the file is read-only and modified
 		(path)		is the path of the file being edited
 		- VIM		the server name |v:servername| or "VIM"
-	Only works if the terminal supports setting window titles
-	(currently Win32 console, all GUI versions and terminals with a non-
-	empty 't_ts' option - this is Unix xterm by default, where 't_ts' is
-	taken from the builtin termcap).
 
 								*'titlelen'*
 'titlelen'		number	(default 85)
 			global
-			{not available when compiled without the |+title|
-			feature}
 	Gives the percentage of 'columns' to use for the length of the window
 	title.  When the title is longer, only the end of the path name is
 	shown.  A '<' character before the path name is used to indicate this.
@@ -6483,8 +6463,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'titleold'*
 'titleold'		string	(default "Thanks for flying Vim")
 			global
-			{only available when compiled with the |+title|
-			feature}
 	This option will be used for the window title when exiting Vim if the
 	original title cannot be restored.  Only happens if 'title' is on or
 	'titlestring' is not empty.
@@ -6493,13 +6471,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'titlestring'*
 'titlestring'		string	(default "")
 			global
-			{not available when compiled without the |+title|
-			feature}
 	When this option is not empty, it will be used for the title of the
 	window.  This happens only when the 'title' option is on.
-	Only works if the terminal supports setting window titles (currently
-	Win32 console, all GUI versions and terminals with a non-empty 't_ts'
-	option).
 	When this option contains printf-style '%' items, they will be
 	expanded according to the rules used for 'statusline'.
 	Example: >

--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -24,6 +24,9 @@ int libuv_process_spawn(LibuvProcess *uvproc)
   if (proc->detach) {
       uvproc->uvopts.flags |= UV_PROCESS_DETACHED;
   }
+  if (!proc->quote_argv) {
+      uvproc->uvopts.flags |= UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
+  }
   uvproc->uvopts.exit_cb = exit_cb;
   uvproc->uvopts.cwd = proc->cwd;
   uvproc->uvopts.env = NULL;

--- a/src/nvim/event/process.h
+++ b/src/nvim/event/process.h
@@ -23,6 +23,8 @@ struct process {
   uint64_t stopped_time;
   char *cwd;
   char **argv;
+  /// In Win32 enable argument quoting
+  bool quote_argv;
   Stream *in, *out, *err;
   process_exit_cb cb;
   internal_process_cb internal_exit_cb, internal_close_cb;
@@ -43,6 +45,7 @@ static inline Process process_init(Loop *loop, ProcessType type, void *data)
     .stopped_time = 0,
     .cwd = NULL,
     .argv = NULL,
+    .quote_argv = true,
     .in = NULL,
     .out = NULL,
     .err = NULL,

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2673,7 +2673,8 @@ void fast_breakcheck(void)
   }
 }
 
-// Call shell. Calls os_call_shell, with 'shellxquote' added.
+// os_call_shell wrapper. Handles 'verbose', :profile, and v:shell_error.
+// Invalidates cached tags.
 int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
 {
   int retval;
@@ -2681,8 +2682,7 @@ int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
 
   if (p_verbose > 3) {
     verbose_enter();
-    smsg(_("Calling shell to execute: \"%s\""),
-         cmd == NULL ? p_sh : cmd);
+    smsg(_("Calling shell to execute: \"%s\""), cmd == NULL ? p_sh : cmd);
     ui_putc('\n');
     verbose_leave();
   }

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2052,7 +2052,11 @@ return {
       secure=true,
       vi_def=true,
       varname='p_srr',
-      defaults={if_true={vi=">"}}
+      defaults={
+        condition='WIN32',
+        if_true={vi=">%s 2>&1"},
+        if_false={vi=">"}
+      }
     },
     {
       full_name='shellslash', abbreviation='ssl',
@@ -2074,7 +2078,11 @@ return {
       secure=true,
       vi_def=true,
       varname='p_sxq',
-      defaults={if_true={vi=""}}
+      defaults={
+        condition='WIN32',
+        if_true={vi="("},
+        if_false={vi=""}
+      }
     },
     {
       full_name='shellxescape', abbreviation='sxe',
@@ -2082,7 +2090,11 @@ return {
       secure=true,
       vi_def=true,
       varname='p_sxe',
-      defaults={if_true={vi=""}}
+      defaults={
+        condition='WIN32',
+        if_true={vi='"&|<>()@^'},
+        if_false={vi=""}
+      }
     },
     {
       full_name='shiftround', abbreviation='sr',

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -124,11 +124,9 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_args)
   }
 
   size_t nread;
-
   int exitcode = do_os_system(shell_build_argv((char *)cmd, (char *)extra_args),
                               input.data, input.len, false, output_ptr, &nread,
                               emsg_silent, forward_output);
-
   xfree(input.data);
 
   if (output) {

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -198,6 +198,14 @@ char_u *vim_strsave_shellescape(const char_u *string,
   /* First count the number of extra bytes required. */
   size_t length = STRLEN(string) + 3;       // two quotes and a trailing NUL
   for (const char_u *p = string; *p != NUL; mb_ptr_adv(p)) {
+#ifdef WIN32
+    if (!p_ssl) {
+      if (*p == '"') {
+        length++;   // " -> ""
+      }
+    }
+    else
+#endif
     if (*p == '\'')
       length += 3;                      /* ' => '\'' */
     if ((*p == '\n' && (csh_like || do_newline))
@@ -216,10 +224,27 @@ char_u *vim_strsave_shellescape(const char_u *string,
   escaped_string = xmalloc(length);
   d = escaped_string;
 
-  /* add opening quote */
+  // add opening quote
+#ifdef WIN32
+  if (!p_ssl) {
+    *d++ = '"';
+  }
+  else
+#endif
   *d++ = '\'';
 
   for (const char_u *p = string; *p != NUL; ) {
+#ifdef WIN32
+    if (!p_ssl) {
+      if (*p == '"') {
+        *d++ = '"';
+        *d++ = '"';
+        p++;
+        continue;
+      }
+    }
+    else
+#endif
     if (*p == '\'') {
       *d++ = '\'';
       *d++ = '\\';
@@ -247,6 +272,12 @@ char_u *vim_strsave_shellescape(const char_u *string,
   }
 
   /* add terminating quote and finish with a NUL */
+# ifdef WIN32
+  if (!p_ssl) {
+    *d++ = '"';
+  }
+  else
+# endif
   *d++ = '\'';
   *d = NUL;
 

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -386,7 +386,11 @@ describe('jobs', function()
     endfunction
     let Callback = function('PrintArgs', ["foo", "bar"])
     let g:job_opts = {'on_stdout': Callback}
-    call jobstart('echo "some text"', g:job_opts)
+    if has('win32')
+      call jobstart(shellescape('echo "some text"'), g:job_opts)
+	else
+      call jobstart('echo some text', g:job_opts)
+    endif
     ]])
     eq({'notification', '1', {'foo', 'bar', {'some text', ''}, 'stdout'}}, next_msg())
   end)
@@ -399,7 +403,11 @@ describe('jobs', function()
           return {id, data, event -> rpcnotify(g:channel, '1', a1, a2, Normalize(data), event)}
       endfun
       let g:job_opts = {'on_stdout': MkFun()}
-      call jobstart('echo "some text"', g:job_opts)
+      if has('win32')
+        call jobstart(shellescape('echo "some text"'), g:job_opts)
+	  else
+        call jobstart('echo some text', g:job_opts)
+      endif
     ]])
     eq({'notification', '1', {'foo', 'bar', {'some text', ''}, 'stdout'}}, next_msg())
   end)
@@ -407,7 +415,11 @@ describe('jobs', function()
   it('jobstart() works when closure passed directly to `jobstart`', function()
     source([[
       let g:job_opts = {'on_stdout': {id, data, event -> rpcnotify(g:channel, '1', 'foo', 'bar', Normalize(data), event)}}
-      call jobstart('echo "some text"', g:job_opts)
+      if has('win32')
+        call jobstart(shellescape('echo "some text"'), g:job_opts)
+	  else
+        call jobstart('echo some text', g:job_opts)
+      endif
     ]])
     eq({'notification', '1', {'foo', 'bar', {'some text', ''}, 'stdout'}}, next_msg())
   end)

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -136,6 +136,13 @@ describe('system()', function()
       end
     end)
 
+    if helpers.os_name() == 'windows' then
+        it('works with cmd.exe', function()
+          eq('a\nb\n', eval([[system('echo a & echo b')]]))
+          eq('c:\\\n', eval([[system('cd c:\ a & echo %cd%')]]))
+        end)
+    end
+
     it('`echo` and waits for its return', function()
       feed(':call system("echo")<cr>')
       screen:expect([[

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -368,7 +368,7 @@ end
 local function set_shell_powershell()
   source([[
     set shell=powershell shellquote=\" shellpipe=\| shellredir=>
-    set shellcmdflag=\ -ExecutionPolicy\ RemoteSigned\ -Command
+    set shellcmdflag=\ -NoProfile\ -ExecutionPolicy\ RemoteSigned\ -Command
     let &shellxquote=' '
   ]])
 end

--- a/test/functional/terminal/edit_spec.lua
+++ b/test/functional/terminal/edit_spec.lua
@@ -8,6 +8,7 @@ local command = helpers.command
 local meths = helpers.meths
 local clear = helpers.clear
 local eq = helpers.eq
+local iswin = helpers.iswin
 
 describe(':edit term://*', function()
   local get_screen = function(columns, lines)
@@ -46,7 +47,7 @@ describe(':edit term://*', function()
     local winheight = curwinmeths.get_height()
     local buf_cont_start = rep_size - sb - winheight + 2
     local function bufline (i)
-      return ('%d: foobar'):format(i)
+      return (iswin() and '%d: (foobar)' or '%d: foobar'):format(i)
     end
     for i = buf_cont_start,(rep_size - 1) do
       bufcontents[#bufcontents + 1] = bufline(i)

--- a/test/unit/os/shell_spec.lua
+++ b/test/unit/os/shell_spec.lua
@@ -46,7 +46,7 @@ describe('shell functions', function()
 
     local argv = ffi.cast('char**',
                           cimported.shell_build_argv(to_cstr(cmd), nil))
-    local status = cimported.os_system(argv, input_or, input_len, output, nread)
+    local status = cimported.os_system(argv, input_or, input_len, false, output, nread)
 
     return status, intern(output[0], nread[0])
   end


### PR DESCRIPTION
This does not change the current behaviour of `system([...])` it only affects the string variant `system('...')` so that it is compatible with Vim (Vim does not have `system([])`). 

This PR disables the libuv quoting when spawning the new process - libuv quotes according to `CommandLineToArgvW()` however cmd.exe does not follow this convention. A good article about the differences can be found here

https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/

This fixes issues when calling the shell (#6329) in particular it should restore compatibility with Vim in this regard. It does however make `system('...')` less usable with regards to other windows shells that use `CommandLineToArgvW()` but these difficulties are also seen in Vim.

TODO;
- [x] add note in system() docs about system(['cmd.exe', '/c', 'echo ""']) not producing the expected result