### PR TITLE
[RFC] Windows :terminal support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,6 +351,11 @@ endif()
 find_package(LibVterm REQUIRED)
 include_directories(SYSTEM ${LIBVTERM_INCLUDE_DIRS})
 
+if(WIN32)
+  find_package(Winpty REQUIRED)
+  include_directories(SYSTEM ${WINPTY_INCLUDE_DIRS})
+endif()
+
 option(CLANG_ASAN_UBSAN "Enable Clang address & undefined behavior sanitizer for nvim binary." OFF)
 option(CLANG_MSAN "Enable Clang memory sanitizer for nvim binary." OFF)
 option(CLANG_TSAN "Enable Clang thread sanitizer for nvim binary." OFF)

--- a/cmake/FindWinpty.cmake
+++ b/cmake/FindWinpty.cmake
@@ -1,0 +1,10 @@
+include(LibFindMacros)
+
+find_path(WINPTY_INCLUDE_DIR winpty.h)
+set(WINPTY_INCLUDE_DIRS ${WINPTY_INCLUDE_DIR})
+
+find_library(WINPTY_LIBRARY winpty)
+find_program(WINPTY_AGENT_EXE winpty-agent.exe)
+set(WINPTY_LIBRARIES ${WINPTY_LIBRARY})
+
+find_package_handle_standard_args(Winpty DEFAULT_MSG WINPTY_LIBRARY WINPTY_INCLUDE_DIR)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -111,6 +111,9 @@ foreach(sfile ${NVIM_SOURCES})
   if(WIN32 AND ${f} MATCHES "^(pty_process_unix.c)$")
     list(APPEND to_remove ${sfile})
   endif()
+  if(NOT WIN32 AND ${f} MATCHES "^(pty_process_win.c)$")
+    list(APPEND to_remove ${sfile})
+  endif()
 endforeach()
 
 list(REMOVE_ITEM NVIM_SOURCES ${to_remove})
@@ -348,6 +351,10 @@ endif()
 
 if(Iconv_LIBRARIES)
   list(APPEND NVIM_LINK_LIBRARIES ${Iconv_LIBRARIES})
+endif()
+
+if(WIN32)
+  list(APPEND NVIM_LINK_LIBRARIES ${WINPTY_LIBRARIES})
 endif()
 
 # Put these last on the link line, since multiple things may depend on them.

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -118,10 +118,6 @@ endforeach()
 
 list(REMOVE_ITEM NVIM_SOURCES ${to_remove})
 
-if (NOT WIN32)
-  list(REMOVE_ITEM NVIM_HEADERS "${PROJECT_SOURCE_DIR}/src/nvim/os/pty_process_win.h")
-endif()
-
 # Legacy files that do not yet pass -Wconversion.
 set(CONV_SOURCES
   diff.c

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -422,6 +422,7 @@ if(WIN32)
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/tee.exe"             ${PROJECT_BINARY_DIR}/windows_runtime_deps/
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/tidy.exe"            ${PROJECT_BINARY_DIR}/windows_runtime_deps/
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/win32yank.exe"       ${PROJECT_BINARY_DIR}/windows_runtime_deps/
+    COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/winpty-agent.exe"    ${PROJECT_BINARY_DIR}/windows_runtime_deps/
 
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/D3Dcompiler_47.dll"  ${PROJECT_BINARY_DIR}/windows_runtime_deps/
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/libEGL.dll"          ${PROJECT_BINARY_DIR}/windows_runtime_deps/

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -436,6 +436,7 @@ if(WIN32)
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/Qt5Network.dll"      ${PROJECT_BINARY_DIR}/windows_runtime_deps/
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/Qt5Svg.dll"          ${PROJECT_BINARY_DIR}/windows_runtime_deps/
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/Qt5Widgets.dll"      ${PROJECT_BINARY_DIR}/windows_runtime_deps/
+    COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/winpty.dll"          ${PROJECT_BINARY_DIR}/windows_runtime_deps/
 
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/platforms/qwindows.dll" ${PROJECT_BINARY_DIR}/windows_runtime_deps/platforms/
     )

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -118,6 +118,10 @@ endforeach()
 
 list(REMOVE_ITEM NVIM_SOURCES ${to_remove})
 
