### PR TITLE
[RDY] vim-patch:8.0.{671,722,948,1507}

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -227,7 +227,7 @@ static int last_insert_skip;      /* nr of chars in front of previous insert */
 static int new_insert_skip;       /* nr of chars in front of current insert */
 static int did_restart_edit;            /* "restart_edit" when calling edit() */
 
-static int can_cindent;                 /* may do cindenting on this line */
+static bool can_cindent;                // may do cindenting on this line
 
 static int old_indent = 0;              /* for ^^D command in insert mode */
 
@@ -5656,8 +5656,8 @@ internal_format (
     }
 
     haveto_redraw = TRUE;
-    can_cindent = TRUE;
-    /* moved the cursor, don't autoindent or cindent now */
+    can_cindent = true;
+    // moved the cursor, don't autoindent or cindent now
     did_ai = FALSE;
     did_si = FALSE;
     can_si = FALSE;
@@ -7468,7 +7468,7 @@ static void ins_shift(int c, int lastc)
   did_si = FALSE;
   can_si = FALSE;
   can_si_back = FALSE;
-  can_cindent = FALSE;          /* no cindenting after ^D or ^T */
+  can_cindent = false;          // no cindenting after ^D or ^T
 }
 
 static void ins_del(void)
@@ -7862,7 +7862,7 @@ static void ins_mouse(int c)
       curwin = new_curwin;
       curbuf = curwin->w_buffer;
     }
-    can_cindent = TRUE;
+    can_cindent = true;
   }
 
   /* redraw status lines (in case another window became active) */
@@ -7921,7 +7921,7 @@ static void ins_mousescroll(int dir)
 
   if (!equalpos(curwin->w_cursor, tpos)) {
     start_arrow(&tpos);
-    can_cindent = TRUE;
+    can_cindent = true;
   }
 }
 
@@ -8389,8 +8389,8 @@ static bool ins_eol(int c)
                      has_format_option(FO_RET_COMS) ? OPENLINE_DO_COM : 0,
                      old_indent);
   old_indent = 0;
-  can_cindent = TRUE;
-  /* When inserting a line the cursor line must never be in a closed fold. */
+  can_cindent = true;
+  // When inserting a line the cursor line must never be in a closed fold.
   foldOpenCursor();
 
   return !i;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7881,7 +7881,7 @@ static void ins_mousescroll(int dir)
     int row = mouse_row;
     int col = mouse_col;
 
