### PR TITLE
vim-patch:8.1.{739,826,998}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2446,7 +2446,7 @@ void get_winopts(buf_T *buf)
  */
 pos_T *buflist_findfpos(buf_T *buf)
 {
-  static pos_T no_position = INIT_POS_T(1, 0, 0);
+  static pos_T no_position = { 1, 0, 0 };
 
   wininfo_T *wip = find_wininfo(buf, FALSE);
   return (wip == NULL) ? &no_position : &(wip->wi_fpos);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10086,10 +10086,23 @@ static void getpos_both(typval_T *argvars, typval_T *rettv, bool getcurpos)
   tv_list_append_number(
       l, (fp != NULL) ? (varnumber_T)fp->coladd : (varnumber_T)0);
   if (getcurpos) {
+    const int save_set_curswant = curwin->w_set_curswant;
+    const colnr_T save_curswant = curwin->w_curswant;
+    const colnr_T save_virtcol = curwin->w_virtcol;
+
     update_curswant();
     tv_list_append_number(l, (curwin->w_curswant == MAXCOL
                               ? (varnumber_T)MAXCOL
                               : (varnumber_T)curwin->w_curswant + 1));
+
+    // Do not change "curswant", as it is unexpected that a get
+    // function has a side effect.
+    if (save_set_curswant) {
+      curwin->w_set_curswant = save_set_curswant;
+      curwin->w_curswant = save_curswant;
+      curwin->w_virtcol = save_virtcol;
+      curwin->w_valid &= ~VALID_VIRTCOL;
+    }
   }
 }
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -602,7 +602,7 @@ EXTERN bool can_si INIT(= false);
 EXTERN bool can_si_back INIT(= false);
 
 // w_cursor before formatting text.
