### PR TITLE
[RFC] Fix location list updates.

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -951,11 +951,17 @@ static void mark_adjust_internal(linenr_T line1, linenr_T line2,
     one_adjust_nodel(&(curbuf->b_visual.vi_start.lnum));
     one_adjust_nodel(&(curbuf->b_visual.vi_end.lnum));
 
-    /* quickfix marks */
-    qf_mark_adjust(NULL, line1, line2, amount, amount_after);
-    /* location lists */
+    // quickfix marks
+    if (!qf_mark_adjust(NULL, line1, line2, amount, amount_after)) {
+      curbuf->b_has_qf_entry &= ~BUF_HAS_QF_ENTRY;
+    }
+    // location lists
+    bool found_one = false;
     FOR_ALL_TAB_WINDOWS(tab, win) {
-      qf_mark_adjust(win, line1, line2, amount, amount_after);
+      found_one |= qf_mark_adjust(win, line1, line2, amount, amount_after);
+    }
+    if (!found_one) {
+      curbuf->b_has_qf_entry &= ~BUF_HAS_LL_ENTRY;
     }
 
     sign_mark_adjust(line1, line2, amount, amount_after);

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2379,7 +2379,8 @@ static void qf_free(qf_info_T *qi, int idx)
 /*
  * qf_mark_adjust: adjust marks
  */
-void qf_mark_adjust(win_T *wp, linenr_T line1, linenr_T line2, long amount, long amount_after)
+bool qf_mark_adjust(win_T *wp, linenr_T line1, linenr_T line2, long amount,
+                    long amount_after)
 {
   int i;
   qfline_T    *qfp;
@@ -2389,11 +2390,12 @@ void qf_mark_adjust(win_T *wp, linenr_T line1, linenr_T line2, long amount, long
   int buf_has_flag = wp == NULL ? BUF_HAS_QF_ENTRY : BUF_HAS_LL_ENTRY;
 
   if (!(curbuf->b_has_qf_entry & buf_has_flag)) {
-    return;
+    return false;
   }
   if (wp != NULL) {
-    if (wp->w_llist == NULL)
-      return;
+    if (wp->w_llist == NULL) {
+      return false;
+    }
     qi = wp->w_llist;
   }
 
@@ -2414,9 +2416,7 @@ void qf_mark_adjust(win_T *wp, linenr_T line1, linenr_T line2, long amount, long
         }
       }
 
-  if (!found_one) {
-    curbuf->b_has_qf_entry &= ~buf_has_flag;
-  }
+  return found_one;
 }
 
 /*

--- a/test/functional/core/quickfix_spec.lua
+++ b/test/functional/core/quickfix_spec.lua
@@ -1,0 +1,31 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+describe('quickfix functionality', function()
+  before_each(function()
+    helpers.clear()
+  end)
+  it('Location list correctly updated when buffer modified', function()
+    helpers.source([[
+        new
+        setl bt=nofile
+        let lines = ['Line 1', 'Line 2', 'Line 3', 'Line 4', 'Line 5']
+        call append(0, lines)
+        new
+        setl bt=nofile
+        call append(0, lines)
+        let qf_item = {
+          \ 'lnum': 4,
+          \ 'text': "This is the error line.",
+          \ }
+        let qf_item['bufnr'] = bufnr('%')
+        call setloclist(0, [qf_item])
+        wincmd p
+        let qf_item['bufnr'] = bufnr('%')
+        call setloclist(0, [qf_item])
+        1del _
+        call append(0, ['New line 1', 'New line 2', 'New line 3'])
+        silent ll
+    ]])
+    helpers.eq({0, 6, 1, 0, 1}, helpers.funcs.getcurpos())
+  end)
+end)


### PR DESCRIPTION

[reproduce.txt](https://github.com/neovim/neovim/files/1347011/reproduce.txt)
Fix quickfix performance optimization which prevented quickfix items
from being updated when there were multiple windows with location lists
but the buffer with errors only in one of the lists.

Attached a script reproducing the issue.