### PR TITLE
[RDY] vim-patch:8.0.0209

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3500,6 +3500,10 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout)
           setmouse();                   /* disable mouse in xterm */
           curwin->w_cursor.col = regmatch.startpos[0].col;
 
+          if (curwin->w_p_crb) {
+            do_check_cursorbind();
+          }
+
           /* When 'cpoptions' contains "u" don't sync undo when
            * asking for confirmation. */
           if (vim_strchr(p_cpo, CPO_UNDO) != NULL)

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -743,7 +743,7 @@ static const int included_patches[] = {
   // 212,
   // 211 NA
   // 210,
-  // 209,
+  209,
   208,
   // 207,
   // 206,


### PR DESCRIPTION
Problem:    When using :substitute with the "c" flag and 'cursorbind' is set
            the cursor is not updated in other windows.
Solution:   Call do_check_cursorbind(). (Masanori Misono)

https://github.com/vim/vim/commit/41baa7983aa81b0343b053e6a672cf8224a10245