### PR TITLE
[RFC] vim-patch:8.1.0{331,333,335,336}

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9239,6 +9239,18 @@ static int ses_do_win(win_T *wp)
   return true;
 }
 
+static int put_view_curpos(FILE *fd, const win_T *wp, char *spaces)
+{
+  int r;
+
+  if (wp->w_curswant == MAXCOL) {
+    r = fprintf(fd, "%snormal! $", spaces);
+  } else {
+    r = fprintf(fd, "%snormal! 0%d|", spaces, wp->w_virtcol + 1);
+  }
+  return r < 0 || put_eol(fd) == FAIL ? FAIL : OK;
+}
+
 /*
  * Write commands to "fd" to restore the view of a window.
  * Caller must make sure 'scrolloff' is zero.
@@ -9405,14 +9417,11 @@ put_view(
                 (int64_t)(wp->w_virtcol + 1)) < 0
             || put_eol(fd) == FAIL
             || put_line(fd, "else") == FAIL
-            || fprintf(fd, "  normal! 0%d|", wp->w_virtcol + 1) < 0
-            || put_eol(fd) == FAIL
+            || put_view_curpos(fd, wp, "  ") == FAIL
             || put_line(fd, "endif") == FAIL)
           return FAIL;
-      } else {
-        if (fprintf(fd, "normal! 0%d|", wp->w_virtcol + 1) < 0
-            || put_eol(fd) == FAIL)
-          return FAIL;
+      } else if (put_view_curpos(fd, wp, "") == FAIL) {
+        return FAIL;
       }
     }
   }

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -161,7 +161,7 @@ func Test_mkview_file()
   help :mkview
   set number
   norm! V}zf0
-  let pos = getcurpos()
+  let pos = getpos('.')
   let linefoldclosed1 = foldclosed('.')
   mkview! Xview
   set nonumber
@@ -173,7 +173,7 @@ func Test_mkview_file()
   source Xview
   call assert_equal(1, &number)
   call assert_match('\*:mkview\*$', getline('.'))
-  call assert_equal(pos, getcurpos())
+  call assert_equal(pos, getpos('.'))
   call assert_equal(linefoldclosed1, foldclosed('.'))
 
   " Creating a view again with the same file name should fail (file
@@ -196,7 +196,7 @@ func Test_mkview_loadview_with_viewdir()
   help :mkview
   set number
   norm! V}zf
-  let pos = getcurpos()
+  let pos = getpos('.')
   let linefoldclosed1 = foldclosed('.')
   mkview 1
   set nonumber
@@ -213,7 +213,7 @@ func Test_mkview_loadview_with_viewdir()
         \           glob('Xviewdir/*'))
   call assert_equal(1, &number)
   call assert_match('\*:mkview\*$', getline('.'))
-  call assert_equal(pos, getcurpos())
+  call assert_equal(pos, getpos('.'))
   call assert_equal(linefoldclosed1, foldclosed('.'))
 
   call delete('Xviewdir', 'rf')

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -206,10 +206,11 @@ func Test_mkview_loadview_with_viewdir()
 
   " The directory Xviewdir/ should have been created and the view
   " should be stored in that directory.
-  call assert_equal('Xviewdir/' .
+  let pathsep = has('win32') ? '\' : '/'
+  call assert_equal('Xviewdir' . pathsep .
         \           substitute(
         \             substitute(
-        \               expand('%:p'), '/', '=+', 'g'), ':', '=-', 'g') . '=1.vim',
+        \               expand('%:p'), pathsep, '=+', 'g'), ':', '=-', 'g') . '=1.vim',
         \           glob('Xviewdir/*'))
   call assert_equal(1, &number)
   call assert_match('\*:mkview\*$', getline('.'))

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -160,7 +160,7 @@ func Test_mkview_file()
   " Create a view with line number and a fold.
   help :mkview
   set number
-  norm! V}zf
+  norm! V}zf0
   let pos = getcurpos()
   let linefoldclosed1 = foldclosed('.')
   mkview! Xview

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -19,7 +19,8 @@ func Test_mksession()
     \   'two	tabs	in one line',
     \   'one ä multibyteCharacter',
     \   'aä Ä  two multiByte characters',
-    \   'Aäöü  three mulTibyte characters'
+    \   'Aäöü  three mulTibyte characters',
+    \   'short line',
     \ ])
   let tmpfile = 'Xtemp'
   exec 'w! ' . tmpfile
@@ -41,6 +42,8 @@ func Test_mksession()
   norm! j16|
   split
   norm! j16|
+  split
+  norm! j$
   wincmd l
 
   set nowrap
@@ -63,7 +66,7 @@ func Test_mksession()
   split
   call wincol()
   mksession! Xtest_mks.out
-  let li = filter(readfile('Xtest_mks.out'), 'v:val =~# "\\(^ *normal! 0\\|^ *exe ''normal!\\)"')
+  let li = filter(readfile('Xtest_mks.out'), 'v:val =~# "\\(^ *normal! [0$]\\|^ *exe ''normal!\\)"')
   let expected = [
     \   'normal! 016|',
     \   'normal! 016|',
@@ -73,6 +76,7 @@ func Test_mksession()
     \   'normal! 016|',
     \   'normal! 016|',
     \   'normal! 016|',
+    \   'normal! $',
     \   "  exe 'normal! ' . s:c . '|zs' . 16 . '|'",
     \   "  normal! 016|",
     \   "  exe 'normal! ' . s:c . '|zs' . 16 . '|'",
@@ -157,7 +161,7 @@ func Test_mkview_file()
   help :mkview
   set number
   norm! V}zf
-  let pos = getpos('.')
+  let pos = getcurpos()
   let linefoldclosed1 = foldclosed('.')
   mkview! Xview
   set nonumber
@@ -169,7 +173,7 @@ func Test_mkview_file()
   source Xview
   call assert_equal(1, &number)
   call assert_match('\*:mkview\*$', getline('.'))
-  call assert_equal(pos, getpos('.'))
+  call assert_equal(pos, getcurpos())
   call assert_equal(linefoldclosed1, foldclosed('.'))
 
   " Creating a view again with the same file name should fail (file
@@ -192,7 +196,7 @@ func Test_mkview_loadview_with_viewdir()
   help :mkview
   set number
   norm! V}zf
-  let pos = getpos('.')
+  let pos = getcurpos()
   let linefoldclosed1 = foldclosed('.')
   mkview 1
   set nonumber
@@ -209,7 +213,7 @@ func Test_mkview_loadview_with_viewdir()
         \           glob('Xviewdir/*'))
   call assert_equal(1, &number)
   call assert_match('\*:mkview\*$', getline('.'))
-  call assert_equal(pos, getpos('.'))
+  call assert_equal(pos, getcurpos())
   call assert_equal(linefoldclosed1, foldclosed('.'))
 
   call delete('Xviewdir', 'rf')

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -151,5 +151,86 @@ func Test_mksession_one_buffer_two_windows()
   call delete('Xtest_mks.out')
 endfunc
 
+" Test :mkview with a file argument.
+func Test_mkview_file()
+  " Create a view with line number and a fold.
+  help :mkview
+  set number
+  norm! V}zf
+  let pos = getpos('.')
+  let linefoldclosed1 = foldclosed('.')
+  mkview! Xview
+  set nonumber
+  norm! zrj
+  " We can close the help window, as mkview with a file name should
+  " generate a command to edit the file.
+  helpclose
+
+  source Xview
+  call assert_equal(1, &number)
+  call assert_match('\*:mkview\*$', getline('.'))
+  call assert_equal(pos, getpos('.'))
+  call assert_equal(linefoldclosed1, foldclosed('.'))
+
+  " Creating a view again with the same file name should fail (file
+  " already exists). But with a !, the previous view should be
+  " overwritten without error.
+  help :loadview
+  call assert_fails('mkview Xview', 'E189:')
+  call assert_match('\*:loadview\*$', getline('.'))
+  mkview! Xview
+  call assert_match('\*:loadview\*$', getline('.'))
+
+  call delete('Xview')
+  bwipe
+endfunc
+
+" Test :mkview and :loadview with a custom 'viewdir'.
+func Test_mkview_loadview_with_viewdir()
+  set viewdir=Xviewdir
+
+  help :mkview
+  set number
+  norm! V}zf
+  let pos = getpos('.')
+  let linefoldclosed1 = foldclosed('.')
+  mkview 1
+  set nonumber
+  norm! zrj
+
+  loadview 1
+
+  " The directory Xviewdir/ should have been created and the view
+  " should be stored in that directory.
+  call assert_equal('Xviewdir/' .
+        \           substitute(
+        \             substitute(
+        \               expand('%:p'), '/', '=+', 'g'), ':', '=-', 'g') . '=1.vim',
+        \           glob('Xviewdir/*'))
+  call assert_equal(1, &number)
+  call assert_match('\*:mkview\*$', getline('.'))
+  call assert_equal(pos, getpos('.'))
+  call assert_equal(linefoldclosed1, foldclosed('.'))
+
+  call delete('Xviewdir', 'rf')
+  set viewdir&
+  helpclose
+endfunc
+
+func Test_mkview_no_file_name()
+  new
+  " :mkview or :mkview {nr} should fail in a unnamed buffer.
+  call assert_fails('mkview', 'E32:')
+  call assert_fails('mkview 1', 'E32:')
+
+  " :mkview {file} should succeed in a unnamed buffer.
+  mkview Xview
+  help
+  source Xview
+  call assert_equal('', bufname('%'))
+
+  call delete('Xview')
+  %bwipe
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:8.1.0331: insufficient test coverage for :mkview and :loadview**

Problem:    Insufficient test coverage for :mkview and :loadview.
Solution:   Add tests. (Dominique Pelle, closes vim/vim#3385)
https://github.com/vim/vim/commit/627cb6a6b37d17433fe2d7df1f287eefb5b370e3

**vim-patch:8.1.0333: :mkview does not restore cursor properly after "$"**

Problem:    :mkview does not restore cursor properly after "$". (Dominique
            Pelle)
Solution:   Position the cursor with "normal! $".
vim/vim@92c1b69

**vim-patch:8.1.0335: mkview test fails on CI**

Problem:    mkview test fails on CI.
Solution:   Attempt to force recomputing curswant after folding.
vim/vim@2bf4fe0

**vim-patch:8.1.0336: mkview test still fails on CI**

Problem:    mkview test still fails on CI.
Solution:   Ignore curswant, don't see another solution.
vim/vim@dd5d18e