### PR TITLE
vim-patch:8.1.0022

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11235,7 +11235,7 @@ void get_user_input(const typval_T *const argvars,
     }
   }
 
-  int cmd_silent_save = cmd_silent;
+  const bool cmd_silent_save = cmd_silent;
 
   cmd_silent = false;  // Want to see the prompt.
   // Only the part of the message after the last NL is considered as

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -123,7 +123,7 @@ void do_debug(char_u *cmd)
   int save_msg_scroll = msg_scroll;
   int save_State = State;
   int save_did_emsg = did_emsg;
-  int save_cmd_silent = cmd_silent;
+  const bool save_cmd_silent = cmd_silent;
   int save_msg_silent = msg_silent;
   int save_emsg_silent = emsg_silent;
   int save_redir_off = redir_off;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -755,6 +755,13 @@ int start_redo(long count, int old_redo)
     if (c >= '1' && c < '9')
       ++c;
     add_char_buff(&readbuf2, c);
+
+    // the expression register should be re-evaluated
+    if (c == '=') {
+      add_char_buff(&readbuf2, CAR);
+      cmd_silent = true;
+    }
+
     c = read_redo(FALSE, old_redo);
   }
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -448,7 +448,7 @@ void flush_buffers(int flush_typeahead)
   }
   typebuf.tb_maplen = 0;
   typebuf.tb_silent = 0;
-  cmd_silent = FALSE;
+  cmd_silent = false;
   typebuf.tb_no_abbr_cnt = 0;
 }
 
@@ -959,7 +959,7 @@ int ins_typebuf(char_u *str, int noremap, int offset, int nottyped, bool silent)
     typebuf.tb_maplen += addlen;
   if (silent || typebuf.tb_silent > offset) {
     typebuf.tb_silent += addlen;
-    cmd_silent = TRUE;
+    cmd_silent = true;
   }
   if (typebuf.tb_no_abbr_cnt && offset == 0)    /* and not used for abbrev.s */
     typebuf.tb_no_abbr_cnt += addlen;
@@ -1723,7 +1723,7 @@ static int vgetorpeek(int advance)
             *typebuf.tb_buf = (char_u)c;
             gotchars(typebuf.tb_buf, 1);
           }
-          cmd_silent = FALSE;
+          cmd_silent = false;
 
           break;
         } else if (typebuf.tb_len > 0) {

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -751,7 +751,7 @@ EXTERN cmdmod_T cmdmod;                 /* Ex command modifiers */
 EXTERN int msg_silent INIT(= 0);         // don't print messages
 EXTERN int emsg_silent INIT(= 0);        // don't print error messages
 EXTERN bool emsg_noredir INIT(= false);  // don't redirect error messages
-EXTERN int cmd_silent INIT(= false);     // don't echo the command line
+EXTERN bool cmd_silent INIT(= false);    // don't echo the command line
 
 /* Values for swap_exists_action: what to do when swap file already exists */
 #define SEA_NONE        0       /* don't use dialog */

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -541,7 +541,7 @@ int emsg(const char_u *s_)
 
     // Reset msg_silent, an error causes messages to be switched back on.
     msg_silent = 0;
-    cmd_silent = FALSE;
+    cmd_silent = false;
 
     if (global_busy) {        // break :global command
       global_busy++;

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -34,3 +34,16 @@ func Test_put_char_block2()
   bw!
   call setreg('a', a[0], a[1])
 endfunc
+
+func Test_put_expr()
+  new
+  call setline(1, repeat(['A'], 6))
+  exec "1norm! \"=line('.')\<cr>p"
+  norm! j0.
+  norm! j0.
+  exec "4norm! \"=\<cr>P"
+  norm! j0.
+  norm! j0.
+  call assert_equal(['A1','A2','A3','4A','5A','6A'], getline(1,'$'))
+  bw!
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0022: repeating put from expression register fails**

Problem:    Repeating put from expression register fails.
Solution:   Re-evaluate the expression register. (Andy Massimino,
            closes vim/vim#2945)
https://github.com/vim/vim/commit/833093bfb0e4a7f89b5adc66babcfa8ac09cfda9