### PR TITLE
[RDY] vim-patch:8.0.0669

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3708,9 +3708,15 @@ static int ins_compl_get_exp(pos_T *ini)
       if (*e_cpt == '.' && !curbuf->b_scanned) {
         ins_buf = curbuf;
         first_match_pos = *ini;
-        /* So that ^N can match word immediately after cursor */
-        if (l_ctrl_x_mode == 0)
-          dec(&first_match_pos);
+        // Move the cursor back one character so that ^N can match the
+        // word immediately after the cursor.
+        if (ctrl_x_mode == 0 && dec(&first_match_pos) < 0) {
+          // Move the cursor to after the last character in the
+          // buffer, so that word at start of buffer is found
+          // correctly.
+          first_match_pos.lnum = ins_buf->b_ml.ml_line_count;
+          first_match_pos.col = (colnr_T)STRLEN(ml_get(first_match_pos.lnum));
+        }
         last_match_pos = first_match_pos;
         type = 0;
 

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -650,5 +650,19 @@ func Test_complete_func_mess()
   set completefunc=
 endfunc
 
+func Test_complete_CTRLN_startofbuffer()
+  new
+  call setline(1, [ 'organize(cupboard, 3, 2);',
+        \ 'prioritize(bureau, 8, 7);',
+        \ 'realize(bannister, 4, 4);',
+        \ 'moralize(railing, 3,9);'])
+  let expected=['cupboard.organize(3, 2);',
+        \ 'bureau.prioritize(8, 7);',
+        \ 'bannister.realize(4, 4);',
+        \ 'railing.moralize(3,9);']
+  call feedkeys("qai\<c-n>\<c-n>.\<esc>3wdW\<cr>q3@a", 'tx')
+  call assert_equal(expected, getline(1,'$'))
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:8.0.0669: CTRL-N at start of the buffer does not work correctly**

Problem:    In Insert mode, CTRL-N at start of the buffer does not work
            correctly. (zuloloxi)
Solution:   Wrap around the start of the buffer. (Christian Brabandt)
https://github.com/vim/vim/commit/24a9e348aa88a6c60ae0cdf5c4a777d8c03b08ca