### PR TITLE
[RFC] vim-patch:8.0.0513

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16216,7 +16216,7 @@ static void f_synIDattr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       break;
     }
     case 'n': {  // name
-      p = get_highlight_name(NULL, id - 1);
+      p = get_highlight_name_ext(NULL, id - 1, false);
       break;
     }
     case 'r': {  // reverse

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5828,7 +5828,8 @@ static void sign_list_defined(sign_T *sp)
   }
   if (sp->sn_line_hl > 0) {
     msg_puts(" linehl=");
-    const char *const p = get_highlight_name(NULL, sp->sn_line_hl - 1);
+    const char *const p = get_highlight_name_ext(NULL,
+                                                 sp->sn_line_hl - 1, false);
     if (p == NULL) {
       msg_puts("NONE");
     } else {
@@ -5837,7 +5838,8 @@ static void sign_list_defined(sign_T *sp)
   }
   if (sp->sn_text_hl > 0) {
     msg_puts(" texthl=");
-    const char *const p = get_highlight_name(NULL, sp->sn_text_hl - 1);
+    const char *const p = get_highlight_name_ext(NULL,
+                                                 sp->sn_line_hl - 1, false);
     if (p == NULL) {
       msg_puts("NONE");
     } else {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5839,7 +5839,7 @@ static void sign_list_defined(sign_T *sp)
   if (sp->sn_text_hl > 0) {
     msg_puts(" texthl=");
     const char *const p = get_highlight_name_ext(NULL,
-                                                 sp->sn_line_hl - 1, false);
+                                                 sp->sn_text_hl - 1, false);
     if (p == NULL) {
       msg_puts("NONE");
     } else {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7758,11 +7758,17 @@ static void highlight_list_two(int cnt, int attr)
 }
 
 
-/*
- * Function given to ExpandGeneric() to obtain the list of group names.
- * Also used for synIDattr() function.
- */
+/// Function given to ExpandGeneric() to obtain the list of group names.
 const char *get_highlight_name(expand_T *const xp, int idx)
+  FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  return get_highlight_name_ext(xp, idx, true);
+}
+
+
+/// Obtain a highlight group name.
+/// When "skip_cleared" is TRUE don't return a cleared entry.
+char_u * get_highlight_name_ext(expand_T *xp, int idx, int skip_cleared)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (idx < 0) {
@@ -7770,8 +7776,8 @@ const char *get_highlight_name(expand_T *const xp, int idx)
   }
 
   // Items are never removed from the table, skip the ones that were cleared.
-  while (idx < highlight_ga.ga_len && HL_TABLE()[idx].sg_cleared) {
-    idx++;
+  if (skip_cleared && idx < highlight_ga.ga_len && HL_TABLE()[idx].sg_cleared) {
+    return (char_u *)"";
   }
 
   if (idx == highlight_ga.ga_len && include_none != 0) {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7768,7 +7768,7 @@ const char *get_highlight_name(expand_T *const xp, int idx)
 
 /// Obtain a highlight group name.
 /// When "skip_cleared" is TRUE don't return a cleared entry.
-char_u * get_highlight_name_ext(expand_T *xp, int idx, int skip_cleared)
+const char *get_highlight_name_ext(expand_T *xp, int idx, int skip_cleared)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (idx < 0) {
@@ -7777,7 +7777,7 @@ char_u * get_highlight_name_ext(expand_T *xp, int idx, int skip_cleared)
 
   // Items are never removed from the table, skip the ones that were cleared.
   if (skip_cleared && idx < highlight_ga.ga_len && HL_TABLE()[idx].sg_cleared) {
-    return (char_u *)"";
+    return "";
   }
 
   if (idx == highlight_ga.ga_len && include_none != 0) {

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -70,6 +70,14 @@ func Test_highlight_completion()
   call assert_equal('"hi default', getreg(':'))
   call feedkeys(":hi c\<S-Tab>\<Home>\"\<CR>", 'xt')
   call assert_equal('"hi clear', getreg(':'))
+
+  " A cleared group does not show up in completions.
+  hi Anders ctermfg=green
+  call assert_equal(['Aardig', 'Anders'], getcompletion('A', 'highlight'))
+  hi clear Aardig
+  call assert_equal(['Anders'], getcompletion('A', 'highlight'))
+  hi clear Anders
+  call assert_equal([], getcompletion('A', 'highlight'))
 endfunc
 
 func Test_expr_completion()

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -322,13 +322,16 @@ func Test_syn_clear()
   syntax keyword Bar tar
   call assert_match('Foo', execute('syntax'))
   call assert_match('Bar', execute('syntax'))
+  call assert_equal('Foo', synIDattr(hlID("Foo"), "name"))
   syn clear Foo
   call assert_notmatch('Foo', execute('syntax'))
   call assert_match('Bar', execute('syntax'))
+  call assert_equal('Foo', synIDattr(hlID("Foo"), "name"))
   syn clear Foo Bar
   call assert_notmatch('Foo', execute('syntax'))
   call assert_notmatch('Bar', execute('syntax'))
   hi clear Foo
+  call assert_equal('Foo', synIDattr(hlID("Foo"), "name"))
   hi clear Bar
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.0.0513: getting name of cleared highlight group is wrong

Problem:    Getting name of cleared highlight group is wrong. (Matt Wozniski)
Solution:   Only skip over cleared names for completion. (closes vim/vim#1592)
            Also fix that a cleared group causes duplicate completions.

https://github.com/vim/vim/commit/c96272e30e2b81e5e0c8418f09d9db4e2fcd5d73