### PR TITLE
doc: fix documented order of xclip/xsel

### DIFF
--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -133,8 +133,8 @@ registers. Nvim looks for these clipboard tools, in order of priority:
 
   - |g:clipboard|
   - pbcopy/pbpaste (macOS)
-  - xclip
-  - xsel (newer alternative to xclip)
+  - xsel (if $DISPLAY is set)
+  - xclip (if $DISPLAY is set)
   - lemonade (for SSH) https://github.com/pocke/lemonade
   - doitclient (for SSH) http://www.chiark.greenend.org.uk/~sgtatham/doit/
   - win32yank (Windows)


### PR DESCRIPTION
This also removes the unclear comment about xsel being a newer
alternative.

Ref: https://github.com/neovim/neovim/issues/5853#issuecomment-269905343