### PR TITLE
[RDY] man.vim: call s:error in man#read_page

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -79,7 +79,7 @@ function! man#read_page(ref) abort
     let [sect, name, path] = s:verify_exists(sect, name)
     let page = s:get_page(path)
   catch
-    " call to s:error() is unnecessary
+    call s:error(v:exception)
     return
   endtry
   let b:man_sect = sect


### PR DESCRIPTION
The comment is incorrect, s:error does need to be called. I thought the
call was unnecessary because it didn't show any message for me but I had
shortmess+=F which was hiding the message.

Also see https://github.com/neovim/neovim/pull/6149#discussion_r103350477