### PR TITLE
CI/Travis: install gperf using package manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
                    -DBUSTED_OUTPUT_TYPE=nvim
                    -DDEPS_PREFIX=$DEPS_BUILD_DIR/usr
                    -DMIN_LOG_LEVEL=3"
-    - DEPS_CMAKE_FLAGS="-DDEPS_DOWNLOAD_DIR:PATH=$DEPS_DOWNLOAD_DIR"
+    - DEPS_CMAKE_FLAGS="-DDEPS_DOWNLOAD_DIR:PATH=$DEPS_DOWNLOAD_DIR -DUSE_BUNDLED_GPERF=OFF"
     # Additional CMake flags for 32-bit builds.
     - CMAKE_FLAGS_32BIT="-DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32
                          -DCMAKE_IGNORE_PATH=/lib:/usr/lib:/usr/local/lib
@@ -107,6 +107,7 @@ addons:
       - g++-multilib
       - gcc-multilib
       - gdb
+      - gperf
       - language-pack-tr
       - libc6-dev-i386
       - libtool-bin


### PR DESCRIPTION
Install gperf using package manager instead of building it from source.
When building/installing gperf from source, its install step requires
`texi2pdf` which randomly goes missing on Travis:

    cd doc; /usr/bin/make install
    make[1]: Entering directory '/home/travis/nvim-deps/build/src/gperf/doc'
    cd . && rm -f gperf.aux gperf.toc gperf.cp gperf.fn gperf.ky gperf.pg gperf.tp gperf.vr gperf.log gperf.cps
    cd . && texi2pdf gperf.texi
    /bin/sh: 1: texi2pdf: not found

It's nice to test the "bundled" deps on Travis, but that gets enough
exercise on Windows and macOS, which are the platforms that actually
need "bundled" gperf.