### PR TITLE
doc, scripts, misc

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,6 +8,7 @@ IndentCaseLabels: true
 BreakBeforeBraces: Linux
 AlignEscapedNewlinesLeft: false
 AllowShortFunctionsOnASingleLine: false
+AlignTrailingComments: true
 SpacesBeforeTrailingComments: 2
 PenaltyReturnTypeOnItsOwnLine: 200
 AllowAllParametersOfDeclarationOnNextLine: false
@@ -15,4 +16,5 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 BinPackParameters: false
 BreakBeforeBinaryOperators: true
+BreakBeforeTernaryOperators: true
 ContinuationIndentWidth: 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ jobs:
     - stage: normal builds
       os: linux
       compiler: clang-4.0
+      # Use Lua so that ASAN can test our embedded Lua support. 8fec4d53d0f6
       env: >
         CLANG_SANITIZER=ASAN_UBSAN
-        # Use Lua so that ASAN can test our embedded Lua support. 8fec4d53d0f6
         CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
         ASAN_SYMBOLIZE=asan_symbolize-4.0
     - os: linux

--- a/man/nvim.1
+++ b/man/nvim.1
@@ -24,7 +24,7 @@ Start
 .Nm
 followed by any number of options and/or files:
 .Pp
-.Dl nvim [options] [filelist]
+.Dl nvim [options] [file ...]
 .Pp
 Commands in
 .Nm

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -478,6 +478,9 @@ nvim_err_writeln({str})                                   *nvim_err_writeln()*
 nvim_list_bufs()                                            *nvim_list_bufs()*
                 Gets the current list of buffer handles
 
+                Includes unlisted (unloaded/deleted) buffers, like `:ls!`. Use
+                |nvim_buf_is_loaded()| to check if a buffer is loaded.
+
                 Return: ~
                     List of buffer handles
 
@@ -528,6 +531,30 @@ nvim_set_current_tabpage({tabpage})               *nvim_set_current_tabpage()*
 
                 Parameters: ~
                     {tabpage}  Tabpage handle
+
+nvim_create_namespace({name})                        *nvim_create_namespace()*
+                create a new namespace, or get one with an exisiting name
+
+                Namespaces are currently used for buffer highlighting and
+                virtual text, see |nvim_buf_add_highlight| and
+                |nvim_buf_set_virtual_text|.
+
+                Namespaces can have a name of be anonymous. If `name` is a
+                non-empty string, and a namespace already exists with that
+                name,the existing namespace id is returned. If an empty string
+                is used, a new anonymous namespace is returned.
+
+                Parameters: ~
+                    {name}  Name of the namespace or empty string
+
+                Return: ~
+                    the namespace id
+
+nvim_get_namespaces()                                  *nvim_get_namespaces()*
+                Get existing named namespaces
+
+                Return: ~
+                    dict that maps from names to namespace ids.
 
 nvim_subscribe({event})                                     *nvim_subscribe()*
                 Subscribes to event broadcasts
@@ -1082,35 +1109,36 @@ nvim_buf_get_mark({buffer}, {name})                      *nvim_buf_get_mark()*
                     (row, col) tuple
 
                                                     *nvim_buf_add_highlight()*
