### PR TITLE
[RDY] vim-patch:8.0.0143

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9079,7 +9079,8 @@ static dict_T *get_buffer_info(buf_T *buf)
   tv_dict_add_nr(dict, S_LEN("bufnr"), buf->b_fnum);
   tv_dict_add_str(dict, S_LEN("name"),
                   buf->b_ffname != NULL ? (const char *)buf->b_ffname : "");
-  tv_dict_add_nr(dict, S_LEN("lnum"), buflist_findlnum(buf));
+  tv_dict_add_nr(dict, S_LEN("lnum"),
+                 buf == curbuf ? curwin->w_cursor.lnum : buflist_findlnum(buf));
   tv_dict_add_nr(dict, S_LEN("loaded"), buf->b_ml.ml_mfp != NULL);
   tv_dict_add_nr(dict, S_LEN("listed"), buf->b_p_bl);
   tv_dict_add_nr(dict, S_LEN("changed"), bufIsChanged(buf));

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -586,7 +586,7 @@ static const int included_patches[] = {
   // 146,
   // 145 NA
   // 144 NA
-  // 143,
+  143,
   // 142,
   // 141,
   // 140,


### PR DESCRIPTION
Problem:    Line number of current buffer in getbufinfo() is wrong.
Solution:   For the current buffer use the current line number. (Ken Takata)

https://github.com/vim/vim/commit/f845b87f2b3a45cbee160e28d7a3f50e54054809