### PR TITLE
[RFC] vim-patch:8.0.0141

### DIFF
--- a/src/nvim/testdir/test_nested_function.vim
+++ b/src/nvim/testdir/test_nested_function.vim
@@ -48,6 +48,10 @@ func Recurse(count)
 endfunc
 
 func Test_max_nesting()
+  " TODO: why does this fail on Windows?  Runs out of stack perhaps?
+  if has('win32')
+    return
+  endif
   let call_depth_here = 2
   let ex_depth_here = 5
   set mfd&

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -962,7 +962,7 @@ static const int included_patches[] = {
   // 144 NA
   143,
   142,
-  // 141,
+  141,
   // 140,
   // 139 NA
   // 138 NA


### PR DESCRIPTION
Problem:    Nested function test fails on AppVeyor.
Solution:   Disable the test on Windows for now.

https://github.com/vim/vim/commit/269aec7e615b7710139a69a4c715dfe534aa3a1a