### PR TITLE
[RFC] vim-patch:8.0.0252

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -826,7 +826,7 @@ bool vim_isIDc(int c)
 /// For multi-byte characters mb_get_class() is used (builtin rules).
 ///
 /// @param  c  character to check
-bool vim_iswordc(int c)
+bool vim_iswordc(const int c)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return vim_iswordc_buf(c, curbuf);
@@ -852,7 +852,7 @@ bool vim_iswordc_tab(const int c, const uint64_t *const chartab)
 ///
 /// @param  c    character to check
 /// @param  buf  buffer whose keywords to use
-bool vim_iswordc_buf(int c, buf_T *buf)
+bool vim_iswordc_buf(const int c, buf_T *const buf)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ARG(2)
 {
   return vim_iswordc_tab(c, buf->b_chartab);
@@ -863,7 +863,7 @@ bool vim_iswordc_buf(int c, buf_T *buf)
 /// @param  p  pointer to the multi-byte character
 ///
 /// @return true if "p" points to a keyword character.
-bool vim_iswordp(char_u *p)
+bool vim_iswordp(const char_u *const p)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
   return vim_iswordp_buf(p, curbuf);
@@ -876,7 +876,7 @@ bool vim_iswordp(char_u *p)
 /// @param  buf  buffer whose keywords to use
 ///
 /// @return true if "p" points to a keyword character.
-bool vim_iswordp_buf(char_u *p, buf_T *buf)
+bool vim_iswordp_buf(const char_u *const p, buf_T *const buf)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
   int c = *p;

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -842,7 +842,7 @@ bool vim_iswordc_tab(const int c, const uint64_t *const chartab)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
   return (c >= 0x100
-          ? (utf_class(c) >= 2)
+          ? (utf_class_tab(c, chartab) >= 2)
           : (c > 0 && GET_CHARTAB_TAB(chartab, c) != 0));
 }
 
@@ -866,10 +866,7 @@ bool vim_iswordc_buf(int c, buf_T *buf)
 bool vim_iswordp(char_u *p)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
-  if (MB_BYTE2LEN(*p) > 1) {
-    return mb_get_class(p) >= 2;
-  }
-  return GET_CHARTAB(curbuf, *p) != 0;
+  return vim_iswordp_buf(p, curbuf);
 }
 
 /// Just like vim_iswordc_buf() but uses a pointer to the (multi-byte)
@@ -882,10 +879,12 @@ bool vim_iswordp(char_u *p)
 bool vim_iswordp_buf(char_u *p, buf_T *buf)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
-  if (MB_BYTE2LEN(*p) > 1) {
-    return mb_get_class(p) >= 2;
+  int c = *p;
+
+  if (MB_BYTE2LEN(c) > 1) {
+    c = utf_ptr2char(p);
   }
-  return GET_CHARTAB(buf, *p) != 0;
+  return vim_iswordc_buf(c, buf);
 }
 
 /// Check that "c" is a valid file-name character.

--- a/test/unit/mbyte_spec.lua
+++ b/test/unit/mbyte_spec.lua
@@ -5,6 +5,7 @@ local ffi     = helpers.ffi
 local eq      = helpers.eq
 
 local mbyte = helpers.cimport("./src/nvim/mbyte.h")
+local charset = helpers.cimport('./src/nvim/charset.h')
 
 describe('mbyte', function()
 
@@ -42,6 +43,15 @@ describe('mbyte', function()
     -- Sequences with more than four bytes
   end)
 
+  itp('utf_char2bytes', function()
+    local char_p = ffi.typeof('char[?]')
+    for c = 0, 0xFFFF do
+      local p = char_p(4, 0)
+      mbyte.utf_char2bytes(c, p)
+      eq(c, mbyte.utf_ptr2char(p))
+      eq(charset.vim_iswordc(c), charset.vim_iswordp(p))
+    end
+  end)
 
   describe('utfc_ptr2char_len', function()
 


### PR DESCRIPTION
**vim-patch:8.0.0252: not properly recognizing word characters between 128 and 255**

Problem:    Characters below 256 that are not one byte are not always
            recognized as word characters.
Solution:   Make vim_iswordc() and vim_iswordp() work the same way. Add a test
            for this. (Ozaki Kiichi)
https://github.com/vim/vim/commit/4019cf90b8657d4ab1c39744db63550f44f405a2

@jamessan suggested on gitter that I adapt `kword_test.c` to a Lua unit test but I don't know how. I'll create one in a separate commit.