### PR TITLE
Merge #8421 "Fix expression highlighting"

### DIFF
--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -556,7 +556,7 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
   const char_u *end_of_name;
   const char_u *src;
   const char_u *bp;
-  const char_u *const end = *srcp + src_len - 1;
+  const char_u *const end = *srcp + src_len;
   int modifiers;
   int bit;
   int key;
@@ -574,23 +574,23 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
 
   // Find end of modifier list
   last_dash = src;
-  for (bp = src + 1; bp <= end && (*bp == '-' || ascii_isident(*bp)); bp++) {
+  for (bp = src + 1; bp < end && (*bp == '-' || ascii_isident(*bp)); bp++) {
     if (*bp == '-') {
       last_dash = bp;
-      if (bp + 1 <= end) {
-        l = utfc_ptr2len_len(bp + 1, (int)(end - bp) + 1);
+      if (bp + 1 < end) {
+        l = utfc_ptr2len_len(bp + 1, (int)(end - (bp + 1)));
         // Anything accepted, like <C-?>.
         // <C-"> or <M-"> are not special in strings as " is
         // the string delimiter. With a backslash it works: <M-\">
-        if (end - bp > l && !(in_string && bp[1] == '"') && bp[2] == '>') {
+        if (end - bp > 2 && !(in_string && bp[1] == '"') && bp[2] == '>') {
           bp += l;
-        } else if (end - bp > 2 && in_string && bp[1] == '\\'
+        } else if (end - bp > 3 && in_string && bp[1] == '\\'
                    && bp[2] == '"' && bp[3] == '>') {
           bp += 2;
         }
       }
     }
-    if (end - bp > 3 && bp[0] == 't' && bp[1] == '_') {
+    if (end - bp > 2 && bp[0] == 't' && bp[1] == '_') {
       bp += 3;  // skip t_xx, xx may be '-' or '>'
     } else if (end - bp > 4 && STRNICMP(bp, "char-", 5) == 0) {
       vim_str2nr(bp + 5, NULL, &l, STR2NR_ALL, NULL, NULL, 0);
@@ -599,7 +599,7 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
     }
   }
 
-  if (bp <= end && *bp == '>') {  // found matching '>'
+  if (end - bp > 0 && *bp == '>') {  // found matching '>'
     end_of_name = bp + 1;
 
     /* Which modifiers are given? */

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1552,6 +1552,20 @@ void mb_copy_char(const char_u **const fp, char_u **const tp)
   *fp += l;
 }
 
+/// Copy a single codepoint, advancing the pointers
+///
+/// @param[in,out]  fp  Source of the character to copy.
+/// @param[in,out]  tp  Destination to copy to.
+/// @param[in]  f_size  Length of the source.
+void mb_copy_len(const char **const fp, char **const tp, const size_t f_size)
+{
+  const size_t l = (size_t)utf_ptr2len_len((const char_u *)*fp, f_size);
+
+  memmove(*tp, *fp, l);
+  *tp += l;
+  *fp += l;
+}
+
 /*
  * Return the offset from "p" to the first byte of a character.  When "p" is
  * at the start of a character 0 is returned, otherwise the offset to the next

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -50,6 +50,7 @@
 #include "nvim/misc1.h"
 #include "nvim/memory.h"
 #include "nvim/option.h"
+#include "nvim/macros.h"
 #include "nvim/screen.h"
 #include "nvim/spell.h"
 #include "nvim/strings.h"
@@ -1559,11 +1560,12 @@ void mb_copy_char(const char_u **const fp, char_u **const tp)
 /// @param[in]  f_size  Length of the source.
 void mb_copy_len(const char **const fp, char **const tp, const size_t f_size)
 {
-  const size_t l = (size_t)utf_ptr2len_len((const char_u *)*fp, f_size);
+  const size_t l = (size_t)utf_ptr2len_len((const char_u *)(*fp), f_size);
+  const size_t adv = MIN(l, f_size);
 
-  memmove(*tp, *fp, l);
-  *tp += l;
-  *fp += l;
+  memmove(*tp, *fp, adv);
+  *tp += adv;
+  *fp += adv;
 }
 
 /*

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -11,7 +11,6 @@
 # include <unistd.h>
 # include <sys/mman.h>
 # include <errno.h>
-# include <string.h>
 #endif
 
 #include "nvim/vim.h"

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -30,6 +30,10 @@ extern MemCalloc mem_calloc;
 
 /// When unit testing: pointer to the `realloc()` function, may be altered
 extern MemRealloc mem_realloc;
+
+size_t mem_pagesize(void);
+void *mem_pagealloc(size_t);
+void mem_pagefree(void *, size_t);
 #endif
 
 #ifdef EXITFREE

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -2790,11 +2790,15 @@ viml_pexpr_parse_figure_brace_closing_error:
           if (want_node == kENodeValue) {
             if (kv_size(ast_stack) > 1) {
               const ExprASTNode *const prev_top_node = *kv_Z(ast_stack, 1);
-              if (prev_top_node->type == kExprNodeCall) {
-                // Function call without arguments, this is not an error.
-                // But further code does not expect NULL nodes.
+              if (prev_top_node->type == kExprNodeCall
+                  || prev_top_node->type == kExprNodeComma) {
+                // These are not errors:
+                // - Function call without arguments.
+                // - Trailing comma in a function call.
+                // Still drop one stack entry as further code does not expect
+                // NULL nodes.
                 kv_drop(ast_stack, 1);
-                goto viml_pexpr_parse_no_paren_closing_error;
+                goto viml_pexpr_parse_paren_up;
               }
             }
             ERROR_FROM_TOKEN_AND_MSG(
@@ -2808,7 +2812,7 @@ viml_pexpr_parse_figure_brace_closing_error:
             // well be "(@a)" which needs not be finished again.
             kv_drop(ast_stack, 1);
           }
-viml_pexpr_parse_no_paren_closing_error: {}
+viml_pexpr_parse_paren_up: {}
           ExprASTNode **new_top_node_p = NULL;
           while (kv_size(ast_stack)
                  && (new_top_node_p == NULL

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -2442,7 +2442,7 @@ viml_pexpr_parse_valid_colon:
 viml_pexpr_parse_bracket_closing_error:
               assert(!kv_size(ast_stack));
               ERROR_FROM_TOKEN_AND_MSG(
-                  cur_token, _("E15: Unexpected closing figure brace: %.*s"));
+                  cur_token, _("E15: Unexpected closing bracket: %.*s"));
               HL_CUR_TOKEN(List);
               break;
             }

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -2398,6 +2398,7 @@ viml_pexpr_parse_valid_colon:
               cur_node->children = *top_node_p;
             }
             *top_node_p = cur_node;
+            new_top_node_p = top_node_p;
             goto viml_pexpr_parse_bracket_closing_error;
           }
           if (want_node == kENodeValue) {

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -1778,13 +1778,13 @@ static void parse_quoted_string(ParserState *const pstate,
               v_p += special_len;
             } else {
               is_unknown = true;
-              mb_copy_char((const char_u **)&p, (char_u **)&v_p);
+              mb_copy_len(&p, &v_p, (size_t)(e - p));
             }
             break;
           }
           default: {
             is_unknown = true;
-            mb_copy_char((const char_u **)&p, (char_u **)&v_p);
+            mb_copy_len(&p, &v_p, (size_t)(e - p));
             break;
           }
         }

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -112,6 +112,7 @@ typedef enum {
   kEOpLvlColon,
   kEOpLvlTernaryValue,
   kEOpLvlTernary,
+  kEOpLvlOpMissing,  ///< Missing operator.
   kEOpLvlOr,
   kEOpLvlAnd,
   kEOpLvlComparison,
@@ -1101,7 +1102,7 @@ static struct {
   ExprOpAssociativity ass;
 } node_type_to_node_props[] = {
   [kExprNodeMissing] = { kEOpLvlInvalid, kEOpAssNo, },
-  [kExprNodeOpMissing] = { kEOpLvlMultiplication, kEOpAssNo },
+  [kExprNodeOpMissing] = { kEOpLvlOpMissing, kEOpAssNo },
 
   [kExprNodeNested] = { kEOpLvlParens, kEOpAssNo },
   // Note: below nodes are kEOpLvlSubscript for “binary operator” itself, but

--- a/test/symbolic/klee/nvim/keymap.c
+++ b/test/symbolic/klee/nvim/keymap.c
@@ -369,7 +369,7 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
   const char_u *end_of_name;
   const char_u *src;
   const char_u *bp;
-  const char_u *const end = *srcp + src_len - 1;
+  const char_u *const end = *srcp + src_len;
   int modifiers;
   int bit;
   int key;
@@ -387,23 +387,23 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
 
   // Find end of modifier list
   last_dash = src;
-  for (bp = src + 1; bp <= end && (*bp == '-' || ascii_isident(*bp)); bp++) {
+  for (bp = src + 1; bp < end && (*bp == '-' || ascii_isident(*bp)); bp++) {
     if (*bp == '-') {
       last_dash = bp;
-      if (bp + 1 <= end) {
-        l = utfc_ptr2len_len(bp + 1, (int)(end - bp) + 1);
+      if (bp + 1 < end) {
+        l = utfc_ptr2len_len(bp + 1, (int)(end - (bp + 1)));
         // Anything accepted, like <C-?>.
         // <C-"> or <M-"> are not special in strings as " is
         // the string delimiter. With a backslash it works: <M-\">
-        if (end - bp > l && !(in_string && bp[1] == '"') && bp[2] == '>') {
+        if (end - bp > 2 && !(in_string && bp[1] == '"') && bp[2] == '>') {
           bp += l;
-        } else if (end - bp > 2 && in_string && bp[1] == '\\'
+        } else if (end - bp > 3 && in_string && bp[1] == '\\'
                    && bp[2] == '"' && bp[3] == '>') {
           bp += 2;
         }
       }
     }
-    if (end - bp > 3 && bp[0] == 't' && bp[1] == '_') {
+    if (end - bp > 2 && bp[0] == 't' && bp[1] == '_') {
       bp += 3;  // skip t_xx, xx may be '-' or '>'
     } else if (end - bp > 4 && STRNICMP(bp, "char-", 5) == 0) {
       vim_str2nr(bp + 5, NULL, &l, STR2NR_ALL, NULL, NULL, 0);
@@ -412,7 +412,7 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
     }
   }
 
-  if (bp <= end && *bp == '>') {  // found matching '>'
+  if (end - bp > 0 && *bp == '>') {  // found matching '>'
     end_of_name = bp + 1;
 
     /* Which modifiers are given? */
@@ -439,9 +439,11 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
 
         // Modifier with single letter, or special key name.
         if (in_string && last_dash[1] == '\\' && last_dash[2] == '"') {
-          off = 2;
+          // Special case for a double-quoted string
+          off = l = 2;
+        } else {
+          l = mb_ptr2len(last_dash + 1);
         }
-        l = mb_ptr2len(last_dash + 1);
         if (modifiers != 0 && last_dash[l + 1] == '>') {
           key = PTR2CHAR(last_dash + off);
         } else {
@@ -482,6 +484,7 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
   }
   return 0;
 }
+
 
 char_u *add_char2buf(int c, char_u *s)
 {

--- a/test/symbolic/klee/nvim/mbyte.c
+++ b/test/symbolic/klee/nvim/mbyte.c
@@ -256,11 +256,11 @@ int utfc_ptr2len(const char_u *const p)
   }
 }
 
-void mb_copy_char(const char_u **fp, char_u **tp)
+void mb_copy_len(const char **const fp, char **const tp, const size_t f_size)
 {
-  const size_t l = utfc_ptr2len(*fp);
+  const size_t l = (size_t)utf_ptr2len_len((const char_u *)*fp, f_size);
 
-  memmove(*tp, *fp, (size_t)l);
+  memmove(*tp, *fp, l);
   *tp += l;
   *fp += l;
 }

--- a/test/symbolic/klee/nvim/mbyte.c
+++ b/test/symbolic/klee/nvim/mbyte.c
@@ -259,8 +259,9 @@ int utfc_ptr2len(const char_u *const p)
 void mb_copy_len(const char **const fp, char **const tp, const size_t f_size)
 {
   const size_t l = (size_t)utf_ptr2len_len((const char_u *)*fp, f_size);
+  const size_t adv = MIN(l, f_size);
 
-  memmove(*tp, *fp, l);
-  *tp += l;
-  *fp += l;
+  memmove(*tp, *fp, adv);
+  *tp += adv;
+  *fp += adv;
 }

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -266,17 +266,17 @@ else
   cimportstr = _cimportstr
 end
 
-local function pagealloc(size, alloc_log)
-  local lib = cimport('./src/nvim/memory.h')
-  local pagesize = lib.mem_pagesize()
+local function pagealloc(size)
+  local m = cimport('./src/nvim/memory.h')
+  local pagesize = m.mem_pagesize()
   local num_pages = 1
   while num_pages * pagesize < size do
     num_pages = num_pages + 1
   end
-  local mem = ffi.gc(lib.mem_pagealloc(num_pages), nil)
+  local mem = ffi.gc(m.mem_pagealloc(num_pages), nil)
   local start = ffi.cast('char*', mem) + ((num_pages * pagesize) - size)
   local free = function(_)
-    lib.mem_pagefree(mem, num_pages)
+    m.mem_pagefree(mem, num_pages)
   end
   return ffi.gc(start, free), free
 end

--- a/test/unit/viml/expressions/parser_spec.lua
+++ b/test/unit/viml/expressions/parser_spec.lua
@@ -471,7 +471,7 @@ describe('Expressions parser', function()
         end
         alloc_log:check({})
 
-        local pstate = new_pstate({str}, opts.pagealloc, alloc_log)
+        local pstate = new_pstate({str}, opts.pagealloc)
         local east = lib.viml_pexpr_parse(pstate, flags)
         local ast = east2lua(str, pstate, east)
         local hls = phl2lua(pstate)

--- a/test/unit/viml/expressions/parser_spec.lua
+++ b/test/unit/viml/expressions/parser_spec.lua
@@ -471,7 +471,7 @@ describe('Expressions parser', function()
         end
         alloc_log:check({})
 
-        local pstate = new_pstate({str})
+        local pstate = new_pstate({str}, opts.pagealloc, alloc_log)
         local east = lib.viml_pexpr_parse(pstate, flags)
         local ast = east2lua(str, pstate, east)
         local hls = phl2lua(pstate)

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -7432,7 +7432,7 @@ return function(itp, _check_parsing, hl, fmtn)
           'OpMissing:0:3:',
           children = {
             {
-              'UnknownFigure(---):0:2:',
+              fmtn('UnknownFigure', '---', ':0:2:'),
               children = {
                 'Integer(val=90):0:0:90',
               },
@@ -7454,7 +7454,7 @@ return function(itp, _check_parsing, hl, fmtn)
         ast = {
           ast = {
             {
-              'UnknownFigure(---):0:2:',
+              fmtn('UnknownFigure', '---', ':0:2:'),
               children = {
                 'Integer(val=90):0:0:90',
                 REMOVE_THIS,
@@ -7656,7 +7656,7 @@ return function(itp, _check_parsing, hl, fmtn)
           'OpMissing:0:2:',
           children = {
             {
-              'UnknownFigure(---):0:1:',
+              fmtn('UnknownFigure', '---', ':0:1:'),
               children = {
                 {
                   'Multiplication:0:0:*',
@@ -7683,7 +7683,7 @@ return function(itp, _check_parsing, hl, fmtn)
         ast = {
           ast = {
             {
-              'UnknownFigure(---):0:1:',
+              fmtn('UnknownFigure', '---', ':0:1:'),
               children = {
                 {
                   'Multiplication:0:0:*',
@@ -8861,7 +8861,7 @@ return function(itp, _check_parsing, hl, fmtn)
             {
               'OpMissing:0:9:',
               children = {
-                'SingleQuotedString(val=NULL):0:7:\'\'',
+                fmtn('SingleQuotedString', 'val=NULL', ':0:7:\'\''),
                 {
                   'Multiplication:0:11: *',
                   children = {

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -5143,8 +5143,8 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('SingleQuote', '\''),
     })
     check_parsing('\'\'\'a\'\'\'\'bc\'', {
-      --           01234567890
-      --           0         1
+      --           0 1 2 34 5 6 7 890
+      --           0                1
       ast = {
         fmtn('SingleQuotedString', 'val="\'a\'\'bc"', ':0:0:\'\'\'a\'\'\'\'bc\''),
       },
@@ -5158,7 +5158,7 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('SingleQuote', '\''),
     })
     check_parsing('"\\"\\"\\"\\""', {
-      --           0123456789
+      --           01 23 45 67 89
       ast = {
         fmtn('DoubleQuotedString', 'val="\\"\\"\\"\\""', ':0:0:"\\"\\"\\"\\""'),
       },
@@ -5171,8 +5171,8 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('DoubleQuote', '"'),
     })
     check_parsing('"abc\\"def\\"ghi\\"jkl\\"mno"', {
-      --           0123456789012345678901234
-      --           0         1         2
+      --           01234 56789 01234 56789 01234
+      --           0           1           2
       ast = {
         fmtn('DoubleQuotedString', 'val="abc\\"def\\"ghi\\"jkl\\"mno"', ':0:0:"abc\\"def\\"ghi\\"jkl\\"mno"'),
       },
@@ -5190,10 +5190,10 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('DoubleQuote', '"'),
     })
     check_parsing('"\\b\\e\\f\\r\\t\\\\"', {
-      --           0123456789012345
-      --           0         1
+      --           01 23 45 67 89 01 2 3
+      --           0              1
       ast = {
-        [[DoubleQuotedString(val="\008\027\012\r\t\\"):0:0:"\b\e\f\r\t\\"]],
+        fmtn('DoubleQuotedString', [[val="\008\027\012\r\t\\"]], [[:0:0:"\b\e\f\r\t\\"]]),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5206,7 +5206,7 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('DoubleQuote', '"'),
     })
     check_parsing('"\\n\n"', {
-      --           01234
+      --           01 23 4
       ast = {
         fmtn('DoubleQuotedString', 'val="\\n\\n"', ':0:0:"\\n\n"'),
       },
@@ -5217,7 +5217,7 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('DoubleQuote', '"'),
     })
     check_parsing('"\\x00"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000"', ':0:0:"\\x00"'),
       },
@@ -5227,7 +5227,7 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('DoubleQuote', '"'),
     })
     check_parsing('"\\xFF"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\255"', ':0:0:"\\xFF"'),
       },
@@ -5237,7 +5237,7 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('DoubleQuote', '"'),
     })
     check_parsing('"\\xF"', {
-      --           012345
+      --           01 235
       ast = {
         fmtn('DoubleQuotedString', 'val="\\015"', ':0:0:"\\xF"'),
       },
@@ -5247,7 +5247,7 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('DoubleQuote', '"'),
     })
     check_parsing('"\\u00AB"', {
-      --           01234567
+      --           01 234567
       ast = {
         fmtn('DoubleQuotedString', 'val="«"', ':0:0:"\\u00AB"'),
       },
@@ -5257,7 +5257,8 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('DoubleQuote', '"'),
     })
     check_parsing('"\\U000000AB"', {
-      --           01234567
+      --           01 2345678901
+      --           0          1
       ast = {
         fmtn('DoubleQuotedString', 'val="«"', ':0:0:"\\U000000AB"'),
       },
@@ -5267,7 +5268,7 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('DoubleQuote', '"'),
     })
     check_parsing('"\\x"', {
-      --           0123
+      --           01 23
       ast = {
         fmtn('DoubleQuotedString', 'val="x"', ':0:0:"\\x"'),
       },
@@ -5278,7 +5279,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\x', {
-      --           012
+      --           0 12
       ast = {
         fmtn('DoubleQuotedString', 'val="x"', ':0:0:"\\x'),
       },
@@ -5292,7 +5293,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\xF', {
-      --           0123
+      --           01 23
       ast = {
         fmtn('DoubleQuotedString', 'val="\\015"', ':0:0:"\\xF'),
       },
@@ -5306,7 +5307,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\u"', {
-      --           0123
+      --           01 23
       ast = {
         fmtn('DoubleQuotedString', 'val="u"', ':0:0:"\\u"'),
       },
@@ -5317,7 +5318,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\u', {
-      --           012
+      --           01 2
       ast = {
         fmtn('DoubleQuotedString', 'val="u"', ':0:0:"\\u'),
       },
@@ -5331,7 +5332,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\U', {
-      --           012
+      --           01 2
       ast = {
         fmtn('DoubleQuotedString', 'val="U"', ':0:0:"\\U'),
       },
@@ -5345,7 +5346,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\U"', {
-      --           0123
+      --           01 23
       ast = {
         fmtn('DoubleQuotedString', 'val="U"', ':0:0:"\\U"'),
       },
@@ -5356,7 +5357,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\xFX"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\\015X"', ':0:0:"\\xFX"'),
       },
@@ -5368,7 +5369,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\XFX"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\\015X"', ':0:0:"\\XFX"'),
       },
@@ -5380,7 +5381,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\xX"', {
-      --           01234
+      --           01 234
       ast = {
         fmtn('DoubleQuotedString', 'val="xX"', ':0:0:"\\xX"'),
       },
@@ -5392,7 +5393,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\XX"', {
-      --           01234
+      --           01 234
       ast = {
         fmtn('DoubleQuotedString', 'val="XX"', ':0:0:"\\XX"'),
       },
@@ -5404,7 +5405,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\uX"', {
-      --           01234
+      --           01 234
       ast = {
         fmtn('DoubleQuotedString', 'val="uX"', ':0:0:"\\uX"'),
       },
@@ -5416,7 +5417,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\UX"', {
-      --           01234
+      --           01 234
       ast = {
         fmtn('DoubleQuotedString', 'val="UX"', ':0:0:"\\UX"'),
       },
@@ -5428,7 +5429,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\x0X"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\x0X"'),
       },
@@ -5440,7 +5441,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\X0X"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\X0X"'),
       },
@@ -5452,7 +5453,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\u0X"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\u0X"'),
       },
@@ -5464,7 +5465,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\U0X"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U0X"'),
       },
@@ -5476,7 +5477,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\x00X"', {
-      --           0123456
+      --           01 23456
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\x00X"'),
       },
@@ -5488,7 +5489,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\X00X"', {
-      --           0123456
+      --           01 23456
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\X00X"'),
       },
@@ -5500,7 +5501,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\u00X"', {
-      --           0123456
+      --           01 23456
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\u00X"'),
       },
@@ -5512,7 +5513,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\U00X"', {
-      --           0123456
+      --           01 23456
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U00X"'),
       },
@@ -5524,7 +5525,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\u000X"', {
-      --           01234567
+      --           01 234567
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\u000X"'),
       },
@@ -5536,7 +5537,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\U000X"', {
-      --           01234567
+      --           01 234567
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U000X"'),
       },
@@ -5548,7 +5549,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\u0000X"', {
-      --           012345678
+      --           01 2345678
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\u0000X"'),
       },
@@ -5560,7 +5561,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\U0000X"', {
-      --           012345678
+      --           01 2345678
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U0000X"'),
       },
@@ -5572,7 +5573,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\U00000X"', {
-      --           0123456789
+      --           01 23456789
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U00000X"'),
       },
@@ -5584,8 +5585,8 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\U000000X"', {
-      --           01234567890
-      --           0         1
+      --           01 234567890
+      --           0          1
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U000000X"'),
       },
@@ -5597,8 +5598,8 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\U0000000X"', {
-      --           012345678901
-      --           0         1
+      --           01 2345678901
+      --           0          1
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U0000000X"'),
       },
@@ -5610,8 +5611,8 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\U00000000X"', {
-      --           0123456789012
-      --           0         1
+      --           01 23456789012
+      --           0          1
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000X"', ':0:0:"\\U00000000X"'),
       },
@@ -5623,7 +5624,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\x000X"', {
-      --           01234567
+      --           01 234567
       ast = {
         fmtn('DoubleQuotedString', 'val="\\0000X"', ':0:0:"\\x000X"'),
       },
@@ -5635,7 +5636,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\X000X"', {
-      --           01234567
+      --           01 234567
       ast = {
         fmtn('DoubleQuotedString', 'val="\\0000X"', ':0:0:"\\X000X"'),
       },
@@ -5647,7 +5648,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\u00000X"', {
-      --           0123456789
+      --           01 23456789
       ast = {
         fmtn('DoubleQuotedString', 'val="\\0000X"', ':0:0:"\\u00000X"'),
       },
@@ -5659,8 +5660,8 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\U000000000X"', {
-      --           01234567890123
-      --           0         1
+      --           01 234567890123
+      --           0          1
       ast = {
         fmtn('DoubleQuotedString', 'val="\\0000X"', ':0:0:"\\U000000000X"'),
       },
@@ -5672,7 +5673,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\0"', {
-      --           0123
+      --           01 23
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000"', ':0:0:"\\0"'),
       },
