### PR TITLE
[RFC] vim-patch:8.0.0507,vim-patch:8.0.0511

### DIFF
--- a/src/nvim/testdir/test_quotestar.vim
+++ b/src/nvim/testdir/test_quotestar.vim
@@ -39,6 +39,15 @@ func Do_test_quotestar_for_x11()
   if cmd == ''
     return 'GetVimCommand() failed'
   endif
+  try
+    call remote_send('xxx', '')
+  catch
+    if v:exception =~ 'E240:'
+      " No connection to the X server, give up.
+      return
+    endif
+    " ignore other errors
+  endtry
 
   let name = 'XVIMCLIPBOARD'
   let cmd .= ' --servername ' . name

--- a/src/nvim/testdir/test_quotestar.vim
+++ b/src/nvim/testdir/test_quotestar.vim
@@ -118,8 +118,12 @@ func Test_quotestar()
 
   if has('macunix')
     let skipped = Do_test_quotestar_for_macunix()
-  elseif !empty("$DISPLAY")
-    let skipped = Do_test_quotestar_for_x11()
+  elseif has('x11')
+    if empty($DISPLAY)
+      let skipped = "Test can only run when $DISPLAY is set."
+    else
+      let skipped = Do_test_quotestar_for_x11()
+    endif
   else
     let skipped = "Test is not implemented yet for this platform."
   endif


### PR DESCRIPTION
#### vim-patch:8.0.0507: client-server tests fail when $DISPLAY is not set

Problem:    Client-server tests fail when $DISPLAY is not set.
Solution:   Check for E240 before running the test.
https://github.com/vim/vim/commit/a2845b8f5a3058c8c89699771ffd4d69513b097d


#### vim-patch:8.0.0511: message for skipping client-server tests is unclear

Problem:    Menuage for skipping client-server tests is unclear.
Solution:   Be more specific about what's missing (Hirohito Higashi, Kazunob Kuriyama)                                                                          
https://github.com/vim/vim/commit/a683ec44c34f0717dcc6a0c03493ba39b879ac38
