### PR TITLE
mac: Set $LANG based on the system locale

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -13,6 +13,9 @@ endif()
 if(WIN32)
   # tell MinGW compiler to enable wmain
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -municode")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework CoreFoundation")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -framework CoreFoundation")
 endif()
 
 set(TOUCHES_DIR ${PROJECT_BINARY_DIR}/touches)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -75,6 +75,7 @@
 #include "nvim/window.h"
 #include "nvim/os/os.h"
 #include "nvim/os/input.h"
+#include "nvim/os/lang.h"
 
 /*
  * The options that are local to a window or buffer have "indir" set to one of
@@ -783,6 +784,8 @@ void set_init_1(void)
   }
 
   didset_options2();
+
+  lang_init();
 
   // enc_locale() will try to find the encoding of the current locale.
   // This will be used when 'default' is used as encoding specifier

--- a/src/nvim/os/lang.c
+++ b/src/nvim/os/lang.c
@@ -1,0 +1,40 @@
+#ifdef __APPLE__
+# define Boolean CFBoolean  // Avoid conflict with API's Boolean
+# include <CoreFoundation/CFLocale.h>
+# include <CoreFoundation/CFString.h>
+# undef Boolean
+#endif
+
+#ifdef HAVE_LOCALE_H
+# include <locale.h>
+#endif
+#include "nvim/os/os.h"
+
+void lang_init(void)
+{
+#ifdef __APPLE__
+  if (os_getenv("LANG") == NULL) {
+    CFLocaleRef cf_locale = CFLocaleCopyCurrent();
+    CFTypeRef cf_lang_region = CFLocaleGetValue(cf_locale,
+                                                kCFLocaleIdentifier);
+    CFRetain(cf_lang_region);
+    CFRelease(cf_locale);
+
+    const char *lang_region = CFStringGetCStringPtr(cf_lang_region,
+                                                    kCFStringEncodingUTF8);
+    if (lang_region) {
+      os_setenv("LANG", lang_region, true);
+    } else {
+      char buf[20] = { 0 };
+      if (CFStringGetCString(cf_lang_region, buf, 20,
+                             kCFStringEncodingUTF8)) {
+        os_setenv("LANG", lang_region, true);
+      }
+    }
+    CFRelease(cf_lang_region);
+# ifdef HAVE_LOCALE_H
+    setlocale(LC_ALL, "");
+# endif
+  }
+#endif
+}

--- a/src/nvim/os/lang.h
+++ b/src/nvim/os/lang.h
@@ -1,0 +1,7 @@
+#ifndef NVIM_OS_LANG_H
+#define NVIM_OS_LANG_H
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "os/lang.h.generated.h"
+#endif
+#endif  // NVIM_OS_LANG_H


### PR DESCRIPTION
Unix's typical locale-related environment variables aren't always set
appropriately on a Mac.  Instead of relying on them, query the locale
information using Mac specific APIs and then set $LANG appropriately for
the rest of nvim.

Closes #5873