### PR TITLE
vim-patch:8.1.0803: session file has problem with single quote in file name

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9391,9 +9391,9 @@ put_view(
       // Note, if a buffer for that file already exists, use :badd to
       // edit that buffer, to not lose folding information (:edit resets
       // folds in other buffers)
-      if (fputs("if bufexists('", fd) < 0
+      if (fputs("if bufexists(\"", fd) < 0
           || ses_fname(fd, wp->w_buffer, flagp, false) == FAIL
-          || fputs("') | buffer ", fd) < 0
+          || fputs("\") | buffer ", fd) < 0
           || ses_fname(fd, wp->w_buffer, flagp, false) == FAIL
           || fputs(" | else | edit ", fd) < 0
           || ses_fname(fd, wp->w_buffer, flagp, false) == FAIL

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -238,4 +238,18 @@ func Test_mkview_no_file_name()
   %bwipe
 endfunc
 
+func Test_mksession_quote_in_filename()
+  let v:errmsg = ''
+  %bwipe!
+  split another
+  split x'y\"z
+  mksession! Xtest_mks_quoted.out
+  %bwipe!
+  source Xtest_mks_quoted.out
+  call assert_true(bufexists("x'y\"z"))
+
+  %bwipe!
+  call delete('Xtest_mks_quoted.out')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
```
Problem:    Session file has problem with single quote in file name. (Jon
            Crowe)
Solution:   Use a double quoted string.  Add a test.
```

https://github.com/vim/vim/commit/ad36a3588d32985ee27bd11aa97e5195ef623158

Fixes https://github.com/neovim/neovim/issues/9618