### PR TITLE
[RDY] vim-patch:8.0.0609

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7464,8 +7464,9 @@ static void nv_esc(cmdarg_T *cap)
     if (restart_edit == 0
         && cmdwin_type == 0
         && !VIsual_active
-        && no_reason)
-      MSG(_("Type  :quit<Enter>  to exit Nvim"));
+        && no_reason) {
+      MSG(_("Type  :qa!  and press <Enter> to abandon all changes and exit Nvim"));  // NOLINT(whitespace/line_length)
+    }
 
     /* Don't reset "restart_edit" when 'insertmode' is set, it won't be
      * set again below when halfway through a mapping. */

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7465,7 +7465,8 @@ static void nv_esc(cmdarg_T *cap)
         && cmdwin_type == 0
         && !VIsual_active
         && no_reason) {
-      MSG(_("Type  :qa!  and press <Enter> to abandon all changes and exit Nvim"));  // NOLINT(whitespace/line_length)
+      MSG(_("Type  :qa!  and press <Enter> to abandon all changes"
+            " and exit Nvim"));
     }
 
     /* Don't reset "restart_edit" when 'insertmode' is set, it won't be

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -241,7 +241,7 @@ describe('system()', function()
         ~                                                    |
         ~                                                    |
         ~                                                    |
-        Type  :quit<Enter>  to exit Nvim                     |
+        Type  :qa!  and press <E...all changes and exit Nvim |
       ]])
     end)
   end)
@@ -448,7 +448,7 @@ describe('systemlist()', function()
         ~                                                    |
         ~                                                    |
         ~                                                    |
-        Type  :quit<Enter>  to exit Nvim                     |
+        Type  :qa!  and press <E...all changes and exit Nvim |
       ]])
     end)
   end)

--- a/test/functional/ui/cmdline_highlight_spec.lua
+++ b/test/functional/ui/cmdline_highlight_spec.lua
@@ -494,7 +494,7 @@ describe('Command-line coloring', function()
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
-      Type  :quit<Enter>  to exit Nvim        |
+      Type  :qa!  and pr...nges and exit Nvim |
     ]])
   end)
   it('works fine with NUL, NL, CR', function()


### PR DESCRIPTION
**vim-patch:8.0.0609: some people still don't know how to quit**

Problem:    For some people the hint about quitting is not sufficient.
Solution:   Put <Enter> separately.  Also use ":qa!" to get out even when
            there are changes.
https://github.com/vim/vim/commit/28a8193e3113f676f89fb6312b099d849df881d3