### PR TITLE
[RFC] allow window specific ui highlighting (currently only window background)

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3128,7 +3128,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	use for that occasion.  The occasions are:
 	|hl-SpecialKey|	 8  Meta and special keys listed with ":map"
 	|hl-Whitespace|	 0
-	|hl-EndOfBuffer|   ~ lines after the last line in the buffer
+	|hl-EndOfBuffer|   ~  lines after the last line in the buffer
+	|hl-NormalNC|	 I  inactive (not the current) window
 	|hl-TermCursor|	 z  Cursor in a focused terminal
 	|hl-TermCursorNC|  Z Cursor in an unfocused terminal
 	|hl-NonText|	 @  '@' at the end of the window and

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6844,6 +6844,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 	'winheight' applies to the current window.  Use 'winminheight' to set
 	the minimal height for other windows.
 
+						*'winhighlight'* *'winhl'*
+'winhighlight' 'winhl'	string (default empty)
+			local to window
+	Highlight groups specific to a window.  It consists of items that must
+	be separated by a comma, each item is a global builtin highlight group
+	and a highlight group overidding it for this window, separated by a
+	colon. Currently only |hl-Normal| and |hl-NormalNC| can be overriden;
+	this is mostly useful for changing the background color. Example: >
+		set winhighlight=Normal:MyBackground,NormalNC:MyBackgroundNC
+<
 			*'winfixheight'* *'wfh'* *'nowinfixheight'* *'nowfh'*
 'winfixheight' 'wfh'	boolean	(default off)
 			local to window

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4922,6 +4922,8 @@ NonText		'@' at the end of the window, characters from 'showbreak'
 		fit at the end of the line). See also |hl-EndOfBuffer|.
 							*hl-Normal*
 Normal		normal text
+							*hl-NormalNC*
+NormalNC	normal text in non-current window
 							*hl-Pmenu*
 Pmenu		Popup menu: normal item.
 							*hl-PmenuSel*

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2316,7 +2316,7 @@ void get_winopts(buf_T *buf)
   /* Set 'foldlevel' to 'foldlevelstart' if it's not negative. */
   if (p_fdls >= 0)
     curwin->w_p_fdl = p_fdls;
-  check_colorcolumn(curwin);
+  didset_window_options(curwin);
 }
 
 /*

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -233,6 +233,8 @@ typedef struct {
 # define w_p_crb_save w_onebuf_opt.wo_crb_save
   char_u *wo_scl;
 # define w_p_scl w_onebuf_opt.wo_scl    // 'signcolumn'
+  char_u *wo_winhl;
+# define w_p_winhl w_onebuf_opt.wo_winhl    // 'winhighlight'
 
   int wo_scriptID[WV_COUNT];            /* SIDs for window-local options */
 # define w_p_scriptID w_onebuf_opt.wo_scriptID
@@ -929,6 +931,10 @@ struct window_S {
                                     ///< often, keep it the first item!)
 
   synblock_T  *w_s;                 /* for :ownsyntax */
+
+  int w_hl_id;                      ///< 'winhighlight' id
+  int w_hl_id_inactive;             ///< 'winhighlight' id for inactive window
+  int w_hl_attr;                    ///< 'winhighlight' final attrs
 
   win_T       *w_prev;              /* link to previous window */
   win_T       *w_next;              /* link to next window */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -465,6 +465,7 @@ typedef enum {
   , HLF_MC          // 'colorcolumn'
   , HLF_QFL         // selected quickfix line
   , HLF_0           // Whitespace
+  , HLF_INACTIVE    // Inactive window
   , HLF_COUNT       // MUST be the last one
 } hlf_T;
 
@@ -473,7 +474,7 @@ typedef enum {
 #define HL_FLAGS { '8', '~', 'z', 'Z', '@', 'd', 'e', 'i', 'l', 'm', 'M', 'n', \
                    'N', 'r', 's', 'S', 'c', 't', 'v', 'V', 'w', 'W', 'f', 'F', \
                    'A', 'C', 'D', 'T', '-', '>', 'B', 'P', 'R', 'L', '+', '=', \
-                   'x', 'X', '*', '#', '_', '!', '.', 'o', 'q', '0' }
+                   'x', 'X', '*', '#', '_', '!', '.', 'o', 'q', '0', 'I' }
 
 EXTERN int highlight_attr[HLF_COUNT];       /* Highl. attr for each context. */
 EXTERN int highlight_user[9];                   /* User[1-9] attributes */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -8,6 +8,9 @@
 //   - Add a BV_XX or WV_XX entry to option_defs.h
 //   - Add a variable to the window or buffer struct in buffer_defs.h.
 //   - For a window option, add some code to copy_winopt().
+//   - For a window string option, add code to check_winopt()
+//     and clear_winopt(). If setting the option needs parsing,
+//     add some code to didset_window_options().
 //   - For a buffer option, add some code to buf_copy_options().
 //   - For a buffer string option, add code to check_buf_options().
 // - If it's a numeric option, add any necessary bounds checks to do_set().
@@ -5514,7 +5517,6 @@ void win_copy_options(win_T *wp_from, win_T *wp_to)
   copy_winopt(&wp_from->w_allbuf_opt, &wp_to->w_allbuf_opt);
   /* Is this right? */
   wp_to->w_farsi = wp_from->w_farsi;
