### PR TITLE
vim-patch:8.1.0468

### DIFF
--- a/src/nvim/testdir/test_filter_cmd.vim
+++ b/src/nvim/testdir/test_filter_cmd.vim
@@ -74,3 +74,16 @@ func Test_filter_cmd_completion()
   call assert_equal('filter /pat/ print', s:complete_filter_cmd('filter /pat/ pri'))
   call assert_equal('filter #pat# print', s:complete_filter_cmd('filter #pat# pri'))
 endfunc
+
+func Test_filter_cmd_with_filter()
+  new
+  set shelltemp
+  %!echo "a|b"
+  let out = getline(1)
+  bw!
+  if has('win32')
+    let out = trim(out, '" ')
+  endif
+  call assert_equal('a|b', out)
+  set shelltemp&
+endfunction


### PR DESCRIPTION
**vim-patch:8.1.0468: MS-Windows: filter command with pipe character fails**

Problem:    MS-Windows: Filter command with pipe character fails. (Johannes
            Riecken)
Solution:   Find the pipe character outside of quotes. (Yasuhiro Matsumoto,
            closes vim/vim#1743, closes vim/vim#3523)
https://github.com/vim/vim/commit/0664089eccec1083dd04ef2255856fb34ce62f15