### PR TITLE
[RFC] api: do not run autocmds on set_option

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -18,6 +18,7 @@
 #include "nvim/memory.h"
 #include "nvim/eval.h"
 #include "nvim/eval/typval.h"
+#include "nvim/fileio.h"
 #include "nvim/map_defs.h"
 #include "nvim/map.h"
 #include "nvim/option.h"
@@ -970,9 +971,11 @@ static void set_option_value_err(char *key,
                                  int opt_flags,
                                  Error *err)
 {
-  char *errmsg;
+  block_autocmds();
+  char *errmsg = set_option_value(key, numval, stringval, opt_flags);
+  unblock_autocmds();
 
-  if ((errmsg = set_option_value(key, numval, stringval, opt_flags))) {
+  if (errmsg) {
     if (try_end(err)) {
       return;
     }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4747,19 +4747,11 @@ char *set_option_value(const char *const name, const long number,
     return NULL;
   }
 
-  int opt_idx;
-  char_u      *varp;
-
-  opt_idx = findoption(name);
+  int opt_idx = findoption(name);
   if (opt_idx < 0) {
     EMSG2(_("E355: Unknown option: %s"), name);
   } else {
     uint32_t flags = options[opt_idx].flags;
-    // Disallow changing some options in the sandbox
-    if (sandbox > 0 && (flags & P_SECURE)) {
-      EMSG(_(e_sandbox));
-      return NULL;
-    }
     if (flags & P_STRING) {
       const char *s = string;
       if (s == NULL) {
@@ -4767,8 +4759,8 @@ char *set_option_value(const char *const name, const long number,
       }
       return set_string_option(opt_idx, s, opt_flags);
     } else {
-      varp = get_varp_scope(&(options[opt_idx]), opt_flags);
-      if (varp != NULL) {       /* hidden option is not changed */
+      char_u *varp = get_varp_scope(&(options[opt_idx]), opt_flags);
+      if (varp != NULL) {  // hidden option is not changed
         if (number == 0 && string != NULL) {
           int idx;
 

--- a/test/functional/legacy/autocmd_option_spec.lua
+++ b/test/functional/legacy/autocmd_option_spec.lua
@@ -295,7 +295,7 @@ describe('au OptionSet', function()
 
         nvim.set_option('autochdir', true)
         eq(true, nvim.get_option('autochdir'))
-        expected_combination({'autochdir', '0', '1', 'global'})
+        expected_empty()
       end)
 
       it('should trigger if a number option be set globally', function()
@@ -303,7 +303,7 @@ describe('au OptionSet', function()
 
         nvim.set_option('cmdheight', 5)
         eq(5, nvim.get_option('cmdheight'))
-        expected_combination({'cmdheight', 1, 5, 'global'})
+        expected_empty()
       end)
 
       it('should trigger if a string option be set globally', function()
@@ -311,7 +311,7 @@ describe('au OptionSet', function()
 
         nvim.set_option('ambiwidth', 'double')
         eq('double', nvim.get_option('ambiwidth'))
-        expected_combination({'ambiwidth', 'single', 'double', 'global'})
+        expected_empty()
       end)
     end)
   end)


### PR DESCRIPTION
Ref #3776.

Not sure where to best document this. Some general statement along the lines of "unless VimL is invoked, no autocmds are executed" at the start of `api.txt` might be good. (I don't know if the other api functions follow this convention yet, though...)

Also: The sandbox check in set_option_value is unnecessary as the type
specific option setter functions do the check as well.