### PR TITLE
vim-patch:8.0.0675

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4061,7 +4061,8 @@ win_line (
      * Also highlight the 'colorcolumn' if it is different than
      * 'cursorcolumn' */
     vcol_save_attr = -1;
-    if (draw_state == WL_LINE && !lnum_in_visual_area) {
+    if (draw_state == WL_LINE && !lnum_in_visual_area
+        && search_attr == 0 && area_attr == 0) {
       if (wp->w_p_cuc && VCOL_HLC == (long)wp->w_virtcol
           && lnum != wp->w_cursor.lnum) {
         vcol_save_attr = char_attr;

--- a/src/nvim/testdir/test_listlbr_utf8.vim
+++ b/src/nvim/testdir/test_listlbr_utf8.vim
@@ -194,6 +194,21 @@ func Test_multibyte_sign_and_colorcolumn()
   call s:close_windows()
 endfunc
 
+func Test_colorcolumn_priority()
+  call s:test_windows('setl cc=4 cuc hls')
+  call setline(1, ["xxyy", ""])
+  norm! gg
+  exe "normal! /xxyy\<CR>"
+  norm! G
+  redraw!
+  let line_attr = s:screen_attr(1, [1, &cc])
+  " Search wins over CursorColumn
+  call assert_equal(line_attr[1], line_attr[0])
+  " Search wins over Colorcolumn
+  call assert_equal(line_attr[2], line_attr[3])
+  call s:close_windows('setl hls&vim')
+endfunc
+
 func Test_illegal_byte_and_breakat()
   call s:test_windows("setl sbr= brk+=<")
   vert resize 18


### PR DESCRIPTION
**vim-patch:8.0.0675:  'colorcolumn' has a higher priority than 'hlsearch'**

Problem:    'colorcolumn' has a higher priority than 'hlsearch', it should be
            the other way around. (Nazri Ramliy)
Solution:   Change the priorities. (LemonBoy, closes vim/vim#1794)
https://github.com/vim/vim/commit/774e5a9673260b1b8b88463669213a96637f72e8