### PR TITLE
[RFC] vim-patch:8.0.0222

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -87,6 +87,7 @@ NEW_TESTS ?= \
 	    test_number.res \
 	    test_options.res \
 	    test_profile.res \
+	    test_put.res \
 	    test_quickfix.res \
 	    test_recover.res \
 	    test_retab.res \

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -24,6 +24,7 @@ source test_mapping.vim
 source test_messages.vim
 source test_partial.vim
 source test_popup.vim
+source test_put.vim
 source test_recover.vim
 source test_regexp_utf8.vim
 source test_source_utf8.vim

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -1,0 +1,12 @@
+
+func Test_put_block()
+  if !has('multi_byte')
+    return
+  endif
+  new
+  call feedkeys("i\<C-V>u2500\<CR>x\<ESC>", 'x')
+  call feedkeys("\<C-V>y", 'x')
+  call feedkeys("gg0p", 'x')
+  call assert_equal("\u2500x", getline(1))
+  bwipe!
+endfunc


### PR DESCRIPTION
#### vim-patch:8.0.0222: blockwise put on multi-byte character misplaced

Problem:    When a multi-byte character ends in a zero byte, putting blockwise
            text puts it before the character instead of after it.
Solution:   Use int instead of char for the character under the cursor.
            (Luchr, closes vim/vim#1403)  Add a test.

https://github.com/vim/vim/commit/c81299684b2b9045e56525d3da3f45e8440fbf0d