### PR TITLE
[RFC] vim-patch:8.0.0225: put in Visual block mode terminates early

### DIFF
--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -10,3 +10,14 @@ func Test_put_block()
   call assert_equal("\u2500x", getline(1))
   bwipe!
 endfunc
+
+func Test_put_char_block()
+  new
+  call setline(1, ['Line 1', 'Line 2'])
+  f Xfile_put
+  " visually select both lines and put the cursor at the top of the visual
+  " selection and then put the buffer name over it
+  exe "norm! G0\<c-v>ke\"%p"
+  call assert_equal(['Xfile_put 1', 'Xfile_put 2'], getline(1,2))
+  bw!
+endfunc


### PR DESCRIPTION
Problem:    When a block is visually selected and put is used on the end of
            the selection only one line is changed.
Solution:   Check for the end properly. (Christian Brabandt, neovim issue
            5781)

https://github.com/vim/vim/commit/9957a10d0f0c34d8083af6ed66e198e4796038e0