### PR TITLE
[RFC] tests: make locale dependent oldtest more reliable

### DIFF
--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -1606,12 +1606,13 @@ fun! Test_normal30_changecase()
   norm! V~
   call assert_equal('THIS IS A simple test: äüöss', getline('.'))
 
-  " Turkish ASCII turns to multi-byte.  On Mac the Turkish locale is available
-  " but toupper()/tolower() don't do the right thing.
-  if !has('mac') && !has('osx')
-    try
-      lang tr_TR.UTF-8
-      set casemap=
+  " Turkish ASCII turns to multi-byte.  On some systems Turkish locale
+  " is available but toupper()/tolower() don't do the right thing.
+  try
+    lang tr_TR.UTF-8
+    set casemap=
+    let iupper = toupper('i')
+    if iupper == "\u0130"
       call setline(1, 'iI')
       1normal gUU
       call assert_equal("\u0130I", getline(1))
@@ -1621,8 +1622,7 @@ fun! Test_normal30_changecase()
       1normal guu
       call assert_equal("i\u0131", getline(1))
       call assert_equal("i\u0131", tolower("iI"))
-
-      set casemap&
+    elseif iupper == "I"
       call setline(1, 'iI')
       1normal gUU
       call assert_equal("II", getline(1))
@@ -1632,13 +1632,25 @@ fun! Test_normal30_changecase()
       1normal guu
       call assert_equal("ii", getline(1))
       call assert_equal("ii", tolower("iI"))
+    else
+      call assert_true(false, "expected toupper('i') to be either 'I' or '\u0131'")
+    endif
+    set casemap&
+    call setline(1, 'iI')
+    1normal gUU
+    call assert_equal("II", getline(1))
+    call assert_equal("II", toupper("iI"))
 
-      lang en_US.UTF-8
-    catch /E197:/
-      " can't use Turkish locale
-      throw 'Skipped: Turkish locale not available'
-    endtry
-  endif
+    call setline(1, 'iI')
+    1normal guu
+    call assert_equal("ii", getline(1))
+    call assert_equal("ii", tolower("iI"))
+
+    lang en_US.UTF-8
+  catch /E197:/
+    " can't use Turkish locale
+    throw 'Skipped: Turkish locale not available'
+  endtry
 
   " clean up
   bw!


### PR DESCRIPTION
Corresponding change to  #6495 but for oldtests. Wasn't catched by ci as we don't run oldtests on as many platforms as functionaltests. Fixes #6525 