### PR TITLE
[RFC] vim-patch:8.0.0398,8.0.0402,8.0.0421

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3366,6 +3366,10 @@ set_context_in_map_cmd (
         arg = skipwhite(arg + 8);
         continue;
       }
+      if (STRNCMP(arg, "<special>", 9) == 0) {
+        arg = skipwhite(arg + 9);
+        continue;
+      }
       if (STRNCMP(arg, "<script>", 8) == 0) {
         arg = skipwhite(arg + 8);
         continue;
@@ -3408,21 +3412,24 @@ int ExpandMappings(regmatch_T *regmatch, int *num_file, char_u ***file)
   for (round = 1; round <= 2; ++round) {
     count = 0;
 
-    for (i = 0; i < 6; ++i) {
-      if (i == 0)
+    for (i = 0; i < 7; i++) {
+      if (i == 0) {
         p = (char_u *)"<silent>";
-      else if (i == 1)
+      } else if (i == 1) {
         p = (char_u *)"<unique>";
-      else if (i == 2)
+      } else if (i == 2) {
         p = (char_u *)"<script>";
-      else if (i == 3)
+      } else if (i == 3) {
         p = (char_u *)"<expr>";
-      else if (i == 4 && !expand_buffer)
+      } else if (i == 4 && !expand_buffer) {
         p = (char_u *)"<buffer>";
-      else if (i == 5)
+      } else if (i == 5) {
         p = (char_u *)"<nowait>";
-      else
+      } else if (i == 6) {
+        p = (char_u *)"<special>";
+      } else {
         continue;
+      }
 
       if (vim_regexec(regmatch, p, (colnr_T)0)) {
         if (round == 1)

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -749,8 +749,9 @@ open_line (
     // Postpone calling changed_lines(), because it would mess up folding
     // with markers.
     // Skip mark_adjust when adding a line after the last one, there can't
-    // be marks there.
-    if (curwin->w_cursor.lnum + 1 < curbuf->b_ml.ml_line_count) {
+    // be marks there. But still needed in diff mode.
+    if (curwin->w_cursor.lnum + 1 < curbuf->b_ml.ml_line_count
+        || curwin->w_p_diff) {
       mark_adjust(curwin->w_cursor.lnum + 1, (linenr_T)MAXLNUM, 1L, 0L, false);
     }
     did_append = true;
@@ -1864,8 +1865,8 @@ void appended_lines(linenr_T lnum, long count)
 void appended_lines_mark(linenr_T lnum, long count)
 {
   // Skip mark_adjust when adding a line after the last one, there can't
-  // be marks there.
-  if (lnum + count < curbuf->b_ml.ml_line_count) {
+  // be marks there. But it's still needed in diff mode.
+  if (lnum + count < curbuf->b_ml.ml_line_count || curwin->w_p_diff) {
     mark_adjust(lnum + 1, (linenr_T)MAXLNUM, count, 0L, false);
   }
   changed_lines(lnum + 1, 0, lnum + 1, count);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3177,9 +3177,9 @@ error:
           curbuf->b_op_start.lnum++;
       }
       // Skip mark_adjust when adding lines after the last one, there
-      // can't be marks there.
+      // can't be marks there. But still needed in diff mode.
       if (curbuf->b_op_start.lnum + (y_type == kMTCharWise) - 1 + nr_lines
-          < curbuf->b_ml.ml_line_count) {
+          < curbuf->b_ml.ml_line_count || curwin->w_p_diff) {
         mark_adjust(curbuf->b_op_start.lnum + (y_type == kMTCharWise),
                     (linenr_T)MAXLNUM, nr_lines, 0L, false);
       }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1382,13 +1382,13 @@ int searchc(cmdarg_T *cap, int t_cmd)
           col -= (*mb_head_off)(p, p + col - 1) + 1;
         }
         if (lastc_bytelen == 1) {
-          if (p[col] == c && stop)
+          if (p[col] == c && stop) {
             break;
-        } else {
-          if (memcmp(p + col, lastc_bytes, lastc_bytelen) == 0 && stop)
+          }
+        } else if (STRNCMP(p + col, lastc_bytes, lastc_bytelen) == 0 && stop) {
             break;
         }
-        stop = TRUE;
+        stop = true;
       }
     } else {
       for (;; ) {

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -25,6 +25,26 @@ func Test_complete_wildmenu()
   set nowildmenu
 endfunc
 
+func Test_map_completion()
+  if !has('cmdline_compl')
+    return
+  endif
+  call feedkeys(":map <unique> <si\<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"map <unique> <silent>', getreg(':'))
+  call feedkeys(":map <script> <un\<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"map <script> <unique>', getreg(':'))
+  call feedkeys(":map <expr> <sc\<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"map <expr> <script>', getreg(':'))
+  call feedkeys(":map <buffer> <e\<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"map <buffer> <expr>', getreg(':'))
+  call feedkeys(":map <nowait> <b\<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"map <nowait> <buffer>', getreg(':'))
+  call feedkeys(":map <special> <no\<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"map <special> <nowait>', getreg(':'))
+  call feedkeys(":map <silent> <sp\<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"map <silent> <special>', getreg(':'))
+endfunc
+
 func Test_expr_completion()
   if !(has('cmdline_compl') && has('eval'))
     return

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -272,3 +272,23 @@ func Test_setting_cursor()
   call delete('Xtest1')
   call delete('Xtest2')
 endfunc
+
+func Test_diff_lastline()
+  enew!
+  only!
+  call setline(1, ['This is a ', 'line with five ', 'rows'])
+  diffthis
+  botright vert new
+  call setline(1, ['This is', 'a line with ', 'four rows'])
+  diffthis
+  1
+  call feedkeys("Je a\<CR>", 'tx')
+  call feedkeys("Je a\<CR>", 'tx')
+  let w1lines = winline()
+  wincmd w
+  $
+  let w2lines = winline()
+  call assert_equal(w2lines, w1lines)
+  bwipe!
+  bwipe!
+endfunc

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -298,3 +298,10 @@ func Test_searchpair()
   q!
 endfunc
 
+func Test_searchc()
+  " These commands used to cause memory overflow in searchc().
+  new
+  norm ixx
+  exe "norm 0t\u93cf"
+  bw!
+endfunc


### PR DESCRIPTION
#### vim-patch:8.0.0398: illegal memory access with "t"

Problem:    Illegal memory access with "t".
Solution:   Use strncmp() instead of memcmp(). (Dominique Pelle, closes vim/vim#1528)

https://github.com/vim/vim/commit/66727e16079fbac6db3897b5c3736ec9fba995bb


#### vim-patch:8.0.0402: :map completion does not have <special>

Problem:    :map completion does not have <special>. (Dominique Pelle)
Solution:   Recognize <special> in completion.  Add a test.

https://github.com/vim/vim/commit/cf5fdf7d1689ecb145b634dcb9c6e9fc60f63869


#### vim-patch:8.0.0421: diff mode wrong when adding line at end of buffer

Problem:    Diff mode is displayed wrong when adding a line at the end of a
            buffer.
Solution:   Adjust marks in diff mode. (James McCoy, closes vim/vim#1329)

https://github.com/vim/vim/commit/f58a8475e17bd566760fc7e2a17d35ddf4edacf2