### PR TITLE
health.vim: remove :CheckHealth command

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -370,10 +370,11 @@ function! s:check_python(version) abort
     let python_bin = ''
   endif
 
-  " Check if $VIRTUAL_ENV is active
-  let virtualenv_inactive = 0
 
+  " Check if $VIRTUAL_ENV is active.
   if exists('$VIRTUAL_ENV')
+    let virtualenv_inactive = 0
+
     if !empty(pyenv)
       let pyenv_prefix = resolve(s:trim(s:system([pyenv, 'prefix'])))
       if $VIRTUAL_ENV != pyenv_prefix
@@ -382,13 +383,13 @@ function! s:check_python(version) abort
     elseif !empty(pyname) && exepath(pyname) !~# '^'.$VIRTUAL_ENV.'/'
       let virtualenv_inactive = 1
     endif
-  endif
 
-  if virtualenv_inactive
-    call health#report_warn(
-      \ '$VIRTUAL_ENV exists but appears to be inactive. '
-      \ . 'This could lead to unexpected results.',
-      \ [ 'If you are using Zsh, see: http://vi.stackexchange.com/a/7654/5229' ])
+    if virtualenv_inactive
+      call health#report_warn(
+        \ '$VIRTUAL_ENV exists but appears to be inactive. '
+        \ . 'This could lead to unexpected results.',
+        \ [ 'If you are using Zsh, see: http://vi.stackexchange.com/a/7654' ])
+    endif
   endif
 
   " Diagnostic output

--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -114,7 +114,7 @@ let s:err = ''
 let s:prog = provider#node#Detect()
 
 if empty(s:prog)
-  let s:err = 'Cannot find the "neovim" node package. Try :CheckHealth'
+  let s:err = 'Cannot find the "neovim" node package. Try :checkhealth'
 endif
 
 call remote#host#RegisterPlugin('node-provider', 'node', [])

--- a/runtime/plugin/health.vim
+++ b/runtime/plugin/health.vim
@@ -1,8 +1,1 @@
-function! s:complete(lead, _line, _pos) abort
-  return sort(filter(map(globpath(&runtimepath, 'autoload/health/*', 1, 1),
-        \ 'fnamemodify(v:val, ":t:r")'),
-        \ 'empty(a:lead) || v:val[:strlen(a:lead)-1] ==# a:lead'))
-endfunction
-
-command! -nargs=* -complete=customlist,s:complete CheckHealth
-      \ call health#check([<f-args>])
+autocmd CmdUndefined CheckHealth checkhealth


### PR DESCRIPTION
For back-compat, :CheckHealth runs :checkhealth. But don't define
:CheckHealth explicitly, it adds noise to wildmenu completion.

Completion of healthchecks doesn't yet work with :checkhealth, this is
a regression but it needs to be implemented for :checkhealth rather than
keeping :CheckHealth around.