### PR TITLE
defaults: shortmess+=F

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5293,7 +5293,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	function to get the effective shiftwidth value.
 
 						*'shortmess'* *'shm'*
-'shortmess' 'shm'	string	(Vim default "filnxtToO", Vi default: "")
+'shortmess' 'shm'	string	(Vim default "filnxtToOF", Vi default: "")
 			global
 	This option helps to avoid all the |hit-enter| prompts caused by file
 	messages, for example  with CTRL-G, and to avoid some other messages.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -49,6 +49,7 @@ a complete and centralized reference of those differences.
 - 'nrformats' defaults to "bin,hex"
 - 'ruler' is set by default
 - 'sessionoptions' doesn't include "options"
+- 'shortmess' sets "F" flag
 - 'showcmd' is set by default
 - 'sidescroll' defaults to 1
 - 'smarttab' is set by default

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2123,7 +2123,7 @@ return {
       type='string', list='flags', scope={'global'},
       vim=true,
       varname='p_shm',
-      defaults={if_true={vi="", vim="filnxtToO"}}
+      defaults={if_true={vi="", vim="filnxtToOF"}}
     },
     {
       full_name='showbreak', abbreviation='sbr',

--- a/test/functional/ex_cmds/drop_spec.lua
+++ b/test/functional/ex_cmds/drop_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require('test.functional.helpers')(after_each)
+local command = helpers.command
 local Screen = require('test.functional.ui.screen')
 local clear, feed, feed_command = helpers.clear, helpers.feed, helpers.feed_command
 
@@ -15,7 +16,7 @@ describe(":drop", function()
       [2] = {reverse = true},
       [3] = {bold = true},
     })
-    feed_command("set laststatus=2")
+    command("set laststatus=2 shortmess-=F")
   end)
 
   after_each(function()

--- a/test/functional/legacy/108_backtrace_debug_commands_spec.lua
+++ b/test/functional/legacy/108_backtrace_debug_commands_spec.lua
@@ -1,6 +1,7 @@
 -- Tests for backtrace debug commands.
 
 local helpers = require('test.functional.helpers')(after_each)
+local command = helpers.command
 local feed, clear = helpers.feed, helpers.clear
 local feed_command, expect = helpers.feed_command, helpers.expect
 
@@ -8,6 +9,7 @@ describe('108', function()
   before_each(clear)
 
   it('is working', function()
+    command("set shortmess-=F")
     feed_command('lang mess C')
     feed_command('function! Foo()')
     feed_command('   let var1 = 1')

--- a/test/functional/options/shortmess_spec.lua
+++ b/test/functional/options/shortmess_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
+local command = helpers.command
 local clear, feed_command = helpers.clear, helpers.feed_command
 
 if helpers.pending_win32(pending) then return end
@@ -19,6 +20,7 @@ describe("'shortmess'", function()
 
   describe('"F" flag', function()
     it('hides messages about the files read', function()
+      command("set shortmess-=F")
       feed_command('e test')
       screen:expect([[
         ^                         |

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -142,7 +142,7 @@ describe('input non-printable chars', function()
       [3] = {bold = true, foreground = Screen.colors.SeaGreen4}
     })
     screen:attach()
-    command("set display-=msgsep")
+    command("set display-=msgsep shortmess-=F")
 
     feed_command("e Xtest-overwrite")
     screen:expect([[


### PR DESCRIPTION
Because we default to laststatus=2 (statusline is always visible), the
:edit message is not useful.

ref #6289