### PR TITLE
[RFC] vim-patch:8.0.{643,644,645}

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3903,7 +3903,7 @@ static int ins_compl_get_exp(pos_T *ini)
           found_new_match = searchit(NULL, ins_buf, pos,
               compl_direction,
               compl_pattern, 1L, SEARCH_KEEP + SEARCH_NFMSG,
-              RE_LAST, (linenr_T)0, NULL);
+              RE_LAST, (linenr_T)0, NULL, NULL);
         --msg_silent;
         if (!compl_started || set_match_pos) {
           /* set "compl_started" even on fail */

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -13773,7 +13773,7 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
 
   pos = save_cursor = curwin->w_cursor;
   subpatnum = searchit(curwin, curbuf, &pos, dir, (char_u *)pat, 1,
-                       options, RE_SEARCH, (linenr_T)lnum_stop, &tm);
+                       options, RE_SEARCH, (linenr_T)lnum_stop, &tm, NULL);
   if (subpatnum != FAIL) {
     if (flags & SP_SUBPAT)
       retval = subpatnum;
@@ -14275,7 +14275,7 @@ do_searchpair(
   pat = pat3;
   for (;; ) {
     n = searchit(curwin, curbuf, &pos, dir, pat, 1L,
-        options, RE_SEARCH, lnum_stop, &tm);
+        options, RE_SEARCH, lnum_stop, &tm, NULL);
     if (n == FAIL || (firstpos.lnum != 0 && equalpos(pos, firstpos)))
       /* didn't find it or found the first match again: FAIL */
       break;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3378,7 +3378,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
            || lnum <= curwin->w_botline);
        lnum++) {
     long nmatch = vim_regexec_multi(&regmatch, curwin, curbuf, lnum,
-                                    (colnr_T)0, NULL);
+                                    (colnr_T)0, NULL, NULL);
     if (nmatch) {
       colnr_T copycol;
       colnr_T matchcol;
@@ -3898,7 +3898,7 @@ skip:
             || nmatch_tl > 0
             || (nmatch = vim_regexec_multi(&regmatch, curwin,
                     curbuf, sub_firstlnum,
-                    matchcol, NULL)) == 0
+                    matchcol, NULL, NULL)) == 0
             || regmatch.startpos[0].lnum > 0) {
           if (new_start != NULL) {
             /*
@@ -3962,7 +3962,7 @@ skip:
           }
           if (nmatch == -1 && !lastone)
             nmatch = vim_regexec_multi(&regmatch, curwin, curbuf,
-                sub_firstlnum, matchcol, NULL);
+                sub_firstlnum, matchcol, NULL, NULL);
 
           /*
            * 5. break if there isn't another match in this line
@@ -4263,7 +4263,7 @@ void ex_global(exarg_T *eap)
   if (global_busy) {
     lnum = curwin->w_cursor.lnum;
     match = vim_regexec_multi(&regmatch, curwin, curbuf, lnum,
-                              (colnr_T)0, NULL);
+                              (colnr_T)0, NULL, NULL);
     if ((type == 'g' && match) || (type == 'v' && !match)) {
       global_exe_one(cmd, lnum);
     }
@@ -4272,7 +4272,7 @@ void ex_global(exarg_T *eap)
     for (lnum = eap->line1; lnum <= eap->line2 && !got_int; lnum++) {
       // a match on this line?
       match = vim_regexec_multi(&regmatch, curwin, curbuf, lnum,
-                                (colnr_T)0, NULL);
+                                (colnr_T)0, NULL, NULL);
       if ((type == 'g' && match) || (type == 'v' && !match)) {
         ml_setmarked(lnum);
         ndone++;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3685,7 +3685,7 @@ static linenr_T get_address(exarg_T *eap,
         }
         searchcmdlen = 0;
         if (!do_search(NULL, c, cmd, 1L,
-                SEARCH_HIS | SEARCH_MSG, NULL)) {
+                SEARCH_HIS | SEARCH_MSG, NULL, NULL)) {
           curwin->w_cursor = pos;
           cmd = NULL;
           goto error;
@@ -3723,7 +3723,7 @@ static linenr_T get_address(exarg_T *eap,
         if (searchit(curwin, curbuf, &pos,
                      *cmd == '?' ? BACKWARD : FORWARD,
                      (char_u *)"", 1L, SEARCH_MSG,
-                     i, (linenr_T)0, NULL) != FAIL)
+                     i, (linenr_T)0, NULL, NULL) != FAIL)
           lnum = pos.lnum;
         else {
           cmd = NULL;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1061,7 +1061,7 @@ static void command_line_next_incsearch(CommandLineState *s, bool next_match)
   s->i = searchit(curwin, curbuf, &t,
                   next_match ? FORWARD : BACKWARD,
                   pat, s->count, search_flags,
-                  RE_SEARCH, 0, NULL);
+                  RE_SEARCH, 0, NULL, NULL);
   emsg_off--;
   ui_busy_stop();
   if (s->i) {
@@ -1837,7 +1837,7 @@ static int command_line_changed(CommandLineState *s)
       }
       s->i = do_search(NULL, s->firstc, ccline.cmdbuff, s->count,
                        search_flags,
-                       &tm);
+                       &tm, NULL);
       emsg_off--;
       // if interrupted while searching, behave like it failed
       if (got_int) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3794,7 +3794,7 @@ find_decl (
   for (;; ) {
     valid = false;
     t = searchit(curwin, curbuf, &curwin->w_cursor, FORWARD,
-        pat, 1L, searchflags, RE_LAST, (linenr_T)0, NULL);
+        pat, 1L, searchflags, RE_LAST, (linenr_T)0, NULL, NULL);
     if (curwin->w_cursor.lnum >= old_pos.lnum)
       t = false;         /* match after start is failure too */
 
@@ -5393,7 +5393,7 @@ static int normal_search(
   curwin->w_set_curswant = true;
 
   i = do_search(cap->oap, dir, pat, cap->count1,
-                opt | SEARCH_OPT | SEARCH_ECHO | SEARCH_MSG, NULL);
+                opt | SEARCH_OPT | SEARCH_ECHO | SEARCH_MSG, NULL, NULL);
   if (i == 0) {
     clearop(cap->oap);
   } else {

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2127,7 +2127,7 @@ win_found:
       save_cursor = curwin->w_cursor;
       curwin->w_cursor.lnum = 0;
       if (!do_search(NULL, '/', qf_ptr->qf_pattern, (long)1,
-              SEARCH_KEEP, NULL))
+              SEARCH_KEEP, NULL, NULL))
         curwin->w_cursor = save_cursor;
     }
 
