### PR TITLE
vim-patch:8.0.{1416,1417}

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3664,18 +3664,18 @@ static linenr_T get_address(exarg_T *eap,
          */
         if (lnum != MAXLNUM)
           curwin->w_cursor.lnum = lnum;
-        /*
-         * Start a forward search at the end of the line (unless
-         * before the first line).
-         * Start a backward search at the start of the line.
-         * This makes sure we never match in the current
-         * line, and can match anywhere in the
-         * next/previous line.
-         */
-        if (c == '/' && curwin->w_cursor.lnum > 0)
+
+        // Start a forward search at the end of the line (unless
+        // before the first line).
+        // Start a backward search at the start of the line.
+        // This makes sure we never match in the current
+        // line, and can match anywhere in the
+        // next/previous line.
+        if (c == '/' && curwin->w_cursor.lnum > 0) {
           curwin->w_cursor.col = MAXCOL;
-        else
+        } else {
           curwin->w_cursor.col = 0;
+        }
         searchcmdlen = 0;
         if (!do_search(NULL, c, cmd, 1L,
                 SEARCH_HIS | SEARCH_MSG, NULL)) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3665,13 +3665,14 @@ static linenr_T get_address(exarg_T *eap,
         if (lnum != MAXLNUM)
           curwin->w_cursor.lnum = lnum;
         /*
-         * Start a forward search at the end of the line.
+         * Start a forward search at the end of the line (unless
+         * before the first line).
          * Start a backward search at the start of the line.
          * This makes sure we never match in the current
          * line, and can match anywhere in the
          * next/previous line.
          */
-        if (c == '/')
+        if (c == '/' && curwin->w_cursor.lnum > 0)
           curwin->w_cursor.col = MAXCOL;
         else
           curwin->w_cursor.col = 0;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3999,18 +3999,15 @@ void goto_byte(long cnt)
 /// Return 0 otherwise.
 int inc(pos_T *lp)
 {
-  char_u  *p = ml_get_pos(lp);
-
-  if (*p != NUL) {      // still within line, move to next char (may be NUL)
-    if (has_mbyte) {
-      int l = (*mb_ptr2len)(p);
+  // when searching position may be set to end of a line
+  if (lp->col != MAXCOL) {
+    const char_u *const p = ml_get_pos(lp);
+    if (*p != NUL) {  // still within line, move to next char (may be NUL)
+      const int l = utfc_ptr2len(p);
 
       lp->col += l;
-      return (p[l] != NUL) ? 0 : 2;
+      return ((p[l] != NUL) ? 0 : 2);
     }
-    lp->col++;
-    lp->coladd = 0;
-    return (p[1] != NUL) ? 0 : 2;
   }
   if (lp->lnum != curbuf->b_ml.ml_line_count) {     // there is a next line
     lp->col = 0;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -4032,20 +4032,32 @@ int incl(pos_T *lp)
 int dec(pos_T *lp)
 {
   lp->coladd = 0;
-  if (lp->col > 0) {            // still within line
+  if (lp->col == MAXCOL) {
+    // past end of line
+    char_u *p = ml_get(lp->lnum);
+    lp->col = (colnr_T)STRLEN(p);
+    lp->col -= utf_head_off(p, p + lp->col);
+    return 0;
+  }
+
+  if (lp->col > 0) {
+    // still within line
     lp->col--;
     char_u *p = ml_get(lp->lnum);
     lp->col -= utf_head_off(p, p + lp->col);
     return 0;
   }
-  if (lp->lnum > 1) {           // there is a prior line
+  if (lp->lnum > 1) {
+    // there is a prior line
     lp->lnum--;
     char_u *p = ml_get(lp->lnum);
     lp->col = (colnr_T)STRLEN(p);
     lp->col -= utf_head_off(p, p + lp->col);
     return 1;
   }
-  return -1;                    // at start of file
+
+  // at start of file
+  return -1;
 }
 
 /// Same as dec(), but skip NUL at the end of non-empty lines.

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1752,6 +1752,10 @@ del_lines (
 
 int gchar_pos(pos_T *pos)
 {
+  // When searching columns is sometimes put at the end of a line.
+  if (pos->col == MAXCOL) {
+    return NUL;
+  }
   return utf_ptr2char(ml_get_pos(pos));
 }
 

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -484,6 +484,8 @@ endfunc
 func Test_search_sentence()
   new
   " this used to cause a crash
-  call assert_fails("/\\%'", 'E486')
+  call assert_fails("/\\%')", 'E486')
   call assert_fails("/", 'E486')
+  /\%'(
+  /
 endfunc

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -480,3 +480,10 @@ func Test_look_behind()
   call search(getline("."))
   bwipe!
 endfunc
+
+func Test_search_sentence()
+  new
+  " this used to cause a crash
+  call assert_fails("/\\%'", 'E486')
+  call assert_fails("/", 'E486')
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1416: crash when searching for a sentence**

Problem:    Crash when searching for a sentence.
Solution:   Return NUL when getting character at MAXCOL. (closes vim/vim#2468)
vim/vim@8ada6aa

**vim-patch:8.0.1417: test doesn't search for a sentence**

Problem:    Test doesn't search for a sentence. Still fails when searching for
            start of sentence. (Dominique Pelle)
Solution:   Add paren. Check for MAXCOL in dec().
vim/vim@1bd999f