### PR TITLE
[RFC] tui: fix resize and use BCE more often

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -606,8 +606,6 @@ static void cursor_goto(UI *ui, int row, int col)
   if (row == grid->row && col == grid->col) {
     return;
   }
-  grid->row = row;
-  grid->col = col;
   if (0 == row && 0 == col) {
     unibi_out(ui, unibi_cursor_home);
     ugrid_goto(grid, row, col);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1394,6 +1394,7 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
   bool roxterm = !!os_getenv("ROXTERM_ID");
 #endif
   bool xterm = terminfo_is_term_family(term, "xterm");
+  bool kitty = terminfo_is_term_family(term, "xterm-kitty");
   bool linuxvt = terminfo_is_term_family(term, "linux");
   bool rxvt = terminfo_is_term_family(term, "rxvt");
   bool teraterm = terminfo_is_term_family(term, "teraterm");
@@ -1449,8 +1450,8 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     }
   }
 
-  if (!true_xterm) {
-    // Cannot trust terminfo; safer to disable BCE. #7624
+  if (tmux || screen || kitty) {
+    // Disable BCE in some cases we know it is not working. #8806
     unibi_set_bool(ut, unibi_back_color_erase, false);
   }
 


### PR DESCRIPTION
Fixes #7861, but currently only on BCE terminals. Also resizing the terminal is _a lot_ smoother, as we don't literally need to fill the screen with space chars one at a time.

Problem is nvim very aggressively disables BCE, even if the terminal supports it. Though you can set `XTERM_VERSION=xx` to say "trust me, I use a non-broken terminal emulator" and it works with at least pangoterm (libvterm) and gnome-terminal (libvte).

What are these terminals that claim to be xterm but doesn't actually support BCE? I tried to navigate the tangle of interlinked issues but have a hard time to extract a list of terminals that were broken, and more importantly remain broken _today_. The most common complaints seem to be about conhost/WSL, and they claim to have fixed their stuff: https://github.com/Microsoft/WSL/issues/1706. Could we switch from (ridiculously narrow) whitelist to blacklist?

- [x] clear the screen correctly on BCE terminal 
- [x]  clear the screen correctly on non-BCE terminal
- [ ] detect BCE more reasonably