### PR TITLE
[RDY] vim-patch:8.1.0327

### DIFF
--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -1830,11 +1830,6 @@ fun! Test_normal33_g_cmd2()
   call assert_equal(15, col('.'))
   call assert_equal('l', getreg(0))
 
-  " Test for g Ctrl-G
-  set ff=unix
-  let a=execute(":norm! g\<c-g>")
-  call assert_match('Col 15 of 43; Line 2 of 2; Word 2 of 2; Byte 16 of 45', a)
-
   " Test for gI
   norm! gIfoo
   call assert_equal(['', 'fooabcdefghijk   lmno0123456789AMNOPQRSTUVWXYZ'], getline(1,'$'))
@@ -1851,6 +1846,81 @@ fun! Test_normal33_g_cmd2()
 
   " clean up
   bw!
+endfunc
+
+func! Test_g_ctrl_g()
+  new
+
+  let a = execute(":norm! g\<c-g>")
+  call assert_equal("\n--No lines in buffer--", a)
+
+  call setline(1, ['first line', 'second line'])
+
+  " Test g CTRL-g with dos, mac and unix file type.
+  norm! gojll
+  set ff=dos
+  let a = execute(":norm! g\<c-g>")
+  call assert_equal("\nCol 3 of 11; Line 2 of 2; Word 3 of 4; Byte 15 of 25", a)
+
+  set ff=mac
+  let a = execute(":norm! g\<c-g>")
+  call assert_equal("\nCol 3 of 11; Line 2 of 2; Word 3 of 4; Byte 14 of 23", a)
+
+  set ff=unix
+  let a = execute(":norm! g\<c-g>")
+  call assert_equal("\nCol 3 of 11; Line 2 of 2; Word 3 of 4; Byte 14 of 23", a)
+
+  " Test g CTRL-g in visual mode (v)
+  let a = execute(":norm! gojllvlg\<c-g>")
+  call assert_equal("\nSelected 1 of 2 Lines; 1 of 4 Words; 2 of 23 Bytes", a)
+
+  " Test g CTRL-g in visual mode (CTRL-V) with end col > start col
+  let a = execute(":norm! \<Esc>gojll\<C-V>kllg\<c-g>")
+  call assert_equal("\nSelected 3 Cols; 2 of 2 Lines; 2 of 4 Words; 6 of 23 Bytes", a)
+
+  " Test g_CTRL-g in visual mode (CTRL-V) with end col < start col
+  let a = execute(":norm! \<Esc>goll\<C-V>jhhg\<c-g>")
+  call assert_equal("\nSelected 3 Cols; 2 of 2 Lines; 2 of 4 Words; 6 of 23 Bytes", a)
+
+  " Test g CTRL-g in visual mode (CTRL-V) with end_vcol being MAXCOL
+  let a = execute(":norm! \<Esc>gojll\<C-V>k$g\<c-g>")
+  call assert_equal("\nSelected 2 of 2 Lines; 4 of 4 Words; 17 of 23 Bytes", a)
+
+  " There should be one byte less with noeol
+  set bin noeol
+  let a = execute(":norm! \<Esc>gog\<c-g>")
+  call assert_equal("\nCol 1 of 10; Line 1 of 2; Word 1 of 4; Char 1 of 23; Byte 1 of 22", a)
+  set bin & eol&
+
+  if has('multi_byte')
+    call setline(1, ['Français', '日本語'])
+
+    let a = execute(":norm! \<Esc>gojlg\<c-g>")
+    call assert_equal("\nCol 4-3 of 9-6; Line 2 of 2; Word 2 of 2; Char 11 of 13; Byte 16 of 20", a)
+
+    let a = execute(":norm! \<Esc>gojvlg\<c-g>")
+    call assert_equal("\nSelected 1 of 2 Lines; 1 of 2 Words; 2 of 13 Chars; 6 of 20 Bytes", a)
+
+    let a = execute(":norm! \<Esc>goll\<c-v>jlg\<c-g>")
+    call assert_equal("\nSelected 4 Cols; 2 of 2 Lines; 2 of 2 Words; 6 of 13 Chars; 11 of 20 Bytes", a)
+
+    set fenc=utf8 bomb
+    let a = execute(":norm! \<Esc>gojlg\<c-g>")
+    call assert_equal("\nCol 4-3 of 9-6; Line 2 of 2; Word 2 of 2; Char 11 of 13; Byte 16 of 20(+3 for BOM)", a)
+
+    set fenc=utf16 bomb
+    let a = execute(":norm! g\<c-g>")
+    call assert_equal("\nCol 4-3 of 9-6; Line 2 of 2; Word 2 of 2; Char 11 of 13; Byte 16 of 20(+2 for BOM)", a)
+
+    set fenc=utf32 bomb
+    let a = execute(":norm! g\<c-g>")
+    call assert_equal("\nCol 4-3 of 9-6; Line 2 of 2; Word 2 of 2; Char 11 of 13; Byte 16 of 20(+4 for BOM)", a)
+
+    set fenc& bomb&
+  endif
+
+  set ff&
+  bwipe!
 endfunc
 
 fun! Test_normal34_g_cmd3()


### PR DESCRIPTION
**vim-patch:8.1.0327: the "g CTRL-G" command isn't tested much**

Problem:    The "g CTRL-G" command isn't tested much.
Solution:   Add more tests. (Dominique Pelle, closes vim/vim#3369)
https://github.com/vim/vim/commit/0529583ff144e2cb8fb57fe61a86997310bd7727