### PR TITLE
job-control: avoid kill race

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5033,10 +5033,9 @@ jobstart({cmd}[, {opts}])				*jobstart()*
 		  width    : (pty only) Width of the terminal screen
 		  height   : (pty only) Height of the terminal screen
 		  TERM     : (pty only) $TERM environment variable
-		  detach   : (non-pty only) Detach the job process from the
-			     nvim process. The process will not get killed
-			     when nvim exits. If the process dies before
-			     nvim exits, "on_exit" will still be invoked.
+		  detach   : (non-pty only) Detach the job process: it will
+			     not be killed when Nvim exits. If the process
+			     exits before Nvim, "on_exit" will be invoked.
 
 		{opts} is passed as |self| dictionary to the callback; the
 		caller may set other keys to pass application-specific data.

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -658,9 +658,9 @@ static void channel_process_exit_cb(Process *proc, int status, void *data)
     terminal_close(chan->term, msg);
   }
 
-  // if status is -1 the process did not really exit,
-  // we just closed the handle onto a detached process
-  if (status >= 0) {
+  // If process did not exit, we only closed the handle of a detached process.
+  bool exited = (status >= 0);
+  if (exited) {
     process_channel_event(chan, &chan->on_exit, "exit", NULL, 0, status);
   }
 

--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -21,7 +21,6 @@ void loop_init(Loop *loop, void *data)
   loop->recursive = 0;
   loop->uv.data = loop;
   loop->children = kl_init(WatcherPtr);
-  loop->children_stop_requests = 0;
   loop->events = multiqueue_new_parent(loop_on_put, loop);
   loop->fast_events = multiqueue_new_child(loop->events);
   loop->thread_events = multiqueue_new_parent(NULL, NULL);

--- a/src/nvim/event/loop.h
+++ b/src/nvim/event/loop.h
@@ -37,7 +37,6 @@ typedef struct loop {
   // generic timer, used by loop_poll_events()
   uv_timer_t poll_timer;
 
-  size_t children_stop_requests;
   uv_async_t async;
   uv_mutex_t mutex;
   int recursive;

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -228,13 +228,10 @@ void process_stop(Process *proc) FUNC_ATTR_NONNULL_ALL
   }
 
   Loop *loop = proc->loop;
-  if (!loop->children_stop_requests++) {
-    // When there's at least one stop request pending, start a timer that
-    // will periodically check if a signal should be send to the job.
-    ILOG("starting job kill timer");
-    uv_timer_start(&loop->children_kill_timer, children_kill_cb,
-                   KILL_TIMEOUT_MS, KILL_TIMEOUT_MS);
-  }
+  // Start a timer to periodically check if a signal should be send to the job.
+  ILOG("starting job kill timer");
+  uv_timer_start(&loop->children_kill_timer, children_kill_cb,
+                 KILL_TIMEOUT_MS, KILL_TIMEOUT_MS);
 }
 
 /// Iterates the process list sending SIGTERM to stopped processes and SIGKILL
@@ -383,10 +380,8 @@ static void process_close_handles(void **argv)
 static void on_process_exit(Process *proc)
 {
   Loop *loop = proc->loop;
-  if (proc->stopped_time && loop->children_stop_requests
-      && !--loop->children_stop_requests) {
-    // Stop the timer if no more stop requests are pending
-    DLOG("Stopping process kill timer");
+  if (proc->stopped_time) {
+    DLOG("stopping process kill timer");
     uv_timer_stop(&loop->children_kill_timer);
   }
 

--- a/src/nvim/event/process.h
+++ b/src/nvim/event/process.h
@@ -19,8 +19,7 @@ struct process {
   Loop *loop;
   void *data;
   int pid, status, refcount;
-  // set to the hrtime of when process_stop was called for the process.
-  uint64_t stopped_time;
+  uint64_t stopped_time;  // process_stop() timestamp
   const char *cwd;
   char **argv;
   Stream in, out, err;

--- a/test/functional/autocmd/termclose_spec.lua
+++ b/test/functional/autocmd/termclose_spec.lua
@@ -32,7 +32,7 @@ describe('TermClose event', function()
   end)
 
   it('kills job trapping SIGTERM', function()
-    if helpers.pending_win32(pending) then return end
+    if iswin() then return end
     nvim('set_option', 'shell', 'sh')
     nvim('set_option', 'shellcmdflag', '-c')
     command([[ let g:test_job = jobstart('trap "" TERM && echo 1 && sleep 60', { ]]
@@ -51,8 +51,8 @@ describe('TermClose event', function()
     ok(duration <= 4000)  -- Epsilon for slow CI
   end)
 
-  it('kills pty job trapping SIGHUP and SIGTERM', function()
-    if helpers.pending_win32(pending) then return end
+  it('kills PTY job trapping SIGHUP and SIGTERM', function()
+    if iswin() then return end
     nvim('set_option', 'shell', 'sh')
     nvim('set_option', 'shellcmdflag', '-c')
     command([[ let g:test_job = jobstart('trap "" HUP TERM && echo 1 && sleep 60', { ]]


### PR DESCRIPTION
see https://github.com/neovim/neovim/issues/8269

@oni-link @bfredl @jamessan @blueyed  sanity-check appreciated.

children_kill_cb() is racey. One obvious problem is that process_close_handles() is *queued* by on_process_exit(), so when children_kill_cb() is invoked, the dead process might still be in the
`loop->children` list.  If the OS already reclaimed the dead PID, Nvim may try to SIGKILL it.

Avoid that by checking `proc->status`.

Vim doesn't have this problem because it doesn't attempt to kill processes that ignored SIGTERM after a timeout. (Future note: maybe we should not attempt this, too ...)