### PR TITLE
[RDY] Vim-patch 8.0.0282 and 8.0.0291

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1942,8 +1942,11 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
          * the lines. */
         auto_format(false, true);
 
-        if (restart_edit == 0)
+        if (restart_edit == 0) {
           restart_edit = restart_edit_save;
+        } else {
+          cap->retval |= CA_COMMAND_BUSY;
+        }
       }
       break;
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2060,7 +2060,7 @@ void op_insert(oparg_T *oap, long count1)
   }
 
   t1 = oap->start;
-  edit(NUL, false, (linenr_T)count1);
+  (void)edit(NUL, false, (linenr_T)count1);
 
   // When a tab was inserted, and the characters in front of the tab
   // have been converted to a tab as well, the column of the cursor

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -15,3 +15,16 @@ func Test_block_shift_multibyte()
   call assert_equal('	ヹxxx', getline(2))
   q!
 endfunc
+
+func Test_Visual_ctrl_o()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  call cursor(1,2)
+  set noshowmode
+  set tw=0
+  call feedkeys("\<c-v>jjlIa\<c-\>\<c-o>:set tw=88\<cr>\<esc>", 'tx')
+  call assert_equal(['oane', 'tawo', 'tahree'], getline(1, 3))
+  call assert_equal(88, &tw)
+  set tw&
+  bw!
+endfu

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -661,7 +661,7 @@ static const int included_patches[] = {
   // 294,
   // 293,
   // 292,
-  // 291,
+  291,
   290,
   // 289,
   // 288 NA
@@ -670,7 +670,7 @@ static const int included_patches[] = {
   // 285 NA
   // 284 NA
   // 283,
-  // 282,
+  282,
   // 281 NA
   280,
   // 279 NA


### PR DESCRIPTION
    vim-patch:8.0.0291
    
    Problem:    Visual block insertion does not insert in all lines.
    Solution:   Don't bail out of insert too early. Add a test. (Christian
                Brabandt, closes vim/vim#1290)
    
    https://github.com/vim/vim/commit/23fa81d2223cd9bb7c51829c48047b2976bc2d11
    
    vim-patch:8.0.0282
    
    Problem:    When doing a Visual selection and using "I" to go to insert mode
                CTRL-O needs to be used twice to go to Normal mode.
                (Coacher)
    Solution:   Check for the return value of edit(). (Christian Brabandt,
                closes #1290)
    
    https://github.com/vim/vim/commit/0b5c93a7f266cd8c90ea27bdaf9f7214a95d64d7