### PR TITLE
clipboard: avoid pathology during :redir

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -90,7 +90,7 @@ endfunction
 
 " Changes ':h clipboard' to ':help |clipboard|'.
 function! s:help_to_link(s) abort
-  return substitute(a:s, '\v:h%[elp] ([^|][^"\r\n]+)', ':help |\1|', 'g')
+  return substitute(a:s, '\v:h%[elp] ([^|][^"\r\n ]+)', ':help |\1|', 'g')
 endfunction
 
 " Format a message for a specific report item

--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -121,14 +121,14 @@ function! s:check_clipboard() abort
   call health#report_start('Clipboard (optional)')
 
   let clipboard_tool = provider#clipboard#Executable()
-  if empty(clipboard_tool)
-    call health#report_warn(
-          \ 'No clipboard tool found. Clipboard registers will not work.',
-          \ [':help clipboard'])
-  elseif exists('g:clipboard') && (type({}) != type(g:clipboard)
-        \ || !has_key(g:clipboard, 'copy') || !has_key(g:clipboard, 'paste'))
+  if exists('g:clipboard') && empty(clipboard_tool)
     call health#report_error(
-          \ 'g:clipboard exists but is malformed. It must be a dictionary with the keys documented at :help g:clipboard')
+          \ provider#clipboard#Error(),
+          \ ["Use the example in :help g:clipboard as a template, or don't set g:clipboard at all."])
+  elseif empty(clipboard_tool)
+    call health#report_warn(
+          \ 'No clipboard tool found. Clipboard registers (`"+` and `"*`) will not work.',
+          \ [':help clipboard'])
   else
     call health#report_ok('Clipboard tool found: '. clipboard_tool)
   endif

--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -3,6 +3,7 @@
 " available.
 let s:copy = {}
 let s:paste = {}
+let s:clipboard = {}
 
 " When caching is enabled, store the jobid of the xclip/xsel process keeping
 " ownership of the selection, so we know how long the cache is valid.
@@ -23,7 +24,7 @@ function! s:selection.on_exit(jobid, data, event) abort
   call provider#clear_stderr(a:jobid)
 endfunction
 
-let s:selections = { '*': s:selection, '+': copy(s:selection)}
+let s:selections = { '*': s:selection, '+': copy(s:selection) }
 
 function! s:try_cmd(cmd, ...) abort
   let argv = split(a:cmd, " ")
@@ -55,6 +56,12 @@ endfunction
 
 function! provider#clipboard#Executable() abort
   if exists('g:clipboard')
+    if type({}) isnot# type(g:clipboard)
+          \ || type({}) isnot# get(g:clipboard, 'copy', v:null)
+          \ || type({}) isnot# get(g:clipboard, 'paste', v:null)
+      let s:err = 'clipboard: invalid g:clipboard'
+      return ''
+    endif
     let s:copy = get(g:clipboard, 'copy', { '+': v:null, '*': v:null })
     let s:paste = get(g:clipboard, 'paste', { '+': v:null, '*': v:null })
     let s:cache_enabled = get(g:clipboard, 'cache_enabled', 1)
@@ -104,15 +111,16 @@ function! provider#clipboard#Executable() abort
     return 'tmux'
   endif
 
