### PR TITLE
[RDY] vim-patch:8.0.0{474,475,492,633,1251}

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2222,6 +2222,8 @@ remote_read({serverid} [, {timeout}])
 				String	read reply string
 remote_send({server}, {string} [, {idvar}])
 				String	send key sequence
+remote_startserver({name})	none	become server {name}
+				String	send key sequence
 remove({list}, {idx} [, {end}])	any	remove items {idx}-{end} from {list}
 remove({dict}, {key})		any	remove entry {key} from {dict}
 rename({from}, {to})		Number	rename (move) file from {from} to {to}
@@ -6268,6 +6270,7 @@ remote_send({server}, {string} [, {idvar}])
 		See also |clientserver| |RemoteReply|.
 		This function is not available in the |sandbox|.
 		{only available when compiled with the |+clientserver| feature}
+
 		Note: Any errors will be reported in the server and may mess
 		up the display.
 		Examples: >
@@ -6279,6 +6282,12 @@ remote_send({server}, {string} [, {idvar}])
 		:echo remote_send("gvim", ":sleep 10 | echo ".
 		 \ 'server2client(expand("<client>"), "HELLO")<CR>')
 <
+					*remote_startserver()* *E941* *E942*
+remote_startserver({name})
+		Become the server {name}.  This fails if already running as a
+		server, when |v:servername| is not empty.
+		{only available when compiled with the |+clientserver| feature}
+
 remove({list}, {idx} [, {end}])				*remove()*
 		Without {end}: Remove the item at {idx} from |List| {list} and
 		return the item.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6198,15 +6198,17 @@ reltimestr({time})				*reltimestr()*
 <		Also see |profiling|.
 
 							*remote_expr()* *E449*
-remote_expr({server}, {string} [, {idvar}])
+remote_expr({server}, {string} [, {idvar} [, {timeout}]])
 		Send the {string} to {server}.	The string is sent as an
 		expression and the result is returned after evaluation.
 		The result must be a String or a |List|.  A |List| is turned
 		into a String by joining the items with a line break in
 		between (not at the end), like with join(expr, "\n").
-		If {idvar} is present, it is taken as the name of a
-		variable and a {serverid} for later use with
+		If {idvar} is present and not empty, it is taken as the name
+		of a variable and a {serverid} for later use with
 		remote_read() is stored there.
+		If {timeout} is given the read times out after this many
+		seconds.  Otherwise a timeout of 600 seconds is used.
 		See also |clientserver| |RemoteReply|.
 		This function is not available in the |sandbox|.
 		{only available when compiled with the |+clientserver| feature}
@@ -6250,9 +6252,10 @@ remote_peek({serverid} [, {retvar}])		*remote_peek()*
 			:let repl = ""
 			:echo "PEEK: ".remote_peek(id, "repl").": ".repl
 
-remote_read({serverid})				*remote_read()*
+remote_read({serverid}, [{timeout}])			*remote_read()*
 		Return the oldest available reply from {serverid} and consume
-		it.  It blocks until a reply is available.
+		it.  Unless a {timeout} in seconds is given, it blocks until a
+		reply is available.
 		See also |clientserver|.
 		This function is not available in the |sandbox|.
 		{only available when compiled with the |+clientserver| feature}

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -41,6 +41,7 @@ NEW_TESTS ?= \
 	    test_changedtick.res \
 	    test_charsearch.res \
 	    test_cindent.res \
+	    test_clientserver.res \
 	    test_close_count.res \
 	    test_cmdline.res \
 	    test_command_count.res \

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -1,0 +1,42 @@
+" Tests for the +clientserver feature.
+
+if !has('job') || !has('clientserver')
+  finish
+endif
+
+source shared.vim
+
+func Test_client_server()
+  let cmd = GetVimCommand()
+  if cmd == ''
+    return
+  endif
+  let name = 'XVIMTEXT'
+  let cmd .= ' --servername ' . name
+  let g:job = job_start(cmd, {'stoponexit': 'kill', 'out_io': 'null'})
+  call WaitFor('job_status(g:job) == "run"')
+  if job_status(g:job) != 'run'
+    call assert_true(0, 'Cannot run the Vim server')
+    return
+  endif
+
+  " Takes a short while for the server to be active.
+  call WaitFor('serverlist() =~ "' . name . '"')
+  call assert_match(name, serverlist())
+
+  call remote_foreground(name)
+
+  call remote_send(name, ":let testvar = 'yes'\<CR>")
+  call WaitFor('remote_expr("' . name . '", "testvar") == "yes"')
+  call assert_equal('yes', remote_expr(name, "testvar"))
+
+  call remote_send(name, ":qa!\<CR>")
+  call WaitFor('job_status(g:job) == "dead"')
+  if job_status(g:job) != 'dead'
+    call assert_true(0, 'Server did not exit')
+    call job_stop(g:job, 'kill')
+  endif
+endfunc
+
+" Uncomment this line to get a debugging log
+" call ch_logfile('channellog', 'w')

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -41,7 +41,7 @@ func Test_client_server()
   call remote_foreground(name)
 
   call remote_send(name, ":let testvar = 'yes'\<CR>")
-  call WaitFor('remote_expr("' . name . '", "testvar", "", 1) == "yes"')
+  call WaitFor('remote_expr("' . name . '", "exists(\"testvar\") ? testvar : \"\"", "", 1) == "yes"')
   call assert_equal('yes', remote_expr(name, "testvar", "", 2))
 
   if has('unix') && has('gui') && !has('gui_running')

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -11,12 +11,13 @@ func Test_client_server()
   if cmd == ''
     return
   endif
