### PR TITLE
[RDY] macros.h: Convert pos_T macros into mark.h funcs

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -15,6 +15,7 @@
 #include "nvim/func_attr.h"
 #include "nvim/indent.h"
 #include "nvim/main.h"
+#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
@@ -1366,7 +1367,7 @@ void getvcols(win_T *wp, pos_T *pos1, pos_T *pos2, colnr_T *left,
   colnr_T to1;
   colnr_T to2;
 
-  if (ltp(pos1, pos2)) {
+  if (lt(*pos1, *pos2)) {
     getvvcol(wp, pos1, &from1, NULL, &to1);
     getvvcol(wp, pos2, &from2, NULL, &to2);
   } else {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -30,6 +30,7 @@
 #include "nvim/if_cscope.h"
 #include "nvim/indent.h"
 #include "nvim/main.h"
+#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/menu.h"

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -7,6 +7,7 @@
 #include "nvim/eval.h"
 #include "nvim/charset.h"
 #include "nvim/cursor.h"
+#include "nvim/mark.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"
@@ -598,7 +599,7 @@ int get_lisp_indent(void)
     paren = *pos;
     pos = findmatch(NULL, '[');
 
-    if ((pos == NULL) || ltp(pos, &paren)) {
+    if ((pos == NULL) || lt(*pos, paren)) {
       pos = &paren;
     }
   }

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -10,6 +10,7 @@
 #include "nvim/edit.h"
 #include "nvim/indent.h"
 #include "nvim/indent_c.h"
+#include "nvim/mark.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/option.h"

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -29,25 +29,6 @@
 #define S_LEN(s) (s), (sizeof(s) - 1)
 
 /*
- * Position comparisons
- */
-# define lt(a, b) (((a).lnum != (b).lnum) \
-                   ? (a).lnum < (b).lnum \
-                   : (a).col != (b).col \
-                   ? (a).col < (b).col \
-                   : (a).coladd < (b).coladd)
-# define ltp(a, b) (((a)->lnum != (b)->lnum) \
-                    ? (a)->lnum < (b)->lnum \
-                    : (a)->col != (b)->col \
-                    ? (a)->col < (b)->col \
-                    : (a)->coladd < (b)->coladd)
-# define equalpos(a, b) (((a).lnum == (b).lnum) && ((a).col == (b).col) && \
-                         ((a).coladd == (b).coladd))
-# define clearpos(a) {(a)->lnum = 0; (a)->col = 0; (a)->coladd = 0; }
-
-#define ltoreq(a, b) (lt(a, b) || equalpos(a, b))
-
-/*
  * lineempty() - return TRUE if the line is empty
  */
 #define lineempty(p) (*ml_get(p) == NUL)

--- a/src/nvim/mark.h
+++ b/src/nvim/mark.h
@@ -4,6 +4,7 @@
 #include "nvim/macros.h"
 #include "nvim/ascii.h"
 #include "nvim/buffer_defs.h"
+#include "nvim/func_attr.h"
 #include "nvim/mark_defs.h"
 #include "nvim/memory.h"
 #include "nvim/pos.h"
@@ -73,6 +74,45 @@ static inline int mark_local_index(const char name)
                 : (name == '.'
                    ? NMARKS + 2
                    : -1))));
+}
+
+static inline bool lt(pos_T, pos_T) REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
+static inline bool equalpos(pos_T, pos_T)
+  REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
+static inline bool ltoreq(pos_T, pos_T)
+  REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
+static inline void clearpos(pos_T *) REAL_FATTR_ALWAYS_INLINE;
+
+/// Return true if position a is before (less than) position b.
+static inline bool lt(pos_T a, pos_T b)
+{
+  if (a.lnum != b.lnum) {
+    return a.lnum < b.lnum;
+  } else if (a.col != b.col) {
+    return a.col < b.col;
+  } else {
+    return a.coladd < b.coladd;
+  }
+}
+
+/// Return true if position a and b are equal.
+static inline bool equalpos(pos_T a, pos_T b)
+{
+  return (a.lnum == b.lnum) && (a.col == b.col) && (a.coladd == b.coladd);
+}
+
+/// Return true if position a is less than or equal to b.
+static inline bool ltoreq(pos_T a, pos_T b)
+{
+  return lt(a, b) || equalpos(a, b);
+}
+
+/// Clear the pos_T structure pointed to by a.
+static inline void clearpos(pos_T *a)
+{
+  a->lnum = 0;
+  a->col = 0;
+  a->coladd = 0;
 }
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -102,6 +102,7 @@
 #include "nvim/indent.h"
 #include "nvim/getchar.h"
 #include "nvim/main.h"
+#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -92,6 +92,7 @@
 #include "nvim/func_attr.h"
 #include "nvim/getchar.h"
 #include "nvim/hashtab.h"
+#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"


### PR DESCRIPTION
This is #3069 by @wandernauta.

I rebased and fixed a missing include.