### PR TITLE
[RDY] Remove duplicate test

### DIFF
--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -428,17 +428,6 @@ describe('systemlist()', function()
     end)
   end)
 
-  describe('passing a lot of input', function()
-    it('returns the program output', function()
-      local input = {}
-      for _ = 1, 0xffff do
-        input[#input + 1] = '01234567890ABCDEFabcdef'
-      end
-      nvim('set_var', 'input', input)
-      eq(input, eval('systemlist("cat -", g:input)'))
-    end)
-  end)
-
   describe('with output containing NULs', function()
     local fname = 'Xtest'
 


### PR DESCRIPTION
There is a test on [line 259](https://github.com/AdnoC/neovim/blob/0fa3a9e40815e89cb0193c12a290d562be486897/test/functional/eval/system_spec.lua#L259) that is the same thing.
The only difference is that it appends a newline onto the input and has a comment.

Since the duplication was most likely due to an unfortunate merge, lets get rid of one of them.