### PR TITLE
os/shell.c: shell_build_argv no longer tokenizes p_sh

### DIFF
--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -56,7 +56,8 @@ char **shell_build_argv(const char *cmd, const char *extra_args)
   char **rv = xmalloc((argc + 4) * sizeof(*rv));
 
   size_t i = 0;
-  rv[i++] = xstrdup((const char *) p_sh);
+  rv[i++] = vim_strnsave_unquoted((const char *) p_sh,
+                                  strlen((const char *) p_sh));
 
   if (extra_args) {
     rv[i++] = xstrdup(extra_args);        // Push a copy of `extra_args`

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -52,11 +52,11 @@ typedef struct {
 char **shell_build_argv(const char *cmd, const char *extra_args)
   FUNC_ATTR_NONNULL_RET
 {
-  size_t argc = tokenize(p_sh, NULL) + (cmd ? tokenize(p_shcf, NULL) : 0);
+  size_t argc = 1 + (cmd ? tokenize(p_shcf, NULL) : 0);
   char **rv = xmalloc((argc + 4) * sizeof(*rv));
 
-  // Split 'shell'
-  size_t i = tokenize(p_sh, rv);
+  size_t i = 0;
+  rv[i++] = xstrdup((const char *) p_sh);
 
   if (extra_args) {
     rv[i++] = xstrdup(extra_args);        // Push a copy of `extra_args`


### PR DESCRIPTION
Fix for #7810. Also see [this patch](https://github.com/chrisbra/vim/commit/9113fa93a498410741f709d0613d56e244b6b922).