### PR TITLE
[RDY]test: win: background command with start /b /wait

### DIFF
--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -255,10 +255,8 @@ describe('system()', function()
       end
     end)
     it('to backgrounded command does not crash', function()
-      -- cmd.exe doesn't background a command with &
-      if iswin() then return end
       -- This is indeterminate, just exercise the codepath. May get E5677.
-      feed_command('call system("echo -n echoed &")')
+      feed_command('call system(has("win32") ? "start /b /wait cmd /c echo echoed" : "echo -n echoed &")')
       local v_errnum = string.match(eval("v:errmsg"), "^E%d*:")
       if v_errnum then
         eq("E5677:", v_errnum)
@@ -272,10 +270,8 @@ describe('system()', function()
       eq("input", eval('system("cat -", "input")'))
     end)
     it('to backgrounded command does not crash', function()
-      -- cmd.exe doesn't background a command with &
-      if iswin() then return end
       -- This is indeterminate, just exercise the codepath. May get E5677.
-      feed_command('call system("cat - &", "input")')
+      feed_command('call system(has("win32") ? "start /b /wait more" : "cat - &", "input")')
       local v_errnum = string.match(eval("v:errmsg"), "^E%d*:")
       if v_errnum then
         eq("E5677:", v_errnum)


### PR DESCRIPTION
Continue #7343
The test cases for backgrounded commands were disabled because & on cmd.exe is for command chaining regardless of the exit status.

This PR enables them by using the `start` builtin from cmd.exe along with the flags `/b /wait` to use the same console and wait for the backgrounded command to finish (otherwise it detaches itself in another console and may have to be killed separately).