### PR TITLE
[RDY] vim-patch:8.0.0321,8.0.1232

### DIFF
--- a/runtime/mswin.vim
+++ b/runtime/mswin.vim
@@ -1,7 +1,7 @@
 " Set options and add mapping such that Vim behaves a lot like MS-Windows
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last change:	2012 Jul 25
+" Last change:	2017 Feb 09
 
 " bail out if this isn't wanted (mrsvim.vim uses this).
 if exists("g:skip_loading_mswin") && g:skip_loading_mswin
@@ -23,20 +23,22 @@ set backspace=indent,eol,start whichwrap+=<,>,[,]
 " backspace in Visual mode deletes selection
 vnoremap <BS> d
 
-" CTRL-X and SHIFT-Del are Cut
-vnoremap <C-X> "+x
-vnoremap <S-Del> "+x
+if has("clipboard")
+    " CTRL-X and SHIFT-Del are Cut
+    vnoremap <C-X> "+x
+    vnoremap <S-Del> "+x
 
-" CTRL-C and CTRL-Insert are Copy
-vnoremap <C-C> "+y
-vnoremap <C-Insert> "+y
+    " CTRL-C and CTRL-Insert are Copy
+    vnoremap <C-C> "+y
+    vnoremap <C-Insert> "+y
 
-" CTRL-V and SHIFT-Insert are Paste
-map <C-V>		"+gP
-map <S-Insert>		"+gP
+    " CTRL-V and SHIFT-Insert are Paste
+    map <C-V>		"+gP
+    map <S-Insert>		"+gP
 
-cmap <C-V>		<C-R>+
-cmap <S-Insert>		<C-R>+
+    cmap <C-V>		<C-R>+
+    cmap <S-Insert>		<C-R>+
+endif
 
 " Pasting blockwise and linewise selections is not possible in Insert and
 " Visual mode without the +virtualedit feature.  They are pasted as if they
@@ -44,8 +46,10 @@ cmap <S-Insert>		<C-R>+
 " Uses the paste.vim autoload script.
 " Use CTRL-G u to have CTRL-Z only undo the paste.
 
-exe 'inoremap <script> <C-V> <C-G>u' . paste#paste_cmd['i']
-exe 'vnoremap <script> <C-V> ' . paste#paste_cmd['v']
+if 1
+    exe 'inoremap <script> <C-V> <C-G>u' . paste#paste_cmd['i']
+    exe 'vnoremap <script> <C-V> ' . paste#paste_cmd['v']
+endif
 
 imap <S-Insert>		<C-V>
 vmap <S-Insert>		<C-V>
@@ -98,6 +102,18 @@ noremap <C-F4> <C-W>c
 inoremap <C-F4> <C-O><C-W>c
 cnoremap <C-F4> <C-C><C-W>c
 onoremap <C-F4> <C-C><C-W>c
+
+if has("gui")
+  " CTRL-F is the search dialog
+  noremap <C-F> :promptfind<CR>
+  inoremap <C-F> <C-\><C-O>:promptfind<CR>
+  cnoremap <C-F> <C-\><C-C>:promptfind<CR>
+
+  " CTRL-H is the replace dialog
+  noremap <C-H> :promptrepl<CR>
+  inoremap <C-H> <C-\><C-O>:promptrepl<CR>
+  cnoremap <C-H> <C-\><C-C>:promptrepl<CR>
+endif
 
 " restore 'cpoptions'
 set cpo&

--- a/runtime/mswin.vim
+++ b/runtime/mswin.vim
@@ -1,7 +1,7 @@
 " Set options and add mapping such that Vim behaves a lot like MS-Windows
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last change:	2017 Feb 09
+" Last change:	2017 Oct 28
 
 " bail out if this isn't wanted (mrsvim.vim uses this).
 if exists("g:skip_loading_mswin") && g:skip_loading_mswin
@@ -105,14 +105,15 @@ onoremap <C-F4> <C-C><C-W>c
 
 if has("gui")
   " CTRL-F is the search dialog
-  noremap <C-F> :promptfind<CR>
-  inoremap <C-F> <C-\><C-O>:promptfind<CR>
-  cnoremap <C-F> <C-\><C-C>:promptfind<CR>
+  noremap  <expr> <C-F> has("gui_running") ? ":promptfind\<CR>" : "/"
+  inoremap <expr> <C-F> has("gui_running") ? "\<C-\>\<C-O>:promptfind\<CR>" : "\<C-\>\<C-O>/"
+  cnoremap <expr> <C-F> has("gui_running") ? "\<C-\>\<C-C>:promptfind\<CR>" : "\<C-\>\<C-O>/"
 
-  " CTRL-H is the replace dialog
-  noremap <C-H> :promptrepl<CR>
-  inoremap <C-H> <C-\><C-O>:promptrepl<CR>
-  cnoremap <C-H> <C-\><C-C>:promptrepl<CR>
+  " CTRL-H is the replace dialog,
+  " but in console, it might be backspace, so don't map it there
+  nnoremap <expr> <C-H> has("gui_running") ? ":promptrepl\<CR>" : "\<C-H>"
+  inoremap <expr> <C-H> has("gui_running") ? "\<C-\>\<C-O>:promptrepl\<CR>" : "\<C-H>"
+  cnoremap <expr> <C-H> has("gui_running") ? "\<C-\>\<C-C>:promptrepl\<CR>" : "\<C-H>"
 endif
 
 " restore 'cpoptions'


### PR DESCRIPTION
 **vim-patch:8.0.0321: errors when trying to use scripts in tiny version**

Problem:    When using the tiny version trying to load the matchit plugin
            gives an error. On MS-Windows some default mappings fail.
Solution:   Add a check if the command used is available. (Christian Brabandt)
vim/vim@8cc2a9c

 **vim-patch:8.0.1232: MS-Windows users are confused about default mappings**

Problem:    MS-Windows users are confused about default mappings.
Solution:   Don't map keys in the console where they don't work.  Add a choice
            in the installer to use MS-Windows key bindings or not. (Christian
            Brabandt, Ken Takata, closes vim/vim#2093)
vim/vim@c3fdf7f