### PR TITLE
[RDY] Adds nvim_get_hl_by_name/by_id

### DIFF
--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -242,39 +242,7 @@ static void push_call(UI *ui, char *name, Array args)
 static void remote_ui_highlight_set(UI *ui, HlAttrs attrs)
 {
   Array args = ARRAY_DICT_INIT;
-  Dictionary hl = ARRAY_DICT_INIT;
-
-  if (attrs.bold) {
-    PUT(hl, "bold", BOOLEAN_OBJ(true));
-  }
-
-  if (attrs.underline) {
-    PUT(hl, "underline", BOOLEAN_OBJ(true));
-  }
-
-  if (attrs.undercurl) {
-    PUT(hl, "undercurl", BOOLEAN_OBJ(true));
-  }
-
-  if (attrs.italic) {
-    PUT(hl, "italic", BOOLEAN_OBJ(true));
-  }
-
-  if (attrs.reverse) {
-    PUT(hl, "reverse", BOOLEAN_OBJ(true));
-  }
-
-  if (attrs.foreground != -1) {
-    PUT(hl, "foreground", INTEGER_OBJ(attrs.foreground));
-  }
-
-  if (attrs.background != -1) {
-    PUT(hl, "background", INTEGER_OBJ(attrs.background));
-  }
-
-  if (attrs.special != -1) {
-    PUT(hl, "special", INTEGER_OBJ(attrs.special));
-  }
+  Dictionary hl = hlattrs2dict(attrs);
 
   ADD(args, DICTIONARY_OBJ(hl));
   push_call(ui, "highlight_set", args);

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -59,9 +59,10 @@ void nvim_command(String command, Error *err)
 /// Retrieves highlight description from its name
 ///
 /// @param name Highlight group name
+/// @param rgb True to export GUI values
 /// @return a highlight description e.g. {'bold': true, 'bg': 123, 'fg': 42}
 /// @see nvim_get_hl_by_id
-Dictionary nvim_get_hl_by_name(String name, Error *err)
+Dictionary nvim_get_hl_by_name(String name, Boolean rgb, Error *err)
   FUNC_API_SINCE(3)
 {
   Dictionary result = ARRAY_DICT_INIT;
@@ -72,15 +73,16 @@ Dictionary nvim_get_hl_by_name(String name, Error *err)
                   name.data);
     return result;
   }
-  result = nvim_get_hl_by_id(id, err);
+  result = nvim_get_hl_by_id(id, rgb, err);
   return result;
 }
 
 /// Retrieves highlight description from its id
 ///
 /// @param hl_id highlight id as returned by |hlID()|
+/// @param rgb True to export GUI values
 /// @see nvim_get_hl_by_name
-Dictionary nvim_get_hl_by_id(Integer hl_id, Error *err)
+Dictionary nvim_get_hl_by_id(Integer hl_id, Boolean rgb, Error *err)
   FUNC_API_SINCE(3)
 {
   Dictionary dic = ARRAY_DICT_INIT;
@@ -89,7 +91,7 @@ Dictionary nvim_get_hl_by_id(Integer hl_id, Error *err)
     return dic;
   }
   int attrcode = syn_id2attr((int)hl_id);
-  return hl_get_attr_by_id(attrcode, err);
+  return hl_get_attr_by_id(attrcode, rgb, err);
 }
 
 /// Passes input keys to Nvim.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -78,7 +78,7 @@ Dictionary nvim_get_hl_by_name(String name, Error *err)
 
 /// Retrieves highlight description from its id
 ///
-/// @param hl_id highlight id as returned by hlID()
+/// @param hl_id highlight id as returned by |hlID()|
 /// @see nvim_get_hl_by_name
 Dictionary nvim_get_hl_by_id(Integer hl_id, Error *err)
   FUNC_API_SINCE(3)
@@ -89,7 +89,7 @@ Dictionary nvim_get_hl_by_id(Integer hl_id, Error *err)
     return dic;
   }
   int attrcode = syn_id2attr((int)hl_id);
