### PR TITLE
[RDY] vim-patch:7.4.2354

### DIFF
--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -3913,7 +3913,7 @@ addstate (
   int k;
   int found = FALSE;
   nfa_thread_T        *thread;
-  lpos_T save_lpos;
+  struct multipos     save_multipos;
   int save_in_use;
   char_u              *save_ptr;
   int i;
@@ -4127,15 +4127,13 @@ skip_add:
 
     /* avoid compiler warnings */
     save_ptr = NULL;
-    save_lpos.lnum = 0;
-    save_lpos.col = 0;
+    memset(&save_multipos, 0, sizeof(save_multipos));
 
     /* Set the position (with "off" added) in the subexpression.  Save
      * and restore it when it was in use.  Otherwise fill any gap. */
     if (REG_MULTI) {
       if (subidx < sub->in_use) {
-        save_lpos.lnum = sub->list.multi[subidx].start_lnum;
-        save_lpos.col = sub->list.multi[subidx].start_col;
+        save_multipos = sub->list.multi[subidx];
         save_in_use = -1;
       } else {
         save_in_use = sub->in_use;
@@ -4178,10 +4176,8 @@ skip_add:
       sub = &subs->norm;
 
     if (save_in_use == -1) {
-      if (REG_MULTI){
-        sub->list.multi[subidx].start_lnum = save_lpos.lnum;
-        sub->list.multi[subidx].start_col = save_lpos.col;
-      }
+      if (REG_MULTI)
+        sub->list.multi[subidx] = save_multipos;
       else
         sub->list.line[subidx].start = save_ptr;
     } else
@@ -4234,8 +4230,7 @@ skip_add:
     if (sub->in_use <= subidx)
       sub->in_use = subidx + 1;
     if (REG_MULTI) {
-      save_lpos.lnum = sub->list.multi[subidx].end_lnum;
-      save_lpos.col = sub->list.multi[subidx].end_col;
+      save_multipos = sub->list.multi[subidx];
       if (off == -1) {
         sub->list.multi[subidx].end_lnum = reglnum + 1;
         sub->list.multi[subidx].end_col = 0;
@@ -4250,8 +4245,7 @@ skip_add:
       save_ptr = sub->list.line[subidx].end;
       sub->list.line[subidx].end = reginput + off;
       /* avoid compiler warnings */
-      save_lpos.lnum = 0;
-      save_lpos.col = 0;
+      memset(&save_multipos, 0, sizeof(save_multipos));
     }
 
     subs = addstate(l, state->out, subs, pim, off_arg);
@@ -4261,10 +4255,8 @@ skip_add:
     else
       sub = &subs->norm;
 
-    if (REG_MULTI){
-      sub->list.multi[subidx].end_lnum = save_lpos.lnum;
-      sub->list.multi[subidx].end_col = save_lpos.col;
-    }
+    if (REG_MULTI)
+      sub->list.multi[subidx] = save_multipos;
     else
       sub->list.line[subidx].end = save_ptr;
     sub->in_use = save_in_use;

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -1,0 +1,14 @@
+func Test_nested_backrefs()
+  " Check example in change.txt.
+  new
+  for re in range(0, 2)
+    exe 'set re=' . re
+    call setline(1, 'aa ab x')
+    1s/\(\(a[a-d] \)*\)\(x\)/-\1- -\2- -\3-/
+    call assert_equal('-aa ab - -ab - -x-', getline(1))
+
+    call assert_equal('-aa ab - -ab - -x-', substitute('aa ab x', '\(\(a[a-d] \)*\)\(x\)', '-\1- -\2- -\3-', ''))
+  endfor
+  bwipe!
+  set re=0
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -90,7 +90,7 @@ static const int included_patches[] = {
   2357,
   2356,
   2355,
-  // 2354,
+  2354,
   2353,
   // 2352 NA
   // 2351 NA


### PR DESCRIPTION
Problem:    The example that explains nested backreferences does not work
            properly with the new regexp engine. (Harm te Hennepe)
Solution:   Also save the end position when adding a state. (closes vim/vim#990)

https://github.com/vim/vim/commit/d563883a1fb5ec6cf4a2758c5e36ac1ff4e9bb3d