### PR TITLE
[RFC] 'nostartofline': preserve window viewport also

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1916,7 +1916,9 @@ void win_set_viewport(win_T *win, wininfo_T *wip)
   if (wip == NULL || wip->wi_topline == 0) {
     return;
   }
-  set_topline(win, wip->wi_topline);
+  // slow
+  // set_topline(win, wip->wi_topline);
+  win->w_topline = wip->wi_topline;
   win->w_topfill = wip->wi_topfill;
   win->w_leftcol = wip->wi_leftcol;
   win->w_skipcol = wip->wi_skipcol;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2439,18 +2439,7 @@ pos_T *buflist_findfpos(buf_T *buf)
 
 wininfo_T *buflist_find_wininfo(buf_T *buf)
 {
-  static wininfo_T no_wininfo = {
-    .wi_next = NULL,
-    .wi_prev = NULL,
-    .wi_win = NULL,
-    .wi_fpos = INIT_POS_T(1, 0, 0),
-    // .wi_topline = 0,
-    // .wi_topfill = 0,
-    // .wi_leftcol = 0,
-    // .wi_skipcol = 0,
-
-  };
-
+  static wininfo_T no_wininfo = INIT_WININFO_T;
   wininfo_T *wip = find_wininfo(buf, FALSE);
   return (wip == NULL) ? &no_wininfo : wip;
 }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1916,9 +1916,7 @@ void win_set_viewport(win_T *win, wininfo_T *wip)
   if (wip == NULL || wip->wi_topline == 0) {
     return;
   }
-  // slow
-  // set_topline(win, wip->wi_topline);
-  win->w_topline = wip->wi_topline;
+  set_topline(win, wip->wi_topline);
   win->w_topfill = wip->wi_topfill;
   win->w_leftcol = wip->wi_leftcol;
   win->w_skipcol = wip->wi_skipcol;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -265,6 +265,20 @@ struct wininfo_S {
   bool wi_fold_manual;          ///< copy of w_fold_manual
   garray_T wi_folds;            ///< clone of w_folds
 };
