### PR TITLE
startup: fix ":if 0|syntax on|endif" bug

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3425,9 +3425,9 @@ static void syn_cmd_off(exarg_T *eap, int syncing)
 static void syn_cmd_onoff(exarg_T *eap, char *name)
   FUNC_ATTR_NONNULL_ALL
 {
-  did_syntax_onoff = true;
   eap->nextcmd = check_nextcmd(eap->arg);
   if (!eap->skip) {
+    did_syntax_onoff = true;
     char buf[100];
     memcpy(buf, "so ", 4);
     vim_snprintf(buf + 3, sizeof(buf) - 3, SYNTAX_FNAME, name);

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -118,6 +118,13 @@ describe('startup defaults', function()
       clear('-u', 'NORC', '-c', 'syntax off')
       eq(0, eval('exists("g:syntax_on")'))
     end)
+
+    it('":if 0|syntax on|endif" does not affect default #8728', function()
+      clear('-u', 'NORC', '--cmd', ':if 0|syntax on|endif')
+      eq(1, eval('exists("g:syntax_on")'))
+      clear('-u', 'NORC', '--cmd', ':if 0|syntax off|endif')
+      eq(1, eval('exists("g:syntax_on")'))
+    end)
   end)
 
   describe("'fillchars'", function()


### PR DESCRIPTION
Problem: ":if 0|syntax {on,off}|endif" skips the default of "syntax on"
because the executor was setting the `did_syntax_onoff` flag even though
"syntax {on,off}" is not actually executed.

closes #8728

--

pushed again to retry quickbuild.