### PR TITLE
[WIP] expose the libuv event loop in lua with luv bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,6 +385,9 @@ include_directories(SYSTEM ${LIBUV_INCLUDE_DIRS})
 find_package(Msgpack 1.0.0 REQUIRED)
 include_directories(SYSTEM ${MSGPACK_INCLUDE_DIRS})
 
+find_package(LibLUV 1.19.1 REQUIRED)
+include_directories(SYSTEM ${LIBLUV_INCLUDE_DIRS})
+
 # Note: The test lib requires LuaJIT; it will be skipped if LuaJIT is missing.
 option(PREFER_LUA "Prefer Lua over LuaJIT in the nvim executable." OFF)
 

--- a/cmake/FindLibLUV.cmake
+++ b/cmake/FindLibLUV.cmake
@@ -1,0 +1,32 @@
+# - Try to find luv
+# Once done this will define
+#  LIBLUV_FOUND - System has libluv
+#  LIBLUV_INCLUDE_DIRS - The libluv include directories
+#  LIBLUV_LIBRARIES - The libraries needed to use libluv
+
+find_path(LIBLUV_INCLUDE_DIR luv/luv.h
+          PATHS ${PC_LIBLUV_INCLUDEDIR} ${PC_LIBLUV_INCLUDE_DIRS}
+          ${LIMIT_SEARCH})
+
+# If we're asked to use static linkage, add libluv.a as a preferred library name.
+if(LIBLUV_USE_STATIC)
+  list(APPEND LIBLUV_NAMES
+    "${CMAKE_STATIC_LIBRARY_PREFIX}luv${CMAKE_STATIC_LIBRARY_SUFFIX}")
+endif()
+
+list(APPEND LIBLUV_NAMES luv)
+
+find_library(LIBLUV_LIBRARY NAMES ${LIBLUV_NAMES}
+  HINTS ${PC_LIBLUV_LIBDIR} ${PC_LIBLUV_LIBRARY_DIRS}
+  ${LIMIT_SEARCH})
+
+set(LIBLUV_LIBRARIES ${LIBLUV_LIBRARY})
+set(LIBLUV_INCLUDE_DIRS ${LIBLUV_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set LIBLUV_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(libluv DEFAULT_MSG
+  LIBLUV_LIBRARY LIBLUV_INCLUDE_DIR)
+
+mark_as_advanced(LIBLUV_INCLUDE_DIR LIBLUV_LIBRARY)

--- a/runtime/lua/luv.lua
+++ b/runtime/lua/luv.lua
@@ -1,0 +1,2 @@
+-- Shim to expose neovim luv instance so that require('luv') works
+return vim.uv

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -383,6 +383,7 @@ endif()
 
 # Put these last on the link line, since multiple things may depend on them.
 list(APPEND NVIM_LINK_LIBRARIES
+  ${LIBLUV_LIBRARIES}
   ${LIBUV_LIBRARIES}
   ${MSGPACK_LIBRARIES}
   ${LIBVTERM_LIBRARIES}

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -38,6 +38,12 @@ typedef struct {
   String lua_err_str;
 } LuaError;
 
+/// We use this to store Lua callbacks
+typedef struct {
+  // TODO: store more info for debugging, traceback?
+  int cb;
+} nlua_ctx;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "lua/vim_module.generated.h"
 # include "lua/executor.c.generated.h"
@@ -110,6 +116,35 @@ static int nlua_stricmp(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   return 1;
 }
 
+static void nlua_schedule_cb(void **argv)
+{
+  nlua_ctx *ctx = argv[0];
+  lua_State *const lstate = nlua_enter();
+  lua_rawgeti(lstate, LUA_REGISTRYINDEX, ctx->cb);
+  lua_pcall(lstate, 0, 0, 0);
+  free(ctx);
+}
+
+/// Schedule Lua callback on main loop's event queue
+///
+/// This is used to make sure nvim API is called at the right moment.
+///
+/// @param  lstate  Lua interpreter state.
+/// @param[in]  msg  Message base, must contain one `%s`.
+static int nlua_schedule(lua_State *const lstate)
+  FUNC_ATTR_NONNULL_ALL
+{
+  // TODO: report error using nlua_error instead
+  luaL_checktype(lstate, 1, LUA_TFUNCTION);
+
+  nlua_ctx* ctx = (nlua_ctx*)malloc(sizeof(nlua_ctx));
+  lua_pushvalue(lstate, 1);
+  ctx->cb = luaL_ref(lstate, LUA_REGISTRYINDEX);
+
+  multiqueue_put(main_loop.events, nlua_schedule_cb, 1, ctx);
+  return 0;
+}
+
 /// Initialize lua interpreter state
 ///
 /// Called by lua interpreter itself to initialize state.
@@ -157,6 +192,10 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   lua_pushstring(lstate, "uv_loop");
   lua_pushlightuserdata(lstate, &main_loop.uv);
   lua_rawset(lstate, LUA_REGISTRYINDEX);
+
+  // schedule
+  lua_pushcfunction(lstate, &nlua_schedule);
+  lua_setglobal(lstate, "nvim_schedule");
 
   return 0;
 }

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -31,6 +31,8 @@
 #include "nvim/lua/executor.h"
 #include "nvim/lua/converter.h"
 
+#include "luv/luv.h"
+
 typedef struct {
   Error err;
   String lua_err_str;
@@ -143,6 +145,11 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   // stricmp
   lua_pushcfunction(lstate, &nlua_stricmp);
   lua_setfield(lstate, -2, "stricmp");
+
+  // vim.uv
+  luv_set_loop(lstate, &main_loop.uv);
+  luaopen_luv(lstate);
+  lua_setfield(lstate, -2, "uv");
 
   lua_setglobal(lstate, "vim");
   return 0;

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -181,6 +181,9 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   // stricmp
   lua_pushcfunction(lstate, &nlua_stricmp);
   lua_setfield(lstate, -2, "stricmp");
+  // schedule
+  lua_pushcfunction(lstate, &nlua_schedule);
+  lua_setfield(lstate, -2, "schedule");
 
   // vim.uv
   luv_set_loop(lstate, &main_loop.uv);
@@ -193,10 +196,6 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   lua_pushstring(lstate, "uv_loop");
   lua_pushlightuserdata(lstate, &main_loop.uv);
   lua_rawset(lstate, LUA_REGISTRYINDEX);
-
-  // schedule
-  lua_pushcfunction(lstate, &nlua_schedule);
-  lua_setglobal(lstate, "nvim_schedule");
 
   return 0;
 }

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -192,11 +192,6 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
 
   lua_setglobal(lstate, "vim");
 
-  // expose main_loop's UV loop for luv
-  lua_pushstring(lstate, "uv_loop");
-  lua_pushlightuserdata(lstate, &main_loop.uv);
-  lua_rawset(lstate, LUA_REGISTRYINDEX);
-
   return 0;
 }
 

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -121,6 +121,7 @@ static void nlua_schedule_cb(void **argv)
   nlua_ctx *ctx = argv[0];
   lua_State *const lstate = nlua_enter();
   lua_rawgeti(lstate, LUA_REGISTRYINDEX, ctx->cb);
+  luaL_unref(lstate, LUA_REGISTRYINDEX, ctx->cb);
   lua_pcall(lstate, 0, 0, 0);
   free(ctx);
 }

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -152,6 +152,12 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   lua_setfield(lstate, -2, "uv");
 
   lua_setglobal(lstate, "vim");
