### PR TITLE
vim-patch:8.1.{651,653}

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1772,7 +1772,7 @@ void ex_args(exarg_T *eap)
     }
   }
 
-  if (!ends_excmd(*eap->arg)) {
+  if (*eap->arg != NUL) {
     // ":args file ..": define new argument list, handle like ":next"
     // Also for ":argslocal file .." and ":argsglobal file ..".
     ex_next(eap);

--- a/src/nvim/testdir/test_arglist.vim
+++ b/src/nvim/testdir/test_arglist.vim
@@ -171,9 +171,12 @@ func Test_argument()
 endfunc
 
 func Test_args_with_quote()
-  args \"foobar
-  call assert_equal('"foobar', argv(0))
-  %argdelete
+  " Only on Unix can a file name include a double quote.
+  if has('unix')
+    args \"foobar
+    call assert_equal('"foobar', argv(0))
+    %argdelete
+  endif
 endfunc
 
 " Test for 0argadd and 0argedit

--- a/src/nvim/testdir/test_arglist.vim
+++ b/src/nvim/testdir/test_arglist.vim
@@ -170,6 +170,12 @@ func Test_argument()
   call assert_fails('argument', 'E163:')
 endfunc
 
+func Test_args_with_quote()
+  args \"foobar
+  call assert_equal('"foobar', argv(0))
+  %argdelete
+endfunc
+
 " Test for 0argadd and 0argedit
 " Ported from the test_argument_0count.in test script
 func Test_zero_argadd()


### PR DESCRIPTION
**vim-patch:8.1.0651: :args \"foo works like :args without argument**

Problem:    :args \"foo works like :args without argument.
Solution:   Fix check for empty argument. (closes vim/vim#3728)
https://github.com/vim/vim/commit/2ac372ccee1af6f9fa105bf2648d5e4efa554236

**vim-patch:8.1.0653: arglist test fails on MS-windows**

Problem:    Arglist test fails on MS-windows.
Solution:   Only use a file name with a double quote on Unix.
https://github.com/vim/vim/commit/3de8c2d1f027410db6a06f0fcd3355d96c8b8596