### PR TITLE
vim-patch:8.0.0261,8.0.0435,8.0.1311

### DIFF
--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -27,6 +27,13 @@ func Test_empty()
   call assert_equal(1, empty(v:false))
   call assert_equal(0, empty(v:true))
 
+  if has('channel')
+    call assert_equal(1, empty(test_null_channel()))
+  endif
+  if has('job')
+    call assert_equal(1, empty(test_null_job()))
+  endif
+
   call assert_equal(0, empty(function('Test_empty')))
 endfunc
 
@@ -496,4 +503,245 @@ func Test_getbufvar()
   close
 
   set fileformats&
+endfunc
+
+func Test_bufexists()
+  call assert_equal(0, bufexists('does_not_exist'))
+  call assert_equal(1, bufexists(bufnr('%')))
+  call assert_equal(0, bufexists(0))
+  new Xfoo
+  let bn = bufnr('%')
+  call assert_equal(1, bufexists(bn))
+  call assert_equal(1, bufexists('Xfoo'))
+  call assert_equal(1, bufexists(getcwd() . '/Xfoo'))
+  call assert_equal(1, bufexists(0))
+  bw
+  call assert_equal(0, bufexists(bn))
+  call assert_equal(0, bufexists('Xfoo'))
+endfunc
+
+func Test_last_buffer_nr()
+  call assert_equal(bufnr('$'), last_buffer_nr())
+endfunc
+
+func Test_stridx()
+  call assert_equal(-1, stridx('', 'l'))
+  call assert_equal(0,  stridx('', ''))
+  call assert_equal(0,  stridx('hello', ''))
+  call assert_equal(-1, stridx('hello', 'L'))
+  call assert_equal(2,  stridx('hello', 'l', -1))
+  call assert_equal(2,  stridx('hello', 'l', 0))
+  call assert_equal(2,  stridx('hello', 'l', 1))
+  call assert_equal(3,  stridx('hello', 'l', 3))
+  call assert_equal(-1, stridx('hello', 'l', 4))
+  call assert_equal(-1, stridx('hello', 'l', 10))
+  call assert_equal(2,  stridx('hello', 'll'))
+  call assert_equal(-1, stridx('hello', 'hello world'))
+endfunc
+
+func Test_strridx()
+  call assert_equal(-1, strridx('', 'l'))
+  call assert_equal(0,  strridx('', ''))
+  call assert_equal(5,  strridx('hello', ''))
+  call assert_equal(-1, strridx('hello', 'L'))
+  call assert_equal(3,  strridx('hello', 'l'))
+  call assert_equal(3,  strridx('hello', 'l', 10))
+  call assert_equal(3,  strridx('hello', 'l', 3))
+  call assert_equal(2,  strridx('hello', 'l', 2))
+  call assert_equal(-1, strridx('hello', 'l', 1))
+  call assert_equal(-1, strridx('hello', 'l', 0))
+  call assert_equal(-1, strridx('hello', 'l', -1))
+  call assert_equal(2,  strridx('hello', 'll'))
+  call assert_equal(-1, strridx('hello', 'hello world'))
+endfunc
+
+func Test_matchend()
+  call assert_equal(7,  matchend('testing', 'ing'))
+  call assert_equal(7,  matchend('testing', 'ing', 2))
+  call assert_equal(-1, matchend('testing', 'ing', 5))
+endfunc
+
+func Test_nextnonblank_prevnonblank()
+  new
+insert
+This
+
+
+is
+
+a
+Test
+.
+  call assert_equal(0, nextnonblank(-1))
+  call assert_equal(0, nextnonblank(0))
+  call assert_equal(1, nextnonblank(1))
+  call assert_equal(4, nextnonblank(2))
+  call assert_equal(4, nextnonblank(3))
+  call assert_equal(4, nextnonblank(4))
+  call assert_equal(6, nextnonblank(5))
+  call assert_equal(6, nextnonblank(6))
+  call assert_equal(7, nextnonblank(7))
+  call assert_equal(0, nextnonblank(8))
+
+  call assert_equal(0, prevnonblank(-1))
+  call assert_equal(0, prevnonblank(0))
+  call assert_equal(1, prevnonblank(1))
+  call assert_equal(1, prevnonblank(2))
+  call assert_equal(1, prevnonblank(3))
+  call assert_equal(4, prevnonblank(4))
+  call assert_equal(4, prevnonblank(5))
+  call assert_equal(6, prevnonblank(6))
+  call assert_equal(7, prevnonblank(7))
+  call assert_equal(0, prevnonblank(8))
+  bw!
+endfunc
+
+func Test_byte2line_line2byte()
+  new
+  call setline(1, ['a', 'bc', 'd'])
+
+  set fileformat=unix
+  call assert_equal([-1, -1, 1, 1, 2, 2, 2, 3, 3, -1],
+  \                 map(range(-1, 8), 'byte2line(v:val)'))
+  call assert_equal([-1, -1, 1, 3, 6, 8, -1],
+  \                 map(range(-1, 5), 'line2byte(v:val)'))
+
+  set fileformat=mac
+  call assert_equal([-1, -1, 1, 1, 2, 2, 2, 3, 3, -1],
+  \                 map(range(-1, 8), 'byte2line(v:val)'))
+  call assert_equal([-1, -1, 1, 3, 6, 8, -1],
+  \                 map(range(-1, 5), 'line2byte(v:val)'))
+
+  set fileformat=dos
+  call assert_equal([-1, -1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, -1],
+  \                 map(range(-1, 11), 'byte2line(v:val)'))
+  call assert_equal([-1, -1, 1, 4, 8, 11, -1],
+  \                 map(range(-1, 5), 'line2byte(v:val)'))
+
+  set fileformat&
+  bw!
+endfunc
+
+func Test_count()
+  let l = ['a', 'a', 'A', 'b']
+  call assert_equal(2, count(l, 'a'))
+  call assert_equal(1, count(l, 'A'))
+  call assert_equal(1, count(l, 'b'))
+  call assert_equal(0, count(l, 'B'))
+
+  call assert_equal(2, count(l, 'a', 0))
+  call assert_equal(1, count(l, 'A', 0))
+  call assert_equal(1, count(l, 'b', 0))
+  call assert_equal(0, count(l, 'B', 0))
+
+  call assert_equal(3, count(l, 'a', 1))
+  call assert_equal(3, count(l, 'A', 1))
+  call assert_equal(1, count(l, 'b', 1))
+  call assert_equal(1, count(l, 'B', 1))
+  call assert_equal(0, count(l, 'c', 1))
+
+  call assert_equal(1, count(l, 'a', 0, 1))
+  call assert_equal(2, count(l, 'a', 1, 1))
+  call assert_fails('call count(l, "a", 0, 10)', 'E684:')
+
+  let d = {1: 'a', 2: 'a', 3: 'A', 4: 'b'}
+  call assert_equal(2, count(d, 'a'))
+  call assert_equal(1, count(d, 'A'))
+  call assert_equal(1, count(d, 'b'))
+  call assert_equal(0, count(d, 'B'))
+
+  call assert_equal(2, count(d, 'a', 0))
+  call assert_equal(1, count(d, 'A', 0))
+  call assert_equal(1, count(d, 'b', 0))
+  call assert_equal(0, count(d, 'B', 0))
+
+  call assert_equal(3, count(d, 'a', 1))
+  call assert_equal(3, count(d, 'A', 1))
+  call assert_equal(1, count(d, 'b', 1))
+  call assert_equal(1, count(d, 'B', 1))
+  call assert_equal(0, count(d, 'c', 1))
+
+  call assert_fails('call count(d, "a", 0, 1)', 'E474:')
+  call assert_fails('call count("a", "a")', 'E712:')
+endfunc
+
+func Test_changenr()
+  new Xchangenr
+  call assert_equal(0, changenr())
+  norm ifoo
+  call assert_equal(1, changenr())
+  set undolevels=10
+  norm Sbar
+  call assert_equal(2, changenr())
+  undo
+  call assert_equal(1, changenr())
+  redo
+  call assert_equal(2, changenr())
+  bw!
+  set undolevels&
+endfunc
+
+func Test_filewritable()
+  new Xfilewritable
+  write!
+  call assert_equal(1, filewritable('Xfilewritable'))
+
+  call assert_notequal(0, setfperm('Xfilewritable', 'r--r-----'))
+  call assert_equal(0, filewritable('Xfilewritable'))
+
+  call assert_notequal(0, setfperm('Xfilewritable', 'rw-r-----'))
+  call assert_equal(1, filewritable('Xfilewritable'))
+
+  call assert_equal(0, filewritable('doesnotexist'))
+
+  call delete('Xfilewritable')
+  bw!
+endfunc
+
+func Test_hostname()
+  let hostname_vim = hostname()
+  if has('unix')
+    let hostname_system = systemlist('uname -n')[0]
+    call assert_equal(hostname_vim, hostname_system)
+  endif
+endfunc
+
+func Test_getpid()
+  " getpid() always returns the same value within a vim instance.
+  call assert_equal(getpid(), getpid())
+  if has('unix')
+    call assert_equal(systemlist('echo $PPID')[0], string(getpid()))
+  endif
+endfunc
+
+func Test_hlexists()
+  call assert_equal(0, hlexists('does_not_exist'))
+  call assert_equal(0, hlexists('Number'))
+  call assert_equal(0, highlight_exists('does_not_exist'))
+  call assert_equal(0, highlight_exists('Number'))
+  syntax on
+  call assert_equal(0, hlexists('does_not_exist'))
+  call assert_equal(1, hlexists('Number'))
+  call assert_equal(0, highlight_exists('does_not_exist'))
+  call assert_equal(1, highlight_exists('Number'))
+  syntax off
+endfunc
+
+func Test_col()
+  new
+  call setline(1, 'abcdef')
+  norm gg4|mx6|mY2|
+  call assert_equal(2, col('.'))
+  call assert_equal(7, col('$'))
+  call assert_equal(4, col("'x"))
+  call assert_equal(6, col("'Y"))
+  call assert_equal(2, col([1, 2]))
+  call assert_equal(7, col([1, '$']))
+
+  call assert_equal(0, col(''))
+  call assert_equal(0, col('x'))
+  call assert_equal(0, col([2, '$']))
+  call assert_equal(0, col([1, 100]))
+  call assert_equal(0, col([1]))
+  bw!
 endfunc

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1,5 +1,21 @@
 " Tests for various functions.
 