+if (NOT WIN32)
+  list(REMOVE_ITEM NVIM_HEADERS "${PROJECT_SOURCE_DIR}/src/nvim/os/pty_process_win.h")
+endif()
+
 # Legacy files that do not yet pass -Wconversion.
 set(CONV_SOURCES
   diff.c

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -535,6 +535,7 @@ endfunction()
 
 set(NO_SINGLE_CHECK_HEADERS
   os/win_defs.h
+  os/pty_process_win.h
   regexp_defs.h
   syntax_defs.h
   terminal.h

--- a/src/nvim/os/pty_process_win.c
+++ b/src/nvim/os/pty_process_win.c
@@ -1,0 +1,189 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "nvim/memory.h"
+#include "nvim/os/pty_process_win.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "os/pty_process_win.c.generated.h"
+#endif
+
+static void CALLBACK pty_process_finish1(void *context, BOOLEAN unused)
+{
+  uv_async_t *finish_async = (uv_async_t *)context;
+  uv_async_send(finish_async);
+}
+
+bool pty_process_spawn(PtyProcess *ptyproc)
+  FUNC_ATTR_NONNULL_ALL
+{
+  Process *proc = (Process *)ptyproc;
+  bool success = false;
+  winpty_error_ptr_t err = NULL;
+  winpty_config_t *cfg = NULL;
+  winpty_spawn_config_t *spawncfg = NULL;
+  winpty_t *wp = NULL;
+  char *in_name = NULL, *out_name = NULL;
+  HANDLE process_handle = NULL;
+
+  assert(proc->in && proc->out && !proc->err);
+
+  if (!(cfg = winpty_config_new(
+      WINPTY_FLAG_ALLOW_CURPROC_DESKTOP_CREATION, &err))) {
+    goto cleanup;
+  }
+  winpty_config_set_initial_size(cfg, ptyproc->width, ptyproc->height);
+
+  if (!(wp = winpty_open(cfg, &err))) {
+    goto cleanup;
+  }
+
+  in_name = utf16_to_utf8(winpty_conin_name(wp));
+  out_name = utf16_to_utf8(winpty_conout_name(wp));
+  uv_pipe_connect(
+      xmalloc(sizeof(uv_connect_t)),
+      &proc->in->uv.pipe,
+      in_name,
+      pty_process_connect_cb);
+  uv_pipe_connect(
+      xmalloc(sizeof(uv_connect_t)),
+      &proc->out->uv.pipe,
+      out_name,
+      pty_process_connect_cb);
+
+  // XXX: Provide the correct ptyprocess parameters (at least, the cmdline...
+  // probably cwd too?  what about environ?)
+  if (!(spawncfg = winpty_spawn_config_new(
+      WINPTY_SPAWN_FLAG_AUTO_SHUTDOWN,
+      L"C:\\Windows\\System32\\cmd.exe",
+      L"C:\\Windows\\System32\\cmd.exe",
+      NULL, NULL,
+      &err))) {
+    goto cleanup;
+  }
+  if (!winpty_spawn(wp, spawncfg, &process_handle, NULL, NULL, &err)) {
+    goto cleanup;
+  }
+
+  uv_async_init(&proc->loop->uv, &ptyproc->finish_async, pty_process_finish2);
+  if (!RegisterWaitForSingleObject(&ptyproc->finish_wait, process_handle,
+      pty_process_finish1, &ptyproc->finish_async, INFINITE, 0)) {
+    abort();
+  }
+
+  ptyproc->wp = wp;
+  ptyproc->process_handle = process_handle;
+  wp = NULL;
+  process_handle = NULL;
+  success = true;
+
+cleanup:
+  winpty_error_free(err);
+  winpty_config_free(cfg);
+  winpty_spawn_config_free(spawncfg);
+  winpty_free(wp);
+  xfree(in_name);
+  xfree(out_name);
+  if (process_handle != NULL) {
+    CloseHandle(process_handle);
+  }
+  return success;
+}
+
+void pty_process_resize(PtyProcess *ptyproc, uint16_t width,
+                        uint16_t height)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (ptyproc->wp != NULL) {
+    winpty_set_size(ptyproc->wp, width, height, NULL);
+  }
+}
+
+void pty_process_close(PtyProcess *ptyproc)
+  FUNC_ATTR_NONNULL_ALL
+{
+  Process *proc = (Process *)ptyproc;
+
+  ptyproc->is_closing = true;
+  pty_process_close_master(ptyproc);
+
+  uv_handle_t *finish_async_handle = (uv_handle_t *)&ptyproc->finish_async;
+  if (ptyproc->finish_wait != NULL) {
+    // Use INVALID_HANDLE_VALUE to block until either the wait is cancelled
+    // or the callback has signalled the uv_async_t.
+    UnregisterWaitEx(ptyproc->finish_wait, INVALID_HANDLE_VALUE);
+    uv_close(finish_async_handle, pty_process_finish_closing);
+  } else {
+    pty_process_finish_closing(finish_async_handle);
+  }
+}
+
+void pty_process_close_master(PtyProcess *ptyproc)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (ptyproc->wp != NULL) {
+    winpty_free(ptyproc->wp);
+    ptyproc->wp = NULL;
+  }
+}
+
+void pty_process_teardown(Loop *loop)
+  FUNC_ATTR_NONNULL_ALL
+{
+}
+
+// Returns a string freeable with xfree.  Never returns NULL (OOM is a fatal
+// error).  Windows appears to replace invalid UTF-16 code points (i.e.
+// unpaired surrogates) using U+FFFD (the replacement character).
+static char *utf16_to_utf8(LPCWSTR str)
+  FUNC_ATTR_NONNULL_ALL
+{
+  int len = WideCharToMultiByte(CP_UTF8, 0, str, -1, NULL, 0, NULL, NULL);
+  assert(len >= 1);  // Even L"" has a non-zero length due to NUL terminator.
+  char *ret = xmalloc(len);
+  int len2 = WideCharToMultiByte(CP_UTF8, 0, str, -1, ret, len, NULL, NULL);
+  assert(len == len2);
+  return ret;
+}
+
+static void pty_process_connect_cb(uv_connect_t *req, int status)
+{
+  assert(status == 0);
+  xfree(req);
+}
+
+static void pty_process_finish2(uv_async_t *finish_async)
+{
+  PtyProcess *ptyproc =
+    (PtyProcess *)((char *)finish_async - offsetof(PtyProcess, finish_async));
+  Process *proc = (Process *)ptyproc;
+
+  if (!ptyproc->is_closing) {
+    // If pty_process_close has already been called, be consistent and never
+    // call the internal_exit callback.
+
+    DWORD exit_code = 0;
+    GetExitCodeProcess(ptyproc->process_handle, &exit_code);
+    proc->status = exit_code;
+
+    if (proc->internal_exit_cb) {
+      proc->internal_exit_cb(proc);
+    }
+  }
+}
+
+static void pty_process_finish_closing(uv_handle_t *finish_async)
+{
+  PtyProcess *ptyproc =
+    (PtyProcess *)((char *)finish_async - offsetof(PtyProcess, finish_async));
+  Process *proc = (Process *)ptyproc;
+
+  if (ptyproc->process_handle != NULL) {
+    CloseHandle(ptyproc->process_handle);
+    ptyproc->process_handle = NULL;
+  }
+  if (proc->internal_close_cb) {
+    proc->internal_close_cb(proc);
+  }
+}

--- a/src/nvim/os/pty_process_win.c
+++ b/src/nvim/os/pty_process_win.c
@@ -19,7 +19,7 @@ static void wait_eof_timer_cb(uv_timer_t* wait_eof_timer)
     (PtyProcess *)((uv_handle_t *)wait_eof_timer->data);
   Process *proc = (Process *)ptyproc;
 
-  if (!uv_is_readable(proc->out->uvstream)) {
+  if (!proc->out || !uv_is_readable(proc->out->uvstream)) {
     uv_timer_stop(&ptyproc->wait_eof_timer);
     pty_process_finish2(ptyproc);
   }
@@ -50,7 +50,7 @@ int pty_process_spawn(PtyProcess *ptyproc)
   uv_connect_t *in_req = NULL, *out_req = NULL;
   wchar_t *cmdline = NULL, *cwd = NULL;
 
-  assert(proc->in && proc->out && !proc->err);
+  assert(!proc->err);
 
   if (!(cfg = winpty_config_new(
       WINPTY_FLAG_ALLOW_CURPROC_DESKTOP_CREATION, &err))) {
@@ -71,18 +71,22 @@ int pty_process_spawn(PtyProcess *ptyproc)
   if ((status = utf16_to_utf8(winpty_conout_name(wp), &out_name))) {
     goto cleanup;
   }
-  in_req = xmalloc(sizeof(uv_connect_t));
-  out_req = xmalloc(sizeof(uv_connect_t));
-  uv_pipe_connect(
-      in_req,
-      &proc->in->uv.pipe,
-      in_name,
-      pty_process_connect_cb);
-  uv_pipe_connect(
-      out_req,
-      &proc->out->uv.pipe,
-      out_name,
-      pty_process_connect_cb);
+  if (proc->in) {
+    in_req = xmalloc(sizeof(uv_connect_t));
+    uv_pipe_connect(
+        in_req,
+        &proc->in->uv.pipe,
+        in_name,
+        pty_process_connect_cb);
+  }
+  if (proc->out) {
+    out_req = xmalloc(sizeof(uv_connect_t));
+    uv_pipe_connect(
+        out_req,
+        &proc->out->uv.pipe,
+        out_name,
+        pty_process_connect_cb);
+  }
 
   if (proc->cwd != NULL && (status = utf8_to_utf16(proc->cwd, &cwd))) {
     goto cleanup;
@@ -107,7 +111,7 @@ int pty_process_spawn(PtyProcess *ptyproc)
     abort();
   }
 
-  while (in_req->handle || out_req->handle) {
+  while ((in_req && in_req->handle) || (out_req && out_req->handle)) {
     uv_run(&proc->loop->uv, UV_RUN_ONCE);
   }
 

--- a/src/nvim/os/pty_process_win.c
+++ b/src/nvim/os/pty_process_win.c
@@ -51,16 +51,19 @@ int pty_process_spawn(PtyProcess *ptyproc)
   winpty_config_set_initial_size(cfg, ptyproc->width, ptyproc->height);
   winpty_object = winpty_open(cfg, &err);
   if (winpty_object == NULL) {
+    write_winpty_elog("Failed, winpty_open.", &status, &err);
     goto cleanup;
   }
 
   status = utf16_to_utf8(winpty_conin_name(winpty_object), &in_name);
   if (status != 0) {
+    write_elog("Failed to convert in_name from utf16 to utf8.", status);
     goto cleanup;
   }
 
   status = utf16_to_utf8(winpty_conout_name(winpty_object), &out_name);
   if (status != 0) {
+    write_elog("Failed to convert out_name from utf16 to utf8.", status);
     goto cleanup;
   }
 
@@ -85,12 +88,14 @@ int pty_process_spawn(PtyProcess *ptyproc)
   if (proc->cwd != NULL) {
     status = utf8_to_utf16(proc->cwd, &cwd);
     if (status != 0) {
+      write_elog("Failed to convert pwd form utf8 to utf16.", status);
       goto cleanup;
     }
   }
 
   status = build_cmd_line(proc->argv, &cmd_line);
   if (status != 0) {
+    write_elog("Failed to convert cmd line form utf8 to utf16.", status);
     goto cleanup;
   }
 
@@ -102,6 +107,7 @@ int pty_process_spawn(PtyProcess *ptyproc)
       NULL,  // Optional environment variables
       &err);
   if (spawncfg == NULL) {
+    write_winpty_elog("Faied winpty_spawn_config_new.", &status, &err);
     goto cleanup;
   }
 
@@ -111,6 +117,7 @@ int pty_process_spawn(PtyProcess *ptyproc)
                     NULL,  // Optional thread handle
                     NULL,  // Optional create process error
                     &err)) {
+    write_winpty_elog("Failed winpty_spawn.", &status, &err);
     goto cleanup;
   }
   proc->pid = GetProcessId(process_handle);
