### PR TITLE
runtime: update vimCommand syntax pattern

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -21,7 +21,7 @@ syn keyword vimTodo contained	COMBAK	FIXME	TODO	XXX
 syn cluster vimCommentGroup	contains=vimTodo,@Spell
 
 " Special and plugin vim commands {{{2
-syn match   vimCommand contained	"\<z[-+^.=]\="
+syn match   vimCommand contained	"\<z[-+^.=]\=\>"
 syn keyword vimOnlyCommand contained	fix[del] op[en] sh[ell] P[rint]
 syn keyword vimStdPlugin contained	DiffOrig Man N[ext] S TOhtml XMLent XMLns
 


### PR DESCRIPTION
Update a flawed match pattern for the vimCommand syntax group. This was already fixed upstream; the [vim commit log](https://github.com/vim/vim/commits/v7.4.568):
* [updated for version 7.4.568](https://github.com/vim/vim/commit/8be6388b7649d9378cd1ba1627a4b0aed61b86e7)
* [Updated syntax files](https://github.com/vim/vim/commit/e2719096250a19ecdd9a35d13702879f163d2a50) <-- the relevant commit
* [updated for version 7.4.567](https://github.com/vim/vim/commit/c60c4f6e06e222e90b2277c09fdaaac20ac9edf8)

The [vim patch report](https://neovim.io/doc/reports/vimpatch/) lists both patches [7.4.567](https://github.com/vim/vim/releases/tag/v7.4.567) and [7.4.568](https://github.com/vim/vim/releases/tag/v7.4.568) as merged, but the syntax files were not updated. #3972 addressed this issue, but omitted `runtime/syntax/vim.vim` intentionally:

> All changes to runtime/syntax/vim.vim are ignored because it is in part auto-generated and has been updated to a more recent version separately (fb0ebb2).

The relevant line:
[neovim master](https://github.com/neovim/neovim/blob/master/runtime/syntax/vim.vim#L24)
```vim
syn match   vimCommand contained	"\<z[-+^.=]\="
```
[vim v7.4.568](https://github.com/vim/vim/blob/v7.4.568/runtime/syntax/vim.vim#L27)
```vim
syn match   vimCommand contained	"\<z[-+^.=]\=\>"
```

To see the bug this addresses, open a vimscript buffer,
```
nvim -u NONE foo.vim
```
configure a couple highlight groups,
```
:hi! vimIsCommand ctermfg=Green
:hi! vimCommand ctermfg=Red
:syntax enable
```
and add the following lines to the buffer:
```
let foo=xFoo
let bar=zBar
```
You'll notice the `z` in zBar is Red, while xFoo and the rest of Bar are green. This will be the case as long as the word following `=` starts with the letter `z`.

The upstream fix added a `\>` word boundary to the match pattern:

- https://github.com/vim/vim/issues/124
- https://github.com/vim/vim/commit/e2719096250a19ecdd9a35d13702879f163d2a50#diff-86da060e2153c8ce5dc317a7b4b5a29dR27

This particular match pattern was also mentioned in issue #5491, but in reference to a different bug.