### PR TITLE
Fix latest Coverity issues

### DIFF
--- a/src/coverity-model.c
+++ b/src/coverity-model.c
@@ -64,7 +64,7 @@ void *je_realloc(void *ptr, size_t size)
 // of the memory allocated for item.
 typedef struct {} dictitem_T;
 typedef struct {} dict_T;
-int dict_add(dict_T *d, dictitem_T *item)
+int tv_dict_add(dict_T *const d, dictitem_T *const item)
 {
   __coverity_escape__(item);
 }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11008,18 +11008,19 @@ static void get_user_input(typval_T *argvars, typval_T *rettv, int inputdialog)
     cmdline_row = msg_row;
 
     const char *defstr = "";
+    char buf[NUMBUFLEN];
     if (argvars[1].v_type != VAR_UNKNOWN) {
-      char buf[NUMBUFLEN];
       defstr = tv_get_string_buf_chk(&argvars[1], buf);
       if (defstr != NULL) {
         stuffReadbuffSpec(defstr);
       }
 
       if (!inputdialog && argvars[2].v_type != VAR_UNKNOWN) {
+        char buf2[NUMBUFLEN];
         // input() with a third argument: completion
         rettv->vval.v_string = NULL;
 
-        const char *const xp_name = tv_get_string_buf_chk(&argvars[2], buf);
+        const char *const xp_name = tv_get_string_buf_chk(&argvars[2], buf2);
         if (xp_name == NULL) {
           return;
         }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4670,6 +4670,7 @@ static void nv_ident(cmdarg_T *cap)
   char_u *kp = *curbuf->b_p_kp == NUL ? p_kp : curbuf->b_p_kp;  // 'keywordprg'
   assert(*kp != NUL);  // option.c:do_set() should default to ":help" if empty.
   bool kp_ex = (*kp == ':');  // 'keywordprg' is an ex command
+  bool kp_help = (STRCMP(kp, ":he") == 0 || STRCMP(kp, ":help") == 0);
   size_t buf_size = n * 2 + 30 + STRLEN(kp);
   char *buf = xmalloc(buf_size);
   buf[0] = NUL;
@@ -4692,7 +4693,9 @@ static void nv_ident(cmdarg_T *cap)
     break;
 
   case 'K':
-    if (kp_ex) {
+    if (kp_help) {
+      STRCPY(buf, "he! ");
+    } else if (kp_ex) {
       if (cap->count0 != 0) {  // Send the count to the ex command.
         snprintf(buf, buf_size, "%" PRId64, (int64_t)(cap->count0));
       }
@@ -4755,7 +4758,7 @@ static void nv_ident(cmdarg_T *cap)
   }
 
   // Now grab the chars in the identifier
-  if (cmdchar == 'K') {
+  if (cmdchar == 'K' && !kp_help) {
     ptr = vim_strnsave(ptr, n);
     if (kp_ex) {
       // Escape the argument properly for an Ex command

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1054,13 +1054,15 @@ void set_init_3(void)
  */
 void set_helplang_default(const char *lang)
 {
-  int idx;
-
-  const size_t lang_len = strlen(lang);
-  if (lang == NULL || lang_len < 2) {  // safety check
+  if (lang == NULL) {
     return;
   }
-  idx = findoption("hlg");
+
+  const size_t lang_len = strlen(lang);
+  if (lang_len < 2) {  // safety check
+    return;
+  }
+  int idx = findoption("hlg");
   if (idx >= 0 && !(options[idx].flags & P_WAS_SET)) {
     if (options[idx].flags & P_ALLOCED)
       free_string_option(p_hlg);

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -615,9 +615,9 @@ char *vim_getenv(const char *name)
       vim_path = (char *)p_hf;
     }
 
+    char exe_name[MAXPATHL];
     // Find runtime path relative to the nvim binary: ../share/nvim/runtime
     if (vim_path == NULL) {
-      char exe_name[MAXPATHL];
       size_t exe_name_len = MAXPATHL;
       if (os_exepath(exe_name, &exe_name_len) == 0) {
         char *path_end = (char *)path_tail_with_sep((char_u *)exe_name);


### PR DESCRIPTION
coverity/161194: Restore check for 'keywordprg' being ":help"
coverity/161195: Increase scope of exe_name