### PR TITLE
fix #6241: "mappings to <Nop> wait forever"

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2056,6 +2056,7 @@ static int vgetorpeek(int advance)
          * place does not matter.
          */
         c = 0;
+        timedout = false;
         new_wcol = curwin->w_wcol;
         new_wrow = curwin->w_wrow;
         if (       advance

--- a/test/functional/normal/map_spec.lua
+++ b/test/functional/normal/map_spec.lua
@@ -1,0 +1,75 @@
+-- See test/functional/legacy/mapping_spec.lua for other tests
+
+local helpers = require('test.functional.helpers')(after_each)
+local clear, feed = helpers.clear, helpers.feed
+local execute = helpers.execute
+local eq = helpers.eq
+local eval = helpers.eval
+local source = helpers.source
+local sleep = helpers.sleep
+
+describe('mapping edge cases', function()
+  if helpers.pending_win32(pending) then return end  -- Need `mkfifo`
+  local fifo_name = 'Xtest-map'
+
+  before_each(function()
+    clear()
+    local script = [[
+      set timeout
+      set timeoutlen=1
+      let a_map_called=0
+      let b_map_called=0
+      function ExprMap(retstring)
+        " Wake up the test thread
+        call system('echo Hello > ]] .. fifo_name .. [[')
+        " Don't worry about time limits on completing mappings.
+        set notimeout
+        return a:retstring
+      endfunction
+    ]]
+    source(script)
+    os.execute('mkfifo ' .. fifo_name)
+  end)
+  after_each(function() os.remove(fifo_name) end)
+
+  -- Requires a timeout of a string suitable to give to the unix `timeout`
+  -- command.
+  local function wait_for(timeout)
+    io.input(fifo_name)
+  end
+
+  it('does not wait for timeout a second time', function()
+    execute("nnoremap aaaa :let a_map_called=1<CR>")
+    execute("nnoremap bb :let b_map_called=1<CR>")
+    execute("nmap <expr> b ExprMap('aaa')")
+    feed('b')
+    -- Wait until the expression times out.
+    wait_for(nil)
+    -- feed 'a' so that the mapping would complete if keys are waited for.
+    -- This won't trigger the map, because vgetorpeek() doesn't attempt to read
+    -- anything due to the 'timedout' setting.
+    -- We don't have to wait because there is no call to os_inchar() between
+    -- the exit of the ExprMap() and finishing the call to eval_map_expr().
+    feed('a')
+    eq(0, eval('a_map_called'))
+  end)
+  it('does not carry over a timeout between user inputs', function()
+    execute("nnoremap <expr> a ExprMap('')",
+            "nnoremap aa :let a_map_called=1<CR>",
+            "nnoremap bb :let b_map_called=1<CR>")
+    feed('a')
+    -- Wait until vim has timed out and called the ExprMap() function
+    wait_for(nil)
+    feed('b')
+    -- Wait enough time that the vgetorpeek() function has had a chance to read
+    -- in the previous input. nvim won't time out on this because notimeout has
+    -- been set in the `a` <expr> map.
+    -- It is possible that we send this input too early so that vgetorpeek()
+    -- reads in the entire 'bb' at once, but not likely.
+    -- This would cause a test pass without actually testing the behaviour we
+    -- want.
+    sleep(100)
+    feed('bl')
+    eq(1, eval('b_map_called'))
+  end)
+end)


### PR DESCRIPTION
vgetorpeek() uses `timedout` to signify whether it should wait for more
keys to complete a partial mapping or not.
Once this has been set, the function expands whatever is the longest
full mapping in the typebuf without waiting for more characters from the
user.
If this expansion results in another possibly incomplete mapping, then
the 'timedout' variable is left-over, and ignores these possibilities.

Bug #6241 was caused because <Nop> is expanded as an empty string into
the typbuffer. This means that vgetorpeek() doesn't return and keeps
waiting for a useful character to come.
Hence vim will take the next key without waiting to see if it is part of
a multi-key map if the user doesn't type quick enough to put more than
one character into the typebuffer at once.
Because in that bug there is a single-key map for <Nop>, this is the one
that is used, perpetuating the problem.

timedout can be reset between checking the typebuffer for characters and
getting input from the user because:
timedout is only used when looking in the typebuffer.
The only time that it could possibly matter that timedout is reset after
looking in the typebuffer is if we don't find a character in the
typbuffer as this is the only time we don't either exit the for loop or
`continue` on the next iteration.
timedout must have previously been set to TRUE, otherwise resetting it
to FALSE doesn't matter.
This means there must be no characters in the typebuffer.

When attempting to get a key from the user, the second chunk of
vgetorpeek() must not `break` out of the for loop with a condition such
that the while() loop will not continue on its iteration.
Otherwise timedout won't be read again (it's only read once, while
checking for mappings).
There are a few places in this chunk that `continue` is used after
setting timedout to TRUE. These won't be affected by the reset of
timedout.
The only times that the loop can continue without timedout being reset,
are either when the end of an input script being reached, or some bytes
are successfully read from the user.

Using these limits, the only time that resetting timedout changes the
behaviour of the function is when a mapping was not completed because of
timeout, and a smaller mapping that was a substring of the timed out
mapping was taken, and (whether after multiple map expansions or just
the one) resulted in a <Nop>.
This had to be a mapping so that the `break` clause is not invoked.
If the mapping actually inserted something, then vgetorpeek() would look
again in typebuf until it either found an unmapped key or couldn't find
anything. If it found an unmapped key, then this key would be returned,
and a reset of timedout between getting a character from typebuf and
from the user doesn't matter.
The only time it can't find anything is when something is mapped to
<Nop>.

In this case the control goes into the section getting input from the
user. Here, there are two possible methods that we could get back into
look_in_typebuf() without resetting timedout.
Either we were reading from a scriptfile, and that now closes, or we
get new input from the user.

When getting new input from the user, we want timedout to be reset, because
otherwise this would mean the user can't use any more maps.

When finishing getting input from the scriptfile I think the same
applies: we want timedout to be reset so that the user (or the next
scriptfile) doesn't get state carried over from the previous file.