### PR TITLE
[RDY] vim-patch:8.0.{971,1547,1843}

### DIFF
--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,7 @@
 " These commands create the option window.
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2018 Feb 27
+" Last Change:	2018 May 15
 
 " If there already is an option window, jump to that one.
 let buf = bufnr('option-window')
@@ -325,7 +325,8 @@ call <SID>OptionL("scr")
 call append("$", "scrolloff\tnumber of screen lines to show around the cursor")
 call append("$", " \tset so=" . &so)
 call append("$", "wrap\tlong lines wrap")
-call <SID>BinOptionG("wrap", &wrap)
+call append("$", "\t(local to window)")
+call <SID>BinOptionL("wrap")
 call append("$", "linebreak\twrap long lines at a character in 'breakat'")
 call append("$", "\t(local to window)")
 call <SID>BinOptionL("lbr")

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -510,6 +510,10 @@ if has("terminal")
   call append("$", "termkey\tkey that precedes Vim commands in a terminal window")
   call append("$", "\t(local to window)")
   call <SID>OptionL("tk")
+  if exists("&winptydll")
+    call append("$", "winptydll\tname of the winpty dynamic library")
+    call <SID>OptionG("winptydll", &winptydll)
+  endif
 endif
 
 

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,7 @@
 " These commands create the option window.
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2017 Oct 19
+" Last Change:	2018 Feb 27
 
 " If there already is an option window, jump to that one.
 let buf = bufnr('option-window')
@@ -122,11 +122,13 @@ fun! <SID>Update(lnum, line, local, thiswin)
 endfun
 
 " Reset 'title' and 'icon' to make it work faster.
+" Reset 'undolevels' to avoid undo'ing until the buffer is empty.
 let s:old_title = &title
 let s:old_icon = &icon
 let s:old_sc = &sc
 let s:old_ru = &ru
-set notitle noicon nosc noru
+let s:old_ul = &ul
+set notitle noicon nosc noru ul=-1
 
 " If the current window is a help window, try finding a non-help window.
 " Relies on syntax highlighting to be switched on.
@@ -714,7 +716,7 @@ call <SID>OptionG("km", &km)
 call <SID>Header("editing text")
 call append("$", "undolevels\tmaximum number of changes that can be undone")
 call append("$", "\t(global or local to buffer)")
-call append("$", " \tset ul=" . &ul)
+call append("$", " \tset ul=" . s:old_ul)
 call append("$", "undofile\tautomatically save and restore undo history")
 call <SID>BinOptionG("udf", &udf)
 call append("$", "undodir\tlist of directories for undo files")
@@ -1319,6 +1321,7 @@ let &icon = s:old_icon
 let &ru = s:old_ru
 let &sc = s:old_sc
 let &cpo = s:cpo_save
-unlet s:old_title s:old_icon s:old_ru s:old_sc s:cpo_save s:idx s:lnum
+let &ul = s:old_ul
+unlet s:old_title s:old_icon s:old_ru s:old_sc s:cpo_save s:idx s:lnum s:old_ul
 
 " vim: ts=8 sw=2 sts=2


### PR DESCRIPTION
**vim-patch:8.0.0971: 'winptydll' missing from :options**

Problem:    'winptydll' missing from :options.
Solution:   Add the entry.
vim/vim@0aed9a2

**vim-patch:8.0.1547: undo in the options window makes it empty**

Problem:    Undo in the options window makes it empty.
Solution:   Set 'undolevels' while filling the buffer. (Yasuhiro Matthew,
            closes vim/vim#2645)
vim/vim@9c474b2

**vim-patch:8.0.1843: entry for 'wrap' in options window is wrong**

Problem:    Entry for 'wrap' in options window is wrong. (John Little)
Solution:   Make the change apply locally.
vim/vim@8776889