### PR TITLE
[RFC] vim-patch:8.0.0245 vim-patch:8.0.0248

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -856,7 +856,7 @@ static const int included_patches[] = {
   // 251,
   250,
   // 249 NA
-  // 248,
+  // 248 NA
   247,
   // 246 NA
   245,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -859,7 +859,7 @@ static const int included_patches[] = {
   // 248,
   247,
   // 246 NA
-  // 245,
+  245,
   // 244,
   243,
   // 242,


### PR DESCRIPTION
vim-patch:8.0.0245
Problem:    The generated zh_CN.cp936.po message file is not encoded properly.
Solution:   Instead of using zh_CN.po as input, use zh_CN.UTF-8.po.

https://github.com/vim/vim/commit/16038d50c4309e8dee33c70ca2c9e7f73439c4df

vim-patch:8.0.0248 (ignored, because vim_strcat had replace by xstrlcat)
                                                                                
Problem:    vim_strcat() cannot handle overlapping arguments.
Solution:   Use mch_memmove() instead of strcpy(). (Justin M Keyes,
            closes vim/vim#1415)

https://github.com/vim/vim/commit/45600ce8f2bead069882032f992623cd5a799ca0
