### PR TITLE
oldtest: use TMPDIR

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -3,10 +3,12 @@
 #
 
 NVIM_PRG ?= ../../../build/bin/nvim
+TMPDIR ?= Xtest-tmpdir
 SCRIPTSOURCE := ../../../runtime
 
 export SHELL := sh
 export NVIM_PRG := $(NVIM_PRG)
+export TMPDIR
 
 SCRIPTS ?= \
            test13.out             \
@@ -149,10 +151,12 @@ clean:
 	        .*.swp         \
 	        .*.swo         \
 	        .gdbinit       \
+	        $(TMPDIR)      \
 	        del
 
 test1.out: .gdbinit test1.in
 	-rm -rf $*.failed $(RM_ON_RUN) $(RM_ON_START) wrongtermsize
+	mkdir -p $(TMPDIR)
 	$(RUN_VIM) $*.in
 	@/bin/sh -c "if test -e wrongtermsize; then                                 \
 	                 echo;                                                      \
@@ -170,6 +174,7 @@ test1.out: .gdbinit test1.in
 
 %.out: %.in .gdbinit
 	-rm -rf $*.failed test.ok $(RM_ON_RUN)
+	mkdir -p $(TMPDIR)
 	cp $*.ok test.ok
 	# Sleep a moment to avoid that the xterm title is messed up.
 	# 200 msec is sufficient, but only modern sleep supports a fraction of
@@ -212,4 +217,5 @@ newtests: newtestssilent
 newtestssilent: $(NEW_TESTS)
 
 %.res: %.vim .gdbinit
+	mkdir -p $(TMPDIR)
 	$(RUN_VIMTEST) -u NONE -S runtest.vim $*.vim

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2,7 +2,7 @@
 
 func Test_complete_tab()
   call writefile(['testfile'], 'Xtestfile')
-  call feedkeys(":e Xtest\t\r", "tx")
+  call feedkeys(":e Xtestf\t\r", "tx")
   call assert_equal('testfile', getline(1))
   call delete('Xtestfile')
 endfunc
@@ -17,7 +17,7 @@ func Test_complete_wildmenu()
   call writefile(['testfile1'], 'Xtestfile1')
   call writefile(['testfile2'], 'Xtestfile2')
   set wildmenu
-  call feedkeys(":e Xtest\t\t\r", "tx")
+  call feedkeys(":e Xtestf\t\t\r", "tx")
   call assert_equal('testfile2', getline(1))
 
   call delete('Xtestfile1')


### PR DESCRIPTION
This doesn't actually work, if anyone can figure it out that would be appreciated.

(We already do this for functional and unit tests, but not `oldtest`)