### PR TITLE
[WIP] Add complete_mode()

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2920,7 +2920,7 @@ complete_check()				*complete_check()*
 							*complete_mode()*
 complete_mode()
 		Return a string that indicates the current completion mode.
-		Note: It does not check popup menu is visible.
+		Note: It does not check whether popup menu is visible.
 
 		   keyword	Keyword completion(|i_CTRL-X_CTRL-N|)
 		   ctrl_x	Just press |i_CTRL-X|

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2007,6 +2007,7 @@ col({expr})			Number	column nr of cursor or mark
 complete({startcol}, {matches}) none	set Insert mode completion
 complete_add({expr})		Number	add completion match
 complete_check()		Number	check for key typed during completion
+complete_mode()			String	current completion mode
 confirm({msg} [, {choices} [, {default} [, {type}]]])
 				Number	number of choice picked by user
 copy({expr})			any	make a shallow copy of {expr}
@@ -2915,6 +2916,29 @@ complete_check()				*complete_check()*
 		zero otherwise.
 		Only to be used by the function specified with the
 		'completefunc' option.
+
+							*complete_mode()*
+complete_mode([expr])
+		Return a string that indicates the current completion mode.
+		Note: It does not check popup menu is visible.
+
+		   keyword	Keyword completion(|i_CTRL-X_CTRL-N|)
+		   ctrl_x	Just press |i_CTRL-X|
+		   whole_line	Whole lines(|i_CTRL-X_CTRL-L|)
+		   files	File names(|i_CTRL-X_CTRL-F|)
+		   tags		Tags(|i_CTRL-X_CTRL-]|)
+		   path_defines
+				Definition completion(|i_CTRL-X_CTRL-D|)
+		   path_patterns
+		   		Include completion(|i_CTRL-X_CTRL-I|)
+		   dictionary	Dictionary(|i_CTRL-X_CTRL-K|)
+		   thesaurus	Thesaurus(|i_CTRL-X_CTRL-T|)
+		   cmdline	Vim Command line completion(|i_CTRL-X_CTRL-V|)
+		   function	User defined completion(|i_CTRL-X_CTRL-U|)
+		   omni		Omni completion(|i_CTRL-X_CTRL-O|)
+		   spell	Spelling suggestions(|i_CTRL-X_s|)
+		   eval		|complete()| completion
+		   unknown	Other internal modes
 
 						*confirm()*
 confirm({msg} [, {choices} [, {default} [, {type}]]])

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2918,7 +2918,7 @@ complete_check()				*complete_check()*
 		'completefunc' option.
 
 							*complete_mode()*
