### PR TITLE
vim-patch:8.0.1363

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2538,7 +2538,7 @@ setfname (
     buf_T *buf,
     char_u *ffname,
     char_u *sfname,
-    int message                    /* give message when buffer already exists */
+    bool message                  // give message when buffer already exists
 )
 {
   buf_T       *obuf = NULL;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1506,7 +1506,7 @@ int rename_buffer(char_u *new_fname)
   xfname = curbuf->b_fname;
   curbuf->b_ffname = NULL;
   curbuf->b_sfname = NULL;
-  if (setfname(curbuf, new_fname, NULL, TRUE) == FAIL) {
+  if (setfname(curbuf, new_fname, NULL, true) == FAIL) {
     curbuf->b_ffname = fname;
     curbuf->b_sfname = sfname;
     return FAIL;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6621,7 +6621,7 @@ static void ex_preserve(exarg_T *eap)
 /// ":recover".
 static void ex_recover(exarg_T *eap)
 {
-  /* Set recoverymode right away to avoid the ATTENTION prompt. */
+  // Set recoverymode right away to avoid the ATTENTION prompt.
   recoverymode = true;
   if (!check_changed(curbuf, (p_awa ? CCGD_AW : 0)
           | CCGD_MULTWIN
@@ -6629,8 +6629,9 @@ static void ex_recover(exarg_T *eap)
           | CCGD_EXCMD)
 
       && (*eap->arg == NUL
-          || setfname(curbuf, eap->arg, NULL, true) == OK))
+          || setfname(curbuf, eap->arg, NULL, true) == OK)) {
     ml_recover();
+  }
   recoverymode = false;
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6622,7 +6622,7 @@ static void ex_preserve(exarg_T *eap)
 static void ex_recover(exarg_T *eap)
 {
   /* Set recoverymode right away to avoid the ATTENTION prompt. */
-  recoverymode = TRUE;
+  recoverymode = true;
   if (!check_changed(curbuf, (p_awa ? CCGD_AW : 0)
           | CCGD_MULTWIN
           | (eap->forceit ? CCGD_FORCEIT : 0)
@@ -6631,7 +6631,7 @@ static void ex_recover(exarg_T *eap)
       && (*eap->arg == NUL
           || setfname(curbuf, eap->arg, NULL, TRUE) == OK))
     ml_recover();
-  recoverymode = FALSE;
+  recoverymode = false;
 }
 
 /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6629,7 +6629,7 @@ static void ex_recover(exarg_T *eap)
           | CCGD_EXCMD)
 
       && (*eap->arg == NUL
-          || setfname(curbuf, eap->arg, NULL, TRUE) == OK))
+          || setfname(curbuf, eap->arg, NULL, true) == OK))
     ml_recover();
   recoverymode = false;
 }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3781,8 +3781,9 @@ static int set_rw_fname(char_u *fname, char_u *sfname)
     return FAIL;
   }
 
-  if (setfname(curbuf, fname, sfname, false) == OK)
+  if (setfname(curbuf, fname, sfname, false) == OK) {
     curbuf->b_flags |= BF_NOTEDITED;
+  }
 
   /* ....and a new named one is created */
   apply_autocmds(EVENT_BUFNEW, NULL, NULL, FALSE, curbuf);

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3781,7 +3781,7 @@ static int set_rw_fname(char_u *fname, char_u *sfname)
     return FAIL;
   }
 
-  if (setfname(curbuf, fname, sfname, FALSE) == OK)
+  if (setfname(curbuf, fname, sfname, false) == OK)
     curbuf->b_flags |= BF_NOTEDITED;
 
   /* ....and a new named one is created */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -780,7 +780,7 @@ IOSIZE
 EXTERN int RedrawingDisabled INIT(= 0);
 
 EXTERN int readonlymode INIT(= FALSE);      /* Set to TRUE for "view" */
-EXTERN int recoverymode INIT(= FALSE);      /* Set to TRUE for "-r" option */
+EXTERN bool recoverymode INIT(= false);     // Set to true for "-r" option
 
 // typeahead buffer
 EXTERN typebuf_T typebuf INIT(= { NULL, NULL, 0, 0, 0, 0, 0, 0, 0 });

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -963,7 +963,7 @@ static void command_line_scan(mparm_T *parmp)
         }
         case 'r':    // "-r" recovery mode
         case 'L': {  // "-L" recovery mode
-          recoverymode = 1;
+          recoverymode = true;
           break;
         }
         case 's': {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1511,7 +1511,7 @@ static void create_windows(mparm_T *parmp)
           /* We can't close the window, it would disturb what
            * happens next.  Clear the file name and set the arg
            * index to -1 to delete it later. */
-          setfname(curbuf, NULL, NULL, FALSE);
+          setfname(curbuf, NULL, NULL, false);
           curwin->w_arg_idx = -1;
           swap_exists_action = SEA_NONE;
         } else

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -769,17 +769,16 @@ void ml_recover(void)
   called_from_main = (curbuf->b_ml.ml_mfp == NULL);
   attr = HL_ATTR(HLF_E);
 
