### PR TITLE
[RFC] vim-patch:8.0.0215 NA

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -889,7 +889,7 @@ static const int included_patches[] = {
   // 218,
   // 217 NA
   // 216,
-  // 215,
+  // 215 NA
   // 214,
   // 213 NA
   // 212,


### PR DESCRIPTION
Problem:    When a Cscope line contains CTRL-L a NULL pointer may be used.
            (Coverity)
Solution:   Don't check for an emacs tag in a cscope line.

https://github.com/vim/vim/commit/e362c3d2c34f2b7ff38b4c3d2a7ff127d2290e09

-----------
This patch should be ignore.

nvim doesn't define macro FEAT_EMACS_TAGS