### PR TITLE
:terminal highlight groups TermColorX

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6141,8 +6141,8 @@ int load_colors(char_u *name)
 /// When using ":hi clear" this is called recursively for each group with
 /// "forceit" and "init" both TRUE.
 /// @param init TRUE when called for initializing
-void
-do_highlight(char_u *line, int forceit, int init) {
+void do_highlight(char_u *line, int forceit, int init)
+{
   char_u      *name_end;
   char_u      *linep;
   char_u      *key_start;


### PR DESCRIPTION
Just a quick hack, seems to work well. Works for non-truecolor also.

If `TermColorX` highlight group is defined, `:terminal` will use that highlight group for color index `X`. E.g. since color index 4 seems to be used by bash for highlighting directories, this highlights as light blue:

    :hi TermColor4 ctermfg=lightblue

Wondering what @DarkDefender @teto @bfredl think about this. Specifically I'm wondering why we didn't do this before, and instead use the `g:terminal_color_` thing. And why does `g:terminal_color_` only work for truecolor?

@teto Somewhat related, I noticed Vim added a [color2index](https://github.com/vim/vim/blob/6daeef1933be68055aabe1d55f8467d46a707753/src/terminal.c#L1716) function which translates from RGB to cterm colors. IIRC we were looking for something like that for other purposes.

ref https://github.com/neovim/neovim/issues/4696
ref  #7018
fix https://github.com/neovim/neovim/issues/8301