-  /*
-   * If the file name ends in ".s[uvw][a-z]" we assume this is the swap file.
-   * Otherwise a search is done to find the swap file(s).
-   */
+  // If the file name ends in ".s[a-w][a-z]" we assume this is the swap file.
+  // Otherwise a search is done to find the swap file(s).
   fname = curbuf->b_fname;
   if (fname == NULL)                /* When there is no file name */
     fname = (char_u *)"";
   len = (int)STRLEN(fname);
   if (len >= 4
       && STRNICMP(fname + len - 4, ".s", 2) == 0
-      && vim_strchr((char_u *)"UVWuvw", fname[len - 2]) != NULL
+      && vim_strchr((char_u *)"abcdefghijklmnopqrstuvw",
+                    TOLOWER_ASC(fname[len - 2])) != NULL
       && ASCII_ISALPHA(fname[len - 1])) {
     directly = TRUE;
     fname_used = vim_strsave(fname);     /* make a copy for mf_open() */

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -745,7 +745,7 @@ void ml_recover(void)
   bool serious_error = true;
   int orig_file_status = NOTDONE;
 
-  recoverymode = TRUE;
+  recoverymode = true;
   const bool called_from_main = (curbuf->b_ml.ml_mfp == NULL);
   const int attr = HL_ATTR(HLF_E);
 
@@ -1172,7 +1172,7 @@ void ml_recover(void)
     ml_delete(curbuf->b_ml.ml_line_count, FALSE);
   curbuf->b_flags |= BF_RECOVERED;
 
-  recoverymode = FALSE;
+  recoverymode = false;
   if (got_int)
     EMSG(_("E311: Recovery Interrupted"));
   else if (error) {
@@ -1198,7 +1198,7 @@ void ml_recover(void)
 
 theend:
   xfree(fname_used);
-  recoverymode = FALSE;
+  recoverymode = false;
   if (mfp != NULL) {
     if (hp != NULL)
       mf_put(mfp, hp, false, false);

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -907,7 +907,7 @@ void ml_recover(void)
    */
   if (directly) {
     expand_env(b0p->b0_fname, NameBuff, MAXPATHL);
-    if (setfname(curbuf, NameBuff, NULL, TRUE) == FAIL)
+    if (setfname(curbuf, NameBuff, NULL, true) == FAIL)
       goto theend;
   }
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -752,8 +752,9 @@ void ml_recover(void)
   // If the file name ends in ".s[a-w][a-z]" we assume this is the swap file.
   // Otherwise a search is done to find the swap file(s).
   char_u *fname = curbuf->b_fname;
-  if (fname == NULL)                /* When there is no file name */
+  if (fname == NULL) {              // When there is no file name
     fname = (char_u *)"";
+  }
   int len = (int)STRLEN(fname);
   if (len >= 4
       && STRNICMP(fname + len - 4, ".s", 2) == 0
@@ -761,7 +762,7 @@ void ml_recover(void)
                     TOLOWER_ASC(fname[len - 2])) != NULL
       && ASCII_ISALPHA(fname[len - 1])) {
     directly = true;
-    fname_used = vim_strsave(fname);     /* make a copy for mf_open() */
+    fname_used = vim_strsave(fname);    // make a copy for mf_open()
   } else {
     directly = false;
 
@@ -907,8 +908,9 @@ void ml_recover(void)
    */
   if (directly) {
     expand_env(b0p->b0_fname, NameBuff, MAXPATHL);
-    if (setfname(curbuf, NameBuff, NULL, true) == FAIL)
+    if (setfname(curbuf, NameBuff, NULL, true) == FAIL) {
       goto theend;
+    }
   }
 
   home_replace(NULL, mfp->mf_fname, NameBuff, MAXPATHL, TRUE);
@@ -937,7 +939,7 @@ void ml_recover(void)
   }
   ui_flush();
 
-  /* Get the 'fileformat' and 'fileencoding' from block zero. */
+  // Get the 'fileformat' and 'fileencoding' from block zero.
   const int b0_ff = (b0p->b0_flags & B0_FF_MASK);
   if (b0p->b0_flags & B0_HAS_FENC) {
     int fnsize = B0_FNAME_SIZE_NOCRYPT;
@@ -1001,11 +1003,11 @@ void ml_recover(void)
       }
       ++error;
       ml_append(lnum++, (char_u *)_("???MANY LINES MISSING"),
-          (colnr_T)0, TRUE);
-    } else {          /* there is a block */
+                (colnr_T)0, TRUE);
+    } else {          // there is a block
       const PTR_BL *pp = hp->bh_data;
-      if (pp->pb_id == PTR_ID) {                /* it is a pointer block */
-        /* check line count when using pointer block first time */
+      if (pp->pb_id == PTR_ID) {                // it is a pointer block
+        // check line count when using pointer block first time
         if (idx == 0 && line_count != 0) {
           for (i = 0; i < (int)pp->pb_count; ++i)
             line_count -= pp->pb_pointer[i].pe_line_count;
@@ -1060,9 +1062,9 @@ void ml_recover(void)
           idx = 0;
           continue;
         }
-      } else {            /* not a pointer block */
+      } else {            // not a pointer block
         DATA_BL *dp = hp->bh_data;
-        if (dp->db_id != DATA_ID) {             /* block id wrong */
+        if (dp->db_id != DATA_ID) {             // block id wrong
           if (bnum == 1) {
             EMSG2(_("E310: Block 1 ID wrong (%s not a .swp file?)"),
                 mfp->mf_fname);
@@ -1077,15 +1079,15 @@ void ml_recover(void)
            * Append all the lines in this block
            */
           bool has_error = false;
-          /*
-           * check length of block
-           * if wrong, use length in pointer block
-           */
+
+          // check length of block
+          // if wrong, use length in pointer block
           if (page_count * mfp->mf_page_size != dp->db_txt_end) {
             ml_append(lnum++,
-                (char_u *)_("??? from here until ???END lines may be messed up"),
-                (colnr_T)0, TRUE);
-            ++error;
+                      (char_u *)_("??? from here until ???END lines"
+                                  " may be messed up"),
+                      (colnr_T)0, TRUE);
+            error++;
             has_error = true;
             dp->db_txt_end = page_count * mfp->mf_page_size;
           }
@@ -1099,14 +1101,14 @@ void ml_recover(void)
            */
           if (line_count != dp->db_line_count) {
             ml_append(lnum++,
-                (char_u *)_(
-                    "??? from here until ???END lines may have been inserted/deleted"),
-                (colnr_T)0, TRUE);
-            ++error;
+                      (char_u *)_("??? from here until ???END lines"
+                                  " may have been inserted/deleted"),
+                      (colnr_T)0, TRUE);
+            error++;
             has_error = true;
           }
 
-          for (i = 0; i < dp->db_line_count; ++i) {
+          for (i = 0; i < dp->db_line_count; i++) {
             const int txt_start = (dp->db_index[i] & DB_INDEX_MASK);
             if (txt_start <= (int)HEADER_SIZE
                 || txt_start >= (int)dp->db_txt_end) {
@@ -1173,10 +1175,10 @@ void ml_recover(void)
   curbuf->b_flags |= BF_RECOVERED;
 
   recoverymode = false;
-  if (got_int)
+  if (got_int) {
     EMSG(_("E311: Recovery Interrupted"));
-  else if (error) {
-    ++no_wait_return;
+  } else if (error) {
+    no_wait_return++;
     MSG(">>>>>>>>>>>>>");
     EMSG(_(
             "E312: Errors detected while recovering; look for lines starting with ???"));

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3955,7 +3955,7 @@ load_dummy_buffer (
     aucmd_prepbuf(&aco, newbuf);
 
     /* Need to set the filename for autocommands. */
-    (void)setfname(curbuf, fname, NULL, FALSE);
+    (void)setfname(curbuf, fname, NULL, false);
 
     /* Create swap file now to avoid the ATTENTION message. */
     check_need_swap(TRUE);


### PR DESCRIPTION
**vim-patch:8.0.1363: recovering does not work when swap file ends in .stz**

Problem:    Recovering does not work when swap file ends in .stz.
Solution:   Check for all possible swap file names. (Elfling, closes vim/vim#2395,
            closes vim/vim#2396)
https://github.com/vim/vim/commit/af903e5d490ec9c6c49079f67de7e92e3c35a725