### PR TITLE
[RDY] vim-patch:8.0.0630

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -37,7 +37,7 @@ of area is used, see |visual-repeat|.
 ==============================================================================
 2. Multiple repeats					*multi-repeat*
 
-						*:g* *:global* *E147* *E148*
+						*:g* *:global* *E148*
 :[range]g[lobal]/{pattern}/[cmd]
 			Execute the Ex command [cmd] (default ":p") on the
 			lines within [range] where {pattern} matches.
@@ -70,8 +70,15 @@ The default for [range] is the whole buffer (1,$).  Use "CTRL-C" to interrupt
 the command.  If an error message is given for a line, the command for that
 line is aborted and the global command continues with the next marked or
 unmarked line.
+								*E147* 
+When the command is used recursively, it only works on one line.  Giving a
+range is then not allowed. This is useful to find all lines that match a
+pattern and do not match another pattern: >
+	:g/found/v/notfound/{cmd}
+This first finds all lines containing "found", but only executes {cmd} when
+there is no match for "notfound".
 
-To repeat a non-Ex command, you can use the ":normal" command: >
+To execute a non-Ex command, you can use the `:normal` command: >
 	:g/pat/normal {commands}
 Make sure that {commands} ends with a whole command, otherwise Vim will wait
 for you to type the rest of the command for each match.  The screen will not

--- a/src/nvim/testdir/test_global.vim
+++ b/src/nvim/testdir/test_global.vim
@@ -9,3 +9,12 @@ func Test_yank_put_clipboard()
   set clipboard&
   bwipe!
 endfunc
+
+func Test_nested_global()
+  new
+  call setline(1, ['nothing', 'found', 'found bad', 'bad'])
+  call assert_fails('g/found/3v/bad/s/^/++/', 'E147')
+  g/found/v/bad/s/^/++/
+  call assert_equal(['nothing', '++found', 'found bad', 'bad'], getline(1, 4))
+  bwipe!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0630: it is not easy to work on lines without a match**

Problem:    The :global command does not work recursively, which makes it
            difficult to execute a command on a line where one pattern matches
            and another does not match. (Miles Cranmer)
Solution:   Allow for recursion if it is for only one line. (closes vim/vim#1760)
https://github.com/vim/vim/commit/f84b122a99da75741ae686fabb6f81b8b4755998