### PR TITLE
lua callbacks for nvim_buf_attach

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -199,6 +199,21 @@ paste a block of 6 lines, emits: >
 User reloads the buffer with ":edit", emits: >
   nvim_buf_detach_event[{buf}]
 
+                                                        *api-buffer-updates-lua*
+In-process lua plugins can also recieve buffer updates, in the form of lua
+callbacks. These callbacks are called frequently in various contexts, buffer
+contents or window layout should not be changed inside these |textlock|.
+
+|nvim_buf_attach| will take keyword args for the callbacks. "on_lines" will
+receive parameters ("lines", {buf}, {changedtick}, {firstline}, {lastline}, {new_lastline}).
+Unlike remote channels the text contents are not passed. The new text can be
+accessed inside the callback as
+`vim.api.nvim_buf_get_lines(buf, firstline, new_lastline, true)`
+"on_changedtick" is invoked when |b:changedtick| was incremented but no text
+was changed. The parameters recieved are ("changedtick", {buf}, {changedtick}).
+
+
+
 ==============================================================================
 Buffer highlighting					       *api-highlights*
 

--- a/src/clint.py
+++ b/src/clint.py
@@ -2539,6 +2539,8 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
                    r'(?<!\bkbtree_t)'
                    r'(?<!\bkbitr_t)'
                    r'(?<!\bPMap)'
+                   r'(?<!\bArrayOf)'
+                   r'(?<!\bDictionaryOf)'
                    r'\((?:const )?(?:struct )?[a-zA-Z_]\w*(?: *\*(?:const)?)*\)'
                    r' +'
                    r'-?(?:\*+|&)?(?:\w+|\+\+|--|\()', cast_line)

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -104,6 +104,7 @@ typedef enum {
   kObjectTypeString,
   kObjectTypeArray,
   kObjectTypeDictionary,
+  kObjectTypeLuaRef,
   // EXT types, cannot be split or reordered, see #EXT_OBJECT_TYPE_SHIFT
   kObjectTypeBuffer,
   kObjectTypeWindow,
@@ -119,6 +120,7 @@ struct object {
     String string;
     Array array;
     Dictionary dictionary;
+    LuaRef luaref;
   } data;
 };
 

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -11,6 +11,7 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/handle.h"
 #include "nvim/msgpack_rpc/helpers.h"
+#include "nvim/lua/executor.h"
 #include "nvim/ascii.h"
 #include "nvim/assert.h"
 #include "nvim/vim.h"
@@ -1145,6 +1146,10 @@ void api_free_object(Object value)
 
     case kObjectTypeDictionary:
       api_free_dictionary(value.data.dictionary);
+      break;
+
+    case kObjectTypeLuaRef:
+      executor_free_luaref(value.data.luaref);
       break;
 
     default:

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -48,6 +48,10 @@
     .type = kObjectTypeDictionary, \
     .data.dictionary = d })
 
+#define LUAREF_OBJ(r) ((Object) { \
+    .type = kObjectTypeLuaRef, \
+    .data.luaref = r })
+
 #define NIL ((Object) {.type = kObjectTypeNil})
 
 #define PUT(dict, k, v) \

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1836,6 +1836,8 @@ buf_T * buflist_new(char_u *ffname, char_u *sfname, linenr_T lnum, int flags)
   buf->b_p_bl = (flags & BLN_LISTED) ? true : false;    // init 'buflisted'
   kv_destroy(buf->update_channels);
   kv_init(buf->update_channels);
