### PR TITLE
[RFC] vim-patch:8.0.0309 NA

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -947,7 +947,7 @@ static const int included_patches[] = {
   // 312,
   311,
   // 310,
-  // 309,
+  // 309 NA
   308,
   307,
   306,


### PR DESCRIPTION
Problem:    Cannot use an empty key in json.
Solution:   Allow for using an empty key.

https://github.com/vim/vim/commit/059b7482a2d9d4cebbf4c01b2b2ea6f1e783cc20

---------
I think this patch should be ignored, because nvim doesn't has json