### PR TITLE
[RFC] vim-patch:8.0.0530,8.0.0531,8.0.0532,8.0.0543,8.0.0545

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4132,7 +4132,6 @@ ins_compl_next (
 )
 {
   int num_matches = -1;
-  int i;
   int todo = count;
   compl_T *found_compl = NULL;
   int found_end = FALSE;
@@ -4294,15 +4293,27 @@ ins_compl_next (
    * Truncate the file name to avoid a wait for return.
    */
   if (compl_shown_match->cp_fname != NULL) {
-    STRCPY(IObuff, "match in file ");
-    i = (vim_strsize(compl_shown_match->cp_fname) + 16) - sc_col;
-    if (i <= 0)
-      i = 0;
-    else
-      STRCAT(IObuff, "<");
-    STRCAT(IObuff, compl_shown_match->cp_fname + i);
-    msg(IObuff);
-    redraw_cmdline = FALSE;         /* don't overwrite! */
+    char *lead = _("match in file");
+    int space = sc_col - vim_strsize((char_u *)lead) - 2;
+    char_u  *s;
+    char_u  *e;
+
+    if (space > 0) {
+      // We need the tail that fits.  With double-byte encoding going
+      // back from the end is very slow, thus go from the start and keep
+      // the text that fits in "space" between "s" and "e".
+      for (s = e = compl_shown_match->cp_fname; *e != NUL; MB_PTR_ADV(e)) {
+        space -= ptr2cells(e);
+        while (space < 0) {
+            space += ptr2cells(s);
+            MB_PTR_ADV(s);
+        }
+      }
+      vim_snprintf((char *)IObuff, IOSIZE, "%s %s%s", lead,
+              s > compl_shown_match->cp_fname ? "<" : "", s);
+      msg(IObuff);
+      redraw_cmdline = false;     // don't overwrite!
+    }
   }
 
   return num_matches;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4305,12 +4305,12 @@ ins_compl_next (
       for (s = e = compl_shown_match->cp_fname; *e != NUL; MB_PTR_ADV(e)) {
         space -= ptr2cells(e);
         while (space < 0) {
-            space += ptr2cells(s);
-            MB_PTR_ADV(s);
+          space += ptr2cells(s);
+          MB_PTR_ADV(s);
         }
       }
       vim_snprintf((char *)IObuff, IOSIZE, "%s %s%s", lead,
-              s > compl_shown_match->cp_fname ? "<" : "", s);
+                   s > compl_shown_match->cp_fname ? "<" : "", s);
       msg(IObuff);
       redraw_cmdline = false;     // don't overwrite!
     }

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1328,10 +1328,14 @@ func Test_edit_complete_very_long_name()
     " Long directory names only work on Unix.
     return
   endif
+  " Try to get the Vim window position before setting 'columns'.
+  let winposx = getwinposx()
+  let winposy = getwinposy()
   let save_columns = &columns
-  set columns=5000
-  call assert_equal(5000, &columns)
+  set columns=2000
+  call assert_equal(2000, &columns)
   set noswapfile
+
   let dirname = getcwd() . "/Xdir"
   let longdirname = dirname . repeat('/' . repeat('d', 255), 4)
   let longfilename = longdirname . '/' . repeat('a', 255)
@@ -1345,5 +1349,8 @@ func Test_edit_complete_very_long_name()
   exe 'bwipe! ' . longfilename
   call delete(dirname, 'rf')
   let &columns = save_columns
+  if winposx >= 0 && winposy >= 0
+    exe 'winpos ' . winposx . ' ' . winposy
+  endif
   set swapfile&
 endfunc

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1324,6 +1324,10 @@ func Test_edit_quit()
 endfunc
 
 func Test_edit_complete_very_long_name()
+  if !has('unix')
+    " Long directory names only work on Unix.
+    return
+  endif
   let save_columns = &columns
   set columns=5000
   call assert_equal(5000, &columns)

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1323,3 +1323,23 @@ func Test_edit_quit()
   only
 endfunc
 
+func Test_edit_complete_very_long_name()
+  let save_columns = &columns
+  set columns=5000
+  call assert_equal(5000, &columns)
+  set noswapfile
+  let dirname = getcwd() . "/Xdir"
+  let longdirname = dirname . repeat('/' . repeat('d', 255), 4)
+  let longfilename = longdirname . '/' . repeat('a', 255)
+  call mkdir(longdirname, 'p')
+  call writefile(['Totum', 'Table'], longfilename)
+  new
+  exe "next Xfile " . longfilename
+  exe "normal iT\<C-N>"
+
+  bwipe!
+  exe 'bwipe! ' . longfilename
+  call delete(dirname, 'rf')
+  let &columns = save_columns
+  set swapfile&
+endfunc

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1324,7 +1324,7 @@ func Test_edit_quit()
 endfunc
 
 func Test_edit_complete_very_long_name()
-  if !has('unix')
+  if !has('unix') || has('mac')
     " Long directory names only work on Unix.
     return
   endif

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1324,22 +1324,31 @@ func Test_edit_quit()
 endfunc
 
 func Test_edit_complete_very_long_name()
-  if !has('unix') || has('mac')
+  if !has('unix')
     " Long directory names only work on Unix.
     return
   endif
+
+  let dirname = getcwd() . "/Xdir"
+  let longdirname = dirname . repeat('/' . repeat('d', 255), 4)
+  try
+    call mkdir(longdirname, 'p')
+  catch /E739:/
+    " Long directory name probably not supported.
+    call delete(dirname, 'rf')
+    return
+  endtry
+
   " Try to get the Vim window position before setting 'columns'.
   let winposx = getwinposx()
   let winposy = getwinposy()
   let save_columns = &columns
+  " Need at least about 1100 columns to reproduce the problem.
   set columns=2000
   call assert_equal(2000, &columns)
   set noswapfile
 
-  let dirname = getcwd() . "/Xdir"
-  let longdirname = dirname . repeat('/' . repeat('d', 255), 4)
   let longfilename = longdirname . '/' . repeat('a', 255)
-  call mkdir(longdirname, 'p')
   call writefile(['Totum', 'Table'], longfilename)
   new
   exe "next Xfile " . longfilename


### PR DESCRIPTION
#### vim-patch:8.0.0530: buffer overflow when 'columns' is very big

Problem:    Buffer overflow when 'columns' is very big. (Nikolai Pavlov)
Solution:   Correctly compute where to truncate.  Fix translation.
            (closes vim/vim#1600)
https://github.com/vim/vim/commit/658a3a2caf5852d071b6b1be92d9d6614a6208dc


#### vim-patch:8.0.0531: test with long directory name fails on non-unix systems

Problem:    Test with long directory name fails on non-unix systems.
Solution:   Skip the test on non-unix systems.
https://github.com/vim/vim/commit/9b81079ddd839a666682f6bdbc24890bf4d1a42c


#### vim-patch:8.0.0532: test with long directory name fails on Mac

Problem:    Test with long directory name fails on Mac.
Solution:   Skip the test on Mac systems.
https://github.com/vim/vim/commit/c77d6757471fa207520586bbdbc1b30af84cf5c8


#### vim-patch:8.0.0543: test_edit causes older xfce4-terminal to close

Problem:    Test_edit causes older xfce4-terminal to close. (Dominique Pelle)
Solution:   Reduce number of columns to 2000.  Try to restore the window
            position.
https://github.com/vim/vim/commit/ba6ec182973af726ce9b7b7eb3753fc3a7ae7d1b


#### vim-patch:8.0.0545: edit test may fail on some systems

Problem:    Edit test may fail on some systems.
Solution:   If creating a directory with a very long path fails, bail out.
https://github.com/vim/vim/commit/15ecbd6f3d39ff04862999a577962ef9369a9e53