### PR TITLE
[RFC] options: make 'listchars' and 'fillchars' local to window

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3662,11 +3662,26 @@ A jump table for the options with a short description can be found at |Q_op|.
 			omitted, there is no extra character at the end of the
 			line.
 							*lcs-tab*
-	  tab:xy	Two characters to be used to show a tab.  The first
-			char is used once.  The second char is repeated to
-			fill the space that the tab normally occupies.
-			"tab:>-" will show a tab that takes four spaces as
-			">---".  When omitted, a tab is show as ^I.
+	  tab:xy[z]	Two or three characters to be used to show a tab.
+			The third character is optional.
+
+	  tab:xy	The 'x' is always used, then 'y' as many times as will
+			fit.  Thus "tab:>-" displays:
+				>
+				>-
+				>--
+				etc.
+
+	  tab:xyz	The 'z' is always used, then 'x' is prepended, and
+			then 'y' is used as many times as will fit.  Thus
+			"tab:<->" displays:
+				>
+				<>
+				<->
+				<-->
+				etc.
+
+			When "tab:" is omitted, a tab is shown as ^I.
 							*lcs-space*
 	  space:c	Character to show for a space.  When omitted, spaces
 			are left blank.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3653,7 +3653,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'listchars'* *'lcs'*
 'listchars' 'lcs'	string	(default: "tab:> ,trail:-,nbsp:+"
 				 Vi default: "eol:$")
-			global
+			local to window
 	Strings to use in 'list' mode and for the |:list| command.  It is a
 	comma separated list of string settings.
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -37,8 +37,8 @@ a complete and centralized reference of those differences.
 - 'display' defaults to "lastline,msgsep"
 - 'encoding' is UTF-8 (cf. 'fileencoding' for file-content encoding)
 - 'fillchars' defaults (in effect) to "vert:│,fold:·"
-- 'fsync' is disabled
 - 'formatoptions' defaults to "tcqj"
+- 'fsync' is disabled
 - 'history' defaults to 10000 (the maximum)
 - 'hlsearch' is set by default
 - 'incsearch' is set by default
@@ -184,9 +184,10 @@ Options:
   'cpoptions' flags: |cpo-_|
   'display' flag `msgsep` to minimize scrolling when showing messages
   'guicursor' works in the terminal
-  'fillchars' flags: `msgsep` (see 'display' above)
-	      and `eob` for |hl-EndOfBuffer| marker
+  'fillchars' local to window. flags: `msgsep` (see 'display' above) and `eob`
+              for |hl-EndOfBuffer| marker
   'inccommand' shows interactive results for |:substitute|-like commands
