### PR TITLE
[RFC] vim-patch:8.0.0{677,688}

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4906,7 +4906,9 @@ void fix_help_buffer(void)
 
   // Set filetype to "help".
   if (STRCMP(curbuf->b_p_ft, "help") != 0) {
+    curbuf_lock++;
     set_option_value("ft", 0L, "help", OPT_LOCAL);
+    curbuf_lock--;
   }
 
   if (!syntax_present(curwin)) {

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2158,7 +2158,7 @@ return {
   },
   {
     command='resize',
-    flags=bit.bor(RANGE, NOTADR, TRLBAR, WORD1),
+    flags=bit.bor(RANGE, NOTADR, TRLBAR, WORD1, CMDWIN),
     addr_type=ADDR_LINES,
     func='ex_resize',
   },

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -59,7 +59,9 @@
 #define BUFUNL        0x20000   /* accepts unlisted buffer too */
 #define ARGOPT        0x40000   /* allow "++opt=val" argument */
 #define SBOXOK        0x80000   /* allowed in the sandbox */
-#define CMDWIN       0x100000   /* allowed in cmdline window */
+#define CMDWIN       0x100000   /* allowed in cmdline window; when missing
+                                 * disallows editing another buffer when
+                                 * curbuf_lock is set */
 #define MODIFY       0x200000   /* forbidden in non-'modifiable' buffer */
 #define EXFLAGS      0x400000   /* allow flags after count in argument */
 #define FILES   (XFILE | EXTRA) /* multiple extra files allowed */

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6057,8 +6057,10 @@ static int open_cmdwin(void)
   curbuf->b_p_ma = true;
   curwin->w_p_fen = false;
 
-  /* Do execute autocommands for setting the filetype (load syntax). */
+  // Do execute autocommands for setting the filetype (load syntax).
   unblock_autocmds();
+  // But don't allow switching to another buffer.
+  curbuf_lock++;
 
   /* Showing the prompt may have set need_wait_return, reset it. */
   need_wait_return = FALSE;
@@ -6071,6 +6073,7 @@ static int open_cmdwin(void)
     }
     set_option_value("ft", 0L, "vim", OPT_LOCAL);
   }
+  curbuf_lock--;
 
   /* Reset 'textwidth' after setting 'filetype' (the Vim filetype plugin
    * sets 'textwidth' to 78). */

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3008,6 +3008,7 @@ static void qf_fill_buffer(qf_info_T *qi, buf_T *buf, qfline_T *old_last)
     // Set the 'filetype' to "qf" each time after filling the buffer.  This
     // resembles reading a file into a buffer, it's more logical when using
     // autocommands.
+    curbuf_lock++;
     set_option_value("ft", 0L, "qf", OPT_LOCAL);
     curbuf->b_p_ma = false;
 
@@ -3017,6 +3018,7 @@ static void qf_fill_buffer(qf_info_T *qi, buf_T *buf, qfline_T *old_last)
     apply_autocmds(EVENT_BUFWINENTER, (char_u *)"quickfix", NULL,
                    false, curbuf);
     keep_filetype = false;
+    curbuf_lock--;
 
     // make sure it will be redrawn
     redraw_curbuf_later(NOT_VALID);

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2172,7 +2172,7 @@ endfunc
 func Test_cclose_from_copen()
     augroup QF_Test
 	au!
-	au FileType qf :cclose
+        au FileType qf :call assert_fails(':cclose', 'E788')
     augroup END
     copen
     augroup QF_Test
@@ -2208,4 +2208,20 @@ endfunc
 func Test_Qf_Size()
   call XsizeTests('c')
   call XsizeTests('l')
+endfunc
+
+func Test_cclose_in_autocmd()
+  " Problem is only triggered if "starting" is zero, so that the OptionsSet
+  " event will be triggered.
+  " call test_override('starting', 1)
+  augroup QF_Test
+    au!
+    au FileType qf :call assert_fails(':cclose', 'E788')
+  augroup END
+  copen
+  augroup QF_Test
+    au!
+  augroup END
+  augroup! QF_Test
+  " call test_override('starting', 0)
 endfunc

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2169,18 +2169,6 @@ func Test_bufoverflow()
   set efm&vim
 endfunc
 
-func Test_cclose_from_copen()
-    augroup QF_Test
-	au!
-        au FileType qf :call assert_fails(':cclose', 'E788')
-    augroup END
-    copen
-    augroup QF_Test
-	au!
-    augroup END
-    augroup! QF_Test
-endfunc
-
 " Tests for getting the quickfix stack size
 func XsizeTests(cchar)
   call s:setup_commands(a:cchar)
@@ -2210,6 +2198,18 @@ func Test_Qf_Size()
   call XsizeTests('l')
 endfunc
 
+func Test_cclose_from_copen()
+    augroup QF_Test
+	au!
+        au FileType qf :call assert_fails(':cclose', 'E788')
+    augroup END
+    copen
+    augroup QF_Test
+	au!
+    augroup END
+    augroup! QF_Test
+endfunc
+
 func Test_cclose_in_autocmd()
   " Problem is only triggered if "starting" is zero, so that the OptionsSet
   " event will be triggered.
@@ -2224,4 +2224,21 @@ func Test_cclose_in_autocmd()
   augroup END
   augroup! QF_Test
   " call test_override('starting', 0)
+endfunc
+
+func Test_resize_from_copen()
+    augroup QF_Test
+	au!
+        au FileType qf resize 5
+    augroup END
+    try
+	" This should succeed without any exception.  No other buffers are
+	" involved in the autocmd.
+	copen
+    finally
+	augroup QF_Test
+	    au!
+	augroup END
+	augroup! QF_Test
+    endtry
 endfunc


### PR DESCRIPTION
**vim-patch:8.0.0677: setting 'filetype' may switch buffers**

Problem:    Setting 'filetype' internally may cause the current buffer and
            window to change unexpectedly.
Solution:   Set curbuf_lock. (closes vim/vim#1734)
vim/vim@1814183

**vim-patch:8.0.0688: cannot resize the window in a FileType autocommand**

Problem:    Cannot resize the window in a FileType autocommand. (Ingo Karkat)
Solution:   Add the CMDWIN flag to :resize. (test by Ingo Karkat,
            closes vim/vim#1804)
vim/vim@9c4feff