### PR TITLE
vim-patch:8.0.1275

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4395,7 +4395,7 @@ void ex_help(exarg_T *eap)
   buf_T       *buf;
   int len;
   char_u      *lang;
-  int old_KeyTyped = KeyTyped;
+  const bool old_KeyTyped = KeyTyped;
 
   if (eap != NULL) {
     /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -974,7 +974,7 @@ static char_u *get_loop_line(int c, void *cookie, int indent)
   }
 
   KeyTyped = false;
-  ++cp->current_line;
+  cp->current_line++;
   wp = (wcmd_T *)(cp->lines_gap->ga_data) + cp->current_line;
   sourcing_lnum = wp->lnum;
   return vim_strsave(wp->line);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -400,7 +400,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
    */
   if (!(flags & DOCMD_KEYTYPED)
       && !getline_equal(fgetline, cookie, getexline))
-    KeyTyped = FALSE;
+    KeyTyped = false;
 
   /*
    * Continue executing command lines:
@@ -973,7 +973,7 @@ static char_u *get_loop_line(int c, void *cookie, int indent)
     return line;
   }
 
-  KeyTyped = FALSE;
+  KeyTyped = false;
   ++cp->current_line;
   wp = (wcmd_T *)(cp->lines_gap->ga_data) + cp->current_line;
   sourcing_lnum = wp->lnum;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -623,7 +623,7 @@ static int command_line_execute(VimState *state, int key)
     }
     s->wim_index = 0;
     if (p_wmnu && wild_menu_showing != 0) {
-      int skt = KeyTyped;
+      const bool skt = KeyTyped;
       int old_RedrawingDisabled = RedrawingDisabled;
 
       if (ccline.input_fn) {
@@ -6108,7 +6108,7 @@ static int open_cmdwin(void)
   RedrawingDisabled = i;
   restore_batch_count(save_count);
 
-  int save_KeyTyped = KeyTyped;
+  const bool save_KeyTyped = KeyTyped;
 
   /* Trigger CmdwinLeave autocommands. */
   apply_autocmds(EVENT_CMDWINLEAVE, typestr, typestr, FALSE, curbuf);

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -6707,6 +6707,7 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
   proftime_T wait_time;
   bool did_save_redobuff = false;
   save_redo_T save_redo;
+  const int save_KeyTyped = KeyTyped;
 
   // Quickly return if there are no autocommands for this event or
   // autocommands are blocked.
@@ -6966,6 +6967,7 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
   restore_funccal(save_funccalp);
   if (do_profiling == PROF_YES)
     prof_child_exit(&wait_time);
+  KeyTyped = save_KeyTyped;
   xfree(fname);
   xfree(sfname);
   --nesting;            /* see matching increment above */

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -6707,7 +6707,7 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
   proftime_T wait_time;
   bool did_save_redobuff = false;
   save_redo_T save_redo;
-  const int save_KeyTyped = KeyTyped;
+  const bool save_KeyTyped = KeyTyped;
 
   // Quickly return if there are no autocommands for this event or
   // autocommands are blocked.

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2883,7 +2883,6 @@ static void foldlevelExpr(fline_T *flp)
   int n;
   int c;
   linenr_T lnum = flp->lnum + flp->off;
-  int save_keytyped;
 
   win = curwin;
   curwin = flp->wp;
@@ -2898,7 +2897,7 @@ static void foldlevelExpr(fline_T *flp)
 
   /* KeyTyped may be reset to 0 when calling a function which invokes
    * do_cmdline().  To make 'foldopen' work correctly restore KeyTyped. */