@@ -271,8 +278,6 @@ static int build_cmd_line(char **argv, wchar_t **cmd_line)
   }
 
   int result = utf8_to_utf16(utf8_cmd_line, cmd_line);
-  if (result != 0) {
-  }
   xfree(utf8_cmd_line);
   return result;
 }

--- a/src/nvim/os/pty_process_win.c
+++ b/src/nvim/os/pty_process_win.c
@@ -23,7 +23,7 @@ static void CALLBACK pty_process_finish1(void *context, BOOLEAN unused)
   uv_timer_start(&ptyproc->wait_eof_timer, wait_eof_timer_cb, 200, 200);
 }
 
-/// @returns zero on sucess, or error code of winpty or MultiByteToWideChar.
+/// @returns zero on success, or UV_EAI_FAIL on failure.
 int pty_process_spawn(PtyProcess *ptyproc)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -157,7 +157,7 @@ cleanup:
   xfree(out_req);
   xfree(cmd_line);
   xfree(cwd);
-  return status;
+  return status ? UV_EAI_FAIL : 0;
 }
 
 void pty_process_resize(PtyProcess *ptyproc, uint16_t width,

--- a/src/nvim/os/pty_process_win.c
+++ b/src/nvim/os/pty_process_win.c
@@ -2,30 +2,53 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "nvim/vim.h"
+#include "nvim/ascii.h"
 #include "nvim/memory.h"
+#include "nvim/mbyte.h"  // for utf8_to_utf16, utf16_to_utf8
 #include "nvim/os/pty_process_win.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/pty_process_win.c.generated.h"
 #endif
 
-static void CALLBACK pty_process_finish1(void *context, BOOLEAN unused)
+static void wait_eof_timer_cb(uv_timer_t* wait_eof_timer)
+  FUNC_ATTR_NONNULL_ALL
 {
-  uv_async_t *finish_async = (uv_async_t *)context;
-  uv_async_send(finish_async);
+  PtyProcess *ptyproc =
+    (PtyProcess *)((uv_handle_t *)wait_eof_timer->data);
+  Process *proc = (Process *)ptyproc;
+
+  if (!uv_is_readable(proc->out->uvstream)) {
+    uv_timer_stop(&ptyproc->wait_eof_timer);
+    pty_process_finish2(ptyproc);
+  }
 }
 
-bool pty_process_spawn(PtyProcess *ptyproc)
+static void CALLBACK pty_process_finish1(void *context, BOOLEAN unused)
+  FUNC_ATTR_NONNULL_ALL
+{
+  PtyProcess *ptyproc = (PtyProcess *)context;
+  Process *proc = (Process *)ptyproc;
+
+  uv_timer_init(&proc->loop->uv, &ptyproc->wait_eof_timer);
+  ptyproc->wait_eof_timer.data = (void *)ptyproc;
+  uv_timer_start(&ptyproc->wait_eof_timer, wait_eof_timer_cb, 200, 200);
+}
+
+int pty_process_spawn(PtyProcess *ptyproc)
   FUNC_ATTR_NONNULL_ALL
 {
   Process *proc = (Process *)ptyproc;
-  bool success = false;
+  int status = 0;
   winpty_error_ptr_t err = NULL;
   winpty_config_t *cfg = NULL;
   winpty_spawn_config_t *spawncfg = NULL;
   winpty_t *wp = NULL;
   char *in_name = NULL, *out_name = NULL;
   HANDLE process_handle = NULL;
+  uv_connect_t *in_req = NULL, *out_req = NULL;
+  wchar_t *cmdline = NULL, *cwd = NULL;
 
   assert(proc->in && proc->out && !proc->err);
 
@@ -33,52 +56,70 @@ bool pty_process_spawn(PtyProcess *ptyproc)
       WINPTY_FLAG_ALLOW_CURPROC_DESKTOP_CREATION, &err))) {
     goto cleanup;
   }
-  winpty_config_set_initial_size(cfg, ptyproc->width, ptyproc->height);
+  winpty_config_set_initial_size(
+      cfg,
+      ptyproc->width,
+      ptyproc->height);
 
   if (!(wp = winpty_open(cfg, &err))) {
     goto cleanup;
   }
 
-  in_name = utf16_to_utf8(winpty_conin_name(wp));
-  out_name = utf16_to_utf8(winpty_conout_name(wp));
+  if ((status = utf16_to_utf8(winpty_conin_name(wp), &in_name))) {
+    goto cleanup;
+  }
+  if ((status = utf16_to_utf8(winpty_conout_name(wp), &out_name))) {
+    goto cleanup;
+  }
+  in_req = xmalloc(sizeof(uv_connect_t));
+  out_req = xmalloc(sizeof(uv_connect_t));
   uv_pipe_connect(
-      xmalloc(sizeof(uv_connect_t)),
+      in_req,
       &proc->in->uv.pipe,
       in_name,
       pty_process_connect_cb);
   uv_pipe_connect(
-      xmalloc(sizeof(uv_connect_t)),
+      out_req,
       &proc->out->uv.pipe,
       out_name,
       pty_process_connect_cb);
 
-  // XXX: Provide the correct ptyprocess parameters (at least, the cmdline...
-  // probably cwd too?  what about environ?)
+  if (proc->cwd != NULL && (status = utf8_to_utf16(proc->cwd, &cwd))) {
+    goto cleanup;
+  }
+  if ((status = build_cmdline(proc->argv, &cmdline))) {
+    goto cleanup;
+  }
   if (!(spawncfg = winpty_spawn_config_new(
       WINPTY_SPAWN_FLAG_AUTO_SHUTDOWN,
-      L"C:\\Windows\\System32\\cmd.exe",
-      L"C:\\Windows\\System32\\cmd.exe",
-      NULL, NULL,
-      &err))) {
+      NULL, cmdline, cwd, NULL, &err))) {
     goto cleanup;
   }
   if (!winpty_spawn(wp, spawncfg, &process_handle, NULL, NULL, &err)) {
     goto cleanup;
   }
+  proc->pid = GetProcessId(process_handle);
 
