### PR TITLE
[RDY] vim-patch:8.1.0024

### DIFF
--- a/src/nvim/testdir/test_goto.vim
+++ b/src/nvim/testdir/test_goto.vim
@@ -309,3 +309,65 @@ func Test_gd_local_block()
   \ ]
   call XTest_goto_decl('1gd', lines, 11, 11)
 endfunc
+
+func Test_motion_if_elif_else_endif()
+  new
+  a
+/* Test pressing % on #if, #else #elsif and #endif,
+ * with nested #if
+ */
+#if FOO
+/* ... */
+#  if BAR
+/* ... */
+#  endif
+#elif BAR
+/* ... */
+#else
+/* ... */
+#endif
+.
+  /#if FOO
+  norm %
+  call assert_equal([9, 1], getpos('.')[1:2])
+  norm %
+  call assert_equal([11, 1], getpos('.')[1:2])
+  norm %
+  call assert_equal([13, 1], getpos('.')[1:2])
+  norm %
+  call assert_equal([4, 1], getpos('.')[1:2])
+  /#  if BAR
+  norm $%
+  call assert_equal([8, 1], getpos('.')[1:2])
+  norm $%
+  call assert_equal([6, 1], getpos('.')[1:2])
+
+  bw!
+endfunc
+
+func Test_motion_c_comment()
+  new
+  a
+/*
+ * Test pressing % on beginning/end
+ * of C comments.
+ */
+/* Another comment */
+.
+  norm gg0%
+  call assert_equal([4, 3], getpos('.')[1:2])
+  norm %
+  call assert_equal([1, 1], getpos('.')[1:2])
+  norm gg0l%
+  call assert_equal([4, 3], getpos('.')[1:2])
+  norm h%
+  call assert_equal([1, 1], getpos('.')[1:2])
+
+  norm G^
+  norm %
+  call assert_equal([5, 21], getpos('.')[1:2])
+  norm %
+  call assert_equal([5, 1], getpos('.')[1:2])
+
+  bw!
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0024: % command not testded on vim/vim#ifdef and comment**

Problem:    % command not testded on vim/vim#ifdef and comment.
Solution:   Add tests. (Dominique Pelle, closes vim/vim#2956)
https://github.com/vim/vim/commit/6b69e5c646faecf2a686bfe71dc17a2a1c6d344f