### PR TITLE
:checkhealth: fix logic error when checking for npm and yarn

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -496,7 +496,7 @@ function! s:check_node() abort
     return
   endif
 
-  if !executable('node') || !executable('npm') || !executable('yarn')
+  if !executable('node') || !executable('npm')
     call health#report_warn(
           \ '`node` and `npm` must be in $PATH.',
           \ ['Install Node.js and verify that `node` and `npm` commands work.'])


### PR DESCRIPTION
Fix bug that checked for npm AND yarn, where we wanted npm OR yarn.
But since we call `npm` exclusively, and it's highly unlikely you have
yarn installed without npm, let's just remove the yarn check altogether.

Addresses https://github.com/neovim/node-client/issues/41