### PR TITLE
third-party: Use luacheck releases (0.21.2 for now) instead of master

### DIFF
--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -150,12 +150,12 @@ if(USE_BUNDLED_BUSTED)
   endif()
 
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
-  add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight/1.3.2-2
+  add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build penlight 1.3.2-2 ${LUAROCKS_BUILDARGS}
+    ARGS build penlight ${LUAROCKS_BUILDARGS}
     DEPENDS ${PENLIGHT_DEPENDS})
   add_custom_target(penlight
-    DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight/1.3.2-2)
+    DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight)
 
   if(WIN32)
     set(BUSTED_EXE "${HOSTDEPS_BIN_DIR}/busted.bat")
@@ -167,7 +167,7 @@ if(USE_BUNDLED_BUSTED)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${BUSTED_EXE}
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build https://raw.githubusercontent.com/Olivine-Labs/busted/v2.0.rc12-1/busted-2.0.rc12-1.rockspec ${LUAROCKS_BUILDARGS}
+    ARGS build busted ${LUAROCKS_BUILDARGS}
     DEPENDS penlight)
   add_custom_target(busted
     DEPENDS ${BUSTED_EXE})
@@ -175,7 +175,7 @@ if(USE_BUNDLED_BUSTED)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${LUACHECK_EXE}
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build https://luarocks.org/manifests/mpeterv/luacheck-0.21.2-1.rockspec ${LUAROCKS_BUILDARGS}
+    ARGS build luacheck ${LUAROCKS_BUILDARGS}
     DEPENDS busted)
   add_custom_target(luacheck
     DEPENDS ${LUACHECK_EXE})
@@ -200,7 +200,7 @@ if(USE_BUNDLED_BUSTED)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build https://raw.githubusercontent.com/neovim/lua-client/0.0.1-26/nvim-client-0.0.1-26.rockspec ${LUAROCKS_BUILDARGS}
+    ARGS build nvim-client ${LUAROCKS_BUILDARGS}
     DEPENDS luv)
   add_custom_target(nvim-client
     DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client)

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -104,7 +104,7 @@ endif()
 # DEPENDS on the previous module, because Luarocks breaks if parallel.
 add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/mpack
   COMMAND ${LUAROCKS_BINARY}
-  ARGS build mpack ${LUAROCKS_BUILDARGS}
+  ARGS build mpack 1.0.7-0 ${LUAROCKS_BUILDARGS}
   DEPENDS luarocks)
 add_custom_target(mpack
   DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/mpack)
@@ -113,7 +113,7 @@ list(APPEND THIRD_PARTY_DEPS mpack)
 # DEPENDS on the previous module, because Luarocks breaks if parallel.
 add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/lpeg
   COMMAND ${LUAROCKS_BINARY}
-  ARGS build lpeg ${LUAROCKS_BUILDARGS}
+  ARGS build lpeg 1.0.1-1 ${LUAROCKS_BUILDARGS}
   DEPENDS mpack)
 add_custom_target(lpeg
   DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/lpeg)
@@ -123,7 +123,7 @@ list(APPEND THIRD_PARTY_DEPS lpeg)
 # DEPENDS on the previous module, because Luarocks breaks if parallel.
 add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/inspect
   COMMAND ${LUAROCKS_BINARY}
-  ARGS build inspect ${LUAROCKS_BUILDARGS}
+  ARGS build inspect 3.1.1-0 ${LUAROCKS_BUILDARGS}
   DEPENDS lpeg)
 add_custom_target(inspect
   DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/inspect)
@@ -134,7 +134,7 @@ if((NOT USE_BUNDLED_LUAJIT) AND USE_BUNDLED_LUA)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/luabitop
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build luabitop ${LUAROCKS_BUILDARGS}
+    ARGS build luabitop 1.0.2-3 ${LUAROCKS_BUILDARGS}
     DEPENDS inspect)
   add_custom_target(luabitop
     DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/luabitop)
@@ -152,7 +152,7 @@ if(USE_BUNDLED_BUSTED)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build penlight ${LUAROCKS_BUILDARGS}
+    ARGS build penlight 1.5.4-1 ${LUAROCKS_BUILDARGS}
     DEPENDS ${PENLIGHT_DEPENDS})
   add_custom_target(penlight
     DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight)
@@ -167,7 +167,7 @@ if(USE_BUNDLED_BUSTED)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${BUSTED_EXE}
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build busted ${LUAROCKS_BUILDARGS}
+    ARGS build busted 2.0.rc12-1 ${LUAROCKS_BUILDARGS}
     DEPENDS penlight)
   add_custom_target(busted
     DEPENDS ${BUSTED_EXE})
@@ -175,7 +175,7 @@ if(USE_BUNDLED_BUSTED)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${LUACHECK_EXE}
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build luacheck ${LUAROCKS_BUILDARGS}
+    ARGS build luacheck 0.21.2-1 ${LUAROCKS_BUILDARGS}
     DEPENDS busted)
   add_custom_target(luacheck
     DEPENDS ${LUACHECK_EXE})
@@ -200,7 +200,7 @@ if(USE_BUNDLED_BUSTED)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build nvim-client ${LUAROCKS_BUILDARGS}
+    ARGS build nvim-client 0.0.1-26 ${LUAROCKS_BUILDARGS}
     DEPENDS luv)
   add_custom_target(nvim-client
     DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client)

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -175,7 +175,7 @@ if(USE_BUNDLED_BUSTED)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${LUACHECK_EXE}
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build https://raw.githubusercontent.com/mpeterv/luacheck/master/luacheck-dev-1.rockspec ${LUAROCKS_BUILDARGS}
+    ARGS build https://luarocks.org/manifests/mpeterv/luacheck-0.21.2-1.rockspec ${LUAROCKS_BUILDARGS}
     DEPENDS busted)
   add_custom_target(luacheck
     DEPENDS ${LUACHECK_EXE})


### PR DESCRIPTION
Tracking master subjects us to breakages (as happened when
luacheck-scm-1.rockspec got renamed to luacheck-dev-1.rockspec) and
makes older releases unbuildable when that happens.