-    /* find the window at the pointer coordinates */
+    // find the window at the pointer coordinates
     win_T *const wp = mouse_find_win(&row, &col);
     if (wp == NULL) {
       return;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4465,7 +4465,7 @@ static int ins_complete(int c, bool enable_pum)
     /* First time we hit ^N or ^P (in a row, I mean) */
 
     did_ai = FALSE;
-    did_si = FALSE;
+    did_si = false;
     can_si = false;
     can_si_back = false;
     if (stop_arrow() == FAIL) {
@@ -5271,7 +5271,7 @@ insertchar (
   end_comment_pending = NUL;
 
   did_ai = FALSE;
-  did_si = FALSE;
+  did_si = false;
   can_si = false;
   can_si_back = false;
 
@@ -5660,7 +5660,7 @@ internal_format (
     can_cindent = true;
     // moved the cursor, don't autoindent or cindent now
     did_ai = FALSE;
-    did_si = FALSE;
+    did_si = false;
     can_si = false;
     can_si_back = false;
     line_breakcheck();
@@ -6082,7 +6082,7 @@ stop_insert (
     }
   }
   did_ai = FALSE;
-  did_si = FALSE;
+  did_si = false;
   can_si = false;
   can_si_back = false;
 
@@ -7466,7 +7466,7 @@ static void ins_shift(int c, int lastc)
 
   if (did_ai && *skipwhite(get_cursor_line_ptr()) != NUL)
     did_ai = FALSE;
-  did_si = FALSE;
+  did_si = false;
   can_si = false;
   can_si_back = false;
   can_cindent = false;          // no cindenting after ^D or ^T
@@ -7490,7 +7490,7 @@ static void ins_del(void)
     vim_beep(BO_BS);
   }
   did_ai = FALSE;
-  did_si = FALSE;
+  did_si = false;
   can_si = false;
   can_si_back = false;
   AppendCharToRedobuff(K_DEL);

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4467,9 +4467,10 @@ static int ins_complete(int c, bool enable_pum)
     did_ai = FALSE;
     did_si = FALSE;
     can_si = FALSE;
-    can_si_back = FALSE;
-    if (stop_arrow() == FAIL)
+    can_si_back = false;
+    if (stop_arrow() == FAIL) {
       return FAIL;
+    }
 
     line = ml_get(curwin->w_cursor.lnum);
     curs_col = curwin->w_cursor.col;
@@ -5272,7 +5273,7 @@ insertchar (
   did_ai = FALSE;
   did_si = FALSE;
   can_si = FALSE;
-  can_si_back = FALSE;
+  can_si_back = false;
 
   // If there's any pending input, grab up to INPUT_BUFLEN at once.
   // This speeds up normal text input considerably.
@@ -5661,7 +5662,7 @@ internal_format (
     did_ai = FALSE;
     did_si = FALSE;
     can_si = FALSE;
-    can_si_back = FALSE;
+    can_si_back = false;
     line_breakcheck();
   }
 
@@ -6083,7 +6084,7 @@ stop_insert (
   did_ai = FALSE;
   did_si = FALSE;
   can_si = FALSE;
-  can_si_back = FALSE;
+  can_si_back = false;
 
   /* Set '[ and '] to the inserted text.  When end_insert_pos is NULL we are
    * now in a different buffer. */
@@ -7467,7 +7468,7 @@ static void ins_shift(int c, int lastc)
     did_ai = FALSE;
   did_si = FALSE;
   can_si = FALSE;
-  can_si_back = FALSE;
+  can_si_back = false;
   can_cindent = false;          // no cindenting after ^D or ^T
 }
 
@@ -7491,7 +7492,7 @@ static void ins_del(void)
   did_ai = FALSE;
   did_si = FALSE;
   can_si = FALSE;
-  can_si_back = FALSE;
+  can_si_back = false;
   AppendCharToRedobuff(K_DEL);
 }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4466,7 +4466,7 @@ static int ins_complete(int c, bool enable_pum)
 
     did_ai = FALSE;
     did_si = FALSE;
-    can_si = FALSE;
+    can_si = false;
     can_si_back = false;
     if (stop_arrow() == FAIL) {
       return FAIL;
@@ -5272,7 +5272,7 @@ insertchar (
 
   did_ai = FALSE;
   did_si = FALSE;
-  can_si = FALSE;
+  can_si = false;
   can_si_back = false;
 
   // If there's any pending input, grab up to INPUT_BUFLEN at once.
@@ -5661,7 +5661,7 @@ internal_format (
     // moved the cursor, don't autoindent or cindent now
     did_ai = FALSE;
     did_si = FALSE;
-    can_si = FALSE;
+    can_si = false;
     can_si_back = false;
     line_breakcheck();
   }
@@ -6083,7 +6083,7 @@ stop_insert (
   }
   did_ai = FALSE;
   did_si = FALSE;
-  can_si = FALSE;
+  can_si = false;
   can_si_back = false;
 
   /* Set '[ and '] to the inserted text.  When end_insert_pos is NULL we are
@@ -7467,7 +7467,7 @@ static void ins_shift(int c, int lastc)
   if (did_ai && *skipwhite(get_cursor_line_ptr()) != NUL)
     did_ai = FALSE;
   did_si = FALSE;
-  can_si = FALSE;
+  can_si = false;
   can_si_back = false;
   can_cindent = false;          // no cindenting after ^D or ^T
 }
@@ -7491,7 +7491,7 @@ static void ins_del(void)
   }
   did_ai = FALSE;
   did_si = FALSE;
-  can_si = FALSE;
+  can_si = false;
   can_si_back = false;
   AppendCharToRedobuff(K_DEL);
 }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4456,7 +4456,7 @@ static int ins_complete(int c, bool enable_pum)
   int save_w_wrow;
   int save_w_leftcol;
   int insert_match;
-  int save_did_ai = did_ai;
+  const bool save_did_ai = did_ai;
 
   compl_direction = ins_compl_key2dir(c);
   insert_match = ins_compl_use_match(c);
@@ -4464,7 +4464,7 @@ static int ins_complete(int c, bool enable_pum)
   if (!compl_started) {
     /* First time we hit ^N or ^P (in a row, I mean) */
 
-    did_ai = FALSE;
+    did_ai = false;
     did_si = false;
     can_si = false;
     can_si_back = false;
@@ -5270,7 +5270,7 @@ insertchar (
   }
   end_comment_pending = NUL;
 
-  did_ai = FALSE;
+  did_ai = false;
   did_si = false;
   can_si = false;
   can_si_back = false;
@@ -5659,7 +5659,7 @@ internal_format (
     haveto_redraw = true;
     can_cindent = true;
     // moved the cursor, don't autoindent or cindent now
-    did_ai = FALSE;
+    did_ai = false;
     did_si = false;
     can_si = false;
     can_si_back = false;
@@ -6081,7 +6081,7 @@ stop_insert (
       }
     }
   }
-  did_ai = FALSE;
+  did_ai = false;
   did_si = false;
   can_si = false;
   can_si_back = false;
@@ -7464,8 +7464,9 @@ static void ins_shift(int c, int lastc)
   } else
     change_indent(c == Ctrl_D ? INDENT_DEC : INDENT_INC, 0, TRUE, 0, TRUE);
 
-  if (did_ai && *skipwhite(get_cursor_line_ptr()) != NUL)
-    did_ai = FALSE;
+  if (did_ai && *skipwhite(get_cursor_line_ptr()) != NUL) {
+    did_ai = false;
+  }
   did_si = false;
   can_si = false;
   can_si_back = false;
@@ -7489,7 +7490,7 @@ static void ins_del(void)
   } else if (del_char(false) == FAIL) {  // delete char under cursor
     vim_beep(BO_BS);
   }
-  did_ai = FALSE;
+  did_ai = false;
   did_si = false;
   can_si = false;
   can_si_back = false;
@@ -7659,7 +7660,7 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
         State = oldState;
       }
     }
