### PR TITLE
diff/highlight: diminish low-priority CursorLine

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -177,6 +177,24 @@ void update_window_hl(win_T *wp, bool invalid)
   }
 }
 
+/// Gets HL_UNDERLINE highlight.
+int hl_get_underline(void)
+{
+  return get_attr_entry((HlEntry){
+      .attr = (HlAttrs){
+          .cterm_ae_attr = (int16_t)HL_UNDERLINE,
+          .cterm_fg_color = 0,
+          .cterm_bg_color = 0,
+          .rgb_ae_attr = (int16_t)HL_UNDERLINE,
+          .rgb_fg_color = 0,
+          .rgb_bg_color = 0,
+      },
+      .kind = kHlUI,
+      .id1 = 0,
+      .id2 = 0,
+  });
+}
+
 /// Get attribute code for forwarded :terminal highlights.
 int hl_get_term_attr(HlAttrs *aep)
 {

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -178,7 +178,7 @@ void update_window_hl(win_T *wp, bool invalid)
 }
 
 /// Get attribute code for forwarded :terminal highlights.
-int get_term_attr_entry(HlAttrs *aep)
+int hl_get_term_attr(HlAttrs *aep)
 {
   return get_attr_entry((HlEntry){ .attr= *aep, .kind = kHlTerminal,
                                    .id1 = 0, .id2 = 0 });

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -22,7 +22,7 @@ typedef enum {
 /// Stores a complete highlighting entry, including colors and attributes
 /// for both TUI and GUI.
 typedef struct attr_entry {
-  int16_t rgb_ae_attr, cterm_ae_attr;  // HL_BOLD, etc.
+  int16_t rgb_ae_attr, cterm_ae_attr;  ///< HlAttrFlags
   RgbValue rgb_fg_color, rgb_bg_color, rgb_sp_color;
   int cterm_fg_color, cterm_bg_color;
 } HlAttrs;
@@ -83,8 +83,8 @@ typedef enum {
   , HLF_TP          // tabpage line
   , HLF_TPS         // tabpage line selected
   , HLF_TPF         // tabpage line filler
-  , HLF_CUC         // 'cursurcolumn'
-  , HLF_CUL         // 'cursurline'
+  , HLF_CUC         // 'cursorcolumn'
+  , HLF_CUL         // 'cursorline'
   , HLF_MC          // 'colorcolumn'
   , HLF_QFL         // selected quickfix line
   , HLF_0           // Whitespace

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -52,6 +52,7 @@
 #include "nvim/window.h"
 #include "nvim/os/os.h"
 #include "nvim/os/shell.h"
+#include "nvim/os/signal.h"
 #include "nvim/os/input.h"
 #include "nvim/os/time.h"
 #include "nvim/event/stream.h"
@@ -2653,6 +2654,8 @@ void preserve_exit(void)
   }
 
   really_exiting = true;
+  // Ignore SIGHUP while we are already exiting. #9274
+  signal_reject_deadly();
   mch_errmsg(IObuff);
   mch_errmsg("\n");
   ui_flush();

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2826,7 +2826,7 @@ win_line (
         draw_state = WL_BRI - 1;
       }
 
-      // draw 'breakindent': indent wrapped text accodringly
+      // draw 'breakindent': indent wrapped text accordingly
       if (draw_state == WL_BRI - 1 && n_extra == 0) {
         draw_state = WL_BRI;
         // if need_showbreak is set, breakindent also applies
@@ -3052,7 +3052,8 @@ win_line (
           diff_hlf = HLF_CHD;                   // changed line
         }
         line_attr = win_hl_attr(wp, diff_hlf);
-        if (wp->w_p_cul && lnum == wp->w_cursor.lnum) {
+        // Overlay CursorLine onto diff highlight, unless it's low-priority.
+        if (!line_attr_lowprio && wp->w_p_cul && lnum == wp->w_cursor.lnum) {
           line_attr = hl_combine_attr(line_attr, win_hl_attr(wp, HLF_CUL));
         }
       }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3052,9 +3052,13 @@ win_line (
           diff_hlf = HLF_CHD;                   // changed line
         }
         line_attr = win_hl_attr(wp, diff_hlf);
-        // Overlay CursorLine onto diff highlight, unless it's low-priority.
-        if (!line_attr_lowprio && wp->w_p_cul && lnum == wp->w_cursor.lnum) {
-          line_attr = hl_combine_attr(line_attr, win_hl_attr(wp, HLF_CUL));
+        // Overlay CursorLine onto diff-mode highlight.
+        if (wp->w_p_cul && lnum == wp->w_cursor.lnum) {
+          line_attr = 0 != line_attr_lowprio  // Low-priority CursorLine
+            ? hl_combine_attr(hl_combine_attr(win_hl_attr(wp, HLF_CUL),
+                                              line_attr),
+                              hl_get_underline())
+            : hl_combine_attr(line_attr, win_hl_attr(wp, HLF_CUL));
         }
       }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -61,6 +61,7 @@ struct hl_group {
   scid_T sg_scriptID;           ///< script in which the group was last set
   // for terminal UIs
   int sg_cterm;                 ///< "cterm=" highlighting attr
+                                ///< (combination of \ref HlAttrFlags)
   int sg_cterm_fg;              ///< terminal fg color number + 1
   int sg_cterm_bg;              ///< terminal bg color number + 1
   bool sg_cterm_bold;           ///< bold attr was set for light color

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -603,7 +603,7 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr,
     int attr_id = 0;
 
     if (hl_attrs || vt_fg != -1 || vt_bg != -1) {
-      attr_id = get_term_attr_entry(&(HlAttrs) {
+      attr_id = hl_get_term_attr(&(HlAttrs) {
         .cterm_ae_attr = (int16_t)hl_attrs,
         .cterm_fg_color = vt_fg_idx,
         .cterm_bg_color = vt_bg_idx,

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -104,7 +104,7 @@ static void ui_thread_run(void *data)
 
 static void ui_bridge_stop(UI *b)
 {
-  // Detach brigde first, so that "stop" is the last event the TUI loop
+  // Detach bridge first, so that "stop" is the last event the TUI loop
   // receives from the main thread. #8041
   ui_detach_impl(b);
   UIBridgeData *bridge = (UIBridgeData *)b;

--- a/src/nvim/ui_bridge.c
+++ b/src/nvim/ui_bridge.c
@@ -117,6 +117,7 @@ static void ui_bridge_stop(UI *b)
     if (stopped) {  // -V547
       break;
     }
+    // TODO(justinmk): Remove this. Use a cond-wait above. #9274
     loop_poll_events(&main_loop, 10);  // Process one event.
   }
   uv_thread_join(&bridge->ui_thread);

--- a/test/functional/autocmd/termclose_spec.lua
+++ b/test/functional/autocmd/termclose_spec.lua
@@ -6,6 +6,7 @@ local clear, command, nvim, nvim_dir =
 local eval, eq, retry =
   helpers.eval, helpers.eq, helpers.retry
 local ok = helpers.ok
+local feed = helpers.feed
 local iswin = helpers.iswin
 
 
@@ -87,5 +88,6 @@ describe('TermClose event', function()
 
     command('3bdelete!')
     retry(nil, nil, function() eq('3', eval('g:abuf')) end)
+    feed('<c-c>:qa!<cr>')
   end)
 end)

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -768,6 +768,38 @@ describe('CursorLine highlight', function()
       {4:[No Name] [+]             }{9:[No Name] [+]           }|
                                                         |
     ]])
+
+    -- CursorLine with fg=NONE is "low-priority".
+    -- Rendered as underline in a diff-line. #9028
+    command('hi CursorLine ctermbg=red ctermfg=NONE guibg=red guifg=NONE')
+    feed('kkkk')
+    screen:expect([[
+      {1:  }line 1 some text       {4:│}{1:  }line 1 some text      |
+      {1:  }{11:line 2 mo}{12:Re text!}{11:      }{4:│}{1:  }{11:^line 2 mo}{12:re text}{11:      }|
+      {1:  }{5:extra line!            }{4:│}{1:  }{6:----------------------}|
+      {1:  }extra line!            {4:│}{1:  }extra line!           |
+      {1:  }extra line!            {4:│}{1:  }extra line!           |
+      {1:  }last line ...          {4:│}{1:  }last line ...         |
+      {1:  }                       {4:│}{1:  }                      |
+      {1:  }{8:~                      }{4:│}{1:  }{8:~                     }|
+      {1:  }{8:~                      }{4:│}{1:  }{8:~                     }|
+      {1:  }{8:~                      }{4:│}{1:  }{8:~                     }|
+      {4:[No Name] [+]             }{9:[No Name] [+]           }|
+                                                        |
+    ]], {
+      [1] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray},
+      [2] = {bold = true, background = Screen.colors.Red},
+      [3] = {background = Screen.colors.LightMagenta},
+      [4] = {reverse = true},
+      [5] = {background = Screen.colors.LightBlue},
+      [6] = {background = Screen.colors.LightCyan1, bold = true, foreground = Screen.colors.Blue1},
+      [7] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+      [8] = {bold = true, foreground = Screen.colors.Blue1},
+      [9] = {bold = true, reverse = true},
+      [10] = {bold = true},
+      [11] = {special = Screen.colors.Grey0, underline = true, foreground = Screen.colors.Grey0, background = Screen.colors.Grey0},
+      [12] = {bold = true, special = Screen.colors.Grey0, background = Screen.colors.Grey0, foreground = Screen.colors.Grey0, underline = true},
+    })
   end)
 end)
 


### PR DESCRIPTION
Render low-priority CursorLine only as underline when the cursor is on a diff line. This is because typically a diff line has a foreground highlight, which makes text difficult to see if CursorLine has a background highlight.

CursorLine highlight with ctermfg/guifg=NONE is "low priority" in the presence of 'colorcolumn' and some other highlights. But before this PR it was not altered in a diff line. 

To see the effect, change `ctermfg=white` to `ctermfg=NONE` in this command:

    nvim -u NORC +'hi CursorLine ctermbg=darkgrey ctermfg=white' +'set cursorline' +'call feedkeys("ifoo\<CR>foo\<CR>foo\<CR>bar", "x")'  +vnew +'call feedkeys("ibee\<CR>foo\<CR>foo\<CR>foo\<CR>baz", "x")' +'windo diffthis'

ref #6380

todo:

- [x] tests

cc @zhou13