### PR TITLE
vim-patch:8.1.{563,564}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19253,7 +19253,7 @@ static void set_var(const char *name, const size_t name_len, typval_T *const tv,
         }
         return;
       } else if (v->di_tv.v_type != tv->v_type) {
-        internal_error("set_var()");
+        EMSG2(_("E963: setting %s to value with wrong type"), name);
       }
     }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19254,6 +19254,7 @@ static void set_var(const char *name, const size_t name_len, typval_T *const tv,
         return;
       } else if (v->di_tv.v_type != tv->v_type) {
         EMSG2(_("E963: setting %s to value with wrong type"), name);
+        return;
       }
     }
 

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -11,3 +11,13 @@ endfunction
 func Test_catch_return_with_error()
   call assert_equal(1, s:foo())
 endfunc
+
+func Test_E963()
+  " These commands used to cause an internal error prior to vim 8.1.0563
+  let v_e = v:errors
+  let v_o = v:oldfiles
+  call assert_fails("let v:errors=''", 'E963:')
+  call assert_equal(v_e, v:errors)
+  call assert_fails("let v:oldfiles=''", 'E963:')
+  call assert_equal(v_o, v:oldfiles)
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0563: setting v:errors to a string give confusing error**
Problem:    Setting v:errors to a string give confusing error. (Christian Brabandt)
Solution:   Change internal error into normal error message.
vim/vim@74ea88c

**vim-patch:8.1.0564: setting v:errors to wrong type still possible**
Problem:    Setting v:errors to wrong type still possible.
Solution:   Return after giving an error message. (Christian Brabandt)
vim/vim@88b53fd