### PR TITLE
vim-patch:8.1.0435: cursorline highlight not removed in some situation

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -98,6 +98,11 @@ static void comp_botline(win_T *wp)
 
 static linenr_T last_cursorline = 0;
 
+void reset_cursorline(void)
+{
+  last_cursorline = 0;
+}
+
 // Redraw when w_cline_row changes and 'relativenumber' or 'cursorline' is set.
 static void redraw_for_cursorline(win_T *wp)
 {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3705,6 +3705,9 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
   } else if ((int *)varp == &p_lnr) {
     // 'langnoremap' -> !'langremap'
     p_lrm = !p_lnr;
+  } else if ((int *)varp == &curwin->w_p_cul && !value && old_value) {
+    // 'cursorline'
+    reset_cursorline();
   // 'undofile'
   } else if ((int *)varp == &curbuf->b_p_udf || (int *)varp == &p_udf) {
     // Only take action when the option was set. When reset we do not


### PR DESCRIPTION
Problem:    Cursorline highlight not removed in some situation. (Vitaly
            Yashin)
Solution:   Reset last_cursorline when resetting 'cursorline'. (Christian
            Brabandt, closes vim/vim#3481)
https://github.com/vim/vim/commit/8c63e0ec314ba07d54b881dc629fe19e6eda1fb8