### PR TITLE
[WIP] vim-patch:8.1.{2,118,119}

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2785,10 +2785,10 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
   }
 
   if (!curbuf->terminal) {
-    // Autocommands may be executed when saving lines for undo, which may make
-    // y_array invalid.  Start undo now to avoid that.
+    // Autocommands may be executed when saving lines for undo.  This might
+    // make "y_array" invalid, so we start undo now to avoid that.
     if (u_save(curwin->w_cursor.lnum, curwin->w_cursor.lnum + 1) == FAIL) {
-      return;
+      goto end;
     }
   }
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6612,11 +6612,17 @@ void unshowmode(bool force)
 // Clear the mode message.
 void clearmode(void)
 {
+    const int save_msg_row = msg_row;
+    const int save_msg_col = msg_col;
+
     msg_pos_mode();
     if (Recording) {
       recording_mode(HL_ATTR(HLF_CM));
     }
     msg_clr_eos();
+
+    msg_col = save_msg_col;
+    msg_row = save_msg_row;
 }
 
 static void recording_mode(int attr)

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6612,17 +6612,17 @@ void unshowmode(bool force)
 // Clear the mode message.
 void clearmode(void)
 {
-    const int save_msg_row = msg_row;
-    const int save_msg_col = msg_col;
+  const int save_msg_row = msg_row;
+  const int save_msg_col = msg_col;
 
-    msg_pos_mode();
-    if (Recording) {
-      recording_mode(HL_ATTR(HLF_CM));
-    }
-    msg_clr_eos();
+  msg_pos_mode();
+  if (Recording) {
+    recording_mode(HL_ATTR(HLF_CM));
+  }
+  msg_clr_eos();
 
-    msg_col = save_msg_col;
-    msg_row = save_msg_row;
+  msg_col = save_msg_col;
+  msg_row = save_msg_row;
 }
 
 static void recording_mode(int attr)

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -39,7 +39,7 @@ function Test_messages()
   endtry
 endfunction
 
-" Patch 7.4.1696 defined the "clearmode()" command for clearing the mode
+" Patch 7.4.1696 defined the "clearmode()" function for clearing the mode
 " indicator (e.g., "-- INSERT --") when ":stopinsert" is invoked.  Message
 " output could then be disturbed when 'cmdheight' was greater than one.
 " This test ensures that the bugfix for this issue remains in place.

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -38,3 +38,24 @@ function Test_messages()
     let &more = oldmore
   endtry
 endfunction
+
+" Patch 7.4.1696 defined the "clearmode()" command for clearing the mode
+" indicator (e.g., "-- INSERT --") when ":stopinsert" is invoked.  Message
+" output could then be disturbed when 'cmdheight' was greater than one.
+" This test ensures that the bugfix for this issue remains in place.
+function! Test_stopinsert_does_not_break_message_output()
+  set cmdheight=2
+  redraw!
+
+  stopinsert | echo 'test echo'
+  call assert_equal(116, screenchar(&lines - 1, 1))
+  call assert_equal(32, screenchar(&lines, 1))
+  redraw!
+
+  stopinsert | echomsg 'test echomsg'
+  call assert_equal(116, screenchar(&lines - 1, 1))
+  call assert_equal(32, screenchar(&lines, 1))
+  redraw!
+
+  set cmdheight&
+endfunction

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -1,3 +1,4 @@
+" Tests for put commands, e.g. ":put", "p", "gp", "P", "gP", etc.
 
 func Test_put_block()
   if !has('multi_byte')
@@ -46,4 +47,49 @@ func Test_put_expr()
   norm! j0.
   call assert_equal(['A1','A2','A3','4A','5A','6A'], getline(1,'$'))
   bw!
+endfunc
+
+func Test_put_fails_when_nomodifiable()
+  new
+  set nomodifiable
+
+  normal! yy
+  call assert_fails(':put', 'E21')
+  call assert_fails(':put!', 'E21')
+  call assert_fails(':normal! p', 'E21')
+  call assert_fails(':normal! gp', 'E21')
+  call assert_fails(':normal! P', 'E21')
+  call assert_fails(':normal! gP', 'E21')
+
+  if has('mouse')
+    set mouse=n
+    call assert_fails('execute "normal! \<MiddleMouse>"', 'E21')
+    set mouse&
+  endif
+
+  bwipeout!
+endfunc
+
+" A bug was discovered where the Normal mode put commands (e.g., "p") would
+" output duplicate error messages when invoked in a non-modifiable buffer.
+func Test_put_p_errmsg_nodup()
+  new
+  set nomodifiable
+
+  normal! yy
+
+  func Capture_p_error()
+    redir => s:p_err
+    normal! p
+    redir END
+  endfunc
+
+  silent! call Capture_p_error()
+
+  " Error message output within a function should be three lines (the function
+  " name, the line number, and the error message).
+  call assert_equal(3, count(s:p_err, "\n"))
+
+  delfunction Capture_p_error
+  bwipeout!
 endfunc

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -51,7 +51,7 @@ endfunc
 
 func Test_put_fails_when_nomodifiable()
   new
-  set nomodifiable
+  setlocal nomodifiable
 
   normal! yy
   call assert_fails(':put', 'E21')
@@ -74,7 +74,7 @@ endfunc
 " output duplicate error messages when invoked in a non-modifiable buffer.
 func Test_put_p_errmsg_nodup()
   new
-  set nomodifiable
+  setlocal nomodifiable
 
   normal! yy
 


### PR DESCRIPTION
**vim-patch:8.1.0002: :stopinsert changes the message position**

Problem:    :stopinsert changes the message position.
Solution:   Save and restore msg_col and msg_row in clearmode(). (Jason
            Franklin)
vim/vim@2abad54

**vim-patch:8.1.0118: duplicate error message for put command**

Problem:    Duplicate error message for put command.
Solution:   Check return value of u_save(). (Jason Franklin)
vim/vim@f52f9ea

**vim-patch:8.1.0119: failing test goes unnoticed because messages is not written**

Problem:    Failing test goes unnoticed because testdir/messages is not
            written.
Solution:   Set 'nomodifiable' only local to the buffer.
vim/vim@ec12d64