### PR TITLE
vim-patch:8.1.0416

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -623,6 +623,7 @@ void ex_sort(exarg_T *eap)
   if (deleted > 0) {
     mark_adjust(eap->line2 - deleted, eap->line2, (long)MAXLNUM, -deleted,
                 false);
+    msgmore(-deleted);
   } else if (deleted < 0) {
     mark_adjust(eap->line2, MAXLNUM, -deleted, 0L, false);
   }

--- a/src/nvim/testdir/test_sort.vim
+++ b/src/nvim/testdir/test_sort.vim
@@ -1221,3 +1221,33 @@ func Test_sort_cmd()
 
   enew!
 endfunc
+
+func Test_sort_cmd_report()
+    enew!
+    call append(0, repeat([1], 3) + repeat([2], 3) + repeat([3], 3))
+    $delete _
+    setlocal nomodified
+    let res = execute('%sort u')
+
+    call assert_equal([1,2,3], map(getline(1, '$'), 'v:val+0'))
+    call assert_match("6 fewer lines", res)
+    enew!
+    call append(0, repeat([1], 3) + repeat([2], 3) + repeat([3], 3))
+    $delete _
+    setlocal nomodified report=10
+    let res = execute('%sort u')
+
+    call assert_equal([1,2,3], map(getline(1, '$'), 'v:val+0'))
+    call assert_equal("", res)
+    enew!
+    call append(0, repeat([1], 3) + repeat([2], 3) + repeat([3], 3))
+    $delete _
+    setl report&vim
+    setlocal nomodified
+    let res = execute('1g/^/%sort u')
+
+    call assert_equal([1,2,3], map(getline(1, '$'), 'v:val+0'))
+    " the output comes from the :g command, not from the :sort
+    call assert_match("6 fewer lines", res)
+    enew!
+  endfunc


### PR DESCRIPTION
**vim-patch:8.1.0416: sort doesn't report deleted lines**

Problem:    Sort doesn't report deleted lines.
Solution:   Call msgmore(). (Christian Brabandt, closes vim/vim#3454)
https://github.com/vim/vim/commit/b0e982bf05feb27eddb5f809b052c1137f4d4add