### PR TITLE
ci: osx: switch default ruby to fix failing builds

### DIFF
--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -39,9 +39,8 @@ else
 fi
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
-  echo "Update default Ruby"
-  brew install ruby
-  brew switch ruby
+  echo "Upgrade Ruby"
+  brew upgrade ruby
 fi
 
 if [[ "${TRAVIS_OS_NAME}" == linux ]]; then

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -38,6 +38,11 @@ else
   pip3 -q install --user --upgrade pip || true
 fi
 
+if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+  echo "Update default Ruby"
+  brew switch ruby 2.2.5
+fi
+
 if [[ "${TRAVIS_OS_NAME}" == linux ]]; then
   echo "Install node (LTS)"
 

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -41,6 +41,7 @@ fi
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   echo "Upgrade Ruby"
   brew install ruby
+  brew link --overwrite ruby
 fi
 
 if [[ "${TRAVIS_OS_NAME}" == linux ]]; then

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -43,6 +43,8 @@ if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   brew install rbenv
   rbenv init
   rbenv install 2.4.2-p198
+  rbenv rehash
+  rbenv global 2.4.2-p198
 fi
 
 if [[ "${TRAVIS_OS_NAME}" == linux ]]; then

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -40,7 +40,7 @@ fi
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   echo "Upgrade Ruby"
-  brew upgrade ruby
+  brew install ruby
 fi
 
 if [[ "${TRAVIS_OS_NAME}" == linux ]]; then

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -40,7 +40,8 @@ fi
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   echo "Update default Ruby"
-  brew switch ruby 2.2.5
+  brew install ruby
+  brew switch ruby
 fi
 
 if [[ "${TRAVIS_OS_NAME}" == linux ]]; then

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -40,8 +40,9 @@ fi
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   echo "Upgrade Ruby"
-  brew install ruby
-  brew link --overwrite ruby
+  brew install rbenv
+  rbenv init
+  rbenv install 2.4.2-p198
 fi
 
 if [[ "${TRAVIS_OS_NAME}" == linux ]]; then


### PR DESCRIPTION
Travis builds on OSX are failing because of neovim-ruby gem dependencies.
Switch default ruby to a newer version to make the builds pass.