### PR TITLE
process_close(): uv_unref() detached processes

### DIFF
--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -38,7 +38,7 @@ int libuv_process_spawn(LibuvProcess *uvproc)
 #endif
   uvproc->uvopts.exit_cb = exit_cb;
   uvproc->uvopts.cwd = proc->cwd;
-  uvproc->uvopts.env = NULL;
+  uvproc->uvopts.env = NULL;  // Inherits the parent (nvim) env.
   uvproc->uvopts.stdio = uvproc->uvstdio;
   uvproc->uvopts.stdio_count = 3;
   uvproc->uvstdio[0].flags = UV_IGNORE;

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -324,6 +324,22 @@ static void process_close(Process *proc)
   }
   assert(!proc->closed);
   proc->closed = true;
+
+  if (proc->detach) {
+    if (proc->in) {
+      uv_unref((uv_handle_t *)&proc->in->uv.pipe);
+    }
+    if (proc->out) {
+      uv_unref((uv_handle_t *)&proc->out->uv.pipe);
+    }
+    if (proc->err) {
+      uv_unref((uv_handle_t *)&proc->err->uv.pipe);
+    }
+    if (proc->type == kProcessTypeUv) {
+      uv_unref((uv_handle_t *)&(((LibuvProcess *)proc)->uv));
+    }
+  }
+
   switch (proc->type) {
     case kProcessTypeUv:
       libuv_process_close((LibuvProcess *)proc);

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -326,15 +326,6 @@ static void process_close(Process *proc)
   proc->closed = true;
 
   if (proc->detach) {
-    if (proc->in) {
-      uv_unref((uv_handle_t *)&proc->in->uv.pipe);
-    }
-    if (proc->out) {
-      uv_unref((uv_handle_t *)&proc->out->uv.pipe);
-    }
-    if (proc->err) {
-      uv_unref((uv_handle_t *)&proc->err->uv.pipe);
-    }
     if (proc->type == kProcessTypeUv) {
       uv_unref((uv_handle_t *)&(((LibuvProcess *)proc)->uv));
     }


### PR DESCRIPTION
Doc for UV_PROCESS_DETACHED in uv.h mentions:
> child process will still keep the parent's event loop alive unless
> the parent process calls uv_unref() on the child's process handle.

http://docs.libuv.org/en/v1.x/process.html?highlight=UV_PROCESS_DETACHED

Not sure if this will help anything, but given the explicit mention in the libuv docs, seems worth a try. cc @bfredl @oni-link 

ref #3944