### PR TITLE
[RFC] vim-patch:8.0.0591,8.0.0634,8.0.0641,8.0.0657

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -37,8 +37,8 @@ Functions ~
 *file_readable()*	Obsolete name for |filereadable()|.
 *highlight_exists()*	Obsolete name for |hlexists()|.
 *highlightID()*		Obsolete name for |hlID()|.
-*jobclose()*	        Obsolete name for |chanclose()|
-*jobsend()*	        Obsolete name for |chansend()|
+*jobclose()*		Obsolete name for |chanclose()|
+*jobsend()*		Obsolete name for |chansend()|
 *last_buffer_nr()*	Obsolete name for bufnr("$").
 
 Modifiers ~
@@ -48,8 +48,10 @@ Modifiers ~
 *:map-special*		<> notation is always enabled. |cpo-<|
 
 Options ~
+'gd'
+'gdefault'		Enables the |:substitute| flag 'g' by default.
 *'fe'*			'fenc'+'enc' before Vim 6.0; no longer used.
-*'highlight'* *'hl'* 	Names of builtin |highlight-groups| cannot be changed.
+*'highlight'* *'hl'*	Names of builtin |highlight-groups| cannot be changed.
 *'langnoremap'*		Deprecated alias to 'nolangremap'.
 *'vi'*
 *'viminfo'*		Deprecated alias to 'shada' option.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4329,12 +4329,16 @@ getqflist([{what}])					*getqflist()*
 		following string items are supported in {what}:
 			context	get the context stored with |setqflist()|
 			nr	get information for this quickfix list; zero
-				means the current quickfix list
+				means the current quickfix list and '$' means
+				the last quickfix list
 			title	get the list title
 			winid	get the |window-ID| (if opened)
 			all	all of the above quickfix properties
 		Non-string items in {what} are ignored.
 		If "nr" is not present then the current quickfix list is used.
+		To get the number of lists in the quickfix stack, set 'nr' to
+		'$' in {what}. The 'nr' value in the returned dictionary
+		contains the quickfix stack size.
 		In case of error processing {what}, an empty dictionary is
 		returned.
 
@@ -6888,7 +6892,9 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		argument is ignored.  The following items can be specified in
 		{what}:
 		    context	any Vim type can be stored as a context
-		    nr		list number in the quickfix stack
+		    nr		list number in the quickfix stack; zero
+				means the current quickfix list and '$' means
+				the last quickfix list
 		    title	quickfix list title text
 		Unsupported keys in {what} are ignored.
 		If the "nr" item is not present, then the current quickfix list
@@ -6993,18 +6999,22 @@ shellescape({string} [, {special}])			*shellescape()*
 		quotes within {string}.
 		Otherwise, it will enclose {string} in single quotes and
 		replace all "'" with "'\''".
+
 		When the {special} argument is present and it's a non-zero
 		Number or a non-empty String (|non-zero-arg|), then special
 		items such as "!", "%", "#" and "<cword>" will be preceded by
 		a backslash.  This backslash will be removed again by the |:!|
 		command.
+
 		The "!" character will be escaped (again with a |non-zero-arg|
 		{special}) when 'shell' contains "csh" in the tail.  That is
 		because for csh and tcsh "!" is used for history replacement
 		even when inside single quotes.
-		The <NL> character is also escaped.  With a |non-zero-arg|
-		{special} and 'shell' containing "csh" in the tail it's
+
+		With a |non-zero-arg| {special} the <NL> character is also
+		escaped.  When 'shell' containing "csh" in the tail it's
 		escaped a second time.
+
 		Example of use with a |:!| command: >
 		    :exe '!dir ' . shellescape(expand('<cfile>'), 1)
 <		This results in a directory listing for the file under the

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4328,6 +4328,7 @@ getqflist([{what}])					*getqflist()*
 		returns only the items listed in {what} as a dictionary. The
 		following string items are supported in {what}:
 			context	get the context stored with |setqflist()|
+			items	quickfix list entries
 			nr	get information for this quickfix list; zero
 				means the current quickfix list and '$' means
 				the last quickfix list
@@ -4344,6 +4345,7 @@ getqflist([{what}])					*getqflist()*
 
 		The returned dictionary contains the following entries:
 			context	context information stored with |setqflist()|
+			items	quickfix list entries
 			nr	quickfix list number
 			title	quickfix list title text
 			winid	quickfix |window-ID| (if opened)
@@ -6892,6 +6894,8 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		argument is ignored.  The following items can be specified in
 		{what}:
 		    context	any Vim type can be stored as a context
