### PR TITLE
doc, gen_vimdoc.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [Wiki](https://github.com/neovim/neovim/wiki) |
 [Documentation](https://neovim.io/doc) |
-[Twitter](https://twitter.com/Neovim) |
-[Community](https://neovim.io/community/) |
-[Gitter **Chat**](https://gitter.im/neovim/neovim)
+[Chat/Discussion](https://gitter.im/neovim/neovim) |
+[Twitter](https://twitter.com/Neovim)
 
 [![Travis build status](https://travis-ci.org/neovim/neovim.svg?branch=master)](https://travis-ci.org/neovim/neovim)
 [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/urdqjrik5u521fac/branch/master?svg=true)](https://ci.appveyor.com/project/neovim/neovim/branch/master)
@@ -34,9 +33,8 @@ Features
 
 - Modern [GUIs](https://github.com/neovim/neovim/wiki/Related-projects#gui)
 - [API access](https://github.com/neovim/neovim/wiki/Related-projects#api-clients)
-  from any language including C/C++, C#, Clojure, D, Elixir, Lisp, Go,
-  Haskell, Java, JavaScript/Node.js, Julia, Lisp, Lua, Perl, Python, Racket,
-  Ruby, Rust
+  from any language including C/C++, C#, Clojure, D, Elixir, Go, Haskell, Java,
+  JavaScript/Node.js, Julia, Lisp, Lua, Perl, Python, Racket, Ruby, Rust
 - Embedded, scriptable [terminal emulator](https://neovim.io/doc/user/nvim_terminal_emulator.html)
 - Asynchronous [job control](https://github.com/neovim/neovim/pull/2247)
 - [Shared data (shada)](https://github.com/neovim/neovim/pull/2506) among multiple editor instances
@@ -51,8 +49,8 @@ Install from package
 Pre-built packages for Windows, macOS, and Linux are found on the
 [Releases](https://github.com/neovim/neovim/releases/) page.
 
-Managed packages are in [Homebrew], [Debian], [Ubuntu], [Fedora], [Arch Linux], [Gentoo],
-and [more](https://github.com/neovim/neovim/wiki/Installing-Neovim)!
+[Managed packages] are in Homebrew, [Debian], [Ubuntu], [Fedora], [Arch Linux],
+[Gentoo], and more!
 
 Install from source
 -------------------
@@ -144,7 +142,7 @@ See `LICENSE` for details.
 [nvim-features]: https://neovim.io/doc/user/vim_diff.html#nvim-features
 [Roadmap]: https://neovim.io/roadmap/
 [advanced UIs]: https://github.com/neovim/neovim/wiki/Related-projects#gui
-[Homebrew]: https://github.com/neovim/homebrew-neovim#installation
+[Managed packages]: https://github.com/neovim/neovim/wiki/Installing-Neovim#install-from-package
 [Debian]: https://packages.debian.org/testing/neovim
 [Ubuntu]: http://packages.ubuntu.com/search?keywords=neovim
 [Fedora]: https://apps.fedoraproject.org/packages/neovim

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -293,6 +293,9 @@ nvim_get_hl_by_name({name}, {rgb})                     *nvim_get_hl_by_name()*
                 Return: ~
                     Highlight definition map
 
+                See also: ~
+                    nvim_get_hl_by_id
+
 nvim_get_hl_by_id({hl_id}, {rgb})                        *nvim_get_hl_by_id()*
                 Gets a highlight definition by id. |hlID()|
 
@@ -302,6 +305,9 @@ nvim_get_hl_by_id({hl_id}, {rgb})                        *nvim_get_hl_by_id()*
 
                 Return: ~
                     Highlight definition map
+
+                See also: ~
+                    nvim_get_hl_by_name
 
 nvim_feedkeys({keys}, {mode}, {escape_csi})                  *nvim_feedkeys()*
                 Sends input-keys to Nvim, subject to various quirks controlled
@@ -316,6 +322,10 @@ nvim_feedkeys({keys}, {mode}, {escape_csi})                  *nvim_feedkeys()*
                     {escape_csi}  If true, escape K_SPECIAL/CSI bytes in
                                   `keys`
 
+                See also: ~
+                    feedkeys()
+                    vim_strsave_escape_csi
+
 nvim_input({keys})                                              *nvim_input()*
                 Queues raw user-input. Unlike |nvim_feedkeys()|, this uses a
                 low-level input buffer and the call is non-blocking (input is
@@ -326,7 +336,6 @@ nvim_input({keys})                                              *nvim_input()*
                 Note:
                     |keycodes| like <CR> are translated, so "<" is special. To
                     input a literal "<", send <LT>.
-
                 Note:
                     For mouse events use |nvim_input_mouse()|. The pseudokey
                     form "<LeftMouse><col,row>" is deprecated since
@@ -346,9 +355,8 @@ nvim_input({keys})                                              *nvim_input()*
 nvim_input_mouse({button}, {action}, {modifier}, {grid}, {row}, {col})
                 Send mouse event from GUI.
 
-                The call is non-blocking. It doesn't wait on any resulting
-                action, but queues the event to be processed soon by the event
-                loop.
+                Non-blocking: does not wait on any result, but queues the
+                event to be processed soon by the event loop.
 
                 Note:
                     Currently this doesn't support "scripting" multiple mouse
@@ -392,6 +400,10 @@ nvim_replace_termcodes({str}, {from_part}, {do_lt}, {special})
                     {special}    Replace |keycodes|, e.g. <CR> becomes a "\n"
                                  char.
 
+                See also: ~
+                    replace_termcodes
+                    cpoptions
+
 nvim_command_output({command})                         *nvim_command_output()*
                 Executes an ex-command and returns its (non-error) output.
                 Shell |:!| output is not captured.
@@ -420,7 +432,7 @@ nvim_execute_lua({code}, {args})                          *nvim_execute_lua()*
                 inside the chunk. The chunk can return a value.
 
                 Only statements are executed. To evaluate an expression,
-                prefix it with `return`: return my_function(...)
+                prefix it with `return` : return my_function(...)
 
                 Parameters: ~
                     {code}  lua code to execute
@@ -458,7 +470,7 @@ nvim_call_dict_function({dict}, {fn}, {args})      *nvim_call_dict_function()*
                     Result of the function call
 
 nvim_strwidth({text})                                        *nvim_strwidth()*
-                Calculates the number of display cells occupied by `text`.
+                Calculates the number of display cells occupied by `text` .
                 <Tab> counts as one cell.
 
                 Parameters: ~
@@ -575,11 +587,14 @@ nvim_err_writeln({str})                                   *nvim_err_writeln()*
                 Parameters: ~
                     {str}  Message
 
+                See also: ~
+                    nvim_err_write()
+
 nvim_list_bufs()                                            *nvim_list_bufs()*
                 Gets the current list of buffer handles
 
-                Includes unlisted (unloaded/deleted) buffers, like `:ls!`. Use
-                |nvim_buf_is_loaded()| to check if a buffer is loaded.
+                Includes unlisted (unloaded/deleted) buffers, like `:ls!` .
+                Use |nvim_buf_is_loaded()| to check if a buffer is loaded.
 
                 Return: ~
                     List of buffer handles
@@ -618,12 +633,15 @@ nvim_create_buf({listed}, {scratch})                       *nvim_create_buf()*
                 Creates a new, empty, unnamed buffer.
 
                 Parameters: ~
-                    {listed}   Controls 'buflisted'
+                    {listed}   Sets 'buflisted'
                     {scratch}  Creates a "throwaway" |scratch-buffer| for
                                temporary work (always 'nomodified')
 
                 Return: ~
                     Buffer handle, or 0 on error
+
+                See also: ~
+                    buf_open_scratch
 
 nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                 Open a new window.
@@ -639,51 +657,6 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
 
                 Exactly one of `external` and `relative` must be specified.
 
-                Parameters: ~
-                    {buffer}   handle of buffer to be displayed in the window
-                    {enter}    whether the window should be entered (made the
-                               current window)
-                    {config}   Dictionary for the window configuration accepts
-                               these keys:
-
-                        `relative`: If set, the window becomes a
-                        floating window. The window will be placed with
-                        row,col coordinates relative to one of the
-                        following:
-                            "editor" the global editor grid
-                            "win"    a window. Use `win` to specify window id,
-                                     or current window will be used by default.
-                            "cursor" the cursor position in current window.
-
-                        `win`: when using `relative='win'`, window id of the window
-                        where the position is defined.
-
-                        `anchor`: the corner of the float that the row,col
-                        position defines
-                            "NW" north-west (default)
-                            "NE" north-east
-                            "SW" south-west
-                            "SE" south-east
-
-                        `focusable`: Whether window can be focused by wincmds and
-                        mouse events. Defaults to true. Even if set to false,
-                        the window can still be entered using
-                        |nvim_set_current_win()| API call.
-
-                        `height`: Window height in character cells. Minimum of 1.
-
-                        `width`: Window width in character cells. Minimum of 2.
-
-                        `row`: row position. Screen cell height are used as unit.
-                        Can be floating point.
-
-                        `col`: column position.  Screen cell width is used as
-                        unit. Can be floating point.
-
-                        `external`: GUI should display the window as an external
-                        top-level window. Currently accepts no other
-                        positioning configuration together with this.
-
                 With editor positioning row=0, col=0 refers to the top-left
                 corner of the screen-grid and row=Lines-1, Columns-1 refers to
                 the bottom-right corner. Floating point values are allowed,
@@ -698,9 +671,49 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                 should not be used to specify arbitrary WM screen positions.
 
                 Parameters: ~
+                    {buffer}  handle of buffer to be displayed in the window
+                    {enter}   whether the window should be entered (made the
+                              current window)
+                    {config}  Dictionary for the window configuration accepts
+                              these keys:
+                              -  `relative` : If set, the window becomes a floating
+                                window. The window will be placed with row,col
+                                coordinates relative to one of the following:
+                                - "editor" the global editor grid
+                                - "win" a window. Use `win` to specify a
+                                  window id, or the current window will be
+                                  used by default. "cursor" the cursor
+                                  position in current window.
+
+                              - `win` : When using relative='win', window id
+                                of the window where the position is defined.
+                              -  `anchor` : The corner of the float that the row,col
+                                position defines:
+                                - "NW" north-west (default)
+                                - "NE" north-east
+                                - "SW" south-west
+                                - "SE" south-east
+
+                              - `height` : window height (in character cells).
+                                Minimum of 1.
+                              - `width` : window width (in character cells).
+                                Minimum of 2.
+                              - `row` : row position. Screen cell height are
+                                used as unit. Can be floating point.
+                              - `col` : column position. Screen cell width is
+                                used as unit. Can be floating point.
+                              - `focusable` : Whether window can be focused by
+                                wincmds and mouse events. Defaults to true.
+                                Even if set to false, the window can still be
+                                entered using |nvim_set_current_win()| API
+                                call.
+                              - `external` : GUI should display the window as
+                                an external top-level window. Currently
+                                accepts no other positioning configuration
+                                together with this.
 
                 Return: ~
-                    the window handle or 0 when error
+                    Window handle, or 0 on error
 
 nvim_list_tabpages()                                    *nvim_list_tabpages()*
                 Gets the current list of tabpage handles.
@@ -808,86 +821,87 @@ nvim_get_api_info()                                      *nvim_get_api_info()*
                                                       *nvim_set_client_info()*
 nvim_set_client_info({name}, {version}, {type}, {methods},
                      {attributes})
-                Identify the client for nvim. Can be called more than once,
-                but subsequent calls will remove earlier info, which should be
-                resent if it is still valid. (This could happen if a library
-                first identifies the channel, and a plugin using that library
-                later overrides that info)
+                Identifies the client. Can be called more than once;
+                subsequent calls remove earlier info, which should be included
+                by the caller if it is still valid. (E.g. if a library first
+                identifies the channel, then a plugin using that library later
+                overrides that info)
 
                 Parameters: ~
-                    {name}        short name for the connected client
-                    {version}     Dictionary describing the version, with the
-                                  following possible keys (all optional)
-                                  "major" major version (defaults to 0 if not
-                                  set, for no release yet)  "minor" minor
-                                  version  "patch" patch number  "prerelease"
-                                  string describing a prerelease, like "dev"
-                                  or "beta1"  "commit" hash or similar
-                                  identifier of commit
-                    {type}        Must be one of the following values. A
-                                  client library should use "remote" if the
-                                  library user hasn't specified other value.
-                                  "remote" remote client that connected to
-                                  nvim.  "ui" gui frontend  "embedder"
-                                  application using nvim as a component, for
-                                  instance IDE/editor implementing a vim mode.
-                                  "host" plugin host, typically started by
-                                  nvim  "plugin" single plugin, started by
-                                  nvim
+                    {name}        Short name for the connected client
+                    {version}     Dictionary describing the version, with
+                                  these (optional) keys:
+                                  - "major" major version (defaults to 0 if
+                                    not set, for no release yet)
+                                  - "minor" minor version
+                                  - "patch" patch number
+                                  - "prerelease" string describing a
+                                    prerelease, like "dev" or "beta1"
+                                  - "commit" hash or similar identifier of
+                                    commit
+                    {type}        Must be one of the following values. Client
+                                  libraries should default to "remote" unless
+                                  overridden by the user.
+                                  - "remote" remote client connected to Nvim.
+                                  - "ui" gui frontend
+                                  - "embedder" application using Nvim as a
+                                    component (for example, IDE/editor
+                                    implementing a vim mode).
+                                  - "host" plugin host, typically started by
+                                    nvim
+                                  - "plugin" single plugin, started by nvim
                     {methods}     Builtin methods in the client. For a host,
                                   this does not include plugin methods which
                                   will be discovered later. The key should be
                                   the method name, the values are dicts with
-                                  the following (optional) keys:   "async" if
-                                  true, send as a notification. If false or
-                                  unspecified, use a blocking request  "nargs"
-                                  Number of arguments. Could be a single
-                                  integer or an array two integers, minimum
-                                  and maximum inclusive. Further keys might be
-                                  added in later versions of nvim and unknown
-                                  keys are thus ignored. Clients must only use
-                                  keys defined in this or later versions of
-                                  nvim!
-                    {attributes}  Informal attributes describing the client.
-                                  Clients might define their own keys, but the
-                                  following are suggested:   "website" Website
-                                  of client (for instance github repository)
-                                  "license" Informal description of the
-                                  license, such as "Apache 2", "GPLv3" or
-                                  "MIT"  "logo" URI or path to image,
-                                  preferably small logo or icon. .png or .svg
-                                  format is preferred.
+                                  these (optional) keys (more keys may be
+                                  added in future versions of Nvim, thus
+                                  unknown keys are ignored. Clients must only
+                                  use keys defined in this or later versions
+                                  of Nvim):
+                                  - "async" if true, send as a notification.
+                                    If false or unspecified, use a blocking
+                                    request
+                                  - "nargs" Number of arguments. Could be a
+                                    single integer or an array of two
+                                    integers, minimum and maximum inclusive.
+                    {attributes}  Arbitrary string:string map of informal
+                                  client properties. Suggested keys:
+                                  - "website": Client homepage URL (e.g.
+                                    GitHub repository)
+                                  - "license": License description ("Apache
+                                    2", "GPLv3", "MIT", …)
+                                  - "logo": URI or path to image, preferably
+                                    small logo or icon. .png or .svg format is
+                                    preferred.
 
 nvim_get_chan_info({chan})                              *nvim_get_chan_info()*
                 Get information about a channel.
 
                 Return: ~
-                    a Dictionary, describing a channel with the following
-                    keys:
+                    Dictionary describing a channel, with these keys:
+                    - "stream" the stream underlying the channel
+                      - "stdio" stdin and stdout of this Nvim instance
+                      - "stderr" stderr of this Nvim instance
+                      - "socket" TCP/IP socket or named pipe
+                      - "job" job with communication over its stdio
 
-                    `stream`: the stream underlying the channel:
-                        "stdio"   stdin and stdout of this Nvim instance.
-                        "stderr"  stderr of this Nvim instance.
-                        "socket"  TCP/IP socket or named pipe.
-                        "job"     job with communication over its stdio.
+                    - "mode" how data received on the channel is interpreted
+                      - "bytes" send and receive raw bytes
+                      - "terminal" a |terminal| instance interprets ASCII
+                        sequences
+                      - "rpc" |RPC| communication on the channel is active
 
-                    `mode`: how data received on the channel is interpreted:
-                        "bytes"    send and recieve raw bytes.
-                        "terminal" a |terminal| instance interprets ASCII sequences
-                        "rpc"      |RPC| communication on the channel is active
-
-                    `pty`: Name of pseudoterminal, if one is used (optional).
-                    On a POSIX system, this will be a device path like
-                    /dev/pts/1. Even if the name is unknown, the key will
-                    still be present to indicate a pty is used. This is
-                    currently the case when using winpty on windows.
-
-                    `buffer`: buffer with connected |terminal|
-                    instance (optional).
-
-                    `client`: information about the client on the other end of
-                    the RPC channel, if it has added it using
-                    |nvim_set_client_info()| (optional).
+                    - "pty" Name of pseudoterminal, if one is used (optional).
+                      On a POSIX system, this will be a device path like
+                      /dev/pts/1. Even if the name is unknown, the key will
+                      still be present to indicate a pty is used. This is
+                      currently the case when using winpty on windows.
+                    - "buffer" buffer with connected |terminal| instance
+                      (optional)
+                    - "client" information about the client on the other end
+                      of the RPC channel, if it has added it using
+                      |nvim_set_client_info()|. (optional)
 
 nvim_list_chans()                                          *nvim_list_chans()*
                 Get information about all open channels.
@@ -901,12 +915,12 @@ nvim_call_atomic({calls})                                 *nvim_call_atomic()*
 
                 This has two main usages:
                 1. To perform several requests from an async context
-                atomically, i.e. without interleaving redraws, RPC requests
-                from other clients, or user interactions (however API methods
-                may trigger autocommands or event processing which have such
-                side-effects, e.g. |:sleep| may wake timers).
+                   atomically, i.e. without interleaving redraws, RPC requests
+                   from other clients, or user interactions (however API
+                   methods may trigger autocommands or event processing which
+                   have such side-effects, e.g. |:sleep| may wake timers).
                 2. To minimize RPC overhead (roundtrips) of a sequence of many
-                requests.
+                   requests.
 
                 Parameters: ~
                     {calls}  an array of calls, where each call is described
@@ -914,13 +928,13 @@ nvim_call_atomic({calls})                                 *nvim_call_atomic()*
                              and an array of arguments.
 
                 Return: ~
-                    an array with two elements. The first is an array of
-                    return values. The second is NIL if all calls succeeded.
-                    If a call resulted in an error, it is a three-element
-                    array with the zero-based index of the call which resulted
-                    in an error, the error type and the error message. If an
-                    error occurred, the values from all preceding calls will
-                    still be returned.
+                    Array of two elements. The first is an array of return
+                    values. The second is NIL if all calls succeeded. If a
+                    call resulted in an error, it is a three-element array
+                    with the zero-based index of the call which resulted in an
+                    error, the error type and the error message. If an error
+                    occurred, the values from all preceding calls will still
+                    be returned.
 
                                                      *nvim_parse_expression()*
 nvim_parse_expression({expr}, {flags}, {highlight})
@@ -930,20 +944,24 @@ nvim_parse_expression({expr}, {flags}, {highlight})
                     {async}
 
                 Parameters: ~
-                    {expr}       Expression to parse. Is always treated as a
+                    {expr}       Expression to parse. Always treated as a
                                  single line.
-                    {flags}      Flags:  - "m" if multiple expressions in a
-                                 row are allowed (only the first one will be
-                                 parsed), - "E" if EOC tokens are not allowed
-                                 (determines whether they will stop parsing
-                                 process or be recognized as an
-                                 operator/space, though also yielding an
-                                 error). - "l" when needing to start parsing
-                                 with lvalues for ":let" or ":for". Common
-                                 flag sets: - "m" to parse like for ":echo". -
-                                 "E" to parse like for "<C-r>=". - empty
-                                 string for ":call". - "lm" to parse for
-                                 ":let".
+                    {flags}      Flags:
+                                 - "m" if multiple expressions in a row are
+                                   allowed (only the first one will be
+                                   parsed),
+                                 - "E" if EOC tokens are not allowed
+                                   (determines whether they will stop parsing
+                                   process or be recognized as an
+                                   operator/space, though also yielding an
+                                   error).
+                                 - "l" when needing to start parsing with
+                                   lvalues for ":let" or ":for". Common flag
+                                   sets:
+                                 - "m" to parse like for ":echo".
+                                 - "E" to parse like for "<C-r>=".
+                                 - empty string for ":call".
+                                 - "lm" to parse for ":let".
                     {highlight}  If true, return value will also include
                                  "highlight" key containing array of 4-tuples
                                  (arrays) (Integer, Integer, Integer, String),
@@ -954,51 +972,66 @@ nvim_parse_expression({expr}, {flags}, {highlight})
                                  [start_col, end_col)).
 
                 Return: ~
-                    AST: top-level dictionary with these keys: "error":
-                    Dictionary with error, present only if parser saw some
-                    error. Contains the following keys: "message": String,
-                    error message in printf format, translated. Must contain
-                    exactly one "%.*s". "arg": String, error message argument.
-                    "len": Amount of bytes successfully parsed. With flags
-                    equal to "" that should be equal to the length of expr
-                    string. @note: “Sucessfully parsed” here means
-                    “participated in AST creation”, not “till the first
-                    error”. "ast": AST, either nil or a dictionary with these
-                    keys: "type": node type, one of the value names from
-                    ExprASTNodeType stringified without "kExprNode" prefix.
-                    "start": a pair [line, column] describing where node is
-                    “started” where "line" is always 0 (will not be 0 if you
-                    will be using nvim_parse_viml() on e.g. ":let", but that
-                    is not present yet). Both elements are Integers. "len":
-                    “length” of the node. This and "start" are there for
-                    debugging purposes primary (debugging parser and providing
-                    debug information). "children": a list of nodes described
-                    in top/"ast". There always is zero, one or two children,
-                    key will not be present if node has no children. Maximum
-                    number of children may be found in node_maxchildren array.
-                    Local values (present only for certain nodes): "scope": a
-                    single Integer, specifies scope for "Option" and
-                    "PlainIdentifier" nodes. For "Option" it is one of
-                    ExprOptScope values, for "PlainIdentifier" it is one of
-                    ExprVarScope values. "ident": identifier (without scope,
-                    if any), present for "Option", "PlainIdentifier",
-                    "PlainKey" and "Environment" nodes. "name": Integer,
-                    register name (one character) or -1. Only present for
-                    "Register" nodes. "cmp_type": String, comparison type, one
-                    of the value names from ExprComparisonType, stringified
-                    without "kExprCmp" prefix. Only present for "Comparison"
-                    nodes. "ccs_strategy": String, case comparison strategy,
-                    one of the value names from ExprCaseCompareStrategy,
-                    stringified without "kCCStrategy" prefix. Only present for
-                    "Comparison" nodes. "augmentation": String, augmentation
-                    type for "Assignment" nodes. Is either an empty string,
-                    "Add", "Subtract" or "Concat" for "=", "+=", "-=" or ".="
-                    respectively. "invert": Boolean, true if result of
-                    comparison needs to be inverted. Only present for
-                    "Comparison" nodes. "ivalue": Integer, integer value for
-                    "Integer" nodes. "fvalue": Float, floating-point value for
-                    "Float" nodes. "svalue": String, value for
-                    "SingleQuotedString" and "DoubleQuotedString" nodes.
+
+                    - AST: top-level dictionary with these keys:
+                      - "error": Dictionary with error, present only if parser
+                        saw some error. Contains the following keys:
+                        - "message": String, error message in printf format,
+                          translated. Must contain exactly one "%.*s".
+                        - "arg": String, error message argument.
+
+                      - "len": Amount of bytes successfully parsed. With flags
+                        equal to "" that should be equal to the length of expr
+                        string. (“Sucessfully parsed” here means “participated
+                        in AST creation”, not “till the first error”.)
+                      - "ast": AST, either nil or a dictionary with these
+                        keys:
+                        - "type": node type, one of the value names from
+                          ExprASTNodeType stringified without "kExprNode"
+                          prefix.
+                        - "start": a pair [line, column] describing where node
+                          is "started" where "line" is always 0 (will not be 0
+                          if you will be using nvim_parse_viml() on e.g.
+                          ":let", but that is not present yet). Both elements
+                          are Integers.
+                        - "len": “length” of the node. This and "start" are
+                          there for debugging purposes primary (debugging
+                          parser and providing debug information).
+                        - "children": a list of nodes described in top/"ast".
+                          There always is zero, one or two children, key will
+                          not be present if node has no children. Maximum
+                          number of children may be found in node_maxchildren
+                          array.
+
+                    - Local values (present only for certain nodes):
+                      - "scope": a single Integer, specifies scope for
+                        "Option" and "PlainIdentifier" nodes. For "Option" it
+                        is one of ExprOptScope values, for "PlainIdentifier"
+                        it is one of ExprVarScope values.
+                      - "ident": identifier (without scope, if any), present
+                        for "Option", "PlainIdentifier", "PlainKey" and
+                        "Environment" nodes.
+                      - "name": Integer, register name (one character) or -1.
+                        Only present for "Register" nodes.
+                      - "cmp_type": String, comparison type, one of the value
+                        names from ExprComparisonType, stringified without
+                        "kExprCmp" prefix. Only present for "Comparison"
+                        nodes.
+                      - "ccs_strategy": String, case comparison strategy, one
+                        of the value names from ExprCaseCompareStrategy,
+                        stringified without "kCCStrategy" prefix. Only present
+                        for "Comparison" nodes.
+                      - "augmentation": String, augmentation type for
+                        "Assignment" nodes. Is either an empty string, "Add",
+                        "Subtract" or "Concat" for "=", "+=", "-=" or ".="
+                        respectively.
+                      - "invert": Boolean, true if result of comparison needs
+                        to be inverted. Only present for "Comparison" nodes.
+                      - "ivalue": Integer, integer value for "Integer" nodes.
+                      - "fvalue": Float, floating-point value for "Float"
+                        nodes.
+                      - "svalue": String, value for "SingleQuotedString" and
+                        "DoubleQuotedString" nodes.
 
 nvim__id({obj})                                                   *nvim__id()*
                 Returns object given as argument.
@@ -1058,23 +1091,22 @@ nvim_list_uis()                                              *nvim_list_uis()*
                 Gets a list of dictionaries representing attached UIs.
 
                 Return: ~
-                    Array of UI dictionaries. Each dictionary has the
-                    following keys:
-                        `height`:  requested height of the UI
-                        `width`:   requested width of the UI
-                        `rgb`:     whether the UI uses rgb colors
-                                   (false implies cterm colors)
-                        `ext_...`: Requested UI extensions, see |ui-options|
-                        `chan`:    Channel id of remote UI (not present for TUI)
+                    Array of UI dictionaries, each with these keys:
+                    - "height" requested height of the UI
+                    - "width" requested width of the UI
+                    - "rgb" whether the UI uses rgb colors (false implies
+                      cterm colors)
+                    - "ext_..." Requested UI extensions, see |ui-options|
+                    - "chan" Channel id of remote UI (not present for TUI)
 
 nvim_get_proc_children({pid})                       *nvim_get_proc_children()*
-                Gets the immediate children of process `pid`.
+                Gets the immediate children of process `pid` .
 
                 Return: ~
                     Array of child process ids, empty if process not found.
 
 nvim_get_proc({pid})                                         *nvim_get_proc()*
-                Gets info describing process `pid`.
+                Gets info describing process `pid` .
 
                 Return: ~
                     Map of process properties, or NIL if process not found.
@@ -1096,7 +1128,7 @@ nvim_select_popupmenu_item({item}, {insert}, {finish}, {opts})
                     {insert}  Whether the selection should be inserted in the
                               buffer.
                     {finish}  Finish the completion and dismiss the popupmenu.
-                              Implies `insert`.
+                              Implies `insert` .
                     {opts}    Optional parameters. Reserved for future use.
 
 nvim__inspect_cell({row}, {col})                        *nvim__inspect_cell()*
@@ -1123,7 +1155,7 @@ nvim_buf_line_count({buffer})                          *nvim_buf_line_count()*
                 Gets the buffer line count
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
 
                 Return: ~
                     Line count, or 0 for unloaded buffer. |api-buffer|
@@ -1132,11 +1164,11 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
                 Activate updates from this buffer to the current channel.
 
                 Parameters: ~
-                    {buffer}       The buffer handle
+                    {buffer}       Buffer handle, or 0 for current buffer
                     {send_buffer}  Set to true if the initial notification
                                    should contain the whole buffer. If so, the
                                    first notification will be a
-                                   `nvim_buf_lines_event`. Otherwise, the
+                                   `nvim_buf_lines_event` . Otherwise, the
                                    first notification will be a
                                    `nvim_buf_changedtick_event`
                     {opts}         Optional parameters. Reserved for future
@@ -1144,14 +1176,14 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
 
                 Return: ~
                     False when updates couldn't be enabled because the buffer
-                    isn't loaded or optscontained an invalid key; otherwise
+                    isn't loaded or `opts` contained an invalid key; otherwise
                     True.
 
 nvim_buf_detach({buffer})                                  *nvim_buf_detach()*
                 Deactivate updates from this buffer to the current channel.
 
                 Parameters: ~
-                    {buffer}  The buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
 
                 Return: ~
                     False when updates couldn't be disabled because the buffer
@@ -1169,7 +1201,7 @@ nvim_buf_get_lines({buffer}, {start}, {end}, {strict_indexing})
                 unless `strict_indexing` is set.
 
                 Parameters: ~
-                    {buffer}           Buffer handle
+                    {buffer}           Buffer handle, or 0 for current buffer
                     {start}            First line index
                     {end}              Last line index (exclusive)
                     {strict_indexing}  Whether out-of-bounds should be an
@@ -1196,7 +1228,7 @@ nvim_buf_set_lines({buffer}, {start}, {end}, {strict_indexing},
                 unless `strict_indexing` is set.
 
                 Parameters: ~
-                    {buffer}           Buffer handle
+                    {buffer}           Buffer handle, or 0 for current buffer
                     {start}            First line index
                     {end}              Last line index (exclusive)
                     {strict_indexing}  Whether out-of-bounds should be an
@@ -1216,7 +1248,7 @@ nvim_buf_get_offset({buffer}, {index})                 *nvim_buf_get_offset()*
                 Returns -1 for unloaded buffer.
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
                     {index}   Line index
 
                 Return: ~
@@ -1226,7 +1258,7 @@ nvim_buf_get_var({buffer}, {name})                        *nvim_buf_get_var()*
                 Gets a buffer-scoped (b:) variable.
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
                     {name}    Variable name
 
                 Return: ~
@@ -1236,17 +1268,17 @@ nvim_buf_get_changedtick({buffer})                *nvim_buf_get_changedtick()*
                 Gets a changed tick of a buffer
 
                 Parameters: ~
-                    {buffer}  Buffer handle.
+                    {buffer}  Buffer handle, or 0 for current buffer
 
                 Return: ~
-                    b:changedtickvalue.
+                    `b:changedtick` value.
 
 nvim_buf_get_keymap({buffer}, {mode})                  *nvim_buf_get_keymap()*
                 Gets a list of buffer-local |mapping| definitions.
 
                 Parameters: ~
                     {mode}    Mode short-name ("n", "i", "v", ...)
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
 
                 Return: ~
                     Array of maparg()-like dictionaries describing mappings.
@@ -1256,7 +1288,7 @@ nvim_buf_get_commands({buffer}, {opts})              *nvim_buf_get_commands()*
                 Gets a map of buffer-local |user-commands|.
 
                 Parameters: ~
-                    {buffer}  Buffer handle.
+                    {buffer}  Buffer handle, or 0 for current buffer
                     {opts}    Optional parameters. Currently not used.
 
                 Return: ~
@@ -1266,7 +1298,7 @@ nvim_buf_set_var({buffer}, {name}, {value})               *nvim_buf_set_var()*
                 Sets a buffer-scoped (b:) variable
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
                     {name}    Variable name
                     {value}   Variable value
 
@@ -1274,14 +1306,14 @@ nvim_buf_del_var({buffer}, {name})                        *nvim_buf_del_var()*
                 Removes a buffer-scoped (b:) variable
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
                     {name}    Variable name
 
 nvim_buf_get_option({buffer}, {name})                  *nvim_buf_get_option()*
                 Gets a buffer option value
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
                     {name}    Option name
 
                 Return: ~
@@ -1292,7 +1324,7 @@ nvim_buf_set_option({buffer}, {name}, {value})         *nvim_buf_set_option()*
                 option (only works if there's a global fallback)
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
                     {name}    Option name
                     {value}   Option value
 
@@ -1300,7 +1332,7 @@ nvim_buf_get_name({buffer})                              *nvim_buf_get_name()*
                 Gets the full file name for the buffer
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
 
                 Return: ~
                     Buffer name
@@ -1309,7 +1341,7 @@ nvim_buf_set_name({buffer}, {name})                      *nvim_buf_set_name()*
                 Sets the full file name for a buffer
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
                     {name}    Buffer name
 
 nvim_buf_is_loaded({buffer})                            *nvim_buf_is_loaded()*
@@ -1317,7 +1349,7 @@ nvim_buf_is_loaded({buffer})                            *nvim_buf_is_loaded()*
                 more info about unloaded buffers.
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
 
                 Return: ~
                     true if the buffer is valid and loaded, false otherwise.
@@ -1330,7 +1362,7 @@ nvim_buf_is_valid({buffer})                              *nvim_buf_is_valid()*
                     |api-buffer| for more info about unloaded buffers.
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
 
                 Return: ~
                     true if the buffer is valid, false otherwise.
@@ -1340,7 +1372,7 @@ nvim_buf_get_mark({buffer}, {name})                      *nvim_buf_get_mark()*
                 named mark
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
                     {name}    Mark name
 
                 Return: ~
@@ -1364,7 +1396,7 @@ nvim_buf_add_highlight({buffer}, {ns_id}, {hl_group}, {line},
                 `ns_id` to add highlights to the namespace. All highlights in
                 the same namespace can then be cleared with single call to
                 |nvim_buf_clear_namespace|. If the highlight never will be
-                deleted by an API call, pass `ns_id = -1`.
+                deleted by an API call, pass `ns_id = -1` .
 
                 As a shorthand, `ns_id = 0` can be used to create a new
                 namespace for the highlight, the allocated id is then
@@ -1374,7 +1406,7 @@ nvim_buf_add_highlight({buffer}, {ns_id}, {hl_group}, {line},
                 |nvim_create_namespace| to create a new empty namespace.
 
                 Parameters: ~
-                    {buffer}     Buffer handle
+                    {buffer}     Buffer handle, or 0 for current buffer
                     {ns_id}      namespace to use or -1 for ungrouped
                                  highlight
                     {hl_group}   Name of the highlight group to use
@@ -1396,7 +1428,7 @@ nvim_buf_clear_namespace({buffer}, {ns_id}, {line_start}, {line_end})
                 to line_start and line_end respectively.
 
                 Parameters: ~
-                    {buffer}      Buffer handle
+                    {buffer}      Buffer handle, or 0 for current buffer
                     {ns_id}       Namespace to clear, or -1 to clear all
                                   namespaces.
                     {line_start}  Start of range of lines to clear
@@ -1420,14 +1452,14 @@ nvim_buf_set_virtual_text({buffer}, {ns_id}, {line}, {chunks}, {opts})
                 both virtual text and highlights added by
                 |nvim_buf_add_highlight|, both can then be cleared with a
                 single call to |nvim_buf_clear_namespace|. If the virtual text
-                never will be cleared by an API call, pass `ns_id = -1`.
+                never will be cleared by an API call, pass `ns_id = -1` .
 
                 As a shorthand, `ns_id = 0` can be used to create a new
                 namespace for the virtual text, the allocated id is then
                 returned.
 
                 Parameters: ~
-                    {buffer}  Buffer handle
+                    {buffer}  Buffer handle, or 0 for current buffer
                     {ns_id}   Namespace to use or 0 to create a namespace, or
                               -1 for a ungrouped annotation
                     {line}    Line to annotate with virtual text
@@ -1601,7 +1633,7 @@ nvim_win_set_config({window}, {config})                *nvim_win_set_config()*
                 parameters.
 
                 When reconfiguring a floating window, absent option keys will
-                not be changed. The following restriction apply: `row`, `col`
+                not be changed. The following restriction apply: `row` , `col`
                 and `relative` must be reconfigured together. Only changing a
                 subset of these is an error.
 
@@ -1636,9 +1668,6 @@ nvim_win_close({window}, {force})                           *nvim_win_close()*
                               buffer will become hidden, even if 'hidden' is
                               not set.
 
-                Return: ~
-                    Window number
-
 
 ==============================================================================
 Tabpage Functions                                                *api-tabpage*
@@ -1650,7 +1679,7 @@ nvim_tabpage_list_wins({tabpage})                   *nvim_tabpage_list_wins()*
                     {tabpage}  Tabpage
 
                 Return: ~
-                    List of windows in tabpage
+                    List of windows in `tabpage`
 
 nvim_tabpage_get_var({tabpage}, {name})               *nvim_tabpage_get_var()*
                 Gets a tab-scoped (t:) variable

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -43,7 +43,7 @@ effects.  Be careful not to destroy your text.
 :au[tocmd] [group] {event} {pat} [++once] [++nested] {cmd}
 			Add {cmd} to the list of commands that Vim will
 			execute automatically on {event} for a file matching
-			{pat} |autocmd-patterns|.
+			{pat} |autocmd-pattern|.
 			Note: A quote character is seen as argument to the
 			:autocmd and won't start a comment.
 			Nvim always adds {cmd} after existing autocommands so
@@ -358,7 +358,7 @@ Name			triggered by ~
 |CompleteDone|		after Insert mode completion is done
 
 |User|			to be used in combination with ":doautocmd"
-|Signal|		after the nvim process received a signal
+|Signal|		after Nvim receives a signal
 
 
 
@@ -870,27 +870,27 @@ MenuPopupChanged 					*MenuPopupChanged*
 				It is not allowed to change the text |textlock|.
 
 							*OptionSet*
-OptionSet			After setting an option.  The pattern is
-				matched against the long option name.
-				The |v:option_old| variable indicates the
-				old option value, |v:option_new| variable
-				indicates the newly set value, the
-				|v:option_type| variable indicates whether
-				it's global or local scoped and |<amatch>|
-				indicates what option has been set.
+OptionSet			After setting an option (except during
+				|startup|).  The |autocmd-pattern| is matched
+				against the long option name.
+				|v:option_old| indicates the old option value,
+				|v:option_new| indicates the new value,
+				|v:option_type| indicates whether it's global
+				or local scoped and |<amatch>| indicates which
+				option was set.
 
 				Usage example: Check for the existence of the
 				directory in the 'backupdir' and 'undodir'
 				options, create the directory if it doesn't
 				exist yet.
 
-				Note: It's a bad idea to reset an option
-				during this autocommand, this may break a
-				plugin. You can always use `:noa` to prevent
-				triggering this autocommand.
+				Note: Do not reset the same option during this
+				autocommand, that may break plugins. You can
+				always use |:noautocmd| to prevent triggering
+				OptionSet.
 
-				When using |:set| in the autocommand the event
-				is not triggered again.
+				Recursion is ignored, thus |:set| in the
+				autocommand does not trigger OptionSet again.
 
 							*QuickFixCmdPre*
 QuickFixCmdPre			Before a quickfix command is run (|:make|,
@@ -943,10 +943,11 @@ ShellCmdPost			After executing a shell command with |:!cmd|,
 				For non-blocking shell commands, see
 				|job-control|.
 							*Signal*
-Signal				After the nvim process received a signal.
-				The pattern is matched against the name of the
-				received signal. Only "SIGUSR1" is supported.
-							*ShellFilterPost*
+Signal				After Nvim receives a signal. The pattern is
+				matched against the signal name. Only
+				"SIGUSR1" is supported.  Example: >
+				    autocmd Signal SIGUSR1 call some#func()
+<							*ShellFilterPost*
 ShellFilterPost			After executing a shell command with
 				":{range}!cmd", ":w !cmd" or ":r !cmd".
 				Can be used to check for any changed files.
@@ -1123,7 +1124,7 @@ WinNew				When a new window was created.  Not done for
 				Before a WinEnter event.
 
 ==============================================================================
-6. Patterns					*autocmd-patterns* *{pat}*
+6. Patterns					*autocmd-pattern* *{pat}*
 
 The {pat} argument can be a comma separated list.  This works as if the
 command was given with each pattern separately.  Thus this command: >

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -63,6 +63,15 @@ Options ~
 *'vi'*
 *'viminfo'*		Deprecated alias to 'shada' option.
 
+UI extensions~
+*ui-wildmenu*		Use `ext_cmdline` and `ext_popupmenu` instead.
+			Enabled by `ext_wildmenu` |ui-options|.
+			If `ext_wildmenu` is set, these events are emitted for
+			backwards-compatibility:
+				["wildmenu_show", items]
+				["wildmenu_select", selected]
+				["wildmenu_hide"]
+
 Variables~
 *b:terminal_job_pid*	PID of the top-level process in a |:terminal|.
 			Use `jobpid(&channel)` instead.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3782,7 +3782,7 @@ function({name} [, {arglist}] [, {dict}])
 		same function.
 
 		When {arglist} or {dict} is present this creates a partial.
-		That mans the argument list and/or the dictionary is stored in
+		That means the argument list and/or the dictionary is stored in
 		the Funcref and will be used when the Funcref is called.
 
 		The arguments are passed to the function in front of other

--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -16,11 +16,11 @@ an idea of what lurks beneath: >
 
     :lua print(vim.inspect(package.loaded))
 
-Nvim includes a "standard library" |lua-stdlib| for Lua.  This library
-complements the Nvim editor |functions| and Ex commands (the editor "stdlib"),
-which can also be used from Lua code.
+Nvim includes a "standard library" |lua-stdlib| for Lua.  It complements the
+"editor stdlib" (|functions| and Ex commands) and the |API|, all of which can
+be used from Lua code.
 
-Nvim resolves module conflicts by "last wins".  For example if both of these
+Module conflicts are resolved by "last wins".  For example if both of these
 are on 'runtimepath':
     runtime/lua/foo.lua
     ~/.config/nvim/lua/foo.lua
@@ -260,9 +260,9 @@ position are restricted when the command is executed in the |sandbox|.
 ==============================================================================
 vim.*							*lua-vim* *lua-stdlib*
 
-The "standard library" (stdlib) of Nvim Lua is the `vim` module, which exposes
-various functions and sub-modules.  The module is implicitly loaded, thus
-require("vim") is unnecessary.
+The Nvim Lua "standard library" (stdlib) is the `vim` module, which exposes
+various functions and sub-modules.  It is always loaded, thus require("vim")
+is unnecessary.
 
 You can peek at the module properties: >
 
@@ -288,7 +288,7 @@ To find documentation on e.g. the "deepcopy" function: >
 
     :help vim.deepcopy
 
-Note: Underscore-prefixed functions (e.g. "_os_proc_children") are
+Note that underscore-prefixed functions (e.g. "_os_proc_children") are
 internal/private and must not be used by plugins.
 
 ------------------------------------------------------------------------------

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -227,14 +227,14 @@ should not either insert or change the v:char.
 
 Be very careful about side effects!  The expression is evaluated while
 obtaining characters, you may very well make the command dysfunctional.
-For this reason the following is blocked:
+Therefore the following is blocked for <expr> mappings:
 - Changing the buffer text |textlock|.
 - Editing another buffer.
 - The |:normal| command.
 - Moving the cursor is allowed, but it is restored afterwards.
 - If the cmdline is changed, the old text and cursor position are restored.
 If you want the mapping to do any of these let the returned characters do
-that. Or use a |<Cmd>| mapping (which doesn't have these restrictions).
+that. (Or use a |<Cmd>| mapping instead.)
 
 You can use getchar(), it consumes typeahead if there is any. E.g., if you
 have these mappings: >
@@ -274,9 +274,9 @@ Using 0x80 as a single byte before other text does not work, it will be seen
 as a special key.
 
 						*<Cmd>* *:map-cmd*
-The <Cmd> pseudokey may be used to define a "command mapping", which executes
-the command directly (without changing modes, etc.).  Where you might use
-":...<CR>" in the {lhs} of a mapping, you can instead use "<Cmd>...<CR>".
+The <Cmd> pseudokey begins a "command mapping", which executes the command
+directly (without changing modes).  Where you might use ":...<CR>" in the
+{lhs} of a mapping, you can instead use "<Cmd>...<CR>".
 Example: >
 	noremap x <Cmd>echo mode(1)<cr>
 <
@@ -284,17 +284,21 @@ This is more flexible than `:<C-U>` in visual and operator-pending mode, or
 `<C-O>:` in insert-mode, because the commands are executed directly in the
 current mode (instead of always going to normal-mode).  Visual-mode is
 preserved, so tricks with |gv| are not needed.  Commands can be invoked
-directly in cmdline-mode (which otherwise would require timer hacks).
-
-Because <Cmd> avoids mode-changes (unlike ":") it does not trigger
-|CmdlineEnter| and |CmdlineLeave| events. This helps performance.
+directly in cmdline-mode (which would otherwise require timer hacks).
 
 Unlike <expr> mappings, there are no special restrictions on the <Cmd>
 command: it is executed as if an (unrestricted) |autocmd| was invoked or an
 async event event was processed.
 
-In select-mode, |:map| and |:vmap| command mappings are executed in
-visual-mode.  Use |:smap| to handle select-mode.
+Note:
+- Because <Cmd> avoids mode-changes (unlike ":") it does not trigger
+  |CmdlineEnter| and |CmdlineLeave| events. This helps performance.
+- For the same reason, |keycodes| like <C-R><C-W> are interpreted in the
+  context of the current mode, not cmdline-mode!  Thus <C-R><C-W> in a
+  :nnoremap (normal-mode) mapping does the normal-mode function of <C-R> and
+  <C-W> rather than the cmdline-mode <C-R><C-W> chord.
+- In select-mode, |:map| and |:vmap| command mappings are executed in
+  visual-mode.  Use |:smap| to handle select-mode.
 
 							*E5520*
 <Cmd> commands must terminate, that is, they must be followed by <CR> in the

--- a/runtime/doc/nvim.txt
+++ b/runtime/doc/nvim.txt
@@ -8,14 +8,14 @@ Nvim							   *nvim* *nvim-intro*
 
 Nvim is based on Vim by Bram Moolenaar.
 
+If you already use Vim see |nvim-from-vim| for a quickstart.
 If you are new to Vim, try the 30-minute tutorial: >
+
     :Tutor<Enter>
 
-If you already use Vim see |nvim-from-vim| for a quickstart.
-
-Nvim is emphatically a fork of Vim, not a clone: compatibility with Vim is
-maintained where possible. See |vim_diff.txt| for the complete reference of
-differences from Vim.
+Nvim is emphatically a fork of Vim, not a clone: compatibility with Vim
+(especially editor and VimL features) is maintained where possible. See
+|vim-differences| for the complete reference of differences from Vim.
 
 				      Type |gO| to see the table of contents.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -694,8 +694,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 							*'background'* *'bg'*
 'background' 'bg'	string	(default "dark")
 			global
-	When set to "dark" or "light", Nvim will adjust the default color
-	groups for a dark or light background, respectively.
+	When set to "dark" or "light", adjusts the default color groups for
+	that background type.  The |TUI| or other UI sets this on startup
+	(triggering |OptionSet|) if it can detect the background color.
 
 	This option does NOT change the background color, it tells Nvim what
 	the "inherited" (terminal/GUI) background looks like.
@@ -878,7 +879,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	A list of file patterns.  When one of the patterns matches with the
 	name of the file which is written, no backup file is created.  Both
 	the specified file name and the full path name of the file are used.
-	The pattern is used like with |:autocmd|, see |autocmd-patterns|.
+	The pattern is used like with |:autocmd|, see |autocmd-pattern|.
 	Watch out for special characters, see |option-backslash|.
 	When $TMPDIR, $TMP or $TEMP is not defined, it is not used for the
 	default value.  "/tmp/*" is only used for Unix.
@@ -1831,9 +1832,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	name.  See |option-backslash| about using backslashes.
 	This has nothing to do with the |Dictionary| variable type.
 	Where to find a list of words?
-	- On FreeBSD, there is the file "/usr/share/dict/words".
-	- In the Simtel archive, look in the "msdos/linguist" directory.
-	- In "miscfiles" of the GNU collection.
+	- BSD/macOS include the "/usr/share/dict/words" file.
+	- Try "apt install spell" to get the "/usr/share/dict/words" file on
+	  apt-managed systems (Debian/Ubuntu).
 	The use of |:set+=| and |:set-=| is preferred when adding or removing
 	directories from the list.  This avoids problems when a future version
 	uses another default.
@@ -4693,6 +4694,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  pack/		packages |:packadd|
 	  plugin/	plugin scripts |write-plugin|
 	  print/	files for printing |postscript-print-encoding|
+	  rplugin/	|remote-plugin| scripts
 	  spell/	spell checking files |spell|
 	  syntax/	syntax files |mysyntaxfile|
 	  tutor/	tutorial files |:Tutor|
@@ -6127,8 +6129,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	When set: Add 's' flag to 'shortmess' option (this makes the message
 	for a search that hits the start or end of the file not being
-	displayed).  When reset: Remove 's' flag from 'shortmess' option.  {Vi
-	shortens a lot of messages}
+	displayed).  When reset: Remove 's' flag from 'shortmess' option.
 
 						*'textwidth'* *'tw'*
 'textwidth' 'tw'	number	(default 0)
@@ -6506,7 +6507,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	patterns is ignored when expanding |wildcards|, completing file or
 	directory names, and influences the result of |expand()|, |glob()| and
 	|globpath()| unless a flag is passed to disable this.
-	The pattern is used like with |:autocmd|, see |autocmd-patterns|.
+	The pattern is used like with |:autocmd|, see |autocmd-pattern|.
 	Also see 'suffixes'.
 	Example: >
 		:set wildignore=*.o,*.obj

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -26,29 +26,34 @@ Nvim supports Python |remote-plugin|s and the Vim legacy |python2| and
 Note: Only the Vim 7.3 legacy interface is supported, not later features such
 as |python-bindeval| (Vim 7.4); use the Nvim API instead.
 
+
 PYTHON QUICKSTART ~
 
-Install the "pynvim" Python package:
+To use Python plugins, you need the "pynvim" module. Run |:checkhealth| to see
+if you already have it (some package managers install the module with Nvim
+itself).
 
-- Run |:checkhealth| to see if you already have the package (some package
-  managers install the "pynvim" Python package with Nvim itself).
+For Python 3 plugins:
+1. Make sure Python 3.4+ is available in your $PATH.
+2. Install the module (try "pip" if "pip3" is missing): >
+   pip3 install --user --upgrade pynvim
 
-- For Python 2 plugins, make sure Python 2.7 is available in your $PATH, then
-  install the package systemwide: >
-    sudo pip2 install --upgrade pynvim
-<  or for the current user: >
-    pip2 install --user --upgrade pynvim
-<  If "pip2" is missing, try "pip".
+For Python 2 plugins:
+1. Make sure Python 2.7 is available in your $PATH.
+2. Install the module (try "pip" if "pip2" is missing): >
+   pip2 install --user --upgrade pynvim
 
-- For Python 3 plugins, make sure Python 3.4+ is available in your $PATH, then
-  install the package systemwide: >
-    sudo pip3 install --upgrade pynvim
-<  or for the current user: >
-    pip3 install --user --upgrade pynvim
-<  If "pip3" is missing, try "pip".
+The pip `--upgrade` flag ensures that you get the latest version even if
+a previous version was already installed.
 
-- The `--upgrade` flag ensures you have the latest version even if a previous
-  version was already installed.
+See also |python-virtualenv|.
+
+Note: The old "neovim" module was renamed to "pynvim".
+https://github.com/neovim/neovim/wiki/Following-HEAD#20181118
+If you run into problems, uninstall _both_ then install "pynvim" again: >
+  pip uninstall neovim pynvim
+  pip install pynvim
+
 
 PYTHON PROVIDER CONFIGURATION ~
 						*g:python_host_prog*
@@ -69,8 +74,9 @@ To disable Python 2 support: >
 To disable Python 3 support: >
     let g:loaded_python3_provider = 1
 
-PYTHON VIRTUALENVS ~
 
+PYTHON VIRTUALENVS ~
+						*python-virtualenv*
 If you plan to use per-project virtualenvs often, you should assign one
 virtualenv for Neovim and hard-code the interpreter path via
 |g:python3_host_prog| (or |g:python_host_prog|) so that the "pynvim" package
@@ -93,12 +99,14 @@ Ruby integration		    	      *provider-ruby*
 Nvim supports Ruby |remote-plugin|s and the Vim legacy |ruby-vim| interface
 (which is itself implemented as a Nvim remote-plugin).
 
+
 RUBY QUICKSTART ~
 
 To use Ruby plugins with Nvim, install the latest "neovim" RubyGem: >
     gem install neovim
 
 Run |:checkhealth| to see if your system is up-to-date.
+
 
 RUBY PROVIDER CONFIGURATION ~
 						*g:loaded_ruby_provider*
@@ -122,12 +130,14 @@ Node.js integration				*provider-nodejs*
 Nvim supports Node.js |remote-plugin|s.
 https://github.com/neovim/node-client/
 
+
 NODEJS QUICKSTART~
 
 To use javascript remote-plugins with Nvim, install the "neovim" npm package: >
     npm install -g neovim
 
 Run |:checkhealth| to see if your system is up-to-date.
+
 
 NODEJS PROVIDER CONFIGURATION~
 						*g:loaded_node_provider*

--- a/runtime/doc/remote_plugin.txt
+++ b/runtime/doc/remote_plugin.txt
@@ -122,10 +122,10 @@ the example, say the Java plugin is a semantic completion engine for Java code.
 If it defines the autocommand "BufEnter *.java", then the Java host is spawned
 only when Nvim loads a buffer matching "*.java".
 
-If the explicit call to |:UpdateRemotePlugins| seems incovenient, try to see it
-like this: It's a way to provide IDE capabilities in Nvim while still keeping
-it fast and lightweight for general use. It's also analogous to the |:helptags|
-command.
+If the explicit call to |:UpdateRemotePlugins| seems inconvenient, try to see
+it like this: It's a way to provide IDE capabilities in Nvim while still
+keeping it fast and lightweight for general use. It's also analogous to the
+|:helptags| command.
 
 						*$NVIM_RPLUGIN_MANIFEST*
 Unless $NVIM_RPLUGIN_MANIFEST is set the manifest will be written to a file

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -649,28 +649,6 @@ compatibility).
 	Hide the block.
 
 ==============================================================================
-Wildmenu Events							   *ui-wildmenu*
-
-Only sent if `ext_wildmenu` option is set in |ui-options|
-
-Deprecated. When `ext_cmdline` and `ext_popupmenu` are both set,
-|ui-popupmenu| events will be used for command-line completion. But if
-`ext_wildmenu` is also set, these events are still used for backwards
-compatibility. New clients should use `ext_popupmenu` instead.
-
-["wildmenu_show", items]
-	Activate the wildmenu (command-line completion). `items` is an array
-	with the completion items.
-
-["wildmenu_select", selected]
-	Select an item in the current wildmenu. `selected` is a zero-based
-	index into the array of items from the last wildmenu_show event, or -1
-	if no item is selected.
-
-["wildmenu_hide"]
-	Hide the wildmenu.
-
-==============================================================================
 Message Events							   *ui-messages*
 
 Only sent if `ext_messages` option is set in |ui-options|. This option implies

--- a/runtime/doc/usr_43.txt
+++ b/runtime/doc/usr_43.txt
@@ -94,7 +94,7 @@ unless it was set already.  This will make sure that 'filetype' isn't set
 twice.
 
 You can use many different patterns to match the name of your file.  Directory
-names can also be included.  See |autocmd-patterns|.  For example, the files
+names can also be included.  See |autocmd-pattern|.  For example, the files
 under "/usr/share/scripts/" are all "ruby" files, but don't have the expected
 file name extension.  Adding this to the example above: >
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -6,8 +6,9 @@
 
 Differences between Nvim and Vim			       *vim-differences*
 
-Nvim differs from Vim in many ways, big and small.  This document is
-a complete and centralized reference of those differences.
+Nvim differs from Vim in many ways, although editor and VimL features are
+mostly identical.  This document is a complete and centralized reference of
+the differences.
 
 				      Type |gO| to see the table of contents.
 

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Parses Doxygen XML output to generate Neovim's API documentation.
+"""Generates Nvim help docs from C docstrings, by parsing Doxygen XML.
 
 This would be easier using lxml and XSLT, but:
 
@@ -35,12 +35,18 @@ import sys
 import shutil
 import textwrap
 import subprocess
+import collections
+import pprint
 
 from xml.dom import minidom
 
 if sys.version_info[0] < 3:
     print("use Python 3")
     sys.exit(1)
+
+DEBUG = ('DEBUG' in os.environ)
+INCLUDE_C_DECL = ('INCLUDE_C_DECL' in os.environ)
+INCLUDE_DEPRECATED = ('INCLUDE_DEPRECATED' in os.environ)
 
 doc_filename = 'api.txt'
 # String used to find the start of the generated part of the doc.
@@ -83,6 +89,12 @@ seen_funcs = set()
 # deprecated functions.
 xrefs = set()
 
+def debug_this(s, n):
+    o = n if isinstance(n, str) else n.toprettyxml(indent='  ', newl='\n')
+    name = '' if isinstance(n, str) else n.nodeName
+    if s in o:
+        raise RuntimeError('xxx: {}\n{}'.format(name, o))
+
 
 # XML Parsing Utilities {{{
 def find_first(parent, name):
@@ -123,6 +135,10 @@ def clean_lines(text):
     return re.sub(r'\A\n\s*\n*|\n\s*\n*\Z', '', re.sub(r'(\n\s*\n+)+', '\n\n', text))
 
 
+def is_blank(text):
+    return '' == clean_lines(text)
+
+
 def get_text(parent):
     """Combine all text in a node."""
     if parent.nodeType == parent.TEXT_NODE:
@@ -137,16 +153,43 @@ def get_text(parent):
     return out
 
 
-def doc_wrap(text, prefix='', width=70, func=False):
+# Gets the length of the last line in `text`, excluding newline ("\n") char.
+def len_lastline(text):
+    lastnl = text.rfind('\n')
+    if -1 == lastnl:
+        return len(text)
+    if '\n' == text[-1]:
+        return lastnl - (1+ text.rfind('\n', 0, lastnl))
+    return len(text) - (1 + lastnl)
+
+
+def len_lastline_withoutindent(text, indent):
+    n = len_lastline(text)
+    return (n - len(indent)) if n > len(indent) else 0
+
+
+# Returns True if node `n` contains only inline (not block-level) elements.
+def is_inline(n):
+    for c in n.childNodes:
+        if c.nodeType != c.TEXT_NODE and c.nodeName != 'computeroutput':
+            return False
+        if not is_inline(c):
+            return False
+    return True
+
+def doc_wrap(text, prefix='', width=70, func=False, indent=None):
     """Wraps text to `width`.
 
-    The first line is prefixed with `prefix`, and subsequent lines are aligned.
+    First line is prefixed with `prefix`, subsequent lines are aligned.
     If `func` is True, only wrap at commas.
     """
     if not width:
+        # return prefix + text
         return text
 
-    indent_space = ' ' * len(prefix)
+    # Whitespace used to indent all lines except the first line.
+    indent = ' ' * len(prefix) if indent is None else indent
+    indent_only = (prefix == '' and indent is not None)
 
     if func:
         lines = [prefix]
@@ -154,27 +197,37 @@ def doc_wrap(text, prefix='', width=70, func=False):
             if part[-1] not in ');':
                 part += ', '
             if len(lines[-1]) + len(part) > width:
-                lines.append(indent_space)
+                lines.append(indent)
             lines[-1] += part
         return '\n'.join(x.rstrip() for x in lines).rstrip()
+
+    # XXX: Dummy prefix to force TextWrapper() to wrap the first line.
+    if indent_only:
+        prefix = indent
 
     tw = textwrap.TextWrapper(break_long_words = False,
                               break_on_hyphens = False,
                               width=width,
                               initial_indent=prefix,
-                              subsequent_indent=indent_space)
-    return '\n'.join(tw.wrap(text.strip()))
+                              subsequent_indent=indent)
+    result = '\n'.join(tw.wrap(text.strip()))
+
+    # XXX: Remove the dummy prefix.
+    if indent_only:
+        result = result[len(indent):]
+
+    return result
 
 
-def parse_params(parent, width=62):
-    """Parse Doxygen `parameterlist`."""
+def render_params(parent, width=62):
+    """Renders Doxygen <parameterlist> tag as Vim help text."""
     name_length = 0
     items = []
-    for child in parent.childNodes:
-        if child.nodeType == child.TEXT_NODE:
+    for node in parent.childNodes:
+        if node.nodeType == node.TEXT_NODE:
             continue
 
-        name_node = find_first(child, 'parametername')
+        name_node = find_first(node, 'parametername')
         if name_node.getAttribute('direction') == 'out':
             continue
 
@@ -184,79 +237,152 @@ def parse_params(parent, width=62):
 
         name = '{%s}' % name
         name_length = max(name_length, len(name) + 2)
+        items.append((name.strip(), node))
+
+    out = ''
+    for name, node in items:
+        name = '    {}'.format(name.ljust(name_length))
 
         desc = ''
-        desc_node = get_child(child, 'parameterdescription')
+        desc_node = get_child(node, 'parameterdescription')
         if desc_node:
-            desc = parse_parblock(desc_node, width=None)
-        items.append((name.strip(), desc.strip()))
+            desc = parse_parblock(desc_node, width=width,
+                    indent=(' ' * len(name)))
 
-    out = 'Parameters: ~\n'
-    for name, desc in items:
-        name = '    %s' % name.ljust(name_length)
-        out += doc_wrap(desc, prefix=name, width=width) + '\n'
-    return out.strip()
+        out += '{}{}\n'.format(name, desc)
+    return out.rstrip()
 
+# Renders a node as Vim help text, recursively traversing all descendants.
+def render_node(n, text, prefix='', indent='', width=62):
+    text = ''
+    # space_preceding = (len(text) > 0 and ' ' == text[-1][-1])
+    # text += (int(not space_preceding) * ' ')
 
-def parse_para(parent, width=62):
-    """Parse doxygen `para` tag.
+    if n.nodeType == n.TEXT_NODE:
+        # `prefix` is NOT sent to doc_wrap, it was already handled by now.
+        text += doc_wrap(n.data, indent=indent, width=width)
+    elif n.nodeName == 'computeroutput':
+        text += ' `{}` '.format(get_text(n))
+    elif is_inline(n):
+        for c in n.childNodes:
+            text += render_node(c, text)
+        text = doc_wrap(text, indent=indent, width=width)
+    elif n.nodeName == 'verbatim':
+        # TODO: currently we don't use this. The "[verbatim]" hint is there as
+        # a reminder that we must decide how to format this if we do use it.
+        text += ' [verbatim] {}'.format(get_text(n))
+    elif n.nodeName == 'listitem':
+        for c in n.childNodes:
+            text += indent + prefix + render_node(c, text, indent=indent+(' ' * len(prefix)), width=width)
+    elif n.nodeName == 'para':
+        for c in n.childNodes:
+            text += render_node(c, text, indent=indent, width=width)
+        if is_inline(n):
+            text = doc_wrap(text, indent=indent, width=width)
+    elif n.nodeName == 'itemizedlist':
+        for c in n.childNodes:
+            text += '{}\n'.format(render_node(c, text, prefix='- ',
+                indent=indent, width=width))
+    elif n.nodeName == 'orderedlist':
+        i = 1
+        for c in n.childNodes:
+            if is_blank(get_text(c)):
+                text += '\n'
+                continue
+            text += '{}\n'.format(render_node(c, text, prefix='{}. '.format(i),
+                indent=indent, width=width))
+            i = i + 1
+    elif n.nodeName == 'simplesect' and 'note' == n.getAttribute('kind'):
+        text += 'Note:\n    '
+        for c in n.childNodes:
+            text += render_node(c, text, indent='    ', width=width)
+        text += '\n'
+    elif n.nodeName == 'simplesect' and 'warning' == n.getAttribute('kind'):
+        text += 'Warning:\n    '
+        for c in n.childNodes:
+            text += render_node(c, text, indent='    ', width=width)
+        text += '\n'
+    elif (n.nodeName == 'simplesect'
+            and n.getAttribute('kind') in ('return', 'see')):
+        text += '    '
+        for c in n.childNodes:
+            text += render_node(c, text, indent='    ', width=width)
+    else:
+        raise RuntimeError('unhandled node type: {}\n{}'.format(
+            n.nodeName, n.toprettyxml(indent='  ', newl='\n')))
+    return text
 
-    I assume <para> is a paragraph block or "a block of text".  It can contain
-    text nodes, or other tags.
+def render_para(parent, indent='', width=62):
+    """Renders Doxygen <para> containing arbitrary nodes.
+
+    NB: Blank lines in a docstring manifest as <para> tags.
     """
-    line = ''
-    lines = []
+    if is_inline(parent):
+        return clean_lines(doc_wrap(render_node(parent, ''),
+            indent=indent, width=width).strip())
+
+    # Ordered dict of ordered lists.
+    groups = collections.OrderedDict([
+        ('params', []),
+        ('return', []),
+        ('seealso', []),
+        ('xrefs', []),
+    ])
+
+    # Gather nodes into groups.  Mostly this is because we want "parameterlist"
+    # nodes to appear together.
+    text = ''
+    kind = ''
+    last = ''
     for child in parent.childNodes:
-        if child.nodeType == child.TEXT_NODE:
-            line += child.data
-        elif child.nodeName == 'computeroutput':
-            line += '`%s`' % get_text(child)
-        else:
-            if line:
-                lines.append(doc_wrap(line, width=width))
-                line = ''
-
-            if child.nodeName == 'parameterlist':
-                lines.append(parse_params(child, width=width))
-            elif child.nodeName == 'xrefsect':
-                title = get_text(get_child(child, 'xreftitle'))
-                xrefs.add(title)
-                xrefdesc = parse_para(get_child(child, 'xrefdescription'))
-                lines.append(doc_wrap(xrefdesc, prefix='%s: ' % title,
-                                      width=width) + '\n')
-            elif child.nodeName == 'simplesect':
-                kind = child.getAttribute('kind')
-                if kind == 'note':
-                    lines.append('Note:')
-                    lines.append(doc_wrap(parse_para(child),
-                                          prefix='    ',
-                                          width=width))
-                elif kind == 'return':
-                    lines.append('%s: ~' % kind.title())
-                    lines.append(doc_wrap(parse_para(child),
-                                          prefix='    ',
-                                          width=width))
+        if child.nodeName == 'parameterlist':
+            groups['params'].append(child)
+        elif child.nodeName == 'xrefsect':
+            groups['xrefs'].append(child)
+        elif child.nodeName == 'simplesect':
+            last = kind
+            kind = child.getAttribute('kind')
+            if kind == 'return' or (kind == 'note' and last == 'return'):
+                groups['return'].append(child)
+            elif kind == 'see':
+                groups['seealso'].append(child)
+            elif kind in ('note', 'warning'):
+                text += render_node(child, text, indent=indent, width=width)
             else:
-                lines.append(get_text(child))
+                raise RuntimeError('unhandled simplesect: {}\n{}'.format(
+                    child.nodeName, child.toprettyxml(indent='  ', newl='\n')))
+        else:
+            text += render_node(child, text, indent=indent, width=width)
 
-    if line:
-        lines.append(doc_wrap(line, width=width))
-    return clean_lines('\n'.join(lines).strip())
+    chunks = [text]
+    # Generate text from the gathered items.
+    if len(groups['params']) > 0:
+        chunks.append('\nParameters: ~')
+        for child in groups['params']:
+            chunks.append(render_params(child, width=width))
+    if len(groups['return']) > 0:
+        chunks.append('\nReturn: ~')
+        for child in groups['return']:
+            chunks.append(render_node(child, chunks[-1][-1], indent=indent, width=width))
+    if len(groups['seealso']) > 0:
+        chunks.append('\nSee also: ~')
+        for child in groups['seealso']:
+            chunks.append(render_node(child, chunks[-1][-1], indent=indent, width=width))
+    for child in groups['xrefs']:
+        title = get_text(get_child(child, 'xreftitle'))
+        xrefs.add(title)
+        xrefdesc = render_para(get_child(child, 'xrefdescription'), width=width)
+        chunks.append(doc_wrap(xrefdesc, prefix='{}: '.format(title),
+                              width=width) + '\n')
+
+    return clean_lines('\n'.join(chunks).strip())
 
 
-def parse_parblock(parent, width=62):
-    """Parses a nested block of `para` tags.
-
-    Named after the \parblock command, but not directly related.
-    """
+def parse_parblock(parent, prefix='', width=62, indent=''):
+    """Renders a nested block of <para> tags as Vim help text."""
     paragraphs = []
     for child in parent.childNodes:
-        if child.nodeType == child.TEXT_NODE:
-            paragraphs.append(doc_wrap(child.data, width=width))
-        elif child.nodeName == 'para':
-            paragraphs.append(parse_para(child, width=width))
-        else:
-            paragraphs.append(doc_wrap(get_text(child), width=width))
+        paragraphs.append(render_para(child, width=width, indent=indent))
         paragraphs.append('')
     return clean_lines('\n'.join(paragraphs).strip())
 # }}}
@@ -292,7 +418,7 @@ def parse_source_xml(filename):
 
         if return_type.startswith(('ArrayOf', 'DictionaryOf')):
             parts = return_type.strip('_').split('_')
-            return_type = '%s(%s)' % (parts[0], ', '.join(parts[1:]))
+            return_type = '{}({})'.format(parts[0], ', '.join(parts[1:]))
 
         name = get_text(get_child(member, 'name'))
 
@@ -306,37 +432,37 @@ def parse_source_xml(filename):
         annotations = filter(None, map(lambda x: annotation_map.get(x),
                                        annotations.split()))
 
-        vimtag = '*%s()*' % name
-        args = []
+        vimtag = '*{}()*'.format(name)
+        params = []
         type_length = 0
 
         for param in get_children(member, 'param'):
-            arg_type = get_text(get_child(param, 'type')).strip()
-            arg_name = ''
+            param_type = get_text(get_child(param, 'type')).strip()
+            param_name = ''
             declname = get_child(param, 'declname')
             if declname:
-                arg_name = get_text(declname).strip()
+                param_name = get_text(declname).strip()
 
-            if arg_name in param_exclude:
+            if param_name in param_exclude:
                 continue
 
-            if arg_type.endswith('*'):
-                arg_type = arg_type.strip('* ')
-                arg_name = '*' + arg_name
-            type_length = max(type_length, len(arg_type))
-            args.append((arg_type, arg_name))
+            if param_type.endswith('*'):
+                param_type = param_type.strip('* ')
+                param_name = '*' + param_name
+            type_length = max(type_length, len(param_type))
+            params.append((param_type, param_name))
 
         c_args = []
-        for arg_type, arg_name in args:
+        for param_type, param_name in params:
             c_args.append('    ' + (
-                '%s %s' % (arg_type.ljust(type_length), arg_name)).strip())
+                '%s %s' % (param_type.ljust(type_length), param_name)).strip())
 
         c_decl = textwrap.indent('%s %s(\n%s\n);' % (return_type, name,
                                                      ',\n'.join(c_args)),
                                  '    ')
 
         prefix = '%s(' % name
-        suffix = '%s)' % ', '.join('{%s}' % a[1] for a in args
+        suffix = '%s)' % ', '.join('{%s}' % a[1] for a in params
                                    if a[0] not in ('void', 'Error'))
 
         # Minimum 8 chars between signature and vimtag
@@ -354,7 +480,7 @@ def parse_source_xml(filename):
         desc = find_first(member, 'detaileddescription')
         if desc:
             doc = parse_parblock(desc)
-            if 'DEBUG' in os.environ:
+            if DEBUG:
                 print(textwrap.indent(
                     re.sub(r'\n\s*\n+', '\n',
                            desc.toprettyxml(indent='  ', newl='\n')), ' ' * 16))
@@ -372,7 +498,7 @@ def parse_source_xml(filename):
             else:
                 doc = doc[:i] + annotations + '\n\n' + doc[i:]
 
-        if 'INCLUDE_C_DECL' in os.environ:
+        if INCLUDE_C_DECL:
             doc += '\n\nC Declaration: ~\n>\n'
             doc += c_decl
             doc += '\n<'
@@ -464,7 +590,7 @@ def gen_docs(config):
                 if functions:
                     doc += '\n\n' + functions
 
-                if 'INCLUDE_DEPRECATED' in os.environ and deprecated:
+                if INCLUDE_DEPRECATED and deprecated:
                     doc += '\n\n\nDeprecated %s Functions: ~\n\n' % name
                     doc += deprecated
 
@@ -551,6 +677,7 @@ XML_PROGRAMLISTING     = NO
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = NO
+MARKDOWN_SUPPORT       = YES
 '''
 # }}}
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -49,7 +49,7 @@
 
 /// Gets the buffer line count
 ///
-/// @param buffer   Buffer handle
+/// @param buffer   Buffer handle, or 0 for current buffer
 /// @param[out] err Error details, if any
 /// @return Line count, or 0 for unloaded buffer. |api-buffer|
 Integer nvim_buf_line_count(Buffer buffer, Error *err)
@@ -99,7 +99,8 @@ String buffer_get_line(Buffer buffer, Integer index, Error *err)
 
 /// Activate updates from this buffer to the current channel.
 ///
-/// @param buffer The buffer handle
+/// @param channel_id
+/// @param buffer Buffer handle, or 0 for current buffer
 /// @param send_buffer Set to true if the initial notification should contain
 ///        the whole buffer. If so, the first notification will be a
 ///        `nvim_buf_lines_event`. Otherwise, the first notification will be
@@ -131,7 +132,8 @@ Boolean nvim_buf_attach(uint64_t channel_id,
 //
 /// Deactivate updates from this buffer to the current channel.
 ///
-/// @param buffer The buffer handle
+/// @param channel_id
+/// @param buffer Buffer handle, or 0 for current buffer
 /// @param[out] err Details of an error that may have occurred
 /// @return False when updates couldn't be disabled because the buffer
 ///         isn't loaded; otherwise True.
@@ -221,7 +223,8 @@ ArrayOf(String) buffer_get_line_slice(Buffer buffer,
 /// Out-of-bounds indices are clamped to the nearest valid value, unless
 /// `strict_indexing` is set.
 ///
-/// @param buffer           Buffer handle
+/// @param channel_id
+/// @param buffer           Buffer handle, or 0 for current buffer
 /// @param start            First line index
 /// @param end              Last line index (exclusive)
 /// @param strict_indexing  Whether out-of-bounds should be an error.
@@ -290,7 +293,7 @@ end:
 ///                   newend = end + int(include_end) + int(end < 0)
 ///                   int(bool) = 1 if bool is true else 0
 ///
-/// @param buffer         Buffer handle
+/// @param buffer         Buffer handle, or 0 for current buffer
 /// @param start          First line index
 /// @param end            Last line index
 /// @param include_start  True if the slice includes the `start` parameter
@@ -324,7 +327,8 @@ void buffer_set_line_slice(Buffer buffer,
 /// Out-of-bounds indices are clamped to the nearest valid value, unless
 /// `strict_indexing` is set.
 ///
-/// @param buffer           Buffer handle
+/// @param channel_id
+/// @param buffer           Buffer handle, or 0 for current buffer
 /// @param start            First line index
 /// @param end              Last line index (exclusive)
 /// @param strict_indexing  Whether out-of-bounds should be an error.
@@ -491,7 +495,7 @@ end:
 /// Unlike |line2byte()|, throws error for out-of-bounds indexing.
 /// Returns -1 for unloaded buffer.
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param index      Line index
 /// @param[out] err   Error details, if any
 /// @return Integer byte offset, or -1 for unloaded buffer.
@@ -518,7 +522,7 @@ Integer nvim_buf_get_offset(Buffer buffer, Integer index, Error *err)
 
 /// Gets a buffer-scoped (b:) variable.
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param name       Variable name
 /// @param[out] err   Error details, if any
 /// @return Variable value
@@ -536,7 +540,7 @@ Object nvim_buf_get_var(Buffer buffer, String name, Error *err)
 
 /// Gets a changed tick of a buffer
 ///
-/// @param[in]  buffer  Buffer handle.
+/// @param[in]  buffer  Buffer handle, or 0 for current buffer
 /// @param[out] err     Error details, if any
 ///
 /// @return `b:changedtick` value.
@@ -555,7 +559,7 @@ Integer nvim_buf_get_changedtick(Buffer buffer, Error *err)
 /// Gets a list of buffer-local |mapping| definitions.
 ///
 /// @param  mode       Mode short-name ("n", "i", "v", ...)
-/// @param  buffer     Buffer handle
+/// @param  buffer     Buffer handle, or 0 for current buffer
 /// @param[out]  err   Error details, if any
 /// @returns Array of maparg()-like dictionaries describing mappings.
 ///          The "buffer" key holds the associated buffer handle.
@@ -573,7 +577,7 @@ ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, Error *err)
 
 /// Gets a map of buffer-local |user-commands|.
 ///
-/// @param  buffer  Buffer handle.
+/// @param  buffer  Buffer handle, or 0 for current buffer
 /// @param  opts  Optional parameters. Currently not used.
 /// @param[out]  err   Error details, if any.
 ///
@@ -613,7 +617,7 @@ Dictionary nvim_buf_get_commands(Buffer buffer, Dictionary opts, Error *err)
 
 /// Sets a buffer-scoped (b:) variable
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param name       Variable name
 /// @param value      Variable value
 /// @param[out] err   Error details, if any
@@ -631,7 +635,7 @@ void nvim_buf_set_var(Buffer buffer, String name, Object value, Error *err)
 
 /// Removes a buffer-scoped (b:) variable
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param name       Variable name
 /// @param[out] err   Error details, if any
 void nvim_buf_del_var(Buffer buffer, String name, Error *err)
@@ -650,7 +654,7 @@ void nvim_buf_del_var(Buffer buffer, String name, Error *err)
 ///
 /// @deprecated
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param name       Variable name
 /// @param value      Variable value
 /// @param[out] err   Error details, if any
@@ -673,7 +677,7 @@ Object buffer_set_var(Buffer buffer, String name, Object value, Error *err)
 ///
 /// @deprecated
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param name       Variable name
 /// @param[out] err   Error details, if any
 /// @return Old value
@@ -691,7 +695,7 @@ Object buffer_del_var(Buffer buffer, String name, Error *err)
 
 /// Gets a buffer option value
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param name       Option name
 /// @param[out] err   Error details, if any
 /// @return Option value
@@ -710,7 +714,8 @@ Object nvim_buf_get_option(Buffer buffer, String name, Error *err)
 /// Sets a buffer option value. Passing 'nil' as value deletes the option (only
 /// works if there's a global fallback)
 ///
-/// @param buffer     Buffer handle
+/// @param channel_id
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param name       Option name
 /// @param value      Option value
 /// @param[out] err   Error details, if any
@@ -732,7 +737,7 @@ void nvim_buf_set_option(uint64_t channel_id, Buffer buffer,
 /// @deprecated The buffer number now is equal to the object id,
 ///             so there is no need to use this function.
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param[out] err   Error details, if any
 /// @return Buffer number
 Integer nvim_buf_get_number(Buffer buffer, Error *err)
@@ -751,7 +756,7 @@ Integer nvim_buf_get_number(Buffer buffer, Error *err)
 
 /// Gets the full file name for the buffer
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param[out] err   Error details, if any
 /// @return Buffer name
 String nvim_buf_get_name(Buffer buffer, Error *err)
@@ -769,7 +774,7 @@ String nvim_buf_get_name(Buffer buffer, Error *err)
 
 /// Sets the full file name for a buffer
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param name       Buffer name
 /// @param[out] err   Error details, if any
 void nvim_buf_set_name(Buffer buffer, String name, Error *err)
@@ -801,7 +806,7 @@ void nvim_buf_set_name(Buffer buffer, String name, Error *err)
 /// Checks if a buffer is valid and loaded. See |api-buffer| for more info
 /// about unloaded buffers.
 ///
-/// @param buffer Buffer handle
+/// @param buffer Buffer handle, or 0 for current buffer
 /// @return true if the buffer is valid and loaded, false otherwise.
 Boolean nvim_buf_is_loaded(Buffer buffer)
   FUNC_API_SINCE(5)
@@ -817,7 +822,7 @@ Boolean nvim_buf_is_loaded(Buffer buffer)
 /// @note Even if a buffer is valid it may have been unloaded. See |api-buffer|
 /// for more info about unloaded buffers.
 ///
-/// @param buffer Buffer handle
+/// @param buffer Buffer handle, or 0 for current buffer
 /// @return true if the buffer is valid, false otherwise.
 Boolean nvim_buf_is_valid(Buffer buffer)
   FUNC_API_SINCE(1)
@@ -849,7 +854,7 @@ void buffer_insert(Buffer buffer,
 
 /// Return a tuple (row,col) representing the position of the named mark
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param name       Mark name
 /// @param[out] err   Error details, if any
 /// @return (row, col) tuple
@@ -914,7 +919,7 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Error *err)
 /// supported for backwards compatibility, new code should use
 /// |nvim_create_namespace| to create a new empty namespace.
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param ns_id      namespace to use or -1 for ungrouped highlight
 /// @param hl_group   Name of the highlight group to use
 /// @param line       Line to highlight (zero-indexed)
@@ -964,7 +969,7 @@ Integer nvim_buf_add_highlight(Buffer buffer,
 /// To clear the namespace in the entire buffer, pass in 0 and -1 to
 /// line_start and line_end respectively.
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param ns_id      Namespace to clear, or -1 to clear all namespaces.
 /// @param line_start Start of range of lines to clear
 /// @param line_end   End of range of lines to clear (exclusive) or -1 to clear
@@ -997,7 +1002,7 @@ void nvim_buf_clear_namespace(Buffer buffer,
 ///
 /// @deprecated use |nvim_buf_clear_namespace|.
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param ns_id      Namespace to clear, or -1 to clear all.
 /// @param line_start Start of range of lines to clear
 /// @param line_end   End of range of lines to clear (exclusive) or -1 to clear
@@ -1031,7 +1036,7 @@ void nvim_buf_clear_highlight(Buffer buffer,
 /// As a shorthand, `ns_id = 0` can be used to create a new namespace for the
 /// virtual text, the allocated id is then returned.
 ///
-/// @param buffer     Buffer handle
+/// @param buffer     Buffer handle, or 0 for current buffer
 /// @param ns_id      Namespace to use or 0 to create a namespace,
 ///                   or -1 for a ungrouped annotation
 /// @param line       Line to annotate with virtual text (zero-indexed)

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -29,8 +29,8 @@ typedef struct {
   uint64_t channel_id;
   Array buffer;
 
-  int hl_id;  // current higlight for legacy put event
-  Integer cursor_row, cursor_col;  // Intended visibule cursor position
+  int hl_id;  // Current highlight for legacy put event.
+  Integer cursor_row, cursor_col;  // Intended visible cursor position.
 
   // Position of legacy cursor, used both for drawing and visible user cursor.
   Integer client_row, client_col;
@@ -264,20 +264,22 @@ static void ui_set_option(UI *ui, bool init, String name, Object value,
 ///
 /// On invalid grid handle, fails with error.
 ///
+/// @param channel_id
 /// @param grid    The handle of the grid to be changed.
 /// @param width   The new requested width.
 /// @param height  The new requested height.
+/// @param[out] err Error details, if any
 void nvim_ui_try_resize_grid(uint64_t channel_id, Integer grid, Integer width,
-                             Integer height, Error *error)
+                             Integer height, Error *err)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY
 {
   if (!pmap_has(uint64_t)(connected_uis, channel_id)) {
-    api_set_error(error, kErrorTypeException,
+    api_set_error(err, kErrorTypeException,
                   "UI not attached to channel: %" PRId64, channel_id);
     return;
   }
 
-  ui_grid_resize((handle_T)grid, (int)width, (int)height, error);
+  ui_grid_resize((handle_T)grid, (int)width, (int)height, err);
 }
 
 /// Pushes data into UI.UIData, to be consumed later by remote_ui_flush().

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -345,6 +345,7 @@ Object nvim_win_get_option(Window window, String name, Error *err)
 /// Sets a window option value. Passing 'nil' as value deletes the option(only
 /// works if there's a global fallback)
 ///
+/// @param channel_id
 /// @param window   Window handle
 /// @param name     Option name
 /// @param value    Option value
@@ -527,9 +528,7 @@ Dictionary nvim_win_get_config(Window window, Error *err)
 /// @param force    Behave like `:close!` The last window of a buffer with
 ///                 unwritten changes can be closed. The buffer will become
 ///                 hidden, even if 'hidden' is not set.
-///
 /// @param[out] err Error details, if any
-/// @return Window number
 void nvim_win_close(Window window, Boolean force, Error *err)
   FUNC_API_SINCE(6)
 {

--- a/src/nvim/event/stream.h
+++ b/src/nvim/event/stream.h
@@ -13,7 +13,7 @@ typedef struct stream Stream;
 /// Type of function called when the Stream buffer is filled with data
 ///
 /// @param stream The Stream instance
-/// @param rbuffer The associated RBuffer instance
+/// @param buf The associated RBuffer instance
 /// @param count Number of bytes that was read.
 /// @param data User-defined data
 /// @param eof If the stream reached EOF.
@@ -23,7 +23,7 @@ typedef void (*stream_read_cb)(Stream *stream, RBuffer *buf, size_t count,
 /// Type of function called when the Stream has information about a write
 /// request.
 ///
-/// @param wstream The Stream instance
+/// @param stream The Stream instance
 /// @param data User-defined data
 /// @param status 0 on success, anything else indicates failure
 typedef void (*stream_write_cb)(Stream *stream, void *data, int status);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -78,7 +78,7 @@
 static int quitmore = 0;
 static int ex_pressedreturn = FALSE;
 
-/* whether ":lcd" was produced for a session */
+/// Whether ":lcd" or ":tcd" was produced for a session.
 static int did_lcd;
 
 typedef struct ucmd {

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -3,6 +3,8 @@
 
 // Compositor: merge floating grids with the main grid for display in
 // TUI and non-multigrid UIs.
+//
+// Layer-based compositing: https://en.wikipedia.org/wiki/Digital_compositing
 
 #include <assert.h>
 #include <stdbool.h>
@@ -104,6 +106,9 @@ bool ui_comp_should_draw(void)
   return composed_uis != 0 && valid_screen;
 }
 
+/// Places `grid` at (col,row) position with (width * height) size.
+/// Adds `grid` as the top layer if it is a new layer.
+///
 /// TODO(bfredl): later on the compositor should just use win_float_pos events,
 /// though that will require slight event order adjustment: emit the win_pos
 /// events in the beginning of  update_screen(0), rather than in ui_flush()

--- a/src/nvim/ui_compositor.h
+++ b/src/nvim/ui_compositor.h
@@ -1,5 +1,3 @@
-// Bridge for communication between a UI thread and nvim core.
-// Used by the built-in TUI and libnvim-based UIs.
 #ifndef NVIM_UI_COMPOSITOR_H
 #define NVIM_UI_COMPOSITOR_H
 

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -259,22 +259,19 @@ local ext_keys = {
   'messages', 'showmode', 'showcmd', 'ruler', 'float_pos',
 }
 
--- Asserts that the screen state eventually matches an expected state
+-- Asserts that the screen state eventually matches an expected state.
 --
--- This function can either be called with the positional forms
---
---  screen:expect(grid, [attr_ids, attr_ignore])
---  screen:expect(condition)
---
--- or to use additional arguments (or grid and condition at the same time)
--- the keyword form has to be used:
---
--- screen:expect{grid=[[...]], cmdline={...}, condition=function() ... end}
+-- Can be called with positional args:
+--    screen:expect(grid, [attr_ids, attr_ignore])
+--    screen:expect(condition)
+-- or keyword args (supports more options):
+--    screen:expect{grid=[[...]], cmdline={...}, condition=function() ... end}
 --
 --
 -- grid:        Expected screen state (string). Each line represents a screen
 --              row. Last character of each row (typically "|") is stripped.
 --              Common indentation is stripped.
+--              Lines containing only "{IGNORE}|" are skipped.
 -- attr_ids:    Expected text attributes. Screen rows are transformed according
 --              to this table, as follows: each substring S composed of
 --              characters having the same attributes will be substituted by


### PR DESCRIPTION
`scripts/gen_vimdoc.py` (renamed from `gen_vimdoc.py`) now supports nested elements and markdown-formatted lists. 

Note: Doxygen does a pretty nice job of interpreting the quasi-Markdown in our doctsrings, but it can't make sense when we do things like this:

```
- foo1
  - foo2
zub
- bar1
```

The guideline is: if you want indented things, they must be lists. That `zub` in the above tree is parsed by Doxygen as belonging to the `foo2` element. Adding line breaks causes different problems... Easiest solution is for the docstring author to make `zub` a list item (`- zub`) with `- bar1` is nested in it.

todo

- [x] https://github.com/neovim/neovim/pull/9710