### PR TITLE
[WIP]: tests for improved Lua messages

### DIFF
--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -102,6 +102,21 @@ describe(':lua command', function()
     {1:~                                                 }|
                                                       |
     ]]
+		feed(':lua error("this is \t\t a really \t\t long \t\t string \t\t.")<cr>')
+		screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E5105: Error while calling lua chunk: [string "<Vi}|
+      {3:mL compiled string>"]:1: this is                 a}|
+      {3: really                  long            string   }|
+      {3:        .}                                         |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
+		feed('<cr>')
+		screen:expect(empty_screen)
     feed(':lua error("")<cr>')
     screen:expect([[
                                                         |

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -102,6 +102,7 @@ describe(':lua command', function()
     {1:~                                                 }|
                                                       |
     ]]
+		-- ################## lua error #######################
 		feed(':lua error("this is a normal error")<cr>')
 		screen:expect([[
                                                         |
@@ -170,6 +171,21 @@ describe(':lua command', function()
     screen:expect(empty_screen)
     feed('<cr>')
     screen:expect(empty_screen)
+		feed(':lua error("' .. ('x'):rep(200) .. '")<cr>')
+		screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E5105: Error while calling lua chunk: [string "<Vi}|
+      {3:mL compiled string>"]:1: xxxxxxxxxxxxxxxxxxxxxxxxx}|
+      {3:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}|
+      {3:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}|
+      {3:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}|
+      {3:xxxxxxxxxxxxxxxxxxxxxxxxx}                         |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
+    feed('<cr>')
+    screen:expect(empty_screen)
     feed(':lua error("fail\\nmuch error\\nsuch details")<cr>')
     screen:expect([[
                                                         |
@@ -185,29 +201,16 @@ describe(':lua command', function()
     ]])
     feed('<cr>')
     screen:expect(empty_screen)
-		feed(':lua error("' .. ('x'):rep(200) .. '")<cr>')
-		screen:expect([[
-                                                        |
-      {1:~                                                 }|
-      {2:                                                  }|
-      {3:E5105: Error while calling lua chunk: [string "<Vi}|
-      {3:mL compiled string>"]:1: xxxxxxxxxxxxxxxxxxxxxxxxx}|
-      {3:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}|
-      {3:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}|
-      {3:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}|
-      {3:xxxxxxxxxxxxxxxxxxxxxxxxx}                         |
-      {4:Press ENTER or type command to continue}^           |
-    ]])
 
-    --eq('E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: fail\nmuch error\nsuch details', eval('v:errmsg'))
+    eq('E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: fail\nmuch error\nsuch details', eval('v:errmsg'))
 
-    --local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
-    --local expected = 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: some error\nin a\nAPI command'
-    --eq(false, status)
-    --eq(expected, string.sub(err, -string.len(expected)))
+    local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
+    local expected = 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: some error\nin a\nAPI command'
+    eq(false, status)
+    eq(expected, string.sub(err, -string.len(expected)))
 
-    --feed(':messages<cr>')
-    --screen:expect(empty_screen)
+    feed('<cr>')
+    screen:expect(empty_screen)
   end)
 end)
 

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -102,6 +102,21 @@ describe(':lua command', function()
     {1:~                                                 }|
                                                       |
     ]]
+		feed(':lua error("this is a normal error")<cr>')
+		screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E5105: Error while calling lua chunk: [string "<Vi}|
+      {3:mL compiled string>"]:1: this is a normal error}   |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
+		feed('<cr>')
+		screen:expect(empty_screen)
 		feed(':lua error("this is \t\t a really \t\t long \t\t string \t\t.")<cr>')
 		screen:expect([[
                                                         |

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -19,7 +19,8 @@ local curbufmeths = helpers.curbufmeths
 
 before_each(clear)
 
-local empty_screen = [[
+local empty_screen =
+[[
       ^                                                  |
       {1:~                                                 }|
       {1:~                                                 }|
@@ -33,59 +34,59 @@ local empty_screen = [[
 ]]
 
 local disptest = function(args)
-	describe(args.descrip, function()
-		it(args.descrip, function()
-			local screen = Screen.new(50,10)
-			screen:attach()
-			screen:set_default_attr_ids({
-				[1] = {bold = true, foreground = Screen.colors.Blue1},
-				[2] = {bold = true, reverse = true},
-				[3] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
-				[4] = {bold = true, foreground = Screen.colors.SeaGreen4},
-			})
+  describe(args.descrip, function()
+  it(args.descrip, function()
+  local screen = Screen.new(50,10)
+  screen:attach()
+  screen:set_default_attr_ids({
+    [1] = {bold = true, foreground = Screen.colors.Blue1},
+    [2] = {bold = true, reverse = true},
+    [3] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+    [4] = {bold = true, foreground = Screen.colors.SeaGreen4},
+  })
 
-			feed(args.cmd)
-			screen:expect(args.expected_scr)
-			feed('<cr>')
-			screen:expect(empty_screen)
-			eq(args.expected_msg, eval('v:errmsg'))
+  feed(args.cmd)
+  screen:expect(args.expected_scr)
+  feed('<cr>')
+  screen:expect(empty_screen)
+  eq(args.expected_msg, eval('v:errmsg'))
 
-			local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
-			local expected = 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: some error\nin a\nAPI command'
-			eq(false, status)
-			eq(expected, string.sub(err, -string.len(expected)))
+  local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
+  local expected = 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: some error\nin a\nAPI command'
+  eq(false, status)
+  eq(expected, string.sub(err, -string.len(expected)))
 
-			feed(':messages<cr>')
-			screen:expect(args.expected_scr)
-		end)
-	end)
+  feed(':messages<cr>')
+  screen:expect(args.expected_scr)
+    end)
+  end)
 end
 
-disptest{ descrip      = 'can show multiline error messages',
-				  cmd          = ':lua error("fail\\nmuch error\\nsuch details")<cr>',
-					expected_msg = 'E5105: Error while calling lua chunk: [string ' ..
-												 '"<VimL compiled string>"]:1: fail\nmuch error\n' ..
-												 'such details',
-					expected_scr = [[
-					                                                  |
-     {1:~                                                 }|
-     {1:~                                                 }|
-     {1:~                                                 }|
-     {2:                                                  }|
-     {3:E5105: Error while calling lua chunk: [string "<Vi}|
-     {3:mL compiled string>"]:1: fail}                     |
-     {3:much error}                                        |
-     {3:such details}                                      |
-     {4:Press ENTER or type command to continue}^           |
-					]]
+disptest{ descrip = 'can show multiline error messages',
+          cmd     = ':lua error("fail\\nmuch error\\nsuch details")<cr>',
+	  expected_msg = 'E5105: Error while calling lua chunk: [string ' ..
+	                 '"<VimL compiled string>"]:1: fail\nmuch error\n' ..
+			 'such details',
+	  expected_scr = [[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E5105: Error while calling lua chunk: [string "<Vi}|
+      {3:mL compiled string>"]:1: fail}                     |
+      {3:much error}                                        |
+      {3:such details}                                      |
+      {4:Press ENTER or type command to continue}^           |
+          ]]
 }
 
 disptest{ descrip = 'can show empty string error message',
-					cmd     = ':lua error("")<cr>',
-					expected_msg = 'E5105: Error while calling lua chunk: [string ' ..
-												 '"<VimL compiled string>"]:1: ',
-					expected_scr = [[
-					                                                  |
+	  cmd     = ':lua error("")<cr>',
+	  expected_msg = 'E5105: Error while calling lua chunk: [string ' ..
+			 '"<VimL compiled string>"]:1: ',
+	  expected_scr = [[
+				                                                   |
      {1:~                                                 }|
      {1:~                                                 }|
      {1:~                                                 }|
@@ -95,7 +96,7 @@ disptest{ descrip = 'can show empty string error message',
      {3:E5105: Error while calling lua chunk: [string "<Vi}|
      {3:mL compiled string>"]:1: }                         |
      {4:Press ENTER or type command to continue}^           |
-					]]
+          ]]
 }
 
 

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -19,88 +19,6 @@ local curbufmeths = helpers.curbufmeths
 
 before_each(clear)
 
-local empty_screen =
-[[
-      ^                                                  |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-                                                        |
-]]
-
-local disptest = function(args)
-  describe(args.descrip, function()
-  it(args.descrip, function()
-  local screen = Screen.new(50,10)
-  screen:attach()
-  screen:set_default_attr_ids({
-    [1] = {bold = true, foreground = Screen.colors.Blue1},
-    [2] = {bold = true, reverse = true},
-    [3] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
-    [4] = {bold = true, foreground = Screen.colors.SeaGreen4},
-  })
-
-  feed(args.cmd)
-  screen:expect(args.expected_scr)
-  feed('<cr>')
-  screen:expect(empty_screen)
-  eq(args.expected_msg, eval('v:errmsg'))
-
-  local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
-  local expected = 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: some error\nin a\nAPI command'
-  eq(false, status)
-  eq(expected, string.sub(err, -string.len(expected)))
-
-  feed(':messages<cr>')
-  screen:expect(args.expected_scr)
-    end)
-  end)
-end
-
-disptest{ descrip = 'can show multiline error messages',
-          cmd     = ':lua error("fail\\nmuch error\\nsuch details")<cr>',
-	  expected_msg = 'E5105: Error while calling lua chunk: [string ' ..
-	                 '"<VimL compiled string>"]:1: fail\nmuch error\n' ..
-			 'such details',
-	  expected_scr = [[
-                                                        |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {2:                                                  }|
-      {3:E5105: Error while calling lua chunk: [string "<Vi}|
-      {3:mL compiled string>"]:1: fail}                     |
-      {3:much error}                                        |
-      {3:such details}                                      |
-      {4:Press ENTER or type command to continue}^           |
-          ]]
-}
-
-disptest{ descrip = 'can show empty string error message',
-	  cmd     = ':lua error("")<cr>',
-	  expected_msg = 'E5105: Error while calling lua chunk: [string ' ..
-			 '"<VimL compiled string>"]:1: ',
-	  expected_scr = [[
-				                                                   |
-     {1:~                                                 }|
-     {1:~                                                 }|
-     {1:~                                                 }|
-     {1:~                                                 }|
-     {1:~                                                 }|
-     {2:                                                  }|
-     {3:E5105: Error while calling lua chunk: [string "<Vi}|
-     {3:mL compiled string>"]:1: }                         |
-     {4:Press ENTER or type command to continue}^           |
-          ]]
-}
-
-
-
 describe(':lua command', function()
   it('works', function()
     eq('', redir_exec(
@@ -161,6 +79,122 @@ describe(':lua command', function()
 
     eq('', redir_exec(('lua vim.api.nvim_buf_set_lines(1, 1, 2, false, {"%s"})'):format(s)))
     eq({'', s}, curbufmeths.get_lines(0, -1, false))
+  end)
+
+  it('can show empty error message', function()
+    local screen = Screen.new(50,10)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue1},
+      [2] = {bold = true, reverse = true},
+      [3] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+      [4] = {bold = true, foreground = Screen.colors.SeaGreen4},
+    })
+
+    feed(':lua error("")<cr>')
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E5105: Error while calling lua chunk: [string "<Vi}|
+      {3:mL compiled string>"]:1: }                         |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
+    feed('<cr>')
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]])
+    eq('E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: ', eval('v:errmsg'))
+
+    local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
+    local expected = 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: some error\nin a\nAPI command'
+    eq(false, status)
+    eq(expected, string.sub(err, -string.len(expected)))
+
+    feed(':messages<cr>')
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E5105: Error while calling lua chunk: [string "<Vi}|
+      {3:mL compiled string>"]:1: }                         |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
+  end)
+
+  it('can show multiline error messages', function()
+    local screen = Screen.new(50,10)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue1},
+      [2] = {bold = true, reverse = true},
+      [3] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+      [4] = {bold = true, foreground = Screen.colors.SeaGreen4},
+    })
+
+    feed(':lua error("fail\\nmuch error\\nsuch details")<cr>')
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E5105: Error while calling lua chunk: [string "<Vi}|
+      {3:mL compiled string>"]:1: fail}                     |
+      {3:much error}                                        |
+      {3:such details}                                      |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
+    feed('<cr>')
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]])
+    eq('E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: fail\nmuch error\nsuch details', eval('v:errmsg'))
+
+    local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
+    local expected = 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: some error\nin a\nAPI command'
+    eq(false, status)
+    eq(expected, string.sub(err, -string.len(expected)))
+
+    feed(':messages<cr>')
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E5105: Error while calling lua chunk: [string "<Vi}|
+      {3:mL compiled string>"]:1: fail}                     |
+      {3:much error}                                        |
+      {3:such details}                                      |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
   end)
 end)
 

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -81,7 +81,7 @@ describe(':lua command', function()
     eq({'', s}, curbufmeths.get_lines(0, -1, false))
   end)
 
-  it('can show empty error message', function()
+  it('can display special characters in error messages', function()
     local screen = Screen.new(50,10)
     screen:attach()
     screen:set_default_attr_ids({
@@ -90,7 +90,18 @@ describe(':lua command', function()
       [3] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
       [4] = {bold = true, foreground = Screen.colors.SeaGreen4},
     })
-
+    local empty_screen = [[
+    ^                                                  |
+    {1:~                                                 }|
+    {1:~                                                 }|
+    {1:~                                                 }|
+    {1:~                                                 }|
+    {1:~                                                 }|
+    {1:~                                                 }|
+    {1:~                                                 }|
+    {1:~                                                 }|
+                                                      |
+    ]]
     feed(':lua error("")<cr>')
     screen:expect([[
                                                         |
@@ -105,26 +116,12 @@ describe(':lua command', function()
       {4:Press ENTER or type command to continue}^           |
     ]])
     feed('<cr>')
-    screen:expect([[
-      ^                                                  |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-                                                        |
-    ]])
-    eq('E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: ', eval('v:errmsg'))
-
-    local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
-    local expected = 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: some error\nin a\nAPI command'
-    eq(false, status)
-    eq(expected, string.sub(err, -string.len(expected)))
-
-    feed(':messages<cr>')
+    screen:expect(empty_screen)
+    feed(':lua error("\n\n\n")<cr>')
+    screen:expect(empty_screen)
+    feed('<cr>')
+    screen:expect(empty_screen)
+    feed(':lua error("\t\t\t")<cr>')
     screen:expect([[
                                                         |
       {1:~                                                 }|
@@ -134,21 +131,15 @@ describe(':lua command', function()
       {1:~                                                 }|
       {2:                                                  }|
       {3:E5105: Error while calling lua chunk: [string "<Vi}|
-      {3:mL compiled string>"]:1: }                         |
+      {3:mL compiled string>"]:1:                        }  |
       {4:Press ENTER or type command to continue}^           |
     ]])
-  end)
-
-  it('can show multiline error messages', function()
-    local screen = Screen.new(50,10)
-    screen:attach()
-    screen:set_default_attr_ids({
-      [1] = {bold = true, foreground = Screen.colors.Blue1},
-      [2] = {bold = true, reverse = true},
-      [3] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
-      [4] = {bold = true, foreground = Screen.colors.SeaGreen4},
-    })
-
+    feed('<cr>')
+    screen:expect(empty_screen)
+    feed(':lua error("\r\r\r")<cr>')
+    screen:expect(empty_screen)
+    feed('<cr>')
+    screen:expect(empty_screen)
     feed(':lua error("fail\\nmuch error\\nsuch details")<cr>')
     screen:expect([[
                                                         |
@@ -163,18 +154,8 @@ describe(':lua command', function()
       {4:Press ENTER or type command to continue}^           |
     ]])
     feed('<cr>')
-    screen:expect([[
-      ^                                                  |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-                                                        |
-    ]])
+    screen:expect(empty_screen)
+
     eq('E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: fail\nmuch error\nsuch details', eval('v:errmsg'))
 
     local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
@@ -182,19 +163,8 @@ describe(':lua command', function()
     eq(false, status)
     eq(expected, string.sub(err, -string.len(expected)))
 
-    feed(':messages<cr>')
-    screen:expect([[
-                                                        |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {2:                                                  }|
-      {3:E5105: Error while calling lua chunk: [string "<Vi}|
-      {3:mL compiled string>"]:1: fail}                     |
-      {3:much error}                                        |
-      {3:such details}                                      |
-      {4:Press ENTER or type command to continue}^           |
-    ]])
+    --feed(':messages<cr>')
+    --screen:expect(empty_screen)
   end)
 end)
 

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -170,13 +170,26 @@ describe(':lua command', function()
     ]])
     feed('<cr>')
     screen:expect(empty_screen)
+		feed(':lua error("' .. ('x'):rep(200) .. '")<cr>')
+		screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {2:                                                  }|
+      {3:E5105: Error while calling lua chunk: [string "<Vi}|
+      {3:mL compiled string>"]:1: xxxxxxxxxxxxxxxxxxxxxxxxx}|
+      {3:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}|
+      {3:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}|
+      {3:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}|
+      {3:xxxxxxxxxxxxxxxxxxxxxxxxx}                         |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
 
-    eq('E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: fail\nmuch error\nsuch details', eval('v:errmsg'))
+    --eq('E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: fail\nmuch error\nsuch details', eval('v:errmsg'))
 
-    local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
-    local expected = 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: some error\nin a\nAPI command'
-    eq(false, status)
-    eq(expected, string.sub(err, -string.len(expected)))
+    --local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
+    --local expected = 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: some error\nin a\nAPI command'
+    --eq(false, status)
+    --eq(expected, string.sub(err, -string.len(expected)))
 
     --feed(':messages<cr>')
     --screen:expect(empty_screen)

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -102,7 +102,19 @@ describe(':lua command', function()
     {1:~                                                 }|
                                                       |
     ]]
-		-- ################## lua error #######################
+		-- ################## lua errors #######################
+    feed(':function A()<cr>')
+    feed(':lua error("error")<cr>')
+    feed(':endfunction<cr>')
+
+    feed(':function B()<cr>')
+    feed(':call A()<cr>')
+    feed(':endfunction<cr>')
+
+		-- FIXME(@tedbauer): uncomment and fix next 2 lines
+		--feed(':call B()')
+		--screen:expect(empty_screen)
+
 		feed(':lua error("this is a normal error")<cr>')
 		screen:expect([[
                                                         |
@@ -209,6 +221,86 @@ describe(':lua command', function()
     eq(false, status)
     eq(expected, string.sub(err, -string.len(expected)))
 
+    feed('<cr>')
+    screen:expect(empty_screen)
+
+		-- ################## echo messages #######################
+    feed(':function C()<cr>')
+    feed(':error("error")<cr>')
+    feed(':endfunction<cr>')
+
+    feed(':function D()<cr>')
+    feed(':call C()<cr>')
+    feed(':endfunction<cr>')
+
+		-- FIXME(@tedbauer): uncomment and fix next 2 lines
+		--feed(':call D()')
+		--screen:expect(empty_screen)
+
+-- 		feed(':echo("this is a normal string")<cr>')
+-- 		screen:expect([[
+--       ^                                                  |
+--       {1:~                                                 }|
+--       {1:~                                                 }|
+--       {1:~                                                 }|
+--       {1:~                                                 }|
+--       {1:~                                                 }|
+--       {1:~                                                 }|
+--       {1:~                                                 }|
+--       {1:~                                                 }|
+-- 			|
+--     ]])
+		feed('<cr>')
+		screen:expect(empty_screen)
+		feed(':echo("this is \t\t a really \t\t long \t\t string \t\t.")<cr>')
+		screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      this is                  a really                l|
+      ong              string                 .         |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
+		feed('<cr>')
+		screen:expect(empty_screen)
+    feed(':echo("")<cr>')
+		screen:expect(empty_screen)
+    feed('<cr>')
+    screen:expect(empty_screen)
+		--FIXME(@tedbauer): uncomment/fix next line
+    --feed(':echo("\n\n\n")<cr>')
+    --screen:expect(empty_screen)
+    feed('<cr>')
+    screen:expect(empty_screen)
+		--FIXME(@tedbauer): uncomment/fix next line
+    --feed(':echo("\t\t\t")<cr>')
+    --screen:expect(empty_screen)
+    feed('<cr>')
+    screen:expect(empty_screen)
+		--FIXME(@tedbauer): uncomment/fix next line
+    --feed(':echo("\r\r\r")<cr>')
+    --screen:expect(empty_screen)
+    feed('<cr>')
+    screen:expect(empty_screen)
+		feed(':echo("' .. ('x'):rep(200) .. '")<cr>')
+		screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {2:                                                  }|
+      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+                                                        |
+      {4:Press ENTER or type command to continue}^           |
+    ]])
+    feed('<cr>')
+    screen:expect(empty_screen)
     feed('<cr>')
     screen:expect(empty_screen)
   end)


### PR DESCRIPTION
Addresses #9541, adds test cases for:

> 1. Regular ones with multiline stack trace.
> 2. Single-line regular (i.e. what a sane developer would want to throw with `error()`) ones.
> 3. Consisting of just three newlines, three tabs and three `\r`s and nothing else. (These are _three_ cases, not one).
> 4. Long (longer then screen width) single-line ones with tabs inside.
> 5. Multiline with long (…) lines.
> 6. Just empty string.

## Todo
- [ ] Lua errors displayed on screen
    - [ ] Regular w/ multiline stack trace
    - [x] Single line regular
    - [X] Three newlines
    - [X] Three tabs
    - [X] Three `\r`s
    - [X] Long single line with tabs
    - [x] Multiline with long lines
    - [X] Empty string
- [ ] Throwing lua errors and catching them with `redir`, `execute()` or `nvim_command_output`
- [ ] Throwing lua errors and catching them with `:try|catch`
- [ ] Echoing messages with `:echon` and displaying them on screen
- [ ] Echoing messages with `:echo` and displaying them on screen
    - [ ] Regular w/ multiline stack trace
    - [ ] Single line regular
    - [ ] Three newlines
    - [ ] Three tabs
    - [ ] Three `\r`s
    - [X] Long single line with tabs
    - [x] Multiline with long lines
    - [X] Empty string
- [ ] Echoing messages with `:echo` and catching them with `redir`/… (…)
- [ ] Echoing messages with `:echon` and catching them with … (…)