### PR TITLE
api: nvim_err_write, nvim_out_write: prepend channel id

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6497,7 +6497,7 @@ static void api_wrapper(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   Object result = fn(VIML_INTERNAL_CALL, args, &err);
 
   if (ERROR_SET(&err)) {
-    nvim_err_writeln(cstr_as_string(err.msg));
+    nvim_err_writeln(VIML_INTERNAL_CALL, cstr_as_string(err.msg));
     goto end;
   }
 
@@ -13848,7 +13848,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   if (ERROR_SET(&err)) {
-    nvim_err_writeln(cstr_as_string(err.msg));
+    nvim_err_writeln(VIML_INTERNAL_CALL, cstr_as_string(err.msg));
     goto end;
   }
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -593,7 +593,7 @@ describe('api', function()
         {0:~                                       }|
         {0:~                                       }|
         {0:~                                       }|
-        {1:has bork}                                |
+        {1:chan 1: has bork}                        |
       ]])
     end)
 
@@ -605,8 +605,8 @@ describe('api', function()
         {0:~                                       }|
         {0:~                                       }|
         {0:~                                       }|
-        {1:something happened}                      |
-        {1:very bad}                                |
+        {1:chan 1: something happened}              |
+        {1:chan 1: very bad}                        |
         {2:Press ENTER or type command to continue}^ |
       ]])
     end)
@@ -617,10 +617,10 @@ describe('api', function()
         {0:~                                       }|
         {0:~                                       }|
         {0:~                                       }|
-        {1:FAILURE}                                 |
-        {1:ERROR}                                   |
-        {1:EXCEPTION}                               |
-        {1:TRACEBACK}                               |
+        {1:chan 1: FAILURE}                         |
+        {1:chan 1: ERROR}                           |
+        {1:chan 1: EXCEPTION}                       |
+        {1:chan 1: TRACEBACK}                       |
         {2:Press ENTER or type command to continue}^ |
       ]])
     end)
@@ -637,7 +637,7 @@ describe('api', function()
         {0:~                                       }|
         {0:~                                       }|
         {0:~                                       }|
-        {1:very fail}                               |
+        {1:chan 1: very fail}                       |
       ]])
       helpers.wait()
 
@@ -649,8 +649,8 @@ describe('api', function()
         {0:~                                       }|
         {0:~                                       }|
         {0:~                                       }|
-        {1:more fail}                               |
-        {1:too fail}                                |
+        {1:chan 1: more fail}                       |
+        {1:chan 1: too fail}                        |
         {2:Press ENTER or type command to continue}^ |
       ]])
       feed('<cr>')  -- exit the press ENTER screen


### PR DESCRIPTION
nvim_err_write/nvim_out_write messages may come from anywhere, without
context or clues about their origin.  To reduce potential for confusion,
prepend the channel-id to the messages.


Note: The logic assumes two channels do not make overlapping non-flushed
calls to nvim_err_write/nvim_out_write, but the existing
"flush-on-newline" logic already depended on that.

closes #8053