### PR TITLE
[RDY] vim-patch:8.0.{1331,1426,1707,1790}

### DIFF
--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -7,7 +7,8 @@ func Test_gf_url()
       \ "first test for URL://machine.name/tmp/vimtest2a and other text",
       \ "second test for URL://machine.name/tmp/vimtest2b. And other text",
       \ "third test for URL:\\\\machine.name\\vimtest2c and other text",
-      \ "fourth test for URL:\\\\machine.name\\tmp\\vimtest2d, and other text"
+      \ "fourth test for URL:\\\\machine.name\\tmp\\vimtest2d, and other text",
+      \ "fifth test for URL://machine.name/tmp?q=vim&opt=yes and other text",
       \ ])
   call cursor(1,1)
   call search("^first")
@@ -27,6 +28,10 @@ func Test_gf_url()
   call search("^fourth")
   call search("URL")
   call assert_equal("URL:\\\\machine.name\\tmp\\vimtest2d", expand("<cfile>"))
+
+  call search("^fifth")
+  call search("URL")
+  call assert_equal("URL://machine.name/tmp?q=vim&opt=yes", expand("<cfile>"))
 
   set isf&vim
   enew!

--- a/src/nvim/testdir/test_winbuf_close.vim
+++ b/src/nvim/testdir/test_winbuf_close.vim
@@ -122,3 +122,39 @@ func Test_winbuf_close()
   call delete('Xtest2')
   call delete('Xtest3')
 endfunc
+
+" Test that ":close" will respect 'winfixheight' when possible.
+func Test_winfixheight_on_close()
+  set nosplitbelow nosplitright
+
+  split | split | vsplit
+
+  $wincmd w
+  setlocal winfixheight
+  let l:height = winheight(0)
+
+  3close
+
+  call assert_equal(l:height, winheight(0))
+
+  %bwipeout!
+  setlocal nowinfixheight splitbelow& splitright&
+endfunc
+
+" Test that ":close" will respect 'winfixwidth' when possible.
+func Test_winfixwidth_on_close()
+  set nosplitbelow nosplitright
+
+  vsplit | vsplit | split
+
+  $wincmd w
+  setlocal winfixwidth
+  let l:width = winwidth(0)
+
+  3close
+
+  call assert_equal(l:width, winwidth(0))
+
+  %bwipeout!
+  setlocal nowinfixwidth splitbelow& splitright&
+endfunction

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -565,6 +565,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
   int before;
   int minheight;
   int wmh1;
+  bool did_set_fraction = false;
 
   if (flags & WSP_TOP)
     oldwin = firstwin;
@@ -729,6 +730,11 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
      * 'winfixheight' window.  Take them from a window above or below
      * instead, if possible. */
     if (oldwin->w_p_wfh) {
+      // Set w_fraction now so that the cursor keeps the same relative
+      // vertical position using the old height.
+      set_fraction(oldwin);
+      did_set_fraction = true;
+
       win_setheight_win(oldwin->w_height + new_size + STATUS_HEIGHT,
           oldwin);
       oldwin_height = oldwin->w_height;
@@ -843,7 +849,9 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
 
   /* Set w_fraction now so that the cursor keeps the same relative
    * vertical position. */
-  set_fraction(oldwin);
+  if (!did_set_fraction) {
+    set_fraction(oldwin);
+  }
   wp->w_fraction = oldwin->w_fraction;
 
   if (flags & WSP_VERT) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -843,8 +843,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
 
   /* Set w_fraction now so that the cursor keeps the same relative
    * vertical position. */
-  if (oldwin->w_height > 0)
-    set_fraction(oldwin);
+  set_fraction(oldwin);
   wp->w_fraction = oldwin->w_fraction;
 
   if (flags & WSP_VERT) {
@@ -4791,10 +4790,13 @@ void win_drag_vsep_line(win_T *dragwin, int offset)
 #define FRACTION_MULT   16384L
 
 // Set wp->w_fraction for the current w_wrow and w_height.
+// Has no effect when the window is less than two lines.
 void set_fraction(win_T *wp)
 {
-  wp->w_fraction = ((long)wp->w_wrow * FRACTION_MULT + wp->w_height / 2)
+  if (wp->w_height > 1) {
+    wp->w_fraction = ((long)wp->w_wrow * FRACTION_MULT + wp->w_height / 2)
                    / (long)wp->w_height;
+  }
 }
 
 /*


### PR DESCRIPTION
**vim-patch:8.0.1331: possible crash when window can be zero lines high**

Problem:    Possible crash when window can be zero lines high. (Joseph
            Dornisch)
Solution:   Only set w_fraction if the window is at least two lines high.
https://github.com/vim/vim/commit/3679c17917d7ff22e836982c81e5816bd07451dd

**vim-patch:8.0.1426: "gf" and <cfile> don't accept ? and & in URL**

Problem:    "gf" and <cfile> don't accept ? and & in URL. (Dmitrii Tcyganok)
Solution:   Check for a URL and allow for extra characters. (closes vim/vim#2493)
vim/vim@9e3dfc6

**vim-patch:8.0.1707: when 'wfh' is set ":bel 10new" scrolls window**

Problem:    When 'wfh' is set ":bel 10new" scrolls window. (Andrew Pyatkov)
Solution:   Set the fraction before changing the window height. (closes vim/vim#2798)
vim/vim@98da6ec

**vim-patch:8.0.1790: 'winfixwidth' is not always respected by :close**

Problem:    'winfixwidth' is not always respected by :close.
Solution:   Prefer a frame without 'winfixwidth' or 'winfixheight'. (Jason
            Franklin)
vim/vim@c136af2