### PR TITLE
test/util: throttle retry()

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -309,6 +309,7 @@ local function retry(max, max_ms, fn)
       error("\nretry() attempts: "..tostring(tries).."\n"..tostring(result))
     end
     tries = tries + 1
+    luv.sleep(20)  -- Avoid hot loop...
   end
 end
 
@@ -467,14 +468,7 @@ end
 
 -- sleeps the test runner (_not_ the nvim instance)
 local function sleep(ms)
-  local function notification_cb(method, _)
-    if method == "redraw" then
-      error("Screen is attached; use screen:sleep() instead.")
-    end
-    return true
-  end
-
-  run(nil, notification_cb, nil, ms)
+  luv.sleep(ms)
 end
 
 local function curbuf_contents()


### PR DESCRIPTION
Avoid a hot loop in retry(), there's no need to retry more than 50/s.

Also use luv.sleep() to implement sleep() instead of spinning the
event-loop, so events are not silently discarded.

---

QB failure (not caused by this PR, obviously) looks legitimate:

```
05:05:00,790 INFO  - not ok 389 - jobs jobwait will run callbacks while waiting
05:05:00,790 INFO  - # test/functional/core/job_spec.lua @ 521
05:05:00,790 INFO  - # Failure message: test/functional/core/job_spec.lua:544: Expected objects to be the same.
05:05:00,790 INFO  - # Passed in:
05:05:00,790 INFO  - # (table) {
05:05:00,790 INFO  - #   [1] = 'notification'
05:05:00,790 INFO  - #   [2] = 'wait'
05:05:00,790 INFO  - #  *[3] = {
05:05:00,790 INFO  - #    *[1] = 3 } }
05:05:00,790 INFO  - # Expected:
05:05:00,790 INFO  - # (table) {
05:05:00,790 INFO  - #   [1] = 'notification'
05:05:00,791 INFO  - #   [2] = 'wait'
05:05:00,791 INFO  - #  *[3] = {
05:05:00,791 INFO  - #    *[1] = 4 } }
05:05:00,791 INFO  - # stack traceback:
05:05:00,791 INFO  - # >test/functional/core/job_spec.lua:544: in function <test/functional/core/job_spec.lua:521>
```

Are the streams all closed somehow before the process exits? Or is `proc->status` not set correctly (`>=0`) in some case? @bfredl 


--

Other QB failure just looks like a test that needs to be fixed:

```
not ok 408 - Command-line option -s does not crash after reading from stdin in non-headless mode
# test/functional/core/main_spec.lua @ 61
# Failure message: ./test/functional/ui/screen.lua:307: Row 1 did not match.
# Expected:
#   |*^                                        |
#   |[Process exited 1]                      |
#   |                                        |
#   |                                        |
#   |                                        |
#   |                                        |
#   |                                        |
#   |                                        |
# Actual:
#   |*                                        |
#   |[Process exited 1]                      |
#   |                                        |
#   |                                        |
#   |                                        |
#   |                                        |
#   |^                                        |
#   |                                        |

```