### PR TITLE
test: Rename includes/pre/uv-errno.h to includes/pre/uv.h

### DIFF
--- a/test/includes/CMakeLists.txt
+++ b/test/includes/CMakeLists.txt
@@ -7,6 +7,13 @@ foreach(gen_include ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
   list(APPEND gen_cflags ${CMAKE_INCLUDE_FLAG_C}${gen_include})
 endforeach()
 
+get_directory_property(gen_cdefs COMPILE_DEFINITIONS)
+foreach(gen_cdef ${gen_cdefs})
+  if(NOT ${gen_cdef} MATCHES "INCLUDE_GENERATED_DECLARATIONS")
+    list(APPEND gen_cflags "-D${gen_cdef}")
+  endif()
+endforeach()
+
 foreach(hfile ${PRE_HEADERS})
   string(REGEX REPLACE ^pre/ post/ post_hfile ${hfile})
   get_filename_component(hdir ${CMAKE_CURRENT_BINARY_DIR}/${post_hfile} PATH)

--- a/test/includes/pre/uv.h
+++ b/test/includes/pre/uv.h
@@ -1,4 +1,4 @@
-#include <uv-errno.h>
+#include <uv.h>
 
 static const int kUV_ENOENT = UV_ENOENT;
 static const int kUV_EEXIST = UV_EEXIST;

--- a/test/unit/os/fs_spec.lua
+++ b/test/unit/os/fs_spec.lua
@@ -27,7 +27,7 @@ cimport('./src/nvim/fileio.h')
 local fs = cimport('./src/nvim/os/os.h', './src/nvim/path.h')
 cppimport('sys/stat.h')
 cppimport('fcntl.h')
-cppimport('uv-errno.h')
+cppimport('uv.h')
 
 local s = ''
 for i = 0, 255 do


### PR DESCRIPTION
libuv users are only supposed to directly include uv.h.  In v1.21.0, all
the `uv-*.h` headers were renamed to `uv/*.h`, which caused the unit tests
to fail with

    [123/125] Generating post/uv-errno.h
    FAILED: test/includes/post/uv-errno.h
    cd «SRCDIR»/src/neovim/build/test/includes && /usr/bin/clang -std=c99 -E -P «SRCDIR»/src/neovim/test/includes/pre/uv-errno.h -I/usr/include -I/usr/include -o «SRCDIR»/neovim/build/test/includes/post/uv-errno.h
    «SRCDIR»/src/neovim/test/includes/pre/uv-errno.h:1:10: error: 'uv-errno.h' file not found with <angled> include; use "quotes" instead
    #include <uv-errno.h>
             ^~~~~~~~~~~~
             "uv-errno.h"

The intention of the file is to extend libuv's error constants with more
values used by the unit tests.  This can just as easily be achieved
without poking into pseudo-private header files.