-complete_mode([expr])
+complete_mode()
 		Return a string that indicates the current completion mode.
 		Note: It does not check popup menu is visible.
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2488,54 +2488,51 @@ void set_completion(colnr_T startcol, list_T *list)
 // complete_mode() implementation.
 const char *ins_compl_mode(void)
 {
-  char_u *mode = NULL;
+  const char *mode = "unknown";
   switch (ctrl_x_mode) {
     case 0:
       // Keyword completion
-      mode = xstrdup("keyword");
+      mode = "keyword";
       break;
     case CTRL_X_NOT_DEFINED_YET:
       // Just press Ctrl_X
-      mode = xstrdup("ctrl_x");
+      mode = "ctrl_x";
       break;
     case CTRL_X_WHOLE_LINE:
-      mode = xstrdup("whole_line");
+      mode = "whole_line";
       break;
     case CTRL_X_FILES:
-      mode = xstrdup("files");
+      mode = "files";
       break;
     case CTRL_X_TAGS:
-      mode = xstrdup("tags");
+      mode = "tags";
       break;
     case CTRL_X_PATH_PATTERNS:
-      mode = xstrdup("path_patterns");
+      mode = "path_patterns";
       break;
     case CTRL_X_PATH_DEFINES:
-      mode = xstrdup("path_defines");
+      mode = "path_defines";
       break;
     case CTRL_X_DICTIONARY:
-      mode = xstrdup("dictionary");
+      mode = "dictionary";
       break;
     case CTRL_X_THESAURUS:
-      mode = xstrdup("thesaurus");
+      mode = "thesaurus";
       break;
     case CTRL_X_CMDLINE:
-      mode = xstrdup("cmdline");
+      mode = "cmdline";
       break;
     case CTRL_X_FUNCTION:
-      mode = xstrdup("function");
+      mode = "function";
       break;
     case CTRL_X_OMNI:
-      mode = xstrdup("omni");
+      mode = "omni";
       break;
     case CTRL_X_SPELL:
-      mode = xstrdup("spell");
+      mode = "spell";
       break;
     case CTRL_X_EVAL:
-      mode = xstrdup("eval");
-      break;
-    default:
-      mode = xstrdup("unknown");
+      mode = "eval";
       break;
   }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2486,7 +2486,7 @@ void set_completion(colnr_T startcol, list_T *list)
 
 
 // complete_mode() implementation.
-char *ins_compl_mode()
+char *ins_compl_mode(void)
 {
   char *mode = NULL;
   switch (ctrl_x_mode) {

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2486,9 +2486,9 @@ void set_completion(colnr_T startcol, list_T *list)
 
 
 // complete_mode() implementation.
-char *ins_compl_mode(void)
+const char *ins_compl_mode(void)
 {
-  char *mode = NULL;
+  char_u *mode = NULL;
   switch (ctrl_x_mode) {
     case 0:
       // Keyword completion

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2485,6 +2485,64 @@ void set_completion(colnr_T startcol, list_T *list)
 }
 
 
+// complete_mode() implementation.
+char *ins_compl_mode()
+{
+  char *mode = NULL;
+  switch (ctrl_x_mode) {
+    case 0:
+      // Keyword completion
+      mode = xstrdup("keyword");
+      break;
+    case CTRL_X_NOT_DEFINED_YET:
+      // Just press Ctrl_X
+      mode = xstrdup("ctrl_x");
+      break;
+    case CTRL_X_WHOLE_LINE:
+      mode = xstrdup("whole_line");
+      break;
+    case CTRL_X_FILES:
+      mode = xstrdup("files");
+      break;
+    case CTRL_X_TAGS:
+      mode = xstrdup("tags");
+      break;
+    case CTRL_X_PATH_PATTERNS:
+      mode = xstrdup("path_patterns");
+      break;
+    case CTRL_X_PATH_DEFINES:
+      mode = xstrdup("path_defines");
+      break;
+    case CTRL_X_DICTIONARY:
+      mode = xstrdup("dictionary");
+      break;
+    case CTRL_X_THESAURUS:
+      mode = xstrdup("thesaurus");
+      break;
+    case CTRL_X_CMDLINE:
+      mode = xstrdup("cmdline");
+      break;
+    case CTRL_X_FUNCTION:
+      mode = xstrdup("function");
+      break;
+    case CTRL_X_OMNI:
+      mode = xstrdup("omni");
+      break;
+    case CTRL_X_SPELL:
+      mode = xstrdup("spell");
+      break;
+    case CTRL_X_EVAL:
+      mode = xstrdup("eval");
+      break;
+    default:
+      mode = xstrdup("unknown");
+      break;
+  }
+
+  return mode;
+}
+
+
 /* "compl_match_array" points the currently displayed list of entries in the
  * popup menu.  It is NULL when there is no popup menu. */
 static pumitem_T *compl_match_array = NULL;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7557,8 +7557,7 @@ static void f_complete_check(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 // "complete_mode()" function
 static void f_complete_mode(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  char *mode = ins_compl_mode();
-  rettv->vval.v_string = (char_u *)mode;
+  rettv->vval.v_string = ins_compl_mode();
   rettv->v_type = VAR_STRING;
 }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7555,6 +7555,16 @@ static void f_complete_check(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 }
 
 /*
+ * "complete_mode()" function
+ */
+static void f_complete_mode(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  char *mode = ins_compl_mode();
+  rettv->vval.v_string = (char_u *)mode;
+  rettv->v_type = VAR_STRING;
+}
+
+/*
  * "confirm(message, buttons[, default [, type]])" function
  */
 static void f_confirm(typval_T *argvars, typval_T *rettv, FunPtr fptr)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7557,7 +7557,7 @@ static void f_complete_check(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 // "complete_mode()" function
 static void f_complete_mode(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  rettv->vval.v_string = ins_compl_mode();
+  rettv->vval.v_string = (char_u *)xstrdup(ins_compl_mode());
   rettv->v_type = VAR_STRING;
 }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7554,9 +7554,7 @@ static void f_complete_check(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   RedrawingDisabled = saved;
 }
 
-/*
- * "complete_mode()" function
- */
+// "complete_mode()" function
 static void f_complete_mode(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   char *mode = ins_compl_mode();

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -64,6 +64,7 @@ return {
     complete={args=2},
     complete_add={args=1},
     complete_check={},
+    complete_mode={},
     confirm={args={1, 4}},
     copy={args=1},
     cos={args=1, func="float_op_wrapper", data="&cos"},

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -712,4 +712,37 @@ func Test_popup_and_window_resize()
   bwipe!
 endfunc
 
+func Test_popup_complete_mode()
+  new
+  for [key, expected] in [
+        \ ["\<C-X>", 'ctrl_x'],
+        \ ["\<C-X>\<C-N>", 'keyword'],
+        \ ["\<C-X>\<C-L>", 'whole_line'],
+        \ ["\<C-X>\<C-F>", 'files'],
+        \ ["\<C-X>\<C-]>", 'tags'],
+        \ ["\<C-X>\<C-D>", 'path_defines'],
+        \ ["\<C-X>\<C-I>", 'path_patterns'],
+        \ ["\<C-X>\<C-K>", 'dictionary'],
+        \ ["\<C-X>\<C-T>", 'thesaurus'],
+        \ ["\<C-X>\<C-V>", 'cmdline'],
+        \ ["\<C-X>\<C-U>", 'function'],
+        \ ["\<C-X>\<C-O>", 'omni'],
+        \ ["\<C-X>s", 'spell'],
+        \]
+    call feedkeys(key . "\<C-r>=complete_mode()\<CR>", 'tx')
+    call assert_equal(expected, getline('.'))
+    %d
+  endfor
+
+  function! s:complTestEval() abort
+    call complete(1, ['source', 'soundfold'])
+    return ''
+  endfunction
+  inoremap <F5>  <C-R>=s:complTestEval()<CR>
+  call feedkeys("\<F5>\<C-r>=complete_mode()\<CR>", 'tx')
+  call assert_equal('eval', getline('.'))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -717,10 +717,10 @@ func Test_popup_complete_mode()
   inoremap <f5> <c-r>=complete_mode()<cr>
   call writefile([
         \ '!rm	src/testdir/amiga.vim	/^cmap !rm !Delete all$/;"	m',
-        \], 'dummy.txt')
-  setlocal tags=dummy.txt
-  setlocal dictionary=dummy.txt
-  setlocal thesaurus=dummy.txt
+        \], 'Xdummy.txt')
+  setlocal tags=Xdummy.txt
+  setlocal dictionary=Xdummy.txt
+  setlocal thesaurus=Xdummy.txt
   setlocal omnifunc=syntaxcomplete#Complete
   setlocal completefunc=syntaxcomplete#Complete
   setlocal spell
@@ -743,17 +743,19 @@ func Test_popup_complete_mode()
     call assert_equal(expected, getline('.'))
     %d
   endfor
-  call delete('dummy.txt')
+  call delete('Xdummy.txt')
 
-  function! s:complTestEval() abort
+  func s:complTestEval() abort
     call complete(1, ['source', 'soundfold'])
     return ''
-  endfunction
-  inoremap <F6>  <c-r>=s:complTestEval()<CR>
+  endfunc
+  inoremap <f6>  <c-r>=s:complTestEval()<CR>
   call feedkeys("i\<f6>\<f5>\<ESC>", 'tx')
   call assert_equal('eval', getline('.'))
 
   bwipe!
+  iunmap <f5>
+  iunmap <f6>
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -714,6 +714,16 @@ endfunc
 
 func Test_popup_complete_mode()
   new
+  inoremap <f5> <c-r>=complete_mode()<cr>
+  call writefile([
+        \ '!rm	src/testdir/amiga.vim	/^cmap !rm !Delete all$/;"	m',
+        \], 'dummy.txt')
+  setlocal tags=dummy.txt
+  setlocal dictionary=dummy.txt
+  setlocal thesaurus=dummy.txt
+  setlocal omnifunc=syntaxcomplete#Complete
+  setlocal completefunc=syntaxcomplete#Complete
+  setlocal spell
   for [key, expected] in [
         \ ["\<C-X>", 'ctrl_x'],
         \ ["\<C-X>\<C-N>", 'keyword'],
@@ -729,17 +739,18 @@ func Test_popup_complete_mode()
         \ ["\<C-X>\<C-O>", 'omni'],
         \ ["\<C-X>s", 'spell'],
         \]
-    call feedkeys(key . "\<C-r>=complete_mode()\<CR>", 'tx')
+    call feedkeys("i" . key . "\<f5>\<ESC>", 'tx')
     call assert_equal(expected, getline('.'))
     %d
   endfor
+  call delete('dummy.txt')
 
   function! s:complTestEval() abort
     call complete(1, ['source', 'soundfold'])
     return ''
   endfunction
-  inoremap <F5>  <C-R>=s:complTestEval()<CR>
-  call feedkeys("\<F5>\<C-r>=complete_mode()\<CR>", 'tx')
+  inoremap <F6>  <c-r>=s:complTestEval()<CR>
+  call feedkeys("i\<f6>\<f5>\<ESC>", 'tx')
   call assert_equal('eval', getline('.'))
 
   bwipe!


### PR DESCRIPTION
I have added `complete_mode()` API for deoplete.

Note: I will send the PR for Vim8 later.  ~~So unit tests are not added now.~~

Usage: https://github.com/Shougo/deoplete.nvim/pull/920