### PR TITLE
[RFC] vim-patch:8.0.0{733,782,904,922}

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6851,10 +6851,12 @@ setpos({expr}, {list})
 
 
 setqflist({list} [, {action}[, {what}]])		*setqflist()*
-		Create or replace or add to the quickfix list using the items
-		in {list}.  Each item in {list} is a dictionary.
-		Non-dictionary items in {list} are ignored.  Each dictionary
-		item can contain the following entries:
+		Create or replace or add to the quickfix list.
+		
+		When {what} is not present, use the items in {list}.  Each
+		item must be a dictionary.  Non-dictionary items in {list} are
+		ignored.  Each dictionary item can contain the following
+		entries:
 
 		    bufnr	buffer number; must be the number of a valid
 				buffer
@@ -6909,6 +6911,10 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		argument is ignored.  The following items can be specified in
 		{what}:
 		    context	any Vim type can be stored as a context
+		    text	use 'errorformat' to extract items from the
+				text and add the resulting entries to the
+				quickfix list {nr}.  The value can be a string
+				with one line or a list with multiple lines.
 		    items	list of quickfix entries. Same as the {list}
 				argument.
 		    nr		list number in the quickfix stack; zero

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6901,7 +6901,10 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 			freed.
 
 		If {action} is not present or is set to ' ', then a new list
-		is created.
+		is created. The new quickfix list is added after the current
+		quickfix list in the stack and all the following lists are
+		freed. To add a new quickfix list at the end of the stack,
+		set "nr" in {what} to '$'.
 
 		If {title} is given, it will be used to set |w:quickfix_title|
 		after opening the quickfix window.

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -842,7 +842,7 @@ void goto_buffer(exarg_T *eap, int start, int dir, int count)
     enter_cleanup(&cs);
 
     /* Quitting means closing the split window, nothing else. */
-    win_close(curwin, TRUE);
+    win_close(curwin, true);
     swap_exists_action = SEA_NONE;
     swap_exists_did_quit = TRUE;
 
@@ -4651,7 +4651,7 @@ void ex_buffer_all(exarg_T *eap)
           && !ONE_WINDOW
           && !(wp->w_closing || wp->w_buffer->b_locked > 0)
           ) {
-        win_close(wp, FALSE);
+        win_close(wp, false);
         wpnext = firstwin;              /* just in case an autocommand does
                                            something strange with windows */
         tpnext = first_tabpage;         /* start all over...*/
@@ -4724,7 +4724,7 @@ void ex_buffer_all(exarg_T *eap)
         enter_cleanup(&cs);
 
         /* User selected Quit at ATTENTION prompt; close this window. */
-        win_close(curwin, TRUE);
+        win_close(curwin, true);
         --open_wins;
         swap_exists_action = SEA_NONE;
         swap_exists_did_quit = TRUE;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -841,7 +841,7 @@ void goto_buffer(exarg_T *eap, int start, int dir, int count)
      * aborting() returns FALSE when closing a window. */
     enter_cleanup(&cs);
 
-    /* Quitting means closing the split window, nothing else. */
+    // Quitting means closing the split window, nothing else.
     win_close(curwin, true);
     swap_exists_action = SEA_NONE;
     swap_exists_did_quit = TRUE;
@@ -4652,9 +4652,9 @@ void ex_buffer_all(exarg_T *eap)
           && !(wp->w_closing || wp->w_buffer->b_locked > 0)
           ) {
         win_close(wp, false);
-        wpnext = firstwin;              /* just in case an autocommand does
-                                           something strange with windows */
-        tpnext = first_tabpage;         /* start all over...*/
+        wpnext = firstwin;              // just in case an autocommand does
+                                        // something strange with windows
+        tpnext = first_tabpage;         // start all over...
         open_wins = 0;
       } else
         ++open_wins;
@@ -4723,9 +4723,9 @@ void ex_buffer_all(exarg_T *eap)
          * aborting() returns FALSE when closing a window. */
         enter_cleanup(&cs);
 
-        /* User selected Quit at ATTENTION prompt; close this window. */
+        // User selected Quit at ATTENTION prompt; close this window.
         win_close(curwin, true);
