### PR TITLE
help, man.vim: change "outline" map to gO

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -11,7 +11,7 @@ via |msgpack-rpc|, Lua and VimL (|eval-api|).
 
 Applications can also embed libnvim to work with the C API directly.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 API Types							   *api-types*

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -8,7 +8,7 @@ Automatic commands					*autocommand*
 
 For a basic explanation, see section |40.3| in the user manual.
 
-				      Type <M-]> to see the table of contents.
+				      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Introduction						*autocmd-intro*

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -11,7 +11,7 @@ commands with the "." command.
 
 For inserting text see |insert.txt|.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Deleting text					*deleting* *E470*

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -13,7 +13,7 @@ Command-line mode is used to enter Ex commands (":"), search patterns
 Basic command line editing is explained in chapter 20 of the user manual
 |usr_20.txt|.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Command-line editing					*cmdline-editing*

--- a/runtime/doc/debug.txt
+++ b/runtime/doc/debug.txt
@@ -9,7 +9,7 @@ Debugging Vim						*debug-vim*
 This is for debugging Vim itself, when it doesn't work properly.
 For debugging Vim scripts, functions, etc. see |debug-scripts|
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -11,7 +11,7 @@ Nvim is open source software.  Everybody is encouraged to contribute.
 
 See src/nvim/README.md for an overview of the source code.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 Design goals						*design-goals*

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -10,7 +10,7 @@ eight versions of the same file.
 
 The basics are explained in section |08.7| of the user manual.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Starting diff mode

--- a/runtime/doc/digraph.txt
+++ b/runtime/doc/digraph.txt
@@ -14,7 +14,7 @@ with CTRL-V (see |i_CTRL-V|).
 There is a brief introduction on digraphs in the user manual: |24.9|
 An alternative is using the 'keymap' option.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Defining digraphs					*digraphs-define*

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -6,7 +6,7 @@
 
 Editing files						*edit-files*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Introduction						*edit-intro*

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -12,7 +12,7 @@ Note: Expression evaluation can be disabled at compile time.  If this has been
 done, the features in this document are not available.	See |+eval| and
 |no-eval-feature|.
 
-				      Type <M-]> to see the table of contents.
+				      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Variables						*variables*

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -8,7 +8,7 @@ Filetypes						*filetype* *file-type*
 
 Also see |autocmd.txt|.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Filetypes					*filetypes* *file-types*
@@ -540,7 +540,7 @@ K or CTRL-]               Jump to the manpage for the <cWORD> under the
                           cursor. Takes a count for the section.
 CTRL-T                    Jump back to the location that the manpage was
                           opened from.
-META-]                    Show the manpage outline in the |location-list|.
+gO                        Show the manpage outline. |gO|
 q                         :quit if invoked as $MANPAGER, otherwise :close.
 
 Variables:

--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -9,7 +9,7 @@ Folding						*Folding* *folding* *folds*
 You can find an introduction on folding in chapter 28 of the user manual.
 |usr_28.txt|
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Fold methods					*fold-methods*

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -6,7 +6,7 @@
 
 Vim's Graphical User Interface				*gui* *GUI*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Starting the GUI				*gui-start* *E229* *E233*

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -6,7 +6,7 @@
 
 Help on help files					*helphelp*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Help commands					*online-help*
@@ -23,7 +23,7 @@ Help on help files					*helphelp*
 			The 'helplang' option is used to select a language, if
 			the main help file is available in several languages.
 
-			Type <M-]> to see the table of contents.
+			Type |gO| to see the table of contents.
 
 						*{subject}* *E149* *E661*
 :h[elp] {subject}	Like ":help", additionally jump to the tag {subject}.

--- a/runtime/doc/if_cscop.txt
+++ b/runtime/doc/if_cscop.txt
@@ -12,7 +12,7 @@ a cscope query is just like jumping to any tag; it is saved on the tag stack
 so that with the right keyboard mappings, you can jump back and forth between
 functions as you normally would with |tags|.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Cscope introduction					*cscope-intro*

