### PR TITLE
vim-patch:8.1.{276,387,668,926}

### DIFF
--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -51,3 +51,4 @@ source test_unlet.vim
 source test_utf8.vim
 source test_virtualedit.vim
 source test_window_cmd.vim
+source test_wnext.vim

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -522,4 +522,33 @@ func Test_setcmdpos()
   call assert_equal(1, setcmdpos(3))
 endfunc
 
+func Test_cmdline_overstrike()
+  let encodings = has('multi_byte') ? [ 'utf8' ] : [ 'latin1' ]
+  let encoding_save = &encoding
+
+  for e in encodings
+    exe 'set encoding=' . e
+
+    " Test overstrike in the middle of the command line.
+    call feedkeys(":\"01234\<home>\<right>\<right>ab\<right>\<insert>cd\<enter>", 'xt')
+    call assert_equal('"0ab1cd4', @:)
+
+    " Test overstrike going beyond end of command line.
+    call feedkeys(":\"01234\<home>\<right>\<right>ab\<right>\<insert>cdefgh\<enter>", 'xt')
+    call assert_equal('"0ab1cdefgh', @:)
+
+    " Test toggling insert/overstrike a few times.
+    call feedkeys(":\"01234\<home>\<right>ab\<right>\<insert>cd\<right>\<insert>ef\<enter>", 'xt')
+    call assert_equal('"ab0cd3ef4', @:)
+  endfor
+
+  if has('multi_byte')
+    " Test overstrike with multi-byte characters.
+    call feedkeys(":\"テキストエディタ\<home>\<right>\<right>ab\<right>\<insert>cd\<enter>", 'xt')
+    call assert_equal('"テabキcdエディタ', @:)
+  endif
+
+  let &encoding = encoding_save
+endfunc
+
 set cpo&

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -454,6 +454,41 @@ func Test_search_multibyte()
   let &encoding = save_enc
 endfunc
 
+" Similar to Test_incsearch_substitute() but with a screendump halfway.
+func Test_incsearch_substitute_dump()
+  if !exists('+incsearch')
+    return
+  endif
+  if !CanRunVimInTerminal()
+    return
+  endif
+  call writefile([
+	\ 'set incsearch hlsearch scrolloff=0',
+	\ 'for n in range(1, 10)',
+	\ '  call setline(n, "foo " . n)',
+	\ 'endfor',
+	\ '3',
+	\ ], 'Xis_subst_script')
+  let buf = RunVimInTerminal('-S Xis_subst_script', {'rows': 9, 'cols': 70})
+  " Give Vim a chance to redraw to get rid of the spaces in line 2 caused by
+  " the 'ambiwidth' check.
+  sleep 100m
+
+  " Need to send one key at a time to force a redraw.
+  call term_sendkeys(buf, ':.,.+2s/')
+  sleep 100m
+  call term_sendkeys(buf, 'f')
+  sleep 100m
+  call term_sendkeys(buf, 'o')
+  sleep 100m
+  call term_sendkeys(buf, 'o')
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_01', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
+  call delete('Xis_subst_script')
+endfunc
+
 func Test_search_undefined_behaviour()
   if !has("terminal")
     return

--- a/src/nvim/testdir/test_startup_utf8.vim
+++ b/src/nvim/testdir/test_startup_utf8.vim
@@ -4,6 +4,7 @@ if !has('multi_byte')
 endif
 
 source shared.vim
+" source screendump.vim
 
 func Test_read_stdin_utf8()
   let linesin = ['テスト', '€ÀÈÌÒÙ']
@@ -61,4 +62,25 @@ func Test_read_fifo_utf8()
   endif
   call delete('Xtestout')
   call delete('Xtestin')
+endfunc
+
+func Test_detect_ambiwidth()
+  if !CanRunVimInTerminal()
+    return
+  endif
+
+  " Use the title termcap entries to output the escape sequence.
+  call writefile([
+	\ 'set enc=utf-8',
+	\ 'set ambiwidth=double',
+	\ 'call test_option_not_set("ambiwidth")',
+	\ 'redraw',
+	\ ], 'Xscript')
+  let buf = RunVimInTerminal('-S Xscript', {})
+  call term_wait(buf)
+  call term_sendkeys(buf, "S\<C-R>=&ambiwidth\<CR>\<Esc>")
+  call WaitForAssert({-> assert_match('single', term_getline(buf, 1))})
+
+  call StopVimInTerminal(buf)
+  call delete('Xscript')
 endfunc

