### PR TITLE
[RDY] vim-patch:8.0.0{704,706,707}

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2352,8 +2352,8 @@ int do_ecmd(
         } else {
           // <VN> We could instead free the synblock
           // and re-attach to buffer, perhaps.
-          if (curwin->w_buffer != NULL
-              && curwin->w_s == &(curwin->w_buffer->b_s)) {
+          if (curwin->w_buffer == NULL
+              || curwin->w_s == &(curwin->w_buffer->b_s)) {
             curwin->w_s = &(buf->b_s);
           }
 

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -3076,7 +3076,7 @@ return {
   },
   {
     command='wincmd',
-    flags=bit.bor(NEEDARG, WORD1, RANGE, NOTADR),
+    flags=bit.bor(NEEDARG, WORD1, RANGE, NOTADR, CMDWIN),
     addr_type=ADDR_WINDOWS,
     func='ex_wincmd',
   },

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6183,9 +6183,13 @@ static int open_cmdwin(void)
       ccline.cmdbuff = NULL;
     } else
       ccline.cmdbuff = vim_strsave(get_cursor_line_ptr());
-    if (ccline.cmdbuff == NULL)
+    if (ccline.cmdbuff == NULL) {
+      ccline.cmdbuff = vim_strsave((char_u *)"");
+      ccline.cmdlen = 0;
+      ccline.cmdbufflen = 1;
+      ccline.cmdpos = 0;
       cmdwin_result = Ctrl_C;
-    else {
+    } else {
       ccline.cmdlen = (int)STRLEN(ccline.cmdbuff);
       ccline.cmdbufflen = ccline.cmdlen + 1;
       ccline.cmdpos = curwin->w_cursor.col;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3243,6 +3243,10 @@ did_set_string_option (
         did_filetype = true;
         apply_autocmds(EVENT_FILETYPE, curbuf->b_p_ft,
                        curbuf->b_fname, true, curbuf);
+        // Just in case the old "curbuf" is now invalid
+        if (varp != &(curbuf->b_p_ft)) {
+          varp = NULL;
+        }
       }
     }
     if (varp == &(curwin->w_s->b_p_spl)) {


### PR DESCRIPTION
**vim-patch:8.0.0704: problems with autocommands when opening help**

Problem:    Problems with autocommands when opening help.
Solution:   Avoid using invalid "varp" value.  Allow using :wincmd if buffer
            is locked. (closes vim/vim#1806, closes vim/vim#1804)
vim/vim@163095f


**vim-patch:8.0.0706: crash when cancelling the cmdline window in Ex mode**

Problem:    Crash when cancelling the cmdline window in Ex mode. (James McCoy)
Solution:   Do not set cmdbuff to NULL, make it empty.
vim/vim@5a15b6a

**vim-patch:8.0.0707: freeing wrong memory with certain autocommands**

Problem:    Freeing wrong memory when manipulating buffers in autocommands.
            (James McCoy)
Solution:   Also set the w_s pointer if w_buffer was NULL.
vim/vim@f1d1347

Is https://gist.github.com/janlazo/cea7acf2711e89a9bc4f7c79612c6e54#filetype related?