### PR TITLE
[RFC] vim-patch:8.0.0427

### DIFF
--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1087,6 +1087,9 @@ if has("quickfix")
   call <SID>OptionG("gp", &gp)
   call append("$", "grepformat\tlist of formats for output of 'grepprg'")
   call <SID>OptionG("gfm", &gfm)
+  call append("$", "makeencoding\tencoding of the \":make\" and \":grep\" output")
+  call append("$", "\t(global or local to buffer)")
+  call <SID>OptionG("menc", &menc)
 endif
 
 


### PR DESCRIPTION
#### vim-patch:8.0.0427: 'makeencoding' missing from the options window

Problem:    'makeencoding' missing from the options window.
Solution:   Add the entry.

https://github.com/vim/vim/commit/ad4187e6fc9c8e1083a172852d958a70a689a75c