### PR TITLE
[RDY] vim-patch:8.0.{724,727,1799}

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2514,7 +2514,7 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
       if (oap->regname == NUL) {
         *namebuf = NUL;
       } else {
-        vim_snprintf(namebuf, sizeof(namebuf), " into \"%c", oap->regname);
+        vim_snprintf(namebuf, sizeof(namebuf), _(" into \"%c"), oap->regname);
       }
 
       // redisplay now, so message is not deleted

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2509,19 +2509,27 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
     }
     // Some versions of Vi use ">=" here, some don't...
     if (yanklines > (size_t)p_report) {
+      char namebuf[100];
+
+      if (oap->regname == NUL) {
+        *namebuf = NUL;
+      } else {
+        vim_snprintf(namebuf, sizeof(namebuf), " into \"%c", oap->regname);
+      }
+
       // redisplay now, so message is not deleted
       update_topline_redraw();
       if (yanklines == 1) {
         if (yank_type == kMTBlockWise) {
-          MSG(_("block of 1 line yanked"));
+          smsg(_("block of 1 line yanked%s"), namebuf);
         } else {
-          MSG(_("1 line yanked"));
+          smsg(_("1 line yanked%s"), namebuf);
         }
       } else if (yank_type == kMTBlockWise) {
-        smsg(_("block of %" PRId64 " lines yanked"),
-             (int64_t)yanklines);
+        smsg(_("block of %" PRId64 " lines yanked%s"),
+             (int64_t)yanklines, namebuf);
       } else {
-        smsg(_("%" PRId64 " lines yanked"), (int64_t)yanklines);
+        smsg(_("%" PRId64 " lines yanked%s"), (int64_t)yanklines, namebuf);
       }
     }
   }

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -93,6 +93,7 @@ NEW_TESTS ?= \
 	    test_quickfix.res \
 	    test_quotestar.res \
 	    test_recover.res \
+	    test_registers.res \
 	    test_retab.res \
 	    test_scrollbind.res \
 	    test_search.res \

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -1,0 +1,27 @@
+
+func Test_yank_shows_register()
+    enew
+    set report=0
+    call setline(1, ['foo', 'bar'])
+    " Line-wise
+    exe 'norm! yy'
+    call assert_equal('1 line yanked', v:statusmsg)
+    exe 'norm! "zyy'
+    call assert_equal('1 line yanked into "z', v:statusmsg)
+    exe 'norm! yj'
+    call assert_equal('2 lines yanked', v:statusmsg)
+    exe 'norm! "zyj'
+    call assert_equal('2 lines yanked into "z', v:statusmsg)
+
+    " Block-wise
+    exe "norm! \<C-V>y"
+    call assert_equal('block of 1 line yanked', v:statusmsg)
+    exe "norm! \<C-V>\"zy"
+    call assert_equal('block of 1 line yanked into "z', v:statusmsg)
+    exe "norm! \<C-V>jy"
+    call assert_equal('block of 2 lines yanked', v:statusmsg)
+    exe "norm! \<C-V>j\"zy"
+    call assert_equal('block of 2 lines yanked into "z', v:statusmsg)
+
+    bwipe!
+endfunc

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -25,3 +25,41 @@ func Test_yank_shows_register()
 
     bwipe!
 endfunc
+
+func Test_display_registers()
+    e file1
+    e file2
+    call setline(1, ['foo', 'bar'])
+    /bar
+    exe 'norm! y2l"axx'
+    call feedkeys("i\<C-R>=2*4\n\<esc>")
+    call feedkeys(":ls\n", 'xt')
+
+    let a = execute('display')
+    let b = execute('registers')
+
+    call assert_equal(a, b)
+    call assert_match('^\n--- Registers ---\n'
+          \ .         '""   a\n'
+          \ .         '"0   ba\n'
+          \ .         '"1   b\n'
+          \ .         '"a   b\n'
+          \ .         '.*'
+          \ .         '"-   a\n'
+          \ .         '.*'
+          \ .         '":   ls\n'
+          \ .         '"%   file2\n'
+          \ .         '"#   file1\n'
+          \ .         '"/   bar\n'
+          \ .         '"=   2\*4', a)
+
+    let a = execute('registers a')
+    call assert_match('^\n--- Registers ---\n'
+          \ .         '"a   b', a)
+
+    let a = execute('registers :')
+    call assert_match('^\n--- Registers ---\n'
+          \ .         '":   ls', a)
+
+    bwipe!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0724: the message for yanking doesn't indicate the register**

Problem:    The message for yanking doesn't indicate the register.
Solution:   Show the register name in the "N lines yanked" message. (Lemonboy,
            closes vim/vim#1803, closes vim/vim#1809)
vim/vim@e45deb7

**vim-patch:8.0.0727: message about what register to yank into is not translated**

Problem:    Message about what register to yank into is not translated.
            (LemonBoy)
Solution:   Add _().
vim/vim@60d0e97

**vim-patch:8.0.1799: no test for :registers command**

Problem:    No test for :registers command.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#2880)
vim/vim@7ce551f