### PR TITLE
pvscheck.sh: Fix download URL

### DIFF
--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -384,8 +384,8 @@ run_analysis() {(
 detect_url() {
   local url="${1:-detect}"
   if test "$url" = detect ; then
-    curl --silent -L 'https://www.viva64.com/en/pvs-studio-download-linux/' \
-    | grep -o 'https\{0,1\}://[^"<>]\{1,\}/pvs-studio[^/"<>]*\.tgz' \
+    curl --silent -L 'https://www.viva64.com/en/pvs-studio-download/' \
+    | grep -o 'https\{0,1\}://[^"<>]\{1,\}/pvs-studio[^/"<>]*-x86_64\.tgz' \
     || echo FAILED
   else
     printf '%s' "$url"


### PR DESCRIPTION
- old URL redirects to https://www.viva64.com/en/pvs-studio-download/
- page now contains tgz files for macOS and Linux; the pattern must
  match only the Linux URL