### PR TITLE
[RFC] runtime: Fix syntax error in `runtime/syntax/tex.vim`

### DIFF
--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -512,7 +512,7 @@ if !exists("g:tex_no_math")
   if &ambw == "double" || exists("g:tex_usedblwidth")
     let s:texMathDelimList= s:texMathDelimList + [
      \ ['\\langle'     , '〈'] ,
-     \ ['\\rangle'     , '〉'] ,
+     \ ['\\rangle'     , '〉']]
   else
     let s:texMathDelimList= s:texMathDelimList + [
      \ ['\\langle'     , '<'] ,


### PR DESCRIPTION
Fix syntax error in `runtime/syntax/tex.vim` line 515.