### PR TITLE
UI: 'pumblend' for cterm (256-color TUI)

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4489,12 +4489,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'pumblend'* *'pb'*
 'pumblend' 'pb'		number	(default 0)
 			global
-	Enables semi-transparency for the completion popupmenu. Valid values
-	are in the range from 0 for fully opaque popupmenu (disabled) to 100
-	for fully transparent background. Lower values 0-30 are typically most
-	useful.
+	Enables pseudo-transparency for the |popup-menu|. Valid values are in
+	the range of 0 for fully opaque popupmenu (disabled) to 100 for fully
+	transparent background. Values between 0-30 are typically most useful.
 
-	UI-dependent. Supported by TUI with 'termguicolors' enabled.
+	UI-dependent. Works best with RGB colors. 'termguicolors'
 
 						*'pyxversion'* *'pyx'*
 'pyxversion' 'pyx'	number	(default depends on the build)

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -160,6 +160,7 @@ the editor.
 	'guifontset'
 	'guifontwide'
 	'linespace'
+	'pumblend'
 	'showtabline'
 	'termguicolors'
 	"ext_*" (all |ui-ext-options|)

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -189,7 +189,7 @@ Options:
               for |hl-EndOfBuffer| marker
   'inccommand' shows interactive results for |:substitute|-like commands
   'listchars' local to window
-  'pumblend' semi-transparent popupmenu
+  'pumblend' pseudo-transparent popupmenu
   'scrollback'
   'statusline' supports unlimited alignment sections
   'tabline' %@Func@foo%X can call any function on mouse-click

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -410,58 +410,13 @@ static int cterm_blend(int ratio, int c1, int c2)
 }
 
 /// Converts RGB color to 8-bit color (0-255).
-/// Reverse engineer the RGB value into a cterm color index.
-/// First color is 1.  Return 0 if no match found (default color).
 static int hl_rgb2cterm_color(int rgb)
 {
-  int red = (rgb & 0xFF0000) >> 16;
-  int green = (rgb & 0x00FF00) >> 8;
-  int blue = (rgb & 0x0000FF) >> 0;
+  int r = (rgb & 0xFF0000) >> 16;
+  int g = (rgb & 0x00FF00) >> 8;
+  int b = (rgb & 0x0000FF) >> 0;
 
-  if (red == blue && red == green) {
-    // 24-color greyscale plus white and black.
-    static int cutoff[23] = {
-      0x0D, 0x17, 0x21, 0x2B, 0x35, 0x3F, 0x49, 0x53, 0x5D, 0x67,
-      0x71, 0x7B, 0x85, 0x8F, 0x99, 0xA3, 0xAD, 0xB7, 0xC1, 0xCB,
-      0xD5, 0xDF, 0xE9};
-    int i;
-
-    if (red < 5) {
-      return 17;  // 00/00/00
-    }
-    if (red > 245) {  // ff/ff/ff
-      return 232;
-    }
-    for (i = 0; i < 23; ++i) {
-      if (red < cutoff[i]) {
-        return i + 233;
-      }
-    }
-    return 256;
-  }
-  {
-    static int cutoff[5] = {0x2F, 0x73, 0x9B, 0xC3, 0xEB};
-    int ri, gi, bi;
-
-    // 216-color cube.
-    for (ri = 0; ri < 5; ++ri) {
-      if (red < cutoff[ri]) {
-        break;
-      }
-    }
-    for (gi = 0; gi < 5; ++gi) {
-      if (green < cutoff[gi]) {
-        break;
-      }
-    }
-    for (bi = 0; bi < 5; ++bi) {
-      if (blue < cutoff[bi]) {
-        break;
-      }
-    }
-    return 17 + ri * 36 + gi * 6 + bi;
-  }
-  return 0;
+  return (r * 6 / 256) * 36 + (g * 6 / 256) * 6 + (b * 6 / 256);
 }
 
 /// Converts 8-bit color (0-255) to RGB color.
@@ -496,10 +451,11 @@ static int hl_cterm2rgb_color(int nr)
     { 255, 255, 255, 16 } ,  // white
   };
 
-  int r;
-  int g;
-  int b;
+  int r = 0;
+  int g = 0;
+  int b = 0;
   int idx;
