### PR TITLE
ci: Run check-single-includes in "lint" build only

### DIFF
--- a/.ci/common/test.sh
+++ b/.ci/common/test.sh
@@ -109,10 +109,6 @@ run_oldtests() {
   check_core_dumps
 }
 
-run_single_includes_tests() {
-  ${MAKE_CMD} -C "${BUILD_DIR}" check-single-includes
-}
-
 install_nvim() {
   ${MAKE_CMD} -C "${BUILD_DIR}" install
 

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -10,7 +10,6 @@ source "${CI_DIR}/common/test.sh"
 check_core_dumps --delete quiet
 
 prepare_build
-run_single_includes_tests
 build_nvim
 
 if [ "$CLANG_SANITIZER" != "TSAN" ]; then

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ clint:
 		-DLINT_SUPPRESS_URL="$(DOC_DOWNLOAD_URL_BASE)$(CLINT_ERRORS_FILE_PATH)" \
 		-P cmake/RunLint.cmake
 
-lint: clint testlint
-
 check-single-includes: build/.ran-cmake
 	+$(BUILD_CMD) -C build check-single-includes
+
+lint: check-single-includes clint testlint
 
 .PHONY: test testlint functionaltest unittest lint clint clean distclean nvim libnvim cmake deps install

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -461,10 +461,8 @@ foreach(hfile ${NVIM_HEADERS})
 
   if(NOT ${hfile} MATCHES "[.]c[.]h$")
     set(tsource "${GENERATED_DIR}/${r}.test-include.c")
-    set(tresult "${GENERATED_DIR}/${r}.test-include.i")
     string(REPLACE "/" "-" texe "test-incl-${r}")
     write_file("${tsource}" "#include \"${hfile}\"\nint main(int argc, char **argv) { return 0; }")
-    get_preproc_output(PREPROC_OUTPUT ${tresult})
     add_executable(
       ${texe}
       EXCLUDE_FROM_ALL


### PR DESCRIPTION
The check-single-includes step causes [hangs](https://s3.amazonaws.com/archive.travis-ci.org/jobs/216149986/log.txt) on travis. We [crashed](https://github.com/neovim/neovim/pull/6375#issuecomment-289522415) clang at least once, but the hangs are probably not a compiler bug since they are observed on both gcc and clang.

- Actually the last message before the hang always is `Generating auto/.../dispatch_wrappers` so the hang may be related to gendispatch.lua. But it may be indirectly provoked by the `check-single-includes` loop which does a mini-build for each source file.

The "lint" build starts (and finishes) before the other builds anyways, so it makes sense to check single includes there too.

cc @ZyX-I  @bfredl 
