### PR TITLE
[RFC] screen.c: add update_window_hl to special redrawing entrypoints

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -507,6 +507,7 @@ void update_single_line(win_T *wp, linenr_T lnum)
         init_search_hl(wp);
         start_search_hl();
         prepare_search_hl(wp, lnum);
+        update_window_hl(wp, false);
         win_line(wp, lnum, row, row + wp->w_lines[j].wl_size, false);
         end_search_hl();
         break;
@@ -579,6 +580,7 @@ void update_debug_sign(buf_T *buf, linenr_T lnum)
 
     FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_redr_type != 0) {
+        update_window_hl(wp, wp->w_redr_type >= NOT_VALID);
         win_update(wp);
       }
       if (wp->w_redr_status) {

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, command = helpers.clear, helpers.feed, helpers.command
+local source = helpers.source
 
 describe('Signs', function()
   local screen
@@ -13,6 +14,9 @@ describe('Signs', function()
       [0] = {bold=true, foreground=255},
       [1] = {background = Screen.colors.Yellow},
       [2] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.Grey},
+      [3] = {background = Screen.colors.Gray90},
+      [4] = {bold = true, reverse = true},
+      [5] = {reverse = true},
     } )
   end)
 
@@ -42,6 +46,35 @@ describe('Signs', function()
         {2:  }{0:~                                                  }|
         {2:  }{0:~                                                  }|
         {2:  }{0:~                                                  }|
+                                                             |
+      ]])
+    end)
+
+    it('can be called right after :split', function()
+      feed('ia<cr>b<cr>c<cr><esc>gg')
+      -- This used to cause a crash due to :sign using a special redraw
+      -- (not updating nvim's specific highlight data structures)
+      -- without proper redraw first, as split just flags for redraw later.
+      source([[
+        set cursorline
+        sign define piet text=>> texthl=Search
+        split
+        sign place 3 line=2 name=piet buffer=1
+      ]])
+      screen:expect([[
+        {2:  }{3:^a                                                  }|
+        {1:>>}b                                                  |
+        {2:  }c                                                  |
+        {2:  }                                                   |
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {4:[No Name] [+]                                        }|
+        {2:  }{3:a                                                  }|
+        {1:>>}b                                                  |
+        {2:  }c                                                  |
+        {2:  }                                                   |
+        {2:  }{0:~                                                  }|
+        {5:[No Name] [+]                                        }|
                                                              |
       ]])
     end)


### PR DESCRIPTION
Might fix https://github.com/neovim/neovim/commit/989b585e105b4f343f639abf5daf820de19d4a26, though I haven't been able to reproduce it. Perhaps the neomake situation can be faked with a short script, I'll look into it.

NB: I do not know what makes debug signs so special snowflakey that they need their own entry point into the redraw subsystem (there are already ways to mark a buffer line range as visually changed even if its text doesn't change, bufhl uses it), perhaps we can just delete this code and use the standard path.