### PR TITLE
Fix value of charset in /.editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 insert_final_newline = true
-charset = utf_8
+charset = utf-8
 
 [{Makefile,**/Makefile,runtime/doc/*.txt}]
 indent_style = tab


### PR DESCRIPTION
According to
https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties the possible values of the charset property are "latin1", "utf-8", "utf-16be", "utf-16le", or "utf-8-bom" (case insensitive), not "utf_8".

It breaks https://github.com/sgur/vim-editorconfig/ for example.