### PR TITLE
[RFC] vim-patch:8.0.0142

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6825,8 +6825,6 @@ int hl_combine_attr(int char_attr, int prim_attr)
   if (char_aep != NULL) {
     // Copy all attributes from char_aep to the new entry
     new_en = *char_aep;
-  } else {
-    memset(&new_en, 0, sizeof(new_en));
   }
 
   spell_aep = syn_cterm_attr2entry(prim_attr);

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6827,6 +6827,9 @@ int hl_combine_attr(int char_attr, int prim_attr)
     new_en = *char_aep;
   } else {
     memset(&new_en, 0, sizeof(new_en));
+    new_en.rgb_fg_color = -1;
+    new_en.rgb_bg_color = -1;
+    new_en.rgb_sp_color = -1;
   }
 
   spell_aep = syn_cterm_attr2entry(prim_attr);

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -961,7 +961,7 @@ static const int included_patches[] = {
   // 145 NA
   // 144 NA
   143,
-  // 142,
+  142,
   // 141,
   // 140,
   // 139 NA


### PR DESCRIPTION
Problem:    Normal colors are wrong with 'termguicolors'.
Solution:   Initialize to INVALCOLOR instead of zero. (Ben Jackson, closes
            vim/vim#1344)

https://github.com/vim/vim/commit/0cdb72aa38c4a0140c94d56bf8bc17cb30260ebf