### PR TITLE
vim-patch:8.0.1731,8.1.0038

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3127,10 +3127,16 @@ static void ins_compl_restart(void)
  */
 static void ins_compl_set_original_text(char_u *str)
 {
-  /* Replace the original text entry. */
-  if (compl_first_match->cp_flags & ORIGINAL_TEXT) {    /* safety check */
+  // Replace the original text entry.
+  // The ORIGINAL_TEXT flag is either at the first item or might possibly be
+  // at the last item for backward completion
+  if (compl_first_match->cp_flags & ORIGINAL_TEXT) {  // safety check
     xfree(compl_first_match->cp_str);
     compl_first_match->cp_str = vim_strsave(str);
+  } else if (compl_first_match->cp_prev != NULL
+             && (compl_first_match->cp_prev->cp_flags & ORIGINAL_TEXT)) {
+    xfree(compl_first_match->cp_prev->cp_str);
+    compl_first_match->cp_prev->cp_str = vim_strsave(str);
   }
 }
 

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -246,6 +246,10 @@ func! Test_popup_completion_insertmode()
   iunmap <F5>
 endfunc
 
+" TODO: Fix what breaks after this line.
+" - Do not use "q!", it may exit Vim if there is an error
+finish
+
 func Test_noinsert_complete()
   function! s:complTest1() abort
     call complete(1, ['source', 'soundfold'])

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -571,6 +571,15 @@ func Test_completion_clear_candidate_list()
   bw!
 endfunc
 
+func Test_popup_complete_backwards()
+  new
+  call setline(1, ['Post', 'Port', 'Po'])
+  let expected=['Post', 'Port', 'Port']
+  call cursor(3,2)
+  call feedkeys("A\<C-X>". repeat("\<C-P>", 3). "rt\<cr>", 'tx')
+  call assert_equal(expected, getline(1,'$'))
+  bwipe!
+endfunc
 
 func Test_popup_and_preview_autocommand()
   " This used to crash Vim


### PR DESCRIPTION
**vim-patch:8.0.1731: characters deleted on completion**

Problem:    Characters deleted on completion. (Adrià Farrés)
Solution:   Also check the last item for the ORIGINAL_TEXT flag. (Christian
            Brabandt, closes vim/vim#1645)
https://github.com/vim/vim/commit/e87edf3b85f607632e5431640071fdbc36b685b2

**vim-patch:8.1.0038: popup test causes Vim to exit**

Problem:    Popup test causes Vim to exit.
Solution:   Disable the broken part of the test for now.
vim/vim@680c99b

8.1.0038 should be followed up with 8.1.0045 but it's missing earlier patches.