### PR TITLE
Revert "rpc: Don't delay notifications when request is pending (#6544)"

### DIFF
--- a/runtime/autoload/remote/define.vim
+++ b/runtime/autoload/remote/define.vim
@@ -169,40 +169,14 @@ function! remote#define#FunctionOnChannel(channel, method, sync, name, opts)
   exe function_def
 endfunction
 
-let s:busy = {}
-let s:pending_notifications = {}
 
 function! s:GetRpcFunction(sync)
-  if a:sync ==# 'urgent'
-    return 'rpcnotify'
-  elseif a:sync
-    return 'remote#define#request'
+  if a:sync
+    return 'rpcrequest'
   endif
-  return 'remote#define#notify'
+  return 'rpcnotify'
 endfunction
 
-function! remote#define#notify(chan, ...)
-  if get(s:busy, a:chan, 0) > 0
-    let pending = get(s:pending_notifications, a:chan, [])
-    call add(pending, deepcopy(a:000))
-    let s:pending_notifications[a:chan] = pending
-  else
-    call call('rpcnotify', [a:chan] + a:000)
-  endif
-endfunction
-
-function! remote#define#request(chan, ...)
-  let s:busy[a:chan] = get(s:busy, a:chan, 0)+1
-  let val = call('rpcrequest', [a:chan]+a:000)
-  let s:busy[a:chan] -= 1
-  if s:busy[a:chan] == 0
-    for msg in get(s:pending_notifications, a:chan, [])
-      call call('rpcnotify', [a:chan] + msg)
-    endfor
-    let s:pending_notifications[a:chan] = []
-  endif
-  return val
-endfunction
 
 function! s:GetCommandPrefix(name, opts)
   return 'command!'.s:StringifyOpts(a:opts, ['nargs', 'complete', 'range',

--- a/src/clint.py
+++ b/src/clint.py
@@ -2531,7 +2531,6 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
                    r'(?<!\bkhash_t)'
                    r'(?<!\bkbtree_t)'
                    r'(?<!\bkbitr_t)'
-                   r'(?<!\bPMap)'
                    r'\((?:const )?(?:struct )?[a-zA-Z_]\w*(?: *\*(?:const)?)*\)'
                    r' +'
                    r'-?(?:\*+|&)?(?:\w+|\+\+|--|\()', cast_line)

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -109,28 +109,7 @@ describe('server -> client', function()
   end)
 
   describe('requests and notifications interleaved', function()
-    it('does not delay notifications during pending request', function()
-      local received = false
-      local function on_setup()
-        eq("retval", funcs.rpcrequest(cid, "doit"))
-        stop()
-      end
-      local function on_request(method)
-        if method == "doit" then
-          funcs.rpcnotify(cid, "headsup")
-          eq(true,received)
-          return "retval"
-        end
-      end
-      local function on_notification(method)
-        if method == "headsup" then
-          received = true
-        end
-      end
-      run(on_request, on_notification, on_setup)
-    end)
-
-    -- This tests the following scenario:
+    -- This tests that the following scenario won't happen:
     --
     -- server->client [request     ] (1)
     -- client->server [request     ] (2) triggered by (1)
@@ -145,38 +124,36 @@ describe('server -> client', function()
     -- only deals with one server->client request at a time. (In other words,
     -- the client cannot send a response to a request that is not at the top
     -- of nvim's request stack).
-    pending('will close connection if not properly synchronized', function()
+    --
+    -- But above scenario shoudn't happen by the way notifications are dealt in
+    -- Nvim: they are only sent after there are no pending server->client
+    -- request(the request stack fully unwinds). So (3) is only sent after the
+    -- client returns (6).
+    it('works', function()
+      local expected = 300
+      local notified = 0
       local function on_setup()
         eq('notified!', eval('rpcrequest('..cid..', "notify")'))
       end
 
       local function on_request(method)
-        if method == "notify" then
-          eq(1, eval('rpcnotify('..cid..', "notification")'))
-          return 'notified!'
-        elseif method == "nested" then
-          -- do some busywork, so the first request will return
-          -- before this one
-          for _ = 1, 5 do
-            eq(2, eval("1+1"))
-          end
-          eq(1, eval('rpcnotify('..cid..', "nested_done")'))
-          return 'done!'
-        end
+        eq('notify', method)
+        eq(1, eval('rpcnotify('..cid..', "notification")'))
+        return 'notified!'
       end
 
       local function on_notification(method)
-        if method == "notification" then
-          eq('done!', eval('rpcrequest('..cid..', "nested")'))
-        elseif method == "nested_done" then
-          -- this should never have been sent
-          ok(false)
+        eq('notification', method)
+        if notified == expected then
+          stop()
+          return
         end
+        notified = notified + 1
+        eq('notified!', eval('rpcrequest('..cid..', "notify")'))
       end
 
       run(on_request, on_notification, on_setup)
-      -- ignore disconnect failure, otherwise detected by after_each
-      clear()
+      eq(expected, notified)
     end)
   end)
 


### PR DESCRIPTION
desperate/lazy attempt to debug  https://github.com/neovim/neovim/issues/7504 , which occurs in ~30% of builds.

ref #6544