### PR TITLE
vim-patch:8.0.0560

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -3082,7 +3082,7 @@ return {
   },
   {
     command='windo',
-    flags=bit.bor(BANG, NEEDARG, EXTRA, NOTRLCOM, RANGE, NOTADR, DFLALL),
+    flags=bit.bor(NEEDARG, EXTRA, NOTRLCOM, RANGE, NOTADR, DFLALL),
     addr_type=ADDR_WINDOWS,
     func='ex_listdo',
   },


### PR DESCRIPTION
**vim-patch:8.0.0560: :windo allows for ! but it's not supported**

Problem:    :windo allows for ! but it's not supported.
Solution:   Disallow passing !. (Hirohito Higashi)
https://github.com/vim/vim/commit/451a4a1cb7797e5d9b9fd625671cb5c652e7da00