### PR TITLE
[RFC]  options: set 'scrollback' to -1 by default

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4761,14 +4761,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	height with ":set scroll=0".
 
 						*'scrollback'* *'scbk'*
-'scrollback' 'scbk'	number	(default: 10000
-				 in normal buffers: -1)
+'scrollback' 'scbk'	number	(default: 10000)
 			local to buffer
 	Maximum number of lines kept beyond the visible screen. Lines at the
 	top are deleted if new lines exceed this limit.
+	Minimum is 1, maximum is 100000.
 	Only in |terminal| buffers.
-	-1 means "unlimited" for normal buffers, 100000 otherwise.
-	Minimum is 1.
 
 			*'scrollbind'* *'scb'* *'noscrollbind'* *'noscb'*
 'scrollbind' 'scb'	boolean  (default off)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4240,8 +4240,7 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
   } else if (pp == &curbuf->b_p_channel || pp == &p_channel) {
     errmsg = e_invarg;
   } else if (pp == &curbuf->b_p_scbk || pp == &p_scbk) {
-    if (value < -1 || value > SB_MAX
-        || (value != -1 && opt_flags == OPT_LOCAL && !curbuf->terminal)) {
+    if (value < -1 || value > SB_MAX) {
       errmsg = e_invarg;
     }
   } else if (pp == &curbuf->b_p_sw || pp == &p_sw) {
@@ -4433,11 +4432,6 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
   // May set global value for local option.
   if ((opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0) {
     *(long *)get_varp_scope(&(options[opt_idx]), OPT_GLOBAL) = *pp;
-  }
-
-  if (pp == &curbuf->b_p_scbk && !curbuf->terminal) {
-    // Normal buffer: reset local 'scrollback' after updating the global value.
-    curbuf->b_p_scbk = -1;
   }
 
   options[opt_idx].flags |= P_WAS_SET;
@@ -5862,7 +5856,7 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_ai = p_ai;
       buf->b_p_ai_nopaste = p_ai_nopaste;
       buf->b_p_sw = p_sw;
-      buf->b_p_scbk = -1;
+      buf->b_p_scbk = p_scbk;
       buf->b_p_tw = p_tw;
       buf->b_p_tw_nopaste = p_tw_nopaste;
       buf->b_p_tw_nobin = p_tw_nobin;

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1934,7 +1934,7 @@ return {
       vi_def=true,
       varname='p_scbk',
       redraw={'current_buffer'},
-      defaults={if_true={vi=10000}}
+      defaults={if_true={vi=-1}}
     },
     {
       full_name='scrollbind', abbreviation='scb',

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -481,25 +481,10 @@ describe("'scrollback' option", function()
     eq(-1, curbufmeths.get_option('scrollback'))
   end)
 
-  it(':setlocal in a normal buffer is an error', function()
-    command('new')
-
-    -- :setlocal to -1 is NOT an error.
-    feed_command('setlocal scrollback=-1')
-    eq(nil, string.match(eval("v:errmsg"), "E%d*:"))
-    feed('<CR>')
-
-    -- :setlocal to anything except -1 is an error.
-    feed_command('setlocal scrollback=42')
-    feed('<CR>')
-    eq('E474:', string.match(eval("v:errmsg"), "E%d*:"))
-    eq(-1, curbufmeths.get_option('scrollback'))
-  end)
-
   it(':set updates local value and global default', function()
     set_fake_shell()
-    command('set scrollback=42')                  -- set global and (attempt) local
-    eq(-1, curbufmeths.get_option('scrollback'))  -- normal buffer: -1
+    command('set scrollback=42')                  -- set global value
+    eq(42, curbufmeths.get_option('scrollback'))
     command('terminal')
     eq(42, curbufmeths.get_option('scrollback'))  -- inherits global default
     command('setlocal scrollback=99')


### PR DESCRIPTION
This patch makes the `'scrollback'` option easier to use (same default for all buffers) and future-proof by foreseeing that `-1` will mean _unlimited_ for all non-terminal buffers.
