### PR TITLE
[RDY] vim-patch:8.0.0{368,370},8.1.0414

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1434,7 +1434,7 @@ do_set (
                         || (long *)varp == &p_wcm)
                        && (*arg == '<'
                            || *arg == '^'
-                           || ((!arg[1] || ascii_iswhite(arg[1]))
+                           || (*arg != NUL && (!arg[1] || ascii_iswhite(arg[1]))
                                && !ascii_isdigit(*arg)))) {
               value = string_to_key(arg);
               if (value == 0 && (long *)varp != &p_wcm) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4019,7 +4019,8 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
 
   options[opt_idx].flags |= P_WAS_SET;
 
-  if (!starting) {
+  // Don't do this while starting up or recursively.
+  if (!starting && *get_vim_var_str(VV_OPTION_TYPE) == NUL) {
     char buf_old[2];
     char buf_new[2];
     char buf_type[7];
@@ -4393,7 +4394,8 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
 
   options[opt_idx].flags |= P_WAS_SET;
 
-  if (!starting && errmsg == NULL) {
+  // Don't do this while starting up, failure or recursively.
+  if (!starting && errmsg == NULL && *get_vim_var_str(VV_OPTION_TYPE) == NUL) {
     char buf_old[NUMBUFLEN];
     char buf_new[NUMBUFLEN];
     char buf_type[7];
@@ -4426,7 +4428,10 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
 static void trigger_optionsset_string(int opt_idx, int opt_flags,
                                       char *oldval, char *newval)
 {
-  if (oldval != NULL && newval != NULL) {
+  // Don't do this recursively.
+  if (oldval != NULL
+      && newval != NULL
+      && *get_vim_var_str(VV_OPTION_TYPE) == NUL) {
     char buf_type[7];
 
     vim_snprintf(buf_type, ARRAY_SIZE(buf_type), "%s",

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -356,6 +356,24 @@ func Test_shortmess_F()
   bwipe
 endfunc
 
+func Test_set_all()
+  set tw=75
+  set iskeyword=a-z,A-Z
+  set nosplitbelow
+  let out = execute('set all')
+  call assert_match('textwidth=75', out)
+  call assert_match('iskeyword=a-z,A-Z', out)
+  call assert_match('nosplitbelow', out)
+  set tw& iskeyword& splitbelow&
+endfunc
+
+func Test_set_values()
+  " The file is only generated when running "make test" in the src directory.
+  if filereadable('opt_test.vim')
+    source opt_test.vim
+  endif
+endfunc
+
 func Test_shortmess_F2()
   e file1
   e file2

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -29,6 +29,19 @@ function! Test_isfname()
   set isfname&
 endfunction
 
+function Test_wildchar()
+  " Empty 'wildchar' used to access invalid memory.
+  call assert_fails('set wildchar=', 'E521:')
+  call assert_fails('set wildchar=abc', 'E521:')
+  set wildchar=<Esc>
+  let a=execute('set wildchar?')
+  call assert_equal("\n  wildchar=<Esc>", a)
+  set wildchar=27
+  let a=execute('set wildchar?')
+  call assert_equal("\n  wildchar=<Esc>", a)
+  set wildchar&
+endfunction
+
 function! Test_options()
   let caught = 'ok'
   try


### PR DESCRIPTION
**vim-patch:8.0.0368: not all options are tested with a range of values**

Problem:    Not all options are tested with a range of values.
Solution:   Generate a test script from the source code.
vim/vim@2f5463d

**vim-patch:8.0.0370: invalid memory access when setting wildchar empty**

Problem:    Invalid memory access when setting wildchar empty.
Solution:   Avoid going over the end of the option value. (Dominique Pelle,
            closes vim/vim#1509)  Make option test check all number options with
            empty value.
vim/vim@a12e403

**vim-patch:8.1.0414: v:option_old is cleared when using :set in OptionSet autocmd**

Problem:    v:option_old and v:option_new are cleared when using :set in
            OptionSet autocmd. (Gary Johnson)
Solution:   Don't trigger OptionSet recursively.
https://github.com/vim/vim/commit/3f3fb0b14734272e7c817020c847aaa0fba5cea5