### PR TITLE
session: restore same :terminal buf split windows

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -173,6 +173,9 @@ if (-not $NoTests) {
   # Functional tests
   # The $LastExitCode from MSBuild can't be trusted
   $failed = $false
+
+  # Run only this test file:
+  # $env:TEST_FILE = "test\functional\foo.lua"
   cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs 2>&1 |
     foreach { $failed = $failed -or
       $_ -match 'functional tests failed with error'; $_ }

--- a/runtime/doc/usr_21.txt
+++ b/runtime/doc/usr_21.txt
@@ -339,21 +339,6 @@ window, move the cursor to the filename and press "O".  Double clicking with
 the mouse will also do this.
 
 
-UNIX AND MS-WINDOWS
-
-Some people have to do work on MS-Windows systems one day and on Unix another
-day.  If you are one of them, consider adding "slash" and "unix" to
-'sessionoptions'.  The session files will then be written in a format that can
-be used on both systems.  This is the command to put in your |init.vim| file:
->
-	:set sessionoptions+=unix,slash
-
-Vim will use the Unix format then, because the MS-Windows Vim can read and
-write Unix files, but Unix Vim can't read MS-Windows format session files.
-Similarly, MS-Windows Vim understands file names with / to separate names, but
-Unix Vim doesn't understand \.
-
-
 SESSIONS AND SHADA
 
 Sessions store many things, but not the position of marks, contents of

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9210,7 +9210,7 @@ static int makeopens(FILE *fd, char_u *dirnow)
   // temporarily to avoid that.
   if (p_stal == 1 && first_tabpage->tp_next != NULL) {
     PUTLINE_FAIL("set stal=2");
-    restore_stal = TRUE;
+    restore_stal = true;
   }
 
   //
@@ -9482,18 +9482,18 @@ static int ses_win_rec(FILE *fd, frame_T *fr)
         // to split.
         if (fprintf(fd, "%s%s",
                     "wincmd _ | wincmd |\n",
-                    (fr->fr_layout == FR_COL ? "split\n" : "vsplit\n")
-                    ) < 0) {
+                    (fr->fr_layout == FR_COL ? "split\n" : "vsplit\n")) < 0) {
           return FAIL;
         }
-        ++count;
+        count++;
       }
 
     // Go back to the first window.
     if (count > 0 && (fprintf(fd, fr->fr_layout == FR_COL
-                          ? "%dwincmd k" : "%dwincmd h", count) < 0
-                      || put_eol(fd) == FAIL))
+                              ? "%dwincmd k" : "%dwincmd h", count) < 0
+                      || put_eol(fd) == FAIL)) {
       return FAIL;
+    }
 
     // Recursively create frames/windows in each window of this column or row.
     frc = ses_skipframe(fr->fr_child);
@@ -9501,8 +9501,9 @@ static int ses_win_rec(FILE *fd, frame_T *fr)
       ses_win_rec(fd, frc);
       frc = ses_skipframe(frc->fr_next);
       // Go to next window.
-      if (frc != NULL && put_line(fd, "wincmd w") == FAIL)
+      if (frc != NULL && put_line(fd, "wincmd w") == FAIL) {
         return FAIL;
+      }
     }
   }
   return OK;
