### PR TITLE
vim-patch:8.0.0231,8.0.0233

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -84,6 +84,7 @@ NEW_TESTS ?= \
 	    test_mksession.res \
 	    test_nested_function.res \
 	    test_normal.res \
+	    test_paste.res \
 	    test_number.res \
 	    test_options.res \
 	    test_profile.res \

--- a/src/nvim/testdir/test_paste.vim
+++ b/src/nvim/testdir/test_paste.vim
@@ -1,0 +1,41 @@
+" Tests for bracketed paste.
+
+" Bracketed paste only works with "xterm".
+set term=xterm
+
+func Test_paste_normal_mode()
+  new
+  call setline(1, ['a', 'b', 'c'])
+  2
+  call feedkeys("\<Esc>[200~foo\<CR>bar\<Esc>[201~", 'xt')
+  call assert_equal('bfoo', getline(2))
+  call assert_equal('bar', getline(3))
+  call assert_equal('c', getline(4))
+
+  normal .
+  call assert_equal('barfoo', getline(3))
+  call assert_equal('bar', getline(4))
+  call assert_equal('c', getline(5))
+  bwipe!
+endfunc
+
+func Test_paste_insert_mode()
+  new
+  call setline(1, ['a', 'b', 'c'])
+  2
+  call feedkeys("i\<Esc>[200~foo\<CR>bar\<Esc>[201~ done\<Esc>", 'xt')
+  call assert_equal('foo', getline(2))
+  call assert_equal('bar doneb', getline(3))
+  call assert_equal('c', getline(4))
+
+  normal .
+  call assert_equal('bar donfoo', getline(3))
+  call assert_equal('bar doneeb', getline(4))
+  call assert_equal('c', getline(5))
+  bwipe!
+endfunc
+
+func Test_paste_cmdline()
+  call feedkeys(":a\<Esc>[200~foo\<CR>bar\<Esc>[201~b\<Home>\"\<CR>", 'xt')
+  call assert_equal("\"afoo\<CR>barb", getreg(':'))
+endfunc

--- a/src/nvim/testdir/test_paste.vim
+++ b/src/nvim/testdir/test_paste.vim
@@ -1,6 +1,9 @@
 " Tests for bracketed paste.
 
-" Bracketed paste only works with "xterm".
+" Bracketed paste only works with "xterm".  Not in GUI.
+if has('gui_running')
+  finish
+endif
 set term=xterm
 
 func Test_paste_normal_mode()

--- a/src/nvim/testdir/test_paste.vim
+++ b/src/nvim/testdir/test_paste.vim
@@ -4,7 +4,6 @@
 if has('gui_running')
   finish
 endif
-set term=xterm
 
 func Test_paste_normal_mode()
   new


### PR DESCRIPTION
**vim-patch:8.0.0231: bracketed paste mode is not tested**

Problem:    There are no tests for bracketed paste mode.
Solution:   Add a test.  Fix repeating with "normal .".
vim/vim@076e502

**vim-patch:8.0.0233: paste test fails in the GUI**

Problem:    The paste test fails if the GUI is being used.
Solution:   Skip the test in the GUI.
vim/vim@bff6ad1