### PR TITLE
doc: Remove invalid names from clipboard option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1319,27 +1319,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			will additionally copy the text into register
 			'*'. See |clipboard|.
 
-						*clipboard-autoselect*
-	autoselect	Works like the 'a' flag in 'guioptions': If present,
-			then whenever Visual mode is started, or the Visual
-			area extended, Vim tries to become the owner of the
-			windowing system's global selection or put the
-			selected text on the clipboard used by the selection
-			register "*.  See |guioptions_a| and |quotestar| for
-			details.  When the GUI is active, the 'a' flag in
-			'guioptions' is used, when the GUI is not active, this
-			"autoselect" flag is used.
-			Also applies to the modeless selection.
-
-						*clipboard-autoselectplus*
-	autoselectplus  Like "autoselect" but using the + register instead of
-			the * register.  Compare to the 'P' flag in
-			'guioptions'.
-
-						*clipboard-autoselectml*
-	autoselectml	Like "autoselect", but for the modeless selection
-			only.  Compare to the 'A' flag in 'guioptions'.
-
 						*'cmdheight'* *'ch'*
 'cmdheight' 'ch'	number	(default 1)
 			global

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -372,10 +372,12 @@ Test functions:
 
 Other options:
   'antialias'
+  'clipboard' ("autoselect", "autoselectplus" and "autoselectml" flags
+               were removed)
   'cpoptions' (g j k H w < * - and all POSIX flags were removed)
   'encoding' ("utf-8" is always used)
   'esckeys'
-  'guioptions' "t" flag was removed
+  'guioptions' ("t" flag was removed)
   *'guipty'* (Nvim uses pipes and PTYs consistently on all platforms.)
   'highlight' (Names of builtin |highlight-groups| cannot be changed.)
   *'imactivatefunc'* *'imaf'*


### PR DESCRIPTION
The clipboard option does not recognize "autoselect", "autoselectplus" and "autoselectml" anymore.
From what I understand these options have been removed but still exist in vim, so I added a note for that in vim_diff.txt.