### PR TITLE
Update jemalloc to latest commit available in dev branch

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -117,8 +117,8 @@ endif()
 set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/a9c7c6fd20fa35e0ad3e0e98901ca12dfca9c25c.tar.gz)
 set(LIBVTERM_SHA256 1a4272be91d9614dc183a503786df83b6584e4afaab7feaaa5409f841afbd796)
 
-set(JEMALLOC_URL https://github.com/jemalloc/jemalloc/releases/download/5.0.1/jemalloc-5.0.1.tar.bz2)
-set(JEMALLOC_SHA256 4814781d395b0ef093b21a08e8e6e0bd3dab8762f9935bbfb71679b0dea7c3e9)
+set(JEMALLOC_URL https://github.com/jemalloc/jemalloc/archive/d41b19f9c70c9dd8244e0879c7aef7943a34c750.tar.gz)
+set(JEMALLOC_SHA256 7e9d67a35f1a217cda83b065c6425073d443fad908731aaf90498d0a5fe13d9e)
 
 set(LUV_URL https://github.com/luvit/luv/archive/1.9.1-1.tar.gz)
 set(LUV_SHA256 562b9efaad30aa051a40eac9ade0c3df48bb8186763769abe47ec3fb3edb1268)

--- a/third-party/cmake/BuildJeMalloc.cmake
+++ b/third-party/cmake/BuildJeMalloc.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(jemalloc
     -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
   BUILD_IN_SOURCE 1
-  CONFIGURE_COMMAND ${DEPS_BUILD_DIR}/src/jemalloc/configure
+  CONFIGURE_COMMAND sh ${DEPS_BUILD_DIR}/src/jemalloc/autogen.sh && ${DEPS_BUILD_DIR}/src/jemalloc/configure
      CC=${DEPS_C_COMPILER} --prefix=${DEPS_INSTALL_DIR}
   BUILD_COMMAND ""
   INSTALL_COMMAND ${MAKE_PRG} install_include install_lib_static)


### PR DESCRIPTION
As requested https://github.com/neovim/neovim/pull/7746#issuecomment-355076992 because `jemalloc 5.0.1`:
> broke[s] the Ubuntu Unstable PPA builds on arm64

Please be indulgent if it's not working ;)