### PR TITLE
[RDY] vim-patch:8.0.0295

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -203,7 +203,6 @@ let s:flaky = [
       \ ]
 
 " Locate Test_ functions and execute them.
-set nomore
 redir @q
 silent function /^Test_
 redir END

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -961,7 +961,7 @@ static const int included_patches[] = {
   // 298,
   297,
   // 296,
-  // 295,
+  295,
   294,
   // 293,
   292,


### PR DESCRIPTION
Problem:    test_viml hangs.
Solution:   Put resetting 'more' before sourcing the script.

https://github.com/vim/vim/commit/7a073549a3b1e72037a4e98ceb406d057ac9ba50