### PR TITLE
Pass directory name to find

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -244,7 +244,7 @@ stage_patch() {
     else
       printf "\nApplying patch...\n"
       patch -p1 < "${patch_file}" || true
-      find -name '*.orig' -type f -delete
+      find . -name '*.orig' -type f -delete
     fi
     printf "\nInstructions:\n  Proceed to port the patch.\n"
   else


### PR DESCRIPTION
BSD/Mac find requires directory names before arguments and does not
allow them omitted.