### PR TITLE
vim-patch:8.1.0700: using "gt" sometimes does not redraw a tab

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -185,6 +185,10 @@ void redraw_all_later(int type)
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     redraw_win_later(wp, type);
   }
+  // This may be needed when switching tabs.
+  if (must_redraw < type) {
+    must_redraw = type;
+  }
 }
 
 void screen_invalidate_highlights(void)

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3355,7 +3355,6 @@ static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, int trigger_enter_au
   }
 
   redraw_all_later(NOT_VALID);
-  must_redraw = NOT_VALID;
 }
 
 /// called when changing current tabpage from old_curtab to curtab


### PR DESCRIPTION
The test from #9155 correctly fails without this change.

---

Problem:    Using "gt" sometimes does not redraw a tab. (Jason Franklin)
Solution:   Always set must_redraw in redraw_all_later().
https://github.com/vim/vim/commit/04b4e1a42409f81d65ae4801ac867dc0bba3d7b8

ref https://github.com/vim/vim/commit/bf3250a8ad39797e3ccdac82d20c6f19533419e4#r31852304

> I fixed it in a more general way, in that if we don't find a window
> that doesn't have the redraw type set it, then it will not set
> must_redraw, even though that's clearly intended.

ref #9152
ref #9155

NA patches:
vim-patch:8.1.0698
vim-patch:8.1.0699

cc @bfredl 