### PR TITLE
[RDY] Do not automatically wipe terminal buffers

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -253,7 +253,7 @@ Name			triggered by ~
 
 |SwapExists|		detected an existing swap file
 |TermOpen|		when a terminal buffer is starting
-|TermClose|		when a terminal buffer ends
+|TermClose|		when a terminal process exits
 
 	Options
 |FileType|		when the 'filetype' option has been set
@@ -916,11 +916,11 @@ TermChanged			After the value of 'term' has changed.  Useful
 				colors, fonts and other terminal-dependent
 				settings.  Executed for all loaded buffers.
 						 {Nvim} *TermClose*
-TermClose			When a terminal buffer ends.
+TermClose			When a |terminal| process exits.
 						 {Nvim} *TermOpen*
-TermOpen			When a terminal buffer is starting.  This can
-				be used to configure the terminal emulator by
-				setting buffer variables. |terminal|
+TermOpen			When a |terminal| buffer starts. This can be
+				used to configure the terminal emulator by
+				setting buffer variables.
 							*TermResponse*
 TermResponse			After the response to |t_RV| is received from
 				the terminal.  The value of |v:termresponse|

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1108,7 +1108,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  nofile	buffer is not related to a file, will not be written
 	  nowrite	buffer will not be written
 	  quickfix	list of errors |:cwindow| or locations |:lwindow|
-	  terminal	|terminal-emulator| buffer
+	  terminal	|terminal| buffer
 
 	This option is used together with 'bufhidden' and 'swapfile' to
 	specify special kinds of buffers.   See |special-buffers|.

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -829,6 +829,7 @@ Short explanation of each option:		*option-list*
 'rulerformat'	  'ruf'     custom format for the ruler
 'runtimepath'	  'rtp'     list of directories used for runtime files
 'scroll'	  'scr'     lines to scroll with CTRL-U and CTRL-D
