### PR TITLE
vim-patch:8.1.{433,436}

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -793,9 +793,11 @@ static int command_line_execute(VimState *state, int key)
     no_mapping--;
     // CTRL-\ e doesn't work when obtaining an expression, unless it
     // is in a mapping.
-    if (s->c != Ctrl_N && s->c != Ctrl_G && (s->c != 'e'
-                                             || (ccline.cmdfirstc == '='
-                                                 && KeyTyped))) {
+    if (s->c != Ctrl_N
+        && s->c != Ctrl_G
+        && (s->c != 'e'
+            || (ccline.cmdfirstc == '=' && KeyTyped)
+            || cmdline_star)) {
       vungetc(s->c);
       s->c = Ctrl_BSL;
     } else if (s->c == 'e') {
@@ -1350,7 +1352,8 @@ static int command_line_handle_key(CommandLineState *s)
     // a new one...
     new_cmdpos = -1;
     if (s->c == '=') {
-      if (ccline.cmdfirstc == '=') {          // can't do this recursively
+      if (ccline.cmdfirstc == '='   // can't do this recursively
+          || cmdline_star) {        // or when typing a password
         beep_flush();
         s->c = ESC;
       } else {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -797,7 +797,7 @@ static int command_line_execute(VimState *state, int key)
         && s->c != Ctrl_G
         && (s->c != 'e'
             || (ccline.cmdfirstc == '=' && KeyTyped)
-            || cmdline_star)) {
+            || cmdline_star > 0)) {
       vungetc(s->c);
       s->c = Ctrl_BSL;
     } else if (s->c == 'e') {
@@ -1353,7 +1353,7 @@ static int command_line_handle_key(CommandLineState *s)
     new_cmdpos = -1;
     if (s->c == '=') {
       if (ccline.cmdfirstc == '='   // can't do this recursively
-          || cmdline_star) {        // or when typing a password
+          || cmdline_star > 0) {    // or when typing a password
         beep_flush();
         s->c = ESC;
       } else {
@@ -5590,6 +5590,9 @@ static struct cmdline_info *get_ccline_ptr(void)
  */
 char_u *get_cmdline_str(void)
 {
+  if (cmdline_star > 0) {
+    return NULL;
+  }
   struct cmdline_info *p = get_ccline_ptr();
 
   if (p == NULL)


### PR DESCRIPTION
**vim-patch:8.1.0433: mapping can obtain text from inputsecret()**

Problem:    Mapping can obtain text from inputsecret(). (Tommy Allen)
Solution:   Disallow CTRL-R = and CTRL-\ e when using inputsecret().
vim/vim@31cbadf

**vim-patch:8.1.0436: can get the text of inputsecret() with getcmdline()**

Problem:    Can get the text of inputsecret() with getcmdline(). (Tommy Allen)
Solution:   Don't return the text.
vim/vim@ee91c33