+  kv_destroy(buf->update_callbacks);
+  kv_init(buf->update_callbacks);
   if (!(flags & BLN_DUMMY)) {
     // Tricky: these autocommands may change the buffer list.  They could also
     // split the window with re-using the one empty buffer. This may result in

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -453,6 +453,12 @@ typedef struct {
 /// Primary exists so that literals of relevant type can be made.
 typedef TV_DICTITEM_STRUCT(sizeof("changedtick")) ChangedtickDictItem;
 
+typedef struct {
+  LuaRef on_lines;
+  LuaRef on_changedtick;
+} BufUpdateCallbacks;
+#define BUF_UPDATE_CALLBACKS_INIT { LUA_NOREF, LUA_NOREF }
+
 #define BUF_HAS_QF_ENTRY 1
 #define BUF_HAS_LL_ENTRY 2
 
@@ -796,6 +802,7 @@ struct file_buffer {
   // array of channelids which have asked to receive updates for this
   // buffer.
   kvec_t(uint64_t) update_channels;
+  kvec_t(BufUpdateCallbacks) update_callbacks;
 
   int b_diff_failed;    // internal diff failed for this buffer
 };

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -5,17 +5,28 @@
 #include "nvim/memline.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/msgpack_rpc/channel.h"
+#include "nvim/lua/executor.h"
 #include "nvim/assert.h"
 #include "nvim/buffer.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "buffer_updates.c.generated.h"
+#endif
 
 // Register a channel. Return True if the channel was added, or already added.
 // Return False if the channel couldn't be added because the buffer is
 // unloaded.
-bool buf_updates_register(buf_T *buf, uint64_t channel_id, bool send_buffer)
+bool buf_updates_register(buf_T *buf, uint64_t channel_id,
+                          BufUpdateCallbacks cb, bool send_buffer)
 {
   // must fail if the buffer isn't loaded
   if (buf->b_ml.ml_mfp == NULL) {
     return false;
+  }
+
+  if (channel_id == LUA_INTERNAL_CALL) {
+    kv_push(buf->update_callbacks, cb);
+    return true;
   }
 
   // count how many channels are currently watching the buffer
@@ -67,6 +78,11 @@ bool buf_updates_register(buf_T *buf, uint64_t channel_id, bool send_buffer)
   }
 
   return true;
+}
+
+bool buf_updates_active(buf_T *buf)
+{
+    return kv_size(buf->update_channels) || kv_size(buf->update_callbacks);
 }
 
 void buf_updates_send_end(buf_T *buf, uint64_t channelid)
@@ -125,6 +141,12 @@ void buf_updates_unregister_all(buf_T *buf)
     kv_destroy(buf->update_channels);
     kv_init(buf->update_channels);
   }
+
+  for (size_t i = 0; i < kv_size(buf->update_callbacks); i++) {
+    free_update_callbacks(kv_A(buf->update_callbacks, i));
+  }
+  kv_destroy(buf->update_callbacks);
+  kv_init(buf->update_callbacks);
 }
 
 void buf_updates_send_changes(buf_T *buf,
@@ -133,6 +155,10 @@ void buf_updates_send_changes(buf_T *buf,
                               int64_t num_removed,
                               bool send_tick)
 {
+  if (!buf_updates_active(buf)) {
+    return;
+  }
+
   // if one the channels doesn't work, put its ID here so we can remove it later
   uint64_t badchannelid = 0;
 
@@ -183,6 +209,47 @@ void buf_updates_send_changes(buf_T *buf,
     ELOG("Disabling buffer updates for dead channel %"PRIu64, badchannelid);
     buf_updates_unregister(buf, badchannelid);
   }
+
+  // notify each of the active channels
+  size_t j = 0;
+  for (size_t i = 0; i < kv_size(buf->update_callbacks); i++) {
+    BufUpdateCallbacks cb = kv_A(buf->update_callbacks, i);
+    bool keep = true;
+    if (cb.on_lines != LUA_NOREF) {
+      Array args = ARRAY_DICT_INIT;
+      Object items[5];
+      args.size = 5;
+      args.items = items;
+
+      // the first argument is always the buffer handle
+      args.items[0] = BUFFER_OBJ(buf->handle);
+
+      // next argument is b:changedtick
+      args.items[1] = send_tick ? INTEGER_OBJ(buf_get_changedtick(buf)) : NIL;
+
+      // the first line that changed (zero-indexed)
+      args.items[2] = INTEGER_OBJ(firstline - 1);
+
+      // the last line that was changed
+      args.items[3] = INTEGER_OBJ(firstline - 1 + num_removed);
+
+      // the last line in the updated range
+      args.items[4] = INTEGER_OBJ(firstline - 1 + num_added);
+
+      textlock++;
+      Object res = executor_exec_lua_cb(cb.on_lines, "lines", args);
+      textlock--;
+
+      if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
+        free_update_callbacks(cb);
+        keep = false;
+      }
+    }
+    if (keep) {
+      kv_A(buf->update_callbacks, j++) = kv_A(buf->update_callbacks, i);
+    }
+  }
+  kv_size(buf->update_callbacks) = j;
 }
 
 void buf_updates_changedtick(buf_T *buf)
