### PR TITLE
Check all child processes for exit in SIGCHLD handler

### DIFF
--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -291,6 +291,5 @@ static void chld_handler(uv_signal_t *handle, int signum)
       proc->status = WTERMSIG(stat);
     }
     proc->internal_exit_cb(proc);
-    break;
   }
 }


### PR DESCRIPTION
If a second and third child exit while we are already in the handler, we
will only see a single additional SIGCHLD.  Therefore the handler must
not stop after processing a single child but should check all children.

Fixes #8740