### PR TITLE
build: enable -Wmissing-prototypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,8 @@ if(MSVC)
   add_definitions(-DWIN32)
 else()
   add_definitions(-Wall -Wextra -pedantic -Wno-unused-parameter
-    -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion)
+    -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion
+    -Wmissing-prototypes)
 
   check_c_compiler_flag(-Wimplicit-fallthrough HAS_WIMPLICIT_FALLTHROUGH_FLAG)
   if(HAS_WIMPLICIT_FALLTHROUGH_FLAG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,11 +172,6 @@ if(CMAKE_C_FLAGS_RELWITHDEBINFO MATCHES DNDEBUG)
   string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 endif()
 
-# Enable -Wconversion.
-if(NOT MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wshadow -Wconversion")
-endif()
-
 # gcc 4.0+ sets _FORTIFY_SOURCE=2 automatically.  This currently
 # does not work with Neovim due to some uses of dynamically-sized structures.
 # https://github.com/neovim/neovim/issues/223
@@ -264,7 +259,7 @@ if(MSVC)
   add_definitions(-DWIN32)
 else()
   add_definitions(-Wall -Wextra -pedantic -Wno-unused-parameter
-    -Wstrict-prototypes -std=gnu99)
+    -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion)
 
   check_c_compiler_flag(-Wimplicit-fallthrough HAS_WIMPLICIT_FALLTHROUGH_FLAG)
   if(HAS_WIMPLICIT_FALLTHROUGH_FLAG)

--- a/src/nvim/assert.h
+++ b/src/nvim/assert.h
@@ -80,7 +80,7 @@
 
 # undef STATIC_ASSERT_PRAGMA_END
 # define STATIC_ASSERT_PRAGMA_END \
-    _Pragma("GCC diagnostic pop") \
+    _Pragma("GCC diagnostic pop")
 
 // the same goes for clang in C99 mode, but we suppress a different warning
 #elif defined(__clang__) && __has_extension(c_static_assert)
@@ -90,11 +90,11 @@
 # undef STATIC_ASSERT_PRAGMA_START
 # define STATIC_ASSERT_PRAGMA_START \
     _Pragma("clang diagnostic push") \
-    _Pragma("clang diagnostic ignored \"-Wc11-extensions\"") \
+    _Pragma("clang diagnostic ignored \"-Wc11-extensions\"")
 
 # undef STATIC_ASSERT_PRAGMA_END
 # define STATIC_ASSERT_PRAGMA_END \
-    _Pragma("clang diagnostic pop") \
+    _Pragma("clang diagnostic pop")
 
 // TODO(aktau): verify that this works, don't have MSVC on hand.
 #elif _MSC_VER >= 1600

--- a/src/nvim/aucmd.c
+++ b/src/nvim/aucmd.c
@@ -6,6 +6,7 @@
 #include "nvim/vim.h"
 #include "nvim/main.h"
 #include "nvim/ui.h"
+#include "nvim/aucmd.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "aucmd.c.generated.h"

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5958,6 +5958,10 @@ static int get_env_tv(char_u **arg, typval_T *rettv, int evaluate)
 #pragma function (floor)
 #endif
 
+// silence -Wmissing-prototypes for funcs.generated.h
+const VimLFuncDef *find_internal_func_gperf(register const char *str,
+                                            register size_t len);
+
 # include "funcs.generated.h"
 #endif
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5958,11 +5958,9 @@ static int get_env_tv(char_u **arg, typval_T *rettv, int evaluate)
 #pragma function (floor)
 #endif
 
-// silence -Wmissing-prototypes for funcs.generated.h
-const VimLFuncDef *find_internal_func_gperf(register const char *str,
-                                            register size_t len);
-
+PRAGMA_DIAG_PUSH_IGNORE_MISSING_PROTOTYPES
 # include "funcs.generated.h"
+PRAGMA_DIAG_POP
 #endif
 
 /*

--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -7,6 +7,7 @@
 
 #include "nvim/eval/typval.h"
 #include "nvim/eval.h"
+#include "nvim/eval/decode.h"
 #include "nvim/eval/encode.h"
 #include "nvim/ascii.h"
 #include "nvim/macros.h"

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -448,6 +448,7 @@ for _, fn in ipairs(functions) do
 end
 
 output:write(string.format([[
+void nlua_add_api_functions(lua_State *lstate);  // silence -Wmissing-prototypes
 void nlua_add_api_functions(lua_State *lstate)
   FUNC_ATTR_NONNULL_ALL
 {

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -198,4 +198,25 @@
 # define IO_COUNT(x)  (x)
 #endif
 
+///
+/// PRAGMA_DIAG_PUSH_IGNORE_MISSING_PROTOTYPES
+///
+#if defined(__clang__) && __clang__ == 1
+# define PRAGMA_DIAG_PUSH_IGNORE_MISSING_PROTOTYPES \
+  _Pragma("clang diagnostic push") \
+  _Pragma("clang diagnostic ignored \"-Wmissing-prototypes\"")
+# define PRAGMA_DIAG_POP \
+    _Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+# define PRAGMA_DIAG_PUSH_IGNORE_MISSING_PROTOTYPES \
+  _Pragma("GCC diagnostic push") \
+  _Pragma("GCC diagnostic ignored \"-Wmissing-prototypes\"")
+# define PRAGMA_DIAG_POP \
+  _Pragma("GCC diagnostic pop")
+#else
+# define PRAGMA_DIAG_PUSH_IGNORE_MISSING_PROTOTYPES
+# define PRAGMA_DIAG_POP
+#endif
+
+
 #endif  // NVIM_MACROS_H

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -222,6 +222,7 @@ void early_init(void)
 }
 
 #ifdef MAKE_LIB
+int nvim_main(int argc, char **argv);  // silence -Wmissing-prototypes
 int nvim_main(int argc, char **argv)
 #elif defined(WIN32)
 int wmain(int argc, wchar_t **argv_w)  // multibyte args on Windows. #7060

--- a/src/nvim/os/dl.c
+++ b/src/nvim/os/dl.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <uv.h>
 
+#include "nvim/os/dl.h"
 #include "nvim/os/os.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"

--- a/src/nvim/os/lang.c
+++ b/src/nvim/os/lang.c
@@ -11,6 +11,7 @@
 #ifdef HAVE_LOCALE_H
 # include <locale.h>
 #endif
+#include "nvim/os/lang.h"
 #include "nvim/os/os.h"
 
 void lang_init(void)

--- a/test/functional/fixtures/tty-test.c
+++ b/test/functional/fixtures/tty-test.c
@@ -20,6 +20,7 @@
 uv_tty_t tty;
 uv_tty_t tty_out;
 
+bool owns_tty(void);  // silence -Wmissing-prototypes
 bool owns_tty(void)
 {
 #ifdef _WIN32


### PR DESCRIPTION
Enable `-Wmissing-prototypes` as suggested in https://github.com/neovim/neovim/issues/343 .    Though I don't see a strong benefit, it isn't too much of a burden, and    maybe avoids confusion in some cases.