+  'listchars' local to window
   'scrollback'
   'statusline' supports unlimited alignment sections
   'tabline' %@Func@foo%X can call any function on mouse-click

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3676,7 +3676,7 @@ int build_stl_str_hl(
     {
       // In list mode virtcol needs to be recomputed
       colnr_T virtcol = wp->w_virtcol;
-      if (wp->w_p_list && lcs_tab1 == NUL) {
+      if (wp->w_p_list && wp->w_p_lcs_chars.tab1 == NUL) {
         wp->w_p_list = FALSE;
         getvcol(wp, &wp->w_cursor, NULL, &virtcol, NULL);
         wp->w_p_list = TRUE;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3677,9 +3677,9 @@ int build_stl_str_hl(
       // In list mode virtcol needs to be recomputed
       colnr_T virtcol = wp->w_virtcol;
       if (wp->w_p_list && wp->w_p_lcs_chars.tab1 == NUL) {
-        wp->w_p_list = FALSE;
+        wp->w_p_list = false;
         getvcol(wp, &wp->w_cursor, NULL, &virtcol, NULL);
-        wp->w_p_list = TRUE;
+        wp->w_p_list = true;
       }
       ++virtcol;
       // Don't display %V if it's the same as %c.

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1016,6 +1016,7 @@ struct window_S {
     int space;
     int tab1;                       ///< first tab character
     int tab2;                       ///< second tab character
+    int tab3;                       ///< third tab character
     int trail;
     int conceal;
   } w_p_lcs_chars;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -248,6 +248,10 @@ typedef struct {
 # define w_p_scl w_onebuf_opt.wo_scl    // 'signcolumn'
   char_u *wo_winhl;
 # define w_p_winhl w_onebuf_opt.wo_winhl    // 'winhighlight'
+  char_u *wo_fcs;
+# define w_p_fcs w_onebuf_opt.wo_fcs    // 'fillchars'
+  char_u *wo_lcs;
+# define w_p_lcs w_onebuf_opt.wo_lcs    // 'listchars'
 
   LastSet wo_scriptID[WV_COUNT];        // SIDs for window-local options
 # define w_p_scriptID w_onebuf_opt.wo_scriptID
@@ -1002,6 +1006,30 @@ struct window_S {
   linenr_T w_old_visual_lnum;       ///< last known start of visual part
   colnr_T w_old_visual_col;         ///< last known start of visual part
   colnr_T w_old_curswant;           ///< last known value of Curswant
+
+  // 'listchars' characters. Defaults set in set_chars_option().
+  struct {
+    int eol;
+    int ext;
+    int prec;
+    int nbsp;
+    int space;
+    int tab1;                       ///< first tab character
+    int tab2;                       ///< second tab character
+    int trail;
+    int conceal;
+  } w_p_lcs_chars;
+
+  // 'fillchars' characters. Defaults set in set_chars_option().
+  struct {
+    int stl;
+    int stlnc;
+    int vert;
+    int fold;
+    int diff;
+    int msgsep;
+    int eob;
+  } w_p_fcs_chars;
 
   /*
    * "w_topline", "w_leftcol" and "w_skipcol" specify the offsets for

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -750,7 +750,7 @@ int vim_strnsize(char_u *s, int len)
 /// @return Number of characters.
 #define RET_WIN_BUF_CHARTABSIZE(wp, buf, p, col) \
   if (*(p) == TAB && (!(wp)->w_p_list || wp->w_p_lcs_chars.tab1)) { \
-    const int ts = (int) (buf)->b_p_ts; \
+    const int ts = (int)(buf)->b_p_ts; \
     return (ts - (int)(col % ts)); \
   } else { \
     return ptr2cells(p); \

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -749,7 +749,7 @@ int vim_strnsize(char_u *s, int len)
 ///
 /// @return Number of characters.
 #define RET_WIN_BUF_CHARTABSIZE(wp, buf, p, col) \
-  if (*(p) == TAB && (!(wp)->w_p_list || lcs_tab1)) { \
+  if (*(p) == TAB && (!(wp)->w_p_list || wp->w_p_lcs_chars.tab1)) { \
     const int ts = (int) (buf)->b_p_ts; \
     return (ts - (int)(col % ts)); \
   } else { \
@@ -1149,7 +1149,7 @@ static int win_nolbr_chartabsize(win_T *wp, char_u *s, colnr_T col, int *headp)
 {
   int n;
 
-  if ((*s == TAB) && (!wp->w_p_list || lcs_tab1)) {
+  if ((*s == TAB) && (!wp->w_p_list || wp->w_p_lcs_chars.tab1)) {
     n = (int)wp->w_buffer->b_p_ts;
     return n - (col % n);
   }
@@ -1241,7 +1241,7 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor,
   // When 'list', 'linebreak', 'showbreak' and 'breakindent' are not set
   // use a simple loop.
   // Also use this when 'list' is set but tabs take their normal size.
-  if ((!wp->w_p_list || (lcs_tab1 != NUL))
+  if ((!wp->w_p_list || (wp->w_p_lcs_chars.tab1 != NUL))
       && !wp->w_p_lbr
       && (*p_sbr == NUL)
       && !wp->w_p_bri ) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16425,7 +16425,9 @@ static void f_synconcealed(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     if ((syntax_flags & HL_CONCEAL) && curwin->w_p_cole < 3) {
       cchar = syn_get_sub_char();
       if (cchar == NUL && curwin->w_p_cole == 1) {
-        cchar = (lcs_conceal == NUL) ? ' ' : lcs_conceal;
+        cchar = (curwin->w_p_lcs_chars.conceal == NUL)
+          ? ' '
+          : curwin->w_p_lcs_chars.conceal;
       }
       if (cchar != NUL) {
         utf_char2bytes(cchar, str);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -842,26 +842,6 @@ extern char_u *compiled_sys;
  * directory is not a local directory, globaldir is NULL. */
 EXTERN char_u   *globaldir INIT(= NULL);
 
-// 'listchars' characters. Defaults are overridden in set_chars_option().
-EXTERN int lcs_eol INIT(= '$');
-EXTERN int lcs_ext INIT(= NUL);
-EXTERN int lcs_prec INIT(= NUL);
-EXTERN int lcs_nbsp INIT(= NUL);
-EXTERN int lcs_space INIT(= NUL);
-EXTERN int lcs_tab1 INIT(= NUL);
-EXTERN int lcs_tab2 INIT(= NUL);
-EXTERN int lcs_trail INIT(= NUL);
-EXTERN int lcs_conceal INIT(= ' ');
-
-// 'fillchars' characters. Defaults are overridden in set_chars_option().
-EXTERN int fill_stl INIT(= ' ');
-EXTERN int fill_stlnc INIT(= ' ');
-EXTERN int fill_vert INIT(= 9474);  // │
-EXTERN int fill_fold INIT(= 183);   // ·
-EXTERN int fill_diff INIT(= '-');
-EXTERN int fill_msgsep INIT(= ' ');
-EXTERN int fill_eob INIT(= '~');
-
 /* Whether 'keymodel' contains "stopsel" and "startsel". */
 EXTERN int km_stopsel INIT(= FALSE);
 EXTERN int km_startsel INIT(= FALSE);

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -61,7 +61,7 @@ int get_indent_str(char_u *ptr, int ts, int list)
   for (; *ptr; ++ptr) {
     // Count a tab for what it is worth.
     if (*ptr == TAB) {
-      if (!list || lcs_tab1) {  // count a tab for what it is worth
+      if (!list || curwin->w_p_lcs_chars.tab1) {  // count a tab for what it is worth
         count += ts - (count % ts);
       } else {
         // In list mode, when tab is not set, count screen char width

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -61,7 +61,8 @@ int get_indent_str(char_u *ptr, int ts, int list)
   for (; *ptr; ++ptr) {
     // Count a tab for what it is worth.
     if (*ptr == TAB) {
-      if (!list || curwin->w_p_lcs_chars.tab1) {  // count a tab for what it is worth
+      if (!list || curwin->w_p_lcs_chars.tab1) {
+        // count a tab for what it is worth
         count += ts - (count % ts);
       } else {
         // In list mode, when tab is not set, count screen char width

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1527,7 +1527,7 @@ void msg_prt_line(char_u *s, int list)
     list = TRUE;
 
   /* find start of trailing whitespace */
-  if (list && lcs_trail) {
+  if (list && curwin->w_p_lcs_chars.trail) {
     trail = s + STRLEN(s);
     while (trail > s && ascii_iswhite(trail[-1]))
       --trail;
@@ -1535,7 +1535,7 @@ void msg_prt_line(char_u *s, int list)
 
   /* output a space for an empty line, otherwise the line will be
    * overwritten */
-  if (*s == NUL && !(list && lcs_eol != NUL))
+  if (*s == NUL && !(list && curwin->w_p_lcs_chars.eol != NUL))
     msg_putchar(' ');
 
   while (!got_int) {
@@ -1550,9 +1550,9 @@ void msg_prt_line(char_u *s, int list)
     } else if ((l = utfc_ptr2len(s)) > 1) {
       col += utf_ptr2cells(s);
       char buf[MB_MAXBYTES + 1];
-      if (lcs_nbsp != NUL && list
+      if (curwin->w_p_lcs_chars.nbsp != NUL && list
           && (utf_ptr2char(s) == 160 || utf_ptr2char(s) == 0x202f)) {
-        utf_char2bytes(lcs_nbsp, (char_u *)buf);
+        utf_char2bytes(curwin->w_p_lcs_chars.nbsp, (char_u *)buf);
         buf[utfc_ptr2len((char_u *)buf)] = NUL;
       } else {
         memmove(buf, s, (size_t)l);
@@ -1564,25 +1564,25 @@ void msg_prt_line(char_u *s, int list)
     } else {
       attr = 0;
       c = *s++;
-      if (c == TAB && (!list || lcs_tab1)) {
+      if (c == TAB && (!list || curwin->w_p_lcs_chars.tab1)) {
         /* tab amount depends on current column */
         n_extra = curbuf->b_p_ts - col % curbuf->b_p_ts - 1;
         if (!list) {
           c = ' ';
           c_extra = ' ';
         } else {
-          c = lcs_tab1;
-          c_extra = lcs_tab2;
+          c = curwin->w_p_lcs_chars.tab1;
+          c_extra = curwin->w_p_lcs_chars.tab2;
           attr = HL_ATTR(HLF_8);
         }
-      } else if (c == 160 && list && lcs_nbsp != NUL) {
-        c = lcs_nbsp;
+      } else if (c == 160 && list && curwin->w_p_lcs_chars.nbsp != NUL) {
+        c = curwin->w_p_lcs_chars.nbsp;
         attr = HL_ATTR(HLF_8);
-      } else if (c == NUL && list && lcs_eol != NUL) {
+      } else if (c == NUL && list && curwin->w_p_lcs_chars.eol != NUL) {
         p_extra = (char_u *)"";
         c_extra = NUL;
         n_extra = 1;
-        c = lcs_eol;
+        c = curwin->w_p_lcs_chars.eol;
         attr = HL_ATTR(HLF_AT);
         s--;
       } else if (c != NUL && (n = byte2cells(c)) > 1) {
@@ -1594,10 +1594,10 @@ void msg_prt_line(char_u *s, int list)
          * the same in plain text. */
         attr = HL_ATTR(HLF_8);
       } else if (c == ' ' && trail != NULL && s > trail) {
-        c = lcs_trail;
+        c = curwin->w_p_lcs_chars.trail;
         attr = HL_ATTR(HLF_8);
-      } else if (c == ' ' && list && lcs_space != NUL) {
-        c = lcs_space;
+      } else if (c == ' ' && list && curwin->w_p_lcs_chars.space != NUL) {
+        c = curwin->w_p_lcs_chars.space;
         attr = HL_ATTR(HLF_8);
       }
     }
@@ -1955,7 +1955,8 @@ static void msg_scroll_up(void)
   if (dy_flags & DY_MSGSEP) {
     if (msg_scrolled == 0) {
       grid_fill(&default_grid, Rows-p_ch-1, Rows-p_ch, 0, (int)Columns,
-                fill_msgsep, fill_msgsep, HL_ATTR(HLF_MSGSEP));
+                curwin->w_p_fcs_chars.msgsep, curwin->w_p_fcs_chars.msgsep,
+                HL_ATTR(HLF_MSGSEP));
     }
     int nscroll = MIN(msg_scrollsize()+1, Rows);
     grid_del_lines(&default_grid, Rows-nscroll, 1, Rows, 0, Columns);

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1523,20 +1523,22 @@ void msg_prt_line(char_u *s, int list)
   char_u      *trail = NULL;
   int l;
 
-  if (curwin->w_p_list)
-    list = TRUE;
-
-  /* find start of trailing whitespace */
-  if (list && curwin->w_p_lcs_chars.trail) {
-    trail = s + STRLEN(s);
-    while (trail > s && ascii_iswhite(trail[-1]))
-      --trail;
+  if (curwin->w_p_list) {
+    list = true;
   }
 
-  /* output a space for an empty line, otherwise the line will be
-   * overwritten */
-  if (*s == NUL && !(list && curwin->w_p_lcs_chars.eol != NUL))
+  // find start of trailing whitespace
+  if (list && curwin->w_p_lcs_chars.trail) {
+    trail = s + STRLEN(s);
+    while (trail > s && ascii_iswhite(trail[-1])) {
+      trail--;
+    }
+  }
+
+  // output a space for an empty line, otherwise the line will be overwritten
+  if (*s == NUL && !(list && curwin->w_p_lcs_chars.eol != NUL)) {
     msg_putchar(' ');
+  }
 
   while (!got_int) {
     if (n_extra > 0) {
@@ -1565,7 +1567,7 @@ void msg_prt_line(char_u *s, int list)
       attr = 0;
       c = *s++;
       if (c == TAB && (!list || curwin->w_p_lcs_chars.tab1)) {
-        /* tab amount depends on current column */
+        // tab amount depends on current column
         n_extra = curbuf->b_p_ts - col % curbuf->b_p_ts - 1;
         if (!list) {
           c = ' ';

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1282,12 +1282,11 @@ int plines_win_nofold(win_T *wp, linenr_T lnum)
     return 1;
   col = win_linetabsize(wp, s, (colnr_T)MAXCOL);
 
-  /*
-   * If list mode is on, then the '$' at the end of the line may take up one
-   * extra column.
-   */
-  if (wp->w_p_list && wp->w_p_lcs_chars.eol != NUL)
+  // If list mode is on, then the '$' at the end of the line may take up one
+  // extra column.
+  if (wp->w_p_list && wp->w_p_lcs_chars.eol != NUL) {
     col += 1;
+  }
 
   /*
    * Add column offset for 'number', 'relativenumber' and 'foldcolumn'.
@@ -1336,7 +1335,8 @@ int plines_win_col(win_T *wp, linenr_T lnum, long column)
   // screen position of the TAB.  This only fixes an error when the TAB wraps
   // from one screen line to the next (when 'columns' is not a multiple of
   // 'ts') -- webb.
-  if (*s == TAB && (State & NORMAL) && (!wp->w_p_list || wp->w_p_lcs_chars.tab1)) {
+  if (*s == TAB && (State & NORMAL)
+      && (!wp->w_p_list || wp->w_p_lcs_chars.tab1)) {
     col += win_lbr_chartabsize(wp, line, s, col, NULL) - 1;
   }
 

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1286,7 +1286,7 @@ int plines_win_nofold(win_T *wp, linenr_T lnum)
    * If list mode is on, then the '$' at the end of the line may take up one
    * extra column.
    */
-  if (wp->w_p_list && lcs_eol != NUL)
+  if (wp->w_p_list && wp->w_p_lcs_chars.eol != NUL)
     col += 1;
 
   /*
@@ -1336,7 +1336,7 @@ int plines_win_col(win_T *wp, linenr_T lnum, long column)
   // screen position of the TAB.  This only fixes an error when the TAB wraps
   // from one screen line to the next (when 'columns' is not a multiple of
   // 'ts') -- webb.
-  if (*s == TAB && (State & NORMAL) && (!wp->w_p_list || lcs_tab1)) {
+  if (*s == TAB && (State & NORMAL) && (!wp->w_p_list || wp->w_p_lcs_chars.tab1)) {
     col += win_lbr_chartabsize(wp, line, s, col, NULL) - 1;
   }
 

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -731,7 +731,7 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
       } else {
         if (!(row > 0 && ptr == ptr_row_offset)
             && (wp->w_p_cole == 1 || (wp->w_p_cole == 2
-                                      && (lcs_conceal != NUL
+                                      && (wp->w_p_lcs_chars.conceal != NUL
                                           || syn_get_sub_char() != NUL)))) {
           // At least one placeholder character will be displayed.
           decr();

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3405,7 +3405,7 @@ static char_u *set_chars_option(win_T *wp, char_u **varp)
 {
   int round, i, len, entries;
   char_u *p, *s;
-  int c1, c2 = 0;
+  int c1 = 0, c2 = 0, c3 = 0;
 
   struct chars_tab {
     int     *cp;    ///< char value
@@ -3462,6 +3462,7 @@ static char_u *set_chars_option(win_T *wp, char_u **varp)
       }
       if (varp == &wp->w_p_lcs) {
         wp->w_p_lcs_chars.tab1 = NUL;
+        wp->w_p_lcs_chars.tab3 = NUL;
       }
     }
     p = *varp;
@@ -3471,6 +3472,7 @@ static char_u *set_chars_option(win_T *wp, char_u **varp)
         if (STRNCMP(p, tab[i].name, len) == 0
             && p[len] == ':'
             && p[len + 1] != NUL) {
+          c1 = c2 = c3 = 0;
           s = p + len + 1;
 
           // TODO(bfredl): use schar_T representation and utfc_ptr2len
@@ -3488,12 +3490,20 @@ static char_u *set_chars_option(win_T *wp, char_u **varp)
             if (mb_char2cells(c2) > 1 || (c2len == 1 && c2 > 127)) {
               continue;
             }
+            if (!(*s == ',' || *s == NUL)) {
+              int c3len = utf_ptr2len(s);
+              c3 = mb_cptr2char_adv((const char_u **)&s);
+              if (mb_char2cells(c3) > 1 || (c3len == 1 && c3 > 127)) {
+                continue;
+              }
+            }
           }
           if (*s == ',' || *s == NUL) {
             if (round) {
               if (tab[i].cp == &wp->w_p_lcs_chars.tab2) {
                 wp->w_p_lcs_chars.tab1 = c1;
                 wp->w_p_lcs_chars.tab2 = c2;
+                wp->w_p_lcs_chars.tab3 = c3;
               } else if (tab[i].cp != NULL) {
                 *(tab[i].cp) = c1;
               }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3494,9 +3494,9 @@ static char_u *set_chars_option(win_T *wp, char_u **varp)
               if (tab[i].cp == &wp->w_p_lcs_chars.tab2) {
                 wp->w_p_lcs_chars.tab1 = c1;
                 wp->w_p_lcs_chars.tab2 = c2;
-              } else if (tab[i].cp != NULL)
+              } else if (tab[i].cp != NULL) {
                 *(tab[i].cp) = c1;
-
+              }
             }
             p = s;
             break;

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -486,7 +486,6 @@ EXTERN long     *p_linespace;   // 'linespace'
 EXTERN char_u   *p_lispwords;   // 'lispwords'
 EXTERN long p_ls;               // 'laststatus'
 EXTERN long p_stal;             // 'showtabline'
-EXTERN char_u   *p_lcs;         // 'listchars'
 
 EXTERN int p_lz;                // 'lazyredraw'
 EXTERN int p_lpl;               // 'loadplugins'
@@ -638,7 +637,6 @@ EXTERN long p_ul;               ///< 'undolevels'
 EXTERN long p_ur;               ///< 'undoreload'
 EXTERN long p_uc;               ///< 'updatecount'
 EXTERN long p_ut;               ///< 'updatetime'
-EXTERN char_u *p_fcs;           ///< 'fillchar'
 EXTERN char_u *p_shada;         ///< 'shada'
 EXTERN char_u *p_vdir;          ///< 'viewdir'
 EXTERN char_u *p_vop;           ///< 'viewoptions'
@@ -814,6 +812,8 @@ enum {
   , WV_WRAP
   , WV_SCL
   , WV_WINHL
+  , WV_FCS
+  , WV_LCS
   , WV_COUNT        // must be the last one
 };
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -806,11 +806,11 @@ return {
     },
     {
       full_name='fillchars', abbreviation='fcs',
-      type='string', list='onecomma', scope={'global'},
+      type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
       vi_def=true,
-      redraw={'all_windows'},
-      varname='p_fcs',
+      alloced=true,
+      redraw={'current_window'},
       defaults={if_true={vi=''}}
     },
     {
@@ -1425,11 +1425,11 @@ return {
     },
     {
       full_name='listchars', abbreviation='lcs',
-      type='string', list='onecomma', scope={'global'},
+      type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
       vim=true,
-      redraw={'all_windows'},
-      varname='p_lcs',
+      alloced=true,
+      redraw={'current_window'},
       defaults={if_true={vi="eol:$", vim="tab:> ,trail:-,nbsp:+"}}
     },
     {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1448,13 +1448,12 @@ static void win_update(win_T *wp)
       wp->w_botline = buf->b_ml.ml_line_count + 1;
       j = diff_check_fill(wp, wp->w_botline);
       if (j > 0 && !wp->w_botfill) {
-        /*
-         * Display filler lines at the end of the file
-         */
-        if (char2cells(wp->w_p_fcs_chars.diff) > 1)
+        // display filler lines at the end of the file
+        if (char2cells(wp->w_p_fcs_chars.diff) > 1) {
           i = '-';
-        else
+        } else {
           i = wp->w_p_fcs_chars.diff;
+        }
         if (row + j > wp->w_grid.Rows) {
           j = wp->w_grid.Rows - row;
         }
@@ -2042,25 +2041,26 @@ win_line (
     bool number_only                  // only update the number column
 )
 {
-  int c = 0;                            // init for GCC
-  long vcol = 0;                        // virtual column (for tabs)
-  long vcol_sbr = -1;                   // virtual column after showbreak
-  long vcol_prev = -1;                  // "vcol" of previous character
-  char_u      *line;                    // current line
-  char_u      *ptr;                     // current position in "line"
-  int row;                              // row in the window, excl w_winrow
-  ScreenGrid *grid = &wp->w_grid;       // grid specfic to the window
+  int c = 0;                          // init for GCC
+  long vcol = 0;                      // virtual column (for tabs)
+  long vcol_sbr = -1;                 // virtual column after showbreak
+  long vcol_prev = -1;                // "vcol" of previous character
+  char_u      *line;                  // current line
+  char_u      *ptr;                   // current position in "line"
+  int row;                            // row in the window, excl w_winrow
+  ScreenGrid *grid = &wp->w_grid;     // grid specfic to the window
 
-  char_u extra[18];                     /* line number and 'fdc' must fit in here */
-  int n_extra = 0;                      /* number of extra chars */
-  char_u      *p_extra = NULL;          /* string of extra chars, plus NUL */
-  char_u      *p_extra_free = NULL;     /* p_extra needs to be freed */
-  int c_extra = NUL;                    /* extra chars, all the same */
-  int extra_attr = 0;                   /* attributes when n_extra != 0 */
-  static char_u *at_end_str = (char_u *)"";   // used for p_extra when displaying
-                                              // curwin->w_p_lcs_chars.eol at end-of-line
-  int lcs_eol_one = wp->w_p_lcs_chars.eol;    // 'eol' until it's been used
-  int lcs_prec_todo = wp->w_p_lcs_chars.prec; // 'prec' until it's been used
+  char_u extra[18];                   // line number and 'fdc' must fit in here
+  int n_extra = 0;                    // number of extra chars
+  char_u      *p_extra = NULL;        // string of extra chars, plus NUL
+  char_u      *p_extra_free = NULL;   // p_extra needs to be freed
+  int c_extra = NUL;                  // extra chars, all the same
+  int extra_attr = 0;                 // attributes when n_extra != 0
+  static char_u *at_end_str = (char_u *)"";  // used for p_extra when displaying
+                                             // curwin->w_p_lcs_chars.eol at
+                                             // end-of-line
+  int lcs_eol_one = wp->w_p_lcs_chars.eol;     // 'eol'  until it's been used
+  int lcs_prec_todo = wp->w_p_lcs_chars.prec;  // 'prec' until it's been used
 
   /* saved "extra" items for when draw_state becomes WL_LINE (again) */
   int saved_n_extra = 0;
@@ -2792,11 +2792,12 @@ win_line (
       if (draw_state == WL_SBR - 1 && n_extra == 0) {
         draw_state = WL_SBR;
         if (filler_todo > 0) {
-          /* Draw "deleted" diff line(s). */
-          if (char2cells(wp->w_p_fcs_chars.diff) > 1)
+          // draw "deleted" diff line(s)
+          if (char2cells(wp->w_p_fcs_chars.diff) > 1) {
             c_extra = '-';
-          else
+          } else {
             c_extra = wp->w_p_fcs_chars.diff;
+          }
           if (wp->w_p_rl) {
             n_extra = col + 1;
           } else {
@@ -3406,7 +3407,8 @@ win_line (
             && (((c == 160
                   || (mb_utf8 && (mb_c == 160 || mb_c == 0x202f)))
                  && curwin->w_p_lcs_chars.nbsp)
-                || (c == ' ' && curwin->w_p_lcs_chars.space && ptr - line <= trailcol))) {
+                || (c == ' ' && curwin->w_p_lcs_chars.space
+                    && ptr - line <= trailcol))) {
           c = (c == ' ') ? wp->w_p_lcs_chars.space : wp->w_p_lcs_chars.nbsp;
           n_attr = 1;
           extra_attr = win_hl_attr(wp, HLF_0);
@@ -3467,7 +3469,8 @@ win_line (
               tab_len += vcol_off;
             }
             // boguscols before FIX_FOR_BOGUSCOLS macro from above.
-            if (wp->w_p_lcs_chars.tab1 && old_boguscols > 0 && n_extra > tab_len) {
+            if (wp->w_p_lcs_chars.tab1 && old_boguscols > 0
+                && n_extra > tab_len) {
               tab_len += n_extra - tab_len;
             }
 
@@ -3486,7 +3489,8 @@ win_line (
             for (i = 0; i < tab_len; i++) {
               utf_char2bytes(wp->w_p_lcs_chars.tab2, p);
               p += mb_char2len(wp->w_p_lcs_chars.tab2);
-              n_extra += mb_char2len(wp->w_p_lcs_chars.tab2) - (saved_nextra > 0 ? 1: 0);
+              n_extra += mb_char2len(wp->w_p_lcs_chars.tab2)
+                         - (saved_nextra > 0 ? 1: 0);
             }
             p_extra = p_extra_free;
 
@@ -3511,7 +3515,8 @@ win_line (
             // Make sure, the highlighting for the tab char will be
             // correctly set further below (effectively reverts the
             // FIX_FOR_BOGSUCOLS macro.
-            if (n_extra == tab_len + vc_saved && wp->w_p_list && wp->w_p_lcs_chars.tab1) {
+            if (n_extra == tab_len + vc_saved && wp->w_p_list
+                && wp->w_p_lcs_chars.tab1) {
               tab_len += vc_saved;
             }
           }
@@ -3858,7 +3863,8 @@ win_line (
 
         // Make sure alignment is the same regardless
         // if listchars=eol:X is used or not.
-        bool delay_virttext = wp->w_p_lcs_chars.eol == lcs_eol_one && eol_hl_off == 0;
+        bool delay_virttext = wp->w_p_lcs_chars.eol == lcs_eol_one
+                              && eol_hl_off == 0;
 
         if (wp->w_p_cuc) {
           rightmost_vcol = wp->w_virtcol;
@@ -3978,7 +3984,7 @@ win_line (
       break;
     }
 
-    /* line continues beyond line end */
+    // line continues beyond line end
     if (wp->w_p_lcs_chars.ext
         && !wp->w_p_wrap
         && filler_todo <= 0
@@ -4164,7 +4170,8 @@ win_line (
     if ((wp->w_p_rl ? (col < 0) : (col >= grid->Columns))
         && (*ptr != NUL
             || filler_todo > 0
-            || (wp->w_p_list && wp->w_p_lcs_chars.eol != NUL && p_extra != at_end_str)
+            || (wp->w_p_list && wp->w_p_lcs_chars.eol != NUL
+                && p_extra != at_end_str)
             || (n_extra != 0 && (c_extra != NUL || *p_extra != NUL)))
         ) {
       bool wrap = wp->w_p_wrap       // Wrapping enabled.
@@ -4227,13 +4234,15 @@ win_line (
       saved_char_attr = char_attr;
       n_extra = 0;
       lcs_prec_todo = wp->w_p_lcs_chars.prec;
-      if (filler_todo <= 0)
-        need_showbreak = TRUE;
-      --filler_todo;
-      /* When the filler lines are actually below the last line of the
-       * file, don't draw the line itself, break here. */
-      if (filler_todo == 0 && wp->w_botfill)
+      if (filler_todo <= 0) {
+        need_showbreak = true;
+      }
+      filler_todo--;
+      // When the filler lines are actually below the last line of the
+      // file, don't draw the line itself, break here.
+      if (filler_todo == 0 && wp->w_botfill) {
         break;
+      }
     }
 
   }     /* for every character in the line */
@@ -7001,12 +7010,12 @@ static void win_redr_ruler(win_T *wp, int always)
       off = 0;
     }
 
-    /* In list mode virtcol needs to be recomputed */
+    // In list mode virtcol needs to be recomputed
     colnr_T virtcol = wp->w_virtcol;
     if (wp->w_p_list && wp->w_p_lcs_chars.tab1 == NUL) {
-      wp->w_p_list = FALSE;
+      wp->w_p_list = false;
       getvvcol(wp, &wp->w_cursor, NULL, &virtcol, NULL);
-      wp->w_p_list = TRUE;
+      wp->w_p_list = true;
     }
 
 #define RULER_BUF_LEN 70

--- a/src/nvim/testdir/test_listchars.vim
+++ b/src/nvim/testdir/test_listchars.vim
@@ -42,6 +42,38 @@ func Test_listchars()
     call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
   endfor
 
+  " tab with 3rd character.
+  set listchars-=tab:>-
+  set listchars+=tab:<=>,trail:-
+  let expected = [
+	      \ '<======>aa<====>$',
+	      \ '..bb<==>--$',
+	      \ '...cccc>-$',
+	      \ 'dd........ee--<>$',
+	      \ '-$'
+	      \ ]
+  redraw!
+  for i in range(1, 5)
+    call cursor(i, 1)
+    call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
+  endfor
+
+  set listchars-=trail:-
+  let expected = [
+	      \ '<======>aa<====>$',
+	      \ '..bb<==>..$',
+	      \ '...cccc>.$',
+	      \ 'dd........ee..<>$',
+	      \ '.$'
+	      \ ]
+  redraw!
+  for i in range(1, 5)
+    call cursor(i, 1)
+    call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
+  endfor
+
+  set listchars-=tab:<=>
+  set listchars+=tab:>-
   set listchars+=trail:<
   set nolist
   normal ggdG

--- a/test/functional/options/chars_spec.lua
+++ b/test/functional/options/chars_spec.lua
@@ -4,6 +4,8 @@ local clear, command = helpers.clear, helpers.command
 local eval = helpers.eval
 local eq = helpers.eq
 local exc_exec = helpers.exc_exec
+local insert = helpers.insert
+local feed = helpers.feed
 
 describe("'fillchars'", function()
   local screen
@@ -69,5 +71,51 @@ describe("'fillchars'", function()
       shouldfail('eob:xy') -- two ascii chars
       shouldfail('eob:\255', 'eob:<ff>') -- invalid UTF-8
     end)
+    it('is local to window', function()
+      clear()
+      screen = Screen.new(50, 5)
+      screen:attach()
+      insert("foo\nbar")
+      command('set laststatus=0')
+      command('1,2fold')
+      command('vsplit')
+      command('set fillchars=fold:x')
+      screen:expect([[
+        ^+--  2 lines: fooxxxxxxxx│+--  2 lines: foo·······|
+        ~                        │~                       |
+        ~                        │~                       |
+        ~                        │~                       |
+                                                          |
+      ]])
+    end)
+  end)
+end)
+
+describe("'listchars'", function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(50, 5)
+    screen:attach()
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  it('is local to window', function()
+    feed('i<tab><tab><tab><esc>')
+    command('set laststatus=0')
+    command('set list listchars=tab:<->')
+    command('vsplit')
+    command('set listchars&')
+    screen:expect([[
+      >       >       ^>        │<------><------><------>|
+      ~                        │~                       |
+      ~                        │~                       |
+      ~                        │~                       |
+                                                        |
+    ]])
   end)
 end)

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -11,6 +11,7 @@ describe('ui/mouse/input', function()
   before_each(function()
     clear()
     meths.set_option('mouse', 'a')
+    meths.set_option('list', true)
     meths.set_option('listchars', 'eol:$')
     screen = Screen.new(25, 5)
     screen:attach()
@@ -82,7 +83,7 @@ describe('ui/mouse/input', function()
     feed('<LeftMouse><0,0>')
     feed('<LeftRelease><0,0>')
     screen:expect([[
-      ^t{1:esting}{3: }                 |
+      ^t{1:esting}                  |
       mouse                    |
       support and selection    |
       {0:~                        }|
@@ -125,7 +126,7 @@ describe('ui/mouse/input', function()
       insert('this is bar')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -162,7 +163,7 @@ describe('ui/mouse/input', function()
       insert('this is bar')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -170,7 +171,7 @@ describe('ui/mouse/input', function()
       feed('<LeftMouse><11,0>')
       screen:expect{grid=[[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -178,7 +179,7 @@ describe('ui/mouse/input', function()
       feed('<LeftDrag><6,0>')
       screen:expect([[
         {sel: + bar }{tab: + foo }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -192,7 +193,7 @@ describe('ui/mouse/input', function()
       insert('this is bar')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -222,7 +223,7 @@ describe('ui/mouse/input', function()
       insert('this is bar')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -260,7 +261,7 @@ describe('ui/mouse/input', function()
       insert('this is bar')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -268,7 +269,7 @@ describe('ui/mouse/input', function()
       feed('<LeftMouse><11,0>')
       screen:expect{grid=[[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -276,7 +277,7 @@ describe('ui/mouse/input', function()
       feed('<LeftDrag><11,1>')
       screen:expect{grid=[[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -284,7 +285,7 @@ describe('ui/mouse/input', function()
       feed('<LeftDrag><6,1>')
       screen:expect([[
         {sel: + bar }{tab: + foo }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -298,7 +299,7 @@ describe('ui/mouse/input', function()
       insert('this is bar')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -347,7 +348,7 @@ describe('ui/mouse/input', function()
       insert('this is bar')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -370,7 +371,7 @@ describe('ui/mouse/input', function()
       insert('this is bar')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -393,7 +394,7 @@ describe('ui/mouse/input', function()
       insert('this is bar')
       screen:expect([[
         {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-        this is ba^r              |
+        this is ba^r{0:$}             |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -401,7 +402,7 @@ describe('ui/mouse/input', function()
       feed('<2-LeftMouse><4,0>')
       screen:expect([[
         {sel:  Name] }{tab: + foo  + bar }{fill:  }{tab:X}|
-        ^                         |
+        {0:^$}                        |
         {0:~                        }|
         {0:~                        }|
                                  |
@@ -517,14 +518,14 @@ describe('ui/mouse/input', function()
     feed('<LeftDrag><2,2>')
     screen:expect([[
       testing                  |
-      mo{1:use}{3: }                   |
+      mo{1:use}                    |
       {1:su}^pport and selection    |
       {0:~                        }|
       {2:-- VISUAL --}             |
     ]])
     feed('<LeftDrag><0,0>')
     screen:expect([[
-      ^t{1:esting}{3: }                 |
+      ^t{1:esting}                  |
       {1:mou}se                    |
       support and selection    |
       {0:~                        }|
@@ -555,7 +556,7 @@ describe('ui/mouse/input', function()
     feed('<LeftMouse><0,1>')
     screen:expect([[
       {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-      ^this is bar              |
+      ^this is bar{0:$}             |
       {0:~                        }|
       {0:~                        }|
       :tabprevious             |
@@ -563,7 +564,7 @@ describe('ui/mouse/input', function()
     feed('<LeftDrag><4,1>')
     screen:expect([[
       {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
-      {vis:this}^ is bar              |
+      {vis:this}^ is bar{0:$}             |
       {0:~                        }|
       {0:~                        }|
       {sel:-- VISUAL --}             |
@@ -586,7 +587,7 @@ describe('ui/mouse/input', function()
     screen:expect([[
       testing                  |
       mouse                    |
-      {1:su}^p{1:port and selection}{3: }   |
+      {1:su}^p{1:port and selection}    |
       {0:~                        }|
       {2:-- VISUAL LINE --}        |
     ]])
@@ -614,8 +615,8 @@ describe('ui/mouse/input', function()
     ]])
     feed('<RightMouse><2,2>')
     screen:expect([[
-      {1:testing}{3: }                 |
-      {1:mouse}{3: }                   |
+      {1:testing}                  |
+      {1:mouse}                    |
       {1:su}^pport and selection    |
       {0:~                        }|
       {2:-- VISUAL --}             |


### PR DESCRIPTION
Using `'listchars'` is a nice way to highlight tabs that were included by accident for buffers that set `'expandtab'`.

But maybe one does not want this for buffers that set `'noexpandtab'`, so now one can use:

    autocmd FileType go let &l:listchars .= ',tab:  '

---

Status:

- [x] Make `'listchars'` and `'fillchars'` local to the window
- [x] Fix the tests
- [x] Make linter happy
- [x] Merge https://github.com/vim/vim/commit/83a52171ba00b2b9fd2d1d22a07e38fc9fc69c1e