### PR TITLE
[RDY] vim-patch:8.0.0186

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6747,6 +6747,8 @@ static void fill_assert_error(garray_T *gap, typval_T *opt_msg_tv,
   } else {
     if (atype == ASSERT_MATCH || atype == ASSERT_NOTMATCH) {
       ga_concat(gap, (char_u *)"Pattern ");
+    } else if (atype == ASSERT_NOTEQUAL) {
+      ga_concat(gap, (char_u *)"Expected not equal to ");
     } else {
       ga_concat(gap, (char_u *)"Expected ");
     }
@@ -6757,18 +6759,18 @@ static void fill_assert_error(garray_T *gap, typval_T *opt_msg_tv,
     } else {
       ga_concat(gap, exp_str);
     }
-    tofree = (char_u *)encode_tv2string(got_tv, NULL);
-    if (atype == ASSERT_MATCH) {
-      ga_concat(gap, (char_u *)" does not match ");
-    } else if (atype == ASSERT_NOTMATCH) {
-      ga_concat(gap, (char_u *)" does match ");
-    } else if (atype == ASSERT_NOTEQUAL) {
-      ga_concat(gap, (char_u *)" differs from ");
-    } else {
-      ga_concat(gap, (char_u *)" but got ");
+    if (atype != ASSERT_NOTEQUAL) {
+      if (atype == ASSERT_MATCH) {
+        ga_concat(gap, (char_u *)" does not match ");
+      } else if (atype == ASSERT_NOTMATCH) {
+        ga_concat(gap, (char_u *)" does match ");
+      } else {
+        ga_concat(gap, (char_u *)" but got ");
+      }
+      tofree = (char_u *)encode_tv2string(got_tv, NULL);
+      ga_concat(gap, tofree);
+      xfree(tofree);
     }
-    ga_concat(gap, tofree);
-    xfree(tofree);
   }
 }
 

--- a/src/nvim/testdir/test_assert.vim
+++ b/src/nvim/testdir/test_assert.vim
@@ -1,0 +1,12 @@
+" Test that the methods used for testing work.
+
+func Test_assert_notequal()
+  let n = 4
+  call assert_notequal('foo', n)
+  let s = 'foo'
+  call assert_notequal([1, 2, 3], s)
+
+  call assert_notequal('foo', s)
+  call assert_match("Expected not equal to 'foo'", v:errors[0])
+  call remove(v:errors, 0)
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -766,7 +766,7 @@ static const int included_patches[] = {
   // 189,
   // 188,
   // 187 NA
-  // 186,
+  186,
   // 185,
   // 184,
   // 183,

--- a/test/functional/legacy/assert_spec.lua
+++ b/test/functional/legacy/assert_spec.lua
@@ -89,7 +89,7 @@ describe('assert function:', function()
 
     it('should change v:errors when expected is equal to actual', function()
       call('assert_notequal', 'foo', 'foo')
-      expected_errors({"Expected 'foo' differs from 'foo'"})
+      expected_errors({"Expected not equal to 'foo'"})
     end)
   end)
 


### PR DESCRIPTION
Problem:    The error message from assert_notequal() is confusing.
Solution:   Only mention the expected value.

https://github.com/vim/vim/commit/5869cf060e60cc09e71b2b3bd85f0576ec78f9f5