### PR TITLE
[WIP] Load init.lua on startup instead of init.vim

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -36,8 +36,20 @@ local nvim_prog = (
 local nvim_set  = 'set shortmess+=I background=light noswapfile noautoindent'
                   ..' laststatus=1 undodir=. directory=. viewdir=. backupdir=.'
                   ..' belloff= noshowcmd noruler nomore'
-local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
-                   '--cmd', nvim_set, '--embed'}
+local function get_default_argv(allow_vimrc)
+  local argv = {nvim_prog}
+  if not allow_vimrc then
+    table.insert(argv, '-u')
+    table.insert(argv, 'NONE')
+  end
+  local other_args = {'-i', 'NONE', '-N', '--cmd', nvim_set, '--embed'}
+  for _, item in ipairs(other_args) do
+    table.insert(argv, item)
+  end
+  return argv
+end
+local nvim_argv = get_default_argv(false)
+
 -- Directory containing nvim.
 local nvim_dir = nvim_prog:gsub("[/\\][^/\\]+$", "")
 if nvim_dir == nvim_prog then
@@ -352,6 +364,11 @@ local function clear(...)
       for k, v in pairs(env_tbl) do
         env[#env + 1] = k .. '=' .. v
       end
+    end
+    -- if we want to load the vimrc, then we need to regenerate the default
+    -- args just for this invocation
+    if opts.allow_vimrc then
+      args = get_default_argv(true)
     end
     new_args = opts.args or {}
   else

--- a/test/functional/ui/startup_spec.lua
+++ b/test/functional/ui/startup_spec.lua
@@ -1,0 +1,38 @@
+-- FIXME: ideally we'll eventually have tests for the entire startup sequence
+-- described at ":help initialization"
+-- For now, I'm just adding tests to ensure an init.lua gets loaded correctly
+
+local helpers = require('test.functional.helpers')(after_each)
+local lfs = require('lfs')
+
+local clear = helpers.clear
+local set_session = helpers.set_session
+local mkdir = helpers.mkdir
+local rmdir = helpers.rmdir
+
+local cwd = lfs.currentdir()
+local fakehome = cwd..'/tmp-test-fakehome'
+
+before_each(function()
+  -- create a fake home directory
+  mkdir(fakehome)
+  mkdir(fakehome..'/.config')
+  mkdir(fakehome..'/.config/nvim')
+
+  -- start a new session that points to our fake $HOME dir
+  clear{env={HOME=fakehome}}
+end)
+
+after_each(function()
+  -- clean up the fake home directory
+  rmdir(fakehome)
+
+  -- destroy any previous session
+  set_session(nil, false)
+end)
+
+describe('init.lua rc file', function()
+  it('is loaded instead of init.vim', function()
+    -- TODO: prove that init.lua is loaded
+  end)
+end)

--- a/test/functional/ui/startup_spec.lua
+++ b/test/functional/ui/startup_spec.lua
@@ -43,7 +43,7 @@ end
 
 local function begin_session()
   -- invoke clear() with our newly crafted home dir
-  clear{env={HOME=fakehome}}
+  clear{allow_vimrc=true, env={HOME=fakehome}}
 end
 
 describe('init.lua rc file', function()

--- a/test/functional/ui/startup_spec.lua
+++ b/test/functional/ui/startup_spec.lua
@@ -21,8 +21,9 @@ before_each(function()
   mkdir(fakehome..'/.config')
   mkdir(fakehome..'/.config/nvim')
 
-  -- start a new session that points to our fake $HOME dir
-  clear{env={HOME=fakehome}}
+  -- NOTE: we can't just call clear() to start a new nvim session because the
+  -- tests need to write out .nvimrc files and such before nvim starts up.
+  -- See begin_session() for how nvim is spawned.
 end)
 
 after_each(function()
@@ -40,6 +41,11 @@ local function writefile(path, data)
   f:close()
 end
 
+local function begin_session()
+  -- invoke clear() with our newly crafted home dir
+  clear{env={HOME=fakehome}}
+end
+
 describe('init.lua rc file', function()
   it('is loaded instead of init.vim', function()
     -- write out a bunch of init scripts that will each define a specific
@@ -50,6 +56,8 @@ describe('init.lua rc file', function()
     writefile('.config/nvim/init.vim', [[
           let g:reached_init_vim = 1
     ]])
+
+    begin_session()
 
     -- prove that init.lua was executed
     eq(1, eval('get(g:, "reached_init_lua", 0)'))


### PR DESCRIPTION
This is a mostly-working prototype for #7895. There's still a few issues to work out (the worst one being that nvim seems to hang if there's a syntax error in your `init.lua` script).

If there are any lua fans out there who'd like to have a crack at migrating their `init.vim` to an `init.lua`, I'd love to hear from you.

Some things that still need doing:
* updating documentation (and probably write a tutorial on how to migrate an `init.vim` to `init.lua`)
* need to confirm this new code interacts correctly with other parts of the startup sequence like `$VIMINIT`, `$EXINIT`, `'exrc'`, `$VIM/sysinit.vim`
* add paranoia tests for things like `init.lua` being a directory instead of a file, etc.