### PR TITLE
vim-patch:8.0.1215

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3723,7 +3723,7 @@ int build_stl_str_hl(
 
     case STL_OFFSET_X:
       base = kNumBaseHexadecimal;
-      // fallthrough
+      FALLTHROUGH;
     case STL_OFFSET:
     {
       long l = ml_find_line_or_offset(wp->w_buffer, wp->w_cursor.lnum, NULL);
@@ -3734,7 +3734,7 @@ int build_stl_str_hl(
     }
     case STL_BYTEVAL_X:
       base = kNumBaseHexadecimal;
-      // fallthrough
+      FALLTHROUGH;
     case STL_BYTEVAL:
       num = byteval;
       if (num == NL)

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -791,7 +791,7 @@ Dictionary channel_info(uint64_t id)
 
     case kChannelStreamInternal:
        PUT(info, "internal", BOOLEAN_OBJ(true));
-      // FALLTHROUGH
+      FALLTHROUGH;
 
     case kChannelStreamSocket:
       stream_desc = "socket";

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -775,7 +775,7 @@ static int insert_handle_key(InsertState *s)
     if (echeck_abbr(ESC + ABBR_OFF)) {
       break;
     }
-  // FALLTHROUGH
+    FALLTHROUGH;
 
   case Ctrl_C:        // End input mode
     if (s->c == Ctrl_C && cmdwin_type != 0) {
@@ -4967,16 +4967,16 @@ static unsigned quote_meta(char_u *dest, char_u *src, int len)
       if (ctrl_x_mode == CTRL_X_DICTIONARY
           || ctrl_x_mode == CTRL_X_THESAURUS)
         break;
-      // fallthrough
+      FALLTHROUGH;
     case '~':
       if (!p_magic)             /* quote these only if magic is set */
         break;
-      // fallthrough
+      FALLTHROUGH;
     case '\\':
       if (ctrl_x_mode == CTRL_X_DICTIONARY
           || ctrl_x_mode == CTRL_X_THESAURUS)
         break;
-      // fallthrough
+      FALLTHROUGH;
     case '^':                   // currently it's not needed.
     case '$':
       m++;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -851,7 +851,7 @@ static int insert_handle_key(InsertState *s)
     if (mod_mask != MOD_MASK_CTRL) {
       goto normalchar;
     }
-  // FALLTHROUGH
+    FALLTHROUGH;
   case K_ZERO:        // Insert the previously inserted text.
   case NUL:
   case Ctrl_A:
@@ -890,7 +890,7 @@ static int insert_handle_key(InsertState *s)
       insert_do_complete(s);
       break;
     }
-  // FALLTHROUGH
+    FALLTHROUGH;
 
   case Ctrl_T:        // Make indent one shiftwidth greater.
     if (s->c == Ctrl_T && ctrl_x_mode == CTRL_X_THESAURUS) {
@@ -1062,7 +1062,7 @@ static int insert_handle_key(InsertState *s)
 
   case K_S_TAB:       // When not mapped, use like a normal TAB
     s->c = TAB;
-  // FALLTHROUGH
+    FALLTHROUGH;
 
   case TAB:           // TAB or Complete patterns along path
     if (ctrl_x_mode == CTRL_X_PATH_PATTERNS) {
@@ -1078,7 +1078,7 @@ static int insert_handle_key(InsertState *s)
 
   case K_KENTER:      // <Enter>
     s->c = CAR;
-  // FALLTHROUGH
+    FALLTHROUGH;
   case CAR:
   case NL:
     // In a quickfix window a <CR> jumps to the error under the
@@ -1157,7 +1157,7 @@ static int insert_handle_key(InsertState *s)
       }
       goto normalchar;
     }
-  // FALLTHROUGH
+    FALLTHROUGH;
 
   case Ctrl_P:        // Do previous/next pattern completion
   case Ctrl_N:
@@ -3269,7 +3269,7 @@ static bool ins_compl_prep(int c)
         compl_cont_status |= CONT_LOCAL;
       else if (compl_cont_mode != 0)
         compl_cont_status &= ~CONT_LOCAL;
-    /* FALLTHROUGH */
+      FALLTHROUGH;
     default:
       /* If we have typed at least 2 ^X's... for modes != 0, we set
        * compl_cont_status = 0 (eg, as if we had just started ^X
@@ -7370,7 +7370,7 @@ static bool ins_start_select(int c)
   case K_KPAGEDOWN:
     if (!(mod_mask & MOD_MASK_SHIFT))
       break;
-  // FALLTHROUGH
+    FALLTHROUGH;
   case K_S_LEFT:
   case K_S_RIGHT:
   case K_S_UP:

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4356,7 +4356,7 @@ eval_index(
       if (evaluate) {
         return FAIL;
       }
-      // fallthrough
+      FALLTHROUGH;
     }
     case VAR_STRING:
     case VAR_NUMBER:
@@ -4755,7 +4755,7 @@ static int get_string_tv(char_u **arg, typval_T *rettv, int evaluate)
           name += extra;
           break;
         }
-        // FALLTHROUGH
+        FALLTHROUGH;
 
       default:  MB_COPY_CHAR(p, name);
         break;
@@ -9749,14 +9749,14 @@ static void f_getcwd(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       if (from) {
         break;
       }
-      // fallthrough
+      FALLTHROUGH;
     case kCdScopeTab:
       assert(tp);
       from = tp->tp_localdir;
       if (from) {
         break;
       }
-      // fallthrough
+      FALLTHROUGH;
     case kCdScopeGlobal:
       if (globaldir) {        // `globaldir` is not always set.
         from = globaldir;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3290,7 +3290,7 @@ const char * set_one_cmd_context(
     while ((xp->xp_pattern = (char_u *)strchr(arg, ' ')) != NULL) {
       arg = (const char *)xp->xp_pattern + 1;
     }
-  // FALLTHROUGH
+    FALLTHROUGH;
   case CMD_buffer:
   case CMD_sbuffer:
   case CMD_checktime:

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1469,7 +1469,7 @@ static int command_line_handle_key(CommandLineState *s)
     if (s->ignore_drag_release) {
       return command_line_not_changed(s);
     }
-  // FALLTHROUGH
+    FALLTHROUGH;
   case K_LEFTMOUSE:
   case K_RIGHTMOUSE:
     if (s->c == K_LEFTRELEASE || s->c == K_RIGHTRELEASE) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1587,7 +1587,7 @@ static int command_line_handle_key(CommandLineState *s)
       }
       return command_line_not_changed(s);
     }
-    // fallthrough
+    FALLTHROUGH;
 
   case K_UP:
   case K_DOWN:

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -930,7 +930,8 @@ static void command_line_scan(mparm_T *parmp)
         }
         case 'M': {  // "-M"  no changes or writing of files
           reset_modifiable();
-        } // FALLTHROUGH
+          FALLTHROUGH;
+        }
         case 'm': {  // "-m"  no writing of files
           p_write = false;
           break;

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1045,7 +1045,8 @@ static void command_line_scan(mparm_T *parmp)
             argv_idx = -1;
             break;
           }
-        } // FALLTHROUGH
+          FALLTHROUGH;
+        }
         case 'S':    // "-S {file}" execute Vim script
         case 'i':    // "-i {shada}" use for ShaDa file
         case 'u':    // "-u {vimrc}" vim inits file
@@ -1189,7 +1190,8 @@ scripterror:
               argv_idx = -1;
               break;
             }
-          } // FALLTHROUGH
+            FALLTHROUGH;
+          }
           case 'W': {  // "-W {scriptout}" overwrite script file
             if (scriptout != NULL) {
               goto scripterror;

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1186,7 +1186,7 @@ get_menu_cmd_modes(
       modes = MENU_NORMAL_MODE;
       break;
     }
-  /* FALLTHROUGH */
+    FALLTHROUGH;
   default:
     cmd--;
     if (forceit) {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2255,7 +2255,7 @@ static int do_more_prompt(int typed_char)
         skip_redraw = TRUE;                     /* skip redraw once */
         need_wait_return = FALSE;               /* don't wait in main() */
       }
-    /*FALLTHROUGH*/
+      FALLTHROUGH;
     case 'q':                   /* quit */
     case Ctrl_C:
     case ESC:

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2256,7 +2256,7 @@ static int do_more_prompt(int typed_char)
         need_wait_return = FALSE;               /* don't wait in main() */
       }
       FALLTHROUGH;
-    case 'q':                   /* quit */
+    case 'q':                   // quit
     case Ctrl_C:
     case ESC:
       if (confirm_msg_used) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4202,12 +4202,12 @@ dozet:
       else
         curwin->w_cursor.lnum = curwin->w_botline;
     }
