### PR TITLE
[RFC] vim-patch:8.0.0649 and vim-patch:8.0.0650

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2017 Nov 02
+" Last Change:	2018 Feb 14
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")
@@ -47,6 +47,9 @@ func! s:StarSetf(ft)
     exe 'setf ' . a:ft
   endif
 endfunc
+
+" Vim help file
+au BufNewFile,BufRead $VIMRUNTIME/doc/*.txt setf help
 
 " Abaqus or Trasys
 au BufNewFile,BufRead *.inp			call s:Check_inp()
@@ -2804,8 +2807,13 @@ au BufNewFile,BufRead zsh*,zlog*		call s:StarSetf('zsh')
 
 " Plain text files, needs to be far down to not override others.  This avoids
 " the "conf" type being used if there is a line starting with '#'.
-au BufNewFile,BufRead *.txt,*.text,README	setf text
+au BufNewFile,BufRead *.text,README setf text
 
+" Help files match *.txt but should have a last line that is a modeline. 
+au BufNewFile,BufRead *.txt
+        \  if getline('$') !~ 'vim:.*ft=help'
+        \|   setf text
+        \| endif       
 
 " Use the filetype detect plugins.  They may overrule any of the previously
 " detected filetypes.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4864,7 +4864,9 @@ void fix_help_buffer(void)
   char_u      *rt;
 
   // Set filetype to "help".
-  set_option_value("ft", 0L, "help", OPT_LOCAL);
+  if (STRCMP(curbuf->b_p_ft, "help") != 0) {
+    set_option_value("ft", 0L, "help", OPT_LOCAL);
+  }
 
   if (!syntax_present(curwin)) {
     for (lnum = 1; lnum <= curbuf->b_ml.ml_line_count; ++lnum) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2455,6 +2455,7 @@ did_set_string_option (
   int did_chartab = FALSE;
   char_u      **gvarp;
   bool free_oldval = (options[opt_idx].flags & P_ALLOCED);
+  int ft_changed = false;
 
   /* Get the global option to compare with, otherwise we would have to check
    * two values for all local options. */
@@ -3174,6 +3175,8 @@ did_set_string_option (
   } else if (gvarp == &p_ft) {
     if (!valid_filetype(*varp)) {
       errmsg = e_invarg;
+    } else {
+      ft_changed = STRCMP(oldval, *varp) != 0;
     }
   } else if (gvarp == &p_syn) {
     if (!valid_filetype(*varp)) {
@@ -3256,10 +3259,12 @@ did_set_string_option (
       apply_autocmds(EVENT_SYNTAX, curbuf->b_p_syn,
           curbuf->b_fname, TRUE, curbuf);
     } else if (varp == &(curbuf->b_p_ft)) {
-      /* 'filetype' is set, trigger the FileType autocommand */
-      did_filetype = TRUE;
-      apply_autocmds(EVENT_FILETYPE, curbuf->b_p_ft,
-          curbuf->b_fname, TRUE, curbuf);
+      // 'filetype' is set, trigger the FileType autocommand
+      if (!(opt_flags & OPT_MODELINE) || ft_changed) {
+        did_filetype = true;
+        apply_autocmds(EVENT_FILETYPE, curbuf->b_p_ft,
+                       curbuf->b_fname, true, curbuf);
+      }
     }
     if (varp == &(curwin->w_s->b_p_spl)) {
       char_u fname[200];

--- a/test/functional/autocmd/filetype_spec.lua
+++ b/test/functional/autocmd/filetype_spec.lua
@@ -1,0 +1,16 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local eval = helpers.eval
+local clear = helpers.clear
+local command = helpers.command
+
+describe('autocmd FileType', function()
+    before_each(clear)
+
+    it("is triggered by :help only once", function()
+        command("let g:foo = 0")
+        command("autocmd FileType help let g:foo = g:foo + 1")
+        command("help help")
+        assert.same(1, eval('g:foo'))
+    end)
+end)


### PR DESCRIPTION
**vim-patch:8.0.0649: when opening a help file the filetype is set several times**
Problem:    When opening a help file the filetype is set several times.
Solution:   When setting the filetype to the same value from a modeline, don't
            trigger FileType autocommands.  Don't set the filetype to "help"
            when it's already set correctly.
**vim-patch 8.0.0650: for extra help files the filetype is set more than once**

Problem:    For extra help files the filetype is set more than once.
Solution:   In *.txt files check that there is no help file modline.

[vim/vim@`904929`](https://github.com/vim/vim/commit/9049298f8d0bbc237b7c666c7ad6cdabe738e8fc) and [vim/vim@`868831`](https://github.com/vim/vim/commit/868831f1224cfc17a4de21fb7386873254592308)