### PR TITLE
vim-patch:8.0.1201

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1271,7 +1271,10 @@ the current line is included.  You can then use "%" to go to the matching line.
 H			To line [count] from top (Home) of window (default:
 			first line on the window) on the first non-blank
 			character |linewise|.  See also 'startofline' option.
-			Cursor is adjusted for 'scrolloff' option.
+			Cursor is adjusted for 'scrolloff' option, unless an
+			operator is pending, in which case the text may
+			scroll.  E.g. "yH" yanks from the first visible line
+			until the cursor line (inclusive).
 
 						*M*
 M			To Middle line of window, on the first non-blank
@@ -1281,7 +1284,10 @@ M			To Middle line of window, on the first non-blank
 L			To line [count] from bottom of window (default: Last
 			line on the window) on the first non-blank character
 			|linewise|.  See also 'startofline' option.
-			Cursor is adjusted for 'scrolloff' option.
+			Cursor is adjusted for 'scrolloff' option, unless an
+			operator is pending, in which case the text may
+			scroll.  E.g. "yL" yanks from the cursor to the last
+			visible line.
 
 <LeftMouse>		Moves to the position on the screen where the mouse
 			click is |exclusive|.  See also |<LeftMouse>|.  If the

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5042,7 +5042,10 @@ static void nv_scroll(cmdarg_T *cap)
       curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
   }
 
-  cursor_correct();     /* correct for 'so' */
+  // Correct for 'so', except when an operator is pending.
+  if (cap->oap->op_type == OP_NOP) {
+    cursor_correct();
+  }
   beginline(BL_SOL | BL_FIX);
 }
 


### PR DESCRIPTION
**vim-patch:8.0.1201: "yL" is affected by 'scrolloff'**

Problem:    "yL" is affected by 'scrolloff'. (Eli the Bearded)
Solution:   Don't use 'scrolloff' when an operator is pending.
https://github.com/vim/vim/commit/44cc4cf72fdd12cd9a779031d443aac4254d51ae