### PR TITLE
typval_encode.c.h: avoid -Wnonnull-compare warning

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1794,15 +1794,20 @@ static inline void _nothing_conv_func_end(typval_T *const tv, const int copyID)
       tv->v_lock = VAR_UNLOCKED; \
     } while (0)
 
+static inline void _nothing_conv_empty_dict(typval_T *const tv,
+                                            dict_T **const dictp)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ARG(2)
+{
+  tv_dict_unref(*dictp);
+  *dictp = NULL;
+  if (tv != NULL) {
+    tv->v_lock = VAR_UNLOCKED;
+  }
+}
 #define TYPVAL_ENCODE_CONV_EMPTY_DICT(tv, dict) \
     do { \
       assert((void *)&dict != (void *)&TYPVAL_ENCODE_NODICT_VAR); \
-      tv_dict_unref((dict_T *)dict); \
-      *((dict_T **)&dict) = NULL; \
-      typval_T *tv_ = tv;  /* Avoid -Wnonnull-compare warning. #6847 */ \
-      if (tv_ != NULL) { \
-        tv_->v_lock = VAR_UNLOCKED; \
-      } \
+      _nothing_conv_empty_dict(tv, ((dict_T **)&dict)); \
     } while (0)
 
 static inline int _nothing_conv_real_list_after_start(

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1799,8 +1799,9 @@ static inline void _nothing_conv_func_end(typval_T *const tv, const int copyID)
       assert((void *)&dict != (void *)&TYPVAL_ENCODE_NODICT_VAR); \
       tv_dict_unref((dict_T *)dict); \
       *((dict_T **)&dict) = NULL; \
-      if (tv != NULL) { \
-        ((typval_T *)tv)->v_lock = VAR_UNLOCKED; \
+      typval_T *tv_ = tv;  /* Avoid -Wnonnull-compare warning. #6847 */ \
+      if (tv_ != NULL) { \
+        tv_->v_lock = VAR_UNLOCKED; \
       } \
     } while (0)
 


### PR DESCRIPTION
closes #6847

The NULL check is needed because TYPVAL_ENCODE_CONV_EMPTY_DICT may be
invoked with literal `NULL`.

Warning occurs even for `Debug` build-type:

    neovim/src/nvim/eval/typval.c: In function ‘_typval_encode_nothing_convert_one_value’:
    neovim/src/nvim/eval/typval.c:1802:10: warning: nonnull argument ‘tv’ compared to NULL [-Wnonnull-compare]
           if (tv != NULL) { \
              ^
    ../src/nvim/eval/typval_encode.c.h:398:9: note: in expansion of macro ‘TYPVAL_ENCODE_CONV_EMPTY_DICT’
             TYPVAL_ENCODE_CONV_EMPTY_DICT(tv, tv->vval.v_dict);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

gcc version:
     gcc (Ubuntu 6.3.0-12ubuntu2) 6.3.0 20170406

cc @ZyX-I 