### PR TITLE
[RFC] vim-patch:8.0.1781

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4312,7 +4312,7 @@ static int make_bom(char_u *buf, char_u *name)
 }
 
 /*
- * Shorten filenames for all buffers.
+ * Shorten filename of a buffer.
  * When "force" is TRUE: Use full path from now on for files currently being
  * edited, both for file name and swap file name.  Try to shorten the file
  * names a bit, if safe to do so.
@@ -4320,29 +4320,38 @@ static int make_bom(char_u *buf, char_u *name)
  * For buffers that have buftype "nofile" or "scratch": never change the file
  * name.
  */
+void shorten_buf_fname(buf_T *buf, char_u *dirname, int force)
+{
+  char_u      *p;
+
+  if (buf->b_fname != NULL
+      && !bt_nofile(buf)
+      && !path_with_url((char *)buf->b_fname)
+      && (force
+          || buf->b_sfname == NULL
+          || path_is_absolute(buf->b_sfname))) {
+    xfree(buf->b_sfname);
+    buf->b_sfname = NULL;
+    p = path_shorten_fname(buf->b_ffname, dirname);
+    if (p != NULL) {
+      buf->b_sfname = vim_strsave(p);
+      buf->b_fname = buf->b_sfname;
+    }
+    if (p == NULL || buf->b_fname == NULL)
+      buf->b_fname = buf->b_ffname;
+  }
+}
+
+/*
+ * Shorten filenames for all buffers.
+ */
 void shorten_fnames(int force)
 {
   char_u dirname[MAXPATHL];
-  char_u      *p;
 
   os_dirname(dirname, MAXPATHL);
   FOR_ALL_BUFFERS(buf) {
-    if (buf->b_fname != NULL
-        && !bt_nofile(buf)
-        && !path_with_url((char *)buf->b_fname)
-        && (force
-            || buf->b_sfname == NULL
-            || path_is_absolute(buf->b_sfname))) {
-      xfree(buf->b_sfname);
-      buf->b_sfname = NULL;
-      p = path_shorten_fname(buf->b_ffname, dirname);
-      if (p != NULL) {
-        buf->b_sfname = vim_strsave(p);
-        buf->b_fname = buf->b_sfname;
-      }
-      if (p == NULL || buf->b_fname == NULL)
-        buf->b_fname = buf->b_ffname;
-    }
+      shorten_buf_fname(buf, dirname, force);
 
     /* Always make the swap file name a full path, a "nofile" buffer may
      * also have a swap file. */

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2240,6 +2240,9 @@ void qf_list(exarg_T *eap)
     }
   }
 
+  /* Shorten all the file names, so that it is easy to read */
+  shorten_fnames(FALSE);
+
   if (qi->qf_lists[qi->qf_curlist].qf_nonevalid)
     all = TRUE;
   qfp = qi->qf_lists[qi->qf_curlist].qf_start;
@@ -2944,6 +2947,10 @@ static void qf_fill_buffer(qf_info_T *qi, buf_T *buf, qfline_T *old_last)
 
   /* Check if there is anything to display */
   if (qi->qf_curlist < qi->qf_listcount) {
+     char_u dirname[MAXPATHL];
+
+     *dirname = NUL;
+
     // Add one line for each error
     if (old_last == NULL) {
       qfp = qi->qf_lists[qi->qf_curlist].qf_start;
@@ -2959,6 +2966,14 @@ static void qf_fill_buffer(qf_info_T *qi, buf_T *buf, qfline_T *old_last)
         if (qfp->qf_type == 1) {  // :helpgrep
           STRLCPY(IObuff, path_tail(errbuf->b_fname), sizeof(IObuff));
         } else {
+          /* shorten the file name if not done already */
+          if (errbuf->b_sfname == NULL
+              || path_is_absolute(errbuf->b_sfname))
+          {
+            if (*dirname == NUL)
+              os_dirname(dirname, MAXPATHL);
+            shorten_buf_fname(errbuf, dirname, FALSE);
+          }
           STRLCPY(IObuff, errbuf->b_fname, sizeof(IObuff));
         }
         len = (int)STRLEN(IObuff);

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2584,3 +2584,27 @@ func Test_qf_id()
   call Xqfid_tests('c')
   call Xqfid_tests('l')
 endfunc
+
+" Test for shortening/simplifying the file name when opening the
+" quickfix window or when displaying the quickfix list
+func Test_shorten_fname()
+  if !has('unix')
+    return
+  endif
+  %bwipe
+  " Create a quickfix list with a absolute path filename
+  let fname = getcwd() . '/test_quickfix.vim'
+  call setqflist([], ' ', {'lines':[fname . ":20:Line20"], 'efm':'%f:%l:%m'})
+  call assert_equal(fname, bufname('test_quickfix.vim'))
+  " Opening the quickfix window should simplify the file path
+  cwindow
+  call assert_equal('test_quickfix.vim', bufname('test_quickfix.vim'))
+  cclose
+  %bwipe
+  " Create a quickfix list with a absolute path filename
+  call setqflist([], ' ', {'lines':[fname . ":20:Line20"], 'efm':'%f:%l:%m'})
+  call assert_equal(fname, bufname('test_quickfix.vim'))
+  " Displaying the quickfix list should simplify the file path
+  silent! clist
+  call assert_equal('test_quickfix.vim', bufname('test_quickfix.vim'))
+endfunc


### PR DESCRIPTION
#### vim-patch:8.0.1781: file names in quickfix window are not shortened

Problem:    File names in quickfix window are not always shortened.
Solution:   Shorten the file name when opening the quickfix window. (Yegappan
            Lakshmanan, closes vim/vim#2851, closes vim/vim#2846)
https://github.com/vim/vim/commit/a796d46f29e3cc235cc981696d7ee80faccb5000