### PR TITLE
health/provider: check Python also with loaded_var

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -260,8 +260,7 @@ function! s:check_python(version) abort
   let python_multiple = []
 
   if exists(loaded_var) && !exists('*provider#'.pyname.'#Call')
-    call health#report_info('Disabled. '.loaded_var.'='.eval(loaded_var))
-    return
+    call health#report_info('Disabled ('.loaded_var.'='.eval(loaded_var).').  This might be due to some previous error.')
   endif
 
   if !empty(pyenv)


### PR DESCRIPTION
`g:loaded_python3_provider` gets set when the autoload file is sourced,
but this might error out, e.g. with deoplete:

    [deoplete] Failed to load python3 host. You can try to see what happened by starting nvim with $NVIM_PYTHON_LOG_FILE set and opening the generated log file. Also, the host stderr is available in messages.
    [deoplete] function remote#define#FunctionBootstrap[1]..remote#host#Require[10]..provider#pythonx#Require[13]..provider#Poll, line 14
    [deoplete] deoplete requires Python3 support("+python3").
    [deoplete] deoplete failed to load. Try the :UpdateRemotePlugins command and restart Neovim.  See also :checkhealth.

It refers to `:checkhealth` from there explicitly, which would then
(without this patch) say that Python 3 is disabled.

This patch changes the reported info to include that it might have been
disabled due to some error, and keeps on going.