### PR TITLE
[RFC] vim-patch: 8.0.0198, 8.0.0200, 8.0.0201, 8.0.0202, 8.0.0204

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5283,7 +5283,9 @@ get_id_list (
           id = SYNID_CONTAINED;
         id += current_syn_inc_tag;
       } else if (name[1] == '@')   {
-        if (!skip) {
+        if (skip) {
+            id = -1;
+        } else {
           id = syn_check_cluster(name + 2, (int)(end - p - 1));
         }
       } else {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -52,7 +52,7 @@ static bool did_syntax_onoff = false;
 struct hl_group {
   char_u      *sg_name;         ///< highlight group name
   char_u      *sg_name_u;       ///< uppercase of sg_name
-  int sg_cleared;       	///< "hi clear" was used
+  int sg_cleared;               ///< "hi clear" was used
   int sg_attr;                  ///< Screen attr @see ATTR_ENTRY
   int sg_link;                  ///< link to this highlight group ID
   int sg_set;                   ///< combination of flags in \ref SG_SET
@@ -3027,9 +3027,9 @@ static void syn_cmd_conceal(exarg_T *eap, int syncing)
         MSG(_("syn conceal off"));
     }
   } else if (STRNICMP(arg, "on", 2) == 0 && next - arg == 2) {
-    curwin->w_s->b_syn_conceal = TRUE;
+    curwin->w_s->b_syn_conceal = true;
   } else if (STRNICMP(arg, "off", 3) == 0 && next - arg == 3) {
-    curwin->w_s->b_syn_conceal = FALSE;
+    curwin->w_s->b_syn_conceal = false;
   } else {
     EMSG2(_("E390: Illegal argument: %s"), arg);
   }
@@ -3055,9 +3055,9 @@ static void syn_cmd_case(exarg_T *eap, int syncing)
         MSG(_("syntax case match"));
     }
   } else if (STRNICMP(arg, "match", 5) == 0 && next - arg == 5) {
-    curwin->w_s->b_syn_ic = FALSE;
+    curwin->w_s->b_syn_ic = false;
   } else if (STRNICMP(arg, "ignore", 6) == 0 && next - arg == 6) {
-    curwin->w_s->b_syn_ic = TRUE;
+    curwin->w_s->b_syn_ic = true;
   } else {
     EMSG2(_("E390: Illegal argument: %s"), arg);
   }
