### PR TITLE
[RFC] Add numhl option to signs, highlighting line number

### DIFF
--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -85,6 +85,10 @@ DEFINING A SIGN.			*:sign-define* *E255* *E160* *E612*
 		Highlighting group used for the whole line the sign is placed
 		in.  Most useful is defining a background color.
 
+	numhl={group}
+		Highlighting group used for the line number on the line where
+		the sign is placed.
+
 	text={text}						*E239*
 		Define the text that is displayed when there is no icon or the
 		GUI is not being used.  Only printable characters are allowed
@@ -92,10 +96,6 @@ DEFINING A SIGN.			*:sign-define* *E255* *E160* *E612*
 
 	texthl={group}
 		Highlighting group used for the text item.
-
-	numhl={group}
-		Highlighting group used for the line number on the line where
-		the sign is placed.
 
 
 DELETING A SIGN						*:sign-undefine* *E155*

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -93,6 +93,10 @@ DEFINING A SIGN.			*:sign-define* *E255* *E160* *E612*
 	texthl={group}
 		Highlighting group used for the text item.
 
+	numhl={group}
+		Highlighting group used for the line number on the line where
+		the sign is placed.
+
 
 DELETING A SIGN						*:sign-undefine* *E155*
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -136,6 +136,7 @@ Commands:
   |:cquit| can use [count] to set the exit code
   |:drop| is always available
   |:Man| is available by default, with many improvements such as completion
+  |:sign-define| accepts a `numhl` argument, to highlight the line number
   |:tchdir| tab-local |current-directory|
 
 Events:

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5084,11 +5084,15 @@ linenr_T buf_change_sign_type(
     return (linenr_T)0;
 }
 
-int buf_getsigntype(
-    buf_T *buf,
-    linenr_T lnum,
-    int type  // SIGN_ICON, SIGN_TEXT, SIGN_ANY, SIGN_LINEHL, SIGN_NUMHL
-)
+/// Get a sign from a given line.
+/// In case of multiple signs, returns the most recently placed one.
+///
+/// @param buf The buffer in which to search
+/// @param lnum The line in which to search
+/// @param type The type of sign to look for. One of
+///             SIGN_ANY, SIGN_ICON, SIGN_TEXT, SIGN_LINEHL, SIGN_NUMHL
+/// @return The identifier of the first matching sign, or 0
+int buf_getsigntype(buf_T *buf, linenr_T lnum, int type)
 {
     signlist_T  *sign;  // a sign in a b_signlist
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5085,12 +5085,12 @@ linenr_T buf_change_sign_type(
 }
 
 int buf_getsigntype(
-        buf_T *buf,
-        linenr_T lnum,
-        int type /* SIGN_ICON, SIGN_TEXT, SIGN_ANY, SIGN_LINEHL */
-        )
+    buf_T *buf,
+    linenr_T lnum,
+    int type  // SIGN_ICON, SIGN_TEXT, SIGN_ANY, SIGN_LINEHL, SIGN_NUMHL
+)
 {
-    signlist_T	*sign;		/* a sign in a b_signlist */
+    signlist_T  *sign;  // a sign in a b_signlist
 
     for (sign = buf->b_signlist; sign != NULL; sign = sign->next) {
         if (sign->lnum == lnum
@@ -5098,7 +5098,9 @@ int buf_getsigntype(
                     || (type == SIGN_TEXT
                         && sign_get_text(sign->typenr) != NULL)
                     || (type == SIGN_LINEHL
-                        && sign_get_attr(sign->typenr, TRUE) != 0))) {
+                        && sign_get_attr(sign->typenr, SIGN_LINEHL) != 0)
+                    || (type == SIGN_NUMHL
+                        && sign_get_attr(sign->typenr, SIGN_NUMHL) != 0))) {
             return sign->typenr;
         }
     }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5092,7 +5092,7 @@ linenr_T buf_change_sign_type(
 /// @param type The type of sign to look for. One of
 ///             SIGN_ANY, SIGN_ICON, SIGN_TEXT, SIGN_LINEHL, SIGN_NUMHL
 /// @return The identifier of the first matching sign, or 0
-int buf_getsigntype(buf_T *buf, linenr_T lnum, int type)
+int buf_getsigntype(buf_T *buf, linenr_T lnum, SignType type)
 {
     signlist_T  *sign;  // a sign in a b_signlist
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5471,13 +5471,14 @@ void ex_helptags(exarg_T *eap)
 
 struct sign
 {
-    sign_T      *sn_next;       /* next sign in list */
-    int         sn_typenr;      /* type number of sign */
-    char_u      *sn_name;       /* name of sign */
-    char_u      *sn_icon;       /* name of pixmap */
-    char_u      *sn_text;       /* text used instead of pixmap */
-    int         sn_line_hl;     /* highlight ID for line */
-    int         sn_text_hl;     /* highlight ID for text */
+    sign_T      *sn_next;       // next sign in list
+    int         sn_typenr;      // type number of sign
+    char_u      *sn_name;       // name of sign
+    char_u      *sn_icon;       // name of pixmap
+    char_u      *sn_text;       // text used instead of pixmap
+    int         sn_line_hl;     // highlight ID for line
+    int         sn_text_hl;     // highlight ID for text
+    int         sn_num_hl;      // highlight ID for line number
 };
 
 static sign_T   *first_sign = NULL;
@@ -5675,6 +5676,9 @@ void ex_sign(exarg_T *eap)
           } else if (STRNCMP(arg, "texthl=", 7) == 0) {
             arg += 7;
             sp->sn_text_hl = syn_check_group(arg, (int)(p - arg));
+          } else if (STRNCMP(arg, "numhl=", 6) == 0) {
+            arg += 6;
+            sp->sn_num_hl = syn_check_group(arg, (int)(p - arg));
           } else {
             EMSG2(_(e_invarg2), arg);
             return;
@@ -5901,6 +5905,16 @@ static void sign_list_defined(sign_T *sp)
       msg_puts(p);
     }
   }
