### PR TITLE
vim-patch:8.1.0935

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -7116,6 +7116,8 @@ regprog_T *vim_regcomp(char_u *expr_arg, int re_flags)
   }
   bt_regengine.expr = expr;
   nfa_regengine.expr = expr;
+  // reg_iswordc() uses rex.reg_buf
+  rex.reg_buf = curbuf;
 
   //
   // First try the NFA engine, unless backtracking was requested.

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -47,3 +47,19 @@ func Test_get_equi_class()
   s/.*/[[.
   call assert_equal(1, search(getline(1)))
 endfunc
+
+func Test_rex_init()
+  set noincsearch
+  set re=1
+  new
+  setlocal iskeyword=a-z
+  call setline(1, ['abc', 'ABC'])
+  call assert_equal(1, search('[[:keyword:]]'))
+  new
+  setlocal iskeyword=A-Z
+  call setline(1, ['abc', 'ABC'])
+  call assert_equal(2, search('[[:keyword:]]'))
+  bwipe!
+  bwipe!
+  set re=0
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0935: old regexp engine may use invalid buffer**

Problem:    Old regexp engine may use invalid buffer for 'iskeyword' or
            uninitialized buffer pointer. (Kuang-che Wu)
Solution:   Set rex.reg_buf when compiling the pattern. (closes vim/vim#3972)
https://github.com/vim/vim/commit/8bfd9469cef536f171e6666f9d9217192e09d161