### PR TITLE
vim-patch:8.1.0110: file name not displayed with ":file"

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1595,15 +1595,16 @@ void ex_file(exarg_T *eap)
   }
 
   if (*eap->arg != NUL || eap->addr_count == 1) {
-    if (rename_buffer(eap->arg) == FAIL)
+    if (rename_buffer(eap->arg) == FAIL) {
       return;
+    }
+    redraw_tabline = true;
   }
 
-  if (!shortmess(SHM_FILEINFO)) {
-    // print full file name if :cd used
+  // print file name if no argument or 'F' is not in 'shortmess'
+  if (*eap->arg == NUL || !shortmess(SHM_FILEINFO)) {
     fileinfo(false, false, eap->forceit);
   }
-  redraw_tabline = true;
 }
 
 /*

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -339,3 +339,17 @@ func Test_copy_winopt()
   call assert_equal(4,&numberwidth)
   bw!
 endfunc
+
+func Test_shortmess_F()
+  new
+  call assert_match('\[No Name\]', execute('file'))
+  set shortmess+=F
+  call assert_match('\[No Name\]', execute('file'))
+  call assert_match('^\s*$', execute('file foo'))
+  call assert_match('foo', execute('file'))
+  set shortmess-=F
+  call assert_match('bar', execute('file bar'))
+  call assert_match('bar', execute('file'))
+  set shortmess&
+  bwipe
+endfunc


### PR DESCRIPTION
Problem:    File name not displayed with ":file" when 'F' is in 'shortmess'.
Solution:   Always display the file name when there is no argument (Christian
            Brabandt, closes vim/vim#3070)
https://github.com/vim/vim/commit/fc0896093c3b3e753859a5f929921933e7a2e6cd

closes #8817
closes #8873