### PR TITLE
vim-patch:8.1.{569,571}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8331,6 +8331,7 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   const bool save_emsg_noredir = emsg_noredir;
   const bool save_redir_off = redir_off;
   garray_T *const save_capture_ga = capture_ga;
+  const int save_msg_col = msg_col;
 
   if (check_secure()) {
     return;
@@ -8358,6 +8359,7 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   ga_init(&capture_local, (int)sizeof(char), 80);
   capture_ga = &capture_local;
   redir_off = false;
+  msg_col = 0;  // prevent leading spaces
 
   if (argvars[0].v_type != VAR_LIST) {
     do_cmdline_cmd(tv_get_string(&argvars[0]));
@@ -8376,6 +8378,9 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   emsg_silent = save_emsg_silent;
   emsg_noredir = save_emsg_noredir;
   redir_off = save_redir_off;
+  // "silent reg" or "silent echo x" leaves msg_col somewhere in the line.
+  // Put it back where it was, since nothing should have been written.
+  msg_col = save_msg_col;
 
   ga_append(capture_ga, NUL);
   rettv->v_type = VAR_STRING;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8332,6 +8332,7 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   const bool save_redir_off = redir_off;
   garray_T *const save_capture_ga = capture_ga;
   const int save_msg_col = msg_col;
+  bool echo_output = false;
 
   if (check_secure()) {
     return;
@@ -8343,6 +8344,9 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
     if (s == NULL) {
       return;
+    }
+    if (*s == NUL) {
+      echo_output = true;
     }
     if (strncmp(s, "silent", 6) == 0) {
       msg_silent++;
@@ -8359,7 +8363,9 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   ga_init(&capture_local, (int)sizeof(char), 80);
   capture_ga = &capture_local;
   redir_off = false;
-  msg_col = 0;  // prevent leading spaces
+  if (!echo_output) {
+    msg_col = 0;  // prevent leading spaces
+  }
 
   if (argvars[0].v_type != VAR_LIST) {
     do_cmdline_cmd(tv_get_string(&argvars[0]));
@@ -8379,8 +8385,15 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   emsg_noredir = save_emsg_noredir;
   redir_off = save_redir_off;
   // "silent reg" or "silent echo x" leaves msg_col somewhere in the line.
-  // Put it back where it was, since nothing should have been written.
-  msg_col = save_msg_col;
+  if (echo_output) {
+    // When not working silently: put it in column zero.  A following
+    // "echon" will overwrite the message, unavoidably.
+    msg_col = 0;
+  } else {
+    // When working silently: Put it back where it was, since nothing
+    // should have been written.
+    msg_col = save_msg_col;
+  }
 
   ga_append(capture_ga, NUL);
   rettv->v_type = VAR_STRING;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -656,10 +656,13 @@ static int command_line_execute(VimState *state, int key)
         redrawcmd();
         save_p_ls = -1;
         wild_menu_showing = 0;
-      } else {
+      // don't redraw statusline if WM_LIST is showing
+      } else if (wild_menu_showing != WM_LIST) {
         win_redraw_last_status(topframe);
         wild_menu_showing = 0;  // must be before redraw_statuslines #8385
         redraw_statuslines();
+      } else {
+        wild_menu_showing = 0;
       }
       KeyTyped = skt;
       if (ccline.input_fn) {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1806,8 +1806,13 @@ void msg_puts_attr_len(const char *const str, const ptrdiff_t len, int attr)
   // different, e.g. for Win32 console) or we just don't know where the
   // cursor is.
   if (msg_use_printf()) {
+    int saved_msg_col = msg_col;
     msg_puts_printf(str, len);
-  } else {
+    if (headless_mode) {
+      msg_col = saved_msg_col;
+    }
+  }
+  if (!msg_use_printf() || headless_mode) {
     msg_puts_display((const char_u *)str, len, attr, false);
   }
 }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1812,7 +1812,7 @@ void msg_puts_attr_len(const char *const str, const ptrdiff_t len, int attr)
       msg_col = saved_msg_col;
     }
   }
-  if (!msg_use_printf() || headless_mode) {
+  if (!msg_use_printf() || (headless_mode && default_grid.chars)) {
     msg_puts_display((const char_u *)str, len, attr, false);
   }
 }

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -16,6 +16,7 @@ set nohidden smarttab noautoindent noautoread complete-=i noruler noshowcmd
 set listchars=eol:$
 set fillchars=vert:\|,fold:-
 set shortmess-=F
+set laststatus=1
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
 

--- a/src/nvim/testdir/test_execute_func.vim
+++ b/src/nvim/testdir/test_execute_func.vim
@@ -53,3 +53,15 @@ func Test_execute_list()
   call assert_equal("", execute([]))
   call assert_equal("", execute(v:_null_list))
 endfunc
+
+func Test_execute_does_not_change_col()
+  echo ''
+  echon 'abcd'
+  let x = execute('silent echo 234343')
+  echon 'xyz'
+  let text = ''
+  for col in range(1, 7)
+    let text .= nr2char(screenchar(&lines, col))
+  endfor
+  call assert_equal('abcdxyz', text)
+endfunc

--- a/src/nvim/testdir/test_execute_func.vim
+++ b/src/nvim/testdir/test_execute_func.vim
@@ -65,3 +65,20 @@ func Test_execute_does_not_change_col()
   endfor
   call assert_equal('abcdxyz', text)
 endfunc
+
+func Test_execute_not_silent()
+  echo ''
+  echon 'abcd'
+  let x = execute('echon 234', '')
+  echo 'xyz'
+  let text1 = ''
+  for col in range(1, 8)
+    let text1 .= nr2char(screenchar(&lines - 1, col))
+  endfor
+  call assert_equal('abcd234 ', text1)
+  let text2 = ''
+  for col in range(1, 4)
+    let text2 .= nr2char(screenchar(&lines, col))
+  endfor
+  call assert_equal('xyz ', text2)
+endfunc

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1336,7 +1336,7 @@ describe('API', function()
       eq({id=2}, meths.create_buf(true, false))
       eq({id=3}, meths.create_buf(false, false))
       eq('  1 %a   "[No Name]"                    line 1\n'..
-         '  2      "[No Name]"                    line 0',
+         '  2  h   "[No Name]"                    line 0',
          meths.command_output("ls"))
       -- current buffer didn't change
       eq({id=1}, meths.get_current_buf())
@@ -1367,14 +1367,24 @@ describe('API', function()
       eq({id=1}, meths.get_current_buf())
     end)
 
+    it("doesn't cause BufEnter or BufWinEnter autocmds", function()
+      command("let g:fired = v:false")
+      command("au BufEnter,BufWinEnter * let g:fired = v:true")
+
+      eq({id=2}, meths.create_buf(true, false))
+      meths.buf_set_lines(2, 0, -1, true, {"test", "text"})
+
+      eq(false, eval('g:fired'))
+    end)
+
     it('|scratch-buffer|', function()
       eq({id=2}, meths.create_buf(false, true))
       eq({id=3}, meths.create_buf(true, true))
       eq({id=4}, meths.create_buf(true, true))
       local scratch_bufs = { 2, 3, 4 }
       eq('  1 %a   "[No Name]"                    line 1\n'..
-         '  3      "[Scratch]"                    line 0\n'..
-         '  4      "[Scratch]"                    line 0',
+         '  3  h   "[Scratch]"                    line 0\n'..
+         '  4  h   "[Scratch]"                    line 0',
          meths.command_output("ls"))
       -- current buffer didn't change
       eq({id=1}, meths.get_current_buf())

--- a/test/functional/eval/execute_spec.lua
+++ b/test/functional/eval/execute_spec.lua
@@ -125,9 +125,141 @@ describe('execute()', function()
     feed('<CR>')
   end)
 
+  it('places cursor correctly #6035', function()
+    local screen = Screen.new(40, 5)
+    screen:attach()
+    source([=[
+      " test 1
+      function! Test1a()
+        echo 12345678
+        let x = execute('echo 1234567890', '')
+        echon '1234'
+      endfunction
+
+      function! Test1b()
+        echo 12345678
+        echo 1234567890
+        echon '1234'
+      endfunction
+
+      " test 2
+      function! Test2a()
+        echo 12345678
+        let x = execute('echo 1234567890', 'silent')
+        echon '1234'
+      endfunction
+
+      function! Test2b()
+        echo 12345678
+        silent echo 1234567890
+        echon '1234'
+      endfunction
+
+      " test 3
+      function! Test3a()
+        echo 12345678
+        let x = execute('echoerr 1234567890', 'silent!')
+        echon '1234'
+      endfunction
+
+      function! Test3b()
+        echo 12345678
+        silent! echoerr 1234567890
+        echon '1234'
+      endfunction
+
+      " test 4
+      function! Test4a()
+        echo 12345678
+        let x = execute('echoerr 1234567890', 'silent')
+        echon '1234'
+      endfunction
+
+      function! Test4b()
+        echo 12345678
+        silent echoerr 1234567890
+        echon '1234'
+      endfunction
+    ]=])
+
+    feed([[:call Test1a()<cr>]])
+    screen:expect([[
+                                              |
+                                              |
+      12345678                                |
+      12345678901234                          |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test1b()<cr>]])
+    screen:expect([[
+      12345678                                |
+      12345678901234                          |
+      12345678                                |
+      12345678901234                          |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test2a()<cr>]])
+    screen:expect([[
+      12345678901234                          |
+      12345678                                |
+      12345678901234                          |
+      123456781234                            |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test2b()<cr>]])
+    screen:expect([[
+      12345678                                |
+      12345678901234                          |
+      123456781234                            |
+      123456781234                            |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test3a()<cr>]])
+    screen:expect([[
+      12345678901234                          |
+      123456781234                            |
+      123456781234                            |
+      123456781234                            |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test3b()<cr>]])
+    screen:expect([[
+      123456781234                            |
+      123456781234                            |
+      123456781234                            |
+      123456781234                            |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test4a()<cr>]])
+    screen:expect([[
+      Error detected while processing function|
+       Test4a:                                |
+      line    2:                              |
+      123456781234                            |
+      Press ENTER or type command to continue^ |
+    ]])
+
+    feed([[:call Test4b()<cr>]])
+    screen:expect([[
+      Error detected while processing function|
+       Test4b:                                |
+      line    2:                              |
+      12345678901234                          |
+      Press ENTER or type command to continue^ |
+    ]])
+
+
+  end)
+
   -- This deviates from vim behavior, but is consistent
   -- with how nvim currently displays the output.
-  it('does capture shell-command output', function()
+  it('captures shell-command output', function()
     local win_lf = iswin() and '\13' or ''
     eq('\n:!echo foo\r\n\nfoo'..win_lf..'\n', funcs.execute('!echo foo'))
   end)

--- a/test/functional/eval/execute_spec.lua
+++ b/test/functional/eval/execute_spec.lua
@@ -114,7 +114,7 @@ describe('execute()', function()
       {1:~                                                                     }|
       {1:~                                                                     }|
       {2:                                                                      }|
-      :echo execute("hi ErrorMsg")                                          |
+                                                                            |
       ErrorMsg       xxx ctermfg=15 ctermbg=1 guifg=White guibg=Red         |
       {3:Press ENTER or type command to continue}^                               |
     ]], {
@@ -188,7 +188,7 @@ describe('execute()', function()
       ~                                       |
       ~                                       |
       ~                                       |
-      1234abcdefABCD                          |
+      ABCD                                    |
     ]])
 
     feed([[:call Test2()<cr>]])
@@ -237,11 +237,11 @@ describe('execute()', function()
 
     feed([[:call Test6()<cr>]])
     screen:expect([[
-      1234                                    |
+                                              |
       Error detected while processing function|
        Test6:                                 |
       line    2:                              |
-      E121: Undefined variable: undefinedABCD |
+      E121ABCD                                |
       Press ENTER or type command to continue^ |
     ]])
 
@@ -250,8 +250,8 @@ describe('execute()', function()
       Error detected while processing function|
        Test6:                                 |
       line    2:                              |
-      E121: Undefined variable: undefinedABCD |
-      abcdefABCD                              |
+      E121ABCD                                |
+      ABCD                                    |
       Press ENTER or type command to continue^ |
     ]])
   end)

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -705,11 +705,8 @@ describe('ui/ext_messages', function()
   end)
 
   it('wildmode=list', function()
-    local default_attr = screen:get_default_attr_ids()
-    screen:detach()
-    screen = Screen.new(25, 7)
-    screen:attach({rgb=true, ext_messages=true})
-    screen:set_default_attr_ids(default_attr)
+    screen:try_resize(25, 7)
+    screen:set_option('ext_popupmenu', false)
 
     command('set wildmenu wildmode=list')
     feed(':set wildm<tab>')

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -15,9 +15,6 @@ describe("'wildmenu'", function()
     screen = Screen.new(25, 5)
     screen:attach()
   end)
-  after_each(function()
-    screen:detach()
-  end)
 
   -- expect the screen stayed unchanged some time after first seen success
   local function expect_stay_unchanged(args)
@@ -170,9 +167,7 @@ describe("'wildmenu'", function()
 
   it('wildmode=list,full and display+=msgsep interaction #10092', function()
     -- Need more than 5 rows, else tabline is covered and will be redrawn.
-    screen:detach()
-    screen = Screen.new(25, 7)
-    screen:attach()
+    screen:try_resize(25, 7)
 
     command('set display+=msgsep')
     command('set wildmenu wildmode=list,full')
@@ -211,9 +206,7 @@ describe("'wildmenu'", function()
 
   it('wildmode=list,full and display-=msgsep interaction', function()
     -- Need more than 5 rows, else tabline is covered and will be redrawn.
-    screen:detach()
-    screen = Screen.new(25, 7)
-    screen:attach()
+    screen:try_resize(25, 7)
 
     command('set display-=msgsep')
     command('set wildmenu wildmode=list,full')
@@ -250,6 +243,8 @@ describe("'wildmenu'", function()
   end)
 
   it('multiple <C-D> renders correctly', function()
+    screen:try_resize(25, 7)
+
     command('set laststatus=2')
     command('set display+=msgsep')
     feed(':set wildm')
@@ -358,10 +353,6 @@ describe('ui/ext_wildmenu', function()
     clear()
     screen = Screen.new(25, 5)
     screen:attach({rgb=true, ext_wildmenu=true})
-  end)
-
-  after_each(function()
-    screen:detach()
   end)
 
   it('works with :sign <tab>', function()

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -248,6 +248,42 @@ describe("'wildmenu'", function()
                                |
     ]])
   end)
+
+  it('multiple <C-D> renders correctly', function()
+    command('set laststatus=2')
+    command('set display+=msgsep')
+    feed(':set wildm')
+    feed('<c-d>')
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+                               |
+      :set wildm               |
+      wildmenu  wildmode       |
+      :set wildm^               |
+    ]])
+    feed('<c-d>')
+    screen:expect([[
+                               |
+                               |
+      :set wildm               |
+      wildmenu  wildmode       |
+      :set wildm               |
+      wildmenu  wildmode       |
+      :set wildm^               |
+    ]])
+    feed('<Esc>')
+    screen:expect([[
+      ^                         |
+      ~                        |
+      ~                        |
+      ~                        |
+      ~                        |
+      [No Name]                |
+                               |
+    ]])
+  end)
 end)
 
 describe('command line completion', function()


### PR DESCRIPTION
closes #6035

**vim-patch:8.1.0569: execute() always resets display column to zero**

Problem:    Execute() always resets display column to zero. (Sha Liu)
Solution:   Don't reset it to zero, restore the previous value. (closes vim/vim#3669)
vim/vim@10ccaa1

**vim-patch:8.1.0571: non-silent execute() resets display column to zero**

Problem:    Non-silent execute() resets display column to zero.
Solution:   Keep the display column as-is.
vim/vim@446e7a3