### PR TITLE
Fix folding problem with :move

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2769,6 +2769,11 @@ void foldMoveRange(garray_T *gap, const linenr_T line1, const linenr_T line2,
   // order.
   // We have to swap folds in the range [move_end, dest_index) with those in
   // the range [move_start, move_end).
+  if (move_end == 0) {
+    // There are no folds after those moved, hence no folds have been moved out
+    // of order.
+    return;
+  }
   reverse_fold_order(gap, move_start, dest_index - 1);
   reverse_fold_order(gap, move_start, move_start + dest_index - move_end - 1);
   reverse_fold_order(gap, move_start + dest_index - move_end, dest_index - 1);

--- a/test/functional/normal/fold_spec.lua
+++ b/test/functional/normal/fold_spec.lua
@@ -232,6 +232,25 @@ a
 a]], '2,3m0')
       eq({1, 2, 0, 0, 0}, get_folds())
     end)
+    it('handles shifting all remaining folds', function()
+      test_move_indent([[
+	a
+		a
+		a
+		a
+	a
+		a
+		a
+		a
+	a
+		a
+		a
+		a
+		a
+	a
+a]], '13m7')
+      eq({1, 2, 2, 2, 1, 2, 2, 1, 1, 1, 2, 2, 2, 1, 0}, get_folds())
+    end)
   end)
   it('updates correctly on :read', function()
     -- luacheck: ignore 621


### PR DESCRIPTION
I made a mistake in `foldMoveRange()` in PR #6221 , this commit fixes that mistake.
Heads up @chrisbra I pushed the same mistake will to vim.

In PR #6221 there was a mistake in calculating which folds need to be
re-ordered. When there are no folds after those that have been adjusted,
then the `move_end` variable is left as `0`.
This results in `reverse_fold_order()` swapping folds that have been
adjusted with uninitialised folds in the remainder of the grow array.

We add a check in `foldMoveRange()` to account for this case.