### PR TITLE
fix the wrong msg_col after calling execute (issue 6035/9250)

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8124,6 +8124,7 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   const int save_msg_silent = msg_silent;
   const int save_emsg_silent = emsg_silent;
+  const int save_msg_col = msg_col;
   const bool save_emsg_noredir = emsg_noredir;
   const bool save_redir_off = redir_off;
   garray_T *const save_capture_ga = capture_ga;
@@ -8132,6 +8133,7 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
+  bool is_silent = false;
   if (argvars[1].v_type != VAR_UNKNOWN) {
     char buf[NUMBUFLEN];
     const char *const s = tv_get_string_buf_chk(&argvars[1], buf);
@@ -8141,6 +8143,7 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     }
     if (strncmp(s, "silent", 6) == 0) {
       msg_silent++;
+      is_silent = true;
     }
     if (strcmp(s, "silent!") == 0) {
       emsg_silent = true;
@@ -8148,6 +8151,7 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     }
   } else {
     msg_silent++;
+    is_silent = true;
   }
 
   garray_T capture_local;
@@ -8172,6 +8176,9 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   emsg_silent = save_emsg_silent;
   emsg_noredir = save_emsg_noredir;
   redir_off = save_redir_off;
+  if (is_silent) {
+    msg_col = save_msg_col;
+  }
 
   ga_append(capture_ga, NUL);
   rettv->v_type = VAR_STRING;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1,4 +1,5 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
+
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
 /*
@@ -8158,6 +8159,8 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   ga_init(&capture_local, (int)sizeof(char), 80);
   capture_ga = &capture_local;
   redir_off = false;
+  const bool save_did_emsg = did_emsg;
+  did_emsg = false;
 
   if (argvars[0].v_type != VAR_LIST) {
     do_cmdline_cmd(tv_get_string(&argvars[0]));
@@ -8172,13 +8175,16 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
                DOCMD_NOWAIT|DOCMD_VERBOSE|DOCMD_REPEAT|DOCMD_KEYTYPED);
     tv_list_unref(list);
   }
+
+  if (is_silent && (emsg_silent || !did_emsg)) {
+    msg_col = save_msg_col;
+  }
+
+  did_emsg = did_emsg || save_did_emsg;
   msg_silent = save_msg_silent;
   emsg_silent = save_emsg_silent;
   emsg_noredir = save_emsg_noredir;
   redir_off = save_redir_off;
-  if (is_silent) {
-    msg_col = save_msg_col;
-  }
 
   ga_append(capture_ga, NUL);
   rettv->v_type = VAR_STRING;

--- a/test/functional/eval/execute_spec.lua
+++ b/test/functional/eval/execute_spec.lua
@@ -125,9 +125,141 @@ describe('execute()', function()
     feed('<CR>')
   end)
 
+  it('places cursor correctly #6035', function()
+    local screen = Screen.new(40, 5)
+    screen:attach()
+    source([=[
+      " test 1
+      function! Test1a()
+        echo 12345678
+        let x = execute('echo 1234567890', '')
+        echon '1234'
+      endfunction
+
+      function! Test1b()
+        echo 12345678
+        echo 1234567890
+        echon '1234'
+      endfunction
+
+      " test 2
+      function! Test2a()
+        echo 12345678
+        let x = execute('echo 1234567890', 'silent')
+        echon '1234'
+      endfunction
+
+      function! Test2b()
+        echo 12345678
+        silent echo 1234567890
+        echon '1234'
+      endfunction
+
+      " test 3
+      function! Test3a()
+        echo 12345678
+        let x = execute('echoerr 1234567890', 'silent!')
+        echon '1234'
+      endfunction
+
+      function! Test3b()
+        echo 12345678
+        silent! echoerr 1234567890
+        echon '1234'
+      endfunction
+
+      " test 4
+      function! Test4a()
+        echo 12345678
+        let x = execute('echoerr 1234567890', 'silent')
+        echon '1234'
+      endfunction
+
+      function! Test4b()
+        echo 12345678
+        silent echoerr 1234567890
+        echon '1234'
+      endfunction
+    ]=])
+
+    feed([[:call Test1a()<cr>]])
+    screen:expect([[
+                                              |
+                                              |
+      12345678                                |
+      12345678901234                          |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test1b()<cr>]])
+    screen:expect([[
+      12345678                                |
+      12345678901234                          |
+      12345678                                |
+      12345678901234                          |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test2a()<cr>]])
+    screen:expect([[
+      12345678901234                          |
+      12345678                                |
+      12345678901234                          |
+      123456781234                            |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test2b()<cr>]])
+    screen:expect([[
+      12345678                                |
+      12345678901234                          |
+      123456781234                            |
+      123456781234                            |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test3a()<cr>]])
+    screen:expect([[
+      12345678901234                          |
+      123456781234                            |
+      123456781234                            |
+      123456781234                            |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test3b()<cr>]])
+    screen:expect([[
+      123456781234                            |
+      123456781234                            |
+      123456781234                            |
+      123456781234                            |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test4a()<cr>]])
+    screen:expect([[
+      Error detected while processing function|
+       Test4a:                                |
+      line    2:                              |
+      123456781234                            |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test4b()<cr>]])
+    screen:expect([[
+      Error detected while processing function|
+       Test4b:                                |
+      line    2:                              |
+      12345678901234                          |
+      Press ENTER or type command to continue^ |
+    ]])
+
+
+  end)
+
   -- This deviates from vim behavior, but is consistent
   -- with how nvim currently displays the output.
-  it('does capture shell-command output', function()
+  it('captures shell-command output', function()
     local win_lf = iswin() and '\13' or ''
     eq('\n:!echo foo\r\n\nfoo'..win_lf..'\n', funcs.execute('!echo foo'))
   end)


### PR DESCRIPTION
addresses [6035](https://github.com/neovim/neovim/issues/6035) and [9250](https://github.com/neovim/neovim/issues/9250)