### PR TITLE
[RFC] vim-patch:8.0.0003

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7039,8 +7039,11 @@ dict_T *get_winbuf_options(const int bufopt)
         if (opt->flags & P_STRING) {
           tv_dict_add_str(d, opt->fullname, strlen(opt->fullname),
                           *(const char **)varp);
+        } else if (opt->flags & P_NUM) {
+          tv_dict_add_nr(d, opt->fullname, strlen(opt->fullname),
+                         *(long *)varp);
         } else {
-          tv_dict_add_nr(d, opt->fullname, strlen(opt->fullname), *varp);
+          tv_dict_add_nr(d, opt->fullname, strlen(opt->fullname), *(int *)varp);
         }
       }
     }

--- a/src/nvim/testdir/test_bufwintabinfo.vim
+++ b/src/nvim/testdir/test_bufwintabinfo.vim
@@ -87,9 +87,17 @@ function Test_get_buf_options()
 endfunc
 
 function Test_get_win_options()
+  if has('folding')
+    set foldlevel=999
+  endif
+  set list
   let opts = getwinvar(1, '&')
   call assert_equal(v:t_dict, type(opts))
   call assert_equal(0, opts.linebreak)
+  call assert_equal(1, opts.list)
+  if has('folding')
+    call assert_equal(999, opts.foldlevel)
+  endif
   if has('signs')
     call assert_equal('auto', opts.signcolumn)
   endif
@@ -97,7 +105,12 @@ function Test_get_win_options()
   let opts = gettabwinvar(1, 1, '&')
   call assert_equal(v:t_dict, type(opts))
   call assert_equal(0, opts.linebreak)
+  call assert_equal(1, opts.list)
   if has('signs')
     call assert_equal('auto', opts.signcolumn)
+  endif
+  set list&
+  if has('folding')
+    set foldlevel=0
   endif
 endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -726,7 +726,7 @@ static const int included_patches[] = {
   6,
   // 5 NA
   4,
-  // 3,
+  3,
   2,
   1,
   0


### PR DESCRIPTION
Problem:    getwinvar() returns wrong Value of boolean and number options,
            especially non big endian systems. (James McCoy)
Solution:   Cast the pointer to long or int. (closes vim/vim#1060)

https://github.com/vim/vim/commit/789a5c0e3d27f09456678f0cfb6c1bd2d8ab4a35