### PR TITLE
Fixed syntax highlighting for ocaml extension points

### DIFF
--- a/runtime/syntax/ocaml.vim
+++ b/runtime/syntax/ocaml.vim
@@ -192,6 +192,7 @@ syn match    ocamlCharacter    "'\\x\x\x'"
 syn match    ocamlCharErr      "'\\\d\d'\|'\\\d'"
 syn match    ocamlCharErr      "'\\[^\'ntbr]'"
 syn region   ocamlString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
+syn region   ocamlPpx          start=+\[@+ end=+\]+ contains=@Spell
 
 syn match    ocamlFunDef       "->"
 syn match    ocamlRefAssign    ":="


### PR DESCRIPTION
Syntax highlighting breaks on extension points, ie:

```ocaml
external foo: string = "bar" [@@bs.module "../foo.json"]
```

Code after this line is messed up because it reads `module` inside the extension point as the module keyword instead of something ppx-specific

This PR fixes the highlighting here