### PR TITLE
runtime: add `-bar` option to UpdateRemotePlugins command

### DIFF
--- a/runtime/plugin/rplugin.vim
+++ b/runtime/plugin/rplugin.vim
@@ -56,6 +56,6 @@ function! s:LoadRemotePlugins() abort
   endif
 endfunction
 
-command! UpdateRemotePlugins call remote#host#UpdateRemotePlugins()
+command! -bar UpdateRemotePlugins call remote#host#UpdateRemotePlugins()
 
 call s:LoadRemotePlugins()


### PR DESCRIPTION
Since `UpdateRemotePlugins` takes no args, it would be nice if it could be used in a chain with bars, e.g. `DoSomething | UpdateRemotePlugins | DoSomethingElse`. I don't think this should cause any problems but there may be subtleties of command definitions that I am not aware of.