### PR TITLE
[RFC] vim-patch:8.0.0147

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14202,6 +14202,8 @@ do_searchpair (
   int nest = 1;
   int options = SEARCH_KEEP;
   proftime_T tm;
+  size_t pat2_len;
+  size_t pat3_len;
 
   /* Make 'cpoptions' empty, the 'l' flag should not be used here. */
   save_cpo = p_cpo;
@@ -14210,18 +14212,22 @@ do_searchpair (
   /* Set the time limit, if there is one. */
   tm = profile_setlimit(time_limit);
 
-  /* Make two search patterns: start/end (pat2, for in nested pairs) and
-   * start/middle/end (pat3, for the top pair). */
-  pat2 = xmalloc(STRLEN(spat) + STRLEN(epat) + 15);
-  pat3 = xmalloc(STRLEN(spat) + STRLEN(mpat) + STRLEN(epat) + 23);
-  sprintf((char *)pat2, "\\(%s\\m\\)\\|\\(%s\\m\\)", spat, epat);
-  if (*mpat == NUL)
+  // Make two search patterns: start/end (pat2, for in nested pairs) and
+  // start/middle/end (pat3, for the top pair).
+  pat2_len = STRLEN(spat) + STRLEN(epat) + 17;
+  pat2 = xmalloc(pat2_len);
+  pat3_len = STRLEN(spat) + STRLEN(mpat) + STRLEN(epat) + 25;
+  pat3 = xmalloc(pat3_len);
+  snprintf((char *)pat2, pat2_len, "\\m\\(%s\\m\\)\\|\\(%s\\m\\)", spat, epat);
+  if (*mpat == NUL) {
     STRCPY(pat3, pat2);
-  else
-    sprintf((char *)pat3, "\\(%s\\m\\)\\|\\(%s\\m\\)\\|\\(%s\\m\\)",
-        spat, epat, mpat);
-  if (flags & SP_START)
+  } else {
+    snprintf((char *)pat3, pat3_len,
+             "\\m\\(%s\\m\\)\\|\\(%s\\m\\)\\|\\(%s\\m\\)", spat, epat, mpat);
+  }
+  if (flags & SP_START) {
     options |= SEARCH_START;
+  }
 
   save_cursor = curwin->w_cursor;
   pos = curwin->w_cursor;

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -283,3 +283,18 @@ func Test_use_sub_pat()
   call X()
   bwipe!
 endfunc
+
+func Test_searchpair()
+  new
+  call setline(1, ['other code here', '', '[', '" cursor here', ']'])
+  4
+  let a=searchpair('\[','',']','bW')
+  call assert_equal(3, a)
+  set nomagic
+  4
+  let a=searchpair('\[','',']','bW')
+  call assert_equal(3, a)
+  set magic
+  q!
+endfunc
+

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -582,7 +582,7 @@ static const int included_patches[] = {
   150,
   // 149,
   // 148,
-  // 147,
+  147,
   // 146,
   // 145 NA
   // 144 NA


### PR DESCRIPTION
Problem:    searchpair() does not work when 'magic' is off. (Chris Paul)
Solution:   Add \m in the pattern. (Christian Brabandt, closes vim/vim#1341)

https://github.com/vim/vim/commit/6e450a57541676036203a72d40b2e604e938371e