### PR TITLE
[WIP] test: win: enable unit tests

### DIFF
--- a/ci/build.bat
+++ b/ci/build.bat
@@ -57,7 +57,7 @@ bin\nvim --version || goto :error
 
 :: Unit tests
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %VS_ARCH%
-mingw32-make unittest VERBOSE=1
+mingw32-make unittest VERBOSE=1 || goto :error
 
 :: Functional tests
 mingw32-make functionaltest VERBOSE=1 || goto :error

--- a/ci/build.bat
+++ b/ci/build.bat
@@ -4,9 +4,11 @@
 echo on
 if "%CONFIGURATION%" == "MINGW_32" (
   set ARCH=i686
+  set VS_ARCH=x86
   set BITS=32
 ) else (
   set ARCH=x86_64
+  set VS_ARCH=x86_amd64
   set BITS=64
 )
 if "%CONFIGURATION%" == "MINGW_64-gcov" (
@@ -52,6 +54,10 @@ cd build
 cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUSTED_OUTPUT_TYPE=nvim %USE_GCOV% -DGPERF_PRG="C:\msys64\usr\bin\gperf.exe" .. || goto :error
 mingw32-make VERBOSE=1 || goto :error
 bin\nvim --version || goto :error
+
+:: Unit tests
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %VS_ARCH%
+mingw32-make unittest VERBOSE=1
 
 :: Functional tests
 mingw32-make functionaltest VERBOSE=1 || goto :error

--- a/test/unit/fixtures/win32.h
+++ b/test/unit/fixtures/win32.h
@@ -1,0 +1,1 @@
+#include <io.h>

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -407,6 +407,16 @@ elseif syscall ~= nil then
     wait = syscall.wait,
     exit = syscall.exit,
   }
+elseif ffi.os == "Windows" then
+  sc = {
+    fork = function() end,
+    pipe = function() end,
+    read = function(rd, len) end,
+    write = function(wr, s) end,
+    close = function(pid) end,
+    wait = function(pid) end,
+    exit = function(status) end,
+  }
 else
   cimport_immediate('./test/unit/fixtures/posix.h')
   sc = {

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -408,12 +408,13 @@ elseif syscall ~= nil then
     exit = syscall.exit,
   }
 elseif ffi.os == "Windows" then
+  cimport_immediate('./test/unit/fixtures/win32.h')
   sc = {
     fork = function() end,
     pipe = function() end,
-    read = function(rd, len) end,
-    write = function(wr, s) end,
-    close = function(pid) end,
+    read = ffi.C._read,
+    write = ffi.C._write,
+    close = ffi.C._close,
     wait = function(pid) end,
     exit = function(status) end,
   }

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -245,7 +245,12 @@ function Gcc:preprocess(previous_defines, ...)
 end
 
 local Clang = Gcc:new()
