### PR TITLE
vim-patch:8.1.0473

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1527,7 +1527,7 @@ static time_t swapfile_info(char_u *fname)
           msg_outnum(char_to_long(b0.b0_pid));
 #if defined(UNIX)
           if (kill((pid_t)char_to_long(b0.b0_pid), 0) == 0) {
-            MSG_PUTS(_(" (still running)"));
+            MSG_PUTS(_(" (STILL RUNNING)"));
             process_still_running = TRUE;
           }
 #endif
@@ -3150,7 +3150,9 @@ attention_message (
   msg_outtrans(buf->b_fname);
   MSG_PUTS("\"\n");
   FileInfo file_info;
-  if (os_fileinfo((char *)buf->b_fname, &file_info)) {
+  if (!os_fileinfo((char *)buf->b_fname, &file_info)) {
+    MSG_PUTS(_("      CANNOT BE FOUND"));
+  } else {
     MSG_PUTS(_("             dated: "));
     x = file_info.stat.st_mtim.tv_sec;
     p = ctime(&x);  // includes '\n'

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1449,7 +1449,7 @@ static char *make_percent_swname(const char *dir, char *name)
 }
 
 #ifdef UNIX
-static int process_still_running;
+static bool process_still_running;
 #endif
 
 /*
@@ -1528,7 +1528,7 @@ static time_t swapfile_info(char_u *fname)
 #if defined(UNIX)
           if (kill((pid_t)char_to_long(b0.b0_pid), 0) == 0) {
             MSG_PUTS(_(" (STILL RUNNING)"));
-            process_still_running = TRUE;
+            process_still_running = true;
           }
 #endif
         }
@@ -3349,7 +3349,7 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname,
           int choice = 0;
 
 #ifdef UNIX
-          process_still_running = FALSE;
+          process_still_running = false;
 #endif
           /*
            * If there is a SwapExists autocommand and we can handle


### PR DESCRIPTION
**vim-patch:8.1.0473: user doesn't notice file does not exist when swap file does**

Problem:    User doesn't notice file does not exist when swap file does.
Solution:   Add a note that the file cannot be found.  Make the "still
            running" notice stand out.
vim/vim@d6105cb