### PR TITLE
vim-patch:8.0.0227

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1622,7 +1622,8 @@ rewind_retry:
             *ptr = NUL;                         /* end of line */
             len = (colnr_T)(ptr - line_start + 1);
             if (fileformat == EOL_DOS) {
-              if (ptr[-1] == CAR) {             /* remove CR */
+              if (ptr > line_start && ptr[-1] == CAR) {
+                // remove CR before NL
                 ptr[-1] = NUL;
                 len--;
               } else if (ff_error != EOL_DOS) {

--- a/src/nvim/testdir/test_fileformat.vim
+++ b/src/nvim/testdir/test_fileformat.vim
@@ -17,7 +17,7 @@ func Test_fileformat_after_bw()
 endfunc
 
 func Test_fileformat_autocommand()
-  let filecnt = ["\<CR>", "foobar\<CR>", "eins\<CR>", "\<CR>", "zwei\<CR>", "drei", "vier", "fünf", ""]
+  let filecnt = ["", "foobar\<CR>", "eins\<CR>", "\<CR>", "zwei\<CR>", "drei", "vier", "fünf", ""]
   let ffs = &ffs
   call writefile(filecnt, 'Xfile', 'b')
   au BufReadPre Xfile set ffs=dos ff=dos


### PR DESCRIPTION
Problem:    Crash when 'fileformat' is forced to "dos" and the first line in
            the file is empty and does not have a CR character.
Solution:   Don't check for CR before the start of the buffer.

https://github.com/vim/vim/commit/2aa5f696b91a51f29873e340de4bdc182e1e8dd4