### PR TITLE
vim-patch:8.0.0355

### DIFF
--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -76,7 +76,7 @@ char *os_get_user_directory(const char *name)
 {
 #if defined(HAVE_GETPWNAM) && defined(HAVE_PWD_H)
   struct passwd *pw;
-  if (name == NULL) {
+  if (name == NULL || *name == NUL) {
     return NULL;
   }
   pw = getpwnam(name);  // NOLINT(runtime/threadsafe_fn)

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1097,17 +1097,18 @@ static bool has_env_var(char_u *p)
 }
 
 #ifdef SPECIAL_WILDCHAR
-/*
- * Return TRUE if "p" contains a special wildcard character.
- * Allowing for escaping.
- */
+
+// Return TRUE if "p" contains a special wildcard character, one that Vim
+// cannot expand, requires using a shell.
 static bool has_special_wildchar(char_u *p)
 {
   for (; *p; mb_ptr_adv(p)) {
-    if (*p == '\\' && p[1] != NUL)
-      ++p;
-    else if (vim_strchr((char_u *)SPECIAL_WILDCHAR, *p) != NULL)
+    // Allow for escaping
+    if (*p == '\\' && p[1] != NUL) {
+      p++;
+    } else if (vim_strchr((char_u *)SPECIAL_WILDCHAR, *p) != NULL) {
       return true;
+    }
   }
   return false;
 }
@@ -2033,7 +2034,7 @@ int expand_wildcards(int num_pat, char_u **pat, int *num_files, char_u ***files,
         break;
       }
       if (match_file_list(p_wig, (*files)[i], ffname)) {
-        // remove this matching files from the list
+        // remove this matching file from the list
         xfree((*files)[i]);
         for (j = i; j + 1 < *num_files; j++) {
           (*files)[j] = (*files)[j + 1];

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -22,6 +22,13 @@ function! Test_whichwrap()
   set whichwrap&
 endfunction
 
+function! Test_isfname()
+  " This used to cause Vim to access uninitialized memory.
+  set isfname=
+  call assert_equal("~X", expand("~X"))
+  set isfname&
+endfunction
+
 function! Test_options()
   let caught = 'ok'
   try


### PR DESCRIPTION
**vim-patch:8.0.0355: using uninitialized memory when 'isfname' is empty**

Problem:    Using uninitialized memory when 'isfname' is empty.
Solution:   Don't call getpwnam() without an argument. (Dominique Pelle,
            closes vim/vim#1464)
https://github.com/vim/vim/commit/187a4f28140f10ff833862be7e3ef823d317e1c7