### PR TITLE
[WIP] version.c: mark NA patches

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -931,10 +931,10 @@ static const int included_patches[] = {
   // 24 NA
   23,
   // 22 NA
-  // 21,
+  // 21 NA
   20,
   19,
-  // 18,
+  // 18 NA
   17,
   // 16 NA
   // 15 NA


### PR DESCRIPTION
vim-patch:8.0.0018: nvim does not use channels.
vim-patch:8.0.0021: nvim does not implement a GUI.