### PR TITLE
loop_close: Drain thread_events

### DIFF
--- a/src/.asan-blacklist
+++ b/src/.asan-blacklist
@@ -1,7 +1,3 @@
 # multiqueue.h pointer arithmetic is not accepted by asan
 fun:multiqueue_node_data
 fun:tv_dict_watcher_node_data
-
-# Allocation in loop_schedule_deferred() is freed by loop_deferred_event(), but
-# this sometimes does not happen during teardown.
-fun:loop_schedule_deferred

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -161,6 +161,7 @@ bool event_teardown(void)
   }
 
   multiqueue_process_events(main_loop.events);
+  loop_poll_events(&main_loop, 0);  // Drain thread_events, fast_events.
   input_stop();
   channel_teardown();
   process_teardown(&main_loop);


### PR DESCRIPTION
Sometimes the ASan build detects a (trivial) leak if Nvim exits quickly:

    = ==22007==ERROR: LeakSanitizer: detected memory leaks
    = Direct leak of 88 byte(s) in 1 object(s) allocated from:
    =      0 0x4ef7a3 in malloc /local/mnt/workspace/tmp/ubuntu_rel/llvm/utils/release/final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:67:3
    =      1 0xfcafc1 in try_malloc /home/travis/build/neovim/neovim/build/../src/nvim/memory.c:88:15
    =      2 0xfcb1e9 in xmalloc /home/travis/build/neovim/neovim/build/../src/nvim/memory.c:122:15
    =      3 0xa6e75f in loop_schedule_deferred /home/travis/build/neovim/neovim/build/../src/nvim/event/loop.c:91:19
    =      4 0x18ab048 in tui_main /home/travis/build/neovim/neovim/build/../src/nvim/tui/tui.c:377:5
    =      5 0x18fe120 in ui_thread_run /home/travis/build/neovim/neovim/build/../src/nvim/ui_bridge.c:102:3
    =      6 0x7f09e5e58183 in start_thread /build/eglibc-ripdx6/eglibc-2.19/nptl/pthread_create.c:312
    = SUMMARY: AddressSanitizer: 88 byte(s) leaked in 1 allocation(s).

This happens because the Event enqueued by loop_schedule_deferred never
gets processed.

(Note: The `.asan-blacklist` directive wasn't working (don't know why).)