### PR TITLE
strings.c, encode.c: avoid clang warning

### DIFF
--- a/src/nvim/eval/encode.c
+++ b/src/nvim/eval/encode.c
@@ -327,7 +327,7 @@ int encode_read_from_list(ListReaderState *const state, char *const buf,
 #define TYPVAL_ENCODE_CONV_FLOAT(tv, flt) \
     do { \
       const float_T flt_ = (flt); \
-      switch (fpclassify(flt_)) { \
+      switch (fpclassify((float)flt_)) { \
         case FP_NAN: { \
           ga_concat(gap, (char_u *) "str2float('nan')"); \
           break; \
@@ -531,7 +531,7 @@ int encode_read_from_list(ListReaderState *const state, char *const buf,
 #define TYPVAL_ENCODE_CONV_FLOAT(tv, flt) \
     do { \
       const float_T flt_ = (flt); \
-      switch (fpclassify(flt_)) { \
+      switch (fpclassify((float)flt_)) { \
         case FP_NAN: { \
           EMSG(_("E474: Unable to represent NaN value in JSON")); \
           return FAIL; \

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -1204,14 +1204,14 @@ int vim_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap,
               remove_trailing_zeroes = true;
             }
 
-            if (isinf(f)
+            if (isinf((float)f)
                 || (strchr("fF", fmt_spec) != NULL && abs_f > 1.0e307)) {
               xstrlcpy(tmp, infinity_str(f > 0.0, fmt_spec,
                                          force_sign, space_for_positive),
                        sizeof(tmp));
               str_arg_l = strlen(tmp);
               zero_padding = 0;
-            } else if (isnan(f)) {
+            } else if (isnan((float)f)) {
               // Not a number: nan or NAN
               memmove(tmp, ASCII_ISUPPER(fmt_spec) ? "NAN" : "nan", 4);
               str_arg_l = 3;


### PR DESCRIPTION
~~Narrowing conversion should be OK for purposes of isinf() and fpclassify(). I think?~~

Avoids warning on clang 5.0.0-3~16.04.1, ubuntu 18.04.1:

    In file included from ../src/nvim/eval/encode.c:762:
    ../src/nvim/eval/typval_encode.c.h:330:7: warning: implicit
    conversion loses floating-point precision: 'const float_T' (aka
    'const double') to 'float' [-Wco
    nversion]
          TYPVAL_ENCODE_CONV_FLOAT(tv, tv->vval.v_float);
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ../src/nvim/eval/encode.c:534:26: note: expanded from macro 'TYPVAL_ENCODE_CONV_FLOAT'
          switch (fpclassify(flt_)) { \
                  ~~~~~~~~~~~^~~~~
    /usr/include/math.h:604:56: note: expanded from macro 'fpclassify'
    ...

failure on 64-bit:

```
Executed 309 tests
1 FAILED:
Found errors in Test_str2float():
function RunTheTest[35]..Test_str2float line 6: Expected '1.0e40' but got 'str2float(''inf'')'
SKIPPED Test_isnan(): Nvim does not support isnan()
SKIPPED Test_tag_file_encoding(): Nvim removed test83-tags2, test83-tags3
```

failure on 32-bit:

```
[1m[35m[  FAILED  ][0m[0m [36m...ovim/neovim/test/functional/eval/json_functions_spec.lua[0m @ [36m547[0m: [1mjson_encode() function dumps floats[0m
...ovim/neovim/test/functional/eval/json_functions_spec.lua:552: Expected objects to be the same.
Passed in:
(nil)
Expected:
(string) '1.0e50'

stack traceback:
	...ovim/neovim/test/functional/eval/json_functions_spec.lua:552: in function <...ovim/neovim/test/functional/eval/json_functions_spec.lua:547>

[1m[31m[  ERROR   ][0m[0m [1m3[0m errors, listed below:
[1m[31m[  ERROR   ][0m[0m [36mtest/functional/helpers.lua[0m @ [36m745[0m: [1mafter_each[0m
test/helpers.lua:148: assertion failed!

stack traceback:
	test/helpers.lua:148: in function 'check_logs'
	test/functional/helpers.lua:749: in function <test/functional/helpers.lua:745>

[1m[31m[  ERROR   ][0m[0m [36m...functional/legacy/065_float_and_logic_operators_spec.lua[0m @ [36m10[0m: [1mfloating point and logical operators is working[0m
test/functional/helpers.lua:473: bad argument #1 to 'curbuf_contents' (table expected, got nil)

stack traceback:
	test/functional/helpers.lua:473: in function 'expect'
	...functional/legacy/065_float_and_logic_operators_spec.lua:100: in function <...functional/legacy/065_float_and_logic_operators_spec.lua:10>

[1m[31m[  ERROR   ][0m[0m [36mtest/functional/helpers.lua[0m @ [36m745[0m: [1mafter_each[0m
test/helpers.lua:148: assertion failed!

stack traceback:
	test/helpers.lua:148: in function 'check_logs'
	test/functional/helpers.lua:749: in function <test/functional/helpers.lua:745>
```