### PR TITLE
[RFC] support "virtual text" annotations (currently after EOL only)

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5375,6 +5375,45 @@ void bufhl_add_hl_pos_offset(buf_T *buf,
   }
 }
 
+int bufhl_add_virt_text(buf_T *buf,
+                        int src_id,
+                        linenr_T lnum,
+                        VirtText virt_text)
+{
+  static int next_src_id = 1;
+  if (src_id == 0) {
+    src_id = next_src_id++;
+  }
+
+  BufhlLine *lineinfo = bufhl_tree_ref(&buf->b_bufhl_info, lnum, true);
+
+  bufhl_clear_virttext(&lineinfo->virt_text);
+  if (kv_size(virt_text) > 0) {
+    lineinfo->virt_text_src = src_id;
+    lineinfo->virt_text = virt_text;
+  } else {
+    lineinfo->virt_text_src = 0;
+    // currently not needed, but allow a future caller with
+    // 0 size and non-zero capacity
+    kv_destroy(virt_text);
+  }
+
+  if (0 < lnum && lnum <= buf->b_ml.ml_line_count) {
+    changed_lines_buf(buf, lnum, lnum+1, 0);
+    redraw_buf_later(buf, VALID);
+  }
+  return src_id;
+}
+
+static void bufhl_clear_virttext(VirtText *text)
+{
+  for (size_t i = 0; i < kv_size(*text); i++) {
+    xfree(kv_A(*text, i).text);
+  }
+  kv_destroy(*text);
+  *text = (VirtText)KV_INITIAL_VALUE;
+}
+
 /// Clear bufhl highlights from a given source group and range of lines.
 ///
 /// @param buf The buffer to remove highlights from
@@ -5430,6 +5469,7 @@ void bufhl_clear_line_range(buf_T *buf,
 static BufhlLineStatus bufhl_clear_line(BufhlLine *lineinfo, int src_id,
                                         linenr_T lnum)
 {
+  BufhlLineStatus changed = kBLSUnchanged;
   size_t oldsize = kv_size(lineinfo->items);
   if (src_id < 0) {
     kv_size(lineinfo->items) = 0;
@@ -5445,13 +5485,24 @@ static BufhlLineStatus bufhl_clear_line(BufhlLine *lineinfo, int src_id,
     }
     kv_size(lineinfo->items) = newidx;
   }
+  if (kv_size(lineinfo->items) != oldsize) {
+    changed = kBLSChanged;
+  }
 
-  if (kv_size(lineinfo->items) == 0) {
+  if (kv_size(lineinfo->virt_text) != 0
+      && (src_id < 0 || src_id == lineinfo->virt_text_src)) {
+    bufhl_clear_virttext(&lineinfo->virt_text);
+    lineinfo->virt_text_src = 0;
+    changed = kBLSChanged;
+  }
+
+  if (kv_size(lineinfo->items) == 0 && kv_size(lineinfo->virt_text) == 0) {
     kv_destroy(lineinfo->items);
     return kBLSDeleted;
   }
-  return kv_size(lineinfo->items) != oldsize ? kBLSChanged : kBLSUnchanged;
+  return changed;
 }
+
 
 /// Remove all highlights and free the highlight data
 void bufhl_clear_all(buf_T *buf)
@@ -5527,8 +5578,8 @@ bool bufhl_start_line(buf_T *buf, linenr_T lnum, BufhlLineInfo *info)
     return false;
   }
   info->valid_to = -1;
-  info->entries = lineinfo->items;
-  return kv_size(info->entries) > 0;
+  info->line = lineinfo;
+  return true;
 }
 
 /// get highlighting at column col
@@ -5548,8 +5599,8 @@ int bufhl_get_attr(BufhlLineInfo *info, colnr_T col)
   }
   int attr = 0;
   info->valid_to = MAXCOL;
-  for (size_t i = 0; i < kv_size(info->entries); i++) {
-    BufhlItem entry = kv_A(info->entries, i);
+  for (size_t i = 0; i < kv_size(info->line->items); i++) {
+    BufhlItem entry = kv_A(info->line->items, i);
     if (entry.start <= col && col <= entry.stop) {
       int entry_attr = syn_id2attr(entry.hl_id);
       attr = hl_combine_attr(attr, entry_attr);

--- a/src/nvim/bufhl_defs.h
+++ b/src/nvim/bufhl_defs.h
@@ -14,16 +14,23 @@ typedef struct {
   colnr_T stop;  // last column to highlight
 } BufhlItem;
 
-typedef kvec_t(BufhlItem) BufhlItemVec;
+typedef struct {
+  char *text;
+  int hl_id;
+} VirtTextChunk;
+
+typedef kvec_t(VirtTextChunk) VirtText;
 
 typedef struct {
   linenr_T line;
-  BufhlItemVec items;
+  kvec_t(BufhlItem) items;
+  int virt_text_src;
+  VirtText virt_text;
 } BufhlLine;
-#define BUFHLLINE_INIT(l) { l, KV_INITIAL_VALUE }
+#define BUFHLLINE_INIT(l) { l, KV_INITIAL_VALUE, 0,  KV_INITIAL_VALUE }
 
 typedef struct {
-  BufhlItemVec entries;
+  BufhlLine *line;
   int current;
   colnr_T valid_to;
 } BufhlLineInfo;


### PR DESCRIPTION
Currently mostly to show that it is possible, not sure what the best API is. Should work like https://github.com/vim/vim/issues/2388, except that it is memory safe and it is possible to specify highlight group. Use

    call nvim_buf_set_eol_text(0, 0, "WarningMsg", 5, " some text")

to show a warning annotation after line 6. Ideally detailed highlighting should be supported, perhaps by adding a flag to bufhl entries. Also a flag to highlight to the end of the current screenline would be nice.

**final API:**

    call nvim_buf_set_virtual_text(0, src_id, linenr, [["text "], ["more text", "Comment"]], {})

Ref #1767 #8068