### PR TITLE
[RDY] vim-patch:8.0.0305

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1749,7 +1749,7 @@ do_set (
 
               if (flags & P_FLAGLIST) {
                 // Remove flags that appear twice.
-                for (s = newval; *s; s++) {
+                for (s = newval; *s;) {
                   // if options have P_FLAGLIST and P_ONECOMMA such as
                   // 'whichwrap'
                   if (flags & P_ONECOMMA) {
@@ -1757,15 +1757,16 @@ do_set (
                         && vim_strchr(s + 2, *s) != NULL) {
                       // Remove the duplicated value and the next comma.
                       STRMOVE(s, s + 2);
-                      s -= 2;
+                      continue;
                     }
                   } else {
                     if ((!(flags & P_COMMA) || *s != ',')
                         && vim_strchr(s + 1, *s) != NULL) {
                       STRMOVE(s, s + 1);
-                      s--;
+                      continue;
                     }
                   }
+                  s++;
                 }
               }
 

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -13,6 +13,12 @@ function! Test_whichwrap()
   set whichwrap+=h,l
   call assert_equal('b,s,h,l', &whichwrap)
 
+  set whichwrap=h,h
+  call assert_equal('h', &whichwrap)
+
+  set whichwrap=h,h,h
+  call assert_equal('h', &whichwrap)
+
   set whichwrap&
 endfunction
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -647,7 +647,7 @@ static const int included_patches[] = {
   308,
   307,
   // 306,
-  // 305,
+  305,
   // 304,
   // 303,
   // 302,


### PR DESCRIPTION
Problem:    Invalid memory access when option has duplicate flag.
Solution:   Correct pointer computation. (Dominique Pelle, closes vim/vim#1442)

https://github.com/vim/vim/commit/aaaf57d8a936efe420190c077e4a74041cc6c72e