-    did_ai = FALSE;
+    did_ai = false;
   } else {
     /*
      * Delete character(s) before the cursor.

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7884,7 +7884,11 @@ static void ins_mousescroll(int dir)
     col = mouse_col;
 
     /* find the window at the pointer coordinates */
-    curwin = mouse_find_win(&row, &col);
+    win_T *const wp = mouse_find_win(&row, &col);
+    if (wp == NULL) {
+      return;
+    }
+    curwin = wp;
     curbuf = curwin->w_buffer;
   }
   if (curwin == old_curwin)

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7871,17 +7871,13 @@ static void ins_mouse(int c)
 
 static void ins_mousescroll(int dir)
 {
-  pos_T tpos;
-  win_T       *old_curwin = curwin;
-  int did_scroll = FALSE;
-
-  tpos = curwin->w_cursor;
+  win_T *const old_curwin = curwin;
+  bool did_scroll = false;
+  pos_T tpos = curwin->w_cursor;
 
   if (mouse_row >= 0 && mouse_col >= 0) {
-    int row, col;
-
-    row = mouse_row;
-    col = mouse_col;
+    int row = mouse_row;
+    int col = mouse_col;
 
     /* find the window at the pointer coordinates */
     win_T *const wp = mouse_find_win(&row, &col);
@@ -7907,7 +7903,7 @@ static void ins_mousescroll(int dir)
     } else {
         mouse_scroll_horiz(dir);
     }
-    did_scroll = TRUE;
+    did_scroll = true;
   }
 
   curwin->w_redr_status = TRUE;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -5367,7 +5367,7 @@ internal_format (
 {
   int cc;
   int save_char = NUL;
-  int haveto_redraw = FALSE;
+  bool haveto_redraw = false;
   int fo_ins_blank = has_format_option(FO_INS_BLANK);
   int fo_multibyte = has_format_option(FO_MBYTE_BREAK);
   int fo_white_par = has_format_option(FO_WHITE_PAR);
@@ -5655,7 +5655,7 @@ internal_format (
         curwin->w_cursor.col = len;
     }
 
-    haveto_redraw = TRUE;
+    haveto_redraw = true;
     can_cindent = true;
     // moved the cursor, don't autoindent or cindent now
     did_ai = FALSE;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9493,6 +9493,9 @@ static void f_getchar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
         /* Find the window at the mouse coordinates and compute the
          * text position. */
         win = mouse_find_win(&row, &col);
+        if (win == NULL) {
+          return;
+        }
         (void)mouse_comp_pos(win, &row, &col, &lnum);
         for (wp = firstwin; wp != win; wp = wp->w_next)
           ++winnr;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1080,9 +1080,10 @@ void del_typebuf(int len, int offset)
 
   /* Reset the flag that text received from a client or from feedkeys()
    * was inserted in the typeahead buffer. */
-  typebuf_was_filled = FALSE;
-  if (++typebuf.tb_change_cnt == 0)
+  typebuf_was_filled = false;
+  if (++typebuf.tb_change_cnt == 0) {
     typebuf.tb_change_cnt = 1;
+  }
 }
 
 /*

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -442,7 +442,7 @@ void flush_buffers(int flush_typeahead)
     // Reset the flag that text received from a client or from feedkeys()
     // was inserted in the typeahead buffer.
     typebuf_was_filled = false;
-  } else {                /* remove mapped characters at the start only */
+  } else {                // remove mapped characters at the start only
     typebuf.tb_off += typebuf.tb_maplen;
     typebuf.tb_len -= typebuf.tb_maplen;
   }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -439,6 +439,9 @@ void flush_buffers(int flush_typeahead)
       ;
     typebuf.tb_off = MAXMAPLEN;
     typebuf.tb_len = 0;
