### PR TITLE
scripts/vim-patch.sh: do not git-reset on push failure

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -280,7 +280,7 @@ submit_pr() {
     echo "Pushing to 'origin/${checked_out_branch}'."
     output="$(git push origin "${checked_out_branch}" 2>&1)" &&
       echo "✔ ${output}" ||
-      (echo "✘ ${output}"; git reset --soft HEAD^1; false)
+      (echo "✘ ${output}"; false)
 
     echo
   fi


### PR DESCRIPTION
This was added from the beginning to submit_pr in 775a16b0b, but I
cannot see why that is useful - in contrast, it will mess with the local
branch in case "origin" cannot be pushed to (i.e. when it points to
neovim/neovim itself).

/cc @fwalch 