### PR TITLE
[RFC] Fix read-only attribute of swap file on Windows

### DIFF
--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -121,7 +121,12 @@
 #if defined(UNIX)  /* open in rw------- mode */
 # define mch_open_rw(n, f)      os_open((n), (f), (mode_t)0600)
 #else
+# ifdef WIN32
+// libuv emulates S_IWRITE using read only attribute on Windows.
+#  define mch_open_rw(n, f)     os_open((n), (f), S_IWRITE)
+# else
 #  define mch_open_rw(n, f)     os_open((n), (f), 0)
+# endif
 #endif
 
 # define REPLACE_NORMAL(s) (((s) & REPLACE_FLAG) && !((s) & VREPLACE_FLAG))


### PR DESCRIPTION
Because creates swap file with read-only attribute on Windows, E301 error occurs when file name is changed with :file command.

In the following procedure ```E301: Oops, lost the swap file !!!``` error will occur on Windows.
```
nvim -u NONE
:e test
:file test2
E301 Oops, lost the swap file!!!
```

The cause of that is due to next code of libuv/src/win/fs.c. 
```
void fs__open(uv_fs_t* req) {
...
  attributes |= FILE_ATTRIBUTE_NORMAL;
  if (flags & _O_CREAT) {
    if (!((req->fs.info.mode & ~current_umask) & _S_IWRITE)) {
      attributes |= FILE_ATTRIBUTE_READONLY;
    }
  }
```

This problem is solved by passing S_IWRITE to mode in the definition of mch_open_rw.