### PR TITLE
 [RDY] vim-patch:8.0.0069, 8.0.0073

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4429,7 +4429,7 @@ do_arg_all (
             }
           }
           /* don't close last window */
-          if (firstwin == lastwin
+          if (ONE_WINDOW
               && (first_tabpage->tp_next == NULL || !had_tab))
             use_firstwin = TRUE;
           else {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1204,7 +1204,7 @@ do_buffer (
     while (buf == curbuf
            && !(curwin->w_closing || curwin->w_buffer->b_locked > 0)
            && (!ONE_WINDOW || first_tabpage->tp_next != NULL)) {
-      if (win_close(curwin, FALSE) == FAIL)
+      if (win_close(curwin, false) == FAIL)
         break;
     }
 
@@ -4428,15 +4428,17 @@ do_arg_all (
               continue;
             }
           }
-          /* don't close last window */
+          // don't close last window
           if (ONE_WINDOW
-              && (first_tabpage->tp_next == NULL || !had_tab))
-            use_firstwin = TRUE;
-          else {
+              && (first_tabpage->tp_next == NULL || !had_tab)) {
+            use_firstwin = true;
+          } else {
             win_close(wp, !P_HID(buf) && !bufIsChanged(buf));
-            /* check if autocommands removed the next window */
-            if (!win_valid(wpnext))
-              wpnext = firstwin;                /* start all over... */
+            // check if autocommands removed the next window
+            if (!win_valid(wpnext)) {
+              // start all over...
+              wpnext = firstwin;                
+            }
           }
         }
       }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1203,7 +1203,7 @@ do_buffer (
      */
     while (buf == curbuf
            && !(curwin->w_closing || curwin->w_buffer->b_locked > 0)
-           && (firstwin != lastwin || first_tabpage->tp_next != NULL)) {
+           && (!ONE_WINDOW || first_tabpage->tp_next != NULL)) {
       if (win_close(curwin, FALSE) == FAIL)
         break;
     }
@@ -4593,7 +4593,7 @@ void ex_buffer_all(exarg_T *eap)
                - tabline_height()
                : wp->w_width != Columns)
            || (had_tab > 0 && wp != firstwin))
