### PR TITLE
[RDY] vim-patch:8.0.0324

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1668,8 +1668,8 @@ static char_u * do_one_cmd(char_u **cmdlinep,
     if (*ea.cmd == ';') {
       if (!ea.skip) {
         curwin->w_cursor.lnum = ea.line2;
-        // Don't leave the cursor on an illegal line (caused by ';')
-        check_cursor_lnum();
+        // don't leave the cursor on an illegal line or column
+        check_cursor();
       }
     } else if (*ea.cmd != ',') {
       break;

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -250,9 +250,21 @@ func Test_remove_char_in_cmdline()
     call assert_equal('"def', @:)
 endfunc
 
-func Test_illegal_address()
+func Test_illegal_address1()
   new
   2;'(
   2;')
   quit
 endfunc
+
+func Test_illegal_address2()
+  call writefile(['c', 'x', '  x', '.', '1;y'], 'Xtest.vim')
+  new
+  source Xtest.vim
+  " Trigger calling validate_cursor()
+  diffsp Xtest.vim
+  quit!
+  bwipe!
+  call delete('Xtest.vim')
+endfunc
+

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -628,7 +628,7 @@ static const int included_patches[] = {
   // 327,
   326,
   325,
-  // 324,
+  324,
   // 323,
   322,
   // 321,


### PR DESCRIPTION
Problem:    Illegal memory access with "1;y".
Solution:   Call check_cursor() instead of check_cursor_lnum(). (Dominique
            Pelle, closes vim/vim#1455)

https://github.com/vim/vim/commit/f1f6f3f7df2938b3583e341482d96c1d53124c51