### PR TITLE
vim-patch:8.1.0146

### DIFF
--- a/src/nvim/testdir/test_compiler.vim
+++ b/src/nvim/testdir/test_compiler.vim
@@ -5,6 +5,11 @@ func Test_compiler()
     return
   endif
 
+  " $LANG changes the output of Perl.
+  if $LANG != ''
+    unlet $LANG
+  endif
+
   e Xfoo.pl
   compiler perl
   call assert_equal('perl', b:current_compiler)


### PR DESCRIPTION
**vim-patch:8.1.0146: when $LANG is set the compiler test may fail**

Problem:    When $LANG is set the compiler test may fail.
Solution:   Unset $LANG.
https://github.com/vim/vim/commit/f0447e89a52885630947510f2d1b55f665a1a20e