### PR TITLE
[RDY] vim-patch:8.0.1765

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1344,7 +1344,11 @@ colnr_T getvcol_nolist(pos_T *posp)
   colnr_T vcol;
 
   curwin->w_p_list = false;
-  getvcol(curwin, posp, NULL, &vcol, NULL);
+  if (posp->coladd) {
+    getvvcol(curwin, posp, NULL, &vcol, NULL);
+  } else {
+    getvcol(curwin, posp, NULL, &vcol, NULL);
+  }
   curwin->w_p_list = list_save;
   return vcol;
 }

--- a/src/nvim/testdir/test_virtualedit.vim
+++ b/src/nvim/testdir/test_virtualedit.vim
@@ -41,3 +41,21 @@ func Test_paste_end_of_line()
   bwipe!
   set virtualedit=
 endfunc
+
+func Test_edit_CTRL_G()
+  new
+  set virtualedit=insert
+  call setline(1, ['123', '1', '12'])
+  exe "normal! ggA\<c-g>jx\<c-g>jx"
+  call assert_equal(['123', '1  x', '12 x'], getline(1,'$'))
+
+  set virtualedit=all
+  %d_
+  call setline(1, ['1', '12'])
+  exe "normal! ggllix\<c-g>jx"
+  call assert_equal(['1 x', '12x'], getline(1,'$'))
+
+
+  bwipe!
+  set virtualedit=
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1765: CTRL-G j in Insert mode is incorrect when 'virtualedit' set**

Problem:    CTRL-G j in Insert mode is incorrect when 'virtualedit' is set.
Solution:   Take coladd into account. (Christian Brabandt, closes vim/vim#2743)
https://github.com/vim/vim/commit/db0eedec16621854c772760d02427804bc0a298d