### PR TITLE
[RFC] Fix bug recovering non-existent swp

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -839,7 +839,7 @@ void ml_recover(void)
                                     mf_open() will consume "fname_used"! */
   mfp = mf_open(fname_used, O_RDONLY);
   fname_used = p;
-  if (mfp->mf_fd < 0) {
+  if (mfp == NULL || mfp->mf_fd < 0) {
     EMSG2(_("E306: Cannot open %s"), fname_used);
     goto theend;
   }


### PR DESCRIPTION
Addresses #9503 by checking if a pointer is null before accessing the memory it points to.