### PR TITLE
lua: expose full interface of vim.inspect and add test

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -152,14 +152,6 @@ local function gsplit(s, sep, plain)
   end
 end
 
-local inspect = (function()
-  local f
-  return function(...)
-    if f == nil then f = require('vim.inspect') end
-    return f(...)
-  end
-end)()
-
 local function split(s,sep,plain)
   local t={} for c in gsplit(s, sep, plain) do table.insert(t,c) end
   return t
@@ -195,6 +187,13 @@ deepcopy = function(orig)
   return deepcopy_funcs[type(orig)](orig)
 end
 
+local function __index(table, key)
+  if key == "inspect" then
+    table.inspect = require("vim.inspect")
+    return table.inspect
+  end
+end
+
 local module = {
   _update_package_paths = _update_package_paths,
   _os_proc_children = _os_proc_children,
@@ -204,7 +203,10 @@ local module = {
   split = split,
   gsplit = gsplit,
   deepcopy = deepcopy,
-  inspect = inspect,
 }
+
+setmetatable(module, {
+  __index = __index
+})
 
 return module

--- a/test/functional/lua/utility_functions_spec.lua
+++ b/test/functional/lua/utility_functions_spec.lua
@@ -176,6 +176,16 @@ describe("vim.inspect", function()
     eq('2', inspect(2))
     eq('{+a = {+b = 1+}+}',
        inspect({ a = { b = 1 } }, { newline = '+', indent = '' }))
+
+    -- special value vim.inspect.KEY works
+    eq('{  KEY_a = "x",  KEY_b = "y"}', meths.execute_lua([[
+      return vim.inspect({a="x", b="y"}, {newline = '', process = function(item, path)
+        if path[#path] == vim.inspect.KEY then
+          return 'KEY_'..item
+        end
+        return item
+      end})
+    ]], {}))
   end)
 end)
 


### PR DESCRIPTION
The current approach of lazy-loading `inspect` breaks the interface, fix it and add a test.

Implement lazy loading for vim.submodule, this would be over-engineering for `inspect` only, but we expect to use this solution also for more and larger modules.