### PR TITLE
[RDY] health.vim: normalize slashes for script path

### DIFF
--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -58,7 +58,7 @@ function! s:check_rplugin_manifest() abort
       let contents = join(readfile(script))
       if contents =~# '\<\%(from\|import\)\s\+neovim\>'
         if script =~# '[\/]__init__\.py$'
-          let script = fnamemodify(script, ':h')
+          let script = tr(fnamemodify(script, ':h'), '\', '/')
         endif
 
         if !has_key(existing_rplugins, script)


### PR DESCRIPTION
`:checkhealth` reports that remote plugins are unregistered
after running :UpdateRemotePlugins because of the backslashes in filepath.
Normalize them to forward slashes because the paths in rplugin.vim are normalized in autoload/remote/host.vim.