-  save_keytyped = KeyTyped;
+  const bool save_keytyped = KeyTyped;
   n = (int)eval_foldexpr(flp->wp->w_p_fde, &c);
   KeyTyped = save_keytyped;
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1670,7 +1670,7 @@ static int vgetorpeek(int advance)
     }
     if (c != NUL && !got_int) {
       if (advance) {
-        // KeyTyped = FALSE;  When the command that stuffed something
+        // KeyTyped = false;  When the command that stuffed something
         // was typed, behave like the stuffed command was typed.
         // needed for CTRL-W CTRL-] to open a fold, for example.
         KeyStuffed = true;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -789,7 +789,7 @@ EXTERN int ex_normal_busy INIT(= 0);     // recursiveness of ex_normal()
 EXTERN int ex_normal_lock INIT(= 0);     // forbid use of ex_normal()
 EXTERN int ignore_script INIT(= false);  // ignore script input
 EXTERN int stop_insert_mode;             // for ":stopinsert" and 'insertmode'
-EXTERN int KeyTyped;                     // TRUE if user typed current char
+EXTERN bool KeyTyped;                    // true if user typed current char
 EXTERN int KeyStuffed;                   // TRUE if current char from stuffbuf
 EXTERN int maptick INIT(= 0);            // tick for each non-mapped char
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6294,7 +6294,7 @@ static void nv_gomark(cmdarg_T *cap)
   pos_T       *pos;
   int c;
   pos_T old_cursor = curwin->w_cursor;
-  int old_KeyTyped = KeyTyped;              /* getting file may reset it */
+  const bool old_KeyTyped = KeyTyped;       // getting file may reset it
 
   if (cap->cmdchar == 'g')
     c = cap->extra_char;
@@ -6331,7 +6331,7 @@ static void nv_pcmark(cmdarg_T *cap)
 {
   pos_T       *pos;
   linenr_T lnum = curwin->w_cursor.lnum;
-  int old_KeyTyped = KeyTyped;              /* getting file may reset it */
+  const bool old_KeyTyped = KeyTyped;       // getting file may reset it
 
   if (!checkclearopq(cap->oap)) {
     if (cap->cmdchar == 'g')

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1759,7 +1759,7 @@ void qf_jump(qf_info_T *qi, int dir, int errornr, int forceit)
   win_T               *oldwin = curwin;
   int print_message = TRUE;
   int len;
-  int old_KeyTyped = KeyTyped;                   /* getting file may reset it */
+  const bool old_KeyTyped = KeyTyped;           // getting file may reset it
   int ok = OK;
   bool usable_win;
 
@@ -2932,7 +2932,7 @@ static void qf_fill_buffer(qf_info_T *qi, buf_T *buf, qfline_T *old_last)
   qfline_T    *qfp;
   buf_T       *errbuf;
   int len;
-  int old_KeyTyped = KeyTyped;
+  const bool old_KeyTyped = KeyTyped;
 
   if (old_last == NULL) {
     if (buf != curbuf) {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -266,7 +266,7 @@ do_tag (
         goto end_do_tag;
       }
 
-      if (type == DT_POP) {             /* go to older position */
+      if (type == DT_POP) {             // go to older position
         const bool old_KeyTyped = KeyTyped;
         if ((tagstackidx -= count) < 0) {
           EMSG(_(bottommsg));

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -267,7 +267,7 @@ do_tag (
       }
 
       if (type == DT_POP) {             /* go to older position */
-        int old_KeyTyped = KeyTyped;
+        const bool old_KeyTyped = KeyTyped;
         if ((tagstackidx -= count) < 0) {
           EMSG(_(bottommsg));
           if (tagstackidx + count == 0) {
@@ -2333,7 +2333,7 @@ static int jumpto_tag(
   int save_no_hlsearch;
   win_T       *curwin_save = NULL;
   char_u      *full_fname = NULL;
-  int old_KeyTyped = KeyTyped;              /* getting the file may reset it */
+  const bool old_KeyTyped = KeyTyped;       // getting the file may reset it
   const int l_g_do_tagpreview = g_do_tagpreview;
   const size_t len = matching_line_len(lbuf_arg) + 1;
   char_u *lbuf = xmalloc(len);


### PR DESCRIPTION
**vim-patch:8.0.1275: CmdlineLeave autocmd prevents fold from opening**

Problem:    CmdlineLeave autocmd prevents fold from opening. (Waivek)
Solution:   Save and restore KeyTyped. (closes vim/vim#2305)
https://github.com/vim/vim/commit/c9e9c7140994154bb4a29764491d42c001b24596