### PR TITLE
[RFC] Fix nvim_err_write to not truncate error information when triggering exceptions and populating v:errmsg

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1737,8 +1737,8 @@ Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight,
 /// @param to_err   true: message is an error (uses `emsg` instead of `msg`)
 static void write_msg(String message, bool to_err)
 {
-  static size_t out_pos = 0, err_pos = 0;
-  static char out_line_buf[LINE_BUFFER_SIZE], err_line_buf[LINE_BUFFER_SIZE];
+  static size_t out_pos = 0;
+  static char out_line_buf[LINE_BUFFER_SIZE];
 
 #define PUSH_CHAR(i, pos, line_buf, msg) \
   if (message.data[i] == NL || pos == LINE_BUFFER_SIZE - 1) { \
@@ -1751,10 +1751,13 @@ static void write_msg(String message, bool to_err)
   line_buf[pos++] = message.data[i];
 
   ++no_wait_return;
-  for (uint32_t i = 0; i < message.size; i++) {
-    if (to_err) {
-      PUSH_CHAR(i, err_pos, err_line_buf, emsg);
-    } else {
+  if (to_err) {
+    // Do not split error messages up into separate lines because then v:errmsg will only
+    // be populated with the first line
+    emsg(message.data);
+  }
+  else {
+    for (uint32_t i = 0; i < message.size; i++) {
       PUSH_CHAR(i, out_pos, out_line_buf, msg);
     }
   }


### PR DESCRIPTION
This is my first time poking around in the code but thought I'd throw this out for consideration anyway.  Error messages that occur in RPC calls are at least displayed without being truncated with this change.

Without this change, if you execute `call nvim_command('py3 foo.bar()')` it will only output the first line of the error:

`Vim(return):Traceback (most recent call last):`

With this change it outputs the full message:

`Vim(return):Traceback (most recent call last):^@^@ File "<string>", line 1, in <module>^@^@NameError: name 'foo' is not defined`

Which is much more useful.

Related:
#7388
#7969
#9350
