### PR TITLE
vim-patch:8.0.0683

### DIFF
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2556,10 +2556,20 @@ void vim_beep(unsigned val)
 {
   if (emsg_silent == 0) {
     if (!((bo_flags & val) || (bo_flags & BO_ALL))) {
-      if (p_vb) {
-        ui_call_visual_bell();
-      } else {
-        ui_call_bell();
+      static bool did_init = false;
+      static uint64_t elapsed = 0u;
+
+      // Only beep once per half a second, otherwise a sequence of beeps
+      // would freeze Vim
+      if (!did_init || uv_hrtime() > elapsed + 500000000u) {
+        did_init = true;
+        elapsed = uv_hrtime();
+
+        if (p_vb) {
+          ui_call_visual_bell();
+        } else {
+          ui_call_bell();
+        }
       }
     }
 


### PR DESCRIPTION
**vim-patch:8.0.0683: visual bell flashes too quickly**

Problem:    When using a visual bell there is no delay, causing the flash to
            be very short, possibly unnoticeable.  Also, the flash and the
            beep can lockup the UI when repeated often.
Solution:   Do the delay in Vim or flush the output before the delay. Limit the
            bell to once per half a second. (Ozaki Kiichi, closes vim/vim#1789)
https://github.com/vim/vim/commit/2e147caa14f622dfd1c1def8e07c113b9b85d4b2