### PR TITLE
[RFC] CmdlineChanged vim-patch:8.0.1445

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -521,10 +521,11 @@ CmdUndefined			When a user command is used but it isn't
 				command is defined.  An alternative is to
 				always define the user command and have it
 				invoke an autoloaded function.  See |autoload|.
- 							*CmdlineChanged*
-CmdlineChanged			After a change was made to the text in the
-				command line.  Be careful not to mess up
-				the command line, it may cause Vim to lock up.
+							*CmdlineChanged*
+CmdlineChanged			After a change was made to the text inside
+				command line.  Be careful not to mess up the
+				command line, it may cause Vim to lock up.
+				<afile> is set to the |cmdline-char|.
 							*CmdlineEnter*
 CmdlineEnter			After entering the command-line (including
 				non-interactive use of ":" in a mapping: use

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -21,6 +21,7 @@ return {
     'BufWritePre',            -- before writing a buffer
     'ChanInfo',               -- info was received about channel
     'ChanOpen',               -- channel was opened
+    'CmdLineChanged',         -- command line was modified
     'CmdLineEnter',           -- after entering cmdline mode
     'CmdLineLeave',           -- before leaving cmdline mode
     'CmdUndefined',           -- command undefined

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1804,6 +1804,13 @@ static int empty_pattern(char_u *p)
 
 static int command_line_changed(CommandLineState *s)
 {
+  // Trigger CmdlineChanged autocommands.
+  char firstcbuf[2];
+  firstcbuf[0] = s->firstc > 0 ? s->firstc : '-';
+  firstcbuf[1] = 0;
+  apply_autocmds(EVENT_CMDLINECHANGED, (char_u *)firstcbuf, (char_u *)firstcbuf,
+                   false, curbuf);
+
   // 'incsearch' highlighting.
   if (p_is && !cmd_silent && (s->firstc == '/' || s->firstc == '?')) {
     pos_T end_pos;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1805,11 +1805,35 @@ static int empty_pattern(char_u *p)
 static int command_line_changed(CommandLineState *s)
 {
   // Trigger CmdlineChanged autocommands.
-  char firstcbuf[2];
-  firstcbuf[0] = s->firstc > 0 ? s->firstc : '-';
-  firstcbuf[1] = 0;
-  apply_autocmds(EVENT_CMDLINECHANGED, (char_u *)firstcbuf, (char_u *)firstcbuf,
-                   false, curbuf);
+  if (has_event(EVENT_CMDLINECHANGED)) {
+    TryState tstate;
+    Error err = ERROR_INIT;
+    bool tl_ret = true;
+    dict_T *dict = get_vim_var_dict(VV_EVENT);
+
+    char firstcbuf[2];
+    firstcbuf[0] = s->firstc > 0 ? s->firstc : '-';
+    firstcbuf[1] = 0;
+
+    // set v:event to a dictionary with information about the commandline
+    tv_dict_add_str(dict, S_LEN("cmdtype"), firstcbuf);
+    tv_dict_add_nr(dict, S_LEN("cmdlevel"), ccline.level);
+    tv_dict_set_keys_readonly(dict);
+    try_enter(&tstate);
+
+    apply_autocmds(EVENT_CMDLINECHANGED, (char_u *)firstcbuf,
+                   (char_u *)firstcbuf, false, curbuf);
+    tv_dict_clear(dict);
+
+    tl_ret = try_leave(&tstate, &err);
+    if (!tl_ret && ERROR_SET(&err)) {
+      msg_putchar('\n');
+      msg_printf_attr(HL_ATTR(HLF_E)|MSG_HIST, (char *)e_autocmd_err, err.msg);
+      api_clear_error(&err);
+      redrawcmd();
+    }
+    tl_ret = true;
+  }
 
   // 'incsearch' highlighting.
   if (p_is && !cmd_silent && (s->firstc == '/' || s->firstc == '?')) {

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -818,6 +818,18 @@ func Test_QuitPre()
 endfunc
 
 func Test_Cmdline()
+  au! CmdlineChanged : let g:text = getcmdline()
+  let g:text = 0
+  call feedkeys(":echom 'hello'\<CR>", 'xt')
+  call assert_equal("echom 'hello'", g:text)
+  au! CmdlineChanged
+
+  au! CmdlineChanged : let g:entered = expand('<afile>')
+  let g:entered = 0
+  call feedkeys(":echom 'hello'\<CR>", 'xt')
+  call assert_equal(':', g:entered)
+  au! CmdlineChanged
+
   au! CmdlineEnter : let g:entered = expand('<afile>')
   au! CmdlineLeave : let g:left = expand('<afile>')
   let g:entered = 0


### PR DESCRIPTION
Problem:    Cannot act on edits in the command line.
Solution:   Add the CmdlineChanged autocommand event. (xtal8, closes vim/vim#2603,
            closes vim/vim#2524)

https://github.com/vim/vim/commit/153b704e20f9c269450a7d3ea8cafcf942579ab7

I'll look into adding some relevant `v:event` keys like cmdlevel