### PR TITLE
vim-patch:8.1.0971: failure for selecting quoted text object moves cu…

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3717,11 +3717,12 @@ current_quote(
   int col_end;
   int col_start = curwin->w_cursor.col;
   bool inclusive = false;
-  int vis_empty = TRUE;                 /* Visual selection <= 1 char */
-  int vis_bef_curs = FALSE;             /* Visual starts before cursor */
-  int inside_quotes = FALSE;            /* Looks like "i'" done before */
-  int selected_quote = FALSE;           /* Has quote inside selection */
+  int vis_empty = TRUE;                 // Visual selection <= 1 char
+  int vis_bef_curs = FALSE;             // Visual starts before cursor
+  int inside_quotes = FALSE;            // Looks like "i'" done before
+  int selected_quote = FALSE;           // Has quote inside selection
   int i;
+  int restore_vis_bef = FALSE;          // resotre VIsual on abort
 
   // Correct cursor when 'selection' is "exclusive".
   if (VIsual_active) {
@@ -3738,7 +3739,8 @@ current_quote(
 
         curwin->w_cursor = VIsual;
         VIsual = t;
-        vis_bef_curs = true;
+        vis_bef_curs = TRUE;
+        restore_vis_bef = TRUE;
       }
       dec_cursor();
     }
@@ -3780,7 +3782,7 @@ current_quote(
        * opening quote. */
       col_start = find_next_quote(line, col_start + 1, quotechar, NULL);
       if (col_start < 0)
-        return FALSE;
+        goto abort_search;
       col_end = find_next_quote(line, col_start + 1, quotechar,
           curbuf->b_p_qe);
       if (col_end < 0) {
@@ -3791,7 +3793,7 @@ current_quote(
     } else {
       col_end = find_prev_quote(line, col_start, quotechar, NULL);
       if (line[col_end] != quotechar)
-        return FALSE;
+        goto abort_search;
       col_start = find_prev_quote(line, col_end, quotechar,
           curbuf->b_p_qe);
       if (line[col_start] != quotechar) {
@@ -3820,12 +3822,12 @@ current_quote(
       /* Find open quote character. */
       col_start = find_next_quote(line, col_start, quotechar, NULL);
       if (col_start < 0 || col_start > first_col)
-        return FALSE;
+        goto abort_search;
       /* Find close quote character. */
       col_end = find_next_quote(line, col_start + 1, quotechar,
           curbuf->b_p_qe);
       if (col_end < 0)
-        return FALSE;
+        goto abort_search;
       /* If is cursor between start and end quote character, it is
        * target text object. */
       if (col_start <= first_col && first_col <= col_end)
@@ -3839,14 +3841,14 @@ current_quote(
       /* No quote before the cursor, look after the cursor. */
       col_start = find_next_quote(line, col_start, quotechar, NULL);
       if (col_start < 0)
-        return FALSE;
+        goto abort_search;
     }
 
     /* Find close quote character. */
     col_end = find_next_quote(line, col_start + 1, quotechar,
         curbuf->b_p_qe);
     if (col_end < 0)
-      return FALSE;
+      goto abort_search;
   }
 
   /* When "include" is TRUE, include spaces after closing quote or before
@@ -3923,6 +3925,20 @@ current_quote(
   }
 
   return OK;
+
+abort_search:
+  if (VIsual_active && *p_sel == 'e')
+  {
+    inc_cursor();
+    if (restore_vis_bef)
+    {
+       pos_T t = curwin->w_cursor;
+
+       curwin->w_cursor = VIsual;
+       VIsual = t;
+    }
+  }
+  return FALSE;
 }
 
 

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3717,12 +3717,12 @@ current_quote(
   int col_end;
   int col_start = curwin->w_cursor.col;
   bool inclusive = false;
-  int vis_empty = TRUE;                 // Visual selection <= 1 char
-  int vis_bef_curs = FALSE;             // Visual starts before cursor
-  int inside_quotes = FALSE;            // Looks like "i'" done before
-  int selected_quote = FALSE;           // Has quote inside selection
+  int vis_empty = true;                 // Visual selection <= 1 char
+  int vis_bef_curs = false;             // Visual starts before cursor
+  int inside_quotes = false;            // Looks like "i'" done before
+  int selected_quote = false;           // Has quote inside selection
   int i;
-  int restore_vis_bef = FALSE;          // resotre VIsual on abort
+  int restore_vis_bef = false;          // resotre VIsual on abort
 
   // Correct cursor when 'selection' is "exclusive".
   if (VIsual_active) {
@@ -3739,8 +3739,8 @@ current_quote(
 
         curwin->w_cursor = VIsual;
         VIsual = t;
-        vis_bef_curs = TRUE;
-        restore_vis_bef = TRUE;
+        vis_bef_curs = true;
+        restore_vis_bef = true;
       }
       dec_cursor();
     }
@@ -3781,8 +3781,9 @@ current_quote(
       /* Assume we are on a closing quote: move to after the next
        * opening quote. */
       col_start = find_next_quote(line, col_start + 1, quotechar, NULL);
-      if (col_start < 0)
+      if (col_start < 0) {
         goto abort_search;
+      }
       col_end = find_next_quote(line, col_start + 1, quotechar,
           curbuf->b_p_qe);
       if (col_end < 0) {
@@ -3792,8 +3793,9 @@ current_quote(
       }
     } else {
       col_end = find_prev_quote(line, col_start, quotechar, NULL);
-      if (line[col_end] != quotechar)
+      if (line[col_end] != quotechar) {
         goto abort_search;
+      }
       col_start = find_prev_quote(line, col_end, quotechar,
           curbuf->b_p_qe);
       if (line[col_start] != quotechar) {
@@ -3821,17 +3823,20 @@ current_quote(
     for (;; ) {
       /* Find open quote character. */
       col_start = find_next_quote(line, col_start, quotechar, NULL);
-      if (col_start < 0 || col_start > first_col)
+      if (col_start < 0 || col_start > first_col) {
         goto abort_search;
-      /* Find close quote character. */
+      }
+      // Find close quote character.
       col_end = find_next_quote(line, col_start + 1, quotechar,
           curbuf->b_p_qe);
-      if (col_end < 0)
+      if (col_end < 0) {
         goto abort_search;
-      /* If is cursor between start and end quote character, it is
-       * target text object. */
-      if (col_start <= first_col && first_col <= col_end)
+      }
+      // If is cursor between start and end quote character, it is
+      // target text object.
+      if (col_start <= first_col && first_col <= col_end) {
         break;
+      }
       col_start = col_end + 1;
     }
   } else {
@@ -3840,15 +3845,17 @@ current_quote(
     if (line[col_start] != quotechar) {
       /* No quote before the cursor, look after the cursor. */
       col_start = find_next_quote(line, col_start, quotechar, NULL);
-      if (col_start < 0)
+      if (col_start < 0) {
         goto abort_search;
+      }
     }
 
     /* Find close quote character. */
     col_end = find_next_quote(line, col_start + 1, quotechar,
-        curbuf->b_p_qe);
-    if (col_end < 0)
+                              curbuf->b_p_qe);
+    if (col_end < 0) {
       goto abort_search;
+    }
   }
 
   /* When "include" is TRUE, include spaces after closing quote or before
@@ -3927,11 +3934,9 @@ current_quote(
   return OK;
 
 abort_search:
-  if (VIsual_active && *p_sel == 'e')
-  {
+  if (VIsual_active && *p_sel == 'e') {
     inc_cursor();
-    if (restore_vis_bef)
-    {
+    if (restore_vis_bef) {
        pos_T t = curwin->w_cursor;
 
        curwin->w_cursor = VIsual;

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -52,6 +52,31 @@ func Test_quote_selection_selection_exclusive()
   bw!
 endfunc
 
+func Test_quote_selection_selection_exclusive_abort()
+  new
+  set selection=exclusive
+  call setline(1, "'abzzc'")
+  let exp_curs = [0, 1, 6, 0]
+  call cursor(1,1)
+  exe 'norm! fcdvi"'
+  " make sure to end visual mode to have a clear state
+  exe "norm! \<esc>"
+  call assert_equal(exp_curs, getpos('.'))
+  call cursor(1,1)
+  exe 'norm! fcvi"'
+  exe "norm! \<esc>"
+  call assert_equal(exp_curs, getpos('.'))
+  call cursor(1,2)
+  exe 'norm! vfcoi"'
+  exe "norm! \<esc>"
+  let exp_curs = [0, 1, 2, 0]
+  let exp_visu = [0, 1, 7, 0]
+  call assert_equal(exp_curs, getpos('.'))
+  call assert_equal(exp_visu, getpos("'>"))
+  set selection&vim
+  bw!
+endfunc
+
 " Tests for string and html text objects
 func Test_string_html_objects()
   enew!


### PR DESCRIPTION
…rsor

Problem:    Failure for selecting quoted text object moves cursor.
Solution:   Restore the Visual selection on failure. (Christian Brabandt,
            closes vim/vim#4024)
https://github.com/vim/vim/commit/55d3bdbbe2bfc7a78b4aa17763788dbddf87cab0