### PR TITLE
[RFC] vim-patch:8.0.0503

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2445,7 +2445,7 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *gap, int level,
   if (lvl < level) {
     /* End of fold found, update the length when it got shorter. */
     if (fp->fd_len != flp->lnum - fp->fd_top) {
-      if (fp->fd_top + fp->fd_len > bot + 1) {
+      if (fp->fd_top + fp->fd_len - 1 > bot) {
         /* fold continued below bot */
         if (getlevel == foldlevelMarker
             || getlevel == foldlevelExpr


### PR DESCRIPTION
**vim-patch:8.0.0503: endless loop in updating folds with 32 bit ints**

Problem:    Endless loop in updating folds with 32 bit ints.
Solution:   Subtract from LHS instead of add to the RHS. (Matthew Malcomson)
[vim/vim@9d20ce6](https://github.com/vim/vim/commit/9d20ce6970158de69202a82529d9e97827a9e71b)