### PR TITLE
vim-patch:8.0.1423

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21800,6 +21800,9 @@ void ex_return(exarg_T *eap)
   }
   /* It's safer to return also on error. */
   else if (!eap->skip) {
+    // In return statement, cause_abort should be force_abort.
+    update_force_abort();
+
     /*
      * Return unless the expression evaluation has been cancelled due to an
      * aborting error, an interrupt, or an exception.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21797,18 +21797,15 @@ void ex_return(exarg_T *eap)
     } else {
       tv_clear(&rettv);
     }
-  }
-  /* It's safer to return also on error. */
-  else if (!eap->skip) {
+  } else if (!eap->skip) {  // It's safer to return also on error.
     // In return statement, cause_abort should be force_abort.
     update_force_abort();
 
-    /*
-     * Return unless the expression evaluation has been cancelled due to an
-     * aborting error, an interrupt, or an exception.
-     */
-    if (!aborting())
-      returning = do_return(eap, FALSE, TRUE, NULL);
+    // Return unless the expression evaluation has been cancelled due to an
+    // aborting error, an interrupt, or an exception.
+    if (!aborting()) {
+      returning = do_return(eap, false, true, NULL);
+    }
   }
 
   /* When skipping or the return gets pending, advance to the next command

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -1,0 +1,13 @@
+" Tests for various eval things.
+
+function s:foo() abort
+  try
+    return [] == 0
+  catch
+    return 1
+  endtry
+endfunction
+
+func Test_catch_return_with_error()
+  call assert_equal(1, s:foo())
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1423: error in return not caught by try/catch**

Problem:    Error in return not caught by try/catch.
Solution:   Call update_force_abort(). (Yasuhiro Matsomoto, closes vim/vim#2483)
https://github.com/vim/vim/commit/fabaf753e26df5a89a854673d14c15a1fa6b321a