### PR TITLE
[RDY] vim-patch:8.0.0286,8.1.{674,683}

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -477,6 +477,25 @@ void update_screen(int type)
 
 }
 
+// Prepare for updating one or more windows.
+// Caller must check for "updating_screen" already set to avoid recursiveness.
+static void update_prepare(void)
+{
+  updating_screen = true;
+  start_search_hl();
+}
+
+// Finish updating one or more windows.
+static void update_finish(void)
+{
+  if (redraw_cmdline) {
+    showmode();
+  }
+
+  end_search_hl();
+  updating_screen = false;
+}
+
 /*
  * Return TRUE if the cursor line in window "wp" may be concealed, according
  * to the 'concealcursor' option.
@@ -522,10 +541,11 @@ void update_single_line(win_T *wp, linenr_T lnum)
   if (linebuf_char == NULL || updating_screen) {
     return;
   }
-  updating_screen = true;
 
   if (lnum >= wp->w_topline && lnum < wp->w_botline
       && foldedCount(wp, lnum, &win_foldinfo) == 0) {
+    update_prepare();
+
     row = 0;
     for (j = 0; j < wp->w_lines_valid; ++j) {
       if (lnum == wp->w_lines[j].wl_lnum) {
@@ -541,33 +561,10 @@ void update_single_line(win_T *wp, linenr_T lnum)
       }
       row += wp->w_lines[j].wl_size;
     }
+
+    update_finish();
   }
   need_cursor_line_redraw = false;
-  updating_screen = false;
-}
-
-
-/*
- * Prepare for updating one or more windows.
- * Caller must check for "updating_screen" already set to avoid recursiveness.
- */
-static void update_prepare(void)
-{
-    updating_screen = TRUE;
-    start_search_hl();
-}
-
-/*
- * Finish updating one or more windows.
- */
-static void update_finish(void)
-{
-    if (redraw_cmdline) {
-        showmode();
-    }
-
-    end_search_hl();
-    updating_screen = FALSE;
 }
 
 void update_debug_sign(const buf_T *const buf, const linenr_T lnum)

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2936,8 +2936,8 @@ win_line (
       break;
     }
 
-    if (draw_state == WL_LINE && area_highlighting) {
-      /* handle Visual or match highlighting in this line */
+    if (draw_state == WL_LINE && (area_highlighting || has_spell)) {
+      // handle Visual or match highlighting in this line
       if (vcol == fromcol
           || (vcol + 1 == fromcol && n_extra == 0
               && utf_ptr2cells(ptr) > 1)

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -550,13 +550,11 @@ void update_single_line(win_T *wp, linenr_T lnum)
     for (j = 0; j < wp->w_lines_valid; ++j) {
       if (lnum == wp->w_lines[j].wl_lnum) {
         init_search_hl(wp);
-        start_search_hl();
         prepare_search_hl(wp, lnum);
         update_window_hl(wp, false);
         // allocate window grid if not already
         win_grid_alloc(wp);
         win_line(wp, lnum, row, row + wp->w_lines[j].wl_size, false, false);
-        end_search_hl();
         break;
       }
       row += wp->w_lines[j].wl_size;


### PR DESCRIPTION
**vim-patch:8.0.0286: not always redrawing after screen resize**

Problem:    When concealing is active and the screen is resized in the GUI it
            is not immediately redrawn.
Solution:   Use update_prepare() and update_finish() from
            update_single_line().
https://github.com/vim/vim/commit/c10f0e7cb0f35eea489b038e56c87b818eee975b

**vim-patch:8.1.0674: leaking memory when updating a single line**

Problem:    Leaking memory when updating a single line.
Solution:   Do not call start_search_hl() twice.
vim/vim@6d5b4f5

**vim-patch:8.1.0683: spell highlighting does not always end**

Problem:    Spell highlighting does not always end. (Gary Johnson)
Solution:   Also reset char_attr when spell errors are highlighted.
vim/vim@637532b

Close https://github.com/neovim/neovim/pull/8853