### PR TITLE
[RDY] vim-patch:8.0.{1006,1023,1029,1031,1040}

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4335,6 +4335,9 @@ getqflist([{what}])					*getqflist()*
 		returns only the items listed in {what} as a dictionary. The
 		following string items are supported in {what}:
 			context	get the context stored with |setqflist()|
+			id	get information for the quickfix list with
+				|quickfix-ID|; zero means the id for the
+				current list or the list specifed by 'nr'
 			items	quickfix list entries
 			nr	get information for this quickfix list; zero
 				means the current quickfix list and '$' means
@@ -4349,6 +4352,8 @@ getqflist([{what}])					*getqflist()*
 			all	all of the above quickfix properties
 		Non-string items in {what} are ignored.
 		If "nr" is not present then the current quickfix list is used.
+		If both "nr" and a non-zero "id" are specified, then the list
+		specified by "id" is used.
 		To get the number of lists in the quickfix stack, set 'nr' to
 		'$' in {what}. The 'nr' value in the returned dictionary
 		contains the quickfix stack size.
@@ -4360,6 +4365,7 @@ getqflist([{what}])					*getqflist()*
 
 		The returned dictionary contains the following entries:
 			context	context information stored with |setqflist()|
+			id	quickfix list ID |quickfix-ID|
 			items	quickfix list entries
 			nr	quickfix list number
 			title	quickfix list title text
@@ -6926,6 +6932,7 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 				text and add the resulting entries to the
 				quickfix list {nr}.  The value can be a string
 				with one line or a list with multiple lines.
+		    id		quickfix list identifier |quickfix-ID|
 		    items	list of quickfix entries. Same as the {list}
 				argument.
 		    nr		list number in the quickfix stack; zero
@@ -6936,6 +6943,9 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		If the "nr" item is not present, then the current quickfix list
 		is modified. When creating a new quickfix list, "nr" can be
 		set to a value one greater than the quickfix stack size.
+		When modifying a quickfix list, to guarantee that the correct
+		list is modified, 'id' should be used instead of 'nr' to
+		specify the list.
 
 		Examples: >
 			:call setqflist([], 'r', {'title': 'My search'})

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4339,14 +4339,13 @@ getqflist([{what}])					*getqflist()*
 				|quickfix-ID|; zero means the id for the
 				current list or the list specifed by 'nr'
 			items	quickfix list entries
+			lines	use 'errorformat' to extract items from a list
+				of lines and return the resulting entries.
+				Only a |List| type is accepted.  The current
+				quickfix list is not modified.
 			nr	get information for this quickfix list; zero
 				means the current quickfix list and '$' means
 				the last quickfix list
-			text	use 'errorformat' to extract items from the
-				text and return the resulting entries. The
-				value can be a string with one line or a list
-				with multiple lines. The current quickfix list
-				is not modified.
 			title	get the list title
 			winid	get the |window-ID| (if opened)
 			all	all of the above quickfix properties
@@ -4374,6 +4373,7 @@ getqflist([{what}])					*getqflist()*
 		Examples: >
 			:echo getqflist({'all': 1})
 			:echo getqflist({'nr': 2, 'title': 1})
+			:echo getqflist({'lines' : ["F1:10:L10"]})
 <
 
 getreg([{regname} [, 1 [, {list}]]])			*getreg()*
@@ -6928,13 +6928,12 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		argument is ignored.  The following items can be specified in
 		{what}:
 		    context	any Vim type can be stored as a context
-		    text	use 'errorformat' to extract items from the
-				text and add the resulting entries to the
-				quickfix list {nr}.  The value can be a string
-				with one line or a list with multiple lines.
 		    id		quickfix list identifier |quickfix-ID|
 		    items	list of quickfix entries. Same as the {list}
 				argument.
+		    lines	use 'errorformat' to parse a list of lines and
+				add the resulting entries to the quickfix list
+				{nr} or {id}.  Only a |List| value is supported.
 		    nr		list number in the quickfix stack; zero
 				means the current quickfix list and '$' means
 				the last quickfix list
