### PR TITLE
[RDY] vim-patch:8.0.1184,8.1.{168,175}

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -599,9 +599,10 @@ static char_u *mark_line(pos_T *mp, int lead_len)
   if (mp->lnum == 0 || mp->lnum > curbuf->b_ml.ml_line_count)
     return vim_strsave((char_u *)"-invalid-");
   assert(Columns >= 0 && (size_t)Columns <= SIZE_MAX);
-  s = vim_strnsave(skipwhite(ml_get(mp->lnum)), (size_t)Columns);
+  // Allow for up to 5 bytes per character.
+  s = vim_strnsave(skipwhite(ml_get(mp->lnum)), (size_t)Columns * 5);
 
-  /* Truncate the line to fit it in the window */
+  // Truncate the line to fit it in the window
   len = 0;
   for (p = s; *p != NUL; MB_PTR_ADV(p)) {
     len += ptr2cells(p);

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -80,7 +80,7 @@ func Test_marks_cmd()
   w!
 
   b Xone
-  let a=split(execute('marks'), "\n")
+  let a = split(execute('marks'), "\n")
   call assert_equal(9, len(a))
   call assert_equal('mark line  col file/text', a[0])
   call assert_equal(" '      2    0 bbb", a[1])
@@ -93,7 +93,7 @@ func Test_marks_cmd()
   call assert_equal(' .      2    0 bbb', a[8])
 
   b Xtwo
-  let a=split(execute('marks'), "\n")
+  let a = split(execute('marks'), "\n")
   call assert_equal(9, len(a))
   call assert_equal('mark line  col file/text', a[0])
   call assert_equal(" '      1    0 ccc", a[1])
@@ -107,7 +107,7 @@ func Test_marks_cmd()
 
   b Xone
   delmarks aB
-  let a=split(execute('marks aBcD'), "\n")
+  let a = split(execute('marks aBcD'), "\n")
   call assert_equal(2, len(a))
   call assert_equal('mark line  col file/text', a[0])
   call assert_equal(' D      2    0 Xtwo', a[1])
@@ -119,4 +119,23 @@ func Test_marks_cmd()
   call delete('Xone')
   call delete('Xtwo')
   %bwipe
+endfunc
+
+func Test_marks_cmd_multibyte()
+  if !has('multi_byte')
+    return
+  endif
+  new Xone
+  call setline(1, ['ááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááá'])
+  norm! ma
+
+  let a = split(execute('marks a'), "\n")
+  call assert_equal(2, len(a))
+  let expected = ' a      1    0 '
+  while strwidth(expected) < &columns - 1
+    let expected .= 'á'
+  endwhile
+  call assert_equal(expected, a[1])
+
+  bwipe!
 endfunc

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -126,15 +126,12 @@ func Test_marks_cmd_multibyte()
     return
   endif
   new Xone
-  call setline(1, ['ááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááááá'])
+  call setline(1, [repeat('á', &columns)])
   norm! ma
 
   let a = split(execute('marks a'), "\n")
   call assert_equal(2, len(a))
-  let expected = ' a      1    0 '
-  while strwidth(expected) < &columns - 1
-    let expected .= 'á'
-  endwhile
+  let expected = ' a      1    0 ' . repeat('á', &columns - 16)
   call assert_equal(expected, a[1])
 
   bwipe!

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -68,3 +68,55 @@ func Test_setpos()
   call win_gotoid(twowin)
   bwipe!
 endfunc
+
+func Test_marks_cmd()
+  new Xone
+  call setline(1, ['aaa', 'bbb'])
+  norm! maG$mB
+  w!
+  new Xtwo
+  call setline(1, ['ccc', 'ddd'])
+  norm! $mcGmD
+  w!
+
+  b Xone
+  let a=split(execute('marks'), "\n")
+  call assert_equal(9, len(a))
+  call assert_equal('mark line  col file/text', a[0])
+  call assert_equal(" '      2    0 bbb", a[1])
+  call assert_equal(' a      1    0 aaa', a[2])
+  call assert_equal(' B      2    2 bbb', a[3])
+  call assert_equal(' D      2    0 Xtwo', a[4])
+  call assert_equal(' "      1    0 aaa', a[5])
+  call assert_equal(' [      1    0 aaa', a[6])
+  call assert_equal(' ]      2    0 bbb', a[7])
+  call assert_equal(' .      2    0 bbb', a[8])
+
+  b Xtwo
+  let a=split(execute('marks'), "\n")
+  call assert_equal(9, len(a))
+  call assert_equal('mark line  col file/text', a[0])
+  call assert_equal(" '      1    0 ccc", a[1])
+  call assert_equal(' c      1    2 ccc', a[2])
+  call assert_equal(' B      2    2 Xone', a[3])
+  call assert_equal(' D      2    0 ddd', a[4])
+  call assert_equal(' "      2    0 ddd', a[5])
+  call assert_equal(' [      1    0 ccc', a[6])
+  call assert_equal(' ]      2    0 ddd', a[7])
+  call assert_equal(' .      2    0 ddd', a[8])
+
+  b Xone
+  delmarks aB
+  let a=split(execute('marks aBcD'), "\n")
+  call assert_equal(2, len(a))
+  call assert_equal('mark line  col file/text', a[0])
+  call assert_equal(' D      2    0 Xtwo', a[1])
+
+  b Xtwo
+  delmarks cD
+  call assert_fails('marks aBcD', 'E283:')
+
+  call delete('Xone')
+  call delete('Xtwo')
+  %bwipe
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1184: the :marks command is not tested**

Problem:    The :marks command is not tested.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#2197)
https://github.com/vim/vim/commit/9b69f22e66d51d764e9ade87ae8a57ac13ab7348

**vim-patch:8.1.0168: output of :marks is too short with multi-byte chars**

Problem:    Output of :marks is too short with multi-byte chars. (Tony
            Mechelynck)
Solution:   Get more bytes from the text line.
vim/vim@9d5185b

**vim-patch:8.1.0175: marks test fails in very wide window**

Problem:    Marks test fails in very wide window. (Vladimir Lomov)
Solution:   Extend the text to match 'columns'. (closes vim/vim#3180, closes vim/vim#3181)
vim/vim@bde14d8