### PR TITLE
vim-patch:8.1.0504

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -468,7 +468,10 @@ static void insert_enter(InsertState *s)
   }
 
   foldUpdateAfterInsert();
-  if (s->cmdchar != 'r' && s->cmdchar != 'v') {
+  // When CTRL-C was typed got_int will be set, with the result
+  // that the autocommands won't be executed. When mapped got_int
+  // is not set, but let's keep the behavior the same.
+  if (s->cmdchar != 'r' && s->cmdchar != 'v' && s->c != Ctrl_C) {
     ins_apply_autocmds(EVENT_INSERTLEAVE);
   }
   did_cursorhold = false;

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1413,3 +1413,33 @@ func Test_edit_alt()
   bwipe XAltFile
   call delete('XAltFile')
 endfunc
+
+func Test_leave_insert_autocmd()
+  new
+  au InsertLeave * let g:did_au = 1
+  let g:did_au = 0
+  call feedkeys("afoo\<Esc>", 'tx')
+  call assert_equal(1, g:did_au)
+  call assert_equal('foo', getline(1))
+
+  let g:did_au = 0
+  call feedkeys("Sbar\<C-C>", 'tx')
+  call assert_equal(0, g:did_au)
+  call assert_equal('bar', getline(1))
+
+  inoremap x xx<Esc>
+  let g:did_au = 0
+  call feedkeys("Saax", 'tx')
+  call assert_equal(1, g:did_au)
+  call assert_equal('aaxx', getline(1))
+
+  inoremap x xx<C-C>
+  let g:did_au = 0
+  call feedkeys("Sbbx", 'tx')
+  call assert_equal(0, g:did_au)
+  call assert_equal('bbxx', getline(1))
+
+  bwipe!
+  au! InsertLeave
+  iunmap x
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0504: when CTRL-C is mapped it triggers InsertLeave**

Problem:    When CTRL-C is mapped it triggers InsertLeave.
Solution:   Make CTRL-C behave the same way when typed or used in a mapping.
https://github.com/vim/vim/commit/4dbc2627641a6b950c30c31cbf7b7e6c36da1927