### PR TITLE
travis: switch from Ubuntu 14.04 to 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - ASAN_OPTIONS="detect_leaks=1:check_initialization_order=1:log_path=$LOG_DIR/asan"
     - TSAN_OPTIONS="log_path=$LOG_DIR/tsan"
     - UBSAN_OPTIONS="print_stacktrace=1 log_path=$LOG_DIR/ubsan"
+    - ASAN_SYMBOLIZE=asan_symbolize
     # Environment variables for Valgrind.
     - VALGRIND_LOG="$LOG_DIR/valgrind-%p.log"
     # If this file exists, the cache is valid (compile was successful).
@@ -50,11 +51,12 @@ jobs:
   include:
     - stage: normal builds
       os: linux
-      compiler: clang
+      compiler: clang-4.0
       env: >
         CLANG_SANITIZER=ASAN_UBSAN
         # Use Lua so that ASAN can test our embedded Lua support. 8fec4d53d0f6
         CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
+        ASAN_SYMBOLIZE=asan_symbolize-4.0
       sudo: true
     - os: linux
       compiler: gcc
@@ -100,7 +102,7 @@ addons:
       - autoconf
       - automake
       - build-essential
-      - clang
+      - clang-4.0
       - cmake
       - cscope
       - g++-multilib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: trusty
-sudo: false
+dist: xenial
+
 language: c
 
 env:
@@ -96,9 +96,9 @@ before_cache:   ci/before_cache.sh
 addons:
   apt:
     packages:
+      - apport
       - autoconf
       - automake
-      - apport
       - build-essential
       - clang
       - cmake
@@ -108,7 +108,7 @@ addons:
       - gdb
       - language-pack-tr
       - libc6-dev-i386
-      - libtool
+      - libtool-bin
       - locales
       - ninja-build
       - pkg-config

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -83,7 +83,7 @@ valgrind_check() {
 
 asan_check() {
   if test "${CLANG_SANITIZER}" = "ASAN_UBSAN" ; then
-    check_logs "${1}" "*san.*" | asan_symbolize
+    check_logs "${1}" "*san.*" | $ASAN_SYMBOLIZE
   fi
 }
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -8,10 +8,8 @@ if [[ "${CI_TARGET}" == lint ]]; then
 fi
 
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
-  brew install ninja
-  brew install gettext
-  brew reinstall libtool
   brew install ccache
+  brew install ninja
   export PATH="/usr/local/opt/ccache/libexec:$PATH"
 fi
 

--- a/src/nvim/aucmd.c
+++ b/src/nvim/aucmd.c
@@ -26,7 +26,6 @@ void aucmd_schedule_focusgained(bool gained)
 }
 
 static void do_autocmd_focusgained(bool gained)
-  FUNC_ATTR_NONNULL_ALL
 {
   static bool recursive = false;
 

--- a/src/nvim/eval/encode.c
+++ b/src/nvim/eval/encode.c
@@ -933,7 +933,7 @@ char *encode_tv2json(typval_T *tv, size_t *len)
 
 #define TYPVAL_ENCODE_CONV_BOOL(tv, num) \
     do { \
-      if ((num)) { \
+      if (num) { \
         msgpack_pack_true(packer); \
       } else { \
         msgpack_pack_false(packer); \


### PR DESCRIPTION
Travis is phasing out its support for containers, so we remove `sudo:
false`, which will be a no-op soon.

Reference:

  https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration