### PR TITLE
add maven compiler support

### DIFF
--- a/runtime/compiler/maven.vim
+++ b/runtime/compiler/maven.vim
@@ -1,0 +1,17 @@
+" Vim compiler file
+" Compiler:	maven
+" Maintainer:	Tim Stewart <tim.j.stewart@gmail.com>
+" Last Change:	2017 June 30
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "maven"
+
+if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+CompilerSet makeprg=mvn
+
+CompilerSet errorformat=[ERROR]\ %f:[%l\\,%c]\ %m


### PR DESCRIPTION
Hi I use neovim with Java and had, with the help of the documentation and others people, found out how to configure the error format for Maven 3 projects. 

How to use:

:set makeprg=mvn
:compiler maven
:make -f /Users/me/myproj/pom.xml compile

I've never contributed to Neovim and would like to know if there are any additional steps.  Thanks!