### PR TITLE
tui: support TERM=konsole-256color

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -38,13 +38,13 @@ Otherwise Nvim cannot know what sequences your terminal expects, and weird
 or sub-optimal behavior will result (scrolling quirks, wrong colors, etc.).
 
 $TERM is also important because it is mirrored by SSH to the remote session,
-unlike other common client-end environment variables ($COLORTERM,
-$XTERM_VERSION, $VTE_VERSION, $KONSOLE_PROFILE_NAME, $TERM_PROGRAM, ...).
+unlike most other environment variables.
 
   For this terminal           Set $TERM to                  |builtin-terms|
   -------------------------------------------------------------------------
   iTerm (original)            iterm, iTerm.app                    N
   iTerm2 (new capabilities)   iterm2, iTerm2.app                  Y
+  Konsole                     konsole-256color                    N
   anything libvte-based       vte, vte-256color                   Y
    (e.g. GNOME Terminal)      (aliases: gnome, gnome-256color)
   tmux                        tmux, tmux-256color                 Y

--- a/src/nvim/tui/terminfo.c
+++ b/src/nvim/tui/terminfo.c
@@ -90,8 +90,8 @@ bool terminfo_is_term_family(const char *term, const char *family)
   size_t tlen = strlen(term);
   size_t flen = strlen(family);
   return tlen >= flen
-    && 0 == memcmp(term, family, flen) \
-    // Per the commentary in terminfo, minus sign is the suffix separator.
+    && 0 == memcmp(term, family, flen)
+    // Per commentary in terminfo, minus is the only valid suffix separator.
     && ('\0' == term[flen] || '-' == term[flen]);
 }
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -222,7 +222,8 @@ static void terminfo_start(UI *ui)
   const char *vte_version_env = os_getenv("VTE_VERSION");
   long vte_version = vte_version_env ? strtol(vte_version_env, NULL, 10) : 0;
   bool iterm_env = termprg && strstr(termprg, "iTerm.app");
-  bool konsole = os_getenv("KONSOLE_PROFILE_NAME")
+  bool konsole = terminfo_is_term_family(term, "konsole")
+    || os_getenv("KONSOLE_PROFILE_NAME")
     || os_getenv("KONSOLE_DBUS_SESSION");
 
   patch_terminfo_bugs(data, term, colorterm, vte_version, konsole, iterm_env);


### PR DESCRIPTION
TERM=konsole-256color is recognized by ncurses.

TERM=konsole-xterm might be more clever, but should not be necessary
(for Nvim at least), we already special-case Konsole in various places.
We may need to clean up some areas that currently assume Konsole always
"pretends xterm" (`TERM=xterm-256color`), though I didn't find any such
cases.

ref #6403
ref https://github.com/neovim/neovim/issues/6403#issuecomment-348713346