### PR TITLE
[RDY] Add curdir as a default viewoption (vim-patch:8.0.128)

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6453,7 +6453,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 						*'viewoptions'* *'vop'*
-'viewoptions' 'vop'	string	(default: "folds,options,cursor")
+'viewoptions' 'vop'	string	(default: "folds,options,cursor,curdir")
 			global
 			{not available when compiled without the |+mksession|
 			feature}
@@ -6461,6 +6461,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	list of words.  Each word enables saving and restoring something:
 	   word		save and restore ~
 	   cursor	cursor position in file and in window
+	   curdir	local current directory, if set with |:lcd|
 	   folds	manually created folds, opened/closed folds and local
 			fold options
 	   options	options and mappings local to a window or buffer (not

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -885,7 +885,7 @@ The output of ":mkview" contains these items:
 5. The scroll position and the cursor position in the file.  Doesn't work very
    well when there are closed folds.
 6. The local current directory, if it is different from the global current
-   directory.
+   directory and 'viewoptions' contains "curdir".
 
 Note that Views and Sessions are not perfect:
 - They don't restore everything.  For example, defined functions, autocommands

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9359,12 +9359,18 @@ put_view (
   /*
    * Local directory.
    */
-  if (wp->w_localdir != NULL) {
+
+  // Do not save if the current flag is view options and the local
+  // directory option not set
+  if (wp->w_localdir != NULL
+      && (flagp != &vop_flags
+          || (*flagp & SSOP_CURDIR))) {
     if (fputs("lcd ", fd) < 0
         || ses_put_fname(fd, wp->w_localdir, flagp) == FAIL
-        || put_eol(fd) == FAIL)
+        || put_eol(fd) == FAIL) {
       return FAIL;
-    did_lcd = TRUE;
+    }
+    did_lcd = true;
   }
 
   return OK;

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -539,7 +539,7 @@ static char *(p_ssop_values[]) = {"buffers", "winpos", "resize", "winsize",
                                   "localoptions", "options", "help", "blank",
                                   "globals", "slash", "unix",
                                   "sesdir", "curdir", "folds", "cursor",
-                                  "tabpages", NULL};
+                                  "tabpages", NULL };
 # endif
 # define SSOP_BUFFERS           0x001
 # define SSOP_WINPOS            0x002
@@ -557,16 +557,17 @@ static char *(p_ssop_values[]) = {"buffers", "winpos", "resize", "winsize",
 # define SSOP_FOLDS             0x2000
 # define SSOP_CURSOR            0x4000
 # define SSOP_TABPAGES          0x8000
-EXTERN char_u   *p_sh;          /* 'shell' */
-EXTERN char_u   *p_shcf;        /* 'shellcmdflag' */
-EXTERN char_u   *p_sp;          /* 'shellpipe' */
-EXTERN char_u   *p_shq;         /* 'shellquote' */
-EXTERN char_u   *p_sxq;         /* 'shellxquote' */
-EXTERN char_u   *p_sxe;         /* 'shellxescape' */
-EXTERN char_u   *p_srr;         /* 'shellredir' */
-EXTERN int p_stmp;              /* 'shelltemp' */
+
+EXTERN char_u   *p_sh;          // 'shell'
+EXTERN char_u   *p_shcf;        // 'shellcmdflag'
+EXTERN char_u   *p_sp;          // 'shellpipe'
+EXTERN char_u   *p_shq;         // 'shellquote'
+EXTERN char_u   *p_sxq;         // 'shellxquote'
+EXTERN char_u   *p_sxe;         // 'shellxescape'
+EXTERN char_u   *p_srr;         // 'shellredir'
+EXTERN int p_stmp;              // 'shelltemp'
 #ifdef BACKSLASH_IN_FILENAME
-EXTERN int p_ssl;               /* 'shellslash' */
+EXTERN int p_ssl;               // 'shellslash'
 #endif
 EXTERN char_u   *p_stl;         // 'statusline'
 EXTERN int p_sr;                // 'shiftround'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2610,7 +2610,7 @@ return {
       deny_duplicates=true,
       vi_def=true,
       varname='p_vop',
-      defaults={if_true={vi="folds,options,cursor"}}
+      defaults={if_true={vi="folds,options,cursor,curdir"}}
     },
     {
       full_name='viminfo', abbreviation='vi',

--- a/test/functional/ex_cmds/mkview_spec.lua
+++ b/test/functional/ex_cmds/mkview_spec.lua
@@ -1,0 +1,67 @@
+local lfs = require('lfs')
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local command = helpers.command
+local get_pathsep = helpers.get_pathsep
+local eq = helpers.eq
+local funcs = helpers.funcs
+local rmdir = helpers.rmdir
+
+local file_prefix = 'Xtest-functional-ex_cmds-mkview_spec'
+
+describe(':mkview', function()
+  local tmp_file_base = file_prefix .. '-tmpfile'
+  local local_dir = file_prefix .. '.d'
+  local view_dir = file_prefix .. '.view.d'
+
+  before_each(function()
+    clear()
+    lfs.mkdir(view_dir)
+    lfs.mkdir(local_dir)
+  end)
+
+  after_each(function()
+    -- Remove any views created in the view directory
+    rmdir(view_dir)
+    lfs.rmdir(local_dir)
+  end)
+
+  it('viewoption curdir restores local current directory', function()
+    local cwd_dir = funcs.getcwd()
+    local set_view_dir_command = 'set viewdir=' .. cwd_dir ..
+          get_pathsep() .. view_dir
+
+    -- By default the local current directory should save
+    command(set_view_dir_command)
+    command('edit ' .. tmp_file_base .. '1')
+    command('lcd ' .. local_dir)
+    command('mkview')
+
+    -- Create a new instance of Nvim to remove the 'lcd'
+    clear()
+
+    -- Disable saving the local current directory for the second view
+    command(set_view_dir_command)
+    command('set viewoptions-=curdir')
+    command('edit ' .. tmp_file_base .. '2')
+    command('lcd ' .. local_dir)
+    command('mkview')
+
+    -- Create a new instance of Nvim to test saved 'lcd' option
+    clear()
+    command(set_view_dir_command)
+
+    -- Load the view without a saved local current directory
+    command('edit ' .. tmp_file_base .. '2')
+    command('loadview')
+    -- The view's current directory should not have changed
+    eq(cwd_dir, funcs.getcwd())
+    -- Load the view with a saved local current directory
+    command('edit ' .. tmp_file_base .. '1')
+    command('loadview')
+    -- The view's local directory should have been saved
+    eq(cwd_dir .. get_pathsep() .. local_dir, funcs.getcwd())
+  end)
+
+end)


### PR DESCRIPTION
The option enables the current local directory set by ":lcd" to be saved
to views which is the current default behaviour. The option can be
removed to disable this behaviour.

This addresses Issue #7435 

This fix also addresses issues in other plugins:
[vim-stay - Issue 10](https://github.com/kopischke/vim-stay/issues/10)
[fzf - Issue 1085](https://github.com/junegunn/fzf/issues/1085)