### PR TITLE
[RFC] Support functions in custom clipboard providers

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -55,11 +55,22 @@ endfunction
 function! provider#clipboard#Executable() abort
   if exists('g:clipboard')
     if type({}) isnot# type(g:clipboard)
-          \ || type({}) isnot# type(get(g:clipboard, 'copy', v:null))
-          \ || type({}) isnot# type(get(g:clipboard, 'paste', v:null))
       let s:err = 'clipboard: invalid g:clipboard'
       return ''
     endif
+
+    if type(get(g:clipboard, 'copy', v:null)) isnot# v:t_dict
+        \ && type(get(g:clipboard, 'copy', v:null)) isnot# v:t_func
+      let s:err = "clipboard: invalid g:clipboard['copy']"
+      return ''
+    endif
+
+    if type(get(g:clipboard, 'paste', v:null)) isnot# v:t_dict
+        \ && type(get(g:clipboard, 'paste', v:null)) isnot# v:t_func
+      let s:err = "clipboard: invalid g:clipboard['paste']"
+      return ''
+    endif
+
     let s:copy = get(g:clipboard, 'copy', { '+': v:null, '*': v:null })
     let s:paste = get(g:clipboard, 'paste', { '+': v:null, '*': v:null })
     let s:cache_enabled = get(g:clipboard, 'cache_enabled', 0)
@@ -127,10 +138,13 @@ if empty(provider#clipboard#Executable())
 endif
 
 function! s:clipboard.get(reg) abort
-  if s:selections[a:reg].owner > 0
+  if type(s:paste[a:reg]) == v:t_func
+    return s:paste[a:reg]()
+  elseif s:selections[a:reg].owner > 0
     return s:selections[a:reg].data
+  else
+    return s:try_cmd(s:paste[a:reg])
   end
-  return s:try_cmd(s:paste[a:reg])
 endfunction
 
 function! s:clipboard.set(lines, regtype, reg) abort
@@ -141,6 +155,12 @@ function! s:clipboard.set(lines, regtype, reg) abort
     end
     return 0
   end
+
+  if type(s:copy[a:reg]) == v:t_func
+    call s:copy[a:reg](a:lines, a:regtype)
+    return 0
+  end
+
   if s:cache_enabled == 0
     call s:try_cmd(s:copy[a:reg], a:lines)
     return 0

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -178,6 +178,20 @@ If `cache_enabled` is |TRUE| then when a selection is copied, Nvim will cache
 the selection until the copy command process dies. When pasting, if the copy
 process has not died, the cached selection is applied.
 
+Instead of using external tools the provider can also use vimscript functions
+>
+    let g:clipboard = {
+          \   'name': 'custom',
+          \   'copy': {
+          \      '+': {lines, regtype -> extend(g:, {'dummy_clipboard_plus': [lines, regtype]}) },
+          \      '*': {lines, regtype -> extend(g:, {'dummy_clipboard_star': [lines, regtype]}) },
+          \    },
+          \   'paste': {
+          \      '+': {-> get(g:, 'dummy_clipboard_plus', [])},
+          \      '*': {-> get(g:, 'dummy_clipboard_star', [])},
+          \   },
+          \ }
+
 ==============================================================================
 X11 selection mechanism			      *clipboard-x11* *x11-selection*
 

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -192,6 +192,16 @@ Instead of using external tools the provider can also use vimscript functions
           \   },
           \ }
 
+The copy function is meant to place a list of lines into the clipboard and
+store a register type specification (as seen in |setreg|, `"v"` for
+|characterwise|, `"V"` for |linewise| and `"b"` for |blockwise-visual|) along with the data.
+
+The paste function returns a list that contains the clipboard data as [lines,
+regtype], where lines is a list of lines and regtype is a register type
+specification as seen in |setreg|. If no data is available in the clipboard an
+empty list can be returned. If no regtype is available it can be omited from
+the return value.
+
 ==============================================================================
 X11 selection mechanism			      *clipboard-x11* *x11-selection*
 

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -183,6 +183,59 @@ describe('clipboard', function()
     command('call setreg("*", "star", "b")')
 	eq({{'star', ''}, 'b'}, eval("g:dummy_clipboard_star"))
   end)
