### PR TITLE
[RDY] vim-patch:8.0.0148

### DIFF
--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -734,16 +734,22 @@ static int cin_ispreproc(char_u *s)
   return FALSE;
 }
 
-/*
- * Return TRUE if line "*pp" at "*lnump" is a preprocessor statement or a
- * continuation line of a preprocessor statement.  Decrease "*lnump" to the
- * start and return the line in "*pp".
- */
-static int cin_ispreproc_cont(char_u **pp, linenr_T *lnump)
+///
+/// Return TRUE if line "*pp" at "*lnump" is a preprocessor statement or a/
+/// continuation line of a preprocessor statement.  Decrease "*lnump" to the
+/// start and return the line in "*pp".
+/// Put the amount of indent in "*amount".
+///
+static int cin_ispreproc_cont(char_u **pp, linenr_T *lnump, int *amount)
 {
   char_u      *line = *pp;
   linenr_T lnum = *lnump;
   int retval = FALSE;
+  int candidate_amount = *amount;
+
+  if (*line != NUL && line[STRLEN(line) - 1] == '\\') {
+    candidate_amount = get_indent_lnum(lnum);
+  }
 
   for (;; ) {
     if (cin_ispreproc(line)) {
@@ -758,8 +764,12 @@ static int cin_ispreproc_cont(char_u **pp, linenr_T *lnump)
       break;
   }
 
-  if (lnum != *lnump)
+  if (lnum != *lnump) {
     *pp = ml_get(*lnump);
+  }
+  if (retval) {
+    *amount = candidate_amount;
+  }
   return retval;
 }
 
@@ -1994,10 +2004,12 @@ int get_c_indent(void)
         amount = -1;
         for (lnum = cur_curpos.lnum - 1; lnum > our_paren_pos.lnum; --lnum) {
           l = skipwhite(ml_get(lnum));
-          if (cin_nocode(l))                    /* skip comment lines */
+          if (cin_nocode(l)) {                   // skip comment lines
             continue;
-          if (cin_ispreproc_cont(&l, &lnum))
-            continue;                           /* ignore #define, #if, etc. */
+          }
+          if (cin_ispreproc_cont(&l, &lnum, &amount)) {
+            continue;                           // ignore #define, #if, etc.
+          }
           curwin->w_cursor.lnum = lnum;
 
           /* Skip a comment or raw string. XXX */
@@ -2353,15 +2365,14 @@ int get_c_indent(void)
            * up with it.
            */
           if (curwin->w_cursor.lnum <= ourscope) {
-            /* we reached end of scope:
-             * if looking for an enum or structure initialization
-             * go further back:
-             * if it is an initializer (enum xxx or xxx =), then
-             * don't add ind_continuation, otherwise it is a variable
-             * declaration:
-             * int x,
-             *     here; <-- add ind_continuation
-             */
+            // We reached end of scope:
+            // If looking for a enum or structure initialization
+            // go further back:
+            // If it is an initializer (enum xxx or xxx =), then
+            // don't add ind_continuation, otherwise it is a variable
+            // declaration:
+            // int x,
+            //     here; <-- add ind_continuation
             if (lookfor == LOOKFOR_ENUM_OR_INIT) {
               if (curwin->w_cursor.lnum == 0
                   || curwin->w_cursor.lnum
@@ -2389,11 +2400,12 @@ int get_c_indent(void)
                 continue;
               }
 
-              /*
-               * Skip preprocessor directives and blank lines.
-               */
-              if (cin_ispreproc_cont(&l, &curwin->w_cursor.lnum))
+              //
+              // Skip preprocessor directives and blank lines.
+              //
+              if (cin_ispreproc_cont(&l, &curwin->w_cursor.lnum, &amount)) {
                 continue;
+              }
 
               if (cin_nocode(l))
                 continue;
@@ -2497,9 +2509,10 @@ int get_c_indent(void)
                   continue;
                 }
 
-                /* Skip preprocessor directives and blank lines. */
-                if (cin_ispreproc_cont(&l, &curwin->w_cursor.lnum))
+                // Skip preprocessor directives and blank lines.
+                if (cin_ispreproc_cont(&l, &curwin->w_cursor.lnum, &amount)) {
                   continue;
+                }
 
                 /* Finally the actual check for "namespace". */
                 if (cin_is_cpp_namespace(l)) {
@@ -2662,9 +2675,10 @@ int get_c_indent(void)
            * unlocked it)
            */
           l = get_cursor_line_ptr();
-          if (cin_ispreproc_cont(&l, &curwin->w_cursor.lnum)
-              || cin_nocode(l))
+          if (cin_ispreproc_cont(&l, &curwin->w_cursor.lnum, &amount)
+              || cin_nocode(l)) {
             continue;
+          }
 
           /*
            * Are we at the start of a cpp base class declaration or
@@ -3309,11 +3323,12 @@ term_again:
       break;
     }
 
-    /*
-     * Skip preprocessor directives and blank lines.
-     */
-    if (cin_ispreproc_cont(&l, &curwin->w_cursor.lnum))
+    //
+    // Skip preprocessor directives and blank lines.
+    //
+    if (cin_ispreproc_cont(&l, &curwin->w_cursor.lnum, &amount)) {
       continue;
+    }
 
     if (cin_nocode(l))
       continue;
@@ -3405,9 +3420,10 @@ term_again:
 
       while (curwin->w_cursor.lnum > 1) {
         look = ml_get(--curwin->w_cursor.lnum);
-        if (!(cin_nocode(look) || cin_ispreproc_cont(
-                &look, &curwin->w_cursor.lnum)))
+        if (!(cin_nocode(look)
+              || cin_ispreproc_cont(&look, &curwin->w_cursor.lnum, &amount))) {
           break;
+        }
       }
       if (curwin->w_cursor.lnum > 0
           && cin_ends_in(look, (char_u *)"}", NULL))

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -955,7 +955,7 @@ static const int included_patches[] = {
   // 151,
   150,
   149,
-  // 148,
+  148,
   147,
   146,
   // 145 NA

--- a/test/functional/legacy/003_cindent_spec.lua
+++ b/test/functional/legacy/003_cindent_spec.lua
@@ -4718,4 +4718,44 @@ describe('cindent', function()
       JSEND
       ]=])
   end)
+
+  it('start of define / vim-patch 8.0.0148', function()
+    insert_([=[
+
+      /* start of define */
+      {
+      }
+      #define AAA \
+      BBB\
+      CCC
+
+      #define CNT \
+      1 + \
+      2 + \
+      4
+      /* end of define */
+
+      ]=])
+
+    feed_command('set cino&')
+    feed_command('/start of define')
+    feed('=/end of define<cr>')
+
+    expect([=[
+
+      /* start of define */
+      {
+      }
+      #define AAA \
+          BBB\
+          CCC
+
+      #define CNT \
+          1 + \
+          2 + \
+          4
+      /* end of define */
+
+      ]=])
+  end)
 end)

--- a/test/functional/legacy/003_cindent_spec.lua
+++ b/test/functional/legacy/003_cindent_spec.lua
@@ -4718,4 +4718,44 @@ describe('cindent', function()
       JSEND
       ]=])
   end)
+
+  it('start of define / vim-patch 8.0.0148', function()
+    insert_([=[
+
+      /* start of define */
+      {
+      }
+      #define AAA \
+      BBB\
+      CCC
+
+      #define CNT \
+      1 + \
+      2 + \
+      4
+      /* end of define */
+
+      ]=])
+
+    feed_command('set cino&')
+    feed_command('/start of define')
+    feed('=/end of define<cr>')
+
+    expect([=[
+
+      /* start of define */
+      {
+      }
+      #define AAA \
+      	BBB\
+      	CCC
+
+      #define CNT \
+      	1 + \
+      	2 + \
+      	4
+      /* end of define */
+
+      ]=])
+  end)
 end)


### PR DESCRIPTION
Problem:    When a C preprocessor statement has two line continuations the
            following line does not have the right indent. (Ken Takata)
Solution:   Add the indent of the previous continuation line. (Hirohito
            Higashi)

https://github.com/vim/vim/commit/c6aa475a27e3ed1645446b014c32ebf68d005d49