### PR TITLE
[RDY] macOS: infer primary language if $LANG is empty

### DIFF
--- a/src/nvim/os/lang.c
+++ b/src/nvim/os/lang.c
@@ -17,14 +17,31 @@ void lang_init(void)
 {
 #ifdef __APPLE__
   if (os_getenv("LANG") == NULL) {
-    CFLocaleRef cf_locale = CFLocaleCopyCurrent();
-    CFTypeRef cf_lang_region = CFLocaleGetValue(cf_locale,
-                                                kCFLocaleIdentifier);
-    CFRetain(cf_lang_region);
-    CFRelease(cf_locale);
+    const char *lang_region = NULL;
+    CFTypeRef cf_lang_region = NULL;
 
-    const char *lang_region = CFStringGetCStringPtr(cf_lang_region,
-                                                    kCFStringEncodingUTF8);
+    CFLocaleRef cf_locale = CFLocaleCopyCurrent();
+    if (cf_locale) {
+      cf_lang_region = CFLocaleGetValue(cf_locale, kCFLocaleIdentifier);
+      CFRetain(cf_lang_region);
+      lang_region = CFStringGetCStringPtr(cf_lang_region,
+                                          kCFStringEncodingUTF8);
+      CFRelease(cf_locale);
+    } else {
+      // Use the primary language defined in Preferences -> Language & Region
+      CFArrayRef cf_langs = CFLocaleCopyPreferredLanguages();
+      if (cf_langs && CFArrayGetCount(cf_langs) > 0) {
+        cf_lang_region = CFArrayGetValueAtIndex(cf_langs, 0);
+        CFRetain(cf_lang_region);
+        CFRelease(cf_langs);
+        lang_region = CFStringGetCStringPtr(cf_lang_region,
+                                            kCFStringEncodingUTF8);
+      } else {
+        ELOG("$LANG is empty and your primary language cannot be inferred.");
+        return;
+      }
+    }
+
     if (lang_region) {
       os_setenv("LANG", lang_region, true);
     } else {


### PR DESCRIPTION
For reference read: https://github.com/neovim/neovim/issues/9134

It's unsure (to me at least) where `CFLocaleCopyCurrent()` is getting its value from, but according to reports on the internet it's not from the macOS preferences.

The macOS preferences have a section called _Language & Region_. There is always at least one language defined, the _primary language_. So, assuming that `CFLocaleCopyPreferredLanguages()` never fails, the first `lang_region` returned by it should be the primary language. In my case it returns `en-DE` (English language, German region).

Use the primary language in case `CFLocaleCopyCurrent()` returned NULL.

What do you think about this approach?