### PR TITLE
[RDY] Capture and display errors from clipboard provider set

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -142,7 +142,7 @@ function! s:clipboard.set(lines, regtype, reg) abort
   \ 'on_stderr': function('s:set_errhandler'),
   \ })
   let jobid = jobstart(argv, selection)
-  if jobid >= 0
+  if jobid > 0
     call jobsend(jobid, a:lines)
     call jobclose(jobid, 'stdin')
     let selection.owner = jobid
@@ -150,7 +150,7 @@ function! s:clipboard.set(lines, regtype, reg) abort
 endfunction
 
 function! s:set_errhandler(job_id, data, event) abort
-  if a:job_id < 0
+  if a:job_id <= 0
     echohl WarningMsg
     echo 'clipboard: error when invoking provider: ' . join(a:data)
     echohl None

--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -137,16 +137,24 @@ function! s:clipboard.set(lines, regtype, reg) abort
   let argv = split(s:copy[a:reg], " ")
   let selection.detach = s:cache_enabled
   let selection.cwd = "/"
+  call extend(selection, {
+  \ 'on_stdout': function('s:set_errhandler'),
+  \ 'on_stderr': function('s:set_errhandler'),
+  \ })
   let jobid = jobstart(argv, selection)
-  if jobid <= 0
-    echohl WarningMsg
-    echo "clipboard: error when invoking provider"
-    echohl None
-    return 0
+  if jobid >= 0
+    call jobsend(jobid, a:lines)
+    call jobclose(jobid, 'stdin')
+    let selection.owner = jobid
   endif
-  call jobsend(jobid, a:lines)
-  call jobclose(jobid, 'stdin')
-  let selection.owner = jobid
+endfunction
+
+function! s:set_errhandler(job_id, data, event) abort
+  if a:job_id < 0
+    echohl WarningMsg
+    echo 'clipboard: error when invoking provider: ' . join(a:data)
+    echohl None
+  endif
 endfunction
 
 function! provider#clipboard#Call(method, args) abort


### PR DESCRIPTION
Fixes part of #6565.

Remaining question is how to handle errors in the `get`. See discussion on #6565. I'd like to use job control, but since the provider API is synchronous it might be difficult. Adding a new parameter to systemlist to capture stderr is possible, but could possibly be overkill.

Also, I'd like to write tests for this, but unsure how to mock a provider that errors and prints to stderr. It works with some local testing, however.