### PR TITLE
[RDY] vim-patch:8.0.1490

### DIFF
--- a/src/nvim/spell_defs.h
+++ b/src/nvim/spell_defs.h
@@ -13,6 +13,9 @@
                                 // Some places assume a word length fits in a
                                 // byte, thus it can't be above 255.
 
+// Number of regions supported.
+#define MAXREGIONS 8
+
 // Type used for indexes in the word tree need to be at least 4 bytes.  If int
 // is 8 bytes we could use something smaller, but what?
 typedef int idx_T;
@@ -124,7 +127,8 @@ struct slang_S {
 
   char_u      *sl_info;         // infotext string or NULL
 
-  char_u sl_regions[17];        // table with up to 8 region names plus NUL
+  char_u sl_regions[MAXREGIONS * 2 + 1];
+                                // table with up to 8 region names plus NUL
 
   char_u      *sl_midword;      // MIDWORD string or NULL
 

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -5136,13 +5136,13 @@ mkspell (
       spin.si_add = true;
   }
 
-  if (incount <= 0)
+  if (incount <= 0) {
     EMSG(_(e_invarg));          // need at least output and input names
-  else if (vim_strchr(path_tail(wfname), '_') != NULL)
+  } else if (vim_strchr(path_tail(wfname), '_') != NULL) {
     EMSG(_("E751: Output file name must not have region name"));
-  else if (incount > MAXREGIONS)
+  } else if (incount > MAXREGIONS) {
     EMSGN(_("E754: Only up to %ld regions supported"), MAXREGIONS);
-  else {
+  } else {
     // Check for overwriting before doing things that may take a lot of
     // time.
     if (!over_write && os_path_exists(wfname)) {


### PR DESCRIPTION
**vim-patch:8.0.1490: number of spell regions is spread out through the code**

Problem:    Number of spell regions is spread out through the code.
Solution:   Define MAXREGIONS.
https://github.com/vim/vim/commit/2993ac5fce5450428322ce43aaa5e643e6994443