### PR TITLE
[RFC] Fix up truecolor support

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1377,14 +1377,21 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     // No bugs in the vanilla terminfo for our purposes.
   }
 
-#define XTERM_SETAF_256 \
+// At this time (2017-07-12) it seems like all terminals that support 256
+// color codes can use semicolons in the terminal code and be fine.
+// However, this is not correct according to the spec. So to reward those
+// terminals that also support colons, we output the code that way on these
+// specific ones.
+
+// using colons like ISO 8613-6:1994/ITU T.416:1993 says.
+#define XTERM_SETAF_256_COLON \
   "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38:5:%p1%d%;m"
-#define XTERM_SETAB_256 \
+#define XTERM_SETAB_256_COLON \
   "\x1b[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e48:5:%p1%d%;m"
-  // "standard" means using colons like ISO 8613-6:1994/ITU T.416:1993 says.
-#define XTERM_SETAF_256_NONSTANDARD \
+
+#define XTERM_SETAF_256 \
   "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m"
-#define XTERM_SETAB_256_NONSTANDARD \
+#define XTERM_SETAB_256 \
   "\x1b[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e48;5;%p1%d%;m"
 #define XTERM_SETAF_16 \
   "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e39%;m"
@@ -1398,8 +1405,8 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     // more on this.
     if (true_xterm || iterm || iterm_pretending_xterm) {
       unibi_set_num(ut, unibi_max_colors, 256);
-      unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF_256);
-      unibi_set_str(ut, unibi_set_a_background, XTERM_SETAB_256);
+      unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF_256_COLON);
+      unibi_set_str(ut, unibi_set_a_background, XTERM_SETAB_256_COLON);
     } else if (konsole || xterm || gnome || rxvt || st || putty
         || linuxvt  // Linux 4.8+ supports 256-colour SGR.
         || mate_pretending_xterm || gnome_pretending_xterm
@@ -1408,8 +1415,8 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
         || (term && strstr(term, "256"))
         ) {
       unibi_set_num(ut, unibi_max_colors, 256);
-      unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF_256_NONSTANDARD);
-      unibi_set_str(ut, unibi_set_a_background, XTERM_SETAB_256_NONSTANDARD);
+      unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF_256);
+      unibi_set_str(ut, unibi_set_a_background, XTERM_SETAB_256);
     }
   }
   // Terminals where there is actually 16-colour SGR support despite what
