### PR TITLE
[RDY] :cquit to take an error code argument

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -138,13 +138,14 @@ processing a quickfix or location list command, it will be aborted.
 			current window is used instead of the quickfix list.
 
 							*:cq* *:cquit*
-:[count]cq[uit]		Quit Vim with an error code (When vim is called from 
-			another program, the caller might behave in a special way if the
-			error code is not 0; e.g. `git commit`, `fc` in bash, some
-			compilers.)
+:[count]cq[uit]		Quit Vim with an error code, or the code specified in
+			[count]. This may make a difference when Vim is called from
+			another program which needs editor: e.g. git commit will abort
+			the comitting process, fc (built-in from various shells including
+			bash and zsh) will not execute the command.
 			WARNING: All changes in files are lost, even when the [!] is not
 			used. It works like ":qall!" |:qall|, except that Vim returns a
-			non-zero exit code.
+			specific exit code.
 
 							*:cf* *:cfile*
 :cf[ile][!] [errorfile]	Read the error file and jump to the first error.

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -138,11 +138,12 @@ processing a quickfix or location list command, it will be aborted.
 			current window is used instead of the quickfix list.
 
 							*:cq* *:cquit*
-:cq[uit][!]		Quit Vim with an error code, so that the compiler
-			will not compile the same file again.
-			WARNING: All changes in files are lost!  Also when the
-			[!] is not used.  It works like ":qall!" |:qall|,
-			except that Vim returns a non-zero exit code.
+:cq[uit][!]		Quit Vim with an error code (When vim is called from
+			another program, the caller might behave in a special way if the
+			error code is not 0; e.g. `git commit`, `fc` in bash, some
+			compilers.) WARNING: All changes in files are lost, even when the
+			[!] is not used. It works like ":qall!" |:qall|, except that Vim
+			returns a non-zero exit code.
 
 							*:cf* *:cfile*
 :cf[ile][!] [errorfile]	Read the error file and jump to the first error.

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -138,12 +138,12 @@ processing a quickfix or location list command, it will be aborted.
 			current window is used instead of the quickfix list.
 
 							*:cq* *:cquit*
-:cq[uit][!]		Quit Vim with an error code (When vim is called from
-			another program, the caller might behave in a special way if the
-			error code is not 0; e.g. `git commit`, `fc` in bash, some
-			compilers.) WARNING: All changes in files are lost, even when the
-			[!] is not used. It works like ":qall!" |:qall|, except that Vim
-			returns a non-zero exit code.
+:cq[uit][!]		Quit Vim with an error code (When vim is called from another
+			program, the caller might behave in a special way if the error
+			code is not 0; e.g. `git commit`, `fc` in bash, some compilers.)
+			WARNING: All changes in files are lost, even when the [!] is not
+			used. It works like ":qall!" |:qall|, except that Vim returns a
+			non-zero exit code.
 
 							*:cf* *:cfile*
 :cf[ile][!] [errorfile]	Read the error file and jump to the first error.

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -138,9 +138,10 @@ processing a quickfix or location list command, it will be aborted.
 			current window is used instead of the quickfix list.
 
 							*:cq* *:cquit*
-:cq[uit][!]		Quit Vim with an error code (When vim is called from another
-			program, the caller might behave in a special way if the error
-			code is not 0; e.g. `git commit`, `fc` in bash, some compilers.)
+:[count]cq[uit]		Quit Vim with an error code (When vim is called from 
+			another program, the caller might behave in a special way if the
+			error code is not 0; e.g. `git commit`, `fc` in bash, some
+			compilers.)
 			WARNING: All changes in files are lost, even when the [!] is not
 			used. It works like ":qall!" |:qall|, except that Vim returns a
 			non-zero exit code.

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -614,7 +614,7 @@ return {
   },
   {
     command='cquit',
-    flags=bit.bor(TRLBAR, BANG),
+    flags=bit.bor(TRLBAR, BANG, WORD1),
     addr_type=ADDR_LINES,
     func='ex_cquit',
   },

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -614,7 +614,7 @@ return {
   },
   {
     command='cquit',
-    flags=bit.bor(TRLBAR, BANG, WORD1),
+    flags=bit.bor(RANGE, NOTADR, ZEROR, COUNT, TRLBAR),
     addr_type=ADDR_LINES,
     func='ex_cquit',
   },

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -614,7 +614,7 @@ return {
   },
   {
     command='cquit',
-    flags=bit.bor(RANGE, NOTADR, ZEROR, COUNT, TRLBAR),
+    flags=bit.bor(RANGE, NOTADR, COUNT, ZEROR, TRLBAR, BANG),
     addr_type=ADDR_LINES,
     func='ex_cquit',
   },

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <inttypes.h>
 
 #include "nvim/vim.h"
