### PR TITLE
vim-patch:8.0.0074

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1927,7 +1927,7 @@ bool vim_is_ctrl_x_key(int c)
   case CTRL_X_EVAL:
     return (c == Ctrl_P || c == Ctrl_N);
   }
-  EMSG(_(e_internal));
+  internal_error("vim_is_ctrl_x_key()");
   return false;
 }
 
@@ -4681,7 +4681,7 @@ static int ins_complete(int c, bool enable_pum)
       line = ml_get(curwin->w_cursor.lnum);
       compl_pattern = vim_strnsave(line + compl_col, compl_length);
     } else {
-      EMSG2(_(e_intern2), "ins_complete()");
+      internal_error("ins_complete()");
       return FAIL;
     }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1102,10 +1102,11 @@ static void restore_vimvar(int idx, typval_T *save_tv)
   vimvars[idx].vv_tv = *save_tv;
   if (vimvars[idx].vv_type == VAR_UNKNOWN) {
     hi = hash_find(&vimvarht, vimvars[idx].vv_di.di_key);
-    if (HASHITEM_EMPTY(hi))
-      EMSG2(_(e_intern2), "restore_vimvar()");
-    else
+    if (HASHITEM_EMPTY(hi)) {
+      internal_error("restore_vimvar()");
+    } else {
       hash_remove(&vimvarht, hi);
+    }
   }
 }
 
@@ -1567,7 +1568,7 @@ ex_let_vars (
       }
       break;
     } else if (*arg != ',' && *arg != ']') {
-      EMSG2(_(e_intern2), "ex_let_vars()");
+      internal_error("ex_let_vars()");
       return FAIL;
     }
   }
@@ -2960,7 +2961,7 @@ int do_unlet(const char *const name, const size_t name_len, const int forceit)
       d = di->di_tv.vval.v_dict;
     }
     if (d == NULL) {
-      EMSG2(_(e_intern2), "do_unlet()");
+      internal_error("do_unlet()");
       return FAIL;
     }
     hashitem_T *hi = hash_find(ht, (const char_u *)varname);
@@ -7959,7 +7960,7 @@ static void f_empty(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     n = argvars[0].vval.v_special != kSpecialVarTrue;
     break;
   case VAR_UNKNOWN:
-    EMSG2(_(e_intern2), "f_empty(UNKNOWN)");
+    internal_error("f_empty(UNKNOWN)");
     break;
   }
 
@@ -17151,7 +17152,7 @@ static void f_type(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       break;
     }
     case VAR_UNKNOWN: {
-      EMSG2(_(e_intern2), "f_type(UNKNOWN)");
+      internal_error("f_type(UNKNOWN)");
       break;
     }
   }
@@ -19030,7 +19031,7 @@ static void set_var(const char *name, const size_t name_len, typval_T *const tv,
         }
         return;
       } else if (v->di_tv.v_type != tv->v_type) {
-        EMSG2(_(e_intern2), "set_var()");
+        internal_error("set_var()");
       }
     }
 
@@ -19297,7 +19298,7 @@ int var_item_copy(const vimconv_T *const conv,
     }
     break;
   case VAR_UNKNOWN:
-    EMSG2(_(e_intern2), "var_item_copy(UNKNOWN)");
+    internal_error("var_item_copy(UNKNOWN)");
     ret = FAIL;
   }
   --recurse;
@@ -20985,11 +20986,11 @@ void func_unref(char_u *name)
   if (fp == NULL && isdigit(*name)) {
 #ifdef EXITFREE
     if (!entered_free_all_mem) {
-      EMSG2(_(e_intern2), "func_unref()");
+      internal_error("func_unref()");
       abort();
     }
 #else
-      EMSG2(_(e_intern2), "func_unref()");
+      internal_error("func_unref()");
       abort();
 #endif
   }
@@ -21028,7 +21029,7 @@ void func_ref(char_u *name)
   } else if (isdigit(*name)) {
     // Only give an error for a numbered function.
     // Fail silently, when named or lambda function isn't found.
-    EMSG2(_(e_intern2), "func_ref()");
+    internal_error("func_ref()");
   }
 }
 

