### PR TITLE
[WIP] fix cmdline_special_char redraw issue

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -266,7 +266,7 @@ Only sent if `ext_cmdline` option is set in |ui-options|
 	`shift` is true the text after the cursor should be shifted, otherwise
 	it should overwrite the char at the cursor.
 
-	Should be hidden at next cmdline_show or cmdline_pos.
+	Should be hidden at next cmdline_show.
 
 ["cmdline_hide"]
 	Hide the cmdline.


### PR DESCRIPTION
cmdline_special_char must not be hidden at cmdline_pos, only cmdline_show (or cmdline_hide, but that is understood), so update the docs. Also, in my config `:<c-r>` does not show the `"`, but it does with `-u NONE` (with TUI there is no problem), I will need to investigate more (the `ui_flush()` didn't help, It sends it a bit later though). 