### PR TITLE
[RDY] vim-patch:8.0.0226 vim-patch:8.0.0224

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -307,7 +307,7 @@ readfile (
   int try_mac;
   int try_dos;
   int try_unix;
-  int file_rewind = FALSE;
+  int file_rewind = false;
   int can_retry;
   linenr_T conv_error = 0;              /* line nr with conversion error */
   linenr_T illegal_byte = 0;            /* line nr with illegal byte */
@@ -647,39 +647,38 @@ readfile (
     int m = msg_scroll;
     int n = msg_scrolled;
 
-    /*
-     * The file must be closed again, the autocommands may want to change
-     * the file before reading it.
-     */
-    if (!read_stdin)
-      close(fd);                /* ignore errors */
+    // The file must be closed again, the autocommands may want to change
+    // the file before reading it.
+    if (!read_stdin) {
+      close(fd);                // ignore errors
+    }
 
-    /*
-     * The output from the autocommands should not overwrite anything and
-     * should not be overwritten: Set msg_scroll, restore its value if no
-     * output was done.
-     */
-    msg_scroll = TRUE;
-    if (filtering)
+    // The output from the autocommands should not overwrite anything and
+    // should not be overwritten: Set msg_scroll, restore its value if no
+    // output was done.
+    msg_scroll = true;
+    if (filtering) {
       apply_autocmds_exarg(EVENT_FILTERREADPRE, NULL, sfname,
-          FALSE, curbuf, eap);
-    else if (read_stdin)
+                           false, curbuf, eap);
+    } else if (read_stdin) {
       apply_autocmds_exarg(EVENT_STDINREADPRE, NULL, sfname,
-          FALSE, curbuf, eap);
-    else if (newfile)
+                           false, curbuf, eap);
+    } else if (newfile) {
       apply_autocmds_exarg(EVENT_BUFREADPRE, NULL, sfname,
-          FALSE, curbuf, eap);
-    else
+                           false, curbuf, eap);
+    } else {
       apply_autocmds_exarg(EVENT_FILEREADPRE, sfname, sfname,
-          FALSE, NULL, eap);
+                           false, NULL, eap);
+    }
 
-  // autocommands may have changed it
-  try_mac = (vim_strchr(p_ffs, 'm') != NULL);
-  try_dos = (vim_strchr(p_ffs, 'd') != NULL);
-  try_unix = (vim_strchr(p_ffs, 'x') != NULL);
+    // autocommands may have changed it
+    try_mac = (vim_strchr(p_ffs, 'm') != NULL);
+    try_dos = (vim_strchr(p_ffs, 'd') != NULL);
+    try_unix = (vim_strchr(p_ffs, 'x') != NULL);
 
