### PR TITLE
health.vim: Remove sensible.vim advice.

### DIFF
--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -4,15 +4,6 @@ function! s:check_config() abort
   let ok = v:true
   call health#report_start('Configuration')
 
-  if get(g:, 'loaded_sensible', 0)
-    let ok = v:false
-    let sensible_pi = globpath(&runtimepath, '**/sensible.vim', 1, 1)
-    call health#report_info("found sensible.vim plugin:\n".join(sensible_pi, "\n"))
-    call health#report_error("sensible.vim plugin is not needed; Nvim has the same defaults built-in."
-      \ ." Also, sensible.vim sets 'ttimeoutlen' to a sub-optimal value.",
-      \ ["Remove sensible.vim plugin, or wrap it in a `if !has('nvim')` check."])
-  endif
-
   if exists('$NVIM_TUI_ENABLE_CURSOR_SHAPE')
     let ok = v:false
     call health#report_warn("$NVIM_TUI_ENABLE_CURSOR_SHAPE is ignored in Nvim 0.2+",


### PR DESCRIPTION
sensible.vim now avoids setting ttimeoutlen for nvim: https://github.com/tpope/vim-sensible/commit/b6033cb4d46e2c16c6066f795b34854b3285a6a6

FWIW, the CheckHealth advice was intended to avoid asking sensible.vim to make such a workaround, since 'ttimeoutlen' needs to be reworked in Nvim.