### PR TITLE
Improve performace with `scripts/vim-patch.sh -l`

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -345,7 +345,8 @@ list_vim_commits() { (
 ) }
 
 # Prints all (sorted) "vim-patch:xxx" tokens found in the Nvim git log.
-# Commit hashes (xxx not starting with "\d\.") are shortened to 7 characters.
+# Uses `{7,7}` with `sed` to canonicalize (internal) Git hashes ((xxx not
+# starting with "\d\.") to 7 chars (used in tokens caches).
 list_vimpatch_tokens() {
   git -C "${NVIM_SOURCE_DIR}" log -E --grep='vim-patch:[^ ,{]{7,}' \
     | grep -oE 'vim-patch:[^ ,{:]{7,}' \

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -392,8 +392,7 @@ list_missing_vimpatches() {
     if [[ "${tokens[$patch_number]-}" ]]; then
       continue
     fi
-    vim_commit="${vim_tag#v}"
-    echo "${vim_commit}"
+    echo "${vim_tag}"
   done
 }
 
@@ -403,7 +402,7 @@ show_vimpatches() {
   printf "\nVim patches missing from Neovim:\n"
 
   list_missing_vimpatches | while read vim_commit; do
-    if [[ "$(git -C "$VIM_SOURCE_DIR" diff-tree --no-commit-id --name-only  "v${vim_commit}" -- runtime)" ]]; then
+    if [[ "$(git -C "$VIM_SOURCE_DIR" diff-tree --no-commit-id --name-only  "${vim_commit}" -- runtime)" ]]; then
       printf '  • %s (+runtime)\n' "${vim_commit}"
     else
       printf '  • %s\n' "${vim_commit}"

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -381,17 +381,16 @@ list_missing_vimpatches() {
       continue
     fi
 
-    if ! vim_tag="$(git -C "${VIM_SOURCE_DIR}" describe --tags --exact-match "${vim_commit}" 2>/dev/null)"; then
-      # Skip commits without tag, i.e. not a Vim patch.
-      continue
+    if vim_tag="$(git -C "${VIM_SOURCE_DIR}" describe --tags --exact-match "${vim_commit}" 2>/dev/null)"; then
+      # Check for vim-patch:<tag> (not commit hash).
+      patch_number="vim-patch:${vim_tag:1}" # "v7.4.0001" => "7.4.0001"
+      if [[ "${tokens[$patch_number]-}" ]]; then
+        continue
+      fi
+      echo "$vim_tag"
+    else
+      echo "$vim_commit"
     fi
-
-    # Check for vim-patch:<tag> (not commit hash).
-    patch_number="vim-patch:${vim_tag:1}" # "v7.4.0001" => "7.4.0001"
-    if [[ "${tokens[$patch_number]-}" ]]; then
-      continue
-    fi
-    echo "${vim_tag}"
   done
 }
 

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -366,7 +366,7 @@ list_vimpatch_numbers() {
 
 # Prints a newline-delimited list of Vim commits, for use by scripts.
 list_missing_vimpatches() {
-  local token vim_commit vim_commits vim_tag patch_number
+  local token vim_commit vim_tag patch_number
   declare -A tokens
 
   # Find all "vim-patch:xxx" tokens in the Nvim git log.
@@ -375,8 +375,7 @@ list_missing_vimpatches() {
   done
 
   # Get missing Vim commits
-  vim_commits="$(list_vim_commits)"
-  for vim_commit in ${vim_commits}; do
+  for vim_commit in $(list_vim_commits); do
     # Check for vim-patch:<commit_hash> (usually runtime updates).
     token="vim-patch:${vim_commit:0:7}"
     if [[ "${tokens[$token]-}" ]]; then

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -345,14 +345,13 @@ list_vim_commits() { (
 ) }
 
 # Prints all (sorted) "vim-patch:xxx" tokens found in the Nvim git log.
+# Commit hashes (xxx not starting with "\d\.") are shortened to 7 characters.
 list_vimpatch_tokens() {
-  local tokens
-  # Find all "vim-patch:xxx" tokens in the Nvim git log.
-  tokens="$(cd "${NVIM_SOURCE_DIR}" && git log -E --grep='vim-patch:[^ ]+' | grep 'vim-patch')"
-  echo "$tokens" | grep -E 'vim-patch:[^ ,{]{7,}' \
-    | sed 's/.*\(vim-patch:[.0-9a-z]\+\).*/\1/' \
+  git -C "${NVIM_SOURCE_DIR}" log -E --grep='vim-patch:[^ ,{]{7,}' \
+    | grep -oE 'vim-patch:[^ ,{:]{7,}' \
     | sort \
-    | uniq
+    | uniq \
+    | sed -nE 's/^(vim-patch:([0-9]+\.[^ ]+|[0-9a-z]{7,7})).*/\1/p'
 }
 
 # Prints all patch-numbers (for the current v:version) for which there is

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -399,7 +399,7 @@ show_vimpatches() {
   printf "\nVim patches missing from Neovim:\n"
 
   list_missing_vimpatches | while read vim_commit; do
-    if (cd "${VIM_SOURCE_DIR}" && git --no-pager  show --color=never --name-only "v${vim_commit}" 2>/dev/null) | grep -q ^runtime; then
+    if [[ "$(git -C "$VIM_SOURCE_DIR" diff-tree --no-commit-id --name-only  "v${vim_commit}" -- runtime)" ]]; then
       printf '  • %s (+runtime)\n' "${vim_commit}"
     else
       printf '  • %s\n' "${vim_commit}"


### PR DESCRIPTION
Differences in output:

- keeps/adds the "v" prefix, which allows to easily copy'n'paste this for "git show" in the Vim repo
- removes commit hashes for runtime file updates, e.g. 7f2e9d7c9cdfc5201a899b7b610edf64bf80c45f` (vim/vim@7f2e9d7c9cdfc5201a899b7b610edf64bf80c45f)

Before:
> 134.99s user 59.14s system 153% cpu 2:06.11 total

After:
> 20.88s user 33.04s system 106% cpu 50.469 total