### PR TITLE
[RDY] vim-patch:8.0.1441

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7577,10 +7577,11 @@ static void ex_bang(exarg_T *eap)
  */
 static void ex_undo(exarg_T *eap)
 {
-  if (eap->addr_count == 1)         /* :undo 123 */
+  if (eap->addr_count == 1) {       // :undo 123
     undo_time(eap->line2, false, false, true);
-  else
+  } else {
     u_undo(1);
+  }
 }
 
 static void ex_wundo(exarg_T *eap)
@@ -7634,7 +7635,7 @@ static void ex_later(exarg_T *eap)
     EMSG2(_(e_invarg2), eap->arg);
   else
     undo_time(eap->cmdidx == CMD_earlier ? -count : count,
-        sec, file, false);
+              sec, file, false);
 }
 
 /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7578,7 +7578,7 @@ static void ex_bang(exarg_T *eap)
 static void ex_undo(exarg_T *eap)
 {
   if (eap->addr_count == 1)         /* :undo 123 */
-    undo_time(eap->line2, FALSE, FALSE, TRUE);
+    undo_time(eap->line2, false, false, true);
   else
     u_undo(1);
 }
@@ -7613,8 +7613,8 @@ static void ex_redo(exarg_T *eap)
 static void ex_later(exarg_T *eap)
 {
   long count = 0;
-  int sec = FALSE;
-  int file = FALSE;
+  bool sec = false;
+  bool file = false;
   char_u      *p = eap->arg;
 
   if (*p == NUL)
@@ -7622,11 +7622,11 @@ static void ex_later(exarg_T *eap)
   else if (isdigit(*p)) {
     count = getdigits_long(&p);
     switch (*p) {
-    case 's': ++p; sec = TRUE; break;
-    case 'm': ++p; sec = TRUE; count *= 60; break;
-    case 'h': ++p; sec = TRUE; count *= 60 * 60; break;
-    case 'd': ++p; sec = TRUE; count *= 24 * 60 * 60; break;
-    case 'f': ++p; file = TRUE; break;
+    case 's': ++p; sec = true; break;
+    case 'm': ++p; sec = true; count *= 60; break;
+    case 'h': ++p; sec = true; count *= 60 * 60; break;
+    case 'd': ++p; sec = true; count *= 24 * 60 * 60; break;
+    case 'f': ++p; file = true; break;
     }
   }
 
@@ -7634,7 +7634,7 @@ static void ex_later(exarg_T *eap)
     EMSG2(_(e_invarg2), eap->arg);
   else
     undo_time(eap->cmdidx == CMD_earlier ? -count : count,
-        sec, file, FALSE);
+        sec, file, false);
 }
 
 /*

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -390,3 +390,47 @@ funct Test_undofile()
 
   set undodir&
 endfunc
+
+func Test_undo_0()
+  new
+  set ul=100
+  normal i1
+  undo
+  normal i2
+  undo
+  normal i3
+
+  undo 0
+  let d = undotree()
+  call assert_equal('', getline(1))
+  call assert_equal(0, d.seq_cur)
+
+  redo
+  let d = undotree()
+  call assert_equal('3', getline(1))
+  call assert_equal(3, d.seq_cur)
+
+  undo 2
+  undo 0
+  let d = undotree()
+  call assert_equal('', getline(1))
+  call assert_equal(0, d.seq_cur)
+
+  redo
+  let d = undotree()
+  call assert_equal('2', getline(1))
+  call assert_equal(2, d.seq_cur)
+
+  undo 1
+  undo 0
+  let d = undotree()
+  call assert_equal('', getline(1))
+  call assert_equal(0, d.seq_cur)
+
+  redo
+  let d = undotree()
+  call assert_equal('1', getline(1))
+  call assert_equal(1, d.seq_cur)
+
+  bwipe!
+endfunc

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1827,8 +1827,8 @@ void undo_time(long step, int sec, int file, int absolute)
   int round;
   int dosec = sec;
   int dofile = file;
-  int above = FALSE;
-  int did_undo = TRUE;
+  bool above = false;
+  bool did_undo = true;
 
   /* First make sure the current undoable change is synced. */
   if (curbuf->b_u_synced == false)
@@ -2016,8 +2016,9 @@ void undo_time(long step, int sec, int file, int absolute)
     target = closest_seq;
     dosec = FALSE;
     dofile = FALSE;
-    if (step < 0)
-      above = TRUE;             /* stop above the header */
+    if (step < 0) {
+      above = true;             // stop above the header
+    }
   }
 
 found:

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2386,8 +2386,8 @@ static void u_undoredo(int undo, bool do_buf_event)
 /// Otherwise, report the number of changes (this may be incorrect
 /// in some cases, but it's better than nothing).
 static void u_undo_end(
-    int did_undo,     ///< just did an undo
-    int absolute,     ///< used ":undo N"
+    bool did_undo,    ///< just did an undo
+    bool absolute,    ///< used ":undo N"
     bool quiet)
 {
   char        *msgstr;
@@ -2427,7 +2427,7 @@ static void u_undo_end(
     /* For ":undo N" we prefer a "after #N" message. */
     if (absolute && curbuf->b_u_curhead->uh_next.ptr != NULL) {
       uhp = curbuf->b_u_curhead->uh_next.ptr;
-      did_undo = FALSE;
+      did_undo = false;
     } else if (did_undo)
       uhp = curbuf->b_u_curhead;
     else

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1675,10 +1675,11 @@ void u_undo(int count)
     count = 1;
   }
 
-  if (vim_strchr(p_cpo, CPO_UNDO) == NULL)
+  if (vim_strchr(p_cpo, CPO_UNDO) == NULL) {
     undo_undoes = true;
-  else
+  } else {
     undo_undoes = !undo_undoes;
+  }
   u_doit(count, false, true);
 }
 
