### PR TITLE
tui: support new 'iterm2'/'iTerm2.app' terminfo entries

### DIFF
--- a/src/nvim/tui/terminfo.c
+++ b/src/nvim/tui/terminfo.c
@@ -104,7 +104,9 @@ unibi_term *load_builtin_terminfo(const char * term)
     return unibi_from_mem((const char *)interix_8colour_terminfo,
                           sizeof interix_8colour_terminfo);
   } else if (terminfo_is_term_family(term, "iterm")
-             || terminfo_is_term_family(term, "iTerm.app")) {
+             || terminfo_is_term_family(term, "iterm2")
+             || terminfo_is_term_family(term, "iTerm.app")
+             || terminfo_is_term_family(term, "iTerm2.app")) {
     return unibi_from_mem((const char *)iterm_256colour_terminfo,
                           sizeof iterm_256colour_terminfo);
   } else if (terminfo_is_term_family(term, "st")) {

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1263,7 +1263,9 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
   bool gnome = terminfo_is_term_family(term, "gnome")
     || terminfo_is_term_family(term, "vte");
   bool iterm = terminfo_is_term_family(term, "iterm")
-    || terminfo_is_term_family(term, "iTerm.app");
+    || terminfo_is_term_family(term, "iterm2")
+    || terminfo_is_term_family(term, "iTerm.app")
+    || terminfo_is_term_family(term, "iTerm2.app");
   // None of the following work over SSH; see :help TERM .
   bool iterm_pretending_xterm = xterm && iterm_env;
   bool konsole_pretending_xterm = xterm && konsole;
@@ -1535,7 +1537,9 @@ static void augment_terminfo(TUIData *data, const char *term,
   bool screen = terminfo_is_term_family(term, "screen");
   bool tmux = terminfo_is_term_family(term, "tmux") || !!os_getenv("TMUX");
   bool iterm = terminfo_is_term_family(term, "iterm")
-    || terminfo_is_term_family(term, "iTerm.app");
+    || terminfo_is_term_family(term, "iterm2")
+    || terminfo_is_term_family(term, "iTerm.app")
+    || terminfo_is_term_family(term, "iTerm2.app");
   // None of the following work over SSH; see :help TERM .
   bool iterm_pretending_xterm = xterm && iterm_env;
 


### PR DESCRIPTION
iTerm2 got its own entry in Thomas Dickey's terminfo.src on 2017-08-16.
Make sure that the new entry is handled in the same way as the old entry.

Fixes https://github.com/neovim/neovim/issues/7209