### PR TITLE
[WIP] vim-patch:8.0.1153

### DIFF
--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -527,7 +527,7 @@ func Test_setting_cursor()
   new Xtest2
   put =range(1,100)
   wq
-  
+
   tabe Xtest2
   $
   diffsp Xtest1
@@ -653,6 +653,47 @@ func Test_diff_nomodifiable()
   call assert_fails('norm dp', 'E793:')
   setl nomodifiable
   call assert_fails('norm do', 'E21:')
+  %bwipe!
+endfunc
+
+func Test_diff_filler()
+  new
+  call setline(1, [1, 2, 3, 'x', 4])
+  diffthis
+  vnew
+  call setline(1, [1, 2, 'y', 'y', 3, 4])
+  diffthis
+  redraw
+
+  call assert_equal([0, 0, 0, 0, 0, 0, 0, 1, 0], map(range(-1, 7), 'diff_filler(v:val)'))
+  wincmd w
+  call assert_equal([0, 0, 0, 0, 2, 0, 0, 0], map(range(-1, 6), 'diff_filler(v:val)'))
+
+  %bwipe!
+endfunc
+
+func Test_diff_hlID()
+  new
+  call setline(1, [1, 2, 3])
+  diffthis
+  vnew
+  call setline(1, ['1x', 2, 'x', 3])
+  diffthis
+  redraw
+
+  call assert_equal(synIDattr(diff_hlID(-1, 1), "name"), "")
+
+  call assert_equal(synIDattr(diff_hlID(1, 1), "name"), "DiffChange")
+  call assert_equal(synIDattr(diff_hlID(1, 2), "name"), "DiffText")
+  call assert_equal(synIDattr(diff_hlID(2, 1), "name"), "")
+  call assert_equal(synIDattr(diff_hlID(3, 1), "name"), "DiffAdd")
+  call assert_equal(synIDattr(diff_hlID(4, 1), "name"), "")
+
+  wincmd w
+  call assert_equal(synIDattr(diff_hlID(1, 1), "name"), "DiffChange")
+  call assert_equal(synIDattr(diff_hlID(2, 1), "name"), "")
+  call assert_equal(synIDattr(diff_hlID(3, 1), "name"), "")
+
   %bwipe!
 endfunc
 


### PR DESCRIPTION
**vim-patch:8.0.1153: no tests for diff_hlID() and diff_filler()**
Problem:    No tests for diff_hlID() and diff_filler().
Solution:   Add tests. (Dominique Pelle, closes vim/vim#2156)
https://github.com/vim/vim/commit/97fbc404fc56f76df12b2d2658b1d6efda28d5dd