### PR TITLE
[RDY] doc: fix reference in lua documentation

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -107,7 +107,7 @@ position are restricted when the command is executed in the |sandbox|.
 
 Lua interfaces Vim through the "vim" module. Currently it only has `api` 
 submodule which is a table with all API functions. Descriptions of these 
-functions may be found in |api-funcs.txt|.
+functions may be found in |api.txt|.
 
 ==============================================================================
 3. The luaeval function					*lua-luaeval* *lua-eval*


### PR DESCRIPTION
This is so small it could be incorporated in some other PR perhaps? Otherwise, it should be ready to go, obviously.