### PR TITLE
[RFC] inccommand: Ignore leading modifiers in the command

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9883,13 +9883,19 @@ static void ex_terminal(exarg_T *eap)
 
 /// Checks if `cmd` is "previewable" (i.e. supported by 'inccommand').
 ///
-/// @param[in] cmd Commandline to check. May start with a range.
+/// @param[in] cmd Commandline to check. May start with a range or modifier.
 ///
 /// @return true if `cmd` is previewable
 bool cmd_can_preview(char_u *cmd)
 {
   if (cmd == NULL) {
     return false;
+  }
+
+  // Ignore any leading modifiers (:keeppatterns, :verbose, etc.)
+  for (int len = modifier_len(cmd); len != 0; len = modifier_len(cmd)) {
+    cmd += len;
+    cmd = skipwhite(cmd);
   }
 
   exarg_T ea;

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -701,6 +701,25 @@ describe(":substitute, inccommand=split", function()
     eq(0, eval("&modified"))
   end)
 
+  it("shows preview when cmd modifiers are present", function()
+    -- one modifier
+    feed(':keeppatterns %s/tw/to')
+    screen:expect([[too lines]], nil, nil, nil, true)
+    feed('<Esc>')
+    screen:expect([[two lines]], nil, nil, nil, true)
+
+    -- multiple modifiers
+    feed(':keeppatterns silent %s/tw/to')
+    screen:expect([[too lines]], nil, nil, nil, true)
+    feed('<Esc>')
+    screen:expect([[two lines]], nil, nil, nil, true)
+
+    -- non-modifier prefix
+    feed(':silent tabedit %s/tw/to')
+    screen:expect([[two lines]], nil, nil, nil, true)
+    feed('<Esc>')
+  end)
+
   it('shows split window when typing the pattern', function()
     feed(":%s/tw")
     screen:expect([[
@@ -1138,6 +1157,25 @@ describe("inccommand=nosplit", function()
       {15:~                   }|
       :%snomagic/3.*/X^    |
     ]])
+  end)
+
+  it("shows preview when cmd modifiers are present", function()
+    -- one modifier
+    feed(':keeppatterns %s/tw/to')
+    screen:expect([[too lines]], nil, nil, nil, true)
+    feed('<Esc>')
+    screen:expect([[two lines]], nil, nil, nil, true)
+
+    -- multiple modifiers
+    feed(':keeppatterns silent %s/tw/to')
+    screen:expect([[too lines]], nil, nil, nil, true)
+    feed('<Esc>')
+    screen:expect([[two lines]], nil, nil, nil, true)
+
+    -- non-modifier prefix
+    feed(':silent tabedit %s/tw/to')
+    screen:expect([[two lines]], nil, nil, nil, true)
+    feed('<Esc>')
   end)
 
   it('never shows preview buffer', function()


### PR DESCRIPTION
@wilywampa suggested this in gitter.  I still need to write the tests for it.