### PR TITLE
external UI: tabline

### DIFF
--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -251,9 +251,9 @@ connect to another with different type codes.
 6. Remote UIs					           *rpc-remote-ui*
 
 GUIs can be implemented as external processes communicating with Nvim over the
-RPC API. Currently the UI model consists of a terminal-like grid with one
-single, monospace font size. Some elements (UI "widgets") can be drawn
-separately from the grid.
+RPC API. The UI model consists of a terminal-like grid with a single,
+monospace font size. Some elements (UI "widgets") can be drawn separately from
+the grid ("externalized").
 
 After connecting to Nvim (usually a spawned, embedded instance) use the
 |nvim_ui_attach| API method to tell Nvim that your program wants to draw the
@@ -264,14 +264,13 @@ a dictionary with these (optional) keys:
 				colors.
 				Set to false to use terminal color codes (at
 				most 256 different colors).
-	`popupmenu_external`	Instead of drawing the completion popupmenu on
-				the grid, Nvim will send higher-level events to
-				the UI and let it draw the popupmenu.
-				Defaults to false.
-	`tabline_external`	Instead of drawing the tabline on the grid,
-			        Nvim will send higher-level events to
-				the UI and let it draw the tabline.
-				Defaults to false.
+	`ui_ext`		String array of "externalized" widgets.
+				Widgets in this list will not be drawn by
+				Nvim; only high-level data will be published
+				in new UI event kinds. Valid names:
+					popupmenu	|ui-ext-popupmenu|
+					tabline         |ui-ext-tabline|
+				Defaults to empty.
 
 Nvim will then send msgpack-rpc notifications, with the method name "redraw"
 and a single argument, an array of screen updates (described below).  These
@@ -421,6 +420,7 @@ properties specified in the corresponding item. The set of modes reported will
 change in new versions of Nvim, for instance more submodes and temporary
 states might be represented as separate modes.
 
+							*ui-ext-popupmenu*
 ["popupmenu_show", items, selected, row, col]
 	When `popupmenu_external` is set to true, nvim will not draw the
 	popupmenu on the grid, instead when the popupmenu is to be displayed
@@ -440,9 +440,10 @@ states might be represented as separate modes.
 ["popupmenu_hide"]
 	The popupmenu is hidden.
 
+							*ui-ext-tabline*
 ["tabline_update", curtab, tabs]
 	Nvim will send this event when drawing tabline. curtab is the tab id
-	of the current tab. tabs is an arrays of the form:
+	of the current tab. tabs is an array of the form:
 	[tabid, { "name": name }]
 
 ==============================================================================

--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -440,9 +440,10 @@ states might be represented as separate modes.
 
 							*ui-ext-tabline*
 ["tabline_update", curtab, tabs]
-	Nvim will send this event when drawing tabline. curtab is the tab id
-	of the current tab. tabs is an array of the form:
-	[tabid, { "name": name }]
+	Tabline was updated. UIs should present this data in a custom tabline
+	widget.
+	curtab:	  Current Tabpage
+	tabs:	  List of Dicts [{ "tab": Tabpage, "name": String }, ...]
 
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -264,13 +264,11 @@ a dictionary with these (optional) keys:
 				colors.
 				Set to false to use terminal color codes (at
 				most 256 different colors).
-	`ui_ext`		String array of "externalized" widgets.
-				Widgets in this list will not be drawn by
+	`ext_popupmenu`		Externalize the popupmenu. |ui-ext-popupmenu|
+	`ext_tabline`		Externalize the tabline. |ui-ext-tabline|
+				Externalized widgets will not be drawn by
 				Nvim; only high-level data will be published
-				in new UI event kinds. Valid names:
-					popupmenu	|ui-ext-popupmenu|
-					tabline         |ui-ext-tabline|
-				Defaults to empty.
+				in new UI event kinds.
 
 Nvim will then send msgpack-rpc notifications, with the method name "redraw"
 and a single argument, an array of screen updates (described below).  These

