### PR TITLE
Add more informative messages about loaded vars

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -243,7 +243,9 @@ function! s:check_python(version) abort
   let python_multiple = []
 
   if exists(loaded_var) && !exists('*provider#'.pyname.'#Call')
-    call health#report_info('Disabled. '.loaded_var.'='.eval(loaded_var))
+    call health#report_info('Disabled due to: `'.loaded_var.'='.eval(loaded_var).'`')
+    call health#report_info('Enable by setting: `'.loaded_var.'='.!eval(loaded_var).'`')
+    call health#report_info('See `:help provider-python` for more information')
     return
   endif
 
@@ -430,7 +432,9 @@ function! s:check_ruby() abort
 
   let loaded_var = 'g:loaded_ruby_provider'
   if exists(loaded_var) && !exists('*provider#ruby#Call')
-    call health#report_info('Disabled. '.loaded_var.'='.eval(loaded_var))
+    call health#report_info('Disabled due to: `'.loaded_var.'='.eval(loaded_var).'`')
+    call health#report_info('Enable by setting: `'.loaded_var.'='.!eval(loaded_var).'`')
+    call health#report_info('See `:help provider-ruby` for more information')
     return
   endif
 


### PR DESCRIPTION
Changes the old message to just saying `Disabled. g:loaded_python_provider=1`, which doesn't really explain the situation to a more informative message:

```
## Python 2 provider (optional)
  - INFO: Disabled due to g:loaded_python_provider=1
  - INFO: Enable by setting: `g:loaded_python_provider=0`
  - INFO: See `:help provider-python` for more information`
```

Should make it clear where to go for more information if it's disabled now.
