### PR TITLE
[RDY] build/msvc: Add libintl to bundled dependencies

### DIFF
--- a/cmake/FindLibIntl.cmake
+++ b/cmake/FindLibIntl.cmake
@@ -27,7 +27,7 @@ find_path(LibIntl_INCLUDE_DIR
 )
 
 find_library(LibIntl_LIBRARY
-    NAMES intl libintl.a
+    NAMES intl libintl
 )
 
 if (LibIntl_INCLUDE_DIR)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -43,6 +43,12 @@ option(USE_BUNDLED_LUV "Use the bundled version of luv." ${USE_BUNDLED})
 # build it unless explicitly requested
 option(USE_BUNDLED_LUA "Use the bundled version of lua." OFF)
 
+if(USE_BUNDLED AND MSVC)
+  option(USE_BUNDLED_GETTEXT "Use the bundled version of gettext." ON)
+else()
+  option(USE_BUNDLED_GETTEXT "Use the bundled version of gettext." OFF)
+endif()
+
 option(USE_EXISTING_SRC_DIR "Skip download of deps sources in case of existing source directory." OFF)
 
 if(WIN32)
@@ -154,6 +160,9 @@ set(WIN32YANK_X86_64_SHA256 33a747a92da60fb65e668edbf7661d3d902411a2d545fe9dc086
 set(WINPTY_URL https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip)
 set(WINPTY_SHA256 35a48ece2ff4acdcbc8299d4920de53eb86b1fb41e64d2fe5ae7898931bcee89)
 
+set(GETTEXT_URL https://ftp.gnu.org/pub/gnu/gettext/gettext-0.19.8.1.tar.gz)
+set(GETTEXT_SHA256 ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43)
+
 if(USE_BUNDLED_UNIBILIUM)
   include(BuildUnibilium)
 endif()
@@ -196,6 +205,10 @@ endif()
 
 if(USE_BUNDLED_GPERF)
   include(BuildGperf)
+endif()
+
+if(USE_BUNDLED_GETTEXT)
+  include(BuildGettext)
 endif()
 
 include(GetBinaryDeps)

--- a/third-party/cmake/BuildGettext.cmake
+++ b/third-party/cmake/BuildGettext.cmake
@@ -1,0 +1,34 @@
+if(MSVC)
+
+  ExternalProject_Add(gettext
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${GETTEXT_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/gettext
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/gettext
+      -DURL=${GETTEXT_URL}
+      -DEXPECTED_SHA256=${GETTEXT_SHA256}
+      -DTARGET=gettext
+      -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    PATCH_COMMAND ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/gettext init
+      COMMAND ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/gettext apply --ignore-whitespace
+        ${CMAKE_CURRENT_SOURCE_DIR}/patches/gettext-Fix-compilation-on-a-system-without-alloca.patch
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E copy
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/GettextCMakeLists.txt
+        ${DEPS_BUILD_DIR}/src/gettext/gettext-runtime/CMakeLists.txt
+      COMMAND ${CMAKE_COMMAND} ${DEPS_BUILD_DIR}/src/gettext/gettext-runtime
+        -DCMAKE_INSTALL_PREFIX=${DEPS_INSTALL_DIR}
+        # Pass toolchain
+        -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN}
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_GENERATOR=${CMAKE_GENERATOR}
+    BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE}
+    INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install --config ${CMAKE_BUILD_TYPE})
+
+else()
+  message(FATAL_ERROR "Trying to build gettext in an unsupported system ${CMAKE_SYSTEM_NAME}/${CMAKE_C_COMPILER_ID}")
+endif()
+
+list(APPEND THIRD_PARTY_DEPS gettext)

--- a/third-party/cmake/GettextCMakeLists.txt
+++ b/third-party/cmake/GettextCMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 2.8.7)
+project(libintl C)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+
+file(READ config.h.in CONFIG_CONTENT)
+string(REPLACE "#undef HAVE_GETCWD" "#define HAVE_GETCWD 1" CONFIG_CONTENT ${CONFIG_CONTENT})
+string(REPLACE "#undef uintmax_t" "
+  #if _WIN64
+  # define intmax_t long long
+  # define uintmax_t unsigned long long
+  #elif _WIN32
+  # define intmax_t long
+  # define uintmax_t unsigned long
+  #endif"
+  CONFIG_CONTENT ${CONFIG_CONTENT})
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/config.h ${CONFIG_CONTENT})
+
+set(HAVE_NEWLOCALE 0)
+set(HAVE_POSIX_PRINTF 0)
+set(HAVE_SNPRINTF 0)
+set(HAVE_ASPRINTF 0)
+set(HAVE_WPRINTF 0)
+configure_file(intl/libgnuintl.in.h libgnuintl.h)
+
+set(LOCALDIR "gettext")
+add_definitions(-DLOCALEDIR=\"${LOCALDIR}\"
+  -DLOCALE_ALIAS_PATH=\"${LOCALDIR}\"
+  -DLIBDIR=\"${LOCALDIR}\"
+  -DINSTALLDIR=\"${LOCALDIR}\")
+
+add_definitions(-DBUILDING_LIBINTL
+  -DIN_LIBINTL
+  -DENABLE_RELOCATABLE=1
+  -DIN_LIBRARY
+  -DNO_XMALLOC
+  -Dset_relocation_prefix=libintl_set_relocation_prefix
+  -Drelocate=libintl_relocate
+  -DHAVE_CONFIG_H
+  -D_CRT_SECURE_NO_WARNINGS)
+
+FILE(GLOB SOURCES
+  intl/bindtextdom.c
+  intl/dcgettext.c
+  intl/dcigettext.c
+  intl/dcngettext.c
+  intl/dgettext.c
+  intl/dngettext.c
+  intl/explodename.c
+  intl/finddomain.c
+  intl/gettext.c
+  intl/hash-string.c
+  intl/l10nflist.c
+  intl/langprefs.c
+  intl/loadmsgcat.c
+  intl/localcharset.c
+  intl/localealias.c
+  intl/localename.c
+  intl/lock.c
+  intl/log.c
+  intl/ngettext.c
+  intl/plural-exp.c
+  intl/plural.c
+  intl/printf.c
+  intl/relocatable.c
+  intl/setlocale.c
+  intl/textdomain.c
+  intl/threadlib.c
+  intl/version.c)
+
+add_library(libintl ${SOURCES})
+
+include(GNUInstallDirs)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/libgnuintl.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  RENAME libintl.h)
+
+install(TARGETS libintl
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/third-party/patches/gettext-Fix-compilation-on-a-system-without-alloca.patch
+++ b/third-party/patches/gettext-Fix-compilation-on-a-system-without-alloca.patch
@@ -1,0 +1,28 @@
+From 1d12aeb7334104f77070361492ff7cc8225503f5 Mon Sep 17 00:00:00 2001
+From: Daiki Ueno <ueno@gnu.org>
+Date: Mon, 14 Nov 2016 13:27:58 +0100
+Subject: [PATCH] intl: Fix compilation on a system without alloca
+
+* gettext-runtime/intl/dcigettext.c (DCIGETTEXT): Fix typo 'tmp_dirname'
+-> 'resolved_dirname'.  Reported by Egor Pugin in:
+http://lists.gnu.org/archive/html/bug-gettext/2016-09/msg00008.html
+---
+ gettext-runtime/intl/dcigettext.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gettext-runtime/intl/dcigettext.c b/gettext-runtime/intl/dcigettext.c
+index 83bd77574..92f6fd685 100644
+--- a/gettext-runtime/intl/dcigettext.c
++++ b/gettext-runtime/intl/dcigettext.c
+@@ -634,7 +634,7 @@ DCIGETTEXT (const char *domainname, const char *msgid1, const char *msgid2,
+ 	  for (;;)
+ 	    {
+ 	      resolved_dirname = (char *) alloca (path_max + dirname_len);
+-	      ADD_BLOCK (block_list, tmp_dirname);
++	      ADD_BLOCK (block_list, resolved_dirname);
+ 
+ 	      __set_errno (0);
+ 	      ret = getcwd (resolved_dirname, path_max);
+-- 
+2.16.1.windows.4
+


### PR DESCRIPTION
libintl is a natural language internationalization library that is part of the gettext package. On most systems it's built in to glibc, however, Microsoft's standard library for MSVC doesn't include it. I have added it to the bundled third-party dependencies and created a basic CMakeLists.txt for building it with MSVC. The included patch file is for a bug that was fixed in the upstream, but hasn't been released in a major version yet. After building with libintl, it appears that only two of the functional tests are still failing.