### PR TITLE
vim-patch:8.1.0768: updating completions may cause the popup menu to …

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2499,7 +2499,8 @@ static void ins_compl_upd_pum(void)
 
   if (compl_match_array != NULL) {
     h = curwin->w_cline_height;
-    update_screen(0);
+    // Update the screen later, before drawing the popup menu over it.
+    pum_call_update_screen();
     if (h != curwin->w_cline_height)
       ins_compl_del_pum();
   }
@@ -2569,8 +2570,8 @@ void ins_compl_show_pum(void)
   /* Dirty hard-coded hack: remove any matchparen highlighting. */
   do_cmdline_cmd("if exists('g:loaded_matchparen')|3match none|endif");
 
-  /* Update the screen before drawing the popup menu over it. */
-  update_screen(0);
+  // Update the screen later, before drawing the popup menu over it.
+  pum_call_update_screen();
 
   if (compl_match_array == NULL) {
     array_changed = true;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -161,7 +161,7 @@ static bool conceal_cursor_used = false;
 /*
  * Redraw the current window later, with update_screen(type).
  * Set must_redraw only if not already set to a higher value.
- * e.g. if must_redraw is CLEAR, type NOT_VALID will do nothing.
+ * E.g. if must_redraw is CLEAR, type NOT_VALID will do nothing.
  */
 void redraw_later(int type)
 {


### PR DESCRIPTION
…flicker

Problem:    Updating completions may cause the popup menu to flicker.
Solution:   Avoid updating the text below the popup menu before drawing the
            popup menu.
https://github.com/vim/vim/commit/ae654385dfb2ae4c1d70789d1dce3676dba4dfbc