### PR TITLE
[WIP] Send core editor status along with RPC requests and replies

### DIFF
--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -393,7 +393,7 @@ static void remote_ui_update_sp(UI *ui, int sp)
 static void remote_ui_flush(UI *ui)
 {
   UIData *data = ui->data;
-  channel_send_event(data->channel_id, "redraw", data->buffer);
+  channel_send_event(data->channel_id, "redraw", data->buffer, false);
   data->buffer = (Array)ARRAY_DICT_INIT;
 }
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -12,6 +12,7 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/api/buffer.h"
 #include "nvim/msgpack_rpc/channel.h"
+#include "nvim/msgpack_rpc/status_event.h"
 #include "nvim/vim.h"
 #include "nvim/buffer.h"
 #include "nvim/file_search.h"
@@ -678,6 +679,18 @@ void nvim_unsubscribe(uint64_t channel_id, String event)
   e[length] = NUL;
   channel_unsubscribe(channel_id, e);
 }
+
+
+void nvim_status_subscribe(uint64_t channel_id, Boolean active)
+    FUNC_API_SINCE(2) FUNC_API_NOEVAL
+{
+  if (active) {
+    status_event_subscribe(channel_id);
+  } else {
+    status_event_unsubscribe(channel_id);
+  }
+}
+
 
 Integer nvim_get_color_by_name(String name)
     FUNC_API_SINCE(1)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -13707,7 +13707,7 @@ static void f_rpcnotify(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   if (!channel_send_event((uint64_t)argvars[0].vval.v_number,
                           tv_get_string(&argvars[1]),
-                          args)) {
+                          args, false)) {
     EMSG2(_(e_invarg2), "Channel doesn't exist");
     return;
   }

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -47,6 +47,7 @@ MAP_DECLS(linenr_T, bufhl_vec_T)
 #define pmap_get(T) map_get(T, ptr_t)
 #define pmap_has(T) map_has(T, ptr_t)
 #define pmap_put(T) map_put(T, ptr_t)
+#define pmap_ref(T) map_ref(T, ptr_t)
 #define pmap_del(T) map_del(T, ptr_t)
 #define pmap_clear(T) map_clear(T, ptr_t)
 

--- a/src/nvim/msgpack_rpc/status_event.c
+++ b/src/nvim/msgpack_rpc/status_event.c
@@ -1,0 +1,74 @@
+#include <stdbool.h>
+#include <inttypes.h>
+
+#include "nvim/api/private/helpers.h"
+#include "nvim/map.h"
+#include "nvim/msgpack_rpc/channel.h"
+#include "nvim/msgpack_rpc/status_event.h"
+#include "nvim/memory.h"
+
+static PMap(uint64_t) *channels = NULL;
+
+/// Initializes the module
+void status_event_init(void)
+{
+  channels = pmap_new(uint64_t)();
+}
+
+void status_event_subscribe(uint64_t channel_id) {
+  StatusInfo **ref = (StatusInfo **)pmap_ref(uint64_t)(channels, channel_id, true);
+  if (!*ref) {
+    *ref = xmalloc(sizeof(**ref));
+  }
+  StatusInfo *status = *ref;
+  status->last_curbuf = -1;
+  status->last_curwin = -1;
+  status->last_curtab = -1;
+}
+
+void status_event_unsubscribe(uint64_t channel_id) {
+  StatusInfo *status = pmap_del(uint64_t)(channels, channel_id);
+  if (status) {
+    xfree(status);
+  }
+}
+
+
+static void update(uint64_t channel_id, StatusInfo *status) {
+  Dictionary update = ARRAY_DICT_INIT;
+  if (curbuf->handle != status->last_curbuf) {
+    PUT(update, "curbuf", BUFFER_OBJ(curbuf->handle));
+    status->last_curbuf = curbuf->handle;
+  }
+  if (curwin->handle != status->last_curwin) {
+    PUT(update, "curwin", BUFFER_OBJ(curwin->handle));
+    status->last_curwin = curwin->handle;
+  }
+  if (curtab->handle != status->last_curtab) {
+    PUT(update, "curtab", BUFFER_OBJ(curtab->handle));
+    status->last_curtab = curtab->handle;
+  }
+  if (update.size > 0) {
+    Array args = ARRAY_DICT_INIT;
+    ADD(args, DICTIONARY_OBJ(update));
+    channel_send_event(channel_id, "nvim_status", args, true);
+  }
+}
+
+
+void status_event_update(uint64_t channel_id) {
+  StatusInfo *status = pmap_get(uint64_t)(channels, channel_id);
+  if (status) {
+    update(channel_id, status);
+  }
+}
+
+void status_event_update_all(void) {
+  uint64_t channel_id;
+  StatusInfo *status;
+  map_foreach(channels, channel_id, status, {
+    update(channel_id, status);
+  });
+}
+
+

--- a/src/nvim/msgpack_rpc/status_event.h
+++ b/src/nvim/msgpack_rpc/status_event.h
@@ -1,0 +1,13 @@
+#ifndef NVIM_MSGPACK_RPC_STATUS_EVENT_H
+#define NVIM_MSGPACK_RPC_STATUS_EVENT_H
+
+typedef struct {
+  handle_T last_curbuf;
+  handle_T last_curwin;
+  handle_T last_curtab;
+} StatusInfo;
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "msgpack_rpc/status_event.h.generated.h"
+#endif
+#endif  // NVIM_MSGPACK_RPC_STATUS_EVENT_H

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -6,6 +6,7 @@
 #include "nvim/state.h"
 #include "nvim/vim.h"
 #include "nvim/main.h"
+#include "nvim/msgpack_rpc/status_event.h"
 #include "nvim/getchar.h"
 #include "nvim/option_defs.h"
 #include "nvim/ui.h"
@@ -41,6 +42,7 @@ getkey:
     } else {
       input_enable_events();
       // Flush screen updates before blocking
+      status_event_update_all();
       ui_flush();
       // Call `os_inchar` directly to block for events or user input without
       // consuming anything from `input_buffer`(os/input.c) or calling the


### PR DESCRIPTION
This sketches an optimization that has been discussed before (but too lazy too find it now), for certain core editor state, instead of rpc clients querying nvim it might be better if nvim sends updates when rpc clients should use a different current buffer etc.

Note that this is quite distinct from autocommands, autocmds are performed whenever an operation was done that changes state, and might be blocked explicitly or because vimL must not be run right now. This instead sends updates whenever control is transferred to  rpc methods (including replies to requests, if the request changed some value) so that the method can use the sent or cached value instead of needing another roundtrip (or many roundtrips as could happen in legacy scripts) to do `nvim_get_current_buffer`, or when returning to the main event loop when nvim might receive async calls (not complete yet, and harder to be completely reliable) 

Currently this only keeps track of current objects, but other state could be relevant. For instance the legacy python host will potentially call `nvim_list_runtime_paths` any time an `import` is done, even an `import` in another thread, which is not thread-safe. Instead a cached value can be used, which is only invalidated when `&rtp` changes, which happens far less often than `vim.list_runtime_paths()` being called.

python-client [branch](https://github.com/neovim/python-client/compare/master...bfredl:statusupdate?expand=1) (also very WIP)