### PR TITLE
api/ui: external 'tabline'

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include "nvim/log.h"
 #include "nvim/api/private/handle.h"
 #include "nvim/ascii.h"
 #include "nvim/assert.h"
@@ -2848,9 +2849,8 @@ void maketitle(void)
 
         use_sandbox = was_set_insecurely((char_u *)"titlestring", 0);
         called_emsg = FALSE;
-        build_stl_str_hl(curwin, t_str, sizeof(buf),
-            p_titlestring, use_sandbox,
-            0, maxlen, NULL, NULL);
+        build_stl_str_hl(curwin, t_str, sizeof(buf), p_titlestring,
+                         use_sandbox, 0, maxlen, NULL, NULL, NULL, NULL);
         if (called_emsg)
           set_string_option_direct((char_u *)"titlestring", -1,
               (char_u *)"", OPT_FREE, SID_ERROR);
@@ -2938,9 +2938,8 @@ void maketitle(void)
 
         use_sandbox = was_set_insecurely((char_u *)"iconstring", 0);
         called_emsg = FALSE;
-        build_stl_str_hl(curwin, i_str, sizeof(buf),
-            p_iconstring, use_sandbox,
-            0, 0, NULL, NULL);
+        build_stl_str_hl(curwin, i_str, sizeof(buf), p_iconstring, use_sandbox,
+                         0, 0, NULL, NULL, NULL, NULL);
         if (called_emsg)
           set_string_option_direct((char_u *)"iconstring", -1,
               (char_u *)"", OPT_FREE, SID_ERROR);
