### PR TITLE
[RFC] Allow unicode characters in python function names.

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -128,7 +128,7 @@ syn match   pythonMatrixMultiply
       \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonFunction,pythonDoctestValue
       \ transparent
 
-syn match   pythonFunction	"\h\w*" display contained
+syn match   pythonFunction	"[A-Za-z_\u0100-\uFFFF][0-9A-Za-z_\u0100-\uFFFF]*" display contained
 
 syn match   pythonComment	"#.*$" contains=pythonTodo,@Spell
 syn keyword pythonTodo		FIXME NOTE NOTES TODO XXX contained


### PR DESCRIPTION
Identifiers can contain unicode characters in python3.  This PR updates the syntax highlighting to support unicode in function names.  There are probably other parts of the syntax file that should be updated to account for unicode as well, but this was what was giving me immediate problems.