### PR TITLE
startup: -es/-Es (silent/batch mode): skip swapfile

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -208,6 +208,7 @@ argument.
 			echo foo | nvim -V1 -es
 <
 		User |init.vim| is skipped (unless given with |-u|).
+		Swap file is skipped (like |-n|).
 		|$TERM| is not used.
 
 		If stdin is not a TTY:
@@ -255,7 +256,7 @@ argument.
 		{not available when compiled without the |+eval| feature}
 
 							*-n*
--n		No swap file will be used.  Recovery after a crash will be
+-n		No |swap-file| will be used.  Recovery after a crash will be
 		impossible.  Handy if you want to view or edit a file on a
 		very slow medium (e.g., a floppy).
 		Can also be done with ":set updatecount=0".  You can switch it

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -346,7 +346,10 @@ Shell:
 
 Startup:
   |-e| and |-es| invoke the same "improved Ex mode" as -E and -Es.
-  |-E| and |-Es| reads stdin as text (into buffer 1).
+  |-E| and |-Es| read stdin as text (into buffer 1).
+  |-es| and |-Es| have improved behavior:
+    - Quits automatically, don't need "-c qa!".
+    - Skips swap-file dialog.
   |-s| reads Normal commands from stdin if the script name is "-".
   Reading text (instead of commands) from stdin |--|:
     - works by default: "-" file is optional

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -114,12 +114,12 @@ typedef struct {
   char *listen_addr;                    // --listen {address}
 } mparm_T;
 
-/* Values for edit_type. */
-#define EDIT_NONE   0       /* no edit type yet */
-#define EDIT_FILE   1       /* file name argument[s] given, use argument list */
-#define EDIT_STDIN  2       /* read file from stdin */
-#define EDIT_TAG    3       /* tag name argument given, use tagname */
-#define EDIT_QF     4       /* start in quickfix mode */
+// Values for edit_type.
+#define EDIT_NONE   0       // no edit type yet
+#define EDIT_FILE   1       // file name argument[s] given, use argument list
+#define EDIT_STDIN  2       // read file from stdin
+#define EDIT_TAG    3       // tag name argument given, use tagname
+#define EDIT_QF     4       // start in quickfix mode
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "main.c.generated.h"
@@ -807,6 +807,7 @@ static void command_line_scan(mparm_T *parmp)
           if (exmode_active) {
             // "nvim -e -" silent mode
             silent_mode = true;
+            parmp->no_swap_file = true;
           } else {
             if (parmp->edit_type != EDIT_NONE
                 && parmp->edit_type != EDIT_FILE
@@ -990,6 +991,7 @@ static void command_line_scan(mparm_T *parmp)
         case 's': {
           if (exmode_active) {    // "-es" silent (batch) Ex-mode
             silent_mode = true;
+            parmp->no_swap_file = true;
           } else {                // "-s {scriptin}" read from script file
             want_argument = true;
           }

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -203,6 +203,20 @@ describe('startup', function()
                     { 'set encoding', '' }))
   end)
 
+  it('-es/-Es disables swapfile, user config #8540', function()
+    for _,arg in ipairs({'-es', '-Es'}) do
+      local out = funcs.system({nvim_prog, arg,
+                                '+set swapfile? updatecount? shada?',
+                                "+put =execute('scriptnames')", '+%print'})
+      local line1 = string.match(out, '^.-\n')
+      -- updatecount=0 means swapfile was disabled.
+      eq("  swapfile  updatecount=0  shada=!,'100,<50,s10,h\n", line1)
+      -- Standard plugins were loaded, but not user config.
+      eq('health.vim', string.match(out, 'health.vim'))
+      eq(nil, string.match(out, 'init.vim'))
+    end
+  end)
+
   it('does not crash if --embed is given twice', function()
     clear{args={'--embed'}}
     eq(2, eval('1+1'))


### PR DESCRIPTION
To use Nvim as a scripting engine the side-effects of swapfiles, ~~shada,~~
and user config should be avoided by default. Now -es/-Es can serve that
purpose.

**Update:** decided not to skip shada, for now. It's useful if someone wants to re-use a macro that they recorded. Easier to specify `-i NONE` than `-i ~/.local/share/nvim/shada/main.shada`.