+
+  // expose main_loop's UV loop for luv
+  lua_pushstring(lstate, "uv_loop");
+  lua_pushlightuserdata(lstate, &main_loop.uv);
+  lua_rawset(lstate, LUA_REGISTRYINDEX);
+
   return 0;
 }
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -153,8 +153,11 @@ set(LIBTERMKEY_SHA256 cecbf737f35d18f433c8d7864f63c0f878af41f8bd0255a3ebb16010dc
 set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/b45b648cab73f9667bde7c0c6045b285e22b3ecd.tar.gz)
 set(LIBVTERM_SHA256 37cc123deff29327efa654358c2ebaaf8589da03754ca5adb8ec47be386a0433)
 
-set(LUV_URL https://github.com/luvit/luv/archive/1.9.1-1.tar.gz)
-set(LUV_SHA256 562b9efaad30aa051a40eac9ade0c3df48bb8186763769abe47ec3fb3edb1268)
+set(LUV_URL https://github.com/luvit/luv/archive/1.29.1-1.tar.gz)
+set(LUV_SHA256 e2d5963621eb757ef0eb8a2b822413b6744c6cf5b7b6c56389629ce751533c2f)
+
+set(LUA_COMPAT53_URL https://github.com/keplerproject/lua-compat-5.3/archive/v0.7.tar.gz)
+set(LUA_COMPAT53_SHA256 bec3a23114a3d9b3218038309657f0f506ad10dfbc03bb54e91da7e5ffdba0a2)
 
 set(GPERF_URL https://github.com/neovim/deps/raw/ff5b4b18a87397a8564016071ae64f64bcd8c635/opt/gperf-3.1.tar.gz)
 set(GPERF_SHA256 588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2)

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -182,7 +182,7 @@ if(USE_BUNDLED_BUSTED)
   add_custom_target(luacheck
     DEPENDS ${LUACHECK_EXE})
 
-  set(LUV_DEPS luacheck luv-static)
+  set(LUV_DEPS luacheck luv-static lua-compat-5.3)
   if(MINGW AND CMAKE_CROSSCOMPILING)
     set(LUV_DEPS ${LUV_DEPS} libuv_host)
   endif()
@@ -190,6 +190,7 @@ if(USE_BUNDLED_BUSTED)
   if(USE_BUNDLED_LIBUV)
     list(APPEND LUV_ARGS LIBUV_DIR=${HOSTDEPS_INSTALL_DIR})
   endif()
+  list(APPEND LUV_ARGS LUA_COMPAT53_INCDIR=${DEPS_BUILD_DIR}/src/lua-compat-5.3)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/luv
     COMMAND ${LUAROCKS_BINARY}

--- a/third-party/cmake/BuildLuv.cmake
+++ b/third-party/cmake/BuildLuv.cmake
@@ -15,8 +15,26 @@ function(BuildLuv)
     message(FATAL_ERROR "Must pass at least one of CONFIGURE_COMMAND, BUILD_COMMAND, INSTALL_COMMAND")
   endif()
 
+  ExternalProject_Add(lua-compat-5.3
+    PREFIX ${DEPS_BUILD_DIR}
+    URL ${LUA_COMPAT53_URL}
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/lua-compat-5.3
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+      -DPREFIX=${DEPS_BUILD_DIR}
+      -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/lua-compat-5.3
+      -DURL=${LUA_COMPAT53_URL}
+      -DEXPECTED_SHA256=${LUA_COMPAT53_SHA256}
+      -DTARGET=lua-compat-5.3
+      -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    PATCH_COMMAND ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND "")
+
   ExternalProject_Add(luv-static
     PREFIX ${DEPS_BUILD_DIR}
+    DEPENDS lua-compat-5.3
     URL ${LUV_URL}
     DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/luv
     DOWNLOAD_COMMAND ${CMAKE_COMMAND}
@@ -94,9 +112,12 @@ endif()
 
 if(CMAKE_GENERATOR MATCHES "Unix Makefiles" AND
         (CMAKE_SYSTEM_NAME MATCHES ".*BSD" OR CMAKE_SYSTEM_NAME MATCHES "DragonFly"))
-  set(LUV_BUILD_COMMAND ${CMAKE_COMMAND} "-DCMAKE_MAKE_PROGRAM=gmake" --build .)
+        set(LUV_BUILD_COMMAND ${CMAKE_COMMAND}
+          "-DLUA_COMPAT53_DIR=${DEPS_BUILD_DIR}/src/lua-compat-5.3"
+          "-DCMAKE_MAKE_PROGRAM=gmake" --build .)
 else()
-  set(LUV_BUILD_COMMAND ${CMAKE_COMMAND} --build .)
+  set(LUV_BUILD_COMMAND ${CMAKE_COMMAND}
+    "-DLUA_COMPAT53_DIR=${DEPS_BUILD_DIR}/src/lua-compat-5.3" --build .)
 endif()
 set(LUV_INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install)
 

--- a/third-party/cmake/BuildLuv.cmake
+++ b/third-party/cmake/BuildLuv.cmake
@@ -1,5 +1,7 @@
 include(CMakeParseArguments)
 
+set(LUV_SRC_DIR ${DEPS_BUILD_DIR}/src/luv)
+
 # BuildLuv(PATCH_COMMAND ... CONFIGURE_COMMAND ... BUILD_COMMAND ... INSTALL_COMMAND ...)
 # Reusable function to build luv, wraps ExternalProject_Add.
 # Failing to pass a command argument will result in no command being run
@@ -51,7 +53,6 @@ function(BuildLuv)
     INSTALL_COMMAND "${_luv_INSTALL_COMMAND}")
 endfunction()
 
-set(LUV_SRC_DIR ${DEPS_BUILD_DIR}/src/luv)
 set(LUV_INCLUDE_FLAGS
   "-I${DEPS_INSTALL_DIR}/include -I${DEPS_INSTALL_DIR}/include/luajit-2.0")
 
@@ -88,6 +89,7 @@ if(MINGW AND CMAKE_CROSSCOMPILING)
     ${LUV_CONFIGURE_COMMAND_COMMON}
     # Pass toolchain
     -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN}
+    -DLUV_NO_INIT_LOOP="yes"
     "-DCMAKE_C_FLAGS:STRING=${LUV_INCLUDE_FLAGS} -D_WIN32_WINNT=0x0600"
     # Hack to avoid -rdynamic in Mingw
     -DCMAKE_SHARED_LIBRARY_LINK_C_FLAGS="")
@@ -95,6 +97,7 @@ elseif(MSVC)
   set(LUV_CONFIGURE_COMMAND
     ${LUV_CONFIGURE_COMMAND_COMMON}
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DLUV_NO_INIT_LOOP="yes"
     # Same as Unix without fPIC
     "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_COMPILER_ARG1} ${LUV_INCLUDE_FLAGS}"
     # Make sure we use the same generator, otherwise we may
@@ -107,6 +110,7 @@ else()
   set(LUV_CONFIGURE_COMMAND
     ${LUV_CONFIGURE_COMMAND_COMMON}
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DLUV_NO_INIT_LOOP="yes"
     "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_COMPILER_ARG1} ${LUV_INCLUDE_FLAGS} -fPIC")
 endif()
 


### PR DESCRIPTION
This PR exposes libuv event loop to in process Lua.

The motivation is to allow to use libuv API when writing neovim plugins with
Lua: networking, filesystem, process management.

The one part of this PR is at https://github.com/andreypopp/luv/tree/andreypopp/external-uv which holds a fork of luv with patches applied which allow to use externally supplied uv loop (patches are simple and I'd say mechanical).

It would be better to vendor luv fork directly into neovim source tree but I wasn't able to figure out how to make cmake to that. 23367934b

The second commit bbd6e0ebc exposes uv loop to Lua.

Then the third commit bc979a355 adds `vim.schedule(cb)` function to nvim Lua API. This function schedules Lua callback to be run on main loop's event queue - at a moment when it's safe to call into nvim API.

Example code:

```lua
local luv = require('luv')
local timer = new_timer()
timer:start(1000, 0, function ()
  vim.schedule(function()
    print('hi')
  end);
  timer:close()
end)
```