### PR TITLE
vim-patch:8.0.{670,1067}

### DIFF
--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -189,6 +189,24 @@ func Test_input_in_timer()
   call assert_equal('hello', g:val)
 endfunc
 
+func FuncWithCaughtError(timer)
+  let g:call_count += 1
+  try
+    doesnotexist
+  catch
+    " nop
+  endtry
+endfunc
+
+func Test_timer_catch_error()
+  let g:call_count = 0
+  let timer = timer_start(10, 'FuncWithCaughtError', {'repeat': 4})
+  " Timer will not be stopped.
+  call WaitFor('g:call_count == 4')
+  sleep 50m
+  call assert_equal(4, g:call_count)
+endfunc
+
 func FeedAndPeek(timer)
   call test_feedinput('a')
   call getchar(1)

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -172,6 +172,23 @@ func Test_stop_all_in_callback()
   call assert_equal(0, len(info))
 endfunc
 
+func FeedkeysCb(timer)
+  call feedkeys("hello\<CR>", 'nt')
+endfunc
+
+func InputCb(timer)
+  call timer_start(10, 'FeedkeysCb')
+  let g:val = input('?')
+  call Resume()
+endfunc
+
+func Test_input_in_timer()
+  let g:val = ''
+  call timer_start(10, 'InputCb')
+  call Standby(1000)
+  call assert_equal('hello', g:val)
+endfunc
+
 func FeedAndPeek(timer)
   call test_feedinput('a')
   call getchar(1)


### PR DESCRIPTION
**vim-patch:8.0.0670: can't use input() in a timer callback**

Problem:    Can't use input() in a timer callback. (Cosmin Popescu)
Solution:   Reset vgetc_busy and set timer_busy. (Ozaki Kiichi, closes vim/vim#1790,
            closes vim/vim#1129)
https://github.com/vim/vim/commit/1e8e14552e0cc8881411eb8fbe39a654dae42554

**vim-patch:8.0.1067: try/catch in timer does not prevent it from being stopped**

Problem:    Using try/catch in timer does not prevent it from being stopped.
Solution:   Reset the exception context and use did_emsg instead of
            called_emsg.
vim/vim@e723c42

Included only the test because of incompatible timers implementation with Vim and the test passes.