### PR TITLE
[RFC] Remove some clang scan-build complaints from eval.c

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2900,6 +2900,7 @@ static int do_unlet_var(lval_T *const lp, char_u *const name_end, int forceit)
                                   lp->ll_name_len))) {
     return FAIL;
   } else if (lp->ll_range) {
+    assert(lp->ll_list != NULL);
     // Delete a range of List items.
     listitem_T *const first_li = lp->ll_li;
     listitem_T *last_li = first_li;
@@ -2926,6 +2927,7 @@ static int do_unlet_var(lval_T *const lp, char_u *const name_end, int forceit)
     } else {
       // unlet a Dictionary item.
       dict_T *d = lp->ll_dict;
+      assert(d != NULL);
       dictitem_T *di = lp->ll_di;
       bool watched = tv_dict_is_watched(d);
       char *key = NULL;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21254,15 +21254,17 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars,
     }
   }
 
+  const bool do_profiling_yes = do_profiling == PROF_YES;
+
   bool func_not_yet_profiling_but_should =
-    do_profiling == PROF_YES
+    do_profiling_yes
     && !fp->uf_profiling && has_profiling(FALSE, fp->uf_name, NULL);
 
   if (func_not_yet_profiling_but_should)
     func_do_profile(fp);
 
   bool func_or_func_caller_profiling =
-    do_profiling == PROF_YES
+    do_profiling_yes
     && (fp->uf_profiling
         || (fc->caller != NULL && fc->caller->func->uf_profiling));
 
@@ -21272,7 +21274,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars,
     fp->uf_tm_children = profile_zero();
   }
 
-  if (do_profiling == PROF_YES) {
+  if (do_profiling_yes) {
     script_prof_save(&wait_start);
   }
 
@@ -21348,7 +21350,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars,
   sourcing_name = save_sourcing_name;
   sourcing_lnum = save_sourcing_lnum;
   current_SID = save_current_SID;
-  if (do_profiling == PROF_YES)
+  if (do_profiling_yes)
     script_prof_restore(&wait_start);
 
   if (p_verbose >= 12 && sourcing_name != NULL) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2417,6 +2417,7 @@ static void set_var_lval(lval_T *lp, char_u *endp, typval_T *rettv,
       if (ri == NULL || (!lp->ll_empty2 && lp->ll_n2 == lp->ll_n1)) {
         break;
       }
+      assert(lp->ll_li != NULL);
       if (TV_LIST_ITEM_NEXT(lp->ll_list, lp->ll_li) == NULL) {
         // Need to add an empty item.
         tv_list_append_number(lp->ll_list, 0);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2480,9 +2480,11 @@ static void set_var_lval(lval_T *lp, char_u *endp, typval_T *rettv,
 notify:
     if (watched) {
       if (oldtv.v_type == VAR_UNKNOWN) {
+        assert(lp->ll_newkey != NULL);
         tv_dict_watcher_notify(dict, (char *)lp->ll_newkey, lp->ll_tv, NULL);
       } else {
         dictitem_T *di = lp->ll_di;
+        assert(di->di_key != NULL);
         tv_dict_watcher_notify(dict, (char *)di->di_key, lp->ll_tv, &oldtv);
         tv_clear(&oldtv);
       }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19016,6 +19016,9 @@ static void set_var(const char *name, const size_t name_len, typval_T *const tv,
       return;
     }
 
+    // Make sure dict is valid
+    assert(dict != NULL);
+
     v = xmalloc(sizeof(dictitem_T) + strlen(varname));
     STRCPY(v->di_key, varname);
     if (tv_dict_add(dict, v) == FAIL) {

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2153,7 +2153,7 @@ void tv_free(typval_T *tv)
 ///
 /// @param[in]  from  Location to copy from.
 /// @param[out]  to  Location to copy to.
-void tv_copy(typval_T *const from, typval_T *const to)
+void tv_copy(const typval_T *const from, typval_T *const to)
 {
   to->v_type = from->v_type;
   to->v_lock = VAR_UNLOCKED;


### PR DESCRIPTION
I believe this addresses 6 "bugs" identified by the clang static analyzer. Some of them are just clang being dumb, but I refactored the code to help clang be less dumb. Other fixes are for code that makes assumptions about a data structure, i.e. that `lval_T` has either `dict` or `list` fields (but not both) `NULL`.

I doubt there are any active bugs that these changes address; rather, it should make it more difficult for changes elsewhere in the codebase to result in null pointer dereferences, etc. I'm not sure what your philosophy is for changes like this- it will probably make it a bigger pain to merge in vim patches.