### PR TITLE
[RFC] eval.c: Add ga_concat_esc function Issue#7256

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6742,15 +6742,13 @@ static void ga_concat_esc(garray_T *gap, char_u *str)
     char_u *p;
     char_u buf[NUMBUFLEN];
 
-    if (str == NULL)
-    {
+    if (str == NULL) {
 	ga_concat(gap, (char_u *)"NULL");
 	return;
     }
 
     for (p = str; *p != NUL; ++p)
-	switch (*p)
-	{
+	switch (*p) {
 	    case BS: ga_concat(gap, (char_u *)"\\b"); break;
 	    case ESC: ga_concat(gap, (char_u *)"\\e"); break;
 	    case FF: ga_concat(gap, (char_u *)"\\f"); break;
@@ -6759,12 +6757,10 @@ static void ga_concat_esc(garray_T *gap, char_u *str)
 	    case CAR: ga_concat(gap, (char_u *)"\\r"); break;
 	    case '\\': ga_concat(gap, (char_u *)"\\\\"); break;
 	    default:
-		if (*p < ' ')
-		{
+		if (*p < ' ') {
 		    vim_snprintf((char *)buf, NUMBUFLEN, "\\x%02x", *p);
 		    ga_concat(gap, buf);
-		}
-		else
+		} else
 		    ga_append(gap, *p);
 		break;
 	}

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6733,19 +6733,19 @@ static void prepare_assert_error(garray_T *gap)
   }
 }
 
