### PR TITLE
[RDY] vim-patch:8.1.0322

### DIFF
--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -338,6 +338,8 @@ func Test_copy_winopt()
   bnext
   call assert_equal(4,&numberwidth)
   bw!
+
+  set hidden&
 endfunc
 
 func Test_shortmess_F()


### PR DESCRIPTION
**vim-patch:8.1.0322: Test_copy_winopt() does not restore 'hidden'**

Problem:    Test_copy_winopt() does not restore 'hidden'.
Solution:   Restore the option, fix indent. (Ozaki Kiichi, closes vim/vim#3367)
https://github.com/vim/vim/commit/7cb33a14c943c0b87dc61c1da438a443f8a43782