### PR TITLE
health.vim: check 'paste' option; fix highlighting

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -96,21 +96,21 @@ endfunction
 " Format a message for a specific report item
 function! s:format_report_message(status, msg, ...) abort " {{{
   let output = '  - ' . a:status . ': ' . s:indent_after_line1(a:msg, 4)
-  let suggestions = []
+  let advice = []
 
   " Optional parameters
   if a:0 > 0
-    let suggestions = type(a:1) == type("") ? [a:1] : a:1
-    if type(suggestions) != type([])
+    let advice = type(a:1) == type("") ? [a:1] : a:1
+    if type(advice) != type([])
       throw "Expected String or List"
     endif
   endif
 
   " Report each suggestion
-  if len(suggestions) > 0
+  if len(advice) > 0
     let output .= "\n    - ADVICE:"
   endif
-  for suggestion in suggestions
+  for suggestion in advice
     let output .= "\n      - " . s:indent_after_line1(suggestion, 10)
   endfor
 

--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -1,15 +1,15 @@
 function! s:enhance_syntax() abort
   syntax case match
 
-  syntax keyword healthError ERROR
+  syntax keyword healthError ERROR[:]
         \ containedin=markdownCodeBlock,mkdListItemLine
   highlight link healthError Error
 
-  syntax keyword healthWarning WARNING
+  syntax keyword healthWarning WARNING[:]
         \ containedin=markdownCodeBlock,mkdListItemLine
   highlight link healthWarning WarningMsg
 
-  syntax keyword healthSuccess SUCCESS
+  syntax keyword healthSuccess OK[:]
         \ containedin=markdownCodeBlock,mkdListItemLine
   highlight healthSuccess guibg=#5fff00 guifg=#080808 ctermbg=82 ctermfg=232
 
@@ -102,13 +102,13 @@ function! s:format_report_message(status, msg, ...) abort " {{{
   if a:0 > 0
     let suggestions = type(a:1) == type("") ? [a:1] : a:1
     if type(suggestions) != type([])
-      echoerr "Expected String or List"
+      throw "Expected String or List"
     endif
   endif
 
   " Report each suggestion
   if len(suggestions) > 0
-    let output .= "\n    - SUGGESTIONS:"
+    let output .= "\n    - ADVICE:"
   endif
   for suggestion in suggestions
     let output .= "\n      - " . s:indent_after_line1(suggestion, 10)
@@ -124,7 +124,7 @@ endfunction " }}}
 
 " Reports a successful healthcheck.
 function! health#report_ok(msg) abort " {{{
-  echo s:format_report_message('SUCCESS', a:msg)
+  echo s:format_report_message('OK', a:msg)
 endfunction " }}}
 
 " Reports a health warning.

--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -10,6 +10,12 @@ function! s:check_config() abort
           \ [ "Use the 'guicursor' option to configure cursor shape. :help 'guicursor'",
           \   'https://github.com/neovim/neovim/wiki/Following-HEAD#20170402' ])
   endif
+  if &paste
+    let ok = v:false
+    call health#report_error("'paste' is enabled. This option is only for pasting text.\nIt should not be set in your config.",
+          \ [ 'Remove `set paste` from your init.vim, if applicable.',
+          \   'Check `:verbose set paste?` to see if a plugin or script set the option.', ])
+  endif
 
   if ok
     call health#report_ok('no issues found')

--- a/runtime/doc/pi_health.txt
+++ b/runtime/doc/pi_health.txt
@@ -64,11 +64,11 @@ health#report_info({msg})				*health#report_info*
 health#report_ok({msg})					*health#report_ok*
 	Displays a "success" message.
 
-health#report_warn({msg}, [{suggestions}])		*health#report_warn*
-        Displays a warning. {suggestions} is an optional List of suggestions.
+health#report_warn({msg}, [{advice}])			*health#report_warn*
+        Displays a warning. {advice} is an optional List of suggestions.
 
-health#report_error({msg}, [{suggestions}])		*health#report_error*
-        Displays an error. {suggestions} is an optional List of suggestions.
+health#report_error({msg}, [{advice}])			*health#report_error*
+        Displays an error. {advice} is an optional List of suggestions.
 
 health#{plugin}#check()					*health.user_checker*
         This is the form of a healthcheck definition. Call the above functions

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
 local plugin_helpers = require('test.functional.plugin.helpers')
 
 local command = helpers.command
@@ -30,13 +31,13 @@ describe('health.vim', function()
 
 
       ## Check Bar
-        - SUCCESS: Bar status
-        - SUCCESS: Other Bar status
+        - OK: Bar status
+        - OK: Other Bar status
         - WARNING: Zub
 
       ## Baz
         - WARNING: Zim
-          - SUGGESTIONS:
+          - ADVICE:
             - suggestion 1
             - suggestion 2]]),
       result)
@@ -51,15 +52,15 @@ describe('health.vim', function()
         health#success1#check
         ========================================================================
         ## report 1
-          - SUCCESS: everything is fine
+          - OK: everything is fine
 
         ## report 2
-          - SUCCESS: nothing to see here
+          - OK: nothing to see here
 
         health#success2#check
         ========================================================================
         ## another 1
-          - SUCCESS: ok
+          - OK: ok
         ]])
     end)
 
@@ -73,6 +74,36 @@ describe('health.vim', function()
             function health#check[21]..health#broken#check, line 1
             caused an error
         ]])
+    end)
+
+    it("highlights OK, ERROR", function()
+      local screen = Screen.new(72, 10)
+      screen:attach()
+      screen:set_default_attr_ids({
+        Ok = { foreground = Screen.colors.Grey3, background = 6291200 },
+        Error = { foreground = Screen.colors.Grey100, background = Screen.colors.Red },
+      })
+      screen:set_default_attr_ignore({
+        Heading = { bold=true, foreground=Screen.colors.Magenta },
+        Heading2 = { foreground = Screen.colors.SlateBlue },
+        Bar = { foreground=Screen.colors.Purple },
+        Bullet = { bold=true, foreground=Screen.colors.Brown },
+      })
+      command("CheckHealth foo success1")
+      command("1tabclose")
+      command("set laststatus=0")
+      screen:expect([[
+        ^                                                                        |
+        health#foo#check                                                        |
+        ========================================================================|
+          - {Error:ERROR:} No healthcheck found for "foo" plugin.                       |
+                                                                                |
+        health#success1#check                                                   |
+        ========================================================================|
+        ## report 1                                                             |
+          - {Ok:OK:} everything is fine                                              |
+                                                                                |
+      ]])
     end)
 
     it("gracefully handles invalid healthcheck", function()


### PR DESCRIPTION
`:syntax keyword` is affected by 'iskeyword'. When we aligned
'iskeyword' to that of filetype=help, colon (:) is now included.
Simplest way to deal with this is to include colon (:) in the `:syntax
keyword` directive.

Also:
- change "SUGGESTIONS" mouthful to "ADVICE"
- change "SUCCESS" to "OK"