### PR TITLE
provider/lang: expand() g:foo_host_prog

### DIFF
--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -49,7 +49,7 @@ endfunction
 
 function! provider#node#Detect() abort
   if exists('g:node_host_prog')
-    return g:node_host_prog
+    return expand(g:node_host_prog)
   endif
   if !s:is_minimum_version(v:null, 6, 0)
     return ''

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -24,13 +24,13 @@ endfunction
 function! provider#pythonx#Detect(major_ver) abort
   if a:major_ver == 2
     if exists('g:python_host_prog')
-      return [g:python_host_prog, '']
+      return [expand(g:python_host_prog), '']
     else
       let progs = ['python2', 'python2.7', 'python2.6', 'python']
     endif
   else
     if exists('g:python3_host_prog')
-      return [g:python3_host_prog, '']
+      return [expand(g:python3_host_prog), '']
     else
       let progs = ['python3', 'python3.7', 'python3.6', 'python3.5',
             \ 'python3.4', 'python3.3', 'python']

--- a/runtime/autoload/provider/ruby.vim
+++ b/runtime/autoload/provider/ruby.vim
@@ -45,7 +45,7 @@ endfunction
 
 function! s:detect()
   if exists("g:ruby_host_prog")
-    return g:ruby_host_prog
+    return expand(g:ruby_host_prog)
   elseif has('win32')
     return exepath('neovim-ruby-host.bat')
   else

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3379,9 +3379,7 @@ expand({expr} [, {nosuf} [, {list}]])				*expand()*
 
 		If {list} is given and it is |TRUE|, a List will be returned.
 		Otherwise the result is a String and when there are several
-		matches, they are separated by <NL> characters.  [Note: in
-		version 5.0 a space was used, which caused problems when a
-		file name contains a space]
+		matches, they are separated by <NL> characters.
 
 		If the expansion fails, the result is an empty string.	A name
 		for a non-existing file is not included, unless {expr} does
@@ -3442,7 +3440,7 @@ expand({expr} [, {nosuf} [, {list}]])				*expand()*
 		all "README" files in the current directory and below: >
 			:echo expand("**/README")
 <
-		Expand() can also be used to expand variables and environment
+		expand() can also be used to expand variables and environment
 		variables that are only known in a shell.  But this can be
 		slow, because a shell may be used to do the expansion.  See
 		|expr-env-expand|.


### PR DESCRIPTION
Before this commit, if user does this:

    let g:node_host_prog = '~/.nvm/versions/node/v11.3.0/bin/neovim-node-host'

the "~/" is not expanded to user's home directory.

`:help g:ruby_host_prog` suggests such a path, so technically we
already claimed to support this.

closes https://github.com/neovim/node-client/issues/102

---

Technically this could also trigger unwanted edge-cases if the path contains dollar sign, then expand() will attempt to resolve that to an environment variable. Oh well.