### PR TITLE
[WIP] vim-patch:8.0.0197

### DIFF
--- a/src/nvim/testdir/test_system.vim
+++ b/src/nvim/testdir/test_system.vim
@@ -46,3 +46,14 @@ function! Test_System()
 
   call assert_fails('call system("wc -l", 99999)', 'E86:')
 endfunction
+
+function! Test_system_exmode()
+  if has('unix')
+    let cmd = ' -es -u NONE -c "source Xscript" +q; echo $?'
+	" Need to put this in a script, "catch" isn't found after an unknown
+	" function.
+	call writefile(['try', 'call doesnotexist()', 'catch', 'endtry'], 'Xscript')
+	let a = system(v:progpath . cmd)
+	call assert_equal('0', a[0])
+	call assert_equal(0, v:shell_error)
+endif


### PR DESCRIPTION
Problem:    On MS-Windows the system() test skips a few parts.

Solution:   Swap single and double quotes for the command.

https://github.com/vim/vim/commit/97d62d4321df358665e2e6504aad8ac2ba7fd841