### PR TITLE
[RFC] test: win: enable  remaining functional tests

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -38,15 +38,18 @@ if ($compiler -eq 'MINGW') {
   # These are native MinGW builds, but they use the toolchain inside
   # MSYS2, this allows using all the dependencies and tools available
   # in MSYS2, but we cannot build inside the MSYS2 shell.
-  $cmakeGenerator = 'MinGW Makefiles'
-  $cmakeGeneratorArgs = 'VERBOSE=1'
+  $cmakeGenerator = 'Ninja'
+  $cmakeGeneratorArgs = '-v'
+  $mingwPackages = @('ninja', 'cmake', 'perl', 'diffutils', 'unibilium').ForEach({
+    "mingw-w64-$arch-$_"
+  })
 
   # Add MinGW to the PATH
   $env:PATH = "C:\msys64\mingw$bits\bin;$env:PATH"
 
   # Build third-party dependencies
   C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm -Su" ; exitIfFailed
-  C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm --needed -S mingw-w64-$arch-cmake mingw-w64-$arch-perl mingw-w64-$arch-diffutils mingw-w64-$arch-unibilium" ; exitIfFailed
+  C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm --needed -S $mingwPackages" ; exitIfFailed
 }
 elseif ($compiler -eq 'MSVC') {
   $cmakeGeneratorArgs = '/verbosity:normal'
@@ -57,9 +60,6 @@ elseif ($compiler -eq 'MSVC') {
     $cmakeGenerator = 'Visual Studio 15 2017 Win64'
   }
 }
-
-# Remove Git Unix utilities from the PATH
-$env:PATH = $env:PATH.Replace('C:\Program Files\Git\usr\bin', '')
 
 # Setup python (use AppVeyor system python)
 C:\Python27\python.exe -m pip install neovim ; exitIfFailed

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -1,4 +1,5 @@
-Set-PSDebug -Trace 1
+$ErrorActionPreference = 'stop'
+Set-PSDebug -Strict -Trace 1
 
 $env:CONFIGURATION -match '^(?<compiler>\w+)_(?<bits>32|64)(?:-(?<option>\w+))?$'
 $compiler = $Matches.compiler
@@ -12,6 +13,7 @@ $nvimCmakeVars = @{
   CMAKE_BUILD_TYPE = $cmakeBuildType;
   BUSTED_OUTPUT_TYPE = 'nvim';
 }
