### PR TITLE
vim-patch:8.1.0120: buffer 'modified' set even when :sort has no changes

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -585,7 +585,7 @@ void ex_sort(exarg_T *eap)
 
   // Insert the lines in the sorted order below the last one.
   lnum = eap->line2;
-  for (i = 0; i < count; ++i) {
+  for (i = 0; i < count; i++) {
     const linenr_T get_lnum = nrs[eap->forceit ? count - i - 1 : i].lnum;
 
     // If the original line number of the line being placed is not the same

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -424,6 +424,7 @@ void ex_sort(exarg_T *eap)
 
   sort_abort = sort_ic = sort_rx = sort_nr = sort_flt = 0;
   size_t format_found = 0;
+  bool change_occurred = false;   // Buffer contents changed.
 
   for (p = eap->arg; *p != NUL; ++p) {
     if (ascii_iswhite(*p)) {
@@ -585,7 +586,15 @@ void ex_sort(exarg_T *eap)
   // Insert the lines in the sorted order below the last one.
   lnum = eap->line2;
   for (i = 0; i < count; ++i) {
-    s = ml_get(nrs[eap->forceit ? count - i - 1 : i].lnum);
+    const linenr_T get_lnum = nrs[eap->forceit ? count - i - 1 : i].lnum;
+
+    // If the original line number of the line being placed is not the same
+    // as "lnum" (accounting for offset), we know that the buffer changed.
+    if (get_lnum + ((linenr_T)count - 1) != lnum) {
+      change_occurred = true;
+    }
+
+    s = ml_get(get_lnum);
     if (!unique || i == 0
         || (sort_ic ? STRICMP(s, sortbuf1) : STRCMP(s, sortbuf1)) != 0) {
       // Copy the line into a buffer, it may become invalid in
@@ -617,7 +626,9 @@ void ex_sort(exarg_T *eap)
   } else if (deleted < 0) {
     mark_adjust(eap->line2, MAXLNUM, -deleted, 0L, false);
   }
-  changed_lines(eap->line1, 0, eap->line2 + 1, -deleted, true);
+  if (change_occurred || deleted != 0) {
+    changed_lines(eap->line1, 0, eap->line2 + 1, -deleted, true);
+  }
 
   curwin->w_cursor.lnum = eap->line1;
   beginline(BL_WHITE | BL_FIX);

--- a/src/nvim/testdir/test_sort.vim
+++ b/src/nvim/testdir/test_sort.vim
@@ -1,13 +1,13 @@
-" Test sort()
+" Tests for the "sort()" function and for the ":sort" command.
 
-:func Compare1(a, b) abort
+func Compare1(a, b) abort
     call sort(range(3), 'Compare2')
     return a:a - a:b
-:endfunc
+endfunc
 
-:func Compare2(a, b) abort
+func Compare2(a, b) abort
     return a:a - a:b
-:endfunc
+endfunc
 
 func Test_sort_strings()
   " numbers compared as strings
@@ -45,7 +45,7 @@ func Test_sort_default()
   call assert_fails('call sort([3.3, 1, "2"], 3)', "E474")
 endfunc
 
-" Tests for the :sort command
+" Tests for the ":sort" command.
 func Test_sort_cmd()
   let tests = [
 	\ {
@@ -1167,15 +1167,54 @@ func Test_sort_cmd()
 	\	'1.234',
 	\	'123.456'
 	\    ]
-	\ }
+	\ },
+	\ {
+	\    'name' : 'alphabetical, sorted input',
+	\    'cmd' : 'sort',
+	\    'input' : [
+	\	'a',
+	\	'b',
+	\	'c',
+	\    ],
+	\    'expected' : [
+	\	'a',
+	\	'b',
+	\	'c',
+	\    ]
+	\ },
+	\ {
+	\    'name' : 'alphabetical, sorted input, unique at end',
+	\    'cmd' : 'sort u',
+	\    'input' : [
+	\	'aa',
+	\	'bb',
+	\	'cc',
+	\	'cc',
+	\    ],
+	\    'expected' : [
+	\	'aa',
+	\	'bb',
+	\	'cc',
+	\    ]
+	\ },
 	\ ]
 
   for t in tests
     enew!
     call append(0, t.input)
     $delete _
-    exe t.cmd
+    setlocal nomodified
+    execute t.cmd
+
     call assert_equal(t.expected, getline(1, '$'), t.name)
+
+    " Previously, the ":sort" command would set 'modified' even if the buffer
+    " contents did not change.  Here, we check that this problem is fixed.
+    if t.input == t.expected
+      call assert_false(&modified, t.name . ': &mod is not correct')
+    else
+      call assert_true(&modified, t.name . ': &mod is not correct')
+    endif
   endfor
 
   call assert_fails('sort no', 'E474')


### PR DESCRIPTION
**vim-patch:8.1.0120: buffer 'modified' set even when :sort has no changes**

Problem:    Buffer 'modified' set even when :sort has no changes.
Solution:   Only set 'modified' when lines are moved. (Jason Franklin)
vim/vim@dc9e955