### PR TITLE
[RDY] vim-patch:8.0.0{469,581,583}

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2655,8 +2655,11 @@ static void foldRemove(garray_T *gap, linenr_T top, linenr_T bot)
   }
 }
 
-// foldMoveRange() {{{2
-static void reverse_fold_order(garray_T *gap, size_t start, size_t end)
+// foldReverseOrder() {{{2
+static void foldReverseOrder(
+    garray_T *gap,
+    linenr_T start,
+    linenr_T end)
 {
   for (; start < end; start++, end--) {
     fold_T *left = (fold_T *)gap->ga_data + start;
@@ -2798,9 +2801,11 @@ void foldMoveRange(garray_T *gap, const linenr_T line1, const linenr_T line2,
     // There are no folds after those moved, so none were moved out of order.
     return;
   }
-  reverse_fold_order(gap, move_start, dest_index - 1);
-  reverse_fold_order(gap, move_start, move_start + dest_index - move_end - 1);
-  reverse_fold_order(gap, move_start + dest_index - move_end, dest_index - 1);
+  foldReverseOrder(gap, (linenr_T)move_start, (linenr_T)(dest_index - 1));
+  foldReverseOrder(gap, (linenr_T)move_start,
+                   (linenr_T)(move_start + dest_index - move_end - 1));
+  foldReverseOrder(gap, (linenr_T)(move_start + dest_index - move_end),
+                   (linenr_T)(dest_index - 1));
 }
 #undef FOLD_END
 #undef VALID_FOLD

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -382,13 +382,13 @@ void closeFoldRecurse(linenr_T lnum)
  * Open or Close folds for current window in lines "first" to "last".
  * Used for "zo", "zO", "zc" and "zC" in Visual mode.
  */
-void 
-opFoldRange (
+void
+opFoldRange(
     linenr_T first,
     linenr_T last,
-    int opening,                    /* TRUE to open, FALSE to close */
-    int recurse,                    /* TRUE to do it recursively */
-    int had_visual                 /* TRUE when Visual selection used */
+    int opening,                    // TRUE to open, FALSE to close
+    int recurse,                    // TRUE to do it recursively
+    int had_visual                  // TRUE when Visual selection used
 )
 {
   int done = DONE_NOTHING;              /* avoid error messages */
@@ -663,12 +663,12 @@ void foldCreate(linenr_T start, linenr_T end)
  * When "end" is not 0, delete all folds from "start" to "end".
  * When "recursive" is TRUE delete recursively.
  */
-void 
-deleteFold (
+void
+deleteFold(
     linenr_T start,
     linenr_T end,
     int recursive,
-    int had_visual                 /* TRUE when Visual selection used */
+    int had_visual                 // TRUE when Visual selection used
 )
 {
   garray_T    *gap;
@@ -837,10 +837,10 @@ void foldUpdateAll(win_T *win)
  * If "updown" is TRUE: move to fold at the same level.
  * If not moved return FAIL.
  */
-int 
-foldMoveTo (
+int
+foldMoveTo(
     int updown,
-    int dir,                    /* FORWARD or BACKWARD */
+    int dir,                    // FORWARD or BACKWARD
     long count
 )
 {
@@ -1156,11 +1156,11 @@ static void setFoldRepeat(linenr_T lnum, long count, int do_open)
  * Open or close the fold in the current window which contains "lnum".
  * Also does this for other windows in diff mode when needed.
  */
-static linenr_T 
-setManualFold (
+static linenr_T
+setManualFold(
     linenr_T lnum,
-    int opening,                /* TRUE when opening, FALSE when closing */
-    int recurse,                /* TRUE when closing/opening recursive */
+    int opening,                // TRUE when opening, FALSE when closing
+    int recurse,                // TRUE when closing/opening recursive
     int *donep
 )
 {
@@ -1194,12 +1194,12 @@ setManualFold (
  * Return the line number of the next line that could be closed.
  * It's only valid when "opening" is TRUE!
  */
-static linenr_T 
-setManualFoldWin (
+static linenr_T
+setManualFoldWin(
     win_T *wp,
     linenr_T lnum,
-    int opening,                /* TRUE when opening, FALSE when closing */
-    int recurse,                /* TRUE when closing/opening recursive */
+    int opening,                // TRUE when opening, FALSE when closing
+    int recurse,                // TRUE when closing/opening recursive
     int *donep
 )
 {
@@ -1505,14 +1505,14 @@ static int getDeepestNestingRecurse(garray_T *gap)
 /*
  * Check if a fold is closed and update the info needed to check nested folds.
  */
-static int 
-check_closed (
+static int
+check_closed(
     win_T *win,
     fold_T *fp,
-    int *use_levelp,            /* TRUE: outer fold had FD_LEVEL */
-    int level,                          /* folding depth */
-    int *maybe_smallp,          /* TRUE: outer this had fd_small == MAYBE */
-    linenr_T lnum_off                  /* line number offset for fp->fd_top */
+    int *use_levelp,            // TRUE: outer fold had FD_LEVEL
+    int level,                  // folding depth
+    int *maybe_smallp,          // TRUE: outer this had fd_small == MAYBE
+    linenr_T lnum_off           // line number offset for fp->fd_top
 )
 {
   int closed = FALSE;
@@ -1543,11 +1543,11 @@ check_closed (
 /*
  * Update fd_small field of fold "fp".
  */
-static void 
-checkSmall (
+static void
+checkSmall(
     win_T *wp,
     fold_T *fp,
-    linenr_T lnum_off              /* offset for fp->fd_top */
+    linenr_T lnum_off             // offset for fp->fd_top
 )
 {
   int count;
@@ -1651,11 +1651,11 @@ static void foldAddMarker(linenr_T lnum, const char_u *marker, size_t markerlen)
 /*
  * Delete the markers for a fold, causing it to be deleted.
  */
-static void 
-deleteFoldMarkers (
+static void
+deleteFoldMarkers(
     fold_T *fp,
     int recursive,
-    linenr_T lnum_off              /* offset for fp->fd_top */
+    linenr_T lnum_off             // offset for fp->fd_top
 )
 {
   if (recursive) {
@@ -2658,9 +2658,11 @@ static void foldRemove(garray_T *gap, linenr_T top, linenr_T bot)
 // foldReverseOrder() {{{2
 static void foldReverseOrder(
     garray_T *gap,
-    linenr_T start,
-    linenr_T end)
+    const linenr_T start_arg,
+    const linenr_T end_arg)
 {
+  linenr_T start = start_arg;
+  linenr_T end = end_arg;
   for (; start < end; start++, end--) {
     fold_T *left = (fold_T *)gap->ga_data + start;
     fold_T *right = (fold_T *)gap->ga_data + end;
@@ -2670,6 +2672,7 @@ static void foldReverseOrder(
   }
 }
 
+// foldMoveRange() {{{2
 // Move folds within the inclusive range "line1" to "line2" to after "dest"
 // require "line1" <= "line2" <= "dest"
 //

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -1,10 +1,10 @@
 " Test for folding
 
-func! PrepIndent(arg)
+func PrepIndent(arg)
   return [a:arg] + repeat(["\t".a:arg], 5)
 endfu
 
-func! Test_address_fold()
+func Test_address_fold()
   new
   call setline(1, ['int FuncName() {/*{{{*/', 1, 2, 3, 4, 5, '}/*}}}*/',
 	      \ 'after fold 1', 'after fold 2', 'after fold 3'])
@@ -68,17 +68,7 @@ func! Test_address_fold()
   quit!
 endfunc
 
-func! Test_indent_fold()
-    new
-    call setline(1, ['', 'a', '    b', '    c'])
-    setl fen fdm=indent
-    2
-    norm! >>
-    let a=map(range(1,4), 'foldclosed(v:val)')
-    call assert_equal([-1,-1,-1,-1], a)
-endfunc
-
-func! Test_indent_fold()
+func Test_indent_fold()
     new
     call setline(1, ['', 'a', '    b', '    c'])
     setl fen fdm=indent
@@ -89,7 +79,7 @@ func! Test_indent_fold()
     bw!
 endfunc
 
-func! Test_indent_fold2()
+func Test_indent_fold2()
     new
     call setline(1, ['', '{{{', '}}}', '{{{', '}}}'])
     setl fen fdm=marker
@@ -122,7 +112,7 @@ func Test_manual_fold_with_filter()
   endfor
 endfunc
 
-func! Test_indent_fold_with_read()
+func Test_indent_fold_with_read()
   new
   set foldmethod=indent
   call setline(1, repeat(["\<Tab>a"], 4))
@@ -224,7 +214,11 @@ func Test_update_folds_expr_read()
   set foldmethod& foldexpr&
 endfunc
 
-func! Test_move_folds_around_manual()
+func Check_foldlevels(expected)
+  call assert_equal(a:expected, map(range(1, line('$')), 'foldlevel(v:val)'))
+endfunc
+
+func Test_move_folds_around_manual()
   new
   let input = PrepIndent("a") + PrepIndent("b") + PrepIndent("c")
   call setline(1, PrepIndent("a") + PrepIndent("b") + PrepIndent("c"))
@@ -293,11 +287,50 @@ func! Test_move_folds_around_manual()
   6m$
   " The first fold has been truncated to the 5'th line.
   " Second fold has been moved up because the moved line is now below it.
-  call assert_equal([0, 1, 1, 1, 1, 0, 0, 0, 1, 0], map(range(1, line('$')), 'foldlevel(v:val)'))
+  call Check_foldlevels([0, 1, 1, 1, 1, 0, 0, 0, 1, 0])
+
+  %delete
+  set fdm=indent foldlevel=0
+  call setline(1, [
+	\ "a",
+	\ "\ta",
+	\ "\t\ta",
+	\ "\t\ta",
+	\ "\t\ta",
+	\ "a",
+	\ "a"])
+  set fdm=manual
+  %foldopen!
+  4,5m6
+  call Check_foldlevels([0, 1, 2, 0, 0, 0, 0])
+
+  %delete
+  set fdm=indent
+  call setline(1, [
+	\ "\ta",
+	\ "\t\ta",
+	\ "\t\ta",
+	\ "\t\ta",
+	\ "\ta",
+	\ "\t\ta",
+	\ "\t\ta",
+	\ "\t\ta",
+	\ "\ta",
+	\ "\t\ta",
+	\ "\t\ta",
+	\ "\t\ta",
+	\ "\t\ta",
+	\ "\ta",
+	\ "a"])
+  set fdm=manual
+  %foldopen!
+  13m7
+  call Check_foldlevels([1, 2, 2, 2, 1, 2, 2, 1, 1, 1, 2, 2, 2, 1, 0])
+  
   bw!
 endfunc
 
-func! Test_move_folds_around_indent()
+func Test_move_folds_around_indent()
   new
   let input = PrepIndent("a") + PrepIndent("b") + PrepIndent("c")
   call setline(1, PrepIndent("a") + PrepIndent("b") + PrepIndent("c"))
@@ -357,7 +390,7 @@ func! Test_move_folds_around_indent()
   6m$
   " The first fold has been truncated to the 5'th line.
   " Second fold has been moved up because the moved line is now below it.
-  call assert_equal([0, 1, 1, 1, 1, 0, 0, 0, 1, 1], map(range(1, line('$')), 'foldlevel(v:val)'))
+  call Check_foldlevels([0, 1, 1, 1, 1, 0, 0, 0, 1, 1])
   bw!
 endfunc
 


### PR DESCRIPTION
 **vim-patch:8.0.0469: compiler warnings on MS-Windows**

Problem:    Compiler warnings on MS-Windows.
Solution:   Add type casts. (Christian Brabandt)
vim/vim@0c0d4ec

**vim-patch:8.0.0581: moving folded text is sometimes not correct**

Problem:    Moving folded text is sometimes not correct.
Solution:   Bail out when "move_end" is zero. (Matthew Malcomson)
vim/vim@94be619

**vim-patch:8.0.0583: fold test hangs on MS-Windows**

Problem:    Fold test hangs on MS-Windows.
Solution:   Avoid overflow in compare.
vim/vim@b11c826