### PR TITLE
[RDY] vim-patch:8.0.0320: warning for unused variable with small build

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -936,7 +936,7 @@ static const int included_patches[] = {
   // 323,
   322,
   // 321,
-  // 320,
+  320,
   319,
   // 318,
   // 317,


### PR DESCRIPTION
Problem:    Warning for unused variable with small build.
Solution:   Change vim/vim#ifdef to exclude FEAT_CMDWIN. (Kazunobu Kuriyama)

https://github.com/vim/vim/commit/4d8505155ec3d0f04e268b2997153ecaf37ee188

vim-patch:8.0.0320 have been patch already