### PR TITLE
[RDY] vim-patch:8.0.0289

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -42,6 +42,7 @@ NEW_TESTS ?= \
 	    test_filter_map.res \
 	    test_fnameescape.res \
 	    test_fold.res \
+	    test_ga.res \
 	    test_glob2regpat.res \
 	    test_gf.res \
 	    test_gn.res \

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -12,6 +12,7 @@ source test_filter_cmd.vim
 source test_filter_map.vim
 source test_float_func.vim
 source test_functions.vim
+source test_ga.vim
 source test_goto.vim
 source test_jumps.vim
 source test_fileformat.vim

--- a/src/nvim/testdir/test_ga.vim
+++ b/src/nvim/testdir/test_ga.vim
@@ -1,0 +1,37 @@
+" Test ga normal command, and :ascii Ex command.
+func Do_ga(c)
+  call setline(1, a:c)
+  let l:a = execute("norm 1goga")
+  let l:b = execute("ascii")
+  call assert_equal(l:a, l:b)
+  return l:a
+endfunc
+
+func Test_ga_command()
+  new
+  set display=uhex
+  call assert_equal("\nNUL",                            Do_ga(''))
+  call assert_equal("\n<<01>>  1,  Hex 01,  Octal 001", Do_ga("\x01"))
+  call assert_equal("\n<<09>>  9,  Hex 09,  Octal 011", Do_ga("\t"))
+
+  set display=
+  call assert_equal("\nNUL",                             Do_ga(''))
+  call assert_equal("\n<^A>  1,  Hex 01,  Octal 001",    Do_ga("\x01"))
+  call assert_equal("\n<^I>  9,  Hex 09,  Octal 011",    Do_ga("\t"))
+
+  call assert_equal("\n<e>  101,  Hex 65,  Octal 145",   Do_ga('e'))
+
+  if !has('multi_byte')
+    return
+  endif
+
+  " Test a few multi-bytes characters.
+  call assert_equal("\n<é> 233, Hex 00e9, Octal 351",    Do_ga('é'))
+  call assert_equal("\n<ẻ> 7867, Hex 1ebb, Octal 17273", Do_ga('ẻ'))
+
+  " Test with combining characters.
+  call assert_equal("\n<e>  101,  Hex 65,  Octal 145 < ́> 769, Hex 0301, Octal 1401", Do_ga("e\u0301"))
+  call assert_equal("\n<e>  101,  Hex 65,  Octal 145 < ́> 769, Hex 0301, Octal 1401 < ̱> 817, Hex 0331, Octal 1461", Do_ga("e\u0301\u0331"))
+  call assert_equal("\n<e>  101,  Hex 65,  Octal 145 < ́> 769, Hex 0301, Octal 1401 < ̱> 817, Hex 0331, Octal 1461 < ̸> 824, Hex 0338, Octal 1470", Do_ga("e\u0301\u0331\u0338"))
+  bwipe!
+endfunc

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -815,7 +815,7 @@ static const int included_patches[] = {
   // 292,
   291,
   290,
-  // 289,
+  289,
   // 288 NA
   // 287,
   // 286,


### PR DESCRIPTION
Problem:    No test for "ga" and :ascii.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#1429)

https://github.com/vim/vim/commit/21d7c9b601f3048e1293ecd6c09b8325a15503cd