### PR TITLE
ci/travis: require "sudo" for ASAN_UBSAN build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,13 +57,13 @@ jobs:
       env: >
         CLANG_SANITIZER=ASAN_UBSAN
         CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
+      sudo: true
     - os: linux
       compiler: gcc
       env: FUNCTIONALTEST=functionaltest-lua
     - os: linux
-      # Travis creates a cache per compiler.
-      # Set a different value here to store 32-bit
-      # dependencies in a separate cache.
+      # Travis creates a cache per compiler. Set a different value here to
+      # store 32-bit dependencies in a separate cache.
       compiler: gcc -m32
       env: BUILD_32BIT=ON
     - os: osx


### PR DESCRIPTION
Attempt to fix this fun new issue:

    ==27404==LeakSanitizer has encountered a fatal error.
    ==27404==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
    ==27404==HINT: LeakSanitizer does not work under ptrace (strace, gdb, etc)
    Failed: E /build|logs :: Runtime errors detected.

edit:

Finally addressed at https://github.com/travis-ci/travis-ci/issues/9033
see also https://github.com/google/sanitizers/issues/764

