### PR TITLE
[RFC] Fix implicit conversion warning

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -6653,7 +6653,7 @@ bool trigger_cursorhold(void) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 /// Return true if "event" autocommand is defined.
 ///
 /// @param event the autocommand to check
-bool has_event(int event) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
+bool has_event(event_T event) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return first_autopat[event] != NULL;
 }


### PR DESCRIPTION
When not casting the argument, clang 6 would report an "implicit conversion changes signedness" warning.