### PR TITLE
Add autocmd MessageAdd

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -346,6 +346,8 @@ Name			triggered by ~
 
 |User|			to be used in combination with ":doautocmd"
 
+|MessageAdd|		after a message was added to |message-history|
+
 
 The alphabetical list of autocommand events:		*autocmd-events-abc*
 
@@ -818,6 +820,9 @@ MenuPopup			Just before showing the popup menu (under the
 					o	Operator-pending
 					i	Insert
 					c	Command line
+
+							*MessageAdd*
+MessageAdd			After a message is added to |message-history|.
 							*OptionSet*
 OptionSet			After setting an option.  The pattern is
 				matched against the long option name.

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -64,6 +64,7 @@ return {
     'InsertLeave',            -- when leaving Insert mode
     'JobActivity',            -- when job sent some data
     'MenuPopup',              -- just before popup menu is displayed
+    'MessageAdd',             -- after a message is added
     'OptionSet',              -- after setting any option
     'QuickFixCmdPost',        -- after :make, :grep etc.
     'QuickFixCmdPre',         -- before :make, :grep etc.
@@ -118,5 +119,6 @@ return {
     TabNewEntered=true,
     TermClose=true,
     TermOpen=true,
+    MessageAdd=true,
   },
 }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -6873,6 +6873,7 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
         || event == EVENT_DIRCHANGED
         || event == EVENT_FILETYPE
         || event == EVENT_FUNCUNDEFINED
+        || event == EVENT_MESSAGEADD
         || event == EVENT_OPTIONSET
         || event == EVENT_QUICKFIXCMDPOST
         || event == EVENT_QUICKFIXCMDPRE

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -745,6 +745,7 @@ static void add_msg_hist(const char *s, int len, int attr)
   if (first_msg_hist == NULL)
     first_msg_hist = last_msg_hist;
   ++msg_hist_len;
+  apply_autocmds(EVENT_MESSAGEADD, NULL, NULL, FALSE, curbuf);
 }
 
 /*

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -744,8 +744,8 @@ static void add_msg_hist(const char *s, int len, int attr)
   last_msg_hist = p;
   if (first_msg_hist == NULL)
     first_msg_hist = last_msg_hist;
-  ++msg_hist_len;
-  apply_autocmds(EVENT_MESSAGEADD, NULL, NULL, FALSE, curbuf);
+  msg_hist_len++;
+  apply_autocmds(EVENT_MESSAGEADD, NULL, NULL, false, curbuf);
 }
 
 /*

--- a/test/functional/autocmd/messageadd_spec.lua
+++ b/test/functional/autocmd/messageadd_spec.lua
@@ -1,0 +1,43 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear, command =
+  helpers.clear, helpers.command
+local eval, eq =
+  helpers.eval, helpers.eq
+local meths = helpers.meths
+local feed = helpers.feed
+local insert = helpers.insert
+
+
+describe('autocmd MessageAdd', function()
+  before_each(clear)
+
+  it('triggered by echomsg', function()
+    command('autocmd MessageAdd * let g:test = 1')
+    command('echomsg "msg"')
+    eq(1, eval('g:test'))
+    eq('msg', meths.command_output('messages'))
+  end)
+
+  it('triggered by echoerr', function()
+    command('autocmd MessageAdd * let g:test = 2')
+    feed(':echoerr "err"<cr>')
+    eq(2, eval('g:test'))
+    eq('err', meths.command_output('messages'))
+  end)
+
+  it('triggered by erroneous command', function()
+    command('autocmd MessageAdd * let g:test = 3')
+    feed(':thiscommandisfake<cr>')
+    eq(3, eval('g:test'))
+    eq('E492: Not an editor command: thiscommandisfake', meths.command_output('messages'))
+  end)
+
+  it('triggered by write', function()
+    command('autocmd MessageAdd * let g:test = 4')
+    insert('test')
+    feed(':write test_file<cr>')
+    eq(4, eval('g:test'))
+    os.remove('test_file')
+  end)
+end)


### PR DESCRIPTION
This PR adds a new autocmd for when new messages are added, the use-case that inspired me to implement it is for assistive technology, it would be nice if plugins could tell when an error occured (or similar status messages)