### PR TITLE
[RFC] Ex mode: use getexline() instead of getexmodeline()

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -78,7 +78,7 @@ Ex mode.  Reads stdin as Ex commands.
 See
 .Ic ":help Ex-mode" .
 .It Fl E
-Ex mode, improved.  Reads stdin as text.
+Ex mode.  Reads stdin as text.
 See
 .Ic :help gQ .
 .It Fl es

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -642,25 +642,12 @@ The command CTRL-\ CTRL-G or <C-\><C-G> can be used to go to Insert mode when
 make sure Vim is in the mode indicated by 'insertmode', without knowing in
 what mode Vim currently is.
 
-				    *Q* *mode-Ex* *Ex-mode* *Ex* *EX* *E501*
-Q			Switch to "Ex" mode.  This is a bit like typing ":"
-			commands one after another, except:
+				*gQ* *Q* *mode-Ex* *Ex-mode* *Ex* *EX* *E501*
+Q or gQ			Switch to Ex mode.  This is like typing ":" commands
+			one after another, except:
 			- You don't have to keep pressing ":".
 			- The screen doesn't get updated after each command.
-			- There is no normal command-line editing.
-			- Mappings and abbreviations are not used.
-			In fact, you are editing the lines with the "standard"
-			line-input editing commands (<Del> or <BS> to erase,
-			CTRL-U to kill the whole line).
-			Vim will enter this mode by default if it's invoked as
-			"ex" on the command-line.
-			Use the ":vi" command |:visual| to exit "Ex" mode.
-
-					*gQ*
-gQ			Switch to "Ex" mode like with "Q", but really behave
-			like typing ":" commands after another.  All command
-			line editing, completion etc. is available.
-			Use the ":vi" command |:visual| to exit "Ex" mode.
+			Use the ":vi" command |:visual| to exit this mode.
 
 ==============================================================================
 7. The window contents					*window-contents*

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -185,11 +185,12 @@ argument.
 		delete(), rename(), mkdir(), writefile(), libcall(),
 		jobstart(), etc.
 
-							*-e*
--e		Start Vim in Ex mode |Q|.
+-e							*-e* *-E*
+-E		Start Nvim in Ex mode |gQ|.
 
-							*-E*
--E		Start Vim in improved Ex mode |gQ|.
+		If stdin is not a TTY:
+		  -e reads stdin as Ex commands.
+		  -E reads stdin as text (into buffer 1).
 
 							*-es* *-Es*
 -es							*-s-ex* *silent-mode*
@@ -207,6 +208,11 @@ argument.
 <
 		User |init.vim| is skipped (unless given with |-u|).
 		|$TERM| is not used.
+
+		If stdin is not a TTY:
+		  -es reads stdin as Ex commands.
+		  -Es reads stdin as text (into buffer 1).
+
 		Example: >
 			printf "put ='foo'\n%%print\n" | nvim -es
 <

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -315,10 +315,15 @@ Macro/|recording| behavior
   macros and 'keymap' at the same time. This also means you can use |:imap| on
   the results of keys from 'keymap'.
 
+Normal commands:
+  |Q| is the same as |gQ|
+
 Options:
   'ttimeout', 'ttimeoutlen' behavior was simplified
 
 Startup:
+  |-e| and |-es| invoke the same "improved Ex mode" as -E and -Es.
+  |-E| and |-Es| reads stdin as text (into buffer 1).
   |-s| reads Normal commands from stdin if the script name is "-".
   Reading text (instead of commands) from stdin |--|:
     - works by default: "-" file is optional
@@ -465,4 +470,4 @@ TUI:
   always uses 7-bit control sequences.
 
 ==============================================================================
- vim:tw=78:ts=8:noet:ft=help:norl:
+ vim:tw=78:ts=8:sw=2:noet:ft=help:norl:

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -188,15 +188,8 @@ static void restore_dbg_stuff(struct dbg_stuff *dsp)
   current_exception = dsp->current_exception;
 }
 
