### PR TITLE
API: nvim_call_dict_function

### DIFF
--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -183,23 +183,34 @@ describe('api', function()
     it('invokes VimL dict', function()
       source('function! F(name) dict\n  return self.greeting . ", " . a:name . "!"\nendfunction')
       nvim('set_var', 'dict_function_dict', { greeting = 'Hello', F = 'function("F")' })
-      eq('Hello, World!', nvim('call_dict_function', 'g:dict_function_dict', false, 'F', {'World'}))
+      eq('Hello, World!', nvim('call_dict_function', 'g:dict_function_dict', 'F', false, {'World'}))
       eq({ greeting = 'Hello', F = 'function("F")' }, nvim('get_var', 'dict_function_dict'))
       nvim('set_var', 'dict_function_dict_i', { greeting = 'Hi', F = "F" })
-      eq('Hi, Moon!', nvim('call_dict_function', 'g:dict_function_dict_i', true, 'F', {'Moon'}))
+      eq('Hi, Moon!', nvim('call_dict_function', 'g:dict_function_dict_i', 'F', true, {'Moon'}))
       eq({ greeting = 'Hi', F = "F" }, nvim('get_var', 'dict_function_dict_i'))
     end)
     it('invokes RPC dict', function()
       source('function! G() dict\n  return self.result\nendfunction')
-      eq('self', nvim('call_dict_function', { result = 'self', G = 'G'}, false, 'G', {}))
+      eq('self', nvim('call_dict_function', { result = 'self', G = 'G'}, 'G', false, {}))
     end)
-    it('fails for a RPC dictionary and internal set to true', function()
-      expect_err('Funcrefs are not supported for RPC dicts', request,
-                 'nvim_call_dict_function', { f = '' }, true, 'f', {1,2})
-    end)
-    it('fails with empty function name', function()
+    it('validates args', function()
+      command('let g:d={"baz":"zub","meep":[]}')
+      expect_err('Function not found in dict', request,
+                 'nvim_call_dict_function', 'g:d', 'bogus', true, {1,2})
+      expect_err('Error calling function.', request,
+                 'nvim_call_dict_function', 'g:d', 'baz', true, {1,2})
+      expect_err('Value found in dict is not a valid function', request,
+                 'nvim_call_dict_function', 'g:d', 'meep', true, {1,2})
+      expect_err('Cannot invoke RPC dict as a VimL reference', request,
+                 'nvim_call_dict_function', { f = '' }, 'f', true, {1,2})
       expect_err('Invalid %(empty%) function name', request,
-                 'nvim_call_dict_function', "{ 'f': '' }", true, 'f', {1,2})
+                 'nvim_call_dict_function', "{ 'f': '' }", 'f', true, {1,2})
+      expect_err('dict argument type must be String or Dictionary', request,
+                 'nvim_call_dict_function', 42, 'f', true, {1,2})
+      expect_err('Failed to evaluate dict expression', request,
+                 'nvim_call_dict_function', 'foo', 'f', true, {1,2})
+      expect_err('Referenced dict does not exist', request,
+                 'nvim_call_dict_function', '42', 'f', true, {1,2})
     end)
   end)
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -183,42 +183,51 @@ describe('api', function()
     it('invokes VimL dict function', function()
       source([[
         function! F(name) dict
-          return self.greeting . ", " . a:name . "!"
+          return self.greeting.', '.a:name.'!'
+        endfunction
+        let g:test_dict_fn = { 'greeting':'Hello', 'F':function('F') }
+
+        let g:test_dict_fn2 = { 'greeting':'Hi' }
+        function g:test_dict_fn2.F2(name)
+          return self.greeting.', '.a:name.' ...'
         endfunction
       ]])
 
-      -- function() ("non-internal") function
-      nvim('set_var', 'dict_function_dict', { greeting = 'Hello', F = 'function("F")' })
-      eq('Hello, World!', nvim('call_dict_function', 'g:dict_function_dict', 'F', {'World'}))
-      eq({ greeting = 'Hello', F = 'function("F")' }, nvim('get_var', 'dict_function_dict'))
+      -- :help Dictionary-function
+      eq('Hello, World!', nvim('call_dict_function', 'g:test_dict_fn', 'F', {'World'}))
+      -- Funcref is sent as NIL over RPC.
+      eq({ greeting = 'Hello', F = NIL }, nvim('get_var', 'test_dict_fn'))
 
-      -- "internal" function
-      nvim('set_var', 'dict_function_dict_i', { greeting = 'Hi', F = "F" })
-      eq('Hi, Moon!', nvim('call_dict_function', 'g:dict_function_dict_i', 'F', {'Moon'}))
-      eq({ greeting = 'Hi', F = "F" }, nvim('get_var', 'dict_function_dict_i'))
+      -- :help numbered-function
+      eq('Hi, Moon ...', nvim('call_dict_function', 'g:test_dict_fn2', 'F2', {'Moon'}))
+      -- Funcref is sent as NIL over RPC.
+      eq({ greeting = 'Hi', F2 = NIL }, nvim('get_var', 'test_dict_fn2'))
+
+      -- Function specified via RPC dict.
+      source('function! G() dict\n  return "@".(self.result)."@"\nendfunction')
+      eq('@it works@', nvim('call_dict_function', { result = 'it works', G = 'G'}, 'G', {}))
     end)
-    it('invokes RPC dict', function()
-      source('function! G() dict\n  return self.result\nendfunction')
-      eq('it works', nvim('call_dict_function', { result = 'it works', G = 'G'}, 'G', {}))
-    end)
+
     it('validates args', function()
       command('let g:d={"baz":"zub","meep":[]}')
-      expect_err('Error calling function', request,
+      expect_err('Not found: bogus', request,
                  'nvim_call_dict_function', 'g:d', 'bogus', {1,2})
-      expect_err('Error calling function', request,
+      expect_err('Not a function: baz', request,
                  'nvim_call_dict_function', 'g:d', 'baz', {1,2})
-      expect_err('Value found in dict is not a valid function', request,
+      expect_err('Not a function: meep', request,
                  'nvim_call_dict_function', 'g:d', 'meep', {1,2})
       expect_err('Error calling function', request,
                  'nvim_call_dict_function', { f = '' }, 'f', {1,2})
-      expect_err('Invalid %(empty%) function name', request,
+      expect_err('Not a function: f', request,
                  'nvim_call_dict_function', "{ 'f': '' }", 'f', {1,2})
       expect_err('dict argument type must be String or Dictionary', request,
                  'nvim_call_dict_function', 42, 'f', {1,2})
       expect_err('Failed to evaluate dict expression', request,
                  'nvim_call_dict_function', 'foo', 'f', {1,2})
-      expect_err('Referenced dict does not exist', request,
+      expect_err('dict not found', request,
                  'nvim_call_dict_function', '42', 'f', {1,2})
+      expect_err('Invalid %(empty%) function name', request,
+                 'nvim_call_dict_function', "{ 'f': '' }", '', {1,2})
     end)
   end)
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -158,12 +158,22 @@ describe('api', function()
       eq(17, nvim('call_function', 'eval', {17}))
       eq('foo', nvim('call_function', 'simplify', {'this/./is//redundant/../../../foo'}))
     end)
-
     it("VimL error: fails (generic error), does NOT update v:errmsg", function()
       local status, rv = pcall(nvim, "call_function", "bogus function", {"arg1"})
       eq(false, status)                 -- nvim_call_function() failed.
       ok(nil ~= string.find(rv, "Error calling function"))
       eq("", nvim("eval", "v:errmsg"))  -- v:errmsg was not updated.
+    end)
+    it('validates args', function()
+      local too_many_args = { 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x' }
+      source([[
+        function! Foo(...) abort
+          echo a:000
+        endfunction
+      ]])
+      -- E740
+      expect_err('Function called with too many arguments', request,
+                 'nvim_call_function', 'Foo', too_many_args)
     end)
   end)
 


### PR DESCRIPTION
- Merge https://github.com/neovim/neovim/pull/3032
- Minor changes: rename, rearrange
- swap args so it is like this (seems more natural for `fn` to immediately follow the `selfdict` arg):
   ```
   nvim_call_dict_function(Object dict, String fn, Boolean internal, Array args, Error *err)
   ```
- Remove `internal` param (see below)