### PR TITLE
Externalize handling of window layout and control (wincmds) to UIs

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -49,6 +49,7 @@ with these (optional) keys:
 				'wildmenu'. |ui-popupmenu|
 	`ext_tabline`		Externalize the tabline. |ui-tabline|
 	`ext_termcolors`	Use external default colors.
+	`ext_windows`		Externalize window handling. |ui-windows|
 
 Specifying an unknown option is an error; UIs can check the |api-metadata|
 `ui_options` key for supported options.
@@ -99,6 +100,11 @@ compatibility); these suffice to implement a terminal-like interface. However
 the new |ui-linegrid| represents text more efficiently (especially highlighted
 text), and allows UI capabilities requiring multiple grids. New UIs should
 implement |ui-linegrid| instead of |ui-grid-old|.
+
+UIs can optionally choose to take care of window positioning and navigation
+(i.e. `wincmd` functions) if they so choose by setting the `ext_windows`
+option. This would implicitly enable the `ext_multigrid` and `ext_newgrid`
+options. See |ui-windows|.
 
 Nvim optionally sends various screen elements "semantically" as structured
 events instead of raw grid-lines, as specified by |ui-ext-options|. The UI
@@ -588,6 +594,73 @@ tabs.
 
 	When |ext_messages| is active, no message grid is used, and this event
 	will not be sent.
+
+==============================================================================
+External Window Events						   *ui-windows*
+
+Only sent if `ext_windows` option is set in |ui-options|. Sets `ext_multigrid`
+and `ext_newgrid` implicitly.
+
+This option enables UIs to take care of how `wincmd`s are interpretted in nvim
+by delegating the position and navigation handling to them instead of nvim.
+Nvim will no longer maintain a frame structure for the windows but rather send
+the events to the UIs which will take the necessary actions.
+
+Only one UI with `ext_windows` option set should connect to one instance of
+nvim ideally, although multiple UIs without this option can connect to that
+instance.
+
+["win_move_cursor", direction, count]
+	NOTE: Implemented as a sync function.
+	Tell the UI to switch to the window "count" windows away in the given
+	"direction" (see below). The UI must return the handle of the window to
+	switch to.
+
+["win_split", win1, grid1, win2, grid2, flags]
+	Tell the UI that there has been a split in the "win1" and a new window
+	"win2" is created in the direction given by the flags (see below).
+
+["win_move", win, grid, flags]
+	Tell the UI that the window "win" is to be moved in the direction
+	specified in flags (see below).
+
+["win_close", win, grid]
+	Tell the UI that the window "win" is no longer open and the UI can get
+	rid of the resources for the same.
+
+["win_exchange", direction, count]
+	Tell the UI to exchange the current window with a window "count"
+	windows away in the given "direction" (either 0 or 1).
+
+["win_rotate", direction, count]
+	Tell the UI to rotate the current window "count" times in the given
+	"direction" (either 0 or 1).
+
+["win_resize_equal"]
+	Tell the UI to resize the windows to allocate equal screen estate to
+	all the windows in the current window row or column.
+
+["win_height_set", win, grid, height]
+	Tell the UI to resize the window height to "height". If "height" is
+	equal to 9999, resize to the maximum possible height.
+
+["win_width_set", win, grid, width]
+	Tell the UI to resize the window width to "width". If "width" is
+	equal to 9999, resize to the maximum possible width.
+
+The "direction" in the `win_move`, `win_move_cursor`, and `win_split` events
+is sent as an Integer with values:
+  0 : above
+  1 : below
+  2 : left
+  3 : right
+  4 : below/right
+  5 : above/left
+  6 : top-left
+  7 : bottom-right
+  8 : previous
+NOTE: The values after 3 (exclusive) are applicable for `win_move_cursor`
+only.
 
 ==============================================================================
 Popupmenu Events						 *ui-popupmenu*

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -640,13 +640,12 @@ instance.
 	Tell the UI to resize the windows to allocate equal screen estate to
 	all the windows in the current window row or column.
 
-["win_height_set", win, grid, height]
-	Tell the UI to resize the window height to "height". If "height" is
-	equal to 9999, resize to the maximum possible height.
-
-["win_width_set", win, grid, width]
-	Tell the UI to resize the window width to "width". If "width" is
-	equal to 9999, resize to the maximum possible width.
+["win_resize", win, grid, width, height]
+	Tell the UI to resize the window to "width" and "height". If "width" or
+	"height" is equal to 9999, resize to the maximum possible height. The
+	UI is expected to call back `try_resize_grid` with the width and height
+	to inform nvim about the size it finally decides on (which may be same
+	or different that sent with `win_resize`).
 
 The "direction" in the `win_move`, `win_move_cursor`, and `win_split` events
 is sent as an Integer with values:

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -151,6 +151,7 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
 
   if (ui->ui_ext[kUIWindows]) {
     if (ext_win_ui == NULL) {
+      ui_set_ext_win_channel(channel_id);
       ext_win_ui = ui;
     }
     ui->ui_ext[kUIMultigrid] = true;
@@ -707,45 +708,4 @@ static void remote_ui_inspect(UI *ui, Dictionary *info)
 {
   UIData *data = ui->data;
   PUT(*info, "chan", INTEGER_OBJ((Integer)data->channel_id));
-}
-
-Integer ui_win_move_cursor(Integer direction, Integer count)
-{
-  UI *ui = ext_win_ui;
-  Array args = ARRAY_DICT_INIT;
-  UIData *data;
-  Error error = ERROR_INIT;
-  typval_T rettv;
-
-  if (!ui_is_external(kUIWindows) || ui == NULL) {
-    abort();  // this should never happen
-  }
-  data = ui->data;
-
-  ADD(args, INTEGER_OBJ(direction));
-  ADD(args, INTEGER_OBJ(count));
-
-  Object result = rpc_send_call(data->channel_id, "win_move_cursor", args,
-                                &error);
-
-  if (ERROR_SET(&error)) {
-    EMSG2(_("Error invoking win_move_cursor: %s"), error.msg);
-    api_clear_error(&error);
-    api_free_object(result);
-    return 0;
-  }
-
-  if (result.type != kObjectTypeInteger) {
-    api_set_error(&error, kErrorTypeValidation,
-                  "Error converting the call result: %s", error.msg);
-    api_clear_error(&error);
-    api_free_object(result);
-    return 0;
-  }
-
-  if (rettv.v_type == VAR_NUMBER) {
-    return (Integer)rettv.vval.v_number;
-  } else {
-    return 0;
-  }
 }

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -729,13 +729,13 @@ Integer ui_win_move_cursor(Integer direction, Integer count)
                                 &error);
 
   if (ERROR_SET(&error)) {
-    api_set_error(&error, kErrorTypeException, "%s", error.msg);
+    EMSG2(_("Error invoking win_move_cursor: %s"), error.msg);
     api_clear_error(&error);
     api_free_object(result);
     return 0;
   }
 
-  if (!object_to_vim(result, &rettv, &error)) {
+  if (result.type != kObjectTypeInteger) {
     api_set_error(&error, kErrorTypeValidation,
                   "Error converting the call result: %s", error.msg);
     api_clear_error(&error);

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -39,6 +39,8 @@ typedef struct {
 
 static PMap(uint64_t) *connected_uis = NULL;
 
+static UI *ext_win_ui = NULL;
+
 void remote_ui_init(void)
   FUNC_API_NOEXPORT
 {
@@ -136,7 +138,6 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
   ui->msg_set_pos = remote_ui_msg_set_pos;
   ui->event = remote_ui_event;
   ui->inspect = remote_ui_inspect;
-  ui->win_move_cursor = remote_ui_win_move_cursor;
 
   memset(ui->ui_ext, 0, sizeof(ui->ui_ext));
 
@@ -149,6 +150,9 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
   }
 
   if (ui->ui_ext[kUIWindows]) {
+    if (ext_win_ui == NULL) {
+      ext_win_ui = ui;
+    }
     ui->ui_ext[kUIMultigrid] = true;
   }
 
@@ -705,16 +709,18 @@ static void remote_ui_inspect(UI *ui, Dictionary *info)
   PUT(*info, "chan", INTEGER_OBJ((Integer)data->channel_id));
 }
 
-static void remote_ui_win_move_cursor(UI *ui, Integer direction, Integer count)
+Integer ui_win_move_cursor(Integer direction, Integer count)
 {
+  UI *ui = ext_win_ui;
   Array args = ARRAY_DICT_INIT;
-  UIData *data = ui->data;
+  UIData *data;
   Error error = ERROR_INIT;
   typval_T rettv;
 
-  if (!ui_is_external(kUIWindows)) {
-    return;
+  if (!ui_is_external(kUIWindows) || ui == NULL) {
+    abort();  // this should never happen
   }
+  data = ui->data;
 
   ADD(args, INTEGER_OBJ(direction));
   ADD(args, INTEGER_OBJ(count));
@@ -726,7 +732,7 @@ static void remote_ui_win_move_cursor(UI *ui, Integer direction, Integer count)
     api_set_error(&error, kErrorTypeException, "%s", error.msg);
     api_clear_error(&error);
     api_free_object(result);
-    return;
+    return 0;
   }
 
   if (!object_to_vim(result, &rettv, &error)) {
@@ -734,10 +740,12 @@ static void remote_ui_win_move_cursor(UI *ui, Integer direction, Integer count)
                   "Error converting the call result: %s", error.msg);
     api_clear_error(&error);
     api_free_object(result);
-    return;
+    return 0;
   }
 
   if (rettv.v_type == VAR_NUMBER) {
-    ui_win_goto((Window)rettv.vval.v_number, &error);
+    return (Integer)rettv.vval.v_number;
+  } else {
+    return 0;
   }
 }

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -136,6 +136,7 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
   ui->msg_set_pos = remote_ui_msg_set_pos;
   ui->event = remote_ui_event;
   ui->inspect = remote_ui_inspect;
+  ui->win_move_cursor = remote_ui_win_move_cursor;
 
   memset(ui->ui_ext, 0, sizeof(ui->ui_ext));
 
@@ -702,4 +703,41 @@ static void remote_ui_inspect(UI *ui, Dictionary *info)
 {
   UIData *data = ui->data;
   PUT(*info, "chan", INTEGER_OBJ((Integer)data->channel_id));
+}
+
+static void remote_ui_win_move_cursor(UI *ui, Integer direction, Integer count)
+{
+  Array args = ARRAY_DICT_INIT;
+  UIData *data = ui->data;
+  Error error = ERROR_INIT;
+  typval_T rettv;
+
+  if (!ui_is_external(kUIWindows)) {
+    return;
+  }
+
+  ADD(args, INTEGER_OBJ(direction));
+  ADD(args, INTEGER_OBJ(count));
+
+  Object result = rpc_send_call(data->channel_id, "win_move_cursor", args,
+                                &error);
+
+  if (ERROR_SET(&error)) {
+    api_set_error(&error, kErrorTypeException, "%s", error.msg);
+    api_clear_error(&error);
+    api_free_object(result);
+    return;
+  }
+
+  if (!object_to_vim(result, &rettv, &error)) {
+    api_set_error(&error, kErrorTypeValidation,
+                  "Error converting the call result: %s", error.msg);
+    api_clear_error(&error);
+    api_free_object(result);
+    return;
+  }
+
+  if (rettv.v_type == VAR_NUMBER) {
+    ui_win_goto((Window)rettv.vval.v_number, &error);
+  }
 }

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -147,6 +147,10 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
     }
   }
 
