### PR TITLE
TUI: support TERM=nsterm

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1466,7 +1466,9 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
 #if 0   // We don't need to identify this specifically, for now.
   bool roxterm = !!os_getenv("ROXTERM_ID");
 #endif
-  bool xterm = terminfo_is_term_family(term, "xterm");
+  bool xterm = terminfo_is_term_family(term, "xterm")
+    // Treat Terminal.app as generic xterm-like, for now.
+    || terminfo_is_term_family(term, "nsterm");
   bool kitty = terminfo_is_term_family(term, "xterm-kitty");
   bool linuxvt = terminfo_is_term_family(term, "linux");
   bool rxvt = terminfo_is_term_family(term, "rxvt");


### PR DESCRIPTION
`:help $TERM` recommends TERM=nsterm for Terminal.app but we did not
actually support it.

NB: We don't include a builtin term for Terminal.app, presumably because
nsterm is commonly available on most systems (`infocmp nsterm`).