### PR TITLE
logging: nvim_log(), other improvements

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1260,6 +1260,40 @@ nvim_load_context({dict})                                *nvim_load_context()*
     Return: ~
         (`any`)
 
+nvim_log({level}, {msg}, {opts})                                  *nvim_log()*
+    Posts a message to the global logger (which by default synchronously
+    writes to |$NVIM_LOG_FILE| using a best-effort, naive implementation).
+
+    Message is skipped (not logged) if `level` is not "error", unless
+    'verbose' is set.
+
+    Example log message: >
+        ERROR 2020-01-12T01:56:19.484 93296 pynvim:remote: connected…
+        ^level ^timestamp             ^pid  ^category      ^message
+<
+
+    Attributes: ~
+        Since: 0.5.0
+
+    Parameters: ~
+      • {level}  (`string`) Log level (from highest to lowest: "error",
+                 "warn", "info", "debug"). If 'verbose' is not set, only
+                 "error" messages are written to |$NVIM_LOG_FILE|.
+      • {msg}    (`string`) Message body
+      • {opts}   (`vim.api.keyset.log`) Optional parameters:
+                 • `join`: (boolean, default false) Replace embedded line
+                   endings with SPACE, to keep the message on one log-line.
+                 • `trunc`: (integer, default 0) Constrain the message body to
+                   this size.
+                 • `type`: (string) Name of the subsystem or grouping (e.g.
+                   "UI", "RPC", "MyPlugin", …). For API clients this
+                   defaults to the `client.name` field of
+                   |nvim_get_chan_info()|.
+
+    See also: ~
+      • |nvim_get_chan_info()|
+      • |nvim_set_client_info()|
+
 nvim_open_term({buf}, {opts})                               *nvim_open_term()*
     Open a terminal instance in a buffer
 

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -391,8 +391,7 @@ was changed. The parameters received are ("changedtick", {buf}, {changedtick}).
 
                                                         *api-lua-detach*
 In-process Lua callbacks can detach by returning `true`. This will detach all
-callbacks attached with the same |nvim_buf_attach()| call without invoking the
-"on_detach" callback.
+callbacks attached with the same |nvim_buf_attach()| call.
 
 
 ==============================================================================
@@ -1278,6 +1277,40 @@ nvim_load_context({dict})                                *nvim_load_context()*
 
     Return: ~
         (`any`)
+
+nvim_log({level}, {msg}, {opts})                                  *nvim_log()*
+    Posts a message to the global logger (which by default synchronously
+    writes to |$NVIM_LOG_FILE| using a best-effort, naive implementation).
+
+    Message is skipped (not logged) if `level` is not "error", unless
+    'verbose' is set.
+
+    Example log message: >
+        ERROR 2020-01-12T01:56:19.484 93296 pynvim:remote: connected…
+        ^level ^timestamp             ^pid  ^category      ^message
+<
+
+    Attributes: ~
+        Since: 0.12.0
+
+    Parameters: ~
+      • {level}  (`string`) Log level (from highest to lowest: "ERR", "WRN",
+                 "INF", "DBG"). If 'verbose' is not set, only "ERR" messages
+                 are written to |$NVIM_LOG_FILE|.
+      • {msg}    (`string`) Message body
+      • {opts}   (`vim.api.keyset.log?`) Optional parameters:
+                 • `join`: (boolean, default false) Replace embedded line
+                   endings with SPACE, to keep the message on one log-line.
+                 • `trunc`: (integer, default 0) Constrain the message body to
+                   this size.
+                 • `type`: (string) Name of the subsystem or grouping (e.g.
+                   "UI", "RPC", "MyPlugin", …). For API clients this
+                   defaults to the `client.name` field of
+                   |nvim_get_chan_info()|.
+
+    See also: ~
+      • |nvim_get_chan_info()|
+      • |nvim_set_client_info()|
 
 nvim_mcursor({buf}, {pos})                                    *nvim_mcursor()*
     Adds a multicursor in the given buffer.

--- a/runtime/doc/dev.txt
+++ b/runtime/doc/dev.txt
@@ -718,7 +718,13 @@ API CLIENT IMPLEMENTATION
 
 
 ------------------------------------------------------------------------------
-External UI                                                           *dev-ui*
+LOGGING                                                          *dev-logging*
+
+- Use |nvim_log()|.  Avoid separate log files for plugins/clients/UIs.
+
+
+------------------------------------------------------------------------------
+EXTERNAL UI                                                           *dev-ui*
 
 External UIs should be aware of the |api-contract|. In particular, future
 versions of Nvim may add new items to existing events. The API is strongly

--- a/runtime/doc/dev.txt
+++ b/runtime/doc/dev.txt
@@ -720,7 +720,13 @@ API CLIENT IMPLEMENTATION
 
 
 ------------------------------------------------------------------------------
-External UI                                                           *dev-ui*
+LOGGING                                                          *dev-logging*
+
+- Use |nvim_log()|.  Avoid separate log files for plugins/clients/UIs.
+
+
+------------------------------------------------------------------------------
+EXTERNAL UI                                                           *dev-ui*
 
 External UIs should be aware of the |api-contract|. In particular, future
 versions of Nvim may add new items to existing events. The API is strongly

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7204,25 +7204,31 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Sets the verbosity level.  Also set by |-V| and |:verbose|.
 
 	Tracing of assignments to options, mappings, etc. in Lua scripts is
-	enabled at level 1; Lua scripts are not traced when 'verbose' is 0,
+	enabled at level 3; Lua scripts are not traced when 'verbose' is 0,
 	for performance.
 
-	If greater than or equal to a given level, Nvim produces the following
+	If greater than or equal to a given level, Nvim logs the following
 	messages:
 
 	Level   Messages ~
 	----------------------------------------------------------------------
-	1	Enables Lua tracing (see above). Does not produce messages.
-	2	When a file is ":source"'ed, or |shada| file is read or written.
-	3	UI info, terminal capabilities.
-	4	Shell commands.
-	5	Every searched tags file and include file.
-	8	Files for which a group of autocommands is executed.
-	9	Executed autocommands.
+	1	Enables |nvim_log()| at "warning" level.
+	2	Enables |nvim_log()| at "info" level.
+	3	Enables Lua tracing (see above).
+		Enables |nvim_log()| at "debug" level.
+		UI info, terminal capabilities.
+	4	Enables |nvim_log()| at "trace" level.
+	        NOTE: channel communication is logged, this may contain
+	        private info, e.g. a password you type in a terminal window.
+	5	Shell commands.
+	6	Activity from |shada|, |swap-file|, |spell|, 'undofile',
+		|:source|, |tags|, |include-search|.
+	8	Filenames where autocommands executed.
+	9	Event handler (autocommands) execution.
 	11	Finding items in a path.
-	12	Vimscript function calls.
-	13	When an exception is thrown, caught, finished, or discarded.
-	14	Anything pending in a ":finally" clause.
+	12	Vimscript function execution.
+	13	Exceptions thrown, caught, finished, or discarded.
+	14	Pending ":finally" clauses.
 	15	Ex commands from a script (truncated at 200 characters).
 	16	Ex commands.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7298,25 +7298,31 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Sets the verbosity level.  Also set by |-V| and |:verbose|.
 
 	Tracing of assignments to options, mappings, etc. in Lua scripts is
-	enabled at level 1; Lua scripts are not traced when 'verbose' is 0,
+	enabled at level 3; Lua scripts are not traced when 'verbose' is 0,
 	for performance.
 
-	If greater than or equal to a given level, Nvim produces the following
+	If greater than or equal to a given level, Nvim logs the following
 	messages:
 
 	Level   Messages ~
 	----------------------------------------------------------------------
-	1	Enables Lua tracing (see above). Does not produce messages.
-	2	When a file is ":source"'ed, or |shada| file is read or written.
-	3	UI info, terminal capabilities.
-	4	Shell commands.
-	5	Every searched tags file and include file.
-	8	Files for which a group of autocommands is executed.
-	9	Executed autocommands.
+	1	Enables |nvim_log()| at "warning" level.
+	2	Enables |nvim_log()| at "info" level.
+	3	Enables Lua tracing (see above).
+		Enables |nvim_log()| at "debug" level.
+		UI info, terminal capabilities.
+	4	Enables |nvim_log()| at "trace" level.
+	        NOTE: channel communication is logged, this may contain
+	        private info, e.g. a password you type in a terminal window.
+	5	Shell commands.
+	6	Activity from |shada|, |swap-file|, |spell|, 'undofile',
+		|:source|, |tags|, |include-search|.
+	8	Filenames where autocommands executed.
+	9	Event handler (autocommands) execution.
 	11	Finding items in a path.
-	12	Vimscript function calls.
-	13	When an exception is thrown, caught, finished, or discarded.
-	14	Anything pending in a ":finally" clause.
+	12	Vimscript function execution.
+	13	Exceptions thrown, caught, finished, or discarded.
+	14	Pending ":finally" clauses.
 	15	Ex commands from a script (truncated at 200 characters).
 	16	Ex commands.
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -263,9 +263,7 @@ argument.
 
                                                         *-V* *verbose*
 -V[N]           Verbose.  Sets the 'verbose' option to [N] (default: 10).
-                Messages will be given for each file that is ":source"d and
-                for reading or writing a ShaDa file.  Can be used to find
-                out what is happening upon startup and exit.
+                Can be used to debug behavior during startup and exit.
                 Example: >
                         nvim -V8
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -268,9 +268,7 @@ argument.
 
                                                         *-V* *verbose*
 -V[N]           Verbose.  Sets the 'verbose' option to [N] (default: 10).
-                Messages will be given for each file that is ":source"d and
-                for reading or writing a ShaDa file.  Can be used to find
-                out what is happening upon startup and exit.
+                Can be used to debug behavior during startup and exit.
                 Example: >
                         nvim -V8
 

--- a/runtime/lua/vim/_core/spell.lua
+++ b/runtime/lua/vim/_core/spell.lua
@@ -23,7 +23,7 @@ function M.select_suggest(items, bad)
     format_item = function(s)
       local extra = s.extra and (' < "' .. s.extra .. '"') or ''
       local score = ''
-      if vim.o.verbose > 0 then
+      if vim.o.verbose > 1 then
         score = s.altscore
             and (' (%s%d - %d)'):format(s.salscore and 's ' or '', s.score, s.altscore)
           or (' (%d)'):format(s.score)

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -1665,6 +1665,30 @@ function vim.api.nvim_list_wins() end
 --- @return any
 function vim.api.nvim_load_context(dict) end
 
+--- Posts a message to the global logger (which by default synchronously writes to `$NVIM_LOG_FILE`
+--- using a best-effort, naive implementation).
+---
+--- Message is skipped (not logged) if `level` is not "error", unless 'verbose' is set.
+---
+--- Example log message:
+--- ```
+--- ERROR 2020-01-12T01:56:19.484 93296 pynvim:remote: connected…
+--- ^level ^timestamp             ^pid  ^category      ^message
+--- ```
+---
+---
+--- @see vim.api.nvim_get_chan_info
+--- @see vim.api.nvim_set_client_info
+--- @param level string Log level (from highest to lowest: "error", "warn", "info", "debug").  If
+--- 'verbose' is not set, only "error" messages are written to `$NVIM_LOG_FILE`.
+--- @param msg string Message body
+--- @param opts vim.api.keyset.log Optional parameters:
+--- - `join`: (boolean, default false) Replace embedded line endings with SPACE, to keep the message on one log-line.
+--- - `trunc`: (integer, default 0) Constrain the message body to this size.
+--- - `type`: (string) Name of the subsystem or grouping (e.g. "UI", "RPC", "MyPlugin", …). For
+---   API clients this defaults to the `client.name` field of `nvim_get_chan_info()`.
+function vim.api.nvim_log(level, msg, opts) end
+
 --- @deprecated
 --- @param msg string
 --- @param log_level integer

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -1681,6 +1681,30 @@ function vim.api.nvim_list_wins() end
 --- @return any
 function vim.api.nvim_load_context(dict) end
 
