### PR TITLE
vim-patch:8.1.0507

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1125,7 +1125,7 @@ au BufNewFile,BufRead *.dpr			setf pascal
 " PDF
 au BufNewFile,BufRead *.pdf			setf pdf
 
-" PCMK - HAE - crm configure edit 
+" PCMK - HAE - crm configure edit
 au BufNewFile,BufRead *.pcmk 			setf pcmk
 
 " Perl
@@ -1892,8 +1892,11 @@ au BufNewFile,BufRead *.yy,*.yxx,*.y++		setf yacc
 " Yacc or racc
 au BufNewFile,BufRead *.y			call dist#ft#FTy()
 
-" Yaml or Raml
-au BufNewFile,BufRead *.yaml,*.yml,*.raml	setf yaml
+" Yaml
+au BufNewFile,BufRead *.yaml,*.yml		setf yaml
+
+" Raml
+au BufNewFile,BufRead *.raml			setf raml
 
 " yum conf (close enough to dosini)
 au BufNewFile,BufRead */etc/yum.conf		setf dosini

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -494,6 +494,7 @@ let s:filename_checks = {
     \ 'xslt': ['file.xsl', 'file.xslt'],
     \ 'yacc': ['file.yy', 'file.yxx', 'file.y++'],
     \ 'yaml': ['file.yaml', 'file.yml'],
+    \ 'raml': ['file.raml'],
     \ 'z8a': ['file.z8a'],
     \ 'zimbu': ['file.zu'],
     \ 'zimbutempl': ['file.zut'],


### PR DESCRIPTION
**vim-patch:8.1.0507: .raml files not properly detected**

Problem:    .raml files not properly detected.
Solution:   Recognize .raml as raml instead of yaml. (closes vim/vim#3594)
https://github.com/vim/vim/commit/da1c11c6411182e9a4bd4374e3fb8851fef77113

Related: https://github.com/neovim/neovim/pull/9189