-nvim_buf_add_highlight({buffer}, {src_id}, {hl_group}, {line},
+nvim_buf_add_highlight({buffer}, {ns_id}, {hl_group}, {line},
                        {col_start}, {col_end})
                 Adds a highlight to buffer.
 
                 Useful for plugins that dynamically generate highlights to a
                 buffer (like a semantic highlighter or linter). The function
-                adds a single highlight to a buffer. Unlike matchaddpos()
+                adds a single highlight to a buffer. Unlike |matchaddpos()|
                 highlights follow changes to line numbering (as lines are
                 inserted/removed above the highlighted line), like signs and
                 marks do.
 
-                `src_id` is useful for batch deletion/updating of a set of
-                highlights. When called with `src_id = 0`, an unique source id
-                is generated and returned. Successive calls can pass that
-                `src_id` to associate new highlights with the same source
-                group. All highlights in the same group can be cleared with
-                `nvim_buf_clear_highlight`. If the highlight never will be
-                manually deleted, pass `src_id = -1`.
+                Namespaces are used for batch deletion/updating of a set of
+                highlights. To create a namespace, use |nvim_create_namespace|
+                which returns a namespace id. Pass it in to this function as
+                `ns_id` to add highlights to the namespace. All highlights in
+                the same namespace can then be cleared with single call to
+                |nvim_buf_clear_highlight|. If the highlight never will be
+                deleted by an API call, pass `ns_id = -1`.
 
-                If `hl_group` is the empty string no highlight is added, but a
-                new `src_id` is still returned. This is useful for an external
-                plugin to synchrounously request an unique `src_id` at
-                initialization, and later asynchronously add and clear
-                highlights in response to buffer changes.
+                As a shorthand, `ns_id = 0` can be used to create a new
+                namespace for the highlight, the allocated id is then
+                returned. If `hl_group` is the empty string no highlight is
+                added, but a new `ns_id` is still returned. This is supported
+                for backwards compatibility, new code should use
+                |nvim_create_namespace| to create a new empty namespace.
 
                 Parameters: ~
                     {buffer}     Buffer handle
-                    {src_id}     Source group to use or 0 to use a new group,
-                                 or -1 for ungrouped highlight
+                    {ns_id}      namespace to use or -1 for ungrouped
+                                 highlight
                     {hl_group}   Name of the highlight group to use
                     {line}       Line to highlight (zero-indexed)
                     {col_start}  Start of (byte-indexed) column range to
@@ -1119,10 +1147,10 @@ nvim_buf_add_highlight({buffer}, {src_id}, {hl_group}, {line},
                                  highlight, or -1 to highlight to end of line
 
                 Return: ~
-                    The src_id that was used
+                    The ns_id that was used
 
                                                   *nvim_buf_clear_highlight()*
-nvim_buf_clear_highlight({buffer}, {src_id}, {line_start}, {line_end})
+nvim_buf_clear_highlight({buffer}, {ns_id}, {line_start}, {line_end})
                 Clears highlights and virtual text from a given source id and
                 range of lines
 
@@ -1131,15 +1159,13 @@ nvim_buf_clear_highlight({buffer}, {src_id}, {line_start}, {line_end})
 
                 Parameters: ~
                     {buffer}      Buffer handle
-                    {src_id}      Highlight source group to clear, or -1 to
-                                  clear all.
+                    {ns_id}       Namespace to clear, or -1 to clear all.
                     {line_start}  Start of range of lines to clear
                     {line_end}    End of range of lines to clear (exclusive)
                                   or -1 to clear to end of file.
 
                                                  *nvim_buf_set_virtual_text()*
-nvim_buf_set_virtual_text({buffer}, {src_id}, {line}, {chunks},
-                          {opts})
+nvim_buf_set_virtual_text({buffer}, {ns_id}, {line}, {chunks}, {opts})
                 Set the virtual text (annotation) for a buffer line.
 
                 By default (and currently the only option) the text will be
@@ -1149,13 +1175,22 @@ nvim_buf_set_virtual_text({buffer}, {src_id}, {line}, {chunks},
                 the right of the ordinary text, this will contain the |lcs-
                 eol| char if set, otherwise just be a space.
 
-                The same src_id can be used for both virtual text and
-                highlights added by nvim_buf_add_highlight. Virtual text is
-                cleared using nvim_buf_clear_highlight.
+                Namespaces are used to support batch deletion/updating of
+                virtual text. To create a namespace, use
+                |nvim_create_namespace|. Virtual text is cleared using
+                |nvim_buf_clear_highlight|. The same `ns_id` can be used for
+                both virtual text and highlights added by
+                |nvim_buf_add_highlight|, both can then be cleared with a
+                single call to |nvim_buf_clear_highlight|. If the virtual text
+                never will be cleared by an API call, pass `src_id = -1`.
+
+                As a shorthand, `ns_id = 0` can be used to create a new
+                namespace for the virtual text, the allocated id is then
+                returned.
 
                 Parameters: ~
                     {buffer}  Buffer handle
-                    {src_id}  Source group to use or 0 to use a new group, or
+                    {ns_id}   Namespace to use or 0 to create a namespace, or
                               -1 for a ungrouped annotation
                     {line}    Line to annotate with virtual text (zero-
                               indexed)
@@ -1166,7 +1201,7 @@ nvim_buf_set_virtual_text({buffer}, {src_id}, {line}, {chunks},
                     {opts}    Optional parameters. Currently not used.
 
                 Return: ~
-                    The src_id that was used
+                    The ns_id that was used
 
 
 ==============================================================================
@@ -1180,6 +1215,13 @@ nvim_win_get_buf({window})                                *nvim_win_get_buf()*
 
                 Return: ~
                     Buffer handle
+
+nvim_win_set_buf({window}, {buffer})                      *nvim_win_set_buf()*
+                Sets the current buffer in a window, without side-effects
+
+                Parameters: ~
+                    {window}  Window handle
+                    {buffer}  Buffer handle
 
 nvim_win_get_cursor({window})                          *nvim_win_get_cursor()*
                 Gets the cursor position in the window

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -526,20 +526,18 @@ CmdlineChanged			After a change was made to the text in the
 				command line.  Be careful not to mess up
 				the command line, it may cause Vim to lock up.
 							*CmdlineEnter*
-CmdlineEnter			After moving the cursor to the command line,
-				where the user can type a command or search
-				string.
-				<afile> is set to a single character,
-				indicating the type of command-line.
-				|cmdline-char|
+CmdlineEnter			After entering the command-line (including
+				non-interactive use of ":" in a mapping: use
+				|<Cmd>| instead to avoid this).
+				<afile> is set to the |cmdline-char|.
 				Sets these |v:event| keys:
 				    cmdlevel
 				    cmdtype
 							*CmdlineLeave*
-CmdlineLeave			Before leaving the command line.
-				<afile> is set to a single character,
-				indicating the type of command-line.
-				|cmdline-char|
+CmdlineLeave			Before leaving the command-line (including
+				non-interactive use of ":" in a mapping: use
+				|<Cmd>| instead to avoid this).
+				<afile> is set to the |cmdline-char|.
 				Sets these |v:event| keys:
 				    abort (mutable)
 				    cmdlevel

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -6,19 +6,20 @@
 
 Development of Nvim					*development*
 
-Nvim is open source software.  Everybody is encouraged to contribute.
-    https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md
+This reference describes design constraints and guidelines, for developing
+Nvim applications or Nvim itself.
+Architecture and internal concepts are covered in src/nvim/README.md
 
-See src/nvim/README.md for an overview of the source code.
+Nvim is free and open source.  Everybody is encouraged to contribute.
+    https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md
 
                                       Type |gO| to see the table of contents.
 
 ==============================================================================
 Design goals						*design-goals*
 
-Most important things come first (roughly).
-
-Note that some items conflict; this is intentional.  A balance must be found.
+Most important things come first (roughly).  Some items conflict; this is
+intentional.  A balance must be found.
 
 
 NVIM IS... IMPROVED					*design-improved*
@@ -80,41 +81,6 @@ include the kitchen sink... but it's good for plumbing."
 ==============================================================================
 Developer guidelines				        *dev*
 
-
-JARGON	 						*dev-jargon*
-
-API client ~
-All external UIs and remote plugins (as opposed to regular Vim plugins) are
-"clients" in general; but we call something an "API client" if its purpose is
-to abstract or wrap the RPC API for the convenience of other applications
-(just like a REST client or SDK such as boto3 for AWS: you can speak AWS REST
-using an HTTP client like curl, but boto3 wraps that in a convenient python
-interface). For example, the Nvim lua-client is an API client:
-    https://github.com/neovim/lua-client
-
-Host ~
-A plugin "host" is both a client (of the Nvim API) and a server (of an
-external platform, e.g. python). It is a remote plugin that hosts other
-plugins.
-
-Remote plugin ~
-Arbitrary code registered via |:UpdateRemotePlugins|, that runs in a separate
-process and communicates with Nvim via the |api|.
-
-Window ~
-The word "window" is commonly used for several things: A window on the screen,
-the xterm window, a window inside Vim to view a buffer.
-To avoid confusion, other items that are sometimes called window have been
-given another name.  Here is an overview of the related items:
-
-screen		The whole display.
-shell		The Vim application.  This can cover the whole screen (e.g.,
-		when running in a console) or part of it (xterm or GUI).
-window		View on a buffer.  There can be several windows in Vim,
-		together with the command line, menubar, toolbar, etc. they
-		fit in the shell.
-frame		Windows are kept in a tree of frames.  Each frame contains
-		a column, row, or window ("leaf" frame).
 
 PROVIDERS 						*dev-provider*
 

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -150,6 +150,7 @@ GUI ~
 
 Interfaces ~
 |if_cscop.txt|	using Cscope with Vim
+|if_lua.txt|	Lua interface
 |if_pyth.txt|	Python interface
 |if_ruby.txt|	Ruby interface
 |sign.txt|	debugging signs

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -94,7 +94,7 @@ For the most recent information about sponsoring look on the Vim web site:
 
 Neovim development is funded separately from Vim:
 
-	https://neovim.io/sponsors/
+	https://neovim.io/#sponsor
 
 ==============================================================================
 Credits				*credits* *author* *Bram* *Moolenaar*
@@ -702,18 +702,15 @@ window.  You may make the window as small as you like, but if it gets too
 small not a single line will fit in it.  Make it at least 40 characters wide
 to be able to read most messages on the last line.
 
-On most Unix systems, resizing the window is recognized and handled correctly
-by Vim.
-
 ==============================================================================
-Definitions						*definitions*
+Definitions						*definitions* *jargon*
 
-  buffer		Contains lines of text, usually read from a file.
-  screen		The whole area that Vim uses to work in.  This can be
-			a terminal emulator window.  Also called "the Vim
-			window".
+  buffer		Contains lines of text, usually from a file.
+  screen		The whole area that Nvim uses to display things.
   window		A view on a buffer.  There can be multiple windows for
 			one buffer.
+  frame			Windows are kept in a tree of frames.  Each frame
+			contains a column, row, or window ("leaf" frame).
 
 A screen contains one or more windows, separated by status lines and with the
 command line at the bottom.
@@ -746,7 +743,7 @@ A difference is made between four types of lines:
 			lines with wrapping, line breaks, etc.  applied.  They
 			can only be as long as the width of the window allows,
 			longer lines are wrapped or truncated.
-  screen lines		The lines of the screen that Vim uses.  Consists of
+  screen lines		The lines of the screen that Nvim uses.  Consists of
 			the window lines of all windows, with status lines
 			and the command line added.  They can only be as long
 			as the width of the screen allows.  When the command
@@ -769,6 +766,28 @@ buffer lines	logical lines	window lines	screen lines ~
 4. ddd		4. ddd		4. cc		12. === status line ===
 				5. ddd		13. (command line)
 				6. ~ 
+
+
+API client ~
+All external UIs and remote plugins (as opposed to regular Vim plugins) are
+"clients" in general; but we call something an "API client" if its purpose is
+to abstract or wrap the RPC API for the convenience of other applications
+(just like a REST client or SDK such as boto3 for AWS: you can speak AWS REST
+using an HTTP client like curl, but boto3 wraps that in a convenient python
+interface). For example, the Nvim lua-client is an API client:
+    https://github.com/neovim/lua-client
+
+
+Host ~
+A plugin "host" is both a client (of the Nvim API) and a server (of an
+external platform, e.g. python). It is a remote plugin that hosts other
+plugins.
+
+
+Remote plugin ~
+Arbitrary code registered via |:UpdateRemotePlugins|, that runs in a separate
+process and communicates with Nvim via the |api|.
+
 
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -286,6 +286,9 @@ current mode (instead of always going to normal-mode).  Visual-mode is
 preserved, so tricks with |gv| are not needed.  Commands can be invoked
 directly in cmdline-mode (which otherwise would require timer hacks).
 
+Because <Cmd> avoids mode-changes (unlike ":") it does not trigger
+|CmdlineEnter| and |CmdlineLeave| events. This helps performance.
+
 Unlike <expr> mappings, there are no special restrictions on the <Cmd>
 command: it is executed as if an (unrestricted) |autocmd| was invoked or an
 async event event was processed.

--- a/runtime/plugin/matchit.vim
+++ b/runtime/plugin/matchit.vim
@@ -716,7 +716,7 @@ fun! s:MultiMatch(spflag, mode)
       execute "if " . skip . "| let skip = '0' | endif"
     catch /^Vim\%((\a\+)\)\=:E363/
       " We won't find anything, so skip searching, should keep Vim responsive.
-      return
+      return {}
     endtry
   endif
   mark '

--- a/scripts/gen_help_html.py
+++ b/scripts/gen_help_html.py
@@ -1,0 +1,355 @@
+# Converts Vim/Nvim documentation to HTML.
+#
+# Adapted from https://github.com/c4rlo/vimhelp/
+# License: MIT
+#
+# Copyright (c) 2016 Carlo Teubner
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import re, urllib.parse
+from itertools import chain
+
+HEAD = """\
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+    "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-type" content="text/html; charset={encoding}"/>
+<title>Nvim: {filename}</title>
+"""
+
+HEAD_END = '</head>\n<body>\n'
+
+INTRO = """
+<h1>Nvim help files</h1>
+<p>HTML export of the <a href="https://neovim.io/">Nvim</a> help pages{vers-note}.
+Updated <a href="https://github.com/neovim/bot-ci" class="d">automatically</a> from the <a
+href="https://github.com/vim/vim/tree/master/runtime/doc" class="d">Nvim source repository</a>.
+Also includes the <a href="vim_faq.txt.html">Vim FAQ</a>, pulled from its
+<a href="https://github.com/chrisbra/vim_faq" class="d">source repository</a>.</p>
+"""
+
+VERSION_NOTE = ", current as of Vim {version}"
+
+SITENAVI_LINKS = """
+Quick links:
+<a href="/">help overview</a> &middot;
+<a href="quickref.txt.html">quick reference</a> &middot;
+<a href="usr_toc.txt.html">user manual toc</a> &middot;
+<a href="{helptxt}#reference_toc">reference manual toc</a> &middot;
+<a href="vim_faq.txt.html">faq</a>
+"""
+
+SITENAVI_LINKS_PLAIN = SITENAVI_LINKS.format(helptxt='help.txt.html')
+SITENAVI_LINKS_WEB = SITENAVI_LINKS.format(helptxt='/')
+
+SITENAVI_PLAIN = '<p>' + SITENAVI_LINKS_PLAIN + '</p>'
+SITENAVI_WEB = '<p>' + SITENAVI_LINKS_WEB + '</p>'
+
+SITENAVI_SEARCH = '<table width="100%"><tbody><tr><td>' + SITENAVI_LINKS_WEB + \
+'</td><td style="text-align: right; max-width: 25vw"><div class="gcse-searchbox">' \
+'</div></td></tr></tbody></table><div class="gcse-searchresults"></div>'
+
+TEXTSTART = """
+<div id="d1">
+<pre id="sp">                                                                                </pre>
+<div id="d2">
+<pre>
+"""
+
+FOOTER = '</pre>'
+
+FOOTER2 = """
+<p id="footer">This site is maintained by Carlo Teubner (<i>(my first name) dot (my last name) at gmail dot com</i>).</p>
+</div>
+</div>
+</body>
+</html>
+"""
+
+VIM_FAQ_LINE = '<a href="vim_faq.txt.html#vim_faq.txt" class="l">' \
+               'vim_faq.txt</a>   Frequently Asked Questions\n'
+
+RE_TAGLINE = re.compile(r'(\S+)\s+(\S+)')
+
+PAT_WORDCHAR = '[!#-)+-{}~\xC0-\xFF]'
+
+PAT_HEADER   = r'(^.*~$)'
+PAT_GRAPHIC  = r'(^.* `$)'
+PAT_PIPEWORD = r'(?<!\\)\|([#-)!+-~]+)\|'
+PAT_STARWORD = r'\*([#-)!+-~]+)\*(?:(?=\s)|$)'
+PAT_COMMAND  = r'`([^` ]+)`'
+PAT_OPTWORD  = r"('(?:[a-z]{2,}|t_..)')"
+PAT_CTRL     = r'(CTRL-(?:W_)?(?:\{char\}|<[A-Za-z]+?>|.)?)'
+PAT_SPECIAL  = r'(<.+?>|\{.+?}|' \
+               r'\[(?:range|line|count|offset|\+?cmd|[-+]?num|\+\+opt|' \
+               r'arg|arguments|ident|addr|group)]|' \
+               r'(?<=\s)\[[-a-z^A-Z0-9_]{2,}])'
+PAT_TITLE    = r'(Vim version [0-9.a-z]+|VIM REFERENCE.*)'
+PAT_NOTE     = r'((?<!' + PAT_WORDCHAR + r')(?:note|NOTE|Notes?):?' \
+                 r'(?!' + PAT_WORDCHAR + r'))'
+PAT_URL      = r'((?:https?|ftp)://[^\'"<> \t]+[a-zA-Z0-9/])'
+PAT_WORD     = r'((?<!' + PAT_WORDCHAR + r')' + PAT_WORDCHAR + r'+' \
+                 r'(?!' + PAT_WORDCHAR + r'))'
+
+RE_LINKWORD = re.compile(
+        PAT_OPTWORD  + '|' +
+        PAT_CTRL     + '|' +
+        PAT_SPECIAL)
+RE_TAGWORD = re.compile(
+        PAT_HEADER   + '|' +
+        PAT_GRAPHIC  + '|' +
+        PAT_PIPEWORD + '|' +
+        PAT_STARWORD + '|' +
+        PAT_COMMAND  + '|' +
+        PAT_OPTWORD  + '|' +
+        PAT_CTRL     + '|' +
+        PAT_SPECIAL  + '|' +
+        PAT_TITLE    + '|' +
+        PAT_NOTE     + '|' +
+        PAT_URL      + '|' +
+        PAT_WORD)
+RE_NEWLINE   = re.compile(r'[\r\n]')
+RE_HRULE     = re.compile(r'[-=]{3,}.*[-=]{3,3}$')
+RE_EG_START  = re.compile(r'(?:.* )?>$')
+RE_EG_END    = re.compile(r'\S')
+RE_SECTION   = re.compile(r'[-A-Z .][-A-Z0-9 .()]*(?=\s+\*)')
+RE_STARTAG   = re.compile(r'\s\*([^ \t|]+)\*(?:\s|$)')
+RE_LOCAL_ADD = re.compile(r'LOCAL ADDITIONS:\s+\*local-additions\*$')
+
+class Link(object):
+    __slots__ = 'link_plain_same',    'link_pipe_same', \
+                'link_plain_foreign', 'link_pipe_foreign', \
+                'filename'
+
+    def __init__(self, link_plain_same, link_plain_foreign,
+                       link_pipe_same,  link_pipe_foreign, filename):
+        self.link_plain_same    = link_plain_same
+        self.link_plain_foreign = link_plain_foreign
+        self.link_pipe_same     = link_pipe_same
+        self.link_pipe_foreign  = link_pipe_foreign
+        self.filename           = filename
+
+class VimH2H(object):
+    def __init__(self, tags, version=None, is_web_version=True):
+        self._urls = { }
+        self._version = version
+        self._is_web_version = is_web_version
+        for line in RE_NEWLINE.split(tags):
+            m = RE_TAGLINE.match(line)
+            if m:
+                tag, filename = m.group(1, 2)
+                self.do_add_tag(filename, tag)
+
+    def add_tags(self, filename, contents):
+        for match in RE_STARTAG.finditer(contents):
+            tag = match.group(1).replace('\\', '\\\\').replace('/', '\\/')
+            self.do_add_tag(str(filename), tag)
+
+    def do_add_tag(self, filename, tag):
+        tag_quoted = urllib.parse.quote_plus(tag)
+        def mkpart1(doc):
+            return '<a href="' + doc + '#' + tag_quoted + '" class="'
+        part1_same = mkpart1('')
+        if self._is_web_version and filename == 'help.txt':
+            doc = '/'
+        else:
+            doc = filename + '.html'
+        part1_foreign = mkpart1(doc)
+        part2 = '">' + html_escape[tag] + '</a>'
+        def mklinks(cssclass):
+            return (part1_same    + cssclass + part2,
+                    part1_foreign + cssclass + part2)
+        cssclass_plain = 'd'
+        m = RE_LINKWORD.match(tag)
+        if m:
+            opt, ctrl, special = m.groups()
+            if opt       is not None: cssclass_plain = 'o'
+            elif ctrl    is not None: cssclass_plain = 'k'
+            elif special is not None: cssclass_plain = 's'
+        links_plain = mklinks(cssclass_plain)
+        links_pipe = mklinks('l')
+        self._urls[tag] = Link(
+            links_plain[0], links_plain[1],
+            links_pipe[0],  links_pipe[1],
+            filename)
+
+    def maplink(self, tag, curr_filename, css_class=None):
+        links = self._urls.get(tag)
+        if links is not None:
+            if links.filename == curr_filename:
+                if css_class == 'l': return links.link_pipe_same
+                else:                return links.link_plain_same
+            else:
+                if css_class == 'l': return links.link_pipe_foreign
+                else:                return links.link_plain_foreign
+        elif css_class is not None:
+            return '<span class="' + css_class + '">' + html_escape[tag] + \
+                    '</span>'
+        else: return html_escape[tag]
+
+    def to_html(self, filename, contents, encoding):
+        out = [ ]
+
+        inexample = 0
+        filename = str(filename)
+        is_help_txt = (filename == 'help.txt')
+        faq_line = False
+        for line in RE_NEWLINE.split(contents):
+            line = line.rstrip('\r\n')
+            line_tabs = line
+            line = line.expandtabs()
+            if RE_HRULE.match(line):
+                out.extend(('<span class="h">', line, '</span>\n'))
+                continue
+            if inexample == 2:
+                if RE_EG_END.match(line):
+                    inexample = 0
+                    if line[0] == '<': line = line[1:]
+                else:
+                    out.extend(('<span class="e">', html_escape[line],
+                               '</span>\n'))
+                    continue
+            if RE_EG_START.match(line_tabs):
+                inexample = 1
+                line = line[0:-1]
+            if RE_SECTION.match(line_tabs):
+                m = RE_SECTION.match(line)
+                out.extend((r'<span class="c">', m.group(0), r'</span>'))
+                line = line[m.end():]
+            if is_help_txt and RE_LOCAL_ADD.match(line_tabs):
+                faq_line = True
+            lastpos = 0
+            for match in RE_TAGWORD.finditer(line):
+                pos = match.start()
+                if pos > lastpos:
+                    out.append(html_escape[line[lastpos:pos]])
+                lastpos = match.end()
+                header, graphic, pipeword, starword, command, opt, ctrl, \
+                        special, title, note, url, word = match.groups()
+                if pipeword is not None:
+                    out.append(self.maplink(pipeword, filename, 'l'))
+                elif starword is not None:
+                    out.extend(('<a name="', urllib.parse.quote_plus(starword),
+                            '" class="t">', html_escape[starword], '</a>'))
+                elif command is not None:
+                    out.extend(('<span class="e">', html_escape[command],
+                                '</span>'))
+                elif opt is not None:
+                    out.append(self.maplink(opt, filename, 'o'))
+                elif ctrl is not None:
+                    out.append(self.maplink(ctrl, filename, 'k'))
+                elif special is not None:
+                    out.append(self.maplink(special, filename, 's'))
+                elif title is not None:
+                    out.extend(('<span class="i">', html_escape[title],
+                                '</span>'))
+                elif note is not None:
+                    out.extend(('<span class="n">', html_escape[note],
+                                '</span>'))
+                elif header is not None:
+                    out.extend(('<span class="h">', html_escape[header[:-1]],
+                                '</span>'))
+                elif graphic is not None:
+                    out.append(html_escape[graphic[:-2]])
+                elif url is not None:
+                    out.extend(('<a class="u" href="', url, '">' +
+                                html_escape[url], '</a>'))
+                elif word is not None:
+                    out.append(self.maplink(word, filename))
+            if lastpos < len(line):
+                out.append(html_escape[line[lastpos:]])
+            out.append('\n')
+            if inexample == 1: inexample = 2
+            if faq_line:
+                out.append(VIM_FAQ_LINE)
+                faq_line = False
+
+        header = []
+        header.append(HEAD.format(encoding=encoding, filename=filename))
+        header.append(HEAD_END)
+        if self._is_web_version and is_help_txt:
+            vers_note = VERSION_NOTE.replace('{version}', self._version) \
+                    if self._version else ''
+            header.append(INTRO.replace('{vers-note}', vers_note))
+        if self._is_web_version:
+            header.append(SITENAVI_SEARCH)
+            sitenavi_footer = SITENAVI_WEB
+        else:
+            header.append(SITENAVI_PLAIN)
+            sitenavi_footer = SITENAVI_PLAIN
+        header.append(TEXTSTART)
+        return ''.join(chain(header, out, (FOOTER, sitenavi_footer, FOOTER2)))
+
+class HtmlEscCache(dict):
+    def __missing__(self, key):
+        r = key.replace('&', '&amp;') \
+               .replace('<', '&lt;') \
+               .replace('>', '&gt;')
+        self[key] = r
+        return r
+
+html_escape = HtmlEscCache()
+
+
+
+import sys, os, os.path
+#import cProfile
+sys.path.append('.')
+
+def slurp(filename):
+    try:
+        with open(filename, encoding='UTF-8') as f:
+            return f.read(), 'UTF-8'
+    except UnicodeError:
+        # 'ISO-8859-1' ?
+        with open(filename, encoding='latin-1') as f:
+            return f.read(), 'latin-1'
+
+def usage():
+    return "usage: " + sys.argv[0] + " IN_DIR OUT_DIR [BASENAMES...]"
+
+def main():
+    if len(sys.argv) < 3: sys.exit(usage())
+
+    in_dir = sys.argv[1]
+    out_dir = sys.argv[2]
+    basenames = sys.argv[3:]
+
+    print( "Processing tags...")
+    h2h = VimH2H(slurp(os.path.join(in_dir, 'tags'))[0], is_web_version=False)
+
+    if len(basenames) == 0:
+        basenames = os.listdir(in_dir)
+
+    for basename in basenames:
+        if os.path.splitext(basename)[1] != '.txt' and basename != 'tags':
+            print( "Ignoring " + basename)
+            continue
+        print( "Processing " + basename + "...")
+        path = os.path.join(in_dir, basename)
+        text, encoding = slurp(path)
+        outpath = os.path.join(out_dir, basename + '.html')
+        of = open(outpath, 'w')
+        of.write(h2h.to_html(basename, text, encoding))
+        of.close()
+
+main()
+#cProfile.run('main()')

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -743,6 +743,9 @@ void nvim_err_writeln(String str)
 
 /// Gets the current list of buffer handles
 ///
+/// Includes unlisted (unloaded/deleted) buffers, like `:ls!`.
+/// Use |nvim_buf_is_loaded()| to check if a buffer is loaded.
+///
 /// @return List of buffer handles
 ArrayOf(Buffer) nvim_list_bufs(void)
   FUNC_API_SINCE(1)

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2173,7 +2173,7 @@ void intro_message(int colon)
     N_(NVIM_VERSION_LONG),
     "",
     N_("Nvim is open source and freely distributable"),
-    N_("https://neovim.io/community"),
+    N_("https://neovim.io/#chat"),
     "",
     N_("type  :help nvim<Enter>       if you are new! "),
     N_("type  :checkhealth<Enter>     to optimize Nvim"),

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1237,7 +1237,7 @@ describe('API', function()
 
   describe('nvim_list_uis', function()
     it('returns empty if --headless', function()
-      -- --embed implies --headless.
+      -- Test runner defaults to --headless.
       eq({}, nvim("list_uis"))
     end)
     it('returns attached UIs', function()

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -494,7 +494,7 @@ function Screen:_wait(check, flags)
   if warn_immediate and immediate_seen then
      print([[
 
-Warning: A screen test has immediate success. Try to avoid this unless the
+warning: Screen test succeeded immediately. Try to avoid this unless the
 purpose of the test really requires it.]])
     if intermediate_seen then
       print([[
@@ -503,8 +503,7 @@ Use screen:snapshot_util() or screen:redraw_debug() to find them, and add them
 to the test if they make sense.
 ]])
     else
-      print([[If necessary, silence this warning by
-supplying the 'unchanged' argument to screen:expect.]])
+      print([[If necessary, silence this warning with 'unchanged' argument of screen:expect.]])
     end
     did_warn = true
   end
@@ -512,19 +511,17 @@ supplying the 'unchanged' argument to screen:expect.]])
   if failure_after_success then
     print([[
 
-Warning: Screen changes were received after the expected state. This indicates
+warning: Screen changes were received after the expected state. This indicates
 indeterminism in the test. Try adding screen:expect(...) (or wait()) between
 asynchronous (feed(), nvim_input()) and synchronous API calls.
-  - Use Screen:redraw_debug() to investigate the problem. It might find
-    relevant intermediate states that should be added to the test to make it
-    more robust.
-  - If the point of the test is to assert the state after some user input
-    sent with feed(...), also adding an screen:expect(...) before the feed(...)
-    will help ensure the input is sent to nvim when nvim is in a predictable
-    state. This is preferable to using wait(), as it is more closely emulates
-    real user interaction.
+  - Use screen:redraw_debug() to investigate; it may find relevant intermediate
+    states that should be added to the test to make it more robust.
+  - If the purpose of the test is to assert state after some user input sent
+    with feed(), adding screen:expect() before the feed() will help to ensure
+    the input is sent when Nvim is in a predictable state. This is preferable
+    to wait(), for being closer to real user interaction.
   - wait() can trigger redraws and consequently generate more indeterminism.
-    In that case try removing every wait().
+    Try removing wait().
       ]])
     did_warn = true
   end


### PR DESCRIPTION
- develop.txt is for design/guidelines; architecture/concepts should
  live elsewhere (currently src/nvim/README.md)
- move dev-jargon to intro.txt
- replace https://neovim.io/community (deprecated) with
  https://neovim.io/#chat