### PR TITLE
vim-patch:8.0.1237

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -939,10 +939,8 @@ void set_init_2(bool headless)
 {
   int idx;
 
-  /*
-   * 'scroll' defaults to half the window height. The stored default is zero,
-   * which results in the actual value computed from the window height.
-   */
+  // 'scroll' defaults to half the window height. The stored default is zero,
+  // which results in the actual value computed from the window height.
   idx = findoption("scroll");
   if (idx >= 0 && !(options[idx].flags & P_WAS_SET)) {
     set_option_default(idx, OPT_LOCAL, p_cp);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -940,10 +940,9 @@ void set_init_2(bool headless)
   int idx;
 
   /*
-   * 'scroll' defaults to half the window height. Note that this default is
-   * wrong when the window height changes.
+   * 'scroll' defaults to half the window height. The stored default is zero,
+   * which results in the actual value computed from the window height.
    */
-  set_number_default("scroll", Rows / 2);
   idx = findoption("scroll");
   if (idx >= 0 && !(options[idx].flags & P_WAS_SET)) {
     set_option_default(idx, OPT_LOCAL, p_cp);

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1922,7 +1922,7 @@ return {
       no_mkrc=true,
       vi_def=true,
       pv_name='p_scroll',
-      defaults={if_true={vi=12}}
+      defaults={if_true={vi=0}}
     },
     {
       full_name='scrollback', abbreviation='scbk',

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -27,6 +27,7 @@ source test_popup.vim
 source test_put.vim
 source test_recover.vim
 source test_regexp_utf8.vim
+source test_scroll_opt.vim
 source test_source_utf8.vim
 source test_sha256.vim
 source test_statusline.vim

--- a/src/nvim/testdir/test_scroll_opt.vim
+++ b/src/nvim/testdir/test_scroll_opt.vim
@@ -1,0 +1,36 @@
+" Test for reset 'scroll'
+"
+
+func Test_reset_scroll()
+  let scr = &l:scroll
+
+  setlocal scroll=1
+  setlocal scroll&
+  call assert_equal(scr, &l:scroll)
+
+  setlocal scroll=1
+  setlocal scroll=0
+  call assert_equal(scr, &l:scroll)
+
+  try
+    execute 'setlocal scroll=' . (winheight(0) + 1)
+    " not reached
+    call assert_false(1)
+  catch
+    call assert_exception('E49:')
+  endtry
+
+  split
+
+  let scr = &l:scroll
+
+  setlocal scroll=1
+  setlocal scroll&
+  call assert_equal(scr, &l:scroll)
+
+  setlocal scroll=1
+  setlocal scroll=0
+  call assert_equal(scr, &l:scroll)
+
+  quit!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1237: ":set scroll&" often gives an error**

Problem:    ":set scroll&" often gives an error.
Solution:   Don't use a fixed default value, use half the window height. Add a
            test. (Ozaki Kiichi, closes vim/vim#2104)
https://github.com/vim/vim/commit/af2d20c6285c1d2973e3d9b5e8f727e3ed180493