### PR TITLE
travis: "shell_session_update: command not found"

### DIFF
--- a/ci/common/build.sh
+++ b/ci/common/build.sh
@@ -95,4 +95,7 @@ macos_rvm_dance() {
   rvm reload
   rvm use 2.2.5
   rvm use
+  # workaround against rvm overriding cd (revisit)
+  # https://github.com/travis-ci/travis-ci/issues/8703#ref-pullrequest-279112274
+  unset -f cd
 }


### PR DESCRIPTION
Rvm overrides shell commands with its own hooks and cause travais to
fail on darwin. We an either bump rvm version or try removing the hooks:
https://github.com/rvm/rvm/commit/cbc4488028ccc682a872034ba823f61bf2d9cf6d