### PR TITLE
vim-patch:8.0.{1428,1443}

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1787,7 +1787,7 @@ static int command_line_not_changed(CommandLineState *s)
 /// as a trailing \|, which can happen while typing a pattern.
 static int empty_pattern(char_u *p)
 {
-  int n = STRLEN(p);
+  size_t n = STRLEN(p);
 
   // remove trailing \v and the like
   while (n >= 2 && p[n - 2] == '\\'

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1901,7 +1901,8 @@ void undo_time(long step, bool sec, bool file, bool absolute)
 
   // When "target" is 0; Back to origin.
   if (target == 0) {
-    goto found;
+    mark = lastmark;  // avoid that GCC complains
+    goto target_zero;
   }
 
   /*
@@ -2020,7 +2021,7 @@ void undo_time(long step, bool sec, bool file, bool absolute)
     }
   }
 
-found:
+target_zero:
   // If we found it: Follow the path to go to where we want to be.
   if (uhp != NULL || target == 0) {
     // First go up the tree as much as needed.


### PR DESCRIPTION
**vim-patch:8.0.1428: compiler warning on 64 bit MS-Windows system**

Problem:    Compiler warning on 64 bit MS-Windows system.
Solution:   Change type from "int" to "size_t". (Mike Williams)
vim/vim@200ea8f


**vim-patch:8.0.1443: compiler complains about uninitialized variable**

Problem:    Compiler complains about uninitialized variable. (Tony Mechelynck)
Solution:   Assign a value to the variable.
vim/vim@059fd01