### PR TITLE
[RFC] FUNC_ATTR_PRINTF_LIKE

### DIFF
--- a/src/nvim/api/private/dispatch.c
+++ b/src/nvim/api/private/dispatch.c
@@ -41,7 +41,7 @@ MsgpackRpcRequestHandler msgpack_rpc_get_handler_for(const char *name,
 
   if (!rv.fn) {
     api_set_error(error, kErrorTypeException, "Invalid method: %.*s",
-                  m.size > 0 ? m.size : sizeof("<empty>"),
+                  m.size > 0 ? (int)m.size : (int)sizeof("<empty>"),
                   m.size > 0 ? m.data : "<empty>");
   }
   return rv;

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1157,7 +1157,7 @@ static void set_option_value_err(char *key,
 }
 
 void api_set_error(Error *err, ErrorType errType, const char *format, ...)
-  FUNC_ATTR_NONNULL_ALL
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PRINTF(3, 4)
 {
   assert(kErrorTypeNone != errType);
   va_list args1;

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -222,9 +222,8 @@ static void ui_set_option(UI *ui, bool init, String name, Object value,
     if (strequal(name.data, ui_ext_names[i])
         || (i == kUIPopupmenu && is_popupmenu)) {
       if (value.type != kObjectTypeBoolean) {
-        snprintf((char *)IObuff, IOSIZE, "%s must be a Boolean",
-                 name.data);
-        api_set_error(error, kErrorTypeValidation, (char *)IObuff);
+        api_set_error(error, kErrorTypeValidation, "%s must be a Boolean",
+                      name.data);
         return;
       }
       bool boolval = value.data.boolean;

--- a/src/nvim/func_attr.h
+++ b/src/nvim/func_attr.h
@@ -99,6 +99,10 @@
 # undef FUNC_ATTR_NO_SANITIZE_UNDEFINED
 #endif
 
+#ifdef FUNC_ATTR_PRINTF
+# undef FUNC_ATTR_PRINTF
+#endif
+
 #ifndef DID_REAL_ATTR
 # define DID_REAL_ATTR
 # ifdef __GNUC__
@@ -117,6 +121,7 @@
 #  define REAL_FATTR_NONNULL_ALL __attribute__((nonnull))
 #  define REAL_FATTR_NONNULL_ARG(...) __attribute__((nonnull(__VA_ARGS__)))
 #  define REAL_FATTR_NORETURN __attribute__((noreturn))
+#  define REAL_FATTR_PRINTF(x, y) __attribute__((format (printf, x, y)))
 
 #  if NVIM_HAS_ATTRIBUTE(returns_nonnull)
 #   define REAL_FATTR_NONNULL_RET __attribute__((returns_nonnull))
@@ -193,6 +198,10 @@
 # ifndef REAL_FATTR_NO_SANITIZE_UNDEFINED
 #  define REAL_FATTR_NO_SANITIZE_UNDEFINED
 # endif
+
+# ifndef REAL_FATTR_PRINTF
+#  define REAL_FATTR_PRINTF(x, y)
+# endif
 #endif
 
 #ifdef DEFINE_FUNC_ATTRIBUTES
@@ -215,6 +224,7 @@
 # define FUNC_ATTR_NONNULL_RET REAL_FATTR_NONNULL_RET
 # define FUNC_ATTR_NORETURN REAL_FATTR_NORETURN
 # define FUNC_ATTR_NO_SANITIZE_UNDEFINED REAL_FATTR_NO_SANITIZE_UNDEFINED
+# define FUNC_ATTR_PRINTF(x, y) REAL_FATTR_PRINTF(x, y)
 #elif !defined(DO_NOT_DEFINE_EMPTY_ATTRIBUTES)
 # define FUNC_ATTR_MALLOC
 # define FUNC_ATTR_ALLOC_SIZE(x)
@@ -230,4 +240,5 @@
 # define FUNC_ATTR_NONNULL_RET
 # define FUNC_ATTR_NORETURN
 # define FUNC_ATTR_NO_SANITIZE_UNDEFINED
+# define FUNC_ATTR_PRINTF(x, y)
 #endif


### PR DESCRIPTION
I added a macro for `__attribute__((format (printf, x, y)))` ; and applied it to api_set_error. After i debugged an error where i used a String struct inside a %s formatting directive. This should help to catch these errors in the future.