### PR TITLE
[RDY] vim-patch:8.0.0038

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -691,7 +691,7 @@ static const int included_patches[] = {
   41,
   40,
   // 39 NA
-  // 38,
+  38,
   37,
   // 36 NA
   35,

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -319,7 +319,7 @@ enum { FOLD_TEXT_LEN = 51 };  //!< buffer size for get_foldtext()
 // Lowest number used for window ID. Cannot have this many windows per tab.
 #define LOWEST_WIN_ID 1000
 
-#if defined(__FreeBSD__) && defined(S_ISCHR)
+#if (defined(__FreeBSD__) || defined(__FreeBSD_kernel__)) && defined(S_ISCHR)
 # define OPEN_CHR_FILES
 #endif
 


### PR DESCRIPTION
Problem:    OPEN_CHR_FILES not defined for FreeBSD using Debian userland
            files.
Solution:   Check for __FreeBSD_kernel__. (James McCoy, closes vim/vim#1166)

https://github.com/vim/vim/commit/ca291aec99b60fe81eaab36aa718e51421bb88d5