### PR TITLE
nvim_buf_*() and unloaded buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,9 +113,9 @@ set(NVIM_VERSION_PATCH 2)
 set(NVIM_VERSION_PRERELEASE "-dev") # for package maintainers
 
 # API level
-set(NVIM_API_LEVEL 4)         # Bump this after any API change.
+set(NVIM_API_LEVEL 5)         # Bump this after any API change.
 set(NVIM_API_LEVEL_COMPAT 0)  # Adjust this after a _breaking_ API change.
-set(NVIM_API_PRERELEASE false)
+set(NVIM_API_PRERELEASE true)
 
 file(TO_CMAKE_PATH ${CMAKE_CURRENT_LIST_DIR}/.git FORCED_GIT_DIR)
 include(GetGitRevisionDescription)

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -836,9 +836,25 @@ nvim_get_proc({pid})                                         *nvim_get_proc()*
                 Return: ~
                     Map of process properties, or NIL if process not found.
 
+nvim__inspect_cell({row}, {col})                        *nvim__inspect_cell()*
+                TODO: Documentation
+
 
 ==============================================================================
 Buffer Functions                                                  *api-buffer*
+
+Unloaded Buffers:~
+
+Buffers may be unloaded by the |:bunload| command or the
+buffer's |'bufhidden'| option. When a buffer is unloaded its
+file contents are freed from memory and vim cannot operate on
+the buffer lines until it is reloaded (usually by opening the
+buffer again in a new window). API methods such as
+|nvim_buf_get_lines()| and |nvim_buf_line_count()| will be
+affected.
+
+You can use |nvim_buf_is_loaded()| or |nvim_buf_line_count()|
+to check whether a buffer is loaded.
 
 nvim_buf_line_count({buffer})                          *nvim_buf_line_count()*
                 Gets the buffer line count
@@ -847,7 +863,8 @@ nvim_buf_line_count({buffer})                          *nvim_buf_line_count()*
                     {buffer}  Buffer handle
 
                 Return: ~
-                    Line count
+                    Line count, or `0` if the buffer has been unloaded (see
+                    |api-buffer|).
 
 nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
                 Activate updates from this buffer to the current channel.
@@ -896,7 +913,8 @@ nvim_buf_get_lines({buffer}, {start}, {end}, {strict_indexing})
                                        error.
 
                 Return: ~
-                    Array of lines
+                    Array of lines. If the buffer has been unloaded then an
+                    empty array will be returned instead. (See |api-buffer|.)
 
                                                         *nvim_buf_set_lines()*
 nvim_buf_set_lines({buffer}, {start}, {end}, {strict_indexing},
@@ -1013,14 +1031,28 @@ nvim_buf_set_name({buffer}, {name})                      *nvim_buf_set_name()*
                     {buffer}  Buffer handle
                     {name}    Buffer name
 
-nvim_buf_is_valid({buffer})                              *nvim_buf_is_valid()*
-                Checks if a buffer is valid
+nvim_buf_is_loaded({buffer})                            *nvim_buf_is_loaded()*
+                Checks if a buffer is valid and loaded. See |api-buffer| for
+                more info about unloaded buffers.
 
                 Parameters: ~
                     {buffer}  Buffer handle
 
                 Return: ~
-                    true if the buffer is valid, false otherwise
+                    true if the buffer is valid and loaded, false otherwise.
+
+nvim_buf_is_valid({buffer})                              *nvim_buf_is_valid()*
+                Checks if a buffer is valid.
+
+                Note:
+                    Even if a buffer is valid it may have been unloaded. See
+                    |api-buffer| for more info about unloaded buffers.
+
+                Parameters: ~
+                    {buffer}  Buffer handle
+
+                Return: ~
+                    true if the buffer is valid, false otherwise.
 
 nvim_buf_get_mark({buffer}, {name})                      *nvim_buf_get_mark()*
                 Return a tuple (row,col) representing the position of the

--- a/scripts/gen_api_vimdoc.py
+++ b/scripts/gen_api_vimdoc.py
@@ -413,10 +413,26 @@ def gen_docs(config):
         sys.exit(p.returncode)
 
     sections = {}
+    intros = {}
     sep = '=' * text_width
 
     base = os.path.join(out_dir, 'xml')
     dom = minidom.parse(os.path.join(base, 'index.xml'))
+
+    # generate docs for section intros
+    for compound in dom.getElementsByTagName('compound'):
+        if compound.getAttribute('kind') != 'group':
+            continue
+
+        groupname = get_text(find_first(compound, 'name'))
+        groupxml = os.path.join(base, '%s.xml' % compound.getAttribute('refid'))
+
+        desc = find_first(minidom.parse(groupxml), 'detaileddescription')
+        if desc:
+            doc = parse_parblock(desc)
+            if doc:
+                intros[groupname] = doc
+
     for compound in dom.getElementsByTagName('compound'):
         if compound.getAttribute('kind') != 'file':
             continue
@@ -437,6 +453,11 @@ def gen_docs(config):
                     name = name.title()
 
                 doc = ''
+
+                intro = intros.get('api-%s' % name.lower())
+                if intro:
+                    doc += '\n\n' + intro
+
                 if functions:
                     doc += '\n\n' + functions
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -45,6 +45,11 @@ Integer nvim_buf_line_count(Buffer buffer, Error *err)
     return 0;
   }
 