-  /* FALLTHROUGH */
+    FALLTHROUGH;
   case NL:
   case CAR:
   case K_KENTER:
     beginline(BL_WHITE | BL_FIX);
-  /* FALLTHROUGH */
+    FALLTHROUGH;
 
   case 't':   scroll_cursor_top(0, true);
     redraw_later(VALID);
@@ -4216,7 +4216,7 @@ dozet:
 
   /* "z." and "zz": put cursor in middle of screen */
   case '.':   beginline(BL_WHITE | BL_FIX);
-  /* FALLTHROUGH */
+  FALLTHROUGH;
 
   case 'z':   scroll_cursor_halfway(true);
     redraw_later(VALID);
@@ -4234,10 +4234,10 @@ dozet:
       curwin->w_cursor.lnum = 1;
     else
       curwin->w_cursor.lnum = curwin->w_topline - 1;
-  /* FALLTHROUGH */
+    FALLTHROUGH;
   case '-':
     beginline(BL_WHITE | BL_FIX);
-  /* FALLTHROUGH */
+    FALLTHROUGH;
 
   case 'b':   scroll_cursor_bot(0, true);
     redraw_later(VALID);
@@ -4247,7 +4247,7 @@ dozet:
   /* "zH" - scroll screen right half-page */
   case 'H':
     cap->count1 *= curwin->w_width / 2;
