### PR TITLE
vim-patch:8.1.0098: segfault when pattern with \z() is very slow

### DIFF
--- a/src/nvim/regexp.h
+++ b/src/nvim/regexp.h
@@ -5,19 +5,20 @@
 #include "nvim/buffer_defs.h"
 #include "nvim/regexp_defs.h"
 
-/* Second argument for vim_regcomp(). */
-#define RE_MAGIC        1       /* 'magic' option */
-#define RE_STRING       2       /* match in string instead of buffer text */
-#define RE_STRICT       4       /* don't allow [abc] without ] */
-#define RE_AUTO         8       /* automatic engine selection */
+// Second argument for vim_regcomp().
+#define RE_MAGIC        1       ///< 'magic' option
+#define RE_STRING       2       ///< match in string instead of buffer text
+#define RE_STRICT       4       ///< don't allow [abc] without ]
+#define RE_AUTO         8       ///< automatic engine selection
 
-/* values for reg_do_extmatch */
-#define REX_SET        1       /* to allow \z\(...\), */
-#define REX_USE        2       /* to allow \z\1 et al. */
+// values for reg_do_extmatch
+#define REX_SET        1       ///< to allow \z\(...\),
+#define REX_USE        2       ///< to allow \z\1 et al.
+#define REX_ALL       (REX_SET | REX_USE)
 
-/* regexp.c */
+// regexp.c
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "regexp.h.generated.h"
 #endif
 
-#endif /* NVIM_REGEXP_H */
+#endif  // NVIM_REGEXP_H

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1367,20 +1367,23 @@ static int nfa_regatom(void)
     case '7':
     case '8':
     case '9':
-      /* \z1...\z9 */
-      if (reg_do_extmatch != REX_USE)
+      // \z1...\z9
+      if ((reg_do_extmatch & REX_USE) == 0) {
         EMSG_RET_FAIL(_(e_z1_not_allowed));
+      }
       EMIT(NFA_ZREF1 + (no_Magic(c) - '1'));
       /* No need to set nfa_has_backref, the sub-matches don't
        * change when \z1 .. \z9 matches or not. */
       re_has_z = REX_USE;
       break;
     case '(':
-      /* \z(  */
-      if (reg_do_extmatch != REX_SET)
+      // \z(
+      if (reg_do_extmatch != REX_SET) {
         EMSG_RET_FAIL(_(e_z_not_allowed));
-      if (nfa_reg(REG_ZPAREN) == FAIL)
-        return FAIL;                        /* cascaded error */
+      }
+      if (nfa_reg(REG_ZPAREN) == FAIL) {
+        return FAIL;                        // cascaded error
+      }
       re_has_z = REX_SET;
       break;
     default:
@@ -5052,10 +5055,11 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
     /* swap lists */
     thislist = &list[flag];
     nextlist = &list[flag ^= 1];
-    nextlist->n = 0;                /* clear nextlist */
-    nextlist->has_pim = FALSE;
-    ++nfa_listid;
-    if (prog->re_engine == AUTOMATIC_ENGINE && nfa_listid >= NFA_MAX_STATES) {
+    nextlist->n = 0;                // clear nextlist
+    nextlist->has_pim = false;
+    nfa_listid++;
+    if (prog->re_engine == AUTOMATIC_ENGINE
+        && (nfa_listid >= NFA_MAX_STATES)) {
       // Too many states, retry with old engine.
       nfa_match = NFA_TOO_EXPENSIVE;
       goto theend;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -5603,6 +5603,7 @@ next_search_hl (
   linenr_T l;
   colnr_T matchcol;
   long nmatched = 0;
+  int save_called_emsg = called_emsg;
 
   if (shl->lnum != 0) {
     /* Check for three situations:
@@ -5695,6 +5696,9 @@ next_search_hl (
       shl->lnum += shl->rm.startpos[0].lnum;
       break;                            /* useful match found */
     }
+
+    // Restore called_emsg for assert_fails().
+    called_emsg = save_called_emsg;
   }
 }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -2894,6 +2894,13 @@ static int syn_regexec(regmmatch_T *rmp, linenr_T lnum, colnr_T col, syn_time_T 
     pt = profile_start();
   }
 
+  if (rmp->regprog == NULL) {
+    // This can happen if a previous call to vim_regexec_multi() tried to
+    // use the NFA engine, which resulted in NFA_TOO_EXPENSIVE, and
+    // compiling the pattern with the other engine fails.
+    return false;
+  }
+
   rmp->rmm_maxcol = syn_buf->b_p_smc;
   r = vim_regexec_multi(rmp, syn_win, syn_buf, lnum, col, NULL);
 

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -482,3 +482,15 @@ fun Test_synstack_synIDtrans()
   syn clear
   bw!
 endfunc
+
+" Using \z() in a region with NFA failing should not crash.
+func Test_syn_wrong_z_one()
+  new
+  call setline(1, ['just some text', 'with foo and bar to match with'])
+  syn region FooBar start="foo\z(.*\)bar" end="\z1"
+  " call test_override("nfa_fail", 1)
+  redraw!
+  redraw!
+  " call test_override("ALL", 0)
+  bwipe!
+endfunc


### PR DESCRIPTION
Problem:    Segfault when pattern with \z() is very slow.
Solution:   Check for NULL regprog.  Add "nfa_fail" to test_override() to be
            able to test this.  Fix that 'searchhl' resets called_emsg.
https://github.com/vim/vim/commit/bcf9442307075bac40d44328c8bf7ea21857b138

closes #8788