### PR TITLE
[RDY] Execute only first command in Live preview mode

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -603,6 +603,12 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
                               cmd_getline, cmd_cookie);
     recursive--;
 
+    // If in preview mode then only the first command separated
+    // '|' should be executed.
+    if (State & CMDPREVIEW) {
+      next_cmdline = NULL;
+    }
+
     if (cmd_cookie == (void *)&cmd_loop_cookie)
       /* Use "current_line" from "cmd_loop_cookie", it may have been
        * incremented when defining a function. */

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -1354,6 +1354,23 @@ describe("inccommand=nosplit", function()
       :echo 'foo'^         |
     ]])
   end)
+
+  it("only executes the first command in preview", function()
+    feed(':%s/two/three/g|q!')
+    screen:expect([[
+      Inc substitution on |
+      {12:three} lines         |
+      Inc substitution on |
+      {12:three} lines         |
+                          |
+      {15:~                   }|
+      {15:~                   }|
+      {15:~                   }|
+      {15:~                   }|
+      :%s/two/three/g|q!^  |
+    ]])
+    eq(eval('v:null'), eval('v:exiting')) 
+  end)
 end)
 
 describe(":substitute, 'inccommand' with a failing expression", function()


### PR DESCRIPTION
Previously, if we have set the `inccommand`, i.e. we are executing in the preview mode, then whole of the command would execute, it was not good as the command like `:%s/hello/bye/g | q!` would be a nuisance, this would quit as in preview whole of the command executes as there is a change in the cmdline text, so to handle it, execution of only the first command is necessary.

Closes #7494 