### PR TITLE
[RFC] vim-patch:7.4.2259,7.4.2268,7.4.2318,7.4.2320

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -376,18 +376,10 @@ CTRL-D		List names that match the pattern in front of the cursor.
 							*c_CTRL-N*
 CTRL-N		After using 'wildchar' which got multiple matches, go to next
 		match.  Otherwise recall more recent command-line from history.
-							*/_CTRL-N*
-		When 'incsearch' is set, entering a search pattern for "/" or
-		"?" and the current match is displayed then CTRL-N will move
-		to the next match (does not take |search-offset| into account)
 <S-Tab>							*c_CTRL-P* *c_<S-Tab>*
 CTRL-P		After using 'wildchar' which got multiple matches, go to
 		previous match.  Otherwise recall older command-line from
 		history.  <S-Tab> only works with the GUI.
-							*/_CTRL-P*
-		When 'incsearch' is set, entering a search pattern for "/" or
-		"?" and the current match is displayed then CTRL-P will move
-		to the previous match (does not take |search-offset| into account).
 							*c_CTRL-A*
 CTRL-A		All names that match the pattern in front of the cursor are
 		inserted.
@@ -404,6 +396,19 @@ CTRL-L		A match is done on the pattern in front of the cursor.  If
 		'ignorecase' and 'smartcase' are set and the command line has
 		no uppercase characters, the added character is converted to
 		lowercase.
+	                                            *c_CTRL-G* */_CTRL-G*
+CTRL-G		When 'incsearch' is set, entering a search pattern for "/" or
+		"?" and the current match is displayed then CTRL-G will move
+		to the next match (does not take |search-offset| into account)
+		Use CTRL-T to move to the previous match.  Hint: on a regular
+		keyboard T is above G.
+	                                            *c_CTRL-T* */_CTRL-T*
+CTRL-T		When 'incsearch' is set, entering a search pattern for "/" or
+		"?" and the current match is displayed then CTRL-T will move
+		to the previous match (does not take |search-offset| into
+		account).
+		Use CTRL-G to move to the next match.  Hint: on a regular
+		keyboard T is above G.
 
 The 'wildchar' option defaults to <Tab> (CTRL-E when in Vi compatible mode; in
 a previous version <Esc> was used).  In the pattern standard wildcards '*' and

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -376,10 +376,18 @@ CTRL-D		List names that match the pattern in front of the cursor.
 							*c_CTRL-N*
 CTRL-N		After using 'wildchar' which got multiple matches, go to next
 		match.  Otherwise recall more recent command-line from history.
+							*/_CTRL-N*
+		When 'incsearch' is set, entering a search pattern for "/" or
+		"?" and the current match is displayed then CTRL-N will move
+		to the next match (does not take |search-offset| into account)
 <S-Tab>							*c_CTRL-P* *c_<S-Tab>*
 CTRL-P		After using 'wildchar' which got multiple matches, go to
 		previous match.  Otherwise recall older command-line from
 		history.  <S-Tab> only works with the GUI.
+							*/_CTRL-P*
+		When 'incsearch' is set, entering a search pattern for "/" or
+		"?" and the current match is displayed then CTRL-P will move
+		to the previous match (does not take |search-offset| into account).
 							*c_CTRL-A*
 CTRL-A		All names that match the pattern in front of the cursor are
 		inserted.
@@ -389,6 +397,7 @@ CTRL-L		A match is done on the pattern in front of the cursor.  If
 		If there are multiple matches the longest common part is
 		inserted in place of the pattern.  If the result is shorter
 		than the pattern, no completion is done.
+							*/_CTRL-L*
 		When 'incsearch' is set, entering a search pattern for "/" or
 		"?" and the current match is displayed then CTRL-L will add
 		one character from the end of the current match.  If

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1489,8 +1489,9 @@ static int command_line_handle_key(CommandLineState *s)
       } else {
         vim_beep(BO_ERROR);
       }
+      return command_line_not_changed(s);
     }
