### PR TITLE
Update Ruby documentation to use puts instead of print

### DIFF
--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -17,7 +17,7 @@ downloading Ruby there.
 
 							*:ruby* *:rub*
 :rub[y] {cmd}		Execute Ruby command {cmd}.  A command to try it out: >
-				:ruby print "Hello"
+				:ruby puts "Hello"
 
 :rub[y] << {endpattern}
 {script}
@@ -50,7 +50,7 @@ Example Vim script: >
 	endfunction
 <
 To see what version of Ruby you have: >
-	:ruby print RUBY_VERSION
+	:ruby puts RUBY_VERSION
 <
 
 						*:rubydo* *:rubyd* *E265*


### PR DESCRIPTION
I came across a functional difference between neovim and vim. The help documentation for Ruby says you can check the Ruby version by running `:ruby print RUBY_VERSION`. In vim, this causes the Ruby version to be printed to the command area. In neovim, the Ruby version is not shown. Using `:ruby puts RUBY_VERSION` will cause the version to show up.

I wasn't sure if it would be preferred to fix the underlying functionality of `:ruby print` or to update the documentation as I did here.