### PR TITLE
vim-patch:8.0.{411,412}

### DIFF
--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1520,7 +1520,7 @@ static char_u *menutrans_lookup(char_u *name, int len)
   char_u              *dname;
 
   for (int i = 0; i < menutrans_ga.ga_len; i++) {
-    if (STRNCMP(name, tp[i].from, len) == 0 && tp[i].from[len] == NUL) {
+    if (STRNICMP(name, tp[i].from, len) == 0 && tp[i].from[len] == NUL) {
       return tp[i].to;
     }
   }
@@ -1531,7 +1531,7 @@ static char_u *menutrans_lookup(char_u *name, int len)
   dname = menu_text(name, NULL, NULL);
   name[len] = c;
   for (int i = 0; i < menutrans_ga.ga_len; i++) {
-    if (STRCMP(dname, tp[i].from_noamp) == 0) {
+    if (STRICMP(dname, tp[i].from_noamp) == 0) {
       xfree(dname);
       return tp[i].to;
     }

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -23,7 +23,7 @@ func Test_translate_menu()
 
   set langmenu=de_de
   source $VIMRUNTIME/menu.vim
-  call assert_match(':browse tabnew', execute(':menu File.In\ neuem\ Tab\ öffnen\.\.\.'))
+  call assert_match('browse confirm w', execute(':menu Datei.Speichern'))
 
   source $VIMRUNTIME/delmenu.vim
 endfunc

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -1,9 +1,29 @@
 " Test that the system menu can be loaded.
 
+if !has('menu')
+  finish
+endif
+
 func Test_load_menu()
   try
     source $VIMRUNTIME/menu.vim
   catch
     call assert_report('error while loading menus: ' . v:exception)
   endtry
+  source $VIMRUNTIME/delmenu.vim
+endfunc
+
+func Test_translate_menu()
+  if !has('multi_lang')
+    return
+  endif
+  if !filereadable($VIMRUNTIME . '/lang/menu_de_de.latin1.vim')
+    throw 'Skipped: translated menu not found'
+  endif
+
+  set langmenu=de_de
+  source $VIMRUNTIME/menu.vim
+  call assert_match(':browse tabnew', execute(':menu File.In\ neuem\ Tab\ öffnen\.\.\.'))
+
+  source $VIMRUNTIME/delmenu.vim
 endfunc


### PR DESCRIPTION
**vim-patch:8.0.0411: menu translations don't match when case is changed. …**
Problem:    We can't change the case in menu entries, it breaks translations.
Solution:   Ignore case when looking up a menu translation.
vim/vim@11dd8c1

**vim-patch:8.0.0412: menu test fails on MS-Windows**
Problem:    Menu test fails on MS-Windows.
Solution:   Use a menu entry with only ASCII characters.
vim/vim@5558d19

Related: https://github.com/neovim/neovim/pull/8173

I did not include 8.0.0413 because of `File.Save` regression, mentioned in https://github.com/neovim/neovim/pull/8194.