### PR TITLE
vim-patch:8.0.1836

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2384,12 +2384,15 @@ void get_winopts(buf_T *buf)
   wip = find_wininfo(buf, true);
   if (wip != NULL && wip->wi_win != curwin && wip->wi_win != NULL
       && wip->wi_win->w_buffer == buf) {
+    // The buffer is currently displayed in the window: use the actual
+    // option values instead of the saved (possibly outdated) values.
     win_T *wp = wip->wi_win;
     copy_winopt(&wp->w_onebuf_opt, &curwin->w_onebuf_opt);
     curwin->w_fold_manual = wp->w_fold_manual;
     curwin->w_foldinvalid = true;
     cloneFoldGrowArray(&wp->w_folds, &curwin->w_folds);
   } else if (wip != NULL && wip->wi_optset) {
+    // the buffer was displayed in the current window earlier
     copy_winopt(&wip->wi_opt, &curwin->w_onebuf_opt);
     curwin->w_fold_manual = wip->wi_fold_manual;
     curwin->w_foldinvalid = true;

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -339,3 +339,55 @@ func Test_copy_winopt()
   call assert_equal(4,&numberwidth)
   bw!
 endfunc
+
+func Test_copy_winopt()
+    set hidden
+
+    " Test copy option from current buffer in window
+    split
+    enew
+    setlocal numberwidth=5
+    wincmd w
+    call assert_equal(4,&numberwidth)
+    bnext
+    call assert_equal(5,&numberwidth)
+    bw!
+    call assert_equal(4,&numberwidth)
+
+    " Test copy value from window that used to be display the buffer
+    split
+    enew
+    setlocal numberwidth=6
+    bnext
+    wincmd w
+    call assert_equal(4,&numberwidth)
+    bnext
+    call assert_equal(6,&numberwidth)
+    bw!
+
+    " Test that if buffer is current, don't use the stale cached value
+    " from the last time the buffer was displayed.
+    split
+    enew
+    setlocal numberwidth=7
+    bnext
+    bnext
+    setlocal numberwidth=8
+    wincmd w
+    call assert_equal(4,&numberwidth)
+    bnext
+    call assert_equal(8,&numberwidth)
+    bw!
+
+    " Test value is not copied if window already has seen the buffer
+    enew
+    split
+    setlocal numberwidth=9
+    bnext
+    setlocal numberwidth=10
+    wincmd w
+    call assert_equal(4,&numberwidth)
+    bnext
+    call assert_equal(4,&numberwidth)
+    bw!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1836: buffer-local window options may not be recent**

Problem:    Buffer-local window options may not be recent if the buffer is
            still open in another window.
Solution:   Copy the options from the window instead of the outdated window
            options. (Bjorn Linse, closes vim/vim#2336)
https://github.com/vim/vim/commit/25782a7ff4755daf16c2e1cb5e5f826b13b672ce

Ref: https://github.com/neovim/neovim/pull/7551