-        --open_wins;
+        open_wins--;
         swap_exists_action = SEA_NONE;
         swap_exists_did_quit = TRUE;
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -252,7 +252,7 @@ open_buffer (
     msg_silent = old_msg_silent;
 
     // Help buffer is filtered.
-    if (curbuf->b_help) {
+    if (bt_help(curbuf)) {
       fix_help_buffer();
     }
   } else if (read_stdin) {
@@ -4928,6 +4928,12 @@ chk_modeline (
   xfree(linecopy);
 
   return retval;
+}
+
+// Return true if "buf" is a help buffer.
+bool bt_help(const buf_T *const buf)
+{
+  return buf != NULL && buf->b_help;
 }
 
 /*

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5510,7 +5510,7 @@ void ex_helpclose(exarg_T *eap)
 {
   FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
     if (bt_help(win->w_buffer)) {
-      win_close(win, FALSE);
+      win_close(win, false);
       return;
     }
   }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4514,7 +4514,7 @@ void ex_help(exarg_T *eap)
    * Re-use an existing help window or open a new one.
    * Always open a new one for ":tab help".
    */
-  if (!curwin->w_buffer->b_help
+  if (!bt_help(curwin->w_buffer)
       || cmdmod.tab != 0
       ) {
     if (cmdmod.tab != 0) {
@@ -4522,7 +4522,7 @@ void ex_help(exarg_T *eap)
     } else {
       wp = NULL;
       FOR_ALL_WINDOWS_IN_TAB(wp2, curtab) {
-        if (wp2->w_buffer != NULL && wp2->w_buffer->b_help) {
+        if (bt_help(wp2->w_buffer)) {
           wp = wp2;
           break;
         }
@@ -5509,7 +5509,7 @@ static int      next_sign_typenr = 1;
 void ex_helpclose(exarg_T *eap)
 {
   FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
-    if (win->w_buffer->b_help) {
+    if (bt_help(win->w_buffer)) {
       win_close(win, FALSE);
       return;
     }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6192,7 +6192,7 @@ static int open_cmdwin(void)
     wp = curwin;
     set_bufref(&bufref, curbuf);
     win_goto(old_curwin);
-    win_close(wp, TRUE);
+    win_close(wp, true);
 
     // win_close() may have already wiped the buffer when 'bh' is
     // set to 'wipe'.

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1540,7 +1540,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
 {
   int arg_idx;                          /* index in argument list */
   int i;
-  int advance = TRUE;
+  bool advance = true;
   win_T       *win;
 
   /*
@@ -1552,7 +1552,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
   /* When w_arg_idx is -1 remove the window (see create_windows()). */
   if (curwin->w_arg_idx == -1) {
     win_close(curwin, true);
-    advance = FALSE;
+    advance = false;
   }
 
   arg_idx = 1;
@@ -1564,7 +1564,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
     if (curwin->w_arg_idx == -1) {
       ++arg_idx;
       win_close(curwin, true);
-      advance = FALSE;
+      advance = false;
       continue;
     }
 
@@ -1579,7 +1579,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
         win_enter(curwin->w_next, false);
       }
     }
-    advance = TRUE;
+    advance = true;
 
     // Only open the file if there is no file in this window yet (that can
     // happen when vimrc contains ":sall").
@@ -1599,7 +1599,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
           getout(1);
         }
         win_close(curwin, true);
-        advance = FALSE;
+        advance = false;
       }
       if (arg_idx == GARGCOUNT - 1)
         arg_had_last = TRUE;

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1551,7 +1551,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
 
   /* When w_arg_idx is -1 remove the window (see create_windows()). */
   if (curwin->w_arg_idx == -1) {
-    win_close(curwin, TRUE);
+    win_close(curwin, true);
     advance = FALSE;
   }
 
@@ -1563,7 +1563,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
     // When w_arg_idx is -1 remove the window (see create_windows()).
     if (curwin->w_arg_idx == -1) {
       ++arg_idx;
-      win_close(curwin, TRUE);
+      win_close(curwin, true);
       advance = FALSE;
       continue;
     }
@@ -1598,7 +1598,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
           did_emsg = FALSE;             /* avoid hit-enter prompt */
           getout(1);
         }
-        win_close(curwin, TRUE);
+        win_close(curwin, true);
         advance = FALSE;
       }
       if (arg_idx == GARGCOUNT - 1)

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1562,7 +1562,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
     }
     // When w_arg_idx is -1 remove the window (see create_windows()).
     if (curwin->w_arg_idx == -1) {
-      ++arg_idx;
+      arg_idx++;
       win_close(curwin, true);
       advance = false;
       continue;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1140,7 +1140,7 @@ qf_init_ext(
   }
   if (state.fd == NULL || !ferror(state.fd)) {
     if (qfl->qf_index == 0) {
-      /* no valid entry found */
+      // no valid entry found
       qfl->qf_ptr = qfl->qf_start;
       qfl->qf_index = 1;
       qfl->qf_nonevalid = true;
@@ -1150,7 +1150,7 @@ qf_init_ext(
         qfl->qf_ptr = qfl->qf_start;
       }
     }
-    /* return number of matches */
+    // return number of matches
     retval = qfl->qf_count;
     goto qf_init_end;
   }
@@ -2597,8 +2597,9 @@ void ex_cclose(exarg_T *eap)
 
   /* Find existing quickfix window and close it. */
   win = qf_find_win(qi);
-  if (win != NULL)
+  if (win != NULL) {
     win_close(win, false);
+  }
 }
 
 /*
@@ -4862,10 +4863,12 @@ void ex_helpgrep(exarg_T *eap)
     /* If the help window is not opened or if it already points to the
      * correct location list, then free the new location list. */
     if (!bt_help(curwin->w_buffer) || curwin->w_llist == qi) {
-      if (new_qi)
+      if (new_qi) {
         ll_free_all(&qi);
-    } else if (curwin->w_llist == NULL)
+      }
+    } else if (curwin->w_llist == NULL) {
       curwin->w_llist = qi;
+    }
   }
 }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2598,7 +2598,7 @@ void ex_cclose(exarg_T *eap)
   /* Find existing quickfix window and close it. */
   win = qf_find_win(qi);
   if (win != NULL)
