### PR TITLE
[RFC] provider: improve error message

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3828,7 +3828,12 @@ static void script_host_execute(char *name, exarg_T *eap)
     // current range
     tv_list_append_number(args, (int)eap->line1);
     tv_list_append_number(args, (int)eap->line2);
-    (void)eval_call_provider(name, "execute", args);
+
+    if (!eval_has_provider(name)) {
+      emsgf("No \"%s\" provider found. Run \":checkhealth provider\"", name);
+    } else {
+      (void)eval_call_provider(name, "execute", args);
+    }
   }
 }
 


### PR DESCRIPTION
Executing `:python`, and similar commands that rely on `eval_call_provider()`,
while the accompanying provider it not available, leads to this error message:

    E117: Unknown function: provider#python#Call

This doesn't say much to a user. Since we introduced `:checkhealth` for this
very reason, we now point to it for further diagnosis.

Fixes #3577