### PR TITLE
Remove wrong assert in dialog_changed

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1285,7 +1285,6 @@ void dialog_changed(buf_T *buf, bool checkall)
   int ret;
   exarg_T ea;
 
-  assert(buf->b_fname != NULL);
   dialog_msg(buff, _("Save changes to \"%s\"?"), buf->b_fname);
   if (checkall) {
     ret = vim_dialog_yesnoallcancel(VIM_QUESTION, NULL, buff, 1);


### PR DESCRIPTION
It fails with `nvim -u NONE -c 'set modified' -c 'confirm q'`.

Introduced in 3dffc842f (vim-patch:8.0.0983), but the Vim patch [1] does not
have this assertion.

NULL gets handled in `dialog_msg` [2].

1: https://github.com/vim/vim/commit/3f9a1ff141412e9e85f7dff47d02946cb9be9228
2: https://github.com/neovim/neovim/blob/c6d36b97bac0df86c1120af323db1b577dc90629/src/nvim/ex_docmd.c#L9704-L9705

/cc @janlazo