### PR TITLE
:terminal : set topline based on window height

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1063,7 +1063,7 @@ struct window_S {
   int w_width;                      /* Width of window, excluding separation. */
   int w_vsep_width;                 /* Number of separator columns (0 or 1). */
 
-  // inner size of window, which can be overriden by external UI
+  // inner size of window, which can be overridden by external UI
   int w_height_inner;
   int w_width_inner;
   // external UI request. If non-zero, the inner size will use this.

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1311,8 +1311,6 @@ static void redraw(bool restore_cursor)
 
 static void adjust_topline(Terminal *term, buf_T *buf, long added)
 {
-  int height, width;
-  vterm_get_size(term->vt, &height, &width);
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer == buf) {
       linenr_T ml_end = buf->b_ml.ml_line_count;
@@ -1321,7 +1319,7 @@ static void adjust_topline(Terminal *term, buf_T *buf, long added)
       if (following || (wp == curwin && is_focused(term))) {
         // "Follow" the terminal output
         wp->w_cursor.lnum = ml_end;
-        set_topline(wp, MAX(wp->w_cursor.lnum - height + 1, 1));
+        set_topline(wp, MAX(wp->w_cursor.lnum - wp->w_height_inner + 1, 1));
       } else {
         // Ensure valid cursor for each window displaying this terminal.
         wp->w_cursor.lnum = MIN(wp->w_cursor.lnum, ml_end);

--- a/test/functional/terminal/altscreen_spec.lua
+++ b/test/functional/terminal/altscreen_spec.lua
@@ -8,7 +8,7 @@ local exit_altscreen = thelpers.exit_altscreen
 
 if helpers.pending_win32(pending) then return end
 
-describe('terminal altscreen', function()
+describe(':terminal altscreen', function()
   local screen
 
   before_each(function()

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -6,7 +6,7 @@ local eval, feed_command, source = helpers.eval, helpers.feed_command, helpers.s
 local eq, neq = helpers.eq, helpers.neq
 local write_file = helpers.write_file
 
-describe('terminal buffer', function()
+describe(':terminal buffer', function()
   local screen
 
   before_each(function()

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -7,7 +7,7 @@ local feed_command = helpers.feed_command
 local hide_cursor = thelpers.hide_cursor
 local show_cursor = thelpers.show_cursor
 
-describe('terminal cursor', function()
+describe(':terminal cursor', function()
   local screen
 
   before_each(function()

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -5,7 +5,7 @@ local feed, clear, nvim = helpers.feed, helpers.clear, helpers.nvim
 local nvim_dir, command = helpers.nvim_dir, helpers.command
 local eq, eval = helpers.eq, helpers.eval
 
-describe('terminal window highlighting', function()
+describe(':terminal window highlighting', function()
   local screen
 
   before_each(function()

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -4,7 +4,7 @@ local clear, eq, eval = helpers.clear, helpers.eq, helpers.eval
 local feed, nvim = helpers.feed, helpers.nvim
 local feed_data = thelpers.feed_data
 
-describe('terminal mouse', function()
+describe(':terminal mouse', function()
   local screen
 
   before_each(function()

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -12,7 +12,7 @@ local curbufmeths = helpers.curbufmeths
 local nvim = helpers.nvim
 local feed_data = thelpers.feed_data
 
-describe('terminal scrollback', function()
+describe(':terminal scrollback', function()
   local screen
 
   before_each(function()
@@ -344,7 +344,7 @@ describe('terminal scrollback', function()
   end)
 end)
 
-describe('terminal prints more lines than the screen height and exits', function()
+describe(':terminal prints more lines than the screen height and exits', function()
   it('will push extra lines to scrollback', function()
     clear()
     local screen = Screen.new(30, 7)
@@ -460,7 +460,7 @@ describe("'scrollback' option", function()
     screen:detach()
   end)
 
-  it('defaults to 10000 in terminal buffers', function()
+  it('defaults to 10000 in :terminal buffers', function()
     set_fake_shell()
     command('terminal')
     eq(10000, curbufmeths.get_option('scrollback'))

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -20,7 +20,7 @@ local read_file = helpers.read_file
 
 if helpers.pending_win32(pending) then return end
 
-describe('tui', function()
+describe('TUI', function()
   local screen
 
   before_each(function()

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -3,13 +3,30 @@ local thelpers = require('test.functional.terminal.helpers')
 local feed, clear = helpers.feed, helpers.clear
 local wait = helpers.wait
 local iswin = helpers.iswin
+local command = helpers.command
+local retry = helpers.retry
+local eq = helpers.eq
+local eval = helpers.eval
 
-describe('terminal window', function()
+describe(':terminal window', function()
   local screen
 
   before_each(function()
     clear()
     screen = thelpers.screen_setup()
+  end)
+
+  it('sets topline correctly #8556', function()
+    -- Test has hardcoded assumptions of dimensions.
+    eq(7, eval('&lines'))
+    command('set shell=sh')
+    command('terminal')
+    retry(nil, nil, function() assert(nil ~= eval('b:terminal_job_pid')) end)
+    -- Terminal/shell contents must exceed the height of this window.
+    command('topleft 1split')
+    feed([[i<cr>]])
+    -- Check topline _while_ in terminal-mode.
+    retry(nil, nil, function() eq(6, eval('winsaveview()["topline"]')) end)
   end)
 
   describe("with 'number'", function()
@@ -124,7 +141,7 @@ describe('terminal window', function()
   end)
 end)
 
-describe('terminal window with multigrid', function()
+describe(':terminal with multigrid', function()
   local screen
 
   before_each(function()

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -9,7 +9,7 @@ local eval = helpers.eval
 local iswin = helpers.iswin
 local retry = helpers.retry
 
-describe('terminal', function()
+describe(':terminal', function()
   local screen
 
   before_each(function()


### PR DESCRIPTION
If the same terminal buffer is displayed in multiple windows of different size, `adjust_topline()` behaves incorrectly because it sets top line based on terminal buffer height. This diff fixes #8324.