### PR TITLE
[WIP/RFC] Appveyor: Rework build types a bit to help debugging

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 version: '{build}'
 configuration:
+- DEBUG
 - MINGW_64
 - MINGW_32
 install: []


### PR DESCRIPTION
I've started this to get debug builds in appveyor, but maybe we should take the change to rework the build types in appveyor, and document some good ways to debug issues in the wiki.

Right now we have the following build types

- mingw 32bit release
- mingw 64bit release
- this PR adds a mingw 32bit debug build

Note: The reason why we did not enable debug builds in the past was because people had problems testing with those, because they depended on the debug runtime DLLs, which are usually not installed in Windows.