### PR TITLE
vim-patch:8.1.0310: file info msg with 'F' in 'shortmess'

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -884,7 +884,15 @@ void handle_swap_exists(bufref_T *old_curbuf)
       buf = old_curbuf->br_buf;
     }
     if (buf != NULL) {
+      int old_msg_silent = msg_silent;
+
+      if (shortmess(SHM_FILEINFO)) {
+        msg_silent = 1;  // prevent fileinfo message
+      }
       enter_buffer(buf);
+      // restore msg_silent, so that the command line will be shown
+      msg_silent = old_msg_silent;
+
       if (old_tw != curbuf->b_p_tw) {
         check_colorcolumn(curwin);
       }

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -528,17 +528,19 @@ void ml_open_file(buf_T *buf)
   buf->b_may_swap = false;
 }
 
-/*
- * If still need to create a swap file, and starting to edit a not-readonly
- * file, or reading into an existing buffer, create a swap file now.
- */
-void 
-check_need_swap (
-    int newfile                    /* reading file into new buffer */
-)
+/// If still need to create a swap file, and starting to edit a not-readonly
+/// file, or reading into an existing buffer, create a swap file now.
+///
+/// @param newfile reading file into new buffer
+void check_need_swap(int newfile)
 {
-  if (curbuf->b_may_swap && (!curbuf->b_p_ro || !newfile))
+  int old_msg_silent = msg_silent;  // might be reset by an E325 message
+
+  if (curbuf->b_may_swap && (!curbuf->b_p_ro || !newfile)) {
     ml_open_file(curbuf);
+  }
+
+  msg_silent = old_msg_silent;
 }
 
 /*

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -15,6 +15,7 @@ set nrformats+=octal
 set nohidden smarttab noautoindent noautoread complete-=i noruler noshowcmd
 set listchars=eol:$
 set fillchars=vert:\|,fold:-
+set shortmess-=F
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
 

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -359,6 +359,8 @@ endfunc
 func Test_shortmess_F2()
   e file1
   e file2
+  " Accommodate Nvim default.
+  set shortmess-=F
   call assert_match('file1', execute('bn', ''))
   call assert_match('file2', execute('bn', ''))
   set shortmess+=F
@@ -370,7 +372,8 @@ func Test_shortmess_F2()
   set nohidden
   call assert_true(empty(execute('bn', '')))
   call assert_true(empty(execute('bn', '')))
-  set shortmess&
+  " Accommodate Nvim default.
+  set shortmess-=F
   call assert_match('file1', execute('bn', ''))
   call assert_match('file2', execute('bn', ''))
   bwipe

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -355,3 +355,24 @@ func Test_shortmess_F()
   set shortmess&
   bwipe
 endfunc
+
+func Test_shortmess_F2()
+  e file1
+  e file2
+  call assert_match('file1', execute('bn', ''))
+  call assert_match('file2', execute('bn', ''))
+  set shortmess+=F
+  call assert_true(empty(execute('bn', '')))
+  call assert_true(empty(execute('bn', '')))
+  set hidden
+  call assert_true(empty(execute('bn', '')))
+  call assert_true(empty(execute('bn', '')))
+  set nohidden
+  call assert_true(empty(execute('bn', '')))
+  call assert_true(empty(execute('bn', '')))
+  set shortmess&
+  call assert_match('file1', execute('bn', ''))
+  call assert_match('file2', execute('bn', ''))
+  bwipe
+  bwipe
+endfunc


### PR DESCRIPTION
Problem:    File info message not always suppressed with 'F' in 'shortmess'.
            (Asheq Imran)
Solution:   Save and restore msg_silent. (Christian Brabandt, closes vim/vim#3221)
https://github.com/vim/vim/commit/2f0f871159b2cba862fcd41edab65b17da75c422

ref #8840
ref #9027