### PR TITLE
[RFC] nvim_list_uis: include channel id

### DIFF
--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -97,6 +97,7 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
   ui->set_icon = remote_ui_set_icon;
   ui->option_set = remote_ui_option_set;
   ui->event = remote_ui_event;
+  ui->inspect = remote_ui_inspect;
 
   memset(ui->ui_ext, 0, sizeof(ui->ui_ext));
 
@@ -274,4 +275,10 @@ static void remote_ui_event(UI *ui, char *name, Array args, bool *args_consumed)
     *args_consumed = true;
   }
   push_call(ui, name, my_args);
+}
+
+static void remote_ui_inspect(UI *ui, Dictionary *info)
+{
+  UIData *data = ui->data;
+  PUT(*info, "chan", INTEGER_OBJ((Integer)data->channel_id));
 }

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -62,7 +62,7 @@ void set_title(String title)
 void set_icon(String icon)
   FUNC_API_SINCE(3);
 void option_set(String name, Object value)
-  FUNC_API_SINCE(4);
+  FUNC_API_SINCE(4) FUNC_API_BRIDGE_IMPL;
 
 void popupmenu_show(Array items, Integer selected, Integer row, Integer col)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1747,6 +1747,14 @@ Dictionary nvim__stats(void)
 /// Gets a list of dictionaries representing attached UIs.
 ///
 /// @return Array of UI dictionaries
+///
+/// Each dictionary has the following keys:
+///     - "height"  requested height of the UI
+///     - "width"   requested width of the UI
+///     - "rgb"     whether the UI uses rgb colors (false implies cterm colors)
+///     - "ext_..." Requested UI extensions, see |ui-options|
+///     - "chan"    Channel id of remote UI (not present for TUI)
+///
 Array nvim_list_uis(void)
   FUNC_API_SINCE(4)
 {

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1172,16 +1172,7 @@ static void tui_option_set(UI *ui, String name, Object value)
   if (strequal(name.data, "termguicolors")) {
     ui->rgb = value.data.boolean;
     invalidate(ui, 0, data->grid.height-1, 0, data->grid.width-1);
-    loop_schedule(&main_loop, event_create(termguicolors_set_event,
-                                           2, ui, (void *)ui->rgb));
   }
-}
-
-static void termguicolors_set_event(void **argv)
-{
-  UI *ui = argv[0];
-  TUIData *data = ui->data;
-  data->bridge->bridge.rgb = (Boolean)argv[1];
 }
 
 static void invalidate(UI *ui, int top, int bot, int left, int right)

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1172,7 +1172,16 @@ static void tui_option_set(UI *ui, String name, Object value)
   if (strequal(name.data, "termguicolors")) {
     ui->rgb = value.data.boolean;
     invalidate(ui, 0, data->grid.height-1, 0, data->grid.width-1);
+    loop_schedule(&main_loop, event_create(termguicolors_set_event,
+                                           2, ui, (void *)ui->rgb));
   }
+}
+
+static void termguicolors_set_event(void **argv)
+{
+  UI *ui = argv[0];
+  TUIData *data = ui->data;
+  data->bridge->bridge.rgb = (Boolean)argv[1];
 }
 
 static void invalidate(UI *ui, int top, int bot, int left, int right)

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -535,14 +535,18 @@ Array ui_array(void)
 {
   Array all_uis = ARRAY_DICT_INIT;
   for (size_t i = 0; i < ui_count; i++) {
-    Dictionary dic = ARRAY_DICT_INIT;
-    PUT(dic, "width", INTEGER_OBJ(uis[i]->width));
-    PUT(dic, "height", INTEGER_OBJ(uis[i]->height));
-    PUT(dic, "rgb", BOOLEAN_OBJ(uis[i]->rgb));
+    UI *ui = uis[i];
+    Dictionary info = ARRAY_DICT_INIT;
+    PUT(info, "width", INTEGER_OBJ(ui->width));
+    PUT(info, "height", INTEGER_OBJ(ui->height));
+    PUT(info, "rgb", BOOLEAN_OBJ(ui->rgb));
     for (UIExtension j = 0; j < kUIExtCount; j++) {
-      PUT(dic, ui_ext_names[j], BOOLEAN_OBJ(uis[i]->ui_ext[j]));
+      PUT(info, ui_ext_names[j], BOOLEAN_OBJ(ui->ui_ext[j]));
     }
-    ADD(all_uis, DICTIONARY_OBJ(dic));
+    if (ui->inspect) {
+      ui->inspect(ui, &info);
+    }
+    ADD(all_uis, DICTIONARY_OBJ(info));
   }
   return all_uis;
 }

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -36,6 +36,7 @@ struct ui_t {
 #endif
   void (*event)(UI *ui, char *name, Array args, bool *args_consumed);
   void (*stop)(UI *ui);
+  void (*inspect)(UI *ui, Dictionary *info);
 };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1226,6 +1226,7 @@ describe('api', function()
       screen:attach()
       local expected = {
         {
+          chan = 1,
           ext_cmdline = false,
           ext_popupmenu = false,
           ext_tabline = false,
@@ -1242,6 +1243,7 @@ describe('api', function()
       screen:attach({ rgb = false })
       expected = {
         {
+          chan = 1,
           ext_cmdline = false,
           ext_popupmenu = false,
           ext_tabline = false,

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -253,6 +253,19 @@ describe('tui', function()
       {4:-- TERMINAL --}                                    |
     ]])
   end)
+
+  it('shows up in nvim_list_uis', function()
+    feed_data(':echo map(nvim_list_uis(), {k,v -> sort(items(v))})\013')
+    screen:expect([=[
+      {5:                                                  }|
+      [[['ext_cmdline', v:false], ['ext_popupmenu', v:fa|
+      lse], ['ext_tabline', v:false], ['ext_wildmenu', v|
+      :false], ['height', 6], ['rgb', v:false], ['width'|
+      , 50]]]                                           |
+      {10:Press ENTER or type command to continue}{1: }          |
+      {3:-- TERMINAL --}                                    |
+    ]=])
+  end)
 end)
 
 describe('tui with non-tty file descriptors', function()


### PR DESCRIPTION
Some minor fixes for `nvim_list_uis()`

- Currently there is no way to tell what channel is associated with what UI in the list. (lack of channel also implicitly identifies TUI, though we could add "term" key)
- Docs for `nvim_list_uis()` are a bit lacking
- `nvim_list_uis()[0].rgb` didn't reflect changes to `termguicolors` when using TUI.

Nominating for 0.3, ping @justinmk.