### PR TITLE
*: Replace b_changedtick with new always-inline functions

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -496,7 +496,7 @@ Integer nvim_buf_get_changedtick(Buffer buffer, Error *err)
     return -1;
   }
 
-  return buf->b_changedtick;
+  return buf_get_changedtick(buf);
 }
 
 /// Gets a list of buffer-local |mapping| definitions.

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1555,7 +1555,7 @@ static inline void buf_init_changedtick(buf_T *const buf)
     .di_tv = (typval_T) {
       .v_type = VAR_NUMBER,
       .v_lock = VAR_FIXED,
-      .vval.v_number = buf->b_changedtick,
+      .vval.v_number = buf_get_changedtick(buf),
     },
     .di_key = "changedtick",
   };

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -96,7 +96,7 @@ static inline void buf_set_changedtick(buf_T *const buf,
                                        const varnumber_T changedtick)
   REAL_FATTR_NONNULL_ALL REAL_FATTR_ALWAYS_INLINE;
 
-/// Set b_changedtick and corresponding variable
+/// Set b:changedtick, also checking b: for consistency in debug build
 ///
 /// @param[out]  buf  Buffer to set changedtick in.
 /// @param[in]  changedtick  New value.
@@ -114,10 +114,35 @@ static inline void buf_set_changedtick(buf_T *const buf,
   assert(changedtick_di->di_flags == (DI_FLAGS_RO|DI_FLAGS_FIX));
 # endif
   assert(changedtick_di == (dictitem_T *)&buf->changedtick_di);
-  assert(&buf->b_changedtick  // -V501
-         == &buf->changedtick_di.di_tv.vval.v_number);
 #endif
-  buf->b_changedtick = changedtick;
+  buf->changedtick_di.di_tv.vval.v_number = changedtick;
+}
+
+static inline varnumber_T buf_get_changedtick(const buf_T *const buf)
+  REAL_FATTR_NONNULL_ALL REAL_FATTR_ALWAYS_INLINE REAL_FATTR_PURE
+  REAL_FATTR_WARN_UNUSED_RESULT;
+
+/// Get b:changedtick value
+///
+/// Faster then querying b:.
+///
+/// @param[in]  buf  Buffer to get b:changedtick from.
+static inline varnumber_T buf_get_changedtick(const buf_T *const buf)
+{
+  return buf->changedtick_di.di_tv.vval.v_number;
+}
+
+static inline void buf_inc_changedtick(buf_T *const buf)
+  REAL_FATTR_NONNULL_ALL REAL_FATTR_ALWAYS_INLINE;
+
+/// Increment b:changedtick value
+///
+/// Also checks b: for consistency in case of debug build.
+///
+/// @param[in,out]  buf  Buffer to increment value in.
+static inline void buf_inc_changedtick(buf_T *const buf)
+{
+  buf_set_changedtick(buf, buf_get_changedtick(buf) + 1);
 }
 
 #define WITH_BUFFER(b, code) \

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -483,9 +483,11 @@ struct file_buffer {
 
   int b_changed;                // 'modified': Set to true if something in the
                                 // file has been changed and not written out.
-/// Change identifier incremented for each change, including undo
-#define b_changedtick changedtick_di.di_tv.vval.v_number
-  ChangedtickDictItem changedtick_di;  // b:changedtick dictionary item.
+
+  /// Change identifier incremented for each change, including undo
+  ///
+  /// This is a dictionary item used to store in b:changedtick.
+  ChangedtickDictItem changedtick_di;
 
   varnumber_T b_last_changedtick;       // b:changedtick when TextChanged or
                                         // TextChangedI was last triggered.
@@ -1194,5 +1196,9 @@ static inline int win_hl_attr(win_T *wp, int hlf)
 {
   return wp->w_hl_attrs[hlf];
 }
+
+/// Macros defined in Vim, but not in Neovim
+#define CHANGEDTICK(buf) \
+    (=== Include buffer.h & use buf_(get|set|inc)_changedtick ===)
 
 #endif // NVIM_BUFFER_DEFS_H

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -6,6 +6,7 @@
 #include "nvim/api/private/helpers.h"
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/assert.h"
+#include "nvim/buffer.h"
 
 // Register a channel. Return True if the channel was added, or already added.
 // Return False if the channel couldn't be added because the buffer is
@@ -38,7 +39,7 @@ bool buf_updates_register(buf_T *buf, uint64_t channel_id, bool send_buffer)
 
     // the first argument is always the buffer handle
     args.items[0] = BUFFER_OBJ(buf->handle);
-    args.items[1] = INTEGER_OBJ(buf->b_changedtick);
+    args.items[1] = INTEGER_OBJ(buf_get_changedtick(buf));
     // the first line that changed (zero-indexed)
     args.items[2] = INTEGER_OBJ(0);
     // the last line that was changed
@@ -148,7 +149,7 @@ void buf_updates_send_changes(buf_T *buf,
     args.items[0] = BUFFER_OBJ(buf->handle);
 
     // next argument is b:changedtick
-    args.items[1] = send_tick ? INTEGER_OBJ(buf->b_changedtick) : NIL;
+    args.items[1] = send_tick ? INTEGER_OBJ(buf_get_changedtick(buf)) : NIL;
 
     // the first line that changed (zero-indexed)
     args.items[2] = INTEGER_OBJ(firstline - 1);
@@ -203,7 +204,7 @@ void buf_updates_changedtick_single(buf_T *buf, uint64_t channel_id)
     args.items[0] = BUFFER_OBJ(buf->handle);
 
     // next argument is b:changedtick
-    args.items[1] = INTEGER_OBJ(buf->b_changedtick);
+    args.items[1] = INTEGER_OBJ(buf_get_changedtick(buf));
 
     // don't try and clean up dead channels here
     rpc_send_event(channel_id, "nvim_buf_changedtick_event", args);

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1386,22 +1386,22 @@ ins_redraw (
     last_cursormoved = curwin->w_cursor;
   }
 
-  // Trigger TextChangedI if b_changedtick differs.
+  // Trigger TextChangedI if changedtick differs.
   if (ready && has_event(EVENT_TEXTCHANGEDI)
-      && curbuf->b_last_changedtick != curbuf->b_changedtick
+      && curbuf->b_last_changedtick != buf_get_changedtick(curbuf)
       && !pum_visible()) {
     apply_autocmds(EVENT_TEXTCHANGEDI, NULL, NULL, false, curbuf);
-    curbuf->b_last_changedtick = curbuf->b_changedtick;
+    curbuf->b_last_changedtick = buf_get_changedtick(curbuf);
   }
 
-  // Trigger TextChangedP if b_changedtick differs. When the popupmenu closes
+  // Trigger TextChangedP if changedtick differs. When the popupmenu closes
   // TextChangedI will need to trigger for backwards compatibility, thus use
   // different b_last_changedtick* variables.
   if (ready && has_event(EVENT_TEXTCHANGEDP)
-      && curbuf->b_last_changedtick_pum != curbuf->b_changedtick
+      && curbuf->b_last_changedtick_pum != buf_get_changedtick(curbuf)
       && pum_visible()) {
       apply_autocmds(EVENT_TEXTCHANGEDP, NULL, NULL, false, curbuf);
-      curbuf->b_last_changedtick_pum = curbuf->b_changedtick;
+      curbuf->b_last_changedtick_pum = buf_get_changedtick(curbuf);
   }
 
   if (must_redraw)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7906,7 +7906,7 @@ static void f_diff_hlID(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   if (lnum < 0)         /* ignore type error in {lnum} arg */
     lnum = 0;
   if (lnum != prev_lnum
-      || changedtick != curbuf->b_changedtick
+      || changedtick != buf_get_changedtick(curbuf)
       || fnum != curbuf->b_fnum) {
     /* New line, buffer, change: need to get the values. */
     filler_lines = diff_check(curwin, lnum);
@@ -7923,7 +7923,7 @@ static void f_diff_hlID(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     } else
       hlID = (hlf_T)0;
     prev_lnum = lnum;
-    changedtick = curbuf->b_changedtick;
+    changedtick = buf_get_changedtick(curbuf);
     fnum = curbuf->b_fnum;
   }
 
@@ -9172,7 +9172,7 @@ static dict_T *get_buffer_info(buf_T *buf)
   tv_dict_add_nr(dict, S_LEN("loaded"), buf->b_ml.ml_mfp != NULL);
   tv_dict_add_nr(dict, S_LEN("listed"), buf->b_p_bl);
   tv_dict_add_nr(dict, S_LEN("changed"), bufIsChanged(buf));
-  tv_dict_add_nr(dict, S_LEN("changedtick"), buf->b_changedtick);
+  tv_dict_add_nr(dict, S_LEN("changedtick"), buf_get_changedtick(buf));
   tv_dict_add_nr(dict, S_LEN("hidden"),
                  buf->b_ml.ml_mfp != NULL && buf->b_nwindows == 0);
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -6293,7 +6293,7 @@ void ex_substitute(exarg_T *eap)
   garray_T save_view;
   win_size_save(&save_view);  // Save current window sizes.
   save_search_patterns();
-  int save_changedtick = curbuf->b_changedtick;
+  int save_changedtick = buf_get_changedtick(curbuf);
   time_t save_b_u_time_cur = curbuf->b_u_time_cur;
   u_header_T *save_b_u_newhead = curbuf->b_u_newhead;
   long save_b_p_ul = curbuf->b_p_ul;
@@ -6310,7 +6310,7 @@ void ex_substitute(exarg_T *eap)
   buf_T *preview_buf = do_sub(eap, profile_setlimit(p_rdt), false);
   p_hls = save_hls;
 
-  if (save_changedtick != curbuf->b_changedtick) {
+  if (save_changedtick != buf_get_changedtick(curbuf)) {
     // Undo invisibly. This also moves the cursor!
     if (!u_undo_and_forget(1)) { abort(); }
     // Restore newhead. It is meaningless when curhead is valid, but we must

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -218,11 +218,11 @@ void do_exmode(int improved)
       exmode_active = FALSE;
       break;
     }
-    msg_scroll = TRUE;
-    need_wait_return = FALSE;
-    ex_pressedreturn = FALSE;
-    ex_no_reprint = FALSE;
-    changedtick = curbuf->b_changedtick;
+    msg_scroll = true;
+    need_wait_return = false;
+    ex_pressedreturn = false;
+    ex_no_reprint = false;
+    changedtick = buf_get_changedtick(curbuf);
     prev_msg_row = msg_row;
     prev_line = curwin->w_cursor.lnum;
     cmdline_row = msg_row;
@@ -230,10 +230,10 @@ void do_exmode(int improved)
     lines_left = Rows - 1;
 
     if ((prev_line != curwin->w_cursor.lnum
-         || changedtick != curbuf->b_changedtick) && !ex_no_reprint) {
-      if (curbuf->b_ml.ml_flags & ML_EMPTY)
+         || changedtick != buf_get_changedtick(curbuf)) && !ex_no_reprint) {
+      if (curbuf->b_ml.ml_flags & ML_EMPTY) {
         EMSG(_(e_emptybuf));
-      else {
+      } else {
         if (ex_pressedreturn) {
           /* go up one line, to overwrite the ":<CR>" line, so the
            * output doesn't contain empty lines. */

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3566,13 +3566,11 @@ restore_backup:
    * writing to the original file and '+' is not in 'cpoptions'. */
   if (reset_changed && whole && !append
       && !write_info.bw_conv_error
-      && (overwriting || vim_strchr(p_cpo, CPO_PLUS) != NULL)
-      ) {
-    unchanged(buf, TRUE);
-    /* buf->b_changedtick is always incremented in unchanged() but that
-     * should not trigger a TextChanged event. */
-    if (buf->b_last_changedtick + 1 == buf->b_changedtick) {
-      buf->b_last_changedtick = buf->b_changedtick;
+      && (overwriting || vim_strchr(p_cpo, CPO_PLUS) != NULL)) {
+    unchanged(buf, true);
+    const varnumber_T changedtick = buf_get_changedtick(buf);
+    if (buf->b_last_changedtick + 1 == changedtick) {
+      buf->b_last_changedtick = changedtick;
     }
     u_unchanged(buf);
     u_update_save_nr(buf);

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -21,6 +21,7 @@
 #include "nvim/search.h"
 #include "nvim/strings.h"
 #include "nvim/undo.h"
+#include "nvim/buffer.h"
 
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -454,11 +455,13 @@ int get_number_indent(linenr_T lnum)
  * parameters into account. Window must be specified, since it is not
  * necessarily always the current one.
  */
-int get_breakindent_win(win_T *wp, char_u *line) {
-  static int prev_indent = 0;  /* cached indent value */
-  static long prev_ts = 0; /* cached tabstop value */
-  static char_u *prev_line = NULL; /* cached pointer to line */
-  static int prev_tick = 0;  // changedtick of cached value
+int get_breakindent_win(win_T *wp, char_u *line)
+  FUNC_ATTR_NONNULL_ARG(1)
+{
+  static int prev_indent = 0;  // Cached indent value.
+  static long prev_ts = 0;  // Cached tabstop value.
+  static char_u *prev_line = NULL;  // cached pointer to line.
+  static varnumber_T prev_tick = 0;  // Changedtick of cached value.
   int bri = 0;
   /* window width minus window margin space, i.e. what rests for text */
   const int eff_wwidth = wp->w_width
@@ -468,12 +471,11 @@ int get_breakindent_win(win_T *wp, char_u *line) {
 
   /* used cached indent, unless pointer or 'tabstop' changed */
   if (prev_line != line || prev_ts != wp->w_buffer->b_p_ts
-      || prev_tick != wp->w_buffer->b_changedtick) {
+      || prev_tick != buf_get_changedtick(wp->w_buffer)) {
     prev_line = line;
     prev_ts = wp->w_buffer->b_p_ts;
-    prev_tick = (int)wp->w_buffer->b_changedtick;
-    prev_indent = get_indent_str(line,
-            (int)wp->w_buffer->b_p_ts, wp->w_p_list);
+    prev_tick = buf_get_changedtick(wp->w_buffer);
+    prev_indent = get_indent_str(line, (int)wp->w_buffer->b_p_ts, wp->w_p_list);
   }
   bri = prev_indent + wp->w_p_brishift;
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -603,7 +603,7 @@ void getout(int exitval)
         }
 
         buf_T *buf = wp->w_buffer;
-        if (buf->b_changedtick != -1) {
+        if (buf_get_changedtick(buf) != -1) {
           apply_autocmds(EVENT_BUFWINLEAVE, buf->b_fname,
                          buf->b_fname, false, buf);
           buf_set_changedtick(buf, -1);  // note that we did it already

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1171,7 +1171,7 @@ void ml_recover(void)
      * empty.  Don't set the modified flag then. */
     if (!(curbuf->b_ml.ml_line_count == 2 && *ml_get(1) == NUL)) {
       changed_int();
-      buf_set_changedtick(curbuf, curbuf->b_changedtick + 1);
+      buf_inc_changedtick(curbuf);
     }
   } else {
     for (idx = 1; idx <= lnum; ++idx) {
@@ -1181,7 +1181,7 @@ void ml_recover(void)
       xfree(p);
       if (i != 0) {
         changed_int();
-        buf_set_changedtick(curbuf, curbuf->b_changedtick + 1);
+        buf_inc_changedtick(curbuf);
         break;
       }
     }

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1795,7 +1795,7 @@ void changed(void)
     }
     changed_int();
   }
-  buf_set_changedtick(curbuf, curbuf->b_changedtick + 1);
+  buf_inc_changedtick(curbuf);
 }
 
 /*
@@ -1922,9 +1922,9 @@ changed_lines(
     linenr_T lnume,       // line below last changed line
     long xtra,            // number of extra lines (negative when deleting)
     bool do_buf_event  // some callers like undo/redo call changed_lines()
-                       // and then increment b_changedtick *again*. This flag
+                       // and then increment changedtick *again*. This flag
                        // allows these callers to send the nvim_buf_lines_event
-                       // events after they're done modifying b_changedtick.
+                       // events after they're done modifying changedtick.
 )
 {
   changed_lines_buf(curbuf, lnum, lnume, xtra);
@@ -2168,7 +2168,7 @@ unchanged (
     redraw_tabline = TRUE;
     need_maketitle = TRUE;          /* set window title later */
   }
-  buf_set_changedtick(buf, buf->b_changedtick + 1);
+  buf_inc_changedtick(buf);
 }
 
 /*

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1213,11 +1213,11 @@ static void normal_check_cursor_moved(NormalState *s)
 
 static void normal_check_text_changed(NormalState *s)
 {
-  // Trigger TextChanged if b_changedtick differs.
+  // Trigger TextChanged if changedtick differs.
   if (!finish_op && has_event(EVENT_TEXTCHANGED)
-      && curbuf->b_last_changedtick != curbuf->b_changedtick) {
+      && curbuf->b_last_changedtick != buf_get_changedtick(curbuf)) {
     apply_autocmds(EVENT_TEXTCHANGED, NULL, NULL, false, curbuf);
-    curbuf->b_last_changedtick = curbuf->b_changedtick;
+    curbuf->b_last_changedtick = buf_get_changedtick(curbuf);
   }
 }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -43,6 +43,7 @@
 #include "nvim/os/os.h"
 #include "nvim/os/time.h"
 #include "nvim/api/private/helpers.h"
+#include "nvim/buffer.h"
 
 static bool did_syntax_onoff = false;
 
@@ -406,12 +407,12 @@ void syntax_start(win_T *wp, linenr_T lnum)
    */
   if (syn_block != wp->w_s
       || syn_buf != wp->w_buffer
-      || changedtick != syn_buf->b_changedtick) {
+      || changedtick != buf_get_changedtick(syn_buf)) {
     invalidate_current_state();
     syn_buf = wp->w_buffer;
     syn_block = wp->w_s;
   }
-  changedtick = syn_buf->b_changedtick;
+  changedtick = buf_get_changedtick(syn_buf);
   syn_win = wp;
 
   /*

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2289,7 +2289,7 @@ static void u_undoredo(int undo, bool do_buf_event)
     unchanged(curbuf, FALSE);
   }
 
-  // because the calls to changed()/unchanged() above will bump b_changedtick
+  // because the calls to changed()/unchanged() above will bump changedtick
   // again, we need to send a nvim_buf_lines_event with just the new value of
   // b:changedtick
   if (do_buf_event && kv_size(curbuf->update_channels)) {


### PR DESCRIPTION
I missed that existing function has some debugging. So I figured it better have always-inline functions with some additional debugging then macros which is easily replaceable when merging. Also functions are more future-proof then `CHANGEDTICK(buf)++` can be. Still have macros using which should throw an error.

Ref #8474