### PR TITLE
vim-patch:7f2e9d7c9cdf

### DIFF
--- a/runtime/ftplugin/python.vim
+++ b/runtime/ftplugin/python.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Tom Picton <tom@tompicton.co.uk>
 " Previous Maintainer: James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	Fri, 20 October 2017
+" Last Change:	Thur, 09 November 2017
 " https://github.com/tpict/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif
@@ -29,8 +29,8 @@ let b:next_endtoplevel='\v%$\|\S.*\n+(def\|class)'
 let b:prev_endtoplevel='\v\S.*\n+(def\|class)'
 let b:next='\v%$\|^\s*(class\|def\|async def)>'
 let b:prev='\v^\s*(class\|def\|async def)>'
-let b:next_end='\v\S\n*(%$\|^\s*(class\|def\|async def)\|^\S)'
-let b:prev_end='\v\S\n*(^\s*(class\|def\|async def)\|^\S)'
+let b:next_end='\v\S\n*(%$\|^(\s*\n*)*(class\|def\|async def)\|^\S)'
+let b:prev_end='\v\S\n*(^(\s*\n*)*(class\|def\|async def)\|^\S)'
 
 execute "nnoremap <silent> <buffer> ]] :call <SID>Python_jump('n', '". b:next_toplevel."', 'W')<cr>"
 execute "nnoremap <silent> <buffer> [[ :call <SID>Python_jump('n', '". b:prev_toplevel."', 'Wb')<cr>"
@@ -43,8 +43,8 @@ execute "nnoremap <silent> <buffer> [M :call <SID>Python_jump('n', '". b:prev_en
 
 execute "onoremap <silent> <buffer> ]] :call <SID>Python_jump('o', '". b:next_toplevel."', 'W')<cr>"
 execute "onoremap <silent> <buffer> [[ :call <SID>Python_jump('o', '". b:prev_toplevel."', 'Wb')<cr>"
-execute "onoremap <silent> <buffer> ][ :call <SID>Python_jump('n', '". b:next_endtoplevel."', 'W', 0)<cr>"
-execute "onoremap <silent> <buffer> [] :call <SID>Python_jump('n', '". b:prev_endtoplevel."', 'Wb', 0)<cr>"
+execute "onoremap <silent> <buffer> ][ :call <SID>Python_jump('o', '". b:next_endtoplevel."', 'W', 0)<cr>"
+execute "onoremap <silent> <buffer> [] :call <SID>Python_jump('o', '". b:prev_endtoplevel."', 'Wb', 0)<cr>"
 execute "onoremap <silent> <buffer> ]m :call <SID>Python_jump('o', '". b:next."', 'W')<cr>"
 execute "onoremap <silent> <buffer> [m :call <SID>Python_jump('o', '". b:prev."', 'Wb')<cr>"
 execute "onoremap <silent> <buffer> ]M :call <SID>Python_jump('o', '". b:next_end."', 'W', 0)<cr>"
@@ -52,8 +52,8 @@ execute "onoremap <silent> <buffer> [M :call <SID>Python_jump('o', '". b:prev_en
 
 execute "xnoremap <silent> <buffer> ]] :call <SID>Python_jump('x', '". b:next_toplevel."', 'W')<cr>"
 execute "xnoremap <silent> <buffer> [[ :call <SID>Python_jump('x', '". b:prev_toplevel."', 'Wb')<cr>"
-execute "xnoremap <silent> <buffer> ][ :call <SID>Python_jump('n', '". b:next_endtoplevel."', 'W', 0)<cr>"
-execute "xnoremap <silent> <buffer> [] :call <SID>Python_jump('n', '". b:prev_endtoplevel."', 'Wb', 0)<cr>"
+execute "xnoremap <silent> <buffer> ][ :call <SID>Python_jump('x', '". b:next_endtoplevel."', 'W', 0)<cr>"
+execute "xnoremap <silent> <buffer> [] :call <SID>Python_jump('x', '". b:prev_endtoplevel."', 'Wb', 0)<cr>"
 execute "xnoremap <silent> <buffer> ]m :call <SID>Python_jump('x', '". b:next."', 'W')<cr>"
 execute "xnoremap <silent> <buffer> [m :call <SID>Python_jump('x', '". b:prev."', 'Wb')<cr>"
 execute "xnoremap <silent> <buffer> ]M :call <SID>Python_jump('x', '". b:next_end."', 'W', 0)<cr>"

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:	Vim
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Sep 07
+" Last Change:	2017 Nov 06
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -24,6 +24,9 @@ setlocal fo-=t fo+=croql
 " To allow tag lookup via CTRL-] for autoload functions, '#' must be a
 " keyword character.  E.g., for netrw#Nread().
 setlocal isk+=#
