### PR TITLE
vim-patch.sh: use --ff with git-pull

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -93,7 +93,7 @@ get_vim_sources() {
       exit 1
     fi
     echo "Updating Vim sources: ${VIM_SOURCE_DIR}"
-    git pull &&
+    git pull --ff &&
       msg_ok "Updated Vim sources." ||
       msg_err "Could not update Vim sources; ignoring error."
   fi


### PR DESCRIPTION
I have `merge.ff = no` in my Git config to not use fast-forward merges
by default, but when updating the Vim sources it should not cause a
merge commit.

[ci skip]