### PR TITLE
[RFC] API: Use `ps -o comm` in nvim_get_proc()

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -13,7 +13,7 @@ local function _os_proc_info(pid)
   if pid == nil or pid <= 0 or type(pid) ~= 'number' then
     error('invalid pid')
   end
-  local cmd = { 'ps', '-p', pid, '-o', 'ucomm=', }
+  local cmd = { 'ps', '-p', pid, '-o', 'comm=', }
   local err, name = _system(cmd)
   if 1 == err and string.gsub(name, '%s*', '') == '' then
     return {}  -- Process not found.

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -23,7 +23,7 @@ local function _os_proc_info(pid)
   end
   local _, ppid = _system({ 'ps', '-p', pid, '-o', 'ppid=', })
   -- Remove trailing whitespace.
-  name = string.gsub(name, '%s+$', '')
+  name = string.gsub(string.gsub(name, '%s+$', ''), '^.*/', '')
   ppid = string.gsub(ppid, '%s+$', '')
   ppid = tonumber(ppid) == nil and -1 or tonumber(ppid)
   return {


### PR DESCRIPTION
The ucomm argument to -o seems to be less portable than the comm version. See
commit message for links to docs.

This was noticed with the alpine docker image like so
```
docker run -t alpine sh -c 'apk add neovim && nvim --headless --cmd "echo nvim_get_proc(1)" --cmd q'
```