### PR TITLE
[RFC] ex_getln: don't redraw statusline on top of scrolled messages

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -295,10 +295,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
 
   redir_off = true;             // don't redirect the typed command
   if (!cmd_silent) {
-    s->i = msg_scrolled;
-    msg_scrolled = 0;           // avoid wait_return message
     gotocmdline(true);
-    msg_scrolled += s->i;
     redrawcmdprompt();          // draw prompt or indent
     set_cmdspos();
   }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -349,7 +349,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
 
   // redraw the statusline for statuslines that display the current mode
   // using the mode() function.
-  if (KeyTyped) {
+  if (KeyTyped && msg_scrolled == 0) {
     curwin->w_redr_status = true;
     redraw_statuslines();
   }

--- a/test/functional/ex_cmds/debug_spec.lua
+++ b/test/functional/ex_cmds/debug_spec.lua
@@ -1,0 +1,110 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local feed = helpers.feed
+local clear = helpers.clear
+
+describe(':debug', function()
+  local screen
+  before_each(function()
+    clear()
+    screen = Screen.new(50, 14)
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue1},
+      [2] = {bold = true, reverse = true},
+      [3] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+      [4] = {bold = true, foreground = Screen.colors.SeaGreen4},
+    })
+    screen:attach()
+  end)
+  it('scrolls messages correctly', function()
+    feed(':echoerr bork<cr>')
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E121: Undefined variable: bork}                    |
+      {3:E15: Invalid expression: bork}                     |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
+
+    feed(':debug echo "aa"| echo "bb"<cr>')
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E121: Undefined variable: bork}                    |
+      {3:E15: Invalid expression: bork}                     |
+      Entering Debug mode.  Type "cont" to continue.    |
+      cmd: echo "aa"| echo "bb"                         |
+      >^                                                 |
+    ]])
+
+    feed('step<cr>')
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E121: Undefined variable: bork}                    |
+      {3:E15: Invalid expression: bork}                     |
+      Entering Debug mode.  Type "cont" to continue.    |
+      cmd: echo "aa"| echo "bb"                         |
+      >step                                             |
+      aa                                                |
+      cmd: echo "bb"                                    |
+      >^                                                 |
+    ]])
+
+    feed('step<cr>')
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E121: Undefined variable: bork}                    |
+      {3:E15: Invalid expression: bork}                     |
+      Entering Debug mode.  Type "cont" to continue.    |
+      cmd: echo "aa"| echo "bb"                         |
+      >step                                             |
+      aa                                                |
+      cmd: echo "bb"                                    |
+      >step                                             |
+      bb                                                |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
+
+    feed('<cr>')
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]])
+  end)
+end)


### PR DESCRIPTION
I was looking into #8251 but found another simpler bug first.
Type invalid commands with at least two error lines, without clearing the errors in between: (this assumes `bork` doesn't exist)
```
:echoerr bork
:echoerr bork
:echoerr bork
```
Now, multiple statuslines will be present and overshadowing lines in the message output. This seems simple to fix.

Will add test later today, and potentially a fix for #8251 (no promises :P )