### PR TITLE
TUI: skip SIGWINCH during teardown

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -405,6 +405,10 @@ static void sigwinch_cb(SignalWatcher *watcher, int signum, void *data)
 {
   got_winch = true;
   UI *ui = data;
+  if (tui_is_stopped(ui)) {
+    return;
+  }
+
   update_size(ui);
   ui_schedule_refresh();
 }


### PR DESCRIPTION
closes #8409

Although 8b05da157728 prevents UI events during TUI teardown, there's
still a chance a SIGWINCH event (which emits from a different source,
not the UI pump) could be queued.
