### PR TITLE
doc: fix typo with :lcd

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1271,7 +1271,7 @@ Commands for changing the working directory can be suffixed with a bang "!"
 
 							*:lcd-* 
 :lcd[!] -		Change to the previous current directory (before the
-			previous ":tcd {path}" command).
+			previous ":lcd {path}" command).
 
 							*:pw* *:pwd* *E187*
 :pw[d]			Print the current directory name.


### PR DESCRIPTION
Not sure if this is really correct though.

Also it could be mentioned maybe that `:tcd - | tcd -` can be used to unset a local directory.
Is there a better way, or should there be one to unset a local or tab-local dir?!