### PR TITLE
[RFC] UI flush tweaks

### DIFF
--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -383,8 +383,10 @@ static void remote_ui_update_sp(UI *ui, int sp)
 static void remote_ui_flush(UI *ui)
 {
   UIData *data = ui->data;
-  channel_send_event(data->channel_id, "redraw", data->buffer);
-  data->buffer = (Array)ARRAY_DICT_INIT;
+  if (data->buffer.size) {
+    channel_send_event(data->channel_id, "redraw", data->buffer);
+    data->buffer = (Array)ARRAY_DICT_INIT;
+  }
 }
 
 static void remote_ui_suspend(UI *ui)

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -393,7 +393,13 @@ int ui_current_col(void)
 
 void ui_flush(void)
 {
+  int save_row = row;
+  int save_col = col;
+  if (!(State & CMDLINE)) {
+    setcursor();
+  }
   UI_CALL(flush);
+  ui_cursor_goto(save_row, save_col);
 }
 
 static void send_output(uint8_t **ptr)

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -395,7 +395,7 @@ void ui_flush(void)
 {
   int save_row = row;
   int save_col = col;
-  if (!(State & CMDLINE)) {
+  if (!(State & CMDLINE) && need_wait_return == 0 && no_mapping == 0) {
     setcursor();
   }
   UI_CALL(flush);

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -395,7 +395,7 @@ void ui_flush(void)
 {
   int save_row = row;
   int save_col = col;
-  if (!(State & CMDLINE) && need_wait_return == 0 && no_mapping == 0) {
+  if (!(State & CMDLINE) && need_wait_return == 0 && no_mapping < 2) {
     setcursor();
   }
   UI_CALL(flush);


### PR DESCRIPTION
If there's a long enough delay between screen updates, the cursor will appear to jump around. `setcursor()` is called to "finalize" the cursor position before the flush.  The original `row` and `col` is restored because a flush isn't always a complete screen update and subsequent screen operations depend on the cursor position set by `ui_cursor_goto()`.

I also noticed that there were several empty `redraw` events being sent to a remote UI.