### PR TITLE
[RDY] vim-patch:8.0.0339: illegal memory access with vi'

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3669,6 +3669,11 @@ current_quote (
 
   /* Correct cursor when 'selection' is exclusive */
   if (VIsual_active) {
+    // this only works within one line
+    if (VIsual.lnum != curwin->w_cursor.lnum) {
+        return FALSE;
+    }
+
     vis_bef_curs = lt(VIsual, curwin->w_cursor);
     if (*p_sel == 'e' && vis_bef_curs)
       dec_cursor();

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3671,7 +3671,7 @@ current_quote (
   if (VIsual_active) {
     // this only works within one line
     if (VIsual.lnum != curwin->w_cursor.lnum) {
-        return FALSE;
+        return false;
     }
 
     vis_bef_curs = lt(VIsual, curwin->w_cursor);

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -43,3 +43,10 @@ func Test_dotregister_paste()
   call assert_equal('hello world world', getline(1))
   q!
 endfunc
+
+func Test_Visual_inner_quote()
+  new
+  normal oxX
+  normal vki'
+  bwipe!
+endfunc


### PR DESCRIPTION
Problem:    Illegal memory access with vi'
Solution:   For quoted text objects bail out if the Visual area spans more
            than one line.

https://github.com/vim/vim/commit/46522af72424c7fadfa7a4cbba3dd21b82d19131