### PR TITLE
vim-patch:8.1.0508

### DIFF
--- a/src/nvim/testdir/test_suspend.vim
+++ b/src/nvim/testdir/test_suspend.vim
@@ -9,7 +9,7 @@ func Test_suspend()
 
   let buf = term_start('/bin/sh')
   " Wait for shell prompt.
-  call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
+  call WaitForAssert({-> assert_match('[$#] $', term_getline(buf, '.'))})
 
   call term_sendkeys(buf, v:progpath
         \               . " --clean -X"
@@ -26,7 +26,7 @@ func Test_suspend()
         \             "\<C-Z>"]
     " Suspend and wait for shell prompt.
     call term_sendkeys(buf, suspend_cmd)
-    call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
+    call WaitForAssert({-> assert_match('[$#] $', term_getline(buf, '.'))})
 
     " Without 'autowrite', buffer should not be written.
     call assert_equal(0, filereadable('Xfoo'))
@@ -40,7 +40,7 @@ func Test_suspend()
   call assert_equal(0, filereadable('Xfoo'))
   call term_sendkeys(buf, ":suspend\<CR>")
   " Wait for shell prompt.
-  call WaitForAssert({-> assert_match('$ $', term_getline(buf, '.'))})
+  call WaitForAssert({-> assert_match('[$#] $', term_getline(buf, '.'))})
   call assert_equal(['foo'], readfile('Xfoo'))
   call term_sendkeys(buf, "fg\<CR>")
   call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})


### PR DESCRIPTION
**vim-patch:8.1.0508: suspend test fails when run by root**

Problem:    Suspend test fails when run by root.
Solution:   Accept both '$' and '#' for the prompt. (James McCoy, closes vim/vim#3590)
https://github.com/vim/vim/commit/0f62cf5b335968f7448af1a6f46e0104b7bc365e