### PR TITLE
[RDY] vim-patch:8.0.{762,1148,1291,1486,1487},8.1.{18,290}

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -570,8 +570,12 @@ int searchit(
                && pos->lnum >= 1 && pos->lnum <= buf->b_ml.ml_line_count
                && pos->col < MAXCOL - 2) {
       // Watch out for the "col" being MAXCOL - 2, used in a closed fold.
-      ptr = ml_get_buf(buf, pos->lnum, false) + pos->col;
-      start_char_len = *ptr == NUL ? 1 : (*mb_ptr2len)(ptr);
+      ptr = ml_get_buf(buf, pos->lnum, false);
+      if ((int)STRLEN(ptr) < pos->col) {
+        start_char_len = 1;
+      } else {
+        start_char_len = utfc_ptr2len(ptr + pos->col);
+      }
     } else {
       start_char_len = 1;
     }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3445,9 +3445,11 @@ again:
       }
     curwin->w_cursor = end_pos;
 
-    /* If we now have the same text as before reset "do_include" and try
-     * again. */
-    if (equalpos(start_pos, old_start) && equalpos(end_pos, old_end)) {
+    // If we are in Visual mode and now have the same text as before set
+    // "do_include" and try again.
+    if (VIsual_active
+        && equalpos(start_pos, old_start)
+        && equalpos(end_pos, old_end)) {
       do_include = TRUE;
       curwin->w_cursor = old_start;
       count = count_arg;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4603,7 +4603,7 @@ search_line:
           if (depth == -1) {
             // match in current file
             if (l_g_do_tagpreview != 0) {
-              if (!GETFILE_SUCCESS(getfile(0, curwin_save->w_buffer->b_fname,
+              if (!GETFILE_SUCCESS(getfile(curwin_save->w_buffer->b_fnum, NULL,
                                            NULL, true, lnum, false))) {
                 break;    // failed to jump to file
               }
@@ -4611,6 +4611,7 @@ search_line:
               setpcmark();
             }
             curwin->w_cursor.lnum = lnum;
+            check_cursor();
           } else {
             if (!GETFILE_SUCCESS(getfile(0, files[depth].name, NULL, true,
                                          files[depth].lnum, false))) {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1849,7 +1849,7 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
       } else {    /* Searching backwards */
         /*
          * A comment may contain / * or / /, it may also start or end
-         * with / * /.	Ignore a / * after / /.
+         * with / * /. Ignore a / * after / / and after *.
          */
         if (pos.col == 0)
           continue;
@@ -1874,6 +1874,7 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
           }
         } else if (  linep[pos.col - 1] == '/'
                    && linep[pos.col] == '*'
+                   && (pos.col == 1 || linep[pos.col - 2] != '*')
                    && (int)pos.col < comment_col) {
           count++;
           match_pos = pos;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -571,7 +571,7 @@ int searchit(
                && pos->col < MAXCOL - 2) {
       // Watch out for the "col" being MAXCOL - 2, used in a closed fold.
       ptr = ml_get_buf(buf, pos->lnum, false);
-      if ((int)STRLEN(ptr) < pos->col) {
+      if ((int)STRLEN(ptr) <= pos->col) {
         start_char_len = 1;
       } else {
         start_char_len = utfc_ptr2len(ptr + pos->col);

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3957,9 +3957,9 @@ current_search(
   if (VIsual_active && *p_sel == 'e' && lt(VIsual, curwin->w_cursor))
     dec_cursor();
 
-  pos_T orig_pos;               /* position of the cursor at beginning */
+  pos_T orig_pos;               // position of the cursor at beginning
   pos_T first_match;            // position of first match
-  pos_T pos;                    /* position after the pattern */
+  pos_T pos;                    // position after the pattern
   int result;                   // result of various function calls
 
   if (VIsual_active) {
@@ -3996,8 +3996,8 @@ current_search(
       flags = SEARCH_END;
 
     result = searchit(curwin, curbuf, &pos, (dir ? FORWARD : BACKWARD),
-        spats[last_idx].pat, i ? count : 1,
-        SEARCH_KEEP | flags, RE_SEARCH, 0, NULL);
+                      spats[last_idx].pat, i ? count : 1,
+                      SEARCH_KEEP | flags, RE_SEARCH, 0, NULL);
 
     /* First search may fail, but then start searching from the
      * beginning of the file (cursor might be on the search match)

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3305,7 +3305,7 @@ int
 current_tagblock(
     oparg_T *oap,
     long count_arg,
-    int include                    /* TRUE == include white space */
+    bool include                  // true == include white space
 )
 {
   long count = count_arg;
@@ -3319,7 +3319,7 @@ current_tagblock(
   char_u      *cp;
   int len;
   int r;
-  int do_include = include;
+  bool do_include = include;
   bool save_p_ws = p_ws;
   int retval = FAIL;
   int is_inclusive = true;
@@ -3450,7 +3450,7 @@ again:
     if (VIsual_active
         && equalpos(start_pos, old_start)
         && equalpos(end_pos, old_end)) {
-      do_include = TRUE;
+      do_include = true;
       curwin->w_cursor = old_start;
       count = count_arg;
       goto again;

--- a/src/nvim/search.h
+++ b/src/nvim/search.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "nvim/types.h"
+#include "nvim/vim.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/eval/typval.h"
 #include "nvim/normal.h"

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -88,6 +88,7 @@ NEW_TESTS ?= \
 	    test_normal.res \
 	    test_number.res \
 	    test_options.res \
+	    test_preview.res \
 	    test_profile.res \
 	    test_put.res \
 	    test_python2.res \

--- a/src/nvim/testdir/test_gn.vim
+++ b/src/nvim/testdir/test_gn.vim
@@ -111,6 +111,15 @@ func Test_gn_command()
   call assert_equal(['foo  baz'], getline(1,'$'))
   sil! %d_
 
+  " search upwards with nowrapscan set
+  call setline('.', ['foo', 'bar', 'foo', 'baz'])
+  set nowrapscan
+  let @/='foo'
+  $
+  norm! dgN
+  call assert_equal(['foo', 'bar', '', 'baz'], getline(1,'$'))
+  sil! %d_
+
   set wrapscan&vim
   set belloff&vim
 endfu

--- a/src/nvim/testdir/test_gn.vim
+++ b/src/nvim/testdir/test_gn.vim
@@ -5,51 +5,51 @@ func Test_gn_command()
   noautocmd new
   " replace a single char by itsself quoted:
   call setline('.', 'abc x def x ghi x jkl')
-  let @/='x'
+  let @/ = 'x'
   exe "norm! cgn'x'\<esc>.."
   call assert_equal("abc 'x' def 'x' ghi 'x' jkl", getline('.'))
   sil! %d_
 
   " simple search match
   call setline('.', 'foobar')
-  let @/='foobar'
+  let @/ = 'foobar'
   exe "norm! gncsearchmatch"
   call assert_equal('searchmatch', getline('.'))
   sil! %d _
 
   " replace a multi-line match
   call setline('.', ['', 'one', 'two'])
-  let @/='one\_s*two\_s'
+  let @/ = 'one\_s*two\_s'
   exe "norm! gnceins\<CR>zwei"
   call assert_equal(['','eins','zwei'], getline(1,'$'))
   sil! %d _
 
   " test count argument
   call setline('.', ['', 'abcdx | abcdx | abcdx'])
-  let @/='[a]bcdx'
+  let @/ = '[a]bcdx'
   exe "norm! 2gnd"
   call assert_equal(['','abcdx |  | abcdx'], getline(1,'$'))
   sil! %d _
 
   " join lines
   call setline('.', ['join ', 'lines'])
-  let @/='$'
+  let @/ = '$'
   exe "norm! 0gnd"
   call assert_equal(['join lines'], getline(1,'$'))
   sil! %d _
 
   " zero-width match
   call setline('.', ['', 'zero width pattern'])
-  let @/='\>\zs'
+  let @/ = '\>\zs'
   exe "norm! 0gnd"
   call assert_equal(['', 'zerowidth pattern'], getline(1,'$'))
   sil! %d _
 
   " delete first and last chars
   call setline('.', ['delete first and last chars'])
-  let @/='^'
+  let @/ = '^'
   exe "norm! 0gnd$"
-  let @/='\zs'
+  let @/ = '\zs'
   exe "norm! gnd"
   call assert_equal(['elete first and last char'], getline(1,'$'))
   sil! %d _
@@ -62,14 +62,14 @@ func Test_gn_command()
 
   " backwards search
   call setline('.', ['my very excellent mother just served us nachos'])
-  let @/='mother'
+  let @/ = 'mother'
   exe "norm! $cgNmongoose"
   call assert_equal(['my very excellent mongoose just served us nachos'], getline(1,'$'))
   sil! %d _
 
   " search for single char
   call setline('.', ['','for (i=0; i<=10; i++)'])
-  let @/='i'
+  let @/ = 'i'
   exe "norm! cgnj"
   call assert_equal(['','for (j=0; i<=10; i++)'], getline(1,'$'))
   sil! %d _
@@ -77,28 +77,28 @@ func Test_gn_command()
   " search hex char
   call setline('.', ['','Y'])
   set noignorecase
-  let @/='\%x59'
+  let @/ = '\%x59'
   exe "norm! gnd"
   call assert_equal(['',''], getline(1,'$'))
   sil! %d _
 
   " test repeating gdn
   call setline('.', ['', '1', 'Johnny', '2', 'Johnny', '3'])
-  let @/='Johnny'
+  let @/ = 'Johnny'
   exe "norm! dgn."
   call assert_equal(['','1', '', '2', '', '3'], getline(1,'$'))
   sil! %d _
 
   " test repeating gUgn
   call setline('.', ['', '1', 'Depp', '2', 'Depp', '3'])
-  let @/='Depp'
+  let @/ = 'Depp'
   exe "norm! gUgn."
   call assert_equal(['', '1', 'DEPP', '2', 'DEPP', '3'], getline(1,'$'))
   sil! %d _
 
   " test using look-ahead assertions
   call setline('.', ['a:10', '', 'a:1', '', 'a:20'])
-  let @/='a:0\@!\zs\d\+'
+  let @/ = 'a:0\@!\zs\d\+'
   exe "norm! 2nygno\<esc>p"
   call assert_equal(['a:10', '', 'a:1', '1', '', 'a:20'], getline(1,'$'))
   sil! %d _
@@ -114,10 +114,19 @@ func Test_gn_command()
   " search upwards with nowrapscan set
   call setline('.', ['foo', 'bar', 'foo', 'baz'])
   set nowrapscan
-  let @/='foo'
+  let @/ = 'foo'
   $
   norm! dgN
   call assert_equal(['foo', 'bar', '', 'baz'], getline(1,'$'))
+  sil! %d_
+
+  " search using the \zs atom
+  call setline(1, [' nnoremap', '' , 'nnoremap'])
+  set wrapscan&vim
+  let @/ = '\_s\zsnnoremap'
+  $
+  norm! cgnmatch
+  call assert_equal([' nnoremap', '', 'match'], getline(1,'$'))
   sil! %d_
 
   set wrapscan&vim

--- a/src/nvim/testdir/test_preview.vim
+++ b/src/nvim/testdir/test_preview.vim
@@ -1,0 +1,13 @@
+" Tests for the preview window
+
+func Test_Psearch()
+  " this used to cause ml_get errors
+  help
+  let wincount = winnr('$')
+  0f
+  ps.
+  call assert_equal(wincount + 1, winnr('$'))
+  pclose
+  call assert_equal(wincount, winnr('$'))
+  bwipe
+endfunc

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -121,6 +121,23 @@ func Test_string_html_objects()
   enew!
 endfunc
 
+func Test_empty_html_tag()
+  new
+  call setline(1, '<div></div>')
+  normal 0citxxx
+  call assert_equal('<div>xxx</div>', getline(1))
+
+  call setline(1, '<div></div>')
+  normal 0f<cityyy
+  call assert_equal('<div>yyy</div>', getline(1))
+
+  call setline(1, '<div></div>')
+  normal 0f<vitsaaa
+  call assert_equal('aaa', getline(1))
+
+  bwipe!
+endfunc
+
 " Tests for match() and matchstr()
 func Test_match()
   call assert_equal("b", matchstr("abcd", ".", 0, 2))

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -152,3 +152,16 @@ func Test_match()
   call assert_equal(3 , match('abc', '\zs', 3, 1))
   call assert_equal(-1, match('abc', '\zs', 4, 1))
 endfunc
+
+" This was causing an illegal memory access
+func Test_inner_tag()
+  new
+  norm ixxx
+  call feedkeys("v", 'xt')
+  insert
+x
+x
+.
+  norm it
+  q!
+endfunc

--- a/test/functional/legacy/003_cindent_spec.lua
+++ b/test/functional/legacy/003_cindent_spec.lua
@@ -4754,4 +4754,21 @@ describe('cindent', function()
       	4
       /* end of define */]=])
   end)
+
+  it('* immediately follows comment / vim-patch 8.0.1291', function()
+    insert_([=[
+      {
+        a = second/*bug*/*line;
+      }]=])
+
+    feed_command('set cin cino&')
+    feed_command('/a = second')
+    feed('ox')
+
+    expect([=[
+      {
+        a = second/*bug*/*line;
+        x
+      }]=])
+  end)
 end)


### PR DESCRIPTION
**vim-patch:8.0.0762: ml_get error with :psearch in buffer without a name**

Problem:    ml_get error with :psearch in buffer without a name. (Dominique Pelle)
Solution:   Use the buffer number instead of the file name.  Check the cursor position.
https://github.com/vim/vim/commit/c31f9ae4f1976544522313b182957793063ee02c

**vim-patch:8.0.1148: gN doesn't work on last match with 'wrapscan' off**

Problem:    "gN" doesn't work on last match with 'wrapscan' off. (fcpg)
Solution:   Adjust for searching backward. (Christian Brabandt)
vim/vim@22ab547

**vim-patch:8.0.1291: C indent wrong when * immediately follows comment**

Problem:    C indent wrong when * immediately follows comment. (John Bowler)
Solution:   Do not see "/*" after "*" as a comment start. (closes vim/vim#2321)
vim/vim@f8c53d3

**vim-patch:8.0.1486: accessing invalid memory with "it"**

Problem:    Accessing invalid memory with "it". (Dominique Pelle)
Solution:   Avoid going over the end of the line. (Christian Brabandt,
            closes vim/vim#2532)
vim/vim@82846a0

**vim-patch:8.0.1487: test 14 fails**

Problem:    Test 14 fails.
Solution:   Fix of-by-one error.
vim/vim@8846ac5

**vim-patch:8.1.0018: using "gn" may select wrong text when wrapping**

Problem:    Using "gn" may select wrong text when wrapping.
Solution:   Avoid wrapping when searching forward. (Christian Brabandt)
vim/vim@bdb6579

**vim-patch:8.1.0290: "cit" on an empty HTML tag changes the whole tag**

Problem:    "cit" on an empty HTML tag changes the whole tag.
Solution:   Only adjust the area in Visual mode. (Andy Massimino,
            closes vim/vim#3332)
vim/vim@b476cb7