### PR TITLE
[RFC] Make script_host.rb rubocop-clean

### DIFF
--- a/runtime/autoload/provider/script_host.rb
+++ b/runtime/autoload/provider/script_host.rb
@@ -1,8 +1,6 @@
 begin
-  require "neovim/ruby_provider"
+  require 'neovim/ruby_provider'
 rescue LoadError
-  warn(
-    "Your neovim RubyGem is missing or out of date. " +
-    "Install the latest version using `gem install neovim`."
-  )
+  warn('Your neovim RubyGem is missing or out of date.',
+       'Install the latest version using `gem install neovim`.')
 end


### PR DESCRIPTION
Fix the following issues according to rubocop:

```
    runtime/autoload/provider/script_host.rb:2:11: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
      require "neovim/ruby_provider"
              ^^^^^^^^^^^^^^^^^^^^^^
    runtime/autoload/provider/script_host.rb:5:5: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
        "Your neovim RubyGem is missing or out of date. " +
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    runtime/autoload/provider/script_host.rb:5:55: C: Use \ instead of + or << to concatenate those strings.
        "Your neovim RubyGem is missing or out of date. " +
    runtime/autoload/provider/script_host.rb:6:5: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
        "Install the latest version using `gem install neovim`."
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```