### PR TITLE
[RDY] vim-patch:8.1.{459,463,466}

### DIFF
--- a/src/nvim/getchar.h
+++ b/src/nvim/getchar.h
@@ -16,6 +16,13 @@ enum {
   REMAP_SKIP = -3,  ///< No remapping for first char.
 } RemapValues;
 
+// Argument for flush_buffers().
+typedef enum {
+  FLUSH_MINIMAL,
+  FLUSH_TYPEAHEAD,  // flush current typebuf contents
+  FLUSH_INPUT       // flush typebuf and inchar() input
+} flush_buffers_T;
+
 #define KEYLEN_PART_KEY -1      /* keylen value for incomplete key-code */
 #define KEYLEN_PART_MAP -2      /* keylen value for incomplete mapping */
 #define KEYLEN_REMOVED  9999    /* keylen value for removed sequence */

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -49,6 +49,7 @@
 #include "nvim/buffer.h"
 #include "nvim/cursor.h"
 #include "nvim/eval.h"
+#include "nvim/getchar.h"
 #include "nvim/fileio.h"
 #include "nvim/func_attr.h"
 #include "nvim/main.h"
@@ -3358,12 +3359,16 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname,
             choice = do_swapexists(buf, (char_u *) fname);
 
           if (choice == 0) {
-            /* Show info about the existing swap file. */
+            // Show info about the existing swap file.
             attention_message(buf, (char_u *) fname);
 
-            /* We don't want a 'q' typed at the more-prompt
-             * interrupt loading a file. */
+            // We don't want a 'q' typed at the more-prompt
+            // interrupt loading a file.
             got_int = FALSE;
+
+            // If vimrc has "simalt ~x" we don't want it to
+            // interfere with the prompt here.
+            flush_buffers(TRUE);
           }
 
           if (swap_exists_action != SEA_NONE && choice == 0) {

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3360,15 +3360,15 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname,
 
           if (choice == 0) {
             // Show info about the existing swap file.
-            attention_message(buf, (char_u *) fname);
+            attention_message(buf, (char_u *)fname);
 
             // We don't want a 'q' typed at the more-prompt
             // interrupt loading a file.
-            got_int = FALSE;
+            got_int = false;
 
             // If vimrc has "simalt ~x" we don't want it to
             // interfere with the prompt here.
-            flush_buffers(TRUE);
+            flush_buffers(FLUSH_TYPEAHEAD);
           }
 
           if (swap_exists_action != SEA_NONE && choice == 0) {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -552,7 +552,7 @@ int emsg(const char_u *s_)
     if (p_eb) {
       beep_flush();           // also includes flush_buffers()
     } else {
-      flush_buffers(false);   // flush internal buffers
+      flush_buffers(FLUSH_MINIMAL);  // flush internal buffers
     }
     did_emsg = true;          // flag for DoOneCmd()
   }

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2548,7 +2548,7 @@ void msgmore(long n)
 void beep_flush(void)
 {
   if (emsg_silent == 0) {
-    flush_buffers(false);
+    flush_buffers(FLUSH_MINIMAL);
     vim_beep(BO_ERROR);
   }
 }

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -873,7 +873,7 @@ func Test_Executable()
     call assert_equal(1, executable('win.ini'))
   elseif has('unix')
     call assert_equal(1, executable('cat'))
-    call assert_equal(0, executable('dog'))
+    call assert_equal(0, executable('nodogshere'))
   endif
 endfunc
 


### PR DESCRIPTION
**vim-patch:8.1.0459: Test_executable fails when there is a dog in the system**

Problem:    Test_executable fails when there is a dog in the system.
Solution:   Rename the dog. (Hirohito Higashi)
vim/vim@a05a0d3

**vim-patch:8.1.0463: "simalt ~x" in .vimrc blocks swap file prompt**

Problem:    "simalt ~x" in .vimrc blocks swap file prompt.
Solution:   Flush buffers before prompting. (Yasuhiro Matsumoto,
            closes vim/vim#3518, closes vim/vim#2192)
vim/vim@798184c

**vim-patch:8.1.0466: autocmd test fails**

Problem:    Autocmd test fails.
Solution:   Do call inchar() when flushing typeahead.
vim/vim@6a2633b