### PR TITLE
CI/codecov: Avoid "fail" status for non-PR

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,9 +13,12 @@ coverage:
 
   status:
     project: yes
+      default:
+        threshold: 1
     patch:
       default:
         threshold: 1
+        only_pulls: true
     changes: no
 
 parsers:


### PR DESCRIPTION
Purpose of codecov is to:

1. show a web UI of lines that need coverage
2. sanity-check PRs
3. show a pretty badge on README

codecov (and/or gcov) is not reliable enough to allow it to cause
a "red" status in the `master` branch CI history.