### PR TITLE
defaults: do :filetype stuff unless explicitly "off"

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -24,10 +24,8 @@ Each time a new or existing file is edited, Vim will try to recognize the type
 of the file and set the 'filetype' option.  This will trigger the FileType
 event, which can be used to set the syntax highlighting, set options, etc.
 
-Detail: The ":filetype on" command will load one of these files:
-		Mac	    $VIMRUNTIME/filetype.vim
-		MS-DOS	    $VIMRUNTIME\filetype.vim
-		Unix	    $VIMRUNTIME/filetype.vim
+Detail: The ":filetype on" command will load this file:
+		$VIMRUNTIME/filetype.vim
 	This file is a Vim script that defines autocommands for the
 	BufNewFile and BufRead events.  If the file type is not found by the
 	name, the file $VIMRUNTIME/scripts.vim is used to detect it from the

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -439,15 +439,14 @@ accordingly.  Vim proceeds in this order:
 		:runtime! filetype.vim
 		:runtime! ftplugin.vim
 		:runtime! indent.vim
-<	This step is skipped if ":filetype ..." was called before now or if
-	the "-u NONE" command line argument was given.
+<	Skipped if ":filetype … off" was called or if the "-u NONE" command
+	line argument was given.
 
 5. Enable syntax highlighting.
 	This does the same as the command: >
 		:runtime! syntax/syntax.vim
-<	Note: This enables filetype detection even if ":filetype off" was
-	called before now.
-	This step is skipped if the "-u NONE" command line argument was given.
+<	Skipped if ":syntax off" was called or if the "-u NONE" command
+	line argument was given.
 
 6. Load the plugin scripts.					*load-plugins*
 	This does the same as the command: >

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9718,17 +9718,18 @@ static void ex_filetype(exarg_T *eap)
     EMSG2(_(e_invarg2), arg);
 }
 
