### PR TITLE
[WIP] Enable more tests in Windows

### DIFF
--- a/test/functional/autocmd/termclose_spec.lua
+++ b/test/functional/autocmd/termclose_spec.lua
@@ -5,8 +5,8 @@ local clear, command, nvim, nvim_dir =
 local eval, eq, retry =
   helpers.eval, helpers.eq, helpers.retry
 local ok = helpers.ok
+local iswin = helpers.iswin
 
-if helpers.pending_win32(pending) then return end
 
 describe('TermClose event', function()
   before_each(function()
@@ -23,7 +23,7 @@ describe('TermClose event', function()
   end)
 
   it('triggers when long-running terminal job gets stopped', function()
-    nvim('set_option', 'shell', 'sh')
+    nvim('set_option', 'shell', iswin() and 'cmd.exe' or 'sh')
     command('autocmd TermClose * let g:test_termclose = 23')
     command('terminal')
     command('call jobstop(b:terminal_job_id)')
@@ -31,6 +31,7 @@ describe('TermClose event', function()
   end)
 
   it('kills job trapping SIGTERM', function()
+    if helpers.pending_win32(pending) then return end
     nvim('set_option', 'shell', 'sh')
     nvim('set_option', 'shellcmdflag', '-c')
     command([[ let g:test_job = jobstart('trap "" TERM && echo 1 && sleep 60', { ]]
@@ -48,6 +49,7 @@ describe('TermClose event', function()
   end)
 
   it('kills pty job trapping SIGHUP and SIGTERM', function()
+    if helpers.pending_win32(pending) then return end
     nvim('set_option', 'shell', 'sh')
     nvim('set_option', 'shellcmdflag', '-c')
     command([[ let g:test_job = jobstart('trap "" HUP TERM && echo 1 && sleep 60', { ]]

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -297,10 +297,6 @@ describe('jobs', function()
     eq({'notification', 'exit', {data, 0}}, next_msg())
   end)
 
-  it('can omit options', function()
-    ok(eval([[jobstart('echo ""')]]) > 0)
-  end)
-
   it('can omit data callbacks', function()
     nvim('command', 'unlet g:job_opts.on_stdout')
     nvim('command', 'let g:job_opts.user = 5')

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -188,8 +188,9 @@ describe('system()', function()
     end)
 
     it('`yes` and is interrupted with CTRL-C', function()
-      if helpers.pending_win32(pending) then return end
-      feed(':call system("yes")<cr>')
+      feed(':call system("' .. (iswin()
+        and 'for /L %I in (1,0,2) do @echo y'
+        or  'yes') .. '")<cr>')
       screen:expect([[
                                                              |
         ~                                                    |
@@ -204,8 +205,11 @@ describe('system()', function()
         ~                                                    |
         ~                                                    |
         ~                                                    |
-        :call system("yes")                                  |
-      ]])
+]] .. (iswin()
+        and [[
+        :call system("for /L %I in (1,0,2) do @echo y")      |]]
+        or  [[
+        :call system("yes")                                  |]]))
       feed('<c-c>')
       screen:expect([[
         ^                                                     |

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -8,8 +8,7 @@ local call = helpers.call
 local clear = helpers.clear
 local command = helpers.command
 local exc_exec = helpers.exc_exec
-
-if helpers.pending_win32(pending) then return end
+local pathsep = helpers.get_pathsep()
 
 -- These directories will be created for testing
 local directories = {
@@ -75,8 +74,8 @@ for _, cmd in ipairs {'cd', 'chdir'} do
         eq(0, lwd(globalwin, tabnr))
 
         -- Window with local dir reports as such
-        eq(globalDir .. '/' .. directories.window, cwd(localwin))
-        eq(globalDir .. '/' .. directories.window, cwd(localwin, tabnr))
+        eq(globalDir .. pathsep .. directories.window, cwd(localwin))
+        eq(globalDir .. pathsep .. directories.window, cwd(localwin, tabnr))
         eq(1, lwd(localwin))
         eq(1, lwd(localwin, tabnr))
 
@@ -86,7 +85,7 @@ for _, cmd in ipairs {'cd', 'chdir'} do
         eq(0, lwd(globalwin, tabnr))
 
         -- From new tab page, local window reports as such
-        eq(globalDir .. '/' .. directories.window, cwd(localwin, tabnr))
+        eq(globalDir .. pathsep .. directories.window, cwd(localwin, tabnr))
         eq(1, lwd(localwin, tabnr))
       end)
 
@@ -109,14 +108,14 @@ for _, cmd in ipairs {'cd', 'chdir'} do
         eq(0, lwd(-1, globaltab))
 
         -- new tab reports local
-        eq(globalDir .. '/' .. directories.tab, cwd(-1, 0))
-        eq(globalDir .. '/' .. directories.tab, cwd(-1, localtab))
+        eq(globalDir .. pathsep .. directories.tab, cwd(-1, 0))
+        eq(globalDir .. pathsep .. directories.tab, cwd(-1, localtab))
         eq(1, lwd(-1, 0))
         eq(1, lwd(-1, localtab))
 
         command('tabnext')
         -- From original tab page, local reports as such
-        eq(globalDir .. '/' .. directories.tab, cwd(-1, localtab))
+        eq(globalDir .. pathsep .. directories.tab, cwd(-1, localtab))
         eq(1, lwd(-1, localtab))
       end)
     end)
@@ -147,17 +146,17 @@ for _, cmd in ipairs {'cd', 'chdir'} do
         -- Create a new tab and change directory
         command('tabnew')
         command('silent t' .. cmd .. ' ' .. directories.tab)
-        eq(globalDir .. '/' .. directories.tab, tcwd())
+        eq(globalDir .. pathsep .. directories.tab, tcwd())
 
         -- Create a new tab and verify it has inherited the directory
         command('tabnew')
-        eq(globalDir .. '/' .. directories.tab, tcwd())
+        eq(globalDir .. pathsep .. directories.tab, tcwd())
 
         -- Change tab and change back, verify that directories are correct
         command('tabnext')
         eq(globalDir, tcwd())
         command('tabprevious')
-        eq(globalDir .. '/' .. directories.tab, tcwd())
+        eq(globalDir .. pathsep .. directories.tab, tcwd())
       end)
     end)
 
@@ -173,7 +172,7 @@ for _, cmd in ipairs {'cd', 'chdir'} do
 
       -- Change tab-local working directory and verify it is different
       command('silent t' .. cmd .. ' ' .. directories.tab)
-      eq(globalDir .. '/' .. directories.tab, cwd())
+      eq(globalDir .. pathsep .. directories.tab, cwd())
       eq(cwd(), tcwd())  -- working directory maches tab directory
       eq(1, tlwd())
       eq(cwd(), wcwd())  -- still no window-directory
@@ -183,16 +182,16 @@ for _, cmd in ipairs {'cd', 'chdir'} do
       command('new')
       eq(1, tlwd())  -- Still tab-local working directory
       eq(0, wlwd())  -- Still no window-local working directory
-      eq(globalDir .. '/' .. directories.tab, cwd())
+      eq(globalDir .. pathsep .. directories.tab, cwd())
       command('silent l' .. cmd .. ' ../' .. directories.window)
-      eq(globalDir .. '/' .. directories.window, cwd())
-      eq(globalDir .. '/' .. directories.tab, tcwd())
+      eq(globalDir .. pathsep .. directories.window, cwd())
+      eq(globalDir .. pathsep .. directories.tab, tcwd())
       eq(1, wlwd())
 
       -- Verify the first window still has the tab local directory
       command('wincmd w')
-      eq(globalDir .. '/' .. directories.tab,  cwd())
-      eq(globalDir .. '/' .. directories.tab, tcwd())
+      eq(globalDir .. pathsep .. directories.tab,  cwd())
+      eq(globalDir .. pathsep .. directories.tab, tcwd())
       eq(0, wlwd())  -- No window-local directory
 
       -- Change back to initial tab and verify working directory has stayed
@@ -203,10 +202,10 @@ for _, cmd in ipairs {'cd', 'chdir'} do
 
       -- Verify global changes don't affect local ones
       command('silent ' .. cmd .. ' ' .. directories.global)
-      eq(globalDir .. '/' .. directories.global, cwd())
+      eq(globalDir .. pathsep .. directories.global, cwd())
       command('tabnext')
-      eq(globalDir .. '/' .. directories.tab,  cwd())
-      eq(globalDir .. '/' .. directories.tab, tcwd())
+      eq(globalDir .. pathsep .. directories.tab,  cwd())
+      eq(globalDir .. pathsep .. directories.tab, tcwd())
       eq(0, wlwd())  -- Still no window-local directory in this window
 
       -- Unless the global change happened in a tab with local directory
@@ -220,9 +219,9 @@ for _, cmd in ipairs {'cd', 'chdir'} do
 
       -- But not in a window with its own local directory
       command('tabnext | wincmd w')
-      eq(globalDir .. '/' .. directories.window, cwd() )
+      eq(globalDir .. pathsep .. directories.window, cwd() )
       eq(0 , tlwd())
-      eq(globalDir .. '/' .. directories.window, wcwd())
+      eq(globalDir .. pathsep .. directories.window, wcwd())
     end)
   end)
 end
@@ -280,6 +279,10 @@ describe("getcwd()", function ()
   end)
 
   it("returns empty string if working directory does not exist", function()
+    if helpers.iswin() then
+      pending('[Cannot delete working directory in Windows]')
+      return
+    end
     command("cd "..directories.global)
     command("call delete('../"..directories.global.."', 'd')")
     eq("", helpers.eval("getcwd()"))

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -280,7 +280,6 @@ describe("getcwd()", function ()
 
   it("returns empty string if working directory does not exist", function()
     if helpers.iswin() then
-      pending('[Cannot delete working directory in Windows]')
       return
     end
     command("cd "..directories.global)

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -88,7 +88,6 @@ describe(':write', function()
     command('let $HOME=""')
     eq(funcs.fnamemodify('.', ':p:h'), funcs.fnamemodify('.', ':p:h:~'))
     -- Message from check_overwrite
-    -- FIXME: 'E13: File exists (add ! to override)' in Windows
     if not helpers.iswin() then
       eq(('\nE17: "'..funcs.fnamemodify('.', ':p:h')..'" is a directory'),
         redir_exec('write .'))

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -10,8 +10,6 @@ local feed_command = helpers.feed_command
 local funcs = helpers.funcs
 local meths = helpers.meths
 
-if helpers.pending_win32(pending) then return end
-
 local fname = 'Xtest-functional-ex_cmds-write'
 local fname_bak = fname .. '~'
 local fname_broken = fname_bak .. 'broken'
@@ -36,7 +34,11 @@ describe(':write', function()
   it('&backupcopy=auto preserves symlinks', function()
     command('set backupcopy=auto')
     write_file('test_bkc_file.txt', 'content0')
-    command("silent !ln -s test_bkc_file.txt test_bkc_link.txt")
+    if helpers.iswin() then
+      command("silent !mklink test_bkc_link.txt test_bkc_file.txt")
+    else
+      command("silent !ln -s test_bkc_file.txt test_bkc_link.txt")
+    end
     source([[
       edit test_bkc_link.txt
       call setline(1, ['content1'])
@@ -49,7 +51,11 @@ describe(':write', function()
   it('&backupcopy=no replaces symlink with new file', function()
     command('set backupcopy=no')
     write_file('test_bkc_file.txt', 'content0')
-    command("silent !ln -s test_bkc_file.txt test_bkc_link.txt")
+    if helpers.iswin() then
+      command("silent !mklink test_bkc_link.txt test_bkc_file.txt")
+    else
+      command("silent !ln -s test_bkc_file.txt test_bkc_link.txt")
+    end
     source([[
       edit test_bkc_link.txt
       call setline(1, ['content1'])
@@ -82,8 +88,11 @@ describe(':write', function()
     command('let $HOME=""')
     eq(funcs.fnamemodify('.', ':p:h'), funcs.fnamemodify('.', ':p:h:~'))
     -- Message from check_overwrite
-    eq(('\nE17: "'..funcs.fnamemodify('.', ':p:h')..'" is a directory'),
-       redir_exec('write .'))
+    -- FIXME: 'E13: File exists (add ! to override)' in Windows
+    if not helpers.iswin() then
+      eq(('\nE17: "'..funcs.fnamemodify('.', ':p:h')..'" is a directory'),
+        redir_exec('write .'))
+    end
     meths.set_option('writeany', true)
     -- Message from buf_write
     eq(('\nE502: "." is a directory'),
@@ -100,9 +109,16 @@ describe(':write', function()
     funcs.setfperm(fname, 'r--------')
     eq('Vim(write):E505: "Xtest-functional-ex_cmds-write" is read-only (add ! to override)',
        exc_exec('write'))
-    os.remove(fname)
-    os.remove(fname_bak)
+    if helpers.iswin() then
+      eq(0, os.execute('del /q/f ' .. fname))
+      eq(0, os.execute('rd /q/s ' .. fname_bak))
+    else
+      eq(true, os.remove(fname))
+      eq(true, os.remove(fname_bak))
+    end
     write_file(fname_bak, 'TTYX')
+    -- FIXME: exc_exec('write!') outputs 0 in Windows
+    if helpers.iswin() then return end
     lfs.link(fname_bak .. ('/xxxxx'):rep(20), fname, true)
     eq('Vim(write):E166: Can\'t open linked file for writing',
        exc_exec('write!'))

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -641,7 +641,7 @@ local function redir_exec(cmd)
 end
 
 local function get_pathsep()
-  return funcs.fnamemodify('.', ':p'):sub(-1)
+  return iswin() and '\\' or '/'
 end
 
 local function pathroot()

--- a/test/functional/legacy/011_autocommands_spec.lua
+++ b/test/functional/legacy/011_autocommands_spec.lua
@@ -18,10 +18,9 @@ local clear, feed_command, expect, eq, neq, dedent, write_file, feed =
   helpers.clear, helpers.feed_command, helpers.expect, helpers.eq, helpers.neq,
   helpers.dedent, helpers.write_file, helpers.feed
 
-if helpers.pending_win32(pending) then return end
-
 local function has_gzip()
-  return os.execute('gzip --help >/dev/null 2>&1') == 0
+  local null = helpers.iswin() and 'nul' or '/dev/null'
+  return os.execute('gzip --help >' .. null .. ' 2>&1') == 0
 end
 
 local function prepare_gz_file(name, text)
@@ -142,6 +141,7 @@ describe('file reading, writing and bufnew and filter autocommands', function()
   end)
 
   it('FilterReadPre, FilterReadPost', function()
+    if helpers.pending_win32(pending) then return end
     -- Write a special input file for this test block.
     write_file('test.out', dedent([[
       startstart

--- a/test/functional/legacy/030_fileformats_spec.lua
+++ b/test/functional/legacy/030_fileformats_spec.lua
@@ -5,8 +5,6 @@ local feed, clear, command = helpers.feed, helpers.clear, helpers.command
 local eq, write_file = helpers.eq, helpers.write_file
 local wait = helpers.wait
 
-if helpers.pending_win32(pending) then return end
-
 describe('fileformats option', function()
   setup(function()
     clear()

--- a/test/functional/legacy/051_highlight_spec.lua
+++ b/test/functional/legacy/051_highlight_spec.lua
@@ -8,8 +8,6 @@ local eq = helpers.eq
 local wait = helpers.wait
 local exc_exec = helpers.exc_exec
 
-if helpers.pending_win32(pending) then return end
-
 describe(':highlight', function()
   setup(clear)
 

--- a/test/functional/legacy/059_utf8_spell_checking_spec.lua
+++ b/test/functional/legacy/059_utf8_spell_checking_spec.lua
@@ -5,8 +5,6 @@ local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, feed_command, expect = helpers.clear, helpers.feed_command, helpers.expect
 local write_file, call = helpers.write_file, helpers.call
 
-if helpers.pending_win32(pending) then return end
-
 local function write_latin1(name, text)
   text = call('iconv', text, 'utf-8', 'latin-1')
   write_file(name, text)
@@ -507,8 +505,13 @@ describe("spell checking with 'encoding' set to utf-8", function()
   -- Vim function in the original legacy test.
   local function test_one(aff, dic)
     -- Generate a .spl file from a .dic and .aff file.
-    os.execute('cp -f Xtest'..aff..'.aff Xtest.aff')
-    os.execute('cp -f Xtest'..dic..'.dic Xtest.dic')
+    if helpers.iswin() then
+      os.execute('copy /y Xtest'..aff..'.aff Xtest.aff')
+      os.execute('copy /y Xtest'..dic..'.dic Xtest.dic')
+    else
+      os.execute('cp -f Xtest'..aff..'.aff Xtest.aff')
+      os.execute('cp -f Xtest'..dic..'.dic Xtest.dic')
+    end
     source([[
       set spellfile=
       function! SpellDumpNoShow()
@@ -559,7 +562,11 @@ describe("spell checking with 'encoding' set to utf-8", function()
     feed_command([[$put =soundfold('kóopërÿnôven')]])
     feed_command([[$put =soundfold('oeverloos gezwets edale')]])
     -- And now with SAL instead of SOFO items; test automatic reloading.
-    os.execute('cp -f Xtest-sal.aff Xtest.aff')
+    if helpers.iswin() then
+      os.execute('copy /y Xtest-sal.aff Xtest.aff')
+    else
+      os.execute('cp -f Xtest-sal.aff Xtest.aff')
+    end
     feed_command('mkspell! Xtest Xtest')
     feed_command([[$put =soundfold('goobledygoook')]])
     feed_command([[$put =soundfold('kóopërÿnôven')]])

--- a/test/functional/legacy/093_mksession_cursor_cols_latin1_spec.lua
+++ b/test/functional/legacy/093_mksession_cursor_cols_latin1_spec.lua
@@ -7,8 +7,6 @@ local helpers = require('test.functional.helpers')(after_each)
 local feed, insert = helpers.feed, helpers.insert
 local clear, feed_command, expect = helpers.clear, helpers.feed_command, helpers.expect
 
-if helpers.pending_win32(pending) then return end
-
 describe('store cursor position in session file in Latin-1', function()
   setup(clear)
 

--- a/test/functional/legacy/097_glob_path_spec.lua
+++ b/test/functional/legacy/097_glob_path_spec.lua
@@ -6,15 +6,19 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local command, expect = helpers.command, helpers.expect
 
-if helpers.pending_win32(pending) then return end
-
 describe('glob() and globpath()', function()
   setup(clear)
 
   setup(function()
-    os.execute("mkdir -p sautest/autoload")
-    os.execute("touch sautest/autoload/Test104.vim")
-    os.execute("touch sautest/autoload/footest.vim")
+    if helpers.iswin() then
+      os.execute("md sautest\\autoload")
+      os.execute(".>sautest\\autoload\\Test104.vim 2>nul")
+      os.execute(".>sautest\\autoload\\footest.vim 2>nul")
+    else
+      os.execute("mkdir -p sautest/autoload")
+      os.execute("touch sautest/autoload/Test104.vim")
+      os.execute("touch sautest/autoload/footest.vim")
+    end
   end)
 
   it('is working', function()
@@ -24,29 +28,55 @@ describe('glob() and globpath()', function()
     -- Consistent sorting of file names
     command('set nofileignorecase')
 
-    command([[$put =glob('Xxx\{')]])
-    command([[$put =glob('Xxx\$')]])
+    if helpers.iswin() then
+      command([[$put =glob('Xxx{')]])
+      command([[$put =glob('Xxx$')]])
 
-    command('silent w! Xxx{')
-    command([[w! Xxx\$]])
-    command([[$put =glob('Xxx\{')]])
-    command([[$put =glob('Xxx\$')]])
+      command('silent w! Xxx{')
+      command([[w! Xxx$]])
+      command([[$put =glob('Xxx{')]])
+      command([[$put =glob('Xxx$')]])
 
-    command("$put =string(globpath('sautest/autoload', '*.vim'))")
-    command("$put =string(globpath('sautest/autoload', '*.vim', 0, 1))")
-
-    expect([=[
-
+      command([[$put =string(globpath('sautest\autoload', '*.vim'))]])
+      command([[$put =string(globpath('sautest\autoload', '*.vim', 0, 1))]])
+      expect([=[
 
 
-      Xxx{
-      Xxx$
-      'sautest/autoload/Test104.vim
-      sautest/autoload/footest.vim'
-      ['sautest/autoload/Test104.vim', 'sautest/autoload/footest.vim']]=])
+
+        Xxx{
+        Xxx$
+        'sautest\autoload\Test104.vim
+        sautest\autoload\footest.vim'
+        ['sautest\autoload\Test104.vim', 'sautest\autoload\footest.vim']]=])
+    else
+      command([[$put =glob('Xxx\{')]])
+      command([[$put =glob('Xxx\$')]])
+
+      command('silent w! Xxx{')
+      command([[w! Xxx\$]])
+      command([[$put =glob('Xxx\{')]])
+      command([[$put =glob('Xxx\$')]])
+
+      command("$put =string(globpath('sautest/autoload', '*.vim'))")
+      command("$put =string(globpath('sautest/autoload', '*.vim', 0, 1))")
+      expect([=[
+
+
+
+        Xxx{
+        Xxx$
+        'sautest/autoload/Test104.vim
+        sautest/autoload/footest.vim'
+        ['sautest/autoload/Test104.vim', 'sautest/autoload/footest.vim']]=])
+    end
   end)
 
   teardown(function()
-    os.execute("rm -rf sautest Xxx{ Xxx$")
+    if helpers.iswin() then
+      os.execute('del /q/f Xxx{ Xxx$')
+      os.execute('rd /q sautest')
+    else
+      os.execute("rm -rf sautest Xxx{ Xxx$")
+    end
   end)
 end)

--- a/test/functional/legacy/107_adjust_window_and_contents_spec.lua
+++ b/test/functional/legacy/107_adjust_window_and_contents_spec.lua
@@ -8,8 +8,6 @@ local clear = helpers.clear
 local insert = helpers.insert
 local command = helpers.command
 
-if helpers.pending_win32(pending) then return end
-
 describe('107', function()
   setup(clear)
 

--- a/test/functional/legacy/arglist_spec.lua
+++ b/test/functional/legacy/arglist_spec.lua
@@ -4,8 +4,6 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear, command, eq = helpers.clear, helpers.command, helpers.eq
 local eval, exc_exec, neq = helpers.eval, helpers.exc_exec, helpers.neq
 
-if helpers.pending_win32(pending) then return end
-
 describe('argument list commands', function()
   before_each(clear)
 

--- a/test/functional/legacy/delete_spec.lua
+++ b/test/functional/legacy/delete_spec.lua
@@ -2,8 +2,6 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear, source = helpers.clear, helpers.source
 local eq, eval, command = helpers.eq, helpers.eval, helpers.command
 
-if helpers.pending_win32(pending) then return end
-
 describe('Test for delete()', function()
   before_each(clear)
 
@@ -48,7 +46,11 @@ describe('Test for delete()', function()
       split Xfile
       call setline(1, ['a', 'b'])
       wq
-      silent !ln -s Xfile Xlink
+      if has('win32')
+        silent !mklink Xlink Xfile
+      else
+        silent !ln -s Xfile Xlink
+      endif
     ]])
     -- Delete the link, not the file
     eq(0, eval("delete('Xlink')"))
@@ -58,7 +60,11 @@ describe('Test for delete()', function()
 
   it('symlink directory delete', function()
     command("call mkdir('Xdir1')")
-    command("silent !ln -s Xdir1 Xlink")
+    if helpers.iswin() then
+      command("silent !mklink /j Xlink Xdir1")
+    else
+      command("silent !ln -s Xdir1 Xlink")
+    end
     eq(1, eval("isdirectory('Xdir1')"))
     eq(1, eval("isdirectory('Xlink')"))
     -- Delete the link, not the directory
@@ -78,7 +84,11 @@ describe('Test for delete()', function()
       w Xdir3/subdir/Xfile
       w Xdir4/Xfile
       close
-      silent !ln -s ../Xdir4 Xdir3/Xlink
+      if has('win32')
+        silent !mklink /j Xdir3\Xlink Xdir4
+      else
+        silent !ln -s ../Xdir4 Xdir3/Xlink
+      endif
     ]])
 
     eq(1, eval("isdirectory('Xdir3')"))

--- a/test/functional/legacy/fixeol_spec.lua
+++ b/test/functional/legacy/fixeol_spec.lua
@@ -4,15 +4,14 @@ local helpers = require('test.functional.helpers')(after_each)
 local feed = helpers.feed
 local clear, feed_command, expect = helpers.clear, helpers.feed_command, helpers.expect
 
-if helpers.pending_win32(pending) then return end
-
 describe('fixeol', function()
   local function rmtestfiles()
-    os.remove('test.out')
-    os.remove('XXEol')
-    os.remove('XXNoEol')
-    os.remove('XXTestEol')
-    os.remove('XXTestNoEol')
+    feed_command('%bwipeout!')
+    feed_command('call delete("test.out")')
+    feed_command('call delete("XXEol")')
+    feed_command('call delete("XXNoEol")')
+    feed_command('call delete("XXTestEol")')
+    feed_command('call delete("XXTestNoEol")')
   end
   setup(function()
     clear()

--- a/test/functional/legacy/getcwd_spec.lua
+++ b/test/functional/legacy/getcwd_spec.lua
@@ -4,8 +4,6 @@ local helpers = require('test.functional.helpers')(after_each)
 local eq, eval, source = helpers.eq, helpers.eval, helpers.source
 local call, clear, command = helpers.call, helpers.clear, helpers.command
 
-if helpers.pending_win32(pending) then return end
-
 describe('getcwd', function()
   before_each(clear)
 

--- a/test/functional/legacy/packadd_spec.lua
+++ b/test/functional/legacy/packadd_spec.lua
@@ -9,17 +9,15 @@ local function expected_empty()
   eq({}, nvim.get_vvar('errors'))
 end
 
-if helpers.pending_win32(pending) then return end
-
 describe('packadd', function()
   before_each(function()
     clear()
 
     source([=[
       func SetUp()
-        let s:topdir = expand('%:p:h') . '/Xdir'
+        let s:topdir = expand(expand('%:p:h') . '/Xdir')
         exe 'set packpath=' . s:topdir
-        let s:plugdir = s:topdir . '/pack/mine/opt/mytest'
+        let s:plugdir = expand(s:topdir . '/pack/mine/opt/mytest')
       endfunc
 
       func TearDown()
@@ -52,8 +50,8 @@ describe('packadd', function()
         call assert_equal(77, g:plugin_also_works)
         call assert_true(17, g:ftdetect_works)
         call assert_true(len(&rtp) > len(rtp))
-        call assert_true(&rtp =~ (s:plugdir . '\($\|,\)'))
-        call assert_true(&rtp =~ (s:plugdir . '/after$'))
+        call assert_true(&rtp =~ (escape(s:plugdir, '\') . '\($\|,\)'))
+        call assert_true(&rtp =~ escape(expand(s:plugdir . '/after$'), '\'))
 
         " Check exception
         call assert_fails("packadd directorynotfound", 'E919:')
@@ -74,7 +72,7 @@ describe('packadd', function()
         packadd! mytest
 
         call assert_true(len(&rtp) > len(rtp))
-        call assert_true(&rtp =~ (s:plugdir . '\($\|,\)'))
+        call assert_true(&rtp =~ (escape(s:plugdir, '\') . '\($\|,\)'))
         call assert_equal(0, g:plugin_works)
 
         " check the path is not added twice
@@ -84,17 +82,18 @@ describe('packadd', function()
       endfunc
 
       func Test_packadd_symlink_dir()
-        if !has('unix')
-          return
-        endif
-        let top2_dir = s:topdir . '/Xdir2'
-        let real_dir = s:topdir . '/Xsym'
+        let top2_dir = expand(s:topdir . '/Xdir2')
+        let real_dir = expand(s:topdir . '/Xsym')
         call mkdir(real_dir, 'p')
-        exec "silent! !ln -s Xsym" top2_dir
-        let &rtp = top2_dir . ',' . top2_dir . '/after'
+        if has('win32')
+          exec "silent! !mklink /d" top2_dir "Xsym"
+        else
+          exec "silent! !ln -s Xsym" top2_dir
+        endif
+        let &rtp = top2_dir . ',' . expand(top2_dir . '/after')
         let &packpath = &rtp
 
-        let s:plugdir = top2_dir . '/pack/mine/opt/mytest'
+        let s:plugdir = expand(top2_dir . '/pack/mine/opt/mytest')
         call mkdir(s:plugdir . '/plugin', 'p')
 
         exe 'split ' . s:plugdir . '/plugin/test.vim'
@@ -105,7 +104,7 @@ describe('packadd', function()
         packadd mytest
 
         " Must have been inserted in the middle, not at the end
-        call assert_true(&rtp =~ '/pack/mine/opt/mytest,')
+        call assert_true(&rtp =~ escape(expand('/pack/mine/opt/mytest').',', '\'))
         call assert_equal(44, g:plugin_works)
 
         " No change when doing it again.
@@ -115,7 +114,7 @@ describe('packadd', function()
 
         set rtp&
         let rtp = &rtp
-        exec "silent !rm" top2_dir
+        exec "silent !" (has('win32') ? "rd /q/s" : "rm") top2_dir
       endfunc
 
       func Test_packloadall()

--- a/test/functional/legacy/wordcount_spec.lua
+++ b/test/functional/legacy/wordcount_spec.lua
@@ -6,8 +6,6 @@ local clear, command = helpers.clear, helpers.command
 local eq, eval = helpers.eq, helpers.eval
 local wait = helpers.wait
 
-if helpers.pending_win32(pending) then return end
-
 describe('wordcount', function()
   before_each(clear)
 

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -60,15 +60,14 @@ describe("'wildmenu'", function()
     command('set wildmenu wildmode=full')
     command('set scrollback=4')
     if iswin() then
-      helpers.set_shell_powershell()
-      feed([[:terminal for ($i = 1; $i -le 5000; $i++) {Write-Output foo foo foo; Start-Sleep -Milliseconds 100}<cr>]])
+      feed([[:terminal for /L \%I in (1,1,5000) do @(echo foo & echo foo & echo foo)<cr>]])
     else
       feed([[:terminal for i in $(seq 1 5000); do printf 'foo\nfoo\nfoo\n'; sleep 0.1; done<cr>]])
     end
 
     feed([[<C-\><C-N>gg]])
     feed([[:sign <Tab>]])   -- Invoke wildmenu.
-    screen:sleep(iswin() and 500 or 50) -- Allow some terminal output.
+    screen:sleep(50)        -- Allow some terminal output.
     screen:expect([[
       foo                      |
       foo                      |
@@ -80,7 +79,7 @@ describe("'wildmenu'", function()
     -- cmdline CTRL-D display should also be preserved.
     feed([[<C-\><C-N>]])
     feed([[:sign <C-D>]])   -- Invoke cmdline CTRL-D.
-    screen:sleep(iswin() and 500 or 50) -- Allow some terminal output.
+    screen:sleep(50)        -- Allow some terminal output.
     screen:expect([[
       :sign                    |
       define    place          |

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -60,15 +60,15 @@ describe("'wildmenu'", function()
     command('set wildmenu wildmode=full')
     command('set scrollback=4')
     if iswin() then
-      if helpers.pending_win32(pending) then return end
-      -- feed([[:terminal 1,2,3,4,5 | foreach-object -process {echo $_; sleep 0.1}]])
+      helpers.set_shell_powershell()
+      feed([[:terminal for ($i = 1; $i -le 5000; $i++) {Write-Output foo foo foo; Start-Sleep -Milliseconds 100}<cr>]])
     else
       feed([[:terminal for i in $(seq 1 5000); do printf 'foo\nfoo\nfoo\n'; sleep 0.1; done<cr>]])
     end
 
     feed([[<C-\><C-N>gg]])
     feed([[:sign <Tab>]])   -- Invoke wildmenu.
-    screen:sleep(50)        -- Allow some terminal output.
+    screen:sleep(iswin() and 500 or 50) -- Allow some terminal output.
     screen:expect([[
       foo                      |
       foo                      |
@@ -80,7 +80,7 @@ describe("'wildmenu'", function()
     -- cmdline CTRL-D display should also be preserved.
     feed([[<C-\><C-N>]])
     feed([[:sign <C-D>]])   -- Invoke cmdline CTRL-D.
-    screen:sleep(50)        -- Allow some terminal output.
+    screen:sleep(iswin() and 500 or 50) -- Allow some terminal output.
     screen:expect([[
       :sign                    |
       define    place          |


### PR DESCRIPTION
Unlike https://github.com/neovim/neovim/pull/7343, this PR focuses on tests only.

The following types of tests must be updated to work in Windows environment:
- any tests with hard dependency on Unix environment
  - Makefile
     - `/bin/sh` must resolve to an absolute path without spaces otherwise you get `shell returned 1` all over the place
  - oldtests that fail in Windows
    - anything that relies on `set shell=sh` because, unlike nvim, vim respects `$SHELL` on Windows and doesn't use `shellescape` in most tests by hardcoding the single quotes (WHY???)
       - in other words, all tests that rely on the shell and must be escaped will most likely fail on cmd.exe
    - test17.in
       - `gf` doesn't work for paths with spaces such as `C:\Program Files (x86)\nvim\share\nvim\runtime\defaults.vim`
       - maybe `set shellslash` breaks it since its shell defaults should be for cmd.exe
    - test32.in
       - infinite loop
       - broken TUI?
  - os.remove()
    - Os module relies on POSIX environment. Windows is not POSIX compatible. WSL doesn't count because the tests run in Appveyor.
    - does not work with directories and read-only files in Windows
      - try nvim's `delete`
    - `os.execute` in `helpers.do_rmdir` works in Windows. What about Unix? `rm -rf` hangs while cmd.exe's `rd` returns early.
  - LuaFileSystem (and other 3rd-party Lua modules)
    - must shim them to run os.execute internally or use VimL equivalents.
    - for anyone who want to use all of its API, just disable the test on Windows.
  - Unix programs like yes
    - replace programs with `cat -` and other shipped tools included in Windows zip
  - `/dev/null`
    - use `nul` in cmd.exe
    - use `$null` in powershell
  - xterm codes (what about winpty?)
- jobstart + jobsend/jobpid/jobclose (generally applies to channels)
   - ~~unreliable for `has('win64')`?~~ Unreliable for both but seems to be more flaky in win64.
   - ~~desync with cat.exe so testing is limited to jobstart only~~
   - `jobpid(jobstart(['cat', '-'))` is unreliable
- nested terminals (or nvim)
  - scrollback (?) issue
    - `feed(G)` and different expected screen output as workaround
  - `Data file mismatch - some data files may have been concurrently updated without locking support`
     - VimL issue with eval.c or terminal buffer updates?
  - ~~fails with `"-u NONE --cmd '" .. nvim_set .. "'"` (how?)~~ It's fine. I mixed up the shells in core/job_spec.lua
    - powershell supports single-quote escaping but it is incompatible with Unix shells
    - cmd.exe supports double-quote escaping and `^` for single character escaping. These two can be combined but it is tedious to escape the entire command this way. There is `sxe` and `sxq` but they don't work well with `shellescape` because 1 mishandled double quote can ruin the entire command.
- screen highlight
  - Any background/foreground color beyond the default 16 colors is hit-or-miss.
- autocmd + (terminal or jobstart)
  - possible race condition
- errors for opening a directory
  - Vim outputs the expected message from the shortmess test
  - Neovim attempts to edit it (?) and gets read errors.
- VimL delete()
  - do not use with working directories in Windows
- `FileWriteCmd`
  - `E13` in Windows
  - reproduced in Vim 8.0.1123 (bug-vim?)
- Viml mkdir()
  - cannot handle directory junctions on  Windows so use directory symlinks  with `mklink /d`
     - directory symlinks require elevated access, directory junctions do not
- build exits early when testing providers (ex. ruby, node) in Windows
  - see https://github.com/neovim/neovim/pull/7412#issuecomment-347750371


I don't know why the Appveyor builds hang when I use `helpers.get_pathsep()` so I hardcode the value of `pathsep` local variable in tests that check filepaths such as test/functional/ex_cmds/cd_spec.lua

~~To minimize diffs, I use `set fileformat=unix` or the `++opt` variant.~~ `\r\n` as eol in Windows is enough for shada on BufWriteCmd, FileAppendCmd, and FileWriteCmd. For some reason, `:w!` is required in FileWriteCmd after os.remove in before_each() and teardown().

~~For some reason, nvim does not kill a parallel process created via  `start /b cmd /s/c "<command>"`, where `<command>` is the user's command entered in a cmd.exe session. `/b` is for not creating a new window. If `start /min` for a minimized new window doesn't work out, then I'll try powershell's `Start-Job` or `Start-Process` since `core/job_spec.lua` defaults to powershell anyway.~~ It works for MINGW_32.