### PR TITLE
Display better error message when BSD make is used

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,0 +1,4 @@
+.DONE:
+	@echo "Please use GNU Make (gmake) to build neovim"
+.DEFAULT:
+	@echo "Please use GNU Make (gmake) to build neovim"


### PR DESCRIPTION
BSD Make will give preference to a BSDmakefile in the same directory
over a generic Makefile; this can be used to instruct BSD users to build
neovim with GNU Make (gmake) instead.

Otherwise, a flood of syntax errors stemming from the GNU-specific
Makefile will be displayed - which most BSD users are accustomed to, but
may confuse beginners nevertheless.

(GNU Make likewise prefers GNUmakefile to Makefile, if it exists)