--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -6,7 +6,7 @@
 
 Lua Interface to Nvim					*lua* *Lua*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Importing modules					*lua-require*

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -8,7 +8,7 @@ The Python Interface to Vim				*python* *Python*
 
 See |provider-python| for more information. {Nvim}
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Commands						*python-commands*

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -10,7 +10,7 @@ The Ruby Interface to Vim				*ruby* *Ruby*
 The home page for ruby is http://www.ruby-lang.org/.  You can find links for
 downloading Ruby there.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Commands						*ruby-commands*

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -6,7 +6,7 @@
 
 This file is about indenting C programs and other files.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Indenting C style programs				*C-indenting*

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -15,7 +15,7 @@ For an overview of built-in functions see |functions|.
 For a list of Vim variables see |vim-variable|.
 For a complete listing of all help items see |help-tags|.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Insert mode						*insert-index*

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -16,7 +16,7 @@ user manual |usr_24.txt|.
 Also see 'virtualedit', for moving the cursor to positions where there is no
 character.  Useful for editing a table.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Special keys						*ins-special-keys*

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -6,7 +6,7 @@
 
 Introduction to Vim					*ref* *reference*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Introduction						*intro*

--- a/runtime/doc/job_control.txt
+++ b/runtime/doc/job_control.txt
@@ -6,7 +6,7 @@
 
 Nvim's facilities for job control				  *job-control*
 
-				      Type <M-]> to see the table of contents.
+				      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Introduction						    *job-control-intro*

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -9,7 +9,7 @@ Key mapping, abbreviations and user-defined commands.
 This subject is introduced in sections |05.3|, |24.7| and |40.1| of the user
 manual.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Key mapping				*key-mapping* *mapping* *macro*

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -14,7 +14,7 @@ For an introduction to the most common features, see |usr_45.txt| in the user
 manual.
 For changing the language of messages and menus see |mlang.txt|.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 Getting started						*mbyte-first*

--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -8,7 +8,7 @@ This file contains an alphabetical list of messages and error messages that
 Vim produces.  You can use this if you don't understand what the message
 means.  It is not complete though.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Old messages			*:messages* *:mes* *message-history*

--- a/runtime/doc/mlang.txt
+++ b/runtime/doc/mlang.txt
@@ -11,7 +11,7 @@ multi-byte text see |multibyte|.
 
 The basics are explained in the user manual: |usr_45.txt|.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Messages						*multilang-messages*

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -26,7 +26,7 @@ The 'virtualedit' option can be set to make it possible to move the cursor to
 positions where there is no character or within a multi-column character (like
 a tab).
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Motions and operators				*operator*

--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -6,7 +6,7 @@
 
 RPC API for Nvim				     *RPC* *rpc* *msgpack-rpc*
 
-				      Type <M-]> to see the table of contents.
+				      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Introduction						            *rpc-intro*

--- a/runtime/doc/nvim.txt
+++ b/runtime/doc/nvim.txt
@@ -15,7 +15,7 @@ Nvim is emphatically a fork of Vim, not a clone: compatibility with Vim is
 maintained where possible. See |vim_diff.txt| for the complete reference of
 differences from Vim.
 
-				      Type <M-]> to see the table of contents.
+				      Type |gO| to see the table of contents.
 
 ==============================================================================
 Transitioning from Vim				*nvim-from-vim*

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -18,7 +18,7 @@ Terminal buffers behave like normal buffers, except:
   closing the terminal buffer.
 - 'bufhidden' defaults to "hide".
 
-				      Type <M-]> to see the table of contents.
+				      Type |gO| to see the table of contents.
 
 ==============================================================================
 Start						*terminal-start*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -14,7 +14,7 @@ achieve special effects.  These options come in three forms:
 	number		has a numeric value
 	string		has a string value
 