+" Must be done first, since the alternate buffer must be unset.
+func Test_00_bufexists()
+  call assert_equal(0, bufexists('does_not_exist'))
+  call assert_equal(1, bufexists(bufnr('%')))
+  call assert_equal(0, bufexists(0))
+  new Xfoo
+  let bn = bufnr('%')
+  call assert_equal(1, bufexists(bn))
+  call assert_equal(1, bufexists('Xfoo'))
+  call assert_equal(1, bufexists(getcwd() . '/Xfoo'))
+  call assert_equal(1, bufexists(0))
+  bw
+  call assert_equal(0, bufexists(bn))
+  call assert_equal(0, bufexists('Xfoo'))
+endfunc
+
 func Test_empty()
   call assert_equal(1, empty(''))
   call assert_equal(0, empty('a'))
@@ -197,6 +213,19 @@ func Test_setbufvar_options()
   bwipe!
   call win_gotoid(dum1_id)
   bwipe!
+endfunc
+
+func Test_strpart()
+  call assert_equal('de', strpart('abcdefg', 3, 2))
+  call assert_equal('ab', strpart('abcdefg', -2, 4))
+  call assert_equal('abcdefg', strpart('abcdefg', -2))
+  call assert_equal('fg', strpart('abcdefg', 5, 4))
+  call assert_equal('defg', strpart('abcdefg', 3))
+
+  if has('multi_byte')
+    call assert_equal('lép', strpart('éléphant', 2, 4))
+    call assert_equal('léphant', strpart('éléphant', 2))
+  endif
 endfunc
 
 func Test_tolower()
