### PR TITLE
[RFC] vim-patch.sh: handle wrapped commit messages

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -449,12 +449,21 @@ review_commit() {
 
   assign_commit_details "${vim_version}"
 
+  echo
+  echo "Creating files."
+  echo "${nvim_patch}" > "${NVIM_SOURCE_DIR}/n${patch_file}"
+  msg_ok "Saved pull request diff to '${NVIM_SOURCE_DIR}/n${patch_file}'."
+  CREATED_FILES+=("${NVIM_SOURCE_DIR}/n${patch_file}")
+
+  local nvim="nvim -u NORC -n -i NONE --headless"
+  2>/dev/null $nvim --cmd 'set dir=/tmp' +'1,/^$/g/^ /-1join' +w +q "${NVIM_SOURCE_DIR}/n${patch_file}"
+
   local expected_commit_message
   expected_commit_message="$(commit_message)"
   local message_length
   message_length="$(wc -l <<< "${expected_commit_message}")"
   local commit_message
-  commit_message="$(tail -n +4 <<< "${nvim_patch}" | head -n "${message_length}")"
+  commit_message="$(tail -n +4 "${NVIM_SOURCE_DIR}/n${patch_file}" | head -n "${message_length}")"
   if [[ "${commit_message#${git_patch_prefix}}" == "${expected_commit_message}" ]]; then
     msg_ok "Found expected commit message."
   else
@@ -464,12 +473,6 @@ review_commit() {
     echo "  Actual:"
     echo "${commit_message#${git_patch_prefix}}"
   fi
-
-  echo
-  echo "Creating files."
-  echo "${nvim_patch}" > "${NVIM_SOURCE_DIR}/n${patch_file}"
-  msg_ok "Saved pull request diff to '${NVIM_SOURCE_DIR}/n${patch_file}'."
-  CREATED_FILES+=("${NVIM_SOURCE_DIR}/n${patch_file}")
 
   get_vimpatch "${vim_version}"
   CREATED_FILES+=("${NVIM_SOURCE_DIR}/${patch_file}")


### PR DESCRIPTION
This only compares the short commit messages, and not the lines usually
containing Problem/Solution, because people should be free to fix the often
weird indentation from Vim patches.

The difference before and after this patch using:

```
  ./scripts/vim-patch.sh -r 8684
```

Before:

```
  ✘ Wrong commit message.
    Expected:
  vim-patch:8.0.1464: completing directory after :find does not add slash

  Problem:    Completing directory after :find does not add slash.
  Solution:   Adjust the flags for globpath(). (Genki Sky)
  https://github.com/vim/vim/commit/8a37b032895b40dd6953280c33585bcba0c7ef8b
    Actual:
  vim-patch:8.0.1464: completing directory after :find does not
   add slash

  Problem:    Completing directory after :find does not add slash.
  Solution:   Adjust the flags for globpath(). (Genki Sky)
```

After:

```
  ✔ Commit messages from Vim and Nvim match.
```