### PR TITLE
inccommand: fix for wrapping of large string in preview mode

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -568,14 +568,19 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
        * from a script or when being called recursive (e.g. for ":e
        * +command file").
        */
-      if (!(flags & DOCMD_NOWAIT) && !recursive) {
+      bool is_preview = !!(State & CMDPREVIEW);
+      if (!((flags & DOCMD_NOWAIT) || recursive) || is_preview) {
         msg_didout_before_start = msg_didout;
-        msg_didany = FALSE;         /* no output yet */
+        msg_didany = false;         // no output yet
         msg_start();
-        msg_scroll = TRUE;          /* put messages below each other */
-        ++no_wait_return;           /* don't wait for return until finished */
-        ++RedrawingDisabled;
-        did_inc = TRUE;
+        msg_scroll = true;          // put messages below each other
+        if (!is_preview) {
+          // For execution of a preview command we have to wait for a return
+          // key, but we don't want the message for it pop out
+          no_wait_return++;           // wait for return until finished
+        }
+        RedrawingDisabled++;
+        did_inc = true;
       }
     }
 

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -1217,6 +1217,24 @@ describe("inccommand=nosplit", function()
     ]])
   end)
 
+  it("don't wrap the text in cmdline in inccommand", function()
+    feed([[ggdG]])
+    insert('hello\nhello')
+    feed(':%s/hello/hellooooooooooooooooooooooooooooooo')
+    screen:expect([[
+      {12:helloooooooooooooooo}|
+      {12:ooooooooooooooo}     |
+      {15:~                   }|
+      {15:~                   }|
+      {15:~                   }|
+      {15:~                   }|
+      {15:~                   }|
+      :%s/hello/helloooooo|
+      oooooooooooooooooooo|
+      ooooo^               |
+    ]])
+  end)
+
   it("shows preview when cmd modifiers are present", function()
     -- one modifier
     feed(':keeppatterns %s/tw/to')


### PR DESCRIPTION
When entering a large string in substitute command when `set inccommand=nosplit` is enabled, the string wraps around the single line. This was due to the condition that in Preview mode, we need a kind of behaviour where the DOCMD_NOWAIT is not completely necessary because there is change in the size of the cmdlilne, but we don't need to wait for the return, so ++no_wait_return was not necessary.