### PR TITLE
build/doc: generate vimindex.html

### DIFF
--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -13,7 +13,7 @@ HTMLS = $(DOCS:.txt=.html)
 .SUFFIXES: .c .o .txt .html
 
 # Awk version of .txt to .html conversion.
-html: noerrors $(HTMLS)
+html: noerrors vimindex.html $(HTMLS)
 	@if test -f errors.log; then cat errors.log; fi
 
 noerrors:

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -85,7 +85,7 @@ Buffer update events					*api-buffer-updates*
 API clients can "attach" to Nvim buffers to subscribe to buffer update events.
 This is similar to |TextChanged| but more powerful and granular.
 
-Call |nvim_buf_attach| to receive these events on the channel:
+Call |nvim_buf_attach()| to receive these events on the channel:
 
                                                         *nvim_buf_lines_event*
 nvim_buf_lines_event[{buf}, {changedtick}, {firstline}, {lastline}, {linedata}, {more}]
@@ -150,7 +150,7 @@ nvim_buf_detach_event[{buf}]                           *nvim_buf_detach_event*
 
 EXAMPLE ~
 
-Calling |nvim_buf_attach| with send_buffer=true on an empty buffer, emits: >
+Calling |nvim_buf_attach()| with send_buffer=true on an empty buffer, emits: >
   nvim_buf_lines_event[{buf}, {changedtick}, 0, 0, [""], v:false]
 
 User adds two lines to the buffer, emits: >
@@ -189,12 +189,11 @@ Another use case are plugins that show output in an append-only buffer, and
 want to add highlights to the outputs. Highlight data cannot be preserved
 on writing and loading a buffer to file, nor in undo/redo cycles.
 
-Highlights are registered using the |nvim_buf_add_highlight| function, see the
-generated API documentation for details. If an external highlighter plugin is
-adding a large number of highlights in a batch, performance can be improved by
-calling |nvim_buf_add_highlight| as an asynchronous notification, after first
-(synchronously) reqesting a source id. Here is an example using wrapper
-functions in the python client:
+Highlights are registered using the |nvim_buf_add_highlight()| function. If an
+external highlighter plugin wants to add many highlights in a batch,
+performance can be improved by calling |nvim_buf_add_highlight()| as an
+asynchronous notification, after first (synchronously) reqesting a source id.
+Example using the Nvim python-client:
 >
     src = vim.new_highlight_source()
 
@@ -207,10 +206,10 @@ functions in the python client:
     buf.clear_highlight(src)
 <
 If the highlights don't need to be deleted or updated, just pass -1 as
-src_id (this is the default in python). |nvim_buf_clear_highlight| can be used
-to clear highlights from a specific source, in a specific line range or the
-entire buffer by passing in the line range 0, -1 (the latter is the default
-in python as used above).
+src_id (this is the default in python). Use |nvim_buf_clear_highlight()| to
+clear highlights from a specific source, in a specific line range or the
+entire buffer by passing in the line range 0, -1 (the latter is the default in
+python as used above).
 
 An example of calling the api from vimscript: >
 
@@ -655,14 +654,14 @@ nvim_get_chan_info({chan})                              *nvim_get_chan_info()*
                     stderr of this Nvim instance  "socket" TCP/IP socket or
                     named pipe  "job" job with communication over its stdio
 
