### PR TITLE
[RFC] Revert unused check from #9304

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -55,19 +55,9 @@ endfunction
 function! provider#clipboard#Executable() abort
   if exists('g:clipboard')
     if type({}) isnot# type(g:clipboard)
+          \ || type({}) isnot# type(get(g:clipboard, 'copy', v:null))
+          \ || type({}) isnot# type(get(g:clipboard, 'paste', v:null))
       let s:err = 'clipboard: invalid g:clipboard'
-      return ''
-    endif
-
-    if type(get(g:clipboard, 'copy', v:null)) isnot# v:t_dict
-        \ && type(get(g:clipboard, 'copy', v:null)) isnot# v:t_func
-      let s:err = "clipboard: invalid g:clipboard['copy']"
-      return ''
-    endif
-
-    if type(get(g:clipboard, 'paste', v:null)) isnot# v:t_dict
-        \ && type(get(g:clipboard, 'paste', v:null)) isnot# v:t_func
-      let s:err = "clipboard: invalid g:clipboard['paste']"
       return ''
     endif
 


### PR DESCRIPTION
PR #9304 added support for functions in clipboard providers. As part of
the PR I meant to move two checks in the provider code out of an if
statement into separate statements and adding additional checks for
g:clipboard attributes - as it turns out the code is wrong and it does
not implement additional checks while it adds two conditions that make
very little sense

    type(g:clipboard['copy']) #isnot# v:t_func

what would make sense would be something along the lines of

    type(g:clipboard['copy']['+']) #isnot# v:t_func

but might not be what we want either, so I'm reverting this.