### PR TITLE
[RFC] vim-patch:8.0.0377,8.0.0378,8.0.0322,8.0.0376

### DIFF
--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1572,6 +1572,10 @@ spell_read_tree (
   int len = get4c(fd);
   if (len < 0)
     return SP_TRUNCERROR;
+  if (len >= 0x3ffffff) {
+    // Invalid length, multiply with sizeof(int) would overflow.
+    return SP_FORMERROR;
+  }
   if (len > 0) {
     // Allocate the byte array.
     bp = xmalloc(len);

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -223,6 +223,7 @@
 //                          few bytes as possible, see offset2bytes())
 
 #include <stdio.h>
+#include <stdint.h>
 #include <wctype.h>
 
 #include "nvim/vim.h"
@@ -1569,10 +1570,10 @@ spell_read_tree (
 
   // The tree size was computed when writing the file, so that we can
   // allocate it as one long block. <nodecount>
-  int len = get4c(fd);
+  long len = get4c(fd);
   if (len < 0)
     return SP_TRUNCERROR;
-  if (len >= 0x3ffffff) {
+  if ((size_t)len >= SIZE_MAX / sizeof(int)) {
     // Invalid length, multiply with sizeof(int) would overflow.
     return SP_FORMERROR;
   }

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1571,8 +1571,9 @@ spell_read_tree (
   // The tree size was computed when writing the file, so that we can
   // allocate it as one long block. <nodecount>
   long len = get4c(fd);
-  if (len < 0)
+  if (len < 0) {
     return SP_TRUNCERROR;
+  }
   if ((size_t)len >= SIZE_MAX / sizeof(int)) {
     // Invalid length, multiply with sizeof(int) would overflow.
     return SP_FORMERROR;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -967,12 +967,12 @@ static u_entry_T *unserialize_uep(bufinfo_T * bi, bool *error,
   uep->ue_lcount = undo_read_4c(bi);
   uep->ue_size = undo_read_4c(bi);
 
-  char_u **array;
+  char_u **array = NULL;
   if (uep->ue_size > 0) {
-    array = xmalloc(sizeof(char_u *) * (size_t)uep->ue_size);
-    memset(array, 0, sizeof(char_u *) * (size_t)uep->ue_size);
-  } else {
-    array = NULL;
+    if ((size_t)uep->ue_size < SIZE_MAX / sizeof(char_u *)) {
+      array = xmalloc(sizeof(char_u *) * (size_t)uep->ue_size);
+      memset(array, 0, sizeof(char_u *) * (size_t)uep->ue_size);
+    }
   }
   uep->ue_array = array;
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -76,6 +76,7 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 #include <fcntl.h>
 
@@ -1400,7 +1401,9 @@ void u_read_undo(char *name, char_u *hash, char_u *orig_name)
   // sequence numbers of the headers.
   // When there are no headers uhp_table is NULL.
   if (num_head > 0) {
-    uhp_table = xmalloc((size_t)num_head * sizeof(u_header_T *));
+    if ((size_t)num_head < SIZE_MAX / sizeof(*uhp_table)) {
+      uhp_table = xmalloc((size_t)num_head * sizeof(*uhp_table));
+    }
   }
 
   long num_read_uhps = 0;


### PR DESCRIPTION
#### vim-patch:8.0.0377

Problem:    Possible overflow when reading corrupted undo file.
Solution:   Check if allocated size is not too big. (King)

https://github.com/vim/vim/commit/3eb1637b1bba19519885dd6d377bd5596e91d22c

CVE-2017-6349


#### vim-patch:8.0.0378

Problem:    Another possible overflow when reading corrupted undo file.
Solution:   Check if allocated size is not too big. (King)

https://github.com/vim/vim/commit/0c8485f0e4931463c0f7986e1ea84a7d79f10c75

CVE-2017-6350

#### vim-patch:8.0.0322

Problem:    Possible overflow with spell file where the tree length is
            corrupted.
Solution:   Check for an invalid length (suggested by shqking)

https://github.com/vim/vim/commit/399c297aa93afe2c0a39e2a1b3f972aebba44c9d

CVE-2017-5953

#### vim-patch:8.0.0376

Problem:    Size computations in spell file reading are not exactly right.
Solution:   Make "len" a "long" and check with LONG_MAX.

https://github.com/vim/vim/commit/6d3c8586fc81b022e9f06c611b9926108fb878c7
