### PR TITLE
vim-patch:8.1.0372: screen updating slow when 'cursorline' is set

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1534,12 +1534,14 @@ void edit_putchar(int c, int highlight)
 void edit_unputchar(void)
 {
   if (pc_status != PC_STATUS_UNSET && pc_row >= msg_scrolled) {
-    if (pc_status == PC_STATUS_RIGHT)
-      ++curwin->w_wcol;
-    if (pc_status == PC_STATUS_RIGHT || pc_status == PC_STATUS_LEFT)
-      redrawWinline(curwin->w_cursor.lnum, FALSE);
-    else
+    if (pc_status == PC_STATUS_RIGHT) {
+      curwin->w_wcol++;
+    }
+    if (pc_status == PC_STATUS_RIGHT || pc_status == PC_STATUS_LEFT) {
+      redrawWinline(curwin, curwin->w_cursor.lnum, false);
+    } else {
       screen_puts(pc_bytes, pc_row - msg_scrolled, pc_col, pc_attr);
+    }
   }
 }
 
@@ -1576,7 +1578,7 @@ static void undisplay_dollar(void)
 {
   if (dollar_vcol >= 0) {
     dollar_vcol = -1;
-    redrawWinline(curwin->w_cursor.lnum, FALSE);
+    redrawWinline(curwin, curwin->w_cursor.lnum, false);
   }
 }
 
@@ -5909,7 +5911,7 @@ static void check_spell_redraw(void)
     linenr_T lnum = spell_redraw_lnum;
 
     spell_redraw_lnum = 0;
-    redrawWinline(lnum, FALSE);
+    redrawWinline(curwin, lnum, false);
   }
 }
 

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -96,16 +96,25 @@ static void comp_botline(win_T *wp)
   set_empty_rows(wp, done);
 }
 
-/*
-* Redraw when w_cline_row changes and 'relativenumber' or 'cursorline' is
-* set.
-*/
+static linenr_T last_cursorline = 0;
+
+// Redraw when w_cline_row changes and 'relativenumber' or 'cursorline' is set.
 static void redraw_for_cursorline(win_T *wp)
 {
   if ((wp->w_p_rnu || wp->w_p_cul)
       && (wp->w_valid & VALID_CROW) == 0
       && !pum_visible()) {
-    redraw_win_later(wp, SOME_VALID);
+    if (!wp->w_p_rnu && wp->w_redr_type <= VALID && last_cursorline != 0) {
+      // "last_cursorline" may be set for another window, worst case we
+      // redraw too much.  This is optimized for moving the cursor around
+      // in the same window.
+      redrawWinline(wp, last_cursorline, false);
+      redrawWinline(wp, wp->w_cursor.lnum, false);
+      last_cursorline = wp->w_cursor.lnum;
+      redraw_win_later(wp, VALID);
+    } else {
+      redraw_win_later(wp, SOME_VALID);
+    }
   }
 }
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -200,24 +200,28 @@ void redraw_buf_later(buf_T *buf, int type)
  * may become invalid and the whole window will have to be redrawn.
  */
 void
-redrawWinline (
+redrawWinline(
+    win_T *wp,
     linenr_T lnum,
     int invalid             /* window line height is invalid now */
 )
 {
   int i;
 
-  if (curwin->w_redraw_top == 0 || curwin->w_redraw_top > lnum)
-    curwin->w_redraw_top = lnum;
-  if (curwin->w_redraw_bot == 0 || curwin->w_redraw_bot < lnum)
-    curwin->w_redraw_bot = lnum;
-  redraw_later(VALID);
+    if (wp->w_redraw_top == 0 || wp->w_redraw_top > lnum) {
+        wp->w_redraw_top = lnum;
+    }
+    if (wp->w_redraw_bot == 0 || wp->w_redraw_bot < lnum) {
+        wp->w_redraw_bot = lnum;
+    }
+    redraw_win_later(wp, VALID);
 
   if (invalid) {
-    /* A w_lines[] entry for this lnum has become invalid. */
-    i = find_wl_entry(curwin, lnum);
-    if (i >= 0)
-      curwin->w_lines[i].wl_valid = FALSE;
+    // A w_lines[] entry for this lnum has become invalid.
+    i = find_wl_entry(wp, lnum);
+    if (i >= 0) {
+      wp->w_lines[i].wl_valid = false;
+    }
   }
 }
 


### PR DESCRIPTION
Problem:    Screen updating slow when 'cursorline' is set.
Solution:   Only redraw the old and new cursor line, not all lines.
https://github.com/vim/vim/commit/90a997987dbbe43af3c15118a35f658f0f037d1d