### PR TITLE
[RFC] Fix issue #7429.

### DIFF
--- a/test/functional/autocmd/bufenter_spec.lua
+++ b/test/functional/autocmd/bufenter_spec.lua
@@ -31,4 +31,17 @@ describe('autocmd BufEnter', function()
     eq(1, eval("exists('g:dir_bufenter')"))  -- Did BufEnter for the directory.
     eq(2, eval("bufnr('%')"))                -- Switched to the dir buffer.
   end)
+
+  it('triggered by ":split normal|:help|:bw"', function()
+    command("split normal")
+    command("wincmd j")
+    command("helptags runtime/doc")
+    command("help")
+    command("wincmd L")
+    command("autocmd BufEnter normal let g:bufentered = 1")
+    command("bw")
+    eq(1, eval('bufnr("%")')) -- The cursor is back to the bottom window
+    eq(0, eval("exists('g:bufentered')")) -- The autocmd hasn't been triggered
+  end)
+
 end)


### PR DESCRIPTION
Link to the issue: https://github.com/neovim/neovim/issues/7429
The problem was that after a help window was closed, a window was selected and
its autocommands triggered. After that, restore_snapshot was called and the
focused window changed, confusing the user.
This commit makes sure restore_snapshot is called before any window is selected
or autocommand triggered.