+
+" Use :help to lookup the keyword under the cursor with K.
+setlocal keywordprg=:help
 
 " Set 'comments' to format dashed lists in comments
 setlocal com=sO:\"\ -,mO:\"\ \ ,eO:\"\",:\"

--- a/runtime/syntax/debcontrol.vim
+++ b/runtime/syntax/debcontrol.vim
@@ -3,7 +3,7 @@
 " Maintainer:  Debian Vim Maintainers <pkg-vim-maintainers@lists.alioth.debian.org>
 " Former Maintainers: Gerfried Fuchs <alfie@ist.org>
 "                     Wichert Akkerman <wakkerma@debian.org>
-" Last Change: 2017 Aug 18
+" Last Change: 2017 Nov 04
 " URL: https://anonscm.debian.org/cgit/pkg-vim/vim.git/plain/runtime/syntax/debcontrol.vim
 
 " Standard syntax initialization
@@ -17,6 +17,8 @@ set cpo&vim
 " Should match case except for the keys of each field
 syn case match
 
+syn iskeyword @,48-57,-,/
+
 " Everything that is not explicitly matched by the rules below
 syn match debcontrolElse "^.*$"
 
@@ -24,24 +26,50 @@ syn match debcontrolElse "^.*$"
 syn match debControlComma ",[ \t]*"
 syn match debControlSpace "[ \t]"
 
-let s:kernels = '\%(linux\|hurd\|kfreebsd\|knetbsd\|kopensolaris\|netbsd\)'
-let s:archs = '\%(alpha\|amd64\|armeb\|armel\|armhf\|arm64\|avr32\|hppa\|i386'
-      \ . '\|ia64\|lpia\|m32r\|m68k\|mipsel\|mips64el\|mips\|powerpcspe\|powerpc\|ppc64el'
-      \ . '\|ppc64\|s390x\|s390\|sh3eb\|sh3\|sh4eb\|sh4\|sh\|sparc64\|sparc\|x32\)'
-let s:pairs = 'hurd-i386\|kfreebsd-i386\|kfreebsd-amd64\|knetbsd-i386\|kopensolaris-i386\|netbsd-alpha\|netbsd-i386'
+let s:kernels = ['linux', 'hurd', 'kfreebsd', 'knetbsd', 'kopensolaris', 'netbsd']
+let s:archs = [
+      \ 'alpha', 'amd64', 'armeb', 'armel', 'armhf', 'arm64', 'avr32', 'hppa'
+      \, 'i386', 'ia64', 'lpia', 'm32r', 'm68k', 'mipsel', 'mips64el', 'mips'
+      \, 'powerpcspe', 'powerpc', 'ppc64el', 'ppc64', 's390x', 's390', 'sh3eb'
+      \, 'sh3', 'sh4eb', 'sh4', 'sh', 'sparc64', 'sparc', 'x32'
+      \ ]
+let s:pairs = [
+      \ 'hurd-i386', 'kfreebsd-i386', 'kfreebsd-amd64', 'knetbsd-i386'
+      \, 'kopensolaris-i386', 'netbsd-alpha', 'netbsd-i386'
+      \ ]
 
 " Define some common expressions we can use later on
-exe 'syn match debcontrolArchitecture contained "\%(all\|'. s:kernels .'-any\|\%(any-\)\='. s:archs .'\|'. s:pairs .'\|any\)"'
+syn keyword debcontrolArchitecture contained all any
+exe 'syn keyword debcontrolArchitecture contained '. join(map(s:kernels, {k,v -> v .'-any'}))
+exe 'syn keyword debcontrolArchitecture contained '. join(map(s:archs, {k,v -> 'any-'.v}))
+exe 'syn keyword debcontrolArchitecture contained '. join(s:archs)
+exe 'syn keyword debcontrolArchitecture contained '. join(s:pairs)
 
 unlet s:kernels s:archs s:pairs
 
