### PR TITLE
[RDY] vim-patch:8.0.0031

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5718,7 +5718,22 @@ void buf_copy_options(buf_T *buf, int flags)
         free_buf_options(buf, TRUE);
         buf->b_p_ro = FALSE;                    /* don't copy readonly */
         buf->b_p_fenc = vim_strsave(p_fenc);
-        buf->b_p_ff = vim_strsave(p_ff);
+        switch (*p_ffs) {
+        case 'm':
+          buf->b_p_ff = vim_strsave((char_u *)FF_MAC);
+          break;
+        case 'd':
+          buf->b_p_ff = vim_strsave((char_u *)FF_DOS);
+          break;
+        case 'u':
+          buf->b_p_ff = vim_strsave((char_u *)FF_UNIX);
+          break;
+        default:
+          buf->b_p_ff = vim_strsave(p_ff);
+        }
+        if (buf->b_p_ff != NULL) {
+          buf->b_start_ffc = *buf->b_p_ff;
+        }
         buf->b_p_bh = empty_option;
         buf->b_p_bt = empty_option;
       } else

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -14,6 +14,7 @@ source test_float_func.vim
 source test_functions.vim
 source test_goto.vim
 source test_jumps.vim
+source test_fileformat.vim
 source test_lambda.vim
 source test_menu.vim
 source test_mapping.vim

--- a/src/nvim/testdir/test_fileformat.vim
+++ b/src/nvim/testdir/test_fileformat.vim
@@ -1,0 +1,17 @@
+" Test behavior of fileformat after bwipeout of last buffer
+
+func Test_fileformat_after_bw()
+  bwipeout
+  set fileformat&
+  if &fileformat == 'dos'
+    let test_fileformats = 'unix'
+  elseif &fileformat == 'unix'
+    let test_fileformats = 'mac'
+  else  " must be mac
+    let test_fileformats = 'dos'
+  endif
+  exec 'set fileformats='.test_fileformats
+  bwipeout!
+  call assert_equal(test_fileformats, &fileformat)
+  set fileformats&
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -698,7 +698,7 @@ static const int included_patches[] = {
   // 34,
   33,
   32,
-  // 31,
+  31,
   // 30 NA
   // 29 NA
   // 28 NA


### PR DESCRIPTION
Problem:    After ":bwipeout" 'fileformat' is not set to the right default.
Solution:   Get the default from 'fileformats'. (Mike Williams)

https://github.com/vim/vim/commit/e8ef3a093453b73594e15462d4de50b011c8ba66