+  // *ansi_idx = 0;
 
   if (nr < 16) {
     r = ansi_table[nr][0];
@@ -518,11 +474,6 @@ static int hl_cterm2rgb_color(int nr)
     g = grey_ramp[idx];
     b = grey_ramp[idx];
     // *ansi_idx = -1;
-  } else {
-    r = 0;
-    g = 0;
-    b = 0;
-    // *ansi_idx = 0;
   }
   return (r << 16) + (g << 8) + b;
 }

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -259,9 +259,10 @@ static void compose_line(Integer row, Integer startcol, Integer endcol,
     memcpy(linebuf+(col-startcol), grid->chars+off, n * sizeof(*linebuf));
     memcpy(attrbuf+(col-startcol), grid->attrs+off, n * sizeof(*attrbuf));
 
+    // 'pumblend'
     if (grid != &default_grid && p_pb) {
       for (int i = col-(int)startcol; i < until-startcol; i++) {
-        bool thru = strequal((char *)linebuf[i], " ");
+        bool thru = strequal((char *)linebuf[i], " ");  // negative space
         attrbuf[i] = (sattr_T)hl_blend_attrs(bg_attrs[i], attrbuf[i], thru);
         if (thru) {
           memcpy(linebuf[i], bg_line[i], sizeof(linebuf[i]));

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1273,7 +1273,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('works with pumblend', function()
+  it("'pumblend' RGB-color", function()
     screen:try_resize(60,14)
     screen:set_default_attr_ids({
       [1] = {background = Screen.colors.Yellow},
@@ -1446,6 +1446,43 @@ describe('builtin popupmenu', function()
       reprehenderit in v{1:ol}uptate v{3:el}it esse cillum                |
       {5:[No Name] [+]                                               }|
       {20:-- INSERT --}                                                |
+    ]])
+  end)
+
+  it("'pumblend' 256-color (non-RGB)", function()
+    screen:detach()
+    screen = Screen.new(60, 8)
+    screen:attach({rgb=false, ext_popupmenu=false})
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.Grey0, background = tonumber('0x000007')},
+      [2] = {foreground = tonumber('0x000055'), background = tonumber('0x000007')},
+      [3] = {foreground = tonumber('0x00008f'), background = Screen.colors.Grey0},
+      [4] = {foreground = Screen.colors.Grey0, background = tonumber('0x0000e1')},
+      [5] = {foreground = tonumber('0x0000d1'), background = tonumber('0x0000e1')},
+      [6] = {foreground = Screen.colors.NavyBlue, background = tonumber('0x0000f8')},
+      [7] = {foreground = tonumber('0x0000a5'), background = tonumber('0x0000f8')},
+      [8] = {foreground = tonumber('0x00000c')},
+      [9] = {bold = true},
+      [10] = {foreground = tonumber('0x000002')},
+    })
+    command('set notermguicolors pumblend=10')
+    insert([[
+      Lorem ipsum dolor sit amet, consectetur
+      adipisicing elit, sed do eiusmod tempor
+      incididunt ut labore et dolore magna aliqua.
+      Ut enim ad minim veniam, quis nostrud
+      laborum.]])
+
+    feed('ggOdo<c-x><c-n>')
+    screen:expect([[
+      dolor^                                                       |
+      {1:dolor}{2: ipsum dol}or sit amet, consectetur                     |
+      {4:do}{5:ipisicing eli}t, sed do eiusmod tempor                     |
+      {4:dolore}{5:dunt ut l}abore et dolore magna aliqua.                |
+      Ut enim ad minim veniam, quis nostrud                       |
+      laborum.                                                    |
+      {8:~                                                           }|
+      {9:-- Keyword Local completion (^N^P) }{10:match 1 of 3}             |
     ]])
   end)
 end)


### PR DESCRIPTION
From the ministry of silly walks.

- Seems to work OK. Would prefer to just have a "greyscale" effect for the negative space, but whatever.
- `hl_cterm2rgb_color` was adapted from Vim 8.1 (`cterm_color2rgb`).
- `hl_cterm2rgb_color` and `hl_rgb2cterm_color` seem useful for other cases, e.g. to add cterm support for cursor coloring? cc @teto 

ref #9571