### PR TITLE
Fix default highlights for (l)Cursor

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5898,6 +5898,8 @@ static void syntime_report(void)
 static char *highlight_init_both[] =
 {
   "Conceal      ctermbg=DarkGrey ctermfg=LightGrey guibg=DarkGrey guifg=LightGrey",
+  "Cursor       guibg=fg guifg=bg",
+  "lCursor      guibg=fg guifg=bg",
   "DiffText     cterm=bold ctermbg=Red gui=bold guibg=Red",
   "ErrorMsg     ctermbg=DarkRed ctermfg=White guibg=Red guifg=White",
   "IncSearch    cterm=reverse gui=reverse",


### PR DESCRIPTION
See https://github.com/neovim/neovim/issues/6508
Change highlight from:
`Cursor         xxx cleared`
to:
`Cursor         xxx guifg=bg guibg=fg`

I will try to add requested improvements to guicursor either in this PR or a new one.