### PR TITLE
[RDY] vim-patch:8.0.0125

### DIFF
--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -230,7 +230,24 @@ func Test_paste_in_cmdline()
 
   call feedkeys("f;:aaa \<C-R>\<C-A> bbb\<C-B>\"\<CR>", 'tx')
   call assert_equal('"aaa a;b-c*d bbb', @:)
+
+  call feedkeys(":\<C-\>etoupper(getline(1))\<CR>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"ASDF.X /TMP/SOME VERYLONGWORD A;B-C*D ', @:)
   bwipe!
+endfunc
+
+func Test_remove_char_in_cmdline()
+    call feedkeys(":abc def\<S-Left>\<Del>\<C-B>\"\<CR>", 'tx')
+    call assert_equal('"abc ef', @:)
+
+    call feedkeys(":abc def\<S-Left>\<BS>\<C-B>\"\<CR>", 'tx')
+    call assert_equal('"abcdef', @:)
+
+    call feedkeys(":abc def ghi\<S-Left>\<C-W>\<C-B>\"\<CR>", 'tx')
+    call assert_equal('"abc ghi', @:)
+
+    call feedkeys(":abc def\<S-Left>\<C-U>\<C-B>\"\<CR>", 'tx')
+    call assert_equal('"def', @:)
 endfunc
 
 func Test_illegal_address()

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -827,7 +827,7 @@ static const int included_patches[] = {
   128,
   127,
   126,
-  // 125,
+  125,
   124,
   // 123 NA
   // 122 NA


### PR DESCRIPTION
Problem:    Not enough testing for entering Ex commands.
Solution:   Add test for CTRL-\ e {expr}. (Dominique Pelle)

https://github.com/vim/vim/commit/eaaa9bbda6ec0a8589a9b23720f95bffe01dc267