### PR TITLE
[RFC] os/shell.c: Display extra newline after output instead of before

### DIFF
--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -443,11 +443,10 @@ static void out_data_append_to_screen(char *output, size_t remaining,
   while (output != NULL && off < remaining) {
     // Found end of line?
     if (output[off] == NL) {
-      // Can we start a new line or do we need to continue the last one?
+      screen_puts_len((char_u *)output, (int)off, last_row, last_col, 0);
       if (last_col == 0) {
         screen_del_lines(0, 0, 1, (int)Rows, NULL);
       }
-      screen_puts_len((char_u *)output, (int)off, last_row, last_col, 0);
       last_col = 0;
 
       size_t skip = off + 1;
@@ -467,11 +466,11 @@ static void out_data_append_to_screen(char *output, size_t remaining,
   }
 
   if (output != NULL && remaining) {
+    screen_puts_len((char_u *)output, (int)remaining, last_row, last_col, 0);
+    last_col += (colnr_T)remaining;
     if (last_col == 0) {
       screen_del_lines(0, 0, 1, (int)Rows, NULL);
     }
-    screen_puts_len((char_u *)output, (int)remaining, last_row, last_col, 0);
-    last_col += (colnr_T)remaining;
   }
 
   if (new_line) {

--- a/test/functional/ex_cmds/bang_filter_spec.lua
+++ b/test/functional/ex_cmds/bang_filter_spec.lua
@@ -40,10 +40,10 @@ describe('issues', function()
       ~                                                    |
       ~                                                    |
       :!ls bang_filter_spec                                |
-                                                           |
       f1                                                   |
       f2                                                   |
       f3                                                   |
+                                                           |
       Press ENTER or type command to continue^              |
     ]])
   end)

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -33,8 +33,8 @@ describe("shell command :!", function()
       {4:~                                                 }|
       {4:~                                                 }|
       {4:~                                                 }|
+      {4:~                                                 }|
       :!printf foo; sleep 200                           |
-                                                        |
       foo                                               |
       {3:-- TERMINAL --}                                    |
     ]])
@@ -56,11 +56,11 @@ describe("shell command :!", function()
     -- Final chunk of output should always be displayed, never skipped.
     -- (Throttling is non-deterministic, this test is merely a sanity check.)
     screen:expect([[
-      XXXXXXXXXX 2996                                   |
       XXXXXXXXXX 2997                                   |
       XXXXXXXXXX 2998                                   |
       XXXXXXXXXX 2999                                   |
       XXXXXXXXXX 3000                                   |
+                                                        |
       {10:Press ENTER or type command to continue}{1: }          |
       {3:-- TERMINAL --}                                    |
     ]])


### PR DESCRIPTION
This fixes #7788.