### PR TITLE
[RDY] tests for folded lines with multibyte and cmdwin char, and double-width rendering

### DIFF
--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -1,0 +1,214 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear, feed, eq = helpers.clear, helpers.feed, helpers.eq
+local feed_command = helpers.feed_command
+local insert = helpers.insert
+local meths = helpers.meths
+
+describe("folded lines", function()
+  local screen
+  before_each(function()
+    clear()
+    screen = Screen.new(45, 8)
+    screen:attach({rgb=true})
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue1},
+      [2] = {reverse = true},
+      [3] = {bold = true, reverse = true},
+      [4] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+      [5] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey},
+      [6] = {background = Screen.colors.Yellow},
+      [7] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray},
+    })
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  it("works with multibyte text", function()
+    -- Soon, we will always use the maximum value of 'maxcombine'.
+    feed_command("set maxcombine=6")
+
+    eq(true, meths.get_option('arabicshape'))
+    insert([[
+      å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢͟ العَرَبِيَّة
+      möre text]])
+    screen:expect([[
+      å 语 x̎͂̀̂͛͛ ﺎﻠﻋَﺮَﺒِﻳَّﺓ                               |
+      möre tex^t                                    |
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+                                                   |
+    ]])
+
+    feed('vkzf')
+    screen:expect([[
+      {5:^+--  2 lines: å 语 x̎͂̀̂͛͛ ﺎﻠﻋَﺮَﺒِﻳَّﺓ·················}|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+                                                   |
+    ]])
+
+    feed_command("set noarabicshape")
+    screen:expect([[
+      {5:^+--  2 lines: å 语 x̎͂̀̂͛͛ العَرَبِيَّة·················}|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+                                                   |
+    ]])
+
+    feed_command("set number foldcolumn=2")
+    screen:expect([[
+      {7:+ }{5:  1 ^+--  2 lines: å 语 x̎͂̀̂͛͛ العَرَبِيَّة···········}|
+      {7:  }{1:~                                          }|
+      {7:  }{1:~                                          }|
+      {7:  }{1:~                                          }|
+      {7:  }{1:~                                          }|
+      {7:  }{1:~                                          }|
+      {7:  }{1:~                                          }|
+      :set number foldcolumn=2                     |
+    ]])
+
+    -- Note: too much of the folded line gets cut off.This is a vim bug.
+    feed_command("set rightleft")
+    screen:expect([[
+      {5:+--  2 lines: å ······················^·  1 }{7: +}|
+      {1:                                          ~}{7:  }|
+      {1:                                          ~}{7:  }|
+      {1:                                          ~}{7:  }|
+      {1:                                          ~}{7:  }|
+      {1:                                          ~}{7:  }|
+      {1:                                          ~}{7:  }|
+      :set rightleft                               |
+    ]])
+
+    feed_command("set nonumber foldcolumn=0")
+    screen:expect([[
+      {5:+--  2 lines: å 语 x̎͂̀̂͛͛ ال·····················^·}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      :set nonumber foldcolumn=0                   |
+    ]])
+
+    feed_command("set arabicshape")
+    screen:expect([[
+      {5:+--  2 lines: å 语 x̎͂̀̂͛͛ ﺍﻟ·····················^·}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+                                                   |
+    ]])
+
+    feed('zo')
+    screen:expect([[
+                                     ﺔﻴَّﺑِﺮَﻌَ^ﻟﺍ x̎͂̀̂͛͛ 语 å|
+                                          txet eröm|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+                                                   |
+    ]])
+
+    feed_command('set noarabicshape')
+    screen:expect([[
+                                     ةيَّبِرَعَ^لا x̎͂̀̂͛͛ 语 å|
+                                          txet eröm|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+      {1:                                            ~}|
+                                                   |
+    ]])
+
+  end)
+
+  it("work in cmdline window", function()
+    feed_command("set foldmethod=manual")
+    feed_command("let x = 1")
+    feed_command("/alpha")
+    feed_command("/omega")
+
+    feed("<cr>q:")
+    screen:expect([[
+                                                   |
+      {2:[No Name]                                    }|
+      {1::}set foldmethod=manual                       |
+      {1::}let x = 1                                   |
+      {1::}^                                            |
+      {1::~                                           }|
+      {3:[Command Line]                               }|
+      :                                            |
+    ]])
+
+    feed("kzfk")
+    screen:expect([[
+                                                   |
+      {2:[No Name]                                    }|
+      {1::}{5:^+--  2 lines: set foldmethod=manual·········}|
+      {1::}                                            |
+      {1::~                                           }|
+      {1::~                                           }|
+      {3:[Command Line]                               }|
+      :                                            |
+    ]])
+
+    feed("<cr>")
+    screen:expect([[
+      ^                                             |
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      :                                            |
+    ]])
+
+    feed("/<c-f>")
+    screen:expect([[
+                                                   |
+      {2:[No Name]                                    }|
+      {1:/}alpha                                       |
+      {1:/}{6:omega}                                       |
+      {1:/}^                                            |
+      {1:/~                                           }|
+      {3:[Command Line]                               }|
+      /                                            |
+    ]])
+
+    feed("ggzfG")
+    screen:expect([[
+                                                   |
+      {2:[No Name]                                    }|
+      {1:/}{5:^+--  3 lines: alpha·························}|
+      {1:/~                                           }|
+      {1:/~                                           }|
+      {1:/~                                           }|
+      {3:[Command Line]                               }|
+      /                                            |
+    ]])
+
+  end)
+end)

