### PR TITLE
vim-patch:8.1.0429: no test for :lcd with 'shellslash'

### DIFF
--- a/src/nvim/testdir/test_getcwd.vim
+++ b/src/nvim/testdir/test_getcwd.vim
@@ -89,3 +89,15 @@ function Test_GetCwd()
 	call assert_equal("y Xdir2 1", GetCwdInfo(2, tp_nr))
 	call assert_equal("z Xdir3 1", GetCwdInfo(1, tp_nr))
 endfunc
+
+function Test_GetCwd_lcd_shellslash()
+	new
+	let root = fnamemodify('/', ':p')
+	exe 'lcd '.root
+	let cwd = getcwd()
+	if !exists('+shellslash') || &shellslash
+		call assert_equal(cwd[-1:], '/')
+	else
+		call assert_equal(cwd[-1:], '\')
+	endif
+endfunc


### PR DESCRIPTION
Problem:    No test for :lcd with 'shellslash'.
Solution:   Add a test. (Daniel Hahler, closes vim/vim#3475)
https://github.com/vim/vim/commit/c75878c923034b883090aef3f08f565513d98f4d

This shows that we can skip patch 8.1.0343 (https://github.com/vim/vim/releases/tag/v8.1.0343).