### PR TITLE
channels: log contents of invalid message

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -205,7 +205,11 @@ void channel_create_event(Channel *chan, const char *ext_source)
   // to pretty print top level dict in defined order
   (void)object_to_vim(DICTIONARY_OBJ(info), &tv, NULL);
   char *str = encode_tv2json(&tv, NULL);
-  ILOG("new channel %" PRIu64 " (%s) : %s", chan->id, source, str);
+  ILOG("new channel %" PRIu64 " (%s%s) : %s",
+       chan->id,
+       chan->streamtype == kChannelStreamInternal ? "loopback, " : "",
+       source,
+       str);
   xfree(str);
   api_free_dictionary(info);
 

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -23,7 +23,7 @@
 #endif
 
 #define LOG(level, eol, ...) do_log((level), NULL, __func__, __LINE__, eol, \
-                               __VA_ARGS__)
+                                    __VA_ARGS__)
 
 #if MIN_LOG_LEVEL <= DEBUG_LOG_LEVEL
 # undef DLOG

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -22,7 +22,7 @@
 #  define MIN_LOG_LEVEL INFO_LOG_LEVEL
 #endif
 
-#define LOG(level, ...) do_log((level), NULL, __func__, __LINE__, true, \
+#define LOG(level, eol, ...) do_log((level), NULL, __func__, __LINE__, eol, \
                                __VA_ARGS__)
 
 #if MIN_LOG_LEVEL <= DEBUG_LOG_LEVEL

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -249,14 +249,16 @@ static void parse_msgpack(Channel *channel)
     log_client_msg(channel->id, !is_response, unpacked.data);
 
     if (is_response) {
-      if (is_valid_rpc_response(&unpacked.data, channel)) {
+      uint64_t response_id;
+      if (is_valid_rpc_response(&unpacked.data, channel, &response_id)) {
         complete_call(&unpacked.data, channel);
       } else {
         char buf[256];
         snprintf(buf, sizeof(buf),
-                 "ch %" PRIu64 " returned a response with an unknown request "
-                 "id. Ensure the client is properly synchronized",
-                 channel->id);
+                 "ch %" PRIu64 " got response for unknown request-id=%" PRIu64
+                 ". Ensure the client is synchronized",
+                 channel->id,
+                 response_id);
         call_set_error(channel, buf, ERROR_LOG_LEVEL);
       }
       msgpack_unpacked_destroy(&unpacked);
@@ -568,16 +570,17 @@ static bool is_rpc_response(msgpack_object *obj)
       && obj->via.array.ptr[1].type == MSGPACK_OBJECT_POSITIVE_INTEGER;
 }
 
-static bool is_valid_rpc_response(msgpack_object *obj, Channel *channel)
+static bool is_valid_rpc_response(msgpack_object *obj, Channel *channel,
+                                  uint64_t *response_id)
 {
-  uint64_t response_id = obj->via.array.ptr[1].via.u64;
+  *response_id = obj->via.array.ptr[1].via.u64;
   if (kv_size(channel->rpc.call_stack) == 0) {
     return false;
   }
 
   // Must be equal to the frame at the stack's bottom
   ChannelCallFrame *frame = kv_last(channel->rpc.call_stack);
-  return response_id == frame->request_id;
+  return *response_id == frame->request_id;
 }
 
 static void complete_call(msgpack_object *obj, Channel *channel)

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -68,7 +68,7 @@ void rpc_start(Channel *channel)
     Stream *out = channel_outstream(channel);
 #if MIN_LOG_LEVEL <= DEBUG_LOG_LEVEL
     Stream *in = channel_instream(channel);
-    DLOG("rpc ch %" PRIu64 " in-stream=%p out-stream=%p", channel->id, in, out);
+    DLOG("RPC ch %" PRIu64 " in-stream=%p out-stream=%p", channel->id, in, out);
 #endif
 
     rstream_start(out, receive_msgpack, channel);

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -338,7 +338,7 @@ describe('server -> client', function()
     end)
   end)
 
-  describe('connecting to its own pipe address', function()
+  describe('connecting to its own ("loopback") pipe address', function()
     it('does not deadlock', function()
       if not os.getenv("TRAVIS") and helpers.os_name() == "osx" then
         -- It does, in fact, deadlock on QuickBuild. #6851


### PR DESCRIPTION
~~This just a first step, it seems to be kind of useless, because (I guess) `log_msg_close .. msgpack_object_print` has nothing useful to print if the message was invalid.~~

- [x] save raw stream bytes for error-reporting
- [x] test `$NVIM_LOG_FILE` contents
- [ ] test for https://github.com/neovim/neovim/pull/8883#discussion_r211848065
- [ ] test currently causes `abort()` :
  ```
  :let c = sockconnect('pipe', v:servername, {'rpc':1})
  :echo chansend(c, "foo \0 \n\t ??  \0 \n \r")        
  ```
- [ ] is `channel_create_event` done for all channel types (e.g. `--embed` ch 1)?