### PR TITLE
Preserve cursor shape on suspend/quit

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -146,13 +146,13 @@ static void terminfo_start(UI *ui)
     data->ut = unibi_dummy();
   }
   fix_terminfo(data);
-  // Initialize the cursor shape.
-  unibi_out(ui, data->unibi_ext.set_cursor_shape_block);
   // Set 't_Co' from the result of unibilium & fix_terminfo.
   t_colors = unibi_get_num(data->ut, unibi_max_colors);
   // Enter alternate screen and clear
   unibi_out(ui, unibi_enter_ca_mode);
   unibi_out(ui, unibi_clear_screen);
+  // Initialize the cursor shape.
+  unibi_out(ui, data->unibi_ext.set_cursor_shape_block);
   // Enable bracketed paste
   unibi_out(ui, data->unibi_ext.enable_bracketed_paste);
   // Enable focus reporting


### PR DESCRIPTION
Only change cursor shape after entering altscreen mode, so leaving it will restore the original shape again