### PR TITLE
[RDY] vim-patch:8.0.{1209,1218,1409,1413,1488,1633}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -296,6 +296,11 @@ open_buffer (
   }
   save_file_ff(curbuf);                 // keep this fileformat
 
+  // Set last_changedtick to avoid triggering a TextChanged autocommand right
+  // after it was added.
+  curbuf->b_last_changedtick = buf_get_changedtick(curbuf);
+  curbuf->b_last_changedtick_pum = buf_get_changedtick(curbuf);
+
   /* require "!" to overwrite the file, because it wasn't read completely */
   if (aborting())
     curbuf->b_flags |= BF_READERR;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4541,11 +4541,6 @@ void ex_cbuffer(exarg_T *eap)
   qf_info_T *qi = &ql_info;
   const char *au_name = NULL;
 
-  if (eap->cmdidx == CMD_lbuffer || eap->cmdidx == CMD_lgetbuffer
-      || eap->cmdidx == CMD_laddbuffer) {
-    qi = ll_get_or_alloc_list(curwin);
-  }
-
   switch (eap->cmdidx) {
     case CMD_cbuffer:
       au_name = "cbuffer";
@@ -4574,6 +4569,13 @@ void ex_cbuffer(exarg_T *eap)
     if (aborting()) {
       return;
     }
+  }
+
+  // Must come after autocommands.
+  if (eap->cmdidx == CMD_lbuffer
+      || eap->cmdidx == CMD_lgetbuffer
+      || eap->cmdidx == CMD_laddbuffer) {
+    qi = ll_get_or_alloc_list(curwin);
   }
 
   if (*eap->arg == NUL)

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -953,11 +953,11 @@ void do_tags(exarg_T *eap)
 
       msg_putchar('\n');
       vim_snprintf((char *)IObuff, IOSIZE, "%c%2d %2d %-15s %5ld  ",
-          i == tagstackidx ? '>' : ' ',
-          i + 1,
-          tagstack[i].cur_match + 1,
-          tagstack[i].tagname,
-          tagstack[i].fmark.mark.lnum);
+                   i == tagstackidx ? '>' : ' ',
+                   i + 1,
+                   tagstack[i].cur_match + 1,
+                   tagstack[i].tagname,
+                   tagstack[i].fmark.mark.lnum);
       msg_outtrans(IObuff);
       msg_outtrans_attr(name, tagstack[i].fmark.fnum == curbuf->b_fnum
                         ? HL_ATTR(HLF_D) : 0);
@@ -2618,7 +2618,7 @@ static int jumpto_tag(
   }
 
 erret:
-  g_do_tagpreview = 0;   /* For next time */
+  g_do_tagpreview = 0;  // For next time
   xfree(lbuf);
   xfree(pbuf);
   xfree(tofree_fname);

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -952,7 +952,7 @@ void do_tags(exarg_T *eap)
         continue;
 
       msg_putchar('\n');
-      sprintf((char *)IObuff, "%c%2d %2d %-15s %5ld  ",
+      vim_snprintf((char *)IObuff, IOSIZE, "%c%2d %2d %-15s %5ld  ",
           i == tagstackidx ? '>' : ' ',
           i + 1,
           tagstack[i].cur_match + 1,

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2223,7 +2223,7 @@ static size_t matching_line_len(const char_u *const lbuf)
   const char_u *p = lbuf + 1;
 
   // does the same thing as parse_match()
-  p += STRLEN(p) + 2;
+  p += STRLEN(p) + 1;
   return (p - lbuf) + STRLEN(p);
 }
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2217,6 +2217,16 @@ static bool test_for_static(tagptrs_T *tagp)
   return FALSE;
 }
 
+// Returns the length of a matching tag line.
+static size_t matching_line_len(const char_u *const lbuf)
+{
+  const char_u *p = lbuf + 1;
+
+  // does the same thing as parse_match()
+  p += STRLEN(p) + 2;
+  return (p - lbuf) + STRLEN(p);
+}
+
 /*
  * Parse a line from a matching tag.  Does not change the line itself.
  *
@@ -2300,11 +2310,10 @@ static char_u *tag_full_fname(tagptrs_T *tagp)
  *
  * returns OK for success, NOTAGFILE when file not found, FAIL otherwise.
  */
