### PR TITLE
unittest: Ignore all _Float-prefixed types

### DIFF
--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -138,7 +138,7 @@ local function filter_complex_blocks(body)
   for line in body:gmatch("[^\r\n]+") do
     if not (string.find(line, "(^)", 1, true) ~= nil
             or string.find(line, "_ISwupper", 1, true)
-            or string.find(line, "_Float128")
+            or string.find(line, "_Float")
             or string.find(line, "msgpack_zone_push_finalizer")
             or string.find(line, "msgpack_unpacker_reserve_buffer")
             or string.find(line, "UUID_NULL")  -- static const uuid_t UUID_NULL = {...}


### PR DESCRIPTION
Previously, we were just ignore _Float128 but glibc 2.27 added _Float32
and _Float32x.  Rather than play whack-a-mole, ignore everything.