### PR TITLE
[RDY] vim-patch:8.0.0149

### DIFF
--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -237,3 +237,31 @@ func Test_insert_expr()
 
   close!
 endfunc
+
+func Test_undofile_earlier()
+  throw 'skipped: Nvim does not support test_settime()'
+
+  let t0 = localtime() - 43200
+  call test_settime(t0)
+  new Xfile
+  call feedkeys("ione\<Esc>", 'xt')
+  set ul=100
+  call test_settime(t0 + 1)
+  call feedkeys("otwo\<Esc>", 'xt')
+  set ul=100
+  call test_settime(t0 + 2)
+  call feedkeys("othree\<Esc>", 'xt')
+  set ul=100
+  w
+  wundo Xundofile
+  bwipe!
+  " restore normal timestamps.
+  call test_settime(0)
+  new Xfile
+  rundo Xundofile
+  earlier 1d
+  call assert_equal('', getline(1))
+  bwipe!
+  call delete('Xfile')
+  call delete('Xundofile')
+endfunc

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1838,11 +1838,9 @@ void undo_time(long step, int sec, int file, int absolute)
     }
     closest = -1;
   } else {
-    /* When doing computations with time_t subtract starttime, because
-     * time_t converted to a long may result in a wrong number. */
-    if (dosec)
-      target = (long)(curbuf->b_u_time_cur - starttime) + step;
-    else if (dofile) {
+    if (dosec) {
+      target = (long)(curbuf->b_u_time_cur) + step;
+    } else if (dofile) {
       if (step < 0) {
         /* Going back to a previous write. If there were changes after
          * the last write, count that as moving one file-write, so
@@ -1880,14 +1878,16 @@ void undo_time(long step, int sec, int file, int absolute)
         target = 0;
       closest = -1;
     } else {
-      if (dosec)
-        closest = (long)(time(NULL) - starttime + 1);
-      else if (dofile)
+      if (dosec) {
+        closest = (long)(os_time() + 1);
+      } else if (dofile) {
         closest = curbuf->b_u_save_nr_last + 2;
-      else
+      } else {
         closest = curbuf->b_u_seq_last + 2;
-      if (target >= closest)
+      }
+      if (target >= closest) {
         target = closest - 1;
+      }
     }
   }
   closest_start = closest;
@@ -1916,12 +1916,13 @@ void undo_time(long step, int sec, int file, int absolute)
 
     while (uhp != NULL) {
       uhp->uh_walk = mark;
-      if (dosec)
-        val = (long)(uhp->uh_time - starttime);
-      else if (dofile)
+      if (dosec) {
+        val = (long)(uhp->uh_time);
+      } else if (dofile) {
         val = uhp->uh_save_nr;
-      else
+      } else {
         val = uhp->uh_seq;
+      }
 
       if (round == 1 && !(dofile && val == 0)) {
         /* Remember the header that is closest to the target.

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -803,7 +803,7 @@ static const int included_patches[] = {
   // 152 NA
   // 151,
   150,
-  // 149,
+  149,
   // 148,
   147,
   146,


### PR DESCRIPTION
Problem:    ":earlier" and ":later" do not work after startup or reading the
            undo file.
Solution:   Use absolute time stamps instead of relative to the Vim start
            time. (Christian Brabandt, Pavel Juhas, closes vim/vim#1300, closes
            vim/vim#1254)

https://github.com/vim/vim/commit/cbd4de44e8d08fba3c09eb40ad6e36e83faf020a