### PR TITLE
ASAN/LeakSanitizer: ignore loop_schedule_deferred()

### DIFF
--- a/src/.asan-blacklist
+++ b/src/.asan-blacklist
@@ -1,3 +1,7 @@
 # multiqueue.h pointer arithmetic is not accepted by asan
 fun:multiqueue_node_data
 fun:tv_dict_watcher_node_data
+
+# Allocation in loop_schedule_deferred() is freed by loop_deferred_event(), but
+# this sometimes does not happen during teardown.
+func:loop_schedule_deferred


### PR DESCRIPTION
clang ASAN/LeakSanitizer error (observed in #7706):

    ==21832==ERROR: LeakSanitizer: detected memory leaks
    Direct leak of 56 byte(s) in 1 object(s) allocated from:
        0 0x511b26 in malloc (/home/travis/build/neovim/neovim/build/bin/nvim+0x511b26)
        1 0x1009a84 in try_malloc /home/travis/build/neovim/neovim/src/nvim/memory.c:87:15
        2 0x1009c44 in xmalloc /home/travis/build/neovim/neovim/src/nvim/memory.c:121:15
        3 0xaa8c36 in loop_schedule_deferred /home/travis/build/neovim/neovim/src/nvim/event/loop.c:89:19
        4 0x190856a in tui_main /home/travis/build/neovim/neovim/src/nvim/tui/tui.c:367:5
        5 0x1963d61 in ui_thread_run /home/travis/build/neovim/neovim/src/nvim/ui_bridge.c:106:3
        6 0x2b5d4190d183 in start_thread /build/eglibc-SvCtMH/eglibc-2.19/nptl/pthread_create.c:312

Possible explanation: During exit, `Loop.thread_events` may not get
flushed, so `loop_deferred_event()` is never called. In `event_teardown()` we only do `multiqueue_process_events(main_loop.events)`.

We could instead try to unwind `Loop.thread_events` during teardown, but
it seems lower-risk to just tell ASAN to ignore it.

Valgrind does not complain:

    $ while :; do { 2>valglog.txt valgrind ./build/bin/nvim -u NONE +q ; } ; if ! [ $? = 0 ] ; then break ; fi ; done