-  briopt_check(wp_to);
 }
 
 /*
@@ -5615,6 +5617,13 @@ void clear_winopt(winopt_T *wop)
   clear_string_option(&wop->wo_cocu);
   clear_string_option(&wop->wo_briopt);
 }
+
+void didset_window_options(win_T *wp)
+{
+  check_colorcolumn(wp);
+  briopt_check(wp);
+}
+
 
 /*
  * Copy global option values to local options for one buffer.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -252,7 +252,7 @@ typedef struct vimoption {
   "B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel," \
   "x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill," \
   "!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixLine," \
-  "0:Whitespace"
+  "0:Whitespace,I:NormalNC"
 
 /*
  * options[] is initialized here.
@@ -3174,6 +3174,10 @@ did_set_string_option (
     if (!valid_filetype(*varp)) {
       errmsg = e_invarg;
     }
+  } else if (varp == &curwin->w_p_winhl) {
+    if (!parse_winhl_opt(curwin)) {
+      errmsg = e_invarg;
+    }
   } else {
     // Options that are a list of flags.
     p = NULL;
@@ -3580,6 +3584,38 @@ static char_u *compile_cap_prog(synblock_T *synblock)
 
   vim_regfree(rp);
   return NULL;
+}
+
+/// Handle setting `winhighlight' in window "wp"
+static bool parse_winhl_opt(win_T *wp)
+{
+  int w_hl_id = 0, w_hl_id_inactive = 0;
+
+  const char *p = (const char *)wp->w_p_winhl;
+  while (*p) {
+    char *colon = strchr(p, ':');
+    if (!colon) {
+      return false;
+    }
+    size_t nlen = (size_t)(colon-p);
+    char *hi = colon+1;
+    char *commap = xstrchrnul(hi, ',');
+    int hl_id = syn_check_group((char_u *)hi, (int)(commap-hi));
+
+    if (strncmp("Normal", p, nlen) == 0) {
+      w_hl_id = hl_id;
+    } else if (strncmp("NormalNC", p, nlen) == 0) {
+      w_hl_id_inactive = hl_id;
+    } else {
+      return false;
+    }
+
+    p = *commap ? commap+1 : "";
+  }
+
+  wp->w_hl_id = w_hl_id;
+  wp->w_hl_id_inactive = w_hl_id_inactive;
+  return true;
 }
 
 /*
@@ -5491,6 +5527,7 @@ static char_u *get_varp(vimoption_T *p)
   case PV_WM:     return (char_u *)&(curbuf->b_p_wm);
   case PV_KMAP:   return (char_u *)&(curbuf->b_p_keymap);
   case PV_SCL:    return (char_u *)&(curwin->w_p_scl);
+  case PV_WINHL:  return (char_u *)&(curwin->w_p_winhl);
   default:        EMSG(_("E356: get_varp ERROR"));
   }
   /* always return a valid pointer to avoid a crash! */
@@ -5568,6 +5605,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_fdt = vim_strsave(from->wo_fdt);
   to->wo_fmr = vim_strsave(from->wo_fmr);
   to->wo_scl = vim_strsave(from->wo_scl);
+  to->wo_winhl = vim_strsave(from->wo_winhl);
   check_winopt(to);             // don't want NULL pointers
 }
 
@@ -5597,6 +5635,7 @@ static void check_winopt(winopt_T *wop)
   check_string_option(&wop->wo_cc);
   check_string_option(&wop->wo_cocu);
   check_string_option(&wop->wo_briopt);
+  check_string_option(&wop->wo_winhl);
 }
 
 /*
@@ -5616,12 +5655,14 @@ void clear_winopt(winopt_T *wop)
   clear_string_option(&wop->wo_cc);
   clear_string_option(&wop->wo_cocu);
   clear_string_option(&wop->wo_briopt);
+  clear_string_option(&wop->wo_winhl);
 }
 
 void didset_window_options(win_T *wp)
 {
   check_colorcolumn(wp);
   briopt_check(wp);
+  parse_winhl_opt(wp);
 }
 
 

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -807,6 +807,7 @@ enum {
   , WV_WFW
   , WV_WRAP
   , WV_SCL
+  , WV_WINHL
   , WV_COUNT        // must be the last one
 };
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2702,6 +2702,14 @@ return {
       defaults={if_true={vi="menu"}}
     },
     {
+      full_name='winhighlight', abbreviation='winhl',
+      type='string', scope={'window'},
+      vi_def=true,
+      alloced=true,
+      redraw={'current_window'},
+      defaults={if_true={vi=""}}
+    },
+    {
       full_name='window', abbreviation='wi',
       type='number', scope={'global'},
       vi_def=true,

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1043,7 +1043,7 @@ static void win_init(win_T *newp, win_T *oldp, int flags)
 
   win_init_some(newp, oldp);
 
-  check_colorcolumn(newp);
+  didset_window_options(newp);
 }
 
 /*

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3722,6 +3722,12 @@ static void win_enter_ext(win_T *wp, bool undo_sync, int curwin_invalid,
   if (restart_edit)
     redraw_later(VALID);        /* causes status line redraw */
 
+  if (hl_attr(HLF_INACTIVE)
+      || (prevwin && prevwin->w_hl_id_inactive)
+      || curwin->w_hl_id_inactive) {
+    redraw_all_later(NOT_VALID);
+  }
+
   /* set window height to desired minimal value */
   if (curwin->w_height < p_wh && !curwin->w_p_wfh)
     win_setheight((int)p_wh);

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -194,8 +194,8 @@ describe('ui/cursor', function()
         if m.blinkoff then m.blinkoff = 400 end
         if m.blinkwait then m.blinkwait = 700 end
       end
-      if m.hl_id then m.hl_id = 46 end
-      if m.id_lm then m.id_lm = 47 end
+      if m.hl_id then m.hl_id = 47 end
+      if m.id_lm then m.id_lm = 48 end
     end
 
     -- Assert the new expectation.


### PR DESCRIPTION
While doing stupid experiments with floating windows, I realized they need to be in a different background color. But this might be useful in general. (It was discussed, issue #5302).

`set winbg=HighlightGroup`

Though it is not currently restricted to background color, any attribute can be set. So maybe the option should have a different name.
