### PR TITLE
[WIP] lua/executor.c: fix ASAN issue

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -107,9 +107,16 @@ static void nlua_error(lua_State *const lstate, const char *const msg)
   FUNC_ATTR_NONNULL_ALL
 {
   size_t len;
-  const char *const str = lua_tolstring(lstate, -1, &len);
+  const char *str = lua_tolstring(lstate, -1, &len);
 
-  emsgf(msg, (int)len, str);
+  char errbuf[IOSIZE];
+  // vim_vsnprintf special case to make tests happy
+  if (str == NULL) {
+    str = "[NULL]";
+    len = 6;
+  }
+  snprintf(errbuf, ARRAY_SIZE(errbuf), msg, (int)len, str);
+  emsg((const char_u *)errbuf);
 
   lua_pop(lstate, 1);
 }
@@ -491,8 +498,17 @@ static int nlua_print(lua_State *const lstate)
   ga_clear(&msg_ga);
   return 0;
 nlua_print_error:
-  emsgf(_("E5114: Error while converting print argument #%i: %.*s"),
-        curargidx, errmsg_len, errmsg);
+  ;
+  char errbuf[IOSIZE];
+  // vim_vsnprintf special case to make tests happy
+  if (errmsg == NULL) {
+    errmsg = "[NULL]";
+    errmsg_len = 6;
+  }
+  snprintf(errbuf, ARRAY_SIZE(errbuf),
+           _("E5114: Error while converting print argument #%i: %.*s"),
+           curargidx, (int)errmsg_len, errmsg);
+  emsg((const char_u *)errbuf);
   ga_clear(&msg_ga);
   lua_pop(lstate, lua_gettop(lstate));
   return 0;


### PR DESCRIPTION
Just applying @oni-link's patch.

https://github.com/neovim/neovim/pull/6735#issuecomment-301316334

cc @oni-link @ZyX-I 

