### PR TITLE
[RFC] vim-patch:8.0.0544

### DIFF
--- a/src/nvim/farsi.c
+++ b/src/nvim/farsi.c
@@ -1580,7 +1580,7 @@ static void conv_to_pvim(void)
         ptr[i] = toF_leading(ptr[i]);
         i++;
 
-        while (canF_Rjoin(ptr[i]) && i < llen) {
+        while (i < llen && canF_Rjoin(ptr[i])) {
           ptr[i] = toF_Rjoin(ptr[i]);
           if (F_isterm(ptr[i]) || !F_isalpha(ptr[i])) {
             break;


### PR DESCRIPTION
#### vim-patch:8.0.0544: cppcheck warnings

Problem:    Cppcheck warnings.
Solution:   Use temp variable. Change NUL to NULL. Swap conditions. (Dominique
            Pelle)
https://github.com/vim/vim/commit/866c68861071f8cd1ef5a82445bebaafc8626e7e