-syn match debcontrolMultiArch contained "\%(no\|foreign\|allowed\|same\)"
+let s:sections = [
+      \ 'admin', 'cli-mono', 'comm', 'database', 'debian-installer', 'debug'
+      \, 'devel', 'doc', 'editors', 'education', 'electronics', 'embedded'
+      \, 'fonts', 'games', 'gnome', 'gnustep', 'gnu-r', 'golang', 'graphics'
+      \, 'hamradio', 'haskell', 'httpd', 'interpreters', 'introspection'
+      \, 'java', 'javascript', 'kde', 'kernel', 'libs', 'libdevel', 'lisp'
+      \, 'localization', 'mail', 'math', 'metapackages', 'misc', 'net'
+      \, 'news', 'ocaml', 'oldlibs', 'otherosfs', 'perl', 'php', 'python'
+      \, 'ruby', 'rust', 'science', 'shells', 'sound', 'text', 'tex'
+      \, 'utils', 'vcs', 'video', 'web', 'x11', 'xfce', 'zope'
+      \ ]
+
+syn keyword debcontrolMultiArch contained no foreign allowed same
 syn match debcontrolName contained "[a-z0-9][a-z0-9+.-]\+"
-syn match debcontrolPriority contained "\(extra\|important\|optional\|required\|standard\)"
-syn match debcontrolSection contained "\v((contrib|non-free|non-US/main|non-US/contrib|non-US/non-free|restricted|universe|multiverse)/)?(admin|cli-mono|comm|database|debian-installer|debug|devel|doc|editors|education|electronics|embedded|fonts|games|gnome|gnustep|gnu-r|graphics|hamradio|haskell|httpd|interpreters|introspection|java%(script)=|kde|kernel|libs|libdevel|lisp|localization|mail|math|metapackages|misc|net|news|ocaml|oldlibs|otherosfs|perl|php|python|ruby|rust|science|shells|sound|text|tex|utils|vcs|video|web|x11|xfce|zope)"
-syn match debcontrolPackageType contained "u\?deb"
+syn keyword debcontrolPriority contained extra important optional required standard
+exe 'syn match debcontrolSection contained "\%(\%(contrib\|non-free\|non-US/main\|non-US/contrib\|non-US/non-free\|restricted\|universe\|multiverse\)/\)\=\%('.join(s:sections, '\|').'\)"'
+syn keyword debcontrolPackageType contained udeb deb
 syn match debcontrolVariable contained "\${.\{-}}"
-syn match debcontrolDmUpload contained "\cyes"
+syn keyword debcontrolDmUpload contained yes
+syn keyword debcontrolYesNo contained yes no
+syn match debcontrolR3 contained "\<\%(no\|binary-targets\|[[:graph:]]\+/[[:graph:]]\+\%( \+[[:graph:]]\+/[[:graph:]]\+\)*\)\>"
+
+unlet s:sections
 
 " A URL (using the domain name definitions from RFC 1034 and 1738), right now
 " only enforce protocol and some sanity on the server/path part;
@@ -59,15 +87,28 @@ syn match debcontrolComment "^#.*$" contains=@Spell
 
 syn case ignore
 
-" List of all legal keys
-syn match debcontrolKey contained "^\%(Source\|Package\|Section\|Priority\|\%(XSBC-Original-\)\=Maintainer\|Uploaders\|Build-\%(Conflicts\|Depends\)\%(-Arch\|-Indep\)\=\|Standards-Version\|\%(Pre-\)\=Depends\|Recommends\|Suggests\|Provides\|Replaces\|Conflicts\|Enhances\|Breaks\|Essential\|Architecture\|Multi-Arch\|Description\|Bugs\|Origin\|X[SB]-Python-Version\|Homepage\|\(XS-\)\=Vcs-\(Browser\|Arch\|Bzr\|Cvs\|Darcs\|Git\|Hg\|Mtn\|Svn\)\|\%(XC-\)\=Package-Type\|\%(XS-\)\=Testsuite\): *"
+" List of all legal keys, in order, from deb-src-control(5)
+" Source fields
+syn match debcontrolKey contained "^\%(Source\|Maintainer\|Uploaders\|Standards-Version\|Description\|Homepage\|Bugs\|Rules-Requires-Root\): *"
+syn match debcontrolKey contained "^\%(XS-\)\=Vcs-\%(Arch\|Bzr\|Cvs\|Darcs\|Git\|Hg\|Mtn\|Svn\|Browser\): *"
+syn match debcontrolKey contained "^\%(Origin\|Section\|Priority\): *"
+syn match debcontrolKey contained "^Build-\%(Depends\|Conflicts\)\%(-Arch\|-Indep\)\=: *"
+
+" Binary fields
+syn match debcontrolKey contained "^\%(Package\%(-Type\)\=\|Architecture\|Build-Profiles\): *"
+syn match debcontrolKey contained "^\%(\%(Build-\)\=Essential\|Multi-Arch\|Tag\): *"
+syn match debcontrolKey contained "^\%(\%(Pre-\)\=Depends\|Recommends\|Suggests\|Breaks\|Enhances\|Replaces\|Conflicts\|Provides\|Built-Using\): *"
+syn match debcontrolKey contained "^\%(Subarchitecture\|Kernel-Version\|Installer-Menu-Item\): *"
+
+" User-defined fields
+syn match debcontrolKey contained "^X[SBC]\{0,3\}\%(-Private\)\=-[-a-zA-Z0-9]\+: *"
 
 syn match debcontrolDeprecatedKey contained "^\%(\%(XS-\)\=DM-Upload-Allowed\): *"
 
 " Fields for which we do strict syntax checking
 syn region debcontrolStrictField start="^Architecture" end="$" contains=debcontrolKey,debcontrolArchitecture,debcontrolSpace oneline
 syn region debcontrolStrictField start="^Multi-Arch" end="$" contains=debcontrolKey,debcontrolMultiArch oneline
