### PR TITLE
man.vim: Fix filename argument in mandoc

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -135,7 +135,12 @@ function! s:get_page(path) abort
   let manwidth = empty($MANWIDTH) ? winwidth(0) : $MANWIDTH
   " Force MANPAGER=cat to ensure Vim is not recursively invoked (by man-db).
   " http://comments.gmane.org/gmane.editors.vim.devel/29085
-  return s:system(['env', 'MANPAGER=cat', 'MANWIDTH='.manwidth, 'man', a:path])
+  let cmd = ['env', 'MANPAGER=cat', 'MANWIDTH='.manwidth, 'man']
+  if has('mac')
+    return s:system(cmd + [a:path])
+  else
+    return s:system(cmd + ['-l', a:path])
+  endif
 endfunction
 
 function! s:put_page(page) abort


### PR DESCRIPTION
This uses the -l flag to open a man file.  While this does not work with
SunOS, it does not appear that man.vim worked with SunOS in the first place.

Fixes #6683