### PR TITLE
vim-patch:8.0.1682

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2104,6 +2104,7 @@ void op_insert(oparg_T *oap, long count1)
 
   if (oap->motion_type == kMTBlockWise) {
     struct block_def bd2;
+    bool did_indent = false;
 
     // if indent kicked in, the firstline might have changed
     // but only do that, if the indent actually increased
@@ -2111,11 +2112,15 @@ void op_insert(oparg_T *oap, long count1)
     if (curbuf->b_op_start.col > ind_pre && ind_post > ind_pre) {
       bd.textcol += ind_post - ind_pre;
       bd.start_vcol += ind_post - ind_pre;
+      did_indent = true;
     }
 
-    /* The user may have moved the cursor before inserting something, try
-     * to adjust the block for that. */
-    if (oap->start.lnum == curbuf->b_op_start_orig.lnum && !bd.is_MAX) {
+    // The user may have moved the cursor before inserting something, try
+    // to adjust the block for that.  But only do it, if the difference
+    // does not come from indent kicking in.
+    if (oap->start.lnum == curbuf->b_op_start_orig.lnum
+        && !bd.is_MAX
+        && !did_indent) {
       if (oap->op_type == OP_INSERT
           && oap->start.col + oap->start.coladd
           != curbuf->b_op_start_orig.col + curbuf->b_op_start_orig.coladd) {

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -36,6 +36,7 @@ SCRIPTS ?= $(SCRIPTS_DEFAULT)
 NEW_TESTS ?= \
 	    test_arabic.res \
 	    test_autocmd.res \
+	    test_blockedit.res \
 	    test_bufwintabinfo.res \
 	    test_changedtick.res \
 	    test_charsearch.res \

--- a/src/nvim/testdir/test_blockedit.vim
+++ b/src/nvim/testdir/test_blockedit.vim
@@ -1,0 +1,20 @@
+" Test for block inserting
+"
+" TODO: rewrite test39.in into this new style test
+
+func Test_blockinsert_indent()
+  new
+  filetype plugin indent on
+  setlocal sw=2 et ft=vim
+  call setline(1, ['let a=[', '  ''eins'',', '  ''zwei'',', '  ''drei'']'])
+  call cursor(2, 3)
+  exe "norm! \<c-v>2jI\\ \<esc>"
+  call assert_equal(['let a=[', '      \ ''eins'',', '      \ ''zwei'',', '      \ ''drei'']'],
+        \ getline(1,'$'))
+  " reset to sane state
+  filetype off
+  bwipe!
+endfunc
+
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:8.0.1682: auto indenting breaks inserting a block**

Problem:    Auto indenting breaks inserting a block.
Solution:   Do not check for cursor movement if indent was changed. (Christian
            Brabandt, closes vim/vim#2778)
https://github.com/vim/vim/commit/8c87a2b1fec85e4aac33f71586ac1514536fc66b