### PR TITLE
temp (ignore): debug Travis CI hang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,43 +48,17 @@ env:
 
 jobs:
   include:
-    - stage: normal builds
-      os: linux
-      compiler: clang
-      env: >
-        CLANG_SANITIZER=ASAN_UBSAN
-        # Use Lua so that ASAN can test our embedded Lua support. 8fec4d53d0f6
-        CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
-      sudo: true
     - os: linux
       compiler: gcc
       env: >
         FUNCTIONALTEST=functionaltest-lua
         CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
         DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED_LUAJIT=OFF"
-    - os: linux
-      # Travis creates a cache per compiler. Set a different value here to
-      # store 32-bit dependencies in a separate cache.
-      compiler: gcc
-      env: BUILD_32BIT=ON
-    - os: osx
-      compiler: clang
-      osx_image: xcode9.4  # macOS 10.13
-    - os: osx
-      compiler: gcc
-      osx_image: xcode9.4  # macOS 10.13
-    - os: linux
-      env: CI_TARGET=lint
-    - stage: Flaky builds
-      os: linux
-      compiler: gcc
-      env: GCOV=gcov CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
-    - os: linux
-      compiler: clang
-      env: CLANG_SANITIZER=TSAN
-  allow_failures:
-    - env: GCOV=gcov CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
-    - env: CLANG_SANITIZER=TSAN
+    # - os: linux
+    #   # Travis creates a cache per compiler. Set a different value here to
+    #   # store 32-bit dependencies in a separate cache.
+    #   compiler: gcc
+    #   env: BUILD_32BIT=ON
   fast_finish: true
 
 before_install: ci/before_install.sh

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -588,6 +588,7 @@ int main(int argc, char **argv)
 
   TIME_MSG("before starting main loop");
   ILOG("starting main loop");
+  init_highlight(FALSE, FALSE);
 
   /*
    * Call the main command loop.  This never returns.

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -34,7 +34,7 @@ local nvim_prog = (
   or Paths.test_build_dir .. '/bin/nvim'
 )
 -- Default settings for the test session.
-local nvim_set  = 'set shortmess+=I background=light noswapfile noautoindent'
+local nvim_set  = 'set shortmess+=I noswapfile noautoindent'
                   ..' laststatus=1 undodir=. directory=. viewdir=. backupdir=.'
                   ..' belloff= noshowcmd noruler nomore'
 local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',


### PR DESCRIPTION
In https://github.com/neovim/neovim/pull/9262 it seems that removing `background=light` from `helpers.nvim_set` prevents the functional tests from starting (only on Travis). The test runner hangs on startup.

# todo

- [x] email Travis CI to enable debug mode
- [ ] use https://docs.travis-ci.com/user/running-build-in-debug-mode/#restarting-a-job-in-debug-mode-via-api to debug the build

# conclusion

see https://github.com/neovim/neovim/pull/9262#issuecomment-441446969