### PR TITLE
vim-patch:8.0.1172

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1912,6 +1912,7 @@ static char_u *ex_let_one(char_u *arg, typval_T *const tv,
         if ((opt_type == 1 && *op == '.')
             || (opt_type == 0 && *op != '.')) {
           EMSG2(_(e_letwrong), op);
+          s = NULL;  // don't set the value
         } else {
           if (opt_type == 1) {  // number
             if (*op == '+') {

--- a/src/nvim/testdir/test_assign.vim
+++ b/src/nvim/testdir/test_assign.vim
@@ -31,3 +31,17 @@ func Test_let_termcap()
   let &t_xx = ""
   call assert_fails('let x = &t_xx', 'E15')
 endfunc
+
+func Test_let_option_error()
+  let _w = &tw
+  let &tw = 80
+  call assert_fails('let &tw .= 1', 'E734')
+  call assert_equal(80, &tw)
+  let &tw = _w
+
+  let _w = &fillchars
+  let &fillchars = "vert:|"
+  call assert_fails('let &fillchars += "diff:-"', 'E734')
+  call assert_equal("vert:|", &fillchars)
+  let &fillchars = _w
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1172: when E734 is given option is still set**

Problem:    When E734 is given option is still set.
Solution:   Assign NULL to "s". (Christian Brabandt)
https://github.com/vim/vim/commit/2a6a6c3014e728cd01c750b0f60484d4eaf22a8c