### PR TITLE
tests: explicit busted LUA_PATH to test scripts

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -38,7 +38,7 @@ set(ENV{SYSTEM_NAME} ${SYSTEM_NAME})
 execute_process(
   COMMAND ${BUSTED_PRG} ${TEST_TAG} ${TEST_FILTER} -v -o ${BUSTED_OUTPUT_TYPE}
     --lua=${LUA_PRG} --lazy --helper=${TEST_DIR}/${TEST_TYPE}/preload.lua
-    --lpath=${BUILD_DIR}/?.lua ${TEST_PATH}
+    --lpath=${BUILD_DIR}/?.lua --lpath=?.lua ${TEST_PATH}
   WORKING_DIRECTORY ${WORKING_DIR}
   ERROR_VARIABLE err
   RESULT_VARIABLE res


### PR DESCRIPTION
in case LUA_PATH does not contain `./?.lua`, busted can not find lua scripts
(for instance on nixos). So we make it explicit.