### PR TITLE
UI: always use concrete colors for default_colors_set

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -35,6 +35,7 @@ a dictionary with these (optional) keys:
 	`ext_linegrid`		Use new revision of the grid events. |ui-linegrid|
 	`ext_multigrid`		Use per-window grid based events. |ui-multigrid|
 	`ext_hlstate`		Use detailed highlight state. |ui-hlstate|
+	`ext_termcolors`	Use external default colors.
 
 Specifying a non-existent option is an error. UIs can check the |api-metadata|
 `ui_options` key for supported options. Additionally Nvim (currently) requires
@@ -238,6 +239,13 @@ numerical highlight `id`:s to the actual attributes.
 	The first three arguments set the default foreground, background and
 	special colors respectively. `cterm_fg` and `cterm_bg` specifies the
 	default color codes to use in a 256-color terminal.
+
+	The rgb values will always be valid colors, by default. If no
+	colors have been set, they will default to black and white, depending
+	on 'background'. By setting the `ext_termcolors` option, instead
+	-1 will be used for unset colors. This is mostly useful for a
+	TUI implementation, where using the terminal emulators builitn
+	defaults are expected.
 
 	Note: unlike the corresponding events in the first revision, the
 	screen is not always cleared after sending this event. The GUI has to

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -210,8 +210,9 @@ static void ui_set_option(UI *ui, bool init, String name, Object value,
       return;
     }
     ui->rgb = value.data.boolean;
-    // A little drastic, but only legacy uis need to use this option
-    if (!init) {
+    // A little drastic, but only takes effect for legacy uis. For linegrid UI
+    // only changes metadata for nvim_list_uis(), no refresh needed.
+    if (!init && !ui->ui_ext[kUILinegrid]) {
       ui_refresh();
     }
     return;
@@ -355,6 +356,12 @@ static void remote_ui_default_colors_set(UI *ui, Integer rgb_fg,
                                          Integer rgb_bg, Integer rgb_sp,
                                          Integer cterm_fg, Integer cterm_bg)
 {
+  if (!ui->ui_ext[kUITermColors]) {
+    bool dark = (*p_bg == 'd');
+    rgb_fg = rgb_fg != -1 ? rgb_fg : (dark ? 0xFFFFFF : 0x000000);
+    rgb_bg = rgb_bg != -1 ? rgb_bg : (dark ? 0x000000 : 0xFFFFFF);
+    rgb_sp = rgb_sp != -1 ? rgb_sp : 0xFF0000;
+  }
   Array args = ARRAY_DICT_INIT;
   ADD(args, INTEGER_OBJ(rgb_fg));
   ADD(args, INTEGER_OBJ(rgb_bg));

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -310,6 +310,9 @@ void ui_set_ext_option(UI *ui, UIExtension ext, bool active)
     ui->option_set(ui, cstr_as_string((char *)ui_ext_names[ext]),
                    BOOLEAN_OBJ(active));
   }
+  if (ext == kUITermColors) {
+    ui_default_colors_set();
+  }
 }
 
 void ui_line(ScreenGrid *grid, int row, int startcol, int endcol, int clearcol,

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -18,6 +18,7 @@ typedef enum {
   kUILinegrid,
   kUIMultigrid,
   kUIHlState,
+  kUITermColors,
   kUIExtCount,
 } UIExtension;
 
@@ -29,6 +30,7 @@ EXTERN const char *ui_ext_names[] INIT(= {
   "ext_linegrid",
   "ext_multigrid",
   "ext_hlstate",
+  "ext_termcolors",
 });
 
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1278,6 +1278,7 @@ describe('API', function()
           ext_linegrid = screen._options.ext_linegrid or false,
           ext_multigrid = false,
           ext_hlstate=false,
+          ext_termcolors=false,
           height = 4,
           rgb = true,
           width = 20,

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -256,13 +256,13 @@ describe('TUI', function()
   end)
 
   it('shows up in nvim_list_uis', function()
-    feed_data(':echo map(nvim_list_uis(), {k,v -> sort(items(v))})\013')
+    feed_data(':echo map(nvim_list_uis(), {k,v -> sort(items(filter(v, {k,v -> k[:3] !=# "ext_" })))})\013')
     screen:expect([=[
-      [[['ext_cmdline', v:false], ['ext_hlstate', v:fals|
-      e], ['ext_linegrid', v:true], ['ext_multigrid', v:|
-      false], ['ext_popupmenu', v:false], ['ext_tabline'|
-      , v:false], ['ext_wildmenu', v:false], ['height', |
-      6], ['rgb', v:false], ['width', 50]]]             |
+                                                        |
+      {4:~                                                 }|
+      {5:                                                  }|
+      [[['height', 6], ['rgb', v:false], ['width', 50]]]|
+                                                        |
       {10:Press ENTER or type command to continue}{1: }          |
       {3:-- TERMINAL --}                                    |
     ]=])

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -27,6 +27,7 @@ describe('ui receives option updates', function()
       ext_linegrid=false,
       ext_hlstate=false,
       ext_multigrid=false,
+      ext_termcolors=false,
     }
 
     clear(...)

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -960,3 +960,46 @@ end)
 describe("Screen (line-based)", function()
   screen_tests(true)
 end)
+
+describe('Screen default colors', function()
+  local screen
+  local function startup(light, termcolors)
+    local extra = (light and ' background=light') or ''
+
+    local nvim_argv = {helpers.nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
+                       '--cmd', 'set shortmess+=I noswapfile belloff= noshowcmd noruler'..extra,
+                       '--embed'}
+    local screen_nvim = spawn(nvim_argv)
+    set_session(screen_nvim)
+    screen = Screen.new()
+    screen:attach(termcolors and {rgb=true,ext_termcolors=true} or {rgb=true})
+  end
+
+  it('are dark per default', function()
+    startup(false, false)
+    screen:expect{condition=function()
+      eq({rgb_bg=0, rgb_fg=Screen.colors.White, rgb_sp=Screen.colors.Red,
+          cterm_bg=0, cterm_fg=0}, screen.default_colors)
+    end}
+  end)
+
+  it('can be set to light', function()
+    startup(true, false)
+    screen:expect{condition=function()
+      eq({rgb_bg=Screen.colors.White, rgb_fg=0, rgb_sp=Screen.colors.Red,
+          cterm_bg=0, cterm_fg=0}, screen.default_colors)
+    end}
+  end)
+
+  it('can be handled by external terminal', function()
+    startup(false, true)
+    screen:expect{condition=function()
+      eq({rgb_bg=-1, rgb_fg=-1, rgb_sp=-1, cterm_bg=0, cterm_fg=0}, screen.default_colors)
+    end}
+
+    startup(true, true)
+    screen:expect{condition=function()
+      eq({rgb_bg=-1, rgb_fg=-1, rgb_sp=-1, cterm_bg=0, cterm_fg=0}, screen.default_colors)
+    end}
+  end)
+end)


### PR DESCRIPTION
This will make external UIs comply with `&background` without any change, when using with `default` colors.

But add an escape hatch needed for external TUI, so it still can use terminal emulator defaults.