### PR TITLE
ci/travis: macOS: switch ruby version

### DIFF
--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -25,6 +25,8 @@ if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   # That allows to test changing the group of the file by `os_fchown`.
   sudo dscl . -create /Groups/chown_test
   sudo dscl . -append /Groups/chown_test GroupMembership "${USER}"
+
+  macos_rvm_dance
 fi
 
 # Compile dependencies.

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -25,8 +25,6 @@ if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   # That allows to test changing the group of the file by `os_fchown`.
   sudo dscl . -create /Groups/chown_test
   sudo dscl . -append /Groups/chown_test GroupMembership "${USER}"
-
-  macos_rvm_dance
 fi
 
 # Compile dependencies.

--- a/ci/common/build.sh
+++ b/ci/common/build.sh
@@ -87,3 +87,12 @@ build_nvim() {
 
   cd "${TRAVIS_BUILD_DIR}"
 }
+
+macos_rvm_dance() {
+  # neovim-ruby gem requires a ruby newer than the macOS default.
+  source ~/.rvm/scripts/rvm
+  rvm get stable --auto-dotfiles
+  rvm reload
+  rvm use 2.2.5
+  rvm use
+}

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -21,12 +21,10 @@ echo "Install neovim module for Python 3."
 # https://github.com/travis-ci/travis-ci/issues/8363
 CC=cc pip3 -q install --user --upgrade neovim || true
 
-echo "Install neovim RubyGem."
-if [ "${TRAVIS_OS_NAME}" = osx ] ; then
-  macos_rvm_dance
-  gem update --system
+if ! [ "${TRAVIS_OS_NAME}" = osx ] ; then
+  echo "Install neovim RubyGem."
+  gem install --no-document --version ">= 0.2.0" neovim
 fi
-gem install --no-document --version ">= 0.2.0" neovim
 
 if [[ "${TRAVIS_OS_NAME}" == linux ]]; then
   echo "Install neovim npm package"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -22,6 +22,10 @@ echo "Install neovim module for Python 3."
 CC=cc pip3 -q install --user --upgrade neovim || true
 
 echo "Install neovim RubyGem."
+if [ "${TRAVIS_OS_NAME}" = osx ] ; then
+  macos_rvm_dance
+  gem update --system
+fi
 gem install --no-document --version ">= 0.2.0" neovim
 
 if [[ "${TRAVIS_OS_NAME}" == linux ]]; then


### PR DESCRIPTION
Travis macOS builds are failing because of neovim-ruby gem dependencies.
Switch default ruby to a newer version to make the builds pass.
