### PR TITLE
Add "Transitioning from Vim" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ and [more](https://github.com/neovim/neovim/wiki/Installing-Neovim)!
 Transitioning from Vim
 --------------------
 
-See [`:help nvim-features`](https://neovim.io/doc/user/nvim.html#nvim-from-vim) for instructions.
+See [`:help nvim-from-vim`](https://neovim.io/doc/user/nvim.html#nvim-from-vim) for instructions.
 
 Project layout
 --------------

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ for more information.
 
 [![Throughput Graph](https://graphs.waffle.io/neovim/neovim/throughput.svg)](https://waffle.io/neovim/neovim/metrics)
 
+Features
+--------
+
+- Modern [GUIs](https://github.com/neovim/neovim/wiki/Related-projects#gui)
+- [API](https://github.com/neovim/neovim/wiki/Related-projects#api-clients)
+  access from any language including clojure, lisp, go, haskell, lua,
+  javascript, perl, python, ruby, rust.
+- Embedded, scriptable [terminal emulator](https://neovim.io/doc/user/nvim_terminal_emulator.html)
+- Asynchronous [job control](https://github.com/neovim/neovim/pull/2247)
+- [Shared data (shada)](https://github.com/neovim/neovim/pull/2506) among multiple editor instances
+- [XDG base directories](https://github.com/neovim/neovim/pull/3470) support
+- Compatible with most Vim plugins, including Ruby and Python plugins.
+
+See [`:help nvim-features`][nvim-features] for the full list!
+
 Install from source
 -------------------
 
@@ -57,6 +72,11 @@ Pre-built packages for Windows, macOS, and Linux are found at the
 Managed packages are in [Homebrew], [Debian], [Ubuntu], [Fedora], [Arch Linux], [Gentoo],
 and [more](https://github.com/neovim/neovim/wiki/Installing-Neovim)!
 
+Transitioning from Vim
+--------------------
+
+See [`:help nvim-features`](https://neovim.io/doc/user/nvim.html#nvim-from-vim) for instructions.
+
 Project layout
 --------------
 
@@ -75,21 +95,6 @@ Project layout
     │  └─ tui/          built-in UI
     ├─ third-party/     cmake subproject to build dependencies
     └─ test/            tests (see test/README.md)
-
-Features
---------
-
-- Modern [GUIs](https://github.com/neovim/neovim/wiki/Related-projects#gui)
-- [API](https://github.com/neovim/neovim/wiki/Related-projects#api-clients)
-  access from any language including clojure, lisp, go, haskell, lua,
-  javascript, perl, python, ruby, rust.
-- Embedded, scriptable [terminal emulator](https://neovim.io/doc/user/nvim_terminal_emulator.html)
-- Asynchronous [job control](https://github.com/neovim/neovim/pull/2247)
-- [Shared data (shada)](https://github.com/neovim/neovim/pull/2506) among multiple editor instances
-- [XDG base directories](https://github.com/neovim/neovim/pull/3470) support
-- Compatible with most Vim plugins, including Ruby and Python plugins.
-
-See [`:help nvim-features`][nvim-features] for the full list!
 
 License
 -------


### PR DESCRIPTION
After installing neovim, I tried following the instructions of several
outdated blog posts to transition from vim to nvim.

This commit adds a prominent link to the README to the docs on this
subject, right after installation instructions. This makes sense to me
because most new neovim users will come from vim (at least for now).

Also, places the "features" section higher in the README, as it pertains
to more people than the project layout section, which is for those who
wish to contribute.