### PR TITLE
[RFC] runtime: Fix where desktop file and icon are installed

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -100,20 +100,6 @@ add_custom_target(
     ${GENERATED_PACKAGE_TAGS}
 )
 
-# Optional targets for nvim.desktop file and icon.
-find_program(XDG_MENU_PRG xdg-desktop-menu)
-find_program(XDG_ICON_PRG xdg-icon-resource)
-if(XDG_MENU_PRG)
-  add_custom_target(desktop-file
-    COMMAND xdg-desktop-menu install --novendor ${PROJECT_SOURCE_DIR}/runtime/nvim.desktop)
-  # add_dependencies(runtime desktop-file)
-endif()
-if(XDG_ICON_PRG)
-  add_custom_target(desktop-icon
-    COMMAND xdg-icon-resource install --novendor --size 128 ${PROJECT_SOURCE_DIR}/runtime/nvim.png)
-  # add_dependencies(runtime desktop-icon)
-endif()
-
 # CMake is painful here.  It will create the destination using the user's
 # current umask, and we don't want that.  And we don't just want to install
 # the target directory, as it will mess with existing permissions.  So this
@@ -127,6 +113,16 @@ install_helper(
 install_helper(
   FILES ${GENERATED_SYN_VIM}
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/nvim/runtime/syntax/vim)
+
+if(NOT APPLE)
+  install_helper(
+    FILES ${CMAKE_CURRENT_SOURCE_DIR}/nvim.desktop
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+
+  install_helper(
+    FILES ${CMAKE_CURRENT_SOURCE_DIR}/nvim.png
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pixmaps)
+endif()
 
 file(GLOB_RECURSE RUNTIME_PROGRAMS
   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
With `xdg-*` utilities CMAKE_INSTALL_PREFIX is incorrectly ignored.

Taken from [nvim-qt][1]. For some reason it only checks for !APPLE.

[1]: https://github.com/equalsraf/neovim-qt/blob/b26596d164394765a0f757c65e266f5f77587521/src/gui/CMakeLists.txt#L48-L55