### PR TITLE
test: calcuate correct buffer size for each test

### DIFF
--- a/test/unit/path_spec.lua
+++ b/test/unit/path_spec.lua
@@ -366,134 +366,156 @@ describe('path.c', function()
   end)
 
   describe('vim_FullName', function()
-    local function vim_FullName(filename, buf, len, force)
-      filename = to_cstr(filename)
-      return cimp.vim_FullName(filename, buf, len, force)
+    local function vim_FullName(filename, buflen, do_expand)
+      local buf = cstr(buflen, '')
+      local result = cimp.vim_FullName(to_cstr(filename), buf, buflen, do_expand)
+      return buf, result
     end
 
-    before_each(function()
-      -- Create empty string buffer which will contain the resulting path.
-      length = (string.len(lfs.currentdir())) + 33
-      buffer = cstr(length, '')
-    end)
+    local function get_buf_len(s, t)
+      return math.max(string.len(s), string.len(t)) + 1
+    end
 
     itp('fails if given filename is NULL', function()
-      local force_expansion = 1
-      local result = cimp.vim_FullName(NULL, buffer, length, force_expansion)
+      local do_expand = 1
+      local buflen = 10
+      local buf = cstr(buflen, '')
+      local result = cimp.vim_FullName(NULL, buf, buflen, do_expand)
       eq(FAIL, result)
     end)
 
     itp('fails safely if given length is wrong #5737', function()
-      local force_expansion = 1
       local filename = 'foo/bar/bazzzzzzz/buz/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/a'
       local too_short_len = 8
       local buf = cstr(too_short_len, '')
-      local result = cimp.vim_FullName(filename, buf, too_short_len, force_expansion)
+      local do_expand = 1
+      local result = cimp.vim_FullName(filename, buf, too_short_len, do_expand)
       local expected = string.sub(filename, 1, (too_short_len - 1))
-      eq(expected, (ffi.string(buf)))
+      eq(expected, ffi.string(buf))
       eq(FAIL, result)
     end)
 
     itp('uses the filename if the filename is a URL', function()
-      local force_expansion = 1
       local filename = 'http://www.neovim.org'
-      local result = vim_FullName(filename, buffer, length, force_expansion)
-      eq(filename, (ffi.string(buffer)))
+      local buflen = string.len(filename) + 1
+      local do_expand = 1
+      local buf, result = vim_FullName(filename, buflen, do_expand)
+      eq(filename, ffi.string(buf))
       eq(OK, result)
     end)
 
     itp('fails and uses filename if given filename contains non-existing directory', function()
-      local force_expansion = 1
       local filename = 'non_existing_dir/test.file'
-      local result = vim_FullName(filename, buffer, length, force_expansion)
-      eq(filename, (ffi.string(buffer)))
+      local buflen = string.len(filename) + 1
+      local do_expand = 1
+      local buf, result = vim_FullName(filename, buflen, do_expand)
+      eq(filename, ffi.string(buf))
       eq(FAIL, result)
     end)
 
     itp('concatenates filename if it does not contain a slash', function()
-      local force_expansion = 1
-      local result = vim_FullName('test.file', buffer, length, force_expansion)
       local expected = lfs.currentdir() .. '/test.file'
-      eq(expected, (ffi.string(buffer)))
+      local filename = 'test.file'
+      local buflen = get_buf_len(expected, filename)
+      local do_expand = 1
+      local buf, result = vim_FullName(filename, buflen, do_expand)
+      eq(expected, ffi.string(buf))
       eq(OK, result)
     end)
 
     itp('concatenates directory name if it does not contain a slash', function()
-      local force_expansion = 1
-      local result = vim_FullName('..', buffer, length, force_expansion)
       local expected = lfs.currentdir() .. '/..'
-      eq(expected, (ffi.string(buffer)))
+      local filename = '..'
+      local buflen = get_buf_len(expected, filename)
+      local do_expand = 1
+      local buf, result = vim_FullName(filename, buflen, do_expand)
+      eq(expected, ffi.string(buf))
       eq(OK, result)
     end)
 
-    -- Is it possible for every developer to enter '..' directory while running
-    -- the unit tests? Which other directory would be better?
     itp('enters given directory (instead of just concatenating the strings) if possible and if path contains a slash', function()
-      local force_expansion = 1
-      local result = vim_FullName('../test.file', buffer, length, force_expansion)
       local old_dir = lfs.currentdir()
       lfs.chdir('..')
       local expected = lfs.currentdir() .. '/test.file'
       lfs.chdir(old_dir)
-      eq(expected, (ffi.string(buffer)))
+      local filename = '../test.file'
+      local buflen = get_buf_len(expected, filename)
+      local do_expand = 1
+      local buf, result = vim_FullName(filename, buflen, do_expand)
+      eq(expected, ffi.string(buf))
       eq(OK, result)
     end)
 
     itp('just copies the path if it is already absolute and force=0', function()
-      local force_expansion = 0
       local absolute_path = '/absolute/path'
-      local result = vim_FullName(absolute_path, buffer, length, force_expansion)
-      eq(absolute_path, (ffi.string(buffer)))
+      local buflen = string.len(absolute_path) + 1
+      local do_expand = 0
+      local buf, result = vim_FullName(absolute_path, buflen, do_expand)
+      eq(absolute_path, ffi.string(buf))
       eq(OK, result)
     end)
 
     itp('fails and uses filename when the path is relative to HOME', function()
       eq(false, cimp.os_isdir('~')) -- sanity check: no literal "~" directory.
-      local force_expansion = 1
       local absolute_path = '~/home.file'
-      local result = vim_FullName(absolute_path, buffer, length, force_expansion)
-      eq(absolute_path, (ffi.string(buffer)))
+      local buflen = string.len(absolute_path) + 1
+      local do_expand = 1
+      local buf, result = vim_FullName(absolute_path, buflen, do_expand)
+      eq(absolute_path, ffi.string(buf))
       eq(FAIL, result)
     end)
 
     itp('works with some "normal" relative path with directories', function()
-      local force_expansion = 1
-      local result = vim_FullName('unit-test-directory/test.file', buffer, length, force_expansion)
+      local expected = lfs.currentdir() .. '/unit-test-directory/test.file'
+      local filename = 'unit-test-directory/test.file'
+      local buflen = get_buf_len(expected, filename)
+      local do_expand = 1
+      local buf, result = vim_FullName(filename, buflen, do_expand)
+      eq(expected, ffi.string(buf))
       eq(OK, result)
-      eq(lfs.currentdir() .. '/unit-test-directory/test.file', (ffi.string(buffer)))
     end)
 
     itp('does not modify the given filename', function()
-      local force_expansion = 1
+      local expected = lfs.currentdir() .. '/unit-test-directory/test.file'
       local filename = to_cstr('unit-test-directory/test.file')
-      -- Don't use the wrapper here but pass a cstring directly to the c
-      -- function.
-      local result = cimp.vim_FullName(filename, buffer, length, force_expansion)
-      eq(lfs.currentdir() .. '/unit-test-directory/test.file', (ffi.string(buffer)))
-      eq('unit-test-directory/test.file', (ffi.string(filename)))
+      local buflen = string.len(expected) + 1
+      local buf = cstr(buflen, '')
+      local do_expand = 1
+      -- Don't use the wrapper but pass a cstring directly to the c function.
+      eq('unit-test-directory/test.file', ffi.string(filename))
+      local result = cimp.vim_FullName(filename, buf, buflen, do_expand)
+      eq(expected, ffi.string(buf))
       eq(OK, result)
     end)
 
     itp('works with directories that have one path component', function()
-      local force_expansion = 1
-      local filename = to_cstr('/tmp')
-      local result = cimp.vim_FullName(filename, buffer, length, force_expansion)
-      eq('/tmp', ffi.string(buffer))
+      local filename = '/tmp'
+      local expected = filename
+      local buflen = get_buf_len(expected, filename)
+      local do_expand = 1
+      local buf, result = vim_FullName(filename, buflen, do_expand)
+      eq('/tmp', ffi.string(buf))
       eq(OK, result)
     end)
 
     itp('expands "./" to the current directory #7117', function()
-      local force_expansion = 1
-      local result = vim_FullName('./unit-test-directory/test.file', buffer, length, force_expansion)
+      local expected = lfs.currentdir() .. '/unit-test-directory/test.file'
+      local filename = './unit-test-directory/test.file'
+      local buflen = get_buf_len(expected, filename)
+      local do_expand = 1
+      local buf, result = vim_FullName(filename, buflen, do_expand)
       eq(OK, result)
-      eq(lfs.currentdir() .. '/unit-test-directory/test.file', (ffi.string(buffer)))
+      eq(expected, ffi.string(buf))
     end)
 
     itp('collapses "foo/../foo" to "foo" #7117', function()
-      local force_expansion = 1
-      local result = vim_FullName('unit-test-directory/../unit-test-directory/test.file', buffer, length, force_expansion)
+      local expected = lfs.currentdir() .. '/unit-test-directory/test.file'
+      local filename = 'unit-test-directory/../unit-test-directory/test.file'
+      local buflen = get_buf_len(expected, filename)
+      local do_expand = 1
+      local buf, result = vim_FullName(filename, buflen, do_expand)
       eq(OK, result)
-      eq(lfs.currentdir() .. '/unit-test-directory/test.file', (ffi.string(buffer)))
+      eq(expected, ffi.string(buf))
     end)
   end)
 


### PR DESCRIPTION
Fixed-size buffers and lfs.currentdir().. does not compute. The tests would fail
if the current working directory was longer than expected.