### PR TITLE
vim-patch:8.0.0466

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5193,7 +5193,7 @@ void sign_list_placed(buf_T *rbuf)
     while (buf != NULL && !got_int) {
         if (buf->b_signlist != NULL) {
             vim_snprintf(lbuf, BUFSIZ, _("Signs for %s:"), buf->b_fname);
-            MSG_PUTS_ATTR(lbuf, hl_attr(HLF_D));
+            MSG_PUTS_ATTR(lbuf, HL_ATTR(HLF_D));
             msg_putchar('\n');
         }
         for (p = buf->b_signlist; p != NULL && !got_int; p = p->next) {

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1711,7 +1711,7 @@ static void printdigraph(digr_T *dp)
     p += (*mb_char2bytes)(dp->result, p);
 
     *p = NUL;
-    msg_outtrans_attr(buf, hl_attr(HLF_8));
+    msg_outtrans_attr(buf, HL_ATTR(HLF_8));
     p = buf;
     if (char2cells(dp->result) == 1) {
       *p++ = ' ';

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1473,10 +1473,11 @@ void edit_putchar(int c, int highlight)
   if (ScreenLines != NULL) {
     update_topline();           /* just in case w_topline isn't valid */
     validate_cursor();
-    if (highlight)
-      attr = hl_attr(HLF_8);
-    else
+    if (highlight) {
+      attr = HL_ATTR(HLF_8);
+    } else {
       attr = 0;
+    }
     pc_row = curwin->w_winrow + curwin->w_wrow;
     pc_col = curwin->w_wincol;
     pc_status = PC_STATUS_UNSET;
@@ -1879,7 +1880,7 @@ static bool check_compl_option(bool dict_opt)
     edit_submode = NULL;
     msg_attr((dict_opt
               ? _("'dictionary' option is empty")
-              : _("'thesaurus' option is empty")), hl_attr(HLF_E));
+              : _("'thesaurus' option is empty")), HL_ATTR(HLF_E));
     if (emsg_silent == 0) {
       vim_beep(BO_COMPL);
       setcursor();
@@ -2772,8 +2773,8 @@ static void ins_compl_files(int count, char_u **files, int thesaurus, int flags,
     fp = mch_fopen((char *)files[i], "r");      /* open dictionary file */
     if (flags != DICT_EXACT) {
       vim_snprintf((char *)IObuff, IOSIZE,
-          _("Scanning dictionary: %s"), (char *)files[i]);
-      (void)msg_trunc_attr(IObuff, TRUE, hl_attr(HLF_R));
+                   _("Scanning dictionary: %s"), (char *)files[i]);
+      (void)msg_trunc_attr(IObuff, true, HL_ATTR(HLF_R));
     }
 
     if (fp == NULL) {
@@ -3733,15 +3734,15 @@ static int ins_compl_get_exp(pos_T *ini)
           dict_f = DICT_EXACT;
         }
         vim_snprintf((char *)IObuff, IOSIZE, _("Scanning: %s"),
-            ins_buf->b_fname == NULL
-            ? buf_spname(ins_buf)
-            : ins_buf->b_sfname == NULL
-            ? ins_buf->b_fname
-            : ins_buf->b_sfname);
-        (void)msg_trunc_attr(IObuff, TRUE, hl_attr(HLF_R));
-      } else if (*e_cpt == NUL)
+                     ins_buf->b_fname == NULL
+                     ? buf_spname(ins_buf)
+                     : ins_buf->b_sfname == NULL
+                     ? ins_buf->b_fname
+                     : ins_buf->b_sfname);
+        (void)msg_trunc_attr(IObuff, true, HL_ATTR(HLF_R));
+      } else if (*e_cpt == NUL) {
         break;
-      else {
+      } else {
         if (CTRL_X_MODE_LINE_OR_EVAL(l_ctrl_x_mode)) {
           type = -1;
         } else if (*e_cpt == 'k' || *e_cpt == 's') {
@@ -3760,9 +3761,10 @@ static int ins_compl_get_exp(pos_T *ini)
         else if (*e_cpt == ']' || *e_cpt == 't') {
           type = CTRL_X_TAGS;
           vim_snprintf((char *)IObuff, IOSIZE, _("Scanning tags."));
-          (void)msg_trunc_attr(IObuff, TRUE, hl_attr(HLF_R));
-        } else
+          (void)msg_trunc_attr(IObuff, true, HL_ATTR(HLF_R));
+        } else {
           type = -1;
+        }
 
         /* in any case e_cpt is advanced to the next entry */
         (void)copy_option_part(&e_cpt, IObuff, IOSIZE, ",");
@@ -4899,7 +4901,7 @@ static int ins_complete(int c, bool enable_pum)
       if (!p_smd) {
         msg_attr((const char *)edit_submode_extra,
                  (edit_submode_highl < HLF_COUNT
-                  ? hl_attr(edit_submode_highl) : 0));
+                  ? HL_ATTR(edit_submode_highl) : 0));
       }
     } else {
       msg_clr_cmdline();  // necessary for "noshowmode"

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -20438,7 +20438,7 @@ static void list_func_head(ufunc_T *fp, int indent)
     MSG_PUTS("   ");
   MSG_PUTS("function ");
   if (fp->uf_name[0] == K_SPECIAL) {
-    MSG_PUTS_ATTR("<SNR>", hl_attr(HLF_8));
+    MSG_PUTS_ATTR("<SNR>", HL_ATTR(HLF_8));
     msg_puts((const char *)fp->uf_name + 3);
   } else {
     msg_puts((const char *)fp->uf_name);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1500,7 +1500,7 @@ void print_line_no_prefix(linenr_T lnum, int use_number, int list)
   if (curwin->w_p_nu || use_number) {
     vim_snprintf(numbuf, sizeof(numbuf), "%*" PRIdLINENR " ",
                  number_width(curwin), lnum);
-    msg_puts_attr(numbuf, hl_attr(HLF_N));  // Highlight line nrs.
+    msg_puts_attr(numbuf, HL_ATTR(HLF_N));  // Highlight line nrs.
   }
   msg_prt_line(ml_get(lnum), list);
 }
@@ -3635,7 +3635,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
               msg_no_more = TRUE;
               /* write message same highlighting as for
                * wait_return */
-              smsg_attr(hl_attr(HLF_R),
+              smsg_attr(HL_ATTR(HLF_R),
                         _("replace with %s (y/n/a/q/l/^E/^Y)?"), sub);
               msg_no_more = FALSE;
               msg_scroll = i;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1512,7 +1512,7 @@ int buf_write_all(buf_T *buf, int forceit)
                       (linenr_T)1, buf->b_ml.ml_line_count, NULL,
                       false, forceit, true, false));
   if (curbuf != old_curbuf) {
-    msg_source(hl_attr(HLF_W));
+    msg_source(HL_ATTR(HLF_W));
     MSG(_("Warning: Entered other buffer unexpectedly (check autocommands)"));
   }
   return retval;
