### PR TITLE
[RFC] save and restore clipboard batch status when entering cmdline window

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -5718,6 +5718,7 @@ static int ex_window(void)
 
   i = RedrawingDisabled;
   RedrawingDisabled = 0;
+  int save_count = save_batch_count();
 
   /*
    * Call the main loop until <CR> or CTRL-C is typed.
@@ -5726,6 +5727,7 @@ static int ex_window(void)
   normal_enter(true, false);
 
   RedrawingDisabled = i;
+  restore_batch_count(save_count);
 
   int save_KeyTyped = KeyTyped;
 

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -392,6 +392,13 @@ describe('clipboard', function()
       eq('---', eval('getreg("*")'))
     end)
 
+    it('works in the cmdline window', function()
+      feed('q:itext<esc>yy')
+      eq({{'text', ''}, 'V'}, eval("g:test_clip['*']"))
+      command("let g:test_clip['*'] = [['star'], 'c']")
+      feed('p')
+      eq('textstar', meths.get_current_line())
+    end)
   end)
 
   describe('clipboard=unnamedplus', function()


### PR DESCRIPTION
fixes #5544.

Quick fix, another solution would be to completely rewrite it to always to the unnamed yank just before going into blocking. But the proper solution would be to reimplement slow clipboard providers in lua. "some day" I will look into that for X11 again.