@@ -5683,7 +5684,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\00"', {
-      --           01234
+      --           01 234
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000"', ':0:0:"\\00"'),
       },
@@ -5694,7 +5695,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\000"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\\000"', ':0:0:"\\000"'),
       },
@@ -5705,7 +5706,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\0000"', {
-      --           0123456
+      --           01 23456
       ast = {
         fmtn('DoubleQuotedString', 'val="\\0000"', ':0:0:"\\0000"'),
       },
@@ -5717,7 +5718,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\8"', {
-      --           0123
+      --           01 23
       ast = {
         fmtn('DoubleQuotedString', 'val="8"', ':0:0:"\\8"'),
       },
@@ -5728,7 +5729,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\08"', {
-      --           01234
+      --           01 234
       ast = {
         fmtn('DoubleQuotedString', 'val="\\0008"', ':0:0:"\\08"'),
       },
@@ -5740,7 +5741,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\008"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\\0008"', ':0:0:"\\008"'),
       },
@@ -5752,7 +5753,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\0008"', {
-      --           0123456
+      --           01 23456
       ast = {
         fmtn('DoubleQuotedString', 'val="\\0008"', ':0:0:"\\0008"'),
       },
@@ -5764,7 +5765,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\777"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\255"', ':0:0:"\\777"'),
       },
