### PR TITLE
Various TUI fixes carrying on from #6816

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -90,12 +90,22 @@ Settings depending on terminal			*term-dependent-settings*
 If you want to set options or mappings, depending on the terminal name, you
 can do this best in your init.vim.  Example: >
 
-    if $TERM =~ '^\(rxvt\|screen\)\(\|-.*\)'
+    if $TERM =~ '^\(rxvt\|screen\|interix\|putty\)\(-.*\)\?$'
         set notermguicolors
-    elseif $TERM =~ '^\(xterm\|tmux\)\(\|-.*\)'
+    elseif $TERM =~ '^\(tmux\|iterm\|vte\|gnome\)\(-.*\)\?$'
         set termguicolors
+    elseif $TERM =~ '^\(xterm\)\(-.*\)\?$'
+        if $XTERM_VERSION != ''
+            set termguicolors
+        elseif $KONSOLE_PROFILE_NAME != ''
+            set termguicolors
+        elseif $VTE_VERSION != ''
+            set termguicolors
+        else
+            set notermguicolors
+        endif
     elseif $TERM =~ ...
-	... and so forth ...
+        ... and so forth ...
     endif
 <
 					*scroll-region* *xterm-scroll-region*

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -161,11 +161,12 @@ constructed "setrgbf" and "setrgbb" capabilities as if they had been in the
 terminfo definition.
 
 If your terminal's terminfo definition does not (yet) have this flag, Nvim
-will fall back to looking at the TERM and other environment variables.  For
-the "rxvt", "linux", "st", and "iterm" terminal types, or when Konsole,
-genuine Xterm, or a terminal emulator that sets the COLORTERM environment
-variable to "truecolor" is detected, it will also add constructed "setrgbf"
-and "setrgbb" capabilities.
+will fall back to looking at the TERM and other environment variables.  It
+will add constructed "setrgbf" and "setrgbb" capabilities in the case of the
+the "rxvt", "linux", "st", "tmux", and "iterm" terminal types, or when
+Konsole, genuine Xterm, a libvte terminal emulator version 0.36 or later, or a
+terminal emulator that sets the COLORTERM environment variable to "truecolor"
+is detected.
 
 							*xterm-resize*
 Nvim can resize the terminal display on some terminals that implement an

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -292,6 +292,12 @@ Nvim does not have special `t_XX` options nor <t_XX> keycodes to configure
 terminal capabilities. Instead Nvim treats the terminal as any other UI. For
 example, 'guicursor' sets the terminal cursor style if possible.
 
+						  *'term'* *E529* *E530* *E531*
+The 'term' option has a fixed value, present only for script compatibility and
+intentionally not the same as any known terminal type name.  It should be a
+rare case in Nvim where one needs |term-dependent-settings|, for which use the
+|TERM| environment variable.
+
 								*termcap*
 Nvim never uses the termcap database and only uses |terminfo|.  See
 |builtin-terms| for what happens on operating systems without a terminfo
@@ -346,7 +352,6 @@ Other options:
   'shelltype'
   *'shortname'* *'sn'* *'noshortname'* *'nosn'*
   *'swapsync'* *'sws'*
-  *'term'* *E529* *E530* *E531*
   *'termencoding'* *'tenc'* (Vim 7.4.852 also removed this for Windows)
   'textauto'
   'textmode'

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1544,7 +1544,10 @@ static void augment_terminfo(TUIData *data, const char *term,
   bool teraterm = terminfo_is_term_family(term, "teraterm");
   bool putty = terminfo_is_term_family(term, "putty");
   bool screen = terminfo_is_term_family(term, "screen");
+  bool tmux = terminfo_is_term_family(term, "tmux");
   bool st = terminfo_is_term_family(term, "st");
+  bool gnome = terminfo_is_term_family(term, "gnome")
+    || terminfo_is_term_family(term, "vte");
   bool iterm = terminfo_is_term_family(term, "iterm")
     || terminfo_is_term_family(term, "iTerm.app");
   // None of the following work over SSH; see :help TERM .
@@ -1575,8 +1578,11 @@ static void augment_terminfo(TUIData *data, const char *term,
   // fixup.  See https://gist.github.com/XVilka/8346728 for more about this.
   int Tc = unibi_find_ext_bool(ut, "Tc");
   // "standard" means using colons like ISO 8613-6:1994/ITU T.416:1993 says.
-  bool has_standard_rgb = vte_version >= 3600  // per GNOME bug #685759
+  bool has_standard_rgb = false
+    // per GNOME bug #685759 and bug #704449
+    || ((gnome || xterm) && (vte_version >= 3600))
     || iterm || iterm_pretending_xterm  // per analysis of VT100Terminal.m
+    // per http://invisible-island.net/xterm/xterm.log.html#xterm_282
     || true_xterm;
   bool has_non_standard_rgb = -1 != Tc
     // terminfo is definitive if it says something.
@@ -1585,6 +1591,8 @@ static void augment_terminfo(TUIData *data, const char *term,
     || konsole  // per commentary in VT102Emulation.cpp
     // per http://lists.schmorp.de/pipermail/rxvt-unicode/2016q2/002261.html
     || rxvt
+    || iterm    // per https://gitlab.com/gnachman/iterm2/issues/218
+    || tmux     // per experimentation
     || st       // per experimentation
     || old_truecolor_env;
   data->unibi_ext.set_rgb_foreground = unibi_find_ext_str(ut, "setrgbf");

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1591,7 +1591,6 @@ static void augment_terminfo(TUIData *data, const char *term,
     || konsole  // per commentary in VT102Emulation.cpp
     // per http://lists.schmorp.de/pipermail/rxvt-unicode/2016q2/002261.html
     || rxvt
-    || iterm    // per https://gitlab.com/gnachman/iterm2/issues/218
     || tmux     // per experimentation
     || st       // per experimentation
     || old_truecolor_env;


### PR DESCRIPTION
I had a final doco improvement that I forgot to push into #6816 .  This explains `term` and gives a more thorough example of how to deal with `termguicolors` following on from #6096 and given that #5089 is still a problem.

This also has a fix for #6982.