### PR TITLE
add "RemoteCommand" to sshconfig syntax

### DIFF
--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -206,6 +206,7 @@ syn keyword sshconfigKeyword PubkeyAcceptedKeyTypes
 syn keyword sshconfigKeyword PubkeyAuthentication
 syn keyword sshconfigKeyword RSAAuthentication
 syn keyword sshconfigKeyword RekeyLimit
+syn keyword sshconfigKeyword RemoteCommand
 syn keyword sshconfigKeyword RemoteForward
 syn keyword sshconfigKeyword RequestTTY
 syn keyword sshconfigKeyword RhostsRSAAuthentication


### PR DESCRIPTION
The keyword can be found here: https://man.openbsd.org/OpenBSD-6.2/ssh_config#RemoteCommand