### PR TITLE
[RFC] cmdline: always use save_cmdline before command_line_enter

### DIFF
--- a/test/functional/ex_cmds/cmd_map_spec.lua
+++ b/test/functional/ex_cmds/cmd_map_spec.lua
@@ -656,7 +656,6 @@ describe('mappings with <Cmd>', function()
   end)
 
   it('works in cmdline mode', function()
-    cmdmap('<F2>', 'call setcmdpos(2)')
     feed(':text<F3>')
     eq('c', eval('m'))
     -- didn't leave cmdline mode
@@ -766,6 +765,33 @@ describe('mappings with <Cmd>', function()
     eq('i', eval('mode(1)'))
     eq(9, eval('g:y'))
 
+  end)
+
+  it("doesn't crash when invoking cmdline mode recursively #8859", function()
+    cmdmap('<F2>', 'norm! :foo')
+    feed(':bar')
+    screen:expect([[
+      some short lines                                                 |
+      of test text                                                     |
+      {1:~                                                                }|
+      {1:~                                                                }|
+      {1:~                                                                }|
+      {1:~                                                                }|
+      {1:~                                                                }|
+      :bar^                                                             |
+    ]])
+
+    feed('<f2>x')
+    screen:expect([[
+      some short lines                                                 |
+      of test text                                                     |
+      {1:~                                                                }|
+      {1:~                                                                }|
+      {1:~                                                                }|
+      {1:~                                                                }|
+      {1:~                                                                }|
+      :barx^                                                            |
+    ]])
   end)
 
 end)


### PR DESCRIPTION
`:norm! :` might be invoked in various ways, so its safest to always allow recursive invocation of cmdline mode. Fixes #8857 .

Simple reproduction without events: `cnoremap <f3> <cmd>norm! :foo<cr>` (might not crash immediately, press another key after `<f3>` )