### PR TITLE
[RDY] vim-patch:8.0.0165

### DIFF
--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -56,13 +56,13 @@ enum {
   NFA_RANGE_MIN,                    /* low end of a range  */
   NFA_RANGE_MAX,                    /* high end of a range  */
 
-  NFA_CONCAT,                       /* concatenate two previous items (postfix
-                                     * only) */
-  NFA_OR,                           /* \| (postfix only) */
-  NFA_STAR,                         /* greedy * (posfix only) */
-  NFA_STAR_NONGREEDY,               /* non-greedy * (postfix only) */
-  NFA_QUEST,                        /* greedy \? (postfix only) */
-  NFA_QUEST_NONGREEDY,              /* non-greedy \? (postfix only) */
+  NFA_CONCAT,                       // concatenate two previous items (postfix
+                                    // only)
+  NFA_OR,                           // \| (postfix only)
+  NFA_STAR,                         // greedy * (postfix only)
+  NFA_STAR_NONGREEDY,               // non-greedy * (postfix only)
+  NFA_QUEST,                        // greedy \? (postfix only)
+  NFA_QUEST_NONGREEDY,              // non-greedy \? (postfix only)
 
   NFA_BOL,                          /* ^    Begin line */
   NFA_EOL,                          /* $    End line */
@@ -1988,7 +1988,7 @@ static int nfa_regpiece(void)
     // The engine is very inefficient (uses too many states) when the maximum
     // is much larger than the minimum and when the maximum is large. Bail out
     // if we can use the other engine.
-    if ((nfa_re_flags & RE_AUTO) && (maxval > minval + 200 || maxval > 500)) {
+    if ((nfa_re_flags & RE_AUTO) && (maxval > 500 || maxval > minval + 200)) {
       return FAIL;
     }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -787,7 +787,7 @@ static const int included_patches[] = {
   168,
   167,
   // 166,
-  // 165,
+  165,
   // 164,
   // 163 NA
   // 162 NA


### PR DESCRIPTION
Problem:    Ubsan warns for integer overflow.
Solution:   Swap two conditions. (Dominique Pelle)

https://github.com/vim/vim/commit/f446b48ff0bffae2b453cd4f9e3c25dfe363d29d