### PR TITLE
health/provider: python: warning with correct host prog

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -349,8 +349,8 @@ function! s:check_python(version) abort
     endif
   endif
 
-  if !empty(python_bin)
-    if empty(venv) && !empty(pyenv) && !exists('g:'.host_prog_var)
+  if !empty(python_bin) && !exists('g:'.host_prog_var)
+    if empty(venv) && !empty(pyenv)
           \ && !empty(pyenv_root) && resolve(python_bin) !~# '^'.pyenv_root.'/'
       call health#report_warn('pyenv is not set up optimally.', [
             \ printf('Create a virtualenv specifically '
@@ -358,7 +358,7 @@ function! s:check_python(version) abort
             \ . 'the need to install the Neovim Python module in each '
             \ . 'version/virtualenv.', host_prog_var)
             \ ])
-    elseif !empty(venv) && exists('g:'.host_prog_var)
+    elseif !empty(venv)
       if !empty(pyenv_root)
         let venv_root = pyenv_root
       else


### PR DESCRIPTION
I have `g:python3_host_prog` set to the system Python, where a packageI have `g:python3_host_prog` set to the system Python, where a packageis also installed to provide the "neovim" module.

`:checkhealth provider` however displays a warning for this:

> Your virtualenv is not set up optimally.

This is because /usr/bin/python is not in /home/user/.pyenv.

I think this warning should not get displayed if host_prog_var exists.

It goes back to the initial commit (20447ba09), and is maybe only
missing the `!` there as with the previous commit.

Full output:
```
  - INFO: pyenv: /home/user/.pyenv/libexec/pyenv
  - INFO: pyenv root: /home/user/.pyenv
  - INFO: Using: g:python3_host_prog = "/usr/bin/python"
  - WARNING: Your virtualenv is not set up optimally (/usr/bin/python is not in /home/user/.pyenv).
    - ADVICE:
      - Create a virtualenv specifically for Neovim and use `g:python3_host_prog`.  This will avoid the need to install Neovim's Python module in each virtualenv.
  - WARNING: $VIRTUAL_ENV exists but appears to be inactive. This could lead to unexpected results.
    - ADVICE:
      - If you are using Zsh, see: http://vi.stackexchange.com/a/7654
  - INFO: Executable: /usr/bin/python
  - INFO: Python3 version: 3.6.4
  - INFO: python-neovim version: 0.2.1
  - OK: Latest python-neovim is installed: 0.2.1
```

/cc @tweekmonster 