### PR TITLE
[RFC] ci: the homebrew formula for Python 3 was renamed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,11 @@ jobs:
     - os: osx
       compiler: clang
       osx_image: xcode7.3  # macOS 10.11
+      env: PATH="/usr/local/opt/python@2/bin:$PATH"
     - os: osx
       compiler: gcc
       osx_image: xcode7.3  # macOS 10.11
+      env: PATH="/usr/local/opt/python@2/bin:$PATH"
     - os: linux
       env: CI_TARGET=lint
     - stage: Flaky builds

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -23,12 +23,17 @@ echo 'python info:'
   2>&1 pyenv versions || true
 ) | sed 's/^/  /'
 
+if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+  echo "Install Python 2."
+  brew install python@2
+fi
+
 echo "Upgrade Python 2 pip."
 pip2.7 -q install --user --upgrade pip
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
-  echo "Install Python 3."
-  brew install python3
+  echo "Upgrade Python 3."
+  brew upgrade python
   echo "Upgrade Python 3 pip."
   pip3 -q install --user --upgrade pip
 else


### PR DESCRIPTION
Homebrew changed a few formulae to meet their standards. "python3" was renamed
to "python", and "python2" to "python@2".

As for why, read this announcement: https://brew.sh/2018/01/19/homebrew-1.5.0

Since we install Python 3 via homebrew anyway, we now do the same for Python 2
as well. We do that because the system Python 2 of macOS comes without pip
installed and this way seems cleaner than doing "sudo easy_install pip".

The Python 2 formula is keg-only now, so it doesn't interfere with the system
Python 2. Therefore we have to add its executables to $PATH ourselves.
