### PR TITLE
jobs: child proc must have a separate process-group

### DIFF
--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -26,15 +26,18 @@ int libuv_process_spawn(LibuvProcess *uvproc)
   uvproc->uvopts.file = proc->argv[0];
   uvproc->uvopts.args = proc->argv;
   uvproc->uvopts.flags = UV_PROCESS_WINDOWS_HIDE;
-  if (proc->detach) {
-      uvproc->uvopts.flags |= UV_PROCESS_DETACHED;
-  }
 #ifdef WIN32
   // libuv collapses the argv to a CommandLineToArgvW()-style string. cmd.exe
   // expects a different syntax (must be prepared by the caller before now).
   if (os_shell_is_cmdexe(proc->argv[0])) {
     uvproc->uvopts.flags |= UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
   }
+  if (proc->detach) {
+    uvproc->uvopts.flags |= UV_PROCESS_DETACHED;
+  }
+#else
+  // Always setsid() on unix-likes. #8107
+  uvproc->uvopts.flags |= UV_PROCESS_DETACHED;
 #endif
   uvproc->uvopts.exit_cb = exit_cb;
   uvproc->uvopts.cwd = proc->cwd;

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -12,6 +12,7 @@
 #include "nvim/event/wstream.h"
 #include "nvim/event/process.h"
 #include "nvim/event/libuv_process.h"
+#include "nvim/os/process.h"
 #include "nvim/os/pty_process.h"
 #include "nvim/globals.h"
 #include "nvim/macros.h"
@@ -199,23 +200,6 @@ int process_wait(Process *proc, int ms, MultiQueue *events)
   }
 
   return proc->status;
