### PR TITLE
[RFC] tui: clip invalid regions on resize

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -802,7 +802,16 @@ static void reset_scroll_region(UI *ui)
 static void tui_grid_resize(UI *ui, Integer g, Integer width, Integer height)
 {
   TUIData *data = ui->data;
-  ugrid_resize(&data->grid, (int)width, (int)height);
+  UGrid *grid = &data->grid;
+  ugrid_resize(grid, (int)width, (int)height);
+
+  // resize might not always be followed by a clear before flush
+  // so clip the invalid region
+  for (size_t i = 0; i < kv_size(data->invalid_regions); i++) {
+    Rect *r = &kv_A(data->invalid_regions, i);
+    r->bot = MIN(r->bot, grid->height-1);
+    r->right = MIN(r->right, grid->width-1);
+  }
 
   if (!got_winch) {  // Try to resize the terminal window.
     UNIBI_SET_NUM_VAR(data->params[0], (int)height);


### PR DESCRIPTION
Hotfix for #8774. This TUI logic could use some simplification/refactor here, such as just storing invalid segment per line instead of intersecting rectangles logic, but I'll might look into that when back from travelling.

Also later on, there is no fundamental reason for not just redrawing as usual on resize in message mode (which could include reflow), there is aldready some logic for redisplaying messages, as used by the builting pager.