### PR TITLE
[RFC] connect to socket (RPC only for the moment)

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6863,6 +6863,21 @@ sinh({expr})						*sinh()*
 			:echo sinh(-0.9)
 <			-1.026517
 
+sockconnect({mode}, {address}, {opts})			 *sockconnect()*
+		Connect a socket to an address. If {mode} is "pipe" then
+		{address} should be the path of a named pipe. If {mode} is
+		"tcp" then {address} should be of the form "host:port" where
+		the host should be an ip adderess or host name, and port the
+		port number. Currently only rpc sockets are supported, so
+		{opts} must be passed with "rpc" set to |TRUE|.
+
+		{opts} is a dictionary with these keys:
+		  rpc      : If set, |msgpack-rpc| will be used to communicate
+			     over the socket.
+		Returns:
+		  - The channel ID on success, which is used by
+		    |rpcnotify()| and |rpcrequest()| and |rpcstop()|.
+		  - 0 on invalid arguments or connection failure.
 
 sort({list} [, {func} [, {dict}]])			*sort()* *E702*
 		Sort the items in {list} in-place.  Returns {list}.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -268,6 +268,7 @@ return {
     simplify={args=1},
     sin={args=1, func="float_op_wrapper", data="&sin"},
     sinh={args=1, func="float_op_wrapper", data="&sinh"},
+    sockconnect={args={2,3}},
     sort={args={1, 3}},
     soundfold={args=1},
     spellbadword={args={0, 1}},

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -97,6 +97,18 @@ char *server_address_new(void)
 #endif
 }
 
+/// Check if this instance owns a pipe address.
+/// The argument must already be resolved to an absolute path!
+bool server_owns_pipe_address(const char *path)
+{
+  for (int i = 0; i < watchers.ga_len; i++) {
+    if (!strcmp(path, ((SocketWatcher **)watchers.ga_data)[i]->addr)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /// Starts listening for API calls.
 ///
 /// The socket type is determined by parsing `endpoint`: If it's a valid IPv4

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1715,7 +1715,7 @@ int vim_FullName(const char *fname, char *buf, size_t len, bool force)
 ///
 /// @param fname is the filename to expand
 /// @return [allocated] Full path (NULL for failure).
-char *fix_fname(char *fname)
+char *fix_fname(const char *fname)
 {
 #ifdef UNIX
   return FullName_save(fname, true);

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -282,4 +282,20 @@ describe('server -> client', function()
     end)
   end)
 
+  describe('when connecting to its own pipe adress', function()
+    it('it does not deadlock', function()
+      local address = funcs.serverlist()[1]
+      local first = string.sub(address,1,1)
+      ok(first == '/' or first == '\\')
+      local serverpid = funcs.getpid()
+
+      local id = funcs.sockconnect('pipe', address, {rpc=true})
+
+      funcs.rpcrequest(id, 'nvim_set_current_line', 'hello')
+      eq('hello', meths.get_current_line())
+      eq(serverpid, funcs.rpcrequest(id, "nvim_eval", "getpid()"))
+
+      eq(id, funcs.rpcrequest(id, 'nvim_get_api_info')[1])
+    end)
+  end)
 end)

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -76,8 +76,8 @@ end
 
 local session, loop_running, last_error
 
-local function set_session(s)
-  if session then
+local function set_session(s, keep)
+  if session and not keep then
     session:close()
   end
   session = s
@@ -609,6 +609,7 @@ local module = {
   nvim = nvim,
   nvim_async = nvim_async,
   nvim_prog = nvim_prog,
+  nvim_argv = nvim_argv,
   nvim_set = nvim_set,
   nvim_dir = nvim_dir,
   buffer = buffer,


### PR DESCRIPTION
Adds `sockopen(mode, address, {options})`

- [x] named pipe
- [x] tcp (ip/hostname)
- [x] rpc protocol
- [ ] bytes protocol (done later in #6844)
- [x] sane error handling
- [x] tests and documentation

Currently connecting to another nvim instance over its named pipe works.