### PR TITLE
[RFC] editorconfig: handle Vim help files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,10 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf_8
 
+[runtime/doc/*.txt]
+indent_style = tab
+indent_size = 8
+
 [Makefile]
 indent_style = tab
 tab_width = 4


### PR DESCRIPTION
Vim help files use tabs but editorconfig plugin sets the indentation to 2 spaces.
I don't know what the tab size should be so I reverted it to the defaults.
Not sure about `tab_width` because it sets `tabstop` only and leaves `shiftwidth` and `softtabstop` at 2. 