### PR TITLE
[RDY] vim-patch:8.0.0455

### DIFF
--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -373,14 +373,17 @@ endfunc
 
 " Tests for the mode() function
 let current_modes = ''
-func! Save_mode()
+func Save_mode()
   let g:current_modes = mode(0) . '-' . mode(1)
   return ''
 endfunc
 
-func! Test_mode()
+func Test_mode()
   new
   call append(0, ["Blue Ball Black", "Brown Band Bowl", ""])
+
+  " Only complete from the current buffer.
+  set complete=.
 
   inoremap <F2> <C-R>=Save_mode()<CR>
 
@@ -490,6 +493,7 @@ func! Test_mode()
 
   bwipe!
   iunmap <F2>
+  set complete&
 endfunc
 
 func Test_getbufvar()


### PR DESCRIPTION
**vim-patch:8.0.0455: the mode test may hang**

Problem:    The mode test may hang in Test_mode(). (Michael Soyka)
Solution:   Set 'complete' to only search the current buffer (as suggested by
            Michael)
https://github.com/vim/vim/commit/ffea8c99d9658b0b51a848a6f674851851e78fa7

Related: https://github.com/neovim/neovim/pull/7941