### PR TITLE
win/build: fix build failures for MSVC_64, MINGW_32

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -14,9 +14,9 @@ $nvimCmakeVars = @{
 }
 
 # For pull requests, skip some build configurations to save time.
-if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $env:CONFIGURATION -match '^(MSVC_64|MINGW_32)$') {
-  exit 0
-}
+# if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $env:CONFIGURATION -match '^(MSVC_64|MINGW_32)$') {
+#   exit 0
+# }
 
 function exitIfFailed() {
   if ($LastExitCode -ne 0) {

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -10,7 +10,7 @@ if(USE_GCOV)
 endif()
 endif()
 
-if(WIN32)
+if(MINGW)
   # tell MinGW compiler to enable wmain
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -municode")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")


### PR DESCRIPTION
For MSVC, investigate `/municode` error and gettext issues such as the following:

```
 C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets\Microsoft.CppCommon.targets(171,5): error MSB6006: "cmd.exe" exited with code 1. [C:\projects\neovim\build\src\nvim\po\translations.vcxproj]
```

For MINGW, investigate the following:

```
cd /d C:\projects\neovim\build\runtime && C:\projects\neovim\build\bin\nvim -u NONE -i NONE -e --headless -c "helptags ++t doc" -c quit
mingw32-make.exe[2]: *** [runtime\CMakeFiles\helptags.dir\build.make:58: runtime/CMakeFiles/helptags] Error -107374151
```