-    return command_line_not_changed(s);
+    break;
 
   case Ctrl_V:
   case Ctrl_Q:

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5231,6 +5231,7 @@ static void nv_dollar(cmdarg_T *cap)
 static void nv_search(cmdarg_T *cap)
 {
   oparg_T     *oap = cap->oap;
+  pos_T save_cursor = curwin->w_cursor;
 
   if (cap->cmdchar == '?' && cap->oap->op_type == OP_ROT13) {
     /* Translate "g??" to "g?g?" */
@@ -5240,6 +5241,8 @@ static void nv_search(cmdarg_T *cap)
     return;
   }
 
+  // When using 'incsearch' the cursor may be moved to set a different search
+  // start position.
   cap->searchbuf = getcmdline(cap->cmdchar, cap->count1, 0);
 
   if (cap->searchbuf == NULL) {
@@ -5248,7 +5251,8 @@ static void nv_search(cmdarg_T *cap)
   }
 
   (void)normal_search(cap, cap->cmdchar, cap->searchbuf,
-      (cap->arg ? 0 : SEARCH_MARK));
+                      (cap->arg || !equalpos(save_cursor, curwin->w_cursor))
+                      ? 0 : SEARCH_MARK);
 }
 
 /*

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -1,5 +1,248 @@
 " Test for the search command
 
+func Test_search_cmdline()
+  throw 'skipped: Nvim does not support test_disable_char_avail()'
+  if !exists('+incsearch')
+    return
+  endif
+  " need to disable char_avail,
+  " so that expansion of commandline works
+  call test_disable_char_avail(1)
+  new
+  call setline(1, ['  1', '  2 these', '  3 the', '  4 their', '  5 there', '  6 their', '  7 the', '  8 them', '  9 these', ' 10 foobar'])
+  " Test 1
+  " CTRL-N / CTRL-P skips through the previous search history
+  set noincsearch
+  :1
+  call feedkeys("/foobar\<cr>", 'tx')
+  call feedkeys("/the\<cr>",'tx')
+  call assert_equal('the', @/)
+  call feedkeys("/thes\<c-p>\<c-p>\<cr>",'tx')
+  call assert_equal('foobar', @/)
+
+  " Test 2
+  " Ctrl-N goes from one match to the next
+  " until the end of the buffer
+  set incsearch nowrapscan
+  :1
+  " first match
+  call feedkeys("/the\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  :1
+  " second match
+  call feedkeys("/the\<c-n>\<cr>", 'tx')
+  call assert_equal('  3 the', getline('.'))
+  :1
+  " third match
+  call feedkeys("/the".repeat("\<c-n>", 2)."\<cr>", 'tx')
+  call assert_equal('  4 their', getline('.'))
+  :1
+  " fourth match
+  call feedkeys("/the".repeat("\<c-n>", 3)."\<cr>", 'tx')
+  call assert_equal('  5 there', getline('.'))
+  :1
+  " fifth match
+  call feedkeys("/the".repeat("\<c-n>", 4)."\<cr>", 'tx')
+  call assert_equal('  6 their', getline('.'))
+  :1
+  " sixth match
+  call feedkeys("/the".repeat("\<c-n>", 5)."\<cr>", 'tx')
+  call assert_equal('  7 the', getline('.'))
+  :1
+  " seventh match
+  call feedkeys("/the".repeat("\<c-n>", 6)."\<cr>", 'tx')
+  call assert_equal('  8 them', getline('.'))
+  :1
+  " eigth match
+  call feedkeys("/the".repeat("\<c-n>", 7)."\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  :1
+  " no further match
+  call feedkeys("/the".repeat("\<c-n>", 8)."\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+
+  " Test 3
+  " Ctrl-N goes from one match to the next
+  " and continues back at the top
+  set incsearch wrapscan
+  :1
+  " first match
+  call feedkeys("/the\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  :1
+  " second match
+  call feedkeys("/the\<c-n>\<cr>", 'tx')
+  call assert_equal('  3 the', getline('.'))
+  :1
+  " third match
+  call feedkeys("/the".repeat("\<c-n>", 2)."\<cr>", 'tx')
+  call assert_equal('  4 their', getline('.'))
+  :1
+  " fourth match
+  call feedkeys("/the".repeat("\<c-n>", 3)."\<cr>", 'tx')
+  call assert_equal('  5 there', getline('.'))
+  :1
+  " fifth match
+  call feedkeys("/the".repeat("\<c-n>", 4)."\<cr>", 'tx')
+  call assert_equal('  6 their', getline('.'))
+  :1
+  " sixth match
+  call feedkeys("/the".repeat("\<c-n>", 5)."\<cr>", 'tx')
+  call assert_equal('  7 the', getline('.'))
+  :1
+  " seventh match
+  call feedkeys("/the".repeat("\<c-n>", 6)."\<cr>", 'tx')
+  call assert_equal('  8 them', getline('.'))
+  :1
+  " eigth match
+  call feedkeys("/the".repeat("\<c-n>", 7)."\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  :1
+  " back at first match
+  call feedkeys("/the".repeat("\<c-n>", 8)."\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+
+  " Test 4
+  " CTRL-P goes to the previous match
+  set incsearch nowrapscan
+  $
+  " first match
+  call feedkeys("?the\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  $
+  " first match
+  call feedkeys("?the\<c-n>\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  $
+  " second match
+  call feedkeys("?the".repeat("\<c-p>", 1)."\<cr>", 'tx')
+  call assert_equal('  8 them', getline('.'))
+  $
+  " last match
+  call feedkeys("?the".repeat("\<c-p>", 7)."\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  $
+  " last match
+  call feedkeys("?the".repeat("\<c-p>", 8)."\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+
+  " Test 5
+  " CTRL-P goes to the previous match
+  set incsearch wrapscan
+  $
+  " first match
+  call feedkeys("?the\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  $
+  " first match at the top
+  call feedkeys("?the\<c-n>\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  $
+  " second match
+  call feedkeys("?the".repeat("\<c-p>", 1)."\<cr>", 'tx')
+  call assert_equal('  8 them', getline('.'))
+  $
+  " last match
+  call feedkeys("?the".repeat("\<c-p>", 7)."\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  $
+  " back at the bottom of the buffer
+  call feedkeys("?the".repeat("\<c-p>", 8)."\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+
+  " Test 6
+  " CTRL-L adds to the search pattern
+  set incsearch wrapscan
+  1
+  " first match
+  call feedkeys("/the\<c-l>\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  1
+  " go to next match of 'thes'
+  call feedkeys("/the\<c-l>\<c-n>\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  1
+  " wrap around
+  call feedkeys("/the\<c-l>\<c-n>\<c-n>\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  1
+  " wrap around
+  set nowrapscan
+  call feedkeys("/the\<c-l>\<c-n>\<c-n>\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+
+  " Test 7
+  " <bs> remove from match, but stay at current match
+  set incsearch wrapscan
+  1
+  " first match
+  call feedkeys("/thei\<cr>", 'tx')
+  call assert_equal('  4 their', getline('.'))
+  1
+  " delete one char, add another
+  call feedkeys("/thei\<bs>s\<cr>", 'tx')
+  call assert_equal('  9 these', getline('.'))
+  1
+  " delete one char, add another,  go to previous match, add one char
+  call feedkeys("/thei\<bs>s\<bs>\<c-p>\<c-l>\<cr>", 'tx')
+  call assert_equal('  8 them', getline('.'))
+  1
+  " delete all chars, start from the beginning again
+  call feedkeys("/them". repeat("\<bs>",4).'the\>'."\<cr>", 'tx')
+  call assert_equal('  3 the', getline('.'))
+
+  " clean up
+  call test_disable_char_avail(0)
+  bw!
+endfunc
+
+func Test_search_cmdline2()
+  throw 'skipped: Nvim does not support test_disable_char_avail()'
+  if !exists('+incsearch')
+    return
+  endif
+  " need to disable char_avail,
+  " so that expansion of commandline works
+  call test_disable_char_avail(1)
+  new
+  call setline(1, ['  1', '  2 these', '  3 the theother'])
+  " Test 1
+  " Ctrl-P goes correctly back and forth
+  set incsearch
+  1
+  " first match
+  call feedkeys("/the\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+  1
+  " go to next match (on next line)
+  call feedkeys("/the\<c-n>\<cr>", 'tx')
+  call assert_equal('  3 the theother', getline('.'))
+  1
+  " go to next match (still on line 3)
+  call feedkeys("/the\<c-n>\<c-n>\<cr>", 'tx')
+  call assert_equal('  3 the theother', getline('.'))
+  1
+  " go to next match (still on line 3)
+  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<cr>", 'tx')
+  call assert_equal('  3 the theother', getline('.'))
+  1
+  " go to previous match (on line 3)
+  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<c-p>\<cr>", 'tx')
+  call assert_equal('  3 the theother', getline('.'))
+  1
+  " go to previous match (on line 3)
+  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<c-p>\<c-p>\<cr>", 'tx')
+  call assert_equal('  3 the theother', getline('.'))
+  1
+  " go to previous match (on line 2)
+  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<c-p>\<c-p>\<c-p>\<cr>", 'tx')
+  call assert_equal('  2 these', getline('.'))
+
+  " clean up
+  call test_disable_char_avail(0)
+  bw!
+endfunc
+
 func Test_use_sub_pat()
   split
   let @/ = ''

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -1,6 +1,7 @@
 " Test for the search command
 
 func Test_search_cmdline()
+  " See test/functional/legacy/search_spec.lua
   throw 'skipped: Nvim does not support test_disable_char_avail()'
   if !exists('+incsearch')
     return
@@ -197,6 +198,7 @@ func Test_search_cmdline()
 endfunc
 
 func Test_search_cmdline2()
+  " See test/functional/legacy/search_spec.lua
   throw 'skipped: Nvim does not support test_disable_char_avail()'
   if !exists('+incsearch')
     return

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -18,11 +18,11 @@ func Test_search_cmdline()
   call feedkeys("/foobar\<cr>", 'tx')
   call feedkeys("/the\<cr>",'tx')
   call assert_equal('the', @/)
-  call feedkeys("/thes\<c-p>\<c-p>\<cr>",'tx')
+  call feedkeys("/thes\<C-P>\<C-P>\<cr>",'tx')
   call assert_equal('foobar', @/)
 
   " Test 2
-  " Ctrl-N goes from one match to the next
+  " Ctrl-G goes from one match to the next
   " until the end of the buffer
   set incsearch nowrapscan
   :1
@@ -31,39 +31,39 @@ func Test_search_cmdline()
   call assert_equal('  2 these', getline('.'))
   :1
   " second match
-  call feedkeys("/the\<c-n>\<cr>", 'tx')
+  call feedkeys("/the\<C-G>\<cr>", 'tx')
   call assert_equal('  3 the', getline('.'))
   :1
   " third match
-  call feedkeys("/the".repeat("\<c-n>", 2)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 2)."\<cr>", 'tx')
   call assert_equal('  4 their', getline('.'))
   :1
   " fourth match
-  call feedkeys("/the".repeat("\<c-n>", 3)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 3)."\<cr>", 'tx')
   call assert_equal('  5 there', getline('.'))
   :1
   " fifth match
-  call feedkeys("/the".repeat("\<c-n>", 4)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 4)."\<cr>", 'tx')
   call assert_equal('  6 their', getline('.'))
   :1
   " sixth match
-  call feedkeys("/the".repeat("\<c-n>", 5)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 5)."\<cr>", 'tx')
   call assert_equal('  7 the', getline('.'))
   :1
   " seventh match
-  call feedkeys("/the".repeat("\<c-n>", 6)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 6)."\<cr>", 'tx')
   call assert_equal('  8 them', getline('.'))
   :1
   " eigth match
-  call feedkeys("/the".repeat("\<c-n>", 7)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 7)."\<cr>", 'tx')
   call assert_equal('  9 these', getline('.'))
   :1
   " no further match
-  call feedkeys("/the".repeat("\<c-n>", 8)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 8)."\<cr>", 'tx')
   call assert_equal('  9 these', getline('.'))
 
   " Test 3
-  " Ctrl-N goes from one match to the next
+  " Ctrl-G goes from one match to the next
   " and continues back at the top
   set incsearch wrapscan
   :1
@@ -72,39 +72,39 @@ func Test_search_cmdline()
   call assert_equal('  2 these', getline('.'))
   :1
   " second match
-  call feedkeys("/the\<c-n>\<cr>", 'tx')
+  call feedkeys("/the\<C-G>\<cr>", 'tx')
   call assert_equal('  3 the', getline('.'))
   :1
   " third match
-  call feedkeys("/the".repeat("\<c-n>", 2)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 2)."\<cr>", 'tx')
   call assert_equal('  4 their', getline('.'))
   :1
   " fourth match
-  call feedkeys("/the".repeat("\<c-n>", 3)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 3)."\<cr>", 'tx')
   call assert_equal('  5 there', getline('.'))
   :1
   " fifth match
-  call feedkeys("/the".repeat("\<c-n>", 4)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 4)."\<cr>", 'tx')
   call assert_equal('  6 their', getline('.'))
   :1
   " sixth match
-  call feedkeys("/the".repeat("\<c-n>", 5)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 5)."\<cr>", 'tx')
   call assert_equal('  7 the', getline('.'))
   :1
   " seventh match
-  call feedkeys("/the".repeat("\<c-n>", 6)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 6)."\<cr>", 'tx')
   call assert_equal('  8 them', getline('.'))
   :1
   " eigth match
-  call feedkeys("/the".repeat("\<c-n>", 7)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 7)."\<cr>", 'tx')
   call assert_equal('  9 these', getline('.'))
   :1
   " back at first match
-  call feedkeys("/the".repeat("\<c-n>", 8)."\<cr>", 'tx')
+  call feedkeys("/the".repeat("\<C-G>", 8)."\<cr>", 'tx')
   call assert_equal('  2 these', getline('.'))
 
   " Test 4
-  " CTRL-P goes to the previous match
+  " CTRL-T goes to the previous match
   set incsearch nowrapscan
   $
   " first match
@@ -112,23 +112,23 @@ func Test_search_cmdline()
   call assert_equal('  9 these', getline('.'))
   $
   " first match
-  call feedkeys("?the\<c-n>\<cr>", 'tx')
+  call feedkeys("?the\<C-G>\<cr>", 'tx')
   call assert_equal('  9 these', getline('.'))
   $
   " second match
-  call feedkeys("?the".repeat("\<c-p>", 1)."\<cr>", 'tx')
+  call feedkeys("?the".repeat("\<C-T>", 1)."\<cr>", 'tx')
   call assert_equal('  8 them', getline('.'))
   $
   " last match
-  call feedkeys("?the".repeat("\<c-p>", 7)."\<cr>", 'tx')
+  call feedkeys("?the".repeat("\<C-T>", 7)."\<cr>", 'tx')
   call assert_equal('  2 these', getline('.'))
   $
   " last match
-  call feedkeys("?the".repeat("\<c-p>", 8)."\<cr>", 'tx')
+  call feedkeys("?the".repeat("\<C-T>", 8)."\<cr>", 'tx')
   call assert_equal('  2 these', getline('.'))
 
   " Test 5
-  " CTRL-P goes to the previous match
+  " CTRL-T goes to the previous match
   set incsearch wrapscan
   $
   " first match
@@ -136,19 +136,19 @@ func Test_search_cmdline()
   call assert_equal('  9 these', getline('.'))
   $
   " first match at the top
-  call feedkeys("?the\<c-n>\<cr>", 'tx')
+  call feedkeys("?the\<C-G>\<cr>", 'tx')
   call assert_equal('  2 these', getline('.'))
   $
   " second match
-  call feedkeys("?the".repeat("\<c-p>", 1)."\<cr>", 'tx')
+  call feedkeys("?the".repeat("\<C-T>", 1)."\<cr>", 'tx')
   call assert_equal('  8 them', getline('.'))
   $
   " last match
-  call feedkeys("?the".repeat("\<c-p>", 7)."\<cr>", 'tx')
+  call feedkeys("?the".repeat("\<C-T>", 7)."\<cr>", 'tx')
   call assert_equal('  2 these', getline('.'))
   $
   " back at the bottom of the buffer
-  call feedkeys("?the".repeat("\<c-p>", 8)."\<cr>", 'tx')
+  call feedkeys("?the".repeat("\<C-T>", 8)."\<cr>", 'tx')
   call assert_equal('  9 these', getline('.'))
 
   " Test 6
@@ -160,16 +160,16 @@ func Test_search_cmdline()
   call assert_equal('  2 these', getline('.'))
   1
   " go to next match of 'thes'
-  call feedkeys("/the\<c-l>\<c-n>\<cr>", 'tx')
+  call feedkeys("/the\<c-l>\<C-G>\<cr>", 'tx')
   call assert_equal('  9 these', getline('.'))
   1
   " wrap around
-  call feedkeys("/the\<c-l>\<c-n>\<c-n>\<cr>", 'tx')
+  call feedkeys("/the\<c-l>\<C-G>\<C-G>\<cr>", 'tx')
   call assert_equal('  2 these', getline('.'))
   1
   " wrap around
   set nowrapscan
-  call feedkeys("/the\<c-l>\<c-n>\<c-n>\<cr>", 'tx')
+  call feedkeys("/the\<c-l>\<C-G>\<C-G>\<cr>", 'tx')
   call assert_equal('  9 these', getline('.'))
 
   " Test 7
@@ -185,7 +185,7 @@ func Test_search_cmdline()
   call assert_equal('  9 these', getline('.'))
   1
   " delete one char, add another,  go to previous match, add one char
-  call feedkeys("/thei\<bs>s\<bs>\<c-p>\<c-l>\<cr>", 'tx')
+  call feedkeys("/thei\<bs>s\<bs>\<C-T>\<c-l>\<cr>", 'tx')
   call assert_equal('  8 them', getline('.'))
   1
   " delete all chars, start from the beginning again
@@ -209,7 +209,7 @@ func Test_search_cmdline2()
   new
   call setline(1, ['  1', '  2 these', '  3 the theother'])
   " Test 1
-  " Ctrl-P goes correctly back and forth
+  " Ctrl-T goes correctly back and forth
   set incsearch
   1
   " first match
@@ -217,27 +217,27 @@ func Test_search_cmdline2()
   call assert_equal('  2 these', getline('.'))
   1
   " go to next match (on next line)
-  call feedkeys("/the\<c-n>\<cr>", 'tx')
+  call feedkeys("/the\<C-G>\<cr>", 'tx')
   call assert_equal('  3 the theother', getline('.'))
   1
   " go to next match (still on line 3)
-  call feedkeys("/the\<c-n>\<c-n>\<cr>", 'tx')
+  call feedkeys("/the\<C-G>\<C-G>\<cr>", 'tx')
   call assert_equal('  3 the theother', getline('.'))
   1
   " go to next match (still on line 3)
-  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<cr>", 'tx')
+  call feedkeys("/the\<C-G>\<C-G>\<C-G>\<cr>", 'tx')
   call assert_equal('  3 the theother', getline('.'))
   1
   " go to previous match (on line 3)
-  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<c-p>\<cr>", 'tx')
+  call feedkeys("/the\<C-G>\<C-G>\<C-G>\<C-T>\<cr>", 'tx')
   call assert_equal('  3 the theother', getline('.'))
   1
   " go to previous match (on line 3)
-  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<c-p>\<c-p>\<cr>", 'tx')
+  call feedkeys("/the\<C-G>\<C-G>\<C-G>\<C-T>\<C-T>\<cr>", 'tx')
   call assert_equal('  3 the theother', getline('.'))
   1
   " go to previous match (on line 2)
-  call feedkeys("/the\<c-n>\<c-n>\<c-n>\<c-p>\<c-p>\<c-p>\<cr>", 'tx')
+  call feedkeys("/the\<C-G>\<C-G>\<C-G>\<C-T>\<C-T>\<C-T>\<cr>", 'tx')
   call assert_equal('  2 these', getline('.'))
 
   " clean up

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -124,7 +124,7 @@ static const int included_patches[] = {
   2323,
   2322,
   2321,
-  // 2320,
+  2320,
   // 2319 NA
   2318,
   2317,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -185,7 +185,7 @@ static const int included_patches[] = {
   // 2262 NA
   // 2261 NA
   // 2260 NA
-  // 2259,
+  2259,
   // 2258 NA
   // 2257 NA
   2256,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -126,7 +126,7 @@ static const int included_patches[] = {
   2321,
   // 2320,
   // 2319 NA
-  // 2318,
+  2318,
   2317,
   // 2316 NA
   2315,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -176,7 +176,7 @@ static const int included_patches[] = {
   // 2271 NA
   // 2270 NA
   2269,
-  // 2268,
+  2268,
   // 2267 NA
   2266,
   2265,

--- a/test/functional/legacy/search_spec.lua
+++ b/test/functional/legacy/search_spec.lua
@@ -48,49 +48,49 @@ describe('search cmdline', function()
           2 {inc:the}se           |
         /the^                |
       ]])
-      feed('<C-N>')
+      feed('<C-G>')
       screen:expect([[
           2 these           |
           3 {inc:the}             |
         /the^                |
       ]])
-      feed('<C-N>')
+      feed('<C-G>')
       screen:expect([[
           3 the             |
           4 {inc:the}ir           |
         /the^                |
       ]])
-      feed('<C-N>')
+      feed('<C-G>')
       screen:expect([[
           4 their           |
           5 {inc:the}re           |
         /the^                |
       ]])
-      feed('<C-N>')
+      feed('<C-G>')
       screen:expect([[
           5 there           |
           6 {inc:the}ir           |
         /the^                |
       ]])
-      feed('<C-N>')
+      feed('<C-G>')
       screen:expect([[
           6 their           |
           7 {inc:the}             |
         /the^                |
       ]])
-      feed('<C-N>')
+      feed('<C-G>')
       screen:expect([[
           7 the             |
           8 {inc:the}m            |
         /the^                |
       ]])
-      feed('<C-N>')
+      feed('<C-G>')
       screen:expect([[
           8 them            |
           9 {inc:the}se           |
         /the^                |
       ]])
-      feed('<C-N>')
+      feed('<C-G>')
       if wrapscan == 'wrapscan' then
         screen:expect([[
             2 {inc:the}se           |
@@ -117,7 +117,7 @@ describe('search cmdline', function()
         ?the^                |
       ]])
       if wrapscan == 'wrapscan' then
-        feed('<C-N>')
+        feed('<C-G>')
         screen:expect([[
             2 {inc:the}se           |
             3 the             |
@@ -130,7 +130,7 @@ describe('search cmdline', function()
           ?the                |
         ]])
       else
-        feed('<C-N>')
+        feed('<C-G>')
         screen:expect([[
             9 {inc:the}se           |
            10 foobar          |
@@ -150,14 +150,14 @@ describe('search cmdline', function()
          10 foobar          |
         ?the^                |
       ]])
-      feed('<C-P>')
+      feed('<C-T>')
       screen:expect([[
           8 {inc:the}m            |
           9 these           |
         ?the^                |
       ]])
       for i = 1, 6 do
-        feed('<C-P>')
+        feed('<C-T>')
         -- Avoid sleep just before expect, otherwise expect will take the full
         -- timeout
         if i ~= 6 then
@@ -169,7 +169,7 @@ describe('search cmdline', function()
           3 the             |
         ?the^                |
       ]])
-      feed('<C-P>')
+      feed('<C-T>')
       if wrapscan == 'wrapscan' then
         screen:expect([[
             9 {inc:the}se           |
@@ -185,19 +185,19 @@ describe('search cmdline', function()
       end
     end
 
-    it("using <C-N> and 'nowrapscan'", function()
+    it("using <C-G> and 'nowrapscan'", function()
       forwarditer('nowrapscan')
     end)
 
-    it("using <C-N> and 'wrapscan'", function()
+    it("using <C-G> and 'wrapscan'", function()
       forwarditer('wrapscan')
     end)
 
-    it("using <C-P> and 'nowrapscan'", function()
+    it("using <C-T> and 'nowrapscan'", function()
       backiter('nowrapscan')
     end)
 
-    it("using <C-P> and 'wrapscan'", function()
+    it("using <C-T> and 'wrapscan'", function()
       backiter('wrapscan')
     end)
   end)
@@ -218,13 +218,13 @@ describe('search cmdline', function()
         2 {inc:thes}e           |
       /thes^               |
     ]])
-    feed('<C-N>')
+    feed('<C-G>')
     screen:expect([[
         9 {inc:thes}e           |
        10 foobar          |
       /thes^               |
     ]])
-    feed('<C-N>')
+    feed('<C-G>')
     screen:expect([[
         2 {inc:thes}e           |
         3 the             |
@@ -251,13 +251,13 @@ describe('search cmdline', function()
         2 {inc:thes}e           |
       /thes^               |
     ]])
-    feed('<C-N>')
+    feed('<C-G>')
     screen:expect([[
         9 {inc:thes}e           |
        10 foobar          |
       /thes^               |
     ]])
-    feed('<C-N><CR>')
+    feed('<C-G><CR>')
     screen:expect([[
         9 ^these           |
        10 foobar          |
@@ -298,7 +298,7 @@ describe('search cmdline', function()
       /the^                |
     ]])
     -- Advance to previous match
-    feed('<C-P>')
+    feed('<C-T>')
     screen:expect([[
         8 {inc:the}m            |
         9 these           |
@@ -332,7 +332,7 @@ describe('search cmdline', function()
     ]])
   end)
 
-  it('can traverse matches in the same line with <C-N>/<C-P>', function()
+  it('can traverse matches in the same line with <C-G>/<C-T>', function()
     funcs.setline(1, { '  1', '  2 these', '  3 the theother' })
     command('1')
     command('set incsearch')
@@ -346,7 +346,7 @@ describe('search cmdline', function()
     ]])
 
     -- Next match, different line
-    feed('<C-N>')
+    feed('<C-G>')
     screen:expect([[
         2 these           |
         3 {inc:the} theother    |
@@ -354,13 +354,13 @@ describe('search cmdline', function()
     ]])
 
     -- Next match, same line
-    feed('<C-N>')
+    feed('<C-G>')
     screen:expect([[
         2 these           |
         3 the {inc:the}other    |
       /the^                |
     ]])
-    feed('<C-N>')
+    feed('<C-G>')
     screen:expect([[
         2 these           |
         3 the theo{inc:the}r    |
@@ -368,13 +368,13 @@ describe('search cmdline', function()
     ]])
 
     -- Previous match, same line
-    feed('<C-P>')
+    feed('<C-T>')
     screen:expect([[
         2 these           |
         3 the {inc:the}other    |
       /the^                |
     ]])
-    feed('<C-P>')
+    feed('<C-T>')
     screen:expect([[
         2 these           |
         3 {inc:the} theother    |
@@ -382,7 +382,7 @@ describe('search cmdline', function()
     ]])
 
     -- Previous match, different line
-    feed('<C-P>')
+    feed('<C-T>')
     screen:expect([[
         2 {inc:the}se           |
         3 the theother    |

--- a/test/functional/legacy/search_spec.lua
+++ b/test/functional/legacy/search_spec.lua
@@ -1,0 +1,392 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local command = helpers.command
+local eq = helpers.eq
+local eval = helpers.eval
+local feed = helpers.feed
+local funcs = helpers.funcs
+
+describe('search cmdline', function()
+  local screen
+
+  before_each(function()
+    clear()
+    command('set nohlsearch')
+    screen = Screen.new(20, 3)
+    screen:attach()
+    screen:set_default_attr_ids({
+      inc = {reverse = true}
+    })
+  end)
+
+  local function tenlines()
+    funcs.setline(1, {
+      '  1', '  2 these', '  3 the', '  4 their', '  5 there',
+      '  6 their', '  7 the', '  8 them', '  9 these', ' 10 foobar'
+    })
+    command('1')
+  end
+
+  it('history can be navigated with <C-N>/<C-P>', function()
+    tenlines()
+    command('set noincsearch')
+    feed('/foobar<CR>')
+    feed('/the<CR>')
+    eq('the', eval('@/'))
+    feed('/thes<C-P><C-P><CR>')
+    eq('foobar', eval('@/'))
+  end)
+
+  describe('can traverse matches', function()
+    before_each(tenlines)
+    local function forwarditer(wrapscan)
+      command('set incsearch '..wrapscan)
+      feed('/the')
+      screen:expect([[
+          1                 |
+          2 {inc:the}se           |
+        /the^                |
+      ]])
+      feed('<C-N>')
+      screen:expect([[
+          2 these           |
+          3 {inc:the}             |
+        /the^                |
+      ]])
+      feed('<C-N>')
+      screen:expect([[
+          3 the             |
+          4 {inc:the}ir           |
+        /the^                |
+      ]])
+      feed('<C-N>')
+      screen:expect([[
+          4 their           |
+          5 {inc:the}re           |
+        /the^                |
+      ]])
+      feed('<C-N>')
+      screen:expect([[
+          5 there           |
+          6 {inc:the}ir           |
+        /the^                |
+      ]])
+      feed('<C-N>')
+      screen:expect([[
+          6 their           |
+          7 {inc:the}             |
+        /the^                |
+      ]])
+      feed('<C-N>')
+      screen:expect([[
+          7 the             |
+          8 {inc:the}m            |
+        /the^                |
+      ]])
+      feed('<C-N>')
+      screen:expect([[
+          8 them            |
+          9 {inc:the}se           |
+        /the^                |
+      ]])
+      feed('<C-N>')
+      if wrapscan == 'wrapscan' then
+        screen:expect([[
+            2 {inc:the}se           |
+            3 the             |
+          /the^                |
+        ]])
+      else
+        screen:expect([[
+            8 them            |
+            9 {inc:the}se           |
+          /the^                |
+        ]])
+      end
+    end
+
+    local function backiter(wrapscan)
+      command('set incsearch '..wrapscan)
+      command('$')
+
+      feed('?the')
+      screen:expect([[
+          9 {inc:the}se           |
+         10 foobar          |
+        ?the^                |
+      ]])
+      if wrapscan == 'wrapscan' then
+        feed('<C-N>')
+        screen:expect([[
+            2 {inc:the}se           |
+            3 the             |
+          ?the^                |
+        ]])
+        feed('<CR>')
+        screen:expect([[
+            2 ^these           |
+            3 the             |
+          ?the                |
+        ]])
+      else
+        feed('<C-N>')
+        screen:expect([[
+            9 {inc:the}se           |
+           10 foobar          |
+          ?the^                |
+        ]])
+        feed('<CR>')
+        screen:expect([[
+            9 ^these           |
+           10 foobar          |
+          ?the                |
+        ]])
+      end
+      command('$')
+      feed('?the')
+      screen:expect([[
+          9 {inc:the}se           |
+         10 foobar          |
+        ?the^                |
+      ]])
+      feed('<C-P>')
+      screen:expect([[
+          8 {inc:the}m            |
+          9 these           |
+        ?the^                |
+      ]])
+      for i = 1, 6 do
+        feed('<C-P>')
+        -- Avoid sleep just before expect, otherwise expect will take the full
+        -- timeout
+        if i ~= 6 then
+          screen:sleep(1)
+        end
+      end
+      screen:expect([[
+          2 {inc:the}se           |
+          3 the             |
+        ?the^                |
+      ]])
+      feed('<C-P>')
+      if wrapscan == 'wrapscan' then
+        screen:expect([[
+            9 {inc:the}se           |
+           10 foobar          |
+          ?the^                |
+        ]])
+      else
+        screen:expect([[
+            2 {inc:the}se           |
+            3 the             |
+          ?the^                |
+        ]])
+      end
+    end
+
+    it("using <C-N> and 'nowrapscan'", function()
+      forwarditer('nowrapscan')
+    end)
+
+    it("using <C-N> and 'wrapscan'", function()
+      forwarditer('wrapscan')
+    end)
+
+    it("using <C-P> and 'nowrapscan'", function()
+      backiter('nowrapscan')
+    end)
+
+    it("using <C-P> and 'wrapscan'", function()
+      backiter('wrapscan')
+    end)
+  end)
+
+  it('expands pattern with <C-L>', function()
+    tenlines()
+    command('set incsearch wrapscan')
+
+    feed('/the')
+    screen:expect([[
+        1                 |
+        2 {inc:the}se           |
+      /the^                |
+    ]])
+    feed('<C-L>')
+    screen:expect([[
+        1                 |
+        2 {inc:thes}e           |
+      /thes^               |
+    ]])
+    feed('<C-N>')
+    screen:expect([[
+        9 {inc:thes}e           |
+       10 foobar          |
+      /thes^               |
+    ]])
+    feed('<C-N>')
+    screen:expect([[
+        2 {inc:thes}e           |
+        3 the             |
+      /thes^               |
+    ]])
+    feed('<CR>')
+    screen:expect([[
+        2 ^these           |
+        3 the             |
+      /thes               |
+    ]])
+
+    command('1')
+    command('set nowrapscan')
+    feed('/the')
+    screen:expect([[
+        1                 |
+        2 {inc:the}se           |
+      /the^                |
+    ]])
+    feed('<C-L>')
+    screen:expect([[
+        1                 |
+        2 {inc:thes}e           |
+      /thes^               |
+    ]])
+    feed('<C-N>')
+    screen:expect([[
+        9 {inc:thes}e           |
+       10 foobar          |
+      /thes^               |
+    ]])
+    feed('<C-N><CR>')
+    screen:expect([[
+        9 ^these           |
+       10 foobar          |
+      /thes               |
+    ]])
+  end)
+
+  it('reduces pattern with <BS> and keeps cursor position', function()
+    tenlines()
+    command('set incsearch wrapscan')
+
+    -- First match
+    feed('/thei')
+    screen:expect([[
+        4 {inc:thei}r           |
+        5 there           |
+      /thei^               |
+    ]])
+    -- Stay on this match when deleting a character
+    feed('<BS>')
+    screen:expect([[
+        4 {inc:the}ir           |
+        5 there           |
+      /the^                |
+    ]])
+    -- New text advances to next match
+    feed('s')
+    screen:expect([[
+        9 {inc:thes}e           |
+       10 foobar          |
+      /thes^               |
+    ]])
+    -- Stay on this match when deleting a character
+    feed('<BS>')
+    screen:expect([[
+        9 {inc:the}se           |
+       10 foobar          |
+      /the^                |
+    ]])
+    -- Advance to previous match
+    feed('<C-P>')
+    screen:expect([[
+        8 {inc:the}m            |
+        9 these           |
+      /the^                |
+    ]])
+    -- Extend search to include next character
+    feed('<C-L>')
+    screen:expect([[
+        8 {inc:them}            |
+        9 these           |
+      /them^               |
+    ]])
+    -- Deleting all characters resets the cursor position
+    feed('<BS><BS><BS><BS>')
+    screen:expect([[
+        1                 |
+        2 these           |
+      /^                   |
+    ]])
+    feed('the')
+    screen:expect([[
+        2 {inc:the}se           |
+        3 the             |
+      /the^                |
+    ]])
+    feed('\\>')
+    screen:expect([[
+        3 {inc:the}             |
+        4 their           |
+      /the\>^              |
+    ]])
+  end)
+
+  it('can traverse matches in the same line with <C-N>/<C-P>', function()
+    funcs.setline(1, { '  1', '  2 these', '  3 the theother' })
+    command('1')
+    command('set incsearch')
+
+    -- First match
+    feed('/the')
+    screen:expect([[
+        1                 |
+        2 {inc:the}se           |
+      /the^                |
+    ]])
+
+    -- Next match, different line
+    feed('<C-N>')
+    screen:expect([[
+        2 these           |
+        3 {inc:the} theother    |
+      /the^                |
+    ]])
+
+    -- Next match, same line
+    feed('<C-N>')
+    screen:expect([[
+        2 these           |
+        3 the {inc:the}other    |
+      /the^                |
+    ]])
+    feed('<C-N>')
+    screen:expect([[
+        2 these           |
+        3 the theo{inc:the}r    |
+      /the^                |
+    ]])
+
+    -- Previous match, same line
+    feed('<C-P>')
+    screen:expect([[
+        2 these           |
+        3 the {inc:the}other    |
+      /the^                |
+    ]])
+    feed('<C-P>')
+    screen:expect([[
+        2 these           |
+        3 {inc:the} theother    |
+      /the^                |
+    ]])
+
+    -- Previous match, different line
+    feed('<C-P>')
+    screen:expect([[
+        2 {inc:the}se           |
+        3 the theother    |
+      /the^                |
+    ]])
+  end)
+end)


### PR DESCRIPTION
#### vim-patch:7.4.2259

Problem:    With 'incsearch' can only see the next match.
Solution:   Make CTRL-N/CTRL-P move to the previous/next match. (Christian
            Brabandt)

https://github.com/vim/vim/commit/4d6f32cbfbaf324ac4a25c0206a5db0e9f7a48f7


#### vim-patch:7.4.2268

Problem:    Using CTRL-N and CTRL-P for incsearch shadows completion keys.
Solution:   Use CTRL-T and CTRL-G instead.

https://github.com/vim/vim/commit/1195669f9e434fa9ab8b57ee9470bf951e4990b8


#### vim-patch:7.4.2318

Problem:    When 'incsearch' is not set CTRL-T and CTRL-G are not inserted as
            before.
Solution:   Move vim/vim#ifdef and don't use goto.

https://github.com/vim/vim/commit/349e7d94e6bbb253bb87adad9039f095128ab543


#### vim-patch:7.4.2320

Problem:    Redraw problem when using 'incsearch'.
Solution:   Save the current view when deleting characters. (Christian
            Brabandt) Fix that the '" mark is set in the wrong position. Don't
            change the search start when using BS.

https://github.com/vim/vim/commit/dda933d06c06c2792bd686d059f6ad19191ad30b