### PR TITLE
[RFC] vim-patch:8.0.0438

### DIFF
--- a/test/functional/legacy/fnamemodify_spec.lua
+++ b/test/functional/legacy/fnamemodify_spec.lua
@@ -22,6 +22,8 @@ describe('filename modifiers', function()
         let tmpdir = resolve($TMPDIR)
         call assert_true(isdirectory(tmpdir))
         execute 'cd '. tmpdir
+        let save_home = $HOME
+        let save_shell = &shell
         let $HOME=fnamemodify('.', ':p:h:h:h')
         call assert_equal('/', fnamemodify('.', ':p')[-1:])
         call assert_equal(tmpdir[strchars(tmpdir) - 1], fnamemodify('.', ':p:h')[-1:])
@@ -59,6 +61,9 @@ describe('filename modifiers', function()
           set shell=tcsh
           call assert_equal("'abc\\\ndef'", fnamemodify("abc\ndef", ':S'))
         endif
+
+        let $HOME = save_home
+        let &shell = save_shell
       endfunc
 
       func Test_expand()


### PR DESCRIPTION
#### vim-patch:8.0.0438: the fnamemodify test may cause later tests to fail

Problem:    The fnamemodify test changes 'shell' in a way later tests may not
            be able to use system().
Solution:   Save and restore 'shell'.
https://github.com/vim/vim/commit/056f700031602a2734b1ddf45f6bc2817e49b996