-    if (msg_scrolled == n)
+    if (msg_scrolled == n) {
       msg_scroll = m;
+    }
 
     if (aborting()) {       /* autocmds may abort script processing */
       --no_wait_return;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -302,11 +302,11 @@ readfile (
   linenr_T skip_count = 0;
   linenr_T read_count = 0;
   int msg_save = msg_scroll;
-  linenr_T read_no_eol_lnum = 0;        /* non-zero lnum when last line of
-                                        * last read was missing the eol */
-  int try_mac = (vim_strchr(p_ffs, 'm') != NULL);
-  int try_dos = (vim_strchr(p_ffs, 'd') != NULL);
-  int try_unix = (vim_strchr(p_ffs, 'x') != NULL);
+  linenr_T read_no_eol_lnum = 0;        // non-zero lnum when last line of
+                                        // last read was missing the eol
+  int try_mac;
+  int try_dos;
+  int try_unix;
   int file_rewind = FALSE;
   int can_retry;
   linenr_T conv_error = 0;              /* line nr with conversion error */
@@ -639,6 +639,10 @@ readfile (
   curbuf->b_op_start.lnum = ((from == 0) ? 1 : from);
   curbuf->b_op_start.col = 0;
 
+  try_mac = (vim_strchr(p_ffs, 'm') != NULL);
+  try_dos = (vim_strchr(p_ffs, 'd') != NULL);
+  try_unix = (vim_strchr(p_ffs, 'x') != NULL);
+
   if (!read_buffer) {
     int m = msg_scroll;
     int n = msg_scrolled;
@@ -668,6 +672,12 @@ readfile (
     else
       apply_autocmds_exarg(EVENT_FILEREADPRE, sfname, sfname,
           FALSE, NULL, eap);
+
+  // autocommands may have changed it
+  try_mac = (vim_strchr(p_ffs, 'm') != NULL);
+  try_dos = (vim_strchr(p_ffs, 'd') != NULL);
+  try_unix = (vim_strchr(p_ffs, 'x') != NULL);
+
     if (msg_scrolled == n)
       msg_scroll = m;
 

--- a/src/nvim/testdir/test_fileformat.vim
+++ b/src/nvim/testdir/test_fileformat.vim
@@ -15,3 +15,17 @@ func Test_fileformat_after_bw()
   call assert_equal(test_fileformats, &fileformat)
   set fileformats&
 endfunc
+
+func Test_fileformat_autocommand()
+	let filecnt=['', 'foobar', 'eins', '', 'zwei', 'drei', 'vier', 'fünf', '']
+	let ffs=&ffs
+	call writefile(filecnt, 'Xfile', 'b')
+	au BufReadPre Xfile set ffs=dos ff=dos
+	new Xfile
+	call assert_equal('dos', &l:ff)
+	call assert_equal('dos', &ffs)
+	" cleanup
+	let &ffs=ffs
+	au! BufReadPre Xfile
+	bw!
+endfunc

--- a/src/nvim/testdir/test_fileformat.vim
+++ b/src/nvim/testdir/test_fileformat.vim
@@ -17,15 +17,17 @@ func Test_fileformat_after_bw()
 endfunc
 
 func Test_fileformat_autocommand()
-	let filecnt=['', 'foobar', 'eins', '', 'zwei', 'drei', 'vier', 'fünf', '']
-	let ffs=&ffs
-	call writefile(filecnt, 'Xfile', 'b')
-	au BufReadPre Xfile set ffs=dos ff=dos
-	new Xfile
-	call assert_equal('dos', &l:ff)
-	call assert_equal('dos', &ffs)
-	" cleanup
-	let &ffs=ffs
-	au! BufReadPre Xfile
-	bw!
+  let filecnt = ["\<CR>", "foobar\<CR>", "eins\<CR>", "\<CR>", "zwei\<CR>", "drei", "vier", "fünf", ""]
+  let ffs = &ffs
+  call writefile(filecnt, 'Xfile', 'b')
+  au BufReadPre Xfile set ffs=dos ff=dos
+  new Xfile
+  call assert_equal('dos', &l:ff)
+  call assert_equal('dos', &ffs)
+
+  " cleanup
+  call delete('Xfile')
+  let &ffs = ffs
+  au! BufReadPre Xfile
+  bw!
 endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -878,7 +878,7 @@ static const int included_patches[] = {
   229,
   // 228,
   // 227,
-  // 226,
+  226,
   // 225,
   224,
   223,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -880,7 +880,7 @@ static const int included_patches[] = {
   // 227,
   // 226,
   // 225,
-  // 224,
+  224,
   223,
   // 222,
   // 221 NA


### PR DESCRIPTION

vim-patch:8.0.0226                                                              

Problem:    The test for patch 8.0.0224 misses the CR characters and passes
            even without the fix. (Christian Brabandt)
Solution:   Use double quotes and \<CR>.

https://github.com/vim/vim/commit/1695f99d08076d77ed3015f1edf09a668a4d449a

vim-patch:8.0.0224

Problem:    When 'fileformats' is changed in a BufReadPre auto command, it
            does not take effect in readfile(). (Gary Johnson)
Solution:   Check the value of 'fileformats' after executing auto commands.
            (Christian Brabandt)

https://github.com/vim/vim/commit/7a2699e868bca781e26b060a44fc714d87cfa4ba