### PR TITLE
API: don't directly call update_screen() in API functions

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -75,7 +75,6 @@ void nvim_command(String command, Error *err)
 {
   try_start();
   do_cmdline_cmd(command.data);
-  update_screen(VALID);
   try_end(err);
 }
 

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -135,7 +135,7 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   // make sure cursor is in visible range even if win != curwin
   update_topline_win(win);
 
-  update_screen(VALID);
+  redraw_win_later(win, VALID);
 }
 
 /// Gets the window height

--- a/test/functional/legacy/051_highlight_spec.lua
+++ b/test/functional/legacy/051_highlight_spec.lua
@@ -3,10 +3,11 @@
 local Screen = require('test.functional.ui.screen')
 local helpers = require('test.functional.helpers')(after_each)
 local clear, feed = helpers.clear, helpers.feed
-local command, expect = helpers.command, helpers.expect
+local expect = helpers.expect
 local eq = helpers.eq
 local wait = helpers.wait
 local exc_exec = helpers.exc_exec
+local feed_command = helpers.feed_command
 
 describe(':highlight', function()
   setup(clear)
@@ -15,7 +16,7 @@ describe(':highlight', function()
     local screen = Screen.new(35, 10)
     screen:attach()
     -- Basic test if ":highlight" doesn't crash
-    command('set more')
+    feed_command('set more')
     feed(':highlight<CR>')
     -- FIXME(tarruda): We need to be sure the prompt is displayed before
     -- continuing, or risk a race condition where some of the following input
@@ -34,52 +35,62 @@ describe(':highlight', function()
     ]])
     feed('q')
     wait() -- wait until we're back to normal
-    command('hi Search')
-    command('hi Normal')
+    feed_command('hi Search')
+    feed_command('hi Normal')
 
     -- Test setting colors.
     -- Test clearing one color and all doesn't generate error or warning
-    command('hi NewGroup cterm=italic ctermfg=DarkBlue ctermbg=Grey gui=NONE guifg=#00ff00 guibg=Cyan')
-    command('hi Group2 cterm=NONE')
-    command('hi Group3 cterm=bold')
-    command('redir! @a')
-    command('hi NewGroup')
-    command('hi Group2')
-    command('hi Group3')
-    command('hi clear NewGroup')
-    command('hi NewGroup')
-    command('hi Group2')
-    command('hi Group2 NONE')
-    command('hi Group2')
-    command('hi clear')
-    command('hi Group3')
+    feed_command('hi NewGroup cterm=italic ctermfg=DarkBlue ctermbg=Grey gui=NONE guifg=#00ff00 guibg=Cyan')
+    feed_command('hi Group2 cterm=NONE')
+    feed_command('hi Group3 cterm=bold')
+    feed_command('redir! @a')
+    feed_command('hi NewGroup')
+    feed_command('hi Group2')
+    feed_command('hi Group3')
+    feed_command('hi clear NewGroup')
+    feed_command('hi NewGroup')
+    feed_command('hi Group2')
+    feed_command('hi Group2 NONE')
+    feed_command('hi Group2')
+    feed_command('hi clear')
+    feed_command('hi Group3')
+    feed('<cr>')
     eq('Vim(highlight):E475: Invalid argument: cterm=\'asdf',
        exc_exec([[hi Crash cterm='asdf]]))
-    command('redir END')
+    feed_command('redir END')
 
     -- Filter ctermfg and ctermbg, the numbers depend on the terminal
-    command('0put a')
-    command([[%s/ctermfg=\d*/ctermfg=2/]])
-    command([[%s/ctermbg=\d*/ctermbg=3/]])
+    feed_command('0put a')
+    feed_command([[%s/ctermfg=\d*/ctermfg=2/]])
+    feed_command([[%s/ctermbg=\d*/ctermbg=3/]])
 
     -- Fix the fileformat
-    command('set ff&')
-    command('$d')
+    feed_command('set ff&')
+    feed_command('$d')
 
     -- Assert buffer contents.
     expect([[
+
 
       NewGroup       xxx cterm=italic
                          ctermfg=2
                          ctermbg=3
                          guifg=#00ff00
                          guibg=Cyan
+
       Group2         xxx cleared
+
       Group3         xxx cterm=bold
+
+
       NewGroup       xxx cleared
+
       Group2         xxx cleared
+
+
       Group2         xxx cleared
+
+
       Group3         xxx cleared]])
-    screen:detach()
   end)
 end)


### PR DESCRIPTION
There is no need to call `update_screen()` directly in an API function, mode input processing invokes `update_screen()` as needed. And if the API call is done in a context where redraw is disabled, then redraw is disabled for a reason. A lot of API functions are of equal semantical strength (`call_function` and `execute_lua` can also do whatever, `command` is not special), this inconsistency has no purpose. (one could consider a `nvim_redraw` function, but `nvim_command("redraw")` works perfectly well for now, for cases where a client wants to force a redraw). This has already some tendency to be cargo-culted, so let's get rid of it.