### PR TITLE
[RFC] node/provider: allow specified node host prog

### DIFF
--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -38,6 +38,9 @@ function! provider#node#can_inspect() abort
 endfunction
 
 function! provider#node#Detect() abort
+  if exists('g:node_host_prog')
+    return g:node_host_prog
+  endif
   let global_modules = get(split(system('npm root -g'), "\n"), 0, '')
   if v:shell_error || !isdirectory(global_modules)
     return ''

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -112,7 +112,33 @@ To use an absolute path (e.g. to an rbenv installation): >
 To use the RVM "system" Ruby installation: >
     let g:ruby_host_prog = 'rvm system do neovim-ruby-host'
 <
+==============================================================================
+Node integration				*provider-node*
 
+The node provider allows nvim to run remote plugin managed by nodejs, see
+https://nodejs.org/
+
+NODE QUICKSTART~
+
+To use javascript remote plugins with Nvim, just install the latest `neovim`
+ package: >
+    $ npm install -g neovim
+<
+NODE PROVIDER CONFIGURATION~
+
+						*g:loaded_node_provider*
+To disable Node support: >
+    let g:loaded_node_provider = 1
+<
+						*g:node_host_prog*
+Command to start the Node host. By default this is `neovim-node-host` that
+searched from >
+    $ npm root -g
+<
+For user who want to speed up the command search or want to use specified
+version of `neovim-node-host`, an absolute path could be used: >
+    let g:node_host_prog = '/usr/local/bin/neovim-node-host'
+<
 ==============================================================================
 Clipboard integration 			      *provider-clipboard* *clipboard*
 


### PR DESCRIPTION
Problem: The system call `npm root -g` could take more than 300ms on my local machine, it's quite slow!

Result of `nvim --startuptime`
```
433.311  331.646  331.646: sourcing /usr/local/share/nvim/runtime/autoload/provider/node.vim
```

Result from fish shell
```
~/lib/neovim(improve_node_provider|✔) 
❯ npm root -g
/usr/local/lib/node_modules

~/lib/neovim(improve_node_provider|✔)
❯ echo $CMD_DURATION
350
```

Solution: Provide `g:node_host_prog` like ruby provider so that the user could speed up their neovim.