### PR TITLE
Tune ctrl_c_spec timeouts for likelyhood of success

### DIFF
--- a/test/functional/ex_cmds/ctrl_c_spec.lua
+++ b/test/functional/ex_cmds/ctrl_c_spec.lua
@@ -47,7 +47,7 @@ describe("CTRL-C (mapped)", function()
     end
 
     -- The test is time-sensitive. Try different sleep values.
-    local ms_values = {1, 10, 100, 1000, 10000}
+    local ms_values = {100, 1000, 10000}
     for i, ms in ipairs(ms_values) do
       if i < #ms_values then
         local status, _ = pcall(test_ctrl_c, ms)


### PR DESCRIPTION
Having timeouts that are likely to fail incurs a penalty of waiting for
`screen:expect()` to fail, hence removing such small timeouts will speed
up the test on average.