### PR TITLE
clipboard: Prefer xclip

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -77,18 +77,18 @@ function! provider#clipboard#Executable() abort
     let s:copy['*'] = 'wl-copy --foreground --primary'
     let s:paste['*'] = 'wl-paste --no-newline --primary'
     return 'wl-copy'
-  elseif exists('$DISPLAY') && executable('xsel') && s:cmd_ok('xsel -o -b')
-    let s:copy['+'] = 'xsel --nodetach -i -b'
-    let s:paste['+'] = 'xsel -o -b'
-    let s:copy['*'] = 'xsel --nodetach -i -p'
-    let s:paste['*'] = 'xsel -o -p'
-    return 'xsel'
   elseif exists('$DISPLAY') && executable('xclip')
     let s:copy['+'] = 'xclip -quiet -i -selection clipboard'
     let s:paste['+'] = 'xclip -o -selection clipboard'
     let s:copy['*'] = 'xclip -quiet -i -selection primary'
     let s:paste['*'] = 'xclip -o -selection primary'
     return 'xclip'
+  elseif exists('$DISPLAY') && executable('xsel') && s:cmd_ok('xsel -o -b')
+    let s:copy['+'] = 'xsel --nodetach -i -b'
+    let s:paste['+'] = 'xsel -o -b'
+    let s:copy['*'] = 'xsel --nodetach -i -p'
+    let s:paste['*'] = 'xsel -o -p'
+    return 'xsel'
   elseif executable('lemonade')
     let s:copy['+'] = 'lemonade copy'
     let s:paste['+'] = 'lemonade paste'

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -150,9 +150,10 @@ The presence of a working clipboard tool implicitly enables the '+' and '*'
 registers. Nvim looks for these clipboard tools, in order of priority:
 
   - |g:clipboard|
-  - pbcopy/pbpaste (macOS)
-  - xsel (if $DISPLAY is set)
+  - pbcopy, pbpaste (macOS)
+  - wl-copy, wl-paste (if $WAYLAND_DISPLAY is set)
   - xclip (if $DISPLAY is set)
+  - xsel (if $DISPLAY is set)
   - lemonade (for SSH) https://github.com/pocke/lemonade
   - doitclient (for SSH) http://www.chiark.greenend.org.uk/~sgtatham/doit/
   - win32yank (Windows)


### PR DESCRIPTION
The order was swapped in #4150 to prefer `xsel` but there wasn't a clear
explanation.  Meanwhile, `xsel` has been neglected upstream.

Let's trying preferring `xclip` again, we've had a few reports of
problems with `xsel`.

closes #7237
ref #5853
ref #7449