### PR TITLE
UI/TUI: improvements and cleanups for scrolling and clearing

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -325,14 +325,14 @@ numerical highlight `id`:s to the actual attributes.
 		+-------------------------+ src_top    |
 		| src (moved up) and dst  |            |
 		|-------------------------| dst_bot    |
-		| src (cleared)           |            |
+		| src (invalid)           |            |
 		+=========================+ src_bot
 <
 	If `rows` is less than zero, move a rectangle in the SR down, this can
 	happen while scrolling up.
 >
 		+=========================+ src_top
-		| src (cleared)           |            |
+		| src (invalid)           |            |
 		|------------------------ | dst_top    |
 		| src (moved down) and dst|            |
 		+-------------------------+ src_bot    |
@@ -347,6 +347,10 @@ numerical highlight `id`:s to the actual attributes.
 	Note when updating code from |ui-grid-old| events: ranges are
 	end-exclusive, which is consistent with API conventions, but different
 	from `set_scroll_region` which was end-inclusive.
+
+	The scrolled-in area will be filled using |ui-event-grid_line| directly
+	after the scroll event. The UI thus doesn't need to clear this area as
+	part of handling the scroll event.
 
 ==============================================================================
 Legacy Grid Events (cell based)					   *ui-grid-old*

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -37,17 +37,6 @@ typedef struct attr_entry {
   .cterm_bg_color = 0, \
 }
 
-// sentinel value that compares unequal to any valid highlight
-#define HLATTRS_INVALID (HlAttrs) { \
-  .rgb_ae_attr = -1, \
-  .cterm_ae_attr = -1, \
-  .rgb_fg_color = -1, \
-  .rgb_bg_color = -1, \
-  .rgb_sp_color = -1, \
-  .cterm_fg_color = 0, \
-  .cterm_bg_color = 0, \
-}
-
 /// Values for index in highlight_attr[].
 /// When making changes, also update hlf_names below!
 typedef enum {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1896,6 +1896,9 @@ static void msg_scroll_up(void)
   } else {
     screen_del_lines(0, 1, (int)Rows, 0, Columns);
   }
