### PR TITLE
vim-patch:8.1.0662: needlessly searching for tilde in string

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -779,7 +779,7 @@ size_t home_replace(const buf_T *const buf, const char_u *src,
   char *homedir_env_mod = (char *)homedir_env;
   bool must_free = false;
 
-  if (homedir_env_mod != NULL && strchr(homedir_env_mod, '~') != NULL) {
+  if (homedir_env_mod != NULL && *homedir_env_mod == '~') {
     must_free = true;
     size_t usedlen = 0;
     size_t flen = strlen(homedir_env_mod);


### PR DESCRIPTION
Problem:    Needlessly searching for tilde in string.
Solution:   Only check the first character. (James McCoy, closes vim/vim#3734)
https://github.com/vim/vim/commit/ef0a1d5ed3566b91143d30ae9de3240f47c6e282