### PR TITLE
Nvim v0.3.3 maintenance release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
 set(NVIM_VERSION_MAJOR 0)
 set(NVIM_VERSION_MINOR 3)
 set(NVIM_VERSION_PATCH 3)
-set(NVIM_VERSION_PRERELEASE "-dev") # for package maintainers
+set(NVIM_VERSION_PRERELEASE "") # for package maintainers
 
 # API level
 set(NVIM_API_LEVEL 5)         # Bump this after any API change.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,8 +112,8 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
 # version string, else they are combined with the result of `git describe`.
 set(NVIM_VERSION_MAJOR 0)
 set(NVIM_VERSION_MINOR 3)
-set(NVIM_VERSION_PATCH 3)
-set(NVIM_VERSION_PRERELEASE "") # for package maintainers
+set(NVIM_VERSION_PATCH 4)
+set(NVIM_VERSION_PRERELEASE "-dev") # for package maintainers
 
 # API level
 set(NVIM_API_LEVEL 5)         # Bump this after any API change.

--- a/scripts/git-log-pretty-since.sh
+++ b/scripts/git-log-pretty-since.sh
@@ -22,7 +22,7 @@ is_merge_commit() {
 for commit in $(git log --format='%H' --first-parent "$__SINCE"..HEAD); do
   if is_merge_commit ${commit} ; then
       if [ -z "$__INVMATCH" ] || ! git log --oneline ${commit}^1..${commit}^2 \
-           | grep -E "$__INVMATCH" >/dev/null 2>&1 ; then
+           | >/dev/null 2>&1 grep -E "$__INVMATCH" ; then
         git log -1 --oneline ${commit}
         git log --format='    %h %s' ${commit}^1..${commit}^2
       fi

--- a/scripts/git-log-pretty-since.sh
+++ b/scripts/git-log-pretty-since.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-# Shows a log with changes grouped next to their merge-commit.
+# Prints a nicely-formatted commit history.
+#   - Commits are grouped below their merge-commit.
+#   - Issue numbers are moved next to the commit-id.
 #
 # Parameters:
 #   $1    "since" commit
@@ -19,6 +21,24 @@ is_merge_commit() {
   git log $1^2 >/dev/null 2>&1 && return 0 || return 1
 }
 
+# Removes parens from issue/ticket/PR numbers.
+#
+# Example:
+#   in:   3340e08becbf foo (#9423)
+#   out:  3340e08becbf foo #9423
+_deparen() {
+  sed 's/(\(\#[0-9]\{3,\}\))/\1/g'
+}
+
+# Cleans up issue/ticket/PR numbers in the commit descriptions.
+#
+# Example:
+#   in:   3340e08becbf foo (#9423)
+#   out:  3340e08becbf #9423 foo
+_format_ticketnums() {
+  nvim -Es +'g/\v(#[0-9]{3,})/norm! ngEldE0ep' +'%p' | _deparen
+}
+
 for commit in $(git log --format='%H' --first-parent "$__SINCE"..HEAD); do
   if is_merge_commit ${commit} ; then
       if [ -z "$__INVMATCH" ] || ! git log --oneline ${commit}^1..${commit}^2 \
@@ -29,4 +49,4 @@ for commit in $(git log --format='%H' --first-parent "$__SINCE"..HEAD); do
   else
     git log -1 --oneline ${commit}
   fi
-done
+done | _format_ticketnums

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -67,7 +67,7 @@ _do_release_commit() {
 
   if ! test "$ARG1" = '--use-current-commit' ; then
     echo "Building changelog since ${__LAST_TAG}..."
-    __CHANGELOG="$(./scripts/git-log-pretty-since.sh "$__LAST_TAG" 'vim-patch:\S')"
+    __CHANGELOG="$(./scripts/git-log-pretty-since.sh "$__LAST_TAG" 'vim-patch:[^[:space:]]')"
 
     git add CMakeLists.txt
     git commit --edit -m "${__RELEASE_MSG} ${__CHANGELOG}"


### PR DESCRIPTION
This maintenance release fixes some issues found in v0.3.2 .

FIXES:

a597ab8 #9442 Merge pull request from jamessan/revert-pynvim
    d7b3ac0 health/provider: Check for available pynvim when neovim module missing
    edeb19d python#CheckForModule: Use the given module string instead of hard-coding pynvim
    0dd89cd {health,provider}/python: Import the neovim, rather than pynvim, module
fc6e8a4 #9423 TUI: Konsole DECSCUSR fixup