-    win_close(win, FALSE);
+    win_close(win, false);
 }
 
 /*

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2608,10 +2608,10 @@ static int jumpto_tag(
       win_enter(curwin_save, true);
     }
 
-    --RedrawingDisabled;
+    RedrawingDisabled--;
   } else {
-    --RedrawingDisabled;
-    if (postponed_split) {              /* close the window */
+    RedrawingDisabled--;
+    if (postponed_split) {              // close the window
       win_close(curwin, false);
       postponed_split = 0;
     }

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2612,7 +2612,7 @@ static int jumpto_tag(
   } else {
     --RedrawingDisabled;
     if (postponed_split) {              /* close the window */
-      win_close(curwin, FALSE);
+      win_close(curwin, false);
       postponed_split = 0;
     }
   }

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2269,3 +2269,17 @@ func Test_changedtick()
     call Xchangedtick_tests('c')
     call Xchangedtick_tests('l')
 endfunc
+
+" Open multiple help windows using ":lhelpgrep
+" This test used to crash Vim
+func Test_Multi_LL_Help()
+    new | only
+    lhelpgrep window
+    lopen
+    e#
+    lhelpgrep buffer
+    call assert_equal(3, winnr('$'))
+    call assert_true(len(getloclist(1)) != 0)
+    call assert_true(len(getloclist(2)) != 0)
+    new | only
+endfunc

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1859,20 +1859,18 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf,
   return true;
 }
 
