### PR TITLE
Remove unnecessary pun in docs

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -319,7 +319,6 @@ Overview of which map command works in which mode.  More details below.
 :vmap  :vnoremap  :vunmap  :vmapclear	  -	    yes		    -
 :omap  :onoremap  :ounmap  :omapclear	  -	     -		   yes
 
-:nunmap can also be used outside of a monastery.
 						*mapmode-x* *mapmode-s*
 Some commands work both in Visual and Select mode, some in only one.  Note
 that quite often "Visual" is mentioned where both Visual and Select mode


### PR DESCRIPTION
This is a very dense part of the manual. The "nun" pun is cute, but so
out of place as to be jarring. Removing this pun should reduce the
cognitive load of reading and understanding the documentation.