### PR TITLE
tui.c: Initialize TUI input component only once.

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -216,11 +216,6 @@ static void tui_terminal_start(UI *ui)
   terminfo_start(ui);
   update_size(ui);
   signal_watcher_start(&data->winch_handle, sigwinch_cb, SIGWINCH);
-
-#if TERMKEY_VERSION_MAJOR > 0 || TERMKEY_VERSION_MINOR > 18
-  data->input.tk_ti_hook_fn = tui_tk_ti_getstr;
-#endif
-  term_input_init(&data->input, data->loop);
   term_input_start(&data->input);
 }
 
@@ -255,8 +250,14 @@ static void tui_main(UIBridgeData *bridge, UI *ui)
 #ifdef UNIX
   signal_watcher_start(&data->cont_handle, sigcont_cb, SIGCONT);
 #endif
+
+#if TERMKEY_VERSION_MAJOR > 0 || TERMKEY_VERSION_MINOR > 18
+  data->input.tk_ti_hook_fn = tui_tk_ti_getstr;
+#endif
+  term_input_init(&data->input, &tui_loop);
   tui_terminal_start(ui);
   data->stop = false;
+
   // allow the main thread to continue, we are ready to start handling UI
   // callbacks
   CONTINUE(bridge);


### PR DESCRIPTION
term_input_start should be called only once. This fixes a leak
introduced by af2e629be4d20dda334a7c6ca817f5599956e4ff.

Closes #6780

Steps to demonstrate memory leak:

    CC=clang CFLAGS=" -O0 -g -DEXITFREE " cmake .. -DMIN_LOG_LEVEL=0 -DCMAKE_BUILD_TYPE=Debug -DBUSTED_OUTPUT_TYPE=nvim -DCMAKE_INSTALL_PREFIX=$PWD/root -DCLANG_ASAN_UBSAN=ON -DPREFER_LUAJIT=false
    nvim -u NONE -i NONE --cmd $'function S()\nsuspend\nendfunction' --cmd 'inoremap <expr> X S()' --cmd 'call feedkeys("iX", "t")'
    fg<CR><Esc>:cq<CR>

```
=================================================================
==25050==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4159 byte(s) in 1 object(s) allocated from:
    #0 0x4f6a30 in calloc /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:72
    #1 0xf8d222 in xcalloc /home/zyx/a.a/Proj/c/neovim/src/nvim/memory.c:147:15
    #2 0x1349d28 in rbuffer_new /home/zyx/a.a/Proj/c/neovim/src/nvim/rbuffer.c:24:17
    #3 0xa6867b in rstream_init /home/zyx/a.a/Proj/c/neovim/src/nvim/event/rstream.c:42:20
    #4 0xa68651 in rstream_init_fd /home/zyx/a.a/Proj/c/neovim/src/nvim/event/rstream.c:28:3
    #5 0x1866451 in term_input_init /home/zyx/a.a/Proj/c/neovim/src/nvim/tui/input.c:55:3
    #6 0x187f049 in tui_terminal_start /home/zyx/a.a/Proj/c/neovim/src/nvim/tui/tui.c:223:3
    #7 0x187b491 in tui_main /home/zyx/a.a/Proj/c/neovim/src/nvim/tui/tui.c:258:3
    #8 0x18b3171 in ui_thread_run /home/zyx/a.a/Proj/c/neovim/src/nvim/ui_bridge.c:124:3
    #9 0x7f54c2d5f39b  (/lib64/libpthread.so.0+0x739b)

Direct leak of 4159 byte(s) in 1 object(s) allocated from:
    #0 0x4f6a30 in calloc /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:72
    #1 0xf8d222 in xcalloc /home/zyx/a.a/Proj/c/neovim/src/nvim/memory.c:147:15
    #2 0x1349d28 in rbuffer_new /home/zyx/a.a/Proj/c/neovim/src/nvim/rbuffer.c:24:17
    #3 0x1865a4a in term_input_init /home/zyx/a.a/Proj/c/neovim/src/nvim/tui/input.c:29:23
    #4 0x187f049 in tui_terminal_start /home/zyx/a.a/Proj/c/neovim/src/nvim/tui/tui.c:223:3
    #5 0x187b491 in tui_main /home/zyx/a.a/Proj/c/neovim/src/nvim/tui/tui.c:258:3
    #6 0x18b3171 in ui_thread_run /home/zyx/a.a/Proj/c/neovim/src/nvim/ui_bridge.c:124:3
    #7 0x7f54c2d5f39b  (/lib64/libpthread.so.0+0x739b)

Indirect leak of 7144 byte(s) in 62 object(s) allocated from:
    #0 0x4f6840 in malloc /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:64
    #1 0x7f54c231636c  (/usr/lib64/libtermkey.so.1+0x636c)

Indirect leak of 1500 byte(s) in 75 object(s) allocated from:
    #0 0x4f6840 in malloc /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:64
    #1 0x7f54c2316b34  (/usr/lib64/libtermkey.so.1+0x6b34)

Indirect leak of 704 byte(s) in 1 object(s) allocated from:
    #0 0x4f6840 in malloc /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:64
    #1 0x7f54c23129dd in _init (/usr/lib64/libtermkey.so.1+0x29dd)

Indirect leak of 520 byte(s) in 1 object(s) allocated from:
    #0 0x4f6c40 in realloc /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:77
    #1 0x7f54c2313b7c in termkey_register_keyname (/usr/lib64/libtermkey.so.1+0x3b7c)

Indirect leak of 256 byte(s) in 1 object(s) allocated from:
    #0 0x4f6840 in malloc /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:64
    #1 0x7f54c2313c3c  (/usr/lib64/libtermkey.so.1+0x3c3c)

Indirect leak of 48 byte(s) in 2 object(s) allocated from:
    #0 0x4f6840 in malloc /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:64
    #1 0x7f54c2313d9e  (/usr/lib64/libtermkey.so.1+0x3d9e)

Indirect leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x4f6840 in malloc /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:64
    #1 0x7f54c2316553  (/usr/lib64/libtermkey.so.1+0x6553)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x4f6840 in malloc /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:64
    #1 0x7f54c2315a2f  (/usr/lib64/libtermkey.so.1+0x5a2f)

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x485ca8 in __interceptor_strdup /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_interceptors.cc:562
    #1 0x7f54c2316bef  (/usr/lib64/libtermkey.so.1+0x6bef)

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x485ca8 in __interceptor_strdup /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_interceptors.cc:562
    #1 0x7f54c2316c0f  (/usr/lib64/libtermkey.so.1+0x6c0f)

Indirect leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x4f6840 in malloc /var/tmp/portage/sys-devel/llvm-3.9.1-r1/work/llvm-3.9.1.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:64
    #1 0x7f54c2316a26  (/usr/lib64/libtermkey.so.1+0x6a26)

SUMMARY: AddressSanitizer: 18574 byte(s) leaked in 149 allocation(s).
```