### PR TITLE
[RFC]Vim 7.4.2250

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12451,7 +12451,7 @@ static void f_matchadd(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
   if (id >= 1 && id <= 3) {
-    EMSGN("E798: ID is reserved for \":match\": %" PRId64, id);
+    EMSGN(_("E798: ID is reserved for \":match\": %" PRId64), id);
     return;
   }
 
@@ -12508,7 +12508,7 @@ static void f_matchaddpos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
     // id == 3 is ok because matchaddpos() is supposed to substitute :3match 
     if (id == 1 || id == 2) {
-        EMSGN("E798: ID is reserved for \"match\": %" PRId64, id);
+        EMSGN(_("E798: ID is reserved for \"match\": %" PRId64), id);
         return;
     }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5023,8 +5023,9 @@ static void helptags_one(char_u *dir, char_u *ext, char_u *tagfname,
   if (gen_expand_wildcards(1, buff_list, &filecount, &files,
           EW_FILE|EW_SILENT) == FAIL
       || filecount == 0) {
-    if (!got_int)
+    if (!got_int) {
       EMSG2(_("E151: No match: %s"), NameBuff);
+    }
     return;
   }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5024,7 +5024,7 @@ static void helptags_one(char_u *dir, char_u *ext, char_u *tagfname,
           EW_FILE|EW_SILENT) == FAIL
       || filecount == 0) {
     if (!got_int)
-      EMSG2("E151: No match: %s", NameBuff);
+      EMSG2(_("E151: No match: %s"), NameBuff);
     return;
   }
 
@@ -5223,7 +5223,7 @@ static void do_helptags(char_u *dirname, bool add_help_tags)
   if (gen_expand_wildcards(1, buff_list, &filecount, &files,
                            EW_FILE|EW_SILENT) == FAIL
       || filecount == 0) {
-    EMSG2("E151: No match: %s", NameBuff);
+    EMSG2(_("E151: No match: %s"), NameBuff);
     xfree(dirname);
     return;
   }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2068,7 +2068,7 @@ char_u *did_set_spelllang(win_T *wp)
         // destroying the buffer we are using...
         if (!bufref_valid(&bufref)) {
           ret_msg =
-            (char_u *)"E797: SpellFileMissing autocommand deleted buffer";
+            (char_u *)N_("E797: SpellFileMissing autocommand deleted buffer");
           goto theend;
         }
       }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -194,7 +194,7 @@ static const int included_patches[] = {
   // 2253 NA
   // 2252 NA
   2251,
-  // 2250,
+  2250,
   2249,
   2248,
   // 2247 NA

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5532,8 +5532,8 @@ int match_add(win_T *wp, const char *const grp, const char *const pat,
     return -1;
   }
   if (id < -1 || id == 0) {
-    EMSGN("E799: Invalid ID: %" PRId64
-          " (must be greater than or equal to 1)",
+    EMSGN(_("E799: Invalid ID: %" PRId64
+          " (must be greater than or equal to 1)"),
           id);
     return -1;
   }
@@ -5541,7 +5541,7 @@ int match_add(win_T *wp, const char *const grp, const char *const pat,
     cur = wp->w_match_head;
     while (cur != NULL) {
       if (cur->id == id) {
-        EMSGN("E801: ID already taken: %" PRId64, id);
+        EMSGN(_("E801: ID already taken: %" PRId64), id);
         return -1;
       }
       cur = cur->next;
@@ -5706,8 +5706,8 @@ int match_delete(win_T *wp, int id, int perr)
 
   if (id < 1) {
     if (perr == TRUE)
-      EMSGN("E802: Invalid ID: %" PRId64
-            " (must be greater than or equal to 1)",
+      EMSGN(_("E802: Invalid ID: %" PRId64
+            " (must be greater than or equal to 1)"),
             id);
     return -1;
   }
@@ -5717,7 +5717,7 @@ int match_delete(win_T *wp, int id, int perr)
   }
   if (cur == NULL) {
     if (perr == TRUE)
-      EMSGN("E803: ID not found: %" PRId64, id);
+      EMSGN(_("E803: ID not found: %" PRId64), id);
     return -1;
   }
   if (cur == prev)

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5533,7 +5533,7 @@ int match_add(win_T *wp, const char *const grp, const char *const pat,
   }
   if (id < -1 || id == 0) {
     EMSGN(_("E799: Invalid ID: %" PRId64
-          " (must be greater than or equal to 1)"),
+            " (must be greater than or equal to 1)"),
           id);
     return -1;
   }
@@ -5705,10 +5705,11 @@ int match_delete(win_T *wp, int id, int perr)
   int rtype = SOME_VALID;
 
   if (id < 1) {
-    if (perr == TRUE)
+    if (perr) {
       EMSGN(_("E802: Invalid ID: %" PRId64
-            " (must be greater than or equal to 1)"),
+              " (must be greater than or equal to 1)"),
             id);
+    }
     return -1;
   }
   while (cur != NULL && cur->id != id) {
@@ -5716,8 +5717,9 @@ int match_delete(win_T *wp, int id, int perr)
     cur = cur->next;
   }
   if (cur == NULL) {
-    if (perr == TRUE)
+    if (perr) {
       EMSGN(_("E803: ID not found: %" PRId64), id);
+    }
     return -1;
   }
   if (cur == prev)


### PR DESCRIPTION
vim-patch:7.4.2250
    
    https://github.com/vim/vim/commit/5b30291785e6b9be1a607504c14bd03c601b59a6
    
    Author: Bram Moolenaar <Bram@vim.org>
    Date:   Wed Aug 24 22:11:55 2016 +0200
    
        patch 7.4.2250
        Problem:    Some error message cannot be translated.
        Solution:   Enclose them in _() and N_(). (Dominique Pelle)
