### PR TITLE
vim-patch:8.1.0574

### DIFF
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1099,7 +1099,6 @@ int get_last_leader_offset(char_u *line, char_u **flags)
     found_one = FALSE;
     for (list = curbuf->b_p_com; *list; ) {
       char_u *flags_save = list;
-      bool is_only_whitespace = false;
 
       /*
        * Get one option part into part_buf[].  Advance list to next one.
@@ -1126,9 +1125,6 @@ int get_last_leader_offset(char_u *line, char_u **flags)
         while (ascii_iswhite(*string)) {
           string++;
         }
-        if (*string == NUL) {
-          is_only_whitespace = true;
-        }
       }
       for (j = 0; string[j] != NUL && string[j] == line[i + j]; ++j)
         /* do nothing */;
@@ -1144,10 +1140,12 @@ int get_last_leader_offset(char_u *line, char_u **flags)
         continue;
       }
 
-      // For a middlepart comment that is only white space, only consider
-      // it to match if everything before the current position in the
-      // line is also whitespace.
-      if (is_only_whitespace && vim_strchr(part_buf, COM_MIDDLE) != NULL) {
+      if (vim_strchr(part_buf, COM_MIDDLE) != NULL) {
+        // For a middlepart comment, only consider it to match if
+        // everything before the current position in the line is
+        // whitespace.  Otherwise we would think we are inside a
+        // comment if the middle part appears somewhere in the middle
+        // of the line.  E.g. for C the "*" appears often.
         for (j = 0; ascii_iswhite(line[j]) && j <= i; j++) {
         }
         if (j < i) {

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -514,6 +514,35 @@ func Test_fold_marker()
   enew!
 endfunc
 
+" test create fold markers with C filetype
+func Test_fold_create_marker_in_C()
+  enew!
+  set fdm=marker fdl=9
+  set filetype=c
+
+  let content = [
+	\ '/*',
+	\ ' * comment',
+	\ ' * ',
+	\ ' *',
+	\ ' */',
+	\ 'int f(int* p) {',
+	\ '    *p = 3;',
+	\ '    return 0;',
+	\ '}'
+	\]
+  for c in range(len(content) - 1)
+    bw!
+    call append(0, content)
+    call cursor(c + 1, 1)
+    norm! zfG
+    call assert_equal(content[c] . (c < 4 ? '{{{' : '/*{{{*/'), getline(c + 1))
+  endfor
+
+  set fdm& fdl&
+  enew!
+endfunc
+
 " test folding with indent
 func Test_fold_indent()
   enew!


### PR DESCRIPTION
**vim-patch:8.1.0574: 'commentstring' not used when adding fold marker in C**

Problem:    'commentstring' not used when adding fold marker in C.
Solution:   Require white space before middle comment part. (mostly by
            Hirohito Higashi)
https://github.com/vim/vim/commit/4af7259b2b35e85c590d54908fcd248d2c733be8