### PR TITLE
pvscheck.sh: Ignore V1028 "cast operands, not the result"

### DIFF
--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -365,7 +365,7 @@ run_analysis() {(
       --sourcetree-root . || true
 
   rm -rf PVS-studio.{xml,err,tsk,html.d}
-  local plog_args="PVS-studio.log --srcRoot . --excludedCodes V011"
+  local plog_args="PVS-studio.log --srcRoot . --excludedCodes V011,V1028"
   plog-converter $plog_args --renderTypes xml       --output PVS-studio.xml
   plog-converter $plog_args --renderTypes errorfile --output PVS-studio.err
   plog-converter $plog_args --renderTypes tasklist  --output PVS-studio.tsk


### PR DESCRIPTION
This PVS warning, while useful, conflicts with changes done to satisfy
`-Wconversion`.

For example:

    assert(orig_char_len + size - ind_done + line_len >= 0);
    newline = xmalloc((size_t)(orig_char_len + size - ind_done + line_len));

We verified that the result is valid for xmalloc, but PVS warns because
the individual terms may result in nonsense (e.g. ind_done + line_len
could overflow `int`, which is UB).

The PVS warning is valid, but satisfying it would be onerous, and
unfeasible.