### PR TITLE
Create pacman cache dir in build.ps1

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -43,7 +43,11 @@ if ($compiler -eq 'MINGW') {
 
   # Add MinGW to the PATH
   $env:PATH = "C:\msys64\mingw$bits\bin;$env:PATH"
-
+  
+  # Pacman may complain that the directory does not exist, which fails the build. Therefore, create it.
+  # See e.g. https://github.com/open62541/open62541/issues/2068
+  C:\msys64\usr\bin\bash -lc "mkdir -p /var/cache/pacman/pkg"
+  
   # Build third-party dependencies
   C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm -Su" ; exitIfFailed
   C:\msys64\usr\bin\bash -lc "pacman --verbose --noconfirm --needed -S mingw-w64-$arch-cmake mingw-w64-$arch-perl mingw-w64-$arch-diffutils mingw-w64-$arch-unibilium" ; exitIfFailed


### PR DESCRIPTION
Otherwise, the build will fail if the directory is not there, see e.g. https://github.com/open62541/open62541/issues/2068.

The problem hasn't shown up on master because the directory is cached, but if that fails for whatever reason (cache deleted...), the build would fail. I noticed this on a fork where I don't cache this directory.