### PR TITLE
vim-patch:8.1.{934,937,945}

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -772,7 +772,7 @@ static int get_equi_class(char_u **pp)
   int l = 1;
   char_u      *p = *pp;
 
-  if (p[1] == '=') {
+  if (p[1] == '=' && p[2] != NUL) {
     l = (*mb_ptr2len)(p + 2);
     if (p[l + 2] == '=' && p[l + 3] == ']') {
       c = utf_ptr2char(p + 2);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1103,7 +1103,7 @@ static int get_coll_element(char_u **pp)
   int l = 1;
   char_u      *p = *pp;
 
-  if (p[0] != NUL && p[1] == '.') {
+  if (p[0] != NUL && p[1] == '.' && p[2] != NUL) {
     l = utfc_ptr2len(p + 2);
     if (p[l + 2] == '.' && p[l + 3] == ']') {
       c = utf_ptr2char(p + 2);

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1692,7 +1692,8 @@ collection:
           MB_PTR_ADV(regparse);
 
           if (*regparse == 'n')
-            startc = reg_string ? NL : NFA_NEWL;
+            startc = (reg_string || emit_range || regparse[1] == '-')
+              ? NL : NFA_NEWL;
           else if  (*regparse == 'd'
                     || *regparse == 'o'
                     || *regparse == 'x'

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1691,16 +1691,16 @@ collection:
             ) {
           MB_PTR_ADV(regparse);
 
-          if (*regparse == 'n')
+          if (*regparse == 'n') {
             startc = (reg_string || emit_range || regparse[1] == '-')
               ? NL : NFA_NEWL;
-          else if  (*regparse == 'd'
-                    || *regparse == 'o'
-                    || *regparse == 'x'
-                    || *regparse == 'u'
-                    || *regparse == 'U'
-                    ) {
-            /* TODO(RE) This needs more testing */
+          } else if  (*regparse == 'd'
+                      || *regparse == 'o'
+                      || *regparse == 'x'
+                      || *regparse == 'u'
+                      || *regparse == 'U'
+                      ) {
+            // TODO(RE): This needs more testing
             startc = coll_get_char();
             got_coll_char = true;
             MB_PTR_BACK(old_regparse, regparse);

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -44,4 +44,6 @@ func Test_get_equi_class()
   " Incomplete equivalence class caused invalid memory access
   s/^/[[=
   call assert_equal(1, search(getline(1)))
+  s/.*/[[.
+  call assert_equal(1, search(getline(1)))
 endfunc

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -38,3 +38,10 @@ func Test_range_with_newline()
   call assert_equal(0, search("[ -*\\t-\\n]"))
   bwipe!
 endfunc
+
+func Test_get_equi_class()
+  new
+  " Incomplete equivalence class caused invalid memory access
+  s/^/[[=
+  call assert_equal(1, search(getline(1)))
+endfunc

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -30,3 +30,11 @@ func Test_equivalence_re2()
   set re=2
   call s:equivalence_test()
 endfunc
+
+func Test_range_with_newline()
+  new
+  call setline(1, "a")
+  call assert_equal(0, search("[ -*\\n- ]"))
+  call assert_equal(0, search("[ -*\\t-\\n]"))
+  bwipe!
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0934: invalid memory access in search pattern**

Problem:    Invalid memory access in search pattern. (Kuang-che Wu)
Solution:   Check for incomplete equivalence class. (closes [vim/vim#3970](https://github.com/vim/vim/issues/3970))
[vim/vim@985079c](https://github.com/vim/vim/commit/985079c514e9ab85598b7bca019c77d3e42526f5)

**vim-patch:8.1.0937: invalid memory access in search pattern**

Problem:    Invalid memory access in search pattern. (Kuang-che Wu)
Solution:   Check for incomplete collation element. (Dominique Pelle,
            closes [vim/vim#3985](https://github.com/vim/vim/issues/3985))
[vim/vim@f1b57ab](https://github.com/vim/vim/commit/f1b57ab2ab18032d19f64bff7d22f3adb3fe93f7)

**vim-patch:8.1.0945: internal error when using pattern with NL in the range**

Problem:    Internal error when using pattern with NL in the range.
Solution:   Use an actual newline for the range. (closes vim/vim#3989)  Also fix
            error message.  (Dominique Pelle)
vim/vim@a548344