### PR TITLE
[RFC] screen: make winhl=Normal:XXX not override syntax

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2044,7 +2044,7 @@ static void fold_line(win_T *wp, long fold_count, foldinfo_T *foldinfo, linenr_T
   }
 
   screen_line(row + wp->w_winrow, wp->w_wincol, wp->w_width,
-              wp->w_width, false, wp);
+              wp->w_width, false, wp, 0);
 
   /*
    * Update w_cline_height and w_cline_folded if the cursor line was
@@ -2463,10 +2463,6 @@ win_line (
   // Highlight the current line in the quickfix window.
   if (bt_quickfix(wp->w_buffer) && qf_current_entry(wp) == lnum) {
     line_attr = win_hl_attr(wp, HLF_QFL);
-  }
-
-  if (wp->w_hl_attr_normal != 0) {
-    line_attr = hl_combine_attr(wp->w_hl_attr_normal, line_attr);
   }
 
   if (line_attr != 0) {
@@ -2926,7 +2922,8 @@ win_line (
         && lnum == wp->w_cursor.lnum && vcol >= (long)wp->w_virtcol
         && filler_todo <= 0
         ) {
-      screen_line(screen_row, wp->w_wincol, col, -wp->w_width, wp->w_p_rl, wp);
+      screen_line(screen_row, wp->w_wincol, col, -wp->w_width, wp->w_p_rl, wp,
+                  wp->w_hl_attr_normal);
       // Pretend we have finished updating the window.  Except when
       // 'cursorcolumn' is set.
       if (wp->w_p_cuc) {
@@ -4019,7 +4016,8 @@ win_line (
           col++;
         }
       }
-      screen_line(screen_row, wp->w_wincol, col, wp->w_width, wp->w_p_rl, wp);
+      screen_line(screen_row, wp->w_wincol, col, wp->w_width, wp->w_p_rl, wp,
+                  wp->w_hl_attr_normal);
       row++;
 
       /*
@@ -4242,7 +4240,7 @@ win_line (
             || (n_extra != 0 && (c_extra != NUL || *p_extra != NUL)))
         ) {
       screen_line(screen_row, wp->w_wincol, col - boguscols,
-                  wp->w_width, wp->w_p_rl, wp);
+                  wp->w_width, wp->w_p_rl, wp, wp->w_hl_attr_normal);
       boguscols = 0;
       ++row;
       ++screen_row;
@@ -4412,7 +4410,7 @@ static int char_needs_redraw(int off_from, int off_to, int cols)
  *    When FALSE and "clear_width" > 0, clear columns "endcol" to "clear_width"
  */
 static void screen_line(int row, int coloff, int endcol,
-                        int clear_width, int rlflag, win_T *wp)
+                        int clear_width, int rlflag, win_T *wp, int bg_attr)
 {
   unsigned off_from;
   unsigned off_to;
@@ -4445,20 +4443,28 @@ static void screen_line(int row, int coloff, int endcol,
     /* Clear rest first, because it's left of the text. */
     if (clear_width > 0) {
       while (col <= endcol && ScreenLines[off_to] == ' '
-             && ScreenAttrs[off_to] == 0
+             && ScreenAttrs[off_to] == bg_attr
              && (!enc_utf8 || ScreenLinesUC[off_to] == 0)
              ) {
         ++off_to;
         ++col;
       }
-      if (col <= endcol)
-        screen_fill(row, row + 1, col + coloff,
-            endcol + coloff + 1, ' ', ' ', 0);
+      if (col <= endcol) {
+        screen_fill(row, row + 1, col + coloff, endcol + coloff + 1, ' ', ' ',
+                    bg_attr);
+      }
     }
     col = endcol + 1;
     off_to = LineOffset[row] + col + coloff;
     off_from += col;
     endcol = (clear_width > 0 ? clear_width : -clear_width);
+  }
+
+  if (bg_attr) {
+    for (int c = col; c < endcol; c++) {
+      ScreenAttrs[off_from+c] = hl_combine_attr(bg_attr,
+                                                ScreenAttrs[off_from+c]);
+    }
   }
 
   redraw_next = char_needs_redraw(off_from, off_to, endcol - col);
@@ -4559,15 +4565,15 @@ static void screen_line(int row, int coloff, int endcol,
 
     /* blank out the rest of the line */
     while (col < clear_width && ScreenLines[off_to] == ' '
-           && ScreenAttrs[off_to] == 0
+           && ScreenAttrs[off_to] == bg_attr
            && (!enc_utf8 || ScreenLinesUC[off_to] == 0)
            ) {
       ++off_to;
       ++col;
     }
     if (col < clear_width) {
-      screen_fill(row, row + 1, col + coloff, clear_width + coloff,
-          ' ', ' ', 0);
+      screen_fill(row, row + 1, col + coloff, clear_width + coloff, ' ', ' ',
+                  bg_attr);
       off_to += clear_width - col;
       col = clear_width;
     }

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -778,6 +778,9 @@ describe("'winhighlight' highlight", function()
       [22] = {bold = true, foreground = Screen.colors.SeaGreen4},
       [23] = {background = Screen.colors.LightMagenta},
       [24] = {background = Screen.colors.WebGray},
+      [25] = {bold = true, foreground = Screen.colors.Green1},
+      [26] = {background = Screen.colors.Red},
+      [27] = {background = Screen.colors.DarkBlue, bold = true, foreground = Screen.colors.Green1},
     })
     command("hi Background1 guibg=DarkBlue")
     command("hi Background2 guibg=DarkGreen")
@@ -1038,6 +1041,39 @@ describe("'winhighlight' highlight", function()
     screen:expect([[
       {10:  1 }{2:❮}{1: dolor ^sit ame}{2:❯}|
       {2:~                   }|
+      {2:~                   }|
+      {2:~                   }|
+      {2:~                   }|
+      {2:~                   }|
+      {2:~                   }|
+                          |
+    ]])
+  end)
+
+  it("background doesn't override syntax background", function()
+    command('syntax on')
+    command('syntax keyword Foobar foobar')
+    command('syntax keyword Article the')
+    command('hi Foobar guibg=#FF0000')
+    command('hi Article guifg=#00FF00 gui=bold')
+    insert('the foobar was foobar')
+    screen:expect([[
+      {25:the} {26:foobar} was {26:fooba}|
+      {26:^r}                   |
+      {0:~                   }|
+      {0:~                   }|
+      {0:~                   }|
+      {0:~                   }|
+      {0:~                   }|
+                          |
+    ]])
+
+    -- winhl=Normal:Group with background doesn't override syntax background,
+    -- but does combine with syntax foreground.
+    command('set winhl=Normal:Background1')
+    screen:expect([[
+      {27:the}{1: }{26:foobar}{1: was }{26:fooba}|
+      {26:^r}{1:                   }|
       {2:~                   }|
       {2:~                   }|
       {2:~                   }|


### PR DESCRIPTION
Fixes #7375.

The new semantics is consistent with how I think multigrid rendering should handle `winhl=Normal`, instead of filling the grid with the the background color, store different "normal" colors per grid. This means NormalNC can be implemented without doing full redraw everytime window focus is changed.

Note: I broke this out of a larger (incomplete) refactor, where nvim can send a single damage event per `screen_line` which compact representation of the changed part of the line (and of end-of-line whitespace, even with vsplit window) Probably this revision should be stabilized together with multigrid, so we only need to support two major revisions of the UI grid protocol and not three...