### PR TITLE
[RFC] vim-patch:8.0.0196       vim-patch:8.0.0194  vim-patch:8.0.0189

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -62,6 +62,7 @@ NEW_TESTS ?= \
 	    test_mksession_utf8.res \
 	    test_nested_function.res \
 	    test_normal.res \
+	    test_profile.res \
 	    test_quickfix.res \
 	    test_search.res \
 	    test_signs.res \

--- a/src/nvim/testdir/test_profile.vim
+++ b/src/nvim/testdir/test_profile.vim
@@ -4,16 +4,13 @@ if !has('profile')
 endif
 
 func Test_profile_func()
-  if !has('unix')
-    return
-  endif
   let lines = [
     \ "func! Foo1()",
     \ "endfunc",
     \ "func! Foo2()",
-    \ "  let count = 100",
-    \ "  while count > 0",
-    \ "    let count = count - 1",
+    \ "  let l:count = 100",
+    \ "  while l:count > 0",
+    \ "    let l:count = l:count - 1",
     \ "  endwhile",
     \ "endfunc",
     \ "func! Foo3()",
@@ -35,47 +32,59 @@ func Test_profile_func()
     \ ]
 
   call writefile(lines, 'Xprofile_func.vim')
-  let a = system(v:progpath
-    \ . " -u NONE -i NONE --noplugin"
-    \ . " -c 'profile start Xprofile_func.log'"
-    \ . " -c 'profile func Foo*'"
-    \ . " -c 'so Xprofile_func.vim'"
-    \ . " -c 'qall!'")
+  call system(v:progpath
+    \ . ' -es -u NONE -U NONE -i NONE --noplugin'
+    \ . ' -c "profile start Xprofile_func.log"'
+    \ . ' -c "profile func Foo*"'
+    \ . ' -c "so Xprofile_func.vim"'
+    \ . ' -c "qall!"')
+  call assert_equal(0, v:shell_error)
+
   let lines = readfile('Xprofile_func.log')
-
-  call assert_equal(28, len(lines))
-
-  call assert_equal('FUNCTION  Foo1()', lines[0])
-  call assert_equal('Called 2 times',   lines[1])
-  call assert_equal('FUNCTION  Foo2()', lines[7])
-  call assert_equal('Called 1 time',    lines[8])
 
   " - Foo1() is called 3 times but should be reported as called twice
   "   since one call is in between "profile pause" .. "profile continue".
-  " - Foo2() should come before Foo1() since Foo1() does much more work.\
+  " - Foo2() should come before Foo1() since Foo1() does much more work.
   " - Foo3() is not reported because function is deleted.
   " - Unlike Foo3(), Foo2() should not be deleted since there is a check
   "   for v:profiling.
   " - Bar() is not reported since it does not match "profile func Foo*".
