### PR TITLE
ftplugin/css.vim: add - to iskeyword

### DIFF
--- a/runtime/ftplugin/css.vim
+++ b/runtime/ftplugin/css.vim
@@ -11,11 +11,12 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-let b:undo_ftplugin = "setl com< cms< inc< fo< ofu<"
+let b:undo_ftplugin = "setl com< cms< inc< fo< ofu< isk<"
 
 setlocal comments=s1:/*,mb:*,ex:*/ commentstring&
 setlocal formatoptions-=t formatoptions+=croql
 setlocal omnifunc=csscomplete#CompleteCSS
+setlocal iskeyword=@,48-57,_,-,192-255
 
 let &l:include = '^\s*@import\s\+\%(url(\)\='
 


### PR DESCRIPTION
CSS class names (.e.g. .btn-info) often contain '-' in it. It is useful
to treat it part of the keyword for code completion.
