### PR TITLE
[RDY] vim-patch:8.0.0137

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -340,12 +340,13 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
   msg_list = &private_msg_list;
   private_msg_list = NULL;
 
-  /* It's possible to create an endless loop with ":execute", catch that
-   * here.  The value of 200 allows nested function calls, ":source", etc. */
-  if (call_depth == 200) {
+  // It's possible to create an endless loop with ":execute", catch that
+  // here.  The value of 200 allows nested function calls, ":source", etc.
+  // Allow 200 or 'maxfuncdepth', whatever is larger.
+  if (call_depth >= 200 && call_depth >= p_mfd) {
     EMSG(_("E169: Command too recursive"));
-    /* When converting to an exception, we do not include the command name
-     * since this is not an error of the specific command. */
+    // When converting to an exception, we do not include the command name
+    // since this is not an error of the specific command.
     do_errthrow((struct condstack *)NULL, (char_u *)NULL);
     msg_list = saved_msg_list;
     return FAIL;

--- a/src/nvim/testdir/test_nested_function.vim
+++ b/src/nvim/testdir/test_nested_function.vim
@@ -40,3 +40,24 @@ func Test_nested_argument()
   delfunc g:X
   unlet g:Y
 endfunc
+
+func Recurse(count)
+  if a:count > 0
+    call Recurse(a:count - 1)
+  endif
+endfunc
+
+func Test_max_nesting()
+  let call_depth_here = 2
+  let ex_depth_here = 5
+  set mfd&
+
+  call Recurse(99 - call_depth_here)
+  call assert_fails('call Recurse(' . (100 - call_depth_here) . ')', 'E132:')
+
+  set mfd=210
+  call Recurse(209 - ex_depth_here)
+  call assert_fails('call Recurse(' . (210 - ex_depth_here) . ')', 'E169:')
+
+  set mfd&
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -592,7 +592,7 @@ static const int included_patches[] = {
   // 140,
   // 139 NA
   // 138 NA
-  // 137,
+  137,
   136,
   135,
   134,


### PR DESCRIPTION
Problem:    When 'maxfuncdepth' is set above 200 the nesting is limited to
                200. (Brett Stahlman)
    Solution:   Allow for Ex command recursion depending on 'maxfuncdepth'.
    
    https://github.com/vim/vim/commit/777b30f827bcbe10a40640b1bf0361cb93a16be1