@@ -3748,7 +3748,7 @@ void ex_vimgrep(exarg_T *eap)
            ++lnum) {
         col = 0;
         while (vim_regexec_multi(&regmatch, curwin, buf, lnum,
-                                 col, NULL) > 0) {
+                                 col, NULL, NULL) > 0) {
           // Pass the buffer number so that it gets used even for a
           // dummy buffer, unless duplicate_name is set, then the
           // buffer will be wiped out below.

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1209,6 +1209,30 @@ char_u *skip_regexp(char_u *startp, int dirc, int magic, char_u **newp)
   return p;
 }
 
+// Return TRUE if the back reference is legal. We must have seen the close
+// brace.
+// TODO: Should also check that we don't refer to something that is repeated
+// (+*=): what instance of the repetition should we match?
+static bool seen_endbrace(const int refnum)
+{
+  if (!had_endbrace[refnum]) {
+    char_u *p;
+
+    /* Trick: check if "@<=" or "@<!" follows, in which case
+     * the \1 can appear before the referenced match. */
+    for (p = regparse; *p != NUL; p++) {
+      if (p[0] == '@' && p[1] == '<' && (p[2] == '!' || p[2] == '=')) {
+        break;
+      }
+    }
+    if (*p == NUL) {
+      EMSG(_("E65: Illegal back reference"));
+      rc_did_emsg = true;
+      return false;
+    }
+  }
+  return true;
+}
 
 /*
  * bt_regcomp() - compile a regular expression into internal code for the
@@ -1927,22 +1951,8 @@ static char_u *regatom(int *flagp)
     int refnum;
 
     refnum = c - Magic('0');
-    /*
-     * Check if the back reference is legal. We must have seen the
-     * close brace.
-     * TODO: Should also check that we don't refer to something
-     * that is repeated (+*=): what instance of the repetition
-     * should we match?
-     */
-    if (!had_endbrace[refnum]) {
-      /* Trick: check if "@<=" or "@<!" follows, in which case
-       * the \1 can appear before the referenced match. */
-      for (p = regparse; *p != NUL; ++p)
-        if (p[0] == '@' && p[1] == '<'
-            && (p[2] == '!' || p[2] == '='))
-          break;
-      if (*p == NUL)
-        EMSG_RET_NULL(_("E65: Illegal back reference"));
+    if (!seen_endbrace(refnum)) {
+      return NULL;
     }
     ret = regnode(BACKREF + refnum);
   }

