### PR TITLE
vim-patch:8.0.0265

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -88,6 +88,8 @@ NEW_TESTS ?= \
 	    test_options.res \
 	    test_profile.res \
 	    test_put.res \
+	    test_python2.res \
+	    test_python3.res \
 	    test_quickfix.res \
 	    test_quotestar.res \
 	    test_recover.res \

--- a/src/nvim/testdir/test_python2.vim
+++ b/src/nvim/testdir/test_python2.vim
@@ -1,0 +1,24 @@
+" Test for python 2 commands.
+" TODO: move tests from test87.in here.
+
+if !has('python')
+  finish
+endif
+
+func Test_pydo()
+  " Check deleting lines does not trigger ml_get error.
+  py import vim
+  new
+  call setline(1, ['one', 'two', 'three'])
+  pydo vim.command("%d_")
+  bwipe!
+
+  " Check switching to another buffer does not trigger ml_get error.
+  new
+  let wincount = winnr('$')
+  call setline(1, ['one', 'two', 'three'])
+  pydo vim.command("new")
+  call assert_equal(wincount + 1, winnr('$'))
+  bwipe!
+  bwipe!
+endfunc

--- a/src/nvim/testdir/test_python3.vim
+++ b/src/nvim/testdir/test_python3.vim
@@ -1,0 +1,24 @@
+" Test for python 2 commands.
+" TODO: move tests from test88.in here.
+
+if !has('python3')
+  finish
+endif
+
+func Test_py3do()
+  " Check deleting lines does not trigger an ml_get error.
+  py3 import vim
+  new
+  call setline(1, ['one', 'two', 'three'])
+  py3do vim.command("%d_")
+  bwipe!
+
+  " Check switching to another buffer does not trigger an ml_get error.
+  new
+  let wincount = winnr('$')
+  call setline(1, ['one', 'two', 'three'])
+  py3do vim.command("new")
+  call assert_equal(wincount + 1, winnr('$'))
+  bwipe!
+  bwipe!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0265: may get ml_get error when :pydo deletes lines**

Problem:    May get ml_get error when :pydo deletes lines or switches to
            another buffer. (Nikolai Pavlov, issue vim/vim#1421)
Solution:   Check the buffer and line every time.
https://github.com/vim/vim/commit/a58883b4ea0bbb813fd4dd7eb49dd6f03e3e5387