### PR TITLE
[RFC] Fix message id type in msgpack RPC

### DIFF
--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -36,7 +36,7 @@ typedef enum {
 } MessageType;
 
 /// Used as the message ID of notifications.
-#define NO_RESPONSE UINT64_MAX
+#define NO_RESPONSE UINT32_MAX
 
 /// Mask for all internal calls
 #define INTERNAL_CALL_MASK (((uint64_t)1) << (sizeof(uint64_t) * 8 - 1))

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -362,18 +362,14 @@ static void on_request_event(void **argv)
   uint32_t request_id = e->request_id;
   Error error = ERROR_INIT;
   Object result = handler.fn(channel->id, args, &error);
-  if (request_id != NO_RESPONSE) {
-    // send the response
-    msgpack_packer response;
-    msgpack_packer_init(&response, &out_buffer, msgpack_sbuffer_write);
-    channel_write(channel, serialize_response(channel->id,
-                                              request_id,
-                                              &error,
-                                              result,
-                                              &out_buffer));
-  } else {
-    api_free_object(result);
-  }
+  // send the response
+  msgpack_packer response;
+  msgpack_packer_init(&response, &out_buffer, msgpack_sbuffer_write);
+  channel_write(channel, serialize_response(channel->id,
+                                            request_id,
+                                            &error,
+                                            result,
+                                            &out_buffer));
   api_free_array(args);
   channel_decref(channel);
   xfree(e);

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -131,7 +131,7 @@ Object rpc_send_call(uint64_t id,
 
   channel_incref(channel);
   RpcState *rpc = &channel->rpc;
-  uint64_t request_id = rpc->next_request_id++;
+  uint32_t request_id = rpc->next_request_id++;
   // Send the msgpack-rpc request
   send_request(channel, request_id, method_name, args);
 
@@ -290,7 +290,7 @@ static void parse_msgpack(Channel *channel)
 static void handle_request(Channel *channel, msgpack_object *request)
   FUNC_ATTR_NONNULL_ALL
 {
-  uint64_t request_id;
+  uint32_t request_id;
   Error error = ERROR_INIT;
   msgpack_rpc_validate(&request_id, request, &error);
 
@@ -359,7 +359,7 @@ static void on_request_event(void **argv)
   Channel *channel = e->channel;
   MsgpackRpcRequestHandler handler = e->handler;
   Array args = e->args;
-  uint64_t request_id = e->request_id;
+  uint32_t request_id = e->request_id;
   Error error = ERROR_INIT;
   Object result = handler.fn(channel->id, args, &error);
   if (request_id != NO_RESPONSE) {
@@ -429,7 +429,7 @@ static void internal_read_event(void **argv)
   wstream_release_wbuffer(buffer);
 }
 
-static void send_error(Channel *channel, uint64_t id, char *err)
+static void send_error(Channel *channel, uint32_t id, char *err)
 {
   Error e = ERROR_INIT;
   api_set_error(&e, kErrorTypeException, "%s", err);
@@ -442,7 +442,7 @@ static void send_error(Channel *channel, uint64_t id, char *err)
 }
 
 static void send_request(Channel *channel,
-                         uint64_t id,
+                         uint32_t id,
                          const char *name,
                          Array args)
 {
@@ -570,7 +570,7 @@ static bool is_rpc_response(msgpack_object *obj)
 
 static bool is_valid_rpc_response(msgpack_object *obj, Channel *channel)
 {
-  uint64_t response_id = obj->via.array.ptr[1].via.u64;
+  uint32_t response_id = (uint32_t)obj->via.array.ptr[1].via.u64;
   if (kv_size(channel->rpc.call_stack) == 0) {
     return false;
   }
@@ -608,7 +608,7 @@ static void call_set_error(Channel *channel, char *msg, int loglevel)
 }
 
 static WBuffer *serialize_request(uint64_t channel_id,
-                                  uint64_t request_id,
+                                  uint32_t request_id,
                                   const String method,
                                   Array args,
                                   msgpack_sbuffer *sbuffer,
@@ -628,7 +628,7 @@ static WBuffer *serialize_request(uint64_t channel_id,
 }
 
 static WBuffer *serialize_response(uint64_t channel_id,
-                                   uint64_t response_id,
+                                   uint32_t response_id,
                                    Error *err,
                                    Object arg,
                                    msgpack_sbuffer *sbuffer)

--- a/src/nvim/msgpack_rpc/channel_defs.h
+++ b/src/nvim/msgpack_rpc/channel_defs.h
@@ -13,7 +13,7 @@
 typedef struct Channel Channel;
 
 typedef struct {
-  uint64_t request_id;
+  uint32_t request_id;
   bool returned, errored;
   Object result;
 } ChannelCallFrame;
@@ -22,14 +22,14 @@ typedef struct {
   Channel *channel;
   MsgpackRpcRequestHandler handler;
   Array args;
-  uint64_t request_id;
+  uint32_t request_id;
 } RequestEvent;
 
 typedef struct {
   PMap(cstr_t) *subscribed_events;
   bool closed;
   msgpack_unpacker *unpacker;
-  uint64_t next_request_id;
+  uint32_t next_request_id;
   kvec_t(ChannelCallFrame *) call_stack;
   Dictionary info;
 } RpcState;

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -489,7 +489,7 @@ void msgpack_rpc_from_dictionary(Dictionary result, msgpack_packer *res)
 }
 
 /// Serializes a msgpack-rpc request or notification(id == 0)
-void msgpack_rpc_serialize_request(uint64_t request_id,
+void msgpack_rpc_serialize_request(uint32_t request_id,
                                    const String method,
                                    Array args,
                                    msgpack_packer *pac)
@@ -499,7 +499,7 @@ void msgpack_rpc_serialize_request(uint64_t request_id,
   msgpack_pack_int(pac, request_id ? 0 : 2);
 
   if (request_id) {
-    msgpack_pack_uint64(pac, request_id);
+    msgpack_pack_uint32(pac, request_id);
   }
 
   msgpack_rpc_from_string(method, pac);
@@ -507,7 +507,7 @@ void msgpack_rpc_serialize_request(uint64_t request_id,
 }
 
 /// Serializes a msgpack-rpc response
-void msgpack_rpc_serialize_response(uint64_t response_id,
+void msgpack_rpc_serialize_response(uint32_t response_id,
                                     Error *err,
                                     Object arg,
                                     msgpack_packer *pac)
@@ -515,7 +515,7 @@ void msgpack_rpc_serialize_response(uint64_t response_id,
 {
   msgpack_pack_array(pac, 4);
   msgpack_pack_int(pac, 1);
-  msgpack_pack_uint64(pac, response_id);
+  msgpack_pack_uint32(pac, response_id);
 
   if (ERROR_SET(err)) {
     // error represented by a [type, message] array
@@ -561,7 +561,7 @@ static msgpack_object *msgpack_rpc_msg_id(msgpack_object *req)
   return obj->type == MSGPACK_OBJECT_POSITIVE_INTEGER ? obj : NULL;
 }
 
-void msgpack_rpc_validate(uint64_t *response_id,
+void msgpack_rpc_validate(uint32_t *response_id,
                           msgpack_object *req,
                           Error *err)
 {
@@ -603,7 +603,7 @@ void msgpack_rpc_validate(uint64_t *response_id,
       api_set_error(err, kErrorTypeValidation, "ID must be a positive integer");
       return;
     }
-    *response_id = id_obj->via.u64;
+    *response_id = (uint32_t)id_obj->via.u64;
   }
 
   if (!msgpack_rpc_method(req)) {

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -566,8 +566,8 @@ void msgpack_rpc_validate(uint32_t *response_id,
                           Error *err)
 {
   // response id not known yet
-
   *response_id = NO_RESPONSE;
+
   // Validate the basic structure of the msgpack-rpc payload
   if (req->type != MSGPACK_OBJECT_ARRAY) {
     api_set_error(err, kErrorTypeValidation, "Message is not an array");


### PR DESCRIPTION
According to [MessagePack RPC specification](https://github.com/msgpack-rpc/msgpack-rpc), message ID must be 32-bit unsigned integer. However, neovim implementation uses `uint64_t` instead of `uint32_t`. The isssue occurs in case of malformed request (see example below) or large ids.

```
Actual response:   [1,18446744073709551615,[1,"Message is not an array"],null]
Expected response: [1,4294967295,[1,"Message is not an array"],null]
```

The issue does not affect RPC clients written in dynamically typed languages like Python. In the same time, wrong type of sequence id number breaks RPC clients written statically typed languages like C/C++/Golang. All of them expects `uint32_t` as message id (see [[1](https://github.com/msgpack-rpc/msgpack-rpc-cpp/blob/11268ba2be5954ddbb2b7676c7da576985e45cfc/src/msgpack/rpc/protocol.h#L27)][[2](https://github.com/ugorji/go/blob/master/codec/msgpack.go#L993)] for example).