### PR TITLE
[RDY] vim-patch:8.0.1620,8.1.{96,340}

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4531,48 +4531,83 @@ bool vim_fgets(char_u *buf, int size, FILE *fp) FUNC_ATTR_NONNULL_ALL
 }
 
 /// Read 2 bytes from "fd" and turn them into an int, MSB first.
+/// Returns -1 when encountering EOF.
 int get2c(FILE *fd)
 {
-  int n;
-
-  n = getc(fd);
-  n = (n << 8) + getc(fd);
-  return n;
+  const int n = getc(fd);
+  if (n == EOF) {
+    return -1;
+  }
+  const int c = getc(fd);
+  if (c == EOF) {
+    return -1;
+  }
+  return (n << 8) + c;
 }
 
 /// Read 3 bytes from "fd" and turn them into an int, MSB first.
+/// Returns -1 when encountering EOF.
 int get3c(FILE *fd)
 {
-  int n;
-
-  n = getc(fd);
-  n = (n << 8) + getc(fd);
-  n = (n << 8) + getc(fd);
-  return n;
+  int n = getc(fd);
+  if (n == EOF) {
+    return -1;
+  }
+  int c = getc(fd);
+  if (c == EOF) {
+    return -1;
+  }
+  n = (n << 8) + c;
+  c = getc(fd);
+  if (c == EOF) {
+    return -1;
+  }
+  return (n << 8) + c;
 }
 
 /// Read 4 bytes from "fd" and turn them into an int, MSB first.
+/// Returns -1 when encountering EOF.
 int get4c(FILE *fd)
 {
   // Use unsigned rather than int otherwise result is undefined
   // when left-shift sets the MSB.
   unsigned n;
 
-  n = (unsigned)getc(fd);
-  n = (n << 8) + (unsigned)getc(fd);
-  n = (n << 8) + (unsigned)getc(fd);
-  n = (n << 8) + (unsigned)getc(fd);
+  int c = getc(fd);
+  if (c == EOF) {
+    return -1;
+  }
+  n = (unsigned)c;
+  c = getc(fd);
+  if (c == EOF) {
+    return -1;
+  }
+  n = (n << 8) + (unsigned)c;
+  c = getc(fd);
+  if (c == EOF) {
+    return -1;
+  }
+  n = (n << 8) + (unsigned)c;
+  c = getc(fd);
+  if (c == EOF) {
+    return -1;
+  }
+  n = (n << 8) + (unsigned)c;
   return (int)n;
 }
 
 /// Read 8 bytes from `fd` and turn them into a time_t, MSB first.
