### PR TITLE
[RDY] bisect QuickBuild hang

### DIFF
--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -282,8 +282,13 @@ describe('server -> client', function()
     end)
   end)
 
-  describe('when connecting to its own pipe adress', function()
-    it('it does not deadlock', function()
+  describe('connecting to its own pipe address', function()
+    it('does not deadlock', function()
+      if not os.getenv("TRAVIS") and helpers.os_name() == "osx" then
+        -- It does, in fact, deadlock on QuickBuild. #6851
+        pending("deadlocks on QuickBuild", function() end)
+        return
+      end
       local address = funcs.serverlist()[1]
       local first = string.sub(address,1,1)
       ok(first == '/' or first == '\\')


### PR DESCRIPTION
QuickBuild is hanging since the last week or two. Attempting to narrow down the cause.

**Update:** problem commit is https://github.com/neovim/neovim/commit/133ae5eeeff3b83e1a3e6da35b57dcdfb92287b0