### PR TITLE
[RFC] vim-patch:8.0.0454

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1018,7 +1018,7 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
   // needs a break here
   if (wp->w_p_lbr
       && vim_isbreak(c)
-      && !vim_isbreak(s[1])
+      && !vim_isbreak((int)s[1])
       && wp->w_p_wrap
       && (wp->w_width != 0)) {
     // Count all characters from first non-blank after a blank up to next
@@ -1042,7 +1042,7 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
       c = *s;
 
       if (!(c != NUL
-            && (vim_isbreak(c) || col2 == col || !vim_isbreak(*ps)))) {
+            && (vim_isbreak(c) || col2 == col || !vim_isbreak((int)(*ps))))) {
         break;
       }
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3454,7 +3454,8 @@ win_line (
         }
 
         // Found last space before word: check for line break.
-        if (wp->w_p_lbr && c0 == c && vim_isbreak(c) && !vim_isbreak(*ptr)) {
+        if (wp->w_p_lbr && c0 == c && vim_isbreak(c)
+            && !vim_isbreak((int)(*ptr))) {
           int mb_off = has_mbyte ? (*mb_head_off)(line, ptr - 1) : 0;
           char_u *p = ptr - (mb_off + 1);
           // TODO: is passing p for start of the line OK?


### PR DESCRIPTION
#### vim-patch:8.0.0454: compiler warnings for "always true" comparison

Problem:    Compiler warnings for comparing unsigned char with 256 always
            being true. (Manuel Ortega)
Solution:   Add type cast.
https://github.com/vim/vim/commit/977d03733601948ab334fec24d0da82bc18c57c3