### PR TITLE
exit: annotate FUNC_ATTR_NORETURN functions

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4466,7 +4466,7 @@ do_arg_all (
   // leaving an empty tab page when executed locally.
   if (keep_tabs && BUFEMPTY() && curbuf->b_nwindows == 1
       && curbuf->b_ffname == NULL && !curbuf->b_changed) {
-    use_firstwin = TRUE;
+    use_firstwin = true;
   }
 
   for (i = 0; i < count && i < opened_len && !got_int; ++i) {

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -855,7 +855,7 @@ void ex_diffpatch(exarg_T *eap)
 {
   char_u *buf = NULL;
   win_T *old_curwin = curwin;
-  char_u *newname = NULL; // name of patched file buffer
+  char_u *newname = NULL;  // name of patched file buffer
   char_u *esc_name = NULL;
 
 #ifdef UNIX
@@ -886,9 +886,9 @@ void ex_diffpatch(exarg_T *eap)
 
   esc_name = vim_strsave_shellescape(
 #ifdef UNIX
-                                             fullname != NULL ? fullname :
+                                     fullname != NULL ? fullname :
 #endif
-                                             eap->arg, true, true);
+                                     eap->arg, true, true);
   if (esc_name == NULL) {
     goto theend;
   }

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -577,8 +577,9 @@ int main(int argc, char **argv)
   return 0;
 }
 
-/* Exit properly */
+/// Exit properly
 void getout(int exitval)
+  FUNC_ATTR_NORETURN
 {
   tabpage_T   *tp, *next_tp;
 

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2610,13 +2610,12 @@ int match_user(char_u *name)
   return result;
 }
 
-/*
- * Preserve files and exit.
- * When called IObuff must contain a message.
- * NOTE: This may be called from deathtrap() in a signal handler, avoid unsafe
- * functions, such as allocating memory.
- */
+/// Preserve files and exit.
+/// @note IObuff must contain a message.
+/// @note This may be called from deadly_signal() in a signal handler, avoid
+///       unsafe functions, such as allocating memory.
 void preserve_exit(void)
+  FUNC_ATTR_NORETURN
 {
   // 'true' when we are sure to exit, e.g., after a deadly signal
   static bool really_exiting = false;

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -133,7 +133,8 @@ void mch_free_acl(vim_acl_T aclent)
 }
 #endif
 
-void mch_exit(int r) FUNC_ATTR_NORETURN
+void mch_exit(int r)
+  FUNC_ATTR_NORETURN
 {
   exiting = true;
 


### PR DESCRIPTION
This should fix a particular false positive from clang 5.0.0 scan-build,
which thinks that nlua_init() can continue after preserve_exit().