### PR TITLE
[RDY] vim-patch:8.0.1151

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8154,6 +8154,10 @@ static void ex_normal(exarg_T *eap)
 static void ex_startinsert(exarg_T *eap)
 {
   if (eap->forceit) {
+    // cursor line can be zero on startup
+    if (!curwin->w_cursor.lnum) {
+      curwin->w_cursor.lnum = 1;
+    }
     coladvance((colnr_T)MAXCOL);
     curwin->w_curswant = MAXCOL;
     curwin->w_set_curswant = FALSE;

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -264,3 +264,27 @@ func Test_default_term()
   call assert_match('nvim', out)
   let $TERM = save_term
 endfunc
+
+func Test_zzz_startinsert()
+  " Test :startinsert
+  call writefile(['123456'], 'Xtestout')
+  let after = [
+	\ ':startinsert',
+  \ 'call feedkeys("foobar\<c-o>:wq\<cr>","t")'
+	\ ]
+  if RunVim([], after, 'Xtestout')
+    let lines = readfile('Xtestout')
+    call assert_equal(['foobar123456'], lines)
+  endif
+  " Test :startinsert!
+  call writefile(['123456'], 'Xtestout')
+  let after = [
+	\ ':startinsert!',
+  \ 'call feedkeys("foobar\<c-o>:wq\<cr>","t")'
+	\ ]
+  if RunVim([], after, 'Xtestout')
+    let lines = readfile('Xtestout')
+    call assert_equal(['123456foobar'], lines)
+  endif
+  call delete('Xtestout')
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1151: "vim -c startinsert!" doesn't append**

Problem:    "vim -c startinsert!" doesn't append.
Solution:   Correct line number on startup. (Christian Brabandt, closes vim/vim#2117)
https://github.com/vim/vim/commit/09ca932f8e7d63a83b39baa7c03d4c6145e3baab