### PR TITLE
[RDY] vim-patch:8.0.{1502,1512,1622}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4420,7 +4420,7 @@ do_arg_all (
           if (i < alist->al_ga.ga_len
               && (AARGLIST(alist)[i].ae_fnum == buf->b_fnum
                   || path_full_compare(alist_name(&AARGLIST(alist)[i]),
-                      buf->b_ffname, TRUE) & kEqualFiles)) {
+                                       buf->b_ffname, true) & kEqualFiles)) {
             int weight = 1;
 
             if (old_curtab == curtab) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4977,7 +4977,8 @@ void fix_help_buffer(void)
       while (*p != NUL) {
         copy_option_part(&p, NameBuff, MAXPATHL, ",");
         rt = (char_u *)vim_getenv("VIMRUNTIME");
-        if (path_full_compare(rt, NameBuff, FALSE) != kEqualFiles) {
+        if (rt != NULL
+            && path_full_compare(rt, NameBuff, false) != kEqualFiles) {
           int fcount;
           char_u      **fnames;
           FILE        *fd;
@@ -5197,8 +5198,9 @@ static void helptags_one(char_u *dir, char_u *ext, char_u *tagfname,
    * add the "help-tags" tag.
    */
   ga_init(&ga, (int)sizeof(char_u *), 100);
-  if (add_help_tags || path_full_compare((char_u *)"$VIMRUNTIME/doc",
-          dir, FALSE) == kEqualFiles) {
+  if (add_help_tags
+      || path_full_compare((char_u *)"$VIMRUNTIME/doc",
+                           dir, false) == kEqualFiles) {
     s = xmalloc(18 + STRLEN(tagfname));
     sprintf((char *)s, "help-tags\t%s\t1\n", tagfname);
     GA_APPEND(char_u *, &ga, s);

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1365,11 +1365,11 @@ recover_names (
      */
     if (curbuf->b_ml.ml_mfp != NULL
         && (p = curbuf->b_ml.ml_mfp->mf_fname) != NULL) {
-      for (int i = 0; i < num_files; ++i)
-        if (path_full_compare(p, files[i], TRUE) & kEqualFiles) {
-          /* Remove the name from files[i].  Move further entries
-           * down.  When the array becomes empty free it here, since
-           * FreeWild() won't be called below. */
+      for (int i = 0; i < num_files; i++) {
+        if (path_full_compare(p, files[i], true) & kEqualFiles) {
+          // Remove the name from files[i].  Move further entries
+          // down.  When the array becomes empty free it here, since
+          // FreeWild() won't be called below.
           xfree(files[i]);
           if (--num_files == 0)
             xfree(files);
@@ -1377,6 +1377,7 @@ recover_names (
             for (; i < num_files; ++i)
               files[i] = files[i + 1];
         }
+      }
     }
     if (nr > 0) {
       file_count += num_files;

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -52,7 +52,8 @@
 /// @param s2 Second file name.
 /// @param checkname When both files don't exist, only compare their names.
 /// @return Enum of type FileComparison. @see FileComparison.
-FileComparison path_full_compare(char_u *s1, char_u *s2, int checkname)
+FileComparison path_full_compare(char_u *const s1, char_u *const s2,
+                                 const bool checkname)
 {
   assert(s1 && s2);
   char_u exp1[MAXPATHL];

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3603,15 +3603,16 @@ void ex_vimgrep(exarg_T *eap)
     goto theend;
   }
 
-  if (s != NULL && *s == NUL) {
-    /* Pattern is empty, use last search pattern. */
+  if (s == NULL || *s == NUL) {
+    // Pattern is empty, use last search pattern.
     if (last_search_pat() == NULL) {
       EMSG(_(e_noprevre));
       goto theend;
     }
     regmatch.regprog = vim_regcomp(last_search_pat(), RE_MAGIC);
-  } else
+  } else {
     regmatch.regprog = vim_regcomp(s, RE_MAGIC);
+  }
 
   if (regmatch.regprog == NULL)
     goto theend;

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2043,9 +2043,11 @@ char_u *did_set_spelllang(win_T *wp)
         dont_use_region = true;
 
       // Check if we loaded this language before.
-      for (slang = first_lang; slang != NULL; slang = slang->sl_next)
-        if (path_full_compare(lang, slang->sl_fname, FALSE) == kEqualFiles)
+      for (slang = first_lang; slang != NULL; slang = slang->sl_next) {
+        if (path_full_compare(lang, slang->sl_fname, false) == kEqualFiles) {
           break;
+        }
+      }
     } else {
       filename = false;
       if (len > 3 && lang[len - 3] == '_') {
@@ -2085,8 +2087,9 @@ char_u *did_set_spelllang(win_T *wp)
     }
 
     // Loop over the languages, there can be several files for "lang".
-    for (slang = first_lang; slang != NULL; slang = slang->sl_next)
-      if (filename ? path_full_compare(lang, slang->sl_fname, FALSE) == kEqualFiles
+    for (slang = first_lang; slang != NULL; slang = slang->sl_next) {
+      if (filename
+          ? path_full_compare(lang, slang->sl_fname, false) == kEqualFiles
           : STRICMP(lang, slang->sl_name) == 0) {
         region_mask = REGION_ALL;
         if (!filename && region != NULL) {
@@ -2116,6 +2119,7 @@ char_u *did_set_spelllang(win_T *wp)
             nobreak = true;
         }
       }
+    }
   }
 
   // round 0: load int_wordlist, if possible.
@@ -2137,17 +2141,21 @@ char_u *did_set_spelllang(win_T *wp)
       // If it was already found above then skip it.
       for (c = 0; c < ga.ga_len; ++c) {
         p = LANGP_ENTRY(ga, c)->lp_slang->sl_fname;
-        if (p != NULL && path_full_compare(spf_name, p, FALSE) == kEqualFiles)
+        if (p != NULL
+            && path_full_compare(spf_name, p, false) == kEqualFiles) {
           break;
+        }
       }
       if (c < ga.ga_len)
         continue;
     }
 
     // Check if it was loaded already.
-    for (slang = first_lang; slang != NULL; slang = slang->sl_next)
-      if (path_full_compare(spf_name, slang->sl_fname, FALSE) == kEqualFiles)
+    for (slang = first_lang; slang != NULL; slang = slang->sl_next) {
+      if (path_full_compare(spf_name, slang->sl_fname, false) == kEqualFiles) {
         break;
+      }
+    }
     if (slang == NULL) {
       // Not loaded, try loading it now.  The language name includes the
       // region name, the region is ignored otherwise.  for int_wordlist

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1786,7 +1786,7 @@ spell_reload_one (
   bool didit = false;
 
   for (slang = first_lang; slang != NULL; slang = slang->sl_next) {
-    if (path_full_compare(fname, slang->sl_fname, FALSE) == kEqualFiles) {
+    if (path_full_compare(fname, slang->sl_fname, false) == kEqualFiles) {
       slang_clear(slang);
       if (spell_load_file(fname, NULL, slang, false) == NULL)
         // reloading failed, clear the language
@@ -4714,9 +4714,11 @@ static void spell_make_sugfile(spellinfo_T *spin, char_u *wfname)
   // pointer-linked version of the trie.  And it avoids having two versions
   // of the code for the soundfolding stuff.
   // It might have been done already by spell_reload_one().
-  for (slang = first_lang; slang != NULL; slang = slang->sl_next)
-    if (path_full_compare(wfname, slang->sl_fname, FALSE) == kEqualFiles)
+  for (slang = first_lang; slang != NULL; slang = slang->sl_next) {
+    if (path_full_compare(wfname, slang->sl_fname, false) == kEqualFiles) {
       break;
+    }
+  }
   if (slang == NULL) {
     spell_message(spin, (char_u *)_("Reading back spell file..."));
     slang = spell_load_file(wfname, NULL, NULL, false);

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2289,7 +2289,7 @@ static char_u *tag_full_fname(tagptrs_T *tagp)
 {
   int c = *tagp->fname_end;
   *tagp->fname_end = NUL;
-  char_u *fullname = expand_tag_fname(tagp->fname, tagp->tag_fname, FALSE);
+  char_u *fullname = expand_tag_fname(tagp->fname, tagp->tag_fname, false);
   *tagp->fname_end = c;
 
   return fullname;
@@ -2363,8 +2363,8 @@ jumpto_tag (
    * Expand file name, when needed (for environment variables).
    * If 'tagrelative' option set, may change file name.
    */
-  fname = expand_tag_fname(fname, tagp.tag_fname, TRUE);
-  tofree_fname = fname;         /* free() it later */
+  fname = expand_tag_fname(fname, tagp.tag_fname, true);
+  tofree_fname = fname;         // free() it later
 
   /*
    * Check if the file with the tag exists before abandoning the current
@@ -2615,13 +2615,12 @@ erret:
   return retval;
 }
 
-/*
- * If "expand" is TRUE, expand wildcards in fname.
- * If 'tagrelative' option set, change fname (name of file containing tag)
- * according to tag_fname (name of tag file containing fname).
- * Returns a pointer to allocated memory.
- */
-static char_u *expand_tag_fname(char_u *fname, char_u *tag_fname, int expand)
+// If "expand" is true, expand wildcards in fname.
+// If 'tagrelative' option set, change fname (name of file containing tag)
+// according to tag_fname (name of tag file containing fname).
+// Returns a pointer to allocated memory.
+static char_u *expand_tag_fname(char_u *fname, char_u *const tag_fname,
+                                const bool expand)
 {
   char_u      *p;
   char_u      *expanded_fname = NULL;
@@ -2676,8 +2675,8 @@ static int test_for_current(char_u *fname, char_u *fname_end, char_u *tag_fname,
       c = *fname_end;
       *fname_end = NUL;
     }
-    fullname = expand_tag_fname(fname, tag_fname, TRUE);
-    retval = (path_full_compare(fullname, buf_ffname, TRUE) & kEqualFiles);
+    fullname = expand_tag_fname(fname, tag_fname, true);
+    retval = (path_full_compare(fullname, buf_ffname, true) & kEqualFiles);
     xfree(fullname);
     *fname_end = c;
   }


### PR DESCRIPTION
**vim-patch:8.0.1502: in out-of-memory situation character is not restored**

Problem:    In out-of-memory situation character is not restored. (Coverity)
Solution:   Restore the character in all situations.
https://github.com/vim/vim/commit/71a43c01377cb0c5cdc5f2d9a357b5ef1aa69ee3

**vim-patch:8.0.1512: warning for possibly using NULL pointer**

Problem:    Warning for possibly using NULL pointer. (Coverity)
Solution:   Skip using the pointer if it's NULL.
vim/vim@e4db7ae

**vim-patch:8.0.1622: possible NULL pointer dereference**

Problem:    Possible NULL pointer dereferencey. (Coverity)
Solution:   Reverse the check for a NULL pointer.
vim/vim@6ed86ad