### PR TITLE
[RFC] Ensure build works without LuaJIT available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,10 @@ jobs:
       sudo: true
     - os: linux
       compiler: gcc
-      env: FUNCTIONALTEST=functionaltest-lua
+      env: >
+        FUNCTIONALTEST=functionaltest-lua
+        CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
+        DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED_LUAJIT=OFF"
     - os: linux
       # Travis creates a cache per compiler. Set a different value here to
       # store 32-bit dependencies in a separate cache.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,28 +515,6 @@ if(BUSTED_PRG)
     list(APPEND TEST_TARGET_ARGS "USES_TERMINAL")
   endif()
 
-  if(${CMAKE_VERSION} VERSION_LESS 2.8.12)
-    if(CMAKE_GENERATOR MATCHES "Visual Studio")
-      set(TEST_LIBNVIM_PATH ${CMAKE_BINARY_DIR}/lib/nvim-test.dll)
-    else()
-      get_target_property(TEST_LIBNVIM_PATH nvim-test LOCATION)
-    endif()
-    configure_file(
-      ${CMAKE_SOURCE_DIR}/test/config/paths.lua.in
-      ${CMAKE_BINARY_DIR}/test/config/paths.lua)
-  else()
-    # To avoid duplicating paths.lua.in while we still support CMake < 2.8.12,
-    # use configure_file() to add the generator expression and then generate
-    # the final file
-    set(TEST_LIBNVIM_PATH $<TARGET_FILE:nvim-test>)
-    configure_file(
-      ${CMAKE_SOURCE_DIR}/test/config/paths.lua.in
-      ${CMAKE_BINARY_DIR}/test/config/paths.lua.gen)
-    file(GENERATE
-      OUTPUT ${CMAKE_BINARY_DIR}/test/config/paths.lua
-      INPUT ${CMAKE_BINARY_DIR}/test/config/paths.lua.gen)
-  endif()
-
   set(UNITTEST_PREREQS nvim-test unittest-headers)
   set(FUNCTIONALTEST_PREREQS nvim printargs-test shell-test)
   if(NOT WIN32)
@@ -571,6 +549,32 @@ if(BUSTED_PRG)
       ${TEST_TARGET_ARGS})
   else()
     message(WARNING "disabling unit tests: no Luajit FFI in ${LUA_PRG}")
