### PR TITLE
Rename Python package "neovim" to "pynvim"

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -152,10 +152,10 @@ function! s:check_clipboard() abort
   endif
 endfunction
 
-" Get the latest Neovim Python client version from PyPI.
+" Get the latest Neovim Python client (pynvim) version from PyPI.
 function! s:latest_pypi_version() abort
   let pypi_version = 'unable to get pypi response'
-  let pypi_response = s:download('https://pypi.python.org/pypi/neovim/json')
+  let pypi_response = s:download('https://pypi.python.org/pypi/pynvim/json')
   if !empty(pypi_response)
     try
       let pypi_data = json_decode(pypi_response)
@@ -192,9 +192,9 @@ function! s:version_info(python) abort
   let nvim_path = s:trim(s:system([
         \ a:python, '-c',
         \ 'import sys; sys.path.remove(""); ' .
-        \ 'import neovim; print(neovim.__file__)']))
+        \ 'import pynvim; print(pynvim.__file__)']))
   if s:shell_error || empty(nvim_path)
-    return [python_version, 'unable to load neovim Python module', pypi_version,
+    return [python_version, 'unable to load pynvim Python module', pypi_version,
           \ nvim_path]
   endif
 
@@ -206,13 +206,13 @@ function! s:version_info(python) abort
     return a == b ? 0 : a > b ? 1 : -1
   endfunction
 
-  " Try to get neovim.VERSION (added in 0.1.11dev).
+  " Try to get pynvim.VERSION (added in 0.1.11dev).
   let nvim_version = s:system([a:python, '-c',
-        \ 'from neovim import VERSION as v; '.
+        \ 'from pynvim import VERSION as v; '.
         \ 'print("{}.{}.{}{}".format(v.major, v.minor, v.patch, v.prerelease))'],
         \ '', 1, 1)
   if empty(nvim_version)
-    let nvim_version = 'unable to find neovim Python module version'
+    let nvim_version = 'unable to find pynvim Python module version'
     let base = fnamemodify(nvim_path, ':h')
     let metas = glob(base.'-*/METADATA', 1, 1)
           \ + glob(base.'-*/PKG-INFO', 1, 1)
@@ -293,7 +293,7 @@ function! s:check_python(version) abort
 
   let [pyname, pythonx_errs] = provider#pythonx#Detect(a:version)
   if empty(pyname)
-    call health#report_warn('No Python interpreter was found with the neovim '
+    call health#report_warn('No Python interpreter was found with the pynvim '
             \ . 'module.  Using the first available for diagnostics.')
   elseif exists('g:'.host_prog_var)
     let python_bin = pyname
@@ -352,7 +352,7 @@ function! s:check_python(version) abort
       call health#report_warn('pyenv is not set up optimally.', [
             \ printf('Create a virtualenv specifically '
             \ . 'for Neovim using pyenv, and set `g:%s`.  This will avoid '
-            \ . 'the need to install the Neovim Python module in each '
+            \ . 'the need to install the pynvim module in each '
             \ . 'version/virtualenv.', host_prog_var)
             \ ])
     elseif !empty(venv)
@@ -366,7 +366,7 @@ function! s:check_python(version) abort
         call health#report_warn('Your virtualenv is not set up optimally.', [
               \ printf('Create a virtualenv specifically '
               \ . 'for Neovim and use `g:%s`.  This will avoid '
-              \ . 'the need to install Neovim''s Python module in each '
+              \ . 'the need to install the pynvim module in each '
               \ . 'virtualenv.', host_prog_var)
               \ ])
       endif
@@ -420,7 +420,7 @@ function! s:check_python(version) abort
     if s:is_bad_response(current)
       call health#report_error(
         \ "Neovim Python client is not installed.\nError: ".current,