@@ -6948,8 +6947,9 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		specify the list.
 
 		Examples: >
-			:call setqflist([], 'r', {'title': 'My search'})
-			:call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
+		   :call setqflist([], 'r', {'title': 'My search'})
+		   :call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
+		   :call setqflist([], 'a', {'id':myid, 'lines':["F1:10:L10"]})
 <
 		Returns zero for success, -1 for failure.
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4339,6 +4339,11 @@ getqflist([{what}])					*getqflist()*
 			nr	get information for this quickfix list; zero
 				means the current quickfix list and '$' means
 				the last quickfix list
+			text	use 'errorformat' to extract items from the
+				text and return the resulting entries. The
+				value can be a string with one line or a list
+				with multiple lines. The current quickfix list
+				is not modified.
 			title	get the list title
 			winid	get the |window-ID| (if opened)
 			all	all of the above quickfix properties
@@ -4347,6 +4352,9 @@ getqflist([{what}])					*getqflist()*
 		To get the number of lists in the quickfix stack, set 'nr' to
 		'$' in {what}. The 'nr' value in the returned dictionary
 		contains the quickfix stack size.
+		When 'text' is specified, all the other items are ignored. The
+		returned dictionary contains the entry 'items' with the list
+		of entries.
 		In case of error processing {what}, an empty dictionary is
 		returned.
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4335,16 +4335,19 @@ getqflist([{what}])					*getqflist()*
 		returns only the items listed in {what} as a dictionary. The
 		following string items are supported in {what}:
 			context	get the context stored with |setqflist()|
+			efm	errorformat to use when parsing "lines". If
+				not present, then the 'erroformat' option
+				value is used.
 			id	get information for the quickfix list with
 				|quickfix-ID|; zero means the id for the
-				current list or the list specifed by 'nr'
+				current list or the list specifed by "nr"
 			items	quickfix list entries
 			lines	use 'errorformat' to extract items from a list
 				of lines and return the resulting entries.
 				Only a |List| type is accepted.  The current
 				quickfix list is not modified.
 			nr	get information for this quickfix list; zero
-				means the current quickfix list and '$' means
+				means the current quickfix list and "$" means
 				the last quickfix list
 			title	get the list title
 			winid	get the |window-ID| (if opened)
@@ -6918,7 +6921,7 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		is created. The new quickfix list is added after the current
 		quickfix list in the stack and all the following lists are
 		freed. To add a new quickfix list at the end of the stack,
-		set "nr" in {what} to '$'.
+		set "nr" in {what} to "$".
 
 		If {title} is given, it will be used to set |w:quickfix_title|
 		after opening the quickfix window.
@@ -6928,6 +6931,9 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		argument is ignored.  The following items can be specified in
 		{what}:
 		    context	any Vim type can be stored as a context
+		    efm		errorformat to use when parsing text from
+				"lines". If this is not present, then the
+				'errorformat' option value is used.
 		    id		quickfix list identifier |quickfix-ID|
 		    items	list of quickfix entries. Same as the {list}
 				argument.
@@ -6935,7 +6941,7 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 				add the resulting entries to the quickfix list
 				{nr} or {id}.  Only a |List| value is supported.
 		    nr		list number in the quickfix stack; zero
-				means the current quickfix list and '$' means
+				means the current quickfix list and "$" means
 				the last quickfix list
 		    title	quickfix list title text
 		Unsupported keys in {what} are ignored.
@@ -6943,7 +6949,7 @@ setqflist({list} [, {action}[, {what}]])		*setqflist()*
 		is modified. When creating a new quickfix list, "nr" can be
 		set to a value one greater than the quickfix stack size.
 		When modifying a quickfix list, to guarantee that the correct
