### PR TITLE
[RFC] vim-patch:7.4.2343 and mark NA patches

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -41,10 +41,12 @@ NEW_TESTS ?= \
 	    test_fnameescape.res \
 	    test_fold.res \
 	    test_glob2regpat.res \
+	    test_gf.res \
 	    test_gn.res \
 	    test_hardcopy.res \
 	    test_help_tagjump.res \
 	    test_history.res \
+	    test_hlsearch.res \
 	    test_increment.res \
 	    test_increment_dbcs.res \
 	    test_lambda.res \
@@ -57,6 +59,7 @@ NEW_TESTS ?= \
 	    test_normal.res \
 	    test_quickfix.res \
 	    test_signs.res \
+	    test_smartindent.res \
 	    test_substitute.res \
 	    test_syntax.res \
 	    test_tabpage.res \

--- a/src/nvim/testdir/test_charsearch.vim
+++ b/src/nvim/testdir/test_charsearch.vim
@@ -2,8 +2,8 @@
 function! Test_charsearch()
   enew!
   call append(0, ['Xabcdefghijkemnopqretuvwxyz',
-      	\ 'Yabcdefghijkemnopqretuvwxyz',
-      	\ 'Zabcdefghijkemnokqretkvwxyz'])
+	      \ 'Yabcdefghijkemnopqretuvwxyz',
+	      \ 'Zabcdefghijkemnokqretkvwxyz'])
   " check that "fe" and ";" work
   1
   normal! ylfep;;p,,p

--- a/src/nvim/testdir/test_fnameescape.vim
+++ b/src/nvim/testdir/test_fnameescape.vim
@@ -6,7 +6,7 @@ function! Test_fnameescape()
   try
     exe "w! " . fnameescape(fname)
     let status = v:true
-  endtry 
+  endtry
   call assert_true(status, "Space")
   call delete(fname)
 

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -1,0 +1,33 @@
+
+" This is a test if a URL is recognized by "gf", with the cursor before and
+" after the "://".  Also test ":\\".
+function! Test_gf_url()
+  enew!
+  call append(0, [
+      \ "first test for URL://machine.name/tmp/vimtest2a and other text",
+      \ "second test for URL://machine.name/tmp/vimtest2b. And other text",
+      \ "third test for URL:\\\\machine.name\\vimtest2c and other text",
+      \ "fourth test for URL:\\\\machine.name\\tmp\\vimtest2d, and other text"
+      \ ])
+  call cursor(1,1)
+  call search("^first")
+  call search("tmp")
+  call assert_equal("URL://machine.name/tmp/vimtest2a", expand("<cfile>"))
+  call search("^second")
+  call search("URL")
+  call assert_equal("URL://machine.name/tmp/vimtest2b", expand("<cfile>"))
+  if has("ebcdic")
+      set isf=@,240-249,/,.,-,_,+,,,$,:,~,\
+  else
+      set isf=@,48-57,/,.,-,_,+,,,$,:,~,\
+  endif
+  call search("^third")
+  call search("name")
+  call assert_equal("URL:\\\\machine.name\\vimtest2c", expand("<cfile>"))
+  call search("^fourth")
+  call search("URL")
+  call assert_equal("URL:\\\\machine.name\\tmp\\vimtest2d", expand("<cfile>"))
+
+  set isf&vim
+  enew!
+endfunction

--- a/src/nvim/testdir/test_hlsearch.vim
+++ b/src/nvim/testdir/test_hlsearch.vim
@@ -1,0 +1,34 @@
+" Test for v:hlsearch
+
+function! Test_hlsearch()
+  new
+  call setline(1, repeat(['aaa'], 10))
+  set hlsearch nolazyredraw
+  let r=[]
+  " redraw is needed to make hlsearch highlight the matches
+  exe "normal! /aaa\<CR>" | redraw
+  let r1 = screenattr(1, 1)
+  nohlsearch | redraw
+  call assert_notequal(r1, screenattr(1,1))
+  let v:hlsearch=1 | redraw
+  call assert_equal(r1, screenattr(1,1))
+  let v:hlsearch=0 | redraw
+  call assert_notequal(r1, screenattr(1,1))
+  set hlsearch | redraw
+  call assert_equal(r1, screenattr(1,1))
+  let v:hlsearch=0 | redraw
+  call assert_notequal(r1, screenattr(1,1))
+  exe "normal! n" | redraw
+  call assert_equal(r1, screenattr(1,1))
+  let v:hlsearch=0 | redraw
+  call assert_notequal(r1, screenattr(1,1))
+  exe "normal! /\<CR>" | redraw
+  call assert_equal(r1, screenattr(1,1))
+  set nohls
+  exe "normal! /\<CR>" | redraw
+  call assert_notequal(r1, screenattr(1,1))
+  call assert_fails('let v:hlsearch=[]', 'E745')
+  call garbagecollect(1)
+  call getchar(1)
+  enew!
+endfunction

