### PR TITLE
Fixed broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ low-risk/isolated tasks:
 Developer guidelines
 --------------------
 
-- Nvim developers should read `:help dev-help`.
+- Nvim developers should read `:help dev`.
 - External UI developers should read `:help dev-ui`.
 
 Reporting problems


### PR DESCRIPTION
Updated the :help dev-help (which doesn't work) to :help dev.

Signed-off-by: mattemagikern <mansgariusson@gmail.com>