### PR TITLE
[RFC] main: make --embed wait for first request so embedding UI can display startup messages

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -349,7 +349,16 @@ argument.
 							*--embed*
 --embed		Use stdin/stdout as a msgpack-RPC channel, so applications can
 		embed and control Nvim via the |rpc-api|.  Implies |--headless|.
-		Equivalent to: >
+
+		Nvim will wait for a single request before sourcing startup
+		files and reading buffers. This is mainly so that UIs can call
+		`nvim_ui_attach` so that the UI can show startup messages
+		and possible swap file dialog for the first loaded file. In
+		addition, a `nvim_get_api_info` call before the `nvim_ui_attach`
+		call is also allowed, so that UI features can be safely
+		detected by the UI.
+
+		To avoid this behavior, this alterative could be used instead: >
 			nvim --headless --cmd "call stdioopen({'rpc': v:true})"
 <
 		See also |channel-stdio|.

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -40,6 +40,8 @@
 static PMap(cstr_t) *event_strings = NULL;
 static msgpack_sbuffer out_buffer;
 
+static bool got_stdio_request = false;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "msgpack_rpc/channel.c.generated.h"
 #endif
@@ -329,6 +331,9 @@ static void handle_request(Channel *channel, msgpack_object *request)
     send_error(channel, request_id, error.msg);
     api_clear_error(&error);
     api_free_array(args);
+    if (channel->id == CHAN_STDIO) {
+      got_stdio_request = true;
+    }
     return;
   }
 
@@ -344,6 +349,9 @@ static void handle_request(Channel *channel, msgpack_object *request)
     if (is_get_mode && !input_blocking()) {
       // Defer the event to a special queue used by os/input.c. #6247
       multiqueue_put(ch_before_blocking_events, on_request_event, 1, evdata);
+      if (channel->id == CHAN_STDIO) {
+        got_stdio_request = true;
+      }
     } else {
       // Invoke immediately.
       on_request_event((void **)&evdata);
@@ -378,6 +386,11 @@ static void on_request_event(void **argv)
   channel_decref(channel);
   xfree(e);
   api_clear_error(&error);
+  bool is_api_info = handler.fn == handle_nvim_get_api_info;
+  // api info is used to initiate client library, ignore it
+  if (channel->id == CHAN_STDIO && !is_api_info) {
+    got_stdio_request = true;
+  }
 }
 
 static bool channel_write(Channel *channel, WBuffer *buffer)
@@ -743,4 +756,17 @@ static void log_msg_close(FILE *f, msgpack_object msg)
   log_unlock();
 }
 #endif
+
+/// Wait until embedder has done a request
+void rpc_wait_for_request(void)
+{
+  Channel *channel = find_rpc_channel(CHAN_STDIO);
+  if (!channel) {
+    // this function should only be called in --embed mode, stdio channel
+    // can be assumed.
+    abort();
+  }
+
+  LOOP_PROCESS_EVENTS_UNTIL(&main_loop, channel->events, -1, got_stdio_request);
+}
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6332,7 +6332,6 @@ int load_colors(char_u *name)
   apply_autocmds(EVENT_COLORSCHEME, name, curbuf->b_fname, FALSE, curbuf);
 
   recursive = false;
-  ui_refresh();
 
   return retval;
 }
@@ -6885,7 +6884,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       // "fg", which have been changed now.
       highlight_attr_set_all();
 
-      if (!ui_is_external(kUINewgrid)) {
+      if (!ui_is_external(kUINewgrid) && starting != NO_SCREEN) {
         // Older UIs assume that we clear the screen after normal group is
         // changed
         ui_refresh();

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -362,6 +362,8 @@ local function clear(...)
     table.insert(args, arg)
   end
   set_session(spawn(args, nil, env))
+  -- Dummy request so that --embed continues past UI initialization
+  session:request('nvim_eval', "0")
 end
 
 local function insert(...)

--- a/test/functional/plugin/helpers.lua
+++ b/test/functional/plugin/helpers.lua
@@ -3,6 +3,7 @@ local paths = require('test.config.paths')
 local helpers = require('test.functional.helpers')(nil)
 local spawn, set_session, nvim_prog, merge_args =
   helpers.spawn, helpers.set_session, helpers.nvim_prog, helpers.merge_args
+local request = helpers.request
 
 local additional_cmd = ''
 
@@ -29,6 +30,7 @@ local function reset(...)
   end
   session = spawn(nvim_argv(...))
   set_session(session)
+  request('nvim_eval', "0")
 end
 
 local function set_additional_cmd(s)

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -1,0 +1,71 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+
+local feed = helpers.feed
+local spawn, set_session = helpers.spawn, helpers.set_session
+local nvim_prog, nvim_set = helpers.nvim_prog, helpers.nvim_set
+local merge_args, prepend_argv = helpers.merge_args, helpers.prepend_argv
+
+describe('--embed UI on startup', function()
+  local session, screen
+  local function startup(...)
+    local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE',
+                       '--cmd', nvim_set, '--embed'}
+    nvim_argv = merge_args(prepend_argv, nvim_argv, {...})
+    session = spawn(nvim_argv)
+    set_session(session)
+
+    -- attach immediately after startup, for early UI
+    screen = Screen.new(60, 8)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+      [2] = {bold = true, foreground = Screen.colors.SeaGreen4},
+      [3] = {bold = true, foreground = Screen.colors.Blue1},
+    })
+  end
+
+  after_each(function()
+    session:close()
+  end)
+
+  it('can display errors', function()
+    startup('--cmd', 'echoerr invalid+')
+    screen:expect([[
+                                                                  |
+                                                                  |
+                                                                  |
+                                                                  |
+      Error detected while processing pre-vimrc command line:     |
+      E121: Undefined variable: invalid                           |
+      E15: Invalid expression: invalid+                           |
+      Press ENTER or type command to continue^                     |
+    ]])
+
+    feed('<cr>')
+    screen:expect([[
+      ^                                                            |
+      {3:~                                                           }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+                                                                  |
+    ]])
+  end)
+
+  it("doesn't erase output when setting colors", function()
+    startup('--cmd', 'echoerr "foo"', '--cmd', 'color default', '--cmd', 'echoerr "bar"')
+    screen:expect([[
+                                                                  |
+                                                                  |
+                                                                  |
+                                                                  |
+      Error detected while processing pre-vimrc command line:     |
+      foo                                                         |
+      {1:bar}                                                         |
+      {2:Press ENTER or type command to continue}^                     |
+    ]])
+  end)
+end)


### PR DESCRIPTION
This allows to properly handle first buffer swap message, as well as
errors in startup files and --cmd commands in an external UI starting nvim as a child, just by using `--embed-ui` option instead of `--embed`

Note: this does nothing that a `rpcrequest()` in a `--cmd` and a corresponding handler in the UI client cannot do. But I think default matters, making a UI that has non-racy startup should be _simple_ out of the box, rather than the UI needing to know details of the nvim startup process and event handling model even if it only ever wants to use `nvim_ui_attach` and `nvim_input`.