### PR TITLE
Remove unused Hash Map implementation.

### DIFF
--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -142,7 +142,6 @@ static inline bool String_eq(String a, String b)
 
 
 MAP_IMPL(int, int, DEFAULT_INITIALIZER)
-MAP_IMPL(cstr_t, uint64_t, DEFAULT_INITIALIZER)
 MAP_IMPL(cstr_t, ptr_t, DEFAULT_INITIALIZER)
 MAP_IMPL(ptr_t, ptr_t, DEFAULT_INITIALIZER)
 MAP_IMPL(uint64_t, ptr_t, DEFAULT_INITIALIZER)

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -25,7 +25,6 @@
   void map_##T##_##U##_clear(Map(T, U) *map);
 
 MAP_DECLS(int, int)
-MAP_DECLS(cstr_t, uint64_t)
 MAP_DECLS(cstr_t, ptr_t)
 MAP_DECLS(ptr_t, ptr_t)
 MAP_DECLS(uint64_t, ptr_t)


### PR DESCRIPTION
Removes the implementation of the cstr_t -> uint64_t hash map, as it is now unused.

When I checked, this change appears to cut the size of the Release binary by ~5KB (0.1%) when built using `make CMAKE_BUILD_TYPE=Release`