### PR TITLE
TUI: Do not indiscriminately disable BCE for builtins

### DIFF
--- a/src/nvim/tui/terminfo.c
+++ b/src/nvim/tui/terminfo.c
@@ -137,9 +137,6 @@ unibi_term *terminfo_from_builtin(const char *term, char **termname)
   if (*termname == NULL) {
     *termname = xstrdup("builtin_?");
   }
-  // Disable BCE by default (for built-in terminfos). #7624
-  // https://github.com/kovidgoyal/kitty/issues/160#issuecomment-346470545
-  unibi_set_bool(ut, unibi_back_color_erase, false);
   return ut;
 }
 


### PR DESCRIPTION
Remove this vestigial hack from #7624.

Since 5a0d0286ff4d we blacklist BCE more surgically. And
patch_terminfo_bugs() is the more appropriate place for that.

ref 5749ecaf228f4a963a4e96ada831f902c73a1e80
ref #4210 #4421 #7035 #7337 #7381 #7425 #7618

cc @bfredl 