### PR TITLE
[RFC] Improve error message if provider is missing

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -22706,6 +22706,16 @@ static void script_host_eval(char *name, typval_T *argvars, typval_T *rettv)
 
 typval_T eval_call_provider(char *provider, char *method, list_T *arguments)
 {
+  if (!eval_has_provider(provider)) {
+    emsgf("E319: No \"%s\" provider found. Run \":checkhealth provider\"",
+          provider);
+    return (typval_T){
+      .v_type = VAR_NUMBER,
+      .v_lock = VAR_UNLOCKED,
+      .vval.v_number = (varnumber_T)0
+    };
+  }
+
   char func[256];
   int name_len = snprintf(func, sizeof(func), "provider#%s#Call", provider);
 

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -4028,12 +4028,7 @@ static void script_host_execute(char *name, exarg_T *eap)
     tv_list_append_number(args, (int)eap->line1);
     tv_list_append_number(args, (int)eap->line2);
 
-    if (!eval_has_provider(name)) {
-      emsgf("E319: No \"%s\" provider found. Run \":checkhealth provider\"",
-            name);
-    } else {
-      (void)eval_call_provider(name, "execute", args);
-    }
+    (void)eval_call_provider(name, "execute", args);
   }
 }
 

--- a/test/functional/provider/python3_spec.lua
+++ b/test/functional/provider/python3_spec.lua
@@ -11,8 +11,9 @@ do
   clear()
   if missing_provider('python3') then
     it(':python3 reports E319 if provider is missing', function()
-      expect_err([[Vim%(python3%):E319: No "python3" provider found.*]],
-                 command, 'python3 print("foo")')
+      local expected = [[Vim%(py3.*%):E319: No "python3" provider found.*]]
+      expect_err(expected, command, 'py3 print("foo")')
+      expect_err(expected, command, 'py3file foo')
     end)
     pending('Python 3 (or the pynvim module) is broken/missing', function() end)
     return

--- a/test/functional/provider/python_spec.lua
+++ b/test/functional/provider/python_spec.lua
@@ -19,8 +19,9 @@ do
   clear()
   if missing_provider('python') then
     it(':python reports E319 if provider is missing', function()
-      expect_err([[Vim%(python%):E319: No "python" provider found.*]],
-                 command, 'python print("foo")')
+      local expected = [[Vim%(py.*%):E319: No "python" provider found.*]]
+      expect_err(expected, command, 'py print("foo")')
+      expect_err(expected, command, 'pyfile foo')
     end)
     pending('Python 2 (or the pynvim module) is broken/missing', function() end)
     return

--- a/test/functional/provider/ruby_spec.lua
+++ b/test/functional/provider/ruby_spec.lua
@@ -19,8 +19,9 @@ do
   clear()
   if missing_provider('ruby') then
     it(':ruby reports E319 if provider is missing', function()
-      expect_err([[Vim%(ruby%):E319: No "ruby" provider found.*]],
-      command, 'ruby puts "foo"')
+      local expected = [[Vim%(ruby.*%):E319: No "ruby" provider found.*]]
+      expect_err(expected, command, 'ruby puts "foo"')
+      expect_err(expected, command, 'rubyfile foo')
     end)
     pending("Missing neovim RubyGem.", function() end)
     return


### PR DESCRIPTION
Move `has_eval_provider()` check to `eval_call_provider()` to make sure that
every code path calls it first.

Previously we would, when pynvim was missing, get a nice error message for
`:python3 1`, but not for `:py3file blah`.

References https://github.com/neovim/neovim/issues/9485