### PR TITLE
Account for multiple byte 'pastetoggle' option

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1903,7 +1903,7 @@ static int vgetorpeek(int advance)
           }
 
           if ((mp == NULL || max_mlen >= mp_match_len)
-              && keylen != KEYLEN_PART_MAP) {
+              && keylen != KEYLEN_PART_MAP && keylen != KEYLEN_PART_KEY) {
             // No matching mapping found or found a non-matching mapping that
             // matches at least what the matching mapping matched
             keylen = 0;

--- a/test/functional/options/pastetoggle_spec.lua
+++ b/test/functional/options/pastetoggle_spec.lua
@@ -1,0 +1,37 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local feed = helpers.feed
+local execute = helpers.execute
+local eq = helpers.eq
+local eval = helpers.eval
+local sleep = helpers.sleep
+
+describe("'pastetoggle' option", function()
+  before_each(function()
+    clear()
+    execute('set nopaste')
+    execute('set pastetoggle=a')
+  end)
+  it("toggles 'paste'", function()
+    eq(eval('&paste'), 0)
+    feed('a')
+    -- Need another key so that the vgetorpeek() function returns.
+    feed('j')
+    eq(eval('&paste'), 1)
+  end)
+  it("multiple key 'pastetoggle' is waited for", function()
+    eq(eval('&paste'), 0)
+    local pastetoggle = 'lllll'
+    execute('set pastetoggle=' .. pastetoggle)
+    execute('set timeoutlen=1', 'set ttimoutlen=10000')
+    feed(pastetoggle:sub(0, 2))
+    -- sleep() for long enough that vgetorpeek() is gotten into, but short
+    -- enough that ttimeoutlen is not reached.
+    sleep(200)
+    feed(pastetoggle:sub(3, -1))
+    -- Need another key so that the vgetorpeek() function returns.
+    feed('j')
+    eq(eval('&paste'), 1)
+  end)
+end)


### PR DESCRIPTION
If we `set pastetoggle=abcde`, and manually type it, then `vgetorpeek()`
sees part of the option before it has all been inserted into the
typebuffer.
To signify this it sets `keylen = KEYLEN_PART_KEY`, but the condition
about whether to return the current key from `vgetorpeek()` only checks
for `keylen = KEYLEN_PART_MAP`.
Add a check for `KEYLEN_PART_KEY` to account for the `'pastetoggle'`
option.