### PR TITLE
coverity/161641: Operands don't affect result

### DIFF
--- a/src/nvim/assert.h
+++ b/src/nvim/assert.h
@@ -94,7 +94,6 @@
 # define STATIC_ASSERT_PRAGMA_END \
     _Pragma("clang diagnostic pop") \
 
-// TODO(aktau): verify that this works, don't have MSVC on hand.
 #elif _MSC_VER >= 1600
 
 # define STATIC_ASSERT_STATEMENT(cond, msg) static_assert(cond, msg)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12770,16 +12770,12 @@ static void f_nr2char(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   bool error = false;
   const varnumber_T num = tv_get_number_chk(&argvars[0], &error);
+  STATIC_ASSERT(sizeof(varnumber_T) <= sizeof(int), "check (num <= INT_MAX)");
   if (error) {
     return;
   }
   if (num < 0) {
     emsgf(_("E5070: Character number must not be less than zero"));
-    return;
-  }
-  if (num > INT_MAX) {
-    emsgf(_("E5071: Character number must not be greater than INT_MAX (%i)"),
-          INT_MAX);
     return;
   }
 


### PR DESCRIPTION
since `varnumber_T ` is defined as `int` we don't need a runtime check. cc @ZyX-I 