--- a/src/nvim/eval/encode.c
+++ b/src/nvim/eval/encode.c
@@ -340,7 +340,7 @@ int encode_read_from_list(ListReaderState *const state, char *const buf,
     do { \
       const char *const fun_ = (const char *)(fun); \
       if (fun_ == NULL) { \
-        EMSG2(_(e_intern2), "string(): NULL function name"); \
+        internal_error("string(): NULL function name"); \
         ga_concat(gap, "function(NULL"); \
       } else { \
         ga_concat(gap, "function("); \

--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -600,7 +600,7 @@ _convert_one_value_regular_dict: {}
       break;
     }
     case VAR_UNKNOWN: {
-      EMSG2(_(e_intern2), STR(_TYPVAL_ENCODE_CONVERT_ONE_VALUE) "()");
+      internal_error(STR(_TYPVAL_ENCODE_CONVERT_ONE_VALUE) "()");
       return FAIL;
     }
   }

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -517,7 +517,7 @@ static void discard_exception(except_T *excp, int was_finished)
   char_u              *saved_IObuff;
 
   if (excp == NULL) {
-    EMSG(_(e_internal));
+    internal_error("discard_exception()");
     return;
   }
 
@@ -619,8 +619,9 @@ static void catch_exception(except_T *excp)
  */
 static void finish_exception(except_T *excp)
 {
-  if (excp != caught_stack)
-    EMSG(_(e_internal));
+  if (excp != caught_stack) {
+    internal_error("finish_exception()");
+  }
   caught_stack = caught_stack->caught;
   if (caught_stack != NULL) {
     set_vim_var_string(VV_EXCEPTION, (char *) caught_stack->value, -1);
@@ -1422,8 +1423,9 @@ void ex_catch(exarg_T *eap)
        * ":endtry" or when the catch clause is left by a ":continue",
        * ":break", ":return", ":finish", error, interrupt, or another
        * exception. */
-      if (cstack->cs_exception[cstack->cs_idx] != current_exception)
-        EMSG(_(e_internal));
+      if (cstack->cs_exception[cstack->cs_idx] != current_exception) {
+        internal_error("ex_catch()");
+      }
     } else {
       /*
        * If there is a preceding catch clause and it caught the exception,
@@ -1547,7 +1549,7 @@ void ex_finally(exarg_T *eap)
          * exception will be discarded. */
         if (did_throw && cstack->cs_exception[cstack->cs_idx]
             != current_exception)
-          EMSG(_(e_internal));
+          internal_error("ex_finally()");
       }
 
       /*

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -254,16 +254,17 @@ static void add_buff(buffheader_T *const buf, const char *const s,
     return;
   }
 
-  if (buf->bh_first.b_next == NULL) {   /* first add to list */
+  if (buf->bh_first.b_next == NULL) {  // first add to list
     buf->bh_space = 0;
     buf->bh_curr = &(buf->bh_first);
-  } else if (buf->bh_curr == NULL) {  /* buffer has already been read */
-    EMSG(_("E222: Add to read buffer"));
+  } else if (buf->bh_curr == NULL) {  // buffer has already been read
+    IEMSG(_("E222: Add to read buffer"));
     return;
-  } else if (buf->bh_index != 0)
+  } else if (buf->bh_index != 0) {
     memmove(buf->bh_first.b_next->b_str,
-        buf->bh_first.b_next->b_str + buf->bh_index,
-        STRLEN(buf->bh_first.b_next->b_str + buf->bh_index) + 1);
+            buf->bh_first.b_next->b_str + buf->bh_index,
+            STRLEN(buf->bh_first.b_next->b_str + buf->bh_index) + 1);
+  }
   buf->bh_index = 0;
 
   size_t len;
@@ -1152,14 +1153,16 @@ void alloc_typebuf(void)
  */
 void free_typebuf(void)
 {
-  if (typebuf.tb_buf == typebuf_init)
-    EMSG2(_(e_intern2), "Free typebuf 1");
-  else
+  if (typebuf.tb_buf == typebuf_init) {
+    internal_error("Free typebuf 1");
+  } else {
     xfree(typebuf.tb_buf);
-  if (typebuf.tb_noremap == noremapbuf_init)
-    EMSG2(_(e_intern2), "Free typebuf 2");
-  else
+  }
+  if (typebuf.tb_noremap == noremapbuf_init) {
+    internal_error("Free typebuf 2");
+  } else {
     xfree(typebuf.tb_noremap);
+  }
 }
 
 /*
@@ -3905,7 +3908,7 @@ makemap (
           c1 = 't';
           break;
         default:
-          EMSG(_("E228: makemap: Illegal mode"));
+          IEMSG(_("E228: makemap: Illegal mode"));
           return FAIL;
         }
         do {            /* do this twice if c2 is set, 3 times with c3 */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1043,6 +1043,7 @@ EXTERN char_u e_for[] INIT(= N_("E588: :endfor without :for"));
 EXTERN char_u e_exists[] INIT(= N_("E13: File exists (add ! to override)"));
 EXTERN char_u e_failed[] INIT(= N_("E472: Command failed"));
 EXTERN char_u e_internal[] INIT(= N_("E473: Internal error"));
