### PR TITLE
runtime: update vimCommand syntax pattern

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -21,7 +21,7 @@ syn keyword vimTodo contained	COMBAK	FIXME	TODO	XXX
 syn cluster vimCommentGroup	contains=vimTodo,@Spell
 
 " Special and plugin vim commands {{{2
-syn match   vimCommand contained	"\<z[-+^.=]\="
+syn match   vimCommand contained	"\<z[-+^.=]\=\>"
 syn keyword vimOnlyCommand contained	fix[del] op[en] sh[ell] P[rint]
 syn keyword vimStdPlugin contained	DiffOrig Man N[ext] S TOhtml XMLent XMLns
 


### PR DESCRIPTION
Update a flawed match pattern for the vimCommand syntax group. To see the bug this addresses, open a vimscript buffer,
```
nvim -u NONE foo.vim
```
configure a couple highlight groups,
```
:hi! vimIsCommand ctermfg=Green
:hi! vimCommand ctermfg=Red
:syntax enable
```
and add the following lines to the buffer:
```
let foo=xFoo
let bar=zBar
```
You'll notice the `z` in zBar is Red, while xFoo and the rest of Bar are green. This will be the case as long as the word following `=` starts with the letter `z`. This has already been fixed upstream by adding a `\>` word boundary to the match pattern:

- https://github.com/vim/vim/issues/124
- https://github.com/vim/vim/commit/e2719096250a19ecdd9a35d13702879f163d2a50#diff-86da060e2153c8ce5dc317a7b4b5a29dR27

This particular match pattern was also mentioned in issue #5491, ~~but in reference to a bug that was related to the generated part of syntax/vim.vim, whereas this bug lives in the non-generated part of the file~~ but in reference to a different bug.

### Note

I'm not sure whether this is the preferred way to incorporate such changes from upstream, but hope this PR can at least get the ball rolling. Please let me know if there's a different approach I should take.