--- a/src/nvim/testdir/test_wnext.vim
+++ b/src/nvim/testdir/test_wnext.vim
@@ -1,0 +1,101 @@
+" Test :wnext :wNext and :wprevious
+
+func Test_wnext()
+  args X1 X2
+
+  call setline(1, '1')
+  wnext
+  call assert_equal(['1'], readfile('X1'))
+  call assert_equal('X2', bufname('%'))
+
+  call setline(1, '2')
+  call assert_fails('wnext', 'E165:')
+  call assert_equal(['2'], readfile('X2'))
+  call assert_equal('X2', bufname('%'))
+
+  " Test :wnext with a single file.
+  args X1
+  call assert_equal('X1', bufname('%'))
+  call assert_fails('wnext', 'E163:')
+
+  " Test :wnext with a count.
+  args X1 X2 X3
+  call assert_equal('X1', bufname('%'))
+  2wnext
+  call assert_equal('X3', bufname('%'))
+
+  " Test :wnext {file}.
+  args X1 X2 X3
+  wnext X4
+  call assert_equal(['1'], readfile('X4'))
+  call assert_equal('X2', bufname('%'))
+  call assert_fails('wnext X4', 'E13:')
+  call assert_equal(['1'], readfile('X4'))
+  wnext! X4
+  call assert_equal(['2'], readfile('X4'))
+  call assert_equal('X3', bufname('%'))
+
+  args X1 X2
+  " Commented out as, E13 occurs on Windows instead of E17
+  "call assert_fails('wnext .', 'E17:')
+  call assert_fails('wnext! .', 'E502:')
+
+  %bwipe!
+  call delete('X1')
+  call delete('X2')
+  call delete('X3')
+  call delete('X4')
+endfunc
+
+func Test_wprevious()
+  args X1 X2
+
+  next
+  call assert_equal('X2', bufname('%'))
+  call setline(1, '2')
+  wprevious
+  call assert_equal(['2'], readfile('X2'))
+  call assert_equal('X1', bufname('%'))
+
+  call setline(1, '1')
+  call assert_fails('wprevious', 'E164:')
+  call assert_fails('wNext', 'E164:')
+
+  " Test :wprevious with a single file.
+  args X1
+  call assert_fails('wprevious', 'E163:')
+  call assert_fails('wNext', 'E163:')
+
+  " Test :wprevious with a count.
+  args X1 X2 X3
+  2next
+  call setline(1, '3')
+  call assert_equal('X3', bufname('%'))
+  2wprevious
+  call assert_equal('X1', bufname('%'))
+  call assert_equal(['3'], readfile('X3'))
+
+  " Test :wprevious {file}
+  args X1 X2 X3
+  2next
+  call assert_equal('X3', bufname('%'))
+  wprevious X4
+  call assert_equal(['3'], readfile('X4'))
+  call assert_equal('X2', bufname('%'))
+  call assert_fails('wprevious X4', 'E13:')
+  call assert_equal(['3'], readfile('X4'))
+  wprevious! X4
+  call assert_equal(['2'], readfile('X4'))
+  call assert_equal('X1', bufname('%'))
+
+  args X1 X2
+  " Commented out as, E13 occurs on Windows instead of E17
+  "call assert_fails('wprevious .', 'E17:')
+  call assert_fails('wprevious! .', 'E502:')
+
+  %bwipe!
+  call delete('X1')
+  call delete('X2')
+  call delete('X3')
+  call delete('X4')
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0276: no test for 'incsearch' highlighting with :s**

Problem:    No test for 'incsearch' highlighting with :s.
Solution:   Add a screendump test.
[vim/vim@164251f](https://github.com/vim/vim/commit/164251ff805e89a3d9a850a77e3139e28908f44a)

**vim-patch:8.1.0387: no test for 'ambiwidth' detection**

Problem:    No test for 'ambiwidth' detection.
Solution:   Add a test.
[vim/vim@24839ed](https://github.com/vim/vim/commit/24839edc54e985ed88d063513226922a6f5b7554)

**vim-patch:8.1.0668: no test for overstrike mode in the command line**

Problem:    No test for overstrike mode in the command line.
Solution:   Add a test. (Dominique Pelle, closes [vim/vim#3742](https://github.com/vim/vim/pull/3742))
[vim/vim@c0676ba](https://github.com/vim/vim/commit/c0676bab92bd6488e17d05a4a70dfff993ef524e)

**vim-patch:8.1.0926: no test for :wnext, :wNext and :wprevious**

Problem:    No test for :wnext, :wNext and :wprevious.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#3963)
https://github.com/vim/vim/commit/e93e5a504f481bd0dad9c504d5fcf0e5f0dfc6e6