### PR TITLE
[RDY] vim-patch:8.0.0157

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5567,8 +5567,10 @@ bool syntax_present(win_T *win)
 
 
 static enum {
-  EXP_SUBCMD,       /* expand ":syn" sub-commands */
-  EXP_CASE          /* expand ":syn case" arguments */
+  EXP_SUBCMD,       // expand ":syn" sub-commands
+  EXP_CASE,         // expand ":syn case" arguments
+  EXP_SPELL,        // expand ":syn spell" arguments
+  EXP_SYNC          // expand ":syn sync" arguments
 } expand_what;
 
 /*
@@ -5612,6 +5614,10 @@ void set_context_in_syntax_cmd(expand_T *xp, const char *arg)
         xp->xp_context = EXPAND_NOTHING;
       } else if (STRNICMP(arg, "case", p - arg) == 0) {
         expand_what = EXP_CASE;
+      } else if (STRNICMP(arg, "spell", p - arg) == 0) {
+        expand_what = EXP_SPELL;
+      } else if (STRNICMP(arg, "sync", p - arg) == 0) {
+        expand_what = EXP_SYNC;
       } else if (STRNICMP(arg, "keyword", p - arg) == 0
                  || STRNICMP(arg, "region", p - arg) == 0
                  || STRNICMP(arg, "match", p - arg) == 0
@@ -5624,17 +5630,33 @@ void set_context_in_syntax_cmd(expand_T *xp, const char *arg)
   }
 }
 
-static char *(case_args[]) = {"match", "ignore", NULL};
-
 /*
  * Function given to ExpandGeneric() to obtain the list syntax names for
  * expansion.
  */
 char_u *get_syntax_name(expand_T *xp, int idx)
 {
-  if (expand_what == EXP_SUBCMD)
-    return (char_u *)subcommands[idx].name;
-  return (char_u *)case_args[idx];
+  switch (expand_what) {
+    case EXP_SUBCMD:
+        return (char_u *)subcommands[idx].name;
+    case EXP_CASE: {
+        static char *case_args[] = { "match", "ignore", NULL };
+        return (char_u *)case_args[idx];
+    }
+    case EXP_SPELL: {
+        static char *spell_args[] =
+        { "toplevel", "notoplevel", "default", NULL };
+        return (char_u *)spell_args[idx];
+    }
+    case EXP_SYNC: {
+        static char *sync_args[] =
+        { "ccomment", "clear", "fromstart",
+         "linebreaks=", "linecont", "lines=", "match",
+         "maxlines=", "minlines=", "region", NULL };
+        return (char_u *)sync_args[idx];
+    }
+  }
+  return NULL;
 }
 
 

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -76,3 +76,11 @@ func Test_syntax_after_reload()
   call assert_true(exists('g:gotit'))
   call delete('Xsomefile')
 endfunc
+
+func Test_syntax_completion()
+  call feedkeys(":syn spell \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"syn spell default notoplevel toplevel', @:)
+
+  call feedkeys(":syn sync \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"syn sync ccomment clear fromstart linebreaks= linecont lines= match maxlines= minlines= region', @:)
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -946,7 +946,7 @@ static const int included_patches[] = {
   // 160,
   159,
   158,
-  // 157,
+  157,
   156,
   // 155,
   // 154,


### PR DESCRIPTION
Problem:    No command line completion for ":syntax spell" and ":syntax sync".
Solution:   Implement the completion. (Dominique Pelle)

https://github.com/vim/vim/commit/2d02839050a2557bf36dab37ccd9f92168a757d1