--- a/test/functional/ui/multibyte_spec.lua
+++ b/test/functional/ui/multibyte_spec.lua
@@ -1,0 +1,122 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local feed = helpers.feed
+local feed_command = helpers.feed_command
+local insert = helpers.insert
+local funcs = helpers.funcs
+
+describe("multibyte rendering", function()
+  local screen
+  before_each(function()
+    clear()
+    screen = Screen.new(60, 6)
+    screen:attach({rgb=true})
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue1},
+      [2] = {background = Screen.colors.WebGray},
+      [3] = {background = Screen.colors.LightMagenta},
+      [4] = {bold = true},
+    })
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  it("works with composed char at start of line", function()
+    insert([[
+      ̊
+      x]])
+    feed("gg")
+     -- verify the modifier infact is alone
+    feed_command("ascii")
+    screen:expect([[
+      ^ ̊                                                           |
+      x                                                           |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      < ̊> 778, Hex 030a, Octal 1412                               |
+    ]])
+
+    -- a char inserted before will spontaneously merge with it
+    feed("ia<esc>")
+    feed_command("ascii")
+    screen:expect([[
+      ^å                                                           |
+      x                                                           |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      <a>  97,  Hex 61,  Octal 141 < ̊> 778, Hex 030a, Octal 1412  |
+    ]])
+  end)
+
+  it('works with doublewidth char at end of line', function()
+    feed('58a <esc>a馬<esc>')
+    screen:expect([[
+                                                                ^馬|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+                                                                  |
+    ]])
+
+    feed('i <esc>')
+    screen:expect([[
+                                                                ^ {1:>}|
+      馬                                                          |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+                                                                  |
+    ]])
+
+    feed('l')
+    screen:expect([[
+                                                                 {1:>}|
+      ^馬                                                          |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+                                                                  |
+    ]])
+  end)
+
+  it('clears left half of double-width char when right half is overdrawn', function()
+    feed('o-馬<esc>ggiab ')
+    screen:expect([[
+      ab ^                                                         |
+      -馬                                                         |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {4:-- INSERT --}                                                |
+    ]])
+
+    -- check double-with char is temporarily hidden when overlapped
+    funcs.complete(4, {'xx', 'yy'})
+    screen:expect([[
+      ab xx^                                                       |
+      - {2: xx             }                                          |
+      {1:~ }{3: yy             }{1:                                          }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {4:-- INSERT --}                                                |
+    ]])
+
+    -- check it is properly restored
+    feed('z')
+    screen:expect([[
+      ab xxz^                                                      |
+      -馬                                                         |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {4:-- INSERT --}                                                |
+    ]])
+  end)
+end)
+


### PR DESCRIPTION
Let's merge the tests in #7992 first, to confirm the behavior from master is not changed (except always use `mco=6`).