+EXTERN char_u e_intern2[] INIT(= N_("E685: Internal error: %s"));
 EXTERN char_u e_interr[] INIT(= N_("Interrupted"));
 EXTERN char_u e_invaddr[] INIT(= N_("E14: Invalid address"));
 EXTERN char_u e_invarg[] INIT(= N_("E474: Invalid argument"));
@@ -1134,7 +1135,6 @@ EXTERN char_u e_write[] INIT(= N_("E80: Error while writing"));
 EXTERN char_u e_zerocount[] INIT(= N_("E939: Positive count required"));
 EXTERN char_u e_usingsid[] INIT(= N_(
     "E81: Using <SID> not in a script context"));
-EXTERN char_u e_intern2[] INIT(= N_("E685: Internal error: %s"));
 EXTERN char_u e_maxmempat[] INIT(= N_(
         "E363: pattern uses more memory than 'maxmempattern'"));
 EXTERN char_u e_emptybuf[] INIT(= N_("E749: empty buffer"));

--- a/src/nvim/hashtab.c
+++ b/src/nvim/hashtab.c
@@ -208,7 +208,7 @@ int hash_add(hashtab_T *ht, char_u *key)
   hash_T hash = hash_hash(key);
   hashitem_T *hi = hash_lookup(ht, (const char *)key, STRLEN(key), hash);
   if (!HASHITEM_EMPTY(hi)) {
-    EMSG2(_(e_intern2), "hash_add()");
+    internal_error("hash_add()");
     return FAIL;
   }
   hash_add_item(ht, hi, key, hash);

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -376,8 +376,9 @@ void mf_put(memfile_T *mfp, bhdr_T *hp, bool dirty, bool infile)
 {
   unsigned flags = hp->bh_flags;
 
-  if ((flags & BH_LOCKED) == 0)
-    EMSG(_("E293: block was not locked"));
+  if ((flags & BH_LOCKED) == 0) {
+    IEMSG(_("E293: block was not locked"));
+  }
   flags &= ~BH_LOCKED;
   if (dirty) {
     flags |= BH_DIRTY;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1743,11 +1743,11 @@ ml_get_buf (
 
   if (lnum > buf->b_ml.ml_line_count) { /* invalid line number */
     if (recursive == 0) {
-      /* Avoid giving this message for a recursive call, may happen when
-       * the GUI redraws part of the text. */
-      ++recursive;
+      // Avoid giving this message for a recursive call, may happen when
+      // the GUI redraws part of the text.
+      recursive++;
       IEMSGN(_("E315: ml_get: invalid lnum: %" PRId64), lnum);
-      --recursive;
+      recursive--;
     }
 errorret:
     STRCPY(IObuff, "???");
@@ -1775,11 +1775,11 @@ errorret:
      */
     if ((hp = ml_find_line(buf, lnum, ML_FIND)) == NULL) {
       if (recursive == 0) {
-        /* Avoid giving this message for a recursive call, may happen
-         * when the GUI redraws part of the text. */
-        ++recursive;
+        // Avoid giving this message for a recursive call, may happen
+        // when the GUI redraws part of the text.
+        recursive++;
         IEMSGN(_("E316: ml_get: cannot find line %" PRId64), lnum);
-        --recursive;
+        recursive--;
       }
       goto errorret;
     }
@@ -2631,9 +2631,9 @@ static void ml_flush_line(buf_T *buf)
     new_line = buf->b_ml.ml_line_ptr;
 
     hp = ml_find_line(buf, lnum, ML_FIND);
-    if (hp == NULL)
+    if (hp == NULL) {
       IEMSGN(_("E320: Cannot find line %" PRId64), lnum);
-    else {
+    } else {
       dp = hp->bh_data;
       idx = lnum - buf->b_ml.ml_locked_low;
       start = ((dp->db_index[idx]) & DB_INDEX_MASK);
@@ -2879,13 +2879,14 @@ static bhdr_T *ml_find_line(buf_T *buf, linenr_T lnum, int action)
         break;
       }
     }
-    if (idx >= (int)pp->pb_count) {         /* past the end: something wrong! */
-      if (lnum > buf->b_ml.ml_line_count)
+    if (idx >= (int)pp->pb_count) {         // past the end: something wrong!
+      if (lnum > buf->b_ml.ml_line_count) {
         IEMSGN(_("E322: line number out of range: %" PRId64 " past the end"),
-            lnum - buf->b_ml.ml_line_count);
+               lnum - buf->b_ml.ml_line_count);
 
-      else
+      } else {
         IEMSGN(_("E323: line count wrong in block %" PRId64), bnum);
+      }
       goto error_block;
     }
     if (action == ML_DELETE) {

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -293,7 +293,7 @@ int ml_open(buf_T *buf)
    */
   hp = mf_new(mfp, false, 1);
   if (hp->bh_bnum != 0) {
-    EMSG(_("E298: Didn't get block nr 0?"));
+    IEMSG(_("E298: Didn't get block nr 0?"));
     goto error;
   }
   b0p = hp->bh_data;
@@ -335,7 +335,7 @@ int ml_open(buf_T *buf)
   if ((hp = ml_new_ptr(mfp)) == NULL)
     goto error;
   if (hp->bh_bnum != 1) {
-    EMSG(_("E298: Didn't get block nr 1?"));
+    IEMSG(_("E298: Didn't get block nr 1?"));
     goto error;
   }
   pp = hp->bh_data;
@@ -351,7 +351,7 @@ int ml_open(buf_T *buf)
    */
   hp = ml_new_data(mfp, FALSE, 1);
   if (hp->bh_bnum != 2) {
-    EMSG(_("E298: Didn't get block nr 2?"));
+    IEMSG(_("E298: Didn't get block nr 2?"));
     goto error;
   }
 
@@ -635,13 +635,14 @@ static void ml_upd_block0(buf_T *buf, upd_block0_T what)
   if (mfp == NULL || (hp = mf_get(mfp, 0, 1)) == NULL)
     return;
   b0p = hp->bh_data;
-  if (ml_check_b0_id(b0p) == FAIL)
-    EMSG(_("E304: ml_upd_block0(): Didn't get block 0??"));
-  else {
-    if (what == UB_FNAME)
+  if (ml_check_b0_id(b0p) == FAIL) {
+    IEMSG(_("E304: ml_upd_block0(): Didn't get block 0??"));
+  } else {
+    if (what == UB_FNAME) {
       set_b0_fname(b0p, buf);
-    else     /* what == UB_SAME_DIR */
+    } else {    // what == UB_SAME_DIR
       set_b0_dir_flag(b0p, buf);
+    }
   }
   mf_put(mfp, hp, true, false);
 }
@@ -1745,7 +1746,7 @@ ml_get_buf (
       /* Avoid giving this message for a recursive call, may happen when
        * the GUI redraws part of the text. */
       ++recursive;
-      EMSGN(_("E315: ml_get: invalid lnum: %" PRId64), lnum);
+      IEMSGN(_("E315: ml_get: invalid lnum: %" PRId64), lnum);
       --recursive;
     }
 errorret:
@@ -1777,7 +1778,7 @@ errorret:
         /* Avoid giving this message for a recursive call, may happen
          * when the GUI redraws part of the text. */
         ++recursive;
-        EMSGN(_("E316: ml_get: cannot find line %" PRId64), lnum);
+        IEMSGN(_("E316: ml_get: cannot find line %" PRId64), lnum);
         --recursive;
       }
       goto errorret;
@@ -2162,7 +2163,7 @@ ml_append_int (
         return FAIL;
       pp = hp->bh_data;         /* must be pointer block */
       if (pp->pb_id != PTR_ID) {
-        EMSG(_("E317: pointer block id wrong 3"));
+        IEMSG(_("E317: pointer block id wrong 3"));
         mf_put(mfp, hp, false, false);
         return FAIL;
       }
@@ -2295,8 +2296,8 @@ ml_append_int (
      * Safety check: fallen out of for loop?
      */
     if (stack_idx < 0) {
-      EMSG(_("E318: Updated too many blocks?"));
-      buf->b_ml.ml_stack_top = 0;       /* invalidate stack */
+      IEMSG(_("E318: Updated too many blocks?"));
+      buf->b_ml.ml_stack_top = 0;       // invalidate stack
     }
   }
 
@@ -2435,7 +2436,7 @@ static int ml_delete_int(buf_T *buf, linenr_T lnum, int message)
         return FAIL;
       pp = hp->bh_data;         /* must be pointer block */
       if (pp->pb_id != PTR_ID) {
-        EMSG(_("E317: pointer block id wrong 4"));
+        IEMSG(_("E317: pointer block id wrong 4"));
         mf_put(mfp, hp, false, false);
         return FAIL;
       }
@@ -2631,7 +2632,7 @@ static void ml_flush_line(buf_T *buf)
 
     hp = ml_find_line(buf, lnum, ML_FIND);
     if (hp == NULL)
-      EMSGN(_("E320: Cannot find line %" PRId64), lnum);
+      IEMSGN(_("E320: Cannot find line %" PRId64), lnum);
     else {
       dp = hp->bh_data;
       idx = lnum - buf->b_ml.ml_locked_low;
@@ -2841,7 +2842,7 @@ static bhdr_T *ml_find_line(buf_T *buf, linenr_T lnum, int action)
 
     pp = (PTR_BL *)(dp);                /* must be pointer block */
     if (pp->pb_id != PTR_ID) {
-      EMSG(_("E317: pointer block id wrong"));
+      IEMSG(_("E317: pointer block id wrong"));
       goto error_block;
     }
 
@@ -2880,11 +2881,11 @@ static bhdr_T *ml_find_line(buf_T *buf, linenr_T lnum, int action)
     }
     if (idx >= (int)pp->pb_count) {         /* past the end: something wrong! */
       if (lnum > buf->b_ml.ml_line_count)
-        EMSGN(_("E322: line number out of range: %" PRId64 " past the end"),
+        IEMSGN(_("E322: line number out of range: %" PRId64 " past the end"),
             lnum - buf->b_ml.ml_line_count);
 
       else
-        EMSGN(_("E323: line count wrong in block %" PRId64), bnum);
+        IEMSGN(_("E323: line count wrong in block %" PRId64), bnum);
       goto error_block;
     }
     if (action == ML_DELETE) {
@@ -2960,7 +2961,7 @@ static void ml_lineadd(buf_T *buf, int count)
     pp = hp->bh_data;       /* must be pointer block */
     if (pp->pb_id != PTR_ID) {
       mf_put(mfp, hp, false, false);
-      EMSG(_("E317: pointer block id wrong 2"));
+      IEMSG(_("E317: pointer block id wrong 2"));
       break;
     }
     pp->pb_pointer[ip->ip_index].pe_line_count += count;

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -49,6 +49,15 @@
 /// Like #EMSG, but for messages with one "%" PRIu64 inside
 #define EMSGU(s, n)                 emsgf((const char *) (s), (uint64_t)(n))
 
+/// Like #EMSG, but for internal messages
+#define IEMSG(s)                    iemsg((const char *)(s))
+
+/// Like #EMSG2, but for internal messages
+#define IEMSG2(s, p)                iemsgf((const char *)(s), (p))
+
+/// Like #EMSGN, but for internal messages
+#define IEMSGN(s, n)                iemsgf((const char *)(s), (int64_t)(n))
+
 /// Display message at the recorded position
 #define MSG_PUTS(s)                 msg_puts((const char *)(s))
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2258,7 +2258,7 @@ int was_set_insecurely(char_u *opt, int opt_flags)
     uint32_t *flagp = insecure_flag(idx, opt_flags);
     return (*flagp & P_INSECURE) != 0;
   }
-  EMSG2(_(e_intern2), "was_set_insecurely()");
+  internal_error("was_set_insecurely()");
   return -1;
 }
 
@@ -2317,8 +2317,8 @@ set_string_option_direct (
   if (idx == -1) {  // Use name.
     idx = findoption((const char *)name);
     if (idx < 0) {  // Not found (should not happen).
-      EMSG2(_(e_intern2), "set_string_option_direct()");
-      EMSG2(_("For option %s"), name);
+      internal_error("set_string_option_direct()");
+      IEMSG2(_("For option %s"), name);
       return;
     }
   }
@@ -5584,7 +5584,7 @@ static char_u *get_varp(vimoption_T *p)
   case PV_KMAP:   return (char_u *)&(curbuf->b_p_keymap);
   case PV_SCL:    return (char_u *)&(curwin->w_p_scl);
   case PV_WINHL:  return (char_u *)&(curwin->w_p_winhl);
-  default:        EMSG(_("E356: get_varp ERROR"));
+  default:        IEMSG(_("E356: get_varp ERROR"));
   }
   /* always return a valid pointer to avoid a crash! */
   return (char_u *)&(curbuf->b_p_wm);

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -887,7 +887,7 @@ bool os_setenv_append_path(const char *fname)
 # define MAX_ENVPATHLEN INT_MAX
 #endif
   if (!path_is_absolute_path((char_u *)fname)) {
-    EMSG2(_(e_intern2), "os_setenv_append_path()");
+    internal_error("os_setenv_append_path()");
     return false;
   }
   const char *tail = (char *)path_tail_with_sep((char_u *)fname);

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2853,7 +2853,7 @@ static void qf_fill_buffer(qf_info_T *qi, buf_T *buf, qfline_T *old_last)
 
   if (old_last == NULL) {
     if (buf != curbuf) {
-      EMSG2(_(e_intern2), "qf_fill_buffer()");
+      internal_error("qf_fill_buffer()");
       return;
     }
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -458,17 +458,13 @@ static int toggle_Magic(int x)
 
 /* Used for an error (down from) vim_regcomp(): give the error message, set
  * rc_did_emsg and return NULL */
-#define EMSG_RET_NULL(m) return (EMSG(m), rc_did_emsg = TRUE, (void *)NULL)
+#define EMSG_RET_NULL(m) return (EMSG(m), rc_did_emsg = true, (void *)NULL)
 #define IEMSG_RET_NULL(m) return (IEMSG(m), rc_did_emsg = true, (void *)NULL)
-#define EMSG_RET_FAIL(m) return (EMSG(m), rc_did_emsg = TRUE, FAIL)
-#define EMSG2_RET_NULL(m, \
-                       c) return (EMSG2((m), \
-                                      (c) ? "" : "\\"), rc_did_emsg = true, \
-                                  (void *)NULL)
-#define EMSG2_RET_FAIL(m, \
-                       c) return (EMSG2((m), \
-                                      (c) ? "" : "\\"), rc_did_emsg = true, \
-                                  FAIL)
+#define EMSG_RET_FAIL(m) return (EMSG(m), rc_did_emsg = true, FAIL)
+#define EMSG2_RET_NULL(m, c) \
+        return (EMSG2((m), (c) ? "" : "\\"), rc_did_emsg = true, (void *)NULL)
+#define EMSG2_RET_FAIL(m, c) \
+        return (EMSG2((m), (c) ? "" : "\\"), rc_did_emsg = true, FAIL)
 #define EMSG_ONE_RET_NULL EMSG2_RET_NULL(_( \
         "E369: invalid item in %s%%[]"), reg_magic == MAGIC_ALL)
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -459,14 +459,15 @@ static int toggle_Magic(int x)
 /* Used for an error (down from) vim_regcomp(): give the error message, set
  * rc_did_emsg and return NULL */
 #define EMSG_RET_NULL(m) return (EMSG(m), rc_did_emsg = TRUE, (void *)NULL)
+#define IEMSG_RET_NULL(m) return (IEMSG(m), rc_did_emsg = true, (void *)NULL)
 #define EMSG_RET_FAIL(m) return (EMSG(m), rc_did_emsg = TRUE, FAIL)
 #define EMSG2_RET_NULL(m, \
                        c) return (EMSG2((m), \
-                                      (c) ? "" : "\\"), rc_did_emsg = TRUE, \
+                                      (c) ? "" : "\\"), rc_did_emsg = true, \
                                   (void *)NULL)
 #define EMSG2_RET_FAIL(m, \
                        c) return (EMSG2((m), \
-                                      (c) ? "" : "\\"), rc_did_emsg = TRUE, \
+                                      (c) ? "" : "\\"), rc_did_emsg = true, \
                                   FAIL)
 #define EMSG_ONE_RET_NULL EMSG2_RET_NULL(_( \
         "E369: invalid item in %s%%[]"), reg_magic == MAGIC_ALL)
