### PR TITLE
[RFC] vim-patch:8.0.0075

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -844,8 +844,6 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
         break;
       case ET_INTERRUPT:
         break;
-      default:
-        p = vim_strsave((char_u *)_(e_internal));
       }
 
       saved_sourcing_name = sourcing_name;

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -374,10 +374,9 @@ int do_intthrow(struct condstack *cstack)
   return TRUE;
 }
 
-/*
- * Get an exception message that is to be stored in current_exception->value.
- */
-char_u *get_exception_string(void *value, int type, char_u *cmdname, int *should_free)
+// Get an exception message that is to be stored in current_exception->value.
+char_u *get_exception_string(void *value, except_type_T type, char_u *cmdname,
+                             int *should_free)
 {
   char_u      *ret, *mesg;
   char_u      *p, *val;
@@ -435,13 +434,11 @@ char_u *get_exception_string(void *value, int type, char_u *cmdname, int *should
 }
 
 
-/*
- * Throw a new exception.  Return FAIL when out of memory or it was tried to
- * throw an illegal user exception.  "value" is the exception string for a
- * user or interrupt exception, or points to a message list in case of an
- * error exception.
- */
-static int throw_exception(void *value, int type, char_u *cmdname)
+// Throw a new exception.  Return FAIL when out of memory or it was tried to
+// throw an illegal user exception.  "value" is the exception string for a
+// user or interrupt exception, or points to a message list in case of an
+// error exception.
+static int throw_exception(void *value, except_type_T type, char_u *cmdname)
 {
   except_T    *excp;
   int should_free;

--- a/src/nvim/ex_eval.h
+++ b/src/nvim/ex_eval.h
@@ -89,26 +89,27 @@ struct msglist {
   struct msglist      *next;            /* next of several messages in a row */
 };
 
+// The exception types.
+typedef enum
+{
+  ET_USER,       // exception caused by ":throw" command
+  ET_ERROR,      // error exception
+  ET_INTERRUPT   // interrupt exception triggered by Ctrl-C
+} except_type_T;
+
 /*
  * Structure describing an exception.
  * (don't use "struct exception", it's used by the math library).
  */
 typedef struct vim_exception except_T;
 struct vim_exception {
-  int type;                             /* exception type */
-  char_u              *value;           /* exception value */
-  struct msglist      *messages;        /* message(s) causing error exception */
-  char_u              *throw_name;      /* name of the throw point */
-  linenr_T throw_lnum;                  /* line number of the throw point */
-  except_T            *caught;          /* next exception on the caught stack */
+  except_type_T type;                   // exception type
+  char_u              *value;           // exception value
+  struct msglist      *messages;        // message(s) causing error exception
+  char_u              *throw_name;      // name of the throw point
+  linenr_T throw_lnum;                  // line number of the throw point
+  except_T            *caught;          // next exception on the caught stack
 };
-
-/*
- * The exception types.
- */
-#define ET_USER         0       /* exception caused by ":throw" command */
-#define ET_ERROR        1       /* error exception */
-#define ET_INTERRUPT    2       /* interrupt exception triggered by Ctrl-C */
 
 /*
  * Structure to save the error/interrupt/exception state between calls to

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -654,7 +654,7 @@ static const int included_patches[] = {
   78,
   // 77 NA
   // 76 NA
-  // 75,
+  75,
   // 74,
   73,
   // 72 NA


### PR DESCRIPTION
```
Problem:    Using number for exception type lacks type checking.
Solution:   Use an enum.
```
https://github.com/vim/vim/commit/8a5883b7488e492419dde7e1637cc72f2d566ba4