### PR TITLE
[RFC] Fix fold bug when switching from a terminal buffer

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -766,6 +766,10 @@ void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
     return;
   }
 
+  if (wp->w_buffer->terminal) {
+    return;
+  }
+
   // Mark all folds from top to bot as maybe-small.
   fold_T *fp;
   (void)foldFind(&wp->w_folds, top, &fp);

--- a/test/functional/legacy/045_folding_spec.lua
+++ b/test/functional/legacy/045_folding_spec.lua
@@ -2,8 +2,8 @@
 local Screen = require('test.functional.ui.screen')
 
 local helpers = require('test.functional.helpers')(after_each)
-local feed, insert, feed_command, expect_any =
-  helpers.feed, helpers.insert, helpers.feed_command, helpers.expect_any
+local feed, insert, feed_command, expect, expect_any =
+  helpers.feed, helpers.insert, helpers.feed_command, helpers.expect, helpers.expect_any
 
 describe('folding', function()
   local screen
@@ -188,6 +188,17 @@ describe('folding', function()
       1
       2
       0]])
+  end)
+
+  it("Regression #6549", function()
+    feed_command('let g:markdown_folding = 1')
+    feed_command('term top')
+    feed_command('e 045_test_data.md')
+
+    feed_command('sleep 2')
+    helpers.wait()
+
+    expect([[# hi]])
   end)
 
   it('can be opened after :move', function()

--- a/test/functional/legacy/045_test_data.md
+++ b/test/functional/legacy/045_test_data.md
@@ -1,0 +1,57 @@
+# hi
+
+## foo
+
+Hi foo.
+
+## bar
+
+Hi bar.
+
+## foo
+
+Hi foo.
+
+## bar
+
+Hi bar.
+
+## foo
+
+Hi foo.
+
+## bar
+
+Hi bar.
+
+## foo
+
+Hi foo.
+
+## bar
+
+Hi bar.
+
+## foo
+
+Hi foo.
+
+## bar
+
+Hi bar.
+
+## foo
+
+Hi foo.
+
+## bar
+
+Hi bar.
+
+## foo
+
+Hi foo.
+
+## bar
+
+Hi bar.


### PR DESCRIPTION
When switching from a terminal buffer to a file using `foldmethod=expr`, Neovim jumps to line 19 (or sometimes 20).

This appears to have been introduced by commit e1079c2a for #5351, which I believe unintentionally deleted an if-statement that I have re-added.

(CC: @Shougo)