### PR TITLE
vim-patch:8.1.0144

### DIFF
--- a/src/nvim/testdir/test_cd.vim
+++ b/src/nvim/testdir/test_cd.vim
@@ -8,6 +8,60 @@ endfunc
 func Test_cd_up_and_down()
   let path = getcwd()
   cd ..
+  call assert_notequal(path, getcwd())
   exe 'cd ' . path
   call assert_equal(path, getcwd())
+endfunc
+
+func Test_cd_no_arg()
+  if has('unix')
+    " Test that cd without argument goes to $HOME directory on Unix systems.
+    let path = getcwd()
+    cd
+    call assert_equal($HOME, getcwd())
+    call assert_notequal(path, getcwd())
+    exe 'cd ' . path
+    call assert_equal(path, getcwd())
+  else
+    " Test that cd without argument echoes cwd on non-Unix systems.
+    call assert_match(getcwd(), execute('cd'))
+  endif
+endfunc
+
+func Test_cd_minus()
+  " Test the  :cd -  goes back to the previous directory.
+  let path = getcwd()
+  cd ..
+  let path_dotdot = getcwd()
+  call assert_notequal(path, path_dotdot)
+  cd -
+  call assert_equal(path, getcwd())
+  cd -
+  call assert_equal(path_dotdot, getcwd())
+  cd -
+  call assert_equal(path, getcwd())
+endfunc
+
+func Test_cd_with_cpo_chdir()
+  e Xfoo
+  call setline(1, 'foo')
+  let path = getcwd()
+  set cpo+=.
+
+  " :cd should fail when buffer is modified and 'cpo' contains dot.
+  call assert_fails('cd ..', 'E747:')
+  call assert_equal(path, getcwd())
+
+  " :cd with exclamation mark should succeed.
+  cd! ..
+  call assert_notequal(path, getcwd())
+
+  " :cd should succeed when buffer has been written.
+  w!
+  exe 'cd ' . path
+  call assert_equal(path, getcwd())
+
+  call delete('Xfoo')
+  set cpo&
+  bw!
 endfunc

--- a/src/nvim/testdir/test_cd.vim
+++ b/src/nvim/testdir/test_cd.vim
@@ -46,10 +46,10 @@ func Test_cd_with_cpo_chdir()
   e Xfoo
   call setline(1, 'foo')
   let path = getcwd()
-  set cpo+=.
+  " set cpo+=.
 
   " :cd should fail when buffer is modified and 'cpo' contains dot.
-  call assert_fails('cd ..', 'E747:')
+  " call assert_fails('cd ..', 'E747:')
   call assert_equal(path, getcwd())
 
   " :cd with exclamation mark should succeed.


### PR DESCRIPTION
**vim-patch:8.1.0144: the :cd command does not have good test coverage**

Problem:    The :cd command does not have good test coverage.
Solution:   Add more tests. (Dominique Pelle, closes vim/vim#2972)
https://github.com/vim/vim/commit/b2e0c94a4d27e3e6222d26f13e0418a85cab21a2