### PR TITLE
redraw: share more code between cursorline and conceal redraws

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -918,10 +918,6 @@ EXTERN disptick_T display_tick INIT(= 0);
  * cursor position in Insert mode. */
 EXTERN linenr_T spell_redraw_lnum INIT(= 0);
 
-/* Set when the cursor line needs to be redrawn. */
-EXTERN int need_cursor_line_redraw INIT(= FALSE);
-
-
 #ifdef USE_MCH_ERRMSG
 // Grow array to collect error messages in until they can be displayed.
 EXTERN garray_T error_ga INIT(= GA_EMPTY_INIT_VALUE);

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -105,14 +105,14 @@ void reset_cursorline(void)
 // Redraw when w_cline_row changes and 'relativenumber' or 'cursorline' is set.
 static void redraw_for_cursorline(win_T *wp)
 {
-  if ((wp->w_p_rnu || wp->w_p_cul)
+  if ((wp->w_p_rnu || win_cursorline_standout(wp))
       && (wp->w_valid & VALID_CROW) == 0
       && !pum_visible()) {
     if (wp->w_p_rnu) {
       // win_line() will redraw the number column only.
       redraw_win_later(wp, VALID);
     }
-    if (wp->w_p_cul) {
+    if (win_cursorline_standout(wp)) {
       if (wp->w_redr_type <= VALID && wp->w_last_cursorline != 0) {
         // "w_last_cursorline" may be outdated, worst case we redraw
         // too much.  This is optimized for moving the cursor around in
@@ -2207,7 +2207,7 @@ void do_check_cursorbind(void)
         int restart_edit_save = restart_edit;
         restart_edit = true;
         check_cursor();
-        if (curwin->w_p_cul || curwin->w_p_cuc) {
+        if (win_cursorline_standout(curwin) || curwin->w_p_cuc) {
           validate_cursor();
         }
         restart_edit = restart_edit_save;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3547,7 +3547,7 @@ void win_goto(win_T *wp)
     redrawWinline(owp, owp->w_cursor.lnum);
   }
   if (curwin->w_p_cole > 0 && !msg_scrolled) {
-    need_cursor_line_redraw = true;
+    redrawWinline(curwin, curwin->w_cursor.lnum);
   }
 }
 

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -741,10 +741,11 @@ describe('ui/mouse/input', function()
       screen:set_default_attr_ids({
         [0] = {bold=true, foreground=Screen.colors.Blue},
         c = { foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGray },
+        sm = {bold = true},
       })
       feed('ggdG')
 
-      feed_command('set concealcursor=n')
+      feed_command('set concealcursor=ni')
       feed_command('set nowrap')
       feed_command('set shiftwidth=2 tabstop=4 list listchars=tab:>-')
       feed_command('syntax match NonText "\\*" conceal')
@@ -972,6 +973,76 @@ describe('ui/mouse/input', function()
                                  |
       ]])
     end) -- level 2 - non wrapped
+
+    it('(level 2) click on non-wrapped lines (insert mode)', function()
+      feed_command('let &conceallevel=2', 'echo')
+
+      feed('<esc>i<LeftMouse><20,0>')
+      screen:expect([[
+        Section{0:>>--->--->---}^t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+        {c:>} 私は猫が大好き{0:>---}{c:X} ✨{0:>}|
+                                 |
+        {0:~                        }|
+        {0:~                        }|
+        {sm:-- INSERT --}             |
+      ]])
+
+      feed('<LeftMouse><14,1>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  ^t2 t3 t4   |
+        {c:>} 私は猫が大好き{0:>---}{c:X} ✨{0:>}|
+                                 |
+        {0:~                        }|
+        {0:~                        }|
+        {sm:-- INSERT --}             |
+      ]])
+
+      feed('<LeftMouse><18,1>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t^3 t4   |
+        {c:>} 私は猫が大好き{0:>---}{c:X} ✨{0:>}|
+                                 |
+        {0:~                        }|
+        {0:~                        }|
+        {sm:-- INSERT --}             |
+      ]])
+
+      feed('<LeftMouse><0,2>')  -- Weirdness
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+        {c:^>} 私は猫が大好き{0:>---}{c:X} ✨{0:>}|
+                                 |
+        {0:~                        }|
+        {0:~                        }|
+        {sm:-- INSERT --}             |
+      ]])
+
+      feed('<LeftMouse><8,2>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+        {c:>} 私は猫^が大好き{0:>---}{c:X} ✨{0:>}|
+                                 |
+        {0:~                        }|
+        {0:~                        }|
+        {sm:-- INSERT --}             |
+      ]])
+
+      feed('<LeftMouse><20,2>')
+      screen:expect([[
+        Section{0:>>--->--->---}t1   |
+        {0:>--->--->---}  t2 t3 t4   |
+        {c:>} 私は猫が大好き{0:>---}{c:^X} ✨{0:>}|
+                                 |
+        {0:~                        }|
+        {0:~                        }|
+        {sm:-- INSERT --}             |
+      ]])
+    end) -- level 2 - non wrapped (insert mode)
 
     it('(level 2) click on wrapped lines', function()
       feed_command('let &conceallevel=2', 'let &wrap=1', 'echo')

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -12,7 +12,11 @@ describe('Screen', function()
     screen:attach()
     screen:set_default_attr_ids( {
       [0] = {bold=true, foreground=Screen.colors.Blue},
-      [1] = {foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGray}
+      [1] = {foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGray},
+      [2] = {bold = true, reverse = true},
+      [3] = {reverse = true},
+      [4] = {bold = true},
+      [5] = {background = Screen.colors.Yellow},
     } )
   end)
 
@@ -329,4 +333,494 @@ describe('Screen', function()
       ]])
     end)
   end) -- conceallevel