+
+  describe('g:clipboard[paste] function', function()
+    it('can return empty list for empty clipboard', function()
+      source([[let g:dummy_clipboard = []
+	          let g:clipboard = {
+              \  'name': 'custom',
+              \  'copy': { '*': {lines, regtype ->  0} },
+              \  'paste': { '*': {-> g:dummy_clipboard} },
+              \}]])
+      eq('', eval('provider#clipboard#Error()'))
+      eq('custom', eval('provider#clipboard#Executable()'))
+      eq('', eval("getreg('*')"))
+    end)
+
+    it('can return a list with a single string', function()
+      source([=[let g:dummy_clipboard = ['hello']
+              let g:clipboard = {
+              \  'name': 'custom',
+              \  'copy': { '*': {lines, regtype ->  0} },
+              \  'paste': { '*': {-> g:dummy_clipboard} },
+              \}]=])
+      eq('', eval('provider#clipboard#Error()'))
+      eq('custom', eval('provider#clipboard#Executable()'))
+
+      eq('hello', eval("getreg('*')"))
+	  source([[let g:dummy_clipboard = [''] ]])
+      eq('', eval("getreg('*')"))
+    end)
+
+    it('can return a list of lines if a regtype is provided', function()
+      source([=[let g:dummy_clipboard = [['hello'], 'v']
+              let g:clipboard = {
+              \  'name': 'custom',
+              \  'copy': { '*': {lines, regtype ->  0} },
+              \  'paste': { '*': {-> g:dummy_clipboard} },
+              \}]=])
+      eq('', eval('provider#clipboard#Error()'))
+      eq('custom', eval('provider#clipboard#Executable()'))
+      eq('hello', eval("getreg('*')"))
+    end)
+
+    it('can return a list of lines instead of [lines, regtype]', function()
+      source([=[let g:dummy_clipboard = ['hello', 'v']
+              let g:clipboard = {
+              \  'name': 'custom',
+              \  'copy': { '*': {lines, regtype ->  0} },
+              \  'paste': { '*': {-> g:dummy_clipboard} },
+              \}]=])
+      eq('', eval('provider#clipboard#Error()'))
+      eq('custom', eval('provider#clipboard#Executable()'))
+      eq('hello\nv', eval("getreg('*')"))
+    end)
+  end)
 end)
 
 describe('clipboard', function()

--- a/test/functional/clipboard/clipboard_provider_spec.lua
+++ b/test/functional/clipboard/clipboard_provider_spec.lua
@@ -3,7 +3,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
-local feed_command, expect, eq, eval = helpers.feed_command, helpers.expect, helpers.eq, helpers.eval
+local feed_command, expect, eq, eval, source = helpers.feed_command, helpers.expect, helpers.eq, helpers.eval, helpers.source
 local command = helpers.command
 local meths = helpers.meths
 
@@ -146,6 +146,42 @@ describe('clipboard', function()
     })
     eq('clippy!', eval('provider#clipboard#Executable()'))
     eq('', eval('provider#clipboard#Error()'))
+  end)
+
+  it('valid g:clipboard using vimscript functions', function()
+    -- implementes a clipboard provider that places data
+    -- in g:dummy_clipboard.
+	-- The cache_enabled should be ignored - setting as 1 should have no consequence
+    source([[let g:clipboard = {
+            \  'name': 'custom',
+            \  'copy': {
+            \     '+': {lines, regtype -> extend(g:, {'dummy_clipboard_plus': [lines, regtype]}) },
+            \     '*': {lines, regtype -> extend(g:, {'dummy_clipboard_star': [lines, regtype]}) },
+            \   },
+            \  'paste': {
+            \     '+': {-> get(g:, 'dummy_clipboard_plus', [])},
+            \     '*': {-> get(g:, 'dummy_clipboard_star', [])},
+            \  },
+            \  'cache_enabled': 1,
+            \}]])
+
+    eq('', eval('provider#clipboard#Error()'))
+    eq('custom', eval('provider#clipboard#Executable()'))
+
+    eq('', eval("getreg('*')"))
+    eq('', eval("getreg('+')"))
+
+    command('call setreg("*", "star")')
+    command('call setreg("+", "plus")')
+    eq('star', eval("getreg('*')"))
+    eq('plus', eval("getreg('+')"))
+
+    command('call setreg("*", "star", "v")')
+	eq({{'star'}, 'v'}, eval("g:dummy_clipboard_star"))
+    command('call setreg("*", "star", "V")')
+	eq({{'star', ''}, 'V'}, eval("g:dummy_clipboard_star"))
+    command('call setreg("*", "star", "b")')
+	eq({{'star', ''}, 'b'}, eval("g:dummy_clipboard_star"))
   end)
 end)
 


### PR DESCRIPTION
Custom clipboard providers can be set using g:clipboard, where
g:clipboard['copy']['+'] was originally meant to be a string with
a command that sets the clipboard.

This commit enables the use of vimscript functions instead. The function
signatures is the same as the clipboard provider itself. A clipboard
provider is expected to store and return a list of lines (i.e. the text)
and a register type (as seen in setreg()).

The cache_enabled attributed is completely ignored if the 'copy'
attribute is set to be a function.

## Why

Primarily to enable integration with clipboards provided by an external UI. But I'm sure someone will find other uses for this.

Originally I tried doing this by overriding the provider in https://github.com/equalsraf/neovim-qt/pull/436 it worked partially (originally from [neovim-gtk](https://github.com/daa84/neovim-gtk/blob/master/runtime/plugin/nvim_gui_shim.vim#L7)) but you run into problems when you want to attach and reattach the UI, because you cannot override the provider again.

##  Reasons not to do this

- we should not expose the internals of the clipboard provider
- the clipboard provider lines go through systemlist() which converts NUL into NL (i think) I dont think this is documented as part of the clipboard, but custom providers would have to conform to this too.
- other approaches e.g. does this overlap with #4448?
