### PR TITLE
options: Default to 'ttimeout' and 'ttimeoutlen=50'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6272,7 +6272,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	for any key that can follow <c-f> in a mapping.
 
 						*'ttimeout'* *'nottimeout'*
-'ttimeout'		boolean (default off)
+'ttimeout'		boolean (default on)
 			global
 	This option and 'ttimeoutlen' determine the behavior when part of a
 	key code sequence has been received by the terminal UI. For example,
@@ -6287,7 +6287,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	complete.
 
 						*'ttimeoutlen'* *'ttm'*
-'ttimeoutlen' 'ttm'	number	(default -1)
+'ttimeoutlen' 'ttm'	number	(default 50)
 			global
 	The time in milliseconds that is waited for a key code
 	sequence to complete. Also used for CTRL-\ CTRL-N and CTRL-\ CTRL-G

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2513,14 +2513,14 @@ return {
       vi_def=true,
       vim=true,
       varname='p_ttimeout',
-      defaults={if_true={vi=false}}
+      defaults={if_true={vi=true}}
     },
     {
       full_name='ttimeoutlen', abbreviation='ttm',
       type='number', scope={'global'},
       vi_def=true,
       varname='p_ttm',
-      defaults={if_true={vi=-1}}
+      defaults={if_true={vi=50}}
     },
     {
       full_name='ttyfast', abbreviation='tf',


### PR DESCRIPTION
This gives libtermkey 50msec to reassemble split multibyte sequences
like DCSes.