### PR TITLE
Fix :highlight completion displaying all cleared highlight groups

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4716,7 +4716,7 @@ ExpandFromContext (
       { EXPAND_MENUNAMES, get_menu_names, false, true },
       { EXPAND_SYNTAX, get_syntax_name, true, true },
       { EXPAND_SYNTIME, get_syntime_arg, true, true },
-      { EXPAND_HIGHLIGHT, (ExpandFunc)get_highlight_name, true, true },
+      { EXPAND_HIGHLIGHT, (ExpandFunc)get_highlight_name_iter, true, true },
       { EXPAND_EVENTS, get_event_name, true, true },
       { EXPAND_AUGROUP, get_augroup_name, true, true },
       { EXPAND_CSCOPE, get_cscope_name, true, true },

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7756,7 +7756,32 @@ static void highlight_list_two(int cnt, int attr)
 
 /*
  * Function given to ExpandGeneric() to obtain the list of group names.
- * Also used for synIDattr() function.
+ */
+const char *get_highlight_name_iter(expand_T *const xp, const int idx)
+  FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  // TODO(justinmk): 'xp' is unused
+  if (idx == highlight_ga.ga_len && include_none != 0) {
+    return "none";
+  } else if (idx == highlight_ga.ga_len + include_none
+      && include_default != 0) {
+    return "default";
+  } else if (idx == highlight_ga.ga_len + include_none + include_default
+      && include_link != 0) {
+    return "link";
+  } else if (idx == highlight_ga.ga_len + include_none + include_default + 1
+      && include_link != 0) {
+    return "clear";
+  } else if (idx < 0) {
+    return NULL;
+  }
+  if (HL_TABLE()[idx].sg_cleared)
+    return (const char *)"";
+  return (const char *)HL_TABLE()[idx].sg_name;
+}
+
+/*
+ * Used for synIDattr() function.
  */
 const char *get_highlight_name(expand_T *const xp, const int idx)
   FUNC_ATTR_WARN_UNUSED_RESULT


### PR DESCRIPTION
:highlight Err<Tab> will display more that 15 Error groups in my setup.
Properly skip cleared highlight groups.