### PR TITLE
clipboard: disallow recursion; show hint only once

### DIFF
--- a/runtime/autoload/provider.vim
+++ b/runtime/autoload/provider.vim
@@ -10,7 +10,9 @@ function! provider#stderr_collector(chan_id, data, event) dict
 endfunction
 
 function! provider#clear_stderr(chan_id)
-   silent! call remove(s:stderr, a:chan_id)
+  if has_key(s:stderr, a:chan_id)
+    call remove(s:stderr, a:chan_id)
+  endif
 endfunction
 
 function! provider#get_stderr(chan_id)

--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -32,7 +32,7 @@ function! s:try_cmd(cmd, ...) abort
   if v:shell_error
     if !exists('s:did_error_try_cmd')
       echohl WarningMsg
-      echomsg "clipboard: error: ".(len(out) ? out[0] : '')
+      echomsg "clipboard: error: ".(len(out) ? out[0] : v:shell_error)
       echohl None
       let s:did_error_try_cmd = 1
     endif
@@ -168,5 +168,13 @@ function! s:clipboard.set(lines, regtype, reg) abort
 endfunction
 
 function! provider#clipboard#Call(method, args) abort
-  return call(s:clipboard[a:method],a:args,s:clipboard)
+  if get(s:, 'here', v:false)  " Clipboard provider must not recurse. #7184
+    return 0
+  endif
+  let s:here = v:true
+  try
+    return call(s:clipboard[a:method],a:args,s:clipboard)
+  finally
+    let s:here = v:false
+  endtry
 endfunction


### PR DESCRIPTION
- Show hint only once per session.
- provider#clipboard#Call(): prevent recursion
- provider#clear_stderr(): use has_key(), because :silent! is still
  captured by :redir.

closes #7184