### PR TITLE
vim-patch:8.1.0553

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -305,6 +305,9 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			first sourced.  The number is used for the script ID
 			|<SID>|.
 
+:scr[iptnames][!] {scriptId}			*:script*
+			Edit script {scriptId}.  Suggested name is ":script".
+
 						*:fini* *:finish* *E168*
 :fini[sh]		Stop sourcing a script.  Can only be used in a Vim
 			script file.  This is a quick way to skip the rest of

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -28,15 +28,15 @@ local FILES      = bit.bor(XFILE, EXTRA)
 local WORD1      = bit.bor(EXTRA, NOSPC)
 local FILE1      = bit.bor(FILES, NOSPC)
 
-local ADDR_LINES            =  0
-local ADDR_WINDOWS          =  1
-local ADDR_ARGUMENTS        =  2
-local ADDR_LOADED_BUFFERS   =  3
-local ADDR_BUFFERS          =  4
-local ADDR_TABS             =  5
-local ADDR_TABS_RELATIVE    =  6
-local ADDR_QUICKFIX         =  7
-local ADDR_OTHER            =  99
+local ADDR_LINES            =  0    -- buffer line numbers
+local ADDR_WINDOWS          =  1    -- window number
+local ADDR_ARGUMENTS        =  2    -- argument number
+local ADDR_LOADED_BUFFERS   =  3    -- buffer number of loaded buffer
+local ADDR_BUFFERS          =  4    -- buffer number
+local ADDR_TABS             =  5    -- tab page number
+local ADDR_TABS_RELATIVE    =  6    -- Tab page that only relative
+local ADDR_QUICKFIX         =  7    -- quickfix list entry number
+local ADDR_OTHER            =  99   -- something else
 
 -- The following table is described in ex_cmds_defs.h file.
 return {
@@ -2326,8 +2326,8 @@ return {
   },
   {
     command='scriptnames',
-    flags=bit.bor(TRLBAR, CMDWIN),
-    addr_type=ADDR_LINES,
+    flags=bit.bor(BANG, RANGE, NOTADR, COUNT, TRLBAR, CMDWIN),
+    addr_type=ADDR_OTHER,
     func='ex_scriptnames',
   },
   {

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3069,6 +3069,17 @@ theend:
 /// ":scriptnames"
 void ex_scriptnames(exarg_T *eap)
 {
+  if (eap->addr_count > 0) {
+    // :script {scriptId}: edit the script
+    if (eap->line2 < 1 || eap->line2 > script_items.ga_len) {
+      EMSG(_(e_invarg));
+    } else {
+      eap->arg = SCRIPT_ITEM(eap->line2).sn_name;
+      do_exedit(eap, NULL);
+    }
+    return;
+  }
+
   for (int i = 1; i <= script_items.ga_len && !got_int; i++) {
     if (SCRIPT_ITEM(i).sn_name != NULL) {
       home_replace(NULL, SCRIPT_ITEM(i).sn_name,

--- a/src/nvim/testdir/test_scriptnames.vim
+++ b/src/nvim/testdir/test_scriptnames.vim
@@ -1,0 +1,26 @@
+" Test for :scriptnames
+
+func Test_scriptnames()
+  call writefile(['let did_load_script = 123'], 'Xscripting')
+  source Xscripting
+  call assert_equal(123, g:did_load_script)
+
+  let scripts = split(execute('scriptnames'), "\n")
+  let last = scripts[-1]
+  call assert_match('\<Xscripting\>', last)
+  let lastnr = substitute(last, '\D*\(\d\+\):.*', '\1', '')
+  exe 'script ' . lastnr
+  call assert_equal('Xscripting', expand('%:t'))
+
+  call assert_fails('script ' . (lastnr + 1), 'E474:')
+  call assert_fails('script 0', 'E939:')
+
+  new
+  call setline(1, 'nothing')
+  call assert_fails('script ' . lastnr, 'E37:')
+  exe 'script! ' . lastnr
+  call assert_equal('Xscripting', expand('%:t'))
+
+  bwipe
+  call delete('Xscripting')
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0553: it is not easy to edit a script that was sourced**

Problem:    It is not easy to edit a script that was sourced.
Solution:   Add a count to ":scriptnames", so that ":script 40" edits the
            script with script ID 40.
https://github.com/vim/vim/commit/07dc18ffa4e7ed202f219fe2fd3d6f58246f71f9