### PR TITLE
TUI cursor motion, SGR, and scrolling optimizations

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -415,7 +415,7 @@ static bool cheap_to_print(UI *ui, int row, int col, int next)
     --next;
     if (attrs_differ(cell->attrs, data->print_attrs)) {
       if (data->default_attr) {
-	return false;
+        return false;
       }
     }
     if (strlen(cell->data) > 1) {
@@ -439,8 +439,9 @@ static void cursor_goto(UI *ui, int row, int col)
 {
   TUIData *data = ui->data;
   UGrid *grid = &data->grid;
-  if (row == grid->row && col == grid->col)
+  if (row == grid->row && col == grid->col) {
     return;
+  }
   if (0 == row && 0 == col) {
     unibi_out(ui, unibi_cursor_home);
     ugrid_goto(&data->grid, row, col);
@@ -456,34 +457,37 @@ static void cursor_goto(UI *ui, int row, int col)
     ugrid_goto(&data->grid, grid->row, 0);
   } else if (col > grid->col) {
       int n = col - grid->col;
-      if (n <= (row == grid->row ? 4 : 2) && cheap_to_print(ui, grid->row, grid->col, n)) {
-	UGRID_FOREACH_CELL(grid, grid->row, grid->row,
-	  grid->col, col - 1, {
-	  print_cell(ui, cell);
-	  ++grid->col;
-	});
+      if (n <= (row == grid->row ? 4 : 2)
+          && cheap_to_print(ui, grid->row, grid->col, n)) {
+        UGRID_FOREACH_CELL(grid, grid->row, grid->row,
+          grid->col, col - 1, {
+          print_cell(ui, cell);
+          ++grid->col;
+        });
       }
   }
   if (row == grid->row) {
     if (col < grid->col) {
       int n = grid->col - col;
       if (n <= 4) { // This might be just BS, so it is considered really cheap.
-	while (n--)
-	  unibi_out(ui, unibi_cursor_left);
+        while (n--) {
+          unibi_out(ui, unibi_cursor_left);
+	}
       } else {
-	data->params[0].i = n;
-	unibi_out(ui, unibi_parm_left_cursor);
+        data->params[0].i = n;
+        unibi_out(ui, unibi_parm_left_cursor);
       }
       ugrid_goto(&data->grid, row, col);
       return;
     } else if (col > grid->col) {
       int n = col - grid->col;
       if (n <= 2) {
-	while (n--)
-	  unibi_out(ui, unibi_cursor_right);
+        while (n--) {
+          unibi_out(ui, unibi_cursor_right);
+	}
       } else {
-	data->params[0].i = n;
-	unibi_out(ui, unibi_parm_right_cursor);
+        data->params[0].i = n;
+        unibi_out(ui, unibi_parm_right_cursor);
       }
       ugrid_goto(&data->grid, row, col);
       return;
@@ -493,22 +497,24 @@ static void cursor_goto(UI *ui, int row, int col)
     if (row > grid->row) {
       int n = row - grid->row;
       if (n <= 4) { // This might be just LF, so it is considered really cheap.
-	while (n--)
-	  unibi_out(ui, unibi_cursor_down);
+        while (n--) {
+          unibi_out(ui, unibi_cursor_down);
+	}
       } else {
-	data->params[0].i = n;
-	unibi_out(ui, unibi_parm_down_cursor);
+        data->params[0].i = n;
+        unibi_out(ui, unibi_parm_down_cursor);
       }
       ugrid_goto(&data->grid, row, col);
       return;
     } else if (row < grid->row) {
       int n = grid->row - row;
       if (n <= 2) {
-	while (n--)
-	  unibi_out(ui, unibi_cursor_up);
+        while (n--) {
+          unibi_out(ui, unibi_cursor_up);
+	}
       } else {
-	data->params[0].i = n;
-	unibi_out(ui, unibi_parm_up_cursor);
+        data->params[0].i = n;
+        unibi_out(ui, unibi_parm_up_cursor);
       }
       ugrid_goto(&data->grid, row, col);
       return;
@@ -575,10 +581,10 @@ static bool can_use_scroll(UI * ui)
 
   return data->scroll_region_is_full_screen ||
     (data->can_change_scroll_region &&
-      ( (grid->left == 0 && grid->right == ui->width - 1) ||
+     ( (grid->left == 0 && grid->right == ui->width - 1) ||
         data->can_set_lr_margin ||
-	data->can_set_left_right_margin
-      )
+        data->can_set_left_right_margin
+     )
     );
 }
 
@@ -1237,7 +1243,8 @@ static void fix_terminfo(TUIData *data)
     unibi_set_if_empty(ut, unibi_set_left_margin_parm, "\x1b[%i%p1%ds");
     unibi_set_if_empty(ut, unibi_set_right_margin_parm, "\x1b[%i;%p2%ds");
   }
-  if (data->term == kTermXTerm || data->term == kTermRxvt || data->term == kTermPuTTY) {
+  if (data->term == kTermXTerm || data->term == kTermRxvt
+      || data->term == kTermPuTTY) {
     unibi_set_if_empty(ut, unibi_change_scroll_region, "\x1b[%i%p1%d;%p2%dr");
     unibi_set_if_empty(ut, unibi_clear_screen, "\x1b[H\x1b[2J");
     unibi_set_bool(ut, unibi_back_color_erase, true);
@@ -1281,10 +1288,11 @@ static void fix_terminfo(TUIData *data)
       || data->term == kTermTeraTerm // per TeraTerm "Supported Control Functions" doco
       || data->term == kTermRxvt) {  // per command.C
     data->unibi_ext.resize_screen = (int)unibi_add_ext_str(ut, NULL,
-	"\x1b[8;%p1%d;%p2%dt");
+        "\x1b[8;%p1%d;%p2%dt");
   }
 
-  if (data->term == kTermXTerm || data->term == kTermRxvt || data->term == kTermPuTTY) {
+  if (data->term == kTermXTerm || data->term == kTermRxvt
+      || data->term == kTermPuTTY) {
     data->unibi_ext.reset_scroll_region = (int)unibi_add_ext_str(ut, NULL,
       "\x1b[r");
   }

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -82,7 +82,7 @@ typedef struct {
   UGrid grid;
   kvec_t(Rect) invalid_regions;
   int out_fd;
-  bool can_use_terminal_scroll;
+  bool scroll_region_is_full_screen;
   bool mouse_enabled;
   bool busy;
   cursorentry_T cursor_shapes[SHAPE_IDX_COUNT];
@@ -96,6 +96,7 @@ typedef struct {
     int set_cursor_color;
     int enable_focus_reporting, disable_focus_reporting;
     int resize_screen;
+    int reset_scroll_region;
   } unibi_ext;
 } TUIData;
 
@@ -147,7 +148,7 @@ UI *tui_start(void)
 static void terminfo_start(UI *ui)
 {
   TUIData *data = ui->data;
-  data->can_use_terminal_scroll = true;
+  data->scroll_region_is_full_screen = true;
   data->bufpos = 0;
   data->bufsize = sizeof(data->buf) - CNORM_COMMAND_MAX_SIZE;
   data->showing_mode = SHAPE_IDX_N;
@@ -159,6 +160,7 @@ static void terminfo_start(UI *ui)
   data->unibi_ext.enable_focus_reporting = -1;
   data->unibi_ext.disable_focus_reporting = -1;
   data->unibi_ext.resize_screen = -1;
+  data->unibi_ext.reset_scroll_region = -1;
   data->out_fd = 1;
   data->out_isatty = os_isatty(data->out_fd);
   // setup unibilium
@@ -424,6 +426,19 @@ static void clear_region(UI *ui, int top, int bot, int left, int right)
   unibi_goto(ui, grid->row, grid->col);
 }
 
+static void reset_scroll_region(UI *ui)
+{
+  TUIData *data = ui->data;
+
+  if (0 <= data->unibi_ext.reset_scroll_region) {
+    unibi_out(ui, data->unibi_ext.reset_scroll_region);
+  } else {
+    data->params[0].i = 0;
+    data->params[1].i = ui->height - 1;
+    unibi_out(ui, unibi_change_scroll_region);
+  }
+}
+
 static void tui_resize(UI *ui, Integer width, Integer height)
 {
   TUIData *data = ui->data;
@@ -433,6 +448,10 @@ static void tui_resize(UI *ui, Integer width, Integer height)
     data->params[0].i = (int)height;
     data->params[1].i = (int)width;
     unibi_out(ui, data->unibi_ext.resize_screen);
+    // DECSLPP does not reset the scroll region.
+    if (data->scroll_region_is_full_screen) {
+      reset_scroll_region(ui);
+    }
   } else {  // Already handled the SIGWINCH signal; avoid double-resize.
     got_winch = false;
   }
@@ -619,10 +638,9 @@ static void tui_set_scroll_region(UI *ui, Integer top, Integer bot,
   TUIData *data = ui->data;
   ugrid_set_scroll_region(&data->grid, (int)top, (int)bot,
                           (int)left, (int)right);
-  data->can_use_terminal_scroll =
+  data->scroll_region_is_full_screen =
     left == 0 && right == ui->width - 1
-    && ((top == 0 && bot == ui->height - 1)
-        || unibi_get_str(data->ut, unibi_change_scroll_region));
+    && top == 0 && bot == ui->height - 1;
 }
 
 static void tui_scroll(UI *ui, Integer count)
@@ -632,31 +650,28 @@ static void tui_scroll(UI *ui, Integer count)
   int clear_top, clear_bot;
   ugrid_scroll(grid, (int)count, &clear_top, &clear_bot);
 
-  if (data->can_use_terminal_scroll) {
+  if (data->scroll_region_is_full_screen || 0 <= unibi_change_scroll_region) {
     // Change terminal scroll region and move cursor to the top
-    data->params[0].i = grid->top;
-    data->params[1].i = grid->bot;
-    unibi_out(ui, unibi_change_scroll_region);
+    if (!data->scroll_region_is_full_screen) {
+      data->params[0].i = grid->top;
+      data->params[1].i = grid->bot;
+      unibi_out(ui, unibi_change_scroll_region);
+    }
     unibi_goto(ui, grid->top, grid->left);
     // also set default color attributes or some terminals can become funny
     HlAttrs clear_attrs = EMPTY_ATTRS;
     clear_attrs.foreground = grid->fg;
     clear_attrs.background = grid->bg;
     update_attrs(ui, clear_attrs);
-  }
 
-  if (count > 0) {
-    if (data->can_use_terminal_scroll) {
+    if (count > 0) {
       if (count == 1) {
         unibi_out(ui, unibi_delete_line);
       } else {
         data->params[0].i = (int)count;
         unibi_out(ui, unibi_parm_delete_line);
       }
-    }
-
-  } else {
-    if (data->can_use_terminal_scroll) {
+    } else {
       if (count == -1) {
         unibi_out(ui, unibi_insert_line);
       } else {
@@ -664,13 +679,11 @@ static void tui_scroll(UI *ui, Integer count)
         unibi_out(ui, unibi_parm_insert_line);
       }
     }
-  }
 
-  if (data->can_use_terminal_scroll) {
     // Restore terminal scroll region and cursor
-    data->params[0].i = 0;
-    data->params[1].i = ui->height - 1;
-    unibi_out(ui, unibi_change_scroll_region);
+    if (!data->scroll_region_is_full_screen) {
+      reset_scroll_region(ui);
+    }
     unibi_goto(ui, grid->row, grid->col);
 
     if (grid->bg != -1) {
@@ -1015,6 +1028,8 @@ static void fix_terminfo(TUIData *data)
     unibi_set_if_empty(ut, unibi_change_scroll_region, "\x1b[%i%p1%d;%p2%dr");
     unibi_set_if_empty(ut, unibi_clear_screen, "\x1b[H\x1b[2J");
     unibi_set_if_empty(ut, unibi_from_status_line, "\x07");
+    data->unibi_ext.reset_scroll_region = (int)unibi_add_ext_str(ut, NULL,
+      "\x1b[r");
   }
 
   data->unibi_ext.enable_bracketed_paste = (int)unibi_add_ext_str(ut, NULL,

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -428,14 +428,12 @@ static void tui_resize(UI *ui, Integer width, Integer height)
   ugrid_resize(&data->grid, (int)width, (int)height);
 
   if (!got_winch) {  // Try to resize the terminal window.
-    // One cannot expect all terminals to cope with any old ECMA-48 control sequence that one might like to emit.
-    // dtterm originated this extension.
-    // xterm and TeraTerm documentation confirm them understanding it.
-    // Konsole understands it, per commentary in VT102Emulation.cpp .
-    if (data->term == kTermDTTerm
-        || data->term == kTermXTerm
-        || data->term == kTermKonsole
-        || data->term == kTermTeraTerm) {
+    // Only send this control sequence extension to terminal types that we know understand it.
+    if (data->term == kTermDTTerm          // originated this extension
+        || data->term == kTermXTerm        // per xterm ctlseqs doco
+        || data->term == kTermKonsole      // per commentary in VT102Emulation.cpp
+        || data->term == kTermTeraTerm     // per TeraTerm "Supported Control Functions" doco
+        || data->term == kTermRxvt) {      // per command.C
       char r[16];  // enough for 9999x9999
       snprintf(r, sizeof(r), "\x1b[8;%d;%dt", height, width);
       out(ui, r, strlen(r));

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -428,12 +428,12 @@ static void tui_resize(UI *ui, Integer width, Integer height)
   ugrid_resize(&data->grid, (int)width, (int)height);
 
   if (!got_winch) {  // Try to resize the terminal window.
-    // Only send this control sequence extension to terminal types that we know understand it.
-    if (data->term == kTermDTTerm          // originated this extension
-        || data->term == kTermXTerm        // per xterm ctlseqs doco
-        || data->term == kTermKonsole      // per commentary in VT102Emulation.cpp
-        || data->term == kTermTeraTerm     // per TeraTerm "Supported Control Functions" doco
-        || data->term == kTermRxvt) {      // per command.C
+    // Only send this extension to terminal types that we know understand it.
+    if (data->term == kTermDTTerm      // originated this extension
+        || data->term == kTermXTerm    // per xterm ctlseqs doco
+        || data->term == kTermKonsole  // per commentary in VT102Emulation.cpp
+        || data->term == kTermTeraTerm // per TeraTerm "Supported Control Functions" doco
+        || data->term == kTermRxvt) {  // per command.C
       char r[16];  // enough for 9999x9999
       snprintf(r, sizeof(r), "\x1b[8;%d;%dt", height, width);
       out(ui, r, strlen(r));

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -543,6 +543,7 @@ static void clear_region(UI *ui, int top, int bot, int left, int right)
       if (bot == ui->height - 1) {
         if (top == 0) {
           unibi_out(ui, unibi_clear_screen);
+          ugrid_goto(&data->grid, top, left);
         } else {
           cursor_goto(ui, top, 0);
           unibi_out(ui, unibi_clr_eos);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -430,8 +430,8 @@ static void tui_resize(UI *ui, Integer width, Integer height)
   ugrid_resize(&data->grid, (int)width, (int)height);
 
   if (!got_winch) {  // Try to resize the terminal window.
-    data->params[0].i = height;
-    data->params[1].i = width;
+    data->params[0].i = (int)height;
+    data->params[1].i = (int)width;
     unibi_out(ui, data->unibi_ext.resize_screen);
   } else {  // Already handled the SIGWINCH signal; avoid double-resize.
     got_winch = false;

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -199,7 +199,11 @@ static void terminfo_start(UI *ui)
   uv_loop_init(&data->write_loop);
   if (data->out_isatty) {
     uv_tty_init(&data->write_loop, &data->output_handle.tty, data->out_fd, 0);
+#ifdef WIN32
     uv_tty_set_mode(&data->output_handle.tty, UV_TTY_MODE_RAW);
+#else
+    uv_tty_set_mode(&data->output_handle.tty, UV_TTY_MODE_IO);
+#endif
   } else {
     uv_pipe_init(&data->write_loop, &data->output_handle.pipe, 0);
     uv_pipe_open(&data->output_handle.pipe, data->out_fd);
@@ -401,10 +405,119 @@ static void print_cell(UI *ui, UCell *ptr)
   out(ui, ptr->data, strlen(ptr->data));
 }
 
+static bool cheap_to_print(UI *ui, int row, int col, int next)
+{
+  TUIData *data = ui->data;
+  UGrid *grid = &data->grid;
+  UCell *cell = grid->cells[row] + col;
+  while (next) {
+    --next;
+    if (attrs_differ(cell->attrs, data->print_attrs)) {
+      if (data->default_attr) {
+	return false;
+      }
+    }
+    if (strlen(cell->data) > 1) {
+      return false;
+    }
+    ++cell;
+  }
+  return true;
+}
+
+/// This optimizes several cases where it is cheaper to do something other
+/// than send a full cursor positioning control sequence.  However, there are
+/// some further optimizations that may seem obvious but that will not work.
+///
+/// We cannot use VT (ASCII 0/11) for moving the cursor up, because VT means
+/// move the cursor down on a DEC terminal.  Similarly, on a DEC terminal FF
+/// (ASCII 0/12) means the same thing and does not mean home.  VT, CVT, and
+/// TAB also stop at software-defined tabulation stops, not at a fixed set
+/// of row/column positions.
+static void cursor_goto(UI *ui, int row, int col)
+{
+  TUIData *data = ui->data;
+  UGrid *grid = &data->grid;
+  if (row == grid->row && col == grid->col)
+    return;
+  if (0 == row && 0 == col) {
+    unibi_out(ui, unibi_cursor_home);
+    ugrid_goto(&data->grid, row, col);
+    return;
+  }
+  if (0 == col && 0 != grid->col) {
+    unibi_out(ui, unibi_carriage_return);
+    ugrid_goto(&data->grid, grid->row, col);
+  } else if (col > grid->col) {
+      int n = col - grid->col;
+      if (n <= (row == grid->row ? 4 : 2) && cheap_to_print(ui, grid->row, grid->col, n)) {
+	UGRID_FOREACH_CELL(grid, grid->row, grid->row,
+	  grid->col, col - 1, {
+	  print_cell(ui, cell);
+	  ++grid->col;
+	});
+      }
+  }
+  if (row == grid->row) {
+    if (col < grid->col) {
+      int n = grid->col - col;
+      if (n <= 4) { // This might be just BS, so it is considered really cheap.
+	while (n--)
+	  unibi_out(ui, unibi_cursor_left);
+      } else {
+	data->params[0].i = n;
+	unibi_out(ui, unibi_parm_left_cursor);
+      }
+      ugrid_goto(&data->grid, row, col);
+      return;
+    } else if (col > grid->col) {
+      int n = col - grid->col;
+      if (n <= 2) {
+	while (n--)
+	  unibi_out(ui, unibi_cursor_right);
+      } else {
+	data->params[0].i = n;
+	unibi_out(ui, unibi_parm_right_cursor);
+      }
+      ugrid_goto(&data->grid, row, col);
+      return;
+    }
+  }
+  if (col == grid->col) {
+    if (row > grid->row) {
+      int n = row - grid->row;
+      if (n <= 4) { // This might be just LF, so it is considered really cheap.
+	while (n--)
+	  unibi_out(ui, unibi_cursor_down);
+      } else {
+	data->params[0].i = n;
+	unibi_out(ui, unibi_parm_down_cursor);
+      }
+      ugrid_goto(&data->grid, row, col);
+      return;
+    } else if (row < grid->row) {
+      int n = grid->row - row;
+      if (n <= 2) {
+	while (n--)
+	  unibi_out(ui, unibi_cursor_up);
+      } else {
+	data->params[0].i = n;
+	unibi_out(ui, unibi_parm_up_cursor);
+      }
+      ugrid_goto(&data->grid, row, col);
+      return;
+    }
+  }
+  unibi_goto(ui, row, col);
+  ugrid_goto(&data->grid, row, col);
+}
+
 static void clear_region(UI *ui, int top, int bot, int left, int right)
 {
   TUIData *data = ui->data;
   UGrid *grid = &data->grid;
+  int saved_row = grid->row;
+  int saved_col = grid->col;
 
   bool cleared = false;
   if (grid->bg == -1 && right == ui->width -1) {
@@ -419,7 +532,7 @@ static void clear_region(UI *ui, int top, int bot, int left, int right)
         if (top == 0) {
           unibi_out(ui, unibi_clear_screen);
         } else {
-          unibi_goto(ui, top, 0);
+          cursor_goto(ui, top, 0);
           unibi_out(ui, unibi_clr_eos);
         }
         cleared = true;
@@ -429,7 +542,7 @@ static void clear_region(UI *ui, int top, int bot, int left, int right)
     if (!cleared) {
       // iterate through each line and clear with clr_eol
       for (int row = top; row <= bot; ++row) {
-        unibi_goto(ui, row, left);
+        cursor_goto(ui, row, left);
         unibi_out(ui, unibi_clr_eol);
       }
       cleared = true;
@@ -438,18 +551,15 @@ static void clear_region(UI *ui, int top, int bot, int left, int right)
 
   if (!cleared) {
     // could not clear using faster terminal codes, refresh the whole region
-    int currow = -1;
     UGRID_FOREACH_CELL(grid, top, bot, left, right, {
-      if (currow != row) {
-        unibi_goto(ui, row, col);
-        currow = row;
-      }
+      cursor_goto(ui, row, col);
       print_cell(ui, cell);
+      ++grid->col;
     });
   }
 
   // restore cursor
-  unibi_goto(ui, grid->row, grid->col);
+  cursor_goto(ui, saved_row, saved_col);
 }
 
 static bool can_use_scroll(UI * ui)
@@ -554,9 +664,7 @@ static void tui_eol_clear(UI *ui)
 
 static void tui_cursor_goto(UI *ui, Integer row, Integer col)
 {
-  TUIData *data = ui->data;
-  ugrid_goto(&data->grid, (int)row, (int)col);
-  unibi_goto(ui, (int)row, (int)col);
+  cursor_goto(ui, (int)row, (int)col);
 }
 
 CursorShape tui_cursor_decode_shape(const char *shape_str)
@@ -730,6 +838,8 @@ static void tui_scroll(UI *ui, Integer count)
   ugrid_scroll(grid, (int)count, &clear_top, &clear_bot);
 
   if (can_use_scroll(ui)) {
+    int saved_row = grid->row;
+    int saved_col = grid->col;
     bool scroll_clears_to_current_colour =
       unibi_get_bool(data->ut, unibi_back_color_erase);
 
@@ -737,7 +847,7 @@ static void tui_scroll(UI *ui, Integer count)
     if (!data->scroll_region_is_full_screen) {
       set_scroll_region(ui);
     }
-    unibi_goto(ui, grid->top, grid->left);
+    cursor_goto(ui, grid->top, grid->left);
     // also set default color attributes or some terminals can become funny
     if (scroll_clears_to_current_colour) {
       HlAttrs clear_attrs = EMPTY_ATTRS;
@@ -766,7 +876,7 @@ static void tui_scroll(UI *ui, Integer count)
     if (!data->scroll_region_is_full_screen) {
       reset_scroll_region(ui);
     }
-    unibi_goto(ui, grid->row, grid->col);
+    cursor_goto(ui, saved_row, saved_col);
 
     if (!scroll_clears_to_current_colour) {
       // This is required because scrolling will leave wrong background in the
@@ -832,19 +942,19 @@ static void tui_flush(UI *ui)
     tui_busy_stop(ui);  // avoid hidden cursor
   }
 
+  int saved_row = grid->row;
+  int saved_col = grid->col;
+
   while (kv_size(data->invalid_regions)) {
     Rect r = kv_pop(data->invalid_regions);
-    int currow = -1;
     UGRID_FOREACH_CELL(grid, r.top, r.bot, r.left, r.right, {
-      if (currow != row) {
-        unibi_goto(ui, row, col);
-        currow = row;
-      }
+      cursor_goto(ui, row, col);
       print_cell(ui, cell);
+      ++grid->col;
     });
   }
 
-  unibi_goto(ui, grid->row, grid->col);
+  cursor_goto(ui, saved_row, saved_col);
 
   flush_buf(ui, true);
 }
@@ -1192,6 +1302,22 @@ end:
   data->unibi_ext.set_rgb_background = (int)unibi_add_ext_str(ut, NULL,
       "\x1b[48;2;%p1%d;%p2%d;%p3%dm");
   unibi_set_if_empty(ut, unibi_cursor_address, "\x1b[%i%p1%d;%p2%dH");
+  unibi_set_if_empty(ut, unibi_cursor_home, "\x1b[H");
+  unibi_set_if_empty(ut, unibi_parm_left_cursor, "\x1b[%p1%dD");
+  unibi_set_if_empty(ut, unibi_parm_right_cursor, "\x1b[%p1%dC");
+  unibi_set_if_empty(ut, unibi_parm_down_cursor, "\x1b[%p1%dB");
+  unibi_set_if_empty(ut, unibi_parm_up_cursor, "\x1b[%p1%dA");
+  unibi_set_if_empty(ut, unibi_cursor_left, "\x08");
+  unibi_set_if_empty(ut, unibi_cursor_right, "\x1b[C");
+#if defined(WIN32)
+  unibi_set_if_empty(ut, unibi_cursor_down, "\x1b[B");
+#else
+  // N.B. This relies upon the terminal really being in cfmakeraw() mode,
+  // which libuv's RAW mode is in fact not.
+  unibi_set_if_empty(ut, unibi_cursor_down, "\x0a");
+#endif
+  unibi_set_if_empty(ut, unibi_cursor_up, "\x1b[A");
+  unibi_set_if_empty(ut, unibi_carriage_return, "\x0d");
   unibi_set_if_empty(ut, unibi_exit_attribute_mode, "\x1b[0;10m");
   unibi_set_if_empty(ut, unibi_set_a_foreground, XTERM_SETAF_16);
   unibi_set_if_empty(ut, unibi_set_a_background, XTERM_SETAB_16);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -430,12 +430,12 @@ static void tui_resize(UI *ui, Integer width, Integer height)
   ugrid_resize(&data->grid, (int)width, (int)height);
 
   if (!got_winch) {  // Try to resize the terminal window.
-    // Only send this control sequence extension to terminal types that we know understand it.
-    if (data->term == kTermDTTerm          // originated this extension
-        || data->term == kTermXTerm        // per xterm ctlseqs doco
-        || data->term == kTermKonsole      // per commentary in VT102Emulation.cpp
-        || data->term == kTermTeraTerm     // per TeraTerm "Supported Control Functions" doco
-        || data->term == kTermRxvt) {      // per command.C
+    // Only send this extension to terminal types that we know understand it.
+    if (data->term == kTermDTTerm      // originated this extension
+        || data->term == kTermXTerm    // per xterm ctlseqs doco
+        || data->term == kTermKonsole  // per commentary in VT102Emulation.cpp
+        || data->term == kTermTeraTerm // per TeraTerm "Supported Control Functions" doco
+        || data->term == kTermRxvt) {  // per command.C
       char r[16];  // enough for 9999x9999
       snprintf(r, sizeof(r), "\x1b[8;%d;%dt", height, width);
       out(ui, r, strlen(r));

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -430,14 +430,12 @@ static void tui_resize(UI *ui, Integer width, Integer height)
   ugrid_resize(&data->grid, (int)width, (int)height);
 
   if (!got_winch) {  // Try to resize the terminal window.
-    // One cannot expect all terminals to cope with any old ECMA-48 control sequence that one might like to emit.
-    // dtterm originated this extension.
-    // xterm and TeraTerm documentation confirm them understanding it.
-    // Konsole understands it, per commentary in VT102Emulation.cpp .
-    if (data->term == kTermDTTerm
-        || data->term == kTermXTerm
-        || data->term == kTermKonsole
-        || data->term == kTermTeraTerm) {
+    // Only send this control sequence extension to terminal types that we know understand it.
+    if (data->term == kTermDTTerm          // originated this extension
+        || data->term == kTermXTerm        // per xterm ctlseqs doco
+        || data->term == kTermKonsole      // per commentary in VT102Emulation.cpp
+        || data->term == kTermTeraTerm     // per TeraTerm "Supported Control Functions" doco
+        || data->term == kTermRxvt) {      // per command.C
       char r[16];  // enough for 9999x9999
       snprintf(r, sizeof(r), "\x1b[8;%d;%dt", height, width);
       out(ui, r, strlen(r));

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -987,6 +987,14 @@ static TermType detect_term(const char *term, const char *colorterm)
   return kTermUnknown;
 }
 
+/// This has three tasks.
+/// 1. On termcap-only systems, it reads $TERM and fills in all of the things
+/// that unibilium (which uses terminfo) will not have.
+/// 2. It fills in extra capabilities that unibilium and terminfo do not know
+/// anything about, such as bracketed paste control.  Some of these are
+/// (wrongly) assumed to be universal.  Others are dependent from $TERM .
+/// 3. It fills in capabilities that might have been missing from the termcap
+/// entry that we nonetheless need, which are also worked out from $TERM .
 static void fix_terminfo(TUIData *data)
 {
   unibi_term *ut = data->ut;

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -446,9 +446,14 @@ static void cursor_goto(UI *ui, int row, int col)
     ugrid_goto(&data->grid, row, col);
     return;
   }
-  if (0 == col && 0 != grid->col) {
+  if (0 == col ? col != grid->col :
+      1 == col ? 2 < grid->col && cheap_to_print(ui, grid->row, 0, col) :
+      2 == col ? 5 < grid->col && cheap_to_print(ui, grid->row, 0, col) :
+      false) {
+    // Motion to left margin from anywhere else, or CR + printing chars is
+    // even less expensive than using BSes or CUB.
     unibi_out(ui, unibi_carriage_return);
-    ugrid_goto(&data->grid, grid->row, col);
+    ugrid_goto(&data->grid, grid->row, 0);
   } else if (col > grid->col) {
       int n = col - grid->col;
       if (n <= (row == grid->row ? 4 : 2) && cheap_to_print(ui, grid->row, grid->col, n)) {

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -56,6 +56,7 @@ typedef enum TermType {
   kTermDTTerm,
   kTermXTerm,
   kTermTeraTerm,
+  kTermPuTTY,
 } TermType;
 
 typedef struct {
@@ -1174,6 +1175,9 @@ static TermType detect_term(const char *term, const char *colorterm)
   if (STARTS_WITH(term, "teraterm")) {
     return kTermTeraTerm;
   }
+  if (STARTS_WITH(term, "putty")) {
+    return kTermPuTTY;
+  }
   return kTermUnknown;
 }
 
@@ -1222,13 +1226,15 @@ static void fix_terminfo(TUIData *data)
     unibi_set_if_empty(ut, unibi_cursor_invisible, "\x1b[?25l");
     unibi_set_if_empty(ut, unibi_flash_screen, "\x1b[?5h$<100/>\x1b[?5l");
     unibi_set_if_empty(ut, unibi_exit_attribute_mode, "\x1b(B\x1b[m");
+    unibi_set_if_empty(ut, unibi_from_status_line, "\x07");
     unibi_set_if_empty(ut, unibi_set_tb_margin, "\x1b[%i%p1%d;%p2%dr");
     unibi_set_if_empty(ut, unibi_set_lr_margin, "\x1b[%i%p1%d;%p2%ds");
     unibi_set_if_empty(ut, unibi_set_left_margin_parm, "\x1b[%i%p1%ds");
     unibi_set_if_empty(ut, unibi_set_right_margin_parm, "\x1b[%i;%p2%ds");
+  }
+  if (data->term == kTermXTerm || data->term == kTermRxvt || data->term == kTermPuTTY) {
     unibi_set_if_empty(ut, unibi_change_scroll_region, "\x1b[%i%p1%d;%p2%dr");
     unibi_set_if_empty(ut, unibi_clear_screen, "\x1b[H\x1b[2J");
-    unibi_set_if_empty(ut, unibi_from_status_line, "\x07");
     unibi_set_bool(ut, unibi_back_color_erase, true);
   }
 
@@ -1273,7 +1279,7 @@ static void fix_terminfo(TUIData *data)
 	"\x1b[8;%p1%d;%p2%dt");
   }
 
-  if (data->term == kTermXTerm || data->term == kTermRxvt) {
+  if (data->term == kTermXTerm || data->term == kTermRxvt || data->term == kTermPuTTY) {
     data->unibi_ext.reset_scroll_region = (int)unibi_add_ext_str(ut, NULL,
       "\x1b[r");
   }

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -53,6 +53,9 @@ typedef enum TermType {
   kTermiTerm,
   kTermKonsole,
   kTermRxvt,
+  kTermDTTerm,
+  kTermXTerm,
+  kTermTeraTerm,
 } TermType;
 
 typedef struct {
@@ -425,9 +428,18 @@ static void tui_resize(UI *ui, Integer width, Integer height)
   ugrid_resize(&data->grid, (int)width, (int)height);
 
   if (!got_winch) {  // Try to resize the terminal window.
-    char r[16];  // enough for 9999x9999
-    snprintf(r, sizeof(r), "\x1b[8;%d;%dt", (int)height, (int)width);
-    out(ui, r, strlen(r));
+    // One cannot expect all terminals to cope with any old ECMA-48 control sequence that one might like to emit.
+    // dtterm originated this extension.
+    // xterm and TeraTerm documentation confirm them understanding it.
+    // Konsole understands it, per commentary in VT102Emulation.cpp .
+    if (data->term == kTermDTTerm
+        || data->term == kTermXTerm
+        || data->term == kTermKonsole
+        || data->term == kTermTeraTerm) {
+      char r[16];  // enough for 9999x9999
+      snprintf(r, sizeof(r), "\x1b[8;%d;%dt", height, width);
+      out(ui, r, strlen(r));
+    }
   } else {  // Already handled the SIGWINCH signal; avoid double-resize.
     got_winch = false;
   }
@@ -957,6 +969,15 @@ static TermType detect_term(const char *term, const char *colorterm)
   if (colorterm && strstr(colorterm, "gnome-terminal")) {
     return kTermGnome;
   }
+  if (STARTS_WITH(term, "xterm")) {
+    return kTermXTerm;
+  }
+  if (STARTS_WITH(term, "dtterm")) {
+    return kTermDTTerm;
+  }
+  if (STARTS_WITH(term, "teraterm")) {
+    return kTermTeraTerm;
+  }
   return kTermUnknown;
 }
 
@@ -977,14 +998,14 @@ static void fix_terminfo(TUIData *data)
     unibi_set_if_empty(ut, unibi_flash_screen, "\x1b[?5h$<20/>\x1b[?5l");
     unibi_set_if_empty(ut, unibi_enter_italics_mode, "\x1b[3m");
     unibi_set_if_empty(ut, unibi_to_status_line, "\x1b]2");
-  } else if (STARTS_WITH(term, "xterm")) {
+  } else if (data->term == kTermXTerm) {
     unibi_set_if_empty(ut, unibi_to_status_line, "\x1b]0;");
   } else if (STARTS_WITH(term, "screen") || STARTS_WITH(term, "tmux")) {
     unibi_set_if_empty(ut, unibi_to_status_line, "\x1b_");
     unibi_set_if_empty(ut, unibi_from_status_line, "\x1b\\");
   }
 
-  if (STARTS_WITH(term, "xterm") || data->term == kTermRxvt) {
+  if (data->term == kTermXTerm || data->term == kTermRxvt) {
     const char *normal = unibi_get_str(ut, unibi_cursor_normal);
     if (!normal) {
       unibi_set_str(ut, unibi_cursor_normal, "\x1b[?25h");

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -430,16 +430,9 @@ static void tui_resize(UI *ui, Integer width, Integer height)
   ugrid_resize(&data->grid, (int)width, (int)height);
 
   if (!got_winch) {  // Try to resize the terminal window.
-    // Only send this extension to terminal types that we know understand it.
-    if (data->term == kTermDTTerm      // originated this extension
-        || data->term == kTermXTerm    // per xterm ctlseqs doco
-        || data->term == kTermKonsole  // per commentary in VT102Emulation.cpp
-        || data->term == kTermTeraTerm // per TeraTerm "Supported Control Functions" doco
-        || data->term == kTermRxvt) {  // per command.C
-      char r[16];  // enough for 9999x9999
-      snprintf(r, sizeof(r), "\x1b[8;%d;%dt", height, width);
-      out(ui, r, strlen(r));
-    }
+    data->params[0].i = height;
+    data->params[1].i = width;
+    unibi_out(ui, data->unibi_ext.resize_screen);
   } else {  // Already handled the SIGWINCH signal; avoid double-resize.
     got_winch = false;
   }

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1000,7 +1000,6 @@ static void fix_terminfo(TUIData *data)
   data->term = detect_term(term, colorterm);
 
   if (data->term == kTermRxvt) {
-    unibi_set_if_empty(ut, unibi_exit_attribute_mode, "\x1b[m\x1b(B");
     unibi_set_if_empty(ut, unibi_flash_screen, "\x1b[?5h$<20/>\x1b[?5l");
     unibi_set_if_empty(ut, unibi_enter_italics_mode, "\x1b[3m");
     unibi_set_if_empty(ut, unibi_to_status_line, "\x1b]2");
@@ -1042,9 +1041,9 @@ static void fix_terminfo(TUIData *data)
   data->unibi_ext.disable_focus_reporting = (int)unibi_add_ext_str(ut, NULL,
       "\x1b[?1004l");
 
-#define XTERM_SETAF \
+#define XTERM_SETAF_256 \
   "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m"
-#define XTERM_SETAB \
+#define XTERM_SETAB_256 \
   "\x1b[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e48;5;%p1%d%;m"
 
   if ((colorterm && strstr(colorterm, "256"))
@@ -1054,8 +1053,8 @@ static void fix_terminfo(TUIData *data)
     // Linux 4.8+ supports 256-color SGR, but terminfo has 8-color setaf/setab.
     // Assume TERM=~xterm|linux or COLORTERM=~256 supports 256 colors.
     unibi_set_num(ut, unibi_max_colors, 256);
-    unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF);
-    unibi_set_str(ut, unibi_set_a_background, XTERM_SETAB);
+    unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF_256);
+    unibi_set_str(ut, unibi_set_a_background, XTERM_SETAB_256);
   }
 
   // Only define this capability for terminal types that we know understand it.
@@ -1069,6 +1068,12 @@ static void fix_terminfo(TUIData *data)
   }
 
 end:
+
+#define XTERM_SETAF_16 \
+  "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e39%;m"
+#define XTERM_SETAB_16 \
+  "\x1b[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e39%;m"
+
   // Fill some empty slots with common terminal strings
   if (data->term == kTermiTerm) {
     data->unibi_ext.set_cursor_color = (int)unibi_add_ext_str(
@@ -1087,14 +1092,14 @@ end:
       "\x1b[48;2;%p1%d;%p2%d;%p3%dm");
   unibi_set_if_empty(ut, unibi_cursor_address, "\x1b[%i%p1%d;%p2%dH");
   unibi_set_if_empty(ut, unibi_exit_attribute_mode, "\x1b[0;10m");
-  unibi_set_if_empty(ut, unibi_set_a_foreground, XTERM_SETAF);
-  unibi_set_if_empty(ut, unibi_set_a_background, XTERM_SETAB);
+  unibi_set_if_empty(ut, unibi_set_a_foreground, XTERM_SETAF_16);
+  unibi_set_if_empty(ut, unibi_set_a_background, XTERM_SETAB_16);
   unibi_set_if_empty(ut, unibi_enter_bold_mode, "\x1b[1m");
   unibi_set_if_empty(ut, unibi_enter_underline_mode, "\x1b[4m");
   unibi_set_if_empty(ut, unibi_enter_reverse_mode, "\x1b[7m");
   unibi_set_if_empty(ut, unibi_bell, "\x07");
-  unibi_set_if_empty(data->ut, unibi_enter_ca_mode, "\x1b[?1049h");
-  unibi_set_if_empty(data->ut, unibi_exit_ca_mode, "\x1b[?1049l");
+  unibi_set_if_empty(ut, unibi_enter_ca_mode, "\x1b[?1049h");
+  unibi_set_if_empty(ut, unibi_exit_ca_mode, "\x1b[?1049l");
   unibi_set_if_empty(ut, unibi_delete_line, "\x1b[M");
   unibi_set_if_empty(ut, unibi_parm_delete_line, "\x1b[%p1%dM");
   unibi_set_if_empty(ut, unibi_insert_line, "\x1b[L");

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -95,6 +95,7 @@ typedef struct {
     int set_rgb_foreground, set_rgb_background;
     int set_cursor_color;
     int enable_focus_reporting, disable_focus_reporting;
+    int resize_screen;
   } unibi_ext;
 } TUIData;
 
@@ -157,6 +158,7 @@ static void terminfo_start(UI *ui)
   data->unibi_ext.disable_bracketed_paste = -1;
   data->unibi_ext.enable_focus_reporting = -1;
   data->unibi_ext.disable_focus_reporting = -1;
+  data->unibi_ext.resize_screen = -1;
   data->out_fd = 1;
   data->out_isatty = os_isatty(data->out_fd);
   // setup unibilium
@@ -428,16 +430,9 @@ static void tui_resize(UI *ui, Integer width, Integer height)
   ugrid_resize(&data->grid, (int)width, (int)height);
 
   if (!got_winch) {  // Try to resize the terminal window.
-    // Only send this extension to terminal types that we know understand it.
-    if (data->term == kTermDTTerm      // originated this extension
-        || data->term == kTermXTerm    // per xterm ctlseqs doco
-        || data->term == kTermKonsole  // per commentary in VT102Emulation.cpp
-        || data->term == kTermTeraTerm // per TeraTerm "Supported Control Functions" doco
-        || data->term == kTermRxvt) {  // per command.C
-      char r[16];  // enough for 9999x9999
-      snprintf(r, sizeof(r), "\x1b[8;%d;%dt", height, width);
-      out(ui, r, strlen(r));
-    }
+    data->params[0].i = height;
+    data->params[1].i = width;
+    unibi_out(ui, data->unibi_ext.resize_screen);
   } else {  // Already handled the SIGWINCH signal; avoid double-resize.
     got_winch = false;
   }
@@ -1046,6 +1041,16 @@ static void fix_terminfo(TUIData *data)
     unibi_set_num(ut, unibi_max_colors, 256);
     unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF);
     unibi_set_str(ut, unibi_set_a_background, XTERM_SETAB);
+  }
+
+  // Only define this capability for terminal types that we know understand it.
+  if (data->term == kTermDTTerm      // originated this extension
+      || data->term == kTermXTerm    // per xterm ctlseqs doco
+      || data->term == kTermKonsole  // per commentary in VT102Emulation.cpp
+      || data->term == kTermTeraTerm // per TeraTerm "Supported Control Functions" doco
+      || data->term == kTermRxvt) {  // per command.C
+    data->unibi_ext.resize_screen = (int)unibi_add_ext_str(ut, NULL,
+	"\x1b[8;%p1%d;%p2%dt");
   }
 
 end:


### PR DESCRIPTION
The TUI sends a lot of extraneous stuff to the terminal.  It repeats SGR sequences unnecessarily.  It uses inefficient cursor motions.  It does not shortcut repainting the cleared area in scrolls for terminals announced as BCE.  It does not take advantage of terminal scrolling margin capabilities.

This builds upon the work in #6792 (née #6685) to address these, and reduce the amount of data that is sent to update and to repaint the screen.  Yes, this is still important to people using SSH and the like.

Some of these optimizations I remember from the days of stevie.
