### PR TITLE
[RFC] Fix type conversion warnings

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -924,7 +924,6 @@ static void tui_set_mode(UI *ui, ModeShape mode)
   }
   TUIData *data = ui->data;
   cursorentry_T c = data->cursor_shapes[mode];
-  int shape = c.shape;
 
   if (c.id != 0 && ui->rgb) {
     int attr = syn_id2attr(c.id);
@@ -935,7 +934,8 @@ static void tui_set_mode(UI *ui, ModeShape mode)
     }
   }
 
-  switch (shape) {
+  int shape;
+  switch (c.shape) {
     case SHAPE_BLOCK: shape = 1; break;
     case SHAPE_HOR:   shape = 3; break;
     case SHAPE_VER:   shape = 5; break;

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -779,7 +779,8 @@ const char *viml_pexpr_repr_token(const ParserState *const pstate,
             eltkn_opt_scope_tab[token.data.opt.scope],
             (int)token.data.opt.len, token.data.opt.name)
     TKNARGS(kExprLexPlainIdentifier, "(scope=%s,autoload=%i)",
-            intchar2str(token.data.var.scope), (int)token.data.var.autoload)
+            intchar2str((int)token.data.var.scope),
+            (int)token.data.var.autoload)
     TKNARGS(kExprLexNumber, "(is_float=%i,base=%i,val=%lg)",
             (int)token.data.num.is_float,
             (int)token.data.num.base,


### PR DESCRIPTION
In both cases we implicitly converted an (unsigned) enum to an int.

Reported by clang 6.0.0.