### PR TITLE
[RFC] vim-patch:8.0.0160

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -943,7 +943,7 @@ static const int included_patches[] = {
   // 163 NA
   // 162 NA
   // 161 NA
-  // 160,
+  // 160 NA
   159,
   158,
   // 157,


### PR DESCRIPTION
Problem:    EMSG() is sometimes used for internal errors.
Solution:   Change them to IEMSG(). (Dominique Pelle)  And a few more.

https://github.com/vim/vim/commit/de33011ec623fd562419dede6bf465b5b9881a20


I don't know whether nvim can be abort on internal error.
Vim has `iemsg` and define macro ABORT_ON_INTERNAL_ERROR, but neovim does have these.
@justinmk 