### PR TITLE
UI/cleanup: Remove most redraw_later_clear() calls

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1176,16 +1176,6 @@ static void do_filter(
   cmd_buf = make_filter_cmd(cmd, itmp, otmp);
   ui_cursor_goto((int)Rows - 1, 0);
 
-  /*
-   * When not redirecting the output the command can write anything to the
-   * screen. If 'shellredir' is equal to ">", screen may be messed up by
-   * stderr output of external command. Clear the screen later.
-   * If do_in is FALSE, this could be something like ":r !cat", which may
-   * also mess up the screen, clear it later.
-   */
-  if (!do_out || STRCMP(p_srr, ">") == 0 || !do_in)
-    redraw_later_clear();
-
   if (do_out) {
     if (u_save((linenr_T)(line2), (linenr_T)(line2 + 1)) == FAIL) {
       xfree(cmd_buf);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1185,19 +1185,8 @@ static void do_filter(
   }
   read_linecount = curbuf->b_ml.ml_line_count;
 
-  // When call_shell() fails wait_return() is called to give the user a chance
-  // to read the error messages. Otherwise errors are ignored, so you can see
-  // the error messages from the command that appear on stdout; use 'u' to fix
-  // the text.
   // Pass on the kShellOptDoOut flag when the output is being redirected.
-  if (call_shell(
-        cmd_buf,
-        kShellOptFilter | shell_flags,
-        NULL
-        )) {
-    redraw_later_clear();
-    wait_return(FALSE);
-  }
+  call_shell(cmd_buf, kShellOptFilter | shell_flags, NULL);
   xfree(cmd_buf);
 
   did_check_timestamps = FALSE;
@@ -1298,23 +1287,17 @@ filterend:
   xfree(otmp);
 }
 
-/*
- * Call a shell to execute a command.
- * When "cmd" is NULL start an interactive shell.
- */
+// Call a shell to execute a command.
+// When "cmd" is NULL start an interactive shell.
 void
 do_shell(
     char_u *cmd,
     int flags             // may be SHELL_DOOUT when output is redirected
 )
 {
-  int save_nwr;
-
-  /*
-   * Disallow shell commands in restricted mode (-Z)
-   * Disallow shell commands from .exrc and .vimrc in current directory for
-   * security reasons.
-   */
+  // Disallow shell commands in restricted mode (-Z)
+  // Disallow shell commands from .exrc and .vimrc in current directory for
+  // security reasons.
   if (check_restricted() || check_secure()) {
     msg_end();
     return;
@@ -1352,33 +1335,7 @@ do_shell(
   msg_row = Rows - 1;
   msg_col = 0;
 
-  if (autocmd_busy) {
-    if (msg_silent == 0)
-      redraw_later_clear();
-  } else {
-    /*
-     * For ":sh" there is no need to call wait_return(), just redraw.
-     * Also for the Win32 GUI (the output is in a console window).
-     * Otherwise there is probably text on the screen that the user wants
-     * to read before redrawing, so call wait_return().
-     */
-    if (cmd == NULL
-        ) {
-      if (msg_silent == 0)
-        redraw_later_clear();
-      need_wait_return = FALSE;
-    } else {
-      /*
-       * If we switch screens when starttermcap() is called, we really
-       * want to wait for "hit return to continue".
-       */
-      save_nwr = no_wait_return;
-      wait_return(msg_silent == 0);
-      no_wait_return = save_nwr;
-    }
-  }
-
-  /* display any error messages now */
+  // display any error messages now
   display_errors();
 
   apply_autocmds(EVENT_SHELLCMDPOST, NULL, NULL, FALSE, curbuf);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6342,9 +6342,7 @@ static void ex_hide(exarg_T *eap)
     }
 }
 
-/*
- * ":stop" and ":suspend": Suspend Vim.
- */
+/// ":stop" and ":suspend": Suspend Vim.
 static void ex_stop(exarg_T *eap)
 {
   // Disallow suspending in restricted mode (-Z)
@@ -6363,7 +6361,6 @@ static void ex_stop(exarg_T *eap)
     ui_flush();
     maketitle();
     resettitle();  // force updating the title
-    redraw_later_clear();
     ui_refresh();  // may have resized window
     apply_autocmds(EVENT_VIMRESUME, NULL, NULL, false, NULL);
   }

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2707,8 +2707,10 @@ void fast_breakcheck(void)
   }
 }
 
-// os_call_shell wrapper. Handles 'verbose', :profile, and v:shell_error.
-// Invalidates cached tags.
+/// os_call_shell() wrapper. Handles 'verbose', :profile, and v:shell_error.
+/// Invalidates cached tags.
+///
+/// @return shell command exit code
 int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
 {
   int retval;

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -101,6 +101,8 @@ void shell_free_argv(char **argv)
 /// @param cmd The command to execute, or NULL to run an interactive shell.
 /// @param opts Options that control how the shell will work.
 /// @param extra_args Extra arguments to the shell, or NULL.
+///
+/// @return shell command exit code
 int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_args)
 {
   DynamicBuffer input = DYNAMIC_BUFFER_INIT;

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -419,7 +419,6 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
     xfree(tempname);
     // With interactive completion, the error message is not printed.
     if (!(flags & EW_SILENT)) {
-      redraw_later_clear();             // probably messed up screen
       msg_putchar('\n');                // clear bottom line quickly
 #if SIZEOF_LONG > SIZEOF_INT
       assert(Rows <= (long)INT_MAX + 1);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -158,10 +158,7 @@ void redraw_win_later(win_T *wp, int type)
   }
 }
 
-/*
- * Force a complete redraw later.  Also resets the highlighting.  To be used
- * after executing a shell command that messes up the screen.
- */
+/// Forces a complete redraw later.  Also resets the highlighting.
 void redraw_later_clear(void)
 {
   redraw_all_later(CLEAR);


### PR DESCRIPTION
Vim :! may "mess up the screen" because of e.g. switching between cooked mode, but Nvim just uses pipes. So maybe we can avoid these `redraw_later_clear()` CYA calls.