-  uv_async_init(&proc->loop->uv, &ptyproc->finish_async, pty_process_finish2);
-  if (!RegisterWaitForSingleObject(&ptyproc->finish_wait, process_handle,
-      pty_process_finish1, &ptyproc->finish_async, INFINITE, 0)) {
+  if (!RegisterWaitForSingleObject(
+        &ptyproc->finish_wait,
+        process_handle, pty_process_finish1, ptyproc,
+        INFINITE, WT_EXECUTEDEFAULT | WT_EXECUTEONLYONCE)) {
     abort();
+  }
+
+  while (in_req->handle || out_req->handle) {
+    uv_run(&proc->loop->uv, UV_RUN_ONCE);
   }
 
   ptyproc->wp = wp;
   ptyproc->process_handle = process_handle;
   wp = NULL;
   process_handle = NULL;
-  success = true;
 
 cleanup:
+  if (err != NULL) {
+    status = (int)winpty_error_code(err);
+  }
   winpty_error_free(err);
   winpty_config_free(cfg);
   winpty_spawn_config_free(spawncfg);
@@ -88,7 +129,11 @@ cleanup:
   if (process_handle != NULL) {
     CloseHandle(process_handle);
   }
-  return success;
+  xfree(in_req);
+  xfree(out_req);
+  xfree(cmdline);
+  xfree(cwd);
+  return status;
 }
 
 void pty_process_resize(PtyProcess *ptyproc, uint16_t width,
@@ -105,17 +150,10 @@ void pty_process_close(PtyProcess *ptyproc)
 {
   Process *proc = (Process *)ptyproc;
 
-  ptyproc->is_closing = true;
   pty_process_close_master(ptyproc);
 
-  uv_handle_t *finish_async_handle = (uv_handle_t *)&ptyproc->finish_async;
-  if (ptyproc->finish_wait != NULL) {
-    // Use INVALID_HANDLE_VALUE to block until either the wait is cancelled
-    // or the callback has signalled the uv_async_t.
-    UnregisterWaitEx(ptyproc->finish_wait, INVALID_HANDLE_VALUE);
-    uv_close(finish_async_handle, pty_process_finish_closing);
-  } else {
-    pty_process_finish_closing(finish_async_handle);
+  if (proc->internal_close_cb) {
+    proc->internal_close_cb(proc);
   }
 }
 
@@ -133,57 +171,124 @@ void pty_process_teardown(Loop *loop)
 {
 }
 
-// Returns a string freeable with xfree.  Never returns NULL (OOM is a fatal
-// error).  Windows appears to replace invalid UTF-16 code points (i.e.
-// unpaired surrogates) using U+FFFD (the replacement character).
-static char *utf16_to_utf8(LPCWSTR str)
+static void pty_process_connect_cb(uv_connect_t *req, int status)
   FUNC_ATTR_NONNULL_ALL
 {
-  int len = WideCharToMultiByte(CP_UTF8, 0, str, -1, NULL, 0, NULL, NULL);
-  assert(len >= 1);  // Even L"" has a non-zero length due to NUL terminator.
-  char *ret = xmalloc(len);
-  int len2 = WideCharToMultiByte(CP_UTF8, 0, str, -1, ret, len, NULL, NULL);
-  assert(len == len2);
+  assert(status == 0);
+  req->handle = NULL;
+}
+
+static void pty_process_finish2(PtyProcess *ptyproc)
+  FUNC_ATTR_NONNULL_ALL
+{
+  Process *proc = (Process *)ptyproc;
+
+  UnregisterWaitEx(ptyproc->finish_wait, NULL);
+  uv_close((uv_handle_t *)&ptyproc->wait_eof_timer, NULL);
+
+  DWORD exit_code = 0;
+  GetExitCodeProcess(ptyproc->process_handle, &exit_code);
+  proc->status = (int)exit_code;
+
+  CloseHandle(ptyproc->process_handle);
+  ptyproc->process_handle = NULL;
+
+  proc->internal_exit_cb(proc);
+}
+
+static int build_cmdline(char **argv, wchar_t **cmdline)
+  FUNC_ATTR_NONNULL_ALL
+{
+  char *args = NULL;
+  size_t args_len = 0, argc = 0;
+  int ret;
+  QUEUE q;
+  QUEUE_INIT(&q);
+
+  while (*argv) {
+    arg_T *arg = xmalloc(sizeof(arg_T));
+    arg->arg = (char *)xmalloc(strlen(*argv) * 2 + 3);
+    quote_cmd_arg(arg->arg, *argv);
+    args_len += strlen(arg->arg);
+    QUEUE_INIT(&arg->node);
+    QUEUE_INSERT_TAIL(&q, &arg->node);
+    ++argc;
+    ++argv;
+  }
+  args = xmalloc(args_len + argc);
+  *args = NUL;
+  while (1) {
+    QUEUE *head = QUEUE_HEAD(&q);
+    QUEUE_REMOVE(head);
+    arg_T *arg = QUEUE_DATA(head, arg_T, node);
+    strcat(args, arg->arg);
+    xfree(arg->arg);
+    xfree(arg);
+    if (QUEUE_EMPTY(&q)) {
+      break;
+    } else {
+      strcat(args, " ");
+    }
+  }
+  ret = utf8_to_utf16(args, cmdline);
+  xfree(args);
   return ret;
 }
 
-static void pty_process_connect_cb(uv_connect_t *req, int status)
+/*
+ * Emulate quote_cmd_arg of libuv and quotes command line arguments
+ */
+static void quote_cmd_arg(char *target, const char *source)
+  FUNC_ATTR_NONNULL_ALL
 {
-  assert(status == 0);
-  xfree(req);
-}
+  size_t len = strlen(source);
+  size_t i;
+  bool quote_hit = true;
+  char *start = target;
+  char tmp;
 
-static void pty_process_finish2(uv_async_t *finish_async)
-{
-  PtyProcess *ptyproc =
-    (PtyProcess *)((char *)finish_async - offsetof(PtyProcess, finish_async));
-  Process *proc = (Process *)ptyproc;
+  if (len == 0) {
+    *(target++) = '"';
+    *(target++) = '"';
+    *target = NUL;
+    return;
+  }
 
-  if (!ptyproc->is_closing) {
-    // If pty_process_close has already been called, be consistent and never
-    // call the internal_exit callback.
+  if (NULL == strpbrk(source, " \t\"")) {
+    strcpy(target, source);
+    return;
+  }
 
-    DWORD exit_code = 0;
-    GetExitCodeProcess(ptyproc->process_handle, &exit_code);
-    proc->status = exit_code;
+  if (NULL == strpbrk(source, "\"\\")) {
+    *(target++) = '"';
+    strncpy(target, source, len);
+    target += len;
+    *(target++) = '"';
+    *target = NUL;
+    return;
+  }
 
-    if (proc->internal_exit_cb) {
-      proc->internal_exit_cb(proc);
+  *(target++) = NUL;
+  *(target++) = '"';
+  for (i = len; i > 0; --i) {
+    *(target++) = source[i - 1];
+
+    if (quote_hit && source[i - 1] == '\\') {
+      *(target++) = '\\';
+    } else if (source[i - 1] == '"') {
+      quote_hit = true;
+      *(target++) = '\\';
+    } else {
+      quote_hit = false;
     }
   }
-}
-
-static void pty_process_finish_closing(uv_handle_t *finish_async)
-{
-  PtyProcess *ptyproc =
-    (PtyProcess *)((char *)finish_async - offsetof(PtyProcess, finish_async));
-  Process *proc = (Process *)ptyproc;
-
-  if (ptyproc->process_handle != NULL) {
-    CloseHandle(ptyproc->process_handle);
-    ptyproc->process_handle = NULL;
+  *target = '"';
+  while(start < target) {
+    tmp = *start;
+    *start = *target;
+    *target = tmp;
+    ++start;
+    --target;
   }
-  if (proc->internal_close_cb) {
-    proc->internal_close_cb(proc);
-  }
+  return;
 }

--- a/src/nvim/os/pty_process_win.h
+++ b/src/nvim/os/pty_process_win.h
@@ -1,20 +1,22 @@
 #ifndef NVIM_OS_PTY_PROCESS_WIN_H
 #define NVIM_OS_PTY_PROCESS_WIN_H
 
+#include <uv.h>
+
+#include <winpty.h>
+
 #include "nvim/event/libuv_process.h"
 
 typedef struct pty_process {
   Process process;
   char *term_name;
   uint16_t width, height;
+  winpty_t *wp;
+  uv_async_t finish_async;
+  HANDLE finish_wait;
+  HANDLE process_handle;
+  bool is_closing;
 } PtyProcess;
-
-#define pty_process_spawn(job) libuv_process_spawn((LibuvProcess *)job)
-#define pty_process_close(job) libuv_process_close((LibuvProcess *)job)
-#define pty_process_close_master(job) libuv_process_close((LibuvProcess *)job)
-#define pty_process_resize(job, width, height) ( \
-    (void)job, (void)width, (void)height, 0)
-#define pty_process_teardown(loop) ((void)loop, 0)
 
 static inline PtyProcess pty_process_init(Loop *loop, void *data)
 {
@@ -23,7 +25,16 @@ static inline PtyProcess pty_process_init(Loop *loop, void *data)
   rv.term_name = NULL;
   rv.width = 80;
   rv.height = 24;
+  rv.wp = NULL;
+  // XXX: Zero rv.finish_async somehow?
+  rv.finish_wait = NULL;
+  rv.process_handle = NULL;
+  rv.is_closing = false;
   return rv;
 }
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "os/pty_process_win.h.generated.h"
+#endif
 
 #endif  // NVIM_OS_PTY_PROCESS_WIN_H

--- a/src/nvim/os/pty_process_win.h
+++ b/src/nvim/os/pty_process_win.h
@@ -12,16 +12,17 @@ typedef struct pty_process {
   Process process;
   char *term_name;
   uint16_t width, height;
-  winpty_t *wp;
+  winpty_t *winpty_object;
   HANDLE finish_wait;
   HANDLE process_handle;
   uv_timer_t wait_eof_timer;
 } PtyProcess;
 
-typedef struct arg_S {
-  char *arg;
-  QUEUE node;
-} arg_T;
+// Structure used by build_cmd_line()
+typedef struct arg_node {
+  char *arg;  // pointer to argument.
+  QUEUE node;  // QUEUE structure.
+} ArgNode;
 
 static inline PtyProcess pty_process_init(Loop *loop, void *data)
 {
@@ -30,7 +31,7 @@ static inline PtyProcess pty_process_init(Loop *loop, void *data)
   rv.term_name = NULL;
   rv.width = 80;
   rv.height = 24;
-  rv.wp = NULL;
+  rv.winpty_object = NULL;
   rv.finish_wait = NULL;
   rv.process_handle = NULL;
   return rv;

--- a/src/nvim/os/pty_process_win.h
+++ b/src/nvim/os/pty_process_win.h
@@ -36,33 +36,6 @@ static inline PtyProcess pty_process_init(Loop *loop, void *data)
   return rv;
 }
 
-/// Output error log with error code.
-///
-/// @param  emsg  error message.
-/// @param  status  error code.
-///
-static inline void write_elog(const char *emsg, int status)
-{
-  ELOG("%s error code: %d", emsg, status);
-}
-
-/// Get error code from winpty error object and output error log.
-///
-/// @param  emsg  error message.
-/// @param[out]  status  Location where saved error code that converted into
-///                      libuv error.
-/// @param  err  winpty error object.
-///
-static inline void write_winpty_elog(const char *emsg, int *status,
-                                     winpty_error_ptr_t *err)
-{
-  assert(err != NULL && *err != NULL);
-
-  *status = (int)winpty_error_code(*err);
-  write_elog(emsg, *status);
-  *status = translate_winpty_error(*status);
-}
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/pty_process_win.h.generated.h"
 #endif

--- a/src/nvim/os/pty_process_win.h
+++ b/src/nvim/os/pty_process_win.h
@@ -2,7 +2,6 @@
 #define NVIM_OS_PTY_PROCESS_WIN_H
 
 #include <uv.h>
-
 #include <winpty.h>
 
 #include "nvim/event/process.h"
@@ -50,7 +49,8 @@ static inline void write_elog(const char *emsg, int status)
 /// Get error code from winpty error object and output error log.
 ///
 /// @param  emsg  error message.
-/// @param[out]  status  Location where saved error code.
+/// @param[out]  status  Location where saved error code that converted into
+///                      libuv error.
 /// @param  err  winpty error object.
 ///
 static inline void write_winpty_elog(const char *emsg, int *status,
@@ -60,6 +60,7 @@ static inline void write_winpty_elog(const char *emsg, int *status,
 
   *status = (int)winpty_error_code(*err);
   write_elog(emsg, *status);
+  *status = translate_winpty_error(*status);
 }
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/os/pty_process_win.h
+++ b/src/nvim/os/pty_process_win.h
@@ -37,6 +37,31 @@ static inline PtyProcess pty_process_init(Loop *loop, void *data)
   return rv;
 }
 
+/// Output error log with error code.
+///
+/// @param  emsg  error message.
+/// @param  status  error code.
+///
+static inline void write_elog(const char *emsg, int status)
+{
+  ELOG("%s error code: %d", emsg, status);
+}
+
+/// Get error code from winpty error object and output error log.
+///
+/// @param  emsg  error message.
+/// @param[out]  status  Location where saved error code.
+/// @param  err  winpty error object.
+///
+static inline void write_winpty_elog(const char *emsg, int *status,
+                                     winpty_error_ptr_t *err)
+{
+  assert(err != NULL && *err != NULL);
+
+  *status = (int)winpty_error_code(*err);
+  write_elog(emsg, *status);
+}
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/pty_process_win.h.generated.h"
 #endif

--- a/test/functional/fixtures/tty-test.c
+++ b/test/functional/fixtures/tty-test.c
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
   uv_prepare_start(&prepare, prepare_cb);
   // uv_tty_t tty;
 #ifndef WIN32
-  uv_tty_init(uv_default_loop, &tty, fileno(stderr), 1);
+  uv_tty_init(uv_default_loop(), &tty, fileno(stderr), 1);
 #else
   uv_tty_init(uv_default_loop(), &tty, fileno(stdin), 1);
 #endif

--- a/test/functional/fixtures/tty-test.c
+++ b/test/functional/fixtures/tty-test.c
@@ -15,10 +15,12 @@ uv_tty_t tty;
 #include <windows.h>
 bool owns_tty(void)
 {
-  HWND consoleWnd = GetConsoleWindow();
-  DWORD dwProcessId;
-  GetWindowThreadProcessId(consoleWnd, &dwProcessId);
-  return GetCurrentProcessId() == dwProcessId;
+  /* XXX: We need to make proper detect owns tty */
+  /* HWND consoleWnd = GetConsoleWindow(); */
+  /* DWORD dwProcessId; */
+  /* GetWindowThreadProcessId(consoleWnd, &dwProcessId); */
+  /* return GetCurrentProcessId() == dwProcessId; */
+  return true;
 }
 #else
 #include <unistd.h>
@@ -54,15 +56,17 @@ static void sig_handler(int signum)
     return;
   }
 }
+#else
+static void sigwinch_cb(uv_signal_t *handle, int signum)
+{
+  int width, height;
+  uv_tty_t out;
+  uv_tty_init(uv_default_loop(), &out, fileno(stdout), 0);
+  uv_tty_get_winsize(&out, &width, &height);
+  fprintf(stderr, "rows: %d, cols: %d\n", height, width);
+  uv_close((uv_handle_t *)&out, NULL);
+}
 #endif
-
-// static void sigwinch_cb(uv_signal_t *handle, int signum)
-// {
-//   int width, height;
-//   uv_tty_t *tty = handle->data;
-//   uv_tty_get_winsize(tty, &width, &height);
-//   fprintf(stderr, "rows: %d, cols: %d\n", height, width);
-// }
 
 static void alloc_cb(uv_handle_t *handle, size_t suggested, uv_buf_t *buf)
 {
@@ -88,7 +92,7 @@ static void read_cb(uv_stream_t *stream, ssize_t cnt, const uv_buf_t *buf)
   uv_loop_t write_loop;
   uv_loop_init(&write_loop);
   uv_tty_t out;
-  uv_tty_init(&write_loop, &out, 1, 0);
+  uv_tty_init(&write_loop, &out, fileno(stdout), 0);
   uv_write_t req;
   uv_buf_t b = {.base = buf->base, .len = (size_t)cnt};
   uv_write(&req, STRUCT_CAST(uv_stream_t, &out), &b, 1, NULL);
@@ -149,7 +153,11 @@ int main(int argc, char **argv)
   uv_prepare_init(uv_default_loop(), &prepare);
   uv_prepare_start(&prepare, prepare_cb);
   // uv_tty_t tty;
-  uv_tty_init(uv_default_loop(), &tty, fileno(stderr), 1);
+#ifndef WIN32
+  uv_tty_init(uv_default_loop, &tty, fileno(stderr), 1);
+#else
+  uv_tty_init(uv_default_loop(), &tty, fileno(stdin), 1);
+#endif
   uv_tty_set_mode(&tty, UV_TTY_MODE_RAW);
   tty.data = &interrupted;
   uv_read_start(STRUCT_CAST(uv_stream_t, &tty), alloc_cb, read_cb);
@@ -160,15 +168,17 @@ int main(int argc, char **argv)
   sa.sa_handler = sig_handler;
   sigaction(SIGHUP, &sa, NULL);
   sigaction(SIGWINCH, &sa, NULL);
-  // uv_signal_t sigwinch_watcher;
-  // uv_signal_init(uv_default_loop(), &sigwinch_watcher);
-  // sigwinch_watcher.data = &tty;
-  // uv_signal_start(&sigwinch_watcher, sigwinch_cb, SIGWINCH);
+#else
+  uv_signal_t sigwinch_watcher;
+  uv_signal_init(uv_default_loop(), &sigwinch_watcher);
+  uv_signal_start(&sigwinch_watcher, sigwinch_cb, SIGWINCH);
 #endif
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
+#ifndef WIN32
   // XXX: Without this the SIGHUP handler is skipped on some systems.
   sleep(100);
+#endif
 
   return 0;
 }

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -6,8 +6,6 @@ local eval, feed_command, source = helpers.eval, helpers.feed_command, helpers.s
 local eq, neq = helpers.eq, helpers.neq
 local write_file = helpers.write_file
 
-if helpers.pending_win32(pending) then return end
-
 describe('terminal buffer', function()
   local screen
 
@@ -72,6 +70,7 @@ describe('terminal buffer', function()
   end)
 
   it('cannot be modified directly', function()
+    if helpers.pending_win32(pending) then return end
     feed('<c-\\><c-n>dd')
     screen:expect([[
       tty ready                                         |
@@ -160,6 +159,7 @@ describe('terminal buffer', function()
   end)
 
   it('handles loss of focus gracefully', function()
+    if helpers.pending_win32(pending) then return end
     -- Change the statusline to avoid printing the file name, which varies.
     nvim('set_option', 'statusline', '==========')
     feed_command('set laststatus=0')
@@ -205,7 +205,7 @@ describe('terminal buffer', function()
 end)
 
 describe('No heap-buffer-overflow when using', function()
-
+  if helpers.pending_win32(pending) then return end
   local testfilename = 'Xtestfile-functional-terminal-buffers_spec'
 
   before_each(function()

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -7,8 +7,6 @@ local feed_command = helpers.feed_command
 local hide_cursor = thelpers.hide_cursor
 local show_cursor = thelpers.show_cursor
 
-if helpers.pending_win32(pending) then return end
-
 describe('terminal cursor', function()
   local screen
 

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -3,10 +3,10 @@ local Screen = require('test.functional.ui.screen')
 local clear, wait, nvim = helpers.clear, helpers.wait, helpers.nvim
 local nvim_dir, source, eq = helpers.nvim_dir, helpers.source, helpers.eq
 local feed_command, eval = helpers.feed_command, helpers.eval
-
-if helpers.pending_win32(pending) then return end
+local iswin = helpers.iswin
 
 describe(':terminal', function()
+  if helpers.pending_win32(pending) then return end
   local screen
 
   before_each(function()
@@ -174,10 +174,15 @@ describe(':terminal (with fake shell)', function()
     eq('term://', string.match(eval('bufname("%")'), "^term://"))
     helpers.feed([[<C-\><C-N>]])
     feed_command([[find */shadacat.py]])
-    eq('scripts/shadacat.py', eval('bufname("%")'))
+    if iswin() then
+      eq('scripts\\shadacat.py', eval('bufname("%")'))
+    else
+      eq('scripts/shadacat.py', eval('bufname("%")'))
+    end
   end)
 
   it('works with gf', function()
+    if helpers.pending_win32(pending) then return end
     terminal_with_fake_shell([[echo "scripts/shadacat.py"]])
     wait()
     screen:expect([[

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -30,10 +30,6 @@ local function clear_attrs() feed_termcode('[0;10m') end
 -- mouse
 local function enable_mouse() feed_termcode('[?1002h') end
 local function disable_mouse() feed_termcode('[?1002l') end
-local function print_screen_size()
-  helpers.sleep(1000)
-  nvim('command', 'call jobsend(b:terminal_job_id, "\\<C-q>")')
-end
 
 local default_command = '["'..nvim_dir..'/tty-test'..'"]'
 
@@ -115,6 +111,5 @@ return {
   clear_attrs = clear_attrs,
   enable_mouse = enable_mouse,
   disable_mouse = disable_mouse,
-  print_screen_size = print_screen_size,
   screen_setup = screen_setup
 }

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -30,10 +30,9 @@ local function clear_attrs() feed_termcode('[0;10m') end
 -- mouse
 local function enable_mouse() feed_termcode('[?1002h') end
 local function disable_mouse() feed_termcode('[?1002l') end
-local function wait_sigwinch()
+local function print_screen_size()
   helpers.sleep(1000)
-  hide_cursor()
-  show_cursor()
+  nvim('command', 'call jobsend(b:terminal_job_id, "\\<C-q>")')
 end
 
 local default_command = '["'..nvim_dir..'/tty-test'..'"]'
@@ -116,6 +115,6 @@ return {
   clear_attrs = clear_attrs,
   enable_mouse = enable_mouse,
   disable_mouse = disable_mouse,
-  wait_sigwinch = wait_sigwinch,
+  print_screen_size = print_screen_size,
   screen_setup = screen_setup
 }

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -30,9 +30,13 @@ local function clear_attrs() feed_termcode('[0;10m') end
 -- mouse
 local function enable_mouse() feed_termcode('[?1002h') end
 local function disable_mouse() feed_termcode('[?1002l') end
+local function wait_sigwinch()
+  helpers.sleep(1000)
+  hide_cursor()
+  show_cursor()
+end
 
 local default_command = '["'..nvim_dir..'/tty-test'..'"]'
-
 
 local function screen_setup(extra_rows, command, cols)
   extra_rows = extra_rows and extra_rows or 0
@@ -112,5 +116,6 @@ return {
   clear_attrs = clear_attrs,
   enable_mouse = enable_mouse,
   disable_mouse = disable_mouse,
+  wait_sigwinch = wait_sigwinch,
   screen_setup = screen_setup
 }

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -5,8 +5,6 @@ local feed, clear, nvim = helpers.feed, helpers.clear, helpers.nvim
 local nvim_dir, command = helpers.nvim_dir, helpers.command
 local eq, eval = helpers.eq, helpers.eval
 
-if helpers.pending_win32(pending) then return end
-
 describe('terminal window highlighting', function()
   local screen
 
@@ -55,6 +53,7 @@ describe('terminal window highlighting', function()
       end)
 
       local function pass_attrs()
+        if helpers.pending_win32(pending) then return end
         screen:expect(sub([[
           tty ready                                         |
           {NUM:text}text{10: }                                         |
@@ -69,6 +68,7 @@ describe('terminal window highlighting', function()
       it('will pass the corresponding attributes', pass_attrs)
 
       it('will pass the corresponding attributes on scrollback', function()
+        if helpers.pending_win32(pending) then return end
         pass_attrs()
         local lines = {}
         for i = 1, 8 do
@@ -145,6 +145,7 @@ describe('terminal window highlighting with custom palette', function()
   end)
 
   it('will use the custom color', function()
+    if helpers.pending_win32(pending) then return end
     thelpers.set_fg(3)
     thelpers.feed_data('text')
     thelpers.clear_attrs()

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -4,8 +4,6 @@ local clear, eq, eval = helpers.clear, helpers.eq, helpers.eval
 local feed, nvim = helpers.feed, helpers.nvim
 local feed_data = thelpers.feed_data
 
-if helpers.pending_win32(pending) then return end
-
 describe('terminal mouse', function()
   local screen
 
@@ -67,6 +65,7 @@ describe('terminal mouse', function()
       end)
 
       it('will forward mouse clicks to the program', function()
+        if helpers.pending_win32(pending) then return end
         feed('<LeftMouse><1,2>')
         screen:expect([[
           line27                                            |
@@ -80,6 +79,7 @@ describe('terminal mouse', function()
       end)
 
       it('will forward mouse scroll to the program', function()
+        if helpers.pending_win32(pending) then return end
         feed('<ScrollWheelUp><0,0>')
         screen:expect([[
           line27                                            |
@@ -94,6 +94,7 @@ describe('terminal mouse', function()
     end)
 
     describe('with a split window and other buffer', function()
+      if helpers.pending_win32(pending) then return end
       before_each(function()
         feed('<c-\\><c-n>:vsp<cr>')
         screen:expect([[

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -396,7 +396,7 @@ describe("'scrollback' option", function()
 
     curbufmeths.set_option('scrollback', 0)
     if iswin() then
-      feed_data('for($i=1;$i -le 30;$i++){Write-Host \"line$i\"}\13') -- \13 = <CR>
+      feed_data('for($i=1;$i -le 30;$i++){Write-Host \"line$i\"}\r')
     else
       feed_data('for i in $(seq 1 30); do echo "line$i"; done\n')
     end
@@ -422,7 +422,7 @@ describe("'scrollback' option", function()
 
     wait()
     if iswin() then
-      feed_data('for($i=1;$i -le 30;$i++){Write-Host \"line$i\"}\13') -- \13 = <CR>
+      feed_data('for($i=1;$i -le 30;$i++){Write-Host \"line$i\"}\r')
     else
       feed_data('for i in $(seq 1 30); do echo "line$i"; done\n')
     end
@@ -439,7 +439,7 @@ describe("'scrollback' option", function()
     -- 'scrollback' option is synchronized with the internal sb_buffer.
     command('sleep 100m')
     if iswin() then
-      feed_data('for($i=1;$i -le 40;$i++){Write-Host \"line$i\"}\13') -- \13 = <CR>
+      feed_data('for($i=1;$i -le 40;$i++){Write-Host \"line$i\"}\r')
     else
       feed_data('for i in $(seq 1 40); do echo "line$i"; done\n')
     end

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -3,7 +3,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
 local clear, eq, curbuf = helpers.clear, helpers.eq, helpers.curbuf
 local feed, nvim_dir, feed_command = helpers.feed, helpers.nvim_dir, helpers.feed_command
-local iswin, wait_sigwinch = helpers.iswin, thelpers.wait_sigwinch
+local iswin, print_screen_size = helpers.iswin, thelpers.print_screen_size
 local eval = helpers.eval
 local command = helpers.command
 local wait = helpers.wait
@@ -142,7 +142,7 @@ describe('terminal scrollback', function()
       local function will_hide_top_line()
         screen:try_resize(screen._width, screen._height - 1)
         if iswin() then
-          wait_sigwinch()
+          print_screen_size()
         end
         screen:expect([[
           line2                         |
@@ -161,7 +161,7 @@ describe('terminal scrollback', function()
           will_hide_top_line()
           screen:try_resize(screen._width, screen._height - 2)
           if iswin() then
-            wait_sigwinch()
+            print_screen_size()
           end
         end)
 
@@ -190,7 +190,7 @@ describe('terminal scrollback', function()
       before_each(function()
         screen:try_resize(screen._width, screen._height - 2)
         if iswin() then
-          wait_sigwinch()
+          print_screen_size()
         end
       end)
 
@@ -214,7 +214,7 @@ describe('terminal scrollback', function()
           will_delete_last_two_lines()
           screen:try_resize(screen._width, screen._height - 1)
           if iswin() then
-            wait_sigwinch()
+            print_screen_size()
           end
         end)
 
@@ -259,7 +259,7 @@ describe('terminal scrollback', function()
       ]])
       screen:try_resize(screen._width, screen._height - 3)
       if iswin() then
-        wait_sigwinch()
+        print_screen_size()
       end
       screen:expect([[
         line4                         |
@@ -274,7 +274,7 @@ describe('terminal scrollback', function()
       local function pop_then_push()
         screen:try_resize(screen._width, screen._height + 1)
         if iswin() then
-          wait_sigwinch()
+          print_screen_size()
         end
         screen:expect([[
           line4                         |
@@ -293,7 +293,7 @@ describe('terminal scrollback', function()
           eq(8, curbuf('line_count'))
           screen:try_resize(screen._width, screen._height + 3)
           if iswin() then
-            wait_sigwinch()
+            print_screen_size()
           end
         end)
 
@@ -331,7 +331,7 @@ describe('terminal scrollback', function()
             feed('Gi')
             screen:try_resize(screen._width, screen._height + 4)
             if iswin() then
-              wait_sigwinch()
+              print_screen_size()
             end
           end)
 

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -3,7 +3,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
 local clear, eq, curbuf = helpers.clear, helpers.eq, helpers.curbuf
 local feed, nvim_dir, feed_command = helpers.feed, helpers.nvim_dir, helpers.feed_command
-local iswin, print_screen_size = helpers.iswin, thelpers.print_screen_size
+local iswin = helpers.iswin
 local eval = helpers.eval
 local command = helpers.command
 local wait = helpers.wait
@@ -141,10 +141,7 @@ describe('terminal scrollback', function()
     describe('and the height is decreased by 1', function()
       local function will_hide_top_line()
         screen:try_resize(screen._width, screen._height - 1)
-        if iswin() then
-          print_screen_size()
-        end
-        screen:expect([[
+        screen:expect_after_resize([[
           line2                         |
           line3                         |
           line4                         |
@@ -160,13 +157,10 @@ describe('terminal scrollback', function()
         before_each(function()
           will_hide_top_line()
           screen:try_resize(screen._width, screen._height - 2)
-          if iswin() then
-            print_screen_size()
-          end
         end)
 
         it('will hide the top 3 lines', function()
-          screen:expect([[
+          screen:expect_after_resize([[
             rows: 5, cols: 30             |
             rows: 3, cols: 30             |
             {1: }                             |
@@ -189,9 +183,6 @@ describe('terminal scrollback', function()
     describe('and the height is decreased by 2', function()
       before_each(function()
         screen:try_resize(screen._width, screen._height - 2)
-        if iswin() then
-          print_screen_size()
-        end
       end)
 
       local function will_delete_last_two_lines()
@@ -213,9 +204,6 @@ describe('terminal scrollback', function()
         before_each(function()
           will_delete_last_two_lines()
           screen:try_resize(screen._width, screen._height - 1)
-          if iswin() then
-            print_screen_size()
-          end
         end)
 
         it('will delete the last line and hide the first', function()
@@ -258,10 +246,7 @@ describe('terminal scrollback', function()
         {3:-- TERMINAL --}                |
       ]])
       screen:try_resize(screen._width, screen._height - 3)
-      if iswin() then
-        print_screen_size()
-      end
-      screen:expect([[
+      screen:expect_after_resize([[
         line4                         |
         rows: 3, cols: 30             |
         {1: }                             |
@@ -273,10 +258,7 @@ describe('terminal scrollback', function()
     describe('and the height is increased by 1', function()
       local function pop_then_push()
         screen:try_resize(screen._width, screen._height + 1)
-        if iswin() then
-          print_screen_size()
-        end
-        screen:expect([[
+        screen:expect_after_resize([[
           line4                         |
           rows: 3, cols: 30             |
           rows: 4, cols: 30             |
@@ -292,13 +274,10 @@ describe('terminal scrollback', function()
           pop_then_push()
           eq(8, curbuf('line_count'))
           screen:try_resize(screen._width, screen._height + 3)
-          if iswin() then
-            print_screen_size()
-          end
         end)
 
         local function pop3_then_push1()
-          screen:expect([[
+          screen:expect_after_resize([[
             line2                         |
             line3                         |
             line4                         |
@@ -330,9 +309,6 @@ describe('terminal scrollback', function()
             pop3_then_push1()
             feed('Gi')
             screen:try_resize(screen._width, screen._height + 4)
-            if iswin() then
-              print_screen_size()
-            end
           end)
 
           it('will show all lines and leave a blank one at the end', function()

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -437,7 +437,7 @@ describe("'scrollback' option", function()
       screen = thelpers.screen_setup(nil,
       "['powershell.exe', '-NoLogo', '-NoProfile', '-NoExit', '-Command', 'function global:prompt {return "..'"$"'.."}']", 30)
     else
-      screen = thelpers.screen_setup(nil, "['"..shell.."']", 30)
+      screen = thelpers.screen_setup(nil, "['sh']", 30)
     end
 
     curbufmeths.set_option('scrollback', 200)

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -396,8 +396,7 @@ describe("'scrollback' option", function()
 
     curbufmeths.set_option('scrollback', 0)
     if iswin() then
-      nvim('command',
-      'call jobsend(b:terminal_job_id, "for($i=1;$i -le 30;$i++){Write-Host \\"line$i\\"}\\<CR>")')
+      feed_data('for($i=1;$i -le 30;$i++){Write-Host \"line$i\"}\13') -- \13 = <CR>
     else
       feed_data('for i in $(seq 1 30); do echo "line$i"; done\n')
     end
@@ -423,8 +422,7 @@ describe("'scrollback' option", function()
 
     wait()
     if iswin() then
-      nvim('command',
-      'call jobsend(b:terminal_job_id, "for($i=1;$i -le 30;$i++){Write-Host \\"line$i\\"}\\<CR>")')
+      feed_data('for($i=1;$i -le 30;$i++){Write-Host \"line$i\"}\13') -- \13 = <CR>
     else
       feed_data('for i in $(seq 1 30); do echo "line$i"; done\n')
     end
@@ -441,8 +439,7 @@ describe("'scrollback' option", function()
     -- 'scrollback' option is synchronized with the internal sb_buffer.
     command('sleep 100m')
     if iswin() then
-      nvim('command',
-      'call jobsend(b:terminal_job_id, "for($i=1;$i -le 40;$i++){Write-Host \\"line$i\\"}\\<CR>")')
+      feed_data('for($i=1;$i -le 40;$i++){Write-Host \"line$i\"}\13') -- \13 = <CR>
     else
       feed_data('for i in $(seq 1 40); do echo "line$i"; done\n')
     end

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -3,8 +3,6 @@ local thelpers = require('test.functional.terminal.helpers')
 local feed, clear = helpers.feed, helpers.clear
 local wait = helpers.wait
 
-if helpers.pending_win32(pending) then return end
-
 describe('terminal window', function()
   local screen
 

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -263,7 +263,7 @@ end
 
 function Screen:expect_after_resize(expected)
   if iswin() then
-    retry(nil, nil, function()
+    retry(nil, 100000, function()
       nvim('command', 'call jobsend(b:terminal_job_id, "\\<C-q>")')
       self:expect(expected)
     end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -73,6 +73,8 @@
 
 local helpers = require('test.functional.helpers')(nil)
 local request, run, uimeths = helpers.request, helpers.run, helpers.uimeths
+local iswin, nvim, retry = helpers.iswin, helpers.nvim, helpers.retry
+
 local dedent = helpers.dedent
 
 local Screen = {}
@@ -257,6 +259,17 @@ screen:redraw_debug() to show all intermediate screen states.  ]])
       end
     end
   end)
+end
+
+function Screen:expect_after_resize(expected)
+  if iswin() then
+    retry(nil, nil, function()
+      nvim('command', 'call jobsend(b:terminal_job_id, "\\<C-q>")')
+      self:expect(expected)
+    end)
+  else
+    self:expect(expected)
+  end
 end
 
 function Screen:wait(check, timeout)


### PR DESCRIPTION
Implementation based on the work of equalsraf. Changes from the equalsraf work  are as follows.

* Changed uv\_run to be called in pty\_process\_spawn because uv\_connect\_cb was not called before calling uv\_read\_start that caused assert.
* Changed to poll using timer until uv\_is\_readable returns false because it does not stop process output polling until winpty-agent is finished.
* Implemented emulate quotiong of libuv's arguments to build cmdline.
* Changed by changing return value of pty\_process\_spawn.
* Changed to set proc->pid.
* Changed enable some test on windows.
* Changed to use utf16_to_utf8 function implemented in mbyte.c.

We do not think that the place to quote the command line is optimal, so we need to consider it.

If the last sleep of tty-test.c is enabled, the following error occurs in the functionaltest.

```
-- Output to stderr:
Uncaught Error: attempt to call a number value
stack traceback:
        [C]: at 0x67191e2e
```

In the case of Windows, I disabled it, is it really necessary to sleep for 100 seconds even in other environments?

At the moment there are the following problems.

<ul>
<li><del>Nvim will crash in the next step.</del>
<ul>
<li><del>nvim-qt.exe -- -u NONE</del></li>
<li><del>:terminal</del></li>
<li><del>:q</del></li>
</ul>
<del>There is no problem in the case of the following step.</del>
<ul>
<li><del>nvim.exe -u NONE</del></li>
<li><del>nvim-qt.exe --server \\.\pipe\nvim-xxxx-0</del></li>
<li><del>:terminal</del></li>
<li><del>:q</del></li>
</ul>
<del>In this case the errorlevel is also 0.</del></li>
<li><del>In the following procedure E301: Oops, lost the swap file !!! error will occur.</del>
<ul>
<li><del>nvim-qt.exe -- -u NONE</del></li>
<li><del>:e test</del></li>
<li><del>:call termopen("dir")</del></li>
</ul>
</ul>
