### PR TITLE
Don't enable set_cursor_color if vte_version < 3900 (#9089)

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1814,14 +1814,17 @@ static void augment_terminfo(TUIData *data, const char *term,
     // would use a tmux control sequence and an extra if(screen) test.
     data->unibi_ext.set_cursor_color = (int)unibi_add_ext_str(
         ut, NULL, TMUX_WRAP(tmux, "\033]Pl%p1%06x\033\\"));
-  } else if (xterm || (vte_version != 0) || rxvt) {
+  } else if ((xterm || rxvt) && ((vte_version == 0) || (vte_version >= 3900))) {
     // This seems to be supported for a long time in VTE
     // urxvt also supports this
     data->unibi_ext.set_cursor_color = (int)unibi_add_ext_str(
         ut, "ext.set_cursor_color", "\033]12;#%p1%06x\007");
   }
-  data->unibi_ext.reset_cursor_color = (int)unibi_add_ext_str(
-      ut, "ext.reset_cursor_color", "\x1b]112\x07");
+
+  if (-1 != data->unibi_ext.set_cursor_color) {
+    data->unibi_ext.reset_cursor_color = (int)unibi_add_ext_str(
+        ut, "ext.reset_cursor_color", "\x1b]112\x07");
+  }
 
   /// Terminals usually ignore unrecognized private modes, and there is no
   /// known ambiguity with these. So we just set them unconditionally.


### PR DESCRIPTION
Trying out a fix for issue #9089, but I doubt this is how terminal feature checks are supposed to work.