### PR TITLE
Rework Python provider/health check to use neovim module again

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -192,9 +192,9 @@ function! s:version_info(python) abort
   let nvim_path = s:trim(s:system([
         \ a:python, '-c',
         \ 'import sys; sys.path.remove(""); ' .
-        \ 'import pynvim; print(pynvim.__file__)']))
+        \ 'import neovim; print(neovim.__file__)']))
   if s:shell_error || empty(nvim_path)
-    return [python_version, 'unable to load pynvim Python module', pypi_version,
+    return [python_version, 'unable to load neovim Python module', pypi_version,
           \ nvim_path]
   endif
 
@@ -206,13 +206,13 @@ function! s:version_info(python) abort
     return a == b ? 0 : a > b ? 1 : -1
   endfunction
 
-  " Try to get pynvim.VERSION (added in 0.1.11dev).
+  " Try to get neovim.VERSION (added in 0.1.11dev).
   let nvim_version = s:system([a:python, '-c',
-        \ 'from pynvim import VERSION as v; '.
+        \ 'from neovim import VERSION as v; '.
         \ 'print("{}.{}.{}{}".format(v.major, v.minor, v.patch, v.prerelease))'],
         \ '', 1, 1)
   if empty(nvim_version)
-    let nvim_version = 'unable to find pynvim Python module version'
+    let nvim_version = 'unable to find neovim Python module version'
     let base = fnamemodify(nvim_path, ':h')
     let metas = glob(base.'-*/METADATA', 1, 1)
           \ + glob(base.'-*/PKG-INFO', 1, 1)

--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -415,17 +415,18 @@ function! s:check_python(version) abort
     call health#report_info('Python version: ' . pyversion)
     if s:is_bad_response(status)
       call health#report_info(printf('pynvim version: %s (%s)', current, status))
-    else
-      call health#report_info(printf('pynvim version: %s', current))
       let [module_found, _msg] = provider#pythonx#CheckForModule(python_bin,
-            \ 'neovim', a:version)
-      if !module_found
+            \ 'pynvim', a:version)
+      if status !=? '^outdated' && module_found
+        " neovim module was not found, but pynvim was
         call health#report_error('Importing "neovim" failed.',
               \ "Reinstall \"pynvim\" and optionally \"neovim\" packages.\n" .
               \    pip ." uninstall pynvim neovim\n" .
               \    pip ." install pynvim\n" .
               \    pip ." install neovim # only if needed by third-party software")
       endif
+    else
+      call health#report_info(printf('pynvim version: %s', current))
     endif
 
     if s:is_bad_response(current)

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -10,7 +10,7 @@ function! provider#pythonx#Require(host) abort
 
   " Python host arguments
   let prog = (ver == '2' ?  provider#python#Prog() : provider#python3#Prog())
-  let args = [prog, '-c', 'import sys; sys.path.remove(""); import pynvim; pynvim.start_host()']
+  let args = [prog, '-c', 'import sys; sys.path.remove(""); import neovim; neovim.start_host()']
 
   " Collect registered Python plugins into args
   let python_plugins = remote#host#PluginsForHost(a:host.name)
@@ -40,7 +40,7 @@ function! provider#pythonx#Detect(major_ver) abort
   let errors = []
 
   for prog in progs
-    let [result, err] = provider#pythonx#CheckForModule(prog, 'pynvim', a:major_ver)
+    let [result, err] = provider#pythonx#CheckForModule(prog, 'neovim', a:major_ver)
     if result
       return [prog, err]
     endif

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -75,12 +75,12 @@ function! provider#pythonx#CheckForModule(prog, module, major_version) abort
 
   let min_version = (a:major_version == 2) ? '2.6' : '3.3'
 
-  " Try to load pynvim module, and output Python version.
+  " Try to load module, and output Python version.
   " Exit codes:
-  "   0  pynvim module can be loaded.
-  "   2  pynvim module cannot be loaded.
+  "   0  module can be loaded.
+  "   2  module cannot be loaded.
   "   Otherwise something else went wrong (e.g. 1 or 127).
-  let [prog_exitcode, prog_version] = s:import_module(a:prog, 'pynvim')
+  let [prog_exitcode, prog_version] = s:import_module(a:prog, a:module)
 
   if prog_exitcode == 2 || prog_exitcode == 0
     " Check version only for expected return codes.
@@ -94,7 +94,7 @@ function! provider#pythonx#CheckForModule(prog, module, major_version) abort
   endif
 
   if prog_exitcode == 2
-    return [0, prog_path.' does not have the "pynvim" module. :help provider-python']
+    return [0, prog_path.' does not have the "' . a:module . '" module. :help provider-python']
   elseif prog_exitcode == 127
     " This can happen with pyenv's shims.
     return [0, prog_path . ' does not exist: ' . prog_version]


### PR DESCRIPTION
All hard-coded interactions with the Python interpreter are back to using the
'neovim' module, so there's time for users to get the pynvim module.

The help statuses still generally refer to pynvim, since that should be the
common name going forward.

The "pip safeguard" (i.e., report when pynvim module is present but neovim
module isn't) should still work, but someone who uses pip should verify that
(@mhinz, @bfredl?).