### PR TITLE
CI/Travis/macOS: Fix "brew reinstall" invocation

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -10,7 +10,7 @@ fi
 if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
   brew install ninja
   brew install gettext
-  brew reinstall -s libtool
+  brew reinstall libtool
   brew install ccache
   export PATH="/usr/local/opt/ccache/libexec:$PATH"
 fi


### PR DESCRIPTION
"-s" is "--build-from-source", an option to `brew install`.  This was
never a documented option per `brew help reinstall`.  It's not clear why
we were using this option, but it now fails the CI build.

ref https://github.com/Homebrew/brew/pull/5274
ref https://github.com/Homebrew/brew/issues/1656

cc @fwalch 