+'scrollback'	  'scbk'    scrollback buffer size for terminal buffers
 'scrollbind'	  'scb'     scroll in window as other windows scroll
 'scrolljump'	  'sj'	    minimum number of lines to scroll
 'scrolloff'	  'so'	    minimum nr. of lines above and below cursor

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -79,7 +79,7 @@ return {
     'TabNew',                 -- when creating a new tab
     'TabNewEntered',          -- after entering a new tab
     'TermChanged',            -- after changing 'term'
-    'TermClose',              -- after the processs exits
+    'TermClose',              -- when the process exits
     'TermOpen',               -- after opening a terminal buffer
     'TermResponse',           -- after setting "v:termresponse"
     'TextChanged',            -- text was modified

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1167,7 +1167,7 @@ do_buffer (
       } else {
         if (buf->terminal) {
           EMSG2(_("E89: %s will be killed (add ! to override)"),
-              (char *)buf->b_fname);
+                (char *)buf->b_fname);
         } else {
           EMSGN(_("E89: No write since last change for buffer %" PRId64
                   " (add ! to override)"),

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -513,7 +513,7 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
     return;
 
   if (buf->terminal) {
-    terminal_close(buf->terminal, NULL);
+    terminal_close(buf->terminal);
   }
 
   /* Always remove the buffer when there is no file name. */
@@ -1166,7 +1166,7 @@ do_buffer (
         }
       } else {
         if (buf->terminal) {
-          EMSG2(_("E89: %s will be killed(add ! to override)"),
+          EMSG2(_("E89: %s will be killed (add ! to override)"),
               (char *)buf->b_fname);
         } else {
           EMSGN(_("E89: No write since last change for buffer %" PRId64

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -22650,6 +22650,7 @@ static void term_delayed_free(void **argv)
   term_job_data_decref(j);
 }
 
+/// Called when the terminal buffer gets wiped while the job is still running
 static void term_close(void *d)
 {
   TerminalJobData *data = d;
@@ -22657,6 +22658,7 @@ static void term_close(void *d)
     data->exited = true;
     process_stop((Process *)&data->proc);
   }
+  data->term = NULL; // Terminal no longer exists
 }
 
 static void term_job_data_decref(TerminalJobData *data)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16703,7 +16703,6 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   topts.write_cb  = term_write;
   topts.resize_cb = term_resize;
   topts.close_cb  = term_close;
-  topts.free_cb   = term_free;
 
   int pid = data->proc.pty.process.pid;
 
@@ -16725,7 +16724,6 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   Terminal *term = terminal_open(topts);
   data->term = term;
-  data->refcount++;
 
   return;
 }
@@ -22636,12 +22634,6 @@ static void term_resize(uint16_t width, uint16_t height, void *d)
 {
   TerminalJobData *data = d;
   pty_process_resize(&data->proc.pty, width, height);
-}
-
-static void term_free(void *d)
-{
-  TerminalJobData *data = d;
-  term_job_data_decref(data);
 }
 
 /// Called when the terminal buffer gets wiped while the job is still running

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16703,7 +16703,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   topts.write_cb  = term_write;
   topts.resize_cb = term_resize;
   topts.close_cb  = term_close;
-  topts.free_cb   = term_delayed_free;
+  topts.free_cb   = term_free;
 
   int pid = data->proc.pty.process.pid;
 
@@ -22638,16 +22638,10 @@ static void term_resize(uint16_t width, uint16_t height, void *d)
   pty_process_resize(&data->proc.pty, width, height);
 }
 
-static void term_delayed_free(void **argv)
+static void term_free(void *d)
 {
-  TerminalJobData *j = argv[0];
-  if (j->in.pending_reqs || j->out.pending_reqs || j->err.pending_reqs) {
-    multiqueue_put(j->events, term_delayed_free, 1, j);
-    return;
-  }
-
-  terminal_destroy(j->term);
-  term_job_data_decref(j);
+  TerminalJobData *data = d;
+  term_job_data_decref(data);
 }
 
 /// Called when the terminal buffer gets wiped while the job is still running

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -22658,7 +22658,7 @@ static void term_close(void *d)
     data->exited = true;
     process_stop((Process *)&data->proc);
   }
-  data->term = NULL; // Terminal no longer exists
+  data->term = NULL;  // Terminal no longer exists
 }
 
 static void term_job_data_decref(TerminalJobData *data)

--- a/src/nvim/po/fi.po
+++ b/src/nvim/po/fi.po
@@ -324,7 +324,7 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Ensimmäisen puskurin ohi ei voi edetä"
 
 #, fuzzy, c-format
-#~ msgid "E89: %s will be killed(add ! to override)"
+#~ msgid "E89: %s will be killed (add ! to override)"
 #~ msgstr "E189: %s on jo olemassa (lisää komentoon ! ohittaaksesi)"
 
 #, fuzzy, c-format

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -272,7 +272,7 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Це вже найперший буфер"
 
 #, c-format
-msgid "E89: %s will be killed(add ! to override)"
+msgid "E89: %s will be killed (add ! to override)"
 msgstr "E89: «%s» буде вбито(! щоб не зважати)"
 
 #, c-format

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -313,7 +313,7 @@ void terminal_exit(Terminal *term, char *msg)
   term->opts.free_cb(&term->opts.data);
 }
 
