### PR TITLE
 [WIP] ui: flush UI state on exit

### DIFF
--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -138,8 +138,8 @@ void mch_exit(int r)
 {
   exiting = true;
 
-  ui_builtin_stop();
   ui_flush();
+  ui_builtin_stop();
   ml_close_all(true);           // remove all memfiles
 
   if (!event_teardown() && r == 0) {


### PR DESCRIPTION
Fix a regression from #8790 https://github.com/neovim/neovim/commit/fa4c2601000df2d792b0de865da3ac8c43ab723f where the following code stops being functional:
```
au VimLeave * set guicursor=a:ver1-Cursor/lCursor-blinkon1
```
@msva does this work for you?
