### PR TITLE
[RFC] Improve behavior of feedkeys(keys, "i")

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -143,17 +143,11 @@ void nvim_feedkeys(String keys, String mode, Boolean escape_csi)
       keys_esc = keys.data;
   }
 
+  int remap_arg = remap ? REMAP_YES : REMAP_NONE;
   if (insert) {
-    // First, try to prepend to readbuffers.
-    // If they are empty, then prepend to typebuf.
-    int res = prepend_buf_pri((char_u *)keys_esc);
-    if (res == FAIL) {
-      ins_typebuf((char_u *)keys_esc, (remap ? REMAP_YES : REMAP_NONE),
-                  0, !typed, false);
-    }
+    prepend_buf_pri((char_u *)keys_esc, remap_arg, !typed, false);
   } else {
-    ins_typebuf((char_u *)keys_esc, (remap ? REMAP_YES : REMAP_NONE),
-                typebuf.tb_len, !typed, false);
+    ins_typebuf((char_u *)keys_esc, remap_arg, typebuf.tb_len, !typed, false);
   }
 
   if (escape_csi) {

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -142,8 +142,19 @@ void nvim_feedkeys(String keys, String mode, Boolean escape_csi)
   } else {
       keys_esc = keys.data;
   }
-  ins_typebuf((char_u *)keys_esc, (remap ? REMAP_YES : REMAP_NONE),
-      insert ? 0 : typebuf.tb_len, !typed, false);
+
+  if (insert) {
+    // First, try to prepend to readbuffers.
+    // If they are empty, then prepend to typebuf.
+    int res = prepend_buf_pri((char_u *)keys_esc);
+    if (res == FAIL) {
+      ins_typebuf((char_u *)keys_esc, (remap ? REMAP_YES : REMAP_NONE),
+                  0, !typed, false);
+    }
+  } else {
+    ins_typebuf((char_u *)keys_esc, (remap ? REMAP_YES : REMAP_NONE),
+                typebuf.tb_len, !typed, false);
+  }
 
   if (escape_csi) {
       xfree(keys_esc);

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -270,22 +270,30 @@ static void prepend_buf(buffheader_T *buf, char_u *s)
 
 /// Prepend string to the current block of the buffer with highest priority.
 ///
+/// The priority of buffers are "readbuf1 > readbuf2 > typebuf".
+/// In order feedkeys(keys, "n") to behave as we expect, feedkeys(keys, "n")
+/// should prepend the keys according to this priority order.
+///   1. if readbuf1 has contents, prepend into readbuf1
+///   2. if readbuf1 is empty and readbuf2 has contents, prepend into readbuf2
+///   3. otherwise prepend into typebuf
+/// Return FAIL for failure in ins_typebuf, otherwise OK.
 /// K_SPECIAL and CSI should have been escaped already.
-/// Return FAIL if both readbuf1 and readbuf2 are empty, otherwise OK.
 ///
 /// @param[in]  s  String to prepend.
-/// @param[in]  slen  String length or -1 for NUL-terminated string.
-int prepend_buf_pri(char_u *s)
+/// @param[in]  noremap   passed to ins_typebuf.
+/// @param[in]  nottyped  passed to ins_typebuf.
+/// @param[in]  silent    passed to ins_typebuf.
+int prepend_buf_pri(char_u *s, int noremap, int nottyped, bool silent)
 {
   if (read_readbuf(&readbuf1, false) != NUL) {
     prepend_buf(&readbuf1, s);
+    return OK;
   } else if (read_readbuf(&readbuf2, false) != NUL) {
     prepend_buf(&readbuf2, s);
+    return OK;
   } else {
-    return FAIL;
+    return ins_typebuf(s, noremap, 0, nottyped, silent);
   }
-
-  return OK;
 }
 
 /// Add string after the current block of the given buffer


### PR DESCRIPTION
## Summary
Before this PR, `feedkeys(keys, "i")` always insert the keys to the head of `typebuf`.
However, when `feedkeys` are invoked, there might be some key sequences in read buffers which have higher read priority than `typebuf`
In such cases, `feedkeys` should insert the keys to the head of read buffers.

## Problem which this PR will fix
`feedkeys` inserting always into `typebuf` occurs following problem:

Assume that we have `init.vim` and `test.xml`
```vim
" init.vim
autocmd InsertEnter * call feedkeys("\<C-x>\<C-o>", 'in')
```
```xml
" test.xml
<tag foo="1"/>
<tag foo="1"/>
```

Note that this `init.vim` is a simplified version of "OmniComp auto-triggering", which is used in various completion plugin, such as deoplete.nvim or nvim-completion-manager.

Suppose we have to change `foo` in both lines into `bar` in following manner:
  1. move cursor onto `foo` in line 1
  2. `ciwbar<ESC>`
  3. move cursor onto `foo` in line 2
  4. `.` (redo by dot)

Now, both `foo` are changed into `bar`, but at the same time as dot-repeat, `1` in the line 2 is declined to `0`.
This is not an intended behavior.

sample screenrecord (ref: https://github.com/Shougo/deoplete.nvim/issues/696)
![simplescreenrecorder-2018-03-21_12 19 48](https://user-images.githubusercontent.com/1460175/37693569-e2743ea0-2d03-11e8-9675-8470f738406f.gif)

## Cause of this problem
The cause of this problem is that the inserted keys by `feedkeys` (on typebuf) are indeed consumed after the redo sequence (on the read buffers).

In the example above, after the `.`-repeat is triggered, redo sequence is copied into `readbuf2`
```
readbuf2:  ciwbar<ESC>
typebuf :
```
Then, operation `ciw` is consumed by nvim.
```
readbuf2:  bar<ESC>
typebuf :  
```
At this time, vim is entering `insert` mode, therefore the `InsertEnter` autocmd is triggered and it executes `feedkeys`.
```
readbuf2:  bar<ESC>
typebuf :  <C-x><C-o>
```
However, `readbuf2` has higher priority than `typebuf`, so `bar<ESC>` is consumed first, and exit insert mode.
```
readbuf2: 
typebuf :  <C-x><C-o>
```
Then, `<C-x><C-o>` are consumed **in the normal mode**, so `<C-x>` is treated as decrement operation, and `<C-o>` is just ignored because it has no mapping.

## Solution implemented in this PR
If a read buffer has any contents, `feedkeys(keys, "i")` inserts the keys into that buffer.
So after the autocmd the buffers will be:
```
readbuf2:  <C-x><C-o>bar<ESC>
typebuf :
```
This behaves as we assume.

## Note
Vim has the same problem, and I'm planning to send a patch to vim