### PR TITLE
vim-patch:8.1.0696

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4698,7 +4698,7 @@ static int ins_complete(int c, bool enable_pum)
       pos = curwin->w_cursor;
       curwin_save = curwin;
       curbuf_save = curbuf;
-      col = call_func_retnr(funcname, 2, args, FALSE);
+      col = call_func_retnr(funcname, 2, args, false);
 
       State = save_State;
       if (curwin_save != curwin || curbuf_save != curbuf) {

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3520,6 +3520,7 @@ expand_by_function (
   win_T       *curwin_save;
   buf_T       *curbuf_save;
   typval_T rettv;
+  const int save_State = State;
 
   funcname = (type == CTRL_X_FUNCTION) ? curbuf->b_p_cfu : curbuf->b_p_ofu;
   if (*funcname == NUL)
@@ -3565,6 +3566,9 @@ expand_by_function (
     ins_compl_add_dict(matchdict);
 
 theend:
+  // Restore State, it might have been changed.
+  State = save_State;
+
   if (matchdict != NULL) {
     tv_dict_unref(matchdict);
   }
@@ -4676,6 +4680,7 @@ static int ins_complete(int c, bool enable_pum)
       pos_T pos;
       win_T       *curwin_save;
       buf_T       *curbuf_save;
+      const int save_State = State;
 
       /* Call 'completefunc' or 'omnifunc' and get pattern length as a
        * string */
@@ -4694,6 +4699,8 @@ static int ins_complete(int c, bool enable_pum)
       curwin_save = curwin;
       curbuf_save = curbuf;
       col = call_func_retnr(funcname, 2, args, FALSE);
+
+      State = save_State;
       if (curwin_save != curwin || curbuf_save != curbuf) {
         EMSG(_(e_complwin));
         return FAIL;
@@ -8667,6 +8674,7 @@ static colnr_T get_nolist_virtcol(void)
 static char_u *do_insert_char_pre(int c)
 {
   char buf[MB_MAXBYTES + 1];
+  const int save_State = State;
 
   // Return quickly when there is nothing to do.
   if (!has_event(EVENT_INSERTCHARPRE)) {
@@ -8690,6 +8698,9 @@ static char_u *do_insert_char_pre(int c)
 
   set_vim_var_string(VV_CHAR, NULL, -1);
   textlock--;
+
+  // Restore the State, it may have been changed.
+  State = save_State;
 
   return res;
 }

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -26,7 +26,7 @@
 " It will be called after each Test_ function.
 "
 " When debugging a test it can be useful to add messages to v:errors:
-" 	call add(v:errors, "this happened")
+"	call add(v:errors, "this happened")
 
 
 " Check that the screen size is at least 24 x 80 characters.
@@ -129,6 +129,10 @@ func RunTheTest(test)
       call add(v:errors, 'Caught exception in ' . a:test . ': ' . v:exception . ' @ ' . v:throwpoint)
     endtry
   endif
+
+  " In case 'insertmode' was set and something went wrong, make sure it is
+  " reset to avoid trouble with anything else.
+  set noinsertmode
 
   if exists("*TearDown")
     try


### PR DESCRIPTION
**vim-patch:8.1.0696: when test_edit fails 'insertmode' may not be reset**

Problem:    When test_edit fails 'insertmode' may not be reset and the next
            test may get stuck. (James McCoy)
Solution:   Always reset 'insertmode' after executing a test.  Avoid that an
            InsertCharPre autocommand or a 'complete' function can change the
            state. (closes vim/vim#3768)
https://github.com/vim/vim/commit/8ad16da7290190f55f88073d5586dfe133fddf45