### PR TITLE
vim-patch:8.0.1779

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2159,9 +2159,17 @@ void op_insert(oparg_T *oap, long count1)
      * Subsequent calls to ml_get() flush the firstline data - take a
      * copy of the required string.
      */
-    firstline = ml_get(oap->start.lnum) + bd.textcol;
-    if (oap->op_type == OP_APPEND)
-      firstline += bd.textlen;
+    firstline = ml_get(oap->start.lnum);
+    const size_t len = STRLEN(firstline);
+    colnr_T add = bd.textcol;
+    if (oap->op_type == OP_APPEND) {
+      add += bd.textlen;
+    }
+    if ((size_t)add > len) {
+      firstline += len;  // short line, point to the NUL
+    } else {
+      firstline += add;
+    }
     ins_len = (long)STRLEN(firstline) - pre_textlen;
     if (pre_textlen >= 0 && ins_len > 0) {
       ins_text = vim_strnsave(firstline, (size_t)ins_len);

--- a/src/nvim/testdir/test_blockedit.vim
+++ b/src/nvim/testdir/test_blockedit.vim
@@ -16,5 +16,18 @@ func Test_blockinsert_indent()
   bwipe!
 endfunc
 
+func Test_blockinsert_delete()
+  new
+  let _bs = &bs
+  set bs=2
+  call setline(1, ['case Arg is ', '        when Name_Async,', '        when Name_Num_Gangs,', 'end if;'])
+  exe "norm! ggjVj\<c-v>$o$A\<bs>\<esc>"
+  "call feedkeys("Vj\<c-v>$o$A\<bs>\<esc>", 'ti')
+  call assert_equal(["case Arg is ", "        when Name_Async", "        when Name_Num_Gangs,", "end if;"],
+        \ getline(1,'$'))
+  " reset to sane state
+  let &bs = _bs
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:8.0.1779: deleting in a block selection causes problems**

Problem:    Deleting in a block selection causes problems.
Solution:   Check the length of the line before adding bd.textcol and
            bd.textlen. (Christian Brabandt, closes vim/vim#2825)
https://github.com/vim/vim/commit/35e802e713382d7e76232ad344af7dcd577e43de