### PR TITLE
screen: remove ad-hoc code path for redrawing signs.

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5347,8 +5347,7 @@ int bufhl_add_hl(buf_T *buf,
   hlentry->stop = col_end;
 
   if (0 < lnum && lnum <= buf->b_ml.ml_line_count) {
-    changed_lines_buf(buf, lnum, lnum+1, 0);
-    redraw_buf_later(buf, VALID);
+    redraw_buf_line_later(buf, lnum);
   }
   return src_id;
 }
@@ -5414,8 +5413,7 @@ int bufhl_add_virt_text(buf_T *buf,
   }
 
   if (0 < lnum && lnum <= buf->b_ml.ml_line_count) {
-    changed_lines_buf(buf, lnum, lnum+1, 0);
-    redraw_buf_later(buf, VALID);
+    redraw_buf_line_later(buf, lnum);
   }
   return src_id;
 }
@@ -5440,8 +5438,6 @@ void bufhl_clear_line_range(buf_T *buf,
                             linenr_T line_start,
                             linenr_T line_end)
 {
-  linenr_T first_changed = MAXLNUM, last_changed = -1;
-
   kbitr_t(bufhl) itr;
   BufhlLine *l, t = BUFHLLINE_INIT(line_start);
   if (!kb_itr_get(bufhl, &buf->b_bufhl_info, &t, &itr)) {
@@ -5456,23 +5452,13 @@ void bufhl_clear_line_range(buf_T *buf,
     if (line_start <= line) {
       BufhlLineStatus status = bufhl_clear_line(l, src_id, line);
       if (status != kBLSUnchanged) {
-        if (line > last_changed) {
-          last_changed = line;
-        }
-        if (line < first_changed) {
-          first_changed = line;
-        }
+        redraw_buf_line_later(buf, line);
       }
       if (status == kBLSDeleted) {
         kb_del_itr(bufhl, &buf->b_bufhl_info, &itr);
         xfree(l);
       }
     }
-  }
-
-  if (last_changed != -1) {
-    changed_lines_buf(buf, first_changed, last_changed+1, 0);
-    redraw_buf_later(buf, VALID);
   }
 }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1542,7 +1542,7 @@ void edit_unputchar(void)
       curwin->w_wcol++;
     }
     if (pc_status == PC_STATUS_RIGHT || pc_status == PC_STATUS_LEFT) {
-      redrawWinline(curwin, curwin->w_cursor.lnum, false);
+      redrawWinline(curwin, curwin->w_cursor.lnum);
     } else {
       grid_puts(&curwin->w_grid, pc_bytes, pc_row - msg_scrolled, pc_col,
                 pc_attr);
@@ -1583,7 +1583,7 @@ static void undisplay_dollar(void)
 {
   if (dollar_vcol >= 0) {
     dollar_vcol = -1;
-    redrawWinline(curwin, curwin->w_cursor.lnum, false);
+    redrawWinline(curwin, curwin->w_cursor.lnum);
   }
 }
 
@@ -5932,7 +5932,7 @@ static void check_spell_redraw(void)
     linenr_T lnum = spell_redraw_lnum;
 
     spell_redraw_lnum = 0;
-    redrawWinline(curwin, lnum, false);
+    redrawWinline(curwin, lnum);
   }
 }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5759,7 +5759,7 @@ void ex_sign(exarg_T *eap)
         id = buf_findsign_id(curwin->w_buffer, curwin->w_cursor.lnum);
         if (id > 0) {
           buf_delsign(curwin->w_buffer, id);
-          update_debug_sign(curwin->w_buffer, curwin->w_cursor.lnum);
+          redraw_buf_line_later(curwin->w_buffer, curwin->w_cursor.lnum);
         } else {
           EMSG(_("E159: Missing sign number"));
         }
@@ -5788,7 +5788,7 @@ void ex_sign(exarg_T *eap)
           // ":sign unplace {id}": remove placed sign by number
           FOR_ALL_BUFFERS(buf) {
             if ((lnum = buf_delsign(buf, id)) != 0) {
-              update_debug_sign(buf, lnum);
+              redraw_buf_line_later(buf, lnum);
             }
           }
           return;
@@ -5888,7 +5888,7 @@ void ex_sign(exarg_T *eap)
       } else {
         // ":sign unplace {id} file={fname}"
         lnum = buf_delsign(buf, id);
-        update_debug_sign(buf, lnum);
+        redraw_buf_line_later(buf, lnum);
       }
     } else if (sign_name != NULL) {
       // idx == SIGNCMD_PLACE
@@ -5910,7 +5910,7 @@ void ex_sign(exarg_T *eap)
         lnum = buf_change_sign_type(buf, id, sp->sn_typenr);
       }
       if (lnum > 0) {
-        update_debug_sign(buf, lnum);
+        redraw_buf_line_later(buf, lnum);
       } else {
         EMSG2(_("E885: Not possible to change sign %s"), sign_name);
       }

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -117,8 +117,8 @@ static void redraw_for_cursorline(win_T *wp)
         // "w_last_cursorline" may be outdated, worst case we redraw
         // too much.  This is optimized for moving the cursor around in
         // the current window.
