### PR TITLE
screen: add missing status redraw when <c-l> was used

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -669,8 +669,8 @@ static void win_update(win_T *wp)
 
   type = wp->w_redr_type;
 
-  if (type == NOT_VALID) {
-    wp->w_redr_status = TRUE;
+  if (type >= NOT_VALID) {
+    wp->w_redr_status = true;
     wp->w_lines_valid = 0;
   }
 

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -156,6 +156,82 @@ local function screen_tests(linegrid)
     end)
   end)
 
+  describe('statusline', function()
+    it('is redrawn after <c-l>', function()
+      command('set laststatus=2')
+      screen:expect([[
+        ^                                                     |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {1:[No Name]                                            }|
+                                                             |
+      ]])
+
+      feed('<c-l>')
+      screen:expect{grid=[[
+        ^                                                     |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {1:[No Name]                                            }|
+                                                             |
+      ]], reset=true}
+
+      command('split')
+      screen:expect([[
+        ^                                                     |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {1:[No Name]                                            }|
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {3:[No Name]                                            }|
+                                                             |
+      ]])
+
+      feed('<c-l>')
+      screen:expect{grid=[[
+        ^                                                     |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {1:[No Name]                                            }|
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {3:[No Name]                                            }|
+                                                             |
+      ]], reset=true}
+    end)
+  end)
+
   describe('window', function()
     describe('split', function()
       it('horizontal', function()


### PR DESCRIPTION
Fixes #9282