### PR TITLE
[RFC] PVS static analysis fixes

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -12,6 +12,7 @@
 #include "nvim/api/private/handle.h"
 #include "nvim/msgpack_rpc/helpers.h"
 #include "nvim/ascii.h"
+#include "nvim/assert.h"
 #include "nvim/vim.h"
 #include "nvim/buffer.h"
 #include "nvim/window.h"
@@ -760,12 +761,9 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
     case kObjectTypeWindow:
     case kObjectTypeTabpage:
     case kObjectTypeInteger:
-      if (obj.data.integer > VARNUMBER_MAX
-          || obj.data.integer < VARNUMBER_MIN) {
-        api_set_error(err, kErrorTypeValidation, "Integer value outside range");
-        return false;
-      }
-
+      STATIC_ASSERT(sizeof(obj.data.integer) <= sizeof(varnumber_T),
+                    "Expected integer size to be less than or equal to VimL "
+                    "number size");
       tv->v_type = VAR_NUMBER;
       tv->vval.v_number = (varnumber_T)obj.data.integer;
       break;

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1696,7 +1696,7 @@ static void printdigraph(digr_T *dp)
       }
     }
 
-    p = buf;
+    p = &buf[0];
     *p++ = dp->char1;
     *p++ = dp->char2;
     *p++ = ' ';

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2206,10 +2206,6 @@ static char_u *get_lval(char_u *const name, typval_T *const rettv,
       if (len == -1) {
         // "[key]": get key from "var1"
         key = (char_u *)tv_get_string(&var1);  // is number or string
-        if (key == NULL) {
-          tv_clear(&var1);
-          return NULL;
-        }
       }
       lp->ll_list = NULL;
       lp->ll_dict = lp->ll_tv->vval.v_dict;
@@ -5706,10 +5702,6 @@ static int get_function_args(char_u **argp, char_u endchar, garray_T *newargs,
         c = *p;
         *p = NUL;
         arg = vim_strsave(arg);
-        if (arg == NULL) {
-          *p = c;
-          goto err_ret;
-        }
 
         // Check for duplicate argument name.
         for (i = 0; i < newargs->ga_len; i++) {
@@ -5833,10 +5825,6 @@ static int get_lambda_tv(char_u **arg, typval_T *rettv, bool evaluate)
 
     fp = (ufunc_T *)xcalloc(1, sizeof(ufunc_T) + STRLEN(name));
     pt = (partial_T *)xcalloc(1, sizeof(partial_T));
-    if (pt == NULL) {
-      xfree(fp);
-      goto errret;
-    }
 
     ga_init(&newlines, (int)sizeof(char_u *), 1);
     ga_grow(&newlines, 1);
@@ -6222,13 +6210,9 @@ static char_u *fname_trans_sid(const char_u *const name,
       fname = fname_buf;
     } else {
       fname = xmalloc(i + STRLEN(name + llen) + 1);
-      if (fname == NULL) {
-        *error = ERROR_OTHER;
-      } else {
-        *tofree = fname;
-        memmove(fname, fname_buf, (size_t)i);
-        STRCPY(fname + i, name + llen);
-      }
+      *tofree = fname;
+      memmove(fname, fname_buf, (size_t)i);
+      STRCPY(fname + i, name + llen);
     }
   } else {
     fname = (char_u *)name;
@@ -6309,9 +6293,6 @@ call_func(
   // Make a copy of the name, if it comes from a funcref variable it could
   // be changed or deleted in the called function.
   name = vim_strnsave(funcname, len);
-  if (name == NULL) {
-    return ret;
-  }
 
   fname = fname_trans_sid(name, fname_buf, &tofree, &error);
 
@@ -7184,8 +7165,7 @@ static void f_bufnr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       && argvars[1].v_type != VAR_UNKNOWN
       && tv_get_number_chk(&argvars[1], &error) != 0
       && !error
-      && (name = tv_get_string_chk(&argvars[0])) != NULL
-      && !error) {
+      && (name = tv_get_string_chk(&argvars[0])) != NULL) {
     buf = buflist_new((char_u *)name, NULL, 1, 0);
   }
 
@@ -7733,7 +7713,7 @@ static void f_delete(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   const char *const name = tv_get_string(&argvars[0]);
-  if (name == NULL || *name == NUL) {
+  if (*name == NUL) {
     EMSG(_(e_invarg));
     return;
   }
@@ -8748,8 +8728,7 @@ static void f_foldtext(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   foldstart = (linenr_T)get_vim_var_nr(VV_FOLDSTART);
   foldend = (linenr_T)get_vim_var_nr(VV_FOLDEND);
   dashes = get_vim_var_str(VV_FOLDDASHES);
-  if (foldstart > 0 && foldend <= curbuf->b_ml.ml_line_count
-      && dashes != NULL) {
+  if (foldstart > 0 && foldend <= curbuf->b_ml.ml_line_count) {
     /* Find first non-empty line in the fold. */
     for (lnum = foldstart; lnum < foldend; ++lnum) {
       if (!linewhite(lnum)) {
@@ -8874,10 +8853,8 @@ static void common_function(typval_T *argvars, typval_T *rettv,
       snprintf(sid_buf, sizeof(sid_buf), "<SNR>%" PRId64 "_",
                (int64_t)current_SID);
       name = xmalloc(STRLEN(sid_buf) + STRLEN(s + off) + 1);
-      if (name != NULL) {
-        STRCPY(name, sid_buf);
-        STRCAT(name, s + off);
-      }
+      STRCPY(name, sid_buf);
+      STRCAT(name, s + off);
     } else {
       name = vim_strsave(s);
     }
@@ -8927,11 +8904,6 @@ static void common_function(typval_T *argvars, typval_T *rettv,
 
         pt->pt_argc = arg_len + lv_len;
         pt->pt_argv = xmalloc(sizeof(pt->pt_argv[0]) * pt->pt_argc);
-        if (pt->pt_argv == NULL) {
-          xfree(pt);
-          xfree(name);
-          goto theend;
-        }
         int i = 0;
         for (; i < arg_len; i++) {
           tv_copy(&arg_pt->pt_argv[i], &pt->pt_argv[i]);
@@ -9197,9 +9169,7 @@ static void f_getbufinfo(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     }
 
     dict_T *const d = get_buffer_info(buf);
-    if (d != NULL) {
-      tv_list_append_dict(rettv->vval.v_list, d);
-    }
+    tv_list_append_dict(rettv->vval.v_list, d);
     if (argbuf != NULL) {
       return;
     }
@@ -9568,13 +9538,11 @@ static void f_getcompletion(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 theend:
   pat = addstar(xpc.xp_pattern, xpc.xp_pattern_len, xpc.xp_context);
   tv_list_alloc_ret(rettv);
-  if (pat != NULL) {
-    ExpandOne(&xpc, pat, NULL, options, WILD_ALL_KEEP);
+  ExpandOne(&xpc, pat, NULL, options, WILD_ALL_KEEP);
 
-    for (int i = 0; i < xpc.xp_numfiles; i++) {
-      tv_list_append_string(rettv->vval.v_list, (const char *)xpc.xp_files[i],
-                            -1);
-    }
+  for (int i = 0; i < xpc.xp_numfiles; i++) {
+    tv_list_append_string(rettv->vval.v_list, (const char *)xpc.xp_files[i],
+                          -1);
   }
   xfree(pat);
   ExpandCleanup(&xpc);
@@ -10136,9 +10104,7 @@ static void f_gettabinfo(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       continue;
     }
     dict_T *const d = get_tabpage_info(tp, tpnr);
-    if (d != NULL) {
-      tv_list_append_dict(rettv->vval.v_list, d);
-    }
+    tv_list_append_dict(rettv->vval.v_list, d);
     if (tparg != NULL) {
       return;
     }
@@ -10240,9 +10206,7 @@ static void f_getwininfo(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       }
       winnr++;
       dict_T *const d = get_win_info(wp, tabnr, winnr);
-      if (d != NULL) {
-        tv_list_append_dict(rettv->vval.v_list, d);
-      }
+      tv_list_append_dict(rettv->vval.v_list, d);
       if (wparg != NULL) {
         // found information about a specific window
         return;
@@ -14803,9 +14767,6 @@ static void f_setmatches(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       if (di == NULL) {
         if (s == NULL) {
           s = tv_list_alloc();
-          if (s == NULL) {
-            return;
-          }
         }
 
         // match from matchaddpos()
@@ -18628,47 +18589,39 @@ void set_selfdict(typval_T *rettv, dict_T *selfdict)
   // Turn "dict.Func" into a partial for "Func" with "dict".
   if (fp != NULL && (fp->uf_flags & FC_DICT)) {
     partial_T *pt = (partial_T *)xcalloc(1, sizeof(partial_T));
+    pt->pt_refcount = 1;
+    pt->pt_dict = selfdict;
+    (selfdict->dv_refcount)++;
+    pt->pt_auto = true;
+    if (rettv->v_type == VAR_FUNC || rettv->v_type == VAR_STRING) {
+      // Just a function: Take over the function name and use selfdict.
+      pt->pt_name = rettv->vval.v_string;
+    } else {
+      partial_T *ret_pt = rettv->vval.v_partial;
+      int i;
 
-    if (pt != NULL) {
-      pt->pt_refcount = 1;
-      pt->pt_dict = selfdict;
-      (selfdict->dv_refcount)++;
-      pt->pt_auto = true;
-      if (rettv->v_type == VAR_FUNC || rettv->v_type == VAR_STRING) {
-        // Just a function: Take over the function name and use selfdict.
-        pt->pt_name = rettv->vval.v_string;
+      // Partial: copy the function name, use selfdict and copy
+      // args. Can't take over name or args, the partial might
+      // be referenced elsewhere.
+      if (ret_pt->pt_name != NULL) {
+        pt->pt_name = vim_strsave(ret_pt->pt_name);
+        func_ref(pt->pt_name);
       } else {
-        partial_T *ret_pt = rettv->vval.v_partial;
-        int i;
-
-        // Partial: copy the function name, use selfdict and copy
-        // args. Can't take over name or args, the partial might
-        // be referenced elsewhere.
-        if (ret_pt->pt_name != NULL) {
-          pt->pt_name = vim_strsave(ret_pt->pt_name);
-          func_ref(pt->pt_name);
-        } else {
-          pt->pt_func = ret_pt->pt_func;
-          func_ptr_ref(pt->pt_func);
-        }
-        if (ret_pt->pt_argc > 0) {
-          size_t arg_size = sizeof(typval_T) * ret_pt->pt_argc;
-          pt->pt_argv = (typval_T *)xmalloc(arg_size);
-          if (pt->pt_argv == NULL) {
-            // out of memory: drop the arguments
-            pt->pt_argc = 0;
-          } else {
-            pt->pt_argc = ret_pt->pt_argc;
-            for (i = 0; i < pt->pt_argc; i++) {
-              tv_copy(&ret_pt->pt_argv[i], &pt->pt_argv[i]);
-            }
-          }
-        }
-        partial_unref(ret_pt);
+        pt->pt_func = ret_pt->pt_func;
+        func_ptr_ref(pt->pt_func);
       }
-      rettv->v_type = VAR_PARTIAL;
-      rettv->vval.v_partial = pt;
+      if (ret_pt->pt_argc > 0) {
+        size_t arg_size = sizeof(typval_T) * ret_pt->pt_argc;
+        pt->pt_argv = (typval_T *)xmalloc(arg_size);
+        pt->pt_argc = ret_pt->pt_argc;
+        for (i = 0; i < pt->pt_argc; i++) {
+          tv_copy(&ret_pt->pt_argv[i], &pt->pt_argv[i]);
+        }
+      }
+      partial_unref(ret_pt);
     }
+    rettv->v_type = VAR_PARTIAL;
+    rettv->vval.v_partial = pt;
   }
 }
 

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1417,7 +1417,8 @@ void ex_emenu(exarg_T *eap)
     idx = MENU_INDEX_NORMAL;
   }
 
-  if (idx != MENU_INDEX_INVALID && menu->strings[idx] != NULL) {
+  assert(idx != MENU_INDEX_INVALID);
+  if (menu->strings[idx] != NULL) {
     /* When executing a script or function execute the commands right now.
      * Otherwise put them in the typeahead buffer. */
     if (current_SID != 0)

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1989,8 +1989,7 @@ void halfpage(bool flag, linenr_T Prenum)
     while (n > 0 && curwin->w_botline <= curbuf->b_ml.ml_line_count) {
       if (curwin->w_topfill > 0) {
         i = 1;
-        if (--n < 0 && scrolled > 0)
-          break;
+        n--;
         --curwin->w_topfill;
       } else {
         i = plines_nofill(curwin->w_topline);
@@ -2067,8 +2066,7 @@ void halfpage(bool flag, linenr_T Prenum)
     while (n > 0 && curwin->w_topline > 1) {
       if (curwin->w_topfill < diff_check_fill(curwin, curwin->w_topline)) {
         i = 1;
-        if (--n < 0 && scrolled > 0)
-          break;
+        n--;
         ++curwin->w_topfill;
       } else {
         i = plines_nofill(curwin->w_topline - 1);

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -199,18 +199,24 @@ static void forward_mouse_event(TermInput *input, TermKeyKey *key)
     len += (size_t)snprintf(buf + len, sizeof(buf) - len, "Right");
   }
 
-  if (ev == TERMKEY_MOUSE_PRESS) {
-    if (button == 4) {
-      len += (size_t)snprintf(buf + len, sizeof(buf) - len, "ScrollWheelUp");
-    } else if (button == 5) {
-      len += (size_t)snprintf(buf + len, sizeof(buf) - len, "ScrollWheelDown");
-    } else {
-      len += (size_t)snprintf(buf + len, sizeof(buf) - len, "Mouse");
-    }
-  } else if (ev == TERMKEY_MOUSE_DRAG) {
-    len += (size_t)snprintf(buf + len, sizeof(buf) - len, "Drag");
-  } else if (ev == TERMKEY_MOUSE_RELEASE) {
-    len += (size_t)snprintf(buf + len, sizeof(buf) - len, "Release");
+  switch (ev) {
+    case TERMKEY_MOUSE_PRESS:
+      if (button == 4) {
+        len += (size_t)snprintf(buf + len, sizeof(buf) - len, "ScrollWheelUp");
+      } else if (button == 5) {
+        len += (size_t)snprintf(buf + len, sizeof(buf) - len, "ScrollWheelDown");
+      } else {
+        len += (size_t)snprintf(buf + len, sizeof(buf) - len, "Mouse");
+      }
+      break;
+    case TERMKEY_MOUSE_DRAG:
+      len += (size_t)snprintf(buf + len, sizeof(buf) - len, "Drag");
+      break;
+    case TERMKEY_MOUSE_RELEASE:
+      len += (size_t)snprintf(buf + len, sizeof(buf) - len, "Release");
+      break;
+    case TERMKEY_MOUSE_UNKNOWN:
+      assert(false);
   }
 
   len += (size_t)snprintf(buf + len, sizeof(buf) - len, "><%d,%d>", col, row);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1644,7 +1644,7 @@ static void flush_buf(UI *ui, bool toggle_cursor)
 {
   uv_write_t req;
   uv_buf_t bufs[3];
-  uv_buf_t *bufp = bufs;
+  uv_buf_t *bufp = &bufs[0];
   TUIData *data = ui->data;
 
   if (data->bufpos <= 0 && data->busy == data->is_invisible) {


### PR DESCRIPTION
Fixes from PVS:
```
./src/nvim/api/private/helpers.c:763:1: warning: V560 A part of conditional expression is always false.
./src/nvim/api/private/helpers.c:764:1: warning: V560 A part of conditional expression is always false.
./src/nvim/digraph.c:1714:1: warning: V782 There is no sense in evaluating the distance between elements from different arrays: 'p - buf'.
./src/nvim/eval.c:2209:1: warning: V547 Expression 'key == NULL' is always false.
./src/nvim/eval.c:5709:1: warning: V547 Expression 'arg == NULL' is always false.
./src/nvim/eval.c:5836:1: warning: V547 Expression 'pt == NULL' is always false.
./src/nvim/eval.c:6225:1: warning: V547 Expression 'fname == NULL' is always false.
./src/nvim/eval.c:6312:1: warning: V547 Expression 'name == NULL' is always false.
./src/nvim/eval.c:7736:1: warning: V560 A part of conditional expression is always false: name == NULL.
./src/nvim/eval.c:8752:1: warning: V560 A part of conditional expression is always true: dashes != NULL.
./src/nvim/eval.c:8877:1: warning: V547 Expression 'name != NULL' is always true.
./src/nvim/eval.c:8930:1: warning: V547 Expression 'pt->pt_argv == NULL' is always false.
./src/nvim/eval.c:9200:1: warning: V547 Expression 'd != NULL' is always true.
./src/nvim/eval.c:9571:1: warning: V547 Expression 'pat != NULL' is always true.
./src/nvim/eval.c:10139:1: warning: V547 Expression 'd != NULL' is always true.
./src/nvim/eval.c:10243:1: warning: V547 Expression 'd != NULL' is always true.
./src/nvim/eval.c:14806:1: warning: V547 Expression 's == NULL' is always false.
./src/nvim/eval.c:18657:1: warning: V547 Expression 'pt->pt_argv == NULL' is always false.
./src/nvim/eval.c:18632:1: warning: V547 Expression 'pt != NULL' is always true.
./src/nvim/menu.c:1420:1: warning: V560 A part of conditional expression is always true: idx != - 1.
./src/nvim/move.c:1992:1: warning: V560 A part of conditional expression is always false: -- n < 0.
./src/nvim/move.c:2070:1: warning: V560 A part of conditional expression is always false: -- n < 0.
./src/nvim/tui/input.c:212:1: error: V547 Expression 'ev == TERMKEY_MOUSE_RELEASE' is always true.
./src/nvim/tui/tui.c:1679:1: warning: V782 There is no sense in evaluating the distance between elements from different arrays: 'bufp - bufs'.
```