### PR TITLE
 [RFC] open subprocess pipes in overlapped mode on windows

### DIFF
--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -51,12 +51,19 @@ int libuv_process_spawn(LibuvProcess *uvproc)
 
   if (!proc->in.closed) {
     uvproc->uvstdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
+#ifdef WIN32
+    uvproc->uvstdio[0].flags |= UV_OVERLAPPED_PIPE;
+#endif
     uvproc->uvstdio[0].data.stream = STRUCT_CAST(uv_stream_t,
                                                  &proc->in.uv.pipe);
   }
 
   if (!proc->out.closed) {
     uvproc->uvstdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
+#ifdef WIN32
+    // pipe must be readable for IOCP to work.
+    uvproc->uvstdio[1].flags |= UV_READABLE_PIPE | UV_OVERLAPPED_PIPE;
+#endif
     uvproc->uvstdio[1].data.stream = STRUCT_CAST(uv_stream_t,
                                                  &proc->out.uv.pipe);
   }

--- a/third-party/patches/libuv-overlapped.patch
+++ b/third-party/patches/libuv-overlapped.patch
@@ -1,0 +1,33 @@
+diff --git a/include/uv.h b/include/uv.h
+index cdd251d8..79b7930e 100644
+--- a/include/uv.h
++++ b/include/uv.h
+@@ -865,7 +865,8 @@ typedef enum {
+    * flags may be specified to create a duplex data stream.
+    */
+   UV_READABLE_PIPE  = 0x10,
+-  UV_WRITABLE_PIPE  = 0x20
++  UV_WRITABLE_PIPE  = 0x20,
++  UV_OVERLAPPED_PIPE = 0x40
+ } uv_stdio_flags;
+ 
+ typedef struct uv_stdio_container_s {
+diff --git a/src/win/process-stdio.c b/src/win/process-stdio.c
+index 032e3093..b53bdea7 100644
+--- a/src/win/process-stdio.c
++++ b/src/win/process-stdio.c
+@@ -131,12 +131,13 @@ static int uv__create_stdio_pipe_pair(uv_loop_t* loop,
+   sa.lpSecurityDescriptor = NULL;
+   sa.bInheritHandle = TRUE;
+ 
++  BOOL overlap = server_pipe->ipc || (flags & UV_OVERLAPPED_PIPE);
+   child_pipe = CreateFileA(pipe_name,
+                            client_access,
+                            0,
+                            &sa,
+                            OPEN_EXISTING,
+-                           server_pipe->ipc ? FILE_FLAG_OVERLAPPED : 0,
++                           overlap ? FILE_FLAG_OVERLAPPED : 0,
+                            NULL);
+   if (child_pipe == INVALID_HANDLE_VALUE) {
+     err = GetLastError();


### PR DESCRIPTION
this does make it easier to use asyncio in pynvim on windows. Opening this now mainly to get build artefacts from appveyor. (so hasn't confirmed it yet)

~~Currently uses a hack: when opening the server pipe in "ipc" mode, the child handle gets created in overlapped mode~~ (doesn't work),  adds a flag to libuv for overlapped mode,  which makes it possible to use it with the "proactor" asyncio event loop. Ideally, this should be upstreamed to libuv.