### PR TITLE
[RFC] vim-patch:8.0.0124

### DIFF
--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -29,7 +29,7 @@ return {
     assert_exception={args={1, 2}},
     assert_fails={args={1, 2}},
     assert_false={args={1, 2}},
-    assert_inrange={args={2, 3}},
+    assert_inrange={args={3, 4}},
     assert_match={args={2, 3}},
     assert_notequal={args={2, 3}},
     assert_notmatch={args={2, 3}},

--- a/src/nvim/testdir/test_assert.vim
+++ b/src/nvim/testdir/test_assert.vim
@@ -1,0 +1,17 @@
+" Test that the methods used for testing work.
+
+func Test_assert_inrange()
+  call assert_inrange(7, 7, 7)
+  call assert_inrange(5, 7, 5)
+  call assert_inrange(5, 7, 6)
+  call assert_inrange(5, 7, 7)
+
+  call assert_inrange(5, 7, 4)
+  call assert_match("Expected range 5 - 7, but got 4", v:errors[0])
+  call remove(v:errors, 0)
+  call assert_inrange(5, 7, 8)
+  call assert_match("Expected range 5 - 7, but got 8", v:errors[0])
+  call remove(v:errors, 0)
+
+  call assert_fails('call assert_inrange(1, 1)', 'E119:')
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -605,7 +605,7 @@ static const int included_patches[] = {
   127,
   // 126,
   // 125,
-  // 124,
+  124,
   // 123 NA
   // 122 NA
   121,


### PR DESCRIPTION
Problem:    Internal error for assert_inrange(1, 1).
Solution:   Adjust number of allowed arguments. (Dominique Pelle)

https://github.com/vim/vim/commit/3421566376b5723213af502bd3c2b9debe025ef1