### PR TITLE
[RDY] vim-patch:8.0.0596

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3988,10 +3988,11 @@ static int ins_compl_get_exp(pos_T *ini)
       p_ws = save_p_ws;
     }
 
-    /* check if compl_curr_match has changed, (e.g. other type of
-     * expansion added something) */
-    if (type != 0 && compl_curr_match != compl_old_match)
+    // check if compl_curr_match has changed, (e.g. other type of
+    // expansion added something)
+    if (type != 0 && compl_curr_match != compl_old_match) {
       found_new_match = OK;
+    }
 
     /* break the loop for specialized modes (use 'complete' just for the
      * generic l_ctrl_x_mode == 0) or when we've found a new match */

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -608,4 +608,47 @@ func Test_popup_and_preview_autocommand()
   bw!
 endfunc
 
+fun MessCompleteMonths()
+  for m in split("Jan Feb Mar Apr May Jun Jul Aug Sep")
+    call complete_add(m)
+    if complete_check()
+      break
+    endif
+  endfor
+  return []
+endfun
+
+fun MessCompleteMore()
+  call complete(1, split("Oct Nov Dec"))
+  return []
+endfun
+
+fun MessComplete(findstart, base)
+  if a:findstart
+    let line = getline('.')
+    let start = col('.') - 1
+    while start > 0 && line[start - 1] =~ '\a'
+      let start -= 1
+    endwhile
+    return start
+  else
+    call MessCompleteMonths()
+    call MessCompleteMore()
+    return []
+  endif
+endf
+
+func Test_complete_func_mess()
+  " Calling complete() after complete_add() in 'completefunc' is wrong, but it
+  " should not crash.
+  set completefunc=MessComplete
+  new
+  call setline(1, 'Ju')
+  call feedkeys("A\<c-x>\<c-u>/\<esc>", 'tx')
+  call assert_equal('Oct/Oct', getline(1))
+  bwipe!
+  set completefunc=
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:8.0.0596: crash when complete() called after complete_add()**

Problem:    Crash when complete() is called after complete_add() in
            'completefunc'. (Lifepillar)
Solution:   Bail out if compl_pattern is NULL. (closes vim/vim#1668)
            Also avoid using freed memory.
https://github.com/vim/vim/commit/4475b623960671898dac6a72b13a8d140402afa6