### PR TITLE
[RFC] vim-patch:8.0.0443

### DIFF
--- a/test/functional/legacy/003_cindent_spec.lua
+++ b/test/functional/legacy/003_cindent_spec.lua
@@ -1957,7 +1957,8 @@ describe('cindent', function()
       }
       ]=])
 
-    feed_command('set tw=0 wm=60 columns=80 noai fo=croq')
+    feed_command('set tw=0 noai fo=croq')
+    feed_command('let &wm = &columns - 20')
     feed_command('/serious/e')
     feed('a about life, the universe, and the rest<esc>')
 


### PR DESCRIPTION
#### vim-patch:8.0.0443: terminal width is set to 80 in test3

Problem:    Terminal width is set to 80 in test3.
Solution:   Instead of setting 'columns' set 'wrapmargin' depending on
            'columns.

https://github.com/vim/vim/commit/38a3d6c9601b637a28f399059263300e9f65eba4