### PR TITLE
[RFC] redraw statusline of current window when entering terminal, fixes some status lines

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4900,7 +4900,7 @@ win_redr_status_matches (
  *
  * If inversion is possible we use it. Else '=' characters are used.
  */
-void win_redr_status(win_T *wp)
+static void win_redr_status(win_T *wp)
 {
   int row;
   char_u      *p;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1273,6 +1273,12 @@ static void redraw(bool restore_cursor)
     maketitle();
   }
 
+  // redraw status line so mode() reports terminal mode correctly.
+  // Some status lines display the current mode in the and they might skip a
+  // beat and report the wrong mode (namely normal mode instead of terminal mode).
+  curwin->w_redr_status = true;
+  redraw_statuslines();
+
   if (restore_cursor) {
     ui_cursor_goto(save_row, save_col);
   } else if (term) {


### PR DESCRIPTION
I'm currently having some issues with my status line (same problem showed up with airline and probably with every other fancy status line that does such things). I'm displaying the current mode in the status line, however TERMINAL mode seems to be somewhat glitchy here. Sometimes it works and sometimes it seems to miss a beat and the `mode()` function reports NORMAL mode even though I'm in TERMINAL mode (`showmode` reports it correctly).

![2018-04-28-190459_564x364_scrot](https://user-images.githubusercontent.com/151506/39399044-1ecf1646-4b17-11e8-951b-438ad7ca6774.png)

I've forced a status line redraw when entering TERMINAL mode (arguably controversial since entering TERMINAL isn't really a situation that should enforce a status line redraw in general). IT seems to work fine now.

![2018-04-28-185832_564x364_scrot](https://user-images.githubusercontent.com/151506/39399053-68d63828-4b17-11e8-9e1b-3151035cae8f.png)

I don't know if this is the best way to do this (probably it isn't, but it's a start).