### PR TITLE
[RDY]vim-patch:8.0.0{533,541}

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7554,7 +7554,7 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
         return false;
       }
       Insstart.lnum--;
-      Insstart.col = STRLEN(ml_get(Insstart.lnum));
+      Insstart.col = (colnr_T)STRLEN(ml_get(Insstart.lnum));
     }
     /*
      * In replace mode:

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7545,9 +7545,7 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
     curwin->w_cursor.coladd = 0;
   }
 
-  /*
-   * delete newline!
-   */
+  // Delete newline!
   if (curwin->w_cursor.col == 0) {
     lnum = Insstart.lnum;
     if (curwin->w_cursor.lnum == lnum || revins_on) {
@@ -7556,7 +7554,7 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
         return false;
       }
       Insstart.lnum--;
-      Insstart.col = MAXCOL;
+      Insstart.col = STRLEN(ml_get(Insstart.lnum));
     }
     /*
      * In replace mode:

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -104,7 +104,7 @@ func Test_map_langmap()
   imap a c
   call feedkeys("Go\<C-R>a\<Esc>", "xt")
   call assert_equal('bbbb', getline('$'))
- 
+
   " langmap should not apply in Command-line mode
   set langmap=+{ nolangremap
   call feedkeys(":call append(line('$'), '+')\<CR>", "xt")
@@ -159,6 +159,17 @@ func Test_map_meta_quotes()
   call assert_equal("-foo-", getline('$'))
   set nomodified
   iunmap <M-">
+endfunc
+
+func Test_abbr_after_line_join()
+  new
+  abbr foo bar
+  set backspace=indent,eol,start
+  exe "normal o\<BS>foo "
+  call assert_equal("bar ", getline(1))
+  bwipe!
+  unabbr foo
+  set backspace&
 endfunc
 
 func Test_map_timeout()


### PR DESCRIPTION
**vim-patch:8.0.0533: abbreviation doesn't work after backspacing newline**

Problem:    Abbreviation doesn't work after backspacing newline. (Hkonrk)
Solution:   Set the insert start column. (closes vim/vim#1609)
https://github.com/vim/vim/commit/878c263a489b7e211eda31fa13a3d5ad9e120554

 **vim-patch:8.0.0541: compiler warning on MS-Windows**

Problem:    Compiler warning on MS-Windows.
Solution:   Add a type cast. (Mike Williams)
vim/vim@0400056