### PR TITLE
[RDY] vim-patch:8.0.{726,734,794,830,835,1778,1839},8.1.0111

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2990,10 +2990,15 @@ cosh({expr})						*cosh()*
 
 count({comp}, {expr} [, {ic} [, {start}]])			*count()*
 		Return the number of times an item with value {expr} appears
-		in |List| or |Dictionary| {comp}.
+		in |String|, |List| or |Dictionary| {comp}.
+
 		If {start} is given then start with the item with this index.
 		{start} can only be used with a |List|.
+
 		When {ic} is given and it's |TRUE| then case is ignored.
+
+		When {comp} is a string then the number of not overlapping
+		occurences of {expr} is returned.
 
 
 							*cscope_connection()*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7592,9 +7592,38 @@ static void f_copy(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 static void f_count(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   long n = 0;
-  int ic = FALSE;
+  int ic = 0;
+  bool error = false;
 
-  if (argvars[0].v_type == VAR_LIST) {
+  if (argvars[2].v_type != VAR_UNKNOWN) {
+    ic = tv_get_number_chk(&argvars[2], &error);
+  }
+
+  if (argvars[0].v_type == VAR_STRING) {
+    const char_u *expr = (char_u *)tv_get_string_chk(&argvars[1]);
+    const char_u *p = argvars[0].vval.v_string;
+
+    if (!error && expr != NULL && p != NULL) {
+      if (ic) {
+        const size_t len = STRLEN(expr);
+
+        while (*p != NUL) {
+          if (mb_strnicmp(p, expr, len) == 0) {
+            n++;
+            p += len;
+          } else {
+            MB_PTR_ADV(p);
+          }
+        }
+      } else {
+        char_u *next;
+        while ((next = (char_u *)strstr((char *)p, (char *)expr)) != NULL) {
+          n++;
+          p = next + STRLEN(expr);
+        }
+      }
+    }
+  } else if (argvars[0].v_type == VAR_LIST) {
     listitem_T      *li;
     list_T          *l;
     long idx;
@@ -7602,9 +7631,6 @@ static void f_count(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     if ((l = argvars[0].vval.v_list) != NULL) {
       li = tv_list_first(l);
       if (argvars[2].v_type != VAR_UNKNOWN) {
-        bool error = false;
-
-        ic = tv_get_number_chk(&argvars[2], &error);
         if (argvars[3].v_type != VAR_UNKNOWN) {
           idx = tv_get_number_chk(&argvars[3], &error);
           if (!error) {
@@ -7630,10 +7656,7 @@ static void f_count(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     hashitem_T      *hi;
 
     if ((d = argvars[0].vval.v_dict) != NULL) {
-      bool error = false;
-
       if (argvars[2].v_type != VAR_UNKNOWN) {
-        ic = tv_get_number_chk(&argvars[2], &error);
         if (argvars[3].v_type != VAR_UNKNOWN) {
           EMSG(_(e_invarg));
         }
@@ -7649,8 +7672,9 @@ static void f_count(typval_T *argvars, typval_T *rettv, FunPtr fptr)
         }
       }
     }
-  } else
+  } else {
     EMSG2(_(e_listdictarg), "count()");
+  }
   rettv->vval.v_number = n;
 }
 

--- a/src/nvim/po/check.vim
+++ b/src/nvim/po/check.vim
@@ -173,12 +173,37 @@ elseif !plural && search('^"Plural-Forms: ', 'n')
   " We allow for a stray plural header, msginit adds one.
 endif
 
+" Check that 8bit encoding is used instead of 8-bit
+let cte = search('^"Content-Transfer-Encoding:\s\+8-bit', 'n')
+let ctc = search('^"Content-Type:.*;\s\+\<charset=[iI][sS][oO]_', 'n')
+let ctu = search('^"Content-Type:.*;\s\+\<charset=utf-8', 'n')
+if cte
+  echomsg "Content-Transfer-Encoding should be 8bit instead of 8-bit"
+  " TODO: make this an error
+  " if error == 0
+  "   let error = cte
+  " endif
+elseif ctc
+  echomsg "Content-Type charset should be 'ISO-...' instead of 'ISO_...'"
+  " TODO: make this an error
+  " if error == 0
+  "   let error = ct
+  " endif
+elseif ctu
+  echomsg "Content-Type charset should be 'UTF-8' instead of 'utf-8'"
+  " TODO: make this an error
+  " if error == 0
+  "   let error = ct
+  " endif
+endif
+
 
 if error == 0
   " If all was OK restore the view.
   call winrestview(wsv)
   echomsg "OK"
 else
+  " Put the cursor on the line with the error.
   exe error
 endif
 

--- a/src/nvim/po/check.vim
+++ b/src/nvim/po/check.vim
@@ -157,6 +157,23 @@ if executable("msgfmt")
   endif
 endif
 
+" Check that the plural form is properly initialized
+1
+let plural = search('^msgid_plural ', 'n')
+if (plural && search('^"Plural-Forms: ', 'n') == 0) || (plural && search('^msgstr\[0\] ".\+"', 'n') != plural + 1)
+  if search('^"Plural-Forms: ', 'n') == 0
+    echomsg "Missing Plural header"
+    if error == 0
+      let error = search('\(^"[A-Za-z-_]\+: .*\\n"\n\)\+\zs', 'n') - 1
+    endif
+  elseif error == 0
+    let error = plural
+  endif
+elseif !plural && search('^"Plural-Forms: ', 'n')
+  " We allow for a stray plural header, msginit adds one.
+endif
+
+
 if error == 0
   " If all was OK restore the view.
   call winrestview(wsv)

--- a/src/nvim/po/check.vim
+++ b/src/nvim/po/check.vim
@@ -117,14 +117,12 @@ endif
 func! CountNl(first, last)
   let nl = 0
   for lnum in range(a:first, a:last)
-    if getline(lnum) =~ '\\n'
-      let nl += 1
-    endif
+    let nl += count(getline(lnum), "\n")
   endfor
   return nl
 endfunc
 
-" Check that the \n at the end of the msid line is also present in the msgstr
+" Check that the \n at the end of the msgid line is also present in the msgstr
 " line.  Skip over the header.
 /^"MIME-Version:
 while 1
@@ -141,7 +139,7 @@ while 1
   let transcount = CountNl(strlnum, end - 1)
   " Allow for a few more or less line breaks when there are 2 or more
   if origcount != transcount && (origcount <= 2 || transcount <= 2)
-    echomsg 'Mismatching "\\n" in line ' . line('.')
+    echomsg 'Mismatching "\n" in line ' . line('.')
     if error == 0
       let error = lnum
     endif

--- a/src/nvim/po/check.vim
+++ b/src/nvim/po/check.vim
@@ -124,6 +124,7 @@ endfunc
 
 " Check that the \n at the end of the msgid line is also present in the msgstr
 " line.  Skip over the header.
+1
 /^"MIME-Version:
 while 1
   let lnum = search('^msgid\>')

--- a/src/nvim/po/check.vim
+++ b/src/nvim/po/check.vim
@@ -149,7 +149,7 @@ endwhile
 " Check that the file is well formed according to msgfmts understanding
 if executable("msgfmt")
   let filename = expand("%")
-  let a = system("msgfmt --statistics OLD_PO_FILE_INPUT=yes" . filename)
+  let a = system("msgfmt --statistics OLD_PO_FILE_INPUT=yes " . filename)
   if v:shell_error != 0
     let error = matchstr(a, filename.':\zs\d\+\ze:')+0
     for line in split(a, '\n') | echomsg line | endfor

--- a/src/nvim/po/check.vim
+++ b/src/nvim/po/check.vim
@@ -146,6 +146,16 @@ while 1
   endif
 endwhile
 
+" Check that the file is well formed according to msgfmts understanding
+if executable("msgfmt")
+  let filename = expand("%")
+  let a = system("msgfmt --statistics OLD_PO_FILE_INPUT=yes" . filename)
+  if v:shell_error != 0
+    let error = matchstr(a, filename.':\zs\d\+\ze:')+0
+    for line in split(a, '\n') | echomsg line | endfor
+  endif
+endif
+
 if error == 0
   " If all was OK restore the view.
   call winrestview(wsv)

--- a/src/nvim/po/cleanup.vim
+++ b/src/nvim/po/cleanup.vim
@@ -8,11 +8,17 @@
 let s:was_diff = &diff
 setl nodiff
 
-silent g/^#: /d
+" untranslated message preceded by c-format or comment
+silent g/^#, c-format\n#/.d
+silent g/^#\..*\n#/.d
+
+silent g/^#[:~] /d
 silent g/^#, fuzzy\(, .*\)\=\nmsgid ""\@!/.+1,/^$/-1s/^/#\~ /
 silent g/^msgstr"/s//msgstr "/
 silent g/^msgid"/s//msgid "/
 silent g/^msgstr ""\(\n"\)\@!/?^msgid?,.s/^/#\~ /
+
+silent g/^\n\n\n/.d
 
 if s:was_diff
   setl diff

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -680,7 +680,13 @@ func Test_count()
   call assert_equal(0, count(d, 'c', 1))
 
   call assert_fails('call count(d, "a", 0, 1)', 'E474:')
-  call assert_fails('call count("a", "a")', 'E712:')
+
+  call assert_equal(0, count("foo", "bar"))
+  call assert_equal(1, count("foo", "oo"))
+  call assert_equal(2, count("foo", "o"))
+  call assert_equal(0, count("foo", "O"))
+  call assert_equal(2, count("foo", "O", 1))
+  call assert_equal(2, count("fooooo", "oo"))
 endfunc
 
 func Test_changenr()


### PR DESCRIPTION
**vim-patch:8.0.0726: translations cleanup script is too conservative**

Problem:    Translations cleanup script is too conservative.
Solution:   Also delete untranslated messages.
vim/vim@4d2ba82

**vim-patch:8.0.0734: the script to check translations can be improved**

Problem:    The script to check translations can be improved.
Solution:   Restore the view when no errors are found.  Check for matching
            line break at the end of the message. (Christian Brabandt)
vim/vim@7f93703

**vim-patch:8.0.0794: checking translations fails with multiple NL**

Problem:    The script to check translations fails if there is more than one
            NL in one line.
Solution:   Count the number of NL characters.  Make count() accept a string.
vim/vim@9966b21

**vim-patch:8.0.0830: translating messages is not ideal**

Problem:    Translating messages is not ideal.
Solution:   Add a remark about obsolete messages.  Use msgfmt in the check
            script. (Christian Brabandt)
vim/vim@aaef1ba

**vim-patch:8.0.0835: translations check with msgfmt does not work**

Problem:    Translations check with msgfmt does not work.
Solution:   Add a space before the file name.
vim/vim@65cedb2

**vim-patch:8.0.1778: script to check translations does not always work**

Problem:    Script to check translations does not always work.
Solution:   Go to first line before searching for MIME.
vim/vim@b07bbb0

**vim-patch:8.0.1839: script to check .po file doesn't check for plural header**

Problem:    Script to check .po file doesn't check for plural header.
Solution:   Add a check that the plural header is present when needed.
vim/vim@9cfc7d8

**vim-patch:8.1.0111: .po files do not use recommended names**

Problem:    .po files do not use recommended names.
Solution:   Give a warning if the recommended name is not used.  Accept the
            recommended name for conversion. (Christian Brabandt, Ken Takata)
vim/vim@d1d037e

https://github.com/vim/vim/commit/01164a6546b4c635daf96a1f17d1cb2d07f32a66#diff-ccd7d8e3c44015469eebd2a14485dc7c includes unrelated `runtime/` changes so I can't add it here.

I didn't include `src/po/README.txt` changes because https://github.com/neovim/neovim/wiki/Building-Neovim#localization exists.