### PR TITLE
scripts/vim-patch.sh: -s: use github.user for remote

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -312,8 +312,10 @@ submit_pr() {
   pr_message="$(printf '[RFC] vim-patch:%s\n\n%s\n' "${pr_title#,}" "${pr_body}")"
 
   if [[ $push_first -ne 0 ]]; then
-    echo "Pushing to 'origin/${checked_out_branch}'."
-    output="$(git push origin "${checked_out_branch}" 2>&1)" &&
+    local push_remote
+    push_remote="$(git config --get github.user || echo origin)"
+    echo "Pushing to '${push_remote}/${checked_out_branch}'."
+    output="$(git push "${push_remote}" "${checked_out_branch}" 2>&1)" &&
       msg_ok "${output}" ||
       (msg_err "${output}"; false)
 

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -315,7 +315,7 @@ submit_pr() {
     local push_remote
     push_remote="$(git config --get github.user || echo origin)"
     echo "Pushing to '${push_remote}/${checked_out_branch}'."
-    output="$(git push "${push_remote}" "${checked_out_branch}" 2>&1)" &&
+    output="$(git push --set-upstream "${push_remote}" "${checked_out_branch}" 2>&1)" &&
       msg_ok "${output}" ||
       (msg_err "${output}"; false)
 


### PR DESCRIPTION
You typically do not have write access at "origin", assuming that this
is neovim/neovim.

Maybe `vim-patch.sh -s` could take an argument for this, but this
appears to be a better default already.

[ci skip]