--- a/src/nvim/regexp_defs.h
+++ b/src/nvim/regexp_defs.h
@@ -158,9 +158,9 @@ struct reg_extmatch {
 struct regengine {
   regprog_T   *(*regcomp)(char_u*, int);
   void (*regfree)(regprog_T *);
-  int (*regexec_nl)(regmatch_T*, char_u*, colnr_T, bool);
-  long (*regexec_multi)(regmmatch_T*, win_T*, buf_T*, linenr_T, colnr_T,
-      proftime_T*);
+  int (*regexec_nl)(regmatch_T *, char_u *, colnr_T, bool);
+  long (*regexec_multi)(regmmatch_T *, win_T *, buf_T *, linenr_T, colnr_T,
+      proftime_T *, int *);
   char_u      *expr;
 };
 

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1338,8 +1338,15 @@ static int nfa_regatom(void)
   case Magic('7'):
   case Magic('8'):
   case Magic('9'):
-    EMIT(NFA_BACKREF1 + (no_Magic(c) - '1'));
-    nfa_has_backref = TRUE;
+    {
+      const int refnum = no_Magic(c) - '1';
+
+      if (!seen_endbrace(refnum + 1)) {
+        return FAIL;
+      }
+      EMIT(NFA_BACKREF1 + refnum);
+      nfa_has_backref = true;
+    }
     break;
 
   case Magic('z'):

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -3564,6 +3564,7 @@ static char *pim_info(nfa_pim_T *pim)
 // Used during execution: whether a match has been found.
 static int nfa_match;
 static proftime_T *nfa_time_limit;
+static int *nfa_timed_out;
 static int nfa_time_count;
 
 // Copy postponed invisible match info from "from" to "to".
@@ -4935,6 +4936,17 @@ static long find_match_text(colnr_T startcol, int regstart, char_u *match_text)
 #undef PTR2LEN
 }
 
+static bool nfa_did_time_out(void)
+{
+  if (nfa_time_limit != NULL && profile_passed_limit(*nfa_time_limit)) {
+    if (nfa_timed_out != NULL) {
+      *nfa_timed_out = true;
+    }
+    return true;
+  }
+  return false;
+}
+
 /// Main matching routine.
 ///
 /// Run NFA to determine whether it matches reginput.
@@ -4978,7 +4990,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
 #endif
     return false;
   }
