### PR TITLE
Add autocommand event when search wraps around

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -804,6 +804,10 @@ RemoteReply			When a reply from a Vim that functions as
 				Note that even if an autocommand is defined,
 				the reply should be read with |remote_read()|
 				to consume it.
+							*SearchWrapped*
+SearchWrapped			After making a search with |n| or |N| if the
+				search wraps around the document back to
+				the start/finish respectively.
 							*SessionLoadPost*
 SessionLoadPost			After loading the session file created using
 				the |:mksession| command.

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -75,6 +75,7 @@ return {
     'QuickFixCmdPre',         -- before :make, :grep etc.
     'QuitPre',                -- before :quit
     'RemoteReply',            -- upon string reception from a remote vim
+    'SearchWrapped',          -- after the search wrapped around
     'SessionLoadPost',        -- after loading a session file
     'ShellCmdPost',           -- after ":!cmd"
     'ShellFilterPost',        -- after ":1,2!cmd", ":w !cmd", ":r !cmd".

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1353,6 +1353,10 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char_u *pat, long count,
     }
     retval = 1;                     // pattern found
 
+    if (sia && sia->sa_wrapped) {
+      apply_autocmds(EVENT_SEARCHWRAPPED, NULL, NULL, false, NULL);
+    }
+
     /*
      * Add character and/or line offset
      */

--- a/test/functional/autocmd/searchwrapped_spec.lua
+++ b/test/functional/autocmd/searchwrapped_spec.lua
@@ -1,0 +1,53 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local command = helpers.command
+local curbufmeths = helpers.curbufmeths
+local eq = helpers.eq
+local eval = helpers.eval
+local feed = helpers.feed
+
+describe('autocmd SearchWrapped', function()
+  before_each(function()
+    clear()
+    command('set ignorecase')
+    command('let g:test = 0')
+    command('autocmd! SearchWrapped * let g:test += 1')
+    curbufmeths.set_lines(0, 1, false, {
+      'The quick brown fox',
+      'jumps over the lazy dog'})
+  end)
+
+  it('gets triggered when search wraps the end', function()
+    feed('/the<Return>')
+    eq(0, eval('g:test'))
+
+    feed('n')
+    eq(1, eval('g:test'))
+
+    feed('nn')
+    eq(2, eval('g:test'))
+  end)
+
+  it('gets triggered when search wraps in reverse order', function()
+    feed('/the<Return>')
+    eq(0, eval('g:test'))
+
+    feed('NN')
+    eq(1, eval('g:test'))
+
+    feed('NN')
+    eq(2, eval('g:test'))
+  end)
+
+  it('does not get triggered on failed searches', function()
+    feed('/blargh<Return>')
+    eq(0, eval('g:test'))
+
+    feed('NN')
+    eq(0, eval('g:test'))
+
+    feed('NN')
+    eq(0, eval('g:test'))
+  end)
+end)


### PR DESCRIPTION
This is just early RFC to know if the feature would be accepted. The idea is emitting an autocommand event because then UIs can display something more meaningful than a message on the corner, that I very often just miss which makes me lose a lot of time.

I've just tried adding this to my config:

```
let commands = ['kdialog', '--passivepopup', 'Search Wrapped', '1', '--title', 'Neovim']
autocmd SearchWrapped * call jobstart(commands)
```
That is also of great help to me because sometimes I really miss something BIG when I'm digging something like a giant log file and I'm too focused on the line where the cursor is.

I would like this to be independent of showing the warning message controlled by 'shortmess' (because in a UI which supports the event it might be redundant), but I don't know how do you suggest that.