### PR TITLE
deps: revert to jemalloc 4.5.0

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -141,8 +141,8 @@ set(LIBTERMKEY_SHA256 6c0d87c94ab9915e76ecd313baec08dedf3bd56de83743d9aa923a0819
 set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/3f62ac6b7bdffda39d68f723fb1806dfd6d6382d.tar.gz)
 set(LIBVTERM_SHA256 1c8b318370f00f831f43e3ec86a48984250e3ee5c76beb106a421c9a42286ac5)
 
-set(JEMALLOC_URL https://github.com/jemalloc/jemalloc/releases/download/5.1.0/jemalloc-5.1.0.tar.bz2)
-set(JEMALLOC_SHA256 5396e61cc6103ac393136c309fae09e44d74743c86f90e266948c50f3dbb7268)
+set(JEMALLOC_URL https://github.com/jemalloc/jemalloc/releases/download/4.5.0/jemalloc-4.5.0.tar.bz2)
+set(JEMALLOC_SHA256 9409d85664b4f135b77518b0b118c549009dc10f6cba14557d170476611f6780)
 
 set(LUV_URL https://github.com/luvit/luv/archive/1.9.1-1.tar.gz)
 set(LUV_SHA256 562b9efaad30aa051a40eac9ade0c3df48bb8186763769abe47ec3fb3edb1268)


### PR DESCRIPTION
(Going to test this locally for a few days to see if it fixes some symptoms I noticed.)

- Since the jemalloc upgrade to 5.1.0, I'm seeing weird behavior such as
  infinite loops inside jemalloc routines.
- VimR maintainer reported major performance regression correlated with
  jemalloc 5.1.0.
- @jamessan noted that even debian sid/unstable has not accepted jemalloc 5.x series due to instability.

ref https://github.com/neovim/neovim/pull/7808

reverts 765515010f8e60596ec67eb7cdfbe7f5e4e60c7d

cc @qvacua