### PR TITLE
vim-patch:8.0.0493

### DIFF
--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -2,6 +2,7 @@
 " This makes testing go faster, since Vim doesn't need to restart.
 
 source test_assign.vim
+source test_cd.vim
 source test_changedtick.vim
 source test_cursor_func.vim
 source test_ex_undo.vim

--- a/src/nvim/testdir/test_cd.vim
+++ b/src/nvim/testdir/test_cd.vim
@@ -1,0 +1,13 @@
+" Test for :cd
+
+func Test_cd_large_path()
+  " This used to crash with a heap write overflow.
+  call assert_fails('cd ' . repeat('x', 5000), 'E472:')
+endfunc
+
+func Test_cd_up_and_down()
+  let path = getcwd()
+  cd ..
+  exe 'cd ' . path
+  call assert_equal(path, getcwd())
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0493: crash with cd command with very long argument**

Problem:    Crash with cd command with very long argument.
Solution:   Check for running out of space. (Dominique Pellé, closes vim/vim#1576)
https://github.com/vim/vim/commit/15618fa643867cf0d9c31f327022a22dff78a0cf