### PR TITLE
[RDY] vim-patch:8.0.0088

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -79,7 +79,11 @@ let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
 func RunTheTest(test)
   echo 'Executing ' . a:test
   if exists("*SetUp")
-    call SetUp()
+    try
+      call SetUp()
+    catch
+      call add(v:errors, 'Caught exception in SetUp() before ' . a:test . ': ' . v:exception . ' @ ' . v:throwpoint)
+    endtry
   endif
 
   call add(s:messages, 'Executing ' . a:test)
@@ -94,7 +98,11 @@ func RunTheTest(test)
   endtry
 
   if exists("*TearDown")
-    call TearDown()
+    try
+      call TearDown()
+    catch
+      call add(v:errors, 'Caught exception in TearDown() after ' . a:test . ': ' . v:exception . ' @ ' . v:throwpoint)
+    endtry
   endif
 
   " Close any extra windows and make the current one not modified.

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -641,7 +641,7 @@ static const int included_patches[] = {
   // 91,
   // 90,
   // 89 NA
-  // 88,
+  88,
   // 87 NA
   // 86,
   85,


### PR DESCRIPTION
Problem:    When a test fails in Setup or Teardown the problem is not reported.
Solution:   Add a try/catch. (Hirohito Higashi)

https://github.com/vim/vim/commit/cc28e2d05d05552d8b72a520be8a193f3d9822d4