### PR TITLE
[RDY] Fix test_vimscript.vim

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2763,6 +2763,12 @@ void give_warning(char_u *message, bool hl) FUNC_ATTR_NONNULL_ARG(1)
   --no_wait_return;
 }
 
+void give_warning2(char_u *const message, char_u *const a1, bool hl)
+{
+  vim_snprintf((char *)IObuff, IOSIZE, (char *)message, a1);
+  give_warning(IObuff, hl);
+}
+
 /*
  * Advance msg cursor to column "col".
  */

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1061,6 +1061,7 @@ func Test_echo_and_string()
     let l = split(result, "\n")
     call assert_equal(["{'a': [], 'b': []}",
 		     \ "{'a': [], 'b': []}"], l)
+endfunc
 
 "-------------------------------------------------------------------------------
 " Test 94:  64-bit Numbers					    {{{1

--- a/test/functional/viml/function_spec.lua
+++ b/test/functional/viml/function_spec.lua
@@ -2,15 +2,10 @@ local helpers = require('test.functional.helpers')(after_each)
 
 local eq = helpers.eq
 local clear = helpers.clear
-local funcs = helpers.funcs
 local dedent = helpers.dedent
 local redir_exec = helpers.redir_exec
 
 before_each(clear)
-
-local function check_nofunc(fname)
-  eq(0, funcs.exists('*' .. fname))
-end
 
 local function check_func(fname, body, indent)
   if type(body) == 'number' then
@@ -141,12 +136,12 @@ describe(':endfunction', function()
     ]]))
     check_func('F1', 42)
   end)
-  it('errors out on an uncommented bar', function()
-    eq('\nE488: Trailing characters: | echo 42', redir_exec([[
+  it('accepts uncommented bar', function()
+    eq('\n42', redir_exec([[
       function F1()
       endfunction | echo 42
     ]]))
-    check_nofunc('F1')
+    check_func('F1')
   end)
   it('allows running multiple commands', function()
     eq('\n2', redir_exec([[


### PR DESCRIPTION
Sourcing test_vimscript.vim always resulted in an error about a missing `endfunc` at the last line but the modeline and nearby code didn't define an unclosed function. 

Missing `endfunc` in https://github.com/neovim/neovim/commit/81be7358be00d3d75453659bcdc7efc69207ca8e#diff-27865aa5cdcb59d85ae2845f4839a11f

This opens the flood gates to running broken but skipped tests after `Test_echo_and_string`.

