### PR TITLE
build/gcc: disable -Warray-bounds entirely (WAS: kbtree: adjust __KB_PRAGMA_START)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,13 +250,14 @@ if(HAS_DIAG_COLOR_FLAG)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8.5")
-    # Array-bounds testing is broken in some GCC versions before 4.8.5.
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56273
-    check_c_compiler_flag(-Wno-array-bounds HAS_NO_ARRAY_BOUNDS_FLAG)
-    if(HAS_NO_ARRAY_BOUNDS_FLAG)
-      add_definitions(-Wno-array-bounds)
-    endif()
+  # 1. Array-bounds testing is broken in some GCC versions before 4.8.5.
+  #    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56273
+  # 2. But _Pragma("...ignored") is broken (unresolved) in GCC 5+:
+  #    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66099
+  # So we must disable -Warray-bounds globally for GCC (for kbtree.h, #7083).
+  check_c_compiler_flag(-Wno-array-bounds HAS_NO_ARRAY_BOUNDS_FLAG)
+  if(HAS_NO_ARRAY_BOUNDS_FLAG)
+    add_definitions(-Wno-array-bounds)
   endif()
 endif()
 

--- a/src/nvim/lib/kbtree.h
+++ b/src/nvim/lib/kbtree.h
@@ -390,34 +390,14 @@
 #define KBTREE_INIT(name, key_t, __cmp, T) \
   KBTREE_INIT_IMPL(name, key_t, kbnode_##name##_t, __cmp, T, (sizeof(kbnode_##name##_t)+(2*T)*sizeof(void *)))
 
-#if (!defined(__clang__) && !defined(__INTEL_COMPILER)) &&  (__GNUC__ > 4 )
-
-// The index trickery shouldn't be UB anymore,
-// still it is to much for gcc:s -Werror=array-bounds
-# define __KB_PRAGMA_START \
-    _Pragma("GCC diagnostic push") \
-    _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
-
-# define __KB_PRAGMA_END \
-    _Pragma("GCC diagnostic pop") \
-
-#else
-
-# define __KB_PRAGMA_START
-# define __KB_PRAGMA_END
-
-#endif
-
 #define KBTREE_INIT_IMPL(name, key_t, kbnode_t, __cmp, T, ILEN)			\
-	__KB_PRAGMA_START \
 	__KB_TREE_T(name, key_t, T)							\
 	__KB_GET_AUX1(name, key_t, kbnode_t, __cmp)			\
 	__KB_GET(name, key_t, kbnode_t)						\
 	__KB_INTERVAL(name, key_t, kbnode_t)					\
 	__KB_PUT(name, key_t, kbnode_t, __cmp, T, ILEN)				\
 	__KB_DEL(name, key_t, kbnode_t, T) \
-	__KB_ITR(name, key_t, kbnode_t) \
-	__KB_PRAGMA_END
+	__KB_ITR(name, key_t, kbnode_t)
 
 #define KB_DEFAULT_SIZE 512
 


### PR DESCRIPTION
closes #7921