### PR TITLE
[RFC] vim-patch:8.0.0565,8.0.0574,8.0.0579,8.0.0580

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6841,6 +6841,7 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		    nr		error number
 		    text	description of the error
 		    type	single-character error type, 'E', 'W', etc.
+		    valid	recognized error message
 
 		The "col", "vcol", "nr", "type" and "text" entries are
 		optional.  Either "lnum" or "pattern" entry can be used to
@@ -6850,6 +6851,8 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		item will not be handled as an error line.
 		If both "pattern" and "lnum" are present then "pattern" will
 		be used.
+		If the "valid" entry is not supplied, then the valid flag is
+		set when "bufnr" is a valid buffer or "filename" exists.
 		If you supply an empty {list}, the quickfix list will be
 		cleared.
 		Note that the list is not exactly the same as what

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2411,6 +2411,7 @@ static void qf_free(qf_info_T *qi, int idx)
   qi->qf_lists[idx].qf_ptr = NULL;
   qi->qf_lists[idx].qf_title = NULL;
   qi->qf_lists[idx].qf_index = 0;
+  qi->qf_lists[idx].qf_last = NULL;
 
   qf_clean_dir_stack(&qi->qf_dir_stack);
   qi->qf_directory = NULL;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4189,6 +4189,11 @@ static int qf_add_entries(qf_info_T *qi, list_T *list, char_u *title,
       bufnum = 0;
     }
 
+    // If the 'valid' field is present it overrules the detected value.
+    if (tv_dict_find(d, "valid", -1) != NULL) {
+      valid = (int)tv_dict_get_number(d, "valid");
+    }
+
     int status = qf_add_entry(qi,
                               NULL,      // dir
                               (char_u *)filename,

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2411,12 +2411,18 @@ static void qf_free(qf_info_T *qi, int idx)
   qi->qf_lists[idx].qf_ptr = NULL;
   qi->qf_lists[idx].qf_title = NULL;
   qi->qf_lists[idx].qf_index = 0;
+  qi->qf_lists[idx].qf_start = NULL;
   qi->qf_lists[idx].qf_last = NULL;
+  qi->qf_lists[idx].qf_ptr = NULL;
+  qi->qf_lists[idx].qf_nonevalid = true;
 
   qf_clean_dir_stack(&qi->qf_dir_stack);
   qi->qf_directory = NULL;
   qf_clean_dir_stack(&qi->qf_file_stack);
   qi->qf_currfile = NULL;
+  qi->qf_multiline = false;
+  qi->qf_multiignore = false;
+  qi->qf_multiscan = false;
 }
 
 /*

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1183,6 +1183,25 @@ func SetXlistTests(cchar, bnum)
   let l = g:Xgetlist()
   call assert_equal(0, len(l))
 
+  " Tests for setting the 'valid' flag
+  call g:Xsetlist([{'bufnr':a:bnum, 'lnum':4, 'valid':0}])
+  Xwindow
+  call assert_equal(1, winnr('$'))
+  let l = g:Xgetlist()
+  call g:Xsetlist(l)
+  call assert_equal(0, g:Xgetlist()[0].valid)
+  call g:Xsetlist([{'text':'Text1', 'valid':1}])
+  Xwindow
+  call assert_equal(2, winnr('$'))
+  Xclose
+  let save_efm = &efm
+  set efm=%m
+  Xgetexpr 'TestMessage'
+  let l = g:Xgetlist()
+  call g:Xsetlist(l)
+  call assert_equal(1, g:Xgetlist()[0].valid)
+  let &efm = save_efm
+
   " Error cases:
   " Refer to a non-existing buffer and pass a non-dictionary type
   call assert_fails("call g:Xsetlist([{'bufnr':998, 'lnum':4}," .

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2004,15 +2004,3 @@ func Test_qf_free()
   call XfreeTests('c')
   call XfreeTests('l')
 endfunc
-
-func Test_no_reuse_mem()
-  set efm=E,%W%m,
-  cgetexpr ['C']
-  set efm=%C%m
-  lexpr '0'
-  lopen
-  call setqflist([], 'r')
-  caddbuf
-
-  set efm&
-endfunc


### PR DESCRIPTION
#### vim-patch:8.0.0565: using freed memory in :caddbuf

Problem:    Using freed memory in :caddbuf after clearing quickfix list.
            (Dominique Pelle)
Solution:   Set qf_last to NULL.

https://github.com/vim/vim/commit/31bdd13c335533c749993b57dcd980a87373139e


#### vim-patch:8.0.0574: get only one quickfix list after :caddbuf

Problem:    Get only one quickfix list after :caddbuf.
Solution:   Reset qf_multiline. (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/99895eac1cf71be43ece7e14b50e206e041fbe9f


#### vim-patch:8.0.0579: duplicate test case for quickfix

Problem:    Duplicate test case for quickfix.
Solution:   Remove the function. (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/9b77016545d5ef1a1f4a90c9bb4b7a6693af8918


#### vim-patch:8.0.0580: cannot set the valid flag with setqflist()

Problem:    Cannot set the valid flag with setqflist().
Solution:   Add the "valid" argument. (Yegappan Lakshmanan, closes vim/vim#1642)

https://github.com/vim/vim/commit/f1d21c8cc83f40c815b6bf13cd2043152db533ee