-/*
- * Close window "win".  Only works for the current tab page.
- * If "free_buf" is TRUE related buffer may be unloaded.
- *
- * Called by :quit, :close, :xit, :wq and findtag().
- * Returns FAIL when the window was not closed.
- */
-int win_close(win_T *win, int free_buf)
+// Close window "win".  Only works for the current tab page.
+// If "free_buf" is true related buffer may be unloaded.
+//
+// Called by :quit, :close, :xit, :wq and findtag().
+// Returns FAIL when the window was not closed.
+int win_close(win_T *win, bool free_buf)
 {
   win_T       *wp;
   int other_buffer = FALSE;
   int close_curwin = FALSE;
   int dir;
-  int help_window = FALSE;
+  bool help_window = false;
   tabpage_T   *prev_curtab = curtab;
   frame_T *win_frame = win->w_frame->fr_parent;
 
@@ -1903,7 +1901,7 @@ int win_close(win_T *win, int free_buf)
   /* When closing the help window, try restoring a snapshot after closing
    * the window.  Otherwise clear the snapshot, it's now invalid. */
   if (bt_help(win->w_buffer))
-    help_window = TRUE;
+    help_window = true;
   else
     clear_snapshot(curtab, SNAP_HELP_IDX);
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1902,7 +1902,7 @@ int win_close(win_T *win, int free_buf)
 
   /* When closing the help window, try restoring a snapshot after closing
    * the window.  Otherwise clear the snapshot, it's now invalid. */
-  if (win->w_buffer != NULL && win->w_buffer->b_help)
+  if (bt_help(win->w_buffer))
     help_window = TRUE;
   else
     clear_snapshot(curtab, SNAP_HELP_IDX);
@@ -1967,8 +1967,8 @@ int win_close(win_T *win, int free_buf)
   if (only_one_window() && win_valid(win) && win->w_buffer == NULL
       && (last_window() || curtab != prev_curtab
           || close_last_window_tabpage(win, free_buf, prev_curtab))) {
-    /* Autocommands have close all windows, quit now.  Restore
-    * curwin->w_buffer, otherwise writing ShaDa file may fail. */
+    // Autocommands have closed all windows, quit now.  Restore
+    // curwin->w_buffer, otherwise writing ShaDa file may fail.
     if (curwin->w_buffer == NULL)
       curwin->w_buffer = curbuf;
     getout(0);
@@ -5341,7 +5341,7 @@ bool only_one_window(void) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
   int count = 0;
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer != NULL
-        && (!((wp->w_buffer->b_help && !curbuf->b_help)
+        && (!((bt_help(wp->w_buffer) && !bt_help(curbuf))
               || wp->w_p_pvw) || wp == curwin) && wp != aucmd_win) {
       count++;
     }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1900,10 +1900,11 @@ int win_close(win_T *win, bool free_buf)
 
   /* When closing the help window, try restoring a snapshot after closing
    * the window.  Otherwise clear the snapshot, it's now invalid. */
-  if (bt_help(win->w_buffer))
+  if (bt_help(win->w_buffer)) {
     help_window = true;
-  else
+  } else {
     clear_snapshot(curtab, SNAP_HELP_IDX);
+  }
 
   if (win == curwin) {
     /*
@@ -1967,8 +1968,9 @@ int win_close(win_T *win, bool free_buf)
           || close_last_window_tabpage(win, free_buf, prev_curtab))) {
     // Autocommands have closed all windows, quit now.  Restore
     // curwin->w_buffer, otherwise writing ShaDa file may fail.
-    if (curwin->w_buffer == NULL)
+    if (curwin->w_buffer == NULL) {
       curwin->w_buffer = curbuf;
+    }
     getout(0);
   }
   // Autocommands may have moved to another tab page.


### PR DESCRIPTION
**vim-patch:8.0.0733: can only add entries to one list in the quickfix stack**

Problem:    Can only add entries to one list in the quickfix stack.
Solution:   Move state variables from qf_list_T to qf_list_T. (Yegappan
            Lakshmanan)
https://github.com/vim/vim/commit/a7df8c70c85c793bc4d75abc625d36883ab029cc

**vim-patch:8.0.0782: using freed memory in quickfix code**

Problem:    Using freed memory in quickfix code. (Dominique Pelle)
Solution:   Handle a help window differently. (Yegappan Lakshmanan)
vim/vim@d28cc3f

**vim-patch:8.0.0904: cannot set a location list from text**

Problem:    Cannot set a location list from text.
Solution:   Add the "text" argument to setqflist(). (Yegappan Lakshmanan)
vim/vim@ae33833

**vim-patch:8.0.0922: quickfix list always added after current one**

Problem:    Quickfix list always added after current one.
Solution:   Make it possible to add a quickfix list after the last one.
            (Yegappan Lakshmanan)
vim/vim@55b6926