### PR TITLE
vim-patch:8.1.0355

### DIFF
--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -201,9 +201,15 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed)
     }
 
     // If there is a preview window above, avoid drawing over it.
+    // Do keep at least 10 entries.
     if (pvwin != NULL && pum_row < above_row && pum_height > above_row) {
-      pum_row += above_row;
-      pum_height -= above_row;
+      if (row - above_row < 10) {
+        pum_row = row - 10;
+        pum_height = 10;
+      } else {
+        pum_row = above_row;
+        pum_height = row - above_row;
+      }
     }
 
     // Compute the width of the widest match and the widest extra.

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -202,7 +202,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed)
 
     // If there is a preview window above, avoid drawing over it.
     // Do keep at least 10 entries.
-    if (pvwin != NULL && pum_row < above_row && pum_height > above_row) {
+    if (pvwin != NULL && pum_row < above_row && pum_height > 10) {
       if (row - above_row < 10) {
         pum_row = row - 10;
         pum_height = 10;

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -170,7 +170,37 @@ describe('popup placement', function()
       ]])
   end)
 
-  it('works with preview-window above and inverted', function()
+  it('works with preview-window above and tall and inverted', function()
+    feed(':ped<CR><c-w>8+')
+    feed('iaa<cr>bb<cr>cc<cr>dd<cr>ee<cr>')
+    feed('ff<cr>gg<cr>hh<cr>ii<cr>jj<cr>')
+    feed('kk<cr>ll<cr>mm<cr>nn<cr>oo<cr>')
+    feed('<c-x><c-n>')
+    screen:expect([[
+      aa                              |
+      bb                              |
+      cc                              |
+      dd                              |
+      {s:aa             }{c: }{3:ew][+]          }|
+      {n:bb             }{c: }                |
+      {n:cc             }{c: }                |
+      {n:dd             }{c: }                |
+      {n:ee             }{c: }                |
+      {n:ff             }{c: }                |
+      {n:gg             }{c: }                |
+      {n:hh             }{c: }                |
+      {n:ii             }{c: }                |
+      {n:jj             }{c: }                |
+      {n:kk             }{c: }                |
+      {n:ll             }{s: }                |
+      {n:mm             }{s: }                |
+      aa^                              |
+      {4:[No Name] [+]                   }|
+      {2:-- }{5:match 1 of 15}                |
+    ]])
+  end)
+
+  it('works with preview-window above and short and inverted', function()
     feed(':ped<CR><c-w>4+')
     feed('iaa<cr>bb<cr>cc<cr>dd<cr>ee<cr>')
     feed('ff<cr>gg<cr>hh<cr>ii<cr>jj<cr>')
@@ -183,16 +213,16 @@ describe('popup placement', function()
       ee                              |
       ff                              |
       gg                              |
-      hh                              |
-      {3:[No Name] [Preview][+]          }|
-      cc                              |
-      dd                              |
-      ee                              |
-      ff                              |
-      gg                              |
-      hh                              |
-      {s:aa             }{c: }                |
-      {n:bb             }{s: }                |
+      {s:aa             }                 |
+      {n:bb             }{3:iew][+]          }|
+      {n:cc             }                 |
+      {n:dd             }                 |
+      {n:ee             }                 |
+      {n:ff             }                 |
+      {n:gg             }                 |
+      {n:hh             }                 |
+      {n:ii             }                 |
+      {n:jj             }                 |
       aa^                              |
       {4:[No Name] [+]                   }|
       {2:-- }{5:match 1 of 10}                |


### PR DESCRIPTION
Previously, in #8913, the popupmenu was fixed to behave like vim, and I said that the behavior for preview-window above with an inverted popup was strange.

I have since submitted a PR to vim, and Bram accepted it with vim-patch:8.1.0355, with an extra quirk that the popup should not shrink below 10 lines to avoid the preview window.

I have replicated his version and added 2 tests to cover the new behavior.