### PR TITLE
[RDY] vim-patch:8.0.0283

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5660,9 +5660,13 @@ mode([expr])	Return a string that indicates the current mode.
 			S	Select by line
 			CTRL-S	Select blockwise
 			i	Insert
+			ic	Insert mode completion |compl-generic|
+			ix	Insert mode |i_CTRL-X| completion
 			R	Replace |R|
+			Rc	Replace mode completion |compl-generic|
 			Rv	Virtual Replace |gR|
-			c	Command-line
+			Rx	Replace mode |i_CTRL-X| completion
+			c	Command-line editing
 			cv	Vim Ex mode |gQ|
 			ce	Normal Ex mode |Q|
 			r	Hit-enter prompt

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -14,6 +14,8 @@
 #include "nvim/option_defs.h"
 #include "nvim/ui.h"
 #include "nvim/os/input.h"
+#include "nvim/ex_docmd.h"
+#include "nvim/edit.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "state.c.generated.h"
@@ -127,19 +129,25 @@ char *get_mode(void)
     if (State & VREPLACE_FLAG) {
       buf[0] = 'R';
       buf[1] = 'v';
-    } else if (State & REPLACE_FLAG) {
-      buf[0] = 'R';
     } else {
-      buf[0] = 'i';
+      if (State & REPLACE_FLAG) {
+        buf[0] = 'R';
+      } else {
+        buf[0] = 'i';
+      }
+      if (ins_compl_active()) {
+        buf[1] = 'c';
+      } else if (ctrl_x_mode == 1) {
+        buf[1] = 'x';
+      }
     }
-  } else if (State & CMDLINE) {
+  } else if (State & CMDLINE || exmode_active) {
     buf[0] = 'c';
-    if (exmode_active) {
+    if (exmode_active == EXMODE_VIM) {
       buf[1] = 'v';
+    } else if (exmode_active == EXMODE_NORMAL) {
+      buf[1] = 'e';
     }
-  } else if (exmode_active) {
-    buf[0] = 'c';
-    buf[1] = 'e';
   } else if (State & TERM_FOCUS) {
     buf[0] = 't';
   } else {

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -191,4 +191,89 @@ func Test_toupper()
   call assert_equal("ⱥ ⱦ", tolower("Ⱥ Ⱦ"))
 endfunc
 
+" Tests for the mode() function
+let current_modes = ''
+func! Save_mode()
+  let g:current_modes = mode(0) . '-' . mode(1)
+  return ''
+endfunc
 
+func! Test_mode()
+  new
+  call append(0, ["Blue Ball Black", "Brown Band Bowl", ""])
+
+  inoremap <F2> <C-R>=Save_mode()<CR>
+
+  normal! 3G
+  exe "normal i\<F2>\<Esc>"
+  call assert_equal('i-i', g:current_modes)
+  exe "normal i\<C-G>uBa\<C-P>\<F2>\<Esc>u"
+  call assert_equal('i-ic', g:current_modes)
+  exe "normal iBro\<C-P>\<F2>\<Esc>u"
+  call assert_equal('i-ic', g:current_modes)
+  exe "normal iBa\<C-X>\<F2>\<Esc>u"
+  call assert_equal('i-ix', g:current_modes)
+  exe "normal iBa\<C-X>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('i-ic', g:current_modes)
+  exe "normal iBro\<C-X>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('i-ic', g:current_modes)
+  exe "normal iBro\<C-X>\<C-P>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('i-ic', g:current_modes)
+  exe "normal iCom\<C-P>\<F2>\<Esc>u"
+  call assert_equal('i-ic', g:current_modes)
+  exe "normal iCom\<C-X>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('i-ic', g:current_modes)
+
+  exe "normal RBa\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rc', g:current_modes)
+  exe "normal RBro\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rc', g:current_modes)
+  exe "normal RBa\<C-X>\<F2>\<Esc>u"
+  call assert_equal('R-Rx', g:current_modes)
+  exe "normal RBa\<C-X>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rc', g:current_modes)
+  exe "normal RBro\<C-X>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rc', g:current_modes)
+  exe "normal RBro\<C-X>\<C-P>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rc', g:current_modes)
+  exe "normal RCom\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rc', g:current_modes)
+  exe "normal RCom\<C-X>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rc', g:current_modes)
+
+  call assert_equal('n', mode(0))
+  call assert_equal('n', mode(1))
+
+  " How to test operator-pending mode?
+
+  call feedkeys("v", 'xt')
+  call assert_equal('v', mode())
+  call assert_equal('v', mode(1))
+  call feedkeys("\<Esc>V", 'xt')
+  call assert_equal('V', mode())
+  call assert_equal('V', mode(1))
+  call feedkeys("\<Esc>\<C-V>", 'xt')
+  call assert_equal("\<C-V>", mode())
+  call assert_equal("\<C-V>", mode(1))
+  call feedkeys("\<Esc>", 'xt')
+
+  call feedkeys("gh", 'xt')
+  call assert_equal('s', mode())
+  call assert_equal('s', mode(1))
+  call feedkeys("\<Esc>gH", 'xt')
+  call assert_equal('S', mode())
+  call assert_equal('S', mode(1))
+  call feedkeys("\<Esc>g\<C-H>", 'xt')
+  call assert_equal("\<C-S>", mode())
+  call assert_equal("\<C-S>", mode(1))
+  call feedkeys("\<Esc>", 'xt')
+
+  call feedkeys(":echo \<C-R>=Save_mode()\<C-U>\<CR>", 'xt')
+  call assert_equal('c-c', g:current_modes)
+  call feedkeys("gQecho \<C-R>=Save_mode()\<CR>\<CR>vi\<CR>", 'xt')
+  call assert_equal('c-cv', g:current_modes)
+  " How to test Ex mode?
+
+  bwipe!
+  iunmap <F2>
+endfunc

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -110,6 +110,8 @@ func Test_map_langmap()
   call feedkeys(":call append(line('$'), '+')\<CR>", "xt")
   call assert_equal('+', getline('$'))
 
+  iunmap a
+  iunmap c
   set nomodified
 endfunc
 
@@ -120,7 +122,7 @@ func Test_map_feedkeys()
   $-1
   call feedkeys("0qqdw.ifoo\<Esc>qj0@q\<Esc>", "xt")
   call assert_equal(['fooc d', 'fooc d'], getline(line('$') - 1, line('$')))
-  unmap .
+  nunmap .
   set nomodified
 endfunc
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -821,7 +821,7 @@ static const int included_patches[] = {
   // 286,
   // 285 NA
   // 284 NA
-  // 283,
+  283,
   282,
   // 281 NA
   280,


### PR DESCRIPTION
Problem:    The return value of mode() does not indicate that completion is
            active in Replace and Insert mode. (Zhen-Huan (Kenny) Hu)
Solution:   Add "c" or "x" for two kinds of completion. (Yegappan Lakshmanan,
            closes vim/vim#1397)  Test some more modes.

https://github.com/vim/vim/commit/e90858d0229444b3cd16b1cd3a8d61a24c435705