### PR TITLE
vim-patch:8.0.0{602,603,604}

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5234,9 +5234,9 @@ static void nv_gotofile(cmdarg_T *cap)
       (void)autowrite(curbuf, false);
     }
     setpcmark();
-    (void)do_ecmd(0, ptr, NULL, NULL, ECMD_LAST,
-                  buf_hide(curbuf) ? ECMD_HIDE : 0, curwin);
-    if (cap->nchar == 'F' && lnum >= 0) {
+    if (do_ecmd(0, ptr, NULL, NULL, ECMD_LAST,
+                buf_hide(curbuf) ? ECMD_HIDE : 0, curwin) == OK
+        && cap->nchar == 'F' && lnum >= 0) {
       curwin->w_cursor.lnum = lnum;
       check_cursor_lnum();
       beginline(BL_SOL | BL_FIX);
@@ -7151,7 +7151,7 @@ static void set_op_var(int optype)
     assert(opchar0 >= 0 && opchar0 <= UCHAR_MAX);
     opchars[0] = (char) opchar0;
 
-    int opchar1 = get_extra_op_char(optype); 
+    int opchar1 = get_extra_op_char(optype);
     assert(opchar1 >= 0 && opchar1 <= UCHAR_MAX);
     opchars[1] = (char) opchar1;
 

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -38,7 +38,7 @@ func Test_gF()
   w! Xfile
   close
   new
-  call setline(1, ['one', 'Xfile:3', 'three'])
+  call setline(1, ['one', 'Xfile@3', 'three'])
   2
   call assert_fails('normal gF', 'E37:')
   call assert_equal(2, getcurpos()[1])

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -1,7 +1,7 @@
 
 " This is a test if a URL is recognized by "gf", with the cursor before and
 " after the "://".  Also test ":\\".
-function! Test_gf_url()
+func Test_gf_url()
   enew!
   call append(0, [
       \ "first test for URL://machine.name/tmp/vimtest2a and other text",
@@ -30,4 +30,25 @@ function! Test_gf_url()
 
   set isf&vim
   enew!
-endfunction
+endfunc
+
+func Test_gF()
+  new
+  call setline(1, ['111', '222', '333', '444'])
+  w! Xfile
+  close
+  new
+  call setline(1, ['one', 'Xfile:3', 'three'])
+  2
+  call assert_fails('normal gF', 'E37:')
+  call assert_equal(2, getcurpos()[1])
+  w! Xfile2
+  normal gF
+  call assert_equal('Xfile', bufname('%'))
+  call assert_equal(3, getcurpos()[1])
+
+  call delete('Xfile')
+  call delete('Xfile2')
+  bwipe Xfile
+  bwipe Xfile2
+endfunc

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -38,7 +38,8 @@ func Test_gF()
   w! Xfile
   close
   new
-  call setline(1, ['one', 'Xfile@3', 'three'])
+  set isfname-=:
+  call setline(1, ['one', 'Xfile:3', 'three'])
   2
   call assert_fails('normal gF', 'E37:')
   call assert_equal(2, getcurpos()[1])
@@ -47,6 +48,7 @@ func Test_gF()
   call assert_equal('Xfile', bufname('%'))
   call assert_equal(3, getcurpos()[1])
 
+  set isfname&
   call delete('Xfile')
   call delete('Xfile2')
   bwipe Xfile


### PR DESCRIPTION
**vim-patch:8.0.0602: when gF fails to edit the file the cursor still moves**

Problem:    When gF fails to edit the file the cursor still moves to the found
            line number.
Solution:   Check the return value of do_ecmd(). (Michael Hwang)
vim/vim@2a79ed2

**vim-patch:8.0.0603: gF test fails on MS-Windows**

Problem:    gF test fails on MS-Windows.
Solution:   Use @ instead of : before the line number
vim/vim@d7aca7a

**vim-patch:8.0.0604: gF test fails still on MS-Windows**

Problem:    gF test fails still on MS-Windows.
Solution:   Use : before the line number and remove it from 'isfname'.
vim/vim@712598f