### PR TITLE
[RFC] edit.c: Don't indent during completion

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -494,7 +494,7 @@ static int insert_check(VimState *state)
     s->inserted_space = false;
   }
 
-  if (can_cindent && cindent_on() && ctrl_x_mode == 0) {
+  if (can_cindent && cindent_on() && ctrl_x_mode == 0 && !compl_started) {
     insert_do_cindent(s);
   }
 


### PR DESCRIPTION
Fixes #8345

The problem was that indentation happens after completions are calculated, so the PUM and the start of the current completion were un-updated. I have it adjusting compl_col the same way it adjusts the autoindent column insert-mode start position the which works as far as I can tell (but may fail in some corner cases).