### PR TITLE
coverity/166184: Check length of str, not term

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -45,7 +45,7 @@
 #define OUTBUF_SIZE 0xffff
 
 #define TOO_MANY_EVENTS 1000000
-#define STARTS_WITH(str, prefix) (strlen(term) >= (sizeof(prefix) - 1) \
+#define STARTS_WITH(str, prefix) (strlen(str) >= (sizeof(prefix) - 1) \
     && 0 == memcmp((str), (prefix), sizeof(prefix) - 1))
 #define TMUX_WRAP(is_tmux, seq) ((is_tmux) \
     ? "\x1bPtmux;\x1b" seq "\x1b\\" : seq)


### PR DESCRIPTION
32396b5879b429def1c48948069c55366d41b9be add length checks to
TERMINAL_FAMILY/STARTS_WITH to ensure memcmp() wouldn't read past the
end of the string.  However, "term" was copy/pasted from TERMINAL_FAMILY
so STARTS_WITH() was unnecessarily reading the, potentially NULL, term
variable.