### PR TITLE
v:recording_register, <Timeout> (WAS: <norecord> for mappings)

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -149,9 +149,9 @@ type "a", then "bar" will get inserted.
 
 1.2 SPECIAL ARGUMENTS					*:map-arguments*
 
-"<buffer>", "<nowait>", "<silent>", "<special>", "<script>", "<expr>" and
-"<unique>" can be used in any order.  They must appear right after the
-command, before any other arguments.
+"<buffer>", "<nowait>", "<silent>", "<special>", "<script>", "<expr>",
+"<norecord>" and "<unique>" can be used in any order.  They must appear right
+after the command, before any other arguments.
 
 				*:map-local* *:map-<buffer>* *E224* *E225*
 If the first argument to one of these commands is "<buffer>" the mapping will
@@ -278,6 +278,10 @@ again for using <expr>.  This does work: >
 Using 0x80 as a single byte before other text does not work, it will be seen
 as a special key.
 
+						*:map-<norecord>* *:map-norecord*
+Define a mapping that is disabled while recording and executing registers
+(|complex-repeat|).  This is useful if the mapping is only used interactively
+or depends on timing information that is lost during the recording process.
 
 1.3 MAPPING AND MODES					*:map-modes*
 		*mapmode-nvo* *mapmode-n* *mapmode-v* *mapmode-o* *mapmode-t*

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -335,6 +335,7 @@ struct mapblock {
   char m_silent;                /* <silent> used, don't echo commands */
   char m_nowait;                /* <nowait> used */
   char m_expr;                  /* <expr> used, m_str is an expression */
+  char m_norecord;              /* <norecord> used */
   scid_T m_script_ID;           /* ID of script where map was defined */
 };
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12151,6 +12151,7 @@ void mapblock_fill_dict(dict_T *const dict,
   tv_dict_add_nr(dict, S_LEN("noremap"), noremap_value);
   tv_dict_add_nr(dict, S_LEN("expr"),  mp->m_expr ? 1 : 0);
   tv_dict_add_nr(dict, S_LEN("silent"), mp->m_silent ? 1 : 0);
+  tv_dict_add_nr(dict, S_LEN("norecord"), mp->m_norecord ? 1 : 0);
   tv_dict_add_nr(dict, S_LEN("sid"), (varnumber_T)mp->m_script_ID);
   tv_dict_add_nr(dict, S_LEN("buffer"), (varnumber_T)buffer_value);
   tv_dict_add_nr(dict, S_LEN("nowait"), mp->m_nowait ? 1 : 0);

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -27,6 +27,7 @@ describe('get_keymap', function()
       rhs='bar',
       expr=0,
       sid=0,
+      norecord=0,
       buffer=0,
       nowait=0,
       mode='n',
@@ -202,6 +203,7 @@ describe('get_keymap', function()
     global_and_buffer_test(mode_list[mode], 'silent', '<silent>', 1, 1, 0, 0)
     global_and_buffer_test(mode_list[mode], 'nowait', '<nowait>', 1, 1, 0, 0)
     global_and_buffer_test(mode_list[mode], 'expr', '<expr>', 1, 1, 0, 0)
+    global_and_buffer_test(mode_list[mode], 'norecord', '<norecord>', 1, 1, 0, 0)
   end
 
   -- noremap will now be 2 if script was used, which is not the same as maparg()

--- a/test/functional/eval/map_functions_spec.lua
+++ b/test/functional/eval/map_functions_spec.lua
@@ -36,6 +36,14 @@ describe('maparg()', function()
     eq(0, funcs.maparg('baz', 'n', false, true)['silent'])
   end)
 
+  it('returns 1 for norecord when <norecord> is used', function()
+    nvim('command', 'nnoremap <norecord> foo bar')
+    eq(1, funcs.maparg('foo', 'n', false, true)['norecord'])
+
+    nvim('command', 'nnoremap baz bat')
+    eq(0, funcs.maparg('baz', 'n', false, true)['norecord'])
+  end)
+
   it('returns an empty string when no map is present', function()
     eq('', funcs.maparg('not a mapping'))
   end)


### PR DESCRIPTION
<norecord> is intended to disable a mapping while recording or
executing a register.  This is especially useful for any mappings like:

    imap jk <Esc>

While recording a macro, one might be tempted to do something like

    qaij<wait a while for timeoutlen to expire>k<Esc>q

Only to find that it doesn't work when playing back the macro.

It is also useful for other plugins that turn on vim "hard-mode"
(disabling too many j/k commands in a short amount of time) or just any
plugin-mappings that depend at all on timing (accelerated-jk) or
user-interface (easymotion) semantics.