### PR TITLE
[RFC] vim-patch:8.0.0085

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4239,10 +4239,16 @@ static int eval7(
         // use its contents.
         s = deref_func_name((const char *)s, &len, &partial, !evaluate);
 
+        // Need to make a copy, in case evaluating the arguments makes
+        // the name invalid.
+        s = xmemdupz(s, len);
+
         // Invoke the function.
         ret = get_func_tv(s, len, rettv, arg,
                           curwin->w_cursor.lnum, curwin->w_cursor.lnum,
                           &len, evaluate, partial, NULL);
+
+        xfree(s);
 
         // If evaluate is false rettv->v_type was not set in
         // get_func_tv, but it's needed in handle_subscript() to parse

--- a/src/nvim/testdir/test_nested_function.vim
+++ b/src/nvim/testdir/test_nested_function.vim
@@ -1,32 +1,42 @@
 "Tests for nested functions
 "
-function! NestedFunc()
-  fu! Func1()
+func NestedFunc()
+  func! Func1()
     let g:text .= 'Func1 '
-  endfunction
+  endfunc
   call Func1()
-  fu! s:func2()
+  func! s:func2()
     let g:text .= 's:func2 '
-  endfunction
+  endfunc
   call s:func2()
-  fu! s:_func3()
+  func! s:_func3()
     let g:text .= 's:_func3 '
-  endfunction
+  endfunc
   call s:_func3()
   let fn = 'Func4'
-  fu! {fn}()
+  func! {fn}()
     let g:text .= 'Func4 '
-  endfunction
+  endfunc
   call {fn}()
   let fn = 'func5'
-  fu! s:{fn}()
+  func! s:{fn}()
     let g:text .= 's:func5'
-  endfunction
+  endfunc
   call s:{fn}()
-endfunction
+endfunc
 
-function! Test_nested_functions()
+func Test_nested_functions()
   let g:text = ''
   call NestedFunc()
   call assert_equal('Func1 s:func2 s:_func3 Func4 s:func5', g:text)
 endfunction
+
+func Test_nested_argument()
+  func g:X()
+    let g:Y = function('sort')
+  endfunc
+  let g:Y = function('sort')
+  echo g:Y([], g:X())
+  delfunc g:X
+  unlet g:Y
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -644,7 +644,7 @@ static const int included_patches[] = {
   // 88,
   // 87 NA
   // 86,
-  // 85,
+  85,
   84,
   83,
   // 82 NA


### PR DESCRIPTION
```
Problem:    Using freed memory with recursive function call. (Dominique Pelle)
Solution:   Make a copy of the function name.
```
https://github.com/vim/vim/commit/8a01f969c198eeb655ad2f96f2796a6f6f4a1924