### PR TITLE
[RDY] vim-patch:8.0.0247

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2406,6 +2406,7 @@ void set_completion(colnr_T startcol, list_T *list)
     ins_compl_prep(' ');
   }
   ins_compl_clear();
+  ins_compl_free();
 
   compl_direction = FORWARD;
   if (startcol > curwin->w_cursor.col)

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -7,10 +7,10 @@ func! ListMonths()
   if g:setting != ''
     exe ":set" g:setting
   endif
-  let mth=copy(g:months)
+  let mth = copy(g:months)
   let entered = strcharpart(getline('.'),0,col('.'))
   if !empty(entered)
-    let mth=filter(mth, 'v:val=~"^".entered')
+    let mth = filter(mth, 'v:val=~"^".entered')
   endif
   call complete(1, mth)
   return ''
@@ -468,7 +468,7 @@ endfunc
 " auto-wrap text.
 func Test_completion_ctrl_e_without_autowrap()
   new
-  let tw_save=&tw
+  let tw_save = &tw
   set tw=78
   let li = [
         \ '"                                                        zzz',
@@ -478,7 +478,7 @@ func Test_completion_ctrl_e_without_autowrap()
   call feedkeys("A\<C-X>\<C-N>\<C-E>\<Esc>", "tx")
   call assert_equal(li, getline(1, '$'))
 
-  let &tw=tw_save
+  let &tw = tw_save
   q!
 endfunc
 
@@ -540,5 +540,34 @@ func Test_completion_comment_formatting()
   call assert_equal(['', '/*', ' *', ' */'], getline(1,4))
   bwipe!
 endfunc
+
+function! DummyCompleteSix()
+  call complete(1, ['Hello', 'World'])
+  return ''
+endfunction
+
+" complete() correctly clears the list of autocomplete candidates
+func Test_completion_clear_candidate_list()
+  new
+  %d
+  " select first entry from the completion popup
+  call feedkeys("a    xxx\<C-N>\<C-R>=DummyCompleteSix()\<CR>", "tx")
+  call assert_equal('Hello', getline(1))
+  %d
+  " select second entry from the completion popup
+  call feedkeys("a    xxx\<C-N>\<C-R>=DummyCompleteSix()\<CR>\<C-N>", "tx")
+  call assert_equal('World', getline(1))
+  %d
+  " select original text
+  call feedkeys("a    xxx\<C-N>\<C-R>=DummyCompleteSix()\<CR>\<C-N>\<C-N>", "tx")
+  call assert_equal('    xxx', getline(1))
+  %d
+  " back at first entry from completion list
+  call feedkeys("a    xxx\<C-N>\<C-R>=DummyCompleteSix()\<CR>\<C-N>\<C-N>\<C-N>", "tx")
+  call assert_equal('Hello', getline(1))
+
+  bw!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -705,7 +705,7 @@ static const int included_patches[] = {
   250,
   // 249 NA
   // 248,
-  // 247,
+  247,
   // 246 NA
   // 245,
   // 244,


### PR DESCRIPTION
Problem:    Under some circumstances, one needs to type Ctrl-N or Ctrl-P twice
            to have a menu entry selected. (Lifepillar)
Solution:   call ins_compl_free(). (Christian Brabandt, closes vim/vim#1411)

https://github.com/vim/vim/commit/aed6d0b81a14a81433c0f3c2c65cef935100db33