### PR TITLE
Redraw statusline when the term title changes

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4508,8 +4508,14 @@ void status_redraw_all(void)
  */
 void status_redraw_curbuf(void)
 {
+  status_redraw_buf(curbuf);
+}
+
+// mark all status lines of the specified buffer for redraw
+void status_redraw_buf(buf_T *buf)
+{
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    if (wp->w_status_height != 0 && wp->w_buffer == curbuf) {
+    if (wp->w_status_height != 0 && wp->w_buffer == buf) {
       wp->w_redr_status = TRUE;
       redraw_later(VALID);
     }

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -668,6 +668,7 @@ static void buf_set_term_title(buf_T *buf, char *title)
                false,
                &err);
   api_clear_error(&err);
+  status_redraw_buf(buf);
 }
 
 static int term_settermprop(VTermProp prop, VTermValue *val, void *data)


### PR DESCRIPTION
The statusline may incorporate b:term_title, so redraw it when that
title changes.

Introduce a new function status_redraw_buf to redraw windows associated
with the current buffer.