-  return get_attr_by_id(attrcode, err);
+  return hl_get_attr_by_id(attrcode, err);
 }
 
 /// Passes input keys to Nvim.

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -8221,6 +8221,32 @@ RgbValue name_to_color(const uint8_t *name)
   return -1;
 }
 
+/// Retrieves attribute description from its id
+///
+/// @param attr_id attribute id
+Dictionary hl_get_attr_by_id(Integer attr_id, Error *err)
+{
+  HlAttrs attrs = HLATTRS_INIT;
+  Dictionary dic = ARRAY_DICT_INIT;
+
+  if (attr_id == 0) {
+    goto end;
+  }
+
+  attrentry_T *aep = syn_cterm_attr2entry((int)attr_id);
+  if (!aep) {
+    api_set_error(err, kErrorTypeException,
+                  "Invalid attribute id %d", attr_id);
+    return dic;
+  }
+
+  attrs = attrentry2hlattrs(aep, p_tgc);
+
+end:
+  return hlattrs2dict(attrs);
+}
+
+
 /**************************************
 *  End of Highlighting stuff	      *
 **************************************/

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6825,8 +6825,6 @@ int hl_combine_attr(int char_attr, int prim_attr)
   if (char_aep != NULL) {
     // Copy all attributes from char_aep to the new entry
     new_en = *char_aep;
-  } else {
-    new_en = (attrentry_T)ATTRENTRY_INIT;
   }
 
   spell_aep = syn_cterm_attr2entry(prim_attr);

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -8224,7 +8224,7 @@ RgbValue name_to_color(const uint8_t *name)
 /// Retrieves attribute description from its id
 ///
 /// @param attr_id attribute id
-Dictionary hl_get_attr_by_id(Integer attr_id, Error *err)
+Dictionary hl_get_attr_by_id(Integer attr_id, Boolean rgb, Error *err)
 {
   HlAttrs attrs = HLATTRS_INIT;
   Dictionary dic = ARRAY_DICT_INIT;
@@ -8240,7 +8240,7 @@ Dictionary hl_get_attr_by_id(Integer attr_id, Error *err)
     return dic;
   }
 