@@ -2020,11 +2021,9 @@ void undo_time(long step, bool sec, bool file, bool absolute)
   }
 
 found:
-  /* If we found it: Follow the path to go to where we want to be. */
+  // If we found it: Follow the path to go to where we want to be.
   if (uhp != NULL || target == 0) {
-    /*
-     * First go up the tree as much as needed.
-     */
+    // First go up the tree as much as needed.
     while (!got_int) {
       /* Do the change warning now, for the same reason as above. */
       change_warning(0);
@@ -2034,9 +2033,11 @@ found:
         uhp = curbuf->b_u_newhead;
       else
         uhp = uhp->uh_next.ptr;
-      if (uhp == NULL || (target > 0 && uhp->uh_walk != mark)
-          || (uhp->uh_seq == target && !above))
+      if (uhp == NULL
+          || (target > 0 && uhp->uh_walk != mark)
+          || (uhp->uh_seq == target && !above)) {
         break;
+      }
       curbuf->b_u_curhead = uhp;
       u_undoredo(true, true);
       if (target > 0) {
@@ -2428,12 +2429,14 @@ static void u_undo_end(
     if (absolute && curbuf->b_u_curhead->uh_next.ptr != NULL) {
       uhp = curbuf->b_u_curhead->uh_next.ptr;
       did_undo = false;
-    } else if (did_undo)
+    } else if (did_undo) {
       uhp = curbuf->b_u_curhead;
-    else
+    } else {
       uhp = curbuf->b_u_curhead->uh_next.ptr;
-  } else
+    }
+  } else {
     uhp = curbuf->b_u_newhead;
+  }
 
   if (uhp == NULL)
     *msgbuf = NUL;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1804,16 +1804,14 @@ static void u_doit(int startcount, bool quiet, bool do_buf_event)
   u_undo_end(undo_undoes, false, quiet);
 }
 
-/*
- * Undo or redo over the timeline.
- * When "step" is negative go back in time, otherwise goes forward in time.
- * When "sec" is FALSE make "step" steps, when "sec" is TRUE use "step" as
- * seconds.
- * When "file" is TRUE use "step" as a number of file writes.
- * When "absolute" is TRUE use "step" as the sequence number to jump to.
- * "sec" must be FALSE then.
- */
-void undo_time(long step, int sec, int file, int absolute)
+// Undo or redo over the timeline.
+// When "step" is negative go back in time, otherwise goes forward in time.
+// When "sec" is false make "step" steps, when "sec" is true use "step" as
+// seconds.
+// When "file" is true use "step" as a number of file writes.
+// When "absolute" is true use "step" as the sequence number to jump to.
+// "sec" must be false then.
+void undo_time(long step, bool sec, bool file, bool absolute)
 {
   long target;
   long closest;
@@ -1825,8 +1823,8 @@ void undo_time(long step, int sec, int file, int absolute)
   int mark;
   int nomark;
   int round;
-  int dosec = sec;
-  int dofile = file;
+  bool dosec = sec;
+  bool dofile = file;
   bool above = false;
   bool did_undo = true;
 
@@ -1867,7 +1865,7 @@ void undo_time(long step, int sec, int file, int absolute)
         if (target <= 0)
           /* Go to before first write: before the oldest change. Use
            * the sequence number for that. */
-          dofile = FALSE;
+          dofile = false;
       } else {
         /* Moving forward to a newer write. */
         target = curbuf->b_u_save_nr_cur + step;
@@ -1875,7 +1873,7 @@ void undo_time(long step, int sec, int file, int absolute)
           /* Go to after last write: after the latest change. Use
            * the sequence number for that. */
           target = curbuf->b_u_seq_last + 1;
-          dofile = FALSE;
+          dofile = false;
         }
       }
     } else
@@ -2014,8 +2012,8 @@ void undo_time(long step, int sec, int file, int absolute)
     }
 
     target = closest_seq;
-    dosec = FALSE;
-    dofile = FALSE;
+    dosec = false;
+    dofile = false;
     if (step < 0) {
       above = true;             // stop above the header
     }

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -122,7 +122,7 @@ static long u_newcount, u_oldcount;
  * When 'u' flag included in 'cpoptions', we behave like vi.  Need to remember
  * the action that "u" should do.
  */
-static int undo_undoes = FALSE;
+static bool undo_undoes = false;
 
 static int lastmark = 0;
 
@@ -591,7 +591,7 @@ int u_savecommon(linenr_T top, linenr_T bot, linenr_T newbot, int reload)
   uep->ue_next = curbuf->b_u_newhead->uh_entry;
   curbuf->b_u_newhead->uh_entry = uep;
   curbuf->b_u_synced = false;
-  undo_undoes = FALSE;
+  undo_undoes = false;
 
 #ifdef U_DEBUG
   u_check(FALSE);
@@ -1676,7 +1676,7 @@ void u_undo(int count)
   }
 
   if (vim_strchr(p_cpo, CPO_UNDO) == NULL)
-    undo_undoes = TRUE;
+    undo_undoes = true;
   else
     undo_undoes = !undo_undoes;
   u_doit(count, false, true);


### PR DESCRIPTION
**vim-patch:8.0.1441: using ":undo 0" leaves undo in wrong state**

Problem:    Using ":undo 0" leaves undo in wrong state.
Solution:   Instead of searching for state 1 and go above, just use the start.
            (Ozaki Kiichi, closes vim/vim#2595)
vim/vim@ce46d93