### PR TITLE
[RDY] vim-patch:8.0.0044

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2147,14 +2147,12 @@ void do_check_cursorbind(void)
     curbuf = curwin->w_buffer;
     /* skip original window  and windows with 'noscrollbind' */
     if (curwin != old_curwin && curwin->w_p_crb) {
-      if (curwin->w_p_diff)
-        curwin->w_cursor.lnum
-          = diff_get_corresponding_line(old_curbuf,
-            line,
-            curbuf,
-            curwin->w_cursor.lnum);
-      else
+      if (curwin->w_p_diff) {
+        curwin->w_cursor.lnum =
+          diff_get_corresponding_line(old_curbuf, line);
+      } else {
         curwin->w_cursor.lnum = line;
+      }
       curwin->w_cursor.col = col;
       curwin->w_cursor.coladd = coladd;
       curwin->w_curswant = curswant;

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -218,3 +218,20 @@ func Test_diffoff()
   bwipe!
   bwipe!
 endfunc
+
+func Test_setting_cursor()
+  new Xtest1
+  put =range(1,90)
+  wq
+  new Xtest2
+  put =range(1,100)
+  wq
+  
+  tabe Xtest2
+  $
+  diffsp Xtest1
+  tabclose
+
+  call delete('Xtest1')
+  call delete('Xtest2')
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -908,7 +908,7 @@ static const int included_patches[] = {
   47,
   46,
   // 45 NA
-  // 44,
+  44,
   43,
   42,
   41,


### PR DESCRIPTION
Problem:    In diff mode the cursor may end up below the last line, resulting
            in an ml_get error.
Solution:   Check the line to be valid.

https://github.com/vim/vim/commit/025e3e0bafbc85cc4e365145af711edf99d0a90d