### PR TITLE
expand_env_esc: fix invalid memory access

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -373,11 +373,10 @@ void expand_env_esc(char_u *restrict srcp,
           *var++ = *tail++;
         }
         *var = NUL;
-        // Use os_get_user_directory() to get the user directory.
-        // If this function fails, the shell is used to
-        // expand ~user. This is slower and may fail if the shell
-        // does not support ~user (old versions of /bin/sh).
-        var = (char_u *)os_get_user_directory((char *)dst + 1);
+        // Get the user directory. If this fails the shell is used to expand
+        // ~user, which is slower and may fail on old versions of /bin/sh.
+        var = (*dst == NUL) ? NULL
+                            : (char_u *)os_get_user_directory((char *)dst + 1);
         mustfree = true;
         if (var == NULL) {
           expand_T xpc;

--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -75,11 +75,10 @@ int os_get_uname(uv_uid_t uid, char *s, size_t len)
 char *os_get_user_directory(const char *name)
 {
 #if defined(HAVE_GETPWNAM) && defined(HAVE_PWD_H)
-  struct passwd *pw;
   if (name == NULL || *name == NUL) {
     return NULL;
   }
-  pw = getpwnam(name);  // NOLINT(runtime/threadsafe_fn)
+  struct passwd *pw = getpwnam(name);  // NOLINT(runtime/threadsafe_fn)
   if (pw != NULL) {
     // save the string from the static passwd entry into malloced memory
     return xstrdup(pw->pw_dir);


### PR DESCRIPTION
ref be68f218ffef

    [OLDTEST] Running test_options
    Failed: F /tests/oldtests|test_options :: Nvim exited with non-zero code
    -en travis_fold:start:-tests-oldtests-test-options

    =================================================================

    ==26191==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x621000067900 at pc 0x0000004768bd bp 0x7ffe6bd02de0 sp 0x7ffe6bd02580
    READ of size 4096 at 0x621000067900 thread T0
        0 0x4768bc in __interceptor_getpwnam /local/mnt/workspace/tmp/ubuntu_rel/llvm/utils/release/final/llvm.src/projects/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:1726:3
        1 0x12847c5 in os_get_user_directory /home/travis/build/neovim/neovim/build/../src/nvim/os/users.c:82:8
        2 0x125a3e3 in expand_env_esc /home/travis/build/neovim/neovim/build/../src/nvim/os/env.c:380:25
        3 0x1257fdb in expand_env_save_opt /home/travis/build/neovim/neovim/build/../src/nvim/os/env.c:255:3
        4 0x1291b77 in gen_expand_wildcards /home/travis/build/neovim/neovim/build/../src/nvim/path.c:1195:13
        5 0x129e2e7 in expand_wildcards /home/travis/build/neovim/neovim/build/../src/nvim/path.c:2018:12
        6 0x129e193 in expand_wildcards_eval /home/travis/build/neovim/neovim/build/../src/nvim/path.c:1986:11
        7 0xc2ddc3 in ExpandFromContext /home/travis/build/neovim/neovim/build/../src/nvim/ex_getln.c:4685:11
        8 0xc29412 in ExpandOne /home/travis/build/neovim/neovim/build/../src/nvim/ex_getln.c:3775:9
        9 0x931364 in f_expand /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:8257:32
        10 0x811954 in call_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6373:11
        11 0x8256b8 in get_func_tv /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6119:11
        12 0x8ad6a1 in eval7 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:4217:15
        13 0x8a9c6b in eval6 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3914:7
        14 0x8a797f in eval5 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3765:7
        15 0x8a319f in eval4 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3502:7
        16 0x8a263c in eval3 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3420:7
        17 0x8a1adc in eval2 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3351:7
        18 0x809b21 in eval1 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3278:7
        19 0x824f24 in get_func_tv /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6092:9
        20 0x81e674 in ex_call /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:2726:9
        21 0xb4db73 in do_one_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:2238:5
        22 0xb30119 in do_cmdline /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:602:20
        23 0x845232 in call_user_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:21396:3
        24 0x81127b in call_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6358:11
        25 0x8256b8 in get_func_tv /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6119:11
        26 0x81e674 in ex_call /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:2726:9
        27 0xb4db73 in do_one_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:2238:5
        28 0xb30119 in do_cmdline /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:602:20
        29 0x8645f1 in ex_execute /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:19541:7
        30 0xb4db73 in do_one_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:2238:5
        31 0xb30119 in do_cmdline /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:602:20
        32 0x845232 in call_user_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:21396:3
        33 0x81127b in call_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6358:11
        34 0x8256b8 in get_func_tv /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6119:11
        35 0x81e674 in ex_call /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:2726:9
        36 0xb4db73 in do_one_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:2238:5
        37 0xb30119 in do_cmdline /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:602:20
        38 0xb19f2d in do_source /home/travis/build/neovim/neovim/build/../src/nvim/ex_cmds2.c:2973:3
        39 0xb16580 in cmd_source /home/travis/build/neovim/neovim/build/../src/nvim/ex_cmds2.c:2718:14
        40 0xb16677 in ex_source /home/travis/build/neovim/neovim/build/../src/nvim/ex_cmds2.c:2699:3
        41 0xb4db73 in do_one_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:2238:5
        42 0xb30119 in do_cmdline /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:602:20
        43 0xb362c5 in do_cmdline_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:278:10
        44 0xe8e3a3 in exe_commands /home/travis/build/neovim/neovim/build/../src/nvim/main.c:1705:5
        45 0xe7bbba in main /home/travis/build/neovim/neovim/build/../src/nvim/main.c:518:5
        46 0x2b0e17bd1f44 in __libc_start_main /build/eglibc-ripdx6/eglibc-2.19/csu/libc-start.c:287
        47 0x44dcfb in _start (/home/travis/build/neovim/neovim/build/bin/nvim+0x44dcfb)

    0x621000067900 is located 0 bytes to the right of 4096-byte region [0x621000066900,0x621000067900)
    allocated by thread T0 here:
        0 0x4eeed3 in malloc /local/mnt/workspace/tmp/ubuntu_rel/llvm/utils/release/final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:67:3
        1 0xf87981 in try_malloc /home/travis/build/neovim/neovim/build/../src/nvim/memory.c:87:15
        2 0xf87ba9 in xmalloc /home/travis/build/neovim/neovim/build/../src/nvim/memory.c:121:15
        3 0x1257f6f in expand_env_save_opt /home/travis/build/neovim/neovim/build/../src/nvim/os/env.c:254:15
        4 0x1291b77 in gen_expand_wildcards /home/travis/build/neovim/neovim/build/../src/nvim/path.c:1195:13
        5 0x129e2e7 in expand_wildcards /home/travis/build/neovim/neovim/build/../src/nvim/path.c:2018:12
        6 0x129e193 in expand_wildcards_eval /home/travis/build/neovim/neovim/build/../src/nvim/path.c:1986:11
        7 0xc2ddc3 in ExpandFromContext /home/travis/build/neovim/neovim/build/../src/nvim/ex_getln.c:4685:11
        8 0xc29412 in ExpandOne /home/travis/build/neovim/neovim/build/../src/nvim/ex_getln.c:3775:9
        9 0x931364 in f_expand /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:8257:32
        10 0x811954 in call_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6373:11
        11 0x8256b8 in get_func_tv /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6119:11
        12 0x8ad6a1 in eval7 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:4217:15
        13 0x8a9c6b in eval6 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3914:7
        14 0x8a797f in eval5 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3765:7
        15 0x8a319f in eval4 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3502:7
        16 0x8a263c in eval3 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3420:7
        17 0x8a1adc in eval2 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3351:7
        18 0x809b21 in eval1 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3278:7
        19 0x824f24 in get_func_tv /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6092:9
        20 0x81e674 in ex_call /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:2726:9
        21 0xb4db73 in do_one_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:2238:5
        22 0xb30119 in do_cmdline /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:602:20
        23 0x845232 in call_user_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:21396:3
        24 0x81127b in call_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6358:11
        25 0x8256b8 in get_func_tv /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6119:11
        26 0x81e674 in ex_call /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:2726:9
        27 0xb4db73 in do_one_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:2238:5
        28 0xb30119 in do_cmdline /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:602:20
        29 0x8645f1 in ex_execute /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:19541:7

    SUMMARY: AddressSanitizer: heap-buffer-overflow /local/mnt/workspace/tmp/ubuntu_rel/llvm/utils/release/final/llvm.src/projects/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:1726:3 in __interceptor_getpwnam
    Shadow bytes around the buggy address:
      0x0c4280004ed0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x0c4280004ee0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x0c4280004ef0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x0c4280004f00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
      0x0c4280004f10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
    =>0x0c4280004f20:[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x0c4280004f30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x0c4280004f40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x0c4280004f50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x0c4280004f60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x0c4280004f70: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
    Shadow byte legend (one shadow byte represents 8 application bytes):
      Addressable:           00
      Partially addressable: 01 02 03 04 05 06 07
      Heap left redzone:       fa
      Freed heap region:       fd
      Stack left redzone:      f1
      Stack mid redzone:       f2
      Stack right redzone:     f3
      Stack after return:      f5
      Stack use after scope:   f8
      Global redzone:          f9
      Global init order:       f6
      Poisoned by user:        f7
      Container overflow:      fc
      Array cookie:            ac
      Intra object redzone:    bb
      ASan internal:           fe
      Left alloca redzone:     ca
      Right alloca redzone:    cb
    ==26191==ABORTING
    Failed: E /tests/oldtests|logs :: Runtime errors detected.
    Job exited with code 1
    Screen (23 lines)