### PR TITLE
[RDY] vim-patch:8.0.1630,8.1.{161,262}

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2336,6 +2336,7 @@ tolower({expr})			String	the String {expr} switched to lowercase
 toupper({expr})			String	the String {expr} switched to uppercase
 tr({src}, {fromstr}, {tostr})	String	translate chars of {src} in {fromstr}
 					to chars in {tostr}
+trim({text}[, {mask}]) 		String	trim characters in {mask} from {text}
 trunc({expr})			Float	truncate Float {expr}
 type({name})			Number	type of variable {name}
 undofile({name})		String	undo file name for {name}
@@ -7961,6 +7962,22 @@ tr({src}, {fromstr}, {tostr})				*tr()*
 <		returns "Hello THere" >
 			echo tr("<blob>", "<>", "{}")
 <		returns "{blob}"
+
+trim({text}[, {mask}])						*trim()*
+		Return {text} as a String where any character in {mask} is
+		removed from the beginning and  end of {text}.
+		If {mask} is not given, {mask} is all characters up to 0x20,
+		which includes Tab, space, NL and CR, plus the non-breaking
+		space character 0xa0.
+		This code deals with multibyte characters properly.
+
+		Examples: >
+			echo trim("  \r\t\t\r RESERVE \t \t\n\x0B\x0B")."_TAIL"
+<		returns "RESERVE_TAIL" >
+			echo trim("needrmvRESERVEnnneeedddrrmmmmvv", "ednmrv")
+<		returns "RESERVE" >
+			echo trim("rm<blob1><blob2><any_chars>rrmm<blob1><blob2><blob2>", "rm<blob1><blob2>")
+<		returns "any_chas"
 
 trunc({expr})							*trunc()*
 		Return the largest integral value with magnitude less than or

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17218,6 +17218,69 @@ error:
   return;
 }
 
