### PR TITLE
Lua: format multiline messages / emsgf_multiline()

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19593,7 +19593,7 @@ void ex_echo(exarg_T *eap)
         msg_puts_attr(" ", echo_attr);
       }
       char *tofree = encode_tv2echo(&rettv, NULL);
-      msg_echo_show(tofree, echo_attr);
+      msg_multiline_attr(tofree, echo_attr);
       xfree(tofree);
     }
     tv_clear(&rettv);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19593,24 +19593,7 @@ void ex_echo(exarg_T *eap)
         msg_puts_attr(" ", echo_attr);
       }
       char *tofree = encode_tv2echo(&rettv, NULL);
-      const char *p = tofree;
-      if (p != NULL) {
-        for (; *p != NUL && !got_int; ++p) {
-          if (*p == '\n' || *p == '\r' || *p == TAB) {
-            if (*p != TAB && needclr) {
-              /* remove any text still there from the command */
-              msg_clr_eos();
-              needclr = false;
-            }
-            msg_putchar_attr((uint8_t)(*p), echo_attr);
-          } else {
-            int i = (*mb_ptr2len)((const char_u *)p);
-
-            (void)msg_outtrans_len_attr((char_u *)p, i, echo_attr);
-            p += i - 1;
-          }
-        }
-      }
+      msg_echo_show(tofree, echo_attr);
       xfree(tofree);
     }
     tv_clear(&rettv);

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -50,7 +50,7 @@ static void nlua_error(lua_State *const lstate, const char *const msg)
   size_t len;
   const char *const str = lua_tolstring(lstate, -1, &len);
 
-  emsgf(msg, (int)len, str);
+  emsgf_echo(msg, (int)len, str);
 
   lua_pop(lstate, 1);
 }

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -50,7 +50,7 @@ static void nlua_error(lua_State *const lstate, const char *const msg)
   size_t len;
   const char *const str = lua_tolstring(lstate, -1, &len);
 
-  emsgf_echo(msg, (int)len, str);
+  emsgf_multiline(msg, (int)len, str);
 
   lua_pop(lstate, 1);
 }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -173,23 +173,9 @@ bool msg_attr_skip(const char *s, const int attr, int *const call)
   return false;
 }
 
-
-bool msg_echo_attr_keep(const char *s, const int attr, const int keep)
+void msg_echo_show(const char *s, int attr)
   FUNC_ATTR_NONNULL_ALL
 {
-  static int entered = 0;
-
-  if (msg_attr_skip(s, attr, &entered)) {
-    return true;
-  }
-
-  msg_start();
-
-  char *const buf = (char *)msg_strtrunc((char_u *)s, false);
-  if (buf != NULL) {
-    s = buf;
-  }
-
   const char *next_spec = s;
 
   while (next_spec != NULL) {
@@ -212,6 +198,25 @@ bool msg_echo_attr_keep(const char *s, const int attr, const int keep)
   if (*s != NUL) {
     msg_outtrans_attr((char_u *)s, attr);
   }
+}
+
+bool msg_echo_attr_keep(const char *s, const int attr, const int keep)
+  FUNC_ATTR_NONNULL_ALL
+{
+  static int entered = 0;
+
+  if (msg_attr_skip(s, attr, &entered)) {
+    return true;
+  }
+
+  msg_start();
+
+  char *const buf = (char *)msg_strtrunc((char_u *)s, false);
+  if (buf != NULL) {
+    s = buf;
+  }
+
+  msg_echo_show(s, attr);
 
   msg_clr_eos();
   const bool retval = msg_end();

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -78,6 +78,7 @@ typedef struct msg_hist {
   struct msg_hist *next;  ///< Next message.
   char_u *msg;            ///< Message text.
   int attr;               ///< Message highlighting.
+  bool multiline;         ///< Multiline message.
 } MessageHistoryEntry;
 
 /// First message

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2155,7 +2155,7 @@ win_found:
       } else if (!msg_scrolled && shortmess(SHM_OVERALL)) {
         msg_scroll = false;
       }
-      msg_attr_keep(IObuff, 0, true);
+      msg_attr_keep(IObuff, 0, true, false);
       msg_scroll = (int)i;
     }
   } else {

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -318,6 +318,10 @@ describe('API', function()
       eq({false, 'Error executing lua: [string "<nvim>"]:1: '..
                  "attempt to call global 'bork' (a nil value)"},
          meth_pcall(meths.execute_lua, 'bork()', {}))
+
+      eq({false, 'Error executing lua: [string "<nvim>"]:1: '..
+                 "did\nthe\nfail"},
+         meth_pcall(meths.execute_lua, 'error("did\\nthe\\nfail")', {}))
     end)
   end)
 


### PR DESCRIPTION
Continuation of  #7969, rebased and tried to simplify the code by removing some duplicate code. History and "keep" logic will need to be made aware so the message can be reprinted consistently. (Should also check `ext_message` support after #7466 is rebased on top of this).

Currently works with lua errors (try `:lua require('nosuchpackage')`) and `rpcrequest` errors (such as `:py3` tracebacks, but pynvim master is needed, I will do a pynvim release in the weekend). The full error will be stored in  `v:errmsg`, not only the first line.

Related: #9519, It might make sense to use this for all `nvim_err_write` calls.

Closes #7388