### PR TITLE
[RFC] vim-patch:8.0.1633: a TextChanged autocmd triggers when it is defined

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -295,6 +295,13 @@ open_buffer (
   }
   save_file_ff(curbuf);                 // keep this fileformat
 
+  /* Set last_changedtick to avoid triggering a TextChanged autocommand right
+   * after it was added. */
+  curbuf->b_last_changedtick = CHANGEDTICK(curbuf);
+#ifdef FEAT_INS_EXPAND
+  curbuf->b_last_changedtick_pum = CHANGEDTICK(curbuf);
+#endif
+
   /* require "!" to overwrite the file, because it wasn't read completely */
   if (aborting())
     curbuf->b_flags |= BF_READERR;


### PR DESCRIPTION
Problem:    A TextChanged autocmd triggers when it is defined after creating a
            buffer.
Solution:   Set b_last_changedtick when opening a buffer. (Hirohito Highlight,
            closes vim/vim#2742)
https://github.com/vim/vim/commit/8c64a36e40b8746404f7151abe6849393396af10

TODO:
- [ ] requires 8.0.0365?! (see https://github.com/neovim/neovim/pull/8474#issuecomment-397953628)