### PR TITLE
[RFC] vim-patch:8.0.0431

### DIFF
--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -321,6 +321,21 @@ The examples below assume a 'shiftwidth' of 4.
 		      void function();       void function();
 		  }                          }
 <
+							*cino-E*
+	EN    Indent inside C++ linkage specifications (extern "C" or
+	      extern "C++") N characters extra compared to a normal block.
+	      (default 0).
+
+		cino=			   cino=E-s >
+		  extern "C" {               extern "C" {
+		      void function();       void function();
+		  }                          }
+
+		  extern "C"                 extern "C"
+		  {                          {
+		      void function();       void function();
+		  }                          }
+<
 							*cino-p*
 	pN    Parameter declarations for K&R-style function declarations will
 	      be indented N characters from the margin.  (default
@@ -550,7 +565,7 @@ The examples below assume a 'shiftwidth' of 4.
 
 
 The defaults, spelled out in full, are:
-	cinoptions=>s,e0,n0,f0,{0,}0,^0,L-1,:s,=s,l0,b0,gs,hs,N0,ps,ts,is,+s,
+	cinoptions=>s,e0,n0,f0,{0,}0,^0,L-1,:s,=s,l0,b0,gs,hs,N0,E0,ps,ts,is,+s,
 			c3,C0,/0,(2s,us,U0,w0,W0,k0,m0,j0,J0,)20,*70,#0
 
 Vim puts a line in column 1 if:

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -718,6 +718,7 @@ struct file_buffer {
   int b_ind_hash_comment;
   int b_ind_cpp_namespace;
   int b_ind_if_for_while;
+  int b_ind_cpp_extern_c;
 
   linenr_T b_no_eol_lnum;       /* non-zero lnum when last line of next binary
                                  * write should not have an end-of-line */

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -1314,6 +1314,43 @@ static int cin_starts_with(char_u *s, char *word)
   return STRNCMP(s, word, l) == 0 && !vim_isIDc(s[l]);
 }
 
+/// Recognize a `extern "C"` or `extern "C++"` linkage specifications.
+static int cin_is_cpp_extern_c(char_u *s)
+{
+  char_u  *p;
+  int     has_string_literal = false;
+
+  s = cin_skipcomment(s);
+  if (STRNCMP(s, "extern", 6) == 0 && (s[6] == NUL || !vim_iswordc(s[6]))) {
+    p = cin_skipcomment(skipwhite(s + 6));
+    while (*p != NUL) {
+      if (ascii_iswhite(*p)) {
+        p = cin_skipcomment(skipwhite(p));
+      } else if (*p == '{') {
+        break;
+      } else if (p[0] == '"' && p[1] == 'C' && p[2] == '"') {
+        if (has_string_literal) {
+          return false;
+        }
+        has_string_literal = true;
+        p += 3;
+      } else if (p[0] == '"' && p[1] == 'C' && p[2] == '+' && p[3] == '+'
+                 && p[4] == '"') {
+        if (has_string_literal) {
+          return false;
+        }
+        has_string_literal = true;
+        p += 5;
+      } else {
+        return false;
+      }
+    }
+    return has_string_literal ? true : false;
+  }
+  return false;
+}
+
+
 /*
  * Skip strings, chars and comments until at or past "trypos".
  * Return the column found.
@@ -1322,14 +1359,19 @@ static int cin_skip2pos(pos_T *trypos)
 {
   char_u      *line;
   char_u      *p;
+  char_u      *new_p;
 
   p = line = ml_get(trypos->lnum);
   while (*p && (colnr_T)(p - line) < trypos->col) {
-    if (cin_iscomment(p))
+    if (cin_iscomment(p)) {
       p = cin_skipcomment(p);
-    else {
-      p = skip_string(p);
-      ++p;
+    } else {
+      new_p = skip_string(p);
+      if (new_p == p) {
+        ++p;
+      } else {
+        p = new_p;
+      }
     }
   }
   return (int)(p - line);
@@ -1622,6 +1664,9 @@ void parse_cino(buf_T *buf)
   // indentation for # comments
   buf->b_ind_hash_comment = 0;
 
+  // Handle C++ extern "C" or "C++"
+  buf->b_ind_cpp_extern_c = 0;
+
   for (p = buf->b_p_cino; *p; ) {
     l = p++;
     if (*p == '-')
@@ -1690,6 +1735,7 @@ void parse_cino(buf_T *buf)
     case '#': buf->b_ind_hash_comment = n; break;
     case 'N': buf->b_ind_cpp_namespace = n; break;
     case 'k': buf->b_ind_if_for_while = n; break;
+    case 'E': buf->b_ind_cpp_extern_c = n; break;
     }
     if (*p == ',')
       ++p;
@@ -2320,8 +2366,11 @@ int get_c_indent(void)
             amount += curbuf->b_ind_open_imag;
 
             l = skipwhite(get_cursor_line_ptr());
-            if (cin_is_cpp_namespace(l))
+            if (cin_is_cpp_namespace(l)) {
               amount += curbuf->b_ind_cpp_namespace;
+            } else if (cin_is_cpp_extern_c(l)) {
+              amount += curbuf->b_ind_cpp_extern_c;
+            }
           } else {
             /* Compensate for adding b_ind_open_extra later. */
             amount -= curbuf->b_ind_open_extra;
@@ -2519,6 +2568,9 @@ int get_c_indent(void)
                 if (cin_is_cpp_namespace(l)) {
                   amount += curbuf->b_ind_cpp_namespace
                             - added_to_amount;
+                  break;
+                } else if (cin_is_cpp_extern_c(l)) {
+                  amount += curbuf->b_ind_cpp_extern_c - added_to_amount;
                   break;
                 }
 

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -1368,7 +1368,7 @@ static int cin_skip2pos(pos_T *trypos)
     } else {
       new_p = skip_string(p);
       if (new_p == p) {
-        ++p;
+        p++;
       } else {
         p = new_p;
       }

--- a/src/nvim/testdir/test_cindent.vim
+++ b/src/nvim/testdir/test_cindent.vim
@@ -14,3 +14,63 @@ func Test_cino_hash()
   call assert_equal(["#include <iostream>", "#include"], getline(1,2))
   bwipe!
 endfunc
+
+func Test_cino_extern_c()
+  " Test for cino-E
+
+  let without_ind = [
+        \ '#ifdef __cplusplus',
+        \ 'extern "C" {',
+        \ '#endif',
+        \ 'int func_a(void);',
+        \ '#ifdef __cplusplus',
+        \ '}',
+        \ '#endif'
+        \ ]
+
+  let with_ind = [
+        \ '#ifdef __cplusplus',
+        \ 'extern "C" {',
+        \ '#endif',
+        \ "\tint func_a(void);",
+        \ '#ifdef __cplusplus',
+        \ '}',
+        \ '#endif'
+        \ ]
+  new
+  setlocal cindent cinoptions=E0
+  call setline(1, without_ind)
+  call feedkeys("gg=G", 'tx')
+  call assert_equal(with_ind, getline(1, '$'))
+
+  setlocal cinoptions=E-s
+  call setline(1, with_ind)
+  call feedkeys("gg=G", 'tx')
+  call assert_equal(without_ind, getline(1, '$'))
+
+  setlocal cinoptions=Es
+  let tests = [
+        \ ['recognized', ['extern "C" {'], "\t\t;"],
+        \ ['recognized', ['extern "C++" {'], "\t\t;"],
+        \ ['recognized', ['extern /* com */ "C"{'], "\t\t;"],
+        \ ['recognized', ['extern"C"{'], "\t\t;"],
+        \ ['recognized', ['extern "C"', '{'], "\t\t;"],
+        \ ['not recognized', ['extern {'], "\t;"],
+        \ ['not recognized', ['extern /*"C"*/{'], "\t;"],
+        \ ['not recognized', ['extern "C" //{'], ";"],
+        \ ['not recognized', ['extern "C" /*{*/'], ";"],
+        \ ]
+
+  for pair in tests
+    let lines = pair[1]
+    call setline(1, lines)
+    call feedkeys(len(lines) . "Go;", 'tx')
+    call assert_equal(pair[2], getline(len(lines) + 1), 'Failed for "' . string(lines) . '"')
+  endfor
+
+
+
+  bwipe!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.0.0431: 'cinoptions' cannot set indent for extern block

Problem:    'cinoptions' cannot set indent for extern block.
Solution:   Add the "E" flag in 'cinoptions'. (Hirohito Higashi)

https://github.com/vim/vim/commit/7720ba8599162fbbb8f7fc034f674a2ccd3ca7f1