-        \ ['Run in shell: pip' . a:version . ' install neovim'])
+        \ ['Run in shell: pip' . a:version . ' install pynvim'])
     endif
 
     if s:is_bad_response(latest)

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -10,7 +10,7 @@ function! provider#pythonx#Require(host) abort
 
   " Python host arguments
   let prog = (ver == '2' ?  provider#python#Prog() : provider#python3#Prog())
-  let args = [prog, '-c', 'import sys; sys.path.remove(""); import neovim; neovim.start_host()']
+  let args = [prog, '-c', 'import sys; sys.path.remove(""); import pynvim; pynvim.start_host()']
 
   " Collect registered Python plugins into args
   let python_plugins = remote#host#PluginsForHost(a:host.name)
@@ -62,17 +62,17 @@ function! s:check_interpreter(prog, major_ver) abort
 
   let min_version = (a:major_ver == 2) ? '2.6' : '3.3'
 
-  " Try to load neovim module, and output Python version.
+  " Try to load pynvim module, and output Python version.
   " Return codes:
-  "   0  Neovim module can be loaded.
-  "   2  Neovim module cannot be loaded.
+  "   0  pynvim module can be loaded.
+  "   2  pynvim module cannot be loaded.
   "   Otherwise something else went wrong (e.g. 1 or 127).
   let prog_ver = system([ a:prog , '-c' ,
         \ 'import sys; ' .
         \ 'sys.path.remove(""); ' .
         \ 'sys.stdout.write(str(sys.version_info[0]) + "." + str(sys.version_info[1])); ' .
         \ 'import pkgutil; ' .
-        \ 'exit(2*int(pkgutil.get_loader("neovim") is None))'
+        \ 'exit(2*int(pkgutil.get_loader("pynvim") is None))'
         \ ])
 
   if v:shell_error == 2 || v:shell_error == 0
@@ -87,7 +87,7 @@ function! s:check_interpreter(prog, major_ver) abort
   endif
 
   if v:shell_error == 2
-    return [0, prog_path.' does not have the "neovim" module. :help provider-python']
+    return [0, prog_path.' does not have the "pynvim" module. :help provider-python']
   elseif v:shell_error == 127
     " This can happen with pyenv's shims.
     return [0, prog_path . ' does not exist: ' . prog_ver]

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -19,23 +19,23 @@ Note: Only the Vim 7.3 API is supported; bindeval (Vim 7.4) is not.
 
 PYTHON QUICKSTART ~
 
-Install the "neovim" Python package:
+Install the "pynvim" Python package:
 
 - Run |:checkhealth| to see if you already have the package (some package
-  managers install the "neovim" Python package with Nvim itself). 
+  managers install the "pynvim" Python package with Nvim itself).
 
 - For Python 2 plugins, make sure Python 2.7 is available in your $PATH, then
   install the package systemwide: >
-    sudo pip2 install --upgrade neovim
+    sudo pip2 install --upgrade pynvim
 <  or for the current user: >
-    pip2 install --user --upgrade neovim
+    pip2 install --user --upgrade pynvim
 <  If "pip2" is missing, try "pip".
 
 - For Python 3 plugins, make sure Python 3.4+ is available in your $PATH, then
   install the package systemwide: >
-    sudo pip3 install --upgrade neovim
+    sudo pip3 install --upgrade pynvim
 <  or for the current user: >
-    pip3 install --user --upgrade neovim
+    pip3 install --user --upgrade pynvim
 <  If "pip3" is missing, try "pip".
 
 - The `--upgrade` flag ensures you have the latest version even if a previous
@@ -64,14 +64,14 @@ PYTHON VIRTUALENVS ~
 
 If you plan to use per-project virtualenvs often, you should assign one
 virtualenv for Neovim and hard-code the interpreter path via
-|g:python3_host_prog| (or |g:python_host_prog|) so that the "neovim" package
+|g:python3_host_prog| (or |g:python_host_prog|) so that the "pynvim" package
 is not required for each virtualenv.
 
 Example using pyenv: >
     pyenv install 3.4.4
     pyenv virtualenv 3.4.4 py3nvim
     pyenv activate py3nvim
-    pip install neovim
+    pip install pynvim
     pyenv which python  # Note the path
 The last command reports the interpreter path, add it to your init.vim: >
     let g:python3_host_prog = '/path/to/py3nvim/bin/python'

--- a/runtime/doc/remote_plugin.txt
+++ b/runtime/doc/remote_plugin.txt
@@ -42,15 +42,15 @@ what a Python plugin looks like. This plugin exports a command, a function, and
 an autocmd. The plugin is called 'Limit', and all it does is limit the number
 of requests made to it. Here's the plugin source code:
 >
-    import neovim
+    import pynvim
 
-    @neovim.plugin
+    @pynvim.plugin
     class Limit(object):
         def __init__(self, vim):
             self.vim = vim
             self.calls = 0
 
-        @neovim.command('Cmd', range='', nargs='*', sync=True)
+        @pynvim.command('Cmd', range='', nargs='*', sync=True)
         def command_handler(self, args, range):
             self._increment_calls()
             self.vim.current.line = (
@@ -58,14 +58,14 @@ of requests made to it. Here's the plugin source code:
                                                                    args,
                                                                    range))
 
-        @neovim.autocmd('BufEnter', pattern='*.py', eval='expand("<afile>")',
+        @pynvim.autocmd('BufEnter', pattern='*.py', eval='expand("<afile>")',
                         sync=True)
         def autocmd_handler(self, filename):
             self._increment_calls()
             self.vim.current.line = (
                 'Autocmd: Called %s times, file: %s' % (self.calls, filename))
 
-        @neovim.function('Func')
+        @pynvim.function('Func')
         def function_handler(self, args):
             self._increment_calls()
             self.vim.current.line = (


### PR DESCRIPTION
For a moment I pondered the idea of adding lots of glue code so that both, `neovim` and `pynvim`, get considered (since the former acts as a transition package for the latter), but I do not think it's worth the effort.

(And since it's directly related to Neovim, maybe the rename should be mentioned at https://github.com/neovim/neovim/wiki/Following-HEAD as well.)