### PR TITLE
editorconfig: set default tab width to 8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 2
+tab_width = 8
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8


### PR DESCRIPTION
Vim patches may include tabs in Vimscript test files.
editorconfig uses "indent_size" for tabs if "tab_width" is unset
so the user sees 2-width tabs.

Saw the 2-width tabs when working on https://github.com/neovim/neovim/pull/9466 so the diff looks wrong. This should fix it.