### PR TITLE
[RFC] bufhl: support creating new groups

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -793,7 +793,11 @@ Integer nvim_buf_add_highlight(Buffer buffer,
     col_end = MAXCOL;
   }
 
-  int hlg_id = syn_name2id((char_u *)(hl_group.data ? hl_group.data : ""));
+  int hlg_id = 0;
+  if (hl_group.size > 0) {
+    hlg_id = syn_check_group((char_u *)hl_group.data, (int)hl_group.size);
+  }
+
   src_id = bufhl_add_hl(buf, (int)src_id, hlg_id, (linenr_T)line+1,
                         (colnr_T)col_start+1, (colnr_T)col_end);
   return src_id;

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -24,7 +24,8 @@ describe('Buffer highlighting', function()
       [6] = {foreground = Screen.colors.DarkCyan}, -- Identifier
       [7] = {bold = true},
       [8] = {underline = true, bold = true, foreground = Screen.colors.SlateBlue},
-      [9] = {foreground = Screen.colors.SlateBlue, underline = true}
+      [9] = {foreground = Screen.colors.SlateBlue, underline = true},
+      [10] = {foreground = Screen.colors.Red}
     })
     curbuf = request('nvim_get_current_buf')
   end)
@@ -246,6 +247,34 @@ describe('Buffer highlighting', function()
 
     screen:expect([[
       Ta {6:båten} över {2:sjön}^!                     |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+                                              |
+    ]])
+  end)
+
+  it('works with new syntax groups', function()
+    insert([[
+      fancy code in a new fancy language]])
+    add_hl(-1, "FancyLangItem", 0, 0, 5)
+    screen:expect([[
+      fancy code in a new fancy languag^e      |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+                                              |
+    ]])
+
+    command('hi FancyLangItem guifg=red')
+    screen:expect([[
+      {10:fancy} code in a new fancy languag^e      |
       {1:~                                       }|
       {1:~                                       }|
       {1:~                                       }|


### PR DESCRIPTION
As pointed out by @justinmk in gitter, bufhl unlike`:syntax` cannot create new syntax groups, which is a hurdle to reimplement syntax highlighting using bufhl.

I copied this behavior from `matchaddpos()` which was a mistake. Rather, they should anyway have the same semantics as signs which also are attached to the lifetime of a buffer, rather than being temporary window highlighting.