### PR TITLE
tui: 'guicursor': use DECSCUSR for xterm-likes

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -14,8 +14,6 @@
 #include "nvim/event/rstream.h"
 
 #define PASTETOGGLE_KEY "<Paste>"
-#define FOCUSGAINED_KEY "<FocusGained>"
-#define FOCUSLOST_KEY   "<FocusLost>"
 #define KEY_BUFFER_SIZE 0xfff
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1453,12 +1453,10 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     data->unibi_ext.set_cursor_style = unibi_find_ext_str(ut, "Ss");
   }
   if (-1 == data->unibi_ext.set_cursor_style) {
-    // The DECSCUSR sequence to change the cursor shape is widely
-    // supported by several terminal types and should be in many
-    // teminfo entries.  See
-    // https://github.com/gnachman/iTerm2/pull/92 for more.
-    // xterm even has an extended version that has a vertical bar.
-    if (!konsole && (true_xterm    // per xterm ctlseqs doco (since version 282)
+    // The DECSCUSR sequence to change the cursor shape is widely supported by
+    // several terminal types.  https://github.com/gnachman/iTerm2/pull/92
+    // xterm extension: vertical bar
+    if (!konsole && ((xterm && !vte_version)  // anything claiming xterm compat
         // per MinTTY 0.4.3-1 release notes from 2009
         || putty
         // per https://bugzilla.gnome.org/show_bug.cgi?id=720821
@@ -1470,9 +1468,8 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
         // per analysis of VT100Terminal.m
         || iterm || iterm_pretending_xterm
         || teraterm    // per TeraTerm "Supported Control Functions" doco
-        // Allows forcing the use of DECSCUSR on linux type terminals, such as
-        // console-terminal-emulator from the nosh toolset, which does indeed
-        // implement the xterm extension:
+        // Some linux-type terminals (such as console-terminal-emulator
+        // from the nosh toolset) implement implement the xterm extension.
         || (linuxvt && (xterm_version || (vte_version > 0) || colorterm)))) {
       data->unibi_ext.set_cursor_style =
         (int)unibi_add_ext_str(ut, "Ss", "\x1b[%p1%d q");


### PR DESCRIPTION
Anything claiming to be an xterm gets DECSCUSR. This is the only
reasonable choice unless/until we get more reliable detection (#7490).

ref #6997
closes #7550

cc @DarkDefender 