### PR TITLE
[RFC] vim-patch:8.0.0448

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -129,7 +129,7 @@ read_buffer(
   if (read_stdin) {
     // Set or reset 'modified' before executing autocommands, so that
     // it can be changed there.
-    if (!readonlymode && !bufempty()) {
+    if (!readonlymode && !BUFEMPTY()) {
       changed();
     } else if (retval != FAIL) {
       unchanged(curbuf, false);
@@ -1616,7 +1616,7 @@ buf_T * buflist_new(char_u *ffname, char_u *sfname, linenr_T lnum, int flags)
       && curbuf != NULL
       && curbuf->b_ffname == NULL
       && curbuf->b_nwindows <= 1
-      && (curbuf->b_ml.ml_mfp == NULL || bufempty())) {
+      && (curbuf->b_ml.ml_mfp == NULL || BUFEMPTY())) {
     buf = curbuf;
     /* It's like this buffer is deleted.  Watch out for autocommands that
      * change curbuf!  If that happens, allocate a new buffer anyway. */
@@ -1872,7 +1872,7 @@ int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
     // If 'switchbuf' contains "split", "vsplit" or "newtab" and the
     // current buffer isn't empty: open new tab or window
     if (wp == NULL && (swb_flags & (SWB_VSPLIT | SWB_SPLIT | SWB_NEWTAB))
-        && !bufempty()) {
+        && !BUFEMPTY()) {
       if (swb_flags & SWB_NEWTAB) {
         tabpage_new();
       } else if (win_split(0, (swb_flags & SWB_VSPLIT) ? WSP_VERT : 0)
@@ -4462,11 +4462,12 @@ do_arg_all (
   last_curwin = curwin;
   last_curtab = curtab;
   win_enter(lastwin, false);
-  /* ":drop all" should re-use an empty window to avoid "--remote-tab"
-   * leaving an empty tab page when executed locally. */
-  if (keep_tabs && bufempty() && curbuf->b_nwindows == 1
-      && curbuf->b_ffname == NULL && !curbuf->b_changed)
+  // ":drop all" should re-use an empty window to avoid "--remote-tab"
+  // leaving an empty tab page when executed locally.
+  if (keep_tabs && BUFEMPTY() && curbuf->b_nwindows == 1
+      && curbuf->b_ffname == NULL && !curbuf->b_changed) {
     use_firstwin = TRUE;
+  }
 
   for (i = 0; i < count && i < opened_len && !got_int; ++i) {
     if (alist == &global_alist && i == global_alist.al_ga.ga_len - 1)

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -2267,7 +2267,7 @@ void ex_diffgetput(exarg_T *eap)
         }
       }
 
-      buf_empty = bufempty();
+      buf_empty = BUFEMPTY();
       added = 0;
 
       for (i = 0; i < count; ++i) {

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7473,13 +7473,11 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
   int oldState;
   int cpc[MAX_MCO];                 /* composing characters */
 
-  /*
-   * can't delete anything in an empty file
-   * can't backup past first character in buffer
-   * can't backup past starting point unless 'backspace' > 1
-   * can backup to a previous line if 'backspace' == 0
-   */
-  if (bufempty()
+  // can't delete anything in an empty file
+  // can't backup past first character in buffer
+  // can't backup past starting point unless 'backspace' > 1
+  // can backup to a previous line if 'backspace' == 0
+  if (BUFEMPTY()
       || (!revins_on
           && ((curwin->w_cursor.lnum == 1 && curwin->w_cursor.col == 0)
               || (!can_bs(BS_START)

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5088,14 +5088,12 @@ void buf_reload(buf_T *buf, int orig_mode)
     flags |= READ_KEEP_UNDO;
   }
 
-  /*
-   * To behave like when a new file is edited (matters for
-   * BufReadPost autocommands) we first need to delete the current
-   * buffer contents.  But if reading the file fails we should keep
-   * the old contents.  Can't use memory only, the file might be
-   * too big.  Use a hidden buffer to move the buffer contents to.
-   */
-  if (bufempty() || saved == FAIL) {
+  // To behave like when a new file is edited (matters for
+  // BufReadPost autocommands) we first need to delete the current
+  // buffer contents.  But if reading the file fails we should keep
+  // the old contents.  Can't use memory only, the file might be
+  // too big.  Use a hidden buffer to move the buffer contents to.
+  if (BUFEMPTY() || saved == FAIL) {
     savebuf = NULL;
   } else {
     // Allocate a buffer without putting it in the buffer list.
@@ -5128,7 +5126,7 @@ void buf_reload(buf_T *buf, int orig_mode)
       if (savebuf != NULL && bufref_valid(&bufref) && buf == curbuf) {
         // Put the text back from the save buffer.  First
         // delete any lines that readfile() added.
-        while (!bufempty()) {
+        while (!BUFEMPTY()) {
           if (ml_delete(buf->b_ml.ml_line_count, false) == FAIL) {
             break;
           }

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -28,15 +28,11 @@
 /// @return `s, sizeof(s) - 1`
 #define S_LEN(s) (s), (sizeof(s) - 1)
 
-/*
- * lineempty() - return TRUE if the line is empty
- */
-#define lineempty(p) (*ml_get(p) == NUL)
+/// LINEEMPTY() - return TRUE if the line is empty
+#define LINEEMPTY(p) (*ml_get(p) == NUL)
 
-/*
- * bufempty() - return TRUE if the current buffer is empty
- */
-#define bufempty() (curbuf->b_ml.ml_line_count == 1 && *ml_get((linenr_T)1) == \
+/// BUFEMPTY() - return TRUE if the current buffer is empty
+#define BUFEMPTY() (curbuf->b_ml.ml_line_count == 1 && *ml_get((linenr_T)1) == \
                     NUL)
 
 /*

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -155,12 +155,11 @@ void update_topline(void)
   old_topline = curwin->w_topline;
   old_topfill = curwin->w_topfill;
 
-  /*
-   * If the buffer is empty, always set topline to 1.
-   */
-  if (bufempty()) {             /* special case - file is empty */
-    if (curwin->w_topline != 1)
+  // If the buffer is empty, always set topline to 1.
+  if (BUFEMPTY()) {             // special case - file is empty
+    if (curwin->w_topline != 1) {
       redraw_later(NOT_VALID);
+    }
     curwin->w_topline = 1;
     curwin->w_botline = 2;
     curwin->w_valid |= VALID_BOTLINE|VALID_BOTLINE_AP;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5031,26 +5031,21 @@ static void nv_right(cmdarg_T *cap)
     if ((!PAST_LINE && oneright() == false)
         || (PAST_LINE && *get_cursor_pos_ptr() == NUL)
         ) {
-      /*
-       *	  <Space> wraps to next line if 'whichwrap' has 's'.
-       *	      'l' wraps to next line if 'whichwrap' has 'l'.
-       * CURS_RIGHT wraps to next line if 'whichwrap' has '>'.
-       */
-      if (       ((cap->cmdchar == ' '
-                   && vim_strchr(p_ww, 's') != NULL)
-                  || (cap->cmdchar == 'l'
-                      && vim_strchr(p_ww, 'l') != NULL)
-                  || (cap->cmdchar == K_RIGHT
-                      && vim_strchr(p_ww, '>') != NULL))
-                 && curwin->w_cursor.lnum < curbuf->b_ml.ml_line_count) {
-        /* When deleting we also count the NL as a character.
-         * Set cap->oap->inclusive when last char in the line is
-         * included, move to next line after that */
-        if (       cap->oap->op_type != OP_NOP
-                   && !cap->oap->inclusive
-                   && !lineempty(curwin->w_cursor.lnum))
+      //	  <Space> wraps to next line if 'whichwrap' has 's'.
+      //	      'l' wraps to next line if 'whichwrap' has 'l'.
+      // CURS_RIGHT wraps to next line if 'whichwrap' has '>'.
+      if (((cap->cmdchar == ' ' && vim_strchr(p_ww, 's') != NULL)
+           || (cap->cmdchar == 'l' && vim_strchr(p_ww, 'l') != NULL)
+           || (cap->cmdchar == K_RIGHT && vim_strchr(p_ww, '>') != NULL))
+          && curwin->w_cursor.lnum < curbuf->b_ml.ml_line_count) {
+        // When deleting we also count the NL as a character.
+        // Set cap->oap->inclusive when last char in the line is
+        // included, move to next line after that
+        if (cap->oap->op_type != OP_NOP
+            && !cap->oap->inclusive
+            && !LINEEMPTY(curwin->w_cursor.lnum)) {
           cap->oap->inclusive = true;
-        else {
+        } else {
           ++curwin->w_cursor.lnum;
           curwin->w_cursor.col = 0;
           curwin->w_cursor.coladd = 0;
@@ -5060,12 +5055,14 @@ static void nv_right(cmdarg_T *cap)
         continue;
       }
       if (cap->oap->op_type == OP_NOP) {
-        /* Only beep and flush if not moved at all */
-        if (n == cap->count1)
+        // Only beep and flush if not moved at all
+        if (n == cap->count1) {
           beep_flush();
+        }
       } else {
-        if (!lineempty(curwin->w_cursor.lnum))
+        if (!LINEEMPTY(curwin->w_cursor.lnum)) {
           cap->oap->inclusive = true;
+        }
       }
       break;
     } else if (PAST_LINE) {
@@ -5123,13 +5120,12 @@ static void nv_left(cmdarg_T *cap)
         coladvance((colnr_T)MAXCOL);
         curwin->w_set_curswant = true;
 
-        /* When the NL before the first char has to be deleted we
-         * put the cursor on the NUL after the previous line.
-         * This is a very special case, be careful!
-         * Don't adjust op_end now, otherwise it won't work. */
-        if (       (cap->oap->op_type == OP_DELETE
-                    || cap->oap->op_type == OP_CHANGE)
-                   && !lineempty(curwin->w_cursor.lnum)) {
+        // When the NL before the first char has to be deleted we
+        // put the cursor on the NUL after the previous line.
+        // This is a very special case, be careful!
+        // Don't adjust op_end now, otherwise it won't work.
+        if ((cap->oap->op_type == OP_DELETE || cap->oap->op_type == OP_CHANGE)
+            && !LINEEMPTY(curwin->w_cursor.lnum)) {
           char_u *cp = get_cursor_pos_ptr();
 
           if (*cp != NUL) {
@@ -6098,10 +6094,11 @@ static void n_swapchar(cmdarg_T *cap)
   pos_T startpos;
   int did_change = 0;
 
-  if (checkclearopq(cap->oap))
+  if (checkclearopq(cap->oap)) {
     return;
+  }
 
-  if (lineempty(curwin->w_cursor.lnum) && vim_strchr(p_ww, '~') == NULL) {
+  if (LINEEMPTY(curwin->w_cursor.lnum) && vim_strchr(p_ww, '~') == NULL) {
     clearopbeep(cap->oap);
     return;
   }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2052,10 +2052,11 @@ void op_insert(oparg_T *oap, long count1)
       curwin->w_cursor = oap->end;
       check_cursor_col();
 
-      /* Works just like an 'i'nsert on the next character. */
-      if (!lineempty(curwin->w_cursor.lnum)
-          && oap->start_vcol != oap->end_vcol)
+      // Works just like an 'i'nsert on the next character.
+      if (!LINEEMPTY(curwin->w_cursor.lnum)
+          && oap->start_vcol != oap->end_vcol) {
         inc_cursor();
+      }
     }
   }
 
@@ -2180,9 +2181,10 @@ int op_change(oparg_T *oap)
   } else if (op_delete(oap) == FAIL)
     return FALSE;
 
-  if ((l > curwin->w_cursor.col) && !lineempty(curwin->w_cursor.lnum)
-      && !virtual_op)
+  if ((l > curwin->w_cursor.col) && !LINEEMPTY(curwin->w_cursor.lnum)
+      && !virtual_op) {
     inc_cursor();
+  }
 
   // check for still on same line (<CR> in inserted text meaningless)
   // skip blank lines too
@@ -2855,25 +2857,30 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
     }
   } else if (y_type == kMTLineWise) {
     lnum = curwin->w_cursor.lnum;
-    /* Correct line number for closed fold.  Don't move the cursor yet,
-     * u_save() uses it. */
-    if (dir == BACKWARD)
+    // Correct line number for closed fold.  Don't move the cursor yet,
+    // u_save() uses it.
+    if (dir == BACKWARD) {
       (void)hasFolding(lnum, &lnum, NULL);
-    else
+    } else {
       (void)hasFolding(lnum, NULL, &lnum);
-    if (dir == FORWARD)
-      ++lnum;
-    /* In an empty buffer the empty line is going to be replaced, include
-     * it in the saved lines. */
-    if ((bufempty() ? u_save(0, 2) : u_save(lnum - 1, lnum)) == FAIL)
+    }
+    if (dir == FORWARD) {
+      lnum++;
+    }
+    // In an empty buffer the empty line is going to be replaced, include
+    // it in the saved lines.
+    if ((BUFEMPTY() ? u_save(0, 2) : u_save(lnum - 1, lnum)) == FAIL) {
       goto end;
-    if (dir == FORWARD)
+    }
+    if (dir == FORWARD) {
       curwin->w_cursor.lnum = lnum - 1;
-    else
+    } else {
       curwin->w_cursor.lnum = lnum;
-    curbuf->b_op_start = curwin->w_cursor;      /* for mark_adjust() */
-  } else if (u_save_cursor() == FAIL)
+    }
+    curbuf->b_op_start = curwin->w_cursor;      // for mark_adjust()
+  } else if (u_save_cursor() == FAIL) {
     goto end;
+  }
 
   yanklen = (int)STRLEN(y_array[0]);
 
@@ -3997,7 +4004,7 @@ format_lines (
           && (do_second_indent || do_number_indent)
           && prev_is_end_par
           && curwin->w_cursor.lnum < curbuf->b_ml.ml_line_count) {
-        if (do_second_indent && !lineempty(curwin->w_cursor.lnum + 1)) {
+        if (do_second_indent && !LINEEMPTY(curwin->w_cursor.lnum + 1)) {
           if (leader_len == 0 && next_leader_len == 0) {
             /* no comment found */
             second_indent =

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1059,7 +1059,7 @@ void set_init_3(void)
     xfree(p);
   }
 
-  if (bufempty()) {
+  if (BUFEMPTY()) {
     int idx_ffs = findoption_len(S_LEN("ffs"));
 
     // Apply the first entry of 'fileformats' to the initial buffer.

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -593,7 +593,7 @@ static int pum_set_selected(int n, int repeat)
             && (curbuf->b_p_bt[2] == 'f')
             && (curbuf->b_p_bh[0] == 'w')) {
           // Already a "wipeout" buffer, make it empty.
-          while (!bufempty()) {
+          while (!BUFEMPTY()) {
             ml_delete((linenr_T)1, FALSE);
           }
         } else {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2227,10 +2227,11 @@ int findsent(int dir, long count)
           break;
         found_dot = TRUE;
       }
-      if (decl(&pos) == -1)
+      if (decl(&pos) == -1) {
         break;
-      /* when going forward: Stop in front of empty line */
-      if (lineempty(pos.lnum) && dir == FORWARD) {
+      }
+      // when going forward: Stop in front of empty line
+      if (LINEEMPTY(pos.lnum) && dir == FORWARD) {
         incl(&pos);
         goto found;
       }
@@ -2534,10 +2535,12 @@ int bck_word(long count, int bigword, int stop)
        */
       while (cls() == 0) {
         if (curwin->w_cursor.col == 0
-            && lineempty(curwin->w_cursor.lnum))
+            && LINEEMPTY(curwin->w_cursor.lnum)) {
           goto finished;
-        if (dec_cursor() == -1)         /* hit start of file, stop here */
+        }
+        if (dec_cursor() == -1) {       // hit start of file, stop here
           return OK;
+        }
       }
 
       /*
@@ -2601,10 +2604,12 @@ int end_word(long count, int bigword, int stop, int empty)
        */
       while (cls() == 0) {
         if (empty && curwin->w_cursor.col == 0
-            && lineempty(curwin->w_cursor.lnum))
+            && LINEEMPTY(curwin->w_cursor.lnum)) {
           goto finished;
-        if (inc_cursor() == -1)             /* hit end of file, stop here */
+        }
+        if (inc_cursor() == -1) {           // hit end of file, stop here
           return FAIL;
+        }
       }
 
       /*
@@ -2657,10 +2662,12 @@ bckend_word (
      * Move backward to end of the previous word
      */
     while (cls() == 0) {
-      if (curwin->w_cursor.col == 0 && lineempty(curwin->w_cursor.lnum))
+      if (curwin->w_cursor.col == 0 && LINEEMPTY(curwin->w_cursor.lnum)) {
         break;
-      if ((i = dec_cursor()) == -1 || (eol && i == 1))
+      }
+      if ((i = dec_cursor()) == -1 || (eol && i == 1)) {
         return OK;
+      }
     }
   }
   return OK;

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -7147,7 +7147,7 @@ void ex_spelldump(exarg_T *eap)
   set_option_value("spl",  dummy, (char *)spl, OPT_LOCAL);
   xfree(spl);
 
-  if (!bufempty()) {
+  if (!BUFEMPTY()) {
     return;
   }
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2268,12 +2268,14 @@ static void u_undoredo(int undo)
 
   curhead->uh_entry = newlist;
   curhead->uh_flags = new_flags;
-  if ((old_flags & UH_EMPTYBUF) && bufempty())
+  if ((old_flags & UH_EMPTYBUF) && BUFEMPTY()) {
     curbuf->b_ml.ml_flags |= ML_EMPTY;
-  if (old_flags & UH_CHANGED)
+  }
+  if (old_flags & UH_CHANGED) {
     changed();
-  else
+  } else {
     unchanged(curbuf, FALSE);
+  }
 
   /*
    * restore marks from before undo/redo

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -1722,7 +1722,7 @@ static void version_msg(char *s)
 /// Show the intro message when not editing a file.
 void maybe_intro_message(void)
 {
-  if (bufempty()
+  if (BUFEMPTY()
       && (curbuf->b_fname == NULL)
       && (firstwin->w_next == NULL)
       && (vim_strchr(p_shm, SHM_INTRO) == NULL)) {


### PR DESCRIPTION
#### vim-patch:8.0.0448: some macros are in lower case

Problem:    Some macros are in lower case, which can be confusing.
Solution:   Make a few lower case macros upper case.

https://github.com/vim/vim/commit/b5aedf3e228d35821591da9ae8501b61cf2e264c