@@ -3258,7 +3258,7 @@ retry:
           ga.ga_len--;
         } else {          // lines like ":map xx yy^M" will have failed
           if (!sp->error) {
-            msg_source(hl_attr(HLF_W));
+            msg_source(HL_ATTR(HLF_W));
             EMSG(_("W15: Warning: Wrong line separator, ^M may be missing"));
           }
           sp->error = true;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4949,7 +4949,7 @@ static void uc_list(char_u *name, size_t name_len)
       msg_putchar(gap != &ucmds ? 'b' : ' ');
       msg_putchar(' ');
 
-      msg_outtrans_attr(cmd->uc_name, hl_attr(HLF_D));
+      msg_outtrans_attr(cmd->uc_name, HL_ATTR(HLF_D));
       len = (int)STRLEN(cmd->uc_name) + 4;
 
       do {
@@ -6767,8 +6767,8 @@ static void ex_tabs(exarg_T *eap)
 
     msg_putchar('\n');
     vim_snprintf((char *)IObuff, IOSIZE, _("Tab page %d"), tabcount++);
-    msg_outtrans_attr(IObuff, hl_attr(HLF_T));
-    ui_flush();            /* output one line at a time */
+    msg_outtrans_attr(IObuff, HL_ATTR(HLF_T));
+    ui_flush();            // output one line at a time
     os_breakcheck();
 
     FOR_ALL_WINDOWS_IN_TAB(wp, tp) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -379,7 +379,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
     tl_ret = try_leave(&tstate, &err);
     if (!tl_ret && ERROR_SET(&err)) {
       msg_putchar('\n');
-      msg_printf_attr(hl_attr(HLF_E)|MSG_HIST, (char *)e_autocmd_err, err.msg);
+      msg_printf_attr(HL_ATTR(HLF_E)|MSG_HIST, (char *)e_autocmd_err, err.msg);
       api_clear_error(&err);
       redrawcmd();
     }
@@ -462,7 +462,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
 
   if (!tl_ret && ERROR_SET(&err)) {
     msg_putchar('\n');
-    msg_printf_attr(hl_attr(HLF_E)|MSG_HIST, (char *)e_autocmd_err, err.msg);
+    msg_printf_attr(HL_ATTR(HLF_E)|MSG_HIST, (char *)e_autocmd_err, err.msg);
     api_clear_error(&err);
   }
 
@@ -2586,7 +2586,7 @@ static bool color_cmdline(CmdlineInfo *colored_ccline)
 #define PRINT_ERRMSG(...) \
   do { \
     msg_putchar('\n'); \
-    msg_printf_attr(hl_attr(HLF_E)|MSG_HIST, __VA_ARGS__); \
+    msg_printf_attr(HL_ATTR(HLF_E)|MSG_HIST, __VA_ARGS__); \
     printed_errmsg = true; \
   } while (0)
   bool ret = true;
@@ -4152,13 +4152,13 @@ static int showmatches(expand_T *xp, int wildmenu)
       lines = (num_files + columns - 1) / columns;
     }
 
-    attr = hl_attr(HLF_D);      /* find out highlighting for directories */
+    attr = HL_ATTR(HLF_D);      // find out highlighting for directories
 
     if (xp->xp_context == EXPAND_TAGS_LISTFILES) {
-      MSG_PUTS_ATTR(_("tagname"), hl_attr(HLF_T));
+      MSG_PUTS_ATTR(_("tagname"), HL_ATTR(HLF_T));
       msg_clr_eos();
       msg_advance(maxlen - 3);
-      MSG_PUTS_ATTR(_(" kind file\n"), hl_attr(HLF_T));
+      MSG_PUTS_ATTR(_(" kind file\n"), HL_ATTR(HLF_T));
     }
 
     /* list the files line by line */
@@ -4166,12 +4166,12 @@ static int showmatches(expand_T *xp, int wildmenu)
       lastlen = 999;
       for (k = i; k < num_files; k += lines) {
         if (xp->xp_context == EXPAND_TAGS_LISTFILES) {
-          msg_outtrans_attr(files_found[k], hl_attr(HLF_D));
+          msg_outtrans_attr(files_found[k], HL_ATTR(HLF_D));
           p = files_found[k] + STRLEN(files_found[k]) + 1;
           msg_advance(maxlen + 1);
           msg_puts((const char *)p);
           msg_advance(maxlen + 3);
-          msg_puts_long_attr(p + 2, hl_attr(HLF_D));
+          msg_puts_long_attr(p + 2, HL_ATTR(HLF_D));
           break;
         }
         for (j = maxlen - lastlen; --j >= 0; )

--- a/src/nvim/farsi.c
+++ b/src/nvim/farsi.c
@@ -1603,7 +1603,7 @@ static void conv_to_pvim(void)
 
   // Assume the screen has been messed up: clear it and redraw.
   redraw_later(CLEAR);
-  MSG_ATTR((const char *)farsi_text_1, hl_attr(HLF_S));
+  MSG_ATTR((const char *)farsi_text_1, HL_ATTR(HLF_S));
 }
 
 /// Convert the Farsi VIM into Farsi 3342 standard.
@@ -1624,7 +1624,7 @@ static void conv_to_pstd(void)
 
   // Assume the screen has been messed up: clear it and redraw.
   redraw_later(CLEAR);
-  msg_attr((const char *)farsi_text_2, hl_attr(HLF_S));
+  msg_attr((const char *)farsi_text_2, HL_ATTR(HLF_S));
 }
 
 /// left-right swap the characters in buf[len].

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3694,7 +3694,7 @@ nofail:
 
     retval = FAIL;
     if (end == 0) {
-      const int attr = hl_attr(HLF_E);  // Set highlight for error messages.
+      const int attr = HL_ATTR(HLF_E);  // Set highlight for error messages.
       MSG_PUTS_ATTR(_("\nWARNING: Original file may be lost or damaged\n"),
                     attr | MSG_HIST);
       MSG_PUTS_ATTR(_(
@@ -3901,7 +3901,7 @@ static int check_mtime(buf_T *buf, FileInfo *file_info)
     msg_silent = 0;     // Must give this prompt.
     // Don't use emsg() here, don't want to flush the buffers.
     msg_attr(_("WARNING: The file has been changed since reading it!!!"),
-             hl_attr(HLF_E));
+             HL_ATTR(HLF_E));
     if (ask_yesno(_("Do you really want to write to it"), true) == 'n') {
       return FAIL;
     }
@@ -5020,9 +5020,9 @@ buf_check_timestamp (
     } else {
       if (!autocmd_busy) {
         msg_start();
-        msg_puts_attr(tbuf, hl_attr(HLF_E) + MSG_HIST);
+        msg_puts_attr(tbuf, HL_ATTR(HLF_E) + MSG_HIST);
         if (*mesg2 != NUL) {
-          msg_puts_attr(mesg2, hl_attr(HLF_W) + MSG_HIST);
+          msg_puts_attr(mesg2, HL_ATTR(HLF_W) + MSG_HIST);
         }
         msg_clr_eos();
         (void)msg_end();
@@ -5445,13 +5445,13 @@ static void show_autocmd(AutoPat *ap, event_T event)
   if (event != last_event || ap->group != last_group) {
     if (ap->group != AUGROUP_DEFAULT) {
       if (AUGROUP_NAME(ap->group) == NULL) {
-        msg_puts_attr(get_deleted_augroup(), hl_attr(HLF_E));
+        msg_puts_attr(get_deleted_augroup(), HL_ATTR(HLF_E));
       } else {
-        msg_puts_attr(AUGROUP_NAME(ap->group), hl_attr(HLF_T));
+        msg_puts_attr(AUGROUP_NAME(ap->group), HL_ATTR(HLF_T));
       }
       msg_puts("  ");
     }
-    msg_puts_attr(event_nr2name(event), hl_attr(HLF_T));
+    msg_puts_attr(event_nr2name(event), HL_ATTR(HLF_T));
     last_event = event;
     last_group = ap->group;
     msg_putchar('\n');

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3197,9 +3197,9 @@ showmap (
   } while (len < 12);
 
   if (mp->m_noremap == REMAP_NONE) {
-    msg_puts_attr("*", hl_attr(HLF_8));
+    msg_puts_attr("*", HL_ATTR(HLF_8));
   } else if (mp->m_noremap == REMAP_SCRIPT) {
-    msg_puts_attr("&", hl_attr(HLF_8));
+    msg_puts_attr("&", HL_ATTR(HLF_8));
   } else {
     msg_putchar(' ');
   }
@@ -3212,7 +3212,7 @@ showmap (
   /* Use FALSE below if we only want things like <Up> to show up as such on
    * the rhs, and not M-x etc, TRUE gets both -- webb */
   if (*mp->m_str == NUL) {
-    msg_puts_attr("<Nop>", hl_attr(HLF_8));
+    msg_puts_attr("<Nop>", HL_ATTR(HLF_8));
   } else {
     // Remove escaping of CSI, because "m_str" is in a format to be used
     // as typeahead.

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -584,7 +584,7 @@ static void prt_header(prt_settings_T *psettings, int pagenum, linenr_T lnum)
 static void prt_message(char_u *s)
 {
   screen_fill((int)Rows - 1, (int)Rows, 0, (int)Columns, ' ', ' ', 0);
-  screen_puts(s, (int)Rows - 1, 0, hl_attr(HLF_R));
+  screen_puts(s, (int)Rows - 1, 0, HL_ATTR(HLF_R));
   ui_flush();
 }
 

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -496,9 +496,9 @@ staterr:
 
     if (p_csverbose) {
       msg_clr_eos();
-      (void)smsg_attr(hl_attr(HLF_R),
-            _("Added cscope database %s"),
-            csinfo[i].fname);
+      (void)smsg_attr(HL_ATTR(HLF_R),
+                      _("Added cscope database %s"),
+                      csinfo[i].fname);
     }
   }
 
@@ -1258,8 +1258,8 @@ static void cs_kill_execute(
 {
   if (p_csverbose) {
     msg_clr_eos();
-    (void)smsg_attr(hl_attr(HLF_R) | MSG_HIST,
-          _("cscope connection %s closed"), cname);
+    (void)smsg_attr(HL_ATTR(HLF_R) | MSG_HIST,
+                    _("cscope connection %s closed"), cname);
   }
   cs_release_csp(i, TRUE);
 }
@@ -1590,16 +1590,16 @@ static void cs_print_tags_priv(char **matches, char **cntxts,
   char *buf = xmalloc(newsize);
   size_t bufsize = newsize;  // Track available bufsize
   (void)snprintf(buf, bufsize, cstag_msg, ptag);
-  MSG_PUTS_ATTR(buf, hl_attr(HLF_T));
+  MSG_PUTS_ATTR(buf, HL_ATTR(HLF_T));
   msg_clr_eos();
 
   // restore matches[0]
   *ptag_end = '\t';
 
   // Column headers for match number, line number and filename.
-  MSG_PUTS_ATTR(_("\n   #   line"), hl_attr(HLF_T));
+  MSG_PUTS_ATTR(_("\n   #   line"), HL_ATTR(HLF_T));
   msg_advance(msg_col + 2);
-  MSG_PUTS_ATTR(_("filename / context / line\n"), hl_attr(HLF_T));
+  MSG_PUTS_ATTR(_("filename / context / line\n"), HL_ATTR(HLF_T));
 
   for (size_t i = 0; i < num_matches; i++) {
     assert(strcnt(matches[i], '\t') >= 2);
@@ -1626,8 +1626,8 @@ static void cs_print_tags_priv(char **matches, char **cntxts,
       bufsize = newsize;
     }
     (void)snprintf(buf, bufsize, csfmt_str, i + 1, lno);
-    MSG_PUTS_ATTR(buf, hl_attr(HLF_CM));
-    MSG_PUTS_LONG_ATTR(cs_pathcomponents(fname), hl_attr(HLF_CM));
+    MSG_PUTS_ATTR(buf, HL_ATTR(HLF_CM));
+    MSG_PUTS_LONG_ATTR(cs_pathcomponents(fname), HL_ATTR(HLF_CM));
 
     // compute the required space for the context
     char *context = cntxts[i] ? cntxts[i] : globalcntx;
@@ -1915,7 +1915,7 @@ static int cs_reset(exarg_T *eap)
          * "Added cscope database..."
          */
         snprintf(buf, ARRAY_SIZE(buf), " (#%zu)", i);
-        MSG_PUTS_ATTR(buf, hl_attr(HLF_R));
+        MSG_PUTS_ATTR(buf, HL_ATTR(HLF_R));
       }
     }
     xfree(dblist[i]);
@@ -1927,7 +1927,7 @@ static int cs_reset(exarg_T *eap)
   xfree(fllist);
 
   if (p_csverbose) {
-    msg_attr(_("All cscope databases reset"), hl_attr(HLF_R) | MSG_HIST);
+    msg_attr(_("All cscope databases reset"), HL_ATTR(HLF_R) | MSG_HIST);
   }
   return CSCOPE_SUCCESS;
 } /* cs_reset */
@@ -1993,7 +1993,7 @@ static int cs_show(exarg_T *eap)
   else {
     MSG_PUTS_ATTR(
         _(" # pid    database name                       prepend path\n"),
-        hl_attr(HLF_T));
+        HL_ATTR(HLF_T));
     for (size_t i = 0; i < csinfo_size; i++) {
       if (csinfo[i].fname == NULL)
         continue;

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -690,9 +690,10 @@ show_one_mark(
         mustfree = TRUE;
       }
       if (name != NULL) {
-        msg_outtrans_attr(name, current ? hl_attr(HLF_D) : 0);
-        if (mustfree)
+        msg_outtrans_attr(name, current ? HL_ATTR(HLF_D) : 0);
+        if (mustfree) {
           xfree(name);
+        }
       }
     }
     ui_flush();                    /* show one line at a time */
@@ -803,8 +804,8 @@ void ex_jumps(exarg_T *eap)
           curwin->w_jumplist[i].fmark.mark.col);
       msg_outtrans(IObuff);
       msg_outtrans_attr(name,
-          curwin->w_jumplist[i].fmark.fnum == curbuf->b_fnum
-          ? hl_attr(HLF_D) : 0);
+                        curwin->w_jumplist[i].fmark.fnum == curbuf->b_fnum
+                        ? HL_ATTR(HLF_D) : 0);
       xfree(name);
       os_breakcheck();
     }
@@ -829,7 +830,7 @@ void ex_changes(exarg_T *eap)
   int i;
   char_u      *name;
 
-  /* Highlight title */
+  // Highlight title
   MSG_PUTS_TITLE(_("\nchange line  col text"));
 
   for (i = 0; i < curbuf->b_changelistlen && !got_int; ++i) {
@@ -845,7 +846,7 @@ void ex_changes(exarg_T *eap)
           curbuf->b_changelist[i].mark.col);
       msg_outtrans(IObuff);
       name = mark_line(&curbuf->b_changelist[i].mark, 17);
-      msg_outtrans_attr(name, hl_attr(HLF_D));
+      msg_outtrans_attr(name, HL_ATTR(HLF_D));
       xfree(name);
       os_breakcheck();
     }

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -767,7 +767,7 @@ void ml_recover(void)
 
   recoverymode = TRUE;
   called_from_main = (curbuf->b_ml.ml_mfp == NULL);
-  attr = hl_attr(HLF_E);
+  attr = HL_ATTR(HLF_E);
 
   /*
    * If the file name ends in ".s[uvw][a-z]" we assume this is the swap file.

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -825,8 +825,8 @@ static void show_menus_recursive(vimmenu_T *menu, int modes, int depth)
       msg_outnum((long)menu->priority);
       MSG_PUTS(" ");
     }
-    /* Same highlighting as for directories!? */
-    msg_outtrans_attr(menu->name, hl_attr(HLF_D));
+    // Same highlighting as for directories!?
+    msg_outtrans_attr(menu->name, HL_ATTR(HLF_D));
   }
 
   if (menu != NULL && menu->children == NULL) {
@@ -854,7 +854,7 @@ static void show_menus_recursive(vimmenu_T *menu, int modes, int depth)
           msg_putchar(' ');
         MSG_PUTS(" ");
         if (*menu->strings[bit] == NUL) {
-          msg_puts_attr("<Nop>", hl_attr(HLF_8));
+          msg_puts_attr("<Nop>", HL_ATTR(HLF_8));
         } else {
           msg_outtrans_special(menu->strings[bit], false);
         }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -434,7 +434,7 @@ void msg_source(int attr)
   }
   p = get_emsg_lnum();
   if (p != NULL) {
-    msg_attr(p, hl_attr(HLF_N));
+    msg_attr(p, HL_ATTR(HLF_N));
     xfree(p);
     last_sourcing_lnum = sourcing_lnum;      /* only once for each line */
   }
@@ -557,7 +557,7 @@ int emsg(const char_u *s_)
 
   emsg_on_display = true;     // remember there is an error message
   msg_scroll++;               // don't overwrite a previous message
-  attr = hl_attr(HLF_E);      // set highlight mode for error messages
+  attr = HL_ATTR(HLF_E);      // set highlight mode for error messages
   if (msg_scrolled != 0) {
     need_wait_return = true;  // needed in case emsg() is called after
   }                           // wait_return has reset need_wait_return
@@ -1034,9 +1034,10 @@ static void hit_return_msg(void)
   if (got_int)
     MSG_PUTS(_("Interrupt: "));
 
-  MSG_PUTS_ATTR(_("Press ENTER or type command to continue"), hl_attr(HLF_R));
-  if (!msg_use_printf())
+  MSG_PUTS_ATTR(_("Press ENTER or type command to continue"), HL_ATTR(HLF_R));
+  if (!msg_use_printf()) {
     msg_clr_eos();
+  }
   p_more = save_p_more;
 }
 
