### PR TITLE
[RFC] test: win: enable more job tests

### DIFF
--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -427,9 +427,19 @@ describe('jobs', function()
         let cmd = ['sh', '-c', 'for i in $(seq 1 5); do echo $i; sleep 0.1; done']
       endif
       call jobwait([jobstart(cmd, d)])
-      call rpcnotify(g:channel, 'data', d.data)
+      call call('rpcnotify', extend([g:channel, 'data'], d.data))
     ]])
-    eq({'notification', 'data', {{{'1', ''}, {'2', ''}, {'3', ''}, {'4', ''}, {'5', ''}, {''}}}}, next_msg())
+    expect_msg_seq(
+      {{'notification', 'data', {
+        {'1', ''}, {'2', ''}, {'3', ''}, {'4', ''}, {'5', ''}, {''}
+      }}},
+      {{'notification', 'data', {
+        {'1', ''}, {'2', ''}, {'3', ''}, {'4'}, {'', ''}, {'5', ''}, {''}
+      }}},
+      {{'notification', 'data', {
+        {'1', ''}, {'2', ''}, {'3', ''}, {'4', ''}, {'5'}, {'', ''}, {''}
+      }}}
+    )
   end)
 
   it('jobstart() works with partial functions', function()

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -141,7 +141,8 @@ describe('jobs', function()
   end)
 
   it('allows interactive commands', function()
-    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     neq(0, eval('j'))
     nvim('command', 'call jobsend(j, "abc\\n")')
     eq({'notification', 'stdout', {0, {'abc', ''}}}, next_msg())
@@ -178,7 +179,7 @@ describe('jobs', function()
     os.remove(filename)
 
     -- jobsend() preserves NULs.
-    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', [[call jobsend(j, ["123\n456",""])]])
     expect_msg_seq(
       { {'notification', 'stdout', {0, {'123\n456', ''} } },
@@ -192,6 +193,7 @@ describe('jobs', function()
   end)
 
   it("will not buffer data if it doesn't end in newlines", function()
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
     if os.getenv("TRAVIS") and os.getenv("CC") == "gcc-4.9"
       and helpers.os_name() == "osx" then
       -- XXX: Hangs Travis macOS since e9061117a5b8f195c3f26a5cb94e18ddd7752d86.
@@ -199,7 +201,7 @@ describe('jobs', function()
       return
     end
 
-    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, "abc\\nxyz")')
     eq({'notification', 'stdout', {0, {'abc', 'xyz'}}}, next_msg())
     nvim('command', "call jobstop(j)")
@@ -208,14 +210,16 @@ describe('jobs', function()
   end)
 
   it('preserves newlines', function()
-    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, "a\\n\\nc\\n\\n\\n\\nb\\n\\n")')
     eq({'notification', 'stdout',
       {0, {'a', '', 'c', '', '', '', 'b', '', ''}}}, next_msg())
   end)
 
   it('preserves NULs', function()
-    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, ["\n123\n", "abc\\nxyz\n", ""])')
     eq({'notification', 'stdout', {0, {'\n123\n', 'abc\nxyz\n', ''}}},
       next_msg())
@@ -225,7 +229,8 @@ describe('jobs', function()
   end)
 
   it('avoids sending final newline', function()
-    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, ["some data", "without\nfinal nl"])')
     eq({'notification', 'stdout', {0, {'some data', 'without\nfinal nl'}}},
       next_msg())
@@ -235,14 +240,16 @@ describe('jobs', function()
   end)
 
   it('closes the job streams with jobclose', function()
-    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobclose(j, "stdin")')
     eq({'notification', 'stdout', {0, {''}}}, next_msg())
     eq({'notification', 'exit', {0, 0}}, next_msg())
   end)
 
   it("disallows jobsend on a job that closed stdin", function()
-    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobclose(j, "stdin")')
     eq(false, pcall(function()
       nvim('command', 'call jobsend(j, ["some data"])')
@@ -255,7 +262,8 @@ describe('jobs', function()
   end)
 
   it('disallows jobstop twice on the same job', function()
-    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     neq(0, eval('j'))
     eq(true, pcall(eval, "jobstop(j)"))
     eq(false, pcall(eval, "jobstop(j)"))
@@ -667,9 +675,10 @@ describe('jobs', function()
   end)
 
   it('cannot have both rpc and pty options', function()
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
     command("let g:job_opts.pty = v:true")
     command("let g:job_opts.rpc = v:true")
-    local _, err = pcall(command, "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
+    local _, err = pcall(command, "let j = jobstart(['cat', '-'], g:job_opts)")
     ok(string.find(err, "E475: Invalid argument: job cannot have both 'pty' and 'rpc' options set") ~= nil)
   end)
 

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -179,10 +179,16 @@ describe('jobs', function()
     os.remove(filename)
 
     -- jobsend() preserves NULs.
-    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
     nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', [[call jobsend(j, ["123\n456",""])]])
-    eq({'notification', 'stdout', {0, {'123\n456', ''}}}, next_msg())
+    expect_msg_seq(
+      { {'notification', 'stdout', {0, {'123\n456', ''} } },
+      },
+      -- Alternative sequence:
+      { {'notification', 'stdout', {0, {'123\n456'} } },
+        {'notification', 'stdout', {0, {'', ''} } },
+      }
+    )
     nvim('command', "call jobstop(j)")
   end)
 

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -130,10 +130,8 @@ describe('jobs', function()
   end)
 
   it('invokes callbacks when the job writes and exits', function()
-    -- TODO: hangs on Windows
-    if helpers.pending_win32(pending) then return end
     nvim('command', "let g:job_opts.on_stderr  = function('OnEvent')")
-    nvim('command', [[call jobstart('echo ""', g:job_opts)]])
+    nvim('command', [[call jobstart(has('win32') ? ['cmd', '/c', 'echo.'] : 'echo ""', g:job_opts)]])
     expect_twostreams({{'notification', 'stdout', {0, {'', ''}}},
                        {'notification', 'stdout', {0, {''}}}},
                       {{'notification', 'stderr', {0, {''}}}})

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -141,8 +141,7 @@ describe('jobs', function()
   end)
 
   it('allows interactive commands', function()
-    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
-    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
     neq(0, eval('j'))
     nvim('command', 'call jobsend(j, "abc\\n")')
     eq({'notification', 'stdout', {0, {'abc', ''}}}, next_msg())
@@ -179,7 +178,7 @@ describe('jobs', function()
     os.remove(filename)
 
     -- jobsend() preserves NULs.
-    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
     nvim('command', [[call jobsend(j, ["123\n456",""])]])
     expect_msg_seq(
       { {'notification', 'stdout', {0, {'123\n456', ''} } },
@@ -193,7 +192,6 @@ describe('jobs', function()
   end)
 
   it("will not buffer data if it doesn't end in newlines", function()
-    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
     if os.getenv("TRAVIS") and os.getenv("CC") == "gcc-4.9"
       and helpers.os_name() == "osx" then
       -- XXX: Hangs Travis macOS since e9061117a5b8f195c3f26a5cb94e18ddd7752d86.
@@ -201,7 +199,7 @@ describe('jobs', function()
       return
     end
 
-    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, "abc\\nxyz")')
     eq({'notification', 'stdout', {0, {'abc', 'xyz'}}}, next_msg())
     nvim('command', "call jobstop(j)")
@@ -210,16 +208,14 @@ describe('jobs', function()
   end)
 
   it('preserves newlines', function()
-    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
-    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, "a\\n\\nc\\n\\n\\n\\nb\\n\\n")')
     eq({'notification', 'stdout',
       {0, {'a', '', 'c', '', '', '', 'b', '', ''}}}, next_msg())
   end)
 
   it('preserves NULs', function()
-    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
-    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, ["\n123\n", "abc\\nxyz\n", ""])')
     eq({'notification', 'stdout', {0, {'\n123\n', 'abc\nxyz\n', ''}}},
       next_msg())
@@ -229,8 +225,7 @@ describe('jobs', function()
   end)
 
   it('avoids sending final newline', function()
-    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
-    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, ["some data", "without\nfinal nl"])')
     eq({'notification', 'stdout', {0, {'some data', 'without\nfinal nl'}}},
       next_msg())
@@ -240,16 +235,14 @@ describe('jobs', function()
   end)
 
   it('closes the job streams with jobclose', function()
-    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
-    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
     nvim('command', 'call jobclose(j, "stdin")')
     eq({'notification', 'stdout', {0, {''}}}, next_msg())
     eq({'notification', 'exit', {0, 0}}, next_msg())
   end)
 
   it("disallows jobsend on a job that closed stdin", function()
-    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
-    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
     nvim('command', 'call jobclose(j, "stdin")')
     eq(false, pcall(function()
       nvim('command', 'call jobsend(j, ["some data"])')
@@ -262,8 +255,7 @@ describe('jobs', function()
   end)
 
   it('disallows jobstop twice on the same job', function()
-    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
-    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
     neq(0, eval('j'))
     eq(true, pcall(eval, "jobstop(j)"))
     eq(false, pcall(eval, "jobstop(j)"))
@@ -675,10 +667,9 @@ describe('jobs', function()
   end)
 
   it('cannot have both rpc and pty options', function()
-    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
     command("let g:job_opts.pty = v:true")
     command("let g:job_opts.rpc = v:true")
-    local _, err = pcall(command, "let j = jobstart(['cat', '-'], g:job_opts)")
+    local _, err = pcall(command, "let j = jobstart(has('win32') ? 'cat.exe -' : ['cat', '-'], g:job_opts)")
     ok(string.find(err, "E475: Invalid argument: job cannot have both 'pty' and 'rpc' options set") ~= nil)
   end)
 

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -165,8 +165,15 @@ describe('jobs', function()
     else
       nvim('command', "let j = jobstart(['cat', '"..filename.."'], g:job_opts)")
     end
-    eq({'notification', 'stdout', {0, {'abc\ndef', ''}}}, next_msg())
-    eq({'notification', 'stdout', {0, {''}}}, next_msg())
+    expect_msg_seq(
+      { {'notification', 'stdout', {0, {'abc\ndef', ''} } },
+        {'notification', 'stdout', {0, {''} } }
+      },
+      -- Alternative sequence:
+      { {'notification', 'stdout', {0, {'abc\ndef'} } },
+        {'notification', 'stdout', {0, {'', ''} } }
+      }
+    )
     eq({'notification', 'exit', {0, 0}}, next_msg())
     os.remove(filename)
 
@@ -420,7 +427,13 @@ describe('jobs', function()
     let g:job_opts = {'on_stdout': Callback}
     call jobstart('echo "some text"', g:job_opts)
     ]])
-    eq({'notification', '1', {'foo', 'bar', {'some text', ''}, 'stdout'}}, next_msg())
+    expect_msg_seq(
+      { {'notification', '1', {'foo', 'bar', {'some text', ''}, 'stdout'} },
+      },
+      -- Alternative sequence:
+      { {'notification', '1', {'foo', 'bar', {'some text'}, 'stdout'} },
+      }
+    )
   end)
 
   it('jobstart() works with closures', function()
@@ -433,7 +446,13 @@ describe('jobs', function()
       let g:job_opts = {'on_stdout': MkFun()}
       call jobstart('echo "some text"', g:job_opts)
     ]])
-    eq({'notification', '1', {'foo', 'bar', {'some text', ''}, 'stdout'}}, next_msg())
+    expect_msg_seq(
+      { {'notification', '1', {'foo', 'bar', {'some text', ''}, 'stdout'} },
+      },
+      -- Alternative sequence:
+      { {'notification', '1', {'foo', 'bar', {'some text'}, 'stdout'} },
+      }
+    )
   end)
 
   it('jobstart() works when closure passed directly to `jobstart`', function()
@@ -441,7 +460,13 @@ describe('jobs', function()
       let g:job_opts = {'on_stdout': {id, data, event -> rpcnotify(g:channel, '1', 'foo', 'bar', Normalize(data), event)}}
       call jobstart('echo "some text"', g:job_opts)
     ]])
-    eq({'notification', '1', {'foo', 'bar', {'some text', ''}, 'stdout'}}, next_msg())
+    expect_msg_seq(
+      { {'notification', '1', {'foo', 'bar', {'some text', ''}, 'stdout'} },
+      },
+      -- Alternative sequence:
+      { {'notification', '1', {'foo', 'bar', {'some text'}, 'stdout'} },
+      }
+    )
   end)
 
   describe('jobwait', function()

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -171,7 +171,8 @@ describe('jobs', function()
       },
       -- Alternative sequence:
       { {'notification', 'stdout', {0, {'abc\ndef'} } },
-        {'notification', 'stdout', {0, {'', ''} } }
+        {'notification', 'stdout', {0, {'', ''} } },
+        {'notification', 'stdout', {0, {''} } }
       }
     )
     eq({'notification', 'exit', {0, 0}}, next_msg())
@@ -325,7 +326,8 @@ describe('jobs', function()
       },
       -- Alternative sequence:
       { {'notification', 'stdout', {5, {'foo'} } },
-        {'notification', 'stdout', {5, {'', ''} } }
+        {'notification', 'stdout', {5, {'', ''} } },
+        {'notification', 'stdout', {5, {''} } }
       }
     )
   end)
@@ -432,6 +434,7 @@ describe('jobs', function()
       },
       -- Alternative sequence:
       { {'notification', '1', {'foo', 'bar', {'some text'}, 'stdout'} },
+        {'notification', '1', {'foo', 'bar', {'', ''}, 'stdout'} },
       }
     )
   end)
@@ -451,6 +454,7 @@ describe('jobs', function()
       },
       -- Alternative sequence:
       { {'notification', '1', {'foo', 'bar', {'some text'}, 'stdout'} },
+        {'notification', '1', {'foo', 'bar', {'', ''}, 'stdout'} },
       }
     )
   end)
@@ -465,6 +469,7 @@ describe('jobs', function()
       },
       -- Alternative sequence:
       { {'notification', '1', {'foo', 'bar', {'some text'}, 'stdout'} },
+        {'notification', '1', {'foo', 'bar', {'', ''}, 'stdout'} },
       }
     )
   end)

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -614,7 +614,7 @@ describe('jobs', function()
         call rpcnotify(g:channel, 'wait', jobwait([
         \  jobstart('exit 4'),
         \  jobstart((has('win32') ? 'Start-Sleep 10' : 'sleep 10').'; exit 5'),
-        \  ], 100))
+        \  ], has('win32') ? 1000 : 100))
         ]])
         eq({'notification', 'wait', {{4, -1}}}, next_msg())
       end)

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -14,7 +14,6 @@ local nvim_set = helpers.nvim_set
 local expect_twostreams = helpers.expect_twostreams
 local expect_msg_seq = helpers.expect_msg_seq
 local Screen = require('test.functional.ui.screen')
