### PR TITLE
[RFC] Fix bug in ex_z

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2874,8 +2874,11 @@ void ex_z(exarg_T *eap)
   if (end > curbuf->b_ml.ml_line_count)
     end = curbuf->b_ml.ml_line_count;
 
-  if (curs > curbuf->b_ml.ml_line_count)
+  if (curs > curbuf->b_ml.ml_line_count) {
     curs = curbuf->b_ml.ml_line_count;
+  } else if (curs < 1) {
+    curs = 1;
+  }
 
   for (i = start; i <= end; i++) {
     if (minus && i == lnum) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2898,8 +2898,11 @@ void ex_z(exarg_T *eap)
     }
   }
 
-  curwin->w_cursor.lnum = curs;
-  ex_no_reprint = TRUE;
+  if (curwin->w_cursor.lnum != curs) {
+    curwin->w_cursor.lnum = curs;
+    curwin->w_cursor.col = 0;
+  }
+  ex_no_reprint = true;
 }
 
 /*

--- a/test/functional/ex_cmds/print_commands_spec.lua
+++ b/test/functional/ex_cmds/print_commands_spec.lua
@@ -1,0 +1,12 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear, eq, command, funcs =
+  helpers.clear, helpers.eq, helpers.command, helpers.funcs
+
+describe(':z^', function()
+  before_each(clear)
+
+  it('correctly sets the cursor after :z^', function()
+    command('z^')
+    eq(1, funcs.line('.'))
+  end)
+end)


### PR DESCRIPTION
In order to get familiar with fuzzing tools (specifically, [afl](http://lcamtuf.coredump.cx/afl/)), I tried fuzzing Neovim. While afl did not encounter any crashes, it did find many hangs. The timeout I used was 4 seconds, which led to a lot of false positives (apparently it's easy to generate input that takes Neovim more than 4 seconds to process). However, there was also a true positive: the command `nvim -u NONE -Z -e -c 'z^' -c ':qa!'`should quit after running the command, but it doesn't. The problem is that the `:qa!` command is not properly executed, because running the `z^` command on an empty file results in a negative value in ` curwin->w_cursor.lnum`.
