### PR TITLE
[RFC] vim-patch:8.0.0{671,714,720,722,948,1020,1048,1507}

### DIFF
--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1464,7 +1464,7 @@ int get_digraph(int cmdline)
 
     if (cmdline) {
       if ((char2cells(c) == 1) && (cmdline_star == 0)) {
-        putcmdline(c, TRUE);
+        putcmdline(c, true);
       }
     } else {
       add_to_showcmd(c);

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7883,8 +7883,12 @@ static void ins_mousescroll(int dir)
     row = mouse_row;
     col = mouse_col;
 
-    /* find the window at the pointer coordinates */
-    curwin = mouse_find_win(&row, &col);
+    // find the window at the pointer coordinates
+    win_T *const wp = mouse_find_win(&row, &col);
+    if (wp == NULL) {
+      return;
+    }
+    curwin = wp;
     curbuf = curwin->w_buffer;
   }
   if (curwin == old_curwin)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9466,9 +9466,12 @@ static void f_getchar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       int winnr = 1;
 
       if (row >= 0 && col >= 0) {
-        /* Find the window at the mouse coordinates and compute the
-         * text position. */
+        // Find the window at the mouse coordinates and compute the
+        // text position.
         win = mouse_find_win(&row, &col);
+        if (win == NULL) {
+          return;
+        }
         (void)mouse_comp_pos(win, &row, &col, &lnum);
         for (wp = firstwin; wp != win; wp = wp->w_next)
           ++winnr;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3068,7 +3068,7 @@ void cmdline_ui_flush(void)
  * right when "shift" is TRUE.  Used for CTRL-V, CTRL-K, etc.
  * "c" must be printable (fit in one display cell)!
  */
-void putcmdline(int c, int shift)
+void putcmdline(const int c, const bool shift)
 {
   if (cmd_silent) {
     return;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -196,6 +196,7 @@ static int new_cmdpos;          /* position set by set_cmdline_pos() */
 
 static int extra_char = NUL;    // extra character to display when redrawing
                                 // the command line
+static bool extra_char_shift;
 
 /// currently displayed block of context
 static Array cmdline_block = ARRAY_DICT_INIT;
@@ -1340,7 +1341,6 @@ static int command_line_handle_key(CommandLineState *s)
 
   case Ctrl_R:                        // insert register
     putcmdline('"', true);
-    extra_char = '"';
     no_mapping++;
     s->i = s->c = plain_vgetc();      // CTRL-R <char>
     if (s->i == Ctrl_O) {
@@ -1703,7 +1703,6 @@ static int command_line_handle_key(CommandLineState *s)
   case Ctrl_Q:
     s->ignore_drag_release = true;
     putcmdline('^', true);
-    extra_char = '^';
     s->c = get_literal();                 // get next (two) character(s)
     s->do_abbr = false;                   // don't do abbreviation now
     extra_char = NUL;
@@ -1723,7 +1722,6 @@ static int command_line_handle_key(CommandLineState *s)
   case Ctrl_K:
     s->ignore_drag_release = true;
     putcmdline('?', true);
-    extra_char = '?';
     s->c = get_digraph(true);
     extra_char = NUL;
 
@@ -3092,6 +3090,8 @@ void putcmdline(int c, int shift)
   }
   cursorcmd();
   ui_cursor_shape();
+  extra_char = c;
+  extra_char_shift = shift;
 }
 
 /// Undo a putcmdline(c, FALSE).
@@ -3109,6 +3109,7 @@ void unputcmdline(void)
   msg_no_more = false;
   cursorcmd();
   ui_cursor_shape();
+  extra_char = NUL;
 }
 
 /*
@@ -3480,7 +3481,7 @@ void redrawcmd(void)
 
   set_cmdspos_cursor();
   if (extra_char != NUL) {
-    putcmdline(extra_char, true);
+    putcmdline(extra_char, extra_char_shift);
   }
 
   /*

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -428,15 +428,12 @@ void flush_buffers(int flush_typeahead)
   while (read_readbuffers(TRUE) != NUL) {
   }
 
-  if (flush_typeahead) {            /* remove all typeahead */
-    /*
-     * We have to get all characters, because we may delete the first part
-     * of an escape sequence.
-     * In an xterm we get one char at a time and we have to get them all.
-     */
-    while (inchar(typebuf.tb_buf, typebuf.tb_buflen - 1, 10L,
-               typebuf.tb_change_cnt) != 0)
-      ;
+  if (flush_typeahead) {            // remove all typeahead
+    // We have to get all characters, because we may delete the first part
+    // of an escape sequence.
+    // In an xterm we get one char at a time and we have to get them all.
+    while (inchar(typebuf.tb_buf, typebuf.tb_buflen - 1, 10L) != 0) {
+    }
     typebuf.tb_off = MAXMAPLEN;
     typebuf.tb_len = 0;
     // Reset the flag that text received from a client or from feedkeys()
@@ -1693,22 +1690,20 @@ static int vgetorpeek(int advance)
           os_breakcheck();                      /* check for CTRL-C */
         keylen = 0;
         if (got_int) {
-          /* flush all input */
-          c = inchar(typebuf.tb_buf, typebuf.tb_buflen - 1, 0L,
-              typebuf.tb_change_cnt);
-          /*
-           * If inchar() returns TRUE (script file was active) or we
-           * are inside a mapping, get out of insert mode.
-           * Otherwise we behave like having gotten a CTRL-C.
-           * As a result typing CTRL-C in insert mode will
-           * really insert a CTRL-C.
-           */
+          // flush all input
+          c = inchar(typebuf.tb_buf, typebuf.tb_buflen - 1, 0L);
+          // If inchar() returns TRUE (script file was active) or we
+          // are inside a mapping, get out of insert mode.
+          // Otherwise we behave like having gotten a CTRL-C.
+          // As a result typing CTRL-C in insert mode will
+          // really insert a CTRL-C.
           if ((c || typebuf.tb_maplen)
-              && (State & (INSERT + CMDLINE)))
+              && (State & (INSERT + CMDLINE))) {
             c = ESC;
-          else
+          } else {
             c = Ctrl_C;
-          flush_buffers(TRUE);                  /* flush all typeahead */
+          }
+          flush_buffers(true);                  // flush all typeahead
 
           if (advance) {
             /* Also record this character, it might be needed to
@@ -2071,18 +2066,17 @@ static int vgetorpeek(int advance)
         c = 0;
         new_wcol = curwin->w_wcol;
         new_wrow = curwin->w_wrow;
-        if (       advance
-                   && typebuf.tb_len == 1
-                   && typebuf.tb_buf[typebuf.tb_off] == ESC
-                   && !no_mapping
-                   && ex_normal_busy == 0
-                   && typebuf.tb_maplen == 0
-                   && (State & INSERT)
-                   && (p_timeout
-                       || (keylen == KEYLEN_PART_KEY && p_ttimeout))
-                   && (c = inchar(typebuf.tb_buf + typebuf.tb_off
-                           + typebuf.tb_len, 3, 25L,
-                           typebuf.tb_change_cnt)) == 0) {
+        if (advance
+            && typebuf.tb_len == 1
+            && typebuf.tb_buf[typebuf.tb_off] == ESC
+            && !no_mapping
+            && ex_normal_busy == 0
+            && typebuf.tb_maplen == 0
+            && (State & INSERT)
+            && (p_timeout
+                || (keylen == KEYLEN_PART_KEY && p_ttimeout))
+            && (c = inchar(typebuf.tb_buf + typebuf.tb_off
+                           + typebuf.tb_len, 3, 25L)) == 0) {
           colnr_T col = 0, vcol;
           char_u      *ptr;
 
@@ -2264,7 +2258,7 @@ static int vgetorpeek(int advance)
                ? -1L
                : ((keylen == KEYLEN_PART_KEY && p_ttm >= 0)
                   ? p_ttm
-                  : p_tm)), typebuf.tb_change_cnt);
+                  : p_tm)));
 
         if (i != 0)
           pop_showcmd();
@@ -2345,16 +2339,15 @@ static int vgetorpeek(int advance)
  *  Return the number of obtained characters.
  *  Return -1 when end of input script reached.
  */
-int 
-inchar (
-    char_u *buf,
-    int maxlen,
-    long wait_time,                     /* milli seconds */
-    int tb_change_cnt
+int inchar(
+    char_u *const buf,
+    const int maxlen,
+    const long wait_time                // milli seconds
 )
 {
   int len = 0;  // Init for GCC.
   int retesc = false;  // Return ESC with gotint.
+  const int tb_change_cnt = typebuf.tb_change_cnt;
 
   if (wait_time == -1L || wait_time > 100L) {
     // flush output before waiting
@@ -2425,8 +2418,17 @@ inchar (
     len = os_inchar(buf, maxlen / 3, (int)wait_time, tb_change_cnt);
   }
 
+  // If the typebuf was changed further down, it is like nothing was added by
+  // this call.
   if (typebuf_changed(tb_change_cnt)) {
     return 0;
+  }
+
+  // Note the change in the typeahead buffer, this matters for when
+  // vgetorpeek() is called recursively, e.g. using getchar(1) in a timer
+  // function.
+  if (len > 0 && ++typebuf.tb_change_cnt == 0) {
+    typebuf.tb_change_cnt = 1;
   }
 
   return fix_input_buffer(buf, len);

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2237,9 +2237,9 @@ static int vgetorpeek(int advance)
           if ((State & CMDLINE)
               && cmdline_star == 0
               && ptr2cells(typebuf.tb_buf + typebuf.tb_off
-                  + typebuf.tb_len - 1) == 1) {
-            putcmdline(typebuf.tb_buf[typebuf.tb_off
-                                      + typebuf.tb_len - 1], FALSE);
+                           + typebuf.tb_len - 1) == 1) {
+            putcmdline(typebuf.tb_buf[typebuf.tb_off + typebuf.tb_len - 1],
+                       false);
             c1 = 1;
           }
         }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -439,7 +439,10 @@ void flush_buffers(int flush_typeahead)
       ;
     typebuf.tb_off = MAXMAPLEN;
     typebuf.tb_len = 0;
-  } else {                /* remove mapped characters at the start only */
+    // Reset the flag that text received from a client or from feedkeys()
+    // was inserted in the typeahead buffer.
+    typebuf_was_filled = false;
+  } else {                // remove mapped characters at the start only
     typebuf.tb_off += typebuf.tb_maplen;
     typebuf.tb_len -= typebuf.tb_maplen;
   }
@@ -1075,11 +1078,12 @@ void del_typebuf(int len, int offset)
       typebuf.tb_no_abbr_cnt -= len;
   }
 
-  /* Reset the flag that text received from a client or from feedkeys()
-   * was inserted in the typeahead buffer. */
-  typebuf_was_filled = FALSE;
-  if (++typebuf.tb_change_cnt == 0)
+  // Reset the flag that text received from a client or from feedkeys()
+  // was inserted in the typeahead buffer.
+  typebuf_was_filled = false;
+  if (++typebuf.tb_change_cnt == 0) {
     typebuf.tb_change_cnt = 1;
+  }
 }
 
 /*

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -942,8 +942,8 @@ EXTERN int no_hlsearch INIT(= FALSE);
 EXTERN linenr_T printer_page_num;
 
 
-EXTERN int typebuf_was_filled INIT(= FALSE);      /* received text from client
-                                                     or from feedkeys() */
+EXTERN bool typebuf_was_filled INIT(= false);     // received text from client
+                                                  // or from feedkeys()
 
 
 #ifdef BACKSLASH_IN_FILENAME

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2479,7 +2479,7 @@ int prompt_for_number(int *mouse_used)
   save_cmdline_row = cmdline_row;
   cmdline_row = 0;
   save_State = State;
-  State = CMDLINE;
+  State = ASKMORE;    // prevents a screen update when using a timer
 
   i = get_number(TRUE, mouse_used);
   if (KeyTyped) {

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -125,6 +125,9 @@ retnomove:
 
     // find the window where the row is in
     wp = mouse_find_win(&row, &col);
+    if (wp == NULL) {
+      return IN_UNKNOWN;
+    }
     dragwin = NULL;
     // winpos and height may change in win_enter()!
     if (row >= wp->w_height) {                  // In (or below) status line
@@ -427,6 +430,7 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
 
 // Find the window at screen position "*rowp" and "*colp".  The positions are
 // updated to become relative to the top-left of the window.
+// Return NULL when something is wrong.
 win_T *mouse_find_win(int *rowp, int *colp)
 {
   frame_T     *fp;
@@ -450,7 +454,14 @@ win_T *mouse_find_win(int *rowp, int *colp)
       }
     }
   }
-  return fp->fr_win;
+  // When using a timer that closes a window the window might not actually
+  // exist
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    if (wp == fp->fr_win) {
+      return wp;
+    }
+  }
+  return NULL;
 }
 
 /*

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3994,8 +3994,12 @@ static void nv_mousescroll(cmdarg_T *cap)
     row = mouse_row;
     col = mouse_col;
 
-    /* find the window at the pointer coordinates */
-    curwin = mouse_find_win(&row, &col);
+    // find the window at the pointer coordinates
+    win_T *const wp = mouse_find_win(&row, &col);
+    if (wp == NULL) {
+      return;
+    }
+    curwin = wp;
     curbuf = curwin->w_buffer;
   }
 

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -240,6 +240,7 @@ let s:flaky = [
       \ 'Test_quoteplus()',
       \ 'Test_quotestar()',
       \ 'Test_reltime()',
+      \ 'Test_repeat_three()',
       \ 'Test_terminal_composing_unicode()',
       \ 'Test_terminal_redir_file()',
       \ 'Test_terminal_tmap()',

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -169,5 +169,25 @@ func Test_stop_all_in_callback()
   call assert_equal(0, len(info))
 endfunc
 
+func FeedAndPeek(timer)
+  call test_feedinput('a')
+  call getchar(1)
+endfunc
+
+func Interrupt(timer)
+  call test_feedinput("\<C-C>")
+endfunc
+
+func Test_peek_and_get_char()
+  throw 'skipped: Nvim does not support test_feedinput()'
+  if !has('unix') && !has('gui_running')
+    return
+  endif
+  call timer_start(0, 'FeedAndPeek')
+  let intr = timer_start(100, 'Interrupt')
+  let c = getchar()
+  call assert_equal(char2nr('a'), c)
+  call timer_stop(intr)
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:8.0.0671: hang when typing CTRL-C in confirm() in timer**

Problem:    When a function invoked from a timer calls confirm() and the user
            types CTRL-C then Vim hangs.
Solution:   Reset typebuf_was_filled. (Ozaki Kiichi, closes vim/vim#1791)
https://github.com/vim/vim/commit/4eb6531b03445b4d492bc52fea0b6dcd886583af

 **vim-patch:8.0.0714: when a timer causes a command line redraw " goes missing**

Problem:    When a timer causes a command line redraw the " that is displayed
            for CTRL-R goes missing.
Solution:   Remember an extra character to display.
vim/vim@a92522f

**vim-patch:8.0.0720: unfinished mapping not displayed when running timer**

Problem:    Unfinished mapping not displayed when running timer.
Solution:   Also use the extra_char while waiting for a mapping and digraph.
            (closes vim/vim#1844)
vim/vim@6a77d26

**vim-patch:8.0.0722: screen is messed by timer up at inputlist() prompt**

Problem:    Screen is messed by timer up at inputlist() prompt.
Solution:   Set state to ASKMORE. (closes vim/vim#1843)
vim/vim@c904107

 **vim-patch:8.0.0948: crash if timer closes window while dragging status line**

Problem:    Crash if timer closes window while dragging status line.
Solution:   Check if the window still exists. (Yasuhiro Matsumoto, closes
            vim/vim#1979)
vim/vim@989a70c

**vim-patch:8.0.1020: when a timer calls getchar(1) input is overwritten**

Problem:    When a timer calls getchar(1) input is overwritten.
Solution:   Increment tb_change_cnt in inchar(). (closes vim/vim#1940)
vim/vim@0f0f230

**vim-patch:8.0.1048: no test for what 8.0.1020 fixes**

Problem:    No test for what 8.0.1020 fixes.
Solution:   Add test_feedinput().  Add a test. (Ozaki Kiichi, closes vim/vim#2046)
vim/vim@5e80de3

**vim-patch:8.0.1507: timer test is a bit flaky**

Problem:    Timer test is a bit flaky.
Solution:   Add it to the list of flaky tests.
vim/vim@bfbea56

I assume patches 671, 714, 720, 722 are OK (but can be improved) so I added more patches. I omitted `test_feedinput` from patch 1048.

I didn't include patches 1424 and 1456 because `Test_paused` already has a longer duration (100 ms).