### PR TITLE
[RDY] vim-patch:8.1.000{3,4,5}

### DIFF
--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -33,4 +33,5 @@ if has('win32')
   let $TERM = ''
   let &shell = empty($COMSPEC) ? exepath('cmd.exe') : $COMSPEC
   set shellcmdflag=/s/c shellxquote=\" shellredir=>%s\ 2>&1
+  let &shellpipe = &shellredir
 endif

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -4,6 +4,7 @@
 source test_assign.vim
 source test_cd.vim
 source test_changedtick.vim
+source test_compiler.vim
 source test_cursor_func.vim
 source test_ex_undo.vim
 source test_ex_z.vim

--- a/src/nvim/testdir/test_compiler.vim
+++ b/src/nvim/testdir/test_compiler.vim
@@ -28,9 +28,9 @@ endfunc
 
 func Test_compiler_without_arg()
   let a=split(execute('compiler'))
-  call assert_equal($VIMRUNTIME . '/compiler/ant.vim',   a[0])
-  call assert_equal($VIMRUNTIME . '/compiler/bcc.vim',   a[1])
-  call assert_equal($VIMRUNTIME . '/compiler/xmlwf.vim', a[-1])
+  call assert_match('^.*runtime/compiler/ant.vim$',   a[0])
+  call assert_match('^.*runtime/compiler/bcc.vim$',   a[1])
+  call assert_match('^.*runtime/compiler/xmlwf.vim$', a[-1])
 endfunc
 
 func Test_compiler_completion()

--- a/src/nvim/testdir/test_compiler.vim
+++ b/src/nvim/testdir/test_compiler.vim
@@ -19,9 +19,8 @@ func Test_compiler()
   w!
   call feedkeys(":make\<CR>\<CR>", 'tx')
   let a=execute('clist')
-  call assert_equal("\n 1 Xfoo.pl:3: Global symbol \"\$foo\" "
-  \ .               "requires explicit package name "
-  \ .               "(did you forget to declare \"my $foo\"?)", a)
+  call assert_match("\n 1 Xfoo.pl:3: Global symbol \"\$foo\" "
+  \ .               "requires explicit package name", a)
 
   call delete('Xfoo.pl')
   bw!

--- a/src/nvim/testdir/test_compiler.vim
+++ b/src/nvim/testdir/test_compiler.vim
@@ -1,0 +1,50 @@
+" Test the :compiler command
+
+func Test_compiler()
+  if !executable('perl')
+    return
+  endif
+
+  e Xfoo.pl
+  compiler perl
+  call assert_equal('perl', b:current_compiler)
+  call assert_fails('let g:current_compiler', 'E121:')
+
+  call setline(1, ['#!/usr/bin/perl -w', 'use strict;', 'my $foo=1'])
+  w!
+  call feedkeys(":make\<CR>\<CR>", 'tx')
+  call assert_fails('clist', 'E42:')
+
+  call setline(1, ['#!/usr/bin/perl -w', 'use strict;', '$foo=1'])
+  w!
+  call feedkeys(":make\<CR>\<CR>", 'tx')
+  let a=execute('clist')
+  call assert_equal("\n 1 Xfoo.pl:3: Global symbol \"\$foo\" "
+  \ .               "requires explicit package name "
+  \ .               "(did you forget to declare \"my $foo\"?)", a)
+
+  call delete('Xfoo.pl')
+  bw!
+endfunc
+
+func Test_compiler_without_arg()
+  let a=split(execute('compiler'))
+  call assert_equal($VIMRUNTIME . '/compiler/ant.vim',   a[0])
+  call assert_equal($VIMRUNTIME . '/compiler/bcc.vim',   a[1])
+  call assert_equal($VIMRUNTIME . '/compiler/xmlwf.vim', a[-1])
+endfunc
+
+func Test_compiler_completion()
+  call feedkeys(":compiler \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_match('^"compiler ant bcc .* xmlwf$', @:)
+
+  call feedkeys(":compiler p\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"compiler pbx perl php pylint pyunit', @:)
+
+  call feedkeys(":compiler! p\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"compiler! pbx perl php pylint pyunit', @:)
+endfunc
+
+func Test_compiler_error()
+  call assert_fails('compiler doesnotexist', 'E666:')
+endfunc

--- a/src/nvim/testdir/test_compiler.vim
+++ b/src/nvim/testdir/test_compiler.vim
@@ -28,9 +28,9 @@ endfunc
 
 func Test_compiler_without_arg()
   let a=split(execute('compiler'))
-  call assert_match('^.*runtime/compiler/ant.vim$',   a[0])
-  call assert_match('^.*runtime/compiler/bcc.vim$',   a[1])
-  call assert_match('^.*runtime/compiler/xmlwf.vim$', a[-1])
+  call assert_match(expand('^.*runtime/compiler/ant.vim$'), a[0])
+  call assert_match(expand('^.*runtime/compiler/bcc.vim$'), a[1])
+  call assert_match(expand('^.*runtime/compiler/xmlwf.vim$'), a[-1])
 endfunc
 
 func Test_compiler_completion()


### PR DESCRIPTION
**vim-patch:8.1.0003: the :compiler command is not tested**

Problem:   The :compiler command is not tested.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#2930)
vim/vim@10561fe

**vim-patch:8.1.0004: test for :compiler command sometimes fails**

Problem:   Test for :compiler command sometimes fails.
Solution:   Be less strict about the error message. (Dominique Pelle)
vim/vim@54651f7

**vim-patch:8.1.0005: test for :compiler command fails on MS-Windows**

Problem:   Test for :compiler command fails on MS-Windows.
Solution:   Ignore difference in path.
vim/vim@d19b234

8.1.0146 depends on 8.0.1832 so it's not included.