@@ -503,21 +532,6 @@ func Test_getbufvar()
   close
 
   set fileformats&
-endfunc
-
-func Test_bufexists()
-  call assert_equal(0, bufexists('does_not_exist'))
-  call assert_equal(1, bufexists(bufnr('%')))
-  call assert_equal(0, bufexists(0))
-  new Xfoo
-  let bn = bufnr('%')
-  call assert_equal(1, bufexists(bn))
-  call assert_equal(1, bufexists('Xfoo'))
-  call assert_equal(1, bufexists(getcwd() . '/Xfoo'))
-  call assert_equal(1, bufexists(0))
-  bw
-  call assert_equal(0, bufexists(bn))
-  call assert_equal(0, bufexists('Xfoo'))
 endfunc
 
 func Test_last_buffer_nr()

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -39,7 +39,7 @@ func Test_empty()
   call assert_equal(0, empty({'a':1}))
 
   call assert_equal(1, empty(v:null))
-  call assert_equal(1, empty(v:none))
+  " call assert_equal(1, empty(v:none))
   call assert_equal(1, empty(v:false))
   call assert_equal(0, empty(v:true))
 
@@ -66,7 +66,7 @@ func Test_len()
   call assert_equal(0, len({}))
   call assert_equal(2, len({'a': 1, 'b': 2}))
 
