### PR TITLE
vim-patch:8.1.{258,298,299,318,376}

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2169,21 +2169,21 @@ win_line (
   static linenr_T checked_lnum = 0;     /* line number for "checked_col" */
   static int checked_col = 0;           /* column in "checked_lnum" up to which
                                          * there are no spell errors */
-  static int cap_col = -1;              /* column to check for Cap word */
-  static linenr_T capcol_lnum = 0;      /* line number where "cap_col" used */
-  int cur_checked_col = 0;              /* checked column for current line */
+  static int cap_col = -1;              // column to check for Cap word
+  static linenr_T capcol_lnum = 0;      // line number where "cap_col"
+  int cur_checked_col = 0;              // checked column for current line
   int extra_check = 0;                  // has syntax or linebreak
-  int multi_attr = 0;                   /* attributes desired by multibyte */
-  int mb_l = 1;                         /* multi-byte byte length */
-  int mb_c = 0;                         /* decoded multi-byte character */
-  int mb_utf8 = FALSE;                  /* screen char is UTF-8 char */
-  int u8cc[MAX_MCO];                    /* composing UTF-8 chars */
-  int filler_lines;                     /* nr of filler lines to be drawn */
-  int filler_todo;                      /* nr of filler lines still to do + 1 */
-  hlf_T diff_hlf = (hlf_T)0;            /* type of diff highlighting */
-  int change_start = MAXCOL;            /* first col of changed area */
-  int change_end = -1;                  /* last col of changed area */
-  colnr_T trailcol = MAXCOL;            /* start of trailing spaces */
+  int multi_attr = 0;                   // attributes desired by multibyte
+  int mb_l = 1;                         // multi-byte byte length
+  int mb_c = 0;                         // decoded multi-byte character
+  bool mb_utf8 = false;                 // screen char is UTF-8 char
+  int u8cc[MAX_MCO];                    // composing UTF-8 chars
+  int filler_lines;                     // nr of filler lines to be drawn
+  int filler_todo;                      // nr of filler lines still to do + 1
+  hlf_T diff_hlf = (hlf_T)0;            // type of diff highlighting
+  int change_start = MAXCOL;            // first col of changed area
+  int change_end = -1;                  // last col of changed area
+  colnr_T trailcol = MAXCOL;            // start of trailing spaces
   int need_showbreak = false;           // overlong line, skip first x chars
   int line_attr = 0;                    // attribute for the whole line
   int line_attr_lowprio = 0;            // low-priority attribute for the line
@@ -3100,8 +3100,9 @@ win_line (
           mb_utf8 = true;
           u8cc[0] = 0;
           c = 0xc0;
-        } else
-          mb_utf8 = FALSE;
+        } else {
+          mb_utf8 = false;
+        }
       } else {
         c = *p_extra;
         if (has_mbyte) {
@@ -3272,7 +3273,7 @@ win_line (
             && (*mb_char2cells)(mb_c) == 2) {
           c = '>';
           mb_c = c;
-          mb_utf8 = FALSE;
+          mb_utf8 = false;
           mb_l = 1;
           multi_attr = win_hl_attr(wp, HLF_AT);
           // Put pointer back so that the character will be
@@ -3295,7 +3296,7 @@ win_line (
             saved_attr2 = char_attr;             // save current attr
           }
           mb_c = c;
-          mb_utf8 = FALSE;
+          mb_utf8 = false;
           mb_l = 1;
         }
 
@@ -3573,7 +3574,7 @@ win_line (
             }
           }
 
-          mb_utf8 = (int)false;  // don't draw as UTF-8
+          mb_utf8 = false;  // don't draw as UTF-8
           if (wp->w_p_list) {
             c = lcs_tab1;
             if (wp->w_p_lbr) {
@@ -3636,8 +3637,9 @@ win_line (
             mb_utf8 = true;
             u8cc[0] = 0;
             c = 0xc0;
-          } else
-            mb_utf8 = FALSE;                    /* don't draw as UTF-8 */
+          } else {
+            mb_utf8 = false;                    // don't draw as UTF-8
+          }
         } else if (c != NUL) {
           p_extra = transchar(c);
           if (n_extra == 0) {
@@ -3726,8 +3728,9 @@ win_line (
           mb_utf8 = true;
           u8cc[0] = 0;
           c = 0xc0;
-        } else
-          mb_utf8 = FALSE;              /* don't draw as UTF-8 */
+        } else {
+          mb_utf8 = false;              // don't draw as UTF-8
+        }
       } else {
         prev_syntax_id = 0;
         is_concealing = FALSE;
@@ -4053,8 +4056,9 @@ win_line (
         mb_utf8 = true;
         u8cc[0] = 0;
         c = 0xc0;
-      } else
-        mb_utf8 = FALSE;
+      } else {
+        mb_utf8 = false;
+      }
     }
 
     /* advance to the next 'colorcolumn' */

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2172,7 +2172,7 @@ win_line (
   static int cap_col = -1;              /* column to check for Cap word */
   static linenr_T capcol_lnum = 0;      /* line number where "cap_col" used */
   int cur_checked_col = 0;              /* checked column for current line */
-  int extra_check;                      /* has syntax or linebreak */
+  int extra_check = 0;                  // has syntax or linebreak
   int multi_attr = 0;                   /* attributes desired by multibyte */
   int mb_l = 1;                         /* multi-byte byte length */
   int mb_c = 0;                         /* decoded multi-byte character */

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -245,6 +245,7 @@ let s:flaky = [
       \ 'Test_oneshot()',
       \ 'Test_out_cb()',
       \ 'Test_paused()',
+      \ 'Test_popup_and_window_resize()',  " sometimes fails on Mac
       \ 'Test_quoteplus()',
       \ 'Test_quotestar()',
       \ 'Test_reltime()',

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -245,7 +245,7 @@ let s:flaky = [
       \ 'Test_oneshot()',
       \ 'Test_out_cb()',
       \ 'Test_paused()',
-      \ 'Test_popup_and_window_resize()',  " sometimes fails on Mac
+      \ 'Test_popup_and_window_resize()',
       \ 'Test_quoteplus()',
       \ 'Test_quotestar()',
       \ 'Test_reltime()',

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -142,6 +142,19 @@ function Test_CompleteDoneDict()
   au! CompleteDone
 endfunc
 
+func Test_CompleteDone_undo()
+  au CompleteDone * call append(0, "prepend1")
+  new
+  call setline(1, ["line1", "line2"])
+  call feedkeys("Go\<C-X>\<C-N>\<CR>\<ESC>", "tx")
+  call assert_equal(["prepend1", "line1", "line2", "line1", ""],
+              \     getline(1, '$'))
+  undo
+  call assert_equal(["line1", "line2"], getline(1, '$'))
+  bwipe!
+  au! CompleteDone
+endfunc
+
 function! s:CompleteDone_CompleteFuncDictNoUserData( findstart, base )
   if a:findstart
     return 0

--- a/src/nvim/testdir/test_stat.vim
+++ b/src/nvim/testdir/test_stat.vim
@@ -141,17 +141,29 @@ func Test_getftype()
   endif
 
   for cdevfile in systemlist('find /dev -type c -maxdepth 2 2>/dev/null')
-    call assert_equal('cdev', getftype(cdevfile))
+    let type = getftype(cdevfile)
+    " ignore empty result, can happen if the file disappeared
+    if type != ''
+      call assert_equal('cdev', type)
+    endif
   endfor
 
   for bdevfile in systemlist('find /dev -type b -maxdepth 2 2>/dev/null')
-    call assert_equal('bdev', getftype(bdevfile))
+    let type = getftype(bdevfile)
+    " ignore empty result, can happen if the file disappeared
+    if type != ''
+      call assert_equal('bdev', type)
+    endif
   endfor
 
   " The /run/ directory typically contains socket files.
   " If it does not, test won't fail but will not test socket files.
   for socketfile in systemlist('find /run -type s -maxdepth 2 2>/dev/null')
-    call assert_equal('socket', getftype(socketfile))
+    let type = getftype(socketfile)
+    " ignore empty result, can happen if the file disappeared
+    if type != ''
+      call assert_equal('socket', type)
+    endif
   endfor
 
   " TODO: file type 'other' is not tested. How can we test it?


### PR DESCRIPTION
**vim-patch:8.1.0258: not enough testing for the CompleteDone event**

Problem:    Not enough testing for the CompleteDone event.
Solution:   Add a test. (closes vim/vim#3297)
https://github.com/vim/vim/commit/af559d2c9f44bc88a7d94f9236b3c024563a8e73

**vim-patch:8.1.0298: window resize test sometimes fails on Mac**

Problem:    Window resize test sometimes fails on Mac.
Solution:   Add Test_popup_and_window_resize() to flaky tests.
vim/vim@46fad2e

**vim-patch:8.1.0299: misplaced comment**

Problem:    misplaced comment
Solution:   Remove comment
vim/vim@142ae73

**vim-patch:8.1.0318: the getftype() test may fail for char devices**

Problem:    The getftype() test may fail for char devices if the file
            disappeared in between the listing and the getftype() call.
Solution:   Ignore empty result. (Ozaki Kiichi, closes vim/vim#3360)
vim/vim@3b3a506

**vim-patch:8.1.0376: compiler warning for uninitialized variable**

Problem:    Compiler warning for uninitialized variable. (Tony Mechelynck)
Solution:   Initialize the variable.
vim/vim@c787539