### PR TITLE
Save cmdline before calling multiqueue_process_events

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -527,7 +527,9 @@ static int command_line_execute(VimState *state, int key)
 
   if (s->c == K_EVENT || s->c == K_COMMAND) {
     if (s->c == K_EVENT) {
+      save_cmdline(&s->save_ccline);
       multiqueue_process_events(main_loop.events);
+      restore_cmdline(&s->save_ccline);
     } else {
       do_cmdline(NULL, getcmdkeycmd, NULL, DOCMD_NOWAIT);
     }


### PR DESCRIPTION
Because it can call command_line_enter recursively too.

Fixes #8857