### PR TITLE
[RDY] vim-patch:8.0.0327

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1813,7 +1813,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
     if (text_locked() && !(ea.argt & CMDWIN)
         && !IS_USER_CMDIDX(ea.cmdidx)) {
       // Command not allowed when editing the command line.
-      errormsg = get_text_locked_msg();
+      errormsg = (char_u *)_(get_text_locked_msg());
       goto doend;
     }
     /* Disallow editing another buffer when "curbuf_lock" is set.

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -625,7 +625,7 @@ static const int included_patches[] = {
   // 330,
   // 329,
   // 328,
-  // 327,
+  327,
   326,
   325,
   // 324,


### PR DESCRIPTION
Problem:    The E11 error message in the command line window is not
            translated.
Solution:   use _(). (Hirohito Higashi)

https://github.com/vim/vim/commit/75c19464ed7fb6024af64747379e61abc4e4a483