@@ -1555,8 +1562,14 @@ static void augment_terminfo(TUIData *data, const char *term,
   // them to terminal types, that do actually have such control sequences but
   // lack the correct definitions in terminfo, is an augmentation, not a
   // fixup.  See https://gist.github.com/XVilka/8346728 for more about this.
-  int Tc = unibi_find_ext_bool(ut, "Tc");
-  // means using colons like ISO 8613-6:1994/ITU T.416:1993 says.
+
+  // At this time (2017-07-12) it seems like all terminals that support rgb
+  // color codes can use semicolons in the terminal code and be fine.
+  // However, this is not correct according to the spec. So to reward those
+  // terminals that also support colons, we output the code that way on these
+  // specific ones.
+
+  // can use colons like ISO 8613-6:1994/ITU T.416:1993 says.
   bool has_colon_rgb = false
     // per GNOME bug #685759 and bug #704449
     || ((gnome || xterm) && (vte_version >= 3600))

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1543,6 +1543,9 @@ static void augment_terminfo(TUIData *data, const char *term,
   bool iterm_pretending_xterm = xterm && iterm_env;
   bool tmux_wrap = screen && !!os_getenv("TMUX");
 
+  const char * xterm_version = os_getenv("XTERM_VERSION");
+  bool true_xterm = xterm && !!xterm_version;
+
   // Only define this capability for terminal types that we know understand it.
   if (dtterm         // originated this extension
       || xterm       // per xterm ctlseqs doco
@@ -1572,7 +1575,7 @@ static void augment_terminfo(TUIData *data, const char *term,
   // can use colons like ISO 8613-6:1994/ITU T.416:1993 says.
   bool has_colon_rgb = false
     // per GNOME bug #685759 and bug #704449
-    || ((gnome || xterm) && (vte_version >= 3600))
+    || (vte_version >= 3600)
     || iterm || iterm_pretending_xterm  // per analysis of VT100Terminal.m
     // per http://invisible-island.net/xterm/xterm.log.html#xterm_282
     || true_xterm;

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1236,18 +1236,6 @@ static int unibi_find_ext_str(unibi_term *ut, const char *name)
   return -1;
 }
 
-static int unibi_find_ext_bool(unibi_term *ut, const char *name)
-{
-  size_t max = unibi_count_ext_bool(ut);
-  for (size_t i = 0; i < max; i++) {
-    const char * n = unibi_get_ext_bool_name(ut, i);
-    if (n && 0 == strcmp(n, name)) {
-      return (int)i;
-    }
-  }
-  return -1;
-}
-
 /// Several entries in terminfo are known to be deficient or outright wrong,
 /// unfortunately; and several terminal emulators falsely announce incorrect
 /// terminal types.  So patch the terminfo records after loading from an

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1378,8 +1378,13 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
   }
 
 #define XTERM_SETAF_256 \
-  "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m"
+  "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38:5:%p1%d%;m"
 #define XTERM_SETAB_256 \
+  "\x1b[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e48:5:%p1%d%;m"
+  // "standard" means using colons like ISO 8613-6:1994/ITU T.416:1993 says.
+#define XTERM_SETAF_256_NONSTANDARD \
+  "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m"
+#define XTERM_SETAB_256_NONSTANDARD \
   "\x1b[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e48;5;%p1%d%;m"
 #define XTERM_SETAF_16 \
   "\x1b[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e39%;m"
@@ -1391,15 +1396,11 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
   if (unibi_get_num(ut, unibi_max_colors) < 256) {
     // See http://fedoraproject.org/wiki/Features/256_Color_Terminals for
     // more on this.
-    if (true_xterm
-        || iterm
-        || iterm_pretending_xterm
-        || konsole
-        || xterm
-        || gnome
-        || rxvt
-        || st
-        || putty
+    if (true_xterm || iterm || iterm_pretending_xterm) {
+      unibi_set_num(ut, unibi_max_colors, 256);
+      unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF_256);
+      unibi_set_str(ut, unibi_set_a_background, XTERM_SETAB_256);
+    } else if (konsole || xterm || gnome || rxvt || st || putty
         || linuxvt  // Linux 4.8+ supports 256-colour SGR.
         || mate_pretending_xterm || gnome_pretending_xterm
         || tmux || tmux_pretending_screen
@@ -1407,8 +1408,8 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
         || (term && strstr(term, "256"))
         ) {
       unibi_set_num(ut, unibi_max_colors, 256);
-      unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF_256);
-      unibi_set_str(ut, unibi_set_a_background, XTERM_SETAB_256);
+      unibi_set_str(ut, unibi_set_a_foreground, XTERM_SETAF_256_NONSTANDARD);
+      unibi_set_str(ut, unibi_set_a_background, XTERM_SETAB_256_NONSTANDARD);
     }
   }
   // Terminals where there is actually 16-colour SGR support despite what
@@ -1554,22 +1555,31 @@ static void augment_terminfo(TUIData *data, const char *term,
   // them to terminal types, that do actually have such control sequences but
   // lack the correct definitions in terminfo, is an augmentation, not a
   // fixup.  See https://gist.github.com/XVilka/8346728 for more about this.
-
-  // Black list for known terminals that do not support rbg codes
-  bool has_no_rgb = false
+  int Tc = unibi_find_ext_bool(ut, "Tc");
+  // means using colons like ISO 8613-6:1994/ITU T.416:1993 says.
+  bool has_colon_rgb = false
     // per GNOME bug #685759 and bug #704449
-    || ((vte_version != 0) && (vte_version < 3600));
+    || ((gnome || xterm) && (vte_version >= 3600))
+    || iterm || iterm_pretending_xterm  // per analysis of VT100Terminal.m
+    // per http://invisible-island.net/xterm/xterm.log.html#xterm_282
+    || true_xterm;
 
   data->unibi_ext.set_rgb_foreground = unibi_find_ext_str(ut, "setrgbf");
   if (-1 == data->unibi_ext.set_rgb_foreground) {
-    if (!has_no_rgb) {
+    if (has_colon_rgb) {
+      data->unibi_ext.set_rgb_foreground = (int)unibi_add_ext_str(ut, "setrgbf",
+          "\x1b[38:2:%p1%d:%p2%d:%p3%dm");
+    } else {
       data->unibi_ext.set_rgb_foreground = (int)unibi_add_ext_str(ut, "setrgbf",
           "\x1b[38;2;%p1%d;%p2%d;%p3%dm");
     }
   }
   data->unibi_ext.set_rgb_background = unibi_find_ext_str(ut, "setrgbb");
   if (-1 == data->unibi_ext.set_rgb_background) {
-    if (!has_no_rgb) {
+    if (has_colon_rgb) {
+      data->unibi_ext.set_rgb_background = (int)unibi_add_ext_str(ut, "setrgbb",
+          "\x1b[48:2:%p1%d:%p2%d:%p3%dm");
+    } else {
       data->unibi_ext.set_rgb_background = (int)unibi_add_ext_str(ut, "setrgbb",
           "\x1b[48;2;%p1%d;%p2%d;%p3%dm");
     }

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1538,18 +1538,14 @@ static void augment_terminfo(TUIData *data, const char *term,
   const char * xterm_version = os_getenv("XTERM_VERSION");
   bool xterm = terminfo_is_term_family(term, "xterm");
   bool dtterm = terminfo_is_term_family(term, "dtterm");
-  bool linuxvt = terminfo_is_term_family(term, "linux");
   bool rxvt = terminfo_is_term_family(term, "rxvt");
   bool teraterm = terminfo_is_term_family(term, "teraterm");
   bool putty = terminfo_is_term_family(term, "putty");
   bool screen = terminfo_is_term_family(term, "screen");
-  bool gnome = terminfo_is_term_family(term, "gnome")
-    || terminfo_is_term_family(term, "vte");
   bool iterm = terminfo_is_term_family(term, "iterm")
     || terminfo_is_term_family(term, "iTerm.app");
   // None of the following work over SSH; see :help TERM .
   bool iterm_pretending_xterm = xterm && iterm_env;
-  bool true_xterm = xterm && !!xterm_version;
   bool tmux_wrap = screen && !!os_getenv("TMUX");
 
   // Only define this capability for terminal types that we know understand it.
@@ -1598,7 +1594,9 @@ static void augment_terminfo(TUIData *data, const char *term,
     // would use a tmux control sequence and an extra if(screen) test.
     data->unibi_ext.set_cursor_color = (int)unibi_add_ext_str(
         ut, NULL, TMUX_WRAP(tmux_wrap, "\033]Pl%p1%06x\033\\"));
-  } else if (xterm) {
+  } else if (xterm || (vte_version != 0) || rxvt) {
+    // This seems to be supported for a long time in VTE
+    // urxvt also supports this
     data->unibi_ext.set_cursor_color = (int)unibi_add_ext_str(
         ut, NULL, "\033]12;#%p1%06x\007");
   }

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1535,7 +1535,6 @@ static void augment_terminfo(TUIData *data, const char *term,
     const char *colorterm, long vte_version, bool konsole, bool iterm_env)
 {
   unibi_term *ut = data->ut;
-  const char * xterm_version = os_getenv("XTERM_VERSION");
   bool xterm = terminfo_is_term_family(term, "xterm");
   bool dtterm = terminfo_is_term_family(term, "dtterm");
   bool rxvt = terminfo_is_term_family(term, "rxvt");


### PR DESCRIPTION
Closes https://github.com/neovim/neovim/issues/7003

This pull requests are two parts.

1. Don't be overly strict about true color 

Because there is not standard way to tell if a terminal supports truecolor (and it doesn't seem like there will be in the near future), I think it would be better to have a blacklist instead of a whitelist for terminals that  is known not to work.

However this blacklist will be quite short as most terminals lies about being xterm which supports truecolor. So currently I have only black listed older versions of VTE that did not support true color.

I think that this is a good solution still because our true color mode is not on by default and the user has to manually switch it on in their config. So I don't see the point of begin overly strict about toggling it on if the users wants it.

2. Not having two code paths for colons/semicolons in the terminal color codes.

As one can see here:
https://gist.github.com/XVilka/8346728

All terminals that support true color, supports having semicolons in the code. However some does also support colons.

If I understand this correctly, then the push for colons was because it would be more future proof so one could easily extend the code from RGB to CMYK and not break other terminals that only supported RGB. That is, those RGB only terminals would notice that the CMYK sequence was not something they supported and would just silently eat the code (no garbage on screen).

However, if we look at how different terminal applications have implemented true color support, you notice that most if not all only have one code path, and that is for semicolons.

It is now nearly 3 years since the true color codes started to gain foothold and got adoptend into terminals and terminal programs. Looking at how it looks now colon/semicolon wise, I think it is safe to say that semicolons (even if they might not be the best thing) is now the de facto standard.

I think it over complicates the code to have these two different color code styles. It also does not bring anything new to the table. They are just two code paths that does the exact same thing and you can safely remove one of them and it will still work.

So I propose the removal of these. At least until they provide any new functionality that the terminals that supports them can use.