### PR TITLE
vim-patch:7.4.2356

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1005,14 +1005,13 @@ int do_search(
     dircp = NULL;
     /* use previous pattern */
     if (pat == NULL || *pat == NUL || *pat == dirc) {
-      if (spats[RE_SEARCH].pat == NULL) {           /* no previous pattern */
-        pat = spats[RE_SUBST].pat;
-        if (pat == NULL) {
+      if (spats[RE_SEARCH].pat == NULL) {           // no previous pattern
+        searchstr = spats[RE_SUBST].pat;
+        if (searchstr == NULL) {
           EMSG(_(e_noprevre));
           retval = 0;
           goto end_do_search;
         }
-        searchstr = pat;
       } else {
         /* make search_regcomp() use spats[RE_SEARCH].pat */
         searchstr = (char_u *)"";

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -58,6 +58,7 @@ NEW_TESTS ?= \
 	    test_nested_function.res \
 	    test_normal.res \
 	    test_quickfix.res \
+	    test_search.res \
 	    test_signs.res \
 	    test_smartindent.res \
 	    test_stat.res \

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -1,0 +1,12 @@
+" Test for the search command
+
+func Test_use_sub_pat()
+  split
+  let @/ = ''
+  func X()
+    s/^/a/
+    /
+  endfunc
+  call X()
+  bwipe!
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -88,7 +88,7 @@ static const int included_patches[] = {
   2359,
   // 2358 NA
   2357,
-  // 2356,
+  2356,
   2355,
   // 2354,
   2353,


### PR DESCRIPTION
Problem:    Reading past end of line when using previous substitute pattern.
            (Dominique Pelle)
Solution:   Don't set "pat" only set "searchstr".

https://github.com/vim/vim/commit/ea683da58cf9ecf3afab9d650d3d2da76e5298d3