### PR TITLE
[RFC] vim-patch:8.0.0364

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1484,21 +1484,23 @@ spell_move_to (
       return found_len;
     }
 
-    if (curline)
+    if (curline) {
       break;            // only check cursor line
+    }
+
+    // If we are back at the starting line and searched it again there
+    // is no match, give up.
+    if (lnum == wp->w_cursor.lnum && wrapped) {
+      break;
+    }
 
     // Advance to next line.
     if (dir == BACKWARD) {
-      // If we are back at the starting line and searched it again there
-      // is no match, give up.
-      if (lnum == wp->w_cursor.lnum && wrapped)
-        break;
-
-      if (lnum > 1)
-        --lnum;
-      else if (!p_ws)
+      if (lnum > 1) {
+        lnum--;
+      } else if (!p_ws) {
         break;              // at first line and 'nowrapscan'
-      else {
+      } else {
         // Wrap around to the end of the buffer.  May search the
         // starting line again and accept the last match.
         lnum = wp->w_buffer->b_ml.ml_line_count;
@@ -1523,8 +1525,9 @@ spell_move_to (
 
       // If we are back at the starting line and there is no match then
       // give up.
-      if (lnum == wp->w_cursor.lnum && (!found_one || wrapped))
+      if (lnum == wp->w_cursor.lnum && !found_one) {
         break;
+      }
 
       // Skip the characters at the start of the next line that were
       // included in a match crossing line boundaries.

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -81,6 +81,7 @@ NEW_TESTS ?= \
 	    test_search.res \
 	    test_signs.res \
 	    test_smartindent.res \
+	    test_spell.res \
 	    test_stat.res \
 	    test_startup.res \
 	    test_startup_utf8.res \

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -1,0 +1,20 @@
+" Test spell checking
+" TODO: move test58 tests here
+
+if !has('spell')
+  finish
+endif
+
+func Test_wrap_search()
+  new
+  call setline(1, ['The', '', 'A plong line with two zpelling mistakes', '', 'End'])
+  set spell wrapscan
+  normal ]s
+  call assert_equal('plong', expand('<cword>'))
+  normal ]s
+  call assert_equal('zpelling', expand('<cword>'))
+  normal ]s
+  call assert_equal('plong', expand('<cword>'))
+  bwipe!
+  set nospell
+endfunc

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -1,7 +1,7 @@
 " Test spell checking
 " TODO: move test58 tests here
 
-if !has('spell')
+if v:false
   finish
 endif
 

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -2,7 +2,7 @@
 " TODO: move test58 tests here
 
 if v:true
-  return
+  finish
 endif
 
 func Test_wrap_search()

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -1,8 +1,8 @@
 " Test spell checking
 " TODO: move test58 tests here
 
-if v:false
-  finish
+if v:true
+  return
 endif
 
 func Test_wrap_search()


### PR DESCRIPTION
#### vim-patch:8.0.0364: ]s does not move cursor with two spell errors in one line

Problem:    ]s does not move cursor with two spell errors in one line. (Manuel
            Ortega)
Solution:   Don't stop search immediately when wrapped, search the line first.
            (Ken Takata)  Add a test.

https://github.com/vim/vim/commit/d3f78dc9ebd729475a7f24a50a91112e300d5ac9