### PR TITLE
vim-patch:8.0.1483: searchpair() might return an invalid value on timeout

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -775,12 +775,17 @@ int searchit(
                 }
               }
               if (ptr[matchcol] == NUL
-                  || (nmatched = vim_regexec_multi(&regmatch,
-                          win, buf, lnum + matchpos.lnum,
-                          matchcol,
-                          tm
-                          )) == 0)
-                break;
+                  || (nmatched = vim_regexec_multi(
+                      &regmatch, win, buf, lnum + matchpos.lnum, matchcol,
+                      tm)) == 0) {
+                  // If the search timed out, we did find a match
+                  // but it might be the wrong one, so that's not
+                  // OK.
+                  if (tm != NULL && profile_passed_limit(*tm)) {
+                      match_ok = false;
+                  }
+                  break;
+              }
 
               /* Need to get the line pointer again, a
                * multi-line search may have made it invalid. */


### PR DESCRIPTION
Problem:    Searchpair() might return an invalid value on timeout.
Solution:   When the second search times out, do not accept a match from the
            first search. (Daniel Hahler, closes vim/vim#2552)

https://github.com/vim/vim/commit/9d32276b52a63fccfae681f0d1d6ccb66efec1c0