### PR TITLE
[RFC] Allow displaying signs in the number column

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -304,7 +304,7 @@ static char *(p_fcl_values[]) =       { "all", NULL };
 static char *(p_cot_values[]) =       { "menu", "menuone", "longest", "preview",
                                         "noinsert", "noselect", NULL };
 static char *(p_icm_values[]) =       { "nosplit", "split", NULL };
-static char *(p_scl_values[]) =       { "yes", "no", "auto", NULL };
+static char *(p_scl_values[]) =       { "yes", "no", "auto", "number", "number_hl", NULL };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "option.c.generated.h"

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -304,7 +304,8 @@ static char *(p_fcl_values[]) =       { "all", NULL };
 static char *(p_cot_values[]) =       { "menu", "menuone", "longest", "preview",
                                         "noinsert", "noselect", NULL };
 static char *(p_icm_values[]) =       { "nosplit", "split", NULL };
-static char *(p_scl_values[]) =       { "yes", "no", "auto", "number", "number_hl", NULL };
+static char *(p_scl_values[]) =       { "yes", "no", "auto", "number",
+                                        "number_hl", NULL };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "option.c.generated.h"

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -304,8 +304,7 @@ static char *(p_fcl_values[]) =       { "all", NULL };
 static char *(p_cot_values[]) =       { "menu", "menuone", "longest", "preview",
                                         "noinsert", "noselect", NULL };
 static char *(p_icm_values[]) =       { "nosplit", "split", NULL };
-static char *(p_scl_values[]) =       { "yes", "no", "auto", "number",
-                                        "number_hl", NULL };
+static char *(p_scl_values[]) =       { "yes", "no", "auto", "number", NULL };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "option.c.generated.h"
@@ -7085,6 +7084,7 @@ int csh_like_shell(void)
 bool signcolumn_on(win_T *wp)
 {
     if (*wp->w_p_scl == 'n') {
+      // This captures both 'no' and 'number'.
       return false;
     }
     if (*wp->w_p_scl == 'y') {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2872,9 +2872,9 @@ win_line (
                 rl_mirror(extra);
               }
               p_extra = extra;
+              c_extra = NUL;
             }
 
-            c_extra = NUL;
           }
 
           char_attr = win_hl_attr(wp, HLF_N);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1637,7 +1637,7 @@ int win_signcol_width(win_T *wp)
 /// Return the total byte length of the output.
 int draw_sign(char_u **pp_extra_free, int text_sign, int width, int pad)
 {
-  char *text = sign_get_text(text_sign);
+  char_u *text = sign_get_text(text_sign);
   int symbol_blen = (int)STRLEN(text);
   int n_extra = 0;
   if (text != NULL) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1638,10 +1638,16 @@ int win_signcol_width(win_T *wp)
 int draw_sign(char_u **pp_extra_free, int text_sign, int width, int pad)
 {
   char_u *text = sign_get_text(text_sign);
-  int symbol_blen = (int)STRLEN(text);
   int n_extra = 0;
   if (text != NULL) {
+		int symbol_blen = (int)STRLEN(text);
     int cell_size = mb_string2cells(text);
+		while (pad > 0 && cell_size > width) {
+			// Eat into the padding if width is not large enough.
+			// This will have to be adjusted when variable width signs are introduced.
+			pad--;
+			width++;
+		}
     // symbol(s) bytes + (filling spaces) (one byte each)
     n_extra = symbol_blen + width + pad - cell_size;
     xfree(*pp_extra_free);
@@ -2874,7 +2880,6 @@ win_line (
               p_extra = extra;
               c_extra = NUL;
             }
-
           }
 
           char_attr = win_hl_attr(wp, HLF_N);

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -17,6 +17,7 @@ describe('Signs', function()
       [3] = {background = Screen.colors.Gray90},
       [4] = {bold = true, reverse = true},
       [5] = {reverse = true},
+      [6] = {foreground = Screen.colors.Brown},
     } )
   end)
 
@@ -75,6 +76,85 @@ describe('Signs', function()
         {2:  }                                                   |
         {2:  }{0:~                                                  }|
         {5:[No Name] [+]                                        }|
+                                                             |
+      ]])
+    end)
+  end)
+
+  describe('signcolumn=number', function()
+    it('show sign in number column', function()
+      feed('ia<cr>b<cr>c<cr>d<cr><esc>')
+      command('sign define piet text=>> texthl=Search')
+      command('sign define pietx text=𠆤 texthl=Search')
+      command('sign define pietxx text=X texthl=Search')
+      command('sign place 1 line=1 name=piet buffer=1')
+      command('sign place 2 line=3 name=pietx buffer=1')
+      command('sign place 3 line=5 name=pietxx buffer=1')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {2:  }b                                                  |
+        {1:𠆤}c                                                  |
+        {2:  }d                                                  |
+        {1:X }^                                                   |
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+                                                             |
+      ]])
+      command('set number')
+      screen:expect([[
+        {1:>>}{6:  1 }a                                              |
+        {2:  }{6:  2 }b                                              |
+        {1:𠆤}{6:  3 }c                                              |
+        {2:  }{6:  4 }d                                              |
+        {1:X }{6:  5 }^                                               |
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+                                                             |
+      ]])
+      command('set signcolumn=number')
+      screen:expect([[
+        {1: >> }a                                                |
+        {6:  2 }b                                                |
+        {1: 𠆤 }c                                                |
+        {6:  4 }d                                                |
+        {1: X  }^                                                 |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      command('set numberwidth=2')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {6:2 }b                                                  |
+        {1:𠆤}c                                                  |
+        {6:4 }d                                                  |
+        {1:X }^                                                   |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
                                                              |
       ]])
     end)


### PR DESCRIPTION
In order to save horizontal space, this patch allows you to display signs in place of line numbers in the number column by setting `signcolumn=number`. Additionally, setting `signcolumn=number_hl` will display the line number, but highlighted according to the sign.

I'm not an experienced C programmer, so please forgive any rookie mistakes. 

Some comments:
 * ~~The code is currently broken with `numberwidth` <= 2. This can either be fixed by forcing the number column to be wider in this case, or by truncating or hiding the sign.~~  It now eats into the padding to get enough room.
 * There is a bug in the old code where the `extra` buffer can be overflown with a sign text with unreasonable amounts of combining characters. I switched to using `p_extra_free` to fix this.
 * I tried to minimize code duplication by moving most of the drawing to the `draw_sign` function, although it's still not very elegant.
 * I currently have the highlight of the sign win out over `cursorline`, but that can easily be changed.
 * The code currently "abuses" the fact that `number` starts with the letter `n`, and hence is interpreted as a `no` by the part of the code that hides the regular sign column. Maybe this is a bit too hacky, but easy to fix.
 * There is a WIP pull request (#6196) to allow showing multiple signs in a line. That would have to be adjusted to work with this.