-
-/*
- * do_exmode(): Repeatedly get commands for the "Ex" mode, until the ":vi"
- * command is given.
- */
-void 
-do_exmode (
-    int improved                       /* TRUE for "improved Ex" mode */
-)
+/// Repeatedly get commands for Ex mode, until the ":vi" command is given.
+void do_exmode(int improved)
 {
   int save_msg_scroll;
   int prev_msg_row;
@@ -232,11 +225,8 @@ do_exmode (
     changedtick = curbuf->b_changedtick;
     prev_msg_row = msg_row;
     prev_line = curwin->w_cursor.lnum;
-    if (improved) {
-      cmdline_row = msg_row;
-      do_cmdline(NULL, getexline, NULL, 0);
-    } else
-      do_cmdline(NULL, getexmodeline, NULL, DOCMD_NOWAIT);
+    cmdline_row = msg_row;
+    do_cmdline(NULL, getexline, NULL, 0);
     lines_left = Rows - 1;
 
     if ((prev_line != curwin->w_cursor.lnum

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -872,7 +872,7 @@ static void command_line_scan(mparm_T *parmp)
           exmode_active = EXMODE_NORMAL;
           break;
         }
-        case 'E': {  // "-E" Improved Ex mode
+        case 'E': {  // "-E" Ex mode
           exmode_active = EXMODE_VIM;
           break;
         }
@@ -1896,8 +1896,8 @@ static void usage(void)
   mch_msg("\n");
   mch_msg(_("  -b                    Binary mode\n"));
   mch_msg(_("  -d                    Diff mode\n"));
-  mch_msg(_("  -e, -E                Ex mode, Improved Ex mode\n"));
-  mch_msg(_("  -es                   Silent (batch) mode\n"));
+  mch_msg(_("  -e, -E                Ex mode\n"));
+  mch_msg(_("  -es, -Es              Silent (batch) mode\n"));
   mch_msg(_("  -h, --help            Print this help message\n"));
   mch_msg(_("  -i <shada>            Use this shada file\n"));
   mch_msg(_("  -m                    Modifications (writing files) not allowed\n"));

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -301,9 +301,11 @@ int main(int argc, char **argv)
   // Read ex-commands if invoked with "-es".
   //
   bool reading_tty = !headless_mode
+                     && !silent_mode
                      && (params.input_isatty || params.output_isatty
                          || params.err_isatty);
-  bool reading_excmds = !params.input_isatty && silent_mode
+  bool reading_excmds = !params.input_isatty
+                        && silent_mode
                         && exmode_active == EXMODE_NORMAL;
   if (reading_tty || reading_excmds) {
     // One of the startup commands (arguments, sourced scripts or plugins) may

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -157,6 +157,14 @@ describe('startup', function()
     eq(inputstr,
        funcs.system({nvim_prog, '-i', 'NONE', '-Es', '+%print', '-' },
                     input))
+    -- with `-u NORC`
+    eq('thepartycontinues\n',
+       funcs.system({nvim_prog, '-n', '-u', 'NORC', '-Es', '+.print' },
+                    { 'thepartycontinues', '' }))
+    -- without `-u`
+    eq('thepartycontinues\n',
+       funcs.system({nvim_prog, '-n', '-Es', '+.print' },
+                    { 'thepartycontinues', '' }))
 
     --
     -- -es: read stdin as ex-commands
@@ -167,6 +175,14 @@ describe('startup', function()
     eq('line1\nline2\n',
        funcs.system({nvim_prog, '-i', 'NONE', '-es', '-' },
                     input))
+    -- with `-u NORC`
+    eq('  encoding=utf-8\n',
+       funcs.system({nvim_prog, '-n', '-u', 'NORC', '-es' },
+                    { 'set encoding', '' }))
+    -- without `-u`
+    eq('  encoding=utf-8\n',
+       funcs.system({nvim_prog, '-n', '-es' },
+                    { 'set encoding', '' }))
   end)
 end)
 

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -123,8 +123,18 @@ describe('startup', function()
   end)
 
   it('-e/-E interactive #7679', function()
-    clear('-E')
+    clear('-e')
     local screen = Screen.new(25, 3)
+    screen:attach()
+    feed("put ='from -e'<CR>")
+    screen:expect([[
+      :put ='from -e'          |
+      from -e                  |
+      :^                        |
+    ]])
+
+    clear('-E')
+    screen = Screen.new(25, 3)
     screen:attach()
     feed("put ='from -E'<CR>")
     screen:expect([[


### PR DESCRIPTION
This is a departure from traditional Ex mode (Q, -e), but it should not
impact most Ex scripts.

Before this change:
* the screen test hangs.

After this change:
* Q acts like gQ.
* -e differs from -E only in its treatment of stdin.

This moves towards potentially removing getexmodeline().
(HINT: That does NOT mean "removing Ex mode", it means removing the
Vi-compatible Ex mode, which differs from Vim's "improved Ex mode" only
in some minor details (e.g. mappings are disabled).)

ref #1089 :-)~