@@ -1891,8 +1892,8 @@ static char_u *regatom(int *flagp)
   case Magic(')'):
     if (one_exactly)
       EMSG_ONE_RET_NULL;
-    EMSG_RET_NULL(_(e_internal));       /* Supposed to be caught earlier. */
-  /* NOTREACHED */
+    IEMSG_RET_NULL(_(e_internal));       // Supposed to be caught earlier.
+  // NOTREACHED
 
   case Magic('='):
   case Magic('?'):
@@ -4534,7 +4535,7 @@ regmatch (
             brace_max[no] = OPERAND_MAX(scan);
             brace_count[no] = 0;
           } else {
-            EMSG(_(e_internal));                    /* Shouldn't happen */
+            internal_error("BRACE_LIMITS");
             status = RA_FAIL;
           }
         }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -5355,7 +5355,7 @@ add_sound_suggest (
   // Find the word nr in the soundfold tree.
   sfwordnr = soundfold_find(slang, goodword);
   if (sfwordnr < 0) {
-    EMSG2(_(e_intern2), "add_sound_suggest()");
+    internal_error("add_sound_suggest()");
     return;
   }
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2096,8 +2096,8 @@ void undo_time(long step, int sec, int file, int absolute)
 
       uhp = uhp->uh_prev.ptr;
       if (uhp == NULL || uhp->uh_walk != mark) {
-        /* Need to redo more but can't find it... */
-        EMSG2(_(e_intern2), "undo_time()");
+        // Need to redo more but can't find it...
+        internal_error("undo_time()");
         break;
       }
     }
