### PR TITLE
[RDY] vim-patch:8.0.0330

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3557,11 +3557,15 @@ extend:
       --start_lnum;
 
   if (VIsual_active) {
-    /* Problem: when doing "Vipipip" nothing happens in a single white
-     * line, we get stuck there.  Trap this here. */
-    if (VIsual_mode == 'V' && start_lnum == curwin->w_cursor.lnum)
+    // Problem: when doing "Vipipip" nothing happens in a single white
+    // line, we get stuck there.  Trap this here.
+    if (VIsual_mode == 'V' && start_lnum == curwin->w_cursor.lnum) {
       goto extend;
-    VIsual.lnum = start_lnum;
+    }
+    if (VIsual.lnum != start_lnum) {
+        VIsual.lnum = start_lnum;
+        VIsual.col = 0;
+    }
     VIsual_mode = 'V';
     redraw_curbuf_later(INVERTED);      /* update the inversion */
     showmode();

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -28,3 +28,10 @@ func Test_Visual_ctrl_o()
   set tw&
   bw!
 endfu
+
+func Test_Visual_vapo()
+  new
+  normal oxx
+  normal vapo
+  bwipe!
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -622,7 +622,7 @@ static const int included_patches[] = {
   // 333,
   // 332,
   331,
-  // 330,
+  330,
   // 329,
   // 328,
   327,


### PR DESCRIPTION
Problem:    Illegal memory access after "vapo". (Dominique Pelle)
Solution:   Fix the cursor column.

https://github.com/vim/vim/commit/84b2a381451e9068b09ef6d85f5e8cf1598e7355