### PR TITLE
[RFC]oldtests: win: run on cmd.exe

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -97,15 +97,21 @@ bin\nvim --version ; exitIfFailed
 
 # Functional tests
 # The $LastExitCode from MSBuild can't be trusted
-$failed = $false
-# Temporarily turn off tracing to reduce log file output
-Set-PSDebug -Off
-cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs |
-  foreach { $failed = $failed -or
-    $_ -match 'Running functional tests failed with error'; $_ }
-Set-PSDebug -Trace 1
-if ($failed) {
-  exit $LastExitCode
+if ($compiler -eq 'MSVC') {
+  $failed = $false
+  # Temporarily turn off tracing to reduce log file output
+  Set-PSDebug -Off
+  cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs |
+    foreach { $failed = $failed -or
+      $_ -match 'Running functional tests failed with error'; $_ }
+  Set-PSDebug -Trace 1
+  if ($failed) {
+    exit $LastExitCode
+  }
+}
+else {
+  cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs
+  exitIfFailed
 }
 
 

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -97,21 +97,15 @@ bin\nvim --version ; exitIfFailed
 
 # Functional tests
 # The $LastExitCode from MSBuild can't be trusted
-if ($compiler -eq 'MSVC') {
-  $failed = $false
-  # Temporarily turn off tracing to reduce log file output
-  Set-PSDebug -Off
-  cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs |
-    foreach { $failed = $failed -or
-      $_ -match 'Running functional tests failed with error'; $_ }
-  Set-PSDebug -Trace 1
-  if ($failed) {
-    exit $LastExitCode
-  }
-}
-else {
-  cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs
-  exitIfFailed
+$failed = $false
+# Temporarily turn off tracing to reduce log file output
+Set-PSDebug -Off
+cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs |
+  foreach { $failed = $failed -or
+    $_ -match 'Running functional tests failed with error'; $_ }
+Set-PSDebug -Trace 1
+if ($failed) {
+  exit $LastExitCode
 }
 
 

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -114,7 +114,7 @@ if ($uploadToCodecov) {
 }
 
 # Old tests
-$env:PATH += ';C:\msys64\usr\bin'
+$env:PATH = "C:\msys64\usr\bin;$env:PATH"
 & "C:\msys64\mingw$bits\bin\mingw32-make.exe" -C $(Convert-Path ..\src\nvim\testdir) VERBOSE=1
 
 if ($uploadToCodecov) {

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -100,7 +100,7 @@ bin\nvim --version ; exitIfFailed
 $failed = $false
 # Temporarily turn off tracing to reduce log file output
 Set-PSDebug -Off
-cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs |
+cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs 2>&1 |
   foreach { $failed = $failed -or
     $_ -match 'Running functional tests failed with error'; $_ }
 Set-PSDebug -Trace 1

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4208,8 +4208,7 @@ getftype({fname})					*getftype()*
 			getftype("/home")
 <		Note that a type such as "link" will only be returned on
 		systems that support it.  On some systems only "dir" and
-		"file" are returned.  On MS-Windows a symbolic link to a
-		directory returns "dir" instead of "link".
+		"file" are returned.
 
 							*getline()*
 getline({lnum} [, {end}])

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -20,13 +20,13 @@ SCRIPTS_DEFAULT = \
            test40.out             \
            test42.out             \
            test48.out             \
-           test49.out             \
            test52.out             \
            test64.out             \
 
 ifneq ($(OS),Windows_NT)
   SCRIPTS_DEFAULTS := $(SCRIPTS_DEFAULT) \
            test17.out             \
+           test49.out             \
 
 endif
 

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -61,7 +61,7 @@ set nomore
 lang mess C
 
 " Always use forward slashes.
-set shellslash
+" set shellslash
 
 " Prepare for calling test_garbagecollect_now().
 let v:testing = 1

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -17,3 +17,11 @@ let &packpath = &rtp
 
 " Make sure $HOME does not get read or written.
 let $HOME = '/does/not/exist'
+
+" Use default shell on Windows to avoid segfault, caused by TUI
+if has('win32')
+  let $SHELL = ''
+  let $TERM = ''
+  let &shell = empty($COMSPEC) ? exepath('cmd.exe') : $COMSPEC
+  set shellcmdflag=/s/c shellxquote=\" shellredir=>%s\ 2>&1
+endif

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -154,7 +154,7 @@ func Test_getcompletion()
   call assert_equal([], l)
 
   let l = getcompletion('', 'dir')
-  call assert_true(index(l, 'sautest/') >= 0)
+  call assert_true(index(l, expand('sautest/')) >= 0)
   let l = getcompletion('NoMatch', 'dir')
   call assert_equal([], l)
 
@@ -246,7 +246,7 @@ func Test_getcompletion()
 
   " Command line completion tests
   let l = getcompletion('cd ', 'cmdline')
-  call assert_true(index(l, 'sautest/') >= 0)
+  call assert_true(index(l, expand('sautest/')) >= 0)
   let l = getcompletion('cd NoMatch', 'cmdline')
   call assert_equal([], l)
   let l = getcompletion('let v:n', 'cmdline')
@@ -288,7 +288,7 @@ func Test_expand_star_star()
   call mkdir('a/b', 'p')
   call writefile(['asdfasdf'], 'a/b/fileXname')
   call feedkeys(":find **/fileXname\<Tab>\<CR>", 'xt')
-  call assert_equal('find a/b/fileXname', getreg(':'))
+  call assert_equal('find '.expand('a/b/fileXname'), getreg(':'))
   bwipe!
   call delete('a', 'rf')
 endfunc

--- a/src/nvim/testdir/test_find_complete.vim
+++ b/src/nvim/testdir/test_find_complete.vim
@@ -3,6 +3,8 @@
 " Do all the tests in a separate window to avoid E211 when we recursively
 " delete the Xfind directory during cleanup
 func Test_find_complete()
+  let shellslash = &shellslash
+  set shellslash
   set belloff=all
 
   " On windows a stale "Xfind" directory may exist, remove it so that
@@ -154,4 +156,5 @@ func Test_find_complete()
   exe 'cd ' . cwd
   call delete('Xfind', 'rf')
   set path&
+  let &shellslash = shellslash
 endfunc

--- a/src/nvim/testdir/test_help_tagjump.vim
+++ b/src/nvim/testdir/test_help_tagjump.vim
@@ -30,7 +30,7 @@ func Test_help_tagjump()
 
   help sp?it
   call assert_equal("help", &filetype)
-  call assert_true(getline('.') =~ '\*:split\*')
+  call assert_true(getline('.') =~ '\*'.(has('win32') ? 'split()' : ':split').'\*')
   helpclose
 
   help :?

--- a/src/nvim/testdir/test_makeencoding.vim
+++ b/src/nvim/testdir/test_makeencoding.vim
@@ -13,12 +13,19 @@ endif
 
 let s:script = 'test_makeencoding.py'
 
-let s:message_tbl = {
+if has('iconv')
+  let s:message_tbl = {
       \ 'utf-8': 'ÀÈÌÒÙ こんにちは 你好',
       \ 'latin1': 'ÀÈÌÒÙ',
       \ 'cp932': 'こんにちは',
       \ 'cp936': '你好',
       \}
+else
+  let s:message_tbl = {
+      \ 'utf-8': 'ÀÈÌÒÙ こんにちは 你好',
+      \ 'latin1': 'ÀÈÌÒÙ',
+      \}
+endif
 
 
 " Tests for :cgetfile and :lgetfile.

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -158,6 +158,8 @@ func Test_set_completion()
   call assert_equal('"set fileencodings:ucs-bom,utf-8,default,latin1', @:)
 
   " Expand directories.
+  let shellslash = &shellslash
+  set shellslash
   call feedkeys(":set cdpath=./\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_match('./samples/ ', @:)
   call assert_notmatch('./small.vim ', @:)
@@ -168,6 +170,7 @@ func Test_set_completion()
 
   call feedkeys(":set tags=./\\\\ dif\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"set tags=./\\ diff diffexpr diffopt', @:)
+  let &shellslash = shellslash
 endfunc
 
 func Test_set_errors()

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -850,17 +850,17 @@ func s:dir_stack_tests(cchar)
 
   let qf = g:Xgetlist()
 
-  call assert_equal('dir1/a/habits2.txt', bufname(qf[1].bufnr))
+  call assert_equal(expand('dir1/a/habits2.txt'), bufname(qf[1].bufnr))
   call assert_equal(1, qf[1].lnum)
-  call assert_equal('dir1/a/b/habits3.txt', bufname(qf[3].bufnr))
+  call assert_equal(expand('dir1/a/b/habits3.txt'), bufname(qf[3].bufnr))
   call assert_equal(2, qf[3].lnum)
-  call assert_equal('dir1/a/habits2.txt', bufname(qf[4].bufnr))
+  call assert_equal(expand('dir1/a/habits2.txt'), bufname(qf[4].bufnr))
   call assert_equal(7, qf[4].lnum)
-  call assert_equal('dir1/c/habits4.txt', bufname(qf[6].bufnr))
+  call assert_equal(expand('dir1/c/habits4.txt'), bufname(qf[6].bufnr))
   call assert_equal(3, qf[6].lnum)
   call assert_equal('habits1.txt', bufname(qf[9].bufnr))
   call assert_equal(4, qf[9].lnum)
-  call assert_equal('dir2/habits5.txt', bufname(qf[11].bufnr))
+  call assert_equal(expand('dir2/habits5.txt'), bufname(qf[11].bufnr))
   call assert_equal(5, qf[11].lnum)
 
   let &efm=save_efm
@@ -1065,7 +1065,7 @@ func Test_efm2()
   call assert_equal(8, len(l))
   call assert_equal(89, l[4].lnum)
   call assert_equal(1, l[4].valid)
-  call assert_equal('unittests/dbfacadeTest.py', bufname(l[4].bufnr))
+  call assert_equal(expand('unittests/dbfacadeTest.py'), bufname(l[4].bufnr))
 
   " The following sequence of commands used to crash Vim
   set efm=%W%m
@@ -1609,11 +1609,11 @@ func Test_two_windows()
   laddexpr 'one.txt:3:one one one'
 
   let loc_one = getloclist(one_id)
-  call assert_equal('Xone/a/one.txt', bufname(loc_one[1].bufnr))
+  call assert_equal(expand('Xone/a/one.txt'), bufname(loc_one[1].bufnr))
   call assert_equal(3, loc_one[1].lnum)
 
   let loc_two = getloclist(two_id)
-  call assert_equal('Xtwo/a/two.txt', bufname(loc_two[1].bufnr))
+  call assert_equal(expand('Xtwo/a/two.txt'), bufname(loc_two[1].bufnr))
   call assert_equal(5, loc_two[1].lnum)
 
   call win_gotoid(one_id)

--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -6,11 +6,6 @@ func Test_recover_root_dir()
   set dir=/
   call assert_fails('recover', 'E305:')
   close!
-
-  if has('win32') || filewritable('/') == 2
-    " can write in / directory on MS-Windows
-    set dir=/notexist/
-  endif
   call assert_fails('split Xtest', 'E303:')
   set dir&
 endfunc

--- a/src/nvim/testdir/test_stat.vim
+++ b/src/nvim/testdir/test_stat.vim
@@ -86,7 +86,7 @@ func Test_win32_symlink_dir()
     let res = system('dir C:\Users /a')
     if match(res, '\C<SYMLINKD> *All Users') >= 0
       " Get the filetype of the symlink.
-      call assert_equal('dir', getftype('C:\Users\All Users'))
+      call assert_equal('link', getftype('C:\Users\All Users'))
     endif
   endif
 endfunc

--- a/src/nvim/testdir/test_system.vim
+++ b/src/nvim/testdir/test_system.vim
@@ -5,14 +5,12 @@ function! Test_System()
     return
   endif
   let out = system('echo 123')
-  " On Windows we may get a trailing space.
-  if out != "123 \n"
-    call assert_equal("123\n", out)
-  endif
+  call assert_equal("123\n", out)
 
   let out = systemlist('echo 123')
-  " On Windows we may get a trailing space and CR.
-  if out != ["123 \r"]
+  if &shell =~# 'cmd.exe$'
+    call assert_equal(["123\r"], out)
+  else
     call assert_equal(['123'], out)
   endif
 


### PR DESCRIPTION
oldtests are failing on Appveyor but the builds pass because the error code is ignored.
Make them pass and check the error code of make.exe