### PR TITLE
plines_win_nofold(): Ignore virtcols after 32000th computation

### DIFF
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1273,7 +1273,7 @@ int plines_win_nofold(win_T *wp, linenr_T lnum)
    * Add column offset for 'number', 'relativenumber' and 'foldcolumn'.
    */
   width = wp->w_width - win_col_off(wp);
-  if (width <= 0) {
+  if (width <= 0 || col > 32000) {
     return 32000;  // bigger than the number of lines of the screen
   }
   if (col <= (unsigned int)width) {

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1274,7 +1274,7 @@ int plines_win_nofold(win_T *wp, linenr_T lnum)
    */
   width = wp->w_width - win_col_off(wp);
   if (width <= 0 || col > 32000) {
-    return 32000;  // bigger than the number of lines of the screen
+    return 32000;  // bigger than the number of screen columns
   }
   if (col <= (unsigned int)width) {
     return 1;

--- a/test/functional/options/tabstop_spec.lua
+++ b/test/functional/options/tabstop_spec.lua
@@ -1,0 +1,23 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local feed = helpers.feed
+local eq = helpers.eq
+local eval = helpers.eval
+
+describe("'tabstop' option", function()
+  before_each(function()
+    clear()
+  end)
+
+  -- NOTE: Setting 'tabstop' to a big number reproduces crash #2838.
+  -- Disallowing big 'tabstop' would not fix #2838, only hide it.
+  it("tabstop=<big-number> does not crash #2838", function()
+    -- Insert a <Tab> character for 'tabstop' to work with.
+    feed('i<Tab><Esc>')
+    -- Set 'tabstop' to a very high value.
+    -- Use feed(), not command(), to provoke crash.
+    feed(':set tabstop=3000000000<CR>')
+    eq(2, eval("1+1"))  -- Still alive?
+  end)
+end)


### PR DESCRIPTION
- rebase #3527 (fixes #2838)
- add a test

 cc @Grimy 