### PR TITLE
[RFC] tui: job-control: use saved termios for pty jobs

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -68,6 +68,9 @@
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/private/handle.h"
 #include "nvim/api/private/dispatch.h"
+#ifndef WIN32
+# include "nvim/os/pty_process_unix.h"
+#endif
 
 /* Maximum number of commands from + or -c arguments. */
 #define MAX_ARG_CMDS 10
@@ -1219,9 +1222,15 @@ static void init_startuptime(mparm_T *paramp)
 
 static void check_and_set_isatty(mparm_T *paramp)
 {
-  paramp->input_isatty = os_isatty(fileno(stdin));
-  paramp->output_isatty = os_isatty(fileno(stdout));
-  paramp->err_isatty = os_isatty(fileno(stderr));
+  paramp->input_isatty = os_isatty(OS_STDIN_FILENO);
+  paramp->output_isatty = os_isatty(OS_STDOUT_FILENO);
+  paramp->err_isatty = os_isatty(OS_STDERR_FILENO);
+  int tty_fd = paramp->input_isatty
+    ? OS_STDIN_FILENO
+    : (paramp->output_isatty
+       ? OS_STDOUT_FILENO
+       : (paramp->err_isatty ? OS_STDERR_FILENO : -1));
+  pty_process_save_termios(tty_fd);
   TIME_MSG("window checked");
 }
 

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -36,13 +36,27 @@
 # include "os/pty_process_unix.c.generated.h"
 #endif
 
+/// termios saved at startup (for TUI) or initialized by pty_process_spawn().
+static struct termios termios_default;
+
+/// Saves the termios properties associated with `tty_fd`.
+///
+/// @param tty_fd   TTY file descriptor, or -1 if not in a terminal.
+void pty_process_save_termios(int tty_fd)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (tty_fd == -1 || tcgetattr(tty_fd, &termios_default) != 0) {
+    return;
+  }
+}
+
 /// @returns zero on success, or negative error code
 int pty_process_spawn(PtyProcess *ptyproc)
   FUNC_ATTR_NONNULL_ALL
 {
-  static struct termios termios;
-  if (!termios.c_cflag) {
-    init_termios(&termios);
+  if (!termios_default.c_cflag) {
+    // TODO(jkeyes): We could pass NULL to forkpty() instead ...
+    init_termios(&termios_default);
   }
 
   int status = 0;  // zero or negative error code (libuv convention)
@@ -52,7 +66,7 @@ int pty_process_spawn(PtyProcess *ptyproc)
   ptyproc->winsize = (struct winsize){ ptyproc->height, ptyproc->width, 0, 0 };
   uv_disable_stdio_inheritance();
   int master;
-  int pid = forkpty(&master, NULL, &termios, &ptyproc->winsize);
+  int pid = forkpty(&master, NULL, &termios_default, &ptyproc->winsize);
 
   if (pid < 0) {
     status = -errno;


### PR DESCRIPTION
Related: #6938

The intention is to make `:terminal` more consistent with the user's actual terminal, to further eliminate "quirks". But this change also affects `jobstart(..., {'pty':v:true})`, not sure if that's a good idea.

On startup, if running in a terminal, save the termios properties.
Use the saved termios for `:terminal` and `jobstart()` pty jobs.

This won't affect nvim spawned outside of a terminal.

questions:

- This affects `:terminal` and `jobstart(..., {'pty':v:true})`.
  Should we be more conservative for `jobstart(..., {'pty':v:true})` (e.g.
  pass NULL to forkpty() and let the OS defaults prevail)?
  - Note: `iutf8` would not be set in that case.
- Ultimately we may need to provide options to let users control options on `jobstart(..., {'pty':v:true})` jobs, or at least a flag that controls whether termios is "inherited" or uses "sane defaults".

cc @bfredl @oni-link @jdebp @jamessan @hardenedapple 