### PR TITLE
version.c: mark NA patches

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -803,7 +803,7 @@ static const int included_patches[] = {
   305,
   // 304,
   // 303,
-  // 302, NA
+  // 302 NA
   // 301,
   300,
   // 299,
@@ -925,7 +925,7 @@ static const int included_patches[] = {
   // 183 NA
   182,
   181,
-  // 180,
+  // 180 NA
   179,
   178,
   177,
@@ -935,11 +935,11 @@ static const int included_patches[] = {
   // 173 NA
   172,
   // 171,
-  // 170,
-  // 169,
+  // 170 NA
+  // 169 NA
   168,
   167,
-  // 166,
+  // 166 NA
   165,
   164,
   // 163 NA
@@ -964,7 +964,7 @@ static const int included_patches[] = {
   // 144 NA
   143,
   142,
-  // 141,
+  // 141 NA
   140,
   // 139 NA
   // 138 NA
@@ -1009,7 +1009,7 @@ static const int included_patches[] = {
   99,
   // 98 NA
   // 97 NA
-  // 96,
+  96,
   // 95 NA
   // 94 NA
   // 93 NA
@@ -1084,10 +1084,10 @@ static const int included_patches[] = {
   // 24 NA
   23,
   // 22 NA
-  // 21,
+  // 21 NA
   20,
   19,
-  // 18,
+  // 18 NA
   17,
   // 16 NA
   // 15 NA


### PR DESCRIPTION
- channels: 8.0.0018
- GUI: 8.0.0021
- Different recursive function implementation: 8.0.0141
- JSON handling: 8.0.0166, 8.0.0169, 8.0.0170, 8.0.0171, 8.0.0180

Mark vim-patch:8.0.0096 applied, since it was added in
860ecd705588470b52094b7036c016b2af15f8c9.

Continuing #7307