```
[ RUN      ] luaeval(vim.api.…) errors out correctly when working with API: FAIL
...vis/build/neovim/neovim/test/functional/lua/api_spec.lua:158: Expected objects to be the same.
Passed in:
(nil)
Expected:
(string) 'Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Cannot convert given lua type'
stack traceback:
	...vis/build/neovim/neovim/test/functional/lua/api_spec.lua:158: in function <...vis/build/neovim/neovim/test/functional/lua/api_spec.lua:156>
==================== File /home/travis/build/neovim/neovim/build/log/ubsan.12582 ====================
= =================================================================
= ==12582==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x7ffd000b65a0 at pc 0x000001771fe9 bp 0x7ffd000b5290 sp 0x7ffd000b5288
= READ of size 8 at 0x7ffd000b65a0 thread T0
=     #0 0x1771fe8 in vim_vsnprintf /home/travis/build/neovim/neovim/src/nvim/strings.c:934:31
=     #1 0xfbbe2d in emsgf /home/travis/build/neovim/neovim/src/nvim/message.c:593:3
=     #2 0xe6fb9f in nlua_error /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:109:3
=     #3 0xe70876 in nlua_eval_lua_string /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:365:5
=     #4 0x19d6386 in lj_BC_JFUNCV (/home/travis/build/neovim/neovim/build/bin/nvim+0x19d6386)
=     #5 0xe6fe6d in executor_eval_lua /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:555:3
=     #6 0x8d2bf3 in f_luaeval /home/travis/build/neovim/neovim/src/nvim/eval.c:12093:3
=     #7 0x7f1478 in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:6390:11
=     #8 0x806dd4 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:6130:11
=     #9 0x7ff545 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
=     #10 0xb686e8 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2241:5
=     #11 0xb46de7 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:607:20
=     #12 0x848b1c in ex_execute /home/travis/build/neovim/neovim/src/nvim/eval.c:19319:7
=     #13 0xb686e8 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2241:5
=     #14 0xb46de7 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:607:20
=     #15 0xb4d0f5 in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:279:10
=     #16 0x6501e3 in nvim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:52:3
=     #17 0x59ea70 in handle_nvim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/api/private/dispatch_wrappers.generated.h:1577:3
=     #18 0x1079987 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:467:19
=     #19 0xa62492 in multiqueue_process_events /home/travis/build/neovim/neovim/src/nvim/event/multiqueue.c:150:7
=     #20 0x1148e45 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7905:3
=     #21 0x10ec79a in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1137:3
=     #22 0x17697a0 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:61:26
=     #23 0x10a473b in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:467:3
=     #24 0xe78763 in main /home/travis/build/neovim/neovim/src/nvim/main.c:556:3
=     #25 0x2adc64c50f44 in __libc_start_main /build/eglibc-MjiXCM/eglibc-2.19/csu/libc-start.c:287
=     #26 0x44bef5 in _start (/home/travis/build/neovim/neovim/build/bin/nvim+0x44bef5)
=
= Address 0x7ffd000b65a0 is located in stack of thread T0==12582==AddressSanitizer CHECK failed: /tmp/buildd/llvm-toolchain-3.9-3.9~svn288847/projects/compiler-rt/lib/asan/asan_thread.cc:314 "((ptr[0] == kCurrentStackFrameMagic)) != (0)" (0x0, 0x0)
=     #0 0x51253f in __asan::AsanCheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/home/travis/build/neovim/neovim/build/bin/nvim+0x51253f)
=     #1 0x528ed5 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/home/travis/build/neovim/neovim/build/bin/nvim+0x528ed5)
=     #2 0x515c3d in __asan::AsanThread::GetStackFrameAccessByAddr(unsigned long, __asan::AsanThread::StackFrameAccess*) (/home/travis/build/neovim/neovim/build/bin/nvim+0x515c3d)
=     #3 0x50c758 in __asan::DescribeAddressIfStack(unsigned long, unsigned long) (/home/travis/build/neovim/neovim/build/bin/nvim+0x50c758)
=     #4 0x50cd02 in __asan::DescribeAddress(unsigned long, unsigned long, char const*) (/home/travis/build/neovim/neovim/build/bin/nvim+0x50cd02)
=     #5 0x510f3d in __asan::ReportGenericError(unsigned long, unsigned long, unsigned long, unsigned long, bool, unsigned long, unsigned int, bool) (/home/travis/build/neovim/neovim/build/bin/nvim+0x510f3d)
=     #6 0x512962 in __asan_report_load8 (/home/travis/build/neovim/neovim/build/bin/nvim+0x512962)
=     #7 0x1771fe8 in vim_vsnprintf /home/travis/build/neovim/neovim/src/nvim/strings.c:934:31
=     #8 0xfbbe2d in emsgf /home/travis/build/neovim/neovim/src/nvim/message.c:593:3
=     #9 0xe6fb9f in nlua_error /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:109:3
=     #10 0xe70876 in nlua_eval_lua_string /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:365:5
=     #11 0x19d6386 in lj_BC_JFUNCV (/home/travis/build/neovim/neovim/build/bin/nvim+0x19d6386)
=     #12 0xe6fe6d in executor_eval_lua /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:555:3
=     #13 0x8d2bf3 in f_luaeval /home/travis/build/neovim/neovim/src/nvim/eval.c:12093:3
=     #14 0x7f1478 in call_func /home/travis/build/neovim/neovim/src/nvim/eval.c:6390:11
=     #15 0x806dd4 in get_func_tv /home/travis/build/neovim/neovim/src/nvim/eval.c:6130:11
=     #16 0x7ff545 in ex_call /home/travis/build/neovim/neovim/src/nvim/eval.c:2761:9
=     #17 0xb686e8 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2241:5
=     #18 0xb46de7 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:607:20
=     #19 0x848b1c in ex_execute /home/travis/build/neovim/neovim/src/nvim/eval.c:19319:7
=     #20 0xb686e8 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2241:5
=     #21 0xb46de7 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:607:20
=     #22 0xb4d0f5 in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:279:10
=     #23 0x6501e3 in nvim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:52:3
=     #24 0x59ea70 in handle_nvim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/api/private/dispatch_wrappers.generated.h:1577:3
=     #25 0x1079987 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:467:19
=     #26 0xa62492 in multiqueue_process_events /home/travis/build/neovim/neovim/src/nvim/event/multiqueue.c:150:7
=     #27 0x1148e45 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7905:3
=     #28 0x10ec79a in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1137:3
=     #29 0x17697a0 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:61:26
=     #30 0x10a473b in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:467:3
=     #31 0xe78763 in main /home/travis/build/neovim/neovim/src/nvim/main.c:556:3
=     #32 0x2adc64c50f44 in __libc_start_main /build/eglibc-MjiXCM/eglibc-2.19/csu/libc-start.c:287
=     #33 0x44bef5 in _start (/home/travis/build/neovim/neovim/build/bin/nvim+0x44bef5)
=
=====================================================================================================
./test/helpers.lua:95: assertion failed!
stack traceback:
	./test/helpers.lua:95: in function 'check_logs'
	./test/functional/helpers.lua:654: in function <./test/functional/helpers.lua:653>
[ RUN      ] luaeval(vim.api.…) accepts any value as API Boolean: 19.19 ms OK
[----------] 13 tests from /home/travis/build/neovim/neovim/test/functional/lua/api_spec.lua (581.74 ms total)
[----------] Running tests from /home/travis/build/neovim/neovim/test/functional/lua/commands_spec.lua
[ RUN      ] :lua command works: 4.55 ms OK
[ RUN      ] :lua command throws catchable errors: FAIL
...uild/neovim/neovim/test/functional/lua/commands_spec.lua:45: Expected objects to be the same.
Passed in:
(nil)
Expected:
(string) 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: Invalid buffer id'
stack traceback:
	...uild/neovim/neovim/test/functional/lua/commands_spec.lua:45: in function <...uild/neovim/neovim/test/functional/lua/commands_spec.lua:40>
==================== File /home/travis/build/neovim/neovim/build/log/ubsan.12588 ====================
= =================================================================
= ==12588==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fff76cfaa18 at pc 0x000001771009 bp 0x7fff76cf9710 sp 0x7fff76cf9708
= READ of size 4 at 0x7fff76cfaa18 thread T0
=     #0 0x1771008 in vim_vsnprintf /home/travis/build/neovim/neovim/src/nvim/strings.c:872:59
=     #1 0xfbbe2d in emsgf /home/travis/build/neovim/neovim/src/nvim/message.c:593:3
=     #2 0xe6fb9f in nlua_error /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:109:3
=     #3 0xe6efed in nlua_exec_lua_string /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:147:5
=     #4 0x19d6386 in lj_BC_JFUNCV (/home/travis/build/neovim/neovim/build/bin/nvim+0x19d6386)
=     #5 0xe6eb52 in executor_exec_lua /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:312:3
=     #6 0xe71b48 in ex_lua /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:596:3
=     #7 0xb686e8 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2241:5
=     #8 0xb46de7 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:607:20
=     #9 0x848b1c in ex_execute /home/travis/build/neovim/neovim/src/nvim/eval.c:19319:7
=     #10 0xb686e8 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2241:5
=     #11 0xb46de7 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:607:20
=     #12 0xb4d0f5 in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:279:10
=     #13 0x6501e3 in nvim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:52:3
=     #14 0x59ea70 in handle_nvim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/api/private/dispatch_wrappers.generated.h:1577:3
=     #15 0x1079987 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:467:19
=     #16 0xa62492 in multiqueue_process_events /home/travis/build/neovim/neovim/src/nvim/event/multiqueue.c:150:7
=     #17 0x1148e45 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7905:3
=     #18 0x10ec79a in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1137:3
=     #19 0x17697a0 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:61:26
=     #20 0x10a473b in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:467:3
=     #21 0xe78763 in main /home/travis/build/neovim/neovim/src/nvim/main.c:556:3
=     #22 0x2b264fbddf44 in __libc_start_main /build/eglibc-MjiXCM/eglibc-2.19/csu/libc-start.c:287
=     #23 0x44bef5 in _start (/home/travis/build/neovim/neovim/build/bin/nvim+0x44bef5)
=
= Address 0x7fff76cfaa18 is located in stack of thread T0==12588==AddressSanitizer CHECK failed: /tmp/buildd/llvm-toolchain-3.9-3.9~svn288847/projects/compiler-rt/lib/asan/asan_thread.cc:314 "((ptr[0] == kCurrentStackFrameMagic)) != (0)" (0x0, 0x0)
=     #0 0x51253f in __asan::AsanCheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/home/travis/build/neovim/neovim/build/bin/nvim+0x51253f)
=     #1 0x528ed5 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/home/travis/build/neovim/neovim/build/bin/nvim+0x528ed5)
=     #2 0x515c3d in __asan::AsanThread::GetStackFrameAccessByAddr(unsigned long, __asan::AsanThread::StackFrameAccess*) (/home/travis/build/neovim/neovim/build/bin/nvim+0x515c3d)
=     #3 0x50c758 in __asan::DescribeAddressIfStack(unsigned long, unsigned long) (/home/travis/build/neovim/neovim/build/bin/nvim+0x50c758)
=     #4 0x50cd02 in __asan::DescribeAddress(unsigned long, unsigned long, char const*) (/home/travis/build/neovim/neovim/build/bin/nvim+0x50cd02)
=     #5 0x510f3d in __asan::ReportGenericError(unsigned long, unsigned long, unsigned long, unsigned long, bool, unsigned long, unsigned int, bool) (/home/travis/build/neovim/neovim/build/bin/nvim+0x510f3d)
=     #6 0x5128a2 in __asan_report_load4 (/home/travis/build/neovim/neovim/build/bin/nvim+0x5128a2)
=     #7 0x1771008 in vim_vsnprintf /home/travis/build/neovim/neovim/src/nvim/strings.c:872:59
=     #8 0xfbbe2d in emsgf /home/travis/build/neovim/neovim/src/nvim/message.c:593:3
=     #9 0xe6fb9f in nlua_error /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:109:3
=     #10 0xe6efed in nlua_exec_lua_string /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:147:5
=     #11 0x19d6386 in lj_BC_JFUNCV (/home/travis/build/neovim/neovim/build/bin/nvim+0x19d6386)
=     #12 0xe6eb52 in executor_exec_lua /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:312:3
=     #13 0xe71b48 in ex_lua /home/travis/build/neovim/neovim/src/nvim/lua/executor.c:596:3
=     #14 0xb686e8 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2241:5
=     #15 0xb46de7 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:607:20
=     #16 0x848b1c in ex_execute /home/travis/build/neovim/neovim/src/nvim/eval.c:19319:7
=     #17 0xb686e8 in do_one_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:2241:5
=     #18 0xb46de7 in do_cmdline /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:607:20
=     #19 0xb4d0f5 in do_cmdline_cmd /home/travis/build/neovim/neovim/src/nvim/ex_docmd.c:279:10
=     #20 0x6501e3 in nvim_command /home/travis/build/neovim/neovim/src/nvim/api/vim.c:52:3
=     #21 0x59ea70 in handle_nvim_command /home/travis/build/neovim/neovim/build/src/nvim/auto/api/private/dispatch_wrappers.generated.h:1577:3
=     #22 0x1079987 in on_request_event /home/travis/build/neovim/neovim/src/nvim/msgpack_rpc/channel.c:467:19
=     #23 0xa62492 in multiqueue_process_events /home/travis/build/neovim/neovim/src/nvim/event/multiqueue.c:150:7
=     #24 0x1148e45 in nv_event /home/travis/build/neovim/neovim/src/nvim/normal.c:7905:3
=     #25 0x10ec79a in normal_execute /home/travis/build/neovim/neovim/src/nvim/normal.c:1137:3
=     #26 0x17697a0 in state_enter /home/travis/build/neovim/neovim/src/nvim/state.c:61:26
=     #27 0x10a473b in normal_enter /home/travis/build/neovim/neovim/src/nvim/normal.c:467:3
=     #28 0xe78763 in main /home/travis/build/neovim/neovim/src/nvim/main.c:556:3
=     #29 0x2b264fbddf44 in __libc_start_main /build/eglibc-MjiXCM/eglibc-2.19/csu/libc-start.c:287
=     #30 0x44bef5 in _start (/home/travis/build/neovim/neovim/build/bin/nvim+0x44bef5)
=
=====================================================================================================
./test/helpers.lua:95: assertion failed!
stack traceback:
	./test/helpers.lua:95: in function 'check_logs'
	./test/functional/helpers.lua:654: in function <./test/functional/helpers.lua:653>
```