-  if (nfa_time_limit != NULL && profile_passed_limit(*nfa_time_limit)) {
+  if (nfa_did_time_out()) {
 #ifdef NFA_REGEXP_DEBUG_LOG
     fclose(debug);
 #endif
@@ -5092,6 +5104,18 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
 
     /* compute nextlist */
     for (listidx = 0; listidx < thislist->n; ++listidx) {
+      // If the list gets very long there probably is something wrong.
+      // At least allow interrupting with CTRL-C.
+      fast_breakcheck();
+      if (got_int) {
+        break;
+      }
+      if (nfa_time_limit != NULL && ++nfa_time_count == 20) {
+        nfa_time_count = 0;
+        if (nfa_did_time_out()) {
+          break;
+        }
+      }
       t = &thislist->t[listidx];
 
 #ifdef NFA_REGEXP_DEBUG_LOG
@@ -6213,7 +6237,7 @@ nextchar:
     // Check for timeout once every twenty times to avoid overhead.
     if (nfa_time_limit != NULL && ++nfa_time_count == 20) {
       nfa_time_count = 0;
-      if (profile_passed_limit(*nfa_time_limit)) {
+      if (nfa_did_time_out()) {
         break;
       }
     }
@@ -6240,7 +6264,12 @@ theend:
 
 // Try match of "prog" with at regline["col"].
 // Returns <= 0 for failure, number of lines contained in the match otherwise.
-static long nfa_regtry(nfa_regprog_T *prog, colnr_T col, proftime_T *tm)
+static long nfa_regtry(
+    nfa_regprog_T *prog,
+    colnr_T col,
+    proftime_T *tm,   // timeout limit or NULL
+    int *timed_out    // flag set on timeout or NULL
+)
 {
   int i;
   regsubs_T subs, m;
@@ -6251,6 +6280,7 @@ static long nfa_regtry(nfa_regprog_T *prog, colnr_T col, proftime_T *tm)
 
   reginput = regline + col;
   nfa_time_limit = tm;
+  nfa_timed_out = timed_out;
   nfa_time_count = 0;
 
 #ifdef REGEXP_DEBUG
@@ -6356,13 +6386,15 @@ static long nfa_regtry(nfa_regprog_T *prog, colnr_T col, proftime_T *tm)
 /// Match a regexp against a string ("line" points to the string) or multiple
 /// lines ("line" is NULL, use reg_getline()).
 ///
-/// @param line String in which to search or NULL
-/// @param startcol Column to start looking for match
-/// @param tm Timeout limit or NULL
+/// @param line       String in which to search or NULL
+/// @param startcol   Column to start looking for match
+/// @param tm         Timeout limit or NULL
+/// @param timed_out  flag set on timeout or NULL
 ///
 /// @return <= 0 if there is no match and number of lines contained in the
 /// match otherwise.
-static long nfa_regexec_both(char_u *line, colnr_T startcol, proftime_T *tm)
+static long nfa_regexec_both(char_u *line, colnr_T startcol, proftime_T *tm,
+                             int *timed_out)
 {
   nfa_regprog_T   *prog;
   long retval = 0L;
@@ -6444,7 +6476,7 @@ static long nfa_regexec_both(char_u *line, colnr_T startcol, proftime_T *tm)
     prog->state[i].lastlist[1] = 0;
   }
 
-  retval = nfa_regtry(prog, col, tm);
+  retval = nfa_regtry(prog, col, tm, timed_out);
 
   nfa_regengine.expr = NULL;
 
@@ -6597,18 +6629,19 @@ nfa_regexec_nl (
   rex.reg_ic = rmp->rm_ic;
   rex.reg_icombine = false;
   rex.reg_maxcol = 0;
-  return nfa_regexec_both(line, col, NULL);
+  return nfa_regexec_both(line, col, NULL, NULL);
 }
 
 /// Matches a regexp against multiple lines.
 /// "rmp->regprog" is a compiled regexp as returned by vim_regcomp().
 /// Uses curbuf for line count and 'iskeyword'.
 ///
-/// @param win Window in which to search or NULL
-/// @param buf Buffer in which to search
-/// @param lnum Number of line to start looking for match
-/// @param col Column to start looking for match
-/// @param tm Timeout limit or NULL
+/// @param win        Window in which to search or NULL
+/// @param buf        Buffer in which to search
+/// @param lnum       Number of line to start looking for match
+/// @param col        Column to start looking for match
+/// @param tm         Timeout limit or NULL
+/// @param timed_out  flag set on timeout or NULL
 ///
 /// @return <= 0 if there is no match and number of lines contained in the match
 /// otherwise.
@@ -6635,7 +6668,8 @@ nfa_regexec_nl (
 /// @par
 /// FIXME if this behavior is not compatible.
 static long nfa_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf,
-                              linenr_T lnum, colnr_T col, proftime_T *tm)
+                              linenr_T lnum, colnr_T col, proftime_T *tm,
+                              int *timed_out)
 {
   rex.reg_match = NULL;
   rex.reg_mmatch = rmp;
@@ -6648,5 +6682,5 @@ static long nfa_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf,
   rex.reg_icombine = false;
   rex.reg_maxcol = rmp->rmm_maxcol;
 
-  return nfa_regexec_both(NULL, col, tm);
+  return nfa_regexec_both(NULL, col, tm, timed_out);
 }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -5730,13 +5730,15 @@ next_search_hl (
                               && cur != NULL
                               && shl == &cur->hl
                               && cur->match.regprog == cur->hl.rm.regprog);
+      int timed_out = false;
 
-      nmatched = vim_regexec_multi(&shl->rm, win, shl->buf, lnum, matchcol, &(shl->tm));
+      nmatched = vim_regexec_multi(&shl->rm, win, shl->buf, lnum, matchcol,
+          &(shl->tm), &timed_out);
       /* Copy the regprog, in case it got freed and recompiled. */
       if (regprog_is_copy) {
         cur->match.regprog = cur->hl.rm.regprog;
       }
-      if (called_emsg || got_int) {
+      if (called_emsg || got_int || timed_out) {
         // Error while handling regexp: stop using this regexp.
         if (shl == &search_hl) {
           // don't free regprog in the match list, it's a copy

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3048,9 +3048,10 @@ void ex_spellrepall(exarg_T *eap)
   sub_nlines = 0;
   curwin->w_cursor.lnum = 0;
   while (!got_int) {
-    if (do_search(NULL, '/', frompat, 1L, SEARCH_KEEP, NULL) == 0
-        || u_save_cursor() == FAIL)
+    if (do_search(NULL, '/', frompat, 1L, SEARCH_KEEP, NULL, NULL) == 0
+        || u_save_cursor() == FAIL) {
       break;
+    }
 
     // Only replace when the right word isn't there yet.  This happens
     // when changing "etc" to "etc.".

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -2894,7 +2894,7 @@ static int syn_regexec(regmmatch_T *rmp, linenr_T lnum, colnr_T col, syn_time_T 
   }
 
   rmp->rmm_maxcol = syn_buf->b_p_smc;
-  r = vim_regexec_multi(rmp, syn_win, syn_buf, lnum, col, NULL);
+  r = vim_regexec_multi(rmp, syn_win, syn_buf, lnum, col, NULL, NULL);
 
   if (l_syn_time_on) {
     pt = profile_end(pt);

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2508,7 +2508,7 @@ static int jumpto_tag(
       save_lnum = curwin->w_cursor.lnum;
       curwin->w_cursor.lnum = 0;        /* start search before first line */
       if (do_search(NULL, pbuf[0], pbuf + 1, (long)1,
-              search_options, NULL))
+              search_options, NULL, NULL))
         retval = OK;
       else {
         int found = 1;
@@ -2519,7 +2519,7 @@ static int jumpto_tag(
          */
         p_ic = TRUE;
         if (!do_search(NULL, pbuf[0], pbuf + 1, (long)1,
-                search_options, NULL)) {
+                search_options, NULL, NULL)) {
           /*
            * Failed to find pattern, take a guess: "^func  ("
            */
@@ -2529,12 +2529,12 @@ static int jumpto_tag(
           *tagp.tagname_end = NUL;
           sprintf((char *)pbuf, "^%s\\s\\*(", tagp.tagname);
           if (!do_search(NULL, '/', pbuf, (long)1,
-                  search_options, NULL)) {
+                  search_options, NULL, NULL)) {
             /* Guess again: "^char * \<func  (" */
             sprintf((char *)pbuf, "^\\[#a-zA-Z_]\\.\\*\\<%s\\s\\*(",
                 tagp.tagname);
             if (!do_search(NULL, '/', pbuf, (long)1,
-                    search_options, NULL))
+                    search_options, NULL, NULL))
               found = 0;
           }
           *tagp.tagname_end = cc;

--- a/src/nvim/testdir/test_hlsearch.vim
+++ b/src/nvim/testdir/test_hlsearch.vim
@@ -37,11 +37,11 @@ func Test_hlsearch_hangs()
     return
   endif
 
-  " This pattern takes forever to match, it should timeout.
+  " This pattern takes a long time to match, it should timeout.
   help
   let start = reltime()
   set hlsearch nolazyredraw redrawtime=101
-  let @/ = '\%#=2\v(a|\1)*'
+  let @/ = '\%#=1a*.*X\@<=b*'
   redraw
   let elapsed = reltimefloat(reltime(start))
   call assert_true(elapsed > 0.1)

--- a/src/nvim/testdir/test_hlsearch.vim
+++ b/src/nvim/testdir/test_hlsearch.vim
@@ -32,6 +32,24 @@ function! Test_hlsearch()
   enew!
 endfunction
 
+func Test_hlsearch_hangs()
+  if !has('reltime') || !has('float')
+    return
+  endif
+
+  " This pattern takes forever to match, it should timeout.
+  help
+  let start = reltime()
+  set hlsearch nolazyredraw redrawtime=101
+  let @/ = '\%#=2\v(a|\1)*'
+  redraw
+  let elapsed = reltimefloat(reltime(start))
+  call assert_true(elapsed > 0.1)
+  call assert_true(elapsed < 1.0)
+  set nohlsearch redrawtime&
+  quit
+endfunc
+
 func Test_hlsearch_eol_highlight()
   new
   call append(1, repeat([''], 9))

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -30,3 +30,13 @@ func Test_equivalence_re2()
   set re=2
   call s:equivalence_test()
 endfunc
+
+func Test_backref()
+  new
+  call setline(1, ['one', 'two', 'three', 'four', 'five'])
+  call assert_equal(3, search('\%#=1\(e\)\1'))
+  call assert_equal(3, search('\%#=2\(e\)\1'))
+  call assert_fails('call search("\\%#=1\\(e\\1\\)")', 'E65:')
+  call assert_fails('call search("\\%#=2\\(e\\1\\)")', 'E65:')
+  bwipe!
+endfunc

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -223,7 +223,7 @@ func Test_statusline()
   set statusline=ab%(cd%q%)de
   call assert_match('^abde\s*$', s:get_statusline())
   copen
-  call assert_match('^abcd\[Quickfix List\1]de\s*$', s:get_statusline())
+  call assert_match('^abcd\[Quickfix List]de\s*$', s:get_statusline())
   cclose
 
   " %#: Set highlight group. The name must follow and then a # again.


### PR DESCRIPTION
**vim-patch:8.0.0643: when a pattern search is slow Vim becomes unusable**

Problem:    When 'hlsearch' is set and matching with the last search pattern
            is very slow, Vim becomes unusable.  Cannot quit search by
            pressing CTRL-C.
Solution:   When the search times out set a flag and don't try again.  Check
            for timeout and CTRL-C in NFA loop that adds states.
https://github.com/vim/vim/commit/fbd0b0af6800f6ff89857863d6a07ea03f09ff6c

**vim-patch:8.0.0644: the timeout for 'hlsearch' is not tested**

Problem:    There is no test for 'hlsearch' timing out.
Solution:   Add a test.
vim/vim@5b1affe

**vim-patch:8.0.0645: no error for illegal back reference in NFA engine**

Problem:    The new regexp engine does not give an error for using a back
            reference where it is not allowed. (Dominique Pelle)
Solution:   Check the back reference like the old engine. (closes vim/vim#1774)
vim/vim@1ef9bbe

This PR will be messy for a while so expect lots of build/lint failures as I include more patches from https://gist.github.com/janlazo/cea7acf2711e89a9bc4f7c79612c6e54#regex. After the non-lint builds pass, I'll refactor some int variables to bool.