### PR TITLE
[RDY] vim-patch:8.0.0100

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2457,12 +2457,11 @@ did_set_string_option (
   if ((secure || sandbox != 0)
       && (options[opt_idx].flags & P_SECURE)) {
     errmsg = e_secure;
-  }
-  /* Check for a "normal" file name in some options.  Disallow a path
-   * separator (slash and/or backslash), wildcards and characters that are
-   * often illegal in a file name. */
-  else if ((options[opt_idx].flags & P_NFNAME)
-           && vim_strpbrk(*varp, (char_u *)"/\\*?[|<>") != NULL) {
+  } else if ((options[opt_idx].flags & P_NFNAME)
+             && vim_strpbrk(*varp, (char_u *)"/\\*?[|;&<>\r\n") != NULL) {
+    // Check for a "normal" file name in some options.  Disallow a path
+    // separator (slash and/or backslash), wildcards and characters that are
+    // often illegal in a file name.
     errmsg = e_invarg;
   }
   /* 'backupcopy' */

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -629,7 +629,7 @@ static const int included_patches[] = {
   // 103 NA
   // 102,
   // 101,
-  // 100,
+  100,
   99,
   // 98 NA
   // 97 NA


### PR DESCRIPTION
Problem:    Options that are a file name may contain non-filename characters.
Solution:   Check for more invalid characters.

https://github.com/vim/vim/commit/319afe3804741db5a6c188bd69535fa7ed044c62