### PR TITLE
Implement `-u NORCP` as short for `-u NORC --noplugins`

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -6,10 +6,10 @@
 - Terminal name/version:
 - `$TERM`:
 
-### Steps to reproduce using `nvim -u NORC`
+### Steps to reproduce using `nvim -u NORCP`
 
 ```
-nvim -u NORC
+nvim -u NORCP
 
 ```
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -94,6 +94,7 @@ argument.
 			(nothing)		yes		    yes
 			-u NONE			no		    no
 			-u NORC			no		    yes
+			-u NORCP		no		    no
 			--noplugin		yes		    no
 
 --startuptime {fname}					*--startuptime*
@@ -227,7 +228,7 @@ argument.
 -b		Binary mode.  File I/O will only recognize <NL> to separate
 		lines.  The 'expandtab' option will be reset.  The 'textwidth'
 		option is set to 0.  'modeline' is reset.  The 'binary' option
-		is set.  This is done after reading the init.vim/exrc files 
+		is set.  This is done after reading the init.vim/exrc files
 		but before reading any file in the arglist.  See also
 		|edit-binary|.
 
@@ -315,7 +316,8 @@ argument.
 		starts.  Plugins and syntax highlighting are also skipped.
 		When {vimrc} is equal to "NORC" (all uppercase), this has the
 		same effect as "NONE", but plugins and syntax highlighting are
-		not skipped.
+		not skipped. When {vimrc} is equal to "NORCP" instead, only
+		the loading of syntax highlighting is not skipped.
 
 							*-i*
 -i {shada}	The file {shada} is used instead of the default ShaDa
@@ -380,7 +382,7 @@ accordingly.  Vim proceeds in this order:
 	Each line in a vimrc file is executed as an Ex command line.  It is
 	sometimes also referred to as "exrc" file.  They are the same type of
 	file, but "exrc" is what Vi always used, "vimrc" is a Vim specific
-	name, "init.vim" is Neovim specific location for vimrc file.  Also see 
+	name, "init.vim" is Neovim specific location for vimrc file.  Also see
 	|vimrc-intro|.
 
 	Places for your personal initializations (see |base-directories|):
@@ -392,8 +394,8 @@ accordingly.  Vim proceeds in this order:
 	The files are searched in the order specified above and only the first
 	one that is found is read.
 
-	RECOMMENDATION: Put all your Vim configuration stuff in the 
-	$HOME/.config/nvim/ directory. That makes it easy to copy it to 
+	RECOMMENDATION: Put all your Vim configuration stuff in the
+	$HOME/.config/nvim/ directory. That makes it easy to copy it to
 	another system.
 
 	If Vim was started with "-u filename", the file "filename" is used.
@@ -419,7 +421,7 @@ accordingly.  Vim proceeds in this order:
 	-  The environment variable VIMINIT
 	   The value of $VIMINIT is used as an Ex command line.
 	-  The user vimrc file: $XDG_CONFIG_HOME/nvim/init.vim.
-	-  Other vimrc file: {xdg_config_dir}/nvim/init.vim where 
+	-  Other vimrc file: {xdg_config_dir}/nvim/init.vim where
 	   {xdg_config_dir} is one of the directories in $XDG_CONFIG_DIRS.
 	-  The environment variable EXINIT.
 	   The value of $EXINIT is used as an Ex command line.
@@ -535,8 +537,8 @@ System setup:
 This only applies if you are managing a Unix system with several users and
 want to set the defaults for all users.  Create a vimrc file with commands
 for default settings and mappings and put it in the place that is given with
-the ":version" command.  NOTE: System vimrc file needs specific compilation 
-options (one needs to define SYS_VIMRC_FILE macros). If :version command does 
+the ":version" command.  NOTE: System vimrc file needs specific compilation
+options (one needs to define SYS_VIMRC_FILE macros). If :version command does
 not show anything like this, consider contacting the nvim package maintainer.
 
 
