### PR TITLE
test: adjust time-sensitive tests

### DIFF
--- a/src/nvim/testdir/test_lambda.vim
+++ b/src/nvim/testdir/test_lambda.vim
@@ -31,11 +31,11 @@ function! Test_lambda_with_timer()
   endfunction
 
   call s:Foo()
-  sleep 200ms
+  sleep 210ms
   " do not collect lambda
   call garbagecollect()
   let m = s:n
-  sleep 200ms
+  sleep 210ms
   call timer_stop(s:timer_id)
   call assert_true(m > 1)
   call assert_true(s:n > m + 1)

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -172,8 +172,8 @@ describe('timers', function()
         let g:val2 += 1
       endfunc
     ]])
-    command("call timer_start(50,  'MyHandler', {'repeat': 3})")
-    command("call timer_start(100, 'MyHandler2', {'repeat': 2})")
+    command("call timer_start(20, 'MyHandler',  {'repeat': 3})")
+    command("call timer_start(40, 'MyHandler2', {'repeat': 2})")
     run(nil, nil, nil, 300)
     eq(3,eval("g:val"))
     eq(2,eval("g:val2"))

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -300,8 +300,10 @@ end
 -- Calls fn() until it succeeds, up to `max` times or until `max_ms`
 -- milliseconds have passed.
 local function retry(max, max_ms, fn)
+  assert(max == nil or max > 0)
+  assert(max_ms == nil or max_ms > 0)
   local tries = 1
-  local timeout = (max_ms and max_ms > 0) and max_ms or 10000
+  local timeout = (max_ms and max_ms or 10000)
   local start_time = luv.now()
   while true do
     local status, result = pcall(fn)

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -68,7 +68,7 @@ describe('terminal', function()
   end)
 
   it('forwards resize request to the program', function()
-    feed([[<C-\><C-N>:]])  -- Go to cmdline-mode, so cursor is at bottom.
+    feed([[<C-\><C-N>G:]])  -- Go to cmdline-mode, so cursor is at bottom.
     local w1, h1 = screen._width - 3, screen._height - 2
     local w2, h2 = w1 - 6, h1 - 3
 

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -2512,7 +2512,7 @@ describe(":substitute", function()
 end)
 
 it(':substitute with inccommand during :terminal activity', function()
-  retry(2, nil, function()
+  retry(2, 40000, function()
     local screen = Screen.new(30,15)
     clear()
 


### PR DESCRIPTION
- window_split_tab_spec.lua: Put cursor at bottom of :terminal buffer so
  that it follows output.
- Timer tests are less reliable on Travis CI macOS 10.12/10.13.
  ref #6829
  ref e39dade80b02
  ref de13113dc16e
  ref https://github.com/neovim/neovim/pull/9095#issuecomment-429603452
  > We don't guarantee that a X ms timer is triggered during Y ms sleep
  > for any X<Y, though I would expect the load to be really bad for this
  > to happen with X=10ms, Y=40ms.