+    // Reset the flag that text received from a client or from feedkeys()
+    // was inserted in the typeahead buffer.
+    typebuf_was_filled = false;
   } else {                /* remove mapped characters at the start only */
     typebuf.tb_off += typebuf.tb_maplen;
     typebuf.tb_len -= typebuf.tb_maplen;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -604,7 +604,7 @@ EXTERN pos_T where_paste_started;
  * reset when any other editing is done on the line. If an <ESC> or <RETURN>
  * is received, and did_ai is TRUE, the line is truncated.
  */
-EXTERN int did_ai INIT(= FALSE);
+EXTERN bool did_ai INIT(= false);
 
 /*
  * Column of first char after autoindent.  0 when no autoindent done.  Used

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -632,7 +632,7 @@ EXTERN int did_syncbind INIT(= FALSE);
  * This flag is set when a smart indent has been performed. When the next typed
  * character is a '{' the inserted tab will be deleted again.
  */
-EXTERN int did_si INIT(= FALSE);
+EXTERN bool did_si INIT(= false);
 
 /*
  * This flag is set after an auto indent. If the next typed character is a '}'

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -644,7 +644,7 @@ EXTERN int can_si INIT(= FALSE);
  * This flag is set after an "O" command. If the next typed character is a '{'
  * one indent will be removed.
  */
-EXTERN int can_si_back INIT(= FALSE);
+EXTERN bool can_si_back INIT(= false);
 
 // w_cursor before formatting text.
 EXTERN pos_T saved_cursor INIT(= INIT_POS_T(0, 0, 0));

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -942,8 +942,8 @@ EXTERN int no_hlsearch INIT(= FALSE);
 EXTERN linenr_T printer_page_num;
 
 
-EXTERN int typebuf_was_filled INIT(= FALSE);      /* received text from client
-                                                     or from feedkeys() */
+EXTERN bool typebuf_was_filled INIT(= false);     // received text from client
+                                                  // or from feedkeys()
 
 
 #ifdef BACKSLASH_IN_FILENAME

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -638,7 +638,7 @@ EXTERN int did_si INIT(= FALSE);
  * This flag is set after an auto indent. If the next typed character is a '}'
  * one indent will be removed.
  */
-EXTERN int can_si INIT(= FALSE);
+EXTERN bool can_si INIT(= false);
 
 /*
  * This flag is set after an "O" command. If the next typed character is a '{'

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2479,7 +2479,7 @@ int prompt_for_number(int *mouse_used)
   save_cmdline_row = cmdline_row;
   cmdline_row = 0;
   save_State = State;
-  State = CMDLINE;
+  State = ASKMORE;  // prevents a screen update when using a timer
 
   i = get_number(TRUE, mouse_used);
   if (KeyTyped) {

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -166,7 +166,7 @@ open_line (
   }
 
   u_clearline();                /* cannot do "U" command when adding lines */
-  did_si = FALSE;
+  did_si = false;
   ai_col = 0;
 
   /*
@@ -286,7 +286,7 @@ open_line (
            * checking for "if" and the like.
            */
           if (last_char == '{') {
-            did_si = TRUE;              /* do indent */
+            did_si = true;              // do indent
             no_si = TRUE;               /* don't delete it when '{' typed */
           }
           /*
@@ -296,7 +296,7 @@ open_line (
            */
           else if (last_char != ';' && last_char != '}'
                    && cin_is_cinword(ptr))
-            did_si = TRUE;
+            did_si = true;
         }
       } else {  // dir == BACKWARD
         // Skip preprocessor directives, unless they are
@@ -321,7 +321,7 @@ open_line (
         }
         p = skipwhite(ptr);
         if (*p == '}') {            // if line starts with '}': do indent
-          did_si = TRUE;
+          did_si = true;
         } else {                    // can delete indent when '{' typed
           can_si_back = true;
         }
@@ -814,8 +814,9 @@ open_line (
       }
     }
     newcol += curwin->w_cursor.col;
