### PR TITLE
vim-patch: Replace shell variables in printf with formatted args

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -37,11 +37,11 @@ usage() {
 }
 
 msg_ok() {
-  printf "\e[32m✔\e[0m $@\n"
+  printf '\e[32m✔\e[0m %s\n' "$@"
 }
 
 msg_err() {
-  printf "\e[31m✘\e[0m $@\n"
+  printf '\e[31m✘\e[0m %s\n' "$@"
 }
 
 # Checks if a program is in the user's PATH, and is executable.
@@ -218,7 +218,7 @@ stage_patch() {
     msg_ok "Current branch '${checked_out_branch}' seems to be a vim-patch"
     echo "  branch; not creating a new branch."
   else
-    printf "\nFetching '${git_remote}/master'.\n"
+    printf '\nFetching "%s/master".\n' "${git_remote}"
     output="$(git fetch "${git_remote}" master 2>&1)" &&
       msg_ok "${output}" ||
       (msg_err "${output}"; false)
@@ -248,21 +248,22 @@ stage_patch() {
     fi
     printf "\nInstructions:\n  Proceed to port the patch.\n"
   else
-    printf "\nInstructions:\n  Proceed to port the patch.\n  Try the 'patch' command (or use '${BASENAME} -P ...' next time):\n    patch -p1 < ${patch_file}\n"
+    printf '\nInstructions:\n  Proceed to port the patch.\n  Try the "patch" command (or use "%s -P ..." next time):\n    patch -p1 < %s\n' "${BASENAME}" "${patch_file}"
   fi
 
-  printf "
-  Stage your changes ('git add ...'), then use 'git commit --amend' to commit.
+  printf '
+  Stage your changes ("git add ..."), then use "git commit --amend" to commit.
 
-  To port more patches (if any) related to ${vim_version},
-  run '${BASENAME}' again.
+  To port more patches (if any) related to %s,
+  run "%s" again.
     * Do this only for _related_ patches (otherwise it increases the
       size of the pull request, making it harder to review)
 
-  When you're done, try '${BASENAME} -s' to create the pull request.
+  When you are done, try "%s -s" to create the pull request.
 
   See the wiki for more information:
-    * https://github.com/neovim/neovim/wiki/Merging-patches-from-upstream-vim\n"
+    * https://github.com/neovim/neovim/wiki/Merging-patches-from-upstream-vim
+' "${vim_version}" "${BASENAME}" "${BASENAME}"
 }
 
 hub_pr() {
@@ -398,24 +399,24 @@ show_vimpatches() {
 
   list_missing_vimpatches | while read vim_commit; do
     if (cd "${VIM_SOURCE_DIR}" && git --no-pager  show --color=never --name-only "v${vim_commit}" 2>/dev/null) | grep -q ^runtime; then
-      printf "  • ${vim_commit} (+runtime)\n"
+      printf '  • %s (+runtime)\n' "${vim_commit}"
     else
-      printf "  • ${vim_commit}\n"
+      printf '  • %s\n' "${vim_commit}"
     fi
   done
 
-  echo
-  echo "Instructions:"
-  echo
-  echo "  To port one of the above patches to Neovim, execute"
-  echo "  this script with the patch revision as argument and"
-  echo "  follow the instructions."
-  echo
-  echo "  Examples: '${BASENAME} -p 7.4.487'"
-  echo "            '${BASENAME} -p 1e8ebf870720e7b671f98f22d653009826304c4f'"
-  echo
-  echo "  NOTE: Please port the _oldest_ patch if you possibly can."
-  echo "        Out-of-order patches increase the possibility of bugs."
+  printf "Instructions:
+
+  To port one of the above patches to Neovim, execute
+  this script with the patch revision as argument and
+  follow the instructions.
+
+  Examples: '%s -p 7.4.487'
+            '%s -p 1e8ebf870720e7b671f98f22d653009826304c4f'
+
+  NOTE: Please port the _oldest_ patch if you possibly can.
+        Out-of-order patches increase the possibility of bugs.
+" "${BASENAME}" "${BASENAME}"
 }
 
 review_commit() {
@@ -436,7 +437,7 @@ review_commit() {
     echo "  This script assumes that the PR contains only commits"
     echo "  with 'vim-patch:XXX' in their title."
     echo
-    printf -- "$(head -n 4 <<< "${nvim_patch}")\n\n"
+    printf -- '%s\n\n' "$(head -n 4 <<< "${nvim_patch}")"
     local reply
     read -p "Continue reviewing (y/N)? " -n 1 -r reply
     if [[ "${reply}" == y ]]; then


### PR DESCRIPTION
This ensures that special characters in the variables are not
interpreted as escapes/format characters in the printf string, as was
seen with upstream patch 8.0.0615.

    $ ./scripts/vim-patch.sh -p 8.0.0615
    Updating Vim sources: /$HOME/src/neovim/.vim-src
    ✔ Updated Vim sources.
    ✔ Found Vim revision 'bf15b8d78b22661db8b19d662b62bb9a061cdd37'.
    Creating patch...
    Pre-processing patch...
    ✔ Saved patch to '/$HOME/src/neovim/vim-8.0.0615.patch'.

    Fetching 'origin/master'.
    ✔ From https://github.com/neovim/neovim
     * branch                master     -> FETCH_HEAD

    Creating new branch 'vim-8.0.0615' based on 'origin/master'.
    ✔ Switched to a new branch 'vim-8.0.0615'
    Branch 'vim-8.0.0615' set up to track remote branch 'master' from 'origin'.

    Creating empty commit with correct commit message.
    ./scripts/vim-patch.sh: line 40: printf: `w': invalid format character
    ✔ [vim-8.0.0615 db7fbb016] vim-patch:8.0.0615: using ./scripts/vim-patch.sh: line 44: printf: `w': invalid format character
    ✘ [vim-8.0.0615 db7fbb016] vim-patch:8.0.0615: using

Cc @janlazo