### PR TITLE
[RFC] cmake: remove stale doc files to avoid "duplicate tags" message

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -71,6 +71,7 @@ foreach(DF ${DOCFILES})
 endforeach()
 
 add_custom_target(helptags
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${GENERATED_RUNTIME_DIR}/doc
   COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${PROJECT_SOURCE_DIR}/runtime/doc ${GENERATED_RUNTIME_DIR}/doc
   COMMAND "${PROJECT_BINARY_DIR}/bin/nvim"


### PR DESCRIPTION
If one switches from branch A with a new `help.txt` file to branch B without that file, the file is not removed. This leads to spurious "duplicate tag" errors. Solution: always clear `build/doc` directory.