### PR TITLE
ci/AppVeyor: build MinGW only on master branch

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -20,6 +20,10 @@ function exitIfFailed() {
 }
 
 if ($compiler -eq 'MINGW') {
+  if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $compileOption -ne 'gcov') {
+    exit 0
+  }
+
   if ($bits -eq 32) {
     $arch = 'i686'
   }


### PR DESCRIPTION
Else the build takes too long.