### PR TITLE
ci: Bump clang version to 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     # http://docs.travis-ci.com/user/speeding-up-the-build/#Paralellizing-your-build-on-one-VM
     - MAKE_CMD="make -j2"
     # Update PATH for pip.
-    - PATH="$(python2.7 -c 'import site; print(site.getuserbase())')/bin:/usr/lib/llvm-symbolizer-3.9/bin:$PATH"
+    - PATH="$(python2.7 -c 'import site; print(site.getuserbase())')/bin:/usr/lib/llvm-symbolizer-4.0/bin:$PATH"
     # Build directory for Neovim.
     - BUILD_DIR="$TRAVIS_BUILD_DIR/build"
     # Build directory for third-party dependencies.
@@ -53,12 +53,12 @@ jobs:
   include:
     - stage: sanitizers
       os: linux
-      compiler: clang-3.9
+      compiler: clang-4.0
       env: >
         CLANG_SANITIZER=ASAN_UBSAN
         CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
     - os: linux
-      compiler: clang-3.9
+      compiler: clang-4.0
       env: CLANG_SANITIZER=TSAN
     - stage: normal builds
       os: linux
@@ -98,13 +98,13 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-3.9
+      - llvm-toolchain-trusty-4.0
     packages:
       - autoconf
       - automake
       - apport
       - build-essential
-      - clang-3.9
+      - clang-4.0
       - cmake
       - cscope
       - g++-5-multilib
@@ -115,7 +115,7 @@ addons:
       - language-pack-tr
       - libc6-dev-i386
       - libtool
-      - llvm-3.9-dev
+      - llvm-4.0-dev
       - locales
       - pkg-config
       - unzip


### PR DESCRIPTION
The CI clang builds have suddently started failing with errors like

```
Linking C executable ../../bin/nvim
/usr/bin/ld: /usr/lib/llvm-3.9/bin/../lib/clang/3.9.1/lib/linux/libclang_rt.asan-x86_64.a(asan_allocator.cc.o): unrecognized relocation (0x2a) in section `.text'
/usr/bin/ld: final link failed: Bad value
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

It seems like this is related to clang getting installed from Ubuntu's
repositories instead of from LLVM's repositories.  The last working CI build
installed

```
Get:8 http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9/main clang-3.9 amd64 1:3.9~svn288847-1~exp1
```

where as the new, failing builds are installing

```
Get:26 http://archive.ubuntu.com/ubuntu/ trusty-updates/universe clang-3.9 amd64 1:3.9.1-4ubuntu3~14.04.2
```

Bumping up to the 4.0 release ensures we're using a newer version than what
comes with the native Trusty environment.