### PR TITLE
[RDY] vim-patch:8.0.0111

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -327,8 +327,11 @@ terminals)
 		List entries 6 to 12 from the search history: >
 			:history / 6,12
 <
-		List the recent five entries from all histories: >
-			:history all -5,
+		List the penultimate entry from all histories: >
+			:history all -2
+<
+		List the most recent two entries from all histories: >
+			:history all -2,
 
 :keepp[atterns] {command}			*:keepp* *:keeppatterns*
 		Execute {command}, without adding anything to the search

--- a/src/nvim/testdir/test_history.vim
+++ b/src/nvim/testdir/test_history.vim
@@ -31,6 +31,30 @@ function History_Tests(hist)
   call assert_equal('ls', histget(a:hist, -1))
   call assert_equal(4, histnr(a:hist))
 
+  let a=execute('history ' . a:hist)
+  call assert_match("^\n      #  \\S* history\n      3  buffers\n>     4  ls$", a)
+  let a=execute('history all')
+  call assert_match("^\n      #  .* history\n      3  buffers\n>     4  ls", a)
+
+  if len(a:hist) > 0
+    let a=execute('history ' . a:hist . ' 2')
+    call assert_match("^\n      #  \\S* history$", a)
+    let a=execute('history ' . a:hist . ' 3')
+    call assert_match("^\n      #  \\S* history\n      3  buffers$", a)
+    let a=execute('history ' . a:hist . ' 4')
+    call assert_match("^\n      #  \\S* history\n>     4  ls$", a)
+    let a=execute('history ' . a:hist . ' 3,4')
+    call assert_match("^\n      #  \\S* history\n      3  buffers\n>     4  ls$", a)
+    let a=execute('history ' . a:hist . ' -1')
+    call assert_match("^\n      #  \\S* history\n>     4  ls$", a)
+    let a=execute('history ' . a:hist . ' -2')
+    call assert_match("^\n      #  \\S* history\n      3  buffers$", a)
+    let a=execute('history ' . a:hist . ' -2,')
+    call assert_match("^\n      #  \\S* history\n      3  buffers\n>     4  ls$", a)
+    let a=execute('history ' . a:hist . ' -3')
+    call assert_match("^\n      #  \\S* history$", a)
+  endif
+
   " Test for removing entries matching a pattern
   for i in range(1, 3)
       call histadd(a:hist, 'text_' . i)

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -618,7 +618,7 @@ static const int included_patches[] = {
   // 114 NA
   // 113 NA
   // 112,
-  // 111,
+  111,
   110,
   // 109 NA
   // 108 NA


### PR DESCRIPTION
Problem:    The :history command is not tested.
Solution:   Add tests. (Dominique Pelle)

https://github.com/vim/vim/commit/eebd84eb94ed7f59a06a52cb4863563642f58899