### PR TITLE
vim-patch:8.1.0011

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12145,8 +12145,12 @@ static void get_maparg(typval_T *argvars, typval_T *rettv, int exact)
   if (!get_dict) {
     // Return a string.
     if (rhs != NULL) {
-      rettv->vval.v_string = (char_u *)str2special_save(
-          (const char *)rhs, false, false);
+      if (*rhs == NUL) {
+        rettv->vval.v_string = vim_strsave((char_u *)"<Nop>");
+      } else {
+        rettv->vval.v_string = (char_u *)str2special_save(
+            (char *)rhs, false, false);
+      }
     }
 
   } else {

--- a/src/nvim/testdir/test_maparg.vim
+++ b/src/nvim/testdir/test_maparg.vim
@@ -29,9 +29,13 @@ function Test_maparg()
         \ maparg('foo', '', 0, 1))
 
   map abc x<char-114>x
-  call assert_equal(maparg('abc'), "xrx")
+  call assert_equal("xrx", maparg('abc'))
   map abc y<S-char-114>y
-  call assert_equal(maparg('abc'), "yRy")
+  call assert_equal("yRy", maparg('abc'))
+
+  map abc <Nop>
+  call assert_equal("<Nop>", maparg('abc'))
+  unmap abc
 endfunction
 
 function Test_range_map()


### PR DESCRIPTION
**vim-patch:8.1.0011: maparg() and mapcheck() confuse empty and non-existing**

Problem:    maparg() and mapcheck() confuse empty and non-existing.
Solution:   Return <Nop> for an existing non-empty mapping. (closes vim/vim#2940)
https://github.com/vim/vim/commit/f88a5bc10232cc3fac92dba4e8455f4c14311f8e