-                  "mode" how data received on the channel is interpreted   "bytes" send and recieve raw bytes  "terminal" a |terminal| instance interprets ASCII sequences  "rpc" |RPC| communication on the channel is active  "pty" Name of pseudoterminal, if one is used (optional). On a POSIX system, this will be a device path like /dev/pts/1. Even if the name is unknown, the key will still be present to indicate a pty is used. This is currently the case when using winpty on windows.  "buffer" buffer with connected |terminal| instance (optional)  "client" information about the client on the other end of the RPC channel, if it has added it using |nvim_set_client_info|. (optional)
+                  "mode" how data received on the channel is interpreted   "bytes" send and recieve raw bytes  "terminal" a |terminal| instance interprets ASCII sequences  "rpc" |RPC| communication on the channel is active  "pty" Name of pseudoterminal, if one is used (optional). On a POSIX system, this will be a device path like /dev/pts/1. Even if the name is unknown, the key will still be present to indicate a pty is used. This is currently the case when using winpty on windows.  "buffer" buffer with connected |terminal| instance (optional)  "client" information about the client on the other end of the RPC channel, if it has added it using |nvim_set_client_info()|. (optional)
 
 nvim_list_chans()                                          *nvim_list_chans()*
                 Get information about all open channels.
 
                 Return: ~
                     Array of Dictionaries, each describing a channel with the
-                    format specified at |nvim_get_chan_info|.
+                    format specified at |nvim_get_chan_info()|.
 
 nvim_call_atomic({calls})                                 *nvim_call_atomic()*
                 Calls many API methods atomically.

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -4,7 +4,7 @@
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
 
 
-Automatic commands					*autocommand*
+Automatic commands					*autocmd* *autocommand*
 
 For a basic explanation, see section |40.3| in the user manual.
 
@@ -494,14 +494,14 @@ ChanInfo			State of channel changed, for instance the
 				client of a RPC channel described itself.
 				Sets these |v:event| keys:
 				    info
-				See |nvim_get_chan_info| for the format of the
-				info Dictionary.
+				See |nvim_get_chan_info()| for the format of
+				the info Dictionary.
 							*ChanOpen*
 ChanOpen			Just after a channel was opened.
 				Sets these |v:event| keys:
 				    info
-				See |nvim_get_chan_info| for the format of the
-				info Dictionary.
+				See |nvim_get_chan_info()| for the format of
+				the info Dictionary.
 							*CmdUndefined*
 CmdUndefined			When a user command is used but it isn't
 				defined.  Useful for defining a command only

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -4,8 +4,8 @@
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
 
 
-				*Cmdline-mode* *Command-line-mode*
-Command-line mode		*Cmdline* *Command-line* *mode-cmdline* *:*
+				*Cmdline-mode* *Command-line-mode* *Cmdline*
+Command-line mode		*cmdline* *Command-line* *mode-cmdline* *:*
 
 Command-line mode is used to enter Ex commands (":"), search patterns
 ("/" and "?"), and filter commands ("!").

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -5,7 +5,7 @@
 
 
 							*diff* *diff-mode*
-This file describes the |+diff| feature: Showing differences between two to
+This file describes the diff feature: Showing differences between two to
 eight versions of the same file.
 
 The basics are explained in section |08.7| of the user manual.

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1225,9 +1225,6 @@ working directory, which in turn takes precedence over the global
 working directory.  If a local working directory (tab or window) does not
 exist, the next-higher scope in the hierarchy applies.
 
-Commands for changing the working directory can be suffixed with a bang "!"
-(e.g. |:cd!|) which is ignored, for compatibility with Vim.
-
 							*:cd* *E747* *E472*
 :cd[!]			On non-Unix systems: Print the current directory
 			name.  On Unix systems: Change the current directory

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1528,7 +1528,7 @@ v:event		Dictionary of event data for the current |autocommand|.  Valid
 			KEY		DESCRIPTION ~
 			abort		Whether the event triggered during
 					an aborting condition (e.g. |c_Esc| or
-					|c_CTRL-c| for |CmdlineLeave|).
+					|c_CTRL-C| for |CmdlineLeave|).
 			cmdlevel	Level of cmdline.
 			cmdtype		Type of cmdline, |cmdline-char|.
 			cwd		Current working directory.
@@ -3230,8 +3230,7 @@ executable({expr})					*executable()*
 		On Windows it only checks if the file exists and
 		is not a directory, not if it's really executable.
 		On Windows an executable in the same directory as Vim is
