### PR TITLE
provider: make :ruby provider check use same code path as :python

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10802,17 +10802,6 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     n = true;
   }
 
-  if (STRICMP(name, "ruby") == 0 && n == true) {
-    char *rubyhost = call_func_retstr("provider#ruby#Detect", 0, NULL, true);
-    if (rubyhost) {
-      if (*rubyhost == NUL) {
-        // Invalid rubyhost executable. Gem is probably not installed.
-        n = false;
-      }
-      xfree(rubyhost);
-    }
-  }
-
   rettv->vval.v_number = n;
 }
 
@@ -22770,7 +22759,18 @@ bool eval_has_provider(const char *name)
     CHECK_PROVIDER(python);
     return has_python;
   } else if (strequal(name, "ruby")) {
+    bool need_check_ruby = (has_ruby == -1);
     CHECK_PROVIDER(ruby);
+    if (need_check_ruby && has_ruby == 1) {
+      char *rubyhost = call_func_retstr("provider#ruby#Detect", 0, NULL, true);
+      if (rubyhost) {
+        if (*rubyhost == NUL) {
+          // Invalid rubyhost executable. Gem is probably not installed.
+          has_ruby = 0;
+        }
+        xfree(rubyhost);
+      }
+    }
     return has_ruby;
   }
 

--- a/test/functional/provider/ruby_spec.lua
+++ b/test/functional/provider/ruby_spec.lua
@@ -6,6 +6,7 @@ local curbufmeths = helpers.curbufmeths
 local eq = helpers.eq
 local eval = helpers.eval
 local expect = helpers.expect
+local expect_err = helpers.expect_err
 local feed = helpers.feed
 local feed_command = helpers.feed_command
 local funcs = helpers.funcs
@@ -17,6 +18,10 @@ local write_file = helpers.write_file
 do
   clear()
   if missing_provider('ruby') then
+    it(':ruby reports E319 if provider is missing', function()
+      expect_err([[Vim%(ruby%):E319: No "ruby" provider found.*]],
+      command, 'ruby puts "foo"')
+    end)
     pending("Missing neovim RubyGem.", function() end)
     return
   end


### PR DESCRIPTION
Change the macro to return the cached has_<provider> variables right away. This
way we can easily put code behind it that is only run once for initialization.

Prior to this change, the provider check for ruby was special-cased and now it
returns E319, like :python etc.

References #9354

cc @justinmk 