### PR TITLE
vim-patch:8.1.0107

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4756,17 +4756,20 @@ int get_option_value_strict(char *name,
       // Special case: 'modified' is b_changed, but we also want to
       // consider it set when 'ff' or 'fenc' changed.
       if (p->indir == PV_MOD) {
-        *numval = bufIsChanged((buf_T *) from);
+        *numval = bufIsChanged((buf_T *)from);
         varp = NULL;
       } else {
-        aco_save_T	aco;
-        aucmd_prepbuf(&aco, (buf_T *) from);
+        buf_T *save_curbuf = curbuf;
+
+        // only getting a pointer, no need to use aucmd_prepbuf()
+        curbuf = (buf_T *)from;
+        curwin->w_buffer = curbuf;
         varp = get_varp(p);
-        aucmd_restbuf(&aco);
+        curbuf = save_curbuf;
+        curwin->w_buffer = curbuf;
       }
     } else if (opt_type == SREQ_WIN) {
-      win_T	*save_curwin;
-      save_curwin = curwin;
+      win_T	*save_curwin = curwin;
       curwin = (win_T *) from;
       curbuf = curwin->w_buffer;
       varp = get_varp(p);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4769,8 +4769,8 @@ int get_option_value_strict(char *name,
         curwin->w_buffer = curbuf;
       }
     } else if (opt_type == SREQ_WIN) {
-      win_T	*save_curwin = curwin;
-      curwin = (win_T *) from;
+      win_T *save_curwin = curwin;
+      curwin = (win_T *)from;
       curbuf = curwin->w_buffer;
       varp = get_varp(p);
       curwin = save_curwin;


### PR DESCRIPTION
https://github.com/vim/vim/commit/defe6424aee6201241b7cb231b62db4bbb9f4a9f

Author: Bram Moolenaar <Bram@vim.org>
Date:   Sun Jun 24 15:14:07 2018 +0200

    patch 8.1.0107: Python: getting buffer option clears message

    Problem:    Python: getting buffer option clears message. (Jacob Niehus)
    Solution:   Don't use aucmd_prepbuf(). (closes #3079)