+// "trim({expr})" function
+static void f_trim(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  char buf1[NUMBUFLEN];
+  char buf2[NUMBUFLEN];
+  const char_u *head = (const char_u *)tv_get_string_buf_chk(&argvars[0], buf1);
+  const char_u *mask = NULL;
+  const char_u *tail;
+  const char_u *prev;
+  const char_u *p;
+  int c1;
+
+  rettv->v_type = VAR_STRING;
+  if (head == NULL) {
+    rettv->vval.v_string = NULL;
+    return;
+  }
+
+  if (argvars[1].v_type == VAR_STRING) {
+    mask = (const char_u *)tv_get_string_buf_chk(&argvars[1], buf2);
+  }
+
+  while (*head != NUL) {
+    c1 = PTR2CHAR(head);
+    if (mask == NULL) {
+      if (c1 > ' ' && c1 != 0xa0) {
+        break;
+      }
+    } else {
+      for (p = mask; *p != NUL; MB_PTR_ADV(p)) {
+        if (c1 == PTR2CHAR(p)) {
+          break;
+        }
+      }
+      if (*p == NUL) {
+        break;
+      }
+    }
+    MB_PTR_ADV(head);
+  }
+
+  for (tail = head + STRLEN(head); tail > head; tail = prev) {
+    prev = tail;
+    MB_PTR_BACK(head, prev);
+    c1 = PTR2CHAR(prev);
+    if (mask == NULL) {
+      if (c1 > ' ' && c1 != 0xa0) {
+        break;
+      }
+    } else {
+      for (p = mask; *p != NUL; MB_PTR_ADV(p)) {
+        if (c1 == PTR2CHAR(p)) {
+          break;
+        }
+      }
+      if (*p == NUL) {
+        break;
+      }
+    }
+  }
+  rettv->vval.v_string = vim_strnsave(head, (int)(tail - head));
+}
+
 /*
  * "type(expr)" function
  */

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9874,7 +9874,7 @@ static void f_getftype(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 # endif
 # ifdef S_ISSOCK
     else if (S_ISSOCK(mode))
-      t = "fifo";
+      t = "socket";
 # endif
     else
       t = "other";

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -323,6 +323,7 @@ return {
     tolower={args=1},
     toupper={args=1},
     tr={args=3},
+    trim={args={1,2}},
     trunc={args=1, func="float_op_wrapper", data="&trunc"},
     type={args=1},
     undofile={args=1},

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4892,10 +4892,12 @@ buf_check_timestamp (
           )) {
     retval = 1;
 
-    /* set b_mtime to stop further warnings (e.g., when executing
-     * FileChangedShell autocmd) */
+    // set b_mtime to stop further warnings (e.g., when executing
+    // FileChangedShell autocmd)
     if (!file_info_ok) {
-      buf->b_mtime = 0;
+      // When 'autoread' is set we'll check the file again to see if it
+      // re-appears.
+      buf->b_mtime = buf->b_p_ar;
       buf->b_orig_size = 0;
       buf->b_orig_mode = 0;
     } else {

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -926,3 +926,26 @@ func Test_redo_in_nested_functions()
   delfunc Operator
   delfunc Apply
 endfunc
+
+func Test_trim()
+  call assert_equal("Testing", trim("  \t\r\r\x0BTesting  \t\n\r\n\t\x0B\x0B"))
+  call assert_equal("Testing", trim("  \t  \r\r\n\n\x0BTesting  \t\n\r\n\t\x0B\x0B"))
+  call assert_equal("RESERVE", trim("xyz \twwRESERVEzyww \t\t", " wxyz\t"))
+  call assert_equal("wRE    \tSERVEzyww", trim("wRE    \tSERVEzyww"))
+  call assert_equal("abcd\t     xxxx   tail", trim(" \tabcd\t     xxxx   tail"))
+  call assert_equal("\tabcd\t     xxxx   tail", trim(" \tabcd\t     xxxx   tail", " "))
+  call assert_equal(" \tabcd\t     xxxx   tail", trim(" \tabcd\t     xxxx   tail", "abx"))
+  call assert_equal("RESERVE", trim("你RESERVE好", "你好"))
+  call assert_equal("您R E SER V E早", trim("你好您R E SER V E早好你你", "你好"))
+  call assert_equal("你好您R E SER V E早好你你", trim(" \n\r\r   你好您R E SER V E早好你你    \t  \x0B", ))
+  call assert_equal("您R E SER V E早好你你    \t  \x0B", trim("    你好您R E SER V E早好你你    \t  \x0B", " 你好"))
+  call assert_equal("您R E SER V E早好你你    \t  \x0B", trim("    tteesstttt你好您R E SER V E早好你你    \t  \x0B ttestt", " 你好tes"))
+  call assert_equal("您R E SER V E早好你你    \t  \x0B", trim("    tteesstttt你好您R E SER V E早好你你    \t  \x0B ttestt", "   你你你好好好tttsses"))
+  call assert_equal("留下", trim("这些些不要这些留下这些", "这些不要"))
+  call assert_equal("", trim("", ""))
+  call assert_equal("a", trim("a", ""))
+  call assert_equal("", trim("", "a"))
+
+  let chars = join(map(range(1, 0x20) + [0xa0], {n -> nr2char(n)}), '')
+  call assert_equal("x", trim(chars . "x" . chars))
+endfunc

--- a/src/nvim/testdir/test_stat.vim
+++ b/src/nvim/testdir/test_stat.vim
@@ -43,7 +43,7 @@ func Test_existent_directory()
 
   call assert_equal(0, getfsize(dname))
   call assert_equal('dir', getftype(dname))
-  call assert_equal('rwx', getfperm(dname)[0:2])
+  call assert_equal(has('win32') ? 'rw-' : 'rwx', getfperm(dname)[0:2])
 endfunc
 
 func SleepForTimestamp()

--- a/src/nvim/testdir/test_stat.vim
+++ b/src/nvim/testdir/test_stat.vim
@@ -46,6 +46,15 @@ func Test_existent_directory()
   call assert_equal('rwx', getfperm(dname)[0:2])
 endfunc
 
+func SleepForTimestamp()
+  " FAT has a granularity of 2 seconds, otherwise it's usually 1 second
+  if has('win32')
+    sleep 2
+  else
+    sleep 2
+  endif
+endfunc
+
 func Test_checktime()
   let fname = 'Xtest.tmp'
 
@@ -53,12 +62,7 @@ func Test_checktime()
   call writefile(fl, fname)
   set autoread
   exec 'e' fname
-  " FAT has a granularity of 2 seconds, otherwise it's usually 1 second
-  if has('win32')
-    sleep 2
-  else
-    sleep 2
-  endif
+  call SleepForTimestamp()
   let fl = readfile(fname)
   let fl[0] .= ' - checktime'
   call writefile(fl, fname)
@@ -67,6 +71,46 @@ func Test_checktime()
 
   call delete(fname)
 endfunc
+
+func Test_autoread_file_deleted()
+  new Xautoread
+  set autoread
+  call setline(1, 'original')
+  w!
+
+  call SleepForTimestamp()
+  if has('win32')
+    silent !echo changed > Xautoread
+  else
+    silent !echo 'changed' > Xautoread
+  endif
+  checktime
+  call assert_equal('changed', trim(getline(1)))
+
+  call SleepForTimestamp()
+  messages clear
+  if has('win32')
+    silent !del Xautoread
+  else
+    silent !rm Xautoread
+  endif
+  checktime
+  call assert_match('E211:', execute('messages'))
+  call assert_equal('changed', trim(getline(1)))
+
+  call SleepForTimestamp()
+  if has('win32')
+    silent !echo recreated > Xautoread
+  else
+    silent !echo 'recreated' > Xautoread
+  endif
+  checktime
+  call assert_equal('recreated', trim(getline(1)))
+
+  call delete('Xautoread')
+  bwipe!
+endfunc
+
 
 func Test_nonexistent_file()
   let fname = 'Xtest.tmp'


### PR DESCRIPTION
**vim-patch:8.0.1630: trimming white space is not that easy**

Problem:    Trimming white space is not that easy.
Solution:   Add the trim() function. (Bukn, closes vim/vim#1280)
vim/vim@295ac5a

**vim-patch:8.1.0161: buffer not updated with 'autoread' set if file was deleted**

Problem:    Buffer not updated with 'autoread' set if file was deleted.
            (Michael Naumann)
Solution:   Don't set the timestamp to zero. (closes vim/vim#3165)
https://github.com/vim/vim/commit/386bc82a3f82f70bad75aaad74dba57a176b5840

**vim-patch:8.1.0262: not enough testing for getftype()**

Problem:    Not enough testing for getftype().
Solution:   Add a test. (Dominique Pelle, closes vim/vim#3300)
vim/vim@1598f99