+  // TODO(bfredl): when msgsep display is properly batched, this fill should be
+  // eliminated.
+  screen_fill(Rows-1, Rows, 0, (int)Columns, ' ', ' ', 0);
 }
 
 /*
@@ -2311,6 +2314,7 @@ static int do_more_prompt(int typed_char)
 
           if (toscroll == -1
               && screen_ins_lines(0, 1, (int)Rows, 0, (int)Columns) == OK) {
+            screen_fill(0, 1, 0, (int)Columns, ' ', ' ', 0);
             // display line at top
             (void)disp_sb_line(0, mp);
           } else {

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -918,9 +918,9 @@ void curs_columns(
 
     extra = ((int)prev_skipcol - (int)curwin->w_skipcol) / width;
     if (extra > 0) {
-      win_ins_lines(curwin, 0, extra, false);
+      win_ins_lines(curwin, 0, extra);
     } else if (extra < 0) {
-      win_del_lines(curwin, 0, -extra, false);
+      win_del_lines(curwin, 0, -extra);
     }
   } else {
     curwin->w_skipcol = 0;

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -104,7 +104,8 @@ typedef struct {
   cursorentry_T cursor_shapes[SHAPE_IDX_COUNT];
   HlAttrs clear_attrs;
   kvec_t(HlAttrs) attrs;
-  HlAttrs print_attrs;
+  int print_attr_id;
+  bool has_bg;
   bool default_attr;
   ModeShape showing_mode;
   struct {
@@ -186,6 +187,7 @@ static void terminfo_start(UI *ui)
   data->scroll_region_is_full_screen = true;
   data->bufpos = 0;
   data->default_attr = false;
+  data->has_bg = false;
   data->is_invisible = true;
   data->busy = false;
   data->cork = false;
@@ -305,7 +307,7 @@ static void terminfo_stop(UI *ui)
 static void tui_terminal_start(UI *ui)
 {
   TUIData *data = ui->data;
-  data->print_attrs = HLATTRS_INVALID;
+  data->print_attr_id = -1;
   ugrid_init(&data->grid);
   terminfo_start(ui);
   update_size(ui);
@@ -439,8 +441,17 @@ static void sigwinch_cb(SignalWatcher *watcher, int signum, void *data)
   ui_schedule_refresh();
 }
 
-static bool attrs_differ(HlAttrs a1, HlAttrs a2, bool rgb)
+static bool attrs_differ(UI *ui, int id1, int id2, bool rgb)
 {
+  TUIData *data = ui->data;
+  if (id1 == id2) {
+    return false;
+  } else if (id1 < 0 || id2 < 0) {
+    return true;
+  }
+  HlAttrs a1 = kv_A(data->attrs, (size_t)id1);
+  HlAttrs a2 = kv_A(data->attrs, (size_t)id2);
+
   if (rgb) {
     return a1.rgb_fg_color != a2.rgb_fg_color
       || a1.rgb_bg_color != a2.rgb_bg_color
@@ -455,21 +466,16 @@ static bool attrs_differ(HlAttrs a1, HlAttrs a2, bool rgb)
   }
 }
 
-static bool no_bg(UI *ui, HlAttrs attrs)
-{
-  return  ui->rgb ? attrs.rgb_bg_color == -1
-                  : attrs.cterm_bg_color == 0;
-}
-
-static void update_attrs(UI *ui, HlAttrs attrs)
+static void update_attrs(UI *ui, int attr_id)
 {
   TUIData *data = ui->data;
 
-  if (!attrs_differ(attrs, data->print_attrs, ui->rgb)) {
+  if (!attrs_differ(ui, attr_id, data->print_attr_id, ui->rgb)) {
+    data->print_attr_id = attr_id;
     return;
   }
-
-  data->print_attrs = attrs;
+  data->print_attr_id = attr_id;
+  HlAttrs attrs = kv_A(data->attrs, (size_t)attr_id);
 
   int fg = ui->rgb ? attrs.rgb_fg_color : (attrs.cterm_fg_color - 1);
   if (fg == -1) {
@@ -482,6 +488,8 @@ static void update_attrs(UI *ui, HlAttrs attrs)
     bg = ui->rgb ? data->clear_attrs.rgb_bg_color
                  : (data->clear_attrs.cterm_bg_color - 1);
   }
+
+  data->has_bg = bg != -1;
 
   int attr = ui->rgb ? attrs.rgb_ae_attr : attrs.cterm_ae_attr;
   bool bold = attr & HL_BOLD;
@@ -599,7 +607,7 @@ static void print_cell(UI *ui, UCell *ptr)
     // Printing the next character finally advances the cursor.
     final_column_wrap(ui);
   }
-  update_attrs(ui, kv_A(data->attrs, ptr->attr));
+  update_attrs(ui, ptr->attr);
   out(ui, ptr->data, strlen(ptr->data));
   grid->col++;
   if (data->immediate_wrap_after_last_column) {
@@ -615,8 +623,8 @@ static bool cheap_to_print(UI *ui, int row, int col, int next)
   UCell *cell = grid->cells[row] + col;
   while (next) {
     next--;
-    if (attrs_differ(kv_A(data->attrs, cell->attr),
-                     data->print_attrs, ui->rgb)) {
+    if (attrs_differ(ui, cell->attr,
+                     data->print_attr_id, ui->rgb)) {
       if (data->default_attr) {
         return false;
       }
@@ -743,11 +751,10 @@ static void clear_region(UI *ui, int top, int bot, int left, int right,
   TUIData *data = ui->data;
   UGrid *grid = &data->grid;
 
-  HlAttrs attrs = kv_A(data->attrs, (size_t)attr_id);
-  update_attrs(ui, attrs);
+  update_attrs(ui, attr_id);
 
   // non-BCE terminals can't clear with non-default background color
-  bool can_clear = data->bce || no_bg(ui, attrs);
+  bool can_clear = data->bce || !data->has_bg;
 
   // Background is set to the default color and the right edge matches the
   // screen end, try to use terminal codes for clearing the requested area.
@@ -1105,7 +1112,7 @@ static void tui_default_colors_set(UI *ui, Integer rgb_fg, Integer rgb_bg,
   data->clear_attrs.cterm_fg_color = (int)cterm_fg;
   data->clear_attrs.cterm_bg_color = (int)cterm_bg;
 
-  data->print_attrs = HLATTRS_INVALID;
+  data->print_attr_id = -1;
   invalidate(ui, 0, data->grid.height, 0, data->grid.width);
 }
 
@@ -1233,7 +1240,7 @@ static void tui_option_set(UI *ui, String name, Object value)
   if (strequal(name.data, "termguicolors")) {
     ui->rgb = value.data.boolean;
 
-    data->print_attrs = HLATTRS_INVALID;
+    data->print_attr_id = -1;
     invalidate(ui, 0, data->grid.height, 0, data->grid.width);
   }
 }

--- a/src/nvim/ugrid.c
+++ b/src/nvim/ugrid.c
@@ -52,8 +52,7 @@ void ugrid_goto(UGrid *grid, int row, int col)
   grid->col = col;
 }
 
-void ugrid_scroll(UGrid *grid, int top, int bot, int left, int right,
-                  int count, int *clear_top, int *clear_bot)
+void ugrid_scroll(UGrid *grid, int top, int bot, int left, int right, int count)
 {
   // Compute start/stop/step for the loop below
   int start, stop, step;
@@ -76,26 +75,18 @@ void ugrid_scroll(UGrid *grid, int top, int bot, int left, int right,
     memcpy(target_row, source_row,
            sizeof(UCell) * (size_t)(right - left + 1));
   }
-
-  // clear cells in the emptied region,
-  if (count > 0) {
-    *clear_top = stop;
-    *clear_bot = stop + count - 1;
-  } else {
-    *clear_bot = stop;
-    *clear_top = stop + count + 1;
-  }
-  clear_region(grid, *clear_top, *clear_bot, left, right, 0);
 }
 
 static void clear_region(UGrid *grid, int top, int bot, int left, int right,
                          sattr_T attr)
 {
-  UGRID_FOREACH_CELL(grid, top, bot, left, right, {
-    cell->data[0] = ' ';
-    cell->data[1] = 0;
-    cell->attr = attr;
-  });
+  for (int row = top; row <= bot; row++) {
+    UGRID_FOREACH_CELL(grid, row, left, right+1, {
+      cell->data[0] = ' ';
+      cell->data[1] = 0;
+      cell->attr = attr;
+    });
+  }
 }
 
 static void destroy_cells(UGrid *grid)

--- a/src/nvim/ugrid.h
+++ b/src/nvim/ugrid.h
@@ -22,15 +22,13 @@ struct ugrid {
 
 // -V:UGRID_FOREACH_CELL:625
 
-#define UGRID_FOREACH_CELL(grid, top, bot, left, right, code) \
+#define UGRID_FOREACH_CELL(grid, row, startcol, endcol, code) \
   do { \
-    for (int row = top; row <= bot; row++) { \
-      UCell *row_cells = (grid)->cells[row]; \
-      for (int col = left; col <= right; col++) { \
-        UCell *cell = row_cells + col; \
-        (void)(cell); \
-        code; \
-      } \
+    UCell *row_cells = (grid)->cells[row]; \
+    for (int col = startcol; col < endcol; col++) { \
+      UCell *cell = row_cells + col; \
+      (void)(cell); \
+      code; \
     } \
   } while (0)
 


### PR DESCRIPTION
- TUI: _never_ rely on BCE for implicit clearing, only explicit commands.
- TUI: use unibi_erase_chars when possible. (easily 1.5-3X-ish bandwidth reduction with vsplits)
- TUI: use end-exclusive ranges for invalid and cleared areas
- screen: scrolling leaves scrolled-in area undefined. This is a conservative change, a client assuming the old semantics will still behave correctly.
- screen: factor out vsep handling from line drawing. This is needed anyway for the multigrid refactor. (#8455)
- screen: simplifications of win_do_lines

Ref https://github.com/neovim/neovim/issues/9153#issuecomment-432953854