### PR TITLE
[RDY] vim-patch:8.0.1242

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1210,8 +1210,12 @@ int call_vim_function(
     if (str_arg_only) {
       len = 0;
     } else {
-      // Recognize a number argument, the others must be strings.
+      // Recognize a number argument, the others must be strings. A dash
+      // is a string too.
       vim_str2nr(argv[i], NULL, &len, STR2NR_ALL, &n, NULL, 0);
+      if (len == 1 && *argv[i] == '-') {
+        len = 0;
+      }
     }
     if (len != 0 && len == (int)STRLEN(argv[i])) {
       argvars[i].v_type = VAR_NUMBER;

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -217,3 +217,22 @@ function Test_CompleteDoneList()
   let s:called_completedone = 0
   au! CompleteDone
 endfunc
+
+func Test_omni_dash()
+  func Omni(findstart, base)
+    if a:findstart
+        return 5
+    else
+        echom a:base
+	return ['-help', '-v']
+    endif
+  endfunc
+  set omnifunc=Omni
+  new
+  exe "normal Gofind -\<C-x>\<C-o>"
+  call assert_equal("\n-\nmatch 1 of 2", execute(':2mess'))
+
+  bwipe!
+  delfunc Omni
+  set omnifunc=
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1242: function argument with only dash is seen as number zero**

Problem:    Function argument with only dash is seen as number zero. (Wang
            Shidong)
Solution:   See a dash as a string. (Christian Brabandt)
https://github.com/vim/vim/commit/ffd99f729bd806e09d9355ede9c17780b61057bf