### PR TITLE
[RFC] ui: notify changed highlights

### DIFF
--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -83,6 +83,7 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
   ui->set_scroll_region = remote_ui_set_scroll_region;
   ui->scroll = remote_ui_scroll;
   ui->highlight_set = remote_ui_highlight_set;
+  ui->highlight_info_set = remote_ui_highlight_info_set;
   ui->put = remote_ui_put;
   ui->bell = remote_ui_bell;
   ui->visual_bell = remote_ui_visual_bell;

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -63,6 +63,8 @@ void set_icon(String icon)
   FUNC_API_SINCE(3);
 void option_set(String name, Object value)
   FUNC_API_SINCE(4);
+void highlight_info_set(Array highlights_changed)
+  FUNC_API_SINCE(4);
 
 void popupmenu_show(Array items, Integer selected, Integer row, Integer col)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -148,6 +148,7 @@ UI *tui_start(void)
   ui->set_title = tui_set_title;
   ui->set_icon = tui_set_icon;
   ui->option_set= tui_option_set;
+  ui->highlight_info_set = tui_highlight_info_set;
 
   memset(ui->ui_ext, 0, sizeof(ui->ui_ext));
 
@@ -1167,6 +1168,14 @@ static void tui_option_set(UI *ui, String name, Object value)
     invalidate(ui, 0, data->grid.height-1, 0, data->grid.width-1);
   }
 }
+
+static void tui_highlight_info_set(UI *ui, Array highlights_changed)
+{
+  TUIData *data = ui->data;
+  // redraw the cursor just in case its hl changed
+  tui_set_mode(ui, data->showing_mode);
+}
+
 
 static void invalidate(UI *ui, int top, int bot, int left, int right)
 {

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -65,6 +65,7 @@ UI *ui_bridge_attach(UI *ui, ui_main_fn ui_main, event_scheduler scheduler)
   rv->bridge.set_title = ui_bridge_set_title;
   rv->bridge.set_icon = ui_bridge_set_icon;
   rv->bridge.option_set = ui_bridge_option_set;
+  rv->bridge.highlight_info_set = ui_bridge_highlight_info_set;
   rv->scheduler = scheduler;
 
   for (UIWidget i = 0; (int)i < UI_WIDGETS; i++) {

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1062,3 +1062,29 @@ describe("'winhighlight' highlight", function()
     ]])
   end)
 end)
+
+
+describe("highlight", function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(20,5)
+    screen:attach()
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  it('notifies UI on update', function()
+    local normal_hl_id = eval("hlID('Normal')")
+    local cursorcolumn_hl_id = eval("hlID('CursorColumn')")
+    command("highlight Normal guibg=red|highlight CursorColumn guibg=red")
+    screen:expect(function()
+      eq(normal_hl_id, screen._changed_highlight_ids[1])
+      eq(cursorcolumn_hl_id, screen._changed_highlight_ids[2])
+    end)
+  end)
+
+end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -141,6 +141,7 @@ function Screen.new(width, height)
     _default_attr_ids = nil,
     _default_attr_ignore = nil,
     _mouse_enabled = true,
+    _changed_highlight_ids = {},
     _attrs = {},
     _cursor = {
       row = 1, col = 1
@@ -434,6 +435,11 @@ function Screen:_handle_scroll(count)
   for i = stop + step, stop + count, step do
     self:_clear_row_section(i, left, right)
   end
+end
+
+function Screen:_handle_highlight_info_set(highlight_ids)
+  --
+  self._changed_highlight_ids = highlight_ids
 end
 
 function Screen:_handle_highlight_set(attrs)


### PR DESCRIPTION
when doing `:hi Cursor guibg=red` for instance, the cursor color is not
necessarily refreshed straightaway, only on mode change.
This PR notifies the UIs with the ids of the changed highlights, the UI can then use nvim_get_hl_by_id to retrieve the updated hl if need be (it's straightforward for the UI).
Adresses https://github.com/neovim/neovim/issues/6591

To test
`bin/nvim -u NONE --cmd "set termguicolors" --cmd "set guicursor=n-v-c:block-Cursor/lCursor,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor"`
then type
`:hi Cursor guibg=red`

On startup it sends several ids depending on your config, i hope it's not a problem. 

Extracted from https://github.com/neovim/neovim/pull/6566