### PR TITLE
vim-patch:8.0.1557: printf() does not work with only one argument

### DIFF
--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -222,7 +222,7 @@ return {
     pathshorten={args=1},
     pow={args=2},
     prevnonblank={args=1},
-    printf={args=varargs(2)},
+    printf={args=varargs(1)},
     pumvisible={},
     py3eval={args=1},
     pyeval={args=1},

--- a/src/nvim/testdir/test_expr.vim
+++ b/src/nvim/testdir/test_expr.vim
@@ -166,6 +166,9 @@ function Test_printf_spec_s()
 endfunc
 
 function Test_printf_misc()
+  call assert_equal('123', printf('123'))
+  call assert_fails("call printf('123', 3)", "E767:")
+
   call assert_equal('123', printf('%d', 123))
   call assert_equal('123', printf('%i', 123))
   call assert_equal('123', printf('%D', 123))


### PR DESCRIPTION
Problem:    printf() does not work with only one argument. (Daniel Hahler)
Solution:   Allow using just the format. (Ken Takata, closes vim/vim#2687)
https://github.com/vim/vim/commit/c71807db9c1821baf86796cd76952df36ff1a29a