### PR TITLE
test/old: $TMPDIR must be absolute

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -941,9 +941,6 @@ void ex_diffpatch(exarg_T *eap)
   }
 #endif
 
-  // patch probably has written over the screen
-  redraw_later(CLEAR);
-
   // Delete any .orig or .rej file created.
   STRCPY(buf, tmp_new);
   STRCAT(buf, ".orig");

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -11,7 +11,7 @@ SCRIPTSOURCE := ../../../runtime
 
 export SHELL := sh
 export NVIM_PRG := $(NVIM_PRG)
-export TMPDIR := Xtest-tmpdir
+export TMPDIR := $(abspath ../../../Xtest-tmpdir)
 
 SCRIPTS_DEFAULT = \
            test14.out             \

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -152,8 +152,8 @@ func Test_set_completion()
 
   " Expand directories.
   call feedkeys(":set cdpath=./\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_match(' ./samples/ ', @:)
-  call assert_notmatch(' ./small.vim ', @:)
+  call assert_match('./samples/ ', @:)
+  call assert_notmatch('./small.vim ', @:)
 
   " Expand files and directories.
   call feedkeys(":set tags=./\<C-A>\<C-B>\"\<CR>", 'tx')


### PR DESCRIPTION
This should fix the `Test_diffpatch()` failure on the macOS build.