### PR TITLE
win: os_get_hostname() 

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -1009,7 +1009,7 @@ char *os_resolve_shortcut(const char *fname)
     WCHAR *p;
     const int conversion_result = utf8_to_utf16(fname, &p);
     if (conversion_result != 0) {
-      EMSG2("utf8_to_utf16 failed: %s", uv_strerror(conversion_result));
+      EMSG2("utf8_to_utf16 failed: %d", conversion_result);
     }
 
     if (p != NULL) {

--- a/test/functional/eval/hostname_spec.lua
+++ b/test/functional/eval/hostname_spec.lua
@@ -1,0 +1,17 @@
+local helpers = require('test.functional.helpers')(after_each)
+local ok = helpers.ok
+local call = helpers.call
+local clear = helpers.clear
+
+describe('hostname()', function()
+  before_each(clear)
+
+  it('returns hostname string', function()
+    local actual = call('hostname')
+    ok(string.len(actual) > 1)
+    if call('executable', 'hostname') == 1 then
+      local expected = string.gsub(call('system', 'hostname'), '[\n\r]', '')
+      helpers.eq(expected, actual)
+    end
+  end)
+end)


### PR DESCRIPTION
continues #5416 

---

QB failure is unrelated:

```
not ok 2038 - tui 't_Co' (terminal colors) unknown TERM sets empty 't_Co'
12:59:38,456 INFO  - # test/functional/terminal/tui_spec.lua @ 343
12:59:38,456 INFO  - # Failure message: ./test/functional/ui/screen.lua:306: Row 1 did not match.
12:59:38,456 INFO  - # Expected:
12:59:38,456 INFO  - # |*{1: } |
12:59:38,456 INFO  - # |{4:~ }|
12:59:38,456 INFO  - # |{4:~ }|
12:59:38,456 INFO  - # |{4:~ }|
12:59:38,456 INFO  - # |{5:[No Name] }|
12:59:38,456 INFO  - # | |
12:59:38,456 INFO  - # |{3:-- TERMINAL --} |
12:59:38,456 INFO  - # Actual:
12:59:38,456 INFO  - # |* |
12:59:38,456 INFO  - # |{4:~ }|
12:59:38,456 INFO  - # |{4:~ }|
12:59:38,456 INFO  - # |{4:~ }|
12:59:38,456 INFO  - # |{5:[No Name] }|
12:59:38,456 INFO  - # |{1: } |
12:59:38,456 INFO  - # |{3:-- TERMINAL --} |
```

unrelated travis failure, seen in other builds (see #6483):

https://s3.amazonaws.com/archive.travis-ci.org/jobs/219764587/log.txt

```
[       OK ] ...is/build/neovim/neovim/test/functional/eval/let_spec.lua @ 24: :let command :unlet self-referencing node in a List graph #6070 (2.21 ms)
./test/helpers.lua:27: cannot open ./Xtest-tmpdir/nvimeB0YeP: No such file or directory

stack traceback:
	./test/helpers.lua:27: in function 'glob'
	./test/helpers.lua:195: in function 'check_cores'
	./test/functional/helpers.lua:628: in function <./test/functional/helpers.lua:626>

[----------] 3 tests from /home/travis/build/neovim/neovim/test/functional/eval/let_spec.lua (13.29 ms total)
```