### PR TITLE
vim-patch:8.0.0822

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -243,6 +243,7 @@ let s:flaky = [
       \ 'Test_quoteplus()',
       \ 'Test_quotestar()',
       \ 'Test_reltime()',
+      \ 'Test_with_partial_callback()',
       \ 'Test_repeat_three()',
       \ 'Test_terminal_composing_unicode()',
       \ 'Test_terminal_redir_file()',


### PR DESCRIPTION
**vim-patch:8.0.0822: Test_with_partial_callback is a tiny bit flaky**

Problem:    Test_with_partial_callback is a tiny bit flaky.
Solution:   Add it to the list of flaky tests.
https://github.com/vim/vim/commit/d09be321422669fc32d4d31a4ac7621c89136f7b

Oops, it's N/A because of https://github.com/neovim/neovim/pull/8899/commits/4a083200078f76f29a84e4788108000009a54020

