### PR TITLE
CI/travis/macOS: fix missing pip3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,10 +69,10 @@ jobs:
       env: BUILD_32BIT=ON
     - os: osx
       compiler: clang
-      osx_image: xcode7.3  # macOS 10.11
+      osx_image: xcode9.4  # macOS 10.13
     - os: osx
       compiler: gcc
-      osx_image: xcode7.3  # macOS 10.11
+      osx_image: xcode9.4  # macOS 10.13
     - os: linux
       env: CI_TARGET=lint
     - stage: Flaky builds

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -9,6 +9,8 @@ fi
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   brew update
+  echo "Upgrade Python 3"
+  brew upgrade python
 fi
 
 echo 'python info:'
@@ -24,17 +26,15 @@ echo 'python info:'
 ) | sed 's/^/  /'
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
-  echo "Upgrade Python 3."
-  brew upgrade python
-  echo "Upgrade Python 3 pip."
+  echo "Upgrade Python 3 pip"
   pip3 -q install --user --upgrade pip
 else
-  echo "Upgrade Python 2 pip."
-  pip2.7 -q install --user --upgrade pip
-  echo "Upgrade Python 3 pip."
+  echo "Upgrade Python 2 pip"
+  python2.7 -m pip -q install --user --upgrade pip
+  echo "Upgrade Python 3 pip"
   # Allow failure. pyenv pip3 on travis is broken:
   # https://github.com/travis-ci/travis-ci/issues/8363
-  pip3 -q install --user --upgrade pip || true
+  python3 -m pip -q install --user --upgrade pip || true
 fi
 
 echo "Install node (LTS)"

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -8,9 +8,9 @@ if [[ "${CI_TARGET}" == lint ]]; then
 fi
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
-  brew update
+  >/dev/null brew update
   echo "Upgrade Python 3"
-  brew upgrade python
+  >/dev/null brew upgrade python
 fi
 
 echo 'python info:'

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -34,8 +34,10 @@ check_core_dumps() {
   local app="${1:-${BUILD_DIR}/bin/nvim}"
   if test "${TRAVIS_OS_NAME}" = osx ; then
     local cores="$(find /cores/ -type f -print)"
+    local _sudo='sudo'
   else
     local cores="$(find ./ -type f -name 'core.*' -print)"
+    local _sudo=
   fi
 
   if test -z "${cores}" ; then
@@ -45,7 +47,7 @@ check_core_dumps() {
   for core in $cores; do
     if test "$del" = "1" ; then
       print_core "$app" "$core" >&2
-      rm "$core"
+      "$_sudo" rm "$core"
     else
       print_core "$app" "$core"
     fi

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -18,14 +18,14 @@ fi
 echo "Install neovim module for Python 3."
 # Allow failure. pyenv pip3 on travis is broken:
 # https://github.com/travis-ci/travis-ci/issues/8363
-CC=cc pip3 -q install --user --upgrade neovim || true
+CC=cc python3 -m pip -q install --user --upgrade neovim || true
 
 if ! [ "${TRAVIS_OS_NAME}" = osx ] ; then
   # Update PATH for pip.
   export PATH="$(python2.7 -c 'import site; print(site.getuserbase())')/bin:$PATH"
   # Use default CC to avoid compilation problems when installing Python modules.
   echo "Install neovim module for Python 2."
-  CC=cc pip2.7 -q install --user --upgrade neovim
+  CC=cc python2.7 -m pip -q install --user --upgrade neovim
 
   echo "Install neovim RubyGem."
   gem install --no-document --version ">= 0.2.0" neovim

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -20,9 +20,9 @@ func Test_oneshot()
   let slept = WaitFor('g:val == 1')
   call assert_equal(1, g:val)
   if has('reltime')
-    call assert_inrange(40, 100, slept)
+    call assert_inrange(40, 120, slept)
   else
-    call assert_inrange(20, 100, slept)
+    call assert_inrange(20, 120, slept)
   endif
 endfunc
 
@@ -39,6 +39,7 @@ func Test_repeat_three()
 endfunc
 
 func Test_repeat_many()
+  call timer_stopall()
   let g:val = 0
   let timer = timer_start(50, 'MyHandler', {'repeat': -1})
   sleep 200m
@@ -89,6 +90,7 @@ func Test_info()
 endfunc
 
 func Test_stopall()
+  call timer_stopall()
   let id1 = timer_start(1000, 'MyHandler')
   let id2 = timer_start(2000, 'MyHandler')
   let info = timer_info()
@@ -161,6 +163,7 @@ func StopTimerAll(timer)
 endfunc
 
 func Test_stop_all_in_callback()
+  call timer_stopall()
   let g:timer1 = timer_start(10, 'StopTimerAll')
   let info = timer_info()
   call assert_equal(1, len(info))

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
-local ok, feed, eq, eval = helpers.ok, helpers.feed, helpers.eq, helpers.eval
+local feed, eq, eval = helpers.feed, helpers.eq, helpers.eval
 local source, nvim_async, run = helpers.source, helpers.nvim_async, helpers.run
 local clear, command, funcs = helpers.clear, helpers.command, helpers.funcs
 local curbufmeths = helpers.curbufmeths
@@ -72,7 +72,8 @@ describe('timers', function()
     run(nil, nil, nil, 300)
     feed("<cr>")
     local diff = eval("g:val") - count
-    ok(0 <= diff and diff <= 4)
+    assert(0 <= diff and diff <= 4,
+           'expected (0 <= diff <= 4), got: '..tostring(diff))
   end)
 
   it('are triggered in blocking getchar() call', function()
@@ -81,7 +82,7 @@ describe('timers', function()
     run(nil, nil, nil, 300)
     feed("c")
     local count = eval("g:val")
-    ok(count >= 4)
+    assert(count >= 4, 'expected count >= 4, got: '..tostring(count))
     eq(99, eval("g:c"))
   end)
 
@@ -142,9 +143,10 @@ describe('timers', function()
     local count = eval("g:val")
     run(nil, nil, nil, 300)
     local count2 = eval("g:val")
-    ok(4 <= count and count <= 7)
     -- when count is eval:ed after timer_stop this should be non-racy
     eq(count, count2)
+    assert(4 <= count and count <= 7,
+           'expected (4 <= count <= 7), got: '..tostring(count))
   end)
 
   it('can be stopped from the handler', function()


### PR DESCRIPTION
# Problem

Try to fix travis macOS build. `pip3` is no longer in `$PATH` for some reason.

# Conclusion

Using the macOS 10.11 image of Travis CI, homebrew no longer installs `pip3` when it installs python3. Did not find a ticket in the homebrew issue tracker. 

The problem goes away after bumping Travis image to `xcode9.2` /  `macOS 10.12`. homebrew installs `pip3` as expected.

With the macOS 10.12 images, `timer_spec.lua` and `test_timers.vim` now fail:

```
[ RUN      ] timers are triggered in blocking getchar() call: FAIL
.../build/neovim/neovim/test/functional/eval/timer_spec.lua:85: expected count >= 4, got: 3

...

From test_timers.vim:
function RunTheTest[35]..Test_stop_all_in_callback line 6: Expected 0 but got 1
function RunTheTest[35]..Test_stopall line 4: Expected 2 but got 3
function RunTheTest[35]..Test_repeat_many line 5: Expected range 2 - 4, but got 1
```