### PR TITLE
vim-patch:8.0.0452

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8827,7 +8827,7 @@ static void f_foldtext(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       }
     }
     unsigned long count = (unsigned long)(foldend - foldstart + 1);
-    txt = ngettext("+-%s%3ld line: ", "+-%s%3ld lines: ", count);
+    txt = NGETTEXT("+-%s%3ld line: ", "+-%s%3ld lines: ", count);
     r = xmalloc(STRLEN(txt)
                 + STRLEN(dashes) // for %s
                 + 20             // for %3ld

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1806,7 +1806,7 @@ char_u *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume,
     unsigned long count = (unsigned long)(lnume - lnum + 1);
 
     vim_snprintf((char *)buf, FOLD_TEXT_LEN,
-                 ngettext("+--%3ld line folded",
+                 NGETTEXT("+--%3ld line folded",
                           "+--%3ld lines folded ", count),
                  count);
     text = buf;

--- a/src/nvim/gettext.h
+++ b/src/nvim/gettext.h
@@ -10,10 +10,11 @@
 # else
 #  define N_(x) x
 # endif
+# define NGETTEXT(x, xs, n) ngettext(x, xs, n)
 #else
 # define _(x) ((char *)(x))
 # define N_(x) x
-# define ngettext(x, xs, n) ((n) == 1 ? (x) : (xs))
+# define NGETTEXT(x, xs, n) ((n) == 1 ? (x) : (xs))
 # define bindtextdomain(x, y)  // empty
 # define bind_textdomain_codeset(x, y)  // empty
 # define textdomain(x)  // empty


### PR DESCRIPTION
**vim-patch:8.0.0452: some macros are in lower case**

Problem:    Some macros are in lower case.
Solution:   Make a few more macros upper case.
https://github.com/vim/vim/commit/1c46544412382db8b3203d6c78e550df885540bd