### PR TITLE
[RDY] Use uv_getaddrinfo() for servers

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6462,11 +6462,20 @@ serverlist()						*serverlist()*
 			nvim --cmd "echo serverlist()" --cmd "q"
 <
 serverstart([{address}])				*serverstart()*
-		Opens a named pipe or TCP socket at {address} for clients to
-		connect to and returns {address}. If no address is given, it
-		is equivalent to: >
+		Opens a TCP socket (IPv4/IPv6), Unix domain socket (Unix),
+		or named pipe (Windows) at {address} for clients to connect
+		to and returns {address}.
+
+		If {address} contains `:`, a TCP socket is used. Everything in
+		front of the last occurrence of `:` is the IP or hostname,
+		everything after it the port. If the port is empty or `0`,
+		a random port will be assigned.
+
+		If no address is given, it is equivalent to: >
 			:call serverstart(tempname())
+
 < 		|$NVIM_LISTEN_ADDRESS| is set to {address} if not already set.
+
 							*--servername*
 		The Vim command-line option `--servername` can be imitated: >
 			nvim --cmd "let g:server_addr = serverstart('foo')"

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14296,23 +14296,39 @@ static void f_serverstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
+  char *address;
   // If the user supplied an address, use it, otherwise use a temp.
   if (argvars[0].v_type != VAR_UNKNOWN) {
     if (argvars[0].v_type != VAR_STRING) {
       EMSG(_(e_invarg));
       return;
     } else {
-      rettv->vval.v_string = (char_u *)xstrdup(tv_get_string(argvars));
+      address = xstrdup(tv_get_string(argvars));
     }
   } else {
-    rettv->vval.v_string = (char_u *)server_address_new();
+    address = server_address_new();
   }
 
-  int result = server_start((char *) rettv->vval.v_string);
+  int result = server_start(address);
+  xfree(address);
+
   if (result != 0) {
     EMSG2("Failed to start server: %s",
           result > 0 ? "Unknonwn system error" : uv_strerror(result));
+    return;
   }
+
+  // Since it's possible server_start adjusted the given {address} (e.g.,
+  // "localhost:" will now have a port), return the final value to the user.
+  size_t n;
+  char **addrs = server_address_list(&n);
+  rettv->vval.v_string = (char_u *)addrs[n - 1];
+
+  n--;
+  for (size_t i = 0; i < n; i++) {
+    xfree(addrs[i]);
+  }
+  xfree(addrs);
 }
 
 /// "serverstop()" function

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14310,7 +14310,8 @@ static void f_serverstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   int result = server_start((char *) rettv->vval.v_string);
   if (result != 0) {
-    EMSG2("Failed to start server: %s", uv_strerror(result));
+    EMSG2("Failed to start server: %s",
+          result > 0 ? "Unknonwn system error" : uv_strerror(result));
   }
 }
 

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -103,9 +103,9 @@ int socket_watcher_start(SocketWatcher *watcher, int backlog, socket_cb cb)
         // contain 0 in this case, unless uv_tcp_getsockname() is used first.
         uv_tcp_getsockname(&watcher->uv.tcp.handle, (struct sockaddr *)&sas,
                            &(int){ sizeof(sas) });