@@ -192,6 +259,36 @@ void buf_updates_changedtick(buf_T *buf)
     uint64_t channel_id = kv_A(buf->update_channels, i);
     buf_updates_changedtick_single(buf, channel_id);
   }
+  size_t j = 0;
+  for (size_t i = 0; i < kv_size(buf->update_callbacks); i++) {
+    BufUpdateCallbacks cb = kv_A(buf->update_callbacks, i);
+    bool keep = true;
+    if (cb.on_changedtick != LUA_NOREF) {
+      Array args = ARRAY_DICT_INIT;
+      Object items[2];
+      args.size = 2;
+      args.items = items;
+
+      // the first argument is always the buffer handle
+      args.items[0] = BUFFER_OBJ(buf->handle);
+
+      // next argument is b:changedtick
+      args.items[1] = INTEGER_OBJ(buf_get_changedtick(buf));
+
+      textlock++;
+      Object res = executor_exec_lua_cb(cb.on_changedtick, "changedtick", args);
+      textlock--;
+
+      if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
+        free_update_callbacks(cb);
+        keep = false;
+      }
+    }
+    if (keep) {
+      kv_A(buf->update_callbacks, j++) = kv_A(buf->update_callbacks, i);
+    }
+  }
+  kv_size(buf->update_callbacks) = j;
 }
 
 void buf_updates_changedtick_single(buf_T *buf, uint64_t channel_id)
@@ -208,4 +305,10 @@ void buf_updates_changedtick_single(buf_T *buf, uint64_t channel_id)
 
     // don't try and clean up dead channels here
     rpc_send_event(channel_id, "nvim_buf_changedtick_event", args);
+}
+
+static void free_update_callbacks(BufUpdateCallbacks cb)
+{
+  executor_free_luaref(cb.on_lines);
+  executor_free_luaref(cb.on_changedtick);
 }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -900,9 +900,7 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
   changed_lines(last_line - num_lines + 1, 0, last_line + 1, -extra, false);
 
   // send update regarding the new lines that were added
