### PR TITLE
vim-patch:8.1.{585,588}

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5685,6 +5685,14 @@ void ex_sign(exarg_T *eap)
             int len;
 
             arg += 5;
+            for (s = arg; s + 1 < p; s++) {
+              if (*s == '\\') {
+                // Remove a backslash, so that it is possible
+                // to use a space.
+                STRMOVE(s, s + 1);
+                p--;
+              }
+            }
 
             // Count cells and check for non-printable chars
             cells = 0;

--- a/src/nvim/testdir/test_signs.vim
+++ b/src/nvim/testdir/test_signs.vim
@@ -104,6 +104,33 @@ func Test_sign()
   exe 'sign jump 43 file=' . fn
   call assert_equal('B', getline('.'))
 
+  " can't define a sign with a non-printable character as text
+  call assert_fails("sign define Sign4 text=\e linehl=Comment", 'E239:')
+  call assert_fails("sign define Sign4 text=a\e linehl=Comment", 'E239:')
+  call assert_fails("sign define Sign4 text=\ea linehl=Comment", 'E239:')
+
+  " Only 1 or 2 character text is allowed
+  call assert_fails("sign define Sign4 text=abc linehl=Comment", 'E239:')
+  call assert_fails("sign define Sign4 text= linehl=Comment", 'E239:')
+  call assert_fails("sign define Sign4 text=\ ab  linehl=Comment", 'E239:')
+
+  " define sign with whitespace
+  sign define Sign4 text=\ X linehl=Comment
+  sign undefine Sign4
+  sign define Sign4 linehl=Comment text=\ X
+  sign undefine Sign4
+
+  sign define Sign5 text=X\  linehl=Comment
+  sign undefine Sign5
+  sign define Sign5 linehl=Comment text=X\ 
+  sign undefine Sign5
+
+  " define sign with backslash
+  sign define Sign4 text=\\\\ linehl=Comment
+  sign undefine Sign4
+  sign define Sign4 text=\\ linehl=Comment
+  sign undefine Sign4
+
   " After undefining the sign, we should no longer be able to place it.
   sign undefine Sign1
   sign undefine Sign2

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -373,7 +373,7 @@ funct Test_undofile()
   let cwd = getcwd()
   if has('win32')
     " Replace windows drive such as C:... into C%...
-    let cwd = substitute(cwd, '^\([A-Z]\):', '\1%', 'g')
+    let cwd = substitute(cwd, '^\([a-zA-Z]\):', '\1%', 'g')
   endif
   let pathsep = has('win32') ? '\' : '/'
   let cwd = substitute(cwd . pathsep . 'Xundofoo', pathsep, '%', 'g')


### PR DESCRIPTION
**vim-patch:8.1.0585: undo test may fail on MS-Windows**

Problem:    Undo test may fail on MS-Windows.
Solution:   Also handle lower case drive letters.
vim/vim@56242f2

**vim-patch:8.1.0588: cannot define a sign with space in the text**

Problem:    Cannot define a sign with space in the text.
Solution:   Allow for escaping characters. (Ben Jackson, closes vim/vim#2967)
vim/vim@06b056e