### PR TITLE
[RFC] cmake,bsd: Fix mandir to saner defaults.

### DIFF
--- a/cmake/InstallHelpers.cmake
+++ b/cmake/InstallHelpers.cmake
@@ -2,8 +2,8 @@
 if(CMAKE_SYSTEM_NAME MATCHES "BSD" AND NOT DEFINED CMAKE_INSTALL_MANDIR)
   if(DEFINED ENV{MANPREFIX})
     set(CMAKE_INSTALL_MANDIR "$ENV{MANPREFIX}/man")
-  else()
-    set(CMAKE_INSTALL_MANDIR "/usr/local/man")
+  elseif(CMAKE_INSTALL_PREFIX MATCHES "^/usr/local$")
+    set(CMAKE_INSTALL_MANDIR "man")
   endif()
 endif()
 


### PR DESCRIPTION
The old behaviour was to set CMAKE_INSTALL_MANDIR to /usr/local/man
when MANPREFIX wasn't defined. This caused mismatching installation
paths when the installation prefix wasn't /usr/local.

This fix explicitely checks that the prefix is /usr/local to change
the value of CMAKE_INSTALL_MANDIR, and uses the default behaviour
otherwise, as /usr/local is the exception rather than the norm
(as per man hier(7)).

---

Tested prefixes are:

| Prefix | Absolute MANDIR |
| --- | --- |
| `/usr` | `/usr/share/man` |
| `/usr/local` | `/usr/local/man` |
| `$HOME/.local` | `$HOME/.local/share/man` |

These paths should be correct according to [hier(7)](https://www.freebsd.org/cgi/man.cgi?hier(7)), and compatible with the XDG defaults.

This fixes #7239.