### PR TITLE
[RDY] vim-patch:8.1.{115,143,311,352}

### DIFF
--- a/runtime/pack/dist/opt/cfilter/plugin/cfilter.vim
+++ b/runtime/pack/dist/opt/cfilter/plugin/cfilter.vim
@@ -1,0 +1,43 @@
+" cfilter.vim: Plugin to filter entries from a quickfix/location list
+" Last Change: 	May 12, 2018
+" Maintainer: 	Yegappan Lakshmanan (yegappan AT yahoo DOT com)
+" Version:	1.0
+"
+" Commands to filter the quickfix list:
+"   :Cfilter[!] {pat}
+"       Create a new quickfix list from entries matching {pat} in the current
+"       quickfix list. Both the file name and the text of the entries are
+"       matched against {pat}. If ! is supplied, then entries not matching
+"       {pat} are used.
+"   :Lfilter[!] {pat}
+"       Same as :Cfilter but operates on the current location list.
+"
+if exists("loaded_cfilter")
+    finish
+endif
+let loaded_cfilter = 1
+
+func s:Qf_filter(qf, pat, bang)
+    if a:qf
+	let Xgetlist = function('getqflist')
+	let Xsetlist = function('setqflist')
+	let cmd = ':Cfilter' . a:bang
+    else
+	let Xgetlist = function('getloclist', [0])
+	let Xsetlist = function('setloclist', [0])
+	let cmd = ':Lfilter' . a:bang
+    endif
+
+    if a:bang == '!'
+	let cond = 'v:val.text !~# a:pat && bufname(v:val.bufnr) !~# a:pat'
+    else
+	let cond = 'v:val.text =~# a:pat || bufname(v:val.bufnr) =~# a:pat'
+    endif
+
+    let items = filter(Xgetlist(), cond)
+    let title = cmd . ' ' . a:pat
+    call Xsetlist([], ' ', {'title' : title, 'items' : items})
+endfunc
+
+com! -nargs=+ -bang Cfilter call s:Qf_filter(1, <q-args>, <q-bang>)
+com! -nargs=+ -bang Lfilter call s:Qf_filter(0, <q-args>, <q-bang>)

--- a/runtime/plugin/matchit.vim
+++ b/runtime/plugin/matchit.vim
@@ -1,5 +1,5 @@
 "  matchit.vim: (global plugin) Extended "%" matching
-"  Last Change: 2017 Sep 15
+"  Last Change: 2018 Jul 3 by Christian Brabandt
 "  Maintainer:  Benji Fisher PhD   <benji@member.AMS.org>
 "  Version:     1.13.3, for Vim 6.3+
 "		Fix from Tommy Allen included.
@@ -268,7 +268,7 @@ function! s:Match_wrapper(word, forward, mode) range
   "   execute "normal!" . curcol . "l"
   " endif
   if skip =~ 'synID' && !(has("syntax") && exists("g:syntax_on"))
-    let skip = "0"
+    let skip = '0'
   else
     execute "if " . skip . "| let skip = '0' | endif"
   endif
@@ -708,10 +708,16 @@ fun! s:MultiMatch(spflag, mode)
   let openpat = substitute(openpat, ',', '\\|', 'g')
   let closepat = substitute(close, '\(\\\@<!\(\\\\\)*\)\@<=\\(', '\\%(', 'g')
   let closepat = substitute(closepat, ',', '\\|', 'g')
+
   if skip =~ 'synID' && !(has("syntax") && exists("g:syntax_on"))
     let skip = '0'
   else
-    execute "if " . skip . "| let skip = '0' | endif"
+    try
+      execute "if " . skip . "| let skip = '0' | endif"
+    catch /^Vim\%((\a\+)\)\=:E363/
+      " We won't find anything, so skip searching, should keep Vim responsive.
+      return
+    endtry
   endif
   mark '
   let level = v:count1

