### PR TITLE
[RFC] vim-patch:8.0.1469,8.0.1734,8.1.0353,8.1.0354

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2683,10 +2683,24 @@ static int APP_BOTH;
 
 static void add_pack_plugin(char_u *fname, void *cookie)
 {
-  if (cookie != &APP_LOAD && strstr((char *)p_rtp, (char *)fname) == NULL) {
-    // directory is not yet in 'runtimepath', add it
-    if (add_pack_dir_to_rtp(fname) == FAIL) {
-      return;
+  if (cookie != &APP_LOAD) {
+    char *buf = xmalloc(MAXPATHL);
+    bool found = false;
+
+    const char *p = (const char *)p_rtp;
+    while (*p != NUL) {
+      copy_option_part((char_u **)&p, (char_u *)buf, MAXPATHL, ",");
+      if (path_fnamecmp(buf, (char *)fname) == 0) {
+        found = true;
+        break;
+      }
+    }
+    xfree(buf);
+    if (!found) {
+      // directory is not yet in 'runtimepath', add it
+      if (add_pack_dir_to_rtp(fname) == FAIL) {
+        return;
+      }
     }
   }
 

--- a/test/functional/legacy/packadd_spec.lua
+++ b/test/functional/legacy/packadd_spec.lua
@@ -57,6 +57,15 @@ describe('packadd', function()
         call assert_match(Escape(s:plugdir) . '\($\|,\)', &rtp)
         call assert_match(Escape(expand(s:plugdir . '/after$')), &rtp)
 
+        " NOTE: '/.../opt/myte' forwardly matches with '/.../opt/mytest'
+        call mkdir(fnamemodify(s:plugdir, ':h') . '/myte', 'p')
+        let rtp = &rtp
+        packadd myte
+
+        " Check the path of 'myte' is added
+        call assert_true(len(&rtp) > len(rtp))
+        call assert_match(Escape(s:plugdir) . '\($\|,\)', &rtp)
+
         " Check exception
         call assert_fails("packadd directorynotfound", 'E919:')
         call assert_fails("packadd", 'E471:')

--- a/test/functional/legacy/packadd_spec.lua
+++ b/test/functional/legacy/packadd_spec.lua
@@ -14,6 +14,10 @@ describe('packadd', function()
     clear()
 
     source([=[
+      func Escape(s)
+        return escape(a:s, '\~')
+      endfunc
+
       func SetUp()
         let s:topdir = expand(getcwd() . '/Xdir')
         exe 'set packpath=' . s:topdir
@@ -50,8 +54,8 @@ describe('packadd', function()
         call assert_equal(77, g:plugin_also_works)
         call assert_true(17, g:ftdetect_works)
         call assert_true(len(&rtp) > len(rtp))
-        call assert_true(&rtp =~ (escape(s:plugdir, '\') . '\($\|,\)'))
-        call assert_true(&rtp =~ escape(expand(s:plugdir . '/after$'), '\'))
+        call assert_match(Escape(s:plugdir) . '\($\|,\)', &rtp)
+        call assert_match(Escape(expand(s:plugdir . '/after$')), &rtp)
 
         " Check exception
         call assert_fails("packadd directorynotfound", 'E919:')
@@ -73,7 +77,7 @@ describe('packadd', function()
 
         call assert_equal(24, g:plugin_works)
         call assert_true(len(&rtp) > len(rtp))
-        call assert_true(&rtp =~ (escape(plugdir, '\') . '\($\|,\)'))
+        call assert_match(Escape(plugdir) . '\($\|,\)', &rtp)
       endfunc
 
       func Test_packadd_noload()
@@ -90,7 +94,7 @@ describe('packadd', function()
         packadd! mytest
 
         call assert_true(len(&rtp) > len(rtp))
-        call assert_true(&rtp =~ (escape(s:plugdir, '\') . '\($\|,\)'))
+        call assert_match(Escape(s:plugdir) . '\($\|,\)', &rtp)
         call assert_equal(0, g:plugin_works)
 
         " check the path is not added twice
@@ -122,7 +126,7 @@ describe('packadd', function()
         packadd mytest
 
         " Must have been inserted in the middle, not at the end
-        call assert_true(&rtp =~ escape(expand('/pack/mine/opt/mytest').',', '\'))
+        call assert_match(Escape(expand('/pack/mine/opt/mytest').','), &rtp)
         call assert_equal(44, g:plugin_works)
 
         " No change when doing it again.
@@ -133,6 +137,48 @@ describe('packadd', function()
         set rtp&
         let rtp = &rtp
         exec "silent !" (has('win32') ? "rd /q/s" : "rm") top2_dir
+      endfunc
+
+      func Test_packadd_symlink_dir2()
+        let top2_dir = expand(s:topdir . '/Xdir2')
+        let real_dir = expand(s:topdir . '/Xsym/pack')
+        call mkdir(top2_dir, 'p')
+        call mkdir(real_dir, 'p')
+        let &rtp = top2_dir . ',' . top2_dir . '/after'
+        let &packpath = &rtp
+
+        if has('win32')
+          exec "silent! !mklink /d" top2_dir "Xsym"
+        else
+          exec "silent !ln -s ../Xsym/pack"  top2_dir . '/pack'
+        endif
+        let s:plugdir = expand(top2_dir . '/pack/mine/opt/mytest')
+        call mkdir(s:plugdir . '/plugin', 'p')
+
+        exe 'split ' . s:plugdir . '/plugin/test.vim'
+        call setline(1, 'let g:plugin_works = 48')
+        wq
+        let g:plugin_works = 0
+
+        packadd mytest
+
+        " Must have been inserted in the middle, not at the end
+        call assert_match(Escape(expand('/Xdir2/pack/mine/opt/mytest').','), &rtp)
+        call assert_equal(48, g:plugin_works)
+
+        " No change when doing it again.
+        let rtp_before = &rtp
+        packadd mytest
+        call assert_equal(rtp_before, &rtp)
+
+        set rtp&
+        let rtp = &rtp
+        if has('win32')
+          exec "silent !rd /q/s" top2_dir
+        else
+          exec "silent !rm" top2_dir . '/pack'
+          exec "silent !rmdir" top2_dir
+        endif
       endfunc
 
       func Test_packloadall()
@@ -190,9 +236,9 @@ describe('packadd', function()
         helptags ALL
 
         let tags1 = readfile(docdir1 . '/tags')
-        call assert_true(tags1[0] =~ 'look-here')
+        call assert_match('look-here', tags1[0])
         let tags2 = readfile(docdir2 . '/tags')
-        call assert_true(tags2[0] =~ 'look-away')
+        call assert_match('look-away', tags2[0])
       endfunc
 
       func Test_colorscheme()

--- a/test/functional/legacy/packadd_spec.lua
+++ b/test/functional/legacy/packadd_spec.lua
@@ -70,9 +70,10 @@ describe('packadd', function()
         call assert_match(Escape(s:plugdir) . '\($\|,\)', &rtp)
 
         let new_after = match(&rtp, Escape(expand(s:plugdir . '/after') . ','))
-        let old_after = match(&rtp, ',' . Escape(first_after_entry) . '\>')
+        let forwarded = substitute(first_after_entry, '\\', '[/\\\\]', 'g')
+        let old_after = match(&rtp, ',' . escape(forwarded, '~') . '\>')
         call assert_true(new_after > 0, 'rtp is ' . &rtp)
-        call assert_true(old_after > 0, 'rtp is ' . &rtp)
+        call assert_true(old_after > 0, 'match ' . forwarded . ' in ' . &rtp)
         call assert_true(new_after < old_after, 'rtp is ' . &rtp)
 
         " NOTE: '/.../opt/myte' forwardly matches with '/.../opt/mytest'


### PR DESCRIPTION
#### vim-patch:8.0.1469: when package path is a symlink 'runtimepath' is wrong

Problem:    When package path is a symlink adding it to 'runtimepath' happens
            at the end.
Solution:   Do not resolve symlinks before locating the position in
            'runtimepath'. (Ozaki Kiichi, closes vim/vim#2604)
https://github.com/vim/vim/commit/2374faae111057ee28e8d487f9a52a95855e2206


#### vim-patch:8.0.1734: package directory not added to 'rtp' if prefix matches

Problem:    Package directory not added to 'rtp' if prefix matches.
Solution:   Check the match is a full match. (Ozaki Kiichi, closes vim/vim#2817)
            Also handle different ways of spelling a path.
https://github.com/vim/vim/commit/f98a39ca57d001ba3e24831bae1e375790fb41f0


#### vim-patch:8.1.0353: an "after" directory of a package is appended to 'rtp'

Problem:    An "after" directory of a package is appended to 'rtp', which
            will be after the user's "after" directory. ()
Solution:   Insert the package "after" directory before any other "after"
            directory in 'rtp'. (closes vim/vim#3409)
https://github.com/vim/vim/commit/99396d4cbf78d313a454c7448acc07412d2e45b7


#### vim-patch:8.1.0354: packadd test fails on MS-Windows

Problem:    Packadd test fails on MS-Windows.
Solution:   Ignore difference between forward and backward slashes.
https://github.com/vim/vim/commit/53c8a478cc4265549597b00214e0da812154742e