### PR TITLE
api: Do not truncate errors <1 MB

### DIFF
--- a/scripts/gendispatch.lua
+++ b/scripts/gendispatch.lua
@@ -225,7 +225,7 @@ for i = 1, #functions do
     end
     output:write('\n')
     output:write('\n  if (args.size != '..#fn.parameters..') {')
-    output:write('\n    _api_set_error(error, error->type, "Wrong number of arguments: expecting '..#fn.parameters..' but got %zu", args.size);')
+    output:write('\n    api_set_error(error, error->type, "Wrong number of arguments: expecting '..#fn.parameters..' but got %zu", args.size);')
     output:write('\n    goto cleanup;')
     output:write('\n  }\n')
 
@@ -250,7 +250,7 @@ for i = 1, #functions do
           output:write('\n    '..converted..' = (handle_T)args.items['..(j - 1)..'].data.integer;')
         end
         output:write('\n  } else {')
-        output:write('\n    _api_set_error(error, error->type, "Wrong type for argument '..j..', expecting '..param[1]..'");')
+        output:write('\n    api_set_error(error, error->type, "Wrong type for argument '..j..', expecting '..param[1]..'");')
         output:write('\n    goto cleanup;')
         output:write('\n  }\n')
       else

--- a/scripts/gendispatch.lua
+++ b/scripts/gendispatch.lua
@@ -225,8 +225,7 @@ for i = 1, #functions do
     end
     output:write('\n')
     output:write('\n  if (args.size != '..#fn.parameters..') {')
-    output:write('\n    snprintf(error->msg, sizeof(error->msg), "Wrong number of arguments: expecting '..#fn.parameters..' but got %zu", args.size);')
-    output:write('\n    error->set = true;')
+    output:write('\n    _api_set_error(error, error->type, "Wrong number of arguments: expecting '..#fn.parameters..' but got %zu", args.size);')
     output:write('\n    goto cleanup;')
     output:write('\n  }\n')
 
@@ -251,8 +250,7 @@ for i = 1, #functions do
           output:write('\n    '..converted..' = (handle_T)args.items['..(j - 1)..'].data.integer;')
         end
         output:write('\n  } else {')
-        output:write('\n    snprintf(error->msg, sizeof(error->msg), "Wrong type for argument '..j..', expecting '..param[1]..'");')
-        output:write('\n    error->set = true;')
+        output:write('\n    _api_set_error(error, error->type, "Wrong type for argument '..j..', expecting '..param[1]..'");')
         output:write('\n    goto cleanup;')
         output:write('\n  }\n')
       else

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -171,7 +171,7 @@ ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
   end = normalize_index(buf, end, &oob);
 
   if (strict_indexing && oob) {
-    api_set_error(err, Validation, _("Index out of bounds"));
+    api_set_error(err, kErrorTypeValidation, _("Index out of bounds"));
     return rv;
   }
 
@@ -187,7 +187,7 @@ ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
     int64_t lnum = start + (int64_t)i;
 
     if (lnum > LONG_MAX) {
-      api_set_error(err, Validation, _("Line index is too high"));
+      api_set_error(err, kErrorTypeValidation, _("Line index is too high"));
       goto end;
     }
 
@@ -283,14 +283,14 @@ void nvim_buf_set_lines(uint64_t channel_id,
   end = normalize_index(buf, end, &oob);
 
   if (strict_indexing && oob) {
-    api_set_error(err, Validation, _("Index out of bounds"));
+    api_set_error(err, kErrorTypeValidation, _("Index out of bounds"));
     return;
   }
 
 
   if (start > end) {
     api_set_error(err,
-                  Validation,
+                  kErrorTypeValidation,
                   _("Argument \"start\" is higher than \"end\""));
     return;
   }
@@ -305,7 +305,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
   for (size_t i = 0; i < new_len; i++) {
     if (replacement.items[i].type != kObjectTypeString) {
       api_set_error(err,
-                    Validation,
+                    kErrorTypeValidation,
                     _("All items in the replacement array must be strings"));
       goto end;
     }
@@ -317,7 +317,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
     lines[i] = xmallocz(l.size);
     for (size_t j = 0; j < l.size; j++) {
       if (l.data[j] == '\n' && channel_id != INTERNAL_CALL) {
-        api_set_error(err, Exception, _("string cannot contain newlines"));
+        api_set_error(err, kErrorTypeException, _("string cannot contain newlines"));
         new_len = i + 1;
         goto end;
       }
@@ -330,7 +330,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
   switch_to_win_for_buf(buf, &save_curwin, &save_curtab, &save_curbuf);
 
   if (u_save((linenr_T)(start - 1), (linenr_T)end) == FAIL) {
-    api_set_error(err, Exception, _("Failed to save undo information"));
+    api_set_error(err, kErrorTypeException, _("Failed to save undo information"));
     goto end;
   }
 
@@ -340,7 +340,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
   size_t to_delete = (new_len < old_len) ? (size_t)(old_len - new_len) : 0;
   for (size_t i = 0; i < to_delete; i++) {
     if (ml_delete((linenr_T)start, false) == FAIL) {
-      api_set_error(err, Exception, _("Failed to delete line"));
+      api_set_error(err, kErrorTypeException, _("Failed to delete line"));
       goto end;
     }
   }
@@ -357,12 +357,12 @@ void nvim_buf_set_lines(uint64_t channel_id,
     int64_t lnum = start + (int64_t)i;
 
     if (lnum > LONG_MAX) {
-      api_set_error(err, Validation, _("Index value is too high"));
+      api_set_error(err, kErrorTypeValidation, _("Index value is too high"));
       goto end;
     }
 
     if (ml_replace((linenr_T)lnum, (char_u *)lines[i], false) == FAIL) {
-      api_set_error(err, Exception, _("Failed to replace line"));
+      api_set_error(err, kErrorTypeException, _("Failed to replace line"));
       goto end;
     }
     // Mark lines that haven't been passed to the buffer as they need
@@ -375,12 +375,12 @@ void nvim_buf_set_lines(uint64_t channel_id,
     int64_t lnum = start + (int64_t)i - 1;
 
     if (lnum > LONG_MAX) {
-      api_set_error(err, Validation, _("Index value is too high"));
+      api_set_error(err, kErrorTypeValidation, _("Index value is too high"));
       goto end;
     }
 
     if (ml_append((linenr_T)lnum, (char_u *)lines[i], 0, false) == FAIL) {
-      api_set_error(err, Exception, _("Failed to insert line"));
+      api_set_error(err, kErrorTypeException, _("Failed to insert line"));
       goto end;
     }
 
@@ -627,7 +627,7 @@ void nvim_buf_set_name(Buffer buffer, String name, Error *err)
   }
 
   if (ren_ret == FAIL) {
-    api_set_error(err, Exception, _("Failed to rename buffer"));
+    api_set_error(err, kErrorTypeException, _("Failed to rename buffer"));
   }
 }
 
@@ -680,7 +680,7 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Error *err)
   }
 
   if (name.size != 1) {
-    api_set_error(err, Validation, _("Mark name must be a single character"));
+    api_set_error(err, kErrorTypeValidation, _("Mark name must be a single character"));
     return rv;
   }
 
@@ -698,7 +698,7 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Error *err)
   }
 
   if (posp == NULL) {
-    api_set_error(err, Validation, _("Invalid mark name"));
+    api_set_error(err, kErrorTypeValidation, _("Invalid mark name"));
     return rv;
   }
 
@@ -753,11 +753,11 @@ Integer nvim_buf_add_highlight(Buffer buffer,
   }
 
   if (line < 0 || line >= MAXLNUM) {
-    api_set_error(err, Validation, _("Line number outside range"));
+    api_set_error(err, kErrorTypeValidation, _("Line number outside range"));
     return 0;
   }
   if (col_start < 0 || col_start > MAXCOL) {
-    api_set_error(err, Validation, _("Column value outside range"));
+    api_set_error(err, kErrorTypeValidation, _("Column value outside range"));
     return 0;
   }
   if (col_end < 0 || col_end > MAXCOL) {
@@ -794,7 +794,7 @@ void nvim_buf_clear_highlight(Buffer buffer,
   }
 
   if (line_start < 0 || line_start >= MAXLNUM) {
-    api_set_error(err, Validation, _("Line number outside range"));
+    api_set_error(err, kErrorTypeValidation, _("Line number outside range"));
     return;
   }
   if (line_end < 0 || line_end > MAXLNUM) {

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -639,7 +639,9 @@ Boolean nvim_buf_is_valid(Buffer buffer)
     FUNC_API_SINCE(1)
 {
   Error stub = ERROR_INIT;
-  return find_buffer_by_handle(buffer, &stub) != NULL;
+  Boolean ret = find_buffer_by_handle(buffer, &stub) != NULL;
+  api_free_error(stub);
+  return ret;
 }
 
 /// Inserts a sequence of lines to a buffer at a certain index

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -171,7 +171,7 @@ ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
   end = normalize_index(buf, end, &oob);
 
   if (strict_indexing && oob) {
-    api_set_error(err, kErrorTypeValidation, _("Index out of bounds"));
+    api_set_error(err, kErrorTypeValidation, "Index out of bounds");
     return rv;
   }
 
@@ -187,7 +187,7 @@ ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
     int64_t lnum = start + (int64_t)i;
 
     if (lnum > LONG_MAX) {
-      api_set_error(err, kErrorTypeValidation, _("Line index is too high"));
+      api_set_error(err, kErrorTypeValidation, "Line index is too high");
       goto end;
     }
 
@@ -283,15 +283,14 @@ void nvim_buf_set_lines(uint64_t channel_id,
   end = normalize_index(buf, end, &oob);
 
   if (strict_indexing && oob) {
-    api_set_error(err, kErrorTypeValidation, _("Index out of bounds"));
+    api_set_error(err, kErrorTypeValidation, "Index out of bounds");
     return;
   }
 
 
   if (start > end) {
-    api_set_error(err,
-                  kErrorTypeValidation,
-                  _("Argument \"start\" is higher than \"end\""));
+    api_set_error(err, kErrorTypeValidation,
+                  "Argument \"start\" is higher than \"end\"");
     return;
   }
 
@@ -306,7 +305,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
     if (replacement.items[i].type != kObjectTypeString) {
       api_set_error(err,
                     kErrorTypeValidation,
-                    _("All items in the replacement array must be strings"));
+                    "All items in the replacement array must be strings");
       goto end;
     }
 
@@ -317,7 +316,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
     lines[i] = xmallocz(l.size);
     for (size_t j = 0; j < l.size; j++) {
       if (l.data[j] == '\n' && channel_id != INTERNAL_CALL) {
-        api_set_error(err, kErrorTypeException, _("string cannot contain newlines"));
+        api_set_error(err, kErrorTypeException, "string cannot contain newlines");
         new_len = i + 1;
         goto end;
       }
@@ -330,7 +329,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
   switch_to_win_for_buf(buf, &save_curwin, &save_curtab, &save_curbuf);
 
   if (u_save((linenr_T)(start - 1), (linenr_T)end) == FAIL) {
-    api_set_error(err, kErrorTypeException, _("Failed to save undo information"));
+    api_set_error(err, kErrorTypeException, "Failed to save undo information");
     goto end;
   }
 
@@ -340,7 +339,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
   size_t to_delete = (new_len < old_len) ? (size_t)(old_len - new_len) : 0;
   for (size_t i = 0; i < to_delete; i++) {
     if (ml_delete((linenr_T)start, false) == FAIL) {
-      api_set_error(err, kErrorTypeException, _("Failed to delete line"));
+      api_set_error(err, kErrorTypeException, "Failed to delete line");
       goto end;
     }
   }
@@ -357,12 +356,12 @@ void nvim_buf_set_lines(uint64_t channel_id,
     int64_t lnum = start + (int64_t)i;
 
     if (lnum > LONG_MAX) {
-      api_set_error(err, kErrorTypeValidation, _("Index value is too high"));
+      api_set_error(err, kErrorTypeValidation, "Index value is too high");
       goto end;
     }
 
     if (ml_replace((linenr_T)lnum, (char_u *)lines[i], false) == FAIL) {
-      api_set_error(err, kErrorTypeException, _("Failed to replace line"));
+      api_set_error(err, kErrorTypeException, "Failed to replace line");
       goto end;
     }
     // Mark lines that haven't been passed to the buffer as they need
@@ -375,12 +374,12 @@ void nvim_buf_set_lines(uint64_t channel_id,
     int64_t lnum = start + (int64_t)i - 1;
 
     if (lnum > LONG_MAX) {
-      api_set_error(err, kErrorTypeValidation, _("Index value is too high"));
+      api_set_error(err, kErrorTypeValidation, "Index value is too high");
       goto end;
     }
 
     if (ml_append((linenr_T)lnum, (char_u *)lines[i], 0, false) == FAIL) {
-      api_set_error(err, kErrorTypeException, _("Failed to insert line"));
+      api_set_error(err, kErrorTypeException, "Failed to insert line");
       goto end;
     }
 
@@ -627,7 +626,7 @@ void nvim_buf_set_name(Buffer buffer, String name, Error *err)
   }
 
   if (ren_ret == FAIL) {
-    api_set_error(err, kErrorTypeException, _("Failed to rename buffer"));
+    api_set_error(err, kErrorTypeException, "Failed to rename buffer");
   }
 }
 
@@ -680,7 +679,7 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Error *err)
   }
 
   if (name.size != 1) {
-    api_set_error(err, kErrorTypeValidation, _("Mark name must be a single character"));
+    api_set_error(err, kErrorTypeValidation, "Mark name must be a single character");
     return rv;
   }
 
@@ -698,7 +697,7 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Error *err)
   }
 
   if (posp == NULL) {
-    api_set_error(err, kErrorTypeValidation, _("Invalid mark name"));
+    api_set_error(err, kErrorTypeValidation, "Invalid mark name");
     return rv;
   }
 
@@ -753,11 +752,11 @@ Integer nvim_buf_add_highlight(Buffer buffer,
   }
 
   if (line < 0 || line >= MAXLNUM) {
-    api_set_error(err, kErrorTypeValidation, _("Line number outside range"));
+    api_set_error(err, kErrorTypeValidation, "Line number outside range");
     return 0;
   }
   if (col_start < 0 || col_start > MAXCOL) {
-    api_set_error(err, kErrorTypeValidation, _("Column value outside range"));
+    api_set_error(err, kErrorTypeValidation, "Column value outside range");
     return 0;
   }
   if (col_end < 0 || col_end > MAXCOL) {
@@ -794,7 +793,7 @@ void nvim_buf_clear_highlight(Buffer buffer,
   }
 
   if (line_start < 0 || line_start >= MAXLNUM) {
-    api_set_error(err, kErrorTypeValidation, _("Line number outside range"));
+    api_set_error(err, kErrorTypeValidation, "Line number outside range");
     return;
   }
   if (line_end < 0 || line_end > MAXLNUM) {

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -8,7 +8,7 @@
 #define ARRAY_DICT_INIT {.size = 0, .capacity = 0, .items = NULL}
 #define STRING_INIT {.data = NULL, .size = 0}
 #define OBJECT_INIT { .type = kObjectTypeNil }
-#define ERROR_INIT { .set = false }
+#define ERROR_INIT { .set = false, .msg = NULL }
 #define REMOTE_TYPE(type) typedef handle_T type
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -38,7 +38,7 @@ typedef enum {
 
 typedef struct {
   ErrorType type;
-  char msg[1024];
+  char *msg;
   bool set;
 } Error;
 

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -61,7 +61,7 @@ bool try_end(Error *err)
       discard_current_exception();
     }
 
-    api_set_error(err, kErrorTypeException, _("Keyboard interrupt"));
+    api_set_error(err, kErrorTypeException, "Keyboard interrupt");
     got_int = false;
   } else if (msg_list != NULL && *msg_list != NULL) {
     int should_free;
@@ -93,7 +93,7 @@ Object dict_get_value(dict_T *dict, String key, Error *err)
   dictitem_T *const di = tv_dict_find(dict, key.data, (ptrdiff_t)key.size);
 
   if (di == NULL) {
-    api_set_error(err, kErrorTypeValidation, _("Key not found"));
+    api_set_error(err, kErrorTypeValidation, "Key not found");
     return (Object) OBJECT_INIT;
   }
 
@@ -117,18 +117,18 @@ Object dict_set_var(dict_T *dict, String key, Object value, bool del,
   Object rv = OBJECT_INIT;
 
   if (dict->dv_lock) {
-    api_set_error(err, kErrorTypeException, _("Dictionary is locked"));
+    api_set_error(err, kErrorTypeException, "Dictionary is locked");
     return rv;
   }
 
   if (key.size == 0) {
     api_set_error(err, kErrorTypeValidation,
-                  _("Empty variable names aren't allowed"));
+                  "Empty variable names aren't allowed");
     return rv;
   }
 
   if (key.size > INT_MAX) {
-    api_set_error(err, kErrorTypeValidation, _("Key length is too high"));
+    api_set_error(err, kErrorTypeValidation, "Key length is too high");
     return rv;
   }
 
@@ -136,14 +136,14 @@ Object dict_set_var(dict_T *dict, String key, Object value, bool del,
 
   if (di != NULL) {
     if (di->di_flags & DI_FLAGS_RO) {
-      api_set_error(err, kErrorTypeException, _("Key is read-only: %s"),
+      api_set_error(err, kErrorTypeException, "Key is read-only: %s",
                     key.data);
       return rv;
     } else if (di->di_flags & DI_FLAGS_FIX) {
-      api_set_error(err, kErrorTypeException, _("Key is fixed: %s"), key.data);
+      api_set_error(err, kErrorTypeException, "Key is fixed: %s", key.data);
       return rv;
     } else if (di->di_flags & DI_FLAGS_LOCK) {
-      api_set_error(err, kErrorTypeException, _("Key is locked: %s"), key.data);
+      api_set_error(err, kErrorTypeException, "Key is locked: %s", key.data);
       return rv;
     }
   }
@@ -152,7 +152,7 @@ Object dict_set_var(dict_T *dict, String key, Object value, bool del,
     // Delete the key
     if (di == NULL) {
       // Doesn't exist, fail
-      api_set_error(err, kErrorTypeValidation, _("Key \"%s\" doesn't exist"),
+      api_set_error(err, kErrorTypeValidation, "Key \"%s\" doesn't exist",
                     key.data);
     } else {
       // Return the old value
@@ -205,7 +205,7 @@ Object get_option_from(void *from, int type, String name, Error *err)
   Object rv = OBJECT_INIT;
 
   if (name.size == 0) {
-    api_set_error(err, kErrorTypeValidation, _("Empty option name"));
+    api_set_error(err, kErrorTypeValidation, "Empty option name");
     return rv;
   }
 
@@ -218,7 +218,7 @@ Object get_option_from(void *from, int type, String name, Error *err)
   if (!flags) {
     api_set_error(err,
                   kErrorTypeValidation,
-                  _("Invalid option name \"%s\""),
+                  "Invalid option name \"%s\"",
                   name.data);
     return rv;
   }
@@ -237,13 +237,13 @@ Object get_option_from(void *from, int type, String name, Error *err)
     } else {
       api_set_error(err,
                     kErrorTypeException,
-                    _("Unable to get value for option \"%s\""),
+                    "Unable to get value for option \"%s\"",
                     name.data);
     }
   } else {
     api_set_error(err,
                   kErrorTypeException,
-                  _("Unknown type for option \"%s\""),
+                  "Unknown type for option \"%s\"",
                   name.data);
   }
 
@@ -260,7 +260,7 @@ Object get_option_from(void *from, int type, String name, Error *err)
 void set_option_to(void *to, int type, String name, Object value, Error *err)
 {
   if (name.size == 0) {
-    api_set_error(err, kErrorTypeValidation, _("Empty option name"));
+    api_set_error(err, kErrorTypeValidation, "Empty option name");
     return;
   }
 
@@ -269,7 +269,7 @@ void set_option_to(void *to, int type, String name, Object value, Error *err)
   if (flags == 0) {
     api_set_error(err,
                   kErrorTypeValidation,
-                  _("Invalid option name \"%s\""),
+                  "Invalid option name \"%s\"",
                   name.data);
     return;
   }
@@ -278,14 +278,14 @@ void set_option_to(void *to, int type, String name, Object value, Error *err)
     if (type == SREQ_GLOBAL) {
       api_set_error(err,
                     kErrorTypeException,
-                    _("Unable to unset option \"%s\""),
+                    "Unable to unset option \"%s\"",
                     name.data);
       return;
     } else if (!(flags & SOPT_GLOBAL)) {
       api_set_error(err,
                     kErrorTypeException,
-                    _("Cannot unset option \"%s\" "
-                      "because it doesn't have a global value"),
+                    "Cannot unset option \"%s\" "
+                    "because it doesn't have a global value",
                     name.data);
       return;
     } else {
@@ -300,7 +300,7 @@ void set_option_to(void *to, int type, String name, Object value, Error *err)
     if (value.type != kObjectTypeBoolean) {
       api_set_error(err,
                     kErrorTypeValidation,
-                    _("Option \"%s\" requires a boolean value"),
+                    "Option \"%s\" requires a boolean value",
                     name.data);
       return;
     }
@@ -311,7 +311,7 @@ void set_option_to(void *to, int type, String name, Object value, Error *err)
     if (value.type != kObjectTypeInteger) {
       api_set_error(err,
                     kErrorTypeValidation,
-                    _("Option \"%s\" requires an integer value"),
+                    "Option \"%s\" requires an integer value",
                     name.data);
       return;
     }
@@ -319,7 +319,7 @@ void set_option_to(void *to, int type, String name, Object value, Error *err)
     if (value.data.integer > INT_MAX || value.data.integer < INT_MIN) {
       api_set_error(err,
                     kErrorTypeValidation,
-                    _("Value for option \"%s\" is outside range"),
+                    "Value for option \"%s\" is outside range",
                     name.data);
       return;
     }
@@ -330,7 +330,7 @@ void set_option_to(void *to, int type, String name, Object value, Error *err)
     if (value.type != kObjectTypeString) {
       api_set_error(err,
                     kErrorTypeValidation,
-                    _("Option \"%s\" requires a string value"),
+                    "Option \"%s\" requires a string value",
                     name.data);
       return;
     }
@@ -563,7 +563,7 @@ buf_T *find_buffer_by_handle(Buffer buffer, Error *err)
   buf_T *rv = handle_get_buffer(buffer);
 
   if (!rv) {
-    api_set_error(err, kErrorTypeValidation, _("Invalid buffer id"));
+    api_set_error(err, kErrorTypeValidation, "Invalid buffer id");
   }
 
   return rv;
@@ -578,7 +578,7 @@ win_T *find_window_by_handle(Window window, Error *err)
   win_T *rv = handle_get_window(window);
 
   if (!rv) {
-    api_set_error(err, kErrorTypeValidation, _("Invalid window id"));
+    api_set_error(err, kErrorTypeValidation, "Invalid window id");
   }
 
   return rv;
@@ -593,7 +593,7 @@ tabpage_T *find_tab_by_handle(Tabpage tabpage, Error *err)
   tabpage_T *rv = handle_get_tabpage(tabpage);
 
   if (!rv) {
-    api_set_error(err, kErrorTypeValidation, _("Invalid tabpage id"));
+    api_set_error(err, kErrorTypeValidation, "Invalid tabpage id");
   }
 
   return rv;
@@ -661,7 +661,7 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
     case kObjectTypeInteger:
       if (obj.data.integer > VARNUMBER_MAX
           || obj.data.integer < VARNUMBER_MIN) {
-        api_set_error(err, kErrorTypeValidation, _("Integer value outside range"));
+        api_set_error(err, kErrorTypeValidation, "Integer value outside range");
         return false;
       }
 
@@ -716,7 +716,7 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
 
         if (key.size == 0) {
           api_set_error(err, kErrorTypeValidation,
-                        _("Empty dictionary keys aren't allowed"));
+                        "Empty dictionary keys aren't allowed");
           // cleanup
           tv_dict_free(dict);
           return false;
@@ -935,7 +935,7 @@ static void set_option_value_for(char *key,
         }
         api_set_error(err,
                       kErrorTypeException,
-                      _("Problem while switching windows"));
+                      "Problem while switching windows");
         return;
       }
       set_option_value_err(key, numval, stringval, opt_flags, err);

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -8,11 +8,6 @@
 #include "nvim/memory.h"
 #include "nvim/lib/kvec.h"
 
-void _api_set_error(Error *err, ErrorType errType, const char *format, ...);
-// -V:api_set_error:618
-#define api_set_error(err, errtype, ...) \
-  _api_set_error(err, kErrorType##errtype, __VA_ARGS__)
-
 #define OBJECT_OBJ(o) o
 
 #define BOOLEAN_OBJ(b) ((Object) { \

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -8,15 +8,10 @@
 #include "nvim/memory.h"
 #include "nvim/lib/kvec.h"
 
+void _api_set_error(Error *err, ErrorType errType, const char *format, ...);
 // -V:api_set_error:618
 #define api_set_error(err, errtype, ...) \
-  do { \
-    snprintf((err)->msg, \
-             sizeof((err)->msg), \
-             __VA_ARGS__); \
-    (err)->set = true; \
-    (err)->type = kErrorType##errtype; \
-  } while (0)
+  _api_set_error(err, kErrorType##errtype, __VA_ARGS__)
 
 #define OBJECT_OBJ(o) o
 

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -193,6 +193,8 @@ Boolean nvim_tabpage_is_valid(Tabpage tabpage)
     FUNC_API_SINCE(1)
 {
   Error stub = ERROR_INIT;
-  return find_tab_by_handle(tabpage, &stub) != NULL;
+  Boolean ret = find_tab_by_handle(tabpage, &stub) != NULL;
+  api_free_error(stub);
+  return ret;
 }
 

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -55,13 +55,13 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
     FUNC_API_SINCE(1) FUNC_API_NOEVAL
 {
   if (pmap_has(uint64_t)(connected_uis, channel_id)) {
-    api_set_error(err, kErrorTypeException, _("UI already attached for channel"));
+    api_set_error(err, kErrorTypeException, "UI already attached for channel");
     return;
   }
 
   if (width <= 0 || height <= 0) {
     api_set_error(err, kErrorTypeValidation,
-                  _("Expected width > 0 and height > 0"));
+                  "Expected width > 0 and height > 0");
     return;
   }
   UI *ui = xcalloc(1, sizeof(UI));
@@ -144,7 +144,7 @@ void nvim_ui_try_resize(uint64_t channel_id, Integer width,
 
   if (width <= 0 || height <= 0) {
     api_set_error(err, kErrorTypeValidation,
-                  _("Expected width > 0 and height > 0"));
+                  "Expected width > 0 and height > 0");
     return;
   }
 
@@ -173,19 +173,19 @@ void nvim_ui_set_option(uint64_t channel_id, String name,
 static void ui_set_option(UI *ui, String name, Object value, Error *error) {
   if (strcmp(name.data, "rgb") == 0) {
     if (value.type != kObjectTypeBoolean) {
-      api_set_error(error, kErrorTypeValidation, _("rgb must be a Boolean"));
+      api_set_error(error, kErrorTypeValidation, "rgb must be a Boolean");
       return;
     }
     ui->rgb = value.data.boolean;
   } else if (strcmp(name.data, "popupmenu_external") == 0) {
     if (value.type != kObjectTypeBoolean) {
       api_set_error(error, kErrorTypeValidation,
-                    _("popupmenu_external must be a Boolean"));
+                    "popupmenu_external must be a Boolean");
       return;
     }
     ui->pum_external = value.data.boolean;
   } else {
-    api_set_error(error, kErrorTypeValidation, _("No such ui option"));
+    api_set_error(error, kErrorTypeValidation, "No such ui option");
   }
 }
 

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -55,12 +55,12 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
     FUNC_API_SINCE(1) FUNC_API_NOEVAL
 {
   if (pmap_has(uint64_t)(connected_uis, channel_id)) {
-    api_set_error(err, Exception, _("UI already attached for channel"));
+    api_set_error(err, kErrorTypeException, _("UI already attached for channel"));
     return;
   }
 
   if (width <= 0 || height <= 0) {
-    api_set_error(err, Validation,
+    api_set_error(err, kErrorTypeValidation,
                   _("Expected width > 0 and height > 0"));
     return;
   }
@@ -126,7 +126,7 @@ void nvim_ui_detach(uint64_t channel_id, Error *err)
     FUNC_API_SINCE(1) FUNC_API_NOEVAL
 {
   if (!pmap_has(uint64_t)(connected_uis, channel_id)) {
-    api_set_error(err, Exception, _("UI is not attached for channel"));
+    api_set_error(err, kErrorTypeException, "UI is not attached for channel");
     return;
   }
   remote_ui_disconnect(channel_id);
@@ -138,12 +138,12 @@ void nvim_ui_try_resize(uint64_t channel_id, Integer width,
     FUNC_API_SINCE(1) FUNC_API_NOEVAL
 {
   if (!pmap_has(uint64_t)(connected_uis, channel_id)) {
-    api_set_error(err, Exception, _("UI is not attached for channel"));
+    api_set_error(err, kErrorTypeException, "UI is not attached for channel");
     return;
   }
 
   if (width <= 0 || height <= 0) {
-    api_set_error(err, Validation,
+    api_set_error(err, kErrorTypeValidation,
                   _("Expected width > 0 and height > 0"));
     return;
   }
@@ -159,7 +159,7 @@ void nvim_ui_set_option(uint64_t channel_id, String name,
     FUNC_API_SINCE(1) FUNC_API_NOEVAL
 {
   if (!pmap_has(uint64_t)(connected_uis, channel_id)) {
-    api_set_error(error, Exception, _("UI is not attached for channel"));
+    api_set_error(error, kErrorTypeException, "UI is not attached for channel");
     return;
   }
   UI *ui = pmap_get(uint64_t)(connected_uis, channel_id);
@@ -173,19 +173,19 @@ void nvim_ui_set_option(uint64_t channel_id, String name,
 static void ui_set_option(UI *ui, String name, Object value, Error *error) {
   if (strcmp(name.data, "rgb") == 0) {
     if (value.type != kObjectTypeBoolean) {
-      api_set_error(error, Validation, _("rgb must be a Boolean"));
+      api_set_error(error, kErrorTypeValidation, _("rgb must be a Boolean"));
       return;
     }
     ui->rgb = value.data.boolean;
   } else if (strcmp(name.data, "popupmenu_external") == 0) {
     if (value.type != kObjectTypeBoolean) {
-      api_set_error(error, Validation,
+      api_set_error(error, kErrorTypeValidation,
                     _("popupmenu_external must be a Boolean"));
       return;
     }
     ui->pum_external = value.data.boolean;
   } else {
-    api_set_error(error, Validation, _("No such ui option"));
+    api_set_error(error, kErrorTypeValidation, _("No such ui option"));
   }
 }
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -188,7 +188,7 @@ Object nvim_eval(String expr, Error *err)
 
   typval_T rettv;
   if (eval0((char_u *)expr.data, &rettv, NULL, true) == FAIL) {
-    api_set_error(err, Exception, "Failed to evaluate expression");
+    api_set_error(err, kErrorTypeException, "Failed to evaluate expression");
   }
 
   if (!try_end(err)) {
@@ -214,7 +214,7 @@ Object nvim_call_function(String fname, Array args, Error *err)
 {
   Object rv = OBJECT_INIT;
   if (args.size > MAX_FUNC_ARGS) {
-    api_set_error(err, Validation,
+    api_set_error(err, kErrorTypeValidation,
       _("Function called with too many arguments."));
     return rv;
   }
@@ -237,7 +237,7 @@ Object nvim_call_function(String fname, Array args, Error *err)
                     curwin->w_cursor.lnum, curwin->w_cursor.lnum, &dummy,
                     true, NULL, NULL);
   if (r == FAIL) {
-    api_set_error(err, Exception, _("Error calling function."));
+    api_set_error(err, kErrorTypeException, _("Error calling function."));
   }
   if (!try_end(err)) {
     rv = vim_to_object(&rettv);
@@ -262,7 +262,7 @@ Integer nvim_strwidth(String str, Error *err)
     FUNC_API_SINCE(1)
 {
   if (str.size > INT_MAX) {
-    api_set_error(err, Validation, _("String length is too high"));
+    api_set_error(err, kErrorTypeValidation, _("String length is too high"));
     return 0;
   }
 
@@ -318,7 +318,7 @@ void nvim_set_current_dir(String dir, Error *err)
     FUNC_API_SINCE(1)
 {
   if (dir.size >= MAXPATHL) {
-    api_set_error(err, Validation, _("Directory string is too long"));
+    api_set_error(err, kErrorTypeValidation, _("Directory string is too long"));
     return;
   }
 
@@ -330,7 +330,7 @@ void nvim_set_current_dir(String dir, Error *err)
 
   if (vim_chdir((char_u *)string, kCdScopeGlobal)) {
     if (!try_end(err)) {
-      api_set_error(err, Exception, _("Failed to change directory"));
+      api_set_error(err, kErrorTypeException, _("Failed to change directory"));
     }
     return;
   }
@@ -539,7 +539,7 @@ void nvim_set_current_buf(Buffer buffer, Error *err)
   int result = do_buffer(DOBUF_GOTO, DOBUF_FIRST, FORWARD, buf->b_fnum, 0);
   if (!try_end(err) && result == FAIL) {
     api_set_error(err,
-                  Exception,
+                  kErrorTypeException,
                   _("Failed to switch to buffer %d"),
                   buffer);
   }
@@ -592,7 +592,7 @@ void nvim_set_current_win(Window window, Error *err)
   goto_tabpage_win(win_find_tabpage(win), win);
   if (!try_end(err) && win != curwin) {
     api_set_error(err,
-                  Exception,
+                  kErrorTypeException,
                   _("Failed to switch to window %d"),
                   window);
   }
@@ -646,7 +646,7 @@ void nvim_set_current_tabpage(Tabpage tabpage, Error *err)
   goto_tabpage_tp(tp, true, true);
   if (!try_end(err) && tp != curtab) {
     api_set_error(err,
-                  Exception,
+                  kErrorTypeException,
                   _("Failed to switch to tabpage %d"),
                   tabpage);
   }
@@ -745,21 +745,21 @@ Array nvim_call_atomic(uint64_t channel_id, Array calls, Error *err)
   for (i = 0; i < calls.size; i++) {
     if (calls.items[i].type != kObjectTypeArray) {
       api_set_error(err,
-                    Validation,
+                    kErrorTypeValidation,
                     _("All items in calls array must be arrays"));
       goto validation_error;
     }
     Array call = calls.items[i].data.array;
     if (call.size != 2) {
       api_set_error(err,
-                    Validation,
+                    kErrorTypeValidation,
                     _("All items in calls array must be arrays of size 2"));
       goto validation_error;
     }
 
     if (call.items[0].type != kObjectTypeString) {
       api_set_error(err,
-                    Validation,
+                    kErrorTypeValidation,
                     _("name must be String"));
       goto validation_error;
     }
@@ -767,7 +767,7 @@ Array nvim_call_atomic(uint64_t channel_id, Array calls, Error *err)
 
     if (call.items[1].type != kObjectTypeArray) {
       api_set_error(err,
-                    Validation,
+                    kErrorTypeValidation,
                     _("args must be Array"));
       goto validation_error;
     }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -794,10 +794,12 @@ Array nvim_call_atomic(uint64_t channel_id, Array calls, Error *err)
   } else {
     ADD(rv, NIL);
   }
-  return rv;
+  goto theend;
 
 validation_error:
   api_free_array(results);
+theend:
+  api_free_error(nested_error);
   return rv;
 }
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -215,7 +215,7 @@ Object nvim_call_function(String fname, Array args, Error *err)
   Object rv = OBJECT_INIT;
   if (args.size > MAX_FUNC_ARGS) {
     api_set_error(err, kErrorTypeValidation,
-      _("Function called with too many arguments."));
+      "Function called with too many arguments.");
     return rv;
   }
 
@@ -237,7 +237,7 @@ Object nvim_call_function(String fname, Array args, Error *err)
                     curwin->w_cursor.lnum, curwin->w_cursor.lnum, &dummy,
                     true, NULL, NULL);
   if (r == FAIL) {
-    api_set_error(err, kErrorTypeException, _("Error calling function."));
+    api_set_error(err, kErrorTypeException, "Error calling function.");
   }
   if (!try_end(err)) {
     rv = vim_to_object(&rettv);
@@ -262,7 +262,7 @@ Integer nvim_strwidth(String str, Error *err)
     FUNC_API_SINCE(1)
 {
   if (str.size > INT_MAX) {
-    api_set_error(err, kErrorTypeValidation, _("String length is too high"));
+    api_set_error(err, kErrorTypeValidation, "String length is too high");
     return 0;
   }
 
@@ -318,7 +318,7 @@ void nvim_set_current_dir(String dir, Error *err)
     FUNC_API_SINCE(1)
 {
   if (dir.size >= MAXPATHL) {
-    api_set_error(err, kErrorTypeValidation, _("Directory string is too long"));
+    api_set_error(err, kErrorTypeValidation, "Directory string is too long");
     return;
   }
 
@@ -330,7 +330,7 @@ void nvim_set_current_dir(String dir, Error *err)
 
   if (vim_chdir((char_u *)string, kCdScopeGlobal)) {
     if (!try_end(err)) {
-      api_set_error(err, kErrorTypeException, _("Failed to change directory"));
+      api_set_error(err, kErrorTypeException, "Failed to change directory");
     }
     return;
   }
@@ -538,9 +538,7 @@ void nvim_set_current_buf(Buffer buffer, Error *err)
   try_start();
   int result = do_buffer(DOBUF_GOTO, DOBUF_FIRST, FORWARD, buf->b_fnum, 0);
   if (!try_end(err) && result == FAIL) {
-    api_set_error(err,
-                  kErrorTypeException,
-                  _("Failed to switch to buffer %d"),
+    api_set_error(err, kErrorTypeException, "Failed to switch to buffer %d",
                   buffer);
   }
 }
@@ -593,7 +591,7 @@ void nvim_set_current_win(Window window, Error *err)
   if (!try_end(err) && win != curwin) {
     api_set_error(err,
                   kErrorTypeException,
-                  _("Failed to switch to window %d"),
+                  "Failed to switch to window %d",
                   window);
   }
 }
@@ -746,21 +744,21 @@ Array nvim_call_atomic(uint64_t channel_id, Array calls, Error *err)
     if (calls.items[i].type != kObjectTypeArray) {
       api_set_error(err,
                     kErrorTypeValidation,
-                    _("All items in calls array must be arrays"));
+                    "All items in calls array must be arrays");
       goto validation_error;
     }
     Array call = calls.items[i].data.array;
     if (call.size != 2) {
       api_set_error(err,
                     kErrorTypeValidation,
-                    _("All items in calls array must be arrays of size 2"));
+                    "All items in calls array must be arrays of size 2");
       goto validation_error;
     }
 
     if (call.items[0].type != kObjectTypeString) {
       api_set_error(err,
                     kErrorTypeValidation,
-                    _("name must be String"));
+                    "name must be String");
       goto validation_error;
     }
     String name = call.items[0].data.string;
@@ -768,7 +766,7 @@ Array nvim_call_atomic(uint64_t channel_id, Array calls, Error *err)
     if (call.items[1].type != kObjectTypeArray) {
       api_set_error(err,
                     kErrorTypeValidation,
-                    _("args must be Array"));
+                    "args must be Array");
       goto validation_error;
     }
     Array args = call.items[1].data.array;

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -387,6 +387,8 @@ Boolean nvim_win_is_valid(Window window)
     FUNC_API_SINCE(1)
 {
   Error stub = ERROR_INIT;
-  return find_window_by_handle(window, &stub) != NULL;
+  Boolean ret = find_window_by_handle(window, &stub) != NULL;
+  api_free_error(stub);
+  return ret;
 }
 

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -65,7 +65,7 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   if (pos.size != 2 || pos.items[0].type != kObjectTypeInteger
       || pos.items[1].type != kObjectTypeInteger) {
     api_set_error(err,
-                  Validation,
+                  kErrorTypeValidation,
                   _("Argument \"pos\" must be a [row, col] array"));
     return;
   }
@@ -78,12 +78,12 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   int64_t col = pos.items[1].data.integer;
 
   if (row <= 0 || row > win->w_buffer->b_ml.ml_line_count) {
-    api_set_error(err, Validation, _("Cursor position outside buffer"));
+    api_set_error(err, kErrorTypeValidation, "Cursor position outside buffer");
     return;
   }
 
   if (col > MAXCOL || col < 0) {
-    api_set_error(err, Validation, _("Column value outside range"));
+    api_set_error(err, kErrorTypeValidation, _("Column value outside range"));
     return;
   }
 
@@ -132,7 +132,7 @@ void nvim_win_set_height(Window window, Integer height, Error *err)
   }
 
   if (height > INT_MAX || height < INT_MIN) {
-    api_set_error(err, Validation, _("Height value outside range"));
+    api_set_error(err, kErrorTypeValidation, _("Height value outside range"));
     return;
   }
 
@@ -177,7 +177,7 @@ void nvim_win_set_width(Window window, Integer width, Error *err)
   }
 
   if (width > INT_MAX || width < INT_MIN) {
-    api_set_error(err, Validation, _("Width value outside range"));
+    api_set_error(err, kErrorTypeValidation, _("Width value outside range"));
     return;
   }
 

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -66,7 +66,7 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
       || pos.items[1].type != kObjectTypeInteger) {
     api_set_error(err,
                   kErrorTypeValidation,
-                  _("Argument \"pos\" must be a [row, col] array"));
+                  "Argument \"pos\" must be a [row, col] array");
     return;
   }
 
@@ -83,7 +83,7 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   }
 
   if (col > MAXCOL || col < 0) {
-    api_set_error(err, kErrorTypeValidation, _("Column value outside range"));
+    api_set_error(err, kErrorTypeValidation, "Column value outside range");
     return;
   }
 
@@ -132,7 +132,7 @@ void nvim_win_set_height(Window window, Integer height, Error *err)
   }
 
   if (height > INT_MAX || height < INT_MIN) {
-    api_set_error(err, kErrorTypeValidation, _("Height value outside range"));
+    api_set_error(err, kErrorTypeValidation, "Height value outside range");
     return;
   }
 
@@ -177,7 +177,7 @@ void nvim_win_set_width(Window window, Integer width, Error *err)
   }
 
   if (width > INT_MAX || width < INT_MIN) {
-    api_set_error(err, kErrorTypeValidation, _("Width value outside range"));
+    api_set_error(err, kErrorTypeValidation, "Width value outside range");
     return;
   }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6524,6 +6524,7 @@ static void api_wrapper(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 end:
   api_free_array(args);
   api_free_object(result);
+  api_free_error(err);
 }
 
 /*
@@ -13802,6 +13803,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
 end:
   api_free_object(result);
+  api_free_error(err);
 }
 
 // "rpcstart()" function (DEPRECATED)
@@ -16533,7 +16535,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   curbuf->b_p_swf = false;
   (void)setfname(curbuf, (char_u *)buf, NULL, true);
   // Save the job id and pid in b:terminal_job_{id,pid}
-  Error err;
+  Error err = ERROR_INIT;
   dict_set_var(curbuf->b_vars, cstr_as_string("terminal_job_id"),
                INTEGER_OBJ(rettv->vval.v_number), false, false, &err);
   dict_set_var(curbuf->b_vars, cstr_as_string("terminal_job_pid"),
@@ -16542,6 +16544,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   Terminal *term = terminal_open(topts);
   data->term = term;
   data->refcount++;
+  api_free_error(err);
 
   return;
 }

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -192,7 +192,8 @@ Object channel_send_call(uint64_t id,
   Channel *channel = NULL;
 
   if (!(channel = pmap_get(uint64_t)(channels, id)) || channel->closed) {
-    api_set_error(err, Exception, _("Invalid channel \"%" PRIu64 "\""), id);
+    api_set_error(err, kErrorTypeException,
+                  _("Invalid channel \"%" PRIu64 "\""), id);
     api_free_array(args);
     return NIL;
   }
@@ -212,7 +213,8 @@ Object channel_send_call(uint64_t id,
 
   if (frame.errored) {
     if (frame.result.type == kObjectTypeString) {
-      api_set_error(err, Exception, "%s", frame.result.data.string.data);
+      api_set_error(err, kErrorTypeException, "%s",
+                    frame.result.data.string.data);
     } else if (frame.result.type == kObjectTypeArray) {
       // Should be an error in the form [type, message]
       Array array = frame.result.data.array;
@@ -220,13 +222,13 @@ Object channel_send_call(uint64_t id,
           && (array.items[0].data.integer == kErrorTypeException
               || array.items[0].data.integer == kErrorTypeValidation)
           && array.items[1].type == kObjectTypeString) {
-        _api_set_error(err, (ErrorType)array.items[0].data.integer, "%s",
+        api_set_error(err, (ErrorType)array.items[0].data.integer, "%s",
                        array.items[1].data.string.data);
       } else {
-        api_set_error(err, Exception, "%s", "unknown error");
+        api_set_error(err, kErrorTypeException, "%s", "unknown error");
       }
     } else {
-      api_set_error(err, Exception, "%s", "unknown error");
+      api_set_error(err, kErrorTypeException, "%s", "unknown error");
     }
 
     api_free_object(frame.result);
@@ -514,7 +516,7 @@ static bool channel_write(Channel *channel, WBuffer *buffer)
 static void send_error(Channel *channel, uint64_t id, char *err)
 {
   Error e = ERROR_INIT;
-  api_set_error(&e, Exception, "%s", err);
+  api_set_error(&e, kErrorTypeException, "%s", err);
   channel_write(channel, serialize_response(channel->id,
                                             id,
                                             &e,

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -193,7 +193,7 @@ Object channel_send_call(uint64_t id,
 
   if (!(channel = pmap_get(uint64_t)(channels, id)) || channel->closed) {
     api_set_error(err, kErrorTypeException,
-                  _("Invalid channel \"%" PRIu64 "\""), id);
+                  "Invalid channel \"%" PRIu64 "\"", id);
     api_free_array(args);
     return NIL;
   }

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -475,8 +475,7 @@ Object msgpack_rpc_handle_missing_method(uint64_t channel_id,
                                          Array args,
                                          Error *error)
 {
-  snprintf(error->msg, sizeof(error->msg), "Invalid method name");
-  error->set = true;
+  _api_set_error(error, error->type, "Invalid method name");
   return NIL;
 }
 
@@ -485,8 +484,7 @@ Object msgpack_rpc_handle_invalid_arguments(uint64_t channel_id,
                                             Array args,
                                             Error *error)
 {
-  snprintf(error->msg, sizeof(error->msg), "Invalid method arguments");
-  error->set = true;
+  _api_set_error(error, error->type, "Invalid method arguments");
   return NIL;
 }
 

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -475,7 +475,7 @@ Object msgpack_rpc_handle_missing_method(uint64_t channel_id,
                                          Array args,
                                          Error *error)
 {
-  _api_set_error(error, error->type, "Invalid method name");
+  api_set_error(error, error->type, "Invalid method name");
   return NIL;
 }
 
@@ -484,7 +484,7 @@ Object msgpack_rpc_handle_invalid_arguments(uint64_t channel_id,
                                             Array args,
                                             Error *error)
 {
-  _api_set_error(error, error->type, "Invalid method arguments");
+  api_set_error(error, error->type, "Invalid method arguments");
   return NIL;
 }
 
@@ -570,49 +570,49 @@ void msgpack_rpc_validate(uint64_t *response_id,
   *response_id = NO_RESPONSE;
   // Validate the basic structure of the msgpack-rpc payload
   if (req->type != MSGPACK_OBJECT_ARRAY) {
-    api_set_error(err, Validation, _("Message is not an array"));
+    api_set_error(err, kErrorTypeValidation, _("Message is not an array"));
     return;
   }
 
   if (req->via.array.size == 0) {
-    api_set_error(err, Validation, _("Message is empty"));
+    api_set_error(err, kErrorTypeValidation, _("Message is empty"));
     return;
   }
 
   if (req->via.array.ptr[0].type != MSGPACK_OBJECT_POSITIVE_INTEGER) {
-    api_set_error(err, Validation, _("Message type must be an integer"));
+    api_set_error(err, kErrorTypeValidation, "Message type must be an integer");
     return;
   }
 
   uint64_t type = req->via.array.ptr[0].via.u64;
   if (type != kMessageTypeRequest && type != kMessageTypeNotification) {
-    api_set_error(err, Validation, _("Unknown message type"));
+    api_set_error(err, kErrorTypeValidation, _("Unknown message type"));
     return;
   }
 
   if ((type == kMessageTypeRequest && req->via.array.size != 4)
       || (type == kMessageTypeNotification && req->via.array.size != 3)) {
-    api_set_error(err, Validation, _("Request array size should be 4 (request) "
-                                     "or 3 (notification)"));
+    api_set_error(err, kErrorTypeValidation,
+                  "Request array size must be 4 (request) or 3 (notification)");
     return;
   }
 
   if (type == kMessageTypeRequest) {
     msgpack_object *id_obj = msgpack_rpc_msg_id(req);
     if (!id_obj) {
-      api_set_error(err, Validation, _("ID must be a positive integer"));
+      api_set_error(err, kErrorTypeValidation, "ID must be a positive integer");
       return;
     }
     *response_id = id_obj->via.u64;
   }
 
   if (!msgpack_rpc_method(req)) {
-    api_set_error(err, Validation, _("Method must be a string"));
+    api_set_error(err, kErrorTypeValidation, _("Method must be a string"));
     return;
   }
 
   if (!msgpack_rpc_args(req)) {
-    api_set_error(err, Validation, _("Parameters must be an array"));
+    api_set_error(err, kErrorTypeValidation, _("Parameters must be an array"));
     return;
   }
 }

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -570,12 +570,12 @@ void msgpack_rpc_validate(uint64_t *response_id,
   *response_id = NO_RESPONSE;
   // Validate the basic structure of the msgpack-rpc payload
   if (req->type != MSGPACK_OBJECT_ARRAY) {
-    api_set_error(err, kErrorTypeValidation, _("Message is not an array"));
+    api_set_error(err, kErrorTypeValidation, "Message is not an array");
     return;
   }
 
   if (req->via.array.size == 0) {
-    api_set_error(err, kErrorTypeValidation, _("Message is empty"));
+    api_set_error(err, kErrorTypeValidation, "Message is empty");
     return;
   }
 
@@ -586,7 +586,7 @@ void msgpack_rpc_validate(uint64_t *response_id,
 
   uint64_t type = req->via.array.ptr[0].via.u64;
   if (type != kMessageTypeRequest && type != kMessageTypeNotification) {
-    api_set_error(err, kErrorTypeValidation, _("Unknown message type"));
+    api_set_error(err, kErrorTypeValidation, "Unknown message type");
     return;
   }
 
@@ -607,12 +607,12 @@ void msgpack_rpc_validate(uint64_t *response_id,
   }
 
   if (!msgpack_rpc_method(req)) {
-    api_set_error(err, kErrorTypeValidation, _("Method must be a string"));
+    api_set_error(err, kErrorTypeValidation, "Method must be a string");
     return;
   }
 
   if (!msgpack_rpc_args(req)) {
-    api_set_error(err, kErrorTypeValidation, _("Parameters must be an array"));
+    api_set_error(err, kErrorTypeValidation, "Parameters must be an array");
     return;
   }
 }

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -633,13 +633,14 @@ static int term_movecursor(VTermPos new, VTermPos old, int visible,
 static void buf_set_term_title(buf_T *buf, char *title)
     FUNC_ATTR_NONNULL_ALL
 {
-  Error err;
+  Error err = ERROR_INIT;
   dict_set_var(buf->b_vars,
                STATIC_CSTR_AS_STRING("term_title"),
                STRING_OBJ(cstr_as_string(title)),
                false,
                false,
                &err);
+  api_free_error(err);
 }
 
 static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
@@ -1220,12 +1221,14 @@ static bool is_focused(Terminal *term)
 
 #define GET_CONFIG_VALUE(k, o) \
   do { \
-    Error err; \
+    Error err = ERROR_INIT; \
     /* Only called from terminal_open where curbuf->terminal is the */ \
     /* context  */ \
     o = dict_get_value(curbuf->b_vars, cstr_as_string(k), &err); \
+    api_free_error(err); \
     if (o.type == kObjectTypeNil) { \
       o = dict_get_value(&globvardict, cstr_as_string(k), &err); \
+      api_free_error(err); \
     } \
   } while (0)
 

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -228,7 +228,7 @@ static int get_key_code_timeout(void)
   if (nvim_get_option(cstr_as_string("ttimeout"), &err).data.boolean) {
     ms = nvim_get_option(cstr_as_string("ttimeoutlen"), &err).data.integer;
   }
-
+  api_free_error(err);
   return (int)ms;
 }
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -412,7 +412,7 @@ describe('api', function()
       eq(5, meths.get_var('avar'))
     end)
 
-    it('throws error on malformated arguments', function()
+    it('throws error on malformed arguments', function()
       local req = {
         {'nvim_set_var', {'avar', 1}},
         {'nvim_set_var'},
@@ -450,6 +450,13 @@ describe('api', function()
     local status, err = pcall(nvim, 'get_option', 'invalid-option')
     eq(false, status)
     ok(err:match('Invalid option name') ~= nil)
+  end)
+
+  it('does not truncate error message <1 MB #5984', function()
+    local very_long_name = 'A'..('x'):rep(10000)..'Z'
+    local status, err = pcall(nvim, 'get_option', very_long_name)
+    eq(false, status)
+    eq(very_long_name, err:match('Ax+Z?'))
   end)
 
   it("doesn't leak memory on incorrect argument types", function()

--- a/test/functional/provider/python3_spec.lua
+++ b/test/functional/provider/python3_spec.lua
@@ -2,6 +2,8 @@ local helpers = require('test.functional.helpers')(after_each)
 local eval, command, feed = helpers.eval, helpers.command, helpers.feed
 local eq, clear, insert = helpers.eq, helpers.clear, helpers.insert
 local expect, write_file = helpers.expect, helpers.write_file
+local feed_command = helpers.feed_command
+local ok = helpers.ok
 
 do
   clear()
@@ -15,7 +17,7 @@ do
   end
 end
 
-describe('python3 commands and functions', function()
+describe('python3', function()
   before_each(function()
     clear()
     command('python3 import vim')
@@ -28,6 +30,15 @@ describe('python3 commands and functions', function()
   it('python3_execute', function()
     command('python3 vim.vars["set_by_python3"] = [100, 0]')
     eq({100, 0}, eval('g:set_by_python3'))
+  end)
+
+  it('does not truncate error message <1 MB', function()
+    -- XXX: Python limits the error name to 200 chars, so this test is
+    -- mostly bogus.
+    local very_long_symbol = string.rep('a', 1200)
+    feed_command(':silent! py3 print('..very_long_symbol..' b)')
+    -- Truncated error message would not contain this (last) line.
+    eq('SyntaxError: invalid syntax', eval('v:errmsg'))
   end)
 
   it('python3_execute with nested commands', function()

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -312,12 +312,13 @@ function Screen:_redraw(updates)
     -- print(require('inspect')(update))
     local method = update[1]
     for i = 2, #update do
-      local handler = self['_handle_'..method]
+      local handler_name = '_handle_'..method
+      local handler = self[handler_name]
       if handler ~= nil then
         handler(self, unpack(update[i]))
       else
         assert(self._on_event,
-          "Add Screen:_handle_XXX method or call Screen:set_on_event_handler")
+          "Add Screen:"..handler_name.." or call Screen:set_on_event_handler")
         self._on_event(method, update[i])
       end
     end


### PR DESCRIPTION
Continues #6237

- [x] limit error message size to 1 MB
- [x] convert all call sites to use `api_set_error` function instead of macro
- [x] test
