### PR TITLE
Add complete support for OpenBSD

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -359,6 +359,10 @@ endforeach()
 
 # Our dependencies come first.
 
+if (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+  list(APPEND NVIM_LINK_LIBRARIES pthread c++abi)
+endif()
+
 if (LibIntl_FOUND)
   list(APPEND NVIM_LINK_LIBRARIES ${LibIntl_LIBRARY})
 endif()

--- a/src/nvim/os/process.c
+++ b/src/nvim/os/process.c
@@ -18,7 +18,7 @@
 # include <sys/user.h>
 #endif
 
-#if defined(__NetBSD__)
+#if defined(__NetBSD__) || defined(__OpenBSD__)
 # include <sys/param.h>
 #endif
 

--- a/third-party/cmake/BuildLuajit.cmake
+++ b/third-party/cmake/BuildLuajit.cmake
@@ -35,10 +35,16 @@ function(BuildLuajit)
     INSTALL_COMMAND "${_luajit_INSTALL_COMMAND}")
 endfunction()
 
+if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+  set(AMD64_ABI "LDFLAGS=-lpthread -lc++abi")
+else()
+  set(AMD64_ABI "")
+endif()
 set(INSTALLCMD_UNIX ${MAKE_PRG} CFLAGS=-fPIC
                                 CFLAGS+=-DLUAJIT_DISABLE_JIT
                                 CFLAGS+=-DLUA_USE_APICHECK
                                 CFLAGS+=-DLUA_USE_ASSERT
+                                ${AMD64_ABI}
                                 CCDEBUG+=-g
                                 Q=
                                 install)


### PR DESCRIPTION
The default compiler (clang) requires linking with c++abi and pthread.

<strike>I tried linking with them, but was unable to do so (not very experienced with `gmake` or `cmake`, I tried adding them to LDLIBS and also tried using target_link_libraries()). If you want to compile with clang, then you need to add `-lpthread -lc++abi`. These libraries contain the symbols for `_Unwind_*`.</strike>