@@ -5775,7 +5776,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\050"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\40"', ':0:0:"\\050"'),
       },
@@ -5786,7 +5787,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\<C-u>"', {
-      --           012345
+      --           01 2345
       ast = {
         fmtn('DoubleQuotedString', 'val="\\021"', ':0:0:"\\<C-u>"'),
       },
@@ -5797,7 +5798,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\<', {
-      --           012
+      --           01 2
       ast = {
         fmtn('DoubleQuotedString', 'val="<"', ':0:0:"\\<'),
       },
@@ -5811,7 +5812,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\<"', {
-      --           0123
+      --           01 23
       ast = {
         fmtn('DoubleQuotedString', 'val="<"', ':0:0:"\\<"'),
       },
@@ -5822,7 +5823,7 @@ return function(itp, _check_parsing, hl, fmtn)
     })
 
     check_parsing('"\\<C-u"', {
-      --           0123456
+      --           01 23456
       ast = {
         fmtn('DoubleQuotedString', 'val="<C-u"', ':0:0:"\\<C-u"'),
       },
@@ -5836,7 +5837,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"<>', {
       --           012
       ast = {
-        'DoubleQuotedString(val="<>"):0:0:"<>',
+        fmtn('DoubleQuotedString', 'val="<>"', ':0:0:"<>'),
       },
       err = {
         arg = '"<>',
@@ -5850,7 +5851,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\<>', {
       --           01 23
       ast = {
-        'DoubleQuotedString(val="<>"):0:0:"\\<>',
+        fmtn('DoubleQuotedString', 'val="<>"', ':0:0:"\\<>'),
       },
       err = {
         arg = '"\\<>',
@@ -5865,7 +5866,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\<-', {
       --           01 23
       ast = {
-        'DoubleQuotedString(val="<-"):0:0:"\\<-',
+        fmtn('DoubleQuotedString', 'val="<-"', ':0:0:"\\<-'),
       },
       err = {
         arg = '"\\<-',
@@ -5880,7 +5881,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\<M-', {
       --           01 234
       ast = {
-        'DoubleQuotedString(val="<M-"):0:0:"\\<M-',
+        fmtn('DoubleQuotedString', 'val="<M-"', ':0:0:"\\<M-'),
       },
       err = {
         arg = '"\\<M-',
@@ -5895,7 +5896,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\<M-"', {
       --           01 2345
       ast = {
-        'DoubleQuotedString(val="<M-"):0:0:"\\<M-"',
+        fmtn('DoubleQuotedString', 'val="<M-"', ':0:0:"\\<M-"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -5910,8 +5911,8 @@ return function(itp, _check_parsing, hl, fmtn)
         {
           'Comparison(type=Greater,inv=0,ccs=UseOption):0:6:>',
           children = {
-            'DoubleQuotedString(val="<M-"):0:0:"\\<M-"',
-            'DoubleQuotedString(val=NULL):0:7:"',
+            fmtn('DoubleQuotedString', 'val="<M-"', ':0:0:"\\<M-"'),
+            fmtn('DoubleQuotedString', 'val=NULL', ':0:7:"'),
           },
         },
       },
@@ -5931,7 +5932,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\<M-\\"', {
       --           01 2345 6
       ast = {
-        'DoubleQuotedString(val="<M-\\""):0:0:"\\<M-\\"',
+        fmtn('DoubleQuotedString', 'val="<M-\\""', ':0:0:"\\<M-\\"'),
       },
       err = {
         arg = '"\\<M-\\"',
@@ -5947,7 +5948,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\<M-\\">', {
       --           01 2345 67
       ast = {
-        'DoubleQuotedString(val="\128\252\\008\\""):0:0:"\\<M-\\">',
+        fmtn('DoubleQuotedString', 'val="\128\252\\008\\""', ':0:0:"\\<M-\\">'),
       },
       err = {
         arg = '"\\<M-\\">',
@@ -5961,7 +5962,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\<M-\\">"', {
       --           01 2345 678
       ast = {
-        'DoubleQuotedString(val="\128\252\\008\\""):0:0:"\\<M-\\">"',
+        fmtn('DoubleQuotedString', 'val="\128\252\\008\\""', ':0:0:"\\<M-\\">"'),
       },
     }, {
       hl('DoubleQuote', '"'),
@@ -6776,8 +6777,8 @@ return function(itp, _check_parsing, hl, fmtn)
       },
     })
 
-    check_parsing('(1+&)', {
-      --           01234
+    check_pagealloc_parsing('(1+&)', {
+      --                     01234
       ast = {
         {
           'Nested:0:0:(',
@@ -7349,7 +7350,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_parsing('"\\U\\', {
       --           0123
       ast = {
-        [[DoubleQuotedString(val="U\\"):0:0:"\U\]],
+        fmtn('DoubleQuotedString', 'val="U\\\\"', ':0:0:"\\U\\'),
       },
       err = {
         arg = '"\\U\\',
@@ -7701,7 +7702,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_pagealloc_parsing('"\\<', {
       --                     01 2
       ast = {
-        'DoubleQuotedString(val="<"):0:0:"\\<',
+        fmtn('DoubleQuotedString', 'val="<"', ':0:0:"\\<'),
       },
       err = {
         arg = '"\\<',
@@ -7877,7 +7878,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_pagealloc_parsing('"\0\0\\Xa\\\248', {
       --                     01 2 3 456 7
       ast = {
-        'DoubleQuotedString(val="\\000\\000\\n\248"):0:0:"',
+        fmtn('DoubleQuotedString', 'val="\\000\\000\\n\248"', ':0:0:"'),
       },
       err = {
         arg = '"\000\000\\Xa\\\248',
@@ -7892,7 +7893,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_pagealloc_parsing('"\\<\\<-\000', {
       --                     01 23 456
       ast = {
-        'DoubleQuotedString(val="<<-\\000"):0:0:"\\<\\<-',
+        fmtn('DoubleQuotedString', 'val="<<-\\000"', ':0:0:"\\<\\<-'),
       },
       err = {
         arg = '"\\<\\<-\000',
@@ -7907,7 +7908,7 @@ return function(itp, _check_parsing, hl, fmtn)
     check_pagealloc_parsing('"\000\\"\\<-\001', {
       --                     01   2 34 567
       ast = {
-        'DoubleQuotedString(val="\\000\\"<-\\001"):0:0:"',
+        fmtn('DoubleQuotedString', 'val="\\000\\"<-\\001"', ':0:0:"'),
       },
       err = {
         arg = '"\000\\"\\<-\001',
@@ -7924,7 +7925,7 @@ return function(itp, _check_parsing, hl, fmtn)
       --                     01   2 3 4 56 78 9   0
       --                     0                    1
       ast = {
-        'DoubleQuotedString(val="\\000\\\\\\n<\193\128"):0:0:"',
+        fmtn('DoubleQuotedString', 'val="\\000\\\\\\n<\193\128"', ':0:0:"'),
       },
       err = {
         arg = '"\000\\\\\\n\\<\\\193\128',
@@ -8908,7 +8909,7 @@ return function(itp, _check_parsing, hl, fmtn)
         {
           'OpMissing:0:6:',
           children = {
-            'DoubleQuotedString(val="«»"):0:0:"«»"',
+            fmtn('DoubleQuotedString', 'val="«»"', ':0:0:"«»"'),
             {
               'ComplexIdentifier:0:8:',
               children = {
@@ -8933,7 +8934,7 @@ return function(itp, _check_parsing, hl, fmtn)
       [1] = {
         ast = {
           ast = {
-            'DoubleQuotedString(val="«»"):0:0:"«»"',
+            fmtn('DoubleQuotedString', 'val="«»"', ':0:0:"«»"'),
           },
           len = 6,
         },
@@ -8949,12 +8950,12 @@ return function(itp, _check_parsing, hl, fmtn)
         {
           'OpMissing:0:3:',
           children = {
-            'DoubleQuotedString(val="\192"):0:0:"\192"',
+            fmtn('DoubleQuotedString', 'val="\192"', ':0:0:"\192"'),
             {
               'OpMissing:0:4:',
               children = {
                 'PlainIdentifier(scope=0,ident=\192):0:3:\192',
-                'DoubleQuotedString(val="foo"):0:4:"foo"',
+                fmtn('DoubleQuotedString', 'val="foo"', ':0:4:"foo"'),
               },
             },
           },
@@ -8976,7 +8977,7 @@ return function(itp, _check_parsing, hl, fmtn)
       [1] = {
         ast = {
           ast = {
-            'DoubleQuotedString(val="\192"):0:0:"\192"',
+            fmtn('DoubleQuotedString', 'val="\192"', ':0:0:"\192"'),
           },
           len = 3,
         },

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -7920,6 +7920,24 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('InvalidDoubleQuotedUnknownEscape', '\\<'),
       hl('InvalidDoubleQuotedBody', '-\001'),
     })
+    check_pagealloc_parsing('"\000\\\\\\n\\<\\\193\128', {
+      --                     01   2 3 4 56 78 9   0
+      --                     0                    1
+      ast = {
+        'DoubleQuotedString(val="\\000\\\\\\n<\193\128"):0:0:"',
+      },
+      err = {
+        arg = '"\000\\\\\\n\\<\\\193\128',
+        msg = 'E114: Missing double quote: %.*s',
+      },
+    }, {
+      hl('InvalidDoubleQuote', '"'),
+      hl('InvalidDoubleQuotedBody', ''),
+      hl('InvalidDoubleQuotedEscape', '\\\\', 1),
+      hl('InvalidDoubleQuotedEscape', '\\n'),
+      hl('InvalidDoubleQuotedUnknownEscape', '\\<'),
+      hl('InvalidDoubleQuotedUnknownEscape', '\\\193\128'),
+    })
   end)
   itp('works with assignments', function()
     check_asgn_parsing('a=b', {

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -12,6 +12,13 @@ return function(itp, _check_parsing, hl, fmtn)
       funcname='check_asgn_parsing',
     }, ...)
   end
+  local function check_pagealloc_parsing(...)
+    return _check_parsing({
+      flags={0, 1, 2, 3},
+      funcname='check_pagealloc_parsing',
+      pagealloc=true,
+    }, ...)
+  end
   itp('works with + and @a', function()
     check_parsing('@a', {
       ast = {
@@ -7579,8 +7586,8 @@ return function(itp, _check_parsing, hl, fmtn)
     --                 MO5836[8] allocated at viml_pexpr_parse():  %7 = alloca %struct.ParserState*, align 8
     --         prev: object at 66546720 of size 50
     --                 MO3352[50] allocated at __user_main():  %input = alloca [50 x i8], align 16
-    check_parsing('"\\<', {
-      --           01 2
+    check_pagealloc_parsing('"\\<', {
+      --                     01 2
       ast = {
         'DoubleQuotedString(val="<"):0:0:"\\<',
       },

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -1075,6 +1075,62 @@ return function(itp, _check_parsing, hl, fmtn)
         },
       },
     })
+    check_parsing('@a(@b,@c,)', {
+      --           0123456789
+      ast = {
+        {
+          'Call:0:2:(',
+          children = {
+            'Register(name=a):0:0:@a',
+            {
+              'Comma:0:5:,',
+              children = {
+                'Register(name=b):0:3:@b',
+                {
+                  'Comma:0:8:,',
+                  children = {
+                    'Register(name=c):0:6:@c',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }, {
+      hl('Register', '@a'),
+      hl('CallingParenthesis', '('),
+      hl('Register', '@b'),
+      hl('Comma', ','),
+      hl('Register', '@c'),
+      hl('Comma', ','),
+      hl('CallingParenthesis', ')'),
+    })
+    check_parsing('(@b,)', {
+      --           01234
+      ast = {
+        {
+          'Nested:0:0:(',
+          children = {
+            {
+              'Comma:0:3:,',
+              children = {
+                'Register(name=b):0:1:@b',
+              },
+            },
+          },
+        },
+      },
+      err = {
+        arg = ',)',
+        msg = 'E15: Comma outside of call, lambda or literal: %.*s',
+      },
+    }, {
+      hl('NestingParenthesis', '('),
+      hl('Register', '@b'),
+      hl('InvalidComma', ','),
+      hl('NestingParenthesis', ')'),
+    })
   end)
   itp('works with variable names, including curly braces ones', function()
     check_parsing('var', {

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -4731,7 +4731,7 @@ return function(itp, _check_parsing, hl, fmtn)
       },
       err = {
         arg = ']',
-        msg = 'E15: Unexpected closing figure brace: %.*s',
+        msg = 'E15: Unexpected closing bracket: %.*s',
       },
     }, {
       hl('InvalidList', ']'),
@@ -4749,7 +4749,7 @@ return function(itp, _check_parsing, hl, fmtn)
       },
       err = {
         arg = ']',
-        msg = 'E15: Unexpected closing figure brace: %.*s',
+        msg = 'E15: Unexpected closing bracket: %.*s',
       },
     }, {
       hl('IdentifierName', 'a'),
@@ -7369,7 +7369,7 @@ return function(itp, _check_parsing, hl, fmtn)
       },
       err = {
         arg = ']$',
-        msg = 'E15: Unexpected closing figure brace: %.*s',
+        msg = 'E15: Unexpected closing bracket: %.*s',
       },
     }, {
       hl('Number', '90'),

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -8806,4 +8806,84 @@ return function(itp, _check_parsing, hl, fmtn)
       },
     })
   end)
+  itp('correctly works with missing operator priority', function()
+    -- Regression test for #7889.
+    check_parsing('0 0 *', {
+      --           01234
+      ast = {
+        {
+          'OpMissing:0:1:',
+          children = {
+            'Integer(val=0):0:0:0',
+            {
+              'Multiplication:0:3: *',
+              children = {
+                'Integer(val=0):0:1: 0',
+              },
+            },
+          },
+        },
+      },
+      err = {
+        arg = '0 *',
+        msg = 'E15: Missing operator: %.*s',
+      },
+    }, {
+      hl('Number', '0'),
+      hl('InvalidSpacing', ' '),
+      hl('Number', '0'),
+      hl('Multiplication', '*', 1),
+    }, {
+      [1] = {
+        ast = {
+          len = 2,
+          ast = {
+            'Integer(val=0):0:0:0',
+          },
+          err = REMOVE_THIS,
+        },
+        hl_fs = {
+          [2] = REMOVE_THIS,
+          [3] = REMOVE_THIS,
+          [4] = REMOVE_THIS,
+        },
+      },
+    })
+
+    check_parsing('system(\'\'ls *', {
+      --           01234567 8 9012
+      --           0           1
+      ast = {
+        {
+          'Call:0:6:(',
+          children = {
+            'PlainIdentifier(scope=0,ident=system):0:0:system',
+            {
+              'OpMissing:0:9:',
+              children = {
+                'SingleQuotedString(val=NULL):0:7:\'\'',
+                {
+                  'Multiplication:0:11: *',
+                  children = {
+                    'PlainIdentifier(scope=0,ident=ls):0:9:ls',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      err = {
+        arg = 'ls *',
+        msg = 'E15: Missing operator: %.*s',
+      },
+    }, {
+      hl('IdentifierName', 'system'),
+      hl('CallingParenthesis', '('),
+      hl('SingleQuote', '\''),
+      hl('SingleQuote', '\''),
+      hl('InvalidIdentifierName', 'ls'),
+      hl('Multiplication', '*', 1),
+    })
+  end)
 end

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -1965,7 +1965,7 @@ return function(itp, _check_parsing, hl, fmtn)
       },
       err = {
         arg = '}',
-        msg = 'E15: Unexpected closing figure brace: %.*s',
+        msg = 'E15: Expected value, got closing figure brace: %.*s',
       },
     }, {
       hl('InvalidFigureBrace', '}'),
@@ -7261,7 +7261,7 @@ return function(itp, _check_parsing, hl, fmtn)
       },
       err = {
         arg = '}l',
-        msg = 'E15: Unexpected closing figure brace: %.*s',
+        msg = 'E15: Expected value, got closing figure brace: %.*s',
       },
     }, {
       hl('InvalidFigureBrace', '}'),
@@ -7486,6 +7486,116 @@ return function(itp, _check_parsing, hl, fmtn)
     }, {
       hl('InvalidDoubleQuote', '"'),
       hl('InvalidDoubleQuotedUnknownEscape', '\\<'),
+    })
+    -- Just an addition, actually found by KLEE is *]08
+    check_parsing('*)08', {
+      --           0123
+      ast = {
+        {
+          'OpMissing:0:2:',
+          children = {
+            {
+              'Nested:0:1:',
+              children = {
+                {
+                  'Multiplication:0:0:*',
+                  children = {
+                    'Missing:0:0:',
+                    'Missing:0:1:',
+                  },
+                },
+              },
+            },
+            'Integer(val=8):0:2:08',
+          },
+        },
+      },
+      err = {
+        arg = '*)08',
+        msg = 'E15: Unexpected multiplication-like operator: %.*s',
+      },
+    }, {
+      hl('InvalidMultiplication', '*'),
+      hl('InvalidNestingParenthesis', ')'),
+      hl('InvalidNumber', '08'),
+    }, {
+      [1] = {
+        ast = {
+          ast = {
+            {
+              'Nested:0:1:',
+              children = {
+                {
+                  'Multiplication:0:0:*',
+                  children = {
+                    'Missing:0:0:',
+                    'Missing:0:1:',
+                  },
+                },
+                REMOVE_THIS,
+              },
+            },
+          },
+          len = 2,
+        },
+        hl_fs = {
+          [3] = REMOVE_THIS,
+        },
+      },
+    })
+    -- Just an addition, actually found by KLEE is *]08
+    check_parsing('*}08', {
+      --           0123
+      ast = {
+        {
+          'OpMissing:0:2:',
+          children = {
+            {
+              'UnknownFigure(---):0:1:',
+              children = {
+                {
+                  'Multiplication:0:0:*',
+                  children = {
+                    'Missing:0:0:',
+                  },
+                },
+              },
+            },
+            'Integer(val=8):0:2:08',
+          },
+        },
+      },
+      err = {
+        arg = '*}08',
+        msg = 'E15: Unexpected multiplication-like operator: %.*s',
+      },
+    }, {
+      hl('InvalidMultiplication', '*'),
+      hl('InvalidFigureBrace', '}'),
+      hl('InvalidNumber', '08'),
+    }, {
+      [1] = {
+        ast = {
+          ast = {
+            {
+              'UnknownFigure(---):0:1:',
+              children = {
+                {
+                  'Multiplication:0:0:*',
+                  children = {
+                    'Missing:0:0:',
+                  },
+                },
+                REMOVE_THIS,
+              },
+            },
+          },
+          len = 2,
+        },
+        hl_fs = {
+          [3] = REMOVE_THIS,
+        },
+      },
     })
   end)
   itp('works with assignments', function()

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -7738,6 +7738,21 @@ return function(itp, _check_parsing, hl, fmtn)
         },
       },
     })
+    check_pagealloc_parsing('"\0\0\\Xa\\\248', {
+      --                     01 2 3 456 7
+      ast = {
+        'DoubleQuotedString(val="\\000\\000\\n\248"):0:0:"',
+      },
+      err = {
+        arg = '"\000\000\\Xa\\\248',
+        msg = 'E114: Missing double quote: %.*s',
+      },
+    }, {
+      hl('InvalidDoubleQuote', '"'),
+      hl('InvalidDoubleQuotedBody', ''),
+      hl('InvalidDoubleQuotedEscape', '\\Xa', 2),
+      hl('InvalidDoubleQuotedUnknownEscape', '\\\248'),
+    })
   end)
   itp('works with assignments', function()
     check_asgn_parsing('a=b', {

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -4612,6 +4612,111 @@ return function(itp, _check_parsing, hl, fmtn)
       hl('IdentifierName', 'f'),
       hl('SubscriptBracket', ']'),
     })
+
+    check_parsing('[:]', {
+      --           012
+      ast = {
+        {
+          'ListLiteral:0:0:[',
+          children = {
+            {
+              'Colon:0:1::',
+              children = {
+                'Missing:0:1:',
+              },
+            },
+          },
+        },
+      },
+      err = {
+        arg = ':]',
+        msg = 'E15: Colon outside of dictionary or ternary operator: %.*s',
+      },
+    }, {
+      hl('List', '['),
+      hl('InvalidColon', ':'),
+      hl('List', ']'),
+    })
+
+    check_parsing('[,]', {
+      --           012
+      ast = {
+        {
+          'ListLiteral:0:0:[',
+          children = {
+            {
+              'Comma:0:1:,',
+              children = {
+                'Missing:0:1:',
+              },
+            },
+          },
+        },
+      },
+      err = {
+        arg = ',]',
+        msg = 'E15: Expected value, got comma: %.*s',
+      },
+    }, {
+      hl('List', '['),
+      hl('InvalidComma', ','),
+      hl('List', ']'),
+    })
+
+    check_parsing('a[,]', {
+      --           0123
+      ast = {
+        {
+          'Subscript:0:1:[',
+          children = {
+            'PlainIdentifier(scope=0,ident=a):0:0:a',
+            {
+              'Comma:0:2:,',
+              children = {
+                'Missing:0:2:',
+              },
+            },
+          },
+        },
+      },
+      err = {
+        arg = ',]',
+        msg = 'E15: Expected value, got comma: %.*s',
+      },
+    }, {
+      hl('IdentifierName', 'a'),
+      hl('SubscriptBracket', '['),
+      hl('InvalidComma', ','),
+      hl('SubscriptBracket', ']'),
+    })
+
+    check_parsing('a[1,]', {
+      --           01234
+      ast = {
+        {
+          'Subscript:0:1:[',
+          children = {
+            'PlainIdentifier(scope=0,ident=a):0:0:a',
+            {
+              'Comma:0:3:,',
+              children = {
+                'Integer(val=1):0:2:1',
+              },
+            },
+          },
+        },
+      },
+      err = {
+        arg = ',]',
+        msg = 'E15: Comma outside of call, lambda or literal: %.*s',
+      },
+    }, {
+      hl('IdentifierName', 'a'),
+      hl('SubscriptBracket', '['),
+      hl('Number', '1'),
+      hl('InvalidComma', ','),
+      hl('SubscriptBracket', ']'),
+    })
   end)
   itp('supports list literals', function()
     check_parsing('[]', {
@@ -4787,7 +4892,7 @@ return function(itp, _check_parsing, hl, fmtn)
       },
       err = {
         arg = ']',
-        msg = 'E15: Unexpected closing bracket: %.*s',
+        msg = 'E15: Expected value, got closing bracket: %.*s',
       },
     }, {
       hl('InvalidList', ']'),
@@ -7579,6 +7684,59 @@ return function(itp, _check_parsing, hl, fmtn)
           ast = {
             {
               'UnknownFigure(---):0:1:',
+              children = {
+                {
+                  'Multiplication:0:0:*',
+                  children = {
+                    'Missing:0:0:',
+                  },
+                },
+                REMOVE_THIS,
+              },
+            },
+          },
+          len = 2,
+        },
+        hl_fs = {
+          [3] = REMOVE_THIS,
+        },
+      },
+    })
+    check_parsing('*]08', {
+      --           0123
+      ast = {
+        {
+          'OpMissing:0:2:',
+          children = {
+            {
+              'ListLiteral:0:1:',
+              children = {
+                {
+                  'Multiplication:0:0:*',
+                  children = {
+                    'Missing:0:0:',
+                  },
+                },
+              },
+            },
+            'Integer(val=8):0:2:08',
+          },
+        },
+      },
+      err = {
+        arg = '*]08',
+        msg = 'E15: Unexpected multiplication-like operator: %.*s',
+      },
+    }, {
+      hl('InvalidMultiplication', '*'),
+      hl('InvalidList', ']'),
+      hl('InvalidNumber', '08'),
+    }, {
+      [1] = {
+        ast = {
+          ast = {
+            {
+              'ListLiteral:0:1:',
               children = {
                 {
                   'Multiplication:0:0:*',

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -7562,30 +7562,6 @@ return function(itp, _check_parsing, hl, fmtn)
         },
       },
     })
-    -- FIXME: Make test actually fail before fixing
-    -- KLEE error:
-    --
-    -- Error: memory error: out of bound pointer
-    -- File: /image/./test/symbolic/klee/nvim/mbyte.c
-    -- Line: 233
-    -- assembly.ll line: 2741
-    -- Stack:
-    --         #000002741 in utfc_ptr2len (p) at /image/./test/symbolic/klee/nvim/mbyte.c:233
-    --         #100002826 in mb_copy_char (fp=1456753968, tp=708135712) at /image/./test/symbolic/klee/nvim/mbyte.c:261
-    --         #200039775 in parse_quoted_string (pstate=66541648, node=532330304, token=67024224, ast_stack=67022192, is_invalid=true) at /image/./src/nvim/viml/parser/expressions.c:1779
-    --         #300034903 in viml_pexpr_parse (agg.result=66344928, pstate=66541648, flags) at /image/./src/nvim/viml/parser/expressions.c:2921
-    --         #400043140 in __user_main (argc=1, argv=55308864, environ=55308880) at /image/./test/symbolic/klee/viml_expressions_parser.c:94
-    --         #500048330 in __uClibc_main (main=21926160, argc=1, argv=55308864, app_init=0, app_fini=0, rtld_fini=0, stack_end=0) at /home/klee/klee_build/klee-uclibc/libc/misc/internals/__uClibc_main.c:401
-    --         #600051592 in main (=1, =55308864)
-    -- Info:
-    --         address: (Add w64 66546723
-    --           (ZExt w64 (Read w8 0 shift)))
-    --         example: 66546770
-    --         range: [66546770, 66546770]
-    --         next: object at 66547328 of size 8
-    --                 MO5836[8] allocated at viml_pexpr_parse():  %7 = alloca %struct.ParserState*, align 8
-    --         prev: object at 66546720 of size 50
-    --                 MO3352[50] allocated at __user_main():  %input = alloca [50 x i8], align 16
     check_pagealloc_parsing('"\\<', {
       --                     01 2
       ast = {

--- a/test/unit/viml/expressions/parser_tests.lua
+++ b/test/unit/viml/expressions/parser_tests.lua
@@ -7263,6 +7263,137 @@ return function(itp, _check_parsing, hl, fmtn)
         },
       },
     })
+    -- Just an addition, actually found by KLEE is 90]$
+    check_parsing('90}$', {
+      --           0123
+      ast = {
+        {
+          'OpMissing:0:3:',
+          children = {
+            {
+              'UnknownFigure(---):0:2:',
+              children = {
+                'Integer(val=90):0:0:90',
+              },
+            },
+            'Environment(ident=):0:3:$',
+          },
+        },
+      },
+      err = {
+        arg = '}$',
+        msg = 'E15: Unexpected closing figure brace: %.*s',
+      },
+    }, {
+      hl('Number', '90'),
+      hl('InvalidFigureBrace', '}'),
+      hl('InvalidEnvironmentSigil', '$'),
+    }, {
+      [1] = {
+        ast = {
+          ast = {
+            {
+              'UnknownFigure(---):0:2:',
+              children = {
+                'Integer(val=90):0:0:90',
+                REMOVE_THIS,
+              },
+            },
+          },
+          len = 3,
+        },
+        hl_fs = {
+          [3] = REMOVE_THIS,
+        },
+      },
+    })
+    -- Just an addition, actually found by KLEE is 90]$
+    check_parsing('90)$', {
+      --           0123
+      ast = {
+        {
+          'OpMissing:0:3:',
+          children = {
+            {
+              'Nested:0:2:',
+              children = {
+                'Integer(val=90):0:0:90',
+              },
+            },
+            'Environment(ident=):0:3:$',
+          },
+        },
+      },
+      err = {
+        arg = ')$',
+        msg = 'E15: Unexpected closing parenthesis: %.*s',
+      },
+    }, {
+      hl('Number', '90'),
+      hl('InvalidNestingParenthesis', ')'),
+      hl('InvalidEnvironmentSigil', '$'),
+    }, {
+      [1] = {
+        ast = {
+          ast = {
+            {
+              'Nested:0:2:',
+              children = {
+                'Integer(val=90):0:0:90',
+                REMOVE_THIS,
+              },
+            },
+          },
+          len = 3,
+        },
+        hl_fs = {
+          [3] = REMOVE_THIS,
+        },
+      },
+    })
+    check_parsing('90]$', {
+      --           0123
+      ast = {
+        {
+          'OpMissing:0:3:',
+          children = {
+            {
+              'ListLiteral:0:2:',
+              children = {
+                'Integer(val=90):0:0:90',
+              },
+            },
+            'Environment(ident=):0:3:$',
+          },
+        },
+      },
+      err = {
+        arg = ']$',
+        msg = 'E15: Unexpected closing figure brace: %.*s',
+      },
+    }, {
+      hl('Number', '90'),
+      hl('InvalidList', ']'),
+      hl('InvalidEnvironmentSigil', '$'),
+    }, {
+      [1] = {
+        ast = {
+          ast = {
+            {
+              'ListLiteral:0:2:',
+              children = {
+                'Integer(val=90):0:0:90',
+                REMOVE_THIS,
+              },
+            },
+          },
+          len = 3,
+        },
+        hl_fs = {
+          [3] = REMOVE_THIS,
+        },
+      },
+    })
   end)
   itp('works with assignments', function()
     check_asgn_parsing('a=b', {

--- a/test/unit/viml/helpers.lua
+++ b/test/unit/viml/helpers.lua
@@ -10,7 +10,7 @@ local make_enum_conv_tab = helpers.make_enum_conv_tab
 
 local lib = cimport('./src/nvim/viml/parser/expressions.h')
 
-local function new_pstate(strings, do_pagealloc, alloc_log)
+local function new_pstate(strings, do_pagealloc)
   local strings_idx = 0
   local frees = {}
   local function get_line(_, ret_pline)
@@ -20,7 +20,7 @@ local function new_pstate(strings, do_pagealloc, alloc_log)
     if type(str) == 'string' then
       size = #str
       if do_pagealloc then
-        local start, free = pagealloc(size, alloc_log)
+        local start, free = pagealloc(size)
         frees[#frees + 1] = free
         data = ffi.gc(start, nil)
         for i = 0, (size - 1) do

--- a/test/unit/viml/helpers.lua
+++ b/test/unit/viml/helpers.lua
@@ -5,19 +5,30 @@ local cimport = helpers.cimport
 local kvi_new = helpers.kvi_new
 local kvi_init = helpers.kvi_init
 local conv_enum = helpers.conv_enum
+local pagealloc = helpers.pagealloc
 local make_enum_conv_tab = helpers.make_enum_conv_tab
 
 local lib = cimport('./src/nvim/viml/parser/expressions.h')
 
-local function new_pstate(strings)
+local function new_pstate(strings, do_pagealloc, alloc_log)
   local strings_idx = 0
+  local allocs = {}
   local function get_line(_, ret_pline)
     strings_idx = strings_idx + 1
     local str = strings[strings_idx]
     local data, size
     if type(str) == 'string' then
-      data = str
       size = #str
+      if do_pagealloc then
+        local start, mem = pagealloc(size, alloc_log)
+        allocs[#allocs + 1] = mem
+        data = ffi.gc(start, nil)
+        for i = 0, (size - 1) do
+          start[i] = str:byte(i + 1)
+        end
+      else
+        data = str
+      end
     elseif type(str) == 'nil' then
       data = nil
       size = 0
@@ -49,6 +60,13 @@ local function new_pstate(strings)
   local ret = ffi.new('ParserState', state)
   kvi_init(ret.reader.lines)
   kvi_init(ret.stack)
+  if do_pagealloc then
+    ret = ffi.gc(ret, function(_)
+      for _, a in ipairs(allocs) do
+        lib.xfree(a)
+      end
+    end)
+  end
   return ret
 end
 


### PR DESCRIPTION
Merge #8421
Closes #8421
Fixes #7889

---

After merging with HEAD, [still fails](https://travis-ci.org/neovim/neovim/builds/454922265) in the same fashion as in #8421 :

```
[ RUN      ] mbyte utf_char2bytes: FAIL
test/unit/helpers.lua:748: (string) '
Test crashed without proper end marker.

Test crashed, trace:
...
```

I wonder why it only fails on macOS and ASAN builds.