### PR TITLE
vim-patch:8.0.1672

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -510,6 +510,10 @@ static int command_line_check(VimState *state)
   // completion may switch it on.
   quit_more = false;       // reset after CTRL-D which had a more-prompt
 
+  did_emsg = false;        // There can't really be a reason why an error
+                           // that occurs while typing a command should
+                           // cause the command not to be executed.
+
   cursorcmd();             // set the cursor on the right spot
   ui_cursor_shape();
   return 1;

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -334,6 +334,17 @@ func Test_paste_in_cmdline()
   call feedkeys(":\<C-\>etoupper(getline(1))\<CR>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"ASDF.X /TMP/SOME VERYLONGWORD A;B-C*D ', @:)
   bwipe!
+
+  " Error while typing a command used to cause that it was not executed
+  " in the end.
+  new
+  try
+    call feedkeys(":file \<C-R>%Xtestfile\<CR>", 'tx')
+  catch /^Vim\%((\a\+)\)\=:E32/
+    " ignore error E32
+  endtry
+  call assert_equal("Xtestfile", bufname("%"))
+  bwipe!
 endfunc
 
 func Test_remove_char_in_cmdline()

--- a/test/functional/ui/cmdline_highlight_spec.lua
+++ b/test/functional/ui/cmdline_highlight_spec.lua
@@ -831,7 +831,7 @@ describe('Ex commands coloring support', function()
                                               |
     ]])
   end)
-  it('does not prevent mapping error from cancelling prompt', function()
+  it('does prevent mapping error from cancelling prompt', function()
     command("cnoremap <expr> x execute('throw 42')[-1]")
     feed(':#x')
     screen:expect([[
@@ -846,14 +846,14 @@ describe('Ex commands coloring support', function()
     ]])
     feed('<CR>')
     screen:expect([[
-      ^                                        |
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
-                                              |
+      :#                                      |
+      {ERR:Error detected while processing :}       |
+      {ERR:E605: Exception not caught: 42}          |
+      {ERR:E749: empty buffer}                      |
+      {PE:Press ENTER or type command to continue}^ |
     ]])
     feed('<CR>')
     screen:expect([[
@@ -866,7 +866,7 @@ describe('Ex commands coloring support', function()
       {EOB:~                                       }|
                                               |
     ]])
-    eq('Error detected while processing :\nE605: Exception not caught: 42',
+    eq('Error detected while processing :\nE605: Exception not caught: 42\nE749: empty buffer',
        meths.command_output('messages'))
   end)
   it('errors out when failing to get callback', function()

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -1503,7 +1503,7 @@ describe("'inccommand' and :cnoremap", function()
       end
   end)
 
-  it('does not work with a failing mapping', function()
+  it('does work with a failing mapping', function()
     for _, case in pairs(cases) do
       refresh(case)
       feed_command("cnoremap <expr> x execute('bwipeout!')[-1].'x'")
@@ -1512,7 +1512,10 @@ describe("'inccommand' and :cnoremap", function()
 
       -- error thrown b/c of the mapping
       neq(nil, eval('v:errmsg'):find('^E523:'))
-      expect(default_text)
+      expect([[
+      Inc substitution on
+      toxo lines
+      ]])
     end
   end)
 


### PR DESCRIPTION
**vim-patch:8.0.1672: error during completion causes command to be cancelled**

Problem:    Error during completion causes command to be cancelled.
Solution:   Reset did_emsg before waiting for another character. (Tom M.)
https://github.com/vim/vim/commit/72532d354e699f1cceec34c0b08e1de4d3ea9641