### PR TITLE
nodejs: Simultaneously query both npm and yarn

### DIFF
--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -83,12 +83,12 @@ function! provider#node#Detect() abort
 
   " npm returns the directory faster, so let's check that first
   let result = jobwait([npm_opts.job_id])
-  if npm_opts.result != ''
+  if result[0] == 0 && npm_opts.result != ''
       return npm_opts.result
   endif
 
   let result = jobwait([yarn_opts.job_id])
-  if yarn_opts.result != ''
+  if result[0] == 0 && yarn_opts.result != ''
       return yarn_opts.result
   endif
 

--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -23,13 +23,9 @@ function! s:is_minimum_version(version, min_major, min_minor) abort
 endfunction
 
 let s:NodeHandler = {}
-let s:NodeHandler.result = ''
-function! s:NodeHandler.on_stdout(job_id, data, event)
-    let self.data += a:data
-endfunction
 
 function! s:NodeHandler.on_exit(job_id, data, event)
-    let bin_dir = join(self.data, '')
+    let bin_dir = join(self.stdout, '')
     let entry_point = bin_dir . self.entry_point
     if filereadable(entry_point)
         let self.result = entry_point
@@ -40,7 +36,8 @@ endfunction
 
 function! s:NodeHandler.new()
     let obj = copy(s:NodeHandler)
-    let obj.data = []
+    let obj.stdout_buffered = v:true
+    let obj.result = ''
 
     return obj
 endfunction
@@ -59,7 +56,6 @@ function! provider#node#can_inspect() abort
   return (ver[1] ==# '6' && s:is_minimum_version(ver, 6, 12))
     \ || s:is_minimum_version(ver, 7, 6)
 endfunction
-
 
 function! provider#node#Detect() abort
   if exists('g:node_host_prog')


### PR DESCRIPTION
Instead of serially querying npm and yarn for neovim, start both as a
neovim job and then wait for a successful result from either.

See discussion in #9001.