### PR TITLE
clint.py: fix stdin handling on py3, add --stdin-filename

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -66,7 +66,7 @@ _USAGE = """
 Syntax: clint.py [--verbose=#] [--output=vs7] [--filter=-x,+y,...]
                  [--counting=total|toplevel|detailed] [--root=subdir]
                  [--linelength=digits] [--record-errors=file]
-                 [--suppress-errors=file]
+                 [--suppress-errors=file] [--stdin-filename=filename]
         <file> [file] ...
 
   The style guidelines this tries to follow are those in
@@ -168,6 +168,9 @@ Syntax: clint.py [--verbose=#] [--output=vs7] [--filter=-x,+y,...]
 
     suppress-errors=file
       Errors listed in the given file will not be reported.
+
+    stdin-filename=filename
+      Use specified filename when reading from stdin (file "-").
 """
 
 # We categorize each error message we print.  Here are the categories.
@@ -3461,6 +3464,8 @@ def ProcessFile(filename, vlevel, extra_check_functions=[]):
             if sys.version_info < (3, 0):
                 stdin = stdin.decode('utf8')
             lines = stdin.split('\n')
+            if _cpplint_state.stdin_filename is not None:
+                filename = _cpplint_state.stdin_filename
         else:
             lines = codecs.open(
                 filename, 'r', 'utf8', 'replace').read().split('\n')
@@ -3541,7 +3546,9 @@ def ParseArguments(args):
                                                      'linelength=',
                                                      'extensions=',
                                                      'record-errors=',
-                                                     'suppress-errors='])
+                                                     'suppress-errors=',
+                                                     'stdin-filename=',
+                                                     ])
     except getopt.GetoptError:
         PrintUsage('Invalid arguments.')
 
@@ -3551,6 +3558,7 @@ def ParseArguments(args):
     counting_style = ''
     record_errors_file = None
     suppress_errors_file = None
+    stdin_filename = None
 
     for (opt, val) in opts:
         if opt == '--help':
@@ -3587,6 +3595,8 @@ def ParseArguments(args):
             record_errors_file = val
         elif opt == '--suppress-errors':
             suppress_errors_file = val
+        elif opt == '--stdin-filename':
+            stdin_filename = val
 
     if not filenames:
         PrintUsage('No files were specified.')
@@ -3597,6 +3607,7 @@ def ParseArguments(args):
     _SetCountingStyle(counting_style)
     _SuppressErrorsFrom(suppress_errors_file)
     _RecordErrorsTo(record_errors_file)
+    _cpplint_state.stdin_filename = stdin_filename
 
     return filenames
 

--- a/src/clint.py
+++ b/src/clint.py
@@ -49,6 +49,7 @@ from __future__ import unicode_literals
 
 import codecs
 import copy
+import fileinput
 import getopt
 import math  # for log
 import os
@@ -3456,10 +3457,10 @@ def ProcessFile(filename, vlevel, extra_check_functions=[]):
         # is processed.
 
         if filename == '-':
-            lines = codecs.StreamReaderWriter(sys.stdin,
-                                              codecs.getreader('utf8'),
-                                              codecs.getwriter('utf8'),
-                                              'replace').read().split('\n')
+            stdin = sys.stdin.read()
+            if sys.version_info < (3, 0):
+                stdin = stdin.decode('utf8')
+            lines = stdin.split('\n')
         else:
             lines = codecs.open(
                 filename, 'r', 'utf8', 'replace').read().split('\n')


### PR DESCRIPTION
This allows the Neomake clint maker to properly handle modified buffers (https://github.com/neovim/nvimdev.nvim/pull/19).