### PR TITLE
[RDY] vim-patch:8.0.0535

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -20498,7 +20498,7 @@ void free_all_functions(void)
 
   // Clean up the call stack.
   while (current_funccal != NULL) {
-    clear_tv(current_funccal->rettv);
+    tv_clear(current_funccal->rettv);
     cleanup_function_call(current_funccal);
   }
 


### PR DESCRIPTION
#### vim-patch:8.0.0535: memory leak when exiting from within a user function

Problem:    Memory leak when exiting from within a user function.
Solution:   Clear the function call stack on exit.
https://github.com/vim/vim/commit/6914c64ee58ce68f31fb8a8793293a9b3f2f6240