### PR TITLE
[RFC] Fix redrawing issues with narrow screen and remove extra wait in resize tests

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6396,6 +6396,13 @@ int showmode(void)
     /* Position on the last line in the window, column 0 */
     msg_pos_mode();
     attr = HL_ATTR(HLF_CM);                     // Highlight mode
+
+    // When the screen is too narrow to show the entire mode messsage,
+    // avoid scrolling and truncate instead.
+    msg_no_more = true;
+    int save_lines_left = lines_left;
+    lines_left = 0;
+
     if (do_mode) {
       MSG_PUTS_ATTR("--", attr);
       // CTRL-X in Insert mode
@@ -6495,10 +6502,13 @@ int showmode(void)
     msg_didout = FALSE;                 /* overwrite this message */
     length = msg_col;
     msg_col = 0;
-    need_wait_return = nwr_save;        /* never ask for hit-return for this */
-  } else if (clear_cmdline && msg_silent == 0)
-    /* Clear the whole command line.  Will reset "clear_cmdline". */
+    msg_no_more = false;
+    lines_left = save_lines_left;
+    need_wait_return = nwr_save;        // never ask for hit-return for this
+  } else if (clear_cmdline && msg_silent == 0) {
+    // Clear the whole command line.  Will reset "clear_cmdline".
     msg_clr_cmdline();
+  }
 
   /* In Visual mode the size of the selected area must be redrawn. */
   if (VIsual_active)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -172,9 +172,6 @@ end
 
 function Screen:try_resize(columns, rows)
   uimeths.try_resize(columns, rows)
-  -- Give ourselves a chance to _handle_resize, which requires using
-  -- self.sleep() (for the resize notification) rather than run()
-  self:sleep(0.1)
 end
 
 function Screen:set_option(option, value)
@@ -210,11 +207,6 @@ function Screen:expect(expected, attr_ids, attr_ignore, condition, any)
       row = row:sub(1, #row - 1) -- Last char must be the screen delimiter.
       table.insert(expected_rows, row)
     end
-    if not any then
-      assert(self._height == #expected_rows,
-        "Expected screen state's row count(" .. #expected_rows
-        .. ') differs from configured height(' .. self._height .. ') of Screen.')
-    end
   end
   local ids = attr_ids or self._default_attr_ids
   local ignore = attr_ignore or self._default_attr_ignore
@@ -225,6 +217,12 @@ function Screen:expect(expected, attr_ids, attr_ignore, condition, any)
         return tostring(res)
       end
     end
+
+    if expected and not any and self._height ~= #expected_rows then
+      return ("Expected screen state's row count(" .. #expected_rows
+              .. ') differs from configured height(' .. self._height .. ') of Screen.')
+    end
+
     local actual_rows = {}
     for i = 1, self._height do
       actual_rows[i] = self:_row_repr(self._rows[i], ids, ignore)

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -651,9 +651,10 @@ describe('Screen', function()
     it('has minimum width/height values', function()
       screen:try_resize(1, 1)
       screen:expect([[
-        {2:-- INS^ERT --}|
-                    |
+        resize^      |
+        {2:-- INSERT -} |
       ]])
+
       feed('<esc>:ls')
       screen:expect([[
         resize      |


### PR DESCRIPTION
Screen size is part of screen state, so treat it as such, instead of some kind of precondition for even doing screen tests.

Saves ~10 seconds in UI tests in local testing.