### PR TITLE
UI: disable clearing almost everywhere

### DIFF
--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1645,9 +1645,6 @@ void listdigraphs(void)
     os_breakcheck();
     dp++;
   }
-  // clear screen, because some digraphs may be wrong, in which case we messed
-  // up ScreenLines
-  must_redraw = CLEAR;
 }
 
 static void printdigraph(digr_T *dp)

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -214,8 +214,6 @@ static int hislen = 0;                  /* actual length of history tables */
 /// user interrupting highlight function to not interrupt command-line.
 static bool getln_interrupted_highlight = false;
 
-static bool need_cursor_update = false;
-
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ex_getln.c.generated.h"
@@ -3020,8 +3018,6 @@ void cmdline_screen_cleared(void)
     }
     line = line->prev_ccline;
   }
-
-  need_cursor_update = true;
 }
 
 /// called by ui_flush, do what redraws neccessary to keep cmdline updated.
@@ -3481,10 +3477,7 @@ static void cursorcmd(void)
     if (ccline.redraw_state < kCmdRedrawPos) {
       ccline.redraw_state = kCmdRedrawPos;
     }
-    if (need_cursor_update) {
-      need_cursor_update = false;
-      setcursor();
-    }
+    setcursor();
     return;
   }
 

--- a/src/nvim/farsi.c
+++ b/src/nvim/farsi.c
@@ -1602,7 +1602,7 @@ static void conv_to_pvim(void)
   do_cmdline_cmd("%s/\201\231/\370\334/ge");
 
   // Assume the screen has been messed up: clear it and redraw.
-  redraw_later(CLEAR);
+  redraw_later(NOT_VALID);
   MSG_ATTR((const char *)farsi_text_1, HL_ATTR(HLF_S));
 }
 
@@ -1623,7 +1623,7 @@ static void conv_to_pstd(void)
   }
 
   // Assume the screen has been messed up: clear it and redraw.
-  redraw_later(CLEAR);
+  redraw_later(NOT_VALID);
   msg_attr((const char *)farsi_text_2, HL_ATTR(HLF_S));
 }
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -191,8 +191,6 @@ EXTERN int cmdline_star INIT(= FALSE);          /* cmdline is crypted */
 
 EXTERN int exec_from_reg INIT(= FALSE);         /* executing register */
 
