### PR TITLE
[RFC] vim-patch:7.4.2152,7.4.2165,7.4.2173,7.4.2179,7.4.2209

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4764,7 +4764,7 @@ static int get_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 
       // Special key, e.g.: "\<C-W>"
       case '<':
-        extra = trans_special((const char_u **) &p, STRLEN(p), name, true);
+        extra = trans_special((const char_u **)&p, STRLEN(p), name, true, true);
         if (extra != 0) {
           name += extra;
           break;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8663,7 +8663,6 @@ static void f_foldtext(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   char_u      *r;
   int         len;
   char        *txt;
-  long        count;
 
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
@@ -8691,8 +8690,8 @@ static void f_foldtext(typval_T *argvars, typval_T *rettv, FunPtr fptr)
           s = skipwhite(s + 1);
       }
     }
-    count = (long)(foldend - foldstart + 1);
-    txt = _("+-%s%3ld lines: ");
+    unsigned long count = (unsigned long)(foldend - foldstart + 1);
+    txt = ngettext("+-%s%3ld line: ", "+-%s%3ld lines: ", count);
     r = xmalloc(STRLEN(txt)
                 + STRLEN(dashes) // for %s
                 + 20             // for %3ld
@@ -8712,7 +8711,7 @@ static void f_foldtext(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 static void f_foldtextresult(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   char_u      *text;
-  char_u buf[51];
+  char_u buf[FOLD_TEXT_LEN];
   foldinfo_T foldinfo;
   int fold_count;
 

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1689,12 +1689,10 @@ static void foldDelMarker(linenr_T lnum, char_u *marker, size_t markerlen)
   }
 }
 
-/* get_foldtext() {{{2 */
-/*
- * Return the text for a closed fold at line "lnum", with last line "lnume".
- * When 'foldtext' isn't set puts the result in "buf[51]".  Otherwise the
- * result is in allocated memory.
- */
+// get_foldtext() {{{2
+/// Return the text for a closed fold at line "lnum", with last line "lnume".
+/// When 'foldtext' isn't set puts the result in "buf[FOLD_TEXT_LEN]".
+/// Otherwise the result is in allocated memory.
 char_u *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume,
                      foldinfo_T *foldinfo, char_u *buf)
   FUNC_ATTR_NONNULL_ARG(1)
@@ -1781,8 +1779,12 @@ char_u *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume,
     }
   }
   if (text == NULL) {
-    sprintf((char *)buf, _("+--%3ld lines folded "),
-        (long)(lnume - lnum + 1));
+    unsigned long count = (unsigned long)(lnume - lnum + 1);
+
+    vim_snprintf((char *)buf, FOLD_TEXT_LEN,
+                 ngettext("+--%3ld line folded",
+                          "+--%3ld lines folded ", count),
+                 count);
     text = buf;
   }
   return text;

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -490,17 +490,19 @@ char_u *get_special_key_name(int c, int modifiers)
 /// @param[out]  dst  Location where translation result will be kept. Must have
 ///                   at least six bytes.
 /// @param[in]  keycode  Prefer key code, e.g. K_DEL in place of DEL.
+/// @param[in]  in_string  Inside a double quoted string
 ///
 /// @return Number of characters added to dst, zero for no match.
 unsigned int trans_special(const char_u **srcp, const size_t src_len,
-                           char_u *const dst, const bool keycode)
+                           char_u *const dst, const bool keycode,
+                           const bool in_string)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   int modifiers = 0;
   int key;
   unsigned int dlen = 0;
 
-  key = find_special_key(srcp, src_len, &modifiers, keycode, false);
+  key = find_special_key(srcp, src_len, &modifiers, keycode, false, in_string);
   if (key == 0) {
     return 0;
   }
@@ -536,10 +538,12 @@ unsigned int trans_special(const char_u **srcp, const size_t src_len,
 /// @param[out]  modp  Location where information about modifiers is saved.
 /// @param[in]  keycode  Prefer key code, e.g. K_DEL in place of DEL.
 /// @param[in]  keep_x_key  Don’t translate xHome to Home key.
+/// @param[in]  in_string  In string, double quote is escaped
 ///
 /// @return Key and modifiers or 0 if there is no match.
 int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
-                     const bool keycode, const bool keep_x_key)
+                     const bool keycode, const bool keep_x_key,
+                     const bool in_string)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
   const char_u *last_dash;
@@ -573,10 +577,14 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
         } else {
           l = 1;
         }
-        if (end - bp > l && bp[l] != '"' && bp[l + 1] == '>') {
-          // Anything accepted, like <C-?>, except <C-">, because the "
-          // ends the string.
+        // Anything accepted, like <C-?>.
+        // <C-"> or <M-"> are not special in strings as " is
+        // the string delimiter. With a backslash it works: <M-\">
+        if (end - bp > l && !(in_string && bp[1] == '"') && bp[2] == '>') {
           bp += l;
+        } else if (end - bp > 2 && in_string && bp[1] == '\\'
+                   && bp[2] == '"' && bp[3] == '>') {
+          bp += 2;
         }
       }
     }
