### PR TITLE
[RFC] vim-patch:8.0.0411,8.0.0412,8.0.0413

### DIFF
--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -10,6 +10,7 @@ func Test_load_menu()
   catch
     call assert_report('error while loading menus: ' . v:exception)
   endtry
+  call assert_match('browse confirm w', execute(':menu File.Save'))
   source $VIMRUNTIME/delmenu.vim
 endfunc
 
@@ -21,6 +22,8 @@ func Test_translate_menu()
     throw 'Skipped: translated menu not found'
   endif
 
+  " First delete any English menus.
+  source $VIMRUNTIME/delmenu.vim
   set langmenu=de_de
   source $VIMRUNTIME/menu.vim
   call assert_match('browse confirm w', execute(':menu Datei.Speichern'))


### PR DESCRIPTION
#### vim-patch:8.0.0411: menu translations don't match when case is changed.

Problem:    We can't change the case in menu entries, it breaks translations.
Solution:   Ignore case when looking up a menu translation.
https://github.com/vim/vim/commit/11dd8c1201033dd74e2ea665ba277425b4b965b0


#### vim-patch:8.0.0412: menu test fails on MS-Windows

Problem:    Menu test fails on MS-Windows.
Solution:   Use a menu entry with only ASCII characters.
https://github.com/vim/vim/commit/5558d19432120696409c007c64d5ba52eed42670


#### vim-patch:8.0.0413: menu test fails on MS-Windows using gvim

Problem:    Menu test fails on MS-Windows using gvim.
Solution:   First delete the English menus.
https://github.com/vim/vim/commit/a1c8ecfda90c0e0e519762ae0521d7f6e297c32e