### PR TITLE
[RFC] vim-patch:8.0.1001

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1774,7 +1774,7 @@ return {
       gettext=true,
       vi_def=true,
       varname='p_header',
-      defaults={if_true={vi=N_("%<%f%h%m%=Page %N")}}
+      defaults={if_true={vi="%<%f%h%m%=Page %N"}}
     },
     {
       full_name='printmbcharset', abbreviation='pmbcs',


### PR DESCRIPTION
**vim-patch:8.0.1001: setting 'encoding' makes 'printheader' invalid**

Problem:    Setting 'encoding' makes 'printheader' invalid.
Solution:   Do not translate the default value of 'printheader'. (Yasuhiro
            Matsumoto, closes vim/vim#2026)
https://github.com/vim/vim/commit/0903d56f5ca69bb1fa0bbb00ed2a3d9c4d06ddb4

Encoding is no-op for Neovim but why is `printheader` translatable to begin with? User can override it.