### PR TITLE
[WIP] win: provider/clipboard.vim: avoid invalid CWD error on WSL

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -8,6 +8,8 @@ let s:paste = {}
 " ownership of the selection, so we know how long the cache is valid.
 let s:selection = { 'owner': 0, 'data': [] }
 
+let s:win_wsl = (system(['uname', '-a']) =~? 'Windows')
+
 function! s:selection.on_exit(jobid, data, event) abort
   " At this point this nvim instance might already have launched
   " a new provider instance. Don't drop ownership in this case.
@@ -136,7 +138,7 @@ function! s:clipboard.set(lines, regtype, reg) abort
   let selection.data = [a:lines, a:regtype]
   let argv = split(s:copy[a:reg], " ")
   let selection.detach = s:cache_enabled
-  let selection.cwd = "/"
+  let selection.cwd = s:win_wsl ? '/mnt/c/' : '/'
   let jobid = jobstart(argv, selection)
   if jobid <= 0
     echohl WarningMsg

--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -8,7 +8,7 @@ let s:paste = {}
 " ownership of the selection, so we know how long the cache is valid.
 let s:selection = { 'owner': 0, 'data': [] }
 
-let s:win_wsl = (system(['uname', '-a']) =~? 'Windows')
+let s:win_wsl = (system(['uname', '-a']) =~? 'Microsoft')
 
 function! s:selection.on_exit(jobid, data, event) abort
   " At this point this nvim instance might already have launched


### PR DESCRIPTION
Closes #7021

This only addresses copy, not paste, because we use `systemlist()` (instead of `jobstart()`) to paste.

todo:

- [ ] `system([...])` and `systemlist([...])` should take an options dict like `jobstart()`, specifically the `{'cwd':...}` option should set the CWD of the command