### PR TITLE
[RDY] vim-patch:8.0.0{538,539}

### DIFF
--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -259,7 +259,7 @@ func Test_default_term()
   endif
 
   let save_term = $TERM
-  let $TERM = 'unknown'
+  let $TERM = 'unknownxxx'
   let out = system(GetVimCommand() . ' -c''set term'' -c cq')
   call assert_match("defaulting to 'ansi'", out)
   let $TERM = save_term

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -260,7 +260,7 @@ func Test_default_term()
 
   let save_term = $TERM
   let $TERM = 'unknownxxx'
-  let out = system(GetVimCommand() . ' -c''set term'' -c cq')
-  call assert_match("defaulting to 'ansi'", out)
+  let out = system(GetVimCommand() . ' -c ''echo &term'' -c cq')
+  call assert_match('nvim', out)
   let $TERM = save_term
 endfunc

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -251,3 +251,16 @@ func Test_silent_ex_mode()
   let out = system(GetVimCommand() . '-u NONE -es -c''set verbose=1|h|exe "%norm\<c-y>\<c-d>"'' -c cq')
   call assert_notmatch('E315:', out)
 endfunc
+
+func Test_default_term()
+  if !has('unix') || has('gui_running')
+    " can't get output of Vim.
+    return
+  endif
+
+  let save_term = $TERM
+  let $TERM = 'unknown'
+  let out = system(GetVimCommand() . ' -c''set term'' -c cq')
+  call assert_match("defaulting to 'ansi'", out)
+  let $TERM = save_term
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0538: no test for falling back to default term value**

Problem:    No test for falling back to default term value.
Solution:   Add a test.
vim/vim@85045a7

**vim-patch:8.0.0539: startup test fails on Mac**

Problem:    Startup test fails on Mac.
Solution:   Use another term name, "unknown" is known. Avoid a 2 second delay.
vim/vim@08f88b1

I omitted code for `not-a-term`.