### PR TITLE
API: nvim_get_commands

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -467,7 +467,7 @@ Integer nvim_buf_get_changedtick(Buffer buffer, Error *err)
 /// @returns Array of maparg()-like dictionaries describing mappings.
 ///          The "buffer" key holds the associated buffer handle.
 ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, Error *err)
-    FUNC_API_SINCE(3)
+  FUNC_API_SINCE(3)
 {
   buf_T *buf = find_buffer_by_handle(buffer, err);
 
@@ -478,16 +478,15 @@ ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, Error *err)
   return keymap_array(mode, buf);
 }
 
-/// Gets a list of buffer-local |user-commands|.
+/// Gets a map of buffer-local |user-commands|.
 ///
 /// @param  buffer  Buffer handle.
 /// @param  opts  Optional parameters. Currently not used.
 /// @param[out]  err   Error details, if any.
 ///
-/// @returns Array of dictionaries describing commands.
-ArrayOf(Dictionary) nvim_buf_get_commands(Buffer buffer, Dictionary opts,
-                                          Error *err)
-    FUNC_API_SINCE(4)
+/// @returns Map of maps describing commands.
+Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, Error *err)
+  FUNC_API_SINCE(4)
 {
   bool global = (buffer == -1);
   bool builtin = false;
@@ -497,7 +496,7 @@ ArrayOf(Dictionary) nvim_buf_get_commands(Buffer buffer, Dictionary opts,
     Object v = opts.items[i].value;
     if (!strequal("builtin", k.data)) {
       api_set_error(err, kErrorTypeValidation, "unexpected key: %s", k.data);
-      return (Array)ARRAY_DICT_INIT;
+      return (Dictionary)ARRAY_DICT_INIT;
     }
     if (strequal("builtin", k.data)) {
       builtin = v.data.boolean;
@@ -507,14 +506,14 @@ ArrayOf(Dictionary) nvim_buf_get_commands(Buffer buffer, Dictionary opts,
   if (global) {
     if (builtin) {
       api_set_error(err, kErrorTypeValidation, "builtin=true not implemented");
-      return (Array)ARRAY_DICT_INIT;
+      return (Dictionary)ARRAY_DICT_INIT;
     }
     return commands_array(NULL);
   }
 
   buf_T *buf = find_buffer_by_handle(buffer, err);
   if (builtin || !buf) {
-    return (Array)ARRAY_DICT_INIT;
+    return (Dictionary)ARRAY_DICT_INIT;
   }
   return commands_array(buf);
 }

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -24,6 +24,7 @@
 #include "nvim/syntax.h"
 #include "nvim/window.h"
 #include "nvim/undo.h"
+#include "nvim/ex_docmd.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/buffer.c.generated.h"
@@ -476,6 +477,26 @@ ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, Error *err)
   }
 
   return keymap_array(mode, buf);
+}
+
+/// Gets a list of dictionaries describing buffer-local commands.
+/// The "buffer" key in the returned dictionary reflects the buffer
+/// handle where the command is present.
+///
+/// @param  buffer     Buffer handle.
+/// @param  opts       Optional parameters, currently always 
+/// @param[out]  err   Error details, if any.
+///
+/// @returns Array of dictionaries describing commands.
+ArrayOf(Dictionary) nvim_buf_get_commands(Buffer buffer, Dictionary opts,
+                                          Error *err)
+    FUNC_API_SINCE(4)
+{
+  buf_T *buf = find_buffer_by_handle(buffer, err);
+  if (!buf) {
+    return (Array)ARRAY_DICT_INIT;
+  }
+  return commands_array(buf);
 }
 
 /// Sets a buffer-scoped (b:) variable

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -459,14 +459,13 @@ Integer nvim_buf_get_changedtick(Buffer buffer, Error *err)
   return buf->b_changedtick;
 }
 
