### PR TITLE
[RDY] vim-patch:8.0.0598

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8611,7 +8611,8 @@ eval_vars (
     default:
       // should not happen
       *errormsg = (char_u *)"";
-      return NULL;
+      result = (char_u *)"";    // avoid gcc warning
+      break;
     }
 
     resultlen = STRLEN(result);         /* length of new string */


### PR DESCRIPTION
**vim-patch:8.0.0598: building with gcc 7.1 yields new warnings**

Problem:    Building with gcc 7.1 yields new warnings.
Solution:   Initialize result. (John Marriott)
https://github.com/vim/vim/commit/9e0f6ec0762575d229b86798b284ca4876bc3d73