### PR TITLE
[RFC] clipboard: check g:clipboard format

### DIFF
--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -121,7 +121,7 @@ describe('clipboard', function()
   it('invalid g:clipboard shows hint if :redir is not active', function()
     command("let g:clipboard = 'bogus'")
     eq('', eval('provider#clipboard#Executable()'))
-    eq('clipboard: invalid g:clipboard', eval('provider#clipboard#Error()'))
+    eq('g:clipboard is no Dictionary', eval('provider#clipboard#Error()'))
 
     local screen = Screen.new(72, 4)
     screen:attach()


### PR DESCRIPTION
Our code requires the `copy` and `paste` keys both to have the `+` and `*` keys. But we don't check for that in `provider#clipboard#Executable()`.

Assume this:

```vim
let g:clipboard = {
      \  'copy':  { '+': 'tmux load-buffer -', '*': 'tmux load-buffer -' },
      \  'paste': { '+': 'tmux save-buffer -' },
      \ }
```

Then `:reg` would error out like this:

```
Error detected while processing function provider#clipboard#Call[6]..2:
line    4:
E716: Key not present in Dictionary: *
E116: Invalid arguments for function s:try_cmd
E15: Invalid expression: s:try_cmd(s:paste[a:reg])
clipboard: provider returned invalid data
```

After this PR `:reg` would silently fail (it omits `+` and `*`) and `:checkhealth provider` would say:

```
## Clipboard (optional)
  - ERROR: g:clipboard.paste has no `*` key with type String
    - ADVICE:
      - Use the example in :help g:clipboard as a template, or don't set g:clipboard at all.
```

We could properly work around it on a lower level, but I guess there's nothing wrong with forcing a proper format right from the beginning.