### PR TITLE
[RFC] vim-patch:8.0.0344

### DIFF
--- a/src/nvim/testdir/test_unlet.vim
+++ b/src/nvim/testdir/test_unlet.vim
@@ -24,3 +24,7 @@ func Test_not_existing()
     call assert_true(v:exception =~ ':E108:')
   endtry
 endfunc
+
+func Test_unlet_fails()
+  call assert_fails('unlet v:["count"]', 'E46:')
+endfunc


### PR DESCRIPTION
#### vim-patch:8.0.0344: unlet command leaks memory

Problem:    Unlet command leaks memory. (Nikolai Pavlov)
Solution:   Free the memory on error. (closes vim/vim#1497)

https://github.com/vim/vim/commit/49439c4cdf7d2822255f292adda4226656fe144d