### PR TITLE
tui: Use unibi_var_from_num when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,21 @@ if(FEAT_TUI)
   find_package(Unibilium REQUIRED)
   include_directories(SYSTEM ${UNIBILIUM_INCLUDE_DIRS})
 
+  list(APPEND CMAKE_REQUIRED_INCLUDES "${UNIBILIUM_INCLUDE_DIRS}")
+  list(APPEND CMAKE_REQUIRED_LIBRARIES "${UNIBILIUM_LIBRARIES}")
+  check_c_source_compiles("
+  #include <unibilium.h>
+
+  int
+  main(void)
+  {
+    return unibi_num_from_var(unibi_var_from_num(0));
+  }
+  " UNIBI_HAS_VAR_FROM)
+  if(UNIBI_HAS_VAR_FROM)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNVIM_UNIBI_HAS_VAR_FROM")
+  endif()
+
   find_package(LibTermkey REQUIRED)
   include_directories(SYSTEM ${LIBTERMKEY_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
As of unibilium 1.2.1, directly manipulating unibi_var_t is deprecated.

    ../src/nvim/tui/tui.c: In function 'update_attrs':
    ../src/nvim/tui/tui.c:321:7: warning: 'i' is deprecated: use unibi_var_from_num or unibi_num_from_var instead [-Wdeprecated-declarations]
           data->params[0].i = (fg >> 16) & 0xff;  // red
           ^~~~
    In file included from ../src/nvim/tui/tui.c:12:0:
    /usr/include/unibilium.h:632:9: note: declared here
         int i   UNIBI_DEPRECATED("use unibi_var_from_num or unibi_num_from_var instead");
             ^

All use should go through `unibi_{num,str}_from_var` and
`unibi_var_from_{num,str}`.  Wrap access of `unibi_var_t` behind a new
`UNIBI_SET_NUM_VAR` macro which uses the new functions when they're
available.