### PR TITLE
build/CMake: find_package(… REQUIRED)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Tools
 .ropeproject/
+# Visual Studio
+/.vs/
 
 # Build/deps dir
 /build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ jobs:
       compiler: clang
       env: >
         CLANG_SANITIZER=ASAN_UBSAN
+        # Use Lua so that ASAN can test our embedded Lua support. 8fec4d53d0f6
         CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
       sudo: true
     - os: linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 
 option(ENABLE_LIBINTL "enable libintl" ON)
 if(MSVC)
-  # TODO(justinmk): need bundled iconv for MSVC.
+  add_definitions(-DDYNAMIC_ICONV)
   option(ENABLE_LIBICONV "enable libiconv" OFF)
 else()
   option(ENABLE_LIBICONV "enable libiconv" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,9 @@ include(PreventInTreeBuilds)
 
 # Prefer our bundled versions of dependencies.
 if(DEFINED ENV{DEPS_BUILD_DIR})
-set(DEPS_PREFIX "$ENV{DEPS_BUILD_DIR}/usr" CACHE PATH "Path prefix for finding dependencies")
+  set(DEPS_PREFIX "$ENV{DEPS_BUILD_DIR}/usr" CACHE PATH "Path prefix for finding dependencies")
 else()
-set(DEPS_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/.deps/usr" CACHE PATH "Path prefix for finding dependencies")
+  set(DEPS_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/.deps/usr" CACHE PATH "Path prefix for finding dependencies")
 endif()
 if(CMAKE_CROSSCOMPILING AND NOT UNIX)
   list(INSERT CMAKE_FIND_ROOT_PATH 0 ${DEPS_PREFIX})
@@ -51,6 +51,14 @@ endif()
 if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   # Enable fixing case-insensitive filenames for Windows and Mac.
   set(USE_FNAME_CASE TRUE)
+endif()
+
+option(ENABLE_LIBINTL "enable libintl" ON)
+if(MSVC)
+  # TODO(justinmk): need bundled iconv for MSVC.
+  option(ENABLE_LIBICONV "enable libiconv" OFF)
+else()
+  option(ENABLE_LIBICONV "enable libiconv" ON)
 endif()
 
 # Set default build type.
@@ -331,6 +339,7 @@ if(PREFER_LUA)
   find_package(Lua REQUIRED)
   set(LUA_PREFERRED_INCLUDE_DIRS ${LUA_INCLUDE_DIR})
   set(LUA_PREFERRED_LIBRARIES ${LUA_LIBRARIES})
+  # Passive (not REQUIRED): if LUAJIT_FOUND is not set, nvim-test is skipped.
   find_package(LuaJit)
 else()
   find_package(LuaJit REQUIRED)
@@ -399,31 +408,30 @@ if((CLANG_ASAN_UBSAN OR CLANG_MSAN OR CLANG_TSAN) AND NOT CMAKE_C_COMPILER_ID MA
   message(FATAL_ERROR "Sanitizers are only supported for Clang.")
 endif()
 
-if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD|FreeBSD")
-  message(STATUS "detected OpenBSD/FreeBSD; disabled jemalloc. #5318")
+if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD|FreeBSD|Windows")  # see #5318
+  message(STATUS "skipping jemalloc on this system: ${CMAKE_SYSTEM_NAME}")
   option(ENABLE_JEMALLOC "enable jemalloc" OFF)
 else()
   option(ENABLE_JEMALLOC "enable jemalloc" ON)
 endif()
 
-if (ENABLE_JEMALLOC)
+if(ENABLE_JEMALLOC)
   if(CLANG_ASAN_UBSAN OR CLANG_MSAN OR CLANG_TSAN)
     message(STATUS "Sanitizers have been enabled; don't use jemalloc.")
   else()
-    find_package(JeMalloc)
-    if(JEMALLOC_FOUND)
-      include_directories(SYSTEM ${JEMALLOC_INCLUDE_DIRS})
-    endif()
+    find_package(JeMalloc REQUIRED)
+    include_directories(SYSTEM ${JEMALLOC_INCLUDE_DIRS})
   endif()
 endif()
 
-find_package(LibIntl)
-if(LibIntl_FOUND)
+if(ENABLE_LIBINTL)
+  # LibIntl (not Intl) selects our FindLibIntl.cmake script. #8464
+  find_package(LibIntl REQUIRED)
   include_directories(SYSTEM ${LibIntl_INCLUDE_DIRS})
 endif()
 
-find_package(Iconv)
-if(Iconv_FOUND)
+if(ENABLE_LIBICONV)
+  find_package(Iconv REQUIRED)
   include_directories(SYSTEM ${Iconv_INCLUDE_DIRS})
 endif()
 

--- a/cmake/FindLibIntl.cmake
+++ b/cmake/FindLibIntl.cmake
@@ -34,9 +34,8 @@ if (LibIntl_INCLUDE_DIR)
   set(CMAKE_REQUIRED_INCLUDES "${LibIntl_INCLUDE_DIR}")
 endif()
 
-# This is required because some operating systems don't have a separate
-# libintl--it is built into glibc.  So we only need to specify the library
-# if one was actually found.
+# On some systems (linux+glibc) libintl is passively available.
+# So only specify the library if one was found.
 if (LibIntl_LIBRARY)
   set(CMAKE_REQUIRED_LIBRARIES "${LibIntl_LIBRARY}")
 endif()
@@ -53,6 +52,13 @@ int main(int argc, char** argv) {
 }" HAVE_WORKING_LIBINTL)
 
 if (HAVE_WORKING_LIBINTL)
+  # On some systems (linux+glibc) libintl is passively available.
+  # If HAVE_WORKING_LIBINTL then we consider the requirement satisfied.
+  # Unset REQUIRED so that libfind_process(LibIntl) can proceed.
+  if(LibIntl_FIND_REQUIRED)
+    unset(LibIntl_FIND_REQUIRED)
+  endif()
+
   check_variable_exists(_nl_msg_cat_cntr HAVE_NL_MSG_CAT_CNTR)
 endif()
 

--- a/makedeps.bat
+++ b/makedeps.bat
@@ -1,0 +1,18 @@
+echo off
+
+if not defined VS150COMNTOOLS (
+  echo error: missing VS150COMNTOOLS environment variable.
+  echo        Run this script from the 'Developer Command Prompt'.
+  exit /b 1
+)
+
+echo on
+
+set CMAKE=%VS150COMNTOOLS%\..\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe
+
+mkdir .deps
+cd .deps
+"%CMAKE%" -G "Visual Studio 15 2017" "-DCMAKE_BUILD_TYPE=RelWithDebInfo" ..\third-party\
+"%CMAKE%" --build . --config RelWithDebInfo -- "/verbosity:normal"
+cd ..
+

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -484,7 +484,9 @@ set_property(
   APPEND_STRING PROPERTY COMPILE_FLAGS " -DMAKE_LIB "
 )
 
-if(LUAJIT_FOUND)
+if(NOT LUAJIT_FOUND)
+  message(STATUS "luajit not found, skipping nvim-test (unit tests) target")
+else()
   set(NVIM_TEST_LINK_LIBRARIES ${NVIM_LINK_LIBRARIES} ${LUAJIT_LIBRARIES})
   add_library(
     nvim-test

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -457,6 +457,8 @@ if(WIN32)
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/Qt5Widgets.dll"      ${PROJECT_BINARY_DIR}/windows_runtime_deps/
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/winpty.dll"          ${PROJECT_BINARY_DIR}/windows_runtime_deps/
 
+    COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/libiconv-2.dll"      ${PROJECT_BINARY_DIR}/windows_runtime_deps/
+
     COMMAND ${CMAKE_COMMAND} -E copy "${DEPS_PREFIX}/bin/platforms/qwindows.dll" ${PROJECT_BINARY_DIR}/windows_runtime_deps/platforms/
     )
   add_dependencies(nvim_runtime_deps external_blobs)

--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -59,7 +59,6 @@
 #define BACKSLASH_IN_FILENAME
 
 #ifdef _MSC_VER
-typedef SSIZE_T ssize_t;
 typedef int mode_t;
 #endif
 

--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Gettext)
+find_package(Gettext REQUIRED)
 find_program(XGETTEXT_PRG xgettext)
 find_program(ICONV_PRG iconv)
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -157,15 +157,21 @@ set(WINGUI_SHA256 260efc686423e2529360b6a45c8e241fbbf276c8de6b04d44f45ab5b6fe8df
 
 set(WIN32YANK_X86_URL https://github.com/equalsraf/win32yank/releases/download/v0.0.4/win32yank-x86.zip)
 set(WIN32YANK_X86_SHA256 62f34e5a46c5d4a7b3f3b512e1ff7b77fedd432f42581cbe825233a996eed62c)
-
 set(WIN32YANK_X86_64_URL https://github.com/equalsraf/win32yank/releases/download/v0.0.4/win32yank-x64.zip)
 set(WIN32YANK_X86_64_SHA256 33a747a92da60fb65e668edbf7661d3d902411a2d545fe9dc08623cecd142a20)
 
 set(WINPTY_URL https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip)
 set(WINPTY_SHA256 35a48ece2ff4acdcbc8299d4920de53eb86b1fb41e64d2fe5ae7898931bcee89)
 
+# gettext source (for building/linking, does NOT provide tools like msgmerge.exe)
 set(GETTEXT_URL https://ftp.gnu.org/pub/gnu/gettext/gettext-0.19.8.1.tar.gz)
 set(GETTEXT_SHA256 ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43)
+
+# gettext binary (for tools like msgmerge.exe)
+set(GETTEXT_X86_URL https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.19.8.1-v1.15/gettext0.19.8.1-iconv1.15-shared-32.zip)
+set(GETTEXT_X86_SHA256 b7d8fe2d038950bc0447d664db614ebfc3100a1ba962a959d78e41bc708a2140)
+set(GETTEXT_X86_64_URL https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.19.8.1-v1.15/gettext0.19.8.1-iconv1.15-shared-64.zip)
+set(GETTEXT_X86_64_SHA256 c8ed2897438efc0a511892c2b38b623ef0c9092aced2acbd3f3daf2f12ba70b4)
 
 if(USE_BUNDLED_UNIBILIUM)
   include(BuildUnibilium)
@@ -228,6 +234,9 @@ if(WIN32)
   include(TargetArch)
   GetBinaryDep(TARGET "win32yank_${TARGET_ARCH}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E copy win32yank.exe ${DEPS_INSTALL_DIR}/bin)
+
+  GetBinaryDep(TARGET "gettext_${TARGET_ARCH}"
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory bin ${DEPS_INSTALL_DIR}/bin)
 
   if("${TARGET_ARCH}" STREQUAL "X86_64")
     set(TARGET_ARCH x64)


### PR DESCRIPTION
"Always use `find_package` with `REQUIRED`."

This is partially a cargo-cult (reference below), but it uncovered at
least one problem: `find_package(LibIntl REQUIRED)` fails on my vanilla
ubuntu 16.04 system, whereas `find_package(Intl REQUIRED)` succeeds.

ref: https://schneide.blog/2017/11/06/4-tips-for-better-cmake/

---

- [x] let `FindLibIntl.cmake` handle `REQUIRED`
- [x] Windows: download iconv/gettext binaries
- [x] Windows: enable `DYNAMIC_ICONV`
- [x] Added `makedeps.bat` until `build.ps1` can replace it for developers using VS.

I didn't enable any new tests related to iconv, but I tested it locally with:

    :edit ++enc=iso-2022-jp foo

Nvim appveyor build log shows `iconv/dyn` feature is enabled:

    Features: -acl +iconv/dyn -jemalloc +tui 
