### PR TITLE
os_system(): do not set up input stream for empty string

### DIFF
--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -260,6 +260,7 @@ describe('system()', function()
     end)
     it('works with an empty string', function()
       eq("test\n", eval('system("echo test", "")'))
+      eq(2, eval("1+1"))  -- Still alive?
     end)
   end)
 


### PR DESCRIPTION
Test failure:
test/functional/eval/system_spec.lua: "works with an empty string"
E5677: Error writing input to shell-command: EPIPE

ref https://github.com/neovim/neovim/pull/6558#issuecomment-361061035