### PR TITLE
[RFC] make rpcrequest on host start for UpdateRemotePlugins only continue of #5856

### DIFF
--- a/runtime/autoload/remote/define.vim
+++ b/runtime/autoload/remote/define.vim
@@ -169,13 +169,26 @@ function! remote#define#FunctionOnChannel(channel, method, sync, name, opts)
 endfunction
 
 
+function! remote#define#SafeRPCNofity(...) abort
+  if !exists('s:poll')
+    let s:poll = {}
+  endif
+  " check the process started correctly
+  if !get(s:poll, a:1, 0)
+    if rpcrequest(a:1, 'poll') ==# 'ok'
+      let s:poll[a:1] = 1
+    endif
+  endif
+  return call('rpcnotify', a:000)
+endfunction
+
+
 function! s:GetRpcFunction(sync)
   if a:sync
     return 'rpcrequest'
   endif
-  return 'rpcnotify'
+  return 'remote#define#SafeRPCNofity'
 endfunction
-
 
 function! s:GetCommandPrefix(name, opts)
   return 'command!'.s:StringifyOpts(a:opts, ['nargs', 'complete', 'range',

--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -125,6 +125,13 @@ function! s:RegistrationCommands(host) abort
     call remote#host#RegisterPlugin(host_id, path, [])
   endfor
   let channel = remote#host#Require(host_id)
+  " check the process started correctly
+  if rpcrequest(channel, 'poll') !=# 'ok'
+    " there could be host that not response for poll request
+    echoerr 'rpcrequest of 'a:host . ' host failed'
+  endif
+
+
   let lines = []
   let registered = []
   for path in paths


### PR DESCRIPTION
Based PR: https://github.com/neovim/neovim/pull/5856
It improves the asynchronous RPC call.
Note: It does not improve the synchronous RPC call like autocmd define in remote plugin.

For example, my tested deoplete initialization:

Before: 71ms(_deoplete()) + 21ms(Python check)
After: 2ms(_deoplete()) + 21ms(Python check)

Note:  You can skip the Python check by `g:python3_host_prog`.
So the loading time is almost 2ms!

https://github.com/neovim/neovim/pull/5856#issuecomment-310956062

It is the faster than Vim if_python initialization(almost 20ms)!