-EXTERN TriState screen_cleared INIT(= kFalse);  // screen has been cleared
-
 /*
  * When '$' is included in 'cpoptions' option set:
  * When a change command is given that deletes only part of a line, a dollar

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -832,12 +832,11 @@ void msg_end_prompt(void)
   lines_left = -1;
 }
 
-/*
- * wait for the user to hit a key (normally a return)
- * if 'redraw' is TRUE, clear and redraw the screen
- * if 'redraw' is FALSE, just redraw the screen
- * if 'redraw' is -1, don't redraw at all
- */
+/// wait for the user to hit a key (normally a return)
+///
+/// if 'redraw' is true, redraw the entire screen NOT_VALID
+/// if 'redraw' is false, do a normal redraw
+/// if 'redraw' is -1, don't redraw at all
 void wait_return(int redraw)
 {
   int c;
@@ -847,8 +846,9 @@ void wait_return(int redraw)
   int save_Recording;
   FILE        *save_scriptout;
 
-  if (redraw == TRUE)
-    must_redraw = CLEAR;
+  if (redraw == true) {
+    redraw_all_later(NOT_VALID);
+  }
 
   /* If using ":silent cmd", don't wait for a return.  Also don't set
    * need_wait_return to do it later. */

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -918,9 +918,9 @@ void curs_columns(
 
     extra = ((int)prev_skipcol - (int)curwin->w_skipcol) / width;
     if (extra > 0) {
-      win_ins_lines(curwin, 0, extra, false, false);
+      win_ins_lines(curwin, 0, extra, false);
     } else if (extra < 0) {
-      win_del_lines(curwin, 0, -extra, false, false);
+      win_del_lines(curwin, 0, -extra, false);
     }
   } else {
     curwin->w_skipcol = 0;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3980,8 +3980,8 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
 
         /* Enable Arabic shaping (major part of what Arabic requires) */
         if (!p_arshape) {
-          p_arshape = TRUE;
-          redraw_later_clear();
+          p_arshape = true;
+          redraw_all_later(NOT_VALID);
         }
       }
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -68,7 +68,7 @@ return {
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
-      redraw={'everything', 'ui_option'},
+      redraw={'all_windows', 'ui_option'},
 
       varname='p_arshape',
       defaults={if_true={vi=true}}
@@ -92,7 +92,7 @@ return {
       full_name='ambiwidth', abbreviation='ambw',
       type='string', scope={'global'},
       vi_def=true,
-      redraw={'everything', 'ui_option'},
+      redraw={'all_windows', 'ui_option'},
       varname='p_ambw',
       defaults={if_true={vi="single"}}
     },
@@ -133,7 +133,7 @@ return {
       full_name='background', abbreviation='bg',
       type='string', scope={'global'},
       vi_def=true,
-      redraw={'everything'},
+      redraw={'all_windows'},
       varname='p_bg',
       defaults={if_true={vi="light"}}
     },
@@ -662,7 +662,7 @@ return {
       full_name='emoji', abbreviation='emo',
       type='bool', scope={'global'},
       vi_def=true,
-      redraw={'everything', 'ui_option'},
+      redraw={'all_windows', 'ui_option'},
       varname='p_emoji',
       defaults={if_true={vi=true}}
     },
@@ -671,7 +671,6 @@ return {
       type='string', scope={'global'},
       deny_in_modelines=true,
       vi_def=true,
-      redraw={'everything'},
       varname='p_enc',
       defaults={if_true={vi=macros('ENC_DFLT')}}
     },
@@ -1023,7 +1022,7 @@ return {
       deny_duplicates=true,
       vi_def=true,
       varname='p_guifont',
-      redraw={'everything', 'ui_option'},
+      redraw={'ui_option'},
       defaults={if_true={vi=""}}
     },
     {
@@ -1031,7 +1030,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       vi_def=true,
       varname='p_guifontset',
-      redraw={'everything', 'ui_option'},
+      redraw={'ui_option'},
       defaults={if_true={vi=""}}
     },
     {
@@ -1039,7 +1038,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
-      redraw={'everything', 'ui_option'},
+      redraw={'ui_option'},
       varname='p_guifontwide',
       defaults={if_true={vi=""}}
     },
@@ -1099,7 +1098,6 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
-      redraw={'everything'},
       varname='p_hl',
       defaults={if_true={vi=macros('HIGHLIGHT_INIT')}}
     },
@@ -1195,7 +1193,7 @@ return {
       full_name='inccommand', abbreviation='icm',
       type='string', scope={'global'},
       vi_def=true,
-      redraw={'everything'},
+      redraw={'all_windows'},
       varname='p_icm',
       defaults={if_true={vi=""}}
     },
@@ -1399,7 +1397,7 @@ return {
       full_name='linespace', abbreviation='lsp',
       type='number', scope={'global'},
       vi_def=true,
-      redraw={'everything', 'ui_option'},
+      redraw={'ui_option'},
       varname='p_linespace',
       defaults={if_true={vi=0}}
     },
@@ -2428,7 +2426,6 @@ return {
       full_name='termencoding', abbreviation='tenc',
       type='string', scope={'global'},
       vi_def=true,
-      redraw={'everything'},
       defaults={if_true={vi=""}}
     },
     {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -167,12 +167,6 @@ void redraw_win_later(win_T *wp, int type)
   }
 }
 
-/// Forces a complete redraw later.  Also resets the highlighting.
-void redraw_later_clear(void)
-{
-  redraw_all_later(CLEAR);
-}
-
 /*
  * Mark all windows to be redrawn later.
  */
@@ -845,14 +839,6 @@ static void win_update(win_T *wp)
       type = VALID;
   }
 
