### PR TITLE
[WIP] Refactor few functions from eval.c Issue: #5081

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -23,6 +23,7 @@
 # include <locale.h>
 #endif
 #include "nvim/eval.h"
+#include "nvim/eval/funcs.h"
 #include "nvim/buffer.h"
 #include "nvim/channel.h"
 #include "nvim/charset.h"
@@ -5931,62 +5932,6 @@ static int get_env_tv(char_u **arg, typval_T *rettv, int evaluate)
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "funcs.generated.h"
 #endif
-
-/*
- * Function given to ExpandGeneric() to obtain the list of internal
- * or user defined function names.
- */
-char_u *get_function_name(expand_T *xp, int idx)
-{
-  static int intidx = -1;
-  char_u      *name;
-
-  if (idx == 0)
-    intidx = -1;
-  if (intidx < 0) {
-    name = get_user_func_name(xp, idx);
-    if (name != NULL)
-      return name;
-  }
-  while ( (size_t)++intidx < ARRAY_SIZE(functions)
-         && functions[intidx].name[0] == '\0') {
-  }
-
-  if ((size_t)intidx >= ARRAY_SIZE(functions)) {
-    return NULL;
-  }
-
-  const char *const key = functions[intidx].name;
-  const size_t key_len = strlen(key);
-  memcpy(IObuff, key, key_len);
-  IObuff[key_len] = '(';
-  if (functions[intidx].max_argc == 0) {
-    IObuff[key_len + 1] = ')';
-    IObuff[key_len + 2] = NUL;
-  } else {
-    IObuff[key_len + 1] = NUL;
-  }
-  return IObuff;
-}
-
-/*
- * Function given to ExpandGeneric() to obtain the list of internal or
- * user defined variable or function names.
- */
-char_u *get_expr_name(expand_T *xp, int idx)
-{
-  static int intidx = -1;
-  char_u      *name;
-
-  if (idx == 0)
-    intidx = -1;
-  if (intidx < 0) {
-    name = get_function_name(xp, idx);
-    if (name != NULL)
-      return name;
-  }
-  return get_user_var_name(xp, ++intidx);
-}
 
 /// Find internal function in hash functions
 ///
@@ -20773,47 +20718,6 @@ static char *autoload_name(const char *const name, const size_t name_len)
   return scriptname;
 }
 
