### PR TITLE
[RFC] Fix get_syn_options release warning

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4009,7 +4009,7 @@ get_syn_options (
 {
   char_u      *gname_start, *gname;
   int syn_id;
-  int len;
+  int len = 0;
   char        *p;
   int fidx;
   static const struct flag {
@@ -4052,7 +4052,6 @@ get_syn_options (
     if (strchr(first_letters, *arg) == NULL)
       break;
 
-    len = 0;
     for (fidx = ARRAY_SIZE(flagtab); --fidx >= 0; ) {
       p = flagtab[fidx].name;
       int i;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4012,7 +4012,7 @@ get_syn_options (
   int len;
   char        *p;
   int fidx;
-  static struct flag {
+  static const struct flag {
     char    *name;
     int argtype;
     int flags;
@@ -4035,7 +4035,7 @@ get_syn_options (
                   {"cCoOnNtTaAiInNsS",        1,      0},
                   {"cCoOnNtTaAiInNeEdDiInN",  2,      0},
                   {"nNeExXtTgGrRoOuUpP",      3,      0},};
-  static char *first_letters = "cCoOkKeEtTsSgGdDfFnN";
+  static const char *const first_letters = "cCoOkKeEtTsSgGdDfFnN";
 
   if (arg == NULL)              /* already detected error */
     return NULL;
@@ -4052,12 +4052,14 @@ get_syn_options (
     if (strchr(first_letters, *arg) == NULL)
       break;
 
+    len = 0;
     for (fidx = ARRAY_SIZE(flagtab); --fidx >= 0; ) {
       p = flagtab[fidx].name;
       int i;
-      for (i = 0, len = 0; p[i] != NUL; i += 2, ++len)
+      for (i = 0, len = 0; p[i] != NUL; i += 2, ++len) {
         if (arg[len] != p[i] && arg[len] != p[i + 1])
           break;
+      }
       if (p[i] == NUL && (ascii_iswhite(arg[len])
                           || (flagtab[fidx].argtype > 0
                               ? arg[len] == '='


### PR DESCRIPTION
When building in release mode, gcc generated a maybe-initialized
warning in get_syn_options. The warning is both right and wrong;
there is an execution path where the len variable is not
initialized in the code:
...
int len;
...
for (fidx = ARRAY_SIZE(flagtab); --fidx >= 0; ) {
  p = flagtab[fidx].name;
  int i;
  for (i = 0, len = 0; p[i] != NUL; i += 2, ++len)
    if (arg[len] != p[i] && arg[len] != p[i + 1])
      break;
  // <snip>
}
...
  arg = skipwhite(arg + len);
...

The initial for loop will not execute if ARRAY_SIZE(flagtab) == 0,
and thus len will never be initialized. flagtab is a local-static
variable, initialized to a long array of structured data, so
ARRAY_SIZE(flagtab) can't be 0.

However, gcc doesn't recognize ARRAY_SIZE(flagtab) as a constant.
There are any number of reasons this could happen. In any case,
the message can be fixed with a len=0 before the first for loop.


In addition to the above warning, I've also added brackets to the
body of the inner for loop (because the indentation alone was
not clear enough in context), and I've labeled flagtab and
first_letters (another static local in the same function) as
const. They should never change.

This is part of Tracking issue #7595.