### PR TITLE
[RFC] vim-patch:8.0.0470,8.0.0471

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -197,6 +197,7 @@ endif
 
 " Names of flaky tests.
 let s:flaky = [
+      \ 'Test_exit_callback_interval()',
       \ 'Test_with_partial_callback()',
       \ 'Test_oneshot()',
       \ 'Test_lambda_with_timer()',

--- a/src/nvim/testdir/test_help_tagjump.vim
+++ b/src/nvim/testdir/test_help_tagjump.vim
@@ -18,6 +18,52 @@ func Test_help_tagjump()
   call assert_true(getline('.') =~ '\*help.txt\*')
   helpclose
 
+  help |
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*bar\*')
+  helpclose
+
+  help "*
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*quotestar\*')
+  helpclose
+
+  help sm?le
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*:smile\*')
+  helpclose
+
+  help :?
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*:?\*')
+  helpclose
+
+  help FileW*Post
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*FileWritePost\*')
+  helpclose
+
+  help `ls`
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*:ls\*')
+  helpclose
+
+  help ^X
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*CTRL-X\*')
+  helpclose
+
+  help i_^_CTRL-D
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*i_^_CTRL-D\*')
+  helpclose
+
+  exec "help \<C-V>"
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*CTRL-V\*')
+  helpclose
+
+
   exec "help! ('textwidth'"
   call assert_equal("help", &filetype)
   call assert_true(getline('.') =~ "\\*'textwidth'\\*")
@@ -46,6 +92,16 @@ func Test_help_tagjump()
   exec "help! {address}."
   call assert_equal("help", &filetype)
   call assert_true(getline('.') =~ '\*{address}\*')
+  helpclose
+
+  exusage
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*:index\*')
+  helpclose
+
+  viusage
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*normal-index\*')
   helpclose
 endfunc
 

--- a/src/nvim/testdir/test_help_tagjump.vim
+++ b/src/nvim/testdir/test_help_tagjump.vim
@@ -28,9 +28,9 @@ func Test_help_tagjump()
   call assert_true(getline('.') =~ '\*quotestar\*')
   helpclose
 
-  help sm?le
+  help sp?it
   call assert_equal("help", &filetype)
-  call assert_true(getline('.') =~ '\*:smile\*')
+  call assert_true(getline('.') =~ '\*:split\*')
   helpclose
 
   help :?


### PR DESCRIPTION
#### vim-patch:8.0.0470: not enough testing for help commands

Problem:    Not enough testing for help commands.
Solution:   Add a few more help tests. (Dominique Pelle, closes vim/vim#1565)

https://github.com/vim/vim/commit/751ba616d1c47de2c273b269df06c36a7ed141a2


#### vim-patch:8.0.0471: exit callback test sometimes fails

Problem:    Exit callback test sometimes fails.
Solution:   Add it to the list of flaky tests.

https://github.com/vim/vim/commit/0529b3eb01fcfd18c0644f8ece9ea107dd460a0f