### PR TITLE
[RPC] Add methods to enumerate channels and clients to identify themselves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,13 +290,14 @@ option(LOG_LIST_ACTIONS "Add list actions logging" OFF)
 
 add_definitions(-DINCLUDE_GENERATED_DECLARATIONS)
 
-if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-undefined")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-undefined")
 
   # For O_CLOEXEC, O_DIRECTORY, and O_NOFOLLOW flags on older systems
   # (pre POSIX.1-2008: glibc 2.11 and earlier). #4042
+  # For ptsname(). #6743
   add_definitions(-D_GNU_SOURCE)
 endif()
 

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -261,6 +261,8 @@ Name			triggered by ~
 |SwapExists|		detected an existing swap file
 |TermOpen|		when a terminal job starts
 |TermClose|		when a terminal job ends
+|ChanOpen|		after a channel opened
+|ChanInfo|		after a channel has its state changed
 
 	Options
 |FileType|		when the 'filetype' option has been set
@@ -487,6 +489,19 @@ BufWriteCmd			Before writing the whole buffer to a file.
 							*BufWritePost*
 BufWritePost			After writing the whole buffer to a file
 				(should undo the commands for BufWritePre).
+							*ChanInfo*
+ChanInfo			State of channel changed, for instance the
+				client of a RPC channel described itself.
+				Sets these |v:event| keys:
+				    info
+				See |nvim_get_chan_info| for the format of the
+				info Dictionary.
+							*ChanOpen*
+ChanOpen			Just after a channel was opened.
+				Sets these |v:event| keys:
+				    info
+				See |nvim_get_chan_info| for the format of the
+				info Dictionary.
 							*CmdUndefined*
 CmdUndefined			When a user command is used but it isn't
 				defined.  Useful for defining a command only

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1030,6 +1030,16 @@ Array copy_array(Array array)
   return rv;
 }
 
+Dictionary copy_dictionary(Dictionary dict)
+{
+  Dictionary rv = ARRAY_DICT_INIT;
+  for (size_t i = 0; i < dict.size; i++) {
+    KeyValuePair item = dict.items[i];
+    PUT(rv, item.key.data, copy_object(item.value));
+  }
+  return rv;
+}
+
 /// Creates a deep clone of an object
 Object copy_object(Object obj)
 {
@@ -1047,12 +1057,7 @@ Object copy_object(Object obj)
       return ARRAY_OBJ(copy_array(obj.data.array));
 
     case kObjectTypeDictionary: {
-      Dictionary rv = ARRAY_DICT_INIT;
-      for (size_t i = 0; i < obj.data.dictionary.size; i++) {
-        KeyValuePair item = obj.data.dictionary.items[i];
-        PUT(rv, item.key.data, copy_object(item.value));
-      }
-      return DICTIONARY_OBJ(rv);
+      return DICTIONARY_OBJ(copy_dictionary(obj.data.dictionary));
     }
     default:
       abort();

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -19,6 +19,8 @@ return {
     'BufWriteCmd',            -- write buffer using command
     'BufWritePost',           -- after writing a buffer
     'BufWritePre',            -- before writing a buffer
+    'ChanOpen',               -- channel was opened
+    'ChanInfo',               -- info was received about channel
     'CmdLineEnter',           -- after entering cmdline mode
     'CmdLineLeave',           -- before leaving cmdline mode
     'CmdUndefined',           -- command undefined

--- a/src/nvim/msgpack_rpc/channel_defs.h
+++ b/src/nvim/msgpack_rpc/channel_defs.h
@@ -31,6 +31,7 @@ typedef struct {
   msgpack_unpacker *unpacker;
   uint64_t next_request_id;
   kvec_t(ChannelCallFrame *) call_stack;
+  Dictionary info;
 } RpcState;
 
 #endif  // NVIM_MSGPACK_RPC_CHANNEL_DEFS_H

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -115,6 +115,11 @@ error:
   return status;
 }
 
+const char *pty_process_tty_name(PtyProcess *ptyproc)
+{
+  return ptsname(ptyproc->tty_fd);
+}
+
 void pty_process_resize(PtyProcess *ptyproc, uint16_t width, uint16_t height)
   FUNC_ATTR_NONNULL_ALL
 {

--- a/src/nvim/os/pty_process_win.c
+++ b/src/nvim/os/pty_process_win.c
@@ -183,6 +183,11 @@ cleanup:
   return status;
 }
 
+const char *pty_process_tty_name(PtyProcess *ptyproc)
+{
+  return "?";
+}
+
 void pty_process_resize(PtyProcess *ptyproc, uint16_t width,
                         uint16_t height)
   FUNC_ATTR_NONNULL_ALL

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -619,6 +619,11 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr,
   }
 }
 
+Buffer terminal_buf(const Terminal *term)
+{
+  return term->buf_handle;
+}
+
 // }}}
 // libvterm callbacks {{{
 


### PR DESCRIPTION
To implement stuff like #6742  in a forward-compatible fashion, @justinmk suggested an api function where embedders and connected clients might identify themselves and their capabilities. Before implementing it would be good to discuss what it should contain. Some suggestions

name
version: a dicitionary with "major", "minor", "commit", "prerelease" etc keys (all optional)
role: informal description of the clients role, with some suggested values: host, plugin (for a single-plugin process), gui
methods: builtin methods (_before_ loading plugins into the host), not sure how detailed, but at least argument count so methods can be extended.

There probably should be an autocommand or something so interested parties (like the rplugin infrastructure) could listen for identified clients. And a `nvim_list_clients()` function for introspection/debugging.