-/// Do ":filetype plugin indent on" if user did not already do some
-/// permutation thereof.
+/// Set all :filetype options ON if user did not explicitly set any to OFF.
 void filetype_maybe_enable(void)
 {
-  if (filetype_detect == kNone
-      && filetype_plugin == kNone
-      && filetype_indent == kNone) {
+  if (filetype_detect == kNone) {
     source_runtime((char_u *)FILETYPE_FILE, true);
     filetype_detect = kTrue;
+  }
+  if (filetype_plugin == kNone) {
     source_runtime((char_u *)FTPLUGIN_FILE, true);
     filetype_plugin = kTrue;
+  }
+  if (filetype_indent == kNone) {
     source_runtime((char_u *)INDENT_FILE, true);
     filetype_indent = kTrue;
   }

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -11,15 +11,6 @@ local neq = helpers.neq
 local mkdir = helpers.mkdir
 local rmdir = helpers.rmdir
 
-local function init_session(...)
-  local args = { helpers.nvim_prog, '-i', 'NONE', '--embed',
-                 '--cmd', helpers.nvim_set }
-  for _, v in ipairs({...}) do
-    table.insert(args, v)
-  end
-  helpers.set_session(helpers.spawn(args))
-end
-
 describe('startup defaults', function()
   describe(':filetype', function()
     if helpers.pending_win32(pending) then return end
@@ -36,50 +27,70 @@ describe('startup defaults', function()
       )
     end
 
-    it('enabled by `-u NORC`', function()
-      init_session('-u', 'NORC')
+    it('all ON after `-u NORC`', function()
+      clear('-u', 'NORC')
       expect_filetype(
         'filetype detection:ON  plugin:ON  indent:ON       |')
     end)
 
-    it('disabled by `-u NONE`', function()
-      init_session('-u', 'NONE')
+    it('all ON after `:syntax …` #7765', function()
+      clear('-u', 'NORC', '--cmd', 'syntax on')
+      expect_filetype(
+        'filetype detection:ON  plugin:ON  indent:ON       |')
+      clear('-u', 'NORC', '--cmd', 'syntax off')
+      expect_filetype(
+        'filetype detection:ON  plugin:ON  indent:ON       |')
+    end)
+
+    it('all OFF after `-u NONE`', function()
+      clear('-u', 'NONE')
       expect_filetype(
         'filetype detection:OFF  plugin:OFF  indent:OFF    |')
     end)
 
-    it('overridden by early `filetype on`', function()
-      init_session('-u', 'NORC', '--cmd', 'filetype on')
+    it('explicit OFF stays OFF', function()
+      clear('-u', 'NORC', '--cmd',
+            'syntax off | filetype off | filetype plugin indent off')
+      expect_filetype(
+        'filetype detection:OFF  plugin:OFF  indent:OFF    |')
+      clear('-u', 'NORC', '--cmd', 'syntax off | filetype plugin indent off')
       expect_filetype(
         'filetype detection:ON  plugin:OFF  indent:OFF     |')
-    end)
-
-    it('overridden by early `filetype plugin on`', function()
-      init_session('-u', 'NORC', '--cmd', 'filetype plugin on')
+      clear('-u', 'NORC', '--cmd', 'filetype indent off')
       expect_filetype(
         'filetype detection:ON  plugin:ON  indent:OFF      |')
-    end)
-
-    it('overridden by early `filetype indent on`', function()
-      init_session('-u', 'NORC', '--cmd', 'filetype indent on')
+      clear('-u', 'NORC', '--cmd', 'syntax off | filetype off')
       expect_filetype(
-        'filetype detection:ON  plugin:OFF  indent:ON      |')
-    end)
-
-    it('adjusted by late `filetype off`', function()
-      init_session('-u', 'NORC', '-c', 'filetype off')
+        'filetype detection:OFF  plugin:(on)  indent:(on)  |')
+      -- Swap the order.
+      clear('-u', 'NORC', '--cmd', 'filetype off | syntax off')
       expect_filetype(
         'filetype detection:OFF  plugin:(on)  indent:(on)  |')
     end)
 
-    it('adjusted by late `filetype plugin off`', function()
-      init_session('-u', 'NORC', '-c', 'filetype plugin off')
+    it('all ON after early `:filetype … on`', function()
+      -- `:filetype … on` should not change the defaults. #7765
+      -- Only an explicit `:filetype … off` sets OFF.
+
+      clear('-u', 'NORC', '--cmd', 'filetype on')
       expect_filetype(
-        'filetype detection:ON  plugin:OFF  indent:ON      |')
+        'filetype detection:ON  plugin:ON  indent:ON       |')
+      clear('-u', 'NORC', '--cmd', 'filetype plugin on')
+      expect_filetype(
+        'filetype detection:ON  plugin:ON  indent:ON       |')
+      clear('-u', 'NORC', '--cmd', 'filetype indent on')
+      expect_filetype(
+        'filetype detection:ON  plugin:ON  indent:ON       |')
     end)
 
-    it('adjusted by late `filetype indent off`', function()
-      init_session('-u', 'NORC', '-c', 'filetype indent off')
+    it('late `:filetype … off` stays OFF', function()
+      clear('-u', 'NORC', '-c', 'filetype off')
+      expect_filetype(
+        'filetype detection:OFF  plugin:(on)  indent:(on)  |')
+      clear('-u', 'NORC', '-c', 'filetype plugin off')
+      expect_filetype(
+        'filetype detection:ON  plugin:OFF  indent:ON      |')
+      clear('-u', 'NORC', '-c', 'filetype indent off')
       expect_filetype(
         'filetype detection:ON  plugin:ON  indent:OFF      |')
     end)
@@ -87,22 +98,21 @@ describe('startup defaults', function()
 
   describe('syntax', function()
     it('enabled by `-u NORC`', function()
-      init_session('-u', 'NORC')
+      clear('-u', 'NORC')
       eq(1, eval('g:syntax_on'))
     end)
 
     it('disabled by `-u NONE`', function()
-      init_session('-u', 'NONE')
+      clear('-u', 'NONE')
       eq(0, eval('exists("g:syntax_on")'))
     end)
 
-    it('overridden by early `syntax off`', function()
-      init_session('-u', 'NORC', '--cmd', 'syntax off')
+    it('`:syntax off` stays off', function()
+      -- early
+      clear('-u', 'NORC', '--cmd', 'syntax off')
       eq(0, eval('exists("g:syntax_on")'))
-    end)
-
-    it('adjusted by late `syntax off`', function()
-      init_session('-u', 'NORC', '-c', 'syntax off')
+      -- late
+      clear('-u', 'NORC', '-c', 'syntax off')
       eq(0, eval('exists("g:syntax_on")'))
     end)
   end)


### PR DESCRIPTION
Until now, the default `:filetype ...` setup was skipped if the user config touched `:filetype` in any way (including implicitly via `:syntax on`).  No one needs that, and it's very confusing.  Instead, proceed with `:filetype ... on` unless the user explicitly called `:filetype ... off`.

closes #7765 
  