-				      Type <M-]> to see the table of contents.
+				      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Setting options					*set-option* *E764*

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -9,7 +9,7 @@ Patterns and search commands				*pattern-searches*
 The very basics can be found in section |03.9| of the user manual.  A few more
 explanations are in chapter 27 |usr_27.txt|.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Search commands				*search-commands*

--- a/runtime/doc/pi_health.txt
+++ b/runtime/doc/pi_health.txt
@@ -2,7 +2,7 @@
 
 Author: TJ DeVries <devries.timothyj@gmail.com>
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 Introduction				*healthcheck* *health.vim-intro*

--- a/runtime/doc/print.txt
+++ b/runtime/doc/print.txt
@@ -6,7 +6,7 @@
 
 Printing						*printing*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Introduction						*print-intro*

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -8,7 +8,7 @@ Providers	 						    *provider*
 
 Nvim delegates some features to dynamic "providers".
 
-				      Type <M-]> to see the table of contents.
+				      Type |gO| to see the table of contents.
 
 ==============================================================================
 Python integration		    	      *provider-python*

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -6,7 +6,7 @@
 
 This subject is introduced in section |30.1| of the user manual.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 =============================================================================
 1. Using QuickFix commands			*quickfix* *Quickfix* *E42*

--- a/runtime/doc/recover.txt
+++ b/runtime/doc/recover.txt
@@ -15,7 +15,7 @@ You can recover most of your changes from the files that Vim uses to store
 the contents of the file.  Mostly you can recover your work with one command:
 	vim -r filename
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. The swap file					*swap-file*

--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -6,7 +6,7 @@
 
 Vim client-server communication				*client-server*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Common functionality					*clientserver*

--- a/runtime/doc/remote_plugin.txt
+++ b/runtime/doc/remote_plugin.txt
@@ -6,7 +6,7 @@
 
 Nvim support for remote plugins 		  *remote-plugin*
 
-				      Type <M-]> to see the table of contents.
+				      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Introduction					    *remote-plugin-intro*

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -8,7 +8,7 @@ Repeating commands, Vim scripts and debugging			*repeating*
 
 Chapter 26 of the user manual introduces repeating |usr_26.txt|.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Single repeats					*single-repeat*

--- a/runtime/doc/russian.txt
+++ b/runtime/doc/russian.txt
@@ -6,7 +6,7 @@
 
 Russian language localization and support in Vim	   *russian* *Russian*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ===============================================================================
 1. Introduction							*russian-intro*

--- a/runtime/doc/scroll.txt
+++ b/runtime/doc/scroll.txt
@@ -16,7 +16,7 @@ upwards in the buffer, the text in the window moves downwards on your screen.
 
 See section |03.7| of the user manual for an introduction.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Scrolling downwards					*scroll-down*

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -7,7 +7,7 @@
 
 Sign Support Features				*sign-support*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Introduction					*sign-intro* *signs*

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -6,7 +6,7 @@
 
 Spell checking						*spell*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Quick start					*spell-quickstart* *E756*

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -6,7 +6,7 @@
 
 Starting Vim						*starting*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Vim arguments					*vim-arguments*

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -20,7 +20,7 @@ In the User Manual:
 |usr_06.txt| introduces syntax highlighting.
 |usr_44.txt| introduces writing a syntax file.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Quick start						*:syn-qstart*

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -10,7 +10,7 @@ The commands which have been added to use multiple tab pages are explained
 here.  Additionally, there are explanations for commands that work differently
 when used in combination with more than one tab page.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Introduction						*tab-page-intro*

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -8,7 +8,7 @@ Tags and special searches				*tags-and-searches*
 
 See section |29.1| of the user manual for an introduction.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Jump to a tag					*tag-commands*

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -10,7 +10,7 @@ Nvim (except in |--headless| mode) uses information about the terminal you are
 using to present a built-in UI.  If that information is not correct, the
 screen may be messed up or keys may not be recognized.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 Startup						*startup-terminal*

