### PR TITLE
vim-patch:8.1.{550,551}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19538,6 +19538,7 @@ void ex_echo(exarg_T *eap)
   typval_T rettv;
   bool needclr = true;
   bool atstart = true;
+  const int did_emsg_before = did_emsg;
 
   if (eap->skip)
     ++emsg_skip;
@@ -19552,7 +19553,7 @@ void ex_echo(exarg_T *eap)
         // Report the invalid expression unless the expression evaluation
         // has been cancelled due to an aborting error, an interrupt, or an
         // exception.
-        if (!aborting()) {
+        if (!aborting() && did_emsg == did_emsg_before) {
           EMSG2(_(e_invexpr2), p);
         }
         need_clr_eos = false;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19642,7 +19642,7 @@ void ex_execute(exarg_T *eap)
   int ret = OK;
   char_u      *p;
   garray_T ga;
-  int save_did_emsg;
+  int save_did_emsg = did_emsg;
 
   ga_init(&ga, 1, 80);
 
@@ -19656,8 +19656,9 @@ void ex_execute(exarg_T *eap)
        * has been cancelled due to an aborting error, an interrupt, or an
        * exception.
        */
-      if (!aborting())
+      if (!aborting() && did_emsg == save_did_emsg) {
         EMSG2(_(e_invexpr2), p);
+      }
       ret = FAIL;
       break;
     }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -505,7 +505,7 @@ int emsg(const char_u *s_)
      */
     if (cause_errthrow((char_u *)s, severe, &ignore) == true) {
       if (!ignore) {
-        did_emsg = true;
+        did_emsg++;
       }
       return true;
     }
@@ -554,7 +554,7 @@ int emsg(const char_u *s_)
     } else {
       flush_buffers(FLUSH_MINIMAL);  // flush internal buffers
     }
-    did_emsg = true;          // flag for DoOneCmd()
+    did_emsg++;               // flag for DoOneCmd()
   }
 
   emsg_on_display = true;     // remember there is an error message

