### PR TITLE
[RFC] vim-patch:8.0.0423

### DIFF
--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -1619,6 +1619,9 @@ void parse_cino(buf_T *buf)
    * while(). */
   buf->b_ind_if_for_while = 0;
 
+  // indentation for # comments
+  buf->b_ind_hash_comment = 0;
+
   for (p = buf->b_p_cino; *p; ) {
     l = p++;
     if (*p == '-')

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -40,11 +40,12 @@ SCRIPTS ?= $(SCRIPTS_DEFAULT)
 # Tests using runtest.vim.
 # Keep test_alot*.res as the last one, sort the others.
 NEW_TESTS ?= \
-	    test_arabic.vim \
+	    test_arabic.res \
 	    test_autocmd.res \
 	    test_bufwintabinfo.res \
 	    test_changedtick.res \
 	    test_charsearch.res \
+	    test_cindent.res \
 	    test_cmdline.res \
 	    test_command_count.res \
 	    test_cscope.res \

--- a/src/nvim/testdir/test_cindent.vim
+++ b/src/nvim/testdir/test_cindent.vim
@@ -1,0 +1,16 @@
+" Test for cinoptions and cindent
+"
+" TODO: rewrite test3.in into this new style test
+
+func Test_cino_hash()
+  " Test that curbuf->b_ind_hash_comment is correctly reset
+  new
+  setlocal cindent cinoptions=#1
+  setlocal cinoptions=
+  call setline(1, ["#include <iostream>"])
+  call cursor(1, 1)
+  norm! o#include
+  "call feedkeys("o#include\<esc>", 't')
+  call assert_equal(["#include <iostream>", "#include"], getline(1,2))
+  bwipe!
+endfunc

--- a/test/functional/legacy/003_cindent_spec.lua
+++ b/test/functional/legacy/003_cindent_spec.lua
@@ -1,4 +1,5 @@
 -- Test for 'cindent'.
+-- For new tests, consider putting them in test_cindent.vim.
 --
 -- There are 50+ test command blocks (the stuff between STARTTEST and ENDTEST)
 -- in the original test. These have been converted to "it" test cases here.


### PR DESCRIPTION
#### vim-patch:8.0.0423: changing 'cinoptions' does not always work

Problem:    The effect of adding "vim/vim#" to 'cinoptions' is not always removed.
            (David Briscoe)
Solution:   Reset b_ind_hash_comment. (Christian Brabandt, closes vim/vim#1475)

https://github.com/vim/vim/commit/6b64394f346594404cffb9591d71ac693040679f