### PR TITLE
vim-patch:8.1.0570

### DIFF
--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -674,3 +674,20 @@ func Test_fold_last_line_with_pagedown()
   set fdm&
   enew!
 endfunc
+
+func Test_folds_marker_in_comment2()
+  new
+  call setline(1, ['Lorem ipsum dolor sit', 'Lorem ipsum dolor sit', 'Lorem ipsum dolor sit'])
+  setl fen fdm=marker
+  setl commentstring=<!--%s-->
+  setl comments=s:<!--,m:\ \ \ \ ,e:-->
+  norm! zf2j
+  setl nofen
+  :1y
+  call assert_equal(['Lorem ipsum dolor sit<!--{{{-->'], getreg(0,1,1))
+  :+2y
+  call assert_equal(['Lorem ipsum dolor sit<!--}}}-->'], getreg(0,1,1))
+
+  set foldmethod&
+  bwipe!
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0570: 'commentstring' not used when adding fold marker**

Problem:    'commentstring' not used when adding fold marker. (Maxim Kim)
Solution:   Only use empty 'comments' middle when leader is empty. (Christian
            Brabandt, closes vim/vim#3670)
https://github.com/vim/vim/commit/539328197c51c1586cbbb6b6be3db3c412249b49