-/// Gets a list of dictionaries describing buffer-local mappings.
-/// The "buffer" key in the returned dictionary reflects the buffer
-/// handle where the mapping is present.
+/// Gets a list of buffer-local |mapping| definitions.
 ///
 /// @param  mode       Mode short-name ("n", "i", "v", ...)
 /// @param  buffer     Buffer handle
 /// @param[out]  err   Error details, if any
-/// @returns Array of maparg()-like dictionaries describing mappings
+/// @returns Array of maparg()-like dictionaries describing mappings.
+///          The "buffer" key holds the associated buffer handle.
 ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, Error *err)
     FUNC_API_SINCE(3)
 {
@@ -479,7 +478,7 @@ ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, Error *err)
   return keymap_array(mode, buf);
 }
 
-/// Gets a list of maps describing buffer-local |user-commands|.
+/// Gets a list of buffer-local |user-commands|.
 ///
 /// @param  buffer  Buffer handle.
 /// @param  opts  Optional parameters. Currently only supports

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -701,7 +701,7 @@ String cchar_to_string(char c)
 String cstr_to_string(const char *str)
 {
     if (str == NULL) {
-        return (String) STRING_INIT;
+      return (String) STRING_INIT;
     }
 
     size_t len = strlen(str);
@@ -1149,7 +1149,7 @@ void api_set_error(Error *err, ErrorType errType, const char *format, ...)
 ///
 /// @param  mode  The abbreviation for the mode
 /// @param  buf  The buffer to get the mapping array. NULL for global
-/// @returns An array of maparg() like dictionaries describing mappings
+/// @returns Array of maparg()-like dictionaries describing mappings
 ArrayOf(Dictionary) keymap_array(String mode, buf_T *buf)
 {
   Array mappings = ARRAY_DICT_INIT;

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -685,7 +685,7 @@ tabpage_T *find_tab_by_handle(Tabpage tabpage, Error *err)
 String cchar_to_string(char c)
 {
   char buf[] = { c, NUL };
-  return (String) {
+  return (String){
     .data = xmemdupz(buf, 1),
     .size = (c != NUL) ? 1 : 0
   };
@@ -701,13 +701,13 @@ String cchar_to_string(char c)
 String cstr_to_string(const char *str)
 {
     if (str == NULL) {
-      return (String) STRING_INIT;
+      return (String)STRING_INIT;
     }
 
     size_t len = strlen(str);
-    return (String) {
-        .data = xmemdupz(str, len),
-        .size = len
+    return (String){
+      .data = xmemdupz(str, len),
+      .size = len,
     };
 }
 
@@ -722,7 +722,7 @@ String cstr_to_string(const char *str)
 String cbuf_to_string(const char *buf, size_t size)
   FUNC_ATTR_NONNULL_ALL
 {
-  return (String) {
+  return (String){
     .data = xmemdupz(buf, size),
     .size = size
   };
@@ -737,9 +737,9 @@ String cbuf_to_string(const char *buf, size_t size)
 String cstr_as_string(char *str) FUNC_ATTR_PURE
 {
   if (str == NULL) {
-    return (String) STRING_INIT;
+    return (String)STRING_INIT;
   }
-  return (String) { .data = str, .size = strlen(str) };
+  return (String){ .data = str, .size = strlen(str) };
 }
 
 /// Converts from type Object to a VimL value.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -948,18 +948,20 @@ Dictionary nvim_get_mode(void)
   return rv;
 }
 
-/// Gets a list of dictionaries describing global (non-buffer) mappings.
-/// The "buffer" key in the returned dictionary is always zero.
+/// Gets a list of global (non-buffer-local) |mapping| definitions.
 ///
 /// @param  mode       Mode short-name ("n", "i", "v", ...)
-/// @returns Array of maparg()-like dictionaries describing mappings
+/// @returns Array of maparg()-like dictionaries describing mappings.
+///          The "buffer" key is always zero.
 ArrayOf(Dictionary) nvim_get_keymap(String mode)
     FUNC_API_SINCE(3)
 {
   return keymap_array(mode, NULL);
 }
 
-/// Gets a list of maps describing global |user-commands|.
+/// Gets a list of global (non-buffer-local) Ex commands.
+///
+/// Currently only |user-commands| are supported, not builtin Ex commands.
 ///
 /// @param  opts  Optional parameters. Currently only supports
 ///               {"builtin":false}

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -959,6 +959,19 @@ ArrayOf(Dictionary) nvim_get_keymap(String mode)
   return keymap_array(mode, NULL);
 }
 
+/// Gets a list of dictionaries describing global(non-buffer) commands.
+///
+/// @param  opts       Holds the API Metadata describing what type of commands
+///                    are needed.
+/// @param[out]  err   Error details, if any.
+///
+/// @returns Array of dictionaries describing commands.
+ArrayOf(Dictionary) nvim_get_commands(Dictionary opts, Error *err)
+    FUNC_API_SINCE(4)
+{
+  return commands_array(NULL);
+}
+
 /// Returns a 2-tuple (Array), where item 0 is the current channel id and item
 /// 1 is the |api-metadata| map (Dictionary).
 ///

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -954,12 +954,12 @@ Dictionary nvim_get_mode(void)
 /// @returns Array of maparg()-like dictionaries describing mappings.
 ///          The "buffer" key is always zero.
 ArrayOf(Dictionary) nvim_get_keymap(String mode)
-    FUNC_API_SINCE(3)
+  FUNC_API_SINCE(3)
 {
   return keymap_array(mode, NULL);
 }
 
-/// Gets a list of global (non-buffer-local) Ex commands.
+/// Gets a map of global (non-buffer-local) Ex commands.
 ///
 /// Currently only |user-commands| are supported, not builtin Ex commands.
 ///
@@ -967,9 +967,9 @@ ArrayOf(Dictionary) nvim_get_keymap(String mode)
 ///               {"builtin":false}
 /// @param[out]  err   Error details, if any.
 ///
-/// @returns Array of dictionaries describing commands.
-ArrayOf(Dictionary) nvim_get_commands(Dictionary opts, Error *err)
-    FUNC_API_SINCE(4)
+/// @returns Map of maps describing commands.
+Dictionary nvim_get_commands(Dictionary opts, Error *err)
+  FUNC_API_SINCE(4)
 {
   return nvim_buf_get_commands(-1, opts, err);
 }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -959,17 +959,17 @@ ArrayOf(Dictionary) nvim_get_keymap(String mode)
   return keymap_array(mode, NULL);
 }
 
-/// Gets a list of dictionaries describing global(non-buffer) commands.
+/// Gets a list of maps describing global |user-commands|.
 ///
-/// @param  opts       Holds the API Metadata describing what type of commands
-///                    are needed.
+/// @param  opts  Optional parameters. Currently only supports
+///               {"builtin":false}
 /// @param[out]  err   Error details, if any.
 ///
 /// @returns Array of dictionaries describing commands.
 ArrayOf(Dictionary) nvim_get_commands(Dictionary opts, Error *err)
     FUNC_API_SINCE(4)
 {
-  return commands_array(NULL);
+  return nvim_buf_get_commands(-1, opts, err);
 }
 
 /// Returns a 2-tuple (Array), where item 0 is the current channel id and item

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9969,15 +9969,15 @@ bool cmd_can_preview(char_u *cmd)
   return false;
 }
 
-/// Gets a list of maps describing user-commands defined for buffer `buf`
-/// or defined globally if `buf` is NULL.
+/// Gets a map of maps describing user-commands defined for buffer `buf` or
+/// defined globally if `buf` is NULL.
 ///
-/// @param buf  Buffer to inspect, or NULL to get global user-commands.
+/// @param buf  Buffer to inspect, or NULL to get global commands.
 ///
-/// @return Array of dictionaries describing commands
-ArrayOf(Dictionary) commands_array(buf_T *buf)
+/// @return Map of maps describing commands
+Dictionary commands_array(buf_T *buf)
 {
-  Array rv = ARRAY_DICT_INIT;
+  Dictionary rv = ARRAY_DICT_INIT;
   Object obj = NIL;
   char str[10];
   garray_T *gap = (buf == NULL) ? &ucmds : &buf->b_ucmds;
@@ -10043,7 +10043,7 @@ ArrayOf(Dictionary) commands_array(buf_T *buf)
     }
     PUT(d, "addr", obj);
 
-    ADD(rv, DICTIONARY_OBJ(d));
+    PUT(rv, (char *)cmd->uc_name, DICTIONARY_OBJ(d));
   }
   return rv;
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9990,14 +9990,16 @@ ArrayOf(Dictionary) commands_array(buf_T *buf)
     PUT(d, "name", STRING_OBJ(cstr_to_string((char *)cmd->uc_name)));
     PUT(d, "definition", STRING_OBJ(cstr_to_string((char *)cmd->uc_rep)));
     PUT(d, "script_id", INTEGER_OBJ(cmd->uc_scriptID));
+    PUT(d, "bang", BOOLEAN_OBJ(!!(cmd->uc_argt & BANG)));
+    PUT(d, "bar", BOOLEAN_OBJ(!!(cmd->uc_argt & TRLBAR)));
+    PUT(d, "register", BOOLEAN_OBJ(!!(cmd->uc_argt & REGSTR)));
 
-    // "nargs" key
     switch (cmd->uc_argt & (EXTRA|NOSPC|NEEDARG)) {
-    case 0:                    arg[0] = '0'; break;
-    case(EXTRA):               arg[0] = '*'; break;
-    case(EXTRA|NOSPC):         arg[0] = '?'; break;
-    case(EXTRA|NEEDARG):       arg[0] = '+'; break;
-    case(EXTRA|NOSPC|NEEDARG): arg[0] = '1'; break;
+      case 0:                    arg[0] = '0'; break;
+      case(EXTRA):               arg[0] = '*'; break;
+      case(EXTRA|NOSPC):         arg[0] = '?'; break;
+      case(EXTRA|NEEDARG):       arg[0] = '+'; break;
+      case(EXTRA|NOSPC|NEEDARG): arg[0] = '1'; break;
     }
     PUT(d, "nargs", STRING_OBJ(cstr_to_string(arg)));
 

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -19,7 +19,7 @@ describe('nvim_get_commands', function()
   end)
 
   it('validates input', function()
-    expect_err('builtin commands not supported yet', meths.get_commands,
+    expect_err('builtin=true not implemented', meths.get_commands,
                {builtin=true})
     expect_err('unexpected key: foo', meths.get_commands,
                {foo='blah'})
@@ -47,6 +47,9 @@ describe('nvim_get_commands', function()
     -- Delete a command.
     command('delcommand Pwd')
     eq({cmd_dict}, curbufmeths.get_commands({builtin=false}))
+
+    -- {builtin=true} always returns empty for buffer-local case.
+    eq({}, curbufmeths.get_commands({builtin=true}))
   end)
 
   it('gets various command attributes', function()

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -1,0 +1,74 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local command = helpers.command
+local curbufmeths = helpers.curbufmeths
+local eq = helpers.eq
+local meths = helpers.meths
+
+describe('nvim_get_commands', function()
+  local dummy_dict = {dummy=''}
+  local cmd_string = 'command Hello echo "Hello World"'
+  local cmd_string2 = 'command Pwd pwd'
+  local cmd_dict = {
+    name='Hello',
+    nargs='0',
+    script_id=0,
+    definition='echo "Hello World"',
+  }
+  local cmd_dict2 = {
+    name='Pwd',
+    nargs='0',
+    script_id=0,
+    definition='pwd',
+  }
+  before_each(clear)
+  it('gets empty list if no commands were defined', function()
+    eq({}, meths.get_commands(dummy_dict))
+  end)
+  it('gets user-def commands', function()
+    -- Insert a command
+    command(cmd_string)
+    eq({cmd_dict}, meths.get_commands(dummy_dict))
+    -- Insert a another command
+    command(cmd_string2);
+    eq({cmd_dict, cmd_dict2}, meths.get_commands(dummy_dict))
+    -- Delete a command
+    command('delcommand Pwd')
+    eq({cmd_dict}, meths.get_commands(dummy_dict))
+  end)
+  it('considers different buffers', function()
+    -- Insert a command
+    command('command -buffer Hello echo "Hello World"')
+    eq({cmd_dict}, curbufmeths.get_commands(dummy_dict))
+    -- Insert a another command
+    command('command -buffer Pwd pwd')
+    eq({cmd_dict, cmd_dict2}, curbufmeths.get_commands(dummy_dict))
+    -- Delete a command
+    command('delcommand Pwd')
+    eq({cmd_dict}, curbufmeths.get_commands(dummy_dict))
+  end)
+  it('gets different attributes of different commands', function()
+    local cmd1 = {
+      complete='custom',
+      nargs='1',
+      name='Finger',
+      script_id=0,
+      complete_arg='ListUsers',
+      definition='!finger <args>',
+    }
+    local cmd2 = {
+      complete='dir',
+      nargs='0',
+      name='TestCmd',
+      range='10c',
+      addr='arguments',
+      script_id=0,
+      definition='pwd <args>',
+    }
+    command('command -complete=custom,ListUsers -nargs=1 Finger !finger <args>')
+    eq({cmd1}, meths.get_commands(dummy_dict))
+    command('command -complete=dir -addr=arguments -count=10 TestCmd pwd <args>')
+    eq({cmd1, cmd2}, meths.get_commands(dummy_dict))
+  end)
+end)

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -10,38 +10,21 @@ local meths = helpers.meths
 local source = helpers.source
 
 describe('nvim_get_commands', function()
-  local cmd_dict = {
-    addr=NIL,
-    complete=NIL,
-    complete_arg=NIL,
-    count=NIL,
-    definition='echo "Hello World"',
-    name='Hello',
-    nargs='1',
-    range=NIL,
-    script_id=0,
-  }
-  local cmd_dict2 = {
-    addr=NIL,
-    complete=NIL,
-    complete_arg=NIL,
-    count=NIL,
-    definition='pwd',
-    name='Pwd',
-    nargs='?',
-    range=NIL,
-    script_id=0,
-  }
+  local cmd_dict  = { addr=NIL, bang=false, bar=false, complete=NIL, complete_arg=NIL, count=NIL, definition='echo "Hello World"', name='Hello', nargs='1', range=NIL, register=false, script_id=0, }
+  local cmd_dict2 = { addr=NIL, bang=false, bar=false, complete=NIL, complete_arg=NIL, count=NIL, definition='pwd',                name='Pwd',   nargs='?', range=NIL, register=false, script_id=0, }
   before_each(clear)
+
   it('gets empty list if no commands were defined', function()
     eq({}, meths.get_commands({builtin=false}))
   end)
+
   it('validates input', function()
     expect_err('builtin commands not supported yet', meths.get_commands,
                {builtin=true})
     expect_err('unexpected key: foo', meths.get_commands,
                {foo='blah'})
   end)
+
   it('gets global user-defined commands', function()
     -- Define a command.
     command('command -nargs=1 Hello echo "Hello World"')
@@ -53,6 +36,7 @@ describe('nvim_get_commands', function()
     command('delcommand Pwd')
     eq({cmd_dict}, meths.get_commands({builtin=false}))
   end)
+
   it('gets buffer-local user-defined commands', function()
     -- Define a buffer-local command.
     command('command -buffer -nargs=1 Hello echo "Hello World"')
@@ -64,34 +48,30 @@ describe('nvim_get_commands', function()
     command('delcommand Pwd')
     eq({cmd_dict}, curbufmeths.get_commands({builtin=false}))
   end)
-  it('gets different attributes of different commands', function()
-    local cmd1 = {
-      addr=NIL,
-      complete='custom',
-      complete_arg='ListUsers',
-      count=NIL,
-      definition='!finger <args>',
-      name='Finger',
-      nargs='+',
-      range=NIL,
-      script_id=1,
-    }
-    local cmd2 = {
-      addr='arguments',
-      complete='dir',
-      complete_arg=NIL,
-      count='10',
-      definition='pwd <args>',
-      name='TestCmd',
-      nargs='0',
-      range='10',
-      script_id=0,
-    }
+
+  it('gets various command attributes', function()
+    local cmd0 = { addr='arguments', bang=false, bar=false, complete='dir',    complete_arg=NIL,         count='10', definition='pwd <args>',                    name='TestCmd', nargs='0', range='10', register=false, script_id=0, }
+    local cmd1 = { addr=NIL,         bang=false, bar=false, complete='custom', complete_arg='ListUsers', count=NIL,  definition='!finger <args>',                name='Finger',  nargs='+', range=NIL,  register=false, script_id=1, }
+    local cmd2 = { addr=NIL,         bang=true,  bar=false, complete=NIL,      complete_arg=NIL,         count=NIL,  definition='call \128\253Q2_foo(<q-args>)', name='Cmd2',    nargs='*', range=NIL,  register=false, script_id=2, }
+    local cmd3 = { addr=NIL,         bang=false, bar=true,  complete=NIL,      complete_arg=NIL,         count=NIL,  definition='call \128\253Q3_ohyeah()',      name='Cmd3',    nargs='0', range=NIL,  register=false, script_id=3, }
+    local cmd4 = { addr=NIL,         bang=false, bar=false, complete=NIL,      complete_arg=NIL,         count=NIL,  definition='call \128\253Q4_just_great()',  name='Cmd4',    nargs='0', range=NIL,  register=true,  script_id=4, }
     source([[
       command -complete=custom,ListUsers -nargs=+ Finger !finger <args>
     ]])
     eq({cmd1}, meths.get_commands({builtin=false}))
     command('command -complete=dir -addr=arguments -count=10 TestCmd pwd <args>')
-    eq({cmd1, cmd2}, meths.get_commands({builtin=false}))
+    eq({cmd1, cmd0}, meths.get_commands({builtin=false}))
+
+    source([[
+      command -bang -nargs=* Cmd2 call <SID>foo(<q-args>)
+    ]])
+    source([[
+      command -bar -nargs=0 Cmd3 call <SID>ohyeah()
+    ]])
+    source([[
+      command -register Cmd4 call <SID>just_great()
+    ]])
+    -- TODO(justinmk): Order is stable but undefined. Sort before return?
+    eq({cmd2, cmd3, cmd4, cmd1, cmd0}, meths.get_commands({builtin=false}))
   end)
 end)

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -1,74 +1,97 @@
 local helpers = require('test.functional.helpers')(after_each)
 
+local NIL = helpers.NIL
 local clear = helpers.clear
 local command = helpers.command
 local curbufmeths = helpers.curbufmeths
 local eq = helpers.eq
+local expect_err = helpers.expect_err
 local meths = helpers.meths
+local source = helpers.source
 
 describe('nvim_get_commands', function()
-  local dummy_dict = {dummy=''}
-  local cmd_string = 'command Hello echo "Hello World"'
-  local cmd_string2 = 'command Pwd pwd'
   local cmd_dict = {
-    name='Hello',
-    nargs='0',
-    script_id=0,
+    addr=NIL,
+    complete=NIL,
+    complete_arg=NIL,
+    count=NIL,
     definition='echo "Hello World"',
+    name='Hello',
+    nargs='1',
+    range=NIL,
+    script_id=0,
   }
   local cmd_dict2 = {
-    name='Pwd',
-    nargs='0',
-    script_id=0,
+    addr=NIL,
+    complete=NIL,
+    complete_arg=NIL,
+    count=NIL,
     definition='pwd',
+    name='Pwd',
+    nargs='?',
+    range=NIL,
+    script_id=0,
   }
   before_each(clear)
   it('gets empty list if no commands were defined', function()
-    eq({}, meths.get_commands(dummy_dict))
+    eq({}, meths.get_commands({builtin=false}))
   end)
-  it('gets user-def commands', function()
-    -- Insert a command
-    command(cmd_string)
-    eq({cmd_dict}, meths.get_commands(dummy_dict))
-    -- Insert a another command
-    command(cmd_string2);
-    eq({cmd_dict, cmd_dict2}, meths.get_commands(dummy_dict))
-    -- Delete a command
-    command('delcommand Pwd')
-    eq({cmd_dict}, meths.get_commands(dummy_dict))
+  it('validates input', function()
+    expect_err('builtin commands not supported yet', meths.get_commands,
+               {builtin=true})
+    expect_err('unexpected key: foo', meths.get_commands,
+               {foo='blah'})
   end)
-  it('considers different buffers', function()
-    -- Insert a command
-    command('command -buffer Hello echo "Hello World"')
-    eq({cmd_dict}, curbufmeths.get_commands(dummy_dict))
-    -- Insert a another command
-    command('command -buffer Pwd pwd')
-    eq({cmd_dict, cmd_dict2}, curbufmeths.get_commands(dummy_dict))
-    -- Delete a command
+  it('gets global user-defined commands', function()
+    -- Define a command.
+    command('command -nargs=1 Hello echo "Hello World"')
+    eq({cmd_dict}, meths.get_commands({builtin=false}))
+    -- Define another command.
+    command('command -nargs=? Pwd pwd');
+    eq({cmd_dict, cmd_dict2}, meths.get_commands({builtin=false}))
+    -- Delete a command.
     command('delcommand Pwd')
-    eq({cmd_dict}, curbufmeths.get_commands(dummy_dict))
+    eq({cmd_dict}, meths.get_commands({builtin=false}))
+  end)
+  it('gets buffer-local user-defined commands', function()
+    -- Define a buffer-local command.
+    command('command -buffer -nargs=1 Hello echo "Hello World"')
+    eq({cmd_dict}, curbufmeths.get_commands({builtin=false}))
+    -- Define another buffer-local command.
+    command('command -buffer -nargs=? Pwd pwd')
+    eq({cmd_dict, cmd_dict2}, curbufmeths.get_commands({builtin=false}))
+    -- Delete a command.
+    command('delcommand Pwd')
+    eq({cmd_dict}, curbufmeths.get_commands({builtin=false}))
   end)
   it('gets different attributes of different commands', function()
     local cmd1 = {
+      addr=NIL,
       complete='custom',
-      nargs='1',
-      name='Finger',
-      script_id=0,
       complete_arg='ListUsers',
+      count=NIL,
       definition='!finger <args>',
+      name='Finger',
+      nargs='+',
+      range=NIL,
+      script_id=1,
     }
     local cmd2 = {
-      complete='dir',
-      nargs='0',
-      name='TestCmd',
-      range='10c',
       addr='arguments',
-      script_id=0,
+      complete='dir',
+      complete_arg=NIL,
+      count='10',
       definition='pwd <args>',
+      name='TestCmd',
+      nargs='0',
+      range='10',
+      script_id=0,
     }
-    command('command -complete=custom,ListUsers -nargs=1 Finger !finger <args>')
-    eq({cmd1}, meths.get_commands(dummy_dict))
+    source([[
+      command -complete=custom,ListUsers -nargs=+ Finger !finger <args>
+    ]])
+    eq({cmd1}, meths.get_commands({builtin=false}))
     command('command -complete=dir -addr=arguments -count=10 TestCmd pwd <args>')
-    eq({cmd1, cmd2}, meths.get_commands(dummy_dict))
+    eq({cmd1, cmd2}, meths.get_commands({builtin=false}))
   end)
 end)

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -28,25 +28,25 @@ describe('nvim_get_commands', function()
   it('gets global user-defined commands', function()
     -- Define a command.
     command('command -nargs=1 Hello echo "Hello World"')
-    eq({cmd_dict}, meths.get_commands({builtin=false}))
+    eq({Hello=cmd_dict}, meths.get_commands({builtin=false}))
     -- Define another command.
     command('command -nargs=? Pwd pwd');
-    eq({cmd_dict, cmd_dict2}, meths.get_commands({builtin=false}))
+    eq({Hello=cmd_dict, Pwd=cmd_dict2}, meths.get_commands({builtin=false}))
     -- Delete a command.
     command('delcommand Pwd')
-    eq({cmd_dict}, meths.get_commands({builtin=false}))
+    eq({Hello=cmd_dict}, meths.get_commands({builtin=false}))
   end)
 
   it('gets buffer-local user-defined commands', function()
     -- Define a buffer-local command.
     command('command -buffer -nargs=1 Hello echo "Hello World"')
-    eq({cmd_dict}, curbufmeths.get_commands({builtin=false}))
+    eq({Hello=cmd_dict}, curbufmeths.get_commands({builtin=false}))
     -- Define another buffer-local command.
     command('command -buffer -nargs=? Pwd pwd')
-    eq({cmd_dict, cmd_dict2}, curbufmeths.get_commands({builtin=false}))
+    eq({Hello=cmd_dict, Pwd=cmd_dict2}, curbufmeths.get_commands({builtin=false}))
     -- Delete a command.
     command('delcommand Pwd')
-    eq({cmd_dict}, curbufmeths.get_commands({builtin=false}))
+    eq({Hello=cmd_dict}, curbufmeths.get_commands({builtin=false}))
 
     -- {builtin=true} always returns empty for buffer-local case.
     eq({}, curbufmeths.get_commands({builtin=true}))
@@ -61,9 +61,9 @@ describe('nvim_get_commands', function()
     source([[
       command -complete=custom,ListUsers -nargs=+ Finger !finger <args>
     ]])
-    eq({cmd1}, meths.get_commands({builtin=false}))
+    eq({Finger=cmd1}, meths.get_commands({builtin=false}))
     command('command -complete=dir -addr=arguments -count=10 TestCmd pwd <args>')
-    eq({cmd1, cmd0}, meths.get_commands({builtin=false}))
+    eq({Finger=cmd1, TestCmd=cmd0}, meths.get_commands({builtin=false}))
 
     source([[
       command -bang -nargs=* Cmd2 call <SID>foo(<q-args>)
@@ -75,6 +75,6 @@ describe('nvim_get_commands', function()
       command -register Cmd4 call <SID>just_great()
     ]])
     -- TODO(justinmk): Order is stable but undefined. Sort before return?
-    eq({cmd2, cmd3, cmd4, cmd1, cmd0}, meths.get_commands({builtin=false}))
+    eq({Cmd2=cmd2, Cmd3=cmd3, Cmd4=cmd4, Finger=cmd1, TestCmd=cmd0}, meths.get_commands({builtin=false}))
   end)
 end)

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -11,7 +11,7 @@ local source = helpers.source
 
 local shallowcopy = global_helpers.shallowcopy
 
-describe('get_keymap', function()
+describe('nvim_get_keymap', function()
   before_each(clear)
 
   -- Basic mapping and table to be used to describe results


### PR DESCRIPTION
Rebase #8060 with some changes:

- Always return all keys, with at least NIL value.
- Require `opts` param to be `{"builtin":false}`
- Validate `opts` param
- Support more attributes: `-bang`, `-bar`, `-register`

closes #7833
ref #8029