### PR TITLE
[WIP] CI/Travis: increase log-level to WARN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
                    -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PREFIX
                    -DBUSTED_OUTPUT_TYPE=nvim
                    -DDEPS_PREFIX=$DEPS_BUILD_DIR/usr
-                   -DMIN_LOG_LEVEL=3"
+                   -DMIN_LOG_LEVEL=2"
     - DEPS_CMAKE_FLAGS="-DDEPS_DOWNLOAD_DIR:PATH=$DEPS_DOWNLOAD_DIR"
     # Additional CMake flags for 32-bit builds.
     - CMAKE_FLAGS_32BIT="-DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32


### PR DESCRIPTION
INFO is too noisy for CI (and causes real slowdown on macOS),
but WARN is useful for tests and should not be too frequent.

---

currently this causes a lot of noise (likely because the test harness disconnects instead of explicitly telling Nvim to exit):

```

WARN  2018-08-26T15:41:18.010 35261 call_set_error:598: RPC: ch 1 was closed by the client
WARN  2018-08-26T15:41:18.117 35270 call_set_error:598: RPC: ch 1 was closed by the client
WARN  2018-08-26T15:41:18.289 35274 call_set_error:598: RPC: ch 1 was closed by the client
...
```