### PR TITLE
[RFC] third-party: build all deps with debugging symbols

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -2,6 +2,9 @@
 cmake_minimum_required (VERSION 2.8.7)
 project(NVIM_DEPS)
 
+# Needed for: check_c_compiler_flag()
+include(CheckCCompilerFlag)
+
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
@@ -9,6 +12,13 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 # recipes (libuv, msgpack), make sure it is set
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(DEFAULT_MAKE_CFLAGS CFLAGS+=-g)
+
+check_c_compiler_flag(-Og HAS_OG_FLAG)
+if(HAS_OG_FLAG)
+  set(DEFAULT_MAKE_CFLAGS CFLAGS+=-Og ${DEFAULT_MAKE_CFLAGS})
 endif()
 
 set(DEPS_INSTALL_DIR "${CMAKE_BINARY_DIR}/usr" CACHE PATH "Dependencies install directory.")

--- a/third-party/cmake/BuildLibtermkey.cmake
+++ b/third-party/cmake/BuildLibtermkey.cmake
@@ -43,6 +43,7 @@ ExternalProject_Add(libtermkey
                               PREFIX=${DEPS_INSTALL_DIR}
                               PKG_CONFIG_PATH=${DEPS_LIB_DIR}/pkgconfig
                               CFLAGS=-fPIC
+                              ${DEFAULT_MAKE_CFLAGS}
                               install)
 endif()
 

--- a/third-party/cmake/BuildLibvterm.cmake
+++ b/third-party/cmake/BuildLibvterm.cmake
@@ -47,9 +47,10 @@ if(WIN32)
   set(LIBVTERM_INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install --config ${CMAKE_BUILD_TYPE})
 else()
   set(LIBVTERM_INSTALL_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
-                                PREFIX=${DEPS_INSTALL_DIR}
-                                CFLAGS=-fPIC
-                                install)
+                                           PREFIX=${DEPS_INSTALL_DIR}
+                                           CFLAGS=-fPIC
+                                           ${DEFAULT_MAKE_CFLAGS}
+                                           install)
 endif()
 
 BuildLibvterm(CONFIGURE_COMMAND ${LIBVTERM_CONFIGURE_COMMAND}

--- a/third-party/cmake/BuildUnibilium.cmake
+++ b/third-party/cmake/BuildUnibilium.cmake
@@ -20,6 +20,7 @@ ExternalProject_Add(unibilium
   BUILD_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
                             PREFIX=${DEPS_INSTALL_DIR}
                             CFLAGS=-fPIC
+                            ${DEFAULT_MAKE_CFLAGS}
   INSTALL_COMMAND ${MAKE_PRG} PREFIX=${DEPS_INSTALL_DIR} install)
 
 list(APPEND THIRD_PARTY_DEPS unibilium)


### PR DESCRIPTION
By default, our Makefile provides `-DCMAKE_BUILD_TYPE` to `CMakeLists.txt`, but not to `third-party/CMakeLists.txt`.

Currently this is only done for unibilium, but I guess it makes sense to make debug builds of all our dependencies if `CMAKE_BUILD_TYPE=Debug` anyway.

This makes it easy to debug the bundled deps in a debugger, since you have access to the C sources.