### PR TITLE
[RDY] vim-patch:8.0.0328

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1146,8 +1146,9 @@ EXTERN char_u e_winheight[] INIT(= N_(
 EXTERN char_u e_winwidth[] INIT(= N_(
         "E592: 'winwidth' cannot be smaller than 'winminwidth'"));
 EXTERN char_u e_write[] INIT(= N_("E80: Error while writing"));
-EXTERN char_u e_zerocount[] INIT(= N_("Zero count"));
-EXTERN char_u e_usingsid[] INIT(= N_("E81: Using <SID> not in a script context"));
+EXTERN char_u e_zerocount[] INIT(= N_("E939: Positive count required"));
+EXTERN char_u e_usingsid[] INIT(= N_(
+    "E81: Using <SID> not in a script context"));
 EXTERN char_u e_intern2[] INIT(= N_("E685: Internal error: %s"));
 EXTERN char_u e_maxmempat[] INIT(= N_(
         "E363: pattern uses more memory than 'maxmempattern'"));

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -624,7 +624,7 @@ static const int included_patches[] = {
   331,
   // 330,
   // 329,
-  // 328,
+  328,
   327,
   326,
   325,


### PR DESCRIPTION
Problem:    The "zero count" error doesn't have a number. (Hirohito Higashi)
Solution:   Give it a number and be more specific about the error.

https://github.com/vim/vim/commit/23a5558cfd860401aa694f0302d621887440f031