-    if (no_si)
-      did_si = FALSE;
+    if (no_si) {
+      did_si = false;
+    }
   }
 
   /*

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -328,8 +328,9 @@ open_line (
       }
       curwin->w_cursor = old_cursor;
     }
-    if (do_si)
-      can_si = TRUE;
+    if (do_si) {
+      can_si = true;
+    }
 
     did_ai = TRUE;
   }
@@ -666,7 +667,7 @@ open_line (
         }
       }
 
-      did_si = can_si = FALSE;
+      did_si = can_si = false;
     } else if (comment_end != NULL) {
       // We have finished a comment, so we don't use the leader.
       // If this was a C-comment and 'ai' or 'si' is set do a normal

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -320,10 +320,11 @@ open_line (
           }
         }
         p = skipwhite(ptr);
-        if (*p == '}')              /* if line starts with '}': do indent */
+        if (*p == '}') {            // if line starts with '}': do indent
           did_si = TRUE;
-        else                        /* can delete indent when '{' typed */
-          can_si_back = TRUE;
+        } else {                    // can delete indent when '{' typed
+          can_si_back = true;
+        }
       }
       curwin->w_cursor = old_cursor;
     }

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -332,7 +332,7 @@ open_line (
       can_si = true;
     }
 
-    did_ai = TRUE;
+    did_ai = true;
   }
 
   /*
@@ -710,8 +710,9 @@ open_line (
         ++less_cols_off;
       }
     }
-    if (*p_extra != NUL)
-      did_ai = FALSE;               /* append some text, don't truncate now */
+    if (*p_extra != NUL) {
+      did_ai = false;               // append some text, don't truncate now
+    }
 
     /* columns for marks adjusted for removed columns */
     less_cols = (int)(p_extra - saved_line);
@@ -738,7 +739,7 @@ open_line (
     }
     STRCAT(leader, p_extra);
     p_extra = leader;
-    did_ai = TRUE;          /* So truncating blanks works with comments */
+    did_ai = true;          // So truncating blanks works with comments
     less_cols -= lead_len;
   } else
     end_comment_pending = NUL;      /* turns out there was no leader */

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -165,7 +165,7 @@ open_line (
     *p_extra = NUL;
   }
 
-  u_clearline();                /* cannot do "U" command when adding lines */
+  u_clearline();                // cannot do "U" command when adding lines
   did_si = false;
   ai_col = 0;
 
