### PR TITLE
[RFC] build/msvc: Fix functional tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,14 +3,13 @@ environment:
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: "-t7z -m0=lzma -mx=9"
 image: Visual Studio 2017
 configuration:
+- MSVC_64
+- MSVC_32
 - MINGW_64
 - MINGW_32
-- MSVC_64
-# - MSVC_32
 - MINGW_64-gcov
 matrix:
   allow_failures:
-    - configuration: MSVC_64
     - configuration: MINGW_64-gcov
 install: []
 before_build:

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -91,7 +91,18 @@ cmake --build . --config $cmakeBuildType -- $cmakeGeneratorArgs ; exitIfFailed
 bin\nvim --version ; exitIfFailed
 
 # Functional tests
-cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs ; exitIfFailed
+# The $LastExitCode from MSBuild can't be trusted
+$failed = $false
+# Temporarily turn off tracing to reduce log file output
+Set-PSDebug -Off
+cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs |
+  foreach { $failed = $failed -or
+    $_ -match 'Running functional tests failed with error'; $_ }
+Set-PSDebug -Trace 1
+if ($failed) {
+  exit $LastExitCode
+}
+
 
 if ($uploadToCodecov) {
   C:\msys64\usr\bin\bash -lc "cd /c/projects/neovim; bash <(curl -s https://codecov.io/bash) -c -F functionaltest || echo 'codecov upload failed.'"

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -39,8 +39,6 @@ if ($compiler -eq 'MINGW') {
 
   # Add MinGW to the PATH
   $env:PATH = "C:\msys64\mingw$bits\bin;$env:PATH"
-  # Remove the Git sh.exe from the PATH
-  $env:PATH = $env:PATH.Replace('C:\Program Files\Git\usr\bin', '')
 
   # Build third-party dependencies
   C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm -Su" ; exitIfFailed
@@ -55,6 +53,9 @@ elseif ($compiler -eq 'MSVC') {
     $cmakeGenerator = 'Visual Studio 15 2017 Win64'
   }
 }
+
+# Remove Git Unix utilities from the PATH
+$env:PATH = $env:PATH.Replace('C:\Program Files\Git\usr\bin', '')
 
 # Setup python (use AppVeyor system python)
 C:\Python27\python.exe -m pip install neovim ; exitIfFailed

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -11,7 +11,6 @@ $depsCmakeVars = @{
 $nvimCmakeVars = @{
   CMAKE_BUILD_TYPE = $cmakeBuildType;
   BUSTED_OUTPUT_TYPE = 'nvim';
-  GPERF_PRG = 'C:\msys64\usr\bin\gperf.exe';
 }
 
 function exitIfFailed() {
@@ -42,7 +41,7 @@ if ($compiler -eq 'MINGW') {
 
   # Build third-party dependencies
   C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm -Su" ; exitIfFailed
-  C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm --needed -S mingw-w64-$arch-cmake mingw-w64-$arch-perl mingw-w64-$arch-diffutils mingw-w64-$arch-unibilium gperf" ; exitIfFailed
+  C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm --needed -S mingw-w64-$arch-cmake mingw-w64-$arch-perl mingw-w64-$arch-diffutils mingw-w64-$arch-unibilium" ; exitIfFailed
 }
 elseif ($compiler -eq 'MSVC') {
   $cmakeGeneratorArgs = '/verbosity:normal'

--- a/test/functional/legacy/077_mf_hash_grow_spec.lua
+++ b/test/functional/legacy/077_mf_hash_grow_spec.lua
@@ -18,7 +18,8 @@ describe('mf_hash_grow()', function()
   setup(clear)
 
   -- Check to see if cksum exists, otherwise skip the test
-  if os.execute('which cksum 2>&1 > /dev/null') ~= 0 then
+  local null = helpers.iswin() and 'nul' or '/dev/null'
+  if os.execute('cksum --help >' .. null .. ' 2>&1') ~= 0 then
     pending('was not tested because cksum was not found', function() end)
   else
     it('is working', function()

--- a/third-party/patches/libvterm-Remove-VLAs-for-MSVC.patch
+++ b/third-party/patches/libvterm-Remove-VLAs-for-MSVC.patch
@@ -23,7 +23,7 @@ index 84299df..f9aabb3 100644
  
    // We'll have at most len codepoints
 -  uint32_t codepoints[len];
-+  uint32_t* codepoints = _alloca(len);
++  uint32_t* codepoints = _alloca(len * sizeof(uint32_t));
    int npoints = 0;
    size_t eaten = 0;
  
@@ -32,7 +32,7 @@ index 84299df..f9aabb3 100644
      int width = 0;
  
 -    uint32_t chars[glyph_ends - glyph_starts + 1];
-+    uint32_t* chars = _alloca(glyph_ends - glyph_starts + 1);
++    uint32_t* chars = _alloca((glyph_ends - glyph_starts + 1) * sizeof(uint32_t));
  
      for( ; i < glyph_ends; i++) {
        chars[i - glyph_starts] = codepoints[i];


### PR DESCRIPTION
All the functional tests are passing, but MSBuild still returns a non-zero exit code because it detects the word "error" in the stdout which is caused by some of the test names such as `api/buf {get,set,del}_line get_line : out-of-bounds is an error`. There is a [CMake mailing list thread](https://cmake.org/pipermail/cmake-developers/2015-October/026775.html) about this problem, but there isn't any good solution for it, so I modified the build script to detect the error message printed by `RunTests.cmake`.