### PR TITLE
[RFC] Retry fgets on EINTR (#7632)

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3199,8 +3199,14 @@ static char_u *get_one_sourceline(struct source_cookie *sp)
     ga_grow(&ga, 120);
     buf = (char_u *)ga.ga_data;
 
+retry:
+    errno = 0;
     if (fgets((char *)buf + ga.ga_len, ga.ga_maxlen - ga.ga_len,
               sp->fp) == NULL) {
+      if (errno == EINTR) {
+        goto retry;
+      }
+
       break;
     }
     len = ga.ga_len + (int)STRLEN(buf + ga.ga_len);

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4448,7 +4448,12 @@ bool vim_fgets(char_u *buf, int size, FILE *fp) FUNC_ATTR_NONNULL_ALL
   char tbuf[FGETS_SIZE];
 
   buf[size - 2] = NUL;
+retry:
+  errno = 0;
   eof = fgets((char *)buf, size, fp);
+  if (eof == NULL && errno == EINTR) {
+    goto retry;
+  }
   if (buf[size - 2] != NUL && buf[size - 2] != '\n') {
     buf[size - 1] = NUL;            /* Truncate the line */
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4443,27 +4443,32 @@ char *modname(const char *fname, const char *ext, bool prepend_dot)
 /// @return true for end-of-file.
 bool vim_fgets(char_u *buf, int size, FILE *fp) FUNC_ATTR_NONNULL_ALL
 {
-  char        *eof;
-#define FGETS_SIZE 200
-  char tbuf[FGETS_SIZE];
+  char *retval;
 
+  assert(size > 0);
   buf[size - 2] = NUL;
-retry:
-  errno = 0;
-  eof = fgets((char *)buf, size, fp);
-  if (eof == NULL && errno == EINTR) {
-    goto retry;
-  }
-  if (buf[size - 2] != NUL && buf[size - 2] != '\n') {
-    buf[size - 1] = NUL;            /* Truncate the line */
 
-    /* Now throw away the rest of the line: */
+  do {
+    errno = 0;
+    retval = fgets((char *)buf, size, fp);
+  } while (retval == NULL && errno == EINTR);
+
+  if (buf[size - 2] != NUL && buf[size - 2] != '\n') {
+    char tbuf[200];
+
+    buf[size - 1] = NUL;  // Truncate the line.
+
+    // Now throw away the rest of the line:
     do {
-      tbuf[FGETS_SIZE - 2] = NUL;
-      ignoredp = fgets((char *)tbuf, FGETS_SIZE, fp);
-    } while (tbuf[FGETS_SIZE - 2] != NUL && tbuf[FGETS_SIZE - 2] != '\n');
+      tbuf[sizeof(tbuf) - 2] = NUL;
+      errno = 0;
+      retval = fgets((char *)tbuf, sizeof(tbuf), fp);
+      if (retval == NULL && errno != EINTR) {
+        break;
+      }
+    } while (tbuf[sizeof(tbuf) - 2] != NUL && tbuf[sizeof(tbuf) - 2] != '\n');
   }
-  return eof == NULL;
+  return retval ? false : feof(fp);
 }
 
 /// Read 2 bytes from "fd" and turn them into an int, MSB first.

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -553,9 +553,15 @@ static int cs_cnt_matches(size_t idx)
 
   char *buf = xmalloc(CSREAD_BUFSIZE);
   for (;; ) {
+    errno = 0;
     if (!fgets(buf, CSREAD_BUFSIZE, csinfo[idx].fr_fp)) {
-      if (feof(csinfo[idx].fr_fp))
+      if (errno == EINTR) {
+        continue;
+      }
+
+      if (feof(csinfo[idx].fr_fp)) {
         errno = EIO;
+      }
 
       cs_reading_emsg(idx);
 
@@ -1381,9 +1387,16 @@ static char *cs_parse_results(size_t cnumber, char *buf, int bufsize,
   char *p;
   char *name;
 
+retry:
+  errno = 0;
   if (fgets(buf, bufsize, csinfo[cnumber].fr_fp) == NULL) {
-    if (feof(csinfo[cnumber].fr_fp))
+    if (errno == EINTR) {
+      goto retry;
+    }
+
+    if (feof(csinfo[cnumber].fr_fp)) {
       errno = EIO;
+    }
 
     cs_reading_emsg(cnumber);
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -570,7 +570,12 @@ static int qf_get_next_file_line(qfstate_T *state)
 {
   size_t growbuflen;
 
+retry:
+  errno = 0;
   if (fgets((char *)IObuff, IOSIZE, state->fd) == NULL) {
+    if (errno == EINTR) {
+        goto retry;
+    }
     return QF_END_OF_INPUT;
   }
 
@@ -590,8 +595,12 @@ static int qf_get_next_file_line(qfstate_T *state)
     growbuflen = state->linelen;
 
     for (;;) {
+      errno = 0;
       if (fgets((char *)state->growbuf + growbuflen,
                 (int)(state->growbufsiz - growbuflen), state->fd) == NULL) {
+        if (errno == EINTR) {
+          continue;
+        }
         break;
       }
       state->linelen = STRLEN(state->growbuf + growbuflen);
@@ -612,9 +621,14 @@ static int qf_get_next_file_line(qfstate_T *state)
     while (discard) {
       // The current line is longer than LINE_MAXLEN, continue reading but
       // discard everything until EOL or EOF is reached.
-      if (fgets((char *)IObuff, IOSIZE, state->fd) == NULL
-          || STRLEN(IObuff) < IOSIZE - 1
-          || IObuff[IOSIZE - 1] == '\n') {
+      errno = 0;
+      if (fgets((char *)IObuff, IOSIZE, state->fd) == NULL) {
+        if (errno == EINTR) {
+          continue;
+        }
+        break;
+      }
+      if (STRLEN(IObuff) < IOSIZE - 1 || IObuff[IOSIZE - 1] == '\n') {
         break;
       }
     }


### PR DESCRIPTION
This fixes #7632 for me. It's tricky to test, since it relies on a race between a subprocess exiting and waiting for cscope's output.

- Should we instead change all of these to use `vim_fgets`? I didn't here because `vim_fgets` has some additional handling for lines that are too long, but that might be alright for all or some of these cases.
- The linter is complaining about missing braces on if statements I didn't change -- is that expected?