### PR TITLE
[RDY] Fix incorrect DECSCUSR fixup codes

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1268,7 +1268,7 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
   bool teraterm = terminfo_is_term_family(term, "teraterm");
   bool putty = terminfo_is_term_family(term, "putty");
   bool screen = terminfo_is_term_family(term, "screen");
-  bool tmux = terminfo_is_term_family(term, "tmux");
+  bool tmux = terminfo_is_term_family(term, "tmux") || !!os_getenv("TMUX");
   bool st = terminfo_is_term_family(term, "st");
   bool gnome = terminfo_is_term_family(term, "gnome")
     || terminfo_is_term_family(term, "vte");
@@ -1282,7 +1282,6 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
   bool mate_pretending_xterm = xterm && colorterm
     && strstr(colorterm, "mate-terminal");
   bool true_xterm = xterm && !!xterm_version;
-  bool tmux_pretending_screen = screen && !!os_getenv("TMUX");
 
   char *fix_normal = (char *)unibi_get_str(ut, unibi_cursor_normal);
   if (fix_normal) {
@@ -1359,7 +1358,7 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     // per the screen manual; 2017-04 terminfo.src lacks these.
     unibi_set_if_empty(ut, unibi_to_status_line, "\x1b_");
     unibi_set_if_empty(ut, unibi_from_status_line, "\x1b\\");
-  } else if (terminfo_is_term_family(term, "tmux")) {
+  } else if (tmux) {
     unibi_set_if_empty(ut, unibi_to_status_line, "\x1b_");
     unibi_set_if_empty(ut, unibi_from_status_line, "\x1b\\");
   } else if (terminfo_is_term_family(term, "interix")) {
@@ -1415,7 +1414,7 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     } else if (konsole || xterm || gnome || rxvt || st || putty
         || linuxvt  // Linux 4.8+ supports 256-colour SGR.
         || mate_pretending_xterm || gnome_pretending_xterm
-        || tmux || tmux_pretending_screen
+        || tmux
         || (colorterm && strstr(colorterm, "256"))
         || (term && strstr(term, "256"))
         ) {
@@ -1458,6 +1457,7 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
         || (vte_version >= 3900)
         // per tmux manual page and per
         // https://lists.gnu.org/archive/html/screen-devel/2013-03/msg00000.html
+        || tmux
         || screen
         || rxvt       // per command.C
         // per analysis of VT100Terminal.m

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1434,19 +1434,16 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     }
   }
 
-  // Dickey ncurses terminfo has included the Ss and Se capabilities, pioneered
-  // by tmux, since 2011-07-14.  So adding them to terminal types, that do
-  // actually have such control sequences but lack the correct definitions in
-  // terminfo, is a fixup, not an augmentation.
-  data->unibi_ext.reset_cursor_style = unibi_find_ext_str(ut, "Se");
-  data->unibi_ext.set_cursor_style = unibi_find_ext_str(ut, "Ss");
-
   // Some terminals can not currently be trusted to report if they support
   // DECSCUSR or not. So we need to have a blacklist for when we should not
   // trust the reported features.
   if( (vte_version != 0 && vte_version < 3900) || konsole ) {
-    data->unibi_ext.reset_cursor_style = -1;
-    data->unibi_ext.set_cursor_style = -1;
+    // Dickey ncurses terminfo has included the Ss and Se capabilities,
+    // pioneered by tmux, since 2011-07-14. So adding them to terminal types,
+    // that do actually have such control sequences but lack the correct
+    // definitions in terminfo, is a fixup, not an augmentation.
+    data->unibi_ext.reset_cursor_style = unibi_find_ext_str(ut, "Se");
+    data->unibi_ext.set_cursor_style = unibi_find_ext_str(ut, "Ss");
   }
   if (-1 == data->unibi_ext.set_cursor_style) {
     // The DECSCUSR sequence to change the cursor shape is widely

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1493,9 +1493,9 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
           // possible to have a steady block (no steady underline)
           "%p1%{2}%<" "%t%{8}"    // blink block
           "%e%p1%{2}%=" "%t%{112}"   // steady block
-          "%e%p1%{3}%=" "%t%{4}"    // blink underline
+          "%e%p1%{3}%=" "%t%{4}"    // blink underline (set to half block)
           "%e%p1%{4}%=" "%t%{4}"   // steady underline
-          "%e%p1%{5}%=" "%t%{2}"    // blink bar (there is no bar cursor shape)
+          "%e%p1%{5}%=" "%t%{2}"    // blink bar (set to underline)
           "%e%p1%{6}%=" "%t%{2}"   // steady bar
           "%e%{0}"                // anything else
           "%;" "%dc");
