### PR TITLE
vim-patch:8.0.0294

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9378,7 +9378,7 @@ ses_arglist (
         (void)vim_FullName((char *)s, (char *)buf, MAXPATHL, FALSE);
         s = buf;
       }
-      if (fputs("argadd ", fd) < 0 || ses_put_fname(fd, s, flagp) == FAIL
+      if (fputs("$argadd ", fd) < 0 || ses_put_fname(fd, s, flagp) == FAIL
           || put_eol(fd) == FAIL) {
         xfree(buf);
         return FAIL;

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -58,6 +58,7 @@ NEW_TESTS ?= \
 	    test_match.res \
 	    test_matchadd_conceal.res \
 	    test_matchadd_conceal_utf8.res \
+	    test_mksession.res \
 	    test_nested_function.res \
 	    test_normal.res \
 	    test_quickfix.res \

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -1,0 +1,15 @@
+" Tests for sessions
+
+" Verify that arglist is stored correctly to the session file.
+func Test_mksession_arglist()
+  argdel *
+  next file1 file2 file3 file4
+  mksession! Xtest_mks.out
+  source Xtest_mks.out
+  call assert_equal(['file1', 'file2', 'file3', 'file4'], argv())
+
+  call delete('Xtest_mks.out')
+  argdel *
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -658,7 +658,7 @@ static const int included_patches[] = {
   297,
   // 296,
   // 295,
-  // 294,
+  294,
   // 293,
   // 292,
   291,


### PR DESCRIPTION
Problem:    Argument list is not stored correctly in a session file.
            (lgpasquale)
Solution:   Use "$argadd" instead of "argadd". (closes vim/vim#1434)

close #7304 

https://github.com/vim/vim/commit/79da563cf9220b9abb83455a68d995684133ea56