-          && firstwin != lastwin
+          && !ONE_WINDOW
           && !(wp->w_closing || wp->w_buffer->b_locked > 0)
           ) {
         win_close(wp, FALSE);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2802,16 +2802,18 @@ void ex_z(exarg_T *eap)
   int j;
   linenr_T lnum = eap->line2;
 
-  /* Vi compatible: ":z!" uses display height, without a count uses
-   * 'scroll' */
-  if (eap->forceit)
+  // Vi compatible: ":z!" uses display height, without a count uses
+  // 'scroll'
+  if (eap->forceit) {
     bigness = curwin->w_height;
-  else if (ONE_WINDOW)
+  } else if (ONE_WINDOW) {
     bigness = curwin->w_p_scr * 2;
-  else
+  } else {
     bigness = curwin->w_height - 3;
-  if (bigness < 1)
+  }
+  if (bigness < 1) {
     bigness = 1;
+  }
 
   x = eap->arg;
   kind = x;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2806,7 +2806,7 @@ void ex_z(exarg_T *eap)
    * 'scroll' */
   if (eap->forceit)
     bigness = curwin->w_height;
-  else if (firstwin == lastwin)
+  else if (ONE_WINDOW)
     bigness = curwin->w_p_scr * 2;
   else
     bigness = curwin->w_height - 3;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5976,7 +5976,7 @@ static void ex_quit(exarg_T *eap)
     // specified. Example:
     // :h|wincmd w|1q     - don't quit
     // :h|wincmd w|q      - quit
-    if (only_one_window() && (firstwin == lastwin || eap->addr_count == 0)) {
+    if (only_one_window() && (ONE_WINDOW || eap->addr_count == 0)) {
       getout(0);
     }
     /* close window; may free buffer */

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6174,12 +6174,14 @@ static void ex_tabonly(exarg_T *eap)
  */
 void tabpage_close(int forceit)
 {
-  /* First close all the windows but the current one.  If that worked then
-   * close the last window in this tab, that will close it. */
-  if (!ONE_WINDOW)
-    close_others(TRUE, forceit);
-  if (ONE_WINDOW)
+  // First close all the windows but the current one.  If that worked then
+  // close the last window in this tab, that will close it.
+  if (!ONE_WINDOW) {
+    close_others(true, forceit);
+  }
+  if (ONE_WINDOW) {
     ex_win_close(forceit, curwin, NULL);
+  }
 }
 
 /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6176,9 +6176,9 @@ void tabpage_close(int forceit)
 {
   /* First close all the windows but the current one.  If that worked then
    * close the last window in this tab, that will close it. */
-  if (lastwin != firstwin)
+  if (!ONE_WINDOW)
     close_others(TRUE, forceit);
-  if (lastwin == firstwin)
+  if (ONE_WINDOW)
     ex_win_close(forceit, curwin, NULL);
 }
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -494,6 +494,7 @@ EXTERN int updating_screen INIT(= FALSE);
 EXTERN win_T    *firstwin;              /* first window */
 EXTERN win_T    *lastwin;               /* last window */
 EXTERN win_T    *prevwin INIT(= NULL);  /* previous window */
+# define ONE_WINDOW (firstwin == lastwin)
 /*
  * When using this macro "break" only breaks out of the inner loop. Use "goto"
  * to break out of the tabpage loop.

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -585,7 +585,7 @@ void free_all_mem(void)
   p_ea = false;
   if (first_tabpage->tp_next != NULL)
     do_cmdline_cmd("tabonly!");
-  if (firstwin != lastwin)
+  if (!ONE_WINDOW)
     do_cmdline_cmd("only!");
 
   /* Free all spell info. */

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1763,7 +1763,7 @@ int onepage(int dir, long count)
 
     loff.fill = 0;
     if (dir == FORWARD) {
-      if (firstwin == lastwin && p_window > 0 && p_window < Rows - 1) {
+      if (ONE_WINDOW && p_window > 0 && p_window < Rows - 1) {
         /* Vi compatible scrolling */
         if (p_window <= 2)
           ++curwin->w_topline;
@@ -1797,7 +1797,7 @@ int onepage(int dir, long count)
         max_topfill();
         continue;
       }
-      if (firstwin == lastwin && p_window > 0 && p_window < Rows - 1) {
+      if (ONE_WINDOW && p_window > 0 && p_window < Rows - 1) {
         /* Vi compatible scrolling (sort of) */
         if (p_window <= 2)
           --curwin->w_topline;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4078,7 +4078,7 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
     }
 
     /* Change window height NOW */
-    if (lastwin != firstwin) {
+    if (!ONE_WINDOW) {
       if (pp == &p_wh && curwin->w_height < p_wh)
         win_setheight((int)p_wh);
       if (pp == &p_hh && curbuf->b_help && curwin->w_height < p_hh)
@@ -4107,7 +4107,7 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
     }
 
     /* Change window width NOW */
-    if (lastwin != firstwin && curwin->w_width < p_wiw)
+    if (!ONE_WINDOW && curwin->w_width < p_wiw)
       win_setwidth((int)p_wiw);
   }
   /* 'winminwidth' */
@@ -5239,7 +5239,7 @@ static int put_setbool(FILE *fd, char *cmd, char *name, int value)
 
 void comp_col(void)
 {
-  int last_has_status = (p_ls == 2 || (p_ls == 1 && firstwin != lastwin));
+  int last_has_status = (p_ls == 2 || (p_ls == 1 && !ONE_WINDOW));
 
   sc_col = 0;
   ru_col = 0;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1878,7 +1878,7 @@ win_found:
      * If there is only one window and it is the quickfix window, create a
      * new one above the quickfix window.
      */
-    if (((firstwin == lastwin) && bt_quickfix(curbuf)) || !usable_win) {
+    if ((ONE_WINDOW && bt_quickfix(curbuf)) || !usable_win) {
       flags = WSP_ABOVE;
       if (ll_ref != NULL)
         flags |= WSP_NEWLOC;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -991,7 +991,7 @@ static void win_update(win_T *wp)
      * first. */
     if (mid_start == 0) {
       mid_end = wp->w_height;
-      if (lastwin == firstwin) {
+      if (ONE_WINDOW) {
         /* Clear the screen when it was not done by win_del_lines() or
          * win_ins_lines() above, "screen_cleared" is FALSE or MAYBE
          * then. */
@@ -7160,7 +7160,7 @@ static int fillchar_status(int *attr, win_T *wp)
    * window differs, or the fillchars differ, or this is not the
    * current window */
   if (*attr != 0 && ((win_hl_attr(wp, HLF_S) != win_hl_attr(wp, HLF_SNC)
-                      || !is_curwin || firstwin == lastwin)
+                      || !is_curwin || ONE_WINDOW)
                      || (fill_stl != fill_stlnc))) {
     return fill;
   }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -656,7 +656,7 @@ static const int included_patches[] = {
   // 76 NA
   // 75,
   // 74,
-  // 73,
+  73,
   // 72 NA
   // 71 NA
   // 70 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -660,7 +660,7 @@ static const int included_patches[] = {
   // 72 NA
   // 71 NA
   // 70 NA
-  // 69,
+  69,
   68,
   // 67 NA
   66,

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -193,7 +193,7 @@ newwindow:
   /* cursor to previous window with wrap around */
   case 'W':
     CHECK_CMDWIN
-    if (firstwin == lastwin && Prenum != 1)             /* just one window */
+    if (ONE_WINDOW && Prenum != 1)             /* just one window */
       beep_flush();
     else {
       if (Prenum) {                             /* go to specified window */
@@ -1271,7 +1271,7 @@ static void win_rotate(int upwards, int count)
   frame_T     *frp;
   int n;
 
-  if (firstwin == lastwin) {            /* nothing to do */
+  if (ONE_WINDOW) {            /* nothing to do */
     beep_flush();
     return;
   }
@@ -2194,7 +2194,7 @@ winframe_remove (
   /*
    * If there is only one window there is nothing to remove.
    */
-  if (tp == NULL ? firstwin == lastwin : tp->tp_firstwin == tp->tp_lastwin)
+  if (tp == NULL ? ONE_WINDOW : tp->tp_firstwin == tp->tp_lastwin)
     return NULL;
 
   /*
@@ -2331,7 +2331,7 @@ win_altframe (
   frame_T     *frp;
   int b;
 
-  if (tp == NULL ? firstwin == lastwin : tp->tp_firstwin == tp->tp_lastwin)
+  if (tp == NULL ? ONE_WINDOW : tp->tp_firstwin == tp->tp_lastwin)
     /* Last window in this tab page, will go to next tab page. */
     return alt_tabpage()->tp_curwin->w_frame;
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -574,7 +574,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
     oldwin = curwin;
 
   /* add a status line when p_ls == 1 and splitting the first window */
-  if (lastwin == firstwin && p_ls == 1 && oldwin->w_status_height == 0) {
+  if (ONE_WINDOW && p_ls == 1 && oldwin->w_status_height == 0) {
     if (oldwin->w_height <= p_wmh && new_wp == NULL) {
       EMSG(_(e_noroom));
       return FAIL;
@@ -1182,7 +1182,7 @@ static void win_exchange(long Prenum)
   win_T       *wp2;
   int temp;
 
-  if (lastwin == firstwin) {        /* just one window */
+  if (ONE_WINDOW) {        /* just one window */
     beep_flush();
     return;
   }
@@ -1343,7 +1343,7 @@ static void win_totop(int size, int flags)
   int dir;
   int height = curwin->w_height;
 
-  if (lastwin == firstwin) {
+  if (ONE_WINDOW) {
     beep_flush();
     return;
   }
@@ -1728,7 +1728,7 @@ void close_windows(buf_T *buf, int keep_curwin)
 
   ++RedrawingDisabled;
 
-  for (win_T *wp = firstwin; wp != NULL && lastwin != firstwin; ) {
+  for (win_T *wp = firstwin; wp != NULL && !ONE_WINDOW; ) {
     if (wp->w_buffer == buf && (!keep_curwin || wp != curwin)
         && !(wp->w_closing || wp->w_buffer->b_locked > 0)) {
       if (win_close(wp, false) == FAIL) {
@@ -1810,7 +1810,7 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf,
                                       tabpage_T *prev_curtab)
   FUNC_ATTR_NONNULL_ARG(1)
 {
-  if (firstwin != lastwin) {
+  if (!ONE_WINDOW) {
     return false;
   }
   buf_T   *old_curbuf = curbuf;
@@ -2851,7 +2851,7 @@ close_others (
     win_close(wp, !P_HID(wp->w_buffer) && !bufIsChanged(wp->w_buffer));
   }
 
-  if (message && lastwin != firstwin)
+  if (message && !ONE_WINDOW)
     EMSG(_("E445: Other window contains changes"));
 }
 
@@ -5173,7 +5173,7 @@ last_status (
 {
   /* Don't make a difference between horizontal or vertical split. */
   last_status_rec(topframe, (p_ls == 2
-                             || (p_ls == 1 && (morewin || lastwin != firstwin))));
+                             || (p_ls == 1 && (morewin || !ONE_WINDOW))));
 }
 
 static void last_status_rec(frame_T *fr, int statusline)


### PR DESCRIPTION
Problem:    Compiler warning for self-comparison.
Solution:   Define ONE_WINDOW and add vim/vim#ifdef.

https://github.com/vim/vim/commit/a1f4cb93ba50ea9e40cd4b1f5592b8a6d1398660