### PR TITLE
[RDY] vim-patch:8.0.{883,1228,1404,1468}

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -605,9 +605,14 @@ void getout(int exitval)
 
         buf_T *buf = wp->w_buffer;
         if (buf_get_changedtick(buf) != -1) {
+          bufref_T bufref;
+
+          set_bufref(&bufref, buf);
           apply_autocmds(EVENT_BUFWINLEAVE, buf->b_fname,
                          buf->b_fname, false, buf);
-          buf_set_changedtick(buf, -1);  // note that we did it already
+          if (bufref_valid(&bufref)) {
+            buf_set_changedtick(buf, -1);  // note that we did it already
+          }
           // start all over, autocommands may mess up the lists
           next_tp = first_tabpage;
           break;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -610,7 +610,7 @@ static bool emsgfv(const char *fmt, va_list ap)
 /// detected when fuzzing vim.
 void iemsg(const char *s)
 {
-    msg((char_u *)s);
+    emsg((char_u *)s);
 #ifdef ABORT_ON_INTERNAL_ERROR
     abort();
 #endif

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1605,11 +1605,19 @@ int del_bytes(colnr_T count, bool fixpos_arg, bool use_delcombine)
   char_u *oldp = ml_get(lnum);
   colnr_T oldlen = (colnr_T)STRLEN(oldp);
 
-  /*
-   * Can't do anything when the cursor is on the NUL after the line.
-   */
-  if (col >= oldlen)
+  // Can't do anything when the cursor is on the NUL after the line.
+  if (col >= oldlen) {
     return FAIL;
+  }
+  // If "count" is zero there is nothing to do.
+  if (count == 0) {
+    return OK;
+  }
+  // If "count" is negative the caller must be doing something wrong.
+  if (count < 1) {
+    IEMSGN("E950: Invalid count for del_bytes(): %ld", count);
+    return FAIL;
+  }
 
   /* If 'delcombine' is set and deleting (less than) one character, only
    * delete the last combining character. */

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -457,12 +457,15 @@ void expand_env_esc(char_u *restrict srcp,
       } else if ((src[0] == ' ' || src[0] == ',') && !one) {
         at_start = true;
       }
-      *dst++ = *src++;
-      --dstlen;
+      if (dstlen > 0) {
+        *dst++ = *src++;
+        dstlen--;
 
-      if (prefix != NULL && src - prefix_len >= srcp
-          && STRNCMP(src - prefix_len, prefix, prefix_len) == 0) {
-        at_start = true;
+        if (prefix != NULL
+            && src - prefix_len >= srcp
+            && STRNCMP(src - prefix_len, prefix, prefix_len) == 0) {
+          at_start = true;
+        }
       }
     }
   }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1448,7 +1448,11 @@ static void win_update(win_T *wp)
 
       wp->w_lines[idx].wl_lnum = lnum;
       wp->w_lines[idx].wl_valid = true;
-      if (row > wp->w_height) {         // past end of screen
+
+      // Past end of the window or end of the screen. Note that after
+      // resizing wp->w_height may be end up too big. That's a problem
+      // elsewhere, but prevent a crash here.
+      if (row > wp->w_height || row + wp->w_winrow >= Rows) {
         // we may need the size of that too long line later on
         if (dollar_vcol == -1) {
           wp->w_lines[idx].wl_size = plines_win(wp, lnum, true);

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -1217,6 +1217,7 @@ int vim_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap,
               str_arg_l = 3;
               zero_padding = 0;
             } else {
+              // Regular float number
               format[0] = '%';
               size_t l = 1;
               if (force_sign) {
@@ -1241,7 +1242,6 @@ int vim_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap,
               format[l] = (char)(fmt_spec == 'F' ? 'f' : fmt_spec);
               format[l + 1] = NUL;
 
-              // Regular float number
               str_arg_l = (size_t)snprintf(tmp, sizeof(tmp), format, f);
               assert(str_arg_l < sizeof(tmp));
 


### PR DESCRIPTION
**vim-patch:8.0.0883: invalid memory access with nonsensical script**

Problem:    Invalid memory access with nonsensical script.
Solution:   Check "dstlen" being positive. (Dominique Pelle)
https://github.com/vim/vim/commit/1c864093f93b0066de25d6c0ddf03a6bc6b1c870

**vim-patch:8.0.1228: invalid memory access in GUI test**

Problem:    Invalid memory access in GUI test.
Solution:   Check that the row is not outside of the screen.
vim/vim@0e19fc0

**vim-patch:8.0.1404: invalid memory access on exit**

Problem:    Invalid memory access on exit when autocommands wipe out a buffer.
            (gy741, Dominique Pelle)
Solution:   Check if the buffer is still valid. (closes vim/vim#2449)
vim/vim@606d45c

**vim-patch:8.0.1468: illegal memory access in del_bytes()**

Problem:    Illegal memory access in del_bytes().
Solution:   Check for negative byte count. (Christian Brabandt, closes vim/vim#2466)
vim/vim@191f18b