### PR TITLE
provider: Remove dict attribute from stderr_collector

### DIFF
--- a/runtime/autoload/provider.vim
+++ b/runtime/autoload/provider.vim
@@ -2,7 +2,7 @@
 
 let s:stderr = {}
 
-function! provider#stderr_collector(chan_id, data, event) dict
+function! provider#stderr_collector(chan_id, data, event)
    let stderr = get(s:stderr, a:chan_id, [''])
    let stderr[-1] .= a:data[0]
    call extend(stderr, a:data[1:])


### PR DESCRIPTION
If an autoloaded function hasn't been resolved before it is used in
function(), the self dict will not be created which causes E725 when
calling the function.  Since self isn't being used in
provider#stderr_collector, we can remove the dict attribute to
workaround the self dict bug[0].

Closes #7115

[0]: https://groups.google.com/d/msg/vim_dev/I7AXOyv-P4o/DzbyOxDHBgAJ