### PR TITLE
[WIP] Restore event/process.c: send SIGTERM directly (#6644)

### DIFF
--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -230,6 +230,7 @@ void process_stop(Process *proc) FUNC_ATTR_NONNULL_ALL
   }
 
   proc->stopped_time = os_hrtime();
+  os_microdelay(1, true);
   switch (proc->type) {
     case kProcessTypeUv:
       // Close the process's stdin. If the process doesn't close its own

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -21,9 +21,9 @@
 # include "event/process.c.generated.h"
 #endif
 
-// Time (ns) for a process to exit cleanly before we send TERM/KILL.
-#define TERM_TIMEOUT 1000000000
-#define KILL_TIMEOUT (TERM_TIMEOUT * 2)
+// Time for a process to exit cleanly before we send KILL.
+#define KILL_TIMEOUT_MS 2000
+#define KILL_TIMEOUT_NS (KILL_TIMEOUT_MS * 1000000)
 
 #define CLOSE_PROC_STREAM(proc, stream) \
   do { \
@@ -125,8 +125,6 @@ void process_teardown(Loop *loop) FUNC_ATTR_NONNULL_ALL
       // Close handles to process without killing it.
       CREATE_EVENT(loop->events, process_close_handles, 1, proc);
     } else {
-      uv_kill(proc->pid, SIGTERM);
-      proc->term_sent = true;
       process_stop(proc);
     }
   }
@@ -248,12 +246,16 @@ void process_stop(Process *proc) FUNC_ATTR_NONNULL_ALL
       abort();
   }
 
+  ILOG("Sending SIGTERM to pid %d", proc->pid);
+  uv_kill(proc->pid, SIGTERM);
+
   Loop *loop = proc->loop;
   if (!loop->children_stop_requests++) {
     // When there's at least one stop request pending, start a timer that
-    // will periodically check if a signal should be send to a to the job
+    // will periodically check if a signal should be send to the job.
     DLOG("Starting job kill timer");
-    uv_timer_start(&loop->children_kill_timer, children_kill_cb, 100, 100);
+    uv_timer_start(&loop->children_kill_timer, children_kill_cb,
+                   KILL_TIMEOUT_MS, 100);
   }
 }
 
@@ -271,11 +273,7 @@ static void children_kill_cb(uv_timer_t *handle)
     }
     uint64_t elapsed = now - proc->stopped_time;
 
-    if (!proc->term_sent && elapsed >= TERM_TIMEOUT) {
-      ILOG("Sending SIGTERM to pid %d", proc->pid);
-      uv_kill(proc->pid, SIGTERM);
-      proc->term_sent = true;
-    } else if (elapsed >= KILL_TIMEOUT) {
+    if (elapsed >= KILL_TIMEOUT_NS) {
       ILOG("Sending SIGKILL to pid %d", proc->pid);
       uv_kill(proc->pid, SIGKILL);
     }

--- a/src/nvim/event/process.h
+++ b/src/nvim/event/process.h
@@ -26,7 +26,7 @@ struct process {
   Stream *in, *out, *err;
   process_exit_cb cb;
   internal_process_cb internal_exit_cb, internal_close_cb;
-  bool closed, term_sent, detach;
+  bool closed, detach;
   MultiQueue *events;
 };
 
@@ -48,7 +48,6 @@ static inline Process process_init(Loop *loop, ProcessType type, void *data)
     .err = NULL,
     .cb = NULL,
     .closed = false,
-    .term_sent = false,
     .internal_close_cb = NULL,
     .internal_exit_cb = NULL,
     .detach = false

--- a/test/functional/fixtures/tty-test.c
+++ b/test/functional/fixtures/tty-test.c
@@ -168,7 +168,7 @@ int main(int argc, char **argv)
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
   // XXX: Without this the SIGHUP handler is skipped on some systems.
-  sleep(100);
+  sleep(1);
 
   return 0;
 }

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -234,6 +234,18 @@ local function connect(file_or_address)
   return Session.new(stream)
 end
 
+-- sleeps the test runner (_not_ the nvim instance)
+local function sleep(ms)
+  local function notification_cb(method, _)
+    if method == "redraw" then
+      error("Screen is attached; use screen:sleep() instead.")
+    end
+    return true
+  end
+
+  run(nil, notification_cb, nil, ms)
+end
+
 -- Calls fn() until it succeeds, up to `max` times or until `max_ms`
 -- milliseconds have passed.
 local function retry(max, max_ms, fn)
@@ -252,6 +264,7 @@ local function retry(max, max_ms, fn)
       error(result)
     end
     tries = tries + 1
+    sleep(1)
   end
 end
 
@@ -388,18 +401,6 @@ local function wait()
   -- Execute 'nvim_eval' (a deferred function) to block
   -- until all pending input is processed.
   session:request('nvim_eval', '1')
-end
-
--- sleeps the test runner (_not_ the nvim instance)
-local function sleep(ms)
-  local function notification_cb(method, _)
-    if method == "redraw" then
-      error("Screen is attached; use screen:sleep() instead.")
-    end
-    return true
-  end
-
-  run(nil, notification_cb, nil, ms)
 end
 
 local function curbuf_contents()


### PR DESCRIPTION
Restore `event/process.c: send SIGTERM directly` (#6644)

In https://github.com/neovim/neovim/pull/6595#issuecomment-299863314 the change was reverted because of CI failures. [Working with](https://en.wikipedia.org/wiki/Extreme_programming) @blueyed we found a fix. Yay!