-  if (kv_size(curbuf->update_channels)) {
-    buf_updates_send_changes(curbuf, dest + 1, num_lines, 0, true);
-  }
+  buf_updates_send_changes(curbuf, dest + 1, num_lines, 0, true);
 
   /*
    * Now we delete the original text -- webb
@@ -939,9 +937,7 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
   }
 
   // send nvim_buf_lines_event regarding lines that were deleted
-  if (kv_size(curbuf->update_channels)) {
-    buf_updates_send_changes(curbuf, line1 + extra, 0, num_lines, true);
-  }
+  buf_updates_send_changes(curbuf, line1 + extra, 0, num_lines, true);
 
   return OK;
 }
@@ -4074,12 +4070,10 @@ skip:
     i = curbuf->b_ml.ml_line_count - old_line_count;
     changed_lines(first_line, 0, last_line - i, i, false);
 
-    if (kv_size(curbuf->update_channels)) {
-      int64_t num_added = last_line - first_line;
-      int64_t num_removed = num_added - i;
-      buf_updates_send_changes(curbuf, first_line, num_added, num_removed,
-                               do_buf_event);
-    }
+    int64_t num_added = last_line - first_line;
+    int64_t num_removed = num_added - i;
+    buf_updates_send_changes(curbuf, first_line, num_added, num_removed,
+                             do_buf_event);
   }
 
   xfree(sub_firstline);   /* may have to free allocated copy of the line */

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -737,15 +737,13 @@ void deleteFold(
     changed_lines(first_lnum, (colnr_T)0, last_lnum, 0L, false);
 
     // send one nvim_buf_lines_event at the end
-    if (kv_size(curbuf->update_channels)) {
-      // last_lnum is the line *after* the last line of the outermost fold
-      // that was modified. Note also that deleting a fold might only require
-      // the modification of the *first* line of the fold, but we send through a
-      // notification that includes every line that was part of the fold
-      int64_t num_changed = last_lnum - first_lnum;
-      buf_updates_send_changes(curbuf, first_lnum, num_changed,
-                               num_changed, true);
-    }
+    // last_lnum is the line *after* the last line of the outermost fold
+    // that was modified. Note also that deleting a fold might only require
+    // the modification of the *first* line of the fold, but we send through a
+    // notification that includes every line that was part of the fold
+    int64_t num_changed = last_lnum - first_lnum;
+    buf_updates_send_changes(curbuf, first_lnum, num_changed,
+                             num_changed, true);
   }
 }
 
@@ -1584,13 +1582,11 @@ static void foldCreateMarkers(linenr_T start, linenr_T end)
    * changed when the start marker is inserted and the end isn't. */
   changed_lines(start, (colnr_T)0, end, 0L, false);
 
-  if (kv_size(curbuf->update_channels)) {
-    // Note: foldAddMarker() may not actually change start and/or end if
-    // u_save() is unable to save the buffer line, but we send the
-    // nvim_buf_lines_event anyway since it won't do any harm.
-    int64_t num_changed = 1 + end - start;
-    buf_updates_send_changes(curbuf, start, num_changed, num_changed, true);
-  }
+  // Note: foldAddMarker() may not actually change start and/or end if
+  // u_save() is unable to save the buffer line, but we send the
+  // nvim_buf_lines_event anyway since it won't do any harm.
+  int64_t num_changed = 1 + end - start;
+  buf_updates_send_changes(curbuf, start, num_changed, num_changed, true);
 }
 
 /* foldAddMarker() {{{2 */

--- a/src/nvim/lua/executor.h
+++ b/src/nvim/lua/executor.h
@@ -2,6 +2,7 @@
 #define NVIM_LUA_EXECUTOR_H
 
 #include <lua.h>
+#include <lauxlib.h>
 
 #include "nvim/api/private/defs.h"
 #include "nvim/func_attr.h"

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1847,9 +1847,7 @@ void changed_bytes(linenr_T lnum, colnr_T col)
   changedOneline(curbuf, lnum);
   changed_common(lnum, col, lnum + 1, 0L);
   // notify any channels that are watching