-EXTERN pos_T saved_cursor INIT(= INIT_POS_T(0, 0, 0));
+EXTERN pos_T saved_cursor INIT(= { 0, 0, 0 });
 
 /*
  * Stuff for insert mode.
@@ -789,7 +789,7 @@ EXTERN int autocmd_bufnr INIT(= 0);            // fnum for <abuf> on cmdline
 EXTERN char_u *autocmd_match INIT(= NULL);     // name for <amatch> on cmdline
 EXTERN int did_cursorhold INIT(= false);       // set when CursorHold t'gerd
 // for CursorMoved event
-EXTERN pos_T last_cursormoved INIT(= INIT_POS_T(0, 0, 0));
+EXTERN pos_T last_cursormoved INIT(= { 0, 0, 0 });
 
 EXTERN int postponed_split INIT(= 0);       /* for CTRL-W CTRL-] command */
 EXTERN int postponed_split_flags INIT(= 0);       /* args for win_split() */

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -924,7 +924,7 @@ static void mark_adjust_internal(linenr_T line1, linenr_T line2,
   int i;
   int fnum = curbuf->b_fnum;
   linenr_T    *lp;
-  static pos_T initpos = INIT_POS_T(1, 0, 0);
+  static pos_T initpos = { 1, 0, 0 };
 
   if (line2 < line1 && amount_after == 0L)          /* nothing to do */
     return;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5443,7 +5443,7 @@ static void nv_csearch(cmdarg_T *cap)
  */
 static void nv_brackets(cmdarg_T *cap)
 {
-  pos_T new_pos = INIT_POS_T(0, 0, 0);
+  pos_T new_pos = { 0, 0, 0 };
   pos_T prev_pos;
   pos_T       *pos = NULL;          /* init for GCC */
   pos_T old_pos;                    /* cursor position before command */

--- a/src/nvim/pos.h
+++ b/src/nvim/pos.h
@@ -24,7 +24,6 @@ typedef struct {
   colnr_T coladd;
 } pos_T;
 
-# define INIT_POS_T(l, c, ca) {l, c, ca}
 
 /*
  * Same, but without coladd.

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -109,7 +109,7 @@ static char_u   *tagmatchname = NULL;   /* name of last used tag */
  * Tag for preview window is remembered separately, to avoid messing up the
  * normal tagstack.
  */
-static taggy_T ptag_entry = {NULL, {INIT_POS_T(0, 0, 0), 0, 0, NULL}, 0, 0};
+static taggy_T ptag_entry = { NULL, { { 0, 0, 0 }, 0, 0, NULL }, 0, 0 };
 
 /*
  * Jump to tag; handling of tag commands and tag stack

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -956,8 +956,8 @@ func Test_balloon_show()
 endfunc
 
 func Test_shellescape()
-  let save_shell = &shell
-  set shell=bash
+  let [save_shell, save_shellslash] = [&shell, &shellslash]
+  set shell=bash shellslash
   call assert_equal("'text'", shellescape('text'))
   call assert_equal("'te\"xt'", shellescape('te"xt'))
   call assert_equal("'te'\\''xt'", shellescape("te'xt"))
@@ -971,13 +971,13 @@ func Test_shellescape()
 
   call assert_equal("'te\nxt'", shellescape("te\nxt"))
   call assert_equal("'te\\\nxt'", shellescape("te\nxt", 1))
-  set shell=tcsh
+  set shell=tcsh shellslash
   call assert_equal("'te\\!xt'", shellescape("te!xt"))
   call assert_equal("'te\\\\!xt'", shellescape("te!xt", 1))
   call assert_equal("'te\\\nxt'", shellescape("te\nxt"))
   call assert_equal("'te\\\\\nxt'", shellescape("te\nxt", 1))
 
-  let &shell = save_shell
+  let [&shell, &shellslash] = [save_shell, save_shellslash]
 endfunc
 
 func Test_redo_in_nested_functions()

--- a/src/nvim/testdir/test_true_false.vim
+++ b/src/nvim/testdir/test_true_false.vim
@@ -57,6 +57,9 @@ endfunc
 
 " Test using TRUE or FALSE values for an argument.
 func Test_true_false_arg()
+  let shellslash = &shellslash
+  let wildignore = &wildignore
+  set shellslash
   call Try_arg_true_false('count(["a", "A"], "a", %v%)', 1, 2)
 
   set wildignore=*.swp
@@ -110,6 +113,8 @@ func Test_true_false_arg()
   let here_id = synID(1, 3, 0)
   call Try_arg_true_false('synID(1, 3, %v%)', here_id, brackets_id)
   bwipe!
+  let &wildignore = wildignore
+  let &shellslash = shellslash
 endfunc
 
 function Try_arg_non_zero(expr, false_val, true_val)

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1,8 +1,4 @@
 " Tests for various Visual mode.
-if !has('visual')
-  finish
-endif
-
 
 func Test_block_shift_multibyte()
   " Uses double-wide character.
@@ -317,4 +313,15 @@ func Test_Visual_sentence_textobject()
   call assert_equal('First sentence. Second', @")
 
   bwipe!
+endfunc
+
+func Test_curswant_not_changed()
+  new
+  call setline(1, ['one', 'two'])
+  au InsertLeave * call getcurpos()
+  call feedkeys("gg0\<C-V>jI123 \<Esc>j", 'xt')
+  call assert_equal([0, 2, 1, 0, 1], getcurpos())
+
+  bwipe!
+  au! InsertLeave
 endfunc

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -274,9 +274,46 @@ func Test_visual_mode_reset()
   set belloff&
 endfunc
 
+func Test_Visual_word_textobject()
+  new
+  call setline(1, ['First sentence. Second sentence.'])
+
+  " When start and end of visual area are identical, 'aw' or 'iw' select
+  " the whole word.
+  norm! 1go2fcvawy
+  call assert_equal('Second ', @")
+  norm! 1go2fcviwy
+  call assert_equal('Second', @")
+
+  " When start and end of visual area are not identical, 'aw' or 'iw'
+  " extend the word in direction of the end of the visual area.
+  norm! 1go2fcvlawy
+  call assert_equal('cond ', @")
+  norm! gv2awy
+  call assert_equal('cond sentence.', @")
+
+  norm! 1go2fcvliwy
+  call assert_equal('cond', @")
+  norm! gv2iwy
+  call assert_equal('cond sentence', @")
+
+  " Extend visual area in opposite direction.
+  norm! 1go2fcvhawy
+  call assert_equal(' Sec', @")
+  norm! gv2awy
+  call assert_equal(' sentence. Sec', @")
+
+  norm! 1go2fcvhiwy
+  call assert_equal('Sec', @")
+  norm! gv2iwy
+  call assert_equal('. Sec', @")
+
+  bwipe!
+endfunc
+
 func Test_Visual_sentence_textobject()
   new
-  call setline(1, ['First sentence. Second sentence. Third', 'sentence. Fouth sentence'])
+  call setline(1, ['First sentence. Second sentence. Third', 'sentence. Fourth sentence'])
 
   " When start and end of visual area are identical, 'as' or 'is' select
   " the whole sentence.
@@ -324,4 +361,53 @@ func Test_curswant_not_changed()
 
   bwipe!
   au! InsertLeave
+endfunc
+
+func Test_Visual_paragraph_textobject()
+  new
+  call setline(1, ['First line.',
+  \                '',
+  \                'Second line.',
+  \                'Third line.',
+  \                'Fourth line.',
+  \                'Fifth line.',
+  \                '',
+  \                'Sixth line.'])
+
+  " When start and end of visual area are identical, 'ap' or 'ip' select
+  " the whole paragraph.
+  norm! 4ggvapy
+  call assert_equal("Second line.\nThird line.\nFourth line.\nFifth line.\n\n", @")
+  norm! 4ggvipy
+  call assert_equal("Second line.\nThird line.\nFourth line.\nFifth line.\n", @")
+
+  " When start and end of visual area are not identical, 'ap' or 'ip'
+  " extend the sentence in direction of the end of the visual area.
+  " FIXME: actually, it is not sufficient to have different start and
+  " end of visual selection, the start line and end line have to differ,
+  " which is not consistent with the documentation.
+  norm! 4ggVjapy
+  call assert_equal("Third line.\nFourth line.\nFifth line.\n\n", @")
+  norm! gvapy
+  call assert_equal("Third line.\nFourth line.\nFifth line.\n\nSixth line.\n", @")
+  norm! 4ggVjipy
+  call assert_equal("Third line.\nFourth line.\nFifth line.\n", @")
+  norm! gvipy
+  call assert_equal("Third line.\nFourth line.\nFifth line.\n\n", @")
+  norm! gvipy
+  call assert_equal("Third line.\nFourth line.\nFifth line.\n\nSixth line.\n", @")
+
+  " Extend visual area in opposite direction.
+  norm! 5ggVkapy
+  call assert_equal("\nSecond line.\nThird line.\nFourth line.\n", @")
+  norm! gvapy
+  call assert_equal("First line.\n\nSecond line.\nThird line.\nFourth line.\n", @")
+  norm! 5ggVkipy
+  call assert_equal("Second line.\nThird line.\nFourth line.\n", @")
+  norma gvipy
+  call assert_equal("\nSecond line.\nThird line.\nFourth line.\n", @")
+  norm! gvipy
+  call assert_equal("First line.\n\nSecond line.\nThird line.\nFourth line.\n", @")
+
+  bwipe!
 endfunc


### PR DESCRIPTION
**vim-patch:8.1.0739: text objects in not sufficiently tested**
Problem:    Text objects in not sufficiently tested.
Solution:   Add a few more test cases. (Dominique Pelle, closes vim/vim#3795)
vim/vim@81b1ba4

**vim-patch:8.1.0826: too many #ifdefs**
Problem:    Too many #ifdefs.
Solution:   Graduate FEAT_VIRTUALEDIT.  Adds about 10Kbyte to the code.
vim/vim@29ddebe

**vim-patch:8.1.0998: getcurpos() unexpectedly changes "curswant"**

Problem:    getcurpos() unexpectedly changes "curswant".
Solution:   Save and restore "curswant". (closes vim/vim#4069)
https://github.com/vim/vim/commit/19a66858a5e3fedadc371321834507c34e2dfb18