### PR TITLE
[RDY] vim-patch:8.0.0616

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6599,7 +6599,7 @@ void vimrc_found(char_u *fname, char_u *envname)
 /// @param[in]  name  Option name.
 ///
 /// @return True if it was set.
-static bool option_was_set(const char *name)
+bool option_was_set(const char *name)
 {
   int idx;
 
@@ -6610,6 +6610,18 @@ static bool option_was_set(const char *name)
     return true;
   }
   return false;
+}
+
+/// Reset the flag indicating option "name" was set.
+///
+/// @param[in]  name  Option name.
+void reset_option_was_set(const char *name)
+{
+  const int idx = findoption(name);
+
+  if (idx >= 0) {
+    options[idx].flags &= ~P_WAS_SET;
+  }
 }
 
 /*

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6812,15 +6812,21 @@ void do_highlight(const char *line, const bool forceit, const bool init)
               if (!ui_rgb_attached()) {
                 must_redraw = CLEAR;
                 if (color >= 0) {
+                  int dark = -1;
+
                   if (t_colors < 16) {
-                    i = (color == 0 || color == 4);
-                  } else {
-                    i = (color < 7 || color == 8);
+                    dark = (color == 0 || color == 4);
+                  } else if (color < 16) {
+                    // Limit the heuristic to the standard 16 colors
+                    dark = (color < 7 || color == 8);
                   }
                   // Set the 'background' option if the value is
                   // wrong.
-                  if (i != (*p_bg == 'd')) {
-                    set_option_value("bg", 0L, (i ? "dark" : "light"), 0);
+                  if (dark != -1
+                      && dark != (*p_bg == 'd')
+                      && !option_was_set("bg")) {
+                    set_option_value("bg", 0L, (dark ? "dark" : "light"), 0);
+                    reset_option_was_set("bg");
                   }
                 }
               }

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -435,3 +435,26 @@ func Test_conceal()
   bw!
 endfunc
 
+func Test_bg_detection()
+  if has('gui_running')
+    return
+  endif
+  " auto-detection of &bg, make sure sure it isn't set anywhere before
+  " this test
+  hi Normal ctermbg=0
+  call assert_equal('dark', &bg)
+  hi Normal ctermbg=4
+  call assert_equal('dark', &bg)
+  hi Normal ctermbg=12
+  call assert_equal('light', &bg)
+  hi Normal ctermbg=15
+  call assert_equal('light', &bg)
+
+  " manually-set &bg takes precendence over auto-detection
+  set bg=light
+  hi Normal ctermbg=4
+  call assert_equal('light', &bg)
+  set bg=dark
+  hi Normal ctermbg=12
+  call assert_equal('dark', &bg)
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0616: not always setting 'background' correctly after hi Normal**

Problem:    When setting the cterm background with ":hi Normal" the value of
            'background' may be set wrongly.
Solution:   Check that the color is less than 16.  Don't set 'background' when
            it was set explicitly. (Lemonboy, closes vim/vim#1710)
https://github.com/vim/vim/commit/1615b36b91b094263240d7b555283ddf33208f62

Restore `reset_option_was_set()`, removed in 419da839e0cbdf6251bc31dc218fa629ccc91b44

Related: https://github.com/neovim/neovim/pull/8597
cc @justinmk 

In the future, I'd like "unused code cleanups" checked with upstream first. I had to traverse the Git history of `src/nvim/option.c` to find the offending the commit. There's no comment or hint where the removed functions are.