### PR TITLE
CI/Travis: test USE_BUNDLED=OFF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,8 @@ jobs:
     - os: linux
       env: >
         CI_TARGET=lint
-        DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED=OFF"
-      install: sudo -E apt-get -yq --no-install-suggests --no-install-recommends install gperf luajit libuv1-dev libluajit-5.1-dev libunibilium-dev libmsgpack-dev libtermkey-dev libvterm-dev libjemalloc-dev
+        DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED=OFF -DUSE_BUNDLED_MSGPACK=ON -DUSE_BUNDLED_LIBVTERM=ON"
+      install: sudo -E apt-get -yq --no-install-suggests --no-install-recommends install gperf luajit libuv1-dev libluajit-5.1-dev libunibilium-dev libtermkey-dev libjemalloc-dev
     - stage: Flaky builds
       os: linux
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,10 @@ jobs:
       compiler: gcc
       osx_image: xcode9.4  # macOS 10.13
     - os: linux
-      env: CI_TARGET=lint
+      env: >
+        CI_TARGET=lint
+        DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED=OFF"
+      install: sudo -E apt-get -yq --no-install-suggests --no-install-recommends install gperf luajit libuv1-dev libluajit-5.1-dev libunibilium-dev libmsgpack-dev libtermkey-dev libvterm-dev libjemalloc-dev
     - stage: Flaky builds
       os: linux
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,11 @@ jobs:
       env: >
         CI_TARGET=lint
         DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED=OFF -DUSE_BUNDLED_MSGPACK=ON -DUSE_BUNDLED_LIBVTERM=ON"
-      install: sudo -E apt-get -yq --no-install-suggests --no-install-recommends install gperf luajit libuv1-dev libluajit-5.1-dev libunibilium-dev libtermkey-dev libjemalloc-dev
+      install:
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install gperf luajit luarocks libuv1-dev libluajit-5.1-dev libunibilium-dev libtermkey-dev libjemalloc-dev
+        - sudo luarocks build mpack 1.0.7-0
+        - sudo luarocks build lpeg 1.0.1-1
+        - sudo luarocks build inspect 3.1.1-0
     - stage: Flaky builds
       os: linux
       compiler: gcc

--- a/ci/run_lint.sh
+++ b/ci/run_lint.sh
@@ -8,6 +8,13 @@ CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CI_DIR}/common/build.sh"
 source "${CI_DIR}/common/suite.sh"
 
+# Build using system packages.
+enter_suite 'build'
+run_test 'make nvim' build
+# build_make install
+run_test './build/bin/nvim --version' run
+exit_suite --continue
+
 enter_suite 'clint'
 
 run_test 'make clint-full' clint


### PR DESCRIPTION
Most of our CI jobs use USE_BUNDLED=ON (bundled dependencies, built from
source).  We also support USE_BUNDLED=OFF, but it was not checked
explicitly in CI.

Use the "lint" build to check this (bonus: it also saves time).