--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -266,7 +266,11 @@ a dictionary with these (optional) keys:
 				most 256 different colors).
 	`popupmenu_external`	Instead of drawing the completion popupmenu on
 				the grid, Nvim will send higher-level events to
-				the ui and let it draw the popupmenu.
+				the UI and let it draw the popupmenu.
+				Defaults to false.
+	`tabline_external`	Instead of drawing the tabline on the grid,
+			        Nvim will send higher-level events to
+				the UI and let it draw the tabline.
 				Defaults to false.
 
 Nvim will then send msgpack-rpc notifications, with the method name "redraw"
@@ -435,6 +439,11 @@ states might be represented as separate modes.
 
 ["popupmenu_hide"]
 	The popupmenu is hidden.
+
+["tabline_update", curtab, tabs]
+	Nvim will send this event when drawing tabline. curtab is the tab id
+	of the current tab. tabs is an arrays of the form:
+	[tabid, { "name": name }]
 
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -69,6 +69,7 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
   ui->height = (int)height;
   ui->rgb = true;
   ui->pum_external = false;
+  ui->tabline_external = false;
   ui->resize = remote_ui_resize;
   ui->clear = remote_ui_clear;
   ui->eol_clear = remote_ui_eol_clear;
@@ -171,19 +172,26 @@ void nvim_ui_set_option(uint64_t channel_id, String name,
 }
 
 static void ui_set_option(UI *ui, String name, Object value, Error *error) {
-  if (strcmp(name.data, "rgb") == 0) {
+  if (strequal(name.data, "rgb")) {
     if (value.type != kObjectTypeBoolean) {
       api_set_error(error, kErrorTypeValidation, "rgb must be a Boolean");
       return;
     }
     ui->rgb = value.data.boolean;
-  } else if (strcmp(name.data, "popupmenu_external") == 0) {
+  } else if (strequal(name.data, "popupmenu_external")) {
     if (value.type != kObjectTypeBoolean) {
       api_set_error(error, kErrorTypeValidation,
                     "popupmenu_external must be a Boolean");
       return;
     }
     ui->pum_external = value.data.boolean;
+  } else if (strequal(name.data, "tabline_external")) {
+    if (value.type != kObjectTypeBoolean) {
+      api_set_error(error, kErrorTypeValidation,
+                    "tabline_external must be a Boolean");
+      return;
+    }
+    ui->tabline_external = value.data.boolean;
   } else {
     api_set_error(error, kErrorTypeValidation, "No such ui option");
   }

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -41,9 +41,7 @@ static int pum_row;                 // top row of pum
 static int pum_col;                 // left column of pum
 
 static bool pum_is_visible = false;
-
 static bool pum_external = false;
-static bool pum_wants_external = false;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "popupmnu.c.generated.h"
@@ -80,7 +78,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed)
   if (!pum_is_visible) {
     // To keep the code simple, we only allow changing the
     // draw mode when the popup menu is not being displayed
-    pum_external = pum_wants_external;
+    pum_external = ui_is_external(kUIPopupmenu);
   }
 
 redo:
@@ -750,9 +748,4 @@ bool pum_drawn(void)
 int pum_get_height(void)
 {
   return pum_height;
-}
-
-void pum_set_external(bool external)
-{
-  pum_wants_external = external;
 }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6886,13 +6886,12 @@ static void draw_tabline(void)
   if (ScreenLines == NULL) {
     return;
   }
+  redraw_tabline = false;
 
-  if (ui_is_widget_external(kUITabline)) {
-    draw_tabline_ext();
+  if (ui_is_external(kUITabline)) {
+    ui_ext_tabline_update();
     return;
   }
-
-  redraw_tabline = false;
 
   if (tabline_height() < 1)
     return;
@@ -7033,20 +7032,13 @@ static void draw_tabline(void)
   redraw_tabline = FALSE;
 }
 
-// send tabline update to external ui
-void draw_tabline_ext(void)
+void ui_ext_tabline_update(void)
 {
-  win_T       *cwp;
-
   Array args = ARRAY_DICT_INIT;
   ADD(args, INTEGER_OBJ(curtab->handle));
   Array tabs = ARRAY_DICT_INIT;
   FOR_ALL_TABS(tp) {
-    if (tp == curtab) {
-      cwp = curwin;
-    } else {
-      cwp = tp->tp_curwin;
-    }
+    win_T *cwp = (tp == curtab) ? curwin : tp->tp_curwin;
     get_trans_bufname(cwp->w_buffer);
     Array tab = ARRAY_DICT_INIT;
     ADD(tab, INTEGER_OBJ(tp->handle));

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -132,6 +132,7 @@
 #include "nvim/version.h"
 #include "nvim/window.h"
 #include "nvim/os/time.h"
+#include "nvim/api/private/helpers.h"
 
 #define MB_FILLER_CHAR '<'  /* character used when a double-width character
                              * doesn't fit. */
@@ -6885,8 +6886,13 @@ static void draw_tabline(void)
   if (ScreenLines == NULL) {
     return;
   }
-  redraw_tabline = false;
 
+  if (ui_is_widget_external(kUITabline)) {
+    draw_tabline_ext();
+    return;
+  }
+
+  redraw_tabline = false;
 
   if (tabline_height() < 1)
     return;
@@ -7025,6 +7031,34 @@ static void draw_tabline(void)
   /* Reset the flag here again, in case evaluating 'tabline' causes it to be
    * set. */
   redraw_tabline = FALSE;
+}
+
+// send tabline update to external ui
+void draw_tabline_ext(void)
+{
+  win_T       *cwp;
+
+  Array args = ARRAY_DICT_INIT;
+  ADD(args, INTEGER_OBJ(curtab->handle));
+  Array tabs = ARRAY_DICT_INIT;
+  FOR_ALL_TABS(tp) {
+    if (tp == curtab) {
+      cwp = curwin;
+    } else {
+      cwp = tp->tp_curwin;
+    }
+    get_trans_bufname(cwp->w_buffer);
+    Array tab = ARRAY_DICT_INIT;
+    ADD(tab, INTEGER_OBJ(tp->handle));
+
+    Dictionary tab_info = ARRAY_DICT_INIT;
+    PUT(tab_info, "name", STRING_OBJ(cstr_to_string((char *)NameBuff)));
+    ADD(tab, DICTIONARY_OBJ(tab_info));
+    ADD(tabs, ARRAY_OBJ(tab));
+  }
+  ADD(args, ARRAY_OBJ(tabs));
+
+  ui_event("tabline_update", args);
 }
 
 /*

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7038,15 +7038,14 @@ void ui_ext_tabline_update(void)
   ADD(args, INTEGER_OBJ(curtab->handle));
   Array tabs = ARRAY_DICT_INIT;
   FOR_ALL_TABS(tp) {
+    Dictionary tab_info = ARRAY_DICT_INIT;
+    PUT(tab_info, "tab", TABPAGE_OBJ(tp->handle));
+
     win_T *cwp = (tp == curtab) ? curwin : tp->tp_curwin;
     get_trans_bufname(cwp->w_buffer);
-    Array tab = ARRAY_DICT_INIT;
-    ADD(tab, INTEGER_OBJ(tp->handle));
-
-    Dictionary tab_info = ARRAY_DICT_INIT;
     PUT(tab_info, "name", STRING_OBJ(cstr_to_string((char *)NameBuff)));
-    ADD(tab, DICTIONARY_OBJ(tab_info));
-    ADD(tabs, ARRAY_OBJ(tab));
+
+    ADD(tabs, DICTIONARY_OBJ(tab_info));
   }
   ADD(args, ARRAY_OBJ(tabs));
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -109,8 +109,6 @@ UI *tui_start(void)
   UI *ui = xcalloc(1, sizeof(UI));
   ui->stop = tui_stop;
   ui->rgb = p_tgc;
-  ui->pum_external = false;
-  ui->tabline_external = false;
   ui->resize = tui_resize;
   ui->clear = tui_clear;
   ui->eol_clear = tui_eol_clear;
@@ -136,6 +134,9 @@ UI *tui_start(void)
   ui->set_title = tui_set_title;
   ui->set_icon = tui_set_icon;
   ui->event = tui_event;
+
+  memset(ui->ui_ext, 0, sizeof(ui->ui_ext));
+
   return ui_bridge_attach(ui, tui_main, tui_scheduler);
 }
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -110,6 +110,7 @@ UI *tui_start(void)
   ui->stop = tui_stop;
   ui->rgb = p_tgc;
   ui->pum_external = false;
+  ui->tabline_external = false;
   ui->resize = tui_resize;
   ui->clear = tui_clear;
   ui->eol_clear = tui_eol_clear;

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -58,6 +58,10 @@ static int busy = 0;
 static int height, width;
 static int old_mode_idx = -1;
 
+static bool tabline_external = false;
+static bool cmdline_external = false;
+static bool wildmenu_external = false;
+
 // UI_CALL invokes a function on all registered UI instances. The functions can
 // have 0-5 arguments (configurable by SELECT_NTH).
 //
@@ -167,17 +171,20 @@ void ui_refresh(void)
 
   int width = INT_MAX, height = INT_MAX;
   bool pum_external = true;
+  bool tabline_external = true;
 
   for (size_t i = 0; i < ui_count; i++) {
     UI *ui = uis[i];
     width = MIN(ui->width, width);
     height = MIN(ui->height, height);
     pum_external &= ui->pum_external;
+    tabline_external &= ui->tabline_external;
   }
 
   row = col = 0;
   screen_resize(width, height);
   pum_set_external(pum_external);
+  ui_set_widget_external(kUITabline, tabline_external);
   ui_mode_info_set();
   old_mode_idx = -1;
   ui_cursor_shape();
@@ -557,3 +564,30 @@ void ui_cursor_shape(void)
   conceal_check_cursur_line();
 }
 
+bool ui_is_widget_external(UIWidget widget)
+{
+  switch (widget) {
+    case kUITabline:
+      return tabline_external;
+    case kUICmdline:
+      return cmdline_external;
+    case kUIWildmenu:
+      return wildmenu_external;
+  }
+  return false;
+}
+
+void ui_set_widget_external(UIWidget widget, bool external)
+{
+  switch (widget) {
+    case kUITabline:
+      tabline_external = external;
+      break;
+    case kUICmdline:
+      cmdline_external = external;
+      break;
+    case kUIWildmenu:
+      wildmenu_external = external;
+      break;
+  }
+}

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -47,6 +47,7 @@
 #define MAX_UI_COUNT 16
 
 static UI *uis[MAX_UI_COUNT];
+static bool ui_ext[UI_WIDGETS] = { 0 };
 static size_t ui_count = 0;
 static int row = 0, col = 0;
 static struct {
@@ -57,10 +58,6 @@ static bool pending_cursor_update = false;
 static int busy = 0;
 static int height, width;
 static int old_mode_idx = -1;
-
-static bool tabline_external = false;
-static bool cmdline_external = false;
-static bool wildmenu_external = false;
 
 // UI_CALL invokes a function on all registered UI instances. The functions can
 // have 0-5 arguments (configurable by SELECT_NTH).
@@ -170,21 +167,25 @@ void ui_refresh(void)
   }
 
   int width = INT_MAX, height = INT_MAX;
-  bool pum_external = true;
-  bool tabline_external = true;
+  bool ext_widgets[UI_WIDGETS];
+  for (UIWidget i = 0; (int)i < UI_WIDGETS; i++) {
+    ext_widgets[i] = true;
+  }
 
   for (size_t i = 0; i < ui_count; i++) {
     UI *ui = uis[i];
     width = MIN(ui->width, width);
     height = MIN(ui->height, height);
-    pum_external &= ui->pum_external;
-    tabline_external &= ui->tabline_external;
+    for (UIWidget i = 0; (int)i < UI_WIDGETS; i++) {
+      ext_widgets[i] &= ui->ui_ext[i];
+    }
   }
 
   row = col = 0;
   screen_resize(width, height);
-  pum_set_external(pum_external);
-  ui_set_widget_external(kUITabline, tabline_external);
+  for (UIWidget i = 0; (int)i < UI_WIDGETS; i++) {
+    ui_set_external(i, ext_widgets[i]);
+  }
   ui_mode_info_set();
   old_mode_idx = -1;
   ui_cursor_shape();
@@ -564,30 +565,16 @@ void ui_cursor_shape(void)
   conceal_check_cursur_line();
 }
 
-bool ui_is_widget_external(UIWidget widget)
+/// Returns true if `widget` is externalized.
+bool ui_is_external(UIWidget widget)
 {
-  switch (widget) {
-    case kUITabline:
-      return tabline_external;
-    case kUICmdline:
-      return cmdline_external;
-    case kUIWildmenu:
-      return wildmenu_external;
-  }
-  return false;
+  return ui_ext[widget];
 }
 
-void ui_set_widget_external(UIWidget widget, bool external)
+/// Sets `widget` as "external".
+/// Such widgets are not drawn by Nvim; external UIs are expected to handle
+/// higher-level UI events and present the data.
+void ui_set_external(UIWidget widget, bool external)
 {
-  switch (widget) {
-    case kUITabline:
-      tabline_external = external;
-      break;
-    case kUICmdline:
-      cmdline_external = external;
-      break;
-    case kUIWildmenu:
-      wildmenu_external = external;
-      break;
-  }
+  ui_ext[widget] = external;
 }

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -8,6 +8,13 @@
 #include "api/private/defs.h"
 #include "nvim/buffer_defs.h"
 
+// values for externalized widgets
+typedef enum {
+  kUITabline,
+  kUICmdline,
+  kUIWildmenu
+} UIWidget;
+
 typedef struct {
   bool bold, underline, undercurl, italic, reverse;
   int foreground, background, special;
@@ -16,7 +23,7 @@ typedef struct {
 typedef struct ui_t UI;
 
 struct ui_t {
-  bool rgb, pum_external;
+  bool rgb, pum_external, tabline_external;
   int width, height;
   void *data;
   void (*resize)(UI *ui, int rows, int columns);

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -8,12 +8,13 @@
 #include "api/private/defs.h"
 #include "nvim/buffer_defs.h"
 
-// values for externalized widgets
 typedef enum {
+  kUICmdline = 0,
+  kUIPopupmenu,
   kUITabline,
-  kUICmdline,
-  kUIWildmenu
+  kUIWildmenu,
 } UIWidget;
+#define UI_WIDGETS (kUIWildmenu + 1)
 
 typedef struct {
   bool bold, underline, undercurl, italic, reverse;
@@ -23,7 +24,8 @@ typedef struct {
 typedef struct ui_t UI;
 
 struct ui_t {
-  bool rgb, pum_external, tabline_external;
+  bool rgb;
+  bool ui_ext[UI_WIDGETS];  ///< Externalized widgets
   int width, height;
   void *data;
   void (*resize)(UI *ui, int rows, int columns);

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -57,8 +57,6 @@ UI *ui_bridge_attach(UI *ui, ui_main_fn ui_main, event_scheduler scheduler)
   UIBridgeData *rv = xcalloc(1, sizeof(UIBridgeData));
   rv->ui = ui;
   rv->bridge.rgb = ui->rgb;
-  rv->bridge.pum_external = ui->pum_external;
-  rv->bridge.tabline_external = ui->tabline_external;
   rv->bridge.stop = ui_bridge_stop;
   rv->bridge.resize = ui_bridge_resize;
   rv->bridge.clear = ui_bridge_clear;
@@ -85,6 +83,10 @@ UI *ui_bridge_attach(UI *ui, ui_main_fn ui_main, event_scheduler scheduler)
   rv->bridge.set_title = ui_bridge_set_title;
   rv->bridge.set_icon = ui_bridge_set_icon;
   rv->scheduler = scheduler;
+
+  for (UIWidget i = 0; (int)i < UI_WIDGETS; i++) {
+    rv->bridge.ui_ext[i] = ui->ui_ext[i];
+  }
 
   rv->ui_main = ui_main;
   uv_mutex_init(&rv->mutex);

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -58,6 +58,7 @@ UI *ui_bridge_attach(UI *ui, ui_main_fn ui_main, event_scheduler scheduler)
   rv->ui = ui;
   rv->bridge.rgb = ui->rgb;
   rv->bridge.pum_external = ui->pum_external;
+  rv->bridge.tabline_external = ui->tabline_external;
   rv->bridge.stop = ui_bridge_stop;
   rv->bridge.resize = ui_bridge_resize;
   rv->bridge.clear = ui_bridge_clear;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -48,6 +48,7 @@
 #include "nvim/syntax.h"
 #include "nvim/terminal.h"
 #include "nvim/undo.h"
+#include "nvim/ui.h"
 #include "nvim/os/os.h"
 
 
@@ -5223,6 +5224,9 @@ static void last_status_rec(frame_T *fr, int statusline)
  */
 int tabline_height(void)
 {
+  if (ui_is_widget_external(kUITabline)) {
+      return 0;
+  }
   assert(first_tabpage);
   switch (p_stal) {
   case 0: return 0;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5224,8 +5224,8 @@ static void last_status_rec(frame_T *fr, int statusline)
  */
 int tabline_height(void)
 {
-  if (ui_is_widget_external(kUITabline)) {
-      return 0;
+  if (ui_is_external(kUITabline)) {
+    return 0;
   }
   assert(first_tabpage);
   switch (p_stal) {

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -577,28 +577,10 @@ describe('nvim_ui_attach()', function()
     eq(999, eval('&lines'))
     eq(999, eval('&columns'))
   end)
-  it('"ui_ext" widgets', function()
+  it('invalid option returns error', function()
     local screen = Screen.new()
-    screen:attach({ui_ext={
-      'cmdline',
-      'popupmenu',
-      'tabline',
-      'wildmenu',
-    }})
-  end)
-  it('invalid "ui_ext" returns error', function()
-    local screen = Screen.new()
-
-    local status, rv = pcall(function() screen:attach({ui_ext={'foo'}}) end)
+    local status, rv = pcall(function() screen:attach({foo={'foo'}}) end)
     eq(false, status)
-    eq('ui_ext: unknown widget: foo', rv:match("ui_ext:.*"))
-
-    status, rv = pcall(function() screen:attach({ui_ext={'cmdline','foo'}}) end)
-    eq(false, status)
-    eq('ui_ext: unknown widget: foo', rv:match("ui_ext:.*"))
-
-    status, rv = pcall(function() screen:attach({ui_ext={'cmdline',1}}) end)
-    eq(false, status)
-    eq('ui_ext: item must be a String', rv:match("ui_ext:.*"))
+    eq('No such ui option', rv:match("No such .*"))
   end)
 end)

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -6,7 +6,7 @@ local insert = helpers.insert
 local eq = helpers.eq
 local eval = helpers.eval
 
-describe('Initial screen', function()
+describe('screen', function()
   local screen
   local nvim_argv = {helpers.nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
                      '--cmd', 'set shortmess+=I background=light noswapfile belloff= noshowcmd noruler',
@@ -27,7 +27,7 @@ describe('Initial screen', function()
     screen:detach()
   end)
 
-  it('is the default initial screen', function()
+  it('default initial screen', function()
       screen:expect([[
       ^                                                     |
       {0:~                                                    }|
@@ -565,12 +565,40 @@ describe('Screen', function()
       ]])
     end)
   end)
+end)
 
-  it('nvim_ui_attach() handles very large width/height #2180', function()
-    screen:detach()
-    screen = Screen.new(999, 999)
+describe('nvim_ui_attach()', function()
+  before_each(function()
+    clear()
+  end)
+  it('handles very large width/height #2180', function()
+    local screen = Screen.new(999, 999)
     screen:attach()
     eq(999, eval('&lines'))
     eq(999, eval('&columns'))
+  end)
+  it('"ui_ext" widgets', function()
+    local screen = Screen.new()
+    screen:attach({ui_ext={
+      'cmdline',
+      'popupmenu',
+      'tabline',
+      'wildmenu',
+    }})
+  end)
+  it('invalid "ui_ext" returns error', function()
+    local screen = Screen.new()
+
+    local status, rv = pcall(function() screen:attach({ui_ext={'foo'}}) end)
+    eq(false, status)
+    eq('ui_ext: unknown widget: foo', rv:match("ui_ext:.*"))
+
+    status, rv = pcall(function() screen:attach({ui_ext={'cmdline','foo'}}) end)
+    eq(false, status)
+    eq('ui_ext: unknown widget: foo', rv:match("ui_ext:.*"))
+
+    status, rv = pcall(function() screen:attach({ui_ext={'cmdline',1}}) end)
+    eq(false, status)
+    eq('ui_ext: item must be a String', rv:match("ui_ext:.*"))
   end)
 end)

--- a/test/functional/ui/tabline_spec.lua
+++ b/test/functional/ui/tabline_spec.lua
@@ -1,0 +1,58 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear, feed, eq = helpers.clear, helpers.feed, helpers.eq
+
+if helpers.pending_win32(pending) then return end
+
+describe('External tab line', function()
+  local screen
+  local tabs, curtab
+
+  before_each(function()
+    clear()
+    screen = Screen.new(25, 5)
+    screen:attach({rgb=true, tabline_external=true})
+    screen:set_on_event_handler(function(name, data)
+      if name == "tabline_update" then
+        curtab, tabs = unpack(data)
+      end
+    end)
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  describe("'tabline'", function()
+    it('tabline', function()
+      local expected = {
+        {1, {['name'] = '[No Name]'}},
+        {2, {['name'] = '[No Name]'}},
+      }
+      feed(":tabnew<CR>")
+      screen:expect([[
+        ^                         |
+        ~                        |
+        ~                        |
+        ~                        |
+                                 |
+      ]], nil, nil, function()
+        eq(2, curtab)
+        eq(expected, tabs)
+      end)
+
+      feed(":tabNext<CR>")
+      screen:expect([[
+        ^                         |
+        ~                        |
+        ~                        |
+        ~                        |
+                                 |
+      ]], nil, nil, function()
+        eq(1, curtab)
+        eq(expected, tabs)
+      end)
+
+    end)
+  end)
+end)

--- a/test/functional/ui/tabline_spec.lua
+++ b/test/functional/ui/tabline_spec.lua
@@ -1,10 +1,10 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
-local clear, feed, eq = helpers.clear, helpers.feed, helpers.eq
+local clear, command, eq = helpers.clear, helpers.command, helpers.eq
 
 describe('ui/tabline', function()
   local screen
-  local tabs, curtab
+  local event_tabs, event_curtab
 
   before_each(function()
     clear()
@@ -12,7 +12,7 @@ describe('ui/tabline', function()
     screen:attach({rgb=true, ext_tabline=true})
     screen:set_on_event_handler(function(name, data)
       if name == "tabline_update" then
-        curtab, tabs = unpack(data)
+        event_curtab, event_tabs = unpack(data)
       end
     end)
   end)
@@ -23,11 +23,12 @@ describe('ui/tabline', function()
 
   describe('externalized', function()
     it('publishes UI events', function()
-      local expected = {
-        {1, {['name'] = '[No Name]'}},
-        {2, {['name'] = '[No Name]'}},
+      command("tabedit another-tab")
+
+      local expected_tabs = {
+        {tab = { id = 1 }, name = '[No Name]'},
+        {tab = { id = 2 }, name = 'another-tab'},
       }
-      feed(":tabnew<CR>")
       screen:expect([[
         ^                         |
         ~                        |
@@ -35,11 +36,11 @@ describe('ui/tabline', function()
         ~                        |
                                  |
       ]], nil, nil, function()
-        eq(2, curtab)
-        eq(expected, tabs)
+        eq(2, event_curtab)
+        eq(expected_tabs, event_tabs)
       end)
 
-      feed(":tabNext<CR>")
+      command("tabNext")
       screen:expect([[
         ^                         |
         ~                        |
@@ -47,8 +48,8 @@ describe('ui/tabline', function()
         ~                        |
                                  |
       ]], nil, nil, function()
-        eq(1, curtab)
-        eq(expected, tabs)
+        eq(1, event_curtab)
+        eq(expected_tabs, event_tabs)
       end)
 
     end)

--- a/test/functional/ui/tabline_spec.lua
+++ b/test/functional/ui/tabline_spec.lua
@@ -2,16 +2,14 @@ local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, eq = helpers.clear, helpers.feed, helpers.eq
 
-if helpers.pending_win32(pending) then return end
-
-describe('External tab line', function()
+describe('ui/tabline', function()
   local screen
   local tabs, curtab
 
   before_each(function()
     clear()
     screen = Screen.new(25, 5)
-    screen:attach({rgb=true, tabline_external=true})
+    screen:attach({rgb=true, ui_ext={'tabline'}})
     screen:set_on_event_handler(function(name, data)
       if name == "tabline_update" then
         curtab, tabs = unpack(data)
@@ -23,8 +21,8 @@ describe('External tab line', function()
     screen:detach()
   end)
 
-  describe("'tabline'", function()
-    it('tabline', function()
+  describe('externalized', function()
+    it('publishes UI events', function()
       local expected = {
         {1, {['name'] = '[No Name]'}},
         {2, {['name'] = '[No Name]'}},

--- a/test/functional/ui/tabline_spec.lua
+++ b/test/functional/ui/tabline_spec.lua
@@ -9,7 +9,7 @@ describe('ui/tabline', function()
   before_each(function()
     clear()
     screen = Screen.new(25, 5)
-    screen:attach({rgb=true, ui_ext={'tabline'}})
+    screen:attach({rgb=true, ext_tabline=true})
     screen:set_on_event_handler(function(name, data)
       if name == "tabline_update" then
         curtab, tabs = unpack(data)

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -874,7 +874,7 @@ describe('ui/externalized/popupmenu', function()
   before_each(function()
     clear()
     screen = Screen.new(60, 8)
-    screen:attach({rgb=true, ui_ext={'popupmenu'}})
+    screen:attach({rgb=true, ext_popupmenu=true})
     screen:set_default_attr_ids({
       [1] = {bold=true, foreground=Screen.colors.Blue},
       [2] = {bold = true},

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -868,13 +868,13 @@ describe('completion', function()
   end)
 end)
 
-describe('External completion popupmenu', function()
+describe('ui/externalized/popupmenu', function()
   local screen
   local items, selected, anchor
   before_each(function()
     clear()
     screen = Screen.new(60, 8)
-    screen:attach({rgb=true, popupmenu_external=true})
+    screen:attach({rgb=true, ui_ext={'popupmenu'}})
     screen:set_default_attr_ids({
       [1] = {bold=true, foreground=Screen.colors.Blue},
       [2] = {bold = true},

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -167,7 +167,7 @@ if(USE_BUNDLED_BUSTED)
 
   add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build https://raw.githubusercontent.com/neovim/lua-client/0.0.1-25/nvim-client-0.0.1-25.rockspec ${LUAROCKS_BUILDARGS}
+    ARGS build https://raw.githubusercontent.com/neovim/lua-client/0.0.1-26/nvim-client-0.0.1-26.rockspec ${LUAROCKS_BUILDARGS}
     DEPENDS luv)
   add_custom_target(nvim-client
     DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client)


### PR DESCRIPTION
Continues #6170

Now that `:help api-contract` formalizes how we can grow the API, we can accelerate UI widget "externalization". We don't need to perfectly implement the UI events because `:help api-contract` allows for adding new items to existing events.

#6170 is simple enough that it's worth including in 0.2.

**Todo (future)**:

- tabline click events (`StlClickRecord`) aren't handled by this change. See https://github.com/neovim/neovim/pull/6170#issuecomment-283006537 

cc @bfredl 