### PR TITLE
[RDY] Allow overriding ruby host with `g:ruby_host_prog`

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -460,7 +460,7 @@ function! s:check_ruby() abort
           \  'Are you behind a firewall or proxy?'])
     return
   endif
-  let latest_gem = get(split(latest_gem, ' (\|, \|)$' ), 1, 'not found')
+  let latest_gem = get(split(latest_gem, 'neovim (\|, \|)$' ), 1, 'not found')
 
   let current_gem_cmd = host .' --version'
   let current_gem = s:system(current_gem_cmd)

--- a/runtime/autoload/provider/ruby.vim
+++ b/runtime/autoload/provider/ruby.vim
@@ -16,7 +16,11 @@ function! s:job_opts.on_stderr(chan_id, data, event)
 endfunction
 
 function! provider#ruby#Detect() abort
-  return exepath('neovim-ruby-host')
+  if exists("g:ruby_host_prog")
+    return g:ruby_host_prog
+  else
+    return exepath('neovim-ruby-host')
+  end
 endfunction
 
 function! provider#ruby#Prog()
@@ -24,15 +28,15 @@ function! provider#ruby#Prog()
 endfunction
 
 function! provider#ruby#Require(host) abort
-  let args = [provider#ruby#Prog()]
+  let prog = provider#ruby#Prog()
   let ruby_plugins = remote#host#PluginsForHost(a:host.name)
 
   for plugin in ruby_plugins
-    call add(args, plugin.path)
+    let prog .= " " . shellescape(plugin.path)
   endfor
 
   try
-    let channel_id = jobstart(args, s:job_opts)
+    let channel_id = jobstart(prog, s:job_opts)
     if rpcrequest(channel_id, 'poll') ==# 'ok'
       return channel_id
     endif

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -99,6 +99,19 @@ RUBY PROVIDER CONFIGURATION ~
 						*g:loaded_ruby_provider*
 To disable Ruby support: >
     let g:loaded_ruby_provider = 1
+<
+						*g:ruby_host_prog*
+Command to start the Ruby host. By default this is `neovim-ruby-host`. For users
+who use per-project Ruby versions with tools like RVM or rbenv, setting this can
+prevent the need to install the `neovim` gem in every project.
+
+To use an absolute path (e.g. to an rbenv installation): >
+    let g:ruby_host_prog = '~/.rbenv/versions/2.4.1/bin/neovim-ruby-host'
+<
+
+To use the RVM "system" Ruby installation: >
+    let g:ruby_host_prog = 'rvm system do neovim-ruby-host'
+<
 
 ==============================================================================
 Clipboard integration 			      *provider-clipboard* *clipboard*


### PR DESCRIPTION
This allows users who have per-project Ruby versions (e.g. with`rvm`) to pin to a particular gem installation. For example: `let g:ruby_host_prog = 'rvm system do neovim-ruby-host'`.

I also tightened up the Ruby health `latest_gem` determination, which can get thrown off by error output.

See https://github.com/alexgenco/neovim-ruby/issues/37