### PR TITLE
[RFC] Simplify Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,32 +59,32 @@ jobs:
         CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
     - stage: normal builds
       os: linux
-      compiler: gcc-5
+      compiler: gcc
       env: FUNCTIONALTEST=functionaltest-lua
     - os: linux
       # Travis creates a cache per compiler.
       # Set a different value here to store 32-bit
       # dependencies in a separate cache.
-      compiler: gcc-5 -m32
+      compiler: gcc -m32
       env: BUILD_32BIT=ON
     - os: osx
       compiler: clang
       osx_image: xcode7.3  # macOS 10.11
     - os: osx
-      compiler: gcc-4.9
+      compiler: gcc
       osx_image: xcode7.3  # macOS 10.11
     - stage: lint
       os: linux
       env: CI_TARGET=lint
     - stage: Flaky builds
       os: linux
-      compiler: gcc-5
-      env: GCOV=gcov-5 CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
+      compiler: gcc
+      env: GCOV=gcov CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
     - os: linux
       compiler: clang
       env: CLANG_SANITIZER=TSAN
   allow_failures:
-    - env: GCOV=gcov-5 CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
+    - env: GCOV=gcov CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
     - env: CLANG_SANITIZER=TSAN
   fast_finish: true
 
@@ -97,8 +97,6 @@ after_success:  ci/after_success.sh
 
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
       - autoconf
       - automake
@@ -107,9 +105,7 @@ addons:
       - clang
       - cmake
       - cscope
-      - g++-5-multilib
       - g++-multilib
-      - gcc-5-multilib
       - gcc-multilib
       - gdb
       - language-pack-tr

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,13 @@ env:
 
 jobs:
   include:
-    - stage: sanitizers
+    - stage: normal builds
       os: linux
       compiler: clang
       env: >
         CLANG_SANITIZER=ASAN_UBSAN
         CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
-    - stage: normal builds
-      os: linux
+    - os: linux
       compiler: gcc
       env: FUNCTIONALTEST=functionaltest-lua
     - os: linux
@@ -73,8 +72,7 @@ jobs:
     - os: osx
       compiler: gcc
       osx_image: xcode7.3  # macOS 10.11
-    - stage: lint
-      os: linux
+    - os: linux
       env: CI_TARGET=lint
     - stage: Flaky builds
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     # http://docs.travis-ci.com/user/speeding-up-the-build/#Paralellizing-your-build-on-one-VM
     - MAKE_CMD="make -j2"
     # Update PATH for pip.
-    - PATH="$(python2.7 -c 'import site; print(site.getuserbase())')/bin:/usr/lib/llvm-symbolizer-4.0/bin:$PATH"
+    - PATH="$(python2.7 -c 'import site; print(site.getuserbase())')/bin:$PATH"
     # Build directory for Neovim.
     - BUILD_DIR="$TRAVIS_BUILD_DIR/build"
     # Build directory for third-party dependencies.
@@ -53,7 +53,7 @@ jobs:
   include:
     - stage: sanitizers
       os: linux
-      compiler: clang-4.0
+      compiler: clang
       env: >
         CLANG_SANITIZER=ASAN_UBSAN
         CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
@@ -81,7 +81,7 @@ jobs:
       compiler: gcc-5
       env: GCOV=gcov-5 CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
     - os: linux
-      compiler: clang-4.0
+      compiler: clang
       env: CLANG_SANITIZER=TSAN
   allow_failures:
     - env: GCOV=gcov-5 CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
@@ -99,13 +99,12 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-4.0
     packages:
       - autoconf
       - automake
       - apport
       - build-essential
-      - clang-4.0
+      - clang
       - cmake
       - cscope
       - g++-5-multilib
@@ -116,7 +115,6 @@ addons:
       - language-pack-tr
       - libc6-dev-i386
       - libtool
-      - llvm-4.0-dev
       - locales
       - pkg-config
       - unzip

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -71,7 +71,7 @@ valgrind_check() {
 }
 
 asan_check() {
-  check_logs "${1}" "*san.*"
+  check_logs "${1}" "*san.*" | asan_symbolize
 }
 
 run_unittests() {(

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -71,7 +71,9 @@ valgrind_check() {
 }
 
 asan_check() {
-  check_logs "${1}" "*san.*" | asan_symbolize
+  if test "${CLANG_SANITIZER}" = "ASAN_UBSAN" ; then
+    check_logs "${1}" "*san.*" | asan_symbolize
+  fi
 }
 
 run_unittests() {(


### PR DESCRIPTION
* Remove both extra apt sources
* Use unversioned gcc/gcov/clang commands
* Avoid mangling $PATH for ASAN symbolizing
* Reduce build stages to just flaky/non-flaky