### PR TITLE
[RDY] vim-patch:8.0.0{549,568}

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3769,14 +3769,17 @@ find_decl (
       t = false;         /* match after start is failure too */
 
     if (thisblock && t != false) {
-      pos_T       *pos;
+      const int64_t maxtravel = old_pos.lnum - curwin->w_cursor.lnum + 1;
+      const pos_T *pos = findmatchlimit(NULL, '}', FM_FORWARD, maxtravel);
 
-      /* Check that the block the match is in doesn't end before the
-       * position where we started the search from. */
-      if ((pos = findmatchlimit(NULL, '}', FM_FORWARD,
-               (int)(old_pos.lnum - curwin->w_cursor.lnum + 1))) != NULL
-          && pos->lnum < old_pos.lnum)
+      // Check that the block the match is in doesn't end before the
+      // position where we started the search from.
+      if (pos != NULL && pos->lnum < old_pos.lnum) {
+        // There can't be a useful match before the end of this block.
+        // Skip to the end
+        curwin->w_cursor = *pos;
         continue;
+      }
     }
 
     if (t == false) {
@@ -6895,7 +6898,7 @@ static void nv_g_cmd(cmdarg_T *cap)
     else
       show_utf8();
     break;
-
+  // "g<": show scrollback text
   case '<':
     show_sb_text();
     break;

--- a/src/nvim/testdir/test_goto.vim
+++ b/src/nvim/testdir/test_goto.vim
@@ -288,3 +288,24 @@ func Test_cursorline_keep_col()
   set nocursorline
 endfunc
 
+func Test_gd_local_block()
+  let lines = [
+	\ '  int main()',
+	\ '{',
+	\ '  char *a = "NOT NULL";',
+	\ '  if(a)',
+	\ '  {',
+	\ '    char *b = a;',
+	\ '    printf("%s\n", b);',
+	\ '  }',
+	\ '  else',
+	\ '  {',
+	\ '    char *b = "NULL";',
+	\ '    return b;',
+	\ '  }',
+	\ '',
+	\ '  return 0;',
+	\ '}',
+  \ ]
+  call XTest_goto_decl('1gd', lines, 11, 11)
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0549: no test for the 8g8 command**

Problem:    No test for the 8g8 command.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#1615)
vim/vim@395b6ba

**vim-patch:8.0.0568: 1gd may hang**

Problem:    "1gd" may hang.
Solution:   Don't get stuck in one position. (Christian Brabandt, closes vim/vim#1643)
vim/vim@60402d6