### PR TITLE
[RFC] ui_bridge: make sure TUI receives no more messages after "stop" message

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -144,12 +144,6 @@ void ui_builtin_stop(void)
   UI_CALL(stop);
 }
 
-/// Returns true if UI `ui` is stopped.
-bool ui_is_stopped(UI *ui)
-{
-  return ui->data == NULL;
-}
-
 bool ui_rgb_attached(void)
 {
   if (!headless_mode && p_tgc) {

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -106,6 +106,9 @@ static void ui_thread_run(void *data)
 
 static void ui_bridge_stop(UI *b)
 {
+  // Detach brigde first, so that "stop" is the last event the TUI loop
+  // receives from the main thread. #8041
+  ui_detach_impl(b);
   UIBridgeData *bridge = (UIBridgeData *)b;
   bool stopped = bridge->stopped = false;
   UI_BRIDGE_CALL(b, stop, 1, b);
@@ -122,7 +125,6 @@ static void ui_bridge_stop(UI *b)
   uv_mutex_destroy(&bridge->mutex);
   uv_cond_destroy(&bridge->cond);
   xfree(bridge->ui);  // Threads joined, now safe to free UI container. #7922
-  ui_detach_impl(b);
   xfree(b);
 }
 static void ui_bridge_stop_event(void **argv)


### PR DESCRIPTION
Fix data race in `tui_scheduler`, there is no guarantee that `tui_stop` has been called at the point `ui_bridge_stop` invokes the main loop, so events might be scheduled on the TUI thread after `tui_stop`.

Ref #8041.