### PR TITLE
[RFC] vim-patch:8.0.0184

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -487,9 +487,6 @@ int emsg(const char_u *s_)
   }
 
   called_emsg = true;
-  if (emsg_silent == 0) {
-    ex_exitval = 1;
-  }
 
   // If "emsg_severe" is TRUE: When an error exception is to be thrown,
   // prefer this message over previous messages for the same command.
@@ -539,6 +536,8 @@ int emsg(const char_u *s_)
       }
       return true;
     }
+
+    ex_exitval = 1;
 
     // Reset msg_silent, an error causes messages to be switched back on.
     msg_silent = 0;

--- a/test/functional/core/exit_spec.lua
+++ b/test/functional/core/exit_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 
 local command = helpers.command
+local feed_command = helpers.feed_command
 local eval = helpers.eval
 local eq = helpers.eq
 local run = helpers.run
@@ -26,6 +27,18 @@ describe('v:exiting', function()
       command('autocmd VimLeavePre * call rpcrequest('..cid..', "")')
       command('autocmd VimLeave    * call rpcrequest('..cid..', "")')
       command('quit')
+    end
+    local function on_request()
+      eq(0, eval('v:exiting'))
+      return ''
+    end
+    run(on_request, nil, on_setup)
+  end)
+  it('is 0 on exit from ex-mode involving try-catch', function()
+    local function on_setup()
+      command('autocmd VimLeavePre * call rpcrequest('..cid..', "")')
+      command('autocmd VimLeave    * call rpcrequest('..cid..', "")')
+      feed_command('call feedkey("Q")','try', 'call NoFunction()', 'catch', 'echo "bye"', 'endtry', 'quit')
     end
     local function on_request()
       eq(0, eval('v:exiting'))


### PR DESCRIPTION
**vim-patch:8.0.0184: when an error is caught Vim still exits with non-zero result**
Problem: When in Ex mode and an error is caught by try-catch, Vim still exits with a non-zero exit code.
Solution: Don't set ex_exitval when inside a try-catch. (partly by ChristianBrabandt)

[`vim/vim@2b7bc5`](https://github.com/vim/vim/commit/2b7bc567b9238aaac682236cb4f727d0376e1302)