### PR TITLE
[RFC] man.vim: use correct offset in presence of modifier commands

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -299,6 +299,12 @@ endfunction
 " see man#extract_sect_and_name_ref on why tolower(sect)
 function! man#complete(arg_lead, cmd_line, cursor_pos) abort
   let args = split(a:cmd_line)
+  let cmd_offset = index(args, 'Man')
+  if cmd_offset > 0
+    " Prune all arguments up to :Man itself. Otherwise modifier commands like
+    " :tab, :vertical, etc. would lead to a wrong length.
+    let args = args[cmd_offset:]
+  endif
   let l = len(args)
   if l > 3
     return


### PR DESCRIPTION
The argument expansion for `:Man` depends on the number of arguments given to it starting at the command itself. But user completion functions always provide the entire command-line which can include modifier commands like `:tab`, `:vert`, etc. leading to a wrong number of arguments.

Prune all arguments up to `:Man`.

Fixes #7872.