+--- Posts a message to the global logger (which by default synchronously writes to `$NVIM_LOG_FILE`
+--- using a best-effort, naive implementation).
+---
+--- Message is skipped (not logged) if `level` is not "error", unless 'verbose' is set.
+---
+--- Example log message:
+--- ```
+--- ERROR 2020-01-12T01:56:19.484 93296 pynvim:remote: connected…
+--- ^level ^timestamp             ^pid  ^category      ^message
+--- ```
+---
+---
+--- @see vim.api.nvim_get_chan_info
+--- @see vim.api.nvim_set_client_info
+--- @param level string Log level (from highest to lowest: "ERR", "WRN", "INF", "DBG"). If 'verbose' is
+--- not set, only "ERR" messages are written to `$NVIM_LOG_FILE`.
+--- @param msg string Message body
+--- @param opts vim.api.keyset.log? Optional parameters:
+--- - `join`: (boolean, default false) Replace embedded line endings with SPACE, to keep the message on one log-line.
+--- - `trunc`: (integer, default 0) Constrain the message body to this size.
+--- - `type`: (string) Name of the subsystem or grouping (e.g. "UI", "RPC", "MyPlugin", …). For
+---   API clients this defaults to the `client.name` field of `nvim_get_chan_info()`.
+function vim.api.nvim_log(level, msg, opts) end
+
 --- Adds a multicursor in the given buffer.
 ---
 --- @param buf integer Buffer handle, or 0 for current buffer

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -373,6 +373,11 @@ error('Cannot require a meta file')
 --- @field silent? boolean
 --- @field unique? boolean
 
+--- @class vim.api.keyset.log
+--- @field join? boolean
+--- @field trunc? integer
+--- @field type? string
+
 --- @class vim.api.keyset.ns_opts
 --- @field wins? any[]
 

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -377,6 +377,11 @@ error('Cannot require a meta file')
 --- @class vim.api.keyset.keymap_del
 --- @field lhs? boolean
 
+--- @class vim.api.keyset.log
+--- @field join? boolean
+--- @field trunc? integer
+--- @field type? string
+
 --- @class vim.api.keyset.ns_opts
 --- @field wins? any[]
 

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -7791,25 +7791,31 @@ vim.bo.vts = vim.bo.vartabstop
 --- Sets the verbosity level.  Also set by `-V` and `:verbose`.
 ---
 --- Tracing of assignments to options, mappings, etc. in Lua scripts is
---- enabled at level 1; Lua scripts are not traced when 'verbose' is 0,
+--- enabled at level 3; Lua scripts are not traced when 'verbose' is 0,
 --- for performance.
 ---
---- If greater than or equal to a given level, Nvim produces the following
+--- If greater than or equal to a given level, Nvim logs the following
 --- messages:
 ---
 --- Level   Messages ~
 --- ----------------------------------------------------------------------
---- 1	Enables Lua tracing (see above). Does not produce messages.
---- 2	When a file is ":source"'ed, or `shada` file is read or written.
---- 3	UI info, terminal capabilities.
---- 4	Shell commands.
---- 5	Every searched tags file and include file.
---- 8	Files for which a group of autocommands is executed.
---- 9	Executed autocommands.
+--- 1	Enables `nvim_log()` at "warning" level.
+--- 2	Enables `nvim_log()` at "info" level.
+--- 3	Enables Lua tracing (see above).
+--- 	Enables `nvim_log()` at "debug" level.
+--- 	UI info, terminal capabilities.
+--- 4	Enables `nvim_log()` at "trace" level.
+---         NOTE: channel communication is logged, this may contain
+---         private info, e.g. a password you type in a terminal window.
+--- 5	Shell commands.
+--- 6	Activity from `shada`, `swap-file`, `spell`, 'undofile',
+--- 	`:source`, `tags`, `include-search`.
+--- 8	Filenames where autocommands executed.
+--- 9	Event handler (autocommands) execution.
 --- 11	Finding items in a path.
---- 12	Vimscript function calls.
---- 13	When an exception is thrown, caught, finished, or discarded.
---- 14	Anything pending in a ":finally" clause.
+--- 12	Vimscript function execution.
+--- 13	Exceptions thrown, caught, finished, or discarded.
+--- 14	Pending ":finally" clauses.
 --- 15	Ex commands from a script (truncated at 200 characters).
 --- 16	Ex commands.
 ---

--- a/runtime/lua/vim/_meta/options.gen.lua
+++ b/runtime/lua/vim/_meta/options.gen.lua
@@ -7870,25 +7870,31 @@ vim.bo.vts = vim.bo.vartabstop
 --- Sets the verbosity level.  Also set by `-V` and `:verbose`.
 ---
 --- Tracing of assignments to options, mappings, etc. in Lua scripts is
---- enabled at level 1; Lua scripts are not traced when 'verbose' is 0,
+--- enabled at level 3; Lua scripts are not traced when 'verbose' is 0,
 --- for performance.
 ---
---- If greater than or equal to a given level, Nvim produces the following
+--- If greater than or equal to a given level, Nvim logs the following
 --- messages:
 ---
 --- Level   Messages ~
 --- ----------------------------------------------------------------------
---- 1	Enables Lua tracing (see above). Does not produce messages.
---- 2	When a file is ":source"'ed, or `shada` file is read or written.
---- 3	UI info, terminal capabilities.
---- 4	Shell commands.
---- 5	Every searched tags file and include file.
---- 8	Files for which a group of autocommands is executed.
---- 9	Executed autocommands.
+--- 1	Enables `nvim_log()` at "warning" level.
+--- 2	Enables `nvim_log()` at "info" level.
+--- 3	Enables Lua tracing (see above).
+--- 	Enables `nvim_log()` at "debug" level.
+--- 	UI info, terminal capabilities.
+--- 4	Enables `nvim_log()` at "trace" level.
+---         NOTE: channel communication is logged, this may contain
+---         private info, e.g. a password you type in a terminal window.
+--- 5	Shell commands.
+--- 6	Activity from `shada`, `swap-file`, `spell`, 'undofile',
+--- 	`:source`, `tags`, `include-search`.
+--- 8	Filenames where autocommands executed.
+--- 9	Event handler (autocommands) execution.
 --- 11	Finding items in a path.
---- 12	Vimscript function calls.
---- 13	When an exception is thrown, caught, finished, or discarded.
---- 14	Anything pending in a ":finally" clause.
+--- 12	Vimscript function execution.
+--- 13	Exceptions thrown, caught, finished, or discarded.
+--- 14	Pending ":finally" clauses.
 --- 15	Ex commands from a script (truncated at 200 characters).
 --- 16	Ex commands.
 ---

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -95,6 +95,13 @@ typedef struct {
 } Dict(keymap);
 
 typedef struct {
+  OptionalKeys is_set__log_;
+  String type;
+  Boolean join;
+  Integer trunc;
+} Dict(log);
+
+typedef struct {
   Boolean builtin;
 } Dict(get_commands);
 

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -100,6 +100,13 @@ typedef struct {
 } Dict(keymap_del);
 
 typedef struct {
+  OptionalKeys is_set__log_;
+  String type;
+  Boolean join;
+  Integer trunc;
+} Dict(log);
+
+typedef struct {
   Boolean builtin;
 } Dict(get_commands);
 

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -37,17 +37,17 @@
 #define CBUF_TO_ARENA_STR(arena, s, len) arena_string(arena, cbuf_as_string((char *)(s), len))
 #define CBUF_TO_ARENA_OBJ(arena, s, len) STRING_OBJ(CBUF_TO_ARENA_STR(arena, s, len))
 
-#define BUFFER_OBJ(s) ((Object) { \
+#define BUFFER_OBJ(o) ((Object) { \
     .type = kObjectTypeBuffer, \
-    .data.integer = s })
+    .data.integer = (o) })
 
-#define WINDOW_OBJ(s) ((Object) { \
+#define WINDOW_OBJ(o) ((Object) { \
     .type = kObjectTypeWindow, \
-    .data.integer = s })
+    .data.integer = (o) })
 
-#define TABPAGE_OBJ(s) ((Object) { \
+#define TABPAGE_OBJ(o) ((Object) { \
     .type = kObjectTypeTabpage, \
-    .data.integer = s })
+    .data.integer = (o) })
 
 #define ARRAY_OBJ(a) ((Object) { \
     .type = kObjectTypeArray, \

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -89,6 +89,52 @@
 
 #include "api/vim.c.generated.h"
 
+/// Posts a message to the global logger (which by default synchronously writes to |$NVIM_LOG_FILE|
+/// using a best-effort, naive implementation).
+///
+/// Message is skipped (not logged) if `level` is not "error", unless 'verbose' is set.
+///
+/// Example log message:
+/// ```
+/// ERROR 2020-01-12T01:56:19.484 93296 pynvim:remote: connected…
+/// ^level ^timestamp             ^pid  ^category      ^message
+/// ```
+///
+/// @see |nvim_get_chan_info()|
+/// @see |nvim_set_client_info()|
+///
+/// @param channel_id Channel id (implicit dispatcher arg)
+/// @param level  Log level (from highest to lowest: "ERR", "WRN", "INF", "DBG"). If 'verbose' is
+///               not set, only "ERR" messages are written to |$NVIM_LOG_FILE|.
+/// @param msg  Message body
+/// @param opts  Optional parameters:
+///   - `join`: (boolean, default false) Replace embedded line endings with SPACE, to keep the message on one log-line.
+///   - `trunc`: (integer, default 0) Constrain the message body to this size.
+///   - `type`: (string) Name of the subsystem or grouping (e.g. "UI", "RPC", "MyPlugin", …). For
+///     API clients this defaults to the `client.name` field of |nvim_get_chan_info()|.
+/// @param[out] err Error details, if any.
+void nvim_log(uint64_t channel_id, String level, String msg, Dict(log) *opts, Error *err)
+  FUNC_API_SINCE(14)
+{
+  int loglevel = log_level_from_name(level.data);
+  VALIDATE_S(loglevel != -1, "level", level.data, {
+    return;
+  });
+
+  bool join = HAS_KEY(opts, log, join) && opts->join;
+  int64_t trunc = HAS_KEY(opts, log, trunc) && opts->trunc > 0 ? opts->trunc : 0;
+
+  char p[32];  // Formatted prefix.
+  if (HAS_KEY(opts, log, type) && opts->type.size > 0) {
+    snprintf(p, sizeof(p), "%s: ", opts->type.data);
+  } else {
+    // Generate a default category/group/prefix.
+    rpc_chan_desc(channel_id, p, sizeof(p) - 2);
+    strcat(p, ": ");
+  }
+  logmsg(loglevel, p, NULL, -1, join, (size_t)trunc, true, "%s", msg.data);
+}
+
 /// Gets a highlight group by name
 ///
 /// similar to |hlID()|, but allocates a new ID if not present.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -92,6 +92,52 @@
 
 #include "api/vim.c.generated.h"
 
+/// Posts a message to the global logger (which by default synchronously writes to |$NVIM_LOG_FILE|
+/// using a best-effort, naive implementation).
+///
+/// Message is skipped (not logged) if `level` is not "error", unless 'verbose' is set.
+///
+/// Example log message:
+/// ```
+/// ERROR 2020-01-12T01:56:19.484 93296 pynvim:remote: connected…
+/// ^level ^timestamp             ^pid  ^category      ^message
+/// ```
+///
+/// @see |nvim_get_chan_info()|
+/// @see |nvim_set_client_info()|
+///
+/// @param channel_id Channel id (implicit dispatcher arg)
+/// @param level  Log level (from highest to lowest: "ERR", "WRN", "INF", "DBG"). If 'verbose' is
+///               not set, only "ERR" messages are written to |$NVIM_LOG_FILE|.
+/// @param msg  Message body
+/// @param opts  Optional parameters:
+///   - `join`: (boolean, default false) Replace embedded line endings with SPACE, to keep the message on one log-line.
+///   - `trunc`: (integer, default 0) Constrain the message body to this size.
+///   - `type`: (string) Name of the subsystem or grouping (e.g. "UI", "RPC", "MyPlugin", …). For
+///     API clients this defaults to the `client.name` field of |nvim_get_chan_info()|.
+/// @param[out] err Error details, if any.
+void nvim_log(uint64_t channel_id, String level, String msg, Dict(log) *opts, Error *err)
+  FUNC_API_SINCE(14)
+{
+  int loglevel = log_level_from_name(level.data);
+  VALIDATE_S(loglevel != -1, "level", level.data, {
+    return;
+  });
+
+  bool join = HAS_KEY(opts, log, join) && opts->join;
+  int64_t trunc = HAS_KEY(opts, log, trunc) && opts->trunc > 0 ? opts->trunc : 0;
+
+  char p[32];  // Formatted prefix.
+  if (HAS_KEY(opts, log, type) && opts->type.size > 0) {
+    snprintf(p, sizeof(p), "%s: ", opts->type.data);
+  } else {
+    // Generate a default category/group/prefix.
+    rpc_chan_desc(channel_id, p, sizeof(p) - 2);
+    strcat(p, ": ");
+  }
+  logmsg(loglevel, p, NULL, -1, join, (size_t)trunc, true, "%s", msg.data);
+}
+
 /// Gets a highlight group by name
 ///
 /// similar to |hlID()|, but allocates a new ID if not present.

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -514,7 +514,7 @@ list_T *eval_spell_expr(char *badword, char *expr)
   // Set "v:val" to the bad word.
   prepare_vimvar(VV_VAL, &save_val);
   set_vim_var_string(VV_VAL, badword, -1);
