### PR TITLE
vim-patch:8.1.0002

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6524,11 +6524,17 @@ void unshowmode(bool force)
 // Clear the mode message.
 void clearmode(void)
 {
+  const int save_msg_row = msg_row;
+  const int save_msg_col = msg_col;
+
     msg_pos_mode();
     if (Recording) {
       recording_mode(HL_ATTR(HLF_CM));
     }
     msg_clr_eos();
+
+  msg_col = save_msg_col;
+  msg_row = save_msg_row;
 }
 
 static void recording_mode(int attr)

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6527,11 +6527,11 @@ void clearmode(void)
   const int save_msg_row = msg_row;
   const int save_msg_col = msg_col;
 
-    msg_pos_mode();
-    if (Recording) {
-      recording_mode(HL_ATTR(HLF_CM));
-    }
-    msg_clr_eos();
+  msg_pos_mode();
+  if (Recording) {
+    recording_mode(HL_ATTR(HLF_CM));
+  }
+  msg_clr_eos();
 
   msg_col = save_msg_col;
   msg_row = save_msg_row;

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -14,6 +14,7 @@ set backspace=
 set nohidden smarttab noautoindent noautoread complete-=i noruler noshowcmd
 set listchars=eol:$
 set fillchars=vert:\|,fold:-
+set shortmess-=F
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
 

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -38,3 +38,24 @@ function Test_messages()
     let &more = oldmore
   endtry
 endfunction
+
+" Patch 7.4.1696 defined the "clearmode()" command for clearing the mode
+" indicator (e.g., "-- INSERT --") when ":stopinsert" is invoked.  Message
+" output could then be disturbed when 'cmdheight' was greater than one.
+" This test ensures that the bugfix for this issue remains in place.
+function! Test_stopinsert_does_not_break_message_output()
+  set cmdheight=2
+  redraw!
+
+  stopinsert | echo 'test echo'
+  call assert_equal(116, screenchar(&lines - 1, 1))
+  call assert_equal(32, screenchar(&lines, 1))
+  redraw!
+
+  stopinsert | echomsg 'test echomsg'
+  call assert_equal(116, screenchar(&lines - 1, 1))
+  call assert_equal(32, screenchar(&lines, 1))
+  redraw!
+
+  set cmdheight&
+endfunction


### PR DESCRIPTION
**vim-patch:8.1.0002: :stopinsert changes the message position**

Problem:    :stopinsert changes the message position.
Solution:   Save and restore msg_col and msg_row in clearmode(). (Jason
            Franklin)
vim/vim@2abad54