### PR TITLE
[WIP] vim-patch:8.0.0411

### DIFF
--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1520,7 +1520,7 @@ static char_u *menutrans_lookup(char_u *name, int len)
   char_u              *dname;
 
   for (int i = 0; i < menutrans_ga.ga_len; i++) {
-    if (STRNCMP(name, tp[i].from, len) == 0 && tp[i].from[len] == NUL) {
+    if (STRNICMP(name, tp[i].from, len) == 0 && tp[i].from[len] == NUL) {
       return tp[i].to;
     }
   }
@@ -1531,7 +1531,7 @@ static char_u *menutrans_lookup(char_u *name, int len)
   dname = menu_text(name, NULL, NULL);
   name[len] = c;
   for (int i = 0; i < menutrans_ga.ga_len; i++) {
-    if (STRCMP(dname, tp[i].from_noamp) == 0) {
+    if (STRICMP(dname, tp[i].from_noamp) == 0) {
       xfree(dname);
       return tp[i].to;
     }

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -1,9 +1,29 @@
 " Test that the system menu can be loaded.
 
+if !has('menu')
+  finish
+endif
+
 func Test_load_menu()
   try
     source $VIMRUNTIME/menu.vim
   catch
     call assert_report('error while loading menus: ' . v:exception)
   endtry
+  source $VIMRUNTIME/delmenu.vim
+endfunc
+
+func Test_translate_menu()
+  if !has('multi_lang')
+    return
+  endif
+  if !filereadable($VIMRUNTIME . '/lang/menu_de_de.latin1.vim')
+    throw 'Skipped: translated menu not found'
+  endif
+
+  set langmenu=de_de
+  source $VIMRUNTIME/menu.vim
+  call assert_match(':browse tabnew', execute(':menu File.In\ neuem\ Tab\ öffnen\.\.\.'))
+
+  source $VIMRUNTIME/delmenu.vim
 endfunc


### PR DESCRIPTION
#### vim-patch:8.0.0411: menu translations don't match when case is changed.

Problem:    We can't change the case in menu entries, it breaks translations.
Solution:   Ignore case when looking up a menu translation.
https://github.com/vim/vim/commit/11dd8c1201033dd74e2ea665ba277425b4b965b0