### PR TITLE
Correct CTRL-K documentation

### DIFF
--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -373,8 +373,7 @@ CTRL-{char}	{char} typed as a control character; that is, typing {char}
 
 					*key-notation* *key-codes* *keycodes*
 These names for keys are used in the documentation.  They can also be used
-with the ":map" command (insert the key name by pressing CTRL-K and then the
-key you want the name for).
+with the ":map" command.
 
 notation	meaning		    equivalent	decimal value(s)	~
 -----------------------------------------------------------------------


### PR DESCRIPTION
CTRL-K does not insert the key-notation for all keys in the table.  CTRL-K actually uses the IS_SPECIAL(c) macro, which only identifies keys that correspond to ANSI escape sequences as "special".

I'm not actually sure about my interpretation of what IS_SPECIAL means, so maybe someone should check that, but the edit to the documentation is sensible even if IS_SPECIAL means something slightly different.