### PR TITLE
[RFC] vim-patch:8.0.0092

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -860,7 +860,7 @@ static const int included_patches[] = {
   // 95 NA
   // 94 NA
   // 93 NA
-  // 92,
+  92,
   // 91,
   90,
   // 89 NA

--- a/test/functional/legacy/003_cindent_spec.lua
+++ b/test/functional/legacy/003_cindent_spec.lua
@@ -3915,6 +3915,26 @@ describe('cindent', function()
       {
         111111111111111111;
       }
+      namespace test::cpp17
+      {
+        111111111111111111;
+      }
+      namespace ::incorrectcpp17
+      {
+        111111111111111111;
+      }
+      namespace test::incorrectcpp17::
+      {
+        111111111111111111;
+      }
+      namespace test:incorrectcpp17
+      {
+        111111111111111111;
+      }
+      namespace test:::incorrectcpp17
+      {
+        111111111111111111;
+      }
       namespace{
         111111111111111111;
       }
@@ -3985,6 +4005,26 @@ describe('cindent', function()
       namespace test
       {
       111111111111111111;
+      }
+      namespace test::cpp17
+      {
+      111111111111111111;
+      }
+      namespace ::incorrectcpp17
+      {
+      	111111111111111111;
+      }
+      namespace test::incorrectcpp17::
+      {
+      	111111111111111111;
+      }
+      namespace test:incorrectcpp17
+      {
+      	111111111111111111;
+      }
+      namespace test:::incorrectcpp17
+      {
+      	111111111111111111;
       }
       namespace{
       111111111111111111;


### PR DESCRIPTION
Problem:    C indenting does not support nested namespaces that C++ 17 has.
Solution:   Add check that passes double colon inside a name. (Pauli, closes
            vim/vim#1214)

https://github.com/vim/vim/commit/ca8b8d6956dd881de6446fc32c38e817a364a6cc