### PR TITLE
pvs/V575: ui_ext_cmdline_block_append

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2784,7 +2784,7 @@ void ui_ext_cmdline_block_append(int indent, const char *line)
 {
   char *buf = xmallocz(indent + strlen(line));
   memset(buf, ' ', indent);
-  memcpy(buf+indent, line, strlen(line));
+  memcpy(buf + indent, line, strlen(line));  // -V575
 
   Array item = ARRAY_DICT_INIT;
   ADD(item, DICTIONARY_OBJ((Dictionary)ARRAY_DICT_INIT));


### PR DESCRIPTION
(Not very important, but I noticed PVS error count went up, so ended up with this.)

```
./src/nvim/ex_getln.c:2787:1: error: V575 The 'memcpy' function doesn't
copy the whole string. Use 'strcpy / strcpy_s' function to preserve
terminal null.
```

The change "tricks" PVS into ignoring the problem without `// -V575`, not sure if that's better or worse that actually marking it.