### PR TITLE
Modified assert for scale_number base

### DIFF
--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -155,7 +155,7 @@ static inline float_T scale_number(const float_T num,
   if (num == 0 || exponent == 0) {
     return num;
   }
-  assert(base);
+  assert(base == 10);
   uvarnumber_T exp = exponent;
   float_T p_base = (float_T)base;
   float_T ret = num;


### PR DESCRIPTION
Change the assert condition for `scale_number`'s base to satisfy the definition constraints (as mentioned in the [function's header](https://github.com/neovim/neovim/blob/master/src/nvim/viml/parser/expressions.c#L145)).

@ZyX-I I was told you were the one looking after the parser, what do you think?