### PR TITLE
macOS clipboard: assume that pbcopy is working

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -65,7 +65,7 @@ function! provider#clipboard#Executable() abort
     let s:paste = get(g:clipboard, 'paste', { '+': v:null, '*': v:null })
     let s:cache_enabled = get(g:clipboard, 'cache_enabled', 0)
     return get(g:clipboard, 'name', 'g:clipboard')
-  elseif has('mac') && executable('pbpaste') && s:cmd_ok('pbpaste')
+  elseif has('mac')
     let s:copy['+'] = 'pbcopy'
     let s:paste['+'] = 'pbpaste'
     let s:copy['*'] = s:copy['+']


### PR DESCRIPTION
macOS users reported slowdowns on startup when g:clipboard isn't set.

Just assume that pbcopy/pbpaste is working when on a Mac.

---

Reference: https://www.reddit.com/r/neovim/comments/ab01n8/improve_neovim_startup_by_60ms_for_free_on_macos