### PR TITLE
[RFC] getchar: allow <SID> in <Cmd> mapping

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -4315,8 +4315,14 @@ char_u * getcmdkeycmd(int promptc, void *cookie, int indent)
       EMSG(e_cmdmap_repeated);
       aborted = true;
     } else if (IS_SPECIAL(c1)) {
-      EMSG2(e_cmdmap_key, get_special_key_name(c1, cmod));
-      aborted = true;
+      if (c1 == K_SNR) {
+        ga_append(&line_ga, (char)K_SPECIAL);
+        ga_append(&line_ga, (char)KS_EXTRA);
+        ga_append(&line_ga, (char)KE_SNR);
+      } else {
+        EMSG2(e_cmdmap_key, get_special_key_name(c1, cmod));
+        aborted = true;
+      }
     } else {
       ga_append(&line_ga, (char)c1);
     }

--- a/test/functional/ex_cmds/cmd_map_spec.lua
+++ b/test/functional/ex_cmds/cmd_map_spec.lua
@@ -8,6 +8,7 @@ local eval = helpers.eval
 local funcs = helpers.funcs
 local insert = helpers.insert
 local exc_exec = helpers.exc_exec
+local source = helpers.source
 local Screen = require('test.functional.ui.screen')
 
 describe('mappings with <Cmd>', function()
@@ -794,5 +795,16 @@ describe('mappings with <Cmd>', function()
     ]])
   end)
 
+  it("works with <SID> mappings", function()
+    source([[
+      map <f2> <Cmd>call <SID>do_it()<Cr>
+      function! s:do_it()
+        let g:x = 10
+      endfunction
+    ]])
+    feed('<f2>')
+    eq('', eval('v:errmsg'))
+    eq(10, eval('g:x'))
+  end)
 end)
 


### PR DESCRIPTION
The following code should be allowed in a script:
```
map <f2> <Cmd>call <SID>do_it()<Cr>
function! s:do_it()
  " do stuff
endfunction
```