### PR TITLE
vim-patch:8.0.1486

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -570,8 +570,12 @@ int searchit(
                && pos->lnum >= 1 && pos->lnum <= buf->b_ml.ml_line_count
                && pos->col < MAXCOL - 2) {
       // Watch out for the "col" being MAXCOL - 2, used in a closed fold.
-      ptr = ml_get_buf(buf, pos->lnum, false) + pos->col;
-      start_char_len = *ptr == NUL ? 1 : (*mb_ptr2len)(ptr);
+      ptr = ml_get_buf(buf, pos->lnum, false);
+      if ((int)STRLEN(ptr) < pos->col) {
+        start_char_len = 1;
+      } else {
+        start_char_len = utfc_ptr2len(ptr + pos->col);
+      }
     } else {
       start_char_len = 1;
     }

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -152,3 +152,16 @@ func Test_match()
   call assert_equal(3 , match('abc', '\zs', 3, 1))
   call assert_equal(-1, match('abc', '\zs', 4, 1))
 endfunc
+
+" This was causing an illegal memory access
+func Test_inner_tag()
+  new
+  norm ixxx
+  call feedkeys("v", 'xt')
+  insert
+x
+x
+.
+  norm it
+  q!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1486: accessing invalid memory with "it"**

Problem:    Accessing invalid memory with "it". (Dominique Pelle)
Solution:   Avoid going over the end of the line. (Christian Brabandt,
            closes vim/vim#2532)
https://github.com/vim/vim/commit/82846a00ac0c135946c93c48c1657018a5c96b11