### PR TITLE
vim-patch:8.0.0528: highlight wrong text when 'wim' includes "longest"

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4058,12 +4058,12 @@ static int showmatches(expand_T *xp, int wildmenu)
     msg_start();                        /* prepare for paging */
   }
 
-  if (got_int)
-    got_int = FALSE;            /* only int. the completion, not the cmd line */
-  else if (wildmenu)
-    win_redr_status_matches(xp, num_files, files_found, 0, showtail);
-  else {
-    /* find the length of the longest file name */
+  if (got_int) {
+    got_int = false;            // only int. the completion, not the cmd line
+  } else if (wildmenu) {
+    win_redr_status_matches(xp, num_files, files_found, -1, showtail);
+  } else {
+    // find the length of the longest file name
     maxlen = 0;
     for (i = 0; i < num_files; ++i) {
       if (!showtail && (xp->xp_context == EXPAND_FILES


### PR DESCRIPTION
Problem:    When 'wildmenu' is set and 'wildmode' has "longest" then the first
            file name is highlighted, even though the text shows the longest
            match.
Solution:   Do not highlight the first match. (LemonBoy, closes vim/vim#1602)

https://github.com/vim/vim/commit/ef8eb0897819099fb00d675afb9bffe1d008c45e