@@ -2163,8 +2163,8 @@ static void u_undoredo(int undo)
     if (top > curbuf->b_ml.ml_line_count || top >= bot
         || bot > curbuf->b_ml.ml_line_count + 1) {
       unblock_autocmds();
-      EMSG(_("E438: u_undo: line numbers wrong"));
-      changed();                /* don't want UNCHANGED now */
+      IEMSG(_("E438: u_undo: line numbers wrong"));
+      changed();                // don't want UNCHANGED now
       return;
     }
 
@@ -2655,7 +2655,7 @@ static void u_unch_branch(u_header_T *uhp)
 static u_entry_T *u_get_headentry(void)
 {
   if (curbuf->b_u_newhead == NULL || curbuf->b_u_newhead->uh_entry == NULL) {
-    EMSG(_("E439: undo list corrupt"));
+    IEMSG(_("E439: undo list corrupt"));
     return NULL;
   }
   return curbuf->b_u_newhead->uh_entry;
@@ -2684,11 +2684,11 @@ static void u_getbot(void)
     extra = curbuf->b_ml.ml_line_count - uep->ue_lcount;
     uep->ue_bot = uep->ue_top + uep->ue_size + 1 + extra;
     if (uep->ue_bot < 1 || uep->ue_bot > curbuf->b_ml.ml_line_count) {
-      EMSG(_("E440: undo line missing"));
-      uep->ue_bot = uep->ue_top + 1;        /* assume all lines deleted, will
-                                             * get all the old lines back
-                                             * without deleting the current
-                                             * ones */
+      IEMSG(_("E440: undo line missing"));
+      uep->ue_bot = uep->ue_top + 1;        // assume all lines deleted, will
+                                            // get all the old lines back
+                                            // without deleting the current
+                                            // ones
     }
 
     curbuf->b_u_newhead->uh_getbot_entry = NULL;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -1182,7 +1182,7 @@ static const int included_patches[] = {
   // 77 NA
   // 76 NA
   75,
-  // 74,
+  74,
   73,
   // 72 NA
   // 71 NA

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2115,7 +2115,7 @@ void win_close_othertab(win_T *win, int free_buf, tabpage_T *tp)
            ptp = ptp->tp_next)
         ;
       if (ptp == NULL) {
-        EMSG2(_(e_intern2), "win_close_othertab()");
+        internal_error("win_close_othertab()");
         return;
       }
       ptp->tp_next = tp->tp_next;


### PR DESCRIPTION
Problem:    Cannot make Vim fail on an internal error.
Solution:   Add IEMSG() and IEMSG2(). (Domenique Pelle)  Avoid reporting an
            internal error without mentioning where.

https://github.com/vim/vim/commit/95f096030ed1a8afea028f2ea295d6f6a70f466f

There is one special thing to consider while applying the patch. It makes it necessary to call `emsgf()` with an already prepared `va_list` from `iemsgf()` to avoid code duplication. Therefore I added `emsgfv()`, which takes an already prepared `va_list` and which is used in both, `emsgf()` and `iemsgf()` after preparing the `va_list`.

Any objections and comments?