### PR TITLE
[RFC] cmake: add "generated-sources" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,9 @@ clint-full: build/.ran-cmake
 check-single-includes: build/.ran-cmake
 	+$(BUILD_CMD) -C build check-single-includes
 
+generated-sources: build/.ran-cmake
+	+$(BUILD_CMD) -C build generated-sources
+
 appimage:
 	bash scripts/genappimage.sh
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -660,4 +660,10 @@ add_custom_target(
   DEPENDS ${LINT_PRG} ${LINT_NVIM_SOURCES} ${LINT_SUPPRESS_FILE}
 )
 
+add_custom_target(generated-sources DEPENDS
+  ${NVIM_GENERATED_FOR_SOURCES}
+  ${NVIM_GENERATED_FOR_HEADERS}
+  ${NVIM_GENERATED_SOURCES}
+)
+
 add_subdirectory(po)


### PR DESCRIPTION
When using a LSP plugin (such as #6856) + clangd for development of nvim itself, suppose the following code in `ui.c`
```
void ui_do_stuff(int x) {
 // do stuff
}
```

is changed to
```
void ui_do_stuff(bool x) {
 // do stuff
}
```

One would immediately get a `conflicting types for 'ui_do_stuff'` error, as clangd only sees the changed source, but with stale generated headers. I think I can remedy these kinds of situations in my extension on top of #6856,  but for that it would be convenient to a have a build command to only regenerate headers (which takes ~100 ms for a single regenerated header) rather than also build all .o files (which can take several seconds if you regenerate a .h file used by many .c files).
