### PR TITLE
Fix up "linux*" terminfo entries, too.

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1016,8 +1016,12 @@ static void fix_terminfo(TUIData *data)
   "\x1b[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e48;5;%p1%d%;m"
 
   if ((colorterm && strstr(colorterm, "256"))
+      || STARTS_WITH(term, "linux")
       || strstr(term, "256")
       || strstr(term, "xterm")) {
+    // Linux has supported the 256-colour control sequences since 4.8, but its
+    // terminfo entry as of 2016-11-27 only advertises 8 colour support.
+    // This also fixes up the linux-16color terminfo entry as a bonus.
     // Assume TERM=~xterm or COLORTERM=~256 supports 256 colors.
     unibi_set_num(ut, unibi_max_colors, 256);
     unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1019,9 +1019,7 @@ static void fix_terminfo(TUIData *data)
       || STARTS_WITH(term, "linux")
       || strstr(term, "256")
       || strstr(term, "xterm")) {
-    // Linux has supported the 256-colour control sequences since 4.8, but its
-    // terminfo entry as of 2016-11-27 only advertises 8 colour support.
-    // This also fixes up the linux-16color terminfo entry as a bonus.
+    // Linux >= 4.8 supports 256-colour SGR, but its terminfo entry only provides 8-colour setaf/setab.
     // Assume TERM=~xterm or COLORTERM=~256 supports 256 colors.
     unibi_set_num(ut, unibi_max_colors, 256);
     unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF);

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -366,7 +366,7 @@ describe("tui 't_Co' (terminal colors)", function()
 
   it("TERM=linux-16color uses 256 colors", function()
     if is_linux then
-      assert_term_colors("linux", nil, 256)
+      assert_term_colors("linux-16color", nil, 256)
     else
       pending()
     end

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -356,9 +356,17 @@ describe("tui 't_Co' (terminal colors)", function()
     assert_term_colors("yet-another-term", "screen-256color", 256)
   end)
 
-  it("TERM=linux uses 8 colors", function()
+  it("TERM=linux uses 256 colors", function()
     if is_linux then
-      assert_term_colors("linux", nil, 8)
+      assert_term_colors("linux", nil, 256)
+    else
+      pending()
+    end
+  end)
+
+  it("TERM=linux-16color uses 256 colors", function()
+    if is_linux then
+      assert_term_colors("linux", nil, 256)
     else
       pending()
     end


### PR DESCRIPTION
The terminfo entry for `linux` only advertises 8 colours, and its `setaf` and `setab` capabilities only work correctly with colours 0 to 7, but nvim tries to make it display 16 colours anyway, resulting in erroneous SGR control sequences for colours 8 and above.

The Linux kernel terminal emulator itself has actually understood the 256-colour control sequences [since version 4.8](https://github.com/torvalds/linux/commit/cec5b2a97a11ade56a701e83044d0a2a984c67b4) (at least ignoring them [well before that](https://github.com/torvalds/linux/commit/3415097ff0529eac264b8ccfa06572871e45c090)) and the 16-colour control sequences since version 4.9 ([foreground](https://github.com/torvalds/linux/commit/cc67dc28b33917227214a692534d817d727fb934) and [background](https://github.com/torvalds/linux/commit/fadb4244085cd04fd9c8b3a4b3bc161f506431f3)).

Thus we apply the same terminfo fixup to `linux*` as we apply for` *xterm*` and` *256*`, to emit the 16-colour and 256-colour control sequences even if terminfo's `setaf` and `setab` do not advertise them.