### PR TITLE
unit/mbyte_spec: Run utf_char2bytes test in batches of 0xFFF characters

### DIFF
--- a/test/unit/mbyte_spec.lua
+++ b/test/unit/mbyte_spec.lua
@@ -43,15 +43,17 @@ describe('mbyte', function()
     -- Sequences with more than four bytes
   end)
 
-  itp('utf_char2bytes', function()
-    local char_p = ffi.typeof('char[?]')
-    for c = 0, 0xFFFF do
-      local p = char_p(4, 0)
-      mbyte.utf_char2bytes(c, p)
-      eq(c, mbyte.utf_ptr2char(p))
-      eq(charset.vim_iswordc(c), charset.vim_iswordp(p))
-    end
-  end)
+  for n = 0, 0xF do
+    itp(('utf_char2bytes for chars 0x%x - 0x%x'):format(n * 0x1000, n * 0x1000 + 0xFFF), function()
+      local char_p = ffi.typeof('char[?]')
+      for c = n * 0x1000, n * 0x1000 + 0xFFF do
+        local p = char_p(4, 0)
+        mbyte.utf_char2bytes(c, p)
+        eq(c, mbyte.utf_ptr2char(p))
+        eq(charset.vim_iswordc(c), charset.vim_iswordp(p))
+      end
+    end)
+  end
 
   describe('utfc_ptr2char_len', function()
 


### PR DESCRIPTION
Running the full 0xFFFF set of tests in one process fails on slower
architectures/when there's CPU contention.