### PR TITLE
vim-patch:8.0.0687: minor issues related to quickfix

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6897,7 +6897,8 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		    title	quickfix list title text
 		Unsupported keys in {what} are ignored.
 		If the "nr" item is not present, then the current quickfix list
-		is modified.
+		is modified. When creating a new quickfix list, "nr" can be
+		set to a value one greater than the quickfix stack size.
 
 		Examples: >
 			:call setqflist([], 'r', {'title': 'My search'})

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1044,10 +1044,12 @@ qf_init_ext(
   if (newlist || qi->qf_curlist == qi->qf_listcount) {
     // make place for a new list
     qf_new_list(qi, qf_title);
-  } else if (qi->qf_lists[qi->qf_curlist].qf_count > 0) {
+  } else {
     // Adding to existing list, use last entry.
     adding = true;
-    old_last = qi->qf_lists[qi->qf_curlist].qf_last;
+    if (qi->qf_lists[qi->qf_curlist].qf_count > 0) {
+      old_last = qi->qf_lists[qi->qf_curlist].qf_last;
+    }
   }
 
   // Use the local value of 'errorformat' if it's set.
@@ -4202,13 +4204,16 @@ int get_errorlist_properties(win_T *wp, dict_T *what, dict_T *retdict)
     list_T *l = tv_list_alloc(kListLenMayKnow);
     (void)get_errorlist(wp, qf_idx, l);
     tv_dict_add_list(retdict, S_LEN("items"), l);
+  } else {
+    status = FAIL;
   }
 
   if ((status == OK) && (flags & QF_GETLIST_CONTEXT)) {
     if (qi->qf_lists[qf_idx].qf_ctx != NULL) {
       di = tv_dict_item_alloc_len(S_LEN("context"));
       tv_copy(qi->qf_lists[qf_idx].qf_ctx, &di->di_tv);
-      if (tv_dict_add(retdict, di) == FAIL) {
+      status = tv_dict_add(retdict, di);
+      if (status == FAIL) {
         tv_dict_item_free(di);
       }
     } else {
@@ -4397,6 +4402,7 @@ static int qf_set_properties(qf_info_T *qi, dict_T *what, int action)
     typval_T *ctx = xcalloc(1, sizeof(typval_T));
     tv_copy(&di->di_tv, ctx);
     qi->qf_lists[qf_idx].qf_ctx = ctx;
+    retval = OK;
   }
 
   return retval;

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1702,7 +1702,8 @@ func Xproperty_tests(cchar)
     Xopen
     wincmd p
     call g:Xsetlist([{'filename':'foo', 'lnum':27}])
-    call g:Xsetlist([], 'a', {'title' : 'Sample'})
+    let s = g:Xsetlist([], 'a', {'title' : 'Sample'})
+    call assert_equal(0, s)
     let d = g:Xgetlist({"title":1})
     call assert_equal('Sample', d.title)
 
@@ -1756,7 +1757,8 @@ func Xproperty_tests(cchar)
     endif
 
     " Context related tests
-    call g:Xsetlist([], 'a', {'context':[1,2,3]})
+    let s = g:Xsetlist([], 'a', {'context':[1,2,3]})
+    call assert_equal(0, s)
     call test_garbagecollect_now()
     let d = g:Xgetlist({'context':1})
     call assert_equal([1,2,3], d.context)
@@ -1821,8 +1823,9 @@ func Xproperty_tests(cchar)
     " Test for setting/getting items
     Xexpr ""
     let qfprev = g:Xgetlist({'nr':0})
-    call g:Xsetlist([], ' ', {'title':'Green',
+    let s = g:Xsetlist([], ' ', {'title':'Green',
 		\ 'items' : [{'filename':'F1', 'lnum':10}]})
+    call assert_equal(0, s)
     let qfcur = g:Xgetlist({'nr':0})
     call assert_true(qfcur.nr == qfprev.nr + 1)
     let l = g:Xgetlist({'items':1})


### PR DESCRIPTION
**vim-patch:8.0.0687: minor issues related to quickfix**

Problem:    Minor issues related to quickfix.
Solution:   Set the proper return status for all cases in setqflist() and at
            test cases for this.  Move the "adding" flag outside of
            FEAT_WINDOWS. Minor update to the setqflist() help text. (Yegappan
            Lakshmanan)
https://github.com/vim/vim/commit/86f100dc0922e83bead7bcd5fd2bb2abbf153f46