-  let s:err = 'clipboard: No clipboard tool available. :help clipboard'
+  let s:err = 'clipboard: No clipboard tool. :help clipboard'
   return ''
 endfunction
 
 if empty(provider#clipboard#Executable())
+  " provider#clipboard#Call() *must not* be defined if the provider is broken.
+  " Otherwise eval_has_provider() thinks the clipboard provider is
+  " functioning, and eval_call_provider() will happily call it.
   finish
 endif
-
-let s:clipboard = {}
 
 function! s:clipboard.get(reg) abort
   if s:selections[a:reg].owner > 0
@@ -154,7 +162,9 @@ function! s:clipboard.set(lines, regtype, reg) abort
     echohl WarningMsg
     echomsg 'clipboard: failed to execute: '.(s:copy[a:reg])
     echohl None
+    return 0
   endif
+  return 1
 endfunction
 
 function! provider#clipboard#Call(method, args) abort

--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -57,14 +57,14 @@ endfunction
 function! provider#clipboard#Executable() abort
   if exists('g:clipboard')
     if type({}) isnot# type(g:clipboard)
-          \ || type({}) isnot# get(g:clipboard, 'copy', v:null)
-          \ || type({}) isnot# get(g:clipboard, 'paste', v:null)
+          \ || type({}) isnot# type(get(g:clipboard, 'copy', v:null))
+          \ || type({}) isnot# type(get(g:clipboard, 'paste', v:null))
       let s:err = 'clipboard: invalid g:clipboard'
       return ''
     endif
     let s:copy = get(g:clipboard, 'copy', { '+': v:null, '*': v:null })
     let s:paste = get(g:clipboard, 'paste', { '+': v:null, '*': v:null })
-    let s:cache_enabled = get(g:clipboard, 'cache_enabled', 1)
+    let s:cache_enabled = get(g:clipboard, 'cache_enabled', 0)
     return get(g:clipboard, 'name', 'g:clipboard')
   elseif has('mac') && executable('pbcopy')
     let s:copy['+'] = 'pbcopy'

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -22775,7 +22775,7 @@ typval_T eval_call_provider(char *provider, char *method, list_T *arguments)
 
 bool eval_has_provider(const char *name)
 {
-#define check_provider(name) \
+#define CHECK_PROVIDER(name) \
   if (has_##name == -1) { \
     has_##name = !!find_func((char_u *)"provider#" #name "#Call"); \
     if (!has_##name) { \
@@ -22791,17 +22791,17 @@ bool eval_has_provider(const char *name)
   static int has_python3 = -1;
   static int has_ruby = -1;
 
-  if (!strcmp(name, "clipboard")) {
-    check_provider(clipboard);
+  if (strequal(name, "clipboard")) {
+    CHECK_PROVIDER(clipboard);
     return has_clipboard;
-  } else if (!strcmp(name, "python3")) {
-    check_provider(python3);
+  } else if (strequal(name, "python3")) {
+    CHECK_PROVIDER(python3);
     return has_python3;
-  } else if (!strcmp(name, "python")) {
-    check_provider(python);
+  } else if (strequal(name, "python")) {
+    CHECK_PROVIDER(python);
     return has_python;
-  } else if (!strcmp(name, "ruby")) {
-    check_provider(ruby);
+  } else if (strequal(name, "ruby")) {
+    CHECK_PROVIDER(ruby);
     return has_ruby;
   }
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2519,6 +2519,7 @@ static void redir_write(const char *const str, const ptrdiff_t maxlen)
   if (redirecting()) {
     /* If the string doesn't start with CR or NL, go to msg_col */
     if (*s != '\n' && *s != '\r') {
+      start_batch_changes();
       while (cur_col < msg_col) {
         if (capture_ga) {
           ga_concat_len(capture_ga, " ", 1);
@@ -2535,6 +2536,7 @@ static void redir_write(const char *const str, const ptrdiff_t maxlen)
         }
         cur_col++;
       }
+      end_batch_changes();
     }
 
     size_t len = maxlen == -1 ? STRLEN(s) : (size_t)maxlen;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2519,7 +2519,6 @@ static void redir_write(const char *const str, const ptrdiff_t maxlen)
   if (redirecting()) {
     /* If the string doesn't start with CR or NL, go to msg_col */
     if (*s != '\n' && *s != '\r') {
-      start_batch_changes();
       while (cur_col < msg_col) {
         if (capture_ga) {
           ga_concat_len(capture_ga, " ", 1);
@@ -2536,7 +2535,6 @@ static void redir_write(const char *const str, const ptrdiff_t maxlen)
         }
         cur_col++;
       }
-      end_batch_changes();
     }
 
     size_t len = maxlen == -1 ? STRLEN(s) : (size_t)maxlen;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5558,7 +5558,7 @@ static yankreg_T *adjust_clipboard_name(int *name, bool quiet, bool writing)
       msg((char_u *)MSG_NO_CLIP);
       clipboard_didwarn_unnamed = true;
     }
-    // ... else, be silent (avoid a flood of messages).
+    // ... else, be silent (don't flood during :while, :redir, etc.).
     goto end;
   }
 
@@ -5567,10 +5567,12 @@ static yankreg_T *adjust_clipboard_name(int *name, bool quiet, bool writing)
     goto end;
   } else {  // unnamed register: "implicit" clipboard
     if (writing && clipboard_delay_update) {
+      // For "set" (copy), defer the clipboard call.
       clipboard_needs_update = true;
       goto end;
     } else if (!writing && clipboard_needs_update) {
-      goto end;  // use the internal value
+      // For "get" (paste), use the internal value.
+      goto end;
     }
 
     if (cb_flags & CB_UNNAMEDPLUS) {
@@ -5772,6 +5774,7 @@ void end_batch_changes(void)
   }
   clipboard_delay_update = false;
   if (clipboard_needs_update) {
+    // unnamed ("implicit" clipboard)
     set_clipboard(NUL, y_previous);
     clipboard_needs_update = false;
   }

--- a/test/functional/fixtures/autoload/provider/clipboard.vim
+++ b/test/functional/fixtures/autoload/provider/clipboard.vim
@@ -5,7 +5,13 @@ let s:methods = {}
 let g:cliplossy = 0
 let g:cliperror = 0
 
+" Count how many times the clipboard was invoked.
+let g:clip_called_get = 0
+let g:clip_called_set = 0
+
 function! s:methods.get(reg)
+  let g:clip_called_get += 1
+
   if g:cliperror
     return 0
   end
@@ -19,6 +25,8 @@ function! s:methods.get(reg)
 endfunction
 
 function! s:methods.set(lines, regtype, reg)
+  let g:clip_called_set += 1
+
   if a:reg == '"'
     call s:methods.set(a:lines,a:regtype,'+')
     call s:methods.set(a:lines,a:regtype,'*')


### PR DESCRIPTION
This was quite an adventure.

redir_write():
- ~~This is a "batch" operation which was not yet covered by
  start_batch_changes()~~ This was irrelevant; the problem actually is that `:redir @+>` is an explicit register (as opposed to "implicit" clipboard target with `clipboard=unnamed[plus]`). We can't go around second-guessing explicit register writes, so there is little we can do to avoid invoking the clipboard provider once-per-line during `:redir @+>`.

adjust_clipboard_name():
- msg() and friends during :redir will, of course, cause redir_write()
  to try to capture that message, which causes recursion.
- EMSG() here is trouble: if it interrupts :redir it is a mess.
  Rather than deal with the mess, show a non-error message.

Closes #7182
Closes #7184
ref #6048