### PR TITLE
Make sure memchr doesn't get a NULL

### DIFF
--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -266,7 +266,7 @@ typval_T decode_string(const char *const s, const size_t len,
 {
   assert(s != NULL || len == 0);
   const bool really_hasnul = (hasnul == kNone
-                              ? memchr(s, NUL, len) != NULL
+                              ? ((s != NULL) && (memchr(s, NUL, len) != NULL))
                               : (bool)hasnul);
   if (really_hasnul) {
     list_T *const list = tv_list_alloc();


### PR DESCRIPTION
Clang complains because memchr has undefined behavior if the ptr is NULL, even if len==0. I added a check for NULL. Under the assumption that a reasonable memchr returns NULL if s is NULL the behavior should be unchanged.