### PR TITLE
Call win32yank as win32yank.exe

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -101,9 +101,9 @@ function! provider#clipboard#Executable() abort
     let s:copy['*'] = s:copy['+']
     let s:paste['*'] = s:paste['+']
     return 'doitclient'
-  elseif executable('win32yank')
-    let s:copy['+'] = 'win32yank -i --crlf'
-    let s:paste['+'] = 'win32yank -o --lf'
+  elseif executable('win32yank.exe')
+    let s:copy['+'] = 'win32yank.exe -i --crlf'
+    let s:paste['+'] = 'win32yank.exe -o --lf'
     let s:copy['*'] = s:copy['+']
     let s:paste['*'] = s:paste['+']
     return 'win32yank'


### PR DESCRIPTION
This improves WSL compatibility, as the Win32 allows omitting the `.exe` extension, but WSL does not. Previously, to make win32yank work in WSL, one had to remove the `.exe` extension on the NTFS side.