### PR TITLE
[RDY]vim-patch:8.0.{1364,1508,1509},8.1.{184,186}

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2352,6 +2352,7 @@ win_getid([{win} [, {tab}]])	Number	get |window-ID| for {win} in {tab}
 win_gotoid({expr})		Number	go to |window-ID| {expr}
 win_id2tabwin({expr})		List	get tab and window nr from |window-ID|
 win_id2win({expr})		Number	get window nr from |window-ID|
+win_screenpos({nr})		List	get screen position of window {nr}
 winbufnr({nr})			Number	buffer number of window {nr}
 wincol()			Number	window column of the cursor
 winheight({nr})			Number	height of window {nr}
@@ -8180,6 +8181,14 @@ win_id2tabwin({expr}					*win_id2tabwin()*
 win_id2win({expr})					*win_id2win()*
 		Return the window number of window with ID {expr}.
 		Return 0 if the window cannot be found in the current tabpage.
+
+win_screenpos({nr})					*win_screenpos()*
+		Return the screen position of window {nr} as a list with two
+		numbers: [row, col].  The first window always has position
+		[1, 1].
+		{nr} can be the window number or the |window-ID|.
+		Return [0, 0] if the window cannot be found in the current
+		tabpage.
 
 							*winbufnr()*
 winbufnr({nr})	The result is a Number, which is the number of the buffer

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4472,8 +4472,10 @@ getwininfo([{winid}])					*getwininfo()*
 			variables	a reference to the dictionary with
 					window-local variables
 			width		window width
+			wincol		leftmost screen column of the window
 			winid		|window-ID|
 			winnr		window number
+			winrow		topmost screen column of the window
 
 		To obtain all window-local variables use: >
 			gettabwinvar({tabnr}, {winnr}, '&')

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10262,8 +10262,10 @@ static dict_T *get_win_info(win_T *wp, int16_t tpnr, int16_t winnr)
   tv_dict_add_nr(dict, S_LEN("winnr"), winnr);
   tv_dict_add_nr(dict, S_LEN("winid"), wp->handle);
   tv_dict_add_nr(dict, S_LEN("height"), wp->w_height);
+  tv_dict_add_nr(dict, S_LEN("winrow"), wp->w_winrow);
   tv_dict_add_nr(dict, S_LEN("width"), wp->w_width);
   tv_dict_add_nr(dict, S_LEN("bufnr"), wp->w_buffer->b_fnum);
+  tv_dict_add_nr(dict, S_LEN("wincol"), wp->w_wincol);
 
   tv_dict_add_nr(dict, S_LEN("quickfix"), bt_quickfix(wp->w_buffer));
   tv_dict_add_nr(dict, S_LEN("loclist"),

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10310,6 +10310,15 @@ static void f_getwininfo(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 }
 
+// "win_screenpos()" function
+static void f_win_screenpos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  tv_list_alloc_ret(rettv, 2);
+  const win_T *const wp = find_win_by_nr(&argvars[0], NULL);
+  tv_list_append_number(rettv->vval.v_list, wp == NULL ? 0 : wp->w_winrow + 1);
+  tv_list_append_number(rettv->vval.v_list, wp == NULL ? 0 : wp->w_wincol + 1);
+}
+
 /*
  * "getwinposx()" function
  */

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -338,6 +338,7 @@ return {
     win_gotoid={args=1},
     win_id2tabwin={args=1},
     win_id2win={args=1},
+    win_screenpos={args=1},
     winbufnr={args=1},
     wincol={},
     winheight={args=1},

--- a/src/nvim/testdir/test_bufwintabinfo.vim
+++ b/src/nvim/testdir/test_bufwintabinfo.vim
@@ -46,15 +46,16 @@ function Test_getbufwintabinfo()
     call assert_equal(5, len(winlist))
     call assert_equal(winwidth(1), winlist[0].width)
     call assert_equal(0, winlist[0].wincol)
-    call assert_equal(1, winlist[0].winrow)  " tabline adds one
+    let tablineheight = winlist[0].winrow == 1 ? 1 : 0
+    call assert_equal(tablineheight, winlist[0].winrow)  " tabline adds one
 
     call assert_equal(winbufnr(2), winlist[1].bufnr)
     call assert_equal(winheight(2), winlist[1].height)
     call assert_equal(0, winlist[1].wincol)
-    call assert_equal(winheight(1) + 2, winlist[1].winrow)
+    call assert_equal(tablineheight + winheight(1) + 1, winlist[1].winrow)
 
     call assert_equal(1, winlist[2].winnr)
-    call assert_equal(1, winlist[2].winrow)
+    call assert_equal(tablineheight, winlist[2].winrow)
     call assert_equal(0, winlist[2].wincol)
 
     call assert_equal(winlist[2].width + 1, winlist[3].wincol)

--- a/src/nvim/testdir/test_bufwintabinfo.vim
+++ b/src/nvim/testdir/test_bufwintabinfo.vim
@@ -39,17 +39,34 @@ function Test_getbufwintabinfo()
     let w2_id = win_getid()
     tabnew | let w3_id = win_getid()
     new | let w4_id = win_getid()
-    new | let w5_id = win_getid()
+    vert new | let w5_id = win_getid()
     call setwinvar(0, 'signal', 'green')
     tabfirst
     let winlist = getwininfo()
     call assert_equal(5, len(winlist))
+    call assert_equal(winwidth(1), winlist[0].width)
+    call assert_equal(0, winlist[0].wincol)
+    call assert_equal(1, winlist[0].winrow)  " tabline adds one
+
     call assert_equal(winbufnr(2), winlist[1].bufnr)
     call assert_equal(winheight(2), winlist[1].height)
+    call assert_equal(0, winlist[1].wincol)
+    call assert_equal(winheight(1) + 2, winlist[1].winrow)
+
     call assert_equal(1, winlist[2].winnr)
+    call assert_equal(1, winlist[2].winrow)
+    call assert_equal(0, winlist[2].wincol)
+
+    call assert_equal(winlist[2].width + 1, winlist[3].wincol)
+    call assert_equal(0, winlist[4].wincol)
+
+    call assert_equal(1, winlist[0].tabnr)
+    call assert_equal(1, winlist[1].tabnr)
+    call assert_equal(2, winlist[2].tabnr)
     call assert_equal(2, winlist[3].tabnr)
+    call assert_equal(2, winlist[4].tabnr)
+
     call assert_equal('green', winlist[2].variables.signal)
-    call assert_equal(winwidth(1), winlist[0].width)
     call assert_equal(w4_id, winlist[3].winid)
     let winfo = getwininfo(w5_id)[0]
     call assert_equal(2, winfo.tabnr)

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2180,9 +2180,6 @@ func! Test_normal44_textobjects2()
 endfunc
 
 func! Test_normal45_drop()
-  if !has("dnd")
-    return
-  endif
   " basic test for :drop command
   " unfortunately, without a gui, we can't really test much here,
   " so simply test that ~p fails (which uses the drop register)

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2180,7 +2180,11 @@ func! Test_normal44_textobjects2()
 endfunc
 
 func! Test_normal45_drop()
-  " basic test for :drop command
+  if !has('dnd')
+    return
+  endif
+
+  " basic test for drag-n-drop
   " unfortunately, without a gui, we can't really test much here,
   " so simply test that ~p fails (which uses the drop register)
   new

--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -42,40 +42,38 @@ function Test_tabpage()
   call assert_true(t:val_num == 100 && t:val_str == 'SetTabVar test'  && t:val_list == ['red', 'blue', 'green'])
   tabclose
 
-  if has('nvim') || has('gui') || has('clientserver')
-    " Test for ":tab drop exist-file" to keep current window.
-    sp test1
-    tab drop test1
-    call assert_true(tabpagenr('$') == 1 && winnr('$') == 2 && winnr() == 1)
-    close
-    "
-    "
-    " Test for ":tab drop new-file" to keep current window of tabpage 1.
-    split
-    tab drop newfile
-    call assert_true(tabpagenr('$') == 2 && tabpagewinnr(1, '$') == 2 && tabpagewinnr(1) == 1)
-    tabclose
-    q
-    "
-    "
-    " Test for ":tab drop multi-opend-file" to keep current tabpage and window.
-    new test1
-    tabnew
-    new test1
-    tab drop test1
-    call assert_true(tabpagenr() == 2 && tabpagewinnr(2, '$') == 2 && tabpagewinnr(2) == 1)
-    tabclose
-    q
-    "
-    "
-    " Test for ":tab drop vertical-split-window" to jump test1 buffer
-    tabedit test1
-    vnew
-    tabfirst
-    tab drop test1
-    call assert_equal([2, 2, 2, 2], [tabpagenr('$'), tabpagenr(), tabpagewinnr(2, '$'), tabpagewinnr(2)])
-    1tabonly
-  endif
+  " Test for ":tab drop exist-file" to keep current window.
+  sp test1
+  tab drop test1
+  call assert_true(tabpagenr('$') == 1 && winnr('$') == 2 && winnr() == 1)
+  close
+  "
+  "
+  " Test for ":tab drop new-file" to keep current window of tabpage 1.
+  split
+  tab drop newfile
+  call assert_true(tabpagenr('$') == 2 && tabpagewinnr(1, '$') == 2 && tabpagewinnr(1) == 1)
+  tabclose
+  q
+  "
+  "
+  " Test for ":tab drop multi-opend-file" to keep current tabpage and window.
+  new test1
+  tabnew
+  new test1
+  tab drop test1
+  call assert_true(tabpagenr() == 2 && tabpagewinnr(2, '$') == 2 && tabpagewinnr(2) == 1)
+  tabclose
+  q
+  "
+  "
+  " Test for ":tab drop vertical-split-window" to jump test1 buffer
+  tabedit test1
+  vnew
+  tabfirst
+  tab drop test1
+  call assert_equal([2, 2, 2, 2], [tabpagenr('$'), tabpagenr(), tabpagewinnr(2, '$'), tabpagewinnr(2)])
+  1tabonly
   "
   "
   for i in range(9) | tabnew | endfor

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -374,6 +374,19 @@ func Test_equalalways_on_close()
   set equalalways&
 endfunc
 
+func Test_win_screenpos()
+  call assert_equal(1, winnr('$'))
+  split
+  vsplit
+  10wincmd _
+  30wincmd |
+  call assert_equal([1, 1], win_screenpos(1))
+  call assert_equal([1, 32], win_screenpos(2))
+  call assert_equal([12, 1], win_screenpos(3))
+  call assert_equal([0, 0], win_screenpos(4))
+  only
+endfunc
+
 func Test_window_jump_tag()
   help
   /iccf


### PR DESCRIPTION
**vim-patch:8.0.1364: there is no easy way to get the window position**

Problem:    There is no easy way to get the window position.
Solution:   Add win_screenpos().
https://github.com/vim/vim/commit/22044dc31788d9f1c2da7725269884d9923b4795

**vim-patch:8.0.1508: the :drop command is not always available**

Problem:    The :drop command is not always available.
Solution:   Include :drop in all builds. (Yasuhiro Matsumoto, closes vim/vim#2639)
vim/vim@5a65686

**vim-patch:8.0.1509: test for failing drag-n-drop command no longer fails**

Problem:    Test for failing drag-n-drop command no longer fails.
Solution:   Check for the "dnd" feature.
vim/vim@2949595

**vim-patch:8.1.0184: not easy to figure out the window layout**

Problem:    Not easy to figure out the window layout.
Solution:   Add "wincol" and "winrow" to what getwininfo() returns.
vim/vim@b6959a8

**vim-patch:8.1.0186: test for getwininfo() fails in GUI**

Problem:    Test for getwininfo() fails in GUI.
Solution:   Account for missing tabline.
vim/vim@44a693a

8.1.0187 includes conflicting `runtime/` changes so I can't include it now.