### PR TITLE
[RFC] Make get_keymap output more reliable

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12170,7 +12170,7 @@ void mapblock_fill_dict(dict_T *const dict,
     noremap_value = mp->m_noremap == REMAP_SCRIPT ? 2 : !!mp->m_noremap;
   }
 
-  tv_dict_add_str(dict, S_LEN("lhs"), lhs);
+  tv_dict_add_allocated_str(dict, S_LEN("lhs"), lhs);
   tv_dict_add_str(dict, S_LEN("rhs"), (const char *)mp->m_orig_str);
   tv_dict_add_nr(dict, S_LEN("noremap"), noremap_value);
   tv_dict_add_nr(dict, S_LEN("expr"),  mp->m_expr ? 1 : 0);
@@ -12178,10 +12178,7 @@ void mapblock_fill_dict(dict_T *const dict,
   tv_dict_add_nr(dict, S_LEN("sid"), (varnumber_T)mp->m_script_ID);
   tv_dict_add_nr(dict, S_LEN("buffer"), (varnumber_T)buffer_value);
   tv_dict_add_nr(dict, S_LEN("nowait"), mp->m_nowait ? 1 : 0);
-  tv_dict_add_str(dict, S_LEN("mode"), mapmode);
-
-  xfree(lhs);
-  xfree(mapmode);
+  tv_dict_add_allocated_str(dict, S_LEN("mode"), mapmode);
 }
 
 /*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12156,7 +12156,8 @@ void mapblock_fill_dict(dict_T *const dict,
                         bool compatible)
   FUNC_ATTR_NONNULL_ALL
 {
-  char *const lhs = str2special_save((const char *)mp->m_keys, true);
+  char *const lhs = str2special_save((const char *)mp->m_keys,
+                                     compatible ? true : false);
   char *const mapmode = map_mode_to_chars(mp->m_mode);
   varnumber_T noremap_value;
 
@@ -12170,8 +12171,13 @@ void mapblock_fill_dict(dict_T *const dict,
     noremap_value = mp->m_noremap == REMAP_SCRIPT ? 2 : !!mp->m_noremap;
   }
 
+  if (compatible) {
+    tv_dict_add_str(dict, S_LEN("rhs"), (const char *)mp->m_orig_str);
+  } else {
+    tv_dict_add_allocated_str(dict, S_LEN("rhs"),
+                              str2special_save((const char *)mp->m_str, false));
+  }
   tv_dict_add_allocated_str(dict, S_LEN("lhs"), lhs);
-  tv_dict_add_str(dict, S_LEN("rhs"), (const char *)mp->m_orig_str);
   tv_dict_add_nr(dict, S_LEN("noremap"), noremap_value);
   tv_dict_add_nr(dict, S_LEN("expr"),  mp->m_expr ? 1 : 0);
   tv_dict_add_nr(dict, S_LEN("silent"), mp->m_silent ? 1 : 0);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12117,9 +12117,11 @@ static void get_maparg(typval_T *argvars, typval_T *rettv, int exact)
   xfree(keys_buf);
 
   if (!get_dict) {
-    /* Return a string. */
-    if (rhs != NULL)
-      rettv->vval.v_string = str2special_save(rhs, FALSE);
+    // Return a string.
+    if (rhs != NULL) {
+      rettv->vval.v_string = (char_u *)str2special_save(
+          (const char *)rhs, false);
+    }
 
   } else {
     tv_dict_alloc_ret(rettv);
@@ -12154,7 +12156,7 @@ void mapblock_fill_dict(dict_T *const dict,
                         bool compatible)
   FUNC_ATTR_NONNULL_ALL
 {
-  char_u *lhs = str2special_save(mp->m_keys, true);
+  char *const lhs = str2special_save((const char *)mp->m_keys, true);
   char *const mapmode = map_mode_to_chars(mp->m_mode);
   varnumber_T noremap_value;
 
@@ -12168,7 +12170,7 @@ void mapblock_fill_dict(dict_T *const dict,
     noremap_value = mp->m_noremap == REMAP_SCRIPT ? 2 : !!mp->m_noremap;
   }
 
-  tv_dict_add_str(dict, S_LEN("lhs"), (const char *)lhs);
+  tv_dict_add_str(dict, S_LEN("lhs"), lhs);
   tv_dict_add_str(dict, S_LEN("rhs"), (const char *)mp->m_orig_str);
   tv_dict_add_nr(dict, S_LEN("noremap"), noremap_value);
   tv_dict_add_nr(dict, S_LEN("expr"),  mp->m_expr ? 1 : 0);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12120,7 +12120,7 @@ static void get_maparg(typval_T *argvars, typval_T *rettv, int exact)
     // Return a string.
     if (rhs != NULL) {
       rettv->vval.v_string = (char_u *)str2special_save(
-          (const char *)rhs, false);
+          (const char *)rhs, false, false);
     }
 
   } else {
@@ -12157,7 +12157,7 @@ void mapblock_fill_dict(dict_T *const dict,
   FUNC_ATTR_NONNULL_ALL
 {
   char *const lhs = str2special_save((const char *)mp->m_keys,
-                                     compatible ? true : false);
+                                     compatible, !compatible);
   char *const mapmode = map_mode_to_chars(mp->m_mode);
   varnumber_T noremap_value;
 
@@ -12175,7 +12175,8 @@ void mapblock_fill_dict(dict_T *const dict,
     tv_dict_add_str(dict, S_LEN("rhs"), (const char *)mp->m_orig_str);
   } else {
     tv_dict_add_allocated_str(dict, S_LEN("rhs"),
-                              str2special_save((const char *)mp->m_str, false));
+                              str2special_save((const char *)mp->m_str, false,
+                                               true));
   }
   tv_dict_add_allocated_str(dict, S_LEN("lhs"), lhs);
   tv_dict_add_nr(dict, S_LEN("noremap"), noremap_value);

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1387,11 +1387,32 @@ int tv_dict_add_str(dict_T *const d,
                     const char *const val)
   FUNC_ATTR_NONNULL_ALL
 {
+  return tv_dict_add_allocated_str(d, key, key_len, xstrdup(val));
+}
+
+/// Add a string entry to dictionary
+///
+/// Unlike tv_dict_add_str() saves val to the new dictionary item in place of
+/// creating a new copy.
+///
+/// @warning String will be freed even in case addition fails.
+///
+/// @param[out]  d  Dictionary to add entry to.
+/// @param[in]  key  Key to add.
+/// @param[in]  key_len  Key length.
+/// @param[in]  val  String to add.
+///
+/// @return OK in case of success, FAIL when key already exists.
+int tv_dict_add_allocated_str(dict_T *const d,
+                              const char *const key, const size_t key_len,
+                              char *const val)
+  FUNC_ATTR_NONNULL_ALL
+{
   dictitem_T *const item = tv_dict_item_alloc_len(key, key_len);
 
   item->di_tv.v_lock = VAR_UNLOCKED;
   item->di_tv.v_type = VAR_STRING;
-  item->di_tv.vval.v_string = (char_u *)xstrdup(val);
+  item->di_tv.vval.v_string = (char_u *)val;
   if (tv_dict_add(d, item) == FAIL) {
     tv_dict_item_free(item);
     return FAIL;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3999,7 +3999,7 @@ int put_escstr(FILE *fd, char_u *strstart, int what)
     return OK;
   }
 
-  for (; *str != NUL; ++str) {
+  for (; *str != NUL; str++) {
     // Check for a multi-byte character, which may contain escaped
     // K_SPECIAL and CSI bytes.
     const char *p = mb_unescape((const char **)&str);

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1806,7 +1806,7 @@ static int vgetorpeek(int advance)
                  * <M-a> and then changing 'encoding'. Beware
                  * that 0x80 is escaped. */
                 char_u *p1 = mp->m_keys;
-                char_u *p2 = mb_unescape(&p1);
+                char_u *p2 = (char_u *)mb_unescape((const char **)&p1);
 
                 if (has_mbyte && p2 != NULL && MB_BYTE2LEN(c1) > MB_PTR2LEN(p2))
                   mlen = 0;
@@ -4000,11 +4000,9 @@ int put_escstr(FILE *fd, char_u *strstart, int what)
   }
 
   for (; *str != NUL; ++str) {
-    char_u  *p;
-
-    /* Check for a multi-byte character, which may contain escaped
-     * K_SPECIAL and CSI bytes */
-    p = mb_unescape(&str);
+    // Check for a multi-byte character, which may contain escaped
+    // K_SPECIAL and CSI bytes.
+    const char *p = mb_unescape((const char **)&str);
     if (p != NULL) {
       while (*p != NUL)
         if (fputc(*p++, fd) < 0)

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1374,19 +1374,25 @@ const char *str2special(const char **const sp, const bool replace_spaces)
   return buf;
 }
 
-/*
- * Translate a key sequence into special key names.
- */
-void str2specialbuf(char_u *sp, char_u *buf, int len)
+/// Convert string, replacing key codes with printables
+///
+/// @param[in]  str  String to convert.
+/// @param[out]  buf  Buffer to save results to.
+/// @param[in]  len  Buffer length.
+void str2specialbuf(const char *sp, char *buf, size_t len)
+  FUNC_ATTR_NONNULL_ALL
 {
-  char_u      *s;
-
-  *buf = NUL;
   while (*sp) {
-    s = str2special(&sp, FALSE);
-    if ((int)(STRLEN(s) + STRLEN(buf)) < len)
-      STRCAT(buf, s);
+    const char *s = str2special(&sp, false);
+    const size_t s_len = strlen(s);
+    if (s_len <= len) {
+      break;
+    }
+    memcpy(buf, s, s_len);
+    buf += s_len;
+    len -= s_len;
   }
+  *buf = NUL;
 }
 
 /*

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1269,7 +1269,7 @@ msg_outtrans_special (
       string = "<Space>";
       str++;
     } else {
-      string = (const char *)str2special((char_u **)&str, from);
+      string = str2special((const char **)&str, from);
     }
     const int len = vim_strsize((char_u *)string);
     // Highlight special keys

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5175,9 +5175,12 @@ static int put_setstring(FILE *fd, char *cmd, char *name, char_u **valuep, int e
      * CTRL-V or backslash */
     if (valuep == &p_pt) {
       s = *valuep;
-      while (*s != NUL)
-        if (put_escstr(fd, str2special(&s, FALSE), 2) == FAIL)
+      while (*s != NUL) {
+        if (put_escstr(fd, (char_u *)str2special((const char **)&s, false), 2)
+            == FAIL) {
           return FAIL;
+        }
+      }
     } else if (expand) {
       buf = xmalloc(MAXPATHL);
       home_replace(NULL, *valuep, buf, MAXPATHL, FALSE);
@@ -6173,15 +6176,16 @@ option_value2string (
     }
   } else {  // P_STRING
     varp = *(char_u **)(varp);
-    if (varp == NULL)                       /* just in case */
+    if (varp == NULL) {  // Just in case.
       NameBuff[0] = NUL;
-    else if (opp->flags & P_EXPAND)
-      home_replace(NULL, varp, NameBuff, MAXPATHL, FALSE);
-    /* Translate 'pastetoggle' into special key names */
-    else if ((char_u **)opp->var == &p_pt)
-      str2specialbuf(p_pt, NameBuff, MAXPATHL);
-    else
+    } else if (opp->flags & P_EXPAND) {
+      home_replace(NULL, varp, NameBuff, MAXPATHL, false);
+    // Translate 'pastetoggle' into special key names.
+    } else if ((char_u **)opp->var == &p_pt) {
+      str2specialbuf((const char *)p_pt, (char *)NameBuff, MAXPATHL);
+    } else {
       STRLCPY(NameBuff, varp, MAXPATHL);
+    }
   }
 }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5176,7 +5176,8 @@ static int put_setstring(FILE *fd, char *cmd, char *name, char_u **valuep, int e
     if (valuep == &p_pt) {
       s = *valuep;
       while (*s != NUL) {
-        if (put_escstr(fd, (char_u *)str2special((const char **)&s, false), 2)
+        if (put_escstr(fd, (char_u *)str2special((const char **)&s, false,
+                                                 false), 2)
             == FAIL) {
           return FAIL;
         }

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -281,13 +281,12 @@ describe('get_keymap', function()
       command(cmd)
       eq({cpomap('\\<C-C>', '\\<C-D>', 'n'), cpomap('\\<C-A>', '\\<C-B>', 'n')},
          meths.get_keymap('n'))
-      -- FIXME
-      -- eq({cpomap('\\<C-C>', '\\<C-D>', 'x'), cpomap('\\<LT>C-A>', '\\<LT>C-B>', 'x')},
-         -- meths.get_keymap('x'))
-      -- eq({cpomap('<LT>C-C>', '<LT>C-D>', 's'), cpomap('<LT>C-A>', '<LT>C-B>', 's')},
-         -- meths.get_keymap('x'))
-      -- eq({cpomap('<LT>C-C>', '<LT>C-D>', 'o'), cpomap('<LT>C-A>', '<LT>C-B>', 'o')},
-         -- meths.get_keymap('x'))
+      eq({cpomap('\\<C-C>', '\\<C-D>', 'x'), cpomap('\\<lt>C-a>', '\\<lt>C-b>', 'x')},
+         meths.get_keymap('x'))
+      eq({cpomap('<lt>C-c>', '<lt>C-d>', 's'), cpomap('<lt>C-a>', '<lt>C-b>', 's')},
+         meths.get_keymap('s'))
+      eq({cpomap('<lt>C-c>', '<lt>C-d>', 'o'), cpomap('<lt>C-a>', '<lt>C-b>', 'o')},
+         meths.get_keymap('o'))
     end
   end)
 end)

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -1,5 +1,6 @@
-
 local helpers = require('test.functional.helpers')(after_each)
+local global_helpers = require('test.helpers')
+
 local clear = helpers.clear
 local command = helpers.command
 local curbufmeths = helpers.curbufmeths
@@ -8,13 +9,7 @@ local funcs = helpers.funcs
 local meths = helpers.meths
 local source = helpers.source
 
-local function local_copy(t)
-  local copy = {}
-  for k,v in pairs(t) do
-    copy[k] = v
-  end
-  return copy
-end
+local shallowcopy = global_helpers.shallowcopy
 
 describe('get_keymap', function()
   before_each(clear)
@@ -50,7 +45,7 @@ describe('get_keymap', function()
 
     -- Add another mapping
     command('nnoremap foo_longer bar_longer')
-    local foolong_bar_map_table = local_copy(foo_bar_map_table)
+    local foolong_bar_map_table = shallowcopy(foo_bar_map_table)
     foolong_bar_map_table['lhs'] = 'foo_longer'
     foolong_bar_map_table['rhs'] = 'bar_longer'
 
@@ -72,7 +67,7 @@ describe('get_keymap', function()
 
     command('inoremap foo bar')
     -- The table will be the same except for the mode
-    local insert_table = local_copy(foo_bar_map_table)
+    local insert_table = shallowcopy(foo_bar_map_table)
     insert_table['mode'] = 'i'
 
     eq({insert_table}, meths.get_keymap('i'))
@@ -81,11 +76,11 @@ describe('get_keymap', function()
   it('considers scope', function()
     -- change the map slightly
     command('nnoremap foo_longer bar_longer')
-    local foolong_bar_map_table = local_copy(foo_bar_map_table)
+    local foolong_bar_map_table = shallowcopy(foo_bar_map_table)
     foolong_bar_map_table['lhs'] = 'foo_longer'
     foolong_bar_map_table['rhs'] = 'bar_longer'
 
-    local buffer_table = local_copy(foo_bar_map_table)
+    local buffer_table = shallowcopy(foo_bar_map_table)
     buffer_table['buffer'] = 1
 
     command('nnoremap <buffer> foo bar')
@@ -98,7 +93,7 @@ describe('get_keymap', function()
   it('considers scope for overlapping maps', function()
     command('nnoremap foo bar')
 
-    local buffer_table = local_copy(foo_bar_map_table)
+    local buffer_table = shallowcopy(foo_bar_map_table)
     buffer_table['buffer'] = 1
 
     command('nnoremap <buffer> foo bar')
@@ -121,7 +116,7 @@ describe('get_keymap', function()
 
     command('nnoremap <buffer> foo bar')
     -- Final buffer will have buffer mappings
-    local buffer_table = local_copy(foo_bar_map_table)
+    local buffer_table = shallowcopy(foo_bar_map_table)
     buffer_table['buffer'] = final_buffer
     eq({buffer_table}, meths.buf_get_keymap(final_buffer, 'n'))
     eq({buffer_table}, meths.buf_get_keymap(0, 'n'))

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -257,20 +257,20 @@ describe('get_keymap', function()
     end
 
     command('set cpo-=< cpo+=B')
-    command('nnoremap \\<C-a> \\<C-b>')
-    command('nnoremap <special> \\<C-c> \\<C-d>')
+    command('nnoremap \\<C-a><C-a><LT>C-a>\\  \\<C-b><C-b><LT>C-b>\\')
+    command('nnoremap <special> \\<C-c><C-c><LT>C-c>\\  \\<C-d><C-d><LT>C-d>\\')
 
     command('set cpo+=B<')
-    command('xnoremap \\<C-a> \\<C-b>')
-    command('xnoremap <special> \\<C-c> \\<C-d>')
+    command('xnoremap \\<C-a><C-a><LT>C-a>\\  \\<C-b><C-b><LT>C-b>\\')
+    command('xnoremap <special> \\<C-c><C-c><LT>C-c>\\  \\<C-d><C-d><LT>C-d>\\')
 
     command('set cpo-=B<')
-    command('snoremap \\<C-a> \\<C-b>')
-    command('snoremap <special> \\<C-c> \\<C-d>')
+    command('snoremap \\<C-a><C-a><LT>C-a>\\  \\<C-b><C-b><LT>C-b>\\')
+    command('snoremap <special> \\<C-c><C-c><LT>C-c>\\  \\<C-d><C-d><LT>C-d>\\')
 
     command('set cpo-=B cpo+=<')
-    command('onoremap \\<C-a> \\<C-b>')
-    command('onoremap <special> \\<C-c> \\<C-d>')
+    command('onoremap \\<C-a><C-a><LT>C-a>\\  \\<C-b><C-b><LT>C-b>\\')
+    command('onoremap <special> \\<C-c><C-c><LT>C-c>\\  \\<C-d><C-d><LT>C-d>\\')
 
     for _, cmd in ipairs({
       'set cpo-=B cpo+=<',
@@ -279,13 +279,17 @@ describe('get_keymap', function()
       'set cpo-=< cpo+=B',
     }) do
       command(cmd)
-      eq({cpomap('\\<C-C>', '\\<C-D>', 'n'), cpomap('\\<C-A>', '\\<C-B>', 'n')},
+      eq({cpomap('\\<C-C><C-C><lt>C-c>\\', '\\<C-D><C-D><lt>C-d>\\', 'n'),
+          cpomap('\\<C-A><C-A><lt>C-a>\\', '\\<C-B><C-B><lt>C-b>\\', 'n')},
          meths.get_keymap('n'))
-      eq({cpomap('\\<C-C>', '\\<C-D>', 'x'), cpomap('\\<lt>C-a>', '\\<lt>C-b>', 'x')},
+      eq({cpomap('\\<C-C><C-C><lt>C-c>\\', '\\<C-D><C-D><lt>C-d>\\', 'x'),
+          cpomap('\\<lt>C-a><lt>C-a><lt>LT>C-a>\\', '\\<lt>C-b><lt>C-b><lt>LT>C-b>\\', 'x')},
          meths.get_keymap('x'))
-      eq({cpomap('<lt>C-c>', '<lt>C-d>', 's'), cpomap('<lt>C-a>', '<lt>C-b>', 's')},
+      eq({cpomap('<lt>C-c><C-C><lt>C-c> ', '<lt>C-d><C-D><lt>C-d>', 's'),
+          cpomap('<lt>C-a><C-A><lt>C-a> ', '<lt>C-b><C-B><lt>C-b>', 's')},
          meths.get_keymap('s'))
-      eq({cpomap('<lt>C-c>', '<lt>C-d>', 'o'), cpomap('<lt>C-a>', '<lt>C-b>', 'o')},
+      eq({cpomap('<lt>C-c><C-C><lt>C-c> ', '<lt>C-d><C-D><lt>C-d>', 'o'),
+          cpomap('<lt>C-a><lt>C-a><lt>LT>C-a> ', '<lt>C-b><lt>C-b><lt>LT>C-b>', 'o')},
          meths.get_keymap('o'))
     end
   end)

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -293,4 +293,20 @@ describe('get_keymap', function()
          meths.get_keymap('o'))
     end
   end)
+
+  it('always uses space for space and bar for bar', function()
+    local space_table = {
+      lhs='|   |',
+      rhs='|    |',
+      mode='n',
+      silent=0,
+      expr=0,
+      sid=0,
+      buffer=0,
+      nowait=0,
+      noremap=1,
+    }
+    command('nnoremap \\|<Char-0x20><Char-32><Space><Bar> \\|<Char-0x20><Char-32><Space> <Bar>')
+    eq({space_table}, meths.get_keymap('n'))
+  end)
 end)

--- a/test/unit/eval/typval_spec.lua
+++ b/test/unit/eval/typval_spec.lua
@@ -1948,8 +1948,8 @@ describe('typval.c', function()
           eq(OK, lib.tv_dict_add_str(d, 'testt', 3, 'TEST'))
           local dis = dict_items(d)
           alloc_log:check({
+            a.str(dis.tes.di_tv.vval.v_string, 'TEST'),
             a.di(dis.tes, 'tes'),
-            a.str(dis.tes.di_tv.vval.v_string, 'TEST')
           })
           eq({test=10, tes='TEST'}, dct2tbl(d))
           eq(FAIL, check_emsg(function() return lib.tv_dict_add_str(d, 'testt', 3, 'TEST') end,
@@ -2007,7 +2007,7 @@ describe('typval.c', function()
         local dis = dict_items(d)
         local di = dis.TES
         local di_s = di.di_tv.vval.v_string
-        alloc_log:check({a.di(di), a.str(di_s)})
+        alloc_log:check({a.str(di_s), a.di(di)})
         eq({TES='tEsT'}, dct2tbl(d))
         lib.tv_dict_clear(d)
         alloc_log:check({a.freed(di_s), a.freed(di)})


### PR DESCRIPTION
Currently it has two main problems:

1. Output depends on `&cpoptions` set *when mapping was created*.
2. Output does not allow to distinguish `<LT>C-C>` and `<C-C>` in lhs.

While second may potentionally be fixed by #6945 (by removing flags which may affect mapping creation), #6945 has no attempts to fix the second problem. Note that Vim has fixed second problem for `maparg()`.