### PR TITLE
More compatible Vim transition instructions

### DIFF
--- a/runtime/doc/nvim.txt
+++ b/runtime/doc/nvim.txt
@@ -20,8 +20,10 @@ Transitioning from Vim				*nvim-from-vim*
 
 To start the transition, create `~/.config/nvim/init.vim` with these contents:
 >
-    set runtimepath+=~/.vim,~/.vim/after
-    set packpath+=~/.vim
+    set runtimepath^=~/.vim
+    set runtimepath+=~/.vim/after
+    set packpath^=~/.vim
+    set packpath+=~/.vim/after
     source ~/.vimrc
 <
 Note: If your system sets `$XDG_CONFIG_HOME`, use that instead of `~/.config`


### PR DESCRIPTION
This change was motivated by an issue I experienced after moving to NeoVim using the transition instructions in the documentation. Alternative [Python indentation plugin](https://github.com/Vimjas/vim-python-pep8-indent) I use stopped working in NeoVim, and I managed to narrow the problem down to the order in which scripts are loaded.

Looks like Vim loads the custom plugin first, which sets `g:did_indent` to skip the built-in indentation script. However, NeoVim seems to be loading the built-in script first, which sets `g:did_indent` and prevents the custom plugin from running.

After comparing `runtimepath` and `packpath` for both versions I noticed that Vim includes `~/.vim` at the beginning and `~/.vim/after` at the end, while NeoVim includes both at the end.

This PR makes the Vim transition documentation more backwards-compatible by prepending `~/.vim` and appending `~/.vim/after`.