-  // Trick: we want to avoid clearing the screen twice.  screenclear() will
-  // set "screen_cleared" to kTrue.  The special value kNone (which is still
-  // non-zero and thus not kFalse) will indicate that screenclear() was not
-  // called.
-  if (screen_cleared) {
-    screen_cleared = kNone;
-  }
-
   /*
    * If there are no changes on the screen that require a complete redraw,
    * handle three cases:
@@ -898,15 +884,14 @@ static void win_update(win_T *wp)
         if (wp->w_lines[0].wl_lnum != wp->w_topline)
           i += diff_check_fill(wp, wp->w_lines[0].wl_lnum)
                - wp->w_old_topfill;
-        if (i < wp->w_height - 2) {             /* less than a screen off */
-          /*
-           * Try to insert the correct number of lines.
-           * If not the last window, delete the lines at the bottom.
-           * win_ins_lines may fail when the terminal can't do it.
-           */
-          if (i > 0)
-            check_for_delay(FALSE);
-          if (win_ins_lines(wp, 0, i, FALSE, wp == firstwin) == OK) {
+        if (i < wp->w_height - 2) {  // less than a screen off
+          // Try to insert the correct number of lines.
+          // If not the last window, delete the lines at the bottom.
+          // win_ins_lines may fail when the terminal can't do it.
+          if (i > 0) {
+            check_for_delay(false);
+          }
+          if (win_ins_lines(wp, 0, i, false) == OK) {
             if (wp->w_lines_valid != 0) {
               /* Need to update rows that are new, stop at the
                * first one that scrolled down. */
@@ -964,11 +949,12 @@ static void win_update(win_T *wp)
         /* ... but don't delete new filler lines. */
         row -= wp->w_topfill;
         if (row > 0) {
-          check_for_delay(FALSE);
-          if (win_del_lines(wp, 0, row, FALSE, wp == firstwin) == OK)
+          check_for_delay(false);
+          if (win_del_lines(wp, 0, row, false) == OK) {
             bot_start = wp->w_height - row;
-          else
-            mid_start = 0;                      /* redraw all lines */
+          } else {
+            mid_start = 0;                      // redraw all lines
+          }
         }
         if ((row == 0 || bot_start < 999) && wp->w_lines_valid != 0) {
           /*
@@ -1006,31 +992,9 @@ static void win_update(win_T *wp)
       }
     }
 
-    /* When starting redraw in the first line, redraw all lines.  When
-     * there is only one window it's probably faster to clear the screen
-     * first. */
+    // When starting redraw in the first line, redraw all lines.
     if (mid_start == 0) {
       mid_end = wp->w_height;
-      if (ONE_WINDOW) {
-        // Clear the screen when it was not done by win_del_lines() or
-        // win_ins_lines() above, "screen_cleared" is kFalse or kNone
-        // then.
-        if (screen_cleared != kTrue) {
-          screenclear();
-        }
-        // The screen was cleared, redraw the tab pages line.
-        if (redraw_tabline) {
-          draw_tabline();
-        }
-      }
-    }
-
-    /* When win_del_lines() or win_ins_lines() caused the screen to be
-     * cleared (only happens for the first window) or when screenclear()
-     * was called directly above, "must_redraw" will have been set to
-     * NOT_VALID, need to reset it here to avoid redrawing twice. */
-    if (screen_cleared == kTrue) {
-      must_redraw = 0;
     }
   } else {
     /* Not VALID or INVERTED: redraw all lines. */
@@ -1338,31 +1302,31 @@ static void win_update(win_T *wp)
              * remaining text or scrolling fails, must redraw the
              * rest.  If scrolling works, must redraw the text
              * below the scrolled text. */
-            if (row - xtra_rows >= wp->w_height - 2)
+            if (row - xtra_rows >= wp->w_height - 2) {
               mod_bot = MAXLNUM;
-            else {
-              check_for_delay(FALSE);
-              if (win_del_lines(wp, row,
-                      -xtra_rows, FALSE, FALSE) == FAIL)
+            } else {
+              check_for_delay(false);
+              if (win_del_lines(wp, row, -xtra_rows, false) == FAIL) {
                 mod_bot = MAXLNUM;
-              else
-                bot_start = wp->w_height + xtra_rows;
+              } else {
+                  bot_start = wp->w_height + xtra_rows;
+              }
             }
           } else if (xtra_rows > 0) {
             /* May scroll text down.  If there is not enough
              * remaining text of scrolling fails, must redraw the
              * rest. */
-            if (row + xtra_rows >= wp->w_height - 2)
+            if (row + xtra_rows >= wp->w_height - 2) {
               mod_bot = MAXLNUM;
-            else {
-              check_for_delay(FALSE);
-              if (win_ins_lines(wp, row + old_rows,
-                      xtra_rows, FALSE, FALSE) == FAIL)
+            } else {
+              check_for_delay(false);
+              if (win_ins_lines(wp, row + old_rows, xtra_rows, false) == FAIL) {
                 mod_bot = MAXLNUM;
-              else if (top_end > row + old_rows)
-                /* Scrolled the part at the top that requires
-                 * updating down. */
+              } else if (top_end > row + old_rows) {
+                // Scrolled the part at the top that requires
+                // updating down.
                 top_end += xtra_rows;
+              }
             }
           }
 
@@ -6137,19 +6101,19 @@ static void screenclear2(void)
   ui_call_grid_clear(1);  // clear the display
   clear_cmdline = false;
   mode_displayed = false;
-  screen_cleared = kTrue;   // can use contents of ScreenLines now
 
-  win_rest_invalid(firstwin);
-  redraw_cmdline = TRUE;
-  redraw_tabline = TRUE;
-  if (must_redraw == CLEAR)     /* no need to clear again */
-    must_redraw = NOT_VALID;
+  redraw_all_later(NOT_VALID);
+  redraw_cmdline = true;
+  redraw_tabline = true;
+  if (must_redraw == CLEAR) {
+    must_redraw = NOT_VALID;  // no need to clear again
+  }
   compute_cmdrow();
-  msg_row = cmdline_row;        /* put cursor on last line for messages */
+  msg_row = cmdline_row;  // put cursor on last line for messages
   msg_col = 0;
-  msg_scrolled = 0;             /* can't scroll back */
-  msg_didany = FALSE;
-  msg_didout = FALSE;
+  msg_scrolled = 0;  // can't scroll back
+  msg_didany = false;
+  msg_didout = false;
 }
 
 /*
@@ -6200,13 +6164,13 @@ void setcursor(void)
 /// If 'mayclear' is TRUE the screen will be cleared if it is faster than
 /// scrolling.
 /// Returns FAIL if the lines are not inserted, OK for success.
-int win_ins_lines(win_T *wp, int row, int line_count, int invalid, int mayclear)
+int win_ins_lines(win_T *wp, int row, int line_count, int invalid)
 {
   if (wp->w_height < 5) {
     return FAIL;
   }
 
-  return win_do_lines(wp, row, line_count, invalid, mayclear, false);
+  return win_do_lines(wp, row, line_count, invalid, false);
 }
 
 /// Delete "line_count" window lines at "row" in window "wp".
@@ -6214,27 +6178,21 @@ int win_ins_lines(win_T *wp, int row, int line_count, int invalid, int mayclear)
 /// If "mayclear" is TRUE the screen will be cleared if it is faster than
 /// scrolling
 /// Return OK for success, FAIL if the lines are not deleted.
-int win_del_lines(win_T *wp, int row, int line_count, int invalid, int mayclear)
+int win_del_lines(win_T *wp, int row, int line_count, int invalid)
 {
-  return win_do_lines(wp, row, line_count, invalid, mayclear, true);
+  return win_do_lines(wp, row, line_count, invalid, true);
 }
 
 // Common code for win_ins_lines() and win_del_lines().
 // Returns OK or FAIL when the work has been done.
 static int win_do_lines(win_T *wp, int row, int line_count,
-                        int invalid, int mayclear, int del)
+                        int invalid, int del)
 {
   if (invalid) {
     wp->w_lines_valid = 0;
   }
 
   if (!redrawing() || line_count <= 0) {
-    return FAIL;
-  }
-
-  // only a few lines left: redraw is faster
-  if (mayclear && Rows - line_count < 5 && wp->w_width == Columns) {
-    screenclear();          /* will set wp->w_lines_valid to 0 */
     return FAIL;
   }
 
@@ -6261,19 +6219,6 @@ static int win_do_lines(win_T *wp, int row, int line_count,
                               wp->w_wincol, wp->w_width);
   }
   return retval;
-}
-
-/*
- * window 'wp' and everything after it is messed up, mark it for redraw
- */
-static void win_rest_invalid(win_T *wp)
-{
-  while (wp != NULL) {
-    redraw_win_later(wp, NOT_VALID);
-    wp->w_redr_status = TRUE;
-    wp = wp->w_next;
-  }
-  redraw_cmdline = TRUE;
 }
 
 /*

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6566,7 +6566,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       }
       init_highlight(true, true);
       highlight_changed();
-      redraw_later_clear();
+      redraw_all_later(NOT_VALID);
       return;
     }
     name_end = (const char *)skiptowhite((const char_u *)line);

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1265,7 +1265,8 @@ static void win_exchange(long Prenum)
   (void)win_comp_pos();                 /* recompute window positions */
 
   win_enter(wp, true);
-  redraw_later(CLEAR);
+  redraw_later(NOT_VALID);
+  redraw_win_later(wp, NOT_VALID);
 }
 
 /*
@@ -1340,7 +1341,7 @@ static void win_rotate(int upwards, int count)
     (void)win_comp_pos();
   }
 
-  redraw_later(CLEAR);
+  redraw_all_later(NOT_VALID);
 }
 
 /*
@@ -1477,10 +1478,10 @@ static void win_equal_rec(
         || topfr->fr_width != width || topfr->fr_win->w_wincol != col
         ) {
       topfr->fr_win->w_winrow = row;
-      frame_new_height(topfr, height, FALSE, FALSE);
+      frame_new_height(topfr, height, false, false);
       topfr->fr_win->w_wincol = col;
-      frame_new_width(topfr, width, FALSE, FALSE);
-      redraw_all_later(CLEAR);
+      frame_new_width(topfr, width, false, false);
+      redraw_all_later(NOT_VALID);
     }
   } else if (topfr->fr_layout == FR_ROW) {
     topfr->fr_width = width;
@@ -3105,7 +3106,7 @@ int win_new_tabpage(int after, char_u *filename)
     newtp->tp_topframe = topframe;
     last_status(FALSE);
 
-    redraw_all_later(CLEAR);
+    redraw_all_later(NOT_VALID);
 
     apply_autocmds(EVENT_WINNEW, NULL, NULL, false, curbuf);
     apply_autocmds(EVENT_WINENTER, NULL, NULL, false, curbuf);
@@ -3310,10 +3311,9 @@ static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, int trigger_enter_au
                 trigger_enter_autocmds, trigger_leave_autocmds);
   prevwin = next_prevwin;
 
-  last_status(FALSE);           /* status line may appear or disappear */
-  (void)win_comp_pos();         /* recompute w_winrow for all windows */
-  must_redraw = CLEAR;          /* need to redraw everything */
-  diff_need_scrollbind = TRUE;
+  last_status(false);  // status line may appear or disappear
+  (void)win_comp_pos();  // recompute w_winrow for all windows
+  diff_need_scrollbind = true;
 
   /* The tabpage line may have appeared or disappeared, may need to resize
    * the frames for that.  When the Vim window was resized need to update
@@ -3335,7 +3335,7 @@ static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, int trigger_enter_au
       apply_autocmds(EVENT_BUFENTER, NULL, NULL, FALSE, curbuf);
   }
 
-  redraw_all_later(CLEAR);
+  redraw_all_later(NOT_VALID);
 }
 
 /*
@@ -5443,7 +5443,7 @@ restore_snapshot (
     win_comp_pos();
     if (wp != NULL && close_curwin)
       win_goto(wp);
-    redraw_all_later(CLEAR);
+    redraw_all_later(NOT_VALID);
   }
   clear_snapshot(curtab, idx);
 }

--- a/test/functional/eval/input_spec.lua
+++ b/test/functional/eval/input_spec.lua
@@ -149,7 +149,7 @@ describe('input()', function()
       {EOB:~                        }|
       {T:Foo>}Bar^                  |
     ]])
-    command('redraw!')
+    command('mode')
     screen:expect{grid=[[
                                |
       {EOB:~                        }|
@@ -165,7 +165,7 @@ describe('input()', function()
       {EOB:~                        }|
       {T:Foo>}Ba^                   |
     ]])
-    command('redraw!')
+    command('mode')
     screen:expect{grid=[[
                                |
       {EOB:~                        }|
@@ -347,7 +347,7 @@ describe('inputdialog()', function()
       {EOB:~                        }|
       {T:Foo>}Bar^                  |
     ]])
-    command('redraw!')
+    command('mode')
     screen:expect{grid=[[
                                |
       {EOB:~                        }|
@@ -363,7 +363,7 @@ describe('inputdialog()', function()
       {EOB:~                        }|
       {T:Foo>}Ba^                   |
     ]])
-    command('redraw!')
+    command('mode')
     screen:expect{grid=[[
                                |
       {EOB:~                        }|

--- a/test/functional/ui/cmdline_highlight_spec.lua
+++ b/test/functional/ui/cmdline_highlight_spec.lua
@@ -32,7 +32,7 @@ before_each(function()
     highlight RBP4 guibg=Blue
     let g:NUM_LVLS = 4
     function Redraw()
-      redraw!
+      mode
       return ''
     endfunction
     let g:id = ''

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -253,7 +253,7 @@ local function test_cmdline(linegrid)
     ]], cmdline=expectation}
 
     -- erase information, so we check if it is retransmitted
-    command("redraw!")
+    command("mode")
     screen:expect{grid=[[
       ^                         |
       {1:~                        }|
@@ -320,7 +320,7 @@ local function test_cmdline(linegrid)
       {{'  line1'}},
     }}
 
-    command("redraw!")
+    command("mode")
     screen:expect{grid=[[
       ^                         |
       {1:~                        }|
@@ -411,7 +411,7 @@ local function test_cmdline(linegrid)
       pos = 4,
     }}}
 
-    command("redraw!")
+    command("mode")
     screen:expect{grid=[[
                                |
       {2:[No Name]                }|
@@ -435,9 +435,9 @@ local function test_cmdline(linegrid)
 
     feed("<c-c>")
     screen:expect{grid=[[
-                               |
+      ^                         |
       {2:[No Name]                }|
-      {1::}make^                    |
+      {1::}make                    |
       {3:[Command Line]           }|
                                |
     ]], cmdline={{
@@ -446,7 +446,6 @@ local function test_cmdline(linegrid)
       pos = 4,
     }}}
 
-    screen.cmdline = {}
     command("redraw!")
     screen:expect{grid=[[
       ^                         |

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -65,7 +65,7 @@ describe("folded lines", function()
       {1:~                                            }|
       {1:~                                            }|
       {1:~                                            }|
-                                                   |
+      :set noarabicshape                           |
     ]])
 
     feed_command("set number foldcolumn=2")
@@ -114,7 +114,7 @@ describe("folded lines", function()
       {1:                                            ~}|
       {1:                                            ~}|
       {1:                                            ~}|
-                                                   |
+      :set arabicshape                             |
     ]])
 
     feed('zo')
@@ -126,7 +126,7 @@ describe("folded lines", function()
       {1:                                            ~}|
       {1:                                            ~}|
       {1:                                            ~}|
-                                                   |
+      :set arabicshape                             |
     ]])
 
     feed_command('set noarabicshape')
@@ -138,7 +138,7 @@ describe("folded lines", function()
       {1:                                            ~}|
       {1:                                            ~}|
       {1:                                            ~}|
-                                                   |
+      :set noarabicshape                           |
     ]])
 
   end)

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -122,7 +122,7 @@ describe('highlight defaults', function()
       {0:~                                                    }|
       {0:~                                                    }|
       {2:[No Name]                                            }|
-                                                           |
+      :vsp                                                 |
     ]])
     -- navigate to verify that the attributes are properly moved
     feed('<c-w>j')
@@ -140,7 +140,7 @@ describe('highlight defaults', function()
       {0:~                                                    }|
       {0:~                                                    }|
       {1:[No Name]                                            }|
-                                                           |
+      :vsp                                                 |
     ]])
     -- note that when moving to a window with small width nvim will increase
     -- the width of the new active window at the expense of a inactive window
@@ -160,7 +160,7 @@ describe('highlight defaults', function()
       {0:~                                                    }|
       {0:~                                                    }|
       {2:[No Name]                                            }|
-                                                           |
+      :vsp                                                 |
     ]])
     feed('<c-w>l')
     screen:expect([[
@@ -177,7 +177,7 @@ describe('highlight defaults', function()
       {0:~                                                    }|
       {0:~                                                    }|
       {2:[No Name]                                            }|
-                                                           |
+      :vsp                                                 |
     ]])
     feed('<c-w>h<c-w>h')
     screen:expect([[
@@ -194,7 +194,7 @@ describe('highlight defaults', function()
       {0:~                                                    }|
       {0:~                                                    }|
       {2:[No Name]                                            }|
-                                                           |
+      :vsp                                                 |
     ]])
   end)
 

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -530,7 +530,7 @@ describe('ui/mouse/input', function()
       mouse                    |
       support and selectio^n    |
       {0:~                        }|
-                               |
+      :tabprevious             |
     ]])
     feed('<LeftMouse><10,0><LeftRelease>')  -- go to second tab
     helpers.wait()
@@ -540,7 +540,7 @@ describe('ui/mouse/input', function()
       ^this is bar              |
       {0:~                        }|
       {0:~                        }|
-                               |
+      :tabprevious             |
     ]])
     feed('<LeftDrag><4,1>')
     screen:expect([[


### PR DESCRIPTION
Avoid clearing the screen in most situations, as discussed in  https://github.com/neovim/neovim/issues/9006#issuecomment-421811512 for instance. `NOT_VALID` should be equivalent to `CLEAR` unless some external force messed up the terminal, for these situations `<c-l>` and `:mode` will still clear the screen.

Also eliminate some obsolete code in `screen.c`, that dealt with that in vim drawing window 1 can mess up window 2, but this never happens in nvim. 

## But what about slow terminals?

"Slow" terminals in the discussions I've seen mean two different things.

Most commonly (and in the sense of vim:s `nottyfast`) it means low bandwidth for sending bytes from nvim to the terminal. If the screen is very similar before and after the `update_screen(CLEAR)` this change should reduce bandwidth. If the screen is quite different, but there is no new regions of contiguous whitespace, clearing doesn't reduce bandwidth significantly. If the new screen contains a lot of whitespace, it will depend of if vsplits are used or not: as long as there is no vsplits, `ce` is used to cheaply clear the rest of the line, so full-screen clear is not needed to reduce bandwith. However a left vsplit currently needs to be padded with whitespace all the way to the separator. It is possible `ec` (clear N chars) can be used to reduce bandwidth here if this is a problem. (All of this assumes that one doesn't set `Normal guibg=...` on a non-BCE terminal, if you do you are doomed regardless of this change).

Slow can also mean that drawing pixels on the screen is slow. [E-ink screens](https://alternativebit.fr/posts/ultimate-writer/) come to mind as a recent example. Avoiding clearing and redrawing the unchanged part of the screen will always improve performance in these cases.