-syn region debcontrolStrictField start="^\(Package\|Source\)" end="$" contains=debcontrolKey,debcontrolName oneline
+syn region debcontrolStrictField start="^\%(Package\|Source\)" end="$" contains=debcontrolKey,debcontrolName oneline
 syn region debcontrolStrictField start="^Priority" end="$" contains=debcontrolKey,debcontrolPriority oneline
 syn region debcontrolStrictField start="^Section" end="$" contains=debcontrolKey,debcontrolSection oneline
 syn region debcontrolStrictField start="^\%(XC-\)\=Package-Type" end="$" contains=debcontrolKey,debcontrolPackageType oneline
@@ -77,10 +118,12 @@ syn region debcontrolStrictField start="^\%(XS-\)\=Vcs-Svn" end="$" contains=deb
 syn region debcontrolStrictField start="^\%(XS-\)\=Vcs-Cvs" end="$" contains=debcontrolKey,debcontrolVcsCvs oneline keepend
 syn region debcontrolStrictField start="^\%(XS-\)\=Vcs-Git" end="$" contains=debcontrolKey,debcontrolVcsGit oneline keepend
 syn region debcontrolStrictField start="^\%(XS-\)\=DM-Upload-Allowed" end="$" contains=debcontrolDeprecatedKey,debcontrolDmUpload oneline
+syn region debcontrolStrictField start="^Rules-Requires-Root" end="$" contains=debcontrolKey,debcontrolR3 oneline
+syn region debcontrolStrictField start="^\%(Build-\)\=Essential" end="$" contains=debcontrolKey,debcontrolYesNo oneline
 
 " Catch-all for the other legal fields
-syn region debcontrolField start="^\%(\%(XSBC-Original-\)\=Maintainer\|Standards-Version\|Essential\|Bugs\|Origin\|X[SB]-Python-Version\|\%(XS-\)\=Vcs-Mtn\|\%(XS-\)\=Testsuite\):" end="$" contains=debcontrolKey,debcontrolVariable,debcontrolEmail oneline
-syn region debcontrolMultiField start="^\%(Build-\%(Conflicts\|Depends\)\%(-Arch\|-Indep\)\=\|\%(Pre-\)\=Depends\|Recommends\|Suggests\|Provides\|Replaces\|Conflicts\|Enhances\|Breaks\|Uploaders\|Description\):" skip="^[ \t]" end="^$"me=s-1 end="^[^ \t#]"me=s-1 contains=debcontrolKey,debcontrolEmail,debcontrolVariable,debcontrolComment
+syn region debcontrolField start="^\%(\%(XSBC-Original-\)\=Maintainer\|Standards-Version\|Bugs\|Origin\|X[SB]-Python-Version\|\%(XS-\)\=Vcs-Mtn\|\%(XS-\)\=Testsuite\|Build-Profiles\|Tag\|Subarchitecture\|Kernel-Version\|Installer-Menu-Item\):" end="$" contains=debcontrolKey,debcontrolVariable,debcontrolEmail oneline
+syn region debcontrolMultiField start="^\%(Build-\%(Conflicts\|Depends\)\%(-Arch\|-Indep\)\=\|\%(Pre-\)\=Depends\|Recommends\|Suggests\|Breaks\|Enhances\|Replaces\|Conflicts\|Provides\|Built-Using\|Uploaders\|X[SBC]\{0,3\}\%(Private-\)\=-[-a-zA-Z0-9]\+\):" skip="^[ \t]" end="^$"me=s-1 end="^[^ \t#]"me=s-1 contains=debcontrolKey,debcontrolEmail,debcontrolVariable,debcontrolComment
 syn region debcontrolMultiFieldSpell start="^\%(Description\):" skip="^[ \t]" end="^$"me=s-1 end="^[^ \t#]"me=s-1 contains=debcontrolKey,debcontrolEmail,debcontrolVariable,debcontrolComment,@Spell
 
 " Associate our matches and regions with pretty colours