+#define INIT_WININFO_T { \
+  .wi_next = NULL, \
+  .wi_prev = NULL, \
+  .wi_win = NULL, \
+  .wi_fpos = INIT_POS_T(1, 0, 0), \
+  .wi_topline = 0, \
+  .wi_topfill = 0, \
+  .wi_leftcol = 0, \
+  .wi_skipcol = 0, \
+  .wi_optset = false, \
+  .wi_opt = { 0 }, \
+  .wi_fold_manual = false, \
+  .wi_folds = { 0 }, \
+  }
 
 /*
  * Argument list: Array of file names.

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -265,20 +265,6 @@ struct wininfo_S {
   bool wi_fold_manual;          ///< copy of w_fold_manual
   garray_T wi_folds;            ///< clone of w_folds
 };
-#define INIT_WININFO_T { \
-  .wi_next = NULL, \
-  .wi_prev = NULL, \
-  .wi_win = NULL, \
-  .wi_fpos = INIT_POS_T(1, 0, 0), \
-  .wi_topline = 0, \
-  .wi_topfill = 0, \
-  .wi_leftcol = 0, \
-  .wi_skipcol = 0, \
-  .wi_optset = false, \
-  .wi_opt = { 0 }, \
-  .wi_fold_manual = false, \
-  .wi_folds = { 0 }, \
-  }
 
 /*
  * Argument list: Array of file names.

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -241,25 +241,29 @@ typedef struct {
 # define w_p_scriptID w_onebuf_opt.wo_scriptID
 } winopt_T;
 
-/*
- * Window info stored with a buffer.
- *
- * Two types of info are kept for a buffer which are associated with a
- * specific window:
- * 1. Each window can have a different line number associated with a buffer.
- * 2. The window-local options for a buffer work in a similar way.
- * The window-info is kept in a list at b_wininfo.  It is kept in
- * most-recently-used order.
- */
+/// Window-specific info stored with a buffer.
+///
+/// Types of info kept:
+/// 1. Viewport info (like winsaveview(): current line, topline, ...)
+/// 2. The window-local options for a buffer work in a similar way.
+///
+/// The window-info is kept in a `b_wininfo` linked list in MRU order.
 struct wininfo_S {
-  wininfo_T   *wi_next;         /* next entry or NULL for last entry */
-  wininfo_T   *wi_prev;         /* previous entry or NULL for first entry */
-  win_T       *wi_win;          /* pointer to window that did set wi_fpos */
-  pos_T wi_fpos;                /* last cursor position in the file */
-  bool wi_optset;               /* true when wi_opt has useful values */
-  winopt_T wi_opt;              /* local window options */
-  bool wi_fold_manual;          /* copy of w_fold_manual */
-  garray_T wi_folds;            /* clone of w_folds */
+  wininfo_T   *wi_next;         ///< next entry or NULL for last entry
+  wininfo_T   *wi_prev;         ///< previous entry or NULL for first entry
+  win_T       *wi_win;          ///< pointer to window that did set wi_fpos
+
+  // viewport info
+  pos_T wi_fpos;                ///< last cursor position in the file
+  linenr_T wi_topline;          ///< last w_topline
+  int wi_topfill;               ///< last w_topfill
+  colnr_T wi_leftcol;           ///< last w_leftcol
+  colnr_T wi_skipcol;           ///< last w_skipcol
+
+  bool wi_optset;               ///< true when wi_opt has useful values
+  winopt_T wi_opt;              ///< local window options
+  bool wi_fold_manual;          ///< copy of w_fold_manual
+  garray_T wi_folds;            ///< clone of w_folds
 };
 
 /*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17449,6 +17449,7 @@ static void f_winrestview(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     wininfo_T wi = INIT_WININFO_T;
     if ((di = tv_dict_find(dict, S_LEN("topline"))) != NULL) {
       wi.wi_topline = tv_get_number(&di->di_tv);
+      set_topline(curwin, wi.wi_topline);
     }
     if ((di = tv_dict_find(dict, S_LEN("topfill"))) != NULL) {
       wi.wi_topfill = tv_get_number(&di->di_tv);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17446,9 +17446,10 @@ static void f_winrestview(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       curwin->w_set_curswant = false;
     }
 
-    wininfo_T wi = INIT_WININFO_T;
+    wininfo_T wi;
     if ((di = tv_dict_find(dict, S_LEN("topline"))) != NULL) {
       wi.wi_topline = tv_get_number(&di->di_tv);
+      set_topline(curwin, wi.wi_topline);
     }
     if ((di = tv_dict_find(dict, S_LEN("topfill"))) != NULL) {
       wi.wi_topfill = tv_get_number(&di->di_tv);
@@ -17460,7 +17461,10 @@ static void f_winrestview(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       wi.wi_skipcol= tv_get_number(&di->di_tv);
     }
 
-    win_set_viewport(curwin, &wi);
+    win_new_height(curwin, curwin->w_height);
+    win_new_width(curwin, curwin->w_width);
+    win_set_viewport(&wi);
+    changed_window_setting();
   }
 }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17449,7 +17449,6 @@ static void f_winrestview(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     wininfo_T wi = INIT_WININFO_T;
     if ((di = tv_dict_find(dict, S_LEN("topline"))) != NULL) {
       wi.wi_topline = tv_get_number(&di->di_tv);
-      set_topline(curwin, wi.wi_topline);
     }
     if ((di = tv_dict_find(dict, S_LEN("topfill"))) != NULL) {
       wi.wi_topfill = tv_get_number(&di->di_tv);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17446,21 +17446,21 @@ static void f_winrestview(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       curwin->w_set_curswant = false;
     }
 
-    wininfo_T wip = { 0 };
+    wininfo_T wi = INIT_WININFO_T;
     if ((di = tv_dict_find(dict, S_LEN("topline"))) != NULL) {
-      wip.wi_topline = tv_get_number(&di->di_tv);
+      wi.wi_topline = tv_get_number(&di->di_tv);
     }
     if ((di = tv_dict_find(dict, S_LEN("topfill"))) != NULL) {
-      wip.wi_topfill = tv_get_number(&di->di_tv);
+      wi.wi_topfill = tv_get_number(&di->di_tv);
     }
     if ((di = tv_dict_find(dict, S_LEN("leftcol"))) != NULL) {
-      wip.wi_leftcol= tv_get_number(&di->di_tv);
+      wi.wi_leftcol= tv_get_number(&di->di_tv);
     }
     if ((di = tv_dict_find(dict, S_LEN("skipcol"))) != NULL) {
-      wip.wi_skipcol= tv_get_number(&di->di_tv);
+      wi.wi_skipcol= tv_get_number(&di->di_tv);
     }
 
-    win_set_viewport(curwin, &wip);
+    win_set_viewport(curwin, &wi);
   }
 }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17445,29 +17445,22 @@ static void f_winrestview(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       curwin->w_curswant = tv_get_number(&di->di_tv);
       curwin->w_set_curswant = false;
     }
+
+    wininfo_T wip = { 0 };
     if ((di = tv_dict_find(dict, S_LEN("topline"))) != NULL) {
-      set_topline(curwin, tv_get_number(&di->di_tv));
+      wip.wi_topline = tv_get_number(&di->di_tv);
     }
     if ((di = tv_dict_find(dict, S_LEN("topfill"))) != NULL) {
-      curwin->w_topfill = tv_get_number(&di->di_tv);
+      wip.wi_topfill = tv_get_number(&di->di_tv);
     }
     if ((di = tv_dict_find(dict, S_LEN("leftcol"))) != NULL) {
-      curwin->w_leftcol = tv_get_number(&di->di_tv);
+      wip.wi_leftcol= tv_get_number(&di->di_tv);
     }
     if ((di = tv_dict_find(dict, S_LEN("skipcol"))) != NULL) {
-      curwin->w_skipcol = tv_get_number(&di->di_tv);
+      wip.wi_skipcol= tv_get_number(&di->di_tv);
     }
 
-    check_cursor();
-    win_new_height(curwin, curwin->w_height);
-    win_new_width(curwin, curwin->w_width);
-    changed_window_setting();
-
-    if (curwin->w_topline <= 0)
-      curwin->w_topline = 1;
-    if (curwin->w_topline > curbuf->b_ml.ml_line_count)
-      curwin->w_topline = curbuf->b_ml.ml_line_count;
-    check_topfill(curwin, true);
+    win_set_viewport(curwin, &wip);
   }
 }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2548,7 +2548,7 @@ int do_ecmd(
         check_cursor_col();
         curwin->w_cursor.coladd = 0;
         curwin->w_set_curswant = TRUE;
-        win_set_viewport(curwin, wip);
+        win_set_viewport(wip);
       } else
         beginline(BL_SOL | BL_FIX);
     } else {                  /* no line number, go to last line in Ex mode */

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2096,7 +2096,7 @@ int do_ecmd(
   linenr_T topline = 0;
   int newcol = -1;
   int solcol = -1;
-  pos_T       *pos;
+  wininfo_T *wip = NULL;  // viewport info
   char_u      *command = NULL;
   int did_get_winopts = FALSE;
   int readfile_flags = 0;
@@ -2244,7 +2244,8 @@ int do_ecmd(
     /* May jump to last used line number for a loaded buffer or when asked
      * for explicitly */
     if ((oldbuf && newlnum == ECMD_LASTL) || newlnum == ECMD_LAST) {
-      pos = buflist_findfpos(buf);
+      pos_T *pos = buflist_findfpos(buf);
+      wip = buflist_find_wininfo(buf);
       newlnum = pos->lnum;
       solcol = pos->col;
     }
@@ -2542,11 +2543,12 @@ int do_ecmd(
       curwin->w_cursor.lnum = newlnum;
       check_cursor_lnum();
       if (solcol >= 0 && !p_sol) {
-        /* 'sol' is off: Use last known column. */
+        // 'sol' is off: Use last known column.
         curwin->w_cursor.col = solcol;
         check_cursor_col();
         curwin->w_cursor.coladd = 0;
         curwin->w_set_curswant = TRUE;
+        win_set_viewport(curwin, wip);
       } else
         beginline(BL_SOL | BL_FIX);
     } else {                  /* no line number, go to last line in Ex mode */


### PR DESCRIPTION
When 'startofline' is disabled (`:set nostartofline`), restore the window view when re-visiting a buffer.

The old behavior drives me crazy. When I use `<C-^>`, `:bnext`, `:bprevious`, etc., I don't want the damn viewport to be reset (cursor placed in middle of window). 

todo

- [ ] tests
- [ ] should it be a new option? Or different approach: expose a new event which allows user to do `win{save,rest}view()` at the correct time?
- [ ] move/rename `win_set_viewport()`