@@ -5995,14 +5996,7 @@ static void ex_quit(exarg_T *eap)
  */
 static void ex_cquit(exarg_T *eap)
 {
-  int exitval = eap->addr_count > 0 ? eap->line2 : 1;
-
-  // Exit status out of range.
-  if (exitval > 255) {
-    exitval = 255;
-  }
-
-  getout(exitval);
+  getout(eap->addr_count > 0 ? (int)eap->line2 : EXIT_FAILURE);
 }
 
 /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5995,11 +5995,11 @@ static void ex_quit(exarg_T *eap)
  */
 static void ex_cquit(exarg_T *eap)
 {
-  int exitval = atoi((const char *)eap->arg);
+  int exitval = eap->addr_count > 0 ? eap->line2 : 1;
 
-  // Default to non-zero exit code.
-  if (exitval == 0) {
-      exitval = 1;
+  // Exit status out of range.
+  if (exitval > 255) {
+      exitval = 255;
   }
 
   getout(exitval);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5995,7 +5995,14 @@ static void ex_quit(exarg_T *eap)
  */
 static void ex_cquit(exarg_T *eap)
 {
-  getout(1);
+  int exitval = atoi((const char *) eap->arg);
+
+  /* Default to non-zero exit code */
+  if (exitval == 0) {
+      exitval = 1;
+  }
+
+  getout(exitval);
 }
 
 /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5999,7 +5999,7 @@ static void ex_cquit(exarg_T *eap)
 
   // Exit status out of range.
   if (exitval > 255) {
-      exitval = 255;
+    exitval = 255;
   }
 
   getout(exitval);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5995,9 +5995,9 @@ static void ex_quit(exarg_T *eap)
  */
 static void ex_cquit(exarg_T *eap)
 {
-  int exitval = atoi((const char *) eap->arg);
+  int exitval = atoi((const char *)eap->arg);
 
-  /* Default to non-zero exit code */
+  // Default to non-zero exit code.
   if (exitval == 0) {
       exitval = 1;
   }

--- a/test/functional/core/exit_spec.lua
+++ b/test/functional/core/exit_spec.lua
@@ -71,10 +71,6 @@ describe(':cquit', function()
     test_cq('0 cquit', 0, nil)
   end)
 
-  it('exits with an out of range exit code after :cquit 258', function()
-    test_cq('cquit 258', 2, nil)
-  end)
-
   it('exits with redir msg for non-number exit code after :cquit X', function()
     test_cq('cquit X', nil, 'E488: Trailing characters: cquit X')
   end)

--- a/test/functional/core/exit_spec.lua
+++ b/test/functional/core/exit_spec.lua
@@ -2,8 +2,12 @@ local helpers = require('test.functional.helpers')(after_each)
 
 local command = helpers.command
 local eval = helpers.eval
-local eq, neq = helpers.eq, helpers.neq
+local eq = helpers.eq
 local run = helpers.run
+local funcs = helpers.funcs
+local nvim_prog = helpers.nvim_prog
+local redir_exec = helpers.redir_exec
+local wait = helpers.wait
 
 describe('v:exiting', function()
   local cid
@@ -29,43 +33,53 @@ describe('v:exiting', function()
     end
     run(on_request, nil, on_setup)
   end)
+end)
 
-  it('is non-zero after :cquit', function()
-    local function on_setup()
-      command('autocmd VimLeavePre * call rpcrequest('..cid..', "")')
-      command('autocmd VimLeave    * call rpcrequest('..cid..', "")')
-      command('cquit')
+describe(':cquit', function()
+  local function test_cq(cmdline, exit_code, redir_msg)
+    if redir_msg then
+      eq('\n' .. redir_msg, redir_exec(cmdline))
+      wait()
+      eq(1, eval('1'))  -- Check that Neovim did not crash or exit
+    else
+      funcs.system({nvim_prog, '-u', 'NONE', '-i', 'NONE', '--headless', '--cmd', cmdline})
+      eq(exit_code, eval('v:shell_error'))
     end
-    local function on_request()
-      neq(0, eval('v:exiting'))
-      return ''
-    end
-    run(on_request, nil, on_setup)
+  end
+
+  before_each(function()
+    helpers.clear()
   end)
 
-  it('is specified a non-zero exit code after :cquit', function()
-    local function on_setup()
-      command('autocmd VimLeavePre * call rpcrequest('..cid..', "")')
-      command('autocmd VimLeave    * call rpcrequest('..cid..', "")')
-      command('cquit 123')
-    end
-    local function on_request()
-      eq(123, eval('v:exiting'))
-      return ''
-    end
-    run(on_request, nil, on_setup)
+  it('exits with non-zero after :cquit', function()
+    test_cq('cquit', 1, nil)
   end)
 
-  it('is specified a zero exit code after :cquit', function()
-    local function on_setup()
-      command('autocmd VimLeavePre * call rpcrequest('..cid..', "")')
-      command('autocmd VimLeave    * call rpcrequest('..cid..', "")')
-      command('cquit 0')
-    end
-    local function on_request()
-      eq(0, eval('v:exiting'))
-      return ''
-    end
-    run(on_request, nil, on_setup)
+  it('exits with non-zero after :cquit 123', function()
+    test_cq('cquit 123', 123, nil)
+  end)
+
+  it('exits with non-zero after :123 cquit', function()
+    test_cq('123 cquit', 123, nil)
+  end)
+
+  it('exits with 0 after :cquit 0', function()
+    test_cq('cquit 0', 0, nil)
+  end)
+
+  it('exits with 0 after :0 cquit', function()
+    test_cq('0 cquit', 0, nil)
+  end)
+
+  it('exits with an out of range exit code after :cquit 258', function()
+    test_cq('cquit 258', 2, nil)
+  end)
+
+  it('exits with redir msg for non-number exit code after :cquit X', function()
+    test_cq('cquit X', nil, 'E488: Trailing characters: cquit X')
+  end)
+
+  it('exits with redir msg for negative exit code after :cquit -1', function()
+    test_cq('cquit -1', nil, 'E488: Trailing characters: cquit -1')
   end)
 end)

--- a/test/functional/core/exit_spec.lua
+++ b/test/functional/core/exit_spec.lua
@@ -43,4 +43,17 @@ describe('v:exiting', function()
     run(on_request, nil, on_setup)
   end)
 
+  it('is specified exit code after :cquit', function()
+    local function on_setup()
+      command('autocmd VimLeavePre * call rpcrequest('..cid..', "")')
+      command('autocmd VimLeave    * call rpcrequest('..cid..', "")')
+      command('cquit 123')
+    end
+    local function on_request()
+      eq(123, eval('v:exiting'))
+      return ''
+    end
+    run(on_request, nil, on_setup)
+  end)
+
 end)

--- a/test/functional/core/exit_spec.lua
+++ b/test/functional/core/exit_spec.lua
@@ -43,7 +43,7 @@ describe('v:exiting', function()
     run(on_request, nil, on_setup)
   end)
 
-  it('is specified exit code after :cquit', function()
+  it('is specified a non-zero exit code after :cquit', function()
     local function on_setup()
       command('autocmd VimLeavePre * call rpcrequest('..cid..', "")')
       command('autocmd VimLeave    * call rpcrequest('..cid..', "")')
@@ -56,4 +56,16 @@ describe('v:exiting', function()
     run(on_request, nil, on_setup)
   end)
 
+  it('is specified a zero exit code after :cquit', function()
+    local function on_setup()
+      command('autocmd VimLeavePre * call rpcrequest('..cid..', "")')
+      command('autocmd VimLeave    * call rpcrequest('..cid..', "")')
+      command('cquit 0')
+    end
+    local function on_request()
+      eq(0, eval('v:exiting'))
+      return ''
+    end
+    run(on_request, nil, on_setup)
+  end)
 end)

--- a/test/functional/core/exit_spec.lua
+++ b/test/functional/core/exit_spec.lua
@@ -71,6 +71,10 @@ describe(':cquit', function()
     test_cq('0 cquit', 0, nil)
   end)
 
+  it('exits with redir msg for multiple exit codes after :cquit 1 2', function()
+    test_cq('cquit 1 2', nil, 'E488: Trailing characters: cquit 1 2')
+  end)
+
   it('exits with redir msg for non-number exit code after :cquit X', function()
     test_cq('cquit X', nil, 'E488: Trailing characters: cquit X')
   end)


### PR DESCRIPTION
Enhance :cquit to take an error code argument #2699.

Update the `:cquit` command to take an error code argument. By default the exit code is still 1, but when an exit code is provided then Neovim will exit with the specified code.