-  if (p_verbose == 0) {
+  if (p_verbose <= 1) {
     emsg_off++;
   }
   sctx_T *ctx = get_option_sctx(kOptSpellsuggest);
@@ -534,7 +534,7 @@ list_T *eval_spell_expr(char *badword, char *expr)
     }
   }
 
-  if (p_verbose == 0) {
+  if (p_verbose <= 1) {
     emsg_off--;
   }
   tv_clear(get_vim_var_tv(VV_VAL));

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -528,7 +528,7 @@ list_T *eval_spell_expr(char *badword, char *expr)
   // Set "v:val" to the bad word.
   prepare_vimvar(VV_VAL, &save_val);
   set_vim_var_string(VV_VAL, badword, -1);
-  if (p_verbose == 0) {
+  if (p_verbose <= 1) {
     emsg_off++;
   }
   sctx_T *ctx = get_option_sctx(kOptSpellsuggest);
@@ -548,7 +548,7 @@ list_T *eval_spell_expr(char *badword, char *expr)
     }
   }
 
-  if (p_verbose == 0) {
+  if (p_verbose <= 1) {
     emsg_off--;
   }
   tv_clear(get_vim_var_tv(VV_VAL));

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2896,7 +2896,7 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
 
     // Obey the 'O' flag in 'cpoptions': overwrite any previous file
     // message.
-    if (shortmess(SHM_OVERALL) && !msg_listdo_overwrite && !exiting && p_verbose == 0) {
+    if (shortmess(SHM_OVERALL) && !msg_listdo_overwrite && !exiting && p_verbose <= 1) {
       msg_scroll = false;
     }
     if (!msg_scroll) {          // wait a bit when overwriting an error msg

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2897,7 +2897,7 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
 
     // Obey the 'O' flag in 'cpoptions': overwrite any previous file
     // message.
-    if (shortmess(kShmOverall) && !msg_listdo_overwrite && !exiting && p_verbose == 0) {
+    if (shortmess(kShmOverall) && !msg_listdo_overwrite && !exiting && p_verbose <= 1) {
       msg_scroll = false;
     }
     if (!msg_scroll) {          // wait a bit when overwriting an error msg

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -124,7 +124,7 @@ void filemess(buf_T *buf, char *name, char *s)
   // For further ones overwrite the previous one, reset msg_scroll before
   // calling filemess().
   int msg_scroll_save = msg_scroll;
-  if (shortmess(SHM_OVERALL) && !msg_listdo_overwrite && !exiting && p_verbose == 0) {
+  if (shortmess(SHM_OVERALL) && !msg_listdo_overwrite && !exiting && p_verbose <= 1) {
     msg_scroll = false;
   }
   if (!msg_scroll) {    // wait a bit when overwriting an error msg
@@ -344,7 +344,7 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
     }
   }
 
-  if (((shortmess(SHM_OVER) && !msg_listdo_overwrite) || curbuf->b_help) && p_verbose == 0) {
+  if (((shortmess(SHM_OVER) && !msg_listdo_overwrite) || curbuf->b_help) && p_verbose <= 1) {
     msg_scroll = false;         // overwrite previous file message
   } else {
     msg_scroll = true;          // don't overwrite previous file message

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -130,7 +130,7 @@ static void filemess(buf_T *buf, char *name, char *s, const char *msg_id)
   // For further ones overwrite the previous one, reset msg_scroll before
   // calling filemess().
   int msg_scroll_save = msg_scroll;
-  if (shortmess(kShmOverall) && !msg_listdo_overwrite && !exiting && p_verbose == 0) {
+  if (shortmess(kShmOverall) && !msg_listdo_overwrite && !exiting && p_verbose <= 1) {
     msg_scroll = false;
   }
   if (!msg_scroll) {    // wait a bit when overwriting an error msg
@@ -350,7 +350,7 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
     }
   }
 
-  if (((shortmess(kShmOver) && !msg_listdo_overwrite) || curbuf->b_help) && p_verbose == 0) {
+  if (((shortmess(kShmOver) && !msg_listdo_overwrite) || curbuf->b_help) && p_verbose <= 1) {
     msg_scroll = false;         // overwrite previous file message
   } else {
     msg_scroll = true;          // don't overwrite previous file message

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -29,7 +29,15 @@
 #include "nvim/os/stdpaths_defs.h"
 #include "nvim/os/time.h"
 #include "nvim/path.h"
+#include "nvim/strings.h"
 #include "nvim/ui_client.h"
+
+static const char *log_levels[] = {
+  [LOGLVL_DBG] = "DBG",
+  [LOGLVL_INF] = "INF",
+  [LOGLVL_WRN] = "WRN",
+  [LOGLVL_ERR] = "ERR",
+};
 
 /// Cached location of the expanded log file path decided by log_path_init().
 static char log_file_path[MAXPATHL + 1] = { 0 };
@@ -127,6 +135,17 @@ void log_unlock(void)
   uv_mutex_unlock(&mutex);
 }
 
+int log_level_from_name(char *name)
+{
+  for (size_t i = 0; i < ARRAY_SIZE(log_levels); i++) {
+    if (log_levels[i] != NULL && striequal(name, log_levels[i])) {
+      assert(i <= INT_MAX);
+      return (int)i;
+    }
+  }
+  return -1;
+}
+
 /// Logs a message to $NVIM_LOG_FILE.
 ///
 /// @param log_level  Log level (see log.h)
@@ -139,9 +158,8 @@ void log_unlock(void)
 /// @param fmt        printf-style format string
 ///
 /// @return true if log was emitted normally, false if failed or recursive
-bool logmsg(int log_level, const char *context, const char *func_name,
-            int line_num, bool join, size_t trunc, bool eol,
-            const char *fmt, ...)
+bool logmsg(int log_level, const char *context, const char *func_name, int line_num, bool join,
+            size_t trunc, bool eol, const char *fmt, ...)
   FUNC_ATTR_PRINTF(8, 9)
 {
   static bool recursive = false;
@@ -287,8 +305,8 @@ void log_callstack(const char *const func_name, const int line_num)
 #endif
 
 static bool do_log_to_file(FILE *log_file, int log_level, const char *context,
-                           const char *func_name, int line_num, bool join,
-                           size_t trunc, bool eol, const char *fmt, ...)
+                           const char *func_name, int line_num, bool join, size_t trunc, bool eol,
+                           const char *fmt, ...)
   FUNC_ATTR_PRINTF(9, 10)
 {
   va_list args;
@@ -301,20 +319,13 @@ static bool do_log_to_file(FILE *log_file, int log_level, const char *context,
 }
 
 static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
-                             const char *func_name, int line_num, bool join,
-                             size_t trunc, bool eol, const char *fmt,
-                             va_list args)
-  FUNC_ATTR_PRINTF(7, 0)
+                             const char *func_name, int line_num, bool join, size_t trunc, bool eol,
+                             const char *fmt, va_list args)
+  FUNC_ATTR_PRINTF(9, 0)
 {
   // Name of the Nvim instance that produced the log.
   static char name[32] = { 0 };
 
-  static const char *log_levels[] = {
-    [LOGLVL_DBG] = "DBG",
-    [LOGLVL_INF] = "INF",
-    [LOGLVL_WRN] = "WRN",
-    [LOGLVL_ERR] = "ERR",
-  };
   assert(log_level >= LOGLVL_DBG && log_level <= LOGLVL_ERR);
 
   // Format the timestamp.
@@ -362,13 +373,13 @@ static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
   int len = 0;  // Total length.
   // Format the log-message "prefix".
   int prefixlen = (line_num == -1 || func_name == NULL)
-           ? snprintf(os_buf, sizeof(os_buf), "%s %s.%03d %-10s %s",
-                     log_levels[log_level], date_time, millis, name,
-                     (context == NULL ? "?:" : context))
-           : snprintf(os_buf, sizeof(os_buf), "%s %s.%03d %-10s %s%s:%d: ",
-                     log_levels[log_level], date_time, millis, name,
-                     (context == NULL ? "" : context),
-                     func_name, line_num);
+                  ? snprintf(os_buf, sizeof(os_buf), "%-*.*s %s.%03d %-10s %s",
+                             5, 5, log_levels[log_level], date_time, millis, name,
+                             (context == NULL ? "?:" : context))
+                  : snprintf(os_buf, sizeof(os_buf), "%-*.*s %s.%03d %-10s %s%s:%d: ",
+                             5, 5, log_levels[log_level], date_time, millis, name,
+                             (context == NULL ? "" : context),
+                             func_name, line_num);
 
   // Append the caller-provided stuff to log message prefix.
   if (prefixlen >= 0 && (size_t)prefixlen < sizeof(os_buf)) {
@@ -384,8 +395,8 @@ static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
   }
   // Write result to file (truncate if specified).
   int rv = (trunc > 0)
-    ? fprintf(log_file, "%.*s", (int)trunc + prefixlen, os_buf)
-    : fprintf(log_file, "%s", os_buf);
+           ? fprintf(log_file, "%.*s", (int)trunc + prefixlen, os_buf)
+           : fprintf(log_file, "%s", os_buf);
 
   if (rv < 0) {
     return false;

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -134,12 +134,15 @@ void log_unlock(void)
 /// @param func_name  Function name, or NULL
 /// @param line_num   Source line number, or -1
 /// @param eol        Append linefeed "\n"
+/// @param join       Replace line endings with SPACE
+/// @param trunc      Truncate to this length
 /// @param fmt        printf-style format string
 ///
 /// @return true if log was emitted normally, false if failed or recursive
-bool logmsg(int log_level, const char *context, const char *func_name, int line_num, bool eol,
+bool logmsg(int log_level, const char *context, const char *func_name,
+            int line_num, bool join, size_t trunc, bool eol,
             const char *fmt, ...)
-  FUNC_ATTR_PRINTF(6, 7)
+  FUNC_ATTR_PRINTF(8, 9)
 {
   static bool recursive = false;
   static bool did_msg = false;  // Showed recursion message?
@@ -186,7 +189,7 @@ bool logmsg(int log_level, const char *context, const char *func_name, int line_
   va_list args;
   va_start(args, fmt);
   ret = v_do_log_to_file(log_file, log_level, context, func_name, line_num,
-                         eol, fmt, args);
+                         join, trunc, eol, fmt, args);
   va_end(args);
 
   if (log_file != stderr && log_file != stdout) {
@@ -231,7 +234,7 @@ FILE *open_log_file(void)
   //  - LOG() is called before log_init()
   //  - Directory does not exist
   //  - File is not writable
-  do_log_to_file(stderr, LOGLVL_ERR, NULL, __func__, __LINE__, true,
+  do_log_to_file(stderr, LOGLVL_ERR, NULL, __func__, __LINE__, false, 0, true,
                  "failed to open $" ENV_LOGFILE " (%s): %s",
                  strerror(errno), log_file_path);
   return stderr;
@@ -260,7 +263,7 @@ void log_callstack_to_file(FILE *log_file, const char *const func_name, const in
   // Now we have a command string like:
   //    addr2line -e /path/to/exe -f -p 0x123 0x456 ...
 
-  do_log_to_file(log_file, LOGLVL_DBG, NULL, func_name, line_num, true, "trace:");
+  do_log_to_file(log_file, LOGLVL_DBG, NULL, func_name, line_num, false, 0, true, "trace:");
   FILE *fp = popen(cmdbuf, "r");
   assert(fp);
   char linebuf[IOSIZE];
@@ -284,20 +287,22 @@ void log_callstack(const char *const func_name, const int line_num)
 #endif
 
 static bool do_log_to_file(FILE *log_file, int log_level, const char *context,
-                           const char *func_name, int line_num, bool eol, const char *fmt, ...)
-  FUNC_ATTR_PRINTF(7, 8)
+                           const char *func_name, int line_num, bool join,
+                           size_t trunc, bool eol, const char *fmt, ...)
+  FUNC_ATTR_PRINTF(9, 10)
 {
   va_list args;
   va_start(args, fmt);
   bool ret = v_do_log_to_file(log_file, log_level, context, func_name,
-                              line_num, eol, fmt, args);
+                              line_num, join, trunc, eol, fmt, args);
   va_end(args);
 
   return ret;
 }
 
 static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
-                             const char *func_name, int line_num, bool eol, const char *fmt,
+                             const char *func_name, int line_num, bool join,
+                             size_t trunc, bool eol, const char *fmt,
                              va_list args)
   FUNC_ATTR_PRINTF(7, 0)
 {
@@ -354,20 +359,35 @@ static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
     }
   }
 
-  // Print the log message.
-  int rv = (line_num == -1 || func_name == NULL)
-           ? fprintf(log_file, "%s %s.%03d %-10s %s",
+  int len = 0;  // Total length.
+  // Format the log-message "prefix".
+  int prefixlen = (line_num == -1 || func_name == NULL)
+           ? snprintf(os_buf, sizeof(os_buf), "%s %s.%03d %-10s %s",
                      log_levels[log_level], date_time, millis, name,
                      (context == NULL ? "?:" : context))
-           : fprintf(log_file, "%s %s.%03d %-10s %s%s:%d: ",
+           : snprintf(os_buf, sizeof(os_buf), "%s %s.%03d %-10s %s%s:%d: ",
                      log_levels[log_level], date_time, millis, name,
                      (context == NULL ? "" : context),
                      func_name, line_num);
 
-  if (rv < 0) {
-    return false;
+  // Append the caller-provided stuff to log message prefix.
+  if (prefixlen >= 0 && (size_t)prefixlen < sizeof(os_buf)) {
+    len = vsnprintf(os_buf + prefixlen, sizeof(os_buf) - (size_t)prefixlen,
+                    fmt, args);
+    len = len >= 0 && (size_t)len > sizeof(os_buf) ? sizeof(os_buf) : MAX(0, len);
+    len += prefixlen;
   }
-  if (vfprintf(log_file, fmt, args) < 0) {
+  // Scrub CRLF if requested.
+  if (join && len - prefixlen > 0) {
+    memchrsub(os_buf + prefixlen, '\n', ' ', (size_t)len - (size_t)prefixlen);
+    memchrsub(os_buf + prefixlen, '\r', ' ', (size_t)len - (size_t)prefixlen);
+  }
+  // Write result to file (truncate if specified).
+  int rv = (trunc > 0)
+    ? fprintf(log_file, "%.*s", (int)trunc + prefixlen, os_buf)
+    : fprintf(log_file, "%s", os_buf);
+
+  if (rv < 0) {
     return false;
   }
   if (eol) {

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -27,13 +27,14 @@
 #define LOGLVL_WRN 3
 #define LOGLVL_ERR 4
 
-#define LOG(level, ...) logmsg((level), NULL, __func__, __LINE__, true, __VA_ARGS__)
+#define LOG(level, join, trunc, ...) logmsg((level), NULL, __func__, __LINE__, \
+                                            (join), (trunc), true, __VA_ARGS__)
 
 #ifdef NVIM_LOG_DEBUG
-# define DLOG(...) logmsg(LOGLVL_DBG, NULL, __func__, __LINE__, true, __VA_ARGS__)
-# define DLOGN(...) logmsg(LOGLVL_DBG, NULL, __func__, __LINE__, false, __VA_ARGS__)
-# define ILOG(...) logmsg(LOGLVL_INF, NULL, __func__, __LINE__, true, __VA_ARGS__)
-# define ILOGN(...) logmsg(LOGLVL_INF, NULL, __func__, __LINE__, false, __VA_ARGS__)
+# define DLOG(...) logmsg(LOGLVL_DBG, NULL, __func__, __LINE__, false, 0, true, __VA_ARGS__)
+# define DLOGN(...) logmsg(LOGLVL_DBG, NULL, __func__, __LINE__, false, 0, false, __VA_ARGS__)
+# define ILOG(...) logmsg(LOGLVL_INF, NULL, __func__, __LINE__, false, 0, true, __VA_ARGS__)
+# define ILOGN(...) logmsg(LOGLVL_INF, NULL, __func__, __LINE__, false, 0, false, __VA_ARGS__)
 #else
 # define DLOG(...)
 # define DLOGN(...)
@@ -41,10 +42,10 @@
 # define ILOGN(...)
 #endif
 
-#define WLOG(...) logmsg(LOGLVL_WRN, NULL, __func__, __LINE__, true, __VA_ARGS__)
-#define WLOGN(...) logmsg(LOGLVL_WRN, NULL, __func__, __LINE__, false, __VA_ARGS__)
-#define ELOG(...) logmsg(LOGLVL_ERR, NULL, __func__, __LINE__, true, __VA_ARGS__)
-#define ELOGN(...) logmsg(LOGLVL_ERR, NULL, __func__, __LINE__, false, __VA_ARGS__)
+#define WLOG(...) logmsg(LOGLVL_WRN, NULL, __func__, __LINE__, false, 0, true, __VA_ARGS__)
+#define WLOGN(...) logmsg(LOGLVL_WRN, NULL, __func__, __LINE__, false, 0, false, __VA_ARGS__)
+#define ELOG(...) logmsg(LOGLVL_ERR, NULL, __func__, __LINE__, false, 0, true, __VA_ARGS__)
+#define ELOGN(...) logmsg(LOGLVL_ERR, NULL, __func__, __LINE__, false, 0, false, __VA_ARGS__)
 
 #ifdef HAVE_EXECINFO_BACKTRACE
 # define LOG_CALLSTACK() log_callstack(__func__, __LINE__)

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3541,7 +3541,7 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname, bool *found_
           // - the swapfile has no changes and looks OK
           if (os_path_exists(buf->b_fname) && swapfile_unchanged(fname)) {
             choice = SEA_CHOICE_DELETE;
-            if (p_verbose > 0) {
+            if (p_verbose > 1) {
               verb_msg(_("Found a swap file that is not useful, deleting it"));
             }
           }

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3571,7 +3571,7 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname, bool *found_
           // - the swapfile has no changes and looks OK
           if (os_path_exists(buf->b_fname) && swapfile_unchanged(fname)) {
             choice = SEA_CHOICE_DELETE;
-            if (p_verbose > 0) {
+            if (p_verbose > 1) {
               verb_msg(_("Found a swap file that is not useful, deleting it"));
             }
           }

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -106,7 +106,7 @@ static void do_outofmem_msg(size_t size)
 ///
 /// @see {try_to_free_memory}
 /// @param size
-/// @return pointer to allocated space. NULL if out of memory
+/// @return Pointer to allocated space. NULL if out of memory
 void *try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1)
 {
   size_t allocated_size = size ? size : 1;
@@ -123,7 +123,7 @@ void *try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1)
 ///
 /// @see {try_malloc}
 /// @param size
-/// @return pointer to allocated space. NULL if out of memory
+/// @return Pointer to allocated space. NULL if out of memory
 void *verbose_try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1)
 {
   void *ret = try_malloc(size);
@@ -140,7 +140,7 @@ void *verbose_try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1)
 ///
 /// @see {try_to_free_memory}
 /// @param size
-/// @return pointer to allocated space. Never NULL
+/// @return Pointer to allocated space. Never NULL
 void *xmalloc(size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1) FUNC_ATTR_NONNULL_RET
 {
@@ -164,7 +164,7 @@ void xfree(void *ptr)
 /// @see {xmalloc}
 /// @param count
 /// @param size
-/// @return pointer to allocated space. Never NULL
+/// @return Pointer to allocated space. Never NULL
 void *xcalloc(size_t count, size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE_PROD(1, 2) FUNC_ATTR_NONNULL_RET
 {
@@ -185,7 +185,7 @@ void *xcalloc(size_t count, size_t size)
 ///
 /// @see {xmalloc}
 /// @param size
-/// @return pointer to reallocated space. Never NULL
+/// @return Pointer to reallocated space. Never NULL
 void *xrealloc(void *ptr, size_t size)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALLOC_SIZE(2) FUNC_ATTR_NONNULL_RET
 {
@@ -207,7 +207,7 @@ void *xrealloc(void *ptr, size_t size)
 ///
 /// @see {xmalloc}
 /// @param size
-/// @return pointer to allocated space. Never NULL
+/// @return Pointer to allocated space. Never NULL
 void *xmallocz(size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_RET FUNC_ATTR_WARN_UNUSED_RESULT
 {
@@ -229,7 +229,7 @@ void *xmallocz(size_t size)
 ///
 /// @see {xmalloc}
 /// @param data Pointer to the data that will be copied
-/// @param len number of bytes that will be copied
+/// @param len Number of bytes that will be copied
 void *xmemdupz(const void *data, size_t len)
   FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_RET FUNC_ATTR_WARN_UNUSED_RESULT
   FUNC_ATTR_NONNULL_ALL
@@ -266,9 +266,9 @@ size_t xstrnlen(const char *s, size_t n)
 /// A version of strchr() that returns a pointer to the terminating NUL if it
 /// doesn't find `c`.
 ///
-/// @param str The string to search.
-/// @param c   The char to look for.
-/// @returns a pointer to the first instance of `c`, or to the NUL terminator
+/// @param str String to search.
+/// @param c   Char to look for.
+/// @returns Pointer to the first instance of `c`, or to the NUL terminator
 ///          if not found.
 char *xstrchrnul(const char *str, char c)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
@@ -280,10 +280,10 @@ char *xstrchrnul(const char *str, char c)
 /// A version of memchr() that returns a pointer one past the end
 /// if it doesn't find `c`.
 ///
-/// @param addr The address of the memory object.
-/// @param c    The char to look for.
-/// @param size The size of the memory object.
-/// @returns a pointer to the first instance of `c`, or one past the end if not
+/// @param addr Address of the memory object.
+/// @param c    Char to look for.
+/// @param size Size of the memory object.
+/// @returns Pointer to the first instance of `c`, or one past the end if not
 ///          found.
 void *xmemscan(const void *addr, char c, size_t size)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
@@ -296,9 +296,9 @@ void *xmemscan(const void *addr, char c, size_t size)
 ///
 /// @warning Will read past `str + strlen(str)` if `c == NUL`.
 ///
-/// @param str A NUL-terminated string.
-/// @param c   The unwanted byte.
-/// @param x   The replacement.
+/// @param str NUL-terminated string.
+/// @param c   Unwanted byte.
+/// @param x   Replacement byte.
 void strchrsub(char *str, char c, char x)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -310,10 +310,10 @@ void strchrsub(char *str, char c, char x)
 
 /// Replaces every instance of `c` with `x`.
 ///
-/// @param data An object in memory. May contain NULs.
-/// @param c    The unwanted byte.
-/// @param x    The replacement.
-/// @param len  The length of data.
+/// @param data Object in memory. May contain NULs.
+/// @param c    Unwanted byte.
+/// @param x    Replacement byte.
+/// @param len  Length of data.
 void memchrsub(void *data, char c, char x, size_t len)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -329,8 +329,8 @@ void memchrsub(void *data, char c, char x, size_t len)
 /// @warning Unsafe if `c == NUL`.
 ///
 /// @param str Pointer to the string to search.
-/// @param c   The byte to search for.
-/// @returns the number of occurrences of `c` in `str`.
+/// @param c   Byte to search for.
+/// @returns Number of occurrences of `c` in `str`.
 size_t strcnt(const char *str, char c)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
@@ -346,9 +346,9 @@ size_t strcnt(const char *str, char c)
 /// Counts the number of occurrences of byte `c` in `data[len]`.
 ///
 /// @param data Pointer to the data to search.
-/// @param c    The byte to search for.
-/// @param len  The length of `data`.
-/// @returns the number of occurrences of `c` in `data[len]`.
+/// @param c    Byte to search for.
+/// @param len  Length of `data`.
+/// @returns Number of occurrences of `c` in `data[len]`.
 size_t memcnt(const void *data, char c, size_t len)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
@@ -365,7 +365,7 @@ size_t memcnt(const void *data, char c, size_t len)
 /// Copies the string pointed to by src (including the terminating NUL
 /// character) into the array pointed to by dst.
 ///
-/// @returns pointer to the terminating NUL char copied into the dst buffer.
+/// @returns Pointer to the terminating NUL char copied into the dst buffer.
 ///          This is the only difference with strcpy(), which returns dst.
 ///
 /// WARNING: If copying takes place between objects that overlap, the behavior
@@ -500,10 +500,10 @@ char *xstrdupnul(const char *const str)
 ///
 /// Based on glibc's memrchr.
 ///
-/// @param src The source memory object.
-/// @param c   The byte to search for.
-/// @param len The length of the memory object.
-/// @returns a pointer to the found byte in src[len], or NULL.
+/// @param src Source memory object.
+/// @param c   Byte to search for.
+/// @param len Length of the memory object.
+/// @returns Pointer to the found byte in src[len], or NULL.
 void *xmemrchr(const void *src, uint8_t c, size_t len)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
@@ -519,7 +519,7 @@ void *xmemrchr(const void *src, uint8_t c, size_t len)
 ///
 /// @see {xmalloc}
 /// @param str 0-terminated string that will be copied
-/// @return pointer to a copy of the string
+/// @return Pointer to a copy of the string
 char *xstrndup(const char *str, size_t len)
   FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_RET
   FUNC_ATTR_NONNULL_ALL
@@ -531,9 +531,9 @@ char *xstrndup(const char *str, size_t len)
 /// Duplicates a chunk of memory using xmalloc
 ///
 /// @see {xmalloc}
-/// @param data pointer to the chunk
-/// @param len size of the chunk
-/// @return a pointer
+/// @param data Pointer to the chunk
+/// @param len Size of the chunk
+/// @return Pointer
 void *xmemdup(const void *data, size_t len)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(2) FUNC_ATTR_NONNULL_RET
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -108,7 +108,7 @@ static void do_outofmem_msg(size_t size)
 ///
 /// @see {try_to_free_memory}
 /// @param size
-/// @return pointer to allocated space. NULL if out of memory
+/// @return Pointer to allocated space. NULL if out of memory
 void *try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1)
 {
   size_t allocated_size = size ? size : 1;
@@ -125,7 +125,7 @@ void *try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1)
 ///
 /// @see {try_malloc}
 /// @param size
-/// @return pointer to allocated space. NULL if out of memory
+/// @return Pointer to allocated space. NULL if out of memory
 void *verbose_try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1)
 {
   void *ret = try_malloc(size);
@@ -142,7 +142,7 @@ void *verbose_try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1)
 ///
 /// @see {try_to_free_memory}
 /// @param size
-/// @return pointer to allocated space. Never NULL
+/// @return Pointer to allocated space. Never NULL
 void *xmalloc(size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1) FUNC_ATTR_NONNULL_RET
 {
@@ -166,7 +166,7 @@ void xfree(void *ptr)
 /// @see {xmalloc}
 /// @param count
 /// @param size
-/// @return pointer to allocated space. Never NULL
+/// @return Pointer to allocated space. Never NULL
 void *xcalloc(size_t count, size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE_PROD(1, 2) FUNC_ATTR_NONNULL_RET
 {
@@ -187,7 +187,7 @@ void *xcalloc(size_t count, size_t size)
 ///
 /// @see {xmalloc}
 /// @param size
-/// @return pointer to reallocated space. Never NULL
+/// @return Pointer to reallocated space. Never NULL
 void *xrealloc(void *ptr, size_t size)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALLOC_SIZE(2) FUNC_ATTR_NONNULL_RET
 {
@@ -209,7 +209,7 @@ void *xrealloc(void *ptr, size_t size)
 ///
 /// @see {xmalloc}
 /// @param size
-/// @return pointer to allocated space. Never NULL
+/// @return Pointer to allocated space. Never NULL
 void *xmallocz(size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_RET FUNC_ATTR_WARN_UNUSED_RESULT
 {
@@ -231,7 +231,7 @@ void *xmallocz(size_t size)
 ///
 /// @see {xmalloc}
 /// @param data Pointer to the data that will be copied
-/// @param len number of bytes that will be copied
+/// @param len Number of bytes that will be copied
 void *xmemdupz(const void *data, size_t len)
   FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_RET FUNC_ATTR_WARN_UNUSED_RESULT
   FUNC_ATTR_NONNULL_ALL
@@ -268,9 +268,9 @@ size_t xstrnlen(const char *s, size_t n)
 /// A version of strchr() that returns a pointer to the terminating NUL if it
 /// doesn't find `c`.
 ///
-/// @param str The string to search.
-/// @param c   The char to look for.
-/// @returns a pointer to the first instance of `c`, or to the NUL terminator
+/// @param str String to search.
+/// @param c   Char to look for.
+/// @returns Pointer to the first instance of `c`, or to the NUL terminator
 ///          if not found.
 char *xstrchrnul(const char *str, char c)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
@@ -282,10 +282,10 @@ char *xstrchrnul(const char *str, char c)
 /// A version of memchr() that returns a pointer one past the end
 /// if it doesn't find `c`.
 ///
-/// @param addr The address of the memory object.
-/// @param c    The char to look for.
-/// @param size The size of the memory object.
-/// @returns a pointer to the first instance of `c`, or one past the end if not
+/// @param addr Address of the memory object.
+/// @param c    Char to look for.
+/// @param size Size of the memory object.
+/// @returns Pointer to the first instance of `c`, or one past the end if not
 ///          found.
 void *xmemscan(const void *addr, char c, size_t size)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
@@ -298,9 +298,9 @@ void *xmemscan(const void *addr, char c, size_t size)
 ///
 /// @warning Will read past `str + strlen(str)` if `c == NUL`.
 ///
-/// @param str A NUL-terminated string.
-/// @param c   The unwanted byte.
-/// @param x   The replacement.
+/// @param str NUL-terminated string.
+/// @param c   Unwanted byte.
+/// @param x   Replacement byte.
 void strchrsub(char *str, char c, char x)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -312,10 +312,10 @@ void strchrsub(char *str, char c, char x)
 
 /// Replaces every instance of `c` with `x`.
 ///
-/// @param data An object in memory. May contain NULs.
-/// @param c    The unwanted byte.
-/// @param x    The replacement.
-/// @param len  The length of data.
+/// @param data Object in memory. May contain NULs.
+/// @param c    Unwanted byte.
+/// @param x    Replacement byte.
+/// @param len  Length of data.
 void memchrsub(void *data, char c, char x, size_t len)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -331,8 +331,8 @@ void memchrsub(void *data, char c, char x, size_t len)
 /// @warning Unsafe if `c == NUL`.
 ///
 /// @param str Pointer to the string to search.
-/// @param c   The byte to search for.
-/// @returns the number of occurrences of `c` in `str`.
+/// @param c   Byte to search for.
+/// @returns Number of occurrences of `c` in `str`.
 size_t strcnt(const char *str, char c)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
@@ -348,9 +348,9 @@ size_t strcnt(const char *str, char c)
 /// Counts the number of occurrences of byte `c` in `data[len]`.
 ///
 /// @param data Pointer to the data to search.
-/// @param c    The byte to search for.
-/// @param len  The length of `data`.
-/// @returns the number of occurrences of `c` in `data[len]`.
+/// @param c    Byte to search for.
+/// @param len  Length of `data`.
+/// @returns Number of occurrences of `c` in `data[len]`.
 size_t memcnt(const void *data, char c, size_t len)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
@@ -367,7 +367,7 @@ size_t memcnt(const void *data, char c, size_t len)
 /// Copies the string pointed to by src (including the terminating NUL
 /// character) into the array pointed to by dst.
 ///
-/// @returns pointer to the terminating NUL char copied into the dst buffer.
+/// @returns Pointer to the terminating NUL char copied into the dst buffer.
 ///          This is the only difference with strcpy(), which returns dst.
 ///
 /// WARNING: If copying takes place between objects that overlap, the behavior
@@ -502,10 +502,10 @@ char *xstrdupnul(const char *const str)
 ///
 /// Based on glibc's memrchr.
 ///
-/// @param src The source memory object.
-/// @param c   The byte to search for.
-/// @param len The length of the memory object.
-/// @returns a pointer to the found byte in src[len], or NULL.
+/// @param src Source memory object.
+/// @param c   Byte to search for.
+/// @param len Length of the memory object.
+/// @returns Pointer to the found byte in src[len], or NULL.
 void *xmemrchr(const void *src, uint8_t c, size_t len)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
@@ -521,7 +521,7 @@ void *xmemrchr(const void *src, uint8_t c, size_t len)
 ///
 /// @see {xmalloc}
 /// @param str 0-terminated string that will be copied
-/// @return pointer to a copy of the string
+/// @return Pointer to a copy of the string
 char *xstrndup(const char *str, size_t len)
   FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_RET
   FUNC_ATTR_NONNULL_ALL
@@ -533,9 +533,9 @@ char *xstrndup(const char *str, size_t len)
 /// Duplicates a chunk of memory using xmalloc
 ///
 /// @see {xmalloc}
-/// @param data pointer to the chunk
-/// @param len size of the chunk
-/// @return a pointer
+/// @param data Pointer to the chunk
+/// @param len Size of the chunk
+/// @return Pointer
 void *xmemdup(const void *data, size_t len)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(2) FUNC_ATTR_NONNULL_RET
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -544,7 +544,7 @@ static void chan_close_on_err(Channel *channel, char *msg, int loglevel)
 
   channel_close(channel->id, kChannelPartRpc, NULL);
 
-  LOG(loglevel, "RPC: %s", msg);
+  LOG(loglevel, false, 0, "RPC: %s", msg);
 }
 
 static void serialize_request(Channel **chans, size_t nchans, uint32_t request_id,

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -29,6 +29,7 @@
 #include "nvim/msgpack_rpc/packer_defs.h"
 #include "nvim/msgpack_rpc/unpacker.h"
 #include "nvim/os/input.h"
+#include "nvim/terminal.h"
 #include "nvim/types_defs.h"
 #include "nvim/ui.h"
 #include "nvim/ui_client.h"
@@ -46,20 +47,20 @@
 
 static void log_request(char *dir, uint64_t channel_id, uint32_t req_id, const char *name)
 {
-  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, "%s %" PRIu64 ": %s id=%u: %s\n", dir, channel_id,
-         REQ, req_id, name);
+  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, 0, true,
+         "%s %" PRIu64 ": %s id=%u: %s\n", dir, channel_id, REQ, req_id, name);
 }
 
 static void log_response(char *dir, uint64_t channel_id, char *kind, uint32_t req_id)
 {
-  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, "%s %" PRIu64 ": %s id=%u\n", dir, channel_id, kind,
-         req_id);
+  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, 0, true,
+         "%s %" PRIu64 ": %s id=%u\n", dir, channel_id, kind, req_id);
 }
 
 static void log_notify(char *dir, uint64_t channel_id, const char *name)
 {
-  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, "%s %" PRIu64 ": %s %s\n", dir, channel_id, NOT,
-         name);
+  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, 0, true,
+         "%s %" PRIu64 ": %s %s\n", dir, channel_id, NOT, name);
 }
 
 #else
@@ -681,6 +682,42 @@ void rpc_set_client_info(uint64_t id, Dict info)
 Dict rpc_client_info(Channel *chan)
 {
   return copy_dict(chan->rpc.info, NULL);
+}
+
+/// Describes a channel, for use in log messages etc.
+///
+/// @param chan_id  Channel id
+/// @param desc[out]  Description result
+/// @param desc_len  Size of `desc` storage
+void rpc_chan_desc(uint64_t chan_id, char *desc, size_t desc_len)
+{
+  Channel *chan = find_rpc_channel(chan_id);
+  char *type = NULL;
+  char *ch_type = NULL;
+  if (chan && chan->is_rpc) {
+    for (size_t i = 0; i < chan->rpc.info.size; i++) {
+      String k = chan->rpc.info.items[i].key;
+      Object v = chan->rpc.info.items[i].value;
+      if (strequal("name", k.data) && v.data.string.data && v.data.string.data[0] != '\0') {
+        type = v.data.string.data;
+      } else if (strequal("type", k.data) && v.data.string.data && v.data.string.data[0] != '\0') {
+        ch_type = v.data.string.data;
+      }
+    }
+    if (type && ch_type) {
+      snprintf(desc, desc_len, "%s:%s", type, ch_type);
+    } else if (type) {
+      snprintf(desc, desc_len, "%s", type);
+    } else {
+      snprintf(desc, desc_len, "%s", "?_?");
+    }
+  } else if (chan && chan->term) {
+    snprintf(desc, desc_len, "term:%" PRId64, (int64_t)terminal_buf(chan->term));
+  } else if (chan) {
+    snprintf(desc, desc_len, "chan:%" PRId64, chan_id);
+  } else {
+    snprintf(desc, desc_len, "%s", "?_?");
+  }
 }
 
 const char *get_client_info(Channel *chan, const char *key)

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -562,7 +562,7 @@ static void chan_close_on_err(Channel *channel, char *msg, int loglevel)
 
   channel_close(channel->id, kChannelPartRpc, NULL);
 
-  LOG(loglevel, "RPC: %s", msg);
+  LOG(loglevel, false, 0, "RPC: %s", msg);
 }
 
 static void serialize_request(Channel **chans, size_t nchans, uint32_t request_id,

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -29,6 +29,7 @@
 #include "nvim/msgpack_rpc/packer_defs.h"
 #include "nvim/msgpack_rpc/unpacker.h"
 #include "nvim/os/input.h"
+#include "nvim/terminal.h"
 #include "nvim/types_defs.h"
 #include "nvim/ui.h"
 #include "nvim/ui_client.h"
@@ -50,20 +51,20 @@
 
 static void log_request(char *dir, uint64_t channel_id, uint32_t req_id, const char *name)
 {
-  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, "%s %" PRIu64 ": %s id=%u: %s\n", dir, channel_id,
-         REQ, req_id, name);
+  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, 0, true,
+         "%s %" PRIu64 ": %s id=%u: %s\n", dir, channel_id, REQ, req_id, name);
 }
 
 static void log_response(char *dir, uint64_t channel_id, char *kind, uint32_t req_id)
 {
-  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, "%s %" PRIu64 ": %s id=%u\n", dir, channel_id, kind,
-         req_id);
+  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, 0, true,
+         "%s %" PRIu64 ": %s id=%u\n", dir, channel_id, kind, req_id);
 }
 
 static void log_notify(char *dir, uint64_t channel_id, const char *name)
 {
-  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, "%s %" PRIu64 ": %s %s\n", dir, channel_id, NOT,
-         name);
+  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, 0, true,
+         "%s %" PRIu64 ": %s %s\n", dir, channel_id, NOT, name);
 }
 
 #else
@@ -548,7 +549,7 @@ void rpc_free(Channel *channel)
 /// Closes a channel after receiving fatal error, and logs a message.
 static void chan_close_on_err(Channel *channel, char *msg, int loglevel)
 {
-  logmsg(loglevel, "RPC: ", NULL, -1, true, "%s", msg);
+  logmsg(loglevel, "RPC: ", NULL, -1, true, 0, true, "%s", msg);
   for (size_t i = 0; i < kv_size(channel->rpc.call_stack); i++) {
     ChannelCallFrame *frame = kv_A(channel->rpc.call_stack, i);
     if (frame->returned) {
@@ -699,6 +700,42 @@ void rpc_set_client_info(uint64_t id, Dict info)
 Dict rpc_client_info(Channel *chan)
 {
   return copy_dict(chan->rpc.info, NULL);
+}
+
+/// Describes a channel, for use in log messages etc.
+///
+/// @param chan_id  Channel id
+/// @param desc[out]  Description result
+/// @param desc_len  Size of `desc` storage
+void rpc_chan_desc(uint64_t chan_id, char *desc, size_t desc_len)
+{
+  Channel *chan = find_rpc_channel(chan_id);
+  char *type = NULL;
+  char *ch_type = NULL;
+  if (chan && chan->is_rpc) {
+    for (size_t i = 0; i < chan->rpc.info.size; i++) {
+      String k = chan->rpc.info.items[i].key;
+      Object v = chan->rpc.info.items[i].value;
+      if (strequal("name", k.data) && v.data.string.data && v.data.string.data[0] != '\0') {
+        type = v.data.string.data;
+      } else if (strequal("type", k.data) && v.data.string.data && v.data.string.data[0] != '\0') {
+        ch_type = v.data.string.data;
+      }
+    }
+    if (type && ch_type) {
+      snprintf(desc, desc_len, "%s:%s", type, ch_type);
+    } else if (type) {
+      snprintf(desc, desc_len, "%s", type);
+    } else {
+      snprintf(desc, desc_len, "%s", "?_?");
+    }
+  } else if (chan && chan->term) {
+    snprintf(desc, desc_len, "term:%" PRId64, (int64_t)terminal_buf(chan->term));
+  } else if (chan) {
+    snprintf(desc, desc_len, "chan:%" PRId64, chan_id);
+  } else {
+    snprintf(desc, desc_len, "%s", "?_?");
+  }
 }
 
 const char *get_client_info(Channel *chan, const char *key)

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10051,25 +10051,31 @@ local options = {
         Sets the verbosity level.  Also set by |-V| and |:verbose|.
 
         Tracing of assignments to options, mappings, etc. in Lua scripts is
-        enabled at level 1; Lua scripts are not traced when 'verbose' is 0,
+        enabled at level 3; Lua scripts are not traced when 'verbose' is 0,
         for performance.
 
-        If greater than or equal to a given level, Nvim produces the following
+        If greater than or equal to a given level, Nvim logs the following
         messages:
 
         Level   Messages ~
         ----------------------------------------------------------------------
-        1	Enables Lua tracing (see above). Does not produce messages.
-        2	When a file is ":source"'ed, or |shada| file is read or written.
-        3	UI info, terminal capabilities.
-        4	Shell commands.
-        5	Every searched tags file and include file.
-        8	Files for which a group of autocommands is executed.
-        9	Executed autocommands.
+        1	Enables |nvim_log()| at "warning" level.
+        2	Enables |nvim_log()| at "info" level.
+        3	Enables Lua tracing (see above).
+        	Enables |nvim_log()| at "debug" level.
+        	UI info, terminal capabilities.
+        4	Enables |nvim_log()| at "trace" level.
+                NOTE: channel communication is logged, this may contain
+                private info, e.g. a password you type in a terminal window.
+        5	Shell commands.
+        6	Activity from |shada|, |swap-file|, |spell|, 'undofile',
+        	|:source|, |tags|, |include-search|.
+        8	Filenames where autocommands executed.
+        9	Event handler (autocommands) execution.
         11	Finding items in a path.
-        12	Vimscript function calls.
-        13	When an exception is thrown, caught, finished, or discarded.
-        14	Anything pending in a ":finally" clause.
+        12	Vimscript function execution.
+        13	Exceptions thrown, caught, finished, or discarded.
+        14	Pending ":finally" clauses.
         15	Ex commands from a script (truncated at 200 characters).
         16	Ex commands.
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10388,25 +10388,31 @@ local options = {
         Sets the verbosity level.  Also set by |-V| and |:verbose|.
 
         Tracing of assignments to options, mappings, etc. in Lua scripts is
-        enabled at level 1; Lua scripts are not traced when 'verbose' is 0,
+        enabled at level 3; Lua scripts are not traced when 'verbose' is 0,
         for performance.
 
-        If greater than or equal to a given level, Nvim produces the following
+        If greater than or equal to a given level, Nvim logs the following
         messages:
 
         Level   Messages ~
         ----------------------------------------------------------------------
-        1	Enables Lua tracing (see above). Does not produce messages.
-        2	When a file is ":source"'ed, or |shada| file is read or written.
-        3	UI info, terminal capabilities.
-        4	Shell commands.
-        5	Every searched tags file and include file.
-        8	Files for which a group of autocommands is executed.
-        9	Executed autocommands.
+        1	Enables |nvim_log()| at "warning" level.
+        2	Enables |nvim_log()| at "info" level.
+        3	Enables Lua tracing (see above).
+        	Enables |nvim_log()| at "debug" level.
+        	UI info, terminal capabilities.
+        4	Enables |nvim_log()| at "trace" level.
+                NOTE: channel communication is logged, this may contain
+                private info, e.g. a password you type in a terminal window.
+        5	Shell commands.
+        6	Activity from |shada|, |swap-file|, |spell|, 'undofile',
+        	|:source|, |tags|, |include-search|.
+        8	Filenames where autocommands executed.
+        9	Event handler (autocommands) execution.
         11	Finding items in a path.
-        12	Vimscript function calls.
-        13	When an exception is thrown, caught, finished, or discarded.
-        14	Anything pending in a ":finally" clause.
+        12	Vimscript function execution.
+        13	Exceptions thrown, caught, finished, or discarded.
+        14	Pending ":finally" clauses.
         15	Ex commands from a script (truncated at 200 characters).
         16	Ex commands.
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -16130,7 +16130,7 @@ void free_regexp_stuff(void)
 
 static void report_re_switch(const char *pat)
 {
-  if (p_verbose > 0) {
+  if (p_verbose > 1) {
     verbose_enter();
     msg_puts(_("Switching to backtracking RE engine for pattern: "));
     msg_puts(pat);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -16204,7 +16204,7 @@ void free_regexp_stuff(void)
 
 static void report_re_switch(const char *pat)
 {
-  if (p_verbose > 0) {
+  if (p_verbose > 1) {
     verbose_enter();
     msg_puts(_("Switching to backtracking RE engine for pattern: "));
     msg_puts(pat);

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -3177,12 +3177,10 @@ static int spell_read_dic(spellinfo_T *spin, char *fname, afffile_T *affile)
     hash_T hash = hash_hash(dw);
     hashitem_T *hi = hash_lookup(&ht, dw, strlen(dw), hash);
     if (!HASHITEM_EMPTY(hi)) {
-      if (p_verbose > 0) {
-        smsg(0, _("Duplicate word in %s line %d: %s"),
-             fname, lnum, dw);
+      if (p_verbose > 1) {
+        smsg(0, _("Duplicate word in %s line %d: %s"), fname, lnum, dw);
       } else if (duplicate == 0) {
-        smsg(0, _("First duplicate word in %s line %d: %s"),
-             fname, lnum, dw);
+        smsg(0, _("First duplicate word in %s line %d: %s"), fname, lnum, dw);
       }
       duplicate++;
     } else {

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -3181,12 +3181,10 @@ static int spell_read_dic(spellinfo_T *spin, char *fname, afffile_T *affile)
     hash_T hash = hash_hash(dw);
     hashitem_T *hi = hash_lookup(&ht, dw, strlen(dw), hash);
     if (!HASHITEM_EMPTY(hi)) {
-      if (p_verbose > 0) {
-        smsg(0, _("Duplicate word in %s line %d: %s"),
-             fname, lnum, dw);
+      if (p_verbose > 1) {
+        smsg(0, _("Duplicate word in %s line %d: %s"), fname, lnum, dw);
       } else if (duplicate == 0) {
-        smsg(0, _("First duplicate word in %s line %d: %s"),
-             fname, lnum, dw);
+        smsg(0, _("First duplicate word in %s line %d: %s"), fname, lnum, dw);
       }
       duplicate++;
     } else {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -3094,7 +3094,7 @@ static int add_tag_field(dict_T *dict, const char *field_name, const char *start
 {
   // Check that the field name doesn't exist yet.
   if (tv_dict_find(dict, field_name, -1) != NULL) {
-    if (p_verbose > 0) {
+    if (p_verbose > 1) {
       verbose_enter();
       smsg(0, _("Duplicate field name: %s"), field_name);
       verbose_leave();

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -3105,7 +3105,7 @@ static int add_tag_field(dict_T *dict, const char *field_name, const char *start
 {
   // Check that the field name doesn't exist yet.
   if (tv_dict_find(dict, field_name, -1) != NULL) {
-    if (p_verbose > 0) {
+    if (p_verbose > 1) {
       verbose_enter();
       smsg(0, _("Duplicate field name: %s"), field_name);
       verbose_leave();

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -86,10 +86,10 @@ static void ui_log(const char *funname)
     uilog_seen++;
   } else {
     if (uilog_seen > 0) {
-      logmsg(LOGLVL_DBG, "UI: ", NULL, -1, true,
+      logmsg(LOGLVL_DBG, "UI: ", NULL, -1, false, 0, true,
              "%s (+%zu times...)", uilog_last_event, uilog_seen);
     }
-    logmsg(LOGLVL_DBG, "UI: ", NULL, -1, true, "%s", funname);
+    logmsg(LOGLVL_DBG, "UI: ", NULL, -1, false, 0, true, "%s", funname);
     uilog_seen = 0;
     uilog_last_event = funname;
   }

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1173,7 +1173,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
   if (name == NULL) {
     file_name = u_get_undo_file_name(buf->b_ffname, false);
     if (file_name == NULL) {
-      if (p_verbose > 0) {
+      if (p_verbose > 1) {
         verbose_enter();
         smsg(0, "%s", _("Cannot write undo file in any directory in 'undodir'"));
         verbose_leave();
@@ -1205,7 +1205,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
       // Check we can read it and it's an undo file.
       int fd = os_open(file_name, O_RDONLY, 0);
       if (fd < 0) {
-        if (name != NULL || p_verbose > 0) {
+        if (name != NULL || p_verbose > 1) {
           if (name == NULL) {
             verbose_enter();
           }
@@ -1222,7 +1222,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
         close(fd);
         if (len < UF_START_MAGIC_LEN
             || memcmp(mbuf, UF_START_MAGIC, UF_START_MAGIC_LEN) != 0) {
-          if (name != NULL || p_verbose > 0) {
+          if (name != NULL || p_verbose > 1) {
             if (name == NULL) {
               verbose_enter();
             }
@@ -1242,7 +1242,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
   // If there is no undo information at all, quit here after deleting any
   // existing undo file.
   if (buf->b_u_numhead == 0 && buf->b_u_line_ptr == NULL) {
-    if (p_verbose > 0) {
+    if (p_verbose > 1) {
       verb_msg(_("Skipping undo file write, nothing to undo"));
     }
     goto theend;
@@ -1254,7 +1254,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
     goto theend;
   }
   os_setperm(file_name, perm);
-  if (p_verbose > 0) {
+  if (p_verbose > 1) {
     verbose_enter();
     smsg(0, _("Writing undo file: %s"), file_name);
     verbose_leave();
@@ -1392,7 +1392,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
         && os_fileinfo(file_name, &file_info_undo)
         && file_info_orig.stat.st_uid != file_info_undo.stat.st_uid
         && file_info_undo.stat.st_uid != getuid()) {
-      if (p_verbose > 0) {
+      if (p_verbose > 1) {
         verbose_enter();
         smsg(0, _("Not reading undo file, owner differs: %s"),
              file_name);
@@ -1405,7 +1405,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
     file_name = name;
   }
 
-  if (p_verbose > 0) {
+  if (p_verbose > 1) {
     verbose_enter();
     smsg(0, _("Reading undo file: %s"), file_name);
     verbose_leave();
@@ -1413,7 +1413,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
 
   FILE *fp = os_fopen(file_name, "r");
   if (fp == NULL) {
-    if (name != NULL || p_verbose > 0) {
+    if (name != NULL || p_verbose > 1) {
       semsg(_("E822: Cannot open undo file for reading: %s"), file_name);
     }
     goto error;
@@ -1445,7 +1445,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
   linenr_T line_count = (linenr_T)undo_read_4c(&bi);
   if (memcmp(hash, read_hash, UNDO_HASH_SIZE) != 0
       || line_count != curbuf->b_ml.ml_line_count) {
-    if (p_verbose > 0 || name != NULL) {
+    if (p_verbose > 1 || name != NULL) {
       if (name == NULL) {
         verbose_enter();
       }

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1180,7 +1180,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
   if (name == NULL) {
     file_name = u_get_undo_file_name(buf->b_ffname, false);
     if (file_name == NULL) {
-      if (p_verbose > 0) {
+      if (p_verbose > 1) {
         verbose_enter();
         smsg(0, "%s", _("Cannot write undo file in any directory in 'undodir'"));
         verbose_leave();
@@ -1212,7 +1212,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
       // Check we can read it and it's an undo file.
       int fd = os_open(file_name, O_RDONLY, 0);
       if (fd < 0) {
-        if (name != NULL || p_verbose > 0) {
+        if (name != NULL || p_verbose > 1) {
           if (name == NULL) {
             verbose_enter();
           }
@@ -1229,7 +1229,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
         close(fd);
         if (len < UF_START_MAGIC_LEN
             || memcmp(mbuf, UF_START_MAGIC, UF_START_MAGIC_LEN) != 0) {
-          if (name != NULL || p_verbose > 0) {
+          if (name != NULL || p_verbose > 1) {
             if (name == NULL) {
               verbose_enter();
             }
@@ -1249,7 +1249,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
   // If there is no undo information at all, quit here after deleting any
   // existing undo file.
   if (buf->b_u_numhead == 0 && buf->b_u_line_ptr == NULL) {
-    if (p_verbose > 0) {
+    if (p_verbose > 1) {
       verb_msg(_("Skipping undo file write, nothing to undo"));
     }
     goto theend;
@@ -1261,7 +1261,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
     goto theend;
   }
   os_setperm(file_name, perm);
-  if (p_verbose > 0) {
+  if (p_verbose > 1) {
     verbose_enter();
     smsg(0, _("Writing undo file: %s"), file_name);
     verbose_leave();
@@ -1430,7 +1430,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
         && os_fileinfo(file_name, &file_info_undo)
         && file_info_orig.stat.st_uid != file_info_undo.stat.st_uid
         && file_info_undo.stat.st_uid != getuid()) {
-      if (p_verbose > 0) {
+      if (p_verbose > 1) {
         verbose_enter();
         smsg(0, _("Not reading undo file, owner differs: %s"),
              file_name);
@@ -1444,7 +1444,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
     file_name = name;
   }
 
-  if (p_verbose > 0) {
+  if (p_verbose > 1) {
     verbose_enter();
     smsg(0, _("Reading undo file: %s"), file_name);
     verbose_leave();
@@ -1452,7 +1452,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
 
   FILE *fp = os_fopen(file_name, "r");
   if (fp == NULL) {
-    if (name != NULL || p_verbose > 0) {
+    if (name != NULL || p_verbose > 1) {
       semsg(_("E822: Cannot open undo file for reading: %s"), file_name);
     }
     goto error;
@@ -1486,7 +1486,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
   linenr_T line_count = (linenr_T)undo_read_4c(&bi);
   if (memcmp(hash, read_hash, UNDO_HASH_SIZE) != 0
       || line_count != curbuf->b_ml.ml_line_count) {
-    if (p_verbose > 0 || name != NULL) {
+    if (p_verbose > 1 || name != NULL) {
       if (name == NULL) {
         verbose_enter();
       }

--- a/test/functional/core/log_spec.lua
+++ b/test/functional/core/log_spec.lua
@@ -9,6 +9,9 @@ local eq = t.eq
 local exec_lua = n.exec_lua
 local expect_exit = n.expect_exit
 local request = n.request
+local api = n.api
+local fn = n.fn
+local eval = n.eval
 
 describe('log', function()
   local testlog = 'Xtest_logging'
@@ -122,14 +125,14 @@ describe('log', function()
 end)
 
 describe('logging', function()
-  describe('$NVIM_LOG_FILE', function()
-    local xdgdir = 'Xtest-startup-xdg-logpath'
-    local xdgstatedir = t.is_os('win') and xdgdir .. '/nvim-data' or xdgdir .. '/nvim'
-    after_each(function()
-      os.remove('Xtest-logpath')
-      n.rmdir(xdgdir)
-    end)
+  local xdgdir = 'Xtest-startup-xdg-logpath'
+  local xdgstatedir = t.is_os('win') and xdgdir .. '/nvim-data' or xdgdir .. '/nvim'
+  after_each(function()
+    os.remove('Xtest-logpath')
+    n.rmdir(xdgdir)
+  end)
 
+  describe('$NVIM_LOG_FILE', function()
     it('is used if expansion succeeds', function()
       clear({ env = {
         NVIM_LOG_FILE = 'Xtest-logpath',
@@ -159,6 +162,45 @@ describe('logging', function()
       eq(('%s/logs/nvim.log'):format(xdgstatedir), n.eval('$NVIM_LOG_FILE'))
       -- Avoid "failed to open $NVIM_LOG_FILE" noise in test output.
       expect_exit(command, 'qall!')
+    end)
+  end)
+
+  describe('nvim_log()', function()
+    it('validation', function()
+      clear({ env = { NVIM_LOG_FILE = 'Xtest-logpath' } })
+      finally(function()
+        os.remove('Xtest-logpath')
+      end)
+      t.matches("Invalid 'level': 'bogus'", t.pcall_err(api.nvim_log, 'bogus', 'msg', {}))
+    end)
+
+    it('acceptance', function()
+      clear({
+        env = {
+          NVIM_LOG_FILE = 'Xtest-logpath',
+        },
+      })
+      finally(function()
+        os.remove('Xtest-logpath')
+      end)
+
+      -- Below "ERR" level, messages are dropped unless 'verbose' is set.
+      api.nvim_log('DBG', 'low-level log message…', {})
+      api.nvim_log('INF', 'you did it! :D', {})
+      api.nvim_log('WRN', 'beware of dragons ノ( º _ ºノ)', {})
+      api.nvim_log('ERR', 'problem (╯°□°)╯︵ ┻━┻', {})
+
+      -- Custom `type` prefix + `join` collapses embedded newlines.
+      api.nvim_log('ERR', 'multi\nline', { type = 'MyPlugin', join = true })
+
+      local content = table.concat(fn.readfile(eval('$NVIM_LOG_FILE')), '\n')
+      -- Default category (channel-derived) for the test session.
+      t.matches(
+        'ERR%s+%S+%s+%S+%s+testclient:remote: problem %(╯°□°%)╯︵ ┻━┻',
+        content
+      )
+      -- Custom `type` + `join` (the embedded \n is replaced with a SPACE).
+      t.matches('ERR%s+%S+%s+%S+%s+MyPlugin: multi line', content)
     end)
   end)
 end)

--- a/test/functional/core/log_spec.lua
+++ b/test/functional/core/log_spec.lua
@@ -120,3 +120,45 @@ describe('log', function()
     end)
   end)
 end)
+
+describe('logging', function()
+  describe('$NVIM_LOG_FILE', function()
+    local xdgdir = 'Xtest-startup-xdg-logpath'
+    local xdgstatedir = t.is_os('win') and xdgdir .. '/nvim-data' or xdgdir .. '/nvim'
+    after_each(function()
+      os.remove('Xtest-logpath')
+      n.rmdir(xdgdir)
+    end)
+
+    it('is used if expansion succeeds', function()
+      clear({ env = {
+        NVIM_LOG_FILE = 'Xtest-logpath',
+      } })
+      eq('Xtest-logpath', n.eval('$NVIM_LOG_FILE'))
+    end)
+
+    it('defaults to stdpath("log")/nvim.log if empty', function()
+      eq(true, t.mkdir(xdgdir) and t.mkdir(xdgstatedir))
+      clear({
+        env = {
+          XDG_STATE_HOME = xdgdir,
+          NVIM_LOG_FILE = '', -- Empty is invalid.
+        },
+      })
+      eq(('%s/logs/nvim.log'):format(xdgstatedir), n.eval('$NVIM_LOG_FILE'))
+    end)
+
+    it('defaults to stdpath("log")/nvim.log if invalid', function()
+      eq(true, t.mkdir(xdgdir) and t.mkdir(xdgstatedir))
+      clear({
+        env = {
+          XDG_STATE_HOME = xdgdir,
+          NVIM_LOG_FILE = '.', -- Any directory is invalid.
+        },
+      })
+      eq(('%s/logs/nvim.log'):format(xdgstatedir), n.eval('$NVIM_LOG_FILE'))
+      -- Avoid "failed to open $NVIM_LOG_FILE" noise in test output.
+      expect_exit(command, 'qall!')
+    end)
+  end)
+end)

--- a/test/functional/core/log_spec.lua
+++ b/test/functional/core/log_spec.lua
@@ -121,3 +121,45 @@ describe('log', function()
     end)
   end)
 end)
+
+describe('logging', function()
+  describe('$NVIM_LOG_FILE', function()
+    local xdgdir = 'Xtest-startup-xdg-logpath'
+    local xdgstatedir = t.is_os('win') and xdgdir .. '/nvim-data' or xdgdir .. '/nvim'
+    after_each(function()
+      os.remove('Xtest-logpath')
+      n.rmdir(xdgdir)
+    end)
+
+    it('is used if expansion succeeds', function()
+      clear({ env = {
+        NVIM_LOG_FILE = 'Xtest-logpath',
+      } })
+      eq('Xtest-logpath', n.eval('$NVIM_LOG_FILE'))
+    end)
+
+    it('defaults to stdpath("log")/nvim.log if empty', function()
+      eq(true, t.mkdir(xdgdir) and t.mkdir(xdgstatedir))
+      clear({
+        env = {
+          XDG_STATE_HOME = xdgdir,
+          NVIM_LOG_FILE = '', -- Empty is invalid.
+        },
+      })
+      eq(('%s/logs/nvim.log'):format(xdgstatedir), n.eval('$NVIM_LOG_FILE'))
+    end)
+
+    it('defaults to stdpath("log")/nvim.log if invalid', function()
+      eq(true, t.mkdir(xdgdir) and t.mkdir(xdgstatedir))
+      clear({
+        env = {
+          XDG_STATE_HOME = xdgdir,
+          NVIM_LOG_FILE = '.', -- Any directory is invalid.
+        },
+      })
+      eq(('%s/logs/nvim.log'):format(xdgstatedir), n.eval('$NVIM_LOG_FILE'))
+      -- Avoid "failed to open $NVIM_LOG_FILE" noise in test output.
+      expect_exit(command, 'qall!')
+    end)
+  end)
+end)

--- a/test/functional/core/log_spec.lua
+++ b/test/functional/core/log_spec.lua
@@ -10,6 +10,9 @@ local eq = t.eq
 local exec_lua = n.exec_lua
 local expect_exit = n.expect_exit
 local request = n.request
+local api = n.api
+local fn = n.fn
+local eval = n.eval
 
 describe('log', function()
   local testlog = 'Xtest_logging'
@@ -123,14 +126,14 @@ describe('log', function()
 end)
 
 describe('logging', function()
-  describe('$NVIM_LOG_FILE', function()
-    local xdgdir = 'Xtest-startup-xdg-logpath'
-    local xdgstatedir = t.is_os('win') and xdgdir .. '/nvim-data' or xdgdir .. '/nvim'
-    after_each(function()
-      os.remove('Xtest-logpath')
-      n.rmdir(xdgdir)
-    end)
+  local xdgdir = 'Xtest-startup-xdg-logpath'
+  local xdgstatedir = t.is_os('win') and xdgdir .. '/nvim-data' or xdgdir .. '/nvim'
+  after_each(function()
+    os.remove('Xtest-logpath')
+    n.rmdir(xdgdir)
+  end)
 
+  describe('$NVIM_LOG_FILE', function()
     it('is used if expansion succeeds', function()
       clear({ env = {
         NVIM_LOG_FILE = 'Xtest-logpath',
@@ -160,6 +163,45 @@ describe('logging', function()
       eq(('%s/logs/nvim.log'):format(xdgstatedir), n.eval('$NVIM_LOG_FILE'))
       -- Avoid "failed to open $NVIM_LOG_FILE" noise in test output.
       expect_exit(command, 'qall!')
+    end)
+  end)
+
+  describe('nvim_log()', function()
+    it('validation', function()
+      clear({ env = { NVIM_LOG_FILE = 'Xtest-logpath' } })
+      finally(function()
+        os.remove('Xtest-logpath')
+      end)
+      t.matches("Invalid 'level': 'bogus'", t.pcall_err(api.nvim_log, 'bogus', 'msg', {}))
+    end)
+
+    it('acceptance', function()
+      clear({
+        env = {
+          NVIM_LOG_FILE = 'Xtest-logpath',
+        },
+      })
+      finally(function()
+        os.remove('Xtest-logpath')
+      end)
+
+      -- Below "ERR" level, messages are dropped unless 'verbose' is set.
+      api.nvim_log('DBG', 'low-level log message…', {})
+      api.nvim_log('INF', 'you did it! :D', {})
+      api.nvim_log('WRN', 'beware of dragons ノ( º _ ºノ)', {})
+      api.nvim_log('ERR', 'problem (╯°□°)╯︵ ┻━┻', {})
+
+      -- Custom `type` prefix + `join` collapses embedded newlines.
+      api.nvim_log('ERR', 'multi\nline', { type = 'MyPlugin', join = true })
+
+      local content = table.concat(fn.readfile(eval('$NVIM_LOG_FILE')), '\n')
+      -- Default category (channel-derived) for the test session.
+      t.matches(
+        'ERR%s+%S+%s+%S+%s+testclient:remote: problem %(╯°□°%)╯︵ ┻━┻',
+        content
+      )
+      -- Custom `type` + `join` (the embedded \n is replaced with a SPACE).
+      t.matches('ERR%s+%S+%s+%S+%s+MyPlugin: multi line', content)
     end)
   end)
 end)

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -243,46 +243,6 @@ describe('startup defaults', function()
     clear()
     eq(eval("fnamemodify(v:progpath, ':p')"), eval('v:progpath'))
   end)
-
-  describe('$NVIM_LOG_FILE', function()
-    local xdgdir = 'Xtest-startup-xdg-logpath'
-    local xdgstatedir = is_os('win') and xdgdir .. '/nvim-data' or xdgdir .. '/nvim'
-    after_each(function()
-      os.remove('Xtest-logpath')
-      rmdir(xdgdir)
-    end)
-
-    it('is used if expansion succeeds', function()
-      clear({ env = {
-        NVIM_LOG_FILE = 'Xtest-logpath',
-      } })
-      eq('Xtest-logpath', eval('$NVIM_LOG_FILE'))
-    end)
-
-    it('defaults to stdpath("log")/nvim.log if empty', function()
-      eq(true, mkdir(xdgdir) and mkdir(xdgstatedir))
-      clear({
-        env = {
-          XDG_STATE_HOME = xdgdir,
-          NVIM_LOG_FILE = '', -- Empty is invalid.
-        },
-      })
-      eq(('%s/logs/nvim.log'):format(xdgstatedir), eval('$NVIM_LOG_FILE'))
-    end)
-
-    it('defaults to stdpath("log")/nvim.log if invalid', function()
-      eq(true, mkdir(xdgdir) and mkdir(xdgstatedir))
-      clear({
-        env = {
-          XDG_STATE_HOME = xdgdir,
-          NVIM_LOG_FILE = '.', -- Any directory is invalid.
-        },
-      })
-      eq(('%s/logs/nvim.log'):format(xdgstatedir), eval('$NVIM_LOG_FILE'))
-      -- Avoid "failed to open $NVIM_LOG_FILE" noise in test output.
-      expect_exit(command, 'qall!')
-    end)
-  end)
 end)
 
 describe('XDG defaults', function()

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -241,46 +241,6 @@ describe('startup defaults', function()
     clear()
     eq(eval("fnamemodify(v:progpath, ':p')"), eval('v:progpath'))
   end)
-
-  describe('$NVIM_LOG_FILE', function()
-    local xdgdir = 'Xtest-startup-xdg-logpath'
-    local xdgstatedir = is_os('win') and xdgdir .. '/nvim-data' or xdgdir .. '/nvim'
-    after_each(function()
-      os.remove('Xtest-logpath')
-      rmdir(xdgdir)
-    end)
-
-    it('is used if expansion succeeds', function()
-      clear({ env = {
-        NVIM_LOG_FILE = 'Xtest-logpath',
-      } })
-      eq('Xtest-logpath', eval('$NVIM_LOG_FILE'))
-    end)
-
-    it('defaults to stdpath("log")/nvim.log if empty', function()
-      eq(true, mkdir(xdgdir) and mkdir(xdgstatedir))
-      clear({
-        env = {
-          XDG_STATE_HOME = xdgdir,
-          NVIM_LOG_FILE = '', -- Empty is invalid.
-        },
-      })
-      eq(('%s/logs/nvim.log'):format(xdgstatedir), eval('$NVIM_LOG_FILE'))
-    end)
-
-    it('defaults to stdpath("log")/nvim.log if invalid', function()
-      eq(true, mkdir(xdgdir) and mkdir(xdgstatedir))
-      clear({
-        env = {
-          XDG_STATE_HOME = xdgdir,
-          NVIM_LOG_FILE = '.', -- Any directory is invalid.
-        },
-      })
-      eq(('%s/logs/nvim.log'):format(xdgstatedir), eval('$NVIM_LOG_FILE'))
-      -- Avoid "failed to open $NVIM_LOG_FILE" noise in test output.
-      expect_exit(command, 'qall!')
-    end)
-  end)
 end)
 
 describe('XDG defaults', function()

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -546,6 +546,10 @@ function M.new_session(keep, ...)
   sessions[new_session] = true
   -- Make it possible to check whether two sessions are from the same test.
   new_session.data = { test_id = test_id }
+
+  -- Identify the test client so it shows up in log messages emitted via |nvim_log()|.
+  new_session:request('nvim_set_client_info', 'testclient', {}, 'remote', {}, {})
+
   return new_session
 end
 

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -547,6 +547,10 @@ function M.new_session(keep, ...)
   sessions[new_session] = true
   -- Make it possible to check whether two sessions are from the same test.
   new_session.data = { test_id = test_id }
+
+  -- Identify the test client so it shows up in log messages emitted via |nvim_log()|.
+  new_session:request('nvim_set_client_info', 'testclient', {}, 'remote', {}, {})
+
   return new_session
 end
 

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1676,7 +1676,7 @@ function Screen:redraw_debug(timeout)
   local function notification_cb(method, args)
     assert(method == 'redraw')
     for _, update in ipairs(args) do
-      -- mode_info_set is quite verbose, comment out the condition to debug it.
+      -- `mode_info_set` is very noisy. Remove this condition to debug it.
       if update[1] ~= 'mode_info_set' then
         print(inspect(update))
       end

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1682,7 +1682,7 @@ function Screen:redraw_debug(timeout)
   local function notification_cb(method, args)
     assert(method == 'redraw')
     for _, update in ipairs(args) do
-      -- mode_info_set is quite verbose, comment out the condition to debug it.
+      -- `mode_info_set` is very noisy. Remove this condition to debug it.
       if update[1] ~= 'mode_info_set' then
         print(inspect(update))
       end


### PR DESCRIPTION


- [x] `nvim_log(level, message)` API function
- [ ] update API clients (python, etc.) to use `nvim_log()` for critical messages
- [ ] `stdpath('log')` ?
- [x] [log Vimscript/editor errors](https://github.com/neovim/neovim/pull/6827#issuecomment-305603694) done in https://github.com/neovim/neovim/pull/10778
- [ ] replace `fake-lsp-server.lua:log()` #11837
- [ ] `logf()` VimL function ?

See also https://github.com/neovim/neovim/pull/8963
