### PR TITLE
Fix standout mode

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -459,8 +459,8 @@ static void update_attrs(UI *ui, HlAttrs attrs)
   bool underline = attr & (HL_UNDERLINE), undercurl = attr & (HL_UNDERCURL);
 
   if (unibi_get_str(data->ut, unibi_set_attributes)) {
-    if (bold || reverse || underline || undercurl) {
-      UNIBI_SET_NUM_VAR(data->params[0], 0);   // standout
+    if (bold || reverse || underline || undercurl || standout) {
+      UNIBI_SET_NUM_VAR(data->params[0], standout);
       UNIBI_SET_NUM_VAR(data->params[1], underline || undercurl);
       UNIBI_SET_NUM_VAR(data->params[2], reverse);
       UNIBI_SET_NUM_VAR(data->params[3], 0);   // blink
@@ -520,7 +520,7 @@ static void update_attrs(UI *ui, HlAttrs attrs)
   }
 
   data->default_attr = fg == -1 && bg == -1
-    && !bold && !italic && !underline && !undercurl && !reverse;
+    && !bold && !italic && !underline && !undercurl && !reverse && !standout;
 }
 
 static void final_column_wrap(UI *ui)


### PR DESCRIPTION
It was not working for me in different terminals.

This patch makes it work in the same way like reverse.

Test:

    :hi jediUsage cterm=standout | hi jediUsage


I've used the following to see what is going on:

```diff
diff --git i/src/nvim/tui/tui.c w/src/nvim/tui/tui.c
index f1db9aed0..bf59b64c7 100644
--- i/src/nvim/tui/tui.c
+++ w/src/nvim/tui/tui.c
@@ -458,8 +458,12 @@ static void update_attrs(UI *ui, HlAttrs attrs)
   bool standout = attr & HL_STANDOUT;
   bool underline = attr & (HL_UNDERLINE), undercurl = attr & (HL_UNDERCURL);
 
+  ILOG("update_attrs: standout=%d", standout);
+
   if (unibi_get_str(data->ut, unibi_set_attributes)) {
+    ILOG("update_attrs: 1");
     if (bold || reverse || underline || undercurl || standout) {
+      ILOG("update_attrs: 2");
       UNIBI_SET_NUM_VAR(data->params[0], standout);
       UNIBI_SET_NUM_VAR(data->params[1], underline || undercurl);
       UNIBI_SET_NUM_VAR(data->params[2], reverse);
@@ -471,9 +475,11 @@ static void update_attrs(UI *ui, HlAttrs attrs)
       UNIBI_SET_NUM_VAR(data->params[8], 0);   // alternate character set
       unibi_out(ui, unibi_set_attributes);
     } else if (!data->default_attr) {
+      ILOG("update_attrs: 3");
       unibi_out(ui, unibi_exit_attribute_mode);
     }
   } else {
+    ILOG("update_attrs: 4");
     if (!data->default_attr) {
       unibi_out(ui, unibi_exit_attribute_mode);
     }
@@ -484,6 +490,7 @@ static void update_attrs(UI *ui, HlAttrs attrs)
       unibi_out(ui, unibi_enter_underline_mode);
     }
     if (standout) {
+      ILOG("update_attrs: 5");
       unibi_out(ui, unibi_enter_standout_mode);
     }
     if (reverse) {
```