+$uploadToCodeCov = $false
 
 # For pull requests, skip some build configurations to save time.
 if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $env:CONFIGURATION -match '^(MSVC_64|MINGW_32|MINGW_64-gcov)$') {
@@ -20,6 +22,7 @@ if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $env:CONFIGURATION -match '^(MSV
 
 function exitIfFailed() {
   if ($LastExitCode -ne 0) {
+    Set-PSDebug -Off
     exit $LastExitCode
   }
 }
@@ -72,18 +75,20 @@ python  -c "import neovim; print(str(neovim))" ; exitIfFailed
 python3 -c "import neovim; print(str(neovim))" ; exitIfFailed
 
 $env:PATH = "C:\Ruby24\bin;$env:PATH"
-cmd /c gem.cmd install neovim ; exitIfFailed
-where.exe neovim-ruby-host.bat ; exitIfFailed
+gem.cmd install neovim
+Get-Command -CommandType Application neovim-ruby-host.bat
 
-cmd /c npm.cmd install -g neovim ; exitIfFailed
-where.exe neovim-node-host.cmd ; exitIfFailed
-cmd /c npm link neovim
+npm.cmd install -g neovim
+Get-Command -CommandType Application neovim-node-host.cmd
+npm.cmd link neovim
 
 function convertToCmakeArgs($vars) {
   return $vars.GetEnumerator() | foreach { "-D$($_.Key)=$($_.Value)" }
 }
 
-mkdir .deps
+if (-Not (Test-Path -PathType container .deps)) {
+  mkdir .deps
+}
 cd .deps
 cmake -G $cmakeGenerator $(convertToCmakeArgs($depsCmakeVars)) ..\third-party\ ; exitIfFailed
 cmake --build . --config $cmakeBuildType -- $cmakeGeneratorArgs ; exitIfFailed
@@ -104,10 +109,10 @@ Set-PSDebug -Off
 cmake --build . --config $cmakeBuildType --target functionaltest -- $cmakeGeneratorArgs 2>&1 |
   foreach { $failed = $failed -or
     $_ -match 'functional tests failed with error'; $_ }
-Set-PSDebug -Trace 1
 if ($failed) {
   exit $LastExitCode
 }
+Set-PSDebug -Strict -Trace 1
 
 
 if ($uploadToCodecov) {

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -538,10 +538,6 @@ describe('API: buffer events:', function()
   end)
 
   it('works with :diffput and :diffget', function()
-    if os.getenv("APPVEYOR") then
-      pending("Fails on appveyor for some reason.", function() end)
-    end
-
     local b1, tick1 = editoriginal(true, {"AAA", "BBB"})
     local channel = nvim('get_api_info')[1]
     command('diffthis')

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -841,10 +841,6 @@ describe('API', function()
     end)
 
     it('works for job channel', function()
-      if iswin() and os.getenv('APPVEYOR') ~= nil then
-        pending("jobstart(['cat']) unreliable on appveyor")
-        return
-      end
       eq(3, eval("jobstart(['cat'], {'rpc': v:true})"))
       local info = {
         stream='job',

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -192,7 +192,6 @@ describe('channels', function()
   end)
 
   it('can use buffered output mode', function()
-    if helpers.pending_win32(pending) then return end
     source([[
       let g:job_opts = {
       \ 'on_stdout': function('OnEvent'),
@@ -225,7 +224,6 @@ describe('channels', function()
   end)
 
   it('can use buffered output mode with no stream callback', function()
-    if helpers.pending_win32(pending) then return end
     source([[
       function! OnEvent(id, data, event) dict
         call rpcnotify(1, a:event, a:id, a:data, self.stdout)

--- a/test/functional/legacy/011_autocommands_spec.lua
+++ b/test/functional/legacy/011_autocommands_spec.lua
@@ -143,7 +143,6 @@ describe('file reading, writing and bufnew and filter autocommands', function()
   end)
 
   it('FilterReadPre, FilterReadPost', function()
-    if helpers.pending_win32(pending) then return end
     -- Write a special input file for this test block.
     write_file('test.out', dedent([[
       startstart

--- a/test/functional/legacy/011_autocommands_spec.lua
+++ b/test/functional/legacy/011_autocommands_spec.lua
@@ -18,6 +18,7 @@ local clear, feed_command, expect, eq, neq, dedent, write_file, feed =
   helpers.clear, helpers.feed_command, helpers.expect, helpers.eq, helpers.neq,
   helpers.dedent, helpers.write_file, helpers.feed
 local iswin = helpers.iswin
+local read_file = helpers.read_file
 
 local function has_gzip()
   local null = iswin() and 'nul' or '/dev/null'
@@ -60,7 +61,7 @@ describe('file reading, writing and bufnew and filter autocommands', function()
     os.remove('test.out')
   end)
 
-  if iswin() or not has_gzip() then
+  if not has_gzip() then
     pending('skipped (missing `gzip` utility)', function() end)
   else
 
@@ -77,7 +78,7 @@ describe('file reading, writing and bufnew and filter autocommands', function()
 
     it('BufReadPre, BufReadPost (using gzip)', function()
       prepare_gz_file('Xtestfile', text1)
-      local gzip_data = io.open('Xtestfile.gz'):read('*all')
+      local gzip_data = read_file('Xtestfile.gz')
       feed_command('let $GZIP = ""')
       -- Setup autocommands to decompress before reading and re-compress afterwards.
       feed_command("au BufReadPre   *.gz  exe '!gzip -d ' . shellescape(expand('<afile>'))")
@@ -91,7 +92,7 @@ describe('file reading, writing and bufnew and filter autocommands', function()
       -- Expect the decompressed file in the buffer.
       expect(text1)
       -- Expect the original file to be unchanged.
-      eq(gzip_data, io.open('Xtestfile.gz'):read('*all'))
+      eq(gzip_data, read_file('Xtestfile.gz'))
     end)
 
     -- luacheck: ignore 621 (Indentation)

--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -2301,7 +2301,6 @@ describe('plugin/shada.vim', function()
 
   describe('event FileWriteCmd', function()
     it('works', function()
-      if helpers.pending_win32(pending) then return end
       nvim('set_var', 'shada#add_own_header', 0)
       curbuf('set_lines', 0, 1, true, {
         'Jump with timestamp ' .. epoch .. ':',


### PR DESCRIPTION
#I'm using this PR to test assumptions for my vimrc and Appveyor environment. This will be similar to https://github.com/neovim/neovim/pull/7412 so expect frequent rebasing. I don't expect this to be merged for the 0.3 release.

Enable the following:
- tests that use `shelltemp`, `shellpipe`, and related autocmd events and features (ie `+quickfix`).
- tests disabled in https://github.com/neovim/neovim/commit/438f2b64747da04875f65eb5a3497cc6e55fa078
  - requires Ninja for Cmake Generator so that gzip (git-for-windows) is available

Thoughts/Wishlist for future releases (not included in this PR):
- backward-compatible `shellescape` that supports powershell
   - user can specify `shell` to determine how the command token is escaped or ommit to use `&shell`
   - based on `fzf#shellescape` (https://github.com/junegunn/fzf) or my version in https://github.com/janlazo/dotvim8/blob/master/autoload/dotvim8.vim
   - intended for Windows to avoid `shellslash` which affects other functions (ie. `fnamemodify`) and discourage plugins authors to reinvent their `shellescape` which is likely for cmd.exe only and doesn't consider edge cases