### PR TITLE
vim-patch:8.0.1154

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -6954,7 +6954,7 @@ bool in_cinkeys(int keytyped, int when, bool line_is_empty)
         if (match && try_match_word && !try_match) {
           /* "0=word": Check if there are only blanks before the
            * word. */
-          if (getwhitecols(line) !=
+          if (getwhitecols_curline() !=
               (int)(curwin->w_cursor.col - (p - look))) {
             match = false;
           }

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -314,6 +314,33 @@ func! Test_edit_11()
   bw!
 endfunc
 
+func! Test_edit_11_indentexpr()
+  " Test that indenting kicks in
+  new
+  " Use indentexpr instead of cindenting
+  func! Do_Indent()
+    let pline=prevnonblank(v:lnum)
+    if empty(getline(v:lnum))
+      if getline(pline) =~ 'if\|then'
+        return shiftwidth()
+      else
+        return 0
+      endif
+    else
+        return 0
+    endif
+  endfunc
+  setl indentexpr=Do_Indent() indentkeys+=0=then,0=fi
+  call setline(1, ['if [ $this ]'])
+  call cursor(1, 1)
+  call feedkeys("othen\<cr>that\<cr>fi", 'tnix')
+  call assert_equal(['if [ $this ]', "then", "\<tab>that", "fi"], getline(1, '$'))
+  set cinkeys&vim indentkeys&vim
+  set nocindent indentexpr=
+  delfu Do_Indent
+  bw!
+endfunc
+
 func! Test_edit_12()
   " Test changing indent in replace mode
   new


### PR DESCRIPTION
**vim-patch:8.0.1154: 'indentkeys' does not work properly**

Problem:    'indentkeys' does not work properly. (Gary Johnson)
Solution:   Get the cursor line again. (Christian Brabandt, closes vim/vim#2151)
https://github.com/vim/vim/commit/1b38344e00af65df12946fffda7f3201621c35ef