### PR TITLE
Make "v:count" distinct from "count"

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1474,7 +1474,6 @@ v:count		The count given for the last Normal mode command.  Can be used
 		When there are two counts, as in "3d2w", they are multiplied,
 		just like what happens in the command, "d6w" for the example.
 		Also used for evaluating the 'formatexpr' option.
-		"count" also works, for backwards compatibility.
 
 					*v:count1* *count1-variable*
 v:count1	Just like "v:count", but defaults to one when no count is

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -298,6 +298,8 @@ Highlight groups:
   |hl-ColorColumn|, |hl-CursorColumn| are lower priority than most other
   groups
 
+The variable name "count" is no fallback for |v:count| anymore.
+
 ==============================================================================
 5. Missing legacy features				 *nvim-features-missing*
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -334,7 +334,7 @@ static struct vimvar {
   // VV_SEND_SERVER "servername"
   // VV_REG "register"
   // VV_OP "operator"
-  VV(VV_COUNT,          "count",            VAR_NUMBER, VV_COMPAT+VV_RO),
+  VV(VV_COUNT,          "count",            VAR_NUMBER, VV_RO),
   VV(VV_COUNT1,         "count1",           VAR_NUMBER, VV_RO),
   VV(VV_PREVCOUNT,      "prevcount",        VAR_NUMBER, VV_RO),
   VV(VV_ERRMSG,         "errmsg",           VAR_STRING, VV_COMPAT),

--- a/test/functional/eval/special_vars_spec.lua
+++ b/test/functional/eval/special_vars_spec.lua
@@ -168,4 +168,11 @@ describe('Special values', function()
       'Expected True but got v:null',
     }, meths.get_vvar('errors'))
   end)
+
+  describe('compat', function()
+    it('v:count is distinct from count', function()
+      command('let count = []') -- v:count is readonly
+      eq(1, eval('count is# g:["count"]'))
+    end)
+  end)
 end)


### PR DESCRIPTION
As discussed on Gitter. This is a a first experiment in removing the v:var compat feature (`v:count` == `count`) step-by-step.

The biggest issue in removing it entirely at once is that probably a lot of plugins still check for `version` instead of `v:version`, because c'n'p.

The rationale behind this commit is that it's likely for beginners to use a variable called `count` and being puzzled by the resulting readonly error message.