### PR TITLE
defaults: background=dark

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -703,47 +703,24 @@ A jump table for the options with a short description can be found at |Q_op|.
 	been set.
 
 							*'background'* *'bg'*
-'background' 'bg'	string	(default "dark" or "light", see below)
+'background' 'bg'	string	(default "dark")
 			global
-	When set to "dark", Vim will try to use colors that look good on a
-	dark background.  When set to "light", Vim will try to use colors that
-	look good on a light background.  Any other value is illegal.
-	Vim tries to set the default value according to the terminal used.
-	This will not always be correct.
-	Setting this option does not change the background color, it tells Vim
-	what the background color looks like.  For changing the background
-	color, see |:hi-normal|.
+	When set to "dark" or "light", Nvim will adjust the default color
+	groups for a dark or light background, respectively.
 
-	When 'background' is set Vim will adjust the default color groups for
-	the new value.  But the colors used for syntax highlighting will not
-	change.					*g:colors_name*
+	This option does NOT change the background color, it tells Nvim what
+	the "inherited" (terminal/GUI) background looks like.
+	See |:hi-normal| if you want to set the background color explicitly.
+						*g:colors_name*
 	When a color scheme is loaded (the "g:colors_name" variable is set)
 	setting 'background' will cause the color scheme to be reloaded.  If
 	the color scheme adjusts to the value of 'background' this will work.
 	However, if the color scheme sets 'background' itself the effect may
 	be undone.  First delete the "g:colors_name" variable when needed.
 
-	When setting 'background' to the default value with: >
-		:set background&
-<	Vim will guess the value.  In the GUI this should work correctly,
-	in other cases Vim might not be able to guess the right value.
-
-	When starting the GUI, the default value for 'background' will be
-	"light".  When the value is not set in the gvimrc, and Vim detects
-	that the background is actually quite dark, 'background' is set to
-	"dark".  But this happens only AFTER the gvimrc file has been read
-	(because the window needs to be opened to find the actual background
-	color).  To get around this, force the GUI window to be opened by
-	putting a ":gui" command in the gvimrc file, before where the value
-	of 'background' is used (e.g., before ":syntax on").
-
-	For Windows the default is "dark". "dark" should be used if $COLORFGBG
-	suggests a dark	background (not yet implemented). Otherwise the default
-	is "light".
-
 	Normally this option would be set in the vimrc file.  Possibly
 	depending on the terminal name.  Example: >
-		:if $TERM == "xterm"
+		:if $TERM ==# "xterm"
 		:  set background=dark
 		:endif
 <	When this option is set, the default settings for the highlight groups

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -27,6 +27,7 @@ a complete and centralized reference of those differences.
 
 - 'autoindent' is set by default
 - 'autoread' is set by default
+- 'background' always defaults to "dark"
 - 'backspace' defaults to "indent,eol,start"
 - 'backupdir' defaults to .,~/.local/share/nvim/backup (|xdg|)
 - 'belloff' defaults to "all"

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -132,10 +132,10 @@ return {
     {
       full_name='background', abbreviation='bg',
       type='string', scope={'global'},
-      vi_def=true,
+      vim=true,
       redraw={'all_windows'},
       varname='p_bg',
-      defaults={if_true={vi="light"}}
+      defaults={if_true={vi="light",vim="dark"}}
     },
     {
       full_name='backspace', abbreviation='bs',

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -52,7 +52,7 @@ local function screen_setup(extra_rows, command, cols)
     [7] = {foreground = 130},
     [8] = {foreground = 15, background = 1}, -- error message
     [9] = {foreground = 4},
-    [10] = {foreground = 2},  -- "Press ENTER" in embedded :terminal session.
+    [10] = {foreground = 121},  -- "Press ENTER" in embedded :terminal session.
   })
 
   screen:attach({rgb=false})

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -134,15 +134,17 @@ describe('tui', function()
     feed_data('\022\007') -- ctrl+g
     feed_data('\022\022') -- ctrl+v
     feed_data('\022\013') -- ctrl+m
+    local attrs = screen:get_default_attr_ids()
+    attrs[11] = {foreground = 81}
     screen:expect([[
-    {9:^G^V^M}{1: }                                           |
+    {11:^G^V^M}{1: }                                           |
     {4:~                                                 }|
     {4:~                                                 }|
     {4:~                                                 }|
     {5:[No Name] [+]                                     }|
     {3:-- INSERT --}                                      |
     {3:-- TERMINAL --}                                    |
-    ]])
+    ]], attrs)
   end)
 
   it('automatically sends <Paste> for bracketed paste sequences', function()

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -17,6 +17,7 @@ local function test_embed(ext_linegrid)
       [1] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
       [2] = {bold = true, foreground = Screen.colors.SeaGreen4},
       [3] = {bold = true, foreground = Screen.colors.Blue1},
+      [4] = {bold = true, foreground = Screen.colors.Green},
     })
   end
 
@@ -56,7 +57,7 @@ local function test_embed(ext_linegrid)
       Error detected while processing pre-vimrc command line:     |
       foo                                                         |
       {1:bar}                                                         |
-      {2:Press ENTER or type command to continue}^                     |
+      {4:Press ENTER or type command to continue}^                     |
     ]])
   end)
 

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -68,7 +68,12 @@ describe("shell command :!", function()
                                                         |
       {10:Press ENTER or type command to continue}{1: }          |
       {3:-- TERMINAL --}                                    |
-    ]])
+    ]], {
+      -- test/functional/helpers.lua defaults to background=light.
+      [1] = {reverse = true},
+      [3] = {bold = true},
+      [10] = {foreground = 2},
+    })
   end)
 end)
 

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -72,6 +72,7 @@
 -- To debug screen tests, see Screen:redraw_debug().
 
 local global_helpers = require('test.helpers')
+local deepcopy = global_helpers.deepcopy
 local shallowcopy = global_helpers.shallowcopy
 local helpers = require('test.functional.helpers')(nil)
 local request, run, uimeths = helpers.request, helpers.run, helpers.uimeths
@@ -174,6 +175,10 @@ end
 
 function Screen:set_default_attr_ids(attr_ids)
   self._default_attr_ids = attr_ids
+end
+
+function Screen:get_default_attr_ids()
+  return deepcopy(self._default_attr_ids)
 end
 
 function Screen:set_default_attr_ignore(attr_ignore)


### PR DESCRIPTION
Rebase of #2894

ref #6289

By accident, Nvim essentially defaults to background=light. This is weird because

    :colorscheme default

looks very wrong on a dark background.

The "smart" logic that Vim uses is in fact extremely confusing for anyone who uses Vim on multiple platforms, so rather than mimic that, just pick a damn default.

- Since Neovim is dark-powered, we assume most users have dark backgrounds.
- Most of the GUIs tend to have a dark background by default.
