### PR TITLE
Fix checkprefix: skip with empty cached prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ lint: check-single-includes clint testlint lualint
 
 checkprefix:
 	@cached_prefix=$$($(CMAKE_PRG) -L -N build | 2>/dev/null grep 'CMAKE_INSTALL_PREFIX' | cut -d '=' -f2); \
-	if [ -n "$(CMAKE_INSTALL_PREFIX)" ] && ! [ "$(CMAKE_INSTALL_PREFIX)" = "$$cached_prefix" ]; then \
+	if [ -n "$(CMAKE_INSTALL_PREFIX)" ] && [ -n "$$cached_prefix" ] && ! [ "$(CMAKE_INSTALL_PREFIX)" = "$$cached_prefix" ]; then \
 		printf "\nerror: CMAKE_INSTALL_PREFIX '$(CMAKE_INSTALL_PREFIX)' does not match cached value '%s'\n" "$$cached_prefix"; \
 		printf "       Run this command, then try again:\n"; \
 		printf "         cmake build -DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX)\n"; \


### PR DESCRIPTION
This regressed in 3b473bb14f9f452461016c7042949a23499df629:
```
% make 'CMAKE_BUILD_TYPE=RelWithDebInfo' 'CMAKE_EXTRA_FLAGS=-DCMAKE_INSTALL_PREFIX=/vim-build/neovim/neovim/master -DENABLE_JEMALLOC=OFF' 'DEPS_CMAKE_FLAGS=-DUSE_BUNDLED=OFF'

error: CMAKE_INSTALL_PREFIX '/vim-build/neovim/neovim/master' does not match cached value ''
       Run this command, then try again:
         cmake build -DCMAKE_INSTALL_PREFIX=/vim-build/neovim/neovim/master
make: *** [Makefile:169: checkprefix] Error 1
```

It was checking before for non-empty also [1].

1: https://github.com/neovim/neovim/pull/9621/files#diff-b67911656ef5d18c4ae36cb6741b7965L22