### PR TITLE
popupmenu: fix alignment of kind and extra after #9530

### DIFF
--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -517,7 +517,7 @@ void pum_redraw(void)
       } else {
         grid_fill(&pum_grid, row, row + 1, col,
                   col_off + pum_base_width + n, ' ', ' ', attr);
-        col = pum_base_width + n;
+        col = col_off + pum_base_width + n;
       }
       totwidth = pum_base_width + n;
     }

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1178,5 +1178,56 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
+  it('works with kind, menu and abbr attributes', function()
+    screen:try_resize(40,8)
+    feed('ixx ')
+    funcs.complete(4, {{word='wordey', kind= 'x', menu='extrainfo'}, 'thing', {word='secret', abbr='sneaky', menu='bar'}})
+    screen:expect([[
+      xx wordey^                               |
+      {1:~ }{s: wordey x extrainfo }{1:                  }|
+      {1:~ }{n: thing              }{1:                  }|
+      {1:~ }{n: sneaky   bar       }{1:                  }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {2:-- INSERT --}                            |
+    ]])
+
+    feed('<c-p>')
+    screen:expect([[
+      xx ^                                     |
+      {1:~ }{n: wordey x extrainfo }{1:                  }|
+      {1:~ }{n: thing              }{1:                  }|
+      {1:~ }{n: sneaky   bar       }{1:                  }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {2:-- INSERT --}                            |
+    ]])
+
+    feed('<c-p>')
+    screen:expect([[
+      xx secret^                               |
+      {1:~ }{n: wordey x extrainfo }{1:                  }|
+      {1:~ }{n: thing              }{1:                  }|
+      {1:~ }{s: sneaky   bar       }{1:                  }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {2:-- INSERT --}                            |
+    ]])
+
+    feed('<esc>')
+    screen:expect([[
+      xx secre^t                               |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+                                              |
+    ]])
+  end)
 
 end)


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/pull/9530#issuecomment-460060107, thanks @purpleP for reporting.