### PR TITLE
[RFC] vim-patch:8.0.{0023,0025}

### DIFF
--- a/src/nvim/testdir/test_goto.vim
+++ b/src/nvim/testdir/test_goto.vim
@@ -1,22 +1,277 @@
 " Test commands that jump somewhere.
 
-func Test_geeDEE()
+" Create a new buffer using "lines" and place the cursor on the word after the
+" first occurrence of return and invoke "cmd". The cursor should now be
+" positioned at the given line and col.
+func XTest_goto_decl(cmd, lines, line, col)
   new
-  call setline(1, ["Filename x;", "", "int Filename", "int func() {", "Filename y;"])
-  /y;/
-  normal gD
-  call assert_equal(1, line('.'))
+  call setline(1, a:lines)
+  /return/
+  normal! W
+  execute 'norm! ' . a:cmd
+  call assert_equal(a:line, line('.'))
+  call assert_equal(a:col, col('.'))
   quit!
 endfunc
 
-func Test_gee_dee()
-  new
-  call setline(1, ["int x;", "", "int func(int x)", "{", "  return x;", "}"])
-  /return/
-  normal $hgd
-  call assert_equal(3, line('.'))
-  call assert_equal(14, col('.'))
-  quit!
+func Test_gD()
+  let lines = [
+    \ 'int x;',
+    \ '',
+    \ 'int func(void)',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gD', lines, 1, 5)
+endfunc
+
+func Test_gD_too()
+  let lines = [
+	\ 'Filename x;',
+	\ '',
+	\ 'int Filename',
+	\ 'int func() {',
+	\ '  Filename x;',
+	\ '  return x;',
+	\ ]
+  call XTest_goto_decl('gD', lines, 1, 10)
+endfunc
+
+func Test_gD_comment()
+  let lines = [
+    \ '/* int x; */',
+    \ 'int x;',
+    \ '',
+    \ 'int func(void)',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gD', lines, 2, 5)
+endfunc
+
+func Test_gD_inline_comment()
+  let lines = [
+    \ 'int y /* , x */;',
+    \ 'int x;',
+    \ '',
+    \ 'int func(void)',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gD', lines, 2, 5)
+endfunc
+
+func Test_gD_string()
+  let lines = [
+    \ 'char *s[] = "x";',
+    \ 'int x = 1;',
+    \ '',
+    \ 'int func(void)',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gD', lines, 2, 5)
+endfunc
+
+func Test_gD_string_same_line()
+  let lines = [
+    \ 'char *s[] = "x", int x = 1;',
+    \ '',
+    \ 'int func(void)',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gD', lines, 1, 22)
+endfunc
+
+func Test_gD_char()
+  let lines = [
+    \ "char c = 'x';",
+    \ 'int x = 1;',
+    \ '',
+    \ 'int func(void)',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gD', lines, 2, 5)
+endfunc
+
+func Test_gd()
+  let lines = [
+    \ 'int x;',
+    \ '',
+    \ 'int func(int x)',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gd', lines, 3, 14)
+endfunc
+
+func Test_gd_not_local()
+  let lines = [
+    \ 'int func1(void)',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ '',
+    \ 'int func2(int x)',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gd', lines, 3, 10)
+endfunc
+
+func Test_gd_kr_style()
+  let lines = [
+    \ 'int func(x)',
+    \ '  int x;',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gd', lines, 2, 7)
+endfunc
+
+func Test_gd_missing_braces()
+  let lines = [
+    \ 'def func1(a)',
+    \ '  a + 1',
+    \ 'end',
+    \ '',
+    \ 'a = 1',
+    \ '',
+    \ 'def func2()',
+    \ '  return a',
+    \ 'end',
+    \ ]
+  call XTest_goto_decl('gd', lines, 1, 11)
+endfunc
+
+func Test_gd_comment()
+  let lines = [
+    \ 'int func(void)',
+    \ '{',
+    \ '  /* int x; */',
+    \ '  int x;',
+    \ '  return x;',
+    \ '}',
+    \]
+  call XTest_goto_decl('gd', lines, 4, 7)
+endfunc
+
+func Test_gd_comment_in_string()
+  let lines = [
+    \ 'int func(void)',
+    \ '{',
+    \ '  char *s ="//"; int x;',
+    \ '  int x;',
+    \ '  return x;',
+    \ '}',
+    \]
+  call XTest_goto_decl('gd', lines, 3, 22)
+endfunc
+
+func Test_gd_string_in_comment()
+  set comments=
+  let lines = [
+    \ 'int func(void)',
+    \ '{',
+    \ '  /* " */ int x;',
+    \ '  int x;',
+    \ '  return x;',
+    \ '}',
+    \]
+  call XTest_goto_decl('gd', lines, 3, 15)
+  set comments&
+endfunc
+
+func Test_gd_inline_comment()
+  let lines = [
+    \ 'int func(/* x is an int */ int x)',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gd', lines, 1, 32)
+endfunc
+
+func Test_gd_inline_comment_only()
+  let lines = [
+    \ 'int func(void) /* one lonely x */',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gd', lines, 3, 10)
+endfunc
+
+func Test_gd_inline_comment_body()
+  let lines = [
+    \ 'int func(void)',
+    \ '{',
+    \ '  int y /* , x */;',
+    \ '',
+    \ '  for (/* int x = 0 */; y < 2; y++);',
+    \ '',
+    \ '  int x = 0;',
+    \ '',
+    \ '  return x;',
+    \ '}',
+  \ ]
+  call XTest_goto_decl('gd', lines, 7, 7)
+endfunc
+
+func Test_gd_trailing_multiline_comment()
+  let lines = [
+    \ 'int func(int x) /* x is an int */',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gd', lines, 1, 14)
+endfunc
+
+func Test_gd_trailing_comment()
+  let lines = [
+    \ 'int func(int x) // x is an int',
+    \ '{',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gd', lines, 1, 14)
+endfunc
+
+func Test_gd_string()
+  let lines = [
+    \ 'int func(void)',
+    \ '{',
+    \ '  char *s = "x";',
+    \ '  int x = 1;',
+    \ '',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gd', lines, 4, 7)
+endfunc
+
+func Test_gd_string_only()
+  let lines = [
+    \ 'int func(void)',
+    \ '{',
+    \ '  char *s = "x";',
+    \ '',
+    \ '  return x;',
+    \ '}',
+    \ ]
+  call XTest_goto_decl('gd', lines, 5, 10)
 endfunc
 
 " Check that setting 'cursorline' does not change curswant

--- a/src/nvim/testdir/test_goto.vim
+++ b/src/nvim/testdir/test_goto.vim
@@ -16,13 +16,13 @@ endfunc
 
 func Test_gD()
   let lines = [
-    \ 'int x;',
-    \ '',
-    \ 'int func(void)',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'int x;',
+	\ '',
+	\ 'int func(void)',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gD', lines, 1, 5)
 endfunc
 
@@ -40,237 +40,237 @@ endfunc
 
 func Test_gD_comment()
   let lines = [
-    \ '/* int x; */',
-    \ 'int x;',
-    \ '',
-    \ 'int func(void)',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ '/* int x; */',
+	\ 'int x;',
+	\ '',
+	\ 'int func(void)',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gD', lines, 2, 5)
 endfunc
 
 func Test_gD_inline_comment()
   let lines = [
-    \ 'int y /* , x */;',
-    \ 'int x;',
-    \ '',
-    \ 'int func(void)',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'int y /* , x */;',
+	\ 'int x;',
+	\ '',
+	\ 'int func(void)',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gD', lines, 2, 5)
 endfunc
 
 func Test_gD_string()
   let lines = [
-    \ 'char *s[] = "x";',
-    \ 'int x = 1;',
-    \ '',
-    \ 'int func(void)',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'char *s[] = "x";',
+	\ 'int x = 1;',
+	\ '',
+	\ 'int func(void)',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gD', lines, 2, 5)
 endfunc
 
 func Test_gD_string_same_line()
   let lines = [
-    \ 'char *s[] = "x", int x = 1;',
-    \ '',
-    \ 'int func(void)',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'char *s[] = "x", int x = 1;',
+	\ '',
+	\ 'int func(void)',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gD', lines, 1, 22)
 endfunc
 
 func Test_gD_char()
   let lines = [
-    \ "char c = 'x';",
-    \ 'int x = 1;',
-    \ '',
-    \ 'int func(void)',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ "char c = 'x';",
+	\ 'int x = 1;',
+	\ '',
+	\ 'int func(void)',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gD', lines, 2, 5)
 endfunc
 
 func Test_gd()
   let lines = [
-    \ 'int x;',
-    \ '',
-    \ 'int func(int x)',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'int x;',
+	\ '',
+	\ 'int func(int x)',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gd', lines, 3, 14)
 endfunc
 
 func Test_gd_not_local()
   let lines = [
-    \ 'int func1(void)',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ '',
-    \ 'int func2(int x)',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'int func1(void)',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ '',
+	\ 'int func2(int x)',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gd', lines, 3, 10)
 endfunc
 
 func Test_gd_kr_style()
   let lines = [
-    \ 'int func(x)',
-    \ '  int x;',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'int func(x)',
+	\ '  int x;',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gd', lines, 2, 7)
 endfunc
 
 func Test_gd_missing_braces()
   let lines = [
-    \ 'def func1(a)',
-    \ '  a + 1',
-    \ 'end',
-    \ '',
-    \ 'a = 1',
-    \ '',
-    \ 'def func2()',
-    \ '  return a',
-    \ 'end',
-    \ ]
+	\ 'def func1(a)',
+	\ '  a + 1',
+	\ 'end',
+	\ '',
+	\ 'a = 1',
+	\ '',
+	\ 'def func2()',
+	\ '  return a',
+	\ 'end',
+	\ ]
   call XTest_goto_decl('gd', lines, 1, 11)
 endfunc
 
 func Test_gd_comment()
   let lines = [
-    \ 'int func(void)',
-    \ '{',
-    \ '  /* int x; */',
-    \ '  int x;',
-    \ '  return x;',
-    \ '}',
-    \]
+	\ 'int func(void)',
+	\ '{',
+	\ '  /* int x; */',
+	\ '  int x;',
+	\ '  return x;',
+	\ '}',
+	\]
   call XTest_goto_decl('gd', lines, 4, 7)
 endfunc
 
 func Test_gd_comment_in_string()
   let lines = [
-    \ 'int func(void)',
-    \ '{',
-    \ '  char *s ="//"; int x;',
-    \ '  int x;',
-    \ '  return x;',
-    \ '}',
-    \]
+	\ 'int func(void)',
+	\ '{',
+	\ '  char *s ="//"; int x;',
+	\ '  int x;',
+	\ '  return x;',
+	\ '}',
+	\]
   call XTest_goto_decl('gd', lines, 3, 22)
 endfunc
 
 func Test_gd_string_in_comment()
   set comments=
   let lines = [
-    \ 'int func(void)',
-    \ '{',
-    \ '  /* " */ int x;',
-    \ '  int x;',
-    \ '  return x;',
-    \ '}',
-    \]
+	\ 'int func(void)',
+	\ '{',
+	\ '  /* " */ int x;',
+	\ '  int x;',
+	\ '  return x;',
+	\ '}',
+	\]
   call XTest_goto_decl('gd', lines, 3, 15)
   set comments&
 endfunc
 
 func Test_gd_inline_comment()
   let lines = [
-    \ 'int func(/* x is an int */ int x)',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'int func(/* x is an int */ int x)',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gd', lines, 1, 32)
 endfunc
 
 func Test_gd_inline_comment_only()
   let lines = [
-    \ 'int func(void) /* one lonely x */',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'int func(void) /* one lonely x */',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gd', lines, 3, 10)
 endfunc
 
 func Test_gd_inline_comment_body()
   let lines = [
-    \ 'int func(void)',
-    \ '{',
-    \ '  int y /* , x */;',
-    \ '',
-    \ '  for (/* int x = 0 */; y < 2; y++);',
-    \ '',
-    \ '  int x = 0;',
-    \ '',
-    \ '  return x;',
-    \ '}',
-  \ ]
+	\ 'int func(void)',
+	\ '{',
+	\ '  int y /* , x */;',
+	\ '',
+	\ '  for (/* int x = 0 */; y < 2; y++);',
+	\ '',
+	\ '  int x = 0;',
+	\ '',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gd', lines, 7, 7)
 endfunc
 
 func Test_gd_trailing_multiline_comment()
   let lines = [
-    \ 'int func(int x) /* x is an int */',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'int func(int x) /* x is an int */',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gd', lines, 1, 14)
 endfunc
 
 func Test_gd_trailing_comment()
   let lines = [
-    \ 'int func(int x) // x is an int',
-    \ '{',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'int func(int x) // x is an int',
+	\ '{',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gd', lines, 1, 14)
 endfunc
 
 func Test_gd_string()
   let lines = [
-    \ 'int func(void)',
-    \ '{',
-    \ '  char *s = "x";',
-    \ '  int x = 1;',
-    \ '',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'int func(void)',
+	\ '{',
+	\ '  char *s = "x";',
+	\ '  int x = 1;',
+	\ '',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gd', lines, 4, 7)
 endfunc
 
 func Test_gd_string_only()
   let lines = [
-    \ 'int func(void)',
-    \ '{',
-    \ '  char *s = "x";',
-    \ '',
-    \ '  return x;',
-    \ '}',
-    \ ]
+	\ 'int func(void)',
+	\ '{',
+	\ '  char *s = "x";',
+	\ '',
+	\ '  return x;',
+	\ '}',
+	\ ]
   call XTest_goto_decl('gd', lines, 5, 10)
 endfunc
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -704,7 +704,7 @@ static const int included_patches[] = {
   // 28 NA
   // 27 NA
   // 26,
-  // 25,
+  25,
   // 24 NA
   23,
   // 22 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -706,7 +706,7 @@ static const int included_patches[] = {
   // 26,
   // 25,
   // 24 NA
-  // 23,
+  23,
   // 22 NA
   // 21,
   // 20,


### PR DESCRIPTION
```
vim-patch:8.0.0023

Problem:    "gd" and "gD" may find a match in a comment or string.
Solution:   Ignore matches in comments and strings. (Anton Lindqvist)
```
https://github.com/vim/vim/commit/226630a030c0d41145e1109f09633360fc9c999d


```
vim-patch:8.0.0025

Problem:    Inconsistent use of spaces vs tabs in gd test.
Solution:   Use tabmatches in comments and strings. (Anton Lindqvist)
```
https://github.com/vim/vim/commit/936c48f8ca82a0257640c8c9d0792538f5a7e813

