### PR TITLE
health#provider: do not use exepath with host_prog

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -291,20 +291,14 @@ function! s:check_python(version) abort
   if empty(pyname)
     call health#report_warn('No Python interpreter was found with the neovim '
             \ . 'module.  Using the first available for diagnostics.')
-  endif
-
-  if !empty(pyname)
-    if exists('g:'.host_prog_var)
-      let python_bin = exepath(pyname)
-    endif
-    let pyname = fnamemodify(pyname, ':t')
+  elseif exists('g:'.host_prog_var)
+    let python_bin = pyname
   endif
 
   if !empty(pythonx_errs)
     call health#report_error('Python provider error', pythonx_errs)
-  endif
 
-  if !empty(pyname) && empty(python_bin) && empty(pythonx_errs)
+  elseif !empty(pyname) && empty(python_bin)
     if !exists('g:'.host_prog_var)
       call health#report_info(printf('`g:%s` is not set.  Searching for '
             \ . '%s in the environment.', host_prog_var, pyname))


### PR DESCRIPTION
This would need to get `expand`ed to not become empty, and is being
handled by s:check_bin already.

`s:check_bin` will also complain about e.g.
"~/.pyenv/versions/3.6.6/bin/python" not being executable, but that
reflects that the host will fail to start with it.

Fixes https://github.com/neovim/neovim/issues/8778.