### PR TITLE
Do not automatically wipe terminal buffers (continuation of #7095)

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -259,8 +259,8 @@ Name			triggered by ~
 |BufNew|		just after creating a new buffer
 
 |SwapExists|		detected an existing swap file
-|TermOpen|		when a terminal job starts
-|TermClose|		when a terminal job ends
+|TermOpen|		when a terminal buffer is starting
+|TermClose|		when a terminal process exits
 |ChanOpen|		after a channel opened
 |ChanInfo|		after a channel has its state changed
 
@@ -953,11 +953,12 @@ TabNewEntered			After entering a new tab page. |tab-page|
 							*TabClosed*
 TabClosed			After closing a tab page. <afile> can be used
 				for the tab page number.
-							*TermClose*
-TermClose			When a |terminal| job ends.
-							*TermOpen*
-TermOpen			When a |terminal| job is starting.  Can be
-				used to configure the terminal buffer.
+						 {Nvim} *TermClose*
+TermClose			When a |terminal| process exits.
+						 {Nvim} *TermOpen*
+TermOpen			When a |terminal| buffer starts. This can be
+				used to configure the terminal emulator by
+				setting buffer variables.
 							*TermResponse*
 TermResponse			After the response to |t_RV| is received from
 				the terminal.  The value of |v:termresponse|

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1132,7 +1132,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  nofile	buffer is not related to a file, will not be written
 	  nowrite	buffer will not be written
 	  quickfix	list of errors |:cwindow| or locations |:lwindow|
-	  terminal	|terminal-emulator| buffer
+	  terminal	|terminal| buffer
 
 	This option is used together with 'bufhidden' and 'swapfile' to
 	specify special kinds of buffers.   See |special-buffers|.

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -826,6 +826,7 @@ Short explanation of each option:		*option-list*
 'rulerformat'	  'ruf'     custom format for the ruler
 'runtimepath'	  'rtp'     list of directories used for runtime files
 'scroll'	  'scr'     lines to scroll with CTRL-U and CTRL-D
+'scrollback'	  'scbk'    scrollback buffer size for terminal buffers
 'scrollbind'	  'scb'     scroll in window as other windows scroll
 'scrolljump'	  'sj'	    minimum number of lines to scroll
 'scrolloff'	  'so'	    minimum nr. of lines above and below cursor

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -83,7 +83,7 @@ return {
     'TabNew',                 -- when creating a new tab
     'TabNewEntered',          -- after entering a new tab
     'TermChanged',            -- after changing 'term'
-    'TermClose',              -- after the processs exits
+    'TermClose',              -- when the process exits
     'TermOpen',               -- after opening a terminal buffer
     'TermResponse',           -- after setting "v:termresponse"
     'TextChanged',            -- text was modified

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -515,7 +515,7 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
     return;
 
   if (buf->terminal) {
-    terminal_close(buf->terminal, NULL);
+    terminal_close(buf->terminal);
   }
 
   /* Always remove the buffer when there is no file name. */
@@ -1178,7 +1178,7 @@ do_buffer (
               return FAIL;
             }
           } else {
-            EMSG2(_("E89: %s will be killed(add ! to override)"),
+            EMSG2(_("E89: %s will be killed (add ! to override)"),
                   (char *)buf->b_fname);
             return FAIL;
           }

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -628,7 +628,7 @@ static void channel_process_exit_cb(Process *proc, int status, void *data)
   if (chan->term) {
     char msg[sizeof("\r\n[Process exited ]") + NUMBUFLEN];
     snprintf(msg, sizeof msg, "\r\n[Process exited %d]", proc->status);
-    terminal_close(chan->term, msg);
+    terminal_exit(chan->term, msg);
   }
 
   // If process did not exit, we only closed the handle of a detached process.
@@ -730,7 +730,8 @@ static void term_close(void *data)
 {
   Channel *chan = data;
   process_stop(&chan->stream.proc);
-  multiqueue_put(chan->events, term_delayed_free, 1, data);
+  //FROM PR:
+  //multiqueue_put(chan->events, term_delayed_free, 1, data);
 }
 
 void channel_info_changed(Channel *chan, bool new)

--- a/src/nvim/po/fi.po
+++ b/src/nvim/po/fi.po
@@ -323,7 +323,7 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Ensimmäisen puskurin ohi ei voi edetä"
 
 #, fuzzy, c-format
-#~ msgid "E89: %s will be killed(add ! to override)"
+#~ msgid "E89: %s will be killed (add ! to override)"
 #~ msgstr "E189: %s on jo olemassa (lisää komentoon ! ohittaaksesi)"
 
 #, fuzzy, c-format

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -88,7 +88,7 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Це вже найперший буфер"
 
 #, c-format
-msgid "E89: %s will be killed(add ! to override)"
+msgid "E89: %s will be killed (add ! to override)"
 msgstr "E89: «%s» буде вбито(! щоб не зважати)"
 
 #, c-format

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -81,7 +81,6 @@ typedef struct terminal_state {
   VimState state;
   Terminal *term;
   int save_rd;              // saved value of RedrawingDisabled
-  bool close;
   bool got_bsl;             // if the last input was <C-\>
 } TerminalState;
 
@@ -113,7 +112,6 @@ struct terminal {
   //  - convert VTermScreen cell arrays into utf8 strings
   //  - receive data from libvterm as a result of key presses.
   char textbuf[0x1fff];
-  unsigned refcount; // reference count
   bool exited;
   ScrollbackLine **sb_buffer;       // Scrollback buffer storage for libvterm
   size_t sb_current;                // number of rows pushed to sb_buffer
@@ -211,7 +209,6 @@ Terminal *terminal_open(TerminalOptions opts)
   Terminal *rv   = (Terminal *) xmalloc(sizeof(Terminal));
   rv->opts       = opts;
   rv->buf_handle = curbuf->handle;
-  rv->refcount   = 0;
   rv->exited     = false;
   // Configure the scrollback buffer.
   rv->sb_current = 0;
@@ -300,48 +297,42 @@ Terminal *terminal_open(TerminalOptions opts)
   return rv;
 }
 
-void terminal_close(Terminal *term, char *msg)
+// Job exited
+void terminal_exit(Terminal *term, char *msg)
 {
-  if (term->closed) {
-    return;
-  }
-
+  assert(!term->exited);
+  term->exited = true;
   term->forward_mouse = false;
+  terminal_receive(term, msg, strlen(msg));
 
-  // flush any pending changes to the buffer
   if (!exiting) {
+    // flush any pending changes to the buffer
     block_autocmds();
     refresh_terminal(term);
     unblock_autocmds();
   }
 
   buf_T *buf = handle_get_buffer(term->buf_handle);
-  term->closed = true;
+  assert(buf);
+  apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, buf);
+}
 
-  if (!msg || exiting) {
-    // If no msg was given, this was called by close_buffer(buffer.c).  Or if
-    // exiting, we must inform the buffer the terminal no longer exists so that
-    // close_buffer() doesn't call this again.
-    term->buf_handle = 0;
-    if (buf) {
-      buf->terminal = NULL;
-    }
-    if (!term->refcount) {
-      // We should not wait for the user to press a key.
-      term->opts.close_cb(term->opts.data);
-    }
-  } else {
-    terminal_receive(term, msg, strlen(msg));
+// Buffer deleted
+void terminal_close(Terminal *term) {
+  if (!term->exited) {
+    term->opts.close_cb(term->opts.data);
   }
 
-  if (buf) {
-    apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, buf);
-  }
+  buf_T *buf = handle_get_buffer(term->buf_handle);
+  assert(buf);
+  buf->terminal = NULL;
+
+  term->opts.free_cb(&term->opts.data);
 }
 
 void terminal_resize(Terminal *term, uint16_t width, uint16_t height)
 {
-  if (term->closed) {
+  if (term->exited) {
     // If two windows display the same terminal and one is closed by keypress.
     return;
   }
@@ -384,6 +375,10 @@ void terminal_enter(void)
 {
   buf_T *buf = curbuf;
   assert(buf->terminal);  // Should only be called when curbuf has a terminal.
+
+  // Do not allow 'TERMINAL' mode if the process already exited
+  if (buf->terminal->exited) return;
+
   TerminalState state, *s = &state;
   memset(s, 0, sizeof(TerminalState));
   s->term = buf->terminal;
@@ -429,18 +424,11 @@ void terminal_enter(void)
   unshowmode(true);
   redraw(curbuf->handle != s->term->buf_handle);
   ui_busy_stop();
-  if (s->close) {
-    bool wipe = s->term->buf_handle != 0;
-    s->term->opts.close_cb(s->term->opts.data);
-    if (wipe) {
-      do_cmdline_cmd("bwipeout!");
-    }
-  }
 }
 
 static int terminal_execute(VimState *state, int key)
 {
-  TerminalState *s = (TerminalState *)state;
+  TerminalState *s = (TerminalState *) state;
 
   switch (key) {
     // Temporary fix until paste events gets implemented
@@ -464,12 +452,8 @@ static int terminal_execute(VimState *state, int key)
       break;
 
     case K_EVENT:
-      // We cannot let an event free the terminal yet. It is still needed.
-      s->term->refcount++;
       multiqueue_process_events(main_loop.events);
-      s->term->refcount--;
-      if (s->term->buf_handle == 0) {
-        s->close = true;
+      if (s->term->exited) {
         return 0;
       }
       break;
@@ -489,8 +473,7 @@ static int terminal_execute(VimState *state, int key)
         s->got_bsl = true;
         break;
       }
-      if (s->term->closed) {
-        s->close = true;
+      if (s->term->exited) {
         return 0;
       }
 
@@ -509,26 +492,24 @@ void terminal_destroy(Terminal *term)
     buf->terminal = NULL;
   }
 
-  if (!term->refcount) {
-    if (pmap_has(ptr_t)(invalidated_terminals, term)) {
-      // flush any pending changes to the buffer
-      block_autocmds();
-      refresh_terminal(term);
-      unblock_autocmds();
-      pmap_del(ptr_t)(invalidated_terminals, term);
-    }
-    for (size_t i = 0; i < term->sb_current; i++) {
-      xfree(term->sb_buffer[i]);
-    }
-    xfree(term->sb_buffer);
-    vterm_free(term->vt);
-    xfree(term);
+  if (pmap_has(ptr_t)(invalidated_terminals, term)) {
+    // flush any pending changes to the buffer
+    block_autocmds();
+    refresh_terminal(term);
+    unblock_autocmds();
+    pmap_del(ptr_t)(invalidated_terminals, term);
   }
+  for (size_t i = 0; i < term->sb_current; i++) {
+    xfree(term->sb_buffer[i]);
+  }
+  xfree(term->sb_buffer);
+  vterm_free(term->vt);
+  xfree(term);
 }
 
 void terminal_send(Terminal *term, char *data, size_t size)
 {
-  if (term->closed) {
+  if (term->exited) {
     return;
   }
   term->opts.write_cb(data, size, term->opts.data);
@@ -1026,7 +1007,6 @@ static bool send_mouse_event(Terminal *term, int c)
 // }}}
 // terminal buffer refresh & misc {{{
 
-
 static void fetch_row(Terminal *term, int row, int end_col)
 {
   int col = 0;
@@ -1143,7 +1123,7 @@ static void refresh_timer_cb(TimeWatcher *watcher, void *data)
 
 static void refresh_size(Terminal *term, buf_T *buf)
 {
-  if (!term->pending_resize || term->closed) {
+  if (!term->pending_resize || term->exited) {
     return;
   }
 
@@ -1368,4 +1348,4 @@ static char *get_config_string(char *key)
 
 // }}}
 
-// vim: foldmethod=marker
+// vim: foldmethod=marker sw=2

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -194,6 +194,7 @@ void terminal_teardown(void)
   multiqueue_free(refresh_timer.events);
   time_watcher_close(&refresh_timer, NULL);
   pmap_free(ptr_t)(invalidated_terminals);
+  invalidated_terminals = NULL;
   map_free(int, int)(color_indexes);
 }
 
@@ -293,11 +294,11 @@ Terminal *terminal_open(TerminalOptions opts)
   return rv;
 }
 
-// Job exited
+/// Called when the terminal job dies
 void terminal_exit(Terminal *term, char *msg)
 {
   assert(!term->exited);
-  term->exited = true;
+
   term->forward_mouse = false;
   if (msg) {
     terminal_receive(term, msg, strlen(msg));
@@ -310,18 +311,15 @@ void terminal_exit(Terminal *term, char *msg)
     unblock_autocmds();
   }
 
-  buf_T *buf = handle_get_buffer(term->buf_handle);
-  assert(buf);
-  apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, buf);
-
   term->opts.free_cb(&term->opts.data);
 }
 
-// Buffer deleted
-void terminal_close(Terminal *term) {
+/// Called when the terminal buffer gets wiped
+void terminal_close(Terminal *term)
+{
   if (!term->exited) {
     term->opts.close_cb(term->opts.data);
-    terminal_exit(term, NULL);
+    terminal_destroy(term);
   }
 
   buf_T *buf = handle_get_buffer(term->buf_handle);
@@ -333,12 +331,7 @@ void terminal_close(Terminal *term) {
   }
   xfree(term->sb_buffer);
   vterm_free(term->vt);
-
-  // It's possible that the buffer gets wiped before the job exits.
-  // If so, let terminal_destroy() free this.
-  if (term->exited) {
-    xfree(term);
-  }
+  xfree(term);
 }
 
 void terminal_resize(Terminal *term, uint16_t width, uint16_t height)
@@ -500,8 +493,12 @@ static int terminal_execute(VimState *state, int key)
 void terminal_destroy(Terminal *term)
 {
   buf_T *buf = handle_get_buffer(term->buf_handle);
-  // Buf handle still needed by upcoming terminal_close
   assert(buf);
+  apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, buf);
+
+  assert(invalidated_terminals);
+  assert(!term->exited);
+  term->exited = true;
 
   if (pmap_has(ptr_t)(invalidated_terminals, term)) {
     if (!exiting) {
@@ -511,12 +508,6 @@ void terminal_destroy(Terminal *term)
       unblock_autocmds();
     }
     pmap_del(ptr_t)(invalidated_terminals, term);
-  }
-
-  // It's possible that the job exits before the buffer gets wiped.
-  // If so, let terminal_close() free this.
-  if (!buf->terminal) {
-    xfree(term);
   }
 }
 
@@ -535,7 +526,7 @@ void terminal_flush_output(Terminal *term)
   terminal_send(term, term->textbuf, len);
 }
 
-void terminal_send_key(Terminal *term, int c)
+static void terminal_send_key(Terminal *term, int c)
 {
   VTermModifier mod = VTERM_MOD_NONE;
 
@@ -560,6 +551,8 @@ void terminal_receive(Terminal *term, char *data, size_t len)
   if (!data) {
     return;
   }
+
+  assert(!term->exited);
 
   vterm_input_write(term->vt, data, len);
   vterm_screen_flush_damage(term->vts);

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -311,7 +311,6 @@ void terminal_exit(Terminal *term, char *msg)
     unblock_autocmds();
   }
 
-  term->opts.free_cb(term->opts.data);
   terminal_destroy(term);
 }
 
@@ -320,7 +319,6 @@ void terminal_close(Terminal *term)
 {
   if (!term->exited) {
     term->opts.close_cb(term->opts.data);
-    term->opts.free_cb(term->opts.data);
     terminal_destroy(term);
   }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -102,14 +102,19 @@ typedef struct {
 } ScrollbackLine;
 
 struct terminal {
+
   TerminalOptions opts;  // options passed to terminal_open
-  VTerm *vt;
-  VTermScreen *vts;
+  // buf_T instance that acts as a "drawing surface" for libvterm
+  // we can't store a direct reference to the buffer because the
+  // refresh_timer_cb may be called after the buffer was freed, and there's
+  // no way to know if the memory was reused.
+  handle_T buf_handle;
   // buffer used to:
   //  - convert VTermScreen cell arrays into utf8 strings
   //  - receive data from libvterm as a result of key presses.
   char textbuf[0x1fff];
-
+  unsigned refcount; // reference count
+  bool exited;
   ScrollbackLine **sb_buffer;       // Scrollback buffer storage for libvterm
   size_t sb_current;                // number of rows pushed to sb_buffer
   size_t sb_size;                   // sb_buffer size
@@ -119,15 +124,9 @@ struct terminal {
   // window height has increased) and must be deleted from the terminal buffer
   int sb_pending;
 
-  // buf_T instance that acts as a "drawing surface" for libvterm
-  // we can't store a direct reference to the buffer because the
-  // refresh_timer_cb may be called after the buffer was freed, and there's
-  // no way to know if the memory was reused.
-  handle_T buf_handle;
-  // program exited
-  bool closed, destroy;
-
-  // some vterm properties
+  // VTerm related fields
+  VTerm *vt;
+  VTermScreen *vts;
   bool forward_mouse;
   int invalid_start, invalid_end;   // invalid rows in libvterm screen
   struct {
@@ -136,8 +135,6 @@ struct terminal {
   } cursor;
   int pressed_button;               // which mouse button is pressed
   bool pending_resize;              // pending width/height
-
-  size_t refcount;                  // reference count
 };
 
 static VTermScreenCallbacks vterm_screen_callbacks = {
@@ -154,6 +151,8 @@ static PMap(ptr_t) *invalidated_terminals;
 static Map(int, int) *color_indexes;
 static int default_vt_fg, default_vt_bg;
 static VTermColor default_vt_bg_rgb;
+
+// init/teardown {{{
 
 void terminal_init(void)
 {
@@ -202,38 +201,49 @@ void terminal_teardown(void)
   map_free(int, int)(color_indexes);
 }
 
+// }}}
 // public API {{{
 
 Terminal *terminal_open(TerminalOptions opts)
 {
   bool true_color = ui_rgb_attached();
-  // Create a new terminal instance and configure it
-  Terminal *rv = xcalloc(1, sizeof(Terminal));
-  rv->opts = opts;
-  rv->cursor.visible = true;
-  // Associate the terminal instance with the new buffer
+
+  Terminal *rv   = (Terminal *) xmalloc(sizeof(Terminal));
+  rv->opts       = opts;
   rv->buf_handle = curbuf->handle;
-  curbuf->terminal = rv;
-  // Create VTerm
+  rv->refcount   = 0;
+  rv->exited     = false;
+  // Configure the scrollback buffer.
+  rv->sb_current = 0;
+  rv->sb_pending = 0;
+  rv->sb_size    = curbuf->b_p_scbk < 0 ? SB_MAX
+      : (size_t) MAX(1, curbuf->b_p_scbk);
+  rv->sb_buffer  = xmalloc(sizeof(ScrollbackLine *) * rv->sb_size);
+
+  // Setup vterm
   rv->vt = vterm_new(opts.height, opts.width);
   vterm_set_utf8(rv->vt, 1);
-  // Setup state
   VTermState *state = vterm_obtain_state(rv->vt);
-  // Set up screen
   rv->vts = vterm_obtain_screen(rv->vt);
+  rv->forward_mouse = 0;
+  rv->invalid_start = 0;
+  rv->invalid_end   = opts.height;
   vterm_screen_enable_altscreen(rv->vts, true);
-  // delete empty lines at the end of the buffer
   vterm_screen_set_callbacks(rv->vts, &vterm_screen_callbacks, rv);
   vterm_screen_set_damage_merge(rv->vts, VTERM_DAMAGE_SCROLL);
+  // delete empty lines at the end of the buffer
   vterm_screen_reset(rv->vts, 1);
+  rv->cursor.row = rv->cursor.col = 0;
+  rv->cursor.visible = true;
+  rv->pressed_button = 0;
+  rv->pending_resize = false;
   // force a initial refresh of the screen to ensure the buffer will always
   // have as many lines as screen rows when refresh_scrollback is called
-  rv->invalid_start = 0;
-  rv->invalid_end = opts.height;
   refresh_screen(rv, curbuf);
-  set_option_value("buftype", 0, "terminal", OPT_LOCAL);  // -V666
 
   // Default settings for terminal buffers
+  set_option_value("buftype", 0, "terminal", OPT_LOCAL);  // -V666
+  curbuf->terminal = rv;
   curbuf->b_p_ma = false;     // 'nomodifiable'
   curbuf->b_p_ul = -1;        // 'undolevels'
   curbuf->b_p_scbk = p_scbk;  // 'scrollback'
@@ -247,11 +257,6 @@ Terminal *terminal_open(TerminalOptions opts)
 
   // Apply TermOpen autocmds _before_ configuring the scrollback buffer.
   apply_autocmds(EVENT_TERMOPEN, NULL, NULL, false, curbuf);
-
-  // Configure the scrollback buffer.
-  rv->sb_size = curbuf->b_p_scbk < 0
-                ? SB_MAX : (size_t)MAX(1, curbuf->b_p_scbk);
-  rv->sb_buffer = xmalloc(sizeof(ScrollbackLine *) * rv->sb_size);
 
   if (!true_color) {
     // Change the first 16 colors so we can easily get the correct color

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -311,7 +311,8 @@ void terminal_exit(Terminal *term, char *msg)
     unblock_autocmds();
   }
 
-  term->opts.free_cb(&term->opts.data);
+  term->opts.free_cb(term->opts.data);
+  terminal_destroy(term);
 }
 
 /// Called when the terminal buffer gets wiped
@@ -319,6 +320,7 @@ void terminal_close(Terminal *term)
 {
   if (!term->exited) {
     term->opts.close_cb(term->opts.data);
+    term->opts.free_cb(term->opts.data);
     terminal_destroy(term);
   }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -210,12 +210,6 @@ Terminal *terminal_open(TerminalOptions opts)
   rv->opts       = opts;
   rv->buf_handle = curbuf->handle;
   rv->exited     = false;
-  // Configure the scrollback buffer.
-  rv->sb_current = 0;
-  rv->sb_pending = 0;
-  rv->sb_size    = curbuf->b_p_scbk < 0 ? SB_MAX
-      : (size_t) MAX(1, curbuf->b_p_scbk);
-  rv->sb_buffer  = xmalloc(sizeof(ScrollbackLine *) * rv->sb_size);
 
   // Setup vterm
   rv->vt = vterm_new(opts.height, opts.width);
@@ -254,6 +248,13 @@ Terminal *terminal_open(TerminalOptions opts)
 
   // Apply TermOpen autocmds _before_ configuring the scrollback buffer.
   apply_autocmds(EVENT_TERMOPEN, NULL, NULL, false, curbuf);
+
+  // Configure the scrollback buffer.
+  rv->sb_current = 0;
+  rv->sb_pending = 0;
+  rv->sb_size    = curbuf->b_p_scbk < 0 ? SB_MAX
+      : (size_t) MAX(1, curbuf->b_p_scbk);
+  rv->sb_buffer  = xmalloc(sizeof(ScrollbackLine *) * rv->sb_size);
 
   if (!true_color) {
     // Change the first 16 colors so we can easily get the correct color
@@ -303,7 +304,9 @@ void terminal_exit(Terminal *term, char *msg)
   assert(!term->exited);
   term->exited = true;
   term->forward_mouse = false;
-  terminal_receive(term, msg, strlen(msg));
+  if (msg) {
+    terminal_receive(term, msg, strlen(msg));
+  }
 
   if (!exiting) {
     // flush any pending changes to the buffer
@@ -323,6 +326,7 @@ void terminal_exit(Terminal *term, char *msg)
 void terminal_close(Terminal *term) {
   if (!term->exited) {
     term->opts.close_cb(term->opts.data);
+    terminal_exit(term, NULL);
   }
 
   buf_T *buf = handle_get_buffer(term->buf_handle);

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -82,7 +82,6 @@ typedef struct terminal_state {
   Terminal *term;
   int save_rd;              // saved value of RedrawingDisabled
   bool got_bsl;             // if the last input was <C-\>
-  bool exited;
 } TerminalState;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -202,35 +201,35 @@ Terminal *terminal_open(TerminalOptions opts)
 {
   bool true_color = ui_rgb_attached();
 
-  Terminal *rv   = xcalloc(1, sizeof(Terminal));
-  rv->opts       = opts;
+  // Create a new terminal instance and configure it
+  Terminal *rv = xcalloc(1, sizeof(Terminal));
+  rv->opts = opts;
+  rv->cursor.visible = true;
+  rv->exited = false;
+  // Associate the terminal instance with the new buffer
   rv->buf_handle = curbuf->handle;
-  rv->exited     = false;
+  curbuf->terminal = rv;
 
-  // Setup vterm
+  // Create VTerm
   rv->vt = vterm_new(opts.height, opts.width);
   vterm_set_utf8(rv->vt, 1);
+  // Setup state
   VTermState *state = vterm_obtain_state(rv->vt);
+  // Set up screen
   rv->vts = vterm_obtain_screen(rv->vt);
-  rv->forward_mouse = 0;
-  rv->invalid_start = 0;
-  rv->invalid_end   = opts.height;
   vterm_screen_enable_altscreen(rv->vts, true);
+  // delete empty lines at the end of the buffer
   vterm_screen_set_callbacks(rv->vts, &vterm_screen_callbacks, rv);
   vterm_screen_set_damage_merge(rv->vts, VTERM_DAMAGE_SCROLL);
-  // delete empty lines at the end of the buffer
   vterm_screen_reset(rv->vts, 1);
-  rv->cursor.row = rv->cursor.col = 0;
-  rv->cursor.visible = true;
-  rv->pressed_button = 0;
-  rv->pending_resize = false;
   // force a initial refresh of the screen to ensure the buffer will always
   // have as many lines as screen rows when refresh_scrollback is called
+  rv->invalid_start = 0;
+  rv->invalid_end = opts.height;
   refresh_screen(rv, curbuf);
+  set_option_value("buftype", 0, "terminal", OPT_LOCAL);  // -V666
 
   // Default settings for terminal buffers
-  set_option_value("buftype", 0, "terminal", OPT_LOCAL);  // -V666
-  curbuf->terminal = rv;
   curbuf->b_p_ma = false;     // 'nomodifiable'
   curbuf->b_p_ul = -1;        // 'undolevels'
   curbuf->b_p_scbk = p_scbk;  // 'scrollback'
@@ -246,11 +245,9 @@ Terminal *terminal_open(TerminalOptions opts)
   apply_autocmds(EVENT_TERMOPEN, NULL, NULL, false, curbuf);
 
   // Configure the scrollback buffer.
-  rv->sb_current = 0;
-  rv->sb_pending = 0;
-  rv->sb_size    = curbuf->b_p_scbk < 0 ? SB_MAX
-      : (size_t)MAX(1, curbuf->b_p_scbk);
-  rv->sb_buffer  = xmalloc(sizeof(ScrollbackLine *) * rv->sb_size);
+  rv->sb_size = curbuf->b_p_scbk < 0
+                ? SB_MAX : (size_t)MAX(1, curbuf->b_p_scbk);
+  rv->sb_buffer = xmalloc(sizeof(ScrollbackLine *) * rv->sb_size);
 
   if (!true_color) {
     // Change the first 16 colors so we can easily get the correct color
@@ -388,7 +385,6 @@ void terminal_enter(void)
   TerminalState state, *s = &state;
   memset(s, 0, sizeof(TerminalState));
   s->term = buf->terminal;
-  s->exited = false;
 
   // Ensure the terminal is properly sized.
   terminal_resize(s->term, 0, 0);
@@ -463,7 +459,6 @@ static int terminal_execute(VimState *state, int key)
     case K_EVENT:
       multiqueue_process_events(main_loop.events);
       if (s->term->exited) {
-        s->exited = true;
         return 0;
       }
       break;
@@ -484,7 +479,6 @@ static int terminal_execute(VimState *state, int key)
         break;
       }
       if (s->term->exited) {
-        s->exited = true;
         return 0;
       }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -150,8 +150,6 @@ static Map(int, int) *color_indexes;
 static int default_vt_fg, default_vt_bg;
 static VTermColor default_vt_bg_rgb;
 
-// init/teardown {{{
-
 void terminal_init(void)
 {
   invalidated_terminals = pmap_new(ptr_t)();
@@ -199,14 +197,11 @@ void terminal_teardown(void)
   map_free(int, int)(color_indexes);
 }
 
-// }}}
-// public API {{{
-
 Terminal *terminal_open(TerminalOptions opts)
 {
   bool true_color = ui_rgb_attached();
 
-  Terminal *rv   = (Terminal *) xcalloc(1, sizeof(Terminal));
+  Terminal *rv   = xcalloc(1, sizeof(Terminal));
   rv->opts       = opts;
   rv->buf_handle = curbuf->handle;
   rv->exited     = false;
@@ -393,7 +388,9 @@ void terminal_enter(void)
   assert(buf->terminal);  // Should only be called when curbuf has a terminal.
 
   // Do not allow 'TERMINAL' mode if the process already exited
-  if (buf->terminal->exited) return;
+  if (buf->terminal->exited) {
+    return;
+  }
 
   TerminalState state, *s = &state;
   memset(s, 0, sizeof(TerminalState));
@@ -444,7 +441,7 @@ void terminal_enter(void)
 
 static int terminal_execute(VimState *state, int key)
 {
-  TerminalState *s = (TerminalState *) state;
+  TerminalState *s = (TerminalState *)state;
 
   switch (key) {
     // Temporary fix until paste events gets implemented
@@ -1020,9 +1017,6 @@ static bool send_mouse_event(Terminal *term, int c)
   return true;
 }
 
-// }}}
-// terminal buffer refresh & misc {{{
-
 static void fetch_row(Terminal *term, int row, int end_col)
 {
   int col = 0;
@@ -1361,7 +1355,5 @@ static char *get_config_string(char *key)
   api_free_object(obj);
   return NULL;
 }
-
-// }}}
 
 // vim: foldmethod=marker sw=2

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -102,7 +102,6 @@ typedef struct {
 } ScrollbackLine;
 
 struct terminal {
-
   TerminalOptions opts;  // options passed to terminal_open
   // buf_T instance that acts as a "drawing surface" for libvterm
   // we can't store a direct reference to the buffer because the
@@ -250,7 +249,7 @@ Terminal *terminal_open(TerminalOptions opts)
   rv->sb_current = 0;
   rv->sb_pending = 0;
   rv->sb_size    = curbuf->b_p_scbk < 0 ? SB_MAX
-      : (size_t) MAX(1, curbuf->b_p_scbk);
+      : (size_t)MAX(1, curbuf->b_p_scbk);
   rv->sb_buffer  = xmalloc(sizeof(ScrollbackLine *) * rv->sb_size);
 
   if (!true_color) {

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -82,6 +82,7 @@ typedef struct terminal_state {
   Terminal *term;
   int save_rd;              // saved value of RedrawingDisabled
   bool got_bsl;             // if the last input was <C-\>
+  bool exited;
 } TerminalState;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -388,6 +389,7 @@ void terminal_enter(void)
   TerminalState state, *s = &state;
   memset(s, 0, sizeof(TerminalState));
   s->term = buf->terminal;
+  s->exited = false;
 
   // Ensure the terminal is properly sized.
   terminal_resize(s->term, 0, 0);
@@ -426,7 +428,9 @@ void terminal_enter(void)
   }
 
   // draw the unfocused cursor
-  invalidate_terminal(s->term, s->term->cursor.row, s->term->cursor.row + 1);
+  if (!s->term->exited) {
+    invalidate_terminal(s->term, s->term->cursor.row, s->term->cursor.row + 1);
+  }
   unshowmode(true);
   redraw(curbuf->handle != s->term->buf_handle);
   ui_busy_stop();
@@ -460,6 +464,7 @@ static int terminal_execute(VimState *state, int key)
     case K_EVENT:
       multiqueue_process_events(main_loop.events);
       if (s->term->exited) {
+        s->exited = true;
         return 0;
       }
       break;
@@ -480,6 +485,7 @@ static int terminal_execute(VimState *state, int key)
         break;
       }
       if (s->term->exited) {
+        s->exited = true;
         return 0;
       }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -956,6 +956,10 @@ static void mouse_action(Terminal *term, int button, int row, int col,
 // terminal should lose focus
 static bool send_mouse_event(Terminal *term, int c)
 {
+  if (term->exited) {
+    return true;
+  }
+
   int row = mouse_row, col = mouse_col;
   win_T *mouse_win = mouse_find_win(&row, &col);
 

--- a/src/nvim/terminal.h
+++ b/src/nvim/terminal.h
@@ -9,7 +9,7 @@ typedef struct terminal Terminal;
 typedef void (*terminal_write_cb)(char *buffer, size_t size, void *data);
 typedef void (*terminal_resize_cb)(uint16_t width, uint16_t height, void *data);
 typedef void (*terminal_close_cb)(void *data);
-typedef void (*terminal_free_cb)(void **data);
+typedef void (*terminal_free_cb)(void *data);
 
 #include "nvim/buffer_defs.h"
 

--- a/src/nvim/terminal.h
+++ b/src/nvim/terminal.h
@@ -9,7 +9,6 @@ typedef struct terminal Terminal;
 typedef void (*terminal_write_cb)(char *buffer, size_t size, void *data);
 typedef void (*terminal_resize_cb)(uint16_t width, uint16_t height, void *data);
 typedef void (*terminal_close_cb)(void *data);
-typedef void (*terminal_free_cb)(void *data);
 
 #include "nvim/buffer_defs.h"
 
@@ -19,7 +18,6 @@ typedef struct {
   terminal_write_cb  write_cb;
   terminal_resize_cb resize_cb;
   terminal_close_cb  close_cb;
-  terminal_free_cb   free_cb;
 } TerminalOptions;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/terminal.h
+++ b/src/nvim/terminal.h
@@ -9,15 +9,17 @@ typedef struct terminal Terminal;
 typedef void (*terminal_write_cb)(char *buffer, size_t size, void *data);
 typedef void (*terminal_resize_cb)(uint16_t width, uint16_t height, void *data);
 typedef void (*terminal_close_cb)(void *data);
+typedef void (*terminal_free_cb)(void **data);
 
 #include "nvim/buffer_defs.h"
 
 typedef struct {
   void *data;
   uint16_t width, height;
-  terminal_write_cb write_cb;
+  terminal_write_cb  write_cb;
   terminal_resize_cb resize_cb;
-  terminal_close_cb close_cb;
+  terminal_close_cb  close_cb;
+  terminal_free_cb   free_cb;
 } TerminalOptions;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/test/functional/autocmd/termclose_spec.lua
+++ b/test/functional/autocmd/termclose_spec.lua
@@ -19,7 +19,6 @@ describe('TermClose event', function()
   it('triggers when fast-exiting terminal job stops', function()
     command('autocmd TermClose * let g:test_termclose = 23')
     command('terminal')
-    command('call jobstop(b:terminal_job_id)')
     retry(nil, nil, function() eq(23, eval('g:test_termclose')) end)
   end)
 

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -858,8 +858,8 @@ describe("pty process teardown", function()
 
     -- Exiting should terminate all descendants (PTY, its children, ...).
     screen:expect([[
-      ^                              |
-      [Process exited 0]            |
+                                    |
+      [Process exited 0^]            |
                                     |
                                     |
                                     |

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -123,10 +123,10 @@ describe(':terminal (with fake shell)', function()
     terminal_with_fake_shell()
     retry(3, 4 * screen.timeout, function()
     screen:expect([[
-      ^ready $                                           |
-      [Process exited 0]                                |
+      ready $                                           |
+      [Process exited 0^]                                |
                                                         |
-      :terminal                                         |
+                                                        |
     ]])
     end)
   end)
@@ -146,10 +146,10 @@ describe(':terminal (with fake shell)', function()
     nvim('set_option', 'shell', nvim_dir..'/shell-test -t jeff')
     terminal_with_fake_shell()
     screen:expect([[
-      ^jeff $                                            |
-      [Process exited 0]                                |
+      jeff $                                            |
+      [Process exited 0^]                                |
                                                         |
-      :terminal                                         |
+                                                        |
     ]])
   end)
 
@@ -159,8 +159,8 @@ describe(':terminal (with fake shell)', function()
     screen:expect([[
       ^ready $ echo hi                                   |
                                                         |
-      [Process exited 0]                                |
-      :terminal echo hi                                 |
+      [Process exited 0^]                                |
+                                                        |
     ]])
   end)
 
@@ -171,8 +171,8 @@ describe(':terminal (with fake shell)', function()
     screen:expect([[
       ^jeff $ echo hi                                    |
                                                         |
-      [Process exited 0]                                |
-      :terminal echo hi                                 |
+      [Process exited 0^]                                |
+                                                        |
     ]])
   end)
 
@@ -182,8 +182,8 @@ describe(':terminal (with fake shell)', function()
     screen:expect([[
       ^ready $ echo 'hello' \ "world"                    |
                                                         |
-      [Process exited 0]                                |
-      :terminal echo 'hello' \ "world"                  |
+      [Process exited 0^]                                |
+                                                        |
     ]])
   end)
 
@@ -215,13 +215,12 @@ describe(':terminal (with fake shell)', function()
   it('works with :find', function()
     terminal_with_fake_shell()
     screen:expect([[
-      ^ready $                                           |
-      [Process exited 0]                                |
+      ready $                                           |
+      [Process exited 0^]                                |
                                                         |
-      :terminal                                         |
+                                                        |
     ]])
     eq('term://', string.match(eval('bufname("%")'), "^term://"))
-    feed([[<C-\><C-N>]])
     feed_command([[find */shadacat.py]])
     if iswin() then
       eq('scripts\\shadacat.py', eval('bufname("%")'))
@@ -236,10 +235,9 @@ describe(':terminal (with fake shell)', function()
     screen:expect([[
       ^ready $ echo "scripts/shadacat.py"                |
                                                         |
-      [Process exited 0]                                |
-      :terminal echo "scripts/shadacat.py"              |
+      [Process exited 0^]                                |
+                                                        |
     ]])
-    feed([[<C-\><C-N>]])
     eq('term://', string.match(eval('bufname("%")'), "^term://"))
     feed([[ggf"lgf]])
     eq('scripts/shadacat.py', eval('bufname("%")'))

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -357,11 +357,11 @@ describe('terminal prints more lines than the screen height and exits', function
       line8                         |
       line9                         |
                                     |
-      [Process exited 0]            |
-      -- TERMINAL --                |
+      [Process exited 0^]            |
+                                    |
     ]])
-    feed('<cr>')
-    -- closes the buffer correctly after pressing a key
+    command('bwipeout!')
+    -- closes the buffer correctly when wiped
     screen:expect([[
       ^                              |
       ~                             |

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -284,9 +284,9 @@ describe('tui with non-tty file descriptors', function()
       :q                                                |
       abc                                               |
                                                         |
-      [Process exited 0]{1: }                               |
+      [Process exited 0^]{2: }                               |
                                                         |
-      {3:-- TERMINAL --}                                    |
+                                                        |
     ]])
   end)
 end)


### PR DESCRIPTION
Supercedes #7095. As I promised @justinmk, I did the legwork, but I can't fix the resulting bugs. I squashed a bit, but not too much, and I'll describe the problems below:

- `TEST_FILTER="pty process teardown does not prevent/delay exit" make functionaltest` shows a test failure. It's simple enough to fix, and in line with how the tests were modified by @madmax28, but I did not simply want to change it back, but let you guys check if it's ok.
- `terminal_send_key` is now static. Please check if that's still appropriate.
- `terminal_close` has been renamed to `terminal_exit`, but a new function named `terminal_close` exists. Both `terminal_exit` and `terminal_close` call to `terminal_destroy`. I don't understand the relation of those functions, please check them. In particular, I changed the call to `terminal_close` in `channel_process_exit_cb` to use `terminal_exit` instead (the only function of the 3 taking a msg parameter), but this produces a failed assert when running `TEST_FILE=/home/pips/Devel/neovim/neovim/test/functional/terminal/buffer_spec.lua make functionaltest`.
- I have oldtest failures in `test_registers.vim` in `Test_display_registers`. The output shows some lines that are part of a file I edited locally and that's surely not part of neovim, so I assume it's just a weird test.
- Many python tests fail. I assume that's a local thing.
- I have a failure in some `strftime` test. I assume that's a local thing, but please check that.

Other than that, unittests pass. The linter is only unhappy about some stuff in main.c, I'll ignore that for now.

Please also note my comment about the changes in auevents.lua, which of course also apply to [autocmd.txt](https://github.com/neovim/neovim/pull/8839/files#diff-0fe7b6318b0164afddbf8e6aa4b95874R262):


> This wording is really unfortunate imho. Often, one really wants to know if your code is executed pre-event or post-event, and "when" doesn't specify that. If it's "after" or "before", it should be specified here and in the docs, and if it can't be specified (because concurrency or whatnot), make a note of it.
