### PR TITLE
Fix example of pathshorten() to use ~/.config/nvim

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5811,7 +5811,7 @@ pathshorten({expr})					*pathshorten()*
 		components in the path are reduced to single letters.  Leading
 		'~' and '.' characters are kept.  Example: >
 			:echo pathshorten('~/.config/nvim/autoload/file1.vim')
-<			~/.v/a/file1.vim ~
+<			~/.c/n/a/file1.vim ~
 		It doesn't matter if the path exists or not.
 
 pow({x}, {y})						*pow()*


### PR DESCRIPTION
The old example seems to assume a path of `~/.vim/autoload/file1.vim` rather than `~/.config/nvim/autoload/file1.vim`.