@@ -287,7 +287,7 @@ open_line (
            */
           if (last_char == '{') {
             did_si = true;              // do indent
-            no_si = TRUE;               /* don't delete it when '{' typed */
+            no_si = true;               // don't delete it when '{' typed
           }
           /*
            * Look for "if" and the like, use 'cinwords'.

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -125,6 +125,9 @@ retnomove:
 
     // find the window where the row is in
     wp = mouse_find_win(&row, &col);
+    if (wp == NULL) {
+      return IN_UNKNOWN;
+    }
     dragwin = NULL;
     // winpos and height may change in win_enter()!
     if (row >= wp->w_height) {                  // In (or below) status line
@@ -427,6 +430,7 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
 
 // Find the window at screen position "*rowp" and "*colp".  The positions are
 // updated to become relative to the top-left of the window.
+// Returns NULL when something is wrong.
 win_T *mouse_find_win(int *rowp, int *colp)
 {
   frame_T     *fp;
@@ -450,7 +454,14 @@ win_T *mouse_find_win(int *rowp, int *colp)
       }
     }
   }
-  return fp->fr_win;
+  // When using a timer that closes a window the window might not actually
+  // exist.
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    if (wp == fp->fr_win) {
+      return wp;
+    }
+  }
+  return NULL;
 }
 
 /*

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3994,7 +3994,7 @@ static void nv_mousescroll(cmdarg_T *cap)
     row = mouse_row;
     col = mouse_col;
 
-    /* find the window at the pointer coordinates */
+    // find the window at the pointer coordinates
     win_T *const wp = mouse_find_win(&row, &col);
     if (wp == NULL) {
       return;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3995,7 +3995,11 @@ static void nv_mousescroll(cmdarg_T *cap)
     col = mouse_col;
 
     /* find the window at the pointer coordinates */
-    curwin = mouse_find_win(&row, &col);
+    win_T *const wp = mouse_find_win(&row, &col);
+    if (wp == NULL) {
+      return;
+    }
+    curwin = wp;
     curbuf = curwin->w_buffer;
   }
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2178,7 +2178,7 @@ int op_change(oparg_T *oap)
     if (!p_paste && curbuf->b_p_si
         && !curbuf->b_p_cin
         )
-      can_si = TRUE;            /* It's like opening a new line, do si */
+      can_si = true;            // It's like opening a new line, do si
   }
 
   /* First delete the text in the region.  In an empty buffer only need to

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1473,8 +1473,8 @@ int op_delete(oparg_T *oap)
       }
       if (u_save_cursor() == FAIL)
         return FAIL;
-      if (curbuf->b_p_ai) {                 /* don't delete indent */
-        beginline(BL_WHITE);                /* cursor on first non-white */
+      if (curbuf->b_p_ai) {                 // don't delete indent
+        beginline(BL_WHITE);                // cursor on first non-white
         did_ai = true;                      // delete the indent when ESC hit
         ai_col = curwin->w_cursor.col;
       } else

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1475,7 +1475,7 @@ int op_delete(oparg_T *oap)
         return FAIL;
       if (curbuf->b_p_ai) {                 /* don't delete indent */
         beginline(BL_WHITE);                /* cursor on first non-white */
-        did_ai = TRUE;                      /* delete the indent when ESC hit */
+        did_ai = true;                      // delete the indent when ESC hit
         ai_col = curwin->w_cursor.col;
       } else
         beginline(0);                       /* cursor in column 0 */

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -243,6 +243,7 @@ let s:flaky = [
       \ 'Test_quoteplus()',
       \ 'Test_quotestar()',
       \ 'Test_reltime()',
+      \ 'Test_repeat_three()',
       \ 'Test_terminal_composing_unicode()',
       \ 'Test_terminal_redir_file()',
       \ 'Test_terminal_tmap()',


### PR DESCRIPTION
**vim-patch:8.0.0671: hang when typing CTRL-C in confirm() in timer**

Problem:    When a function invoked from a timer calls confirm() and the user
            types CTRL-C then Vim hangs.
Solution:   Reset typebuf_was_filled. (Ozaki Kiichi, closes vim/vim#1791)
vim/vim@4eb6531

**vim-patch:8.0.0722: screen is messed by timer up at inputlist() prompt**

Problem:    Screen is messed by timer up at inputlist() prompt.
Solution:   Set state to ASKMORE. (closes vim/vim#1843)
vim/vim@c904107

**vim-patch:8.0.0948: crash if timer closes window while dragging status line**

Problem:    Crash if timer closes window while dragging status line.
Solution:   Check if the window still exists. (Yasuhiro Matsumoto, closes
            vim/vim#1979)
vim/vim@989a70c

**vim-patch:8.0.1507: timer test is a bit flaky**

Problem:    Timer test is a bit flaky.
Solution:   Add it to the list of flaky tests.
vim/vim@bfbea56

Subset of #8710 so that I don't have work on `extra_char`, `extra_char_shift` static variables from patches 8.0.0714 and 8.0.0720.