### PR TITLE
repeatbusy() (detects execution of dot-repeat)

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -13530,6 +13530,14 @@ static void f_repeat(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 }
 
 /*
+ * "repeatbusy()" function
+ */
+static void f_repeatbusy(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  rettv->vval.v_number = repeat_busy;
+}
+
+/*
  * "resolve()" function
  */
 static void f_resolve(typval_T *argvars, typval_T *rettv, FunPtr fptr)

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -236,6 +236,7 @@ return {
     remove={args={2, 3}},
     rename={args=2},
     ['repeat']={args=2},
+    repeatbusy={},
     resolve={args=1},
     reverse={args=1},
     round={args=1, func="float_op_wrapper", data="&round"},

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -739,6 +739,9 @@ int start_redo(long count, bool old_redo)
     return FAIL;
   }
 
+  // mark the beginning of the repeat sequence
+  add_char_buff(&readbuf2, K_REPEAT_BEGIN);
+
   c = read_redo(false, old_redo);
 
   /* copy the buffer name, if present */
@@ -780,6 +783,9 @@ int start_redo(long count, bool old_redo)
   /* copy from the redo buffer into the stuff buffer */
   add_char_buff(&readbuf2, c);
   copy_redo(old_redo);
+
+  // mark the end of the repeat sequence
+  add_char_buff(&readbuf2, K_REPEAT_END);
   return OK;
 }
 
@@ -1510,6 +1516,18 @@ int vgetc(void)
    * avoid internally used Lists and Dicts to be freed.
    */
   may_garbage_collect = FALSE;
+
+  // beginning / end of the repeat sequence
+  // since K_REPEAT_BEGIN/END are just for marking the repeat sequence,
+  // they don't have any effects and thus they are replaced with K_NOP.
+  if (c == K_REPEAT_BEGIN) {
+    repeat_busy = 1;
+    c = K_NOP;
+  }
+  if (c == K_REPEAT_END) {
+    repeat_busy = 0;
+    c = K_NOP;
+  }
 
   return c;
 }

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -244,6 +244,8 @@ EXTERN int quit_more INIT(= false);         // 'q' hit at "--more--" msg
 EXTERN int ex_keep_indent INIT(= false);    // getexmodeline(): keep indent
 EXTERN int vgetc_busy INIT(= 0);            // when inside vgetc() then > 0
 
+EXTERN int repeat_busy INIT(= 0);           // when executing a repeat sequence then == 1
+
 EXTERN int didset_vim INIT(= FALSE);        /* did set $VIM ourselves */
 EXTERN int didset_vimruntime INIT(= FALSE);        /* idem for $VIMRUNTIME */
 

--- a/src/nvim/keymap.h
+++ b/src/nvim/keymap.h
@@ -87,6 +87,10 @@
 /* Used for menu in a tab pages line. */
 #define KS_TABMENU              239
 
+/* Used as marks indicating the beginning and the end of a repeat sequence. */
+#define KS_REPEAT_BEGIN         238
+#define KS_REPEAT_END           237
+
 /*
  * Filler used after KS_SPECIAL and others
  */
@@ -403,6 +407,9 @@ enum key_extra {
 
 #define K_TABLINE       TERMCAP2KEY(KS_TABLINE, KE_FILLER)
 #define K_TABMENU       TERMCAP2KEY(KS_TABMENU, KE_FILLER)
+
+#define K_REPEAT_BEGIN  TERMCAP2KEY(KS_REPEAT_BEGIN, KE_FILLER)
+#define K_REPEAT_END    TERMCAP2KEY(KS_REPEAT_END, KE_FILLER)
 
 /*
  * Symbols for pseudo keys which are translated from the real key symbols

--- a/test/functional/normal/dot_spec.lua
+++ b/test/functional/normal/dot_spec.lua
@@ -1,0 +1,24 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local command = helpers.command
+local expect = helpers.expect
+local eq = helpers.eq
+local eval = helpers.eval
+local feed = helpers.feed
+
+describe('.', function()
+  before_each(clear)
+
+  it('toggle repeatbusy flag during repeat sequence execution.', function()
+    command('autocmd InsertEnter * let g:test = repeatbusy()')
+
+    feed('afoo<esc>')
+    expect('foo')
+    eq(0, eval('g:test'))
+
+    feed('.')
+    expect('foofoo')
+    eq(1, eval('g:test'))
+  end)
+end)


### PR DESCRIPTION
This PR supercedes #8177 

[Edit 2019.Apr.4; See comment below]
~~`feedkeys(keys, 's')` will not insert the `keys` into the typebuf
when '.' repeat sequence is being executed (`repeatbusy == 1`)~~

cc @justinmk @brammool