### PR TITLE
ci: run oldtests in Appveyor

### DIFF
--- a/ci/build.bat
+++ b/ci/build.bat
@@ -53,6 +53,12 @@ bin\nvim --version || goto :error
 :: Functional tests
 mingw32-make functionaltest VERBOSE=1 || goto :error
 
+:: Unit tests
+setlocal
+set PATH=C:\msys64\usr\bin;%PATH%
+mingw32-make -C "%~dp0\..\src\nvim\testdir" VERBOSE=1
+endlocal
+
 if defined USE_GCOV (
   C:\msys64\usr\bin\bash -lc "cd /c/projects/neovim; bash <(curl -s https://codecov.io/bash) || echo 'codecov upload failed.'"
 )

--- a/ci/build.bat
+++ b/ci/build.bat
@@ -55,7 +55,7 @@ mingw32-make functionaltest VERBOSE=1 || goto :error
 
 :: Unit tests
 setlocal
-set PATH=C:\msys64\usr\bin;%PATH%
+set PATH=%PATH%;C:\msys64\usr\bin
 mingw32-make -C "%~dp0\..\src\nvim\testdir" VERBOSE=1
 endlocal
 

--- a/ci/build.bat
+++ b/ci/build.bat
@@ -53,7 +53,7 @@ bin\nvim --version || goto :error
 :: Functional tests
 mingw32-make functionaltest VERBOSE=1 || goto :error
 
-:: Unit tests
+:: Old tests
 setlocal
 set PATH=%PATH%;C:\msys64\usr\bin
 mingw32-make -C "%~dp0\..\src\nvim\testdir" VERBOSE=1

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -14,21 +14,20 @@ export SHELL := sh
 export NVIM_PRG := $(NVIM_PRG)
 export TMPDIR
 
-
 SCRIPTS_DEFAULT = \
-		   test13.out             \
-		   test14.out             \
-		   test24.out             \
-		   test37.out             \
-		   test40.out             \
-		   test42.out             \
-		   test48.out             \
-		   test49.out             \
-		   test52.out             \
-		   test53.out             \
-		   test64.out             \
-		   test73.out             \
-		   test79.out             \
+           test13.out             \
+           test14.out             \
+           test24.out             \
+           test37.out             \
+           test40.out             \
+           test42.out             \
+           test48.out             \
+           test49.out             \
+           test52.out             \
+           test53.out             \
+           test64.out             \
+           test73.out             \
+           test79.out             \
 
 ifneq ($(OS),Windows_NT)
   SCRIPTS_DEFAULTS := $(SCRIPTS_DEFAULT) \

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -14,41 +14,30 @@ export SHELL := sh
 export NVIM_PRG := $(NVIM_PRG)
 export TMPDIR
 
-ifeq ($(OS),Windows_NT)
-  SCRIPTS ?= \
-	test13.out             \
-	test14.out             \
-	test24.out             \
-	test37.out             \
-	test40.out             \
-	test42.out             \
-	test48.out             \
-	test49.out             \
-	test52.out             \
-	test53.out             \
-	test64.out             \
-	test73.out             \
-	test79.out             \
 
-else
-  SCRIPTS ?= \
-	test13.out             \
-	test14.out             \
+SCRIPTS_DEFAULT = \
+		   test13.out             \
+		   test14.out             \
+		   test24.out             \
+		   test37.out             \
+		   test40.out             \
+		   test42.out             \
+		   test48.out             \
+		   test49.out             \
+		   test52.out             \
+		   test53.out             \
+		   test64.out             \
+		   test73.out             \
+		   test79.out             \
+
+ifneq ($(OS),Windows_NT)
+  SCRIPTS_DEFAULTS := $(SCRIPTS_DEFAULT) \
 	test17.out             \
-	test24.out             \
 	test32.out             \
-	test37.out             \
-	test40.out             \
-	test42.out             \
-	test48.out             \
-	test49.out             \
-	test52.out             \
-	test53.out             \
-	test64.out             \
-	test73.out             \
-	test79.out             \
 
 endif
+
+SCRIPTS ?= $(SCRIPTS_DEFAULT)
 
 # Tests using runtest.vim.
 # Keep test_alot*.res as the last one, sort the others.

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -2,6 +2,11 @@
 # Makefile to run all tests for Vim
 #
 
+ifeq ($(OS),Windows_NT)
+  NVIM_PRG ?= ../../../build/bin/nvim.exe
+else
+  NVIM_PRG ?= ../../../build/bin/nvim
+endif
 NVIM_PRG ?= ../../../build/bin/nvim
 TMPDIR ?= Xtest-tmpdir
 SCRIPTSOURCE := ../../../runtime
@@ -10,22 +15,41 @@ export SHELL := sh
 export NVIM_PRG := $(NVIM_PRG)
 export TMPDIR
 
-SCRIPTS ?= \
-           test13.out             \
-           test14.out             \
-           test17.out             \
-           test24.out             \
-           test32.out             \
-           test37.out             \
-           test40.out             \
-           test42.out             \
-           test48.out             \
-           test49.out             \
-           test52.out             \
-           test53.out             \
-           test64.out             \
-           test73.out             \
-           test79.out             \
+ifeq ($(OS),Windows_NT)
+  SCRIPTS ?= \
+	test13.out             \
+	test14.out             \
+	test24.out             \
+	test37.out             \
+	test40.out             \
+	test42.out             \
+	test48.out             \
+	test49.out             \
+	test52.out             \
+	test53.out             \
+	test64.out             \
+	test73.out             \
+	test79.out             \
+
+else
+  SCRIPTS ?= \
+	test13.out             \
+	test14.out             \
+	test17.out             \
+	test24.out             \
+	test32.out             \
+	test37.out             \
+	test40.out             \
+	test42.out             \
+	test48.out             \
+	test49.out             \
+	test52.out             \
+	test53.out             \
+	test64.out             \
+	test73.out             \
+	test79.out             \
+
+endif
 
 # Tests using runtest.vim.
 # Keep test_alot*.res as the last one, sort the others.

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -7,7 +7,6 @@ ifeq ($(OS),Windows_NT)
 else
   NVIM_PRG ?= ../../../build/bin/nvim
 endif
-NVIM_PRG ?= ../../../build/bin/nvim
 TMPDIR ?= Xtest-tmpdir
 SCRIPTSOURCE := ../../../runtime
 

--- a/src/nvim/testdir/unix.vim
+++ b/src/nvim/testdir/unix.vim
@@ -2,6 +2,12 @@
 " Always use "sh", don't use the value of "$SHELL".
 set shell=sh
 
+if has('win32')
+  set shellcmdflag=-c shellxquote= shellxescape= shellquote=
+  let &shellredir = '>%s 2>&1'
+  set shellslash
+endif
+
 " Don't depend on system locale, always use utf-8
 set encoding=utf-8
 


### PR DESCRIPTION
Ref #7412 

This patch is only for running legacy tests in `src/nvim/testdir`. I don't intend on adding vim patches here or fixing any legacy tests.