### PR TITLE
build: remove build/runtime/doc/* surgically

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -71,7 +71,7 @@ foreach(DF ${DOCFILES})
 endforeach()
 
 add_custom_target(helptags
-  COMMAND ${CMAKE_COMMAND} -E remove_directory ${GENERATED_RUNTIME_DIR}/doc
+  COMMAND ${CMAKE_COMMAND} -E remove ${GENERATED_RUNTIME_DIR}/doc/*
   COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${PROJECT_SOURCE_DIR}/runtime/doc ${GENERATED_RUNTIME_DIR}/doc
   COMMAND "${PROJECT_BINARY_DIR}/bin/nvim"


### PR DESCRIPTION
If the directory is removed, then `sudo make install` creates
a root-owned …/doc/ directory. That breaks the next non-root build.

This was an accident of 0b1904d835a2.