-local nvim_cat = iswin() and nvim_dir..'\\cat' or 'cat'
 
 describe('jobs', function()
   local channel
@@ -142,7 +141,8 @@ describe('jobs', function()
   end)
 
   it('allows interactive commands', function()
-    nvim('command', "let j = jobstart(['"..nvim_cat.."', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     neq(0, eval('j'))
     nvim('command', 'call jobsend(j, "abc\\n")')
     eq({'notification', 'stdout', {0, {'abc', ''}}}, next_msg())
@@ -179,7 +179,7 @@ describe('jobs', function()
     os.remove(filename)
 
     -- jobsend() preserves NULs.
-    nvim('command', "let j = jobstart(['"..nvim_cat.."', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', [[call jobsend(j, ["123\n456",""])]])
     expect_msg_seq(
       { {'notification', 'stdout', {0, {'123\n456', ''} } },
@@ -193,6 +193,7 @@ describe('jobs', function()
   end)
 
   it("will not buffer data if it doesn't end in newlines", function()
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
     if os.getenv("TRAVIS") and os.getenv("CC") == "gcc-4.9"
       and helpers.os_name() == "osx" then
       -- XXX: Hangs Travis macOS since e9061117a5b8f195c3f26a5cb94e18ddd7752d86.
@@ -200,7 +201,7 @@ describe('jobs', function()
       return
     end
 
-    nvim('command', "let j = jobstart(['"..nvim_cat.."', '-'], g:job_opts)")
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, "abc\\nxyz")')
     eq({'notification', 'stdout', {0, {'abc', 'xyz'}}}, next_msg())
     nvim('command', "call jobstop(j)")
@@ -209,14 +210,16 @@ describe('jobs', function()
   end)
 
   it('preserves newlines', function()
-    nvim('command', "let j = jobstart(['"..nvim_cat.."', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, "a\\n\\nc\\n\\n\\n\\nb\\n\\n")')
     eq({'notification', 'stdout',
       {0, {'a', '', 'c', '', '', '', 'b', '', ''}}}, next_msg())
   end)
 
   it('preserves NULs', function()
-    nvim('command', "let j = jobstart(['"..nvim_cat.."', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, ["\n123\n", "abc\\nxyz\n", ""])')
     eq({'notification', 'stdout', {0, {'\n123\n', 'abc\nxyz\n', ''}}},
       next_msg())
@@ -226,7 +229,8 @@ describe('jobs', function()
   end)
 
   it('avoids sending final newline', function()
-    nvim('command', "let j = jobstart(['"..nvim_cat.."', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobsend(j, ["some data", "without\nfinal nl"])')
     eq({'notification', 'stdout', {0, {'some data', 'without\nfinal nl'}}},
       next_msg())
@@ -236,14 +240,16 @@ describe('jobs', function()
   end)
 
   it('closes the job streams with jobclose', function()
-    nvim('command', "let j = jobstart(['"..nvim_cat.."', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobclose(j, "stdin")')
     eq({'notification', 'stdout', {0, {''}}}, next_msg())
     eq({'notification', 'exit', {0, 0}}, next_msg())
   end)
 
   it("disallows jobsend on a job that closed stdin", function()
-    nvim('command', "let j = jobstart(['"..nvim_cat.."', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     nvim('command', 'call jobclose(j, "stdin")')
     eq(false, pcall(function()
       nvim('command', 'call jobsend(j, ["some data"])')
@@ -256,7 +262,8 @@ describe('jobs', function()
   end)
 
   it('disallows jobstop twice on the same job', function()
-    nvim('command', "let j = jobstart(['"..nvim_cat.."', '-'], g:job_opts)")
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+    nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     neq(0, eval('j'))
     eq(true, pcall(eval, "jobstop(j)"))
     eq(false, pcall(eval, "jobstop(j)"))
@@ -668,9 +675,10 @@ describe('jobs', function()
   end)
 
   it('cannot have both rpc and pty options', function()
+    if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
     command("let g:job_opts.pty = v:true")
     command("let g:job_opts.rpc = v:true")
-    local _, err = pcall(command, "let j = jobstart(['"..nvim_cat.."', '-'], g:job_opts)")
+    local _, err = pcall(command, "let j = jobstart(['cat', '-'], g:job_opts)")
     ok(string.find(err, "E475: Invalid argument: job cannot have both 'pty' and 'rpc' options set") ~= nil)
   end)
 

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -609,12 +609,11 @@ describe('jobs', function()
     end)
 
     describe('with timeout argument', function()
-      if helpers.pending_win32(pending) then return end
       it('will return -1 if the wait timed out', function()
         source([[
         call rpcnotify(g:channel, 'wait', jobwait([
         \  jobstart('exit 4'),
-        \  jobstart('sleep 10; exit 5'),
+        \  jobstart((has('win32') ? 'Start-Sleep 10' : 'sleep 10').'; exit 5'),
         \  ], 100))
         ]])
         eq({'notification', 'wait', {{4, -1}}}, next_msg())

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -304,8 +304,16 @@ describe('jobs', function()
     nvim('command', 'let g:job_opts.user = {"n": 5, "s": "str", "l": [1]}')
     nvim('command', [[call jobstart('echo "foo"', g:job_opts)]])
     local data = {n = 5, s = 'str', l = {1}}
-    eq({'notification', 'stdout', {data, {'foo', ''}}}, next_msg())
-    eq({'notification', 'stdout', {data, {''}}}, next_msg())
+    expect_msg_seq(
+      { {'notification', 'stdout', {data, {'foo', ''}}},
+        {'notification', 'stdout', {data, {''}}}
+      },
+      -- Alternative sequence:
+      { {'notification', 'stdout', {data, {'foo'}}},
+        {'notification', 'stdout', {data, {'', ''}}},
+        {'notification', 'stdout', {data, {''}}}
+      }
+    )
     eq({'notification', 'exit', {data, 0}}, next_msg())
   end)
 
@@ -619,7 +627,7 @@ describe('jobs', function()
         call rpcnotify(g:channel, 'wait', jobwait([
         \  jobstart('exit 4'),
         \  jobstart((has('win32') ? 'Start-Sleep 10' : 'sleep 10').'; exit 5'),
-        \  ], has('win32') ? 1000 : 100))
+        \  ], has('win32') ? 5000 : 100))
         ]])
         eq({'notification', 'wait', {{4, -1}}}, next_msg())
       end)

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -425,7 +425,7 @@ end
 local function set_shell_powershell()
   source([[
     set shell=powershell shellquote=( shellpipe=\| shellredir=> shellxquote=
-    let &shellcmdflag = '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command Remove-Item -Force alias:sleep;'
+    let &shellcmdflag = '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command Remove-Item -Force alias:sleep; Remove-Item -Force alias:cat;'
   ]])
 end
 

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -425,7 +425,7 @@ end
 local function set_shell_powershell()
   source([[
     set shell=powershell shellquote=( shellpipe=\| shellredir=> shellxquote=
-    set shellcmdflag=-NoLogo\ -NoProfile\ -ExecutionPolicy\ RemoteSigned\ -Command
+    let &shellcmdflag = '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command Remove-Item -Force alias:sleep;'
   ]])
 end
 


### PR DESCRIPTION
Continue #7412 to resolve flaky tests in `job_spec.lua`.

This PR modifies `shellcmdflag` for powershell to remove aliases to avoid confusion such as `sleep.exe` (executable) and `Start-Sleep` (powershell built-in, doesn't accept floats).

I cannot make `cat.exe` reliably work on Windows. I'm considering cmd.exe to test `jobsend()` if there's no powershell alternative to `cat.exe -`. Powershell has `Read-Host` and `$host.UI.RawUI.ReadKey()` but neither work with `jobsend()`.