### PR TITLE
[RDY] vim-patch:8.0.0133

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1665,11 +1665,15 @@ static char_u * do_one_cmd(char_u **cmdlinep,
     ea.addr_count++;
 
     if (*ea.cmd == ';') {
-      if (!ea.skip)
+      if (!ea.skip) {
         curwin->w_cursor.lnum = ea.line2;
-    } else if (*ea.cmd != ',')
+        // Don't leave the cursor on an illegal line (caused by ';')
+        check_cursor_lnum();
+      }
+    } else if (*ea.cmd != ',') {
       break;
-    ++ea.cmd;
+    }
+    ea.cmd++;
   }
 
   /* One address given: set start and end lines */
@@ -1679,9 +1683,6 @@ static char_u * do_one_cmd(char_u **cmdlinep,
     if (lnum == MAXLNUM)
       ea.addr_count = 0;
   }
-
-  /* Don't leave the cursor on an illegal line (caused by ';') */
-  check_cursor_lnum();
 
   /*
    * 5. Parse the command.

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -232,3 +232,10 @@ func Test_paste_in_cmdline()
   call assert_equal('"aaa a;b-c*d bbb', @:)
   bwipe!
 endfunc
+
+func Test_illegal_address()
+  new
+  2;'(
+  2;')
+  quit
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -596,7 +596,7 @@ static const int included_patches[] = {
   136,
   135,
   // 134,
-  // 133,
+  133,
   // 132,
   // 131,
   // 130 NA


### PR DESCRIPTION

    vim-patch:8.0.0133
    
    Problem:    "2;'(" causes ml_get errors in an empty buffer.  (Dominique Pelle)
    Solution:   Check the cursor line earlier.
    
    https://github.com/vim/vim/commit/fe38b494fff56cd9b2fcaeef26a8fd7b6557d69c
