### PR TITLE
highlight: Fix missing .rgb_sp_color in initializers

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -188,6 +188,7 @@ int hl_get_underline(void)
           .rgb_ae_attr = (int16_t)HL_UNDERLINE,
           .rgb_fg_color = -1,
           .rgb_bg_color = -1,
+          .rgb_sp_color = -1,
       },
       .kind = kHlUI,
       .id1 = 0,

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -610,6 +610,7 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr,
         .rgb_ae_attr = (int16_t)hl_attrs,
         .rgb_fg_color = vt_fg,
         .rgb_bg_color = vt_bg,
+        .rgb_sp_color = -1,
       });
     }
 

--- a/test/functional/core/main_spec.lua
+++ b/test/functional/core/main_spec.lua
@@ -77,8 +77,8 @@ describe('Command-line option', function()
                                                 |
                                                 |
       ]], {
-        [1] = {foreground = 4210943, special = Screen.colors.Grey0},
-        [2] = {special = Screen.colors.Grey0, bold = true, reverse = true}
+        [1] = {foreground = 4210943},
+        [2] = {bold = true, reverse = true}
       })
       feed('i:cq<CR>')
       screen:expect([[

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -120,7 +120,7 @@ describe('terminal window highlighting with custom palette', function()
     clear()
     screen = Screen.new(50, 7)
     screen:set_default_attr_ids({
-      [1] = {foreground = 1193046, special = Screen.colors.Black},
+      [1] = {foreground = tonumber('0x123456')},
       [2] = {foreground = 12},
       [3] = {bold = true, reverse = true},
       [5] = {background = 11},

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -207,14 +207,14 @@ describe('tui', function()
     screen:set_option('rgb', true)
     screen:set_default_attr_ids({
       [1] = {reverse = true},
-      [2] = {foreground = 13, special = Screen.colors.Grey0},
-      [3] = {bold = true, reverse = true, special = Screen.colors.Grey0},
+      [2] = {foreground = 13},
+      [3] = {bold = true, reverse = true},
       [4] = {bold = true},
-      [5] = {special = Screen.colors.Grey0, reverse = true, foreground = 4},
-      [6] = {foreground = 4, special = Screen.colors.Grey0},
-      [7] = {special = Screen.colors.Grey0, reverse = true, foreground = Screen.colors.SeaGreen4},
-      [8] = {foreground = Screen.colors.SeaGreen4, special = Screen.colors.Grey0},
-      [9] = {special = Screen.colors.Grey0, bold = true, foreground = Screen.colors.Blue1},
+      [5] = {reverse = true, foreground = 4},
+      [6] = {foreground = 4},
+      [7] = {reverse = true, foreground = Screen.colors.SeaGreen4},
+      [8] = {foreground = Screen.colors.SeaGreen4},
+      [9] = {bold = true, foreground = Screen.colors.Blue1},
     })
 
     feed_data(':hi SpecialKey ctermfg=3 guifg=SeaGreen\n')

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -797,9 +797,9 @@ describe('CursorLine highlight', function()
       [8] = {bold = true, foreground = Screen.colors.Blue1},
       [9] = {bold = true, reverse = true},
       [10] = {bold = true},
-      [11] = {special = Screen.colors.Grey0, underline = true,
+      [11] = {underline = true,
               background = Screen.colors.LightMagenta},
-      [12] = {bold = true, underline = true, special = Screen.colors.Grey0,
+      [12] = {bold = true, underline = true,
               background = Screen.colors.Red},
     })
   end)

--- a/test/functional/ui/hlstate_spec.lua
+++ b/test/functional/ui/hlstate_spec.lua
@@ -177,11 +177,11 @@ describe('ext_hlstate detailed highlights', function()
   it("work with :terminal", function()
     screen:set_default_attr_ids({
       [1] = {{}, {{hi_name = "TermCursorNC", ui_name = "TermCursorNC", kind = "ui"}}},
-      [2] = {{special = Screen.colors.Grey0, foreground = 52479}, {{kind = "term"}}},
-      [3] = {{special = Screen.colors.Grey0, bold = true, foreground = 52479}, {{kind = "term"}}},
-      [4] = {{special = Screen.colors.Grey0, foreground = 52479}, {2, 1}},
-      [5] = {{special = Screen.colors.Grey0, foreground = 4259839}, {{kind = "term"}}},
-      [6] = {{special = Screen.colors.Grey0, foreground = 4259839}, {5, 1}},
+      [2] = {{foreground = 52479}, {{kind = "term"}}},
+      [3] = {{bold = true, foreground = 52479}, {{kind = "term"}}},
+      [4] = {{foreground = 52479}, {2, 1}},
+      [5] = {{foreground = 4259839}, {{kind = "term"}}},
+      [6] = {{foreground = 4259839}, {5, 1}},
     })
     command('enew | call termopen(["'..nvim_dir..'/tty-test"])')
     screen:expect([[


### PR DESCRIPTION
ref #9028
ref 60f845ca55a1

gcc 7.3 / clang 5.0 doesn't warn about this even with:

    add_definitions(-Wmissing-field-initializers)
