### PR TITLE
build: set MIN_LOG_LEVEL correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,15 +113,14 @@ else()
   set(HAS_OG_FLAG 0)
 endif()
 
-# Set custom build flags for RelWithDebInfo.
-# -DNDEBUG purposely omitted because we want assertions.
+#
+# Build-type: RelWithDebInfo
+#
 if(HAS_OG_FLAG)
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-Og -g"
-    CACHE STRING "Flags used by the compiler during release-with-debug builds." FORCE)
-elseif(NOT MSVC)
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g"
-    CACHE STRING "Flags used by the compiler during release-with-debug builds." FORCE)
-elseif(CMAKE_C_FLAGS_RELWITHDEBINFO MATCHES DNDEBUG)
+  set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -Og -g")
+endif()
+# We _want_ assertions in RelWithDebInfo build-type.
+if(CMAKE_C_FLAGS_RELWITHDEBINFO MATCHES DNDEBUG)
   string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 endif()
 
@@ -479,20 +478,19 @@ install_helper(
   DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
 # MIN_LOG_LEVEL for log.h
-if(DEFINED MIN_LOG_LEVEL)
+if("${MIN_LOG_LEVEL}" MATCHES "^$")
+  message(STATUS "MIN_LOG_LEVEL not specified")
+else()
   if(NOT MIN_LOG_LEVEL MATCHES "^[0-3]$")
     message(FATAL_ERROR "invalid MIN_LOG_LEVEL: " ${MIN_LOG_LEVEL})
   endif()
   message(STATUS "MIN_LOG_LEVEL set to ${MIN_LOG_LEVEL}")
-else()
-  message(STATUS "MIN_LOG_LEVEL not specified, defaulting to 1 (INFO)")
 endif()
 
 # Go down the tree.
 
 add_subdirectory(src/nvim)
-# Read compilation flags from src/nvim,
-# used in config subdirectory below.
+# Read compilation flags from src/nvim, used in config subdirectory below.
 include(GetCompileFlags)
 get_compile_flags(NVIM_VERSION_CFLAGS)
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -164,7 +164,7 @@ if(NOT MSVC)
   endif()
 endif()
 
-if(DEFINED MIN_LOG_LEVEL)
+if(NOT "${MIN_LOG_LEVEL}" MATCHES "^$")
   add_definitions(-DMIN_LOG_LEVEL=${MIN_LOG_LEVEL})
 endif()
 


### PR DESCRIPTION
closes #7283
regression by 42d892913daa215c27e41b2255e96c1ce09ea56c

- Don't need to explicitly put "-O2 -g" in RelWithDebInfo; CMake does
  that already. That was left-over from 42d892913daa2 which removed the
  "Dev" custom build-type, but repurposed the logic for RelWithDebInfo.

- `if(DEFINED MIN_LOG_LEVEL)` doesn't work.
- `if(${MIN_LOG_LEVEL} MATCHES "^$")` doesn't work if -DMIN_LOG_LEVEL is
  omitted.
- `if(MIN_LOG_LEVEL)` also isn't what we want: it would be true if
  MIN_LOG_LEVEL=0.