### PR TITLE
[RFC] vim-patch:8.0.0310 NA

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -946,7 +946,7 @@ static const int included_patches[] = {
   // 313,
   // 312,
   311,
-  // 310,
+  // 310 NA
   // 309,
   308,
   307,


### PR DESCRIPTION
Problem:    Not enough testing for GUI functionality.
Solution:   Add tests for v:windowid and getwinpos[xy](). (Kazunobu Kuriyama)

https://github.com/vim/vim/commit/13c724fb3a630257b736a1c91643b396fee917c1

-------
I think this patch should be ignored, nvim has no testing for GUI 