### PR TITLE
[RFC] vim-patch:8.0.0212

### DIFF
--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -477,7 +477,7 @@ char_u *get_special_key_name(int c, int modifiers)
   } else {            // use name of special key
     size_t len = STRLEN(key_names_table[table_idx].name);
 
-    if (len + idx + 2 <= MAX_KEY_NAME_LEN) {
+    if ((int)len + idx + 2 <= MAX_KEY_NAME_LEN) {
         STRCPY(string + idx, key_names_table[table_idx].name);
         idx += (int)len;
     }

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -40,6 +40,7 @@ static const struct modmasktable {
   // 'A' must be the last one
   { MOD_MASK_ALT,              MOD_MASK_ALT,           (char_u)'A' },
   { 0, 0, NUL }
+  // NOTE: when adding an entry, update MAX_KEY_NAME_LEN!
 };
 
 /*
@@ -285,6 +286,7 @@ static const struct key_name_entry {
   { K_PLUG,            "Plug" },
   { K_PASTE,           "Paste" },
   { 0,                 NULL }
+  // NOTE: When adding a long name update MAX_KEY_NAME_LEN.
 };
 
 static struct mousetable {
@@ -472,9 +474,13 @@ char_u *get_special_key_name(int c, int modifiers)
           string[idx++] = *s++;
       }
     }
-  } else {            /* use name of special key */
-    STRCPY(string + idx, key_names_table[table_idx].name);
-    idx = (int)STRLEN(string);
+  } else {            // use name of special key
+    size_t len = STRLEN(key_names_table[table_idx].name);
+
+    if (len + idx + 2 <= MAX_KEY_NAME_LEN) {
+        STRCPY(string + idx, key_names_table[table_idx].name);
+        idx += (int)len;
+    }
   }
   string[idx++] = '>';
   string[idx] = NUL;

--- a/src/nvim/keymap.h
+++ b/src/nvim/keymap.h
@@ -448,9 +448,10 @@ enum key_extra {
 
 /*
  * The length of the longest special key name, including modifiers.
- * Current longest is <M-C-S-T-4-MiddleRelease> (length includes '<' and '>').
+ * Current longest is <M-C-S-T-D-A-4-ScrollWheelRight> (length includes '<' and
+ * '>').
  */
-#define MAX_KEY_NAME_LEN    25
+#define MAX_KEY_NAME_LEN    32
 
 // Maximum length of a special key event as tokens.  This includes modifiers.
 // The longest event is something like <M-C-S-T-4-LeftDrag> which would be the


### PR DESCRIPTION
#### vim-patch:8.0.0212: buffer for key name may be too small

Problem:    The buffer used to store a key name theoreticaly could be too
            small. (Coverity)
Solution:   Count all possible modifier characters.  Add a check for the
            length just in case.

https://github.com/vim/vim/commit/423977d3cebac2be1158b1d11da60fe96db4b750