### PR TITLE
[RFC] vim-patch:8.0.0505

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2404,11 +2404,14 @@ jumpto_tag (
     }
   }
 
-  /* If it was a CTRL-W CTRL-] command split window now.  For ":tab tag"
-   * open a new tab page. */
+  // If it was a CTRL-W CTRL-] command split window now.  For ":tab tag"
+  // open a new tab page.
   if (postponed_split || cmdmod.tab != 0) {
-    (void)win_split(postponed_split > 0 ? postponed_split : 0,
-                    postponed_split_flags);
+    if (win_split(postponed_split > 0 ? postponed_split : 0,
+                  postponed_split_flags) == FAIL) {
+      RedrawingDisabled--;
+      goto erret;
+    }
     RESET_BINDING(curwin);
   }
 


### PR DESCRIPTION
#### vim-patch:8.0.0505: failed window split for :stag not handled

Problem:    Failed window split for :stag not handled. (Coverity CID 99204)
Solution:   If the split fails skip to the end. (bstaletic, closes vim/vim#1577)
https://github.com/vim/vim/commit/ba6ad17378ddb9b33412d85174224997b8ff7a4f