### PR TITLE
vim-patch:8.1.{677,685,687}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7103,7 +7103,7 @@ static void f_bufloaded(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /*
  * Get buffer by number or pattern.
  */
-static buf_T *get_buf_tv(typval_T *tv, int curtab_only)
+static buf_T *tv_get_buf(typval_T *tv, int curtab_only)
 {
   char_u      *name = tv->vval.v_string;
   int save_magic;
@@ -7149,7 +7149,7 @@ static void f_bufname(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
   emsg_off++;
-  const buf_T *const buf = get_buf_tv(&argvars[0], false);
+  const buf_T *const buf = tv_get_buf(&argvars[0], false);
   emsg_off--;
   if (buf != NULL && buf->b_fname != NULL) {
     rettv->vval.v_string = (char_u *)xstrdup((char *)buf->b_fname);
@@ -7168,7 +7168,7 @@ static void f_bufnr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
   emsg_off++;
-  const buf_T *buf = get_buf_tv(&argvars[0], false);
+  const buf_T *buf = tv_get_buf(&argvars[0], false);
   emsg_off--;
 
   // If the buffer isn't found and the second argument is not zero create a
@@ -7195,7 +7195,7 @@ static void buf_win_common(typval_T *argvars, typval_T *rettv, bool get_nr)
   }
 
   emsg_off++;
-  buf_T *buf = get_buf_tv(&argvars[0], true);
+  buf_T *buf = tv_get_buf(&argvars[0], true);
   if (buf == NULL) {  // no need to search if buffer was not found
     rettv->vval.v_number = -1;
     goto end;
@@ -9280,7 +9280,7 @@ static void f_getbufinfo(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     // Information about one buffer.  Argument specifies the buffer
     if (tv_check_num(&argvars[0])) {  // issue errmsg if type error
       emsg_off++;
-      argbuf = get_buf_tv(&argvars[0], false);
+      argbuf = tv_get_buf(&argvars[0], false);
       emsg_off--;
       if (argbuf == NULL) {
         return;
@@ -9376,7 +9376,7 @@ static void f_getbufline(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   if (tv_check_str_or_nr(&argvars[0])) {
     emsg_off++;
-    buf = get_buf_tv(&argvars[0], false);
+    buf = tv_get_buf(&argvars[0], false);
     emsg_off--;
   }
 
@@ -9404,7 +9404,7 @@ static void f_getbufvar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   const char *varname = tv_get_string_chk(&argvars[1]);
   emsg_off++;
-  buf_T *const buf = get_buf_tv(&argvars[0], false);
+  buf_T *const buf = tv_get_buf(&argvars[0], false);
 
   if (buf != NULL && varname != NULL) {
     // set curbuf to be our buf, temporarily
@@ -14491,7 +14491,7 @@ static void f_setbufvar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
   const char *varname = tv_get_string_chk(&argvars[1]);
-  buf_T *const buf = get_buf_tv(&argvars[0], false);
+  buf_T *const buf = tv_get_buf(&argvars[0], false);
   typval_T *varp = &argvars[2];
 
   if (buf != NULL && varname != NULL) {

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -4920,7 +4920,7 @@ regmatch (
               }
             } else {
               const char_u *const line =
-                  reg_getline(behind_pos.rs_u.pos.lnum);
+                  reg_getline(rp->rs_un.regsave.rs_u.pos.lnum);
 
               rp->rs_un.regsave.rs_u.pos.col -=
                   utf_head_off(line,

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -277,3 +277,44 @@ func Test_visual_mode_reset()
 
   set belloff&
 endfunc
+
+func Test_Visual_sentence_textobject()
+  new
+  call setline(1, ['First sentence. Second sentence. Third', 'sentence. Fouth sentence'])
+
+  " When start and end of visual area are identical, 'as' or 'is' select
+  " the whole sentence.
+  norm! 1gofdvasy
+  call assert_equal('Second sentence. ', @")
+  norm! 1gofdvisy
+  call assert_equal('Second sentence.', @")
+
+  " When start and end of visual area are not identical, 'as' or 'is'
+  " extend the sentence in direction of the end of the visual area.
+  norm! 1gofdvlasy
+  call assert_equal('d sentence. ', @")
+  norm! gvasy
+  call assert_equal("d sentence. Third\nsentence. ", @")
+
+  norm! 1gofdvlisy
+  call assert_equal('d sentence.', @")
+  norm! gvisy
+  call assert_equal('d sentence. ', @")
+  norm! gvisy
+  call assert_equal("d sentence. Third\nsentence.", @")
+
+  " Extend visual area in opposite direction.
+  norm! 1gofdvhasy
+  call assert_equal(' Second', @")
+  norm! gvasy
+  call assert_equal("First sentence. Second", @")
+
+  norm! 1gofdvhisy
+  call assert_equal('Second', @")
+  norm! gvisy
+  call assert_equal(' Second', @")
+  norm! gvisy
+  call assert_equal('First sentence. Second', @")
+
+  bwipe!
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0677: look-behind match may use the wrong line number**

Problem:    Look-behind match may use the wrong line number. (Dominique Pelle)
Solution:   Use the line number in regsave instead of the one in behind_pos,
            we may be looking at the previous line. (closes vim/vim#3749)
vim/vim@866f355

**vim-patch:8.1.0685: get_buf_tv() is named inconsistently**

Problem:    get_buf_tv() is named inconsistently.
Solution:   Rename it to tv_get_buf(). (Yegappan Lakshmanan, closes vim/vim#3759)
vim/vim@f2d79fa

**vim-patch:8.1.0687: sentence text object in Visual mode is not tested**

Problem:    Sentence text object in Visual mode is not tested.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#3758)
vim/vim@6d3a194