### PR TITLE
Vim insert setline undo fixes

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1392,11 +1392,20 @@ ins_redraw (
       && !pum_visible()) {
     aco_save_T aco;
 
+    // Sync undo when the autocommand calls setline() or append(), so that
+    // it can be undone separately.
+    u_sync_once = 2;
+
     // save and restore curwin and curbuf, in case the autocmd changes them
     aucmd_prepbuf(&aco, curbuf);
     apply_autocmds(EVENT_TEXTCHANGEDI, NULL, NULL, false, curbuf);
     aucmd_restbuf(&aco);
     curbuf->b_last_changedtick = buf_get_changedtick(curbuf);
+
+    if (u_sync_once == 1) {
+      ins_need_undo = true;
+    }
+    u_sync_once = 0;
   }
 
   // Trigger TextChangedP if changedtick differs. When the popupmenu closes

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1390,7 +1390,12 @@ ins_redraw (
   if (ready && has_event(EVENT_TEXTCHANGEDI)
       && curbuf->b_last_changedtick != buf_get_changedtick(curbuf)
       && !pum_visible()) {
+    aco_save_T aco;
+
+    // save and restore curwin and curbuf, in case the autocmd changes them
+    aucmd_prepbuf(&aco, curbuf);
     apply_autocmds(EVENT_TEXTCHANGEDI, NULL, NULL, false, curbuf);
+    aucmd_restbuf(&aco);
     curbuf->b_last_changedtick = buf_get_changedtick(curbuf);
   }
 
@@ -1400,8 +1405,13 @@ ins_redraw (
   if (ready && has_event(EVENT_TEXTCHANGEDP)
       && curbuf->b_last_changedtick_pum != buf_get_changedtick(curbuf)
       && pum_visible()) {
-      apply_autocmds(EVENT_TEXTCHANGEDP, NULL, NULL, false, curbuf);
-      curbuf->b_last_changedtick_pum = buf_get_changedtick(curbuf);
+    aco_save_T aco;
+
+    // save and restore curwin and curbuf, in case the autocmd changes them
+    aucmd_prepbuf(&aco, curbuf);
+    apply_autocmds(EVENT_TEXTCHANGEDP, NULL, NULL, false, curbuf);
+    aucmd_restbuf(&aco);
+    curbuf->b_last_changedtick_pum = buf_get_changedtick(curbuf);
   }
 
   if (must_redraw)

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -8680,11 +8680,12 @@ static char_u *do_insert_char_pre(int c)
 
   char_u *res = NULL;
   if (ins_apply_autocmds(EVENT_INSERTCHARPRE)) {
-    /* Get the value of v:char.  It may be empty or more than one
-     * character.  Only use it when changed, otherwise continue with the
-     * original character to avoid breaking autoindent. */
-    if (STRCMP(buf, get_vim_var_str(VV_CHAR)) != 0)
+    // Get the value of v:char.  It may be empty or more than one
+    // character.  Only use it when changed, otherwise continue with the
+    // original character to avoid breaking autoindent.
+    if (STRCMP(buf, get_vim_var_str(VV_CHAR)) != 0) {
       res = vim_strsave(get_vim_var_str(VV_CHAR));
+    }
   }
 
   set_vim_var_string(VV_CHAR, NULL, -1);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -423,7 +423,7 @@ void update_screen(int type)
 
     /* redraw status line after the window to minimize cursor movement */
     if (wp->w_redr_status) {
-      win_redr_status(wp);
+      win_redr_status(wp, true);  // any popup menu will be redrawn below
     }
   }
   end_search_hl();
@@ -589,7 +589,7 @@ void update_debug_sign(const buf_T *const buf, const linenr_T lnum)
       win_update(wp);
     }
     if (wp->w_redr_status) {
-      win_redr_status(wp);
+      win_redr_status(wp, false);
     }
   }
 
@@ -4542,7 +4542,7 @@ void redraw_statuslines(void)
 {
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_redr_status) {
-      win_redr_status(wp);
+      win_redr_status(wp, false);
     }
   }
   if (redraw_tabline)
@@ -4809,7 +4809,9 @@ win_redr_status_matches (
 /// Redraw the status line of window `wp`.
 ///
 /// If inversion is possible we use it. Else '=' characters are used.
-static void win_redr_status(win_T *wp)
+/// If "ignore_pum" is true, also redraw statusline when the popup menu is
+/// displayed.
+static void win_redr_status(win_T *wp, int ignore_pum)
 {
   int row;
   char_u      *p;
@@ -4832,7 +4834,7 @@ static void win_redr_status(win_T *wp)
   if (wp->w_status_height == 0) {
     // no status line, can only be last window
     redraw_cmdline = true;
-  } else if (!redrawing() || pum_drawn()) {
+  } else if (!redrawing() || (!ignore_pum && pum_drawn())) {
     // Don't redraw right now, do it later. Don't update status line when
     // popup menu is visible and may be drawn over it
     wp->w_redr_status = true;

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -567,7 +567,7 @@ func Test_OptionSet()
   " Cleanup
   au! OptionSet
   for opt in ['nu', 'ai', 'acd', 'ar', 'bs', 'backup', 'cul', 'cp']
-    exe printf(":set %s&vi", opt)
+    exe printf(":set %s&vim", opt)
   endfor
   call test_override('starting', 0)
   delfunc! AutoCommandOptionSet
@@ -1220,4 +1220,30 @@ func Test_ChangedP()
   set complete&vim completeopt&vim
 
   bw!
+endfunc
+
+let g:setline_handled = v:false
+func! SetLineOne()
+  if !g:setline_handled
+    call setline(1, "(x)")
+    let g:setline_handled = v:true
+  endif
+endfunc
+
+func Test_TextChangedI_with_setline()
+  throw 'skipped: Nvim does not support test_override()'
+  new
+  call test_override('char_avail', 1)
+  autocmd TextChangedI <buffer> call SetLineOne()
+  call feedkeys("i(\<CR>\<Esc>", 'tx')
+  call assert_equal('(', getline(1))
+  call assert_equal('x)', getline(2))
+  undo
+  call assert_equal('(', getline(1))
+  call assert_equal('', getline(2))
+  undo
+  call assert_equal('', getline(1))
+
+  call test_override('starting', 0)
+  bwipe!
 endfunc

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1239,10 +1239,8 @@ func Test_TextChangedI_with_setline()
   call assert_equal('(', getline(1))
   call assert_equal('x)', getline(2))
   undo
-  call assert_equal('(', getline(1))
-  call assert_equal('', getline(2))
-  undo
   call assert_equal('', getline(1))
+  call assert_equal('', getline(2))
 
   call test_override('starting', 0)
   bwipe!


### PR DESCRIPTION
These two patches from Vim fixed eraserhd/parinfer-rust#14 .

The first prevents corruption of undo history when setline() is called from a TextChangeI handler.  The second merges undo in insert mode to behave more like the user expects.