### PR TITLE
[RFC] vim-patch:8.0.0590,8.0.0595,8.0.0597,8.0.0606

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5173,6 +5173,8 @@ bool garbage_collect(bool testing)
     ABORTING(set_ref_list)(sub.additional_elements, copyID);
   }
 
+  ABORTING(set_ref_in_quickfix)(copyID);
+
   bool did_free = false;
   if (!abort) {
     // 2. Free lists and dictionaries that are not referenced.

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4278,7 +4278,10 @@ static int qf_set_properties(qf_info_T *qi, dict_T *what, int action)
   if ((di = tv_dict_find(what, S_LEN("nr"))) != NULL) {
     // Use the specified quickfix/location list
     if (di->di_tv.v_type == VAR_NUMBER) {
-      qf_idx = (int)di->di_tv.vval.v_number - 1;
+      // for zero use the current list
+      if (di->di_tv.vval.v_number != 0) {
+        qf_idx = (int)di->di_tv.vval.v_number - 1;
+      }
       if (qf_idx < 0 || qf_idx >= qi->qf_listcount) {
         return FAIL;
       }
@@ -4306,11 +4309,11 @@ static int qf_set_properties(qf_info_T *qi, dict_T *what, int action)
   }
 
   if ((di = tv_dict_find(what, S_LEN("context"))) != NULL) {
-    tv_free(qi->qf_lists[qi->qf_curlist].qf_ctx);
+    tv_free(qi->qf_lists[qf_idx].qf_ctx);
 
     typval_T *ctx = xcalloc(1, sizeof(typval_T));
     tv_copy(&di->di_tv, ctx);
-    qi->qf_lists[qi->qf_curlist].qf_ctx = ctx;
+    qi->qf_lists[qf_idx].qf_ctx = ctx;
   }
 
   return retval;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -801,7 +801,7 @@ restofline:
         fields->type = *regmatch.startp[i];
       }
       if (fmt_ptr->flags == '+' && !qi->qf_multiscan) {       // %+
-        if (linelen > fields->errmsglen) {
+        if (linelen >= fields->errmsglen) {
           // linelen + null terminator
           fields->errmsg = xrealloc(fields->errmsg, linelen + 1);
           fields->errmsglen = linelen + 1;
@@ -812,7 +812,7 @@ restofline:
           continue;
         }
         len = (size_t)(regmatch.endp[i] - regmatch.startp[i]);
-        if (len > fields->errmsglen) {
+        if (len >= fields->errmsglen) {
           // len + null terminator
           fields->errmsg = xrealloc(fields->errmsg, len + 1);
           fields->errmsglen = len + 1;
@@ -889,7 +889,7 @@ restofline:
     fields->namebuf[0] = NUL;                // no match found, remove file name
     fields->lnum = 0;                        // don't jump to this line
     fields->valid = false;
-    if (linelen > fields->errmsglen) {
+    if (linelen >= fields->errmsglen) {
       // linelen + null terminator
       fields->errmsg = xrealloc(fields->errmsg, linelen + 1);
       fields->errmsglen = linelen + 1;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4147,7 +4147,9 @@ int get_errorlist_properties(win_T *wp, dict_T *what, dict_T *retdict)
       di = tv_dict_item_alloc_len(S_LEN("context"));
       if (di != NULL) {
         tv_copy(qi->qf_lists[qf_idx].qf_ctx, &di->di_tv);
-        tv_dict_add(retdict, di);
+        if (tv_dict_add(retdict, di) == FAIL) {
+          tv_dict_item_free(di);
+        }
       }
     } else {
       status = tv_dict_add_str(retdict, S_LEN("context"), "");

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1786,6 +1786,37 @@ func Xproperty_tests(cchar)
 	call setloclist(0, [], 'f')
 	call assert_equal({}, getloclist(0, {'context':1}))
     endif
+
+    " Test for changing the context of previous quickfix lists
+    call g:Xsetlist([], 'f')
+    Xexpr "One"
+    Xexpr "Two"
+    Xexpr "Three"
+    call g:Xsetlist([], ' ', {'context' : [1], 'nr' : 1})
+    call g:Xsetlist([], ' ', {'context' : [2], 'nr' : 2})
+    " Also, check for setting the context using quickfix list number zero.
+    call g:Xsetlist([], ' ', {'context' : [3], 'nr' : 0})
+    call test_garbagecollect_now()
+    let l = g:Xgetlist({'nr' : 1, 'context' : 1})
+    call assert_equal([1], l.context)
+    let l = g:Xgetlist({'nr' : 2, 'context' : 1})
+    call assert_equal([2], l.context)
+    let l = g:Xgetlist({'nr' : 3, 'context' : 1})
+    call assert_equal([3], l.context)
+
+    " Test for changing the context through reference and for garbage
+    " collection of quickfix context
+    let l = ["red"]
+    call g:Xsetlist([], ' ', {'context' : l})
+    call add(l, "blue")
+    let x = g:Xgetlist({'context' : 1})
+    call add(x.context, "green")
+    call assert_equal(["red", "blue", "green"], l)
+    call assert_equal(["red", "blue", "green"], x.context)
+    unlet l
+    call test_garbagecollect_now()
+    let m = g:Xgetlist({'context' : 1})
+    call assert_equal(["red", "blue", "green"], m.context)
 endfunc
 
 func Test_qf_property()
@@ -2055,3 +2086,19 @@ func Test_qf_free()
   call XfreeTests('c')
   call XfreeTests('l')
 endfunc
+
+" Test for buffer overflow when parsing lines and adding new entries to
+" the quickfix list.
+func Test_bufoverflow()
+  set efm=%f:%l:%m
+  cgetexpr ['File1:100:' . repeat('x', 1025)]
+
+  set efm=%+GCompiler:\ %.%#,%f:%l:%m
+  cgetexpr ['Compiler: ' . repeat('a', 1015), 'File1:10:Hello World']
+
+  set efm=%DEntering\ directory\ %f,%f:%l:%m
+  cgetexpr ['Entering directory ' . repeat('a', 1006),
+	      \ 'File1:10:Hello World']
+  set efm&vim
+endfunc
+

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1754,6 +1754,38 @@ func Xproperty_tests(cchar)
     if a:cchar == 'l'
 	call assert_equal({}, getloclist(99, {'title': 1}))
     endif
+
+    " Context related tests
+    call g:Xsetlist([], 'a', {'context':[1,2,3]})
+    call test_garbagecollect_now()
+    let d = g:Xgetlist({'context':1})
+    call assert_equal([1,2,3], d.context)
+    call g:Xsetlist([], 'a', {'context':{'color':'green'}})
+    let d = g:Xgetlist({'context':1})
+    call assert_equal({'color':'green'}, d.context)
+    call g:Xsetlist([], 'a', {'context':"Context info"})
+    let d = g:Xgetlist({'context':1})
+    call assert_equal("Context info", d.context)
+    call g:Xsetlist([], 'a', {'context':246})
+    let d = g:Xgetlist({'context':1})
+    call assert_equal(246, d.context)
+    if a:cchar == 'l'
+	" Test for copying context across two different location lists
+	new | only
+	let w1_id = win_getid()
+	let l = [1]
+	call setloclist(0, [], 'a', {'context':l})
+	new
+	let w2_id = win_getid()
+	call add(l, 2)
+	call assert_equal([1, 2], getloclist(w1_id, {'context':1}).context)
+	call assert_equal([1, 2], getloclist(w2_id, {'context':1}).context)
+	unlet! l
+	call assert_equal([1, 2], getloclist(w2_id, {'context':1}).context)
+	only
+	call setloclist(0, [], 'f')
+	call assert_equal({}, getloclist(0, {'context':1}))
+    endif
 endfunc
 
 func Test_qf_property()


### PR DESCRIPTION
#### vim-patch:8.0.0590: cannot add a context to locations

Problem:    Cannot add a context to locations.
Solution:   Add the "context" entry in location entries. (Yegappan Lakshmanan,
            closes vim/vim#1012)

https://github.com/vim/vim/commit/8f77c5a4ec756f3f866bd6b18feb6fca6f2a2e91


#### vim-patch:8.0.0595: Coverity warning for not checking return value

Problem:    Coverity warning for not checking return value of dict_add().
Solution:   Check the return value for FAIL.

https://github.com/vim/vim/commit/beb9cb19c660484488a71a25eda46ab0fa579278


#### vim-patch:8.0.0597: off-by-one error in size computation

Problem:    Off-by-one error in buffer size computation.
Solution:   Use ">=" instead of ">". (Lemonboy, closes vim/vim#1694)

https://github.com/vim/vim/commit/253f9128779f315ea670f9b4a17446b7b4c74927


#### vim-patch:8.0.0606: cannot set the context for a specified quickfix list

Problem:    Cannot set the context for a specified quickfix list.
Solution:   Use the list index instead of the current list. (Yegappan
            Lakshmanan)

https://github.com/vim/vim/commit/6e62da3e14d32f76f60d5cc8b267059923842f17