### PR TITLE
doc: remove duplicate word

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ Features
 
 - Modern [GUIs](https://github.com/neovim/neovim/wiki/Related-projects#gui)
 - [API access](https://github.com/neovim/neovim/wiki/Related-projects#api-clients)
-  from any language including C/C++, C#, Clojure, D, Elixir, Lisp, Go,
-  Haskell, Java, JavaScript/Node.js, Julia, Lisp, Lua, Perl, Python, Racket,
-  Ruby, Rust
+  from any language including C/C++, C#, Clojure, D, Elixir, Go, Haskell,
+  Java, JavaScript/Node.js, Julia, Lisp, Lua, Perl, Python, Racket, Ruby, Rust
 - Embedded, scriptable [terminal emulator](https://neovim.io/doc/user/nvim_terminal_emulator.html)
 - Asynchronous [job control](https://github.com/neovim/neovim/pull/2247)
 - [Shared data (shada)](https://github.com/neovim/neovim/pull/2506) among multiple editor instances


### PR DESCRIPTION
There is two "lisp" in this sentence. Remove the first one to respect alphabetical order.