### PR TITLE
WIP: complete_update()

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2487,8 +2487,9 @@ void set_completion(colnr_T startcol, list_T *list)
 
 void update_completion(colnr_T startcol, list_T *list)
 {
-  // If already doing completions stop it.
+  // If already doing completions, fallback to complete().
   if (ctrl_x_mode == 0) {
+    set_completion(startcol, list);
     return;
   }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2489,7 +2489,6 @@ void update_completion(colnr_T startcol, list_T *list)
 {
   // If already doing completions stop it.
   if (ctrl_x_mode == 0) {
-    set_completion(startcol, list);
     return;
   }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2485,13 +2485,14 @@ void set_completion(colnr_T startcol, list_T *list)
 }
 
 
-void update_completion(list_T *list)
+void update_completion(colnr_T startcol, list_T *list)
 {
   // If already doing completions stop it.
   if (ctrl_x_mode == 0) {
     return;
   }
 
+  compl_length = (int)curwin->w_cursor.col - (int)startcol;
   /* compl_pattern doesn't need to be set */
   compl_orig_text = vim_strnsave(get_cursor_line_ptr() + compl_col,
                                  compl_length);
@@ -2631,7 +2632,7 @@ void ins_compl_show_pum(void)
   do_cmdline_cmd("if exists('g:loaded_matchparen')|3match none|endif");
 
   /* Update the screen before drawing the popup menu over it. */
-  //update_screen(0);
+  update_screen(0);
 
   if (compl_match_array == NULL) {
     array_changed = true;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2485,14 +2485,13 @@ void set_completion(colnr_T startcol, list_T *list)
 }
 
 
-void update_completion(colnr_T startcol, list_T *list)
+void update_completion(list_T *list)
 {
   // If already doing completions stop it.
   if (ctrl_x_mode == 0) {
     return;
   }
 
-  compl_length = (int)curwin->w_cursor.col - (int)startcol;
   /* compl_pattern doesn't need to be set */
   compl_orig_text = vim_strnsave(get_cursor_line_ptr() + compl_col,
                                  compl_length);
@@ -2632,7 +2631,7 @@ void ins_compl_show_pum(void)
   do_cmdline_cmd("if exists('g:loaded_matchparen')|3match none|endif");
 
   /* Update the screen before drawing the popup menu over it. */
-  update_screen(0);
+  //update_screen(0);
 
   if (compl_match_array == NULL) {
     array_changed = true;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7569,12 +7569,17 @@ static void f_complete_update(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   if (!undo_allowed())
     return;
 
-  if (argvars[0].v_type != VAR_LIST) {
+  if (argvars[1].v_type != VAR_LIST) {
     EMSG(_(e_invarg));
     return;
   }
 
-  update_completion(argvars[0].vval.v_list);
+  const colnr_T startcol = tv_get_number_chk(&argvars[0], NULL);
+  if (startcol <= 0) {
+    return;
+  }
+
+  update_completion(startcol - 1, argvars[1].vval.v_list);
 }
 
 /*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7569,17 +7569,12 @@ static void f_complete_update(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   if (!undo_allowed())
     return;
 
-  if (argvars[1].v_type != VAR_LIST) {
+  if (argvars[0].v_type != VAR_LIST) {
     EMSG(_(e_invarg));
     return;
   }
 
-  const colnr_T startcol = tv_get_number_chk(&argvars[0], NULL);
-  if (startcol <= 0) {
-    return;
-  }
-
-  update_completion(startcol - 1, argvars[1].vval.v_list);
+  update_completion(argvars[0].vval.v_list);
 }
 
 /*

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7555,6 +7555,34 @@ static void f_complete_check(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 }
 
 /*
+ * "complete_update()" function
+ */
+static void f_complete_update(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  if ((State & INSERT) == 0) {
+    EMSG(_("E785: complete() can only be used in Insert mode"));
+    return;
+  }
+
+  /* Check for undo allowed here, because if something was already inserted
+   * the line was already saved for undo and this check isn't done. */
+  if (!undo_allowed())
+    return;
+
+  if (argvars[1].v_type != VAR_LIST) {
+    EMSG(_(e_invarg));
+    return;
+  }
+
+  const colnr_T startcol = tv_get_number_chk(&argvars[0], NULL);
+  if (startcol <= 0) {
+    return;
+  }
+
+  update_completion(startcol - 1, argvars[1].vval.v_list);
+}
+
+/*
  * "confirm(message, buttons[, default [, type]])" function
  */
 static void f_confirm(typval_T *argvars, typval_T *rettv, FunPtr fptr)

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -64,6 +64,7 @@ return {
     complete={args=2},
     complete_add={args=1},
     complete_check={},
+    complete_update={args=2},
     confirm={args={1, 4}},
     copy={args=1},
     cos={args=1, func="float_op_wrapper", data="&cos"},

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -64,7 +64,7 @@ return {
     complete={args=2},
     complete_add={args=1},
     complete_check={},
-    complete_update={args=2},
+    complete_update={args=1},
     confirm={args={1, 4}},
     copy={args=1},
     cos={args=1, func="float_op_wrapper", data="&cos"},

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -64,7 +64,7 @@ return {
     complete={args=2},
     complete_add={args=1},
     complete_check={},
-    complete_update={args=1},
+    complete_update={args=2},
     confirm={args={1, 4}},
     copy={args=1},
     cos={args=1, func="float_op_wrapper", data="&cos"},


### PR DESCRIPTION
I need `complete_update()` API for auto completion plugins implementation.
The API does not close the current popup menu instead of `complete()`.

Note:  The complete position must be same.

It is the WIP and Code of concept.

It is partly works, but it is broken.
For example: `<C-y>` and `<C-e>` behavior.

https://github.com/Shougo/deoplete.nvim/pull/918