@@ -102,6 +145,8 @@ hi def link debcontrolVcsCvs        Identifier
 hi def link debcontrolVcsGit        Identifier
 hi def link debcontrolHTTPUrl       Identifier
 hi def link debcontrolDmUpload      Identifier
+hi def link debcontrolYesNo         Identifier
+hi def link debcontrolR3            Identifier
 hi def link debcontrolComment       Comment
 hi def link debcontrolElse          Special
 

--- a/runtime/syntax/debsources.vim
+++ b/runtime/syntax/debsources.vim
@@ -2,7 +2,7 @@
 " Language:     Debian sources.list
 " Maintainer:   Debian Vim Maintainers <pkg-vim-maintainers@lists.alioth.debian.org>
 " Former Maintainer: Matthijs Mohlmann <matthijs@cacholong.nl>
-" Last Change: 2017 Apr 22
+" Last Change: 2017 Oct 28
 " URL: https://anonscm.debian.org/cgit/pkg-vim/vim.git/plain/runtime/syntax/debsources.vim
 
 " Standard syntax initialization
@@ -23,18 +23,18 @@ let s:cpo = &cpo
 set cpo-=C
 let s:supported = [
       \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental',
-      \ 'squeeze', 'wheezy', 'jessie', 'stretch', 'sid', 'rc-buggy',
+      \ 'wheezy', 'jessie', 'stretch', 'sid', 'rc-buggy',
       \
-      \ 'trusty', 'xenial', 'yakkety', 'zesty', 'artful', 'devel'
+      \ 'trusty', 'xenial', 'zesty', 'artful', 'bionic', 'devel'
       \ ]
 let s:unsupported = [
       \ 'buzz', 'rex', 'bo', 'hamm', 'slink', 'potato',
-      \ 'woody', 'sarge', 'etch', 'lenny',
+      \ 'woody', 'sarge', 'etch', 'lenny', 'squeeze',
       \
       \ 'warty', 'hoary', 'breezy', 'dapper', 'edgy', 'feisty',
       \ 'gutsy', 'hardy', 'intrepid', 'jaunty', 'karmic', 'lucid',
       \ 'maverick', 'natty', 'oneiric', 'precise', 'quantal', 'raring', 'saucy',
-      \ 'utopic', 'vivid', 'wily'
+      \ 'utopic', 'vivid', 'wily', 'yakkety'
       \ ]
 let &cpo=s:cpo
 

--- a/runtime/syntax/fstab.vim
+++ b/runtime/syntax/fstab.vim
@@ -2,8 +2,8 @@
 " Language: fstab file
 " Maintainer: Radu Dineiu <radu.dineiu@gmail.com>
 " URL: https://raw.github.com/rid9/vim-fstab/master/fstab.vim
-" Last Change: 2013 May 21
-" Version: 1.0
+" Last Change: 2017 Nov 09
+" Version: 1.2
 "
 " Credits:
 "   David Necas (Yeti) <yeti@physics.muni.cz>
