### PR TITLE
[RFC] always run timer close callback after due callback

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17039,7 +17039,8 @@ static void timer_stop(timer_T *timer)
   time_watcher_close(&timer->tw, timer_close_cb);
 }
 
-// invoked on next event loop tick, so queue is empty
+// This will be run on the main loop after the last timer_due_cb, so at this
+// point it is safe to free the callback.
 static void timer_close_cb(TimeWatcher *tw, void *data)
 {
   timer_T *timer = (timer_T *)data;

--- a/src/nvim/event/time.c
+++ b/src/nvim/event/time.c
@@ -61,10 +61,17 @@ static void time_watcher_cb(uv_timer_t *handle)
   CREATE_EVENT(watcher->events, time_event, 1, watcher);
 }
 
+static void close_event(void **argv)
+{
+  TimeWatcher *watcher = argv[0];
+  watcher->close_cb(watcher, watcher->data);
+}
+
 static void close_cb(uv_handle_t *handle)
+  FUNC_ATTR_NONNULL_ALL
 {
   TimeWatcher *watcher = handle->data;
   if (watcher->close_cb) {
-    watcher->close_cb(watcher, watcher->data);
+    CREATE_EVENT(watcher->events, close_event, 1, watcher);
   }
 }


### PR DESCRIPTION
fixes #6974, at least it seems after some minutes of manual testing. Unfortunately I haven't managed to prouduce any somewhat-deterministic test case (which I thought would be quite easy with ASAN which should turn the use-after-free into an immediate error)