### PR TITLE
[RFC] vim-patch:8.0.0515

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8104,6 +8104,7 @@ static void ex_normal(exarg_T *eap)
       if (eap->addr_count != 0) {
         curwin->w_cursor.lnum = eap->line1++;
         curwin->w_cursor.col = 0;
+        check_cursor_moved(curwin);
       }
 
       exec_normal_cmd(

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2443,27 +2443,27 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *gap, int level,
       flp->lnum - 1 - fp->fd_top);
 
   if (lvl < level) {
-    /* End of fold found, update the length when it got shorter. */
+    // End of fold found, update the length when it got shorter.
     if (fp->fd_len != flp->lnum - fp->fd_top) {
       if (fp->fd_top + fp->fd_len - 1 > bot) {
-        /* fold continued below bot */
+        // fold continued below bot
         if (getlevel == foldlevelMarker
             || getlevel == foldlevelExpr
             || getlevel == foldlevelSyntax) {
-          /* marker method: truncate the fold and make sure the
-           * previously included lines are processed again */
+          // marker method: truncate the fold and make sure the
+          // previously included lines are processed again
           bot = fp->fd_top + fp->fd_len - 1;
           fp->fd_len = flp->lnum - fp->fd_top;
         } else {
-          /* indent or expr method: split fold to create a new one
-           * below bot */
+          // indent or expr method: split fold to create a new one
+          // below bot
           i = (int)(fp - (fold_T *)gap->ga_data);
           foldSplit(gap, i, flp->lnum, bot);
           fp = (fold_T *)gap->ga_data + i;
         }
       } else
         fp->fd_len = flp->lnum - fp->fd_top;
-      fold_changed = TRUE;
+      fold_changed = true;
     }
   }
 

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -132,11 +132,9 @@ void update_topline(void)
   bool check_botline = false;
   long save_so = p_so;
 
-  if (!screen_valid(true))
-    return;
-
-  // If the window height is zero, just use the cursor line.
-  if (curwin->w_height == 0) {
+  // If there is no valid screen and when the window height is zero just use
+  // the cursor line.
+  if (!screen_valid(true) || curwin->w_height == 0) {
     curwin->w_topline = curwin->w_cursor.lnum;
     curwin->w_botline = curwin->w_topline;
     curwin->w_valid |= VALID_BOTLINE|VALID_BOTLINE_AP;
@@ -1979,6 +1977,7 @@ void halfpage(bool flag, linenr_T Prenum)
   int n = curwin->w_p_scr <= curwin->w_height ? (int)curwin->w_p_scr
                                               : curwin->w_height;
 
+  update_topline();
   validate_botline();
   int room = curwin->w_empty_rows + curwin->w_filler_rows;
   if (flag) {

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -240,3 +240,14 @@ func Test_progpath()
   " Only expect "vim" to appear in v:progname.
   call assert_match('vim\c', v:progname)
 endfunc
+
+func Test_silent_ex_mode()
+  if !has('unix') || has('gui_running')
+    " can't get output of Vim.
+    return
+  endif
+
+  " This caused an ml_get error.
+  let out = system(GetVimCommand() . '-u NONE -es -c''set verbose=1|h|exe "%norm\<c-y>\<c-d>"'' -c cq')
+  call assert_notmatch('E315:', out)
+endfunc


### PR DESCRIPTION
#### vim-patch:8.0.0515: ml_get errors in silent Ex mode

Problem:    ml_get errors in silent Ex mode. (Dominique Pelle)
Solution:   Clear valid flags when setting the cursor.  Set the topline when
            not in full screen mode.
https://github.com/vim/vim/commit/d5d37537d1fa46fd468bd378af2006dd09840f38