### PR TITLE
[RFC] vim-patch:8.0.0140

### DIFF
--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1,13 +1,13 @@
-" Tests for Visual mode
-if !has('multi_byte')
-  finish
-endif
-
+" Tests for various Visual mode.
 if !has('visual')
   finish
 endif
 
 func Test_block_shift_multibyte()
+  " Uses double-wide character.
+  if !has('multi_byte')
+    return
+  endif
   split
   call setline(1, ['xヹxxx', 'ヹxxx'])
   exe "normal 1G0l\<C-V>jl>"
@@ -34,4 +34,12 @@ func Test_Visual_vapo()
   normal oxx
   normal vapo
   bwipe!
+endfunc
+
+func Test_dotregister_paste()
+  new
+  exe "norm! ihello world\<esc>"
+  norm! 0ve".p
+  call assert_equal('hello world world', getline(1))
+  q!
 endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -963,7 +963,7 @@ static const int included_patches[] = {
   143,
   142,
   // 141,
-  // 140,
+  140,
   // 139 NA
   // 138 NA
   137,


### PR DESCRIPTION
Problem:    Pasting inserted text in Visual mode does not work properly.
            (Matthew Malcomson)
Solution:   Stop Visual mode before stuffing the inserted text. (Christian
            Brabandt, from neovim vim/vim#5709)

https://github.com/vim/vim/commit/f8eb9c51e5bbd10e59c9b1247f8f6c7f5b77ccd0

follow file doesn't merge, because `TEST_FILE=test_visual.res make oldtest` work fine.

>src/nvim/ops.c