--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -114,7 +114,7 @@ function! s:Highlight_Matching_Pair()
   " within those syntax types (i.e., not skip).  Otherwise, the cursor is
   " outside of the syntax types and s_skip should keep its value so we skip any
   " matching pair inside the syntax types.
-  execute 'if' s_skip '| let s_skip = 0 | endif'
+  execute 'if' s_skip '| let s_skip = "0" | endif'
 
   " Limit the search to lines visible in the window.
   let stoplinebottom = line('w$')

--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -1,6 +1,6 @@
 " Vim plugin for showing matching parens
 " Maintainer:  Bram Moolenaar <Bram@vim.org>
-" Last Change: 2018 Jun 23
+" Last Change: 2018 Jul 3
 
 " Exit quickly when:
 " - this plugin was already loaded (or disabled)
@@ -103,18 +103,28 @@ function! s:Highlight_Matching_Pair()
     call cursor(c_lnum, c_col - before)
   endif
 
-  " Build an expression that detects whether the current cursor position is in
-  " certain syntax types (string, comment, etc.), for use as searchpairpos()'s
-  " skip argument.
-  " We match "escape" for special items, such as lispEscapeSpecial.
-  let s_skip = '!empty(filter(map(synstack(line("."), col(".")), ''synIDattr(v:val, "name")''), ' .
+  if !has("syntax") || !exists("g:syntax_on")
+    let s_skip = "0"
+  else
+    " Build an expression that detects whether the current cursor position is
+    " in certain syntax types (string, comment, etc.), for use as
+    " searchpairpos()'s skip argument.
+    " We match "escape" for special items, such as lispEscapeSpecial.
+    let s_skip = '!empty(filter(map(synstack(line("."), col(".")), ''synIDattr(v:val, "name")''), ' .
 	\ '''v:val =~? "string\\|character\\|singlequote\\|escape\\|comment"''))'
-  " If executing the expression determines that the cursor is currently in
-  " one of the syntax types, then we want searchpairpos() to find the pair
-  " within those syntax types (i.e., not skip).  Otherwise, the cursor is
-  " outside of the syntax types and s_skip should keep its value so we skip any
-  " matching pair inside the syntax types.
-  execute 'if' s_skip '| let s_skip = "0" | endif'
+    " If executing the expression determines that the cursor is currently in
+    " one of the syntax types, then we want searchpairpos() to find the pair
+    " within those syntax types (i.e., not skip).  Otherwise, the cursor is
+    " outside of the syntax types and s_skip should keep its value so we skip
+    " any matching pair inside the syntax types.
+    " Catch if this throws E363: pattern uses more memory than 'maxmempattern'.
+    try
+      execute 'if ' . s_skip . ' | let s_skip = "0" | endif'
+    catch /^Vim\%((\a\+)\)\=:E363/
+      " We won't find anything, so skip searching, should keep Vim responsive.
+      return
+    endtry
+  endif
 
   " Limit the search to lines visible in the window.
   let stoplinebottom = line('w$')


### PR DESCRIPTION
**vim-patch:8.1.0115: the matchparen plugin may throw an error**

Problem:    The matchparen plugin may throw an error.
Solution:   Change the skip argument from zero to "0".
vim/vim@b7a5ab1

**vim-patch:8.1.0143: matchit and matchparen don't handle E363**

Problem:    Matchit and matchparen don't handle E363.
Solution:   Catch the E363 error. (Christian Brabandt)
vim/vim@3d1d647

**vim-patch:8.1.0311: filtering entries in a quickfix list is not easy**

Problem:    Filtering entries in a quickfix list is not easy.
Solution:   Add the cfilter plugin. (Yegappan Lakshmanan)
vim/vim@8c5e009

**vim-patch:8.1.0352: browsing compressed tar files does not always work**

Problem:    Browsing compressed tar files does not always work.
Solution:   Use the "file" command to get the compression type.
vim/vim@d4a1aab