### PR TITLE
vim-patch:8.0.0525

### DIFF
--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -366,6 +366,15 @@ func Test_cmdline_complete_wildoptions()
   bw!
 endfunc
 
+func Test_cmdline_complete_user_cmd()
+  command! -complete=color -nargs=1 Foo :
+  call feedkeys(":Foo \<Tab>\<Home>\"\<cr>", 'tx')
+  call assert_equal('"Foo blue', @:)
+  call feedkeys(":Foo b\<Tab>\<Home>\"\<cr>", 'tx')
+  call assert_equal('"Foo blue', @:)
+  delcommand Foo
+endfunc
+
 " using a leading backslash here
 set cpo+=C
 


### PR DESCRIPTION
**vim-patch:8.0.0525: completion for user command argument not tested**

Solution:   Completion for user command argument not tested.
Problem:    Add a test.
https://github.com/vim/vim/commit/a33ddbbd04ca9b81cba6114708f42b8e26293b99