### PR TITLE
build: remove reference to non-exisiting script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,6 @@ install:        ci/install.sh
 before_script:  ci/before_script.sh
 script:         ci/script.sh
 before_cache:   ci/before_cache.sh
-after_success:  ci/after_success.sh
 
 addons:
   apt:


### PR DESCRIPTION
This script doesn't exist in the ci directory so it shouldn't be listed in the travis config.
```
$ ci/after_success.sh
/home/travis/.travis/job_stages: line 57: ci/after_success.sh: No such file or directory
```