### PR TITLE
[RFC] vim-patch:8.0.{1020,1048},8.1.0052

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -434,8 +434,8 @@ void flush_buffers(int flush_typeahead)
      * of an escape sequence.
      * In an xterm we get one char at a time and we have to get them all.
      */
-    while (inchar(typebuf.tb_buf, typebuf.tb_buflen - 1, 10L) != 0)
-      ;
+    while (inchar(typebuf.tb_buf, typebuf.tb_buflen - 1, 10L) != 0) {
+    }
     typebuf.tb_off = MAXMAPLEN;
     typebuf.tb_len = 0;
     // Reset the flag that text received from a client or from feedkeys()
@@ -1696,21 +1696,20 @@ static int vgetorpeek(int advance)
           os_breakcheck();                      /* check for CTRL-C */
         keylen = 0;
         if (got_int) {
-          /* flush all input */
+          // flush all input
           c = inchar(typebuf.tb_buf, typebuf.tb_buflen - 1, 0L);
-          /*
-           * If inchar() returns TRUE (script file was active) or we
-           * are inside a mapping, get out of insert mode.
-           * Otherwise we behave like having gotten a CTRL-C.
-           * As a result typing CTRL-C in insert mode will
-           * really insert a CTRL-C.
-           */
+          // If inchar() returns TRUE (script file was active) or we
+          // are inside a mapping, get out of insert mode.
+          // Otherwise we behave like having gotten a CTRL-C.
+          // As a result typing CTRL-C in insert mode will
+          // really insert a CTRL-C.
           if ((c || typebuf.tb_maplen)
-              && (State & (INSERT + CMDLINE)))
+              && (State & (INSERT + CMDLINE))) {
             c = ESC;
-          else
+          } else {
             c = Ctrl_C;
-          flush_buffers(TRUE);                  /* flush all typeahead */
+          }
+          flush_buffers(true);                  // flush all typeahead
 
           if (advance) {
             /* Also record this character, it might be needed to
@@ -2073,17 +2072,17 @@ static int vgetorpeek(int advance)
         c = 0;
         new_wcol = curwin->w_wcol;
         new_wrow = curwin->w_wrow;
-        if (       advance
-                   && typebuf.tb_len == 1
-                   && typebuf.tb_buf[typebuf.tb_off] == ESC
-                   && !no_mapping
-                   && ex_normal_busy == 0
-                   && typebuf.tb_maplen == 0
-                   && (State & INSERT)
-                   && (p_timeout
-                       || (keylen == KEYLEN_PART_KEY && p_ttimeout))
-                   && (c = inchar(typebuf.tb_buf + typebuf.tb_off
-                                  + typebuf.tb_len, 3, 25L)) == 0) {
+        if (advance
+            && typebuf.tb_len == 1
+            && typebuf.tb_buf[typebuf.tb_off] == ESC
+            && !no_mapping
+            && ex_normal_busy == 0
+            && typebuf.tb_maplen == 0
+            && (State & INSERT)
+            && (p_timeout
+                || (keylen == KEYLEN_PART_KEY && p_ttimeout))
+            && (c = inchar(typebuf.tb_buf + typebuf.tb_off + typebuf.tb_len,
+                           3, 25L)) == 0) {
           colnr_T col = 0, vcol;
           char_u      *ptr;
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2255,6 +2255,11 @@ static int vgetorpeek(int advance)
         /*
          * get a character: 3. from the user - get it
          */
+        if (typebuf.tb_len == 0) {
+          // timedout may have been set while waiting for a mapping
+          // that has a <Nop> RHS.
+          timedout = false;
+        }
         wait_tb_len = typebuf.tb_len;
         c = inchar(typebuf.tb_buf + typebuf.tb_off + typebuf.tb_len,
             typebuf.tb_buflen - typebuf.tb_off - typebuf.tb_len - 1,

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -169,5 +169,25 @@ func Test_stop_all_in_callback()
   call assert_equal(0, len(info))
 endfunc
 
+func FeedAndPeek(timer)
+  call test_feedinput('a')
+  call getchar(1)
+endfunc
+
+func Interrupt(timer)
+  call test_feedinput("\<C-C>")
+endfunc
+
+func Test_peek_and_get_char()
+  throw 'skipped: Nvim does not support test_feedinput()'
+  if !has('unix') && !has('gui_running')
+    return
+  endif
+  call timer_start(0, 'FeedAndPeek')
+  let intr = timer_start(100, 'Interrupt')
+  let c = getchar()
+  call assert_equal(char2nr('a'), c)
+  call timer_stop(intr)
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -96,6 +96,7 @@ describe('timers', function()
     source([[
       func! AddItem(timer)
         call nvim_buf_set_lines(0, 2, 2, v:true, ['ITEM 3'])
+        call getchar(1)
         redraw
       endfunc
       call timer_start(200, 'AddItem')


### PR DESCRIPTION
**vim-patch:8.0.1020: when a timer calls getchar(1) input is overwritten**

Problem:    When a timer calls getchar(1) input is overwritten.
Solution:   Increment tb_change_cnt in inchar(). (closes vim/vim#1940)
vim/vim@0f0f230

**vim-patch:8.0.1048: no test for what 8.0.1020 fixes**

Problem:    No test for what 8.0.1020 fixes.
Solution:   Add test_feedinput().  Add a test. (Ozaki Kiichi, closes vim/vim#2046)
vim/vim@5e80de3

**vim-patch:8.1.0052: when mapping to <Nop> times out the next mapping is skipped**

Problem:    When a mapping to <Nop> times out the next mapping is skipped.
Solution:   Reset "timedout" when waiting for a character. (Christian
            Brabandt, closes vim/vim#2921)
vim/vim@83f4cbd

I omit code for `test_feedinput` so 8.0.1048 includes the test code only.