### PR TITLE
[RFC] vim-patch:8.0.0537

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1309,7 +1309,7 @@ filterend:
 void
 do_shell(
     char_u *cmd,
-    int flags              /* may be SHELL_DOOUT when output is redirected */
+    int flags             // may be SHELL_DOOUT when output is redirected
 )
 {
   int save_nwr;
@@ -1793,10 +1793,10 @@ int
 check_overwrite(
     exarg_T *eap,
     buf_T *buf,
-    char_u *fname,         /* file name to be used (can differ from
-                               buf->ffname) */
-    char_u *ffname,        /* full path version of fname */
-    int other                  /* writing under other name */
+    char_u *fname,         // file name to be used (can differ from
+                           //   buf->ffname)
+    char_u *ffname,        // full path version of fname
+    int other              // writing under other name
 )
 {
   /*
@@ -4597,8 +4597,8 @@ char_u *check_help_lang(char_u *arg)
 int
 help_heuristic(
     char_u *matched_string,
-    int offset,                             /* offset for match */
-    int wrong_case                         /* no matching case */
+    int offset,                             // offset for match
+    int wrong_case                          // no matching case
 )
 {
   int num_letters;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1306,8 +1306,8 @@ filterend:
  * Call a shell to execute a command.
  * When "cmd" is NULL start an interactive shell.
  */
-void 
-do_shell (
+void
+do_shell(
     char_u *cmd,
     int flags              /* may be SHELL_DOOUT when output is redirected */
 )
@@ -1789,8 +1789,8 @@ theend:
  * May set eap->forceit if a dialog says it's OK to overwrite.
  * Return OK if it's OK, FAIL if it is not.
  */
-int 
-check_overwrite (
+int
+check_overwrite(
     exarg_T *eap,
     buf_T *buf,
     char_u *fname,         /* file name to be used (can differ from
@@ -2823,7 +2823,7 @@ void ex_change(exarg_T *eap)
 void ex_z(exarg_T *eap)
 {
   char_u      *x;
-  int bigness;
+  int64_t     bigness;
   char_u      *kind;
   int minus = 0;
   linenr_T start, end, curs, i;
@@ -2856,10 +2856,17 @@ void ex_z(exarg_T *eap)
       EMSG(_("E144: non-numeric argument to :z"));
       return;
     }
-    bigness = atoi((char *)x);
+    bigness = atol((char *)x);
+
+    // bigness could be < 0 if atol(x) overflows.
+    if (bigness > 2 * curbuf->b_ml.ml_line_count || bigness < 0) {
+      bigness = 2 * curbuf->b_ml.ml_line_count;
+    }
+
     p_window = bigness;
-    if (*kind == '=')
+    if (*kind == '=') {
       bigness += 2;
+    }
   }
 
   /* the number of '-' and '+' multiplies the distance */
@@ -4587,8 +4594,8 @@ char_u *check_help_lang(char_u *arg)
  * Assumption is made that the matched_string passed has already been found to
  * match some string for which help is requested.  webb.
  */
-int 
-help_heuristic (
+int
+help_heuristic(
     char_u *matched_string,
     int offset,                             /* offset for match */
     int wrong_case                         /* no matching case */

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -5,6 +5,7 @@ source test_assign.vim
 source test_changedtick.vim
 source test_cursor_func.vim
 source test_ex_undo.vim
+source test_ex_z.vim
 source test_execute_func.vim
 source test_expr.vim
 source test_feedkeys.vim
@@ -19,8 +20,8 @@ source test_jumps.vim
 source test_fileformat.vim
 source test_filetype.vim
 source test_lambda.vim
-source test_menu.vim
 source test_mapping.vim
+source test_menu.vim
 source test_messages.vim
 source test_partial.vim
 source test_popup.vim

--- a/src/nvim/testdir/test_ex_z.vim
+++ b/src/nvim/testdir/test_ex_z.vim
@@ -1,0 +1,78 @@
+" Test :z
+
+func Test_z()
+  call setline(1, range(1, 100))
+
+  let a = execute('20z3')
+  call assert_equal("\n20\n21\n22", a)
+  call assert_equal(22, line('.'))
+  " 'window' should be set to the {count} value.
+  call assert_equal(3, &window)
+
+  " If there is only one window, then twice the amount of 'scroll' is used.
+  set scroll=2
+  let a = execute('20z')
+  call assert_equal("\n20\n21\n22\n23", a)
+  call assert_equal(23, line('.'))
+
+  let a = execute('20z+3')
+  " FIXME: I would expect the same result as '20z3' but it
+  " gives "\n21\n22\n23" instead. Bug in Vim or in ":help :z"?
+  "call assert_equal("\n20\n21\n22", a)
+  "call assert_equal(22, line('.'))
+
+  let a = execute('20z-3')
+  call assert_equal("\n18\n19\n20", a)
+  call assert_equal(20, line('.'))
+
+  let a = execute('20z=3')
+  call assert_match("^\n18\n19\n-\\+\n20\n-\\+\n21\n22$", a)
+  call assert_equal(20, line('.'))
+
+  let a = execute('20z^3')
+  call assert_equal("\n14\n15\n16\n17", a)
+  call assert_equal(17, line('.'))
+
+  let a = execute('20z.3')
+  call assert_equal("\n19\n20\n21", a)
+  call assert_equal(21, line('.'))
+
+  let a = execute('20z#3')
+  call assert_equal("\n 20 20\n 21 21\n 22 22", a)
+  call assert_equal(22, line('.'))
+
+  let a = execute('20z#-3')
+  call assert_equal("\n 18 18\n 19 19\n 20 20", a)
+  call assert_equal(20, line('.'))
+
+  let a = execute('20z#=3')
+  call assert_match("^\n 18 18\n 19 19\n-\\+\n 20 20\n-\\+\n 21 21\n 22 22$", a)
+  call assert_equal(20, line('.'))
+
+  " Test with {count} bigger than the number of lines in buffer.
+  let a = execute('20z1000')
+  call assert_match("^\n20\n21\n.*\n99\n100$", a)
+  call assert_equal(100, line('.'))
+
+  let a = execute('20z-1000')
+  call assert_match("^\n1\n2\n.*\n19\n20$", a)
+  call assert_equal(20, line('.'))
+
+  let a = execute('20z=1000')
+  call assert_match("^\n1\n.*\n-\\+\n20\n-\\\+\n.*\n100$", a)
+  call assert_equal(20, line('.'))
+
+  call assert_fails('20z=a', 'E144:')
+
+  set window& scroll&
+  bw!
+endfunc
+
+func Test_z_bug()
+  " This used to access invalid memory as a result of an integer overflow
+  " and freeze vim.
+  normal ox
+  normal Heat
+  z777777776666666
+  ')
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0537: illegal memory access with :z and large count**

Problem:    Illegal memory access with :z and large count.
Solution:   Check for number overflow, using long instead of int. (Dominique
            Pelle, closes vim/vim#1612)
https://github.com/vim/vim/commit/fa0ad0bb0b4255e64ebcf9269d60a942e0ae7ff9