### PR TITLE
terminal: Account for number column in terminal (#5310)

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1466,7 +1466,7 @@ void enter_buffer(buf_T *buf)
 
   if (buf->terminal) {
     terminal_resize(buf->terminal,
-                    (uint16_t)curwin->w_width,
+                    (uint16_t)(MAX(0, curwin->w_width - win_col_off(curwin))),
                     (uint16_t)curwin->w_height);
   }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16723,9 +16723,10 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     }
   }
 
+  uint16_t term_width = MAX(0, curwin->w_width - win_col_off(curwin));
   TerminalJobData *data = common_job_init(argv, on_stdout, on_stderr, on_exit,
                                           true, false, false, cwd);
-  data->proc.pty.width = curwin->w_width;
+  data->proc.pty.width = term_width;
   data->proc.pty.height = curwin->w_height;
   data->proc.pty.term_name = xstrdup("xterm-256color");
   if (!common_job_start(data, rettv)) {
@@ -16733,7 +16734,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
   TerminalOptions topts;
   topts.data = data;
-  topts.width = curwin->w_width;
+  topts.width = term_width;
   topts.height = curwin->w_height;
   topts.write_cb = term_write;
   topts.resize_cb = term_resize;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -692,6 +692,12 @@ static void win_update(win_T *wp)
   if (wp->w_nrwidth != i) {
     type = NOT_VALID;
     wp->w_nrwidth = i;
+
+    if (buf->terminal) {
+      terminal_resize(buf->terminal,
+                      (uint16_t)(MAX(0, curwin->w_width - win_col_off(curwin))),
+                      (uint16_t)curwin->w_height);
+    }
   } else if (buf->b_mod_set && buf->b_mod_xlines != 0 && wp->w_redraw_top != 0) {
     /*
      * When there are both inserted/deleted lines and specific lines to be

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -698,18 +698,16 @@ static void win_update(win_T *wp)
                       (uint16_t)(MAX(0, curwin->w_width - win_col_off(curwin))),
                       (uint16_t)curwin->w_height);
     }
-  } else if (buf->b_mod_set && buf->b_mod_xlines != 0 && wp->w_redraw_top != 0) {
-    /*
-     * When there are both inserted/deleted lines and specific lines to be
-     * redrawn, w_redraw_top and w_redraw_bot may be invalid, just redraw
-     * everything (only happens when redrawing is off for while).
-     */
+  } else if (buf->b_mod_set
+             && buf->b_mod_xlines != 0
+             && wp->w_redraw_top != 0) {
+    // When there are both inserted/deleted lines and specific lines to be
+    // redrawn, w_redraw_top and w_redraw_bot may be invalid, just redraw
+    // everything (only happens when redrawing is off for while).
     type = NOT_VALID;
   } else {
-    /*
-     * Set mod_top to the first line that needs displaying because of
-     * changes.  Set mod_bot to the first line after the changes.
-     */
+    // Set mod_top to the first line that needs displaying because of
+    // changes.  Set mod_bot to the first line after the changes.
     mod_top = wp->w_redraw_top;
     if (wp->w_redraw_bot != 0)
       mod_bot = wp->w_redraw_bot + 1;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3747,7 +3747,9 @@ static void win_enter_ext(win_T *wp, bool undo_sync, int curwin_invalid,
   do_autochdir();
 
   if (curbuf->terminal) {
-    terminal_resize(curbuf->terminal, curwin->w_width, curwin->w_height);
+    terminal_resize(curbuf->terminal,
+                    (uint16_t)(MAX(0, curwin->w_width - win_col_off(curwin))),
+                    (uint16_t)curwin->w_height);
   }
 }
 
@@ -4946,7 +4948,9 @@ void win_new_width(win_T *wp, int width)
 
   if (wp->w_buffer->terminal) {
     if (wp->w_height != 0) {
-      terminal_resize(wp->w_buffer->terminal, wp->w_width, 0);
+      terminal_resize(wp->w_buffer->terminal,
+                      (uint16_t)(MAX(0, curwin->w_width - win_col_off(curwin))),
+                      0);
     }
   }
 }

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -11,6 +11,34 @@ describe('terminal window', function()
     screen = thelpers.screen_setup()
   end)
 
+  describe('with number set', function()
+    before_each(function()
+      feed('<c-\\><c-n>:set number<cr>i')
+      screen:expect([[
+        {7:  1 }tty ready                                     |
+        {7:  2 }rows: 6, cols: 46                             |
+        {7:  3 }{1: }                                             |
+        {7:  4 }                                              |
+        {7:  5 }                                              |
+        {7:  6 }                                              |
+        {3:-- TERMINAL --}                                    |
+      ]])
+    end)
+
+    it('wraps text correctly', function()
+      thelpers.feed_data({'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'})
+      screen:expect([[
+        {7:  1 }tty ready                                     |
+        {7:  2 }rows: 6, cols: 46                             |
+        {7:  3 }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST|
+        {7:  4 }UVWXYZ{1: }                                       |
+        {7:  5 }                                              |
+        {7:  6 }                                              |
+        {3:-- TERMINAL --}                                    |
+      ]])
+    end)
+  end)
+
   describe('with colorcolumn set', function()
     before_each(function()
       feed('<c-\\><c-n>')


### PR DESCRIPTION
This is my attempt at fixing Issue #5310: Terminal split and relativenumber cuts off the end of lines

This is my first neovim PR, so be gentle, but I would appreciate feedback.

In particular I'm not sure if I should be using `w_nrwidth` since it's a cached value. There's two other bugs I'd like to fix, but I'm not sure how to approach them:
- Turning number on/off doesn't cause the terminal to be resized
- The terminal is created with 80 columns, regardless of the size of the window.