### PR TITLE
vim-patch:8.0.1207

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1068,7 +1068,7 @@ static void profile_init(scriptitem_T *si)
   si->sn_pr_nest = 0;
 }
 
-/// save time when starting to invoke another script or function.
+/// Save time when starting to invoke another script or function.
 void script_prof_save(
     proftime_T  *tm             // place to store wait time
 )
@@ -1141,12 +1141,14 @@ static void script_dump_profile(FILE *fd)
       if (sfd == NULL) {
         fprintf(fd, "Cannot open file!\n");
       } else {
-        for (int i = 0; i < si->sn_prl_ga.ga_len; i++) {
+        // Keep going till the end of file, so that trailing
+        // continuation lines are listed.
+        for (int i = 0; ; i++) {
           if (vim_fgets(IObuff, IOSIZE, sfd)) {
             break;
           }
-          pp = &PRL_ITEM(si, i);
-          if (pp->snp_count > 0) {
+          if (i < si->sn_prl_ga.ga_len
+              && (pp = &PRL_ITEM(si, i))->snp_count > 0) {
             fprintf(fd, "%5d ", pp->snp_count);
             if (profile_equal(pp->sn_prl_total, pp->sn_prl_self)) {
               fprintf(fd, "           ");
@@ -2871,22 +2873,6 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
   save_sourcing_lnum = sourcing_lnum;
   sourcing_lnum = 0;
 
-  cookie.conv.vc_type = CONV_NONE;              // no conversion
-
-  // Read the first line so we can check for a UTF-8 BOM.
-  firstline = getsourceline(0, (void *)&cookie, 0);
-  if (firstline != NULL && STRLEN(firstline) >= 3 && firstline[0] == 0xef
-      && firstline[1] == 0xbb && firstline[2] == 0xbf) {
-    // Found BOM; setup conversion, skip over BOM and recode the line.
-    convert_setup(&cookie.conv, (char_u *)"utf-8", p_enc);
-    p = string_convert(&cookie.conv, firstline + 3, NULL);
-    if (p == NULL) {
-      p = vim_strsave(firstline + 3);
-    }
-    xfree(firstline);
-    firstline = p;
-  }
-
   // start measuring script load time if --startuptime was passed and
   // time_fd was successfully opened afterwards.
   proftime_T rel_time;
@@ -2957,6 +2943,22 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
       si->sn_pr_start = profile_start();
       si->sn_pr_children = profile_zero();
     }
+  }
+
+  cookie.conv.vc_type = CONV_NONE;              // no conversion
+
+  // Read the first line so we can check for a UTF-8 BOM.
+  firstline = getsourceline(0, (void *)&cookie, 0);
+  if (firstline != NULL && STRLEN(firstline) >= 3 && firstline[0] == 0xef
+      && firstline[1] == 0xbb && firstline[2] == 0xbf) {
+    // Found BOM; setup conversion, skip over BOM and recode the line.
+    convert_setup(&cookie.conv, (char_u *)"utf-8", p_enc);
+    p = string_convert(&cookie.conv, firstline + 3, NULL);
+    if (p == NULL) {
+      p = vim_strsave(firstline + 3);
+    }
+    xfree(firstline);
+    firstline = p;
   }
 
   // Call do_cmdline, which will call getsourceline() to get the lines.
@@ -3281,7 +3283,8 @@ void script_line_start(void)
   if (si->sn_prof_on && sourcing_lnum >= 1) {
     // Grow the array before starting the timer, so that the time spent
     // here isn't counted.
-    ga_grow(&si->sn_prl_ga, (int)(sourcing_lnum - si->sn_prl_ga.ga_len));
+    (void)ga_grow(&si->sn_prl_ga,
+                  (int)(sourcing_lnum - si->sn_prl_ga.ga_len));
     si->sn_prl_idx = sourcing_lnum - 1;
     while (si->sn_prl_ga.ga_len <= si->sn_prl_idx
            && si->sn_prl_ga.ga_len < si->sn_prl_ga.ga_maxlen) {

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1039,9 +1039,14 @@ static void profile_reset(void)
         uf->uf_tm_total     = profile_zero();
         uf->uf_tm_self      = profile_zero();
         uf->uf_tm_children  = profile_zero();
+
+        xfree(uf->uf_tml_count);
+        xfree(uf->uf_tml_total);
+        xfree(uf->uf_tml_self);
         uf->uf_tml_count    = NULL;
         uf->uf_tml_total    = NULL;
         uf->uf_tml_self     = NULL;
+
         uf->uf_tml_start    = profile_zero();
         uf->uf_tml_children = profile_zero();
         uf->uf_tml_wait     = profile_zero();
@@ -3070,6 +3075,8 @@ char_u *get_scriptname(scid_T id)
 # if defined(EXITFREE)
 void free_scriptnames(void)
 {
+  profile_reset();
+
 # define FREE_SCRIPTNAME(item) xfree((item)->sn_name)
   GA_DEEP_CLEAR(&script_items, scriptitem_T, FREE_SCRIPTNAME);
 }


### PR DESCRIPTION
Problem:    Profiling skips the first and last script line.
Solution:   Check for BOM after setting script ID. (Lemonboy, closes vim/vim#2103,
            closes vim/vim#2112) Add a test. List the trailing script lines.

https://github.com/vim/vim/commit/67435d9983965c5c77fc74f0559779ce4554dacb