### PR TITLE
functionaltest: Use octal escapes for printf

### DIFF
--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -111,10 +111,10 @@ describe("shell command :!", function()
     feed([[<CR>]])
     -- Print BELL control code. #4338
     screen.bell = false
-    feed([[:!printf '\x07\x07\x07\x07text'<CR>]])
+    feed([[:!printf '\007\007\007\007text'<CR>]])
     screen:expect([[
       ~                                                 |
-      :!printf '\x07\x07\x07\x07text'                   |
+      :!printf '\007\007\007\007text'                   |
       text                                              |
       Press ENTER or type command to continue^           |
     ]], nil, nil, function()
@@ -122,7 +122,7 @@ describe("shell command :!", function()
     end)
     feed([[<CR>]])
     -- Print BS control code.
-    feed([[:echo system('printf ''\x08\n''')<CR>]])
+    feed([[:echo system('printf ''\010\n''')<CR>]])
     screen:expect([[
       ~                                                 |
       ^H                                                |


### PR DESCRIPTION
According to POSIX[0], only octal escapes are supported by the printf
command.  GNU coreutils' printf and some shells' builtin printf versions
which support hex escapes, but dash and non-GNU printf do not.

[0]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html