### PR TITLE
[RFC] vim-patch:8.0.0516

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -745,11 +745,9 @@ EXTERN int State INIT(= NORMAL);        /* This is the current state of the
 EXTERN bool finish_op INIT(= false);    // true while an operator is pending
 EXTERN long opcount INIT(= 0);          // count for pending operator
 
-/*
- * ex mode (Q) state
- */
-EXTERN int exmode_active INIT(= 0);     /* zero, EXMODE_NORMAL or EXMODE_VIM */
-EXTERN int ex_no_reprint INIT(= FALSE); /* no need to print after z or p */
+// EX Mode (Q) state
+EXTERN int exmode_active INIT(= 0);     // zero, EXMODE_NORMAL or EXMODE_VIM
+EXTERN int ex_no_reprint INIT(= false);  // no need to print after z or p
 
 EXTERN int Recording INIT(= FALSE);     /* TRUE when recording into a reg. */
 EXTERN int Exec_reg INIT(= FALSE);      /* TRUE when executing a register */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -745,7 +745,7 @@ EXTERN int State INIT(= NORMAL);        /* This is the current state of the
 EXTERN bool finish_op INIT(= false);    // true while an operator is pending
 EXTERN long opcount INIT(= 0);          // count for pending operator
 
-// EX Mode (Q) state
+// Ex Mode (Q) state
 EXTERN int exmode_active INIT(= 0);     // zero, EXMODE_NORMAL or EXMODE_VIM
 EXTERN int ex_no_reprint INIT(= false);  // no need to print after z or p
 

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2314,28 +2314,36 @@ func! Test_normal53_digraph()
   bw!
 endfunc
 
-func! Test_normal54_Ctrl_bsl()
-	new
-	call setline(1, 'abcdefghijklmn')
-	exe "norm! df\<c-\>\<c-n>"
-	call assert_equal(['abcdefghijklmn'], getline(1,'$'))
-	exe "norm! df\<c-\>\<c-g>"
-	call assert_equal(['abcdefghijklmn'], getline(1,'$'))
-	exe "norm! df\<c-\>m"
-	call assert_equal(['abcdefghijklmn'], getline(1,'$'))
+func Test_normal54_Ctrl_bsl()
+  new
+  call setline(1, 'abcdefghijklmn')
+  exe "norm! df\<c-\>\<c-n>"
+  call assert_equal(['abcdefghijklmn'], getline(1,'$'))
+  exe "norm! df\<c-\>\<c-g>"
+  call assert_equal(['abcdefghijklmn'], getline(1,'$'))
+  exe "norm! df\<c-\>m"
+  call assert_equal(['abcdefghijklmn'], getline(1,'$'))
   if !has("multi_byte")
     return
   endif
-	call setline(2, 'abcdefghijklmnāf')
-	norm! 2gg0
-	exe "norm! df\<Char-0x101>"
-	call assert_equal(['abcdefghijklmn', 'f'], getline(1,'$'))
-	norm! 1gg0
-	exe "norm! df\<esc>"
-	call assert_equal(['abcdefghijklmn', 'f'], getline(1,'$'))
+  call setline(2, 'abcdefghijklmnāf')
+  norm! 2gg0
+  exe "norm! df\<Char-0x101>"
+  call assert_equal(['abcdefghijklmn', 'f'], getline(1,'$'))
+  norm! 1gg0
+  exe "norm! df\<esc>"
+  call assert_equal(['abcdefghijklmn', 'f'], getline(1,'$'))
 
-	" clean up
-	bw!
+  " clean up
+  bw!
+endfunc
+
+func Test_normal_large_count()
+  " This may fail with 32bit long, how do we detect that?
+  new
+  normal o
+  normal 6666666666dL
+  bwipe!
 endfunc
 
 " Test for the gr (virtual replace) command


### PR DESCRIPTION
#### vim-patch:8.0.0516: a large count on a normal command causes trouble

Problem:    A large count on a normal command causes trouble. (Dominique
            Pelle)
Solution:   Make "opcount" long.
https://github.com/vim/vim/commit/b1e04fca3704e272a30afbe062498819eaacd4f9