-		list is modified, 'id' should be used instead of 'nr' to
+		list is modified, "id" should be used instead of "nr" to
 		specify the list.
 
 		Examples: >

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9943,7 +9943,7 @@ static void get_qf_loc_list(int is_qf, win_T *wp, typval_T *what_arg,
   if (what_arg->v_type == VAR_UNKNOWN) {
     tv_list_alloc_ret(rettv, kListLenMayKnow);
     if (is_qf || wp != NULL) {
-      (void)get_errorlist(wp, -1, rettv->vval.v_list);
+      (void)get_errorlist(NULL, wp, -1, rettv->vval.v_list);
     }
   } else {
     tv_dict_alloc_ret(rettv);

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4122,15 +4122,12 @@ enum {
 };
 
 // Parse text from 'di' and return the quickfix list items
-static int qf_get_list_from_text(dictitem_T *di, dict_T *retdict)
+static int qf_get_list_from_lines(dictitem_T *di, dict_T *retdict)
 {
   int status = FAIL;
 
-  // Only string and list values are supported
-  if ((di->di_tv.v_type == VAR_STRING
-       && di->di_tv.vval.v_string != NULL)
-      || (di->di_tv.v_type == VAR_LIST
-          && di->di_tv.vval.v_list != NULL)) {
+  // Only a List value is supported
+  if (di->di_tv.v_type == VAR_LIST && di->di_tv.vval.v_list != NULL) {
     list_T *l = tv_list_alloc(kListLenMayKnow);
     qf_info_T *qi = xmalloc(sizeof(*qi));
     memset(qi, 0, sizeof(*qi));
@@ -4158,8 +4155,8 @@ int get_errorlist_properties(win_T *wp, dict_T *what, dict_T *retdict)
   qf_info_T *qi = &ql_info;
   dictitem_T *di;
 
-  if ((di = tv_dict_find(what, S_LEN("text"))) != NULL) {
-    return qf_get_list_from_text(di, retdict);
+  if ((di = tv_dict_find(what, S_LEN("lines"))) != NULL) {
+    return qf_get_list_from_lines(di, retdict);
   }
 
   if (wp != NULL) {
@@ -4474,12 +4471,9 @@ static int qf_set_properties(qf_info_T *qi, dict_T *what, int action,
     }
   }
 
-  if ((di = tv_dict_find(what, S_LEN("text"))) != NULL) {
-    // Only string and list values are supported
-    if ((di->di_tv.v_type == VAR_STRING
-         && di->di_tv.vval.v_string != NULL)
-        || (di->di_tv.v_type == VAR_LIST
-            && di->di_tv.vval.v_list != NULL)) {
+  if ((di = tv_dict_find(what, S_LEN("lines"))) != NULL) {
+    // Only a List value is supported
+    if (di->di_tv.v_type == VAR_LIST && di->di_tv.vval.v_list != NULL) {
       if (action == 'r') {
         qf_free_items(qi, qf_idx);
       }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4122,18 +4122,30 @@ enum {
 };
 
 // Parse text from 'di' and return the quickfix list items
-static int qf_get_list_from_lines(dictitem_T *di, dict_T *retdict)
+static int qf_get_list_from_lines(dict_T *what, dictitem_T *di, dict_T *retdict)
 {
   int status = FAIL;
+  char_u *errorformat = p_efm;
+  dictitem_T *efm_di;
 
   // Only a List value is supported
   if (di->di_tv.v_type == VAR_LIST && di->di_tv.vval.v_list != NULL) {
+    // If errorformat is supplied then use it, otherwise use the 'efm'
+    // option setting
+    if ((efm_di = tv_dict_find(what, S_LEN("efm"))) != NULL) {
+      if (efm_di->di_tv.v_type != VAR_STRING
+          || efm_di->di_tv.vval.v_string == NULL) {
+        return FAIL;
+      }
+      errorformat = efm_di->di_tv.vval.v_string;
+    }
+
     list_T *l = tv_list_alloc(kListLenMayKnow);
     qf_info_T *qi = xmalloc(sizeof(*qi));
     memset(qi, 0, sizeof(*qi));
     qi->qf_refcount++;
 
-    if (qf_init_ext(qi, 0, NULL, NULL, &di->di_tv, p_efm,
+    if (qf_init_ext(qi, 0, NULL, NULL, &di->di_tv, errorformat,
                     true, (linenr_T)0, (linenr_T)0, NULL, NULL) > 0) {
       (void)get_errorlist(qi, NULL, 0, l);
       qf_free(qi, 0);
@@ -4156,7 +4168,7 @@ int get_errorlist_properties(win_T *wp, dict_T *what, dict_T *retdict)
   dictitem_T *di;
 
   if ((di = tv_dict_find(what, S_LEN("lines"))) != NULL) {
-    return qf_get_list_from_lines(di, retdict);
+    return qf_get_list_from_lines(what, di, retdict);
   }
 
   if (wp != NULL) {
@@ -4390,6 +4402,7 @@ static int qf_set_properties(qf_info_T *qi, dict_T *what, int action,
   dictitem_T *di;
   int retval = FAIL;
   int newlist = false;
+  char_u *errorformat = p_efm;
 
   if (action == ' ' || qi->qf_curlist == qi->qf_listcount) {
     newlist = true;
@@ -4471,13 +4484,20 @@ static int qf_set_properties(qf_info_T *qi, dict_T *what, int action,
     }
   }
 
+  if ((di = tv_dict_find(what, S_LEN("efm"))) != NULL) {
+    if (di->di_tv.v_type != VAR_STRING || di->di_tv.vval.v_string == NULL) {
+      return FAIL;
+    }
+    errorformat = di->di_tv.vval.v_string;
+  }
+
   if ((di = tv_dict_find(what, S_LEN("lines"))) != NULL) {
     // Only a List value is supported
     if (di->di_tv.v_type == VAR_LIST && di->di_tv.vval.v_list != NULL) {
       if (action == 'r') {
         qf_free_items(qi, qf_idx);
       }
-      if (qf_init_ext(qi, qf_idx, NULL, NULL, &di->di_tv, p_efm,
+      if (qf_init_ext(qi, qf_idx, NULL, NULL, &di->di_tv, errorformat,
                       false, (linenr_T)0, (linenr_T)0, NULL, NULL) > 0) {
         retval = OK;
       }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -117,7 +117,7 @@ struct qf_info_S {
   qf_list_T qf_lists[LISTCOUNT];
 };
 
-static qf_info_T ql_info;       /* global quickfix list */
+static qf_info_T ql_info;         // global quickfix list
 static unsigned last_qf_id = 0;   // Last Used quickfix list id
 
 #define FMT_PATTERNS 10         /* maximum number of % recognized */

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4131,19 +4131,20 @@ static int qf_get_list_from_text(dictitem_T *di, dict_T *retdict)
        && di->di_tv.vval.v_string != NULL)
       || (di->di_tv.v_type == VAR_LIST
           && di->di_tv.vval.v_list != NULL)) {
+    list_T *l = tv_list_alloc(kListLenMayKnow);
     qf_info_T *qi = xmalloc(sizeof(*qi));
     memset(qi, 0, sizeof(*qi));
     qi->qf_refcount++;
 
     if (qf_init_ext(qi, 0, NULL, NULL, &di->di_tv, p_efm,
                     true, (linenr_T)0, (linenr_T)0, NULL, NULL) > 0) {
-      list_T *l = tv_list_alloc(kListLenMayKnow);
       (void)get_errorlist(qi, NULL, 0, l);
-      tv_dict_add_list(retdict, S_LEN("items"), l);
-      status = OK;
       qf_free(qi, 0);
     }
     xfree(qi);
+
+    tv_dict_add_list(retdict, S_LEN("items"), l);
+    status = OK;
   }
 
   return status;

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2501,3 +2501,29 @@ func Test_add_qf()
   call XaddQf_tests('c')
   call XaddQf_tests('l')
 endfunc
+
+" Test for getting the quickfix list items from some text without modifying
+" the quickfix stack
+func XgetListFromText(cchar)
+  call s:setup_commands(a:cchar)
+  call g:Xsetlist([], 'f')
+
+  let l = g:Xgetlist({'text' : "File1:10:Line10"}).items
+  call assert_equal(1, len(l))
+  call assert_equal('Line10', l[0].text)
+
+  let l = g:Xgetlist({'text' : ["File2:20:Line20", "File2:30:Line30"]}).items
+  call assert_equal(2, len(l))
+  call assert_equal(30, l[1].lnum)
+
+  call assert_equal({}, g:Xgetlist({'text' : 10}))
+  call assert_equal({}, g:Xgetlist({'text' : []}))
+
+  " Make sure that the quickfix stack is not modified
+  call assert_equal(0, g:Xgetlist({'nr' : '$'}).nr)
+endfunc
+
+func Test_get_list_from_text()
+  call XgetListFromText('c')
+  call XgetListFromText('l')
+endfunc

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2335,9 +2335,9 @@ func Xmultidirstack_tests(cchar)
 
   let l1 = g:Xgetlist({'nr':1, 'items':1})
   let l2 = g:Xgetlist({'nr':2, 'items':1})
-  call assert_equal('Xone/a/one.txt', bufname(l1.items[1].bufnr))
+  call assert_equal(expand('Xone/a/one.txt'), bufname(l1.items[1].bufnr))
   call assert_equal(3, l1.items[1].lnum)
-  call assert_equal('Xtwo/a/two.txt', bufname(l2.items[1].bufnr))
+  call assert_equal(expand('Xtwo/a/two.txt'), bufname(l2.items[1].bufnr))
   call assert_equal(5, l2.items[1].lnum)
 endfunc
 

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1879,8 +1879,9 @@ func Xproperty_tests(cchar)
     call g:Xsetlist([], 'r', {'nr':2,'title':'Fruits','context':['Fruits']})
     let l1=g:Xgetlist({'nr':1,'all':1})
     let l2=g:Xgetlist({'nr':2,'all':1})
-    let l1.nr=2
-    let l2.nr=1
+    let save_id = l1.id
+    let l1.id=l2.id
+    let l2.id=save_id
     call g:Xsetlist([], 'r', l1)
     call g:Xsetlist([], 'r', l2)
     let newl1=g:Xgetlist({'nr':1,'all':1})
@@ -2526,4 +2527,39 @@ endfunc
 func Test_get_list_from_text()
   call XgetListFromText('c')
   call XgetListFromText('l')
+endfunc
+
+" Tests for the quickfix list id
+func Xqfid_tests(cchar)
+  call s:setup_commands(a:cchar)
+
+  call g:Xsetlist([], 'f')
+  call assert_equal({}, g:Xgetlist({'id':0}))
+  Xexpr ''
+  let start_id = g:Xgetlist({'id' : 0}).id
+  Xexpr '' | Xexpr ''
+  Xolder
+  call assert_equal(start_id, g:Xgetlist({'id':0, 'nr':1}).id)
+  call assert_equal(start_id + 1, g:Xgetlist({'id':0, 'nr':0}).id)
+  call assert_equal(start_id + 2, g:Xgetlist({'id':0, 'nr':'$'}).id)
+  call assert_equal({}, g:Xgetlist({'id':0, 'nr':99}))
+  call assert_equal(2, g:Xgetlist({'id':start_id + 1, 'nr':0}).nr)
+  call assert_equal({}, g:Xgetlist({'id':99, 'nr':0}))
+  call assert_equal({}, g:Xgetlist({'id':"abc", 'nr':0}))
+
+  call g:Xsetlist([], 'a', {'id':start_id, 'context':[1,2]})
+  call assert_equal([1,2], g:Xgetlist({'nr':1, 'context':1}).context)
+  call g:Xsetlist([], 'a', {'id':start_id+1, 'text':'F1:10:L10'})
+  call assert_equal('L10', g:Xgetlist({'nr':2, 'items':1}).items[0].text)
+  call assert_equal(-1, g:Xsetlist([], 'a', {'id':999, 'title':'Vim'}))
+  call assert_equal(-1, g:Xsetlist([], 'a', {'id':'abc', 'title':'Vim'}))
+
+  let qfid = g:Xgetlist({'id':0, 'nr':0})
+  call g:Xsetlist([], 'f')
+  call assert_equal({}, g:Xgetlist({'id':qfid, 'nr':0}))
+endfunc
+
+func Test_qf_id()
+  call Xqfid_tests('c')
+  call Xqfid_tests('l')
 endfunc

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2281,25 +2281,26 @@ func Xsetexpr_tests(cchar)
   call s:setup_commands(a:cchar)
 
   let t = ["File1:10:Line10", "File1:20:Line20"]
-  call g:Xsetlist([], ' ', {'text' : t})
-  call g:Xsetlist([], 'a', {'text' : "File1:30:Line30"})
+  call g:Xsetlist([], ' ', {'lines' : t})
+  call g:Xsetlist([], 'a', {'lines' : ["File1:30:Line30"]})
 
   let l = g:Xgetlist()
   call assert_equal(3, len(l))
   call assert_equal(20, l[1].lnum)
   call assert_equal('Line30', l[2].text)
-  call g:Xsetlist([], 'r', {'text' : "File2:5:Line5"})
+  call g:Xsetlist([], 'r', {'lines' : ["File2:5:Line5"]})
   let l = g:Xgetlist()
   call assert_equal(1, len(l))
   call assert_equal('Line5', l[0].text)
-  call assert_equal(-1, g:Xsetlist([], 'a', {'text' : 10}))
+  call assert_equal(-1, g:Xsetlist([], 'a', {'lines' : 10}))
+  call assert_equal(-1, g:Xsetlist([], 'a', {'lines' : "F1:10:L10"}))
 
   call g:Xsetlist([], 'f')
   " Add entries to multiple lists
-  call g:Xsetlist([], 'a', {'nr' : 1, 'text' : ["File1:10:Line10"]})
-  call g:Xsetlist([], 'a', {'nr' : 2, 'text' : ["File2:20:Line20"]})
-  call g:Xsetlist([], 'a', {'nr' : 1, 'text' : ["File1:15:Line15"]})
-  call g:Xsetlist([], 'a', {'nr' : 2, 'text' : ["File2:25:Line25"]})
+  call g:Xsetlist([], 'a', {'nr' : 1, 'lines' : ["File1:10:Line10"]})
+  call g:Xsetlist([], 'a', {'nr' : 2, 'lines' : ["File2:20:Line20"]})
+  call g:Xsetlist([], 'a', {'nr' : 1, 'lines' : ["File1:15:Line15"]})
+  call g:Xsetlist([], 'a', {'nr' : 2, 'lines' : ["File2:25:Line25"]})
   call assert_equal('Line15', g:Xgetlist({'nr':1, 'items':1}).items[1].text)
   call assert_equal('Line25', g:Xgetlist({'nr':2, 'items':1}).items[1].text)
 endfunc
@@ -2316,10 +2317,10 @@ func Xmultidirstack_tests(cchar)
   call g:Xsetlist([], 'f')
   Xexpr "" | Xexpr ""
 
-  call g:Xsetlist([], 'a', {'nr' : 1, 'text' : "Entering dir 'Xone/a'"})
-  call g:Xsetlist([], 'a', {'nr' : 2, 'text' : "Entering dir 'Xtwo/a'"})
-  call g:Xsetlist([], 'a', {'nr' : 1, 'text' : "one.txt:3:one one one"})
-  call g:Xsetlist([], 'a', {'nr' : 2, 'text' : "two.txt:5:two two two"})
+  call g:Xsetlist([], 'a', {'nr' : 1, 'lines' : ["Entering dir 'Xone/a'"]})
+  call g:Xsetlist([], 'a', {'nr' : 2, 'lines' : ["Entering dir 'Xtwo/a'"]})
+  call g:Xsetlist([], 'a', {'nr' : 1, 'lines' : ["one.txt:3:one one one"]})
+  call g:Xsetlist([], 'a', {'nr' : 2, 'lines' : ["two.txt:5:two two two"]})
 
   let l1 = g:Xgetlist({'nr':1, 'items':1})
   let l2 = g:Xgetlist({'nr':2, 'items':1})
@@ -2353,10 +2354,10 @@ func Xmultifilestack_tests(cchar)
   call g:Xsetlist([], 'f')
   Xexpr "" | Xexpr ""
 
-  call g:Xsetlist([], 'a', {'nr' : 1, 'text' : "[one.txt]"})
-  call g:Xsetlist([], 'a', {'nr' : 2, 'text' : "[two.txt]"})
-  call g:Xsetlist([], 'a', {'nr' : 1, 'text' : "(3,5) one one one"})
-  call g:Xsetlist([], 'a', {'nr' : 2, 'text' : "(5,9) two two two"})
+  call g:Xsetlist([], 'a', {'nr' : 1, 'lines' : ["[one.txt]"]})
+  call g:Xsetlist([], 'a', {'nr' : 2, 'lines' : ["[two.txt]"]})
+  call g:Xsetlist([], 'a', {'nr' : 1, 'lines' : ["(3,5) one one one"]})
+  call g:Xsetlist([], 'a', {'nr' : 2, 'lines' : ["(5,9) two two two"]})
 
   let l1 = g:Xgetlist({'nr':1, 'items':1})
   let l2 = g:Xgetlist({'nr':2, 'items':1})
@@ -2505,28 +2506,26 @@ endfunc
 
 " Test for getting the quickfix list items from some text without modifying
 " the quickfix stack
-func XgetListFromText(cchar)
+func XgetListFromLines(cchar)
   call s:setup_commands(a:cchar)
   call g:Xsetlist([], 'f')
 
-  let l = g:Xgetlist({'text' : "File1:10:Line10"}).items
-  call assert_equal(1, len(l))
-  call assert_equal('Line10', l[0].text)
-
-  let l = g:Xgetlist({'text' : ["File2:20:Line20", "File2:30:Line30"]}).items
+  let l = g:Xgetlist({'lines' : ["File2:20:Line20", "File2:30:Line30"]}).items
   call assert_equal(2, len(l))
   call assert_equal(30, l[1].lnum)
 
-  call assert_equal({}, g:Xgetlist({'text' : 10}))
-  call assert_equal([], g:Xgetlist({'text' : []}).items)
+  call assert_equal({}, g:Xgetlist({'lines' : 10}))
+  call assert_equal({}, g:Xgetlist({'lines' : 'File1:10:Line10'}))
+  call assert_equal([], g:Xgetlist({'lines' : []}).items)
+  call assert_equal([], g:Xgetlist({'lines' : [10, 20]}).items)
 
   " Make sure that the quickfix stack is not modified
   call assert_equal(0, g:Xgetlist({'nr' : '$'}).nr)
 endfunc
 
-func Test_get_list_from_text()
-  call XgetListFromText('c')
-  call XgetListFromText('l')
+func Test_get_list_from_lines()
+  call XgetListFromLines('c')
+  call XgetListFromLines('l')
 endfunc
 
 " Tests for the quickfix list id
@@ -2549,7 +2548,7 @@ func Xqfid_tests(cchar)
 
   call g:Xsetlist([], 'a', {'id':start_id, 'context':[1,2]})
   call assert_equal([1,2], g:Xgetlist({'nr':1, 'context':1}).context)
-  call g:Xsetlist([], 'a', {'id':start_id+1, 'text':'F1:10:L10'})
+  call g:Xsetlist([], 'a', {'id':start_id+1, 'lines':['F1:10:L10']})
   call assert_equal('L10', g:Xgetlist({'nr':2, 'items':1}).items[0].text)
   call assert_equal(-1, g:Xsetlist([], 'a', {'id':999, 'title':'Vim'}))
   call assert_equal(-1, g:Xsetlist([], 'a', {'id':'abc', 'title':'Vim'}))

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2518,7 +2518,7 @@ func XgetListFromText(cchar)
   call assert_equal(30, l[1].lnum)
 
   call assert_equal({}, g:Xgetlist({'text' : 10}))
-  call assert_equal({}, g:Xgetlist({'text' : []}))
+  call assert_equal([], g:Xgetlist({'text' : []}).items)
 
   " Make sure that the quickfix stack is not modified
   call assert_equal(0, g:Xgetlist({'nr' : '$'}).nr)

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2303,6 +2303,17 @@ func Xsetexpr_tests(cchar)
   call g:Xsetlist([], 'a', {'nr' : 2, 'lines' : ["File2:25:Line25"]})
   call assert_equal('Line15', g:Xgetlist({'nr':1, 'items':1}).items[1].text)
   call assert_equal('Line25', g:Xgetlist({'nr':2, 'items':1}).items[1].text)
+
+  " Adding entries using a custom efm
+  set efm&
+  call g:Xsetlist([], ' ', {'efm' : '%f#%l#%m',
+				\ 'lines' : ["F1#10#L10", "F2#20#L20"]})
+  call assert_equal(20, g:Xgetlist({'items':1}).items[1].lnum)
+  call g:Xsetlist([], 'a', {'efm' : '%f#%l#%m', 'lines' : ["F3:30:L30"]})
+  call assert_equal('F3:30:L30', g:Xgetlist({'items':1}).items[2].text)
+  call assert_equal(20, g:Xgetlist({'items':1}).items[1].lnum)
+  call assert_equal(-1, g:Xsetlist([], 'a', {'efm' : [],
+				\ 'lines' : ['F1:10:L10']}))
 endfunc
 
 func Test_setexpr()
@@ -2518,6 +2529,17 @@ func XgetListFromLines(cchar)
   call assert_equal({}, g:Xgetlist({'lines' : 'File1:10:Line10'}))
   call assert_equal([], g:Xgetlist({'lines' : []}).items)
   call assert_equal([], g:Xgetlist({'lines' : [10, 20]}).items)
+
+  " Parse text using a custom efm
+  set efm&
+  let l = g:Xgetlist({'lines':['File3#30#Line30'], 'efm' : '%f#%l#%m'}).items
+  call assert_equal('Line30', l[0].text)
+  let l = g:Xgetlist({'lines':['File3:30:Line30'], 'efm' : '%f-%l-%m'}).items
+  call assert_equal('File3:30:Line30', l[0].text)
+  let l = g:Xgetlist({'lines':['File3:30:Line30'], 'efm' : [1,2]})
+  call assert_equal({}, l)
+  call assert_fails("call g:Xgetlist({'lines':['abc'], 'efm':'%2'})", 'E376:')
+  call assert_fails("call g:Xgetlist({'lines':['abc'], 'efm':''})", 'E378:')
 
   " Make sure that the quickfix stack is not modified
   call assert_equal(0, g:Xgetlist({'nr' : '$'}).nr)


### PR DESCRIPTION
**vim-patch:8.0.1006: quickfix list changes when parsing text with 'erroformat'**

Problem:    Cannot parse text with 'erroformat' without changing a quickfix
            list.
Solution:   Add the "text" argument to getqflist(). (Yegappan Lakshmanan)
https://github.com/vim/vim/commit/7adf06f4e25c795ba32ff0b2e8591330f6a41afb

**vim-patch:8.0.1023: it is not easy to identify a quickfix list**

Problem:    It is not easy to identify a quickfix list.
Solution:   Add the "id" field. (Yegappan Lakshmanan)
vim/vim@a539f4f

**vim-patch:8.0.1029: return value of getqflist() is inconsistent**

Problem:    Return value of getqflist() is inconsistent.  (Lcd47)
Solution:   Always return an "items" entry.
vim/vim@da73253

**vim-patch:8.0.1031: "text" argument for getqflist() is confusing**

Problem:    "text" argument for getqflist() is confusing. (Lcd47)
Solution:   Use "lines" instead. (Yegappan Lakshmanan)
vim/vim@2c809b7

**vim-patch:8.0.1040: cannot use another error format in getqflist()**

Problem:    Cannot use another error format in getqflist().
Solution:   Add the "efm" argument to getqflist(). (Yegappan Lakshmanan)
vim/vim@3653822