### PR TITLE
nvim.1: Add missing .El directive

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -56,6 +56,7 @@ Reads text from standard input until
 .Dv EOF ,
 then opens a buffer with that text.
 User input is read from standard error, which should be a terminal.
+.El
 .Sh OPTIONS
 .Bl -tag -width Fl
 .It Fl t Ar tag


### PR DESCRIPTION
    $ LC_ALL=en_US.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z man/nvim.1 >/dev/null
    mdoc warning: A .Bl directive has no matching .El (#59)

[ci skip]