### PR TITLE
[RDY] vim-patch:8.0.0493

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -683,28 +683,40 @@ char_u *vim_findfile(void *search_ctx_arg)
         dirptrs[0] = file_path;
         dirptrs[1] = NULL;
 
-        /* if we have a start dir copy it in */
+        // if we have a start dir copy it in
         if (!vim_isAbsName(stackp->ffs_fix_path)
             && search_ctx->ffsc_start_dir) {
+          if (STRLEN(search_ctx->ffsc_start_dir) + 1 >= MAXPATHL) {
+            goto fail;
+          }
           STRCPY(file_path, search_ctx->ffsc_start_dir);
-          add_pathsep((char *)file_path);
+          if (!add_pathsep((char *)file_path)) {
+            goto fail;
+          }
         }
 
-        /* append the fix part of the search path */
+        // append the fix part of the search path
+        if (STRLEN(file_path) + STRLEN(stackp->ffs_fix_path) + 1 >= MAXPATHL) {
+          goto fail;
+        }
         STRCAT(file_path, stackp->ffs_fix_path);
-        add_pathsep((char *)file_path);
+        if (!add_pathsep((char *)file_path)) {
+          goto fail;
+        }
 
         rest_of_wildcards = stackp->ffs_wc_path;
         if (*rest_of_wildcards != NUL) {
           len = STRLEN(file_path);
           if (STRNCMP(rest_of_wildcards, "**", 2) == 0) {
-            /* pointer to the restrict byte
-             * The restrict byte is not a character!
-             */
+            // pointer to the restrict byte
+            // The restrict byte is not a character!
             p = rest_of_wildcards + 2;
 
             if (*p > 0) {
               (*p)--;
+              if (len + 1 >= MAXPATHL) {
+                goto fail;
+              }
               file_path[len++] = '*';
             }
 
@@ -729,8 +741,12 @@ char_u *vim_findfile(void *search_ctx_arg)
            * on the stack again for further search.
            */
           while (*rest_of_wildcards
-                 && !vim_ispathsep(*rest_of_wildcards))
+                 && !vim_ispathsep(*rest_of_wildcards)) {
+            if (len + 1 >= MAXPATHL) {
+              goto fail;
+            }
             file_path[len++] = *rest_of_wildcards++;
+          }
 
           file_path[len] = NUL;
           if (vim_ispathsep(*rest_of_wildcards))
@@ -773,10 +789,15 @@ char_u *vim_findfile(void *search_ctx_arg)
                 && !os_isdir(stackp->ffs_filearray[i]))
               continue;                 /* not a directory */
 
-            /* prepare the filename to be checked for existence
-             * below */
+            // prepare the filename to be checked for existence below
+            if (STRLEN(stackp->ffs_filearray[i]) + 1
+                + STRLEN(search_ctx->ffsc_file_to_search) >= MAXPATHL) {
+              goto fail;
+            }
             STRCPY(file_path, stackp->ffs_filearray[i]);
-            add_pathsep((char *)file_path);
+            if (!add_pathsep((char *)file_path)) {
+              goto fail;
+            }
             STRCAT(file_path, search_ctx->ffsc_file_to_search);
 
             /*
@@ -924,8 +945,14 @@ char_u *vim_findfile(void *search_ctx_arg)
       if (*search_ctx->ffsc_start_dir == 0)
         break;
 
+      if (STRLEN(search_ctx->ffsc_start_dir) + 1
+          + STRLEN(search_ctx->ffsc_fix_path) >= MAXPATHL) {
+        goto fail;
+      }
       STRCPY(file_path, search_ctx->ffsc_start_dir);
-      add_pathsep((char *)file_path);
+      if (!add_pathsep((char *)file_path)) {
+        goto fail;
+      }
       STRCAT(file_path, search_ctx->ffsc_fix_path);
 
       /* create a new stack entry */
@@ -936,6 +963,7 @@ char_u *vim_findfile(void *search_ctx_arg)
       break;
   }
 
+fail:
   xfree(file_path);
   return NULL;
 }

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -577,7 +577,7 @@ char_u *vim_findfile(void *search_ctx_arg)
   char_u      *file_path;
   char_u      *rest_of_wildcards;
   char_u      *path_end = NULL;
-  ff_stack_T  *stackp;
+  ff_stack_T  *stackp = NULL;
   size_t len;
   char_u      *p;
   char_u      *suf;
@@ -964,6 +964,7 @@ char_u *vim_findfile(void *search_ctx_arg)
   }
 
 fail:
+  ff_free_stack_element(stackp);
   xfree(file_path);
   return NULL;
 }
@@ -1222,6 +1223,10 @@ static ff_stack_T *ff_pop(ff_search_ctx_T *search_ctx)
  */
 static void ff_free_stack_element(ff_stack_T *stack_ptr)
 {
+  if (stack_ptr == NULL) {
+    return;
+  }
+
   /* free handles possible NULL pointers */
   xfree(stack_ptr->ffs_fix_path);
   xfree(stack_ptr->ffs_wc_path);

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -2,6 +2,7 @@
 " This makes testing go faster, since Vim doesn't need to restart.
 
 source test_assign.vim
+source test_cd.vim
 source test_changedtick.vim
 source test_cursor_func.vim
 source test_ex_undo.vim

--- a/src/nvim/testdir/test_cd.vim
+++ b/src/nvim/testdir/test_cd.vim
@@ -1,0 +1,13 @@
+" Test for :cd
+
+func Test_cd_large_path()
+  " This used to crash with a heap write overflow.
+  call assert_fails('cd ' . repeat('x', 5000), 'E472:')
+endfunc
+
+func Test_cd_up_and_down()
+  let path = getcwd()
+  cd ..
+  exe 'cd ' . path
+  call assert_equal(path, getcwd())
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0493: crash with cd command with very long argument**

Problem:    Crash with cd command with very long argument.
Solution:   Check for running out of space. (Dominique Pellé, closes vim/vim#1576)
https://github.com/vim/vim/commit/15618fa643867cf0d9c31f327022a22dff78a0cf

~~I didn't include the changes to `vim_findfile` because the test passed on my machine (Ubuntu 16.04).
Question is why it passed (for me) but not in Vim? It crashes if I run the test individually.~~ It passes now after freeing `stackp` in `vim_findfile`.

Close https://github.com/neovim/neovim/pull/7991