### PR TITLE
win: locale independent argv

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -10,6 +10,11 @@ if(USE_GCOV)
 endif()
 endif()
 
+if(WIN32)
+  # tell MinGW compiler to enable wmain
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -municode")
+endif()
+
 set(TOUCHES_DIR ${PROJECT_BINARY_DIR}/touches)
 set(GENERATOR_DIR ${CMAKE_CURRENT_LIST_DIR}/generators)
 set(GENERATED_DIR ${PROJECT_BINARY_DIR}/src/nvim/auto)


### PR DESCRIPTION
fix #7060

What should I do when `malloc()` fails? (https://github.com/neovim/neovim/commit/8926d6c684c5afc66a9d842effb544d810356e09#diff-21cf87db76bbcab0a3b5054f99b4ef85R245)