### PR TITLE
vim-patch.sh: Fix replacement which converts #1234 to vim/vim#1234

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -131,7 +131,7 @@ assign_commit_details() {
   vim_commit_url="https://github.com/vim/vim/commit/${vim_commit}"
   vim_message="$(cd "${VIM_SOURCE_DIR}" \
     && git log -1 --pretty='format:%B' "${vim_commit}" \
-      | sed -e 's/\(#[0-9]*\)/vim\/vim\1/g')"
+      | sed -e 's/\(#[0-9]\{1,\}\)/vim\/vim\1/g')"
   if [[ ${munge_commit_line} == "true" ]]; then
     # Remove first line of commit message.
     vim_message="$(echo "${vim_message}" | sed -e '1s/^patch /vim-patch:/')"


### PR DESCRIPTION
Noticed in cb7bdf5f, where the script incorrectly converted `#ifdef` to
`vim/vim#ifdef`.