### PR TITLE
vim-patch:8.1.0389

### DIFF
--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -2,6 +2,7 @@
 " This makes testing go faster, since Vim doesn't need to restart.
 
 source test_assign.vim
+source test_behave.vim
 source test_cd.vim
 source test_changedtick.vim
 source test_compiler.vim

--- a/src/nvim/testdir/test_behave.vim
+++ b/src/nvim/testdir/test_behave.vim
@@ -1,0 +1,29 @@
+" Test the :behave command
+
+func Test_behave()
+  behave mswin
+  call assert_equal('mouse,key', &selectmode)
+  call assert_equal('popup', &mousemodel)
+  call assert_equal('startsel,stopsel', &keymodel)
+  call assert_equal('exclusive', &selection)
+
+  behave xterm
+  call assert_equal('', &selectmode)
+  call assert_equal('extend', &mousemodel)
+  call assert_equal('', &keymodel)
+  call assert_equal('inclusive', &selection)
+
+  set selection&
+  set mousemodel&
+  set keymodel&
+  set selection&
+endfunc
+
+func Test_behave_completion()
+  call feedkeys(":behave \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"behave mswin xterm', @:)
+endfunc
+
+func Test_behave_error()
+  call assert_fails('behave x', 'E475:')
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0389: :behave command is not tested**

Problem:    :behave command is not tested.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#3429)
https://github.com/vim/vim/commit/da1f71d75f0bf5d5ef876a09aa08fb19f6f24b3b