### PR TITLE
vim-patch:8.1.0225: mode() to indicate CTRL-O from Insert mode

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5774,6 +5774,9 @@ mode([expr])	Return a string that indicates the current mode.
 		This is useful in the 'statusline' option or when used
 		with |remote_expr()| In most other places it always returns
 		"c" or "n".
+		Note that in the future more modes and more specific modes may
+		be added. It's better not to compare the whole string but only
+		the leading character(s).
 		Also see |visualmode()|.
 
 msgpackdump({list})					*msgpackdump()*

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -162,6 +162,10 @@ char *get_mode(void)
       buf[1] = 'o';
       // to be able to detect force-linewise/blockwise/characterwise operations
       buf[2] = (char)motion_force;
+    } else if (restart_edit == 'I' || restart_edit == 'R'
+               || restart_edit == 'V') {
+      buf[1] = 'i';
+      buf[2] = (char)restart_edit;
     }
   }
 

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -556,6 +556,18 @@ func Test_mode()
   call assert_equal('n', mode(0))
   call assert_equal('n', mode(1))
 
+  " i_CTRL-O
+  exe "normal i\<C-O>:call Save_mode()\<Cr>\<Esc>"
+  call assert_equal("n-niI", g:current_modes)
+
+  " R_CTRL-O
+  exe "normal R\<C-O>:call Save_mode()\<Cr>\<Esc>"
+  call assert_equal("n-niR", g:current_modes)
+
+  " gR_CTRL-O
+  exe "normal gR\<C-O>:call Save_mode()\<Cr>\<Esc>"
+  call assert_equal("n-niV", g:current_modes)
+
   " How to test operator-pending mode?
 
   call feedkeys("v", 'xt')


### PR DESCRIPTION
Problem:    Mode() does not indicate using CTRL-O from Insert mode.
Solution:   Add "niI", "niR" and "niV" to mode() result. (closes vim/vim#3000)
https://github.com/vim/vim/commit/612cc3888b136e80485132d9f997ed457dbc5501