-}
-
-/// Kills a process and its descendants.
-static void os_proc_tree_kill(int pid, int sig) {
-  assert(sig == SIGTERM || sig == SIGKILL);
-  int pgid = getpgid(pid);
-  if (pgid > 0) {  // Ignore error. Never kill self (pid=0).
-    if (pgid == pid) {
-      ILOG("sending %s to process group: -%d",
-           sig == SIGTERM ? "SIGTERM" : "SIGKILL",
-           pgid);
-      uv_kill(-pgid, sig);
-    } else {
-      // Should never happen, because process_spawn() did setsid() in the child.
-      ELOG("pgid %d != pid %d", pgid, pid);
-    }
-  }
 }
 
 /// Ask a process to terminate and eventually kill if it doesn't respond

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -1,3 +1,26 @@
+-- Gets the children of process `ppid` via the shell.
+-- Used by nvim_get_proc_children() as a fallback.
+local function _os_proc_children(ppid)
+  if ppid == nil or ppid <= 0 or type(ppid) ~= 'number' then
+    error('invalid ppid')
+  end
+  local out = vim.api.nvim_call_function('system', { 'pgrep -P '..ppid })
+  local err = vim.api.nvim_get_vvar('shell_error')
+  if 1 == err and out == '' then
+    return {}  -- Process not found.
+  elseif 0 ~= err then
+    error('pgrep failed')
+  end
+  local children = {}
+  for s in string.gmatch(out, '%S+') do
+    local i = tonumber(s)
+    if i ~= nil then
+      table.insert(children, i)
+    end
+  end
+  return children
+end
+
 -- TODO(ZyX-I): Create compatibility layer.
 --{{{1 package.path updater function
 -- Last inserted paths. Used to clear out items from package.[c]path when they
@@ -61,4 +84,5 @@ end
 --{{{1 Module definition
 return {
   _update_package_paths = _update_package_paths,
+  _os_proc_children = _os_proc_children,
 }

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -1,18 +1,54 @@
--- Gets the children of process `ppid` via the shell.
+-- Internal-only until comments in #8107 are addressed.
+-- Returns:
+--    {errcode}, {output}
+local function _system(cmd)
+  local out = vim.api.nvim_call_function('system', { cmd })
+  local err = vim.api.nvim_get_vvar('shell_error')
+  return err, out
+end
+
+-- Gets process info from the `ps` command.
+-- Used by nvim_get_proc() as a fallback.
+local function _os_proc_info(pid)
+  if pid == nil or pid <= 0 or type(pid) ~= 'number' then
+    error('invalid pid')
+  end
+  local cmd = { 'ps', '-p', pid, '-o', 'ucomm=', }
+  local err, name = _system(cmd)
+  if 1 == err and string.gsub(name, '%s*', '') == '' then
+    return {}  -- Process not found.
+  elseif 0 ~= err then
+    local args_str = vim.api.nvim_call_function('string', { cmd })
+    error('command failed: '..args_str)
+  end
+  local _, ppid = _system({ 'ps', '-p', pid, '-o', 'ppid=', })
+  -- Remove trailing whitespace.
+  name = string.gsub(name, '%s+$', '')
+  ppid = string.gsub(ppid, '%s+$', '')
+  ppid = tonumber(ppid) == nil and -1 or tonumber(ppid)
+  return {
+    name = name,
+    pid = pid,
+    ppid = ppid,
+  }
+end
+
+-- Gets process children from the `pgrep` command.
 -- Used by nvim_get_proc_children() as a fallback.
 local function _os_proc_children(ppid)
   if ppid == nil or ppid <= 0 or type(ppid) ~= 'number' then
     error('invalid ppid')
   end
-  local out = vim.api.nvim_call_function('system', { 'pgrep -P '..ppid })
-  local err = vim.api.nvim_get_vvar('shell_error')
-  if 1 == err and out == '' then
+  local cmd = { 'pgrep', '-P', ppid, }
+  local err, rv = _system(cmd)
+  if 1 == err and string.gsub(rv, '%s*', '') == '' then
     return {}  -- Process not found.
   elseif 0 ~= err then
-    error('pgrep failed')
+    local args_str = vim.api.nvim_call_function('string', { cmd })
+    error('command failed: '..args_str)
   end
   local children = {}
-  for s in string.gmatch(out, '%S+') do
+  for s in string.gmatch(rv, '%S+') do
     local i = tonumber(s)
     if i ~= nil then
       table.insert(children, i)
@@ -81,8 +117,12 @@ local function _update_package_paths()
   end
   last_nvim_paths = cur_nvim_paths
 end
---{{{1 Module definition
-return {
+
+local module = {
   _update_package_paths = _update_package_paths,
   _os_proc_children = _os_proc_children,
+  _os_proc_info = _os_proc_info,
+  _system = _system,
 }
+
+return module

--- a/src/nvim/os/fileio.c
+++ b/src/nvim/os/fileio.c
@@ -4,7 +4,7 @@
 /// @file fileio.c
 ///
 /// Buffered reading/writing to a file. Unlike fileio.c this is not dealing with
-/// Neovim stuctures for buffer, with autocommands, etc: just fopen/fread/fwrite
+/// Nvim stuctures for buffer, with autocommands, etc: just fopen/fread/fwrite
 /// replacement.
 
 #include <assert.h>
@@ -43,7 +43,7 @@
 /// @param[in]  mode  Permissions for the newly created file (ignored if flags
 ///                   does not have kFileCreate\*).
 ///
-/// @return Error code (@see os_strerror()) or 0.
+/// @return Error code, or 0 on success. @see os_strerror()
 int file_open(FileDescriptor *const ret_fp, const char *const fname,
               const int flags, const int mode)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
@@ -115,8 +115,7 @@ int file_open_fd(FileDescriptor *const ret_fp, const int fd, const bool wr)
 
 /// Like file_open(), but allocate and return ret_fp
 ///
-/// @param[out]  error  Error code, @see os_strerror(). Is set to zero on
-///                     success.
+/// @param[out]  error  Error code, or 0 on success. @see os_strerror()
 /// @param[in]  fname  File name to open.
 /// @param[in]  flags  Flags, @see FileOpenFlags.
 /// @param[in]  mode  Permissions for the newly created file (ignored if flags
@@ -137,8 +136,7 @@ FileDescriptor *file_open_new(int *const error, const char *const fname,
 
 /// Like file_open_fd(), but allocate and return ret_fp
 ///
-/// @param[out]  error  Error code, @see os_strerror(). Is set to zero on
-///                     success.
+/// @param[out]  error  Error code, or 0 on success. @see os_strerror()
 /// @param[in]  fd  File descriptor to wrap.
 /// @param[in]  wr  True if fd is opened for writing only, false if it is read
 ///                 only.

--- a/src/nvim/os/process.c
+++ b/src/nvim/os/process.c
@@ -1,0 +1,87 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+#include <uv.h>  // for HANDLE (win32)
+#ifdef WIN32
+# include <tlhelp32.h>  // for CreateToolhelp32Snapshot
+#endif
+
+#include "nvim/log.h"
+#include "nvim/os/process.h"
+#include "nvim/os/os.h"
+#include "nvim/os/os_defs.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "os/process.c.generated.h"
+#endif
+
+#ifdef WIN32
+/// Kills process `pid` and its descendants recursively.
+bool os_proc_tree_kill_rec(HANDLE process, int sig)
+{
+  if (process == NULL) {
+    return false;
+  }
+  PROCESSENTRY32 pe;
+  DWORD pid = GetProcessId(process);
+
+  if (pid != 0) {
+    HANDLE h = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (h != INVALID_HANDLE_VALUE) {
+      pe.dwSize = sizeof(PROCESSENTRY32);
+      if (!Process32First(h, &pe)) {
+        goto theend;
+      }
+
+      do {
+        if (pe.th32ParentProcessID == pid) {
+          HANDLE ph = OpenProcess(PROCESS_ALL_ACCESS, FALSE, pe.th32ProcessID);
+          if (ph != NULL) {
+            os_proc_tree_kill_rec(ph, sig);
+            CloseHandle(ph);
+          }
+        }
+      } while (Process32Next(h, &pe));
+
+      CloseHandle(h);
+    }
+  }
+
+theend:
+  return (bool)TerminateProcess(process, (unsigned int)sig);
+}
+bool os_proc_tree_kill(int pid, int sig)
+{
+  assert(sig >= 0);
+  assert(sig == SIGTERM || sig == SIGKILL);
+  if (pid > 0) {
+    ILOG("terminating process tree: %d", pid);
+    HANDLE h = OpenProcess(PROCESS_ALL_ACCESS, FALSE, (DWORD)pid);
+    return os_proc_tree_kill_rec(h, sig);
+  } else {
+    ELOG("invalid pid: %d", pid);
+  }
+  return false;
+}
+#else
+/// Kills process group where `pid` is the process group leader.
+bool os_proc_tree_kill(int pid, int sig)
+{
+  assert(sig == SIGTERM || sig == SIGKILL);
+  int pgid = getpgid(pid);
+  if (pgid > 0) {  // Ignore error. Never kill self (pid=0).
+    if (pgid == pid) {
+      ILOG("sending %s to process group: -%d",
+           sig == SIGTERM ? "SIGTERM" : "SIGKILL", pgid);
+      int rv = uv_kill(-pgid, sig);
+      return rv == 0;
+    } else {
+      // Should never happen, because process_spawn() did setsid() in the child.
+      ELOG("pgid %d != pid %d", pgid, pid);
+    }
+  } else {
+    ELOG("getpgid(%d) returned %d", pid, pgid);
+  }
+  return false;
+}
+#endif

--- a/src/nvim/os/process.c
+++ b/src/nvim/os/process.c
@@ -2,6 +2,7 @@
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
 #include <uv.h>  // for HANDLE (win32)
+
 #ifdef WIN32
 # include <tlhelp32.h>  // for CreateToolhelp32Snapshot
 #endif
@@ -165,7 +166,7 @@ int os_proc_children(int ppid, int **proc_list, size_t *proc_count)
   snprintf(proc_p, sizeof(proc_p), "/proc/%d/task/%d/children", ppid, ppid);
   FILE *fp = fopen(proc_p, "r");
   if (fp == NULL) {
-    return 1;  // Process not found.
+    return 2;  // Process not found, or /proc/…/children not supported.
   }
   int match_pid;
   while (fscanf(fp, "%d", &match_pid) > 0) {

--- a/src/nvim/os/process.h
+++ b/src/nvim/os/process.h
@@ -2,6 +2,7 @@
 #define NVIM_OS_PROCESS_H
 
 #include <stddef.h>
+#include "nvim/api/private/defs.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/process.h.generated.h"

--- a/src/nvim/os/process.h
+++ b/src/nvim/os/process.h
@@ -1,0 +1,8 @@
+#ifndef NVIM_OS_PROCESS_H
+#define NVIM_OS_PROCESS_H
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "os/process.h.generated.h"
+#endif
+
+#endif  // NVIM_OS_PROCESS_H

--- a/src/nvim/os/process.h
+++ b/src/nvim/os/process.h
@@ -1,6 +1,8 @@
 #ifndef NVIM_OS_PROCESS_H
 #define NVIM_OS_PROCESS_H
 
+#include <stddef.h>
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/process.h.generated.h"
 #endif

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -145,8 +145,12 @@ void pty_process_teardown(Loop *loop)
   uv_signal_stop(&loop->children_watcher);
 }
 
-static void init_child(PtyProcess *ptyproc) FUNC_ATTR_NONNULL_ALL
+static void init_child(PtyProcess *ptyproc)
+  FUNC_ATTR_NONNULL_ALL
 {
+  // New session/process-group. #6530
+  setsid();
+
   unsetenv("COLUMNS");
   unsetenv("LINES");
   unsetenv("TERMCAP");

--- a/test/functional/api/proc_spec.lua
+++ b/test/functional/api/proc_spec.lua
@@ -1,0 +1,53 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear, eq = helpers.clear, helpers.eq
+local funcs = helpers.funcs
+local nvim_argv = helpers.nvim_argv
+local request = helpers.request
+local retry = helpers.retry
+
+describe('api', function()
+  before_each(clear)
+
+  describe('nvim_get_proc_children', function()
+    it('returns child process ids', function()
+      local this_pid = funcs.getpid()
+
+      local job1 = funcs.jobstart(nvim_argv)
+      retry(nil, nil, function()
+        eq(1, #request('nvim_get_proc_children', this_pid))
+      end)
+
+      local job2 = funcs.jobstart(nvim_argv)
+      retry(nil, nil, function()
+        eq(2, #request('nvim_get_proc_children', this_pid))
+      end)
+
+      funcs.jobstop(job1)
+      retry(nil, nil, function()
+        eq(1, #request('nvim_get_proc_children', this_pid))
+      end)
+
+      funcs.jobstop(job2)
+      retry(nil, nil, function()
+        eq(0, #request('nvim_get_proc_children', this_pid))
+      end)
+    end)
+
+    it('validates input', function()
+      local status, rv = pcall(request, "nvim_get_proc_children", -1)
+      eq(false, status)
+      eq("Invalid pid: -1", string.match(rv, "Invalid.*"))
+
+      status, rv = pcall(request, "nvim_get_proc_children", 0)
+      eq(false, status)
+      eq("Invalid pid: 0", string.match(rv, "Invalid.*"))
+
+      -- Assume PID 99999999 does not exist.
+      status, rv = pcall(request, "nvim_get_proc_children", 99999999)
+      eq(true, status)
+      eq({}, rv)
+    end)
+  end)
+
+end)

--- a/test/functional/api/proc_spec.lua
+++ b/test/functional/api/proc_spec.lua
@@ -1,10 +1,14 @@
 local helpers = require('test.functional.helpers')(after_each)
 
-local clear, eq = helpers.clear, helpers.eq
+local clear = helpers.clear
+local eq = helpers.eq
 local funcs = helpers.funcs
+local iswin = helpers.iswin
 local nvim_argv = helpers.nvim_argv
+local ok = helpers.ok
 local request = helpers.request
 local retry = helpers.retry
+local NIL = helpers.NIL
 
 describe('api', function()
   before_each(clear)
@@ -43,11 +47,35 @@ describe('api', function()
       eq(false, status)
       eq("Invalid pid: 0", string.match(rv, "Invalid.*"))
 
-      -- Assume PID 99999999 does not exist.
-      status, rv = pcall(request, "nvim_get_proc_children", 99999999)
+      -- Assume PID 99999 does not exist.
+      status, rv = pcall(request, "nvim_get_proc_children", 99999)
       eq(true, status)
       eq({}, rv)
     end)
   end)
 
+  describe('nvim_get_proc', function()
+    it('returns process info', function()
+      local pid = funcs.getpid()
+      local pinfo = request('nvim_get_proc', pid)
+      eq((iswin() and 'nvim.exe' or 'nvim'), pinfo.name)
+      ok(pinfo.pid == pid)
+      ok(type(pinfo.ppid) == 'number' and pinfo.ppid ~= pid)
+    end)
+
+    it('validates input', function()
+      local status, rv = pcall(request, "nvim_get_proc", -1)
+      eq(false, status)
+      eq("Invalid pid: -1", string.match(rv, "Invalid.*"))
+
+      status, rv = pcall(request, "nvim_get_proc", 0)
+      eq(false, status)
+      eq("Invalid pid: 0", string.match(rv, "Invalid.*"))
+
+      -- Assume PID 99999 does not exist.
+      status, rv = pcall(request, "nvim_get_proc", 99999)
+      eq(true, status)
+      eq(NIL, rv)
+    end)
+  end)
 end)

--- a/test/functional/autocmd/termclose_spec.lua
+++ b/test/functional/autocmd/termclose_spec.lua
@@ -1,3 +1,4 @@
+local luv = require('luv')
 local helpers = require('test.functional.helpers')(after_each)
 
 local clear, command, nvim, nvim_dir =
@@ -39,13 +40,15 @@ describe('TermClose event', function()
       .. [[ 'on_exit': {-> execute('let g:test_job_exited = 1')}}) ]])
     retry(nil, nil, function() eq(1, eval('get(g:, "test_job_started", 0)')) end)
 
-    local start = os.time()
+    luv.update_time()
+    local start = luv.now()
     command('call jobstop(g:test_job)')
     retry(nil, nil, function() eq(1, eval('get(g:, "test_job_exited", 0)')) end)
-    local duration = os.time() - start
-    -- nvim starts sending SIGTERM after KILL_TIMEOUT_MS
-    ok(duration >= 2)
-    ok(duration <= 4)  -- <= 2 + delta because of slow CI
+    luv.update_time()
+    local duration = luv.now() - start
+    -- Nvim begins SIGTERM after KILL_TIMEOUT_MS.
+    ok(duration >= 2000)
+    ok(duration <= 4000)  -- Epsilon for slow CI
   end)
 
   it('kills pty job trapping SIGHUP and SIGTERM', function()
@@ -58,13 +61,15 @@ describe('TermClose event', function()
       .. [[ 'on_exit': {-> execute('let g:test_job_exited = 1')}}) ]])
     retry(nil, nil, function() eq(1, eval('get(g:, "test_job_started", 0)')) end)
 
-    local start = os.time()
+    luv.update_time()
+    local start = luv.now()
     command('call jobstop(g:test_job)')
     retry(nil, nil, function() eq(1, eval('get(g:, "test_job_exited", 0)')) end)
-    local duration = os.time() - start
-    -- nvim starts sending kill after 2*KILL_TIMEOUT_MS
-    ok(duration >= 4)
-    ok(duration <= 7)  -- <= 4 + delta because of slow CI
+    luv.update_time()
+    local duration = luv.now() - start
+    -- Nvim begins SIGKILL after (2 * KILL_TIMEOUT_MS).
+    ok(duration >= 4000)
+    ok(duration <= 7000)  -- Epsilon for slow CI
   end)
 
   it('reports the correct <abuf>', function()

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -641,6 +641,8 @@ describe('jobs', function()
   end)
 
   it('jobstop() kills entire process tree #6530', function()
+    command('set shell& shellcmdflag& shellquote& shellpipe& shellredir& shellxquote&')
+
     -- XXX: Using `nvim` isn't a good test, it reaps its children on exit.
     -- local c = 'call jobstart([v:progpath, "-u", "NONE", "-i", "NONE", "--headless"])'
     -- local j = eval("jobstart([v:progpath, '-u', 'NONE', '-i', 'NONE', '--headless', '-c', '"

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -6,6 +6,10 @@ local clear, eq, eval, exc_exec, feed_command, feed, insert, neq, next_msg, nvim
   helpers.nvim_dir, helpers.ok, helpers.source,
   helpers.write_file, helpers.mkdir, helpers.rmdir
 local command = helpers.command
+local funcs = helpers.funcs
+local retry = helpers.retry
+local meths = helpers.meths
+local NIL = helpers.NIL
 local wait = helpers.wait
 local iswin = helpers.iswin
 local get_pathsep = helpers.get_pathsep
@@ -634,6 +638,40 @@ describe('jobs', function()
     command("let g:job_opts.rpc = v:true")
     local _, err = pcall(command, "let j = jobstart(['cat', '-'], g:job_opts)")
     ok(string.find(err, "E475: Invalid argument: job cannot have both 'pty' and 'rpc' options set") ~= nil)
+  end)
+
+  it('jobstop() kills entire process tree #6530', function()
+    -- XXX: Using `nvim` isn't a good test, it reaps its children on exit.
+    -- local c = 'call jobstart([v:progpath, "-u", "NONE", "-i", "NONE", "--headless"])'
+    -- local j = eval("jobstart([v:progpath, '-u', 'NONE', '-i', 'NONE', '--headless', '-c', '"
+    --                ..c.."', '-c', '"..c.."'])")
+
+    -- Create child with several descendants.
+    local j = (iswin()
+               and eval([=[jobstart('start /b cmd /c "ping 127.0.0.1 -n 1 -w 30000 > NUL"]=]
+                             ..[=[ & start /b cmd /c "ping 127.0.0.1 -n 1 -w 40000 > NUL"]=]
+                             ..[=[ & start /b cmd /c "ping 127.0.0.1 -n 1 -w 50000 > NUL"')]=])
+               or eval("jobstart('sleep 30 | sleep 30 | sleep 30')"))
+    local ppid = funcs.jobpid(j)
+    local children
+    retry(nil, nil, function()
+      children = meths.get_proc_children(ppid)
+      eq(3, #children)
+    end)
+    -- Assert that nvim_get_proc() sees the children.
+    for _, child_pid in ipairs(children) do
+      local info = meths.get_proc(child_pid)
+      -- eq((iswin() and 'nvim.exe' or 'nvim'), info.name)
+      eq(ppid, info.ppid)
+    end
+    -- Kill the root of the tree.
+    funcs.jobstop(j)
+    -- Assert that the children were killed.
+    retry(nil, nil, function()
+      for _, child_pid in ipairs(children) do
+        eq(NIL, meths.get_proc(child_pid))
+      end
+    end)
   end)
 
   describe('running tty-test program', function()


### PR DESCRIPTION
closes #6530 

- are PTY jobs being killed correctly?
- ~~is #6891 related?~~
- [x] win: iterate through children (`os_proc_tree_kill()`)
- [x] implement new API function: `nvim_get_proc_children()`
- [x] implement new API function: `nvim_get_proc()`
- [x] tests

Didn't fix this common test failure (maybe #7376 ?):

```
TermClose event reports the correct <abuf>: -- Output to stderr:
Vim: Caught deadly signal 'SIGHUP'
Vim: Finished.
CMake Error at /home/travis/build/neovim/neovim/cmake/RunTests.cmake:53 (message):
  Running functional tests failed with error: 1.
...
===============================================================================
NVIM_LOG_FILE: /home/travis/build/neovim/neovim/build/.nvimlog
2018/03/06 08:57:28 ERROR 11479 loop_close:133: uv_loop_close() hang?
[--I] signal   0xa310e8
[-AI] async    0xa30f30
[R--] signal   0xa2a620
```

quickbuild failure is unrelated, `spell_spec.lua` #8102