### PR TITLE
[RFC] vim-patch:8.0.{1377,1378}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19820,7 +19820,7 @@ void ex_function(exarg_T *eap)
   // s:func      script-local function name
   // g:func      global function name, same as "func"
   p = eap->arg;
-  name = trans_function_name(&p, eap->skip, 0, &fudi, NULL);
+  name = trans_function_name(&p, eap->skip, TFN_NO_AUTOLOAD, &fudi, NULL);
   paren = (vim_strchr(p, '(') != NULL);
   if (name == NULL && (fudi.fd_dict == NULL || !paren) && !eap->skip) {
     /*

--- a/src/nvim/testdir/sautest/autoload/foo.vim
+++ b/src/nvim/testdir/sautest/autoload/foo.vim
@@ -1,0 +1,7 @@
+let g:loaded_foo_vim += 1
+
+let foo#bar = {}
+
+func foo#bar.echo()
+  let g:called_foo_bar_echo += 1
+endfunc

--- a/src/nvim/testdir/sautest/autoload/globone.vim
+++ b/src/nvim/testdir/sautest/autoload/globone.vim
@@ -1,0 +1,1 @@
+" used by Test_globpath()

--- a/src/nvim/testdir/sautest/autoload/globtwo.vim
+++ b/src/nvim/testdir/sautest/autoload/globtwo.vim
@@ -1,0 +1,1 @@
+" used by Test_globpath()

--- a/src/nvim/testdir/sautest/autoload/sourced.vim
+++ b/src/nvim/testdir/sautest/autoload/sourced.vim
@@ -1,0 +1,3 @@
+let g:loaded_sourced_vim += 1
+func! sourced#something()
+endfunc

--- a/src/nvim/testdir/test_autoload.vim
+++ b/src/nvim/testdir/test_autoload.vim
@@ -2,10 +2,16 @@
 
 set runtimepath=./sautest
 
-func! Test_autoload_dict_func()
+func Test_autoload_dict_func()
   let g:loaded_foo_vim = 0
   let g:called_foo_bar_echo = 0
   call g:foo#bar.echo()
   call assert_equal(1, g:loaded_foo_vim)
   call assert_equal(1, g:called_foo_bar_echo)
+endfunc
+
+func Test_source_autoload()
+  let g:loaded_sourced_vim = 0
+  source sautest/autoload/sourced.vim
+  call assert_equal(1, g:loaded_sourced_vim)
 endfunc

--- a/src/nvim/testdir/test_autoload.vim
+++ b/src/nvim/testdir/test_autoload.vim
@@ -1,0 +1,11 @@
+" Tests for autoload
+
+set runtimepath=./sautest
+
+func! Test_autoload_dict_func()
+  let g:loaded_foo_vim = 0
+  let g:called_foo_bar_echo = 0
+  call g:foo#bar.echo()
+  call assert_equal(1, g:loaded_foo_vim)
+  call assert_equal(1, g:called_foo_bar_echo)
+endfunc

--- a/src/nvim/testdir/test_escaped_glob.vim
+++ b/src/nvim/testdir/test_escaped_glob.vim
@@ -17,6 +17,7 @@ function Test_glob()
   call assert_equal("", glob('Xxx\{'))
   call assert_equal("", glob('Xxx\$'))
   w! Xxx{
+  " } to fix highlighting
   w! Xxx\$
   call assert_equal("Xxx{", glob('Xxx\{'))
   call assert_equal("Xxx$", glob('Xxx\$'))
@@ -25,9 +26,8 @@ function Test_glob()
 endfunction
 
 function Test_globpath()
-  let slash = (!exists('+shellslash') || &shellslash) ? '/' : '\'
-  call assert_equal('sautest'.slash.'autoload'.slash.'footest.vim',
-        \ globpath('sautest/autoload', '*.vim'))
-  call assert_equal(['sautest'.slash.'autoload'.slash.'footest.vim'],
-        \ globpath('sautest/autoload', '*.vim', 0, 1))
+  call assert_equal(expand("sautest/autoload/globone.vim\nsautest/autoload/globtwo.vim"),
+  \ globpath('sautest/autoload', 'glob*.vim'))
+  call assert_equal([expand('sautest/autoload/globone.vim'), expand('sautest/autoload/globtwo.vim')],
+  \ globpath('sautest/autoload', 'glob*.vim', 0, 1))
 endfunction


### PR DESCRIPTION
**vim-patch:8.0.1377: cannot call a dict function in autoloaded dict**

Problem:    Cannot call a dict function in autoloaded dict.
Solution:   Call get_lval() passing the read-only flag.
https://github.com/vim/vim/commit/6e65d594aa33be11f6074f26e9ff81b52504c62b

**vim-patch:8.0.1378: autoload script sources itself when defining function**

Problem:    Autoload script sources itself when defining function.
Solution:   Pass TFN_NO_AUTOLOAD to trans_function_name(). (Yasuhiro
            Matsumoto, closes vim/vim#2423)
vim/vim@3388d33