### PR TITLE
[RDY] vim-patch:8.1.0083

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2216,15 +2216,12 @@ showmatch(
 // sentence when found.  If the next sentence is found, return OK.  Return FAIL
 // otherwise.  See ":h sentence" for the precise definition of a "sentence"
 // text object.
-int findsent(int dir, long count)
+int findsent(Direction dir, long count)
 {
   pos_T pos, tpos;
   int c;
   int         (*func)(pos_T *);
-  int startlnum;
-  int noskip = FALSE;               /* do not skip blanks */
-  int cpo_J;
-  int found_dot;
+  bool noskip = false;              // do not skip blanks
 
   pos = curwin->w_cursor;
   if (dir == FORWARD)
@@ -2259,7 +2256,7 @@ int findsent(int dir, long count)
     }
 
     // go back to the previous non-white non-punctuation character
-    found_dot = false;
+    bool found_dot = false;
     while (c = gchar_pos(&pos), ascii_iswhite(c)
            || vim_strchr((char_u *)".!?)]\"'", c) != NULL) {
       tpos = pos;
@@ -2279,9 +2276,9 @@ int findsent(int dir, long count)
       decl(&pos);
     }
 
-    /* remember the line where the search started */
-    startlnum = pos.lnum;
-    cpo_J = vim_strchr(p_cpo, CPO_ENDOFSENT) != NULL;
+    // remember the line where the search started
+    const int startlnum = pos.lnum;
+    const bool cpo_J = vim_strchr(p_cpo, CPO_ENDOFSENT) != NULL;
 
     for (;; ) {                 /* find end of sentence */
       c = gchar_pos(&pos);
@@ -2309,7 +2306,7 @@ int findsent(int dir, long count)
       if ((*func)(&pos) == -1) {
         if (count)
           return FAIL;
-        noskip = TRUE;
+        noskip = true;
         break;
       }
     }

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -182,3 +182,78 @@ x
   norm it
   q!
 endfunc
+
+func Test_sentence()
+  enew!
+  call setline(1, 'A sentence.  A sentence?  A sentence!')
+
+  normal yis
+  call assert_equal('A sentence.', @")
+  normal yas
+  call assert_equal('A sentence.  ', @")
+
+  normal )
+
+  normal yis
+  call assert_equal('A sentence?', @")
+  normal yas
+  call assert_equal('A sentence?  ', @")
+
+  normal )
+
+  normal yis
+  call assert_equal('A sentence!', @")
+  normal yas
+  call assert_equal('  A sentence!', @")
+
+  normal 0
+  normal 2yis
+  call assert_equal('A sentence.  ', @")
+  normal 3yis
+  call assert_equal('A sentence.  A sentence?', @")
+  normal 2yas
+  call assert_equal('A sentence.  A sentence?  ', @")
+
+  %delete _
+endfunc
+
+func Test_sentence_with_quotes()
+  enew!
+  call setline(1, 'A "sentence."  A sentence.')
+
+  normal yis
+  call assert_equal('A "sentence."', @")
+  normal yas
+  call assert_equal('A "sentence."  ', @")
+
+  normal )
+
+  normal yis
+  call assert_equal('A sentence.', @")
+  normal yas
+  call assert_equal('  A sentence.', @")
+
+  %delete _
+endfunc
+
+func! Test_sentence_with_cursor_on_delimiter()
+  enew!
+  call setline(1, "A '([sentence.])'  A sentence.")
+
+  normal! 15|yis
+  call assert_equal("A '([sentence.])'", @")
+  normal! 15|yas
+  call assert_equal("A '([sentence.])'  ", @")
+
+  normal! 16|yis
+  call assert_equal("A '([sentence.])'", @")
+  normal! 16|yas
+  call assert_equal("A '([sentence.])'  ", @")
+
+  normal! 17|yis
+  call assert_equal("A '([sentence.])'", @")
+  normal! 17|yas
+  call assert_equal("A '([sentence.])'  ", @")
+
+  %delete _
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0083: "is" and "as" have trouble with quoted punctuation**

Problem:    "is" and "as" have trouble with quoted punctuation.
Solution:   Check for punctuation before a quote. (Jason Franklin)
https://github.com/vim/vim/commit/8516071124dbb7ad7caa43cc98ae3c57ae093c9e