### PR TITLE
Multigrid: fix popupmenu position + some cleanup

### DIFF
--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -94,7 +94,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed)
     if (curwin->w_p_rl) {
       col = curwin->w_width - curwin->w_wcol - 1;
     } else {
-      col = curwin->w_wincol + curwin->w_wcol;
+      col = curwin->w_wcol;
     }
 
     int grid = (int)curwin->w_grid.handle;

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed = helpers.clear, helpers.feed
 local source = helpers.source
+local insert = helpers.insert
 
 describe('ui/ext_popupmenu', function()
   local screen
@@ -255,6 +256,81 @@ describe('popup placement', function()
       hh                              |
       {3:[No Name] [Preview][+]          }|
       {2:-- }{5:match 1 of 10}                |
+    ]])
+  end)
+
+  it('works with vsplits', function()
+    insert('aaa aab aac\n')
+    feed(':vsplit<cr>')
+    screen:expect([[
+      aaa aab aac         {3:│}aaa aab aac|
+      ^                    {3:│}           |
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {4:[No Name] [+]        }{3:<Name] [+] }|
+      :vsplit                         |
+    ]])
+
+    feed('ibbb a<c-x><c-n>')
+    screen:expect([[
+      aaa aab aac         {3:│}aaa aab aac|
+      bbb aaa^             {3:│}bbb aaa    |
+      {1:~  }{s: aaa            }{1: }{3:│}{1:~          }|
+      {1:~  }{n: aab            }{1: }{3:│}{1:~          }|
+      {1:~  }{n: aac            }{1: }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {1:~                   }{3:│}{1:~          }|
+      {4:[No Name] [+]        }{3:<Name] [+] }|
+      {2:-- }{5:match 1 of 3}                 |
+    ]])
+
+    feed('<esc><c-w><c-w>oc a<c-x><c-n>')
+    screen:expect([[
+      aaa aab aac{3:│}aaa aab aac         |
+      bbb aaa    {3:│}bbb aaa             |
+      c aaa      {3:│}c aaa^               |
+      {1:~          }{3:│}{1:~}{s: aaa            }{1:   }|
+      {1:~          }{3:│}{1:~}{n: aab            }{1:   }|
+      {1:~          }{3:│}{1:~}{n: aac            }{1:   }|
+      {1:~          }{3:│}{1:~                   }|
+      {1:~          }{3:│}{1:~                   }|
+      {1:~          }{3:│}{1:~                   }|
+      {1:~          }{3:│}{1:~                   }|
+      {1:~          }{3:│}{1:~                   }|
+      {1:~          }{3:│}{1:~                   }|
+      {1:~          }{3:│}{1:~                   }|
+      {1:~          }{3:│}{1:~                   }|
+      {1:~          }{3:│}{1:~                   }|
+      {1:~          }{3:│}{1:~                   }|
+      {1:~          }{3:│}{1:~                   }|
+      {1:~          }{3:│}{1:~                   }|
+      {3:<Name] [+]  }{4:[No Name] [+]       }|
+      {2:-- }{5:match 1 of 3}                 |
     ]])
   end)
 end)


### PR DESCRIPTION
I messed up the pum position in right vsplit window. Fixed and added a test.

Also some cleanup of grid management mostly taken from #6619. Only `screen.c` layer should deal with the decision of which grid to use, not `ui.c`.