### PR TITLE
tui.c: request focus-reporting (fix regression)

### DIFF
--- a/src/nvim/event/loop.h
+++ b/src/nvim/event/loop.h
@@ -19,12 +19,11 @@ typedef struct loop {
   MultiQueue *events;
   MultiQueue *thread_events;
   // Immediate events:
-  //    "Events that should be processed after exiting uv_run() (to avoid
-  //    recursion), but before returning from loop_poll_events()."
-  //    502aee690c980fcb3cfcb3f211dcfad06103db46
-  // Practical consequence: these events are processed by
+  //    "Processed after exiting uv_run() (to avoid recursion), but before
+  //    returning from loop_poll_events()." 502aee690c98
+  // Practical consequence (for main_loop): these events are processed by
   //    state_enter()..os_inchar()
-  // whereas "regular" (main_loop.events) events are processed by
+  // whereas "regular" events (main_loop.events) are processed by
   //    state_enter()..VimState.execute()
   // But state_enter()..os_inchar() can be "too early" if you want the event
   // to trigger UI updates and other user-activity-related side-effects.


### PR DESCRIPTION
27f9b1c7b029d8 caused a regression: it uses loop_schedule_deferred() to
defer emitting the "enable focus reporting" termcode. But tui_main()
never processes `tui_loop.events`, so the event was never actually
processed.

But fixing that (by processing `tui_loop.events`) would bring back the
problem 27f9b1c7b029 tried to fix: it still emits the event too soon.

Instead, do a little dance: schedule the event on `main_loop` and then
forward it to `tui_loop`.

**NOTE:** after this commit, in tmux 2.3 with `focus-events` enabled,
FocusGained is fired on startup and when resuming from suspend.
This seems fine to me. Only happens in tmux, not other terminals.