### PR TITLE
oldtest: Disable tests that :py(3)do stop executing when buffer changes

### DIFF
--- a/src/nvim/testdir/test_python2.vim
+++ b/src/nvim/testdir/test_python2.vim
@@ -13,12 +13,15 @@ func Test_pydo()
   pydo vim.command("%d_")
   bwipe!
 
-  " Check switching to another buffer does not trigger ml_get error.
-  new
-  let wincount = winnr('$')
-  call setline(1, ['one', 'two', 'three'])
-  pydo vim.command("new")
-  call assert_equal(wincount + 1, winnr('$'))
-  bwipe!
-  bwipe!
+  " Disabled until neovim/neovim#8554 is resolved
+  if 0
+    " Check switching to another buffer does not trigger ml_get error.
+    new
+    let wincount = winnr('$')
+    call setline(1, ['one', 'two', 'three'])
+    pydo vim.command("new")
+    call assert_equal(wincount + 1, winnr('$'))
+    bwipe!
+    bwipe!
+  endif
 endfunc

--- a/src/nvim/testdir/test_python3.vim
+++ b/src/nvim/testdir/test_python3.vim
@@ -13,12 +13,15 @@ func Test_py3do()
   py3do vim.command("%d_")
   bwipe!
 
-  " Check switching to another buffer does not trigger an ml_get error.
-  new
-  let wincount = winnr('$')
-  call setline(1, ['one', 'two', 'three'])
-  py3do vim.command("new")
-  call assert_equal(wincount + 1, winnr('$'))
-  bwipe!
-  bwipe!
+  " Disabled until neovim/neovim#8554 is resolved
+  if 0
+    " Check switching to another buffer does not trigger an ml_get error.
+    new
+    let wincount = winnr('$')
+    call setline(1, ['one', 'two', 'three'])
+    py3do vim.command("new")
+    call assert_equal(wincount + 1, winnr('$'))
+    bwipe!
+    bwipe!
+  endif
 endfunc


### PR DESCRIPTION
The current nvim <-> client handling of do_range needs to be adapted to
handle these sorts of checks.

See https://github.com/neovim/neovim/issues/8554