### PR TITLE
vim-patch:8.1.0428

### DIFF
--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -38,6 +38,7 @@ source test_sort.vim
 source test_source_utf8.vim
 source test_sha256.vim
 source test_statusline.vim
+source test_suspend.vim
 source test_syn_attr.vim
 source test_tabline.vim
 " source test_tabpage.vim

--- a/src/nvim/testdir/test_suspend.vim
+++ b/src/nvim/testdir/test_suspend.vim
@@ -1,0 +1,51 @@
+" Test :suspend
+
+source shared.vim
+
+func Test_suspend()
+  if !has('terminal') || !executable('/bin/sh')
+    return
+  endif
+
+  let buf = term_start('/bin/sh')
+  " Wait for shell prompt.
+  call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
+
+  call term_sendkeys(buf, v:progpath
+        \               . " --clean -X"
+        \               . " -c 'set nu'"
+        \               . " -c 'call setline(1, \"foo\")'"
+        \               . " Xfoo\<CR>")
+  " Cursor in terminal buffer should be on first line in spawned vim.
+  call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})
+
+  for suspend_cmd in [":suspend\<CR>",
+        \             ":stop\<CR>",
+        \             ":suspend!\<CR>",
+        \             ":stop!\<CR>",
+        \             "\<C-Z>"]
+    " Suspend and wait for shell prompt.
+    call term_sendkeys(buf, suspend_cmd)
+    call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
+
+    " Without 'autowrite', buffer should not be written.
+    call assert_equal(0, filereadable('Xfoo'))
+
+    call term_sendkeys(buf, "fg\<CR>")
+    call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})
+  endfor
+
+  " Test that :suspend! with 'autowrite' writes content of buffers if modified.
+  call term_sendkeys(buf, ":set autowrite\<CR>")
+  call assert_equal(0, filereadable('Xfoo'))
+  call term_sendkeys(buf, ":suspend\<CR>")
+  " Wait for shell prompt.
+  call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
+  call assert_equal(['foo'], readfile('Xfoo'))
+  call term_sendkeys(buf, "fg\<CR>")
+  call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})
+
+  exe buf . 'bwipe!'
+  call delete('Xfoo')
+  set autowrite&
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0428: the :suspend command is not tested**

Problem:    The :suspend command is not tested.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#3472)
https://github.com/vim/vim/commit/3b30168f04b8a2a2f1bbaa2f90be546550463146

The test won't run so this is only to make it easier to merge future patches.