### PR TITLE
[WIP] Fix passed timeout with backwards searchpair

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -743,7 +743,7 @@ int searchit(
               }
               if (ptr[matchcol] == NUL
                   || (nmatched = vim_regexec_multi(
-                      &regmatch, hjwin, buf, lnum + matchpos.lnum, matchcol,
+                      &regmatch, win, buf, lnum + matchpos.lnum, matchcol,
                       tm)) == 0) {
                 if (tm != NULL && profile_passed_limit(*tm)) {
                   match_ok = false;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -742,11 +742,9 @@ int searchit(
                 }
               }
               if (ptr[matchcol] == NUL
-                  || (nmatched = vim_regexec_multi(&regmatch,
-                          win, buf, lnum + matchpos.lnum,
-                          matchcol,
-                          tm
-                          )) == 0) {
+                  || (nmatched = vim_regexec_multi(
+                      &regmatch, hjwin, buf, lnum + matchpos.lnum, matchcol,
+                      tm)) == 0) {
                 if (tm != NULL && profile_passed_limit(*tm)) {
                   match_ok = false;
                 }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -746,8 +746,12 @@ int searchit(
                           win, buf, lnum + matchpos.lnum,
                           matchcol,
                           tm
-                          )) == 0)
+                          )) == 0) {
+                if (tm != NULL && profile_passed_limit(*tm)) {
+                  match_ok = false;
+                }
                 break;
+              }
 
               /* Need to get the line pointer again, a
                * multi-line search may have made it invalid. */


### PR DESCRIPTION
searchpair(pos) might return an invalid value in case a timeout is used.

This can be triggered using `searchpairpos('(', '', ')', 'bnW', '', 1,
500)`.

This is a WIP PR to check if any existing tests are failing.