### PR TITLE
ci: use default nvm on Travis

### DIFF
--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -40,12 +40,6 @@ fi
 
 if [[ "${TRAVIS_OS_NAME}" == linux ]]; then
   echo "Install node (LTS)"
-
-  if [ ! -f ~/.nvm/nvm.sh ]; then
-    curl -o ~/.nvm/nvm.sh https://raw.githubusercontent.com/creationix/nvm/master/nvm.sh
-  fi
-
-  source ~/.nvm/nvm.sh
   nvm install --lts
   nvm use --lts
 fi

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -40,6 +40,7 @@ fi
 
 if [[ "${TRAVIS_OS_NAME}" == linux ]]; then
   echo "Install node (LTS)"
+  source ~/.nvm/nvm.sh
   nvm install --lts
   nvm use --lts
 fi


### PR DESCRIPTION
Try to use the default nvm on Trusty image (and use the absolute path if it is unavailable from PATH).
This is only for trying to speed up the build and use preinstalled nvm and node versions if possible.

I think this is not necessary for Appveyor because Appveyor's powershell helper command, `Install-Product` switches the default version with a preinstalled version. However, there is a `LTS` alias (https://www.appveyor.com/docs/build-environment/) to to reduce the need of tracking the current lts release version on Appveyor, similar to nvm on Travis.