@@ -612,18 +620,17 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
         vim_str2nr(last_dash + 6, NULL, NULL, STR2NR_ALL, NULL, &n, 0);
         key = (int)n;
       } else {
-        /*
-         * Modifier with single letter, or special key name.
-         */
-        if (has_mbyte) {
-          l = mb_ptr2len(last_dash + 1);
-        } else {
-          l = 1;
+        int off = 1;
+
+        // Modifier with single letter, or special key name.
+        if (in_string && last_dash[1] == '\\' && last_dash[2] == '"') {
+          off = 2;
         }
+        l = mb_ptr2len(last_dash + 1);
         if (modifiers != 0 && last_dash[l + 1] == '>') {
-          key = PTR2CHAR(last_dash + 1);
+          key = PTR2CHAR(last_dash + off);
         } else {
-          key = get_special_key_code(last_dash + 1);
+          key = get_special_key_code(last_dash + off);
           if (!keep_x_key) {
             key = handle_x_keys(key);
           }
@@ -828,7 +835,8 @@ char_u *replace_termcodes(const char_u *from, const size_t from_len,
         }
       }
 
-      slen = trans_special(&src, (size_t) (end - src) + 1, result + dlen, true);
+      slen = trans_special(&src, (size_t)(end - src) + 1, result + dlen, true,
+                           true);
       if (slen) {
         dlen += slen;
         continue;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4818,7 +4818,7 @@ int find_key_option_len(const char_u *arg, size_t len)
   } else {
     arg--;  // put arg at the '<'
     modifiers = 0;
-    key = find_special_key(&arg, len + 1, &modifiers, true, true);
+    key = find_special_key(&arg, len + 1, &modifiers, true, true, false);
     if (modifiers) {  // can't handle modifiers here
       key = 0;
     }

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -182,7 +182,8 @@ size_t input_enqueue(String keys)
   while (rbuffer_space(input_buffer) >= 6 && ptr < end) {
     uint8_t buf[6] = { 0 };
     unsigned int new_size
-        = trans_special((const uint8_t **)&ptr, (size_t)(end - ptr), buf, true);
+        = trans_special((const uint8_t **)&ptr, (size_t)(end - ptr), buf, true,
+                        true);
 
     if (new_size) {
       new_size = handle_mouse_event(&ptr, buf, new_size);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1684,7 +1684,7 @@ static int compute_foldcolumn(win_T *wp, int col)
  */
 static void fold_line(win_T *wp, long fold_count, foldinfo_T *foldinfo, linenr_T lnum, int row)
 {
-  char_u buf[51];
+  char_u buf[FOLD_TEXT_LEN];
   pos_T       *top, *bot;
   linenr_T lnume = lnum + fold_count - 1;
   int len;

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -150,3 +150,11 @@ func Test_break_undo()
   call assert_equal('new line here', getline(line('$') - 1))
   set nomodified
 endfunc
+
+func Test_map_meta_quotes()
+  imap <M-"> foo
+  call feedkeys("Go-\<M-\">-\<Esc>", "xt")
+  call assert_equal("-foo-", getline('$'))
+  set nomodified
+  iunmap <M-">
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -232,7 +232,7 @@ static const int included_patches[] = {
   2212,
   // 2211 NA
   // 2210 NA
-  // 2209,
+  2209,
   2208,
   // 2207 NA
   // 2206 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -289,7 +289,7 @@ static const int included_patches[] = {
   // 2155 NA
   // 2154 NA
   // 2153 NA
-  // 2152,
+  2152,
   2151,
   // 2150 NA
   2149,

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -204,6 +204,8 @@ enum {
 
 #define DIALOG_MSG_SIZE 1000    /* buffer size for dialog_msg() */
 
+enum { FOLD_TEXT_LEN = 51 };  //!< buffer size for get_foldtext()
+
 /*
  * Maximum length of key sequence to be mapped.
  * Must be able to hold an Amiga resize report.


### PR DESCRIPTION
#### vim-patch:7.4.2152

Problem:    No proper translation of messages with a count.
Solution:   Use ngettext(). (Sergey Alyoshin)

https://github.com/vim/vim/commit/ee695f787ade7fd88fc5f5497553d95c0c3645b5


#### vim-patch:7.4.2165

Problem:    Startup test fails on MS-Windows.
Solution:   Don't check output if RunVim() returns zero.

https://github.com/vim/vim/commit/83b3c3d8a0fa1afed06c13163b9f72c0925f2a61

Already applied in 6baa669c10518b8751904a31899feb897fb7c995


#### vim-patch:7.4.2173

Problem:    Can't test help on MS-Windows.
Solution:   Skip the test.

https://github.com/vim/vim/commit/3321e9d8a36c91c62d8ba3d43430b5c213b87f8b

Applied in 6baa669c10518b8751904a31899feb897fb7c995


#### vim-patch:7.4.2179

Problem:    Reading from stdin test fails on MS-Windows.
Solution:   Strip the extra space.

https://github.com/vim/vim/commit/e4a76ad0e74a31bbd9f1b1ac5b816d714d19a412

Applied in 6baa669c10518b8751904a31899feb897fb7c995


#### vim-patch:7.4.2209

Problem:    Cannot map <M-">. (Stephen Riehm)
Solution:   Solve the memory access problem in another way. (Dominique Pelle)
            Allow for using <M-\"> in a string.

https://github.com/vim/vim/commit/35a4cfa200917dd171b1fff3cd5b6cee9add673d