### PR TITLE
Default options to ttimeout ttimeoutlen=50

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2505,14 +2505,14 @@ return {
       vi_def=true,
       vim=true,
       varname='p_ttimeout',
-      defaults={if_true={vi=false}}
+      defaults={if_true={vi=true}}
     },
     {
       full_name='ttimeoutlen', abbreviation='ttm',
       type='number', scope={'global'},
       vi_def=true,
       varname='p_ttm',
-      defaults={if_true={vi=-1}}
+      defaults={if_true={vi=50}}
     },
     {
       full_name='ttyfast', abbreviation='tf',


### PR DESCRIPTION
This gives libtermkey 50msec to reässemble split multibyte sequences like DCSes