@@ -9694,9 +9695,9 @@ put_view(
   if (f == FAIL)
     return FAIL;
 
-  /*
-   * Save Folds when 'buftype' is empty and for help files.
-   */
+  //
+  // Save Folds when 'buftype' is empty and for help files.
+  //
   if ((*flagp & SSOP_FOLDS)
       && wp->w_buffer->b_ffname != NULL
       && (bt_normal(wp->w_buffer) || bt_help(wp->w_buffer))
@@ -9705,11 +9706,10 @@ put_view(
       return FAIL;
   }
 
-  /*
-   * Set the cursor after creating folds, since that moves the cursor.
-   */
+  //
+  // Set the cursor after creating folds, since that moves the cursor.
+  //
   if (do_cursor) {
-
     // Restore the cursor line in the file and relatively in the
     // window.  Don't use "G", it changes the jumplist.
     if (fprintf(fd,
@@ -9718,14 +9718,12 @@ put_view(
                 "if s:l < 1 | let s:l = 1 | endif\n"
                 "exe s:l\n"
                 "normal! zt\n"
-                "%" PRId64 "\n"
-                 ,
+                "%" PRId64 "\n",
                 (int64_t)wp->w_cursor.lnum,
                 (int64_t)(wp->w_cursor.lnum - wp->w_topline),
                 (int64_t)(wp->w_height_inner / 2),
                 (int64_t)wp->w_height_inner,
-                (int64_t)wp->w_cursor.lnum
-                ) < 0) {
+                (int64_t)wp->w_cursor.lnum) < 0) {
       return FAIL;
     }
     // Restore the cursor column and left offset when not wrapping.
@@ -9791,8 +9789,8 @@ static int ses_arglist(FILE *fd, char *cmd, garray_T *gap, int fullname,
     return FAIL;
   }
   PUTLINE_FAIL("%argdel");
-  for (int i = 0; i < gap->ga_len; ++i) {
-    /* NULL file names are skipped (only happens when out of memory). */
+  for (int i = 0; i < gap->ga_len; i++) {
+    // NULL file names are skipped (only happens when out of memory).
     s = alist_name(&((aentry_T *)gap->ga_data)[i]);
     if (s != NULL) {
       if (fullname) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8085,11 +8085,6 @@ static void close_redir(void)
   }
 }
 
-#ifdef USE_CRNL
-# define MKSESSION_NL
-static int mksession_nl = FALSE;    /* use NL only in put_eol() */
-#endif
-
 /// ":mkexrc", ":mkvimrc", ":mkview", ":mksession".
 static void ex_mkrc(exarg_T *eap)
 {
@@ -8141,12 +8136,6 @@ static void ex_mkrc(exarg_T *eap)
       flagp = &vop_flags;
     else
       flagp = &ssop_flags;
-
-#ifdef MKSESSION_NL
-    /* "unix" in 'sessionoptions': use NL line separator */
-    if (view_session && (*flagp & SSOP_UNIX))
-      mksession_nl = TRUE;
-#endif
 
     /* Write the version command for :mkvimrc */
     if (eap->cmdidx == CMD_mkvimrc)
@@ -8236,9 +8225,6 @@ static void ex_mkrc(exarg_T *eap)
       }
       xfree(tbuf);
     }
-#ifdef MKSESSION_NL
-    mksession_nl = FALSE;
-#endif
   }
 
   xfree(viewFile);
@@ -9964,19 +9950,11 @@ static char *get_view_file(int c)
 }
 
 
-/*
- * Write end-of-line character(s) for ":mkexrc", ":mkvimrc" and ":mksession".
- * Return FAIL for a write error.
- */
+/// TODO(justinmk): remove this. Formerly used to choose CRLF or LF for session
+// files, but that's useless--instead we always write LF.
 int put_eol(FILE *fd)
 {
-#if defined(USE_CRNL) && defined(MKSESSION_NL)
-  if ((!mksession_nl && putc('\r', fd) < 0) || putc('\n', fd) < 0) {
-#elif defined(USE_CRNL)
-  if (putc('\r', fd) < 0 || putc('\n', fd) < 0) {
-#else
   if (putc('\n', fd) < 0) {
-#endif
     return FAIL;
   }
   return OK;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8089,6 +8089,10 @@ static void close_redir(void)
   do { if (FAIL == put_line(fd, (s))) { return FAIL; } } while (0)
 
 /// ":mkexrc", ":mkvimrc", ":mkview", ":mksession".
+///
+/// Legacy 'sessionoptions' flags SSOP_UNIX, SSOP_SLASH are always enabled.
+///   - SSOP_UNIX: line-endings are always LF
+///   - SSOP_SLASH: filenames are always written with "/" slash
 static void ex_mkrc(exarg_T *eap)
 {
   FILE        *fd;
@@ -9112,6 +9116,8 @@ char_u *expand_sfile(char_u *arg)
 
 /// Writes commands for restoring the current buffers, for :mksession.
 ///
+/// Legacy 'sessionoptions' flags SSOP_UNIX, SSOP_SLASH are always enabled.
+///
 /// @param dirnow  Current directory name
 /// @param fd  File descriptor to write to
 ///
@@ -9840,12 +9846,10 @@ static char *ses_escape_fname(char *name, unsigned *flagp)
   char *p;
   char *sname = (char *)home_replace_save(NULL, (char_u *)name);
 
-  if (*flagp & SSOP_SLASH) {
-    // change all backslashes to forward slashes
-    for (p = sname; *p != NUL; MB_PTR_ADV(p)) {
-      if (*p == '\\') {
-        *p = '/';
-      }
+  // Always SSOP_SLASH: change all backslashes to forward slashes.
+  for (p = sname; *p != NUL; MB_PTR_ADV(p)) {
+    if (*p == '\\') {
+      *p = '/';
     }
   }
 

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -578,7 +578,7 @@ static char *(p_ssop_values[]) = {
 # define SSOP_BLANK             0x080
 # define SSOP_GLOBALS           0x100
 # define SSOP_SLASH             0x200
-# define SSOP_UNIX              0x400  /* Deprecated, not used. */
+# define SSOP_UNIX              0x400  // Deprecated, not used.
 # define SSOP_SESDIR            0x800
 # define SSOP_CURDIR            0x1000
 # define SSOP_FOLDS             0x2000

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -577,8 +577,8 @@ static char *(p_ssop_values[]) = {
 # define SSOP_HELP              0x040
 # define SSOP_BLANK             0x080
 # define SSOP_GLOBALS           0x100
-# define SSOP_SLASH             0x200
-# define SSOP_UNIX              0x400  // Deprecated, not used.
+# define SSOP_SLASH             0x200  // Deprecated, always set.
+# define SSOP_UNIX              0x400  // Deprecated, always set.
 # define SSOP_SESDIR            0x800
 # define SSOP_CURDIR            0x1000
 # define SSOP_FOLDS             0x2000

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -578,7 +578,7 @@ static char *(p_ssop_values[]) = {
 # define SSOP_BLANK             0x080
 # define SSOP_GLOBALS           0x100
 # define SSOP_SLASH             0x200
-# define SSOP_UNIX              0x400
+# define SSOP_UNIX              0x400  /* Deprecated, not used. */
 # define SSOP_SESDIR            0x800
 # define SSOP_CURDIR            0x1000
 # define SSOP_FOLDS             0x2000

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -96,7 +96,8 @@ describe(':mksession', function()
 
   it('restores CWD for :terminal buffers #11288', function()
     local cwd_dir = funcs.fnamemodify('.', ':p:~'):gsub([[[\/]*$]], '')
-    local session_path = cwd_dir..get_pathsep()..session_file
+    cwd_dir = cwd_dir:gsub([[\]], '/')  -- :mksession always uses unix slashes.
+    local session_path = cwd_dir..'/'..session_file
 
     command('cd '..tab_dir)
     command('terminal echo $PWD')
@@ -108,7 +109,7 @@ describe(':mksession', function()
     clear()
     command('silent source '..session_path)
 
-    local expected_cwd = cwd_dir..get_pathsep()..tab_dir
+    local expected_cwd = cwd_dir..'/'..tab_dir
     matches('^term://'..pesc(expected_cwd)..'//%d+:', funcs.expand('%'))
     command('qall!')
   end)

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -91,4 +91,23 @@ describe(':mksession', function()
     matches('^term://'..pesc(expected_cwd)..'//%d+:', funcs.expand('%'))
     command('qall!')
   end)
+
+	it('restores multiple windows with same terminal instances', function()
+		-- Create a view with two buffers referencing the same terminal instance
+		command('terminal')
+		command('split')
+		command('mksession ' .. session_file)
+
+		clear()
+
+		command('source ' .. session_file)
+		-- Getting the name of the buffer shown to compare with the other window
+		local eval = helpers.eval
+
+		command('exe 1 . "wincmd w"')
+		local expected_pid = eval('b:terminal_job_pid')
+
+		command('exe 2 . "wincmd w"')
+		eq(expected_pid, eval('b:terminal_job_pid'))
+	end)
 end)

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -794,7 +794,7 @@ function module.alter_slashes(obj)
     end
     return ret
   else
-    assert(false, 'Could only alter slashes for tables of strings and strings')
+    assert(false, 'expected string or table of strings, got '..type(obj))
   end
 end
 


### PR DESCRIPTION
Attempt to fix for issue #5250 .

When creating a terminal buffer with command like `:edit term://.//16450:/bin/bash`, the buffer get a different name (depending on the PID of the terminal instance). Thus, further call to `bufexists('term://.//16450:/bin/bash)` will return false.

To fix this, I added a `char_u *` field in the structure `Terminal` so when looking for a buffer by name, it look at this name too.

There is still one test that need to pass at the moment.