### PR TITLE
vim-patch:8.1.0627

### DIFF
--- a/src/nvim/testdir/test_python2.vim
+++ b/src/nvim/testdir/test_python2.vim
@@ -25,3 +25,30 @@ func Test_pydo()
     bwipe!
   endif
 endfunc
+
+func Test_vim_function()
+  " Check creating vim.Function object
+  py import vim
+
+  func s:foo()
+    return matchstr(expand('<sfile>'), '<SNR>\zs\d\+_foo$')
+  endfunc
+  let name = '<SNR>' . s:foo()
+
+  try
+    py f = vim.bindeval('function("s:foo")')
+    call assert_equal(name, pyeval('f.name'))
+  catch
+    call assert_false(v:exception)
+  endtry
+
+  try
+    py f = vim.Function('\x80\xfdR' + vim.eval('s:foo()'))
+    call assert_equal(name, pyeval('f.name'))
+  catch
+    call assert_false(v:exception)
+  endtry
+
+  py del f
+  delfunc s:foo
+endfunc

--- a/src/nvim/testdir/test_python3.vim
+++ b/src/nvim/testdir/test_python3.vim
@@ -25,3 +25,30 @@ func Test_py3do()
     bwipe!
   endif
 endfunc
+
+func Test_vim_function()
+  " Check creating vim.Function object
+  py3 import vim
+
+  func s:foo()
+    return matchstr(expand('<sfile>'), '<SNR>\zs\d\+_foo$')
+  endfunc
+  let name = '<SNR>' . s:foo()
+
+  try
+    py3 f = vim.bindeval('function("s:foo")')
+    call assert_equal(name, py3eval('f.name'))
+  catch
+    call assert_false(v:exception)
+  endtry
+
+  try
+    py3 f = vim.Function(b'\x80\xfdR' + vim.eval('s:foo()').encode())
+    call assert_equal(name, py3eval('f.name'))
+  catch
+    call assert_false(v:exception)
+  endtry
+
+  py3 del f
+  delfunc s:foo
+endfunc


### PR DESCRIPTION
vim-patch:8.1.0627: Python cannot handle function name of script-local function

Problem:    Python cannot handle function name of script-local function.
Solution:   Use <SNR> instead of the special byte code. (Ozaki Kiichi, closes
            vim/vim#3681)
https://github.com/vim/vim/commit/9123c0b31a283f460ed2b6af95080120cf528118