### PR TITLE
[RFC] screen: fix colorcolumn drawing order

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4038,7 +4038,7 @@ win_line (
         char_attr = hl_combine_attr(char_attr, win_hl_attr(wp, HLF_CUC));
       } else if (draw_color_col && VCOL_HLC == *color_cols) {
         vcol_save_attr = char_attr;
-        char_attr = hl_combine_attr(char_attr, win_hl_attr(wp, HLF_MC));
+        char_attr = hl_combine_attr(win_hl_attr(wp, HLF_MC), char_attr);
       }
     }
 


### PR DESCRIPTION
Reverse order of attributes, giving precedence to user-defined highlight
over ColorColumn.

Without this change, when character is covered by both ColorColumn and
user-defined highlight (e.g. for ExtraHighlight or search highlight),
then ColorColumn had precedence - which looks weird and in some cases
might hide information, that is important to user (e.g. highlighted
trailing whitespace).