--- a/runtime/doc/tips.txt
+++ b/runtime/doc/tips.txt
@@ -13,7 +13,7 @@ http://www.vim.org
 Don't forget to browse the user manual, it also contains lots of useful tips
 |usr_toc.txt|.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 Editing C programs					*C-editing*

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -8,7 +8,7 @@ Undo and redo						*undo-redo*
 
 The basics are explained in section |02.5| of the user manual.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Undo and redo commands				*undo-commands*

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -6,7 +6,7 @@
 
 Various commands					*various*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Various commands					*various-cmds*
@@ -608,6 +608,13 @@ which it was defined is reported.
 			the keyword.  Only works when the highlighted text is
 			not more than one line.
 
+							*gO*
+gO			Show a filetype-specific, navigable "outline" of the
+			current buffer. For example, in a |help| buffer this
+			shows the table of contents.
+
+			Currently works in |help| and |:Man| buffers.
+
 [N]gs							*gs* *:sl* *:sleep*
 :[N]sl[eep] [N]	[m]	Do nothing for [N] seconds.  When [m] is included,
 			sleep for [N] milliseconds.  The count for "gs" always
@@ -646,4 +653,4 @@ LessInitFunc in your vimrc, for example: >
 	endfunc
 <
 
- vim:tw=78:ts=8:ft=help:norl:
+ vim:noet:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -6,7 +6,7 @@
 
 Differences between Vim and Vi				*vi-differences*
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Limits						*limits*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -9,7 +9,7 @@ Differences between Nvim and Vim			       *vim-differences*
 Nvim differs from Vim in many ways, big and small.  This document is
 a complete and centralized reference of those differences.
 
-				      Type <M-]> to see the table of contents.
+				      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Configuration					    *nvim-configuration*
@@ -100,7 +100,7 @@ by Nvim developers.
 
 FEATURES ~
 
-"Outline": Type <M-]> in |:Man| and |:help| pages to see a document outline.
+"Outline": Type |gO| in |:Man| and |:help| pages to see a document outline.
 
 |META| (ALT) chords are recognized, even in the terminal. Any |<M-| mapping
 will work. Some examples: <M-1>, <M-2>, <M-BS>, <M-Del>, <M-Ins>, <M-/>,

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -11,7 +11,7 @@ operator.  It is the only way to select a block of text.
 
 This is introduced in section |04.4| of the user manual.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Using Visual mode					*visual-use*

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -13,7 +13,7 @@ differently when used in combination with more than one window.
 The basics are explained in chapter 7 and 8 of the user manual |usr_07.txt|
 |usr_08.txt|.
 
-                                      Type <M-]> to see the table of contents.
+                                      Type |gO| to see the table of contents.
 
 ==============================================================================
 1. Introduction					*windows-intro* *window*

--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -90,7 +90,7 @@ if !exists('g:no_plugin_maps')
     let w:qf_toc = bufname
   endfunction
 
-  nnoremap <silent><buffer> <M-]> :call <sid>show_toc()<cr>
+  nnoremap <silent><buffer> gO :call <sid>show_toc()<cr>
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -31,7 +31,7 @@ setlocal nolist
 setlocal nofoldenable
 
 if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
-  nnoremap <silent> <buffer> <M-]>      :call man#show_toc()<CR>
+  nnoremap <silent> <buffer> gO         :call man#show_toc()<CR>
   nnoremap <silent> <buffer> <C-]>      :Man<CR>
   nnoremap <silent> <buffer> K          :Man<CR>
   nnoremap <silent> <buffer> <C-T>      :call man#pop_tag()<CR>


### PR DESCRIPTION
@ZyX-I pointed out that meta maps aren't good for many common keyboard layouts.

Also `gO` is a better mapping anyway.