### PR TITLE
[RDY] vim-patch:8.0.{828,1254,1470,1517},8.1.{78,90,97,99}

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -4921,16 +4921,13 @@ regmatch (
                   (colnr_T)STRLEN(regline);
               }
             } else {
-              if (has_mbyte) {
-                const char_u *const line =
-                    reg_getline(behind_pos.rs_u.pos.lnum);
+              const char_u *const line =
+                  reg_getline(behind_pos.rs_u.pos.lnum);
 
-                rp->rs_un.regsave.rs_u.pos.col -=
-                  (*mb_head_off)(line, line
-                                 + rp->rs_un.regsave.rs_u.pos.col - 1) + 1;
-              } else {
-                rp->rs_un.regsave.rs_u.pos.col--;
-              }
+              rp->rs_un.regsave.rs_u.pos.col -=
+                  utf_head_off(line,
+                               line + rp->rs_un.regsave.rs_u.pos.col - 1)
+                  + 1;
             }
           } else {
             if (rp->rs_un.regsave.rs_u.ptr == regline) {

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1664,9 +1664,8 @@ static char_u *regpiece(int *flagp)
   case Magic('@'):
   {
     int lop = END;
-    int nr;
+    int64_t nr = getdecchrs();
 
-    nr = getdecchrs();
     switch (no_Magic(getchr())) {
     case '=': lop = MATCH; break;                                 /* \@= */
     case '!': lop = NOMATCH; break;                               /* \@! */
@@ -2087,7 +2086,7 @@ static char_u *regatom(int *flagp)
     case 'u':               /* %uabcd hex 4 */
     case 'U':               /* %U1234abcd hex 8 */
     {
-      int i;
+      int64_t i;
 
       switch (c) {
       case 'd': i = getdecchrs(); break;
@@ -2976,9 +2975,9 @@ static void ungetchr(void)
  * The parameter controls the maximum number of input characters. This will be
  * 2 when reading a \%x20 sequence and 4 when reading a \%u20AC sequence.
  */
-static int gethexchrs(int maxinputlen)
+static int64_t gethexchrs(int maxinputlen)
 {
-  int nr = 0;
+  int64_t nr = 0;
   int c;
   int i;
 
@@ -3000,9 +2999,9 @@ static int gethexchrs(int maxinputlen)
  * Get and return the value of the decimal string immediately after the
  * current position. Return -1 for invalid.  Consumes all digits.
  */
-static int getdecchrs(void)
+static int64_t getdecchrs(void)
 {
-  int nr = 0;
+  int64_t nr = 0;
   int c;
   int i;
 
@@ -3029,9 +3028,9 @@ static int getdecchrs(void)
  *     blahblah\%o210asdf
  *	   before-^  ^-after
  */
-static int getoctchrs(void)
+static int64_t getoctchrs(void)
 {
-  int nr = 0;
+  int64_t nr = 0;
   int c;
   int i;
 
@@ -3055,7 +3054,7 @@ static int getoctchrs(void)
  */
 static int coll_get_char(void)
 {
-  int nr = -1;
+  int64_t nr = -1;
 
   switch (*regparse++) {
   case 'd': nr = getdecchrs(); break;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -4922,8 +4922,11 @@ regmatch (
               }
             } else {
               if (has_mbyte) {
+                const char_u *const line =
+                    reg_getline(behind_pos.rs_u.pos.lnum);
+
                 rp->rs_un.regsave.rs_u.pos.col -=
-                  (*mb_head_off)(regline, regline
+                  (*mb_head_off)(line, line
                                  + rp->rs_un.regsave.rs_u.pos.col - 1) + 1;
               } else {
                 rp->rs_un.regsave.rs_u.pos.col--;

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -2038,9 +2038,10 @@ static int nfa_regpiece(void)
     break;
   }     /* end switch */
 
-  if (re_multi_type(peekchr()) != NOT_MULTI)
-    /* Can't have a multi follow a multi. */
+  if (re_multi_type(peekchr()) != NOT_MULTI) {
+    // Can't have a multi follow a multi.
     EMSG_RET_FAIL(_("E871: (NFA regexp) Can't have a multi follow a multi"));
+  }
 
   return OK;
 }
@@ -2453,7 +2454,8 @@ static void nfa_set_code(int c)
 }
 
 static FILE *log_fd;
-static char_u e_log_open_failed[] = N_("Could not open temporary log file for writing, displaying on stderr... ");
+static char_u e_log_open_failed[] = N_(
+    "Could not open temporary log file for writing, displaying on stderr... ");
 
 /*
  * Print the postfix notation of the current regexp.
@@ -2466,10 +2468,11 @@ static void nfa_postfix_dump(char_u *expr, int retval)
   f = fopen(NFA_REGEXP_DUMP_LOG, "a");
   if (f != NULL) {
     fprintf(f, "\n-------------------------\n");
-    if (retval == FAIL)
+    if (retval == FAIL) {
       fprintf(f, ">>> NFA engine failed... \n");
-    else if (retval == OK)
+    } else if (retval == OK) {
       fprintf(f, ">>> NFA engine succeeded !\n");
+    }
     fprintf(f, "Regexp: \"%s\"\nPostfix notation (char): \"", expr);
     for (p = post_start; *p && p < post_ptr; p++) {
       nfa_set_code(*p);
@@ -5067,8 +5070,9 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
     fprintf(log_fd, "------------------------------------------\n");
     fprintf(log_fd, ">>> Reginput is \"%s\"\n", reginput);
     fprintf(log_fd,
-        ">>> Advanced one character... Current char is %c (code %d) \n", curc,
-        (int)curc);
+            ">>> Advanced one character... Current char is %c (code %d) \n",
+            curc,
+            (int)curc);
     fprintf(log_fd, ">>> Thislist has %d states available: ", thislist->n);
     {
       int i;
@@ -5100,16 +5104,17 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
       {
         int col;
 
-        if (t->subs.norm.in_use <= 0)
+        if (t->subs.norm.in_use <= 0) {
           col = -1;
-        else if (REG_MULTI)
+        } else if (REG_MULTI) {
           col = t->subs.norm.list.multi[0].start_col;
-        else
+        } else {
           col = (int)(t->subs.norm.list.line[0].start - regline);
+        }
         nfa_set_code(t->state->c);
         fprintf(log_fd, "(%d) char %d %s (start col %d)%s... \n",
-            abs(t->state->id), (int)t->state->c, code, col,
-            pim_info(&t->pim));
+                abs(t->state->id), (int)t->state->c, code, col,
+                pim_info(&t->pim));
       }
 #endif
 
@@ -6263,8 +6268,9 @@ static long nfa_regtry(nfa_regprog_T *prog, colnr_T col, proftime_T *tm)
     nfa_print_state(f, start);
     fprintf(f, "\n\n");
     fclose(f);
-  } else
+  } else {
     EMSG("Could not open temporary log file for writing");
+  }
 #endif
 
   clear_sub(&subs.norm);
@@ -6490,10 +6496,10 @@ static regprog_T *nfa_regcomp(char_u *expr, int re_flags)
     FILE *f = fopen(NFA_REGEXP_RUN_LOG, "a");
 
     if (f != NULL) {
-      fprintf(
-          f,
-          "\n*****************************\n\n\n\n\tCompiling regexp \"%s\"... hold on !\n",
-          expr);
+      fprintf(f,
+              "\n*****************************\n\n\n\n\t"
+              "Compiling regexp \"%s\"... hold on !\n",
+              expr);
       fclose(f);
     }
   }

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1409,7 +1409,7 @@ static int nfa_regatom(void)
     case 'u':               /* %uabcd hex 4 */
     case 'U':               /* %U1234abcd hex 8 */
     {
-      int nr;
+      int64_t nr;
 
       switch (c) {
       case 'd': nr = getdecchrs(); break;
@@ -1859,7 +1859,7 @@ static int nfa_regpiece(void)
   int greedy = TRUE;                /* Braces are prefixed with '-' ? */
   parse_state_T old_state;
   parse_state_T new_state;
-  int c2;
+  int64_t c2;
   int old_post_pos;
   int my_post_start;
   int quest;

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -2040,7 +2040,7 @@ static int nfa_regpiece(void)
 
   if (re_multi_type(peekchr()) != NOT_MULTI)
     /* Can't have a multi follow a multi. */
-    EMSG_RET_FAIL(_("E871: (NFA regexp) Can't have a multi follow a multi !"));
+    EMSG_RET_FAIL(_("E871: (NFA regexp) Can't have a multi follow a multi"));
 
   return OK;
 }
@@ -6264,7 +6264,7 @@ static long nfa_regtry(nfa_regprog_T *prog, colnr_T col, proftime_T *tm)
     fprintf(f, "\n\n");
     fclose(f);
   } else
-    EMSG(_("Could not open temporary log file for writing "));
+    EMSG("Could not open temporary log file for writing");
 #endif
 
   clear_sub(&subs.norm);

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -2723,7 +2723,7 @@ static void st_error(int *postfix, int *end, int *p)
     fclose(df);
   }
 #endif
-  EMSG(_("E874: (NFA) Could not pop the stack !"));
+  EMSG(_("E874: (NFA) Could not pop the stack!"));
 }
 
 /*
@@ -4964,7 +4964,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
   FILE        *debug = fopen(NFA_REGEXP_DEBUG_LOG, "a");
 
   if (debug == NULL) {
-    EMSG2(_("(NFA) COULD NOT OPEN %s !"), NFA_REGEXP_DEBUG_LOG);
+    EMSG2("(NFA) COULD NOT OPEN %s!", NFA_REGEXP_DEBUG_LOG);
     return false;
   }
 #endif

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -4698,7 +4698,7 @@ static int recursive_regmatch(nfa_state_T *state, nfa_pim_T *pim, nfa_regprog_T 
     fprintf(log_fd, "****************************\n");
   } else {
     EMSG(_(
-            "Could not open temporary log file for writing, displaying on stderr ... "));
+            "Could not open temporary log file for writing, displaying on stderr... "));
     log_fd = stderr;
   }
 #endif

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1485,7 +1485,7 @@ static int nfa_regatom(void)
 
     default:
     {
-      int n = 0;
+      long n = 0;
       int cmp = c;
 
       if (c == '<' || c == '>')
@@ -1511,7 +1511,13 @@ static int nfa_regatom(void)
           EMIT(cmp == '<' ? NFA_VCOL_LT :
                cmp == '>' ? NFA_VCOL_GT : NFA_VCOL);
         }
-        EMIT(n);
+#if SIZEOF_INT < SIZEOF_LONG
+        if (n > INT_MAX) {
+          EMSG(_("E951: \\% value too large"));
+          return FAIL;
+        }
+#endif
+        EMIT((int)n);
         break;
       } else if (c == '\'' && n == 0) {
         /* \%'m  \%<'m  \%>'m  */

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -2453,6 +2453,7 @@ static void nfa_set_code(int c)
 }
 
 static FILE *log_fd;
+static char_u e_log_open_failed[] = N_("Could not open temporary log file for writing, displaying on stderr... ");
 
 /*
  * Print the postfix notation of the current regexp.
@@ -2466,7 +2467,7 @@ static void nfa_postfix_dump(char_u *expr, int retval)
   if (f != NULL) {
     fprintf(f, "\n-------------------------\n");
     if (retval == FAIL)
-      fprintf(f, ">>> NFA engine failed ... \n");
+      fprintf(f, ">>> NFA engine failed... \n");
     else if (retval == OK)
       fprintf(f, ">>> NFA engine succeeded !\n");
     fprintf(f, "Regexp: \"%s\"\nPostfix notation (char): \"", expr);
@@ -4697,8 +4698,7 @@ static int recursive_regmatch(nfa_state_T *state, nfa_pim_T *pim, nfa_regprog_T 
     fprintf(log_fd, "MATCH = %s\n", !result ? "FALSE" : "OK");
     fprintf(log_fd, "****************************\n");
   } else {
-    EMSG(_(
-            "Could not open temporary log file for writing, displaying on stderr... "));
+    EMSG(_(e_log_open_failed));
     log_fd = stderr;
   }
 #endif
@@ -5002,8 +5002,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
         abs(start->id), code);
     fprintf(log_fd, "**********************************\n");
   } else {
-    EMSG(_(
-            "Could not open temporary log file for writing, displaying on stderr ... "));
+    EMSG(_(e_log_open_failed));
     log_fd = stderr;
   }
 #endif
@@ -5068,7 +5067,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
     fprintf(log_fd, "------------------------------------------\n");
     fprintf(log_fd, ">>> Reginput is \"%s\"\n", reginput);
     fprintf(log_fd,
-        ">>> Advanced one character ... Current char is %c (code %d) \n", curc,
+        ">>> Advanced one character... Current char is %c (code %d) \n", curc,
         (int)curc);
     fprintf(log_fd, ">>> Thislist has %d states available: ", thislist->n);
     {
@@ -5108,7 +5107,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
         else
           col = (int)(t->subs.norm.list.line[0].start - regline);
         nfa_set_code(t->state->c);
-        fprintf(log_fd, "(%d) char %d %s (start col %d)%s ... \n",
+        fprintf(log_fd, "(%d) char %d %s (start col %d)%s... \n",
             abs(t->state->id), (int)t->state->c, code, col,
             pim_info(&t->pim));
       }
@@ -6493,7 +6492,7 @@ static regprog_T *nfa_regcomp(char_u *expr, int re_flags)
     if (f != NULL) {
       fprintf(
           f,
-          "\n*****************************\n\n\n\n\tCompiling regexp \"%s\" ... hold on !\n",
+          "\n*****************************\n\n\n\n\tCompiling regexp \"%s\"... hold on !\n",
           expr);
       fclose(f);
     }

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -3224,7 +3224,13 @@ static nfa_state_T *post2nfa(int *postfix, int *end, int nfa_calc_size)
       if (pattern) {
         /* NFA_ZEND -> NFA_END_PATTERN -> NFA_SKIP -> what follows. */
         skip = alloc_state(NFA_SKIP, NULL, NULL);
+        if (skip == NULL) {
+          goto theend;
+        }
         zend = alloc_state(NFA_ZEND, s1, NULL);
+        if (zend == NULL) {
+          goto theend;
+        }
         s1->out= skip;
         patch(e.out, zend);
         PUSH(frag(s, list1(&skip->out)));

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -3032,7 +3032,7 @@ static int spell_read_dic(spellinfo_T *spin, char_u *fname, afffile_T *affile)
   hash_init(&ht);
 
   vim_snprintf((char *)IObuff, IOSIZE,
-      _("Reading dictionary file %s..."), fname);
+               _("Reading dictionary file %s..."), fname);
   spell_message(spin, IObuff);
 
   // start with a message for the first line
@@ -4998,7 +4998,7 @@ static void sug_write(spellinfo_T *spin, char_u *fname)
   }
 
   vim_snprintf((char *)IObuff, IOSIZE,
-      _("Writing suggestion file %s..."), fname);
+               _("Writing suggestion file %s..."), fname);
   spell_message(spin, IObuff);
 
   // <SUGHEADER>: <fileID> <versionnr> <timestamp>
@@ -5234,7 +5234,7 @@ mkspell (
     if (!error && !got_int) {
       // Write the info in the spell file.
       vim_snprintf((char *)IObuff, IOSIZE,
-          _("Writing spell file %s..."), wfname);
+                   _("Writing spell file %s..."), wfname);
       spell_message(&spin, IObuff);
 
       error = write_vim_spell(&spin, wfname) == FAIL;

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1993,7 +1993,7 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
     return NULL;
   }
 
-  vim_snprintf((char *)IObuff, IOSIZE, _("Reading affix file %s ..."), fname);
+  vim_snprintf((char *)IObuff, IOSIZE, _("Reading affix file %s..."), fname);
   spell_message(spin, IObuff);
 
   // Only do REP lines when not done in another .aff file already.
@@ -3032,7 +3032,7 @@ static int spell_read_dic(spellinfo_T *spin, char_u *fname, afffile_T *affile)
   hash_init(&ht);
 
   vim_snprintf((char *)IObuff, IOSIZE,
-      _("Reading dictionary file %s ..."), fname);
+      _("Reading dictionary file %s..."), fname);
   spell_message(spin, IObuff);
 
   // start with a message for the first line
@@ -3548,7 +3548,7 @@ static int spell_read_wordfile(spellinfo_T *spin, char_u *fname)
     return FAIL;
   }
 
-  vim_snprintf((char *)IObuff, IOSIZE, _("Reading word file %s ..."), fname);
+  vim_snprintf((char *)IObuff, IOSIZE, _("Reading word file %s..."), fname);
   spell_message(spin, IObuff);
 
   // Read all the lines in the file one by one.
@@ -4998,7 +4998,7 @@ static void sug_write(spellinfo_T *spin, char_u *fname)
   }
 
   vim_snprintf((char *)IObuff, IOSIZE,
-      _("Writing suggestion file %s ..."), fname);
+      _("Writing suggestion file %s..."), fname);
   spell_message(spin, IObuff);
 
   // <SUGHEADER>: <fileID> <versionnr> <timestamp>
