### PR TITLE
win: default grepprg to findstr.exe

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -993,11 +993,11 @@ return {
       expand=true,
       varname='p_gp',
       defaults={
-        condition='UNIX',
+        condition='WIN32',
         -- Add an extra file name so that grep will always
         -- insert a file name in the match line. */
-        if_true={vi="grep -n $* /dev/null"},
-        if_false={vi="grep -n "},
+        if_true={vi="findstr /n $* nul"},
+        if_false={vi="grep -n $* /dev/null"}
       }
     },
     {


### PR DESCRIPTION
Windows doesn't have `grep` but it has `findstr.exe`. Vim uses it on Windows but Vim's default is `findstr /n` so it cannot be used with `:grep`. The patch adds the missing `$*` and uses `nul` because `/dev/null` doesn't exist in Windows.