### PR TITLE
[RFC] vim-patch:8.0.0522

### DIFF
--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -15,6 +15,7 @@ source test_findfile.vim
 source test_float_func.vim
 source test_functions.vim
 source test_ga.vim
+source test_global.vim
 source test_goto.vim
 source test_jumps.vim
 source test_fileformat.vim

--- a/src/nvim/testdir/test_global.vim
+++ b/src/nvim/testdir/test_global.vim
@@ -1,0 +1,11 @@
+
+func Test_yank_put_clipboard()
+  new
+  call setline(1, ['a', 'b', 'c'])
+  set clipboard=unnamed
+  g/^/normal yyp
+  call assert_equal(['a', 'a', 'b', 'b', 'c', 'c'], getline(1, 6))
+
+  set clipboard&
+  bwipe!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0522: Win32: when 'clipboard' is "unnamed" yyp does not work**

Problem:    MS-Windows: when 'clipboard' is "unnamed" yyp does not work in a
            :global command.
Solution:   When setting the clipboard was postponed, do not clear the
            register.
https://github.com/vim/vim/commit/3fcfa35f82b9d1ef5e95051b3a45578e10c14ec3

I included only the test because it passes with no changes to the clipboard code.