### PR TITLE
oldtests: Run nvim using --headless to avoid requesting user input

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -132,7 +132,7 @@ $(SCRIPTS) $(SCRIPTS_GUI): $(NVIM_PRG) test1.out
 
 RM_ON_RUN   := test.out X* viminfo
 RM_ON_START := test.ok
-RUN_VIM     := VIMRUNTIME=$(SCRIPTSOURCE); export VIMRUNTIME; $(TOOL) $(NVIM_PRG) -u unix.vim -U NONE -i viminfo --noplugin -s dotest.in
+RUN_VIM     := VIMRUNTIME=$(SCRIPTSOURCE); export VIMRUNTIME; $(TOOL) $(NVIM_PRG) -u unix.vim -U NONE -i viminfo --headless --noplugin -s dotest.in
 
 clean:
 	-rm -rf *.out          \
@@ -201,7 +201,7 @@ nolog:
 # New style of tests uses Vim script with assert calls.  These are easier
 # to write and a lot easier to read and debug.
 # Limitation: Only works with the +eval feature.
-RUN_VIMTEST = VIMRUNTIME=$(SCRIPTSOURCE); export VIMRUNTIME; $(VALGRIND) $(NVIM_PRG) -u unix.vim -U NONE --noplugin
+RUN_VIMTEST = VIMRUNTIME=$(SCRIPTSOURCE); export VIMRUNTIME; $(VALGRIND) $(NVIM_PRG) -u unix.vim -U NONE --headless --noplugin
 
 newtests: newtestssilent
 	@/bin/sh -c "if test -f messages && grep -q 'FAILED' messages; then \


### PR DESCRIPTION
Certain functions (e.g. feedkeys(…, 'x!') and input()) will attempt to
read from stdin, which shouldn't be expected to work during oldtests.
In Debian/Ubuntu's build environment, it explicitly can't work because
/dev/null is redirected to stdin, which causes read_error_exit() to
exit.

Running oldtests with --headless prevents nvim from setting up its input
handling, thus avoiding the problem altogether.

Reference #6794