### PR TITLE
test/env: multibyte env var to child process

### DIFF
--- a/test/functional/eval/let_spec.lua
+++ b/test/functional/eval/let_spec.lua
@@ -5,6 +5,9 @@ local clear = helpers.clear
 local meths = helpers.meths
 local redir_exec = helpers.redir_exec
 local source = helpers.source
+local command = helpers.command
+local eval = helpers.eval
+local nvim_dir = helpers.nvim_dir
 
 before_each(clear)
 
@@ -41,5 +44,23 @@ describe(':let command', function()
       call garbagecollect(1)
       call feedkeys(":\e:echo l1 l3\n:echo 42\n:cq\n", "t")
     ]=])
+  end)
+
+  it("multibyte env var to child process #8398 #9267",  function()
+    local cmd_get_child_env = "let g:env_from_child = system(['"..nvim_dir.."/printenv-test', 'NVIM_TEST'])"
+    command("let $NVIM_TEST = 'AìaB'")
+    command(cmd_get_child_env)
+    eq(eval('$NVIM_TEST'), eval('g:env_from_child'))
+
+    command("let $NVIM_TEST = 'AaあB'")
+    command(cmd_get_child_env)
+    eq(eval('$NVIM_TEST'), eval('g:env_from_child'))
+
+    local mbyte = [[\p* .ม .ม .ม .ม่ .ม่ .ม่ ֹ ֹ ֹ .ֹ .ֹ .ֹ ֹֻ ֹֻ ֹֻ
+                    .ֹֻ .ֹֻ .ֹֻ ֹֻ ֹֻ ֹֻ .ֹֻ .ֹֻ .ֹֻ ֹ ֹ ֹ .ֹ .ֹ .ֹ ֹ ֹ ֹ .ֹ .ֹ .ֹ ֹֻ ֹֻ
+                    .ֹֻ .ֹֻ .ֹֻ a a a ca ca ca à à à]]
+    command("let $NVIM_TEST = '"..mbyte.."'")
+    command(cmd_get_child_env)
+    eq(eval('$NVIM_TEST'), eval('g:env_from_child'))
   end)
 end)

--- a/test/functional/fixtures/CMakeLists.txt
+++ b/test/functional/fixtures/CMakeLists.txt
@@ -3,3 +3,7 @@ target_link_libraries(tty-test ${LIBUV_LIBRARIES})
 
 add_executable(shell-test shell-test.c)
 add_executable(printargs-test printargs-test.c)
+add_executable(printenv-test printenv-test.c)
+if(WIN32)
+  set_target_properties(printenv-test PROPERTIES LINK_FLAGS -municode)
+endif()

--- a/test/functional/fixtures/printenv-test.c
+++ b/test/functional/fixtures/printenv-test.c
@@ -1,0 +1,58 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+#include <stdio.h>
+
+#ifdef WIN32
+# include <windows.h>
+#else
+# include <stdlib.h>
+#endif
+
+#ifdef WIN32
+int wmain(int argc, wchar_t **argv)
+#else
+int main(int argc, char **argv)
+#endif
+{
+  if (argc != 2) {
+    return 1;
+  }
+
+#ifdef WIN32
+  wchar_t *value = _wgetenv(argv[1]);
+  if (value == NULL) {
+    return 1;
+  }
+  int utf8_len = WideCharToMultiByte(CP_UTF8,
+                                     0,
+                                     value,
+                                     -1,
+                                     NULL,
+                                     0,
+                                     NULL,
+                                     NULL);
+  if (utf8_len == 0) {
+    return (int)GetLastError();
+  }
+  char *utf8_value = (char *)calloc((size_t)utf8_len, sizeof(char));
+  utf8_len = WideCharToMultiByte(CP_UTF8,
+                                 0,
+                                 value,
+                                 -1,
+                                 utf8_value,
+                                 utf8_len,
+                                 NULL,
+                                 NULL);
+  printf("%s", utf8_value);
+  free(utf8_value);
+#else
+  char *value = getenv(argv[1]);
+  if (value == NULL) {
+    printf("env var not found: %s", argv[1]);
+    return 1;
+  }
+  printf("%s", value);
+#endif
+  return 0;
+}


### PR DESCRIPTION
Run this test from #7920 on current master.

This demonstrates:

- The test correctly fails on Windows/AppVeyor, before #7920.
- Travis/Quickbuild fail in the same way as in #7920.
   ```
  [ RUN      ] :let command multibyte env var to child process #8398 #9267: FAIL
  ...uild/neovim/neovim/test/functional/eval/let_spec.lua:53: Expected objects to be the same.
  Passed in:
  (string) ''
  Expected:
  (string) 'AÃ¬aB'

  stack traceback:
	  (tail call): ?
	  ...uild/neovim/neovim/test/functional/eval/let_spec.lua:53: in function <...uild/neovim/neovim/test/functional/eval/let_spec.lua:49><Paste>

   ```