### PR TITLE
[RDY] vim-patch:8.0.0298

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3492,8 +3492,9 @@ char_u *skip_range(
         break;
       }
     } else if (*cmd == '\'') {
-      if (*++cmd == NUL && ctx != NULL)
+      if (*++cmd == NUL && ctx != NULL) {
         *ctx = EXPAND_NOTHING;
+      }
     } else if (*cmd == '/' || *cmd == '?') {
       delim = *cmd++;
       while (*cmd != NUL && *cmd != delim)

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3484,8 +3484,14 @@ char_u *skip_range(
 {
   unsigned delim;
 
-  while (vim_strchr((char_u *)" \t0123456789.$%'/?-+,;", *cmd) != NULL) {
-    if (*cmd == '\'') {
+  while (vim_strchr((char_u *)" \t0123456789.$%'/?-+,;\\", *cmd) != NULL) {
+    if (*cmd == '\\') {
+      if (cmd[1] == '?' || cmd[1] == '/' || cmd[1] == '&') {
+        cmd++;
+      } else {
+        break;
+      }
+    } else if (*cmd == '\'') {
       if (*++cmd == NUL && ctx != NULL)
         *ctx = EXPAND_NOTHING;
     } else if (*cmd == '/' || *cmd == '?') {

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -306,3 +306,28 @@ func Test_cmdline_complete_wildoptions()
   call assert_equal(a, b)
   bw!
 endfunc
+
+" using a leading backslash here
+set cpo+=C
+
+func Test_cmdline_search_range()
+  new
+  call setline(1, ['a', 'b', 'c', 'd'])
+  /d
+  1,\/s/b/B/
+  call assert_equal('B', getline(2))
+
+  /a
+  $
+  \?,4s/c/C/
+  call assert_equal('C', getline(3))
+
+  call setline(1, ['a', 'b', 'c', 'd'])
+  %s/c/c/
+  1,\&s/b/B/
+  call assert_equal('B', getline(2))
+
+  bwipe!
+endfunc
+
+set cpo&

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -958,7 +958,7 @@ static const int included_patches[] = {
   // 301,
   300,
   // 299,
-  // 298,
+  298,
   297,
   // 296,
   // 295,


### PR DESCRIPTION
vim-patch:8.0.0298
    
Problem:    Ex command range with repeated search does not work. (Bruce
                DeVisser)
Solution:   Skip over \/, \? and \&.
    
https://github.com/vim/vim/commit/cbf20fbcd3e9bb006f694bcc35da859930fb12a2