@@ -1140,7 +1141,7 @@ void msg_home_replace(char_u *fname)
 
 void msg_home_replace_hl(char_u *fname)
 {
-  msg_home_replace_attr(fname, hl_attr(HLF_D));
+  msg_home_replace_attr(fname, HL_ATTR(HLF_D));
 }
 
 static void msg_home_replace_attr(char_u *fname, int attr)
@@ -1230,7 +1231,7 @@ int msg_outtrans_len_attr(char_u *msgstr, int len, int attr)
         }
         plain_start = str + mb_l;
         msg_puts_attr((const char *)transchar(c),
-                      (attr == 0 ? hl_attr(HLF_8) : attr));
+                      (attr == 0 ? HL_ATTR(HLF_8) : attr));
         retval += char2cells(c);
       }
       len -= mb_l - 1;
@@ -1244,7 +1245,7 @@ int msg_outtrans_len_attr(char_u *msgstr, int len, int attr)
           msg_puts_attr_len(plain_start, str - plain_start, attr);
         }
         plain_start = str + 1;
-        msg_puts_attr((const char *)s, attr == 0 ? hl_attr(HLF_8) : attr);
+        msg_puts_attr((const char *)s, attr == 0 ? HL_ATTR(HLF_8) : attr);
         retval += (int)STRLEN(s);
       } else {
         retval++;
@@ -1299,7 +1300,7 @@ int msg_outtrans_special(
   }
   const char_u *str = strstart;
   int retval = 0;
-  int attr = hl_attr(HLF_8);
+  int attr = HL_ATTR(HLF_8);
 
   while (*str != NUL) {
     const char *string;
@@ -1501,18 +1502,18 @@ void msg_prt_line(char_u *s, int list)
         } else {
           c = lcs_tab1;
           c_extra = lcs_tab2;
-          attr = hl_attr(HLF_8);
+          attr = HL_ATTR(HLF_8);
         }
       } else if (c == 160 && list && lcs_nbsp != NUL) {
         c = lcs_nbsp;
-        attr = hl_attr(HLF_8);
+        attr = HL_ATTR(HLF_8);
       } else if (c == NUL && list && lcs_eol != NUL) {
         p_extra = (char_u *)"";
         c_extra = NUL;
         n_extra = 1;
         c = lcs_eol;
-        attr = hl_attr(HLF_AT);
-        --s;
+        attr = HL_ATTR(HLF_AT);
+        s--;
       } else if (c != NUL && (n = byte2cells(c)) > 1) {
         n_extra = n - 1;
         p_extra = transchar_byte(c);
@@ -1520,13 +1521,13 @@ void msg_prt_line(char_u *s, int list)
         c = *p_extra++;
         /* Use special coloring to be able to distinguish <hex> from
          * the same in plain text. */
-        attr = hl_attr(HLF_8);
+        attr = HL_ATTR(HLF_8);
       } else if (c == ' ' && trail != NULL && s > trail) {
         c = lcs_trail;
-        attr = hl_attr(HLF_8);
+        attr = HL_ATTR(HLF_8);
       } else if (c == ' ' && list && lcs_space != NUL) {
         c = lcs_space;
-        attr = hl_attr(HLF_8);
+        attr = HL_ATTR(HLF_8);
       }
     }
 
