### PR TITLE
normal/edit: add missing "need_cursor_line_redraw = false"

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1462,6 +1462,7 @@ ins_redraw (
     redrawWinline(curwin, conceal_new_cursor_line == 0
                   ? curwin->w_cursor.lnum : conceal_new_cursor_line);
     curwin->w_valid &= ~VALID_CROW;
+    need_cursor_line_redraw = false;
   }
 
   if (must_redraw) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1263,6 +1263,7 @@ static void normal_redraw(NormalState *s)
 
     redrawWinline(curwin, s->conceal_new_cursor_line);
     curwin->w_valid &= ~VALID_CROW;
+    need_cursor_line_redraw = false;
   }
 
   if (VIsual_active) {


### PR DESCRIPTION
Add missing `need_cursor_line_redraw = false` to avoid superfluous redraws. 

[vim-patch:8.1.0726: redrawing specifically for conceal feature](https://github.com/vim/vim/commit/535d5b653a1eddf49ee11dc9639c5355ef023301)