### PR TITLE
vim-patch:8.0.1374

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4418,7 +4418,7 @@ void op_addsub(oparg_T *oap, linenr_T Prenum1, bool g_cmd)
         length = (colnr_T)STRLEN(ml_get(pos.lnum));
       } else {
         // oap->motion_type == kMTCharWise
-        if (!oap->inclusive) {
+        if (pos.lnum == oap->start.lnum && !oap->inclusive) {
           dec(&(oap->end));
         }
         length = (colnr_T)STRLEN(ml_get(pos.lnum));

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -11,6 +11,7 @@ set sidescroll=0
 set directory^=.
 set undodir^=.
 set backspace=
+set nrformats+=octal
 set nohidden smarttab noautoindent noautoread complete-=i noruler noshowcmd
 set listchars=eol:$
 set fillchars=vert:\|,fold:-

--- a/src/nvim/testdir/test_increment.vim
+++ b/src/nvim/testdir/test_increment.vim
@@ -364,11 +364,25 @@ endfunc
 "     Expected:
 "     1) Ctrl-a on visually selected zero
 "     111
+"
+" Also: 019 with "01" selected increments to "029".
 func Test_visual_increment_15()
   call setline(1, ["101"])
   exec "norm! lv\<C-A>"
   call assert_equal(["111"], getline(1, '$'))
   call assert_equal([0, 1, 2, 0], getpos('.'))
+
+  call setline(1, ["019"])
+  exec "norm! 0vl\<C-A>"
+  call assert_equal("029", getline(1))
+
+  call setline(1, ["01239"])
+  exec "norm! 0vlll\<C-A>"
+  call assert_equal("01249", getline(1))
+
+  call setline(1, ["01299"])
+  exec "norm! 0vlll\<C-A>"
+  call assert_equal("1309", getline(1))
 endfunc
 
 " 16) increment right aligned numbers
@@ -756,5 +770,12 @@ func Test_normal_increment_03()
   call assert_equal([0, 3, 25, 0], getpos('.'))
 endfunc
 
+func Test_increment_empty_line()
+  new
+  call setline(1, ['0', '0', '0', '0', '0', '0', ''])
+  exe "normal Gvgg\<C-A>"
+  call assert_equal(['1', '1', '1', '1', '1', '1', ''], getline(1, 7))
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_increment.vim
+++ b/src/nvim/testdir/test_increment.vim
@@ -3,6 +3,7 @@
 func SetUp()
   new dummy
   set nrformats&vim
+  set nrformats+=octal
 endfunc
 
 func TearDown()


### PR DESCRIPTION
**vim-patch:8.0.1374: CTRL-A does not work with an empty line**

Problem:    CTRL-A does not work with an empty line. (Alex)
Solution:   Decrement the end only once. (Hirohito Higashi, closes vim/vim#2387)
https://github.com/vim/vim/commit/5fe6bdf858a7f2f288d599ffb5efb3c08449c817