### PR TITLE
[RFC] provider/clipboard: add tmux support

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -84,6 +84,12 @@ function! provider#clipboard#Executable() abort
     let s:copy['*'] = s:copy['+']
     let s:paste['*'] = s:paste['+']
     return 'win32yank'
+  elseif exists('$TMUX') && executable('tmux')
+    let s:copy['+'] = 'tmux load-buffer -'
+    let s:paste['+'] = 'tmux save-buffer -'
+    let s:copy['*'] = s:copy['+']
+    let s:paste['*'] = s:paste['+']
+    return 'tmux'
   endif
 
   let s:err = 'clipboard: No clipboard tool available. :help clipboard'


### PR DESCRIPTION
Support using tmux's buffer as clipboard,
this is specially beneficial when running
multiple vim instances inside tmux session
on a headless environment.