-static int 
-jumpto_tag (
-    char_u *lbuf,              /* line from the tags file for this tag */
-    int forceit,                    /* :ta with ! */
-    int keep_help                  /* keep help flag (FALSE for cscope) */
+static int jumpto_tag(
+    const char_u *lbuf_arg,   // line from the tags file for this tag
+    int forceit,              // :ta with !
+    int keep_help             // keep help flag (FALSE for cscope)
 )
 {
   int save_secure;
@@ -2312,7 +2321,6 @@ jumpto_tag (
   bool save_p_ws;
   int save_p_scs, save_p_ic;
   linenr_T save_lnum;
-  int csave = 0;
   char_u      *str;
   char_u      *pbuf;                    /* search pattern buffer */
   char_u      *pbuf_end;
@@ -2327,6 +2335,9 @@ jumpto_tag (
   char_u      *full_fname = NULL;
   int old_KeyTyped = KeyTyped;              /* getting the file may reset it */
   const int l_g_do_tagpreview = g_do_tagpreview;
+  const size_t len = matching_line_len(lbuf_arg) + 1;
+  char_u *lbuf = xmalloc(len);
+  memmove(lbuf, lbuf_arg, len);
 
   pbuf = xmalloc(LSIZE);
 
@@ -2336,8 +2347,7 @@ jumpto_tag (
     goto erret;
   }
 
-  /* truncate the file name, so it can be used as a string */
-  csave = *tagp.fname_end;
+  // truncate the file name, so it can be used as a string
   *tagp.fname_end = NUL;
   fname = tagp.fname;
 
@@ -2447,7 +2457,10 @@ jumpto_tag (
     else
       keep_help_flag = curbuf->b_help;
   }
+
   if (getfile_result == GETFILE_UNUSED) {
+    // Careful: getfile() may trigger autocommands and call jumpto_tag()
+    // recursively.
     getfile_result = getfile(0, fname, NULL, true, (linenr_T)0, forceit);
   }
   keep_help_flag = false;
@@ -2606,8 +2619,7 @@ jumpto_tag (
 
 erret:
   g_do_tagpreview = 0;   /* For next time */
-  if (tagp.fname_end != NULL)
-    *tagp.fname_end = csave;
+  xfree(lbuf);
   xfree(pbuf);
   xfree(tofree_fname);
   xfree(full_fname);

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -114,6 +114,7 @@ NEW_TESTS ?= \
 	    test_timers.res \
 	    test_undo.res \
 	    test_usercommands.res \
+	    test_user_func.res \
 	    test_vimscript.res \
 	    test_visual.res \
 	    test_winbuf_close.res \

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -19,6 +19,7 @@ source test_functions.vim
 source test_ga.vim
 source test_global.vim
 source test_goto.vim
+source test_join.vim
 source test_jumps.vim
 source test_fileformat.vim
 source test_filetype.vim

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -253,16 +253,15 @@ func Test_BufReadCmdHelp()
   au BufReadCmd * e +h
   help
 
-  helpclose
   au! BufReadCmd
 endfunc
 
 func Test_BufReadCmdHelpJump()
   " This used to cause access to free memory
   au BufReadCmd * e +h{
-  help
+  " } to fix highlighting
+  call assert_fails('help', 'E434:')
 
-  helpclose
   au! BufReadCmd
 endfunc
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -248,6 +248,24 @@ func Test_augroup_warning()
   au! VimEnter
 endfunc
 
+func Test_BufReadCmdHelp()
+  " This used to cause access to free memory
+  au BufReadCmd * e +h
+  help
+
+  helpclose
+  au! BufReadCmd
+endfunc
+
+func Test_BufReadCmdHelpJump()
+  " This used to cause access to free memory
+  au BufReadCmd * e +h{
+  help
+
+  helpclose
+  au! BufReadCmd
+endfunc
+
 func Test_augroup_deleted()
   " This caused a crash before E936 was introduced
   augroup x

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1182,6 +1182,13 @@ func Test_nocatch_wipe_dummy_buffer()
   au!
 endfunc
 
+func Test_wipe_cbuffer()
+  sv x
+  au * * bw
+  lb
+  au!
+endfunc
+
 " Test TextChangedI and TextChangedP
 func Test_ChangedP()
   " Nvim does not support test_override().

--- a/src/nvim/testdir/test_join.vim
+++ b/src/nvim/testdir/test_join.vim
@@ -1,0 +1,35 @@
+" Test for joining lines.
+
+func Test_join_with_count()
+  new
+  call setline(1, ['one', 'two', 'three', 'four'])
+  normal J
+  call assert_equal('one two', getline(1))
+  %del
+  call setline(1, ['one', 'two', 'three', 'four'])
+  normal 10J
+  call assert_equal('one two three four', getline(1))
+  quit!
+endfunc
+
+" Tests for setting the '[,'] marks when joining lines.
+func Test_join_marks()
+  enew
+  call append(0, [
+	      \ "\t\tO sodales, ludite, vos qui",
+	      \ "attamen consulite per voster honur. Tua pulchra " .
+	      \ "facies me fay planszer milies",
+	      \ "",
+	      \ "This line.",
+	      \ "Should be joined with the next line",
+	      \ "and with this line"])
+
+  normal gg0gqj
+  call assert_equal([0, 1, 1, 0], getpos("'["))
+  call assert_equal([0, 2, 1, 0], getpos("']"))
+
+  /^This line/;'}-join
+  call assert_equal([0, 4, 11, 0], getpos("'["))
+  call assert_equal([0, 4, 67, 0], getpos("']"))
+  enew!
+endfunc

--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -230,4 +230,32 @@ func Test_tag_file_encoding()
   call delete('Xtags1')
 endfunc
 
+func Test_tagjump_etags()
+  if !has('emacs_tags')
+    return
+  endif
+  call writefile([
+        \ "void foo() {}",
+        \ "int main(int argc, char **argv)",
+        \ "{",
+        \ "\tfoo();",
+        \ "\treturn 0;",
+        \ "}",
+        \ ], 'Xmain.c')
+
+  call writefile([
+	\ "\x0c",
+        \ "Xmain.c,64",
+        \ "void foo() {}\x7ffoo\x011,0",
+        \ "int main(int argc, char **argv)\x7fmain\x012,14",
+	\ ], 'Xtags')
+  set tags=Xtags
+  ta foo
+  call assert_equal('void foo() {}', getline('.'))
+
+  call delete('Xtags')
+  call delete('Xmain.c')
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -1,4 +1,4 @@
-" test 'taglist' function
+" test 'taglist' function and :tags command
 
 func Test_taglist()
   call writefile([
@@ -55,4 +55,9 @@ func Test_taglist_ctags_etags()
 	\ map(taglist('set_signals'), {i, v -> [v.name, v.cmd]}))
 
   call delete('Xtags')
+endfunc
+
+func Test_tags_too_long()
+  call assert_fails('tag ' . repeat('x', 1020), 'E426')
+  tags
 endfunc

--- a/src/nvim/testdir/test_user_func.vim
+++ b/src/nvim/testdir/test_user_func.vim
@@ -1,0 +1,96 @@
+" Test for user functions.
+" Also test an <expr> mapping calling a function.
+" Also test that a builtin function cannot be replaced.
+" Also test for regression when calling arbitrary expression.
+
+func Table(title, ...)
+  let ret = a:title
+  let idx = 1
+  while idx <= a:0
+    exe "let ret = ret . a:" . idx
+    let idx = idx + 1
+  endwhile
+  return ret
+endfunc
+
+func Compute(n1, n2, divname)
+  if a:n2 == 0
+    return "fail"
+  endif
+  exe "let g:" . a:divname . " = ". a:n1 / a:n2
+  return "ok"
+endfunc
+
+func Expr1()
+  silent! normal! v
+  return "111"
+endfunc
+
+func Expr2()
+  call search('XX', 'b')
+  return "222"
+endfunc
+
+func ListItem()
+  let g:counter += 1
+  return g:counter . '. '
+endfunc
+
+func ListReset()
+  let g:counter = 0
+  return ''
+endfunc
+
+func FuncWithRef(a)
+  unlet g:FuncRef
+  return a:a
+endfunc
+
+func Test_user_func()
+  let g:FuncRef=function("FuncWithRef")
+  let g:counter = 0
+  inoremap <expr> ( ListItem()
+  inoremap <expr> [ ListReset()
+  imap <expr> + Expr1()
+  imap <expr> * Expr2()
+  let g:retval = "nop"
+
+  call assert_equal('xxx4asdf', Table("xxx", 4, "asdf"))
+  call assert_equal('fail', Compute(45, 0, "retval"))
+  call assert_equal('nop', g:retval)
+  call assert_equal('ok', Compute(45, 5, "retval"))
+  call assert_equal(9, g:retval)
+  call assert_equal(333, g:FuncRef(333))
+
+  enew
+
+  normal oXX+-XX
+  call assert_equal('XX111-XX', getline('.'))
+  normal o---*---
+  call assert_equal('---222---', getline('.'))
+  normal o(one
+  call assert_equal('1. one', getline('.'))
+  normal o(two
+  call assert_equal('2. two', getline('.'))
+  normal o[(one again
+  call assert_equal('1. one again', getline('.'))
+
+  call assert_equal(3, max([1, 2, 3]))
+  call assert_fails("call extend(g:, {'max': function('min')})", 'E704')
+  call assert_equal(3, max([1, 2, 3]))
+
+  " Regression: the first line below used to throw ?E110: Missing ')'?
+  " Second is here just to prove that this line is correct when not skipping
+  " rhs of &&.
+  call assert_equal(0, (0 && (function('tr'))(1, 2, 3)))
+  call assert_equal(1, (1 && (function('tr'))(1, 2, 3)))
+
+  delfunc Table
+  delfunc Compute
+  delfunc Expr1
+  delfunc Expr2
+  delfunc ListItem
+  delfunc ListReset
+  unlet g:retval g:counter
+  enew!
+endfunc

--- a/test/functional/legacy/packadd_spec.lua
+++ b/test/functional/legacy/packadd_spec.lua
@@ -15,7 +15,7 @@ describe('packadd', function()
 
     source([=[
       func SetUp()
-        let s:topdir = expand(expand('%:p:h') . '/Xdir')
+        let s:topdir = expand(getcwd() . '/Xdir')
         exe 'set packpath=' . s:topdir
         let s:plugdir = expand(s:topdir . '/pack/mine/opt/mytest')
       endfunc


### PR DESCRIPTION
**vim-patch:8.0.1209: still too many old style tests**

Problem:    Still too many old style tests.
Solution:   Convert a few more tests to new style. (Yegappan Lakshmanan,
            closes vim/vim#2230)
https://github.com/vim/vim/commit/53f0c962394dc6bc66d5b0762af9434e672d1b25

**vim-patch:8.0.1218: writing to freed memory in autocmd**

Problem:    Writing to freed memory in autocmd.
Solution:   Make a copy of the tag line. (Dominique Pelle, closes vim/vim#2245)
vim/vim@8d84ff1

**vim-patch:8.0.1409: buffer overflow in :tags command**

Problem:    Buffer overflow in :tags command.
Solution:   Use vim_snprintf(). (Dominique Pelle, closes vim/vim#2471, closes vim/vim#2475)
            Add a test.
vim/vim@132f752

**vim-patch:8.0.1413: accessing freed memory in :cbuffer**

Problem:    Accessing freed memory in :cbuffer.
Solution:   Get quickfix list after executing autocmds. (closes vim/vim#2470)
vim/vim@aaf6e43

**vim-patch:8.0.1488: emacs tags no longer work**

Problem:    Emacs tags no longer work. (zdohnal)
Solution:   Do not skip over end of line.
vim/vim@0d20737

**vim-patch:8.0.1633: a TextChanged autocmd triggers when it is defined**

Problem:    A TextChanged autocmd triggers when it is defined after creating a
            buffer.
Solution:   Set b_last_changedtick when opening a buffer. (Hirohito Highlight,
            closes vim/vim#2742)
vim/vim@8c64a36

Close #8582

#7960 includes the test_autocmd.vim changes for 8.0.1193 and 8.0.1209.

8.0.1748 needs 8.0.1445 so I can't include it now.