### PR TITLE
vim-patch:7.4.2190

### DIFF
--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -83,7 +83,7 @@ func Test_help_arg()
 	call add(found, "--version")
       endif
     endfor
-    call assert_equal(['--version'], found)
+    call assert_equal(['Readonly mode', '--version'], found)
   endif
   call delete('Xtestout')
 endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -254,7 +254,7 @@ static const int included_patches[] = {
   // 2193 NA
   // 2192 NA
   // 2191 NA
-  // 2190,
+  2190,
   // 2189,
   2188,
   2187,


### PR DESCRIPTION
Problem:    When startup test fails it's not easy to find out why.
            GUI test fails with Gnome.
Solution:   Add the help entry matches to a list an assert that.
            Set $HOME for Gnome to create .gnome2 directory.

https://github.com/vim/vim/commit/50fa8dd00c241fa0786fe92ecc02fee4e5d28e06