### PR TITLE
[RDY] vim-patch:8.0.0983

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1279,7 +1279,7 @@ bool check_changed(buf_T *buf, int flags)
 ///
 /// @param buf
 /// @param checkall may abandon all changed buffers
-void dialog_changed(buf_T *buf, int checkall)
+void dialog_changed(buf_T *buf, bool checkall)
 {
   char_u buff[DIALOG_MSG_SIZE];
   int ret;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1285,9 +1285,8 @@ void dialog_changed(buf_T *buf, int checkall)
   int ret;
   exarg_T ea;
 
-  dialog_msg(buff, _("Save changes to \"%s\"?"),
-             (buf->b_fname != NULL) ?
-             buf->b_fname : (char_u *)_("Untitled"));
+  assert(buf->b_fname != NULL);
+  dialog_msg(buff, _("Save changes to \"%s\"?"), buf->b_fname);
   if (checkall) {
     ret = vim_dialog_yesnoallcancel(VIM_QUESTION, NULL, buff, 1);
   } else {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2883,7 +2883,7 @@ close_others (
     if (!r) {
       if (message && (p_confirm || cmdmod.confirm) && p_write) {
         dialog_changed(wp->w_buffer, false);
-        if (!win_valid(wp)) {                 /* autocommands messed wp up */
+        if (!win_valid(wp)) {                 // autocommands messed wp up
           nextwp = firstwin;
           continue;
         }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2882,7 +2882,7 @@ close_others (
     }
     if (!r) {
       if (message && (p_confirm || cmdmod.confirm) && p_write) {
-        dialog_changed(wp->w_buffer, FALSE);
+        dialog_changed(wp->w_buffer, false);
         if (!win_valid(wp)) {                 /* autocommands messed wp up */
           nextwp = firstwin;
           continue;


### PR DESCRIPTION
**vim-patch:8.0.0983: unnecessary check for NULL pointer**

Problem:    Unnecessary check for NULL pointer.
Solution:   Remove the NULL check in dialog_changed(), it already happens in
            dialog_msg(). (Ken Takata)
https://github.com/vim/vim/commit/3f9a1ff141412e9e85f7dff47d02946cb9be9228

I added an assertion because of the assumption in the commit message for this vim-patch.