@@ -1513,7 +1513,7 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
       data->unibi_ext.set_cursor_style = (int)unibi_add_ext_str(ut, "Ss",
           TMUX_WRAP(tmux, "\x1b]50;CursorShape=%?"
           "%p1%{3}%<" "%t%{0}"    // block
-          "%e%p1%{4}%<" "%t%{2}"  // underline
+          "%e%p1%{5}%<" "%t%{2}"  // underline
           "%e%{1}"                // everything else is bar
           "%;%d;BlinkingCursorEnabled=%?"
           "%p1%{1}%<" "%t%{1}"  // Fortunately if we exclude zero as special,

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1434,21 +1434,21 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     }
   }
 
-  // Some terminals can not currently be trusted to report if they support
-  // DECSCUSR or not. So we need to have a blacklist for when we should not
-  // trust the reported features.
-  bool not_trustworthy = false;
-  if( (vte_version != 0 && vte_version < 3900) || konsole ) {
-    not_trustworthy = true;
-  }
-
   // Dickey ncurses terminfo has included the Ss and Se capabilities, pioneered
   // by tmux, since 2011-07-14.  So adding them to terminal types, that do
   // actually have such control sequences but lack the correct definitions in
   // terminfo, is a fixup, not an augmentation.
   data->unibi_ext.reset_cursor_style = unibi_find_ext_str(ut, "Se");
   data->unibi_ext.set_cursor_style = unibi_find_ext_str(ut, "Ss");