-/// Called when the terminal buffer get's wiped
+/// Called when the terminal buffer gets wiped
 void terminal_close(Terminal *term)
 {
   if (!term->exited) {

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -102,7 +102,6 @@ typedef struct {
 } ScrollbackLine;
 
 struct terminal {
-
   TerminalOptions opts;  // options passed to terminal_open
   // buf_T instance that acts as a "drawing surface" for libvterm
   // we can't store a direct reference to the buffer because the
@@ -249,7 +248,7 @@ Terminal *terminal_open(TerminalOptions opts)
   rv->sb_current = 0;
   rv->sb_pending = 0;
   rv->sb_size    = curbuf->b_p_scbk < 0 ? SB_MAX
-      : (size_t) MAX(1, curbuf->b_p_scbk);
+      : (size_t)MAX(1, curbuf->b_p_scbk);
   rv->sb_buffer  = xmalloc(sizeof(ScrollbackLine *) * rv->sb_size);
 
   if (!true_color) {

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -310,7 +310,6 @@ void terminal_exit(Terminal *term, char *msg)
     unblock_autocmds();
   }
 
-  term->opts.free_cb(term->opts.data);
   terminal_destroy(term);
 }
 
@@ -319,7 +318,6 @@ void terminal_close(Terminal *term)
 {
   if (!term->exited) {
     term->opts.close_cb(term->opts.data);
-    term->opts.free_cb(term->opts.data);
     terminal_destroy(term);
   }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -310,7 +310,8 @@ void terminal_exit(Terminal *term, char *msg)
     unblock_autocmds();
   }
 
-  term->opts.free_cb(&term->opts.data);
+  term->opts.free_cb(term->opts.data);
+  terminal_destroy(term);
 }
 
 /// Called when the terminal buffer gets wiped
@@ -318,6 +319,7 @@ void terminal_close(Terminal *term)
 {
   if (!term->exited) {
     term->opts.close_cb(term->opts.data);
+    term->opts.free_cb(term->opts.data);
     terminal_destroy(term);
   }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -847,6 +847,10 @@ static void mouse_action(Terminal *term, int button, int row, int col,
 // terminal should lose focus
 static bool send_mouse_event(Terminal *term, int c)
 {
+  if (term->exited) {
+    return true;
+  }
+
   int row = mouse_row, col = mouse_col;
   win_T *mouse_win = mouse_find_win(&row, &col);
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -150,8 +150,6 @@ static Map(int, int) *color_indexes;
 static int default_vt_fg, default_vt_bg;
 static VTermColor default_vt_bg_rgb;
 
-// init/teardown {{{
-
 void terminal_init(void)
 {
   invalidated_terminals = pmap_new(ptr_t)();
@@ -198,14 +196,11 @@ void terminal_teardown(void)
   map_free(int, int)(color_indexes);
 }
 
-// }}}
-// public API {{{
-
 Terminal *terminal_open(TerminalOptions opts)
 {
   bool true_color = ui_rgb_attached();
 
-  Terminal *rv   = (Terminal *) xcalloc(1, sizeof(Terminal));
+  Terminal *rv   = xcalloc(1, sizeof(Terminal));
   rv->opts       = opts;
   rv->buf_handle = curbuf->handle;
   rv->exited     = false;
@@ -383,7 +378,9 @@ void terminal_enter(void)
   assert(buf->terminal);  // Should only be called when curbuf has a terminal.
 
   // Do not allow 'TERMINAL' mode if the process already exited
-  if (buf->terminal->exited) return;
+  if (buf->terminal->exited) {
+    return;
+  }
 
   TerminalState state, *s = &state;
   memset(s, 0, sizeof(TerminalState));
@@ -438,7 +435,7 @@ void terminal_enter(void)
 
 static int terminal_execute(VimState *state, int key)
 {
-  TerminalState *s = (TerminalState *) state;
+  TerminalState *s = (TerminalState *)state;
 
   switch (key) {
     case K_FOCUSGAINED:  // nvim has been given focus
@@ -614,9 +611,6 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr,
   }
 }
 
-// }}}
-// libvterm callbacks {{{
-
 static int term_damage(VTermRect rect, void *data)
 {
   invalidate_terminal(data, rect.start_row, rect.end_row);
@@ -782,9 +776,6 @@ static int term_sb_pop(int cols, VTermScreenCell *cells, void *data)
   return 1;
 }
 
-// }}}
-// input handling {{{
-
 static void convert_modifiers(VTermModifier *statep)
 {
   if (mod_mask & MOD_MASK_SHIFT) { *statep |= VTERM_MOD_SHIFT; }
@@ -916,9 +907,6 @@ static bool send_mouse_event(Terminal *term, int c)
   ins_char_typebuf(c);
   return true;
 }
-
-// }}}
-// terminal buffer refresh & misc {{{
 
 static void fetch_row(Terminal *term, int row, int end_col)
 {
@@ -1255,7 +1243,5 @@ static char *get_config_string(char *key)
   api_free_object(obj);
   return NULL;
 }
-
-// }}}
 
 // vim: foldmethod=marker sw=2

--- a/src/nvim/terminal.h
+++ b/src/nvim/terminal.h
@@ -9,13 +9,15 @@ typedef struct terminal Terminal;
 typedef void (*terminal_write_cb)(char *buffer, size_t size, void *data);
 typedef void (*terminal_resize_cb)(uint16_t width, uint16_t height, void *data);
 typedef void (*terminal_close_cb)(void *data);
+typedef void (*terminal_free_cb)(void **data);
 
 typedef struct {
   void *data;
   uint16_t width, height;
-  terminal_write_cb write_cb;
+  terminal_write_cb  write_cb;
   terminal_resize_cb resize_cb;
-  terminal_close_cb close_cb;
+  terminal_close_cb  close_cb;
+  terminal_free_cb   free_cb;
 } TerminalOptions;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/terminal.h
+++ b/src/nvim/terminal.h
@@ -9,7 +9,6 @@ typedef struct terminal Terminal;
 typedef void (*terminal_write_cb)(char *buffer, size_t size, void *data);
 typedef void (*terminal_resize_cb)(uint16_t width, uint16_t height, void *data);
 typedef void (*terminal_close_cb)(void *data);
-typedef void (*terminal_free_cb)(void *data);
 
 typedef struct {
   void *data;
@@ -17,7 +16,6 @@ typedef struct {
   terminal_write_cb  write_cb;
   terminal_resize_cb resize_cb;
   terminal_close_cb  close_cb;
-  terminal_free_cb   free_cb;
 } TerminalOptions;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/terminal.h
+++ b/src/nvim/terminal.h
@@ -9,7 +9,7 @@ typedef struct terminal Terminal;
 typedef void (*terminal_write_cb)(char *buffer, size_t size, void *data);
 typedef void (*terminal_resize_cb)(uint16_t width, uint16_t height, void *data);
 typedef void (*terminal_close_cb)(void *data);
-typedef void (*terminal_free_cb)(void **data);
+typedef void (*terminal_free_cb)(void *data);
 
 typedef struct {
   void *data;

--- a/test/functional/autocmd/termclose_spec.lua
+++ b/test/functional/autocmd/termclose_spec.lua
@@ -17,7 +17,6 @@ describe('TermClose event', function()
   it('triggers when fast-exiting terminal job stops', function()
     command('autocmd TermClose * let g:test_termclose = 23')
     command('terminal')
-    command('call jobstop(b:terminal_job_id)')
     retry(nil, nil, function() eq(23, eval('g:test_termclose')) end)
   end)
 

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -678,11 +678,11 @@ describe("pty process teardown", function()
     -- Exiting should terminate all descendants (PTY, its children, ...).
     screen:expect([[
                                     |
-      [Process exited 0]            |
+      [Process exited 0^]            |
                                     |
                                     |
                                     |
-      -- TERMINAL --                |
+                                    |
     ]])
   end)
 end)

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -73,9 +73,9 @@ describe(':terminal (with fake shell)', function()
     wait()
     screen:expect([[
       ready $                                           |
-      [Process exited 0]                                |
+      [Process exited 0^]                                |
                                                         |
-      -- TERMINAL --                                    |
+                                                        |
     ]])
   end)
 
@@ -97,9 +97,9 @@ describe(':terminal (with fake shell)', function()
     wait()
     screen:expect([[
       jeff $                                            |
-      [Process exited 0]                                |
+      [Process exited 0^]                                |
                                                         |
-      -- TERMINAL --                                    |
+                                                        |
     ]])
   end)
 
@@ -109,8 +109,8 @@ describe(':terminal (with fake shell)', function()
     screen:expect([[
       ready $ echo hi                                   |
                                                         |
-      [Process exited 0]                                |
-      -- TERMINAL --                                    |
+      [Process exited 0^]                                |
+                                                        |
     ]])
   end)
 
@@ -121,8 +121,8 @@ describe(':terminal (with fake shell)', function()
     screen:expect([[
       jeff $ echo hi                                    |
                                                         |
-      [Process exited 0]                                |
-      -- TERMINAL --                                    |
+      [Process exited 0^]                                |
+                                                        |
     ]])
   end)
 
@@ -132,8 +132,8 @@ describe(':terminal (with fake shell)', function()
     screen:expect([[
       ready $ echo 'hello' \ "world"                    |
                                                         |
-      [Process exited 0]                                |
-      -- TERMINAL --                                    |
+      [Process exited 0^]                                |
+                                                        |
     ]])
   end)
 
@@ -167,12 +167,11 @@ describe(':terminal (with fake shell)', function()
     wait()
     screen:expect([[
       ready $                                           |
-      [Process exited 0]                                |
+      [Process exited 0^]                                |
                                                         |
-      -- TERMINAL --                                    |
+                                                        |
     ]])
     eq('term://', string.match(eval('bufname("%")'), "^term://"))
-    helpers.feed([[<C-\><C-N>]])
     feed_command([[find */shadacat.py]])
     if iswin() then
       eq('scripts\\shadacat.py', eval('bufname("%")'))
@@ -186,10 +185,9 @@ describe(':terminal (with fake shell)', function()
     screen:expect([[
       ready $ echo "scripts/shadacat.py"                |
                                                         |
-      [Process exited 0]                                |
-      -- TERMINAL --                                    |
+      [Process exited 0^]                                |
+                                                        |
     ]])
-    helpers.feed([[<C-\><C-N>]])
     eq('term://', string.match(eval('bufname("%")'), "^term://"))
     helpers.feed([[ggf"lgf]])
     eq('scripts/shadacat.py', eval('bufname("%")'))

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -357,11 +357,11 @@ describe('terminal prints more lines than the screen height and exits', function
       line8                         |
       line9                         |
                                     |
-      [Process exited 0]            |
-      -- TERMINAL --                |
+      [Process exited 0^]            |
+                                    |
     ]])
-    feed('<cr>')
-    -- closes the buffer correctly after pressing a key
+    command('bwipeout!')
+    -- closes the buffer correctly when wiped
     screen:expect([[
       ^                              |
       ~                             |

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -5,7 +5,6 @@ local thelpers = require('test.functional.terminal.helpers')
 local feed_data = thelpers.feed_data
 local feed_command = helpers.feed_command
 local nvim_dir = helpers.nvim_dir
-local retry = helpers.retry
 
 if helpers.pending_win32(pending) then return end
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -187,9 +187,9 @@ describe('tui with non-tty file descriptors', function()
       :q                                                |
       abc                                               |
                                                         |
-      [Process exited 0]{1: }                               |
+      [Process exited 0^]{2: }                               |
                                                         |
-      {3:-- TERMINAL --}                                    |
+                                                        |
     ]])
   end)
 end)
@@ -280,36 +280,30 @@ describe('tui focus event handling', function()
   end)
 
   it('can handle focus events in terminal mode', function()
-    feed_data(':set shell='..nvim_dir..'/shell-test\n')
-    feed_data(':set noshowmode laststatus=0\n')
+    feed_command('set shell='..nvim_dir..'/tty-test')
+    feed_command('set noshowmode laststatus=0')
+    feed_command('terminal')
 
-    retry(2, 3 * screen.timeout, function()
-      feed_data(':terminal\n')
-      feed_data('\027[I')
-      screen:expect([[
-        ready $                                           |
-        [Process exited 0]{1: }                               |
-                                                          |
-                                                          |
-                                                          |
-        gained                                            |
-        {3:-- TERMINAL --}                                    |
-      ]])
-      feed_data('\027[O')
-      screen:expect([[
-        ready $                                           |
-        [Process exited 0]{1: }                               |
-                                                          |
-                                                          |
-                                                          |
-        lost                                              |
-        {3:-- TERMINAL --}                                    |
-      ]])
-
-      -- If retry is needed...
-      feed_data("\034\016")  -- CTRL-\ CTRL-N
-      feed_data(':bwipeout!\n')
-    end)
+    feed_data('\027[I')
+    screen:expect([[
+      tty ready                                         |
+      {1: }                                                 |
+                                                        |
+                                                        |
+                                                        |
+      gained                                            |
+      {3:-- TERMINAL --}                                    |
+    ]])
+    feed_data('\027[O')
+    screen:expect([[
+      tty ready                                         |
+      {1: }                                                 |
+                                                        |
+                                                        |
+                                                        |
+      lost                                              |
+      {3:-- TERMINAL --}                                    |
+    ]])
   end)
 end)
 


### PR DESCRIPTION
This changes the behaviour of the terminal emulator.
Previously, the lifetimes of a terminal job and the associated vim buffer were tightly coupled. When a process exited, the terminal waited for an additional key input and then wiped the buffer automatically. This no longer happens. The vim buffer is kept until the user manually wipes it:

- **Scenario 1**:  The job dies while the user is in `-TERMINAL-` mode (e.g. by hitting `<c-d>`)
    - **Old behavior**: Neovim stays in `-TERMINAL-` mode, and any additional key stroke will wipe the buffer.
    - **New behavior**: The user is put into normal mode, and the buffer stays alive.

- **Scenario 2**: The job dies while the user is in normal mode.
    - **Old behavior**: The buffer stays around. When the user enters insert mode, `-TERMINAL-` mode is entered and any key stroke will wipe the buffer.
    - **New behavior**: The buffer stays around. When the user attempts to enter insert mode, nvim refuses and stays in normal mode.

Several tests needed adjustment to pass with the new behavior. The `shell-test` tool used during many of the tests immediately exits, and the tests assume that nvim stays in `-TERMINAL-` mode after that. Functionally, all tests work fine.

While working on this, I noticed several other issues with the current behavior (that i might address in the future):

- Terminal buffers get killed **silently** when `'hidden'`/`'bufhidden'` is not set and the user executes `:only` in another window, executes `:q`, changes to a different buffer using `:b`, etc. Instead, a warning should be issued that the process will be killed (by giving `!`).
- Terminal buffers ignore `'hidden'`/`'bufhidden'`, and always become hidden when left through `gf`, `:enew` or another `:terminal`.
- When attemping to wipe a terminal buffer _after_ the process died, nvim will still warn that the process will be killed. Instead, it should wipe the buffer (as it does for `nofile` buffers).