### PR TITLE
[RFC] Revise `nvim-from-vim` advice to avoid creating symlinks

### DIFF
--- a/runtime/doc/nvim.txt
+++ b/runtime/doc/nvim.txt
@@ -16,11 +16,11 @@ differences from Vim.
 ==============================================================================
 Transitioning from Vim				*nvim-from-vim*
 
-To start the transition, link your previous configuration so Nvim can use it:
+To start the transition, create `~/.config/nvim/init.vim` with these contents:
 >
-    mkdir ~/.config
-    ln -s ~/.vim ~/.config/nvim
-    ln -s ~/.vimrc ~/.config/nvim/init.vim
+    set runtimepath+=~/.vim,~/.vim/after
+    set packpath+=~/.vim
+    source ~/.vimrc
 <
 Note: If your system sets `$XDG_CONFIG_HOME`, use that instead of `~/.config`
 in the code above. Nvim follows the XDG |base-directories| convention.


### PR DESCRIPTION
There's no issue for this at present, but I can create one if that helps.

The current advice in [`:help nvim-from-vim`](https://neovim.io/doc/user/nvim.html#nvim-from-vim) is to create symlinks:

    mkdir ~/.config
    ln -s ~/.vim ~/.config/nvim
    ln -s ~/.vimrc ~/.config/nvim/init.vim

@justinmk says

> the biggest pain point i'm seeing when people migrate from vim is assumptions in their config or plugins about 'runtimepath'. So even after symlinking, 'rtp' might be set instead of appended/prepended

An alternative approach is to create a `~/.config/nvim/init.vim` file containing just these two lines:

    source ~/.vimrc
    set runtimepath+=~/.vim
