### PR TITLE
ci/appveyor: debug failed 7z.exe in MINGW_32 build

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,4 +1,0 @@
-.DONE:
-	@echo "Please use GNU Make (gmake) to build neovim"
-.DEFAULT:
-	@echo "Please use GNU Make (gmake) to build neovim"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,5 +15,7 @@ cache:
 artifacts:
 - path: build/Neovim.zip
 - path: build/bin/nvim.exe
+init:
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 on_finish:
 - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,3 +15,5 @@ cache:
 artifacts:
 - path: build/Neovim.zip
 - path: build/bin/nvim.exe
+on_finish:
+- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))


### PR DESCRIPTION
**Update:** see support ticket: http://help.appveyor.com/discussions/problems/8193-build-cache-failure-7zexe-uncompress-error

 appveyor error:

```
Cache '.deps' - Unzipping...
Error uncompressing cache item: 7z.exe process has exited with code 2. 
Check C:\Users\appveyor\AppData\Local\Temp\1\build-cache-logs\69731fe8b0155899a53c5aabbdf609f8f85ff800.zip.001.log for details.
```