### PR TITLE
[RDY]vim-patch:8.0.0451

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -804,7 +804,7 @@ unsigned int win_linetabsize(win_T *wp, char_u *line, colnr_T len)
 
   for (char_u *s = line;
        *s != NUL && (len == MAXCOL || s < line + len);
-       mb_ptr_adv(s)) {
+       MB_PTR_ADV(s)) {
     col += win_lbr_chartabsize(wp, line, s, col, NULL);
   }
 
@@ -971,7 +971,7 @@ int lbr_chartabsize_adv(char_u *line, char_u **s, colnr_T col)
   int retval;
 
   retval = lbr_chartabsize(line, *s, col);
-  mb_ptr_adv(*s);
+  MB_PTR_ADV(*s);
   return retval;
 }
 
@@ -1038,7 +1038,7 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
 
     for (;;) {
       ps = s;
-      mb_ptr_adv(s);
+      MB_PTR_ADV(s);
       c = *s;
 
       if (!(c != NUL
@@ -1283,7 +1283,7 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor,
       }
 
       vcol += incr;
-      mb_ptr_adv(ptr);
+      MB_PTR_ADV(ptr);
     }
   } else {
     for (;;) {
@@ -1304,7 +1304,7 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor,
       }
 
       vcol += incr;
-      mb_ptr_adv(ptr);
+      MB_PTR_ADV(ptr);
     }
   }
 

