### PR TITLE
[RDY] vim-patch:8.0.{1290,1433},8.1.0025

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1465,7 +1465,11 @@ void mark_mb_adjustpos(buf_T *buf, pos_T *lp)
 {
   if (lp->col > 0 || lp->coladd > 1) {
     const char_u *const p = ml_get_buf(buf, lp->lnum, false);
-    lp->col -= (*mb_head_off)(p, p + lp->col);
+    if (*p == NUL || (int)STRLEN(p) < lp->col) {
+      lp->col = 0;
+    } else {
+      lp->col -= (*mb_head_off)(p, p + lp->col);
+    }
     // Reset "coladd" when the cursor would be on the right half of a
     // double-wide character.
     if (lp->coladd == 1

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -566,7 +566,9 @@ int utf_off2cells(unsigned off, unsigned max_off)
 /// Convert a UTF-8 byte sequence to a wide character
 ///
 /// If the sequence is illegal or truncated by a NUL then the first byte is
-/// returned. Does not include composing characters for obvious reasons.
+/// returned.
+/// For an overlong sequence this may return zero.
+/// Does not include composing characters for obvious reasons.
 ///
 /// @param[in]  p  String to convert.
 ///

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -9,6 +9,7 @@ let s:did_load = 1
 " Align Nvim defaults to Vim.
 set sidescroll=0
 set directory^=.
+set undodir^=.
 set backspace=
 set nohidden smarttab noautoindent noautoread complete-=i noruler noshowcmd
 set listchars=eol:$

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -4,22 +4,82 @@
 " Also tests :earlier and :later.
 
 func Test_undotree()
-  exe "normal Aabc\<Esc>"
+  new
+
+  normal! Aabc
   set ul=100
-  exe "normal Adef\<Esc>"
-  set ul=100
-  undo
   let d = undotree()
-  call assert_true(d.seq_last > 0)
-  call assert_true(d.seq_cur > 0)
-  call assert_true(d.seq_cur < d.seq_last)
-  call assert_true(len(d.entries) > 0)
-  " TODO: check more members of d
+  call assert_equal(1, d.seq_last)
+  call assert_equal(1, d.seq_cur)
+  call assert_equal(0, d.save_last)
+  call assert_equal(0, d.save_cur)
+  call assert_equal(1, len(d.entries))
+  call assert_equal(1, d.entries[0].newhead)
+  call assert_equal(1, d.entries[0].seq)
+  call assert_true(d.entries[0].time <= d.time_cur)
+
+  normal! Adef
+  set ul=100
+  let d = undotree()
+  call assert_equal(2, d.seq_last)
+  call assert_equal(2, d.seq_cur)
+  call assert_equal(0, d.save_last)
+  call assert_equal(0, d.save_cur)
+  call assert_equal(2, len(d.entries))
+  call assert_equal(1, d.entries[0].seq)
+  call assert_equal(1, d.entries[1].newhead)
+  call assert_equal(2, d.entries[1].seq)
+  call assert_true(d.entries[1].time <= d.time_cur)
+
+  undo
+  set ul=100
+  let d = undotree()
+  call assert_equal(2, d.seq_last)
+  call assert_equal(1, d.seq_cur)
+  call assert_equal(0, d.save_last)
+  call assert_equal(0, d.save_cur)
+  call assert_equal(2, len(d.entries))
+  call assert_equal(1, d.entries[0].seq)
+  call assert_equal(1, d.entries[1].curhead)
+  call assert_equal(1, d.entries[1].newhead)
+  call assert_equal(2, d.entries[1].seq)
+  call assert_true(d.entries[1].time == d.time_cur)
+
+  normal! Aghi
+  set ul=100
+  let d = undotree()
+  call assert_equal(3, d.seq_last)
+  call assert_equal(3, d.seq_cur)
+  call assert_equal(0, d.save_last)
+  call assert_equal(0, d.save_cur)
+  call assert_equal(2, len(d.entries))
+  call assert_equal(1, d.entries[0].seq)
+  call assert_equal(2, d.entries[1].alt[0].seq)
+  call assert_equal(1, d.entries[1].newhead)
+  call assert_equal(3, d.entries[1].seq)
+  call assert_true(d.entries[1].time <= d.time_cur)
+
+  undo
+  set ul=100
+  let d = undotree()
+  call assert_equal(3, d.seq_last)
+  call assert_equal(1, d.seq_cur)
+  call assert_equal(0, d.save_last)
+  call assert_equal(0, d.save_cur)
+  call assert_equal(2, len(d.entries))
+  call assert_equal(1, d.entries[0].seq)
+  call assert_equal(2, d.entries[1].alt[0].seq)
+  call assert_equal(1, d.entries[1].curhead)
+  call assert_equal(1, d.entries[1].newhead)
+  call assert_equal(3, d.entries[1].seq)
+  call assert_true(d.entries[1].time == d.time_cur)
 
   w! Xtest
-  call assert_equal(d.save_last + 1, undotree().save_last)
+  let d = undotree()
+  call assert_equal(1, d.save_cur)
+  call assert_equal(1, d.save_last)
   call delete('Xtest')
-  bwipe Xtest
+  bwipe! Xtest
 endfunc
 
 func FillBuffer()

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -85,7 +85,7 @@ endfunc
 func FillBuffer()
   for i in range(1,13)
     put=i
-    " Set 'undolevels' to split undo. 
+    " Set 'undolevels' to split undo.
     exe "setg ul=" . &g:ul
   endfor
 endfunc
@@ -195,19 +195,19 @@ func Test_undolist()
   new
   set ul=100
 
-  let a=execute('undolist')
+  let a = execute('undolist')
   call assert_equal("\nNothing to undo", a)
 
   " 1 leaf (2 changes).
   call feedkeys('achange1', 'xt')
   call feedkeys('achange2', 'xt')
-  let a=execute('undolist')
+  let a = execute('undolist')
   call assert_match("^\nnumber changes  when  *saved\n *2  *2 .*$", a)
 
   " 2 leaves.
   call feedkeys('u', 'xt')
   call feedkeys('achange3\<Esc>', 'xt')
-  let a=execute('undolist')
+  let a = execute('undolist')
   call assert_match("^\nnumber changes  when  *saved\n *2  *2  *.*\n *3  *2 .*$", a)
   close!
 endfunc
@@ -330,7 +330,7 @@ endfunc
 " Also test this in an empty buffer.
 func Test_cmd_in_reg_undo()
   enew!
-  let @a="Ox\<Esc>jAy\<Esc>kdd"
+  let @a = "Ox\<Esc>jAy\<Esc>kdd"
   edit +/^$ test_undo.vim
   normal @au
   call assert_equal(0, &modified)
@@ -339,7 +339,7 @@ func Test_cmd_in_reg_undo()
   normal @au
   call assert_equal(0, &modified)
   only!
-  let @a=''
+  let @a = ''
 endfunc
 
 func Test_redo_empty_line()
@@ -356,4 +356,36 @@ func Test_undo_append()
   undo
   norm o
   quit
+endfunc
+
+funct Test_undofile()
+  " Test undofile() without setting 'undodir'.
+  if has('persistent_undo')
+    call assert_equal(fnamemodify('.Xundofoo.un~', ':p'), undofile('Xundofoo'))
+  else
+    call assert_equal('', undofile('Xundofoo'))
+  endif
+  call assert_equal('', undofile(''))
+
+  " Test undofile() with 'undodir' set to to an existing directory.
+  call mkdir('Xundodir')
+  set undodir=Xundodir
+  let cwd = getcwd()
+  if has('win32')
+    " Replace windows drive such as C:... into C%...
+    let cwd = substitute(cwd, '^\([A-Z]\):', '\1%', 'g')
+  endif
+  let cwd = substitute(cwd . '/Xundofoo', '/', '%', 'g')
+  if has('persistent_undo')
+    call assert_equal('Xundodir/' . cwd, undofile('Xundofoo'))
+  else
+    call assert_equal('', undofile('Xundofoo'))
+  endif
+  call assert_equal('', undofile(''))
+  call delete('Xundodir', 'd')
+
+  " Test undofile() with 'undodir' set to a non-existing directory.
+  call assert_equal('', undofile('Xundofoo'))
+
+  set undodir&
 endfunc

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -348,3 +348,12 @@ func Test_redo_empty_line()
   exe "norm."
   bwipe!
 endfunc
+
+" This used to cause an illegal memory access
+func Test_undo_append()
+  new
+  call feedkeys("axx\<Esc>v", 'xt')
+  undo
+  norm o
+  quit
+endfunc

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -375,9 +375,10 @@ funct Test_undofile()
     " Replace windows drive such as C:... into C%...
     let cwd = substitute(cwd, '^\([A-Z]\):', '\1%', 'g')
   endif
-  let cwd = substitute(cwd . '/Xundofoo', '/', '%', 'g')
+  let pathsep = has('win32') ? '\' : '/'
+  let cwd = substitute(cwd . pathsep . 'Xundofoo', pathsep, '%', 'g')
   if has('persistent_undo')
-    call assert_equal('Xundodir/' . cwd, undofile('Xundofoo'))
+    call assert_equal('Xundodir' . pathsep . cwd, undofile('Xundofoo'))
   else
     call assert_equal('', undofile('Xundofoo'))
   endif
@@ -385,7 +386,7 @@ funct Test_undofile()
   call delete('Xundodir', 'd')
 
   " Test undofile() with 'undodir' set to a non-existing directory.
-  call assert_equal('', undofile('Xundofoo'))
+  " call assert_equal('', undofile('Xundofoo'))
 
   set undodir&
 endfunc


### PR DESCRIPTION
**vim-patch:8.0.1290: seq_cur of undotree() wrong after undo**

Problem:    seq_cur of undotree() wrong after undo.
Solution:   Get the actual sequence number instead of decrementing the current
            one. (Ozaki Kiichi, closes vim/vim#2319)
https://github.com/vim/vim/commit/80eaddd3a0bc47cb14168964678420cfe03a2502

**vim-patch:8.0.1433: illegal memory access after undo**

Problem:    Illegal memory access after undo. (Dominique Pelle)
Solution:   Avoid the column becomes negative. (Christian Brabandt,
            closes vim/vim#2533)
vim/vim@95dbcbe

**vim-patch:8.1.0025: no test for the undofile() function**

Problem:    No test for the undofile() function.
Solution:   Add test. (Dominique Pelle, closes vim/vim#2958)
vim/vim@e5fa111

#6016 includes the `undo.c` changes from patch 8.0.1290.