### PR TITLE
[RFC] Man Plugin: Improve C highlighting

### DIFF
--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -30,17 +30,28 @@ endif
 if !exists('b:man_sect')
   call man#init_pager()
 endif
-if b:man_sect =~# '^[23]'
+if b:man_sect =~# '^[023]'
+  syntax case match
   syntax include @c $VIMRUNTIME/syntax/c.vim
   syntax match manCFuncDefinition display '\<\h\w*\>\ze\(\s\|\n\)*(' contained
+  syntax match manSentence display '\%(^ \{3,7}\u\|\.  \u\)\_.\{-}
+        \\%(-$\|\.$\|:$\)\|
+        \ \{3,7}\a.*\%(\.\|:\)$' contained contains=manReference
   syntax region manSynopsis start='^\%(
         \SYNOPSIS\|
         \SYNTAX\|
         \SINTASSI\|
         \SKŁADNIA\|
         \СИНТАКСИС\|
-        \書式\)$' end='^\%(\S.*\)\=\S$' keepend contains=manSectionHeading,@c,manCFuncDefinition
+        \書式\)$' end='^\%(\S.*\)\=\S$' keepend contains=manSentence,manSectionHeading,@c,manCFuncDefinition
   highlight default link manCFuncDefinition Function
+
+  syntax region manExample start='^EXAMPLES\=$' end='^\%(\S.*\)\=\S$' keepend contains=manSentence,manSectionHeading,manSubHeading,@c,manCFuncDefinition
+
+  " XXX: groupthere doesn't seem to work
+  syntax sync minlines=500
+  "syntax sync match manSyncExample groupthere manExample '^EXAMPLES\=$'
+  "syntax sync match manSyncExample groupthere NONE '^\%(EXAMPLES\=\)\@!\%(\S.*\)\=\S$'
 endif
 
 " Prevent everything else from matching the last line


### PR DESCRIPTION
I added a new region for Example sections because those sections are usually a page long, while Synopsis sections are usually a few lines. This should only sync to the start of `EXAMPLE[S]`

I'm not sure if `group[t]here` works.

You can see it in action on all man pages with Example sections with this shell command:
```bash
MANPAGER="nvim -c 'set ft=man' -" man -IKs 0:2:3 EXAMPLE
```