### PR TITLE
screen: make update_screen() the only entry point for redrawing

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1452,21 +1452,24 @@ ins_redraw (
     }
   }
 
-  if (must_redraw)
-    update_screen(0);
-  else if (clear_cmdline || redraw_cmdline)
-    showmode();                 /* clear cmdline and show mode */
   if ((conceal_update_lines
        && (conceal_old_cursor_line != conceal_new_cursor_line
            || conceal_cursor_line(curwin)))
       || need_cursor_line_redraw) {
-    if (conceal_old_cursor_line != conceal_new_cursor_line)
-      update_single_line(curwin, conceal_old_cursor_line);
-    update_single_line(curwin, conceal_new_cursor_line == 0
-        ? curwin->w_cursor.lnum : conceal_new_cursor_line);
+    if (conceal_old_cursor_line != conceal_new_cursor_line) {
+      redrawWinline(curwin, conceal_old_cursor_line);
+    }
+    redrawWinline(curwin, conceal_new_cursor_line == 0
+                  ? curwin->w_cursor.lnum : conceal_new_cursor_line);
     curwin->w_valid &= ~VALID_CROW;
   }
-  showruler(FALSE);
+
+  if (must_redraw) {
+    update_screen(0);
+  } else if (clear_cmdline || redraw_cmdline) {
+    showmode();  // clear cmdline and show mode
+  }
+  showruler(false);
   setcursor();
   emsg_on_display = FALSE;      /* may remove error message now */
 }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -482,25 +482,6 @@ void update_screen(int type)
 
 }
 
-// Prepare for updating one or more windows.
-// Caller must check for "updating_screen" already set to avoid recursiveness.
-static void update_prepare(void)
-{
-  updating_screen = true;
-  start_search_hl();
-}
-
-// Finish updating one or more windows.
-static void update_finish(void)
-{
-  if (redraw_cmdline) {
-    showmode();
-  }
-
-  end_search_hl();
-  updating_screen = false;
-}
-
 /*
  * Return TRUE if the cursor line in window "wp" may be concealed, according
  * to the 'concealcursor' option.
@@ -535,39 +516,6 @@ void conceal_check_cursor_line(void)
      * without concealing. */
     curs_columns(TRUE);
   }
-}
-
-void update_single_line(win_T *wp, linenr_T lnum)
-{
-  int row;
-  int j;
-
-  // Don't do anything if the screen structures are (not yet) valid.
-  if (linebuf_char == NULL || updating_screen) {
-    return;
-  }
-
-  if (lnum >= wp->w_topline && lnum < wp->w_botline
-      && foldedCount(wp, lnum, &win_foldinfo) == 0) {
-    update_prepare();
-
-    row = 0;
-    for (j = 0; j < wp->w_lines_valid; ++j) {
-      if (lnum == wp->w_lines[j].wl_lnum) {
-        init_search_hl(wp);
-        prepare_search_hl(wp, lnum);
-        update_window_hl(wp, false);
-        // allocate window grid if not already
-        win_grid_alloc(wp);
-        win_line(wp, lnum, row, row + wp->w_lines[j].wl_size, false, false);
-        break;
-      }
-      row += wp->w_lines[j].wl_size;
-    }
-
-    update_finish();
-  }
-  need_cursor_line_redraw = false;
 }
 
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3542,11 +3542,13 @@ void win_goto(win_T *wp)
 
   win_enter(wp, true);
 
-  /* Conceal cursor line in previous window, unconceal in current window. */
-  if (win_valid(owp) && owp->w_p_cole > 0 && !msg_scrolled)
-    update_single_line(owp, owp->w_cursor.lnum);
-  if (curwin->w_p_cole > 0 && !msg_scrolled)
-    need_cursor_line_redraw = TRUE;
+  // Conceal cursor line in previous window, unconceal in current window.
+  if (win_valid(owp) && owp->w_p_cole > 0 && !msg_scrolled) {
+    redrawWinline(owp, owp->w_cursor.lnum);
+  }
+  if (curwin->w_p_cole > 0 && !msg_scrolled) {
+    need_cursor_line_redraw = true;
+  }
 }
 
 


### PR DESCRIPTION
`update_single_line()` was only used for 'concealcursor'. But 'cursorline' has very similiar characteristics (redraw both lines on move cursor between lines) and works without its own special entry point to the redraw subsystem.  

Get rid of `update_prepare()` and `update_finish()`, and all issues from them and their callsites not being in sync with changes to `update_screen()`.

~~WIP because late afternoon hack, and needs a bit more manual testing for eventual missing redraws.~~