### PR TITLE
test: mouse_spec: remove obnoxious wait times

### DIFF
--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -13,9 +13,6 @@ describe('ui/mouse/input', function()
     clear()
     meths.set_option('mouse', 'a')
     meths.set_option('listchars', 'eol:$')
-    -- set mousetime to very high value to ensure that even in valgrind/travis,
-    -- nvim will still pick multiple clicks
-    meths.set_option('mousetime', 5000)
     screen = Screen.new(25, 5)
     screen:attach()
     screen:set_default_attr_ids({
@@ -119,7 +116,6 @@ describe('ui/mouse/input', function()
         sel  = { bold=true },
         fill = { reverse=true }
       })
-      screen.timeout = 15000
     end)
 
     it('in tabline on filler space moves tab to the end', function()


### PR DESCRIPTION
helpers.skip_fragile() already skips the problematic tests
on the ASan build. But the 15s timeout plus 5s 'mousetime'
cause the tests to take 1+ minutes anyways.