### PR TITLE
build: Do not ref `libuv` CMake target if USE_BUNDLED_LIBUV=OFF.

### DIFF
--- a/third-party/cmake/BuildLuv.cmake
+++ b/third-party/cmake/BuildLuv.cmake
@@ -87,5 +87,9 @@ BuildLuv(PATCH_COMMAND ${LUV_PATCH_COMMAND}
   INSTALL_COMMAND ${LUV_INSTALL_COMMAND})
 
 list(APPEND THIRD_PARTY_DEPS luv-static)
-add_dependencies(luv-static luajit)
-add_dependencies(luv-static libuv)
+if(USE_BUNDLED_LUAJIT)
+  add_dependencies(luv-static luajit)
+endif()
+if(USE_BUNDLED_LIBUV)
+  add_dependencies(luv-static libuv)
+endif()


### PR DESCRIPTION
CMake Warning: The dependency target "libuv" of target "luv-static" does
not exist. (CMP0046)

Closes #6355