### PR TITLE
[WIP] os/env.c: Fix bug where empty $HOME breaks init_homedir().

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -223,6 +223,13 @@ void init_homedir(void)
 #endif
     homedir = xstrdup(var);
   }
+  else {
+    char IObuff_signed[MAXPATHL] = "";
+    if (uv_os_homedir(IObuff_signed, (size_t *)MAXPATHL)) {
+      var = IObuff_signed;
+      homedir = xstrdup(var);
+    }
+  }
 }
 
 #if defined(EXITFREE)


### PR DESCRIPTION
When HOME environment variable is not set in a UNIX environment, `init_homedir()` fails.This provides an else clause using `uv_os_homedir()` to get the current users home directoy when HOME is not set.

I had to create a new signed char array to work with `uv_os_homedir()`. This is probably not the best way of doing it, so please advise how I should be doing it.

Functional tests are failing at the moment.

Fixes #8614 .