### PR TITLE
[RDY] vim-patch:8.0.0119

### DIFF
--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -209,3 +209,26 @@ func Test_expand_star_star()
   bwipe!
   call delete('a', 'rf')
 endfunc
+
+func Test_paste_in_cmdline()
+  let @a = "def"
+  call feedkeys(":abc \<C-R>a ghi\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"abc def ghi', @:)
+
+  new
+  call setline(1, 'asdf.x /tmp/some verylongword a;b-c*d ')
+
+  call feedkeys(":aaa \<C-R>\<C-W> bbb\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"aaa asdf bbb', @:)
+
+  call feedkeys("ft:aaa \<C-R>\<C-F> bbb\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"aaa /tmp/some bbb', @:)
+
+  set incsearch
+  call feedkeys("fy:aaa veryl\<C-R>\<C-W> bbb\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"aaa verylongword bbb', @:)
+
+  call feedkeys("f;:aaa \<C-R>\<C-A> bbb\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"aaa a;b-c*d bbb', @:)
+  bwipe!
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -610,7 +610,7 @@ static const int included_patches[] = {
   // 122 NA
   121,
   // 120 NA
-  // 119,
+  119,
   // 118,
   // 117 NA
   116,


### PR DESCRIPTION
Problem:    No test for using CTRL-R on the command line.
Solution:   Add a test. (Dominique Pelle) And some more.

https://github.com/vim/vim/commit/21efc3633edb58809c5dd89b025d34d7002e731c