### PR TITLE
vim-patch:8.1.0476

### DIFF
--- a/src/nvim/testdir/test_escaped_glob.vim
+++ b/src/nvim/testdir/test_escaped_glob.vim
@@ -2,8 +2,6 @@
 " characters.
 
 function SetUp()
-  " make sure glob() doesn't use the shell
-  set shell=doesnotexist
   " consistent sorting of file names
   set nofileignorecase
 endfunction
@@ -14,20 +12,23 @@ function Test_glob()
     " filenames. Disable the test on non-Unix systems for now.
     return
   endif
-  call assert_equal("", glob('Xxx\{'))
-  call assert_equal("", glob('Xxx\$'))
+
+  " Execute these commands in the sandbox, so that using the shell fails.
+  " Setting 'shell' to an invalid name causes a memory leak.
+  sandbox call assert_equal("", glob('Xxx\{'))
+  sandbox call assert_equal("", glob('Xxx\$'))
   w! Xxx{
   " } to fix highlighting
   w! Xxx\$
-  call assert_equal("Xxx{", glob('Xxx\{'))
-  call assert_equal("Xxx$", glob('Xxx\$'))
+  sandbox call assert_equal("Xxx{", glob('Xxx\{'))
+  sandbox call assert_equal("Xxx$", glob('Xxx\$'))
   call delete('Xxx{')
   call delete('Xxx$')
 endfunction
 
 function Test_globpath()
-  call assert_equal(expand("sautest/autoload/globone.vim\nsautest/autoload/globtwo.vim"),
+  sandbox call assert_equal(expand("sautest/autoload/globone.vim\nsautest/autoload/globtwo.vim"),
   \ globpath('sautest/autoload', 'glob*.vim'))
-  call assert_equal([expand('sautest/autoload/globone.vim'), expand('sautest/autoload/globtwo.vim')],
+  sandbox call assert_equal([expand('sautest/autoload/globone.vim'), expand('sautest/autoload/globtwo.vim')],
   \ globpath('sautest/autoload', 'glob*.vim', 0, 1))
 endfunction


### PR DESCRIPTION
**vim-patch:8.1.0476: memory leaks in test_escaped_glob**

Problem:    Memory leaks in test_escaped_glob.
Solution:   Avoid failure when running the shell, use the sandbox.
https://github.com/vim/vim/commit/a2aad028305c306ecf33e0fd720fe1ed98596371