### PR TITLE
[RFC] vim-patch:8.0.0{467,547}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19533,7 +19533,6 @@ void ex_execute(exarg_T *eap)
       // follows is displayed on a new line when scrolling back at the
       // more prompt.
       msg_sb_eol();
-      msg_start();
     }
 
     if (eap->cmdidx == CMD_echomsg) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19528,6 +19528,14 @@ void ex_execute(exarg_T *eap)
   }
 
   if (ret != FAIL && ga.ga_data != NULL) {
+    if (eap->cmdidx == CMD_echomsg || eap->cmdidx == CMD_echoerr) {
+      // Mark the already saved text as finishing the line, so that what
+      // follows is displayed on a new line when scrolling back at the
+      // more prompt.
+      msg_sb_eol();
+      msg_start();
+    }
+
     if (eap->cmdidx == CMD_echomsg) {
       MSG_ATTR(ga.ga_data, echo_attr);
       ui_flush();

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -430,4 +430,14 @@ func Test_getcmdtype()
   cunmap <F6>
 endfunc
 
+func Test_verbosefile()
+  set verbosefile=Xlog
+  echomsg 'foo'
+  echomsg 'bar'
+  set verbosefile=
+  let log = readfile('Xlog')
+  call assert_match("foo\nbar", join(log, "\n"))
+  call delete('Xlog')
+endfunc
+
 set cpo&


### PR DESCRIPTION
**vim-patch:8.0.0467: using g< after :for does not show the right output**

Problem:    Using g< after :for does not show the right output. (Marcin
            Szamotulski)
Solution:   Call msg_sb_eol() in :echomsg.
vim/vim@57002ad

**vim-patch:8.0.0547: extra line break in verbosefile**

Problem:    Extra line break in verbosefile when using ":echomsg". (Ingo
            Karkat)
Solution:   Don't call msg_start(). (closes vim/vim#1618)
vim/vim@52604f2

Related:  https://github.com/neovim/neovim/pull/7941