--- a/test/functional/ex_cmds/debug_spec.lua
+++ b/test/functional/ex_cmds/debug_spec.lua
@@ -7,7 +7,7 @@ describe(':debug', function()
   local screen
   before_each(function()
     clear()
-    screen = Screen.new(50, 14)
+    screen = Screen.new(30, 14)
     screen:set_default_attr_ids({
       [1] = {bold = true, foreground = Screen.colors.Blue1},
       [2] = {bold = true, reverse = true},
@@ -19,92 +19,92 @@ describe(':debug', function()
   it('scrolls messages correctly', function()
     feed(':echoerr bork<cr>')
     screen:expect([[
-      ^                                                  |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {3:E121: Undefined variable: bork}                    |
+                                    |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {2:                              }|
+      {3:E121: Undefined variable: bork}|
+                                    |
+      {4:Press ENTER or type command to}|
+      {4: continue}^                     |
     ]])
 
     feed(':debug echo "aa"| echo "bb"<cr>')
     screen:expect([[
-                                                        |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {2:                                                  }|
-      Entering Debug mode.  Type "cont" to continue.    |
-      cmd: echo "aa"| echo "bb"                         |
-      >^                                                 |
+                                    |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {2:                              }|
+      {3:E121: Undefined variable: bork}|
+                                    |
+      {4:Press ENTER or type command to}|
+      Entering Debug mode.  Type "co|
+      nt" to continue.              |
+      cmd: echo "aa"| echo "bb"     |
+      >^                             |
     ]])
 
     feed('step<cr>')
     screen:expect([[
-                                                        |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {2:                                                  }|
-      Entering Debug mode.  Type "cont" to continue.    |
-      cmd: echo "aa"| echo "bb"                         |
-      >step                                             |
-      aa                                                |
-      cmd: echo "bb"                                    |
-      >^                                                 |
+                                    |
+      {1:~                             }|
+      {1:~                             }|
+      {2:                              }|
+      {3:E121: Undefined variable: bork}|
+                                    |
+      {4:Press ENTER or type command to}|
+      Entering Debug mode.  Type "co|
+      nt" to continue.              |
+      cmd: echo "aa"| echo "bb"     |
+      >step                         |
+      aa                            |
+      cmd: echo "bb"                |
+      >^                             |
     ]])
 
     feed('step<cr>')
     screen:expect([[
-                                                        |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {2:                                                  }|
-      Entering Debug mode.  Type "cont" to continue.    |
-      cmd: echo "aa"| echo "bb"                         |
-      >step                                             |
-      aa                                                |
-      cmd: echo "bb"                                    |
-      >step                                             |
-      bb                                                |
-      {4:Press ENTER or type command to continue}^           |
+      {2:                              }|
+      {3:E121: Undefined variable: bork}|
+                                    |
+      {4:Press ENTER or type command to}|
+      Entering Debug mode.  Type "co|
+      nt" to continue.              |
+      cmd: echo "aa"| echo "bb"     |
+      >step                         |
+      aa                            |
+      cmd: echo "bb"                |
+      >step                         |
+      bb                            |
+      {4:Press ENTER or type command to}|
+      {4: continue}^                     |
     ]])
 
     feed('<cr>')
     screen:expect([[
-      ^                                                  |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-                                                        |
+      ^                              |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+                                    |
     ]])
   end)
 end)

--- a/test/functional/ex_cmds/debug_spec.lua
+++ b/test/functional/ex_cmds/debug_spec.lua
@@ -19,7 +19,7 @@ describe(':debug', function()
   it('scrolls messages correctly', function()
     feed(':echoerr bork<cr>')
     screen:expect([[
-                                                        |
+      ^                                                  |
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
@@ -29,10 +29,10 @@ describe(':debug', function()
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
-      {2:                                                  }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
       {3:E121: Undefined variable: bork}                    |
-      {3:E15: Invalid expression: bork}                     |
-      {4:Press ENTER or type command to continue}^           |
     ]])
 
     feed(':debug echo "aa"| echo "bb"<cr>')
@@ -45,9 +45,9 @@ describe(':debug', function()
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
       {2:                                                  }|
-      {3:E121: Undefined variable: bork}                    |
-      {3:E15: Invalid expression: bork}                     |
       Entering Debug mode.  Type "cont" to continue.    |
       cmd: echo "aa"| echo "bb"                         |
       >^                                                 |
@@ -60,9 +60,9 @@ describe(':debug', function()
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
       {2:                                                  }|
-      {3:E121: Undefined variable: bork}                    |
-      {3:E15: Invalid expression: bork}                     |
       Entering Debug mode.  Type "cont" to continue.    |
       cmd: echo "aa"| echo "bb"                         |
       >step                                             |
@@ -76,9 +76,9 @@ describe(':debug', function()
                                                         |
       {1:~                                                 }|
       {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
       {2:                                                  }|
-      {3:E121: Undefined variable: bork}                    |
-      {3:E15: Invalid expression: bork}                     |
       Entering Debug mode.  Type "cont" to continue.    |
       cmd: echo "aa"| echo "bb"                         |
       >step                                             |

--- a/test/functional/legacy/108_backtrace_debug_commands_spec.lua
+++ b/test/functional/legacy/108_backtrace_debug_commands_spec.lua
@@ -121,7 +121,6 @@ describe('108', function()
       Error detected while processing function Foo[2]..Bar[2]..Bazz:
       line    3:
       E121: Undefined variable: var3
-      E15: Invalid expression: var3
       here var3 is defined with "another var":
       another var
 
@@ -129,7 +128,6 @@ describe('108', function()
       Error detected while processing function Foo[2]..Bar:
       line    3:
       E121: Undefined variable: var2
-      E15: Invalid expression: var2
       here var2 is defined with 10:
       10
 

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -117,60 +117,60 @@ local function test_cmdline(linegrid)
     end)
 
     it('but not with scrolled messages', function()
-      screen:try_resize(49,10)
+      screen:try_resize(35,10)
       feed(':echoerr doesnotexist<cr>')
       screen:expect{grid=[[
-        ^                                                 |
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {3:n                                                }|
-        {4:E121: Undefined variable: doesnotexist}           |
+                                           |
+        {1:~                                  }|
+        {1:~                                  }|
+        {1:~                                  }|
+        {1:~                                  }|
+        {3:                                   }|
+        {4:E121: Undefined variable: doesnotex}|
+        {4:ist}                                |
+        {5:Press ENTER or type command to cont}|
+        {5:inue}^                               |
       ]]}
       feed(':echoerr doesnotexist<cr>')
       screen:expect{grid=[[
-        ^                                                 |
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {3:n                                                }|
-        {4:E121: Undefined variable: doesnotexist}           |
+                                           |
+        {1:~                                  }|
+        {3:                                   }|
+        {4:E121: Undefined variable: doesnotex}|
+        {4:ist}                                |
+        {5:Press ENTER or type command to cont}|
+        {4:E121: Undefined variable: doesnotex}|
+        {4:ist}                                |
+        {5:Press ENTER or type command to cont}|
+        {5:inue}^                               |
       ]]}
 
       feed(':echoerr doesnotexist<cr>')
       screen:expect{grid=[[
-        ^                                                 |
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {3:n                                                }|
-        {4:E121: Undefined variable: doesnotexist}           |
+        {4:E121: Undefined variable: doesnotex}|
+        {4:ist}                                |
+        {5:Press ENTER or type command to cont}|
+        {4:E121: Undefined variable: doesnotex}|
+        {4:ist}                                |
+        {5:Press ENTER or type command to cont}|
+        {4:E121: Undefined variable: doesnotex}|
+        {4:ist}                                |
+        {5:Press ENTER or type command to cont}|
+        {5:inue}^                               |
       ]]}
 
       feed('<cr>')
       screen:expect{grid=[[
-        ^                                                 |
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {1:~                                                }|
-        {3:n                                                }|
-        {4:E121: Undefined variable: doesnotexist}           |
+        ^                                   |
+        {1:~                                  }|
+        {1:~                                  }|
+        {1:~                                  }|
+        {1:~                                  }|
+        {1:~                                  }|
+        {1:~                                  }|
+        {1:~                                  }|
+        {3:n                                  }|
+                                           |
       ]]}
     end)
   end)

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -117,60 +117,60 @@ local function test_cmdline(linegrid)
     end)
 
     it('but not with scrolled messages', function()
-      screen:try_resize(50,10)
+      screen:try_resize(49,10)
       feed(':echoerr doesnotexist<cr>')
       screen:expect{grid=[[
-                                                          |
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {3:                                                  }|
-        {4:E121: Undefined variable: doesnotexist}            |
-        {4:E15: Invalid expression: doesnotexist}             |
-        {5:Press ENTER or type command to continue}^           |
+        ^                                                 |
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {3:n                                                }|
+        {4:E121: Undefined variable: doesnotexist}           |
       ]]}
       feed(':echoerr doesnotexist<cr>')
       screen:expect{grid=[[
-                                                          |
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {3:                                                  }|
-        {4:E121: Undefined variable: doesnotexist}            |
-        {4:E15: Invalid expression: doesnotexist}             |
-        {4:E121: Undefined variable: doesnotexist}            |
-        {4:E15: Invalid expression: doesnotexist}             |
-        {5:Press ENTER or type command to continue}^           |
+        ^                                                 |
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {3:n                                                }|
+        {4:E121: Undefined variable: doesnotexist}           |
       ]]}
 
       feed(':echoerr doesnotexist<cr>')
       screen:expect{grid=[[
-                                                          |
-        {1:~                                                 }|
-        {3:                                                  }|
-        {4:E121: Undefined variable: doesnotexist}            |
-        {4:E15: Invalid expression: doesnotexist}             |
-        {4:E121: Undefined variable: doesnotexist}            |
-        {4:E15: Invalid expression: doesnotexist}             |
-        {4:E121: Undefined variable: doesnotexist}            |
-        {4:E15: Invalid expression: doesnotexist}             |
-        {5:Press ENTER or type command to continue}^           |
+        ^                                                 |
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {3:n                                                }|
+        {4:E121: Undefined variable: doesnotexist}           |
       ]]}
 
       feed('<cr>')
       screen:expect{grid=[[
-        ^                                                  |
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {1:~                                                 }|
-        {3:n                                                 }|
-                                                          |
+        ^                                                 |
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {1:~                                                }|
+        {3:n                                                }|
+        {4:E121: Undefined variable: doesnotexist}           |
       ]]}
     end)
   end)

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -28,9 +28,9 @@ local function test_embed(ext_linegrid)
                                                                   |
                                                                   |
                                                                   |
+                                                                  |
       Error detected while processing pre-vimrc command line:     |
       E121: Undefined variable: invalid                           |
-      E15: Invalid expression: invalid+                           |
       Press ENTER or type command to continue^                     |
     ]])
 


### PR DESCRIPTION
**vim-patch:8.1.0550: expression evaluation may repeat an error message**

Problem:    Expression evaluation may repeat an error message. (Jason Franklin)
Solution:   Increment did_emsg and check for the value when giving an error for the echo command.
vim/vim@76a6345

**vim-patch:8.1.0551: expression evaluation may repeat an error message**

Problem:    Expression evaluation may repeat an error message. (Jason Franklin)
Solution:   Check for the value of did_emsg when giving an error for the :execute command.
vim/vim@8ff5af9