### PR TITLE
Added goheadless ex_command

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1241,6 +1241,7 @@ tag	      command	      action ~
 |:function|	:fu[nction]	define a user function
 |:global|	:g[lobal]	execute commands for matching lines
 |:goto|		:go[to]		go to byte in the buffer
+|:goheadless|	:goh[eadless]	Detach UI and run in headless mode
 |:grep|		:gr[ep]		run 'grepprg' and jump to first match
 |:grepadd|	:grepa[dd]	like :grep, but append to current list
 |:gui|		:gu[i]		start the GUI

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1015,6 +1015,12 @@ return {
     func='ex_global',
   },
   {
+    command='goheadless',
+    flags=bit.bor(BANG),
+    addr_type=ADDR_LINES,
+    func='ex_goheadless',
+  },
+  {
     command='goto',
     flags=bit.bor(RANGE, NOTADR, COUNT, TRLBAR, SBOXOK, CMDWIN),
     addr_type=ADDR_LINES,

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5937,9 +5937,7 @@ void not_exiting(void)
 }
 
 
-/*
- * Detach TUI and run running instance of neovim in headless mode. #6871
- */
+// Detach TUI and run running instance of neovim in headless mode. #6871
 static void ex_goheadless(void)
 {
   ui_builtin_stop();

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5936,6 +5936,15 @@ void not_exiting(void)
   exiting = FALSE;
 }
 
+
+/*
+ * Detach TUI and run running instance of neovim in headless mode. #6871
+ */
+static void ex_goheadless(void)
+{
+  ui_builtin_stop();
+}
+
 /*
  * ":quit": quit current window, quit Vim if the last window is closed.
  */


### PR DESCRIPTION
Attempt for #6871 , 
added and ex_cmd `go_headless` which just calls `ui_builtin_stop` so that nvim keeps running as if it were started in headless mode.