-//Append "str" to "gap", escaping unprintable characters.
-//Changes NL to \n, CR to \r, etc.
+// Append "str" to "gap", escaping unprintable characters.
+// Changes NL to \n, CR to \r, etc.
 static void ga_concat_esc(garray_T *gap, char_u *str)
 {
   char_u *p;
   char_u buf[NUMBUFLEN];
-  
+
   if (str == NULL) {
     ga_concat(gap, (char_u *)"NULL");
     return;
   }
 
-  for (p = str; *p != NUL; ++p) {
+  for (p = str; *p != NUL; p++) {
     switch (*p) {
       case BS: ga_concat(gap, (char_u *)"\\b"); break;
       case ESC: ga_concat(gap, (char_u *)"\\e"); break;
@@ -6771,8 +6771,8 @@ static void fill_assert_error(garray_T *gap, typval_T *opt_msg_tv,
                               char_u *exp_str, typval_T *exp_tv,
                               typval_T *got_tv, assert_type_T atype)
 {
-  char_u *tofree; 
-  
+  char_u *tofree;
+
   if (opt_msg_tv->v_type != VAR_UNKNOWN) {
     tofree = (char_u *) encode_tv2string(opt_msg_tv, NULL);
     ga_concat(gap, tofree);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6733,56 +6733,14 @@ static void prepare_assert_error(garray_T *gap)
   }
 }
 
-// Fill "gap" with information about an assert error.
-static void fill_assert_error(garray_T *gap, typval_T *opt_msg_tv,
-                              char_u *exp_str, typval_T *exp_tv,
-                              typval_T *got_tv, assert_type_T atype)
-{
-  char_u *tofree;
-
-  if (opt_msg_tv->v_type != VAR_UNKNOWN) {
-    tofree = (char_u *) encode_tv2string(opt_msg_tv, NULL);
-    ga_concat(gap, tofree);
-    xfree(tofree);
-  } else {
-    if (atype == ASSERT_MATCH || atype == ASSERT_NOTMATCH) {
-      ga_concat(gap, (char_u *)"Pattern ");
-    } else if (atype == ASSERT_NOTEQUAL) {
-      ga_concat(gap, (char_u *)"Expected not equal to ");
-    } else {
-      ga_concat(gap, (char_u *)"Expected ");
-    }
-    if (exp_str == NULL) {
-      tofree = (char_u *) encode_tv2string(exp_tv, NULL);
-      ga_concat(gap, tofree);
-      xfree(tofree);
-    } else {
-      ga_concat(gap, exp_str);
-    }
-    if (atype != ASSERT_NOTEQUAL) {
-      if (atype == ASSERT_MATCH) {
-        ga_concat(gap, (char_u *)" does not match ");
-      } else if (atype == ASSERT_NOTMATCH) {
-        ga_concat(gap, (char_u *)" does match ");
-      } else {
-        ga_concat(gap, (char_u *)" but got ");
-      }
-      tofree = (char_u *)encode_tv2string(got_tv, NULL);
-      ga_concat(gap, tofree);
-      xfree(tofree);
-    }
-  }
-}
-
 /*
  * Append "str" to "gap", escaping unprintable characters.
  * Changes NL to \n, CR to \r, etc.
  */
-    static void
-ga_concat_esc(garray_T *gap, char_u *str)
+static void ga_concat_esc(garray_T *gap, char_u *str)
 {
-    char_u  *p;
-    char_u  buf[NUMBUFLEN];
+    char_u *p;
+    char_u buf[NUMBUFLEN];
 
     if (str == NULL)
     {
@@ -6810,6 +6768,47 @@ ga_concat_esc(garray_T *gap, char_u *str)
 		    ga_append(gap, *p);
 		break;
 	}
+}
+
+// Fill "gap" with information about an assert error.
+static void fill_assert_error(garray_T *gap, typval_T *opt_msg_tv,
+                              char_u *exp_str, typval_T *exp_tv,
+                              typval_T *got_tv, assert_type_T atype)
+{
+  char_u *tofree;
+
+  if (opt_msg_tv->v_type != VAR_UNKNOWN) {
+    tofree = (char_u *) encode_tv2string(opt_msg_tv, NULL);
+    ga_concat(gap, tofree);
+    xfree(tofree);
+  } else {
+    if (atype == ASSERT_MATCH || atype == ASSERT_NOTMATCH) {
+      ga_concat(gap, (char_u *)"Pattern ");
+    } else if (atype == ASSERT_NOTEQUAL) {
+      ga_concat(gap, (char_u *)"Expected not equal to ");
+    } else {
+      ga_concat(gap, (char_u *)"Expected ");
+    }
+    if (exp_str == NULL) {
+      tofree = (char_u *) encode_tv2string(exp_tv, NULL);
+      ga_concat_esc(gap, tofree);
+      xfree(tofree);
+    } else {
+      ga_concat_esc(gap, exp_str);
+    }
+    if (atype != ASSERT_NOTEQUAL) {
+      if (atype == ASSERT_MATCH) {
+        ga_concat(gap, (char_u *)" does not match ");
+      } else if (atype == ASSERT_NOTMATCH) {
+        ga_concat(gap, (char_u *)" does match ");
+      } else {
+        ga_concat(gap, (char_u *)" but got ");
+      }
+      tofree = (char_u *)encode_tv2string(got_tv, NULL);
+      ga_concat_esc(gap, tofree);
+      xfree(tofree);
+    }
+  }
 }
 
 // Add an assert error to v:errors.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6733,10 +6733,8 @@ static void prepare_assert_error(garray_T *gap)
   }
 }
 
-/*
- * Append "str" to "gap", escaping unprintable characters.
- * Changes NL to \n, CR to \r, etc.
- */
+//Append "str" to "gap", escaping unprintable characters.
+//Changes NL to \n, CR to \r, etc.
 static void ga_concat_esc(garray_T *gap, char_u *str)
 {
   char_u *p;
@@ -6746,7 +6744,7 @@ static void ga_concat_esc(garray_T *gap, char_u *str)
     ga_concat(gap, (char_u *)"NULL");
     return;
   }
-  
+
   for (p = str; *p != NUL; ++p) {
     switch (*p) {
       case BS: ga_concat(gap, (char_u *)"\\b"); break;
@@ -6773,8 +6771,8 @@ static void fill_assert_error(garray_T *gap, typval_T *opt_msg_tv,
                               char_u *exp_str, typval_T *exp_tv,
                               typval_T *got_tv, assert_type_T atype)
 {
-  char_u *tofree;
-
+  char_u *tofree; 
+  
   if (opt_msg_tv->v_type != VAR_UNKNOWN) {
     tofree = (char_u *) encode_tv2string(opt_msg_tv, NULL);
     ga_concat(gap, tofree);
@@ -6788,7 +6786,7 @@ static void fill_assert_error(garray_T *gap, typval_T *opt_msg_tv,
       ga_concat(gap, (char_u *)"Expected ");
     }
     if (exp_str == NULL) {
-      tofree = (char_u *) encode_tv2string(exp_tv, NULL);
+      tofree = (char_u *)encode_tv2string(exp_tv, NULL);
       ga_concat_esc(gap, tofree);
       xfree(tofree);
     } else {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6774,6 +6774,44 @@ static void fill_assert_error(garray_T *gap, typval_T *opt_msg_tv,
   }
 }
 
+/*
+ * Append "str" to "gap", escaping unprintable characters.
+ * Changes NL to \n, CR to \r, etc.
+ */
+    static void
+ga_concat_esc(garray_T *gap, char_u *str)
+{
+    char_u  *p;
+    char_u  buf[NUMBUFLEN];
+
+    if (str == NULL)
+    {
+	ga_concat(gap, (char_u *)"NULL");
+	return;
+    }
+
+    for (p = str; *p != NUL; ++p)
+	switch (*p)
+	{
+	    case BS: ga_concat(gap, (char_u *)"\\b"); break;
+	    case ESC: ga_concat(gap, (char_u *)"\\e"); break;
+	    case FF: ga_concat(gap, (char_u *)"\\f"); break;
+	    case NL: ga_concat(gap, (char_u *)"\\n"); break;
+	    case TAB: ga_concat(gap, (char_u *)"\\t"); break;
+	    case CAR: ga_concat(gap, (char_u *)"\\r"); break;
+	    case '\\': ga_concat(gap, (char_u *)"\\\\"); break;
+	    default:
+		if (*p < ' ')
+		{
+		    vim_snprintf((char *)buf, NUMBUFLEN, "\\x%02x", *p);
+		    ga_concat(gap, buf);
+		}
+		else
+		    ga_append(gap, *p);
+		break;
+	}
+}
+
 // Add an assert error to v:errors.
 static void assert_error(garray_T *gap)
 {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6739,31 +6739,33 @@ static void prepare_assert_error(garray_T *gap)
  */
 static void ga_concat_esc(garray_T *gap, char_u *str)
 {
-    char_u *p;
-    char_u buf[NUMBUFLEN];
-
-    if (str == NULL) {
-	ga_concat(gap, (char_u *)"NULL");
-	return;
+  char_u *p;
+  char_u buf[NUMBUFLEN];
+  
+  if (str == NULL) {
+    ga_concat(gap, (char_u *)"NULL");
+    return;
+  }
+  
+  for (p = str; *p != NUL; ++p) {
+    switch (*p) {
+      case BS: ga_concat(gap, (char_u *)"\\b"); break;
+      case ESC: ga_concat(gap, (char_u *)"\\e"); break;
+      case FF: ga_concat(gap, (char_u *)"\\f"); break;
+      case NL: ga_concat(gap, (char_u *)"\\n"); break;
+      case TAB: ga_concat(gap, (char_u *)"\\t"); break;
+      case CAR: ga_concat(gap, (char_u *)"\\r"); break;
+      case '\\': ga_concat(gap, (char_u *)"\\\\"); break;
+      default:
+        if (*p < ' ') {
+          vim_snprintf((char *)buf, NUMBUFLEN, "\\x%02x", *p);
+          ga_concat(gap, buf);
+        } else {
+          ga_append(gap, *p);
+        }
+        break;
     }
-
-    for (p = str; *p != NUL; ++p)
-	switch (*p) {
-	    case BS: ga_concat(gap, (char_u *)"\\b"); break;
-	    case ESC: ga_concat(gap, (char_u *)"\\e"); break;
-	    case FF: ga_concat(gap, (char_u *)"\\f"); break;
-	    case NL: ga_concat(gap, (char_u *)"\\n"); break;
-	    case TAB: ga_concat(gap, (char_u *)"\\t"); break;
-	    case CAR: ga_concat(gap, (char_u *)"\\r"); break;
-	    case '\\': ga_concat(gap, (char_u *)"\\\\"); break;
-	    default:
-		if (*p < ' ') {
-		    vim_snprintf((char *)buf, NUMBUFLEN, "\\x%02x", *p);
-		    ga_concat(gap, buf);
-		} else
-		    ga_append(gap, *p);
-		break;
-	}
+  }
 }
 
 // Fill "gap" with information about an assert error.


### PR DESCRIPTION
Add ga_concat_esc present in vim-patch: vim/vim@2368917