### PR TITLE
"tabgrid" (multiple top-level windows)

### DIFF
--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -199,6 +199,7 @@ static void ui_set_option(UI *ui, String name, Object value, Error *error)
   UI_EXT_OPTION(ext_popupmenu, kUIPopupmenu);
   UI_EXT_OPTION(ext_tabline, kUITabline);
   UI_EXT_OPTION(ext_wildmenu, kUIWildmenu);
+  UI_EXT_OPTION(ext_multigrid, kUIMultigrid);
 
   if (strequal(name.data, "popupmenu_external")) {
     // LEGACY: Deprecated option, use `ui_ext` instead.

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -91,4 +91,7 @@ void wildmenu_select(Integer selected)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 void wildmenu_hide(void)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
+
+void set_grid(Integer nr)
+  FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 #endif  // NVIM_API_UI_EVENTS_IN_H

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -58,6 +58,8 @@ void set_title(String title)
   FUNC_API_SINCE(3);
 void set_icon(String icon)
   FUNC_API_SINCE(3);
+void grid_cursor_goto(Integer grid, Integer row, Integer col)
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
 
 void popupmenu_show(Array items, Integer selected, Integer row, Integer col)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
@@ -92,6 +94,4 @@ void wildmenu_select(Integer selected)
 void wildmenu_hide(void)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 
-void set_grid(Integer nr)
-  FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 #endif  // NVIM_API_UI_EVENTS_IN_H

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1173,6 +1173,9 @@ struct window_S {
    * In a non-location list window, w_llist_ref is NULL.
    */
   qf_info_T   *w_llist_ref;
+
+  ScreenGrid grid; // own grid, only used for floats
+
 };
 
 static inline int win_hl_attr(win_T *wp, int hlf)

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -820,6 +820,9 @@ struct tabpage_S {
   ScopeDictDictItem tp_winvar;      ///< Variable for "t:" Dictionary.
   dict_T          *tp_vars;         ///< Internal variables, local to tab page.
   char_u          *tp_localdir;     ///< Absolute path of local cwd or NULL.
+
+
+  ScreenGrid grid; // own grid, only allocated when ext_multigrid
 };
 
 /*
@@ -1173,9 +1176,6 @@ struct window_S {
    * In a non-location list window, w_llist_ref is NULL.
    */
   qf_info_T   *w_llist_ref;
-
-  ScreenGrid grid; // own grid, only used for floats
-
 };
 
 static inline int win_hl_attr(win_T *wp, int hlf)

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -160,6 +160,7 @@ EXTERN int screen_Rows INIT(= 0);           /* actual size of ScreenLines[] */
 EXTERN int screen_Columns INIT(= 0);        /* actual size of ScreenLines[] */
 
 EXTERN ScreenGrid default_grid INIT(= {0});
+EXTERN ScreenGrid *current_grid INIT(= &default_grid);
 /*
  * When vgetc() is called, it sets mod_mask to the set of modifiers that are
  * held down based on the MOD_MASK_* symbols that are read first.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -16,7 +16,6 @@
 
 #define IOSIZE         (1024+1)          // file I/O and sprintf buffer size
 
-#define MAX_MCO        6                 // maximum value for 'maxcombine'
 
 # define MSG_BUF_LEN 480                 // length of buffer for small messages
 # define MSG_BUF_CLEN  (MSG_BUF_LEN / 6) // cell length (worst case: utf-8
@@ -126,12 +125,6 @@ typedef off_t off_T;
 #endif
 
 /*
- * The characters and attributes cached for the screen.
- */
-typedef char_u schar_T;
-typedef unsigned short sattr_T;
-
-/*
  * The characters that are currently on the screen are kept in ScreenLines[].
  * It is a single block of characters, the size of the screen plus one line.
  * The attributes for those characters are kept in ScreenAttrs[].
@@ -160,13 +153,13 @@ EXTERN u8char_T *ScreenLinesC[MAX_MCO];         /* composing characters */
 EXTERN int Screen_mco INIT(= 0);                /* value of p_mco used when
                                                    allocating ScreenLinesC[] */
 
-/* Only used for euc-jp: Second byte of a character that starts with 0x8e.
- * These are single-width. */
+/// Obsolete. Remove this when all enc_dbcs contitions are gone.
 EXTERN schar_T  *ScreenLines2 INIT(= NULL);
 
 EXTERN int screen_Rows INIT(= 0);           /* actual size of ScreenLines[] */
 EXTERN int screen_Columns INIT(= 0);        /* actual size of ScreenLines[] */
 
+EXTERN ScreenGrid default_grid INIT(= {0});
 /*
  * When vgetc() is called, it sets mod_mask to the set of modifiers that are
  * held down based on the MOD_MASK_* symbols that are read first.

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -689,7 +689,7 @@ void free_all_mem(void)
   }
 
   /* screenlines (can't display anything now!) */