@@ -1547,13 +1548,12 @@ static char_u *screen_puts_mbyte(char_u *s, int l, int attr)
 {
   int cw;
 
-  msg_didout = TRUE;            /* remember that line is not empty */
+  msg_didout = true;            // remember that line is not empty
   cw = (*mb_ptr2cells)(s);
-  if (cw > 1 && (
-        cmdmsg_rl ? msg_col <= 1 :
-        msg_col == Columns - 1)) {
-    /* Doesn't fit, print a highlighted '>' to fill it up. */
-    msg_screen_putchar('>', hl_attr(HLF_AT));
+  if (cw > 1
+      && (cmdmsg_rl ? msg_col <= 1 : msg_col == Columns - 1)) {
+    // Doesn't fit, print a highlighted '>' to fill it up.
+    msg_screen_putchar('>', HL_ATTR(HLF_AT));
     return s;
   }
 
@@ -1585,7 +1585,7 @@ void msg_puts(const char *s)
 
 void msg_puts_title(const char *s)
 {
-  msg_puts_attr(s, hl_attr(HLF_T));
+  msg_puts_attr(s, HL_ATTR(HLF_T));
 }
 
 /*
@@ -1607,7 +1607,7 @@ void msg_puts_long_len_attr(char_u *longstr, int len, int attr)
   if (len > room && room >= 20) {
     slen = (room - 3) / 2;
     msg_outtrans_len_attr(longstr, slen, attr);
-    msg_puts_attr("...", hl_attr(HLF_8));
+    msg_puts_attr("...", HL_ATTR(HLF_8));
   }
   msg_outtrans_len_attr(longstr + len - slen, slen, attr);
 }
@@ -1886,7 +1886,7 @@ static void msg_scroll_up(void)
   if (dy_flags & DY_MSGSEP) {
     if (msg_scrolled == 0) {
       screen_fill(Rows-p_ch-1, Rows-p_ch, 0, (int)Columns,
-                  fill_msgsep, fill_msgsep, hl_attr(HLF_MSGSEP));
+                  fill_msgsep, fill_msgsep, HL_ATTR(HLF_MSGSEP));
     }
     int nscroll = MIN(msg_scrollsize()+1, Rows);
     ui_call_set_scroll_region(Rows-nscroll, Rows-1, 0, Columns-1);
@@ -2436,7 +2436,7 @@ void msg_moremsg(int full)
   int attr;
   char_u      *s = (char_u *)_("-- More --");
 
-  attr = hl_attr(HLF_M);
+  attr = HL_ATTR(HLF_M);
   screen_puts(s, (int)Rows - 1, 0, attr);
   if (full)
     screen_puts((char_u *)
@@ -2719,7 +2719,7 @@ void give_warning(char_u *message, bool hl) FUNC_ATTR_NONNULL_ARG(1)
   xfree(keep_msg);
   keep_msg = NULL;
   if (hl) {
-    keep_msg_attr = hl_attr(HLF_W);
+    keep_msg_attr = HL_ATTR(HLF_W);
   } else {
     keep_msg_attr = 0;
   }
@@ -3068,7 +3068,7 @@ void display_confirm_msg(void)
   // Avoid that 'q' at the more prompt truncates the message here.
   confirm_msg_used++;
   if (confirm_msg != NULL) {
-    msg_puts_attr((const char *)confirm_msg, hl_attr(HLF_M));
+    msg_puts_attr((const char *)confirm_msg, HL_ATTR(HLF_M));
   }
   confirm_msg_used--;
 }

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2219,8 +2219,8 @@ change_warning (
     msg_start();
     if (msg_row == Rows - 1)
       msg_col = col;
-    msg_source(hl_attr(HLF_W));
-    MSG_PUTS_ATTR(_(w_readonly), hl_attr(HLF_W) | MSG_HIST);
+    msg_source(HL_ATTR(HLF_W));
+    MSG_PUTS_ATTR(_(w_readonly), HL_ATTR(HLF_W) | MSG_HIST);
     set_vim_var_string(VV_WARNINGMSG, _(w_readonly), -1);
     msg_clr_eos();
     (void)msg_end();
@@ -2260,7 +2260,7 @@ int ask_yesno(const char *const str, const bool direct)
   int r = ' ';
   while (r != 'y' && r != 'n') {
     // Same highlighting as for wait_return.
-    smsg_attr(hl_attr(HLF_R), "%s (y/n)?", str);
+    smsg_attr(HL_ATTR(HLF_R), "%s (y/n)?", str);
     if (direct) {
       r = get_keystroke();
     } else {
@@ -2566,8 +2566,8 @@ void vim_beep(unsigned val)
     /* When 'verbose' is set and we are sourcing a script or executing a
      * function give the user a hint where the beep comes from. */
     if (vim_strchr(p_debug, 'e') != NULL) {
-      msg_source(hl_attr(HLF_W));
-      msg_attr(_("Beep!"), hl_attr(HLF_W));
+      msg_source(HL_ATTR(HLF_W));
+      msg_attr(_("Beep!"), HL_ATTR(HLF_W));
     }
   }
 }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2933,8 +2933,9 @@ void check_visual_highlight(void)
   static bool did_check = false;
 
   if (full_screen) {
-    if (!did_check && hl_attr(HLF_V) == 0)
+    if (!did_check && HL_ATTR(HLF_V) == 0) {
       MSG(_("Warning: terminal cannot highlight"));
+    }
     did_check = true;
   }
 }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3334,7 +3334,7 @@ void ex_display(exarg_T *eap)
 
   if (arg != NULL && *arg == NUL)
     arg = NULL;