+  if (ui->ui_ext[kUIWindows]) {
+    ui->ui_ext[kUIMultigrid] = true;
+  }
+
   if (ui->ui_ext[kUIHlState] || ui->ui_ext[kUIMultigrid]) {
     ui->ui_ext[kUILinegrid] = true;
   }

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -129,9 +129,7 @@ void win_rotate(Integer win, Integer grid, Integer direction, Integer count)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_move(Integer win, Integer grid, Integer flags)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
-void win_height_set(Integer win, Integer grid, Integer height)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
-void win_width_set(Integer win, Integer grid, Integer width)
+void win_resize(Integer win, Integer grid, Integer width, Integer height)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 
 void popupmenu_show(Array items, Integer selected,

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -115,6 +115,25 @@ void win_close(Integer grid)
 void msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char)
   FUNC_API_SINCE(6) FUNC_API_BRIDGE_IMPL FUNC_API_COMPOSITOR_IMPL;
 
+void win_split(Integer win1, Integer grid1, Integer win2, Integer grid2, Integer flags)
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+void win_move_cursor(Integer direction, Integer count)
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+void win_exchange(Integer win, Integer grid, Integer count)
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+void win_resize_equal (void)
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+void win_close(Integer win, Integer grid)
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+void win_rotate(Integer win, Integer grid, Integer direction, Integer count)
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+void win_move(Integer win, Integer grid, Integer flags)
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+void win_height_set(Integer win, Integer grid, Integer height)
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+void win_width_set(Integer win, Integer grid, Integer width)
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+
 void popupmenu_show(Array items, Integer selected,
                     Integer row, Integer col, Integer grid)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -118,7 +118,7 @@ void msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char)
 void win_split(Integer win1, Integer grid1, Integer win2, Integer grid2, Integer flags)
   FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
 void win_move_cursor(Integer direction, Integer count)
-  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_IMPL;
 void win_exchange(Integer win, Integer grid, Integer count)
   FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
 void win_resize_equal (void)

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -123,8 +123,6 @@ void win_exchange(Integer win, Integer grid, Integer count)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_resize_equal (void)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
-void win_close(Integer win, Integer grid)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_rotate(Integer win, Integer grid, Integer direction, Integer count)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_move(Integer win, Integer grid, Integer flags)

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -118,7 +118,7 @@ void msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char)
 void win_split(Integer win1, Integer grid1, Integer win2, Integer grid2, Integer flags)
   FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
 void win_move_cursor(Integer direction, Integer count)
-  FUNC_API_SINCE(4) FUNC_API_REMOTE_IMPL;
+  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
 void win_exchange(Integer win, Integer grid, Integer count)
   FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
 void win_resize_equal (void)

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -116,23 +116,23 @@ void msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char)
   FUNC_API_SINCE(6) FUNC_API_BRIDGE_IMPL FUNC_API_COMPOSITOR_IMPL;
 
 void win_split(Integer win1, Integer grid1, Integer win2, Integer grid2, Integer flags)
-  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_move_cursor(Integer direction, Integer count)
-  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_exchange(Integer win, Integer grid, Integer count)
-  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_resize_equal (void)
-  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_close(Integer win, Integer grid)
-  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_rotate(Integer win, Integer grid, Integer direction, Integer count)
-  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_move(Integer win, Integer grid, Integer flags)
-  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_height_set(Integer win, Integer grid, Integer height)
-  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_width_set(Integer win, Integer grid, Integer width)
-  FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 
 void popupmenu_show(Array items, Integer selected,
                     Integer row, Integer col, Integer grid)

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -498,9 +498,3 @@ void ui_grid_resize(handle_T grid_handle, int width, int height, Error *error)
     win_set_inner_size(wp);
   }
 }
-
-void ui_win_goto(handle_T win_handle, Error *error)
-{
-  win_T *win = find_window_by_handle(win_handle, error);
-  win_goto(win);
-}

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -498,3 +498,9 @@ void ui_grid_resize(handle_T grid_handle, int width, int height, Error *error)
     win_set_inner_size(wp);
   }
 }
+
+void ui_win_goto(handle_T win_handle, Error *error)
+{
+  win_T *win = find_window_by_handle(win_handle, error);
+  win_goto(win);
+}

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -36,6 +36,7 @@
 #include "nvim/ui_compositor.h"
 #include "nvim/window.h"
 #include "nvim/cursor_shape.h"
+#include "nvim/msgpack_rpc/channel.h"
 #ifdef FEAT_TUI
 # include "nvim/tui/tui.h"
 #else
@@ -59,6 +60,7 @@ static int busy = 0;
 static bool pending_mode_info_update = false;
 static bool pending_mode_update = false;
 static handle_T cursor_grid_handle = DEFAULT_GRID_HANDLE;
+static uint64_t ext_win_ui_channel = 0;
 
 #if MIN_LOG_LEVEL > DEBUG_LOG_LEVEL
 # define UI_LOG(funname)
@@ -496,5 +498,44 @@ void ui_grid_resize(handle_T grid_handle, int width, int height, Error *error)
     wp->w_height_request = (int)MAX(height, 0);
     wp->w_width_request = (int)MAX(width, 0);
     win_set_inner_size(wp);
+  }
+}
+
+void ui_set_ext_win_channel(uint64_t channel_id)
+{
+  ext_win_ui_channel = channel_id;
+}
+
+Integer ui_win_move_cursor(Integer direction, Integer count)
+{
+  Array args = ARRAY_DICT_INIT;
+  Error error = ERROR_INIT;
+  typval_T rettv;
+
+  ADD(args, INTEGER_OBJ(direction));
+  ADD(args, INTEGER_OBJ(count));
+
+  Object result = rpc_send_call(ext_win_ui_channel, "win_move_cursor", args,
+                                &error);
+
+  if (ERROR_SET(&error)) {
+    EMSG2(_("Error invoking win_move_cursor: %s"), error.msg);
+    api_clear_error(&error);
+    api_free_object(result);
+    return 0;
+  }
+
+  if (result.type != kObjectTypeInteger) {
+    api_set_error(&error, kErrorTypeValidation,
+                  "Error converting the call result: %s", error.msg);
+    api_clear_error(&error);
+    api_free_object(result);
+    return 0;
+  }
+
+  if (rettv.v_type == VAR_NUMBER) {
+    return (Integer)rettv.vval.v_number;
+  } else {
+    return 0;
   }
 }

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -21,6 +21,7 @@ typedef enum {
   kUIHlState,
   kUITermColors,
   kUIFloatDebug,
+  kUIWindows,
   kUIExtCount,
 } UIExtension;
 
@@ -35,6 +36,7 @@ EXTERN const char *ui_ext_names[] INIT(= {
   "ext_hlstate",
   "ext_termcolors",
   "_debug_float",
+  "ext_windows",
 });
 
 typedef struct ui_t UI;

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -63,7 +63,6 @@ UI *ui_bridge_attach(UI *ui, ui_main_fn ui_main, event_scheduler scheduler)
   rv->bridge.set_icon = ui_bridge_set_icon;
   rv->bridge.option_set = ui_bridge_option_set;
   rv->bridge.raw_line = ui_bridge_raw_line;
