### PR TITLE
[RFC] vim-patch:8.0.0183 NA

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -920,7 +920,7 @@ static const int included_patches[] = {
   186,
   // 185,
   // 184,
-  // 183,
+  // 183 NA
   182,
   181,
   // 180,


### PR DESCRIPTION
Problem:    Ubsan warns for using a pointer that is not aligned.
Solution:   First copy the address. (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/7173b47958a238bb07f80b8f26fb232b0ea69b4a


I think this patch should be NA

v@v:~/work/neovim$ `grep diff vim-8.0.0183.patch `
>diff --git a/src/nvim/channel.c b/src/nvim/channel.c
diff --git a/src/nvim/version.c b/src/nvim/version.c
