### PR TITLE
tests: stderr output contains `cp` noise

### DIFF
--- a/test/functional/shada/helpers.lua
+++ b/test/functional/shada/helpers.lua
@@ -37,7 +37,6 @@ local function add_argv(...)
 end
 
 local clear = function()
-  os.execute('cp ' .. tmpname .. ' /tmp/test.shada')
   os.remove(tmpname)
   append_argv = nil
 end


### PR DESCRIPTION
closes #7811