### PR TITLE
[RFC] vim-patch:8.0.0244 NA

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -860,7 +860,7 @@ static const int included_patches[] = {
   247,
   // 246 NA
   // 245,
-  // 244,
+  // 244 NA
   243,
   // 242,
   // 241 NA


### PR DESCRIPTION
Problem:    When the user sets t_BE empty after startup to disable bracketed
            paste, this has no direct effect.
Solution:   When t_BE is made empty write t_BD.  When t_BE is made non-empty
            write the new value.

https://github.com/vim/vim/commit/d9c60648e50a82dcb85b8dffb47f6416c3d56972

--------------
This patch should be ignore, because nvim doesn't have `terminal options`