### PR TITLE
test: fnamemodify()

### DIFF
--- a/test/functional/eval/fnamemodify_spec.lua
+++ b/test/functional/eval/fnamemodify_spec.lua
@@ -1,0 +1,21 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local eq = helpers.eq
+local iswin = helpers.iswin
+local fnamemodify = helpers.funcs.fnamemodify
+
+describe('fnamemodify()', function()
+  before_each(clear)
+
+  it('works', function()
+    if iswin() then
+      eq([[C:\]], fnamemodify([[\]], ':p:h'))
+      eq([[C:\]], fnamemodify([[\]], ':p'))
+      eq([[C:/]], fnamemodify([[/]], ':p:h'))
+      eq([[C:/]], fnamemodify([[/]], ':p'))
+    else
+      eq('/', fnamemodify([[/]], ':p:h'))
+      eq('/', fnamemodify([[/]], ':p'))
+    end
+  end)
+end)


### PR DESCRIPTION
```
[  FAILED  ] ...rojects/neovim/test/functional\eval\fnamemodify_spec.lua @ 10: fnamemodify() works
...rojects/neovim/test/functional\eval\fnamemodify_spec.lua:14: Expected objects to be the same.
Passed in:
(string) 'C:\projects\neovim'
Expected:
(string) 'C:/'
stack traceback:
	...rojects/neovim/test/functional\eval\fnamemodify_spec.lua:14: in function <...rojects/neovim/test/functional\eval\fnamemodify_spec.lua:10>
```  