### PR TITLE
[RFC] vim-patch:8.0.0323

### DIFF
--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -374,7 +374,7 @@ func Test_getcmdtype()
   call feedkeys("?MyCmd a\<C-R>=Check_cmdline('?')\<CR>\<Esc>", "xt")
 
   call feedkeys(":call input('Answer?')\<CR>", "t")
-  call feedkeys("MyCmd a\<C-R>=Check_cmdline('@')\<CR>\<Esc>", "xt")
+  call feedkeys("MyCmd a\<C-R>=Check_cmdline('@')\<CR>\<C-C>", "xt")
 
   call feedkeys(":insert\<CR>MyCmd a\<C-R>=Check_cmdline('-')\<CR>\<Esc>", "xt")
 


### PR DESCRIPTION
Problem:    When running the command line tests there is a one-second wait.

Solution:   Change an Esc to Ctrl-C. (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/31eb139b8877439d06db0ca57692dfe35fec3f0c