### PR TITLE
server_spec: Tolerate lack of protocol support

### DIFF
--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -316,6 +316,18 @@ describe('server -> client', function()
       connect_test(server, 'tcp', address)
     end)
 
+    it('via ipv6 address', function()
+      local server = spawn(nvim_argv)
+      set_session(server)
+      local address = funcs.serverstart('::1:')
+      if #address == 0 then
+        pending('no ipv6 stack', function() end)
+        return
+      end
+      eq('::1:', string.sub(address,1,4))
+      connect_test(server, 'tcp', address)
+    end)
+
     it('via hostname', function()
       local server = spawn(nvim_argv)
       set_session(server)

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -304,10 +304,14 @@ describe('server -> client', function()
       connect_test(server, 'pipe', address)
     end)
 
-    it('via ip address', function()
+    it('via ipv4 address', function()
       local server = spawn(nvim_argv)
       set_session(server)
       local address = funcs.serverstart("127.0.0.1:")
+      if #address == 0 then
+        pending('no ipv4 stack', function() end)
+        return
+      end
       eq('127.0.0.1:', string.sub(address,1,10))
       connect_test(server, 'tcp', address)
     end)

--- a/test/functional/eval/server_spec.lua
+++ b/test/functional/eval/server_spec.lua
@@ -63,23 +63,33 @@ describe('serverstart(), serverstop()', function()
     eq({}, funcs.serverlist())
 
     local s = funcs.serverstart('127.0.0.1:0')  -- assign random port
-    assert(string.match(s, '127.0.0.1:%d+'))
-    eq(s, funcs.serverlist()[1])
-    clear_serverlist()
+    if #s > 0 then
+      assert(string.match(s, '127.0.0.1:%d+'))
+      eq(s, funcs.serverlist()[1])
+      clear_serverlist()
+    end
 
     s = funcs.serverstart('127.0.0.1:')  -- assign random port
-    assert(string.match(s, '127.0.0.1:%d+'))
-    eq(s, funcs.serverlist()[1])
-    clear_serverlist()
+    if #s > 0 then
+      assert(string.match(s, '127.0.0.1:%d+'))
+      eq(s, funcs.serverlist()[1])
+      clear_serverlist()
+    end
 
-    funcs.serverstart('127.0.0.1:12345')
-    funcs.serverstart('127.0.0.1:12345')  -- exists already; ignore
-    funcs.serverstart('::1:12345')
-    funcs.serverstart('::1:12345')        -- exists already; ignore
-    local expected = {
-      '127.0.0.1:12345',
-      '::1:12345',
-    }
+    local expected = {}
+    local v4 = '127.0.0.1:12345'
+    s = funcs.serverstart(v4)
+    if #s > 0 then
+      table.insert(expected, v4)
+      funcs.serverstart(v4)  -- exists already; ignore
+    end
+
+    local v6 = '::1:12345'
+    s = funcs.serverstart(v6)
+    if #s > 0 then
+      table.insert(expected, v6)
+      funcs.serverstart(v6)  -- exists already; ignore
+    end
     eq(expected, funcs.serverlist())
     clear_serverlist()
 


### PR DESCRIPTION
This test started failing in Travis since they disabled IPv6 in the
environment:

```
[ RUN      ] serverstart(), serverstop() parses endpoints correctly: FAIL
...build/neovim/neovim/test/functional/eval/server_spec.lua:83: Expected objects to be the same.
Passed in:
(table) {
  [1] = '127.0.0.1:12345' }
Expected:
(table) {
  [1] = '127.0.0.1:12345'
 *[2] = '::1:12345' }
```

Change all tests to ensure a server was actually started before
expecting it to be returned from `serverlist()`.