### PR TITLE
TUI: enter/exit alternate screen with "title stacking"

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1573,9 +1573,9 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     unibi_set_if_empty(ut, unibi_exit_italics_mode, "\x1b[23m");
     unibi_set_if_empty(ut, unibi_to_status_line, "\x1b]2");
     unibi_set_if_empty(ut, unibi_from_status_line, "\x07");
-    // 2017-04 terminfo.src has older control sequences.
-    unibi_set_str(ut, unibi_enter_ca_mode, "\x1b[?1049h");
-    unibi_set_str(ut, unibi_exit_ca_mode, "\x1b[?1049l");
+    // Enter/exit alternate screen with "title stacking". #4063
+    unibi_set_str(ut, unibi_enter_ca_mode, "\x1b[?1049h\x1b[22;0;0t");
+    unibi_set_str(ut, unibi_exit_ca_mode, "\x1b[?1049l\x1b[23;0;0t");
   } else if (screen) {
     // per the screen manual; 2017-04 terminfo.src lacks these.
     unibi_set_if_empty(ut, unibi_to_status_line, "\x1b_");
@@ -1595,9 +1595,9 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
   } else if (putty) {
     // No bugs in the vanilla terminfo for our purposes.
   } else if (iterm) {
-    // 2017-04 terminfo.src has older control sequences.
-    unibi_set_str(ut, unibi_enter_ca_mode, "\x1b[?1049h");
-    unibi_set_str(ut, unibi_exit_ca_mode, "\x1b[?1049l");
+    // Enter/exit alternate screen with "title stacking". #4063
+    unibi_set_str(ut, unibi_enter_ca_mode, "\x1b[?1049h\x1b[22;0;0t");
+    unibi_set_str(ut, unibi_exit_ca_mode, "\x1b[?1049l\x1b[23;0;0t");
     // 2017-04 terminfo.src lacks these.
     unibi_set_if_empty(ut, unibi_set_tb_margin, "\x1b[%i%p1%d;%p2%dr");
     unibi_set_if_empty(ut, unibi_orig_pair, "\x1b[39;49m");


### PR DESCRIPTION
**Update:** see #9408.

---

Works in iTerm2 and xterm.

- patch_terminfo_bugs(): Add title-stacking sequences (\e[22t and
  \e[23t) to the overrides for iTerm2 and xterm.
- Note: the builtins (terminfo_defs.h) for `iterm_256colour_terminfo`
  and `xterm_256colour_terminfo` already include the sequences.

Test case (title should be "foo" after the final :q):

    TERM=iterm2 nvim -u NONE +'set title titleold=foo'
    :q
    TERM=iterm2 nvim -u NONE +'set title titlestring=zub'
    :q

**Forcing TERM=iterm2** is necessary because  terminfo on my system is outdated:

```
$ infocmp xterm-256color|grep smcup
	sgr0=\E(B\E[m, smacs=\E(0, smam=\E[?7h, smcup=\E[?1049h,
```

closes #4063