### PR TITLE
screen: don't unconditionally clear messages on window scroll

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6274,10 +6274,6 @@ static int win_do_lines(win_T *wp, int row, int line_count, int del)
     return OK;
   }
 
-  // when scrolling, the message on the command line should be cleared,
-  // otherwise it will stay there forever.
-  check_for_delay(false);
-  clear_cmdline = true;
   int retval;
   if (del) {
     retval = grid_del_lines(&wp->w_grid, row, line_count,

--- a/test/functional/ex_cmds/cmd_map_spec.lua
+++ b/test/functional/ex_cmds/cmd_map_spec.lua
@@ -279,7 +279,7 @@ describe('mappings with <Cmd>', function()
       {1:~                                                                }|
       {1:~                                                                }|
       {1:~                                                                }|
-                                                                       |
+      :normal ,x                                                       |
     ]])
 
     eq('Vim:E492: Not an editor command: nosuchcommand', exc_exec("normal ,f"))
@@ -294,7 +294,7 @@ describe('mappings with <Cmd>', function()
       {1:~                                                                }|
       {1:~                                                                }|
       {1:~                                                                }|
-                                                                       |
+      :normal ,x                                                       |
     ]])
 
     feed_command(':%d')

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -662,7 +662,7 @@ describe('ui/mouse/input', function()
                                                            |
       {0:~                                                    }|
       {4:[No Name] [+]                                        }|
-                                                           |
+      :vsp                                                 |
     ]])
     feed('<ScrollWheelUp><27,0>')
     screen:expect([[
@@ -679,7 +679,7 @@ describe('ui/mouse/input', function()
                                                            |
       {0:~                                                    }|
       {4:[No Name] [+]                                        }|
-                                                           |
+      :vsp                                                 |
     ]])
     feed('<ScrollWheelUp><27,7><ScrollWheelUp>')
     screen:expect([[
@@ -696,7 +696,7 @@ describe('ui/mouse/input', function()
       many                                                 |
       lines                                                |
       {4:[No Name] [+]                                        }|
-                                                           |
+      :vsp                                                 |
     ]])
   end)
 


### PR DESCRIPTION
In vim, the terminal implementation of scrolling a window might mess up the cmdline. To keep it simple, cmdline was always cleared for any window scroll. In nvim, where safe scrolling is implemented in the TUI layer, this problem doesn't exist.

Clearing the message on scrolling, when we not do it e.g when switching tabs is a bit weird, as the former is a much smaller context change.

A vim patch introduced the possibility to avoid the cmdline clear for redraws caused by async events. This case will now trivially be covered by always avoiding the clear, if possible.

[vim-patch: 8.0.0592: if a job writes to a buffer screen is not updated](https://github.com/vim/vim/commit/29ae377ea7039874337bc79ace9ab2b37b9056e5)