### PR TITLE
Fix incorrect highlighting of after-EOL matches under the cursor.

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3916,14 +3916,6 @@ win_line (
      * At end of the text line.
      */
     if (c == NUL) {
-      if (eol_hl_off > 0 && vcol - eol_hl_off == (long)wp->w_virtcol
-          && lnum == wp->w_cursor.lnum) {
-        /* highlight last char after line */
-        --col;
-        --off;
-        --vcol;
-      }
-
       /* Highlight 'cursorcolumn' & 'colorcolumn' past end of the line. */
       if (wp->w_p_wrap)
         v = wp->w_skipcol;

--- a/src/nvim/testdir/test_hlsearch.vim
+++ b/src/nvim/testdir/test_hlsearch.vim
@@ -4,7 +4,6 @@ function! Test_hlsearch()
   new
   call setline(1, repeat(['aaa'], 10))
   set hlsearch nolazyredraw
-  let r=[]
   " redraw is needed to make hlsearch highlight the matches
   exe "normal! /aaa\<CR>" | redraw
   let r1 = screenattr(1, 1)
@@ -32,3 +31,16 @@ function! Test_hlsearch()
   call getchar(1)
   enew!
 endfunction
+
+func Test_hlsearch_eol_highlight()
+  new
+  call append(1, repeat([''], 9))
+  set hlsearch nolazyredraw
+  exe "normal! /$\<CR>" | redraw
+  let attr = screenattr(1, 1)
+  for row in range(2, 10)
+    call assert_equal(attr, screenattr(row, 1), 'in line ' . row)
+  endfor
+  set nohlsearch
+  bwipe!
+endfunc

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -93,6 +93,59 @@ describe('search highlighting', function()
     ]])
   end)
 
+  it('highlights after EOL', function()
+    insert("\n\n\n\n\n\n")
+
+    feed("gg/^<cr>")
+    screen:expect([[
+      {2: }                                       |
+      {2:^ }                                       |
+      {2: }                                       |
+      {2: }                                       |
+      {2: }                                       |
+      {2: }                                       |
+      /^                                      |
+    ]])
+
+    -- Test that highlights are preserved after moving the cursor.
+    feed("j")
+    screen:expect([[
+      {2: }                                       |
+      {2: }                                       |
+      {2:^ }                                       |
+      {2: }                                       |
+      {2: }                                       |
+      {2: }                                       |
+      /^                                      |
+    ]])
+
+    -- Repeat the test in rightleft mode.
+    feed_command("nohlsearch")
+    feed_command("set rightleft")
+    feed("gg/^<cr>")
+
+    screen:expect([[
+                                             {2: }|
+                                             {2:^ }|
+                                             {2: }|
+                                             {2: }|
+                                             {2: }|
+                                             {2: }|
+      ^/                                      |
+    ]])
+
+    feed("j")
+    screen:expect([[
+                                             {2: }|
+                                             {2: }|
+                                             {2:^ }|
+                                             {2: }|
+                                             {2: }|
+                                             {2: }|
+      ^/                                      |
+    ]])
+  end)
+
   it('is preserved during :terminal activity', function()
     if iswin() then
       feed([[:terminal for /L \%I in (1,1,5000) do @(echo xxx & echo xxx & echo xxx)<cr>]])


### PR DESCRIPTION
To reproduce this issue:

1) nvim -u NONE
2) Insert a couple of empty new lines
2) Search for either ^ or $.
3) Move the cursor away from its current row

Observe that the cell that the cursor moved out of is not highlighted.
 