--- a/src/nvim/testdir/test_smartindent.vim
+++ b/src/nvim/testdir/test_smartindent.vim
@@ -1,0 +1,14 @@
+
+" Tests for not doing smart indenting when it isn't set.
+function! Test_nosmartindent()
+  new
+  call append(0, ["		some test text",
+      	\ "		test text",
+      	\ "test text",
+      	\ "		test text"])
+  set nocindent nosmartindent autoindent
+  exe "normal! gg/some\<CR>"
+  exe "normal! 2cc#test\<Esc>"
+  call assert_equal("		#test", getline(1))
+  enew! | close
+endfunction

--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -65,4 +65,34 @@ func Test_duplicate_tagjump()
   call delete('Xfile1')
 endfunc
 
+" Tests for [ CTRL-I and CTRL-W CTRL-I commands
+function Test_keyword_jump()
+  call writefile(["#include Xinclude", "",
+	      \ "",
+	      \ "/* test text test tex start here",
+	      \ "		some text",
+	      \ "		test text",
+	      \ "		start OK if found this line",
+	      \ "	start found wrong line",
+	      \ "test text"], 'Xtestfile')
+  call writefile(["/* test text test tex start here",
+	      \ "		some text",
+	      \ "		test text",
+	      \ "		start OK if found this line",
+	      \ "	start found wrong line",
+	      \ "test text"], 'Xinclude')
+  new Xtestfile
+  call cursor(1,1)
+  call search("start")
+  exe "normal! 5[\<C-I>"
+  call assert_equal("		start OK if found this line", getline('.'))
+  call cursor(1,1)
+  call search("start")
+  exe "normal! 5\<C-W>\<C-I>"
+  call assert_equal("		start OK if found this line", getline('.'))
+  enew! | only
+  call delete('Xtestfile')
+  call delete('Xinclude')
+endfunction
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -98,7 +98,7 @@ static int included_patches[] = {
   2346,
   // 2345 NA
   // 2344 NA
-  // 2343,
+  2343,
   // 2342 NA
   2341,
   // 2340 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -74,10 +74,10 @@ static char *features[] = {
 
 // clang-format off
 static int included_patches[] = {
-  // 2367,
+  // 2367,NA
   // 2366 NA
   // 2365 NA
-  // 2364,
+  // 2364,NA
   // 2363 NA
   2362,
   // 2361 NA

--- a/test/functional/legacy/arglist_spec.lua
+++ b/test/functional/legacy/arglist_spec.lua
@@ -269,4 +269,33 @@ describe('argument list commands', function()
     eq(0, eval('argidx()'))
     execute('%argd')
   end)
+
+
+  it('test for autocommand that redefines the argument list, when doing ":all"', function()
+    execute('autocmd BufReadPost Xxx2 next Xxx2 Xxx1')
+    execute("call writefile(['test file Xxx1'], 'Xxx1')")
+    execute("call writefile(['test file Xxx2'], 'Xxx2')")
+    execute("call writefile(['test file Xxx3'], 'Xxx3')")
+    
+    execute('new')
+    -- redefine arglist; go to Xxx1
+    execute('next! Xxx1 Xxx2 Xxx3')
+    -- open window for all args
+    execute('all')
+    eq('test file Xxx1', eval('getline(1)'))
+    execute('wincmd w')
+    execute('wincmd w')
+    eq('test file Xxx1', eval('getline(1)'))
+    -- should now be in Xxx2
+    execute('rewind')
+    eq('test file Xxx2', eval('getline(1)'))
+    
+    execute('autocmd! BufReadPost Xxx2')
+    execute('enew! | only')
+    execute("call delete('Xxx1')")
+    execute("call delete('Xxx2')")
+    execute("call delete('Xxx3')")
+    execute('argdelete Xxx*')
+    execute('bwipe! Xxx1 Xxx2 Xxx3')
+  end)
 end)


### PR DESCRIPTION
#### vim-patch:7.4.2343
Problem:    Too many old file tests.
Solution:   Turn several into new style tests. (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/53f1673cd909eb1c809c6a9086e3d104a0df9bed

#### patch 7.4.2364
Problem:    Sort test sometimes fails.
Solution:   Add it to the list of flaky tests

https://github.com/vim/vim/commit/e1c8c7a6742be6072290f9aa54ae358060d9c42f


#### patch 7.4.2367
Problem:    Test runner misses a comma.
Solution:   Add the comma.
https://github.com/vim/vim/commit/edeb846c1f04a49466992077eaea3396838bf4fd

mark as NA:
7.4.2364: channel test
7.4.2367: fix for 7.42364