--- a/src/nvim/charset.h
+++ b/src/nvim/charset.h
@@ -34,4 +34,15 @@ typedef enum {
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "charset.h.generated.h"
 #endif
+
+static inline bool vim_isbreak(int c)
+  REAL_FATTR_CONST
+  REAL_FATTR_ALWAYS_INLINE;
+
+/// Check if `c` is one of the characters in 'breakat'.
+/// Used very often if 'linebreak' is set
+static inline bool vim_isbreak(int c)
+{
+  return breakat_flags[(char_u)c];
+}
 #endif  // NVIM_CHARSET_H

--- a/src/nvim/charset.h
+++ b/src/nvim/charset.h
@@ -5,6 +5,7 @@
 #include "nvim/pos.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/eval/typval.h"
+#include "nvim/option_defs.h"
 
 /// Return the folded-case equivalent of the given character
 ///

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -144,7 +144,7 @@ static int coladvance2(
     while (col <= wcol && *ptr != NUL) {
       /* Count a tab for what it's worth (if list mode not on) */
       csize = win_lbr_chartabsize(curwin, line, ptr, col, &head);
-      mb_ptr_adv(ptr);
+      MB_PTR_ADV(ptr);
       col += csize;
     }
     idx = (int)(ptr - line);

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -658,7 +658,7 @@ static int insert_execute(VimState *state, int key)
         char_u *p;
 
         if (str != NULL) {
-          for (p = str; *p != NUL; mb_ptr_adv(p)) {
+          for (p = str; *p != NUL; MB_PTR_ADV(p)) {
             ins_compl_addleader(PTR2CHAR(p));
           }
           xfree(str);
@@ -1196,7 +1196,7 @@ normalchar:
       if (str != NULL) {
         if (*str != NUL && stop_arrow() != FAIL) {
           // Insert the new value of v:char literally.
-          for (p = str; *p != NUL; mb_ptr_adv(p)) {
+          for (p = str; *p != NUL; MB_PTR_ADV(p)) {
             s->c = PTR2CHAR(p);
             if (s->c == CAR || s->c == K_KENTER || s->c == NL) {
               ins_eol(s->c);
@@ -2008,8 +2008,8 @@ int ins_compl_add_infercase(char_u *str, int len, int icase, char_u *fname, int 
       const char_u *p = str;
       actual_len = 0;
       while (*p != NUL) {
-        mb_ptr_adv(p);
-        ++actual_len;
+        MB_PTR_ADV(p);
+        actual_len++;
       }
     } else
       actual_len = len;
@@ -2019,8 +2019,8 @@ int ins_compl_add_infercase(char_u *str, int len, int icase, char_u *fname, int 
       const char_u *p = compl_orig_text;
       actual_compl_length = 0;
       while (*p != NUL) {
-        mb_ptr_adv(p);
-        ++actual_compl_length;
+        MB_PTR_ADV(p);
+        actual_compl_length++;
       }
     } else
       actual_compl_length = compl_length;
@@ -2322,8 +2322,8 @@ static void ins_compl_longest_match(compl_T *match)
         break;
       }
       if (has_mbyte) {
-        mb_ptr_adv(p);
-        mb_ptr_adv(s);
+        MB_PTR_ADV(p);
+        MB_PTR_ADV(s);
       } else {
         ++p;
         ++s;
@@ -2974,7 +2974,7 @@ static int ins_compl_bs(void)
 
   line = get_cursor_line_ptr();
   p = line + curwin->w_cursor.col;
-  mb_ptr_back(line, p);
+  MB_PTR_BACK(line, p);
 
   // Stop completion when the whole word was deleted.  For Omni completion
   // allow the word to be deleted, we won't match everything.
@@ -3440,8 +3440,9 @@ static void ins_compl_fixRedoBufForLeader(char_u *ptr_arg)
       ;
     if (len > 0)
       len -= (*mb_head_off)(p, p + len);
-    for (p += len; *p != NUL; mb_ptr_adv(p))
+    for (p += len; *p != NUL; MB_PTR_ADV(p)) {
       AppendCharToRedobuff(K_BS);
+    }
   } else {
     len = 0;
   }
@@ -4597,13 +4598,15 @@ static int ins_complete(int c, bool enable_pum)
       if (startcol > 0) {
         char_u  *p = line + startcol;
 
-        mb_ptr_back(line, p);
-        while (p > line && vim_isfilec(PTR2CHAR(p)))
-          mb_ptr_back(line, p);
-        if (p == line && vim_isfilec(PTR2CHAR(p)))
+        MB_PTR_BACK(line, p);
+        while (p > line && vim_isfilec(PTR2CHAR(p))) {
+          MB_PTR_BACK(line, p);
+        }
+        if (p == line && vim_isfilec(PTR2CHAR(p))) {
           startcol = 0;
-        else
+        } else {
           startcol = (int)(p - line) + 1;
+        }
       }
 
       compl_col += startcol;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -110,8 +110,8 @@
 
 #define DICT_MAXNEST 100        /* maximum nesting of lists and dicts */
 
-#define AUTOLOAD_CHAR '#'       /* Character used as separator in autoload 
-                                   function/variable names. */
+// Character used as separator in autoload function/variable names.
+#define AUTOLOAD_CHAR '#'
 
 /*
  * Structure returned by get_lval() and used by set_var_lval().
@@ -728,8 +728,8 @@ static char_u   *redir_varname = NULL;
  * Start recording command output to a variable
  * Returns OK if successfully completed the setup.  FAIL otherwise.
  */
-int 
-var_redir_start (
+int
+var_redir_start(
     char_u *name,
     int append                     /* append to an existing variable */
 )
@@ -926,8 +926,8 @@ void eval_patch(const char *const origfile, const char *const difffile,
  * Sets "error" to TRUE if there was an error.
  * Return TRUE or FALSE.
  */
-int 
-eval_to_bool (
+int
+eval_to_bool(
     char_u *arg,
     bool *error,
     char_u **nextcmd,
@@ -1503,8 +1503,8 @@ void ex_let(exarg_T *eap)
  * or concatenate.
  * Returns OK or FAIL;
  */
-static int 
-ex_let_vars (
+static int
+ex_let_vars(
     char_u *arg_start,
     typval_T *tv,
     int copy,                       /* copy values from "tv", don't move */
@@ -2581,9 +2581,10 @@ void set_context_for_expression(expand_T *xp, char_u *arg, cmdidx_T cmdidx)
       /* ":let var1 var2 ...": find last space. */
       for (p = arg + STRLEN(arg); p >= arg; ) {
         xp->xp_pattern = p;
-        mb_ptr_back(arg, p);
-        if (ascii_iswhite(*p))
+        MB_PTR_BACK(arg, p);
+        if (ascii_iswhite(*p)) {
           break;
+        }
       }
       return;
     }
@@ -4307,8 +4308,8 @@ static int eval7(
  * "*arg" points to the '[' or '.'.
  * Returns FAIL or OK. "*arg" is advanced to after the ']'.
  */
-static int 
-eval_index (
+static int
+eval_index(
     char_u **arg,
     typval_T *rettv,
     int evaluate,
@@ -4653,7 +4654,7 @@ static int get_string_tv(char_u **arg, typval_T *rettv, int evaluate)
   /*
    * Find the end of the string, skipping backslashed characters.
    */
-  for (p = *arg + 1; *p != NUL && *p != '"'; mb_ptr_adv(p)) {
+  for (p = *arg + 1; *p != NUL && *p != '"'; MB_PTR_ADV(p)) {
     if (*p == '\\' && p[1] != NUL) {
       ++p;
       /* A "\<x>" form occupies at least 4 characters, and produces up
@@ -4777,7 +4778,7 @@ static int get_lit_string_tv(char_u **arg, typval_T *rettv, int evaluate)
   /*
    * Find the end of the string, skipping ''.
    */
-  for (p = *arg + 1; *p != NUL; mb_ptr_adv(p)) {
+  for (p = *arg + 1; *p != NUL; MB_PTR_ADV(p)) {
     if (*p == '\'') {
       if (p[1] != '\'')
         break;
@@ -6061,15 +6062,15 @@ static char_u *deref_func_name(const char *name, int *lenp,
  * Allocate a variable for the result of a function.
  * Return OK or FAIL.
  */
-static int 
-get_func_tv (
-    char_u *name,              /* name of the function */
-    int len,                        /* length of "name" */
+static int
+get_func_tv(
+    char_u *name,           // name of the function
+    int len,                // length of "name"
     typval_T *rettv,
-    char_u **arg,              /* argument, pointing to the '(' */
-    linenr_T firstline,             /* first line of range */
-    linenr_T lastline,              /* last line of range */
-    int *doesrange,         /* return: function handled range */
+    char_u **arg,           // argument, pointing to the '('
+    linenr_T firstline,     // first line of range
+    linenr_T lastline,      // last line of range
+    int *doesrange,         // return: function handled range
     int evaluate,
     partial_T *partial,     // for extra arguments
     dict_T *selfdict        // Dictionary for "self"
@@ -9961,8 +9962,8 @@ static void f_getmatches(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   while (cur != NULL) {
     dict_T *dict = tv_dict_alloc();
     if (cur->match.regprog == NULL) {
-      // match added with matchaddpos() 
-      for (i = 0; i < MAXPOSMATCH; ++i) {
+      // match added with matchaddpos()
+      for (i = 0; i < MAXPOSMATCH; i++) {
         llpos_T   *llpos;
         char buf[6];
 
@@ -10380,8 +10381,8 @@ static void f_getwinvar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /*
  * getwinvar() and gettabwinvar()
  */
-static void 
-getwinvar (
+static void
+getwinvar(
     typval_T *argvars,
     typval_T *rettv,
     int off                    /* 1 for gettabwinvar() */
@@ -14163,17 +14164,17 @@ static void f_searchpairpos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
  * Used by searchpair(), see its documentation for the details.
  * Returns 0 or -1 for no match,
  */
-long 
-do_searchpair (
-    char_u *spat,          /* start pattern */
-    char_u *mpat,          /* middle pattern */
-    char_u *epat,          /* end pattern */
-    int dir,                    /* BACKWARD or FORWARD */
-    char_u *skip,          /* skip expression */
-    int flags,                  /* SP_SETPCMARK and other SP_ values */
+long
+do_searchpair(
+    char_u *spat,          // start pattern
+    char_u *mpat,          // middle pattern
+    char_u *epat,          // end pattern
+    int dir,               // BACKWARD or FORWARD
+    char_u *skip,          // skip expression
+    int flags,             // SP_SETPCMARK and other SP_ values
     pos_T *match_pos,
-    linenr_T lnum_stop,         /* stop at this line if not zero */
-    long time_limit            /* stop after this many msec */
+    linenr_T lnum_stop,    // stop at this line if not zero
+    long time_limit        // stop after this many msec
 )
 {
   char_u      *save_cpo;
@@ -16401,7 +16402,7 @@ static list_T *string_to_list(const char *str, size_t len, const bool keepempty)
   return list;
 }
 
-static void get_system_output_as_rettv(typval_T *argvars, typval_T *rettv, 
+static void get_system_output_as_rettv(typval_T *argvars, typval_T *rettv,
                                        bool retlist)
 {
   rettv->v_type = VAR_STRING;
@@ -18064,16 +18065,17 @@ static const char_u *find_name_end(const char_u *arg, const char_u **expr_start,
            || *p == '{'
            || ((flags & FNE_INCL_BR) && (*p == '[' || *p == '.'))
            || mb_nest != 0
-           || br_nest != 0); mb_ptr_adv(p)) {
+           || br_nest != 0); MB_PTR_ADV(p)) {
     if (*p == '\'') {
-      /* skip over 'string' to avoid counting [ and ] inside it. */
-      for (p = p + 1; *p != NUL && *p != '\''; mb_ptr_adv(p))
-        ;
-      if (*p == NUL)
+      // skip over 'string' to avoid counting [ and ] inside it.
+      for (p = p + 1; *p != NUL && *p != '\''; MB_PTR_ADV(p)) {
+      }
+      if (*p == NUL) {
         break;
+      }
     } else if (*p == '"') {
       // skip over "str\"ing" to avoid counting [ and ] inside it.
-      for (p = p + 1; *p != NUL && *p != '"'; mb_ptr_adv(p)) {
+      for (p = p + 1; *p != NUL && *p != '"'; MB_PTR_ADV(p)) {
         if (*p == '\\' && p[1] != NUL) {
           ++p;
         }
@@ -20696,8 +20698,8 @@ void func_dump_profile(FILE *fd)
   xfree(sorttab);
 }
 
-static void 
-prof_sort_list (
+static void
+prof_sort_list(
     FILE *fd,
     ufunc_T **sorttab,
     int st_len,
@@ -21554,8 +21556,8 @@ static int can_free_funccal(funccall_T *fc, int copyID)
 /*
  * Free "fc" and what it contains.
  */
-static void 
-free_funccal (
+static void
+free_funccal(
     funccall_T *fc,
     int free_val              /* a: vars were allocated */
 )
@@ -22109,13 +22111,13 @@ void reset_v_option_vars(void)
  * Returns VALID_ flags or -1 for failure.
  * When there is an error, *fnamep is set to NULL.
  */
-int 
-modify_fname (
-    char_u *src,               /* string with modifiers */
-    size_t *usedlen,           /* characters after src that are used */
-    char_u **fnamep,           /* file name so far */
-    char_u **bufp,             /* buffer for allocated file name or NULL */
-    size_t *fnamelen           /* length of fnamep */
+int
+modify_fname(
+    char_u *src,              // string with modifiers
+    size_t *usedlen,          // characters after src that are used
+    char_u **fnamep,          // file name so far
+    char_u **bufp,            // buffer for allocated file name or NULL
+    size_t *fnamelen          // length of fnamep
 )
 {
   int valid = 0;
@@ -22151,15 +22153,16 @@ repeat:
         return -1;
     }
 
-    /* When "/." or "/.." is used: force expansion to get rid of it. */
-    for (p = *fnamep; *p != NUL; mb_ptr_adv(p)) {
+    // When "/." or "/.." is used: force expansion to get rid of it.
+    for (p = *fnamep; *p != NUL; MB_PTR_ADV(p)) {
       if (vim_ispathsep(*p)
           && p[1] == '.'
           && (p[2] == NUL
               || vim_ispathsep(p[2])
               || (p[2] == '.'
-                  && (p[3] == NUL || vim_ispathsep(p[3])))))
+                  && (p[3] == NUL || vim_ispathsep(p[3]))))) {
         break;
+      }
     }
 
     /* FullName_save() is slow, don't use it when not needed. */
@@ -22239,8 +22242,9 @@ repeat:
     valid |= VALID_HEAD;
     *usedlen += 2;
     s = get_past_head(*fnamep);
-    while (tail > s && after_pathsep((char *)s, (char *)tail))
-      mb_ptr_back(*fnamep, tail);
+    while (tail > s && after_pathsep((char *)s, (char *)tail)) {
+      MB_PTR_BACK(*fnamep, tail);
+    }
     *fnamelen = (size_t)(tail - *fnamep);
     if (*fnamelen == 0) {
       /* Result is empty.  Turn it into "." to make ":cd %:h" work. */
@@ -22248,8 +22252,9 @@ repeat:
       *bufp = *fnamep = tail = vim_strsave((char_u *)".");
       *fnamelen = 1;
     } else {
-      while (tail > s && !after_pathsep((char *)s, (char *)tail))
-        mb_ptr_back(*fnamep, tail);
+      while (tail > s && !after_pathsep((char *)s, (char *)tail)) {
+        MB_PTR_BACK(*fnamep, tail);
+      }
     }
   }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3269,9 +3269,10 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
         *cmd++ = NUL;                           /* replace it with a NUL */
         break;
       }
-      if (cmd[0] == '\\' && cmd[1] != 0)        /* skip escaped characters */
-        ++cmd;
-      mb_ptr_adv(cmd);
+      if (cmd[0] == '\\' && cmd[1] != 0) {      // skip escaped characters
+        cmd++;
+      }
+      MB_PTR_ADV(cmd);
     }
 
     if (!eap->skip && !preview) {

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2532,7 +2532,7 @@ static void add_pack_plugin(char_u *fname, void *cookie)
   if (cookie != &APP_LOAD && strstr((char *)p_rtp, ffname) == NULL) {
     // directory is not yet in 'runtimepath', add it
     p4 = p3 = p2 = p1 = get_past_head((char_u *)ffname);
-    for (p = p1; *p; mb_ptr_adv(p)) {
+    for (p = p1; *p; MB_PTR_ADV(p)) {
       if (vim_ispathsep_nocolon(*p)) {
         p4 = p3; p3 = p2; p2 = p1; p1 = p;
       }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2872,7 +2872,7 @@ const char * set_one_cmd_context(
           return NULL;              /* It's a comment */
         }
       }
-      mb_ptr_adv(p);
+      MB_PTR_ADV(p);
     }
   }
 
@@ -2890,9 +2890,10 @@ const char * set_one_cmd_context(
       // Argument starts after a space.
       xp->xp_pattern = (char_u *)++p;
     } else {
-      if (*p == '\\' && *(p + 1) != NUL)
-        ++p;         /* skip over escaped character */
-      mb_ptr_adv(p);
+      if (*p == '\\' && *(p + 1) != NUL) {
+        p++;        // skip over escaped character
+      }
+      MB_PTR_ADV(p);
     }
   }
 
@@ -2943,7 +2944,7 @@ const char * set_one_cmd_context(
           } else {
             len = 1;
           }
-          mb_ptr_adv(p);
+          MB_PTR_ADV(p);
         }
         if (in_quote) {
           bow = p;
@@ -2952,7 +2953,7 @@ const char * set_one_cmd_context(
         }
         p -= len;
       }
-      mb_ptr_adv(p);
+      MB_PTR_ADV(p);
     }
 
     /*
@@ -3336,12 +3337,13 @@ const char * set_one_cmd_context(
         // Find start of last argument.
         p = arg;
         while (*p) {
-          if (*p == ' ')
-            /* argument starts after a space */
+          if (*p == ' ') {
+            // argument starts after a space
             arg = p + 1;
-          else if (*p == '\\' && *(p + 1) != NUL)
-            ++p;                 /* skip over escaped character */
-          mb_ptr_adv(p);
+          } else if (*p == '\\' && *(p + 1) != NUL) {
+            p++;                // skip over escaped character
+          }
+          MB_PTR_ADV(p);
         }
         xp->xp_pattern = (char_u *)arg;
       }
@@ -4238,7 +4240,7 @@ void separate_nextcmd(exarg_T *eap)
 
   p = skip_grep_pat(eap);
 
-  for (; *p; mb_ptr_adv(p)) {
+  for (; *p; MB_PTR_ADV(p)) {
     if (*p == Ctrl_V) {
       if (eap->argt & (USECTRLV | XFILE))
         ++p;                    /* skip CTRL-V and next char */
@@ -4322,7 +4324,7 @@ skip_cmd_arg (
       else
         ++p;
     }
-    mb_ptr_adv(p);
+    MB_PTR_ADV(p);
   }
   return p;
 }
@@ -9486,10 +9488,12 @@ static int ses_put_fname(FILE *fd, char_u *name, unsigned *flagp)
   char_u *sname = home_replace_save(NULL, name);
 
   if (*flagp & SSOP_SLASH) {
-    /* change all backslashes to forward slashes */
-    for (p = sname; *p != NUL; mb_ptr_adv(p))
-      if (*p == '\\')
+    // change all backslashes to forward slashes
+    for (p = sname; *p != NUL; MB_PTR_ADV(p)) {
+      if (*p == '\\') {
         *p = '/';
+      }
+    }
   }
 
   // Escape special characters.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2934,7 +2934,7 @@ static void ui_ext_cmdline_show(CmdlineInfo *line)
   Array content = ARRAY_DICT_INIT;
   if (cmdline_star) {
     size_t len = 0;
-    for (char_u *p = ccline.cmdbuff; *p; mb_ptr_adv(p)) {
+    for (char_u *p = ccline.cmdbuff; *p; MB_PTR_ADV(p)) {
       len++;
     }
     char *buf = xmallocz(len);
@@ -4254,7 +4254,7 @@ char_u *sm_gettail(char_u *s)
       t = p;
       had_sep = FALSE;
     }
-    mb_ptr_adv(p);
+    MB_PTR_ADV(p);
   }
   return t;
 }
@@ -5179,7 +5179,7 @@ static int ExpandRTDir(char_u *pat, int flags, int *num_file, char_u ***file,
     char_u *e = s + STRLEN(s);
     if (e - s > 4 && STRNICMP(e - 4, ".vim", 4) == 0) {
       e -= 4;
-      for (s = e; s > match; mb_ptr_back(match, s)) {
+      for (s = e; s > match; MB_PTR_BACK(match, s)) {
         if (vim_ispathsep(*s)) {
           break;
         }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4404,7 +4404,7 @@ char *modname(const char *fname, const char *ext, bool prepend_dot)
   // Search backwards until we hit a '/', '\' or ':'.
   // Then truncate what is after the '/', '\' or ':' to BASENAMELEN characters.
   char *ptr = NULL;
-  for (ptr = retval + fnamelen; ptr > retval; mb_ptr_back(retval, ptr)) {
+  for (ptr = retval + fnamelen; ptr > retval; MB_PTR_BACK(retval, ptr)) {
     if (vim_ispathsep(*ptr)) {
       ptr++;
       break;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1883,7 +1883,7 @@ void foldtext_cleanup(char_u *str)
         ++len;
       STRMOVE(s, s + len);
     } else {
-      mb_ptr_adv(s);
+      MB_PTR_ADV(s);
     }
   }
 }
@@ -3054,10 +3054,12 @@ static void foldlevelMarker(fline_T *flp)
           if (flp->lvl_next > start_lvl)
             flp->lvl_next = start_lvl;
         }
-      } else
-        --flp->lvl_next;
-    } else
-      mb_ptr_adv(s);
+      } else {
+        flp->lvl_next--;
+      }
+    } else {
+      MB_PTR_ADV(s);
+    }
   }
 
   /* The level can't go negative, must be missing a start marker. */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -871,8 +871,6 @@ enum {
 };
 
 
-EXTERN char breakat_flags[256];         /* which characters are in 'breakat' */
-
 /*
  * Some file names are stored in pathdef.c, which is generated from the
  * Makefile to make their value depend on the Makefile.

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -82,12 +82,6 @@
     } \
   } while (0)
 
-/*
- * vim_isbreak() is used very often if 'linebreak' is set, use a macro to make
- * it work fast.
- */
-#define vim_isbreak(c) (breakat_flags[(char_u)(c)])
-
 #define WRITEBIN   "wb"        /* no CR-LF translation */
 #define READBIN    "rb"
 #define APPENDBIN  "ab"
@@ -110,9 +104,9 @@
 /* Whether to draw the vertical bar on the right side of the cell. */
 # define CURSOR_BAR_RIGHT (curwin->w_p_rl && (!(State & CMDLINE) || cmdmsg_rl))
 
-// mb_ptr_adv(): advance a pointer to the next character, taking care of
+// MB_PTR_ADV(): advance a pointer to the next character, taking care of
 // multi-byte characters if needed.
-// mb_ptr_back(): backup a pointer to the previous character, taking care of
+// MB_PTR_BACK(): backup a pointer to the previous character, taking care of
 // multi-byte characters if needed.
 // MB_COPY_CHAR(f, t): copy one char from "f" to "t" and advance the pointers.
 // PTR2CHAR(): get character from pointer.
@@ -120,11 +114,11 @@
 // Get the length of the character p points to
 # define MB_PTR2LEN(p)          mb_ptr2len(p)
 // Advance multi-byte pointer, skip over composing chars.
-# define mb_ptr_adv(p)      (p += mb_ptr2len((char_u *)p))
+# define MB_PTR_ADV(p)      (p += mb_ptr2len((char_u *)p))
 // Advance multi-byte pointer, do not skip over composing chars.
-# define mb_cptr_adv(p)     (p += utf_ptr2len(p))
+# define MB_CPTR_ADV(p)     (p += utf_ptr2len(p))
 // Backup multi-byte pointer. Only use with "p" > "s" !
-# define mb_ptr_back(s, p)  (p -= mb_head_off((char_u *)s, (char_u *)p - 1) + 1)
+# define MB_PTR_BACK(s, p)  (p -= mb_head_off((char_u *)s, (char_u *)p - 1) + 1)
 // get length of multi-byte char, not including composing chars
 # define MB_CPTR2LEN(p)     utf_ptr2len(p)
 

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -603,7 +603,7 @@ static char_u *mark_line(pos_T *mp, int lead_len)
 
   /* Truncate the line to fit it in the window */
   len = 0;
-  for (p = s; *p != NUL; mb_ptr_adv(p)) {
+  for (p = s; *p != NUL; MB_PTR_ADV(p)) {
     len += ptr2cells(p);
     if (len >= Columns - lead_len)
       break;

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1743,8 +1743,9 @@ char_u * mb_prevptr(
     char_u *p
     )
 {
-  if (p > line)
-    mb_ptr_back(line, p);
+  if (p > line) {
+    MB_PTR_BACK(line, p);
+  }
   return p;
 }
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1432,7 +1432,7 @@ static char *make_percent_swname(const char *dir, char *name)
   char *f = fix_fname(name != NULL ? name : "");
   if (f != NULL) {
     char *s = xstrdup(f);
-    for (d = s; *d != NUL; mb_ptr_adv(d)) {
+    for (d = s; *d != NUL; MB_PTR_ADV(d)) {
       if (vim_ispathsep(*d)) {
         *d = '%';
       }

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -97,7 +97,7 @@ ex_menu(exarg_T *eap)
     while (*arg != NUL && *arg != ' ') {
       if (*arg == '\\')
         STRMOVE(arg, arg + 1);
-      mb_ptr_adv(arg);
+      MB_PTR_ADV(arg);
     }
     if (*arg != NUL) {
       *arg++ = NUL;
@@ -1099,7 +1099,7 @@ char_u *menu_name_skip(char_u *const name)
 {
   char_u  *p;
 
-  for (p = name; *p && *p != '.'; mb_ptr_adv(p)) {
+  for (p = name; *p && *p != '.'; MB_PTR_ADV(p)) {
     if (*p == '\\' || *p == Ctrl_V) {
       STRMOVE(p, p + 1);
       if (*p == NUL)
@@ -1549,9 +1549,11 @@ static void menu_unescape_name(char_u *name)
 {
   char_u  *p;
 
-  for (p = name; *p && *p != '.'; mb_ptr_adv(p))
-    if (*p == '\\')
+  for (p = name; *p && *p != '.'; MB_PTR_ADV(p)) {
+    if (*p == '\\') {
       STRMOVE(p, p + 1);
+    }
+  }
 }
 
 /*

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2935,7 +2935,7 @@ static char_u * console_dialog_alloc(const char_u *message,
     }
 
     // Advance to the next character
-    mb_ptr_adv(r);
+    MB_PTR_ADV(r);
   }
 
   len += (int)(STRLEN(message)
@@ -3053,7 +3053,7 @@ static void copy_hotkeys_and_msg(const char_u *message, char_u *buttons,
     }
 
     // advance to the next character
-    mb_ptr_adv(r);
+    MB_PTR_ADV(r);
   }
 
   *msgp++ = ':';

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -531,7 +531,7 @@ open_line (
             int l;
 
             while (old_size < repl_size && p > leader) {
-              mb_ptr_back(leader, p);
+              MB_PTR_BACK(leader, p);
               old_size += ptr2cells(p);
             }
             l = lead_repl_len - (int)(endp - p);
@@ -1311,7 +1311,7 @@ int plines_win_col(win_T *wp, linenr_T lnum, long column)
   colnr_T col = 0;
   while (*s != NUL && --column >= 0) {
     col += win_lbr_chartabsize(wp, line, s, col, NULL);
-    mb_ptr_adv(s);
+    MB_PTR_ADV(s);
   }
 
   // If *s is a TAB, and the TAB is not displayed as ^I, and we're not in

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -525,7 +525,7 @@ static colnr_T scroll_line_len(linenr_T lnum)
   if (*line != NUL) {
     for (;;) {
       int numchar = chartabsize(line, col);
-      mb_ptr_adv(line);
+      MB_PTR_ADV(line);
       if (*line == NUL) {    // don't count the last character
         break;
       }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -406,8 +406,9 @@ static void shift_block(oparg_T *oap, int amount)
     /* If "bd.startspaces" is set, "bd.textstart" points to the character,
      * the part of which is displayed at the block's beginning. Let's start
      * searching from the next character. */
-    if (bd.startspaces)
-      mb_ptr_adv(non_white);
+    if (bd.startspaces) {
+      MB_PTR_ADV(non_white);
+    }
 
     /* The character's column is in "bd.start_vcol".  */
     non_white_col = bd.start_vcol;
@@ -443,7 +444,7 @@ static void shift_block(oparg_T *oap, int amount)
       if (verbatim_copy_width + incr > destination_col)
         break;
       verbatim_copy_width += incr;
-      mb_ptr_adv(verbatim_copy_end);
+      MB_PTR_ADV(verbatim_copy_end);
     }
 
     /* If "destination_col" is different from the width of the initial
@@ -2820,7 +2821,7 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
       }
       char_u *p = get_cursor_pos_ptr();
       if (dir == FORWARD && *p != NUL) {
-        mb_ptr_adv(p);
+        MB_PTR_ADV(p);
       }
       ptr = vim_strsave(p);
       ml_append(curwin->w_cursor.lnum, ptr, (colnr_T)0, false);
@@ -2829,7 +2830,7 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
       oldp = get_cursor_line_ptr();
       p = oldp + curwin->w_cursor.col;
       if (dir == FORWARD && *p != NUL) {
-        mb_ptr_adv(p);
+        MB_PTR_ADV(p);
       }
       ptr = vim_strnsave(oldp, (size_t)(p - oldp));
       ml_replace(curwin->w_cursor.lnum, ptr, false);
@@ -3632,10 +3633,10 @@ int do_join(size_t count,
     if (insert_space && currsize > 0) {
       if (has_mbyte) {
         cend = curr + currsize;
-        mb_ptr_back(curr, cend);
+        MB_PTR_BACK(curr, cend);
         endcurr1 = (*mb_ptr2char)(cend);
         if (cend > curr) {
-          mb_ptr_back(curr, cend);
+          MB_PTR_BACK(curr, cend);
           endcurr2 = (*mb_ptr2char)(cend);
         }
       } else {
@@ -4272,7 +4273,7 @@ static void block_prep(oparg_T *oap, struct block_def *bdp, linenr_T lnum, int i
       bdp->pre_whitesp_c = 0;
     }
     prev_pstart = pstart;
-    mb_ptr_adv(pstart);
+    MB_PTR_ADV(pstart);
   }
   bdp->start_char_vcols = incr;
   if (bdp->start_vcol < oap->start_vcol) {      /* line too short */

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2830,7 +2830,7 @@ did_set_string_option (
     for (s = p_sbr; *s; ) {
       if (ptr2cells(s) != 1)
         errmsg = (char_u *)N_("E595: contains unprintable or wide character");
-      mb_ptr_adv(s);
+      MB_PTR_ADV(s);
     }
   }
 
@@ -6210,13 +6210,15 @@ void ExpandOldSetting(int *num_file, char_u ***file)
 #ifdef BACKSLASH_IN_FILENAME
   /* For MS-Windows et al. we don't double backslashes at the start and
    * before a file name character. */
-  for (var = buf; *var != NUL; mb_ptr_adv(var))
+  for (var = buf; *var != NUL; MB_PTR_ADV(var)) {
     if (var[0] == '\\' && var[1] == '\\'
         && expand_option_idx >= 0
         && (options[expand_option_idx].flags & P_EXPAND)
         && vim_isfilec(var[2])
-        && (var[2] != '\\' || (var == buf && var[4] != '\\')))
+        && (var[2] != '\\' || (var == buf && var[4] != '\\'))) {
       STRMOVE(var, var + 1);
+    }
+  }
 #endif
 
   *file[0] = buf;
@@ -6384,9 +6386,10 @@ static void langmap_set(void)
 
   for (p = p_langmap; p[0] != NUL; ) {
     for (p2 = p; p2[0] != NUL && p2[0] != ',' && p2[0] != ';';
-         mb_ptr_adv(p2)) {
-      if (p2[0] == '\\' && p2[1] != NUL)
-        ++p2;
+         MB_PTR_ADV(p2)) {
+      if (p2[0] == '\\' && p2[1] != NUL) {
+        p2++;
+      }
     }
     if (p2[0] == ';')
       ++p2;                 /* abcd;ABCD form, p2 points to A */
@@ -6402,7 +6405,7 @@ static void langmap_set(void)
       from = (*mb_ptr2char)(p);
       to = NUL;
       if (p2 == NULL) {
-        mb_ptr_adv(p);
+        MB_PTR_ADV(p);
         if (p[0] != ',') {
           if (p[0] == '\\')
             ++p;
@@ -6428,10 +6431,10 @@ static void langmap_set(void)
         langmap_mapchar[from & 255] = (char_u)to;
       }
 
-      /* Advance to next pair */
-      mb_ptr_adv(p);
+      // Advance to next pair
+      MB_PTR_ADV(p);
       if (p2 != NULL) {
-        mb_ptr_adv(p2);
+        MB_PTR_ADV(p2);
         if (*p == ';') {
           p = p2;
           if (p[0] != NUL) {

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -314,9 +314,10 @@ static char *(p_bkc_values[]) =
 # define BKC_NO                 0x004
 # define BKC_BREAKSYMLINK       0x008
 # define BKC_BREAKHARDLINK      0x010
-EXTERN char_u   *p_bdir;        /* 'backupdir' */
-EXTERN char_u   *p_bex;         /* 'backupext' */
-EXTERN char_u   *p_bo;          // 'belloff'
+EXTERN char_u *p_bdir;            // 'backupdir'
+EXTERN char_u *p_bex;             // 'backupext'
+EXTERN char_u *p_bo;              // 'belloff'
+EXTERN char breakat_flags[256];   // which characters are in 'breakat'
 EXTERN unsigned bo_flags;
 # ifdef IN_OPTION_C
 static char *(p_bo_values[]) = {"all", "backspace", "cursor", "complete",

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -101,7 +101,7 @@ char_u *path_tail(const char_u *fname)
     if (vim_ispathsep_nocolon(*p)) {
       tail = p + 1;
     }
-    mb_ptr_adv(p);
+    MB_PTR_ADV(p);
   }
   return (char_u *)tail;
 }
@@ -144,7 +144,7 @@ const char_u *invocation_path_tail(const char_u *invocation, size_t *len)
   const char_u *p = tail;
   while (*p != NUL && *p != ' ') {
     bool was_sep = vim_ispathsep_nocolon(*p);
-    mb_ptr_adv(p);
+    MB_PTR_ADV(p);
     if (was_sep) {
       tail = p;  // Now tail points one past the separator.
     }
@@ -166,7 +166,7 @@ const char *path_next_component(const char *fname)
 {
   assert(fname != NULL);
   while (*fname != NUL && !vim_ispathsep(*fname)) {
-    mb_ptr_adv(fname);
+    MB_PTR_ADV(fname);
   }
   if (*fname != NUL) {
     fname++;
@@ -468,7 +468,7 @@ char_u *save_abs_path(const char_u *name)
 bool path_has_wildcard(const char_u *p)
   FUNC_ATTR_NONNULL_ALL
 {
-  for (; *p; mb_ptr_adv(p)) {
+  for (; *p; MB_PTR_ADV(p)) {
 #if defined(UNIX)
     if (p[0] == '\\' && p[1] != NUL) {
       p++;
@@ -503,7 +503,7 @@ static int pstrcmp(const void *a, const void *b)
 bool path_has_exp_wildcard(const char_u *p)
   FUNC_ATTR_NONNULL_ALL
 {
-  for (; *p != NUL; mb_ptr_adv(p)) {
+  for (; *p != NUL; MB_PTR_ADV(p)) {
 #if defined(UNIX)
     if (p[0] == '\\' && p[1] != NUL) {
       p++;
@@ -744,7 +744,7 @@ static int find_previous_pathsep(char_u *path, char_u **psep)
   while (*psep > path) {
     if (vim_ispathsep(**psep))
       return OK;
-    mb_ptr_back(path, *psep);
+    MB_PTR_BACK(path, *psep);
   }
 
   return FAIL;
@@ -859,10 +859,12 @@ static char_u *get_path_cutoff(char_u *fname, garray_T *gap)
     }
   }
 
-  /* skip to the file or directory name */
-  if (cutoff != NULL)
-    while (vim_ispathsep(*cutoff))
-      mb_ptr_adv(cutoff);
+  // skip to the file or directory name
+  if (cutoff != NULL) {
+    while (vim_ispathsep(*cutoff)) {
+      MB_PTR_ADV(cutoff);
+    }
+  }
 
   return cutoff;
 }
@@ -1038,7 +1040,7 @@ const char *gettail_dir(const char *const fname)
         dir_end = next_dir_end;
       look_for_sep = true;
     }
-    mb_ptr_adv(p);
+    MB_PTR_ADV(p);
   }
   return dir_end;
 }
@@ -1085,13 +1087,12 @@ expand_in_path (
  */
 static bool has_env_var(char_u *p)
 {
-  for (; *p; mb_ptr_adv(p)) {
-    if (*p == '\\' && p[1] != NUL)
-      ++p;
-    else if (vim_strchr((char_u *)
-                 "$"
-                 , *p) != NULL)
+  for (; *p; MB_PTR_ADV(p)) {
+    if (*p == '\\' && p[1] != NUL) {
+      p++;
+    } else if (vim_strchr((char_u *) "$" , *p) != NULL) {
       return true;
+    }
   }
   return false;
 }
@@ -1102,7 +1103,7 @@ static bool has_env_var(char_u *p)
 // cannot expand, requires using a shell.
 static bool has_special_wildchar(char_u *p)
 {
-  for (; *p; mb_ptr_adv(p)) {
+  for (; *p; MB_PTR_ADV(p)) {
     // Allow for escaping
     if (*p == '\\' && p[1] != NUL) {
       p++;
@@ -1343,7 +1344,7 @@ void slash_adjust(char_u *p)
     if (*p == (char_u)psepcN) {
       *p = (char_u)psepc;
     }
-    mb_ptr_adv(p);
+    MB_PTR_ADV(p);
   }
 }
 #endif
@@ -1444,19 +1445,22 @@ void simplify_filename(char_u *filename)
          * we are after "start", or strip "." if we are at the beginning
          * of an absolute path name . */
         tail = p + 1;
-        if (p[1] != NUL)
-          while (vim_ispathsep(*tail))
-            mb_ptr_adv(tail);
-        else if (p > start)
-          --p;                          /* strip preceding path separator */
+        if (p[1] != NUL) {
+          while (vim_ispathsep(*tail)) {
+            MB_PTR_ADV(tail);
+          }
+        } else if (p > start) {
+          p--;                          // strip preceding path separator
+        }
         STRMOVE(p, tail);
       }
     } else if (p[0] == '.' && p[1] == '.'
                && (vim_ispathsep(p[2]) || p[2] == NUL)) {
       // Skip to after ".." or "../" or "..///".
       tail = p + 2;
-      while (vim_ispathsep(*tail))
-        mb_ptr_adv(tail);
+      while (vim_ispathsep(*tail)) {
+        MB_PTR_ADV(tail);
+      }
 
       if (components > 0) {             /* strip one preceding component */
         bool do_strip = false;
@@ -1475,10 +1479,11 @@ void simplify_filename(char_u *filename)
           }
           p[-1] = saved_char;
 
-          --p;
-          /* Skip back to after previous '/'. */
-          while (p > start && !after_pathsep((char *)start, (char *)p))
-            mb_ptr_back(start, p);
+          p--;
+          // Skip back to after previous '/'.
+          while (p > start && !after_pathsep((char *)start, (char *)p)) {
+            MB_PTR_BACK(start, p);
+          }
 
           if (!do_strip) {
             /* If the component exists in the file system, check

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -374,7 +374,7 @@ void pum_redraw(void)
       }
 
       if (p != NULL) {
-        for (;; mb_ptr_adv(p)) {
+        for (;; MB_PTR_ADV(p)) {
           if (s == NULL) {
             s = p;
           }
@@ -398,7 +398,7 @@ void pum_redraw(void)
               if (size > pum_width) {
                 do {
                   size -= has_mbyte ? (*mb_ptr2cells)(rt) : 1;
-                  mb_ptr_adv(rt);
+                  MB_PTR_ADV(rt);
                 } while (size > pum_width);
 
                 if (size < pum_width) {

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1142,24 +1142,28 @@ static char_u *skip_anyof(char_u *p)
   if (*p == ']' || *p == '-')
     ++p;
   while (*p != NUL && *p != ']') {
-    if (has_mbyte && (l = (*mb_ptr2len)(p)) > 1)
+    if (has_mbyte && (l = (*mb_ptr2len)(p)) > 1) {
       p += l;
-    else if (*p == '-')  {
-      ++p;
-      if (*p != ']' && *p != NUL)
-        mb_ptr_adv(p);
+    } else if (*p == '-')  {
+      p++;
+      if (*p != ']' && *p != NUL) {
+        MB_PTR_ADV(p);
+      }
     } else if (*p == '\\'
                && (vim_strchr(REGEXP_INRANGE, p[1]) != NULL
-                   || (!reg_cpo_lit && vim_strchr(REGEXP_ABBR, p[1]) != NULL)))
+                   || (!reg_cpo_lit
+                       && vim_strchr(REGEXP_ABBR, p[1]) != NULL))) {
       p += 2;
-    else if (*p == '[') {
+    } else if (*p == '[') {
       if (get_char_class(&p) == CLASS_NONE
           && get_equi_class(&p) == 0
           && get_coll_element(&p) == 0
-          && *p != NUL)
-        ++p;         /* It is not a class name and not NUL */
-    } else
-      ++p;
+          && *p != NUL) {
+        p++;          // It is not a class name and not NUL
+      }
+    } else {
+      p++;
+    }
   }
 
   return p;
@@ -1185,9 +1189,10 @@ char_u *skip_regexp(char_u *startp, int dirc, int magic, char_u **newp)
     mymagic = MAGIC_OFF;
   get_cpo_flags();
 
-  for (; p[0] != NUL; mb_ptr_adv(p)) {
-    if (p[0] == dirc)           /* found end of regexp */
+  for (; p[0] != NUL; MB_PTR_ADV(p)) {
+    if (p[0] == dirc) {         // found end of regexp
       break;
+    }
     if ((p[0] == '[' && mymagic >= MAGIC_ON)
         || (p[0] == '\\' && p[1] == '[' && mymagic <= MAGIC_OFF)) {
       p = skip_anyof(p + 1);
@@ -3476,14 +3481,14 @@ static long bt_regexec_both(char_u *line,
         if (cstrncmp(s, prog->regmust, &prog->regmlen) == 0) {
           break;  // Found it.
         }
-        mb_ptr_adv(s);
+        MB_PTR_ADV(s);
       }
     } else {
       while ((s = cstrchr(s, c)) != NULL) {
         if (cstrncmp(s, prog->regmust, &prog->regmlen) == 0) {
           break;  // Found it.
         }
-        mb_ptr_adv(s);
+        MB_PTR_ADV(s);
       }
     }
     if (s == NULL) {  // Not present.
@@ -3753,7 +3758,7 @@ static int reg_match_visual(void)
   return TRUE;
 }
 
-#define ADVANCE_REGINPUT() mb_ptr_adv(reginput)
+#define ADVANCE_REGINPUT() MB_PTR_ADV(reginput)
 
 /*
  * The arguments from BRACE_LIMITS are stored here.  They are actually local
@@ -4287,7 +4292,7 @@ regmatch (
           if (enc_utf8) {
             // Skip composing characters.
             while (utf_iscomposing(utf_ptr2char(reginput))) {
-              mb_cptr_adv(reginput);
+              MB_CPTR_ADV(reginput);
             }
           }
           break;
@@ -4951,21 +4956,24 @@ regmatch (
                   (colnr_T)STRLEN(regline);
               }
             } else {
-              if (has_mbyte)
+              if (has_mbyte) {
                 rp->rs_un.regsave.rs_u.pos.col -=
                   (*mb_head_off)(regline, regline
                                  + rp->rs_un.regsave.rs_u.pos.col - 1) + 1;
-              else
-                --rp->rs_un.regsave.rs_u.pos.col;
+              } else {
+                rp->rs_un.regsave.rs_u.pos.col--;
+              }
             }
           } else {
-            if (rp->rs_un.regsave.rs_u.ptr == regline)
+            if (rp->rs_un.regsave.rs_u.ptr == regline) {
               no = FAIL;
-            else {
-              mb_ptr_back(regline, rp->rs_un.regsave.rs_u.ptr);
-              if (limit > 0 && (long)(behind_pos.rs_u.ptr
-                                      - rp->rs_un.regsave.rs_u.ptr) > limit)
+            } else {
+              MB_PTR_BACK(regline, rp->rs_un.regsave.rs_u.ptr);
+              if (limit > 0
+                  && (long)(behind_pos.rs_u.ptr
+                            - rp->rs_un.regsave.rs_u.ptr) > limit) {
                 no = FAIL;
+              }
             }
           }
           if (no == OK) {
@@ -5025,17 +5033,18 @@ regmatch (
               if (--rst->count < rst->minval)
                 break;
               if (reginput == regline) {
-                /* backup to last char of previous line */
-                --reglnum;
+                // backup to last char of previous line
+                reglnum--;
                 regline = reg_getline(reglnum);
-                /* Just in case regrepeat() didn't count
-                 * right. */
-                if (regline == NULL)
+                // Just in case regrepeat() didn't count right.
+                if (regline == NULL) {
                   break;
+                }
                 reginput = regline + STRLEN(regline);
                 fast_breakcheck();
-              } else
-                mb_ptr_back(regline, reginput);
+              } else {
+                MB_PTR_BACK(regline, reginput);
+              }
             } else {
               /* Range is backwards, use shortest match first.
                * Careful: maxval and minval are exchanged!
@@ -5165,8 +5174,8 @@ regrepeat (
       /* Matching anything means we continue until end-of-line (or
        * end-of-file for ANY + ADD_NL), only limited by maxcount. */
       while (*scan != NUL && count < maxcount) {
-        ++count;
-        mb_ptr_adv(scan);
+        count++;
+        MB_PTR_ADV(scan);
       }
       if (!REG_MULTI || !WITH_NL(OP(p)) || reglnum > rex.reg_maxline
           || rex.reg_line_lbr || count == maxcount) {
@@ -5188,7 +5197,7 @@ regrepeat (
   case SIDENT + ADD_NL:
     while (count < maxcount) {
       if (vim_isIDc(PTR2CHAR(scan)) && (testval || !ascii_isdigit(*scan))) {
-        mb_ptr_adv(scan);
+        MB_PTR_ADV(scan);
       } else if (*scan == NUL) {
         if (!REG_MULTI || !WITH_NL(OP(p)) || reglnum > rex.reg_maxline
             || rex.reg_line_lbr) {
@@ -5216,7 +5225,7 @@ regrepeat (
     while (count < maxcount) {
       if (vim_iswordp_buf(scan, rex.reg_buf)
           && (testval || !ascii_isdigit(*scan))) {
-        mb_ptr_adv(scan);
+        MB_PTR_ADV(scan);
       } else if (*scan == NUL) {
         if (!REG_MULTI || !WITH_NL(OP(p)) || reglnum > rex.reg_maxline
             || rex.reg_line_lbr) {
@@ -5244,7 +5253,7 @@ regrepeat (
   case SFNAME + ADD_NL:
     while (count < maxcount) {
       if (vim_isfilec(PTR2CHAR(scan)) && (testval || !ascii_isdigit(*scan))) {
-        mb_ptr_adv(scan);
+        MB_PTR_ADV(scan);
       } else if (*scan == NUL) {
         if (!REG_MULTI || !WITH_NL(OP(p)) || reglnum > rex.reg_maxline
             || rex.reg_line_lbr) {
@@ -5283,7 +5292,7 @@ regrepeat (
         }
       } else if (vim_isprintc(PTR2CHAR(scan)) == 1
                  && (testval || !ascii_isdigit(*scan))) {
-        mb_ptr_adv(scan);
+        MB_PTR_ADV(scan);
       } else if (rex.reg_line_lbr && *scan == '\n' && WITH_NL(OP(p))) {
         scan++;
       } else {
@@ -6679,7 +6688,7 @@ static int vim_regsub_both(char_u *source, typval_T *expr, char_u *dest,
       if (eval_result != NULL) {
         int had_backslash = FALSE;
 
-        for (s = eval_result; *s != NUL; mb_ptr_adv(s)) {
+        for (s = eval_result; *s != NUL; MB_PTR_ADV(s)) {
           // Change NL to CR, so that it becomes a line break,
           // unless called from vim_regexec_nl().
           // Skip over a backslashed character.

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1323,7 +1323,7 @@ static int nfa_regatom(void)
       EMSG(_(e_nopresub));
       return FAIL;
     }
-    for (lp = reg_prev_sub; *lp != NUL; mb_cptr_adv(lp)) {
+    for (lp = reg_prev_sub; *lp != NUL; MB_CPTR_ADV(lp)) {
       EMIT(PTR2CHAR(lp));
       if (lp != reg_prev_sub)
         EMIT(NFA_CONCAT);
@@ -1557,7 +1557,7 @@ collection:
         } else
           EMIT(result);
         regparse = endp;
-        mb_ptr_adv(regparse);
+        MB_PTR_ADV(regparse);
         return OK;
       }
       /*
@@ -1565,10 +1565,10 @@ collection:
        * version that turns [abc] into 'a' OR 'b' OR 'c'
        */
       startc = endc = oldstartc = -1;
-      negated = FALSE;
-      if (*regparse == '^') {                           /* negated range */
-        negated = TRUE;
-        mb_ptr_adv(regparse);
+      negated = false;
+      if (*regparse == '^') {                           // negated range
+        negated = true;
+        MB_PTR_ADV(regparse);
         EMIT(NFA_START_NEG_COLL);
       } else
         EMIT(NFA_START_COLL);
@@ -1576,7 +1576,7 @@ collection:
         startc = '-';
         EMIT(startc);
         EMIT(NFA_CONCAT);
-        mb_ptr_adv(regparse);
+        MB_PTR_ADV(regparse);
       }
       /* Emit the OR branches for each character in the [] */
       emit_range = FALSE;
@@ -1666,8 +1666,8 @@ collection:
         if (*regparse == '-' && oldstartc != -1) {
           emit_range = TRUE;
           startc = oldstartc;
-          mb_ptr_adv(regparse);
-          continue;                         /* reading the end of the range */
+          MB_PTR_ADV(regparse);
+          continue;                         // reading the end of the range
         }
 
         /* Now handle simple and escaped characters.
@@ -1683,7 +1683,7 @@ collection:
                     != NULL)
                 )
             ) {
-          mb_ptr_adv(regparse);
+          MB_PTR_ADV(regparse);
 
           if (*regparse == 'n')
             startc = reg_string ? NL : NFA_NEWL;
@@ -1695,8 +1695,8 @@ collection:
                     ) {
             /* TODO(RE) This needs more testing */
             startc = coll_get_char();
-            got_coll_char = TRUE;
-            mb_ptr_back(old_regparse, regparse);
+            got_coll_char = true;
+            MB_PTR_BACK(old_regparse, regparse);
           } else {
             /* \r,\t,\e,\b */
             startc = backslash_trans(*regparse);
@@ -1768,18 +1768,18 @@ collection:
           }
         }
 
-        mb_ptr_adv(regparse);
-      }           /* while (p < endp) */
+        MB_PTR_ADV(regparse);
+      }           // while (p < endp)
 
-      mb_ptr_back(old_regparse, regparse);
-      if (*regparse == '-') {               /* if last, '-' is just a char */
+      MB_PTR_BACK(old_regparse, regparse);
+      if (*regparse == '-') {               // if last, '-' is just a char
         EMIT('-');
         EMIT(NFA_CONCAT);
       }
 
       /* skip the trailing ] */
       regparse = endp;
-      mb_ptr_adv(regparse);
+      MB_PTR_ADV(regparse);
 
       /* Mark end of the collection. */
       if (negated == TRUE)

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2528,7 +2528,7 @@ win_line (
       c = win_lbr_chartabsize(wp, line, ptr, (colnr_T)vcol, NULL);
       vcol += c;
       prev_ptr = ptr;
-      mb_ptr_adv(ptr);
+      MB_PTR_ADV(ptr);
     }
 
     // When:
@@ -4697,7 +4697,7 @@ static int status_match_len(expand_T *xp, char_u *s)
   while (*s != NUL) {
     s += skip_status_match_char(xp, s);
     len += ptr2cells(s);
-    mb_ptr_adv(s);
+    MB_PTR_ADV(s);
   }
 
   return len;
@@ -6951,7 +6951,7 @@ static void draw_tabline(void)
         if (has_mbyte)
           while (len > room) {
             len -= ptr2cells(p);
-            mb_ptr_adv(p);
+            MB_PTR_ADV(p);
           }
         else if (len > room) {
           p += len - room;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3239,35 +3239,41 @@ static int in_html_tag(int end_tag)
 
     /* We search forward until the cursor, because searching backwards is
      * very slow for DBCS encodings. */
-    for (p = line; p < line + curwin->w_cursor.col; mb_ptr_adv(p))
+    for (p = line; p < line + curwin->w_cursor.col; MB_PTR_ADV(p)) {
       if (*p == '>' || *p == '<') {
         lc = *p;
         lp = p;
       }
-    if (*p != '<') {        /* check for '<' under cursor */
-      if (lc != '<')
-        return FALSE;
+    }
+    if (*p != '<') {        // check for '<' under cursor
+      if (lc != '<') {
+        return false;
+      }
       p = lp;
     }
   } else {
     for (p = line + curwin->w_cursor.col; p > line; ) {
-      if (*p == '<')            /* find '<' under/before cursor */
+      if (*p == '<') {           // find '<' under/before cursor
         break;
-      mb_ptr_back(line, p);
-      if (*p == '>')            /* find '>' before cursor */
+      }
+      MB_PTR_BACK(line, p);
+      if (*p == '>') {           // find '>' before cursor
         break;
+      }
     }
-    if (*p != '<')
-      return FALSE;
+    if (*p != '<') {
+      return false;
+    }
   }
 
   pos.lnum = curwin->w_cursor.lnum;
   pos.col = (colnr_T)(p - line);
 
-  mb_ptr_adv(p);
-  if (end_tag)
-    /* check that there is a '/' after the '<' */
+  MB_PTR_ADV(p);
+  if (end_tag) {
+    // check that there is a '/' after the '<'
     return *p == '/';
+  }
 
   /* check that there is no '/' after the '<' */
   if (*p == '/')
@@ -3371,8 +3377,10 @@ again:
    */
   inc_cursor();
   p = get_cursor_pos_ptr();
-  for (cp = p; *cp != NUL && *cp != '>' && !ascii_iswhite(*cp); mb_ptr_adv(cp))
-    ;
+  for (cp = p;
+       *cp != NUL && *cp != '>' && !ascii_iswhite(*cp);
+       MB_PTR_ADV(cp)) {
+  }
   len = (int)(cp - p);
   if (len == 0) {
     curwin->w_cursor = old_pos;

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1507,9 +1507,10 @@ static int set_sofo(slang_T *lp, char_u *from, char_u *to)
     // sl_sal_first[] for this.
     for (p = from, s = to; *p != NUL && *s != NUL; ) {
       c = mb_cptr2char_adv((const char_u **)&p);
-      mb_cptr_adv(s);
-      if (c >= 256)
-        ++lp->sl_sal_first[c & 0xff];
+      MB_CPTR_ADV(s);
+      if (c >= 256) {
+        lp->sl_sal_first[c & 0xff]++;
+      }
     }
     if (*p != NUL || *s != NUL)             // lengths differ
       return SP_FORMERROR;
@@ -2427,7 +2428,7 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
                       || PTR2CHAR(aff_entry->ae_cond) == c)) {
                 p = aff_entry->ae_add
                     + STRLEN(aff_entry->ae_add);
-                mb_ptr_back(aff_entry->ae_add, p);
+                MB_PTR_BACK(aff_entry->ae_add, p);
                 if (PTR2CHAR(p) == c_up) {
                   upper = true;
                   aff_entry->ae_chop = NULL;
@@ -2528,12 +2529,16 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
         if (items[0][3] == 'S' ? do_repsal : do_rep) {
           // Replace underscore with space (can't include a space
           // directly).
-          for (p = items[1]; *p != NUL; mb_ptr_adv(p))
-            if (*p == '_')
+          for (p = items[1]; *p != NUL; MB_PTR_ADV(p)) {
+            if (*p == '_') {
               *p = ' ';
-          for (p = items[2]; *p != NUL; mb_ptr_adv(p))
-            if (*p == '_')
+            }
+          }
+          for (p = items[2]; *p != NUL; MB_PTR_ADV(p)) {
+            if (*p == '_') {
               *p = ' ';
+            }
+          }
           add_fromto(spin, items[0][3] == 'S'
               ? &spin->si_repsal
               : &spin->si_rep, items[1], items[2]);
@@ -3070,10 +3075,10 @@ static int spell_read_dic(spellinfo_T *spin, char_u *fname, afffile_T *affile)
     // Truncate the word at the "/", set "afflist" to what follows.
     // Replace "\/" by "/" and "\\" by "\".
     afflist = NULL;
-    for (p = w; *p != NUL; mb_ptr_adv(p)) {
-      if (*p == '\\' && (p[1] == '\\' || p[1] == '/'))
+    for (p = w; *p != NUL; MB_PTR_ADV(p)) {
+      if (*p == '\\' && (p[1] == '\\' || p[1] == '/')) {
         STRMOVE(p, p + 1);
-      else if (*p == '/') {
+      } else if (*p == '/') {
         *p = NUL;
         afflist = p + 1;
         break;
@@ -3343,19 +3348,22 @@ store_aff_word (
             // Match.  Remove the chop and add the affix.
             if (xht == NULL) {
               // prefix: chop/add at the start of the word
-              if (ae->ae_add == NULL)
+              if (ae->ae_add == NULL) {
                 *newword = NUL;
-              else
+              } else {
                 STRLCPY(newword, ae->ae_add, MAXWLEN);
+              }
               p = word;
               if (ae->ae_chop != NULL) {
                 // Skip chop string.
                 if (has_mbyte) {
                   i = mb_charlen(ae->ae_chop);
-                  for (; i > 0; --i)
-                    mb_ptr_adv(p);
-                } else
+                  for (; i > 0; i--) {
+                    MB_PTR_ADV(p);
+                  }
+                } else {
                   p += STRLEN(ae->ae_chop);
+                }
               }
               STRCAT(newword, p);
             } else {
@@ -3365,8 +3373,9 @@ store_aff_word (
                 // Remove chop string.
                 p = newword + STRLEN(newword);
                 i = (int)MB_CHARLEN(ae->ae_chop);
-                for (; i > 0; --i)
-                  mb_ptr_back(newword, p);
+                for (; i > 0; i--) {
+                  MB_PTR_BACK(newword, p);
+                }
                 *p = NUL;
               }
               if (ae->ae_add != NULL)

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -207,7 +207,7 @@ char_u *vim_strsave_shellescape(const char_u *string,
 
   /* First count the number of extra bytes required. */
   size_t length = STRLEN(string) + 3;       // two quotes and a trailing NUL
-  for (const char_u *p = string; *p != NUL; mb_ptr_adv(p)) {
+  for (const char_u *p = string; *p != NUL; MB_PTR_ADV(p)) {
 #ifdef WIN32
     if (!p_ssl) {
       if (*p == '"') {
@@ -469,7 +469,7 @@ char_u *vim_strrchr(const char_u *string, int c)
   while (*p) {
     if (*p == c)
       retval = p;
-    mb_ptr_adv(p);
+    MB_PTR_ADV(p);
   }
   return (char_u *) retval;
 }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -2824,11 +2824,12 @@ syn_add_end_off (
     base = ml_get_buf(syn_buf, result->lnum, FALSE);
     p = base + col;
     if (off > 0) {
-      while (off-- > 0 && *p != NUL)
-        mb_ptr_adv(p);
+      while (off-- > 0 && *p != NUL) {
+        MB_PTR_ADV(p);
+      }
     } else {
       while (off++ < 0 && base < p) {
-        mb_ptr_back(base, p);
+        MB_PTR_BACK(base, p);
       }
     }
     col = (int)(p - base);
@@ -2873,11 +2874,11 @@ syn_add_start_off (
     p = base + col;
     if (off > 0) {
       while (off-- && *p != NUL) {
-        mb_ptr_adv(p);
+        MB_PTR_ADV(p);
       }
     } else {
       while (off++ && base < p) {
-        mb_ptr_back(base, p);
+        MB_PTR_BACK(base, p);
       }
     }
     col = (int)(p - base);

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -703,7 +703,7 @@ char *u_get_undo_file_name(const char *const buf_ffname, const bool reading)
       if (has_directory) {
         if (munged_name == NULL) {
           munged_name = xstrdup(ffname);
-          for (char *p = munged_name; *p != NUL; mb_ptr_adv(p)) {
+          for (char *p = munged_name; *p != NUL; MB_PTR_ADV(p)) {
             if (vim_ispathsep(*p)) {
               *p = '%';
             }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5101,11 +5101,13 @@ file_name_in_line (
    * search forward for what could be the start of a file name
    */
   ptr = line + col;
-  while (*ptr != NUL && !vim_isfilec(*ptr))
-    mb_ptr_adv(ptr);
-  if (*ptr == NUL) {            /* nothing found */
-    if (options & FNAME_MESS)
+  while (*ptr != NUL && !vim_isfilec(*ptr)) {
+    MB_PTR_ADV(ptr);
+  }
+  if (*ptr == NUL) {            // nothing found
+    if (options & FNAME_MESS) {
       EMSG(_("E446: No file name under cursor"));
+    }
     return NULL;
   }
 


### PR DESCRIPTION
**vim-patch:8.0.0451: some macros are in lower case**

Problem:    Some macros are in lower case.
Solution:   Make a few more macros upper case. Avoid lower case macros use an
            argument twice.
https://github.com/vim/vim/commit/91acfffc1e6c0d8c2abfb186a0e79a5bf19c3f3f

Related: https://github.com/neovim/neovim/issues/6297