### PR TITLE
OpenBSD libuv does not use KVM, so no need to link it.

### DIFF
--- a/cmake/FindLibUV.cmake
+++ b/cmake/FindLibUV.cmake
@@ -65,7 +65,7 @@ if(HAVE_LIBKSTAT)
 endif()
 
 check_library_exists(kvm kvm_open "kvm.h" HAVE_LIBKVM)
-if(HAVE_LIBKVM)
+if(HAVE_LIBKVM AND NOT CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
   list(APPEND LIBUV_LIBRARIES kvm)
 endif()
 


### PR DESCRIPTION
Having discussed on gitter, we think the only use of KVM on the BSDs is to get the resident memory usage. E.g.:

https://github.com/libuv/libuv/blob/f277cb6f920f0abbb2fb314861b3d79ef1de02fd/src/unix/freebsd.c#L207-L235

But libuv on OpenBSD uses sysctl instead:

https://github.com/libuv/libuv/blob/f277cb6f920f0abbb2fb314861b3d79ef1de02fd/src/unix/openbsd.c#L180-L198

So we should not need to link libkvm.