### PR TITLE
terminal: Do not change 'number', 'relativenumber'

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -93,12 +93,11 @@ Terminal sets local defaults for some options, which may differ from your
 global configuration.
 
 - 'list' is disabled
-- 'number' is disabled
-- 'relativenumber' is disabled (cannot be changed in |Terminal-mode|)
 - 'wrap' is disabled
+- 'relativenumber' is disabled in |Terminal-mode| (and cannot be enabled)
 
 You can change the defaults with a TermOpen autocommand: >
-	au TermOpen * setlocal number
+	au TermOpen * setlocal list
 
 Terminal colors can be customized with these variables:
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -237,8 +237,6 @@ Terminal *terminal_open(TerminalOptions opts)
   curbuf->b_p_scbk = p_scbk;  // 'scrollback'
   curbuf->b_p_tw = 0;         // 'textwidth'
   set_option_value("wrap", false, NULL, OPT_LOCAL);
-  set_option_value("number", false, NULL, OPT_LOCAL);
-  set_option_value("relativenumber", false, NULL, OPT_LOCAL);
   set_option_value("list", false, NULL, OPT_LOCAL);
   buf_set_term_title(curbuf, (char *)curbuf->b_ffname);
   RESET_BINDING(curwin);


### PR DESCRIPTION
Showing the 'number' column in terminal buffers is a bit silly because
of 'scrollback'. But it's mostly harmless and technically works as
expected. So the least surprising thing is to respect the user's global setting.

We still disable 'relativenumber' in *terminal-mode* (as opposed to
normal-mode) because it is totally broken: the Nvim cursor (not terminal
cursor) is always on the last line.