### PR TITLE
[RFC] CheckHealth: Fix logic for yarn & npm when checking for neovim node package

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -502,10 +502,10 @@ function! s:check_node() abort
     return
   endif
 
-  if !executable('node') || !executable('npm')
+  if !executable('node') || (!executable('npm') && !executable('yarn'))
     call health#report_warn(
-          \ '`node` and `npm` must be in $PATH.',
-          \ ['Install Node.js and verify that `node` and `npm` commands work.'])
+          \ '`node` and `npm` or `yarn` must be in $PATH.',
+          \ ['Install Node.js and verify that `node` and `npm` or `yarn` commands work.'])
     return
   endif
   let node_v = get(split(s:system('node -v'), "\n"), 0, '')
@@ -523,7 +523,7 @@ function! s:check_node() abort
   if empty(host)
     call health#report_warn('Missing "neovim" npm package.',
           \ ['Run in shell: npm install -g neovim',
-          \  'Is the npm bin directory in $PATH?'])
+          \  'Run in shell (if you use yarn): yarn global add neovim'])
     return
   endif
   call health#report_info('Neovim node.js host: '. host)

--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -22,6 +22,29 @@ function! s:is_minimum_version(version, min_major, min_minor) abort
     \         && str2nr(v_list[1]) >= str2nr(a:min_minor)))
 endfunction
 
+function! s:get_node_client_entry(package_manager) abort
+  if !executable(a:package_manager)
+    return ''
+  endif
+  let is_yarn = a:package_manager ==# 'yarn'
+  let cmd = is_yarn ? 'yarn global dir' : 'npm root -g'
+  let global_modules_dir = get(split(system(cmd), "\n"), 0, '')
+  if v:shell_error || !isdirectory(global_modules_dir)
+    return ''
+  endif
+  " `yarn global dir` returns the root directory of the global modules
+  " so we need to append the `/node_modules` part
+  let global_modules_dir = is_yarn ? global_modules_dir . '/node_modules' : global_modules_dir
+  if !isdirectory(global_modules_dir)
+    return ''
+  endif
+  let entry_path = global_modules_dir . '/neovim/bin/cli.js'
+  if !filereadable(entry_path)
+    return ''
+  endif
+  return entry_path
+endfunction
+
 " Support for --inspect-brk requires node 6.12+ or 7.6+ or 8+
 " Return 1 if it is supported
 " Return 0 otherwise
@@ -41,17 +64,11 @@ function! provider#node#Detect() abort
   if exists('g:node_host_prog')
     return g:node_host_prog
   endif
-  let global_modules = get(split(system('npm root -g'), "\n"), 0, '')
-  if v:shell_error || !isdirectory(global_modules)
-    return ''
-  endif
   if !s:is_minimum_version(v:null, 6, 0)
     return ''
   endif
-  let entry_point = glob(global_modules . '/neovim/bin/cli.js')
-  if !filereadable(entry_point)
-    return ''
-  endif
+  let entry_point = s:get_node_client_entry('npm')
+  let entry_point = !empty(entry_point) ? entry_point : s:get_node_client_entry('yarn')
   return entry_point
 endfunction
 


### PR DESCRIPTION
The current checks assume only that the node package is installed globally using `npm` only. This PR will make it work if it's installed globally using `npm` or `yarn`.