### PR TITLE
log: include milliseconds, tweak format

### DIFF
--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -285,10 +285,10 @@ static bool v_do_log_to_file(FILE *log_file, int log_level,
   // Print the log message.
   int64_t pid = os_get_pid();
   int rv = (line_num == -1 || func_name == NULL)
-    ? fprintf(log_file, "%s %s.%-3d %" PRId64 " %s",
+    ? fprintf(log_file, "%s %s.%03d %-5" PRId64 " %s",
               log_levels[log_level], date_time, millis, pid,
               (context == NULL ? "?:" : context))
-    : fprintf(log_file, "%s %s.%-3d %" PRId64 " %s%s:%d: ",
+    : fprintf(log_file, "%s %s.%03d %-5" PRId64 " %s%s:%d: ",
               log_levels[log_level], date_time, millis, pid,
               (context == NULL ? "" : context),
               func_name, line_num);

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -269,7 +269,7 @@ static bool v_do_log_to_file(FILE *log_file, int log_level,
     return false;
   }
   char date_time[20];
-  if (strftime(date_time, sizeof(date_time), "%y%m%d.%H%M%S",
+  if (strftime(date_time, sizeof(date_time), "%Y-%m-%dT%H:%M:%S",
                &local_time) == 0) {
     return false;
   }

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -262,7 +262,7 @@ static bool v_do_log_to_file(FILE *log_file, int log_level,
 
   // format current timestamp in local time
   struct tm local_time;
-  if (os_get_localtime(&local_time) == NULL) {
+  if (os_localtime(&local_time) == NULL) {
     return false;
   }
   char date_time[20];

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -260,25 +260,25 @@ static bool v_do_log_to_file(FILE *log_file, int log_level,
   };
   assert(log_level >= DEBUG_LOG_LEVEL && log_level <= ERROR_LOG_LEVEL);
 
-  // format current timestamp in local time
+  // Format the timestamp.
   struct tm local_time;
   if (os_localtime(&local_time) == NULL) {
     return false;
   }
   char date_time[20];
-  if (strftime(date_time, sizeof(date_time), "%Y/%m/%d %H:%M:%S",
+  if (strftime(date_time, sizeof(date_time), "%y%m%d.%H%M%S",
                &local_time) == 0) {
     return false;
   }
 
-  // print the log message prefixed by the current timestamp and pid
+  // Print the log message.
   int64_t pid = os_get_pid();
   int rv = (line_num == -1 || func_name == NULL)
-    ? fprintf(log_file, "%s %s %" PRId64 " %s", date_time,
-              log_levels[log_level], pid,
+    ? fprintf(log_file, "%s %s %" PRId64 " %s", log_levels[log_level],
+              date_time, pid,
               (context == NULL ? "?:" : context))
-    : fprintf(log_file, "%s %s %" PRId64 " %s%s:%d: ", date_time,
-              log_levels[log_level], pid,
+    : fprintf(log_file, "%s %s %" PRId64 " %s%s:%d: ", log_levels[log_level],
+              date_time, pid,
               (context == NULL ? "" : context),
               func_name, line_num);
   if (rv < 0) {

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -114,12 +114,12 @@ struct tm *os_localtime_r(const time_t *restrict clock,
 #endif
 }
 
-/// Obtains the current Unix timestamp and adjusts it to local time.
+/// Gets the current Unix timestamp and adjusts it to local time.
 ///
 /// @param result Pointer to a 'struct tm' where the result should be placed
 /// @return A pointer to a 'struct tm' in the current time zone (the 'result'
 ///         argument) or NULL in case of error
-struct tm *os_get_localtime(struct tm *result) FUNC_ATTR_NONNULL_ALL
+struct tm *os_localtime(struct tm *result) FUNC_ATTR_NONNULL_ALL
 {
   time_t rawtime = time(NULL);
   return os_localtime_r(&rawtime, result);


### PR DESCRIPTION
closes #8727

Before:

    2018/07/11 23:39:56 INFO  11124 main:560: starting main loop

After:

    INFO  180711.233956.807 11124 main:560: starting main loop

About the format changes:

- Log-level name (INFO/ERROR/…) should be in the first column, so that  filtering by log-level is maximally trivial.
- Use 2-digit year. 4-digit year is useless, logs don't survive for  decades without context.

Note:
  - Only implemented for Unix, `gettimeofday()` is not available on Windows.
  - Can't use uv_hrtime() nor uv_now(), they are not "since the epoch".    Also, log.c can't assume a loop exists.