### PR TITLE
[RFC] vim-patch:8.0.1809,8.1.{34,219}

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -298,7 +298,7 @@ static void insert_enter(InsertState *s)
 
   // Check if the cursor line needs redrawing before changing State. If
   // 'concealcursor' is "n" it needs to be redrawn without concealing.
-  conceal_check_cursur_line();
+  conceal_check_cursor_line();
 
   // When doing a paste with the middle mouse button, Insstart is set to
   // where the paste started.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2546,11 +2546,17 @@ int do_ecmd(
     }
     check_arg_idx(curwin);
 
-    // If autocommands change the cursor position or topline, we should keep
-    // it.  Also when it moves within a line.
+    // If autocommands change the cursor position or topline, we should
+    // keep it.  Also when it moves within a line. But not when it moves
+    // to the first non-blank.
     if (!equalpos(curwin->w_cursor, orig_pos)) {
-      newlnum = curwin->w_cursor.lnum;
-      newcol = curwin->w_cursor.col;
+      const char_u *text = get_cursor_line_ptr();
+
+      if (curwin->w_cursor.lnum != orig_pos.lnum
+          || curwin->w_cursor.col != (int)(skipwhite(text) - text)) {
+        newlnum = curwin->w_cursor.lnum;
+        newcol = curwin->w_cursor.col;
+      }
     }
     if (curwin->w_topline == topline)
       topline = 0;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8735,7 +8735,7 @@ static char_u *arg_all(void)
 #ifndef BACKSLASH_IN_FILENAME
             || *p == '\\'
 #endif
-            ) {
+            || *p == '`') {
           // insert a backslash
           if (retval != NULL) {
             retval[len] = '\\';

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6496,7 +6496,7 @@ void may_start_select(int c)
  */
 static void n_start_visual_mode(int c)
 {
-  /* Check for redraw before changing the state. */
+  // Check for redraw before changing the state.
   conceal_check_cursor_line();
 
   VIsual_mode = c;
@@ -6514,7 +6514,7 @@ static void n_start_visual_mode(int c)
   foldAdjustVisual();
 
   setmouse();
-  /* Check for redraw after changing the state. */
+  // Check for redraw after changing the state.
   conceal_check_cursor_line();
 
   if (p_smd && msg_silent == 0)

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6497,7 +6497,7 @@ void may_start_select(int c)
 static void n_start_visual_mode(int c)
 {
   /* Check for redraw before changing the state. */
-  conceal_check_cursur_line();
+  conceal_check_cursor_line();
 
   VIsual_mode = c;
   VIsual_active = true;
@@ -6515,7 +6515,7 @@ static void n_start_visual_mode(int c)
 
   setmouse();
   /* Check for redraw after changing the state. */
-  conceal_check_cursur_line();
+  conceal_check_cursor_line();
 
   if (p_smd && msg_silent == 0)
     redraw_cmdline = true;      /* show visual mode later */

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -478,7 +478,7 @@ int conceal_cursor_line(win_T *wp)
 /*
  * Check if the cursor line needs to be redrawn because of 'concealcursor'.
  */
-void conceal_check_cursur_line(void)
+void conceal_check_cursor_line(void)
 {
   if (curwin->w_p_cole > 0 && conceal_cursor_line(curwin)) {
     need_cursor_line_redraw = TRUE;

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1338,6 +1338,14 @@ func! Test_edit_rightleft()
   bw!
 endfunc
 
+func Test_edit_backtick()
+  next a\`b c
+  call assert_equal('a`b', expand('%'))
+  next
+  call assert_equal('c', expand('%'))
+  call assert_equal('a\`b c', expand('##'))
+endfunc
+
 func Test_edit_quit()
   edit foo.txt
   split

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1390,3 +1390,18 @@ func Test_edit_complete_very_long_name()
   endif
   set swapfile&
 endfunc
+
+func Test_edit_alt()
+  " Keeping the cursor line didn't happen when the first line has indent.
+  new
+  call setline(1, ['  one', 'two', 'three'])
+  w XAltFile
+  $
+  call assert_equal(3, line('.'))
+  e Xother
+  e #
+  call assert_equal(3, line('.'))
+
+  bwipe XAltFile
+  call delete('XAltFile')
+endfunc

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -393,7 +393,7 @@ void ui_cursor_shape(void)
     mode_idx = new_mode_idx;
     pending_mode_update = true;
   }
-  conceal_check_cursur_line();
+  conceal_check_cursor_line();
 }
 
 /// Returns true if `widget` is externalized.


### PR DESCRIPTION
**vim-patch:8.0.1809: various typos**

Problem:    Various typos.
Solution:   Correct the mistakes, change "cursur" to "cursor". (closes vim/vim#2887)
vim/vim@b946482

**vim-patch:8.1.0034: cursor not restored with ":edit #"**

Problem:    Cursor not restored with ":edit #".
Solution:   Don't assume autocommands moved the cursor when it was moved to
            the first non-blank.
https://github.com/vim/vim/commit/adb8fbec4f4059d214fe6acf2485ffd35e803450

**vim-patch:8.1.0219: expanding ## fails to escape backtick**

Problem:    Expanding ## fails to escape backtick.
Solution:   Escape a backtick in a file name. (closes vim/vim#3257)
vim/vim@2c8c681