### PR TITLE
vim-patch:8.0.0607

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -330,7 +330,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
   }
 
   try_start();
-  bufref_T save_curbuf = { NULL, 0 };
+  bufref_T save_curbuf = { NULL, 0, 0 };
   switch_to_win_for_buf(buf, &save_curwin, &save_curtab, &save_curbuf);
 
   if (u_save((linenr_T)(start - 1), (linenr_T)end) == FAIL) {

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -961,7 +961,7 @@ static void set_option_value_for(char *key,
 {
   win_T *save_curwin = NULL;
   tabpage_T *save_curtab = NULL;
-  bufref_T save_curbuf =  { NULL, 0 };
+  bufref_T save_curbuf =  { NULL, 0, 0 };
 
   try_start();
   switch (opt_type)

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -115,7 +115,7 @@ static inline void buf_set_changedtick(buf_T *const buf,
   do { \
     win_T *save_curwin = NULL; \
     tabpage_T *save_curtab = NULL; \
-    bufref_T save_curbuf = { NULL, 0 }; \
+    bufref_T save_curbuf = { NULL, 0, 0 }; \
     switch_to_win_for_buf(b, &save_curwin, &save_curtab, &save_curbuf); \
     code; \
     restore_win_for_buf(save_curwin, save_curtab, &save_curbuf); \

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -12,6 +12,7 @@ typedef struct file_buffer buf_T; // Forward declaration
 // bufref_valid() only needs to check "buf" when the count differs.
 typedef struct {
   buf_T *br_buf;
+  int    br_fnum;
   int    br_buf_free_count;
 } bufref_T;
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -568,7 +568,7 @@ EXTERN int keep_filetype INIT(= FALSE);         /* value for did_filetype when
 
 // When deleting the current buffer, another one must be loaded.
 // If we know which one is preferred, au_new_curbuf is set to it.
-EXTERN bufref_T au_new_curbuf INIT(= { NULL, 0 });
+EXTERN bufref_T au_new_curbuf INIT(= { NULL, 0, 0 });
 
 // When deleting a buffer/window and autocmd_busy is TRUE, do not free the
 // buffer/window. but link it in the list starting with

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -191,7 +191,7 @@ typedef struct {
 // Looking up a buffer can be slow if there are many.  Remember the last one
 // to make this a lot faster if there are multiple matches in the same file.
 static char_u *qf_last_bufname = NULL;
-static bufref_T  qf_last_bufref = { NULL, 0 };
+static bufref_T  qf_last_bufref = { NULL, 0, 0 };
 
 /*
  * Read the errorfile "efile" into memory, line by line, building the error
@@ -2330,9 +2330,7 @@ void qf_history(exarg_T *eap)
   }
 }
 
-/*
- * Free error list "idx".
- */
+/// Free all the entries in the error list "idx".
 static void qf_free(qf_info_T *qi, int idx)
 {
   qfline_T    *qfp;


### PR DESCRIPTION
Problem:    When creating a bufref, then using :bwipe and :new it might get
            the same memory and bufref_valid() returns true.
Solution:   Add br_fnum to check the buffer number didn't change.

https://github.com/vim/vim/commit/45e5fd135da5710f24a1acc142692f120f8b0b78