@@ -550,7 +552,7 @@ mapping, then you may want to save them in a vimrc file for later use.  See
 Avoiding setup problems for Vi users ~
 
 Vi uses the variable EXINIT and the file "~/.exrc".  So if you do not want to
-interfere with Vi, then use the variable VIMINIT and the file init.vim 
+interfere with Vi, then use the variable VIMINIT and the file init.vim
 instead.
 
 
@@ -745,7 +747,7 @@ vimrc file.
 These commands will write ":map" and ":set" commands to a file, in such a way
 that when these commands are executed, the current key mappings and options
 will be set to the same values.  The options 'columns', 'endofline',
-'fileformat', 'lines', 'modified', and 'scroll' are not included, because 
+'fileformat', 'lines', 'modified', and 'scroll' are not included, because
 these are terminal or file dependent.
 Note that the options 'binary', 'paste' and 'readonly' are included, this
 might not always be what you want.
@@ -761,8 +763,8 @@ A common method is to use a default |init.vim| file, make some modifications
 with ":map" and ":set" commands and write the modified file.  First read the
 default vimrc in with a command like ":source ~piet/.vimrc.Cprogs", change
 the settings and then save them in the current directory with ":mkvimrc!".  If
-you want to make this file your default |init.vim|, move it to 
-$XDG_CONFIG_HOME/nvim.  You could also use autocommands |autocommand| and/or 
+you want to make this file your default |init.vim|, move it to
+$XDG_CONFIG_HOME/nvim.  You could also use autocommands |autocommand| and/or
 modelines |modeline|.
 
 						*vimrc-option-example*
@@ -926,7 +928,7 @@ To automatically save and restore views for *.c files: >
 
 If you exit Vim and later start it again, you would normally lose a lot of
 information.  The ShaDa file can be used to remember that information, which
-enables you to continue where you left off.  Its name is the abbreviation of 
+enables you to continue where you left off.  Its name is the abbreviation of
 SHAred DAta because it is used for sharing data between Neovim sessions.
 
 This is introduced in section |21.3| of the user manual.
@@ -957,9 +959,9 @@ The |v:oldfiles| variable is filled.  The marks are not read in at startup
 option upon startup.
 
 							*shada-write*