-        uint16_t port = (sas.ss_family == AF_INET)
-          ? ((struct sockaddr_in  *)&sas)->sin_port
-          : ((struct sockaddr_in6 *)&sas)->sin6_port;
+        uint16_t port = (uint16_t)((sas.ss_family == AF_INET)
+                                   ? ((struct sockaddr_in  *)&sas)->sin_port
+                                   : ((struct sockaddr_in6 *)&sas)->sin6_port);
         // v:servername uses the string from watcher->addr
         size_t len = strlen(watcher->addr);
         snprintf(watcher->addr+len, sizeof(watcher->addr)-len, ":%" PRIu16,

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -45,6 +45,12 @@ int socket_watcher_init(Loop *loop, SocketWatcher *watcher,
       return UV_EINVAL;
     }
 
+    if (*port == NUL) {
+      // When no port is given, (uv_)getaddrinfo expects NULL otherwise the
+      // implementation may attempt to lookup the service by name (and fail)
+      port = NULL;
+    }
+
     uv_getaddrinfo_t request;
 
     int retval = uv_getaddrinfo(&loop->uv, &request, NULL, addr, port,

--- a/src/nvim/event/socket.h
+++ b/src/nvim/event/socket.h
@@ -20,7 +20,7 @@ struct socket_watcher {
   union {
     struct {
       uv_tcp_t handle;
-      struct sockaddr_in addr;
+      struct addrinfo *addrinfo;
     } tcp;
     struct {
       uv_pipe_t handle;

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -118,7 +118,12 @@ int server_start(const char *endpoint)
   }
 
   SocketWatcher *watcher = xmalloc(sizeof(SocketWatcher));
-  socket_watcher_init(&main_loop, watcher, endpoint);
+
+  int result = socket_watcher_init(&main_loop, watcher, endpoint);
+  if (result < 0) {
+    xfree(watcher);
+    return result;
+  }
 
   // Check if a watcher for the endpoint already exists
   for (int i = 0; i < watchers.ga_len; i++) {
@@ -132,7 +137,7 @@ int server_start(const char *endpoint)
     }
   }
 
-  int result = socket_watcher_start(watcher, MAX_CONNECTIONS, connection_cb);
+  result = socket_watcher_start(watcher, MAX_CONNECTIONS, connection_cb);
   if (result < 0) {
     ELOG("Failed to start server: %s", uv_strerror(result));
     socket_watcher_close(watcher, free_server);

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -97,31 +97,36 @@ char *server_address_new(void)
 #endif
 }
 
-/// Starts listening for API calls on the TCP address or pipe path `endpoint`.
-/// The socket type is determined by parsing `endpoint`: If it's a valid IPv4
-/// address in 'ip[:port]' format, then it will be TCP socket. The port is
-/// optional and if omitted defaults to NVIM_DEFAULT_TCP_PORT. Otherwise it
-/// will be a unix socket or named pipe.
+/// Starts listening for API calls.
 ///
-/// @param endpoint Address of the server. Either a 'ip[:port]' string or an
-///        arbitrary identifier (trimmed to 256 bytes) for the unix socket or
-///        named pipe.
+/// The socket type is determined by parsing `endpoint`: If it's a valid IPv4
+/// or IPv6 address in 'ip:[port]' format, then it will be a TCP socket.
+/// Otherwise it will be a Unix socket or named pipe (Windows).
+///
+/// If no port is given, a random one will be assigned.
+///
+/// @param endpoint Address of the server. Either a 'ip:[port]' string or an
+///                 arbitrary identifier (trimmed to 256 bytes) for the Unix
+///                 socket or named pipe.
 /// @returns 0 on success, 1 on a regular error, and negative errno
-///          on failure to bind or connect.
+///          on failure to bind or listen.
 int server_start(const char *endpoint)
 {
-  if (endpoint == NULL) {
-    ELOG("Attempting to start server on NULL endpoint");
+  if (endpoint == NULL || endpoint[0] == '\0') {
+    ELOG("Empty or NULL endpoint");
     return 1;
   }
 
   SocketWatcher *watcher = xmalloc(sizeof(SocketWatcher));
-  socket_watcher_init(&main_loop, watcher, endpoint, NULL);
+  socket_watcher_init(&main_loop, watcher, endpoint);
 
   // Check if a watcher for the endpoint already exists
   for (int i = 0; i < watchers.ga_len; i++) {
     if (!strcmp(watcher->addr, ((SocketWatcher **)watchers.ga_data)[i]->addr)) {
       ELOG("Already listening on %s", watcher->addr);
+      if (watcher->stream->type == UV_TCP) {
+        uv_freeaddrinfo(watcher->uv.tcp.addrinfo);
+      }
       socket_watcher_close(watcher, free_server);
       return 1;
     }

--- a/test/functional/eval/server_spec.lua
+++ b/test/functional/eval/server_spec.lua
@@ -1,6 +1,7 @@
 
 local helpers = require('test.functional.helpers')(after_each)
-local nvim, eq, neq, eval = helpers.nvim, helpers.eq, helpers.neq, helpers.eval
+local eq, neq, eval = helpers.eq, helpers.neq, helpers.eval
+local command = helpers.command
 local clear, funcs, meths = helpers.clear, helpers.funcs, helpers.meths
 local os_name = helpers.os_name
 
@@ -9,12 +10,12 @@ describe('serverstart(), serverstop()', function()
 
   it('sets $NVIM_LISTEN_ADDRESS on first invocation', function()
     -- Unset $NVIM_LISTEN_ADDRESS
-    nvim('command', 'let $NVIM_LISTEN_ADDRESS = ""')
+    command('let $NVIM_LISTEN_ADDRESS = ""')
 
     local s = eval('serverstart()')
     assert(s ~= nil and s:len() > 0, "serverstart() returned empty")
     eq(s, eval('$NVIM_LISTEN_ADDRESS'))
-    nvim('command', "call serverstop('"..s.."')")
+    command("call serverstop('"..s.."')")
     eq('', eval('$NVIM_LISTEN_ADDRESS'))
   end)
 
@@ -47,8 +48,8 @@ describe('serverstart(), serverstop()', function()
   end)
 
   it('serverstop() ignores invalid input', function()
-    nvim('command', "call serverstop('')")
-    nvim('command', "call serverstop('bogus-socket-name')")
+    command("call serverstop('')")
+    command("call serverstop('bogus-socket-name')")
   end)
 
 end)
@@ -75,7 +76,7 @@ describe('serverlist()', function()
     -- The new servers should be at the end of the list.
     for i = 1, #servs do
       eq(servs[i], new_servs[i + n])
-      nvim('command', "call serverstop('"..servs[i].."')")
+      command("call serverstop('"..servs[i].."')")
     end
     -- After serverstop() the servers should NOT be in the list.
     eq(n, eval('len(serverlist())'))

--- a/test/functional/eval/server_spec.lua
+++ b/test/functional/eval/server_spec.lua
@@ -62,12 +62,14 @@ describe('serverstart(), serverstop()', function()
     clear_serverlist()
     eq({}, funcs.serverlist())
 
-    funcs.serverstart('127.0.0.1:0')  -- assign random port
-    assert(string.match(funcs.serverlist()[1], '127.0.0.1:%d+'))
+    local s = funcs.serverstart('127.0.0.1:0')  -- assign random port
+    assert(string.match(s, '127.0.0.1:%d+'))
+    eq(s, funcs.serverlist()[1])
     clear_serverlist()
 
-    funcs.serverstart('127.0.0.1:')  -- assign random port
-    assert(string.match(funcs.serverlist()[1], '127.0.0.1:%d+'))
+    s = funcs.serverstart('127.0.0.1:')  -- assign random port
+    assert(string.match(s, '127.0.0.1:%d+'))
+    eq(s, funcs.serverlist()[1])
     clear_serverlist()
 
     funcs.serverstart('127.0.0.1:12345')


### PR DESCRIPTION
This change implicitly adds IPv6 support.

If the address contains ":", we try to use a TCP socket instead of a Unix domain
socket. Everything in front of the last occurrence of ":" is the hostname and
everything after it the port.

If the hostname lookup fails, we fall back to using a Unix domain socket.

If the port is empty ("localhost:"), a random port will be assigned.

Examples:

```
  NVIM_LISTEN_ADDRESS=localhost:12345  -> TCP (IPv4 or IPv6), port: 12345
  NVIM_LISTEN_ADDRESS=localhost:       -> TCP (IPv4 or IPv6), port: random (> 1024)
  NVIM_LISTEN_ADDRESS=localhost        -> Unix domain socket "localhost" in current dir
```