@@ -3040,6 +3039,7 @@ typedef enum {
 /// @param out The output buffer to write the statusline to
 ///            Note: This should not be NameBuff
 /// @param outlen The length of the output buffer
+/// @param outitems[out] Allocated NULL-terminated array of statusline items.
 /// @param fmt The statusline format string
 /// @param use_sandbox Use a sandboxed environment when evaluating fmt
 /// @param fillchar Character to use when filling empty space in the statusline
@@ -3057,30 +3057,18 @@ int build_stl_str_hl(
     char_u fillchar,
     int maxwidth,
     struct stl_hlrec *hltab,
-    StlClickRecord *tabtab
+    StlClickRecord *tabtab,
+    StlItem *outitems,
+    size_t *outitemscnt
 )
 {
+  static bool entered = false;
+  static StlItem items2[STL_MAX_ITEM];
+  assert(!entered);
+  entered = true;
+
   int groupitems[STL_MAX_ITEM];
-  struct stl_item {
-    // Where the item starts in the status line output buffer
-    char_u *start;
-    // Function to run for ClickFunc items.
-    char *cmd;
-    // The minimum width of the item
-    int minwid;
-    // The maximum width of the item
-    int maxwid;
-    enum {
-      Normal,
-      Empty,
-      Group,
-      Separate,
-      Highlight,
-      TabPage,
-      ClickFunc,
-      Trunc
-    } type;
-  } items[STL_MAX_ITEM];
+  StlItem *items = outitems ? outitems : items2;
 #define TMPLEN 70
   char_u tmp[TMPLEN];
   char_u      *usefmt = fmt;
@@ -3900,6 +3888,10 @@ int build_stl_str_hl(
     xfree(usefmt);
   }
 
+  if (outitemscnt) {
+    *outitemscnt = (size_t)itemcnt;
+  }
+
   // We have now processed the entire statusline format string.
   // What follows is post-processing to handle alignment and highlighting.
 
@@ -4123,6 +4115,7 @@ int build_stl_str_hl(
     cur_tab_rec->def.func = NULL;
   }
 
+  entered = false;
   return width;
 }
 

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -88,6 +88,7 @@ typedef struct {
 typedef struct window_S win_T;
 typedef struct wininfo_S wininfo_T;
 typedef struct frame_S frame_T;
+typedef struct StlItem StlItem;
 
 // for struct memline (it needs memfile_T)
 #include "nvim/memline_defs.h"
@@ -1157,6 +1158,27 @@ struct window_S {
    * In a non-location list window, w_llist_ref is NULL.
    */
   qf_info_T   *w_llist_ref;
+};
+
+struct StlItem {
+  // Where the item starts in the status line output buffer
+  char_u *start;
+  // Function to run for ClickFunc items.
+  char *cmd;
+  // The minimum width of the item
+  int minwid;
+  // The maximum width of the item
+  int maxwid;
+  enum {
+    Normal,
+    Empty,
+    Group,
+    Separate,
+    Highlight,
+    TabPage,
+    ClickFunc,
+    Trunc
+  } type;
 };
 
 #endif // NVIM_BUFFER_DEFS_H

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -535,9 +535,8 @@ static void prt_header(prt_settings_T *psettings, int pagenum, linenr_T lnum)
     printer_page_num = pagenum;
 
     use_sandbox = was_set_insecurely((char_u *)"printheader", 0);
-    build_stl_str_hl(curwin, tbuf, (size_t)width + IOSIZE,
-        p_header, use_sandbox,
-        ' ', width, NULL, NULL);
+    build_stl_str_hl(curwin, tbuf, (size_t)width + IOSIZE, p_header,
+                     use_sandbox, ' ', width, NULL, NULL, NULL, NULL);
 
     /* Reset line numbers */
     curwin->w_cursor.lnum = tmp_lnum;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -5133,9 +5133,8 @@ win_redr_custom (
   /* Make a copy, because the statusline may include a function call that
    * might change the option value and free the memory. */
   stl = vim_strsave(stl);
-  width = build_stl_str_hl(ewp, buf, sizeof(buf),
-      stl, use_sandbox,
-      fillchar, maxwidth, hltab, tabtab);
+  width = build_stl_str_hl(ewp, buf, sizeof(buf), stl, use_sandbox, fillchar,
+                           maxwidth, hltab, tabtab, NULL, NULL);
   xfree(stl);
   ewp->w_p_crb = p_crb_save;
 
@@ -7034,6 +7033,49 @@ static void draw_tabline(void)
 
 void ui_ext_tabline_update(void)
 {
+  char_u buf[MAXPATHL];
+  char_u      *stl;
+  int fillchar = ' ';
+  int maxwidth = Columns;
+  int use_sandbox = was_set_insecurely((char_u *)"tabline", 0);
+  struct stl_hlrec hltab[STL_MAX_ITEM];
+  StlClickRecord tabtab[STL_MAX_ITEM];
+  char_u *p;
+  int len;
+  size_t tabcount = 0;
+  FOR_ALL_TABS(tp) {
+    tabcount++;
+  }
+
+  if (*p_tal != NUL) {
+    // XXX: Cargo-cult copied from win_redr_custom(). Still needed?
+    int p_crb_save = curwin->w_p_crb;
+    curwin->w_p_crb = FALSE;
+
+    /* Make a copy, because the statusline may include a function call that
+     * might change the option value and free the memory. */
+    stl = vim_strsave(p_tal);
+    StlItem items[STL_MAX_ITEM];
+    size_t itemscnt = 0;
+    (void)build_stl_str_hl(curwin, buf, sizeof(buf), stl, use_sandbox,
+                           fillchar, maxwidth, hltab, tabtab, items, &itemscnt);
+    xfree(stl);
+
+    curwin->w_p_crb = p_crb_save;
+
+    char *prevstart = itemscnt > 0 ? (char *)items[0].start : NULL;
+    char str[1024] = { 0 };
+    for (size_t l = 0; l < itemscnt; l++) {
+      if (items[l].type == TabPage) {
+        memset(str, 0, sizeof(str));
+        size_t len = (size_t)((char *)items[l].start - prevstart);
+        memcpy(str, prevstart, MIN(len, sizeof(str)));
+        prevstart = (char *)items[l].start;
+        ILOG("tab=%s", str);
+      }
+    }
+  }
+
   Array args = ARRAY_DICT_INIT;
   ADD(args, INTEGER_OBJ(curtab->handle));
   Array tabs = ARRAY_DICT_INIT;


### PR DESCRIPTION
Just pushing this for reference, not going to try to finish it before 0.2.

Currently the externalized tabline doesn't reflect the user's actual `'tabline'` customizations. This PR addresses that.

cc @dzhou121 

Related:

- https://github.com/neovim/neovim/pull/16020