### PR TITLE
test: expand_env_esc: Pass correct buffer size for outlen and assertion

### DIFF
--- a/test/unit/os/env_spec.lua
+++ b/test/unit/os/env_spec.lua
@@ -229,10 +229,10 @@ describe('env.c', function()
 
       local src = to_cstr("~"..curuser.."/Vcs/django-rest-framework/rest_framework/renderers.py")
       local dst = cstr(256, "~"..curuser)
-      cimp.expand_env_esc(src, dst, 1024, false, false, NULL)
+      cimp.expand_env_esc(src, dst, 256, false, false, NULL)
       local len = string.len(ffi.string(dst))
       assert.True(len > 56)
-      assert.True(len < 99)
+      assert.True(len < 256)
     end)
 
     itp('respects `dstlen` without expansion', function()


### PR DESCRIPTION
Running this test with a mocked passwd file whose $HOME was set to
/home/jamessan/src/debian.org/pkg-vim/deb-packages/neovim/neovim-0.2.0/debian/fakehome
caused the test to fail, since the expanded result was >= 99 bytes.  The
test should be reflecting the actual size of the buffer, instead of some
arbitrary other number, anwyay.

Cc @justinmk, since he added the original test