### PR TITLE
[RFC] redraw statusline when entering command mode

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -347,6 +347,13 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
     redrawcmd();
   }
 
+  // redraw the statusline for statuslines that display the current mode
+  // using the mode() function.
+  if (KeyTyped) {
+    curwin->w_redr_status = true;
+    redraw_statuslines();
+  }
+
   did_emsg = false;
   got_int = false;
   s->state.check = command_line_check;

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -157,6 +157,27 @@ describe('external cmdline', function()
     end)
   end)
 
+  it("redraws statusline on entering", function()
+    command('set laststatus=2')
+    command('set statusline=%{mode()}')
+    feed(':')
+    screen:expect([[
+                               |
+      {1:~                        }|
+      {1:~                        }|
+      {3:c^                        }|
+                               |
+    ]], nil, nil, function()
+      eq({{
+        content = { { {}, "" } },
+        firstc = ":",
+        indent = 0,
+        pos = 0,
+        prompt = ""
+      }}, cmdline)
+    end)
+  end)
+
   it("works with input()", function()
     feed(':call input("input", "default")<cr>')
     screen:expect([[


### PR DESCRIPTION
I experimented a little bit more with `mode()` in the status line and finally found an explanation why for some reason airline suddenly reported COMMAND mode for previously unknown reasons in the statusline. When entering COMMAND mode with ':' the statusline does not get immediately redrawn. Interestingly enough when entering \ (e.g. when writing a regex, this seems to be related to leader key mappings somehow, I need to investigate further) status line gets redrawn and mode() suddenly reports 'c' making statuslines suddenly switch modes for no apparent reason (even though Neovim already is in COMMAND mode). I've added a redraw when entering COMMAND mode to give more consistent feedback here. I think this result is pretty neat because now I have a more consistent experience with fancy statuslines like airline et al, since they don't switch to COMMAND mode just because something unrelated triggered a redraw. Any thoughts on this?

I'm still trying to isolate a minimal test case and will post it here once I can work something out.