### PR TITLE
startup: go to buffer 2 if stdin is empty

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1410,6 +1410,12 @@ static void read_stdin(void)
   int save_msg_didany = msg_didany;
   set_buflisted(true);
   (void)open_buffer(true, NULL, 0);  // create memfile and read file
+  if (BUFEMPTY() && curbuf->b_next != NULL) {
+    // stdin was empty, go to buffer 2 (e.g. "echo file1 | xargs nvim"). #8561
+    msg_silent++;
+    do_buffer(DOBUF_GOTO, DOBUF_FIRST, FORWARD, curbuf->b_next->handle, 0);
+    msg_silent--;
+  }
   no_wait_return = false;
   msg_didany = save_msg_didany;
   TIME_MSG("reading stdin");

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1412,9 +1412,9 @@ static void read_stdin(void)
   (void)open_buffer(true, NULL, 0);  // create memfile and read file
   if (BUFEMPTY() && curbuf->b_next != NULL) {
     // stdin was empty, go to buffer 2 (e.g. "echo file1 | xargs nvim"). #8561
-    msg_silent++;
-    do_buffer(DOBUF_GOTO, DOBUF_FIRST, FORWARD, curbuf->b_next->handle, 0);
-    msg_silent--;
+    do_cmdline_cmd("silent! bnext");
+    // Delete the empty stdin buffer.
+    do_cmdline_cmd("bwipeout 1");
   }
   no_wait_return = false;
   msg_didany = save_msg_didany;

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -122,6 +122,18 @@ describe('startup', function()
                     { 'ohyeah', '' }))
   end)
 
+  it('goes to buffer 2 if stdin is empty #8561', function()
+    eq('\r\n  1u#    "[No Name]"                    line 1\r\n  2 %a   "file1"                        line 0\r\n  3      "file2"                        line 0',
+       funcs.system({nvim_prog, '-n', '-u', 'NONE', '-i', 'NONE', '--headless',
+                     '+ls!',
+                     '+qall!',
+                     '-',
+                     'file1',
+                     'file2',
+                    },
+                    { '' }))
+  end)
+
   it('-e/-E interactive #7679', function()
     clear('-e')
     local screen = Screen.new(25, 3)

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -122,8 +122,8 @@ describe('startup', function()
                     { 'ohyeah', '' }))
   end)
 
-  it('goes to buffer 2 if stdin is empty #8561', function()
-    eq('\r\n  1u#    "[No Name]"                    line 1\r\n  2 %a   "file1"                        line 0\r\n  3      "file2"                        line 0',
+  it('if stdin is empty: selects buffer 2, deletes buffer 1 #8561', function()
+    eq('\r\n  2 %a   "file1"                        line 0\r\n  3      "file2"                        line 0',
        funcs.system({nvim_prog, '-n', '-u', 'NONE', '-i', 'NONE', '--headless',
                      '+ls!',
                      '+qall!',


### PR DESCRIPTION
If stdin is not a TTY we read it into buffer 1, as text. But if the
stdin pipe is empty, Nvim was most likely invoked for some other reason.
DWIM: select buffer 2 (if it exists). Example:

    echo file1 | xargs nvim

closes #8560
closes #8561
ref https://github.com/equalsraf/neovim-qt/issues/417