-local Msvc = Gcc:new()
+local Msvc = {
+  preprocessor_extra_flags = {},
+  get_defines_extra_flags = {},
+  get_declarations_extra_flags = {},
+  init_defines = function() end,
+}
 
 local type_to_class = {
   ["gcc"] = Gcc,

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -22,12 +22,23 @@ table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.7"}, type = "gcc"})
 table.insert(ccs, {path = {"/usr/bin/env", "clang"}, type = "clang"})
 table.insert(ccs, {path = {"/usr/bin/env", "icc"}, type = "gcc"})
 
-local quote_me = '[^.%w%+%-%@%_%/]' -- complement (needn't quote)
-local function shell_quote(str)
-  if string.find(str, quote_me) or str == '' then
-    return "'" .. string.gsub(str, "'", [['"'"']]) .. "'"
-  else
-    return str
+local shell_quote
+
+if ffi.os == "Windows" then
+  shell_quote = function (str)
+    -- standard argv
+    local escaped = '"'..string.gsub(str, [[(["\])]], [[\%1]])..'"'
+    -- cmd-specific
+    return escaped:gsub('([&|<>()@^%%!"])', '^%1')
+  end
+else
+  local quote_me = '[^.%w%+%-%@%_%/]' -- complement (needn't quote)
+  shell_quote = function (str)
+    if string.find(str, quote_me) or str == '' then
+      return "'" .. string.gsub(str, "'", [['"'"']]) .. "'"
+    else
+      return str
+    end
   end
 end
 

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -6,21 +6,23 @@ local ffi = require("ffi")
 local ccs = {}
 
 local env_cc = os.getenv("CC")
-if env_cc then
-  table.insert(ccs, {path = {"/usr/bin/env", env_cc}, type = "gcc"})
-end
 
 if ffi.os == "Windows" then
+  table.insert(ccs, {path = {"gcc"}, type = "gcc"})
   table.insert(ccs, {path = {"cl"}, type = "msvc"})
-end
+else
+  if env_cc then
+    table.insert(ccs, {path = {"/usr/bin/env", env_cc}, type = "gcc"})
+  end
 
-table.insert(ccs, {path = {"/usr/bin/env", "cc"}, type = "gcc"})
-table.insert(ccs, {path = {"/usr/bin/env", "gcc"}, type = "gcc"})
-table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.9"}, type = "gcc"})
-table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.8"}, type = "gcc"})
-table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.7"}, type = "gcc"})
-table.insert(ccs, {path = {"/usr/bin/env", "clang"}, type = "clang"})
-table.insert(ccs, {path = {"/usr/bin/env", "icc"}, type = "gcc"})
+  table.insert(ccs, {path = {"/usr/bin/env", "cc"}, type = "gcc"})
+  table.insert(ccs, {path = {"/usr/bin/env", "gcc"}, type = "gcc"})
+  table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.9"}, type = "gcc"})
+  table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.8"}, type = "gcc"})
+  table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.7"}, type = "gcc"})
+  table.insert(ccs, {path = {"/usr/bin/env", "clang"}, type = "clang"})
+  table.insert(ccs, {path = {"/usr/bin/env", "icc"}, type = "gcc"})
+end
 
 local shell_quote
 

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -249,8 +249,29 @@ local Msvc = {
   preprocessor_extra_flags = {},
   get_defines_extra_flags = {},
   get_declarations_extra_flags = {},
-  init_defines = function() end,
 }
+
+function Msvc:define(name, args, val)
+end
+
+function Msvc:undefine(name)
+end
+
+function Msvc:new(obj)
+  obj = obj or {}
+  setmetatable(obj, self)
+  self.__index = self
+  return obj
+end
+
+function Msvc:dependencies()
+end
+
+function Msvc:preprocess(previous_defines, ...)
+end
+
+function Msvc:add_to_include_path(...)
+end
 
 local type_to_class = {
   ["gcc"] = Gcc,

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -10,6 +10,10 @@ if env_cc then
   table.insert(ccs, {path = {"/usr/bin/env", env_cc}, type = "gcc"})
 end
 
+if ffi.os == "Windows" then
+  table.insert(ccs, {path = {"cl"}, type = "msvc"})
+end
+
 table.insert(ccs, {path = {"/usr/bin/env", "cc"}, type = "gcc"})
 table.insert(ccs, {path = {"/usr/bin/env", "gcc"}, type = "gcc"})
 table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.9"}, type = "gcc"})
@@ -17,10 +21,6 @@ table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.8"}, type = "gcc"})
 table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.7"}, type = "gcc"})
 table.insert(ccs, {path = {"/usr/bin/env", "clang"}, type = "clang"})
 table.insert(ccs, {path = {"/usr/bin/env", "icc"}, type = "gcc"})
-
-if ffi.os == "Windows" then
-  table.insert(ccs, {path = {"cl"}, type = "msvc"})
-end
 
 local quote_me = '[^.%w%+%-%@%_%/]' -- complement (needn't quote)
 local function shell_quote(str)

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -251,10 +251,19 @@ local Msvc = {
   get_declarations_extra_flags = {},
 }
 
+-- Like Gcc:define but ignore args parameter
+-- cl.exe does not support function-like macros
 function Msvc:define(name, args, val)
+  local define = '/D' .. name
+  if val ~= nil then
+    define = define .. '=' .. val
+  end
+  self.preprocessor_extra_flags[#self.preprocessor_extra_flags + 1] = define
 end
 
 function Msvc:undefine(name)
+  self.preprocessor_extra_flags[#self.preprocessor_extra_flags + 1] = (
+      '/U' .. name)
 end
 
 function Msvc:new(obj)

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -251,10 +251,11 @@ local Msvc = {
   get_declarations_extra_flags = {'/nologo'},
 }
 
--- Like Gcc:define but ignore args parameter
--- cl.exe does not support function-like macros
 function Msvc:define(name, args, val)
   local define = '/D' .. name
+  if args ~= nil then
+    error("cl.exe does not support function-like macros")
+  end
   if val ~= nil then
     define = define .. '=' .. val
   end

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -298,7 +298,8 @@ local type_to_class = {
 -- http://scite-ru.googlecode.com/svn/trunk/pack/tools/LuaLib/shell.html#exec
 local function find_best_cc(compilers)
   for _, meta in pairs(compilers) do
-    local version = io.popen(tostring(meta.path) .. " -v 2>&1")
+    local cc_args = meta.type == 'msvc' and '' or '-v'
+    local version = io.popen(tostring(meta.path).." "..cc_args.." 2>&1")
     version:close()
     if version then
       return type_to_class[meta.type]:new({path = meta.path})

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -285,7 +285,17 @@ function Msvc:new(obj)
   return obj
 end
 
-function Msvc:dependencies()
+function Msvc:dependencies(hdr)
+  local cmd = argss_to_cmd(self.path, {'/nologo', '/showIncludes', '/c', '/Tc'..hdr}) .. ' 2>&1'
+  local out = io.popen(cmd)
+  local deps = out:read("*a")
+  out:close()
+  if deps then
+    -- TODO: parse cl.exe output, incompatible with make
+    return nil
+  else
+    return nil
+  end
 end
 
 function Msvc:preprocess(previous_defines, ...)

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -280,6 +280,11 @@ function Msvc:preprocess(previous_defines, ...)
 end
 
 function Msvc:add_to_include_path(...)
+  for i = 1, select('#', ...) do
+    local path = select(i, ...)
+    local ef = self.preprocessor_extra_flags
+    ef[#ef + 1] = '/I' .. path
+  end
 end
 
 local type_to_class = {

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -246,9 +246,9 @@ end
 
 local Clang = Gcc:new()
 local Msvc = {
-  preprocessor_extra_flags = {},
-  get_defines_extra_flags = {},
-  get_declarations_extra_flags = {},
+  preprocessor_extra_flags = {'/nologo'},
+  get_defines_extra_flags = {'/nologo'},
+  get_declarations_extra_flags = {'/nologo'},
 }
 
 -- Like Gcc:define but ignore args parameter

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -10,10 +10,6 @@ if env_cc then
   table.insert(ccs, {path = {"/usr/bin/env", env_cc}, type = "gcc"})
 end
 
-if ffi.os == "Windows" then
-  table.insert(ccs, {path = {"cl"}, type = "msvc"})
-end
-
 table.insert(ccs, {path = {"/usr/bin/env", "cc"}, type = "gcc"})
 table.insert(ccs, {path = {"/usr/bin/env", "gcc"}, type = "gcc"})
 table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.9"}, type = "gcc"})
@@ -21,6 +17,10 @@ table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.8"}, type = "gcc"})
 table.insert(ccs, {path = {"/usr/bin/env", "gcc-4.7"}, type = "gcc"})
 table.insert(ccs, {path = {"/usr/bin/env", "clang"}, type = "clang"})
 table.insert(ccs, {path = {"/usr/bin/env", "icc"}, type = "gcc"})
+
+if ffi.os == "Windows" then
+  table.insert(ccs, {path = {"cl"}, type = "msvc"})
+end
 
 local quote_me = '[^.%w%+%-%@%_%/]' -- complement (needn't quote)
 local function shell_quote(str)

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -8,7 +8,6 @@ local ccs = {}
 local env_cc = os.getenv("CC")
 
 if ffi.os == "Windows" then
-  table.insert(ccs, {path = {"gcc"}, type = "gcc"})
   table.insert(ccs, {path = {"cl"}, type = "msvc"})
 else
   if env_cc then


### PR DESCRIPTION
Unit tests rely on posix api and lua ffi so they don't run on Appveyor. msvc is not setup properly such that even if it is installed properly, gcc options are passed to cl.exe (msvc) so the compilation fails.

Goal is to create (or reuse) a posix api and make unit tests work with gcc (or clang). 

If time permits, support msvc (setup in ci/build.bat and update test/unit/preprocess.lua to pass the right arguments).

The following are tests that I expect to fail on Windows:
- https://github.com/neovim/neovim/pull/7846#issuecomment-357504968
  - filepaths with spaces