### PR TITLE
[RDY] Inccomand: Fix the performance improvement

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3333,12 +3333,8 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout)
 
   // Check for a match on each line.
   linenr_T line2 = eap->line2;
-  // Condition: If preview, then go on if one of the following holds:
-  // * EITHER we don't yet have enough matches for the preview window
-  //    matched_lines.size < (size_t)p_cwh
-  // * OR we're not yet done looking through the lines shown in the
-  //   curren window
-  //     lnum <= curwin->w_botline
+  // Last condition: If preview, go on if we don't have enough matches
+  // for the preview window or we did not yet check all lines shown
   for (linenr_T lnum = eap->line1;
        lnum <= line2 && !got_quit && !aborting()
        && (!preview || matched_lines.size < (size_t)p_cwh

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3340,7 +3340,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout)
   //   curren window
   //     lnum <= curwin->w_botline
   for (linenr_T lnum = eap->line1;
-       lnum <= line2 && !(got_quit || aborting())
+       lnum <= line2 && !got_quit && !aborting()
        && (!preview || matched_lines.size < (size_t)p_cwh
            || lnum <= curwin->w_botline);
        lnum++) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3333,9 +3333,16 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout)
 
   // Check for a match on each line.
   linenr_T line2 = eap->line2;
+  // Condition: If preview, then go on if one of the following holds:
+  // * EITHER we don't yet have enough matches for the preview window
+  //    matched_lines.size < (size_t)p_cwh
+  // * OR we're not yet done looking through the lines shown in the
+  //   curren window
+  //     lnum <= curwin->w_botline
   for (linenr_T lnum = eap->line1;
        lnum <= line2 && !(got_quit || aborting())
-       && (!preview || matched_lines.size <= (size_t)p_cwh);
+       && (!preview || matched_lines.size < (size_t)p_cwh
+           || lnum <= curwin->w_botline);
        lnum++) {
     long nmatch = vim_regexec_multi(&regmatch, curwin, curbuf, lnum,
                                     (colnr_T)0, NULL);

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -892,6 +892,31 @@ describe(":substitute, inccommand=split", function()
     ]])
   end)
 
+  it('previews correctly when previewhight is small', function()
+    feed_command('set cwh=3')
+    feed_command('set hls')
+    feed('ggdG')
+    insert(string.rep('abc abc abc\n', 20))
+    feed(':%s/abc/MMM/g')
+    screen:expect([[
+      MMM MMM MMM                   |
+      MMM MMM MMM                   |
+      MMM MMM MMM                   |
+      MMM MMM MMM                   |
+      MMM MMM MMM                   |
+      MMM MMM MMM                   |
+      MMM MMM MMM                   |
+      MMM MMM MMM                   |
+      MMM MMM MMM                   |
+      {11:[No Name] [+]                 }|
+      | 1| {12:MMM} {12:MMM} {12:MMM}              |
+      | 2| {12:MMM} {12:MMM} {12:MMM}              |
+      | 3| {12:MMM} {12:MMM} {12:MMM}              |
+      {10:[Preview]                     }|
+      :%s/abc/MMM/g^                 |
+    ]])
+  end)
+
   it('actually replaces text', function()
     feed(":%s/tw/XX/g<Enter>")
 


### PR DESCRIPTION
Fixes up  #6949.
Closes https://github.com/neovim/neovim/issues/7220.

The issue would show up whenever the active window has more matches than `cwh`, the height of the preview window. Now we keep looking for matches if we're not yet looking "below" the active window.

This isn't _totally_ optimal in all cases (e.g. if `cwh` is large, but the window small and you're using `icm=nosplit`, then we could stop looking even earlier), but I think the condition of the for loop is complicated enough and further gains would be pretty minor.