### PR TITLE
[RFC] make 'writedelay' show all redraws

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6922,7 +6922,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'writedelay' 'wd'	number	(default 0)
 			global
 	The number of milliseconds to wait for each character sent to the
-	screen.  When non-zero, characters are sent to the terminal one by
-	one.  For debugging purposes.
+	screen.  When positive, characters are sent to the UI one by one.
+	When negative, all redrawn characters cause a delay, even if the
+	character already was displayed by the UI.  For debugging purposes.
 
  vim:tw=78:ts=8:ft=help:noet:norl:

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4361,7 +4361,8 @@ static int char_needs_redraw(int off_from, int off_to, int cols)
                       && comp_char_differs(off_from, off_to))
                   || ((*mb_off2cells)(off_from, off_from + cols) > 1
                       && ScreenLines[off_from + 1]
-                      != ScreenLines[off_to + 1])))));
+                      != ScreenLines[off_to + 1])))
+          || p_wd < 0));
 }
 
 /*

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -437,9 +437,8 @@ void ui_puts(uint8_t *str)
 
     if (p_wd) {  // 'writedelay': flush & delay each time.
       ui_flush();
-      assert(p_wd >= 0
-             && (sizeof(long) <= sizeof(uint64_t) || p_wd <= UINT64_MAX));
-      os_delay((uint64_t)p_wd, false);
+      uint64_t wd = (uint64_t)labs(p_wd);
+      os_delay(wd, false);
     }
   }
 }


### PR DESCRIPTION
Currently `writedelay` shows the sequence of characters that are sent to the UI/TUI module. Here vim/nvim has already applied an optimization: when attempting to put a char in a screen cell, if the same char already was there with the same attributes, UI output is disabled.  When I'm debugging redrawing I am more interested in the dataflow one step earlier, i e what region of the screen nvim actually is recomputing from buffer contents (`win_line`) and by reevaluating statuslines exprs. 

Take the popupmenu as an example. When closing the pum (in the TUI), currently `'writedelay'` looks like vim only is redrawing the region the pum covered, nice and fully optimized. This is not what happens internally: vim redraws the entire screen, even if only outputs the changed region.

Though I guess the current behavior is more useful in some other situations. An alternative then is of course to enable this stricter mode by setting `'writedelay'` to a negative value.