### PR TITLE
[RDY] cmake: Remove custom "Dev" build-type.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,14 +51,14 @@ endif()
 
 # Set default build type.
 if(NOT CMAKE_BUILD_TYPE)
-  message(STATUS "CMAKE_BUILD_TYPE not given, defaulting to 'Dev'.")
-  set(CMAKE_BUILD_TYPE "Dev" CACHE STRING "Choose the type of build." FORCE)
+  message(STATUS "CMAKE_BUILD_TYPE not given, defaulting to 'Debug'.")
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
 # Set available build types for CMake GUIs.
 # A different build type can still be set by -DCMAKE_BUILD_TYPE=...
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
-  STRINGS "Debug" "Dev" "Release" "MinSizeRel" "RelWithDebInfo")
+  STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 
 # If not in a git repo (e.g., a tarball) these tokens define the complete
 # version string, else they are combined with the result of `git describe`.
@@ -107,45 +107,23 @@ if(NOT CMAKE_C_FLAGS_RELWITHDEBINFO MATCHES DMIN_LOG_LEVEL)
   set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -DMIN_LOG_LEVEL=3")
 endif()
 
-# Enable assertions for RelWithDebInfo.
-if(CMAKE_C_FLAGS_RELWITHDEBINFO MATCHES DNDEBUG)
+if(CMAKE_COMPILER_IS_GNUCC)
+  check_c_compiler_flag(-Og HAS_OG_FLAG)
+else()
+  set(HAS_OG_FLAG 0)
+endif()
+
+# Set custom build flags for RelWithDebInfo.
+# -DNDEBUG purposely omitted because we want assertions.
+if(HAS_OG_FLAG)
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-Og -g"
+    CACHE STRING "Flags used by the compiler during release-with-debug builds." FORCE)
+elseif(NOT MSVC)
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g"
+    CACHE STRING "Flags used by the compiler during release-with-debug builds." FORCE)
+elseif(CMAKE_C_FLAGS_RELWITHDEBINFO MATCHES DNDEBUG)
   string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 endif()
-
-# Set build flags for custom Dev build type.
-# -DNDEBUG purposely omitted because we want assertions.
-if(MSVC)
-  SET(CMAKE_C_FLAGS_DEV ""
-      CACHE STRING "Flags used by the compiler during development (optimized, but with debug info and logging) builds."
-      FORCE)
-else()
-  if(CMAKE_COMPILER_IS_GNUCC)
-    check_c_compiler_flag(-Og HAS_OG_FLAG)
-  else()
-    set(HAS_OG_FLAG 0)
-  endif()
-
-  if(HAS_OG_FLAG)
-    set(CMAKE_C_FLAGS_DEV "-Og -g"
-        CACHE STRING "Flags used by the compiler during development (optimized, but with debug info and logging) builds."
-        FORCE)
-  else()
-    set(CMAKE_C_FLAGS_DEV "-O2 -g"
-        CACHE STRING "Flags used by the compiler during development (optimized, but with debug info and logging) builds."
-        FORCE)
-  endif()
-endif()
-SET(CMAKE_EXE_LINKER_FLAGS_DEV ""
-    CACHE STRING "Flags used for linking binaries during development (optimized, but with debug info and logging) builds."
-    FORCE)
-SET(CMAKE_SHARED_LINKER_FLAGS_DEV ""
-    CACHE STRING "Flags used by the shared libraries linker during development (optimized, but with debug info and logging) builds."
-    FORCE)
-
-MARK_AS_ADVANCED(
-  CMAKE_C_FLAGS_DEV
-  CMAKE_EXE_LINKER_FLAGS_DEV
-  CMAKE_SHARED_LINKER_FLAGS_DEV)
 
 # Enable -Wconversion.
 if(NOT MSVC)

--- a/contrib/local.mk.example
+++ b/contrib/local.mk.example
@@ -13,26 +13,21 @@
 
 # Sets the build type; defaults to Debug. Valid values:
 #
-# - Debug:          Disables optimizations (-O0), enables debug information and logging.
+# - Debug:          Disables optimizations (-O0), enables debug information.
 #
-# - Dev:            Enables all optimizations that do not interfere with
-#                   debugging (-Og if available, -O2 and -g if not).
-#                   Enables debug information and logging.
-#
-# - RelWithDebInfo: Enables optimizations (-O2) and debug information.
-#                   Disables logging.
+# - RelWithDebInfo: Enables optimizations (-Og or -O2) with debug information.
 #
 # - MinSizeRel:     Enables all -O2 optimization that do not typically
 #                   increase code size, and performs further optimizations
 #                   designed to reduce code size (-Os).
-#                   Disables debug information and logging.
+#                   Disables debug information.
 #
 # - Release:        Same as RelWithDebInfo, but disables debug information.
 #
 # CMAKE_BUILD_TYPE := Debug
 
-# The default log level is 1 (INFO) (unless CMAKE_BUILD_TYPE is "Release").
 # Log levels: 0 (DEBUG), 1 (INFO), 2 (WARNING), 3 (ERROR)
+# Default is 1 (INFO) unless CMAKE_BUILD_TYPE is Release or RelWithDebInfo.
 # CMAKE_EXTRA_FLAGS += -DMIN_LOG_LEVEL=1
 
 # By default, nvim uses bundled versions of its required third-party


### PR DESCRIPTION
The main purpose of this build-type was to avoid unwanted ~/.nvimlog
files (which could get really big, and also affects performance) for
non-devs. But that is no longer necessary since the log system now
avoids non-critical logging by default (#6827).

This essentially reverts 87e5a4131666e44354f280538cbc6bbe52225092