### PR TITLE
:terminal : fix crash on resize

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -64,7 +64,6 @@
 #include "nvim/spell.h"
 #include "nvim/strings.h"
 #include "nvim/syntax.h"
-#include "nvim/terminal.h"
 #include "nvim/ui.h"
 #include "nvim/undo.h"
 #include "nvim/version.h"
@@ -1463,12 +1462,6 @@ void enter_buffer(buf_T *buf)
 
   /* mark cursor position as being invalid */
   curwin->w_valid = 0;
-
-  if (buf->terminal) {
-    terminal_resize(buf->terminal,
-                    (uint16_t)(MAX(0, curwin->w_width - win_col_off(curwin))),
-                    (uint16_t)curwin->w_height);
-  }
 
   /* Make sure the buffer is loaded. */
   if (curbuf->b_ml.ml_mfp == NULL) {    /* need to load the file */

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -696,8 +696,8 @@ static void win_update(win_T *wp)
 
     if (buf->terminal) {
       terminal_resize(buf->terminal,
-                      (uint16_t)(MAX(0, curwin->w_width - win_col_off(curwin))),
-                      (uint16_t)curwin->w_height);
+                      (uint16_t)(MAX(0, wp->w_width - win_col_off(wp))),
+                      (uint16_t)wp->w_height);
     }
   } else if (buf->b_mod_set
              && buf->b_mod_xlines != 0

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1846,12 +1846,6 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf,
       shell_new_rows();
   }
 
-  if (term) {
-    // When a window containing a terminal buffer is closed, recalculate its
-    // size
-    terminal_resize(term, 0, 0);
-  }
-
   // Since goto_tabpage_tp above did not trigger *Enter autocommands, do
   // that now.
   apply_autocmds(EVENT_TABCLOSED, prev_idx, prev_idx, false, curbuf);
@@ -3745,12 +3739,6 @@ static void win_enter_ext(win_T *wp, bool undo_sync, int curwin_invalid,
 
   /* Change directories when the 'acd' option is set. */
   do_autochdir();
-
-  if (curbuf->terminal) {
-    terminal_resize(curbuf->terminal,
-                    (uint16_t)(MAX(0, curwin->w_width - win_col_off(curwin))),
-                    (uint16_t)curwin->w_height);
-  }
 }
 
 
@@ -4930,9 +4918,7 @@ void scroll_to_fraction(win_T *wp, int prev_height)
   }
 }
 