-  /* FALLTHROUGH */
+    FALLTHROUGH;
 
   /* "zh" - scroll screen to the right */
   case 'h':
@@ -4263,7 +4263,7 @@ dozet:
 
   /* "zL" - scroll screen left half-page */
   case 'L':   cap->count1 *= curwin->w_width / 2;
-  /* FALLTHROUGH */
+    FALLTHROUGH;
 
   /* "zl" - scroll screen to the left */
   case 'l':
@@ -6663,7 +6663,7 @@ static void nv_g_cmd(cmdarg_T *cap)
    */
   case K_BS:
     cap->nchar = Ctrl_H;
-  /* FALLTHROUGH */
+    FALLTHROUGH;
   case 'h':
   case 'H':
   case Ctrl_H:
@@ -6729,7 +6729,7 @@ static void nv_g_cmd(cmdarg_T *cap)
    */
   case '^':
     flag = true;
-  /* FALLTHROUGH */
+    FALLTHROUGH;
 
   case '0':
   case 'm':

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1867,7 +1867,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
       } else {
         bangredo = true;  // do_bang() will put cmd in redo buffer.
       }
-      // fallthrough
+      FALLTHROUGH;
 
     case OP_INDENT:
     case OP_COLON:
@@ -4480,7 +4480,7 @@ dozet:
       break;
     }
     undo = true;
-  /*FALLTHROUGH*/
+    FALLTHROUGH;
 
   case 'g':     /* "zg": add good word to word list */
   case 'w':     /* "zw": add wrong word to word list */
@@ -6907,7 +6907,7 @@ static void nv_g_cmd(cmdarg_T *cap)
   /* "g'm" and "g`m": jump to mark without setting pcmark */
   case '\'':
     cap->arg = true;
-  /*FALLTHROUGH*/
+    FALLTHROUGH;
   case '`':
     nv_gomark(cap);
     break;
@@ -6965,7 +6965,7 @@ static void nv_g_cmd(cmdarg_T *cap)
   case 'q':
   case 'w':
     oap->cursor_start = curwin->w_cursor;
