### PR TITLE
[RFC] ui_events: correct wrong argument order in resize event

### DIFF
--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -10,7 +10,7 @@
 #include "nvim/func_attr.h"
 #include "nvim/ui.h"
 
-void resize(Integer rows, Integer columns)
+void resize(Integer width, Integer height)
   FUNC_API_SINCE(3);
 void clear(void)
   FUNC_API_SINCE(3);


### PR DESCRIPTION
Seems everything else uses the same (width, height) order, including `ui.txt` documented order, so simplest just to change this.