-When Vim exits and 'shada' is non-empty, the info is stored in the ShaDa file 
-(it's actually merged with the existing one, if one exists |shada-merging|).  
-The 'shada' option is a string containing information about what info should 
+When Vim exits and 'shada' is non-empty, the info is stored in the ShaDa file
+(it's actually merged with the existing one, if one exists |shada-merging|).
+The 'shada' option is a string containing information about what info should
 be stored, and contains limits on how much should be stored (see 'shada').
 
 Notes for Unix:
@@ -1017,73 +1019,73 @@ remembered.
 
 MERGING							*shada-merging*
 									{Nvim}
-When writing ShaDa files with |:wshada| without bang or at regular exit 
-information in the existing ShaDa file is merged with information from current 
-Neovim instance.  For this purpose ShaDa files store timestamps associated 
+When writing ShaDa files with |:wshada| without bang or at regular exit
+information in the existing ShaDa file is merged with information from current
+Neovim instance.  For this purpose ShaDa files store timestamps associated
 with ShaDa entries.  Specifically the following is being done:
 
-1. History lines are merged, ordered by timestamp.  Maximum amount of items in 
-   ShaDa file is defined by 'shada' option (|shada-/|, |shada-:|, |shada-@|, 
-   etc: one suboption for each character that represents history name 
+1. History lines are merged, ordered by timestamp.  Maximum amount of items in
+   ShaDa file is defined by 'shada' option (|shada-/|, |shada-:|, |shada-@|,
+   etc: one suboption for each character that represents history name
    (|:history|)).
-2. Local marks and changes for files that were not opened by Neovim are copied 
-   to new ShaDa file. Marks for files that were opened by Neovim are merged, 
+2. Local marks and changes for files that were not opened by Neovim are copied
+   to new ShaDa file. Marks for files that were opened by Neovim are merged,
    changes to files opened by Neovim are ignored. |shada-'|
-3. Jump list is merged: jumps are ordered by timestamp, identical jumps 
+3. Jump list is merged: jumps are ordered by timestamp, identical jumps
    (identical position AND timestamp) are squashed.
-4. Search patterns and substitute strings are not merged: search pattern or 
-   substitute string which has greatest timestamp will be the only one copied 
+4. Search patterns and substitute strings are not merged: search pattern or
+   substitute string which has greatest timestamp will be the only one copied
    to ShaDa file.
-5. For each register entity with greatest timestamp is the only saved. 
+5. For each register entity with greatest timestamp is the only saved.
    |shada-<|
-6. All saved variables are saved from current Neovim instance. Additionally 
-   existing variable values are copied, meaning that the only way to remove 
-   variable from a ShaDa file is either removing it by hand or disabling 
+6. All saved variables are saved from current Neovim instance. Additionally
+   existing variable values are copied, meaning that the only way to remove
+   variable from a ShaDa file is either removing it by hand or disabling
    writing variables completely. |shada-!|
 7. For each global mark entity with greatest timestamp is the only saved.
-8. Buffer list and header are the only entries which are not merged in any 
-   fashion: the only header and buffer list present are the ones from the 
+8. Buffer list and header are the only entries which are not merged in any
+   fashion: the only header and buffer list present are the ones from the
    Neovim instance which was last writing the file. |shada-%|
 
 COMPATIBILITY						*shada-compatibility*
 									{Nvim}
 ShaDa files are forward and backward compatible.  This means that
 
-1. Entries which have unknown type (i.e. that hold unidentified data) are 
+1. Entries which have unknown type (i.e. that hold unidentified data) are
    ignored when reading and blindly copied when writing.
-2. Register entries with unknown register name are ignored when reading and 
-   blindly copied when writing. Limitation: only registers that use name with 
+2. Register entries with unknown register name are ignored when reading and
+   blindly copied when writing. Limitation: only registers that use name with
    code in interval [1, 255] are supported. |registers|
-3. Register entries with unknown register type are ignored when reading and 
+3. Register entries with unknown register type are ignored when reading and
    merged as usual when writing. |getregtype()|
-4. Local and global mark entries with unknown mark names are ignored when 
-   reading. When writing global mark entries are blindly copied and local mark 
-   entries are also blindly copied, but only if file they are attached to fits 
-   in the |shada-'| limit. Unknown local mark entry's timestamp is also taken 
-   into account when calculating which files exactly should fit into this 
-   limit. Limitation: only marks that use name with code in interval [1, 255] 
+4. Local and global mark entries with unknown mark names are ignored when
+   reading. When writing global mark entries are blindly copied and local mark
+   entries are also blindly copied, but only if file they are attached to fits
+   in the |shada-'| limit. Unknown local mark entry's timestamp is also taken
+   into account when calculating which files exactly should fit into this
+   limit. Limitation: only marks that use name with code in interval [1, 255]
    are supported. |mark-motions|
-5. History entries with unknown history type are ignored when reading and 
-   blindly copied when writing. Limitation: there can be only up to 256 
+5. History entries with unknown history type are ignored when reading and
+   blindly copied when writing. Limitation: there can be only up to 256
    history types. |history|
-6. Unknown keys found in register, local mark, global mark, change, jump and 
-   search pattern entries are saved internally and dumped when writing. 
+6. Unknown keys found in register, local mark, global mark, change, jump and
+   search pattern entries are saved internally and dumped when writing.
    Entries created during Neovim session never have such additions.
-7. Additional elements found in replacement string and history entries are 
-   saved internally and dumped. Entries created during Neovim session never 
+7. Additional elements found in replacement string and history entries are
+   saved internally and dumped. Entries created during Neovim session never
    have such additions.
-8. Additional elements found in variable entries are simply ignored when 
-   reading. When writing new variables they will be preserved during merging, 
-   but that's all. Variable values dumped from current Neovim session never 
-   have additional elements, even if variables themselves were obtained by 
+8. Additional elements found in variable entries are simply ignored when
+   reading. When writing new variables they will be preserved during merging,
+   but that's all. Variable values dumped from current Neovim session never
+   have additional elements, even if variables themselves were obtained by
    reading ShaDa files.
 
-"Blindly" here means that there will be no attempts to somehow merge them, 
+"Blindly" here means that there will be no attempts to somehow merge them,
 even if other entries (with known name/type/etc) are merged. |shada-merging|
 
 SHADA FILE NAME						*shada-file-name*
 
-- The default name of the ShaDa file is "$XDG_DATA_HOME/nvim/shada/main.shada" 
+- The default name of the ShaDa file is "$XDG_DATA_HOME/nvim/shada/main.shada"
   for Unix. Default for $XDG_DATA_HOME is ~/.local/share. |base-directories|
 - The 'n' flag in the 'shada' option can be used to specify another ShaDa
   file name |'shada'|.
@@ -1104,55 +1106,55 @@ however that this means everything will be overwritten with information from
 the first Vim, including the command line history, etc.
 
 The ShaDa file itself can be edited by hand too, although we suggest you
-start with an existing one to get the format right.  You need to understand 
-MessagePack (or, more likely, find software that is able to use it) format to 
-do this.  This can be useful in order to create a second file, say 
-"~/.my.shada" which could contain certain settings that you always want when 
-you first start Neovim.  For example, you can preload registers with 
-particular data, or put certain commands in the command line history.  A line 
+start with an existing one to get the format right.  You need to understand
+MessagePack (or, more likely, find software that is able to use it) format to
+do this.  This can be useful in order to create a second file, say
+"~/.my.shada" which could contain certain settings that you always want when
+you first start Neovim.  For example, you can preload registers with
+particular data, or put certain commands in the command line history.  A line
 in your |init.vim| file like >
 	:rshada! ~/.my.shada
-can be used to load this information.  You could even have different ShaDa 
-files for different types of files (e.g., C code) and load them based on the 
-file name, using the ":autocmd" command (see |:autocmd|).  More information on 
+can be used to load this information.  You could even have different ShaDa
+files for different types of files (e.g., C code) and load them based on the
+file name, using the ":autocmd" command (see |:autocmd|).  More information on
 ShaDa file format is contained in |shada-format| section.
 
 					  *E136* *E929* *shada-error-handling*
-Some errors make Neovim leave temporary file named `{basename}.tmp.X` (X is 
-any free letter from `a` to `z`) while normally it will create this file, 
-write to it and then rename `{basename}.tmp.X` to `{basename}`. Such errors 
+Some errors make Neovim leave temporary file named `{basename}.tmp.X` (X is
+any free letter from `a` to `z`) while normally it will create this file,
+write to it and then rename `{basename}.tmp.X` to `{basename}`. Such errors
 include:
 
-- Errors which make Neovim think that read file is not a ShaDa file at all: 
-  non-ShaDa files are not overwritten for safety reasons to avoid accidentally 
-  destroying an unrelated file.  This could happen e.g. when typing "nvim -i 
-  file" in place of "nvim -R file" (yes, somebody did that at least with Vim).  
+- Errors which make Neovim think that read file is not a ShaDa file at all:
+  non-ShaDa files are not overwritten for safety reasons to avoid accidentally
+  destroying an unrelated file.  This could happen e.g. when typing "nvim -i
+  file" in place of "nvim -R file" (yes, somebody did that at least with Vim).
   Such errors are listed at |shada-critical-contents-errors|.
-- If writing to the temporary file failed: e.g. because of the insufficient 
+- If writing to the temporary file failed: e.g. because of the insufficient
   space left.
 - If renaming file failed: e.g. because of insufficient permissions.
-- If target ShaDa file has different from the Neovim instance's owners (user 
-  and group) and changing them failed.  Unix-specific, applies only when 
+- If target ShaDa file has different from the Neovim instance's owners (user
+  and group) and changing them failed.  Unix-specific, applies only when
   Neovim was launched from root.
 
-Do not forget to remove the temporary file or replace the target file with 
-temporary one after getting one of the above errors or all attempts to create 
-a ShaDa file may fail with |E929|.  If you got one of them when using 
-|:wshada| (and not when exiting Neovim: i.e. when you have Neovim session 
+Do not forget to remove the temporary file or replace the target file with
+temporary one after getting one of the above errors or all attempts to create
+a ShaDa file may fail with |E929|.  If you got one of them when using
+|:wshada| (and not when exiting Neovim: i.e. when you have Neovim session
 running) you have additional options:
 
-- First thing which you should consider if you got any error, except failure 
-  to write to the temporary file: remove existing file and replace it with the 
+- First thing which you should consider if you got any error, except failure
+  to write to the temporary file: remove existing file and replace it with the
   temporary file.  Do it even if you have running Neovim instance.
-- Fix the permissions and/or file ownership, free some space and attempt to 
+- Fix the permissions and/or file ownership, free some space and attempt to
   write again.  Do not remove the existing file.
-- Use |:wshada| with bang.  Does not help in case of permission error.  If 
-  target file was actually the ShaDa file some information may be lost in this 
-  case.  To make the matters slightly better use |:rshada| prior to writing, 
-  but this still will loose buffer-local marks and change list entries for any 
+- Use |:wshada| with bang.  Does not help in case of permission error.  If
+  target file was actually the ShaDa file some information may be lost in this
+  case.  To make the matters slightly better use |:rshada| prior to writing,
+  but this still will loose buffer-local marks and change list entries for any
   file which is not opened in the current Neovim instance.
-- Remove the target file from shell and use |:wshada|.  Consequences are not 
-  different from using |:wshada| with bang, but "rm -f" works in some cases 
+- Remove the target file from shell and use |:wshada|.  Consequences are not
+  different from using |:wshada| with bang, but "rm -f" works in some cases
   when you don't have write permissions.
 
 						    *:rsh* *:rshada* *E886*
@@ -1166,12 +1168,12 @@ running) you have additional options:
 			The information in the file is first read in to make
 			a merge between old and new info.  When [!] is used,
 			the old information is not read first, only the
-			internal info is written (also disables safety checks 
-			described in |shada-error-handling|).  If 'shada' is 
+			internal info is written (also disables safety checks
+			described in |shada-error-handling|).  If 'shada' is
 			empty, marks for up to 100 files will be written.
-			When you get error "E929: All .tmp.X files exist, 
-			cannot write ShaDa file!" check that no old temp files 
-			were left behind (e.g. 
+			When you get error "E929: All .tmp.X files exist,
+			cannot write ShaDa file!" check that no old temp files
+			were left behind (e.g.
 			~/.local/share/nvim/shada/main.shada.tmp*).
 
 			Note: Executing :wshada will reset all |'quote| marks.
@@ -1195,82 +1197,82 @@ running) you have additional options:
 
 SHADA FILE FORMAT						*shada-format*
 
-ShaDa files are concats of MessagePack entries.  Each entry is a concat of 
+ShaDa files are concats of MessagePack entries.  Each entry is a concat of
 exactly four MessagePack objects:
 
-1. First goes type of the entry.  Object type must be an unsigned integer.  
+1. First goes type of the entry.  Object type must be an unsigned integer.
    Object type must not be equal to zero.
 2. Second goes entry timestamp.  It must also be an unsigned integer.
-3. Third goes the length of the fourth entry.  Unsigned integer as well, used 
+3. Third goes the length of the fourth entry.  Unsigned integer as well, used
    for fast skipping without parsing.
-4. Fourth is actual entry data.  All currently used ShaDa entries use 
-   containers to hold data: either map or array.  All string values in those 
-   containers are either binary (applies to filenames) or UTF-8, yet parser 
+4. Fourth is actual entry data.  All currently used ShaDa entries use
+   containers to hold data: either map or array.  All string values in those
+   containers are either binary (applies to filenames) or UTF-8, yet parser
    needs to expect that invalid bytes may be present in a UTF-8 string.
 
    Exact format depends on the entry type:
 
    Entry type (name)   Entry data ~
-   1 (Header)          Map containing data that describes the generator 
-                       instance that wrote this ShaDa file.  It is ignored 
+   1 (Header)          Map containing data that describes the generator
+                       instance that wrote this ShaDa file.  It is ignored
                        when reading ShaDa files.  Contains the following data:
                        Key        Data ~
-                       generator  Binary, software used to generate ShaDa 
-                                  file. Is equal to "nvim" when ShaDa file was 
+                       generator  Binary, software used to generate ShaDa
+                                  file. Is equal to "nvim" when ShaDa file was
                                   written by Neovim.
                        version    Binary, generator version.
                        encoding   Binary, effective 'encoding' value.
                        max_kbyte  Integer, effective |shada-s| limit value.
                        pid        Integer, instance process ID.
-                       *          It is allowed to have any number of 
+                       *          It is allowed to have any number of
                                   additional keys with any data.
-   2 (SearchPattern)   Map containing data describing last used search or 
-                       substitute pattern.  Normally ShaDa file contains two 
-                       such entries: one with "ss" key set to true (describes 
-                       substitute pattern, see |:substitute|), and one set to 
-                       false (describes search pattern, see 
-                       |search-commands|). "su" key should be true on one of 
-                       the entries.  If key value is equal to default then it 
+   2 (SearchPattern)   Map containing data describing last used search or
+                       substitute pattern.  Normally ShaDa file contains two
+                       such entries: one with "ss" key set to true (describes
+                       substitute pattern, see |:substitute|), and one set to
+                       false (describes search pattern, see
+                       |search-commands|). "su" key should be true on one of
+                       the entries.  If key value is equal to default then it
                        is normally not present.  Keys:
                        Key  Type     Default  Description ~
                        sm   Boolean  true     Effective 'magic' value.
                        sc   Boolean  false    Effective 'smartcase' value.
-                       sl   Boolean  true     True if search pattern comes 
-                                              with a line offset.  See 
+                       sl   Boolean  true     True if search pattern comes
+                                              with a line offset.  See
                                               |search-offset|.
-                       se   Boolean  false    True if |search-offset| 
-                                              requested to place cursor at 
-                                              (relative to) the end of the 
+                       se   Boolean  false    True if |search-offset|
+                                              requested to place cursor at
+                                              (relative to) the end of the
                                               pattern.
                        so   Integer  0        Offset value. |search-offset|
-                       su   Boolean  false    True if current entry was the 
+                       su   Boolean  false    True if current entry was the
                                               last used search pattern.
-                       ss   Boolean  false    True if current entry describes 
+                       ss   Boolean  false    True if current entry describes
                                               |:substitute| pattern.
                        sh   Boolean  false    True if |v:hlsearch| is on.
-                                              With |shada-h| or 'nohlsearch' 
+                                              With |shada-h| or 'nohlsearch'
                                               this key is always false.
                        sp   Binary   N/A      Actual pattern.  Required.
-                       sb   Boolean  false    True if search direction is 
+                       sb   Boolean  false    True if search direction is
                                               backward.
-                       *    any      none     Other keys are allowed for 
-                                              compatibility reasons, see 
+                       *    any      none     Other keys are allowed for
+                                              compatibility reasons, see
                                               |shada-compatibility|.
-   3 (SubString)       Array containing last |:substitute| replacement string.  
-                       Contains single entry: binary, replacement string used.  
-                       More entries are allowed for compatibility reasons, see 
+   3 (SubString)       Array containing last |:substitute| replacement string.
+                       Contains single entry: binary, replacement string used.
+                       More entries are allowed for compatibility reasons, see
                        |shada-compatibility|.
-   4 (HistoryEntry)    Array containing one entry from history.  Should have 
-                       two or three entries.  First one is history type 
-                       (unsigned integer), second is history line (binary), 
-                       third is the separator character (unsigned integer, 
-                       must be in interval [0, 255]).  Third item is only 
-                       valid for search history.  Possible history types are 
-                       listed in |hist-names|, here are the corresponding 
-                       numbers: 0 - cmd, 1 - search, 2 - expr, 3 - input, 
+   4 (HistoryEntry)    Array containing one entry from history.  Should have
+                       two or three entries.  First one is history type
+                       (unsigned integer), second is history line (binary),
+                       third is the separator character (unsigned integer,
+                       must be in interval [0, 255]).  Third item is only
+                       valid for search history.  Possible history types are
+                       listed in |hist-names|, here are the corresponding
+                       numbers: 0 - cmd, 1 - search, 2 - expr, 3 - input,
                        4 - debug.
-   5 (Register)        Map describing one register (|registers|).  If key 
-                       value is equal to default then it is normally not 
+   5 (Register)        Map describing one register (|registers|).  If key
+                       value is equal to default then it is normally not
                        present.  Keys:
                        Key  Type             Def   Description ~
                        rt   UInteger         0     Register type:
@@ -1298,12 +1300,12 @@ exactly four MessagePack objects:
                        *    any              none  Other keys are allowed
                                                    for compatibility reasons,
                                                    see |shada-compatibility|.
-   6 (Variable)        Array containing two items: variable name (binary) and 
-                       variable value (any object).  Values are converted 
-                       using the same code |msgpackparse()| uses when reading, 
-                       |msgpackdump()| when writing, so there may appear 
-                       |msgpack-special-dict|s.  If there are more then two 
-                       entries then the rest are ignored 
+   6 (Variable)        Array containing two items: variable name (binary) and
+                       variable value (any object).  Values are converted
+                       using the same code |msgpackparse()| uses when reading,
+                       |msgpackdump()| when writing, so there may appear
+                       |msgpack-special-dict|s.  If there are more then two
+                       entries then the rest are ignored
                        (|shada-compatibility|).
    7 (GlobalMark)
    8 (Jump)
@@ -1317,43 +1319,43 @@ exactly four MessagePack objects:
 
                        Data contained in the map:
                        Key  Type      Default  Description ~
-                       l    UInteger  1        Position line number.  Must be 
+                       l    UInteger  1        Position line number.  Must be
                                                greater then zero.
                        c    UInteger  0        Position column number.
-                       n    UInteger  34 ('"') Mark name.  Only valid for 
-                                               GlobalMark and LocalMark 
+                       n    UInteger  34 ('"') Mark name.  Only valid for
+                                               GlobalMark and LocalMark
                                                entries.
                        f    Binary    N/A      File name.  Required.
-                       *    any       none     Other keys are allowed for 
-                                               compatibility reasons, see 
+                       *    any       none     Other keys are allowed for
+                                               compatibility reasons, see
                                                |shada-compatibility|.
-   9 (BufferList)      Array containing maps.  Each map in the array 
+   9 (BufferList)      Array containing maps.  Each map in the array
                        represents one buffer.  Possible keys:
                        Key  Type      Default  Description ~
-                       l    UInteger  1        Position line number.  Must be 
+                       l    UInteger  1        Position line number.  Must be
                                                greater then zero.
                        c    UInteger  0        Position column number.
                        f    Binary    N/A      File name.  Required.
-                       *    any       none     Other keys are allowed for 
-                                               compatibility reasons, see 
+                       *    any       none     Other keys are allowed for
+                                               compatibility reasons, see
                                                |shada-compatibility|.
-   * (Unknown)         Any other entry type is allowed for compatibility 
+   * (Unknown)         Any other entry type is allowed for compatibility
                        reasons, see |shada-compatibility|.
 
 								*E575* *E576*
-Errors in ShaDa file may have two types: E575 used for all “logical” errors 
-and E576 used for all “critical” errors.  Critical errors trigger behaviour 
-described in |shada-error-handling| when writing and skipping the rest of the 
+Errors in ShaDa file may have two types: E575 used for all “logical” errors
+and E576 used for all “critical” errors.  Critical errors trigger behaviour
+described in |shada-error-handling| when writing and skipping the rest of the
 file when reading and include:
 					    *shada-critical-contents-errors*
 - Any of first three MessagePack objects being not an unsigned integer.
-- Third object requesting amount of bytes greater then bytes left in the ShaDa 
+- Third object requesting amount of bytes greater then bytes left in the ShaDa
   file.
 - Entry with zero type.  I.e. first object being equal to zero.
 - MessagePack parser failing to parse the entry data.
-- MessagePack parser consuming less or requesting greater bytes then described 
-  in the third object for parsing fourth object.  I.e. when fourth object 
-  either contains more then one MessagePack object or it does not contain 
+- MessagePack parser consuming less or requesting greater bytes then described
+  in the third object for parsing fourth object.  I.e. when fourth object
+  either contains more then one MessagePack object or it does not contain
   complete MessagePack object.
 
 ==============================================================================

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -345,9 +345,11 @@ int main(int argc, char **argv)
   do_cmdline_cmd("augroup END");
 #undef PROTO
 
-  // Reset 'loadplugins' for "-u NONE" before "--cmd" arguments.
+  // Reset 'loadplugins' for "-u NONE" or "-u NORCP" before "--cmd" arguments.
   // Allows for setting 'loadplugins' there.
-  if (params.use_vimrc != NULL && strcmp(params.use_vimrc, "NONE") == 0) {
+  if (params.use_vimrc != NULL && (
+              strcmp(params.use_vimrc, "NONE") == 0 ||
+              strcmp(params.use_vimrc, "NORCP") == 0)) {
     p_lpl = false;
   }
 
@@ -1793,7 +1795,8 @@ static void source_startup_scripts(const mparm_T *const parmp)
   // nothing else.
   if (parmp->use_vimrc != NULL) {
     if (strcmp(parmp->use_vimrc, "NONE") == 0
-        || strcmp(parmp->use_vimrc, "NORC") == 0) {
+        || strcmp(parmp->use_vimrc, "NORC") == 0
+        || strcmp(parmp->use_vimrc, "NORCP") == 0) {
     } else {
       if (do_source((char_u *)parmp->use_vimrc, FALSE, DOSO_NONE) != OK)
         EMSG2(_("E282: Cannot read from \"%s\""), parmp->use_vimrc);

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -32,6 +32,21 @@ describe('startup defaults', function()
         'filetype detection:ON  plugin:ON  indent:ON       |')
     end)
 
+    it('noloadplugins after `-u NORCP`', function()
+      clear('-u', 'NORCP')
+    end)
+
+    it('syntax ON after `-u NORCP`', function()
+      clear('-u', 'NORCP')
+      eq(1, eval('g:syntax_on'))
+    end)
+
+    it('all ON after `-u NORCP`', function()
+      clear('-u', 'NORCP')
+      expect_filetype(
+        'filetype detection:ON  plugin:ON  indent:ON       |')
+    end)
+
     it('all ON after `:syntax …` #7765', function()
       clear('-u', 'NORC', '--cmd', 'syntax on')
       expect_filetype(


### PR DESCRIPTION
Can be used to retain syntax highlighting (a là `-u NORC`) but without
the dangers/side-effects of loading plugins. Shorter than `-u NORC
--noplugins` and easier to tell people to use in GitHub issues and other
problem reports.