### PR TITLE
K_EVENT should not finish operator

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7958,6 +7958,7 @@ static void nv_event(cmdarg_T *cap)
   may_garbage_collect = false;
   multiqueue_process_events(main_loop.events);
   cap->retval |= CA_COMMAND_BUSY;       // don't call edit() now
+  finish_op = false;
 }
 
 /// Trigger FocusGained event.

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -345,6 +345,24 @@ describe('api', function()
     end)
   end)
 
+  describe('RPC during operator pending #6166', function()
+    it('does not complete a pending operator', function()
+      helpers.insert([[
+      FIRST LINE
+      SECOND LINE]])
+      nvim('input', 'gg')
+      nvim("input", "gu")
+      -- Make any plain RPC request, this should not complete operator pending mode.
+      helpers.expect([[
+      FIRST LINE
+      SECOND LINE]])
+      nvim("input", "j")
+      helpers.expect([[
+      first line
+      second line]])
+    end)
+  end)
+
   describe('nvim_replace_termcodes', function()
     it('escapes K_SPECIAL as K_SPECIAL KS_SPECIAL KE_FILLER', function()
       eq('\128\254X', helpers.nvim('replace_termcodes', '\128', true, true, true))

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -334,13 +334,11 @@ describe('api', function()
            NIL}, meths.call_atomic(req))
       eq({mode='r', blocking=true}, nvim("get_mode"))
     end)
-    -- TODO: bug #6166
     it("during insert-mode map-pending, returns blocking=true #6166", function()
       command("inoremap xx foo")
       nvim("input", "ix")
       eq({mode='i', blocking=true}, nvim("get_mode"))
     end)
-    -- TODO: bug #6166
     it("during normal-mode gU, returns blocking=false #6166", function()
       nvim("input", "gu")
       eq({mode='no', blocking=false}, nvim("get_mode"))


### PR DESCRIPTION
reference #5398 and #6166 

Thanks to @bfredl and @justinmk on IRC for help.

It appears `normal_finish_command()` and `normal_prepare()` assume that any pending operator needs to be finished after any subsequent key.

We set `finish_op = false` in `nv_event()` to indicate that this operator shouldn't be finished after the current `normal_execute()`.

This is the same way that `nv_visual()` indicates that `'v'` or `'V'` in operator-pending mode should not finish the current pending operator.