+		    items	list of quickfix entries. Same as the {list}
+				argument.
 		    nr		list number in the quickfix stack; zero
 				means the current quickfix list and '$' means
 				the last quickfix list

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4327,6 +4327,7 @@ getqflist([{what}])					*getqflist()*
 		If the optional {what} dictionary argument is supplied, then
 		returns only the items listed in {what} as a dictionary. The
 		following string items are supported in {what}:
+			context	get the context stored with |setqflist()|
 			nr	get information for this quickfix list; zero
 				means the current quickfix list
 			title	get the list title
@@ -4338,6 +4339,7 @@ getqflist([{what}])					*getqflist()*
 		returned.
 
 		The returned dictionary contains the following entries:
+			context	context information stored with |setqflist()|
 			nr	quickfix list number
 			title	quickfix list title text
 			winid	quickfix |window-ID| (if opened)
@@ -6885,6 +6887,7 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		only the items listed in {what} are set. The first {list}
 		argument is ignored.  The following items can be specified in
 		{what}:
+		    context	any Vim type can be stored as a context
 		    nr		list number in the quickfix stack
 		    title	quickfix list title text
 		Unsupported keys in {what} are ignored.
@@ -10508,18 +10511,19 @@ missing: >
 
 To execute a command only when the |+eval| feature is disabled requires a trick,
 as this example shows: >
-	if 1
-	  nnoremap : :"
-	endif
-	normal :set history=111<CR>
-	if 1
-	  nunmap :
-	endif
+
+	silent! while 0
+	  set history=111
+	silent! endwhile
+
+When the |+eval| feature is available the command is skipped because of the
+"while 0".  Without the |+eval| feature the "while 0" is an error, which is
+silently ignored, and the command is executed.
 
 The "<CR>" here is a real CR character, type CTRL-V Enter to get it.
 
 When the |+eval| feature is available the ":" is remapped to add a double
-quote, which has the effect of commenting-out the command.  without the
+quote, which has the effect of commenting-out the command.  Without the
 |+eval| feature the nnoremap command is skipped and the command is executed.
 
 ==============================================================================

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2712,6 +2712,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		:s///g		  subst. one	  subst. all
 		:s///gg		  subst. all	  subst. one
 
+	DEPRECATED: Setting this option may break plugins that are not aware
+	of this option.  Also, many users get confused that adding the /g flag
+	has the opposite effect of that it normally does.
+
 						*'grepformat'* *'gfm'*
 'grepformat' 'gfm'	string	(default "%f:%l:%m,%f:%l%m,%f  %l%m")
 			global

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -470,7 +470,11 @@ keep its height, ignoring 'winheight' and 'equalalways'.  You can change the
 height manually (e.g., by dragging the status line above it with the mouse).
 
 In the quickfix window, each line is one error.  The line number is equal to
