### PR TITLE
[RFC] Parse special keys (keycode, "<> name") as if unquoted

### DIFF
--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -834,7 +834,7 @@ char_u *replace_termcodes(const char_u *from, const size_t from_len,
       }
 
       slen = trans_special(&src, (size_t)(end - src) + 1, result + dlen, true,
-                           true);
+                           false);
       if (slen) {
         dlen += slen;
         continue;

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -625,9 +625,11 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
 
         // Modifier with single letter, or special key name.
         if (in_string && last_dash[1] == '\\' && last_dash[2] == '"') {
-          off = 2;
+          // Special case for a double-quoted string
+          off = l = 2;
+        } else {
+          l = mb_ptr2len(last_dash + 1);
         }
-        l = mb_ptr2len(last_dash + 1);
         if (modifiers != 0 && last_dash[l + 1] == '>') {
           key = PTR2CHAR(last_dash + off);
         } else {

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -188,7 +188,7 @@ size_t input_enqueue(String keys)
     uint8_t buf[6] = { 0 };
     unsigned int new_size
         = trans_special((const uint8_t **)&ptr, (size_t)(end - ptr), buf, true,
-                        true);
+                        false);
 
     if (new_size) {
       new_size = handle_mouse_event(&ptr, buf, new_size);

--- a/test/unit/keymap_spec.lua
+++ b/test/unit/keymap_spec.lua
@@ -1,0 +1,76 @@
+local helpers = require("test.unit.helpers")(after_each)
+local itp = helpers.gen_itp(it)
+
+local ffi     = helpers.ffi
+local eq      = helpers.eq
+local neq     = helpers.neq
+
+local keymap = helpers.cimport("./src/nvim/keymap.h")
+
+-- Get value of character in a string
+local byte = string.byte
+
+describe('keymap', function()
+
+  describe('find_special_key', function()
+    -- int find_special_key(const char_u **srcp, const size_t src_len,
+    --                      int *const modp, const bool keycode,
+    --                      const bool keep_x_key, const bool in_string)
+
+    local srcp = ffi.new('const unsigned char *[1]')
+    local modp = ffi.new('int[1]')
+
+    itp('Non-special character', function()
+      srcp[0] = 'abc'
+      eq(0, keymap.find_special_key(srcp, 3, modp, false, false, false))
+    end)
+
+    itp('Multiple modifiers', function()
+      srcp[0] = '<C-M-S-A>'
+      neq(0, keymap.find_special_key(srcp, 9, modp, false, false, false))
+      neq(0, modp[0])
+    end)
+
+    itp('Case insensitive', function()
+      -- Compare other capitalizations to this
+      srcp[0] = '<C-A>'
+      local all_caps_key =
+          keymap.find_special_key(srcp, 5, modp, false, false, false)
+      local all_caps_mod = modp[0]
+
+      srcp[0] = '<C-a>'
+      eq(all_caps_key,
+         keymap.find_special_key(srcp, 5, modp, false, false, false))
+      eq(all_caps_mod, modp[0])
+
+      srcp[0] = '<c-A>'
+      eq(all_caps_key,
+         keymap.find_special_key(srcp, 5, modp, false, false, false))
+      eq(all_caps_mod, modp[0])
+
+      srcp[0] = '<c-a>'
+      eq(all_caps_key,
+         keymap.find_special_key(srcp, 5, modp, false, false, false))
+      eq(all_caps_mod, modp[0])
+    end)
+
+    itp('Double quote in special character', function()
+      -- Unescaped with in_string = false
+      srcp[0] = '<C-">'
+      eq(byte('"'), keymap.find_special_key(srcp, 5, modp, false, false, false))
+
+      -- Unescaped with in_string = true
+      eq(0, keymap.find_special_key(srcp, 5, modp, false, false, true))
+
+      -- Escaped with in_string = false
+      srcp[0] = '<C-\\">'
+      -- This should fail as the key is invalid (more than 1 non-modifier
+      -- character).
+      eq(0, keymap.find_special_key(srcp, 6, modp, false, false, false))
+
+      -- Escaped with in_string = true
+      eq(byte('"'), keymap.find_special_key(srcp, 6, modp, false, false, true))
+    end)
+  end)
+
+end)


### PR DESCRIPTION
Special characters were always parsed as if inside double-quoted strings. I changed this in some places, though I am not entirely sure if this breaks anything else (if double quoted strings could be passed to the functions in those places).

Fixes #7410