### PR TITLE
anticonceal (virtual text occupying horizontal space)

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1515,8 +1515,9 @@ static void ins_redraw(bool ready)
     curbuf->b_changed_invalid = false;
   }
 
-  if (curwin->w_p_cole > 0 && conceal_cursor_line(curwin)
-      && conceal_cursor_moved) {
+  // TODO: NO!
+  if ((curwin->w_p_cole > 0 && conceal_cursor_line(curwin)
+      && conceal_cursor_moved) || curwin->w_cursor.lnum == 3) {
     redrawWinline(curwin, curwin->w_cursor.lnum);
   }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1289,7 +1289,8 @@ static void normal_redraw(NormalState *s)
   // If the cursor moves horizontally when 'concealcursor' is active, then the
   // current line needs to be redrawn in order to calculate the correct
   // cursor position.
-  if (curwin->w_p_cole > 0 && conceal_cursor_line(curwin)) {
+  if ((curwin->w_p_cole > 0 && conceal_cursor_line(curwin))
+      || curwin->w_cursor.lnum == 3) {
     redrawWinline(curwin, curwin->w_cursor.lnum);
   }
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2112,6 +2112,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
   int win_col_offset = 0;               // offset for window columns
 
   char_u buf_fold[FOLD_TEXT_LEN + 1];   // Hold value returned by get_foldtext
+  bool do_anticonceal = true;
 
   bool area_active = false;
 
@@ -2143,6 +2144,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
                                         ///< force wrapping
   int vcol_off        = 0;              ///< offset for concealed characters
   int did_wcol        = false;
+  int extratext       = lnum == 3;
   int match_conc      = 0;              ///< cchar for match functions
   int old_boguscols = 0;
 #define VCOL_HLC (vcol - vcol_off)
@@ -2994,6 +2996,20 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
           line_attr = cul_attr;
         }
       }
+    }
+
+    if (lnum == 3 && v == 10 && do_anticonceal) {
+      p_extra = (char_u *)"TEST";
+      c_extra = NUL;
+      n_extra = 4;
+      vcol -= 4; // TODO: this seems awful. But it works?
+      //col += n_extra;
+      //vcol_off -= n_extra;
+      //boguscols -= n_extra;
+      n_attr = 4;
+      extra_attr = win_hl_attr(wp, HLF_E);
+      p_extra_free = NULL;
+      do_anticonceal = false;
     }
 
     // When still displaying '$' of change command, stop at cursor
@@ -3932,11 +3948,12 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
       }
     }  // end of printing from buffer content
 
+
     /* In the cursor line and we may be concealing characters: correct
      * the cursor column when we reach its position. */
     if (!did_wcol && draw_state == WL_LINE
         && wp == curwin && lnum == wp->w_cursor.lnum
-        && conceal_cursor_line(wp)
+        && (conceal_cursor_line(wp) || extratext)
         && (int)wp->w_virtcol <= vcol + n_skip) {
       if (wp->w_p_rl) {
         wp->w_wcol = grid->Columns - col + boguscols - 1;


### PR DESCRIPTION
More of TODO than WIP to be honest, but at least "conceptual" preview of something that can become a generalization of virttext, where virtual text also can be placed in the middle of a line an not only at the end. When working on #9492 I finally understood the remaining missing pieces how horizontal cursor movement/tracking works with conceal, and general virttext can be understood as the the inverse of conceal: we shift vcols to the right rather than the left on the screen. 

This currently hard codes some virtual text at line 3 column 10. `h` `l` etc cursor movement and mouse clicks should be handled properly. Proper implementation would really need tracking of horizontal changes to marks, so further work will be scheduled after the initial extmark merge #5031.

Also an open question is how to deal with extra needed vertical space. Should virttext be truncated, or should the line be allowed to grow vertically due to virtual text? The later sounds more ideal, though this will differ with conceal behaviour, and might break some invariants.

One could even go so far and allow vcols to change, though that could be a larger and more risky endeavour. But on the other hand flexible vcols might be something we want anyway, so the text rendering of an external UI can affect what `gj` and `gk` does, and not only vim's hard coded calculation for how much space text should take on screen.