### PR TITLE
[RDY] vim-patch:8.0.{737,1163,1165,1171,1249,1427}

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2661,6 +2661,8 @@ void ex_copen(exarg_T *eap)
       }
     }
   } else {
+    int flags = 0;
+
     qf_buf = qf_find_buf(qi);
 
     /* The current window becomes the previous window afterwards. */
@@ -2668,11 +2670,17 @@ void ex_copen(exarg_T *eap)
 
     if ((eap->cmdidx == CMD_copen || eap->cmdidx == CMD_cwindow)
         && cmdmod.split == 0)
-      /* Create the new window at the very bottom, except when
-       * :belowright or :aboveleft is used. */
+      // Create the new quickfix window at the very bottom, except when
+      // :belowright or :aboveleft is used.
       win_goto(lastwin);
-    if (win_split(height, WSP_BELOW | WSP_NEWLOC) == FAIL)
-      return;                   /* not enough room for window */
+    // Default is to open the window below the current window
+    if (cmdmod.split == 0) {
+      flags = WSP_BELOW;
+    }
+    flags |= WSP_NEWLOC;
+    if (win_split(height, flags) == FAIL) {
+      return;                   // not enough room for window
+    }
     RESET_BINDING(curwin);
 
     if (eap->cmdidx == CMD_lopen || eap->cmdidx == CMD_lwindow) {

--- a/src/nvim/testdir/shared.vim
+++ b/src/nvim/testdir/shared.vim
@@ -136,14 +136,15 @@ endfunc
 " Wait for up to a second for "expr" to become true.
 " Return time slept in milliseconds.  With the +reltime feature this can be
 " more than the actual waiting time.  Without +reltime it can also be less.
-func WaitFor(expr)
+func WaitFor(expr, ...)
+  let timeout = get(a:000, 0, 1000)
   " using reltime() is more accurate, but not always available
   if has('reltime')
     let start = reltime()
   else
     let slept = 0
   endif
-  for i in range(100)
+  for i in range(timeout / 10)
     try
       if eval(a:expr)
 	if has('reltime')
@@ -158,7 +159,7 @@ func WaitFor(expr)
     endif
     sleep 10m
   endfor
-  return 1000
+  return timeout
 endfunc
 
 " Wait for up to a given milliseconds.

--- a/src/nvim/testdir/shared.vim
+++ b/src/nvim/testdir/shared.vim
@@ -145,15 +145,12 @@ func WaitFor(expr, ...)
     let slept = 0
   endif
   for i in range(timeout / 10)
-    try
-      if eval(a:expr)
-	if has('reltime')
-	  return float2nr(reltimefloat(reltime(start)) * 1000)
-	endif
-	return slept
+    if eval(a:expr)
+      if has('reltime')
+	return float2nr(reltimefloat(reltime(start)) * 1000)
       endif
-    catch
-    endtry
+      return slept
+    endif
     if !has('reltime')
       let slept += 10
     endif

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -677,20 +677,26 @@ func Test_popup_and_window_resize()
   endif
   let g:buf = term_start([$NVIM_PRG, '--clean', '-c', 'set noswapfile'], {'term_rows': h / 3})
   call term_sendkeys(g:buf, (h / 3 - 1)."o\<esc>G")
+  call term_wait(g:buf, 100)
   call term_sendkeys(g:buf, "i\<c-x>")
   call term_wait(g:buf, 100)
   call term_sendkeys(g:buf, "\<c-v>")
   call term_wait(g:buf, 100)
+  " popup first entry "!" must be at the top
   call WaitFor('term_getline(g:buf, 1) =~ "^!"')
   call assert_match('^!\s*$', term_getline(g:buf, 1))
   exe 'resize +' . (h - 1)
   call term_wait(g:buf, 100)
   redraw!
+  " popup shifted down, first line is now empty
   call WaitFor('term_getline(g:buf, 1) == ""')
   call assert_equal('', term_getline(g:buf, 1))
   sleep 100m
+  " popup is below cursor line and shows first match "!"
   call WaitFor('term_getline(g:buf, term_getcursor(g:buf)[0] + 1) =~ "^!"')
   call assert_match('^!\s*$', term_getline(g:buf, term_getcursor(g:buf)[0] + 1))
+  " cursor line also shows !
+  call assert_match('^!\s*$', term_getline(g:buf, term_getcursor(g:buf)[0]))
   bwipe!
 endfunc
 

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -677,9 +677,8 @@ func Test_popup_and_window_resize()
   endif
   let g:buf = term_start([$NVIM_PRG, '--clean', '-c', 'set noswapfile'], {'term_rows': h / 3})
   call term_sendkeys(g:buf, (h / 3 - 1)."o\<esc>G")
-  call term_wait(g:buf, 100)
   call term_sendkeys(g:buf, "i\<c-x>")
-  call term_wait(g:buf, 100)
+  call term_wait(g:buf, 200)
   call term_sendkeys(g:buf, "\<c-v>")
   call term_wait(g:buf, 100)
   " popup first entry "!" must be at the top

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -681,14 +681,15 @@ func Test_popup_and_window_resize()
   call term_wait(g:buf, 100)
   call term_sendkeys(g:buf, "\<c-v>")
   call term_wait(g:buf, 100)
+  call WaitFor('term_getline(g:buf, 1) =~ "^!"')
   call assert_match('^!\s*$', term_getline(g:buf, 1))
   exe 'resize +' . (h - 1)
   call term_wait(g:buf, 100)
   redraw!
-  call WaitFor('"" == term_getline(g:buf, 1)')
+  call WaitFor('term_getline(g:buf, 1) == ""')
   call assert_equal('', term_getline(g:buf, 1))
   sleep 100m
-  call WaitFor('"^!" =~ term_getline(g:buf, term_getcursor(g:buf)[0] + 1)')
+  call WaitFor('term_getline(g:buf, term_getcursor(g:buf)[0] + 1) =~ "^!"')
   call assert_match('^!\s*$', term_getline(g:buf, term_getcursor(g:buf)[0] + 1))
   bwipe!
 endfunc

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2637,3 +2637,30 @@ func Test_shorten_fname()
   silent! clist
   call assert_equal('test_quickfix.vim', bufname('test_quickfix.vim'))
 endfunc
+
+" Test for the position of the quickfix and location list window
+func Test_qfwin_pos()
+  " Open two windows
+  new | only
+  new
+  cexpr ['F1:10:L10']
+  copen
+  " Quickfix window should be the bottom most window
+  call assert_equal(3, winnr())
+  close
+  " Open at the very top
+  wincmd t
+  topleft copen
+  call assert_equal(1, winnr())
+  close
+  " open left of the current window
+  wincmd t
+  below new
+  leftabove copen
+  call assert_equal(2, winnr())
+  close
+  " open right of the current window
+  rightbelow copen
+  call assert_equal(3, winnr())
+  close
+endfunc

--- a/src/nvim/testdir/test_quotestar.vim
+++ b/src/nvim/testdir/test_quotestar.vim
@@ -87,6 +87,18 @@ func Do_test_quotestar_for_x11()
   " Check that the *-register of this vim instance is changed as expected.
   call WaitFor('@* == "yes"', 3000)
 
+  " Handle the large selection over 262040 byte.
+  let length = 262044
+  let sample = 'a' . repeat('b', length - 2) . 'c'
+  let @* = sample
+  call WaitFor('remote_expr("' . name . '", "len(@*) >= ' . length . '", "", 1)', 3000)
+  let res = remote_expr(name, "@*", "", 2)
+  call assert_equal(length, len(res))
+  " Check length to prevent a large amount of output at assertion failure.
+  if length == len(res)
+    call assert_equal(sample, res)
+  endif
+
   if has('unix') && has('gui') && !has('gui_running')
     let @* = ''
 


### PR DESCRIPTION
**vim-patch:8.0.0737: crash when X11 selection is very big**

Problem:    Crash when X11 selection is very big.
Solution:   Use static items instead of allocating them.  Add callbacks.
            (Ozaki Kiichi)
vim/vim@cdb7e1b

**vim-patch:8.0.1163: popup test is flaky**

Problem:    Popup test is flaky.
Solution:   Add a WaitFor() and fix another.
vim/vim@c79977a

**vim-patch:8.0.1165: popup test is still flaky**

Problem:    Popup test is still flaky.
Solution:   Add a term_wait() call. (Ozaki Kiichi)
vim/vim@f52c383

**vim-patch:8.0.1171: popup test is still a bit flaky**

Problem:    Popup test is still a bit flaky.
Solution:   Change term_wait() calls. (Ozaki Kiichi)
vim/vim@712549e

**vim-patch:8.0.1249: no error when WaitFor() gets an invalid wrong expression**

Problem:    No error when WaitFor() gets an invalid wrong expression.
Solution:   Do not ignore errors in evaluationg the expression.  Fix places
            where the expression was wrong.
vim/vim@c20e0d5

**vim-patch:8.0.1427: the :leftabove modifier doesn't work for :copen**

Problem:    The :leftabove modifier doesn't work for :copen.
Solution:   Respect the split modifier. (Yegappan Lakshmanan, closes vim/vim#2496)
vim/vim@de04654