### PR TITLE
tui: abort on an incorrect shape instead of defaulting to the block shape

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -937,7 +937,7 @@ static void tui_set_mode(UI *ui, ModeShape mode)
 
   int shape;
   switch (c.shape) {
-    default:
+    default:          abort(); break;
     case SHAPE_BLOCK: shape = 1; break;
     case SHAPE_HOR:   shape = 3; break;
     case SHAPE_VER:   shape = 5; break;


### PR DESCRIPTION
We've been discussing the merits of aborting vs not in #8261.  While I don't personally like aborting, this doesn't really add any additional problems as we're aborting in a number of other places already.