### PR TITLE
:terminal Enter/Leave should not increment jumplist

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -61,7 +61,6 @@
 #include "nvim/edit.h"
 #include "nvim/mouse.h"
 #include "nvim/memline.h"
-#include "nvim/mark.h"
 #include "nvim/map.h"
 #include "nvim/misc1.h"
 #include "nvim/move.h"
@@ -376,8 +375,6 @@ void terminal_enter(void)
   // Ensure the terminal is properly sized.
   terminal_resize(s->term, 0, 0);
 
-  checkpcmark();
-  setpcmark();
   int save_state = State;
   s->save_rd = RedrawingDisabled;
   State = TERM_FOCUS;


### PR DESCRIPTION
The old behavior is probably not justified, for the usual reason:
terminal buffers may have interactive processes, so cursor placement is
arbitrary, therefore tracking it in the jumplist is useless (or worse).

N.B.: per the docstring for `checkpcmark()` it looks like we were
calling `checkpcmark()` and `setpcmark()` in the wrong order.

closes #3723