### PR TITLE
test: check_cores(): Fix tmp dir exclusion

### DIFF
--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -1,6 +1,7 @@
 local assert = require('luassert')
 local luv = require('luv')
 local lfs = require('lfs')
+local relpath = require('pl.path').relpath
 
 local quote_me = '[^.%w%+%-%@%_%/]' -- complement (needn't quote)
 local function shell_quote(str)
@@ -244,7 +245,7 @@ local function check_cores(app, force)
   -- Workspace-local $TMPDIR, scrubbed and pattern-escaped.
   -- "./Xtest-tmpdir/" => "Xtest%-tmpdir"
   local local_tmpdir = (tmpdir_is_local(tmpdir_get())
-    and tmpdir_get():gsub('^[ ./]+',''):gsub('%/+$',''):gsub('([^%w])', '%%%1')
+    and relpath(tmpdir_get()):gsub('^[ ./]+',''):gsub('%/+$',''):gsub('([^%w])', '%%%1')
     or nil)
   local db_cmd
   if hasenv('NVIM_TEST_CORE_GLOB_DIRECTORY') then


### PR DESCRIPTION
tmpdir_get() may be an absolute path, but we invoke glob() with
a relative `initial_path`.

That can lead to this error:

    [  ERROR   ] test/functional/helpers.lua @ 752: after_each
    test/helpers.lua:95: cannot open ./Xtest-tmpdir/nvim8jKCjR: No such file or directory
    stack traceback:
            test/helpers.lua:95: in function 'glob'
            test/helpers.lua:273: in function 'check_cores'
            test/functional/helpers.lua:757: in function <test/functional/helpers.lua:752>