### PR TITLE
[RFC] man.vim: highlight bold and underlined text

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -391,48 +391,10 @@ function! man#highlight_backspaced_text() abort
   let l:modifiable = &modifiable
   set modifiable
 
-  let l:lines = getline(1, line('$'))
-  call map(l:lines, function('s:highlight_backspaced_line'))
-  call setline(1, l:lines)
+  lua man = require("man")
+  luado return man.highlight_backspaced(line, linenr)
 
   let &modifiable = l:modifiable
-endfunction
-
-" This pattern is for "overstruck" text containing backspaces. It matches bold
-" text first, so a word beginning with "_^H_" is bold and text such as
-" "_^Hf_^Ho_^Ho_^H__^Hb_^Ha_^Hr" is entirely underlined.
-"
-" Bolded text can also be mixed with whitespace as a performance tweak, since
-" it's visually identical.
-let s:backspace_pattern = '\v%((.)\b\1\s*)+|%(_\b.)+'
-
-function! s:highlight_backspaced_line(index, val) abort
-  let l:line = a:val
-  let l:search_pos = 0
-
-  while 1
-    " Scanning for the next backspace without matching the entire pattern is
-    " slightly faster
-    let l:match_start = stridx(l:line, "\b", l:search_pos)
-    if l:match_start == -1
-      break
-    endif
-
-    let l:match = matchstrpos(l:line, s:backspace_pattern, l:match_start - 1)
-    if l:match[0] =~# '^_\b[^_]'
-      let l:hlgroup = 'manUnderline'
-    else
-      let l:hlgroup = 'manBold'
-    endif
-
-    let l:stripped = substitute(l:match[0], '.\b', '', 'g')
-    let l:search_pos = l:match[1] + len(l:stripped)
-    let l:line = strpart(l:line, 0, l:match[1]) . l:stripped . strpart(l:line, l:match[2])
-
-    call nvim_buf_add_highlight(0, -1, l:hlgroup, a:index, l:match[1], l:search_pos)
-  endwhile
-
-  return l:line
 endfunction
 
 call s:init()

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -161,7 +161,7 @@ function! s:put_page(page) abort
   while getline(1) =~# '^\s*$'
     silent keepjumps 1delete _
   endwhile
-  call man#highlight_backspaced_text()
+  call man#highlight_formatted_text()
   setlocal filetype=man
 endfunction
 
@@ -375,7 +375,7 @@ function! man#init_pager() abort
   else
     keepjumps 1
   endif
-  call man#highlight_backspaced_text()
+  call man#highlight_formatted_text()
   " This is not perfect. See `man glDrawArraysInstanced`. Since the title is
   " all caps it is impossible to tell what the original capitilization was.
   let ref = substitute(matchstr(getline(1), '^[^)]\+)'), ' ', '_', 'g')
@@ -387,12 +387,12 @@ function! man#init_pager() abort
   execute 'silent file man://'.fnameescape(ref)
 endfunction
 
-function! man#highlight_backspaced_text() abort
+function! man#highlight_formatted_text() abort
   let l:modifiable = &modifiable
   set modifiable
 
   lua man = require("man")
-  luado return man.highlight_backspaced(line, linenr)
+  luado return man.highlight_formatted(line, linenr)
 
   let &modifiable = l:modifiable
 endfunction

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -161,7 +161,7 @@ function! s:put_page(page) abort
   while getline(1) =~# '^\s*$'
     silent keepjumps 1delete _
   endwhile
-  call man#highlight_formatted_text()
+  lua require("man").highlight_man_page()
   setlocal filetype=man
 endfunction
 
@@ -375,7 +375,7 @@ function! man#init_pager() abort
   else
     keepjumps 1
   endif
-  call man#highlight_formatted_text()
+  lua require("man").highlight_man_page()
   " This is not perfect. See `man glDrawArraysInstanced`. Since the title is
   " all caps it is impossible to tell what the original capitilization was.
   let ref = substitute(matchstr(getline(1), '^[^)]\+)'), ' ', '_', 'g')
@@ -385,16 +385,6 @@ function! man#init_pager() abort
     let b:man_sect = ''
   endtry
   execute 'silent file man://'.fnameescape(ref)
-endfunction
-
-function! man#highlight_formatted_text() abort
-  let l:modifiable = &modifiable
-  set modifiable
-
-  lua man = require("man")
-  luado return man.highlight_formatted(line, linenr)
-
-  let &modifiable = l:modifiable
 endfunction
 
 call s:init()

