### PR TITLE
[RFC] vim-patch:8.0.0490

### DIFF
--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -306,20 +306,14 @@ func Test_window_width()
   set winfixwidth
   vsplit Xc
   let [ww1, ww2, ww3] = [winwidth(1), winwidth(2), winwidth(3)]
-  " FIXME: commented out: I would expect the width of 2nd window to 
-  " remain 2 but it's actually 1?!
-  "call assert_equal(2, winwidth(2))
+  call assert_equal(2, winwidth(2))
   call assert_inrange(ww3, ww3 + 1, ww1)
   3wincmd >
-  " FIXME: commented out: I would expect the width of 2nd window to 
-  " remain 2 but it's actually 1?!
-  "call assert_equal(2,       winwidth(2))
+  call assert_equal(2,       winwidth(2))
   call assert_equal(ww1 + 3, winwidth(1))
   call assert_equal(ww3 - 3, winwidth(3))
   wincmd =
-  " FIXME: commented out: I would expect the width of 2nd window to 
-  " remain 2 but it's actually 1?!
-  "call assert_equal(2,   winwidth(2))
+  call assert_equal(2,   winwidth(2))
   call assert_equal(ww1, winwidth(1))
   call assert_equal(ww3, winwidth(3))
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -641,11 +641,12 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
     if (oldwin->w_width - new_size - 1 < p_wmw)
       do_equal = TRUE;
 
-    /* We don't like to take lines for the new window from a
-     * 'winfixwidth' window.  Take them from a window to the left or right
-     * instead, if possible. */
-    if (oldwin->w_p_wfw)
-      win_setwidth_win(oldwin->w_width + new_size, oldwin);
+    // We don't like to take lines for the new window from a
+    // 'winfixwidth' window.  Take them from a window to the left or right
+	// instead, if possible. Add one for the separator.
+    if (oldwin->w_p_wfw) {
+      win_setwidth_win(oldwin->w_width + new_size + 1, oldwin);
+    }
 
     /* Only make all windows the same width if one of them (except oldwin)
      * is wider than one of the split windows. */

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -643,7 +643,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
 
     // We don't like to take lines for the new window from a
     // 'winfixwidth' window.  Take them from a window to the left or right
-	// instead, if possible. Add one for the separator.
+    // instead, if possible. Add one for the separator.
     if (oldwin->w_p_wfw) {
       win_setwidth_win(oldwin->w_width + new_size + 1, oldwin);
     }


### PR DESCRIPTION
#### vim-patch:8.0.0490: vertical split makes 'winfixwidth' window smaller

Problem:    Splitting a 'winfixwidth' window vertically makes it one column
            smaller. (Dominique Pelle)
Solution:   Add one to the width for the separator.

https://github.com/vim/vim/commit/38e3483637c16e018f88c07b1dcff97cdb821a29