### PR TITLE
terminal.c:redraw(): Avoid invalid cursor col

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1155,7 +1155,6 @@ static void redraw(bool restore_cursor)
     save_col = ui_current_col();
   }
   block_autocmds();
-  validate_cursor();
 
   if (must_redraw) {
     update_screen(0);
@@ -1172,7 +1171,7 @@ static void redraw(bool restore_cursor)
     int off = is_focused(term) ? 0 : (curwin->w_p_rl ? 1 : -1);
     curwin->w_cursor.col = MAX(0, term->cursor.col + win_col_off(curwin) + off);
     curwin->w_cursor.coladd = 0;
-    setcursor();
+    mb_check_adjust_col(curwin);
   }
 
   unblock_autocmds();

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -60,16 +60,17 @@ describe('terminal cursor', function()
       ]])
     end)
 
-    pending('is positioned correctly when focused', function()
+    it('is positioned correctly when focused', function()
       feed('i')
+      helpers.wait()
       screen:expect([[
-          1 tty ready                                     |
-          2 {1: }                                             |
-          3                                               |
-          4                                               |
-          5                                               |
-          6                                               |
-        -- TERMINAL --                                    |
+        {7:  1 }tty ready                                     |
+        {7:  2 }{1: }                                             |
+        {7:  3 }                                              |
+        {7:  4 }                                              |
+        {7:  5 }                                              |
+        {7:  6 }                                              |
+        {3:-- TERMINAL --}                                    |
       ]])
     end)
   end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -322,6 +322,7 @@ describe("tui 't_Co' (terminal colors)", function()
       helpers.nvim_prog))
 
     thelpers.feed_data(":echo &t_Co\n")
+    helpers.wait()
     local tline
     if maxcolors == 8 then
       tline = "~                                                 "


### PR DESCRIPTION
#6378 is another case similar to #6203. This time it happens on `terminal_enter()`.

cc @oni-link 