### PR TITLE
executable(): return false if user is not owner

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -288,7 +288,11 @@ static bool is_executable(const char *name)
   // a directory.
   return (S_ISREG(mode));
 #else
-  return (S_ISREG(mode) && (S_IXUSR & mode));
+  int r = -1;
+  if (S_ISREG(mode)) {
+    RUN_UV_FS_FUNC(r, uv_fs_access, name, X_OK, NULL);
+  }
+  return (r == 0);
 #endif
 }
 


### PR DESCRIPTION
This PR will fix the following problem.

- `nvim --version`: N/A
- Vim (version: ) behaves differently? Yes
- Operating system/version: Linux
- Terminal name/version: N/A
- `$TERM`: N/A

### Steps to reproduce using `nvim -u NORC`

```
touch test.txt
chmod 744 test.txt
sudo chown root:root test.txt
nvim -u NORC
:echo executable('./test.txt')
```

### Actual behaviour

```
1
```

### Expected behaviour
```
0
```