-  call assert_equal('FUNCTIONS SORTED ON TOTAL TIME',        lines[18])
-  call assert_equal('count  total (s)   self (s)  function', lines[19])
-  call assert_match('^\s*1\s\+\d\+\.\d\+\s\+Foo2()$',        lines[20])
-  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+Foo1()$',        lines[21])
-  call assert_equal('',                                      lines[22])
-  call assert_equal('FUNCTIONS SORTED ON SELF TIME',         lines[23])
-  call assert_equal('count  total (s)   self (s)  function', lines[24])
-  call assert_match('^\s*1\s\+\d\+\.\d\+\s\+Foo2()$',        lines[25])
-  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+Foo1()$',        lines[26])
-  call assert_equal('',                                      lines[27])
+  call assert_equal(28, len(lines))
+
+  call assert_equal('FUNCTION  Foo1()',                            lines[0])
+  call assert_equal('Called 2 times',                              lines[1])
+  call assert_match('^Total time:\s\+\d\+\.\d\+$',                 lines[2])
+  call assert_match('^ Self time:\s\+\d\+\.\d\+$',                 lines[3])
+  call assert_equal('',                                            lines[4])
+  call assert_equal('count  total (s)   self (s)',                 lines[5])
+  call assert_equal('',                                            lines[6])
+  call assert_equal('FUNCTION  Foo2()',                            lines[7])
+  call assert_equal('Called 1 time',                               lines[8])
+  call assert_match('^Total time:\s\+\d\+\.\d\+$',                 lines[9])
+  call assert_match('^ Self time:\s\+\d\+\.\d\+$',                 lines[10])
+  call assert_equal('',                                            lines[11])
+  call assert_equal('count  total (s)   self (s)',                 lines[12])
+  call assert_match('^\s*1\s\+.*\slet l:count = 100$',             lines[13])
+  call assert_match('^\s*101\s\+.*\swhile l:count > 0$',           lines[14])
+  call assert_match('^\s*100\s\+.*\s  let l:count = l:count - 1$', lines[15])
+  call assert_match('^\s*100\s\+.*\sendwhile$',                    lines[16])
+  call assert_equal('',                                            lines[17])
+  call assert_equal('FUNCTIONS SORTED ON TOTAL TIME',              lines[18])
+  call assert_equal('count  total (s)   self (s)  function',       lines[19])
+  call assert_match('^\s*1\s\+\d\+\.\d\+\s\+Foo2()$',              lines[20])
+  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+Foo1()$',              lines[21])
+  call assert_equal('',                                            lines[22])
+  call assert_equal('FUNCTIONS SORTED ON SELF TIME',               lines[23])
+  call assert_equal('count  total (s)   self (s)  function',       lines[24])
+  call assert_match('^\s*1\s\+\d\+\.\d\+\s\+Foo2()$',              lines[25])
+  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+Foo1()$',              lines[26])
+  call assert_equal('',                                            lines[27])
 
   call delete('Xprofile_func.vim')
   call delete('Xprofile_func.log')
 endfunc
 
 func Test_profile_file()
-  if !has('unix')
-    return
-  endif
   let lines = [
     \ 'func! Foo()',
     \ 'endfunc',
@@ -87,13 +96,14 @@ func Test_profile_file()
     \ ]
 
   call writefile(lines, 'Xprofile_file.vim')
-  let a = system(v:progpath
-    \ . " -u NONE -i NONE --noplugin"
-    \ . " -c 'profile start Xprofile_file.log'"
-    \ . " -c 'profile file Xprofile_file.vim'"
-    \ . " -c 'so Xprofile_file.vim'"
-    \ . " -c 'so Xprofile_file.vim'"
-    \ . " -c 'qall!'")
+  call system(v:progpath
+    \ . ' -es -u NONE -U NONE -i NONE --noplugin'
+    \ . ' -c "profile start Xprofile_file.log"'
+    \ . ' -c "profile file Xprofile_file.vim"'
+    \ . ' -c "so Xprofile_file.vim"'
+    \ . ' -c "so Xprofile_file.vim"'
+    \ . ' -c "qall!"')
+  call assert_equal(0, v:shell_error)
 
   let lines = readfile('Xprofile_file.log')
 

--- a/src/nvim/testdir/test_profile.vim
+++ b/src/nvim/testdir/test_profile.vim
@@ -113,7 +113,8 @@ func Test_profile_file()
   call assert_equal('                              " a comment',      lines[9])
   call assert_match('^\s*20\s\+\d\+\.\d\+\s\+\d\+\.\d\+\s\+call Foo()$', lines[10])
   call assert_match('^\s*20\s\+\d\+\.\d\+\s\+endfor$',                lines[11])
-  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+\d\+\.\d\+\s\+call Foo()$', lines[12])
+  " if self and total are equal we only get one number
+  call assert_match('^\s*2\s\+\(\d\+\.\d\+\s\+\)\=\d\+\.\d\+\s\+call Foo()$', lines[12])
   call assert_equal('',                                               lines[13])
 
   call delete('Xprofile_file.vim')

