### PR TITLE
test/CI: skip "throttles output" test on Travis macOS

### DIFF
--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -51,7 +51,8 @@ describe("shell command :!", function()
   end)
 
   it("throttles shell-command output greater than ~10KB", function()
-    if helpers.skip_fragile(pending) then
+    if helpers.skip_fragile(pending,
+        (os.getenv("TRAVIS") and helpers.os_name() == "osx")) then
       return
     end
     child_session.feed_data(


### PR DESCRIPTION
Travis macOS is not fast enough to run this test reliably. The test
depends on the system producing output faster than the Nvim TUI can
handle it.