### PR TITLE
[RFC] jobwait: return -2 on interrupt even with timeout

### DIFF
--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -491,10 +491,19 @@ describe('jobs', function()
       eq({'notification', 'wait', {{-3, 5}}}, next_msg())
     end)
 
-    it('will return -2 when interrupted', function()
+    it('will return -2 when interrupted without timeout', function()
       feed_command('call rpcnotify(g:channel, "ready") | '..
               'call rpcnotify(g:channel, "wait", '..
               'jobwait([jobstart("sleep 10; exit 55")]))')
+      eq({'notification', 'ready', {}}, next_msg())
+      feed('<c-c>')
+      eq({'notification', 'wait', {{-2}}}, next_msg())
+    end)
+
+    it('will return -2 when interrupted with timeout', function()
+      feed_command('call rpcnotify(g:channel, "ready") | '..
+              'call rpcnotify(g:channel, "wait", '..
+              'jobwait([jobstart("sleep 10; exit 55")], 10000))')
       eq({'notification', 'ready', {}}, next_msg())
       feed('<c-c>')
       eq({'notification', 'wait', {{-2}}}, next_msg())


### PR DESCRIPTION
Might have been an accident of the refactor in #6844 .

This is triggered in the `health#provider` module, where interrupting a stalled job in `s:system` throws a messy unexpected exception instead of just considering it a failure of that particular check.