### PR TITLE
API: nvim_create_buf: add scratch parameter

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1256,6 +1256,7 @@ directory	Displays directory contents.  Can be used by a file explorer
 <		The buffer name is the name of the directory and is adjusted
 		when using the |:cd| command.
 
+						*scratch-buffer*
 scratch		Contains text that can be discarded at any time.  It is kept
 		when closing the window, it must be deleted explicitly.
 		Settings: >


### PR DESCRIPTION
Creating a scratch buffer is a bit of a chore/ritual, and would be more useful/common if formally exposed.

todo:

- [x] add tests

cc @bfredl 	