### PR TITLE
tui: Only enable/disable mouse when there's something to do

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -452,15 +452,19 @@ static void tui_busy_stop(UI *ui)
 static void tui_mouse_on(UI *ui)
 {
   TUIData *data = ui->data;
-  unibi_out(ui, data->unibi_ext.enable_mouse);
-  data->mouse_enabled = true;
+  if (!data->mouse_enabled) {
+    unibi_out(ui, data->unibi_ext.enable_mouse);
+    data->mouse_enabled = true;
+  }
 }
 
 static void tui_mouse_off(UI *ui)
 {
   TUIData *data = ui->data;
-  unibi_out(ui, data->unibi_ext.disable_mouse);
-  data->mouse_enabled = false;
+  if (data->mouse_enabled) {
+    unibi_out(ui, data->unibi_ext.disable_mouse);
+    data->mouse_enabled = false;
+  }
 }
 
 static void tui_mode_change(UI *ui, int mode)


### PR DESCRIPTION
If we get a mouse_on/mouse_off event, but the mouse is already in the
corresponding state, there's no need to send the event up to the
terminal.

Closes #4394