### PR TITLE
[RFC] macOS: system('pbcopy') empties the pasteboard

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -126,7 +126,7 @@ endfunction
 function! s:check_clipboard() abort
   call health#report_start('Clipboard (optional)')
 
-  if !empty($TMUX) && executable('tmux') && executable('pbcopy') && !s:cmd_ok('pbcopy')
+  if !empty($TMUX) && executable('tmux') && executable('pbpaste') && !s:cmd_ok('pbpaste')
     let tmux_version = matchstr(system('tmux -V'), '\d\+\.\d\+')
     call health#report_error('pbcopy does not work with tmux version: '.tmux_version,
           \ ['Install tmux 2.6+.  https://superuser.com/q/231130',

--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -64,7 +64,7 @@ function! provider#clipboard#Executable() abort
     let s:paste = get(g:clipboard, 'paste', { '+': v:null, '*': v:null })
     let s:cache_enabled = get(g:clipboard, 'cache_enabled', 0)
     return get(g:clipboard, 'name', 'g:clipboard')
-  elseif has('mac') && executable('pbcopy') && s:cmd_ok('pbcopy')
+  elseif has('mac') && executable('pbpaste') && s:cmd_ok('pbpaste')
     let s:copy['+'] = 'pbcopy'
     let s:paste['+'] = 'pbpaste'
     let s:copy['*'] = s:copy['+']


### PR DESCRIPTION
`try_cmd('pbcopy')` would run `system('pbcopy')` which empties the pasteboard.

Changing all occurrences of `pbcopy` to `pbpaste` should work just as well without the mentioned side-effect.

Alternative approaches:

1. Simply don't use `try_cmd()` in `provider/clipboard.vim`. If the clipboard isn't working, `:checkhealth` would still give the correct pointer (but still empty the pasteboard).
1. Use `try_cmd('pbpaste | pbcopy')`. This way we still test `pbcopy`, but don't lose the pasteboard content.