-		always found.  Since this directory is added to $PATH it
-		should also work to execute it |win32-PATH|.
+		always found (it is added to $PATH at |startup|).
 		The result is a Number:
 			1	exists
 			0	does not exist
@@ -4809,7 +4808,7 @@ input({opts})
 		where
 			hl_start_col is the first highlighted column,
 			hl_end_col is the last highlighted column (+ 1!),
-			hl_group is |:hl| group used for highlighting.
+			hl_group is |:hi| group used for highlighting.
 					      *E5403* *E5404* *E5405* *E5406*
 		Both hl_start_col and hl_end_col + 1 must point to the start
 		of the multibyte character (highlighting must not break
@@ -5014,7 +5013,7 @@ jobstart({cmd}[, {opts}])				*jobstart()*
 		was used) to send data to stdin and |chanclose()| to close stdio
 		streams without stopping the job explicitly.
 
-		See |job-control| and |rpc|.
+		See |job-control| and |RPC|.
 
 		NOTE: on Windows if {cmd} is a List:
 		  - cmd[0] must be an executable (not a "built-in"). If it is
@@ -5056,7 +5055,7 @@ jobstart({cmd}[, {opts}])				*jobstart()*
 		  - The channel ID on success
 		  - 0 on invalid arguments
 		  - -1 if {cmd}[0] is not executable.
-		See |job-control|, |channels|, and |msgpack-rpc| for more information.
+		See also |job-control|, |channel|, |msgpack-rpc|.
 
 jobstop({id})						*jobstop()*
 		Stop |job-id| {id} by sending SIGTERM to the job process. If
@@ -6390,11 +6389,9 @@ rpcstart({prog}[, {argv}])				   {Nvim} *rpcstart()*
 			:let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
 
 rpcstop({channel})					    {Nvim} *rpcstop()*
-		Deprecated. This function was used to stop a job with |rpc|
-		channel, and additionally closed rpc sockets.  Instead use
-		|jobstop()| to stop any job, and |chanclose|(id, "rpc") to close
-		rpc communication without stopping the job. Use |chanclose|(id)
-		to close any socket.
+		Deprecated. Instead use |jobstop()| to stop any job, and
+		chanclose(id, "rpc") to close RPC communication without
+		stopping the job. Use chanclose(id) to close any socket.
 
 screenattr({row}, {col})					*screenattr()*
 		Like |screenchar()|, but return the attribute.  This is a rather
@@ -8888,9 +8885,6 @@ Also note that if you have two script files, and one calls a function in the
 other and vice versa, before the used function is defined, it won't work.
 Avoid using the autoload functionality at the toplevel.
 
-Hint: If you distribute a bunch of scripts you can pack them together with the
-|vimball| utility.  Also read the user manual |distribute-script|.
-
 ==============================================================================
 6. Curly braces names					*curly-braces-names*
 
@@ -10762,7 +10756,7 @@ Group                              Default link            Colored expression ~
                                                            |expr-entry|
 
 *hl-NvimColon*                       Delimiter               `:` in |dict| literal
-*hl-NvimComma*                       Delimiter               `,` in |dict|/|list|
+*hl-NvimComma*                       Delimiter               `,` in |dict| or |list|
                                                            literal or
                                                            |expr-function|
 *hl-NvimArrow*                       Delimiter               `->` in |lambda|

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -4,7 +4,7 @@
 		  VIM REFERENCE MANUAL    by Paul Moore
 
 
-The Python Interface to Vim				*python* *Python*
+The Python Interface to Vim				*if_pyth* *python* *Python*
 
 See |provider-python| for more information. {Nvim}
 

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -3,7 +3,7 @@
 
 		  VIM REFERENCE MANUAL    by Shugo Maeda
 
-The Ruby Interface to Vim				*ruby* *Ruby*
+The Ruby Interface to Vim				*if_ruby* *ruby* *Ruby*
 
 			*E266* *E267* *E268* *E269* *E270* *E271* *E272* *E273*
 

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -439,7 +439,7 @@ notation	meaning		    equivalent	decimal value(s)	~
 <k0> - <k9>	keypad 0 to 9			*keypad-0* *keypad-9*
 <S-...>		shift-key			*shift* *<S-*
 <C-...>		control-key			*control* *ctrl* *<C-*
