### PR TITLE
[RFC] do not disable relative numbers when entering terminal

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -96,7 +96,6 @@ global configuration.
 
 - 'list' is disabled
 - 'wrap' is disabled
-- 'relativenumber' is disabled in |Terminal-mode| (and cannot be enabled)
 
 You can change the defaults with a TermOpen autocommand: >
 	au TermOpen * setlocal list

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -396,10 +396,8 @@ void terminal_enter(void)
   win_T *save_curwin = curwin;
   int save_w_p_cul = curwin->w_p_cul;
   int save_w_p_cuc = curwin->w_p_cuc;
-  int save_w_p_rnu = curwin->w_p_rnu;
   curwin->w_p_cul = false;
   curwin->w_p_cuc = false;
-  curwin->w_p_rnu = false;
 
   adjust_topline(s->term, buf, 0);  // scroll to end
   // erase the unfocused cursor
@@ -417,7 +415,6 @@ void terminal_enter(void)
   if (save_curwin == curwin) {  // save_curwin may be invalid (window closed)!
     curwin->w_p_cul = save_w_p_cul;
     curwin->w_p_cuc = save_w_p_cuc;
-    curwin->w_p_rnu = save_w_p_rnu;
   }
 
   // draw the unfocused cursor


### PR DESCRIPTION
Entering the terminal should not change the width of the terminal since it might lead to characters being cut off.

I have `relativenumber` enabled in my terminal since I like to be able to use efficient motions when in NORMAL mode. The thing is to make that possible I have to have `number` enabled as well which provides me with a rather useless line number. I'd rather have 0 on my current line since it keeps the number column smaller and the line number offers no useful information to me.

However. Neovim disables `relativenumber` when entering the terminal, but this leads to above lines being truncated by the width of the number column.

This patch removes the forceful removal of the `relativenumber` option. I'm arguing that it might
do more harm than good, taking away what some people want (I admit that I'm probably in the minority here ^^) and also causing some issues with certain configurations.

![2018-05-04-215619_354x364_scrot](https://user-images.githubusercontent.com/151506/39649452-1b58932e-4fe6-11e8-818c-eca621e23f21.png)
![2018-05-04-215633_354x364_scrot](https://user-images.githubusercontent.com/151506/39649455-1b803aa0-4fe6-11e8-9a44-99dd8f8be012.png)
![2018-05-04-215640_354x364_scrot](https://user-images.githubusercontent.com/151506/39649456-1ba1e786-4fe6-11e8-901d-ab2a3492d323.png)
