### PR TITLE
[RFC] lazy flush (better lazyredraw)

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3797,10 +3797,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'lazyredraw'* *'lz'* *'nolazyredraw'* *'nolz'*
 'lazyredraw' 'lz'	boolean	(default off)
 			global
-	When this option is set, the screen will not be redrawn while
-	executing macros, registers and other commands that have not been
-	typed.  Also, updating the window title is postponed.  To force an
-	update use |:redraw|.
+	When this option is set, the screen will only be redrawn before
+	blocking or by |:redraw|.
 
 			*'linebreak'* *'lbr'* *'nolinebreak'* *'nolbr'*
 'linebreak' 'lbr'	boolean	(default off)

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -754,7 +754,7 @@ Short explanation of each option:		*option-list*
 'langmenu'	  'lm'	    language to be used for the menus
 'langnoremap'	  'lnr'	    do not apply 'langmap' to mapped characters
 'laststatus'	  'ls'	    tells when last window has status lines
-'lazyredraw'	  'lz'	    don't redraw while executing macros
+'lazyredraw'	  'lz'	    only redraw before blocking or |:redraw|
 'linebreak'	  'lbr'     wrap long lines at a blank
 'lines'			    number of lines in the display
 'linespace'	  'lsp'     number of pixel lines to use between characters

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7637,6 +7637,7 @@ static void ex_redraw(exarg_T *eap)
   need_wait_return = FALSE;
 
   ui_flush();
+  ui_flush_urgent();
 }
 
 /*

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -69,9 +69,9 @@
 
 #endif
 
-#if __linux__ && MIN_LOG_LEVEL <= DEBUG_LOG_LEVEL
+#if __linux__ && MIN_LOG_LEVEL <= INFO_LOG_LEVEL
 #  include <execinfo.h>
-#  define DLOG_CALL_STACK(prefix) \
+#  define LOG_CALLSTACK(prefix) \
   do { \
     void *trace[100]; \
     int trace_size = backtrace(trace, 100); \
@@ -86,13 +86,13 @@
       FILE *fp = popen(buf, "r"); \
       while (fgets(buf, sizeof(buf) - 1, fp) != NULL) { \
         buf[strlen(buf)-1] = 0; \
-        DLOG(prefix "%s", buf); \
+        ILOG(prefix "%s", buf); \
       } \
       fclose(fp); \
     } \
   } while (0)
 #else
-#  define DLOG_CALL_STACK(prefix) (void)(0)
+#  define LOG_CALLSTACK(prefix) (void)(0)
 #endif
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -96,6 +96,11 @@ int os_inchar(uint8_t *buf, int maxlen, int ms, int tb_change_cnt)
     return (int)rbuffer_read(input_buffer, (char *)buf, (size_t)maxlen);
   }
 
+  // If getchar timeout is longer than 30ms, call ui_flush_urgent for lazyredraw
+  if (ms < 0 || ms > 30) {
+    ui_flush_urgent();
+  }
+
   InbufPollResult result;
   if (ms >= 0) {
     if ((result = inbuf_poll(ms)) == kInputNone) {

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -395,8 +395,8 @@ int ui_current_col(void)
 void ui_flush(void)
 {
   if (!p_lz) {
-    DLOG("ui_flush");
-    // DLOG_CALL_STACK();
+    ILOG("ui_flush");
+    // LOG_CALLSTACK("   ");
     UI_CALL(flush);
   }
   pending_redraw = true;
@@ -408,8 +408,8 @@ void ui_flush(void)
 void ui_flush_urgent(void)
 {
   if (p_lz && pending_redraw) {
-    DLOG("ui_flush_urgent");
-    // DLOG_CALL_STACK("   ");
+    ILOG("ui_flush_urgent");
+    // LOG_CALLSTACK("   ");
     UI_CALL(flush);
     pending_redraw = false;
   }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -396,7 +396,7 @@ int ui_current_col(void)
 void ui_flush(void)
 {
   if (!p_lz) {
-    ILOG("ui_flush");
+    DLOG("ui_flush");
     // LOG_CALLSTACK("   ");
     UI_CALL(flush);
   }
@@ -408,7 +408,7 @@ void ui_flush(void)
 void ui_flush_urgent(void)
 {
   if (p_lz && pending_flush) {
-    ILOG("ui_flush_urgent");
+    DLOG("ui_flush_urgent");
     // LOG_CALLSTACK("   ");
     UI_CALL(flush);
     pending_flush = false;

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -52,7 +52,7 @@ static int current_attr_code = 0;
 static bool pending_cursor_update = false;
 static int busy = 0;
 static int height, width;
-static int pending_redraw = false;
+static int pending_flush = false;
 
 // UI_CALL invokes a function on all registered UI instances. The functions can
 // have 0-5 arguments (configurable by SELECT_NTH).
@@ -392,6 +392,7 @@ int ui_current_col(void)
   return col;
 }
 
+// When 'lazyredraw' is NOT set: force a redraw
 void ui_flush(void)
 {
   if (!p_lz) {
@@ -399,19 +400,18 @@ void ui_flush(void)
     // LOG_CALLSTACK("   ");
     UI_CALL(flush);
   }
-  pending_redraw = true;
+  pending_flush = true;
 }
 
-// ui_flush_urgent is only called by os_inchar for now.  When 'lazydraw' is
-// enabled, we use only this function in os_inchar to redraw before waiting for
-// input while disable all other ui_flush calls.
+// When 'lazyredraw' is set and there is a flush pending: force a redraw
+// ui_flush_urgent is only called by os_inchar & :redraw for now.
 void ui_flush_urgent(void)
 {
-  if (p_lz && pending_redraw) {
+  if (p_lz && pending_flush) {
     ILOG("ui_flush_urgent");
     // LOG_CALLSTACK("   ");
     UI_CALL(flush);
-    pending_redraw = false;
+    pending_flush = false;
   }
 }
 


### PR DESCRIPTION
This simple patch removes all the calls of `ui_flush()` except the one before idle, which makes neovim super smooth in my TUI.  I like this behavior: no unnecessary cursor moving and flicker at all!

Obviously I don't want to have this patch merged.  A practical implementation should also include an option that can disable/enable this behavior (I think `lazyredraw` is very broken now. maybe we can use this to replace it?) and link `:redraw` to a real flush. I just want to hear others' opinion on this.