### PR TITLE
[RFC] vim-patch:8.0.0520

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -286,7 +286,7 @@ void trunc_string(char_u *s, char_u *buf, int room_in, int buflen)
   half = i = (int)STRLEN(s);
   for (;;) {
     do {
-      half = half - (*mb_head_off)(s, s + half - 1) - 1;
+      half = half - utf_head_off(s, s + half - 1) - 1;
     } while (half > 0 && utf_iscomposing(utf_ptr2char(s + half)));
     n = ptr2cells(s + half);
     if (len + n > room || half == 0) {

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -4246,26 +4246,28 @@ regmatch (
             int opndc = 0, inpc;
 
             opnd = OPERAND(scan);
-            /* Safety check (just in case 'encoding' was changed since
-             * compiling the program). */
+            // Safety check (just in case 'encoding' was changed since
+            // compiling the program).
             if ((len = (*mb_ptr2len)(opnd)) < 2) {
               status = RA_NOMATCH;
               break;
             }
-            if (enc_utf8)
-              opndc = mb_ptr2char(opnd);
+            if (enc_utf8) {
+              opndc = utf_ptr2char(opnd);
+            }
             if (enc_utf8 && utf_iscomposing(opndc)) {
               /* When only a composing char is given match at any
                * position where that composing char appears. */
               status = RA_NOMATCH;
               for (i = 0; reginput[i] != NUL; i += utf_ptr2len(reginput + i)) {
-                inpc = mb_ptr2char(reginput + i);
+                inpc = utf_ptr2char(reginput + i);
                 if (!utf_iscomposing(inpc)) {
-                  if (i > 0)
+                  if (i > 0) {
                     break;
+                  }
                 } else if (opndc == inpc) {
-                  /* Include all following composing chars. */
-                  len = i + mb_ptr2len(reginput + i);
+                  // Include all following composing chars.
+                  len = i + utfc_ptr2len(reginput + i);
                   status = RA_MATCH;
                   break;
                 }

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1805,9 +1805,9 @@ collection:
     int plen;
 
 nfa_do_multibyte:
-    /* plen is length of current char with composing chars */
+    // plen is length of current char with composing chars
     if (enc_utf8 && ((*mb_char2len)(c)
-                     != (plen = (*mb_ptr2len)(old_regparse))
+                     != (plen = utfc_ptr2len(old_regparse))
                      || utf_iscomposing(c))) {
       int i = 0;
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3106,9 +3106,9 @@ win_line (
     if (n_extra > 0) {
       if (c_extra != NUL) {
         c = c_extra;
-        mb_c = c;               /* doesn't handle non-utf-8 multi-byte! */
-        if (enc_utf8 && (*mb_char2len)(c) > 1) {
-          mb_utf8 = TRUE;
+        mb_c = c;               // doesn't handle non-utf-8 multi-byte!
+        if (enc_utf8 && utf_char2len(c) > 1) {
+          mb_utf8 = true;
           u8cc[0] = 0;
           c = 0xc0;
         } else
@@ -3118,15 +3118,15 @@ win_line (
         if (has_mbyte) {
           mb_c = c;
           if (enc_utf8) {
-            /* If the UTF-8 character is more than one byte:
-             * Decode it into "mb_c". */
-            mb_l = (*mb_ptr2len)(p_extra);
-            mb_utf8 = FALSE;
-            if (mb_l > n_extra)
+            // If the UTF-8 character is more than one byte:
+            // Decode it into "mb_c".
+            mb_l = utfc_ptr2len(p_extra);
+            mb_utf8 = false;
+            if (mb_l > n_extra) {
               mb_l = 1;
-            else if (mb_l > 1) {
+            } else if (mb_l > 1) {
               mb_c = utfc_ptr2char(p_extra, u8cc);
-              mb_utf8 = TRUE;
+              mb_utf8 = true;
               c = 0xc0;
             }
           } else {
@@ -3177,10 +3177,10 @@ win_line (
       if (has_mbyte) {
         mb_c = c;
         if (enc_utf8) {
-          /* If the UTF-8 character is more than one byte: Decode it
-           * into "mb_c". */
-          mb_l = (*mb_ptr2len)(ptr);
-          mb_utf8 = FALSE;
+          // If the UTF-8 character is more than one byte: Decode it
+          // into "mb_c".
+          mb_l = utfc_ptr2len(ptr);
+          mb_utf8 = false;
           if (mb_l > 1) {
             mb_c = utfc_ptr2char(ptr, u8cc);
             // Overlong encoded ASCII or ASCII with composing char
@@ -3486,7 +3486,7 @@ win_line (
           extra_attr = win_hl_attr(wp, HLF_0);
           saved_attr2 = char_attr;  // save current attr
           mb_c = c;
-          if (enc_utf8 && (*mb_char2len)(c) > 1) {
+          if (enc_utf8 && utf_char2len(c) > 1) {
             mb_utf8 = true;
             u8cc[0] = 0;
             c = 0xc0;
@@ -3501,12 +3501,13 @@ win_line (
           extra_attr = win_hl_attr(wp, HLF_0);
           saved_attr2 = char_attr;  // save current attr
           mb_c = c;
-          if (enc_utf8 && (*mb_char2len)(c) > 1) {
-            mb_utf8 = TRUE;
+          if (enc_utf8 && utf_char2len(c) > 1) {
+            mb_utf8 = true;
             u8cc[0] = 0;
             c = 0xc0;
-          } else
-            mb_utf8 = FALSE;
+          } else {
+            mb_utf8 = false;
+          }
         }
       }
 
@@ -3602,8 +3603,8 @@ win_line (
             extra_attr = win_hl_attr(wp, HLF_0);
             saved_attr2 = char_attr;  // save current attr
             mb_c = c;
-            if (enc_utf8 && (*mb_char2len)(c) > 1) {
-              mb_utf8 = TRUE;
+            if (enc_utf8 && utf_char2len(c) > 1) {
+              mb_utf8 = true;
               u8cc[0] = 0;
               c = 0xc0;
             }
@@ -3647,8 +3648,8 @@ win_line (
           extra_attr = win_hl_attr(wp, HLF_AT);
           n_attr = 1;
           mb_c = c;
-          if (enc_utf8 && (*mb_char2len)(c) > 1) {
-            mb_utf8 = TRUE;
+          if (enc_utf8 && utf_char2len(c) > 1) {
+            mb_utf8 = true;
             u8cc[0] = 0;
             c = 0xc0;
           } else
@@ -3762,8 +3763,8 @@ win_line (
           n_skip = 1;
         }
         mb_c = c;
-        if (enc_utf8 && (*mb_char2len)(c) > 1) {
-          mb_utf8 = TRUE;
+        if (enc_utf8 && utf_char2len(c) > 1) {
+          mb_utf8 = true;
           u8cc[0] = 0;
           c = 0xc0;
         } else
@@ -3816,8 +3817,8 @@ win_line (
         extra_attr = win_hl_attr(wp, HLF_AT);
       }
       mb_c = c;
-      if (enc_utf8 && (*mb_char2len)(c) > 1) {
-        mb_utf8 = TRUE;
+      if (enc_utf8 && utf_char2len(c) > 1) {
+        mb_utf8 = true;
         u8cc[0] = 0;
         c = 0xc0;
       } else {
@@ -4044,8 +4045,8 @@ win_line (
       c = lcs_ext;
       char_attr = win_hl_attr(wp, HLF_AT);
       mb_c = c;
-      if (enc_utf8 && (*mb_char2len)(c) > 1) {
-        mb_utf8 = TRUE;
+      if (enc_utf8 && utf_char2len(c) > 1) {
+        mb_utf8 = true;
         u8cc[0] = 0;
         c = 0xc0;
       } else


### PR DESCRIPTION
#### vim-patch:8.0.0520: using a function pointer while the function is known

Problem:    Using a function pointer instead of the actual function, which we
            know.
Solution:   Change mb_ functions to utf_ functions when already checked for
            Unicode. (Dominique Pelle, closes vim/vim#1582)
https://github.com/vim/vim/commit/ace95989ed81929a84e205b26d0972cb9d6b4b19