### PR TITLE
API/buffer: use aucmd_prepbuf() to manipulate invisible buffer, fix some issues

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -31,6 +31,7 @@
 #include "nvim/edit.h"
 #include "nvim/eval.h"
 #include "nvim/eval/typval.h"
+#include "nvim/fileio.h"
 #include "nvim/option.h"
 #include "nvim/state.h"
 #include "nvim/syntax.h"
@@ -978,11 +979,12 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
     return 0;
   }
   if (scratch) {
-    WITH_BUFFER(buf, {
-      set_option_value("bh", 0L, "hide", OPT_LOCAL);
-      set_option_value("bt", 0L, "nofile", OPT_LOCAL);
-      set_option_value("swf", 0L, NULL, OPT_LOCAL);
-    });
+    aco_save_T aco;
+    aucmd_prepbuf(&aco, buf);
+    set_option_value("bh", 0L, "hide", OPT_LOCAL);
+    set_option_value("bt", 0L, "nofile", OPT_LOCAL);
+    set_option_value("swf", 0L, NULL, OPT_LOCAL);
+    aucmd_restbuf(&aco);
   }
   return buf->b_fnum;
 }

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -63,35 +63,6 @@ enum bfa_values {
 # include "buffer.h.generated.h"
 #endif
 
-// Find a window that contains "buf" and switch to it.
-// If there is no such window, use the current window and change "curbuf".
-// Caller must initialize save_curbuf to NULL.
-// restore_win_for_buf() MUST be called later!
-static inline void switch_to_win_for_buf(buf_T *buf,
-                                         win_T **save_curwinp,
-                                         tabpage_T **save_curtabp,
-                                         bufref_T *save_curbuf)
-{
-  win_T *wp;
-  tabpage_T *tp;
-
-  if (!find_win_for_buf(buf, &wp, &tp)
-      || switch_win(save_curwinp, save_curtabp, wp, tp, true) == FAIL) {
-    switch_buffer(save_curbuf, buf);
-  }
-}
-
-static inline void restore_win_for_buf(win_T *save_curwin,
-                                       tabpage_T *save_curtab,
-                                       bufref_T *save_curbuf)
-{
-  if (save_curbuf->br_buf == NULL) {
-    restore_win(save_curwin, save_curtab, true);
-  } else {
-    restore_buffer(save_curbuf);
-  }
-}
-
 static inline void buf_set_changedtick(buf_T *const buf,
                                        const varnumber_T changedtick)
   REAL_FATTR_NONNULL_ALL REAL_FATTR_ALWAYS_INLINE;
@@ -144,16 +115,5 @@ static inline void buf_inc_changedtick(buf_T *const buf)
 {
   buf_set_changedtick(buf, buf_get_changedtick(buf) + 1);
 }
-
-#define WITH_BUFFER(b, code) \
-  do { \
-    win_T *save_curwin = NULL; \
-    tabpage_T *save_curtab = NULL; \
-    bufref_T save_curbuf = { NULL, 0, 0 }; \
-    switch_to_win_for_buf(b, &save_curwin, &save_curtab, &save_curbuf); \
-    code; \
-    restore_win_for_buf(save_curwin, save_curtab, &save_curbuf); \
-  } while (0)
-
 
 #endif  // NVIM_BUFFER_H

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1112,11 +1112,15 @@ static void refresh_terminal(Terminal *term)
     return;
   }
   long ml_before = buf->b_ml.ml_line_count;
-  WITH_BUFFER(buf, {
-    refresh_size(term, buf);
-    refresh_scrollback(term, buf);
-    refresh_screen(term, buf);
-  });
+
+  // refresh_ functions assume the terminal buffer is current
+  aco_save_T aco;
+  aucmd_prepbuf(&aco, buf);
+  refresh_size(term, buf);
+  refresh_scrollback(term, buf);
+  refresh_screen(term, buf);
+  aucmd_restbuf(&aco);
+
   long ml_added = buf->b_ml.ml_line_count - ml_before;
   adjust_topline(term, buf, ml_added);
 }

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1359,6 +1359,9 @@ describe('API', function()
       eq({id=1}, meths.get_current_buf())
 
       local screen = Screen.new(20, 4)
+      screen:set_default_attr_ids({
+        [1] = {bold = true, foreground = Screen.colors.Blue1},
+      })
       screen:attach()
 
       --
@@ -1373,7 +1376,7 @@ describe('API', function()
       end
 
       --
-      -- Visiting a scratch-buffer DOES change its properties.
+      -- Visiting a scratch-buffer DOES NOT change its properties.
       --
       meths.set_current_buf(edited_buf)
       screen:expect([[
@@ -1381,12 +1384,19 @@ describe('API', function()
         {1:~                   }|
         {1:~                   }|
                             |
-      ]], {
-        [1] = {bold = true, foreground = Screen.colors.Blue1},
-      })
-      eq('', meths.buf_get_option(edited_buf, 'buftype'))
-      eq('', meths.buf_get_option(edited_buf, 'bufhidden'))
+      ]])
+      eq('nofile', meths.buf_get_option(edited_buf, 'buftype'))
+      eq('hide', meths.buf_get_option(edited_buf, 'bufhidden'))
       eq(false, meths.buf_get_option(edited_buf, 'swapfile'))
