### PR TITLE
vim-patch:8.0.1489

### DIFF
--- a/src/nvim/testdir/test_getcwd.vim
+++ b/src/nvim/testdir/test_getcwd.vim
@@ -37,6 +37,7 @@ function SetUp()
 	new
 	call mkdir('Xtopdir')
 	cd Xtopdir
+	let g:topdir = getcwd()
 	call mkdir('Xdir1')
 	call mkdir('Xdir2')
 	call mkdir('Xdir3')
@@ -56,38 +57,46 @@ function Test_GetCwd()
 	3wincmd w
 	lcd Xdir1
 	call assert_equal("a Xdir1 1", GetCwdInfo(0, 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	wincmd W
 	call assert_equal("b Xtopdir 0", GetCwdInfo(0, 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	wincmd W
 	lcd Xdir3
 	call assert_equal("c Xdir3 1", GetCwdInfo(0, 0))
 	call assert_equal("a Xdir1 1", GetCwdInfo(bufwinnr("a"), 0))
 	call assert_equal("b Xtopdir 0", GetCwdInfo(bufwinnr("b"), 0))
 	call assert_equal("c Xdir3 1", GetCwdInfo(bufwinnr("c"), 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	wincmd W
 	call assert_equal("a Xdir1 1", GetCwdInfo(bufwinnr("a"), tabpagenr()))
 	call assert_equal("b Xtopdir 0", GetCwdInfo(bufwinnr("b"), tabpagenr()))
 	call assert_equal("c Xdir3 1", GetCwdInfo(bufwinnr("c"), tabpagenr()))
+	call assert_equal(g:topdir, getcwd(-1))
 
 	tabnew x
 	new y
 	new z
 	3wincmd w
 	call assert_equal("x Xtopdir 0", GetCwdInfo(0, 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	wincmd W
 	lcd Xdir2
 	call assert_equal("y Xdir2 1", GetCwdInfo(0, 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	wincmd W
 	lcd Xdir3
 	call assert_equal("z Xdir3 1", GetCwdInfo(0, 0))
 	call assert_equal("x Xtopdir 0", GetCwdInfo(bufwinnr("x"), 0))
 	call assert_equal("y Xdir2 1", GetCwdInfo(bufwinnr("y"), 0))
 	call assert_equal("z Xdir3 1", GetCwdInfo(bufwinnr("z"), 0))
+	call assert_equal(g:topdir, getcwd(-1))
 	let tp_nr = tabpagenr()
 	tabrewind
 	call assert_equal("x Xtopdir 0", GetCwdInfo(3, tp_nr))
 	call assert_equal("y Xdir2 1", GetCwdInfo(2, tp_nr))
 	call assert_equal("z Xdir3 1", GetCwdInfo(1, tp_nr))
+	call assert_equal(g:topdir, getcwd(-1))
 endfunc
 
 function Test_GetCwd_lcd_shellslash()


### PR DESCRIPTION
**vim-patch:8.0.1489: there is no easy way to get the global directory**

Problem:    There is no easy way to get the global directory, esp. if some
            windows have a local directory.
Solution:   Make getcwd(-1) return the global directory. (Andy Massimino,
            closes vim/vim#2606)
https://github.com/vim/vim/commit/5459129af2a832a027a1e7ca2d6177c26647d64f

I included the test changes only because it passes on my machine and I don't know to apply the code and runtime changes.