### PR TITLE
[RFC] vim-patch:8.0.0214

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4968,6 +4968,8 @@ static void syn_cmd_cluster(exarg_T *eap, int syncing)
       if (scl_id >= 0) {
         syn_combine_list(&SYN_CLSTR(curwin->w_s)[scl_id].scl_list,
                          &clstr_list, list_op);
+      } else {
+        xfree(clstr_list);
       }
       got_clstr = true;
     }
@@ -5276,8 +5278,9 @@ get_id_list (
           break;
         }
         if (count != 0) {
-          EMSG2(_("E408: %s must be first in contains list"), name + 1);
-          failed = TRUE;
+          EMSG2(_("E408: %s must be first in contains list"),
+                name + 1);
+          failed = true;
           xfree(name);
           break;
         }


### PR DESCRIPTION
#### vim-patch:8.0.0214: leaking memory when syntax cluster id is unknown

Problem:    Leaking memory when syntax cluster id is unknown. (Coverity)
Solution:   Free the memory.

https://github.com/vim/vim/commit/d7a96151e0c86e8d4f9162c919cf3ff400a893b6