### PR TITLE
[RFC] vim-patch:8.0.1372

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1152,6 +1152,21 @@ static void script_dump_profile(FILE *fd)
           if (vim_fgets(IObuff, IOSIZE, sfd)) {
             break;
           }
+          // When a line has been truncated, append NL, taking care
+          // of multi-byte characters .
+          if (IObuff[IOSIZE - 2] != NUL && IObuff[IOSIZE - 2] != NL) {
+            int n = IOSIZE - 2;
+
+            // Move to the first byte of this char.
+            // utf_head_off() doesn't work, because it checks
+            // for a truncated character.
+            while (n > 0 && (IObuff[n] & 0xc0) == 0x80) {
+              n--;
+            }
+
+            IObuff[n] = NL;
+            IObuff[n + 1] = NUL;
+          }
           if (i < si->sn_prl_ga.ga_len
               && (pp = &PRL_ITEM(si, i))->snp_count > 0) {
             fprintf(fd, "%5d ", pp->snp_count);

--- a/src/nvim/testdir/test_profile.vim
+++ b/src/nvim/testdir/test_profile.vim
@@ -181,3 +181,44 @@ func Test_profile_errors()
   call assert_fails("profile pause", 'E750:')
   call assert_fails("profile continue", 'E750:')
 endfunc
+
+func Test_profile_truncate_mbyte()
+  if !has('multi_byte') || &enc !=# 'utf-8'
+    return
+  endif
+
+  let lines = [
+    \ 'scriptencoding utf-8',
+    \ 'func! Foo()',
+    \ '  return [',
+    \ '  \ "' . join(map(range(0x4E00, 0x4E00 + 340), 'nr2char(v:val)'), '') . '",',
+    \ '  \ "' . join(map(range(0x4F00, 0x4F00 + 340), 'nr2char(v:val)'), '') . '",',
+    \ '  \ ]',
+    \ 'endfunc',
+    \ 'call Foo()',
+    \ ]
+
+  call writefile(lines, 'Xprofile_file.vim')
+  call system(v:progpath
+    \ . ' -es --cmd "set enc=utf-8"'
+    \ . ' -c "profile start Xprofile_file.log"'
+    \ . ' -c "profile file Xprofile_file.vim"'
+    \ . ' -c "so Xprofile_file.vim"'
+    \ . ' -c "qall!"')
+  call assert_equal(0, v:shell_error)
+
+  split Xprofile_file.log
+  if &fenc != ''
+    call assert_equal('utf-8', &fenc)
+  endif
+  /func! Foo()
+  let lnum = line('.')
+  call assert_match('^\s*return \[$', getline(lnum + 1))
+  call assert_match("\u4F52$", getline(lnum + 2))
+  call assert_match("\u5052$", getline(lnum + 3))
+  call assert_match('^\s*\\ \]$', getline(lnum + 4))
+  bwipe!
+
+  call delete('Xprofile_file.vim')
+  call delete('Xprofile_file.log')
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1372: profile log may be truncated halfway a character**

Problem:    Profile log may be truncated halfway a character.
Solution:   Find the start of the character. (Ozaki Kiichi, closes vim/vim#2385)
https://github.com/vim/vim/commit/ac112f01a6930c9d15cf0360b657373699916bfd

Need vim-patch:8.0.0716 for `--clean`.