### PR TITLE
[RFC] vim-patch:8.1.0240

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3603,7 +3603,7 @@ int build_stl_str_hl(
 
       // Store the current buffer number as a string variable
       vim_snprintf((char *)tmp, sizeof(tmp), "%d", curbuf->b_fnum);
-      set_internal_string_var((char_u *)"actual_curbuf", tmp);
+      set_internal_string_var((char_u *)"g:actual_curbuf", tmp);
 
       buf_T *o_curbuf = curbuf;
       win_T *o_curwin = curwin;


### PR DESCRIPTION
#### vim-patch:8.1.0240: g:actual_curbuf set in wrong scope

Problem:    g:actual_curbuf set in wrong scope. (Daniel Hahler)
Solution:   Prepend the "g:" name space. (closes vim/vim#3279)
https://github.com/vim/vim/commit/3cb4448b8a5c0192988f4e349aba6d7a91a9a4bd