### PR TITLE
test/legacy: robust cleanup, filenames

### DIFF
--- a/test/functional/eval/buf_functions_spec.lua
+++ b/test/functional/eval/buf_functions_spec.lua
@@ -14,6 +14,7 @@ local curbufmeths = helpers.curbufmeths
 local curwinmeths = helpers.curwinmeths
 local curtabmeths = helpers.curtabmeths
 local get_pathsep = helpers.get_pathsep
+local rmdir = helpers.rmdir
 
 local fname = 'Xtest-functional-eval-buf_functions'
 local fname2 = fname .. '.2'
@@ -61,7 +62,7 @@ describe('bufname() function', function()
     lfs.mkdir(dirname)
   end)
   after_each(function()
-    lfs.rmdir(dirname)
+    rmdir(dirname)
   end)
   it('returns expected buffer name', function()
     eq('', funcs.bufname('%'))  -- Buffer has no name yet
@@ -143,7 +144,7 @@ describe('bufwinnr() function', function()
     lfs.mkdir(dirname)
   end)
   after_each(function()
-    lfs.rmdir(dirname)
+    rmdir(dirname)
   end)
   it('returns expected window number', function()
     eq(1, funcs.bufwinnr('%'))

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -6,6 +6,7 @@ local command = helpers.command
 local get_pathsep = helpers.get_pathsep
 local eq = helpers.eq
 local funcs = helpers.funcs
+local rmdir = helpers.rmdir
 
 local file_prefix = 'Xtest-functional-ex_cmds-mksession_spec'
 
@@ -20,7 +21,7 @@ describe(':mksession', function()
 
   after_each(function()
     os.remove(session_file)
-    lfs.rmdir(tab_dir)
+    rmdir(tab_dir)
   end)
 
   it('restores tab-local working directories', function()

--- a/test/functional/ex_cmds/mkview_spec.lua
+++ b/test/functional/ex_cmds/mkview_spec.lua
@@ -24,7 +24,7 @@ describe(':mkview', function()
   after_each(function()
     -- Remove any views created in the view directory
     rmdir(view_dir)
-    lfs.rmdir(local_dir)
+    rmdir(local_dir)
   end)
 
   it('viewoption curdir restores local current directory', function()

--- a/test/functional/legacy/008_autocommands_spec.lua
+++ b/test/functional/legacy/008_autocommands_spec.lua
@@ -5,9 +5,10 @@ local helpers = require('test.functional.helpers')(after_each)
 local feed, source = helpers.feed, helpers.source
 local clear, feed_command, expect, eq, eval = helpers.clear, helpers.feed_command, helpers.expect, helpers.eq, helpers.eval
 local write_file, wait, dedent = helpers.write_file, helpers.wait, helpers.dedent
-local io = require('io')
+local read_file = helpers.read_file
 
 describe('autocommands that delete and unload buffers:', function()
+  local test_file = 'Xtest-008_autocommands.out'
   local text1 = dedent([[
     start of Xxx1
       test
@@ -18,7 +19,7 @@ describe('autocommands that delete and unload buffers:', function()
     write_file('Xxx2', text2..'\n')
   end)
   teardown(function()
-    os.remove('test.out')
+    os.remove(test_file)
     os.remove('Xxx1')
     os.remove('Xxx2')
   end)
@@ -65,7 +66,8 @@ describe('autocommands that delete and unload buffers:', function()
 	endwhile
       endfunc
       func WriteToOut()
-	edit! test.out
+	edit! ]]..test_file..[[
+
 	$put ='VimLeave done'
 	write
       endfunc
@@ -86,6 +88,6 @@ describe('autocommands that delete and unload buffers:', function()
     feed_command('q')
     wait()
     eq('VimLeave done',
-       string.match(io.open('test.out', 'r'):read('*all'), "^%s*(.-)%s*$"))
+       string.match(read_file(test_file), "^%s*(.-)%s*$"))
   end)
 end)

--- a/test/functional/legacy/096_location_list_spec.lua
+++ b/test/functional/legacy/096_location_list_spec.lua
@@ -11,10 +11,10 @@ local source = helpers.source
 local clear, command, expect = helpers.clear, helpers.command, helpers.expect
 
 describe('location list', function()
+  local test_file = 'Xtest-096_location_list.out'
   setup(clear)
-
   teardown(function()
-    os.remove('test.out')
+    os.remove(test_file)
   end)
 
   it('is working', function()
@@ -70,9 +70,9 @@ describe('location list', function()
       endfor
     ]])
 
-    -- Set up the result buffer "test.out".
+    -- Set up the result buffer.
     command('enew')
-    command('w! test.out')
+    command('w! '..test_file)
     command('b 1')
 
     -- Test A.
@@ -99,7 +99,7 @@ describe('location list', function()
     command([[let locationListFileName = substitute(getline(line('.')), '\([^|]*\)|.*', '\1', '')]])
     command('wincmd n')
     command('wincmd K')
-    command('b test.out')
+    command('b '..test_file)
 
     -- Prepare test output and write it to the result buffer.
     command([[let fileName = substitute(fileName, '\\', '/', 'g')]])
@@ -132,7 +132,7 @@ describe('location list', function()
     command('let numberOfWindowsOpen = winnr("$")')
     command('wincmd n')
     command('wincmd K')
-    command('b test.out')
+    command('b '..test_file)
 
     -- Prepare test output and write it to the result buffer.
     command('call append(line("$"), "Test B:")')
@@ -170,7 +170,7 @@ describe('location list', function()
     command('let bufferName = expand("%")')
     command('wincmd n')
     command('wincmd K')
-    command('b test.out')
+    command('b '..test_file)
 
     -- Prepare test output and write it to the result buffer.
     command([[let bufferName = substitute(bufferName, '\\', '/', 'g')]])

--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -3,6 +3,7 @@ local eq, nvim_eval, nvim_command, nvim, exc_exec, funcs, nvim_feed, curbuf =
   helpers.eq, helpers.eval, helpers.command, helpers.nvim, helpers.exc_exec,
   helpers.funcs, helpers.feed, helpers.curbuf
 local neq = helpers.neq
+local read_file = helpers.read_file
 
 local mpack = require('mpack')
 
@@ -2152,9 +2153,7 @@ describe('plugin/shada.vim', function()
   end)
 
   local shada_eq = function(expected, fname_)
-    local fd = io.open(fname_)
-    local mpack_result = fd:read('*a')
-    fd:close()
+    local mpack_result = read_file(fname_)
     mpack_eq(expected, mpack_result)
   end
 
@@ -2278,7 +2277,7 @@ describe('plugin/shada.vim', function()
         '  + f            file name    ["foo"]',
         '  + l            line number  2',
         '  + c            column       -200',
-      }, eol) .. eol, io.open(fname .. '.tst'):read('*a'))
+      }, eol) .. eol, read_file(fname .. '.tst'))
       shada_eq({{
         timestamp=0,
         type=8,
@@ -2326,7 +2325,7 @@ describe('plugin/shada.vim', function()
         'Jump with timestamp ' .. epoch .. ':',
         '  % Key________  Description  Value',
         '  + n            name         \'A\'',
-      }, eol) .. eol, io.open(fname .. '.tst'):read('*a'))
+      }, eol) .. eol, read_file(fname .. '.tst'))
       shada_eq({{
         timestamp=0,
         type=8,
@@ -2383,7 +2382,7 @@ describe('plugin/shada.vim', function()
         '  + f            file name    ["foo"]',
         '  + l            line number  2',
         '  + c            column       -200',
-      }, eol) .. eol, io.open(fname .. '.tst'):read('*a'))
+      }, eol) .. eol, read_file(fname .. '.tst'))
       shada_eq({{
         timestamp=0,
         type=8,


### PR DESCRIPTION
Use unique filenames.
Use read_file() instead of io.popen(), to ensures the file is closed.
Use helpers.rmdir(), it is far more robust than lfs.

closes #7911