### PR TITLE
[RDY] hl-Syntax should override cursorline and cursorcolumn

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2207,6 +2207,8 @@ win_line (
   int prev_c1 = 0;                      /* first composing char for prev_c */
   int did_line_attr = 0;
 
+  int line_attr_low_priority = 0;       // attribute for current line
+                                        // with very low priority
   bool search_attr_from_match = false;  // if search_attr is from :match
   bool has_bufhl = false;               // this buffer has highlight matches
   int bufhl_attr = 0;                   // attributes desired by bufhl
@@ -2421,10 +2423,18 @@ win_line (
     filler_lines = wp->w_topfill;
   filler_todo = filler_lines;
 
-  /* If this line has a sign with line highlighting set line_attr. */
+  // Cursor line highlighting for 'cursorline' in the current window.  Not
+  // when Visual mode is active, because it's not clear what is selected
+  // then.
+  if (wp->w_p_cul && lnum == wp->w_cursor.lnum
+      && !(wp == curwin && VIsual_active)) {
+    line_attr_low_priority = win_hl_attr(wp, HLF_CUL);
+  }
+
   v = buf_getsigntype(wp->w_buffer, lnum, SIGN_LINEHL);
-  if (v != 0)
-      line_attr = sign_get_attr((int)v, TRUE);
+  if (v != 0) {
+    line_attr = sign_get_attr((int)v, true);
+  }
 
   // Highlight the current line in the quickfix window.
   if (bt_quickfix(wp->w_buffer) && qf_current_entry(wp) == lnum) {
@@ -2435,7 +2445,7 @@ win_line (
     line_attr = hl_combine_attr(wp->w_hl_attr_normal, line_attr);
   }
 
-  if (line_attr != 0) {
+  if (line_attr_low_priority || line_attr) {
     area_highlighting = true;
   }
 
@@ -2651,20 +2661,6 @@ win_line (
     }
     if (shl != &search_hl && cur != NULL)
       cur = cur->next;
-  }
-
-  /* Cursor line highlighting for 'cursorline' in the current window.  Not
-   * when Visual mode is active, because it's not clear what is selected
-   * then. */
-  if (wp->w_p_cul && lnum == wp->w_cursor.lnum
-      && !(wp == curwin && VIsual_active)) {
-    if (line_attr != 0 && !(State & INSERT) && bt_quickfix(wp->w_buffer)
-        && qf_current_entry(wp) == lnum) {
-      line_attr = hl_combine_attr(win_hl_attr(wp, HLF_CUL), line_attr);
-    } else {
-      line_attr = win_hl_attr(wp, HLF_CUL);
-    }
-    area_highlighting = true;
   }
 
   off = (unsigned)(current_ScreenLine - ScreenLines);
@@ -3580,13 +3576,14 @@ win_line (
           // character if the line break is included.
           // For a diff line the highlighting continues after the
           // "$".
-          if (diff_hlf == (hlf_T)0 && line_attr == 0) {
-            /* In virtualedit, visual selections may extend
-             * beyond end of line. */
+          if (diff_hlf == (hlf_T)0
+              && line_attr == 0
+              && line_attr_low_priority == 0) {
+            // In virtualedit, visual selections may extend beyond end of line
             if (area_highlighting && virtual_active()
-                && tocol != MAXCOL && vcol < tocol)
+                && tocol != MAXCOL && vcol < tocol) {
               n_extra = 0;
-            else {
+            } else {
               p_extra = at_end_str;
               n_extra = 1;
               c_extra = NUL;
@@ -3644,7 +3641,7 @@ win_line (
                      (col < wp->w_width))) {
           c = ' ';
           ptr--;  // put it back at the NUL
-        } else if ((diff_hlf != (hlf_T)0 || line_attr != 0)
+        } else if ((diff_hlf != (hlf_T)0 || line_attr_low_priority || line_attr)
                    && (wp->w_p_rl
                        ? (col >= 0)
                        : (col - boguscols < wp->w_width))) {
@@ -3656,7 +3653,8 @@ win_line (
           did_line_attr++;
 
           // don't do search HL for the rest of the line
-          if (line_attr != 0 && char_attr == search_attr && col > 0) {
+          if ((line_attr_low_priority || line_attr)
+              && char_attr == search_attr && col > 0) {
             char_attr = line_attr;
           }
           if (diff_hlf == HLF_TXD) {
@@ -4018,12 +4016,15 @@ win_line (
       if (wp->w_p_cuc && VCOL_HLC == (long)wp->w_virtcol
           && lnum != wp->w_cursor.lnum) {
         vcol_save_attr = char_attr;
-        char_attr = hl_combine_attr(char_attr, win_hl_attr(wp, HLF_CUC));
+        char_attr = hl_combine_attr(win_hl_attr(wp, HLF_CUC), char_attr);
       } else if (draw_color_col && VCOL_HLC == *color_cols) {
         vcol_save_attr = char_attr;
-        char_attr = hl_combine_attr(char_attr, win_hl_attr(wp, HLF_MC));
+        char_attr = hl_combine_attr(win_hl_attr(wp, HLF_MC), char_attr);
       }
     }
+
+    // apply line attr with lowest priority so that everthing can override it
+    char_attr = hl_combine_attr(line_attr_low_priority, char_attr);
 
     /*
      * Store character to be displayed.

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -518,7 +518,7 @@ describe("'listchars' highlight", function()
     ]])
     feed_command('set cursorline')
     screen:expect([[
-      {2:^>-------.}{1:abcd}{2:.}{1:Lorem}{4:>}|
+      {2:^>-------.}{1:abcd}{2:.}{1:Lorem}{3:>}|
       {5:>-------.}abcd{5:*}{4:¬}     |
       {4:¬}                   |
       {4:~                   }|
@@ -526,7 +526,7 @@ describe("'listchars' highlight", function()
     ]])
     feed('$')
     screen:expect([[
-      {4:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
+      {3:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
       {4:<}                   |
       {4:<}                   |
       {4:~                   }|
@@ -607,7 +607,7 @@ describe("'listchars' highlight", function()
     feed('<esc>$')
     screen:expect([[
       {4:<}                   |
-      {4:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
+      {3:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
       {4:<}                   |
       {4:~                   }|
                           |


### PR DESCRIPTION
This patch makes syntax highlight correctly overrides 'cursorline' and 'cursorcolumn'

Before this patch (default json syntax highlights every comment as error):

![2017-03-27_18 53 53_826x446](https://cloud.githubusercontent.com/assets/576382/24385404/be3a13ac-131e-11e7-962a-ec4abfd8cd75.png)
![2017-03-27_18 53 46_826x446](https://cloud.githubusercontent.com/assets/576382/24385403/be39990e-131e-11e7-8e6f-ccb070a1fb58.png)

After this patch:
![2017-03-27_18 47 36_826x446](https://cloud.githubusercontent.com/assets/576382/24385344/880b4fe4-131e-11e7-935d-ae94f5c7230c.png)
![2017-03-27_18 47 35_826x446](https://cloud.githubusercontent.com/assets/576382/24385357/925d1ad6-131e-11e7-9ef6-d3ba7a6e1fa0.png)

While `nvim -d` or "folding" is not affected (This may be good but I don't know exactly why):
![2017-03-27_18 55 55_826x446](https://cloud.githubusercontent.com/assets/576382/24385462/06dca75a-131f-11e7-892b-9e62b9a236d5.png)


