### PR TITLE
Stub ngettext when libintl isn't available

### DIFF
--- a/cmake/FindLibIntl.cmake
+++ b/cmake/FindLibIntl.cmake
@@ -46,6 +46,7 @@ check_c_source_compiles("
 
 int main(int argc, char** argv) {
   gettext(\"foo\");
+  ngettext(\"foo\", \"bar\", 1);
   bindtextdomain(\"foo\", \"bar\");
   bind_textdomain_codeset(\"foo\", \"bar\");
   textdomain(\"foo\");

--- a/src/nvim/gettext.h
+++ b/src/nvim/gettext.h
@@ -13,6 +13,7 @@
 #else
 # define _(x) ((char *)(x))
 # define N_(x) x
+# define ngettext(x, xs, n) ((n) == 1 ? (x) : (xs))
 # define bindtextdomain(x, y)  // empty
 # define bind_textdomain_codeset(x, y)  // empty
 # define textdomain(x)  // empty


### PR DESCRIPTION
This should have been included in #6547 as part of vim-patch:7.4.2152.

Closes #7352