### PR TITLE
vim-patch:8.1.1002

### DIFF
--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -9,6 +9,7 @@ func Test_gf_url()
       \ "third test for URL:\\\\machine.name\\vimtest2c and other text",
       \ "fourth test for URL:\\\\machine.name\\tmp\\vimtest2d, and other text",
       \ "fifth test for URL://machine.name/tmp?q=vim&opt=yes and other text",
+      \ "sixth test for URL://machine.name:1234?q=vim and other text",
       \ ])
   call cursor(1,1)
   call search("^first")
@@ -20,7 +21,7 @@ func Test_gf_url()
   if has("ebcdic")
       set isf=@,240-249,/,.,-,_,+,,,$,:,~,\
   else
-      set isf=@,48-57,/,.,-,_,+,,,$,:,~,\
+      set isf=@,48-57,/,.,-,_,+,,,$,~,\
   endif
   call search("^third")
   call search("name")
@@ -32,6 +33,10 @@ func Test_gf_url()
   call search("^fifth")
   call search("URL")
   call assert_equal("URL://machine.name/tmp?q=vim&opt=yes", expand("<cfile>"))
+
+  call search("^sixth")
+  call search("URL")
+  call assert_equal("URL://machine.name:1234?q=vim", expand("<cfile>"))
 
   set isf&vim
   enew!

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5710,9 +5710,9 @@ file_name_in_line (
   len = 0;
   while (vim_isfilec(ptr[len]) || (ptr[len] == '\\' && ptr[len + 1] == ' ')
          || ((options & FNAME_HYP) && path_is_url((char *)ptr + len))
-         || (is_url && vim_strchr((char_u *)"?&=", ptr[len]) != NULL)) {
-    // After type:// we also include ?, & and = as valid characters, so that
-    // http://google.com?q=this&that=ok works.
+         || (is_url && vim_strchr((char_u *)":?&=", ptr[len]) != NULL)) {
+    // After type:// we also include :, ?, & and = as valid characters, so that
+    // http://google.com:8080?q=this&that=ok works.
     if ((ptr[len] >= 'A' && ptr[len] <= 'Z')
         || (ptr[len] >= 'a' && ptr[len] <= 'z')) {
       if (in_type && path_is_url((char *)ptr + len + 1)) {


### PR DESCRIPTION
**vim-patch:8.1.1002: "gf" does not always work when URL has a port number**

Problem:    "gf" does not always work when URL has a port number. (Jakob
            Schöttl)
Solution:   When a URL is recognized also accept ":". (closes vim/vim#4082)
https://github.com/vim/vim/commit/cbef8e1aa1f260ffde16491b1678eae53a36cf68