### PR TITLE
Fix clang warnings with glibc 2.25

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1328,7 +1328,7 @@ static int utf_strnicmp(const char_u *s1, const char_u *s2, size_t n1,
 #endif
 
 /// Reassigns `strw` to a new, allocated pointer to a UTF16 string.
-int utf8_to_utf16(const char *str, WCHAR **strw)
+int utf8_to_utf16(const char *str, wchar_t **strw)
   FUNC_ATTR_NONNULL_ALL
 {
   ssize_t wchar_len = 0;
@@ -1344,7 +1344,7 @@ int utf8_to_utf16(const char *str, WCHAR **strw)
     return GetLastError();
   }
 
-  ssize_t buf_sz = wchar_len * sizeof(WCHAR);
+  ssize_t buf_sz = wchar_len * sizeof(wchar_t);
 
   if (buf_sz == 0) {
     *strw = NULL;
@@ -1358,19 +1358,19 @@ int utf8_to_utf16(const char *str, WCHAR **strw)
                               0,
                               str,
                               -1,
-                              (WCHAR *)pos,
+                              (wchar_t *)pos,
                               wchar_len);
   assert(r == wchar_len);
   if (r != wchar_len) {
     EMSG2("MultiByteToWideChar failed: %d", r);
   }
-  *strw = (WCHAR *)pos;
+  *strw = (wchar_t *)pos;
 
   return 0;
 }
 
 /// Reassigns `str` to a new, allocated pointer to a UTF8 string.
-int utf16_to_utf8(const WCHAR *strw, char **str)
+int utf16_to_utf8(const wchar_t *strw, char **str)
   FUNC_ATTR_NONNULL_ALL
 {
   // Compute the space required to store the string as UTF-8.
@@ -2201,7 +2201,7 @@ HINSTANCE vimLoadLib(char *name)
 
   // NOTE: Do not use mch_dirname() and mch_chdir() here, they may call
   //       vimLoadLib() recursively, which causes a stack overflow.
-  WCHAR old_dirw[MAXPATHL];
+  wchar_t old_dirw[MAXPATHL];
 
   // Path to exe dir.
   char *buf = xstrdup((char *)get_vim_var_str(VV_PROGPATH));

--- a/src/nvim/mbyte.h
+++ b/src/nvim/mbyte.h
@@ -7,8 +7,8 @@
 
 #include "nvim/iconv.h"
 #include "nvim/func_attr.h"
-#include "nvim/os/os_defs.h"  // For WCHAR, indirect
-#include "nvim/types.h" // for char_u
+#include "nvim/os/os_defs.h"  // For indirect
+#include "nvim/types.h"  // for char_u
 
 /*
  * Return byte length of character that starts with byte "b".

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -56,7 +56,7 @@ int os_setenv(const char *name, const char *value, int overwrite)
   char *envbuf = xmalloc(envbuflen);
   snprintf(envbuf, envbuflen, "%s=%s", name, value);
 
-  WCHAR *p;
+  wchar_t *p;
   utf8_to_utf16(envbuf, &p);
   xfree(envbuf);
   if (p == NULL) {
@@ -146,7 +146,7 @@ void os_get_hostname(char *hostname, size_t size)
     xstrlcpy(hostname, vutsname.nodename, size);
   }
 #elif defined(WIN32)
-  WCHAR host_utf16[MAX_COMPUTERNAME_LENGTH + 1];
+  wchar_t host_utf16[MAX_COMPUTERNAME_LENGTH + 1];
   DWORD host_wsize = sizeof(host_utf16) / sizeof(host_utf16[0]);
   if (GetComputerNameW(host_utf16, &host_wsize) == 0) {
     *hostname = '\0';

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -1052,7 +1052,7 @@ char *os_resolve_shortcut(const char *fname)
   hr = CoCreateInstance(&CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER,
                         &IID_IShellLinkW, (void **)&pslw);
   if (hr == S_OK) {
-    WCHAR *p;
+    wchar_t *p;
     const int conversion_result = utf8_to_utf16(fname, &p);
     if (conversion_result != 0) {
       EMSG2("utf8_to_utf16 failed: %d", conversion_result);
@@ -1080,7 +1080,7 @@ char *os_resolve_shortcut(const char *fname)
 #  endif
 
       // Get the path to the link target.
-      ZeroMemory(wsz, MAX_PATH * sizeof(WCHAR));
+      ZeroMemory(wsz, MAX_PATH * sizeof(wchar_t));
       hr = pslw->lpVtbl->GetPath(pslw, wsz, MAX_PATH, &ffdw, 0);
       if (hr == S_OK && wsz[0] != NUL) {
         const int conversion_result = utf16_to_utf8(wsz, &rfname);


### PR DESCRIPTION
When building with `-pedantic` (as neovim does),
clang complains about how `assert()` - among other things - is defined.
The Clang devs say that this is a glibc issue; see the thread at
http://lists.llvm.org/pipermail/cfe-dev/2017-April/053382.html for all
the fun details.

At any rate, these problems go away when building with `-std=c99`
instead of `-std=gnu99`. When doing so, `-D_DEFAULT_SOURCE` is also
needed. See:
http://man7.org/linux/man-pages/man7/feature_test_macros.7.html
https://github.com/neovim/neovim/issues/4042
https://github.com/libuv/libuv/issues/891

As a side note, if we do define `-D_DEFAULT_SOURCE`, is
https://github.com/neovim/neovim/pull/4094 still needed?