### PR TITLE
[RFC] vim-patch: 8.0.00{12, 46, 63}

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3127,7 +3127,7 @@ static char_u *get_mef_name(void)
     STRCPY(name, p_mef);
     sprintf((char *)name + (p - p_mef), "%d%d", start, off);
     STRCAT(name, p + 2);
-    // Don't accept a symbolic link, its a security risk.
+    // Don't accept a symbolic link, it's a security risk.
     FileInfo file_info;
     bool file_or_link_found = os_fileinfo_link((char *)name, &file_info);
     if (!file_or_link_found) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -717,7 +717,7 @@ static const int included_patches[] = {
   // 15 NA
   // 14 NA
   // 13 NA
-  // 12,
+  12,
   // 11 NA
   // 10 NA
   // 9 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -666,7 +666,7 @@ static const int included_patches[] = {
   66,
   // 65 NA
   64,
-  // 63,
+  // 63 NA
   62,
   // 61 NA
   60,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -683,7 +683,7 @@ static const int included_patches[] = {
   49,
   // 48 NA
   47,
-  // 46,
+  46,
   // 45 NA
   // 44,
   43,


### PR DESCRIPTION
vim-patch:8.0.0012
    
Problem:    Typos in comments.
Solution:   Change "its" to "it's". (Matthew Brener, closes vim/vim#1088)
    
https://github.com/vim/vim/commit/9af418427652562384744648d7d173a4bfebba95

vim-patch:8.0.0046 

This patch is already applied.

vim-patch:8.0.0063

FEAT_CRYPT is removed, so marked as NA