-  let name = 'XVIMTEXT'
+
+  let name = 'XVIMTEST'
   let cmd .= ' --servername ' . name
   let g:job = job_start(cmd, {'stoponexit': 'kill', 'out_io': 'null'})
   call WaitFor('job_status(g:job) == "run"')
   if job_status(g:job) != 'run'
-    call assert_true(0, 'Cannot run the Vim server')
+    call assert_report('Cannot run the Vim server')
     return
   endif
 
@@ -27,19 +28,26 @@ func Test_client_server()
   call remote_foreground(name)
 
   call remote_send(name, ":let testvar = 'yes'\<CR>")
-  call WaitFor('remote_expr("' . name . '", "testvar") == "yes"')
-  call assert_equal('yes', remote_expr(name, "testvar"))
+  call WaitFor('remote_expr("' . name . '", "testvar", "", 1) == "yes"')
+  call assert_equal('yes', remote_expr(name, "testvar", "", 2))
 
   if has('unix') && has('gui') && !has('gui_running')
     " Running in a terminal and the GUI is avaiable: Tell the server to open
     " the GUI and check that the remote command still works.
     " Need to wait for the GUI to start up, otherwise the send hangs in trying
     " to send to the terminal window.
-    call remote_send(name, ":gui -f\<CR>")
-    sleep 500m
+    if has('gui_athena') || has('gui_motif')
+      " For those GUIs, ignore the 'failed to create input context' error.
+      call remote_send(name, ":call test_ignore_error('E285') | gui -f\<CR>")
+    else
+      call remote_send(name, ":gui -f\<CR>")
+    endif
+    " Wait for the server to be up and answering requests.
+    call WaitFor('remote_expr("' . name . '", "v:version", "", 1) != ""')
+
     call remote_send(name, ":let testvar = 'maybe'\<CR>")
-    call WaitFor('remote_expr("' . name . '", "testvar") == "maybe"')
-    call assert_equal('maybe', remote_expr(name, "testvar"))
+    call WaitFor('remote_expr("' . name . '", "testvar", "", 1) == "maybe"')
+    call assert_equal('maybe', remote_expr(name, "testvar", "", 2))
   endif
 
   call assert_fails('call remote_send("XXX", ":let testvar = ''yes''\<CR>")', 'E241')
@@ -47,18 +55,35 @@ func Test_client_server()
   " Expression evaluated locally.
   if v:servername == ''
     call remote_startserver('MYSELF')
-    call assert_equal('MYSELF', v:servername)
+    " May get MYSELF1 when running the test again.
+    call assert_match('MYSELF', v:servername)
   endif
   let g:testvar = 'myself'
   call assert_equal('myself', remote_expr(v:servername, 'testvar'))
 
   call remote_send(name, ":call server2client(expand('<client>'), 'got it')\<CR>", 'g:myserverid')
-  call assert_equal('got it', remote_read(g:myserverid))
+  call assert_equal('got it', remote_read(g:myserverid, 2))
+
+  call remote_send(name, ":call server2client(expand('<client>'), 'another')\<CR>", 'g:myserverid')
+  let peek_result = 'nothing'
+  let r = remote_peek(g:myserverid, 'peek_result')
+  " unpredictable whether the result is already avaialble.
+  if r > 0
+    call assert_equal('another', peek_result)
+  elseif r == 0
+    call assert_equal('nothing', peek_result)
+  else
+    call assert_report('remote_peek() failed')
+  endif
+  let g:peek_result = 'empty'
+  call WaitFor('remote_peek(g:myserverid, "g:peek_result") > 0')
+  call assert_equal('another', g:peek_result)
+  call assert_equal('another', remote_read(g:myserverid, 2))
 
   call remote_send(name, ":qa!\<CR>")
   call WaitFor('job_status(g:job) == "dead"')
   if job_status(g:job) != 'dead'
-    call assert_true(0, 'Server did not exit')
+    call assert_report('Server did not exit')
     call job_stop(g:job, 'kill')
   endif
 endfunc


### PR DESCRIPTION
**vim-patch:8.0.0474: the client-server feature is not tested**

Problem:    The client-server feature is not tested.
Solution:   Add a test.
vim/vim@15bf76d

**vim-patch:8.0.0475: not enough testing for the client-server feature**

Problem:    Not enough testing for the client-server feature.
Solution:   Add more tests.  Add the remote_startserver() function.  Fix that
            a locally evaluated expression uses function-local variables.
vim/vim@7416f3e

**vim-patch:8.0.0492: a failing client-server request can make Vim hang**

Problem:    A failing client-server request can make Vim hang.
Solution:   Add a timeout argument to functions that wait.
vim/vim@81b9d0b

**vim-patch:8.0.0633: the client-server test is still a bit flaky**

Problem:    The client-server test is still a bit flaky.
Solution:   Wait a bit for the GUI to start.  Check that the version number
            can be obtained.
vim/vim@60964f6

**vim-patch:8.0.1251: invalid expressin passed to WaitFor()**

Problem:    Invalid expressin passed to WaitFor().
Solution:   Check if the variable exists.
vim/vim@d97fbf1

nvim doesn't support `+clientserver` (yet) so I included only the oldtests and patch 476 is N/A. I included missing changes from patches 477, 479, 507, 511.

`test_clientserver.vim` tests shouldn't run because of the feature check at the top of the file.