### PR TITLE
vim-patch:7.4.2354

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -58,6 +58,7 @@ NEW_TESTS ?= \
 	    test_nested_function.res \
 	    test_normal.res \
 	    test_quickfix.res \
+	    test_regexp_latin.res \
 	    test_search.res \
 	    test_signs.res \
 	    test_smartindent.res \

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -1,0 +1,19 @@
+" Tests for regexp in latin1 encoding
+" Nvim does not support encoding=latin1
+" set encoding=latin1
+scriptencoding latin1
+
+func Test_nested_backrefs()
+  " Check example in change.txt.
+  new
+  for re in range(0, 2)
+    exe 'set re=' . re
+    call setline(1, 'aa ab x')
+    1s/\(\(a[a-d] \)*\)\(x\)/-\1- -\2- -\3-/
+    call assert_equal('-aa ab - -ab - -x-', getline(1))
+
+    call assert_equal('-aa ab - -ab - -x-', substitute('aa ab x', '\(\(a[a-d] \)*\)\(x\)', '-\1- -\2- -\3-', ''))
+  endfor
+  bwipe!
+  set re=0
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -90,7 +90,7 @@ static const int included_patches[] = {
   2357,
   2356,
   2355,
-  // 2354,
+  2354,
   2353,
   // 2352 NA
   // 2351 NA


### PR DESCRIPTION
Problem:    The example that explains nested backreferences does not work
            properly with the new regexp engine. (Harm te Hennepe)
Solution:   Also save the end position when adding a state. (closes vim/vim#990)

https://github.com/vim/vim/commit/d563883a1fb5ec6cf4a2758c5e36ac1ff4e9bb3d