+
+      -- scratch buffer can be wiped without error
+      command('bwipe')
+      screen:expect([[
+        ^                    |
+        {1:~                   }|
+        {1:~                   }|
+                            |
+      ]])
     end)
   end)
 end)

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -504,7 +504,7 @@ describe('floating windows', function()
       local win = meths.open_win(buf, false, 15, 4, {relative='editor', row=2, col=10})
       meths.win_set_option(win , 'winhl', 'Normal:PMenu')
       local expected_pos = {
-          [3]={{id=1001}, 'NW', 1, 2, 10, true},
+          [4]={{id=1002}, 'NW', 1, 2, 10, true},
       }
       if multigrid then
         screen:expect{grid=[[
@@ -523,7 +523,7 @@ describe('floating windows', function()
           {0:~                                       }|
           {0:~                                       }|
           {0:~                                       }|
-        ## grid 3
+        ## grid 4
           {1:such           }|
           {1:very           }|
           {1:float          }|
@@ -555,7 +555,7 @@ describe('floating windows', function()
           {0:~                                       }|
           {0:~                                       }|
           {0:~                                       }|
-        ## grid 3
+        ## grid 4
           {1:such           }|
           {1:very           }|
           {1:float          }|
@@ -583,7 +583,7 @@ describe('floating windows', function()
           ^                                        |
           {0:~                                       }|
           {0:~                                       }|
-        ## grid 3
+        ## grid 4
           {1:such           }|
           {1:very           }|
           {1:float          }|
@@ -608,7 +608,7 @@ describe('floating windows', function()
         ## grid 2
           ^                                        |
           {0:~                                       }|
-        ## grid 3
+        ## grid 4
           {1:such           }|
           {1:very           }|
           {1:float          }|
@@ -631,7 +631,7 @@ describe('floating windows', function()
         ## grid 2
                                                   |
           {0:~                                       }|
-        ## grid 3
+        ## grid 4
           {1:such           }|
           {1:very           }|
           {1:^float          }|
@@ -663,7 +663,7 @@ describe('floating windows', function()
           {0:~                                       }|
           {0:~                                       }|
           {0:~                                       }|
-        ## grid 3
+        ## grid 4
           {1:such           }|
           {1:very           }|
           {1:^float          }|
@@ -700,7 +700,7 @@ describe('floating windows', function()
           {0:~                                       }|
           {0:~                                       }|
           {0:~                                       }|
-        ## grid 3
+        ## grid 4
           {1:^such           }|
           {1:very           }|
           {1:float          }|
@@ -735,7 +735,7 @@ describe('floating windows', function()
           {0:~                         }|
           {0:~                         }|
           {0:~                         }|
-        ## grid 3
+        ## grid 4
           {1:^such           }|
           {1:very           }|
           {1:float          }|
@@ -770,7 +770,7 @@ describe('floating windows', function()
           {0:~                        }|
           {0:~                        }|
           {0:~                        }|
-        ## grid 3
+        ## grid 4
           {1:^such           }|
           {1:very           }|
           {1:float          }|
@@ -805,7 +805,7 @@ describe('floating windows', function()
           {0:~                       }|
           {0:~                       }|
           {0:~                       }|
-        ## grid 3
+        ## grid 4
           {1:^such           }|
           {1:very           }|
           {1:float          }|
@@ -840,7 +840,7 @@ describe('floating windows', function()
           {0:~               }|
           {0:~               }|
           {0:~               }|
-        ## grid 3
+        ## grid 4
           {1:^such           }|
           {1:very           }|
           {1:float          }|
@@ -875,7 +875,7 @@ describe('floating windows', function()
           {0:~              }|
           {0:~              }|
           {0:~              }|
-        ## grid 3
+        ## grid 4
           {1:^such           }|
           {1:very           }|
           {1:float          }|
@@ -910,7 +910,7 @@ describe('floating windows', function()
           {0:~             }|
           {0:~             }|
           {0:~             }|
-        ## grid 3
+        ## grid 4
           {1:^such           }|
           {1:very           }|
           {1:float          }|
@@ -945,7 +945,7 @@ describe('floating windows', function()
           {0:~           }|
           {0:~           }|
           {0:~           }|
-        ## grid 3
+        ## grid 4
           {1:^such           }|
           {1:very           }|
           {1:float          }|
@@ -971,7 +971,7 @@ describe('floating windows', function()
                       |
         ## grid 2
                       |
-        ## grid 3
+        ## grid 4
           {1:^such           }|
           {1:very           }|
           {1:float          }|
@@ -1001,7 +1001,7 @@ describe('floating windows', function()
           {0:~                                       }|
           {0:~                                       }|
           {0:~                                       }|
-        ## grid 3
+        ## grid 4
           {1:^such           }|
           {1:very           }|
           {1:float          }|


### PR DESCRIPTION
Problem: `nvim_buf_set_lines()` sometimes messes up the cursor in curwin, if the buffer is displayed in no window. This is because `switch_to_win_for_buf()` reuses curwin if no window is found.

Problem: `nvim_create_buf(false, \* scratch *\ true)` doesn't work, because `switch_to_win_for_buf` doesn't handle buffer options correctly.

Problem: `switch_to_win_for_buf` seems to do the same thing as `aucmd_prepbuf` but with issues and glitches.

Solution: always use `aucmd_prepbuf()` and delete `switch_to_win_for_buf()`. The only downside to the former might cause two extra frame layout calculations. We could avoid that by making `aucmd_win` a float. It shares the property that it can't be the only window, anyway, so that might eliminate some ad-hoc checks.