-  call assert_fails('call len(v:none)', 'E701:')
+  " call assert_fails('call len(v:none)', 'E701:')
   call assert_fails('call len({-> 0})', 'E701:')
 endfunc
 
@@ -80,7 +80,7 @@ func Test_max()
   call assert_equal(2, max({'a':1, 'b':2}))
 
   call assert_fails('call max(1)', 'E712:')
-  call assert_fails('call max(v:none)', 'E712:')
+  " call assert_fails('call max(v:none)', 'E712:')
 endfunc
 
 func Test_min()
@@ -93,7 +93,7 @@ func Test_min()
   call assert_equal(1, min({'a':1, 'b':2}))
 
   call assert_fails('call min(1)', 'E712:')
-  call assert_fails('call min(v:none)', 'E712:')
+  " call assert_fails('call min(v:none)', 'E712:')
 endfunc
 
 func Test_str2nr()
@@ -139,7 +139,7 @@ func Test_str2nr()
   call assert_equal(1, str2nr('1g', 16))
 
   call assert_equal(0, str2nr(v:null))
-  call assert_equal(0, str2nr(v:none))
+  " call assert_equal(0, str2nr(v:none))
 
   call assert_fails('call str2nr([])', 'E730:')
   call assert_fails('call str2nr({->2})', 'E729:')

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -730,14 +730,14 @@ endfunc
 
 func Test_hlexists()
   call assert_equal(0, hlexists('does_not_exist'))
-  call assert_equal(0, hlexists('Number'))
+  " call assert_equal(0, hlexists('Number'))
   call assert_equal(0, highlight_exists('does_not_exist'))
-  call assert_equal(0, highlight_exists('Number'))
+  " call assert_equal(0, highlight_exists('Number'))
   syntax on
   call assert_equal(0, hlexists('does_not_exist'))
-  call assert_equal(1, hlexists('Number'))
+  " call assert_equal(1, hlexists('Number'))
   call assert_equal(0, highlight_exists('does_not_exist'))
-  call assert_equal(1, highlight_exists('Number'))
+  " call assert_equal(1, highlight_exists('Number'))
   syntax off
 endfunc
 


### PR DESCRIPTION
**vim-patch:8.0.0261: not enough test coverage for eval functions**

Problem:    Not enough test coverage for eval functions.
Solution:   Add more tests. (Dominique Pelle, closes vim/vim#1420)
vim/vim@24c2e48

**vim-patch:8.0.0435: some functions are not tested**

Problem:    Some functions are not tested.
Solution:   Add more tests for functions. (Dominique Pelle, closes vim/vim#1541)
vim/vim@41042f3

**vim-patch:8.0.1311: no test for strpart()**

Problem:    No test for strpart().
Solution:   Add a test. (Dominique Pelle, closes vim/vim#2347)
vim/vim@c7d16dc

Close #8230