### PR TITLE
completion: add equal field in complete-items

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1074,6 +1074,9 @@ items:
 	icase		when non-zero case is to be ignored when comparing
 			items to be equal; when omitted zero is used, thus
 			items that only differ in case are added
+	equal		when non-zero, always treat this item to be equal when
+			comparing. Which means, "equal=1" disables filtering
+			of this item.
 	dup		when non-zero this match will be added even when an
 			item with the same word is already present.
 	empty		when non-zero this match will be added even when it is

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -246,6 +246,38 @@ func! Test_popup_completion_insertmode()
   iunmap <F5>
 endfunc
 
+func Test_complete_no_filter()
+  func! s:complTest1() abort
+    call complete(1, [{'word': 'foobar'}])
+    return ''
+  endfunc
+  func! s:complTest2() abort
+    call complete(1, [{'word': 'foobar', 'equal': 1}])
+    return ''
+  endfunc
+
+  let completeopt = &completeopt
+
+  " without equal=1
+  new
+  set completeopt=menuone,noinsert,menu
+  inoremap <F5>  <C-R>=s:complTest1()<CR>
+  call feedkeys("i\<F5>z\<CR>\<CR>\<ESC>.", 'tx')
+  call assert_equal('z', getline(1))
+  bwipe!
+
+  " with equal=1
+  new
+  set completeopt=menuone,noinsert,menu
+  inoremap <F5>  <C-R>=s:complTest2()<CR>
+  call feedkeys("i\<F5>z\<CR>\<CR>\<ESC>.", 'tx')
+  call assert_equal('foobar', getline(1))
+  bwipe!
+
+  let &completeopt = completeopt
+  iunmap <F5>
+endfunc
+
 " TODO: Fix what breaks after this line.
 " - Do not use "q!", it may exit Vim if there is an error
 finish


### PR DESCRIPTION
When calling complete() with items's equal set to 1, nvim will not try
to compare the text with user's typing.  This is very useful for auto
completion plugin, which usually has its own filtering logic.

Without this commit, the popup menu may flicker when auto completion
plugin is active:
1. The popup gets closed by nvim when it believes that the popup
items does not match the user input.
2. The popup gets re-opened by the auto completion plugin after finishing
the customized filtering.

Additional information: vim/vim#1713

Minimal vimrc for testing:

```vim
set iskeyword=@,$,48-57,_,192-255
set completeopt=noinsert,menuone,noselect
" imap . <c-r>=complete(1, ['the_popup_does_not_close_when_text_doesnot_match'])?'':''<cr>
imap . <c-r>=complete(1, [{'word':'the_popup_does_not_close_when_text_doesnot_match', 'equal': 1}])?'':''<cr>
```

demo:

![neovim-pr](https://user-images.githubusercontent.com/4538941/52030718-1ae1d880-2554-11e9-9101-ed09e815d516.gif)

cc @Shougo at #9502 I'm not sure whether we're addressing similar issue.


EDIT:

no idea why the ci failed. But it does seem to be related to this PR http://neovim-qb.szakmeister.net/build/21424/tap_report/by_test?reportset=functionaltest-freebsd-64-debug
