### PR TITLE
man.vim: Ignore $MANWIDTH and use vim's soft wrap

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -149,8 +149,9 @@ function! s:system(cmd, ...) abort
 endfunction
 
 function! s:get_page(path) abort
-  " Respect $MANWIDTH or default to window width.
-  let manwidth = empty($MANWIDTH) ? winwidth(0) : $MANWIDTH
+  " Disable hard-wrap by setting $MANWIDTH to a high value.
+  " Use soft wrap instead (ftplugin/man.vim sets 'wrap', 'breakindent').
+  let manwidth = 9999
   " Force MANPAGER=cat to ensure Vim is not recursively invoked (by man-db).
   " http://comments.gmane.org/gmane.editors.vim.devel/29085
   " Set MAN_KEEP_FORMATTING so Debian man doesn't discard backspaces.

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -167,6 +167,10 @@ function! s:put_page(page) abort
   while getline(1) =~# '^\s*$'
     silent keepjumps 1delete _
   endwhile
+  " XXX: nroff justifies text by filling it with whitespace.  That interacts
+  " badly with our use of $MANWIDTH=9999.  Hack around this by using a fixed
+  " size for those whitespace regions.
+  silent! keeppatterns keepjumps %s/\s\{999,}/\=repeat(' ', 10)/g
   lua require("man").highlight_man_page()
   setlocal filetype=man
 endfunction

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -149,8 +149,10 @@ function! s:system(cmd, ...) abort
 endfunction
 
 function! s:get_page(path) abort
-  " Respect $MANWIDTH or default to window width.
-  let manwidth = empty($MANWIDTH) ? winwidth(0) : $MANWIDTH
+  " Set $MANWIDTH to a really high value so lines will be wrapped will be
+  " soft through Vim's `set wrap` and `set breakindent` and not hard wraps by
+  " the man program itself which uses internally nroff(1)
+  let manwidth = 10000000
   " Force MANPAGER=cat to ensure Vim is not recursively invoked (by man-db).
   " http://comments.gmane.org/gmane.editors.vim.devel/29085
   " Set MAN_KEEP_FORMATTING so Debian man doesn't discard backspaces.

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -544,9 +544,6 @@ q                         :quit if invoked as $MANPAGER, otherwise :close.
 Variables:
 *g:no_man_maps*                  Do not create mappings in manpage buffers.
 *g:ft_man_folding_enable*        Fold manpages with foldmethod=indent foldnestmax=1.
-*g:ft_man_wrap_disable*          Disable |wrap|, enabled by default.
-*g:ft_man_linebreak_disable*     Disable |linebreak| wraps, enabled by default.
-*g:ft_man_breakindent_disable*   Disable |breakindent| wraps, enabled by default.
 *b:man_default_sects*            Comma-separated, ordered list of preferred sections.
                                For example in C one usually wants section 3 or 2: >
                                :let b:man_default_sections = '3,2'

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -542,10 +542,13 @@ gO                        Show the manpage outline. |gO|
 q                         :quit if invoked as $MANPAGER, otherwise :close.
 
 Variables:
-*g:no_man_maps*             Do not create mappings in manpage buffers.
-*g:ft_man_folding_enable*   Fold manpages with foldmethod=indent foldnestmax=1.
-*b:man_default_sects*       Comma-separated, ordered list of preferred sections.
-                          For example in C one usually wants section 3 or 2: >
+*g:no_man_maps*                  Do not create mappings in manpage buffers.
+*g:ft_man_folding_enable*        Fold manpages with foldmethod=indent foldnestmax=1.
+*g:ft_man_wrap_disable*          Disable |wrap|, enabled by default.
+*g:ft_man_linebreak_disable*     Disable |linebreak| wraps, enabled by default.
+*g:ft_man_breakindent_disable*   Disable |breakindent| wraps, enabled by default.
+*b:man_default_sects*            Comma-separated, ordered list of preferred sections.
+                               For example in C one usually wants section 3 or 2: >
                                :let b:man_default_sections = '3,2'
 
 PDF							*ft-pdf-plugin*

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -22,6 +22,8 @@ setlocal noexpandtab
 setlocal tabstop=8
 setlocal softtabstop=8
 setlocal shiftwidth=8
+setlocal wrap
+setlocal breakindent
 
 setlocal nonumber
 setlocal norelativenumber
@@ -31,6 +33,8 @@ setlocal nolist
 setlocal nofoldenable
 
 if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
+  nnoremap <silent> <buffer> j          gj
+  nnoremap <silent> <buffer> k          gk
   nnoremap <silent> <buffer> gO         :call man#show_toc()<CR>
   nnoremap <silent> <buffer> <C-]>      :Man<CR>
   nnoremap <silent> <buffer> K          :Man<CR>

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -52,17 +52,5 @@ if get(g:, 'ft_man_folding_enable', 0)
   setlocal foldnestmax=1
 endif
 
-if !get(g:, 'ft_man_wrap_disable', 0)
-  setlocal wrap
-endif
-
-if ! get(g:, 'ft_man_linebreak_disable', 0)
-  setlocal wrap
-endif
-
-if ! get(g:, 'ft_man_breakindnet_disable', 0)
-  setlocal breakindent
-endif
-
 let b:undo_ftplugin = ''
 " vim: set sw=2:

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -48,5 +48,17 @@ if get(g:, 'ft_man_folding_enable', 0)
   setlocal foldnestmax=1
 endif
 
+if !get(g:, 'ft_man_wrap_disable', 0)
+  setlocal wrap
+endif
+
+if ! get(g:, 'ft_man_linebreak_disable', 0)
+  setlocal wrap
+endif
+
+if ! get(g:, 'ft_man_breakindnet_disable', 0)
+  setlocal breakindent
+endif
+
 let b:undo_ftplugin = ''
 " vim: set sw=2:


### PR DESCRIPTION
Fixes #9017 