### PR TITLE
scripts/vim-patch.sh: continue when patching with -P fails

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -234,7 +234,7 @@ stage_patch() {
       printf "\n✘ 'patch' command not found\n"
     else
       printf "\nApplying patch...\n"
-      patch -p1 --posix < "${patch_file}"
+      patch -p1 --posix < "${patch_file}" || true
     fi
     printf "\nInstructions:\n  Proceed to port the patch.\n"
   else


### PR DESCRIPTION
The `set -e` caused the script to stop in case `patch` fails, but it is
better to continue giving instructions.

[ci skip]