### PR TITLE
[RFC] make: ability to list targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,3 +144,8 @@ appimage:
 lint: check-single-includes clint testlint lualint
 
 .PHONY: test testlint lualint functionaltest unittest lint clint clean distclean nvim libnvim cmake deps install appimage
+
+.PHONY: no_targets__ list
+no_targets__:
+list:
+	sh -c "$(MAKE) -p no_targets__ | awk -F':' '/^[a-zA-Z0-9][^\$$#\/\\t=]*:([^=]|$$)/ {split(\$$1,A,/ /);for(i in A)print A[i]}' | grep -v '__\$$' | sort"


### PR DESCRIPTION
This isn't necessary, but it's a nice feature to have when others wanted to know 
what targets they can use. 
Executing this `$ make -s list` to view a listing of the available targets to build from.
I give credit from an answer that is posted from here:
<https://stackoverflow.com/questions/4219255/how-do-you-get-the-list-of-targets-in-a-makefile/15058900#15058900>

I can make note of this feature in the `README.md` and from wiki.

Please let me know to drop this or make any changes.