### PR TITLE
vim-patch:8.1.0891

### DIFF
--- a/src/nvim/testdir/test_findfile.vim
+++ b/src/nvim/testdir/test_findfile.vim
@@ -119,6 +119,14 @@ func Test_findfile()
   let &shellslash = save_shellslash
 endfunc
 
+func Test_findfile_error()
+  call assert_fails('call findfile([])', 'E730:')
+  call assert_fails('call findfile("x", [])', 'E730:')
+  call assert_fails('call findfile("x", "", [])', 'E745:')
+  call assert_fails('call findfile("x", "**x")', 'E343:')
+  call assert_fails('call findfile("x", repeat("x", 5000))', 'E854:')
+endfunc
+
 " Test finddir({name} [, {path} [, {count}]])
 func Test_finddir()
   let save_path = &path
@@ -166,4 +174,12 @@ func Test_finddir()
   call CleanFiles()
   let &path = save_path
   let &shellslash = save_shellslash
+endfunc
+
+func Test_finddir_error()
+  call assert_fails('call finddir([])', 'E730:')
+  call assert_fails('call finddir("x", [])', 'E730:')
+  call assert_fails('call finddir("x", "", [])', 'E745:')
+  call assert_fails('call finddir("x", "**x")', 'E343:')
+  call assert_fails('call finddir("x", repeat("x", 5000))', 'E854:')
 endfunc

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -136,3 +136,44 @@ func Test_marks_cmd_multibyte()
 
   bwipe!
 endfunc
+
+func Test_delmarks()
+  new
+  norm mx
+  norm `x
+  delmarks x
+  call assert_fails('norm `x', 'E20:')
+
+  " Deleting an already deleted mark should not fail.
+  delmarks x
+
+  " Test deleting a range of marks.
+  norm ma
+  norm mb
+  norm mc
+  norm mz
+  delmarks b-z
+  norm `a
+  call assert_fails('norm `b', 'E20:')
+  call assert_fails('norm `c', 'E20:')
+  call assert_fails('norm `z', 'E20:')
+  call assert_fails('delmarks z-b', 'E475:')
+
+  call assert_fails('delmarks', 'E471:')
+  call assert_fails('delmarks /', 'E475:')
+
+  " Test delmarks!
+  norm mx
+  norm `x
+  delmarks!
+  call assert_fails('norm `x', 'E20:')
+  call assert_fails('delmarks! x', 'E474:')
+
+  bwipe!
+endfunc
+
+func Test_mark_error()
+  call assert_fails('mark', 'E471:')
+  call assert_fails('mark xx', 'E488:')
+  call assert_fails('mark _', 'E191:')
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0891: substitute command inssuficiently tested**

Problem:    Substitute command inssuficiently tested.
Solution:   Add more test coverage. (Dominique Pelle)
https://github.com/vim/vim/commit/d77aa4d22e943998c337d5a603622ac5cf2928cb