-        redrawWinline(wp, wp->w_last_cursorline, false);
-        redrawWinline(wp, wp->w_cursor.lnum, false);
+        redrawWinline(wp, wp->w_last_cursorline);
+        redrawWinline(wp, wp->w_cursor.lnum);
         redraw_win_later(wp, VALID);
       } else {
         redraw_win_later(wp, SOME_VALID);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -214,6 +214,15 @@ void redraw_buf_later(buf_T *buf, int type)
   }
 }
 
+void redraw_buf_line_later(buf_T *buf,  linenr_T line)
+{
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    if (wp->w_buffer == buf) {
+      redrawWinline(wp, line, false);
+    }
+  }
+}
+
 /*
  * Changed something in the current window, at buffer line "lnum", that
  * requires that line and possibly other lines to be redrawn.
@@ -231,6 +240,8 @@ redrawWinline(
 {
   int i;
 
+  if (lnum >= wp->w_topline
+      && lnum < wp->w_botline) {
     if (wp->w_redraw_top == 0 || wp->w_redraw_top > lnum) {
         wp->w_redraw_top = lnum;
     }
@@ -239,11 +250,12 @@ redrawWinline(
     }
     redraw_win_later(wp, VALID);
 
-  if (invalid) {
-    // A w_lines[] entry for this lnum has become invalid.
-    i = find_wl_entry(wp, lnum);
-    if (i >= 0) {
-      wp->w_lines[i].wl_valid = false;
+    if (invalid) {
+      // A w_lines[] entry for this lnum has become invalid.
+      i = find_wl_entry(wp, lnum);
+      if (i >= 0) {
+        wp->w_lines[i].wl_valid = false;
+      }
     }
   }
 }
@@ -569,58 +581,6 @@ void update_single_line(win_T *wp, linenr_T lnum)
   need_cursor_line_redraw = false;
 }
 
-void update_debug_sign(const buf_T *const buf, const linenr_T lnum)
-{
-  bool doit = false;
-  win_foldinfo.fi_level = 0;
-
-  // update/delete a specific mark
-  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    if (buf != NULL && lnum > 0) {
-      if (wp->w_buffer == buf && lnum >= wp->w_topline
-          && lnum < wp->w_botline) {
-        if (wp->w_redraw_top == 0 || wp->w_redraw_top > lnum) {
-          wp->w_redraw_top = lnum;
-        }
-        if (wp->w_redraw_bot == 0 || wp->w_redraw_bot < lnum) {
-          wp->w_redraw_bot = lnum;
-        }
-        redraw_win_later(wp, VALID);
-      }
-    } else {
-      redraw_win_later(wp, VALID);
-    }
-    if (wp->w_redr_type != 0) {
-      doit = true;
-    }
-  }
-
-  // Return when there is nothing to do, screen updating is already
-  // happening (recursive call), messages on the screen or still starting up.
-  if (!doit
-      || updating_screen
-      || State == ASKMORE
-      || State == HITRETURN
-      || msg_scrolled
-      || starting) {
-    return;
-  }
-
-  // update all windows that need updating
-  update_prepare();
-
-  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    if (wp->w_redr_type != 0) {
-      update_window_hl(wp, wp->w_redr_type >= NOT_VALID);
-      win_update(wp);
-    }
-    if (wp->w_redr_status) {
-      win_redr_status(wp, false);
-    }
-  }
-
-  update_finish();
-}
 
 /*
  * Update a single window.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -218,7 +218,7 @@ void redraw_buf_line_later(buf_T *buf,  linenr_T line)
 {
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer == buf) {
-      redrawWinline(wp, line, false);
+      redrawWinline(wp, line);
     }
   }
 }
@@ -234,12 +234,9 @@ void redraw_buf_line_later(buf_T *buf,  linenr_T line)
 void
 redrawWinline(
     win_T *wp,
-    linenr_T lnum,
-    int invalid             /* window line height is invalid now */
+    linenr_T lnum
 )
 {
-  int i;
-
   if (lnum >= wp->w_topline
       && lnum < wp->w_botline) {
     if (wp->w_redraw_top == 0 || wp->w_redraw_top > lnum) {
@@ -249,14 +246,6 @@ redrawWinline(
         wp->w_redraw_bot = lnum;
     }
     redraw_win_later(wp, VALID);
-
-    if (invalid) {
-      // A w_lines[] entry for this lnum has become invalid.
-      i = find_wl_entry(wp, lnum);
-      if (i >= 0) {
-        wp->w_lines[i].wl_valid = false;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Remove special case for immediately redrawing signs when placing them. If multiple signs are added in a for-loop, redrawing can become inefficient (I've noticed this when gitgutter does a batch update). The windows will be redrawn anyway as part of the normal event loop. Also as changes are done to `update_screen()`, i e to support floats, this special case code path can easily become invalid (already happened for `winhl'  #8789 ).

`invalid` argument to `redrawWinline` is never used, neither in neovim nor vim codebases, so removing it.

@brammool Is there a particular reason signs are redrawn in this way? Otherwise the performance improvement is probably interesting in vim also.