@@ -5234,7 +5234,7 @@ mkspell (
     if (!error && !got_int) {
       // Write the info in the spell file.
       vim_snprintf((char *)IObuff, IOSIZE,
-          _("Writing spell file %s ..."), wfname);
+          _("Writing spell file %s..."), wfname);
       spell_message(&spin, IObuff);
 
       error = write_vim_spell(&spin, wfname) == FAIL;


### PR DESCRIPTION
**vim-patch:8.0.0828: Coverity: may dereference NULL pointer**

Problem:    Coverity: may dereference NULL pointer.
Solution:   Bail out if calloc_state() returns NULL.
vim/vim@983b3a5

**vim-patch:8.0.1254: undefined left shift in gethexchrs()**

Problem:    Undefined left shift in gethexchrs(). (geeknik)
Solution:   Use unsigned long. (idea by Christian Brabandt, closes vim/vim#2255)
vim/vim@4c22a91

**vim-patch:8.0.1470: integer overflow when using regexp pattern**

Problem:    Integer overflow when using regexp pattern. (geeknik)
Solution:   Use a long instead of int. (Christian Brabandt, closes vim/vim#2251)
vim/vim@2c7b906

**vim-patch:8.0.1517: invalid memory acces with pattern using look-behind match**

Problem:    Invalid memory acces with pattern using look-behind match.
            (Dominique Pelle)
Solution:   Get a pointer to the right line.
vim/vim@bc19719

**vim-patch:8.1.0078: "..." used inconsistently in messages**

Problem:    "..." used inconsistently in messages.
Solution:   Drop the space before " ...".
vim/vim@c166927

**vim-patch:8.1.0090: "..." used inconsistently in a message**

Problem:    "..." used inconsistently in a message.
Solution:   Define the message with " ..." once. (hint by Ken Takata)
vim/vim@9b0c5c2

**vim-patch:8.1.0097: superfluous space before exclamation mark**

Problem:    Superfluous space before exclamation mark.
Solution:   Remove the space.  Don't translate debug message.
vim/vim@5efa010

**vim-patch:8.1.0099: exclamation mark in error message not needed**

Problem:    Exclamation mark in error message not needed.
Solution:   Remove the exclamation mark.
vim/vim@3c867da


Breaking up https://github.com/neovim/neovim/pull/8662 into smaller PRs so it's easier to debug 8.0.0286.