### PR TITLE
vim-patch:8.0.1485,8.1.{66,67,68}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4535,7 +4535,7 @@ do_arg_all (
 
   for (i = 0; i < count && i < opened_len && !got_int; ++i) {
     if (alist == &global_alist && i == global_alist.al_ga.ga_len - 1)
-      arg_had_last = TRUE;
+      arg_had_last = true;
     if (opened[i] > 0) {
       /* Move the already present window to below the current window */
       if (curwin->w_arg_idx != i) {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4533,9 +4533,10 @@ do_arg_all (
     use_firstwin = true;
   }
 
-  for (i = 0; i < count && i < opened_len && !got_int; ++i) {
-    if (alist == &global_alist && i == global_alist.al_ga.ga_len - 1)
+  for (i = 0; i < count && i < opened_len && !got_int; i++) {
+    if (alist == &global_alist && i == global_alist.al_ga.ga_len - 1) {
       arg_had_last = true;
+    }
     if (opened[i] > 0) {
       /* Move the already present window to below the current window */
       if (curwin->w_arg_idx != i) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14664,12 +14664,16 @@ static void set_qf_ll_list(win_T *wp, typval_T *args, typval_T *rettv)
   static char *e_invact = N_("E927: Invalid action: '%s'");
   const char *title = NULL;
   int action = ' ';
+  static int recursive = 0;
   rettv->vval.v_number = -1;
   dict_T *d = NULL;
 
   typval_T *list_arg = &args[0];
   if (list_arg->v_type != VAR_LIST) {
     EMSG(_(e_listreq));
+    return;
+  } else if (recursive != 0) {
+    EMSG(_(e_au_recursive));
     return;
   }
 
@@ -14712,10 +14716,12 @@ skip_args:
     title = (wp ? "setloclist()" : "setqflist()");
   }
 
+  recursive++;
   list_T *const l = list_arg->vval.v_list;
   if (set_errorlist(wp, l, action, (char_u *)title, d) == OK) {
     rettv->vval.v_number = 0;
   }
+  recursive--;
 }
 
 /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6567,9 +6567,9 @@ void alist_set(alist_T *al, int count, char_u **files, int use_curbuf, int *fnum
     xfree(files);
   }
 
-  if (al == &global_alist)
+  if (al == &global_alist) {
     arg_had_last = false;
-
+  }
   recursive--;
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6568,7 +6568,7 @@ void alist_set(alist_T *al, int count, char_u **files, int use_curbuf, int *fnum
   }
 
   if (al == &global_alist)
-    arg_had_last = FALSE;
+    arg_had_last = false;
 
   recursive--;
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6536,6 +6536,13 @@ void alist_expand(int *fnum_list, int fnum_len)
 void alist_set(alist_T *al, int count, char_u **files, int use_curbuf, int *fnum_list, int fnum_len)
 {
   int i;
+  static int recursive = 0;
+
+  if (recursive) {
+    EMSG(_(e_au_recursive));
+    return;
+  }
+  recursive++;
 
   alist_clear(al);
   ga_grow(&al->al_ga, count);
@@ -6562,6 +6569,8 @@ void alist_set(alist_T *al, int count, char_u **files, int use_curbuf, int *fnum
 
   if (al == &global_alist)
     arg_had_last = FALSE;
+
+  recursive--;
 }
 
 /*

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -528,8 +528,8 @@ EXTERN buf_T    *curbuf INIT(= NULL);    // currently active buffer
  */
 EXTERN alist_T global_alist;    /* global argument list */
 EXTERN int max_alist_id INIT(= 0);     ///< the previous argument list id
-EXTERN bool arg_had_last INIT(= false);      /* accessed last file in
-                                               global_alist */
+EXTERN bool arg_had_last INIT(= false);     // accessed last file in
+                                            // global_alist
 
 EXTERN int ru_col;              /* column for ruler */
 EXTERN int ru_wid;              /* 'rulerfmt' width of ruler when non-zero */

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1099,6 +1099,8 @@ EXTERN char_u e_notset[] INIT(= N_("E764: Option '%s' is not set"));
 EXTERN char_u e_invalidreg[] INIT(= N_("E850: Invalid register name"));
 EXTERN char_u e_dirnotf[] INIT(= N_(
     "E919: Directory not found in '%s': \"%s\""));
+EXTERN char_u e_au_recursive[] INIT(= N_(
+    "E952: Autocommand caused recursive behavior"));
 EXTERN char_u e_unsupportedoption[] INIT(= N_("E519: Option not supported"));
 EXTERN char_u e_fnametoolong[] INIT(= N_("E856: Filename too long"));
 EXTERN char_u e_float_as_string[] INIT(= N_("E806: using Float as a String"));

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -528,7 +528,7 @@ EXTERN buf_T    *curbuf INIT(= NULL);    // currently active buffer
  */
 EXTERN alist_T global_alist;    /* global argument list */
 EXTERN int max_alist_id INIT(= 0);     ///< the previous argument list id
-EXTERN int arg_had_last INIT(= FALSE);      /* accessed last file in
+EXTERN bool arg_had_last INIT(= false);      /* accessed last file in
                                                global_alist */
 
 EXTERN int ru_col;              /* column for ruler */

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1625,7 +1625,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
         advance = false;
       }
       if (arg_idx == GARGCOUNT - 1)
-        arg_had_last = TRUE;
+        arg_had_last = true;
       ++arg_idx;
     }
     os_breakcheck();

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1624,9 +1624,10 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
         win_close(curwin, true);
         advance = false;
       }
-      if (arg_idx == GARGCOUNT - 1)
+      if (arg_idx == GARGCOUNT - 1) {
         arg_had_last = true;
-      ++arg_idx;
+      }
+      arg_idx++;
     }
     os_breakcheck();
     if (got_int) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3237,20 +3237,28 @@ did_set_string_option (
      */
     /* When 'syntax' is set, load the syntax of that name */
     if (varp == &(curbuf->b_p_syn)) {
-      // Only pass true for "force" when the value changed, to avoid
-      // endless recurrence.
-      apply_autocmds(EVENT_SYNTAX, curbuf->b_p_syn,
-                     curbuf->b_fname, value_changed, curbuf);
+      static int syn_recursive = 0;
+
+      syn_recursive++;
+      // Only pass true for "force" when the value changed or not used
+      // recursively, to avoid endless recurrence.
+      apply_autocmds(EVENT_SYNTAX, curbuf->b_p_syn, curbuf->b_fname,
+                     value_changed || syn_recursive == 1, curbuf);
+      syn_recursive--;
     } else if (varp == &(curbuf->b_p_ft)) {
       // 'filetype' is set, trigger the FileType autocommand
       // Skip this when called from a modeline and the filetype was
       // already set to this value.
-      // Only pass true for "force" when the value changed, to avoid
-      // endless recurrence.
       if (!(opt_flags & OPT_MODELINE) || value_changed) {
+        static int ft_recursive = 0;
+
+        ft_recursive++;
         did_filetype = true;
-        apply_autocmds(EVENT_FILETYPE, curbuf->b_p_ft,
-                       curbuf->b_fname, value_changed, curbuf);
+        // Only pass true for "force" when the value changed or not
+        // used recursively, to avoid endless recurrence.
+        apply_autocmds(EVENT_FILETYPE, curbuf->b_p_ft, curbuf->b_fname,
+                       value_changed || ft_recursive == 1, curbuf);
+        ft_recursive--;
         // Just in case the old "curbuf" is now invalid
         if (varp != &(curbuf->b_p_ft)) {
           varp = NULL;


### PR DESCRIPTION
**vim-patch:8.0.1485: weird autocmd may cause arglist to be changed recursively**

Problem:    Weird autocmd may cause arglist to be changed recursively.
Solution:   Prevent recursively changing the argument list. (Christian
            Brabandt, closes vim/vim#2472)
vim/vim@9e33efd

**vim-patch:8.1.0066: nasty autocommand causes using freed memory**

Problem:    Nasty autocommand causes using freed memory. (Dominique Pelle)
Solution:   Do not force executing autocommands if the value of 'syntax' or
            'filetype' did not change.
vim/vim@c3ffc9b

**vim-patch:8.1.0067: syntax highlighting not working when re-entering a buffer**

Problem:    Syntax highlighting not working when re-entering a buffer.
Solution:   Do force executing autocommands when not called recursively.
vim/vim@a5616b0

**vim-patch:8.1.0068: nasty autocommands can still cause using freed memory**

Problem:    Nasty autocommands can still cause using freed memory.
Solution:   Disallow using setloclist() and setqflist() recursively.
vim/vim@2f82ca7