### PR TITLE
[RDY] mbyte: Fix crash when using multibyte characters in maparg() return

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1780,7 +1780,7 @@ const char *mb_unescape(const char **const pp)
     // Return a multi-byte character if it's found.  An illegal sequence
     // will result in a 1 here.
     if (utf_ptr2len((const char_u *)buf) > 1) {
-      *pp = (const char *)str + buf_idx + 1;
+      *pp = (const char *)str + str_idx + 1;
       return buf;
     }
 


### PR DESCRIPTION
This is a refactoring typo from #6947.

Fixes #6985

Combined with #6947 where typo was made it also fixes vim/vim#1827 which was 
present in Neovim.