-  int attr = hl_attr(HLF_8);
+  int attr = HL_ATTR(HLF_8);
 
   /* Highlight title */
   MSG_PUTS_TITLE(_("\n--- Registers ---"));

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3963,8 +3963,8 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
         static char *w_arabic = N_(
             "W17: Arabic requires UTF-8, do ':set encoding=utf-8'");
 
-        msg_source(hl_attr(HLF_W));
-        msg_attr(_(w_arabic), hl_attr(HLF_W));
+        msg_source(HL_ATTR(HLF_W));
+        msg_attr(_(w_arabic), HL_ATTR(HLF_W));
         set_vim_var_string(VV_WARNINGMSG, _(w_arabic), -1);
       }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2260,7 +2260,7 @@ void qf_list(exarg_T *eap)
         vim_snprintf((char *)IObuff, IOSIZE, "%2d %s",
             i, (char *)fname);
       msg_outtrans_attr(IObuff, i == qi->qf_lists[qi->qf_curlist].qf_index
-                        ? hl_attr(HLF_QFL) : hl_attr(HLF_D));
+                        ? HL_ATTR(HLF_QFL) : HL_ATTR(HLF_D));
       if (qfp->qf_lnum == 0) {
         IObuff[0] = NUL;
       } else if (qfp->qf_col == 0) {
@@ -2271,7 +2271,7 @@ void qf_list(exarg_T *eap)
       }
       vim_snprintf((char *)IObuff + STRLEN(IObuff), IOSIZE, "%s:",
                    (char *)qf_types(qfp->qf_type, qfp->qf_nr));
