### PR TITLE
Fix crash in lang_init() on macOS if lang_region = NULL

### DIFF
--- a/src/nvim/os/lang.c
+++ b/src/nvim/os/lang.c
@@ -31,7 +31,7 @@ void lang_init(void)
       char buf[20] = { 0 };
       if (CFStringGetCString(cf_lang_region, buf, 20,
                              kCFStringEncodingUTF8)) {
-        os_setenv("LANG", lang_region, true);
+        os_setenv("LANG", buf, true);
       }
     }
     CFRelease(cf_lang_region);


### PR DESCRIPTION
This is a regression after PR #7704:
mac: Set $LANG based on the system locale

CFStringGetCStringPtr sometimes returns "lang_region" = NULL,
in this case CFStringGetCString is used instead,
which places output to "buf", but "buf" was not used
by the code.