### PR TITLE
[RFC] win: test: enable more non-legacy functional tests on Windows

### DIFF
--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -89,7 +89,9 @@ describe('system()', function()
     end)
 
     it('does NOT run in shell', function()
-      if not iswin() then
+      if iswin() then
+        eq("C:\\Windows\\System32\\cmd.exe\n", eval("system(['where', 'cmd'])"))
+      else
         eq("* $PATH %PATH%\n", eval("system(['echo', '*', '$PATH', '%PATH%'])"))
       end
     end)

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -90,7 +90,7 @@ describe('system()', function()
 
     it('does NOT run in shell', function()
       if iswin() then
-        eq("C:\\Windows\\System32\\cmd.exe\n", eval("system(['where', 'cmd'])"))
+        eq("%PATH%\n", eval("system(['powershell', '-NoProfile', '-NoLogo', '-ExecutionPolicy', 'RemoteSigned', '-Command', 'echo', '%PATH%'])"))
       else
         eq("* $PATH %PATH%\n", eval("system(['echo', '*', '$PATH', '%PATH%'])"))
       end

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -442,11 +442,13 @@ describe('systemlist()', function()
   describe('with output containing NULs', function()
     local fname = 'Xtest'
 
-    before_each(create_file_with_nuls(fname))
+    before_each(function()
+      command('set ff=unix')
+      create_file_with_nuls(fname)()
+    end)
     after_each(delete_file(fname))
 
     it('replaces NULs by newline characters', function()
-      if helpers.pending_win32(pending) then return end
       eq({'part1\npart2\npart3'}, eval('systemlist("cat '..fname..'")'))
     end)
   end)

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -187,6 +187,7 @@ describe('system()', function()
     end)
 
     it('`yes` and is interrupted with CTRL-C', function()
+      if helpers.pending_win32(pending) then return end
       feed(':call system("yes")<cr>')
       screen:expect([[
                                                              |

--- a/test/functional/normal/K_spec.lua
+++ b/test/functional/normal/K_spec.lua
@@ -2,8 +2,6 @@ local helpers = require('test.functional.helpers')(after_each)
 local eq, clear, eval, feed =
   helpers.eq, helpers.clear, helpers.eval, helpers.feed
 
-if helpers.pending_win32(pending) then return end
-
 describe('K', function()
   local test_file = 'K_spec_out'
   before_each(function()
@@ -29,7 +27,7 @@ describe('K', function()
   it("invokes non-prefixed 'keywordprg' as shell command", function()
     helpers.source([[
       let @a='fnord'
-      set keywordprg=echo\ fnord\ >>]])
+      set keywordprg=echo\ fnord>>]])
 
     -- K on the text "K_spec_out" resolves to `!echo fnord >> K_spec_out`.
     feed('i'..test_file..'<ESC>K')

--- a/test/functional/options/autochdir_spec.lua
+++ b/test/functional/options/autochdir_spec.lua
@@ -3,8 +3,6 @@ local clear = helpers.clear
 local eq = helpers.eq
 local getcwd = helpers.funcs.getcwd
 
-if helpers.pending_win32(pending) then return end
-
 describe("'autochdir'", function()
   it('given on the shell gets processed properly', function()
     local targetdir = 'test/functional/fixtures'
@@ -12,9 +10,10 @@ describe("'autochdir'", function()
     -- By default 'autochdir' is off, thus getcwd() returns the repo root.
     clear(targetdir..'/tty-test.c')
     local rootdir = getcwd()
+    local expected = rootdir .. '/' .. targetdir
 
     -- With 'autochdir' on, we should get the directory of tty-test.c.
     clear('--cmd', 'set autochdir', targetdir..'/tty-test.c')
-    eq(rootdir..'/'..targetdir, getcwd())
+    eq(helpers.iswin() and expected:gsub('/', '\\') or expected, getcwd())
   end)
 end)

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -22,8 +22,6 @@ end
 
 describe('startup defaults', function()
   describe(':filetype', function()
-    if helpers.pending_win32(pending) then return end
-
     local function expect_filetype(expected)
       local screen = Screen.new(50, 4)
       screen:attach()

--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -43,8 +43,6 @@ local wshada, _, fname = get_shada_rw('Xtest-functional-plugin-shada.shada')
 local wshada_tmp, _, fname_tmp =
   get_shada_rw('Xtest-functional-plugin-shada.shada.tmp.f')
 
-if helpers.pending_win32(pending) then return end
-
 describe('In autoload/shada.vim', function()
   local epoch = os.date('%Y-%m-%dT%H:%M:%S', 0)
   before_each(function()
@@ -2140,6 +2138,7 @@ end)
 
 describe('In plugin/shada.vim', function()
   local epoch = os.date('%Y-%m-%dT%H:%M:%S', 0)
+  local eol = helpers.iswin() and '\r\n' or '\n'
   before_each(function()
     reset()
     os.remove(fname)
@@ -2279,7 +2278,7 @@ describe('In plugin/shada.vim', function()
         '  + f            file name    ["foo"]',
         '  + l            line number  2',
         '  + c            column       -200',
-      }, '\n') .. '\n', io.open(fname .. '.tst'):read('*a'))
+      }, eol) .. eol, io.open(fname .. '.tst'):read('*a'))
       shada_eq({{
         timestamp=0,
         type=8,
@@ -2303,6 +2302,7 @@ describe('In plugin/shada.vim', function()
 
   describe('event FileWriteCmd', function()
     it('works', function()
+      if helpers.pending_win32(pending) then return end
       nvim('set_var', 'shada#add_own_header', 0)
       curbuf('set_lines', 0, 1, true, {
         'Jump with timestamp ' .. epoch .. ':',
@@ -2326,7 +2326,7 @@ describe('In plugin/shada.vim', function()
         'Jump with timestamp ' .. epoch .. ':',
         '  % Key________  Description  Value',
         '  + n            name         \'A\'',
-      }, '\n') .. '\n', io.open(fname .. '.tst'):read('*a'))
+      }, eol) .. eol, io.open(fname .. '.tst'):read('*a'))
       shada_eq({{
         timestamp=0,
         type=8,
@@ -2383,7 +2383,7 @@ describe('In plugin/shada.vim', function()
         '  + f            file name    ["foo"]',
         '  + l            line number  2',
         '  + c            column       -200',
-      }, '\n') .. '\n', io.open(fname .. '.tst'):read('*a'))
+      }, eol) .. eol, io.open(fname .. '.tst'):read('*a'))
       shada_eq({{
         timestamp=0,
         type=8,

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -7,7 +7,6 @@ local retry = helpers.retry
 local iswin = helpers.iswin
 
 describe(':terminal', function()
-  if helpers.pending_win32(pending) then return end
   local screen
 
   before_each(function()
@@ -24,7 +23,11 @@ describe(':terminal', function()
       echomsg "msg3"
     ]])
     -- Invoke a command that emits frequent terminal activity.
-    feed_command([[terminal while true; do echo X; done]])
+    if iswin() then
+      feed_command([[terminal for /L \\%I in (1,0,2) do echo \\%I]])
+    else
+      feed_command([[terminal while true; do echo X; done]])
+    end
     helpers.feed([[<C-\><C-N>]])
     wait()
     screen:sleep(10)  -- Let some terminal activity happen.
@@ -38,7 +41,11 @@ describe(':terminal', function()
   end)
 
   it("in normal-mode :split does not move cursor", function()
-    feed_command([[terminal while true; do echo foo; sleep .1; done]])
+    if iswin() then
+      feed_command([[terminal for /L \\%I in (1,0,2) do echo \\%I]])
+    else
+      feed_command([[terminal while true; do echo X; done]])
+    end
     helpers.feed([[<C-\><C-N>M]])  -- move cursor away from last line
     wait()
     eq(3, eval("line('$')"))  -- window height

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -42,9 +42,9 @@ describe(':terminal', function()
 
   it("in normal-mode :split does not move cursor", function()
     if iswin() then
-      feed_command([[terminal for /L \\%I in (1,0,2) do echo \\%I]])
+      feed_command([[terminal for /L \\%I in (1,0,2) do ( echo foo & ping -w 100 -n 1 127.0.0.1 > nul )]])
     else
-      feed_command([[terminal while true; do echo X; done]])
+      feed_command([[terminal while true; do echo foo; sleep .1; done]])
     end
     helpers.feed([[<C-\><C-N>M]])  -- move cursor away from last line
     wait()

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -4,8 +4,6 @@ local Screen = require('test.functional.ui.screen')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local command, request, neq = helpers.command, helpers.request, helpers.neq
 
-if helpers.pending_win32(pending) then return end
-
 describe('Buffer highlighting', function()
   local screen
   local curbuf

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -121,8 +121,6 @@ describe(":substitute, inccommand=split does not trigger preview", function()
 end)
 
 describe(":substitute, 'inccommand' preserves", function()
-   if helpers.pending_win32(pending) then return end
-
   before_each(clear)
 
   it('listed buffers (:ls)', function()
@@ -285,8 +283,6 @@ describe(":substitute, 'inccommand' preserves", function()
 end)
 
 describe(":substitute, 'inccommand' preserves undo", function()
-   if helpers.pending_win32(pending) then return end
-
   local cases = { "", "split", "nosplit" }
 
   local substrings = {
@@ -700,8 +696,6 @@ describe(":substitute, 'inccommand' preserves undo", function()
 end)
 
 describe(":substitute, inccommand=split", function()
-  if helpers.pending_win32(pending) then return end
-
   local screen = Screen.new(30,15)
 
   before_each(function()
@@ -1169,8 +1163,6 @@ describe(":substitute, inccommand=split", function()
 end)
 
 describe("inccommand=nosplit", function()
-  if helpers.pending_win32(pending) then return end
-
   local screen = Screen.new(20,10)
 
   before_each(function()
@@ -1356,8 +1348,6 @@ describe("inccommand=nosplit", function()
 end)
 
 describe(":substitute, 'inccommand' with a failing expression", function()
-  if helpers.pending_win32(pending) then return end
-
   local screen = Screen.new(20,10)
   local cases = { "", "split", "nosplit" }
 
@@ -1621,8 +1611,6 @@ describe("'inccommand' autocommands", function()
 end)
 
 describe("'inccommand' split windows", function()
-  if helpers.pending_win32(pending) then return end
-
   local screen
   local function refresh()
     clear()

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -4,8 +4,6 @@ local feed, next_message, eq = helpers.feed, helpers.next_message, helpers.eq
 local expect = helpers.expect
 local Screen = require('test.functional.ui.screen')
 
-if helpers.pending_win32(pending) then return end
-
 describe('mappings', function()
   local cid
 

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -4,8 +4,6 @@ local clear, feed, meths = helpers.clear, helpers.feed, helpers.meths
 local insert, feed_command = helpers.insert, helpers.feed_command
 local eq, funcs = helpers.eq, helpers.funcs
 
-if helpers.pending_win32(pending) then return end
-
 describe('ui/mouse/input', function()
   local screen
 

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -3,8 +3,6 @@ local Screen = require('test.functional.ui.screen')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local feed_command = helpers.feed_command
 
-if helpers.pending_win32(pending) then return end
-
 describe('search highlighting', function()
   local screen
   local colors = Screen.colors

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -2,8 +2,6 @@ local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, command = helpers.clear, helpers.feed, helpers.command
 
-if helpers.pending_win32(pending) then return end
-
 describe('Signs', function()
   local screen
 

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -3,8 +3,6 @@ local Screen = require('test.functional.ui.screen')
 local clear, feed, command = helpers.clear, helpers.feed, helpers.command
 local insert = helpers.insert
 
-if helpers.pending_win32(pending) then return end
-
 describe('Screen', function()
   local screen
 

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -5,8 +5,6 @@ local eval, eq, neq = helpers.eval, helpers.eq, helpers.neq
 local feed_command, source, expect = helpers.feed_command, helpers.source, helpers.expect
 local meths = helpers.meths
 
-if helpers.pending_win32(pending) then return end
-
 describe('completion', function()
   local screen
 


### PR DESCRIPTION
Cherry-picked from #7412 
The patch enables some functional tests with minimal changes to work in Windows.