### PR TITLE
In functional tests, set 'nomore' by default

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -23,7 +23,7 @@ local nvim_prog = os.getenv('NVIM_PROG') or os.getenv('NVIM_PRG') or 'build/bin/
 -- Default settings for the test session.
 local nvim_set  = 'set shortmess+=I background=light noswapfile noautoindent'
                   ..' laststatus=1 undodir=. directory=. viewdir=. backupdir=.'
-                  ..' belloff= noshowcmd noruler'
+                  ..' belloff= noshowcmd noruler nomore'
 local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
                    '--cmd', nvim_set, '--embed'}
 

--- a/test/functional/legacy/051_highlight_spec.lua
+++ b/test/functional/legacy/051_highlight_spec.lua
@@ -16,7 +16,7 @@ describe(':highlight', function()
     local screen = Screen.new(35, 10)
     screen:attach()
     -- Basic test if ":highlight" doesn't crash
-    execute('highlight')
+    execute('set more', 'highlight')
     -- FIXME(tarruda): We need to be sure the prompt is displayed before
     -- continuing, or risk a race condition where some of the following input
     -- is discarded resulting in test failure


### PR DESCRIPTION
Escaping from a '-- More --' prompt in tests is awkward as it doesn't
take keys from the typebuffer, requiring a call to `feed()` in lua at
the correct time. Moreover, it's rarer that a test will want the
'-- More --' prompt to be activeted than not.