### PR TITLE
[RDY]vim-patch:8.1.0516

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -816,8 +816,21 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
   linenr_T last_line;  // Last line in file after adding new text
 
   if (dest >= line1 && dest < line2) {
-    EMSG(_("E134: Move lines into themselves"));
+    EMSG(_("E134: Cannot move a range of lines into itself"));
     return FAIL;
+  }
+
+  // Do nothing if we are not actually moving any lines.  This will prevent
+  // the 'modified' flag from being set without cause.
+  if (dest == line1 - 1 || dest == line2) {
+    // Move the cursor as if lines were moved (see below) to be backwards
+    // compatible.
+    if (dest >= line1) {
+      curwin->w_cursor.lnum = dest;
+    } else {
+      curwin->w_cursor.lnum = dest + (line2 - line1) + 1;
+    }
+    return OK;
   }
 
   num_lines = line2 - line1 + 1;

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -28,6 +28,7 @@ source test_lambda.vim
 source test_mapping.vim
 source test_menu.vim
 source test_messages.vim
+source test_move.vim
 source test_partial.vim
 source test_popup.vim
 source test_put.vim

--- a/src/nvim/testdir/test_move.vim
+++ b/src/nvim/testdir/test_move.vim
@@ -1,0 +1,40 @@
+" Test the ":move" command.
+
+func Test_move()
+  enew!
+  call append(0, ['line 1', 'line 2', 'line 3'])
+  g /^$/ delete _
+  set nomodified
+
+  move .
+  call assert_equal(['line 1', 'line 2', 'line 3'], getline(1, 3))
+  call assert_false(&modified)
+
+  1,2move 0
+  call assert_equal(['line 1', 'line 2', 'line 3'], getline(1, 3))
+  call assert_false(&modified)
+
+  1,3move 3
+  call assert_equal(['line 1', 'line 2', 'line 3'], getline(1, 3))
+  call assert_false(&modified)
+
+  1move 2
+  call assert_equal(['line 2', 'line 1', 'line 3'], getline(1, 3))
+  call assert_true(&modified)
+  set nomodified
+
+  3move 0
+  call assert_equal(['line 3', 'line 2', 'line 1'], getline(1, 3))
+  call assert_true(&modified)
+  set nomodified
+
+  2,3move 0
+  call assert_equal(['line 2', 'line 1', 'line 3'], getline(1, 3))
+  call assert_true(&modified)
+  set nomodified
+
+  call assert_fails('1,2move 1', 'E134')
+  call assert_fails('2,3move 2', 'E134')
+
+  %bwipeout!
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0516: :move command marks buffer modified when nothing changed**

Problem:    :move command marks buffer modified when nothing changed.
Solution:   Do not set 'modified'.  Add a test. (Jason Franklin)
https://github.com/vim/vim/commit/ddd1f9183bed00d096f29c503721ac559174a29f