### PR TITLE
[RFC] vim-patch:8.0.0126

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2704,13 +2704,18 @@ win_line (
 
         draw_state = WL_FOLD;
         if (fdc > 0) {
-          // Draw the 'foldcolumn'.
-          fill_foldcolumn(extra, wp, false, lnum);
-          n_extra = fdc;
-          p_extra = extra;
-          p_extra[n_extra] = NUL;
-          c_extra = NUL;
-          char_attr = win_hl_attr(wp, HLF_FC);
+          // Draw the 'foldcolumn'.  Allocate a buffer, "extra" may
+          // already be in used.
+          p_extra_free = xmalloc(12 + 1);
+
+          if (p_extra_free != NULL) {
+            fill_foldcolumn(p_extra_free, wp, false, lnum);
+            n_extra = fdc;
+            p_extra_free[n_extra] = NUL;
+            p_extra = p_extra_free;
+            c_extra = NUL;
+            char_attr = hl_attr(HLF_FC);
+          }
         }
       }
 

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -1,0 +1,34 @@
+" Test for displaying stuff
+
+function! s:screenline(lnum, nr) abort
+  let line = []
+  for j in range(a:nr)
+    for c in range(1, winwidth(0))
+        call add(line, nr2char(screenchar(a:lnum+j, c)))
+    endfor
+    call add(line, "\n")
+  endfor
+  return join(line, '')
+endfunction
+
+function! Test_display_foldcolumn()
+  new
+  vnew
+  vert resize 25
+
+  1put='e more noise blah blah more stuff here'
+
+  let expect = "e more noise blah blah<82\n> more stuff here        \n"
+
+  call cursor(2, 1)
+  norm! zt
+  redraw!
+  call assert_equal(expect, s:screenline(1,2))
+  set fdc=2
+  redraw!
+  let expect = "  e more noise blah blah<\n  82> more stuff here    \n"
+  call assert_equal(expect, s:screenline(1,2))
+
+  quit!
+  quit!
+endfunction

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -603,7 +603,7 @@ static const int included_patches[] = {
   // 129 NA
   // 128,
   127,
-  // 126,
+  126,
   // 125,
   // 124,
   // 123 NA


### PR DESCRIPTION
Problem:    Display problem with 'foldcolumn' and a wide character.
            (esiegerman)
Solution:   Don't use "extra" but an allocated buffer. (Christian Brabandt,
            closes vim/vim#1310)

https://github.com/vim/vim/commit/6270660611a151c5d0f614a5f0248ccdc80ed971