### PR TITLE
log: Add log_callstack_to_file()

### DIFF
--- a/src/nvim/README.md
+++ b/src/nvim/README.md
@@ -11,8 +11,9 @@ Logs
 
 Low-level log messages sink to `$NVIM_LOG_FILE`.
 
-You can use `LOG_CALLSTACK()` anywhere in the source to log the current
-stacktrace. (Currently Linux-only.)
+You can use `LOG_CALLSTACK();` anywhere in the source to log the current
+stacktrace. To log in an alternate file, e.g. stderr, use
+`LOG_CALLSTACK_TO_FILE(FILE*)`. (Currently Linux-only.)
 
 UI events are logged at level 0 (`DEBUG_LOG_LEVEL`).
 

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -63,6 +63,7 @@
 
 #ifdef HAVE_EXECINFO_BACKTRACE
 # define LOG_CALLSTACK() log_callstack(__func__, __LINE__)
+# define LOG_CALLSTACK_TO_FILE(fp) log_callstack_to_file(fp, __func__, __LINE__)
 #endif
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS


### PR DESCRIPTION
This makes it trivial to log the callstack to, e.g., stderr, which can
simplify debug cycles.