### PR TITLE
channel.c: defer exit_event

### DIFF
--- a/src/nvim/event/multiqueue.c
+++ b/src/nvim/event/multiqueue.c
@@ -66,7 +66,7 @@ struct multiqueue_item {
       MultiQueueItem *parent_item;
     } item;
   } data;
-  bool link;  // true: current item is just a link to a node in a child queue
+  bool link;  // Item links to a child queue.
   QUEUE node;
 };
 
@@ -213,6 +213,7 @@ static Event multiqueueitem_get_event(MultiQueueItem *item, bool remove)
 static Event multiqueue_remove(MultiQueue *this)
 {
   assert(!multiqueue_empty(this));
+  assert(this->size > 0);
   QUEUE *h = QUEUE_HEAD(&this->headtail);
   QUEUE_REMOVE(h);
   MultiQueueItem *item = multiqueue_node_data(h);
@@ -230,13 +231,14 @@ static void multiqueue_push(MultiQueue *this, Event event)
   item->data.item.event = event;
   item->data.item.parent_item = NULL;
   QUEUE_INSERT_TAIL(&this->headtail, &item->node);
-  if (this->parent) {
+  if (this->parent != NULL) {
     // push link node to the parent queue
     item->data.item.parent_item = xmalloc(sizeof(MultiQueueItem));
     item->data.item.parent_item->link = true;
     item->data.item.parent_item->data.queue = this;
     QUEUE_INSERT_TAIL(&this->parent->headtail,
                       &item->data.item.parent_item->node);
+    this->parent->size++;
   }
   this->size++;
 }

--- a/src/nvim/event/multiqueue.c
+++ b/src/nvim/event/multiqueue.c
@@ -196,12 +196,14 @@ static Event multiqueueitem_get_event(MultiQueueItem *item, bool remove)
     // remove the child node
     if (remove) {
       QUEUE_REMOVE(&child->node);
+      linked->size--;
       xfree(child);
     }
   } else {
     // remove the corresponding link node in the parent queue
     if (remove && item->data.item.parent_item) {
       QUEUE_REMOVE(&item->data.item.parent_item->node);
+      item->data.item.parent_item->data.queue->size--;
       xfree(item->data.item.parent_item);
       item->data.item.parent_item = NULL;
     }

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -12,6 +12,7 @@
 #include "nvim/api/vim.h"
 #include "nvim/api/ui.h"
 #include "nvim/channel.h"
+#include "nvim/getchar.h"
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/libuv_process.h"
@@ -558,7 +559,9 @@ void rpc_close(Channel *channel)
 static void exit_event(void **argv)
 {
   if (!exiting) {
-    mch_exit(0);
+    // <C-\><C-N>:qall!<CR>
+    ins_typebuf((char_u *)"\034\016:qall!\n", REMAP_NONE, typebuf.tb_len, 1,
+                true);
   }
 }
 

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -12,7 +12,6 @@
 #include "nvim/api/vim.h"
 #include "nvim/api/ui.h"
 #include "nvim/channel.h"
-#include "nvim/getchar.h"
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/libuv_process.h"
@@ -552,16 +551,14 @@ void rpc_close(Channel *channel)
   channel_decref(channel);
 
   if (channel->streamtype == kChannelStreamStdio) {
-    multiqueue_put(main_loop.fast_events, exit_event, 0);
+    multiqueue_put(main_loop.events, exit_event, 0);
   }
 }
 
 static void exit_event(void **argv)
 {
   if (!exiting) {
-    // <C-\><C-N>:qall!<CR>
-    ins_typebuf((char_u *)"\034\016:qall!\n", REMAP_NONE, typebuf.tb_len, 1,
-                true);
+    mch_exit(0);
   }
 }
 

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -346,7 +346,7 @@ static bool input_poll(int ms)
     prof_inchar_enter();
   }
 
-  if ((ms == - 1 || ms > 0) && !events_enabled && !input_eof) {
+  if ((ms == -1 || ms > 0) && !events_enabled && !input_eof) {
     // The pending input provoked a blocking wait. Do special events now. #6247
     blocking = true;
     multiqueue_process_events(ch_before_blocking_events);

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -38,7 +38,7 @@ static Stream read_stream = { .closed = true };  // Input before UI starts.
 static RBuffer *input_buffer = NULL;
 static bool input_eof = false;
 static int global_fd = -1;
-static int events_enabled = 0;
+static int events_enabled = 1;
 static bool blocking = false;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -88,9 +88,9 @@ static void create_cursorhold_event(void)
 {
   // If events are enabled and the queue has any items, this function should not
   // have been called(inbuf_poll would return kInputAvail)
-  // TODO(tarruda): Cursorhold should be implemented as a timer set during the
+  // TODO(justinmk): Cursorhold should be implemented as a timer set during the
   // `state_check` callback for the states where it can be triggered.
-  assert(!events_enabled || multiqueue_empty(main_loop.events));
+  assert(multiqueue_empty(main_loop.events));
   multiqueue_put(main_loop.events, cursorhold_event, 0);
 }
 
@@ -172,7 +172,7 @@ void input_enable_events(void)
 
 void input_disable_events(void)
 {
-  events_enabled--;
+  // events_enabled--;
 }
 
 /// Test whether a file descriptor refers to a terminal.

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -129,6 +129,7 @@ describe('system()', function()
     end)
 
     after_each(function()
+      -- feed('<c-c>')
       screen:detach()
     end)
 


### PR DESCRIPTION
closes #8813
ref https://github.com/neovim/neovim/pull/7813#issuecomment-380949586
ref https://github.com/neovim/neovim/pull/8088#issuecomment-376312511

Deferring the event:

```diff
diff --git a/src/nvim/msgpack_rpc/channel.c b/src/nvim/msgpack_rpc/channel.c
index 3244d83a93c..62c7717c2e9 100644
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -532,7 +532,7 @@ void rpc_close(Channel *channel)
   channel_decref(channel);
 
   if (channel->streamtype == kChannelStreamStdio) {
-    multiqueue_put(main_loop.fast_events, exit_event, 0);
+    multiqueue_put(main_loop.events, exit_event, 0);
   }
 }
```

...leads to hangs (waiting for input):
 
```
[5/7] Building C object test/functiona...s/CMakeFiles/tty-test.dir/tty-test.c.o[K
[6/7] Linking C executable bin/tty-test[K
[6/7] Linking C executable bin/tty-test[K
[7/7] cd /home/travis/build/neovim/neo...ild/neovim/neovim/cmake/RunTests.cmake[K

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

The build has been terminated
```

---

Notes from chat with @bfredl :

> The problem is that scheduling an event doesn't guarantee any progress back to the main normal mode.

* Screen tests may hang (regardless of success or failure), after the test harness (busted) closes the channel, but nvim is stuck in press-enter
* Root cause is that Nvim doesn't check for events during press-enter (`events_enabled=0` in `os/input.c`)
    * `normal_execute..wait_return..os_inchar` waits for input forever, because it doesn't process `main_loop.events`, because `events_enabled=0`, because our current policy is that it's unsafe to process `main_loop.events` until we get back to the top of the `state_enter` loop. See also https://github.com/neovim/neovim/pull/8814#issuecomment-422274556
