### PR TITLE
[RFC] api/window.c: use w_virtcol in nvim_win_get_cursor

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -46,7 +46,7 @@ ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, Error *err)
 
   if (win) {
     ADD(rv, INTEGER_OBJ(win->w_cursor.lnum));
-    ADD(rv, INTEGER_OBJ(win->w_cursor.col));
+    ADD(rv, INTEGER_OBJ(win->w_virtcol));
   }
 
   return rv;


### PR DESCRIPTION
w_cursor.col is counted by bytes. That's a problem when line contains
unicode chars - col number is wrong. Using w_virtcol fixes this issue.