### PR TITLE
make vim_snprintf handle %d correctly again, fix ":sign place" output

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -999,7 +999,10 @@ int vim_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap,
           } else if (fmt_spec == 'd') {
             // signed
             switch (length_modifier) {
-              case '\0':
+              case '\0': {
+                arg = (int)(tvs ? tv_nr(tvs, &arg_idx) : va_arg(ap, int));
+                break;
+              }
               case 'h': {
                 // char and short arguments are passed as int16_t
                 arg = (int16_t)(tvs ? tv_nr(tvs, &arg_idx) : va_arg(ap, int));
@@ -1031,11 +1034,16 @@ int vim_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap,
           } else {
             // unsigned
             switch (length_modifier) {
-              case '\0':
+              case '\0': {
+                uarg = (unsigned int)(tvs
+                                      ? tv_nr(tvs, &arg_idx)
+                                      : va_arg(ap, unsigned int));
+                break;
+              }
               case 'h': {
                 uarg = (uint16_t)(tvs
                                   ? tv_nr(tvs, &arg_idx)
-                                  : va_arg(ap, unsigned));
+                                  : va_arg(ap, unsigned int));
                 break;
               }
               case 'l': {

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -20,6 +20,9 @@ describe('Signs', function()
       [6] = {foreground = Screen.colors.Brown},
       [7] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey},
       [8] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+      [9] = {bold = true, foreground = Screen.colors.Magenta},
+      [10] = {foreground = Screen.colors.Blue1},
+      [11] = {bold = true, foreground = Screen.colors.SeaGreen4},
     } )
   end)
 
@@ -99,6 +102,46 @@ describe('Signs', function()
         {2:  }{6:  2 }{8:b                                              }|
         {2:  }{7:  3 }c                                              |
         {1:>>}{7:  4 }{8:^                                               }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+                                                             |
+      ]])
+    end)
+
+    it('can have 32bit sign IDs', function()
+      command('sign define piet text=>> texthl=Search')
+      command('sign place 100000 line=1 name=piet buffer=1')
+      feed(':sign place<cr>')
+      screen:expect([[
+        {1:>>}                                                   |
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {4:                                                     }|
+        :sign place                                          |
+        {9:--- Signs ---}                                        |
+        {10:Signs for [NULL]:}                                    |
+            line=1  id=100000  name=piet                     |
+                                                             |
+        {11:Press ENTER or type command to continue}^              |
+      ]])
+
+      feed('<cr>')
+      screen:expect([[
+        {1:>>}^                                                   |
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
+        {2:  }{0:~                                                  }|
         {2:  }{0:~                                                  }|
         {2:  }{0:~                                                  }|
         {2:  }{0:~                                                  }|


### PR DESCRIPTION
This was broken in #9369 (4680ca2), where `%d` was changed to be `int16_t`

should fix #9388, as ALE uses `redir ... execute 'sign place'` to read signs back in.