### PR TITLE
coverity/112076: fixing "Explicit null dereferenced"

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1408,6 +1408,10 @@ int op_delete(oparg_T *oap)
     }
 
     if (oap->regname == 0) {
+      if (reg == NULL) {
+        // Guard against NULL reg
+        abort();
+      }
       set_clipboard(0, reg);
       do_autocmd_textyankpost(oap, reg);
     }


### PR DESCRIPTION

    if (oap->regname == 0 &&
       oap->motion_type != kMTLineWise &&
       oap->line_count == 0 &&
       !oap->use_reg_one    ){
        then reg is not initialised
        and our call to set_clipboard will dereference NULL
    }
