### PR TITLE
[RFC] defaults: 'fillchars'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2374,7 +2374,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Only normal file name characters can be used, "/\*?[|<>" are illegal.
 
 						*'fillchars'* *'fcs'*
-'fillchars' 'fcs'	string	(default "vert:|,fold:-")
+'fillchars' 'fcs'	string	(default "vert:│,fold:·")
 			global
 			{not available when compiled without the |+windows|
 			and |+folding| features}
@@ -2384,8 +2384,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  item		default		Used for ~
 	  stl:c		' ' or '^'	statusline of the current window
 	  stlnc:c	' ' or '='	statusline of the non-current windows
-	  vert:c	'|'		vertical separators |:vsplit|
-	  fold:c	'-'		filling 'foldtext'
+	  vert:c	'│'		vertical separators |:vsplit|
+	  fold:c	'·'		filling 'foldtext'
 	  diff:c	'-'		deleted lines of the 'diff' option
 
 	Any one that is omitted will fall back to the default.  For "stl" and
@@ -2393,7 +2393,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	otherwise.
 
 	Example: >
-	    :set fillchars=stl:^,stlnc:=,vert:\|,fold:-,diff:-
+	    :set fillchars=stl:^,stlnc:=,vert:│,fold:·,diff:-
 <	This is similar to the default, except that these characters will also
 	be used when there is highlighting.
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -973,8 +973,8 @@ EXTERN int lcs_conceal INIT(= ' ');
 /* Characters from 'fillchars' option */
 EXTERN int fill_stl INIT(= ' ');
 EXTERN int fill_stlnc INIT(= ' ');
-EXTERN int fill_vert INIT(= ' ');
-EXTERN int fill_fold INIT(= '-');
+EXTERN int fill_vert INIT(= 9474);  // │
+EXTERN int fill_fold INIT(= 183);   // ·
 EXTERN int fill_diff INIT(= '-');
 
 /* Whether 'keymodel' contains "stopsel" and "startsel". */

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -802,7 +802,7 @@ return {
       vi_def=true,
       redraw={'all_windows'},
       varname='p_fcs',
-      defaults={if_true={vi="vert:|,fold:-"}}
+      defaults={if_true={vi="vert:│,fold:·"}}
     },
     {
       full_name='fixendofline', abbreviation='fixeol',

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7194,7 +7194,7 @@ static int fillchar_vsep(win_T *wp, int *attr)
 {
   *attr = win_hl_attr(wp, HLF_C);
   if (*attr == 0 && fill_vert == ' ') {
-    return '|';
+    return 9474;  // default: "│"
   } else {
     return fill_vert;
   }


### PR DESCRIPTION
(Tests need to be updated, but I would like to hear any objections first.)

Most fonts should have these by now. Both are a significant visual
improvement.

- Vertical connecting bar `│` is used by tmux, pstree, etc. It also works in Windows 7 cmd.exe
  and nvim-qt.exe.
- Middle dot `·` works on Windows 7 cmd.exe, nvim-qt.exe.