### PR TITLE
vim-patch:8.0.{1227,1243,1257,1397}

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1380,15 +1380,15 @@ retry:
             }
           } else if (fio_flags & FIO_UCS4) {
             if (fio_flags & FIO_ENDIAN_L) {
-              u8c = (*--p << 24);
-              u8c += (*--p << 16);
-              u8c += (*--p << 8);
+              u8c = (unsigned)*--p << 24;
+              u8c += (unsigned)*--p << 16;
+              u8c += (unsigned)*--p << 8;
               u8c += *--p;
             } else {          /* big endian */
               u8c = *--p;
-              u8c += (*--p << 8);
-              u8c += (*--p << 16);
-              u8c += (*--p << 24);
+              u8c += (unsigned)*--p << 8;
+              u8c += (unsigned)*--p << 16;
+              u8c += (unsigned)*--p << 24;
             }
           } else {        /* UTF-8 */
             if (*--p < 0x80)

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1380,15 +1380,15 @@ retry:
             }
           } else if (fio_flags & FIO_UCS4) {
             if (fio_flags & FIO_ENDIAN_L) {
-              u8c = (unsigned)*--p << 24;
-              u8c += (unsigned)*--p << 16;
-              u8c += (unsigned)*--p << 8;
+              u8c = (unsigned)(*--p) << 24;
+              u8c += (unsigned)(*--p) << 16;
+              u8c += (unsigned)(*--p) << 8;
               u8c += *--p;
             } else {          /* big endian */
               u8c = *--p;
-              u8c += (unsigned)*--p << 8;
-              u8c += (unsigned)*--p << 16;
-              u8c += (unsigned)*--p << 24;
+              u8c += (unsigned)(*--p) << 8;
+              u8c += (unsigned)(*--p) << 16;
+              u8c += (unsigned)(*--p) << 24;
             }
           } else {        /* UTF-8 */
             if (*--p < 0x80)

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -2131,7 +2131,6 @@ static int nfa_regconcat(void)
  */
 static int nfa_regbranch(void)
 {
-  int ch;
   int old_post_pos;
 
   old_post_pos = (int)(post_ptr - post_start);
@@ -2140,10 +2139,13 @@ static int nfa_regbranch(void)
   if (nfa_regconcat() == FAIL)
     return FAIL;
 
-  ch = peekchr();
   /* Try next concats */
-  while (ch == Magic('&')) {
+  while (peekchr() == Magic('&')) {
     skipchr();
+    // if concat is empty do emit a node
+    if (old_post_pos == (int)(post_ptr - post_start)) {
+      EMIT(NFA_EMPTY);
+    }
     EMIT(NFA_NOPEN);
     EMIT(NFA_PREV_ATOM_NO_WIDTH);
     old_post_pos = (int)(post_ptr - post_start);
@@ -2153,7 +2155,6 @@ static int nfa_regbranch(void)
     if (old_post_pos == (int)(post_ptr - post_start))
       EMIT(NFA_EMPTY);
     EMIT(NFA_CONCAT);
-    ch = peekchr();
   }
 
   /* if a branch is empty, emit one node for it */

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -2139,7 +2139,7 @@ static int nfa_regbranch(void)
   if (nfa_regconcat() == FAIL)
     return FAIL;
 
-  /* Try next concats */
+  // Try next concats
   while (peekchr() == Magic('&')) {
     skipchr();
     // if concat is empty do emit a node

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -1201,6 +1201,13 @@ func! Test_normal19_z_spell()
   call assert_match("Word 'goood' added to ./Xspellfile2.add", a)
   call assert_equal('goood', cnt[0])
 
+  " Test for :spellgood!
+  let temp = execute(':spe!0/0')
+  call assert_match('Invalid region', temp)
+  let spellfile = matchstr(temp, 'Invalid region nr in \zs.*\ze line \d: 0')
+  call assert_equal(['# goood', '# goood/!', '#oood', '0/0'], readfile(spellfile))
+  call delete(spellfile)
+
   " clean up
   exe "lang" oldlang
   call delete("./Xspellfile.add")

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -453,3 +453,18 @@ func Test_search_multibyte()
   enew!
   let &encoding = save_enc
 endfunc
+
+func Test_search_undefined_behaviour()
+  if !has("terminal")
+    return
+  endif
+  let h = winheight(0)
+  if h < 3
+    return
+  endif
+  " did cause an undefined left shift
+  let g:buf = term_start([GetVimProg(), '--clean', '-e', '-s', '-c', 'call search(getline("."))', 'samples/test000'], {'term_rows': 3})
+  call assert_equal([''], getline(1, '$'))
+  call term_sendkeys(g:buf, ":qa!\<cr>")
+  bwipe!
+endfunc

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -468,3 +468,7 @@ func Test_search_undefined_behaviour()
   call term_sendkeys(g:buf, ":qa!\<cr>")
   bwipe!
 endfunc
+
+func Test_search_undefined_behaviour2()
+  call search("\%UC0000000")
+endfunc

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -472,3 +472,11 @@ endfunc
 func Test_search_undefined_behaviour2()
   call search("\%UC0000000")
 endfunc
+
+" This was causing E874.  Also causes an invalid read?
+func Test_look_behind()
+  new
+  call setline(1, '0\|\&\n\@<=') 
+  call search(getline("."))
+  bwipe!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1227: undefined left shift in readfile()**

Problem:    Undefined left shift in readfile(). (Brian 'geeknik' Carpenter)
Solution:   Add cast to unsigned. (Dominique Pelle, closes vim/vim#2253)
vim/vim@dc1c981

**vim-patch:8.0.1243: no test for what 8.0.1227 fixes**

Problem:    No test for what 8.0.1227 fixes.
Solution:   Add a test that triggers the problem. (Christian Brabandt)
vim/vim@f45938c

**vim-patch:8.0.1257: no test for fix of undefined behavior**

Problem:    No test for fix of undefined behavior.
Solution:   Add a test. (closes vim/vim#2255)
vim/vim@2973daa

**vim-patch:8.0.1397: pattern with \& following nothing gives an error**

Problem:    Pattern with \& following nothing gives an error.
Solution:   Emit an empty node when needed.
vim/vim@890dd05