### PR TITLE
[RFC] Fix PVS analysis warnings

### DIFF
--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -306,7 +306,7 @@ realdir() {(
 
 patch_sources() {(
   local tgt="$1" ; shift
-  local only_bulid="${1:-}"
+  local only_bulid="${1}" ; shift
 
   get_pvs_comment "$tgt"
 
@@ -420,7 +420,7 @@ main() {
   set -x
 
   if test -n "$patch" ; then
-    patch_sources "$only_build" "$tgt"
+    patch_sources "$tgt" "$only_build"
   elif test -n "$pvs_install" ; then
     install_pvs "$tgt" "$pvs_url"
   elif test -n "$recheck" ; then

--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -50,7 +50,17 @@ help() {
 }
 
 getopts_error() {
-  printf '%s\n' "$1" >&2
+  local msg="$1" ; shift
+  local do_help=
+  if test "$msg" = "--help" ; then
+    msg="$1" ; shift
+    do_help=1
+  fi
+  printf '%s\n' "$msg" >&2
+  if test -n "$do_help" ; then
+    printf '\n' >&2
+    help >&2
+  fi
   echo 'return 1'
   return 1
 }
@@ -146,8 +156,8 @@ getopts_long() {
     if test -n "$opt_base" ; then
       eval "local occurred_$opt_base=1"
 
-      eval "local act_1=\"\$act_1_$opt_base\""
-      eval "local varname=\"\$varname_$opt_base\""
+      eval "local act_1=\"\${act_1_$opt_base:-}\""
+      eval "local varname=\"\${varname_$opt_base:-}\""
       local need_val=
       local func=
       case "$act_1" in
@@ -169,6 +179,9 @@ getopts_long() {
           eval "func=\"\${act_2_${opt_base}}\""
           eval "varname=\"\${act_3_${opt_base}:-$varname}\""
           need_val=1
+          ;;
+        ("")
+          getopts_error --help "Wrong argument: $argument"
           ;;
       esac
       if test -n "$need_val" ; then

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -828,7 +828,7 @@ void handle_swap_exists(bufref_T *old_curbuf)
      * new aborting error, interrupt, or uncaught exception. */
     leave_cleanup(&cs);
   }
-  swap_exists_action = SEA_NONE;
+  swap_exists_action = SEA_NONE;  // -V519
 }
 
 /*

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -545,18 +545,8 @@ void transchar_nonprint(char_u *buf, int c)
     buf[1] = (char_u)(c ^ 0x40);
 
     buf[2] = NUL;
-  } else if (c >= 0x80) {
-    transchar_hex(buf, c);
-  } else if ((c >= ' ' + 0x80) && (c <= '~' + 0x80)) {
-    // 0xa0 - 0xfe
-    buf[0] = '|';
-    buf[1] = (char_u)(c - 0x80);
-    buf[2] = NUL;
   } else {
-    // 0x80 - 0x9f and 0xff
-    buf[0] = '~';
-    buf[1] = (char_u)((c - 0x80) ^ 0x40);
-    buf[2] = NUL;
+    transchar_hex(buf, c);
   }
 }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3422,7 +3422,6 @@ static void ins_compl_fixRedoBufForLeader(char_u *ptr_arg)
     else
       return;        /* nothing to do */
   }
-  assert(ptr != NULL);
   if (compl_orig_text != NULL) {
     p = compl_orig_text;
     for (len = 0; p[len] != NUL && p[len] == ptr[len]; ++len)
@@ -3434,7 +3433,6 @@ static void ins_compl_fixRedoBufForLeader(char_u *ptr_arg)
   } else {
     len = 0;
   }
-  assert(ptr != NULL);
   AppendToRedobuffLit(ptr + len, -1);
 }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -13058,8 +13058,9 @@ static void f_readfile(typval_T *argvars, typval_T *rettv, FunPtr fptr)
             /* have to shuffle buf to close gap */
             int adjust_prevlen = 0;
 
-            if (dest < buf) {
-              adjust_prevlen = (int)(buf - dest);               /* must be 1 or 2 */
+            if (dest < buf) {  // -V782
+              adjust_prevlen = (int)(buf - dest);  // -V782
+              // adjust_prevlen must be 1 or 2.
               dest = buf;
             }
             if (readlen > p - buf + 1)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21094,9 +21094,9 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars,
             // Do not want errors such as E724 here.
             emsg_off++;
             char *tofree = encode_tv2string(&argvars[i], NULL);
-            char *s = tofree;
             emsg_off--;
-            if (s != NULL) {
+            if (tofree != NULL) {
+              char *s = tofree;
               char buf[MSG_BUF_LEN];
               if (vim_strsize((char_u *)s) > MSG_BUF_CLEN) {
                 trunc_string((char_u *)s, (char_u *)buf, MSG_BUF_CLEN,

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21160,7 +21160,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars,
 
   if (func_or_func_caller_profiling) {
     call_start = profile_end(call_start);
-    call_start = profile_sub_wait(wait_start, call_start);
+    call_start = profile_sub_wait(wait_start, call_start);  // -V614
     fp->uf_tm_total = profile_add(fp->uf_tm_total, call_start);
     fp->uf_tm_self = profile_self(fp->uf_tm_self, call_start,
         fp->uf_tm_children);

--- a/src/nvim/eval/encode.c
+++ b/src/nvim/eval/encode.c
@@ -253,9 +253,11 @@ int encode_read_from_list(ListReaderState *const state, char *const buf,
   char *const buf_end = buf + nbuf;
   char *p = buf;
   while (p < buf_end) {
+    assert(state->li_length == 0 || state->li->li_tv.vval.v_string != NULL);
     for (size_t i = state->offset; i < state->li_length && p < buf_end; i++) {
-      const char ch = (char) state->li->li_tv.vval.v_string[state->offset++];
-      *p++ = (char) ((char) ch == (char) NL ? (char) NUL : (char) ch);
+      assert(state->li->li_tv.vval.v_string != NULL);
+      const char ch = (char)state->li->li_tv.vval.v_string[state->offset++];
+      *p++ = (char)((char)ch == (char)NL ? (char)NUL : (char)ch);
     }
     if (p < buf_end) {
       state->li = state->li->li_next;

--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -11,6 +11,7 @@
 #include "nvim/event/process.h"
 #include "nvim/event/libuv_process.h"
 #include "nvim/log.h"
+#include "nvim/macros.h"
 #include "nvim/os/os.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -47,17 +48,20 @@ int libuv_process_spawn(LibuvProcess *uvproc)
 
   if (proc->in) {
     uvproc->uvstdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
-    uvproc->uvstdio[0].data.stream = (uv_stream_t *)&proc->in->uv.pipe;
+    uvproc->uvstdio[0].data.stream = STRUCT_CAST(uv_stream_t,
+                                                 &proc->in->uv.pipe);
   }
 
   if (proc->out) {
     uvproc->uvstdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
-    uvproc->uvstdio[1].data.stream = (uv_stream_t *)&proc->out->uv.pipe;
+    uvproc->uvstdio[1].data.stream = STRUCT_CAST(uv_stream_t,
+                                                 &proc->out->uv.pipe);
   }
 
   if (proc->err) {
     uvproc->uvstdio[2].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
-    uvproc->uvstdio[2].data.stream = (uv_stream_t *)&proc->err->uv.pipe;
+    uvproc->uvstdio[2].data.stream = STRUCT_CAST(uv_stream_t,
+                                                 &proc->err->uv.pipe);
   }
 
   int status;

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -14,6 +14,7 @@
 #include "nvim/event/libuv_process.h"
 #include "nvim/os/pty_process.h"
 #include "nvim/globals.h"
+#include "nvim/macros.h"
 #include "nvim/log.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -82,7 +83,8 @@ int process_spawn(Process *proc) FUNC_ATTR_NONNULL_ALL
   }
 
   if (proc->in) {
-    stream_init(NULL, proc->in, -1, (uv_stream_t *)&proc->in->uv.pipe);
+    stream_init(NULL, proc->in, -1,
+                STRUCT_CAST(uv_stream_t, &proc->in->uv.pipe));
     proc->in->events = proc->events;
     proc->in->internal_data = proc;
     proc->in->internal_close_cb = on_process_stream_close;
@@ -90,7 +92,8 @@ int process_spawn(Process *proc) FUNC_ATTR_NONNULL_ALL
   }
 
   if (proc->out) {
-    stream_init(NULL, proc->out, -1, (uv_stream_t *)&proc->out->uv.pipe);
+    stream_init(NULL, proc->out, -1,
+                STRUCT_CAST(uv_stream_t, &proc->out->uv.pipe));
     proc->out->events = proc->events;
     proc->out->internal_data = proc;
     proc->out->internal_close_cb = on_process_stream_close;
@@ -98,7 +101,8 @@ int process_spawn(Process *proc) FUNC_ATTR_NONNULL_ALL
   }
 
   if (proc->err) {
-    stream_init(NULL, proc->err, -1, (uv_stream_t *)&proc->err->uv.pipe);
+    stream_init(NULL, proc->err, -1,
+                STRUCT_CAST(uv_stream_t, &proc->err->uv.pipe));
     proc->err->events = proc->events;
     proc->err->internal_data = proc;
     proc->err->internal_close_cb = on_process_stream_close;

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -16,6 +16,7 @@
 #include "nvim/strings.h"
 #include "nvim/path.h"
 #include "nvim/memory.h"
+#include "nvim/macros.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "event/socket.c.generated.h"
@@ -71,10 +72,10 @@ void socket_watcher_init(Loop *loop, SocketWatcher *watcher,
 
   if (tcp) {
     uv_tcp_init(&loop->uv, &watcher->uv.tcp.handle);
-    watcher->stream = (uv_stream_t *)&watcher->uv.tcp.handle;
+    watcher->stream = STRUCT_CAST(uv_stream_t, &watcher->uv.tcp.handle);
   } else {
     uv_pipe_init(&loop->uv, &watcher->uv.pipe.handle, 0);
-    watcher->stream = (uv_stream_t *)&watcher->uv.pipe.handle;
+    watcher->stream = STRUCT_CAST(uv_stream_t, &watcher->uv.pipe.handle);
   }
 
   watcher->stream->data = watcher;
@@ -122,10 +123,10 @@ int socket_watcher_accept(SocketWatcher *watcher, Stream *stream)
   uv_stream_t *client;
 
   if (watcher->stream->type == UV_TCP) {
-    client = (uv_stream_t *)&stream->uv.tcp;
+    client = STRUCT_CAST(uv_stream_t, &stream->uv.tcp);
     uv_tcp_init(watcher->uv.tcp.handle.loop, (uv_tcp_t *)client);
   } else {
-    client = (uv_stream_t *)&stream->uv.pipe;
+    client = STRUCT_CAST(uv_stream_t, &stream->uv.pipe);
     uv_pipe_init(watcher->uv.pipe.handle.loop, (uv_pipe_t *)client, 0);
   }
 

--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -8,6 +8,7 @@
 #include <uv.h>
 
 #include "nvim/rbuffer.h"
+#include "nvim/macros.h"
 #include "nvim/event/stream.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -26,8 +27,9 @@ int stream_set_blocking(int fd, bool blocking)
   uv_loop_init(&loop);
   uv_pipe_init(&loop, &stream, 0);
   uv_pipe_open(&stream, fd);
-  int retval = uv_stream_set_blocking((uv_stream_t *)&stream, blocking);
-  uv_close((uv_handle_t *)&stream, NULL);
+  int retval = uv_stream_set_blocking(STRUCT_CAST(uv_stream_t, &stream),
+                                      blocking);
+  uv_close(STRUCT_CAST(uv_handle_t, &stream), NULL);
   uv_run(&loop, UV_RUN_NOWAIT);  // not necessary, but couldn't hurt.
   uv_loop_close(&loop);
   return retval;
@@ -52,7 +54,7 @@ void stream_init(Loop *loop, Stream *stream, int fd, uv_stream_t *uvstream)
       assert(type == UV_NAMED_PIPE || type == UV_TTY);
       uv_pipe_init(&loop->uv, &stream->uv.pipe, 0);
       uv_pipe_open(&stream->uv.pipe, fd);
-      stream->uvstream = (uv_stream_t *)&stream->uv.pipe;
+      stream->uvstream = STRUCT_CAST(uv_stream_t, &stream->uv.pipe);
     }
   }
 

--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -118,8 +118,7 @@ local get_value = function(v)
 end
 
 local get_defaults = function(d)
-  return ('{' .. get_value(d.vi) .. '/* -V542 */, '
-          .. get_value(d.vim) .. '/* -V542 */}')
+  return ('{' .. get_value(d.vi) .. ', ' .. get_value(d.vim) .. '}')
 end
 
 local defines = {}

--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -118,7 +118,8 @@ local get_value = function(v)
 end
 
 local get_defaults = function(d)
-  return '{' .. get_value(d.vi) .. ', ' .. get_value(d.vim) .. '}  /* -V542 */'
+  return ('{' .. get_value(d.vi) .. '/* -V542 */, '
+          .. get_value(d.vim) .. '/* -V542 */}')
 end
 
 local defines = {}

--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -118,7 +118,7 @@ local get_value = function(v)
 end
 
 local get_defaults = function(d)
-  return '{' .. get_value(d.vi) .. ', ' .. get_value(d.vim) .. '}'
+  return '{' .. get_value(d.vi) .. ', ' .. get_value(d.vim) .. '}  /* -V542 */'
 end
 
 local defines = {}

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3794,8 +3794,7 @@ makemap (
   char        *cmd;
   int abbr;
   int hash;
-  int did_cpo = FALSE;
-  int i;
+  bool did_cpo = false;
 
   validate_maphash();
 
@@ -3923,13 +3922,15 @@ makemap (
           /* When outputting <> form, need to make sure that 'cpo'
            * is set to the Vim default. */
           if (!did_cpo) {
-            if (*mp->m_str == NUL)                      /* will use <Nop> */
-              did_cpo = TRUE;
-            else
-              for (i = 0; i < 2; ++i)
-                for (p = (i ? mp->m_str : mp->m_keys); *p; ++p)
-                  if (*p == K_SPECIAL || *p == NL)
-                    did_cpo = TRUE;
+            if (*mp->m_str == NUL) {  // Will use <Nop>.
+              did_cpo = true;
+            } else {
+              const char specials[] = { (char)(uint8_t)K_SPECIAL, NL, NUL };
+              if (strpbrk((const char *)mp->m_str, specials) != NULL
+                  || strpbrk((const char *)mp->m_keys, specials) != NULL) {
+                did_cpo = true;
+              }
+            }
             if (did_cpo) {
               if (fprintf(fd, "let s:cpo_save=&cpo") < 0
                   || put_eol(fd) < 0

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -1,3 +1,6 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1,3 +1,6 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -171,4 +171,16 @@
 # define FALLTHROUGH
 #endif
 
+// -V:STRUCT_CAST:641
+
+/// Change type of structure pointers: cast `struct a *` to `struct b *`
+///
+/// Used to silence PVS errors.
+///
+/// @param  Type  Structure to cast to.
+/// @param  obj  Object to cast.
+///
+/// @return ((Type *)obj).
+#define STRUCT_CAST(Type, obj) ((Type *)(obj))
+
 #endif  // NVIM_MACROS_H

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -656,8 +656,9 @@ void getout(int exitval)
 ///
 /// @return argument's numeric value otherwise
 static int get_number_arg(const char *p, int *idx, int def)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  if (ascii_isdigit(p[*idx])) {
+  if (ascii_isdigit(p[*idx])) {  // -V522
     def = atoi(&(p[*idx]));
     while (ascii_isdigit(p[*idx])) {
       *idx = *idx + 1;

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -54,6 +54,7 @@
 #include "nvim/memory.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
+#include "nvim/assert.h"
 #include "nvim/os/os.h"
 #include "nvim/os/input.h"
 
@@ -108,7 +109,8 @@ memfile_T *mf_open(char_u *fname, int flags)
   if (mfp->mf_fd >= 0 && os_fileinfo_fd(mfp->mf_fd, &file_info)) {
     uint64_t blocksize = os_fileinfo_blocksize(&file_info);
     if (blocksize >= MIN_SWAP_PAGE_SIZE && blocksize <= MAX_SWAP_PAGE_SIZE) {
-      assert(blocksize <= UINT_MAX);
+      STATIC_ASSERT(MAX_SWAP_PAGE_SIZE <= UINT_MAX,
+                    "MAX_SWAP_PAGE_SIZE must fit into an unsigned");
       mfp->mf_page_size = (unsigned)blocksize;
     }
   }

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -34,6 +34,11 @@ local macros=function(s)
     return s
   end
 end
+local imacros=function(s)
+  return function()
+    return '(intptr_t)' .. s
+  end
+end
 local N_=function(s)
   return function()
     return 'N_(' .. cstr(s) .. ')'
@@ -2648,7 +2653,7 @@ return {
       type='number', scope={'global'},
       vim=true,
       varname='p_wc',
-      defaults={if_true={vi=macros('Ctrl_E'), vim=macros('TAB')}}
+      defaults={if_true={vi=imacros('Ctrl_E'), vim=imacros('TAB')}}
     },
     {
       full_name='wildcharm', abbreviation='wcm',

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -616,7 +616,7 @@ int searchit(
              * otherwise "/$" will get stuck on end of line.
              */
             while (matchpos.lnum == 0
-                   && ((options & SEARCH_END) && first_match
+                   && (((options & SEARCH_END) && first_match)
                        ?  (nmatched == 1
                            && (int)endpos.col - 1
                            < (int)start_pos.col + extra_col)

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1277,8 +1277,6 @@ static void shada_read(ShaDaReadDef *const sd_reader, const int flags)
         if (cur_entry.data.search_pattern.is_last_used) {
           set_last_used_pattern(
               cur_entry.data.search_pattern.is_substitute_pattern);
-        }
-        if (cur_entry.data.search_pattern.is_last_used) {
           SET_NO_HLSEARCH(!cur_entry.data.search_pattern.highlighted);
         }
         // Do not free shada entry: its allocated memory was saved above.

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -2468,8 +2468,7 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
               }
             }
 
-            if (aff_entry->ae_chop == NULL
-                && aff_entry->ae_flags == NULL) {
+            if (aff_entry->ae_chop == NULL) {
               int idx;
               char_u      **pp;
               int n;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -309,6 +309,8 @@ static keyentry_T dumkey;
 #define HIKEY2KE(p)   ((keyentry_T *)((p) - (dumkey.keyword - (char_u *)&dumkey)))
 #define HI2KE(hi)      HIKEY2KE((hi)->hi_key)
 
+// -V:HI2KE:782
+
 /*
  * To reduce the time spent in keepend(), remember at which level in the state
  * stack the first item with "keepend" is present.  When "-1", there is no

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -208,10 +208,9 @@ do_tag (
   clearpos(&saved_fmark.mark);          /* shutup gcc 4.0 */
   saved_fmark.fnum = 0;
 
-  /*
-   * Don't add a tag to the tagstack if 'tagstack' has been reset.
-   */
-  if (!p_tgst && *tag != NUL) {
+  // Don't add a tag to the tagstack if 'tagstack' has been reset.
+  assert(tag != NULL);
+  if (!p_tgst && *tag != NUL) {  // -V522
     use_tagstack = false;
     new_tag = true;
     if (g_do_tagpreview != 0) {

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -36,6 +36,7 @@
 #include "nvim/tui/tui.h"
 #include "nvim/cursor_shape.h"
 #include "nvim/syntax.h"
+#include "nvim/macros.h"
 
 // Space reserved in the output buffer to restore the cursor to normal when
 // flushing. No existing terminal will require 32 bytes to do that.
@@ -1079,7 +1080,7 @@ static void flush_buf(UI *ui, bool toggle_cursor)
 
   buf.base = data->buf;
   buf.len = data->bufpos;
-  uv_write(&req, (uv_stream_t *)&data->output_handle, &buf, 1, NULL);
+  uv_write(&req, STRUCT_CAST(uv_stream_t, &data->output_handle), &buf, 1, NULL);
   uv_run(&data->write_loop, UV_RUN_DEFAULT);
   data->bufpos = 0;
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1123,13 +1123,13 @@ static const char *tui_tk_ti_getstr(const char *name, const char *value,
 
   if (strequal(name, "key_backspace")) {
     ILOG("libtermkey:kbs=%s", value);
-    if (stty_erase != NULL && stty_erase[0] != 0) {
+    if (stty_erase[0] != 0) {
       return stty_erase;
     }
   } else if (strequal(name, "key_dc")) {
     ILOG("libtermkey:kdch1=%s", value);
     // Vim: "If <BS> and <DEL> are now the same, redefine <DEL>."
-    if (stty_erase != NULL && value != NULL && strequal(stty_erase, value)) {
+    if (value != NULL && strequal(stty_erase, value)) {
       return stty_erase[0] == DEL ? CTRL_H_STR : DEL_STR;
     }
   }

--- a/test/functional/fixtures/tty-test.c
+++ b/test/functional/fixtures/tty-test.c
@@ -6,6 +6,9 @@
 #include <stdlib.h>
 #include <uv.h>
 
+// -V:STRUCT_CAST:641
+#define STRUCT_CAST(Type, obj) ((Type *)(obj))
+
 uv_tty_t tty;
 
 #ifdef _WIN32
@@ -88,9 +91,9 @@ static void read_cb(uv_stream_t *stream, ssize_t cnt, const uv_buf_t *buf)
   uv_tty_init(&write_loop, &out, 1, 0);
   uv_write_t req;
   uv_buf_t b = {.base = buf->base, .len = (size_t)cnt};
-  uv_write(&req, (uv_stream_t *)&out, &b, 1, NULL);
+  uv_write(&req, STRUCT_CAST(uv_stream_t, &out), &b, 1, NULL);
   uv_run(&write_loop, UV_RUN_DEFAULT);
-  uv_close((uv_handle_t *)&out, NULL);
+  uv_close(STRUCT_CAST(uv_handle_t, &out), NULL);
   uv_run(&write_loop, UV_RUN_DEFAULT);
   if (uv_loop_close(&write_loop)) {
     abort();
@@ -149,7 +152,7 @@ int main(int argc, char **argv)
   uv_tty_init(uv_default_loop(), &tty, fileno(stderr), 1);
   uv_tty_set_mode(&tty, UV_TTY_MODE_RAW);
   tty.data = &interrupted;
-  uv_read_start((uv_stream_t *)&tty, alloc_cb, read_cb);
+  uv_read_start(STRUCT_CAST(uv_stream_t, &tty), alloc_cb, read_cb);
 #ifndef WIN32
   struct sigaction sa;
   sigemptyset(&sa.sa_mask);


### PR DESCRIPTION
Left only four of them:

1. Mysterious “unreachable code” in msgpack_rpc_from_object (line 389).
2. Buffer undeflow in spell.c:3638: not sure what to do with this exactly (may leave as-is for sanitizers to catch some possible bugs or just zero out the entire stack).
3. Parameter rewrite in syntax.c:2186: almost sure it is intentional, but I am not familiar with this part of code.
4. Potential NULL dereference at regexp.c:6932. There is no NULL dereference there as far as I see, but what there is is a two-interation for loop antipattern (for loop: compute length then do allocation and fill the buffer).