### PR TITLE
buf_write(): wrong argument to os_fileinfo_hardlinks()

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3162,8 +3162,8 @@ nobackup:
 #ifdef UNIX
       FileInfo file_info;
 
-      /* Don't delete the file when it's a hard or symbolic link. */
-      if ((!newfile && os_fileinfo_hardlinks(&file_info) > 1)
+      // Don't delete the file when it's a hard or symbolic link.
+      if ((!newfile && os_fileinfo_hardlinks(&file_info_old) > 1)
           || (os_fileinfo_link((char *)fname, &file_info)
               && !os_fileinfo_id_equal(&file_info, &file_info_old))) {
         SET_ERRMSG(_("E166: Can't open linked file for writing"));
@@ -4547,6 +4547,7 @@ int put_time(FILE *fd, time_t time_)
 ///
 /// @return -1 for failure, 0 for success
 int vim_rename(const char_u *from, const char_u *to)
+  FUNC_ATTR_NONNULL_ALL
 {
   int fd_in;
   int fd_out;
@@ -4822,6 +4823,7 @@ buf_check_timestamp (
     buf_T *buf,
     int focus               /* called for GUI focus event */
 )
+  FUNC_ATTR_NONNULL_ALL
 {
   int retval = 0;
   char_u      *path;

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -131,6 +131,7 @@ bool os_isdir(const char_u *name)
 ///         NODE_WRITABLE: writable device, socket, fifo, etc.
 ///         NODE_OTHER: non-writable things
 int os_nodetype(const char *name)
+  FUNC_ATTR_NONNULL_ALL
 {
 #ifdef WIN32
   // Edge case from Vim os_win32.c:


### PR DESCRIPTION
This was broken in ye olde refactor from 2014:
e85fe0957d40080f43cbfcbe9eb8864475325b09

References #4370