-  if (-1 == data->unibi_ext.set_cursor_style || not_trustworthy) {
+
+  // Some terminals can not currently be trusted to report if they support
+  // DECSCUSR or not. So we need to have a blacklist for when we should not
+  // trust the reported features.
+  if( (vte_version != 0 && vte_version < 3900) || konsole ) {
+    data->unibi_ext.reset_cursor_style = -1;
+    data->unibi_ext.set_cursor_style = -1;
+  }
+  if (-1 == data->unibi_ext.set_cursor_style) {
     // The DECSCUSR sequence to change the cursor shape is widely
     // supported by several terminal types and should be in many
     // teminfo entries.  See

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1473,18 +1473,22 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     } else if (linuxvt) {
       // Linux uses an idiosyncratic escape code to set the cursor shape and
       // does not support DECSCUSR.
+      // See http://linuxgazette.net/137/anonymous.html for more info
       data->unibi_ext.set_cursor_style = (int)unibi_add_ext_str(ut, "Ss",
           "\x1b[?"
           "%?"
           // The parameter passed to Ss is the DECSCUSR parameter, so the
           // terminal capability has to translate into the Linux idiosyncratic
           // parameter.
+          //
+          // linuxvt only supports block and underline. It is also only
+          // possible to have a steady block (no steady underline)
           "%p1%{2}%<" "%t%{8}"    // blink block
-          "%p1%{2}%=" "%t%{24}"   // steady block
-          "%p1%{3}%=" "%t%{1}"    // blink underline
-          "%p1%{4}%=" "%t%{17}"   // steady underline
-          "%p1%{5}%=" "%t%{1}"    // blink bar
-          "%p1%{6}%=" "%t%{17}"   // steady bar
+          "%e%p1%{2}%=" "%t%{112}"   // steady block
+          "%e%p1%{3}%=" "%t%{4}"    // blink underline
+          "%e%p1%{4}%=" "%t%{4}"   // steady underline
+          "%e%p1%{5}%=" "%t%{2}"    // blink bar (there is no bar cursor shape)
+          "%e%p1%{6}%=" "%t%{2}"   // steady bar
           "%e%{0}"                // anything else
           "%;" "%dc");
       if (-1 == data->unibi_ext.reset_cursor_style) {

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1434,13 +1434,21 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     }
   }
 
+  // Some terminals can not currently be trusted to report if they support
+  // DECSCUSR or not. So we need to have a blacklist for when we should not
+  // trust the reported features.
+  bool not_trustworthy = false;
+  if( (vte_version != 0 && vte_version < 3900) || konsole ) {
+    not_trustworthy = true;
+  }
+
   // Dickey ncurses terminfo has included the Ss and Se capabilities, pioneered
   // by tmux, since 2011-07-14.  So adding them to terminal types, that do
   // actually have such control sequences but lack the correct definitions in
   // terminfo, is a fixup, not an augmentation.
   data->unibi_ext.reset_cursor_style = unibi_find_ext_str(ut, "Se");
   data->unibi_ext.set_cursor_style = unibi_find_ext_str(ut, "Ss");
-  if (-1 == data->unibi_ext.set_cursor_style || konsole) {
+  if (-1 == data->unibi_ext.set_cursor_style || not_trustworthy) {
     // The DECSCUSR sequence to change the cursor shape is widely
     // supported by several terminal types and should be in many
     // teminfo entries.  See

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1437,7 +1437,7 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
   // Some terminals can not currently be trusted to report if they support
   // DECSCUSR or not. So we need to have a blacklist for when we should not
   // trust the reported features.
-  if( (vte_version != 0 && vte_version < 3900) || konsole ) {
+  if( !((vte_version != 0 && vte_version < 3900) || konsole ) ) {
     // Dickey ncurses terminfo has included the Ss and Se capabilities,
     // pioneered by tmux, since 2011-07-14. So adding them to terminal types,
     // that do actually have such control sequences but lack the correct

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1440,7 +1440,7 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
   // terminfo, is a fixup, not an augmentation.
   data->unibi_ext.reset_cursor_style = unibi_find_ext_str(ut, "Se");
   data->unibi_ext.set_cursor_style = unibi_find_ext_str(ut, "Ss");
-  if (-1 == data->unibi_ext.set_cursor_style) {
+  if (-1 == data->unibi_ext.set_cursor_style || konsole) {
     // The DECSCUSR sequence to change the cursor shape is widely
     // supported by several terminal types and should be in many
     // teminfo entries.  See
@@ -1503,14 +1503,14 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
       // nonce profile, which has side-effects on temporary font resizing.
       // In an ideal world, Konsole would just support DECSCUSR.
       data->unibi_ext.set_cursor_style = (int)unibi_add_ext_str(ut, "Ss",
-          "\x1b]50;CursorShape=%?"
+          TMUX_WRAP(tmux, "\x1b]50;CursorShape=%?"
           "%p1%{3}%<" "%t%{0}"    // block
           "%e%p1%{4}%<" "%t%{2}"  // underline
           "%e%{1}"                // everything else is bar
           "%;%d;BlinkingCursorEnabled=%?"
           "%p1%{1}%<" "%t%{1}"  // Fortunately if we exclude zero as special,
           "%e%p1%{1}%&"  // in all other cases we can treat bit #0 as a flag.
-          "%;%d\x07");
+          "%;%d\x07"));
       if (-1 == data->unibi_ext.reset_cursor_style) {
           data->unibi_ext.reset_cursor_style = (int)unibi_add_ext_str(ut, "Se",
               "");


### PR DESCRIPTION
After some testing and reading changelogs from screen/tmux and mintty, I don't know what the previous code tried to do. It broke VTE terminals that did not lie and say they were xterm and it also broke tmux.

To me it seems like all the terminals that should have DECSCUSR support in the previous if statments should and is changing cursor shape with simply `"\x1b[%p1%d q"`. Nothing else is really needed here...

This fixed #6978 for me.
closes https://github.com/neovim/neovim/issues/7002