+/// Returns -1 when encountering EOF.
 time_t get8ctime(FILE *fd)
 {
   time_t n = 0;
-  int i;
 
-  for (i = 0; i < 8; i++) {
-    n = (n << 8) + getc(fd);
+  for (int i = 0; i < 8; i++) {
+    const int c = getc(fd);
+    if (c == EOF) {
+      return -1;
+    }
+    n = (n << 8) + c;
   }
   return n;
 }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5967,19 +5967,19 @@ void au_event_restore(char_u *old_ei)
  *				    will be automatically executed for <event>
  *				    when editing a file matching <pat>, in
  *				    the current group.
- * :autocmd <event> <pat>	    Show the auto-commands associated with
+ * :autocmd <event> <pat>	    Show the autocommands associated with
  *				    <event> and <pat>.
- * :autocmd <event>		    Show the auto-commands associated with
+ * :autocmd <event>		    Show the autocommands associated with
  *				    <event>.
- * :autocmd			    Show all auto-commands.
- * :autocmd! <event> <pat> <cmd>    Remove all auto-commands associated with
+ * :autocmd			    Show all autocommands.
+ * :autocmd! <event> <pat> <cmd>    Remove all autocommands associated with
  *				    <event> and <pat>, and add the command
  *				    <cmd>, for the current group.
- * :autocmd! <event> <pat>	    Remove all auto-commands associated with
+ * :autocmd! <event> <pat>	    Remove all autocommands associated with
  *				    <event> and <pat> for the current group.
- * :autocmd! <event>		    Remove all auto-commands associated with
+ * :autocmd! <event>		    Remove all autocommands associated with
  *				    <event> for the current group.
- * :autocmd!			    Remove ALL auto-commands for the current
+ * :autocmd!			    Remove ALL autocommands for the current
  *				    group.
  *
  *  Multiple events and patterns may be given separated by commas.  Here are
@@ -6073,7 +6073,7 @@ void do_autocmd(char_u *arg_in, int forceit)
    */
   if (!forceit && *cmd == NUL) {
     /* Highlight title */
-    MSG_PUTS_TITLE(_("\n--- Auto-Commands ---"));
+    MSG_PUTS_TITLE(_("\n--- Autocommands ---"));
   }
 
   /*
@@ -6942,7 +6942,7 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
   autocmd_match = fname;
 
 
-  /* Don't redraw while doing auto commands. */
+  // Don't redraw while doing autocommands.
   ++RedrawingDisabled;
   save_sourcing_name = sourcing_name;
   sourcing_name = NULL;         /* don't free this one */
@@ -7154,7 +7154,7 @@ auto_next_pat (
                            apc->tail, ap->allow_dirs)
           : ap->buflocal_nr == apc->arg_bufnr) {
         const char *const name = event_nr2name(apc->event);
-        s = _("%s Auto commands for \"%s\"");
+        s = _("%s Autocommands for \"%s\"");
         const size_t sourcing_name_len = (STRLEN(s) + strlen(name) + ap->patlen
                                           + 1);
         sourcing_name = xmalloc(sourcing_name_len);

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -6072,7 +6072,7 @@ void do_autocmd(char_u *arg_in, int forceit)
    * Print header when showing autocommands.
    */
   if (!forceit && *cmd == NUL) {
-    /* Highlight title */
+    // Highlight title
     MSG_PUTS_TITLE(_("\n--- Autocommands ---"));
   }
 
@@ -6943,7 +6943,7 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
 
 
   // Don't redraw while doing autocommands.
-  ++RedrawingDisabled;
+  RedrawingDisabled++;
   save_sourcing_name = sourcing_name;
   sourcing_name = NULL;         /* don't free this one */
   save_sourcing_lnum = sourcing_lnum;

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -86,6 +86,7 @@ func Test_spellreall()
 endfunc
 
 func Test_spellinfo()
+  throw 'skipped: Nvim does not support enc=latin1'
   new
 
   set enc=latin1 spell spelllang=en

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -85,6 +85,35 @@ func Test_spellreall()
   bwipe!
 endfunc
 
+func Test_spellinfo()
+  new
+
+  set enc=latin1 spell spelllang=en
+  call assert_match("^\nfile: .*/runtime/spell/en.latin1.spl\n$", execute('spellinfo'))
+
+  set enc=cp1250 spell spelllang=en
+  call assert_match("^\nfile: .*/runtime/spell/en.ascii.spl\n$", execute('spellinfo'))
+
+  if has('multi_byte')
+    set enc=utf-8 spell spelllang=en
+    call assert_match("^\nfile: .*/runtime/spell/en.utf-8.spl\n$", execute('spellinfo'))
+  endif
+
+  set enc=latin1 spell spelllang=en_us,en_nz
+  call assert_match("^\n" .
+                 \  "file: .*/runtime/spell/en.latin1.spl\n" .
+                 \  "file: .*/runtime/spell/en.latin1.spl\n$", execute('spellinfo'))
+
+  set spell spelllang=
+  call assert_fails('spellinfo', 'E756:')
+
+  set nospell spelllang=en
+  call assert_fails('spellinfo', 'E756:')
+
+  set enc& spell& spelllang&
+  bwipe
+endfunc
+
 func Test_zz_basic()
   call LoadAffAndDic(g:test_data_aff1, g:test_data_dic1)
   call RunGoodBad("wrong OK puts. Test the end",


### PR DESCRIPTION
**vim-patch:8.0.1620: reading spell file has no good EOF detection**

Problem:    Reading spell file has no good EOF detection.
Solution:   Check for EOF at every character read for a length field.
vim/vim@e26e0d2

**vim-patch:8.1.0096: inconsistent use of the word autocommands**

Problem:    Inconsistent use of the word autocommands.
Solution:   Don't use auto-commands or "auto commands".
vim/vim@8c55533

**vim-patch:8.1.0340: no test for :spellinfo**

Problem:    No test for :spellinfo.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#3394)
vim/vim@9049b68