### PR TITLE
minor: terminfo_start: use unibi_from_term directly

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -209,7 +209,7 @@ static void terminfo_start(UI *ui)
 
   // Set up unibilium/terminfo.
   const char *term = os_getenv("TERM");
-  data->ut = unibi_from_env();
+  data->ut = unibi_from_term(term);
   char *termname = NULL;
   if (!term || !data->ut) {
     data->ut = terminfo_from_builtin(term, &termname);


### PR DESCRIPTION
This avoids calling `getenv("TERM")` twice unnecessarily.
Ref: https://github.com/mauke/unibilium/blob/e3b16d6219ca1cb92d98b1d9cc416b49a3ac468e/uniutil.c#L203-L211