### PR TITLE
API: make nvim_win_set_option() set the window value

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -394,7 +394,9 @@ void set_option_to(uint64_t channel_id, void *to, int type,
   current_SID = channel_id == LUA_INTERNAL_CALL ? SID_LUA : SID_API_CLIENT;
   current_channel_id = channel_id;
 
-  const int opt_flags = (type == SREQ_GLOBAL) ? OPT_GLOBAL : OPT_LOCAL;
+  const int opt_flags = (type == SREQ_WIN && !(flags & SOPT_GLOBAL))
+                        ? 0 : (type == SREQ_GLOBAL)
+                              ? OPT_GLOBAL : OPT_LOCAL;
   set_option_value_for(name.data, numval, stringval,
                        opt_flags, type, to, err);
 

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -212,10 +212,18 @@ describe('API/win', function()
     it('works', function()
       curwin('set_option', 'colorcolumn', '4,3')
       eq('4,3', curwin('get_option', 'colorcolumn'))
+      command("set modified hidden")
+      command("enew") -- edit new buffer, window option is preserved
+      eq('4,3', curwin('get_option', 'colorcolumn'))
+
       -- global-local option
       curwin('set_option', 'statusline', 'window-status')
       eq('window-status', curwin('get_option', 'statusline'))
       eq('', nvim('get_option', 'statusline'))
+      command("set modified")
+      command("enew") -- global-local: not preserved in new buffer
+      eq({false, "Failed to get value for option 'statusline'"}, meth_pcall(curwin, 'get_option', 'statusline'))
+      eq('', eval('&l:statusline')) -- confirm local value was not copied
     end)
   end)
 

--- a/test/functional/eval/buf_functions_spec.lua
+++ b/test/functional/eval/buf_functions_spec.lua
@@ -228,9 +228,9 @@ describe('getbufvar() function', function()
     eq(0, funcs.getbufvar(1, '&g:number'))
     command('new')
     -- But with window-local options it probably does not what you expect
-    curwinmeths.set_option('number', true)
+    command("setl number")
     -- (note that current window’s buffer is 2, but getbufvar() receives 1)
-    eq(2, bufmeths.get_number(curwinmeths.get_buf()))
+    eq({id=2}, curwinmeths.get_buf())
     eq(1, funcs.getbufvar(1, '&number'))
     eq(1, funcs.getbufvar(1, '&l:number'))
     -- You can get global value though, if you find this useful.


### PR DESCRIPTION
Compare these two behaviors:
```
e file1
set winhl=Normal:ErrorMsg
e file2
```
and
```
e file1
setlocal winhl=Normal:ErrorMsg
e file2
```
In the former case the option is set for the window, and used for both files, but in the later case, the option is reset when switich buffer (buffer-local value).

`nvim_win_set_option(0, 'winhl', 'Normal:ErrorMsg')` should arguably work like the former and set the option for the entire window. We could also allow `nvim_buf_set_option(0, 'winhl', 'Normal:ErrorMsg')`. If the buffer is shown in a window this would work like `setl` in that window. If it is currently not shown in a window, it will set the value used when the buffer is visited in a new window.