### PR TITLE
[RDY] vim-patch:8.0.{805,806,810,1012,1017}

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -116,6 +116,7 @@ NEW_TESTS ?= \
 	    test_visual.res \
 	    test_winbuf_close.res \
 	    test_window_id.res \
+	    test_windows_home.res \
 	    test_wordcount.res \
 	    test_writefile.res \
 	    test_alot_latin.res \

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -173,6 +173,9 @@ func FinishTesting()
   " Don't write viminfo on exit.
   set viminfo=
 
+  " Clean up files created by setup.vim
+  call delete('XfakeHOME', 'rf')
+
   if s:fail == 0
     " Success, create the .res file so that make knows it's done.
     exe 'split ' . fnamemodify(g:testname, ':r') . '.res'

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -16,7 +16,8 @@ set rtp=$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after
 let &packpath = &rtp
 
 " Make sure $HOME does not get read or written.
-let $HOME = '/does/not/exist'
+let $HOME = getcwd() . '/XfakeHOME'
+call mkdir($HOME)
 
 " Use default shell on Windows to avoid segfault, caused by TUI
 if has('win32')

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -1,5 +1,11 @@
 " Common preparations for running tests.
 
+" Only load this once.
+if exists('s:did_load')
+  finish
+endif
+let s:did_load = 1
+
 " Align Nvim defaults to Vim.
 set sidescroll=0
 set directory^=.

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -22,8 +22,10 @@ set rtp=$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after
 let &packpath = &rtp
 
 " Make sure $HOME does not get read or written.
-let $HOME = getcwd() . '/XfakeHOME'
-call mkdir($HOME)
+let $HOME = expand(getcwd() . '/XfakeHOME')
+if !isdirectory($HOME)
+  call mkdir($HOME)
+endif
 
 " Use default shell on Windows to avoid segfault, caused by TUI
 if has('win32')

--- a/src/nvim/testdir/test_windows_home.vim
+++ b/src/nvim/testdir/test_windows_home.vim
@@ -1,0 +1,124 @@
+" Test for $HOME on Windows.
+
+if !has('win32')
+  finish
+endif
+
+let s:env = {}
+
+func s:restore_env()
+  for i in keys(s:env)
+    exe 'let ' . i . '=s:env["' . i . '"]'
+  endfor
+endfunc
+
+func s:save_env(...)
+  for i in a:000
+    exe 'let s:env["' . i . '"]=' . i
+  endfor
+endfunc
+
+func s:unlet_env(...)
+  for i in a:000
+    exe 'let ' . i . '=""'
+  endfor
+endfunc
+
+func CheckHomeIsMissingFromSubprocessEnvironment()
+  silent! let out = system('set')
+  let env = filter(split(out, "\n"), 'v:val=~"^HOME="')
+  call assert_equal(0, len(env))
+endfunc
+
+func CheckHomeIsInSubprocessEnvironment(exp)
+  silent! let out = system('set')
+  let env = filter(split(out, "\n"), 'v:val=~"^HOME="')
+  let home = len(env) == 0 ? "" : substitute(env[0], '[^=]\+=', '', '')
+  call assert_equal(a:exp, home)
+endfunc
+
+func CheckHome(exp, ...)
+  "call assert_equal(a:exp, $HOME)
+  "call assert_equal(a:exp, expand('~', ':p'))
+  if !a:0
+    call CheckHomeIsMissingFromSubprocessEnvironment()
+  else
+    call CheckHomeIsInSubprocessEnvironment(a:exp)
+  endif
+endfunc
+
+func TestWindowsHome()
+  command! -nargs=* SaveEnv call <SID>save_env(<f-args>)
+  command! -nargs=* RestoreEnv call <SID>restore_env()
+  command! -nargs=* UnletEnv call <SID>unlet_env(<f-args>)
+
+  SaveEnv $HOME $USERPROFILE $HOMEDRIVE $HOMEPATH
+  try
+    RestoreEnv
+    UnletEnv $HOME $USERPROFILE $HOMEPATH
+    let $HOMEDRIVE = 'C:'
+    call CheckHome('C:\')
+
+    RestoreEnv
+    UnletEnv $HOME $USERPROFILE
+    let $HOMEDRIVE = 'C:'
+    let $HOMEPATH = '\foobar'
+    call CheckHome('C:\foobar')
+
+    RestoreEnv
+    UnletEnv $HOME $HOMEDRIVE $HOMEPATH
+    let $USERPROFILE = 'C:\foo'
+    call CheckHome('C:\foo')
+
+    RestoreEnv
+    UnletEnv $HOME
+    let $USERPROFILE = 'C:\foo'
+    let $HOMEDRIVE = 'C:'
+    let $HOMEPATH = '\baz'
+    call CheckHome('C:\foo')
+
+    RestoreEnv
+    let $HOME = 'C:\bar'
+    let $USERPROFILE = 'C:\foo'
+    let $HOMEDRIVE = 'C:'
+    let $HOMEPATH = '\baz'
+    call CheckHome('C:\bar', 1)
+
+    RestoreEnv
+    let $HOME = '%USERPROFILE%\bar'
+    let $USERPROFILE = 'C:\foo'
+    let $HOMEDRIVE = 'C:'
+    let $HOMEPATH = '\baz'
+    call CheckHome('%USERPROFILE%\bar', 1)
+
+    RestoreEnv
+    let $HOME = '%USERPROFILE'
+    let $USERPROFILE = 'C:\foo'
+    let $HOMEDRIVE = 'C:'
+    let $HOMEPATH = '\baz'
+    call CheckHome('%USERPROFILE', 1)
+
+    RestoreEnv
+    let $HOME = 'C:\%USERPROFILE%'
+    let $USERPROFILE = 'C:\foo'
+    let $HOMEDRIVE = 'C:'
+    let $HOMEPATH = '\baz'
+    call CheckHome('C:\%USERPROFILE%', 1)
+
+    if has('channel')
+      RestoreEnv
+      UnletEnv $HOME
+      let env = ''
+      let job = job_start('cmd /c set', {'out_cb': {ch,x->[env,execute('let env=x')]}})
+      sleep 1
+      let env = filter(split(env, "\n"), 'v:val=="HOME"')
+      let home = len(env) == 0 ? "" : env[0]
+      call assert_equal('', home)
+    endif
+  finally
+    RestoreEnv
+    delcommand SaveEnv
+    delcommand RestoreEnv
+    delcommand UnletEnv
+  endtry
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0805: GUI test fails with gnome2**

Problem:    GUI test fails with gnome2.
Solution:   Set $HOME to an existing directory.
vim/vim@d1ee004

**vim-patch:8.0.0806: tests may try to create XfakeHOME twice**

Problem:    Tests may try to create XfakeHOME twice.
Solution:   Avoid loading setup.vim twice.
vim/vim@f98246d

**vim-patch:8.0.0810: MS-Windows: tests still hang**

Problem:    MS-Windows: tests still hang.
Solution:   Only create the XfakeHOME directory if it does not exist yet.
vim/vim@d0b6c6c

**vim-patch:8.0.1012: MS-Windows: problem with $HOME when is was set internally**

Problem:    MS-Windows: Problem with $HOME when is was set internally.
Solution:   Only use the $HOME default internally. (Yasuhiro Matsumoto, closes
            vim/vim#2013)
vim/vim@48340b6

**vim-patch:8.0.1017: test for MS-Windows $HOME always passes**

Problem:    Test for MS-Windows $HOME always passes.
Solution:   Rename the test function.  Make the test pass.
vim/vim@dde6034