### PR TITLE
[RFC] vim-patch:8.0.1494: no autocmd triggered in Insert mode with visible …

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -324,6 +324,9 @@ Name			triggered by ~
 
 |TextChanged|		after a change was made to the text in Normal mode
 |TextChangedI|		after a change was made to the text in Insert mode
+			when popup menu is not visible
+|TextChangedP|		after a change was made to the text in Insert mode
+			when popup menu visible
 
 |ColorScheme|		after loading a color scheme
 
@@ -968,6 +971,11 @@ TextChangedI			After a change was made to the text in the
 				current buffer in Insert mode.
 				Not triggered when the popup menu is visible.
 				Otherwise the same as TextChanged.
+							*TextChangedP*
+TextChangedP			After a change was made to the text in the
+				current buffer in Insert mode, only when the
+				popup menu is visible.  Otherwise the same as
+				TextChanged.
 							*User*
 User				Never executed automatically.  To be used for
 				autocommands that are only executed with

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -85,7 +85,8 @@ return {
     'TermOpen',               -- after opening a terminal buffer
     'TermResponse',           -- after setting "v:termresponse"
     'TextChanged',            -- text was modified
-    'TextChangedI',           -- text was modified in Insert mode
+    'TextChangedI',           -- text was modified in Insert mode(no popup)
+    'TextChangedP',           -- text was modified in Insert mode(popup)
     'TextYankPost',           -- after a yank or delete was done (y, d, c)
     'User',                   -- user defined autocommand
     'VimEnter',               -- after starting Vim

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -484,6 +484,11 @@ struct file_buffer {
 #define b_changedtick changedtick_di.di_tv.vval.v_number
   ChangedtickDictItem changedtick_di;  // b:changedtick dictionary item.
 
+  varnumber_T b_last_changedtick;       // b:changedtick when TextChanged or
+                                        // TextChangedI was last triggered.
+  varnumber_T b_last_changedtick_pum;   // b:changedtick when TextChangedP was
+                                        // last triggered.
+
   bool b_saving;                /* Set to true if we are in the middle of
                                    saving the buffer. */
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1375,13 +1375,20 @@ ins_redraw (
 
   // Trigger TextChangedI if b_changedtick differs.
   if (ready && has_event(EVENT_TEXTCHANGEDI)
-      && last_changedtick != curbuf->b_changedtick
+      && curbuf->b_last_changedtick != curbuf->b_changedtick
       && !pum_visible()) {
-    if (last_changedtick_buf == curbuf) {
       apply_autocmds(EVENT_TEXTCHANGEDI, NULL, NULL, false, curbuf);
-    }
-    last_changedtick_buf = curbuf;
-    last_changedtick = curbuf->b_changedtick;
+      curbuf->b_last_changedtick = curbuf->b_changedtick;
+  }
+
+  // Trigger TextChangedP if b_changedtick differs. When the popupmenu closes
+  // TextChangedI will need to trigger for backwards compatibility, thus use
+  // different b_last_changedtick* variables.
+  if (ready && has_event(EVENT_TEXTCHANGEDP)
+      && curbuf->b_last_changedtick_pum != curbuf->b_changedtick
+      && pum_visible()) {
+      apply_autocmds(EVENT_TEXTCHANGEDP, NULL, NULL, false, curbuf);
+      curbuf->b_last_changedtick_pum = curbuf->b_changedtick;
   }
 
   if (must_redraw)
@@ -1402,6 +1409,7 @@ ins_redraw (
   setcursor();
   emsg_on_display = FALSE;      /* may remove error message now */
 }
+
 
 /*
  * Handle a CTRL-V or CTRL-Q typed in Insert mode.

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3556,9 +3556,8 @@ restore_backup:
     unchanged(buf, TRUE);
     /* buf->b_changedtick is always incremented in unchanged() but that
      * should not trigger a TextChanged event. */
-    if (last_changedtick + 1 == buf->b_changedtick
-        && last_changedtick_buf == buf) {
-      last_changedtick = buf->b_changedtick;
+    if (buf->b_last_changedtick + 1 == buf->b_changedtick) {
+        buf->b_last_changedtick = buf->b_changedtick;
     }
     u_unchanged(buf);
     u_update_save_nr(buf);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -879,9 +879,6 @@ EXTERN int did_cursorhold INIT(= false);       // set when CursorHold t'gerd
 // for CursorMoved event
 EXTERN pos_T last_cursormoved INIT(= INIT_POS_T(0, 0, 0));
 
-EXTERN varnumber_T last_changedtick INIT(= 0);  // for TextChanged event
-EXTERN buf_T    *last_changedtick_buf INIT(= NULL);
-
 EXTERN int postponed_split INIT(= 0);       /* for CTRL-W CTRL-] command */
 EXTERN int postponed_split_flags INIT(= 0);       /* args for win_split() */
 EXTERN int postponed_split_tab INIT(= 0);       /* cmdmod.tab */

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1214,13 +1214,9 @@ static void normal_check_text_changed(NormalState *s)
 {
   // Trigger TextChanged if b_changedtick differs.
   if (!finish_op && has_event(EVENT_TEXTCHANGED)
-      && last_changedtick != curbuf->b_changedtick) {
-    if (last_changedtick_buf == curbuf) {
+      && curbuf->b_last_changedtick != curbuf->b_changedtick) {
       apply_autocmds(EVENT_TEXTCHANGED, NULL, NULL, false, curbuf);
-    }
-
-    last_changedtick_buf = curbuf;
-    last_changedtick = curbuf->b_changedtick;
+      curbuf->b_last_changedtick = curbuf->b_changedtick;
   }
 }
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1164,4 +1164,59 @@ func Test_nocatch_wipe_dummy_buffer()
   au * x bwipe
   call assert_fails('lv½ /x', 'E480')
   au!
+
+" Test TextChangedI and TextChangedP
+func Test_ChangedP()
+  new
+  call setline(1, ['foo', 'bar', 'foobar'])
+  call test_override("char_avail", 1)
+  set complete=. completeopt=menuone
+
+  func! TextChangedAutocmd(char)
+    let g:autocmd .= a:char
+  endfunc
+
+  au! TextChanged <buffer> :call TextChangedAutocmd('N')
+  au! TextChangedI <buffer> :call TextChangedAutocmd('I')
+  au! TextChangedP <buffer> :call TextChangedAutocmd('P')
+
+  call cursor(3, 1)
+  let g:autocmd = ''
+  call feedkeys("o\<esc>", 'tnix')
+  call assert_equal('I', g:autocmd)
+
+  let g:autocmd = ''
+  call feedkeys("Sf", 'tnix')
+  call assert_equal('II', g:autocmd)
+
+  let g:autocmd = ''
+  call feedkeys("Sf\<C-N>", 'tnix')
+  call assert_equal('IIP', g:autocmd)
+
+  let g:autocmd = ''
+  call feedkeys("Sf\<C-N>\<C-N>", 'tnix')
+  call assert_equal('IIPP', g:autocmd)
+
+  let g:autocmd = ''
+  call feedkeys("Sf\<C-N>\<C-N>\<C-N>", 'tnix')
+  call assert_equal('IIPPP', g:autocmd)
+
+  let g:autocmd = ''
+  call feedkeys("Sf\<C-N>\<C-N>\<C-N>\<C-N>", 'tnix')
+  call assert_equal('IIPPPP', g:autocmd)
+
+  call assert_equal(['foo', 'bar', 'foobar', 'foo'], getline(1, '$'))
+  " TODO: how should it handle completeopt=noinsert,noselect?
+
+  " CleanUp
+  throw 'skipped: Nvim does not support test_override()'
+  call test_override("char_avail", 0)
+  au! TextChanged
+  au! TextChangedI
+  au! TextChangedP
+  delfu TextChangedAutocmd
+  unlet! g:autocmd
+  set complete&vim completeopt&vim
+
+  bw!
 endfunc


### PR DESCRIPTION
…popup menu

Problem:    No autocmd triggered in Insert mode with visible popup menu.
Solution:   Add TextChangedP. (Prabir Shrestha, Christian Brabandt,
            closes vim/vim#2372, closes vim/vim#1691)
            Fix that the TextChanged autocommands are not always triggered
            when sourcing a script.

https://github.com/vim/vim/commit/5a093437199001a0d60d8e18e2b9539b99a7757c