### PR TITLE
vim-patch:8.1.{9,241}

### DIFF
--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -107,6 +107,19 @@ function Test_tabpage()
   call assert_equal(4, tabpagenr())
   7tabmove 5
   call assert_equal(5, tabpagenr())
+
+  " The following are a no-op
+  norm! 2gt
+  call assert_equal(2, tabpagenr())
+  tabmove 2
+  call assert_equal(2, tabpagenr())
+  2tabmove
+  call assert_equal(2, tabpagenr())
+  tabmove 1
+  call assert_equal(2, tabpagenr())
+  1tabmove
+  call assert_equal(2, tabpagenr())
+
   call assert_fails("99tabmove", 'E16:')
   call assert_fails("+99tabmove", 'E16:')
   call assert_fails("-99tabmove", 'E16:')

--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -1,5 +1,6 @@
 " Tests for tabpage
 
+
 function Test_tabpage()
   bw!
   " Simple test for opening and closing a tab page
@@ -319,6 +320,34 @@ function s:reconstruct_tabpage_for_test(nr)
   endfor
 endfunc
 
+func Test_tabpage_ctrl_pgup_pgdown()
+  enew!
+  tabnew tab1
+  tabnew tab2
+
+  call assert_equal(3, tabpagenr())
+  exe "norm! \<C-PageUp>"
+  call assert_equal(2, tabpagenr())
+  exe "norm! \<C-PageDown>"
+  call assert_equal(3, tabpagenr())
+
+  " Check wrapping at last or first page.
+  exe "norm! \<C-PageDown>"
+  call assert_equal(1, tabpagenr())
+  exe "norm! \<C-PageUp>"
+  call assert_equal(3, tabpagenr())
+
+ " With a count, <C-PageUp> and <C-PageDown> are not symmetrical somehow:
+ " - {count}<C-PageUp> goes {count} pages downward (relative count)
+ " - {count}<C-PageDown> goes to page number {count} (absolute count)
+  exe "norm! 2\<C-PageUp>"
+  call assert_equal(1, tabpagenr())
+  exe "norm! 2\<C-PageDown>"
+  call assert_equal(2, tabpagenr())
+
+  1tabonly!
+endfunc
+
 " Test for [count] of tabclose
 function Test_tabpage_with_tabclose()
 
@@ -491,6 +520,20 @@ func Test_close_on_quitpre()
     bwipe!
   endwhile
   buf Xtest
+endfunc
+
+func Test_tabs()
+  enew!
+  tabnew tab1
+  norm ixxx
+  let a=split(execute(':tabs'), "\n")
+  call assert_equal(['Tab page 1',
+      \              '    [No Name]',
+      \              'Tab page 2',
+      \              '> + tab1'], a)
+
+  1tabonly!
+  bw!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:8.1.0009: tabpages insufficiently tested**

Problem:    Tabpages insufficiently tested.
Solution:   Add more test coverage. (Dominique Pelle, closes vim/vim#2934)
vim/vim@dbe8869

**vim-patch:8.1.0241: effect of ":tabmove N" is not clear**

Problem:    Effect of ":tabmove N" is not clear.
Solution:   Add a test that shows the behavior. (Christian Brabandt,
            closes vim/vim#3288)
vim/vim@7cc5965