### PR TITLE
[RDY] vim-patch:8.0.0218

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3272,6 +3272,12 @@ const char * set_one_cmd_context(
   case CMD_echoerr:
   case CMD_call:
   case CMD_return:
+  case CMD_cexpr:
+  case CMD_caddexpr:
+  case CMD_cgetexpr:
+  case CMD_lexpr:
+  case CMD_laddexpr:
+  case CMD_lgetexpr:
     set_context_for_expression(xp, (char_u *)arg, ea.cmdidx);
     break;
 

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -25,6 +25,34 @@ func Test_complete_wildmenu()
   set nowildmenu
 endfunc
 
+func Test_expr_completion()
+  if !(has('cmdline_compl') && has('eval'))
+    return
+  endif
+  for cmd in [
+	\ 'let a = ',
+	\ 'if',
+	\ 'elseif',
+	\ 'while',
+	\ 'for',
+	\ 'echo',
+	\ 'echon',
+	\ 'execute',
+	\ 'echomsg',
+	\ 'echoerr',
+	\ 'call',
+	\ 'return',
+	\ 'cexpr',
+	\ 'caddexpr',
+	\ 'cgetexpr',
+	\ 'lexpr',
+	\ 'laddexpr',
+	\ 'lgetexpr']
+    call feedkeys(":" . cmd . " getl\<Tab>\<Home>\"\<CR>", 'xt')
+    call assert_equal('"' . cmd . ' getline(', getreg(':'))
+  endfor
+endfunc
+
 func Test_getcompletion()
   if !has('cmdline_compl')
     return

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -886,7 +886,7 @@ static const int included_patches[] = {
   // 221 NA
   // 220,
   219,
-  // 218,
+  218,
   // 217 NA
   // 216,
   // 215,


### PR DESCRIPTION
Problem:    No command line completion for :cexpr, :cgetexpr, :caddexpr, etc.
Solution:   Make completion work. (Yegappan Lakshmanan)  Add a test.

https://github.com/vim/vim/commit/2b2207ba69c6b009e466a36eef0644ca723e16d3