### PR TITLE
vim-patch:8.0.1766

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -8360,10 +8360,10 @@ static bool ins_tab(void)
 static bool ins_eol(int c)
 {
   if (echeck_abbr(c + ABBR_OFF)) {
-    return false;
+    return true;
   }
   if (stop_arrow() == FAIL) {
-    return true;
+    return false;
   }
   undisplay_dollar();
 

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -198,3 +198,19 @@ func Test_map_timeout()
   set timeoutlen&
   delfunc ExitInsert
 endfunc
+
+func Test_abbreviation_CR()
+  new
+  func Eatchar(pat)
+    let c = nr2char(getchar(0))
+    return (c =~ a:pat) ? '' : c
+  endfunc
+  iabbrev <buffer><silent> ~~7 <c-r>=repeat('~', 7)<CR><c-r>=Eatchar('\s')<cr>
+  call feedkeys("GA~~7 \<esc>", 'xt')
+  call assert_equal('~~~~~~~', getline('$'))
+  %d
+  call feedkeys("GA~~7\<cr>\<esc>", 'xt')
+  call assert_equal(['~~~~~~~', ''], getline(1,'$'))
+  delfunc Eatchar
+  bw!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1766: expanding abbreviation doesn't work**

Problem:    Expanding abbreviation doesn't work. (Tooth Pik)
Solution:   Return OK instead of FALSE and FAIL instead of TRUE. (Christian
            Brabandt)
https://github.com/vim/vim/commit/c3c3e698966fac86dee94799b70947defb85440d