### PR TITLE
[RFC] vim-patch:8.0.0404,8.0.0484

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4502,6 +4502,9 @@ void ex_helpgrep(exarg_T *eap)
     }
   }
 
+  // Autocommands may change the list. Save it for later comparison
+  qf_info_T *save_qi = qi;
+
   regmatch.regprog = vim_regcomp(eap->arg, RE_MAGIC + RE_STRING);
   regmatch.rm_ic = FALSE;
   if (regmatch.regprog != NULL) {
@@ -4614,10 +4617,11 @@ void ex_helpgrep(exarg_T *eap)
 
   if (au_name != NULL) {
     apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name,
-        curbuf->b_fname, TRUE, curbuf);
-    if (!new_qi && qi != &ql_info && qf_find_buf(qi) == NULL)
-      /* autocommands made "qi" invalid */
+                   curbuf->b_fname, true, curbuf);
+    if (!new_qi && qi != save_qi && qf_find_buf(qi) == NULL) {
+      // autocommands made "qi" invalid
       return;
+    }
   }
 
   /* Jump to first match. */


### PR DESCRIPTION
#### vim-patch:8.0.0404: not enough testing for quickfix

Problem:    Not enough testing for quickfix.
Solution:   Add some more tests. (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/391b1dd040af204b150d43c5a1c97477ee450a28


#### vim-patch:8.0.0484: :lhelpgrep does not fail after a successful one

Problem:    Using :lhelpgrep with an argument that should fail does not
            produce an error if the previous :helpgrep worked.
Solution:   Use another way to detect that autocommands made the quickfix info
            invalid. (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/ee85df37634dfb0c40ae5de0b4f246aef460b392