### PR TITLE
terminal: Refresh before on_exit.

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -449,7 +449,7 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
 
   if (buf->terminal) {
     terminal_close(buf->terminal, NULL);
-  } 
+  }
 
   /* Always remove the buffer when there is no file name. */
   if (buf->b_ffname == NULL)

--- a/src/nvim/event/process.h
+++ b/src/nvim/event/process.h
@@ -26,7 +26,7 @@ struct process {
   Stream *in, *out, *err;
   process_exit_cb cb;
   internal_process_cb internal_exit_cb, internal_close_cb;
-  bool closed, detach;
+  bool closed, term_sent, detach;
   MultiQueue *events;
 };
 
@@ -48,6 +48,7 @@ static inline Process process_init(Loop *loop, ProcessType type, void *data)
     .err = NULL,
     .cb = NULL,
     .closed = false,
+    .term_sent = false,
     .internal_close_cb = NULL,
     .internal_exit_cb = NULL,
     .detach = false

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -302,8 +302,16 @@ void terminal_close(Terminal *term, char *msg)
   }
 
   term->forward_mouse = false;
-  term->closed = true;
+
+  // flush any pending changes to the buffer
+  if (!exiting) {
+    block_autocmds();
+    refresh_terminal(term);
+    unblock_autocmds();
+  }
+
   buf_T *buf = handle_get_buffer(term->buf_handle);
+  term->closed = true;
 
   if (!msg || exiting) {
     // If no msg was given, this was called by close_buffer(buffer.c).  Or if


### PR DESCRIPTION
see #5217

The terminal is updated by a timer, but on_exit needs the final state.
Before this change, on_exit callback could see a stale terminal buffer.