### PR TITLE
[RFC] vim-patch:8.0.0374

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3541,6 +3541,9 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout)
 
               getvcol(curwin, &curwin->w_cursor, &sc, NULL, NULL);
               curwin->w_cursor.col = regmatch.endpos[0].col - 1;
+              if (curwin->w_cursor.col < 0) {
+                curwin->w_cursor.col = 0;
+              }
               getvcol(curwin, &curwin->w_cursor, NULL, NULL, &ec);
               if (subflags.do_number || curwin->w_p_nu) {
                 int numw = number_width(curwin) + 1;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2164,7 +2164,13 @@ getexmodeline (
     /* Get one character at a time.  Don't use inchar(), it can't handle
      * special characters. */
     prev_char = c1;
-    c1 = vgetc();
+
+    // Check for a ":normal" command and no more characters left.
+    if (ex_normal_busy > 0 && typebuf.tb_len == 0) {
+        c1 = '\n';
+    } else {
+        c1 = vgetc();
+    }
 
     /*
      * Handle line editing.

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -106,3 +106,11 @@ function! Test_substitute_variants()
     endfor
   endfor
 endfunction
+
+func Test_substitute_repeat()
+  " This caused an invalid memory access.
+  split Xfile
+  s/^/x
+  call feedkeys("Qsc\<CR>y", 'tx')
+  bwipe!
+endfunc


### PR DESCRIPTION
#### vim-patch:8.0.0374: invalid memory access when using :sc in Ex mode

Problem:    Invalid memory access when using :sc in Ex mode. (Dominique Pelle)
Solution:   Avoid the column being negative.  Also fix a hang in Ex mode.

https://github.com/vim/vim/commit/ba748c8a847561c043a63827bcb1d98bdebe16e6