-
-/*
- * Function given to ExpandGeneric() to obtain the list of user defined
- * function names.
- */
-char_u *get_user_func_name(expand_T *xp, int idx)
-{
-  static size_t done;
-  static hashitem_T   *hi;
-  ufunc_T             *fp;
-
-  if (idx == 0) {
-    done = 0;
-    hi = func_hashtab.ht_array;
-  }
-  assert(hi);
-  if (done < func_hashtab.ht_used) {
-    if (done++ > 0)
-      ++hi;
-    while (HASHITEM_EMPTY(hi))
-      ++hi;
-    fp = HI2UF(hi);
-
-    if ((fp->uf_flags & FC_DICT)
-        || STRNCMP(fp->uf_name, "<lambda>", 8) == 0) {
-      return (char_u *)"";       // don't show dict and lambda functions
-    }
-
-    if (STRLEN(fp->uf_name) + 4 >= IOSIZE)
-      return fp->uf_name;       /* prevents overflow */
-
-    cat_func_name(IObuff, fp);
-    if (xp->xp_context != EXPAND_USER_FUNC) {
-      STRCAT(IObuff, "(");
-      if (!fp->uf_varargs && GA_EMPTY(&fp->uf_args))
-        STRCAT(IObuff, ")");
-    }
-    return IObuff;
-  }
-  return NULL;
-}
 
 
 /*

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1,0 +1,106 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+#include <stdio.h>
+#include <stddef.h>
+#include <nvim/eval.h>
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "funcs.generated.h"
+#endif
+/*
+ * Function given to ExpandGeneric() to obtain the list of internal
+ * or user defined function names.
+ */
+char_u *get_function_name(expand_T *xp, int idx)
+{
+  static int intidx = -1;
+  char_u      *name;
+
+  if (idx == 0)
+    intidx = -1;
+  if (intidx < 0) {
+    name = get_user_func_name(xp, idx);
+    if (name != NULL)
+      return name;
+  }
+  while ( (size_t)++intidx < ARRAY_SIZE(functions)
+         && functions[intidx].name[0] == '\0') {
+  }
+
+  if ((size_t)intidx >= ARRAY_SIZE(functions)) {
+    return NULL;
+  }
+
+  const char *const key = functions[intidx].name;
+  const size_t key_len = strlen(key);
+  memcpy(IObuff, key, key_len);
+  IObuff[key_len] = '(';
+  if (functions[intidx].max_argc == 0) {
+    IObuff[key_len + 1] = ')';
+    IObuff[key_len + 2] = NUL;
+  } else {
+    IObuff[key_len + 1] = NUL;
+  }
+  return IObuff;
+}
+
+/*
+ * Function given to ExpandGeneric() to obtain the list of internal
+ * or user defined function names.
+ */
+char_u *get_user_func_name(expand_T *xp, int idx)
+{
+  static size_t done;
+  static hashitem_T   *hi;
+  ufunc_T             *fp;
+
+  if (idx == 0) {
+    done = 0;
+    hi = func_hashtab.ht_array;
+  }
+  assert(hi);
+  if (done < func_hashtab.ht_used) {
+    if (done++ > 0)
+      ++hi;
+    while (HASHITEM_EMPTY(hi))
+      ++hi;
+    fp = HI2UF(hi);
+
+    if ((fp->uf_flags & FC_DICT)
+        || STRNCMP(fp->uf_name, "<lambda>", 8) == 0) {
+      return (char_u *)"";       // don't show dict and lambda functions
+    }
+
+    if (STRLEN(fp->uf_name) + 4 >= IOSIZE)
+      return fp->uf_name;       /* prevents overflow */
+
+    cat_func_name(IObuff, fp);
+    if (xp->xp_context != EXPAND_USER_FUNC) {
+      STRCAT(IObuff, "(");
+      if (!fp->uf_varargs && GA_EMPTY(&fp->uf_args))
+        STRCAT(IObuff, ")");
+    }
+    return IObuff;
+  }
+  return NULL;
+}
+
+/*
+ * Function given to ExpandGeneric() to obtain the list of internal or
+ * user defined variable or function names.
+ */
+char_u *get_expr_name(expand_T *xp, int idx)
+{
+  static int intidx = -1;
+  char_u      *name;
+
+  if (idx == 0)
+    intidx = -1;
+  if (intidx < 0) {
+    name = get_function_name(xp, idx);
+    if (name != NULL)
+      return name;
+  }
+  return get_user_var_name(xp, ++intidx);
+}

--- a/src/nvim/eval/funcs.h
+++ b/src/nvim/eval/funcs.h
@@ -1,0 +1,10 @@
+#ifndef NVIM_EVAL_FUNCS_H
+#define NVIM_EVAL_FUNCS_H
+
+
+char_u *get_function_name(expand_T *xp, int idx);
+
+char_u *get_expr_name(expand_T *xp, int idx);
+
+char_u *get_user_func_name(expand_T *xp, int idx);
+#endif

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -23,6 +23,7 @@
 #include "nvim/digraph.h"
 #include "nvim/edit.h"
 #include "nvim/eval.h"
+#include "nvim/eval/funcs.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_cmds2.h"
 #include "nvim/ex_docmd.h"


### PR DESCRIPTION
Tried to move functions `get_function_name()`, `get_user_func_name` and `get_expr_name()` from `eval.c` to `eval/func.c` as mentioned by @justinmk in #5081. However i get the following error while compiling.

```
CMakeFiles/nvim.dir/ex_getln.c.o:(.rodata+0x358): undefined reference to `get_function_name'
CMakeFiles/nvim.dir/ex_getln.c.o:(.rodata+0x370): undefined reference to `get_user_func_name'
CMakeFiles/nvim.dir/ex_getln.c.o:(.rodata+0x388): undefined reference to `get_expr_name'
```

Can someone help ?