### PR TITLE
[RDY] vim-patch:8.0.1819

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3525,8 +3525,8 @@ static int b0_magic_wrong(ZERO_BL *b0p)
  *		== 0   == 0	OK	FAIL	TRUE
  *
  * current file doesn't exist, inode for swap unknown, both file names not
- * available -> probably same file
- *		== 0   == 0    FAIL	FAIL	FALSE
+ * available -> compare file names
+ *		== 0   == 0    FAIL	FAIL	fname_c != fname_s
  *
  * Only the last 32 bits of the inode will be used. This can't be changed
  * without making the block 0 incompatible with 32 bit versions.
@@ -3576,10 +3576,12 @@ fnamecmp_ino (
 
   /*
    * Can't compare inodes or file names, guess that the files are different,
-   * unless both appear not to exist at all.
+   * unless both appear not to exist at all, then compare with the file name
+   * in the swap file.
    */
-  if (ino_s == 0 && ino_c == 0 && retval_c == FAIL && retval_s == FAIL)
-    return FALSE;
+  if (ino_s == 0 && ino_c == 0 && retval_c == FAIL && retval_s == FAIL) {
+    return STRCMP(fname_c, fname_s) != 0;
+  }
   return TRUE;
 }
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3532,10 +3532,9 @@ static int b0_magic_wrong(ZERO_BL *b0p)
  * without making the block 0 incompatible with 32 bit versions.
  */
 
-static int
-fnamecmp_ino (
-    char_u *fname_c,               /* current file name */
-    char_u *fname_s,               /* file name from swap file */
+static bool fnamecmp_ino(
+    char_u *fname_c,              // current file name
+    char_u *fname_s,              // file name from swap file
     long ino_block0
 )
 {
@@ -3582,7 +3581,7 @@ fnamecmp_ino (
   if (ino_s == 0 && ino_c == 0 && retval_c == FAIL && retval_s == FAIL) {
     return STRCMP(fname_c, fname_s) != 0;
   }
-  return TRUE;
+  return true;
 }
 
 /*

--- a/src/nvim/testdir/test_swap.vim
+++ b/src/nvim/testdir/test_swap.vim
@@ -46,3 +46,18 @@ func Test_swap_directory()
   call delete("Xtest2", "rf")
   call delete("Xtest.je", "rf")
 endfunc
+
+func Test_missing_dir()
+  call mkdir('Xswapdir')
+  exe 'set directory=' . getcwd() . '/Xswapdir'
+
+  call assert_equal('', glob('foo'))
+  call assert_equal('', glob('bar'))
+  edit foo/x.txt
+  " This should not give a warning for an existing swap file.
+  split bar/x.txt
+  only
+
+  set directory&
+  call delete('Xswapdir', 'rf')
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1819: swap file warning for file with non-existing directory**

Problem:    Swap file warning for a file in a non-existing directory, if there
            is another with the same file name. (Juergen Weigert)
Solution:   When expanding the file name fails compare the file names.
https://github.com/vim/vim/commit/8c3169c58eef3e04f643fe9e045a97b81429e0cb