### PR TITLE
[RFC] vim-patch:8.0.0160

### DIFF
--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1369,7 +1369,7 @@ static char *cs_manage_matches(char **matches, char **contexts,
   case Print:
     cs_print_tags_priv(mp, cp, cnt);
     break;
-  default:      /* should not reach here */
+  default:      // should not reach here
     IEMSG(_("E570: fatal error in cs_manage_matches"));
     return NULL;
   }

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1370,7 +1370,7 @@ static char *cs_manage_matches(char **matches, char **contexts,
     cs_print_tags_priv(mp, cp, cnt);
     break;
   default:      /* should not reach here */
-    (void)EMSG(_("E570: fatal error in cs_manage_matches"));
+    IEMSG(_("E570: fatal error in cs_manage_matches"));
     return NULL;
   }
 

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -4413,7 +4413,7 @@ static int check_char_class(int class, int c)
     break;
 
   default:
-    /* should not be here :P */
+    // should not be here :P
     IEMSGN(_(e_ill_char_class), class);
     return FAIL;
   }
@@ -5992,8 +5992,9 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
         int c = t->state->c;
 
 #ifdef REGEXP_DEBUG
-        if (c < 0)
+        if (c < 0) {
           IEMSGN("INTERNAL: Negative state char: %" PRId64, c);
+        }
 #endif
         result = (c == curc);
 
@@ -6462,12 +6463,13 @@ static regprog_T *nfa_regcomp(char_u *expr, int re_flags)
    * (and count its size). */
   postfix = re2post();
   if (postfix == NULL) {
-    /* TODO: only give this error for debugging? */
-    if (post_ptr >= post_end)
+    // TODO(vim): only give this error for debugging?
+    if (post_ptr >= post_end) {
       IEMSGN("Internal error: estimated max number "
              "of states insufficient: %" PRId64,
              post_end - post_start);
-    goto fail;              /* Cascaded (syntax?) error */
+    }
+    goto fail;              // Cascaded (syntax?) error
   }
 
   /*

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1263,7 +1263,7 @@ static int nfa_regatom(void)
         rc_did_emsg = TRUE;
         return FAIL;
       }
-      EMSGN("INTERNAL: Unknown character class char: %" PRId64, c);
+      IEMSGN("INTERNAL: Unknown character class char: %" PRId64, c);
       return FAIL;
     }
     /* When '.' is followed by a composing char ignore the dot, so that
@@ -4414,7 +4414,7 @@ static int check_char_class(int class, int c)
 
   default:
     /* should not be here :P */
-    EMSGN(_(e_ill_char_class), class);
+    IEMSGN(_(e_ill_char_class), class);
     return FAIL;
   }
   return FAIL;
@@ -5993,7 +5993,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
 
 #ifdef REGEXP_DEBUG
         if (c < 0)
-          EMSGN("INTERNAL: Negative state char: %" PRId64, c);
+          IEMSGN("INTERNAL: Negative state char: %" PRId64, c);
 #endif
         result = (c == curc);
 
@@ -6464,9 +6464,9 @@ static regprog_T *nfa_regcomp(char_u *expr, int re_flags)
   if (postfix == NULL) {
     /* TODO: only give this error for debugging? */
     if (post_ptr >= post_end)
-      EMSGN("Internal error: estimated max number "
-            "of states insufficient: %" PRId64,
-            post_end - post_start);
+      IEMSGN("Internal error: estimated max number "
+             "of states insufficient: %" PRId64,
+             post_end - post_start);
     goto fail;              /* Cascaded (syntax?) error */
   }
 


### PR DESCRIPTION
#### vim-patch:8.0.0160: EMSG() is sometimes used where it should be IEMSG()

Problem:    EMSG() is sometimes used for internal errors.
Solution:   Change them to IEMSG(). (Dominique Pelle)  And a few more.

https://github.com/vim/vim/commit/de33011ec623fd562419dede6bf465b5b9881a20