### PR TITLE
[RDY] vim-patch:8.0.0642

### DIFF
--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -1,5 +1,6 @@
+" Tests for the writefile() function.
 
-function! Test_WriteFile()
+func Test_writefile()
   let f = tempname()
   call writefile(["over","written"], f, "b")
   call writefile(["hello","world"], f, "b")
@@ -13,4 +14,20 @@ function! Test_WriteFile()
   call assert_equal("morning", l[3])
   call assert_equal("vimmers", l[4])
   call delete(f)
-endfunction
+endfunc
+
+func Test_writefile_fails_gently()
+  call assert_fails('call writefile(["test"], "Xfile", [])', 'E730:')
+  call assert_false(filereadable("Xfile"))
+  call delete("Xfile")
+
+  call assert_fails('call writefile(["test", [], [], [], "tset"], "Xfile")', 'E730:')
+  call assert_false(filereadable("Xfile"))
+  call delete("Xfile")
+
+  call assert_fails('call writefile([], "Xfile", [])', 'E730:')
+  call assert_false(filereadable("Xfile"))
+  call delete("Xfile")
+
+  call assert_fails('call writefile([], [])', 'E730:')
+endfunc

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -21,7 +21,7 @@ func Test_writefile_fails_gently()
   call assert_false(filereadable("Xfile"))
   call delete("Xfile")
 
-  call assert_fails('call writefile(["test", [], [], [], "tset"], "Xfile")', 'E730:')
+  call assert_fails('call writefile(["test", [], [], [], "tset"], "Xfile")', 'E745:')
   call assert_false(filereadable("Xfile"))
   call delete("Xfile")
 

--- a/test/functional/eval/writefile_spec.lua
+++ b/test/functional/eval/writefile_spec.lua
@@ -127,23 +127,20 @@ describe('writefile()', function()
     eq('TEST', read_file(fname))
   end)
 
-  it('stops writing to file after error in list', function()
+  it('does not write to file if error in list', function()
     local args = '["tset"] + repeat([%s], 3), "' .. fname .. '"'
-    eq('\nE806: using Float as a String',
+    eq('\nE805: Expected a Number or a String, Float found',
         redir_exec(('call writefile(%s)'):format(args:format('0.0'))))
-    eq('tset\n', read_file(fname))
+    eq(nil, read_file(fname))
     write_file(fname, 'TEST')
-    eq('\nE730: using List as a String',
+    eq('\nE745: Expected a Number or a String, List found',
         redir_exec(('call writefile(%s)'):format(args:format('[]'))))
-    eq('tset\n', read_file(fname))
-    write_file(fname, 'TEST')
-    eq('\nE731: using Dictionary as a String',
+    eq('TEST', read_file(fname))
+    eq('\nE728: Expected a Number or a String, Dictionary found',
         redir_exec(('call writefile(%s)'):format(args:format('{}'))))
-    eq('tset\n', read_file(fname))
-    write_file(fname, 'TEST')
-    eq('\nE729: using Funcref as a String',
+    eq('TEST', read_file(fname))
+    eq('\nE703: Expected a Number or a String, Funcref found',
         redir_exec(('call writefile(%s)'):format(args:format('function("tr")'))))
-    eq('tset\n', read_file(fname))
-    write_file(fname, 'TEST')
+    eq('TEST', read_file(fname))
   end)
 end)


### PR DESCRIPTION
**vim-patch:8.0.0642: writefile() continues after detecting an error**

Problem:    writefile() continues after detecting an error.
Solution:   Bail out as soon as an error is detected. (suggestions by Nikolai
            Pavlov, closes vim/vim#1476)
https://github.com/vim/vim/commit/8cf91286ca46a501d24e4b7d631b193256782c88