@@ -3144,11 +3144,11 @@ static void syn_cmd_iskeyword(exarg_T *eap, int syncing)
  */
 void syntax_clear(synblock_T *block)
 {
-  block->b_syn_error = FALSE;       /* clear previous error */
-  block->b_syn_ic = FALSE;          /* Use case, by default */
-  block->b_syn_spell = SYNSPL_DEFAULT;   /* default spell checking */
-  block->b_syn_containedin = FALSE;
-  block->b_syn_conceal = FALSE;
+  block->b_syn_error = false;           // clear previous error
+  block->b_syn_ic = false;              // Use case, by default
+  block->b_syn_spell = SYNSPL_DEFAULT;  // default spell checking
+  block->b_syn_containedin = false;
+  block->b_syn_conceal = false;
 
   /* free the keywords */
   clear_keywtab(&block->b_keywtab);
@@ -4025,11 +4025,11 @@ get_group_name (
  * Return NULL for any error;
  */
 static char_u *
-get_syn_options (
-    char_u *arg,                   /* next argument to be checked */
-    syn_opt_arg_T *opt,                   /* various things */
+get_syn_options(
+    char_u *arg,            // next argument to be checked
+    syn_opt_arg_T *opt,     // various things
     int *conceal_char,
-    int skip                       /* TRUE if skipping over command */
+    int skip                // TRUE if skipping over command
 )
 {
   char_u      *gname_start, *gname;
@@ -4105,14 +4105,17 @@ get_syn_options (
         EMSG(_("E395: contains argument not accepted here"));
         return NULL;
       }
-      if (get_id_list(&arg, 8, &opt->cont_list, skip) == FAIL)
+      if (get_id_list(&arg, 8, &opt->cont_list, skip) == FAIL) {
         return NULL;
+      }
     } else if (flagtab[fidx].argtype == 2)   {
-      if (get_id_list(&arg, 11, &opt->cont_in_list, skip) == FAIL)
+      if (get_id_list(&arg, 11, &opt->cont_in_list, skip) == FAIL) {
         return NULL;
+      }
     } else if (flagtab[fidx].argtype == 3)   {
-      if (get_id_list(&arg, 9, &opt->next_list, skip) == FAIL)
+      if (get_id_list(&arg, 9, &opt->next_list, skip) == FAIL) {
         return NULL;
+      }
     } else if (flagtab[fidx].argtype == 11 && arg[5] == '=')   {
       /* cchar=? */
       if (has_mbyte) {
@@ -4410,10 +4413,11 @@ syn_cmd_match (
   init_syn_patterns();
   memset(&item, 0, sizeof(item));
   rest = get_syn_pattern(rest, &item);
-  if (vim_regcomp_had_eol() && !(syn_opt_arg.flags & HL_EXCLUDENL))
+  if (vim_regcomp_had_eol() && !(syn_opt_arg.flags & HL_EXCLUDENL)) {
     syn_opt_arg.flags |= HL_HAS_EOL;
+  }
 
-  /* Get options after the pattern */
+  // Get options after the pattern
   rest = get_syn_options(rest, &syn_opt_arg, &conceal_char, eap->skip);
 
   if (rest != NULL) {           /* all arguments are valid */
@@ -4526,14 +4530,13 @@ syn_cmd_region (
   syn_opt_arg.cont_in_list = NULL;
   syn_opt_arg.next_list = NULL;
 
-  /*
-   * get the options, patterns and matchgroup.
-   */
+  // get the options, patterns and matchgroup.
   while (rest != NULL && !ends_excmd(*rest)) {
-    /* Check for option arguments */
+    // Check for option arguments
     rest = get_syn_options(rest, &syn_opt_arg, &conceal_char, eap->skip);
-    if (rest == NULL || ends_excmd(*rest))
+    if (rest == NULL || ends_excmd(*rest)) {
       break;
+    }
 
     /* must be a pattern or matchgroup then */
     key_end = rest;
@@ -4963,7 +4966,7 @@ static void syn_cmd_cluster(exarg_T *eap, int syncing)
         syn_combine_list(&SYN_CLSTR(curwin->w_s)[scl_id].scl_list,
                          &clstr_list, list_op);
       }
-      got_clstr = TRUE;
+      got_clstr = true;
     }
 
     if (got_clstr) {
@@ -5211,9 +5214,9 @@ static void syn_cmd_sync(exarg_T *eap, int syncing)
 static int 
 get_id_list (
     char_u **arg,
-    int keylen,                     /* length of keyword */
-    short **list,             /* where to store the resulting list, if not
-                                   NULL, the list is silently skipped! */
+    int keylen,         // length of keyword
+    int16_t **list,     // where to store the resulting list, if not
+                        // NULL, the list is silently skipped!
     int skip
 )
 {
@@ -6493,7 +6496,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
           HL_TABLE()[from_id - 1].sg_set |= SG_LINK;
         HL_TABLE()[from_id - 1].sg_link = to_id;
         HL_TABLE()[from_id - 1].sg_scriptID = current_SID;
-	HL_TABLE()[from_id - 1].sg_cleared = false;
+        HL_TABLE()[from_id - 1].sg_cleared = false;
         redraw_all_later(SOME_VALID);
       }
     }
@@ -7774,14 +7777,14 @@ const char *get_highlight_name(expand_T *const xp, const int idx)
     return NULL;
   }
 
-  /* Items are never removed from the table, skip the ones that were cleared.
-   */
-  int current_idx = idx; 
-  while (current_idx < highlight_ga.ga_len && HL_TABLE()[current_idx].sg_cleared) {
-      ++current_idx;
+  // Items are never removed from the table, skip the ones that were cleared.
+  int current_idx = idx;
+  while (current_idx < highlight_ga.ga_len
+         && HL_TABLE()[current_idx].sg_cleared) {
+    current_idx++;
   }
   if (current_idx >= highlight_ga.ga_len) {
-      return NULL;
+    return NULL;
   }
   return (const char *)HL_TABLE()[current_idx].sg_name;
 }

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -184,6 +184,10 @@ func Test_syntax_arg_skipped()
     call assert_match('conceal off', execute('syntax conceal'))
   endif
 
+  syntax conceal on
+  syntax conceal off
+  call assert_match('conceal off', execute('syntax conceal'))
+
   syntax region Tar start=/</ end=/>/
   if 0
     syntax region NotTest start=/</ end=/>/ contains=@Spell

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -158,3 +158,133 @@ func Test_syntax_completion()
   call feedkeys(":syn match \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_match('^"syn match Boolean Character ', @:)
 endfunc
+
+func Test_syntax_arg_skipped()
+  syn clear
+  syntax case ignore
+  if 0
+    syntax case match
+  endif
+  call assert_match('case ignore', execute('syntax case'))
+
+  syn keyword Foo foo
+  call assert_match('Foo', execute('syntax'))
+  syn clear
+  call assert_match('case match', execute('syntax case'))
+  call assert_notmatch('Foo', execute('syntax'))
+
+  if has('conceal')
+    syn clear
+    syntax conceal on
+    if 0
+      syntax conceal off
+    endif
+    call assert_match('conceal on', execute('syntax conceal'))
+    syn clear
+    call assert_match('conceal off', execute('syntax conceal'))
+  endif
+
+  syntax region Tar start=/</ end=/>/
+  if 0
+    syntax region NotTest start=/</ end=/>/ contains=@Spell
+  endif
+  call assert_match('Tar', execute('syntax'))
+  call assert_notmatch('NotTest', execute('syntax'))
+  call assert_notmatch('Spell', execute('syntax'))
+
+  hi Foo ctermfg=blue
+  let a = execute('hi Foo')
+  if 0
+    syntax rest
+  endif
+  call assert_equal(a, execute('hi Foo'))
+
+  set ft=tags
+  syn off
+  if 0
+    syntax enable
+  endif
+  call assert_match('No Syntax items defined', execute('syntax'))
+  syntax enable
+  call assert_match('tagComment', execute('syntax'))
+  set ft=
+
+  syn clear
+  if 0
+    syntax include @Spell nothing
+  endif
+  call assert_notmatch('Spell', execute('syntax'))
+
+  syn clear
+  syn iskeyword 48-57,$,_
+  call assert_match('48-57,$,_', execute('syntax iskeyword'))
+  if 0
+    syn clear
+    syn iskeyword clear
+  endif
+  call assert_match('48-57,$,_', execute('syntax iskeyword'))
+  syn iskeyword clear
+  call assert_match('not set', execute('syntax iskeyword'))
+  syn iskeyword 48-57,$,_
+  syn clear
+  call assert_match('not set', execute('syntax iskeyword'))
+
+  syn clear
+  syn keyword Foo foo
+  if 0
+    syn keyword NotAdded bar
+  endif
+  call assert_match('Foo', execute('syntax'))
+  call assert_notmatch('NotAdded', execute('highlight'))
+
+  syn clear
+  syn keyword Foo foo
+  call assert_match('Foo', execute('syntax'))
+  call assert_match('Foo', execute('syntax list'))
+  call assert_notmatch('Foo', execute('if 0 | syntax | endif'))
+  call assert_notmatch('Foo', execute('if 0 | syntax list | endif'))
+
+  syn clear
+  syn match Fopi /asdf/
+  if 0
+    syn match Fopx /asdf/
+  endif
+  call assert_match('Fopi', execute('syntax'))
+  call assert_notmatch('Fopx', execute('syntax'))
+
+  syn clear
+  syn spell toplevel
+  call assert_match('spell toplevel', execute('syntax spell'))
+  if 0
+    syn spell notoplevel
+  endif
+  call assert_match('spell toplevel', execute('syntax spell'))
+  syn spell notoplevel
+  call assert_match('spell notoplevel', execute('syntax spell'))
+  syn spell default
+  call assert_match('spell default', execute('syntax spell'))
+
+  syn clear
+  if 0
+    syntax cluster Spell
+  endif
+  call assert_notmatch('Spell', execute('syntax'))
+
+  syn clear
+  syn keyword Foo foo
+  syn sync ccomment
+  syn sync maxlines=5
+  if 0
+    syn sync maxlines=11
+  endif
+  call assert_match('on C-style comments', execute('syntax sync'))
+  call assert_match('maximal 5 lines', execute('syntax sync'))
+  syn clear
+  syn keyword Foo foo
+  if 0
+    syn sync ccomment
+  endif
+  call assert_notmatch('on C-style comments', execute('syntax sync'))
+
+  syn clear
+endfunc

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -329,3 +329,14 @@ func Test_syn_clear()
   hi clear Foo
   hi clear Bar
 endfunc
+
+func Test_invalid_name()
+  syn clear
+  syn keyword Nop yes
+  call assert_fails("syntax keyword Wr\x17ong bar", 'E669:')
+  syntax keyword @Wrong bar
+  call assert_match('W18:', execute('1messages'))
+  syn clear
+  hi clear Nop
+  hi clear @Wrong
+endfunc


### PR DESCRIPTION
Problem:    Some syntax arguments take effect even after "if 0". (Taylor
            Venable)
Solution:   Properly skip the syntax statements.  Make "syn case" and "syn
            conceal" report the current state.  Fix that "syn clear" didn't
            reset the conceal flag.  Add tests for :syntax skipping properly.

https://github.com/vim/vim/commit/de318c5c35ed0d65fd2a07196cb8acd5ee6d9bf8

First time merging a Vim patch (or working on Neovim's codebase for that matter), my apologies if I didn't follow the protocol to the letter. I'm quite happy to change anything if necessary.

I've made some very minor code style changes on this PR (conditional statement curly brace positioning mostly) so this patch satisfies Neovim's coding standards.