### PR TITLE
[RDY] vim-patch:8.1.0174

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1884,16 +1884,18 @@ int onepage(int dir, long count)
   }
   curwin->w_valid &= ~(VALID_WCOL|VALID_WROW|VALID_VIRTCOL);
 
-  /*
-   * Avoid the screen jumping up and down when 'scrolloff' is non-zero.
-   * But make sure we scroll at least one line (happens with mix of long
-   * wrapping lines and non-wrapping line).
-   */
-  if (retval == OK && dir == FORWARD && check_top_offset()) {
-    scroll_cursor_top(1, false);
-    if (curwin->w_topline <= old_topline
-        && old_topline < curbuf->b_ml.ml_line_count) {
-      curwin->w_topline = old_topline + 1;
+  if (retval == OK && dir == FORWARD) {
+    // Avoid the screen jumping up and down when 'scrolloff' is non-zero.
+    // But make sure we scroll at least one line (happens with mix of long
+    // wrapping lines and non-wrapping line).
+    if (check_top_offset()) {
+      scroll_cursor_top(1, false);
+      if (curwin->w_topline <= old_topline
+          && old_topline < curbuf->b_ml.ml_line_count) {
+        curwin->w_topline = old_topline + 1;
+        (void)hasFolding(curwin->w_topline, &curwin->w_topline, NULL);
+      }
+    } else if (curwin->w_botline > curbuf->b_ml.ml_line_count) {
       (void)hasFolding(curwin->w_topline, &curwin->w_topline, NULL);
     }
   }

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -16,7 +16,6 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
-#include "nvim/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/move.h"
 #include "nvim/charset.h"
@@ -1726,7 +1725,7 @@ void cursor_correct(void)
  *
  * return FAIL for failure, OK otherwise
  */
-int onepage(int dir, long count)
+int onepage(Direction dir, long count)
 {
   long n;
   int retval = OK;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2168,9 +2168,7 @@ void do_check_cursorbind(void)
         restart_edit = restart_edit_save;
       }
       // Correct cursor for multi-byte character.
-      if (has_mbyte) {
-        mb_adjust_cursor();
-      }
+      mb_adjust_cursor();
       redraw_later(VALID);
 
       // Only scroll when 'scrollbind' hasn't done this.

--- a/src/nvim/move.h
+++ b/src/nvim/move.h
@@ -2,8 +2,7 @@
 #define NVIM_MOVE_H
 
 #include <stdbool.h>
-#include "nvim/buffer_defs.h"
-#include "nvim/pos.h"
+#include "nvim/vim.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "move.h.generated.h"

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -1,5 +1,7 @@
 " Test for folding
 
+source view_util.vim
+
 func PrepIndent(arg)
   return [a:arg] + repeat(["\t".a:arg], 5)
 endfu
@@ -647,4 +649,28 @@ func Test_foldtext_recursive()
   call assert_equal(1, foldclosed(2))
   call assert_equal(3, foldclosedend(2))
   bwipe!
+endfunc
+
+func Test_fold_last_line_with_pagedown()
+  enew!
+  set fdm=manual
+
+  let expect = '+-- 11 lines: 9---'
+  let content = range(1,19)
+  call append(0, content)
+  normal dd9G
+  normal zfG
+  normal zt
+  call assert_equal('9', getline(foldclosed('.')))
+  call assert_equal('19', getline(foldclosedend('.')))
+  call assert_equal(expect, ScreenLines(1, len(expect))[0])
+  call feedkeys("\<C-F>", 'xt')
+  call assert_equal(expect, ScreenLines(1, len(expect))[0])
+  call feedkeys("\<C-F>", 'xt')
+  call assert_equal(expect, ScreenLines(1, len(expect))[0])
+  call feedkeys("\<C-B>\<C-F>\<C-F>", 'xt')
+  call assert_equal(expect, ScreenLines(1, len(expect))[0])
+
+  set fdm&
+  enew!
 endfunc


### PR DESCRIPTION
**vim-patch:8.1.0174: after paging up and down fold line is wrong**

Problem:    After paging up and down fold line is wrong.
Solution:   Correct the computation of w_topline and w_botline. (Hirohito
            Higashi)
https://github.com/vim/vim/commit/907dad72ef9d29422352fb74ba156e7085a3fc71