### PR TITLE
[RDY] vim-patch:8.0.0206

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -63,6 +63,7 @@ NEW_TESTS ?= \
 	    test_nested_function.res \
 	    test_normal.res \
 	    test_quickfix.res \
+	    test_retab.res \
 	    test_search.res \
 	    test_signs.res \
 	    test_smartindent.res \

--- a/src/nvim/testdir/test_retab.vim
+++ b/src/nvim/testdir/test_retab.vim
@@ -1,0 +1,77 @@
+" Test :retab
+func SetUp()
+  new
+  call setline(1, "\ta  \t    b        c    ")
+endfunc
+
+func TearDown()
+  bwipe!
+endfunc
+
+func Retab(bang, n)
+  let l:old_tabstop = &tabstop
+  let l:old_line = getline(1)
+  exe "retab" . a:bang . a:n
+  let l:line = getline(1)
+  call setline(1, l:old_line)
+  if a:n > 0
+    " :retab changes 'tabstop' to n with argument n > 0.
+    call assert_equal(a:n, &tabstop)
+    exe 'set tabstop=' . l:old_tabstop
+  else
+    " :retab does not change 'tabstop' with empty or n <= 0.
+    call assert_equal(l:old_tabstop, &tabstop)
+  endif
+  return l:line
+endfunc
+
+func Test_retab()
+  set tabstop=8 noexpandtab
+  call assert_equal("\ta\t    b        c    ",            Retab('',  ''))
+  call assert_equal("\ta\t    b        c    ",            Retab('',  0))
+  call assert_equal("\ta\t    b        c    ",            Retab('',  8))
+  call assert_equal("\ta\t    b\t     c\t  ",             Retab('!', ''))
+  call assert_equal("\ta\t    b\t     c\t  ",             Retab('!', 0))
+  call assert_equal("\ta\t    b\t     c\t  ",             Retab('!', 8))
+
+  call assert_equal("\t\ta\t\t\tb        c    ",          Retab('',  4))
+  call assert_equal("\t\ta\t\t\tb\t\t c\t  ",             Retab('!', 4))
+
+  call assert_equal("        a\t\tb        c    ",        Retab('',  10))
+  call assert_equal("        a\t\tb        c    ",        Retab('!', 10))
+
+  set tabstop=8 expandtab
+  call assert_equal("        a           b        c    ", Retab('',  ''))
+  call assert_equal("        a           b        c    ", Retab('',  0))
+  call assert_equal("        a           b        c    ", Retab('',  8))
+  call assert_equal("        a           b        c    ", Retab('!', ''))
+  call assert_equal("        a           b        c    ", Retab('!', 0))
+  call assert_equal("        a           b        c    ", Retab('!', 8))
+
+  call assert_equal("        a           b        c    ", Retab(' ', 4))
+  call assert_equal("        a           b        c    ", Retab('!', 4))
+
+  call assert_equal("        a           b        c    ", Retab(' ', 10))
+  call assert_equal("        a           b        c    ", Retab('!', 10))
+
+  set tabstop=4 noexpandtab
+  call assert_equal("\ta\t\tb        c    ",              Retab('',  ''))
+  call assert_equal("\ta\t\tb\t\t c\t  ",                 Retab('!', ''))
+  call assert_equal("\t a\t\t\tb        c    ",           Retab('',  3))
+  call assert_equal("\t a\t\t\tb\t\t\tc\t  ",             Retab('!', 3))
+  call assert_equal("    a\t  b        c    ",            Retab('',  5))
+  call assert_equal("    a\t  b\t\t c\t ",                Retab('!', 5))
+
+  set tabstop=4 expandtab
+  call assert_equal("    a       b        c    ",         Retab('',  ''))
+  call assert_equal("    a       b        c    ",         Retab('!', ''))
+  call assert_equal("    a       b        c    ",         Retab('',  3))
+  call assert_equal("    a       b        c    ",         Retab('!', 3))
+  call assert_equal("    a       b        c    ",         Retab('',  5))
+  call assert_equal("    a       b        c    ",         Retab('!', 5))
+endfunc
+
+func Test_retab_error()
+  call assert_fails('retab -1',  'E487:')
+  call assert_fails('retab! -1', 'E487:')
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -898,7 +898,7 @@ static const int included_patches[] = {
   209,
   208,
   // 207,
-  // 206,
+  206,
   205,
   // 204,
   // 203 NA


### PR DESCRIPTION
Problem:    Test coverage for :retab insufficient.
Solution:   Add test for :retab. (Dominique Pelle, closes vim/vim#1391)

https://github.com/vim/vim/commit/8822744b4d9d40aa1fd59870a8bdd7c64c59a42b