-  free_screenlines();
+  free_screengrid(&default_grid);
 
   clear_hl_tables();
 }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4129,6 +4129,9 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
   }
   /* (re)set tab page line */
   else if (pp == &p_stal) {
+    if (ui_is_external(kUIMultigrid)) {
+      p_stal=0;
+    }
     shell_new_rows();           /* recompute window positions and heights */
   }
   /* 'foldlevel' */

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -264,7 +264,7 @@ void update_curbuf(int type)
 
 
 void set_tabpage_grid(tabpage_T* tp) {
-  ui_call_set_grid(tp->handle);
+  ui_set_grid(tp->handle);
   if (tp->grid.Columns == 0 || tp->grid.Rows == 0) {
     alloc_screengrid(&tp->grid, Rows, Columns, false);
     ui_call_resize(tp->grid.Columns, tp->grid.Rows);

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -15,4 +15,27 @@ typedef uint32_t u8char_T;
 
 typedef struct expand expand_T;
 
+#define MAX_MCO        6                 // maximum value for 'maxcombine'
+
+/*
+ * The characters and attributes cached for the screen.
+ */
+typedef char_u schar_T;
+typedef unsigned short sattr_T;
+
+// TODO(bfredl): find me a good home
+typedef struct {
+  schar_T  *ScreenLines;
+  sattr_T  *ScreenAttrs;
+  unsigned *LineOffset;
+  char_u   *LineWraps;
+
+  u8char_T *ScreenLinesUC;
+  u8char_T *ScreenLinesC[MAX_MCO];
+  int Screen_mco;
+
+  int Rows;
+  int Columns;
+} ScreenGrid;
+
 #endif  // NVIM_TYPES_H

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -284,6 +284,17 @@ void ui_refresh(void)
   screen_resize(width, height);
   p_lz = save_p_lz;
 
+  // HACK: assume client connects when only one tabpage exists
+  if (ext_widgets[kUIMultigrid] && !ui_ext[kUIMultigrid]) {
+    memcpy(&curtab->grid,&default_grid,sizeof(default_grid));
+    memset(&default_grid,0,sizeof(default_grid));
+    current_grid = &curtab->grid;
+    p_stal = 0;
+    do_cmdline_cmd("redraw!"); // HAXX
+  } else if (!ext_widgets[kUIMultigrid] && ui_ext[kUIMultigrid]) {
+    abort(); // for now
+  }
+
   for (UIWidget i = 0; (int)i < UI_WIDGETS; i++) {
     ui_set_external(i, ext_widgets[i]);
   }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -60,6 +60,7 @@ static bool pending_cursor_update = false;
 static int busy = 0;
 static int height, width;
 static int old_mode_idx = -1;
+static int grid = 1;
 
 #if MIN_LOG_LEVEL > DEBUG_LOG_LEVEL
 # define UI_LOG(funname, ...)
@@ -466,6 +467,14 @@ void ui_putc(uint8_t c)
   ui_puts(buf);
 }
 
+void ui_set_grid(int new_grid) {
+  if (new_grid != grid) {
+    grid = new_grid;
+    pending_cursor_update = true;
+  }
+}
+
+
 void ui_cursor_goto(int new_row, int new_col)
 {
   if (new_row == row && new_col == col) {
@@ -537,7 +546,11 @@ static void flush_cursor_update(void)
 {
   if (pending_cursor_update) {
     pending_cursor_update = false;
-    ui_call_cursor_goto(row, col);
+    if (ui_is_external(kUIMultigrid)) {
+      ui_call_grid_cursor_goto(grid, row, col);
+    } else {
+      ui_call_cursor_goto(row, col);
+    }
   }
 }
 

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -13,8 +13,9 @@ typedef enum {
   kUIPopupmenu,
   kUITabline,
   kUIWildmenu,
+  kUIMultigrid,
 } UIWidget;
-#define UI_WIDGETS (kUIWildmenu + 1)
+#define UI_WIDGETS (kUIMultigrid + 1)
 
 typedef struct {
   bool bold, underline, undercurl, italic, reverse;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3256,6 +3256,11 @@ leave_tabpage (
  */
 static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, int trigger_enter_autocmds, int trigger_leave_autocmds)
 {
+
+  if (ui_is_external(kUIMultigrid)) {
+    set_tabpage_grid(tp);
+  }
+
   int old_off = tp->tp_firstwin->w_winrow;
   win_T       *next_prevwin = tp->tp_prevwin;
 
@@ -3368,6 +3373,7 @@ void goto_tabpage_tp(tabpage_T *tp, int trigger_enter_autocmds, int trigger_leav
 
   if (tp != curtab && leave_tabpage(tp->tp_curwin->w_buffer,
           trigger_leave_autocmds) == OK) {
+
     if (valid_tabpage(tp))
       enter_tabpage(tp, curbuf, trigger_enter_autocmds,
           trigger_leave_autocmds);


### PR DESCRIPTION
This enables a external ui to draw multiple top-level windows from one nvim instance. Currently, follows the simple formula "one tabpage == one top-level window". Thus, tab commands as `tabnew` and `tabnext` manage top-level windows when `ext_multigrid` is active.

Can be tested with the multigrid branch of python-gui https://github.com/neovim/python-gui/pull/36. The pyhon-gui code is a big mess though because I changed my mind 5 times how to communicate grid/cursor focus to the UI. I might clean it up later. The rule I ended up with was to manage grids together with cursor position: the most recent `set_grid` tells the cilent the current grid, and together with the most recent `set_cursor` forms the 3-tuple `(grid_id, row, col)`which tells where drawing is done, and this state at the end of a `"redraw"` array of updates should be seen as the current focus. Perhaps the event should be changed to a joint `grid_cursor_goto(grid_id, row, col)` to make this explicit. Also `resize` and `scroll` operates on the currently focused grid. 

Currently, keyboard input, mouse, and resizing with the mouse only works as expected for the (according to nvim) currently focused tabpage.

NB: expect a lot of redraw glitches and crashes. Before working much more on this I intend to get #6619 done, which already will introduce the generic multigrid abstraction, and "just" drawing buffer lines on a separate grid has lot less glitches than drawing exactly everything on multiple grids

Related: #2161 #5686 #2464 