--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -1,0 +1,75 @@
+local function highlight_backspaced(line, linenr)
+  local chars = {}
+  local prev_char = ''
+  local overstrike = false
+  local hls = {} -- Store highlight groups as { attr, start, end }
+  local NONE, BOLD, UNDERLINE = 0, 1, 2
+  local attr = NONE
+  local byte = 0 -- byte offset
+
+  -- Break input into UTF8 characters
+  for char in line:gmatch("[^\128-\191][\128-\191]*") do
+    if overstrike then
+      local last_hl = hls[#hls]
+      if char == prev_char then
+        if char == '_' and attr == UNDERLINE and last_hl and last_hl[3] == byte then
+          -- This underscore is in the middle of an underlined word
+          attr = UNDERLINE
+        else
+          attr = BOLD
+        end
+      elseif prev_char == '_' then
+        -- char is underlined
+        attr = UNDERLINE
+      elseif prev_char == '+' and char == 'o' then
+        -- bullet (overstrike text '+^Ho')
+        attr = BOLD
+        char = [[·]]
+      elseif prev_char == [[·]] and char == 'o' then
+        -- bullet (additional handling for '+^H+^Ho^Ho')
+        attr = BOLD
+        char = [[·]]
+      else
+        -- use plain char
+        attr = NONE
+      end
+
+      -- Grow the previous highlight group if possible
+      if last_hl and last_hl[1] == attr and last_hl[3] == byte then
+        last_hl[3] = byte + #char
+      else
+        hls[#hls + 1] = {attr, byte, byte + #char}
+      end
+
+      overstrike = false
+      prev_char = ''
+      byte = byte + #char
+      chars[#chars + 1] = char
+    elseif char == "\b" then
+      overstrike = true
+      prev_char = chars[#chars]
+      byte = byte - #prev_char
+      chars[#chars] = nil
+    else
+      byte = byte + #char
+      chars[#chars + 1] = char
+    end
+  end
+
+  for i, hl in ipairs(hls) do
+    if hl[1] ~= NONE then
+      vim.api.nvim_buf_add_highlight(
+        0,
+        -1,
+        hl[1] == BOLD and "manBold" or "manUnderline",
+        linenr - 1,
+        hl[2],
+        hl[3]
+      )
+    end
+  end
+
+  return table.concat(chars, '')
+end
+
+return { highlight_backspaced = highlight_backspaced }

--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -1,11 +1,59 @@
-local function highlight_backspaced(line, linenr)
+local function highlight_formatted(line, linenr)
   local chars = {}
   local prev_char = ''
-  local overstrike = false
+  local overstrike, escape = false, false
   local hls = {} -- Store highlight groups as { attr, start, end }
-  local NONE, BOLD, UNDERLINE = 0, 1, 2
+  local NONE, BOLD, UNDERLINE, ITALIC = 0, 1, 2, 3
+  local hl_groups = {[BOLD]="manBold", [UNDERLINE]="manUnderline", [ITALIC]="manItalic"}
   local attr = NONE
   local byte = 0 -- byte offset
+
+  local function end_attr_hl(attr)
+    for i, hl in ipairs(hls) do
+      if hl[1] == attr and hl[3] == -1 then
+        hl[3] = byte
+        hls[i] = hl
+      end
+    end
+  end
+
+  local function add_attr_hl(code)
+    local on = true
+    if code == 0 then
+      attr = NONE
+      on = false
+    elseif code == 1 then
+      attr = BOLD
+    elseif code == 21 or code == 22 then
+      attr = BOLD
+      on = false
+    elseif code == 3 then
+      attr = ITALIC
+    elseif code == 23 then
+      attr = ITALIC
+      on = false
+    elseif code == 4 then
+      attr = UNDERLINE
+    elseif code == 24 then
+      attr = UNDERLINE
+      on = false
+    else
+      attr = NONE
+      return
+    end
+
+    if on then
+      hls[#hls + 1] = {attr, byte, -1}
+    else
+      if attr == NONE then
+        for a, _ in pairs(hl_groups) do
+          end_attr_hl(a)
+        end
+      else
+        end_attr_hl(attr)
+      end
+    end
+  end
 
   -- Break input into UTF8 characters
   for char in line:gmatch("[^\128-\191][\128-\191]*") do
@@ -45,6 +93,24 @@ local function highlight_backspaced(line, linenr)
       prev_char = ''
       byte = byte + #char
       chars[#chars + 1] = char
+    elseif escape then
+      -- Use prev_char to store the escape sequence
+      prev_char = prev_char .. char
+      local sgr = prev_char:match("^%[([\020-\063]*)m$")
+      if sgr then
+        local match = ''
+        while sgr and #sgr > 0 do
+          match, sgr = sgr:match("^(%d*);?(.*)")
+          add_attr_hl(match + 0) -- coerce to number
+        end
+        escape = false
+      elseif not prev_char:match("^%[[\020-\063]*$") then
+        -- Stop looking if this isn't a partial CSI sequence
+        escape = false
+      end
+    elseif char == "\027" then
+      escape = true
+      prev_char = ''
     elseif char == "\b" then
       overstrike = true
       prev_char = chars[#chars]
@@ -61,7 +127,7 @@ local function highlight_backspaced(line, linenr)
       vim.api.nvim_buf_add_highlight(
         0,
         -1,
-        hl[1] == BOLD and "manBold" or "manUnderline",
+        hl_groups[hl[1]],
         linenr - 1,
         hl[2],
         hl[3]
@@ -72,4 +138,4 @@ local function highlight_backspaced(line, linenr)
   return table.concat(chars, '')
 end
 
-return { highlight_backspaced = highlight_backspaced }
+return { highlight_formatted = highlight_formatted }

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -21,6 +21,7 @@ highlight default link manSubHeading     Function
 function! s:init_highlight_groups()
   highlight default manUnderline cterm=underline gui=underline
   highlight default manBold      cterm=bold      gui=bold
+  highlight default manItalic    cterm=italic    gui=italic
 endfunction
 
 augroup man_init_highlight_groups

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -18,18 +18,9 @@ highlight default link manOptionDesc     Constant
 highlight default link manReference      PreProc
 highlight default link manSubHeading     Function
 
-function! s:init_highlight_groups()
-  highlight default manUnderline cterm=underline gui=underline
-  highlight default manBold      cterm=bold      gui=bold
-  highlight default manItalic    cterm=italic    gui=italic
-endfunction
-
-augroup man_init_highlight_groups
-  autocmd!
-  autocmd ColorScheme * call s:init_highlight_groups()
-augroup END
-
-call s:init_highlight_groups()
+highlight default manUnderline cterm=underline gui=underline
+highlight default manBold      cterm=bold      gui=bold
+highlight default manItalic    cterm=italic    gui=italic
 
 if &filetype != 'man'
   " May have been included by some other filetype.

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -18,6 +18,18 @@ highlight default link manOptionDesc     Constant
 highlight default link manReference      PreProc
 highlight default link manSubHeading     Function
 
+function! s:init_highlight_groups()
+  highlight default manUnderline cterm=underline gui=underline
+  highlight default manBold      cterm=bold      gui=bold
+endfunction
+
+augroup man_init_highlight_groups
+  autocmd!
+  autocmd ColorScheme * call s:init_highlight_groups()
+augroup END
+
+call s:init_highlight_groups()
+
 if &filetype != 'man'
   " May have been included by some other filetype.
   finish

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -1,0 +1,181 @@
+local helpers = require('test.functional.helpers')(after_each)
+local plugin_helpers = require('test.functional.plugin.helpers')
+
+local Screen = require('test.functional.ui.screen')
+
+local buffer, command, eval = helpers.buffer, helpers.command, helpers.eval
+
+before_each(function()
+  plugin_helpers.reset()
+  helpers.clear()
+  command('syntax on')
+  command('set filetype=man')
+end)
+
+describe('In autoload/man.vim', function()
+  describe('function man#highlight_formatted_text', function()
+    local screen
+
+    before_each(function()
+      command('syntax off') -- Ignore syntax groups
+      screen = Screen.new(52, 5)
+      screen:attach()
+    end)
+
+    after_each(function()
+      screen:detach()
+    end)
+
+    local function expect(string)
+      screen:expect(string,
+      {
+        b = { bold = true },
+        i = { italic = true },
+        u = { underline = true },
+        bi = { bold = true, italic = true },
+        biu = { bold = true, italic = true, underline = true },
+      },
+      {{ bold = true, foreground = Screen.colors.Blue }})
+    end
+
+    local function expect_without_highlights(string)
+      screen:expect(string, nil, true)
+    end
+
+    local function insert_lines(...)
+      buffer('set_lines', 0, 0, 1, false, { ... })
+    end
+
+    it('clears backspaces from text', function()
+      insert_lines(
+        "this i\bis\bs a\ba test",
+        "with _\bo_\bv_\be_\br_\bs_\bt_\br_\bu_\bc_\bk text"
+      )
+
+      expect_without_highlights([[
+      ^this i^His^Hs a^Ha test                             |
+      with _^Ho_^Hv_^He_^Hr_^Hs_^Ht_^Hr_^Hu_^Hc_^Hk text  |
+      ~                                                   |
+      ~                                                   |
+                                                          |
+      ]])
+
+      eval('man#highlight_formatted_text()')
+
+      expect_without_highlights([[
+      ^this is a test                                      |
+      with overstruck text                                |
+      ~                                                   |
+      ~                                                   |
+                                                          |
+      ]])
+    end)
+
+    it('clears escape sequences from text', function()
+      insert_lines(
+        "this \027[1mis \027[3ma \027[4mtest\027[0m",
+        "\027[4mwith\027[24m \027[4mescaped\027[24m \027[4mtext\027[24m"
+      )
+
+      expect_without_highlights([[
+      ^this ^[[1mis ^[[3ma ^[[4mtest^[[0m                  |
+      ^[[4mwith^[[24m ^[[4mescaped^[[24m ^[[4mtext^[[24m  |
+      ~                                                   |
+      ~                                                   |
+                                                          |
+      ]])
+
+      eval('man#highlight_formatted_text()')
+
+      expect_without_highlights([[
+      ^this is a test                                      |
+      with escaped text                                   |
+      ~                                                   |
+      ~                                                   |
+                                                          |
+      ]])
+    end)
+
+    it('highlights overstruck text', function()
+      insert_lines(
+        "this i\bis\bs a\ba test",
+        "with _\bo_\bv_\be_\br_\bs_\bt_\br_\bu_\bc_\bk text"
+      )
+      eval('man#highlight_formatted_text()')
+
+      expect([[
+      ^this {b:is} {b:a} test                                      |
+      with {u:overstruck} text                                |
+      ~                                                   |
+      ~                                                   |
+                                                          |
+      ]])
+    end)
+
+    it('highlights escape sequences in text', function()
+      insert_lines(
+        "this \027[1mis \027[3ma \027[4mtest\027[0m",
+        "\027[4mwith\027[24m \027[4mescaped\027[24m \027[4mtext\027[24m"
+      )
+      eval('man#highlight_formatted_text()')
+
+      expect([[
+      ^this {b:is }{bi:a }{biu:test}                                      |
+      {u:with} {u:escaped} {u:text}                                   |
+      ~                                                   |
+      ~                                                   |
+                                                          |
+      ]])
+    end)
+
+    it('highlights multibyte text', function()
+      insert_lines(
+        "this i\bis\bs あ\bあ test",
+        "with _\bö_\bv_\be_\br_\bs_\bt_\br_\bu_\bc_\bk te\027[3mxt¶\027[0m"
+      )
+      eval('man#highlight_formatted_text()')
+
+      expect([[
+      ^this {b:is} {b:あ} test                                     |
+      with {u:överstruck} te{i:xt¶}                               |
+      ~                                                   |
+      ~                                                   |
+                                                          |
+      ]])
+    end)
+
+    it('highlights underscores based on context', function()
+      insert_lines(
+        "_\b_b\bbe\beg\bgi\bin\bns\bs",
+        "m\bmi\bid\bd_\b_d\bdl\ble\be",
+        "_\bm_\bi_\bd_\b__\bd_\bl_\be"
+      )
+      eval('man#highlight_formatted_text()')
+
+      expect([[
+      {b:^_begins}                                             |
+      {b:mid_dle}                                             |
+      {u:mid_dle}                                             |
+      ~                                                   |
+                                                          |
+      ]])
+    end)
+
+    it('highlights various bullet formats', function()
+      insert_lines(
+        "· ·\b·",
+        "+\bo",
+        "+\b+\bo\bo double"
+      )
+      eval('man#highlight_formatted_text()')
+
+      expect([[
+      ^· {b:·}                                                 |
+      {b:·}                                                   |
+      {b:·} double                                            |
+      ~                                                   |
+                                                          |
+      ]])
+    end)
+  end)
+end)


### PR DESCRIPTION
I was inspired by #5847, but wanted to keep the original syntax highlighting colors:
![screenshot 2017-11-22 at 8 39 29 pm](https://user-images.githubusercontent.com/1683303/33156195-5b711112-cfc5-11e7-8a79-888e522a0263.png)
As much as I optimized the Vimscript version it felt a little too slow. Working in Lua speeds things up nicely. My (very informal) testing with LuaJIT shows a roughly 10% overall increase in the time to start `nvim` and render a man page.

It doesn't look like there's any other Lua code included in the runtime yet, but I hope this can still be considered.

I also didn't handle any ANSI SGR sequences, since `man` on my system just uses backspaces, but if there's interest I can try to include those too.