### PR TITLE
ci: more permissive about termclose_spec timer

### DIFF
--- a/test/functional/autocmd/termclose_spec.lua
+++ b/test/functional/autocmd/termclose_spec.lua
@@ -57,7 +57,9 @@ describe('TermClose event', function()
     command('call jobstop(g:test_job)')
     retry(nil, nil, function() eq(1, eval('get(g:, "test_job_exited", 0)')) end)
     local duration = os.time() - start
-    eq(4, duration)
+    -- nvim starts sending kill after 2*KILL_TIMEOUT_MS
+    helpers.ok(4 <= duration)
+    helpers.ok(duration <= 7)  -- <= 4 + delta because of slow CI
   end)
 
   it('reports the correct <abuf>', function()


### PR DESCRIPTION
the ci being slow, testing the duration of 4 seconds is flaky.