### PR TITLE
[RDY] Always detach when reloading a buffer

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -592,6 +592,7 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
   do_autochdir();
 
   // disable buffer updates for the current buffer
+  // no need to check unload_buf b/c in that case the function returned above
   buf_updates_unregister_all(buf);
 
   /*

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2491,6 +2491,7 @@ int do_ecmd(
       // Tell readfile() not to clear or reload undo info.
       readfile_flags = READ_KEEP_UNDO;
     } else {
+      buf_updates_unregister_all(curbuf);
       buf_freeall(curbuf, 0);  // Free all things for buffer.
     }
     // If autocommands deleted the buffer we were going to re-edit, give

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -678,6 +678,32 @@ describe('API: buffer events:', function()
     expectn('Hello There', {})
   end)
 
+  it('detaches if the file is reloaded', function()
+    local b, tick = editoriginal(true, {'AAA', 'BBB'})
+    command('set undoreload=1')
+
+    command('normal! x')
+    tick = tick + 1
+    expectn('nvim_buf_lines_event', {b, tick, 0, 1, {'AA'}, false})
+
+    command('edit!')
+    expectn('nvim_buf_detach_event', {b})
+  end)
+
+  it('does not detach from hidden buffers with enew', function()
+    local b, tick = editoriginal(true, {'AAA', 'BBB'})
+    local channel = nvim('get_api_info')[1]
+
+    command('set undoreload=1 hidden')
+    command('normal! x')
+    tick = tick + 1
+    expectn('nvim_buf_lines_event', {b, tick, 0, 1, {'AA'}, false})
+
+    command('enew!')
+    eval('rpcnotify('..channel..', "Hello There")')
+    expectn('Hello There', {})
+  end)
+
   it('stays attached if the buffer is hidden', function()
     local b, tick = editoriginal(true, {'AAA'})
     local channel = nvim('get_api_info')[1]


### PR DESCRIPTION
Independently of the value of undoreload and the length of the file.

Closes https://github.com/neovim/neovim/issues/9642.

Note that I was wrong about `enew`, the behavior is correct, depending on the value of `hidden`/`bufhidden`. I added a test anyways to ensure this behavior. I also added a comment, because I took the time to figure out why we don't need to check for `unload_buf` at the appropriate place.