### PR TITLE
vim-patch:8.0.{1758,1766}

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1096,7 +1096,7 @@ static int insert_handle_key(InsertState *s)
       cmdwin_result = CAR;
       return 0;
     }
-    if (ins_eol(s->c) && !p_im) {
+    if (!ins_eol(s->c) && !p_im) {
       return 0;  // out of memory
     }
     auto_format(false, false);
@@ -8356,7 +8356,7 @@ static bool ins_tab(void)
 
 /// Handle CR or NL in insert mode.
 ///
-/// @return true when it can't undo.
+/// @return false when it can't undo.
 static bool ins_eol(int c)
 {
   if (echeck_abbr(c + ABBR_OFF)) {
@@ -8405,7 +8405,7 @@ static bool ins_eol(int c)
   // When inserting a line the cursor line must never be in a closed fold.
   foldOpenCursor();
 
-  return !i;
+  return i;
 }
 
 /*

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -8360,10 +8360,10 @@ static bool ins_tab(void)
 static bool ins_eol(int c)
 {
   if (echeck_abbr(c + ABBR_OFF)) {
-    return false;
+    return true;
   }
   if (stop_arrow() == FAIL) {
-    return true;
+    return false;
   }
   undisplay_dollar();
 

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -98,7 +98,7 @@ open_line (
   colnr_T newcol = 0;             // new cursor column
   int newindent = 0;              // auto-indent of the new line
   bool trunc_line = false;        // truncate current line afterwards
-  bool retval = false;            // return value, default is false
+  bool retval = false;            // return value
   int extra_len = 0;              // length of p_extra string
   int lead_len;                   // length of comment leader
   char_u *lead_flags;             // position in 'comments' for comment leader
@@ -922,7 +922,7 @@ open_line (
     next_line = NULL;
   }
 
-  retval = TRUE;                /* success! */
+  retval = true;                // success!
 theend:
   curbuf->b_p_pi = saved_pi;
   xfree(saved_line);

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -214,3 +214,19 @@ func Test_cabbr_visual_mode()
   call assert_equal(expected, getreg(':'))
   cunabbr s
 endfunc
+
+func Test_abbreviation_CR()
+  new
+  func Eatchar(pat)
+    let c = nr2char(getchar(0))
+    return (c =~ a:pat) ? '' : c
+  endfunc
+  iabbrev <buffer><silent> ~~7 <c-r>=repeat('~', 7)<CR><c-r>=Eatchar('\s')<cr>
+  call feedkeys("GA~~7 \<esc>", 'xt')
+  call assert_equal('~~~~~~~', getline('$'))
+  %d
+  call feedkeys("GA~~7\<cr>\<esc>", 'xt')
+  call assert_equal(['~~~~~~~', ''], getline(1,'$'))
+  delfunc Eatchar
+  bw!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.1758: open_line() returns TRUE/FALSE for success/failure**

Problem:    open_line() returns TRUE/FALSE for success/failure.
Solution:   Return OK or FAIL.
vim/vim@24a2d72

**vim-patch:8.0.1766: expanding abbreviation doesn't work**

Problem:    Expanding abbreviation doesn't work. (Tooth Pik)
Solution:   Return OK instead of FALSE and FAIL instead of TRUE. (Christian Brabandt)
vim/vim@c3c3e69