### PR TITLE
test: Improve 008_autocommands_spec reliability

### DIFF
--- a/test/functional/legacy/008_autocommands_spec.lua
+++ b/test/functional/legacy/008_autocommands_spec.lua
@@ -2,9 +2,9 @@
 -- Test for BufUnload autocommand that unloads all other buffers.
 
 local helpers = require('test.functional.helpers')(after_each)
-local feed, source = helpers.feed, helpers.source
-local clear, feed_command, expect, eq, eval = helpers.clear, helpers.feed_command, helpers.expect, helpers.eq, helpers.eval
-local write_file, wait, dedent = helpers.write_file, helpers.wait, helpers.dedent
+local source = helpers.source
+local clear, command, expect, eq, eval = helpers.clear, helpers.command, helpers.expect, helpers.eq, helpers.eval
+local write_file, dedent = helpers.write_file, helpers.dedent
 local read_file = helpers.read_file
 
 describe('autocommands that delete and unload buffers:', function()
@@ -26,29 +26,25 @@ describe('autocommands that delete and unload buffers:', function()
   before_each(clear)
 
   it('BufWritePre, BufUnload', function()
-    feed_command('au BufWritePre Xxx1 bunload')
-    feed_command('au BufWritePre Xxx2 bwipe')
-    feed_command('e Xxx2')
+    command('au BufWritePre Xxx1 bunload')
+    command('au BufWritePre Xxx2 bwipe')
+    command('e Xxx2')
     eq('Xxx2', eval('bufname("%")'))
-    feed_command('e Xxx1')
+    command('e Xxx1')
     eq('Xxx1', eval('bufname("%")'))
     -- The legacy test file did not check the error message.
-    feed_command('let v:errmsg = "no error"')
-    feed_command('write')
-    -- Discard all "hit enter" prompts and messages.
-    feed('<C-L>')
+    command('let v:errmsg = "no error"')
+    command('silent! write')
     eq('E203: Autocommands deleted or unloaded buffer to be written',
       eval('v:errmsg'))
     eq('Xxx2', eval('bufname("%")'))
     expect(text2)
     -- Start editing Xxx2.
-    feed_command('e! Xxx2')
+    command('e! Xxx2')
     -- The legacy test file did not check the error message.
-    feed_command('let v:errmsg = "no error"')
+    command('let v:errmsg = "no error"')
     -- Write Xxx2, will delete the buffer and give an error msg.
-    feed_command('w')
-    -- Discard all "hit enter" prompts and messages.
-    feed('<C-L>')
+    command('silent! write')
     eq('E203: Autocommands deleted or unloaded buffer to be written',
       eval('v:errmsg'))
     eq('Xxx1', eval('bufname("%")'))
@@ -75,18 +71,11 @@ describe('autocommands that delete and unload buffers:', function()
       au BufUnload * call CloseAll()
       au VimLeave * call WriteToOut()
     ]])
-    feed_command('e Xxx2')
-    -- Discard all "hit enter" prompts and messages.
-    feed('<C-L>')
-    feed_command('e Xxx1')
-    -- Discard all "hit enter" prompts and messages.
-    feed('<C-L>')
-    feed_command('e Makefile') -- an existing file
-    feed('<C-L>')
-    feed_command('sp new2')
-    feed('<C-L>')
-    feed_command('q')
-    wait()
+    command('silent! edit Xxx2')
+    command('silent! edit Xxx1')
+    command('silent! edit Makefile') -- an existing file
+    command('silent! split new2')
+    command('silent! quit')
     eq('VimLeave done',
        string.match(read_file(test_file), "^%s*(.-)%s*$"))
   end)


### PR DESCRIPTION
Sometimes 008_autocommands_spec fails like this:

    [ RUN      ] autocommands that delete and unload buffers: BufUnload, VimLeave: -- Output to stderr:
    CMake Error at /home/travis/build/neovim/neovim/cmake/RunTests.cmake:53 (message):
      functional tests failed with error: 1

The final :quit + wait() is a race. Use command() instead, which is
synchronous.  Use command('silent! ...') everywhere else too, because
it's clearer instead of feeding input and clearing the expected errors
with CTRL-L.