### PR TITLE
[RFC] if_cscope: Fix truncation of formated output

### DIFF
--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1972,7 +1972,7 @@ static void cs_release_csp(size_t i, int freefnpp)
 static int cs_reset(exarg_T *eap)
 {
   char        **dblist = NULL, **pplist = NULL, **fllist = NULL;
-  char buf[20];   /* for snprintf " (#%zu)" */
+  char buf[25];  // for snprintf " (#%zu)"
 
   if (csinfo_size == 0)
     return CSCOPE_SUCCESS;


### PR DESCRIPTION
if_cscope: Fix truncation of formated output

snprintf() has to truncate the string written to buffer buf for maximal
size_t value.

Increase buffer size to fix this.

This was found when compiling in release mode with gcc-7.1:
```bash
/home/oni-link/git/neovim/src/nvim/if_cscope.c: In function ‘cs_reset’:
/home/oni-link/git/neovim/src/nvim/if_cscope.c:2002:44: warning: ‘%zu’ directive output may be truncated writing between 1 and 19 bytes into a region of size 17 [-Wformat-truncation=]
         snprintf(buf, ARRAY_SIZE(buf), " (#%zu)", i);
                                            ^~~
/home/oni-link/git/neovim/src/nvim/if_cscope.c:2002:40: note: directive argument in the range [0, 2305843009213693951]
         snprintf(buf, ARRAY_SIZE(buf), " (#%zu)", i);
                                        ^~~~~~~~~
In file included from /usr/include/stdio.h:936:0,
                 from /home/oni-link/git/neovim/src/nvim/os/os_defs.h:5,
                 from /home/oni-link/git/neovim/src/nvim/vim.h:26,
                 from /home/oni-link/git/neovim/src/nvim/if_cscope.c:19:
/usr/include/bits/stdio2.h:64:10: note: ‘__builtin_snprintf’ output between 6 and 24 bytes into a destination of size 20
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```