### PR TITLE
[RFC] vim-patch:8.0.0499,8.0.0550

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2291,7 +2291,7 @@ tabpagebuflist([{arg}])		List	list of buffer numbers in tab page
 tabpagenr([{arg}])		Number	number of current or last tab page
 tabpagewinnr({tabarg}[, {arg}])
 				Number	number of current window in tab page
-taglist({expr})		List	list of tags matching {expr}
+taglist({expr}[, {filename}])	List	list of tags matching {expr}
 tagfiles()			List	tags files used
 tan({expr})			Float	tangent of {expr}
 tanh({expr})			Float	hyperbolic tangent of {expr}
@@ -7427,8 +7427,13 @@ tagfiles()	Returns a |List| with the file names used to search for tags
 		for the current buffer.  This is the 'tags' option expanded.
 
 
-taglist({expr})							*taglist()*
+taglist({expr}[, {filename}])				*taglist()*
 		Returns a list of tags matching the regular expression {expr}.
+
+		If {filename} is passed it is used to prioritize the results
+		in the same way that |:tselect| does. See |tag-priority|.
+		{filename} should be the full path of the file.
+
 		Each list item is a dictionary with at least the following
 		entries:
 			name		Name of the tag.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8728,8 +8728,7 @@ static void f_foldtextresult(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
   fold_count = foldedCount(curwin, lnum, &foldinfo);
   if (fold_count > 0) {
-    text = get_foldtext(curwin, lnum, lnum + fold_count - 1,
-        &foldinfo, buf);
+    text = get_foldtext(curwin, lnum, lnum + fold_count - 1, &foldinfo, buf);
     if (text == buf)
       text = vim_strsave(text);
     rettv->vval.v_string = text;
@@ -16436,7 +16435,12 @@ static void f_taglist(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
-  (void)get_tags(tv_list_alloc_ret(rettv), (char_u *)tag_pattern);
+  const char *fname = NULL;
+  if (argvars[1].v_type != VAR_UNKNOWN) {
+    fname = tv_get_string(&argvars[1]);
+  }
+  (void)get_tags(tv_list_alloc_ret(rettv), (char_u *)tag_pattern,
+                 (char_u *)fname);
 }
 
 /*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8729,8 +8729,9 @@ static void f_foldtextresult(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   fold_count = foldedCount(curwin, lnum, &foldinfo);
   if (fold_count > 0) {
     text = get_foldtext(curwin, lnum, lnum + fold_count - 1, &foldinfo, buf);
-    if (text == buf)
+    if (text == buf) {
       text = vim_strsave(text);
+    }
     rettv->vval.v_string = text;
   }
 }

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -300,7 +300,7 @@ return {
     tabpagenr={args={0, 1}},
     tabpagewinnr={args={1, 2}},
     tagfiles={},
-    taglist={args=1},
+    taglist={args={1, 2}},
     tan={args=1, func="float_op_wrapper", data="&tan"},
     tanh={args=1, func="float_op_wrapper", data="&tanh"},
     tempname={},

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1847,14 +1847,14 @@ parse_line:
               }
             }
           } else {
-#define TAG_SEP 0x01
+#define TAG_SEP 0x02
             size_t tag_fname_len = STRLEN(tag_fname);
             // Save the tag in a buffer.
-            // Use 0x01 to separate fields (Can't use NUL, because the
+            // Use 0x02 to separate fields (Can't use NUL, because the
             // hash key is terminated by NUL).
-            // Emacs tag: <mtt><tag_fname><NUL><ebuf><NUL><lbuf>
-            // other tag: <mtt><tag_fname><NUL><NUL><lbuf>
-            // without Emacs tags: <mtt><tag_fname><NUL><lbuf>
+            // Emacs tag: <mtt><tag_fname><0x02><ebuf><0x02><lbuf><NUL>
+            // other tag: <mtt><tag_fname><0x02><0x02><lbuf><NUL>
+            // without Emacs tags: <mtt><tag_fname><0x02><lbuf><NUL>
             // Here <mtt> is the "mtt" value plus 1 to avoid NUL.
             len = (int)tag_fname_len + (int)STRLEN(lbuf) + 3;
             mfp = xmalloc(sizeof(char_u) + len + 1);

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2797,11 +2797,9 @@ add_tag_field (
   return retval;
 }
 
-/*
- * Add the tags matching the specified pattern to the list "list"
- * as a dictionary
- */
-int get_tags(list_T *list, char_u *pat)
+/// Add the tags matching the specified pattern "pat" to the list "list"
+/// as a dictionary. Use "buf_fname" for priority, unless NULL.
+int get_tags(list_T *list, char_u *pat, char_u *buf_fname)
 {
   int num_matches, i, ret;
   char_u      **matches, *p;
@@ -2811,7 +2809,7 @@ int get_tags(list_T *list, char_u *pat)
   bool is_static;
 
   ret = find_tags(pat, &num_matches, &matches,
-      TAG_REGEXP | TAG_NOIC, (int)MAXCOL, NULL);
+                  TAG_REGEXP | TAG_NOIC, (int)MAXCOL, buf_fname);
   if (ret == OK && num_matches > 0) {
     for (i = 0; i < num_matches; ++i) {
       int parse_result = parse_match(matches[i], &tp);

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -26,6 +26,7 @@ source test_tabline.vim
 " source test_tabpage.vim
 source test_tagcase.vim
 source test_tagjump.vim
+source test_taglist.vim
 source test_true_false.vim
 source test_unlet.vim
 source test_utf8.vim

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -19,3 +19,40 @@ func Test_taglist()
   bwipe
 endfunc
 
+func Test_taglist_native_etags()
+  if !has('emacs_tags')
+    return
+  endif
+  call writefile([
+	\ "\x0c",
+	\ "src/os_unix.c,13491",
+	\ "set_signals(\x7f1335,32699",
+	\ "reset_signals(\x7f1407,34136",
+	\ ], 'Xtags')
+
+  set tags=Xtags
+
+  call assert_equal([['set_signals', '1335,32699'], ['reset_signals', '1407,34136']],
+	\ map(taglist('set_signals'), {i, v -> [v.name, v.cmd]}))
+
+  call delete('Xtags')
+endfunc
+
+func Test_taglist_ctags_etags()
+  if !has('emacs_tags')
+    return
+  endif
+  call writefile([
+	\ "\x0c",
+	\ "src/os_unix.c,13491",
+	\ "set_signals(void)\x7fset_signals\x011335,32699",
+	\ "reset_signals(void)\x7freset_signals\x011407,34136",
+	\ ], 'Xtags')
+
+  set tags=Xtags
+
+  call assert_equal([['set_signals', '1335,32699'], ['reset_signals', '1407,34136']],
+	\ map(taglist('set_signals'), {i, v -> [v.name, v.cmd]}))
+
+  call delete('Xtags')
+endfunc

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -1,0 +1,21 @@
+" test 'taglist' function
+
+func Test_taglist()
+  call writefile([
+	\ "FFoo\tXfoo\t1",
+	\ "FBar\tXfoo\t2",
+	\ "BFoo\tXbar\t1",
+	\ "BBar\tXbar\t2"
+	\ ], 'Xtags')
+  set tags=Xtags
+  split Xtext
+
+  call assert_equal(['FFoo', 'BFoo'], map(taglist("Foo"), {i, v -> v.name}))
+  call assert_equal(['FFoo', 'BFoo'], map(taglist("Foo", "Xtext"), {i, v -> v.name}))
+  call assert_equal(['FFoo', 'BFoo'], map(taglist("Foo", "Xfoo"), {i, v -> v.name}))
+  call assert_equal(['BFoo', 'FFoo'], map(taglist("Foo", "Xbar"), {i, v -> v.name}))
+
+  call delete('Xtags')
+  bwipe
+endfunc
+


### PR DESCRIPTION
#### vim-patch:8.0.0499

Problem:    taglist() does not prioritize tags for a buffer.
Solution:   Add an optional buffer argument. (Duncan McDougall, closes vim/vim#1194)

https://github.com/vim/vim/commit/c6aafbaf3ea755e3ab4ee2e3045911126a08b038


#### vim-patch:8.0.0550

Problem:    Some etags format tags file use 0x01, breaking the parsing.
Solution:   Use 0x02 for TAG_SEP. (James McCoy, closes vim/vim#1614)

https://github.com/vim/vim/commit/9585a1655ba0d34ea88574617112093a9bd4f2e9