### PR TITLE
defaults: scrollback=10000

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4789,7 +4789,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	height with ":set scroll=0".
 
 						*'scrollback'* *'scbk'*
-'scrollback' 'scbk'	number	(default: 1000
+'scrollback' 'scbk'	number	(default: 10000
 				 in normal buffers: -1)
 			local to buffer
 	Maximum number of lines kept beyond the visible screen. Lines at the

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1924,7 +1924,7 @@ return {
       vi_def=true,
       varname='p_scbk',
       redraw={'current_buffer'},
-      defaults={if_true={vi=1000}}
+      defaults={if_true={vi=10000}}
     },
     {
       full_name='scrollbind', abbreviation='scb',

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -462,10 +462,10 @@ describe("'scrollback' option", function()
     screen:detach()
   end)
 
-  it('defaults to 1000 in terminal buffers', function()
+  it('defaults to 10000 in terminal buffers', function()
     set_fake_shell()
     command('terminal')
-    eq(1000, curbufmeths.get_option('scrollback'))
+    eq(10000, curbufmeths.get_option('scrollback'))
   end)
 
   it('error if set to invalid value', function()


### PR DESCRIPTION
1000 often truncates one-off commands, so default to 10000.