### PR TITLE
[RDY] vim-patch:8.0.0052

### DIFF
--- a/src/nvim/testdir/test_matchadd_conceal.vim
+++ b/src/nvim/testdir/test_matchadd_conceal.vim
@@ -277,6 +277,7 @@ function! Test_matchadd_and_syn_conceal()
   call assert_notequal(screenattr(1, 11) , screenattr(1, 12))
   call assert_equal(screenattr(1, 11) , screenattr(1, 32))
   call matchadd('CheckedByCoq', '\%<2l\%>9c\%<16c')
+  redraw!
   call assert_equal(expect, s:screenline(1))
   call assert_notequal(screenattr(1, 10) , screenattr(1, 11))
   call assert_notequal(screenattr(1, 11) , screenattr(1, 12))

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -677,7 +677,7 @@ static const int included_patches[] = {
   // 55 NA
   // 54 NA
   53,
-  // 52,
+  52,
   // 51 NA
   // 50 NA
   49,


### PR DESCRIPTION
Problem:    Conceal test passes even without the bug fix.
Solution:   Add a redraw command. (Christian Brabandt)

https://github.com/vim/vim/commit/35a1f59d635d9a655e1267c18f7cc757afd0d5b0