### PR TITLE
vim_findfile() should return nothing when path is an URL

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -826,8 +826,13 @@ char_u *vim_findfile(void *search_ctx_arg)
                 stackp->ffs_filearray_cur = (char_u)(i + 1);
                 ff_push(search_ctx, stackp);
 
-                if (!path_with_url((char *)file_path))
-                  simplify_filename(file_path);
+                if (path_with_url((char *)file_path)) {
+                  *file_path = NUL;
+                  return file_path;
+                }
+
+                simplify_filename(file_path);
+
                 if (os_dirname(ff_expand_buffer, MAXPATHL)
                     == OK) {
                   p = path_shorten_fname(file_path,


### PR DESCRIPTION
Before:

```
  :echo findfile('foo', 'http://')
  http://foo
```

After:

```
  :echo find('foo', 'http://')
  <empty string>
```

---

If you consider this useful, I'll add tests.

I sent a patch to vim/vim first: https://github.com/vim/vim/issues/1832