+  // return sentinel value if the buffer isn't loaded
+  if (buf->b_ml.ml_mfp == NULL) {
+    return 0;
+  }
+
   return buf->b_ml.ml_line_count;
 }
 
@@ -218,6 +223,11 @@ ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
   buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
+    return rv;
+  }
+
+  // return sentinel value if the buffer isn't loaded
+  if (buf->b_ml.ml_mfp == NULL) {
     return rv;
   }
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -755,6 +755,19 @@ void nvim_buf_set_name(Buffer buffer, String name, Error *err)
   }
 }
 
+/// Checks if a buffer is valid and loaded
+///
+/// @param buffer Buffer handle
+/// @return true if the buffer is valid and loaded, false otherwise
+Boolean nvim_buf_is_loaded(Buffer buffer)
+  FUNC_API_SINCE(5)
+{
+  Error stub = ERROR_INIT;
+  buf_T *buf = find_buffer_by_handle(buffer, &stub);
+  api_clear_error(&stub);
+  return buf && buf->b_ml.ml_mfp != NULL;
+}
+
 /// Checks if a buffer is valid
 ///
 /// @param buffer Buffer handle

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -31,11 +31,27 @@
 # include "api/buffer.c.generated.h"
 #endif
 
+
+/// \defgroup api-buffer
+///
+/// Unloaded Buffers:~
+///
+/// Buffers may be unloaded by the |:bunload| command or the buffer's
+/// |'bufhidden'| option. When a buffer is unloaded its file contents are freed
+/// from memory and vim cannot operate on the buffer lines until it is reloaded
+/// (usually by opening the buffer again in a new window). API methods such as
+/// |nvim_buf_get_lines()| and |nvim_buf_line_count()| will be affected.
+///
+/// You can use |nvim_buf_is_loaded()| or |nvim_buf_line_count()| to check
+/// whether a buffer is loaded.
+
+
 /// Gets the buffer line count
 ///
 /// @param buffer   Buffer handle
 /// @param[out] err Error details, if any
-/// @return Line count
+/// @return Line count, or \`0` if the buffer has been unloaded (see
+///         |api-buffer|).
 Integer nvim_buf_line_count(Buffer buffer, Error *err)
   FUNC_API_SINCE(1)
 {
@@ -210,7 +226,8 @@ ArrayOf(String) buffer_get_line_slice(Buffer buffer,
 /// @param end              Last line index (exclusive)
 /// @param strict_indexing  Whether out-of-bounds should be an error.
 /// @param[out] err         Error details, if any
-/// @return Array of lines
+/// @return Array of lines. If the buffer has been unloaded then an empty array
+///                         will be returned instead. (See |api-buffer|.)
 ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
                                    Buffer buffer,
                                    Integer start,
@@ -755,10 +772,11 @@ void nvim_buf_set_name(Buffer buffer, String name, Error *err)
   }
 }
 
-/// Checks if a buffer is valid and loaded
+/// Checks if a buffer is valid and loaded. See |api-buffer| for more info
+/// about unloaded buffers.
 ///
 /// @param buffer Buffer handle
-/// @return true if the buffer is valid and loaded, false otherwise
+/// @return true if the buffer is valid and loaded, false otherwise.
 Boolean nvim_buf_is_loaded(Buffer buffer)
   FUNC_API_SINCE(5)
 {
@@ -768,10 +786,13 @@ Boolean nvim_buf_is_loaded(Buffer buffer)
   return buf && buf->b_ml.ml_mfp != NULL;
 }
 
-/// Checks if a buffer is valid
+/// Checks if a buffer is valid.
+///
+/// @note Even if a buffer is valid it may have been unloaded. See |api-buffer|
+/// for more info about unloaded buffers.
 ///
 /// @param buffer Buffer handle
-/// @return true if the buffer is valid, false otherwise
+/// @return true if the buffer is valid, false otherwise.
 Boolean nvim_buf_is_valid(Buffer buffer)
   FUNC_API_SINCE(1)
 {


### PR DESCRIPTION
Proposed solution for #7688 and #5534. Changes in this PR:

* `nvim_buf_get_lines()` will now always return an empty list for an unloaded buffer, instead of a list containing a single empty string.
* `nvim_buf_line_count()` will now always return `0` for an unloaded buffer, instead of `1`.
* `nvim_buf_is_loaded()` has been added to check if a buffer is loaded
* help text updates for the above
* extra unit tests for the above