### PR TITLE
Add UseBlacklist to runtime/syntax/sshdconfig.vim

### DIFF
--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -221,6 +221,7 @@ syn keyword sshdconfigKeyword Subsystem
 syn keyword sshdconfigKeyword SyslogFacility
 syn keyword sshdconfigKeyword TCPKeepAlive
 syn keyword sshdconfigKeyword TrustedUserCAKeys
+syn keyword sshdconfigKeyword UseBlacklist
 syn keyword sshdconfigKeyword UseDNS
 syn keyword sshdconfigKeyword UseLogin
 syn keyword sshdconfigKeyword UsePAM


### PR DESCRIPTION
Add UseBlacklist to the sshdconfigKeyword syntax
group since support for blacklistd has been added
to OpenSSH since FreeBSD 11.1 and NetBSD 7.

https://www.freebsd.org/releases/11.1R/relnotes.html
http://www.netbsd.org/releases/formal-7/NetBSD-7.0.html

Problem:    UseBlacklist is not highlighted when editing sshd_config.
Solution:   Add UseBlacklist to sshdconfig.vim. (Samy Mahmoudi)

Please note that this pull request is identical to: https://github.com/vim/vim/pull/3258