### PR TITLE
[RFC] scripts: Mark generated functions table readonly

### DIFF
--- a/scripts/geneval.lua
+++ b/scripts/geneval.lua
@@ -41,6 +41,7 @@ funcsdata:close()
 gperfpipe:write([[
 %language=ANSI-C
 %global-table
+%readonly-tables
 %define initializer-suffix ,0,0,NULL,NULL
 %define word-array-name functions
 %define hash-function-name hash_internal_func_gperf

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6009,7 +6009,7 @@ char_u *get_expr_name(expand_T *xp, int idx)
 /// @param[in]  name  Name of the function.
 ///
 /// Returns pointer to the function definition or NULL if not found.
-static VimLFuncDef *find_internal_func(const char *const name)
+static const VimLFuncDef *find_internal_func(const char *const name)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE FUNC_ATTR_NONNULL_ALL
 {
   size_t len = strlen(name);
@@ -6378,7 +6378,7 @@ call_func(
       }
     } else {
       // Find the function name in the table, call its implementation.
-      VimLFuncDef *const fdef = find_internal_func((const char *)fname);
+      const VimLFuncDef *const fdef = find_internal_func((const char *)fname);
       if (fdef != NULL) {
         if (argcount < fdef->min_argc) {
           error = ERROR_TOOFEW;


### PR DESCRIPTION
Modifies the settings for gperf to generate the `functions` lookup table as const, and propagates the `const` in eval.c.

The comments in geneval.lua suggest that it was intended to be created as a static const, but the gperf settings were slightly incorrect.