### PR TITLE
[RDY] vim-patch:8.0.0237

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4147,7 +4147,9 @@ addstar (
         || context == EXPAND_OWNSYNTAX
         || context == EXPAND_FILETYPE
         || context == EXPAND_PACKADD
-        || (context == EXPAND_TAGS && fname[0] == '/'))
+        || ((context == EXPAND_TAGS_LISTFILES
+             || context == EXPAND_TAGS)
+            && fname[0] == '/'))
       retval = vim_strnsave(fname, len);
     else {
       new_len = len + 2;                /* +2 for '^' at start, NUL at end */

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -268,3 +268,13 @@ func Test_illegal_address2()
   call delete('Xtest.vim')
 endfunc
 
+func Test_cmdline_complete_wildoptions()
+  help
+  call feedkeys(":tag /\<c-a>\<c-b>\"\<cr>", 'tx')
+  let a = join(sort(split(@:)),' ')
+  set wildoptions=tagfile
+  call feedkeys(":tag /\<c-a>\<c-b>\"\<cr>", 'tx')
+  let b = join(sort(split(@:)),' ')
+  call assert_equal(a, b)
+  bw!
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -867,7 +867,7 @@ static const int included_patches[] = {
   // 240 NA
   // 239 NA
   // 238,
-  // 237,
+  237,
   // 236,
   235,
   // 234,


### PR DESCRIPTION
Problem:    When setting wildoptions=tagfile the completion context is not set
            correctly. (desjardins)
Solution:   Check for EXPAND_TAGS_LISTFILES. (Christian Brabandt, closes vim/vim#1399)

https://github.com/vim/vim/commit/ba47b51ff88d91c9bb5aa522183e23a656865697