### PR TITLE
[RFC] Pastetoggle revert multikey

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4368,7 +4368,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Note that typing <F10> in paste mode inserts "<F10>", since in paste
 	mode everything is inserted literally, except the 'pastetoggle' key
 	sequence.
-	When the value has several bytes 'ttimeoutlen' applies.
+	No timeout is used, this means that a multi-key 'pastetoggle' can not
+	be triggered manually.
 
 						*'pex'* *'patchexpr'*
 'patchexpr' 'pex'	string	(default "")

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1908,7 +1908,7 @@ static int vgetorpeek(int advance)
           }
 
           if ((mp == NULL || max_mlen >= mp_match_len)
-              && keylen != KEYLEN_PART_MAP && keylen != KEYLEN_PART_KEY) {
+              && keylen != KEYLEN_PART_MAP) {
             // No matching mapping found or found a non-matching mapping that
             // matches at least what the matching mapping matched
             keylen = 0;

--- a/test/functional/options/pastetoggle_spec.lua
+++ b/test/functional/options/pastetoggle_spec.lua
@@ -6,32 +6,35 @@ local command = helpers.command
 local eq = helpers.eq
 local eval = helpers.eval
 local sleep = helpers.sleep
+local expect = helpers.expect
 
 describe("'pastetoggle' option", function()
   before_each(function()
     clear()
     command('set nopaste')
-    command('set pastetoggle=a')
   end)
+
   it("toggles 'paste'", function()
-    eq(eval('&paste'), 0)
+    command('set pastetoggle=a')
+    eq(0, eval('&paste'))
     feed('a')
     -- Need another key so that the vgetorpeek() function returns.
     feed('j')
-    eq(eval('&paste'), 1)
+    eq(1, eval('&paste'))
   end)
-  it("multiple key 'pastetoggle' is waited for", function()
-    eq(eval('&paste'), 0)
-    local pastetoggle = 'lllll'
-    command('set pastetoggle=' .. pastetoggle)
-    command('set timeoutlen=1 ttimeoutlen=10000')
-    feed(pastetoggle:sub(0, 2))
-    -- sleep() for long enough that vgetorpeek() is gotten into, but short
-    -- enough that ttimeoutlen is not reached.
-    sleep(200)
-    feed(pastetoggle:sub(3, -1))
-    -- Need another key so that the vgetorpeek() function returns.
-    feed('j')
-    eq(eval('&paste'), 1)
+
+
+  it('does not wait for timeout', function()
+    command('set pastetoggle=abc')
+    command('set ttimeoutlen=9999999')
+    eq(0, eval('&paste'))
+    -- n.b. need <esc> to return from vgetorpeek()
+    feed('abc<esc>')
+    eq(1, eval('&paste'))
+    feed('ab')
+    sleep(10)
+    feed('c<esc>')
+    expect('bc')
+    eq(1, eval('&paste'))
   end)
 end)


### PR DESCRIPTION
While looking into #6716 I saw that there were quite a few special cases in original `vim` for whether `'pastetoggle'` should be applied or not.

I implemented the same checks that `vim` does, apart from checking for `allow_keys != 0` because that is a global that `neovim` doesn't have.

Because of this difference there are still a few differences between neovim and vim behaviour at the moment.

I'll be honest, while looking into everywhere that `vim` sets `allow_keys`, and how it sets it relative to `no_mapping`, I realised it would take quite a bit of time & thought so decided to not finish as I don't have much time to give at the moment.

This PR is here to help anyone wanting to work on it.