### PR TITLE
[RDY] vim-patch:7.4.2189

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -91,21 +91,21 @@ static char *e_auabort = N_("E855: Autocommands caused command to abort");
 // Number of times free_buffer() was called.
 static int buf_free_count = 0;
 
-/* Read data from buffer for retrying. */
+// Read data from buffer for retrying.
 static int
 read_buffer(
-    int     read_stdin,     /* read file from stdin, otherwise fifo */
-    exarg_T *eap,           /* for forced 'ff' and 'fenc' or NULL */
-    int     flags)          /* extra flags for readfile() */
+    int     read_stdin,     // read file from stdin, otherwise fifo
+    exarg_T *eap,           // for forced 'ff' and 'fenc' or NULL
+    int     flags)          // extra flags for readfile()
 {
   int       retval = OK;
   linenr_T  line_count;
 
-  /*
-   * Read from the buffer which the text is already filled in and append at
-   * the end.  This makes it possible to retry when 'fileformat' or
-   * 'fileencoding' was guessed wrong.
-   */
+  //
+  // Read from the buffer which the text is already filled in and append at
+  // the end.  This makes it possible to retry when 'fileformat' or
+  // 'fileencoding' was guessed wrong.
+  //
   line_count = curbuf->b_ml.ml_line_count;
   retval = readfile(
       read_stdin ? NULL : curbuf->b_ffname,
@@ -113,27 +113,30 @@ read_buffer(
       (linenr_T)line_count, (linenr_T)0, (linenr_T)MAXLNUM, eap,
       flags | READ_BUFFER);
   if (retval == OK) {
-    /* Delete the binary lines. */
-    while (--line_count >= 0)
-      ml_delete((linenr_T)1, FALSE);
+    // Delete the binary lines.
+    while (--line_count >= 0) {
+      ml_delete((linenr_T)1, false);
+    }
   } else {
-    /* Delete the converted lines. */
-    while (curbuf->b_ml.ml_line_count > line_count)
-      ml_delete(line_count, FALSE);
+    // Delete the converted lines.
+    while (curbuf->b_ml.ml_line_count > line_count) {
+      ml_delete(line_count, false);
+    }
   }
-  /* Put the cursor on the first line. */
+  // Put the cursor on the first line.
   curwin->w_cursor.lnum = 1;
   curwin->w_cursor.col = 0;
 
   if (read_stdin) {
-    /* Set or reset 'modified' before executing autocommands, so that
-     * it can be changed there. */
-    if (!readonlymode && !bufempty())
+    // Set or reset 'modified' before executing autocommands, so that
+    // it can be changed there.
+    if (!readonlymode && !bufempty()) {
       changed();
-    else if (retval != FAIL)
-      unchanged(curbuf, FALSE);
+    } else if (retval != FAIL) {
+      unchanged(curbuf, false);
+    }
 
-    apply_autocmds_retval(EVENT_STDINREADPOST, NULL, NULL, FALSE,
+    apply_autocmds_retval(EVENT_STDINREADPOST, NULL, NULL, false,
                           curbuf, &retval);
   }
   return retval;
@@ -154,7 +157,7 @@ open_buffer (
   int retval = OK;
   bufref_T       old_curbuf;
   long old_tw = curbuf->b_p_tw;
-  int read_fifo = FALSE;
+  int read_fifo = false;
 
   /*
    * The 'readonly' flag is only set when BF_NEVERLOADED is being reset.
@@ -212,18 +215,22 @@ open_buffer (
     perm = os_getperm((const char *)curbuf->b_ffname);
     if (perm >= 0 && (0
 # ifdef S_ISFIFO
-          || S_ISFIFO(perm)
+                      || S_ISFIFO(perm)
 # endif
 # ifdef S_ISSOCK
-          || S_ISSOCK(perm)
+                      || S_ISSOCK(perm)
 # endif
 # ifdef OPEN_CHR_FILES
-          || (S_ISCHR(perm) && is_dev_fd_file(curbuf->b_ffname))
+                      || (S_ISCHR(perm)
+                          && is_dev_fd_file(curbuf->b_ffname))
 # endif
-        ))
-        read_fifo = TRUE;
-    if (read_fifo)
-        curbuf->b_p_bin = TRUE;
+                      )
+        ) {
+      read_fifo = true;
+    }
+    if (read_fifo) {
+      curbuf->b_p_bin = true;
+    }
 #endif
     if (shortmess(SHM_FILEINFO)) {
       msg_silent = 1;
@@ -235,8 +242,9 @@ open_buffer (
 #ifdef UNIX
     if (read_fifo) {
       curbuf->b_p_bin = save_bin;
-      if (retval == OK)
-      retval = read_buffer(FALSE, eap, flags);
+      if (retval == OK) {
+        retval = read_buffer(false, eap, flags);
+      }
     }
 #endif
     msg_silent = old_msg_silent;
@@ -246,7 +254,7 @@ open_buffer (
       fix_help_buffer();
     }
   } else if (read_stdin) {
-    int	save_bin = curbuf->b_p_bin;
+    int save_bin = curbuf->b_p_bin;
 
     /*
      * First read the text in binary mode into the buffer.
@@ -259,14 +267,14 @@ open_buffer (
         (linenr_T)0, (linenr_T)MAXLNUM, NULL,
         flags | (READ_NEW + READ_STDIN));
     curbuf->b_p_bin = save_bin;
-    if (retval == OK)
-	    retval = read_buffer(TRUE, eap, flags);
-    
+    if (retval == OK) {
+      retval = read_buffer(true, eap, flags);
+    }
   }
 
   /* if first time loading this buffer, init b_chartab[] */
   if (curbuf->b_flags & BF_NEVERLOADED) {
-    (void)buf_init_chartab(curbuf, FALSE);
+    (void)buf_init_chartab(curbuf, false);
     parse_cino(curbuf);
   }
 
@@ -463,8 +471,8 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
       return;
     }
 
-    /* When the buffer becomes hidden, but is not unloaded, trigger
-     * BufHidden */
+    // When the buffer becomes hidden, but is not unloaded, trigger
+    // BufHidden
     if (!unload_buf) {
       buf->b_locked++;
       if (apply_autocmds(EVENT_BUFHIDDEN, buf->b_fname, buf->b_fname, false,

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -217,6 +217,9 @@ open_buffer (
 # ifdef S_ISSOCK
           || S_ISSOCK(perm)
 # endif
+# ifdef OPEN_CHR_FILES
+          || (S_ISCHR(perm) && is_dev_fd_file(curbuf->b_ffname))
+# endif
         ))
         read_fifo = TRUE;
     if (read_fifo)

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1974,7 +1974,7 @@ failed:
 /// Do not accept "/dev/fd/[012]", opening these may hang Vim.
 ///
 /// @param fname file name to check
-static bool is_dev_fd_file(char_u *fname)
+bool is_dev_fd_file(char_u *fname)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return STRNCMP(fname, "/dev/fd/", 8) == 0

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -268,7 +268,7 @@ readfile (
   int filtering = (flags & READ_FILTER);
   int read_stdin = (flags & READ_STDIN);
   int read_buffer = (flags & READ_BUFFER);
-  int	read_fifo = (flags & READ_FIFO);
+  int read_fifo = (flags & READ_FIFO);
   int set_options = newfile || read_buffer
                     || (eap != NULL && eap->read_edit);
   linenr_T read_buf_lnum = 1;           /* next line to read from curbuf */
@@ -471,7 +471,7 @@ readfile (
     curbuf->b_p_ro = FALSE;
 
   if (newfile && !read_stdin && !read_buffer && !read_fifo) {
-    /* Remember time of file. */
+    // Remember time of file.
     FileInfo file_info;
     if (os_fileinfo((char *)fname, &file_info)) {
       buf_store_file_info(curbuf, &file_info);

--- a/src/nvim/fileio.h
+++ b/src/nvim/fileio.h
@@ -4,14 +4,14 @@
 #include "nvim/buffer_defs.h"
 #include "nvim/os/os.h"
 
-/* Values for readfile() flags */
-#define READ_NEW        0x01    /* read a file into a new buffer */
-#define READ_FILTER     0x02    /* read filter output */
-#define READ_STDIN      0x04    /* read from stdin */
-#define READ_BUFFER     0x08    /* read from curbuf (converting stdin) */
-#define READ_DUMMY      0x10    /* reading into a dummy buffer */
-#define READ_KEEP_UNDO  0x20    /* keep undo info */
-#define READ_FIFO	      0x40	  /* read from fifo or socket */
+// Values for readfile() flags
+#define READ_NEW        0x01    // read a file into a new buffer
+#define READ_FILTER     0x02    // read filter output
+#define READ_STDIN      0x04    // read from stdin
+#define READ_BUFFER     0x08    // read from curbuf (converting stdin)
+#define READ_DUMMY      0x10    // reading into a dummy buffer
+#define READ_KEEP_UNDO  0x20    // keep undo info
+#define READ_FIFO       0x40    // read from fifo or socket
 
 #define READ_STRING(x, y) (char_u *)read_string((x), (size_t)(y))
 

--- a/src/nvim/fileio.h
+++ b/src/nvim/fileio.h
@@ -10,7 +10,8 @@
 #define READ_STDIN      0x04    /* read from stdin */
 #define READ_BUFFER     0x08    /* read from curbuf (converting stdin) */
 #define READ_DUMMY      0x10    /* reading into a dummy buffer */
-#define READ_KEEP_UNDO  0x20    /* keep undo info*/
+#define READ_KEEP_UNDO  0x20    /* keep undo info */
+#define READ_FIFO	      0x40	  /* read from fifo or socket */
 
 #define READ_STRING(x, y) (char_u *)read_string((x), (size_t)(y))
 

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -62,6 +62,8 @@ NEW_TESTS ?= \
 	    test_signs.res \
 	    test_smartindent.res \
 	    test_stat.res \
+	    test_startup.res \
+	    test_startup_utf8.res \
 	    test_substitute.res \
 	    test_syntax.res \
 	    test_tabpage.res \

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -75,7 +75,7 @@ func Test_help_arg()
     " check if  couple of lines are there
     let found = []
     for line in lines
-      if line =~ '-R.*Readonly mode'
+      if line =~ '-R.*Read-only mode'
 	call add(found, 'Readonly mode')
       endif
       " Watch out for a second --version line in the Gnome version.

--- a/src/nvim/testdir/test_startup_utf8.vim
+++ b/src/nvim/testdir/test_startup_utf8.vim
@@ -1,0 +1,64 @@
+" Tests for startup using utf-8.
+if !has('multi_byte')
+  finish
+endif
+
+source shared.vim
+
+func Test_read_stdin_utf8()
+  let linesin = ['テスト', '€ÀÈÌÒÙ']
+  call writefile(linesin, 'Xtestin')
+  let before = [
+	\ 'set enc=utf-8',
+	\ 'set fencs=cp932,utf-8',
+	\ ]
+  let after = [
+	\ 'write ++enc=utf-8 Xtestout',
+	\ 'quit!',
+	\ ]
+  if has('win32')
+    let pipecmd = 'type Xtestin | '
+  else
+    let pipecmd = 'cat Xtestin | '
+  endif
+  if RunVimPiped(before, after, '-', pipecmd)
+    let lines = readfile('Xtestout')
+    call assert_equal(linesin, lines)
+  else
+    call assert_equal('', 'RunVimPiped failed.')
+  endif
+  call delete('Xtestout')
+  call delete('Xtestin')
+endfunc
+
+func Test_read_fifo_utf8()
+  if !has('unix')
+    return
+  endif
+  " Using bash/zsh's process substitution.
+  if executable('bash')
+    set shell=bash
+  elseif executable('zsh')
+    set shell=zsh
+  else
+    return
+  endif
+  let linesin = ['テスト', '€ÀÈÌÒÙ']
+  call writefile(linesin, 'Xtestin')
+  let before = [
+	\ 'set enc=utf-8',
+	\ 'set fencs=cp932,utf-8',
+	\ ]
+  let after = [
+	\ 'write ++enc=utf-8 Xtestout',
+	\ 'quit!',
+	\ ]
+  if RunVim(before, after, '<(cat Xtestin)')
+    let lines = readfile('Xtestout')
+    call assert_equal(linesin, lines)
+  else
+    call assert_equal('', 'RunVim failed.')
+  endif
+  call delete('Xtestout')
+  call delete('Xtestin')
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -215,7 +215,7 @@ static const int included_patches[] = {
   // 2232 NA
   2231,
   2230,
-  // 2229,
+  2229,
   2228,
   2227,
   2226,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -255,7 +255,7 @@ static const int included_patches[] = {
   // 2192 NA
   // 2191 NA
   2190,
-  // 2189,
+  2189,
   2188,
   2187,
   // 2186 NA

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -319,4 +319,8 @@ enum { FOLD_TEXT_LEN = 51 };  //!< buffer size for get_foldtext()
 // Lowest number used for window ID. Cannot have this many windows per tab.
 #define LOWEST_WIN_ID 1000
 
+#if defined(__FreeBSD__) && defined(S_ISCHR)
+# define OPEN_CHR_FILES
+#endif
+
 #endif /* NVIM_VIM_H */


### PR DESCRIPTION
vim-patch:7.4.2189
    
    https://github.com/vim/vim/commit/f71d7b9ee5ceba75f70c30845332ddd728fd16c6
    
    Author: Bram Moolenaar <Bram@vim.org>
    Date:   Tue Aug 9 22:14:05 2016 +0200
    
        patch 7.4.2189
        Problem:    Cannot detect encoding in a fifo.
        Solution:   Extend the stdin way of detecting encoding to fifo.  Add a t
                    for detecting encoding on stdin and fifo. (Ken Takata)
