### PR TITLE
ruby: detect rbenv shims for other versions

### DIFF
--- a/runtime/autoload/provider/ruby.vim
+++ b/runtime/autoload/provider/ruby.vim
@@ -5,11 +5,7 @@ endif
 let g:loaded_ruby_provider = 1
 
 function! provider#ruby#Detect() abort
-  if exists("g:ruby_host_prog")
-    return g:ruby_host_prog
-  else
-    return has('win32') ? exepath('neovim-ruby-host.bat') : exepath('neovim-ruby-host')
-  end
+  return s:prog
 endfunction
 
 function! provider#ruby#Prog() abort
@@ -47,8 +43,24 @@ function! provider#ruby#Call(method, args) abort
   return call('rpcrequest', insert(insert(a:args, 'ruby_'.a:method), s:host))
 endfunction
 
+function! s:detect()
+  if exists("g:ruby_host_prog")
+    return g:ruby_host_prog
+  elseif has('win32')
+    return exepath('neovim-ruby-host.bat')
+  else
+    let p = exepath('neovim-ruby-host')
+    if empty(p)
+      return ''
+    endif
+    " neovim-ruby-host could be an rbenv shim for another Ruby version.
+    call system(p)
+    return v:shell_error ? '' : p
+  end
+endfunction
+
 let s:err = ''
-let s:prog = provider#ruby#Detect()
+let s:prog = s:detect()
 let s:plugin_path = expand('<sfile>:p:h') . '/script_host.rb'
 
 if empty(s:prog)


### PR DESCRIPTION
When rbenv is used for managing Ruby installations, just checking for an
executable called "neovim-ruby-host" is not enough. It has to be run as well.

If it does not return 0, then neovim-ruby-host is merely a shim for another Ruby
installation.

```
  $ rbenv versions
    2.5.0
  * 2.5.1 (set by /Users/mhi/.rbenv/version)

  $ rbenv whence neovim-ruby-host
  2.5.0

  $ which neovim-ruby-host
  /Users/mhi/.rbenv/shims/neovim-ruby-host

  $ neovim-ruby-host
  rbenv: neovim-ruby-host: command not found

  The `neovim-ruby-host' command exists in these Ruby versions:
    2.5.0

  $ echo $?
  127
```

Additionally, the detection logic was moved from provider#ruby#Detect() to
s:detect(), because the former is run in the sandbox which forbids calling
system().

---

I found this because the tests would hang for me, because `missing_provider('ruby')` (which uses `provider#ruby#Detect()` reported the shim exectuable and tried running the Ruby tests with it.