### PR TITLE
[RDY] test: win: use cmd.exe by default in job_spec.lua

### DIFF
--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -671,8 +671,6 @@ describe('jobs', function()
   end)
 
   it('jobstop() kills entire process tree #6530', function()
-    command('set shell& shellcmdflag& shellquote& shellpipe& shellredir& shellxquote&')
-
     -- XXX: Using `nvim` isn't a good test, it reaps its children on exit.
     -- local c = 'call jobstart([v:progpath, "-u", "NONE", "-i", "NONE", "--headless"])'
     -- local j = eval("jobstart([v:progpath, '-u', 'NONE', '-i', 'NONE', '--headless', '-c', '"

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -677,11 +677,10 @@ describe('jobs', function()
     --                ..c.."', '-c', '"..c.."'])")
 
     -- Create child with several descendants.
-    local j = (iswin()
-               and eval([=[jobstart('start /b cmd /c "ping 127.0.0.1 -n 1 -w 30000 > NUL"]=]
-                             ..[=[ & start /b cmd /c "ping 127.0.0.1 -n 1 -w 40000 > NUL"]=]
-                             ..[=[ & start /b cmd /c "ping 127.0.0.1 -n 1 -w 50000 > NUL"')]=])
-               or eval("jobstart('sleep 30 | sleep 30 | sleep 30')"))
+    local sleep_cmd = (iswin()
+      and 'ping -n 31 127.0.0.1'
+      or  'sleep 30')
+    local j = eval("jobstart('"..sleep_cmd..' | '..sleep_cmd..' | '..sleep_cmd.."')")
     local ppid = funcs.jobpid(j)
     local children
     retry(nil, nil, function()

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -425,7 +425,7 @@ end
 local function set_shell_powershell()
   source([[
     set shell=powershell shellquote=( shellpipe=\| shellredir=> shellxquote=
-    set shellcmdflag=-NoLogo\ -NoProfile\ -ExecutionPolicy\ RemoteSigned\ -Command
+    let &shellcmdflag = '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command Remove-Item -Force alias:sleep;'
   ]])
 end
 


### PR DESCRIPTION
Ref https://github.com/neovim/neovim/pull/7412#issuecomment-366822555, https://github.com/neovim/neovim/pull/8034
Need #8107 for `jobstop` to return exit code 0 if the program successfully exits and returns exit code 0 if run from a shell (ex. cmd.exe, bash).

Testing to see if switching to cmd.exe improves testing with job API and cat.exe on Windows.

I'm giving up on NULs and newlines for jobsend (list argument). cat.exe still has the `invalid channel id` error, `write_file` truncates the string with `\0` and find.exe truncates the input string after `\0`.

~~`start` (cmd.exe builtin) reaps its child processes with `/b` (I can't find them with tasklist) so I'm using `/min` instead for a minimized window. Redirecting to `nul` shouldn't be necessary. If that's intended with the `jobstop()` test, so be it.~~

Not sure what's the expected behaviour for start (cmd.exe builtin) because nvim is not reaping the child processes on exit after `:qa!`, even on nested nvim termnal. Seems to have different semantics from fork (or what bash does with `&`). Perhaps powershell is better suited here ~~but I don't know how (yes, there's `Start-Process` but I can't pass arguments to the external program).~~ ~~I can use `Start-Job` so if the session terminates, the jobs die too. Is that close enough?~~ Leave it for later. I disabled the pty teardown test.

more.com (like less) is the default pager in Windows so it can be used to display files. That leaves the NUL tests for cat if more can't do it.

fnamemodify doesn't adjust slashes and it's the same on Vim too. Have to use expand() again. 