### PR TITLE
[RDY] vim-patch:8.1.0303

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3955,7 +3955,7 @@ long ml_find_line_or_offset(buf_T *buf, linenr_T lnum, long *offp)
     /* Don't count the last line break if 'noeol' and ('bin' or
      * 'nofixeol'). */
     if ((!buf->b_p_fixeol || buf->b_p_bin) && !buf->b_p_eol
-        && buf->b_ml.ml_line_count == lnum) {
+        && lnum > buf->b_ml.ml_line_count) {
       size -= ffdos + 1;
     }
   }

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -701,6 +701,7 @@ endfunc
 
 func Test_byte2line_line2byte()
   new
+  set endofline
   call setline(1, ['a', 'bc', 'd'])
 
   set fileformat=unix
@@ -721,7 +722,16 @@ func Test_byte2line_line2byte()
   call assert_equal([-1, -1, 1, 4, 8, 11, -1],
   \                 map(range(-1, 5), 'line2byte(v:val)'))
 
-  set fileformat&
+  bw!
+  set noendofline nofixendofline
+  normal a-
+  for ff in ["unix", "mac", "dos"]
+    let &fileformat = ff
+    call assert_equal(1, line2byte(1))
+    call assert_equal(2, line2byte(2))  " line2byte(line("$") + 1) is the buffer size plus one (as per :help line2byte).
+  endfor
+
+  set endofline& fixendofline& fileformat&
   bw!
 endfunc
 


### PR DESCRIPTION
**vim-patch:8.1.0303: line2byte() is wrong for last line with 'noeol'**

Problem:    line2byte() is wrong for last line with 'noeol' and 'nofixeol'.
Solution:   Fix off-by-one error. (Shane Harper, closes vim/vim#3351)
https://github.com/vim/vim/commit/c26f7c60532a37a2bf0a5e69aa81081b440dfc38