### PR TITLE
[RDY] vim-patch:8.0.1398

### DIFF
--- a/test/functional/legacy/packadd_spec.lua
+++ b/test/functional/legacy/packadd_spec.lua
@@ -58,6 +58,24 @@ describe('packadd', function()
         call assert_fails("packadd", 'E471:')
       endfunc
 
+      func Test_packadd_start()
+        let plugdir = expand(s:topdir . '/pack/mine/start/other')
+        call mkdir(plugdir . '/plugin', 'p')
+        set rtp&
+        let rtp = &rtp
+        filetype on
+
+        exe 'split ' . plugdir . '/plugin/test.vim'
+        call setline(1, 'let g:plugin_works = 24')
+        wq
+
+        packadd other
+
+        call assert_equal(24, g:plugin_works)
+        call assert_true(len(&rtp) > len(rtp))
+        call assert_true(&rtp =~ (escape(plugdir, '\') . '\($\|,\)'))
+      endfunc
+
       func Test_packadd_noload()
         call mkdir(s:plugdir . '/plugin', 'p')
         call mkdir(s:plugdir . '/syntax', 'p')
@@ -283,6 +301,11 @@ describe('packadd', function()
 
   it('works with :runtime [what]', function()
     call('Test_runtime')
+    expected_empty()
+  end)
+
+  it('loads packages from "start" directory', function()
+    call('Test_packadd_start')
     expected_empty()
   end)
 


### PR DESCRIPTION
**vim-patch:8.0.1398: :packadd does not load packages from the "start" directory**

Problem:    :packadd does not load packages from the "start" directory.
            (Alejandro Hernandez)
Solution:   Make :packadd look in the "start" directory if those packages were
            not loaded on startup.
https://github.com/vim/vim/commit/9e1d399e63903c6f84d7888ad8d84ebf4e29d8a1