### PR TITLE
syntax: 'cursorline': revert priority change

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -281,8 +281,8 @@ other arguments if used).
 |input()| and |inputdialog()| support user-defined cmdline highlighting.
 
 Highlight groups:
-  |hl-ColorColumn|, |hl-CursorColumn|, |hl-CursorLine| are lower priority than
-  (overridden by) most other highlight groups.
+  |hl-ColorColumn|, |hl-CursorColumn| are lower priority than most other
+  groups
 
 ==============================================================================
 5. Missing legacy features				 *nvim-features-missing*

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2202,7 +2202,6 @@ win_line (
   colnr_T trailcol = MAXCOL;            /* start of trailing spaces */
   int need_showbreak = false;           // overlong line, skip first x chars
   int line_attr = 0;                    // attribute for the whole line
-  int line_attr_low_priority = 0;       // current line, lowest priority
   matchitem_T *cur;                     // points to the match list
   match_T     *shl;                     // points to search_hl or a match
   int shl_flag;                         // flag to indicate whether search_hl
@@ -2428,13 +2427,7 @@ win_line (
     filler_lines = wp->w_topfill;
   filler_todo = filler_lines;
 
-  // 'cursorline' highlighting for the current window.  Not when Visual mode is
-  // active, because it's not clear what is selected then.
-  if (wp->w_p_cul && lnum == wp->w_cursor.lnum
-      && !(wp == curwin && VIsual_active)) {
-    line_attr_low_priority = win_hl_attr(wp, HLF_CUL);
-  }
-
+  // If this line has a sign with line highlighting set line_attr.
   v = buf_getsigntype(wp->w_buffer, lnum, SIGN_LINEHL);
   if (v != 0) {
     line_attr = sign_get_attr((int)v, true);
@@ -2449,7 +2442,7 @@ win_line (
     line_attr = hl_combine_attr(wp->w_hl_attr_normal, line_attr);
   }
 
-  if (line_attr_low_priority || line_attr) {
+  if (line_attr != 0) {
     area_highlighting = true;
   }
 
@@ -2669,6 +2662,20 @@ win_line (
     }
     if (shl != &search_hl && cur != NULL)
       cur = cur->next;
+  }
+
+  // Cursor line highlighting for 'cursorline' in the current window.  Not
+  // when Visual mode is active, because it's not clear what is selected
+  // then.
+  if (wp->w_p_cul && lnum == wp->w_cursor.lnum
+      && !(wp == curwin && VIsual_active)) {
+    if (line_attr != 0 && !(State & INSERT) && bt_quickfix(wp->w_buffer)
+        && qf_current_entry(wp) == lnum) {
+      line_attr = hl_combine_attr(win_hl_attr(wp, HLF_CUL), line_attr);
+    } else {
+      line_attr = win_hl_attr(wp, HLF_CUL);
+    }
+    area_highlighting = true;
   }
 
   off = (unsigned)(current_ScreenLine - ScreenLines);
@@ -3589,9 +3596,7 @@ win_line (
           // Display a '$' after the line or highlight an extra
           // character if the line break is included.
           // For a diff line the highlighting continues after the "$".
-          if (diff_hlf == (hlf_T)0
-              && line_attr == 0
-              && line_attr_low_priority == 0) {
+          if (diff_hlf == (hlf_T)0 && line_attr == 0) {
             // In virtualedit, visual selections may extend beyond end of line.
             if (area_highlighting && virtual_active()
                 && tocol != MAXCOL && vcol < tocol) {
@@ -3655,7 +3660,7 @@ win_line (
                      (col < wp->w_width))) {
           c = ' ';
           ptr--;  // put it back at the NUL
-        } else if ((diff_hlf != (hlf_T)0 || line_attr_low_priority || line_attr)
+        } else if ((diff_hlf != (hlf_T)0 || line_attr != 0)
                    && (wp->w_p_rl
                        ? (col >= 0)
                        : (col - boguscols < wp->w_width))) {
@@ -3667,8 +3672,7 @@ win_line (
           did_line_attr++;
 
           // don't do search HL for the rest of the line
-          if ((line_attr_low_priority || line_attr)
-              && char_attr == search_attr && col > 0) {
+          if (line_attr != 0 && char_attr == search_attr && col > 0) {
             char_attr = line_attr;
           }
           if (diff_hlf == HLF_TXD) {
@@ -4036,9 +4040,6 @@ win_line (
         char_attr = hl_combine_attr(win_hl_attr(wp, HLF_MC), char_attr);
       }
     }
-
-    // Apply `line_attr_low_priority` now, so that everthing can override it.
-    char_attr = hl_combine_attr(line_attr_low_priority, char_attr);
 
     /*
      * Store character to be displayed.

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -518,7 +518,7 @@ describe("'listchars' highlight", function()
     ]])
     feed_command('set cursorline')
     screen:expect([[
-      {2:^>-------.}{1:abcd}{2:.}{1:Lorem}{3:>}|
+      {2:^>-------.}{1:abcd}{2:.}{1:Lorem}{4:>}|
       {5:>-------.}abcd{5:*}{4:¬}     |
       {4:¬}                   |
       {4:~                   }|
@@ -526,7 +526,7 @@ describe("'listchars' highlight", function()
     ]])
     feed('$')
     screen:expect([[
-      {3:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
+      {4:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
       {4:<}                   |
       {4:<}                   |
       {4:~                   }|
@@ -607,7 +607,7 @@ describe("'listchars' highlight", function()
     feed('<esc>$')
     screen:expect([[
       {4:<}                   |
-      {3:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
+      {4:<}{1:r}{2:.}{1:sit}{2:.}{1:ame^t}{3:¬}{1:        }|
       {4:<}                   |
       {4:~                   }|
                           |


### PR DESCRIPTION
ref #7383
reverts d1874ab2821d076397290cc154d87ec2dc352c79
ref #6380 

Does not revert https://github.com/neovim/neovim/commit/7a832c312f13bd6be9350952cdac3bd30613a824 ;  'cursorcolumn' and 'colorcolumn' _are_ still low-priority.