--- a/src/nvim/testdir/test_profile.vim
+++ b/src/nvim/testdir/test_profile.vim
@@ -1,0 +1,135 @@
+" Test Vim profiler
+if !has('profile')
+  finish
+endif
+
+func Test_profile_func()
+  if !has('unix')
+    return
+  endif
+  let lines = [
+    \ "func! Foo1()",
+    \ "endfunc",
+    \ "func! Foo2()",
+    \ "  let count = 100",
+    \ "  while count > 0",
+    \ "    let count = count - 1",
+    \ "  endwhile",
+    \ "endfunc",
+    \ "func! Foo3()",
+    \ "endfunc",
+    \ "func! Bar()",
+    \ "endfunc",
+    \ "call Foo1()",
+    \ "call Foo1()",
+    \ "profile pause",
+    \ "call Foo1()",
+    \ "profile continue",
+    \ "call Foo2()",
+    \ "call Foo3()",
+    \ "call Bar()",
+    \ "if !v:profiling",
+    \ "  delfunc Foo2",
+    \ "endif",
+    \ "delfunc Foo3",
+    \ ]
+
+  call writefile(lines, 'Xprofile_func.vim')
+  let a = system(v:progpath
+    \ . " -u NONE -i NONE --noplugin"
+    \ . " -c 'profile start Xprofile_func.log'"
+    \ . " -c 'profile func Foo*'"
+    \ . " -c 'so Xprofile_func.vim'"
+    \ . " -c 'qall!'")
+  let lines = readfile('Xprofile_func.log')
+
+  call assert_equal(28, len(lines))
+
+  call assert_equal('FUNCTION  Foo1()', lines[0])
+  call assert_equal('Called 2 times',   lines[1])
+  call assert_equal('FUNCTION  Foo2()', lines[7])
+  call assert_equal('Called 1 time',    lines[8])
+
+  " - Foo1() is called 3 times but should be reported as called twice
+  "   since one call is in between "profile pause" .. "profile continue".
+  " - Foo2() should come before Foo1() since Foo1() does much more work.\
+  " - Foo3() is not reported because function is deleted.
+  " - Unlike Foo3(), Foo2() should not be deleted since there is a check
+  "   for v:profiling.
+  " - Bar() is not reported since it does not match "profile func Foo*".
+  call assert_equal('FUNCTIONS SORTED ON TOTAL TIME',        lines[18])
+  call assert_equal('count  total (s)   self (s)  function', lines[19])
+  call assert_match('^\s*1\s\+\d\+\.\d\+\s\+Foo2()$',        lines[20])
+  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+Foo1()$',        lines[21])
+  call assert_equal('',                                      lines[22])
+  call assert_equal('FUNCTIONS SORTED ON SELF TIME',         lines[23])
+  call assert_equal('count  total (s)   self (s)  function', lines[24])
+  call assert_match('^\s*1\s\+\d\+\.\d\+\s\+Foo2()$',        lines[25])
+  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+Foo1()$',        lines[26])
+  call assert_equal('',                                      lines[27])
+
+  call delete('Xprofile_func.vim')
+  call delete('Xprofile_func.log')
+endfunc
+
+func Test_profile_file()
+  if !has('unix')
+    return
+  endif
+  let lines = [
+    \ 'func! Foo()',
+    \ 'endfunc',
+    \ 'for i in range(10)',
+    \ '  " a comment',
+    \ '  call Foo()',
+    \ 'endfor',
+    \ 'call Foo()',
+    \ ]
+
+  call writefile(lines, 'Xprofile_file.vim')
+  let a = system(v:progpath
+    \ . " -u NONE -i NONE --noplugin"
+    \ . " -c 'profile start Xprofile_file.log'"
+    \ . " -c 'profile file Xprofile_file.vim'"
+    \ . " -c 'so Xprofile_file.vim'"
+    \ . " -c 'so Xprofile_file.vim'"
+    \ . " -c 'qall!'")
+
+  let lines = readfile('Xprofile_file.log')
+
+  call assert_equal(14, len(lines))
+
+  call assert_match('^SCRIPT .*Xprofile_file.vim$',                   lines[0])
+  call assert_equal('Sourced 2 times',                                lines[1])
+  call assert_match('^Total time:\s\+\d\+\.\d\+$',                    lines[2])
+  call assert_match('^ Self time:\s\+\d\+\.\d\+$',                    lines[3])
+  call assert_equal('',                                               lines[4])
+  call assert_equal('count  total (s)   self (s)',                    lines[5])
+  call assert_equal('                            func! Foo()',        lines[6])
+  call assert_equal('                            endfunc',            lines[7])
+  " Loop iterates 10 times. Since script runs twice, body executes 20 times.
+  " First line of loop executes one more time than body to detect end of loop.
+  call assert_match('^\s*22\s\+\d\+\.\d\+\s\+for i in range(10)$',    lines[8])
+  call assert_equal('                              " a comment',      lines[9])
+  call assert_match('^\s*20\s\+\d\+\.\d\+\s\+\d\+\.\d\+\s\+call Foo()$', lines[10])
+  call assert_match('^\s*20\s\+\d\+\.\d\+\s\+endfor$',                lines[11])
+  call assert_match('^\s*2\s\+\d\+\.\d\+\s\+\d\+\.\d\+\s\+call Foo()$', lines[12])
+  call assert_equal('',                                               lines[13])
+
+  call delete('Xprofile_file.vim')
+  call delete('Xprofile_file.log')
+endfunc
+
+func Test_profile_completion()
+  call feedkeys(":profile \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"profile continue file func pause start', @:)
+
+  call feedkeys(":profile start test_prof\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_match('^"profile start.* test_profile\.vim', @:)
+endfunc
+
+func Test_profile_errors()
+  call assert_fails("profile func Foo", 'E750:')
+  call assert_fails("profile pause", 'E750:')
+  call assert_fails("profile continue", 'E750:')
+endfunc

--- a/src/nvim/testdir/test_profile.vim
+++ b/src/nvim/testdir/test_profile.vim
@@ -133,7 +133,7 @@ endfunc
 
 func Test_profile_completion()
   call feedkeys(":profile \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"profile continue file func pause start', @:)
+  call assert_equal('"profile continue dump file func pause start stop', @:)
 
   call feedkeys(":profile start test_prof\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_match('^"profile start.* test_profile\.vim', @:)

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -910,7 +910,7 @@ static const int included_patches[] = {
   // 197,
   // 196,
   195,
-  // 194,
+  194,
   // 193 NA
   // 192 NA
   // 191 NA

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -915,7 +915,7 @@ static const int included_patches[] = {
   // 192 NA
   // 191 NA
   190,
-  // 189,
+  189,
   188,
   // 187 NA
   186,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -908,7 +908,7 @@ static const int included_patches[] = {
   // 199 NA
   // 198,
   // 197,
-  // 196,
+  196,
   195,
   194,
   // 193 NA


### PR DESCRIPTION
vim-patch:8.0.0196                                                                                                                                     

Problem:    The test for :profile is slow and does not work on MS-Windows.
Solution:   Use the "-es" argument. (Dominique Pelle)  Swap single and doubl
quotes for system()

https://github.com/vim/vim/commit/c011a3d083001bcd9853b4447422f1819f3cee2f


vim-patch:8.0.0194

Problem:    Profile tests fails if total and self time are equal.
Solution:   Make one time optional.

https://github.com/vim/vim/commit/e32bbded641a5da0263ecf82f9ccc95a8e0a089e

vim-patch:8.0.0189

Problem:    There are no tests for the :profile command.
Solution:   Add tests. (Dominique Pelle, closes vim/vim#1383)

https://github.com/vim/vim/commit/296b1f28ca9cedeb55872f306808b2214b519ce7


---------------------------
`TEST_FILE=test_profile.res make oldtest` failed,

>From test_profile.vim:
Found errors in Test_profile_completion():
function RunTheTest[13]..Test_profile_completion line 2: Expected '"profile continue file func pause start' but got '"profile continue dump file func pause start stop'
TEST FAILURE
