### PR TITLE
vim-patch:8.0.1837

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3524,8 +3524,9 @@ static int ccheck_abbr(int c)
 {
   int spos = 0;
 
-  if (p_paste || no_abbr)           /* no abbreviations or in paste mode */
-    return FALSE;
+  if (p_paste || no_abbr) {         // no abbreviations or in paste mode
+    return false;
+  }
 
   // Do not consider '<,'> be part of the mapping, skip leading whitespace.
   // Actually accepts any mark.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3522,10 +3522,27 @@ void gotocmdline(int clr)
  */
 static int ccheck_abbr(int c)
 {
+  int spos = 0;
+
   if (p_paste || no_abbr)           /* no abbreviations or in paste mode */
     return FALSE;
 
-  return check_abbr(c, ccline.cmdbuff, ccline.cmdpos, 0);
+  // Do not consider '<,'> be part of the mapping, skip leading whitespace.
+  // Actually accepts any mark.
+  while (ascii_iswhite(ccline.cmdbuff[spos]) && spos < ccline.cmdlen) {
+    spos++;
+  }
+  if (ccline.cmdlen - spos > 5
+      && ccline.cmdbuff[spos] == '\''
+      && ccline.cmdbuff[spos + 2] == ','
+      && ccline.cmdbuff[spos + 3] == '\'') {
+    spos += 5;
+  } else {
+    // check abbreviation from the beginning of the commandline
+    spos = 0;
+  }
+
+  return check_abbr(c, ccline.cmdbuff, ccline.cmdpos, spos);
 }
 
 static int sort_func_compare(const void *s1, const void *s2)

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -198,3 +198,19 @@ func Test_map_timeout()
   set timeoutlen&
   delfunc ExitInsert
 endfunc
+
+func Test_cabbr_visual_mode()
+  cabbr s su
+  call feedkeys(":s \<c-B>\"\<CR>", 'itx')
+  call assert_equal('"su ', getreg(':'))
+  call feedkeys(":'<,'>s \<c-B>\"\<CR>", 'itx')
+  let expected = '"'. "'<,'>su "
+  call assert_equal(expected, getreg(':'))
+  call feedkeys(":  '<,'>s \<c-B>\"\<CR>", 'itx')
+  let expected = '"  '. "'<,'>su "
+  call assert_equal(expected, getreg(':'))
+  call feedkeys(":'a,'bs \<c-B>\"\<CR>", 'itx')
+  let expected = '"'. "'a,'bsu "
+  call assert_equal(expected, getreg(':'))
+  cunabbr s
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1837: one character cmdline abbreviation not triggered after '<,'>**

Problem:    One character cmdline abbreviation not triggered after '<,'>.
Solution:   Skip over the special range. (Christian Brabandt, closes vim/vim#2320)
vim/vim@5e3423d