### PR TITLE
eval: save_tv_as_string: Correctly handle an empty string

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17504,7 +17504,8 @@ static char *save_tv_as_string(typval_T *tv, ptrdiff_t *const len, bool endnl)
   // print an error.
   if (tv->v_type != VAR_LIST && tv->v_type != VAR_NUMBER) {
     const char *ret = tv_get_string_chk(tv);
-    if (ret && (*len = strlen(ret))) {
+    if (ret) {
+      *len = strlen(ret);
       return xmemdupz(ret, (size_t)(*len));
     } else {
       *len = -1;

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -258,6 +258,9 @@ describe('system()', function()
       end
       eq(2, eval("1+1"))  -- Still alive?
     end)
+    it('works with an empty string', function()
+      eq("test\n", eval('system("echo test", "")'))
+    end)
   end)
 
   describe('passing a lot of input', function()


### PR DESCRIPTION
When tv_get_string_chk returns a non-NULL value, we have a valid string.
Propagating an error state (*len = -1, NULL return) for an empty string
is invalid.

Closes #6554