### PR TITLE
[WIP] output digraphs in a buffer

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1811,24 +1811,28 @@ int ml_line_alloced(void)
   return curbuf->b_ml.ml_flags & ML_LINE_DIRTY;
 }
 
-/*
- * Append a line after lnum (may be 0 to insert a line in front of the file).
- * "line" does not need to be allocated, but can't be another line in a
- * buffer, unlocking may make it invalid.
- *
- *   newfile: TRUE when starting to edit a new file, meaning that pe_old_lnum
- *		will be set for recovery
- * Check: The caller of this function should probably also call
- * appended_lines().
- *
- * return FAIL for failure, OK otherwise
- */
-int 
-ml_append (
-    linenr_T lnum,                  /* append after this line (can be 0) */
-    char_u *line,              /* text of the new line */
-    colnr_T len,                    /* length of new line, including NUL, or 0 */
-    int newfile                    /* flag, see above */
+/// Append a line after lnum
+///
+/// @param lnum line after which to append (0 to insert in front of the file).
+/// "line" does not need to be allocated, but can't be another line in a
+/// buffer, unlocking may make it invalid.
+/// @param line text of the new line
+/// @param len length of new line, including NUL, or 0
+/// @param newfile TRUE when starting to edit a new file, meaning that
+/// pe_old_lnum will be set for recovery
+///
+/// @param flags flag, see above
+///
+/// Check: The caller of this function should probably also call
+/// appended_lines().
+///
+/// @return FAIL for failure, OK otherwise
+int
+ml_append(
+    linenr_T lnum,
+    char_u *line,
+    colnr_T len,
+    int newfile
 )
 {
   /* When starting up, we might still need to create the memfile */


### PR DESCRIPTION
I've just started using digraphs (didn't really need it before), and while it's a really cool feature, the pseudo pager drives me mad (this is true for :messages too). 
In the spur of frustration of not being able to search and disabled mappings/Ctrl-F, I wrote this patch just to see have a feel for the complexity.

:digraphs shows a dense view of the mappings which allows to see (too?) many of them in a blink of an eye
```
NU ^@  10    SH ^A   1    SX ^B   2    EX ^C   3    ET ^D   4    EQ ^E   5    AK ^F   6    BL ^G   7    BS ^H   8    HT ^I   9    LF ^@  10    VT ^K  11    FF ^L  12            
CR ^M  13    SO ^N  14    SI ^O  15    DL ^P  16    D1 ^Q  17    D2 ^R  18    D3 ^S  19    D4 ^T  20    NK ^U
```
It's not possible to search in the list of digraphs because of 1/ the pager and 2/ you can't search via the digraph character since you precisely don't have it.

It is possible to search for the description via
:h digraphs table
```
							*digraph-table*
char  digraph	hex	dec	official name ~
^@	NU	0x00	  0	NULL (NUL)
^A	SH	0x01	  1	START OF HEADING (SOH)
^B	SX	0x02	  2	START OF TEXT (STX)
^C	EX	0x03	  3	END OF TEXT (ETX)
^D	ET	0x04	  4	END OF TRANSMISSION (EOT)
^E	EQ	0x05	  5	ENQUIRY (ENQ)
^F	AK	0x06	  6	ACKNOWLEDGE (ACK)
^G	BL	0x07	  7	BELL (BEL)
^H	BS	0x08	  8	BACKSPACE (BS)
^I	HT	0x09	  9	CHARACTER TABULATION (HT)
^@	LF	0x0a	 10	LINE FEED (LF)
^K	VT	0x0b	 11	LINE TABULATION (VT)
```

My patch currently displays                                                                                                                                                               
```
n~ ñ  241                                                                                                                                                                
o` ò  242                                                                                                                                                                
o^ ô  244                                                                                                                                                                
o~ õ  245
```

I wonder if replacing the pager with a buffer is an acceptable solution in this case ? if yes, should we keep the current "dense" representation or output the descriptions in :digraphs too ?