-      msg_puts_attr((const char *)IObuff, hl_attr(HLF_N));
+      msg_puts_attr((const char *)IObuff, HL_ATTR(HLF_N));
       if (qfp->qf_pattern != NULL) {
         qf_fmt_text(qfp->qf_pattern, IObuff, IOSIZE);
         xstrlcat((char *)IObuff, ":", IOSIZE);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4890,7 +4890,7 @@ win_redr_status_matches (
     screen_puts(buf, row, 0, attr);
     if (selstart != NULL && highlight) {
       *selend = NUL;
-      screen_puts(selstart, row, selstart_col, hl_attr(HLF_WM));
+      screen_puts(selstart, row, selstart_col, HL_ATTR(HLF_WM));
     }
 
     screen_fill(row, row + 1, clen, (int)Columns, fillchar, fillchar, attr);
@@ -5155,7 +5155,7 @@ win_redr_custom (
     stl = p_tal;
     row = 0;
     fillchar = ' ';
-    attr = hl_attr(HLF_TPF);
+    attr = HL_ATTR(HLF_TPF);
     maxwidth = Columns;
     use_sandbox = was_set_insecurely((char_u *)"tabline", 0);
   } else {
@@ -5568,7 +5568,7 @@ static void update_window_hl(win_T *wp, bool invalid)
     wp->w_hl_attr_normal = 0;
   }
   if (wp != curwin) {
-    wp->w_hl_attr_normal = hl_combine_attr(hl_attr(HLF_INACTIVE),
+    wp->w_hl_attr_normal = hl_combine_attr(HL_ATTR(HLF_INACTIVE),
                                            wp->w_hl_attr_normal);
   }
 
@@ -5577,7 +5577,7 @@ static void update_window_hl(win_T *wp, bool invalid)
     if (wp->w_hl_ids[hlf] > 0) {
       attr = syn_id2attr(wp->w_hl_ids[hlf]);
     } else {
-      attr = hl_attr(hlf);
+      attr = HL_ATTR(hlf);
     }
     if (wp->w_hl_attr_normal != 0) {
       attr = hl_combine_attr(wp->w_hl_attr_normal, attr);
@@ -6654,7 +6654,7 @@ int showmode(void)
 
     /* Position on the last line in the window, column 0 */
     msg_pos_mode();
-    attr = hl_attr(HLF_CM);                     /* Highlight mode */
+    attr = HL_ATTR(HLF_CM);                     // Highlight mode
     if (do_mode) {
       MSG_PUTS_ATTR("--", attr);
       // CTRL-X in Insert mode
@@ -6802,7 +6802,7 @@ void clearmode(void)
 {
     msg_pos_mode();
     if (Recording) {
-      recording_mode(hl_attr(HLF_CM));
+      recording_mode(HL_ATTR(HLF_CM));
     }
     msg_clr_eos();
 }
@@ -6833,8 +6833,8 @@ static void draw_tabline(void)
   int modified;
   int c;
   int len;
-  int attr_nosel = hl_attr(HLF_TP);
-  int attr_fill = hl_attr(HLF_TPF);
+  int attr_nosel = HL_ATTR(HLF_TP);
+  int attr_fill = HL_ATTR(HLF_TPF);
   char_u      *p;
   int room;
   int use_sep_chars = (t_colors < 8

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4288,7 +4288,7 @@ find_pattern_in_path(
           if (new_fname != NULL) {
             /* using "new_fname" is more reliable, e.g., when
              * 'includeexpr' is set. */
-            msg_outtrans_attr(new_fname, hl_attr(HLF_D));
+            msg_outtrans_attr(new_fname, HL_ATTR(HLF_D));
           } else {
             /*
              * Isolate the file name.
@@ -4326,7 +4326,7 @@ find_pattern_in_path(
             }
             save_char = p[i];
             p[i] = NUL;
-            msg_outtrans_attr(p, hl_attr(HLF_D));
+            msg_outtrans_attr(p, HL_ATTR(HLF_D));
             p[i] = save_char;
           }
 
@@ -4373,11 +4373,11 @@ find_pattern_in_path(
           files[depth].lnum = 0;
           files[depth].matched = FALSE;
           if (action == ACTION_EXPAND) {
-            msg_hist_off = TRUE;                /* reset in msg_trunc_attr() */
-            vim_snprintf((char*)IObuff, IOSIZE,
-                _("Scanning included file: %s"),
-                (char *)new_fname);
-            msg_trunc_attr(IObuff, TRUE, hl_attr(HLF_R));
+            msg_hist_off = true;                // reset in msg_trunc_attr()
+            vim_snprintf((char *)IObuff, IOSIZE,
+                         _("Scanning included file: %s"),
+                         (char *)new_fname);
+            msg_trunc_attr(IObuff, true, HL_ATTR(HLF_R));
           } else if (p_verbose >= 5) {
             verbose_enter();
             smsg(_("Searching included file %s"),
@@ -4730,7 +4730,7 @@ static void show_pat_in_path(char_u *line, int type, int did_show, int action, F
       msg_puts((const char *)IObuff);
       snprintf((char *)IObuff, IOSIZE, "%4ld", *lnum);  // Show line nr.
       // Highlight line numbers.
-      msg_puts_attr((const char *)IObuff, hl_attr(HLF_N));
+      msg_puts_attr((const char *)IObuff, HL_ATTR(HLF_N));
       msg_puts(" ");
     }
     msg_prt_line(line, FALSE);

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3591,7 +3591,7 @@ syn_list_one (
     {0, NULL}
   };
 
-  attr = hl_attr(HLF_D);                /* highlight like directories */
+  attr = HL_ATTR(HLF_D);                // highlight like directories
 
   /* list the keywords for "id" */
   if (!syncing) {
@@ -3691,9 +3691,9 @@ static void syn_list_cluster(int id)
 
   msg_advance(endcol);
   if (SYN_CLSTR(curwin->w_s)[id].scl_list != NULL) {
-    put_id_list("cluster", SYN_CLSTR(curwin->w_s)[id].scl_list, hl_attr(HLF_D));
+    put_id_list("cluster", SYN_CLSTR(curwin->w_s)[id].scl_list, HL_ATTR(HLF_D));
   } else {
-    msg_puts_attr("cluster", hl_attr(HLF_D));
+    msg_puts_attr("cluster", HL_ATTR(HLF_D));
     msg_puts("=NONE");
   }
 }
@@ -7186,7 +7186,7 @@ static void highlight_list_one(int id)
   if (sgp->sg_link && !got_int) {
     (void)syn_list_header(didh, 9999, id);
     didh = true;
-    msg_puts_attr("links to", hl_attr(HLF_D));
+    msg_puts_attr("links to", HL_ATTR(HLF_D));
     msg_putchar(' ');
     msg_outtrans(HL_TABLE()[HL_TABLE()[id - 1].sg_link - 1].sg_name);
   }
@@ -7234,8 +7234,8 @@ static int highlight_list_arg(int id, int didh, int type, int iarg,
     didh = TRUE;
     if (!got_int) {
       if (*name != NUL) {
-        MSG_PUTS_ATTR(name, hl_attr(HLF_D));
-        MSG_PUTS_ATTR("=", hl_attr(HLF_D));
+        MSG_PUTS_ATTR(name, HL_ATTR(HLF_D));
+        MSG_PUTS_ATTR("=", HL_ATTR(HLF_D));
       }
       msg_outtrans(ts);
     }
@@ -7507,7 +7507,7 @@ static int syn_add_group(char_u *name)
     } else if (!ASCII_ISALNUM(*p) && *p != '_')   {
       /* This is an error, but since there previously was no check only
        * give a warning. */
-      msg_source(hl_attr(HLF_W));
+      msg_source(HL_ATTR(HLF_W));
       MSG(_("W18: Invalid character in group name"));
       break;
     }
@@ -7749,10 +7749,12 @@ static void highlight_list(void)
 {
   int i;
 
-  for (i = 10; --i >= 0; )
-    highlight_list_two(i, hl_attr(HLF_D));
-  for (i = 40; --i >= 0; )
+  for (i = 10; --i >= 0; ) {
+    highlight_list_two(i, HL_ATTR(HLF_D));
+  }
+  for (i = 40; --i >= 0; ) {
     highlight_list_two(99, 0);
+  }
 }
 
 static void highlight_list_two(int cnt, int attr)

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -512,10 +512,10 @@ do_tag (
         if (msg_col == 0)
           msg_didout = FALSE;           /* overwrite previous message */
         msg_start();
-        MSG_PUTS_ATTR(_("  # pri kind tag"), hl_attr(HLF_T));
+        MSG_PUTS_ATTR(_("  # pri kind tag"), HL_ATTR(HLF_T));
         msg_clr_eos();
         taglen_advance(taglen);
-        MSG_PUTS_ATTR(_("file\n"), hl_attr(HLF_T));
+        MSG_PUTS_ATTR(_("file\n"), HL_ATTR(HLF_T));
 
         for (i = 0; i < num_matches && !got_int; i++) {
           parse_match(matches[i], &tagp);
@@ -535,15 +535,15 @@ do_tag (
           }
           msg_advance(13);
           msg_outtrans_len_attr(tagp.tagname,
-              (int)(tagp.tagname_end - tagp.tagname),
-              hl_attr(HLF_T));
+                                (int)(tagp.tagname_end - tagp.tagname),
+                                HL_ATTR(HLF_T));
           msg_putchar(' ');
           taglen_advance(taglen);
 
           /* Find out the actual file name. If it is long, truncate
            * it and put "..." in the middle */
           p = tag_full_fname(&tagp);
-          msg_puts_long_attr(p, hl_attr(HLF_D));
+          msg_puts_long_attr(p, HL_ATTR(HLF_D));
           xfree(p);
 
           if (msg_col > 0)
@@ -573,8 +573,8 @@ do_tag (
                 p = tagp.tagkind_end;
                 continue;
               }
-              /* print all other extra fields */
-              attr = hl_attr(HLF_CM);
+              // print all other extra fields
+              attr = HL_ATTR(HLF_CM);
               while (*p && *p != '\r' && *p != '\n') {
                 if (msg_col + ptr2cells(p) >= Columns) {
                   msg_putchar('\n');
@@ -849,7 +849,7 @@ do_tag (
         if ((num_matches > prev_num_matches || new_tag)
             && num_matches > 1) {
           if (ic) {
-            msg_attr((const char *)IObuff, hl_attr(HLF_W));
+            msg_attr((const char *)IObuff, HL_ATTR(HLF_W));
           } else {
             msg(IObuff);
           }
@@ -960,7 +960,7 @@ void do_tags(exarg_T *eap)
           tagstack[i].fmark.mark.lnum);
       msg_outtrans(IObuff);
       msg_outtrans_attr(name, tagstack[i].fmark.fnum == curbuf->b_fnum
-          ? hl_attr(HLF_D) : 0);
+                        ? HL_ATTR(HLF_D) : 0);
       xfree(name);
     }
     ui_flush();                    /* show one line at a time */

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2534,7 +2534,7 @@ void ex_undolist(exarg_T *eap)
 
     msg_start();
     msg_puts_attr(_("number changes  when               saved"),
-                  hl_attr(HLF_T));
+                  HL_ATTR(HLF_T));
     for (int i = 0; i < ga.ga_len && !got_int; i++) {
       msg_putchar('\n');
       if (got_int) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -1983,7 +1983,8 @@ static void do_intro_line(long row, char_u *mesg, int attr)
       }
     }
     assert(row <= INT_MAX && col <= INT_MAX);
-    screen_puts_len(p, l, (int)row, (int)col, *p == '<' ? hl_attr(HLF_8) : attr);
+    screen_puts_len(p, l, (int)row, (int)col,
+                    *p == '<' ? HL_ATTR(HLF_8) : attr);
     col += clen;
   }
 }

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -272,8 +272,8 @@ enum { FOLD_TEXT_LEN = 51 };  //!< buffer size for get_foldtext()
 
 
 // Enums need a typecast to be used as array index (for Ultrix).
-#define hl_attr(n)      highlight_attr[(int)(n)]
-#define term_str(n)     term_strings[(int)(n)]
+#define HL_ATTR(n)      highlight_attr[(int)(n)]
+#define TERM_STR(n)     term_strings[(int)(n)]
 
 /// Maximum number of bytes in a multi-byte character.  It can be one 32-bit
 /// character of up to 6 bytes, or one 16-bit character of up to three bytes

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3732,7 +3732,7 @@ static void win_enter_ext(win_T *wp, bool undo_sync, int curwin_invalid,
   if (restart_edit)
     redraw_later(VALID);        /* causes status line redraw */
 
-  if (hl_attr(HLF_INACTIVE)
+  if (HL_ATTR(HLF_INACTIVE)
       || (prevwin && prevwin->w_hl_ids[HLF_INACTIVE])
       || curwin->w_hl_ids[HLF_INACTIVE]) {
     redraw_all_later(NOT_VALID);


### PR DESCRIPTION
**vim-patch:8.0.0466: still macros that should be all-caps**

Problem:    There are still a few macros that should be all-caps.
Solution:   Make a few more macros all-caps.
https://github.com/vim/vim/commit/8820b48654b62472821d9b155fe03ab7ac13a05c