### PR TITLE
vim-patch:8.1.0214

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10609,6 +10609,9 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 #ifdef HAVE_ACL
     "acl",
 #endif
+#ifdef FEAT_AUTOCHDIR
+    "autochdir",
+#endif
     "arabic",
     "autocmd",
     "browsefilter",


### PR DESCRIPTION
Problem:    +autochdir feature not reported by has() or :version.
Solution:   Add the feature in the list.
Author:     Bram Moolenaar <Bram@vim.org>

https://github.com/vim/vim/commit/83ec2a7f5fb481b30a5d556b6aad49a62585bccd