### PR TITLE
VimSuspend, VimResume

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -294,6 +294,8 @@ Name			triggered by ~
 |SourceCmd|		before sourcing a Vim script |Cmd-event|
 
 |VimResized|		after the Vim window size changed
+|VimResumed|		after Vim is resumed
+|VimSuspendPre|		before Vim is suspended
 |FocusGained|		Vim got input focus
 |FocusLost|		Vim lost input focus
 |CursorHold|		the user doesn't press a key for a while
@@ -1009,6 +1011,10 @@ VimLeavePre			Before exiting Vim, just before writing the
 VimResized			After the Vim window was resized, thus 'lines'
 				and/or 'columns' changed.  Not when starting
 				up though.
+							*VimResumed*
+VimResumed			After nvim is resumed from a suspended state
+							*VimSuspendPre*
+VimSuspendPre			Before nvim is sent off to suspended state
 							*WinEnter*
 WinEnter			After entering another window.  Not done for
 				the first window, when Vim has just started.

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -294,8 +294,8 @@ Name			triggered by ~
 |SourceCmd|		before sourcing a Vim script |Cmd-event|
 
 |VimResized|		after the Vim window size changed
-|VimResumed|		after Vim is resumed
-|VimSuspendPre|		before Vim is suspended
+|VimResume|		after nvim is resumed
+|VimSuspend|		before nvim is suspended
 |FocusGained|		Vim got input focus
 |FocusLost|		Vim lost input focus
 |CursorHold|		the user doesn't press a key for a while
@@ -1011,10 +1011,10 @@ VimLeavePre			Before exiting Vim, just before writing the
 VimResized			After the Vim window was resized, thus 'lines'
 				and/or 'columns' changed.  Not when starting
 				up though.
-							*VimResumed*
-VimResumed			After nvim is resumed from a suspended state
-							*VimSuspendPre*
-VimSuspendPre			Before nvim is sent off to suspended state
+							*VimResume*
+VimResume			After nvim is resumed from a suspended state
+							*VimSuspend*
+VimSuspend			Before nvim is sent off to suspended state
 							*WinEnter*
 WinEnter			After entering another window.  Not done for
 				the first window, when Vim has just started.

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -294,8 +294,8 @@ Name			triggered by ~
 |SourceCmd|		before sourcing a Vim script |Cmd-event|
 
 |VimResized|		after the Vim window size changed
-|VimResume|		after nvim is resumed
-|VimSuspend|		before nvim is suspended
+|VimResume|		after Nvim is resumed
+|VimSuspend|		before Nvim is suspended
 |FocusGained|		Vim got input focus
 |FocusLost|		Vim lost input focus
 |CursorHold|		the user doesn't press a key for a while
@@ -1012,9 +1012,9 @@ VimResized			After the Vim window was resized, thus 'lines'
 				and/or 'columns' changed.  Not when starting
 				up though.
 							*VimResume*
-VimResume			After nvim is resumed from a suspended state
+VimResume			After Nvim is resumed from a suspended state
 							*VimSuspend*
