### PR TITLE
vim-patch:8.0.0851

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -698,7 +698,7 @@ return {
   },
   {
     command='delfunction',
-    flags=bit.bor(NEEDARG, WORD1, CMDWIN),
+    flags=bit.bor(BANG, NEEDARG, WORD1, CMDWIN),
     addr_type=ADDR_LINES,
     func='ex_delfunction',
   },

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -106,7 +106,8 @@ open_line (
   char_u *p;
   char_u saved_char = NUL;        // init for GCC
   pos_T *pos;
-  bool do_si = (!p_paste && curbuf->b_p_si && !curbuf->b_p_cin);
+  bool do_si = (!p_paste && curbuf->b_p_si && !curbuf->b_p_cin
+                && *curbuf->b_p_inde == NUL);
   bool no_si = false;             // reset did_si afterwards
   int first_char = NUL;           // init for GCC
   int vreplace_mode;

--- a/src/nvim/testdir/test_smartindent.vim
+++ b/src/nvim/testdir/test_smartindent.vim
@@ -1,3 +1,4 @@
+" Tests for smartindent
 
 " Tests for not doing smart indenting when it isn't set.
 function! Test_nosmartindent()
@@ -12,3 +13,29 @@ function! Test_nosmartindent()
   call assert_equal("		#test", getline(1))
   enew! | close
 endfunction
+
+function MyIndent()
+endfunction
+
+" When 'indentexpr' is set, setting 'si' has no effect.
+function Test_smartindent_has_no_effect()
+  new
+  exe "normal! i\<Tab>one\<Esc>"
+  set noautoindent
+  set smartindent
+  set indentexpr=
+  exe "normal! Gotwo\<Esc>"
+  call assert_equal("\ttwo", getline("$"))
+
+  set indentexpr=MyIndent
+  exe "normal! Gothree\<Esc>"
+  call assert_equal("three", getline("$"))
+
+  delfunction! MyIndent
+  set autoindent&
+  set smartindent&
+  set indentexpr&
+  bwipe!
+endfunction
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:8.0.0851: 'smartindent' is used even when 'indentexpr' is set**

Problem:    'smartindent' is used even when 'indentexpr' is set.
Solution:   Ignore 'smartindent' when 'indentexpr' is set. (Hirohito Higashi)
vim/vim@69a76fe