### PR TITLE
[WIP] ex_getln: clear cmdline_block after it's freed

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -194,7 +194,8 @@ static int cmd_showtail;                /* Only show path tail in lists ? */
 
 static int new_cmdpos;          /* position set by set_cmdline_pos() */
 
-static Array cmdline_block;  ///< currently displayed block of context
+/// currently displayed block of context
+static Array cmdline_block = ARRAY_DICT_INIT;
 
 /*
  * Type used by call_user_expand_func
@@ -2990,6 +2991,7 @@ void ui_ext_cmdline_block_append(int indent, const char *line)
 void ui_ext_cmdline_block_leave(void)
 {
   api_free_array(cmdline_block);
+  cmdline_block = (Array)ARRAY_DICT_INIT;
   ui_call_cmdline_block_hide();
 }
 

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -348,6 +348,35 @@ describe('external cmdline', function()
            { { {}, '  line1'} } }, block)
     end)
 
+    feed('endfunction<cr>')
+    screen:expect([[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+                               |
+    ]], nil, nil, function()
+      eq(nil, block)
+    end)
+
+    -- Try once more, to check buffer is reinitialized. #8007
+    feed(':function Bar()<cr>')
+    screen:expect([[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+                               |
+    ]], nil, nil, function()
+      eq({{
+        content = { { {}, "" } },
+        firstc = ":",
+        indent = 2,
+        pos = 0,
+        prompt = "",
+      }}, cmdline)
+      eq({ { { {}, 'function Bar()'} } }, block)
+    end)
 
     feed('endfunction<cr>')
     screen:expect([[


### PR DESCRIPTION
Missing reinitialization of `cmdline_block` after freeing it. Might have caused #8007. I'll try to construct a master failing test also.