### PR TITLE
ci/win: list build permutations explicitly

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,14 +2,7 @@ version: '{build}'
 configuration:
 - MINGW_64
 - MINGW_32
-environment:
-  matrix:
-    - USE_GCOV: ON
-    - USE_GCOV: OFF
-matrix:
-  exclude:
-    - configuration: MINGW_32
-      USE_GCOV: ON
+- MINGW_64-gcov
 install: []
 build_script:
 - call ci\build.bat

--- a/ci/build.bat
+++ b/ci/build.bat
@@ -9,6 +9,10 @@ if "%CONFIGURATION%" == "MINGW_32" (
   set ARCH=x86_64
   set BITS=64
 )
+if "%CONFIGURATION%" == "MINGW_64-gcov" (
+  set USE_GCOV="-DUSE_GCOV=ON"
+)
+
 :: We cannot have sh.exe in the PATH (MinGW)
 set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
 set PATH=C:\msys64\mingw%BITS%\bin;C:\Windows\System32;C:\Windows;%PATH%
@@ -38,14 +42,14 @@ cd ..
 :: Build Neovim
 mkdir build
 cd build
-cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUSTED_OUTPUT_TYPE=nvim -DUSE_GCOV="%USE_GCOV%" -DGPERF_PRG="C:\msys64\usr\bin\gperf.exe" .. || goto :error
+cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUSTED_OUTPUT_TYPE=nvim %USE_GCOV% -DGPERF_PRG="C:\msys64\usr\bin\gperf.exe" .. || goto :error
 mingw32-make VERBOSE=1 || goto :error
 bin\nvim --version || goto :error
 
 :: Functional tests
 mingw32-make functionaltest VERBOSE=1 || goto :error
 
-if "%USE_GCOV%" == "ON" (
+if defined USE_GCOV (
   C:\msys64\usr\bin\bash -lc "cd /c/projects/neovim; bash <(curl -s https://codecov.io/bash) || echo 'codecov upload failed.'"
 )
 


### PR DESCRIPTION
This avoids changing the matrix permutations for the old non-gcov
builds, so that old URLs continue to work:

https://ci.appveyor.com/api/projects/neovim/neovim/artifacts/build/Neovim.zip?branch=master&job=Configuration%3A%20MINGW_32
https://ci.appveyor.com/api/projects/neovim/neovim/artifacts/build/Neovim.zip?branch=master&job=Configuration%3A%20MINGW_64