-<M-...>		alt-key or meta-key		*META* *meta* *alt* *<M-*
+<M-...>		alt-key or meta-key		*META* *ALT* *<M-*
 <A-...>		same as <M-...>			*<A-*
 <D-...>		command-key or "super" key	*<D-*
 -----------------------------------------------------------------------

--- a/runtime/doc/makehtml.awk
+++ b/runtime/doc/makehtml.awk
@@ -135,11 +135,11 @@ NR == 1 { nf=split(FILENAME,f,".")
 	    # common case - Latin1
 	    print "<META HTTP-EQUIV=\"Content-type\" content=\"text/html; charset=ISO-8859-1\">";
 	}
-	print "<TITLE>Vim documentation: " f[1] "</TITLE>";
+	print "<TITLE>Nvim documentation: " f[1] "</TITLE>";
 	print "</HEAD>";
 
 	print "<BODY BGCOLOR=\"#ffffff\">";
-	print "<H1>Vim documentation: " f[1] "</H1>";
+	print "<H1>Nvim documentation: " f[1] "</H1>";
 	print "<A NAME=\"top\"></A>";
 	if ( FILENAME != "help.txt" ) {
 	  print "<A HREF=\"index.html\">main help file</A>\n";

--- a/runtime/doc/msgpack_rpc.txt
+++ b/runtime/doc/msgpack_rpc.txt
@@ -61,18 +61,15 @@ To get a formatted dump of the API using python (requires the `pyyaml` and
 3. Connecting						      *rpc-connecting*
 
 See |channel-intro|, for various ways to open a channel. Most of the channel
-opening functions take an `rpc` key in the options dictionary, to enable rpc.
+opening functions take an `rpc` key in the options dictionary, to enable RPC.
 
-Additionally, rpc channels can be opened by other processes connecting to
+Additionally, RPC channels can be opened by other processes connecting to
 TCP/IP sockets or named pipes listened to by nvim.
 
-An rpc socket is automatically created with each instance. The socket
- location is stored in |v:servername|. By default this is a named pipe
-with an automatically generated address. See |XXX|.
-
-To make Nvim listen on a TCP/IP socket instead, specify |--listen|: >
+Nvim creates a default RPC socket at |startup|, given by |v:servername|. To
+start with a TCP/IP socket instead, use |--listen| with a TCP-style address: >
     nvim --listen 127.0.0.1:6666
-<Also, more sockets and named pipes can be listened on using |serverstart()|.
+Additional sockets and named pipes can be started with |serverstart()|.
 
 Note that localhost TCP sockets are generally less secure than named pipes,
 and can lead to vunerabilities like remote code execution.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -728,13 +728,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	Vim will guess the value.  In the GUI this should work correctly,
 	in other cases Vim might not be able to guess the right value.
 
-	When the |t_RB| option is set, Vim will use it to request the background
-	color from the terminal.  If the returned RGB value is dark/light and
-	'background' is not dark/light, 'background' will be set and the
-	screen is redrawn.  This may have side effects, make t_BG empty in
-	your .vimrc if you suspect this problem.  The response to |t_RB| can
-	be found in |v:termrbgresp|.
-
 	When starting the GUI, the default value for 'background' will be
 	"light".  When the value is not set in the gvimrc, and Vim detects
 	that the background is actually quite dark, 'background' is set to
@@ -1216,8 +1209,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'channel'*
 'channel'		number (default: 0)
 			local to buffer
-	|Channel| connected to the buffer. Currently only used by
-	|terminal-emulator|. Is 0 if no terminal is open. Cannot be changed.
+	|channel| connected to the buffer, or 0 if no channel is connected.
+	In a |:terminal| buffer this is the terminal channel.
+	Read-only.
 
 				*'charconvert'* *'ccv'* *E202* *E214* *E513*
 'charconvert' 'ccv'	string (default "")
@@ -2041,8 +2035,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			instead of using ^C and ~C.
 	msgsep		When showing messages longer than 'cmdheight', only
 			scroll the message lines, not the entire screen. The
-			separator line is decorated by |MsgSeparator| and the
-			"msgsep" flag of 'fillchars'.
+			separator line is decorated by |hl-MsgSeparator| and
+			the "msgsep" flag of 'fillchars'.
 
 	When neither "lastline" nor "truncate" is included, a last line that
 	doesn't fit is replaced with "@" lines.
@@ -6767,8 +6761,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	syntax highlighting (use |:ownsyntax| for that).
 	
 	Highlights of vertical separators are determined by the window to the
-	left of the separator.  The highlight of a tabpage in |tabline| is
-	determined by the last-focused window of the tabpage.  Highlights of
+	left of the separator.  The 'tabline' highlight of a tabpage is
+	decided by the last-focused window of the tabpage.  Highlights of
 	the popupmenu are determined by the current window.  Highlights in the
 	message area cannot be overridden.
 

--- a/runtime/doc/pi_msgpack.txt
+++ b/runtime/doc/pi_msgpack.txt
@@ -49,7 +49,7 @@ does not check whether argument matches its description.
 
 *{msgpack-value}*	Either |msgpack-special-dict| or a regular value, but 
 			not function reference.
-*{msgpack-integer}*	Any value for which |msgpack#type| will return 
+*{msgpack-integer}*	Any value for which |msgpack#type()| will return 
 			"integer".
 *{msgpack-special-int}*	|msgpack-special-dict| representing integer.
 

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -3719,8 +3719,6 @@ netrw:
 	   or
 	     http://vim.sourceforge.net/scripts/script.php?script_id=120
 
-	  Decho.vim is provided as a "vimball"; see |vimball-intro|.
-
 	2. Edit the <netrw.vim> file by typing: >
 
 		vim netrw.vim

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5189,7 +5189,7 @@ To test your color setup, a file has been included in the Vim distribution.
 To use it, execute this command: >
    :runtime syntax/colortest.vim
 
-Nvim uses |256-color| and |true-color| terminal capabilities whereever possible.
+Nvim uses 256-color and |true-color| terminal capabilities whereever possible.
 
 ==============================================================================
 18. When syntax is slow						*:syntime*

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -18,17 +18,17 @@ the grid ("externalized").
 
 								  *ui-options*
 After connecting to Nvim (usually a spawned, embedded instance) use the
-|nvim_ui_attach| API method to tell Nvim that your program wants to draw the
+|nvim_ui_attach()| API method to tell Nvim that your program wants to draw the
 Nvim screen grid with a size of width × height cells. `options` must be
 a dictionary with these (optional) keys:
-	`rgb`			Decides the color format. |ui-rgb|
+	`rgb`			Decides the color format. *ui-rgb*
 				Set true (default) for 24-bit RGB colors.
 				Set false for terminal colors (max of 256).
 							      *ui-ext-options*
 	`ext_popupmenu`		Externalize the popupmenu. |ui-popupmenu|
 	`ext_tabline`		Externalize the tabline. |ui-tabline|
 	`ext_cmdline`		Externalize the cmdline. |ui-cmdline|
-	`ext_wildmenu`		Externalize the wildmenu. |ui-ext-wildmenu|
+	`ext_wildmenu`		Externalize the wildmenu. |ui-wildmenu|
 	`ext_newgrid`		Use new revision of the grid events. |ui-newgrid|
 	`ext_hlstate`		Use detailed highlight state. |ui-hlstate|
 
@@ -150,7 +150,7 @@ Global Events							    *ui-global*
 	user input. This could be indicated to the user by hiding the cursor.
 
 ["suspend"]
-	|:suspend| command or |Ctrl-Z| mapping is used. A terminal client (or other
+	|:suspend| command or |CTRL-Z| mapping is used. A terminal client (or other
 	client where it makes sense) could suspend itself.  Other clients can
 	safely ignore it.
 
@@ -407,7 +407,7 @@ with the following possible keys:
 	"ui":       A builtin ui highlight.
 	"syntax":   highlight applied to a buffer by a syntax declaration or
 	            other runtime/plugin functionallity such as
-		    |nvim_buf_add_highlight|
+		    |nvim_buf_add_highlight()|
 	"terminal": highlight from a process running in a |terminal-emulator|.
 		    Contains no futher semantic information.
     `ui_name`:	Name of the builtin highlight. See |highlight-groups| for
@@ -417,7 +417,7 @@ with the following possible keys:
     `id`:	Unique numeric id representing this item.
 
 Note: "ui" items will have both `ui_name` and `hi_name` present. These can
-differ, because the builtin group was linked to another group |hi-link| , or
+differ, because the builtin group was linked to another group |:hi-link| , or
 because 'winhighlight' was used. UI items will be transmitted, even if the
 highlight group is cleared, so `ui_name` can always be used to reliably identify
 screen elements, even if no attributes have been applied.
@@ -480,7 +480,7 @@ Only sent if `ext_cmdline` option is set in |ui-options|
 	typing `<c-r>=` at the command line prompt. The `level` field is used
 	to distinguish different command lines active at the same time. The
 	first invoked command line has level 1, the next recursively-invoked
-	prompt has level 2. A command line invoked from the |cmd-line-window|
+	prompt has level 2. A command line invoked from the |cmdline-window|
 	has a higher level than than the edited command line.
 
 ["cmdline_pos", pos, level]

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -323,8 +323,6 @@ Where can you find plugins?
 - They are sometimes posted in a Vim |maillist|.
 - You could write one yourself, see |write-plugin|.
 
-Some plugins come as a vimball archive, see |vimball|.
-
 
 USING A GLOBAL PLUGIN
 

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -2506,9 +2506,6 @@ Vim scripts can be used on any system.  There might not be a tar or gzip
 command.  If you want to pack files together and/or compress them the "zip"
 utility is recommended.
 
-For utmost portability use Vim itself to pack scripts together.  This can be
-done with the Vimball utility.  See |vimball|.
-
 ==============================================================================
 
 Next chapter: |usr_42.txt|  Add new menus

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -388,7 +388,6 @@ m  *+writebackup*	|'writebackup'| is default on
 m  *+xim*		X input method |xim|
    *+xfontset*		X fontset support |xfontset|
    *+xpm*		pixmap support
-m  *+xpm_w32*		Win32 GUI only: pixmap support |w32-xpm-support|
 
 							*/dyn* *E370* *E448*
 			To some of the features "/dyn" is added when the

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -322,7 +322,7 @@ Scripts and Expressions.				|expression|
 	Debugging and profiling are supported. |debug-scripts| |profile|
 	If this is not enough, an interface is provided to |Python|.
 
-Viminfo.						|viminfo-file|
+Viminfo.
 	The command-line history, marks and registers can be stored in a file
 	that is read on startup.  This can be used to repeat a search command
 	or command-line command after exiting and restarting Vim.  It is also

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -111,7 +111,7 @@ ARCHITECTURE ~
 
 External plugins run in separate processes. |remote-plugin| This improves
 stability and allows those plugins to work without blocking the editor. Even
-"legacy" Python and Ruby plugins which use the old Vim interfaces (|if_py| and
+"legacy" Python and Ruby plugins which use the old Vim interfaces (|if_pyth|,
 |if_ruby|) run out-of-process.
 
 Platform and I/O facilities are built upon libuv. Nvim benefits from libuv
@@ -182,7 +182,7 @@ Options:
   'display' flag `msgsep` to minimize scrolling when showing messages
   'guicursor' works in the terminal
   'fillchars' flags: `msgsep` (see 'display' above)
-	      and `eob` for |EndOfBuffer| marker
+	      and `eob` for |hl-EndOfBuffer| marker
   'inccommand' shows interactive results for |:substitute|-like commands
   'scrollback'
   'statusline' supports unlimited alignment sections
@@ -245,7 +245,7 @@ makes things faster. |:terminal| output is never throttled.
 4. Stringifyed infinite and NaN values now use |str2float()| and can be evaled
    back.
 5. (internal) Trying to print or stringify VAR_UNKNOWN in Vim results in 
-   nothing, |E908|, in Neovim it is internal error.
+   nothing, E908, in Nvim it is internal error.
 
 |json_decode()| behaviour changed:
 1. It may output |msgpack-special-dict|.
@@ -287,12 +287,11 @@ coerced to strings. See |id()| for more details, currently it uses
 
 Lua interface (|if_lua.txt|):
 
-- `:lua print("a\0b")` will print `a^@b`, like with `:echomsg "a\nb"` . In Vim 
+- `:lua print("a\0b")` will print `a^@b`, like with `:echomsg "a\nb"` . In Vim
   that prints `a` and `b` on separate lines, exactly like
   `:lua print("a\nb")` .
-- `:lua error('TEST')` will print “TEST” as the error in Vim and “E5105: Error 
-  while calling lua chunk: [string "<VimL compiled string>"]:1: TEST” in 
-  Neovim.
+- `:lua error('TEST')` emits the error “E5105: Error while calling lua chunk:
+  [string "<VimL compiled string>"]:1: TEST”, whereas Vim emits only “TEST”.
 - Lua has direct access to Nvim |API| via `vim.api`.
 - Lua package.path and package.cpath are automatically updated according to
   'runtimepath': |lua-require|.
@@ -347,7 +346,7 @@ TUI:
   only 8 colours plus bright foreground on Linux VTs.
 
   Vim combines what is in its |builtin-terms| with what it reads from terminfo,
-  and has a |ttybuiltin| setting to control how that combination works.  Nvim
+  and has a 'ttybuiltin' setting to control how that combination works.  Nvim
   uses one or the other, it does not attempt to merge the two.
 
 VimL (Vim script) compatibility:

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -70,10 +70,7 @@ position.
 			selected.
 
 						*CTRL-V* *blockwise-visual*
-[count]CTRL-V		Start Visual mode blockwise.  Note: Under Windows
-			CTRL-V could be mapped to paste text, it doesn't work
-			to start Visual mode then, see |CTRL-V-alternative|.
-			[count] is used as with `v` above.
+[count]CTRL-V		Start Visual mode blockwise.
 
 If you use <Esc>, click the left mouse button or use any command that
 does a jump to another buffer while in Visual mode, the highlighting stops

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1083,7 +1083,7 @@ void nvim_set_client_info(uint64_t channel_id, String name,
 ///    -  "buffer"  buffer with connected |terminal| instance (optional)
 ///    -  "client"  information about the client on the other end of the
 ///                 RPC channel, if it has added it using
-///                 |nvim_set_client_info|. (optional)
+///                 |nvim_set_client_info()|. (optional)
 ///
 Dictionary nvim_get_chan_info(Integer chan, Error *err)
   FUNC_API_SINCE(4)
@@ -1097,7 +1097,7 @@ Dictionary nvim_get_chan_info(Integer chan, Error *err)
 /// Get information about all open channels.
 ///
 /// @returns Array of Dictionaries, each describing a channel with
-///          the format specified at |nvim_get_chan_info|.
+///          the format specified at |nvim_get_chan_info()|.
 Array nvim_list_chans(void)
   FUNC_API_SINCE(4)
 {


### PR DESCRIPTION
This note in runtime/doc/Makefile explains the special-case:

    index.html is the starting point for HTML, but for the help files it
    is help.txt.  Therefore use vimindex.html for index.txt.

- fix #8907
- fix broken links reported by `make html`