### PR TITLE
add ability to disable languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ if(POLICY CMP0059)
   cmake_policy(SET CMP0059 OLD)  # Needed until cmake 2.8.12. #4389
 endif()
 
+if(POLICY CMP0057)
+  cmake_policy(SET CMP0057 NEW)
+endif()
+
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 

--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -2,35 +2,16 @@ find_package(Gettext)
 find_program(XGETTEXT_PRG xgettext)
 find_program(ICONV_PRG iconv)
 
+set(DEFAULT_LANGUAGES af ca cs de en_GB eo es fi fr ga it ja ko.UTF-8 nl no pl.UTF-8 pt_BR ru sk sv uk vi zh_CN.UTF-8 zh_TW.UTF-8)
+option(LANGUAGES "Localizations to build")
+if(NOT LANGUAGES)
+  set(LANGUAGES "${DEFAULT_LANGUAGES}")
+endif()
+
 if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
   set(ENV{OLD_PO_FILE_INPUT} yes)
   set(ENV{OLD_PO_FILE_OUTPUT} yes)
 
-  set(LANGUAGES
-    af
-    ca
-    cs
-    de
-    en_GB
-    eo
-    es
-    fi
-    fr
-    ga
-    it
-    ja
-    ko.UTF-8
-    nl
-    no
-    pl.UTF-8
-    pt_BR
-    ru
-    sk
-    sv
-    uk
-    vi
-    zh_CN.UTF-8
-    zh_TW.UTF-8)
 
   set(NVIM_RELATIVE_SOURCES)
   foreach(SRC ${NVIM_SOURCES} ${NVIM_HEADERS})
@@ -135,22 +116,30 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
   endmacro()
 
   # Create some translations from others.
-  BuildPoIconv(ja utf-8 euc-jp)
-  BuildMo(ja.euc-jp)
+  if("ja" IN_LIST LANGUAGES)
+    BuildPoIconv(ja utf-8 euc-jp)
+    BuildMo(ja.euc-jp)
+  endif()
 
-  BuildPoIconv(cs ISO-8859-2 cp1250)
-  BuildMo(cs.cp1250)
+  if("cs" IN_LIST LANGUAGES)
+    BuildPoIconv(cs ISO-8859-2 cp1250)
+    BuildMo(cs.cp1250)
+  endif()
 
-  BuildPoIconv(sk ISO-8859-2 cp1250)
-  BuildMo(sk.cp1250)
+  if("sk" IN_LIST LANGUAGES)
+    BuildPoIconv(sk ISO-8859-2 cp1250)
+    BuildMo(sk.cp1250)
+  endif()
 
   add_custom_target(update-po-nb
     COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_CURRENT_SOURCE_DIR}/no.po ${CMAKE_CURRENT_SOURCE_DIR}/nb.po
     DEPENDS no.po)
   list(APPEND UPDATE_PO_TARGETS update-po-nb)
-  CheckPo(nb)
-  BuildMo(nb)
+  if("nb" IN_LIST LANGUAGES)
+    CheckPo(nb)
+    BuildMo(nb)
+  endif()
 
   foreach(LANGUAGE ${LANGUAGES})
     set(poFile "${CMAKE_CURRENT_SOURCE_DIR}/${LANGUAGE}.po")


### PR DESCRIPTION
By default this should not change any behaviour in building, as not setting -DLANGUAGES
will build them all. However, not every person or every distro wants to build/install every l10n
localization type possible.

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>