### PR TITLE
[RFC] terminal: flush vterm output buffer on pty output

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -602,6 +602,7 @@ static void on_channel_output(Stream *stream, Channel *chan, RBuffer *buf,
   // process_channel_event will modify the read buffer(convert NULs into NLs)
   if (chan->term) {
     terminal_receive(chan->term, ptr, count);
+    terminal_flush_output(chan->term);
   }
 
   rbuffer_consumed(buf, count);

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -528,6 +528,13 @@ void terminal_send(Terminal *term, char *data, size_t size)
   term->opts.write_cb(data, size, term->opts.data);
 }
 
+void terminal_flush_output(Terminal *term)
+{
+  size_t len = vterm_output_read(term->vt, term->textbuf,
+      sizeof(term->textbuf));
+  terminal_send(term, term->textbuf, (size_t)len);
+}
+
 void terminal_send_key(Terminal *term, int c)
 {
   VTermModifier mod = VTERM_MOD_NONE;
@@ -545,9 +552,7 @@ void terminal_send_key(Terminal *term, int c)
     vterm_keyboard_unichar(term->vt, (uint32_t)c, mod);
   }
 
-  size_t len = vterm_output_read(term->vt, term->textbuf,
-      sizeof(term->textbuf));
-  terminal_send(term, term->textbuf, (size_t)len);
+  terminal_flush_output(term);
 }
 
 void terminal_receive(Terminal *term, char *data, size_t len)

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -47,6 +47,16 @@ describe(':terminal', function()
     ]])
   end)
 
+  it("should read output buffer on terminal reporting", function()
+    if iswin() then
+      feed_command([[terminal powershell -NoProfile -NoLogo -Command Write-Host -NoNewline "\"$([char]27)[6n\""; Start-Sleep -Milliseconds 500 ]])
+    else
+      feed_command([[terminal printf '\e[6n'; sleep 0.5 ]])
+    end
+    wait()
+    screen:expect('%^%[%[1;1R', nil, nil, nil, true)
+  end)
+
   it("in normal-mode :split does not move cursor", function()
     if iswin() then
       feed_command([[terminal for /L \\%I in (1,0,2) do ( echo foo & ping -w 100 -n 1 127.0.0.1 > nul )]])


### PR DESCRIPTION
Fixes #4151

libvterm uses an "output buffer" for terminal reporting
(e.g. `\e[6n` to report cursor position)
Flush it in `on_channel_output()` not just `terminal_send_key()`.

Effectively the equivalent of this line from pangoterm: https://bazaar.launchpad.net/~leonerd/pangoterm/trunk/view/607/pangoterm.c#L2159