### PR TITLE
[RFC] vim-patch:8.0.0220

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7760,7 +7760,7 @@ static void highlight_list_two(int cnt, int attr)
  * Function given to ExpandGeneric() to obtain the list of group names.
  * Also used for synIDattr() function.
  */
-const char *get_highlight_name(expand_T *const xp, const int idx)
+const char *get_highlight_name(expand_T *const xp, int idx)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (idx < 0) {
@@ -7768,10 +7768,9 @@ const char *get_highlight_name(expand_T *const xp, const int idx)
   }
 
   // Items are never removed from the table, skip the ones that were cleared.
-  int current_idx = idx;
-  while (current_idx < highlight_ga.ga_len
-         && HL_TABLE()[current_idx].sg_cleared) {
-    current_idx++;
+  while (idx < highlight_ga.ga_len
+         && HL_TABLE()[idx].sg_cleared) {
+    idx++;
   }
 
   // TODO(justinmk): 'xp' is unused
@@ -7786,10 +7785,10 @@ const char *get_highlight_name(expand_T *const xp, const int idx)
   } else if (idx == highlight_ga.ga_len + include_none + include_default + 1
              && include_link != 0) {
     return "clear";
-  } else if (current_idx >= highlight_ga.ga_len) {
+  } else if (idx >= highlight_ga.ga_len) {
     return NULL;
   }
-  return (const char *)HL_TABLE()[current_idx].sg_name;
+  return (const char *)HL_TABLE()[idx].sg_name;
 }
 
 color_name_table_T color_name_table[] = {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7760,6 +7760,17 @@ static void highlight_list_two(int cnt, int attr)
 const char *get_highlight_name(expand_T *const xp, const int idx)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
+  if (idx < 0) {
+    return NULL;
+  }
+
+  // Items are never removed from the table, skip the ones that were cleared.
+  int current_idx = idx;
+  while (current_idx < highlight_ga.ga_len
+         && HL_TABLE()[current_idx].sg_cleared) {
+    current_idx++;
+  }
+
   // TODO(justinmk): 'xp' is unused
   if (idx == highlight_ga.ga_len && include_none != 0) {
     return "none";
@@ -7772,17 +7783,7 @@ const char *get_highlight_name(expand_T *const xp, const int idx)
   } else if (idx == highlight_ga.ga_len + include_none + include_default + 1
              && include_link != 0) {
     return "clear";
-  } else if (idx < 0) {
-    return NULL;
-  }
-
-  // Items are never removed from the table, skip the ones that were cleared.
-  int current_idx = idx;
-  while (current_idx < highlight_ga.ga_len
-         && HL_TABLE()[current_idx].sg_cleared) {
-    current_idx++;
-  }
-  if (current_idx >= highlight_ga.ga_len) {
+  } else if (current_idx >= highlight_ga.ga_len) {
     return NULL;
   }
   return (const char *)HL_TABLE()[current_idx].sg_name;

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -46,8 +46,34 @@ func Test_map_completion()
   call assert_equal('"map <silent> <special>', getreg(':'))
 endfunc
 
+func Test_match_completion()
+  if !has('cmdline_compl')
+    return
+  endif
+  hi Aardig ctermfg=green
+  call feedkeys(":match \<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"match Aardig', getreg(':'))
+  call feedkeys(":match \<S-Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"match none', getreg(':'))
+endfunc
+
+func Test_highlight_completion()
+  if !has('cmdline_compl')
+    return
+  endif
+  hi Aardig ctermfg=green
+  call feedkeys(":hi \<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"hi Aardig', getreg(':'))
+  call feedkeys(":hi li\<S-Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"hi link', getreg(':'))
+  call feedkeys(":hi d\<S-Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"hi default', getreg(':'))
+  call feedkeys(":hi c\<S-Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal('"hi clear', getreg(':'))
+endfunc
+
 func Test_expr_completion()
-  if !(has('cmdline_compl') && has('eval'))
+  if !has('cmdline_compl')
     return
   endif
   for cmd in [


### PR DESCRIPTION
#### vim-patch:8.0.0220: completion of highlight names misses a few values

Problem:    Completion for :match does not show "none" and other missing
            highlight names.
Solution:   Skip over cleared entries before checking the index to be at the
            end.

https://github.com/vim/vim/commit/15eedf1d621d980cb40f50cc6a78a09ab94388c7