### PR TITLE
[RDY] vim-patch:8.0.0{621,648}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -343,7 +343,7 @@ open_buffer (
 void set_bufref(bufref_T *bufref, buf_T *buf)
 {
   bufref->br_buf = buf;
-  bufref->br_fnum = buf->b_fnum;
+  bufref->br_fnum = buf == NULL ? 0 : buf->b_fnum;
   bufref->br_buf_free_count = buf_free_count;
 }
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1901,10 +1901,10 @@ int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
     }
   }
 
-  ++RedrawingDisabled;
-  if (getfile(buf->b_fnum, NULL, NULL, (options & GETF_SETMARK),
-          lnum, forceit) <= 0) {
-    --RedrawingDisabled;
+  RedrawingDisabled++;
+  if (GETFILE_SUCCESS(getfile(buf->b_fnum, NULL, NULL,
+                              (options & GETF_SETMARK), lnum, forceit))) {
+    RedrawingDisabled--;
 
     /* cursor is at to BOL and w_cursor.lnum is checked due to getfile() */
     if (!p_sol && col != 0) {
@@ -1915,7 +1915,7 @@ int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
     }
     return OK;
   }
-  --RedrawingDisabled;
+  RedrawingDisabled--;
   return FAIL;
 }
 

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -17,6 +17,15 @@ enum getf_values {
   GETF_SWITCH  = 0x04, // respect 'switchbuf' settings when jumping
 };
 
+// Return values of getfile()
+enum getf_retvalues {
+  GETFILE_ERROR       = 1,    // normal error
+  GETFILE_NOT_WRITTEN = 2,    // "not written" error
+  GETFILE_SAME_FILE   = 0,    // success, same file
+  GETFILE_OPEN_OTHER  = -1,   // success, opened another file
+  GETFILE_UNUSED      = 8
+};
+
 // Values for buflist_new() flags
 enum bln_values {
   BLN_CURBUF = 1,   // May re-use curbuf for new buffer

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -41,6 +41,7 @@ typedef struct {
 // for kvec
 #include "nvim/lib/kvec.h"
 
+#define GETFILE_SUCCESS(x)    ((x) <= 0)
 #define MODIFIABLE(buf) (buf->b_p_ma)
 
 /*

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1288,9 +1288,9 @@ end_do_search:
  * search_for_exact_line(buf, pos, dir, pat)
  *
  * Search for a line starting with the given pattern (ignoring leading
- * white-space), starting from pos and going in direction dir.	pos will
+ * white-space), starting from pos and going in direction "dir". "pos" will
  * contain the position of the match found.    Blank lines match only if
- * ADDING is set.  if p_ic is set then the pattern must be in lowercase.
+ * ADDING is set.  If p_ic is set then the pattern must be in lowercase.
  * Return OK for success, or FAIL if no line found.
  */
 int search_for_exact_line(buf_T *buf, pos_T *pos, int dir, char_u *pat)
@@ -4595,20 +4595,23 @@ search_line:
             RESET_BINDING(curwin);
           }
           if (depth == -1) {
-            /* match in current file */
+            // match in current file
             if (l_g_do_tagpreview != 0) {
-              if (getfile(0, curwin_save->w_buffer->b_fname,
-                      NULL, TRUE, lnum, FALSE) > 0)
-                break;                  /* failed to jump to file */
-            } else
+              if (!GETFILE_SUCCESS(getfile(0, curwin_save->w_buffer->b_fname,
+                                           NULL, true, lnum, false))) {
+                break;    // failed to jump to file
+              }
+            } else {
               setpcmark();
+            }
             curwin->w_cursor.lnum = lnum;
           } else {
-            if (getfile(0, files[depth].name, NULL, TRUE,
-                    files[depth].lnum, FALSE) > 0)
-              break;                    /* failed to jump to file */
-            /* autocommands may have changed the lnum, we don't
-             * want that here */
+            if (!GETFILE_SUCCESS(getfile(0, files[depth].name, NULL, true,
+                                         files[depth].lnum, false))) {
+              break;    // failed to jump to file
+            }
+            // autocommands may have changed the lnum, we don't
+            // want that here
             curwin->w_cursor.lnum = files[depth].lnum;
           }
         }

--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -65,6 +65,48 @@ func Test_duplicate_tagjump()
   call delete('Xfile1')
 endfunc
 
+func Test_tagjump_switchbuf()
+  set tags=Xtags
+  call writefile(["!_TAG_FILE_ENCODING\tutf-8\t//",
+        \ "second\tXfile1\t2",
+        \ "third\tXfile1\t3",],
+        \ 'Xtags')
+  call writefile(['first', 'second', 'third'], 'Xfile1')
+
+  enew | only
+  set switchbuf=
+  stag second
+  call assert_equal(2, winnr('$'))
+  call assert_equal(2, line('.'))
+  stag third
+  call assert_equal(3, winnr('$'))
+  call assert_equal(3, line('.'))
+
+  enew | only
+  set switchbuf=useopen
+  stag second
+  call assert_equal(2, winnr('$'))
+  call assert_equal(2, line('.'))
+  stag third
+  call assert_equal(2, winnr('$'))
+  call assert_equal(3, line('.'))
+
+  enew | only
+  set switchbuf=usetab
+  tab stag second
+  call assert_equal(2, tabpagenr('$'))
+  call assert_equal(2, line('.'))
+  1tabnext | stag third
+  call assert_equal(2, tabpagenr('$'))
+  call assert_equal(3, line('.'))
+
+  tabclose!
+  enew | only
+  call delete('Xfile1')
+  call delete('Xtags')
+  set switchbuf&vim
+endfunc
+
 " Tests for [ CTRL-I and CTRL-W CTRL-I commands
 function Test_keyword_jump()
   call writefile(["#include Xinclude", "",


### PR DESCRIPTION
**vim-patch:8.0.0621: :stag does not respect 'switchbuf'**

Problem:    The ":stag" command does not respect 'switchbuf'.
Solution:   Check 'switchbuf' for tag commands that may open a new window.
            (Ingo Karkat, closes vim/vim#1681)  Define macros for the return values
            of getfile().
vim/vim@8ad80de

**vim-patch:8.0.0648: possible use of NULL pointer**

Problem:    Possible use of NULL pointer if buflist_new() returns NULL.
            (Coverity)
Solution:   Check for NULL pointer in set_bufref().
vim/vim@fadacf0