### PR TITLE
[RDY] vim-patch:8.0.{900,1214}

### DIFF
--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -4,17 +4,14 @@
 " Last Change:	2017 Oct 19
 
 " If there already is an option window, jump to that one.
-if bufwinnr("option-window") > 0
-  let s:thiswin = winnr()
-  while 1
-    if @% == "option-window"
+let buf = bufnr('option-window')
+if buf >= 0
+  let winids = win_findbuf(buf)
+  if len(winids) > 0
+    if win_gotoid(winids[0]) == 1
       finish
     endif
-    wincmd w
-    if s:thiswin == winnr()
-      break
-    endif
-  endwhile
+  endif
 endif
 
 " Make sure the '<' flag is not included in 'cpoptions', otherwise <CR> would
@@ -141,8 +138,8 @@ while exists("b:current_syntax") && b:current_syntax == "help"
   endif
 endwhile
 
-" Open the window
-new option-window
+" Open the window.  $OPTWIN_CMD is set to "tab" for ":tab options".
+exe $OPTWIN_CMD . ' new option-window'
 setlocal ts=15 tw=0 noro buftype=nofile
 
 " Insert help and a "set" command for each option.

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2728,6 +2728,7 @@ void ex_packadd(exarg_T *eap)
 /// ":options"
 void ex_options(exarg_T *eap)
 {
+  vim_setenv("OPTWIN_CMD", cmdmod.tab ? "tab" : "");
   cmd_source((char_u *)SYS_OPTWIN_FILE, NULL);
 }
 

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -619,7 +619,6 @@ void free_all_mem(void)
 
   /* Obviously named calls. */
   free_all_autocmds();
-  free_all_options();
   free_all_marks();
   alist_clear(&global_alist);
   free_homedir();
@@ -656,6 +655,9 @@ void free_all_mem(void)
 
   /* Destroy all windows.  Must come before freeing buffers. */
   win_free_all();
+
+  // Free all option values.  Must come after closing windows.
+  free_all_options();
 
   free_cmdline_buf();
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -149,7 +149,7 @@ void redraw_later(int type)
 
 void redraw_win_later(win_T *wp, int type)
 {
-  if (wp->w_redr_type < type) {
+  if (!exiting && wp->w_redr_type < type) {
     wp->w_redr_type = type;
     if (type >= NOT_VALID)
       wp->w_lines_valid = 0;


### PR DESCRIPTION
**vim-patch:8.0.0900: :tab options doesn't open a new tab page**

Problem:    :tab options doesn't open a new tab page. (Aviany)
Solution:   Support the :tab modifier. (closes vim/vim#1960)
https://github.com/vim/vim/commit/ab6c8587ba846d08cd70e7b225c4952a468fc1e8

**vim-patch:8.0.1214: accessing freed memory when EXITFREE is set**

Problem:    Accessing freed memory when EXITFREE is set and there is more than
            one tab and window. (Dominique Pelle)
Solution:   Free options later.  Skip redraw when exiting.
vim/vim@4f19828