-/*
- * Set the width of a window.
- */
+/// Set the width of a window.
 void win_new_width(win_T *wp, int width)
 {
   wp->w_width = width;
@@ -4949,7 +4935,7 @@ void win_new_width(win_T *wp, int width)
   if (wp->w_buffer->terminal) {
     if (wp->w_height != 0) {
       terminal_resize(wp->w_buffer->terminal,
-                      (uint16_t)(MAX(0, curwin->w_width - win_col_off(curwin))),
+                      (uint16_t)(MAX(0, wp->w_width - win_col_off(wp))),
                       0);
     }
   }

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -101,7 +101,7 @@ describe('terminal mouse', function()
           line28                   |line28                  |
           line29                   |line29                  |
           line30                   |line30                  |
-          rows: 5, cols: 25        |rows: 5, cols: 25       |
+          rows: 5, cols: 24        |rows: 5, cols: 24       |
           {2:^ }                        |{2: }                       |
           ==========                ==========              |
           :vsp                                              |
@@ -111,7 +111,7 @@ describe('terminal mouse', function()
           {7:  1 }^                     |line28                  |
           {4:~                        }|line29                  |
           {4:~                        }|line30                  |
-          {4:~                        }|rows: 5, cols: 25       |
+          {4:~                        }|rows: 5, cols: 24       |
           {4:~                        }|{2: }                       |
           ==========                ==========              |
           :enew | set number                                |
@@ -121,16 +121,16 @@ describe('terminal mouse', function()
           {7: 27 }line                 |line28                  |
           {7: 28 }line                 |line29                  |
           {7: 29 }line                 |line30                  |
-          {7: 30 }line                 |rows: 5, cols: 25       |
+          {7: 30 }line                 |rows: 5, cols: 24       |
           {7: 31 }^                     |{2: }                       |
           ==========                ==========              |
                                                             |
         ]])
         feed('<c-w>li')
         screen:expect([[
-          {7: 27 }line                 |line29                  |
-          {7: 28 }line                 |line30                  |
-          {7: 29 }line                 |rows: 5, cols: 25       |
+          {7: 27 }line                 |line28                  |
+          {7: 28 }line                 |line29                  |
+          {7: 29 }line                 |line30                  |
           {7: 30 }line                 |rows: 5, cols: 24       |
           {7: 31 }                     |{1: }                       |
           ==========                ==========              |
@@ -140,8 +140,8 @@ describe('terminal mouse', function()
         thelpers.enable_mouse()
         thelpers.feed_data('mouse enabled\n')
         screen:expect([[
-          {7: 27 }line                 |line30                  |
-          {7: 28 }line                 |rows: 5, cols: 25       |
+          {7: 27 }line                 |line29                  |
+          {7: 28 }line                 |line30                  |
           {7: 29 }line                 |rows: 5, cols: 24       |
           {7: 30 }line                 |mouse enabled           |
           {7: 31 }                     |{1: }                       |
@@ -153,8 +153,8 @@ describe('terminal mouse', function()
       it('wont lose focus if another window is scrolled', function()
         feed('<ScrollWheelUp><0,0><ScrollWheelUp><0,0>')
         screen:expect([[
-          {7: 21 }line                 |line30                  |
-          {7: 22 }line                 |rows: 5, cols: 25       |
+          {7: 21 }line                 |line29                  |
+          {7: 22 }line                 |line30                  |
           {7: 23 }line                 |rows: 5, cols: 24       |
           {7: 24 }line                 |mouse enabled           |
           {7: 25 }line                 |{1: }                       |
@@ -163,8 +163,8 @@ describe('terminal mouse', function()
         ]])
         feed('<S-ScrollWheelDown><0,0>')
         screen:expect([[
-          {7: 26 }line                 |line30                  |
-          {7: 27 }line                 |rows: 5, cols: 25       |
+          {7: 26 }line                 |line29                  |
+          {7: 27 }line                 |line30                  |
           {7: 28 }line                 |rows: 5, cols: 24       |
           {7: 29 }line                 |mouse enabled           |
           {7: 30 }line                 |{1: }                       |
@@ -176,8 +176,8 @@ describe('terminal mouse', function()
       it('will lose focus if another window is clicked', function()
         feed('<LeftMouse><5,1>')
         screen:expect([[
-          {7: 27 }line                 |line30                  |
-          {7: 28 }l^ine                 |rows: 5, cols: 25       |
+          {7: 27 }line                 |line29                  |
+          {7: 28 }l^ine                 |line30                  |
           {7: 29 }line                 |rows: 5, cols: 24       |
           {7: 30 }line                 |mouse enabled           |
           {7: 31 }                     |{2: }                       |

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -3,6 +3,9 @@ local thelpers = require('test.functional.terminal.helpers')
 local clear = helpers.clear
 local feed, nvim = helpers.feed, helpers.nvim
 local feed_command = helpers.feed_command
+local command = helpers.command
+local eq = helpers.eq
+local eval = helpers.eval
 
 describe('terminal', function()
   local screen
@@ -22,72 +25,66 @@ describe('terminal', function()
     screen:detach()
   end)
 
-  it('resets its size when entering terminal window', function()
+  it('next to a closing window', function()
+    command('split')
+    command('terminal')
+    command('vsplit foo')
+    eq(3, eval("winnr('$')"))
+    feed('ZQ')  -- Close split, should not crash. #7538
+    eq(2, eval("1+1"))  -- Still alive?
+  end)
+
+  it('does not change size on WinEnter', function()
     if helpers.pending_win32(pending) then return end
     feed('<c-\\><c-n>')
     feed_command('2split')
     screen:expect([[
-      rows: 2, cols: 50                                 |
-      {2:^ }                                                 |
+      tty ready                                         |
+      ^rows: 5, cols: 50                                 |
       ==========                                        |
-      rows: 2, cols: 50                                 |
+      tty ready                                         |
+      rows: 5, cols: 50                                 |
       {2: }                                                 |
-      {4:~                                                 }|
-      {4:~                                                 }|
-      {4:~                                                 }|
+                                                        |
+                                                        |
       ==========                                        |
       :2split                                           |
     ]])
     feed_command('wincmd p')
     screen:expect([[
       tty ready                                         |
-      rows: 2, cols: 50                                 |
+      rows: 5, cols: 50                                 |
       ==========                                        |
       tty ready                                         |
-      rows: 2, cols: 50                                 |
-      rows: 5, cols: 50                                 |
+      ^rows: 5, cols: 50                                 |
       {2: }                                                 |
-      ^                                                  |
-      ==========                                        |
-      :wincmd p                                         |
-    ]])
-    feed_command('wincmd p')
-    screen:expect([[
-      rows: 2, cols: 50                                 |
-      {2:^ }                                                 |
-      ==========                                        |
-      rows: 2, cols: 50                                 |
-      {2: }                                                 |
-      {4:~                                                 }|
-      {4:~                                                 }|
-      {4:~                                                 }|
+                                                        |
+                                                        |
       ==========                                        |
       :wincmd p                                         |
     ]])
   end)
 
-  describe('when the screen is resized', function()
-    it('will forward a resize request to the program', function()
-      feed([[<C-\><C-N>:]])  -- Go to cmdline-mode, so cursor is at bottom.
-      screen:try_resize(screen._width - 3, screen._height - 2)
-      screen:expect([[
-        tty ready                                      |
-        rows: 7, cols: 47                              |
-        {2: }                                              |
-                                                       |
-                                                       |
-                                                       |
-                                                       |
-        :^                                              |
-      ]])
-      screen:try_resize(screen._width - 6, screen._height - 3)
-      screen:expect([[
-        tty ready                                |
-        rows: 7, cols: 47                        |
-        rows: 4, cols: 41                        |
-        {2: }                                        |
-        :^                                        |
-      ]])
-    end)
+  it('forwards resize request to the program', function()
+    feed([[<C-\><C-N>:]])  -- Go to cmdline-mode, so cursor is at bottom.
+    screen:try_resize(screen._width - 3, screen._height - 2)
+    screen:expect([[
+      tty ready                                      |
+      rows: 7, cols: 47                              |
+      {2: }                                              |
+                                                     |
+                                                     |
+                                                     |
+                                                     |
+      :^                                              |
+    ]])
+    screen:try_resize(screen._width - 6, screen._height - 3)
+    screen:expect([[
+      tty ready                                |
+      rows: 7, cols: 47                        |
+      rows: 4, cols: 41                        |
+      {2: }                                        |
+      :^                                        |
+    ]])
   end)
 end)


### PR DESCRIPTION
closes #7538
Fix wrong window references from #7440

Remove some eager resizing. Still mostly doesn't address #4997.