### PR TITLE
vim-patch:8.0.0254

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6742,36 +6742,39 @@ static void fill_assert_error(garray_T *gap, typval_T *opt_msg_tv,
   char_u *tofree;
 
   if (opt_msg_tv->v_type != VAR_UNKNOWN) {
-    tofree = (char_u *) encode_tv2string(opt_msg_tv, NULL);
+    tofree = (char_u *)encode_tv2echo(opt_msg_tv, NULL);
     ga_concat(gap, tofree);
     xfree(tofree);
+    ga_concat(gap, (char_u *)": ");
+  }
+
+  if (atype == ASSERT_MATCH || atype == ASSERT_NOTMATCH) {
+    ga_concat(gap, (char_u *)"Pattern ");
+  } else if (atype == ASSERT_NOTEQUAL) {
+    ga_concat(gap, (char_u *)"Expected not equal to ");
   } else {
-    if (atype == ASSERT_MATCH || atype == ASSERT_NOTMATCH) {
-      ga_concat(gap, (char_u *)"Pattern ");
-    } else if (atype == ASSERT_NOTEQUAL) {
-      ga_concat(gap, (char_u *)"Expected not equal to ");
+    ga_concat(gap, (char_u *)"Expected ");
+  }
+
+  if (exp_str == NULL) {
+    tofree = (char_u *)encode_tv2string(exp_tv, NULL);
+    ga_concat_esc(gap, tofree);
+    xfree(tofree);
+  } else {
+    ga_concat_esc(gap, exp_str);
+  }
+
+  if (atype != ASSERT_NOTEQUAL) {
+    if (atype == ASSERT_MATCH) {
+      ga_concat(gap, (char_u *)" does not match ");
+    } else if (atype == ASSERT_NOTMATCH) {
+      ga_concat(gap, (char_u *)" does match ");
     } else {
-      ga_concat(gap, (char_u *)"Expected ");
+      ga_concat(gap, (char_u *)" but got ");
     }
-    if (exp_str == NULL) {
-      tofree = (char_u *)encode_tv2string(exp_tv, NULL);
-      ga_concat_esc(gap, tofree);
-      xfree(tofree);
-    } else {
-      ga_concat_esc(gap, exp_str);
-    }
-    if (atype != ASSERT_NOTEQUAL) {
-      if (atype == ASSERT_MATCH) {
-        ga_concat(gap, (char_u *)" does not match ");
-      } else if (atype == ASSERT_NOTMATCH) {
-        ga_concat(gap, (char_u *)" does match ");
-      } else {
-        ga_concat(gap, (char_u *)" but got ");
-      }
-      tofree = (char_u *)encode_tv2string(got_tv, NULL);
-      ga_concat_esc(gap, tofree);
-      xfree(tofree);
-    }
+    tofree = (char_u *)encode_tv2string(got_tv, NULL);
+    ga_concat_esc(gap, tofree);
+    xfree(tofree);
   }
 }
 

--- a/test/functional/legacy/assert_spec.lua
+++ b/test/functional/legacy/assert_spec.lua
@@ -169,10 +169,10 @@ describe('assert function:', function()
         call assert_true('', 'file two')
       ]])
       expected_errors({
-        tmpname_one .. " line 1: 'equal assertion failed'",
-        tmpname_one .. " line 2: 'true  assertion failed'",
-        tmpname_one .. " line 3: 'false assertion failed'",
-        tmpname_two .. " line 1: 'file two'",
+        tmpname_one .. " line 1: equal assertion failed: Expected 1 but got 100",
+        tmpname_one .. " line 2: true  assertion failed: Expected False but got 'true'",
+        tmpname_one .. " line 3: false assertion failed: Expected True but got 'false'",
+        tmpname_two .. " line 1: file two: Expected True but got ''",
       })
     end)
 
@@ -203,7 +203,7 @@ describe('assert function:', function()
 
     it('should set v:errors to msg when given and match fails', function()
       call('assert_match', 'bar.*foo', 'foobar', 'wrong')
-      expected_errors({"'wrong'"})
+      expected_errors({"wrong: Pattern 'bar.*foo' does not match 'foobar'"})
     end)
   end)
 

--- a/test/functional/legacy/assert_spec.lua
+++ b/test/functional/legacy/assert_spec.lua
@@ -77,6 +77,11 @@ describe('assert function:', function()
       eq('Vim(call):E724: unable to correctly dump variable with self-referencing container',
          exc_exec('call CheckAssert()'))
     end)
+
+    it('can specify a message and get a message about what failed', function()
+      call('assert_equal', 'foo', 'bar', 'testing')
+      expected_errors({"testing: Expected 'foo' but got 'bar'"})
+    end)
   end)
 
   -- assert_notequal({expected}, {actual}[, {msg}])


### PR DESCRIPTION
**vim-patch:8.0.0254: error message of assert functions is sometimes incomplete**

Problem:    When using an assert function one can either specify a message or
            get a message about what failed, not both.
Solution:   Concatenate the error with the message.
https://github.com/vim/vim/commit/c7b831ca154537505f5a22d01335a86b2e9cb023