+
+
+  describe("cursor movement", function()
+    before_each(function()
+      command("syn keyword concealy barf conceal cchar=b")
+      command("set cole=2")
+      feed('5Ofoo barf bar barf eggs<esc>')
+      screen:expect([[
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo barf bar barf egg^s                               |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+
+    end)
+
+    it('between windows', function()
+      command("split")
+      screen:expect([[
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo barf bar barf egg^s                               |
+                                                             |
+        {2:[No Name] [+]                                        }|
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {3:[No Name] [+]                                        }|
+                                                             |
+      ]])
+      feed('<c-w>w')
+
+      screen:expect([[
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {3:[No Name] [+]                                        }|
+        foo {1:b} bar {1:b} eggs                                     |
+        foo barf bar barf egg^s                               |
+                                                             |
+        {2:[No Name] [+]                                        }|
+                                                             |
+      ]])
+    end)
+
+    it('in insert mode', function()
+      feed('i')
+      screen:expect([[
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo barf bar barf egg^s                               |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {4:-- INSERT --}                                         |
+      ]])
+
+      feed('<up>')
+      screen:expect([[
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo barf bar barf egg^s                               |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {4:-- INSERT --}                                         |
+      ]])
+    end)
+
+    it('between modes cocu=iv', function()
+      command('set cocu=iv')
+      feed('gg')
+      screen:expect([[
+        ^foo barf bar barf eggs                               |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+
+      feed('i')
+      screen:expect([[
+        ^foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {4:-- INSERT --}                                         |
+      ]])
+
+      feed('<esc>')
+      screen:expect([[
+        ^foo barf bar barf eggs                               |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+
+      feed('v')
+      screen:expect([[
+        ^foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {4:-- VISUAL --}                                         |
+      ]])
+
+      feed('<esc>')
+      screen:expect([[
+        ^foo barf bar barf eggs                               |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+
+    end)
+
+    it('between modes cocu=n', function()
+      command('set cocu=n')
+      feed('gg')
+      screen:expect([[
+        ^foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+
+      feed('i')
+      screen:expect([[
+        ^foo barf bar barf eggs                               |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {4:-- INSERT --}                                         |
+      ]])
+
+      feed('<esc>')
+      screen:expect([[
+        ^foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+
+
+      feed('v')
+      screen:expect([[
+        ^foo barf bar barf eggs                               |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {4:-- VISUAL --}                                         |
+      ]])
+
+      feed('<esc>')
+      screen:expect([[
+        ^foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+    end)
+
+    it('and open line', function()
+      feed('o')
+      screen:expect([[
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        ^                                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {4:-- INSERT --}                                         |
+      ]])
+    end)
+
+    it('and open line cocu=i', function()
+      command('set cocu=i')
+      feed('o')
+      screen:expect([[
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        ^                                                     |
+                                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {4:-- INSERT --}                                         |
+      ]])
+    end)
+
+    describe('with incsearch', function()
+      before_each(function()
+        command('set incsearch hlsearch')
+        feed('2GA x<esc>3GA xy<esc>gg')
+        screen:expect([[
+          ^foo barf bar barf eggs                               |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo {1:b} bar {1:b} eggs xy                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+                                                               |
+        ]])
+      end)
+
+      it('cocu=', function()
+        feed('/')
+        screen:expect([[
+          foo barf bar barf eggs                               |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo {1:b} bar {1:b} eggs xy                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          /^                                                    |
+        ]])
+
+        feed('x')
+        screen:expect([[
+          foo {1:b} bar {1:b} eggs                                     |
+          foo barf bar barf eggs {3:x}                             |
+          foo {1:b} bar {1:b} eggs {5:x}y                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          /x^                                                   |
+        ]])
+
+        feed('y')
+        screen:expect([[
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo barf bar barf eggs {3:xy}                            |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          /xy^                                                  |
+        ]])
+
+        feed('<c-w>')
+        screen:expect([[
+          foo barf bar barf eggs                               |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo {1:b} bar {1:b} eggs xy                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          /^                                                    |
+        ]])
+      end)
+
+      it('cocu=c', function()
+        command('set cocu=c')
+
+        feed('/')
+        -- NB: we don't do this redraw. Probably best to still skip it,
+        -- to avoid annoying distraction from the cmdline
+        screen:expect([[
+          foo barf bar barf eggs                               |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo {1:b} bar {1:b} eggs xy                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          /^                                                    |
+        ]])
+
+        feed('x')
+        screen:expect([[
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs {3:x}                                   |
+          foo {1:b} bar {1:b} eggs {5:x}y                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          /x^                                                   |
+        ]])
+
+        feed('y')
+        screen:expect([[
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo {1:b} bar {1:b} eggs {3:xy}                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          /xy^                                                  |
+        ]])
+
+        feed('<c-w>')
+        screen:expect([[
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo {1:b} bar {1:b} eggs xy                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          /^                                                    |
+        ]])
+
+        feed('<esc>')
+        screen:expect([[
+          ^foo barf bar barf eggs                               |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo {1:b} bar {1:b} eggs xy                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+                                                               |
+        ]])
+      end)
+
+      it('cocu=n', function()
+        command('set cocu=n')
+        screen:expect([[
+          ^foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo {1:b} bar {1:b} eggs xy                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+                                                               |
+        ]])
+
+        feed('/')
+        -- NB: we don't do this redraw. Probably best to still skip it,
+        -- to avoid annoying distraction from the cmdline
+        screen:expect([[
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo {1:b} bar {1:b} eggs xy                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          /^                                                    |
+        ]])
+
+        feed('x')
+        screen:expect([[
+          foo {1:b} bar {1:b} eggs                                     |
+          foo barf bar barf eggs {3:x}                             |
+          foo {1:b} bar {1:b} eggs {5:x}y                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          /x^                                                   |
+        ]])
+
+        feed('<c-w>')
+        screen:expect([[
+          foo barf bar barf eggs                               |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo {1:b} bar {1:b} eggs xy                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+          /^                                                    |
+        ]])
+
+        feed('<esc>')
+        screen:expect([[
+          ^foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs x                                   |
+          foo {1:b} bar {1:b} eggs xy                                  |
+          foo {1:b} bar {1:b} eggs                                     |
+          foo {1:b} bar {1:b} eggs                                     |
+                                                               |
+          {0:~                                                    }|
+          {0:~                                                    }|
+          {0:~                                                    }|
+                                                               |
+        ]])
+      end)
+    end)
+  end)
 end)


### PR DESCRIPTION
Followup to #9484.
There is various places where 'conceallevel' and 'concealcursor' necessitates additional redraws. This tries to separate the different cases and handle each accordingly:

- share code with 'cursorline' for the common case: vertical move of cursor within the same window (concealcursor not active)
- improve the logic for managing 'concealcursor' and switching modes: test for the case where the new mode behaves differently from the last one.
- clarify the special case for horizontal movement within a line when 'concealcursor' is active, now there is an if-statement only for this and not hidden in larger check mostly for the first point.
- keep the special case for moving between windows as is.

NB: there might still remain glitches. I will add more tests tomorrow (and fix if needed).

NB2: the third point is especially interesting. I plan to reuse the same logic to support virtualtext in the middle of a line (drawing the text I can do, but I have never managed to get cursor position right. Now I think I understand how conceal does it...)