### PR TITLE
runtime/doc/eval.txt: remove references to E706

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -394,10 +394,6 @@ This works like: >
 	:   let index = index + 1
 	:endwhile
 
-Note that all items in the list should be of the same type, otherwise this
-results in error |E706|.  To avoid this |:unlet| the variable at the end of
-the loop.
-
 If all you want to do is modify each item in the list then the |map()|
 function will be a simpler method than a for loop.
 
@@ -7423,8 +7419,7 @@ systemlist({cmd} [, {input} [, {keepempty}]])		*systemlist()*
 		set to "b", except that a final newline is not preserved,
 		unless {keepempty} is present and it's non-zero.
 
-		Returns an empty string on error, so be careful not to run 
-		into |E706|.
+		Returns an empty string on error.
 
 
 tabpagebuflist([{arg}])					*tabpagebuflist()*


### PR DESCRIPTION
This has been removed in Vim in 7.4.1578 (975b5271) and 7.4.1546
(f6f32c38b).