+  endif()
+
+  if(${CMAKE_VERSION} VERSION_LESS 2.8.12)
+    if(CMAKE_GENERATOR MATCHES "Visual Studio")
+      set(TEST_LIBNVIM_PATH ${CMAKE_BINARY_DIR}/lib/nvim-test.dll)
+    else()
+      get_target_property(TEST_LIBNVIM_PATH nvim-test LOCATION)
+    endif()
+    configure_file(
+      ${CMAKE_SOURCE_DIR}/test/config/paths.lua.in
+      ${CMAKE_BINARY_DIR}/test/config/paths.lua)
+  else()
+    # To avoid duplicating paths.lua.in while we still support CMake < 2.8.12,
+    # use configure_file() to add the generator expression and then generate
+    # the final file
+    if(LUA_HAS_FFI)
+      set(TEST_LIBNVIM_PATH $<TARGET_FILE:nvim-test>)
+    else()
+      set(TEST_LIBNVIM_PATH "")
+    endif()
+    configure_file(
+      ${CMAKE_SOURCE_DIR}/test/config/paths.lua.in
+      ${CMAKE_BINARY_DIR}/test/config/paths.lua.gen)
+    file(GENERATE
+      OUTPUT ${CMAKE_BINARY_DIR}/test/config/paths.lua
+      INPUT ${CMAKE_BINARY_DIR}/test/config/paths.lua.gen)
   endif()
 
   add_custom_target(functionaltest

--- a/ci/common/build.sh
+++ b/ci/common/build.sh
@@ -71,9 +71,11 @@ build_nvim() {
       exit 1
     fi
 
-    echo "Building nvim-test."
-    if ! top_make nvim-test ; then
-      exit 1
+    if test "${FUNCTIONALTEST}" != "functionaltest-lua"; then
+      echo "Building nvim-test."
+      if ! top_make nvim-test ; then
+        exit 1
+      fi
     fi
   fi
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -22,7 +22,9 @@ enter_suite tests
 if test "$CLANG_SANITIZER" != "TSAN" ; then
   # Additional threads are only created when the builtin UI starts, which
   # doesn't happen in the unit/functional tests
-  run_test run_unittests
+  if test "${FUNCTIONALTEST}" != "functionaltest-lua"; then
+    run_test run_unittests
+  fi
   run_test run_functionaltests
 fi
 run_test run_oldtests

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -951,9 +951,20 @@ describe('api', function()
           end
         end)
         if not err then
-          msg = format_string('Error while processing test (%r, %s):\n%s',
-                              str, FLAGS_TO_STR[flags], msg)
-          error(msg)
+          if type(msg) == 'table' then
+            local merr, new_msg = pcall(
+              format_string, 'table error:\n%s\n\n(%r)', msg.message, msg)
+            if merr then
+              msg = new_msg
+            else
+              msg = format_string('table error without .message:\n(%r)',
+                                  msg)
+            end
+          elseif type(msg) ~= 'string' then
+            msg = format_string('non-string non-table error:\n%r', msg)
+          end
+          error(format_string('Error while processing test (%r, %s):\n%s',
+                              str, FLAGS_TO_STR[flags], msg))
         end
       end
     end

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -66,13 +66,13 @@ describe(':Man', function()
         ithis <C-v><ESC>[1mis <C-v><ESC>[3ma <C-v><ESC>[4mtest<C-v><ESC>[0m
         <C-v><ESC>[4mwith<C-v><ESC>[24m <C-v><ESC>[4mescaped<C-v><ESC>[24m <C-v><ESC>[4mtext<C-v><ESC>[24m<ESC>]])
 
-      screen:expect([[
+      screen:expect([=[
       this ^[[1mis ^[[3ma ^[[4mtest^[[0m                  |
       ^[[4mwith^[[24m ^[[4mescaped^[[24m ^[[4mtext^[[24^m  |
       ~                                                   |
       ~                                                   |
                                                           |
-      ]])
+      ]=])
 
       eval('man#init_pager()')
 

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -423,7 +423,7 @@ format_luav = function(v, indent, opts)
     if opts.literal_strings then
       ret = v
     else
-      quote = opts.dquote_strings and '"' or '\''
+      local quote = opts.dquote_strings and '"' or '\''
       ret = quote .. tostring(v):gsub(
         opts.dquote_strings and '["\\]' or '[\'\\]',
         '\\%0'):gsub(
@@ -493,7 +493,7 @@ local function format_string(fmt, ...)
       arg = getarg()
     end
     if subfmt:sub(-1) == 'r' or subfmt:sub(-1) == 'q' then
-      -- %r is like built-in %q, but it is supposed to single-quote strings and 
+      -- %r is like built-in %q, but it is supposed to single-quote strings and
       -- not double-quote them, and also work not only for strings.
       -- Builtin %q is replaced here as it gives invalid and inconsistent with
       -- luajit results for e.g. "\e" on lua: luajit transforms that into `\27`,

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -423,11 +423,13 @@ format_luav = function(v, indent, opts)
     if opts.literal_strings then
       ret = v
     else
-      ret = tostring(v):gsub('[\'\\]', '\\%0'):gsub(
-        '[%z\1-\31]', function(match)
-          return SUBTBL[match:byte() + 1]
-        end)
-      ret = '\'' .. ret .. '\''
+      quote = opts.dquote_strings and '"' or '\''
+      ret = quote .. tostring(v):gsub(
+        opts.dquote_strings and '["\\]' or '[\'\\]',
+        '\\%0'):gsub(
+          '[%z\1-\31]', function(match)
+            return SUBTBL[match:byte() + 1]
+          end) .. quote
     end
   elseif type(v) == 'table' then
     if v == REMOVE_THIS then
@@ -490,11 +492,14 @@ local function format_string(fmt, ...)
     if subfmt:sub(-1) ~= '%' then
       arg = getarg()
     end
-    if subfmt:sub(-1) == 'r' then
-      -- %r is like %q, but it is supposed to single-quote strings and not
-      -- double-quote them, and also work not only for strings.
+    if subfmt:sub(-1) == 'r' or subfmt:sub(-1) == 'q' then
+      -- %r is like built-in %q, but it is supposed to single-quote strings and 
+      -- not double-quote them, and also work not only for strings.
+      -- Builtin %q is replaced here as it gives invalid and inconsistent with
+      -- luajit results for e.g. "\e" on lua: luajit transforms that into `\27`,
+      -- lua leaves as-is.
+      arg = format_luav(arg, nil, {dquote_strings = (subfmt:sub(-1) == 'q')})
       subfmt = subfmt:sub(1, -2) .. 's'
-      arg = format_luav(arg)
     end
     if subfmt == '%e' then
       return format_float(arg)

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -5025,7 +5025,7 @@ return function(itp, _check_parsing, hl, fmtn)
       --           0123456789012345
       --           0         1
       ast = {
-        [[DoubleQuotedString(val="\8\27\12\13\9\\"):0:0:"\b\e\f\r\t\\"]],
+        [[DoubleQuotedString(val="\008\027\012\r\t\\"):0:0:"\b\e\f\r\t\\"]],
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5040,7 +5040,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\n\n"', {
       --           01234
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\\n\\\n"', ':0:0:"\\n\n"'),
+        fmtn('DoubleQuotedString', 'val="\\n\\n"', ':0:0:"\\n\n"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5051,7 +5051,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\x00"', {
       --           012345
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0"', ':0:0:"\\x00"'),
+        fmtn('DoubleQuotedString', 'val="\\000"', ':0:0:"\\x00"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5071,7 +5071,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\xF"', {
       --           012345
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\15"', ':0:0:"\\xF"'),
+        fmtn('DoubleQuotedString', 'val="\\015"', ':0:0:"\\xF"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5126,7 +5126,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\xF', {
       --           0123
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\15"', ':0:0:"\\xF'),
+        fmtn('DoubleQuotedString', 'val="\\015"', ':0:0:"\\xF'),
       },
       err = {
         arg = '"\\xF',
@@ -5190,7 +5190,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\xFX"', {
       --           012345
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\15X"', ':0:0:"\\xFX"'),
+        fmtn('DoubleQuotedString', 'val="\\015X"', ':0:0:"\\xFX"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5202,7 +5202,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\XFX"', {
       --           012345
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\15X"', ':0:0:"\\XFX"'),
+        fmtn('DoubleQuotedString', 'val="\\015X"', ':0:0:"\\XFX"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5262,7 +5262,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\x0X"', {
       --           012345
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\x0X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\x0X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5274,7 +5274,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\X0X"', {
       --           012345
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\X0X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\X0X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5286,7 +5286,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\u0X"', {
       --           012345
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\u0X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\u0X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5298,7 +5298,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\U0X"', {
       --           012345
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\U0X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U0X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5310,7 +5310,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\x00X"', {
       --           0123456
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\x00X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\x00X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5322,7 +5322,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\X00X"', {
       --           0123456
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\X00X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\X00X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5334,7 +5334,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\u00X"', {
       --           0123456
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\u00X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\u00X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5346,7 +5346,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\U00X"', {
       --           0123456
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\U00X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U00X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5358,7 +5358,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\u000X"', {
       --           01234567
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\u000X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\u000X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5370,7 +5370,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\U000X"', {
       --           01234567
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\U000X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U000X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5382,7 +5382,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\u0000X"', {
       --           012345678
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\u0000X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\u0000X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5394,7 +5394,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\U0000X"', {
       --           012345678
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\U0000X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U0000X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5406,7 +5406,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\U00000X"', {
       --           0123456789
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\U00000X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U00000X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5419,7 +5419,7 @@ return function(itp, _check_parsing, hl, fmtn)
       --           01234567890
       --           0         1
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\U000000X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U000000X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5432,7 +5432,7 @@ return function(itp, _check_parsing, hl, fmtn)
       --           012345678901
       --           0         1
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\U0000000X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U0000000X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5445,7 +5445,7 @@ return function(itp, _check_parsing, hl, fmtn)
       --           0123456789012
       --           0         1
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0X"', ':0:0:"\\U00000000X"'),
+        fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U00000000X"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5506,7 +5506,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\0"', {
       --           0123
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0"', ':0:0:"\\0"'),
+        fmtn('DoubleQuotedString', 'val="\\000"', ':0:0:"\\0"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5517,7 +5517,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\00"', {
       --           01234
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0"', ':0:0:"\\00"'),
+        fmtn('DoubleQuotedString', 'val="\\000"', ':0:0:"\\00"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5528,7 +5528,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\000"', {
       --           012345
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\0"', ':0:0:"\\000"'),
+        fmtn('DoubleQuotedString', 'val="\\000"', ':0:0:"\\000"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5620,7 +5620,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\<C-u>"', {
       --           012345
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\21"', ':0:0:"\\<C-u>"'),
+        fmtn('DoubleQuotedString', 'val="\\021"', ':0:0:"\\<C-u>"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -7119,7 +7119,7 @@ return function(itp, _check_parsing, hl, fmtn)
               'Or:0:0:|',
               children = {
                 'Missing:0:0:',
-                fmtn('DoubleQuotedString', 'val="\\27"', ':0:1:"\\e"'),
+                fmtn('DoubleQuotedString', 'val="\\027"', ':0:1:"\\e"'),
               },
             },
           },
@@ -7180,9 +7180,9 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('InvalidDoubleQuotedUnknownEscape', '\\<'),
     })
     check_parsing('"\\1', {
-      --           012
+      --           01 2
       ast = {
-        fmtn('DoubleQuotedString', 'val="\\1"', ':0:0:"\\1'),
+        fmtn('DoubleQuotedString', 'val="\\001"', ':0:0:"\\1'),
       },
       err = {
         arg = '"\\1',

--- a/third-party/cmake/BuildLua.cmake
+++ b/third-party/cmake/BuildLua.cmake
@@ -71,6 +71,7 @@ set(LUA_CONFIGURE_COMMAND
       -e "s@-lncurses@@g"
       -i ${DEPS_BUILD_DIR}/src/lua/src/Makefile &&
   sed -e "/#define LUA_USE_READLINE/d"
+      -e "s@\\(#define LUA_ROOT[ 	]*\"\\)/usr/local@\\1${DEPS_INSTALL_DIR}@"
       -i ${DEPS_BUILD_DIR}/src/lua/src/luaconf.h)
 set(LUA_INSTALL_TOP_ARG "INSTALL_TOP=${DEPS_INSTALL_DIR}")
 set(LUA_BUILD_COMMAND

--- a/third-party/cmake/BuildLua.cmake
+++ b/third-party/cmake/BuildLua.cmake
@@ -84,14 +84,13 @@ BuildLua(CONFIGURE_COMMAND ${LUA_CONFIGURE_COMMAND}
   BUILD_COMMAND ${LUA_BUILD_COMMAND}
   INSTALL_COMMAND ${LUA_INSTALL_COMMAND})
 list(APPEND THIRD_PARTY_DEPS lua)
-add_dependencies(lua busted)
 
 set(BUSTED ${DEPS_INSTALL_DIR}/bin/busted)
 set(BUSTED_LUA ${BUSTED}-lua)
 
 add_custom_command(OUTPUT ${BUSTED_LUA}
   COMMAND sed -e 's/^exec/exec $$LUA_DEBUGGER/' -e 's/jit//g' < ${BUSTED} > ${BUSTED_LUA} && chmod +x ${BUSTED_LUA}
-  DEPENDS lua)
+  DEPENDS lua busted)
 add_custom_target(busted-lua
   DEPENDS ${DEPS_INSTALL_DIR}/bin/busted-lua)
 

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -130,12 +130,30 @@ add_custom_target(inspect
 
 list(APPEND THIRD_PARTY_DEPS inspect)
 
+if((NOT USE_BUNDLED_LUAJIT) AND USE_BUNDLED_LUA)
+  # DEPENDS on the previous module, because Luarocks breaks if parallel.
+  add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/luabitop
+    COMMAND ${LUAROCKS_BINARY}
+    ARGS build luabitop ${LUAROCKS_BUILDARGS}
+    DEPENDS inspect)
+  add_custom_target(luabitop
+    DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/luabitop)
+
+  list(APPEND THIRD_PARTY_DEPS luabitop)
+endif()
+
 if(USE_BUNDLED_BUSTED)
+  if((NOT USE_BUNDLED_LUAJIT) AND USE_BUNDLED_LUA)
+    set(PENLIGHT_DEPENDS luabitop)
+  else()
+    set(PENLIGHT_DEPENDS inspect)
+  endif()
+
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight/1.3.2-2
     COMMAND ${LUAROCKS_BINARY}
     ARGS build penlight 1.3.2-2 ${LUAROCKS_BUILDARGS}
-    DEPENDS inspect)
+    DEPENDS ${PENLIGHT_DEPENDS})
   add_custom_target(penlight
     DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight/1.3.2-2)
 

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -56,13 +56,16 @@ if(UNIX OR (MINGW AND CMAKE_CROSSCOMPILING))
   if(USE_BUNDLED_LUAJIT)
     list(APPEND LUAROCKS_OPTS
       --with-lua=${HOSTDEPS_INSTALL_DIR}
-      --with-lua-include=${HOSTDEPS_INSTALL_DIR}/include/luajit-2.0)
+      --with-lua-include=${HOSTDEPS_INSTALL_DIR}/include/luajit-2.0
+      --lua-suffix=jit)
+  elseif(USE_BUNDLED_LUA)
+    list(APPEND LUAROCKS_OPTS
+      --with-lua=${HOSTDEPS_INSTALL_DIR})
   endif()
 
   BuildLuarocks(
     CONFIGURE_COMMAND ${DEPS_BUILD_DIR}/src/luarocks/configure
       --prefix=${HOSTDEPS_INSTALL_DIR} --force-config ${LUAROCKS_OPTS}
-      --lua-suffix=jit
     INSTALL_COMMAND ${MAKE_PRG} bootstrap)
 elseif(MSVC OR MINGW)
 
@@ -94,6 +97,8 @@ if(USE_BUNDLED_LUAJIT)
   if(MINGW AND CMAKE_CROSSCOMPILING)
     add_dependencies(luarocks luajit_host)
   endif()
+elseif(USE_BUNDLED_LUA)
+  add_dependencies(luarocks lua)
 endif()
 
 # DEPENDS on the previous module, because Luarocks breaks if parallel.


### PR DESCRIPTION
@teto ran into the below build failure, which this PR intends to fix (and cover
in CI to avoid regressions).

```
 -DCMAKE_INSTALL_PREFIX=/nix/store/szzyx7ay5j573s75wgiv421my2a8wvkb-neovim-local -DPREFER_LUA=ON -DLUA_PRG=/nix/store/8fm9n1w6janc5cvhn4dxnlkgdvflhxbx-lua-5.1.5-env/bin/lua -DLUA_PRG=/nix/store/8fm9n1w6janc5cvhn4dxnlkgdvflhxbx-lua-5.1.5-env/bin/lua -DCMAKE_BUILD_TYPE=Debug -DBUSTED_PRG=/nix/store/8fm9n1w6janc5cvhn4dxnlkgdvflhxbx-lua-5.1.5-env/bin/busted 
-- Replacing -O3 in CMAKE_C_FLAGS_RELEASE with -O2.
-- Could NOT find LuaJit (missing: LUAJIT_LIBRARY LUAJIT_INCLUDE_DIR) 
-- Found Iconv 
-- Checking Lua interpreter /nix/store/8fm9n1w6janc5cvhn4dxnlkgdvflhxbx-lua-5.1.5-env/bin/lua
-- Using the Lua interpreter /nix/store/8fm9n1w6janc5cvhn4dxnlkgdvflhxbx-lua-5.1.5-env/bin/lua.
-- MIN_LOG_LEVEL not specified
CMake Warning at CMakeLists.txt:573 (message):
  disabling unit tests: no Luajit FFI in
  /nix/store/8fm9n1w6janc5cvhn4dxnlkgdvflhxbx-lua-5.1.5-env/bin/lua
-- Configuring done
CMake Error at CMakeLists.txt:535 (file):
  Error evaluating generator expression:
    $<TARGET_FILE:nvim-test>
  No target "nvim-test"
CMake Error at CMakeLists.txt:535 (file):
  Error evaluating generator expression:
```