### PR TITLE
os/lang: use the correct LC_NUMERIC also for OS X

### DIFF
--- a/src/nvim/os/lang.c
+++ b/src/nvim/os/lang.c
@@ -54,6 +54,11 @@ void lang_init(void)
     CFRelease(cf_lang_region);
 # ifdef HAVE_LOCALE_H
     setlocale(LC_ALL, "");
+
+#  ifdef LC_NUMERIC
+    // Make sure strtod() uses a decimal point, not a comma.
+    setlocale(LC_NUMERIC, "C");
+#  endif
 # endif
   }
 #endif

--- a/test/functional/viml/lang_spec.lua
+++ b/test/functional/viml/lang_spec.lua
@@ -18,4 +18,13 @@ describe('viml', function()
     ]])
     eq(nil, string.find(eval('v:errmsg'), '^E129'))
   end)
+
+  it('str2float is not affected by locale', function()
+    if exc_exec('lang ctype sv_SE.UTF-8') ~= 0 then
+      pending("Locale sv_SE.UTF-8 not supported")
+      return
+    end
+    clear{env={LANG="", LC_NUMERIC="sv_SE.UTF-8"}}
+    eq(2.2, eval('str2float("2.2")'))
+  end)
 end)


### PR DESCRIPTION
might fix #9340.

NB: this is the cargo-cult solution, I don't know why OS X needs two `setlocale(LC_ALL, "")` calls or if it could be eliminated by reorganizing the code. But at least it hopefully fixes the issue.