### PR TITLE
man.vim: Add g:man_hard_wrap option

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -152,6 +152,10 @@ function! s:get_page(path) abort
   " Disable hard-wrap by using a big $MANWIDTH (max 1000 on some systems #9065).
   " We use soft wrap: ftplugin/man.vim sets wrap/breakindent/….
   let manwidth = 999
+  if exists('g:man_hard_wrap')
+    " Respect $MANWIDTH or default to window width.
+    let manwidth = empty($MANWIDTH) ? winwidth(0) : $MANWIDTH
+  endif
   " Force MANPAGER=cat to ensure Vim is not recursively invoked (by man-db).
   " http://comments.gmane.org/gmane.editors.vim.devel/29085
   " Set MAN_KEEP_FORMATTING so Debian man doesn't discard backspaces.

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -549,6 +549,7 @@ q                         :quit if invoked as $MANPAGER, otherwise :close.
 Variables:
 *g:no_man_maps*             Do not create mappings in manpage buffers.
 *g:ft_man_folding_enable*   Fold manpages with foldmethod=indent foldnestmax=1.
+*g:man_hard_wrap*           Let man hard-wrap text with $MANWIDTH.
 *b:man_default_sects*       Comma-separated, ordered list of preferred sections.
                           For example in C one usually wants section 3 or 2: >
                                :let b:man_default_sections = '3,2'


### PR DESCRIPTION
This option allows restoring the behaviour prior to #9023.

Fixes #9583.