### PR TITLE
[RDY] vim-patch:8.0.0{575,577}

### DIFF
--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -538,7 +538,14 @@ int get_expr_indent(void)
     sandbox++;
   }
   textlock++;
-  indent = (int)eval_to_number(curbuf->b_p_inde);
+
+  // Need to make a copy, the 'indentexpr' option could be changed while
+  // evaluating it.
+  char_u *inde_copy = vim_strsave(curbuf->b_p_inde);
+  if (inde_copy != NULL) {
+    indent = (int)eval_to_number(inde_copy);
+    xfree(inde_copy);
+  }
 
   if (use_sandbox) {
     sandbox--;

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -520,7 +520,7 @@ int inindent(int extra)
 // Get indent level from 'indentexpr'.
 int get_expr_indent(void)
 {
-  int indent;
+  int indent = -1;
   pos_T save_pos;
   colnr_T save_curswant;
   int save_set_curswant;

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -275,3 +275,15 @@ func Test_complete()
   set complete&
 endfun
 
+func ResetIndentexpr()
+  set indentexpr=
+endfunc
+
+func Test_set_indentexpr()
+  " this was causing usage of freed memory
+  set indentexpr=ResetIndentexpr()
+  new
+  call feedkeys("i\<c-f>", 'x')
+  call assert_equal('', &indentexpr)
+  bwipe!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0575: using freed memory when resetting 'indentexpr'**

Problem:    Using freed memory when resetting 'indentexpr' while evaluating
            it. (Dominique Pelle)
Solution:   Make a copy of 'indentexpr'.
https://github.com/vim/vim/commit/a701b3b6f0f06ac0c9fcc75c6c34a1258fc3b1a2

 **vim-patch:8.0.0577: warning for uninitialized variable**

Problem:    Warning for uninitialized variable. (John Marriott)
Solution:   Initialize "indent".
vim/vim@97db554