### PR TITLE
cleanup/TUI: remove old unused code

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3632,12 +3632,8 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
               }
             }
 
-            need_wait_return = FALSE;             /* no hit-return prompt */
-            if (typed == 'q' || typed == ESC || typed == Ctrl_C
-#ifdef UNIX
-                || typed == intr_char
-#endif
-                ) {
+            need_wait_return = false;             // no hit-return prompt
+            if (typed == 'q' || typed == ESC || typed == Ctrl_C) {
               got_quit = true;
               break;
             }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3354,9 +3354,6 @@ void cmdline_paste_str(char_u *s, int literally)
       }
       if (cv == Ctrl_V || c == ESC || c == Ctrl_C
           || c == CAR || c == NL || c == Ctrl_L
-#ifdef UNIX
-          || c == intr_char
-#endif
           || (c == Ctrl_BSL && *s == Ctrl_N)) {
         stuffcharReadbuff(Ctrl_V);
       }

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -280,13 +280,9 @@ EXTERN int did_wait_return INIT(= FALSE);       /* wait_return() was used and
                                                    nothing written since then */
 EXTERN int need_maketitle INIT(= TRUE);      /* call maketitle() soon */
 
-EXTERN int quit_more INIT(= FALSE);         /* 'q' hit at "--more--" msg */
-#if defined(UNIX) || defined(MACOS_X)
-EXTERN int newline_on_exit INIT(= FALSE);       /* did msg in altern. screen */
-EXTERN int intr_char INIT(= 0);             /* extra interrupt character */
-#endif
-EXTERN int ex_keep_indent INIT(= FALSE);      /* getexmodeline(): keep indent */
-EXTERN int vgetc_busy INIT(= 0);            /* when inside vgetc() then > 0 */
+EXTERN int quit_more INIT(= false);         // 'q' hit at "--more--" msg
+EXTERN int ex_keep_indent INIT(= false);    // getexmodeline(): keep indent
+EXTERN int vgetc_busy INIT(= 0);            // when inside vgetc() then > 0
 
 EXTERN int didset_vim INIT(= FALSE);        /* did set $VIM ourselves */
 EXTERN int didset_vimruntime INIT(= FALSE);        /* idem for $VIMRUNTIME */

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2398,10 +2398,6 @@ int get_keystroke(void)
     }
     buf[len >= buflen ? buflen - 1 : len] = NUL;
     n = utf_ptr2char(buf);
-#ifdef UNIX
-    if (n == intr_char)
-      n = ESC;
-#endif
     break;
   }
   xfree(buf);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1852,7 +1852,7 @@ static void flush_buf(UI *ui)
 static const char *tui_get_stty_erase(void)
 {
   static char stty_erase[2] = { 0 };
-#if defined(ECHOE) && defined(ICANON) && defined(HAVE_TERMIOS_H)
+#if defined(HAVE_TERMIOS_H)
   struct termios t;
   if (tcgetattr(input_global_fd(), &t) != -1) {
     stty_erase[0] = (char)t.c_cc[VERASE];


### PR DESCRIPTION
- Checks for ECHOE, ICANON were left over from Vim code. We already
  reference the symbols elsewhere without checking.
- newline_on_exit, intr_char: Both are vestigial remnants of Vim 4.x,
  not implemented in Nvim. intr_char is a termios/stty feature, it's
  probably not useful because users have other ways to configure their
  terminals.
