### PR TITLE
[RFC] gitignore: patch(1) artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ local.mk
 /runtime/doc/*.html
 /runtime/doc/tags.ref
 /runtime/doc/errors.log
+
+# files from patch(1)
+*.patch
+*.orig
+*.rej


### PR DESCRIPTION
Ignore `.orig` and `.rej` files which get created after a failed attempt to apply a patch.