### PR TITLE
[RFC] Fuzzy match option for completion popup, based on fzy.

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1470,6 +1470,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    select one from the menu. Only works in combination with
 		    "menu" or "menuone".
 
+	     fuzzy  Use fuzzy matching algorithm in popup menu.
+
 
 						*'concealcursor'* *'cocu'*
 'concealcursor' 'cocu'	string (default: "")

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -88,6 +88,7 @@ foreach(subdir
         tui
         event
         eval
+        fzy
         lua
         viml
         viml/parser

--- a/src/nvim/edit.h
+++ b/src/nvim/edit.h
@@ -13,6 +13,25 @@
 #define CPT_USER_DATA   4   // "user data"
 #define CPT_COUNT       5   // Number of entries
 
+/*
+ * Structure used to store one match for insert completion.
+ */
+typedef struct compl_S compl_T;
+struct compl_S {
+  compl_T     *cp_next;
+  compl_T     *cp_prev;
+  char_u      *cp_str;          /* matched text */
+  char cp_icase;                /* TRUE or FALSE: ignore case */
+  char_u      *(cp_text[CPT_COUNT]);    /* text for the menu */
+  char_u      *cp_fname;        /* file containing the match, allocated when
+                                 * cp_flags has FREE_FNAME */
+  int cp_flags;                 /* ORIGINAL_TEXT, CONT_S_IPOS or FREE_FNAME */
+  int cp_number;                /* sequence number */
+};
+
+#define ORIGINAL_TEXT   (1)   /* the original text when the expansion begun */
+#define FREE_FNAME      (2)
+
 typedef int (*IndentGetter)(void);
 
 /* Values for in_cinkeys() */

--- a/src/nvim/fzy/bonus.h
+++ b/src/nvim/fzy/bonus.h
@@ -1,0 +1,106 @@
+#ifndef BONUS_H
+#define BONUS_H BONUS_H
+
+#define ASSIGN_LOWER(v) \
+	['a'] = (v), \
+	['b'] = (v), \
+	['c'] = (v), \
+	['d'] = (v), \
+	['e'] = (v), \
+	['f'] = (v), \
+	['g'] = (v), \
+	['h'] = (v), \
+	['i'] = (v), \
+	['j'] = (v), \
+	['k'] = (v), \
+	['l'] = (v), \
+	['m'] = (v), \
+	['n'] = (v), \
+	['o'] = (v), \
+	['p'] = (v), \
+	['q'] = (v), \
+	['r'] = (v), \
+	['s'] = (v), \
+	['t'] = (v), \
+	['u'] = (v), \
+	['v'] = (v), \
+	['w'] = (v), \
+	['x'] = (v), \
+	['y'] = (v), \
+	['z'] = (v)
+
+#define ASSIGN_UPPER(v) \
+	['A'] = (v), \
+	['B'] = (v), \
+	['C'] = (v), \
+	['D'] = (v), \
+	['E'] = (v), \
+	['F'] = (v), \
+	['G'] = (v), \
+	['H'] = (v), \
+	['I'] = (v), \
+	['J'] = (v), \
+	['K'] = (v), \
+	['L'] = (v), \
+	['M'] = (v), \
+	['N'] = (v), \
+	['O'] = (v), \
+	['P'] = (v), \
+	['Q'] = (v), \
+	['R'] = (v), \
+	['S'] = (v), \
+	['T'] = (v), \
+	['U'] = (v), \
+	['V'] = (v), \
+	['W'] = (v), \
+	['X'] = (v), \
+	['Y'] = (v), \
+	['Z'] = (v)
+
+#define ASSIGN_DIGIT(v) \
+	['0'] = (v), \
+	['1'] = (v), \
+	['2'] = (v), \
+	['3'] = (v), \
+	['4'] = (v), \
+	['5'] = (v), \
+	['6'] = (v), \
+	['7'] = (v), \
+	['8'] = (v), \
+	['9'] = (v)
+
+const score_t bonus_states[3][256] = {
+	{ 0 },
+	{
+		['/'] = SCORE_MATCH_SLASH,
+		['-'] = SCORE_MATCH_WORD,
+		['_'] = SCORE_MATCH_WORD,
+		[' '] = SCORE_MATCH_WORD,
+		['.'] = SCORE_MATCH_DOT,
+	},
+	{
+		['/'] = SCORE_MATCH_SLASH,
+		['-'] = SCORE_MATCH_WORD,
+		['_'] = SCORE_MATCH_WORD,
+		[' '] = SCORE_MATCH_WORD,
+		['.'] = SCORE_MATCH_DOT,
+
+		/* ['a' ... 'z'] = SCORE_MATCH_CAPITAL, */
+		ASSIGN_LOWER(SCORE_MATCH_CAPITAL)
+	}
+};
+
+const size_t bonus_index[256] = {
+	/* ['A' ... 'Z'] = 2 */
+	ASSIGN_UPPER(2),
+
+	/* ['a' ... 'z'] = 1 */
+	ASSIGN_LOWER(1),
+
+	/* ['0' ... '9'] = 1 */
+	ASSIGN_DIGIT(1)
+};
+
+#define COMPUTE_BONUS(last_ch, ch) (bonus_states[bonus_index[(unsigned char)(ch)]][(unsigned char)(last_ch)])
+
+#endif

--- a/src/nvim/fzy/match.c
+++ b/src/nvim/fzy/match.c
@@ -1,0 +1,170 @@
+#include <ctype.h>
+#include <string.h>
+#include <strings.h>
+#include <stdio.h>
+#include <float.h>
+#include <math.h>
+
+#include "match.h"
+#include "bonus.h"
+
+char *strcasechr(const char *s, char c) {
+	const char accept[3] = {c, toupper(c), 0};
+	return strpbrk(s, accept);
+}
+
+int has_match(const char *needle, const char *haystack) {
+	while (*needle) {
+		char nch = *needle++;
+
+		if (!(haystack = strcasechr(haystack, nch))) {
+			return 0;
+		}
+		haystack++;
+	}
+	return 1;
+}
+
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+
+#ifdef DEBUG_VERBOSE
+/* print one of the internal matrices */
+void mat_print(score_t *mat, char name, const char *needle, const char *haystack) {
+	int n = strlen(needle);
+	int m = strlen(haystack);
+	int i, j;
+	fprintf(stderr, "%c   ", name);
+	for (j = 0; j < m; j++) {
+		fprintf(stderr, "     %c", haystack[j]);
+	}
+	fprintf(stderr, "\n");
+	for (i = 0; i < n; i++) {
+		fprintf(stderr, " %c |", needle[i]);
+		for (j = 0; j < m; j++) {
+			score_t val = mat[i * m + j];
+			if (val == SCORE_MIN) {
+				fprintf(stderr, "    -\u221E");
+			} else {
+				fprintf(stderr, " %.3f", val);
+			}
+		}
+		fprintf(stderr, "\n");
+	}
+	fprintf(stderr, "\n\n");
+}
+#endif
+
+static void precompute_bonus(const char *haystack, score_t *match_bonus) {
+	/* Which positions are beginning of words */
+	int m = strlen(haystack);
+	char last_ch = '/';
+	for (int i = 0; i < m; i++) {
+		char ch = haystack[i];
+		match_bonus[i] = COMPUTE_BONUS(last_ch, ch);
+		last_ch = ch;
+	}
+}
+
+score_t match_positions(const char *needle, const char *haystack, size_t *positions) {
+	if (!*needle)
+		return SCORE_MIN;
+
+	int n = strlen(needle);
+	int m = strlen(haystack);
+
+	if (n == m) {
+		/* Since this method can only be called with a haystack which
+		 * matches needle. If the lengths of the strings are equal the
+		 * strings themselves must also be equal (ignoring case).
+		 */
+		if (positions)
+			for (int i = 0; i < n; i++)
+				positions[i] = i;
+		return SCORE_MAX;
+	}
+
+	if (m > 1024) {
+		/*
+		 * Unreasonably large candidate: return no score
+		 * If it is a valid match it will still be returned, it will
+		 * just be ranked below any reasonably sized candidates
+		 */
+		return SCORE_MIN;
+	}
+
+	score_t match_bonus[m];
+	score_t D[n][m], M[n][m];
+
+	/*
+	 * D[][] Stores the best score for this position ending with a match.
+	 * M[][] Stores the best possible score at this position.
+	 */
+	precompute_bonus(haystack, match_bonus);
+
+	for (int i = 0; i < n; i++) {
+		score_t prev_score = SCORE_MIN;
+		score_t gap_score = i == n - 1 ? SCORE_GAP_TRAILING : SCORE_GAP_INNER;
+
+		for (int j = 0; j < m; j++) {
+			if (tolower(needle[i]) == tolower(haystack[j])) {
+				score_t score = SCORE_MIN;
+				if (!i) {
+					score = (j * SCORE_GAP_LEADING) + match_bonus[j];
+				} else if (j) { /* i > 0 && j > 0*/
+					score = max(
+					    M[i - 1][j - 1] + match_bonus[j],
+
+					    /* consecutive match, doesn't stack with match_bonus */
+					    D[i - 1][j - 1] + SCORE_MATCH_CONSECUTIVE);
+				}
+				D[i][j] = score;
+				M[i][j] = prev_score = max(score, prev_score + gap_score);
+			} else {
+				D[i][j] = SCORE_MIN;
+				M[i][j] = prev_score = prev_score + gap_score;
+			}
+		}
+	}
+
+#ifdef DEBUG_VERBOSE
+	fprintf(stderr, "\"%s\" =~ \"%s\"\n", needle, haystack);
+	mat_print(&D[0][0], 'D', needle, haystack);
+	mat_print(&M[0][0], 'M', needle, haystack);
+	fprintf(stderr, "\n");
+#endif
+
+	/* backtrace to find the positions of optimal matching */
+	if (positions) {
+		int match_required = 0;
+		for (int i = n - 1, j = m - 1; i >= 0; i--) {
+			for (; j >= 0; j--) {
+				/*
+				 * There may be multiple paths which result in
+				 * the optimal weight.
+				 *
+				 * For simplicity, we will pick the first one
+				 * we encounter, the latest in the candidate
+				 * string.
+				 */
+				if (D[i][j] != SCORE_MIN &&
+				    (match_required || D[i][j] == M[i][j])) {
+					/* If this score was determined using
+					 * SCORE_MATCH_CONSECUTIVE, the
+					 * previous character MUST be a match
+					 */
+					match_required =
+					    i && j &&
+					    M[i][j] == D[i - 1][j - 1] + SCORE_MATCH_CONSECUTIVE;
+					positions[i] = j--;
+					break;
+				}
+			}
+		}
+	}
+
+	return M[n - 1][m - 1];
+}
+
+score_t match(const char *needle, const char *haystack) {
+	return match_positions(needle, haystack, NULL);
+}

--- a/src/nvim/fzy/match.c
+++ b/src/nvim/fzy/match.c
@@ -9,7 +9,7 @@
 #include "bonus.h"
 
 char *strcasechr(const char *s, char c) {
-	const char accept[3] = {c, toupper(c), 0};
+	const char accept[3] = {c, (char)toupper(c), 0};
 	return strpbrk(s, accept);
 }
 
@@ -56,7 +56,7 @@ void mat_print(score_t *mat, char name, const char *needle, const char *haystack
 
 static void precompute_bonus(const char *haystack, score_t *match_bonus) {
 	/* Which positions are beginning of words */
-	int m = strlen(haystack);
+	int m = (int)strlen(haystack);
 	char last_ch = '/';
 	for (int i = 0; i < m; i++) {
 		char ch = haystack[i];
@@ -69,8 +69,11 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 	if (!*needle)
 		return SCORE_MIN;
 
-	int n = strlen(needle);
-	int m = strlen(haystack);
+	int n = (int)strlen(needle);
+	if (n > MAX_NEEDLE_SIZE) {
+		n = MAX_NEEDLE_SIZE;
+	}
+	int m = (int)strlen(haystack);
 
 	if (n == m) {
 		/* Since this method can only be called with a haystack which
@@ -79,11 +82,11 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 		 */
 		if (positions)
 			for (int i = 0; i < n; i++)
-				positions[i] = i;
+				positions[i] = (size_t)i;
 		return SCORE_MAX;
 	}
 
-	if (m > 1024) {
+	if (m > MAX_HAYSTACK_SIZE) {
 		/*
 		 * Unreasonably large candidate: return no score
 		 * If it is a valid match it will still be returned, it will
@@ -92,8 +95,9 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 		return SCORE_MIN;
 	}
 
-	score_t match_bonus[m];
-	score_t D[n][m], M[n][m];
+	static score_t match_bonus[MAX_HAYSTACK_SIZE];
+	static score_t D[MAX_NEEDLE_SIZE][MAX_HAYSTACK_SIZE];
+	static score_t M[MAX_NEEDLE_SIZE][MAX_HAYSTACK_SIZE];
 
 	/*
 	 * D[][] Stores the best score for this position ending with a match.
@@ -155,7 +159,7 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 					match_required =
 					    i && j &&
 					    M[i][j] == D[i - 1][j - 1] + SCORE_MATCH_CONSECUTIVE;
-					positions[i] = j--;
+					positions[i] = (size_t)(j--);
 					break;
 				}
 			}

--- a/src/nvim/fzy/match.h
+++ b/src/nvim/fzy/match.h
@@ -16,6 +16,9 @@ typedef double score_t;
 #define SCORE_MATCH_CAPITAL 0.7
 #define SCORE_MATCH_DOT 0.6
 
+#define MAX_HAYSTACK_SIZE 512
+#define MAX_NEEDLE_SIZE 80
+
 int has_match(const char *needle, const char *haystack);
 score_t match_positions(const char *needle, const char *haystack, size_t *positions);
 score_t match(const char *needle, const char *haystack);

--- a/src/nvim/fzy/match.h
+++ b/src/nvim/fzy/match.h
@@ -1,0 +1,23 @@
+#ifndef MATCH_H
+#define MATCH_H MATCH_H
+
+#include <math.h>
+
+typedef double score_t;
+#define SCORE_MAX INFINITY
+#define SCORE_MIN -INFINITY
+
+#define SCORE_GAP_LEADING -0.005
+#define SCORE_GAP_TRAILING -0.005
+#define SCORE_GAP_INNER -0.01
+#define SCORE_MATCH_CONSECUTIVE 1.0
+#define SCORE_MATCH_SLASH 0.9
+#define SCORE_MATCH_WORD 0.8
+#define SCORE_MATCH_CAPITAL 0.7
+#define SCORE_MATCH_DOT 0.6
+
+int has_match(const char *needle, const char *haystack);
+score_t match_positions(const char *needle, const char *haystack, size_t *positions);
+score_t match(const char *needle, const char *haystack);
+
+#endif

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -1,0 +1,79 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+/*
+ * match.c: functions for custom completion matching
+ */
+
+#include "edit.h"
+#include "match.h"
+#include "fzy/match.h"
+
+/*
+ * Returns true if needle can be found in haystack. Both are null-terminated.
+ */
+bool has_custom_match(const char_u *needle, const char_u *haystack,
+                      bool ignore_case) {
+  (void)ignore_case; // not used in fuzzy matching
+  return has_match((const char *)needle, (const char *)haystack);
+}
+
+typedef struct {
+  compl_T   *cs_compl;
+  score_t   cs_score;
+} compl_score_T;
+
+/* Comparator for compl_score_T based on fuzzy match score. */
+static int compl_score_cmp(const void *l, const void *r) {
+  const compl_score_T *li = (const compl_score_T *)l;
+  const compl_score_T *ri = (const compl_score_T *)r;
+  if (li->cs_score > ri->cs_score)
+    return -1;
+  if (li->cs_score < ri->cs_score)
+    return 1;
+  return 0;
+}
+
+/*
+ * Resort match list based on fuzzy match score. Modifies *first_match to
+ * point to the new list head.
+ */
+void sort_custom_matches(const char_u *pattern, compl_T **first_match) {
+  if (!first_match || !*first_match) {
+    return;
+  }
+  compl_T *compl_first_match = *first_match;
+  const bool cyclic = (compl_first_match->cp_prev != NULL);
+  int num = 0;
+  compl_T *c;
+  for (c = compl_first_match; c != NULL;
+       c = (c->cp_next == compl_first_match) ? NULL : c->cp_next) {
+    ++num;
+  }
+  compl_score_T *compl_score =
+    (compl_score_T *)xcalloc((size_t)num, sizeof(compl_score_T));
+  if (!compl_score) {
+    return;
+  }
+  c = compl_first_match;
+  for (int i = 0; i < num; ++i, c = c->cp_next) {
+    compl_score[i].cs_compl = c;
+    const char *text = (const char *)
+      (c->cp_text[CPT_ABBR] ? c->cp_text[CPT_ABBR] : c->cp_str);
+    compl_score[i].cs_score = match((const char *)pattern, text);
+  }
+  qsort(compl_score, (size_t)num, sizeof(compl_score_T), compl_score_cmp);
+  for (int i = 1; i < num; ++i) {
+    compl_T *prev = compl_score[i - 1].cs_compl;
+    compl_T *cur = compl_score[i].cs_compl;
+    prev->cp_next = cur;
+    cur->cp_prev = prev;
+  }
+  compl_T *first = compl_score[0].cs_compl;
+  compl_T *last = compl_score[num - 1].cs_compl;
+  first->cp_prev = cyclic ? last : NULL;
+  last->cp_next = cyclic ? first : NULL;
+
+  *first_match = compl_score[0].cs_compl;
+  xfree(compl_score);
+}

--- a/src/nvim/match.h
+++ b/src/nvim/match.h
@@ -1,0 +1,8 @@
+#ifndef NVIM_MATCH_H
+#define NVIM_MATCH_H
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "match.h.generated.h"
+#endif
+
+#endif  // NVIM_MATCH_H

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -300,8 +300,9 @@ static char *(p_bs_values[]) =        { "indent", "eol", "start", NULL };
 static char *(p_fdm_values[]) =       { "manual", "expr", "marker", "indent",
                                         "syntax",  "diff", NULL };
 static char *(p_fcl_values[]) =       { "all", NULL };
-static char *(p_cot_values[]) =       { "menu", "menuone", "longest", "preview",
-                                        "noinsert", "noselect", NULL };
+static char *(p_cot_values[]) =       { "menu", "menuone", "longest",
+                                        "preview", "noinsert", "noselect",
+                                        "fuzzy", NULL };
 static char *(p_icm_values[]) =       { "nosplit", "split", NULL };
 static char *(p_scl_values[]) =       { "yes", "no", "auto", NULL };
 


### PR DESCRIPTION
Bring fuzzy matching algorithm from [fzy](https://github.com/jhawthorn/fzy) to completion popup. It can be enabled by `set completeopt+=fuzzy`. Note that the files under `src/nvim/fzy/` dir are copied from `fzy` project with minimal changes intentionally, to make it easier to update them in the future, if needed.