### PR TITLE
[RFC] vim-patch:8.1.0449,8.1.0450

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1460,7 +1460,13 @@ static void win_update(win_T *wp)
       if (wp->w_p_rnu) {
         // 'relativenumber' set: The text doesn't need to be drawn, but
         // the number column nearly always does.
-        (void)win_line(wp, lnum, srow, wp->w_grid.Rows, true, true);
+        fold_count = foldedCount(wp, lnum, &win_foldinfo);
+        if (fold_count != 0) {
+          fold_line(wp, fold_count, &win_foldinfo, lnum, row);
+          --fold_count;
+        } else {
+          (void)win_line(wp, lnum, srow, wp->w_grid.Rows, true, true);
+        }
       }
 
       // This line does not need to be drawn, advance to the next one.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1463,7 +1463,6 @@ static void win_update(win_T *wp)
         fold_count = foldedCount(wp, lnum, &win_foldinfo);
         if (fold_count != 0) {
           fold_line(wp, fold_count, &win_foldinfo, lnum, row);
-          --fold_count;
         } else {
           (void)win_line(wp, lnum, srow, wp->w_grid.Rows, true, true);
         }

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -26,6 +26,27 @@ describe("folded lines", function()
     screen:detach()
   end)
 
+  it("highlighting works with relative line numbers", function()
+    feed_command("set fdm=marker")
+    feed_command("set rnu")
+    feed_command("set foldcolumn=2")
+    helpers.funcs.setline(1, '{{{1')
+    helpers.funcs.setline(2, 'line 1')
+    helpers.funcs.setline(3, '{{{1')
+    helpers.funcs.setline(4, 'line 2')
+    feed("j")
+    screen:expect([[
+      {7:+ }{5:  1 +--  2 lines: ·························}|
+      {7:+ }{5:  0 ^+--  2 lines: ·························}|
+      {7:  }{1:~                                          }|
+      {7:  }{1:~                                          }|
+      {7:  }{1:~                                          }|
+      {7:  }{1:~                                          }|
+      {7:  }{1:~                                          }|
+      :set foldcolumn=2                            |
+    ]])
+  end)
+
   it("works with multibyte text", function()
     -- Currently the only allowed value of 'maxcombine'
     eq(6, meths.get_option('maxcombine'))


### PR DESCRIPTION
#### vim-patch:8.1.0449: when 'rnu' is set folded lines are not displayed correctly

Problem:    When 'rnu' is set folded lines are not displayed correctly.
            (Vitaly Yashin)
Solution:   When only redrawing line numbers do draw folded lines.
            (closes vim/vim#3484)
https://github.com/vim/vim/commit/7701f308565fdc7b5096a6597d9c3b63de0bbcec


#### vim-patch:8.1.0450: build failure without the +fold feature

Problem:    Build failure without the +fold feature.
Solution:   Add #ifdef.
https://github.com/vim/vim/commit/0e9deefb4fb4f99d0ab90b21ca38260be26bf5de


This upstream patch fixes a conflict between relative line numbers and fold highlighting. Previously, relative line numbers would update on a cursor movement and overwrite fold highlighting in the line number columns. Other operations can cause the fold highlighting to overwrite the line number styles. Together, this causes the highlighting in the line number columns to flicker back and forth while editing.

The second commit (8.1.0450) has no effect (as it adds a feature ifdef that no longer exists in neovim and modifies a variable that is not used again), but it has been included for completeness.

To observe the effect of these commits, create a file `Xtest_folds_with_rnu` with the following contents:

```
set fdm=marker rnu foldcolumn=2
call setline(1, ["{{{1", "nline 1", "{{{1", "line 2"])
```

and then call `nvim -S Xtest_folds_with_rnu` and press `j` (i.e. the cursor down key); observe that the fold highlighting disappears.