### PR TITLE
fix copying setl options for buffer currently displayed in another window

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2381,8 +2381,15 @@ void get_winopts(buf_T *buf)
   clear_winopt(&curwin->w_onebuf_opt);
   clearFolding(curwin);
 
-  wip = find_wininfo(buf, TRUE);
-  if (wip != NULL && wip->wi_optset) {
+  wip = find_wininfo(buf, true);
+  if (wip != NULL && wip->wi_win != curwin && wip->wi_win != NULL
+      && wip->wi_win->w_buffer == buf) {
+    win_T *wp = wip->wi_win;
+    copy_winopt(&wp->w_onebuf_opt, &curwin->w_onebuf_opt);
+    curwin->w_fold_manual = wp->w_fold_manual;
+    curwin->w_foldinvalid = true;
+    cloneFoldGrowArray(&wp->w_folds, &curwin->w_folds);
+  } else if (wip != NULL && wip->wi_optset) {
     copy_winopt(&wip->wi_opt, &curwin->w_onebuf_opt);
     curwin->w_fold_manual = wip->wi_fold_manual;
     curwin->w_foldinvalid = true;

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -287,3 +287,55 @@ func Test_set_indentexpr()
   call assert_equal('', &indentexpr)
   bwipe!
 endfunc
+
+func Test_copy_winopt()
+  set hidden
+
+  " Test copy option from current buffer in window
+  split
+  enew
+  setlocal numberwidth=5
+  wincmd w
+  call assert_equal(4,&numberwidth)
+  bnext
+  call assert_equal(5,&numberwidth)
+  bw!
+  call assert_equal(4,&numberwidth)
+
+  " Test copy value from window that used to be display the buffer
+  split
+  enew
+  setlocal numberwidth=6
+  bnext
+  wincmd w
+  call assert_equal(4,&numberwidth)
+  bnext
+  call assert_equal(6,&numberwidth)
+  bw!
+
+  " Test that if buffer is current, don't use the stale cached value
+  " from the last time the buffer was displayed.
+  split
+  enew
+  setlocal numberwidth=7
+  bnext
+  bnext
+  setlocal numberwidth=8
+  wincmd w
+  call assert_equal(4,&numberwidth)
+  bnext
+  call assert_equal(8,&numberwidth)
+  bw!
+
+  " Test value is not copied if window already has seen the buffer
+  enew
+  split
+  setlocal numberwidth=9
+  bnext
+  setlocal numberwidth=10
+  wincmd w
+  call assert_equal(4,&numberwidth)
+  bnext
+  call assert_equal(4,&numberwidth)
+  bw!
+endfunc


### PR DESCRIPTION
In this sequence of commands the buffer-local value of window option `winhl` is copied
```
e /tmp/xx
split
e /tmp/yy
setl winhl=Normal:ErrorMsg
b /tmp/xx
wincmd w
b /tmp/yy
```
but NOT in this sequence
```
e /tmp/xx
split
e /tmp/yy
setl winhl=Normal:ErrorMsg
wincmd w
b /tmp/yy
```

This seem counter to the intended behavior stated at https://github.com/neovim/neovim/blob/e6beb60da517b6d7d7461687bf91f87d097b9563/src/nvim/buffer.c#L2353 . At least the discrepancy seems quite jarring.

As discussed with @leonerd on IRC/Gitter, this will make filetype autocmds that `setl` window options behave more reasonably.