@@ -38,10 +38,14 @@ syn match fsDeviceError /\%([^a-zA-Z0-9_\/#@:\.-]\|^\w\{-}\ze\W\)/ contained
 syn keyword fsDeviceKeyword contained none proc linproc tmpfs devpts devtmpfs sysfs usbfs
 syn keyword fsDeviceKeyword contained LABEL nextgroup=fsDeviceLabel
 syn keyword fsDeviceKeyword contained UUID nextgroup=fsDeviceUUID
+syn keyword fsDeviceKeyword contained PARTLABEL nextgroup=fsDevicePARTLABEL
+syn keyword fsDeviceKeyword contained PARTUUID nextgroup=fsDevicePARTUUID
 syn keyword fsDeviceKeyword contained sshfs nextgroup=fsDeviceSshfs
 syn match fsDeviceKeyword contained /^[a-zA-Z0-9.\-]\+\ze:/
 syn match fsDeviceLabel contained /=[^ \t]\+/hs=s+1 contains=fsOperator
 syn match fsDeviceUUID contained /=[^ \t]\+/hs=s+1 contains=fsOperator
+syn match fsDevicePARTLABEL contained /=[^ \t]\+/hs=s+1 contains=fsOperator
+syn match fsDevicePARTUUID contained /=[^ \t]\+/hs=s+1 contains=fsOperator
 syn match fsDeviceSshfs contained /#[_=[:alnum:]\.\/+-]\+@[a-z0-9._-]\+\a\{2}:[^ \t]\+/hs=s+1 contains=fsOperator
 
 " Mount Point
@@ -64,7 +68,7 @@ syn match fsOptionsString /[a-zA-Z0-9_-]\+/
 syn keyword fsOptionsYesNo yes no
 syn cluster fsOptionsCheckCluster contains=fsOptionsExt2Check,fsOptionsFatCheck
 syn keyword fsOptionsSize 512 1024 2048
-syn keyword fsOptionsGeneral async atime auto bind current defaults dev devgid devmode devmtime devuid dirsync exec force fstab kudzu loop mand move noatime noauto noclusterr noclusterw nodev nodevmtime nodiratime noexec nomand nosuid nosymfollow nouser owner rbind rdonly remount ro rq rw suid suiddir supermount sw sync union update user users xx
+syn keyword fsOptionsGeneral async atime auto bind current defaults dev devgid devmode devmtime devuid dirsync exec force fstab kudzu loop mand move noatime noauto noclusterr noclusterw nodev nodevmtime nodiratime noexec nomand norelatime nosuid nosymfollow nouser owner rbind rdonly relatime remount ro rq rw suid suiddir supermount sw sync union update user users wxallowed xx
 syn match fsOptionsGeneral /_netdev/
 
 " Options: adfs
@@ -137,7 +141,7 @@ syn match fsOptionsKeywords contained /\<\%(dir\|file\|\)_umask=/ nextgroup=fsOp
 syn match fsOptionsKeywords contained /\<\%(session\|part\)=/ nextgroup=fsOptionsNumber
 
 " Options: ffs
-syn keyword fsOptionsKeyWords contained softdep
+syn keyword fsOptionsKeyWords contained noperm softdep
 
 " Options: hpfs
 syn match fsOptionsKeywords contained /\<case=/ nextgroup=fsOptionsHpfsCase
@@ -228,7 +232,6 @@ syn match fsFreqPass /\s\+.\{-}$/ contains=@fsFreqPassCluster,@fsGeneralCluster 
 " Whole line comments
 syn match fsCommentLine /^#.*$/ contains=@Spell
 
-
 hi def link fsOperator Operator
 hi def link fsComment Comment
 hi def link fsCommentLine Comment
@@ -237,15 +240,17 @@ hi def link fsTypeKeyword Type
 hi def link fsDeviceKeyword Identifier
 hi def link fsDeviceLabel String
 hi def link fsDeviceUUID String
+hi def link fsDevicePARTLABEL String
+hi def link fsDevicePARTUUID String
 hi def link fsDeviceSshfs String
 hi def link fsFreqPassNumber Number
 
 if exists('fstab_unknown_fs_errors') && fstab_unknown_fs_errors == 1
-hi def link fsTypeUnknown Error
+	hi def link fsTypeUnknown Error
 endif
 
 if !exists('fstab_unknown_device_errors') || fstab_unknown_device_errors == 1
-hi def link fsDeviceError Error
+	hi def link fsDeviceError Error
 endif
 
 hi def link fsMountPointError Error
@@ -277,7 +282,6 @@ hi def link fsOptionsUfsType String
 hi def link fsOptionsUfsError String
 
 hi def link fsOptionsVfatShortname String
-
 
 let b:current_syntax = "fstab"
 


### PR DESCRIPTION
Update runtime files.
https://github.com/vim/vim/commit/7f2e9d7c9cdfc5201a899b7b610edf64bf80c45f

Unapplied changes:
- runtime/doc/*: All either irrelevant or already applied
- runtime/ftplugin/man.vim, runtime/plugin/manpager.vim: Neovim has its own implementation
- termdebug: This needs its own porting effort
- runtime/syntax/tex.vim: Already applied