+  if (sp->sn_num_hl > 0) {
+    msg_puts(" numhl=");
+    const char *const p = get_highlight_name_ext(NULL,
+                                                 sp->sn_num_hl - 1, false);
+    if (p == NULL) {
+      msg_puts("NONE");
+    } else {
+      msg_puts(p);
+    }
+  }
 }
 
 /*
@@ -5920,20 +5934,29 @@ static void sign_undefine(sign_T *sp, sign_T *sp_prev)
 
 /*
  * Get highlighting attribute for sign "typenr".
- * If "line" is TRUE: line highl, if FALSE: text highl.
+ * Gets the highlight corresponding to "type", which should be
+ * SIGN_TEXT, SIGN_LINEHL or SIGN_NUMHL.
  */
-int sign_get_attr(int typenr, int line)
+int sign_get_attr(int typenr, int type)
 {
   sign_T  *sp;
+  int sign_hl = 0;
 
   for (sp = first_sign; sp != NULL; sp = sp->sn_next)
     if (sp->sn_typenr == typenr) {
-      if (line) {
-        if (sp->sn_line_hl > 0)
-          return syn_id2attr(sp->sn_line_hl);
-      } else {
-        if (sp->sn_text_hl > 0)
-          return syn_id2attr(sp->sn_text_hl);
+      switch (type) {
+        case SIGN_TEXT:
+          sign_hl = sp->sn_text_hl;
+          break;
+        case SIGN_LINEHL:
+          sign_hl = sp->sn_line_hl;
+          break;
+        case SIGN_NUMHL:
+          sign_hl = sp->sn_num_hl;
+          break;
+      }
+      if (sign_hl > 0) {
+        return syn_id2attr(sign_hl);
       }
       break;
     }
@@ -5997,7 +6020,8 @@ char_u * get_sign_name(expand_T *xp, int idx)
     case EXP_SUBCMD:
       return (char_u *)cmds[idx];
     case EXP_DEFINE: {
-        char *define_arg[] = { "icon=", "linehl=", "text=", "texthl=", NULL };
+        char *define_arg[] = { "icon=", "linehl=", "text=", "texthl=", "numhl=",
+                               NULL };
         return (char_u *)define_arg[idx];
       }
     case EXP_PLACE: {
@@ -6120,7 +6144,8 @@ void set_context_in_sign_cmd(expand_T *xp, char_u *arg)
     {
       case SIGNCMD_DEFINE:
         if (STRNCMP(last, "texthl", p - last) == 0
-            || STRNCMP(last, "linehl", p - last) == 0) {
+            || STRNCMP(last, "linehl", p - last) == 0
+            || STRNCMP(last, "numhl", p - last) == 0) {
           xp->xp_context = EXPAND_HIGHLIGHT;
         } else if (STRNCMP(last, "icon", p - last) == 0) {
           xp->xp_context = EXPAND_FILES;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5955,7 +5955,7 @@ int sign_get_attr(int typenr, SignType type)
           sign_hl = sp->sn_num_hl;
           break;
         default:
-          break;
+          abort();
       }
       if (sign_hl > 0) {
         return syn_id2attr(sign_hl);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5942,7 +5942,7 @@ int sign_get_attr(int typenr, SignType type)
   sign_T  *sp;
   int sign_hl = 0;
 
-  for (sp = first_sign; sp != NULL; sp = sp->sn_next)
+  for (sp = first_sign; sp != NULL; sp = sp->sn_next) {
     if (sp->sn_typenr == typenr) {
       switch (type) {
         case SIGN_TEXT:
@@ -5954,12 +5954,15 @@ int sign_get_attr(int typenr, SignType type)
         case SIGN_NUMHL:
           sign_hl = sp->sn_num_hl;
           break;
+        default:
+          break;
       }
       if (sign_hl > 0) {
         return syn_id2attr(sign_hl);
       }
       break;
     }
+  }
   return 0;
 }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5937,7 +5937,7 @@ static void sign_undefine(sign_T *sp, sign_T *sp_prev)
  * Gets the highlight corresponding to "type", which should be
  * SIGN_TEXT, SIGN_LINEHL or SIGN_NUMHL.
  */
-int sign_get_attr(int typenr, int type)
+int sign_get_attr(int typenr, SignType type)
 {
   sign_T  *sp;
   int sign_hl = 0;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2486,7 +2486,7 @@ win_line (
   // If this line has a sign with line highlighting set line_attr.
   v = buf_getsigntype(wp->w_buffer, lnum, SIGN_LINEHL);
   if (v != 0) {
-    line_attr = sign_get_attr((int)v, true);
+    line_attr = sign_get_attr((int)v, SIGN_LINEHL);
   }
 
   // Highlight the current line in the quickfix window.
@@ -2794,7 +2794,7 @@ win_line (
                           p_extra = extra;
                           p_extra[n_extra] = NUL;
                       }
-                      char_attr = sign_get_attr(text_sign, FALSE);
+                      char_attr = sign_get_attr(text_sign, SIGN_TEXT);
                   }
               }
           }
@@ -2841,12 +2841,18 @@ win_line (
             c_extra = ' ';
           n_extra = number_width(wp) + 1;
           char_attr = win_hl_attr(wp, HLF_N);
-          // When 'cursorline' is set highlight the line number of
-          // the current line differently.
-          // TODO(vim): Can we use CursorLine instead of CursorLineNr
-          // when CursorLineNr isn't set?
-          if ((wp->w_p_cul || wp->w_p_rnu)
-              && lnum == wp->w_cursor.lnum) {
+
+          int num_sign = buf_getsigntype(wp->w_buffer, lnum, SIGN_NUMHL);
+          if (num_sign != 0) {
+            // If this line has a sign with number highlighting, highlight
+            // accordingly.
+            char_attr = sign_get_attr(num_sign, SIGN_NUMHL);
+          } else if ((wp->w_p_cul || wp->w_p_rnu)
+                     && lnum == wp->w_cursor.lnum) {
+            // When 'cursorline' is set highlight the line number of
+            // the current line differently.
+            // TODO(vim): Can we use CursorLine instead of CursorLineNr
+            // when CursorLineNr isn't set?
             char_attr = win_hl_attr(wp, HLF_CLN);
           }
         }

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -15,12 +15,14 @@ struct signlist
     signlist_T *next;   // next signlist entry
 };
 
-// type argument for buf_getsigntype()
-#define SIGN_ANY     0
-#define SIGN_LINEHL  1
-#define SIGN_ICON    2
-#define SIGN_TEXT    3
-#define SIGN_NUMHL   4
+// type argument for buf_getsigntype() and sign_get_attr()
+typedef enum {
+  SIGN_ANY,
+  SIGN_LINEHL,
+  SIGN_ICON,
+  SIGN_TEXT,
+  SIGN_NUMHL,
+} SignType;
 
 
 

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -9,17 +9,18 @@ typedef struct signlist signlist_T;
 
 struct signlist
 {
-    int id;             /* unique identifier for each placed sign */
-    linenr_T lnum;      /* line number which has this sign */
-    int typenr;         /* typenr of sign */
-    signlist_T *next;   /* next signlist entry */
+    int id;             // unique identifier for each placed sign
+    linenr_T lnum;      // line number which has this sign
+    int typenr;         // typenr of sign
+    signlist_T *next;   // next signlist entry
 };
 
-/* type argument for buf_getsigntype() */
-#define SIGN_ANY	0
-#define SIGN_LINEHL	1
-#define SIGN_ICON	2
-#define SIGN_TEXT	3
+// type argument for buf_getsigntype()
+#define SIGN_ANY     0
+#define SIGN_LINEHL  1
+#define SIGN_ICON    2
+#define SIGN_TEXT    3
+#define SIGN_NUMHL   4
 
 
 

--- a/src/nvim/testdir/test_signs.vim
+++ b/src/nvim/testdir/test_signs.vim
@@ -14,7 +14,7 @@ func Test_sign()
   " the icon name when listing signs.
   sign define Sign1 text=x
   try
-    sign define Sign2 text=xy texthl=Title linehl=Error icon=../../pixmaps/stock_vim_find_help.png
+    sign define Sign2 text=xy texthl=Title linehl=Error numhl=Number icon=../../pixmaps/stock_vim_find_help.png
   catch /E255:/
     " ignore error: E255: Couldn't read in sign data!
     " This error can happen when running in gui.
@@ -23,7 +23,7 @@ func Test_sign()
 
   " Test listing signs.
   let a=execute('sign list')
-  call assert_match("^\nsign Sign1 text=x \nsign Sign2 icon=../../pixmaps/stock_vim_find_help.png .*text=xy linehl=Error texthl=Title$", a)
+  call assert_match("^\nsign Sign1 text=x \nsign Sign2 icon=../../pixmaps/stock_vim_find_help.png .*text=xy linehl=Error texthl=Title numhl=Number$", a)
 
   let a=execute('sign list Sign1')
   call assert_equal("\nsign Sign1 text=x ", a)
@@ -140,7 +140,7 @@ func Test_sign_completion()
   call assert_equal('"sign define jump list place undefine unplace', @:)
 
   call feedkeys(":sign define Sign \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"sign define Sign icon= linehl= text= texthl=', @:)
+  call assert_equal('"sign define Sign icon= linehl= numhl= text= texthl=', @:)
 
   call feedkeys(":sign define Sign linehl=Spell\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"sign define Sign linehl=SpellBad SpellCap SpellLocal SpellRare', @:)

--- a/test/functional/ex_cmds/sign_spec.lua
+++ b/test/functional/ex_cmds/sign_spec.lua
@@ -7,7 +7,7 @@ describe('sign', function()
     describe('without specifying buffer', function()
       it('deletes the sign from all buffers', function()
         -- place a sign with id 34 to first buffer
-        nvim('command', 'sign define Foo text=+ texthl=Delimiter linehl=Comment')
+        nvim('command', 'sign define Foo text=+ texthl=Delimiter linehl=Comment numhl=Number')
         local buf1 = nvim('eval', 'bufnr("%")')
         nvim('command', 'sign place 34 line=3 name=Foo buffer='..buf1)
         -- create a second buffer and place the sign on it as well

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -17,6 +17,9 @@ describe('Signs', function()
       [3] = {background = Screen.colors.Gray90},
       [4] = {bold = true, reverse = true},
       [5] = {reverse = true},
+      [6] = {foreground = Screen.colors.Brown},
+      [7] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey},
+      [8] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
     } )
   end)
 
@@ -75,6 +78,36 @@ describe('Signs', function()
         {2:  }                                                   |
         {2:  }{0:~                                                  }|
         {5:[No Name] [+]                                        }|
+                                                             |
+      ]])
+    end)
+
+    it('can combine text, linehl and numhl', function()
+      feed('ia<cr>b<cr>c<cr><esc>')
+      command('set number')
+      command('sign define piet text=>> texthl=Search')
+      command('sign define pietx linehl=ErrorMsg')
+      command('sign define pietxx numhl=Folded')
+      command('sign place 1 line=1 name=piet buffer=1')
+      command('sign place 2 line=2 name=pietx buffer=1')
+      command('sign place 3 line=3 name=pietxx buffer=1')
+      command('sign place 4 line=4 name=piet buffer=1')
+      command('sign place 5 line=4 name=pietx buffer=1')
+      command('sign place 6 line=4 name=pietxx buffer=1')
+      screen:expect([[
+        {1:>>}{6:  1 }a                                              |
+        {2:  }{6:  2 }{8:b                                              }|
+        {2:  }{7:  3 }c                                              |
+        {1:>>}{7:  4 }{8:^                                               }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
                                                              |
       ]])
     end)


### PR DESCRIPTION
As suggested by @bfredl in #9040, this adds an option `numhl=` to `sign define`, which highlights the line number wherever the sign is placed. This can be used in parallel with signs which define a `text=` and `texthl=`, for example to use gitgutter in the sign column and a linter in the number column.

As far as I'm concerned, this removes the need for #9040, so I'll put that on hold unless other people are interested in it. It wouldn't be hard though to combine it with this PR.

![numhl_screenshot](https://user-images.githubusercontent.com/6820152/46883112-3adc7780-ce51-11e8-8fb7-4cfc645f8710.png)

