### PR TITLE
document `ttimeoutlen` default difference from vim

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -55,6 +55,7 @@ a complete and centralized reference of those differences.
 - 'smarttab' is set by default
 - 'tabpagemax' defaults to 50
 - 'tags' defaults to "./tags;,tags"
+- 'ttimeoutlen' defaults to 50
 - 'ttyfast' is always set
 - 'undodir' defaults to ~/.local/share/nvim/undo (|xdg|), auto-created
 - 'viminfo' includes "!"


### PR DESCRIPTION
I didn't see this difference mentioned in the `vim-differences` section. There is a bit about how the "behavior was simplified" but it doesn't say what the default `ttimeoutlen` actually is, or that it differs from Vim's default (1000).