### PR TITLE
vim-patch:8.1.0501

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3709,9 +3709,9 @@ static void ml_updatechunk(buf_T *buf, linenr_T line, long len, int updtype)
          curix++) {
       curline += buf->b_ml.ml_chunksize[curix].mlcs_numlines;
     }
-  } else if (line >= curline + buf->b_ml.ml_chunksize[curix].mlcs_numlines
-             && curix < buf->b_ml.ml_usedchunks - 1) {
-    /* Adjust cached curix & curline */
+  } else if (curix < buf->b_ml.ml_usedchunks - 1
+             && line >= curline + buf->b_ml.ml_chunksize[curix].mlcs_numlines) {
+    // Adjust cached curix & curline
     curline += buf->b_ml.ml_chunksize[curix].mlcs_numlines;
     curix++;
   }


### PR DESCRIPTION
vim-patch:8.1.0501: cppcheck warns for using array index before bounds check

Problem:    Cppcheck warns for using array index before bounds check.
Solution:   Swap the conditions. (Dominique Pelle)
https://github.com/vim/vim/commit/a9a8e04eab106c1d21381f79f8965fe50b94e235