-VimSuspend			Before nvim is sent off to suspended state
+VimSuspend			Before Nvim is sent off to suspended state
 							*WinEnter*
 WinEnter			After entering another window.  Not done for
 				the first window, when Vim has just started.

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -92,8 +92,8 @@ return {
     'VimLeave',               -- before exiting Vim
     'VimLeavePre',            -- before exiting Vim and writing ShaDa file
     'VimResized',             -- after Vim window was resized
-    'VimResumed',             -- after Vim is resumed
-    'VimSuspendPre',          -- before Vim is suspended
+    'VimResume',              -- after Vim is resumed
+    'VimSuspend',             -- before Vim is suspended
     'WinNew',                 -- when entering a new window
     'WinEnter',               -- after entering a window
     'WinLeave',               -- before leaving a window

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -92,8 +92,8 @@ return {
     'VimLeave',               -- before exiting Vim
     'VimLeavePre',            -- before exiting Vim and writing ShaDa file
     'VimResized',             -- after Vim window was resized
-    'VimResume',              -- after Vim is resumed
-    'VimSuspend',             -- before Vim is suspended
+    'VimResume',              -- after Nvim is resumed
+    'VimSuspend',             -- before Nvim is suspended
     'WinNew',                 -- when entering a new window
     'WinEnter',               -- after entering a window
     'WinLeave',               -- before leaving a window

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -92,6 +92,8 @@ return {
     'VimLeave',               -- before exiting Vim
     'VimLeavePre',            -- before exiting Vim and writing ShaDa file
     'VimResized',             -- after Vim window was resized
+    'VimResumed',             -- after Vim is resumed
+    'VimSuspendPre',          -- before Vim is suspended
     'WinNew',                 -- when entering a new window
     'WinEnter',               -- after entering a window
     'WinLeave',               -- before leaving a window

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6305,6 +6305,7 @@ static void ex_stop(exarg_T *eap)
     ui_linefeed();
     ui_flush();
     ui_call_suspend();  // call machine specific function
+
     ui_flush();
     maketitle();
     resettitle();  // force updating the title

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6300,7 +6300,7 @@ static void ex_stop(exarg_T *eap)
     if (!eap->forceit) {
       autowrite_all();
     }
-    apply_autocmds(EVENT_VIMSUSPENDPRE, NULL, NULL, FALSE, NULL);
+    apply_autocmds(EVENT_VIMSUSPEND, NULL, NULL, FALSE, NULL);
     ui_cursor_goto((int)Rows - 1, 0);
     ui_linefeed();
     ui_flush();
@@ -6311,7 +6311,7 @@ static void ex_stop(exarg_T *eap)
     resettitle();  // force updating the title
     redraw_later_clear();
     ui_refresh();  // may have resized window
-    apply_autocmds(EVENT_VIMRESUMED, NULL, NULL, FALSE, NULL);
+    apply_autocmds(EVENT_VIMRESUME, NULL, NULL, FALSE, NULL);
   }
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6300,6 +6300,7 @@ static void ex_stop(exarg_T *eap)
     if (!eap->forceit) {
       autowrite_all();
     }
+    apply_autocmds(EVENT_VIMSUSPENDPRE, NULL, NULL, FALSE, NULL);
     ui_cursor_goto((int)Rows - 1, 0);
     ui_linefeed();
     ui_flush();
@@ -6309,6 +6310,7 @@ static void ex_stop(exarg_T *eap)
     resettitle();  // force updating the title
     redraw_later_clear();
     ui_refresh();  // may have resized window
+    apply_autocmds(EVENT_VIMRESUMED, NULL, NULL, FALSE, NULL);
   }
 }
 

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -79,8 +79,8 @@ describe('Screen', function()
 
       -- when we use eval in the test, nvim instance is already foregrounded
       -- after being suspended, therefore both events are triggered here.
-      command('autocmd VimSuspendPre  * :let g:foo=42')
-      command('autocmd VimResumed  * :let g:bar=24')
+      command('autocmd VimSuspend  * :let g:foo=42')
+      command('autocmd VimResume  * :let g:bar=24')
 
       command('suspend')
       eq(42, eval('g:foo'))

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -4,6 +4,7 @@ local spawn, set_session, clear = helpers.spawn, helpers.set_session, helpers.cl
 local feed, command = helpers.feed, helpers.command
 local insert = helpers.insert
 local eq = helpers.eq
+local eval = helpers.eval
 local iswin = helpers.iswin
 
 describe('screen', function()
@@ -75,9 +76,19 @@ describe('Screen', function()
       local function check()
         eq(true, screen.suspended)
       end
+
+      -- when we use eval in the test, nvim instance is already foregrounded
+      -- after being suspended, therefore both events are triggered here.
+      command('autocmd VimSuspendPre  * :let g:foo=42')
+      command('autocmd VimResumed  * :let g:bar=24')
+
       command('suspend')
+      eq(42, eval('g:foo'))
+      eq(24, eval('g:bar'))
+
       screen:expect(check)
       screen.suspended = false
+
       feed('<c-z>')
       screen:expect(check)
     end)

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -77,20 +77,25 @@ describe('Screen', function()
         eq(true, screen.suspended)
       end
 
-      -- when we use eval in the test, nvim instance is already foregrounded
-      -- after being suspended, therefore both events are triggered here.
-      command('autocmd VimSuspend  * :let g:foo=42')
-      command('autocmd VimResume  * :let g:bar=24')
+      -- using eval after suspending, resumes nvim.
+      -- hence both events trigger one after another
+      command('autocmd VimSuspend  * :let g:suspend=1+get(g:, "suspend", 0)') -- increment by 1
+      command('autocmd VimResume  * :let g:suspend=get(g:, "suspend", 0)-2') -- decrement by 2
 
       command('suspend')
-      eq(42, eval('g:foo'))
-      eq(24, eval('g:bar'))
+      eq(-1, eval('g:suspend'))
 
       screen:expect(check)
       screen.suspended = false
 
       feed('<c-z>')
+      eq(-2, eval('g:suspend'))
+
       screen:expect(check)
+      screen.suspended = false
+
+      command('suspend')
+      eq(-3, eval('g:suspend'))
     end)
   end)
 

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -79,23 +79,26 @@ describe('Screen', function()
 
       -- using eval after suspending, resumes nvim.
       -- hence both events trigger one after another
-      command('autocmd VimSuspend  * :let g:suspend=1+get(g:, "suspend", 0)') -- increment by 1
-      command('autocmd VimResume  * :let g:suspend=get(g:, "suspend", 0)-2') -- decrement by 2
+      command('autocmd VimSuspend  * :let g:suspend=1+get(g:, "suspend", 0)')
+      command('autocmd VimResume  * :let g:resume=1+get(g:, "resume", 0)')
 
       command('suspend')
-      eq(-1, eval('g:suspend'))
+      eq(1, eval('g:suspend'))
+      eq(1, eval('g:resume'))
 
       screen:expect(check)
       screen.suspended = false
 
       feed('<c-z>')
-      eq(-2, eval('g:suspend'))
+      eq(2, eval('g:suspend'))
+      eq(2, eval('g:resume'))
 
       screen:expect(check)
       screen.suspended = false
 
       command('suspend')
-      eq(-3, eval('g:suspend'))
+      eq(3, eval('g:suspend'))
+      eq(3, eval('g:resume'))
     end)
   end)
 


### PR DESCRIPTION
Closes #3648

This is the continuation of @DarkDeepBlue 's work on #5959 

I just did some name modifications which I think are more appropriate to the events, added the tests.

Note about the test:
After `:suspend` or `<C-Z>` , I don't know how to get it back to foreground. But using `eval` after the `suspend` command seems to get it to the foreground, so that works.

I've commented the same in the test.

Please let me know of changes to make, I hope @DarkDeepBlue won't mind :smile: