### PR TITLE
Create v2 AppImages and include update information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,11 @@ check-single-includes: build/.ran-cmake
 appimage:
 	bash scripts/genappimage.sh
 
+# Build an appimage with embedded update information appimage-nightly for
+# nightly builds or appimage-latest for a release
+appimage-%:
+	bash scripts/genappimage.sh $*
+
 lint: check-single-includes clint testlint lualint
 
 .PHONY: test testlint lualint functionaltest unittest lint clint clean distclean nvim libnvim cmake deps install appimage

--- a/scripts/genappimage.sh
+++ b/scripts/genappimage.sh
@@ -11,6 +11,8 @@ if [ -z "$ARCH" ]; then
   export ARCH="$(arch)"
 fi
 
+TAG=$1
+
 # App name, used by generate_appimage.
 APP=nvim
 
@@ -69,12 +71,16 @@ cd "$APP_BUILD_DIR" # Get out of AppImage directory.
 #   - Expects: $ARCH, $APP, $VERSION env vars
 #   - Expects: ./$APP.AppDir/ directory
 #   - Produces: ../out/$APP-$VERSION.glibc$GLIBC_NEEDED-$ARCH.AppImage
-generate_type2_appimage
+if [ -n "$TAG" ]; then
+  generate_type2_appimage -u "gh-releases-zsync|neovim|neovim|$TAG|nvim.appimage.zsync"
+else
+  generate_type2_appimage
+fi
 
 # Moving the final executable to a different folder so it isn't in the
 # way for a subsequent build.
 
-mv "$ROOT_DIR"/out/*.AppImage "$ROOT_DIR"/build/bin
+mv "$ROOT_DIR"/out/*.AppImage* "$ROOT_DIR"/build/bin
 # Remove the (now empty) folder the AppImage was built in
 rmdir "$ROOT_DIR"/out
 

--- a/scripts/genappimage.sh
+++ b/scripts/genappimage.sh
@@ -35,7 +35,7 @@ VERSION=$("$ROOT_DIR"/build/bin/nvim --version | head -n 1 | grep -o 'v.*')
 
 cd "$APP_BUILD_DIR"
 
-curl -Lo "$APP_BUILD_DIR"/appimage_functions.sh https://github.com/probonopd/AppImages/raw/master/functions.sh
+curl -Lo "$APP_BUILD_DIR"/appimage_functions.sh https://github.com/AppImage/AppImages/raw/master/functions.sh
 . ./appimage_functions.sh
 
 # Copy desktop and icon file to AppDir for AppRun to pick them up.
@@ -53,7 +53,7 @@ move_lib
 
 # Delete stuff that should not go into the AppImage.
 # Delete dangerous libraries; see
-# https://github.com/probonopd/AppImages/blob/master/excludelist
+# https://github.com/AppImage/AppImages/blob/master/excludelist
 delete_blacklisted
 
 ########################################################################
@@ -71,10 +71,8 @@ cd "$APP_BUILD_DIR" # Get out of AppImage directory.
 #   - Produces: ../out/$APP-$VERSION.glibc$GLIBC_NEEDED-$ARCH.AppImage
 generate_appimage
 
-# NOTE: There is currently a bug in the `generate_appimage` function (see
-# https://github.com/probonopd/AppImages/issues/228) that causes repeated builds
-# that result in the same name to fail.
-# Moving the final executable to a different folder gets around this issue.
+# Moving the final executable to a different folder so it isn't in the
+# way for a subsequent build.
 
 mv "$ROOT_DIR"/out/*.AppImage "$ROOT_DIR"/build/bin
 # Remove the (now empty) folder the AppImage was built in

--- a/scripts/genappimage.sh
+++ b/scripts/genappimage.sh
@@ -69,7 +69,7 @@ cd "$APP_BUILD_DIR" # Get out of AppImage directory.
 #   - Expects: $ARCH, $APP, $VERSION env vars
 #   - Expects: ./$APP.AppDir/ directory
 #   - Produces: ../out/$APP-$VERSION.glibc$GLIBC_NEEDED-$ARCH.AppImage
-generate_appimage
+generate_type2_appimage
 
 # Moving the final executable to a different folder so it isn't in the
 # way for a subsequent build.


### PR DESCRIPTION
The update information will allow users to run AppImageUpdate to update.  This
will require some changes in bot-ci to publish the created zsync files for the
nightly builds as well as including the zsync files for official releases.

I didn't look into using linuxdeployqt, since the changes to our existing
support were pretty minimal.

Closes #7537

This will allow users to use AppImageUpdate to update their AppImage.
It requires publishing the created zsync file alongside the appimage
file for the releases.