### PR TITLE
[RDY] vim-patch:8.0.0{615,617}

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2317,9 +2317,9 @@ doend:
  */
 int
 checkforcmd(
-    char_u **pp,               /* start of command */
-    char *cmd,               /* name of command */
-    int len                        /* required length */
+    char_u **pp,              // start of command
+    char *cmd,                // name of command
+    int len                   // required length
 )
 {
   int i;
@@ -4705,7 +4705,7 @@ char_u *check_nextcmd(char_u *p)
  */
 static int
 check_more(
-    int message,                /* when FALSE check only, no messages */
+    int message,                // when FALSE check only, no messages
     int forceit
 )
 {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2315,8 +2315,8 @@ doend:
  * Check for an Ex command with optional tail.
  * If there is a match advance "pp" to the argument and return TRUE.
  */
-int 
-checkforcmd (
+int
+checkforcmd(
     char_u **pp,               /* start of command */
     char *cmd,               /* name of command */
     int len                        /* required length */
@@ -4080,6 +4080,7 @@ int expand_filename(exarg_T *eap, char_u **cmdlinep, char_u **errormsgp)
         && eap->cmdidx != CMD_lgrep
         && eap->cmdidx != CMD_grepadd
         && eap->cmdidx != CMD_lgrepadd
+        && eap->cmdidx != CMD_hardcopy
         && !(eap->argt & NOSPC)
         ) {
       char_u      *l;
@@ -4702,8 +4703,8 @@ char_u *check_nextcmd(char_u *p)
  *    return FAIL and give error message if 'message' TRUE
  * return OK otherwise
  */
-static int 
-check_more (
+static int
+check_more(
     int message,                /* when FALSE check only, no messages */
     int forceit
 )
@@ -5371,8 +5372,8 @@ static size_t add_cmd_modifier(char_u *buf, char *mod_str, bool *multi_mods)
  * Returns the length of the replacement, which has been added to "buf".
  * Returns -1 if there was no match, and only the "<" has been copied.
  */
-static size_t 
-uc_check_code (
+static size_t
+uc_check_code(
     char_u *code,
     size_t len,
     char_u *buf,
@@ -6103,8 +6104,8 @@ static void ex_pclose(exarg_T *eap)
  * Close window "win" and take care of handling closing the last window for a
  * modified buffer.
  */
-static void 
-ex_win_close (
+static void
+ex_win_close(
     int forceit,
     win_T *win,
     tabpage_T *tp                /* NULL or the tab page "win" is in */
@@ -6520,8 +6521,8 @@ void alist_set(alist_T *al, int count, char_u **files, int use_curbuf, int *fnum
  * Add file "fname" to argument list "al".
  * "fname" must have been allocated and "al" must have been checked for room.
  */
-void 
-alist_add (
+void
+alist_add(
     alist_T *al,
     char_u *fname,
     int set_fnum                   /* 1: set buffer number; 2: re-use curbuf */
@@ -6868,8 +6869,8 @@ static void ex_edit(exarg_T *eap)
 /*
  * ":edit <file>" command and alikes.
  */
-void 
-do_exedit (
+void
+do_exedit(
     exarg_T *eap,
     win_T *old_curwin            /* curwin before doing a split or NULL */
 )
@@ -8759,8 +8760,8 @@ char_u *expand_sfile(char_u *arg)
  * Write openfile commands for the current buffers to an .exrc file.
  * Return FAIL on error, OK otherwise.
  */
-static int 
-makeopens (
+static int
+makeopens(
     FILE *fd,
     char_u *dirnow            /* Current directory name */
 )
@@ -9206,8 +9207,8 @@ static int ses_do_win(win_T *wp)
  * Write commands to "fd" to restore the view of a window.
  * Caller must make sure 'scrolloff' is zero.
  */
-static int 
-put_view (
+static int
+put_view(
     FILE *fd,
     win_T *wp,
     int add_edit,                   /* add ":edit" command to view */
@@ -9401,8 +9402,8 @@ put_view (
  * Write an argument list to the session file.
  * Returns FAIL if writing fails.
  */
-static int 
-ses_arglist (
+static int
+ses_arglist(
     FILE *fd,
     char *cmd,
     garray_T *gap,

--- a/src/nvim/testdir/test_hardcopy.vim
+++ b/src/nvim/testdir/test_hardcopy.vim
@@ -61,3 +61,12 @@ func Test_with_syntax()
     set printoptions&
   endif
 endfunc
+
+func Test_fname_with_spaces()
+  split t\ e\ s\ t.txt
+  call setline(1, ['just', 'some', 'text'])
+  hardcopy > %.ps
+  call assert_true(filereadable('t e s t.txt.ps'))
+  call delete('t e s t.txt.ps')
+  bwipe!
+endfunc

--- a/src/nvim/testdir/test_hardcopy.vim
+++ b/src/nvim/testdir/test_hardcopy.vim
@@ -63,10 +63,12 @@ func Test_with_syntax()
 endfunc
 
 func Test_fname_with_spaces()
-  split t\ e\ s\ t.txt
-  call setline(1, ['just', 'some', 'text'])
-  hardcopy > %.ps
-  call assert_true(filereadable('t e s t.txt.ps'))
-  call delete('t e s t.txt.ps')
-  bwipe!
+  if has('postscript')
+    split t\ e\ s\ t.txt
+    call setline(1, ['just', 'some', 'text'])
+    hardcopy > %.ps
+    call assert_true(filereadable('t e s t.txt.ps'))
+    call delete('t e s t.txt.ps')
+    bwipe!
+  endif
 endfunc


### PR DESCRIPTION
**vim-patch:8.0.0615: using % with :hardcopy wrongly escapes spaces**

Problem:    Using % with :hardcopy wrongly escapes spaces. (Alexey Muranov)
Solution:   Expand % differently. (Christian Brabandt, closes vim/vim#1682)
vim/vim@bf15b8d

**vim-patch:8.0.0617: hardcopy test hangs on MS-Windows**

Problem:    Hardcopy test hangs on MS-Windows.
Solution:   Check the postscript feature is supported.
vim/vim@763209c

`has('postscript')` returns 1 in Windows.
~~I expect the new test to fail on Appveyor. Vim opens a new dialog window for the printer on Windows so the new test is expected to run on Unix only.~~
`:hardcopy` fails by itself but `hardcopy > %.ps` works?!