### PR TITLE
[RFC] Set ':filetype plugin indent on' before sourcing startup scripts

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -338,9 +338,6 @@ int main(int argc, char **argv)
   /* Execute --cmd arguments. */
   exe_pre_commands(&params);
 
-  /* Source startup scripts. */
-  source_startup_scripts(&params);
-
   // If using the runtime (-u is not NONE), enable syntax & filetype plugins.
   if (params.use_vimrc == NULL || strcmp(params.use_vimrc, "NONE") != 0) {
     // Does ":filetype plugin indent on".
@@ -348,6 +345,9 @@ int main(int argc, char **argv)
     // Sources syntax/syntax.vim, which calls `:filetype on`.
     syn_maybe_on();
   }
+
+  // Source startup scripts.
+  source_startup_scripts(&params);
 
   /*
    * Read all the plugin files.


### PR DESCRIPTION
Assume the following vimrc:

      colorscheme desert
      hi Cursor ...

Using this with `nvim -u vimrc` would result in main.c executing the following functions:

      source_startup_scripts()
      syn_maybe_on()

This would result in the colorscheme getting sourced twice. Thus the custom definition of `Cursor` would be overwritten by the second sourcing of the colorscheme.

This commit simply swaps both function calls.

References #6591.

---

Here are both backtraces of how it behaved _before_ this commit:

<details>
<summary>First call</summary>

```
  * frame #0: 0x00000001000dbe6c nvim`ex_colorscheme(eap=0x00007fff5fbfe5c8) at ex_docmd.c:5834
    frame #1: 0x00000001000cefe5 nvim`do_one_cmd(cmdlinep=0x00007fff5fbfe8c8, flags=7, cstack=0x00007fff5fbfe8d0, fgetline=(nvim`getsourceline at ex_cmds2.c:3055), cookie=0x00007
fff5fbfeee0) at ex_docmd.c:2207
    frame #2: 0x00000001000cb24c nvim`do_cmdline(cmdline="colorscheme desert", fgetline=(nvim`getsourceline at ex_cmds2.c:3055), cookie=0x00007fff5fbfeee0, flags=7) at ex_docmd.c
:606
    frame #3: 0x00000001000c8874 nvim`do_source(fname="/tmp/vimrc", check_other=0, is_vimrc=0) at ex_cmds2.c:2935
    frame #4: 0x000000010013e1bd nvim`source_startup_scripts(parmp=0x00007fff5fbfefe0) at main.c:1728
    frame #5: 0x000000010013c013 nvim`main(argc=3, argv=0x00007fff5fbff118) at main.c:342
```
</details>

<details>
<summary>Second call</summary>

```
  * frame #0: 0x00000001000dbe6c nvim`ex_colorscheme(eap=0x00007fff5fbfc218) at ex_docmd.c:5834
    frame #1: 0x00000001000cefe5 nvim`do_one_cmd(cmdlinep=0x00007fff5fbfc518, flags=3, cstack=0x00007fff5fbfc520, fgetline=(nvim`getsourceline at ex_cmds2.c:3055), cookie=0x00007fff5fbfd5d0) at ex_docmd.c:2207
    frame #2: 0x00000001000cb24c nvim`do_cmdline(cmdline="colors desert", fgetline=(nvim`getsourceline at ex_cmds2.c:3055), cookie=0x00007fff5fbfd5d0, flags=3) at ex_docmd.c:606
    frame #3: 0x0000000100064a73 nvim`ex_execute(eap=0x00007fff5fbfccb8) at eval.c:19343
    frame #4: 0x00000001000cefe5 nvim`do_one_cmd(cmdlinep=0x00007fff5fbfcfb8, flags=7, cstack=0x00007fff5fbfcfc0, fgetline=(nvim`getsourceline at ex_cmds2.c:3055), cookie=0x00007fff5fbfd5d0) at ex_docmd.c:2207
    frame #5: 0x00000001000cb24c nvim`do_cmdline(cmdline="\" Vim syntax support file", fgetline=(nvim`getsourceline at ex_cmds2.c:3055), cookie=0x00007fff5fbfd5d0, flags=7) at ex_docmd.c:606
    frame #6: 0x00000001000c8874 nvim`do_source(fname="/usr/local/share/nvim/runtime/syntax/synload.vim", check_other=0, is_vimrc=0) at ex_cmds2.c:2935
    frame #7: 0x00000001000c6f8f nvim`source_callback(fname="/usr/local/share/nvim/runtime/syntax/synload.vim", cookie=0x0000000000000000) at ex_cmds2.c:2318
    frame #8: 0x00000001000c738d nvim`do_in_path(path="/Users/mhi/.config/nvim,/etc/xdg/nvim,/Users/mhi/.local/share/nvim/site,/usr/local/share/nvim/site,/usr/share/nvim/site,/usr/local/share/nvim/runtime,/usr/share/nvim/site/after,/usr/local/share/nvim/site/after,/Users/mhi/.local/share/nvim/site/after,/etc/xdg/nvim/after,/Users/mhi/.config/nvim/after", name="syntax/synload.vim", flags=0, callback=(nvim`source_callback at ex_cmds2.c:2317), cookie=0x0000000000000000) at ex_cmds2.c:2406
    frame #9: 0x00000001000c6e0e nvim`do_in_runtimepath(name="syntax/synload.vim", flags=0, callback=(nvim`source_callback at ex_cmds2.c:2317), cookie=0x0000000000000000) at ex_cmds2.c:2450
    frame #10: 0x00000001000c6c46 nvim`source_runtime(name="syntax/synload.vim", flags=0) at ex_cmds2.c:2328
    frame #11: 0x00000001000c6daa nvim`ex_runtime(eap=0x00007fff5fbfda18) at ex_cmds2.c:2312
    frame #12: 0x00000001000cefe5 nvim`do_one_cmd(cmdlinep=0x00007fff5fbfdd18, flags=7, cstack=0x00007fff5fbfdd20, fgetline=(nvim`getsourceline at ex_cmds2.c:3055), cookie=0x00007fff5fbfe330) at ex_docmd.c:2207
    frame #13: 0x00000001000cb24c nvim`do_cmdline(cmdline="\" Vim syntax support file", fgetline=(nvim`getsourceline at ex_cmds2.c:3055), cookie=0x00007fff5fbfe330, flags=7) at ex_docmd.c:606
    frame #14: 0x00000001000c8874 nvim`do_source(fname="/usr/local/share/nvim/runtime/syntax/syntax.vim", check_other=0, is_vimrc=0) at ex_cmds2.c:2935
    frame #15: 0x00000001000c7e68 nvim`cmd_source(fname="/usr/local/share/nvim/runtime/syntax/syntax.vim", eap=0x00007fff5fbfe5c8) at ex_cmds2.c:2680
    frame #16: 0x00000001000c7ebc nvim`ex_source(eap=0x00007fff5fbfe5c8) at ex_cmds2.c:2661
    frame #17: 0x00000001000cefe5 nvim`do_one_cmd(cmdlinep=0x00007fff5fbfe8c8, flags=10, cstack=0x00007fff5fbfe8d0, fgetline=0x0000000000000000, cookie=0x0000000000000000) at ex_docmd.c:2207
    frame #18: 0x00000001000cb24c nvim`do_cmdline(cmdline="so $VIMRUNTIME/syntax/syntax.vim", fgetline=0x0000000000000000, cookie=0x0000000000000000, flags=10) at ex_docmd.c:606
    frame #19: 0x00000001000cc1c6 nvim`do_cmdline_cmd(cmd="so $VIMRUNTIME/syntax/syntax.vim") at ex_docmd.c:278
    frame #20: 0x0000000100272e74 nvim`syn_cmd_onoff(eap=0x00007fff5fbfeeb0, name="syntax") at syntax.c:3390
    frame #21: 0x0000000100272db1 nvim`syn_maybe_on at syntax.c:3400
    frame #22: 0x000000010013c047 nvim`main(argc=3, argv=0x00007fff5fbff118) at main.c:349
```
</details>