### PR TITLE
[RDY] vim-patch:8.0.0287

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -18732,7 +18732,7 @@ static dictitem_T *find_var_in_ht(hashtab_T *const ht,
       case 'l': return (current_funccal == NULL
                         ? NULL : (dictitem_T *)&current_funccal->l_vars_var);
       case 'a': return (current_funccal == NULL
-                        ? NULL : (dictitem_T *)&current_funccal->l_avars_var);
+                        ? NULL : (dictitem_T *)&get_funccal()->l_avars_var);
     }
     return NULL;
   }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -817,7 +817,7 @@ static const int included_patches[] = {
   290,
   // 289,
   // 288 NA
-  // 287,
+  287,
   // 286,
   // 285 NA
   // 284 NA


### PR DESCRIPTION
Problem:    Cannot access the arguments of the current function in debug mode.
            (Luc Hermitte)
Solution:   use get_funccal(). (Lemonboy, closes vim/vim#1432, closes vim/vim#1352)

https://github.com/vim/vim/commit/c7d9eacefa319e5ac3b3b2334fda5acb126b8716