### PR TITLE
API: nvim_list_uis

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1482,6 +1482,7 @@ Array nvim_list_uis(void)
     Dictionary dic = ARRAY_DICT_INIT;
     PUT(dic, "width", INTEGER_OBJ(uis[i]->width));
     PUT(dic, "height", INTEGER_OBJ(uis[i]->height));
+    PUT(dic, "rgb", BOOLEAN_OBJ(uis[i]->rgb));
     for (UIExtension j = 0; j < kUIExtCount; j++) {
       PUT(dic, ui_ext_names[j], BOOLEAN_OBJ(uis[i]->ui_ext[j]));
     }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1470,6 +1470,10 @@ Float nvim__id_float(Float flt)
   return flt;
 }
 
+/// Returns Array of UI Dictionaries for the currently running TUI
+/// and empty Array otherwise
+///
+/// @return Array of UI Dictionaries
 Array nvim_list_uis(void)
   FUNC_API_SINCE(4)
 {

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1475,7 +1475,7 @@ Float nvim__id_float(Float flt)
 }
 
 Array nvim_list_uis(void)
-  FUNC_API_SINCE(1)
+  FUNC_API_SINCE(4)
 {
   Array alluis = ARRAY_DICT_INIT;
   for (unsigned int i = 0; i < ui_count ; i++) {

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -35,12 +35,17 @@
 #include "nvim/os/input.h"
 #include "nvim/viml/parser/expressions.h"
 #include "nvim/viml/parser/parser.h"
+#include "nvim/ui.h"
 
 #define LINE_BUFFER_SIZE 4096
+#define MAX_UI_COUNT 16
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/vim.c.generated.h"
 #endif
+
+extern UI *uis[MAX_UI_COUNT];
+extern size_t ui_count;
 
 /// Executes an ex-command.
 ///
@@ -1467,4 +1472,20 @@ Dictionary nvim__id_dictionary(Dictionary dct)
 Float nvim__id_float(Float flt)
 {
   return flt;
+}
+
+Array nvim_list_uis(void)
+  FUNC_API_SINCE(1)
+{
+  Array alluis = ARRAY_DICT_INIT;
+  for (unsigned int i = 0; i < ui_count ; i++) {
+    Dictionary dic = ARRAY_DICT_INIT;
+    PUT(dic, "width", INTEGER_OBJ(uis[i]->width));
+    PUT(dic, "height", INTEGER_OBJ(uis[i]->height));
+    for (UIExtension j = 0; j < kUIExtCount; j++) {
+      PUT(dic, ui_ext_names[j], BOOLEAN_OBJ(uis[i]->ui_ext[j]));
+    }
+    ADD(alluis, DICTIONARY_OBJ(dic));
+  }
+  return alluis;
 }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -44,9 +44,6 @@
 # include "api/vim.c.generated.h"
 #endif
 
-extern UI *uis[MAX_UI_COUNT];
-extern size_t ui_count;
-
 /// Executes an ex-command.
 ///
 /// On parse error: forwards the Vim error; does not update v:errmsg.
@@ -1477,16 +1474,5 @@ Float nvim__id_float(Float flt)
 Array nvim_list_uis(void)
   FUNC_API_SINCE(4)
 {
-  Array alluis = ARRAY_DICT_INIT;
-  for (unsigned int i = 0; i < ui_count ; i++) {
-    Dictionary dic = ARRAY_DICT_INIT;
-    PUT(dic, "width", INTEGER_OBJ(uis[i]->width));
-    PUT(dic, "height", INTEGER_OBJ(uis[i]->height));
-    PUT(dic, "rgb", BOOLEAN_OBJ(uis[i]->rgb));
-    for (UIExtension j = 0; j < kUIExtCount; j++) {
-      PUT(dic, ui_ext_names[j], BOOLEAN_OBJ(uis[i]->ui_ext[j]));
-    }
-    ADD(alluis, DICTIONARY_OBJ(dic));
-  }
-  return alluis;
+  return ui_list();
 }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -38,7 +38,6 @@
 #include "nvim/ui.h"
 
 #define LINE_BUFFER_SIZE 4096
-#define MAX_UI_COUNT 16
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/vim.c.generated.h"

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -537,7 +537,7 @@ bool ui_is_external(UIExtension widget)
 Array ui_list(void)
 {
   Array all_uis = ARRAY_DICT_INIT;
-  for (unsigned int i = 0; i < ui_count ; i++) {
+  for (size_t i = 0; i < ui_count ; i++) {
     Dictionary dic = ARRAY_DICT_INIT;
     PUT(dic, "width", INTEGER_OBJ(uis[i]->width));
     PUT(dic, "height", INTEGER_OBJ(uis[i]->height));

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -48,9 +48,9 @@
 
 #define MAX_UI_COUNT 16
 
-UI *uis[MAX_UI_COUNT];
+static UI *uis[MAX_UI_COUNT];
 static bool ui_ext[kUIExtCount] = { 0 };
-size_t ui_count = 0;
+static size_t ui_count = 0;
 static int row = 0, col = 0;
 static struct {
   int top, bot, left, right;
@@ -532,4 +532,20 @@ void ui_cursor_shape(void)
 bool ui_is_external(UIExtension widget)
 {
   return ui_ext[widget];
+}
+
+Array ui_list(void)
+{
+  Array all_uis = ARRAY_DICT_INIT;
+  for (unsigned int i = 0; i < ui_count ; i++) {
+    Dictionary dic = ARRAY_DICT_INIT;
+    PUT(dic, "width", INTEGER_OBJ(uis[i]->width));
+    PUT(dic, "height", INTEGER_OBJ(uis[i]->height));
+    PUT(dic, "rgb", BOOLEAN_OBJ(uis[i]->rgb));
+    for (UIExtension j = 0; j < kUIExtCount; j++) {
+      PUT(dic, ui_ext_names[j], BOOLEAN_OBJ(uis[i]->ui_ext[j]));
+    }
+    ADD(all_uis, DICTIONARY_OBJ(dic));
+  }
+  return all_uis;
 }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -48,9 +48,9 @@
 
 #define MAX_UI_COUNT 16
 
-static UI *uis[MAX_UI_COUNT];
+UI *uis[MAX_UI_COUNT];
 static bool ui_ext[kUIExtCount] = { 0 };
-static size_t ui_count = 0;
+size_t ui_count = 0;
 static int row = 0, col = 0;
 static struct {
   int top, bot, left, right;

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -38,8 +38,6 @@ struct ui_t {
   void (*stop)(UI *ui);
 };
 
-Array ui_list(void);
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui.h.generated.h"
 # include "ui_events_call.h.generated.h"

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -38,6 +38,8 @@ struct ui_t {
   void (*stop)(UI *ui);
 };
 
+Array ui_list(void);
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui.h.generated.h"
 # include "ui_events_call.h.generated.h"

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -998,4 +998,29 @@ describe('api', function()
         it, _check_parsing, hl, fmtn)
   end)
 
+  describe('nvim_list_uis', function()
+    it('returns empty if --headless', function()
+      clear({args={'--headless'}})
+      local status = nvim("list_uis")
+      eq({ }, status)  -- nvim_list_uis() returned empty Array.
+    end)
+    it('returns attached UIs', function()
+      local screen1 = Screen.new(20, 4)
+      screen1:attach()
+      local status = nvim("list_uis")
+      local expected_status = {
+        {
+          ext_cmdline = false,
+          ext_popupmenu = false,
+          ext_tabline = false,
+          ext_wildmenu = false,
+          height = 4,
+          rgb = true,
+          width = 20
+        }
+      }
+      eq(expected_status, status)  -- nvim_list_uis() returned UI Dict.
+    end)
+  end)
+
 end)


### PR DESCRIPTION
`nvim_list_uis` returns a list of UI dicts.

running 
```
./nvim -u NONE +"echo nvim_list_uis()" 
```
returns 
> `[{'ext_cmdline': v:false, 'ext_wildmenu': v:false, 'ext_popupmenu': v:false, 'width': 192, 'height': 47, 'ext_tabline': v:false}]`
>
running 
```
./nvim -u NONE --headless +"echo nvim_list_uis()" 
```
returns `[]`

#7438 