-  rv->bridge.win_move_cursor = ui_bridge_win_move_cursor;
   rv->scheduler = scheduler;
 
   for (UIExtension i = 0; (int)i < kUIExtCount; i++) {

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -63,6 +63,7 @@ UI *ui_bridge_attach(UI *ui, ui_main_fn ui_main, event_scheduler scheduler)
   rv->bridge.set_icon = ui_bridge_set_icon;
   rv->bridge.option_set = ui_bridge_option_set;
   rv->bridge.raw_line = ui_bridge_raw_line;
+  rv->bridge.win_move_cursor = ui_bridge_win_move_cursor;
   rv->scheduler = scheduler;
 
   for (UIExtension i = 0; (int)i < kUIExtCount; i++) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4266,7 +4266,7 @@ win_T *win_horz_neighbor(tabpage_T *tp, win_T *wp, bool left, long count)
 
   if (ui_is_external(kUIWindows)) {
     // TODO(utkarshme): 0, 1 for vertical directions. 2, 3 for horizontal.
-    ui_call_win_move_cursor(2 + left, count);
+    ui_call_win_move_cursor(2 + left, count);  // calls win_goto
     return;
   }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4975,7 +4975,7 @@ void win_setheight_win(int height, win_T *win)
     frame_setheight(win->w_frame, height + win->w_status_height);
     win_grid_alloc(win);
   } else {
-    ui_call_win_height_set(win->handle, win->w_grid.handle, height);
+    ui_call_win_resize(win->handle, win->w_grid.handle, win->w_width, height);
   }
 
     // recompute the window positions
@@ -5186,7 +5186,7 @@ void win_setwidth_win(int width, win_T *wp)
     (void)win_comp_pos();
     redraw_all_later(NOT_VALID);
   } else {
-    ui_call_win_width_set(wp->handle, wp->w_grid.handle, width);
+    ui_call_win_resize(wp->handle, wp->w_grid.handle, width, wp->w_height);
   }
 }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -979,6 +979,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
   int minheight;
   int wmh1;
   bool did_set_fraction = false;
+  int ext_windows = ui_is_external(kUIWindows);
 
   if (flags & WSP_TOP) {
     oldwin = firstwin;
@@ -1000,8 +1001,9 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
     need_status = STATUS_HEIGHT;
   }
 