-the error number.  You can use ":.cc" to jump to the error under the cursor.
+the error number.  The current entry is highlighted with the QuickFixLine
+highlighting.  You can change it to your liking, e.g.: >
+	:hi QuickFixLine ctermbg=Yellow guibg=Yellow
+
+You can use ":.cc" to jump to the error under the cursor.
 Hitting the <Enter> key or double-clicking the mouse on a line has the same
 effect.  The file containing the error is opened in the window above the
 quickfix window.  If there already is a window for that file, it is used

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -76,18 +76,25 @@ struct qfline_S {
  */
 #define LISTCOUNT   10
 
+/// Quickfix/Location list definition
+///
+/// Usually the list contains one or more entries. But an empty list can be
+/// created using setqflist()/setloclist() with a title and/or user context
+/// information and entries can be added later using setqflist()/setloclist().
 typedef struct qf_list_S {
-  qfline_T    *qf_start;        // pointer to the first error
-  qfline_T    *qf_last;         // pointer to the last error
-  qfline_T    *qf_ptr;          // pointer to the current error
-  int qf_count;                 // number of errors (0 means no error list)
-  int qf_index;                 // current index in the error list
-  int qf_nonevalid;             // TRUE if not a single valid entry found
-  char_u      *qf_title;        // title derived from the command that created
-                                // the error list
-  typval_T    *qf_ctx;          // context set by setqflist/setloclist
+  qfline_T    *qf_start;        ///< pointer to the first error
+  qfline_T    *qf_last;         ///< pointer to the last error
+  qfline_T    *qf_ptr;          ///< pointer to the current error
+  int qf_count;                 ///< number of errors (0 means empty list)
+  int qf_index;                 ///< current index in the error list
+  int qf_nonevalid;             ///< TRUE if not a single valid entry found
+  char_u      *qf_title;        ///< title derived from the command that created
+                                ///< the error list or set by setqflist
+  typval_T    *qf_ctx;          ///< context set by setqflist/setloclist
 } qf_list_T;
 
+/// Quickfix/Location list stack definition
+/// Contains a list of quickfix/location lists (qf_list_T)
 struct qf_info_S {
   /*
    * Count of references to this list. Used only for location lists.
@@ -1185,6 +1192,9 @@ qf_init_end:
 
 static void qf_store_title(qf_info_T *qi, int qf_idx, char_u *title)
 {
+  xfree(qi->qf_lists[qf_idx].qf_title);
+  qi->qf_lists[qf_idx].qf_title = NULL;
+
   if (title != NULL) {
     size_t len = STRLEN(title) + 1;
     char_u *p = xmallocz(len);
@@ -2396,8 +2406,9 @@ void qf_history(exarg_T *eap)
   }
 }
 
-/// Free all the entries in the error list "idx".
-static void qf_free(qf_info_T *qi, int idx)
+/// Free all the entries in the error list "idx". Note that other information
+/// associated with the list like context and title are not freed.
+static void qf_free_items(qf_info_T *qi, int idx)
 {
   qfline_T    *qfp;
   qfline_T    *qfpnext;
@@ -2421,12 +2432,9 @@ static void qf_free(qf_info_T *qi, int idx)
     qi->qf_lists[idx].qf_start = qfpnext;
     qi->qf_lists[idx].qf_count--;
   }
-  xfree(qi->qf_lists[idx].qf_title);
+
   qi->qf_lists[idx].qf_start = NULL;
   qi->qf_lists[idx].qf_ptr = NULL;
-  qi->qf_lists[idx].qf_title = NULL;
-  tv_free(qi->qf_lists[idx].qf_ctx);
-  qi->qf_lists[idx].qf_ctx = NULL;
   qi->qf_lists[idx].qf_index = 0;
   qi->qf_lists[idx].qf_start = NULL;
   qi->qf_lists[idx].qf_last = NULL;
@@ -2440,6 +2448,18 @@ static void qf_free(qf_info_T *qi, int idx)
   qi->qf_multiline = false;
   qi->qf_multiignore = false;
   qi->qf_multiscan = false;
+}
+
+/// Free error list "idx". Frees all the entries in the quickfix list,
+/// associated context information and the title.
+static void qf_free(qf_info_T *qi, int idx)
+{
+  qf_free_items(qi, idx);
+
+  xfree(qi->qf_lists[idx].qf_title);
+  qi->qf_lists[idx].qf_title = NULL;
+  tv_free(qi->qf_lists[idx].qf_ctx);
+  qi->qf_lists[idx].qf_ctx = NULL;
 }
 
 /*
@@ -4150,6 +4170,10 @@ int get_errorlist_properties(win_T *wp, dict_T *what, dict_T *retdict)
     if (tv_dict_find(what, S_LEN("context")) != NULL) {
       flags |= QF_GETLIST_CONTEXT;
     }
+
+    if (tv_dict_find(what, S_LEN("items")) != NULL) {
+      flags |= QF_GETLIST_ITEMS;
+    }
   }
 
   if (flags & QF_GETLIST_TITLE) {
@@ -4167,6 +4191,11 @@ int get_errorlist_properties(win_T *wp, dict_T *what, dict_T *retdict)
     if (win != NULL) {
       status = tv_dict_add_nr(retdict, S_LEN("winid"), win->handle);
     }
+  }
+  if ((status == OK) && (flags & QF_GETLIST_ITEMS)) {
+    list_T *l = tv_list_alloc();
+    (void)get_errorlist(wp, qf_idx, l);
+    tv_dict_add_list(retdict, S_LEN("items"), l);
   }
 
   if ((status == OK) && (flags & QF_GETLIST_CONTEXT)) {
@@ -4204,7 +4233,7 @@ static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
     // Adding to existing list, use last entry.
     old_last = qi->qf_lists[qf_idx].qf_last;
   } else if (action == 'r') {
-    qf_free(qi, qf_idx);
+    qf_free_items(qi, qf_idx);
     qf_store_title(qi, qf_idx, title);
   }
 
@@ -4312,17 +4341,24 @@ static int qf_set_properties(qf_info_T *qi, dict_T *what, int action)
       if (di->di_tv.vval.v_number != 0) {
         qf_idx = (int)di->di_tv.vval.v_number - 1;
       }
-      if (qf_idx < 0 || qf_idx >= qi->qf_listcount) {
+
+      if ((action == ' ' || action == 'a') && qf_idx == qi->qf_listcount) {
+        // When creating a new list, accept qf_idx pointing to the next
+        // non-available list
+        newlist = true;
+      } else if (qf_idx < 0 || qf_idx >= qi->qf_listcount) {
         return FAIL;
+      } else {
+        newlist = false;  // use the specified list
       }
     } else if (di->di_tv.v_type == VAR_STRING
                && strequal((const char *)di->di_tv.vval.v_string, "$")
                && qi->qf_listcount > 0) {
       qf_idx = qi->qf_listcount - 1;
+      newlist = false;
     } else {
       return FAIL;
     }
-    newlist = false;  // use the specified list
   }
 
   if (newlist) {
@@ -4339,6 +4375,15 @@ static int qf_set_properties(qf_info_T *qi, dict_T *what, int action)
         qf_update_win_titlevar(qi);
       }
       retval = OK;
+    }
+  }
+  if ((di = tv_dict_find(what, S_LEN("items"))) != NULL) {
+    if (di->di_tv.v_type == VAR_LIST) {
+      char_u *title_save = vim_strsave(qi->qf_lists[qf_idx].qf_title);
+
+      retval = qf_add_entries(qi, qf_idx, di->di_tv.vval.v_list,
+                              title_save, action == ' ' ? 'a' : action);
+      xfree(title_save);
     }
   }
 

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1632,12 +1632,12 @@ func XbottomTests(cchar)
       call assert_fails('lbottom', 'E776:')
   endif
 
-  call g:Xsetlist([{'filename': 'foo', 'lnum': 42}]) 
+  call g:Xsetlist([{'filename': 'foo', 'lnum': 42}])
   Xopen
   let wid = win_getid()
   call assert_equal(1, line('.'))
   wincmd w
-  call g:Xsetlist([{'filename': 'var', 'lnum': 24}], 'a') 
+  call g:Xsetlist([{'filename': 'var', 'lnum': 24}], 'a')
   Xbottom
   call win_gotoid(wid)
   call assert_equal(2, line('.'))
@@ -2102,3 +2102,43 @@ func Test_bufoverflow()
   set efm&vim
 endfunc
 
+func Test_cclose_from_copen()
+    augroup QF_Test
+	au!
+	au FileType qf :cclose
+    augroup END
+    copen
+    augroup QF_Test
+	au!
+    augroup END
+    augroup! QF_Test
+endfunc
+
+" Tests for getting the quickfix stack size
+func XsizeTests(cchar)
+  call s:setup_commands(a:cchar)
+
+  call g:Xsetlist([], 'f')
+  call assert_equal(0, g:Xgetlist({'nr':'$'}).nr)
+  call assert_equal(1, len(g:Xgetlist({'nr':'$', 'all':1})))
+  call assert_equal(0, len(g:Xgetlist({'nr':0})))
+
+  Xexpr "File1:10:Line1"
+  Xexpr "File2:20:Line2"
+  Xexpr "File3:30:Line3"
+  Xolder | Xolder
+  call assert_equal(3, g:Xgetlist({'nr':'$'}).nr)
+  call g:Xsetlist([], 'f')
+
+  Xexpr "File1:10:Line1"
+  Xexpr "File2:20:Line2"
+  Xexpr "File3:30:Line3"
+  Xolder | Xolder
+  call g:Xsetlist([], 'a', {'nr':'$', 'title':'Compiler'})
+  call assert_equal('Compiler', g:Xgetlist({'nr':3, 'all':1}).title)
+endfunc
+
+func Test_Qf_Size()
+  call XsizeTests('c')
+  call XsizeTests('l')
+endfunc


### PR DESCRIPTION
#### vim-patch:8.0.0591: changes to eval functionality not documented

Problem:    Changes to eval functionality not documented.
Solution:   Include all the changes.

https://github.com/vim/vim/commit/45d2cca1ea3f90fc70ad99d0c6812a9d8536303c


#### vim-patch:8.0.0634: cannot easily get to the last quickfix list

Problem:    Cannot easily get to the last quickfix list.
Solution:   Add "$" as a value for the "nr" argument of getqflist() and
            setqflist(). (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/875feea6ce223462d55543735143d747dcaf4287


#### vim-patch:8.0.0641: cannot set a separate highlighting for the quickfix line

Problem:    Cannot set a separate highlighting for the current line in the
            quickfix window.
Solution:   Add QuickFixLine. (anishsane, closes vim/vim#1755)

https://github.com/vim/vim/commit/2102035488e80ef6fd5038ed15d21672712ba0f6


#### vim-patch:8.0.0657: cannot get and set quickfix list items

Problem:    Cannot get and set quickfix list items.
Solution:   Add the "items" argument to getqflist() and setqflist(). (Yegappan
            Lakshmanan)

https://github.com/vim/vim/commit/6a8958db259d4444da6e6956e54a6513c1af8860