-  attrs = attrentry2hlattrs(aep, p_tgc);
+  attrs = attrentry2hlattrs(aep, rgb);
 
 end:
   return hlattrs2dict(attrs);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -288,7 +288,7 @@ static void terminfo_stop(UI *ui)
 static void tui_terminal_start(UI *ui)
 {
   TUIData *data = ui->data;
-  data->print_attrs = EMPTY_ATTRS;
+  data->print_attrs = HLATTRS_INIT;
   ugrid_init(&data->grid);
   terminfo_start(ui);
   update_size(ui);
@@ -628,7 +628,7 @@ static void clear_region(UI *ui, int top, int bot, int left, int right)
   if (grid->bg == -1 && right == ui->width -1) {
     // Background is set to the default color and the right edge matches the
     // screen end, try to use terminal codes for clearing the requested area.
-    HlAttrs clear_attrs = EMPTY_ATTRS;
+    HlAttrs clear_attrs = HLATTRS_INIT;
     clear_attrs.foreground = grid->fg;
     clear_attrs.background = grid->bg;
     update_attrs(ui, clear_attrs);
@@ -926,7 +926,7 @@ static void tui_scroll(UI *ui, Integer count)
     cursor_goto(ui, grid->top, grid->left);
     // also set default color attributes or some terminals can become funny
     if (scroll_clears_to_current_colour) {
-      HlAttrs clear_attrs = EMPTY_ATTRS;
+      HlAttrs clear_attrs = HLATTRS_INIT;
       clear_attrs.foreground = grid->fg;
       clear_attrs.background = grid->bg;
       update_attrs(ui, clear_attrs);

--- a/src/nvim/ugrid.c
+++ b/src/nvim/ugrid.c
@@ -16,7 +16,7 @@
 
 void ugrid_init(UGrid *grid)
 {
-  grid->attrs = EMPTY_ATTRS;
+  grid->attrs = HLATTRS_INIT;
   grid->fg = grid->bg = -1;
   grid->cells = NULL;
 }
@@ -118,7 +118,7 @@ UCell *ugrid_put(UGrid *grid, uint8_t *text, size_t size)
 
 static void clear_region(UGrid *grid, int top, int bot, int left, int right)
 {
-  HlAttrs clear_attrs = EMPTY_ATTRS;
+  HlAttrs clear_attrs = HLATTRS_INIT;
   clear_attrs.foreground = grid->fg;
   clear_attrs.background = grid->bg;
   UGRID_FOREACH_CELL(grid, top, bot, left, right, {

--- a/src/nvim/ugrid.h
+++ b/src/nvim/ugrid.h
@@ -21,8 +21,6 @@ struct ugrid {
   UCell **cells;
 };
 
-#define EMPTY_ATTRS ((HlAttrs){ false, false, false, false, false, -1, -1, -1 })
-
 #define UGRID_FOREACH_CELL(grid, top, bot, left, right, code) \
   do { \
     for (int row = top; row <= bot; row++) { \

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -166,6 +166,115 @@ void ui_event(char *name, Array args)
   }
 }
 
+/// Retrieves attribute description from its id
+///
+/// @param attr_id attribute id
+Dictionary get_attr_by_id(Integer attr_id, Error *err)
+{
+  HlAttrs attrs = HLATTRS_INIT;
+  Dictionary dic = ARRAY_DICT_INIT;
+
+  if (attr_id == 0) {
+    goto end;
+  }
+
+  attrentry_T *aep = syn_cterm_attr2entry((int)attr_id);
+  if (!aep) {
+    api_set_error(err, kErrorTypeException,
+                  "Invalid attribute id %d", attr_id);
+    return dic;
+  }
+
+  attrs = attrentry2hlattrs(aep, p_tgc);
+
+end:
+  return hlattrs2dict(attrs);
+}
+
+
+/// Converts an attrentry_T into an HlAttrs
+///
+/// @param[in] aep data to convert
+/// @param use_rgb use 'gui*' settings if true, else resorts to 'cterm*'
+HlAttrs attrentry2hlattrs(const attrentry_T *aep, bool use_rgb)
+{
+  assert(aep);
+
+  HlAttrs attrs = HLATTRS_INIT;
+  int mask = 0;
+
+  mask = use_rgb ? aep->rgb_ae_attr : aep->cterm_ae_attr;
+
+  attrs.bold = mask & HL_BOLD;
+  attrs.underline = mask & HL_UNDERLINE;
+  attrs.undercurl = mask & HL_UNDERCURL;
+  attrs.italic = mask & HL_ITALIC;
+  attrs.reverse = mask & (HL_INVERSE | HL_STANDOUT);
+
+  if (use_rgb) {
+    if (aep->rgb_fg_color != -1) {
+      attrs.foreground = aep->rgb_fg_color;
+    }
+
+    if (aep->rgb_bg_color != -1) {
+      attrs.background = aep->rgb_bg_color;
+    }
+
+    if (aep->rgb_sp_color != -1) {
+      attrs.special = aep->rgb_sp_color;
+    }
+  } else {
+    if (cterm_normal_fg_color != aep->cterm_fg_color) {
+      attrs.foreground = aep->cterm_fg_color - 1;
+    }
+
+    if (cterm_normal_bg_color != aep->cterm_bg_color) {
+        attrs.background = aep->cterm_bg_color - 1;
+    }
+  }
+
+  return attrs;
+}
+
+Dictionary hlattrs2dict(HlAttrs attrs)
+{
+  Dictionary hl = ARRAY_DICT_INIT;
+
+  if (attrs.bold) {
+    PUT(hl, "bold", BOOLEAN_OBJ(true));
+  }
+
+  if (attrs.underline) {
+    PUT(hl, "underline", BOOLEAN_OBJ(true));
+  }
+
+  if (attrs.undercurl) {
+    PUT(hl, "undercurl", BOOLEAN_OBJ(true));
+  }
+
+  if (attrs.italic) {
+    PUT(hl, "italic", BOOLEAN_OBJ(true));
+  }
+
+  if (attrs.reverse) {
+    PUT(hl, "reverse", BOOLEAN_OBJ(true));
+  }
+
+  if (attrs.foreground != -1) {
+    PUT(hl, "foreground", INTEGER_OBJ(attrs.foreground));
+  }
+
+  if (attrs.background != -1) {
+    PUT(hl, "background", INTEGER_OBJ(attrs.background));
+  }
+
+  if (attrs.special != -1) {
+    PUT(hl, "special", INTEGER_OBJ(attrs.special));
+  }
+
+  return hl;
+}
+
 void ui_refresh(void)
 {
   if (!ui_active()) {
@@ -405,54 +514,20 @@ void ui_flush(void)
 
 static void set_highlight_args(int attr_code)
 {
-  HlAttrs rgb_attrs = { false, false, false, false, false, -1, -1, -1 };
+  HlAttrs rgb_attrs = HLATTRS_INIT;
   HlAttrs cterm_attrs = rgb_attrs;
 
   if (attr_code == HL_NORMAL) {
     goto end;
   }
-
-  int rgb_mask = 0;
-  int cterm_mask = 0;
   attrentry_T *aep = syn_cterm_attr2entry(attr_code);
 
   if (!aep) {
     goto end;
   }
 
-  rgb_mask = aep->rgb_ae_attr;
-  cterm_mask = aep->cterm_ae_attr;
-
-  rgb_attrs.bold = rgb_mask & HL_BOLD;
-  rgb_attrs.underline = rgb_mask & HL_UNDERLINE;
-  rgb_attrs.undercurl = rgb_mask & HL_UNDERCURL;
-  rgb_attrs.italic = rgb_mask & HL_ITALIC;
-  rgb_attrs.reverse = rgb_mask & (HL_INVERSE | HL_STANDOUT);
-  cterm_attrs.bold = cterm_mask & HL_BOLD;
-  cterm_attrs.underline = cterm_mask & HL_UNDERLINE;
-  cterm_attrs.undercurl = cterm_mask & HL_UNDERCURL;
-  cterm_attrs.italic = cterm_mask & HL_ITALIC;
-  cterm_attrs.reverse = cterm_mask & (HL_INVERSE | HL_STANDOUT);
-
-  if (aep->rgb_fg_color != normal_fg) {
-    rgb_attrs.foreground = aep->rgb_fg_color;
-  }
-
-  if (aep->rgb_bg_color != normal_bg) {
-    rgb_attrs.background = aep->rgb_bg_color;
-  }
-
-  if (aep->rgb_sp_color != normal_sp) {
-    rgb_attrs.special = aep->rgb_sp_color;
-  }
-
-  if (cterm_normal_fg_color != aep->cterm_fg_color) {
-    cterm_attrs.foreground = aep->cterm_fg_color - 1;
-  }
-
-  if (cterm_normal_bg_color != aep->cterm_bg_color) {
-    cterm_attrs.background = aep->cterm_bg_color - 1;
-  }
+  rgb_attrs = attrentry2hlattrs(aep, true);
+  cterm_attrs = attrentry2hlattrs(aep, false);
 
 end:
   UI_CALL(highlight_set, (ui->rgb ? rgb_attrs : cterm_attrs));

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -166,31 +166,6 @@ void ui_event(char *name, Array args)
   }
 }
 
-/// Retrieves attribute description from its id
-///
-/// @param attr_id attribute id
-Dictionary get_attr_by_id(Integer attr_id, Error *err)
-{
-  HlAttrs attrs = HLATTRS_INIT;
-  Dictionary dic = ARRAY_DICT_INIT;
-
-  if (attr_id == 0) {
-    goto end;
-  }
-
-  attrentry_T *aep = syn_cterm_attr2entry((int)attr_id);
-  if (!aep) {
-    api_set_error(err, kErrorTypeException,
-                  "Invalid attribute id %d", attr_id);
-    return dic;
-  }
-
-  attrs = attrentry2hlattrs(aep, p_tgc);
-
-end:
-  return hlattrs2dict(attrs);
-}
-
 
 /// Converts an attrentry_T into an HlAttrs
 ///

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -21,6 +21,9 @@ typedef struct {
   int foreground, background, special;
 } HlAttrs;
 
+#define HLATTRS_INIT \
+  ((HlAttrs){ false, false, false, false, false, -1, -1, -1 })
+
 typedef struct ui_t UI;
 
 struct ui_t {

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -8,47 +8,53 @@ local ok = helpers.ok
 local meths = helpers.meths
 
 
-describe('highlight api', function()
+describe('highlight api',function()
+  local expected_rgb = { background = Screen.colors.Yellow,
+                          foreground = Screen.colors.Red,
+                          special = Screen.colors.Blue,
+                          bold = true,
+                        }
+
+  local expected_cterm = { background = 10,
+                          underline = true,
+                        }
 
   before_each(function()
-    clear('--cmd', 'set termguicolors')
+    clear()
+    command("hi NewHighlight cterm=underline ctermbg=green guifg=red guibg=yellow guisp=blue gui=bold")
   end)
 
   it("nvim_get_hl_by_id", function()
-    local expected_hl = { background = Screen.colors.Yellow,
-                          foreground = Screen.colors.Red,
-                          special = Screen.colors.Blue
-                        }
-
-    command('hi NewHighlight guifg=red guibg=yellow guisp=blue')
-
     local hl_id = eval("hlID('NewHighlight')")
-    eq(expected_hl, nvim("get_hl_by_id", hl_id))
 
-    -- assume there is no hl with 30000
+    eq(expected_cterm, nvim("get_hl_by_id", hl_id))
+
+    command('set termguicolors')
+    hl_id = eval("hlID('NewHighlight')")
+    eq(expected_rgb, nvim("get_hl_by_id", hl_id))
+
+    -- assume there is no hl with id 30000
     local err, emsg = pcall(meths.get_hl_by_id, 30000)
     eq(false, err)
     ok(string.find(emsg, 'Invalid highlight id') ~= nil)
   end)
 
   it("nvim_get_hl_by_name", function()
-    local expected_hl = { background = Screen.colors.Yellow,
+    local expected_normal = { background = Screen.colors.Yellow,
                           foreground = Screen.colors.Red }
 
     -- test "Normal" hl defaults
     eq({}, nvim("get_hl_by_name", 'Normal'))
 
-    command('hi NewHighlight guifg=red guibg=yellow')
-    eq(expected_hl, nvim("get_hl_by_name", 'NewHighlight'))
+    eq(expected_cterm, nvim("get_hl_by_name", 'NewHighlight'))
+    command('set termguicolors')
+    eq(expected_rgb, nvim("get_hl_by_name", 'NewHighlight'))
 
     command('hi Normal guifg=red guibg=yellow')
-    eq(expected_hl, nvim("get_hl_by_name", 'Normal'))
+    eq(expected_normal, nvim("get_hl_by_name", 'Normal'))
+
     local err, emsg = pcall(meths.get_hl_by_name , 'unknown_highlight')
     eq(false, err)
     ok(string.find(emsg, 'Invalid highlight name') ~= nil)
   end)
-
-
-
 end)
-

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -27,14 +27,13 @@ describe('highlight api',function()
   it("nvim_get_hl_by_id", function()
     local hl_id = eval("hlID('NewHighlight')")
 
-    eq(expected_cterm, nvim("get_hl_by_id", hl_id))
+    eq(expected_cterm, nvim("get_hl_by_id", hl_id, false))
 
-    command('set termguicolors')
     hl_id = eval("hlID('NewHighlight')")
-    eq(expected_rgb, nvim("get_hl_by_id", hl_id))
+    eq(expected_rgb, nvim("get_hl_by_id", hl_id, true))
 
-    -- assume there is no hl with id 30000
-    local err, emsg = pcall(meths.get_hl_by_id, 30000)
+    -- assume there is no hl with id = 30000
+    local err, emsg = pcall(meths.get_hl_by_id, 30000, false)
     eq(false, err)
     ok(string.find(emsg, 'Invalid highlight id') ~= nil)
   end)
@@ -44,16 +43,15 @@ describe('highlight api',function()
                           foreground = Screen.colors.Red }
 
     -- test "Normal" hl defaults
-    eq({}, nvim("get_hl_by_name", 'Normal'))
+    eq({}, nvim("get_hl_by_name", 'Normal', true))
 
-    eq(expected_cterm, nvim("get_hl_by_name", 'NewHighlight'))
-    command('set termguicolors')
-    eq(expected_rgb, nvim("get_hl_by_name", 'NewHighlight'))
+    eq(expected_cterm, nvim("get_hl_by_name", 'NewHighlight', false))
+    eq(expected_rgb, nvim("get_hl_by_name", 'NewHighlight', true))
 
     command('hi Normal guifg=red guibg=yellow')
-    eq(expected_normal, nvim("get_hl_by_name", 'Normal'))
+    eq(expected_normal, nvim("get_hl_by_name", 'Normal', true))
 
-    local err, emsg = pcall(meths.get_hl_by_name , 'unknown_highlight')
+    local err, emsg = pcall(meths.get_hl_by_name , 'unknown_highlight', false)
     eq(false, err)
     ok(string.find(emsg, 'Invalid highlight name') ~= nil)
   end)

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -1,0 +1,54 @@
+
+local helpers = require('test.functional.helpers')(after_each)
+local clear, nvim = helpers.clear, helpers.nvim
+local Screen = require('test.functional.ui.screen')
+local eq, eval = helpers.eq, helpers.eval
+local command = helpers.command
+local ok = helpers.ok
+local meths = helpers.meths
+
+
+describe('highlight api', function()
+
+  before_each(function()
+    clear('--cmd', 'set termguicolors')
+  end)
+
+  it("nvim_get_hl_by_id", function()
+    local expected_hl = { background = Screen.colors.Yellow,
+                          foreground = Screen.colors.Red,
+                          special = Screen.colors.Blue
+                        }
+
+    command('hi NewHighlight guifg=red guibg=yellow guisp=blue')
+
+    local hl_id = eval("hlID('NewHighlight')")
+    eq(expected_hl, nvim("get_hl_by_id", hl_id))
+
+    -- assume there is no hl with 30000
+    local err, emsg = pcall(meths.get_hl_by_id, 30000)
+    eq(false, err)
+    ok(string.find(emsg, 'Invalid highlight id') ~= nil)
+  end)
+
+  it("nvim_get_hl_by_name", function()
+    local expected_hl = { background = Screen.colors.Yellow,
+                          foreground = Screen.colors.Red }
+
+    -- test "Normal" hl defaults
+    eq({}, nvim("get_hl_by_name", 'Normal'))
+
+    command('hi NewHighlight guifg=red guibg=yellow')
+    eq(expected_hl, nvim("get_hl_by_name", 'NewHighlight'))
+
+    command('hi Normal guifg=red guibg=yellow')
+    eq(expected_hl, nvim("get_hl_by_name", 'Normal'))
+    local err, emsg = pcall(meths.get_hl_by_name , 'unknown_highlight')
+    eq(false, err)
+    ok(string.find(emsg, 'Invalid highlight name') ~= nil)
+  end)
+
+
+
+end)
+


### PR DESCRIPTION
...in order to retrieve highlights.
UIs are also sent new/modified highlights.

I renamed EMPTY_ATTR to HLATTRS_INIT because it's more consistent with the rest of the code and it helps disambiguate the highlight vs attribute vs hlattr confusion. I can revert it though.