-  /*FALLTHROUGH*/
+    FALLTHROUGH;
   case '~':
   case 'u':
   case 'U':

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -2420,7 +2420,7 @@ collection:
       } else if (reg_strict)
         EMSG2_RET_NULL(_(e_missingbracket), reg_magic > MAGIC_OFF);
     }
-  /* FALLTHROUGH */
+    FALLTHROUGH;
 
   default:
   {

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1805,7 +1805,7 @@ static char_u *regatom(int *flagp)
     if (c == '[')
       goto collection;
 
-  /* "\_x" is character class plus newline */
+  // "\_x" is character class plus newline
   FALLTHROUGH;
 
   /*
@@ -5154,7 +5154,7 @@ regrepeat (
 
   case IDENT:
   case IDENT + ADD_NL:
-    testval = TRUE;
+    testval = 1;
     FALLTHROUGH;
   case SIDENT:
   case SIDENT + ADD_NL:
@@ -5181,7 +5181,7 @@ regrepeat (
 
   case KWORD:
   case KWORD + ADD_NL:
-    testval = TRUE;
+    testval = 1;
     FALLTHROUGH;
   case SKWORD:
   case SKWORD + ADD_NL:
@@ -5210,7 +5210,7 @@ regrepeat (
 
   case FNAME:
   case FNAME + ADD_NL:
-    testval = TRUE;
+    testval = 1;
     FALLTHROUGH;
   case SFNAME:
   case SFNAME + ADD_NL:
@@ -5238,7 +5238,7 @@ regrepeat (
 
   case PRINT:
   case PRINT + ADD_NL:
-    testval = TRUE;
+    testval = 1;
     FALLTHROUGH;
   case SPRINT:
   case SPRINT + ADD_NL:
@@ -5417,7 +5417,7 @@ do_class:
 
   case ANYOF:
   case ANYOF + ADD_NL:
-    testval = TRUE;
+    testval = 1;
     FALLTHROUGH;
 
   case ANYBUT:

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1806,7 +1806,7 @@ static char_u *regatom(int *flagp)
       goto collection;
 
   /* "\_x" is character class plus newline */
-  /*FALLTHROUGH*/
+  FALLTHROUGH;
 
   /*
    * Character classes.
@@ -5155,7 +5155,7 @@ regrepeat (
   case IDENT:
   case IDENT + ADD_NL:
     testval = TRUE;
-  /*FALLTHROUGH*/
+    FALLTHROUGH;
   case SIDENT:
   case SIDENT + ADD_NL:
     while (count < maxcount) {
@@ -5182,7 +5182,7 @@ regrepeat (
   case KWORD:
   case KWORD + ADD_NL:
     testval = TRUE;
-  /*FALLTHROUGH*/
+    FALLTHROUGH;
   case SKWORD:
   case SKWORD + ADD_NL:
     while (count < maxcount) {
@@ -5211,7 +5211,7 @@ regrepeat (
   case FNAME:
   case FNAME + ADD_NL:
     testval = TRUE;
-  /*FALLTHROUGH*/
+    FALLTHROUGH;
   case SFNAME:
   case SFNAME + ADD_NL:
     while (count < maxcount) {
@@ -5239,7 +5239,7 @@ regrepeat (
   case PRINT:
   case PRINT + ADD_NL:
     testval = TRUE;
-  /*FALLTHROUGH*/
+    FALLTHROUGH;
   case SPRINT:
   case SPRINT + ADD_NL:
     while (count < maxcount) {
@@ -5418,7 +5418,7 @@ do_class:
   case ANYOF:
   case ANYOF + ADD_NL:
     testval = TRUE;
-  /*FALLTHROUGH*/
+    FALLTHROUGH;
 
   case ANYBUT:
   case ANYBUT + ADD_NL:

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1220,7 +1220,7 @@ static int nfa_regatom(void)
     if (c == '[')
       goto collection;
 
-  /* "\_x" is character class plus newline */
+  // "\_x" is character class plus newline
   FALLTHROUGH;
 
   /*
@@ -3256,7 +3256,7 @@ static nfa_state_T *post2nfa(int *postfix, int *end, int nfa_calc_size)
       break;
     }
 
-    case NFA_COMPOSING:         /* char with composing char */
+    case NFA_COMPOSING:         // char with composing char
       FALLTHROUGH;
 
     case NFA_MOPEN:     /* \( \) Submatch */

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1221,7 +1221,7 @@ static int nfa_regatom(void)
       goto collection;
 
   /* "\_x" is character class plus newline */
-  /*FALLTHROUGH*/
+  FALLTHROUGH;
 
   /*
    * Character classes.
@@ -4209,7 +4209,7 @@ skip_add:
       subs = addstate(l, state->out, subs, pim, off_arg);
       break;
     }
-    // fallthrough
+    FALLTHROUGH;
   case NFA_MCLOSE1:
   case NFA_MCLOSE2:
   case NFA_MCLOSE3:

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1801,7 +1801,7 @@ collection:
 
     if (reg_strict)
       EMSG_RET_FAIL(_(e_missingbracket));
-  /* FALLTHROUGH */
+    FALLTHROUGH;
 
   default:
   {
@@ -3257,7 +3257,7 @@ static nfa_state_T *post2nfa(int *postfix, int *end, int nfa_calc_size)
     }
 
     case NFA_COMPOSING:         /* char with composing char */
-    /* FALLTHROUGH */
+      FALLTHROUGH;
 
     case NFA_MOPEN:     /* \( \) Submatch */
     case NFA_MOPEN1:
@@ -3986,7 +3986,7 @@ addstate (
             || !REG_MULTI
             || reglnum == nfa_endp->se_u.pos.lnum))
       goto skip_add;
-  /* FALLTHROUGH */
+    FALLTHROUGH;
 
   case NFA_MOPEN1:
   case NFA_MOPEN2:

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2030,7 +2030,7 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
           }
         }
       }
-    /* FALLTHROUGH */
+      FALLTHROUGH;
 
     default:
       /*

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -4204,7 +4204,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
       }
       PROF_STORE(sp->ts_state)
       sp->ts_state = STATE_PLAIN;
-    // FALLTHROUGH
+      FALLTHROUGH;
 
     case STATE_PLAIN:
       // Go over all possible bytes at this node, add each to tword[]
@@ -4386,7 +4386,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
 
         break;
       }
-    // FALLTHROUGH
+      FALLTHROUGH;
 
     case STATE_INS_PREP:
       if (sp->ts_flags & TSF_DIDDEL) {
@@ -4416,7 +4416,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
       }
       break;
 
-    // FALLTHROUGH
+      FALLTHROUGH;
 
     case STATE_INS:
       // Insert one byte.  Repeat this for each possible byte at this
@@ -4552,7 +4552,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
       memmove(p + MB_PTR2LEN(p + n), p, n);
       utf_char2bytes(c, p);
 
-    // FALLTHROUGH
+      FALLTHROUGH;
 
     case STATE_SWAP3:
       // Swap two bytes, skipping one: "123" -> "321".  We change
@@ -4695,7 +4695,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
       memmove(p, p + tl, n);
       utf_char2bytes(c, p + n);
 
-    // FALLTHROUGH
+      FALLTHROUGH;
 
     case STATE_REP_INI:
       // Check if matching with REP items from the .aff file would work.

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -4726,7 +4726,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
 
       PROF_STORE(sp->ts_state)
       sp->ts_state = STATE_REP;
-    // FALLTHROUGH
+      FALLTHROUGH;
 
     case STATE_REP:
       // Try matching with REP items from the .aff file.  For each match

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -477,7 +477,7 @@ static int terminal_execute(VimState *state, int key)
       if (s->got_bsl) {
         return 0;
       }
-      // FALLTHROUGH
+      FALLTHROUGH;
 
     default:
       if (key == Ctrl_BSL && !s->got_bsl) {
@@ -841,20 +841,20 @@ static VTermKey convert_key(int key, VTermModifier *statep)
 
   switch (key) {
     case K_BS:        return VTERM_KEY_BACKSPACE;
-    case K_S_TAB:     // FALLTHROUGH
+    case K_S_TAB:     FALLTHROUGH;
     case TAB:         return VTERM_KEY_TAB;
     case Ctrl_M:      return VTERM_KEY_ENTER;
     case ESC:         return VTERM_KEY_ESCAPE;
 
-    case K_S_UP:      // FALLTHROUGH
+    case K_S_UP:      FALLTHROUGH;
     case K_UP:        return VTERM_KEY_UP;
-    case K_S_DOWN:    // FALLTHROUGH
+    case K_S_DOWN:    FALLTHROUGH;
     case K_DOWN:      return VTERM_KEY_DOWN;
-    case K_S_LEFT:    // FALLTHROUGH
-    case K_C_LEFT:    // FALLTHROUGH
+    case K_S_LEFT:    FALLTHROUGH;
+    case K_C_LEFT:    FALLTHROUGH;
     case K_LEFT:      return VTERM_KEY_LEFT;
-    case K_S_RIGHT:   // FALLTHROUGH
-    case K_C_RIGHT:   // FALLTHROUGH
+    case K_S_RIGHT:   FALLTHROUGH;
+    case K_C_RIGHT:   FALLTHROUGH;
     case K_RIGHT:     return VTERM_KEY_RIGHT;
 
     case K_INS:       return VTERM_KEY_INS;
@@ -864,22 +864,22 @@ static VTermKey convert_key(int key, VTermModifier *statep)
     case K_PAGEUP:    return VTERM_KEY_PAGEUP;
     case K_PAGEDOWN:  return VTERM_KEY_PAGEDOWN;
 
-    case K_K0:        // FALLTHROUGH
+    case K_K0:        FALLTHROUGH;
     case K_KINS:      return VTERM_KEY_KP_0;
-    case K_K1:        // FALLTHROUGH
+    case K_K1:        FALLTHROUGH;
     case K_KEND:      return VTERM_KEY_KP_1;
     case K_K2:        return VTERM_KEY_KP_2;
-    case K_K3:        // FALLTHROUGH
+    case K_K3:        FALLTHROUGH;
     case K_KPAGEDOWN: return VTERM_KEY_KP_3;
     case K_K4:        return VTERM_KEY_KP_4;
     case K_K5:        return VTERM_KEY_KP_5;
     case K_K6:        return VTERM_KEY_KP_6;
-    case K_K7:        // FALLTHROUGH
+    case K_K7:        FALLTHROUGH;
     case K_KHOME:     return VTERM_KEY_KP_7;
     case K_K8:        return VTERM_KEY_KP_8;
-    case K_K9:        // FALLTHROUGH
+    case K_K9:        FALLTHROUGH;
     case K_KPAGEUP:   return VTERM_KEY_KP_9;
-    case K_KDEL:      // FALLTHROUGH
+    case K_KDEL:      FALLTHROUGH;
     case K_KPOINT:    return VTERM_KEY_KP_PERIOD;
     case K_KENTER:    return VTERM_KEY_KP_ENTER;
     case K_KPLUS:     return VTERM_KEY_KP_PLUS;
@@ -887,29 +887,29 @@ static VTermKey convert_key(int key, VTermModifier *statep)
     case K_KMULTIPLY: return VTERM_KEY_KP_MULT;
     case K_KDIVIDE:   return VTERM_KEY_KP_DIVIDE;
 
-    case K_S_F1:      // FALLTHROUGH
+    case K_S_F1:      FALLTHROUGH;
     case K_F1:        return VTERM_KEY_FUNCTION(1);
-    case K_S_F2:      // FALLTHROUGH
+    case K_S_F2:      FALLTHROUGH;
     case K_F2:        return VTERM_KEY_FUNCTION(2);
-    case K_S_F3:      // FALLTHROUGH
+    case K_S_F3:      FALLTHROUGH;
     case K_F3:        return VTERM_KEY_FUNCTION(3);
-    case K_S_F4:      // FALLTHROUGH
+    case K_S_F4:      FALLTHROUGH;
     case K_F4:        return VTERM_KEY_FUNCTION(4);
-    case K_S_F5:      // FALLTHROUGH
+    case K_S_F5:      FALLTHROUGH;
     case K_F5:        return VTERM_KEY_FUNCTION(5);
-    case K_S_F6:      // FALLTHROUGH
+    case K_S_F6:      FALLTHROUGH;
     case K_F6:        return VTERM_KEY_FUNCTION(6);
-    case K_S_F7:      // FALLTHROUGH
+    case K_S_F7:      FALLTHROUGH;
     case K_F7:        return VTERM_KEY_FUNCTION(7);
-    case K_S_F8:      // FALLTHROUGH
+    case K_S_F8:      FALLTHROUGH;
     case K_F8:        return VTERM_KEY_FUNCTION(8);
-    case K_S_F9:      // FALLTHROUGH
+    case K_S_F9:      FALLTHROUGH;
     case K_F9:        return VTERM_KEY_FUNCTION(9);
-    case K_S_F10:     // FALLTHROUGH
+    case K_S_F10:     FALLTHROUGH;
     case K_F10:       return VTERM_KEY_FUNCTION(10);
-    case K_S_F11:     // FALLTHROUGH
+    case K_S_F11:     FALLTHROUGH;
     case K_F11:       return VTERM_KEY_FUNCTION(11);
-    case K_S_F12:     // FALLTHROUGH
+    case K_S_F12:     FALLTHROUGH;
     case K_F12:       return VTERM_KEY_FUNCTION(12);
 
     case K_F13:       return VTERM_KEY_FUNCTION(13);
@@ -975,11 +975,11 @@ static bool send_mouse_event(Terminal *term, int c)
     bool drag = false;
 
     switch (c) {
-      case K_LEFTDRAG: drag = true;  // FALLTHROUGH
+      case K_LEFTDRAG: drag = true;   FALLTHROUGH;
       case K_LEFTMOUSE: button = 1; break;
-      case K_MIDDLEDRAG: drag = true;  // FALLTHROUGH
+      case K_MIDDLEDRAG: drag = true; FALLTHROUGH;
       case K_MIDDLEMOUSE: button = 2; break;
-      case K_RIGHTDRAG: drag = true;  // FALLTHROUGH
+      case K_RIGHTDRAG: drag = true;  FALLTHROUGH;
       case K_RIGHTMOUSE: button = 3; break;
       case K_MOUSEDOWN: button = 4; break;
       case K_MOUSEUP: button = 5; break;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -421,7 +421,7 @@ wingotofile:
   case Ctrl_I:
     type = FIND_ANY;
     FALLTHROUGH;
-  case 'd':                         /* Go to definition, using 'define' */
+  case 'd':                         // Go to definition, using 'define'
   case Ctrl_D:
     CHECK_CMDWIN
     if ((len = find_ident_under_cursor(&ptr, FIND_IDENT)) == 0)

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -367,7 +367,7 @@ newwindow:
       g_do_tagpreview = Prenum;
     else
       g_do_tagpreview = p_pvh;
-  /*FALLTHROUGH*/
+    FALLTHROUGH;
   case ']':
   case Ctrl_RSB:
     CHECK_CMDWIN
@@ -465,7 +465,7 @@ wingotofile:
         g_do_tagpreview = Prenum;
       else
         g_do_tagpreview = p_pvh;
-    /*FALLTHROUGH*/
+      FALLTHROUGH;
     case ']':
     case Ctrl_RSB:
       // Keep visual mode, can select words to use as a tag.

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -420,7 +420,7 @@ wingotofile:
   case 'i':                         /* Go to any match */
   case Ctrl_I:
     type = FIND_ANY;
-  /* FALLTHROUGH */
+    FALLTHROUGH;
   case 'd':                         /* Go to definition, using 'define' */
   case Ctrl_D:
     CHECK_CMDWIN


### PR DESCRIPTION
**vim-patch:8.0.1215: newer gcc warns for implicit fallthrough**

Problem:    Newer gcc warns for implicit fallthrough.
Solution:   Consistently use a FALLTHROUGH comment. (Christian Brabandt)
https://github.com/vim/vim/commit/2f40d129bf45cd35976e4120336ae6d504f5a5dd