### PR TITLE
test/check_cores(): Skip workspace-local temp dir.

### DIFF
--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -17,18 +17,28 @@ local ok = function(res)
   return assert.is_true(res)
 end
 
+-- initial_path:  directory to recurse into
+-- re:            include pattern (string)
+-- exc_re:        exclude pattern(s) (string or table)
 local function glob(initial_path, re, exc_re)
+  exc_re = type(exc_re) == 'table' and exc_re or { exc_re }
   local paths_to_check = {initial_path}
   local ret = {}
   local checked_files = {}
+  local function is_excluded(path)
+    for _, pat in pairs(exc_re) do
+      if path:match(pat) then return true end
+    end
+    return false
+  end
+
   while #paths_to_check > 0 do
     local cur_path = paths_to_check[#paths_to_check]
     paths_to_check[#paths_to_check] = nil
     for e in lfs.dir(cur_path) do
       local full_path = cur_path .. '/' .. e
       local checked_path = full_path:sub(#initial_path + 1)
-      if ((not exc_re or not checked_path:match(exc_re))
-          and e:sub(1, 1) ~= '.') then
+      if (not is_excluded(checked_path)) and e:sub(1, 1) ~= '.' then
         local attrs = lfs.attributes(full_path)
         if attrs then
           local check_key = attrs.dev .. ':' .. tostring(attrs.ino)
@@ -106,13 +116,20 @@ local uname = (function()
   end)
 end)()
 
+local function tmpdir_get()
+  return os.getenv('TMPDIR') and os.getenv('TMPDIR') or os.getenv('TEMP')
+end
+
+-- Is temp directory `dir` defined local to the project workspace?
+local function tmpdir_is_local(dir)
+  return not not (dir and string.find(dir, 'Xtest'))
+end
+
 local tmpname = (function()
   local seq = 0
-  local tmpdir = os.getenv('TMPDIR') and os.getenv('TMPDIR') or os.getenv('TEMP')
-  -- Is $TMPDIR defined local to the project workspace?
-  local in_workspace = not not (tmpdir and string.find(tmpdir, 'Xtest'))
+  local tmpdir = tmpdir_get()
   return (function()
-    if in_workspace then
+    if tmpdir_is_local(tmpdir) then
       -- Cannot control os.tmpname() dir, so hack our own tmpname() impl.
       seq = seq + 1
       local fname = tmpdir..'/nvim-test-lua-'..seq
@@ -168,22 +185,23 @@ local function check_cores(app, force)
   local gdb_db_cmd = 'gdb -n -batch -ex "thread apply all bt full" "$_NVIM_TEST_APP" -c "$_NVIM_TEST_CORE"'
   local lldb_db_cmd = 'lldb -Q -o "bt all" -f "$_NVIM_TEST_APP" -c "$_NVIM_TEST_CORE"'
   local random_skip = false
+  local local_tmpdir = tmpdir_is_local(tmpdir_get()) and tmpdir_get() or nil
   local db_cmd
   if hasenv('NVIM_TEST_CORE_GLOB_DIRECTORY') then
     initial_path = os.getenv('NVIM_TEST_CORE_GLOB_DIRECTORY')
     re = os.getenv('NVIM_TEST_CORE_GLOB_RE')
-    exc_re = os.getenv('NVIM_TEST_CORE_EXC_RE')
+    exc_re = { os.getenv('NVIM_TEST_CORE_EXC_RE'), local_tmpdir }
     db_cmd = os.getenv('NVIM_TEST_CORE_DB_CMD') or gdb_db_cmd
     random_skip = os.getenv('NVIM_TEST_CORE_RANDOM_SKIP')
   elseif os.getenv('TRAVIS_OS_NAME') == 'osx' then
     initial_path = '/cores'
     re = nil
-    exc_re = nil
+    exc_re = { local_tmpdir }
     db_cmd = lldb_db_cmd
   else
     initial_path = '.'
     re = '/core[^/]*$'
-    exc_re = '^/%.deps$'
+    exc_re = { '^/%.deps$', local_tmpdir }
     db_cmd = gdb_db_cmd
     random_skip = true
   end


### PR DESCRIPTION

Avoids this error:

    ./test/helpers.lua:27: cannot open ./Xtest-tmpdir/nvimfqH9dL: No such file or directory
    stack traceback:
        ./test/helpers.lua:27: in function 'glob'
        ./test/helpers.lua:195: in function 'check_cores'
        ./test/functional/helpers.lua:628: in function <./test/functional/helpers.lua:626>

ref https://github.com/neovim/neovim/pull/6236#issuecomment-291392875

cc @ZyX-I 