### PR TITLE
[RDY] vim-patch:8.0.0004

### DIFF
--- a/src/nvim/testdir/test_expr.vim
+++ b/src/nvim/testdir/test_expr.vim
@@ -418,6 +418,9 @@ func Test_function_with_funcref()
   let s:fref = function(s:f)
   call assert_equal(v:t_string, s:fref('x'))
   call assert_fails("call function('s:f')", 'E700:')
+
+  call assert_fails("call function('foo()')", 'E475:')
+  call assert_fails("call function('foo()')", 'foo()')
 endfunc
 
 func Test_funcref()

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -725,7 +725,7 @@ static const int included_patches[] = {
   // 7 NA
   6,
   // 5 NA
-  // 4,
+  4,
   // 3,
   2,
   1,


### PR DESCRIPTION
Problem:    A string argument for function() that is not a function name
            results in an error message with NULL. (Christian Brabandt)
Solution:   Use the argument for the error message.

https://github.com/vim/vim/commit/5582ef14384525e8cec86016876d97a6b32dd548