### PR TITLE
[RDY] vim-patch:8.0.0{640,686}

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -337,6 +337,8 @@ void update_screen(int type)
     screenclear();              // will reset clear_cmdline
     cmdline_screen_cleared();   // clear external cmdline state
     type = NOT_VALID;
+    // must_redraw may be set indirectly, avoid another redraw later
+    must_redraw = 0;
   }
 
   if (clear_cmdline)            /* going to clear cmdline (done below) */

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3034,9 +3034,9 @@ static void syn_cmd_conceal(exarg_T *eap, int syncing)
   next = skiptowhite(arg);
   if (*arg == NUL) {
     if (curwin->w_s->b_syn_conceal) {
-      MSG(_("syn conceal on"));
+      MSG(_("syntax conceal on"));
     } else {
-      MSG(_("syn conceal off"));
+      MSG(_("syntax conceal off"));
     }
   } else if (STRNICMP(arg, "on", 2) == 0 && next - arg == 2) {
     curwin->w_s->b_syn_conceal = true;


### PR DESCRIPTION
**vim-patch:8.0.0640: mismatch between help and actual message**

Problem:    Mismatch between help and actual message for ":syn conceal".
Solution:   Change the message to match the help. (Ken Takata)
vim/vim@8306406

**vim-patch:8.0.0686: extra redraw when using CTRL-L in second window**

Problem:    When typing CTRL-L in a window that's not the first one, another
            redraw will happen later. (Christian Brabandt)
Solution:   Reset must_redraw after calling screenclear().
vim/vim@9f5f7bf