### PR TITLE
tui: expose terminal type in 'term' option

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -333,9 +333,11 @@ terminal capabilities. Instead Nvim treats the terminal as any other UI. For
 example, 'guicursor' sets the terminal cursor style if possible.
 
 						  *'term'* *E529* *E530* *E531*
-The 'term' option has a fixed value, present only for script compatibility and
-intentionally not the same as any known terminal type name.  It should be a
-rare case in Nvim where one needs |term-dependent-settings|.
+'term' reflects the terminal type derived from |$TERM| and other environment
+checks.  For debugging only; not reliable during startup. >
+	:echo &term
+"builtin_x" means one of the |builtin-terms| was chosen, because the expected
+terminfo file was not found on the system.
 
 								*termcap*
 Nvim never uses the termcap database, only |terminfo| and |builtin-terms|.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4619,10 +4619,10 @@ static int findoption(const char *const arg)
 /// Hidden Number or Toggle option: -1.
 ///           hidden String option: -2.
 ///                 unknown option: -3.
-int get_option_value (
+int get_option_value(
     char_u *name,
     long *numval,
-    char_u **stringval,            /* NULL when only checking existence */
+    char_u **stringval,            ///< NULL when only checking existence
     int opt_flags
 )
 {
@@ -4630,32 +4630,31 @@ int get_option_value (
     return 0;
   }
 
-  int opt_idx;
-  char_u      *varp;
-
-  opt_idx = findoption((const char *)name);
+  int opt_idx = findoption((const char *)name);
   if (opt_idx < 0) {  // Unknown option.
     return -3;
   }
 
-  varp = get_varp_scope(&(options[opt_idx]), opt_flags);
+  char_u *varp = get_varp_scope(&(options[opt_idx]), opt_flags);
 
   if (options[opt_idx].flags & P_STRING) {
-    if (varp == NULL)                       /* hidden option */
+    if (varp == NULL) {  // hidden option
       return -2;
+    }
     if (stringval != NULL) {
       *stringval = vim_strsave(*(char_u **)(varp));
     }
     return 0;
   }
 
-  if (varp == NULL)                 /* hidden option */
+  if (varp == NULL) {  // hidden option
     return -1;
-  if (options[opt_idx].flags & P_NUM)
+  }
+  if (options[opt_idx].flags & P_NUM) {
     *numval = *(long *)varp;
-  else {
-    /* Special case: 'modified' is b_changed, but we also want to consider
-     * it set when 'ff' or 'fenc' changed. */
+  } else {
+    // Special case: 'modified' is b_changed, but we also want to consider
+    // it set when 'ff' or 'fenc' changed.
     if ((int *)varp == &curbuf->b_changed) {
       *numval = curbufIsChanged();
     } else {

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -603,6 +603,15 @@ local function get_pathsep()
   return funcs.fnamemodify('.', ':p'):sub(-1)
 end
 
+-- Returns a valid, platform-independent $NVIM_LISTEN_ADDRESS.
+-- Useful for communicating with child instances.
+local function new_pipename()
+  -- HACK: Start a server temporarily, get the name, then stop it.
+  local pipename = nvim_eval('serverstart()')
+  funcs.serverstop(pipename)
+  return pipename
+end
+
 local function missing_provider(provider)
   if provider == 'ruby' then
     local prog = funcs['provider#' .. provider .. '#Detect']()
@@ -732,6 +741,7 @@ local module = {
   missing_provider = missing_provider,
   alter_slashes = alter_slashes,
   hexdump = hexdump,
+  new_pipename = new_pipename,
 }
 
 return function(after_each)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -19,8 +19,8 @@ describe('tui', function()
 
   before_each(function()
     clear()
-    screen = thelpers.screen_setup(0, '["'..helpers.nvim_prog
-      ..'", "-u", "NONE", "-i", "NONE", "--cmd", "set noswapfile noshowcmd noruler"]')
+    screen = thelpers.screen_setup(0, '["'..nvim_prog
+      ..'", "-u", "NONE", "-i", "NONE", "--cmd", "set noswapfile noshowcmd noruler undodir=. directory=. viewdir=. backupdir=."]')
     -- right now pasting can be really slow in the TUI, especially in ASAN.
     -- this will be fixed later but for now we require a high timeout.
     screen.timeout = 60000
@@ -383,10 +383,11 @@ describe("tui 't_Co' (terminal colors)", function()
     -- This is ugly because :term/termopen() forces TERM=xterm-256color.
     -- TODO: Revisit this after jobstart/termopen accept `env` dict.
     screen = thelpers.screen_setup(0, string.format(
-      [=[['sh', '-c', 'LANG=C TERM=%s %s %s -u NONE -i NONE --cmd "silent set noswapfile noshowcmd noruler"']]=],
+      [=[['sh', '-c', 'LANG=C TERM=%s %s %s -u NONE -i NONE --cmd "%s"']]=],
       term or "",
       (colorterm ~= nil and "COLORTERM="..colorterm or ""),
-      helpers.nvim_prog))
+      nvim_prog,
+      nvim_set))
 
     feed_data(":echo &t_Co\n")
     helpers.wait()
@@ -401,10 +402,10 @@ describe("tui 't_Co' (terminal colors)", function()
       %s|
       %s|
       %s|
-      {5:[No Name]                                         }|
+      %s|
       %-3s                                               |
       {3:-- TERMINAL --}                                    |
-    ]], tline, tline, tline, tostring(maxcolors and maxcolors or "")))
+    ]], tline, tline, tline, tline, tostring(maxcolors and maxcolors or "")))
   end
 
   -- ansi and no terminal type at all:

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -4,7 +4,7 @@ local os = require('os')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local command = helpers.command
 local eval, exc_exec = helpers.eval, helpers.exc_exec
-local feed_command, request, eq = helpers.feed_command, helpers.request, helpers.eq
+local feed_command, eq = helpers.feed_command, helpers.eq
 local curbufmeths = helpers.curbufmeths
 
 describe('colorscheme compatibility', function()

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -14,8 +14,6 @@ describe('colorscheme compatibility', function()
 
   it('t_Co is set to 256 by default', function()
     eq('256', eval('&t_Co'))
-    request('nvim_set_option', 't_Co', '88')
-    eq('88', eval('&t_Co'))
   end)
 end)
 


### PR DESCRIPTION
Since "builtin" terminfo definitions were implemented (7cbf52db1bdf),
the decisions made by tui.c and terminfo.c are more relevant. Exposing
that decision in the 'term' option helps with troubleshooting.