### PR TITLE
[RFC] Close wildmenu before redrawing statusline

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -641,6 +641,7 @@ static int command_line_execute(VimState *state, int key)
         save_p_ls = -1;
       } else {
         win_redraw_last_status(topframe);
+        wild_menu_showing = 0;  // must be before redraw_statuslines #8385
         redraw_statuslines();
       }
       KeyTyped = skt;

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -31,9 +31,9 @@ describe("'wildmenu'", function()
     ]])
   end)
 
-  it(':sign <tab> <space> hides wildmenu, selects design, when laststatus=2 #8453', function()
+  it(':sign <tab> <space> hides wildmenu #8453', function()
     command('set wildmode=full')
-    -- only a regression if laststatus=2
+    -- only a regression if status-line open
     command('set laststatus=2')
     command('set wildmenu')
     feed(':sign <tab> ')

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -31,6 +31,21 @@ describe("'wildmenu'", function()
     ]])
   end)
 
+  it(':sign <tab> <space> hides wildmenu, selects design, when laststatus=2 #8453', function()
+    command('set wildmode=full')
+    -- only a regression if laststatus=2
+    command('set laststatus=2')
+    command('set wildmenu')
+    feed(':sign <tab> ')
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+      [No Name]                |
+      :sign define ^            |
+    ]])
+  end)
+
   it('does not crash after cycling back to original text', function()
     command('set wildmode=full')
     feed(':j<Tab><Tab><Tab>')

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -36,7 +36,15 @@ describe("'wildmenu'", function()
     -- only a regression if status-line open
     command('set laststatus=2')
     command('set wildmenu')
-    feed(':sign <tab> ')
+    feed(':sign <tab>')
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+      define  jump  list  >    |
+      :sign define^             |
+    ]])
+    feed('<space>')
     screen:expect([[
                                |
       ~                        |


### PR DESCRIPTION
Hello! First time opening a PR here! I have a simple change that will hopefully fix #8385.

## Description

I found that in `ex_getln.c`, when a character not used by the wildmenu is pressed (not <TAB>, CTRL-P, etc) the check to close the wildmenu is already in the code at line 620.

The bug is that `redraw_statuslines()` is called before the global `wild_menu_showing` is set to 0.

`redraw_statuslines`(screen.c) calls `win_redr_status` (screen.c) which will return early if `wild_menu_showing != 0`. Thus without the one line commit I posted, the status line is not redrawn, causing the issue.

By simply setting `wild_menu_showing = 0` prior to calling `redraw_statuslines`, the issue seems to be fixed (I am no longer able to reproduce).

---

This all said, I'm new to the code base and I'm not 100% confident this will fix all cases! I'd love any input and help / feedback!

Thank you!
