### PR TITLE
vim-patch:8.0.1777

### DIFF
--- a/runtime/colors/README.txt
+++ b/runtime/colors/README.txt
@@ -42,7 +42,16 @@ this autocmd might be useful:
 Replace "blue_sky" with the name of the colorscheme.
 
 In case you want to tweak a colorscheme after it was loaded, check out the
-ColorScheme autocmd event.
+ColorScheme autocommand event.
+
+To clean up just before loading another colorscheme, use the ColorSchemePre
+autocommand event.  For example:
+	let g:term_ansi_colors = ...
+	augroup MyColorscheme
+	  au!
+	  au ColorSchemePre * unlet g:term_ansi_colors
+	  au ColorSchemePre * au! MyColorscheme
+	augroup END
 
 To customize a colorscheme use another name, e.g.  "~/.vim/colors/mine.vim",
 and use `:runtime` to load the original colorscheme:

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -27,6 +27,7 @@ return {
     'CmdWinEnter',            -- after entering the cmdline window
     'CmdWinLeave',            -- before leaving the cmdline window
     'ColorScheme',            -- after loading a colorscheme
+    'ColorSchemePre',         -- before loading a colorscheme
     'CompleteDone',           -- after finishing insert complete
     'CursorHold',             -- cursor in same position for a while
     'CursorHoldI',            -- idem, in Insert mode

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -6779,7 +6779,9 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
    * invalid.
    */
   if (fname_io == NULL) {
-    if (event == EVENT_COLORSCHEME || event == EVENT_OPTIONSET) {
+    if (event == EVENT_COLORSCHEME
+        || event == EVENT_COLORSCHEMEPRE
+        || event == EVENT_OPTIONSET) {
       autocmd_fname = NULL;
     } else if (fname != NULL && !ends_excmd(*fname)) {
       autocmd_fname = fname;
@@ -6830,6 +6832,7 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
     sfname = vim_strsave(fname);
     // Don't try expanding the following events.
     if (event == EVENT_COLORSCHEME
+        || event == EVENT_COLORSCHEMEPRE
         || event == EVENT_DIRCHANGED
         || event == EVENT_FILETYPE
         || event == EVENT_FUNCUNDEFINED

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6326,6 +6326,7 @@ int load_colors(char_u *name)
   recursive = true;
   size_t buflen = STRLEN(name) + 12;
   buf = xmalloc(buflen);
+  apply_autocmds(EVENT_COLORSCHEMEPRE, name, curbuf->b_fname, false, curbuf);
   snprintf((char *)buf, buflen, "colors/%s.vim", name);
   retval = source_runtime(buf, DIP_START + DIP_OPT);
   xfree(buf);


### PR DESCRIPTION
**vim-patch:8.0.1777: cannot cleanup before loading another colorscheme**

Problem:    Cannot cleanup before loading another colorscheme.
Solution:   Add the ColorSchemePre autocommand event.
https://github.com/vim/vim/commit/60a68362aa73f4a6cb534688978f9dc2b16e60fe

I can't find any tests using `ColorSchemePre` event.