-  if (kv_size(curbuf->update_channels)) {
-    buf_updates_send_changes(curbuf, lnum, 1, 1, true);
-  }
+  buf_updates_send_changes(curbuf, lnum, 1, 1, true);
 
   /* Diff highlighting in other diff windows may need to be updated too. */
   if (curwin->w_p_diff) {
@@ -1973,7 +1971,7 @@ changed_lines(
 
   changed_common(lnum, col, lnume, xtra);
 
-  if (do_buf_event && kv_size(curbuf->update_channels)) {
+  if (do_buf_event) {
     int64_t num_added = (int64_t)(lnume + xtra - lnum);
     int64_t num_removed = lnume - lnum;
     buf_updates_send_changes(curbuf, lnum, num_added, num_removed, true);

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -253,7 +253,8 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
           case kObjectTypeFloat:
           case kObjectTypeString:
           case kObjectTypeArray:
-          case kObjectTypeDictionary: {
+          case kObjectTypeDictionary:
+          case kObjectTypeLuaRef: {
             break;
           }
         }
@@ -384,6 +385,13 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
                   "Buffer, window and tabpage enum items are in order");
     switch (cur.aobj->type) {
       case kObjectTypeNil: {
+        msgpack_pack_nil(res);
+        break;
+      }
+      case kObjectTypeLuaRef: {
+        // TODO(bfredl): could also be an error. Though kObjectTypeLuaRef
+        // should only appear when the caller has opted in to handle references,
+        // see nlua_pop_Object.
         msgpack_pack_nil(res);
         break;
       }

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -16,6 +16,11 @@ typedef uint32_t u8char_T;
 // Opaque handle used by API clients to refer to various objects in vim
 typedef int handle_T;
 
+// Opaque handle to a lua value. Must be free with `executor_free_luaref` when
+// not needed anymore! LUA_NOREF represents missing reference, i e to indicate
+// absent callback etc.
+typedef int LuaRef;
+
 typedef struct expand expand_T;
 
 #endif  // NVIM_TYPES_H

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2299,7 +2299,7 @@ static void u_undoredo(int undo, bool do_buf_event)
   // because the calls to changed()/unchanged() above will bump changedtick
   // again, we need to send a nvim_buf_lines_event with just the new value of
   // b:changedtick
-  if (do_buf_event && kv_size(curbuf->update_channels)) {
+  if (do_buf_event) {
     buf_updates_changedtick(curbuf);
   }
 

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -760,7 +760,7 @@ describe('API: buffer events:', function()
   it('returns a proper error on nonempty options dict', function()
     clear()
     local b = editoriginal(false)
-    expect_err("dict isn't empty", buffer, 'attach', b, false, {builtin="asfd"})
+    expect_err("unexpected key: builtin", buffer, 'attach', b, false, {builtin="asfd"})
   end)
 
   it('nvim_buf_attach returns response after delay #8634', function()


### PR DESCRIPTION
I want to respond to detailed buffer change events in an in-process lua plugin. Currently these events are available only for rplugins. In general I think we want to accept lua callbacks in API `_attach' methods. Another application that has been discussed is lua code rendering "external" UI elements by subscribing to the high-level UI events.

This patch sketches the following:
```lua
local a = vim.api
function thecb(...)
  -- args are "nvim_buf_lines_event", 1, 85, 8, 8, { "" }, false
  print(require'inspect'({..}))
 -- return true to unsubscribe (not implemented yet)
end

a.nvim_buf_attach(0, false, {on_event=thecb})
print(require'inspect'(lastargs))
```

The usual caveats about incomplete implementation of lowest-effort design apply, suggestions welcome. Some considerations:

This design passes different event kinds to the same callback, an alterative would be to register one callback for update, changedtick and detach events. The later would imply that `api.nvim_ui_attach(..., {'on_popupmenu_show': on_show, ...})` implicitly filters out only the interesting events, though we could of course make event subgroups opt-in also for the single callback approach.

The current implementation adds lua references to recursive `Object` structures, which would affect everything that dispatches over object types, I'm not sure we really want this. An alternatively that doesn't touch Object semantics or go deep into serialization logic, would be to just allow a `union{Dictionary,LuaRef}` top-level type for parameters to API functions (the visible metadata type will still be `Dictionary`). Then the function implementation will do all the unpacking of the lua table containing references itself.

Unlike rpc clients, the lua callback can reliably get the changed text using `get_lines` if it wants to. If the callback doesn't use the actual text, only the range information, the text would have been converted to lua strings for no reason, which would be costly for larger changes.  As an example, the tree-sitter library has one API function to mark a region as changed, which one would call in the change event, and another function to actually reparse the tree, which could be done later when the tree is really needed. Though we could keep the same behavior by default, and disable sending text with a flag (which then would be available also for RPC clients).