### PR TITLE
[RFC] startup: don't erase screen on `:hi Normal` during startup (for non-newgrid UIs)

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6884,7 +6884,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       // "fg", which have been changed now.
       highlight_attr_set_all();
 
-      if (!ui_is_external(kUINewgrid) && starting != NO_SCREEN) {
+      if (!ui_is_external(kUINewgrid) && starting == 0) {
         // Older UIs assume that we clear the screen after normal group is
         // changed
         ui_refresh();

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -2,11 +2,12 @@ local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 
 local feed = helpers.feed
+local eq = helpers.eq
 local spawn, set_session = helpers.spawn, helpers.set_session
 local nvim_prog, nvim_set = helpers.nvim_prog, helpers.nvim_set
 local merge_args, prepend_argv = helpers.merge_args, helpers.prepend_argv
 
-describe('--embed UI on startup', function()
+local function test_embed(ext_newgrid)
   local session, screen
   local function startup(...)
     local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE',
@@ -17,7 +18,7 @@ describe('--embed UI on startup', function()
 
     -- attach immediately after startup, for early UI
     screen = Screen.new(60, 8)
-    screen:attach()
+    screen:attach{ext_newgrid=ext_newgrid}
     screen:set_default_attr_ids({
       [1] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
       [2] = {bold = true, foreground = Screen.colors.SeaGreen4},
@@ -55,7 +56,7 @@ describe('--embed UI on startup', function()
     ]])
   end)
 
-  it("doesn't erase output when setting colors", function()
+  it("doesn't erase output when setting color scheme", function()
     startup('--cmd', 'echoerr "foo"', '--cmd', 'color default', '--cmd', 'echoerr "bar"')
     screen:expect([[
                                                                   |
@@ -68,4 +69,23 @@ describe('--embed UI on startup', function()
       {2:Press ENTER or type command to continue}^                     |
     ]])
   end)
-end)
+
+  it("doesn't erase output when setting Normal colors", function()
+    startup('--cmd', 'echoerr "foo"', '--cmd', 'hi Normal guibg=Green', '--cmd', 'echoerr "bar"')
+    screen:expect{grid=[[
+                                                                  |
+                                                                  |
+                                                                  |
+                                                                  |
+      Error detected while processing pre-vimrc command line:     |
+      foo                                                         |
+      bar                                                         |
+      Press ENTER or type command to continue^                     |
+    ]], condition=function()
+      eq(Screen.colors.Green, screen.default_colors.rgb_bg)
+    end}
+  end)
+end
+
+describe('--embed UI on startup (ext_newgrid=true)', function() test_embed(true) end)
+describe('--embed UI on startup (ext_newgrid=false)', function() test_embed(false) end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -183,7 +183,7 @@ end
 
 function Screen:attach(options)
   if options == nil then
-    options = {rgb=true}
+    options = {}
   end
   if options.ext_newgrid == nil then
     options.ext_newgrid = true
@@ -191,6 +191,11 @@ function Screen:attach(options)
   self._options = options
   self._clear_attrs = (options.ext_newgrid and {{},{}}) or {}
   uimeths.attach(self._width, self._height, options)
+  if self._options.rgb == nil then
+    -- nvim defaults to rgb=true internally,
+    -- simplify test code by doing the same.
+    self._options.rgb = true
+  end
 end
 
 function Screen:detach()
@@ -641,7 +646,14 @@ function Screen:_handle_visual_bell()
   self.visual_bell = true
 end
 
-function Screen:_handle_default_colors_set()
+function Screen:_handle_default_colors_set(rgb_fg, rgb_bg, rgb_sp, cterm_fg, cterm_bg)
+  self.default_colors = {
+    rgb_fg=rgb_fg,
+    rgb_bg=rgb_bg,
+    rgb_sp=rgb_sp,
+    cterm_fg=cterm_fg,
+    cterm_bg=cterm_bg
+  }
 end
 
 function Screen:_handle_update_fg(fg)


### PR DESCRIPTION
FIXUP to #8754. I only tested with ext_newgrid UIs (test default + my branch of python-gui) right before merging, so I didn't notice this until testing with neovim-qt today.

NB: existing `color default` test is actually enough to trigger the bug when ext_newgrid=false is used. I first created the `:hi Normal` test as I thought the bug wasn't triggered as the builtin colors wouldn't set Normal (unless 'bg' is changed or something), which wasn't the case.
But as the root cause actually comes from `:hi Normal`, it makes sense to still add the separate test (if `color default` here gets optimized to become a no-op, or something).