### PR TITLE
[RFC] Enhance error reporting for unit tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -27,8 +27,8 @@ groups by the semantic component they are testing.
 
 Test behaviour is affected by environment variables. Currently supported 
 (Functional, Unit, Benchmarks) (when Defined; when set to _1_; when defined, 
-treated as Integer; when defined, treated as String; !must be defined to 
-function properly):
+treated as Integer; when defined, treated as String; when defined, treated as 
+Number; !must be defined to function properly):
 
 `GDB` (F) (D): makes nvim instances to be run under `gdbserver`. It will be 
 accessible on `localhost:7777`: use `gdb build/bin/nvim`, type `target remote 
@@ -103,11 +103,8 @@ defined and this variable is not) cores are checked for after each test.
 `NVIM_TEST_RUN_TESTTEST` (U) (1): allows running `test/unit/testtest_spec.lua` 
 used to check how testing infrastructure works.
 
-`NVIM_TEST_NO_TRACE` (U) (1): omits getting traces from tests. This means that 
-if tests crashed without core dump you will have no clues regarding where, but 
-this makes tests run a lot faster. Combine with `NVIM_TEST_MAIN_CDEFS` for 
-maximal speed.
-
-`NVIM_TEST_TRACE_EVERYTHING` (U) (1): by default unit test only record C calls 
-which is faster then recording everything. Set this variable to 1 if you want to 
-see all traces.
+`NVIM_TEST_TRACE_LEVEL` (U) (N): specifies unit tests tracing level: `0` 
+disables tracing (the fastest, but you get no data if tests crash and there was 
+no core dump generated), `1` or empty/undefined leaves only C function cals and 
+returns in the trace (faster then recording everything), `2` records all 
+function calls, returns and lua source lines exuecuted.

--- a/test/README.md
+++ b/test/README.md
@@ -99,3 +99,6 @@ get backtrace from).
 approximately 90% of the tests. Should be used when finding cores is too hard 
 for some reason. Normally (on OS X or when `NVIM_TEST_CORE_GLOB_DIRECTORY` is 
 defined and this variable is not) cores are checked for after each test.
+
+`NVIM_TEST_RUN_TESTTEST` (U) (1): allows running `test/unit/testtest_spec.lua` 
+used to check how testing infrastructure works.

--- a/test/README.md
+++ b/test/README.md
@@ -107,3 +107,7 @@ used to check how testing infrastructure works.
 if tests crashed without core dump you will have no clues regarding where, but 
 this makes tests run a lot faster. Combine with `NVIM_TEST_MAIN_CDEFS` for 
 maximal speed.
+
+`NVIM_TEST_TRACE_EVERYTHING` (U) (1): by default unit test only record C calls 
+which is faster then recording everything. Set this variable to 1 if you want to 
+see all traces.

--- a/test/README.md
+++ b/test/README.md
@@ -102,3 +102,8 @@ defined and this variable is not) cores are checked for after each test.
 
 `NVIM_TEST_RUN_TESTTEST` (U) (1): allows running `test/unit/testtest_spec.lua` 
 used to check how testing infrastructure works.
+
+`NVIM_TEST_NO_TRACE` (U) (1): omits getting traces from tests. This means that 
+if tests crashed without core dump you will have no clues regarding where, but 
+this makes tests run a lot faster. Combine with `NVIM_TEST_MAIN_CDEFS` for 
+maximal speed.

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -16,6 +16,7 @@ local eq = global_helpers.eq
 local ok = global_helpers.ok
 local map = global_helpers.map
 local filter = global_helpers.filter
+local dedent = global_helpers.dedent
 
 local start_dir = lfs.currentdir()
 -- XXX: NVIM_PROG takes precedence, QuickBuild sets it.
@@ -189,28 +190,6 @@ local function nvim_feed(input)
     local written = request('nvim_input', input)
     input = input:sub(written + 1)
   end
-end
-
-local function dedent(str)
-  -- find minimum common indent across lines
-  local indent = nil
-  for line in str:gmatch('[^\n]+') do
-    local line_indent = line:match('^%s+') or ''
-    if indent == nil or #line_indent < #indent then
-      indent = line_indent
-    end
-  end
-  if indent == nil or #indent == 0 then
-    -- no minimum common indent
-    return str
-  end
-  -- create a pattern for the indent
-  indent = indent:gsub('%s', '[ \t]')
-  -- strip it from the first line
-  str = str:gsub('^'..indent, '')
-  -- strip it from the remaining lines
-  str = str:gsub('[\n]'..indent, '\n')
-  return str
 end
 
 local function feed(...)

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -251,6 +251,28 @@ local function concat_tables(...)
   return ret
 end
 
+local function dedent(str)
+  -- find minimum common indent across lines
+  local indent = nil
+  for line in str:gmatch('[^\n]+') do
+    local line_indent = line:match('^%s+') or ''
+    if indent == nil or #line_indent < #indent then
+      indent = line_indent
+    end
+  end
+  if indent == nil or #indent == 0 then
+    -- no minimum common indent
+    return str
+  end
+  -- create a pattern for the indent
+  indent = indent:gsub('%s', '[ \t]')
+  -- strip it from the first line
+  str = str:gsub('^'..indent, '')
+  -- strip it from the remaining lines
+  str = str:gsub('[\n]'..indent, '\n')
+  return str
+end
+
 return {
   eq = eq,
   neq = neq,
@@ -265,4 +287,5 @@ return {
   hasenv = hasenv,
   which = which,
   concat_tables = concat_tables,
+  dedent = dedent,
 }

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -704,7 +704,7 @@ local function gen_itp(it)
         itp_child(wr, func)
       else
         sc.close(wr)
-        saved_child_pid = child_pid
+        local saved_child_pid = child_pid
         child_pid = nil
         itp_parent(rd, saved_child_pid, allow_failure)
       end

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -554,8 +554,6 @@ local function gen_itp(it)
         end
       else
         sc.close(wr)
-        sc.wait(child_pid)
-        child_pid = nil
         local function check()
           local res = sc.read(rd, 2)
           eq(2, #res)
@@ -570,6 +568,8 @@ local function gen_itp(it)
           assert.just_fail(err)
         end
         local err, emsg = pcall(check)
+        sc.wait(child_pid)
+        child_pid = nil
         sc.close(rd)
         if not err then
           if allow_failure then

--- a/test/unit/testtest_spec.lua
+++ b/test/unit/testtest_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('test.unit.helpers')(after_each)
 local assert = require('luassert')
+
 local itp = helpers.gen_itp(it)
 
 -- All of the below tests must fail. Check how exactly they fail.

--- a/test/unit/testtest_spec.lua
+++ b/test/unit/testtest_spec.lua
@@ -3,6 +3,8 @@ local assert = require('luassert')
 
 local itp = helpers.gen_itp(it)
 
+local sc = helpers.sc
+
 -- All of the below tests must fail. Check how exactly they fail.
 if os.getenv('NVIM_TEST_RUN_TESTTEST') ~= '1' then
   return
@@ -10,5 +12,8 @@ end
 describe('test code', function()
   itp('does not hang when working with lengthy errors', function()
     assert.just_fail(('x'):rep(65536))
+  end)
+  itp('shows trace after exiting abnormally', function()
+    sc.exit(0)
   end)
 end)

--- a/test/unit/testtest_spec.lua
+++ b/test/unit/testtest_spec.lua
@@ -1,0 +1,13 @@
+local helpers = require('test.unit.helpers')(after_each)
+local assert = require('luassert')
+local itp = helpers.gen_itp(it)
+
+-- All of the below tests must fail. Check how exactly they fail.
+if os.getenv('NVIM_TEST_RUN_TESTTEST') ~= '1' then
+  return
+end
+describe('test code', function()
+  itp('does not hang when working with lengthy errors', function()
+    assert.just_fail(('x'):rep(65536))
+  end)
+end)


### PR DESCRIPTION
This PR adds ability to get traces from the unit tests and report them when test crashed. Useful when test crashes without any core dumps, but rather slow. Example traceback from testtest_spec.vim:

```
./test/unit/helpers.lua:643: (string) 'Test crashed, trace:
lLu @./test/unit/helpers          :child_sethook                 :00594
rLu @./test/unit/helpers          :child_sethook                 :00594
lLu @./test/unit/helpers          :itp_child                     :00600
cCg =[C]                          :pcall                         :nknwn
cL  @test/unit/testtest_spec      :                              :00016
lL  @test/unit/testtest_spec      :                              :00017
cCf =[C]                          :exit                          :nknwn
'
```

I did not add disambiguation of `lLu`/etc to printing code because it appears to be rather not needed, main thing is what `=[C]` function appears in the output last. First character here is what is trace about (_l_ine, _r_eturn, _c_all, _C_ount, _t_ail return), second and third are about what third colum means, see `what` and `namewhat` fields description in https://www.lua.org/manual/5.1/manual.html#lua_Debug (that takes first byte out of field value).