### PR TITLE
options: do not use gettext for +printheader

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1771,7 +1771,6 @@ return {
     {
       full_name='printheader', abbreviation='pheader',
       type='string', scope={'global'},
-      gettext=true,
       vi_def=true,
       varname='p_header',
       defaults={if_true={vi="%<%f%h%m%=Page %N"}}


### PR DESCRIPTION
Follow-up for https://github.com/neovim/neovim/commit/10e885bdfc42322dee3312b4373dc8f6653d2412

Are `N_()` and `gettext` still needed for `options.lua`?