### PR TITLE
hl-Syntax can override 'cursorline', 'cursorcolumn'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6747,19 +6747,19 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'winhighlight'* *'winhl'*
 'winhighlight' 'winhl'	string (default empty)
 			local to window
-	Window-local highlights.  Comma-delimited list of |group-name| pairs
-	"{hl-builtin}:{hl-group},..." where each {hl-builtin} is a group (from
-	|highlight-groups|) to be overridden by {hl-group} in the window where
-	this option was set.  Only builting ui highlights are supported, not
-	syntax highlighting.  For that purpose, use |:ownsyntax|.
+	Window-local highlights.  Comma-delimited list of highlight
+	|group-name| pairs "{hl-builtin}:{hl},..." where each {hl-builtin} is
+	a built-in |highlight-groups| item to be overridden by {hl} group in
+	the window.  Only built-in |highlight-groups| are supported, not
+	syntax highlighting (use |:ownsyntax| for that).
 	
-	Most highlights occuring within the frame of a window are supported.
 	Highlights of vertical separators are determined by the window to the
 	left of the separator.  The highlight of a tabpage in |tabline| is
-	determined by the last focused window in the tabpage.  Highlights of
+	determine by the last-focused window of the tabpage.  Highlights of
 	the popupmenu are determined by the current window.  Highlights in the
-	message area are not overridable.  Example for overriding the
-	backgrond color: >
+	message area cannot be overridden.
+
+	Example: show a different color for non-current windows: >
 		set winhighlight=Normal:MyNormal,NormalNC:MyNormalNC
 <
 			*'winfixheight'* *'wfh'* *'nowinfixheight'* *'nowfh'*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -280,6 +280,10 @@ other arguments if used).
 
 |input()| and |inputdialog()| support user-defined cmdline highlighting.
 
+Highlight groups:
+  |hl-ColorColumn|, |hl-CursorColumn| are lower priority than most other
+  groups
+
 ==============================================================================
 5. Missing legacy features				 *nvim-features-missing*
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -281,8 +281,8 @@ other arguments if used).
 |input()| and |inputdialog()| support user-defined cmdline highlighting.
 
 Highlight groups:
-  |hl-ColorColumn|, |hl-CursorColumn| are lower priority than most other
-  groups
+  |hl-ColorColumn|, |hl-CursorColumn|, |hl-CursorLine| are lower priority than
+  (overridden by) most other highlight groups.
 
 ==============================================================================
 5. Missing legacy features				 *nvim-features-missing*

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2202,6 +2202,7 @@ win_line (
   colnr_T trailcol = MAXCOL;            /* start of trailing spaces */
   int need_showbreak = false;           // overlong line, skip first x chars
   int line_attr = 0;                    // attribute for the whole line
+  int line_attr_low_priority = 0;       // current line, lowest priority
   matchitem_T *cur;                     // points to the match list
   match_T     *shl;                     // points to search_hl or a match
   int shl_flag;                         // flag to indicate whether search_hl
@@ -2427,10 +2428,17 @@ win_line (
     filler_lines = wp->w_topfill;
   filler_todo = filler_lines;
 
-  /* If this line has a sign with line highlighting set line_attr. */
+  // 'cursorline' highlighting for the current window.  Not when Visual mode is
+  // active, because it's not clear what is selected then.
+  if (wp->w_p_cul && lnum == wp->w_cursor.lnum
+      && !(wp == curwin && VIsual_active)) {
+    line_attr_low_priority = win_hl_attr(wp, HLF_CUL);
+  }
+
   v = buf_getsigntype(wp->w_buffer, lnum, SIGN_LINEHL);
-  if (v != 0)
-      line_attr = sign_get_attr((int)v, TRUE);
+  if (v != 0) {
+    line_attr = sign_get_attr((int)v, true);
+  }
 
   // Highlight the current line in the quickfix window.
   if (bt_quickfix(wp->w_buffer) && qf_current_entry(wp) == lnum) {
@@ -2441,7 +2449,7 @@ win_line (
     line_attr = hl_combine_attr(wp->w_hl_attr_normal, line_attr);
   }
 
-  if (line_attr != 0) {
+  if (line_attr_low_priority || line_attr) {
     area_highlighting = true;
   }
 
@@ -2661,20 +2669,6 @@ win_line (
     }
     if (shl != &search_hl && cur != NULL)
       cur = cur->next;
-  }
-
-  /* Cursor line highlighting for 'cursorline' in the current window.  Not
-   * when Visual mode is active, because it's not clear what is selected
-   * then. */
-  if (wp->w_p_cul && lnum == wp->w_cursor.lnum
-      && !(wp == curwin && VIsual_active)) {
-    if (line_attr != 0 && !(State & INSERT) && bt_quickfix(wp->w_buffer)
-        && qf_current_entry(wp) == lnum) {
-      line_attr = hl_combine_attr(win_hl_attr(wp, HLF_CUL), line_attr);
-    } else {
-      line_attr = win_hl_attr(wp, HLF_CUL);
-    }
-    area_highlighting = true;
   }
 
   off = (unsigned)(current_ScreenLine - ScreenLines);
@@ -3595,7 +3589,9 @@ win_line (
           // Display a '$' after the line or highlight an extra
           // character if the line break is included.
           // For a diff line the highlighting continues after the "$".
-          if (diff_hlf == (hlf_T)0 && line_attr == 0) {
+          if (diff_hlf == (hlf_T)0
+              && line_attr == 0
+              && line_attr_low_priority == 0) {
             // In virtualedit, visual selections may extend beyond end of line.
             if (area_highlighting && virtual_active()
                 && tocol != MAXCOL && vcol < tocol) {
@@ -3659,7 +3655,7 @@ win_line (
                      (col < wp->w_width))) {
           c = ' ';
           ptr--;  // put it back at the NUL
-        } else if ((diff_hlf != (hlf_T)0 || line_attr != 0)
+        } else if ((diff_hlf != (hlf_T)0 || line_attr_low_priority || line_attr)
                    && (wp->w_p_rl
                        ? (col >= 0)
                        : (col - boguscols < wp->w_width))) {
@@ -3671,7 +3667,8 @@ win_line (
           did_line_attr++;
 
           // don't do search HL for the rest of the line
-          if (line_attr != 0 && char_attr == search_attr && col > 0) {
+          if ((line_attr_low_priority || line_attr)
+              && char_attr == search_attr && col > 0) {
             char_attr = line_attr;
           }
           if (diff_hlf == HLF_TXD) {
@@ -4039,6 +4036,9 @@ win_line (
         char_attr = hl_combine_attr(win_hl_attr(wp, HLF_MC), char_attr);
       }
     }
+
+    // Apply `line_attr_low_priority` now, so that everthing can override it.
+    char_attr = hl_combine_attr(line_attr_low_priority, char_attr);
 
     /*
      * Store character to be displayed.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2201,16 +2201,16 @@ win_line (
   int change_end = -1;                  /* last col of changed area */
   colnr_T trailcol = MAXCOL;            /* start of trailing spaces */
   int need_showbreak = false;           // overlong line, skip first x chars
-  int line_attr = 0;                    /* attribute for the whole line */
-  matchitem_T *cur;                     /* points to the match list */
-  match_T     *shl;                     /* points to search_hl or a match */
-  int shl_flag;                         /* flag to indicate whether search_hl
-                                           has been processed or not */
-  int prevcol_hl_flag;                  /* flag to indicate whether prevcol
-                                           equals startcol of search_hl or one
-                                           of the matches */
-  int prev_c = 0;                       /* previous Arabic character */
-  int prev_c1 = 0;                      /* first composing char for prev_c */
+  int line_attr = 0;                    // attribute for the whole line
+  matchitem_T *cur;                     // points to the match list
+  match_T     *shl;                     // points to search_hl or a match
+  int shl_flag;                         // flag to indicate whether search_hl
+                                        // has been processed or not
+  int prevcol_hl_flag;                  // flag to indicate whether prevcol
+                                        // equals startcol of search_hl or one
+                                        // of the matches
+  int prev_c = 0;                       // previous Arabic character
+  int prev_c1 = 0;                      // first composing char for prev_c
   int did_line_attr = 0;
 
   bool search_attr_from_match = false;  // if search_attr is from :match
@@ -3594,15 +3594,13 @@ win_line (
                    && lcs_eol_one > 0) {
           // Display a '$' after the line or highlight an extra
           // character if the line break is included.
-          // For a diff line the highlighting continues after the
-          // "$".
+          // For a diff line the highlighting continues after the "$".
           if (diff_hlf == (hlf_T)0 && line_attr == 0) {
-            /* In virtualedit, visual selections may extend
-             * beyond end of line. */
+            // In virtualedit, visual selections may extend beyond end of line.
             if (area_highlighting && virtual_active()
-                && tocol != MAXCOL && vcol < tocol)
+                && tocol != MAXCOL && vcol < tocol) {
               n_extra = 0;
-            else {
+            } else {
               p_extra = at_end_str;
               n_extra = 1;
               c_extra = NUL;
@@ -4035,10 +4033,10 @@ win_line (
       if (wp->w_p_cuc && VCOL_HLC == (long)wp->w_virtcol
           && lnum != wp->w_cursor.lnum) {
         vcol_save_attr = char_attr;
-        char_attr = hl_combine_attr(char_attr, win_hl_attr(wp, HLF_CUC));
+        char_attr = hl_combine_attr(win_hl_attr(wp, HLF_CUC), char_attr);
       } else if (draw_color_col && VCOL_HLC == *color_cols) {
         vcol_save_attr = char_attr;
-        char_attr = hl_combine_attr(char_attr, win_hl_attr(wp, HLF_MC));
+        char_attr = hl_combine_attr(win_hl_attr(wp, HLF_MC), char_attr);
       }
     }
 

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -518,7 +518,7 @@ describe("'listchars' highlight", function()
     ]])
     feed_command('set cursorline')
     screen:expect([[
-      {2:^>-------.}{1:abcd}{2:.}{1:Lorem}{4:>}|
+      {2:^>-------.}{1:abcd}{2:.}{1:Lorem}{3:>}|
       {5:>-------.}abcd{5:*}{4:¬}     |
       {4:¬}                   |
       {4:~                   }|
@@ -526,7 +526,7 @@ describe("'listchars' highlight", function()
     ]])
     feed('$')
     screen:expect([[
-      {4:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
+      {3:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
       {4:<}                   |
       {4:<}                   |
       {4:~                   }|
@@ -607,7 +607,7 @@ describe("'listchars' highlight", function()
     feed('<esc>$')
     screen:expect([[
       {4:<}                   |
-      {4:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
+      {3:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
       {4:<}                   |
       {4:~                   }|
                           |


### PR DESCRIPTION
Rebase of #6380 

- Break out 'cursorcolumn'/'colorcolumn' change into a separate commit (so that the higher-risk change for 'cursorline' can be reverted if necessary)
- Document change in `vim_diff.txt`