### PR TITLE
provider: Fix ruby and node providers for Windows

### DIFF
--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -19,13 +19,17 @@ function! provider#node#Require(host) abort
     return
   endif
 
-  let args = ['node']
+  if has('win32')
+    let args = ['node']
 
-  if !empty($NVIM_NODE_HOST_DEBUG)
-    call add(args, '--inspect-brk')
+    if !empty($NVIM_NODE_HOST_DEBUG)
+      call add(args, '--inspect-brk')
+    endif
+
+    call add(args , provider#node#Prog())
+  else
+    let args = provider#node#Prog()
   endif
-
-  call add(args , provider#node#Prog())
 
   try
     let channel_id = jobstart(args, s:job_opts)

--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -6,7 +6,7 @@ let g:loaded_node_provider = 1
 let s:job_opts = {'rpc': v:true, 'on_stderr': function('provider#stderr_collector')}
 
 function! provider#node#Detect() abort
-  return exepath('neovim-node-host')
+  return has('win32') ? exepath('neovim-node-host.cmd') : exepath('neovim-node-host')
 endfunction
 
 function! provider#node#Prog()

--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -20,6 +20,8 @@ function! provider#node#Require(host) abort
   endif
 
   if has('win32')
+    let args = provider#node#Prog()
+  else
     let args = ['node']
 
     if !empty($NVIM_NODE_HOST_DEBUG)
@@ -27,8 +29,6 @@ function! provider#node#Require(host) abort
     endif
 
     call add(args , provider#node#Prog())
-  else
-    let args = provider#node#Prog()
   endif
 
   try

--- a/runtime/autoload/provider/ruby.vim
+++ b/runtime/autoload/provider/ruby.vim
@@ -19,7 +19,7 @@ function! provider#ruby#Detect() abort
   if exists("g:ruby_host_prog")
     return g:ruby_host_prog
   else
-    return exepath('neovim-ruby-host')
+    return has('win32') ? exepath('neovim-ruby-host.cmd') : exepath('neovim-ruby-host')
   end
 endfunction
 


### PR DESCRIPTION
Add some workarounds because of `exepath` return non-executable files in Windows and the current viml for node provider attempts to run the shell script via node.

I like to test this in Appveyor but node and ruby aren't installed there in the current builds.

This should resolve my issues mentioned in #7568 but I don't have a use case for these providers and I don't know what plugins to test these providers with besides https://github.com/clojure-vim/nvim-parinfer.js