### PR TITLE
Add support for has("wsl") to detect Windows Subsystem for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 if (CMAKE_HOST_SYSTEM_VERSION MATCHES ".*-Microsoft")
   # Detect WSL, which is also UNIX but not Windows/WIN32/WIN64
-  add_definitions(-DWSL)
+  add_definitions(-DNVIM_WSL)
 endif()
 
 if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   endif()
 endif()
 
+if (CMAKE_HOST_SYSTEM_VERSION MATCHES ".*-Microsoft")
+  # Detect WSL, which is also UNIX but not Windows/WIN32/WIN64
+  add_definitions(-DWSL)
+endif()
+
 if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   # Enable fixing case-insensitive filenames for Windows and Mac.
   set(USE_FNAME_CASE TRUE)

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8442,6 +8442,7 @@ win32			Windows version of Vim (32 or 64 bit).
 winaltkeys		Compiled with 'winaltkeys' option.
 windows			Compiled with support for more than one window.
 writebackup		Compiled with 'writebackup' default on.
+wsl			WSL version of Vim (Windows 10 Linux subsystem).
 
 							*string-match*
 Matching a pattern in a String

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10671,7 +10671,7 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     "windows",
     "winaltkeys",
     "writebackup",
-#if defined(WSL)
+#if defined(NVIM_WSL)
     "wsl",
 #endif
     "nvim",

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10671,6 +10671,9 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     "windows",
     "winaltkeys",
     "writebackup",
+#if defined(WSL)
+    "wsl",
+#endif
     "nvim",
   };
 

--- a/test/functional/eval/has_spec.lua
+++ b/test/functional/eval/has_spec.lua
@@ -57,4 +57,10 @@ describe('has()', function()
       eq(0, funcs.has("unnamedplus"))
     end
   end)
+
+  it('"wsl"', function()
+    if 1 == funcs.has('win32') or 1 == funcs.has('mac') then
+      eq(0, funcs.has('wsl'))
+    end
+  end)
 end)


### PR DESCRIPTION
Based on the value of `CMAKE_SYSTEM_VERSION` (which is the output of
`uname -r` where available), detect when running under WSL and define
a preprocessor variable WSL. Use that to set the feature flag `has("wsl")`.

Closes #7329