-
-  if (flags & WSP_VERT) {
+  if (ext_windows) {
+    // do nothing
+  } else if (flags & WSP_VERT) {
     int wmw1;
     int minwidth;
 
@@ -1204,7 +1206,9 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
     if (wp == NULL)
       return FAIL;
 
-    new_frame(wp);
+    if (!ext_windows) {
+      new_frame(wp);
+    }
 
     /* make the contents of the new window the same as the current one */
     win_init(wp, curwin, flags);
@@ -1218,152 +1222,154 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
   /*
    * Reorganise the tree of frames to insert the new window.
    */
-  if (flags & (WSP_TOP | WSP_BOT)) {
-    if ((topframe->fr_layout == FR_COL && (flags & WSP_VERT) == 0)
-        || (topframe->fr_layout == FR_ROW && (flags & WSP_VERT) != 0)) {
-      curfrp = topframe->fr_child;
-      if (flags & WSP_BOT)
-        while (curfrp->fr_next != NULL)
-          curfrp = curfrp->fr_next;
-    } else
-      curfrp = topframe;
-    before = (flags & WSP_TOP);
-  } else {
-    curfrp = oldwin->w_frame;
-    if (flags & WSP_BELOW)
-      before = FALSE;
-    else if (flags & WSP_ABOVE)
-      before = TRUE;
-    else if (flags & WSP_VERT)
-      before = !p_spr;
+  if (!ext_windows) {
+    if (flags & (WSP_TOP | WSP_BOT)) {
+      if ((topframe->fr_layout == FR_COL && (flags & WSP_VERT) == 0)
+          || (topframe->fr_layout == FR_ROW && (flags & WSP_VERT) != 0)) {
+        curfrp = topframe->fr_child;
+        if (flags & WSP_BOT)
+          while (curfrp->fr_next != NULL)
+            curfrp = curfrp->fr_next;
+      } else
+        curfrp = topframe;
+      before = (flags & WSP_TOP);
+    } else {
+      curfrp = oldwin->w_frame;
+      if (flags & WSP_BELOW)
+        before = FALSE;
+      else if (flags & WSP_ABOVE)
+        before = TRUE;
+      else if (flags & WSP_VERT)
+        before = !p_spr;
+      else
+        before = !p_sb;
+    }
+    if (curfrp->fr_parent == NULL || curfrp->fr_parent->fr_layout != layout) {
+      /* Need to create a new frame in the tree to make a branch. */
+      frp = xcalloc(1, sizeof(frame_T));
+      *frp = *curfrp;
+      curfrp->fr_layout = layout;
+      frp->fr_parent = curfrp;
+      frp->fr_next = NULL;
+      frp->fr_prev = NULL;
+      curfrp->fr_child = frp;
+      curfrp->fr_win = NULL;
+      curfrp = frp;
+      if (frp->fr_win != NULL) {
+        oldwin->w_frame = frp;
+      } else {
+        FOR_ALL_FRAMES(frp, frp->fr_child) {
+          frp->fr_parent = curfrp;
+        }
+      }
+    }
+
+    if (new_wp == NULL)
+      frp = wp->w_frame;
     else
-      before = !p_sb;
-  }
-  if (curfrp->fr_parent == NULL || curfrp->fr_parent->fr_layout != layout) {
-    /* Need to create a new frame in the tree to make a branch. */
-    frp = xcalloc(1, sizeof(frame_T));
-    *frp = *curfrp;
-    curfrp->fr_layout = layout;
-    frp->fr_parent = curfrp;
-    frp->fr_next = NULL;
-    frp->fr_prev = NULL;
-    curfrp->fr_child = frp;
-    curfrp->fr_win = NULL;
-    curfrp = frp;
-    if (frp->fr_win != NULL) {
-      oldwin->w_frame = frp;
-    } else {
-      FOR_ALL_FRAMES(frp, frp->fr_child) {
-        frp->fr_parent = curfrp;
-      }
-    }
-  }
+      frp = new_wp->w_frame;
+    frp->fr_parent = curfrp->fr_parent;
 
-  if (new_wp == NULL)
-    frp = wp->w_frame;
-  else
-    frp = new_wp->w_frame;
-  frp->fr_parent = curfrp->fr_parent;
-
-  /* Insert the new frame at the right place in the frame list. */
-  if (before)
-    frame_insert(curfrp, frp);
-  else
-    frame_append(curfrp, frp);
-
-  /* Set w_fraction now so that the cursor keeps the same relative
-   * vertical position. */
-  if (!did_set_fraction) {
-    set_fraction(oldwin);
-  }
-  wp->w_fraction = oldwin->w_fraction;
-
-  if (flags & WSP_VERT) {
-    wp->w_p_scr = curwin->w_p_scr;
-
-    if (need_status) {
-      win_new_height(oldwin, oldwin->w_height - 1);
-      oldwin->w_status_height = need_status;
-    }
-    if (flags & (WSP_TOP | WSP_BOT)) {
-      /* set height and row of new window to full height */
-      wp->w_winrow = tabline_height();
-      win_new_height(wp, curfrp->fr_height - (p_ls > 0));
-      wp->w_status_height = (p_ls > 0);
-    } else {
-      /* height and row of new window is same as current window */
-      wp->w_winrow = oldwin->w_winrow;
-      win_new_height(wp, oldwin->w_height);
-      wp->w_status_height = oldwin->w_status_height;
-    }
-    frp->fr_height = curfrp->fr_height;
-
-    /* "new_size" of the current window goes to the new window, use
-     * one column for the vertical separator */
-    win_new_width(wp, new_size);
+    /* Insert the new frame at the right place in the frame list. */
     if (before)
-      wp->w_vsep_width = 1;
-    else {
-      wp->w_vsep_width = oldwin->w_vsep_width;
-      oldwin->w_vsep_width = 1;
+      frame_insert(curfrp, frp);
+    else
+      frame_append(curfrp, frp);
+
+    /* Set w_fraction now so that the cursor keeps the same relative
+    * vertical position. */
+    if (!did_set_fraction) {
+      set_fraction(oldwin);
     }
-    if (flags & (WSP_TOP | WSP_BOT)) {
+    wp->w_fraction = oldwin->w_fraction;
+
+    if (flags & WSP_VERT) {
+      wp->w_p_scr = curwin->w_p_scr;
+
+      if (need_status) {
+        win_new_height(oldwin, oldwin->w_height - 1);
+        oldwin->w_status_height = need_status;
+      }
+      if (flags & (WSP_TOP | WSP_BOT)) {
+        /* set height and row of new window to full height */
+        wp->w_winrow = tabline_height();
+        win_new_height(wp, curfrp->fr_height - (p_ls > 0));
+        wp->w_status_height = (p_ls > 0);
+      } else {
+        /* height and row of new window is same as current window */
+        wp->w_winrow = oldwin->w_winrow;
+        win_new_height(wp, oldwin->w_height);
+        wp->w_status_height = oldwin->w_status_height;
+      }
+      frp->fr_height = curfrp->fr_height;
+
+      /* "new_size" of the current window goes to the new window, use
+      * one column for the vertical separator */
+      win_new_width(wp, new_size);
+      if (before)
+        wp->w_vsep_width = 1;
+      else {
+        wp->w_vsep_width = oldwin->w_vsep_width;
+        oldwin->w_vsep_width = 1;
+      }
+      if (flags & (WSP_TOP | WSP_BOT)) {
+        if (flags & WSP_BOT)
+          frame_add_vsep(curfrp);
+        /* Set width of neighbor frame */
+        frame_new_width(curfrp, curfrp->fr_width
+            - (new_size + ((flags & WSP_TOP) != 0)), flags & WSP_TOP,
+            FALSE);
+      } else
+        win_new_width(oldwin, oldwin->w_width - (new_size + 1));
+      if (before) {       /* new window left of current one */
+        wp->w_wincol = oldwin->w_wincol;
+        oldwin->w_wincol += new_size + 1;
+      } else              /* new window right of current one */
+        wp->w_wincol = oldwin->w_wincol + oldwin->w_width + 1;
+      frame_fix_width(oldwin);
+      frame_fix_width(wp);
+    } else {
+      /* width and column of new window is same as current window */
+      if (flags & (WSP_TOP | WSP_BOT)) {
+        wp->w_wincol = 0;
+        win_new_width(wp, Columns);
+        wp->w_vsep_width = 0;
+      } else {
+        wp->w_wincol = oldwin->w_wincol;
+        win_new_width(wp, oldwin->w_width);
+        wp->w_vsep_width = oldwin->w_vsep_width;
+      }
+      frp->fr_width = curfrp->fr_width;
+
+      /* "new_size" of the current window goes to the new window, use
+      * one row for the status line */
+      win_new_height(wp, new_size);
+      if (flags & (WSP_TOP | WSP_BOT)) {
+        int new_fr_height = curfrp->fr_height - new_size;
+
+        if (!((flags & WSP_BOT) && p_ls == 0)) {
+          new_fr_height -= STATUS_HEIGHT;
+        }
+        frame_new_height(curfrp, new_fr_height, flags & WSP_TOP, false);
+      } else {
+        win_new_height(oldwin, oldwin_height - (new_size + STATUS_HEIGHT));
+      }
+      if (before) {       // new window above current one
+        wp->w_winrow = oldwin->w_winrow;
+        wp->w_status_height = STATUS_HEIGHT;
+        oldwin->w_winrow += wp->w_height + STATUS_HEIGHT;
+      } else {          /* new window below current one */
+        wp->w_winrow = oldwin->w_winrow + oldwin->w_height + STATUS_HEIGHT;
+        wp->w_status_height = oldwin->w_status_height;
+        if (!(flags & WSP_BOT)) {
+          oldwin->w_status_height = STATUS_HEIGHT;
+        }
+      }
       if (flags & WSP_BOT)
-        frame_add_vsep(curfrp);
-      /* Set width of neighbor frame */
-      frame_new_width(curfrp, curfrp->fr_width
-          - (new_size + ((flags & WSP_TOP) != 0)), flags & WSP_TOP,
-          FALSE);
-    } else
-      win_new_width(oldwin, oldwin->w_width - (new_size + 1));
-    if (before) {       /* new window left of current one */
-      wp->w_wincol = oldwin->w_wincol;
-      oldwin->w_wincol += new_size + 1;
-    } else              /* new window right of current one */
-      wp->w_wincol = oldwin->w_wincol + oldwin->w_width + 1;
-    frame_fix_width(oldwin);
-    frame_fix_width(wp);
-  } else {
-    /* width and column of new window is same as current window */
-    if (flags & (WSP_TOP | WSP_BOT)) {
-      wp->w_wincol = 0;
-      win_new_width(wp, Columns);
-      wp->w_vsep_width = 0;
-    } else {
-      wp->w_wincol = oldwin->w_wincol;
-      win_new_width(wp, oldwin->w_width);
-      wp->w_vsep_width = oldwin->w_vsep_width;
+        frame_add_statusline(curfrp);
+      frame_fix_height(wp);
+      frame_fix_height(oldwin);
     }
-    frp->fr_width = curfrp->fr_width;
-
-    /* "new_size" of the current window goes to the new window, use
-     * one row for the status line */
-    win_new_height(wp, new_size);
-    if (flags & (WSP_TOP | WSP_BOT)) {
-      int new_fr_height = curfrp->fr_height - new_size;
-
-      if (!((flags & WSP_BOT) && p_ls == 0)) {
-        new_fr_height -= STATUS_HEIGHT;
-      }
-      frame_new_height(curfrp, new_fr_height, flags & WSP_TOP, false);
-    } else {
-      win_new_height(oldwin, oldwin_height - (new_size + STATUS_HEIGHT));
-    }
-    if (before) {       // new window above current one
-      wp->w_winrow = oldwin->w_winrow;
-      wp->w_status_height = STATUS_HEIGHT;
-      oldwin->w_winrow += wp->w_height + STATUS_HEIGHT;
-    } else {          /* new window below current one */
-      wp->w_winrow = oldwin->w_winrow + oldwin->w_height + STATUS_HEIGHT;
-      wp->w_status_height = oldwin->w_status_height;
-      if (!(flags & WSP_BOT)) {
-        oldwin->w_status_height = STATUS_HEIGHT;
-      }
-    }
-    if (flags & WSP_BOT)
-      frame_add_statusline(curfrp);
-    frame_fix_height(wp);
-    frame_fix_height(oldwin);
   }
 
   if (flags & (WSP_TOP | WSP_BOT))
@@ -1410,6 +1416,13 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
 
   // Keep same changelist position in new window.
   wp->w_changelistidx = oldwin->w_changelistidx;
+
+  grid_assign_handle(&wp->w_grid);
+  if (ext_windows) {
+    // TODO(utkarshme): Correct the flags according to the direction in docs
+    ui_call_win_split(curwin->handle, curwin->w_grid.handle, wp->handle,
+                      wp->w_grid.handle, flags);
+  }
 
   /*
    * make the new window the current window
@@ -1628,6 +1641,10 @@ static void win_exchange(long Prenum)
     return;
   }
 
+  if (ui_is_external(kUIWindows)) {
+    ui_call_win_exchange(curwin->handle, curwin->w_grid.handle, Prenum);
+    return;
+  }
 
   /*
    * find window to exchange with
@@ -1722,6 +1739,11 @@ static void win_rotate(bool upwards, int count)
     return;
   }
 
+  if (ui_is_external(kUIWindows)) {
+    ui_call_win_rotate(curwin->handle, curwin->w_grid.handle, upwards, count);
+    return;
+  }
+
   // Check if all frames in this row/col have one window.
   FOR_ALL_FRAMES(frp, curwin->w_frame->fr_parent->fr_child) {
     if (frp->fr_win == NULL) {
@@ -1807,10 +1829,15 @@ static void win_totop(int size, int flags)
       ui_call_win_hide(curwin->w_grid.handle);
       win_free_grid(curwin, false);
     }
+  } else if (ui_is_external(kUIWindows)) {
+    // TODO(utkarshme): Correct the flags according to the direction in docs
+    ui_call_win_move(curwin->handle, curwin->w_grid.handle, flags);
+    return;
   } else {
     // Remove the window and frame from the tree of frames.
     (void)winframe_remove(curwin, &dir, NULL);
   }
+
   win_remove(curwin, NULL);
   last_status(FALSE);       /* may need to remove last status line */
   (void)win_comp_pos();     /* recompute window positions */
@@ -1892,6 +1919,11 @@ void win_equal(
                                    // 'b' for both, 0 for using p_ead
 )
 {
+  if (ui_is_external(kUIWindows)) {
+    ui_call_win_resize_equal();
+    return;
+  }
+
   if (dir == 0)
     dir = *p_ead;
   win_equal_rec(next_curwin == NULL ? curwin : next_curwin, current,
@@ -2382,7 +2414,9 @@ int win_close(win_T *win, bool free_buf)
     clear_snapshot(curtab, SNAP_HELP_IDX);
   }
 
-  if (win == curwin) {
+  if (ui_is_external(kUIWindows)) {
+    ui_call_win_close(win->handle, win->w_grid.handle);
+  } else if (win == curwin) {
     /*
      * Guess which window is going to be the new current window.
      * This may change because of the autocommands (sigh).
@@ -2560,7 +2594,10 @@ int win_close(win_T *win, bool free_buf)
    * If last window has a status line now and we don't want one,
    * remove the status line.
    */
-  last_status(FALSE);
+  // TODO(utkarshme): This eventually uses frames. Figure it out.
+  if (!ui_is_external(kUIWindows)) {
+    last_status(FALSE);
+  }
 
   /* After closing the help window, try restoring the window layout from
    * before it was opened. */
@@ -2664,6 +2701,7 @@ static win_T *win_free_mem(
   win_T       *wp;
 
   if (!win->w_floating) {
+    // TODO(utkarshme): kUIWindows
     // Remove the window and its frame from the tree of frames.
     frp = win->w_frame;
     wp = winframe_remove(win, dirp, tp);
@@ -3529,10 +3567,12 @@ static int win_alloc_firstwin(win_T *oldwin)
     RESET_BINDING(curwin);
   }
 
-  new_frame(curwin);
-  topframe = curwin->w_frame;
-  topframe->fr_width = Columns;
-  topframe->fr_height = Rows - p_ch;
+  if (!ui_is_external(kUIWindows)) {
+    new_frame(curwin);
+    topframe = curwin->w_frame;
+    topframe->fr_width = Columns;
+    topframe->fr_height = Rows - p_ch;
+  }
 
   return OK;
 }
@@ -3556,10 +3596,13 @@ void win_init_size(void)
 {
   firstwin->w_height = ROWS_AVAIL;
   firstwin->w_height_inner = firstwin->w_height;
-  topframe->fr_height = ROWS_AVAIL;
   firstwin->w_width = Columns;
   firstwin->w_width_inner = firstwin->w_width;
-  topframe->fr_width = Columns;
+
+  if (!ui_is_external(kUIWindows)) {
+    topframe->fr_height = ROWS_AVAIL;
+    topframe->fr_width = Columns;
+  }
 }
 
 /*
@@ -4128,6 +4171,11 @@ win_T *win_vert_neighbor(tabpage_T *tp, win_T *wp, bool up, long count)
   frame_T     *nfr;
   frame_T     *foundfr;
 
+  if (ui_is_external(kUIWindows)) {
+    ui_call_win_move_cursor(up, count);
+    return;
+  }
+
   foundfr = wp->w_frame;
 
   if (wp->w_floating) {
@@ -4208,6 +4256,12 @@ win_T *win_horz_neighbor(tabpage_T *tp, win_T *wp, bool left, long count)
   frame_T     *fr;
   frame_T     *nfr;
   frame_T     *foundfr;
+
+  if (ui_is_external(kUIWindows)) {
+    // TODO(utkarshme): 0, 1 for vertical directions. 2, 3 for horizontal.
+    ui_call_win_move_cursor(2 + left, count);
+    return;
+  }
 
   foundfr = wp->w_frame;
 
@@ -4807,7 +4861,9 @@ int win_comp_pos(void)
   int row = tabline_height();
   int col = 0;
 
-  frame_comp_pos(topframe, &row, &col);
+  if (!ui_is_external(kUIWindows)) {
+    frame_comp_pos(topframe, &row, &col);
+  }
 
   // Too often, but when we support anchoring floats to split windows,
   // this will be needed
@@ -4888,8 +4944,12 @@ void win_setheight_win(int height, win_T *win)
     win->w_float_config.height = height;
     win_config_float(win, win->w_float_config);
     redraw_win_later(win, NOT_VALID);
-  } else {
+  } else if (!ui_is_external(kUIWindows)) {
     frame_setheight(win->w_frame, height + win->w_status_height);
+    win_grid_alloc(win);
+  } else {
+    ui_call_win_height_set(win->handle, win->w_grid.handle, height);
+  }
 
     // recompute the window positions
     int row = win_comp_pos();
@@ -5091,14 +5151,16 @@ void win_setwidth_win(int width, win_T *wp)
     wp->w_float_config.width = width;
     win_config_float(wp, wp->w_float_config);
     redraw_win_later(wp, NOT_VALID);
-  } else {
+  } else if (!ui_is_external(kUIWindows)) {
     frame_setwidth(wp->w_frame, width + wp->w_vsep_width);
+    win_grid_alloc(wp);
 
     // recompute the window positions
     (void)win_comp_pos();
     redraw_all_later(NOT_VALID);
+  } else {
+    ui_call_win_width_set(wp->handle, wp->w_grid.handle, width);
   }
-
 }
 
 /*
@@ -5283,95 +5345,99 @@ void win_drag_status_line(win_T *dragwin, int offset)
 
   fr = dragwin->w_frame;
   curfr = fr;
-  if (fr != topframe) {         /* more than one window */
-    fr = fr->fr_parent;
-    /* When the parent frame is not a column of frames, its parent should
-     * be. */
-    if (fr->fr_layout != FR_COL) {
-      curfr = fr;
-      if (fr != topframe)       /* only a row of windows, may drag statusline */
-        fr = fr->fr_parent;
-    }
-  }
-
-  /* If this is the last frame in a column, may want to resize the parent
-   * frame instead (go two up to skip a row of frames). */
-  while (curfr != topframe && curfr->fr_next == NULL) {
-    if (fr != topframe)
+  if (ui_is_external(kUIWindows)) {
+    /*win_call_height_inc(dragwin, offset);*/
+  } else {
+    if (fr != topframe) {         /* more than one window */
       fr = fr->fr_parent;
-    curfr = fr;
-    if (fr != topframe)
-      fr = fr->fr_parent;
-  }
-
-  if (offset < 0) { /* drag up */
-    up = TRUE;
-    offset = -offset;
-    /* sum up the room of the current frame and above it */
-    if (fr == curfr) {
-      /* only one window */
-      room = fr->fr_height - frame_minheight(fr, NULL);
-    } else {
-      room = 0;
-      for (fr = fr->fr_child;; fr = fr->fr_next) {
-        room += fr->fr_height - frame_minheight(fr, NULL);
-        if (fr == curfr)
-          break;
+      /* When the parent frame is not a column of frames, its parent should
+      * be. */
+      if (fr->fr_layout != FR_COL) {
+        curfr = fr;
+        if (fr != topframe)       /* only a row of windows, may drag statusline */
+          fr = fr->fr_parent;
       }
     }
-    fr = curfr->fr_next;                /* put fr at frame that grows */
-  } else { /* drag down */
-    up = FALSE;
+
+    /* If this is the last frame in a column, may want to resize the parent
+    * frame instead (go two up to skip a row of frames). */
+    while (curfr != topframe && curfr->fr_next == NULL) {
+      if (fr != topframe)
+        fr = fr->fr_parent;
+      curfr = fr;
+      if (fr != topframe)
+        fr = fr->fr_parent;
+    }
+
+    if (offset < 0) { /* drag up */
+      up = TRUE;
+      offset = -offset;
+      /* sum up the room of the current frame and above it */
+      if (fr == curfr) {
+        /* only one window */
+        room = fr->fr_height - frame_minheight(fr, NULL);
+      } else {
+        room = 0;
+        for (fr = fr->fr_child;; fr = fr->fr_next) {
+          room += fr->fr_height - frame_minheight(fr, NULL);
+          if (fr == curfr)
+            break;
+        }
+      }
+      fr = curfr->fr_next;                /* put fr at frame that grows */
+    } else { /* drag down */
+      up = FALSE;
+      /*
+      * Only dragging the last status line can reduce p_ch.
+      */
+      room = Rows - cmdline_row;
+      if (curfr->fr_next == NULL)
+        room -= 1;
+      else
+        room -= p_ch;
+      if (room < 0)
+        room = 0;
+      // sum up the room of frames below of the current one
+      FOR_ALL_FRAMES(fr, curfr->fr_next) {
+        room += fr->fr_height - frame_minheight(fr, NULL);
+      }
+      fr = curfr;  // put fr at window that grows
+    }
+
+    if (room < offset)            /* Not enough room */
+      offset = room;              /* Move as far as we can */
+    if (offset <= 0)
+      return;
+
     /*
-     * Only dragging the last status line can reduce p_ch.
-     */
-    room = Rows - cmdline_row;
-    if (curfr->fr_next == NULL)
-      room -= 1;
-    else
-      room -= p_ch;
-    if (room < 0)
-      room = 0;
-    // sum up the room of frames below of the current one
-    FOR_ALL_FRAMES(fr, curfr->fr_next) {
-      room += fr->fr_height - frame_minheight(fr, NULL);
-    }
-    fr = curfr;  // put fr at window that grows
-  }
+    * Grow frame fr by "offset" lines.
+    * Doesn't happen when dragging the last status line up.
+    */
+    if (fr != NULL)
+      frame_new_height(fr, fr->fr_height + offset, up, FALSE);
 
-  if (room < offset)            /* Not enough room */
-    offset = room;              /* Move as far as we can */
-  if (offset <= 0)
-    return;
-
-  /*
-   * Grow frame fr by "offset" lines.
-   * Doesn't happen when dragging the last status line up.
-   */
-  if (fr != NULL)
-    frame_new_height(fr, fr->fr_height + offset, up, FALSE);
-
-  if (up)
-    fr = curfr;                 /* current frame gets smaller */
-  else
-    fr = curfr->fr_next;        /* next frame gets smaller */
-
-  /*
-   * Now make the other frames smaller.
-   */
-  while (fr != NULL && offset > 0) {
-    n = frame_minheight(fr, NULL);
-    if (fr->fr_height - offset <= n) {
-      offset -= fr->fr_height - n;
-      frame_new_height(fr, n, !up, FALSE);
-    } else {
-      frame_new_height(fr, fr->fr_height - offset, !up, FALSE);
-      break;
-    }
     if (up)
-      fr = fr->fr_prev;
+      fr = curfr;                 /* current frame gets smaller */
     else
-      fr = fr->fr_next;
+      fr = curfr->fr_next;        /* next frame gets smaller */
+
+    /*
+    * Now make the other frames smaller.
+    */
+    while (fr != NULL && offset > 0) {
+      n = frame_minheight(fr, NULL);
+      if (fr->fr_height - offset <= n) {
+        offset -= fr->fr_height - n;
+        frame_new_height(fr, n, !up, FALSE);
+      } else {
+        frame_new_height(fr, fr->fr_height - offset, !up, FALSE);
+        break;
+      }
+      if (up)
+        fr = fr->fr_prev;
+      else
+        fr = fr->fr_next;
+    }
   }
   row = win_comp_pos();
   grid_fill(&default_grid, row, cmdline_row, 0, Columns, ' ', ' ', 0);
@@ -5398,90 +5464,94 @@ void win_drag_vsep_line(win_T *dragwin, int offset)
   int left;             /* if TRUE, drag separator line left, otherwise right */
   int n;
 
-  fr = dragwin->w_frame;
-  if (fr == topframe)           /* only one window (cannot happen?) */
-    return;
-  curfr = fr;
-  fr = fr->fr_parent;
-  /* When the parent frame is not a row of frames, its parent should be. */
-  if (fr->fr_layout != FR_ROW) {
-    if (fr == topframe)         /* only a column of windows (cannot happen?) */
+  if (ui_is_external(kUIWindows)) {
+    /*win_call_width_inc(dragwin, offset);*/
+  } else {
+    fr = dragwin->w_frame;
+    if (fr == topframe)           /* only one window (cannot happen?) */
       return;
     curfr = fr;
     fr = fr->fr_parent;
-  }
-
-  /* If this is the last frame in a row, may want to resize a parent
-   * frame instead. */
-  while (curfr->fr_next == NULL) {
-    if (fr == topframe)
-      break;
-    curfr = fr;
-    fr = fr->fr_parent;
-    if (fr != topframe) {
+    /* When the parent frame is not a row of frames, its parent should be. */
+    if (fr->fr_layout != FR_ROW) {
+      if (fr == topframe)         /* only a column of windows (cannot happen?) */
+        return;
       curfr = fr;
       fr = fr->fr_parent;
     }
-  }
 
-  if (offset < 0) { /* drag left */
-    left = TRUE;
-    offset = -offset;
-    /* sum up the room of the current frame and left of it */
-    room = 0;
-    for (fr = fr->fr_child;; fr = fr->fr_next) {
-      room += fr->fr_width - frame_minwidth(fr, NULL);
-      if (fr == curfr)
+    /* If this is the last frame in a row, may want to resize a parent
+    * frame instead. */
+    while (curfr->fr_next == NULL) {
+      if (fr == topframe)
         break;
+      curfr = fr;
+      fr = fr->fr_parent;
+      if (fr != topframe) {
+        curfr = fr;
+        fr = fr->fr_parent;
+      }
     }
-    fr = curfr->fr_next;                /* put fr at frame that grows */
-  } else { /* drag right */
-    left = FALSE;
-    /* sum up the room of frames right of the current one */
-    room = 0;
-    FOR_ALL_FRAMES(fr, curfr->fr_next) {
-      room += fr->fr_width - frame_minwidth(fr, NULL);
+
+    if (offset < 0) { /* drag left */
+      left = TRUE;
+      offset = -offset;
+      /* sum up the room of the current frame and left of it */
+      room = 0;
+      for (fr = fr->fr_child;; fr = fr->fr_next) {
+        room += fr->fr_width - frame_minwidth(fr, NULL);
+        if (fr == curfr)
+          break;
+      }
+      fr = curfr->fr_next;                /* put fr at frame that grows */
+    } else { /* drag right */
+      left = FALSE;
+      /* sum up the room of frames right of the current one */
+      room = 0;
+      FOR_ALL_FRAMES(fr, curfr->fr_next) {
+        room += fr->fr_width - frame_minwidth(fr, NULL);
+      }
+      fr = curfr;  // put fr at window that grows
     }
-    fr = curfr;  // put fr at window that grows
-  }
-  assert(fr);
+    assert(fr);
 
-  // Not enough room
-  if (room < offset) {
-    offset = room;  // Move as far as we can
-  }
-
-  // No room at all, quit.
-  if (offset <= 0) {
-    return;
-  }
-
-  if (fr == NULL) {
-    return;  // Safety check, should not happen.
-  }
-
-  /* grow frame fr by offset lines */
-  frame_new_width(fr, fr->fr_width + offset, left, FALSE);
-
-  /* shrink other frames: current and at the left or at the right */
-  if (left)
-    fr = curfr;                 /* current frame gets smaller */
-  else
-    fr = curfr->fr_next;        /* next frame gets smaller */
-
-  while (fr != NULL && offset > 0) {
-    n = frame_minwidth(fr, NULL);
-    if (fr->fr_width - offset <= n) {
-      offset -= fr->fr_width - n;
-      frame_new_width(fr, n, !left, FALSE);
-    } else {
-      frame_new_width(fr, fr->fr_width - offset, !left, FALSE);
-      break;
+    // Not enough room
+    if (room < offset) {
+      offset = room;  // Move as far as we can
     }
+
+    // No room at all, quit.
+    if (offset <= 0) {
+      return;
+    }
+
+    if (fr == NULL) {
+      return;  // Safety check, should not happen.
+    }
+
+    /* grow frame fr by offset lines */
+    frame_new_width(fr, fr->fr_width + offset, left, FALSE);
+
+    /* shrink other frames: current and at the left or at the right */
     if (left)
-      fr = fr->fr_prev;
+      fr = curfr;                 /* current frame gets smaller */
     else
-      fr = fr->fr_next;
+      fr = curfr->fr_next;        /* next frame gets smaller */
+
+    while (fr != NULL && offset > 0) {
+      n = frame_minwidth(fr, NULL);
+      if (fr->fr_width - offset <= n) {
+        offset -= fr->fr_width - n;
+        frame_new_width(fr, n, !left, FALSE);
+      } else {
+        frame_new_width(fr, fr->fr_width - offset, !left, FALSE);
+        break;
+      }
+      if (left)
+        fr = fr->fr_prev;
+      else
+        fr = fr->fr_next;
+    }
   }
   (void)win_comp_pos();
   redraw_all_later(NOT_VALID);

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2421,6 +2421,8 @@ int win_close(win_T *win, bool free_buf)
 
   if (ui_is_external(kUIWindows)) {
     ui_call_win_close(win->handle, win->w_grid.handle);
+    // If not handling windows, send the next (or prev) window in the list
+    wp = win->w_next == NULL ? win->w_prev : win->w_next;
   } else if (win == curwin) {
     /*
      * Guess which window is going to be the new current window.
@@ -2578,7 +2580,8 @@ int win_close(win_T *win, bool free_buf)
   }
 
   if (!was_floating) {
-    if (!curwin->w_floating && p_ea && (*p_ead == 'b' || *p_ead == dir)) {
+    if (!curwin->w_floating && !ui_is_external(kUIWindows)
+        && p_ea && (*p_ead == 'b' || *p_ead == dir)) {
       // If the frame of the closed window contains the new current window,
       // only resize that frame.  Otherwise resize all windows.
       win_equal(curwin, curwin->w_frame->fr_parent == win_frame, dir);
@@ -2606,7 +2609,7 @@ int win_close(win_T *win, bool free_buf)
 
   /* After closing the help window, try restoring the window layout from
    * before it was opened. */
-  if (help_window)
+  if (!ui_is_external(kUIWindows) && help_window)
     restore_snapshot(SNAP_HELP_IDX, close_curwin);
 
   curwin->w_pos_changed = true;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2374,7 +2374,11 @@ int win_close(win_T *win, bool free_buf)
   int dir;
   bool help_window = false;
   tabpage_T   *prev_curtab = curtab;
-  frame_T *win_frame = win->w_floating ? NULL : win->w_frame->fr_parent;
+  frame_T *win_frame;
+
+  if (!ui_is_external(kUIWindows)) {
+    win_frame = win->w_floating ? NULL : win->w_frame->fr_parent;
+  }
 
   if (last_window() && !win->w_floating) {
     EMSG(_("E444: Cannot close last window"));
@@ -2700,8 +2704,11 @@ static win_T *win_free_mem(
   frame_T     *frp;
   win_T       *wp;
 
-  if (!win->w_floating) {
+  if (ui_is_external(kUIWindows)) {
     // TODO(utkarshme): kUIWindows
+    // If not handling windows, send the next (or prev) window in the list
+    wp = win->w_next == NULL ? win->w_prev : win->w_next;
+  } else if (!win->w_floating) {
     // Remove the window and its frame from the tree of frames.
     frp = win->w_frame;
     wp = winframe_remove(win, dirp, tp);

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -984,7 +984,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
   int minheight;
   int wmh1;
   bool did_set_fraction = false;
-  int ext_windows = ui_is_external(kUIWindows);
+  int ext_windows = ui_has(kUIWindows);
 
   if (flags & WSP_TOP) {
     oldwin = firstwin;
@@ -1645,7 +1645,7 @@ static void win_exchange(long Prenum)
     return;
   }
 
-  if (ui_is_external(kUIWindows)) {
+  if (ui_has(kUIWindows)) {
     ui_call_win_exchange(curwin->handle, curwin->w_grid.handle, Prenum);
     return;
   }
@@ -1743,7 +1743,7 @@ static void win_rotate(bool upwards, int count)
     return;
   }
 
-  if (ui_is_external(kUIWindows)) {
+  if (ui_has(kUIWindows)) {
     ui_call_win_rotate(curwin->handle, curwin->w_grid.handle, upwards, count);
     return;
   }
@@ -1833,7 +1833,7 @@ static void win_totop(int size, int flags)
       ui_call_win_hide(curwin->w_grid.handle);
       win_free_grid(curwin, false);
     }
-  } else if (ui_is_external(kUIWindows)) {
+  } else if (ui_has(kUIWindows)) {
     // TODO(utkarshme): Correct the flags according to the direction in docs
     ui_call_win_move(curwin->handle, curwin->w_grid.handle, UI_WIN_FLAGS(flags));
     return;
@@ -1923,7 +1923,7 @@ void win_equal(
                                    // 'b' for both, 0 for using p_ead
 )
 {
-  if (ui_is_external(kUIWindows)) {
+  if (ui_has(kUIWindows)) {
     ui_call_win_resize_equal();
     return;
   }
@@ -2380,7 +2380,7 @@ int win_close(win_T *win, bool free_buf)
   tabpage_T   *prev_curtab = curtab;
   frame_T *win_frame;
 
-  if (!ui_is_external(kUIWindows)) {
+  if (!ui_has(kUIWindows)) {
     win_frame = win->w_floating ? NULL : win->w_frame->fr_parent;
   }
 
@@ -2422,8 +2422,8 @@ int win_close(win_T *win, bool free_buf)
     clear_snapshot(curtab, SNAP_HELP_IDX);
   }
 
-  if (ui_is_external(kUIWindows)) {
-    ui_call_win_close(win->handle, win->w_grid.handle);
+  if (ui_has(kUIWindows)) {
+    ui_call_win_close(win->w_grid.handle);
     // If not handling windows, send the next (or prev) window in the list
     wp = win->w_next == NULL ? win->w_prev : win->w_next;
   } else if (win == curwin) {
@@ -2583,7 +2583,7 @@ int win_close(win_T *win, bool free_buf)
   }
 
   if (!was_floating) {
-    if (!curwin->w_floating && !ui_is_external(kUIWindows)
+    if (!curwin->w_floating && !ui_has(kUIWindows)
         && p_ea && (*p_ead == 'b' || *p_ead == dir)) {
       // If the frame of the closed window contains the new current window,
       // only resize that frame.  Otherwise resize all windows.
@@ -2606,13 +2606,13 @@ int win_close(win_T *win, bool free_buf)
    * remove the status line.
    */
   // TODO(utkarshme): This eventually uses frames. Figure it out.
-  if (!ui_is_external(kUIWindows)) {
+  if (!ui_has(kUIWindows)) {
     last_status(FALSE);
   }
 
   /* After closing the help window, try restoring the window layout from
    * before it was opened. */
-  if (!ui_is_external(kUIWindows) && help_window)
+  if (!ui_has(kUIWindows) && help_window)
     restore_snapshot(SNAP_HELP_IDX, close_curwin);
 
   curwin->w_pos_changed = true;
@@ -2711,7 +2711,7 @@ static win_T *win_free_mem(
   frame_T     *frp;
   win_T       *wp;
 
-  if (ui_is_external(kUIWindows)) {
+  if (ui_has(kUIWindows)) {
     // TODO(utkarshme): kUIWindows
     // If not handling windows, send the next (or prev) window in the list
     wp = win->w_next == NULL ? win->w_prev : win->w_next;
@@ -3581,7 +3581,7 @@ static int win_alloc_firstwin(win_T *oldwin)
     RESET_BINDING(curwin);
   }
 
-  if (!ui_is_external(kUIWindows)) {
+  if (!ui_has(kUIWindows)) {
     new_frame(curwin);
     topframe = curwin->w_frame;
     topframe->fr_width = Columns;
@@ -3613,7 +3613,7 @@ void win_init_size(void)
   firstwin->w_width = Columns;
   firstwin->w_width_inner = firstwin->w_width;
 
-  if (!ui_is_external(kUIWindows)) {
+  if (!ui_has(kUIWindows)) {
     topframe->fr_height = ROWS_AVAIL;
     topframe->fr_width = Columns;
   }
@@ -4185,7 +4185,7 @@ win_T *win_vert_neighbor(tabpage_T *tp, win_T *wp, bool up, long count)
   frame_T     *nfr;
   frame_T     *foundfr;
 
-  if (ui_is_external(kUIWindows)) {
+  if (ui_has(kUIWindows)) {
     handle_T win_handle = ui_win_move_cursor(up, count);
     Error error = ERROR_INIT;
     win_T *win = find_window_by_handle(win_handle, &error);
@@ -4193,7 +4193,7 @@ win_T *win_vert_neighbor(tabpage_T *tp, win_T *wp, bool up, long count)
     if (win != NULL) {
       win_goto(win);
     }
-    return;
+    return win;
   }
 
   foundfr = wp->w_frame;
@@ -4278,7 +4278,7 @@ win_T *win_horz_neighbor(tabpage_T *tp, win_T *wp, bool left, long count)
   frame_T     *nfr;
   frame_T     *foundfr;
 
-  if (ui_is_external(kUIWindows)) {
+  if (ui_has(kUIWindows)) {
     // "0" and "1" is reserved for top, bottom directions. left, right are 2, 3
     handle_T win_handle = ui_win_move_cursor(2 + left, count);
     Error error = ERROR_INIT;
@@ -4287,7 +4287,7 @@ win_T *win_horz_neighbor(tabpage_T *tp, win_T *wp, bool left, long count)
     if (win != NULL) {
       win_goto(win);
     }
-    return;
+    return win;
   }
 
   foundfr = wp->w_frame;
@@ -4888,7 +4888,7 @@ int win_comp_pos(void)
   int row = tabline_height();
   int col = 0;
 
-  if (!ui_is_external(kUIWindows)) {
+  if (!ui_has(kUIWindows)) {
     frame_comp_pos(topframe, &row, &col);
   }
 
@@ -4971,27 +4971,25 @@ void win_setheight_win(int height, win_T *win)
     win->w_float_config.height = height;
     win_config_float(win, win->w_float_config);
     redraw_win_later(win, NOT_VALID);
-  } else if (!ui_is_external(kUIWindows)) {
+  } else if (!ui_has(kUIWindows)) {
     frame_setheight(win->w_frame, height + win->w_status_height);
     win_grid_alloc(win);
   } else {
     ui_call_win_resize(win->handle, win->w_grid.handle, win->w_width, height);
   }
 
-    // recompute the window positions
-    int row = win_comp_pos();
+  // recompute the window positions
+  int row = win_comp_pos();
 
-    // If there is extra space created between the last window and the command
-    // line, clear it.
-    if (full_screen && msg_scrolled == 0 && row < cmdline_row) {
-      grid_fill(&default_grid, row, cmdline_row, 0, Columns, ' ', ' ', 0);
-    }
-    cmdline_row = row;
-    msg_row = row;
-    msg_col = 0;
-    redraw_all_later(NOT_VALID);
+  // If there is extra space created between the last window and the command
+  // line, clear it.
+  if (full_screen && msg_scrolled == 0 && row < cmdline_row) {
+    grid_fill(&default_grid, row, cmdline_row, 0, Columns, ' ', ' ', 0);
   }
-
+  cmdline_row = row;
+  msg_row = row;
+  msg_col = 0;
+  redraw_all_later(NOT_VALID);
 }
 
 
@@ -5178,7 +5176,7 @@ void win_setwidth_win(int width, win_T *wp)
     wp->w_float_config.width = width;
     win_config_float(wp, wp->w_float_config);
     redraw_win_later(wp, NOT_VALID);
-  } else if (!ui_is_external(kUIWindows)) {
+  } else if (!ui_has(kUIWindows)) {
     frame_setwidth(wp->w_frame, width + wp->w_vsep_width);
     win_grid_alloc(wp);
 
@@ -5372,7 +5370,7 @@ void win_drag_status_line(win_T *dragwin, int offset)
 
   fr = dragwin->w_frame;
   curfr = fr;
-  if (ui_is_external(kUIWindows)) {
+  if (ui_has(kUIWindows)) {
     /*win_call_height_inc(dragwin, offset);*/
   } else {
     if (fr != topframe) {         /* more than one window */
@@ -5491,7 +5489,7 @@ void win_drag_vsep_line(win_T *dragwin, int offset)
   int left;             /* if TRUE, drag separator line left, otherwise right */
   int n;
 
-  if (ui_is_external(kUIWindows)) {
+  if (ui_has(kUIWindows)) {
     /*win_call_width_inc(dragwin, offset);*/
   } else {
     fr = dragwin->w_frame;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -65,6 +65,10 @@
 
 # define ROWS_AVAIL (Rows - p_ch - tabline_height())
 
+#define UI_WIN_FLAGS(FLAGS) \
+  ((flags & WSP_VERT) == 0 \
+  ? ((flags & WSP_BOT) || (flags & WSP_BELOW) || !(flags & WSP_ABOVE) ? 0 : 1 )\
+  : ((flags & WSP_BOT) || (flags & WSP_BELOW) || !(flags & WSP_ABOVE) ? 2 : 3 ))
 
 static char *m_onlyone = N_("Already only one window");
 
@@ -1420,9 +1424,8 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
 
   grid_assign_handle(&wp->w_grid);
   if (ext_windows) {
-    // TODO(utkarshme): Correct the flags according to the direction in docs
     ui_call_win_split(curwin->handle, curwin->w_grid.handle, wp->handle,
-                      wp->w_grid.handle, flags);
+                      wp->w_grid.handle, UI_WIN_FLAGS(flags));
   }
 
   /*
@@ -1832,7 +1835,7 @@ static void win_totop(int size, int flags)
     }
   } else if (ui_is_external(kUIWindows)) {
     // TODO(utkarshme): Correct the flags according to the direction in docs
-    ui_call_win_move(curwin->handle, curwin->w_grid.handle, flags);
+    ui_call_win_move(curwin->handle, curwin->w_grid.handle, UI_WIN_FLAGS(flags));
     return;
   } else {
     // Remove the window and frame from the tree of frames.

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7,6 +7,7 @@
 
 #include "nvim/api/private/handle.h"
 #include "nvim/api/private/helpers.h"
+#include "nvim/api/ui.h"
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/window.h"
@@ -4179,7 +4180,13 @@ win_T *win_vert_neighbor(tabpage_T *tp, win_T *wp, bool up, long count)
   frame_T     *foundfr;
 
   if (ui_is_external(kUIWindows)) {
-    ui_call_win_move_cursor(up, count);
+    handle_T win_handle = ui_win_move_cursor(up, count);
+    Error error = ERROR_INIT;
+    win_T *win = find_window_by_handle(win_handle, &error);
+    api_clear_error(&error);
+    if (win != NULL) {
+      win_goto(win);
+    }
     return;
   }
 
@@ -4233,6 +4240,7 @@ win_T *win_vert_neighbor(tabpage_T *tp, win_T *wp, bool up, long count)
       nfr = fr;
     }
   }
+
 end:
   return foundfr != NULL ? foundfr->fr_win : NULL;
 }
@@ -4265,8 +4273,14 @@ win_T *win_horz_neighbor(tabpage_T *tp, win_T *wp, bool left, long count)
   frame_T     *foundfr;
 
   if (ui_is_external(kUIWindows)) {
-    // TODO(utkarshme): 0, 1 for vertical directions. 2, 3 for horizontal.
-    ui_call_win_move_cursor(2 + left, count);  // calls win_goto
+    // "0" and "1" is reserved for top, bottom directions. left, right are 2, 3
+    handle_T win_handle = ui_win_move_cursor(2 + left, count);
+    Error error = ERROR_INIT;
+    win_T *win = find_window_by_handle(win_handle, &error);
+    api_clear_error(&error);
+    if (win != NULL) {
+      win_goto(win);
+    }
     return;
   }
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1590,6 +1590,7 @@ describe('API', function()
           ext_hlstate = false,
           ext_termcolors = false,
           ext_messages = false,
+          ext_windows = screen._options.ext_windows or false,
           height = 4,
           rgb = true,
           override = true,

--- a/test/functional/ui/ext_win_spec.lua
+++ b/test/functional/ui/ext_win_spec.lua
@@ -1,0 +1,465 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local spawn, set_session, clear = helpers.spawn, helpers.set_session, helpers.clear
+local feed, command = helpers.feed, helpers.command
+local eq, iswin = helpers.eq, helpers.iswin
+
+describe('In ext-win mode', function()
+  local screen
+  local nvim_argv = {helpers.nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
+                     '--cmd', 'set shortmess+=I background=light noswapfile belloff= noshowcmd noruler',
+                     '--embed'}
+
+  before_each(function()
+    local screen_nvim = spawn(nvim_argv)
+    set_session(screen_nvim)
+    screen = Screen.new(15, 5)
+    -- TODO(utkarshme): should not have to set ext_multigrid
+    screen:attach({ext_windows=true})
+    screen:set_default_attr_ids({
+      [1] = {bold = true, reverse = true},
+      [2] = {bold = true, foreground = Screen.colors.Blue1},
+      [3] = {reverse = true},
+      [4] = {bold = true},
+      [5] = {background = Screen.colors.LightGrey, underline = true},
+      [6] = {bold = true, foreground = Screen.colors.Magenta}
+    })
+    screen:set_on_event_handler(function(name, data)
+      if name == 'win_split' then
+        local win1, grid1, win2, grid2, flags = unpack(data)
+        screen.split = {
+          old_win = {win1, grid1},
+          new_win = {win2, grid2},
+          flags = flags
+          -- must call resize_grid for the split grid
+          -- and set a dummy win_pos (locally) for the window
+        }
+        screen:_handle_win_pos(grid2, win2, 0, 0, 0, 0)
+      elseif name == 'win_rotate' then
+        local win, grid, direction, count = unpack(data)
+        screen.rotate = {
+          win = win,
+          grid = grid,
+          direction = direction,
+          count = count
+        }
+      elseif name == 'win_exchange' then
+        local win, grid, count = unpack(data)
+        screen.exchange = {
+          win = win,
+          grid = grid,
+          count = count
+        }
+      elseif name == 'win_move' then
+        local win, grid, flags = unpack(data)
+        screen.win_move = {
+          win = win,
+          grid = grid,
+          flags = flags
+        }
+      elseif name == 'win_resize_equal' then
+        screen.got_resize_equal = true
+      elseif name == 'win_height_set' then
+        local win, grid, height = unpack(data)
+        screen.height_set = {
+          win = win, grid = grid, height = height
+        }
+      elseif name == 'win_width_set' then
+        local win, grid, width = unpack(data)
+        screen.width_set = {
+          win = win, grid = grid, width = width
+        }
+      elseif name == 'win_close' then
+        local win, grid = unpack(data)
+        screen.win_close = {
+          win = win, grid = grid
+        }
+      end
+    end)
+    screen:set_on_request_handler(function(method, args)
+      if method == 'win_move_cursor' then
+        local direction, count = unpack(args)
+        screen.move_cursor = {
+          direction = direction,
+          count = count
+        }
+      end
+    end)
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  it('default initial screen is correct', function()
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {1:[No Name]      }|
+                       |
+      ## grid 2
+        ^               |
+        {2:~              }|
+        {2:~              }|
+      ]])
+  end)
+
+  describe(':(v)split', function()
+    it('creates empty grids', function()
+      command('split')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        eq(0, screen.split.flags)
+        eq(2, screen.split.old_win[2])
+        eq(3, screen.split.new_win[2])
+      end)
+      screen:try_resize_grid(screen.split.old_win[2], 10, 5)
+      screen:try_resize_grid(screen.split.new_win[2], 10, 5)
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                  |
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+      ## grid 3
+        ^          |
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+      ]])
+
+      command('vsplit')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                  |
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+      ## grid 3
+                  |
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+      ## grid 4
+      ]], nil, nil, function()
+        eq(2, screen.split.flags)
+        iswin(screen.split.old_win[1])
+        eq(3, screen.split.old_win[2])
+        iswin(screen.split.new_win[1])
+        eq(4, screen.split.new_win[2])
+      end)
+      screen:try_resize_grid(screen.split.old_win[2], 10, 10)
+      screen:try_resize_grid(screen.split.new_win[2], 10, 10)
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                  |
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+      ## grid 3
+                  |
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+      ## grid 4
+        ^          |
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+        {2:~         }|
+      ]])
+    end)
+  end)
+
+  describe(':resize', function()
+    it('sends height_set event', function()
+      command('resize 5')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {1:[No Name]      }|
+                       |
+      ## grid 2
+        ^               |
+        {2:~              }|
+        {2:~              }|
+      ]], nil, nil, function()
+        iswin(screen.height_set.win)
+        eq(2, screen.height_set.grid)
+        eq(5, screen.height_set.height)
+      end)
+    end)
+  end)
+
+  describe(':vertical resize', function()
+    it('sends width_set event', function()
+      command('vertical resize 5')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {1:[No Name]      }|
+                       |
+      ## grid 2
+        ^               |
+        {2:~              }|
+        {2:~              }|
+      ]], nil, nil, function()
+        iswin(screen.width_set.win)
+        eq(2, screen.width_set.grid)
+        eq(5, screen.width_set.width)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-r', function()
+    it('sends rotate event', function()
+      command('split')
+      feed('<C-W>r')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        iswin(screen.rotate.win)
+        eq(3, screen.rotate.grid)
+        eq(1, screen.rotate.count)
+        eq(0, screen.rotate.direction)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-x', function()
+    it('sends exchange event', function()
+      command('split')
+      feed('<C-W>x')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        iswin(screen.exchange.win)
+        eq(3, screen.exchange.grid)
+        eq(0, screen.exchange.count)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-J', function()
+    it('sends win_move event', function()
+      command('split')
+      feed('<C-W>J')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        iswin(screen.win_move.win)
+        eq(3, screen.win_move.grid)
+        eq(1, screen.win_move.flags)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W T', function()
+    it('sends win_close and creates a new grid', function()
+      command('split')
+      feed('<C-W>T')
+      screen:expect([[
+      ## grid 1
+        {4: Name]  Name] }{5:X}|
+        [4:---------------]|
+        [4:---------------]|
+        [4:---------------]|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 4
+        ^               |
+        {2:~              }|
+        {2:~              }|
+      ]], nil, nil, function()
+        iswin(screen.win_close.win)
+        eq(3, screen.win_close.grid)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W =', function()
+    it('sends resize_equal event', function()
+      command('split')
+      feed('<C-W>=')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        eq(true, screen.got_resize_equal)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-+', function()
+    it('sends win_height_set event', function()
+      feed('<C-W>+')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {1:[No Name]      }|
+                       |
+      ## grid 2
+        ^               |
+        {2:~              }|
+        {2:~              }|
+      ]], nil, nil, function()
+        iswin(screen.height_set.win)
+        eq(2, screen.height_set.grid)
+        eq(4, screen.height_set.height)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-j', function()
+    it('sends move_cursor event', function()
+      command('split')
+      feed('<C-W>j')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]], nil, nil, function()
+        eq(0, screen.move_cursor.direction)
+        eq(1, screen.move_cursor.count)
+      end)
+    end)
+  end)
+
+  describe('CTRL_W-c', function()
+    it('sends close event', function()
+      command('split')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {3:[No Name]      }|
+                       |
+      ## grid 2
+                       |
+        {2:~              }|
+        {2:~              }|
+      ## grid 3
+      ]])
+      feed('<C-W>c')
+      screen:expect([[
+      ## grid 1
+        [2:---------------]|
+        [2:---------------]|
+        [2:---------------]|
+        {1:[No Name]      }|
+                       |
+      ## grid 2
+        ^               |
+        {2:~              }|
+        {2:~              }|
+      ]], nil, nil, function()
+        iswin(screen.win_close.win)
+        eq(3, screen.win_close.grid)
+      end)
+    end)
+  end)
+end)

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -24,6 +24,7 @@ describe('ui receives option updates', function()
       ext_popupmenu=false,
       ext_tabline=false,
       ext_wildmenu=false,
+      ext_windows=false,
       ext_linegrid=false,
       ext_hlstate=false,
       ext_multigrid=false,

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -221,6 +221,14 @@ function Screen:attach(options, session)
     options.ext_linegrid = true
   end
 
+  if options.ext_windows then
+    options.ext_multigrid = true
+  end
+  if options.ext_multigrid then
+    options.ext_linegrid = true
+    self._multigrid = true
+  end
+
   self._session = session
   self._options = options
   self._clear_attrs = (options.ext_linegrid and {{},{}}) or {}
@@ -636,6 +644,10 @@ end
 
 function Screen:set_on_event_handler(callback)
   self._on_event = callback
+end
+
+function Screen:set_on_request_handler(callback)
+  self._on_request = callback
 end
 
 function Screen:_handle_resize(width, height)


### PR DESCRIPTION
Nvim manages all the window layout by keeping a frame structure for it. UIs might want to take greater control over the layout and navigation which could not be provided in the current scenario.

This work delegates handling of these actions to external UIs (if they choose to by setting `ext_windows`) and gets rid of the frames internally. UIs have control over how to interpret `wincmd`s which can be pretty useful to UI rich text editors like Oni.

This work build on top of previous work by @bfredl in #8221 and me in #8455. Ref #8320.