### PR TITLE
inccommand: auto-disable if folding is slow

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4125,10 +4125,6 @@ skip:
     changed_window_setting();
   }
 
-  if (profile_passed_limit(timeout)) {
-    got_quit = true;
-  }
-
   vim_regfree(regmatch.regprog);
 
   // Restore the flag values, they can be used for ":&&".
@@ -4139,7 +4135,7 @@ skip:
   buf_T *preview_buf = NULL;
   size_t subsize = preview_lines.subresults.size;
   if (preview && !aborting()) {
-    if (got_quit) {  // Substitution is too slow, disable 'inccommand'.
+    if (got_quit || profile_passed_limit(timeout)) {  // Too slow, disable.
       set_string_option_direct((char_u *)"icm", -1, (char_u *)"", OPT_FREE,
                                SID_NONE);
     } else if (*p_icm != NUL &&  pat != NULL) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4125,6 +4125,10 @@ skip:
     changed_window_setting();
   }
 
+  if (profile_passed_limit(timeout)) {
+    got_quit = true;
+  }
+
   vim_regfree(regmatch.regprog);
 
   // Restore the flag values, they can be used for ":&&".

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -1151,7 +1151,7 @@ describe(":substitute, inccommand=split", function()
     eq("split", eval("&inccommand"))
   end)
 
-  it("deactivates if folding is slow", function()
+  it('deactivates if folding is slow', function()
     insert([[
       a
       a
@@ -1161,25 +1161,27 @@ describe(":substitute, inccommand=split", function()
       a
       a
       a
-      ]])
+    ]])
+    source([[
+      function! Slowfold(lnum)
+        sleep 5m
+        return a:lnum % 3
+      endfun
+    ]])
+    command('set redrawtime=1 inccommand=split')
+    command('set foldmethod=expr foldexpr=Slowfold(v:lnum)')
+    feed(':%s/a/bcdef')
 
-      source([[
-        function! Slowfold(lnum)
-          sleep 5m
-          return a:lnum % 3
-        endfun
-        set foldexpr=Slowfold(v:lnum)
-      ]])
+    -- Assert that 'inccommand' is DISABLED in cmdline mode.
+    retry(nil, nil, function()
+      eq('', eval('&inccommand'))
+    end)
 
-      command("set redrawtime=1")
-      command("set foldmethod=expr")
-      command("set icm=split")
-      helpers.sleep(100)
-      feed(":%s/a/bcdef")
-      helpers.sleep(1000)
-
-      -- Assert that 'inccommand' is DISABLED in cmdline mode.
-      eq("", eval("&inccommand"))
+    -- Assert that 'inccommand' is again ENABLED after leaving cmdline mode.
+    feed([[<C-\><C-N>]])
+    retry(nil, nil, function()
+      eq('split', eval('&inccommand'))
+    end)
   end)
 
   it("clears preview if non-previewable command is edited #5585", function()

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -1151,7 +1151,7 @@ describe(":substitute, inccommand=split", function()
     eq("split", eval("&inccommand"))
   end)
 
-  it('deactivates if folding is slow', function()
+  it("deactivates if 'foldexpr' is slow #9557", function()
     insert([[
       a
       a

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -1151,6 +1151,37 @@ describe(":substitute, inccommand=split", function()
     eq("split", eval("&inccommand"))
   end)
 
+  it("deactivates if folding is slow", function()
+    insert([[
+      a
+      a
+      a
+      a
+      a
+      a
+      a
+      a
+      ]])
+
+      source([[
+        function! Slowfold(lnum)
+          sleep 5m
+          return a:lnum % 3
+        endfun
+        set foldexpr=Slowfold(v:lnum)
+      ]])
+
+      command("set redrawtime=1")
+      command("set foldmethod=expr")
+      command("set icm=split")
+      helpers.sleep(100)
+      feed(":%s/a/bcdef")
+      helpers.sleep(1000)
+
+      -- Assert that 'inccommand' is DISABLED in cmdline mode.
+      eq("", eval("&inccommand"))
+  end)
+
   it("clears preview if non-previewable command is edited #5585", function()
     -- Put a non-previewable command in history.
     feed_command("echo 'foo'")


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/issues/9557

The test fails without the patch, and passes afterwards... on my local machine. I could not really make it without putting those ugly `sleep`s in there, even though just before it there's a similar test that seems to work. Copying that stuff did not work, the tests kept on failing (I can verify it works manually, too, so it's really a question of writing the test correctly). Help please :)

What it does: Before, we checked after a single iteration step (it steps through lines, but might need to step larger for multiline substitutions) if we exceeded the time budget. That notably did not include folding, which is reevaluated after the substitution loop. So I simply opted to check again after folds were evaluated. The time budget is still the same, though.