### PR TITLE
[WIP]vim-patch:8.0.1518

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2205,11 +2205,19 @@ static char_u * do_one_cmd(char_u **cmdlinep,
     ea.arg = skipwhite(p);
   }
 
-  /*
-   * 7. Switch on command name.
-   *
-   * The "ea" structure holds the arguments that can be used.
-   */
+  // The :try command saves the emsg_silent flag, reset it here when
+  // ":silent! try" was used, it should only apply to :try itself.
+  if (ea.cmdidx == CMD_try && did_esilent > 0) {
+    emsg_silent -= did_esilent;
+    if (emsg_silent < 0) {
+      emsg_silent = 0;
+    }
+    did_esilent = 0;
+  }
+
+  // 7. Execute the command.
+  //
+  // The "ea" structure holds the arguments that can be used.
   ea.cmdlinep = cmdlinep;
   ea.getline = fgetline;
   ea.cookie = cookie;

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -11,3 +11,17 @@ endfunction
 func Test_catch_return_with_error()
   call assert_equal(1, s:foo())
 endfunc
+
+func Test_nocatch_restore_silent_emsg()
+  silent! try
+    throw 1
+  catch
+  endtry
+  echoerr 'wrong'
+  let c1 = nr2char(screenchar(&lines, 1))
+  let c2 = nr2char(screenchar(&lines, 2))
+  let c3 = nr2char(screenchar(&lines, 3))
+  let c4 = nr2char(screenchar(&lines, 4))
+  let c5 = nr2char(screenchar(&lines, 5))
+  call assert_equal('wrong', c1 . c2 . c3 . c4 . c5)
+endfunc

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -17,11 +17,8 @@ func Test_nocatch_restore_silent_emsg()
     throw 1
   catch
   endtry
+  redir @z
   echoerr 'wrong'
-  let c1 = nr2char(screenchar(&lines, 1))
-  let c2 = nr2char(screenchar(&lines, 2))
-  let c3 = nr2char(screenchar(&lines, 3))
-  let c4 = nr2char(screenchar(&lines, 4))
-  let c5 = nr2char(screenchar(&lines, 5))
-  call assert_equal('wrong', c1 . c2 . c3 . c4 . c5)
+  redir END
+  call assert_equal('wrong', split(@z, '\n')[-1])
 endfunc


### PR DESCRIPTION
**vim-patch:8.0.1518: error messages suppressed after ":silent! try"**

Problem:    Error messages suppressed after ":silent! try". (Ben Reilly)
Solution:   Restore emsg_silent before executing :try. (closes vim/vim#2531)
https://github.com/vim/vim/commit/2be57331524e93da52a0663f4a334d21c05123bb