### PR TITLE
[wip] Add support for setting filetype/syntax to bash directly

### DIFF
--- a/runtime/ftplugin/bash.vim
+++ b/runtime/ftplugin/bash.vim
@@ -1,0 +1,19 @@
+" Vim filetype plugin file
+" Language: bash
+" Maintainer: Mahmoud Al-Qudsi <mqudsi@neosmart.net>
+" Last Changed: 1 March 2018
+
+" let b:is_bash=1
+" runtime! ftplugin/sh.vim
+" runtime! ftplugin/sh_*.vim ftplugin/sh/*.vim
+"
+if exists("b:did_ftplugin_bash") | finish | endif
+
+let b:is_bash=1
+runtime! ftplugin/sh.vim
+runtime! ftplugin/sh_*.vim ftplugin/sh/*.vim
+
+autocmd FileType bash set filetype=sh
+autocmd Syntax bash set syntax=sh
+
+let b:did_ft_plugin_bash=1

--- a/runtime/syntax/bash.vim
+++ b/runtime/syntax/bash.vim
@@ -1,0 +1,18 @@
+" Vim syntax plugin file
+" Language: bash
+" Maintainer: Mahmoud Al-Qudsi <mqudsi@neosmart.net>
+" Last Changed: 1 March 2018
+
+" if &compatible || v:version < 603
+" 	finish
+" endif
+"
+" if exists("b:current_syntax") | finish | endif
+"
+" syn case match
+"
+" let b:is_bash = 1
+" unlet! b:current_syntax
+" syn include @shTop syntax/sh.vim
+"
+" let b:current_syntax="sh"


### PR DESCRIPTION
Currently, there is no language/filetype/syntax called "bash", it's the
sh syntax/filetype with a buffer-local variable `b:is_bash` that
determines whether or not bash-specific features are enabled when
processing the script.

The problem is that a) `set [ft|syntax]=bash` does not work, and more
importantly, b) as a result, it is not possible to set the filetype to
bash via a modeline, as `#vim: let b:is_bash=1` isn't legal.

This patch will let `set ft=bash` or `set syntax=bash` act as if
`let b:is_bash=1` were defined and then `set ft=sh` or `set syntax=sh`
was called, i.e.:

    set ft=bash
    let b:is_bash "returns 1
    echo &ft "returns sh