### PR TITLE
let remote hosts update their specs

### DIFF
--- a/runtime/plugin/rplugin.vim
+++ b/runtime/plugin/rplugin.vim
@@ -65,4 +65,9 @@ endfunction
 
 command! -bar UpdateRemotePlugins call remote#host#UpdateRemotePlugins()
 
+augroup remote_host
+    au!
+    au ChanInfo * call remote#host#on_channelinfo(v:event.info)
+augroup END
+
 call s:LoadRemotePlugins()


### PR DESCRIPTION
Currently works only in the following scenario: when the user starts the host by calling some already registered plugin, or starts a not started plugin in a running host, the host is allowed to send back updated specs, for all or some subset of already registered plugins, which updates the registration file and takes effect in _real_ time.

goals, not necessarily in this PR, but should be made possible to implement in a _forward_ compatible fashion with out breaking compatibility either way:

- [ ] nvim at startup detecting specs are out of date and start the host and asks for updated specs
- [ ] even if the host is already running, if a new plugin is installed, ask the host to load it and return specs for the new plugin
- [ ] the host can take initiative to reload an already running plugin, and update its specs
- [ ] use timestamps in the registration file so old specs don't overwrite new (reuse shada logic?)
- [ ] Figure out the right time points load errors should be shown to the user.
- [ ] nvim should do what the user asks it, never reply with confusing error messages like "host x is already running", "plugin x is already registered"

There is probably some relevant discussion from 2015 to reread...

[python-client branch](https://github.com/neovim/python-client/compare/master...bfredl:specs?expand=1)