### PR TITLE
[RFC] vim-patch:8.0.1561

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -2133,9 +2133,11 @@ syn_current_attr (
 
   /* nextgroup ends at end of line, unless "skipnl" or "skipempty" present */
   if (current_next_list != NULL
-      && syn_getcurline()[current_col + 1] == NUL
-      && !(current_next_flags & (HL_SKIPNL | HL_SKIPEMPTY)))
+      && (line = syn_getcurline())[current_col] != NUL
+      && line[current_col + 1] == NUL
+      && !(current_next_flags & (HL_SKIPNL | HL_SKIPEMPTY))) {
     current_next_list = NULL;
+  }
 
   if (!GA_EMPTY(&zero_width_next_ga))
     ga_clear(&zero_width_next_ga);


### PR DESCRIPTION
#### vim-patch:8.0.1561: crash with rust syntax highligting

Problem:    Crash with rust syntax highligting. (Edd Barrett)
Solution:   Avoid going past the end of an empty line.

https://github.com/vim/vim/commit/069dafc1ded60d9ee0fee4bcecce78ac8a235d87

Closes #6248